### PR TITLE
fix(test): stabilize TestWithPostInstallNotesDoesNotChangeNonGGA in CI

### DIFF
--- a/internal/cli/run_notes_test.go
+++ b/internal/cli/run_notes_test.go
@@ -23,6 +23,10 @@ func TestWithPostInstallNotesAddsGGANextSteps(t *testing.T) {
 }
 
 func TestWithPostInstallNotesDoesNotChangeNonGGA(t *testing.T) {
+	// Set GOBIN to a directory already in PATH so that withGoInstallPathNote
+	// does not append a PATH guidance note for the Engram component.
+	t.Setenv("GOBIN", "/usr/local/bin")
+
 	report := verify.Report{Ready: true, FinalNote: "You're ready."}
 	resolved := planner.ResolvedPlan{OrderedComponents: []model.ComponentID{model.ComponentEngram}}
 


### PR DESCRIPTION
The test expected FinalNote to remain unchanged when only Engram was in
the plan, but withGoInstallPathNote appends a PATH guidance note when
the Go bin directory is not in $PATH — which is the case in CI. Fix by
setting GOBIN to /usr/local/bin (already in PATH) during the test.

https://claude.ai/code/session_01GU8Nx1z571JHNWV7mG5Yyp