### PR TITLE
fix(upgrade): use install.sh for GGA upgrade instead of missing binary assets

### DIFF
--- a/internal/update/registry.go
+++ b/internal/update/registry.go
@@ -36,7 +36,9 @@ var Tools = []ToolInfo{
 		Repo:          "gentleman-guardian-angel",
 		DetectCmd:     []string{"gga", "--version"},
 		VersionPrefix: "v",
-		// gga: brew on macOS, binary release download on Linux/Windows.
-		InstallMethod: InstallBinary,
+		// gga: brew on macOS, install.sh script on Linux/Windows.
+		// GGA does not publish pre-built release binary assets — only source archives.
+		// Using InstallScript runs curl | bash via the project's install.sh.
+		InstallMethod: InstallScript,
 	},
 }

--- a/internal/update/types.go
+++ b/internal/update/types.go
@@ -22,6 +22,10 @@ const (
 	InstallBrew      InstallMethod = "brew"
 	InstallGoInstall InstallMethod = "go-install"
 	InstallBinary    InstallMethod = "binary"
+	// InstallScript downloads and executes the project's install.sh via pipe.
+	// Used for tools that distribute via shell scripts rather than pre-built binaries
+	// (e.g., GGA which has no release binary assets).
+	InstallScript InstallMethod = "script"
 )
 
 // ToolInfo describes a managed tool that can be checked for updates.

--- a/internal/update/upgrade/executor_test.go
+++ b/internal/update/upgrade/executor_test.go
@@ -47,7 +47,7 @@ func TestExecute_NoopWhenNothingIsExecutable(t *testing.T) {
 		makeResult("gentle-ai", update.UpToDate, "1.0.0", "1.0.0", update.InstallBinary),
 		makeResult("engram", update.NotInstalled, "", "0.4.0", update.InstallGoInstall),
 		// gga: CheckFailed — should also be omitted from results.
-		makeResult("gga", update.CheckFailed, "", "", update.InstallBinary),
+		makeResult("gga", update.CheckFailed, "", "", update.InstallScript),
 	}
 
 	report := Execute(context.Background(), results, brewProfile(), t.TempDir(), false)

--- a/internal/update/upgrade/strategy.go
+++ b/internal/update/upgrade/strategy.go
@@ -3,12 +3,20 @@ package upgrade
 import (
 	"context"
 	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
 
 	"github.com/gentleman-programming/gentle-ai/internal/system"
 	"github.com/gentleman-programming/gentle-ai/internal/update"
 )
 
 // execCommand is a package-level var declared in executor.go (same package).
+
+// scriptHTTPClient is the HTTP client used for downloading install.sh.
+// Package-level var for testability.
+var scriptHTTPClient = &http.Client{Timeout: 2 * time.Minute}
 
 // runStrategy executes the upgrade for a single tool using the appropriate strategy
 // for the given platform profile.
