### PR TITLE
fix(upgrade): fall back to declared install method when tool is not in brew

### DIFF
--- a/internal/update/upgrade/executor.go
+++ b/internal/update/upgrade/executor.go
@@ -362,10 +362,23 @@ func executeOne(ctx context.Context, r update.UpdateResult, profile system.Platf
 	return base
 }
 
+// isBrewManagedFn checks whether a tool is actually installed via Homebrew.
+// Package-level var for testability — swapped in tests to avoid real brew calls.
+var isBrewManagedFn = isBrewManaged
+
+// isBrewManaged returns true if `brew list --versions <toolName>` succeeds,
+// meaning the tool was installed via Homebrew (present in the Cellar).
+func isBrewManaged(toolName string) bool {
+	return execCommand("brew", "list", "--versions", toolName).Run() == nil
+}
+
 // effectiveMethod resolves the actual upgrade strategy for a tool on a given platform.
-// On brew-managed platforms, brew takes precedence over the tool's declared method.
+// On brew-managed platforms, brew takes precedence — but only if the tool is actually
+// installed via brew. On Linux it is common to have Linuxbrew for some packages while
+// other tools are installed via binary download or go install. Blindly forcing brew
+// would cause "No available formula" errors for those tools.
 func effectiveMethod(tool update.ToolInfo, profile system.PlatformProfile) update.InstallMethod {
-	if profile.PackageManager == "brew" {
+	if profile.PackageManager == "brew" && isBrewManagedFn(tool.Name) {
 		return update.InstallBrew
 	}
 	return tool.InstallMethod

--- a/internal/update/upgrade/executor.go
+++ b/internal/update/upgrade/executor.go
@@ -10,6 +10,7 @@ package upgrade
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -400,15 +401,27 @@ var checkBrewManagedFn = checkBrewManaged
 //   - brewNotManaged   — command failed (exit non-zero) with empty/whitespace output,
 //     meaning brew is functional but the tool is not installed via it.
 //   - brewError        — command failed AND produced non-empty stderr/stdout,
-//     indicating an operational failure (brew broken, permissions, timeout, etc.).
+//     indicating an operational failure (brew broken, permissions, timeout, etc.);
+//     OR the command could not be started at all (e.g. brew not found / exec.ErrNotFound).
 //
 // Using CombinedOutput() captures both stdout and stderr in one call so we can
 // distinguish an empty "not found" result from a real error message.
+// Startup failures (non-ExitError from CombinedOutput) are classified as brewError
+// so callers never mistake "brew binary not found" for "tool not brew-managed".
 func checkBrewManaged(toolName string) brewCheckResult {
 	out, err := execCommand("brew", "list", "--versions", toolName).CombinedOutput()
 	if err == nil {
 		return brewManaged
 	}
+	// If the error is NOT an ExitError, the command failed to start (e.g. brew
+	// binary not found, permission denied, PATH misconfiguration). Treat as an
+	// operational error — do NOT misclassify as "tool not brew-managed".
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		return brewError
+	}
+	// ExitError: the process ran and exited non-zero.
+	// Empty output → tool not in Cellar (clean not-found). Non-empty → operational error.
 	if len(strings.TrimSpace(string(out))) == 0 {
 		return brewNotManaged
 	}

--- a/internal/update/upgrade/executor.go
+++ b/internal/update/upgrade/executor.go
@@ -267,6 +267,16 @@ func Execute(ctx context.Context, results []update.UpdateResult, profile system.
 		}
 	}
 
+	// Resolve the effective upgrade method for every tool exactly once.
+	// This avoids redundant `brew list --versions` calls (one per tool per call
+	// site) and ensures the same resolved value is used for both reporting and
+	// execution. The resolved method is stored by tool name.
+	allTools := append(append(executable, devBuilds...), versionUnknowns...)
+	resolvedMethods := make(map[string]update.InstallMethod, len(allTools))
+	for _, r := range allTools {
+		resolvedMethods[r.Tool.Name] = resolveMethod(r.Tool, profile)
+	}
+
 	// Build results slice: dev-build skips first (no exec), then executable tools.
 	toolResults := make([]ToolUpgradeResult, 0, len(executable)+len(devBuilds)+len(versionUnknowns))
 
@@ -276,7 +286,7 @@ func Execute(ctx context.Context, results []update.UpdateResult, profile system.
 			ToolName:   r.Tool.Name,
 			OldVersion: r.InstalledVersion,
 			NewVersion: r.LatestVersion,
-			Method:     effectiveMethod(r.Tool, profile),
+			Method:     resolvedMethods[r.Tool.Name],
 			Status:     UpgradeSkipped,
 			ManualHint: fmt.Sprintf("source build — upgrade manually or install a release binary from https://github.com/Gentleman-Programming/%s/releases", r.Tool.Repo),
 		})
