### PR TITLE
fix: use agent-specific permission overlays instead of shared Claude …

### DIFF
--- a/internal/components/permissions/inject.go
+++ b/internal/components/permissions/inject.go
@@ -14,10 +14,78 @@ type InjectionResult struct {
 	Files   []string
 }
 
-var permissionsOverlayJSON = []byte("{\n  \"permissions\": {\n    \"defaultMode\": \"ask\",\n    \"deny\": [\n      \"rm -rf /\",\n      \"sudo rm -rf /\",\n      \".env\"\n    ]\n  }\n}\n")
+// claudeCodeOverlayJSON sets Claude Code to bypassPermissions mode (auto-accept all).
+// Valid modes: "acceptEdits", "bypassPermissions", "default", "dontAsk", "plan".
+var claudeCodeOverlayJSON = []byte(`{
+  "permissions": {
+    "defaultMode": "bypassPermissions",
+    "deny": [
+      "rm -rf /",
+      "sudo rm -rf /",
+      ".env"
+    ]
+  }
+}
+`)
 
-// openCodePermissionsOverlayJSON uses the OpenCode "permission" key with bash/read granularity.
-var openCodePermissionsOverlayJSON = []byte("{\n  \"permission\": {\n    \"bash\": {\n      \"*\": \"allow\",\n      \"git commit *\": \"ask\",\n      \"git push *\": \"ask\",\n      \"git push\": \"ask\",\n      \"git push --force *\": \"ask\",\n      \"git rebase *\": \"ask\",\n      \"git reset --hard *\": \"ask\"\n    },\n    \"read\": {\n      \"*\": \"allow\",\n      \"*.env\": \"deny\",\n      \"*.env.*\": \"deny\",\n      \"**/.env\": \"deny\",\n      \"**/.env.*\": \"deny\",\n      \"**/secrets/**\": \"deny\",\n      \"**/credentials.json\": \"deny\"\n    }\n  }\n}\n")
+// openCodeOverlayJSON uses the OpenCode "permission" key with bash/read granularity.
+var openCodeOverlayJSON = []byte(`{
+  "permission": {
+    "bash": {
+      "*": "allow",
+      "git commit *": "ask",
+      "git push *": "ask",
+      "git push": "ask",
+      "git push --force *": "ask",
+      "git rebase *": "ask",
+      "git reset --hard *": "ask"
+    },
+    "read": {
+      "*": "allow",
+      "*.env": "deny",
+      "*.env.*": "deny",
+      "**/.env": "deny",
+      "**/.env.*": "deny",
+      "**/secrets/**": "deny",
+      "**/credentials.json": "deny"
+    }
+  }
+}
+`)
+
+// geminiCLIOverlayJSON sets Gemini CLI to "yolo" mode (auto-approve all tool calls).
+var geminiCLIOverlayJSON = []byte(`{
+  "general": {
+    "defaultApprovalMode": "yolo"
+  }
+}
+`)
+
+// vscodeCopilotOverlayJSON enables auto-approve for VS Code Copilot chat tools.
+var vscodeCopilotOverlayJSON = []byte(`{
+  "chat.tools.autoApprove": true
+}
+`)
+
+// agentOverlay returns the correct permission overlay for the given agent,
+// or nil if the agent does not support permission injection via settings.json.
+func agentOverlay(id model.AgentID) []byte {
+	switch id {
+	case model.AgentClaudeCode:
+		return claudeCodeOverlayJSON
+	case model.AgentOpenCode:
+		return openCodeOverlayJSON
+	case model.AgentGeminiCLI:
+		return geminiCLIOverlayJSON
+	case model.AgentVSCodeCopilot:
+		return vscodeCopilotOverlayJSON
+	case model.AgentCursor:
+		// Cursor manages permissions via cli-config.json, not settings.json.
+		return nil
+	default:
+		return nil
+	}
+}
 
 func Inject(homeDir string, adapter agents.Adapter) (InjectionResult, error) {
 	settingsPath := adapter.SettingsPath(homeDir)
@@ -25,9 +93,9 @@ func Inject(homeDir string, adapter agents.Adapter) (InjectionResult, error) {
 		return InjectionResult{}, nil
 	}
 
-	overlay := permissionsOverlayJSON
-	if adapter.Agent() == model.AgentOpenCode {
-		overlay = openCodePermissionsOverlayJSON
+	overlay := agentOverlay(adapter.Agent())
+	if overlay == nil {
+		return InjectionResult{}, nil
 	}
 
 	writeResult, err := mergeJSONFile(settingsPath, overlay)

--- a/internal/components/permissions/inject_test.go
+++ b/internal/components/permissions/inject_test.go
@@ -9,11 +9,17 @@ import (
 
 	"github.com/gentleman-programming/gentle-ai/internal/agents"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/claude"
+	"github.com/gentleman-programming/gentle-ai/internal/agents/cursor"
+	"github.com/gentleman-programming/gentle-ai/internal/agents/gemini"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/opencode"
+	"github.com/gentleman-programming/gentle-ai/internal/agents/vscode"
 )
 
 func claudeAdapter() agents.Adapter   { return claude.NewAdapter() }
 func opencodeAdapter() agents.Adapter { return opencode.NewAdapter() }
+func geminiAdapter() agents.Adapter   { return gemini.NewAdapter() }
+func cursorAdapter() agents.Adapter   { return cursor.NewAdapter() }
+func vscodeAdapter() agents.Adapter   { return vscode.NewAdapter() }
 
 func TestInjectOpenCodeIsIdempotent(t *testing.T) {
 	home := t.TempDir()
@@ -94,4 +100,119 @@ func TestInjectAddsEnvToDenyList(t *testing.T) {
 	}
 
 	t.Fatalf("deny list missing explicit .env rule: %#v", denyList)
+}
+
+func TestInjectClaudeCodeUsesBypassPermissions(t *testing.T) {
+	home := t.TempDir()
+
+	if _, err := Inject(home, claudeAdapter()); err != nil {
+		t.Fatalf("Inject() error = %v", err)
+	}
+
+	settingsPath := filepath.Join(home, ".claude", "settings.json")
+	content, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("read settings file: %v", err)
+	}
+
+	var settings map[string]any
+	if err := json.Unmarshal(content, &settings); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	perms, ok := settings["permissions"].(map[string]any)
+	if !ok {
+		t.Fatalf("permissions node missing")
+	}
+
+	mode, ok := perms["defaultMode"].(string)
+	if !ok || mode != "bypassPermissions" {
+		t.Fatalf("expected defaultMode=bypassPermissions, got %q", mode)
+	}
+}
+
+func TestInjectGeminiCLIUsesYoloMode(t *testing.T) {
+	home := t.TempDir()
+
+	result, err := Inject(home, geminiAdapter())
+	if err != nil {
+		t.Fatalf("Inject() error = %v", err)
+	}
+	if !result.Changed {
+		t.Fatal("Inject() changed = false")
+	}
+
+	settingsPath := filepath.Join(home, ".gemini", "settings.json")
+	content, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("read settings file: %v", err)
+	}
+
+	var settings map[string]any
+	if err := json.Unmarshal(content, &settings); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	general, ok := settings["general"].(map[string]any)
+	if !ok {
+		t.Fatalf("general node missing: %#v", settings)
+	}
+
+	mode, ok := general["defaultApprovalMode"].(string)
+	if !ok || mode != "yolo" {
+		t.Fatalf("expected defaultApprovalMode=yolo, got %q", mode)
+	}
+
+	// Ensure no Claude Code keys leaked
+	if _, exists := settings["permissions"]; exists {
+		t.Fatal("gemini settings should not contain 'permissions' key")
+	}
+}
+
+func TestInjectVSCodeCopilotUsesAutoApprove(t *testing.T) {
+	home := t.TempDir()
+
+	result, err := Inject(home, vscodeAdapter())
+	if err != nil {
+		t.Fatalf("Inject() error = %v", err)
+	}
+	if !result.Changed {
+		t.Fatal("Inject() changed = false")
+	}
+
+	settingsPath := filepath.Join(home, ".vscode", "settings.json")
+	content, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("read settings file: %v", err)
+	}
+
+	var settings map[string]any
+	if err := json.Unmarshal(content, &settings); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	autoApprove, ok := settings["chat.tools.autoApprove"].(bool)
+	if !ok || !autoApprove {
+		t.Fatalf("expected chat.tools.autoApprove=true, got %v", settings["chat.tools.autoApprove"])
+	}
+
+	// Ensure no Claude Code keys leaked
+	if _, exists := settings["permissions"]; exists {
+		t.Fatal("vscode settings should not contain 'permissions' key")
+	}
+}
+
+func TestInjectCursorSkipsPermissions(t *testing.T) {
+	home := t.TempDir()
+
+	result, err := Inject(home, cursorAdapter())
+	if err != nil {
+		t.Fatalf("Inject() error = %v", err)
+	}
+	if result.Changed {
+		t.Fatal("Inject() for Cursor should not change anything (permissions via cli-config.json)")
+	}
+	if len(result.Files) != 0 {
+		t.Fatalf("Inject() for Cursor should return no files, got %v", result.Files)
+	}
 }


### PR DESCRIPTION
The previous permissionsOverlayJSON used "defaultMode": "ask" which is not a valid Claude Code permission mode, and was incorrectly shared across all non-OpenCode agents. Each agent now gets its own overlay:

- Claude Code: permissions.defaultMode = "bypassPermissions" (valid mode)
- Gemini CLI: general.defaultApprovalMode = "yolo"
- VS Code Copilot: chat.tools.autoApprove = true
- Cursor: skipped (permissions managed via cli-config.json, not settings.json)
- OpenCode: unchanged (already had its own granular overlay)

Fixes permission injection errors reported by users where Claude Code rejected the invalid "ask" mode value.
