### PR TITLE
fix(tui): show feedback when upgrade results are empty

### DIFF
--- a/internal/tui/screens/upgrade.go
+++ b/internal/tui/screens/upgrade.go
@@ -116,6 +116,13 @@ func renderUpgradeReady(b *strings.Builder, results []update.UpdateResult) strin
 }
 
 func renderUpgradeResult(b *strings.Builder, report *upgrade.UpgradeReport) string {
+	if len(report.Results) == 0 {
+		b.WriteString("  " + styles.SuccessStyle.Render("✓ All tools are up to date"))
+		b.WriteString("\n\n")
+		b.WriteString(styles.HelpStyle.Render("enter: return • esc: back • q: quit"))
+		return b.String()
+	}
+
 	succeeded, failed, skipped := 0, 0, 0
 
 	for _, r := range report.Results {

--- a/internal/tui/screens/upgrade_sync.go
+++ b/internal/tui/screens/upgrade_sync.go
@@ -118,6 +118,11 @@ func renderUpgradeSyncResult(report *upgrade.UpgradeReport, syncFilesChanged int
 		b.WriteString(styles.ErrorStyle.Render("✗ Upgrade failed: " + upgradeErr.Error()))
 		b.WriteString("\n")
 	} else if report != nil {
+		if len(report.Results) == 0 {
+			b.WriteString("  " + styles.SuccessStyle.Render("✓ All tools are up to date"))
+			b.WriteString("\n")
+		}
+
 		upgradeSucceeded, upgradeFailed, upgradeSkipped := 0, 0, 0
 
 		for _, r := range report.Results {

--- a/internal/tui/screens/upgrade_sync_test.go
+++ b/internal/tui/screens/upgrade_sync_test.go
@@ -91,6 +91,26 @@ func TestRenderUpgradeSync_CombinedResult(t *testing.T) {
 	}
 }
 
+// TestRenderUpgradeSync_CombinedResultEmptyUpgradeReport verifies that the
+// combined results view still renders when the upgrade report has no tool
+// results because everything is already up to date.
+func TestRenderUpgradeSync_CombinedResultEmptyUpgradeReport(t *testing.T) {
+	report := &upgrade.UpgradeReport{}
+
+	out := RenderUpgradeSync(nil, report, 0, nil, nil, false, true, 0, 0)
+
+	lower := strings.ToLower(out)
+	if !strings.Contains(lower, "up to date") {
+		t.Errorf("RenderUpgradeSync(empty upgrade report) should contain 'up to date'; got:\n%s", out)
+	}
+	if !strings.Contains(out, "Sync Results") {
+		t.Errorf("RenderUpgradeSync(empty upgrade report) should show 'Sync Results'; got:\n%s", out)
+	}
+	if !strings.Contains(lower, "no files needed updating") {
+		t.Errorf("RenderUpgradeSync(empty upgrade report) should preserve sync results path; got:\n%s", out)
+	}
+}
+
 // TestRenderUpgradeSync_CombinedResultWithSyncError verifies that a sync error
 // is shown in the combined result.
 func TestRenderUpgradeSync_CombinedResultWithSyncError(t *testing.T) {

--- a/internal/tui/screens/upgrade_test.go
+++ b/internal/tui/screens/upgrade_test.go
@@ -86,6 +86,22 @@ func TestRenderUpgrade_ResultState(t *testing.T) {
 	}
 }
 
+// TestRenderUpgrade_ResultStateEmptyReport verifies that an empty upgrade report
+// still renders the completed result path with an "up to date" message.
+func TestRenderUpgrade_ResultStateEmptyReport(t *testing.T) {
+	report := &upgrade.UpgradeReport{}
+
+	out := RenderUpgrade(nil, report, nil, false, true, 0, 0)
+
+	lower := strings.ToLower(out)
+	if !strings.Contains(lower, "up to date") {
+		t.Errorf("RenderUpgrade(empty report) should contain 'up to date'; got:\n%s", out)
+	}
+	if !strings.Contains(lower, "return") {
+		t.Errorf("RenderUpgrade(empty report) should contain return hint; got:\n%s", out)
+	}
+}
+
 // TestRenderUpgrade_RunningState verifies that while an upgrade is running
 // (operationRunning=true, report=nil), the screen shows a spinner/progress indicator.
 func TestRenderUpgrade_RunningState(t *testing.T) {


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #131

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- When all tools are up to date, the TUI "Upgrade Results" section rendered completely empty
- Added empty-results check in both TUI render functions, matching the existing CLI behavior in `render.go:24-27`
- Sync Results already handled this case correctly — now Upgrade Results does too

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/tui/screens/upgrade.go` | Added early return with "✓ All tools are up to date" when `report.Results` is empty |
| `internal/tui/screens/upgrade_sync.go` | Added inline message when `report.Results` is empty (no early return to preserve Sync section) |

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./...
```

- [x] Unit tests pass (`go test ./...`)
- [x] Manually tested locally — confirmed message appears where blank space was before

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

Minimal fix — only adds `if len(report.Results) == 0` checks. No existing logic modified. The CLI path in `internal/update/upgrade/render.go:24-27` already handles this case; this PR brings the TUI in line.