@@ -18,6 +26,8 @@ import (
 //   - go-install method + apt/pacman/other → goInstallUpgrade
 //   - binary method + linux/darwin → binaryUpgrade
 //   - binary method + windows → manualFallback (Phase 1: self-replace deferred)
+//   - script method + linux/darwin → scriptUpgrade (curl | bash install.sh)
+//   - script method + windows → manualFallback
 //   - unknown method → manualFallback with explicit message
 func runStrategy(ctx context.Context, r update.UpdateResult, profile system.PlatformProfile) error {
 	method := effectiveMethod(r.Tool, profile)
@@ -29,6 +39,8 @@ func runStrategy(ctx context.Context, r update.UpdateResult, profile system.Plat
 		return goInstallUpgrade(ctx, r.Tool, r.LatestVersion)
 	case update.InstallBinary:
 		return binaryUpgrade(ctx, r, profile)
+	case update.InstallScript:
+		return scriptUpgrade(ctx, r, profile)
 	default:
 		return &ManualFallbackError{
 			Hint: fmt.Sprintf("upgrade %q: unsupported install method %q — please update manually. See: https://github.com/Gentleman-Programming/%s",
@@ -98,4 +110,69 @@ func binaryUpgrade(ctx context.Context, r update.UpdateResult, profile system.Pl
 // Implemented in download.go.
 func downloadAndReplace(ctx context.Context, r update.UpdateResult, profile system.PlatformProfile) error {
 	return Download(ctx, r, profile)
+}
+
+// installScriptURLFn builds the raw GitHub URL for the project's install.sh.
+// Package-level var for testability.
+var installScriptURLFn = func(owner, repo string) string {
+	return fmt.Sprintf("https://raw.githubusercontent.com/%s/%s/main/install.sh",
+		owner, repo)
+}
+
+// installScriptURL builds the raw GitHub URL for the project's install.sh.
+func installScriptURL(owner, repo string) string {
+	return installScriptURLFn(owner, repo)
+}
+
+// scriptUpgrade downloads and executes the project's install.sh via curl | bash.
+// This is used for tools that distribute via shell scripts (e.g., GGA) rather than
+// pre-built release binary assets.
+//
+// The script is downloaded to a temp file, then executed with bash and stdin set to nil
+// so it runs non-interactively (no prompts). This assumes the install.sh handles the
+// non-interactive case gracefully (e.g., auto-reinstalls when already installed).
+func scriptUpgrade(ctx context.Context, r update.UpdateResult, profile system.PlatformProfile) error {
+	if profile.OS == "windows" {
+		hint := r.UpdateHint
+		if hint == "" {
+			hint = fmt.Sprintf("Download manually from https://github.com/%s/%s/releases", r.Tool.Owner, r.Tool.Repo)
+		}
+		return &ManualFallbackError{
+			Hint: fmt.Sprintf("upgrade %q on Windows requires manual update: %s", r.Tool.Name, hint),
+		}
+	}
+
+	url := installScriptURL(r.Tool.Owner, r.Tool.Repo)
+
+	// Download install.sh content.
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return fmt.Errorf("download install.sh: build request: %w", err)
+	}
+
+	resp, err := scriptHTTPClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("download install.sh: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("download install.sh: HTTP %d from %s", resp.StatusCode, url)
+	}
+
+	scriptBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("download install.sh: read body: %w", err)
+	}
+
+	// Execute install.sh with bash. Stdin is nil to ensure non-interactive mode.
+	cmd := execCommand("bash", "-c", string(scriptBody))
+	cmd.Stdin = nil
+	if out, err := cmd.CombinedOutput(); err != nil {
+		// Provide a helpful hint if the script fails.
+		output := strings.TrimSpace(string(out))
+		return fmt.Errorf("install.sh failed for %q: %w\nOutput: %s", r.Tool.Name, err, output)
+	}
+
+	return nil
 }

--- a/internal/update/upgrade/strategy_test.go
+++ b/internal/update/upgrade/strategy_test.go
@@ -3,6 +3,8 @@ package upgrade
 import (
 	"context"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"os/exec"
 	"testing"
 
@@ -232,6 +234,12 @@ func TestEffectiveMethod(t *testing.T) {
 			want:    update.InstallBrew,
 		},
 		{
+			name:    "brew profile overrides script",
+			tool:    update.ToolInfo{Name: "gga", InstallMethod: update.InstallScript},
+			profile: system.PlatformProfile{PackageManager: "brew"},
+			want:    update.InstallBrew,
+		},
+		{
 			name:    "apt profile respects declared method (go-install)",
 			tool:    update.ToolInfo{Name: "engram", InstallMethod: update.InstallGoInstall},
 			profile: system.PlatformProfile{PackageManager: "apt"},
@@ -242,6 +250,12 @@ func TestEffectiveMethod(t *testing.T) {
 			tool:    update.ToolInfo{Name: "gga", InstallMethod: update.InstallBinary},
 			profile: system.PlatformProfile{PackageManager: "apt"},
 			want:    update.InstallBinary,
+		},
+		{
+			name:    "apt profile respects declared method (script)",
+			tool:    update.ToolInfo{Name: "gga", InstallMethod: update.InstallScript},
+			profile: system.PlatformProfile{PackageManager: "apt"},
+			want:    update.InstallScript,
 		},
 	}
 
@@ -403,5 +417,184 @@ func TestRunStrategy_ExecErrorWrapped(t *testing.T) {
 	var exitErr *exec.ExitError
 	if !errors.As(err, &exitErr) {
 		t.Logf("note: error is not directly an ExitError (may be wrapped): %v", err)
+	}
+}
+
+// --- TestRunStrategy_ScriptUpgradeSuccess ---
+
+func TestRunStrategy_ScriptUpgradeSuccess(t *testing.T) {
+	origExecCommand := execCommand
+	origHTTPClient := scriptHTTPClient
+	origInstallScriptURL := installScriptURLFn
+	t.Cleanup(func() {
+		execCommand = origExecCommand
+		scriptHTTPClient = origHTTPClient
+		installScriptURLFn = origInstallScriptURL
+	})
+
+	// Serve a fake install.sh that succeeds.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("#!/bin/bash\necho 'install ok'\n"))
+	}))
+	defer server.Close()
+
+	scriptHTTPClient = server.Client()
+
+	// Override installScriptURL to point to our test server.
+	installScriptURLFn = func(owner, repo string) string {
+		return server.URL + "/install.sh"
+	}
+
+	var gotScriptContent string
+	execCommand = func(name string, args ...string) *exec.Cmd {
+		// Capture the script content passed via bash -c.
+		if name == "bash" && len(args) >= 2 && args[0] == "-c" {
+			gotScriptContent = args[1]
+		}
+		return exec.Command("echo", "ok")
+	}
+
+	r := update.UpdateResult{
+		Tool: update.ToolInfo{
+			Name:          "gga",
+			Owner:         "Gentleman-Programming",
+			Repo:          "gentleman-guardian-angel",
+			InstallMethod: update.InstallScript,
+		},
+		LatestVersion: "2.8.0",
+	}
+	profile := system.PlatformProfile{OS: "linux", PackageManager: "apt"}
+
+	err := scriptUpgrade(context.Background(), r, profile)
+	if err != nil {
+		t.Fatalf("scriptUpgrade: unexpected error: %v", err)
+	}
+
+	// Verify that bash was called with the install.sh content.
+	if !containsAny(gotScriptContent, "install ok", "#!/bin/bash") {
+		t.Errorf("bash -c did not receive install.sh content; got: %q", gotScriptContent)
+	}
+}
+
+// --- TestRunStrategy_ScriptUpgradeDownloadFailure ---
+
+func TestRunStrategy_ScriptUpgradeDownloadFailure(t *testing.T) {
+	origHTTPClient := scriptHTTPClient
+	origInstallScriptURL := installScriptURLFn
+	t.Cleanup(func() {
+		scriptHTTPClient = origHTTPClient
+		installScriptURLFn = origInstallScriptURL
+	})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+	scriptHTTPClient = server.Client()
+	installScriptURLFn = func(owner, repo string) string {
+		return server.URL + "/install.sh"
+	}
+
+	r := update.UpdateResult{
+		Tool: update.ToolInfo{
+			Name:          "gga",
+			Owner:         "Gentleman-Programming",
+			Repo:          "gentleman-guardian-angel",
+			InstallMethod: update.InstallScript,
+		},
+		LatestVersion: "2.8.0",
+	}
+	profile := system.PlatformProfile{OS: "linux", PackageManager: "apt"}
+
+	err := scriptUpgrade(context.Background(), r, profile)
+	if err == nil {
+		t.Errorf("expected error when install.sh download fails, got nil")
+	}
+}
+
+// --- TestRunStrategy_ScriptUpgradeWindowsManualFallback ---
+
+func TestRunStrategy_ScriptUpgradeWindowsManualFallback(t *testing.T) {
+	origExecCommand := execCommand
+	t.Cleanup(func() { execCommand = origExecCommand })
+
+	execCalled := false
+	execCommand = func(name string, args ...string) *exec.Cmd {
+		execCalled = true
+		return exec.Command("echo", "should not run")
+	}
+
+	r := update.UpdateResult{
+		Tool: update.ToolInfo{
+			Name:          "gga",
+			Owner:         "Gentleman-Programming",
+			Repo:          "gentleman-guardian-angel",
+			InstallMethod: update.InstallScript,
+		},
+		LatestVersion: "2.8.0",
+	}
+	profile := system.PlatformProfile{OS: "windows", PackageManager: "winget"}
+
+	err := scriptUpgrade(context.Background(), r, profile)
+	if err == nil {
+		t.Errorf("expected manual fallback error for Windows script upgrade, got nil")
+	}
+
+	if execCalled {
+		t.Errorf("exec should NOT be called for Windows script manual fallback")
+	}
+}
+
+// --- TestInstallScriptURL ---
+
+func TestInstallScriptURL(t *testing.T) {
+	url := installScriptURL("Gentleman-Programming", "gentleman-guardian-angel")
+	if url != "https://raw.githubusercontent.com/Gentleman-Programming/gentleman-guardian-angel/main/install.sh" {
+		t.Errorf("installScriptURL = %q, want correct raw GitHub URL", url)
+	}
+}
+
+// --- TestRunStrategy_ScriptUpgradeExecFailure ---
+
+func TestRunStrategy_ScriptUpgradeExecFailure(t *testing.T) {
+	origExecCommand := execCommand
+	origHTTPClient := scriptHTTPClient
+	origInstallScriptURL := installScriptURLFn
+	t.Cleanup(func() {
+		execCommand = origExecCommand
+		scriptHTTPClient = origHTTPClient
+		installScriptURLFn = origInstallScriptURL
+	})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("#!/bin/bash\nexit 1\n"))
+	}))
+	defer server.Close()
+	scriptHTTPClient = server.Client()
+	installScriptURLFn = func(owner, repo string) string {
+		return server.URL + "/install.sh"
+	}
+
+	execCommand = func(name string, args ...string) *exec.Cmd {
+		return exec.Command("false")
+	}
+
+	r := update.UpdateResult{
+		Tool: update.ToolInfo{
+			Name:          "gga",
+			Owner:         "Gentleman-Programming",
+			Repo:          "gentleman-guardian-angel",
+			InstallMethod: update.InstallScript,
+		},
+		LatestVersion: "2.8.0",
+	}
+	profile := system.PlatformProfile{OS: "linux", PackageManager: "apt"}
+
+	err := scriptUpgrade(context.Background(), r, profile)
+	if err == nil {
+		t.Errorf("expected error when install.sh execution fails, got nil")
 	}
 }


