### PR TITLE
fix(skill-creator): do not hardcode author in template and docs

### DIFF
--- a/internal/assets/skills/skill-creator/SKILL.md
+++ b/internal/assets/skills/skill-creator/SKILL.md
@@ -49,7 +49,7 @@ description: >
   Trigger: {When the AI should load this skill}.
 license: Apache-2.0
 metadata:
-  author: gentleman-programming
+  author: "{your-github-username}"
   version: "1.0"
 ---
 
@@ -111,7 +111,7 @@ Link to external guides?    → references/ (with local path)
 | `name` | Yes | Skill identifier (lowercase, hyphens) |
 | `description` | Yes | What + Trigger in one block |
 | `license` | Yes | Always `Apache-2.0` |
-| `metadata.author` | Yes | `gentleman-programming` |
+| `metadata.author` | Yes | Author's GitHub username — infer from `git config user.name` or ask the user. Do NOT hardcode. |
 | `metadata.version` | Yes | Semantic version as string |
 
 ---

--- a/testdata/golden/skills-claude-skill-creator.golden
+++ b/testdata/golden/skills-claude-skill-creator.golden
@@ -49,7 +49,7 @@ description: >
   Trigger: {When the AI should load this skill}.
 license: Apache-2.0
 metadata:
-  author: gentleman-programming
+  author: "{your-github-username}"
   version: "1.0"
 ---
 
@@ -111,7 +111,7 @@ Link to external guides?    → references/ (with local path)
 | `name` | Yes | Skill identifier (lowercase, hyphens) |
 | `description` | Yes | What + Trigger in one block |
 | `license` | Yes | Always `Apache-2.0` |
-| `metadata.author` | Yes | `gentleman-programming` |
+| `metadata.author` | Yes | Author's GitHub username — infer from `git config user.name` or ask the user. Do NOT hardcode. |
 | `metadata.version` | Yes | Semantic version as string |
 
 ---

--- a/testdata/golden/skills-opencode-skill-creator.golden
+++ b/testdata/golden/skills-opencode-skill-creator.golden
@@ -49,7 +49,7 @@ description: >
   Trigger: {When the AI should load this skill}.
 license: Apache-2.0
 metadata:
-  author: gentleman-programming
+  author: "{your-github-username}"
   version: "1.0"
 ---
 
@@ -111,7 +111,7 @@ Link to external guides?    → references/ (with local path)
 | `name` | Yes | Skill identifier (lowercase, hyphens) |
 | `description` | Yes | What + Trigger in one block |
 | `license` | Yes | Always `Apache-2.0` |
-| `metadata.author` | Yes | `gentleman-programming` |
+| `metadata.author` | Yes | Author's GitHub username — infer from `git config user.name` or ask the user. Do NOT hardcode. |
 | `metadata.version` | Yes | Semantic version as string |
 
 ---

--- a/testdata/golden/skills-windsurf-skill-creator.golden
+++ b/testdata/golden/skills-windsurf-skill-creator.golden
@@ -49,7 +49,7 @@ description: >
   Trigger: {When the AI should load this skill}.
 license: Apache-2.0
 metadata:
-  author: gentleman-programming
+  author: "{your-github-username}"
   version: "1.0"
 ---
 
@@ -111,7 +111,7 @@ Link to external guides?    → references/ (with local path)
 | `name` | Yes | Skill identifier (lowercase, hyphens) |
 | `description` | Yes | What + Trigger in one block |
 | `license` | Yes | Always `Apache-2.0` |
-| `metadata.author` | Yes | `gentleman-programming` |
+| `metadata.author` | Yes | Author's GitHub username — infer from `git config user.name` or ask the user. Do NOT hardcode. |
 | `metadata.version` | Yes | Semantic version as string |
 
 ---


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #98

## 🏷️ PR Type

- [x] \`type:bug\` — Bug fix (non-breaking change that fixes an issue)

## 📝 Summary

The \`skill-creator\` skill's SKILL.md template and the Frontmatter Fields table both instructed every generated skill to set \`metadata.author: gentleman-programming\`, so skills created by any user ended up attributed to the wrong author (reporter of #98 had 17 skills misattributed before noticing).

This PR replaces the hardcoded value in the template with a \`{your-github-username}\` placeholder and rewrites the docs row to instruct the AI to infer the author from \`git config user.name\` or ask the user — never hardcode.

The skill-creator's own frontmatter author is intentionally kept, since that file IS authored by gentleman-programming.

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| \`internal/assets/skills/skill-creator/SKILL.md\` | Template author → \`{your-github-username}\` placeholder; docs row now instructs inference, not a hardcoded value |
| \`testdata/golden/skills-claude-skill-creator.golden\` | Regenerated via \`go test ./internal/components/ -run Golden -update\` |
| \`testdata/golden/skills-opencode-skill-creator.golden\` | Same |
| \`testdata/golden/skills-windsurf-skill-creator.golden\` | Same |

Total: 4 files, +8/-8.

## 🧪 Test Plan

- [x] Unit tests pass (\`go test ./...\`)
- [x] \`go vet ./...\` clean
- [ ] E2E tests pass (\`cd e2e && ./docker-test.sh\`) — not run locally (Docker not available in this environment)
- [x] Manually inspected diff: only the intended 3 lines changed in the asset, goldens mirror exactly

## ✅ Contributor Checklist

- [x] PR is linked to an issue with \`status:approved\` (#98)
- [x] I have added the appropriate \`type:*\` label to this PR
- [x] Unit tests pass (\`go test ./...\`)
- [ ] E2E tests pass (\`cd e2e && ./docker-test.sh\`) — see test plan note above
- [x] I have updated documentation if necessary (docs row in the skill itself)
- [x] My commits follow Conventional Commits format
- [x] My commits do not include \`Co-Authored-By\` trailers