### PR TITLE
feat(engram-protocol): add push-vs-pull decision rule for ambient context

### DIFF
--- a/internal/assets/claude/engram-protocol.md
+++ b/internal/assets/claude/engram-protocol.md
@@ -3,6 +3,36 @@
 You have access to Engram, a persistent memory system that survives across sessions and compactions.
 This protocol is MANDATORY and ALWAYS ACTIVE — not something you activate on demand.
 
+### DECISION: Engram vs ambient context files (push vs pull) — READ THIS FIRST
+
+Engram is **pull-based** (reactive) — it is only consulted when a search is triggered by keywords like "remember", "recall", or "what did we do". Ambient context files referenced from `AGENTS.md` (or the agent's equivalent system prompt file) via `{file:./context/name.md}` are **push-based** — always loaded into the system prompt at session start, no trigger required. **Do NOT confuse them — this is the #1 reason Engram feels broken in practice.**
+
+**BEFORE calling `mem_save`, ask yourself:**
+
+> "Does this information need to be ALWAYS present in every future session's context, without the user having to trigger a search?"
+
+- **YES** → it belongs in a static file under `context/` referenced from `AGENTS.md` via `{file:./context/name.md}`. **Do NOT save it to Engram.**
+- **NO** (it is episodic — you will only need it when the topic resurfaces) → save it to Engram.
+
+**What goes in `context/` files (push / ambient):**
+- **User infrastructure**: machines, hosts, IPs, credentials, SSH shortcuts, tailnet topology
+- **Stack defaults**: "always use TypeScript + Drizzle + Hono for new APIs"
+- **Active project list**: "current projects are X, Y, Z with these roles"
+- **Shortcut resolutions**: "when the user says 'my PC', they mean hostname X"
+- **User preferences applying to EVERY task**: naming conventions, commit style, preferred explanations
+
+**What goes in Engram (pull / episodic):**
+- **Architecture decisions with rationale**: "We chose Zustand over Redux because..."
+- **Bug fixes with root cause**: "Fixed N+1 in UserList by adding eager loading at line X"
+- **Non-trivial patterns discovered**: "Auth uses JWT with refresh token rotation in middleware X"
+- **Config changes with context**: "Migrated from X to Y because of performance issue Z"
+
+**Rule of thumb:**
+- **"When the user says X, I should automatically know Y"** → ambient, use `context/`
+- **"When I'm working on X, I might want to recall how we handled a similar case"** → episodic, use Engram
+
+**If `context/` doesn't exist yet:** create it next to the `AGENTS.md` you own (e.g. `~/.config/opencode/context/` for OpenCode, `~/.claude/context/` for Claude Code, `~/.codeium/windsurf/context/` for Windsurf), add the file, and reference it from the nearest `AGENTS.md`-equivalent in a `## Personal Context (always loaded)` section using `{file:./context/name.md}`. The file is automatically expanded into the system prompt at boot — no further setup needed.
+
 ### PROACTIVE SAVE TRIGGERS (mandatory — do NOT wait for user to ask)
 
 Call `mem_save` IMMEDIATELY and WITHOUT BEING ASKED after any of these:

--- a/internal/assets/codex/engram-instructions.md
+++ b/internal/assets/codex/engram-instructions.md
@@ -2,6 +2,36 @@
 
 You have access to Engram, a persistent memory system that survives across sessions and compactions. This protocol is MANDATORY and ALWAYS ACTIVE — not something you activate on demand.
 
+### DECISION: Engram vs ambient context files (push vs pull) — READ THIS FIRST
+
+Engram is **pull-based** (reactive) — it is only consulted when a search is triggered by keywords like "remember", "recall", or "what did we do". Ambient context files referenced from the Codex system prompt (`~/.codex/agents.md`) via `{file:./context/name.md}` are **push-based** — always loaded into the system prompt at session start, no trigger required. **Do NOT confuse them — this is the #1 reason Engram feels broken in practice.**
+
+**BEFORE calling mem_save, ask yourself:**
+
+> "Does this information need to be ALWAYS present in every future session's context, without the user having to trigger a search?"
+
+- **YES** → it belongs in a static file under `~/.codex/context/` referenced from `~/.codex/agents.md` via `{file:./context/name.md}`. **Do NOT save it to Engram.**
+- **NO** (it is episodic — you will only need it when the topic resurfaces) → save it to Engram.
+
+**What goes in `context/` files (push / ambient):**
+- **User infrastructure**: machines, hosts, IPs, credentials, SSH shortcuts, tailnet topology
+- **Stack defaults**: "always use TypeScript + Drizzle + Hono for new APIs"
+- **Active project list**: "current projects are X, Y, Z with these roles"
+- **Shortcut resolutions**: "when the user says 'my PC', they mean hostname X"
+- **User preferences applying to EVERY task**: naming conventions, commit style, preferred explanations
+
+**What goes in Engram (pull / episodic):**
+- **Architecture decisions with rationale**: "We chose Zustand over Redux because..."
+- **Bug fixes with root cause**: "Fixed N+1 in UserList by adding eager loading at line X"
+- **Non-trivial patterns discovered**: "Auth uses JWT with refresh token rotation in middleware X"
+- **Config changes with context**: "Migrated from X to Y because of performance issue Z"
+
+**Rule of thumb:**
+- **"When the user says X, I should automatically know Y"** → ambient, use `context/`
+- **"When I'm working on X, I might want to recall how we handled a similar case"** → episodic, use Engram
+
+**If `~/.codex/context/` doesn't exist yet:** create it, add the file, and reference it from `~/.codex/agents.md` in a `## Personal Context (always loaded)` section using `{file:./context/name.md}`. The file is automatically expanded into the system prompt at boot — no further setup needed.
+
 ### WHEN TO SAVE (mandatory — not optional)
 
 Call mem_save IMMEDIATELY and WITHOUT BEING ASKED after any of these:

--- a/testdata/golden/combined-claude-claudemd.golden
+++ b/testdata/golden/combined-claude-claudemd.golden
@@ -302,6 +302,36 @@ Convention files under the agent's global skills directory (global) or `.agent/s
 You have access to Engram, a persistent memory system that survives across sessions and compactions.
 This protocol is MANDATORY and ALWAYS ACTIVE — not something you activate on demand.
 
+### DECISION: Engram vs ambient context files (push vs pull) — READ THIS FIRST
+
+Engram is **pull-based** (reactive) — it is only consulted when a search is triggered by keywords like "remember", "recall", or "what did we do". Ambient context files referenced from `AGENTS.md` (or the agent's equivalent system prompt file) via `{file:./context/name.md}` are **push-based** — always loaded into the system prompt at session start, no trigger required. **Do NOT confuse them — this is the #1 reason Engram feels broken in practice.**
+
+**BEFORE calling `mem_save`, ask yourself:**
+
+> "Does this information need to be ALWAYS present in every future session's context, without the user having to trigger a search?"
+
+- **YES** → it belongs in a static file under `context/` referenced from `AGENTS.md` via `{file:./context/name.md}`. **Do NOT save it to Engram.**
+- **NO** (it is episodic — you will only need it when the topic resurfaces) → save it to Engram.
+
+**What goes in `context/` files (push / ambient):**
+- **User infrastructure**: machines, hosts, IPs, credentials, SSH shortcuts, tailnet topology
+- **Stack defaults**: "always use TypeScript + Drizzle + Hono for new APIs"
+- **Active project list**: "current projects are X, Y, Z with these roles"
+- **Shortcut resolutions**: "when the user says 'my PC', they mean hostname X"
+- **User preferences applying to EVERY task**: naming conventions, commit style, preferred explanations
+
+**What goes in Engram (pull / episodic):**
+- **Architecture decisions with rationale**: "We chose Zustand over Redux because..."
+- **Bug fixes with root cause**: "Fixed N+1 in UserList by adding eager loading at line X"
+- **Non-trivial patterns discovered**: "Auth uses JWT with refresh token rotation in middleware X"
+- **Config changes with context**: "Migrated from X to Y because of performance issue Z"
+
+**Rule of thumb:**
+- **"When the user says X, I should automatically know Y"** → ambient, use `context/`
+- **"When I'm working on X, I might want to recall how we handled a similar case"** → episodic, use Engram
+
+**If `context/` doesn't exist yet:** create it next to the `AGENTS.md` you own (e.g. `~/.config/opencode/context/` for OpenCode, `~/.claude/context/` for Claude Code, `~/.codeium/windsurf/context/` for Windsurf), add the file, and reference it from the nearest `AGENTS.md`-equivalent in a `## Personal Context (always loaded)` section using `{file:./context/name.md}`. The file is automatically expanded into the system prompt at boot — no further setup needed.
+
 ### PROACTIVE SAVE TRIGGERS (mandatory — do NOT wait for user to ask)
 
 Call `mem_save` IMMEDIATELY and WITHOUT BEING ASKED after any of these:

--- a/testdata/golden/combined-windsurf-global-rules.golden
+++ b/testdata/golden/combined-windsurf-global-rules.golden
@@ -373,6 +373,36 @@ DAG state is tracked in Engram under `sdd/{change-name}/state`. Update it after 
 You have access to Engram, a persistent memory system that survives across sessions and compactions.
 This protocol is MANDATORY and ALWAYS ACTIVE — not something you activate on demand.
 
+### DECISION: Engram vs ambient context files (push vs pull) — READ THIS FIRST
+
+Engram is **pull-based** (reactive) — it is only consulted when a search is triggered by keywords like "remember", "recall", or "what did we do". Ambient context files referenced from `AGENTS.md` (or the agent's equivalent system prompt file) via `{file:./context/name.md}` are **push-based** — always loaded into the system prompt at session start, no trigger required. **Do NOT confuse them — this is the #1 reason Engram feels broken in practice.**
+
+**BEFORE calling `mem_save`, ask yourself:**
+
+> "Does this information need to be ALWAYS present in every future session's context, without the user having to trigger a search?"
+
+- **YES** → it belongs in a static file under `context/` referenced from `AGENTS.md` via `{file:./context/name.md}`. **Do NOT save it to Engram.**
+- **NO** (it is episodic — you will only need it when the topic resurfaces) → save it to Engram.
+
+**What goes in `context/` files (push / ambient):**
+- **User infrastructure**: machines, hosts, IPs, credentials, SSH shortcuts, tailnet topology
+- **Stack defaults**: "always use TypeScript + Drizzle + Hono for new APIs"
+- **Active project list**: "current projects are X, Y, Z with these roles"
+- **Shortcut resolutions**: "when the user says 'my PC', they mean hostname X"
+- **User preferences applying to EVERY task**: naming conventions, commit style, preferred explanations
+
+**What goes in Engram (pull / episodic):**
+- **Architecture decisions with rationale**: "We chose Zustand over Redux because..."
+- **Bug fixes with root cause**: "Fixed N+1 in UserList by adding eager loading at line X"
+- **Non-trivial patterns discovered**: "Auth uses JWT with refresh token rotation in middleware X"
+- **Config changes with context**: "Migrated from X to Y because of performance issue Z"
+
+**Rule of thumb:**
+- **"When the user says X, I should automatically know Y"** → ambient, use `context/`
+- **"When I'm working on X, I might want to recall how we handled a similar case"** → episodic, use Engram
+
+**If `context/` doesn't exist yet:** create it next to the `AGENTS.md` you own (e.g. `~/.config/opencode/context/` for OpenCode, `~/.claude/context/` for Claude Code, `~/.codeium/windsurf/context/` for Windsurf), add the file, and reference it from the nearest `AGENTS.md`-equivalent in a `## Personal Context (always loaded)` section using `{file:./context/name.md}`. The file is automatically expanded into the system prompt at boot — no further setup needed.
+
 ### PROACTIVE SAVE TRIGGERS (mandatory — do NOT wait for user to ask)
 
 Call `mem_save` IMMEDIATELY and WITHOUT BEING ASKED after any of these:

--- a/testdata/golden/engram-antigravity-rulesmd.golden
+++ b/testdata/golden/engram-antigravity-rulesmd.golden
@@ -4,6 +4,36 @@
 You have access to Engram, a persistent memory system that survives across sessions and compactions.
 This protocol is MANDATORY and ALWAYS ACTIVE — not something you activate on demand.
 
+### DECISION: Engram vs ambient context files (push vs pull) — READ THIS FIRST
+
+Engram is **pull-based** (reactive) — it is only consulted when a search is triggered by keywords like "remember", "recall", or "what did we do". Ambient context files referenced from `AGENTS.md` (or the agent's equivalent system prompt file) via `{file:./context/name.md}` are **push-based** — always loaded into the system prompt at session start, no trigger required. **Do NOT confuse them — this is the #1 reason Engram feels broken in practice.**
+
+**BEFORE calling `mem_save`, ask yourself:**
+
+> "Does this information need to be ALWAYS present in every future session's context, without the user having to trigger a search?"
+
+- **YES** → it belongs in a static file under `context/` referenced from `AGENTS.md` via `{file:./context/name.md}`. **Do NOT save it to Engram.**
+- **NO** (it is episodic — you will only need it when the topic resurfaces) → save it to Engram.
+
+**What goes in `context/` files (push / ambient):**
+- **User infrastructure**: machines, hosts, IPs, credentials, SSH shortcuts, tailnet topology
+- **Stack defaults**: "always use TypeScript + Drizzle + Hono for new APIs"
+- **Active project list**: "current projects are X, Y, Z with these roles"
+- **Shortcut resolutions**: "when the user says 'my PC', they mean hostname X"
+- **User preferences applying to EVERY task**: naming conventions, commit style, preferred explanations
+
+**What goes in Engram (pull / episodic):**
+- **Architecture decisions with rationale**: "We chose Zustand over Redux because..."
+- **Bug fixes with root cause**: "Fixed N+1 in UserList by adding eager loading at line X"
+- **Non-trivial patterns discovered**: "Auth uses JWT with refresh token rotation in middleware X"
+- **Config changes with context**: "Migrated from X to Y because of performance issue Z"
+
+**Rule of thumb:**
+- **"When the user says X, I should automatically know Y"** → ambient, use `context/`
+- **"When I'm working on X, I might want to recall how we handled a similar case"** → episodic, use Engram
+
+**If `context/` doesn't exist yet:** create it next to the `AGENTS.md` you own (e.g. `~/.config/opencode/context/` for OpenCode, `~/.claude/context/` for Claude Code, `~/.codeium/windsurf/context/` for Windsurf), add the file, and reference it from the nearest `AGENTS.md`-equivalent in a `## Personal Context (always loaded)` section using `{file:./context/name.md}`. The file is automatically expanded into the system prompt at boot — no further setup needed.
+
 ### PROACTIVE SAVE TRIGGERS (mandatory — do NOT wait for user to ask)
 
 Call `mem_save` IMMEDIATELY and WITHOUT BEING ASKED after any of these:

--- a/testdata/golden/engram-claude-claudemd.golden
+++ b/testdata/golden/engram-claude-claudemd.golden
@@ -4,6 +4,36 @@
 You have access to Engram, a persistent memory system that survives across sessions and compactions.
 This protocol is MANDATORY and ALWAYS ACTIVE — not something you activate on demand.
 
+### DECISION: Engram vs ambient context files (push vs pull) — READ THIS FIRST
+
+Engram is **pull-based** (reactive) — it is only consulted when a search is triggered by keywords like "remember", "recall", or "what did we do". Ambient context files referenced from `AGENTS.md` (or the agent's equivalent system prompt file) via `{file:./context/name.md}` are **push-based** — always loaded into the system prompt at session start, no trigger required. **Do NOT confuse them — this is the #1 reason Engram feels broken in practice.**
+
+**BEFORE calling `mem_save`, ask yourself:**
+
+> "Does this information need to be ALWAYS present in every future session's context, without the user having to trigger a search?"
+
+- **YES** → it belongs in a static file under `context/` referenced from `AGENTS.md` via `{file:./context/name.md}`. **Do NOT save it to Engram.**
+- **NO** (it is episodic — you will only need it when the topic resurfaces) → save it to Engram.
+
+**What goes in `context/` files (push / ambient):**
+- **User infrastructure**: machines, hosts, IPs, credentials, SSH shortcuts, tailnet topology
+- **Stack defaults**: "always use TypeScript + Drizzle + Hono for new APIs"
+- **Active project list**: "current projects are X, Y, Z with these roles"
+- **Shortcut resolutions**: "when the user says 'my PC', they mean hostname X"
+- **User preferences applying to EVERY task**: naming conventions, commit style, preferred explanations
+
+**What goes in Engram (pull / episodic):**
+- **Architecture decisions with rationale**: "We chose Zustand over Redux because..."
+- **Bug fixes with root cause**: "Fixed N+1 in UserList by adding eager loading at line X"
+- **Non-trivial patterns discovered**: "Auth uses JWT with refresh token rotation in middleware X"
+- **Config changes with context**: "Migrated from X to Y because of performance issue Z"
+
+**Rule of thumb:**
+- **"When the user says X, I should automatically know Y"** → ambient, use `context/`
+- **"When I'm working on X, I might want to recall how we handled a similar case"** → episodic, use Engram
+
+**If `context/` doesn't exist yet:** create it next to the `AGENTS.md` you own (e.g. `~/.config/opencode/context/` for OpenCode, `~/.claude/context/` for Claude Code, `~/.codeium/windsurf/context/` for Windsurf), add the file, and reference it from the nearest `AGENTS.md`-equivalent in a `## Personal Context (always loaded)` section using `{file:./context/name.md}`. The file is automatically expanded into the system prompt at boot — no further setup needed.
+
 ### PROACTIVE SAVE TRIGGERS (mandatory — do NOT wait for user to ask)
 
 Call `mem_save` IMMEDIATELY and WITHOUT BEING ASKED after any of these:


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #271

---

## 🏷️ PR Type

- [x] `type:feature` — New feature (non-breaking change that adds functionality)

---

## 📝 Summary

Adds a new `### DECISION: Engram vs ambient context files (push vs pull) — READ THIS FIRST` section to the `engram-protocol` template, placed **before** `PROACTIVE SAVE TRIGGERS` so the agent reads the routing guardrail first and the detailed save triggers after (filter → detail order).

The rule teaches the distinction between:

- **Engram** — pull-based, episodic, searched on demand via keywords (`remember`, `recall`, `what did we do`)
- **Ambient context files** — push-based, always loaded at boot via `{file:./context/name.md}` referenced from `AGENTS.md`

### Problem

The current protocol tells agents to proactively save "user preferences", "patterns", and "discoveries" to Engram. But ambient knowledge (user machines, stack defaults, project lists, shortcut resolutions) needs to be ALWAYS present in context, not retrieved on demand. Since `WHEN TO SEARCH MEMORY` only fires on keywords like "remember" / "recall", ambient info saved to Engram is effectively lost for task-oriented queries.

#### Real failure case (reproduced on my own setup)

1. User provides tailnet topology: *"`windows` is home, `mafia` is work, `asus` is my mom's"*
2. Agent follows the `User preference learned` trigger → saves to Engram
3. Next session: user says *"check RAM on my PC"*
4. No search keyword fires → agent never queries Engram → asks the user to disambiguate between 3 Windows hosts
5. User: *"I already told you this yesterday"*

The fix was a static `context/machines.md` referenced from `AGENTS.md` via `{file:./}` — always loaded, zero triggers needed.

### Solution

Teach the agent the distinction and give a concrete decision rule. The new section includes:

- A clear question to ask BEFORE `mem_save`: *"Does this information need to be ALWAYS present in every future session's context, without the user having to trigger a search?"*
- Categorized examples (what goes where)
- A rule of thumb for ambiguous cases
- Bootstrap instructions for creating `context/` if it doesn't exist yet

The same guardrail is applied to the Codex template (`internal/assets/codex/engram-instructions.md`) so Codex users get the same benefit — Codex uses a separate template but suffers from the same anti-pattern.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/assets/claude/engram-protocol.md` | Added the new `DECISION` section before `PROACTIVE SAVE TRIGGERS` |
| `internal/assets/codex/engram-instructions.md` | Same decision rule, adapted to `~/.codex/context/` paths, placed before `WHEN TO SAVE` |
| `testdata/golden/engram-claude-claudemd.golden` | Regenerated via `go test -update` to match new template |
| `testdata/golden/engram-antigravity-rulesmd.golden` | Regenerated |
| `testdata/golden/combined-claude-claudemd.golden` | Regenerated |
| `testdata/golden/combined-windsurf-global-rules.golden` | Regenerated |

No Go code changes — template content only.

---

## 🧪 Test Plan

**Unit Tests**

```bash
go test ./...
```

- [x] Unit tests pass (`go test ./...`) — all 37 packages green on my machine (linux/arm64, Go 1.24.2)
- [x] Golden files regenerated and verified: new section appears inside `<!-- gentle-ai:engram-protocol -->` markers, positioned BEFORE `### PROACTIVE SAVE TRIGGERS`
- [x] Manually traced the decision flow with sample ambient + episodic examples, confirmed correct routing
- [x] E2E tests (`cd e2e && ./docker-test.sh`) — not run locally (no Docker in my sandbox). Existing e2e assertions only check for marker presence (`gentle-ai:engram-protocol`) and no-duplicate section, neither of which is affected by content additions.

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved` (once #271 is approved)
- [x] I will request the appropriate `type:feature` label on this PR
- [x] Unit tests pass (`go test ./...`)
- [x] E2E tests pass — see note above
- [x] Documentation updated where needed (the template IS the documentation the agents read)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

- **Placement rationale**: the new section intentionally sits BEFORE `PROACTIVE SAVE TRIGGERS` so the agent reads the "is this ambient?" guardrail first, before it reads the detailed list of save triggers. Filter → detail order.
- **Style**: I kept the section flat (no `####` H4 headers) and used bold labels to match the existing template style.
- **Codex parallel**: the Codex template has an identical anti-pattern (`WHEN TO SAVE` → "User preference or constraint learned"), so I added the same rule there, adapted for `~/.codex/context/`. Happy to drop that second change if you'd prefer scoping this PR strictly to `claude/engram-protocol.md`.
- **Why not just fix the triggers?** Removing "User preference learned" from `PROACTIVE SAVE TRIGGERS` would lose a legitimate save category (episodic preferences that only apply to specific work contexts still belong in Engram). The decision rule is the surgical fix — it doesn't remove any trigger, it just teaches the agent when NOT to fire them.