@@ -285,22 +295,26 @@ func Execute(ctx context.Context, results []update.UpdateResult, profile system.
 	// VersionUnknown tools: surface them as skipped so the user gets a clear hint
 	// instead of a silent omission from the upgrade report.
 	for _, r := range versionUnknowns {
+		detectHint := r.Tool.Name
+		if len(r.Tool.DetectCmd) > 0 {
+			detectHint = strings.Join(r.Tool.DetectCmd, " ")
+		}
 		toolResults = append(toolResults, ToolUpgradeResult{
 			ToolName:   r.Tool.Name,
 			OldVersion: r.InstalledVersion,
 			NewVersion: r.LatestVersion,
-			Method:     effectiveMethod(r.Tool, profile),
+			Method:     resolvedMethods[r.Tool.Name],
 			Status:     UpgradeSkipped,
-			ManualHint: fmt.Sprintf("installed binary was found but its version could not be determined — check `%s` and reinstall if it is a stale source/dev build", detectCommandHint(r.Tool)),
+			ManualHint: fmt.Sprintf("installed binary was found but its version could not be determined — check `%s` and reinstall if it is a stale source/dev build", detectHint),
 		})
 	}
 
 	// Executable tools: run upgrade strategy.
 	for _, r := range executable {
-		method := effectiveMethod(r.Tool, profile)
+		method := resolvedMethods[r.Tool.Name]
 		msg := fmt.Sprintf("Upgrading %s via %s (%s → %s)", r.Tool.Name, method, r.InstalledVersion, r.LatestVersion)
 		sp := NewSpinner(pw, msg)
-		toolResult := executeOne(ctx, r, profile, dryRun)
+		toolResult := executeOne(ctx, r, method, profile, dryRun)
 		switch toolResult.Status {
 		case UpgradeSucceeded:
 			sp.Finish(true)
@@ -322,21 +336,17 @@ func Execute(ctx context.Context, results []update.UpdateResult, profile system.
 	}
 }
 
-func detectCommandHint(tool update.ToolInfo) string {
-	if len(tool.DetectCmd) == 0 {
-		return tool.Name
-	}
-
-	return strings.Join(tool.DetectCmd, " ")
-}
-
-// executeOne runs the upgrade for a single tool.
-func executeOne(ctx context.Context, r update.UpdateResult, profile system.PlatformProfile, dryRun bool) ToolUpgradeResult {
+// executeOne runs the upgrade for a single tool using an already-resolved method.
+// The method parameter is the effective install method computed once by Execute
+// via resolveMethod — it must not be recomputed here.
+// profile is forwarded to runStrategy for OS-specific routing within binary/script
+// strategies (e.g. Windows manual fallback detection).
+func executeOne(ctx context.Context, r update.UpdateResult, method update.InstallMethod, profile system.PlatformProfile, dryRun bool) ToolUpgradeResult {
 	base := ToolUpgradeResult{
 		ToolName:   r.Tool.Name,
 		OldVersion: r.InstalledVersion,
 		NewVersion: r.LatestVersion,
-		Method:     effectiveMethod(r.Tool, profile),
+		Method:     method,
 	}
 
 	if dryRun {
@@ -344,7 +354,7 @@ func executeOne(ctx context.Context, r update.UpdateResult, profile system.Platf
 		return base
 	}
 
-	err := runStrategy(ctx, r, profile)
+	err := runStrategy(ctx, r, method, profile)
 	if err != nil {
 		// Distinguish manual fallback (informational skip) from real failures.
 		if hint, ok := AsManualFallback(err); ok {
@@ -362,24 +372,84 @@ func executeOne(ctx context.Context, r update.UpdateResult, profile system.Platf
 	return base
 }
 
-// isBrewManagedFn checks whether a tool is actually installed via Homebrew.
-// Package-level var for testability — swapped in tests to avoid real brew calls.
-var isBrewManagedFn = isBrewManaged
+// brewCheckResult is a three-state result for Homebrew ownership detection.
+// It distinguishes between a tool that is not installed via brew, a tool that
+// IS installed via brew, and an operational brew failure (e.g. brew unavailable,
+// permission error, unexpected stderr output). The third state prevents silently
+// treating brew failures as "not managed" and falling back to another installer.
+type brewCheckResult int
 
-// isBrewManaged returns true if `brew list --versions <toolName>` succeeds,
-// meaning the tool was installed via Homebrew (present in the Cellar).
-func isBrewManaged(toolName string) bool {
-	return execCommand("brew", "list", "--versions", toolName).Run() == nil
+const (
+	// brewNotManaged means the tool is not in the Homebrew Cellar.
+	brewNotManaged brewCheckResult = iota
+	// brewManaged means the tool is present in the Homebrew Cellar.
+	brewManaged
+	// brewError means `brew list --versions` exited non-zero AND produced
+	// non-empty output — indicating an operational brew failure rather than
+	// a simple "not found" result.
+	brewError
+)
+
+// checkBrewManagedFn checks whether a tool is actually installed via Homebrew.
+// Package-level var for testability — swapped in tests to avoid real brew calls.
+var checkBrewManagedFn = checkBrewManaged
+
+// checkBrewManaged probes `brew list --versions <toolName>` and returns a
+// three-state brewCheckResult:
+//   - brewManaged      — command succeeded (exit 0), tool is in the Cellar.
+//   - brewNotManaged   — command failed (exit non-zero) with empty/whitespace output,
+//     meaning brew is functional but the tool is not installed via it.
+//   - brewError        — command failed AND produced non-empty stderr/stdout,
+//     indicating an operational failure (brew broken, permissions, timeout, etc.).
+//
+// Using CombinedOutput() captures both stdout and stderr in one call so we can
+// distinguish an empty "not found" result from a real error message.
+func checkBrewManaged(toolName string) brewCheckResult {
+	out, err := execCommand("brew", "list", "--versions", toolName).CombinedOutput()
+	if err == nil {
+		return brewManaged
+	}
+	if len(strings.TrimSpace(string(out))) == 0 {
+		return brewNotManaged
+	}
+	return brewError
 }
 
-// effectiveMethod resolves the actual upgrade strategy for a tool on a given platform.
-// On brew-managed platforms, brew takes precedence — but only if the tool is actually
-// installed via brew. On Linux it is common to have Linuxbrew for some packages while
-// other tools are installed via binary download or go install. Blindly forcing brew
-// would cause "No available formula" errors for those tools.
-func effectiveMethod(tool update.ToolInfo, profile system.PlatformProfile) update.InstallMethod {
-	if profile.PackageManager == "brew" && isBrewManagedFn(tool.Name) {
-		return update.InstallBrew
+// effectiveMethod resolves the actual upgrade strategy for a tool given a
+// pre-computed brew ownership result. This function is the single policy
+// point for method selection:
+//   - Non-brew platform profiles: always return the tool's declared method.
+//   - Brew platform + brewManaged:   return InstallBrew.
+//   - Brew platform + brewNotManaged: return declared method (Linuxbrew regression fix).
+//   - Brew platform + brewError:     return InstallBrew so the brew path is
+//     attempted and the error surfaces honestly (no silent fallback).
+//
+// The caller is responsible for computing brewResult exactly once per tool via
+// resolveMethod and passing it here.
+func effectiveMethod(tool update.ToolInfo, profile system.PlatformProfile, brewResult brewCheckResult) update.InstallMethod {
+	if profile.PackageManager != "brew" {
+		return tool.InstallMethod
 	}
-	return tool.InstallMethod
+	switch brewResult {
+	case brewManaged:
+		return update.InstallBrew
+	case brewError:
+		// Keep brew as the method so the error surfaces through the normal
+		// brew upgrade path instead of silently falling back to another method.
+		return update.InstallBrew
+	default: // brewNotManaged
+		return tool.InstallMethod
+	}
+}
+
+// resolveMethod computes the effective upgrade method for a tool, calling the
+// brew ownership probe at most once. On non-brew platforms the probe is skipped
+// entirely. This is the entry point that Execute uses so each tool's method is
+// resolved exactly once.
+func resolveMethod(tool update.ToolInfo, profile system.PlatformProfile) update.InstallMethod {
+	var result brewCheckResult
+	if profile.PackageManager == "brew" {
+		result = checkBrewManagedFn(tool.Name)
+	}
+	return effectiveMethod(tool, profile, result)
 }

--- a/internal/update/upgrade/executor_test.go
+++ b/internal/update/upgrade/executor_test.go
@@ -1269,24 +1269,29 @@ func TestEnumerateFilesInDir_CaseInsensitiveExclude(t *testing.T) {
 // Task 1.1 — checkBrewManaged helper: three-state coverage
 // =============================================================================
 
-// TestCheckBrewManaged is the entry point for the helper-process tests below.
-// It uses the standard Go helper process pattern to control both the exit code
-// and the combined output of the stubbed exec.Command.
+// Helper process pattern for checkBrewManaged tests.
 //
-// The test re-executes itself as a subprocess with the environment variable
-// BREW_CHECK_TEST_MODE set so that TestMain can detect it and run the helper
-// instead of the normal test suite.
+// fakeBrewCmd and TestBrewCheckHelperProcess together implement the standard Go
+// helper-process pattern: the test binary re-invokes itself as a subprocess with
+// BREW_CHECK_HELPER=1 set. TestBrewCheckHelperProcess detects this env var and
+// acts as the fake brew binary, exiting with the behavior specified by
+// BREW_CHECK_MODE instead of running the normal test suite.
 
-// fakeBrewCmd returns a *exec.Cmd that re-invokes the test binary as a
-// subprocess. The subprocess detects the helper flag via the environment
-// variable BREW_CHECK_HELPER and behaves according to MODE:
-//   - "managed"      → exits 0 (no output needed; CombinedOutput success → brewManaged)
-//   - "not-managed"  → prints nothing and exits 1 (empty output → brewNotManaged)
-//   - "error"        → prints "Error: brew damaged" and exits 1 (non-empty → brewError)
+// fakeBrewCmd returns an execCommand stub that intercepts all "brew" invocations
+// by re-executing the test binary as a subprocess. The subprocess runs
+// TestBrewCheckHelperProcess (detected via BREW_CHECK_HELPER=1) and exits
+// according to MODE:
+//
+//   - "managed"      → exits 0 (brew list success → brewManaged)
+//   - "not-managed"  → exits 1 with no output (empty output → brewNotManaged)
+//   - "error"        → exits 1 with error text on stderr (non-empty → brewError)
+//
+// Non-brew commands (e.g. "go", "echo") pass through to a real no-op command.
 func fakeBrewCmd(t *testing.T, mode string) func(name string, args ...string) *exec.Cmd {
 	t.Helper()
 	return func(name string, args ...string) *exec.Cmd {
-		// Only intercept "brew list --versions <tool>" calls.
+		// Intercept all "brew" invocations (including brew update, brew upgrade,
+		// and brew list) by running the helper subprocess.
 		if name == "brew" {
 			cmd := exec.Command(os.Args[0], "-test.run=TestBrewCheckHelperProcess")
 			cmd.Env = append(os.Environ(),
@@ -1295,7 +1300,7 @@ func fakeBrewCmd(t *testing.T, mode string) func(name string, args ...string) *e
 			)
 			return cmd
 		}
-		// Any other command (e.g. brew update in brewUpgrade): succeed silently.
+		// Non-brew commands succeed silently.
 		return exec.Command("echo", "ok")
 	}
 }
@@ -1365,6 +1370,34 @@ func TestCheckBrewManaged_BrewError(t *testing.T) {
 	got := checkBrewManaged("engram")
 	if got != brewError {
 		t.Errorf("checkBrewManaged = %v, want brewError", got)
+	}
+}
+
+// TestCheckBrewManaged_StartFailure verifies that when brew itself cannot be
+// started — e.g. the brew binary is not found (exec.ErrNotFound) or fails to
+// launch for any reason — checkBrewManaged returns brewError, NOT brewNotManaged.
+//
+// This is the PR review blocker: before the fix, a command launch error produced
+// empty output with a non-ExitError, which the empty-output branch misclassified
+// as brewNotManaged (silent "not found" result). The correct classification is
+// brewError so the caller does NOT silently fall back to another install method.
+func TestCheckBrewManaged_StartFailure(t *testing.T) {
+	origExecCommand := execCommand
+	t.Cleanup(func() { execCommand = origExecCommand })
+
+	// Return a command pointing to a non-existent binary so cmd.Start() fails
+	// with *os.PathError (NOT *exec.ExitError). CombinedOutput() returns empty
+	// output and a non-ExitError — this is the "startup/lookup failure" path.
+	execCommand = func(name string, args ...string) *exec.Cmd {
+		if name == "brew" {
+			return exec.Command("/nonexistent-binary-brew-start-failure-test")
+		}
+		return exec.Command("echo", "ok")
+	}
+
+	got := checkBrewManaged("engram")
+	if got != brewError {
+		t.Errorf("checkBrewManaged with start failure = %v, want brewError — startup/lookup failures must not be classified as brewNotManaged", got)
 	}
 }
 

--- a/internal/update/upgrade/executor_test.go
+++ b/internal/update/upgrade/executor_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -420,9 +421,9 @@ func TestExecute_DevBuildSurfacedAsSkipped(t *testing.T) {
 // must be populated from the error message so RenderUpgradeReport can display it.
 func TestExecute_ManualFallbackSurfacedAsSkippedNotFailed(t *testing.T) {
 	origExecCommand := execCommand
-	origIsBrewManaged := isBrewManagedFn
+	origCheckBrewManaged := checkBrewManagedFn
 	t.Cleanup(func() { execCommand = origExecCommand })
-	t.Cleanup(func() { isBrewManagedFn = origIsBrewManaged })
+	t.Cleanup(func() { checkBrewManagedFn = origCheckBrewManaged })
 
 	execCalled := false
 	execCommand = func(name string, args ...string) *exec.Cmd {
@@ -472,11 +473,11 @@ func TestExecute_ManualFallbackSurfacedAsSkippedNotFailed(t *testing.T) {
 // method instead of forcing `brew upgrade <tool>`.
 func TestExecute_BrewProfileNonBrewToolFallsBackToDeclaredMethod(t *testing.T) {
 	origExecCommand := execCommand
-	origIsBrewManaged := isBrewManagedFn
+	origCheckBrewManaged := checkBrewManagedFn
 	t.Cleanup(func() { execCommand = origExecCommand })
-	t.Cleanup(func() { isBrewManagedFn = origIsBrewManaged })
+	t.Cleanup(func() { checkBrewManagedFn = origCheckBrewManaged })
 
-	isBrewManagedFn = func(string) bool { return false }
+	checkBrewManagedFn = func(string) brewCheckResult { return brewNotManaged }
 
 	var calls [][]string
 	execCommand = func(name string, args ...string) *exec.Cmd {
@@ -1261,5 +1262,267 @@ func TestEnumerateFilesInDir_CaseInsensitiveExclude(t *testing.T) {
 	}
 	if _, ok := pathSet[mixedDir]; ok {
 		t.Errorf("mixed-case 'Cache' dir should be excluded by lowercase 'cache' key: %q", mixedDir)
+	}
+}
+
+// =============================================================================
+// Task 1.1 — checkBrewManaged helper: three-state coverage
+// =============================================================================
+
+// TestCheckBrewManaged is the entry point for the helper-process tests below.
+// It uses the standard Go helper process pattern to control both the exit code
+// and the combined output of the stubbed exec.Command.
+//
+// The test re-executes itself as a subprocess with the environment variable
+// BREW_CHECK_TEST_MODE set so that TestMain can detect it and run the helper
+// instead of the normal test suite.
+
+// fakeBrewCmd returns a *exec.Cmd that re-invokes the test binary as a
+// subprocess. The subprocess detects the helper flag via the environment
+// variable BREW_CHECK_HELPER and behaves according to MODE:
+//   - "managed"      → exits 0 (no output needed; CombinedOutput success → brewManaged)
+//   - "not-managed"  → prints nothing and exits 1 (empty output → brewNotManaged)
+//   - "error"        → prints "Error: brew damaged" and exits 1 (non-empty → brewError)
+func fakeBrewCmd(t *testing.T, mode string) func(name string, args ...string) *exec.Cmd {
+	t.Helper()
+	return func(name string, args ...string) *exec.Cmd {
+		// Only intercept "brew list --versions <tool>" calls.
+		if name == "brew" {
+			cmd := exec.Command(os.Args[0], "-test.run=TestBrewCheckHelperProcess")
+			cmd.Env = append(os.Environ(),
+				"BREW_CHECK_HELPER=1",
+				fmt.Sprintf("BREW_CHECK_MODE=%s", mode),
+			)
+			return cmd
+		}
+		// Any other command (e.g. brew update in brewUpgrade): succeed silently.
+		return exec.Command("echo", "ok")
+	}
+}
+
+// TestBrewCheckHelperProcess is the subprocess entry point for the helper
+// process pattern. It is ONLY run when BREW_CHECK_HELPER=1 is set in the
+// environment; under normal test execution this function returns immediately.
+func TestBrewCheckHelperProcess(t *testing.T) {
+	if os.Getenv("BREW_CHECK_HELPER") != "1" {
+		return
+	}
+	mode := os.Getenv("BREW_CHECK_MODE")
+	switch mode {
+	case "managed":
+		// Exit 0 — brew list --versions succeeded; tool is in Cellar.
+		fmt.Println("engram 0.4.0")
+		os.Exit(0)
+	case "not-managed":
+		// Exit 1, no output — tool not in Cellar (clean not-found).
+		os.Exit(1)
+	case "error":
+		// Exit 1 with error text — operational brew failure (e.g. Homebrew damaged).
+		fmt.Fprintln(os.Stderr, "Error: Homebrew damaged: /usr/local/Cellar is not writable")
+		os.Exit(1)
+	default:
+		fmt.Fprintf(os.Stderr, "unknown BREW_CHECK_MODE: %q\n", mode)
+		os.Exit(2)
+	}
+}
+
+// TestCheckBrewManaged_Managed verifies that when `brew list --versions` exits 0
+// (tool IS in the Cellar), checkBrewManaged returns brewManaged.
+func TestCheckBrewManaged_Managed(t *testing.T) {
+	origExecCommand := execCommand
+	t.Cleanup(func() { execCommand = origExecCommand })
+	execCommand = fakeBrewCmd(t, "managed")
+
+	got := checkBrewManaged("engram")
+	if got != brewManaged {
+		t.Errorf("checkBrewManaged = %v, want brewManaged", got)
+	}
+}
+
+// TestCheckBrewManaged_NotManaged verifies that when `brew list --versions` exits
+// non-zero with EMPTY output (tool simply not in Cellar), checkBrewManaged returns
+// brewNotManaged — the "clean miss" case, NOT a brew error.
+func TestCheckBrewManaged_NotManaged(t *testing.T) {
+	origExecCommand := execCommand
+	t.Cleanup(func() { execCommand = origExecCommand })
+	execCommand = fakeBrewCmd(t, "not-managed")
+
+	got := checkBrewManaged("engram")
+	if got != brewNotManaged {
+		t.Errorf("checkBrewManaged = %v, want brewNotManaged", got)
+	}
+}
+
+// TestCheckBrewManaged_BrewError verifies that when `brew list --versions` exits
+// non-zero AND produces non-empty output (operational brew failure, e.g. Homebrew
+// damaged), checkBrewManaged returns brewError — NOT brewNotManaged. This is the
+// key semantic distinction that prevents silent fallback to another installer.
+func TestCheckBrewManaged_BrewError(t *testing.T) {
+	origExecCommand := execCommand
+	t.Cleanup(func() { execCommand = origExecCommand })
+	execCommand = fakeBrewCmd(t, "error")
+
+	got := checkBrewManaged("engram")
+	if got != brewError {
+		t.Errorf("checkBrewManaged = %v, want brewError", got)
+	}
+}
+
+// =============================================================================
+// Task 1.2 — Execute: brew detection runs exactly once per tool
+// =============================================================================
+
+// TestExecute_BrewDetectionRunsOncePerTool verifies that on a brew platform
+// profile, Execute calls the brew ownership probe EXACTLY ONCE per executable
+// tool — not once per call site (pre-refactor issue that was fixed).
+//
+// With two tools (engram + gga), the probe must be called exactly twice total.
+func TestExecute_BrewDetectionRunsOncePerTool(t *testing.T) {
+	origExecCommand := execCommand
+	origCheckBrewManaged := checkBrewManagedFn
+	t.Cleanup(func() {
+		execCommand = origExecCommand
+		checkBrewManagedFn = origCheckBrewManaged
+	})
+
+	// Count how many times the brew ownership probe is invoked.
+	probeCount := 0
+	checkBrewManagedFn = func(toolName string) brewCheckResult {
+		probeCount++
+		return brewManaged // both tools are brew-managed for simplicity
+	}
+
+	// Stub exec so that brew upgrade succeeds silently.
+	execCommand = func(name string, args ...string) *exec.Cmd {
+		return exec.Command("echo", "ok")
+	}
+
+	brewMacProfile := system.PlatformProfile{OS: "darwin", PackageManager: "brew", Supported: true}
+
+	// Two executable tools on a brew platform.
+	results := []update.UpdateResult{
+		makeResult("engram", update.UpdateAvailable, "0.3.0", "0.4.0", update.InstallGoInstall),
+		makeResult("gga", update.UpdateAvailable, "2.7.0", "2.8.0", update.InstallScript),
+	}
+	results[0].Tool.GoImportPath = "github.com/Gentleman-Programming/engram/cmd/engram"
+	results[1].Tool.Owner = "Gentleman-Programming"
+	results[1].Tool.Repo = "gentleman-guardian-angel"
+
+	Execute(context.Background(), results, brewMacProfile, t.TempDir(), false)
+
+	// Probe must be called exactly once per tool (2 tools → exactly 2 calls).
+	if probeCount != 2 {
+		t.Errorf("brew ownership probe called %d times, want exactly 2 (once per tool)", probeCount)
+	}
+}
+
+// TestExecute_BrewDetectionNotCalledOnNonBrewPlatform verifies that on a
+// non-brew platform (e.g. apt on Linux), the brew ownership probe is NEVER
+// called — resolveMethod short-circuits it for non-brew profiles.
+func TestExecute_BrewDetectionNotCalledOnNonBrewPlatform(t *testing.T) {
+	origExecCommand := execCommand
+	origCheckBrewManaged := checkBrewManagedFn
+	t.Cleanup(func() {
+		execCommand = origExecCommand
+		checkBrewManagedFn = origCheckBrewManaged
+	})
+
+	probeCount := 0
+	checkBrewManagedFn = func(toolName string) brewCheckResult {
+		probeCount++
+		return brewManaged
+	}
+
+	execCommand = func(name string, args ...string) *exec.Cmd {
+		return exec.Command("echo", "ok")
+	}
+
+	results := []update.UpdateResult{
+		makeResult("engram", update.UpdateAvailable, "0.3.0", "0.4.0", update.InstallGoInstall),
+	}
+	results[0].Tool.GoImportPath = "github.com/Gentleman-Programming/engram/cmd/engram"
+
+	Execute(context.Background(), results, linuxProfile(), t.TempDir(), false)
+
+	if probeCount != 0 {
+		t.Errorf("brew ownership probe called %d times on non-brew platform, want 0", probeCount)
+	}
+}
+
+// =============================================================================
+// Task 1.3 — Execute: brew operational errors produce UpgradeFailed (no fallback)
+// =============================================================================
+
+// TestExecute_BrewOperationalErrorProducesUpgradeFailed verifies the core
+// semantic fix: when the brew ownership probe returns brewError (operational
+// brew failure), Execute must NOT silently fall back to the tool's declared
+// method. Instead, it must attempt brew upgrade (keeping InstallBrew as the
+// resolved method) and — because brew itself fails — surface the result as
+// UpgradeFailed with a non-nil Err.
+//
+// Before this fix, brewError was treated the same as brewNotManaged, causing
+// a silent fallback to go-install/binary/script. After the fix, brewError
+// maps to InstallBrew, which then fails explicitly through the normal error path.
+func TestExecute_BrewErrorProducesUpgradeFailedNotFallback(t *testing.T) {
+	origExecCommand := execCommand
+	origCheckBrewManaged := checkBrewManagedFn
+	t.Cleanup(func() {
+		execCommand = origExecCommand
+		checkBrewManagedFn = origCheckBrewManaged
+	})
+
+	// Simulate an operational brew error (e.g. Homebrew damaged / not writable).
+	checkBrewManagedFn = func(string) brewCheckResult { return brewError }
+
+	// Track which commands are actually called.
+	var calledCommands []string
+	execCommand = func(name string, args ...string) *exec.Cmd {
+		calledCommands = append(calledCommands, name)
+		// brew update succeeds (non-fatal), brew upgrade fails.
+		if name == "brew" && len(args) > 0 && args[0] == "upgrade" {
+			return exec.Command("false") // brew upgrade fails
+		}
+		// brew update: succeed silently.
+		return exec.Command("echo", "ok")
+	}
+
+	brewMacProfile := system.PlatformProfile{OS: "darwin", PackageManager: "brew", Supported: true}
+
+	// Tool declared as go-install — must NOT fall back to go install on brew error.
+	results := []update.UpdateResult{
+		makeResult("engram", update.UpdateAvailable, "0.3.0", "0.4.0", update.InstallGoInstall),
+	}
+	results[0].Tool.GoImportPath = "github.com/Gentleman-Programming/engram/cmd/engram"
+
+	report := Execute(context.Background(), results, brewMacProfile, t.TempDir(), false)
+
+	if len(report.Results) != 1 {
+		t.Fatalf("len(Results) = %d, want 1", len(report.Results))
+	}
+
+	r := report.Results[0]
+
+	// Must be UpgradeFailed — the brew path failed and there was no silent fallback.
+	if r.Status != UpgradeFailed {
+		t.Errorf("brew operational error: Status = %q, want UpgradeFailed (must not silently fall back to declared method)", r.Status)
+	}
+
+	// Err must be non-nil — the failure must surface through the error field.
+	if r.Err == nil {
+		t.Errorf("brew operational error: Err is nil, want non-nil (failure must surface)")
+	}
+
+	// Method must be InstallBrew — the resolved method must NOT be go-install
+	// (which would mean effectiveMethod silently fell back on brewError).
+	if r.Method != update.InstallBrew {
+		t.Errorf("brew operational error: Method = %q, want InstallBrew (no silent fallback)", r.Method)
+	}
+
+	// Must NOT have called "go" (which would indicate fallback to go-install).
+	for _, cmd := range calledCommands {
+		if cmd == "go" {
+			t.Errorf("brew error triggered go-install fallback — calledCommands: %v; expected only brew calls", calledCommands)
+			break
+		}
 	}
 }

--- a/internal/update/upgrade/executor_test.go
+++ b/internal/update/upgrade/executor_test.go
@@ -420,7 +420,9 @@ func TestExecute_DevBuildSurfacedAsSkipped(t *testing.T) {
 // must be populated from the error message so RenderUpgradeReport can display it.
 func TestExecute_ManualFallbackSurfacedAsSkippedNotFailed(t *testing.T) {
 	origExecCommand := execCommand
+	origIsBrewManaged := isBrewManagedFn
 	t.Cleanup(func() { execCommand = origExecCommand })
+	t.Cleanup(func() { isBrewManagedFn = origIsBrewManaged })
 
 	execCalled := false
 	execCommand = func(name string, args ...string) *exec.Cmd {
@@ -461,6 +463,50 @@ func TestExecute_ManualFallbackSurfacedAsSkippedNotFailed(t *testing.T) {
 	// Err should be nil for a manual skip (it is not a failure).
 	if r.Err != nil {
 		t.Errorf("Windows binary fallback Err = %v, want nil (manual skips are not errors)", r.Err)
+	}
+}
+
+// TestExecute_BrewProfileNonBrewToolFallsBackToDeclaredMethod verifies the full
+// executor path for the Linuxbrew regression: even when the platform profile uses
+// brew, a tool that is not actually brew-managed must execute its declared install
+// method instead of forcing `brew upgrade <tool>`.
+func TestExecute_BrewProfileNonBrewToolFallsBackToDeclaredMethod(t *testing.T) {
+	origExecCommand := execCommand
+	origIsBrewManaged := isBrewManagedFn
+	t.Cleanup(func() { execCommand = origExecCommand })
+	t.Cleanup(func() { isBrewManagedFn = origIsBrewManaged })
+
+	isBrewManagedFn = func(string) bool { return false }
+
+	var calls [][]string
+	execCommand = func(name string, args ...string) *exec.Cmd {
+		calls = append(calls, append([]string{name}, args...))
+		return exec.Command("echo", "ok")
+	}
+
+	linuxBrewProfile := system.PlatformProfile{OS: "linux", PackageManager: "brew", Supported: true}
+	results := []update.UpdateResult{
+		makeResult("engram", update.UpdateAvailable, "0.3.0", "0.4.0", update.InstallGoInstall),
+	}
+	results[0].Tool.GoImportPath = "github.com/Gentleman-Programming/engram/cmd/engram"
+
+	report := Execute(context.Background(), results, linuxBrewProfile, t.TempDir(), false)
+
+	if len(report.Results) != 1 {
+		t.Fatalf("len(Results) = %d, want 1", len(report.Results))
+	}
+	if report.Results[0].Status != UpgradeSucceeded {
+		t.Fatalf("status = %q, want UpgradeSucceeded", report.Results[0].Status)
+	}
+
+	if len(calls) != 1 {
+		t.Fatalf("execCommand call count = %d, want 1", len(calls))
+	}
+	if calls[0][0] != "go" {
+		t.Fatalf("first exec command = %q, want %q (declared go-install fallback, not brew)", calls[0][0], "go")
+	}
+	if len(calls[0]) < 3 || calls[0][1] != "install" {
+		t.Fatalf("exec args = %v, want go install invocation", calls[0])
 	}
 }
 

--- a/internal/update/upgrade/strategy.go
+++ b/internal/update/upgrade/strategy.go
@@ -37,14 +37,14 @@ const maxScriptSize = 1 * 1024 * 1024 // 1 MB
 // (via resolveMethod in Execute) and passed here directly — this function
 // MUST NOT re-evaluate the effective method to avoid redundant brew probes.
 //
-// Strategy routing:
-//   - brew profile → brewUpgrade (regardless of tool's declared method)
-//   - go-install method + apt/pacman/other → goInstallUpgrade
-//   - binary method + linux/darwin → binaryUpgrade
-//   - binary method + windows → manualFallback (Phase 1: self-replace deferred)
-//   - script method + linux/darwin + gga → ggaScriptUpgrade (git clone approach)
-//   - script method + linux/darwin + other → scriptUpgrade (curl | bash install.sh)
-//   - script method + windows → manualFallback
+// Strategy routing (by resolved method, not by platform profile):
+//   - InstallBrew method   → brewUpgrade (set by effectiveMethod for brew-managed tools and brew errors)
+//   - InstallGoInstall     → goInstallUpgrade
+//   - InstallBinary + linux/darwin → binaryUpgrade
+//   - InstallBinary + windows → manualFallback (Phase 1: self-replace deferred)
+//   - InstallScript + linux/darwin + gga → ggaScriptUpgrade (git clone approach)
+//   - InstallScript + linux/darwin + other → scriptUpgrade (curl | bash install.sh)
+//   - InstallScript + windows → manualFallback
 //   - unknown method → manualFallback with explicit message
 func runStrategy(ctx context.Context, r update.UpdateResult, method update.InstallMethod, profile system.PlatformProfile) error {
 	switch method {

--- a/internal/update/upgrade/strategy.go
+++ b/internal/update/upgrade/strategy.go
@@ -32,8 +32,10 @@ var scriptHTTPClient = &http.Client{Timeout: 2 * time.Minute}
 // server or CDN could still serve a malicious script within this size limit.
 const maxScriptSize = 1 * 1024 * 1024 // 1 MB
 
-// runStrategy executes the upgrade for a single tool using the appropriate strategy
-// for the given platform profile.
+// runStrategy executes the upgrade for a single tool using the provided
+// pre-resolved install method. The method must be computed by the caller
+// (via resolveMethod in Execute) and passed here directly — this function
+// MUST NOT re-evaluate the effective method to avoid redundant brew probes.
 //
 // Strategy routing:
 //   - brew profile → brewUpgrade (regardless of tool's declared method)
@@ -44,9 +46,7 @@ const maxScriptSize = 1 * 1024 * 1024 // 1 MB
 //   - script method + linux/darwin + other → scriptUpgrade (curl | bash install.sh)
 //   - script method + windows → manualFallback
 //   - unknown method → manualFallback with explicit message
-func runStrategy(ctx context.Context, r update.UpdateResult, profile system.PlatformProfile) error {
-	method := effectiveMethod(r.Tool, profile)
-
+func runStrategy(ctx context.Context, r update.UpdateResult, method update.InstallMethod, profile system.PlatformProfile) error {
 	switch method {
 	case update.InstallBrew:
 		return brewUpgrade(ctx, r.Tool.Name)

--- a/internal/update/upgrade/strategy_test.go
+++ b/internal/update/upgrade/strategy_test.go
@@ -35,7 +35,7 @@ func TestRunStrategy_BrewUpgrade(t *testing.T) {
 	}
 	profile := system.PlatformProfile{OS: "darwin", PackageManager: "brew"}
 
-	err := runStrategy(context.Background(), r, profile)
+	err := runStrategy(context.Background(), r, update.InstallBrew, profile)
 	if err != nil {
 		t.Fatalf("runStrategy brew: unexpected error: %v", err)
 	}
@@ -72,7 +72,7 @@ func TestRunStrategy_GoInstallUpgrade(t *testing.T) {
 	}
 	profile := system.PlatformProfile{OS: "linux", PackageManager: "apt"}
 
-	err := runStrategy(context.Background(), r, profile)
+	err := runStrategy(context.Background(), r, update.InstallGoInstall, profile)
 	if err != nil {
 		t.Fatalf("runStrategy go-install: unexpected error: %v", err)
 	}
@@ -100,7 +100,7 @@ func TestRunStrategy_GoInstallMissingImportPath(t *testing.T) {
 	}
 	profile := system.PlatformProfile{OS: "linux", PackageManager: "apt"}
 
-	err := runStrategy(context.Background(), r, profile)
+	err := runStrategy(context.Background(), r, update.InstallGoInstall, profile)
 	if err == nil {
 		t.Errorf("expected error when GoImportPath is empty, got nil")
 	}
@@ -118,7 +118,7 @@ func TestRunStrategy_UnsupportedMethodManualFallback(t *testing.T) {
 	}
 	profile := system.PlatformProfile{OS: "linux", PackageManager: "apt"}
 
-	err := runStrategy(context.Background(), r, profile)
+	err := runStrategy(context.Background(), r, update.InstallMethod("unsupported-method"), profile)
 	// Unsupported method → manual fallback error.
 	if err == nil {
 		t.Errorf("expected error for unsupported install method, got nil")
@@ -144,7 +144,7 @@ func TestRunStrategy_BrewUpgradeFailure(t *testing.T) {
 	}
 	profile := system.PlatformProfile{OS: "darwin", PackageManager: "brew"}
 
-	err := runStrategy(context.Background(), r, profile)
+	err := runStrategy(context.Background(), r, update.InstallBrew, profile)
 	if err == nil {
 		t.Errorf("expected error when brew upgrade fails, got nil")
 	}
@@ -170,7 +170,7 @@ func TestRunStrategy_GoInstallFailure(t *testing.T) {
 	}
 	profile := system.PlatformProfile{OS: "linux", PackageManager: "apt"}
 
-	err := runStrategy(context.Background(), r, profile)
+	err := runStrategy(context.Background(), r, update.InstallGoInstall, profile)
 	if err == nil {
 		t.Errorf("expected error when go install fails, got nil")
 	}
@@ -201,7 +201,7 @@ func TestRunStrategy_BinaryWindowsSelfUpdateSkipped(t *testing.T) {
 	}
 	profile := system.PlatformProfile{OS: "windows", PackageManager: "winget"}
 
-	err := runStrategy(context.Background(), r, profile)
+	err := runStrategy(context.Background(), r, update.InstallBinary, profile)
 	// Windows binary self-replace must return an error (manual hint) in Phase 1.
 	if err == nil {
 		t.Errorf("expected manual fallback error for Windows binary self-replace, got nil")
@@ -215,57 +215,61 @@ func TestRunStrategy_BinaryWindowsSelfUpdateSkipped(t *testing.T) {
 // --- TestEffectiveMethod ---
 
 func TestEffectiveMethod(t *testing.T) {
-	origIsBrewManaged := isBrewManagedFn
-	t.Cleanup(func() { isBrewManagedFn = origIsBrewManaged })
-
 	tests := []struct {
-		name         string
-		tool         update.ToolInfo
-		profile      system.PlatformProfile
-		brewManaged  bool // mock return value for isBrewManagedFn
-		want         update.InstallMethod
+		name       string
+		tool       update.ToolInfo
+		profile    system.PlatformProfile
+		brewResult brewCheckResult // explicit 3-state result
+		want       update.InstallMethod
 	}{
 		{
-			name:        "brew profile + brew-managed tool overrides go-install",
-			tool:        update.ToolInfo{Name: "engram", InstallMethod: update.InstallGoInstall},
-			profile:     system.PlatformProfile{PackageManager: "brew"},
-			brewManaged: true,
-			want:        update.InstallBrew,
+			name:       "brew profile + brewManaged overrides go-install",
+			tool:       update.ToolInfo{Name: "engram", InstallMethod: update.InstallGoInstall},
+			profile:    system.PlatformProfile{PackageManager: "brew"},
+			brewResult: brewManaged,
+			want:       update.InstallBrew,
 		},
 		{
-			name:        "brew profile + brew-managed tool overrides binary",
-			tool:        update.ToolInfo{Name: "gga", InstallMethod: update.InstallBinary},
-			profile:     system.PlatformProfile{PackageManager: "brew"},
-			brewManaged: true,
-			want:        update.InstallBrew,
+			name:       "brew profile + brewManaged overrides binary",
+			tool:       update.ToolInfo{Name: "gga", InstallMethod: update.InstallBinary},
+			profile:    system.PlatformProfile{PackageManager: "brew"},
+			brewResult: brewManaged,
+			want:       update.InstallBrew,
 		},
 		{
-			name:        "brew profile + brew-managed tool overrides script",
-			tool:        update.ToolInfo{Name: "gga", InstallMethod: update.InstallScript},
-			profile:     system.PlatformProfile{PackageManager: "brew"},
-			brewManaged: true,
-			want:        update.InstallBrew,
+			name:       "brew profile + brewManaged overrides script",
+			tool:       update.ToolInfo{Name: "gga", InstallMethod: update.InstallScript},
+			profile:    system.PlatformProfile{PackageManager: "brew"},
+			brewResult: brewManaged,
+			want:       update.InstallBrew,
 		},
 		{
-			name:        "brew profile + non-brew tool falls back to declared binary",
-			tool:        update.ToolInfo{Name: "gentle-ai", InstallMethod: update.InstallBinary},
-			profile:     system.PlatformProfile{PackageManager: "brew"},
-			brewManaged: false,
-			want:        update.InstallBinary,
+			name:       "brew profile + brewNotManaged falls back to declared binary",
+			tool:       update.ToolInfo{Name: "gentle-ai", InstallMethod: update.InstallBinary},
+			profile:    system.PlatformProfile{PackageManager: "brew"},
+			brewResult: brewNotManaged,
+			want:       update.InstallBinary,
 		},
 		{
-			name:        "brew profile + non-brew tool falls back to declared script",
-			tool:        update.ToolInfo{Name: "gga", InstallMethod: update.InstallScript},
-			profile:     system.PlatformProfile{PackageManager: "brew"},
-			brewManaged: false,
-			want:        update.InstallScript,
+			name:       "brew profile + brewNotManaged falls back to declared script",
+			tool:       update.ToolInfo{Name: "gga", InstallMethod: update.InstallScript},
+			profile:    system.PlatformProfile{PackageManager: "brew"},
+			brewResult: brewNotManaged,
+			want:       update.InstallScript,
 		},
 		{
-			name:        "brew profile + non-brew tool falls back to declared go-install",
-			tool:        update.ToolInfo{Name: "engram", InstallMethod: update.InstallGoInstall},
-			profile:     system.PlatformProfile{PackageManager: "brew"},
-			brewManaged: false,
-			want:        update.InstallGoInstall,
+			name:       "brew profile + brewNotManaged falls back to declared go-install",
+			tool:       update.ToolInfo{Name: "engram", InstallMethod: update.InstallGoInstall},
+			profile:    system.PlatformProfile{PackageManager: "brew"},
+			brewResult: brewNotManaged,
+			want:       update.InstallGoInstall,
+		},
+		{
+			name:       "brew profile + brewError keeps InstallBrew (no silent fallback)",
+			tool:       update.ToolInfo{Name: "engram", InstallMethod: update.InstallGoInstall},
+			profile:    system.PlatformProfile{PackageManager: "brew"},
+			brewResult: brewError,
+			want:       update.InstallBrew,
 		},
 		{
 			name:    "apt profile respects declared method (go-install)",
@@ -289,8 +293,7 @@ func TestEffectiveMethod(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			isBrewManagedFn = func(string) bool { return tc.brewManaged }
-			got := effectiveMethod(tc.tool, tc.profile)
+			got := effectiveMethod(tc.tool, tc.profile, tc.brewResult)
 			if got != tc.want {
 				t.Errorf("effectiveMethod = %q, want %q", got, tc.want)
 			}
@@ -313,7 +316,7 @@ func TestManualFallbackHint(t *testing.T) {
 	}
 	profile := system.PlatformProfile{OS: "windows", PackageManager: "winget"}
 
-	err := runStrategy(context.Background(), r, profile)
+	err := runStrategy(context.Background(), r, update.InstallBinary, profile)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -432,7 +435,7 @@ func TestRunStrategy_ExecErrorWrapped(t *testing.T) {
 	}
 	profile := system.PlatformProfile{OS: "darwin", PackageManager: "brew"}
 
-	err := runStrategy(context.Background(), r, profile)
+	err := runStrategy(context.Background(), r, update.InstallBrew, profile)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -732,7 +735,7 @@ func TestRunStrategy_GGAUsesGitClone(t *testing.T) {
 	}
 	profile := system.PlatformProfile{OS: "linux", PackageManager: "apt"}
 
-	err := runStrategy(context.Background(), r, profile)
+	err := runStrategy(context.Background(), r, update.InstallScript, profile)
 	if err != nil {
 		t.Fatalf("runStrategy GGA: unexpected error: %v", err)
 	}
@@ -791,7 +794,7 @@ func TestEngramUpgradeUsesDownloadNotGoInstall(t *testing.T) {
 	}
 	profile := system.PlatformProfile{OS: "windows", PackageManager: "winget"}
 
-	err := runStrategy(context.Background(), r, profile)
+	err := runStrategy(context.Background(), r, update.InstallBinary, profile)
 	if err != nil {
 		t.Fatalf("runStrategy engram windows: unexpected error: %v", err)
 	}
@@ -840,7 +843,7 @@ func TestEngramUpgradeLinuxUsesDownload(t *testing.T) {
 	}
 	profile := system.PlatformProfile{OS: "linux", PackageManager: "apt"}
 
-	err := runStrategy(context.Background(), r, profile)
+	err := runStrategy(context.Background(), r, update.InstallBinary, profile)
 	if err != nil {
 		t.Fatalf("runStrategy engram linux: unexpected error: %v", err)
 	}

--- a/internal/update/upgrade/strategy_test.go
+++ b/internal/update/upgrade/strategy_test.go
@@ -215,29 +215,57 @@ func TestRunStrategy_BinaryWindowsSelfUpdateSkipped(t *testing.T) {
 // --- TestEffectiveMethod ---
 
 func TestEffectiveMethod(t *testing.T) {
+	origIsBrewManaged := isBrewManagedFn
+	t.Cleanup(func() { isBrewManagedFn = origIsBrewManaged })
+
 	tests := []struct {
-		name    string
-		tool    update.ToolInfo
-		profile system.PlatformProfile
-		want    update.InstallMethod
+		name         string
+		tool         update.ToolInfo
+		profile      system.PlatformProfile
+		brewManaged  bool // mock return value for isBrewManagedFn
+		want         update.InstallMethod
 	}{
 		{
-			name:    "brew profile overrides go-install",
-			tool:    update.ToolInfo{Name: "engram", InstallMethod: update.InstallGoInstall},
-			profile: system.PlatformProfile{PackageManager: "brew"},
-			want:    update.InstallBrew,
+			name:        "brew profile + brew-managed tool overrides go-install",
+			tool:        update.ToolInfo{Name: "engram", InstallMethod: update.InstallGoInstall},
+			profile:     system.PlatformProfile{PackageManager: "brew"},
+			brewManaged: true,
+			want:        update.InstallBrew,
 		},
 		{
-			name:    "brew profile overrides binary",
-			tool:    update.ToolInfo{Name: "gga", InstallMethod: update.InstallBinary},
-			profile: system.PlatformProfile{PackageManager: "brew"},
-			want:    update.InstallBrew,
+			name:        "brew profile + brew-managed tool overrides binary",
+			tool:        update.ToolInfo{Name: "gga", InstallMethod: update.InstallBinary},
+			profile:     system.PlatformProfile{PackageManager: "brew"},
+			brewManaged: true,
+			want:        update.InstallBrew,
 		},
 		{
-			name:    "brew profile overrides script",
-			tool:    update.ToolInfo{Name: "gga", InstallMethod: update.InstallScript},
-			profile: system.PlatformProfile{PackageManager: "brew"},
-			want:    update.InstallBrew,
+			name:        "brew profile + brew-managed tool overrides script",
+			tool:        update.ToolInfo{Name: "gga", InstallMethod: update.InstallScript},
+			profile:     system.PlatformProfile{PackageManager: "brew"},
+			brewManaged: true,
+			want:        update.InstallBrew,
+		},
+		{
+			name:        "brew profile + non-brew tool falls back to declared binary",
+			tool:        update.ToolInfo{Name: "gentle-ai", InstallMethod: update.InstallBinary},
+			profile:     system.PlatformProfile{PackageManager: "brew"},
+			brewManaged: false,
+			want:        update.InstallBinary,
+		},
+		{
+			name:        "brew profile + non-brew tool falls back to declared script",
+			tool:        update.ToolInfo{Name: "gga", InstallMethod: update.InstallScript},
+			profile:     system.PlatformProfile{PackageManager: "brew"},
+			brewManaged: false,
+			want:        update.InstallScript,
+		},
+		{
+			name:        "brew profile + non-brew tool falls back to declared go-install",
+			tool:        update.ToolInfo{Name: "engram", InstallMethod: update.InstallGoInstall},
+			profile:     system.PlatformProfile{PackageManager: "brew"},
+			brewManaged: false,
+			want:        update.InstallGoInstall,
 		},
 		{
 			name:    "apt profile respects declared method (go-install)",
@@ -261,6 +289,7 @@ func TestEffectiveMethod(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			isBrewManagedFn = func(string) bool { return tc.brewManaged }
 			got := effectiveMethod(tc.tool, tc.profile)
 			if got != tc.want {
 				t.Errorf("effectiveMethod = %q, want %q", got, tc.want)


### PR DESCRIPTION
## Linked Issue

Closes #186

## PR Type

- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary

- Fixes Linux/Linuxbrew upgrade routing so brew is only used when the specific tool is actually managed by Homebrew.
- Prevents `gentle-ai upgrade` and the TUI `Upgrade tools` / `Upgrade + Sync` flows from failing with `No available formula` for tools installed via binary download, script, or `go install`.
- Adds both method-selection unit coverage and executor-level regression coverage for the Linuxbrew mixed-install scenario.

## Problem Statement

On Linux systems that have Linuxbrew installed for unrelated packages, Gentle AI treated the entire platform as "brew-managed" and forced `brew upgrade <tool>` for every managed tool.

That assumption is wrong.

A machine can have Homebrew installed and still have individual tools installed by other methods:
- `gentle-ai` via release binary in `~/.local/bin`
- `engram` via binary download or `go install`
- `gga` via `install.sh`
- unrelated packages like `zellij` via Linuxbrew

Before this change, `effectiveMethod()` only looked at `profile.PackageManager == "brew"`. That caused upgrade execution to route non-brew tools into the Homebrew strategy, which then failed with errors like:

```text
brew upgrade gentle-ai: exit status 1 (output: Error: No available formula with the name "gentle-ai")
```

This was reproducible from both TUI entry points because `Upgrade tools` and `Upgrade + Sync` share the same backend upgrade executor.

## Root Cause

The bug was not "brew exists".
The bug was "brew exists, therefore every tool must be brew-managed".

Those are different concepts.

The previous logic used the platform profile as a global proxy for per-tool install provenance. On Linux/Linuxbrew, that collapses distinct install methods into a single strategy and breaks mixed installations.

## Solution

The fix introduces a per-tool Homebrew ownership check before selecting the brew strategy:

- Added `isBrewManaged(toolName string) bool`, implemented via `brew list --versions <tool>`.
- Added package-level var `isBrewManagedFn` so tests can swap the check without hitting the real system.
- Updated `effectiveMethod()` to use Homebrew only when BOTH conditions are true:
  - the platform profile uses `brew`
  - the specific tool is actually present in the Homebrew Cellar
- If the tool is not brew-managed, upgrade falls back to the tool's declared `InstallMethod`:
  - `binary`
  - `script`
  - `go-install`

## Why This Approach

This is the minimal correct fix.

It preserves the existing behavior for genuine Homebrew installs while restoring correct behavior for mixed-install Linux environments.

Alternatives considered:
- Keep using platform package manager only: incorrect on mixed-install systems.
- Add tool-specific hardcoded exceptions: brittle and guaranteed to rot.
- Detect install method from PATH alone: unreliable compared to checking Homebrew's own package registry.

## Changes Table

| File | Change |
|------|--------|
| `internal/update/upgrade/executor.go` | Added `isBrewManagedFn`, added `isBrewManaged()`, and changed `effectiveMethod()` to require per-tool brew ownership before forcing brew strategy |
| `internal/update/upgrade/strategy_test.go` | Expanded method-selection coverage for brew-managed vs non-brew tools |
| `internal/update/upgrade/executor_test.go` | Added executor-level regression test covering a Linuxbrew profile where a non-brew tool must fall back to its declared method |

## Test Coverage

### Focused regression coverage

- [x] `TestEffectiveMethod` updated to cover:
  - brew profile + brew-managed tool => `InstallBrew`
  - brew profile + non-brew tool => declared `InstallBinary`
  - brew profile + non-brew tool => declared `InstallScript`
  - brew profile + non-brew tool => declared `InstallGoInstall`
- [x] Added `TestExecute_BrewProfileNonBrewToolFallsBackToDeclaredMethod`
  - exercises the higher-level executor path
  - verifies that under a brew profile, a non-brew-managed tool does NOT call `brew upgrade`
  - verifies fallback to the declared `go install` strategy instead

### Broader validation

- [x] `go test ./internal/update/upgrade`
- [x] `go test ./internal/update/...`
- [x] `go test ./...`

### Manual validation

- [x] Reproduced the failure on Fedora 43 with `gentle-ai` installed in `~/.local/bin` and Linuxbrew present for unrelated packages
- [x] Built and installed the branch locally
- [x] Verified the TUI no longer attempts `brew upgrade gentle-ai`
- [x] Verified `Upgrade tools` now reports up to date after the local fixed binary is installed

## Reproduction Before Fix

1. Install `gentle-ai` outside Homebrew (for example as a binary in `~/.local/bin`).
2. Have Linuxbrew installed for some unrelated package.
3. Run the TUI and choose `Upgrade tools` or `Upgrade + Sync`.
4. Observe upgrade routing to Homebrew for `gentle-ai`.
5. Observe failure: `No available formula with the name \"gentle-ai\"`.

## Behavior After Fix

1. Same mixed-install environment.
2. Upgrade checks whether `gentle-ai` is actually brew-managed.
3. If not brew-managed, Homebrew is NOT selected.
4. Upgrade falls back to the tool's declared install method.
5. The Linuxbrew false-positive path is eliminated.

## Risk / Non-Goals

- This PR does NOT change how tools are initially installed.
- This PR does NOT add a full end-to-end CI harness for Linuxbrew mixed installs.
- This PR intentionally keeps Homebrew precedence for tools that really are installed via Homebrew.

## Maintainer Actions Needed

- Add `status:approved` to issue `#186`
- Add PR label `type:bug`
- Approve workflows for forked PR execution if required by GitHub

## Contributor Checklist

- [x] Linked an issue
- [ ] Added exactly one `type:*` label (maintainer permission required)
- [x] Ran the relevant automated tests locally
- [x] Manually validated the affected functionality
- [x] Conventional commit format used
- [x] No `Co-Authored-By` trailers added