### PR TITLE
feat(tui): integrate OpenCode plugin-sdd for profiles and Engram memories

### DIFF
--- a/docs/prd-plugin-visual-opencode.md
+++ b/docs/prd-plugin-visual-opencode.md
@@ -91,7 +91,7 @@ The user selects **"Create New SDD Profile"** and enters a name. The plugin read
 }
 ```
 
-A backup of the current `opencode.json` is written to `opencode.json.bak` before any activation operation.
+No backup file is generated during profile activation. The plugin applies model changes via OpenCode runtime API and avoids direct `opencode.json` rewrites from plugin code.
 
 ---
 
@@ -152,10 +152,10 @@ The flow:
 2. Fetch the current global config via `api.client.global.config.get`
 3. Merge the profile models into the config (only the `agent[name].model` fields are touched — all other agent config is preserved)
 4. Push the updated config via `api.client.global.config.update`
-5. Persist the result to `opencode.json` on disk
+5. Let OpenCode runtime persistence handle storage (no plugin-side `opencode.json` rewrite)
 6. Update the in-plugin state so the status badge reflects the new active model immediately
 
-If the API call fails, the user receives an error toast and the disk file is not modified.
+If the API call fails, the user receives an error toast and no plugin-side file mutation is attempted.
 
 ---
 
@@ -267,9 +267,9 @@ Minimal additions to existing files:
 InstallSddPlugin(homeDir)
   │
   ├── 1. copyEmbeddedPlugin
-  │       └── os.RemoveAll(destDir)           — clean stale files from previous versions
-  │       └── fs.WalkDir(assets.FS, ...)      — copy from embed.FS recursively
+  │       └── fs.WalkDir(assets.FS, ...)      — sync from embed.FS recursively
   │       └── filemerge.WriteFileAtomic(...)  — atomic write per file
+  │       └── remove stale files              — cleanup entries not present in embedded assets
   │
   ├── 2. writeTUIJSON
   │       └── os.ReadFile(tui.json)           — read existing if present
@@ -311,15 +311,16 @@ An early version treated `plugin` as `[]string` and destroyed tuple entries on r
   - missing → added with the required version
   - existing and `@opencode-ai/plugin < 1.4.2` → upgraded to `1.4.2`
   - existing and `≥ 1.4.2` or non-semver (e.g. `latest`) → left untouched
-- `unique-names-generator`: added if missing, never upgraded (patch-range versions are user-managed)
+
+No additional plugin package dependencies are injected beyond `@opencode-ai/plugin`.
 
 **Semver comparison:** Implemented via `parseSemverPrefix` — strips `^`, `~`, `v`, `>`, `<`, `=` prefixes and compares major.minor.patch numerically. Non-semver values (e.g. `latest`, workspace aliases) return `false` for `isVersionBelowMinimum` and are preserved as-is.
 
-#### Plugin directory — always reinstall clean
+#### Plugin directory — idempotent sync with stale-file cleanup
 
-**Why:** If the user runs "Install OpenCode Plugin" again after a `gga` update, the plugin may have new or renamed files. Leaving the old directory would result in stale files that could conflict.
+**Why:** The installer must be idempotent. Re-running it should not rewrite unchanged files, but still needs to clean stale files from older plugin versions.
 
-**Fix:** `os.RemoveAll(destDir)` is called before copying, guaranteeing a clean state on every install.
+**Fix:** Embedded files are synchronized with atomic writes (only changed files are rewritten), and stale files not present in embedded assets are removed after sync.
 
 #### opencode.json — not touched
 
@@ -331,15 +332,15 @@ The installer does **not** modify `~/.config/opencode/opencode.json`. That file 
 |-----------|----------------|
 | Only `sdd-*` agents managed by plugin | `isManagedSddAgent(name)` checks `name.startsWith("sdd-")` |
 | Profile files isolated | Profiles live in `~/.config/opencode/profiles/`, separate from `opencode.json` |
-| Activation never silently fails | API errors surface as error toasts; disk write only after successful API call |
+| Activation never silently fails | API errors surface as error toasts |
 | Memory operations are project-scoped | SQLite query always filters by resolved project name |
 | Soft delete is safe | Memory ID validated as positive integer; `UPDATE` only touches `deleted_at` and `updated_at` |
-| Backup before any write | `opencode.json.bak` written before profile activation |
+| No plugin-side backup/rewrite | Activation does not create `opencode.json.bak` and does not rewrite `opencode.json` |
 | tui.json entries never duplicated | `pluginEntryExists` checks string and tuple-style entries |
 | tui.json unrelated fields preserved | Parsed as `map[string]json.RawMessage`, only `plugin` and `$schema` are updated |
 | package.json unrelated fields preserved | Parsed as `map[string]json.RawMessage`, only `dependencies` is touched |
 | Plugin API version enforced | `@opencode-ai/plugin < 1.4.2` is upgraded; newer versions preserved |
-| Plugin dir always clean on reinstall | `os.RemoveAll(destDir)` before copy |
+| Plugin dir stays clean on reinstall | Idempotent sync + stale-file cleanup |
 | opencode.json never modified | Installer does not read or write opencode.json |
 | Cross-OS compatibility | `os.UserHomeDir()` + `filepath.Join()` — no OS-specific paths |
 
@@ -364,7 +365,6 @@ The installer does **not** modify `~/.config/opencode/opencode.json`. That file 
 | `~/.config/opencode/tui.json` | Plugin registry (OpenCode reads this on startup) |
 | `~/.config/opencode/package.json` | Runtime Node dependencies for all plugins |
 | `~/.config/opencode/opencode.json` | Global config — **not touched by installer** |
-| `~/.config/opencode/opencode.json.bak` | Pre-activation backup (written by plugin at runtime) |
 | `~/.config/opencode/profiles/*.json` | Named profile files |
 | `~/.engram/engram.db` | Engram SQLite database |
 
@@ -378,18 +378,18 @@ The integration is fully implemented. The installer exposes a new **"Install Ope
 
 ### What the installer does
 
-1. **Copies the plugin** — `internal/assets/opencode/plugins/plugin-sdd-opencode/` (embedded via `//go:embed all:opencode`) is extracted to `~/.config/opencode/plugins/plugin-sdd-opencode/`. If the directory already exists it is removed first (clean reinstall).
+1. **Copies the plugin** — `internal/assets/opencode/plugins/plugin-sdd-opencode/` (embedded via `//go:embed all:opencode`) is synchronized to `~/.config/opencode/plugins/plugin-sdd-opencode/` idempotently (unchanged files are preserved, stale files are removed).
 
 2. **Registers in `tui.json`** — adds `"./plugins/plugin-sdd-opencode/"` to the `plugin` array. Existing entries (including complex tuple-style entries) are preserved. The entry is not duplicated if already present.
 
-3. **Ensures `package.json` deps** — adds `@opencode-ai/plugin` and `unique-names-generator` if missing. Upgrades `@opencode-ai/plugin` to `1.4.2` if the installed version is older. All other fields and dependencies are left untouched.
+3. **Ensures `package.json` deps** — ensures `@opencode-ai/plugin` is present, upgrading to `1.4.2` only if installed version is older. All other fields and dependencies are left untouched.
 
-4. **Shows result screen** — success, already-installed, or error, with a reminder to run `bun install` if `package.json` was modified.
+4. **Shows result screen** — success, already-installed, or error. In normal flow no manual install step is required because OpenCode resolves plugin dependencies automatically. If `package.json` cannot be read/written, installer shows an exceptional warning with fallback guidance.
 
 ### Prerequisites
 
 - `sqlite3` must be available on the system (present by default on macOS; on Linux it may need to be installed)
-- `bun` or `npm` must be available to install Node dependencies after the plugin is copied
+- `bun`/`npm` are only needed as fallback for exceptional cases where dependency resolution fails outside the normal OpenCode-managed flow
 
 ---
 
@@ -398,7 +398,7 @@ The integration is fully implemented. The installer exposes a new **"Install Ope
 ### In Scope
 
 - Plugin installation from `gga` welcome menu
-- Plugin directory clean reinstall (removes stale files)
+- Idempotent plugin directory sync (preserves unchanged files and removes stale files)
 - `tui.json` registration with full preservation of existing entries
 - `package.json` dependency enforcement with semver minimum check
 - Profile creation from current config
@@ -426,7 +426,7 @@ The integration is fully implemented. The installer exposes a new **"Install Ope
 | Criterion | Target | Status |
 |-----------|--------|--------|
 | Plugin installation from gga menu | ✅ Always | ✅ Verified |
-| Clean reinstall removes stale files | ✅ Always | ✅ Verified |
+| Idempotent sync preserves unchanged files and removes stale files | ✅ Always | ✅ Verified |
 | tui.json preserves existing entries | ✅ String and tuple-style | ✅ Verified |
 | tui.json no duplicate plugin entries | ✅ Always | ✅ Verified |
 | package.json preserves unrelated fields | ✅ Always | ✅ Verified |

--- a/docs/prd-plugin-visual-opencode.md
+++ b/docs/prd-plugin-visual-opencode.md
@@ -1,0 +1,443 @@
+# PRD: plugin-sdd — OpenCode Visual Plugin for SDD Profile Management & Engram Viewer
+
+> **Manage SDD model profiles and inspect Engram project memories without leaving OpenCode.**
+
+**Version**: 1.1.0
+**Author**: Gentleman Programming
+**Date**: 2026-04-09
+**Status**: Implemented & manually verified — pending PR merge
+**Related issue**: [#270](https://github.com/Gentleman-Programming/gentle-ai/issues/270)
+**Related PRD**: [`prd-opencode-profiles.md`](./prd-opencode-profiles.md)
+
+---
+
+## 1. Context & Distinction
+
+This PRD covers the **OpenCode visual plugin** (`plugin-sdd-opencode`) — an in-session TUI plugin that runs **inside OpenCode** and is activated via `alt+k` or `/sdd-model`.
+
+It is **not** the same as the profile management feature described in `prd-opencode-profiles.md`, which covers a dedicated screen inside the `gga` CLI TUI. Both solve complementary problems:
+
+| | `prd-opencode-profiles.md` | **This PRD** |
+|---|---|---|
+| **Where it runs** | `gga` terminal UI | Inside OpenCode (active session) |
+| **How to access** | `gentle-ai` CLI command | `alt+k` or `/sdd-model` |
+| **Restart required** | Yes — edits `opencode.json` | **No** — live runtime patching |
+| **Engram viewer** | No | Yes |
+| **Status badge** | No | Yes |
+
+---
+
+## 2. Problem Statement
+
+OpenCode users working with the SDD workflow face two recurring pain points in every session:
+
+**Profile switching requires manual config editing and a session restart.**
+Switching between SDD model configurations — for example, from "premium" (Opus orchestrator + Sonnet sub-agents) to "cheap" (Haiku everywhere) — requires manually editing `~/.config/opencode/opencode.json` and restarting OpenCode. There is no in-session mechanism to switch profiles.
+
+**Engram memory is invisible from within OpenCode.**
+Developers using Engram for persistent memory across sessions have no way to view, audit, or clean up memories for a project without leaving OpenCode and using a separate DB browser or CLI tool. Stale or incorrect memories silently affect agent behavior without the developer noticing.
+
+---
+
+## 3. Solution
+
+`plugin-sdd-opencode` is an OpenCode TUI plugin that exposes profile management and Engram memory operations directly from within an active OpenCode session.
+
+It is installed by `gga` via the **"Install OpenCode Plugin"** option in the welcome menu. The installer:
+
+1. Copies the plugin to `~/.config/opencode/plugins/plugin-sdd-opencode/`
+2. Registers it in `~/.config/opencode/tui.json`
+3. Ensures `~/.config/opencode/package.json` has the required runtime dependencies
+
+Once installed, the plugin registers:
+- A keybind (`alt+k`) and slash command (`/sdd-model`) to open the plugin menu
+- UI slots in the status bar and sidebar showing the currently active model profile
+
+### Entry point
+
+Activated via `alt+k` or `/sdd-model` from anywhere in OpenCode.
+
+```
+┌─────────────────────────────────────────┐
+│  SDD Profile Management                  │
+│                                          │
+│  ▸  Create New SDD Profile               │
+│     Manage SDD Profiles                  │
+│     View Project Memories                │
+│     ✕ Close                              │
+└─────────────────────────────────────────┘
+```
+
+---
+
+## 4. Features
+
+### 4.1 Profile Creation
+
+The user selects **"Create New SDD Profile"** and enters a name. The plugin reads the current SDD agent model assignments from `opencode.json` (agent entries whose key starts with `sdd-`) and saves them as a named JSON file under `~/.config/opencode/profiles/<name>.json`.
+
+**Validation:**
+- Name is trimmed and stripped of the `.json` extension if provided
+- If the profile already exists, the user receives an error toast — no silent overwrites
+- If no SDD agents with model assignments are found in the current config, the operation is aborted with an informative error
+
+**Profile file format:**
+```json
+{
+  "sdd-orchestrator": "anthropic/claude-opus-4-20250514",
+  "sdd-init": "anthropic/claude-sonnet-4-20250514",
+  "sdd-explore": "anthropic/claude-sonnet-4-20250514",
+  "sdd-apply": "anthropic/claude-sonnet-4-20250514"
+}
+```
+
+A backup of the current `opencode.json` is written to `opencode.json.bak` before any activation operation.
+
+---
+
+### 4.2 Profile List & Detection
+
+**"Manage SDD Profiles"** shows all `.json` files under `~/.config/opencode/profiles/`. The active profile is automatically detected by comparing the model assignments in each profile file against the current live config (`api.state.config`). The matching profile is highlighted with a `✓` prefix.
+
+```
+┌─────────────────────────────────────────┐
+│  Select SDD Profile                      │
+│                                          │
+│  ✓ premium                               │
+│    cheap                                 │
+│    gemini-experimental                   │
+│  ← Back                                  │
+└─────────────────────────────────────────┘
+```
+
+---
+
+### 4.3 Profile Detail & Per-Agent Editing
+
+Selecting a profile opens its detail view, which lists every SDD agent in that profile alongside its current model assignment. From this view the user can:
+
+- **Activate** the profile
+- **Rename** the profile file
+- **Delete** the profile file (with confirmation)
+- **Reassign the model** for any individual agent — a provider picker and then a model picker (populated from `api.state.provider`) let the user drill down to any available model
+
+```
+┌─────────────────────────────────────────┐
+│  Profile: cheap                          │
+│                                          │
+│  Profile                                 │
+│  ✏ Name: cheap                           │
+│                                          │
+│  Agents (Click to edit model)            │
+│  sdd-orchestrator   anthropic/claude-haiku-3.5
+│  sdd-init           anthropic/claude-haiku-3.5
+│  sdd-apply          anthropic/claude-haiku-3.5
+│  ...                                     │
+│                                          │
+│  ──────────────                          │
+│  ✓ Activate Profile                      │
+│  ✕ Delete Profile                        │
+│  ← Back                                  │
+└─────────────────────────────────────────┘
+```
+
+---
+
+### 4.4 Profile Activation — No Restart Required
+
+Activating a profile patches the global config at runtime using `api.client.global.config.update`. This means model assignments take effect in the **current session** without restarting OpenCode.
+
+The flow:
+1. Read the profile's model assignments
+2. Fetch the current global config via `api.client.global.config.get`
+3. Merge the profile models into the config (only the `agent[name].model` fields are touched — all other agent config is preserved)
+4. Push the updated config via `api.client.global.config.update`
+5. Persist the result to `opencode.json` on disk
+6. Update the in-plugin state so the status badge reflects the new active model immediately
+
+If the API call fails, the user receives an error toast and the disk file is not modified.
+
+---
+
+### 4.5 Engram Memory Viewer
+
+**"View Project Memories"** opens a list of Engram observations scoped to the current project. The project name is resolved in this order:
+
+1. `git remote get-url origin` → repo name (last path segment, lowercase, `.git` stripped)
+2. `git rev-parse --show-toplevel` → root directory name
+3. `basename` of the current working directory
+
+The plugin reads directly from `~/.engram/engram.db` via the `sqlite3` CLI (timeout: 5 seconds). Only rows where `project = <resolved name>` and `deleted_at IS NULL` are shown, ordered by `updated_at DESC`.
+
+```
+┌─────────────────────────────────────────┐
+│  Memories: gentle-ai                     │
+│                                          │
+│  [42] JWT auth middleware                │
+│       [DECISION] 09/04/2026 · project   │
+│  [38] Fixed N+1 in user list            │
+│       [BUGFIX] 08/04/2026 · project     │
+│  ← Back                                  │
+└─────────────────────────────────────────┘
+```
+
+---
+
+### 4.6 Memory Detail & Soft Delete
+
+Selecting a memory opens a detail view that displays:
+- Title and topic key
+- Type, scope, and date (formatted with `toLocaleString`)
+- Full content, word-wrapped at 52 characters per line, with markdown formatting stripped (`**bold**`, `` `code` ``, smart quotes, arrows)
+
+From the detail view the user can **delete** the memory. Deletion is a soft delete: `deleted_at` and `updated_at` are set to `datetime('now')` via a direct SQLite `UPDATE`. The memory ID is validated as a positive integer before execution.
+
+```
+┌─────────────────────────────────────────┐
+│  Delete Memory                           │
+│                                          │
+│  Eliminar 'JWT auth middleware'?         │
+│                                          │
+│  ▸ Confirm                               │
+│    Cancel                                │
+└─────────────────────────────────────────┘
+```
+
+---
+
+### 4.7 Status Badge
+
+The plugin registers UI slots in `home_bottom` and `sidebar_content` that display the active model at all times:
+
+- **Profile active**: `󰚩 claude-sonnet-4 · 200k ctx` (in the theme's primary color, bold)
+- **No profile**: `󱚧 No SDD model active` (in muted color)
+
+The badge updates immediately when a profile is activated.
+
+---
+
+## 5. Technical Design
+
+### 5.1 Plugin File Structure
+
+```
+plugin-sdd-opencode/
+├── index.tsx            # Plugin entry — registers command, slots, reads active profile
+├── components.tsx       # ActiveModelBadge UI component
+├── package.json         # Plugin manifest — entry point: index.tsx
+└── src/
+    ├── index.ts         # Barrel exports — re-exports all src modules
+    ├── config.ts        # Path resolution (~/.config/opencode/profiles/, opencode.json)
+    ├── dialogs.tsx      # All TUI dialog flows
+    ├── memories.ts      # SQLite reads and soft-delete via sqlite3 CLI
+    ├── profiles.ts      # Profile CRUD — read, write, activate, detect, rename, delete
+    ├── state.ts         # Global reactive state (activeProfile)
+    ├── types.ts         # Shared types: ActiveProfileState, ProfileModels, EngramObservation
+    └── utils.ts         # Formatting helpers, isManagedSddAgent, resolveModelInfo
+```
+
+> **Note on `src/index.ts`:** This is a barrel file that re-exports all modules in `src/` so that `index.tsx` (the plugin entry point) can import from a single location. It is required for clean module resolution and is not the plugin entry point itself — that role belongs to the root `index.tsx` declared in `package.json`.
+
+### 5.2 gga Installer File Structure
+
+The installer lives entirely in new files — no existing file was rewritten:
+
+```
+internal/
+├── components/sdd/
+│   └── plugin_sdd_install.go   # InstallSddPlugin — copy, tui.json, package.json
+├── tui/
+│   ├── plugin_install_test.go  # Navigation test for the new menu item
+│   └── screens/
+│       └── plugin_sdd_screen.go # RenderPluginInstall — result screen
+```
+
+Minimal additions to existing files:
+
+| File | What changed |
+|------|--------------|
+| `internal/tui/screens/welcome.go` | +1 option `"Install OpenCode Plugin"` at index 6 |
+| `internal/tui/model.go` | +`ScreenPluginInstall`, `PluginInstallDoneMsg`, `startPluginInstall`, handlers in `Update`/`View`/`confirmSelection` |
+| `internal/tui/router.go` | +1 route `ScreenPluginInstall → ScreenWelcome` |
+| `internal/assets/assets.go` | No change needed — `//go:embed all:opencode` already embeds the plugin directory |
+
+### 5.3 Installation Flow (`InstallSddPlugin`)
+
+```
+InstallSddPlugin(homeDir)
+  │
+  ├── 1. copyEmbeddedPlugin
+  │       └── os.RemoveAll(destDir)           — clean stale files from previous versions
+  │       └── fs.WalkDir(assets.FS, ...)      — copy from embed.FS recursively
+  │       └── filemerge.WriteFileAtomic(...)  — atomic write per file
+  │
+  ├── 2. writeTUIJSON
+  │       └── os.ReadFile(tui.json)           — read existing if present
+  │       └── json.Unmarshal → map[string]json.RawMessage  — preserve all top-level keys
+  │       └── pluginEntryExists(plugins, key) — check string AND tuple-style entries
+  │       └── append(plugins, registryKey)    — add only if missing
+  │       └── filemerge.WriteFileAtomic(...)  — atomic write
+  │
+  └── 3. ensureOpencodePackageJSON
+          └── os.ReadFile(package.json)       — read existing or start fresh
+          └── json.Unmarshal → map[string]json.RawMessage  — preserve all top-level keys
+          └── for each required dep:
+          │       if missing        → add it
+          │       if @opencode-ai/plugin < 1.4.2 → upgrade to minimum
+          │       if existing ≥ minimum → leave untouched
+          └── filemerge.WriteFileAtomic(...)  — atomic write
+```
+
+### 5.4 Key Design Decisions
+
+#### tui.json — preserve everything, add only what's missing
+
+**Why:** OpenCode's `tui.json` supports heterogeneous plugin entries:
+- Simple strings: `"./plugins/my-plugin/"`
+- Tuple-style with options: `["./plugins/my-plugin/", { "theme": "dark", ... }]`
+
+An early version treated `plugin` as `[]string` and destroyed tuple entries on rewrite.
+
+**Fix:** The file is parsed as `map[string]json.RawMessage` to preserve all top-level keys (`keybinds`, `theme`, etc.). The `plugin` array is decoded as `[]any`, and duplicates are checked against both string entries and the first element of tuple entries.
+
+#### package.json — preserve everything, enforce minimum semver
+
+**Why:** The `~/.config/opencode/package.json` file is owned by the user and may contain `scripts`, `devDependencies`, `name`, and other fields unrelated to the plugin.
+
+**Rules:**
+- All top-level fields are preserved via `map[string]json.RawMessage` round-trip
+- `devDependencies` is never touched
+- `dependencies`:
+  - missing → added with the required version
+  - existing and `@opencode-ai/plugin < 1.4.2` → upgraded to `1.4.2`
+  - existing and `≥ 1.4.2` or non-semver (e.g. `latest`) → left untouched
+- `unique-names-generator`: added if missing, never upgraded (patch-range versions are user-managed)
+
+**Semver comparison:** Implemented via `parseSemverPrefix` — strips `^`, `~`, `v`, `>`, `<`, `=` prefixes and compares major.minor.patch numerically. Non-semver values (e.g. `latest`, workspace aliases) return `false` for `isVersionBelowMinimum` and are preserved as-is.
+
+#### Plugin directory — always reinstall clean
+
+**Why:** If the user runs "Install OpenCode Plugin" again after a `gga` update, the plugin may have new or renamed files. Leaving the old directory would result in stale files that could conflict.
+
+**Fix:** `os.RemoveAll(destDir)` is called before copying, guaranteeing a clean state on every install.
+
+#### opencode.json — not touched
+
+The installer does **not** modify `~/.config/opencode/opencode.json`. That file is managed by the existing SDD inject flow and the plugin's own runtime API (`api.client.global.config.update`). Modifying it from the installer would risk clobbering user model assignments.
+
+### 5.5 Key Invariants
+
+| Invariant | Implementation |
+|-----------|----------------|
+| Only `sdd-*` agents managed by plugin | `isManagedSddAgent(name)` checks `name.startsWith("sdd-")` |
+| Profile files isolated | Profiles live in `~/.config/opencode/profiles/`, separate from `opencode.json` |
+| Activation never silently fails | API errors surface as error toasts; disk write only after successful API call |
+| Memory operations are project-scoped | SQLite query always filters by resolved project name |
+| Soft delete is safe | Memory ID validated as positive integer; `UPDATE` only touches `deleted_at` and `updated_at` |
+| Backup before any write | `opencode.json.bak` written before profile activation |
+| tui.json entries never duplicated | `pluginEntryExists` checks string and tuple-style entries |
+| tui.json unrelated fields preserved | Parsed as `map[string]json.RawMessage`, only `plugin` and `$schema` are updated |
+| package.json unrelated fields preserved | Parsed as `map[string]json.RawMessage`, only `dependencies` is touched |
+| Plugin API version enforced | `@opencode-ai/plugin < 1.4.2` is upgraded; newer versions preserved |
+| Plugin dir always clean on reinstall | `os.RemoveAll(destDir)` before copy |
+| opencode.json never modified | Installer does not read or write opencode.json |
+| Cross-OS compatibility | `os.UserHomeDir()` + `filepath.Join()` — no OS-specific paths |
+
+### 5.6 Plugin Dependencies
+
+| Dependency | Role |
+|------------|------|
+| `@opencode-ai/plugin` | Plugin API (command, slots, dialog, toast, state, client) |
+| `@opentui/solid` | JSX renderer for TUI components |
+| `solid-js` | Reactive primitives |
+| `sqlite3` CLI | Engram DB access (must be installed on the system) |
+| `node:fs`, `node:path`, `node:os` | Profile file I/O |
+| `node:child_process` | `sqlite3` and `git` subprocess calls |
+
+**Minimum OpenCode version**: `>=1.3.13`
+
+### 5.7 Paths
+
+| Path | Purpose |
+|------|---------|
+| `~/.config/opencode/plugins/plugin-sdd-opencode/` | Installed plugin directory |
+| `~/.config/opencode/tui.json` | Plugin registry (OpenCode reads this on startup) |
+| `~/.config/opencode/package.json` | Runtime Node dependencies for all plugins |
+| `~/.config/opencode/opencode.json` | Global config — **not touched by installer** |
+| `~/.config/opencode/opencode.json.bak` | Pre-activation backup (written by plugin at runtime) |
+| `~/.config/opencode/profiles/*.json` | Named profile files |
+| `~/.engram/engram.db` | Engram SQLite database |
+
+XDG: `configRoot` respects `$XDG_CONFIG_HOME` if set.
+
+---
+
+## 6. Integration into gga
+
+The integration is fully implemented. The installer exposes a new **"Install OpenCode Plugin"** option in the `gga` welcome menu (index 6, between "Create your own Agent" and "OpenCode SDD Profiles").
+
+### What the installer does
+
+1. **Copies the plugin** — `internal/assets/opencode/plugins/plugin-sdd-opencode/` (embedded via `//go:embed all:opencode`) is extracted to `~/.config/opencode/plugins/plugin-sdd-opencode/`. If the directory already exists it is removed first (clean reinstall).
+
+2. **Registers in `tui.json`** — adds `"./plugins/plugin-sdd-opencode/"` to the `plugin` array. Existing entries (including complex tuple-style entries) are preserved. The entry is not duplicated if already present.
+
+3. **Ensures `package.json` deps** — adds `@opencode-ai/plugin` and `unique-names-generator` if missing. Upgrades `@opencode-ai/plugin` to `1.4.2` if the installed version is older. All other fields and dependencies are left untouched.
+
+4. **Shows result screen** — success, already-installed, or error, with a reminder to run `bun install` if `package.json` was modified.
+
+### Prerequisites
+
+- `sqlite3` must be available on the system (present by default on macOS; on Linux it may need to be installed)
+- `bun` or `npm` must be available to install Node dependencies after the plugin is copied
+
+---
+
+## 7. Scope
+
+### In Scope
+
+- Plugin installation from `gga` welcome menu
+- Plugin directory clean reinstall (removes stale files)
+- `tui.json` registration with full preservation of existing entries
+- `package.json` dependency enforcement with semver minimum check
+- Profile creation from current config
+- Profile listing with active detection
+- Profile activation at runtime (no restart)
+- Per-agent model reassignment within a profile
+- Profile rename and delete
+- Engram memory listing scoped to the current project
+- Engram memory detail view
+- Engram memory soft delete
+- Status badge in OpenCode UI slots (`home_bottom`, `sidebar_content`)
+
+### Out of Scope
+
+- **Other agents** (Claude Code, Cursor, Codex, Windsurf) — the plugin relies on OpenCode's plugin API exclusively
+- **Engram memory creation or editing** — read and soft-delete only
+- **Cross-machine profile sync** — profiles are local files
+- **Full gga TUI screens** for profile management — covered by [`prd-opencode-profiles.md`](./prd-opencode-profiles.md)
+- **`opencode.json` modification** — the installer does not touch the global config
+
+---
+
+## 8. Success Criteria
+
+| Criterion | Target | Status |
+|-----------|--------|--------|
+| Plugin installation from gga menu | ✅ Always | ✅ Verified |
+| Clean reinstall removes stale files | ✅ Always | ✅ Verified |
+| tui.json preserves existing entries | ✅ String and tuple-style | ✅ Verified |
+| tui.json no duplicate plugin entries | ✅ Always | ✅ Verified |
+| package.json preserves unrelated fields | ✅ Always | ✅ Verified |
+| package.json enforces minimum plugin version | ✅ `>= 1.4.2` | ✅ Verified |
+| package.json preserves newer versions | ✅ Always | ✅ Verified |
+| opencode.json not modified | ✅ Always | ✅ Verified |
+| Profile activation applies without restart | ✅ Always | ✅ Verified |
+| Active profile detected correctly on plugin open | ✅ Always | ✅ Verified |
+| Memory list scoped to current project only | ✅ No cross-project leakage | ✅ Verified |
+| Soft delete does not affect other memories | ✅ ID-validated UPDATE | ✅ Verified |
+| No crash if Engram DB does not exist | ✅ `execFileSync` caught, returns `[]` | ✅ Verified |
+| No crash if profiles directory is empty | ✅ Warning toast, returns to menu | ✅ Verified |
+| Status badge updates after activation | ✅ State updated synchronously | ✅ Verified |
+| Cross-OS compatibility | ✅ Linux, macOS, Windows | ✅ Verified |

--- a/internal/assets/opencode/plugins/plugin-sdd-opencode/components.tsx
+++ b/internal/assets/opencode/plugins/plugin-sdd-opencode/components.tsx
@@ -1,0 +1,30 @@
+/** @jsxImportSource @opentui/solid */
+// @ts-nocheck
+
+export function ActiveModelBadge(props: { profile: any; theme: any }) {
+  const formatContext = (tokens: number | null): string => {
+    if (!tokens || typeof tokens !== "number") return "ctx: N/A";
+    if (tokens >= 1_000_000) return `${(tokens / 1_000_000).toFixed(1).replace(/\.0$/, "")}M ctx`;
+    if (tokens >= 1_000) return `${Math.round(tokens / 1_000)}k ctx`;
+    return `${tokens} ctx`;
+  };
+
+  const text = props.profile 
+    ? `${props.profile.modelName} · ${formatContext(props.profile.contextLimit)}` 
+    : "No SDD model active";
+
+  const color = props.profile 
+    ? (props.theme?.primary || "#00ff00") 
+    : (props.theme?.textMuted || "#888");
+
+  return (
+    <box flexDirection="row" alignItems="center" padding={{ left: 1, right: 1 }}>
+      <text fg={color} bold={props.profile ? true : false}>
+        {props.profile ? "󰚩 " : "󱚧 "}
+      </text>
+      <text fg={props.theme?.text || "inherit"}>
+        {text}
+      </text>
+    </box>
+  );
+}

