### PR TITLE
fix(tui): pre-load existing model assignments in model pickers

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -2,8 +2,10 @@ package tui
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -238,9 +240,15 @@ type Model struct {
 
 	// UpgradeErr holds the error from the last upgrade run (nil on success).
 	UpgradeErr error
+
+	// HomeDir is the user's home directory, resolved once at construction.
+	// Used to locate config files (opencode.json, CLAUDE.md) for pre-loading
+	// model picker assignments (issue #115).
+	HomeDir string
 }
 
 func NewModel(detection system.DetectionResult, version string) Model {
+	homeDir, _ := os.UserHomeDir()
 	selection := model.Selection{
 		Agents:     preselectedAgents(detection),
 		Persona:    model.PersonaGentleman,
@@ -253,6 +261,7 @@ func NewModel(detection system.DetectionResult, version string) Model {
 		Version:   version,
 		Selection: selection,
 		Detection: detection,
+		HomeDir:   homeDir,
 		Progress: NewProgressState([]string{
 			"Install dependencies",
 			"Configure selected agents",
@@ -669,12 +678,20 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 		case 0: // Configure Claude models
 			m.ModelConfigMode = true
 			m.ClaudeModelPicker = screens.NewClaudeModelPickerState()
+			if existing := readExistingClaudeModelAssignments(m.HomeDir); existing != nil {
+				m.ClaudeModelPicker.Preset = claudeAssignmentsMatchPreset(existing)
+				m.ClaudeModelPicker.CustomAssignments = existing
+				m.Selection.ClaudeModelAssignments = existing
+			}
 			m.setScreen(ScreenClaudeModelPicker)
 		case 1: // Configure OpenCode models
 			m.ModelConfigMode = true
 			cachePath := opencode.DefaultCachePath()
 			if _, err := osStatModelCache(cachePath); err == nil {
 				m.ModelPicker = screens.NewModelPickerState(cachePath)
+				if existing := readExistingOpenCodeModelAssignments(m.HomeDir); existing != nil {
+					m.Selection.ModelAssignments = existing
+				}
 			} else {
 				m.ModelPicker = screens.ModelPickerState{}
 			}
@@ -714,6 +731,11 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 			m.Selection.Components = componentsForPreset(options[m.Cursor])
 			if m.shouldShowClaudeModelPickerScreen() {
 				m.ClaudeModelPicker = screens.NewClaudeModelPickerState()
+				if existing := readExistingClaudeModelAssignments(m.HomeDir); existing != nil {
+					m.ClaudeModelPicker.Preset = claudeAssignmentsMatchPreset(existing)
+					m.ClaudeModelPicker.CustomAssignments = existing
+					m.Selection.ClaudeModelAssignments = existing
+				}
 				m.setScreen(ScreenClaudeModelPicker)
 				return m, nil
 			}
@@ -741,6 +763,9 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 					// Cache exists — OpenCode has been run at least once.
 					// Show the model picker so the user can assign models.
 					m.ModelPicker = screens.NewModelPickerState(cachePath)
+					if existing := readExistingOpenCodeModelAssignments(m.HomeDir); existing != nil {
+						m.Selection.ModelAssignments = existing
+					}
 					m.setScreen(ScreenModelPicker)
 					return m, nil
 				}
@@ -812,6 +837,11 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 				// Show model picker screens if needed (components are now set).
 				if m.shouldShowClaudeModelPickerScreen() {
 					m.ClaudeModelPicker = screens.NewClaudeModelPickerState()
+					if existing := readExistingClaudeModelAssignments(m.HomeDir); existing != nil {
+						m.ClaudeModelPicker.Preset = claudeAssignmentsMatchPreset(existing)
+						m.ClaudeModelPicker.CustomAssignments = existing
+						m.Selection.ClaudeModelAssignments = existing
+					}
 					m.setScreen(ScreenClaudeModelPicker)
 					return m, nil
 				}
@@ -1451,4 +1481,162 @@ func hasSelectedComponent(components []model.ComponentID, target model.Component
 		}
 	}
 	return false
+}
+
+// ─── Model picker pre-loading (issue #115) ──────────────────────────────
+
+// readExistingOpenCodeModelAssignments reads ~/.config/opencode/opencode.json
+// and extracts the "model" field from each SDD agent entry under the "agent"
+// map. Returns a map of phase name → ModelAssignment (provider/model-id).
+// Returns nil if the file does not exist or has no agent model assignments.
+func readExistingOpenCodeModelAssignments(homeDir string) map[string]model.ModelAssignment {
+	path := filepath.Join(homeDir, ".config", "opencode", "opencode.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+
+	root := map[string]any{}
+	if err := json.Unmarshal(data, &root); err != nil {
+		return nil
+	}
+
+	agentRaw, ok := root["agent"]
+	if !ok {
+		return nil
+	}
+	agentMap, ok := agentRaw.(map[string]any)
+	if !ok {
+		return nil
+	}
+
+	assignments := make(map[string]model.ModelAssignment)
+	for name, entryRaw := range agentMap {
+		entry, ok := entryRaw.(map[string]any)
+		if !ok {
+			continue
+		}
+		modelVal, ok := entry["model"].(string)
+		if !ok || modelVal == "" {
+			continue
+		}
+		// Split "provider/model-id" into ProviderID and ModelID.
+		parts := strings.SplitN(modelVal, "/", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		assignments[name] = model.ModelAssignment{
+			ProviderID: parts[0],
+			ModelID:    parts[1],
+		}
+	}
+
+	if len(assignments) == 0 {
+		return nil
+	}
+	return assignments
+}
+
+// claudeModelAssignmentMarkers are the HTML comments that delimit the model
+// assignment table inside CLAUDE.md.
+const (
+	claudeModelOpenMarker  = "<!-- gentle-ai:sdd-model-assignments -->"
+	claudeModelCloseMarker = "<!-- /gentle-ai:sdd-model-assignments -->"
+)
+
+// readExistingClaudeModelAssignments reads ~/.claude/CLAUDE.md and extracts
+// the model assignment table between the gentle-ai markers. Returns a map of
+// phase name → ClaudeModelAlias. Returns nil if the file or markers are missing.
+func readExistingClaudeModelAssignments(homeDir string) map[string]model.ClaudeModelAlias {
+	path := filepath.Join(homeDir, ".claude", "CLAUDE.md")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+
+	content := string(data)
+	start := strings.Index(content, claudeModelOpenMarker)
+	end := strings.Index(content, claudeModelCloseMarker)
+	if start == -1 || end == -1 || end < start {
+		return nil
+	}
+
+	// Extract the section between markers.
+	section := content[start+len(claudeModelOpenMarker) : end]
+
+	assignments := make(map[string]model.ClaudeModelAlias)
+	// Each row looks like: | phase | model | reason |
+	lines := strings.Split(section, "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "|") {
+			continue
+		}
+		// Skip header and separator rows.
+		if strings.Contains(line, "---") || strings.Contains(line, "Phase") {
+			continue
+		}
+		cells := strings.Split(line, "|")
+		if len(cells) < 3 {
+			continue
+		}
+		phase := strings.TrimSpace(cells[1])
+		alias := strings.TrimSpace(cells[2])
+		if phase == "" {
+			continue
+		}
+		a := model.ClaudeModelAlias(alias)
+		if a.Valid() {
+			assignments[phase] = a
+		}
+	}
+
+	if len(assignments) == 0 {
+		return nil
+	}
+	return assignments
+}
+
+// claudeAssignmentsMatchPreset checks whether the given assignments map
+// exactly matches a known preset. Returns the matching preset name, or empty
+// string if no match (meaning custom assignments).
+func claudeAssignmentsMatchPreset(assignments map[string]model.ClaudeModelAlias) screens.ClaudeModelPreset {
+	presets := []struct {
+		name  screens.ClaudeModelPreset
+		build func() map[string]model.ClaudeModelAlias
+	}{
+		{screens.ClaudePresetBalanced, model.ClaudeModelPresetBalanced},
+		{screens.ClaudePresetPerformance, model.ClaudeModelPresetPerformance},
+		{screens.ClaudePresetEconomy, model.ClaudeModelPresetEconomy},
+	}
+
+	for _, p := range presets {
+		candidate := p.build()
+		if mapsEqual(assignments, candidate) {
+			return p.name
+		}
+	}
+	return screens.ClaudePresetCustom
+}
+
+func mapsEqual[K, V comparable](a, b map[K]V) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if b[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
+// opencodeSettingsPath returns the path to the opencode.json settings file.
+func opencodeSettingsPath(homeDir string) string {
+	return filepath.Join(homeDir, ".config", "opencode", "opencode.json")
+}
+
+// claudeSystemPromptPath returns the path to the CLAUDE.md system prompt file.
+func claudeSystemPromptPath(homeDir string) string {
+	return filepath.Join(homeDir, ".claude", "CLAUDE.md")
 }

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 
@@ -1220,6 +1221,160 @@ func TestPreselectedAgents_AllSixAgentsMappedCorrectly(t *testing.T) {
 			if len(selected) != 1 {
 				t.Errorf("preselectedAgents() returned %d agents, want 1 (only %q detected); got %v",
 					len(selected), tt.configAgent, selected)
+			}
+		})
+	}
+}
+
+// ─── Model picker pre-loading tests (issue #115) ────────────────────────
+
+func TestReadExistingOpenCodeModelAssignments(t *testing.T) {
+	home := t.TempDir()
+	configDir := filepath.Join(home, ".config", "opencode")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+
+	// No file yet → nil.
+	assignments := readExistingOpenCodeModelAssignments(home)
+	if assignments != nil {
+		t.Fatalf("expected nil when file missing, got %v", assignments)
+	}
+
+	// Write a config with SDD agent model assignments.
+	config := `{
+  "model": "anthropic/claude-sonnet-4-20250514",
+  "agent": {
+    "sdd-orchestrator": {"mode": "primary", "model": "anthropic/claude-opus-4-6"},
+    "sdd-init": {"mode": "subagent", "model": "openai/gpt-4o"},
+    "sdd-apply": {"mode": "subagent", "model": "google/gemini-2.5-pro"},
+    "other-agent": {"mode": "subagent"}
+  }
+}`
+	path := filepath.Join(configDir, "opencode.json")
+	if err := os.WriteFile(path, []byte(config), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	assignments = readExistingOpenCodeModelAssignments(home)
+	if assignments == nil {
+		t.Fatalf("expected non-nil assignments")
+	}
+
+	// sdd-orchestrator → anthropic/claude-opus-4-6
+	if a, ok := assignments["sdd-orchestrator"]; !ok {
+		t.Error("missing sdd-orchestrator")
+	} else if a.ProviderID != "anthropic" || a.ModelID != "claude-opus-4-6" {
+		t.Errorf("sdd-orchestrator = %s/%s, want anthropic/claude-opus-4-6", a.ProviderID, a.ModelID)
+	}
+
+	// sdd-init → openai/gpt-4o
+	if a, ok := assignments["sdd-init"]; !ok {
+		t.Error("missing sdd-init")
+	} else if a.ProviderID != "openai" || a.ModelID != "gpt-4o" {
+		t.Errorf("sdd-init = %s/%s, want openai/gpt-4o", a.ProviderID, a.ModelID)
+	}
+
+	// other-agent has no model field → should be skipped.
+	if _, ok := assignments["other-agent"]; ok {
+		t.Error("other-agent should be skipped (no model field)")
+	}
+}
+
+func TestReadExistingClaudeModelAssignments(t *testing.T) {
+	home := t.TempDir()
+	claudeDir := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+
+	// No file yet → nil.
+	assignments := readExistingClaudeModelAssignments(home)
+	if assignments != nil {
+		t.Fatalf("expected nil when file missing, got %v", assignments)
+	}
+
+	// Write CLAUDE.md with model assignment table (balanced preset).
+	content := `# CLAUDE.md
+
+Some intro text.
+
+<!-- gentle-ai:sdd-model-assignments -->
+## Model Assignments
+
+| Phase | Default Model | Reason |
+|-------|---------------|--------|
+| orchestrator | opus | Coordinates |
+| sdd-explore | sonnet | Reads code |
+| sdd-propose | opus | Architecture |
+| sdd-spec | sonnet | Writing |
+| sdd-design | opus | Architecture |
+| sdd-tasks | sonnet | Breakdown |
+| sdd-apply | sonnet | Implementation |
+| sdd-verify | sonnet | Validation |
+| sdd-archive | haiku | Copy and close |
+| default | sonnet | General delegation |
+
+<!-- /gentle-ai:sdd-model-assignments -->
+`
+	path := filepath.Join(claudeDir, "CLAUDE.md")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	assignments = readExistingClaudeModelAssignments(home)
+	if assignments == nil {
+		t.Fatalf("expected non-nil assignments")
+	}
+
+	// Verify balanced preset values.
+	if assignments["orchestrator"] != model.ClaudeModelOpus {
+		t.Errorf("orchestrator = %q, want opus", assignments["orchestrator"])
+	}
+	if assignments["sdd-explore"] != model.ClaudeModelSonnet {
+		t.Errorf("sdd-explore = %q, want sonnet", assignments["sdd-explore"])
+	}
+	if assignments["sdd-archive"] != model.ClaudeModelHaiku {
+		t.Errorf("sdd-archive = %q, want haiku", assignments["sdd-archive"])
+	}
+	if assignments["default"] != model.ClaudeModelSonnet {
+		t.Errorf("default = %q, want sonnet", assignments["default"])
+	}
+}
+
+func TestClaudeAssignmentsMatchPreset(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  map[string]model.ClaudeModelAlias
+		expect screens.ClaudeModelPreset
+	}{
+		{
+			name:   "balanced matches",
+			input:  model.ClaudeModelPresetBalanced(),
+			expect: screens.ClaudePresetBalanced,
+		},
+		{
+			name:   "performance matches",
+			input:  model.ClaudeModelPresetPerformance(),
+			expect: screens.ClaudePresetPerformance,
+		},
+		{
+			name:   "economy matches",
+			input:  model.ClaudeModelPresetEconomy(),
+			expect: screens.ClaudePresetEconomy,
+		},
+		{
+			name:   "custom does not match any preset",
+			input:  map[string]model.ClaudeModelAlias{"orchestrator": model.ClaudeModelOpus, "sdd-explore": model.ClaudeModelHaiku},
+			expect: screens.ClaudePresetCustom,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := claudeAssignmentsMatchPreset(tt.input)
+			if got != tt.expect {
+				t.Errorf("got %q, want %q", got, tt.expect)
 			}
 		})
 	}


### PR DESCRIPTION
Re-running gentle-ai install (or using "Configure models" from the welcome menu) always showed the model picker with empty/default values, ignoring the user's previously chosen models. Users who carefully assigned models for each SDD phase had to redo the entire selection on every install run.
The v1.8.9 release notes state "Reinstalling gentle-ai is now safe — your model choices survive." This is true at the file level (3-way priority preserves existing config), but the TUI picker forced users to redo their selections, creating confusion about whether their choices were actually preserved.
Add pre-loading that reads existing config before showing the picker:
- OpenCode: reads opencode.json and extracts per-agent model fields into Selection.ModelAssignments
- Claude: reads CLAUDE.md and parses the model assignment table, including automatic preset detection (balanced/performance/economy/custom)
When existing assignments are found, the picker displays previous choices instead of "(default)". Users can still change any assignment. When no config exists (first install), behavior is unchanged.
Closes #115
<!-- ⚠️ READ BEFORE SUBMITTING
  Every PR must be linked to an issue that has the "status:approved" label.
  PRs without a linked approved issue will be automatically rejected by CI.
  See CONTRIBUTING.md for the full contribution workflow.
-->
## 🔗 Linked Issue
Closes #115
---
## 🏷️ PR Type
- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
> **Note for maintainers:** Please apply the `type:bug` label — fork contributors cannot set labels on upstream PRs.
---
## 📝 Summary
Re-running `gentle-ai install` (or using "Configure models" from the welcome menu) always showed the model picker with empty/default values, ignoring the user's previously chosen models. The v1.8.9 release notes state model choices survive reinstallation at the file level, but the TUI picker did not reflect this.
Adds pre-loading of existing model assignments before showing the picker, for both OpenCode and Claude agents.
---
## 📂 Changes
| File / Area | What Changed |
|-------------|-------------|
| `internal/tui/model.go` | New `readExistingOpenCodeModelAssignments()` — parses opencode.json for per-agent model fields |
| `internal/tui/model.go` | New `readExistingClaudeModelAssignments()` — parses CLAUDE.md markdown table between markers |
| `internal/tui/model.go` | New `claudeAssignmentsMatchPreset()` — detects balanced/performance/economy/custom from existing assignments |
| `internal/tui/model.go` | Added `HomeDir` field to `Model` struct for config file resolution |
| `internal/tui/model.go` | Pre-load wired into all 5 model picker call sites (2 OpenCode, 3 Claude) |
| `internal/tui/model_test.go` | 3 new tests: OpenCode pre-load, Claude pre-load, preset detection |
---
## 🧪 Test Plan
**Unit Tests**
```bash
go test ./...
E2E Tests (Docker required)
cd e2e && ./docker-test.sh
- [x] Unit tests pass (go test ./..., 0 failures, 37 packages)
- [x] E2E tests pass (cd e2e && ./docker-test.sh, 3/3 platforms, 210/210 tests)
- [x] TestReadExistingOpenCodeModelAssignments — parses opencode.json, skips agents without model field
- [x] TestReadExistingClaudeModelAssignments — parses CLAUDE.md table between markers
- [x] TestClaudeAssignmentsMatchPreset — balanced/performance/economy/custom detection
---
✅ Contributor Checklist
- [x] PR is linked to an issue with status:approved
- [x] I have added the appropriate type:* label to this PR
- [x] Unit tests pass (go test ./...)
- [x] E2E tests pass (cd e2e && ./docker-test.sh)
- [x] My commits follow Conventional Commits format
- [x] My commits do not include Co-Authored-By trailers