### PR TITLE
fix(cli): skip self-update for explicit update/upgrade commands

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -68,11 +68,22 @@ func RunArgs(args []string, stdout io.Writer) error {
 		return system.EnsureSupportedPlatform(result.System.Profile)
 	}
 
+	var (
+		profile         system.PlatformProfile
+		profileResolved bool
+	)
+	resolveProfile := func() system.PlatformProfile {
+		if !profileResolved {
+			profile = cli.ResolveInstallProfile(result)
+			profileResolved = true
+		}
+		return profile
+	}
+
 	// Self-update: check for a newer gentle-ai release and apply it before
 	// CLI/TUI dispatch. Errors are non-fatal — logged and swallowed.
-	profile := cli.ResolveInstallProfile(result)
 	if !isExplicitUpdateFlow(args) {
-		if err := selfUpdateRun(context.Background(), Version, profile, stdout); err != nil {
+		if err := selfUpdateRun(context.Background(), Version, resolveProfile(), stdout); err != nil {
 			_, _ = fmt.Fprintf(stdout, "Warning: self-update failed: %v\n", err)
 		}
 	}
@@ -97,7 +108,7 @@ func RunArgs(args []string, stdout io.Writer) error {
 		}
 		m.ListBackupsFn = ListBackups
 		m.Backups = ListBackups()
-		m.UpgradeFn = tuiUpgrade(profile, homeDir)
+		m.UpgradeFn = tuiUpgrade(resolveProfile(), homeDir)
 		m.SyncFn = tuiSync(homeDir)
 		p := tea.NewProgram(m, tea.WithAltScreen())
 		_, err = p.Run()
@@ -106,8 +117,7 @@ func RunArgs(args []string, stdout io.Writer) error {
 
 	switch args[0] {
 	case "update":
-		profile := cli.ResolveInstallProfile(result)
-		return runUpdate(context.Background(), Version, profile, stdout)
+		return runUpdate(context.Background(), Version, resolveProfile(), stdout)
 	case "upgrade":
 		return runUpgrade(context.Background(), args[1:], result, stdout)
 	case "install":

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -30,7 +30,7 @@ var (
 	updateCheckAll      = update.CheckAll
 	updateCheckFiltered = update.CheckFiltered
 	upgradeExecute      = upgrade.Execute
-	selfUpdateRun       = selfUpdate
+	selfUpdateFn        = selfUpdate
 )
 
 func Run() error {
@@ -83,7 +83,7 @@ func RunArgs(args []string, stdout io.Writer) error {
 	// Self-update: check for a newer gentle-ai release and apply it before
 	// CLI/TUI dispatch. Errors are non-fatal — logged and swallowed.
 	if !isExplicitUpdateFlow(args) {
-		if err := selfUpdateRun(context.Background(), Version, resolveProfile(), stdout); err != nil {
+		if err := selfUpdateFn(context.Background(), Version, resolveProfile(), stdout); err != nil {
 			_, _ = fmt.Fprintf(stdout, "Warning: self-update failed: %v\n", err)
 		}
 	}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -30,6 +30,7 @@ var (
 	updateCheckAll      = update.CheckAll
 	updateCheckFiltered = update.CheckFiltered
 	upgradeExecute      = upgrade.Execute
+	selfUpdateRun       = selfUpdate
 )
 
 func Run() error {
@@ -70,8 +71,10 @@ func RunArgs(args []string, stdout io.Writer) error {
 	// Self-update: check for a newer gentle-ai release and apply it before
 	// CLI/TUI dispatch. Errors are non-fatal — logged and swallowed.
 	profile := cli.ResolveInstallProfile(result)
-	if err := selfUpdate(context.Background(), Version, profile, stdout); err != nil {
-		_, _ = fmt.Fprintf(stdout, "Warning: self-update failed: %v\n", err)
+	if !isExplicitUpdateFlow(args) {
+		if err := selfUpdateRun(context.Background(), Version, profile, stdout); err != nil {
+			_, _ = fmt.Fprintf(stdout, "Warning: self-update failed: %v\n", err)
+		}
 	}
 
 	if len(args) == 0 {
@@ -436,4 +439,14 @@ func ListBackups() []backup.Manifest {
 	}
 
 	return manifests
+}
+
+// isExplicitUpdateFlow reports whether the current invocation is already in the
+// explicit update/upgrade path. In those cases, self-update must be skipped to
+// avoid preempting the user's requested command behavior.
+func isExplicitUpdateFlow(args []string) bool {
+	if len(args) == 0 {
+		return false
+	}
+	return args[0] == "update" || args[0] == "upgrade"
 }

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -558,10 +558,19 @@ func TestUnknownCommandSuggestsHelp(t *testing.T) {
 func TestRunArgs_UpdateSkipsSelfUpdate(t *testing.T) {
 	origSelfUpdate := selfUpdateFn
 	origCheckAll := updateCheckAll
+	origDetect := detectSystem
+	origEnsure := ensureCurrentOSSupported
 	t.Cleanup(func() {
 		selfUpdateFn = origSelfUpdate
 		updateCheckAll = origCheckAll
+		detectSystem = origDetect
+		ensureCurrentOSSupported = origEnsure
 	})
+
+	ensureCurrentOSSupported = func() error { return nil }
+	detectSystem = func(context.Context) (system.DetectionResult, error) {
+		return system.DetectionResult{System: system.SystemInfo{Supported: true}}, nil
+	}
 
 	selfUpdateCalled := 0
 	selfUpdateFn = func(context.Context, string, system.PlatformProfile, io.Writer) error {
@@ -594,11 +603,20 @@ func TestRunArgs_UpgradeSkipsSelfUpdate(t *testing.T) {
 	origSelfUpdate := selfUpdateFn
 	origCheckFiltered := updateCheckFiltered
 	origUpgradeExecute := upgradeExecute
+	origDetect := detectSystem
+	origEnsure := ensureCurrentOSSupported
 	t.Cleanup(func() {
 		selfUpdateFn = origSelfUpdate
 		updateCheckFiltered = origCheckFiltered
 		upgradeExecute = origUpgradeExecute
+		detectSystem = origDetect
+		ensureCurrentOSSupported = origEnsure
 	})
+
+	ensureCurrentOSSupported = func() error { return nil }
+	detectSystem = func(context.Context) (system.DetectionResult, error) {
+		return system.DetectionResult{System: system.SystemInfo{Supported: true}}, nil
+	}
 
 	selfUpdateCalled := 0
 	selfUpdateFn = func(context.Context, string, system.PlatformProfile, io.Writer) error {

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -2,7 +2,9 @@ package app
 
 import (
 	"bytes"
+	"context"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -12,6 +14,9 @@ import (
 	"github.com/gentleman-programming/gentle-ai/internal/backup"
 	"github.com/gentleman-programming/gentle-ai/internal/model"
 	"github.com/gentleman-programming/gentle-ai/internal/state"
+	"github.com/gentleman-programming/gentle-ai/internal/system"
+	"github.com/gentleman-programming/gentle-ai/internal/update"
+	"github.com/gentleman-programming/gentle-ai/internal/update/upgrade"
 )
 
 // TestListBackupsNewestFirst verifies that ListBackups returns manifests sorted
@@ -465,5 +470,106 @@ func TestUnknownCommandSuggestsHelp(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "gentle-ai help") {
 		t.Error("unknown command error should suggest 'gentle-ai help'")
+	}
+}
+
+func TestRunArgs_UpdateSkipsSelfUpdate(t *testing.T) {
+	origSelfUpdate := selfUpdateRun
+	origCheckAll := updateCheckAll
+	t.Cleanup(func() {
+		selfUpdateRun = origSelfUpdate
+		updateCheckAll = origCheckAll
+	})
+
+	selfUpdateCalled := 0
+	selfUpdateRun = func(context.Context, string, system.PlatformProfile, io.Writer) error {
+		selfUpdateCalled++
+		return nil
+	}
+
+	updateCheckAll = func(context.Context, string, system.PlatformProfile) []update.UpdateResult {
+		return []update.UpdateResult{
+			{
+				Tool:             update.ToolInfo{Name: "gentle-ai"},
+				InstalledVersion: "1.0.0",
+				LatestVersion:    "1.0.0",
+				Status:           update.UpToDate,
+			},
+		}
+	}
+
+	var buf bytes.Buffer
+	err := RunArgs([]string{"update"}, &buf)
+	if err != nil {
+		t.Fatalf("RunArgs(update) error = %v", err)
+	}
+	if selfUpdateCalled != 0 {
+		t.Fatalf("selfUpdate should be skipped for explicit update flow; got %d call(s)", selfUpdateCalled)
+	}
+}
+
+func TestRunArgs_UpgradeSkipsSelfUpdate(t *testing.T) {
+	origSelfUpdate := selfUpdateRun
+	origCheckFiltered := updateCheckFiltered
+	origUpgradeExecute := upgradeExecute
+	t.Cleanup(func() {
+		selfUpdateRun = origSelfUpdate
+		updateCheckFiltered = origCheckFiltered
+		upgradeExecute = origUpgradeExecute
+	})
+
+	selfUpdateCalled := 0
+	selfUpdateRun = func(context.Context, string, system.PlatformProfile, io.Writer) error {
+		selfUpdateCalled++
+		return nil
+	}
+
+	updateCheckFiltered = func(context.Context, string, system.PlatformProfile, []string) []update.UpdateResult {
+		return []update.UpdateResult{
+			{
+				Tool:             update.ToolInfo{Name: "gentle-ai", InstallMethod: update.InstallBinary},
+				InstalledVersion: "1.0.0",
+				LatestVersion:    "1.0.0",
+				Status:           update.UpToDate,
+			},
+		}
+	}
+
+	upgradeExecute = func(context.Context, []update.UpdateResult, system.PlatformProfile, string, bool, ...io.Writer) upgrade.UpgradeReport {
+		return upgrade.UpgradeReport{}
+	}
+
+	var buf bytes.Buffer
+	err := RunArgs([]string{"upgrade", "--dry-run"}, &buf)
+	if err != nil {
+		t.Fatalf("RunArgs(upgrade --dry-run) error = %v", err)
+	}
+	if selfUpdateCalled != 0 {
+		t.Fatalf("selfUpdate should be skipped for explicit upgrade flow; got %d call(s)", selfUpdateCalled)
+	}
+}
+
+func TestIsExplicitUpdateFlow(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{name: "empty args", args: nil, want: false},
+		{name: "no command", args: []string{}, want: false},
+		{name: "update", args: []string{"update"}, want: true},
+		{name: "upgrade", args: []string{"upgrade"}, want: true},
+		{name: "version", args: []string{"version"}, want: false},
+		{name: "help", args: []string{"help"}, want: false},
+		{name: "install", args: []string{"install"}, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isExplicitUpdateFlow(tt.args)
+			if got != tt.want {
+				t.Fatalf("isExplicitUpdateFlow(%v) = %v, want %v", tt.args, got, tt.want)
+			}
+		})
 	}
 }

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -474,15 +474,15 @@ func TestUnknownCommandSuggestsHelp(t *testing.T) {
 }
 
 func TestRunArgs_UpdateSkipsSelfUpdate(t *testing.T) {
-	origSelfUpdate := selfUpdateRun
+	origSelfUpdate := selfUpdateFn
 	origCheckAll := updateCheckAll
 	t.Cleanup(func() {
-		selfUpdateRun = origSelfUpdate
+		selfUpdateFn = origSelfUpdate
 		updateCheckAll = origCheckAll
 	})
 
 	selfUpdateCalled := 0
-	selfUpdateRun = func(context.Context, string, system.PlatformProfile, io.Writer) error {
+	selfUpdateFn = func(context.Context, string, system.PlatformProfile, io.Writer) error {
 		selfUpdateCalled++
 		return nil
 	}
@@ -509,17 +509,17 @@ func TestRunArgs_UpdateSkipsSelfUpdate(t *testing.T) {
 }
 
 func TestRunArgs_UpgradeSkipsSelfUpdate(t *testing.T) {
-	origSelfUpdate := selfUpdateRun
+	origSelfUpdate := selfUpdateFn
 	origCheckFiltered := updateCheckFiltered
 	origUpgradeExecute := upgradeExecute
 	t.Cleanup(func() {
-		selfUpdateRun = origSelfUpdate
+		selfUpdateFn = origSelfUpdate
 		updateCheckFiltered = origCheckFiltered
 		upgradeExecute = origUpgradeExecute
 	})
 
 	selfUpdateCalled := 0
-	selfUpdateRun = func(context.Context, string, system.PlatformProfile, io.Writer) error {
+	selfUpdateFn = func(context.Context, string, system.PlatformProfile, io.Writer) error {
 		selfUpdateCalled++
 		return nil
 	}


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #231

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

This PR fixes a UX bug where `selfUpdate()` ran before explicit `gentle-ai update` and `gentle-ai upgrade` commands, causing unexpected backups/binary replacement before the requested command behavior.

Now, when users explicitly invoke `update` or `upgrade`, the pre-dispatch self-update is skipped so command output matches user intent. Self-update remains enabled for other command paths.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/app/app.go` | Added `isExplicitUpdateFlow(args)` guard and skipped `selfUpdate` for `update`/`upgrade` command paths; introduced `selfUpdateRun` indirection for testability |
| `internal/app/app_test.go` | Added regression tests for update/upgrade self-update bypass and table-driven tests for `isExplicitUpdateFlow` |

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./...
```

**E2E Tests** (Docker required)
```bash
cd e2e && ./docker-test.sh
```

- [x] Unit tests pass (`go test ./...`)
- [x] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Manually tested locally

Manual verification examples:
```bash
gentle-ai update
gentle-ai upgrade --dry-run
```
Expected: no pre-dispatch self-update spinner/backup before these explicit commands.

---

## 🤖 Automated Checks

| Check | Status | Description |
|-------|--------|-------------|
| Check Issue Reference | ✅ | PR body contains `Closes #231` |
| Check Issue Has `status:approved` | ✅ | Issue #231 is approved |
| Check PR Has `type:*` Label | ⏳ | Add `type:bug` label after PR creation |
| Unit Tests | ✅ | `go test ./...` passes locally |
| E2E Tests | ✅ | `cd e2e && ./docker-test.sh` passes locally |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [ ] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [x] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [ ] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

- This is a focused behavior fix for explicit update flows only.
- `selfUpdate` behavior for normal command/TUI paths remains unchanged.
- Regression coverage added to prevent future reintroduction.