--- a/internal/assets/opencode/plugins/plugin-sdd-opencode/index.tsx
+++ b/internal/assets/opencode/plugins/plugin-sdd-opencode/index.tsx
@@ -1,0 +1,84 @@
+/** @jsxImportSource @opentui/solid */
+// @ts-nocheck
+
+/**
+ * Entry point del plugin SDD Model Select
+ */
+
+import type { TuiPlugin, TuiPluginModule } from "@opencode-ai/plugin";
+import * as fs from "node:fs";
+import { ActiveModelBadge } from "./components";
+
+// Importaciones directas (sin barrel export para evitar problemas de resolución)
+import { activeProfile, setActiveProfile } from "./src/state";
+import { resolvePaths } from "./src/config";
+import { parseActiveProfileFromRaw } from "./src/utils";
+import {
+  showProfilesMenu,
+  showProfileList,
+  showProfileDetail,
+  showProjectMemoriesMenu,
+  registerDialogCallbacks,
+} from "./src/dialogs";
+
+// -- Plugin Initialization ---------------------------------------------------
+
+function initializeDialogs() {
+  // Registra los callbacks para resolver dependencias circulares entre dialogs
+  registerDialogCallbacks({
+    showProfilesMenu,
+    showProfileList,
+    showProfileDetail,
+    showProjectMemoriesMenu,
+  });
+}
+
+function readActiveProfile(api: any) {
+  const { configPath } = resolvePaths();
+  try {
+    if (!fs.existsSync(configPath)) return null;
+    const raw = fs.readFileSync(configPath, "utf-8");
+    return parseActiveProfileFromRaw(raw, api);
+  } catch {
+    return null;
+  }
+}
+
+// -- Plugin Entry ------------------------------------------------------------
+
+const id = "sdd-model-select";
+
+const tui: TuiPlugin = async (api) => {
+  // Inicializar callbacks de dialogs
+  initializeDialogs();
+
+  // Leer y establecer perfil activo en estado global
+  const profile = readActiveProfile(api);
+  setActiveProfile(profile);
+
+  // Registrar comando
+  api.command.register(() => [
+    {
+      title: "󰓅 SDD Profiles",
+      value: "sdd-profiles",
+      keybind: "alt+k",
+      slash: { name: "sdd-model" },
+      onSelect: () => showProfilesMenu(api),
+    },
+  ]);
+
+  // Registrar slots UI - usan estado global directamente
+  api.slots.register({
+    slots: {
+      home_bottom(ctx: any) {
+        return <ActiveModelBadge profile={activeProfile} theme={ctx.theme.current} />;
+      },
+      sidebar_content(ctx: any) {
+        return <ActiveModelBadge profile={activeProfile} theme={ctx.theme.current} />;
+      },
+    },
+  });
+};
+
+const plugin: TuiPluginModule & { id: string } = { id, tui };
+export default plugin;

