### PR TITLE
fix(sdd): register sdd-onboard skill in Go injection pipeline

### DIFF
--- a/internal/catalog/skills.go
+++ b/internal/catalog/skills.go
@@ -21,6 +21,7 @@ var mvpSkills = []Skill{
 	{ID: model.SkillSDDDesign, Name: "sdd-design", Category: "sdd", Priority: "p0"},
 	{ID: model.SkillSDDTasks, Name: "sdd-tasks", Category: "sdd", Priority: "p0"},
 	{ID: model.SkillSDDArchive, Name: "sdd-archive", Category: "sdd", Priority: "p0"},
+	{ID: model.SkillSDDOnboard, Name: "sdd-onboard", Category: "sdd", Priority: "p0"},
 	// Foundation skills
 	{ID: model.SkillGoTesting, Name: "go-testing", Category: "testing", Priority: "p0"},
 	{ID: model.SkillCreator, Name: "skill-creator", Category: "workflow", Priority: "p0"},

--- a/internal/components/sdd/inject.go
+++ b/internal/components/sdd/inject.go
@@ -374,7 +374,7 @@ func Inject(homeDir string, adapter agents.Adapter, sddMode model.SDDModeID, opt
 			sddSkills := []string{
 				"sdd-init", "sdd-explore", "sdd-propose", "sdd-spec",
 				"sdd-design", "sdd-tasks", "sdd-apply", "sdd-verify", "sdd-archive",
-				"judgment-day",
+				"sdd-onboard", "judgment-day",
 			}
 
 			for _, skill := range sddSkills {

--- a/internal/components/skills/presets.go
+++ b/internal/components/skills/presets.go
@@ -13,6 +13,7 @@ var sddSkills = []model.SkillID{
 	model.SkillSDDApply,
 	model.SkillSDDVerify,
 	model.SkillSDDArchive,
+	model.SkillSDDOnboard,
 	model.SkillJudgmentDay,
 }
 

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -49,6 +49,7 @@ const (
 	SkillSDDDesign     SkillID = "sdd-design"
 	SkillSDDTasks      SkillID = "sdd-tasks"
 	SkillSDDArchive    SkillID = "sdd-archive"
+	SkillSDDOnboard    SkillID = "sdd-onboard"
 	SkillGoTesting     SkillID = "go-testing"
 	SkillCreator       SkillID = "skill-creator"
 	SkillJudgmentDay   SkillID = "judgment-day"

--- a/internal/tui/screens/skill_picker.go
+++ b/internal/tui/screens/skill_picker.go
@@ -19,6 +19,7 @@ var sddSkillIDs = []model.SkillID{
 	model.SkillSDDApply,
 	model.SkillSDDVerify,
 	model.SkillSDDArchive,
+	model.SkillSDDOnboard,
 	model.SkillJudgmentDay,
 }
 
@@ -41,6 +42,7 @@ var skillLabels = map[model.SkillID]string{
 	model.SkillSDDApply:      "SDD Apply",
 	model.SkillSDDVerify:     "SDD Verify",
 	model.SkillSDDArchive:    "SDD Archive",
+	model.SkillSDDOnboard:    "SDD Onboard",
 	model.SkillJudgmentDay:   "Judgment Day",
 	model.SkillGoTesting:     "Go Testing",
 	model.SkillCreator:       "Skill Creator",


### PR DESCRIPTION
## Summary

The `sdd-onboard` skill added in v1.15.10 (`eb857c3`) has the embedded asset and all 7 orchestrator references, but was never registered in the Go code that handles skill injection. As a result, `gentle-ai install` and `gentle-ai sync` never deploy it to any runtime.

**Fixes**: #195

## Changes

Adds `sdd-onboard` to the 5 registration points that every skill requires:

| File | Change |
|------|--------|
| `internal/model/types.go` | `SkillSDDOnboard` constant |
| `internal/components/skills/presets.go` | Added to `sddSkills` slice |
| `internal/tui/screens/skill_picker.go` | Added to `sddSkillIDs` + `skillLabels` |
| `internal/catalog/skills.go` | Added to `mvpSkills` catalog |
| `internal/components/sdd/inject.go` | Added to hardcoded SDD injection list |

Total: **+6 lines, -1 line** across 5 files. Zero logic changes — follows the exact same pattern as the other 9 SDD skills.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/model/...` passes
- [x] `go test ./internal/components/skills/...` passes
- [x] `go test ./internal/tui/screens/...` passes
- [x] `go test ./internal/catalog/...` passes
- [x] `go test ./internal/components/sdd/...` passes (54 tests, 0.97s)
- [ ] `gentle-ai install` deploys `sdd-onboard/SKILL.md` to configured agents
- [ ] `/sdd-onboard` command works end-to-end in Claude Code