### PR TITLE
fix(installer): auto-confirm GGA install.sh on Windows

### DIFF
--- a/internal/installcmd/resolver.go
+++ b/internal/installcmd/resolver.go
@@ -124,6 +124,7 @@ func resolveOpenCodeInstall(profile system.PlatformProfile) (CommandSequence, er
 // resolveGGAInstall returns the correct install command sequence for GGA per platform.
 // - darwin: brew tap + brew install (via Gentleman-Programming/homebrew-tap)
 // - linux: git clone + install.sh (GGA is a pure Bash project, NOT a Go module)
+// Handles non-interactive install by auto-confirming the Y/N prompt.
 func resolveGGAInstall(profile system.PlatformProfile) (CommandSequence, error) {
 	switch profile.PackageManager {
 	case "brew":
@@ -149,7 +150,7 @@ func resolveGGAInstall(profile system.PlatformProfile) (CommandSequence, error) 
 		return CommandSequence{
 			{"powershell", "-NoProfile", "-Command", fmt.Sprintf("Remove-Item -Recurse -Force -ErrorAction SilentlyContinue '%s'; exit 0", cloneDst)},
 			{"git", "clone", "https://github.com/Gentleman-Programming/gentleman-guardian-angel.git", cloneDst},
-			{bash, bashScriptPath(profile, filepath.Join(cloneDst, "install.sh"))},
+			{bash, "-c", fmt.Sprintf("echo 'y' | %s", bashScriptPath(profile, filepath.Join(cloneDst, "install.sh")))},
 		}, nil
 	default:
 		return nil, fmt.Errorf(

--- a/internal/installcmd/resolver_test.go
+++ b/internal/installcmd/resolver_test.go
@@ -491,13 +491,13 @@ func TestResolveComponentInstall(t *testing.T) {
 			want:      CommandSequence{{"go", "install", "github.com/Gentleman-Programming/engram/cmd/engram@latest"}},
 		},
 		{
-			name:      "gga on windows cleans temp dir and uses git bash",
+			name:      "gga on windows cleans temp dir and uses git bash with auto-confirm",
 			profile:   system.PlatformProfile{OS: "windows", PackageManager: "winget"},
 			component: model.ComponentGGA,
 			want: CommandSequence{
 				{"powershell", "-NoProfile", "-Command", fmt.Sprintf("Remove-Item -Recurse -Force -ErrorAction SilentlyContinue '%s'; exit 0", filepath.Join(os.TempDir(), "gentleman-guardian-angel"))},
 				{"git", "clone", "https://github.com/Gentleman-Programming/gentleman-guardian-angel.git", filepath.Join(os.TempDir(), "gentleman-guardian-angel")},
-				{gitBashPath(), bashScriptPath(system.PlatformProfile{OS: "windows"}, filepath.Join(os.TempDir(), "gentleman-guardian-angel", "install.sh"))},
+				{gitBashPath(), "-c", fmt.Sprintf("echo 'y' | %s", bashScriptPath(system.PlatformProfile{OS: "windows"}, filepath.Join(os.TempDir(), "gentleman-guardian-angel", "install.sh")))},
 			},
 		},
 		{


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #84

## 🏷️ PR Type

What kind of change does this PR introduce?

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)

---

## 📝 Summary

The GGA (Gentleman Guardian Angel) installation fails on Windows when the install.sh script prompts for user confirmation ("Reinstall? (y/N):") in a non-interactive context. This fix adds automatic confirmation ("echo 'y' |") to the install.sh execution on Windows (winget), allowing installation to proceed without user input.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/installcmd/resolver.go` | Added auto-confirm ("echo 'y' ") to GGA install.sh command on Windows |
| `internal/installcmd/resolver_test.go` | Updated test case to expect the new command format |

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./...
```

- [x] Unit tests pass (`go test ./...`)
- [x] Manually tested locally

---

## 🤖 Automated Checks

The following checks run automatically on this PR:

| Check | Status | Description |
|-------|--------|-------------|
| Check Issue Reference | ✅ | PR body must contain `Closes/Fixes/Resolves #N` |
| Check Issue Has `status:approved` | ⏳ | Linked issue must have been approved before work began |
| Check PR Has `type:*` Label | ✅ | Exactly one `type:*` label must be applied |
| Unit Tests | ✅ | `go test ./...` must pass |
| E2E Tests | ⏳ | `cd e2e && ./docker-test.sh` must pass |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

This fix is scoped to Windows only (winget). The Linux and macOS installation paths for GGA are not affected by this issue and remain unchanged.