--- a/internal/assets/opencode/plugins/plugin-sdd-opencode/package-lock.json
+++ b/internal/assets/opencode/plugins/plugin-sdd-opencode/package-lock.json
@@ -1,0 +1,2731 @@
+{
+  "name": "model-selection-plugin",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "model-selection-plugin",
+      "version": "1.0.0",
+      "engines": {
+        "opencode": ">=1.3.13"
+      },
+      "peerDependencies": {
+        "@opencode-ai/plugin": "*",
+        "@opentui/core": "*",
+        "@opentui/solid": "*",
+        "solid-js": "*"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
+      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.0.tgz",
+      "integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@ampproject/remapping": "^2.2.0",
+        "@babel/code-frame": "^7.27.1",
+        "@babel/generator": "^7.28.0",
+        "@babel/helper-compilation-targets": "^7.27.2",
+        "@babel/helper-module-transforms": "^7.27.3",
+        "@babel/helpers": "^7.27.6",
+        "@babel/parser": "^7.28.0",
+        "@babel/template": "^7.27.2",
+        "@babel/traverse": "^7.28.0",
+        "@babel/types": "^7.28.0",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-annotate-as-pure": {
+      "version": "7.27.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.27.3.tgz",
+      "integrity": "sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/types": "^7.27.3"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-create-class-features-plugin": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.28.6.tgz",
+      "integrity": "sha512-dTOdvsjnG3xNT9Y0AUg1wAl38y+4Rl4sf9caSQZOXdNqVn+H+HbbJ4IyyHaIqNR6SW9oJpA/RuRjsjCw2IdIow==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.27.3",
+        "@babel/helper-member-expression-to-functions": "^7.28.5",
+        "@babel/helper-optimise-call-expression": "^7.27.1",
+        "@babel/helper-replace-supers": "^7.28.6",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
+        "@babel/traverse": "^7.28.6",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-member-expression-to-functions": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.28.5.tgz",
+      "integrity": "sha512-cwM7SBRZcPCLgl8a7cY0soT1SptSzAlMH39vwiRpOQkJlh53r5hdHwLSCZpQdVLT39sZt+CRpNwYG4Y2v77atg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/traverse": "^7.28.5",
+        "@babel/types": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-optimise-call-expression": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.27.1.tgz",
+      "integrity": "sha512-URMGH08NzYFhubNSGJrpUEphGKQwMQYBySzat5cAByY1/YgIRkULnIy3tAMeszlL/so2HbeilYloUmSpd7GdVw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/types": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-replace-supers": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.28.6.tgz",
+      "integrity": "sha512-mq8e+laIk94/yFec3DxSjCRD2Z0TAjhVbEJY3UQrlwVo15Lmt7C2wAUbK4bjnTs4APkwsYLTahXRraQXhb1WCg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-member-expression-to-functions": "^7.28.5",
+        "@babel/helper-optimise-call-expression": "^7.27.1",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.27.1.tgz",
+      "integrity": "sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/traverse": "^7.27.1",
+        "@babel/types": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-jsx": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.28.6.tgz",
+      "integrity": "sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-typescript": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.28.6.tgz",
+      "integrity": "sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-modules-commonjs": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.28.6.tgz",
+      "integrity": "sha512-jppVbf8IV9iWWwWTQIxJMAJCWBuuKx71475wHwYytrRGQ2CWiDvYlADQno3tcYpS/T2UUWFQp3nVtYfK/YBQrA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-typescript": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.28.6.tgz",
+      "integrity": "sha512-0YWL2RFxOqEm9Efk5PvreamxPME8OyY0wM5wh5lHjF+VtVhdneCWGzZeSqzOfiobVqQaNCd2z0tQvnI9DaPWPw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.27.3",
+        "@babel/helper-create-class-features-plugin": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
+        "@babel/plugin-syntax-typescript": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/preset-typescript": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.27.1.tgz",
+      "integrity": "sha512-l7WfQfX0WK4M0v2RudjuQK4u99BS6yLHYEmdtVPP7lKV013zr9DygFuWNlnbvQ9LR+LS0Egz/XAvGx5U9MX0fQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/plugin-syntax-jsx": "^7.27.1",
+        "@babel/plugin-transform-modules-commonjs": "^7.27.1",
+        "@babel/plugin-transform-typescript": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@dimforge/rapier2d-simd-compat": {
+      "version": "0.17.3",
+      "resolved": "https://registry.npmjs.org/@dimforge/rapier2d-simd-compat/-/rapier2d-simd-compat-0.17.3.tgz",
+      "integrity": "sha512-bijvwWz6NHsNj5e5i1vtd3dU2pDhthSaTUZSh14DUGGKJfw8eMnlWZsxwHBxB/a3AXVNDjL9abuHw1k9FGR+jg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/@jimp/core": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/core/-/core-1.6.0.tgz",
+      "integrity": "sha512-EQQlKU3s9QfdJqiSrZWNTxBs3rKXgO2W+GxNXDtwchF3a4IqxDheFX1ti+Env9hdJXDiYLp2jTRjlxhPthsk8w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jimp/file-ops": "1.6.0",
+        "@jimp/types": "1.6.0",
+        "@jimp/utils": "1.6.0",
+        "await-to-js": "^3.0.0",
+        "exif-parser": "^0.1.12",
+        "file-type": "^16.0.0",
+        "mime": "3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/diff": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/diff/-/diff-1.6.0.tgz",
+      "integrity": "sha512-+yUAQ5gvRC5D1WHYxjBHZI7JBRusGGSLf8AmPRPCenTzh4PA+wZ1xv2+cYqQwTfQHU5tXYOhA0xDytfHUf1Zyw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jimp/plugin-resize": "1.6.0",
+        "@jimp/types": "1.6.0",
+        "@jimp/utils": "1.6.0",
+        "pixelmatch": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/file-ops": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/file-ops/-/file-ops-1.6.0.tgz",
+      "integrity": "sha512-Dx/bVDmgnRe1AlniRpCKrGRm5YvGmUwbDzt+MAkgmLGf+jvBT75hmMEZ003n9HQI/aPnm/YKnXjg/hOpzNCpHQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/js-bmp": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/js-bmp/-/js-bmp-1.6.0.tgz",
+      "integrity": "sha512-FU6Q5PC/e3yzLyBDXupR3SnL3htU7S3KEs4e6rjDP6gNEOXRFsWs6YD3hXuXd50jd8ummy+q2WSwuGkr8wi+Gw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jimp/core": "1.6.0",
+        "@jimp/types": "1.6.0",
+        "@jimp/utils": "1.6.0",
+        "bmp-ts": "^1.0.9"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/js-gif": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/js-gif/-/js-gif-1.6.0.tgz",
+      "integrity": "sha512-N9CZPHOrJTsAUoWkWZstLPpwT5AwJ0wge+47+ix3++SdSL/H2QzyMqxbcDYNFe4MoI5MIhATfb0/dl/wmX221g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jimp/core": "1.6.0",
+        "@jimp/types": "1.6.0",
+        "gifwrap": "^0.10.1",
+        "omggif": "^1.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/js-jpeg": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/js-jpeg/-/js-jpeg-1.6.0.tgz",
+      "integrity": "sha512-6vgFDqeusblf5Pok6B2DUiMXplH8RhIKAryj1yn+007SIAQ0khM1Uptxmpku/0MfbClx2r7pnJv9gWpAEJdMVA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jimp/core": "1.6.0",
+        "@jimp/types": "1.6.0",
+        "jpeg-js": "^0.4.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/js-png": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/js-png/-/js-png-1.6.0.tgz",
+      "integrity": "sha512-AbQHScy3hDDgMRNfG0tPjL88AV6qKAILGReIa3ATpW5QFjBKpisvUaOqhzJ7Reic1oawx3Riyv152gaPfqsBVg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jimp/core": "1.6.0",
+        "@jimp/types": "1.6.0",
+        "pngjs": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/js-tiff": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/js-tiff/-/js-tiff-1.6.0.tgz",
+      "integrity": "sha512-zhReR8/7KO+adijj3h0ZQUOiun3mXUv79zYEAKvE0O+rP7EhgtKvWJOZfRzdZSNv0Pu1rKtgM72qgtwe2tFvyw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jimp/core": "1.6.0",
+        "@jimp/types": "1.6.0",
+        "utif2": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-blit": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-blit/-/plugin-blit-1.6.0.tgz",
+      "integrity": "sha512-M+uRWl1csi7qilnSK8uxK4RJMSuVeBiO1AY0+7APnfUbQNZm6hCe0CCFv1Iyw1D/Dhb8ph8fQgm5mwM0eSxgVA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jimp/types": "1.6.0",
+        "@jimp/utils": "1.6.0",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-blit/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@jimp/plugin-blur": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-blur/-/plugin-blur-1.6.0.tgz",
+      "integrity": "sha512-zrM7iic1OTwUCb0g/rN5y+UnmdEsT3IfuCXCJJNs8SZzP0MkZ1eTvuwK9ZidCuMo4+J3xkzCidRwYXB5CyGZTw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jimp/core": "1.6.0",
+        "@jimp/utils": "1.6.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-circle": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-circle/-/plugin-circle-1.6.0.tgz",
+      "integrity": "sha512-xt1Gp+LtdMKAXfDp3HNaG30SPZW6AQ7dtAtTnoRKorRi+5yCJjKqXRgkewS5bvj8DEh87Ko1ydJfzqS3P2tdWw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jimp/types": "1.6.0",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-circle/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@jimp/plugin-color": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-color/-/plugin-color-1.6.0.tgz",
+      "integrity": "sha512-J5q8IVCpkBsxIXM+45XOXTrsyfblyMZg3a9eAo0P7VPH4+CrvyNQwaYatbAIamSIN1YzxmO3DkIZXzRjFSz1SA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jimp/core": "1.6.0",
+        "@jimp/types": "1.6.0",
+        "@jimp/utils": "1.6.0",
+        "tinycolor2": "^1.6.0",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-color/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@jimp/plugin-contain": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-contain/-/plugin-contain-1.6.0.tgz",
+      "integrity": "sha512-oN/n+Vdq/Qg9bB4yOBOxtY9IPAtEfES8J1n9Ddx+XhGBYT1/QTU/JYkGaAkIGoPnyYvmLEDqMz2SGihqlpqfzQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jimp/core": "1.6.0",
+        "@jimp/plugin-blit": "1.6.0",
+        "@jimp/plugin-resize": "1.6.0",
+        "@jimp/types": "1.6.0",
+        "@jimp/utils": "1.6.0",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-contain/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@jimp/plugin-cover": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-cover/-/plugin-cover-1.6.0.tgz",
+      "integrity": "sha512-Iow0h6yqSC269YUJ8HC3Q/MpCi2V55sMlbkkTTx4zPvd8mWZlC0ykrNDeAy9IJegrQ7v5E99rJwmQu25lygKLA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jimp/core": "1.6.0",
+        "@jimp/plugin-crop": "1.6.0",
+        "@jimp/plugin-resize": "1.6.0",
+        "@jimp/types": "1.6.0",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-cover/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@jimp/plugin-crop": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-crop/-/plugin-crop-1.6.0.tgz",
+      "integrity": "sha512-KqZkEhvs+21USdySCUDI+GFa393eDIzbi1smBqkUPTE+pRwSWMAf01D5OC3ZWB+xZsNla93BDS9iCkLHA8wang==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jimp/core": "1.6.0",
+        "@jimp/types": "1.6.0",
+        "@jimp/utils": "1.6.0",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-crop/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@jimp/plugin-displace": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-displace/-/plugin-displace-1.6.0.tgz",
+      "integrity": "sha512-4Y10X9qwr5F+Bo5ME356XSACEF55485j5nGdiyJ9hYzjQP9nGgxNJaZ4SAOqpd+k5sFaIeD7SQ0Occ26uIng5Q==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jimp/types": "1.6.0",
+        "@jimp/utils": "1.6.0",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-displace/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@jimp/plugin-dither": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-dither/-/plugin-dither-1.6.0.tgz",
+      "integrity": "sha512-600d1RxY0pKwgyU0tgMahLNKsqEcxGdbgXadCiVCoGd6V6glyCvkNrnnwC0n5aJ56Htkj88PToSdF88tNVZEEQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jimp/types": "1.6.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-fisheye": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-fisheye/-/plugin-fisheye-1.6.0.tgz",
+      "integrity": "sha512-E5QHKWSCBFtpgZarlmN3Q6+rTQxjirFqo44ohoTjzYVrDI6B6beXNnPIThJgPr0Y9GwfzgyarKvQuQuqCnnfbA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jimp/types": "1.6.0",
+        "@jimp/utils": "1.6.0",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-fisheye/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@jimp/plugin-flip": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-flip/-/plugin-flip-1.6.0.tgz",
+      "integrity": "sha512-/+rJVDuBIVOgwoyVkBjUFHtP+wmW0r+r5OQ2GpatQofToPVbJw1DdYWXlwviSx7hvixTWLKVgRWQ5Dw862emDg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jimp/types": "1.6.0",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-flip/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@jimp/plugin-hash": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-hash/-/plugin-hash-1.6.0.tgz",
+      "integrity": "sha512-wWzl0kTpDJgYVbZdajTf+4NBSKvmI3bRI8q6EH9CVeIHps9VWVsUvEyb7rpbcwVLWYuzDtP2R0lTT6WeBNQH9Q==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jimp/core": "1.6.0",
+        "@jimp/js-bmp": "1.6.0",
+        "@jimp/js-jpeg": "1.6.0",
+        "@jimp/js-png": "1.6.0",
+        "@jimp/js-tiff": "1.6.0",
+        "@jimp/plugin-color": "1.6.0",
+        "@jimp/plugin-resize": "1.6.0",
+        "@jimp/types": "1.6.0",
+        "@jimp/utils": "1.6.0",
+        "any-base": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-mask": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-mask/-/plugin-mask-1.6.0.tgz",
+      "integrity": "sha512-Cwy7ExSJMZszvkad8NV8o/Z92X2kFUFM8mcDAhNVxU0Q6tA0op2UKRJY51eoK8r6eds/qak3FQkXakvNabdLnA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jimp/types": "1.6.0",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-mask/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@jimp/plugin-print": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-print/-/plugin-print-1.6.0.tgz",
+      "integrity": "sha512-zarTIJi8fjoGMSI/M3Xh5yY9T65p03XJmPsuNet19K/Q7mwRU6EV2pfj+28++2PV2NJ+htDF5uecAlnGyxFN2A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jimp/core": "1.6.0",
+        "@jimp/js-jpeg": "1.6.0",
+        "@jimp/js-png": "1.6.0",
+        "@jimp/plugin-blit": "1.6.0",
+        "@jimp/types": "1.6.0",
+        "parse-bmfont-ascii": "^1.0.6",
+        "parse-bmfont-binary": "^1.0.6",
+        "parse-bmfont-xml": "^1.1.6",
+        "simple-xml-to-json": "^1.2.2",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-print/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@jimp/plugin-quantize": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-quantize/-/plugin-quantize-1.6.0.tgz",
+      "integrity": "sha512-EmzZ/s9StYQwbpG6rUGBCisc3f64JIhSH+ncTJd+iFGtGo0YvSeMdAd+zqgiHpfZoOL54dNavZNjF4otK+mvlg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "image-q": "^4.0.0",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-quantize/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@jimp/plugin-resize": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-1.6.0.tgz",
+      "integrity": "sha512-uSUD1mqXN9i1SGSz5ov3keRZ7S9L32/mAQG08wUwZiEi5FpbV0K8A8l1zkazAIZi9IJzLlTauRNU41Mi8IF9fA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jimp/core": "1.6.0",
+        "@jimp/types": "1.6.0",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-resize/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@jimp/plugin-rotate": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-rotate/-/plugin-rotate-1.6.0.tgz",
+      "integrity": "sha512-JagdjBLnUZGSG4xjCLkIpQOZZ3Mjbg8aGCCi4G69qR+OjNpOeGI7N2EQlfK/WE8BEHOW5vdjSyglNqcYbQBWRw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jimp/core": "1.6.0",
+        "@jimp/plugin-crop": "1.6.0",
+        "@jimp/plugin-resize": "1.6.0",
+        "@jimp/types": "1.6.0",
+        "@jimp/utils": "1.6.0",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-rotate/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@jimp/plugin-threshold": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-threshold/-/plugin-threshold-1.6.0.tgz",
+      "integrity": "sha512-M59m5dzLoHOVWdM41O8z9SyySzcDn43xHseOH0HavjsfQsT56GGCC4QzU1banJidbUrePhzoEdS42uFE8Fei8w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jimp/core": "1.6.0",
+        "@jimp/plugin-color": "1.6.0",
+        "@jimp/plugin-hash": "1.6.0",
+        "@jimp/types": "1.6.0",
+        "@jimp/utils": "1.6.0",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-threshold/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@jimp/types": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/types/-/types-1.6.0.tgz",
+      "integrity": "sha512-7UfRsiKo5GZTAATxm2qQ7jqmUXP0DxTArztllTcYdyw6Xi5oT4RaoXynVtCD4UyLK5gJgkZJcwonoijrhYFKfg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/types/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@jimp/utils": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-1.6.0.tgz",
+      "integrity": "sha512-gqFTGEosKbOkYF/WFj26jMHOI5OH2jeP1MmC/zbK6BF6VJBf8rIC5898dPfSzZEbSA0wbbV5slbntWVc5PKLFA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jimp/types": "1.6.0",
+        "tinycolor2": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@opencode-ai/plugin": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.4.0.tgz",
+      "integrity": "sha512-VFIff6LHp/RVaJdrK3EQ1ijx0K1tV5i1DY5YJ+pRqwC6trunPHbvqSN0GHSTZX39RdnSc+XuzCTZQCy1W2qNOg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@opencode-ai/sdk": "1.4.0",
+        "zod": "4.1.8"
+      },
+      "peerDependencies": {
+        "@opentui/core": ">=0.1.97",
+        "@opentui/solid": ">=0.1.97"
+      },
+      "peerDependenciesMeta": {
+        "@opentui/core": {
+          "optional": true
+        },
+        "@opentui/solid": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@opencode-ai/sdk": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.4.0.tgz",
+      "integrity": "sha512-mfa3MzhqNM+Az4bgPDDXL3NdG+aYOHClXmT6/4qLxf2ulyfPpMNHqb9Dfmo4D8UfmrDsPuJHmbune73/nUQnuw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "cross-spawn": "7.0.6"
+      }
+    },
+    "node_modules/@opentui/core": {
+      "version": "0.1.97",
+      "resolved": "https://registry.npmjs.org/@opentui/core/-/core-0.1.97.tgz",
+      "integrity": "sha512-2ENH0Dc4NUAeHeeQCQhF1lg68RuyntOUP68UvortvDqTz/hqLG0tIwF+DboCKtWi8Nmao4SAQEJ7lfmyQNEDOQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "bun-ffi-structs": "0.1.2",
+        "diff": "8.0.2",
+        "jimp": "1.6.0",
+        "marked": "17.0.1",
+        "yoga-layout": "3.2.1"
+      },
+      "optionalDependencies": {
+        "@dimforge/rapier2d-simd-compat": "^0.17.3",
+        "@opentui/core-darwin-arm64": "0.1.97",
+        "@opentui/core-darwin-x64": "0.1.97",
+        "@opentui/core-linux-arm64": "0.1.97",
+        "@opentui/core-linux-x64": "0.1.97",
+        "@opentui/core-win32-arm64": "0.1.97",
+        "@opentui/core-win32-x64": "0.1.97",
+        "bun-webgpu": "0.1.5",
+        "planck": "^1.4.2",
+        "three": "0.177.0"
+      },
+      "peerDependencies": {
+        "web-tree-sitter": "0.25.10"
+      }
+    },
+    "node_modules/@opentui/core-darwin-arm64": {
+      "version": "0.1.97",
+      "resolved": "https://registry.npmjs.org/@opentui/core-darwin-arm64/-/core-darwin-arm64-0.1.97.tgz",
+      "integrity": "sha512-t7oMGEfMPQsqLEx7/rPqv/UGJ+vqhe4RWHRRQRYcuHuLKssZ2S8P9mSS7MBPtDqGcxg4PosCrh5nHYeZ94EXUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true
+    },
+    "node_modules/@opentui/core-darwin-x64": {
+      "version": "0.1.97",
+      "resolved": "https://registry.npmjs.org/@opentui/core-darwin-x64/-/core-darwin-x64-0.1.97.tgz",
+      "integrity": "sha512-ZuPWAawlVat6ZHb8vaH/CVUeGwI0pI4vd+6zz1ZocZn95ZWJztfyhzNZOJrq1WjHmUROieJ7cOuYUZfvYNuLrg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true
+    },
+    "node_modules/@opentui/core-linux-arm64": {
+      "version": "0.1.97",
+      "resolved": "https://registry.npmjs.org/@opentui/core-linux-arm64/-/core-linux-arm64-0.1.97.tgz",
+      "integrity": "sha512-QXxhz654vXgEu2wrFFFFnrSWbyk6/r6nXNnDTcMRWofdMZQLx87NhbcsErNmz9KmFdzoPiQSmlpYubLflKKzqQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/@opentui/core-linux-x64": {
+      "version": "0.1.97",
+      "resolved": "https://registry.npmjs.org/@opentui/core-linux-x64/-/core-linux-x64-0.1.97.tgz",
+      "integrity": "sha512-v3z0QWpRS3p8blE/A7pTu15hcFMtSndeiYhRxhrjp6zAhQ+UlruQs9DAG1ifSuVO1RJJ0pUKklFivdbu0pMzuw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/@opentui/core-win32-arm64": {
+      "version": "0.1.97",
+      "resolved": "https://registry.npmjs.org/@opentui/core-win32-arm64/-/core-win32-arm64-0.1.97.tgz",
+      "integrity": "sha512-o/m9mD1dvOCwkxOUUyoEILl+d6tzh/85foJc4uqjXYi71NNcwg8u+Eq3/gdHuSKnlT1pusCPKoS1IDuBvZE24A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true
+    },
+    "node_modules/@opentui/core-win32-x64": {
+      "version": "0.1.97",
+      "resolved": "https://registry.npmjs.org/@opentui/core-win32-x64/-/core-win32-x64-0.1.97.tgz",
+      "integrity": "sha512-Rwp7JOwrYm4wtzPHY2vv+2l91LXmKSI7CtbmWN1sSUGhBPtPGSvfwux3W5xaAZQa2KPEXicPjaKJZc+pob3YRg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true
+    },
+    "node_modules/@opentui/solid": {
+      "version": "0.1.97",
+      "resolved": "https://registry.npmjs.org/@opentui/solid/-/solid-0.1.97.tgz",
+      "integrity": "sha512-ma/uihG38F+6oLJVD8yR7z82FWmR8QhfesNV5SBXbN74riMCRyy6kyQ6SI4xs4ykt9BbZOjrKLq+Xt/0Pd0SJQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/core": "7.28.0",
+        "@babel/preset-typescript": "7.27.1",
+        "@opentui/core": "0.1.97",
+        "babel-plugin-module-resolver": "5.0.2",
+        "babel-preset-solid": "1.9.10",
+        "entities": "7.0.1",
+        "s-js": "^0.4.9"
+      },
+      "peerDependencies": {
+        "solid-js": "1.9.11"
+      }
+    },
+    "node_modules/@tokenizer/token": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/node": {
+      "version": "16.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.1.tgz",
+      "integrity": "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@webgpu/types": {
+      "version": "0.1.69",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.69.tgz",
+      "integrity": "sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
+    "node_modules/any-base": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/any-base/-/any-base-1.1.0.tgz",
+      "integrity": "sha512-uMgjozySS8adZZYePpaWs8cxB9/kdzmpX6SgJZ+wbz1K5eYk5QMYDVJaZKhxyIHUdnnJkfR7SVgStgH7LkGUyg==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/await-to-js": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/await-to-js/-/await-to-js-3.0.0.tgz",
+      "integrity": "sha512-zJAaP9zxTcvTHRlejau3ZOY4V7SRpiByf3/dxx2uyKxxor19tpmpV2QRsTKikckwhaPmr2dVpxxMr7jOCYVp5g==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/babel-plugin-jsx-dom-expressions": {
+      "version": "0.40.6",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jsx-dom-expressions/-/babel-plugin-jsx-dom-expressions-0.40.6.tgz",
+      "integrity": "sha512-v3P1MW46Lm7VMpAkq0QfyzLWWkC8fh+0aE5Km4msIgDx5kjenHU0pF2s+4/NH8CQn/kla6+Hvws+2AF7bfV5qQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-module-imports": "7.18.6",
+        "@babel/plugin-syntax-jsx": "^7.18.6",
+        "@babel/types": "^7.20.7",
+        "html-entities": "2.3.3",
+        "parse5": "^7.1.2"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.20.12"
+      }
+    },
+    "node_modules/babel-plugin-jsx-dom-expressions/node_modules/@babel/helper-module-imports": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz",
+      "integrity": "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/types": "^7.18.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/babel-plugin-module-resolver": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-module-resolver/-/babel-plugin-module-resolver-5.0.2.tgz",
+      "integrity": "sha512-9KtaCazHee2xc0ibfqsDeamwDps6FZNo5S0Q81dUqEuFzVwPhcT4J5jOqIVvgCA3Q/wO9hKYxN/Ds3tIsp5ygg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "find-babel-config": "^2.1.1",
+        "glob": "^9.3.3",
+        "pkg-up": "^3.1.0",
+        "reselect": "^4.1.7",
+        "resolve": "^1.22.8"
+      }
+    },
+    "node_modules/babel-preset-solid": {
+      "version": "1.9.10",
+      "resolved": "https://registry.npmjs.org/babel-preset-solid/-/babel-preset-solid-1.9.10.tgz",
+      "integrity": "sha512-HCelrgua/Y+kqO8RyL04JBWS/cVdrtUv/h45GntgQY+cJl4eBcKkCDV3TdMjtKx1nXwRaR9QXslM/Npm1dxdZQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "babel-plugin-jsx-dom-expressions": "^0.40.3"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0",
+        "solid-js": "^1.9.10"
+      },
+      "peerDependenciesMeta": {
+        "solid-js": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.16",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.16.tgz",
+      "integrity": "sha512-Lyf3aK28zpsD1yQMiiHD4RvVb6UdMoo8xzG2XzFIfR9luPzOpcBlAsT/qfB1XWS1bxWT+UtE4WmQgsp297FYOA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bmp-ts": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/bmp-ts/-/bmp-ts-1.0.9.tgz",
+      "integrity": "sha512-cTEHk2jLrPyi+12M3dhpEbnnPOsaZuq7C45ylbbQIiWgDFZq4UVYPEY5mlqjvsj/6gJv9qX5sa+ebDzLXT28Vw==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/bun-ffi-structs": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/bun-ffi-structs/-/bun-ffi-structs-0.1.2.tgz",
+      "integrity": "sha512-Lh1oQAYHDcnesJauieA4UNkWGXY9hYck7OA5IaRwE3Bp6K2F2pJSNYqq+hIy7P3uOvo3km3oxS8304g5gDMl/w==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "typescript": "^5"
+      }
+    },
+    "node_modules/bun-webgpu": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/bun-webgpu/-/bun-webgpu-0.1.5.tgz",
+      "integrity": "sha512-91/K6S5whZKX7CWAm9AylhyKrLGRz6BUiiPiM/kXadSnD4rffljCD/q9cNFftm5YXhx4MvLqw33yEilxogJvwA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@webgpu/types": "^0.1.60"
+      },
+      "optionalDependencies": {
+        "bun-webgpu-darwin-arm64": "^0.1.5",
+        "bun-webgpu-darwin-x64": "^0.1.5",
+        "bun-webgpu-linux-x64": "^0.1.5",
+        "bun-webgpu-win32-x64": "^0.1.5"
+      }
+    },
+    "node_modules/bun-webgpu-darwin-arm64": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/bun-webgpu-darwin-arm64/-/bun-webgpu-darwin-arm64-0.1.6.tgz",
+      "integrity": "sha512-lIsDkPzJzPl6yrB5CUOINJFPnTRv6fF/Q8J1mAr43ogSp86WZEg9XZKaT6f3EUJ+9ETogGoMnoj1q0AwHUTbAQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true
+    },
+    "node_modules/bun-webgpu-darwin-x64": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/bun-webgpu-darwin-x64/-/bun-webgpu-darwin-x64-0.1.6.tgz",
+      "integrity": "sha512-uEddf5U7GvKIkM/BV18rUKtYHL6d0KeqBjNHwfqDH9QgEo9KVSKvJXS5I/sMefk5V5pIYE+8tQhtrREevhocng==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true
+    },
+    "node_modules/bun-webgpu-linux-x64": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/bun-webgpu-linux-x64/-/bun-webgpu-linux-x64-0.1.6.tgz",
+      "integrity": "sha512-Y/f15j9r8ba0xUz+3lATtS74OE+PPzQXO7Do/1eCluJcuOlfa77kMjvBK/ShWnem3Y9xqi59pebTPOGRB+CaJA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/bun-webgpu-win32-x64": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/bun-webgpu-win32-x64/-/bun-webgpu-win32-x64-0.1.6.tgz",
+      "integrity": "sha512-MHSFAKqizISb+C5NfDrFe3g0Al5Njnu0j/A+oO2Q+bIWX+fUYjBSowiYE1ZXJx65KuryuB+tiM7Qh6cQbVvkEg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001786",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001786.tgz",
+      "integrity": "sha512-4oxTZEvqmLLrERwxO76yfKM7acZo310U+v4kqexI2TL1DkkUEMT8UijrxxcnVdxR3qkVf5awGRX+4Z6aPHVKrA==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0",
+      "peer": true
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/diff": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.2.tgz",
+      "integrity": "sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.332",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.332.tgz",
+      "integrity": "sha512-7OOtytmh/rINMLwaFTbcMVvYXO3AUm029X0LcyfYk0B557RlPkdpTpnH9+htMlfu5dKwOmT0+Zs2Aw+lnn6TeQ==",
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/exif-parser": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/exif-parser/-/exif-parser-0.1.12.tgz",
+      "integrity": "sha512-c2bQfLNbMzLPmzQuOr8fy0csy84WmwnER81W88DzTp9CYNPJ6yzOj2EZAh9pywYpqHnshVLHQJ8WzldAyfY+Iw==",
+      "peer": true
+    },
+    "node_modules/file-type": {
+      "version": "16.5.4",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
+      "integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "readable-web-to-node-stream": "^3.0.0",
+        "strtok3": "^6.2.4",
+        "token-types": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
+      }
+    },
+    "node_modules/find-babel-config": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/find-babel-config/-/find-babel-config-2.1.2.tgz",
+      "integrity": "sha512-ZfZp1rQyp4gyuxqt1ZqjFGVeVBvmpURMqdIWXbPRfB97Bf6BzdK/xSIbylEINzQ0kB5tlDQfn9HkNXXWsqTqLg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "json5": "^2.2.3"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "locate-path": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/gifwrap": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/gifwrap/-/gifwrap-0.10.1.tgz",
+      "integrity": "sha512-2760b1vpJHNmLzZ/ubTtNnEx5WApN/PYWJvXvgS+tL1egTTthayFYIQQNi136FLEDcN/IyEY2EcGpIITD6eYUw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "image-q": "^4.0.0",
+        "omggif": "^1.0.10"
+      }
+    },
+    "node_modules/glob": {
+      "version": "9.3.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.5.tgz",
+      "integrity": "sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "minimatch": "^8.0.2",
+        "minipass": "^4.2.4",
+        "path-scurry": "^1.6.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-entities": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.3.3.tgz",
+      "integrity": "sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/image-q": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/image-q/-/image-q-4.0.0.tgz",
+      "integrity": "sha512-PfJGVgIfKQJuq3s0tTDOKtztksibuUEbJQIYT3by6wctQo+Rdlh7ef4evJ5NCdxY4CfMbvFkocEwbl4BF8RlJw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/node": "16.9.1"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/jimp": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/jimp/-/jimp-1.6.0.tgz",
+      "integrity": "sha512-YcwCHw1kiqEeI5xRpDlPPBGL2EOpBKLwO4yIBJcXWHPj5PnA5urGq0jbyhM5KoNpypQ6VboSoxc9D8HyfvngSg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jimp/core": "1.6.0",
+        "@jimp/diff": "1.6.0",
+        "@jimp/js-bmp": "1.6.0",
+        "@jimp/js-gif": "1.6.0",
+        "@jimp/js-jpeg": "1.6.0",
+        "@jimp/js-png": "1.6.0",
+        "@jimp/js-tiff": "1.6.0",
+        "@jimp/plugin-blit": "1.6.0",
+        "@jimp/plugin-blur": "1.6.0",
+        "@jimp/plugin-circle": "1.6.0",
+        "@jimp/plugin-color": "1.6.0",
+        "@jimp/plugin-contain": "1.6.0",
+        "@jimp/plugin-cover": "1.6.0",
+        "@jimp/plugin-crop": "1.6.0",
+        "@jimp/plugin-displace": "1.6.0",
+        "@jimp/plugin-dither": "1.6.0",
+        "@jimp/plugin-fisheye": "1.6.0",
+        "@jimp/plugin-flip": "1.6.0",
+        "@jimp/plugin-hash": "1.6.0",
+        "@jimp/plugin-mask": "1.6.0",
+        "@jimp/plugin-print": "1.6.0",
+        "@jimp/plugin-quantize": "1.6.0",
+        "@jimp/plugin-resize": "1.6.0",
+        "@jimp/plugin-rotate": "1.6.0",
+        "@jimp/plugin-threshold": "1.6.0",
+        "@jimp/types": "1.6.0",
+        "@jimp/utils": "1.6.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/jpeg-js": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.4.tgz",
+      "integrity": "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/marked": {
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.1.tgz",
+      "integrity": "sha512-boeBdiS0ghpWcSwoNm/jJBwdpFaMnZWRzjA6SkUMYb40SVaN1x7mmfGKp0jvexGcx+7y2La5zRZsYFZI6Qpypg==",
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "8.0.7",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.7.tgz",
+      "integrity": "sha512-V+1uQNdzybxa14e/p00HZnQNNcTjnRJjDxg2V8wtkjFctq4M7hXFws4oekyTP0Jebeq7QYtpFyOeBAjc88zvYg==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
+      "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.37",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
+      "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/omggif": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/omggif/-/omggif-1.0.10.tgz",
+      "integrity": "sha512-LMJTtvgc/nugXj0Vcrrs68Mn2D1r0zf630VNtqtpI1FEO7e+O9FP4gqs9AcnBaSEeoHIPm28u6qgPR0oyEpGSw==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "p-limit": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)",
+      "peer": true
+    },
+    "node_modules/parse-bmfont-ascii": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/parse-bmfont-ascii/-/parse-bmfont-ascii-1.0.6.tgz",
+      "integrity": "sha512-U4RrVsUFCleIOBsIGYOMKjn9PavsGOXxbvYGtMOEfnId0SVNsgehXh1DxUdVPLoxd5mvcEtvmKs2Mmf0Mpa1ZA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/parse-bmfont-binary": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/parse-bmfont-binary/-/parse-bmfont-binary-1.0.6.tgz",
+      "integrity": "sha512-GxmsRea0wdGdYthjuUeWTMWPqm2+FAd4GI8vCvhgJsFnoGhTrLhXDDupwTo7rXVAgaLIGoVHDZS9p/5XbSqeWA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/parse-bmfont-xml": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/parse-bmfont-xml/-/parse-bmfont-xml-1.1.6.tgz",
+      "integrity": "sha512-0cEliVMZEhrFDwMh4SxIyVJpqYoOWDJ9P895tFuS+XuNzI5UBmBk5U5O4KuJdTnZpSBI4LFA2+ZiJaiwfSwlMA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "xml-parse-from-string": "^1.0.0",
+        "xml2js": "^0.5.0"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "license": "BlueOak-1.0.0",
+      "peer": true,
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/path-scurry/node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "peer": true,
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/peek-readable": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-4.1.0.tgz",
+      "integrity": "sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/pixelmatch": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-5.3.0.tgz",
+      "integrity": "sha512-o8mkY4E/+LNUf6LzX96ht6k6CEDi65k9G2rjMtBe9Oo+VPKSvl+0GKHuH/AlG+GA5LPG/i5hrekkxUc3s2HU+Q==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "pngjs": "^6.0.0"
+      },
+      "bin": {
+        "pixelmatch": "bin/pixelmatch"
+      }
+    },
+    "node_modules/pixelmatch/node_modules/pngjs": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-6.0.0.tgz",
+      "integrity": "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12.13.0"
+      }
+    },
+    "node_modules/pkg-up": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-3.1.0.tgz",
+      "integrity": "sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "find-up": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/planck": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/planck/-/planck-1.5.0.tgz",
+      "integrity": "sha512-dlvqJE+FscZgrGUXJ5ybd0o5bvZ5XXyZNbm08xGsXp9WjXeAyWSFT6n9s/1PQcUBo4546fDXA5RMA4wbDyZw6g==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=24.0"
+      },
+      "peerDependencies": {
+        "stage-js": "^1.0.0-alpha.12"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-7.0.0.tgz",
+      "integrity": "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=14.19.0"
+      }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/readable-web-to-node-stream": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.4.tgz",
+      "integrity": "sha512-9nX56alTf5bwXQ3ZDipHJhusu9NTQJ/CVPtb/XHAJCXihZeitfJvIRS4GqQ/mfIoOE3IelHMrpayVrosdHBuLw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "readable-stream": "^4.7.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/reselect": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.8.tgz",
+      "integrity": "sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/resolve": {
+      "version": "1.22.11",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
+      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/s-js": {
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/s-js/-/s-js-0.4.9.tgz",
+      "integrity": "sha512-RtpOm+cM6O0sHg6IA70wH+UC3FZcND+rccBZpBAHzlUgNO2Bm5BN+FnM8+OBxzXdwpKWFwX11JGF0MFRkhSoIQ==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/sax": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "license": "BlueOak-1.0.0",
+      "peer": true,
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
+      "peer": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/seroval": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.5.2.tgz",
+      "integrity": "sha512-xcRN39BdsnO9Tf+VzsE7b3JyTJASItIV1FVFewJKCFcW4s4haIKS3e6vj8PGB9qBwC7tnuOywQMdv5N4qkzi7Q==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/seroval-plugins": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/seroval-plugins/-/seroval-plugins-1.5.2.tgz",
+      "integrity": "sha512-qpY0Cl+fKYFn4GOf3cMiq6l72CpuVaawb6ILjubOQ+diJ54LfOWaSSPsaswN8DRPIPW4Yq+tE1k5aKd7ILyaFg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "seroval": "^1.0"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/simple-xml-to-json": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/simple-xml-to-json/-/simple-xml-to-json-1.2.7.tgz",
+      "integrity": "sha512-mz9VXphOxQWX3eQ/uXCtm6upltoN0DLx8Zb5T4TFC4FHB7S9FDPGre8CfLWqPWQQH/GrQYd2AXhhVM5LDpYx6Q==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.12.2"
+      }
+    },
+    "node_modules/solid-js": {
+      "version": "1.9.11",
+      "resolved": "https://registry.npmjs.org/solid-js/-/solid-js-1.9.11.tgz",
+      "integrity": "sha512-WEJtcc5mkh/BnHA6Yrg4whlF8g6QwpmXXRg4P2ztPmcKeHHlH4+djYecBLhSpecZY2RRECXYUwIc/C2r3yzQ4Q==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "csstype": "^3.1.0",
+        "seroval": "~1.5.0",
+        "seroval-plugins": "~1.5.0"
+      }
+    },
+    "node_modules/stage-js": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/stage-js/-/stage-js-1.0.2.tgz",
+      "integrity": "sha512-EWTRBYlg7Qv9wGUao99/PfRe3KaiQqWmgSvTOXvaWnu1Jk/q/vV8yJVu6bi/3EqDZeMVnCPAjheba6OFc5k1GQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=24.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/strtok3": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
+      "integrity": "sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0",
+        "peek-readable": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/three": {
+      "version": "0.177.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.177.0.tgz",
+      "integrity": "sha512-EiXv5/qWAaGI+Vz2A+JfavwYCMdGjxVsrn3oBwllUoqYeaBO75J63ZfyaQKoiLrqNHoTlUc6PFgMXnS0kI45zg==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/tinycolor2": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
+      "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/token-types": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-4.2.1.tgz",
+      "integrity": "sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/utif2": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/utif2/-/utif2-4.1.0.tgz",
+      "integrity": "sha512-+oknB9FHrJ7oW7A2WZYajOcv4FcDR4CfoGB0dPNfxbi4GO05RRnFmt5oa23+9w32EanrYcSJWspUiJkLMs+37w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "pako": "^1.0.11"
+      }
+    },
+    "node_modules/web-tree-sitter": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.25.10.tgz",
+      "integrity": "sha512-Y09sF44/13XvgVKgO2cNDw5rGk6s26MgoZPXLESvMXeefBf7i6/73eFurre0IsTW6E14Y0ArIzhUMmjoc7xyzA==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@types/emscripten": "^1.40.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/emscripten": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/xml-parse-from-string": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml-parse-from-string/-/xml-parse-from-string-1.0.1.tgz",
+      "integrity": "sha512-ErcKwJTF54uRzzNMXq2X5sMIy88zJvfN2DmdoQvy7PAFJ+tPRU6ydWuOKNMyfmOjdyBQTFREi60s0Y0SyI0G0g==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/xml2js": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/yoga-layout": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
+      "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/zod": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.8.tgz",
+      "integrity": "sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/internal/assets/opencode/plugins/plugin-sdd-opencode/package.json
+++ b/internal/assets/opencode/plugins/plugin-sdd-opencode/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "model-selection-plugin",
+  "version": "1.0.0",
+  "description": "Interactive SDD model selection and profile management for opencode",
+  "type": "module",
+  "main": "index.tsx",
+  "exports": {
+    "./tui": {
+      "import": "./index.tsx"
+    }
+  },
+  "peerDependencies": {
+    "@opencode-ai/plugin": "*",
+    "@opentui/core": "*",
+    "@opentui/solid": "*",
+    "solid-js": "*"
+  },
+  "engines": {
+    "opencode": ">=1.3.13"
+  }
+}

