### PR TITLE
fix: detect brew on Linux and skip already-installed agents

### DIFF
--- a/internal/agents/claude/adapter.go
+++ b/internal/agents/claude/adapter.go
@@ -11,6 +11,8 @@ import (
 	"github.com/gentleman-programming/gentle-ai/internal/system"
 )
 
+var LookPathOverride = exec.LookPath
+
 type statResult struct {
 	isDir bool
 	err   error
@@ -24,7 +26,7 @@ type Adapter struct {
 
 func NewAdapter() *Adapter {
 	return &Adapter{
-		lookPath: exec.LookPath,
+		lookPath: LookPathOverride,
 		statPath: defaultStat,
 		resolver: installcmd.NewResolver(),
 	}

--- a/internal/agents/gemini/adapter.go
+++ b/internal/agents/gemini/adapter.go
@@ -10,6 +10,8 @@ import (
 	"github.com/gentleman-programming/gentle-ai/internal/system"
 )
 
+var LookPathOverride = exec.LookPath
+
 type statResult struct {
 	isDir bool
 	err   error
@@ -22,7 +24,7 @@ type Adapter struct {
 
 func NewAdapter() *Adapter {
 	return &Adapter{
-		lookPath: exec.LookPath,
+		lookPath: LookPathOverride,
 		statPath: defaultStat,
 	}
 }

--- a/internal/agents/opencode/adapter.go
+++ b/internal/agents/opencode/adapter.go
@@ -11,6 +11,8 @@ import (
 	"github.com/gentleman-programming/gentle-ai/internal/system"
 )
 
+var LookPathOverride = exec.LookPath
+
 type statResult struct {
 	isDir bool
 	err   error
@@ -24,7 +26,7 @@ type Adapter struct {
 
 func NewAdapter() *Adapter {
 	return &Adapter{
-		lookPath: exec.LookPath,
+		lookPath: LookPathOverride,
 		statPath: defaultStat,
 		resolver: installcmd.NewResolver(),
 	}

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -193,7 +193,7 @@ func (r *installRuntime) stagePlan() pipeline.StagePlan {
 	apply = append(apply, rollbackRestoreStep{id: "apply:rollback-restore", state: r.state})
 
 	for _, agent := range r.resolved.Agents {
-		apply = append(apply, agentInstallStep{id: "agent:" + string(agent), agent: agent, profile: r.profile})
+		apply = append(apply, agentInstallStep{id: "agent:" + string(agent), agent: agent, homeDir: r.homeDir, profile: r.profile})
 	}
 
 	for _, component := range r.resolved.OrderedComponents {
@@ -256,6 +256,7 @@ func (s rollbackRestoreStep) Rollback() error {
 type agentInstallStep struct {
 	id      string
 	agent   model.AgentID
+	homeDir string
 	profile system.PlatformProfile
 }
 
@@ -270,6 +271,14 @@ func (s agentInstallStep) Run() error {
 	}
 
 	if !adapter.SupportsAutoInstall() {
+		return nil
+	}
+
+	installed, _, _, _, err := adapter.Detect(context.Background(), s.homeDir)
+	if err != nil {
+		return fmt.Errorf("detect agent %q: %w", s.agent, err)
+	}
+	if installed {
 		return nil
 	}
 

--- a/internal/cli/run_integration_test.go
+++ b/internal/cli/run_integration_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gentleman-programming/gentle-ai/internal/agents/opencode"
 	"github.com/gentleman-programming/gentle-ai/internal/system"
 )
 
@@ -373,6 +374,13 @@ func TestRunInstallLinuxAgentInstallResolvesGoInstallCommand(t *testing.T) {
 	cmdLookPath = missingBinaryLookPath
 	recorder := &commandRecorder{}
 	runCommand = recorder.record
+
+	// Set the agent adapter's lookPath to simulate missing opencode
+	opencodeAdapterLookPath := opencode.LookPathOverride
+	opencode.LookPathOverride = missingBinaryLookPath
+	t.Cleanup(func() {
+		opencode.LookPathOverride = opencodeAdapterLookPath
+	})
 
 	detection := linuxDetectionResult(system.LinuxDistroUbuntu, "apt")
 	_, err := RunInstall(

--- a/internal/system/detect.go
+++ b/internal/system/detect.go
@@ -84,7 +84,7 @@ func detectFromInputs(goos, arch, shell, linuxOSRelease string, tools map[string
 		}
 	}
 
-	profile := resolvePlatformProfile(goos, linuxOSRelease)
+	profile := resolvePlatformProfile(goos, linuxOSRelease, tools)
 
 	return DetectionResult{
 		System: SystemInfo{
@@ -112,7 +112,7 @@ func osReleaseContent(goos string) (string, error) {
 	return string(data), nil
 }
 
-func resolvePlatformProfile(goos, linuxOSRelease string) PlatformProfile {
+func resolvePlatformProfile(goos, linuxOSRelease string, tools map[string]ToolStatus) PlatformProfile {
 	profile := PlatformProfile{OS: goos}
 
 	switch goos {
@@ -123,6 +123,13 @@ func resolvePlatformProfile(goos, linuxOSRelease string) PlatformProfile {
 	case "linux":
 		distro := detectLinuxDistro(linuxOSRelease)
 		profile.LinuxDistro = distro
+
+		// Check if brew is available on Linux
+		if brew, ok := tools["brew"]; ok && brew.Installed {
+			profile.PackageManager = "brew"
+			profile.Supported = true
+			return profile
+		}
 
 		switch distro {
 		case LinuxDistroUbuntu, LinuxDistroDebian:

--- a/internal/system/detect_test.go
+++ b/internal/system/detect_test.go
@@ -181,6 +181,7 @@ func TestResolvePlatformProfileMatrix(t *testing.T) {
 		name          string
 		goos          string
 		osRelease     string
+		tools         map[string]ToolStatus
 		wantOS        string
 		wantPM        string
 		wantDistro    string
@@ -191,6 +192,16 @@ func TestResolvePlatformProfileMatrix(t *testing.T) {
 			goos:          "darwin",
 			wantOS:        "darwin",
 			wantPM:        "brew",
+			wantSupported: true,
+		},
+		{
+			name:          "linux with brew",
+			goos:          "linux",
+			osRelease:     "ID=debian\n",
+			tools:         map[string]ToolStatus{"brew": {Name: "brew", Installed: true}},
+			wantOS:        "linux",
+			wantPM:        "brew",
+			wantDistro:    LinuxDistroDebian,
 			wantSupported: true,
 		},
 		{
@@ -249,7 +260,7 @@ func TestResolvePlatformProfileMatrix(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			profile := resolvePlatformProfile(tc.goos, tc.osRelease)
+			profile := resolvePlatformProfile(tc.goos, tc.osRelease, tc.tools)
 			if profile.OS != tc.wantOS {
 				t.Fatalf("OS = %q, want %q", profile.OS, tc.wantOS)
 			}


### PR DESCRIPTION
## Summary
- Detect brew package manager on Linux systems
- Skip agent installation if already installed (via exec.LookPath)
- Fixes npm not found error on Linux with brew installed

## Changes
- `internal/system/detect.go`: Added brew detection for Linux
- `internal/cli/run.go`: Added detection check before agent installation
- `internal/agents/*/adapter.go`: Exported LookPathOverride for testability

## Testing
- Verified on Debian with brew installed
- All tests pass"