### PR TITLE
fix(install): read state.json to pre-select previously installed agents

### DIFF
--- a/internal/cli/install_test.go
+++ b/internal/cli/install_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/gentleman-programming/gentle-ai/internal/model"
+	"github.com/gentleman-programming/gentle-ai/internal/state"
 	"github.com/gentleman-programming/gentle-ai/internal/system"
 )
 
@@ -37,6 +38,10 @@ func TestParseInstallFlagsSupportsCSVAndRepeated(t *testing.T) {
 }
 
 func TestNormalizeInstallFlagsDefaults(t *testing.T) {
+	// Use a temp dir as HOME so state.json from the real home doesn't interfere.
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
 	input, err := NormalizeInstallFlags(InstallFlags{}, system.DetectionResult{})
 	if err != nil {
 		t.Fatalf("NormalizeInstallFlags() error = %v", err)
@@ -222,7 +227,7 @@ func makeDetectionWithAgents(present ...string) system.DetectionResult {
 // omitted codex, so detection-driven selection silently dropped it.
 func TestDefaultAgentsFromDetection_CodexIsIncludedWhenPresent(t *testing.T) {
 	detection := makeDetectionWithAgents("codex")
-	agents := defaultAgentsFromDetection(detection)
+	agents := defaultAgentsFromDetection("", detection)
 
 	found := false
 	for _, id := range agents {
@@ -263,7 +268,7 @@ func TestDefaultAgentsFromDetection_AllAgentsMappedCorrectly(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.configAgent, func(t *testing.T) {
 			detection := makeDetectionWithAgents(tt.configAgent)
-			agents := defaultAgentsFromDetection(detection)
+			agents := defaultAgentsFromDetection("", detection)
 
 			found := false
 			for _, id := range agents {
@@ -281,5 +286,53 @@ func TestDefaultAgentsFromDetection_AllAgentsMappedCorrectly(t *testing.T) {
 				t.Errorf("defaultAgentsFromDetection() returned %d agents, want 1; got %v", len(agents), agents)
 			}
 		})
+	}
+}
+
+// TestDefaultAgentsFromDetection_UsesStateFileWhenPresent verifies that
+// defaultAgentsFromDetection returns only the agents recorded in state.json
+// when the file exists and is non-empty, ignoring any agent config dirs that
+// happen to be on disk. This covers issue #114.
+func TestDefaultAgentsFromDetection_UsesStateFileWhenPresent(t *testing.T) {
+	home := t.TempDir()
+
+	// Write state recording only opencode — even though we also simulate the
+	// claude-code config dir existing on disk.
+	if err := state.Write(home, state.InstallState{InstalledAgents: []string{"opencode"}}); err != nil {
+		t.Fatalf("state.Write() error = %v", err)
+	}
+
+	// Simulate detection with claude-code present on disk.
+	detection := makeDetectionWithAgents("claude-code")
+	agents := defaultAgentsFromDetection(home, detection)
+
+	// Must return exactly the persisted selection: only opencode.
+	want := []model.AgentID{model.AgentOpenCode}
+	if !reflect.DeepEqual(agents, want) {
+		t.Errorf("defaultAgentsFromDetection() with state = %v, want %v", agents, want)
+	}
+}
+
+// TestDefaultAgentsFromDetection_FallsBackToFSWhenStateMissing verifies that
+// defaultAgentsFromDetection falls back to filesystem detection when state.json
+// is absent. This is the backward-compat path for users who installed before
+// state persistence was added.
+func TestDefaultAgentsFromDetection_FallsBackToFSWhenStateMissing(t *testing.T) {
+	home := t.TempDir()
+	// No state.Write — state.json does not exist.
+
+	detection := makeDetectionWithAgents("claude-code")
+	agents := defaultAgentsFromDetection(home, detection)
+
+	// FS discovery must return claude-code since its config dir exists.
+	found := false
+	for _, id := range agents {
+		if id == model.AgentClaudeCode {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("defaultAgentsFromDetection() without state should fall back to FS; got %v", agents)
 	}
 }

--- a/internal/cli/validate.go
+++ b/internal/cli/validate.go
@@ -2,10 +2,12 @@ package cli
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/gentleman-programming/gentle-ai/internal/catalog"
 	"github.com/gentleman-programming/gentle-ai/internal/model"
+	"github.com/gentleman-programming/gentle-ai/internal/state"
 	"github.com/gentleman-programming/gentle-ai/internal/system"
 )
 
@@ -17,7 +19,8 @@ type InstallInput struct {
 func NormalizeInstallFlags(flags InstallFlags, detection system.DetectionResult) (InstallInput, error) {
 	selection := model.Selection{}
 
-	agents := defaultAgentsFromDetection(detection)
+	homeDir, _ := os.UserHomeDir()
+	agents := defaultAgentsFromDetection(homeDir, detection)
 	if len(flags.Agents) > 0 {
 		agents = asAgentIDs(flags.Agents)
 	}
@@ -163,7 +166,21 @@ func componentsForPreset(preset model.PresetID) []model.ComponentID {
 	}
 }
 
-func defaultAgentsFromDetection(detection system.DetectionResult) []model.AgentID {
+func defaultAgentsFromDetection(homeDir string, detection system.DetectionResult) []model.AgentID {
+	// Priority 1: Read persisted state (~/.gentle-ai/state.json).
+	// When present and non-empty, only the agents the user explicitly
+	// installed are returned. This prevents install from injecting into
+	// every IDE config dir that happens to exist on the system (issue #114).
+	if agents := state.InstalledAgentsFromState(homeDir); len(agents) > 0 {
+		ids := make([]model.AgentID, 0, len(agents))
+		for _, a := range agents {
+			ids = append(ids, model.AgentID(a))
+		}
+		return ids
+	}
+
+	// Priority 2: Fallback to filesystem detection (backward compat
+	// for users who installed before state persistence was added).
 	agents := []model.AgentID{}
 	for _, state := range detection.Configs {
 		if !state.Exists {

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -75,3 +75,15 @@ func Write(homeDir string, s InstallState) error {
 	}
 	return os.WriteFile(Path(homeDir), append(data, '\n'), 0o644)
 }
+
+// InstalledAgentsFromState reads the persisted agent list from state.json.
+// Returns the installed agent names, or nil if the file is absent, unreadable,
+// or contains an empty list. Callers should fall back to filesystem detection
+// when the result is nil.
+func InstalledAgentsFromState(homeDir string) []string {
+	s, err := Read(homeDir)
+	if err != nil || len(s.InstalledAgents) == 0 {
+		return nil
+	}
+	return s.InstalledAgents
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -22,6 +22,7 @@ import (
 	"github.com/gentleman-programming/gentle-ai/internal/opencode"
 	"github.com/gentleman-programming/gentle-ai/internal/pipeline"
 	"github.com/gentleman-programming/gentle-ai/internal/planner"
+	"github.com/gentleman-programming/gentle-ai/internal/state"
 	"github.com/gentleman-programming/gentle-ai/internal/system"
 	"github.com/gentleman-programming/gentle-ai/internal/tui/screens"
 	"github.com/gentleman-programming/gentle-ai/internal/update"
@@ -412,8 +413,9 @@ type Model struct {
 }
 
 func NewModel(detection system.DetectionResult, version string) Model {
+	homeDir, _ := os.UserHomeDir()
 	selection := model.Selection{
-		Agents:     preselectedAgents(detection),
+		Agents:     preselectedAgents(homeDir, detection),
 		Persona:    model.PersonaGentleman,
 		Preset:     model.PresetFullGentleman,
 		Components: componentsForPreset(model.PresetFullGentleman),
@@ -424,7 +426,7 @@ func NewModel(detection system.DetectionResult, version string) Model {
 		Version:              version,
 		Selection:            selection,
 		Detection:            detection,
-		UninstallAgents:      preselectedAgents(detection),
+		UninstallAgents:      preselectedAgents(homeDir, detection),
 		UninstallComponents:  defaultUninstallComponents(),
 		UninstallEngramScope: model.EngramUninstallScopeGlobal,
 		Progress: NewProgressState([]string{
@@ -2023,7 +2025,7 @@ func (m Model) withResetOperationState() Model {
 
 func (m Model) withResetUninstallState() Model {
 	m.UninstallMode = model.UninstallModePartial
-	m.UninstallAgents = preselectedAgents(m.Detection)
+	m.UninstallAgents = preselectedAgents(homeDir(), m.Detection)
 	m.UninstallComponents = defaultUninstallComponents()
 	m.UninstallProfilesAvailable = nil
 	m.UninstallProfilesToRemove = nil
@@ -3015,14 +3017,28 @@ func (m *Model) buildDependencyPlan() {
 	m.DependencyPlan = resolved
 }
 
-func preselectedAgents(detection system.DetectionResult) []model.AgentID {
+func preselectedAgents(homeDir string, detection system.DetectionResult) []model.AgentID {
+	// Priority 1: Read persisted state (~/.gentle-ai/state.json).
+	// When present and non-empty, only the agents the user explicitly
+	// installed are returned. This prevents install from injecting into
+	// every IDE config dir that happens to exist on the system (issue #114).
+	if agents := state.InstalledAgentsFromState(homeDir); len(agents) > 0 {
+		ids := make([]model.AgentID, 0, len(agents))
+		for _, a := range agents {
+			ids = append(ids, model.AgentID(a))
+		}
+		return ids
+	}
+
+	// Priority 2: Fallback to filesystem detection (backward compat
+	// for users who installed before state persistence was added).
 	selected := []model.AgentID{}
-	for _, state := range detection.Configs {
-		if !state.Exists {
+	for _, cs := range detection.Configs {
+		if !cs.Exists {
 			continue
 		}
 
-		switch strings.TrimSpace(state.Agent) {
+		switch strings.TrimSpace(cs.Agent) {
 		case string(model.AgentClaudeCode):
 			selected = append(selected, model.AgentClaudeCode)
 		case string(model.AgentOpenCode):

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gentleman-programming/gentle-ai/internal/model"
 	"github.com/gentleman-programming/gentle-ai/internal/pipeline"
 	"github.com/gentleman-programming/gentle-ai/internal/planner"
+	"github.com/gentleman-programming/gentle-ai/internal/state"
 	"github.com/gentleman-programming/gentle-ai/internal/system"
 	"github.com/gentleman-programming/gentle-ai/internal/tui/screens"
 	"github.com/gentleman-programming/gentle-ai/internal/update"
@@ -1878,7 +1879,7 @@ func TestDeleteResult_EnterRefreshesAndReturnsToBackups(t *testing.T) {
 // detection-driven TUI preselection silently dropped it.
 func TestPreselectedAgents_CodexIsIncludedWhenPresent(t *testing.T) {
 	detection := makeDetectionWithAgents("codex")
-	selected := preselectedAgents(detection)
+	selected := preselectedAgents("", detection)
 
 	found := false
 	for _, id := range selected {
@@ -2313,7 +2314,7 @@ func TestPreselectedAgents_AllSixAgentsMappedCorrectly(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.configAgent, func(t *testing.T) {
 			detection := makeDetectionWithAgents(tt.configAgent)
-			selected := preselectedAgents(detection)
+			selected := preselectedAgents("", detection)
 
 			found := false
 			for _, id := range selected {
@@ -3434,5 +3435,60 @@ func TestPinErrClearedOnScreenReentry(t *testing.T) {
 	// PinErr must be cleared on re-entry.
 	if afterReturn.PinErr != nil {
 		t.Fatalf("PinErr should be nil after returning to ScreenBackups, got: %v", afterReturn.PinErr)
+	}
+}
+
+// ─── state.json priority in preselectedAgents ───────────────────────────────
+
+// TestPreselectedAgents_UsesStateFileWhenPresent verifies that preselectedAgents
+// returns only the agents recorded in state.json when the file exists, ignoring
+// agent config dirs on disk. Covers issue #114.
+func TestPreselectedAgents_UsesStateFileWhenPresent(t *testing.T) {
+	home := t.TempDir()
+
+	// Write state recording only opencode.
+	if err := state.Write(home, state.InstallState{InstalledAgents: []string{"opencode"}}); err != nil {
+		t.Fatalf("state.Write() error = %v", err)
+	}
+
+	// Simulate detection with claude-code present on disk.
+	detection := system.DetectionResult{
+		Configs: []system.ConfigState{
+			{Agent: "claude-code", Path: "/home/user/.claude", Exists: true, IsDirectory: true},
+		},
+	}
+	selected := preselectedAgents(home, detection)
+
+	// Must return exactly the persisted selection: only opencode.
+	want := []model.AgentID{model.AgentOpenCode}
+	if !reflect.DeepEqual(selected, want) {
+		t.Errorf("preselectedAgents() with state = %v, want %v", selected, want)
+	}
+}
+
+// TestPreselectedAgents_FallsBackToFSWhenStateMissing verifies that
+// preselectedAgents falls back to filesystem detection when state.json
+// is absent.
+func TestPreselectedAgents_FallsBackToFSWhenStateMissing(t *testing.T) {
+	home := t.TempDir()
+	// No state.Write — state.json does not exist.
+
+	detection := system.DetectionResult{
+		Configs: []system.ConfigState{
+			{Agent: "claude-code", Path: "/home/user/.claude", Exists: true, IsDirectory: true},
+		},
+	}
+	selected := preselectedAgents(home, detection)
+
+	// FS discovery must return claude-code.
+	found := false
+	for _, id := range selected {
+		if id == model.AgentClaudeCode {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("preselectedAgents() without state should fall back to FS; got %v", selected)
 	}
 }


### PR DESCRIPTION
install (both CLI and TUI paths) ignored ~/.gentle-ai/state.json when determining which agents to configure. It always fell back to filesystem detection, selecting every IDE config dir on disk (claude-code, cursor, gemini-cli, etc.) regardless of the user's previous explicit selection.
This caused install to write configs, skills, and verification checks for all detected agents — the same issue fixed for sync in v1.8.12 (#107).
Add state.json as Priority 1 in both defaultAgentsFromDetection() (CLI) and preselectedAgents() (TUI), matching the pattern used by DiscoverAgents() in sync. When state.json exists and is non-empty, only the agents the user previously installed are returned. Falls back to filesystem detection when state.json is absent or empty (backward compat).
Closes #114
<!-- ⚠️ READ BEFORE SUBMITTING
  Every PR must be linked to an issue that has the "status:approved" label.
  PRs without a linked approved issue will be automatically rejected by CI.
  See CONTRIBUTING.md for the full contribution workflow.
-->
## 🔗 Linked Issue
Closes #114
---
## 🏷️ PR Type
- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
**Note for maintainers:** Please apply the `type:bug` label — fork contributors cannot set labels on upstream PRs.
---
## 📝 Summary
`install` (both CLI and TUI paths) ignored `~/.gentle-ai/state.json` when determining which agents to configure. It always fell back to filesystem detection, selecting every IDE config dir on disk regardless of the user's previous explicit selection. This caused configs, skills, and verification checks to be written for all detected agents — the same issue fixed for `sync` in v1.8.12 (#107).
Adds `state.json` as Priority 1 in both `defaultAgentsFromDetection()` (CLI) and `preselectedAgents()` (TUI), matching the pattern used by `DiscoverAgents()` in sync.
---
## 📂 Changes
| File / Area | What Changed |
|-------------|-------------|
| `internal/cli/validate.go` | `defaultAgentsFromDetection()` reads `state.json` first, falls back to FS detection |
| `internal/tui/model.go` | `preselectedAgents()` same pattern; `NewModel()` passes `homeDir` |
| `internal/cli/install_test.go` | Updated existing tests for new signature + 2 new tests (state priority + FS fallback) |
| `internal/tui/model_test.go` | Updated existing tests for new signature + 2 new tests (state priority + FS fallback) |
---
## 🧪 Test Plan
**Unit Tests**
```bash
go test ./...
E2E Tests (Docker required)
cd e2e && ./docker-test.sh
- [x] Unit tests pass (go test ./..., 0 failures, 37 packages)
- [x] E2E tests pass (cd e2e && ./docker-test.sh, 3/3 platforms, 210/210 tests)
- [x] TestDefaultAgentsFromDetection_UsesStateFileWhenPresent — state.json wins over FS detection
- [x] TestDefaultAgentsFromDetection_FallsBackToFSWhenStateMissing — backward compat
- [x] TestPreselectedAgents_UsesStateFileWhenPresent — TUI path respects state.json
- [x] TestPreselectedAgents_FallsBackToFSWhenStateMissing — TUI backward compat
- [x] All existing agent-mapping regression tests pass with empty homeDir
---
✅ Contributor Checklist
- [x] PR is linked to an issue with status:approved
- [x] I have added the appropriate type:* label to this PR
- [x] Unit tests pass (go test ./...)
- [x] E2E tests pass (cd e2e && ./docker-test.sh)
- [x] My commits follow Conventional Commits format
- [x] My commits do not include Co-Authored-By trailers