### PR TITLE
feat(kilocode): add support for Kilo Code agent

### DIFF
--- a/internal/agents/factory.go
+++ b/internal/agents/factory.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gentleman-programming/gentle-ai/internal/agents/codex"
 	cursoradapter "github.com/gentleman-programming/gentle-ai/internal/agents/cursor"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/gemini"
+	"github.com/gentleman-programming/gentle-ai/internal/agents/kilocode"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/opencode"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/vscode"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/windsurf"
@@ -20,6 +21,8 @@ func NewAdapter(agent model.AgentID) (Adapter, error) {
 		return claude.NewAdapter(), nil
 	case model.AgentOpenCode:
 		return opencode.NewAdapter(), nil
+	case model.AgentKilocode:
+		return kilocode.NewAdapter(), nil
 	case model.AgentGeminiCLI:
 		return gemini.NewAdapter(), nil
 	case model.AgentCursor:
@@ -43,6 +46,7 @@ func NewDefaultRegistry() (*Registry, error) {
 	for _, agent := range []model.AgentID{
 		model.AgentClaudeCode,
 		model.AgentOpenCode,
+		model.AgentKilocode,
 		model.AgentGeminiCLI,
 		model.AgentCursor,
 		model.AgentVSCodeCopilot,

--- a/internal/agents/kilocode/adapter.go
+++ b/internal/agents/kilocode/adapter.go
@@ -1,0 +1,156 @@
+package kilocode
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/gentleman-programming/gentle-ai/internal/installcmd"
+	"github.com/gentleman-programming/gentle-ai/internal/model"
+	"github.com/gentleman-programming/gentle-ai/internal/system"
+)
+
+var LookPathOverride = exec.LookPath
+
+type statResult struct {
+	isDir bool
+	err   error
+}
+
+type Adapter struct {
+	lookPath func(string) (string, error)
+	statPath func(string) statResult
+	resolver installcmd.Resolver
+}
+
+func NewAdapter() *Adapter {
+	return &Adapter{
+		lookPath: LookPathOverride,
+		statPath: defaultStat,
+		resolver: installcmd.NewResolver(),
+	}
+}
+
+// --- Identity ---
+
+func (a *Adapter) Agent() model.AgentID {
+	return model.AgentKilocode
+}
+
+func (a *Adapter) Tier() model.SupportTier {
+	return model.TierFull
+}
+
+// --- Detection ---
+
+func (a *Adapter) Detect(_ context.Context, homeDir string) (bool, string, string, bool, error) {
+	configPath := ConfigPath(homeDir)
+
+	binaryPath, err := a.lookPath("kilo")
+	installed := err == nil
+
+	stat := a.statPath(configPath)
+	if stat.err != nil {
+		if os.IsNotExist(stat.err) {
+			return installed, binaryPath, configPath, false, nil
+		}
+		return false, "", "", false, stat.err
+	}
+
+	return installed, binaryPath, configPath, stat.isDir, nil
+}
+
+// --- Installation ---
+
+func (a *Adapter) SupportsAutoInstall() bool {
+	return true
+}
+
+func (a *Adapter) InstallCommand(profile system.PlatformProfile) ([][]string, error) {
+	resolver := a.resolver
+	if resolver == nil {
+		resolver = installcmd.NewResolver()
+	}
+
+	return resolver.ResolveAgentInstall(profile, a.Agent())
+}
+
+// --- Config paths ---
+
+func (a *Adapter) GlobalConfigDir(homeDir string) string {
+	return filepath.Join(homeDir, ".config", "kilo")
+}
+
+func (a *Adapter) SystemPromptDir(homeDir string) string {
+	return filepath.Join(homeDir, ".config", "kilo")
+}
+
+func (a *Adapter) SystemPromptFile(homeDir string) string {
+	return filepath.Join(homeDir, ".config", "kilo", "AGENTS.md")
+}
+
+func (a *Adapter) SkillsDir(homeDir string) string {
+	return filepath.Join(homeDir, ".config", "kilo", "skills")
+}
+
+func (a *Adapter) SettingsPath(homeDir string) string {
+	return filepath.Join(homeDir, ".config", "kilo", "opencode.json")
+}
+
+// --- Config strategies ---
+
+func (a *Adapter) SystemPromptStrategy() model.SystemPromptStrategy {
+	return model.StrategyFileReplace
+}
+
+func (a *Adapter) MCPStrategy() model.MCPStrategy {
+	return model.StrategyMergeIntoSettings
+}
+
+// --- MCP ---
+
+func (a *Adapter) MCPConfigPath(homeDir string, serverName string) string {
+	// Kilocode merges into opencode.json, but this provides the path
+	// for components that use the separate-file strategy fallback.
+	return filepath.Join(homeDir, ".config", "kilo", "opencode.json")
+}
+
+// --- Optional capabilities ---
+
+func (a *Adapter) SupportsOutputStyles() bool {
+	return false
+}
+
+func (a *Adapter) OutputStyleDir(_ string) string {
+	return ""
+}
+
+func (a *Adapter) SupportsSlashCommands() bool {
+	return true
+}
+
+func (a *Adapter) CommandsDir(homeDir string) string {
+	return filepath.Join(homeDir, ".config", "kilo", "commands")
+}
+
+func (a *Adapter) SupportsSkills() bool {
+	return true
+}
+
+func (a *Adapter) SupportsSystemPrompt() bool {
+	return true
+}
+
+func (a *Adapter) SupportsMCP() bool {
+	return true
+}
+
+func defaultStat(path string) statResult {
+	info, err := os.Stat(path)
+	if err != nil {
+		return statResult{err: err}
+	}
+
+	return statResult{isDir: info.IsDir()}
+}

--- a/internal/agents/kilocode/adapter_test.go
+++ b/internal/agents/kilocode/adapter_test.go
@@ -1,0 +1,241 @@
+package kilocode
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/internal/model"
+	"github.com/gentleman-programming/gentle-ai/internal/system"
+)
+
+func TestDetect(t *testing.T) {
+	tests := []struct {
+		name            string
+		lookPathPath    string
+		lookPathErr     error
+		stat            statResult
+		wantInstalled   bool
+		wantBinaryPath  string
+		wantConfigPath  string
+		wantConfigFound bool
+		wantErr         bool
+	}{
+		{
+			name:            "binary found and config directory found",
+			lookPathPath:    "/usr/local/bin/kilo",
+			stat:            statResult{isDir: true},
+			wantInstalled:   true,
+			wantBinaryPath:  "/usr/local/bin/kilo",
+			wantConfigPath:  filepath.Join("/tmp/home", ".config", "kilo"),
+			wantConfigFound: true,
+		},
+		{
+			name:            "binary not found and config exists",
+			lookPathErr:     errors.New("executable file not found"),
+			stat:            statResult{isDir: true},
+			wantInstalled:   false,
+			wantBinaryPath:  "",
+			wantConfigPath:  filepath.Join("/tmp/home", ".config", "kilo"),
+			wantConfigFound: true,
+		},
+		{
+			name:            "binary found and config not exists",
+			lookPathPath:    "/usr/local/bin/kilo",
+			stat:            statResult{err: os.ErrNotExist},
+			wantInstalled:   true,
+			wantBinaryPath:  "/usr/local/bin/kilo",
+			wantConfigPath:  filepath.Join("/tmp/home", ".config", "kilo"),
+			wantConfigFound: false,
+		},
+		{
+			name:            "binary not found and config not exists",
+			lookPathErr:     errors.New("executable file not found"),
+			stat:            statResult{err: os.ErrNotExist},
+			wantInstalled:   false,
+			wantBinaryPath:  "",
+			wantConfigPath:  filepath.Join("/tmp/home", ".config", "kilo"),
+			wantConfigFound: false,
+		},
+		{
+			name:    "stat error bubbles up",
+			stat:    statResult{err: errors.New("permission denied")},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := &Adapter{
+				lookPath: func(string) (string, error) {
+					return tt.lookPathPath, tt.lookPathErr
+				},
+				statPath: func(string) statResult {
+					return tt.stat
+				},
+			}
+
+			installed, binaryPath, configPath, configFound, err := a.Detect(context.Background(), "/tmp/home")
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Detect() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if tt.wantErr {
+				return
+			}
+
+			if installed != tt.wantInstalled {
+				t.Fatalf("Detect() installed = %v, want %v", installed, tt.wantInstalled)
+			}
+
+			if binaryPath != tt.wantBinaryPath {
+				t.Fatalf("Detect() binaryPath = %q, want %q", binaryPath, tt.wantBinaryPath)
+			}
+
+			if configPath != tt.wantConfigPath {
+				t.Fatalf("Detect() configPath = %q, want %q", configPath, tt.wantConfigPath)
+			}
+
+			if configFound != tt.wantConfigFound {
+				t.Fatalf("Detect() configFound = %v, want %v", configFound, tt.wantConfigFound)
+			}
+		})
+	}
+}
+
+func TestGlobalConfigDir(t *testing.T) {
+	a := NewAdapter()
+	want := filepath.Join("/home/user", ".config", "kilo")
+	if got := a.GlobalConfigDir("/home/user"); got != want {
+		t.Fatalf("GlobalConfigDir() = %q, want %q", got, want)
+	}
+}
+
+func TestSystemPromptFile(t *testing.T) {
+	a := NewAdapter()
+	want := filepath.Join("/home/user", ".config", "kilo", "AGENTS.md")
+	if got := a.SystemPromptFile("/home/user"); got != want {
+		t.Fatalf("SystemPromptFile() = %q, want %q", got, want)
+	}
+}
+
+func TestSkillsDir(t *testing.T) {
+	a := NewAdapter()
+	want := filepath.Join("/home/user", ".config", "kilo", "skills")
+	if got := a.SkillsDir("/home/user"); got != want {
+		t.Fatalf("SkillsDir() = %q, want %q", got, want)
+	}
+}
+
+func TestSettingsPath(t *testing.T) {
+	a := NewAdapter()
+	want := filepath.Join("/home/user", ".config", "kilo", "opencode.json")
+	if got := a.SettingsPath("/home/user"); got != want {
+		t.Fatalf("SettingsPath() = %q, want %q", got, want)
+	}
+}
+
+func TestCapabilities(t *testing.T) {
+	a := NewAdapter()
+
+	tests := []struct {
+		name   string
+		method func() bool
+		want   bool
+	}{
+		{"SupportsSkills", a.SupportsSkills, true},
+		{"SupportsMCP", a.SupportsMCP, true},
+		{"SupportsSystemPrompt", a.SupportsSystemPrompt, true},
+		{"SupportsSlashCommands", a.SupportsSlashCommands, true},
+		{"SupportsOutputStyles", a.SupportsOutputStyles, false},
+		{"SupportsAutoInstall", a.SupportsAutoInstall, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.method(); got != tt.want {
+				t.Fatalf("%s() = %v, want %v", tt.name, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStrategies(t *testing.T) {
+	a := NewAdapter()
+
+	if got := a.SystemPromptStrategy(); got != model.StrategyFileReplace {
+		t.Fatalf("SystemPromptStrategy() = %v, want %v", got, model.StrategyFileReplace)
+	}
+
+	if got := a.MCPStrategy(); got != model.StrategyMergeIntoSettings {
+		t.Fatalf("MCPStrategy() = %v, want %v", got, model.StrategyMergeIntoSettings)
+	}
+}
+
+func TestCommandsDir(t *testing.T) {
+	a := NewAdapter()
+	want := filepath.Join("/home/user", ".config", "kilo", "commands")
+	if got := a.CommandsDir("/home/user"); got != want {
+		t.Fatalf("CommandsDir() = %q, want %q", got, want)
+	}
+}
+
+func TestMCPConfigPath(t *testing.T) {
+	a := NewAdapter()
+	want := filepath.Join("/home/user", ".config", "kilo", "opencode.json")
+	if got := a.MCPConfigPath("/home/user", "test-server"); got != want {
+		t.Fatalf("MCPConfigPath() = %q, want %q", got, want)
+	}
+}
+
+func TestInstallCommand(t *testing.T) {
+	a := NewAdapter()
+
+	tests := []struct {
+		name    string
+		profile system.PlatformProfile
+		want    [][]string
+	}{
+		{
+			name:    "darwin resolves npm install without sudo",
+			profile: system.PlatformProfile{OS: "darwin", PackageManager: "brew"},
+			want:    [][]string{{"npm", "install", "-g", "@kilocode/cli"}},
+		},
+		{
+			name:    "ubuntu resolves npm install with sudo",
+			profile: system.PlatformProfile{OS: "linux", LinuxDistro: system.LinuxDistroUbuntu, PackageManager: "apt"},
+			want:    [][]string{{"sudo", "npm", "install", "-g", "@kilocode/cli"}},
+		},
+		{
+			name:    "arch resolves npm install with sudo",
+			profile: system.PlatformProfile{OS: "linux", LinuxDistro: system.LinuxDistroArch, PackageManager: "pacman"},
+			want:    [][]string{{"sudo", "npm", "install", "-g", "@kilocode/cli"}},
+		},
+		{
+			name:    "fedora resolves npm install with sudo",
+			profile: system.PlatformProfile{OS: "linux", LinuxDistro: system.LinuxDistroFedora, PackageManager: "dnf"},
+			want:    [][]string{{"sudo", "npm", "install", "-g", "@kilocode/cli"}},
+		},
+		{
+			name:    "linux with writable npm skips sudo",
+			profile: system.PlatformProfile{OS: "linux", LinuxDistro: system.LinuxDistroFedora, PackageManager: "dnf", NpmWritable: true},
+			want:    [][]string{{"npm", "install", "-g", "@kilocode/cli"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			command, err := a.InstallCommand(tt.profile)
+			if err != nil {
+				t.Fatalf("InstallCommand() unexpected error = %v", err)
+			}
+
+			if !reflect.DeepEqual(command, tt.want) {
+				t.Fatalf("InstallCommand() = %v, want %v", command, tt.want)
+			}
+		})
+	}
+}

--- a/internal/agents/kilocode/paths.go
+++ b/internal/agents/kilocode/paths.go
@@ -1,0 +1,7 @@
+package kilocode
+
+import "path/filepath"
+
+func ConfigPath(homeDir string) string {
+	return filepath.Join(homeDir, ".config", "kilo")
+}

--- a/internal/catalog/agents.go
+++ b/internal/catalog/agents.go
@@ -12,6 +12,7 @@ type Agent struct {
 var allAgents = []Agent{
 	{ID: model.AgentClaudeCode, Name: "Claude Code", Tier: model.TierFull, ConfigPath: "~/.claude"},
 	{ID: model.AgentOpenCode, Name: "OpenCode", Tier: model.TierFull, ConfigPath: "~/.config/opencode"},
+	{ID: model.AgentKilocode, Name: "Kilo Code", Tier: model.TierFull, ConfigPath: "~/.config/kilo"},
 	{ID: model.AgentGeminiCLI, Name: "Gemini CLI", Tier: model.TierFull, ConfigPath: "~/.gemini"},
 	{ID: model.AgentCodex, Name: "Codex", Tier: model.TierFull, ConfigPath: "~/.codex"},
 	{ID: model.AgentCursor, Name: "Cursor", Tier: model.TierFull, ConfigPath: "~/.cursor"},

--- a/internal/cli/install_test.go
+++ b/internal/cli/install_test.go
@@ -43,7 +43,7 @@ func TestNormalizeInstallFlagsDefaults(t *testing.T) {
 	}
 
 	want := model.Selection{
-		Agents:  []model.AgentID{model.AgentClaudeCode, model.AgentOpenCode, model.AgentGeminiCLI, model.AgentCodex, model.AgentCursor, model.AgentVSCodeCopilot, model.AgentAntigravity, model.AgentWindsurf},
+		Agents:  []model.AgentID{model.AgentClaudeCode, model.AgentOpenCode, model.AgentKilocode, model.AgentGeminiCLI, model.AgentCodex, model.AgentCursor, model.AgentVSCodeCopilot, model.AgentAntigravity, model.AgentWindsurf},
 		Persona: model.PersonaGentleman,
 		Preset:  model.PresetFullGentleman,
 		Components: []model.ComponentID{

--- a/internal/cli/install_test.go
+++ b/internal/cli/install_test.go
@@ -183,7 +183,7 @@ func TestRunInstallDryRunSkipsExecution(t *testing.T) {
 func makeDetectionWithAgents(present ...string) system.DetectionResult {
 	var configs []system.ConfigState
 	// Full canonical agent set — mirrors knownAgentConfigDirs in config_scan.go.
-	known := []string{"claude-code", "opencode", "gemini-cli", "cursor", "vscode-copilot", "codex", "antigravity", "windsurf"}
+	known := []string{"claude-code", "opencode", "kilocode", "gemini-cli", "cursor", "vscode-copilot", "codex", "antigravity", "windsurf"}
 	presentSet := make(map[string]bool, len(present))
 	for _, p := range present {
 		presentSet[p] = true
@@ -230,6 +230,7 @@ func TestDefaultAgentsFromDetection_AllAgentsMappedCorrectly(t *testing.T) {
 	}{
 		{"claude-code", model.AgentClaudeCode},
 		{"opencode", model.AgentOpenCode},
+		{"kilocode", model.AgentKilocode},
 		{"gemini-cli", model.AgentGeminiCLI},
 		{"cursor", model.AgentCursor},
 		{"vscode-copilot", model.AgentVSCodeCopilot},

--- a/internal/cli/validate.go
+++ b/internal/cli/validate.go
@@ -172,6 +172,8 @@ func defaultAgentsFromDetection(detection system.DetectionResult) []model.AgentI
 			agents = append(agents, model.AgentClaudeCode)
 		case string(model.AgentOpenCode):
 			agents = append(agents, model.AgentOpenCode)
+		case string(model.AgentKilocode):
+			agents = append(agents, model.AgentKilocode)
 		case string(model.AgentGeminiCLI):
 			agents = append(agents, model.AgentGeminiCLI)
 		case string(model.AgentCursor):

--- a/internal/components/engram/inject.go
+++ b/internal/components/engram/inject.go
@@ -76,7 +76,7 @@ func engramServerJSON() []byte {
 func engramOverlayJSON(agentID model.AgentID) []byte {
 	cmd, _ := resolveEngramCommand()
 	var cfg map[string]any
-	if agentID == model.AgentOpenCode {
+	if agentID == model.AgentOpenCode || agentID == model.AgentKilocode {
 		// OpenCode 1.3.3+ requires command as an array for type:local servers.
 		// The separate "args" field is not accepted; all args must be in the
 		// command array itself.

--- a/internal/components/engram/setup.go
+++ b/internal/components/engram/setup.go
@@ -41,6 +41,8 @@ func SetupAgentSlug(agent model.AgentID) (string, bool) {
 	switch agent {
 	case model.AgentOpenCode:
 		return "opencode", true
+	case model.AgentKilocode:
+		return "kilocode", true
 	case model.AgentClaudeCode:
 		return "claude-code", true
 	case model.AgentGeminiCLI:

--- a/internal/components/mcp/inject.go
+++ b/internal/components/mcp/inject.go
@@ -54,7 +54,7 @@ func injectMergeIntoSettings(homeDir string, adapter agents.Adapter) (InjectionR
 	}
 
 	overlay := DefaultContext7OverlayJSON()
-	if adapter.Agent() == model.AgentOpenCode {
+	if adapter.Agent() == model.AgentOpenCode || adapter.Agent() == model.AgentKilocode {
 		overlay = OpenCodeContext7OverlayJSON()
 	}
 

--- a/internal/components/permissions/inject.go
+++ b/internal/components/permissions/inject.go
@@ -78,7 +78,7 @@ func agentOverlay(id model.AgentID) []byte {
 	switch id {
 	case model.AgentClaudeCode:
 		return claudeCodeOverlayJSON
-	case model.AgentOpenCode:
+	case model.AgentOpenCode, model.AgentKilocode:
 		return openCodeOverlayJSON
 	case model.AgentGeminiCLI:
 		return geminiCLIOverlayJSON

--- a/internal/components/persona/inject.go
+++ b/internal/components/persona/inject.go
@@ -176,8 +176,8 @@ func Inject(homeDir string, adapter agents.Adapter, persona model.PersonaID) (In
 		files = append(files, promptPath)
 	}
 
-	// 2. OpenCode agent definitions — Tab-switchable agents in opencode.json.
-	if adapter.Agent() == model.AgentOpenCode && persona != model.PersonaCustom {
+	// 2. OpenCode/Kilocode agent definitions — Tab-switchable agents in settings.
+	if (adapter.Agent() == model.AgentOpenCode || adapter.Agent() == model.AgentKilocode) && persona != model.PersonaCustom {
 		settingsPath := adapter.SettingsPath(homeDir)
 		if settingsPath != "" {
 			agentResult, err := mergeJSONFile(settingsPath, openCodeAgentOverlayJSON)
@@ -231,7 +231,7 @@ func personaContent(agent model.AgentID, persona model.PersonaID) string {
 		switch agent {
 		case model.AgentClaudeCode:
 			return assets.MustRead("claude/persona-gentleman.md")
-		case model.AgentOpenCode:
+		case model.AgentOpenCode, model.AgentKilocode:
 			return assets.MustRead("opencode/persona-gentleman.md")
 		default:
 			// Generic persona includes Gentleman personality + skills table + SDD orchestrator.

--- a/internal/components/sdd/inject.go
+++ b/internal/components/sdd/inject.go
@@ -190,9 +190,9 @@ func Inject(homeDir string, adapter agents.Adapter, sddMode model.SDDModeID, opt
 	changed := false
 
 	// 1. Inject SDD orchestrator into the global system prompt for agents that
-	// rely on prompt files. OpenCode is handled differently: its orchestrator
-	// instructions must be scoped to the sdd-orchestrator agent only, otherwise
-	// the SDD phase sub-agents inherit coordinator-only delegation rules.
+	// rely on prompt files. OpenCode and Kilocode are handled differently: their
+	// orchestrator instructions must be scoped to the sdd-orchestrator agent only,
+	// otherwise the SDD phase sub-agents inherit coordinator-only delegation rules.
 	if adapter.Agent() != model.AgentOpenCode && adapter.Agent() != model.AgentKilocode {
 		switch adapter.SystemPromptStrategy() {
 		case model.StrategyMarkdownSections:
@@ -344,7 +344,7 @@ func Inject(homeDir string, adapter agents.Adapter, sddMode model.SDDModeID, opt
 			mergedSettingsBytes = agentResult.merged
 
 			// Install OpenCode plugins (all SDD modes).
-			pluginResult, err := installOpenCodePlugins(homeDir)
+			pluginResult, err := installOpenCodePlugins(homeDir, adapter)
 			if err != nil {
 				return InjectionResult{}, err
 			}
@@ -654,11 +654,11 @@ func inlineOpenCodeSDDPrompts(overlayBytes []byte, homeDir string) ([]byte, erro
 }
 
 // installOpenCodePlugins copies the background-agents plugin and installs its
-// npm/bun dependency into ~/.config/opencode/. Returns an error with an
-// actionable message if the package manager is present but the install fails.
-// If no package manager is available, the install is skipped (soft failure).
-func installOpenCodePlugins(homeDir string) (InjectionResult, error) {
-	opencodeDir := filepath.Join(homeDir, ".config", "opencode")
+// npm/bun dependency into the agent's global config directory. Returns an error
+// with an actionable message if the package manager is present but the install
+// fails. If no package manager is available, the install is skipped (soft failure).
+func installOpenCodePlugins(homeDir string, adapter agents.Adapter) (InjectionResult, error) {
+	opencodeDir := adapter.GlobalConfigDir(homeDir)
 	pluginsDir := filepath.Join(opencodeDir, "plugins")
 
 	if err := os.MkdirAll(pluginsDir, 0o755); err != nil {

--- a/internal/components/sdd/inject.go
+++ b/internal/components/sdd/inject.go
@@ -193,7 +193,7 @@ func Inject(homeDir string, adapter agents.Adapter, sddMode model.SDDModeID, opt
 	// rely on prompt files. OpenCode is handled differently: its orchestrator
 	// instructions must be scoped to the sdd-orchestrator agent only, otherwise
 	// the SDD phase sub-agents inherit coordinator-only delegation rules.
-	if adapter.Agent() != model.AgentOpenCode {
+	if adapter.Agent() != model.AgentOpenCode && adapter.Agent() != model.AgentKilocode {
 		switch adapter.SystemPromptStrategy() {
 		case model.StrategyMarkdownSections:
 			result, err := injectMarkdownSections(homeDir, adapter, opts.ClaudeModelAssignments)
@@ -220,7 +220,7 @@ func Inject(homeDir string, adapter agents.Adapter, sddMode model.SDDModeID, opt
 
 	// 1b. If StrictTDD is enabled, inject the strict-tdd-mode marker section
 	// into the system prompt file so agents know Strict TDD is active.
-	if opts.StrictTDD && adapter.Agent() != model.AgentOpenCode {
+	if opts.StrictTDD && adapter.Agent() != model.AgentOpenCode && adapter.Agent() != model.AgentKilocode {
 		promptPath := adapter.SystemPromptFile(homeDir)
 		strictTDDContent := "Strict TDD Mode: enabled"
 		existing, readErr := readFileOrEmpty(promptPath)
@@ -283,7 +283,7 @@ func Inject(homeDir string, adapter agents.Adapter, sddMode model.SDDModeID, opt
 	// os.ReadFile call due to VFS/NTFS metadata caching, which caused the spurious
 	// "post-check: .../opencode.json missing sdd-apply sub-agent" error.
 	var mergedSettingsBytes []byte
-	if adapter.Agent() == model.AgentOpenCode {
+	if adapter.Agent() == model.AgentOpenCode || adapter.Agent() == model.AgentKilocode {
 		settingsPath := adapter.SettingsPath(homeDir)
 		if settingsPath != "" {
 			overlayContent, err := assets.Read(overlayAssetPath(sddMode))

--- a/internal/installcmd/resolver.go
+++ b/internal/installcmd/resolver.go
@@ -43,6 +43,8 @@ func (profileResolver) ResolveAgentInstall(profile system.PlatformProfile, agent
 		return resolveClaudeCodeInstall(profile), nil
 	case model.AgentOpenCode:
 		return resolveOpenCodeInstall(profile)
+	case model.AgentKilocode:
+		return resolveKilocodeInstall(profile), nil
 	default:
 		return nil, fmt.Errorf("install command is not supported for agent %q", agent)
 	}
@@ -56,6 +58,16 @@ func resolveClaudeCodeInstall(profile system.PlatformProfile) CommandSequence {
 		return CommandSequence{{"sudo", "npm", "install", "-g", "@anthropic-ai/claude-code"}}
 	}
 	return CommandSequence{{"npm", "install", "-g", "@anthropic-ai/claude-code"}}
+}
+
+// resolveKilocodeInstall returns the npm install command sequence for Kilocode.
+// On Linux with system npm, sudo is required. With nvm/fnm/volta, it is not.
+// On Windows and macOS, sudo is never needed.
+func resolveKilocodeInstall(profile system.PlatformProfile) CommandSequence {
+	if profile.OS == "linux" && !profile.NpmWritable {
+		return CommandSequence{{"sudo", "npm", "install", "-g", "@kilocode/cli"}}
+	}
+	return CommandSequence{{"npm", "install", "-g", "@kilocode/cli"}}
 }
 
 func (profileResolver) ResolveComponentInstall(profile system.PlatformProfile, component model.ComponentID) (CommandSequence, error) {

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -5,6 +5,7 @@ type AgentID string
 const (
 	AgentClaudeCode    AgentID = "claude-code"
 	AgentOpenCode      AgentID = "opencode"
+	AgentKilocode      AgentID = "kilocode"
 	AgentGeminiCLI     AgentID = "gemini-cli"
 	AgentCursor        AgentID = "cursor"
 	AgentVSCodeCopilot AgentID = "vscode-copilot"

--- a/internal/system/config_scan.go
+++ b/internal/system/config_scan.go
@@ -27,6 +27,7 @@ func knownAgentConfigDirs(homeDir string) []ConfigState {
 	return []ConfigState{
 		{Agent: "claude-code", Path: filepath.Join(homeDir, ".claude")},
 		{Agent: "opencode", Path: filepath.Join(homeDir, ".config", "opencode")},
+		{Agent: "kilocode", Path: filepath.Join(homeDir, ".config", "kilo")},
 		{Agent: "gemini-cli", Path: filepath.Join(homeDir, ".gemini")},
 		{Agent: "cursor", Path: filepath.Join(homeDir, ".cursor")},
 		{Agent: "vscode-copilot", Path: vscodeCopilotGlobalConfigDir(homeDir)},


### PR DESCRIPTION
## 🔗 Linked Issue
Closes #118
## 🏷️ PR Type
- [ ] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [x] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change
## 📝 Summary
Adds full support for **Kilo Code CLI** agent. Kilo Code is a fork of OpenCode, so this implementation follows the same patterns with adapted paths and binary detection.
Configuration paths were verified against a real Kilo CLI installation using `kilo debug paths`:
- Config dir: `~/.config/kilo/`
- Settings file: `~/.config/kilo/opencode.json`
- System prompt: `~/.config/kilo/AGENTS.md`
- Skills: `~/.config/kilo/skills/`
- Binary: `kilo`
## 📂 Changes
| File / Area | What Changed |
|-------------|-------------|
| `internal/model/types.go` | Added `AgentKilocode` constant |
| `internal/agents/kilocode/` | **NEW** - adapter package (adapter.go, paths.go, adapter_test.go) |
| `internal/agents/factory.go` | Registered Kilocode adapter |
| `internal/catalog/agents.go` | Added Kilo Code metadata |
| `internal/system/config_scan.go` | Added Kilocode config detection |
| `internal/installcmd/resolver.go` | Added npm install command (`@kilocode/cli`) |
| `internal/components/sdd/inject.go` | Handle Kilocode same as OpenCode |
| `internal/components/engram/inject.go` | Handle Kilocode MCP format |
| `internal/components/engram/setup.go` | Added kilocode slug mapping |
| `internal/components/mcp/inject.go` | Handle Kilocode Context7 overlay |
| `internal/components/persona/inject.go` | Handle Kilocode persona injection |
| `internal/components/permissions/inject.go` | Handle Kilocode permissions |
| `internal/cli/install_test.go` | Updated expected agents list |
## 🧪 Test Plan
**Unit Tests**
```bash
go test ./...
Kilocode Adapter Tests
go test -v ./internal/agents/kilocode/...
- [x] Unit tests pass (go test ./...)
- [ ] E2E tests pass (cd e2e && ./docker-test.sh) — requires Docker
- [x] Manually tested locally with kilo debug paths verification
- [x] Dry-run install verified: GENTLE_AI_NO_SELF_UPDATE=1 ./gentle-ai install --agents kilocode --dry-run
✅ Contributor Checklist
- [x] PR is linked to an issue with status:approved
- [x] I have added the appropriate type:* label to this PR
- [x] Unit tests pass (go test ./...)
- [ ] E2E tests pass (cd e2e && ./docker-test.sh)
- [x] I have updated documentation if necessary
- [x] My commits follow Conventional Commits format
- [x] My commits do not include Co-Authored-By trailers