### PR TITLE
docs(install): add PATH notification for go install users (fixes #42)

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,10 @@ brew install gentle-ai
 go install github.com/gentleman-programming/gentle-ai/cmd/gentle-ai@latest
 ```
 
+> **Note**: By default, Go installs binaries to `~/go/bin`. Make sure this directory is in your PATH:
+> - **Linux/macOS**: `export PATH=$PATH:~/go/bin`
+> - **Windows**: Add `%USERPROFILE%\go\bin` to your PATH
+
 ### Windows (PowerShell)
 
 ```powershell

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -144,9 +144,24 @@ function Install-ViaGo {
         $gobin = Join-Path $gopath "bin"
     }
 
-    if ($env:PATH -notlike "*$gobin*") {
-        Write-Warn "$gobin is not in your PATH"
-        Write-Warn "Add it to your PATH environment variable."
+    # Show where binary was installed
+    Write-Info "Binary installed in: $gobin\$BINARY_NAME.exe"
+
+    if ($env:PATH -like "*$gobin*") {
+        Write-Success "$gobin is in your PATH"
+        Write-Info "Run '$BINARY_NAME' to get started"
+    } else {
+        Write-Warn ""
+        Write-Host "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━" -ForegroundColor Yellow
+        Write-Host "  ⚠️  $gobin is not in your PATH" -ForegroundColor Yellow
+        Write-Host "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━" -ForegroundColor Yellow
+        Write-Warn ""
+        Write-Host "The binary was installed in: $gobin\$BINARY_NAME.exe" -ForegroundColor White
+        Write-Host "To use '$BINARY_NAME' command, run:" -ForegroundColor White
+        Write-Host "  [Environment]::SetEnvironmentVariable('PATH', `$env:PATH + ';$gobin', 'User')" -ForegroundColor Green
+        Write-Warn ""
+        Write-Host "Or restart your terminal to apply PATH changes." -ForegroundColor DarkGray
+        Write-Warn ""
     }
 
     Write-Success "Installed $BINARY_NAME via go install"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -228,9 +228,24 @@ install_go() {
         gobin="$(go env GOPATH)/bin"
     fi
 
-    if [[ ":$PATH:" != *":$gobin:"* ]]; then
-        warn "${gobin} is not in your PATH"
-        warn "Add this to your shell profile: export PATH=\"\$PATH:${gobin}\""
+    # Show where binary was installed
+    info "Binary installed in: ${gobin}/${BINARY_NAME}"
+
+    if [[ ":$PATH:" == *":$gobin:"* ]]; then
+        success "${gobin} is in your PATH"
+        info "Run '${BINARY_NAME}' to get started"
+    else
+        warn ""
+        warn "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+        warn "  ⚠️  ${gobin} is not in your PATH"
+        warn "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+        warn ""
+        warn "The binary was installed in: ${gobin}/${BINARY_NAME}"
+        warn "To use '${BINARY_NAME}' command, add this to your shell profile:"
+        echo -e "  ${GREEN}export PATH=\"\$PATH:${gobin}\"${NC}"
+        warn ""
+        warn "Then restart your terminal or run: source ~/.bashrc"
+        warn ""
     fi
 
     success "Installed ${BINARY_NAME} via go install"
@@ -282,6 +297,9 @@ install_binary() {
     # Create temp directory — clean up on exit
     local tmpdir
     tmpdir="$(mktemp -d)"
+    if [ -z "$tmpdir" ] || [ ! -d "$tmpdir" ]; then
+        fatal "Failed to create temporary directory (mktemp -d returned empty or invalid path)"
+    fi
     trap 'rm -rf "$tmpdir"' EXIT
 
     # Download archive


### PR DESCRIPTION
## Summary

- Issue #42: Users new to Go don't know where `go install` places the binary (~/go/bin by default), causing confusion when the `gentle-ai` command is not available after installation
- Added documentation and improved install scripts to clearly indicate where the binary is installed

## Changes

- **README.md**: Added note in "Go install" section about ~/go/bin default location
- **scripts/install.sh**: Enhanced install_go() to show installation path and display success/warning banner based on PATH
- **scripts/install.ps1**: Enhanced Install-ViaGo() to show installation path and display success/warning banner based on PATH

## Testing

- [x] Manual testing: install.sh and install.ps1 show correct messages
- [x] Verified both success (GOBIN in PATH) and warning (GOBIN not in PATH) cases work

Closes #42