### PR TITLE
feat: add Fedora Linux support

### DIFF
--- a/internal/system/detect.go
+++ b/internal/system/detect.go
@@ -29,6 +29,7 @@ const (
 	LinuxDistroUbuntu  = "ubuntu"
 	LinuxDistroDebian  = "debian"
 	LinuxDistroArch    = "arch"
+	LinuxDistroFedora  = "fedora"
 )
 
 type DetectionResult struct {
@@ -122,6 +123,9 @@ func resolvePlatformProfile(goos, linuxOSRelease string) PlatformProfile {
 		case LinuxDistroArch:
 			profile.PackageManager = "pacman"
 			profile.Supported = true
+		case LinuxDistroFedora:
+			profile.PackageManager = "dnf"
+			profile.Supported = true
 		default:
 			profile.PackageManager = ""
 			profile.Supported = false
@@ -168,6 +172,10 @@ func detectLinuxDistro(linuxOSRelease string) string {
 
 	if isArchLike(id, idLike) {
 		return LinuxDistroArch
+	}
+
+	if id == LinuxDistroFedora {
+		return LinuxDistroFedora
 	}
 
 	return LinuxDistroUnknown


### PR DESCRIPTION
## Summary

Adds official support for Fedora Linux to gentle-ai. Currently the tool only supports Ubuntu/Debian and Arch Linux, but Fedora is a popular distribution that should be supported.

## Changes

- Added `LinuxDistroFedora` constant in `internal/system/detect.go`
- Added Fedora detection in `resolvePlatformProfile` with `dnf` as package manager
- Added Fedora `ID` detection in `detectLinuxDistro`

## Testing

Tested on Fedora 43 (KDE Plasma Desktop Edition):

```
$ gentle-ai install --dry-run --agent opencode --preset minimal
Platform decision: os=linux distro=fedora package-manager=dnf status=supported
```

## Related

This resolves the issue where users on Fedora get:
```
Error: unsupported linux distro: Linux support is limited to Ubuntu/Debian and Arch (detected unknown)
```