### PR TITLE
fix(cli): add help/--help/-h command to resolve unknown command error

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -72,6 +72,20 @@ func RunArgs(args []string, stdout io.Writer) error {
 		}
 
 		return nil
+	case "help", "--help", "-h":
+		_, _ = fmt.Fprintf(stdout, "gentle-ai %s\n\n", Version)
+		_, _ = fmt.Fprintln(stdout, "Usage:")
+		_, _ = fmt.Fprintln(stdout, "  gentle-ai [command]")
+		_, _ = fmt.Fprintln(stdout, "")
+		_, _ = fmt.Fprintln(stdout, "Available commands:")
+		_, _ = fmt.Fprintln(stdout, "  (no args)   Launch interactive TUI installer")
+		_, _ = fmt.Fprintln(stdout, "  install     Install agents and components non-interactively")
+		_, _ = fmt.Fprintln(stdout, "  update      Check for available updates")
+		_, _ = fmt.Fprintln(stdout, "  version     Print version")
+		_, _ = fmt.Fprintln(stdout, "  help        Show this help message")
+		_, _ = fmt.Fprintln(stdout, "")
+		_, _ = fmt.Fprintln(stdout, "Docs: https://github.com/Gentleman-Programming/gentle-ai")
+		return nil
 	default:
 		return fmt.Errorf("unknown command %q", args[0])
 	}

--- a/internal/app/parity_test.go
+++ b/internal/app/parity_test.go
@@ -168,6 +168,30 @@ func TestRunArgsNoCommandLaunchesTUI(t *testing.T) {
 	}
 }
 
+func TestRunArgsHelpCommands(t *testing.T) {
+	helpArgs := [][]string{
+		{"help"},
+		{"--help"},
+		{"-h"},
+	}
+	for _, args := range helpArgs {
+		t.Run(args[0], func(t *testing.T) {
+			var buf bytes.Buffer
+			err := RunArgs(args, &buf)
+			if err != nil {
+				t.Fatalf("RunArgs(%v) unexpected error = %v", args, err)
+			}
+			out := buf.String()
+			if !strings.Contains(out, "gentle-ai") {
+				t.Fatalf("RunArgs(%v) output missing 'gentle-ai': %q", args, out)
+			}
+			if !strings.Contains(out, "install") {
+				t.Fatalf("RunArgs(%v) output missing 'install': %q", args, out)
+			}
+		})
+	}
+}
+
 func TestRunArgsUnknownCommandReturnsError(t *testing.T) {
 	var buf bytes.Buffer
 	err := RunArgs([]string{"bogus"}, &buf)


### PR DESCRIPTION
## Summary

- `gentle-ai --help`, `gentle-ai -h`, and `gentle-ai help` returned `unknown command "--help"` because the args switch in `RunArgs` had no case for help flags

## Changes

- Added `case "help", "--help", "-h":` to `RunArgs` in `internal/app/app.go` with full usage output
- Added `TestRunArgsHelpCommands` table-driven test to `internal/app/parity_test.go` to prevent regression

## Testing

- [x] Tests added: `TestRunArgsHelpCommands` covers `help`, `--help`, `-h`
- [x] Existing `TestRunArgsUnknownCommandReturnsError` still passes
- [x] Manual testing: `go test ./internal/app/...` passes

Closes #33