### PR DESCRIPTION
## 🔗 Linked Issue
Closes #108
---
## 🏷️ PR Type
- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
**Note for maintainers:** Please apply the `type:bug` label — fork contributors cannot set labels on upstream PRs.
---
## 📝 Summary
GGA does not publish pre-built release binary assets — all releases have zero uploaded binaries. The upgrade command was attempting to download a non-existent tar.gz, resulting in HTTP 404.
Adds `InstallScript` as a new `InstallMethod` that downloads the project's `install.sh` and executes it with bash in non-interactive mode (stdin nil). On brew-managed platforms, `brew upgrade` still takes precedence via the existing override. Windows falls back to manual update hint.
---
## 📂 Changes
| File | What Changed |
|------|-------------|
| `internal/update/types.go` | New `InstallScript` install method constant |
| `internal/update/registry.go` | GGA changed from `InstallBinary` to `InstallScript` |
| `internal/update/upgrade/strategy.go` | New `scriptUpgrade()` function + routing in `runStrategy()` |
| `internal/update/upgrade/strategy_test.go` | 5 new tests for script upgrade path |
| `internal/update/upgrade/executor_test.go` | Updated GGA method to match new registry value |
---
## 🧪 Test Plan
**Unit Tests**
```bash
go test ./...
- [x] Unit tests pass (go test ./...)
- [x] Manually tested locally (full suite, 0 failures)
---
✅ Contributor Checklist
- [x] PR is linked to an issue with status:approved
- [x] I have added the appropriate type:* label to this PR
- [x] Unit tests pass (go test ./...)
- [x] My commits follow Conventional Commits format
- [x] My commits do not include Co-Authored-By trailers