### PR TITLE
ci: run workflows with Go 1.24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
+          go-version: "1.24"
 
       - name: Run unit tests
         run: go test ./...
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
+          go-version: "1.24"
 
       - name: Run E2E tests
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
+          go-version: "1.24"
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gentleman-programming/gentle-ai
 
-go 1.22
+go 1.24
 
 require (
 	github.com/charmbracelet/bubbletea v1.3.4


### PR DESCRIPTION
Closes #64

## Summary
- update CI jobs to use Go 1.24
- update the release workflow to use Go 1.24
- align `go.mod` with the repository minimum supported Go version

## Why
Recent install and preflight flows now expect Go 1.24+, so keeping workflows on Go 1.22 makes CI and release behavior diverge from the actual supported toolchain.