### PR TITLE
fix(installcmd): add symlink step for engram on linux to improve DX

### DIFF
--- a/internal/components/engram/install_test.go
+++ b/internal/components/engram/install_test.go
@@ -22,12 +22,18 @@ func TestInstallCommandByProfile(t *testing.T) {
 		{
 			name:    "ubuntu uses go install with correct module path",
 			profile: system.PlatformProfile{OS: "linux", LinuxDistro: system.LinuxDistroUbuntu, PackageManager: "apt"},
-			want:    [][]string{{"env", "CGO_ENABLED=0", "go", "install", "github.com/Gentleman-Programming/engram/cmd/engram@latest"}},
+			want: [][]string{
+				{"env", "CGO_ENABLED=0", "go", "install", "github.com/Gentleman-Programming/engram/cmd/engram@latest"},
+				{"sh", "-c", "sudo ln -sf \"$(go env GOPATH | cut -d: -f1)/bin/engram\" /usr/local/bin/engram || echo '\\n\\033[33mWARNING: Could not symlink engram to /usr/local/bin. Please ensure $(go env GOPATH | cut -d: -f1)/bin is in your PATH\\033[0m\\n'"},
+			},
 		},
 		{
 			name:    "arch uses go install with correct module path",
 			profile: system.PlatformProfile{OS: "linux", LinuxDistro: system.LinuxDistroArch, PackageManager: "pacman"},
-			want:    [][]string{{"env", "CGO_ENABLED=0", "go", "install", "github.com/Gentleman-Programming/engram/cmd/engram@latest"}},
+			want: [][]string{
+				{"env", "CGO_ENABLED=0", "go", "install", "github.com/Gentleman-Programming/engram/cmd/engram@latest"},
+				{"sh", "-c", "sudo ln -sf \"$(go env GOPATH | cut -d: -f1)/bin/engram\" /usr/local/bin/engram || echo '\\n\\033[33mWARNING: Could not symlink engram to /usr/local/bin. Please ensure $(go env GOPATH | cut -d: -f1)/bin is in your PATH\\033[0m\\n'"},
+			},
 		},
 		{
 			name:    "unsupported package manager errors",

--- a/internal/installcmd/resolver.go
+++ b/internal/installcmd/resolver.go
@@ -134,7 +134,10 @@ func resolveEngramInstall(profile system.PlatformProfile) (CommandSequence, erro
 			{"brew", "install", "engram"},
 		}, nil
 	case "apt", "pacman":
-		return CommandSequence{{"env", "CGO_ENABLED=0", "go", "install", "github.com/Gentleman-Programming/engram/cmd/engram@latest"}}, nil
+		return CommandSequence{
+			{"env", "CGO_ENABLED=0", "go", "install", "github.com/Gentleman-Programming/engram/cmd/engram@latest"},
+			{"sh", "-c", "sudo ln -sf \"$(go env GOPATH | cut -d: -f1)/bin/engram\" /usr/local/bin/engram || echo '\\n\\033[33mWARNING: Could not symlink engram to /usr/local/bin. Please ensure $(go env GOPATH | cut -d: -f1)/bin is in your PATH\\033[0m\\n'"},
+		}, nil
 	default:
 		return nil, fmt.Errorf(
 			"unsupported platform for engram: os=%q distro=%q pm=%q",

--- a/internal/installcmd/resolver_test.go
+++ b/internal/installcmd/resolver_test.go
@@ -172,13 +172,19 @@ func TestResolveComponentInstall(t *testing.T) {
 			name:      "engram on ubuntu uses go install with correct module path",
 			profile:   system.PlatformProfile{OS: "linux", LinuxDistro: system.LinuxDistroUbuntu, PackageManager: "apt"},
 			component: model.ComponentEngram,
-			want:      CommandSequence{{"env", "CGO_ENABLED=0", "go", "install", "github.com/Gentleman-Programming/engram/cmd/engram@latest"}},
+			want: CommandSequence{
+				{"env", "CGO_ENABLED=0", "go", "install", "github.com/Gentleman-Programming/engram/cmd/engram@latest"},
+				{"sh", "-c", "sudo ln -sf \"$(go env GOPATH | cut -d: -f1)/bin/engram\" /usr/local/bin/engram || echo '\\n\\033[33mWARNING: Could not symlink engram to /usr/local/bin. Please ensure $(go env GOPATH | cut -d: -f1)/bin is in your PATH\\033[0m\\n'"},
+			},
 		},
 		{
 			name:      "engram on arch uses go install with correct module path",
 			profile:   system.PlatformProfile{OS: "linux", LinuxDistro: system.LinuxDistroArch, PackageManager: "pacman"},
 			component: model.ComponentEngram,
-			want:      CommandSequence{{"env", "CGO_ENABLED=0", "go", "install", "github.com/Gentleman-Programming/engram/cmd/engram@latest"}},
+			want: CommandSequence{
+				{"env", "CGO_ENABLED=0", "go", "install", "github.com/Gentleman-Programming/engram/cmd/engram@latest"},
+				{"sh", "-c", "sudo ln -sf \"$(go env GOPATH | cut -d: -f1)/bin/engram\" /usr/local/bin/engram || echo '\\n\\033[33mWARNING: Could not symlink engram to /usr/local/bin. Please ensure $(go env GOPATH | cut -d: -f1)/bin is in your PATH\\033[0m\\n'"},
+			},
 		},
 		{
 			name:      "gga on darwin uses brew tap and install",


### PR DESCRIPTION
# [FIX] Improve DX for engram installation on Linux (GOPATH/bin issue)

## Descripción
Al instalar las dependencias de `gentle-ai` en distribuciones de Linux que utilizan `apt` o `pacman`, la instalación de `engram` se resuelve mediante `go install` (definido en `internal/installcmd/resolver.go`).

El proceso de instalación finaliza correctamente. Sin embargo, si el usuario no tiene el directorio de binarios de Go (`$GOPATH/bin` o usualmente `~/go/bin`) agregado al `$PATH` de su sistema, intentar ejecutar `engram` inmediatamente después de la instalación falla con un error de `command not found: engram`.

Aunque esto es fundamentalmente un problema de configuración del entorno por parte del usuario, el CLI no advierte sobre este requisito, lo que resulta en una experiencia de desarrollo (**DX**) confusa.

## Pasos para reproducir
1. Utilizar un entorno Linux limpio (Ubuntu/Debian con `apt` o Arch con `pacman`).
2. Asegurarse de que `~/go/bin` no esté en el `$PATH`.
3. Ejecutar el proceso de instalación que dispara la instalación de la dependencia `engram`.
4. Intentar ejecutar `engram` desde la terminal.
5. Observar el error: `zsh: command not found: engram` (o similar dependiendo de la shell).

## Comportamiento esperado
Idealmente, el proceso de instalación debería ser fluido. Si se utiliza `go install`, el sistema debería:
- Crear un enlace simbólico (symlink) interactivo en una ruta del sistema conocida como `/usr/local/bin/engram`.
- O, al menos, detectar si la carpeta de instalación está en el `$PATH` y mostrar una advertencia o instrucción clara al usuario sobre cómo agregarlo a su perfil de configuración del shell (`.bashrc`, `.zshrc`, etc.).

## Comportamiento actual
El comando `go install` finaliza silenciosamente. El CLI informa una instalación exitosa, pero el usuario no puede utilizar la herramienta instalada sin descubrir manualmente que necesita agregar `~/go/bin` a su `$PATH`.

## Solución Propuesta
He añadido un paso adicional a la secuencia de comandos (`CommandSequence`) de instalación en Linux para intentar crear un enlace simbólico que exponga `engram` en una ruta estándar. Si esto falla (por ejemplo, por permisos), se emite una advertencia explícita:

```sh
sudo ln -sf "$(go env GOPATH | cut -d: -f1)/bin/engram" /usr/local/bin/engram || echo '\n\033[33mWARNING: Could not symlink engram to /usr/local/bin. Please ensure $(go env GOPATH | cut -d: -f1)/bin is in your PATH\033[0m\n'