### PR TITLE
fix: add missing "mcp" arg to default engram MCP config

### DIFF
--- a/internal/components/engram/inject.go
+++ b/internal/components/engram/inject.go
@@ -16,10 +16,10 @@ type InjectionResult struct {
 }
 
 // defaultEngramServerJSON is the MCP server config for separate-file strategy.
-var defaultEngramServerJSON = []byte("{\n  \"command\": \"engram\",\n  \"args\": []\n}\n")
+var defaultEngramServerJSON = []byte("{\n  \"command\": \"engram\",\n  \"args\": [\"mcp\"]\n}\n")
 
 // defaultEngramOverlayJSON is the settings.json overlay for merge strategy (Gemini, etc.).
-var defaultEngramOverlayJSON = []byte("{\n  \"mcpServers\": {\n    \"engram\": {\n      \"command\": \"engram\",\n      \"args\": []\n    }\n  }\n}\n")
+var defaultEngramOverlayJSON = []byte("{\n  \"mcpServers\": {\n    \"engram\": {\n      \"command\": \"engram\",\n      \"args\": [\"mcp\"]\n    }\n  }\n}\n")
 
 // openCodeEngramOverlayJSON is the opencode.json overlay using the new MCP format.
 var openCodeEngramOverlayJSON = []byte("{\n  \"mcp\": {\n    \"engram\": {\n      \"command\": [\"engram\", \"mcp\"],\n      \"enabled\": true,\n      \"type\": \"local\"\n    }\n  }\n}\n")

--- a/testdata/golden/engram-claude-mcp.golden
+++ b/testdata/golden/engram-claude-mcp.golden
@@ -1,4 +1,4 @@
 {
   "command": "engram",
-  "args": []
+  "args": ["mcp"]
 }


### PR DESCRIPTION
## Resumen

Corrige el bug donde `defaultEngramServerJSON` y `defaultEngramOverlayJSON` generan `"args": []` en vez de `"args": ["mcp"]`.

Esto afecta a **todos los agentes que usan los defaults**: Cursor, Windsurf, y Gemini (via merge strategy). El resultado es que el cliente MCP ejecuta `engram` a secas (sin el subcomando `mcp`), engram imprime su texto de ayuda por stdout, y el cliente explota intentando parsear texto plano como JSON-RPC:

```
Client error for command Unexpected token 'e', "engram v1."... is not valid JSON
```

## Causa raíz

En `internal/components/engram/inject.go`, las variables default tenían:

```go
var defaultEngramServerJSON = []byte("... \"args\": [] ...")
var defaultEngramOverlayJSON = []byte("... \"args\": [] ...")
```

Mientras que los overlays de VS Code y OpenCode ya tenían los args correctos con `"mcp"`. Solo los defaults se quedaron sin el subcomando.

## Fix

- `internal/components/engram/inject.go`: cambiar `"args": []` → `"args": ["mcp"]` en ambas variables
- `testdata/golden/engram-claude-mcp.golden`: actualizar el golden file del test para reflejar el fix

## Agentes afectados

| Agente | Antes | Después |
|--------|-------|---------|
| Cursor | `engram` (imprime help, falla) | `engram mcp` (arranca MCP server) |
| Windsurf | `engram` (imprime help, falla) | `engram mcp` (arranca MCP server) |
| Gemini | `engram` (imprime help, falla) | `engram mcp` (arranca MCP server) |
| Claude Code | No afectado (usa `StrategySeparateMCPFiles` con el mismo default, ahora corregido) |
| VS Code | No afectado (ya tenía overlay propio con `["mcp"]`) |
| OpenCode | No afectado (ya tenía overlay propio con `["engram", "mcp"]`) |

Closes #58