--- a/internal/assets/opencode/plugins/plugin-sdd-opencode/src/config.ts
+++ b/internal/assets/opencode/plugins/plugin-sdd-opencode/src/config.ts
@@ -1,0 +1,84 @@
+/** @jsxImportSource @opentui/solid */
+// @ts-nocheck
+
+/**
+ * Configuración y paths del plugin
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { execFileSync } from "node:child_process";
+
+export type Paths = {
+  configRoot: string;
+  profilesDir: string;
+  configPath: string;
+  backupPath: string;
+};
+
+export function resolvePaths(): Paths {
+  const home = os.homedir();
+  const xdgConfig = process.env.XDG_CONFIG_HOME || path.join(home, ".config");
+  const configRoot = path.join(xdgConfig, "opencode");
+
+  return {
+    configRoot,
+    profilesDir: path.join(configRoot, "profiles"),
+    configPath: path.join(configRoot, "opencode.json"),
+    backupPath: path.join(configRoot, "opencode.json.bak"),
+  };
+}
+
+export function ensureProfilesDir(): void {
+  const { profilesDir } = resolvePaths();
+  if (!fs.existsSync(profilesDir)) {
+    try {
+      fs.mkdirSync(profilesDir, { recursive: true });
+    } catch (e) {}
+  }
+}
+
+export function resolveProjectName(api: any): string {
+  return resolveProjectCandidates(api)[0] || "unknown";
+}
+
+export function resolveProjectCandidates(api: any): string[] {
+  const directory = api?.state?.path?.directory || process.cwd();
+  const candidates: string[] = [];
+
+  try {
+    const remote = execFileSync("git", ["-C", directory, "remote", "get-url", "origin"], {
+      encoding: "utf-8",
+      timeout: 2000,
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+
+    if (remote) {
+      const repoName = remote.replace(/\.git$/, "").split(/[/:]/).pop()?.trim().toLowerCase();
+      if (repoName) candidates.push(repoName);
+    }
+  } catch {}
+
+  try {
+    const root = execFileSync("git", ["-C", directory, "rev-parse", "--show-toplevel"], {
+      encoding: "utf-8",
+      timeout: 2000,
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+
+    if (root) {
+      const rootName = path.basename(root)?.trim().toLowerCase();
+      if (rootName) candidates.push(rootName);
+    }
+  } catch {}
+
+  const dirName = path.basename(directory)?.trim().toLowerCase();
+  if (dirName) candidates.push(dirName);
+
+  return [...new Set(candidates.filter(Boolean))];
+}
+
+export function resolveWorkspaceRoot(api: any): string {
+  return api?.state?.path?.directory || process.cwd();
+}

--- a/internal/assets/opencode/plugins/plugin-sdd-opencode/src/config.ts
+++ b/internal/assets/opencode/plugins/plugin-sdd-opencode/src/config.ts
@@ -14,7 +14,6 @@ export type Paths = {
   configRoot: string;
   profilesDir: string;
   configPath: string;
-  backupPath: string;
 };
 
 export function resolvePaths(): Paths {
@@ -26,7 +25,6 @@ export function resolvePaths(): Paths {
     configRoot,
     profilesDir: path.join(configRoot, "profiles"),
     configPath: path.join(configRoot, "opencode.json"),
-    backupPath: path.join(configRoot, "opencode.json.bak"),
   };
 }
 

--- a/internal/assets/opencode/plugins/plugin-sdd-opencode/src/dialogs.tsx
+++ b/internal/assets/opencode/plugins/plugin-sdd-opencode/src/dialogs.tsx
@@ -1,0 +1,516 @@
+/** @jsxImportSource @opentui/solid */
+// @ts-nocheck
+
+/**
+ * Dialogs de UI del plugin
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { NAV_CATEGORY } from "./types";
+import {
+  resolveModelInfo,
+  formatMemoryDate,
+  truncateText,
+  parseActiveProfileFromRaw,
+  formatContext,
+} from "./utils";
+import { resolvePaths, ensureProfilesDir } from "./config";
+import {
+  listProfileFiles,
+  readProfileModels,
+  writeProfileModels,
+  extractSddAgentModels,
+  detectActiveProfileFile,
+  activateProfileFile,
+  deleteProfileFile,
+  renameProfileFile,
+} from "./profiles";
+import { deleteProjectMemory, listProjectMemories } from "./memories";
+import { setActiveProfile } from "./state";
+
+function showMemoryDetail(api: any, memory: any) {
+  const sanitizeMemoryDisplayText = (value: string): string =>
+    value
+      .replace(/\*\*(.*?)\*\*/g, "$1")
+      .replace(/`([^`]+)`/g, "$1")
+      .replace(/[“”]/g, '"')
+      .replace(/[‘’]/g, "'")
+      .replace(/→/g, "->");
+
+  const wrapDisplayText = (value: string, max = 52): string[] => {
+    if (!value) return [" "];
+    const words = sanitizeMemoryDisplayText(value).split(/\s+/).filter(Boolean);
+    if (words.length === 0) return [" "];
+
+    const lines: string[] = [];
+    let current = "";
+
+    for (const word of words) {
+      if (!current) {
+        current = word;
+        continue;
+      }
+
+      if (`${current} ${word}`.length <= max) {
+        current = `${current} ${word}`;
+        continue;
+      }
+
+      lines.push(current);
+      current = word;
+    }
+
+    if (current) lines.push(current);
+    return lines.length > 0 ? lines : [value];
+  };
+
+  const title = memory.title || memory.topic_key || `Memory #${memory.id}`;
+  const metadata = `[${(memory.type || "manual").toUpperCase()}] ${formatMemoryDate(
+    memory.updated_at || memory.created_at
+  )} · ${memory.scope || "project"}`;
+  const contentLines = (memory.content || "Sin contenido")
+    .split("\n")
+    .flatMap((line: string) => wrapDisplayText(line || " "));
+
+  api.ui.dialog.replace(() => (
+    <api.ui.DialogSelect
+      title={truncateText(title, 60)}
+      options={[
+        {
+          title: metadata,
+          value: "__meta__",
+          category: "Memory",
+        },
+        ...contentLines.map((line: string, index: number) => ({
+          title: line || " ",
+          value: `__line__${index}`,
+        })),
+        { title: "✕ Delete Memory", value: "__delete__", category: NAV_CATEGORY },
+        { title: "← Back", value: "__back__", category: NAV_CATEGORY },
+      ]}
+      onSelect={(opt: any) => {
+        if (opt.value === "__back__") showProjectMemoriesMenuFn(api);
+        else if (opt.value === "__delete__") showDeleteMemory(api, memory);
+        else showMemoryDetail(api, memory);
+      }}
+      onCancel={() => showProjectMemoriesMenuFn(api)}
+    />
+  ));
+}
+
+function showDeleteMemory(api: any, memory: any) {
+  const title = memory.title || memory.topic_key || `Memory #${memory.id}`;
+
+  api.ui.dialog.replace(() => (
+    <api.ui.DialogConfirm
+      title="Delete Memory"
+      message={`Eliminar '${truncateText(title, 48)}'?`}
+      onConfirm={() => {
+        try {
+          deleteProjectMemory(memory.id);
+          api.ui.toast({ title: "Deleted", message: "Memory eliminada", variant: "success" });
+          showProjectMemoriesMenuFn(api);
+        } catch (e: any) {
+          api.ui.toast({ title: "Error", message: e.message || "No se pudo eliminar la memory", variant: "error" });
+          showMemoryDetail(api, memory);
+        }
+      }}
+      onCancel={() => showMemoryDetail(api, memory)}
+    />
+  ));
+}
+
+// Referencias a funciones de dialog para evitar dependencias circulares
+let showProfilesMenuFn: (api: any) => void;
+let showProfileListFn: (api: any) => void;
+let showProfileDetailFn: (api: any, profileOpt: any) => void;
+let showProjectMemoriesMenuFn: (api: any) => void;
+
+export function registerDialogCallbacks(callbacks: {
+  showProfilesMenu: (api: any) => void;
+  showProfileList: (api: any) => void;
+  showProfileDetail: (api: any, profileOpt: any) => void;
+  showProjectMemoriesMenu: (api: any) => void;
+}) {
+  showProfilesMenuFn = callbacks.showProfilesMenu;
+  showProfileListFn = callbacks.showProfileList;
+  showProfileDetailFn = callbacks.showProfileDetail;
+  showProjectMemoriesMenuFn = callbacks.showProjectMemoriesMenu;
+}
+
+export function showProfilesMenu(api: any) {
+  api.ui.dialog.replace(() => (
+    <api.ui.DialogSelect
+      title="SDD Profile Management"
+      options={[
+        {
+          title: "󰏪 Create New SDD Profile",
+          value: "create",
+          description: "Save current config as 'name.json'.",
+        },
+        {
+          title: "󰓅 Manage SDD Profiles",
+          value: "list",
+          description: "List and activate saved SDD profiles.",
+        },
+        {
+          title: "󰄄 View Project Memories",
+          value: "view_memories",
+          description: "Show recent Engram memories for this project.",
+        },
+        {
+          title: "✕ Close",
+          value: "__close__",
+          category: NAV_CATEGORY,
+        },
+      ]}
+      onSelect={(opt: any) => {
+        if (opt.value === "create") showCreateProfile(api);
+        else if (opt.value === "list") showProfileListFn(api);
+        else if (opt.value === "view_memories") showProjectMemoriesMenuFn(api);
+        else api.ui.dialog.clear();
+      }}
+      onCancel={() => api.ui.dialog.clear()}
+    />
+  ));
+}
+
+export function showCreateProfile(api: any) {
+  const { configPath, profilesDir } = resolvePaths();
+  ensureProfilesDir();
+
+  api.ui.dialog.replace(() => (
+    <api.ui.DialogPrompt
+      title="New SDD Profile Name"
+      placeholder="Enter profile name"
+      onConfirm={(name: string) => {
+        const trimmed = name?.trim();
+        if (!trimmed) {
+          showProfilesMenuFn(api);
+          return;
+        }
+
+        const finalName = trimmed.replace(/\.json$/i, "");
+        const fileName = `${finalName}.json`;
+        const profilePath = path.join(profilesDir, fileName);
+
+        if (fs.existsSync(profilePath)) {
+          api.ui.toast({
+            title: "Error",
+            message: `Profile '${finalName}' already exists`,
+            variant: "error",
+          });
+          showProfilesMenuFn(api);
+          return;
+        }
+
+        try {
+          const currentConfig = JSON.parse(fs.readFileSync(configPath, "utf-8"));
+          const profileModels = extractSddAgentModels(currentConfig);
+
+          if (Object.keys(profileModels).length === 0) {
+            api.ui.toast({
+              title: "Error",
+              message: "No encontré agentes SDD con modelo asignado",
+              variant: "error",
+            });
+            showProfilesMenuFn(api);
+            return;
+          }
+
+          writeProfileModels(profilePath, profileModels);
+          api.ui.toast({
+            title: "Success",
+            message: `Profile '${finalName}' created`,
+            variant: "success",
+          });
+          showProfilesMenuFn(api);
+        } catch (e: any) {
+          api.ui.toast({
+            title: "Error",
+            message: `Failed to create profile: ${e.message}`,
+            variant: "error",
+          });
+          showProfilesMenuFn(api);
+        }
+      }}
+      onCancel={() => showProfilesMenuFn(api)}
+    />
+  ));
+}
+
+export function showProfileList(api: any) {
+  ensureProfilesDir();
+
+  const files = listProfileFiles();
+
+  if (files.length === 0) {
+    api.ui.toast({
+      title: "No Profiles",
+      message: "No profiles starting with 'sdd-' found.",
+      variant: "warning",
+    });
+    showProfilesMenuFn(api);
+    return;
+  }
+
+  const activeFile = detectActiveProfileFile(files, api);
+
+  api.ui.dialog.replace(() => (
+    <api.ui.DialogSelect
+      title="Select SDD Profile"
+      current={activeFile}
+      options={[
+        ...files.map((f) => ({
+          title: `${f === activeFile ? "✓ " : ""}${f.replace(".json", "")}`,
+          value: f,
+          description: f === activeFile ? "✓ Active" : "SDD Profile",
+        })),
+        { title: "← Back", value: "__back__", category: NAV_CATEGORY },
+      ]}
+      onSelect={(opt: any) => {
+        if (opt.value === "__back__") showProfilesMenuFn(api);
+        else showProfileDetailFn(api, { title: String(opt.value).replace(".json", ""), value: opt.value });
+      }}
+      onCancel={() => showProfilesMenuFn(api)}
+    />
+  ));
+}
+
+export function showProfileDetail(api: any, profileOpt: any) {
+  const { profilesDir } = resolvePaths();
+  try {
+    const profilePath = path.join(profilesDir, profileOpt.value);
+    const profileModels = readProfileModels(profilePath);
+    const sddAgents = Object.entries(profileModels);
+
+    api.ui.dialog.replace(() => (
+      <api.ui.DialogSelect
+        title={`Profile: ${profileOpt.title}`}
+        options={[
+          { title: `✏ Name: ${profileOpt.title}`, value: "__rename__", category: "Profile" },
+          ...sddAgents.map(([name, modelId]) => ({
+            title: name,
+            value: name,
+            description: resolveModelInfo(api, modelId),
+            category: "Agents (Click to edit model)",
+          })),
+          { title: "✓ Activate Profile", value: "__assign__", category: NAV_CATEGORY },
+          { title: "✕ Delete Profile", value: "__delete__", category: NAV_CATEGORY },
+          { title: "← Back", value: "__back__", category: NAV_CATEGORY },
+        ]}
+        onSelect={(opt: any) => {
+          if (opt.value === "__back__") showProfileListFn(api);
+          else if (opt.value === "__assign__") handleActivateProfile(api, profilePath, profileOpt.title);
+          else if (opt.value === "__delete__") showDeleteProfile(api, profileOpt);
+          else if (opt.value === "__rename__") showRenameProfile(api, profileOpt);
+          else if (!opt.value.startsWith("__")) showProviderPickerForAgent(api, profileOpt, opt.value);
+        }}
+        onCancel={() => showProfileListFn(api)}
+      />
+    ));
+  } catch (e) {
+    api.ui.toast({ title: "Error", message: "Failed to read profile details", variant: "error" });
+  }
+}
+
+async function handleActivateProfile(api: any, profilePath: string, profileName: string) {
+  const updatedConfig = await activateProfileFile(api, profilePath, profileName);
+  if (!updatedConfig) return;
+
+  setActiveProfile(parseActiveProfileFromRaw(JSON.stringify(updatedConfig), api));
+
+  api.ui.dialog.replace(() => (
+    <api.ui.DialogConfirm
+      title="Profile Activated"
+      message={`Perfil '${profileName}' aplicado sobre la config global. Probando recarga en runtime.`}
+      onConfirm={() => api.ui.dialog.clear()}
+      onCancel={() => api.ui.dialog.clear()}
+    />
+  ));
+}
+
+function showDeleteProfile(api: any, profileOpt: any) {
+  api.ui.dialog.replace(() => (
+    <api.ui.DialogConfirm
+      title="Delete Profile"
+      message={`Permanently delete '${profileOpt.title}'?`}
+      onConfirm={() => {
+        try {
+          deleteProfileFile(profileOpt.value);
+          api.ui.toast({ title: "Deleted", message: `Profile '${profileOpt.title}' deleted` });
+          showProfileListFn(api);
+        } catch (e: any) {
+          api.ui.toast({ title: "Error", message: `Failed to delete: ${e.message}`, variant: "error" });
+          showProfileDetailFn(api, profileOpt);
+        }
+      }}
+      onCancel={() => showProfileDetailFn(api, profileOpt)}
+    />
+  ));
+}
+
+function showRenameProfile(api: any, profileOpt: any) {
+  api.ui.dialog.replace(() => (
+    <api.ui.DialogPrompt
+      title="Rename Profile"
+      value={profileOpt.title}
+      onConfirm={(newName: string) => {
+        const trimmed = newName?.trim();
+        if (!trimmed || trimmed === profileOpt.title) {
+          showProfileDetailFn(api, profileOpt);
+          return;
+        }
+
+        const finalName = trimmed.replace(/\.json$/i, "");
+        const newFileName = `${finalName}.json`;
+
+        const { profilesDir } = resolvePaths();
+        const newPath = path.join(profilesDir, newFileName);
+
+        if (fs.existsSync(newPath)) {
+          api.ui.toast({ title: "Error", message: "Name already exists", variant: "error" });
+          showProfileDetailFn(api, profileOpt);
+          return;
+        }
+
+        try {
+          renameProfileFile(profileOpt.value, newFileName);
+          api.ui.toast({ title: "Renamed", message: `Profile renamed to '${finalName}'` });
+          showProfileListFn(api);
+        } catch (e: any) {
+          api.ui.toast({ title: "Error", message: `Failed to rename: ${e.message}`, variant: "error" });
+          showProfileDetailFn(api, profileOpt);
+        }
+      }}
+      onCancel={() => showProfileDetailFn(api, profileOpt)}
+    />
+  ));
+}
+
+function showProviderPickerForAgent(api: any, profileOpt: any, agentName: string) {
+  const providers = (api.state.provider || []).filter((p: any) => Object.keys(p.models || {}).length > 0);
+
+  if (providers.length === 0) {
+    api.ui.toast({ title: "No Providers", message: "No authenticated providers found.", variant: "warning" });
+    showProfileDetailFn(api, profileOpt);
+    return;
+  }
+
+  api.ui.dialog.replace(() => (
+    <api.ui.DialogSelect
+      title={`Provider for ${agentName}`}
+      options={[
+        ...providers.map((p: any) => ({
+          title: p.name || p.id,
+          value: p.id,
+          description: `${Object.keys(p.models || {}).length} models available`,
+        })),
+        { title: "← Back", value: "__back__", category: NAV_CATEGORY },
+      ]}
+      onSelect={(opt: any) => {
+        if (opt.value === "__back__") showProfileDetailFn(api, profileOpt);
+        else {
+          const selected = providers.find((p: any) => p.id === opt.value);
+          showModelPickerForAgent(api, profileOpt, agentName, selected);
+        }
+      }}
+      onCancel={() => showProfileDetailFn(api, profileOpt)}
+    />
+  ));
+}
+
+function showModelPickerForAgent(api: any, profileOpt: any, agentName: string, provider: any) {
+  const models = provider.models || {};
+  const modelKeys = Object.keys(models);
+
+  api.ui.dialog.replace(() => (
+    <api.ui.DialogSelect
+      title={`${provider.name || provider.id} › ${agentName}`}
+      options={[
+        ...modelKeys.map((key) => {
+          const model = models[key];
+          const ctxText = model.limit?.context ? formatContext(model.limit.context) : "ctx: N/A";
+          return {
+            title: model.name || key,
+            value: `${provider.id}/${key}`,
+            description: ctxText,
+          };
+        }),
+        { title: "← Back", value: "__back__", category: NAV_CATEGORY },
+      ]}
+      onSelect={(opt: any) => {
+        if (opt.value === "__back__") showProviderPickerForAgent(api, profileOpt, agentName);
+        else updateAgentModel(api, profileOpt, agentName, opt.value);
+      }}
+      onCancel={() => showProviderPickerForAgent(api, profileOpt, agentName)}
+    />
+  ));
+}
+
+function updateAgentModel(api: any, profileOpt: any, agentName: string, fullModelId: string) {
+  const { profilesDir } = resolvePaths();
+  const profilePath = path.join(profilesDir, profileOpt.value);
+
+  try {
+    const profileModels = readProfileModels(profilePath);
+    profileModels[agentName] = fullModelId;
+    writeProfileModels(profilePath, profileModels);
+    api.ui.toast({ title: "Updated", message: `${agentName} set to ${fullModelId}`, variant: "success" });
+    showProfileDetailFn(api, profileOpt);
+  } catch (e: any) {
+    api.ui.toast({ title: "Error", message: `Failed to update agent: ${e.message}`, variant: "error" });
+    showProfileDetailFn(api, profileOpt);
+  }
+}
+
+export function showProjectMemoriesMenu(api: any) {
+  const projectName = api?.state?.path?.directory ? path.basename(api.state.path.directory) : "project";
+
+  try {
+    const memories = listProjectMemories(api);
+
+    if (memories.length === 0) {
+      api.ui.toast({
+        title: "No Memories",
+        message: `No engram memories for ${projectName}`,
+        variant: "warning",
+      });
+      showProfilesMenuFn(api);
+      return;
+    }
+
+    api.ui.dialog.replace(() => (
+      <api.ui.DialogSelect
+        title={`Memories: ${projectName}`}
+        options={[
+          ...memories.map((m) => ({
+            title: truncateText(`[${m.id}] ${m.title || m.topic_key || `Memory #${m.id}`}`, 60),
+            value: String(m.id),
+            description: `[${(m.type || "manual").toUpperCase()}] ${formatMemoryDate(
+              m.updated_at || m.created_at
+            )} · ${m.scope || "project"}`,
+          })),
+          { title: "← Back", value: "__back__", category: NAV_CATEGORY },
+        ]}
+        onSelect={(opt: any) => {
+          if (opt.value === "__back__") showProfilesMenuFn(api);
+          else {
+            const memory = memories.find((item) => String(item.id) === opt.value);
+            if (!memory) return;
+            showMemoryDetail(api, memory);
+          }
+        }}
+        onCancel={() => showProfilesMenuFn(api)}
+      />
+    ));
+  } catch (e) {
+    api.ui.toast({
+      title: "Engram Error",
+      message: "Failed to read local project memories.",
+      variant: "error",
+    });
+    showProfilesMenuFn(api);
+  }
+}

--- a/internal/assets/opencode/plugins/plugin-sdd-opencode/src/dialogs.tsx
+++ b/internal/assets/opencode/plugins/plugin-sdd-opencode/src/dialogs.tsx
@@ -15,7 +15,7 @@ import {
   parseActiveProfileFromRaw,
   formatContext,
 } from "./utils";
-import { resolvePaths, ensureProfilesDir } from "./config";
+import { resolvePaths, ensureProfilesDir, resolveProjectName } from "./config";
 import {
   listProfileFiles,
   readProfileModels,
@@ -466,7 +466,7 @@ function updateAgentModel(api: any, profileOpt: any, agentName: string, fullMode
 }
 
 export function showProjectMemoriesMenu(api: any) {
-  const projectName = api?.state?.path?.directory ? path.basename(api.state.path.directory) : "project";
+  const projectName = resolveProjectName(api) || "project";
 
   try {
     const memories = listProjectMemories(api);

--- a/internal/assets/opencode/plugins/plugin-sdd-opencode/src/dialogs.tsx
+++ b/internal/assets/opencode/plugins/plugin-sdd-opencode/src/dialogs.tsx
@@ -248,7 +248,7 @@ export function showProfileList(api: any) {
   if (files.length === 0) {
     api.ui.toast({
       title: "No Profiles",
-      message: "No profiles starting with 'sdd-' found.",
+      message: "No .json profiles found in ~/.config/opencode/profiles.",
       variant: "warning",
     });
     showProfilesMenuFn(api);

--- a/internal/assets/opencode/plugins/plugin-sdd-opencode/src/index.ts
+++ b/internal/assets/opencode/plugins/plugin-sdd-opencode/src/index.ts
@@ -1,0 +1,21 @@
+/** @jsxImportSource @opentui/solid */
+// @ts-nocheck
+
+/**
+ * Barrel exports del módulo src
+ */
+
+export * from "./types";
+export * from "./utils";
+export * from "./config";
+export * from "./profiles";
+export * from "./memories";
+export * from "./state";
+export {
+  showProfilesMenu,
+  showCreateProfile,
+  showProfileList,
+  showProfileDetail,
+  showProjectMemoriesMenu,
+  registerDialogCallbacks,
+} from "./dialogs";

--- a/internal/assets/opencode/plugins/plugin-sdd-opencode/src/memories.ts
+++ b/internal/assets/opencode/plugins/plugin-sdd-opencode/src/memories.ts
@@ -13,6 +13,46 @@ import type { EngramObservation } from "./types";
 
 const ENGRAM_DB = path.join(os.homedir(), ".engram", "engram.db");
 
+function toArrayOutput(output: string): any[] {
+  const trimmed = output?.trim();
+  if (!trimmed) return [];
+
+  try {
+    const parsed = JSON.parse(trimmed);
+    if (Array.isArray(parsed)) return parsed;
+    if (parsed && typeof parsed === "object") return [parsed];
+    return [];
+  } catch {}
+
+  const rows: any[] = [];
+  for (const line of trimmed.split(/\r?\n/)) {
+    const row = line.trim();
+    if (!row) continue;
+    try {
+      const parsed = JSON.parse(row);
+      if (Array.isArray(parsed)) rows.push(...parsed);
+      else if (parsed && typeof parsed === "object") rows.push(parsed);
+    } catch {}
+  }
+
+  return rows;
+}
+
+function normalizeMemory(memory: any, fallbackProject: string): EngramObservation {
+  const id = Number(memory?.id);
+  return {
+    id: Number.isFinite(id) ? id : 0,
+    type: String(memory?.type || "manual"),
+    title: typeof memory?.title === "string" ? memory.title : "",
+    topic_key: typeof memory?.topic_key === "string" ? memory.topic_key : "",
+    content: typeof memory?.content === "string" ? memory.content : "",
+    project: String(memory?.project || fallbackProject || "unknown"),
+    scope: typeof memory?.scope === "string" && memory.scope ? memory.scope : "project",
+    updated_at: typeof memory?.updated_at === "string" ? memory.updated_at : "",
+    created_at: typeof memory?.created_at === "string" ? memory.created_at : "",
+  };
+}
+
 function execSQLiteJson(query: string): EngramObservation[] {
   try {
     const output = execFileSync(
@@ -25,9 +65,7 @@ function execSQLiteJson(query: string): EngramObservation[] {
       }
     );
 
-    if (!output.trim()) return [];
-
-    return JSON.parse(output) as EngramObservation[];
+    return toArrayOutput(output) as EngramObservation[];
   } catch {
     return [];
   }
@@ -45,6 +83,7 @@ export function listProjectMemories(api: any): EngramObservation[] {
   const projectName = resolveProjectName(api);
   const projectCandidates = resolveProjectCandidates(api);
   const escapedProjects = projectCandidates
+    .map((name) => String(name).toLowerCase())
     .map((name) => name.replace(/'/g, "''"))
     .map((name) => `'${name}'`)
     .join(", ");
@@ -63,16 +102,12 @@ export function listProjectMemories(api: any): EngramObservation[] {
       updated_at,
       ifnull(topic_key, '') as topic_key
     FROM observations
-    WHERE project IN (${escapedProjects})
+    WHERE lower(project) IN (${escapedProjects})
       AND deleted_at IS NULL
     ORDER BY updated_at DESC
   `;
 
-  return execSQLiteJson(query).map((memory) => ({
-    ...memory,
-    project: memory.project || projectName,
-    scope: memory.scope || "project",
-  }));
+  return execSQLiteJson(query).map((memory) => normalizeMemory(memory, projectName));
 }
 
 export function deleteProjectMemory(memoryId: number): void {

--- a/internal/assets/opencode/plugins/plugin-sdd-opencode/src/memories.ts
+++ b/internal/assets/opencode/plugins/plugin-sdd-opencode/src/memories.ts
@@ -1,0 +1,90 @@
+/** @jsxImportSource @opentui/solid */
+// @ts-nocheck
+
+/**
+ * Lógica de memorias Engram - Lee directamente de SQLite
+ */
+
+import { execFileSync } from "node:child_process";
+import * as path from "node:path";
+import * as os from "node:os";
+import { resolveProjectCandidates, resolveProjectName } from "./config";
+import type { EngramObservation } from "./types";
+
+const ENGRAM_DB = path.join(os.homedir(), ".engram", "engram.db");
+
+function execSQLiteJson(query: string): EngramObservation[] {
+  try {
+    const output = execFileSync(
+      "sqlite3",
+      ["-json", ENGRAM_DB, query],
+      {
+        encoding: "utf-8",
+        timeout: 5000,
+        stdio: ["ignore", "pipe", "ignore"],
+      }
+    );
+
+    if (!output.trim()) return [];
+
+    return JSON.parse(output) as EngramObservation[];
+  } catch {
+    return [];
+  }
+}
+
+function execSQLite(query: string): void {
+  execFileSync("sqlite3", [ENGRAM_DB, query], {
+    encoding: "utf-8",
+    timeout: 5000,
+    stdio: ["ignore", "pipe", "ignore"],
+  });
+}
+
+export function listProjectMemories(api: any): EngramObservation[] {
+  const projectName = resolveProjectName(api);
+  const projectCandidates = resolveProjectCandidates(api);
+  const escapedProjects = projectCandidates
+    .map((name) => name.replace(/'/g, "''"))
+    .map((name) => `'${name}'`)
+    .join(", ");
+
+  if (!escapedProjects) return [];
+
+  const query = `
+    SELECT
+      id,
+      type,
+      title,
+      content,
+      project,
+      scope,
+      created_at,
+      updated_at,
+      ifnull(topic_key, '') as topic_key
+    FROM observations
+    WHERE project IN (${escapedProjects})
+      AND deleted_at IS NULL
+    ORDER BY updated_at DESC
+  `;
+
+  return execSQLiteJson(query).map((memory) => ({
+    ...memory,
+    project: memory.project || projectName,
+    scope: memory.scope || "project",
+  }));
+}
+
+export function deleteProjectMemory(memoryId: number): void {
+  const safeId = Number(memoryId);
+  if (!Number.isInteger(safeId) || safeId <= 0) {
+    throw new Error("Memory ID inválido");
+  }
+
+  execSQLite(`
+    UPDATE observations
+    SET deleted_at = datetime('now'), updated_at = datetime('now')
+    WHERE id = ${safeId}
+      AND deleted_at IS NULL;
+  `);
+}

--- a/internal/assets/opencode/plugins/plugin-sdd-opencode/src/profiles.ts
+++ b/internal/assets/opencode/plugins/plugin-sdd-opencode/src/profiles.ts
@@ -1,0 +1,148 @@
+/** @jsxImportSource @opentui/solid */
+// @ts-nocheck
+
+/**
+ * Lógica de perfiles SDD
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { ProfileModels } from "./types";
+import { isManagedSddAgent } from "./utils";
+import { resolvePaths, ensureProfilesDir } from "./config";
+
+export function isSddProfile(fileName: string): boolean {
+  return fileName.endsWith(".json");
+}
+
+export function extractSddAgentModels(config: any): ProfileModels {
+  const agents = config?.agent || {};
+  return Object.fromEntries(
+    Object.entries(agents).filter(
+      ([name, value]: any) => isManagedSddAgent(name) && typeof value?.model === "string" && value.model
+    ).map(([name, value]: any) => [name, value.model])
+  );
+}
+
+export function readProfileModels(profilePath: string): ProfileModels {
+  const raw = JSON.parse(fs.readFileSync(profilePath, "utf-8"));
+
+  if (raw && typeof raw === "object" && !Array.isArray(raw) && !raw.agent) {
+    return Object.fromEntries(
+      Object.entries(raw)
+        .filter(
+          ([name, value]: any) =>
+            isManagedSddAgent(name) &&
+            ((typeof value === "string" && value) || (typeof value?.model === "string" && value.model))
+        )
+        .map(([name, value]: any) => [name, typeof value === "string" ? value : value.model])
+    );
+  }
+
+  return extractSddAgentModels(raw);
+}
+
+export function writeProfileModels(profilePath: string, models: ProfileModels): void {
+  fs.writeFileSync(profilePath, JSON.stringify(models, null, 2));
+}
+
+export function detectActiveProfileFile(files: string[], api: any): string | undefined {
+  const activeAgents = (api.state.config as any)?.agent || {};
+  const { profilesDir } = resolvePaths();
+  const activeSddAgents = Object.fromEntries(
+    Object.entries(activeAgents)
+      .filter(([name, value]: any) => isManagedSddAgent(name) && typeof value?.model === "string" && value.model)
+      .map(([name, value]: any) => [name, value.model])
+  );
+
+  for (const file of files) {
+    try {
+      const profileModels = readProfileModels(path.join(profilesDir, file));
+      const keys = Object.keys(profileModels);
+      if (keys.length === 0) continue;
+
+      if (keys.length !== Object.keys(activeSddAgents).length) continue;
+
+      const allMatch = keys.every((agentName) => {
+        const profileModel = profileModels[agentName];
+        const activeModel = activeSddAgents[agentName];
+        return profileModel && profileModel === activeModel;
+      });
+
+      if (allMatch) return file;
+    } catch (e) {}
+  }
+  return undefined;
+}
+
+function applyProfileModelsToConfig(currentConfig: any, profileModels: ProfileModels): any {
+  const nextConfig = JSON.parse(JSON.stringify(currentConfig || {}));
+  if (!nextConfig.agent) nextConfig.agent = {};
+
+  for (const [agentName, modelId] of Object.entries(profileModels)) {
+    nextConfig.agent[agentName] = {
+      ...(nextConfig.agent[agentName] || {}),
+      model: modelId,
+    };
+  }
+
+  return nextConfig;
+}
+
+export async function activateProfileFile(api: any, profilePath: string, profileName: string): Promise<any | null> {
+  const { configPath, backupPath } = resolvePaths();
+  try {
+    const profileModels = readProfileModels(profilePath);
+
+    if (Object.keys(profileModels).length === 0) {
+      api.ui.toast({
+        title: "Activation Failed",
+        message: "El perfil no tiene modelos SDD para aplicar",
+        variant: "error",
+      });
+      return;
+    }
+
+    if (fs.existsSync(configPath)) fs.writeFileSync(backupPath, fs.readFileSync(configPath, "utf-8"));
+
+    const globalConfigResult = await api.client.global.config.get();
+    const currentConfig = globalConfigResult?.data || JSON.parse(fs.readFileSync(configPath, "utf-8"));
+    const nextConfig = applyProfileModelsToConfig(currentConfig, profileModels);
+
+    const result = await api.client.global.config.update({
+      config: nextConfig,
+    });
+
+    if (result?.error) throw new Error(result.error.message || "No se pudo actualizar la config global runtime");
+
+    const updatedConfig = result?.data || nextConfig;
+    fs.writeFileSync(configPath, JSON.stringify(updatedConfig, null, 2));
+    return updatedConfig;
+  } catch (err: any) {
+    api.ui.toast({ title: "Activation Failed", message: err.message, variant: "error" });
+    return null;
+  }
+}
+
+export function listProfileFiles(): string[] {
+  const { profilesDir } = resolvePaths();
+  ensureProfilesDir();
+  try {
+    return fs.readdirSync(profilesDir).filter((f) => isSddProfile(f));
+  } catch {
+    return [];
+  }
+}
+
+export function deleteProfileFile(fileName: string): void {
+  const { profilesDir } = resolvePaths();
+  const profilePath = path.join(profilesDir, fileName);
+  fs.unlinkSync(profilePath);
+}
+
+export function renameProfileFile(oldFileName: string, newFileName: string): void {
+  const { profilesDir } = resolvePaths();
+  const oldPath = path.join(profilesDir, oldFileName);
+  const newPath = path.join(profilesDir, newFileName);
+  fs.renameSync(oldPath, newPath);
+}

--- a/internal/assets/opencode/plugins/plugin-sdd-opencode/src/profiles.ts
+++ b/internal/assets/opencode/plugins/plugin-sdd-opencode/src/profiles.ts
@@ -90,7 +90,7 @@ function applyProfileModelsToConfig(currentConfig: any, profileModels: ProfileMo
 }
 
 export async function activateProfileFile(api: any, profilePath: string, profileName: string): Promise<any | null> {
-  const { configPath, backupPath } = resolvePaths();
+  const { configPath } = resolvePaths();
   try {
     const profileModels = readProfileModels(profilePath);
 
@@ -103,10 +103,17 @@ export async function activateProfileFile(api: any, profilePath: string, profile
       return;
     }
 
-    if (fs.existsSync(configPath)) fs.writeFileSync(backupPath, fs.readFileSync(configPath, "utf-8"));
-
-    const globalConfigResult = await api.client.global.config.get();
-    const currentConfig = globalConfigResult?.data || JSON.parse(fs.readFileSync(configPath, "utf-8"));
+    // IMPORTANT:
+    // Use on-disk config as source-of-truth to preserve declarative links like
+    // {file:...}. Runtime `global.config.get()` may return resolved content,
+    // and sending that back can materialize/inline file contents.
+    let currentConfig: any;
+    if (fs.existsSync(configPath)) {
+      currentConfig = JSON.parse(fs.readFileSync(configPath, "utf-8"));
+    } else {
+      const globalConfigResult = await api.client.global.config.get();
+      currentConfig = globalConfigResult?.data || {};
+    }
     const nextConfig = applyProfileModelsToConfig(currentConfig, profileModels);
 
     const result = await api.client.global.config.update({
@@ -115,9 +122,12 @@ export async function activateProfileFile(api: any, profilePath: string, profile
 
     if (result?.error) throw new Error(result.error.message || "No se pudo actualizar la config global runtime");
 
-    const updatedConfig = result?.data || nextConfig;
-    fs.writeFileSync(configPath, JSON.stringify(updatedConfig, null, 2));
-    return updatedConfig;
+    // IMPORTANT:
+    // Do NOT rewrite opencode.json from plugin-side after profile switch.
+    // The runtime config API is the source of truth for persistence/format.
+    // Rewriting here causes full-file churn (indent/style drift) and can
+    // materialize resolved/default fields that were not explicitly set.
+    return result?.data || nextConfig;
   } catch (err: any) {
     api.ui.toast({ title: "Activation Failed", message: err.message, variant: "error" });
     return null;

--- a/internal/assets/opencode/plugins/plugin-sdd-opencode/src/state.ts
+++ b/internal/assets/opencode/plugins/plugin-sdd-opencode/src/state.ts
@@ -1,0 +1,14 @@
+/** @jsxImportSource @opentui/solid */
+// @ts-nocheck
+
+/**
+ * Estado global del plugin
+ */
+
+import { ActiveProfileState } from "./types";
+
+export let activeProfile: ActiveProfileState | null = null;
+
+export function setActiveProfile(profile: ActiveProfileState | null): void {
+  activeProfile = profile;
+}

--- a/internal/assets/opencode/plugins/plugin-sdd-opencode/src/types.ts
+++ b/internal/assets/opencode/plugins/plugin-sdd-opencode/src/types.ts
@@ -1,0 +1,39 @@
+/** @jsxImportSource @opentui/solid */
+// @ts-nocheck
+
+/**
+ * Tipos compartidos del plugin SDD Model Select
+ */
+
+export type ActiveProfileState = {
+  modelId: string;
+  contextLimit: number | null;
+  providerName: string;
+  modelName: string;
+};
+
+export type ProfileModels = Record<string, string>;
+
+export type ProfileState = {
+  activeProfile?: string;
+  updatedAt?: string;
+};
+
+export type EngramObservation = {
+  id: number;
+  type: string;
+  title?: string;
+  topic_key?: string;
+  content?: string;
+  project: string;
+  scope?: string;
+  updated_at?: string;
+  created_at?: string;
+};
+
+export type ProfileOption = {
+  title: string;
+  value: string;
+};
+
+export const NAV_CATEGORY = "─────────────";

--- a/internal/assets/opencode/plugins/plugin-sdd-opencode/src/utils.ts
+++ b/internal/assets/opencode/plugins/plugin-sdd-opencode/src/utils.ts
@@ -1,0 +1,79 @@
+/** @jsxImportSource @opentui/solid */
+// @ts-nocheck
+
+/**
+ * Utilidades generales del plugin
+ */
+
+import { ActiveProfileState } from "./types";
+
+export function formatContext(tokens: number | null): string {
+  if (!tokens || typeof tokens !== "number") return "ctx: N/A";
+  if (tokens >= 1_000_000) return `${(tokens / 1_000_000).toFixed(1).replace(/\.0$/, "")}M ctx`;
+  if (tokens >= 1_000) return `${Math.round(tokens / 1_000)}k ctx`;
+  return `${tokens} ctx`;
+}
+
+export function formatMemoryDate(value: string | undefined): string {
+  if (!value) return "Sin fecha";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleString();
+}
+
+export function truncateText(value: string, max = 120): string {
+  if (!value) return "";
+  return value.length > max ? `${value.slice(0, max - 1)}…` : value;
+}
+
+export function isManagedSddAgent(agentName: string): boolean {
+  return agentName.startsWith("sdd-");
+}
+
+export function resolveModelInfo(api: any, modelId: string): string {
+  if (!modelId) return "Sin asignar";
+  const [providerId, ...rest] = modelId.split("/");
+  const modelKey = rest.join("/");
+  const provider = api.state.provider.find((p: any) => p.id === providerId);
+  const model = provider?.models?.[modelKey];
+  const ctx = model?.limit?.context;
+  const ctxStr = ctx ? ` (${formatContext(ctx)})` : "";
+  return `${modelId}${ctxStr}`;
+}
+
+export function parseActiveProfileFromRaw(raw: string, api: any): ActiveProfileState | null {
+  try {
+    const config = JSON.parse(raw);
+    const providers = api.state.provider || [];
+    const agentConfigs = config.agent || config.model || {};
+    const agentNames = Object.keys(agentConfigs);
+
+    if (agentNames.length === 0) return null;
+
+    const firstAgent =
+      agentNames.find((name) => isManagedSddAgent(name) && agentConfigs[name]?.model) ||
+      agentNames.find((name) => agentConfigs[name]?.model) ||
+      agentNames[0];
+
+    const modelId = agentConfigs[firstAgent]?.model;
+    if (!modelId) return null;
+
+    const [providerId, ...rest] = modelId.split("/");
+    const modelKey = rest.join("/");
+    const provider = providers.find((p: any) => p.id === providerId);
+
+    if (!provider) {
+      return { modelId, modelName: modelId, providerName: providerId, contextLimit: null };
+    }
+
+    const modelDef = provider.models?.[modelKey];
+    return {
+      modelId,
+      modelName: modelDef?.name || modelKey,
+      providerName: provider.name || provider.id,
+      contextLimit: modelDef?.limit?.context || null,
+    };
+  } catch {
+    return null;
+  }
+}

--- a/internal/components/sdd/plugin_sdd_install.go
+++ b/internal/components/sdd/plugin_sdd_install.go
@@ -6,6 +6,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/gentleman-programming/gentle-ai/internal/assets"
@@ -25,8 +26,7 @@ const tuiJSONSchema = "https://opencode.ai/tui.json"
 // opencodePackageRequirements lists the dependencies that must be present in
 // ~/.config/opencode/package.json for the plugin to load correctly.
 var opencodePackageRequirements = map[string]string{
-	"@opencode-ai/plugin":    "1.4.2",
-	"unique-names-generator": "^4.7.1",
+	"@opencode-ai/plugin": "1.4.2",
 }
 
 // opencodePluginMinVersion is the minimum supported version for the runtime
@@ -35,14 +35,15 @@ const opencodePluginMinVersion = "1.4.2"
 
 // PluginInstallResult holds the outcome of InstallSddPlugin.
 type PluginInstallResult struct {
-	// FilesChanged is the number of files that were created or updated.
+	// FilesChanged is the number of files that were created, updated, or removed.
 	FilesChanged int
 	// AlreadyInstalled is true when the plugin was already present and
 	// tui.json already registered it — nothing was written.
 	AlreadyInstalled bool
 	// PackageWarning is non-empty when ~/.config/opencode/package.json is
-	// missing a required dependency. The plugin is still installed but the
-	// user should run `bun install` (or npm install) in that directory.
+	// not readable/writable or cannot be validated.
+	// In the normal path this remains empty because OpenCode resolves plugin
+	// dependency installation automatically.
 	PackageWarning string
 }
 
@@ -73,10 +74,11 @@ func InstallSddPlugin(homeDir string) (PluginInstallResult, error) {
 		filesChanged++
 	}
 
-	// 3. Ensure package.json has required deps — non-fatal, produces a warning only.
+	// 3. Ensure package.json has required deps — non-fatal, warning only on
+	// exceptional read/write/parse failures.
 	warning := ensureOpencodePackageJSON(opencodeDir)
 
-	alreadyInstalled := filesChanged == 0 && !tuiChanged
+	alreadyInstalled := filesChanged == 0
 	return PluginInstallResult{
 		FilesChanged:     filesChanged,
 		AlreadyInstalled: alreadyInstalled,
@@ -84,20 +86,14 @@ func InstallSddPlugin(homeDir string) (PluginInstallResult, error) {
 	}, nil
 }
 
-// copyEmbeddedPlugin removes any existing plugin directory at destDir and
-// copies all files from the embedded asset tree fresh. This ensures stale
-// files from a previous version are never left behind.
-// Returns the number of files written.
+// copyEmbeddedPlugin synchronizes embedded plugin files into destDir.
+// It is idempotent: unchanged files are not rewritten.
+// Stale files from previous plugin versions are removed after sync.
+// Returns the number of filesystem changes (writes + stale file removals).
 func copyEmbeddedPlugin(destDir string) (int, error) {
-	// Remove existing directory so stale files from older versions are cleaned up.
-	if _, err := os.Stat(destDir); err == nil {
-		if err := os.RemoveAll(destDir); err != nil {
-			return 0, fmt.Errorf("remove existing plugin directory %q: %w", destDir, err)
-		}
-	}
-
 	assetRoot := "opencode/plugins/" + pluginSddDirName
 	changed := 0
+	expected := map[string]struct{}{}
 
 	err := fs.WalkDir(assets.FS, assetRoot, func(path string, d fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
@@ -112,6 +108,7 @@ func copyEmbeddedPlugin(destDir string) (int, error) {
 		if err != nil {
 			return fmt.Errorf("resolve relative path %q: %w", path, err)
 		}
+		expected[filepath.ToSlash(filepath.Clean(rel))] = struct{}{}
 
 		content, err := assets.Read(path)
 		if err != nil {
@@ -130,6 +127,51 @@ func copyEmbeddedPlugin(destDir string) (int, error) {
 	})
 	if err != nil {
 		return 0, err
+	}
+
+	// Remove stale files that are no longer part of embedded assets.
+	if _, err := os.Stat(destDir); err == nil {
+		dirs := []string{}
+		err = filepath.WalkDir(destDir, func(path string, d fs.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return walkErr
+			}
+
+			if d.IsDir() {
+				dirs = append(dirs, path)
+				return nil
+			}
+
+			rel, err := filepath.Rel(destDir, path)
+			if err != nil {
+				return err
+			}
+			rel = filepath.ToSlash(filepath.Clean(rel))
+
+			if _, ok := expected[rel]; ok {
+				return nil
+			}
+
+			if err := os.Remove(path); err != nil {
+				return fmt.Errorf("remove stale plugin file %q: %w", path, err)
+			}
+			changed++
+			return nil
+		})
+		if err != nil {
+			return 0, err
+		}
+
+		// Try to remove now-empty stale directories bottom-up.
+		sort.Slice(dirs, func(i, j int) bool {
+			return len(dirs[i]) > len(dirs[j])
+		})
+		for _, dir := range dirs {
+			if filepath.Clean(dir) == filepath.Clean(destDir) {
+				continue
+			}
+			_ = os.Remove(dir)
+		}
 	}
 
 	return changed, nil
@@ -228,7 +270,7 @@ type opencodePackageJSON struct {
 // If the file does not exist it is created with the required deps.
 // Existing entries with equal or newer versions are left untouched.
 // Returns a non-empty warning string only when the file could not be written
-// and the caller should inform the user to run `bun install` manually.
+// or validated; the normal successful path returns empty warning.
 func ensureOpencodePackageJSON(opencodeDir string) string {
 	pkgPath := filepath.Join(opencodeDir, "package.json")
 
@@ -289,38 +331,15 @@ func ensureOpencodePackageJSON(opencodeDir string) string {
 	if err != nil {
 		return fmt.Sprintf(
 			"Could not write ~/.config/opencode/package.json: %v\n"+
-				"Run manually: cd %s && bun add %s",
-			err, opencodeDir, joinDeps(added),
+				"OpenCode usually installs plugin dependencies automatically. "+
+				"If the plugin fails to load, run `bun install` (or `npm install`) in %s.",
+			err, opencodeDir,
 		)
 	}
 
-	if result.Changed {
-		actions := []string{}
-		if len(added) > 0 {
-			actions = append(actions, "added missing deps: "+joinDeps(added))
-		}
-		if len(updated) > 0 {
-			actions = append(actions, "updated deps to minimum supported version: "+joinDeps(updated))
-		}
-		return fmt.Sprintf(
-			"Updated package.json (%s)\n"+
-				"Run: cd %s && bun install",
-			joinDeps(actions), opencodeDir,
-		)
-	}
+	_ = result
 
 	return ""
-}
-
-func joinDeps(deps []string) string {
-	result := ""
-	for i, d := range deps {
-		if i > 0 {
-			result += " "
-		}
-		result += d
-	}
-	return result
 }
 
 func isVersionBelowMinimum(current, minimum string) bool {

--- a/internal/components/sdd/plugin_sdd_install.go
+++ b/internal/components/sdd/plugin_sdd_install.go
@@ -1,0 +1,390 @@
+package sdd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/gentleman-programming/gentle-ai/internal/assets"
+	"github.com/gentleman-programming/gentle-ai/internal/components/filemerge"
+)
+
+// pluginSddDirName is the name of the plugin directory as it lives in assets
+// and as it will be installed under ~/.config/opencode/plugins/.
+const pluginSddDirName = "plugin-sdd-opencode"
+
+// pluginSddRegistryKey is the key used to register the plugin in tui.json.
+const pluginSddRegistryKey = "./plugins/" + pluginSddDirName + "/"
+
+// tuiJSONSchema is the $schema value written to tui.json.
+const tuiJSONSchema = "https://opencode.ai/tui.json"
+
+// opencodePackageRequirements lists the dependencies that must be present in
+// ~/.config/opencode/package.json for the plugin to load correctly.
+var opencodePackageRequirements = map[string]string{
+	"@opencode-ai/plugin":    "1.4.2",
+	"unique-names-generator": "^4.7.1",
+}
+
+// opencodePluginMinVersion is the minimum supported version for the runtime
+// plugin API dependency.
+const opencodePluginMinVersion = "1.4.2"
+
+// PluginInstallResult holds the outcome of InstallSddPlugin.
+type PluginInstallResult struct {
+	// FilesChanged is the number of files that were created or updated.
+	FilesChanged int
+	// AlreadyInstalled is true when the plugin was already present and
+	// tui.json already registered it — nothing was written.
+	AlreadyInstalled bool
+	// PackageWarning is non-empty when ~/.config/opencode/package.json is
+	// missing a required dependency. The plugin is still installed but the
+	// user should run `bun install` (or npm install) in that directory.
+	PackageWarning string
+}
+
+// InstallSddPlugin copies the plugin-sdd-opencode directory from embedded
+// assets into ~/.config/opencode/plugins/, writes tui.json with the plugin
+// registration, and validates that ~/.config/opencode/package.json contains
+// the required dependencies.
+//
+// homeDir is the user home directory (os.UserHomeDir()).
+// The function is idempotent: re-running it only writes files that changed.
+func InstallSddPlugin(homeDir string) (PluginInstallResult, error) {
+	opencodeDir := filepath.Join(homeDir, ".config", "opencode")
+	pluginsDir := filepath.Join(opencodeDir, "plugins")
+	destDir := filepath.Join(pluginsDir, pluginSddDirName)
+
+	// 1. Copy all embedded plugin files recursively.
+	filesChanged, err := copyEmbeddedPlugin(destDir)
+	if err != nil {
+		return PluginInstallResult{}, fmt.Errorf("copy plugin-sdd-opencode: %w", err)
+	}
+
+	// 2. Write / update tui.json.
+	tuiChanged, err := writeTUIJSON(opencodeDir)
+	if err != nil {
+		return PluginInstallResult{}, fmt.Errorf("write tui.json: %w", err)
+	}
+	if tuiChanged {
+		filesChanged++
+	}
+
+	// 3. Ensure package.json has required deps — non-fatal, produces a warning only.
+	warning := ensureOpencodePackageJSON(opencodeDir)
+
+	alreadyInstalled := filesChanged == 0 && !tuiChanged
+	return PluginInstallResult{
+		FilesChanged:     filesChanged,
+		AlreadyInstalled: alreadyInstalled,
+		PackageWarning:   warning,
+	}, nil
+}
+
+// copyEmbeddedPlugin removes any existing plugin directory at destDir and
+// copies all files from the embedded asset tree fresh. This ensures stale
+// files from a previous version are never left behind.
+// Returns the number of files written.
+func copyEmbeddedPlugin(destDir string) (int, error) {
+	// Remove existing directory so stale files from older versions are cleaned up.
+	if _, err := os.Stat(destDir); err == nil {
+		if err := os.RemoveAll(destDir); err != nil {
+			return 0, fmt.Errorf("remove existing plugin directory %q: %w", destDir, err)
+		}
+	}
+
+	assetRoot := "opencode/plugins/" + pluginSddDirName
+	changed := 0
+
+	err := fs.WalkDir(assets.FS, assetRoot, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			return nil
+		}
+
+		// Compute relative path from asset root.
+		rel, err := filepath.Rel(assetRoot, path)
+		if err != nil {
+			return fmt.Errorf("resolve relative path %q: %w", path, err)
+		}
+
+		content, err := assets.Read(path)
+		if err != nil {
+			return fmt.Errorf("read embedded asset %q: %w", path, err)
+		}
+
+		dest := filepath.Join(destDir, rel)
+		result, err := filemerge.WriteFileAtomic(dest, []byte(content), 0o644)
+		if err != nil {
+			return fmt.Errorf("write %q: %w", dest, err)
+		}
+		if result.Changed {
+			changed++
+		}
+		return nil
+	})
+	if err != nil {
+		return 0, err
+	}
+
+	return changed, nil
+}
+
+// writeTUIJSON writes ~/.config/opencode/tui.json with the plugin-sdd-opencode
+// entry. If the file already exists and already contains the entry, it is left
+// unchanged (idempotent). Other existing plugin entries are preserved,
+// including tuple-style entries like [path, options].
+func writeTUIJSON(opencodeDir string) (bool, error) {
+	tuiPath := filepath.Join(opencodeDir, "tui.json")
+
+	raw := map[string]json.RawMessage{}
+	plugins := []any{}
+	schema := tuiJSONSchema
+
+	// Read existing tui.json if present.
+	if data, err := os.ReadFile(tuiPath); err == nil {
+		// Best-effort parse — if it fails we start fresh with the correct schema.
+		_ = json.Unmarshal(data, &raw)
+
+		if schemaRaw, ok := raw["$schema"]; ok {
+			_ = json.Unmarshal(schemaRaw, &schema)
+			if schema == "" {
+				schema = tuiJSONSchema
+			}
+		}
+
+		if pluginsRaw, ok := raw["plugin"]; ok {
+			_ = json.Unmarshal(pluginsRaw, &plugins)
+		}
+	}
+
+	// Check if the plugin is already registered.
+	if pluginEntryExists(plugins, pluginSddRegistryKey) {
+		return false, nil // already present, nothing to do
+	}
+
+	// Append the plugin entry.
+	plugins = append(plugins, pluginSddRegistryKey)
+
+	schemaJSON, err := json.Marshal(schema)
+	if err != nil {
+		return false, fmt.Errorf("marshal tui.json schema: %w", err)
+	}
+	raw["$schema"] = schemaJSON
+
+	pluginsJSON, err := json.Marshal(plugins)
+	if err != nil {
+		return false, fmt.Errorf("marshal tui.json plugins: %w", err)
+	}
+	raw["plugin"] = pluginsJSON
+
+	out, err := json.MarshalIndent(raw, "", "  ")
+	if err != nil {
+		return false, fmt.Errorf("marshal tui.json: %w", err)
+	}
+	out = append(out, '\n')
+
+	result, err := filemerge.WriteFileAtomic(tuiPath, out, 0o644)
+	if err != nil {
+		return false, err
+	}
+
+	return result.Changed, nil
+}
+
+func pluginEntryExists(entries []any, target string) bool {
+	for _, entry := range entries {
+		switch v := entry.(type) {
+		case string:
+			if v == target {
+				return true
+			}
+		case []any:
+			if len(v) > 0 {
+				if path, ok := v[0].(string); ok && path == target {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// opencodePackageJSON is the shape of ~/.config/opencode/package.json.
+// We use map[string]json.RawMessage for the top level so we can round-trip
+// unknown fields (scripts, engines, etc.) without losing them.
+type opencodePackageJSON struct {
+	Dependencies    map[string]string `json:"dependencies"`
+	DevDependencies map[string]string `json:"devDependencies"`
+}
+
+// ensureOpencodePackageJSON reads ~/.config/opencode/package.json, adds any
+// required dependencies that are missing, and writes the file back.
+// If the file does not exist it is created with the required deps.
+// Existing entries with equal or newer versions are left untouched.
+// Returns a non-empty warning string only when the file could not be written
+// and the caller should inform the user to run `bun install` manually.
+func ensureOpencodePackageJSON(opencodeDir string) string {
+	pkgPath := filepath.Join(opencodeDir, "package.json")
+
+	// raw holds the full JSON so we preserve all unknown keys on write.
+	raw := map[string]json.RawMessage{}
+
+	data, err := os.ReadFile(pkgPath)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Sprintf("Could not read ~/.config/opencode/package.json: %v", err)
+	}
+	if len(data) > 0 {
+		if err := json.Unmarshal(data, &raw); err != nil {
+			return "Could not parse ~/.config/opencode/package.json — verify it manually."
+		}
+	}
+
+	// Decode the dependencies section (create if absent).
+	deps := map[string]string{}
+	if v, ok := raw["dependencies"]; ok {
+		_ = json.Unmarshal(v, &deps)
+	}
+
+	// Add missing entries and enforce a minimum version for @opencode-ai/plugin.
+	added := []string{}
+	updated := []string{}
+	for pkg, requiredVer := range opencodePackageRequirements {
+		currentVer, exists := deps[pkg]
+		if !exists {
+			deps[pkg] = requiredVer
+			added = append(added, pkg)
+			continue
+		}
+
+		if pkg == "@opencode-ai/plugin" && isVersionBelowMinimum(currentVer, opencodePluginMinVersion) {
+			deps[pkg] = requiredVer
+			updated = append(updated, pkg)
+		}
+	}
+
+	if len(added) == 0 && len(updated) == 0 {
+		return "" // nothing to do
+	}
+
+	// Re-encode the dependencies section.
+	depsJSON, err := json.Marshal(deps)
+	if err != nil {
+		return fmt.Sprintf("Could not encode dependencies for package.json: %v", err)
+	}
+	raw["dependencies"] = depsJSON
+
+	out, err := json.MarshalIndent(raw, "", "  ")
+	if err != nil {
+		return fmt.Sprintf("Could not marshal package.json: %v", err)
+	}
+	out = append(out, '\n')
+
+	result, err := filemerge.WriteFileAtomic(pkgPath, out, 0o644)
+	if err != nil {
+		return fmt.Sprintf(
+			"Could not write ~/.config/opencode/package.json: %v\n"+
+				"Run manually: cd %s && bun add %s",
+			err, opencodeDir, joinDeps(added),
+		)
+	}
+
+	if result.Changed {
+		actions := []string{}
+		if len(added) > 0 {
+			actions = append(actions, "added missing deps: "+joinDeps(added))
+		}
+		if len(updated) > 0 {
+			actions = append(actions, "updated deps to minimum supported version: "+joinDeps(updated))
+		}
+		return fmt.Sprintf(
+			"Updated package.json (%s)\n"+
+				"Run: cd %s && bun install",
+			joinDeps(actions), opencodeDir,
+		)
+	}
+
+	return ""
+}
+
+func joinDeps(deps []string) string {
+	result := ""
+	for i, d := range deps {
+		if i > 0 {
+			result += " "
+		}
+		result += d
+	}
+	return result
+}
+
+func isVersionBelowMinimum(current, minimum string) bool {
+	currentParts, okCurrent := parseSemverPrefix(current)
+	minimumParts, okMinimum := parseSemverPrefix(minimum)
+	if !okMinimum {
+		return false
+	}
+	if !okCurrent {
+		// Unknown/non-semver range like "latest" or workspace aliases:
+		// preserve it instead of guessing.
+		return false
+	}
+
+	for i := 0; i < 3; i++ {
+		if currentParts[i] < minimumParts[i] {
+			return true
+		}
+		if currentParts[i] > minimumParts[i] {
+			return false
+		}
+	}
+	return false
+}
+
+func parseSemverPrefix(v string) ([3]int, bool) {
+	var result [3]int
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return result, false
+	}
+
+	for len(v) > 0 {
+		switch v[0] {
+		case '^', '~', 'v', 'V', '>', '<', '=', ' ':
+			v = v[1:]
+		default:
+			goto cleaned
+		}
+	}
+
+cleaned:
+	if v == "" {
+		return result, false
+	}
+
+	parts := strings.Split(v, ".")
+	if len(parts) < 3 {
+		return result, false
+	}
+
+	for i := 0; i < 3; i++ {
+		num := 0
+		if parts[i] == "" {
+			return result, false
+		}
+		for _, r := range parts[i] {
+			if r < '0' || r > '9' {
+				break
+			}
+			num = num*10 + int(r-'0')
+		}
+		result[i] = num
+	}
+
+	return result, true
+}

--- a/internal/components/sdd/plugin_sdd_install_test.go
+++ b/internal/components/sdd/plugin_sdd_install_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func TestInstallSddPlugin_ReinstallsAndUpdatesConfig(t *testing.T) {
+func TestInstallSddPlugin_IdempotentAndUpdatesConfig(t *testing.T) {
 	home := t.TempDir()
 	opencodeDir := filepath.Join(home, ".config", "opencode")
 	pluginDir := filepath.Join(opencodeDir, "plugins", pluginSddDirName)
@@ -117,6 +117,12 @@ func TestInstallSddPlugin_ReinstallsAndUpdatesConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("second InstallSddPlugin(): %v", err)
 	}
+	if result2.FilesChanged != 0 {
+		t.Fatalf("second install FilesChanged = %d, want 0", result2.FilesChanged)
+	}
+	if !result2.AlreadyInstalled {
+		t.Fatal("second install AlreadyInstalled = false, want true")
+	}
 	if result2.PackageWarning != "" {
 		t.Fatalf("second install PackageWarning = %q, want empty", result2.PackageWarning)
 	}
@@ -157,14 +163,14 @@ func TestInstallSddPlugin_ReinstallsAndUpdatesConfig(t *testing.T) {
 	if got := deps["@opencode-ai/plugin"]; got != "9.9.9" {
 		t.Fatalf("@opencode-ai/plugin version = %v, want preserved existing version 9.9.9", got)
 	}
-	if got := deps["unique-names-generator"]; got != "^4.7.1" {
-		t.Fatalf("unique-names-generator version = %v, want ^4.7.1", got)
+	if _, exists := deps["unique-names-generator"]; exists {
+		t.Fatal("dependencies should not include unique-names-generator")
 	}
 	if _, ok := pkg["scripts"]; !ok {
 		t.Fatal("package.json scripts field was lost during rewrite")
 	}
-	if result.PackageWarning == "" {
-		t.Fatal("PackageWarning = empty, want bun install warning after adding missing deps")
+	if result.PackageWarning != "" {
+		t.Fatalf("PackageWarning = %q, want empty in normal successful flow", result.PackageWarning)
 	}
 
 }
@@ -177,8 +183,8 @@ func TestEnsureOpencodePackageJSON_CreatesFileWhenMissing(t *testing.T) {
 	}
 
 	warning := ensureOpencodePackageJSON(opencodeDir)
-	if warning == "" {
-		t.Fatal("ensureOpencodePackageJSON() warning = empty, want bun install hint")
+	if warning != "" {
+		t.Fatalf("ensureOpencodePackageJSON() warning = %q, want empty in successful flow", warning)
 	}
 
 	pkgBytes, err := os.ReadFile(filepath.Join(opencodeDir, "package.json"))
@@ -192,8 +198,8 @@ func TestEnsureOpencodePackageJSON_CreatesFileWhenMissing(t *testing.T) {
 	if got := pkg.Dependencies["@opencode-ai/plugin"]; got != "1.4.2" {
 		t.Fatalf("@opencode-ai/plugin = %q, want %q", got, "1.4.2")
 	}
-	if got := pkg.Dependencies["unique-names-generator"]; got != "^4.7.1" {
-		t.Fatalf("unique-names-generator = %q, want %q", got, "^4.7.1")
+	if _, exists := pkg.Dependencies["unique-names-generator"]; exists {
+		t.Fatal("dependencies should not include unique-names-generator")
 	}
 }
 
@@ -216,8 +222,8 @@ func TestEnsureOpencodePackageJSON_UpdatesPluginToMinimumWhenTooOld(t *testing.T
 	}
 
 	warning := ensureOpencodePackageJSON(opencodeDir)
-	if warning == "" {
-		t.Fatal("ensureOpencodePackageJSON() warning = empty, want install hint")
+	if warning != "" {
+		t.Fatalf("ensureOpencodePackageJSON() warning = %q, want empty in successful flow", warning)
 	}
 
 	pkgBytes, err := os.ReadFile(filepath.Join(opencodeDir, "package.json"))
@@ -242,8 +248,7 @@ func TestEnsureOpencodePackageJSON_PreservesNewerPluginVersion(t *testing.T) {
 
 	initialPackage := map[string]any{
 		"dependencies": map[string]string{
-			"@opencode-ai/plugin":    "1.9.0",
-			"unique-names-generator": "^4.7.1",
+			"@opencode-ai/plugin": "1.9.0",
 		},
 	}
 	initialPackageBytes, _ := json.MarshalIndent(initialPackage, "", "  ")
@@ -299,8 +304,8 @@ func TestEnsureOpencodePackageJSON_PreservesUnrelatedFields(t *testing.T) {
 	}
 
 	warning := ensureOpencodePackageJSON(opencodeDir)
-	if warning == "" {
-		t.Fatal("ensureOpencodePackageJSON() warning = empty, want install hint after adding missing dep")
+	if warning != "" {
+		t.Fatalf("ensureOpencodePackageJSON() warning = %q, want empty in successful flow", warning)
 	}
 
 	pkgBytes, err := os.ReadFile(filepath.Join(opencodeDir, "package.json"))
@@ -339,8 +344,8 @@ func TestEnsureOpencodePackageJSON_PreservesUnrelatedFields(t *testing.T) {
 	if got := deps["@opencode-ai/plugin"]; got != "1.4.2" {
 		t.Fatalf("dependencies[@opencode-ai/plugin] = %v, want %q", got, "1.4.2")
 	}
-	if got := deps["unique-names-generator"]; got != "^4.7.1" {
-		t.Fatalf("dependencies[unique-names-generator] = %v, want %q", got, "^4.7.1")
+	if _, exists := deps["unique-names-generator"]; exists {
+		t.Fatal("dependencies should not include unique-names-generator")
 	}
 }
 

--- a/internal/components/sdd/plugin_sdd_install_test.go
+++ b/internal/components/sdd/plugin_sdd_install_test.go
@@ -1,0 +1,370 @@
+package sdd
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestInstallSddPlugin_ReinstallsAndUpdatesConfig(t *testing.T) {
+	home := t.TempDir()
+	opencodeDir := filepath.Join(home, ".config", "opencode")
+	pluginDir := filepath.Join(opencodeDir, "plugins", pluginSddDirName)
+
+	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(pluginDir): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(pluginDir, "stale.txt"), []byte("old"), 0o644); err != nil {
+		t.Fatalf("WriteFile(stale.txt): %v", err)
+	}
+
+	initialTUI := map[string]any{
+		"$schema": tuiJSONSchema,
+		"keybinds": map[string]any{
+			"tool_details": "ctrl+alt+t",
+		},
+		"plugin": []any{
+			[]any{
+				"/home/test/opencode-mask/",
+				map[string]any{
+					"enabled":      true,
+					"theme":        "tokyo-night-dev",
+					"set_theme":    true,
+					"show_sidebar": true,
+				},
+			},
+		},
+	}
+	initialTUIBytes, _ := json.MarshalIndent(initialTUI, "", "  ")
+	initialTUIBytes = append(initialTUIBytes, '\n')
+	if err := os.WriteFile(filepath.Join(opencodeDir, "tui.json"), initialTUIBytes, 0o644); err != nil {
+		t.Fatalf("WriteFile(tui.json): %v", err)
+	}
+
+	initialPackage := map[string]any{
+		"name": "opencode-config",
+		"dependencies": map[string]string{
+			"@opencode-ai/plugin": "9.9.9",
+		},
+		"scripts": map[string]string{
+			"dev": "bun run dev",
+		},
+	}
+	initialPackageBytes, _ := json.MarshalIndent(initialPackage, "", "  ")
+	initialPackageBytes = append(initialPackageBytes, '\n')
+	if err := os.WriteFile(filepath.Join(opencodeDir, "package.json"), initialPackageBytes, 0o644); err != nil {
+		t.Fatalf("WriteFile(package.json): %v", err)
+	}
+
+	result, err := InstallSddPlugin(home)
+	if err != nil {
+		t.Fatalf("InstallSddPlugin(): %v", err)
+	}
+	if result.FilesChanged == 0 {
+		t.Fatal("InstallSddPlugin() FilesChanged = 0, want > 0")
+	}
+
+	if _, err := os.Stat(filepath.Join(pluginDir, "stale.txt")); !os.IsNotExist(err) {
+		t.Fatalf("stale plugin file still exists after reinstall")
+	}
+	if _, err := os.Stat(filepath.Join(pluginDir, "index.tsx")); err != nil {
+		t.Fatalf("plugin entry file missing after install: %v", err)
+	}
+
+	tuiBytes, err := os.ReadFile(filepath.Join(opencodeDir, "tui.json"))
+	if err != nil {
+		t.Fatalf("ReadFile(tui.json): %v", err)
+	}
+	var tuiCfg map[string]any
+	if err := json.Unmarshal(tuiBytes, &tuiCfg); err != nil {
+		t.Fatalf("unmarshal tui.json: %v", err)
+	}
+	if got := tuiCfg["$schema"]; got != tuiJSONSchema {
+		t.Fatalf("tui.json schema = %v, want %q", got, tuiJSONSchema)
+	}
+	if _, ok := tuiCfg["keybinds"].(map[string]any); !ok {
+		t.Fatal("tui.json keybinds field was lost during rewrite")
+	}
+	pluginList, ok := tuiCfg["plugin"].([]any)
+	if !ok {
+		t.Fatal("tui.json plugin field is not an array")
+	}
+	count := 0
+	hasTuplePlugin := false
+	for _, p := range pluginList {
+		switch v := p.(type) {
+		case string:
+			if v == pluginSddRegistryKey {
+				count++
+			}
+		case []any:
+			if len(v) > 0 {
+				if path, ok := v[0].(string); ok && path == "/home/test/opencode-mask/" {
+					hasTuplePlugin = true
+				}
+			}
+		}
+	}
+	if !hasTuplePlugin {
+		t.Fatal("existing tuple-style plugin entry was lost from tui.json")
+	}
+	if count != 1 {
+		t.Fatalf("plugin registry count = %d, want 1; plugin list = %v", count, pluginList)
+	}
+
+	result2, err := InstallSddPlugin(home)
+	if err != nil {
+		t.Fatalf("second InstallSddPlugin(): %v", err)
+	}
+	if result2.PackageWarning != "" {
+		t.Fatalf("second install PackageWarning = %q, want empty", result2.PackageWarning)
+	}
+
+	tuiBytes2, err := os.ReadFile(filepath.Join(opencodeDir, "tui.json"))
+	if err != nil {
+		t.Fatalf("ReadFile(tui.json) after second install: %v", err)
+	}
+	if err := json.Unmarshal(tuiBytes2, &tuiCfg); err != nil {
+		t.Fatalf("unmarshal tui.json after second install: %v", err)
+	}
+	pluginList, ok = tuiCfg["plugin"].([]any)
+	if !ok {
+		t.Fatal("tui.json plugin field is not an array after second install")
+	}
+	count = 0
+	for _, p := range pluginList {
+		if s, ok := p.(string); ok && s == pluginSddRegistryKey {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("after second install plugin registry count = %d, want 1; plugin list = %v", count, pluginList)
+	}
+
+	pkgBytes, err := os.ReadFile(filepath.Join(opencodeDir, "package.json"))
+	if err != nil {
+		t.Fatalf("ReadFile(package.json): %v", err)
+	}
+	var pkg map[string]any
+	if err := json.Unmarshal(pkgBytes, &pkg); err != nil {
+		t.Fatalf("unmarshal package.json: %v", err)
+	}
+	deps, ok := pkg["dependencies"].(map[string]any)
+	if !ok {
+		t.Fatal("package.json missing dependencies object")
+	}
+	if got := deps["@opencode-ai/plugin"]; got != "9.9.9" {
+		t.Fatalf("@opencode-ai/plugin version = %v, want preserved existing version 9.9.9", got)
+	}
+	if got := deps["unique-names-generator"]; got != "^4.7.1" {
+		t.Fatalf("unique-names-generator version = %v, want ^4.7.1", got)
+	}
+	if _, ok := pkg["scripts"]; !ok {
+		t.Fatal("package.json scripts field was lost during rewrite")
+	}
+	if result.PackageWarning == "" {
+		t.Fatal("PackageWarning = empty, want bun install warning after adding missing deps")
+	}
+
+}
+
+func TestEnsureOpencodePackageJSON_CreatesFileWhenMissing(t *testing.T) {
+	home := t.TempDir()
+	opencodeDir := filepath.Join(home, ".config", "opencode")
+	if err := os.MkdirAll(opencodeDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(opencodeDir): %v", err)
+	}
+
+	warning := ensureOpencodePackageJSON(opencodeDir)
+	if warning == "" {
+		t.Fatal("ensureOpencodePackageJSON() warning = empty, want bun install hint")
+	}
+
+	pkgBytes, err := os.ReadFile(filepath.Join(opencodeDir, "package.json"))
+	if err != nil {
+		t.Fatalf("ReadFile(package.json): %v", err)
+	}
+	var pkg opencodePackageJSON
+	if err := json.Unmarshal(pkgBytes, &pkg); err != nil {
+		t.Fatalf("unmarshal package.json: %v", err)
+	}
+	if got := pkg.Dependencies["@opencode-ai/plugin"]; got != "1.4.2" {
+		t.Fatalf("@opencode-ai/plugin = %q, want %q", got, "1.4.2")
+	}
+	if got := pkg.Dependencies["unique-names-generator"]; got != "^4.7.1" {
+		t.Fatalf("unique-names-generator = %q, want %q", got, "^4.7.1")
+	}
+}
+
+func TestEnsureOpencodePackageJSON_UpdatesPluginToMinimumWhenTooOld(t *testing.T) {
+	home := t.TempDir()
+	opencodeDir := filepath.Join(home, ".config", "opencode")
+	if err := os.MkdirAll(opencodeDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(opencodeDir): %v", err)
+	}
+
+	initialPackage := map[string]any{
+		"dependencies": map[string]string{
+			"@opencode-ai/plugin": "1.2.0",
+		},
+	}
+	initialPackageBytes, _ := json.MarshalIndent(initialPackage, "", "  ")
+	initialPackageBytes = append(initialPackageBytes, '\n')
+	if err := os.WriteFile(filepath.Join(opencodeDir, "package.json"), initialPackageBytes, 0o644); err != nil {
+		t.Fatalf("WriteFile(package.json): %v", err)
+	}
+
+	warning := ensureOpencodePackageJSON(opencodeDir)
+	if warning == "" {
+		t.Fatal("ensureOpencodePackageJSON() warning = empty, want install hint")
+	}
+
+	pkgBytes, err := os.ReadFile(filepath.Join(opencodeDir, "package.json"))
+	if err != nil {
+		t.Fatalf("ReadFile(package.json): %v", err)
+	}
+	var pkg opencodePackageJSON
+	if err := json.Unmarshal(pkgBytes, &pkg); err != nil {
+		t.Fatalf("unmarshal package.json: %v", err)
+	}
+	if got := pkg.Dependencies["@opencode-ai/plugin"]; got != opencodePluginMinVersion {
+		t.Fatalf("@opencode-ai/plugin = %q, want %q", got, opencodePluginMinVersion)
+	}
+}
+
+func TestEnsureOpencodePackageJSON_PreservesNewerPluginVersion(t *testing.T) {
+	home := t.TempDir()
+	opencodeDir := filepath.Join(home, ".config", "opencode")
+	if err := os.MkdirAll(opencodeDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(opencodeDir): %v", err)
+	}
+
+	initialPackage := map[string]any{
+		"dependencies": map[string]string{
+			"@opencode-ai/plugin":    "1.9.0",
+			"unique-names-generator": "^4.7.1",
+		},
+	}
+	initialPackageBytes, _ := json.MarshalIndent(initialPackage, "", "  ")
+	initialPackageBytes = append(initialPackageBytes, '\n')
+	if err := os.WriteFile(filepath.Join(opencodeDir, "package.json"), initialPackageBytes, 0o644); err != nil {
+		t.Fatalf("WriteFile(package.json): %v", err)
+	}
+
+	warning := ensureOpencodePackageJSON(opencodeDir)
+	if warning != "" {
+		t.Fatalf("ensureOpencodePackageJSON() warning = %q, want empty", warning)
+	}
+
+	pkgBytes, err := os.ReadFile(filepath.Join(opencodeDir, "package.json"))
+	if err != nil {
+		t.Fatalf("ReadFile(package.json): %v", err)
+	}
+	var pkg opencodePackageJSON
+	if err := json.Unmarshal(pkgBytes, &pkg); err != nil {
+		t.Fatalf("unmarshal package.json: %v", err)
+	}
+	if got := pkg.Dependencies["@opencode-ai/plugin"]; got != "1.9.0" {
+		t.Fatalf("@opencode-ai/plugin = %q, want preserved newer version %q", got, "1.9.0")
+	}
+}
+
+func TestEnsureOpencodePackageJSON_PreservesUnrelatedFields(t *testing.T) {
+	home := t.TempDir()
+	opencodeDir := filepath.Join(home, ".config", "opencode")
+	if err := os.MkdirAll(opencodeDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(opencodeDir): %v", err)
+	}
+
+	initialPackage := map[string]any{
+		"name":    "my-opencode-config",
+		"private": true,
+		"scripts": map[string]string{
+			"dev":   "bun run dev",
+			"build": "bun run build",
+		},
+		"dependencies": map[string]string{
+			"@opencode-ai/plugin": "1.4.2",
+		},
+		"devDependencies": map[string]string{
+			"@types/node": "^22.0.0",
+			"bun-types":   "latest",
+		},
+	}
+	initialPackageBytes, _ := json.MarshalIndent(initialPackage, "", "  ")
+	initialPackageBytes = append(initialPackageBytes, '\n')
+	if err := os.WriteFile(filepath.Join(opencodeDir, "package.json"), initialPackageBytes, 0o644); err != nil {
+		t.Fatalf("WriteFile(package.json): %v", err)
+	}
+
+	warning := ensureOpencodePackageJSON(opencodeDir)
+	if warning == "" {
+		t.Fatal("ensureOpencodePackageJSON() warning = empty, want install hint after adding missing dep")
+	}
+
+	pkgBytes, err := os.ReadFile(filepath.Join(opencodeDir, "package.json"))
+	if err != nil {
+		t.Fatalf("ReadFile(package.json): %v", err)
+	}
+	var pkg map[string]any
+	if err := json.Unmarshal(pkgBytes, &pkg); err != nil {
+		t.Fatalf("unmarshal package.json: %v", err)
+	}
+
+	if got := pkg["name"]; got != "my-opencode-config" {
+		t.Fatalf("name = %v, want %q", got, "my-opencode-config")
+	}
+	if got := pkg["private"]; got != true {
+		t.Fatalf("private = %v, want true", got)
+	}
+	if _, ok := pkg["scripts"].(map[string]any); !ok {
+		t.Fatal("scripts field was lost or changed type")
+	}
+	devDeps, ok := pkg["devDependencies"].(map[string]any)
+	if !ok {
+		t.Fatal("devDependencies field was lost or changed type")
+	}
+	if got := devDeps["@types/node"]; got != "^22.0.0" {
+		t.Fatalf("devDependencies[@types/node] = %v, want %q", got, "^22.0.0")
+	}
+	if got := devDeps["bun-types"]; got != "latest" {
+		t.Fatalf("devDependencies[bun-types] = %v, want %q", got, "latest")
+	}
+
+	deps, ok := pkg["dependencies"].(map[string]any)
+	if !ok {
+		t.Fatal("dependencies field was lost or changed type")
+	}
+	if got := deps["@opencode-ai/plugin"]; got != "1.4.2" {
+		t.Fatalf("dependencies[@opencode-ai/plugin] = %v, want %q", got, "1.4.2")
+	}
+	if got := deps["unique-names-generator"]; got != "^4.7.1" {
+		t.Fatalf("dependencies[unique-names-generator] = %v, want %q", got, "^4.7.1")
+	}
+}
+
+func TestIsVersionBelowMinimum(t *testing.T) {
+	tests := []struct {
+		name    string
+		current string
+		minimum string
+		want    bool
+	}{
+		{name: "older exact version", current: "1.2.0", minimum: "1.4.2", want: true},
+		{name: "equal version", current: "1.4.2", minimum: "1.4.2", want: false},
+		{name: "newer version", current: "1.9.0", minimum: "1.4.2", want: false},
+		{name: "caret version older", current: "^1.3.0", minimum: "1.4.2", want: true},
+		{name: "caret version newer", current: "^1.5.0", minimum: "1.4.2", want: false},
+		{name: "unknown tag preserved", current: "latest", minimum: "1.4.2", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isVersionBelowMinimum(tt.current, tt.minimum)
+			if got != tt.want {
+				t.Fatalf("isVersionBelowMinimum(%q, %q) = %v, want %v", tt.current, tt.minimum, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -105,6 +105,11 @@ type AgentBuilderInstallDoneMsg struct {
 	Err     error
 }
 
+// PluginInstallDoneMsg is sent when the plugin installation goroutine completes.
+type PluginInstallDoneMsg struct {
+	Payload screens.PluginInstallPayload
+}
+
 // AgentBuilderState holds all transient state for the agent-builder TUI flow.
 type AgentBuilderState struct {
 	AvailableEngines []model.AgentID
@@ -192,6 +197,7 @@ const (
 	ScreenAgentBuilderPreview
 	ScreenAgentBuilderInstalling
 	ScreenAgentBuilderComplete
+	ScreenPluginInstall
 )
 
 type Model struct {
@@ -328,6 +334,9 @@ type Model struct {
 
 	// AgentBuilder holds the transient state for the agent-builder TUI flow.
 	AgentBuilder AgentBuilderState
+
+	// PluginInstallPayload holds the result of the last "Install OpenCode Plugin" run.
+	PluginInstallPayload screens.PluginInstallPayload
 }
 
 func NewModel(detection system.DetectionResult, version string) Model {
@@ -420,6 +429,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.AgentBuilder.InstallErr = nil
 			m.setScreen(ScreenAgentBuilderComplete)
 		}
+		return m, nil
+	case PluginInstallDoneMsg:
+		m.PluginInstallPayload = msg.Payload
+		m.setScreen(ScreenPluginInstall)
 		return m, nil
 	case StepProgressMsg:
 		return m.handleStepProgress(msg)
@@ -674,6 +687,8 @@ func (m Model) View() string {
 		return screens.RenderABInstalling(engineName, m.SpinnerFrame, m.AgentBuilder.InstallErr)
 	case ScreenAgentBuilderComplete:
 		return screens.RenderABComplete(m.AgentBuilder.Generated, m.AgentBuilder.InstallResults)
+	case ScreenPluginInstall:
+		return screens.RenderPluginInstall(m.PluginInstallPayload)
 	default:
 		return ""
 	}
@@ -942,6 +957,9 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 			m.AgentBuilder.Textarea = ta
 			m.setScreen(ScreenAgentBuilderEngine)
 		case 6:
+			// "Install OpenCode Plugin" — always visible.
+			return m, m.startPluginInstall()
+		case 7:
 			if m.hasDetectedOpenCode() {
 				// "OpenCode SDD Profiles" (only shown when OpenCode is detected)
 				m.setScreen(ScreenProfiles)
@@ -949,7 +967,7 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 				// "Manage backups"
 				m.setScreen(ScreenBackups)
 			}
-		case 7:
+		case 8:
 			if m.hasDetectedOpenCode() {
 				// "Manage backups"
 				m.setScreen(ScreenBackups)
@@ -957,7 +975,7 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 				// "Quit"
 				return m, tea.Quit
 			}
-		case 8:
+		case 9:
 			// "Quit" (only reachable when showProfiles is true, so OpenCode is detected)
 			return m, tea.Quit
 		}
@@ -1593,6 +1611,8 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 		}
 	case ScreenAgentBuilderComplete:
 		m.setScreen(ScreenWelcome)
+	case ScreenPluginInstall:
+		m.setScreen(ScreenWelcome)
 	}
 
 	return m, nil
@@ -1699,6 +1719,28 @@ func (m Model) startSync(overrides *model.SyncOverrides) tea.Cmd {
 		}
 		filesChanged, err := syncFn(overrides)
 		return SyncDoneMsg{FilesChanged: filesChanged, Err: err}
+	}
+}
+
+// startPluginInstall runs the plugin-sdd-opencode installation in a goroutine
+// and sends PluginInstallDoneMsg when it completes.
+func (m Model) startPluginInstall() tea.Cmd {
+	return func() tea.Msg {
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return PluginInstallDoneMsg{Payload: screens.PluginInstallPayload{
+				Err: fmt.Errorf("resolve home directory: %w", err),
+			}}
+		}
+		result, err := sdd.InstallSddPlugin(homeDir)
+		if err != nil {
+			return PluginInstallDoneMsg{Payload: screens.PluginInstallPayload{Err: err}}
+		}
+		return PluginInstallDoneMsg{Payload: screens.PluginInstallPayload{
+			FilesChanged:     result.FilesChanged,
+			AlreadyInstalled: result.AlreadyInstalled,
+			PackageWarning:   result.PackageWarning,
+		}}
 	}
 }
 

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -824,33 +824,33 @@ func TestWelcomeMenu_ConfigureModelsNavigation(t *testing.T) {
 	}
 }
 
-// TestWelcomeMenu_BackupsNavigation verifies cursor 6 (Manage backups) goes to ScreenBackups.
+// TestWelcomeMenu_BackupsNavigation verifies cursor 7 (Manage backups) goes to ScreenBackups.
 func TestWelcomeMenu_BackupsNavigation(t *testing.T) {
 	m := NewModel(system.DetectionResult{}, "dev")
 	m.Screen = ScreenWelcome
-	m.Cursor = 6
+	m.Cursor = 7
 
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	state := updated.(Model)
 
 	if state.Screen != ScreenBackups {
-		t.Fatalf("cursor=6 (Backups): screen = %v, want %v", state.Screen, ScreenBackups)
+		t.Fatalf("cursor=7 (Backups): screen = %v, want %v", state.Screen, ScreenBackups)
 	}
 }
 
-// TestWelcomeMenu_OptionCount verifies the welcome menu has 8 items without OpenCode
-// and 9 items when OpenCode is detected (adds "OpenCode SDD Profiles" option).
+// TestWelcomeMenu_OptionCount verifies the welcome menu has 9 items without OpenCode
+// and 10 items when OpenCode is detected (adds "OpenCode SDD Profiles" option).
 func TestWelcomeMenu_OptionCount(t *testing.T) {
 	m := NewModel(system.DetectionResult{}, "dev")
-	// Without OpenCode detected: 8 options (includes "Create your own Agent").
+	// Without OpenCode detected: 9 options (includes "Install OpenCode Plugin").
 	opts := screens.WelcomeOptions(m.UpdateResults, m.UpdateCheckDone, false, 0, true)
-	if len(opts) != 8 {
-		t.Fatalf("WelcomeOptions(showProfiles=false) len = %d, want 8; got %v", len(opts), opts)
+	if len(opts) != 9 {
+		t.Fatalf("WelcomeOptions(showProfiles=false) len = %d, want 9; got %v", len(opts), opts)
 	}
-	// With OpenCode detected: 9 options (adds "OpenCode SDD Profiles").
+	// With OpenCode detected: 10 options (adds "OpenCode SDD Profiles").
 	optsWithProfiles := screens.WelcomeOptions(m.UpdateResults, m.UpdateCheckDone, true, 0, true)
-	if len(optsWithProfiles) != 9 {
-		t.Fatalf("WelcomeOptions(showProfiles=true) len = %d, want 9; got %v", len(optsWithProfiles), optsWithProfiles)
+	if len(optsWithProfiles) != 10 {
+		t.Fatalf("WelcomeOptions(showProfiles=true) len = %d, want 10; got %v", len(optsWithProfiles), optsWithProfiles)
 	}
 }
 
@@ -2753,12 +2753,12 @@ func TestPinErrClearedOnScreenReentry(t *testing.T) {
 		t.Fatalf("Esc from ScreenBackups: screen = %v, want ScreenWelcome", afterEsc.Screen)
 	}
 
-	// Navigate back to ScreenBackups (cursor 6 on Welcome → enter).
-	afterEsc.Cursor = 6
+	// Navigate back to ScreenBackups (cursor 7 on Welcome → enter).
+	afterEsc.Cursor = 7
 	updated2, _ := afterEsc.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	afterReturn := updated2.(Model)
 	if afterReturn.Screen != ScreenBackups {
-		t.Fatalf("Enter cursor=6 from ScreenWelcome: screen = %v, want ScreenBackups", afterReturn.Screen)
+		t.Fatalf("Enter cursor=7 from ScreenWelcome: screen = %v, want ScreenBackups", afterReturn.Screen)
 	}
 
 	// PinErr must be cleared on re-entry.

--- a/internal/tui/plugin_install_test.go
+++ b/internal/tui/plugin_install_test.go
@@ -1,0 +1,39 @@
+package tui
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/gentleman-programming/gentle-ai/internal/system"
+)
+
+func TestWelcomeMenu_PluginInstallNavigation(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Screen = ScreenWelcome
+	m.Cursor = 6
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	state := updated.(Model)
+	if cmd == nil {
+		t.Fatal("plugin install command = nil, want command")
+	}
+
+	msg := cmd()
+	updated, _ = state.Update(msg)
+	state = updated.(Model)
+
+	if state.Screen != ScreenPluginInstall {
+		t.Fatalf("screen = %v, want %v", state.Screen, ScreenPluginInstall)
+	}
+	if state.PluginInstallPayload.Err != nil {
+		t.Fatalf("PluginInstallPayload.Err = %v, want nil", state.PluginInstallPayload.Err)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".config", "opencode", "plugins", "plugin-sdd-opencode", "index.tsx")); err != nil {
+		t.Fatalf("installed plugin file not found: %v", err)
+	}
+}

--- a/internal/tui/router.go
+++ b/internal/tui/router.go
@@ -41,6 +41,7 @@ var linearRoutes = map[Screen]Route{
 	ScreenAgentBuilderPreview:    {Backward: ScreenAgentBuilderPrompt},
 	ScreenAgentBuilderInstalling: {Forward: ScreenAgentBuilderComplete},
 	ScreenAgentBuilderComplete:   {Backward: ScreenWelcome},
+	ScreenPluginInstall:          {Backward: ScreenWelcome},
 }
 
 func NextScreen(screen Screen) (Screen, bool) {

--- a/internal/tui/screens/plugin_sdd_screen.go
+++ b/internal/tui/screens/plugin_sdd_screen.go
@@ -1,0 +1,71 @@
+package screens
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/gentleman-programming/gentle-ai/internal/tui/styles"
+)
+
+// PluginInstallPayload holds everything the plugin install result screen needs.
+type PluginInstallPayload struct {
+	// FilesChanged is the number of files written during installation.
+	FilesChanged int
+	// AlreadyInstalled is true when the plugin was already present and up to date.
+	AlreadyInstalled bool
+	// PackageWarning is non-empty when package.json is missing required deps.
+	PackageWarning string
+	// Err is non-nil when the installation failed.
+	Err error
+}
+
+// RenderPluginInstall renders the result of the "Install OpenCode Plugin" operation.
+func RenderPluginInstall(payload PluginInstallPayload) string {
+	var b strings.Builder
+
+	b.WriteString(styles.TitleStyle.Render("Install OpenCode Plugin"))
+	b.WriteString("\n\n")
+
+	if payload.Err != nil {
+		b.WriteString(styles.ErrorStyle.Render("✗ Installation failed"))
+		b.WriteString("\n\n")
+		b.WriteString(styles.SubtextStyle.Render(payload.Err.Error()))
+		b.WriteString("\n\n")
+		b.WriteString(styles.HelpStyle.Render("Check your configuration and try again."))
+		b.WriteString("\n\n")
+		b.WriteString(styles.HelpStyle.Render("enter: return • esc: back • q: quit"))
+		return b.String()
+	}
+
+	if payload.AlreadyInstalled {
+		b.WriteString(styles.SuccessStyle.Render("✓ Plugin already installed"))
+		b.WriteString("\n\n")
+		b.WriteString(styles.SubtextStyle.Render("plugin-sdd-opencode is up to date."))
+		b.WriteString("\n")
+		b.WriteString(styles.SubtextStyle.Render("tui.json already contains the plugin entry."))
+	} else {
+		b.WriteString(styles.SuccessStyle.Render("✓ Plugin installed"))
+		b.WriteString("\n\n")
+		b.WriteString(styles.SubtextStyle.Render("plugin-sdd-opencode copied to ~/.config/opencode/plugins/"))
+		b.WriteString("\n")
+		b.WriteString(styles.SubtextStyle.Render("tui.json updated with plugin entry."))
+		if payload.FilesChanged > 0 {
+			b.WriteString("\n")
+			b.WriteString(styles.UnselectedStyle.Render(
+				strings.Repeat(" ", 2) + fmt.Sprintf("%d file(s) written.", payload.FilesChanged),
+			))
+		}
+	}
+
+	if payload.PackageWarning != "" {
+		b.WriteString("\n\n")
+		b.WriteString(styles.WarningStyle.Render("⚠ " + payload.PackageWarning))
+	}
+
+	b.WriteString("\n\n")
+	b.WriteString(styles.HelpStyle.Render("Restart OpenCode to activate the plugin."))
+	b.WriteString("\n\n")
+	b.WriteString(styles.HelpStyle.Render("enter: return • esc: back • q: quit"))
+
+	return b.String()
+}

--- a/internal/tui/screens/plugin_sdd_screen.go
+++ b/internal/tui/screens/plugin_sdd_screen.go
@@ -9,11 +9,11 @@ import (
 
 // PluginInstallPayload holds everything the plugin install result screen needs.
 type PluginInstallPayload struct {
-	// FilesChanged is the number of files written during installation.
+	// FilesChanged is the number of files written or removed during installation sync.
 	FilesChanged int
 	// AlreadyInstalled is true when the plugin was already present and up to date.
 	AlreadyInstalled bool
-	// PackageWarning is non-empty when package.json is missing required deps.
+	// PackageWarning is non-empty only for exceptional package.json read/write/validation issues.
 	PackageWarning string
 	// Err is non-nil when the installation failed.
 	Err error

--- a/internal/tui/screens/welcome.go
+++ b/internal/tui/screens/welcome.go
@@ -34,6 +34,7 @@ func WelcomeOptions(updateResults []update.UpdateResult, updateCheckDone bool, s
 		"Upgrade + Sync",
 		"Configure models",
 		agentLabel,
+		"Install OpenCode Plugin",
 	}
 
 	if showProfiles {

--- a/internal/tui/screens/welcome_test.go
+++ b/internal/tui/screens/welcome_test.go
@@ -66,25 +66,25 @@ func TestWelcomeOptions_WithProfiles_CountOne(t *testing.T) {
 	}
 }
 
-// TestWelcomeOptions_OptionCount_WithoutProfiles verifies 8 options when showProfiles=false
+// TestWelcomeOptions_OptionCount_WithoutProfiles verifies 9 options when showProfiles=false
 // and hasEngines=true (agent option visible).
 func TestWelcomeOptions_OptionCount_WithoutProfiles(t *testing.T) {
 	opts := screens.WelcomeOptions(nil, true, false, 0, true)
 	// Expected: Start installation, Upgrade tools, Sync configs, Upgrade + Sync,
-	// Configure models, Create your own Agent, Manage backups, Quit = 8
-	want := 8
+	// Configure models, Create your own Agent, Install OpenCode Plugin, Manage backups, Quit = 9
+	want := 9
 	if len(opts) != want {
 		t.Errorf("WelcomeOptions(showProfiles=false, hasEngines=true) = %d options, want %d; opts: %v", len(opts), want, opts)
 	}
 }
 
-// TestWelcomeOptions_OptionCount_WithProfiles verifies 9 options when showProfiles=true
+// TestWelcomeOptions_OptionCount_WithProfiles verifies 10 options when showProfiles=true
 // and hasEngines=true.
 func TestWelcomeOptions_OptionCount_WithProfiles(t *testing.T) {
 	opts := screens.WelcomeOptions(nil, true, true, 2, true)
 	// Expected: Start installation, Upgrade tools, Sync configs, Upgrade + Sync,
-	// Configure models, Create your own Agent, OpenCode SDD Profiles (2), Manage backups, Quit = 9
-	want := 9
+	// Configure models, Create your own Agent, Install OpenCode Plugin, OpenCode SDD Profiles (2), Manage backups, Quit = 10
+	want := 10
 	if len(opts) != want {
 		t.Errorf("WelcomeOptions(showProfiles=true, hasEngines=true) = %d options, want %d; opts: %v", len(opts), want, opts)
 	}
@@ -105,17 +105,22 @@ func TestWelcomeOptions_NoEngines_ShowsDisabledLabel(t *testing.T) {
 	}
 }
 
-// TestWelcomeOptions_ProfilesInsertedBeforeManageBackups verifies the ordering:
-// profiles option sits between "Create your own Agent" and "Manage backups".
-func TestWelcomeOptions_ProfilesInsertedBeforeManageBackups(t *testing.T) {
+// TestWelcomeOptions_PluginAndProfilesOrdering verifies the ordering:
+// install plugin sits after "Create your own Agent", profiles after that,
+// and then "Manage backups".
+func TestWelcomeOptions_PluginAndProfilesOrdering(t *testing.T) {
 	opts := screens.WelcomeOptions(nil, true, true, 1, true)
 
 	agentIdx := -1
+	pluginIdx := -1
 	profilesIdx := -1
 	manageBackupsIdx := -1
 	for i, opt := range opts {
 		if strings.HasPrefix(opt, "Create your own Agent") {
 			agentIdx = i
+		}
+		if opt == "Install OpenCode Plugin" {
+			pluginIdx = i
 		}
 		if strings.HasPrefix(opt, "OpenCode SDD Profiles") {
 			profilesIdx = i
@@ -128,6 +133,9 @@ func TestWelcomeOptions_ProfilesInsertedBeforeManageBackups(t *testing.T) {
 	if agentIdx < 0 {
 		t.Fatal("option 'Create your own Agent' not found")
 	}
+	if pluginIdx < 0 {
+		t.Fatal("option 'Install OpenCode Plugin' not found")
+	}
 	if profilesIdx < 0 {
 		t.Fatal("option 'OpenCode SDD Profiles' not found")
 	}
@@ -135,9 +143,13 @@ func TestWelcomeOptions_ProfilesInsertedBeforeManageBackups(t *testing.T) {
 		t.Fatal("option 'Manage backups' not found")
 	}
 
-	if profilesIdx != agentIdx+1 {
-		t.Errorf("profiles option at index %d, expected %d (right after 'Create your own Agent' at %d)",
-			profilesIdx, agentIdx+1, agentIdx)
+	if pluginIdx != agentIdx+1 {
+		t.Errorf("plugin option at index %d, expected %d (right after 'Create your own Agent' at %d)",
+			pluginIdx, agentIdx+1, agentIdx)
+	}
+	if profilesIdx != pluginIdx+1 {
+		t.Errorf("profiles option at index %d, expected %d (right after plugin at %d)",
+			profilesIdx, pluginIdx+1, pluginIdx)
 	}
 	if manageBackupsIdx != profilesIdx+1 {
 		t.Errorf("'Manage backups' at index %d, expected %d (right after profiles at %d)",


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #270

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [ ] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [x] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Integrates the OpenCode `plugin-sdd` installation flow into the TUI so users can enable the plugin as part of the SDD setup.
- Adds the bundled plugin assets for profile management and project-scoped Engram memory viewing directly from OpenCode.
- Includes follow-up fixes so profile activation preserves declarative config links and memory lookup works reliably across project name variants.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/components/sdd/plugin_sdd_install.go` | Added the plugin installation step and integration flow for OpenCode SDD setup |
| `internal/components/sdd/plugin_sdd_install_test.go` | Added coverage for plugin installation behavior |
| `internal/tui/plugin_install_test.go` | Added TUI-level coverage for plugin install integration |
| `internal/tui/model.go`, `internal/tui/router.go`, `internal/tui/screens/plugin_sdd_screen.go`, `internal/tui/screens/welcome.go` | Wired the new install flow into the TUI navigation and screens |
| `internal/assets/opencode/plugins/plugin-sdd-opencode/**` | Added the bundled OpenCode plugin, profile management, memory viewer, and subsequent bug fixes |
| `docs/prd-plugin-visual-opencode.md` | Added product/design documentation for the plugin work |

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./...
```

**E2E Tests** (Docker required)
```bash
cd e2e && ./docker-test.sh
```

- [ ] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [ ] Manually tested locally

Additional notes:
- PR created from the current branch state after rebasing on top of the latest `upstream/main`.

---

## 🤖 Automated Checks

The following checks run automatically on this PR:

| Check | Status | Description |
|-------|--------|-------------|
| Check Issue Reference | ⏳ | PR body must contain `Closes/Fixes/Resolves #N` |
| Check Issue Has `status:approved` | ⏳ | Linked issue must have been approved before work began |
| Check PR Has `type:*` Label | ⏳ | Exactly one `type:*` label must be applied |
| Unit Tests | ⏳ | `go test ./...` must pass |
| E2E Tests | ⏳ | `cd e2e && ./docker-test.sh` must pass |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [ ] I have added the appropriate `type:*` label to this PR
- [ ] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

- The branch includes the main feature work from issue #270 plus a follow-up bugfix commit needed to stabilize the plugin behavior before review.