### PR TITLE
fix(persona): strip stale Gentleman outputStyle when switching to Neutral

### DIFF
--- a/internal/components/filemerge/json_merge.go
+++ b/internal/components/filemerge/json_merge.go
@@ -30,6 +30,16 @@ func MergeJSONObjects(baseJSON []byte, overlayJSON []byte) ([]byte, error) {
 	return append(encoded, '\n'), nil
 }
 
+// UnmarshalJSONTolerant parses a JSON object while tolerating JSONC-style
+// features that frequent user-edited config files carry: line/block comments
+// and trailing commas. Callers that only need a plain map[string]any — with
+// the same parsing rules used by MergeJSONObjects — should use this helper
+// instead of json.Unmarshal directly so JSONC inputs are not silently
+// rejected.
+func UnmarshalJSONTolerant(raw []byte) (map[string]any, error) {
+	return unmarshalJSONObject(raw)
+}
+
 func unmarshalJSONObject(raw []byte) (map[string]any, error) {
 	object := map[string]any{}
 	if len(bytes.TrimSpace(raw)) == 0 {

--- a/internal/components/persona/inject.go
+++ b/internal/components/persona/inject.go
@@ -1,6 +1,8 @@
 package persona
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -216,7 +218,66 @@ func Inject(homeDir string, adapter agents.Adapter, persona model.PersonaID) (In
 		}
 	}
 
+	// 4. Non-Gentleman personas: strip any stale "outputStyle": "Gentleman"
+	// entry left behind by a previous Gentleman install. The key is only
+	// removed when its value is exactly "Gentleman" — a user-configured
+	// custom style (e.g. "MyStyle") is preserved untouched.
+	if persona == model.PersonaNeutral && adapter.SupportsOutputStyles() {
+		settingsPath := adapter.SettingsPath(homeDir)
+		if settingsPath != "" {
+			removeResult, err := removeGentlemanOutputStyle(settingsPath)
+			if err != nil {
+				return InjectionResult{}, err
+			}
+			if removeResult.Changed {
+				changed = true
+				files = append(files, settingsPath)
+			}
+		}
+	}
+
 	return InjectionResult{Changed: changed, Files: files}, nil
+}
+
+// removeGentlemanOutputStyle strips the "outputStyle": "Gentleman" entry from
+// a settings.json file written by a prior Gentleman install. The key is only
+// removed when its value is exactly "Gentleman"; any user-configured custom
+// value is left in place. Missing files, empty files, and malformed JSON are
+// treated as no-ops.
+func removeGentlemanOutputStyle(path string) (filemerge.WriteResult, error) {
+	baseJSON, err := osReadFile(path)
+	if err != nil {
+		return filemerge.WriteResult{}, err
+	}
+	if len(bytes.TrimSpace(baseJSON)) == 0 {
+		return filemerge.WriteResult{}, nil
+	}
+
+	var obj map[string]any
+	if err := json.Unmarshal(baseJSON, &obj); err != nil {
+		// Malformed settings.json — same policy as MergeJSONObjects:
+		// leave the user's file alone rather than aborting the install.
+		return filemerge.WriteResult{}, nil
+	}
+
+	value, present := obj["outputStyle"]
+	if !present {
+		return filemerge.WriteResult{}, nil
+	}
+	str, isStr := value.(string)
+	if !isStr || str != "Gentleman" {
+		// User has a custom output style — preserve it.
+		return filemerge.WriteResult{}, nil
+	}
+
+	delete(obj, "outputStyle")
+	encoded, err := json.MarshalIndent(obj, "", "  ")
+	if err != nil {
+		return filemerge.WriteResult{}, fmt.Errorf("marshal settings json: %w", err)
+	}
+	encoded = append(encoded, '\n')
+
+	return filemerge.WriteFileAtomic(path, encoded, 0o644)
 }
 
 func personaContent(agent model.AgentID, persona model.PersonaID) string {

--- a/internal/components/persona/inject.go
+++ b/internal/components/persona/inject.go
@@ -244,6 +244,12 @@ func Inject(homeDir string, adapter agents.Adapter, persona model.PersonaID) (In
 // removed when its value is exactly "Gentleman"; any user-configured custom
 // value is left in place. Missing files, empty files, and malformed JSON are
 // treated as no-ops.
+//
+// Parsing goes through filemerge.UnmarshalJSONTolerant so JSONC-style line
+// comments and trailing commas are accepted — matching the tolerance that
+// MergeJSONObjects uses on the write side. Without this, users who
+// hand-edited their settings.json with comments would silently fall into the
+// malformed-JSON no-op branch and the stale key would never be cleaned up.
 func removeGentlemanOutputStyle(path string) (filemerge.WriteResult, error) {
 	baseJSON, err := osReadFile(path)
 	if err != nil {
@@ -253,8 +259,8 @@ func removeGentlemanOutputStyle(path string) (filemerge.WriteResult, error) {
 		return filemerge.WriteResult{}, nil
 	}
 
-	var obj map[string]any
-	if err := json.Unmarshal(baseJSON, &obj); err != nil {
+	obj, err := filemerge.UnmarshalJSONTolerant(baseJSON)
+	if err != nil {
 		// Malformed settings.json — same policy as MergeJSONObjects:
 		// leave the user's file alone rather than aborting the install.
 		return filemerge.WriteResult{}, nil

--- a/internal/components/persona/inject_test.go
+++ b/internal/components/persona/inject_test.go
@@ -269,6 +269,92 @@ func TestInjectClaudeNeutralPreservesUserCustomOutputStyle(t *testing.T) {
 	}
 }
 
+func TestInjectClaudeNeutralRemovesGentlemanOutputStyleFromJSONCSettings(t *testing.T) {
+	// Hand-edited Claude Code settings.json files frequently carry VS Code-style
+	// line comments and trailing commas. The cleanup path must tolerate that
+	// — a plain json.Unmarshal would silently reject the file and leave the
+	// stale "Gentleman" key in place.
+	home := t.TempDir()
+
+	settingsDir := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(settingsDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	existing := `{
+  // style set by gentle-ai
+  "outputStyle": "Gentleman",
+  "permissions": {"allow": ["Read"]},
+}`
+	settingsPath := filepath.Join(settingsDir, "settings.json")
+	if err := os.WriteFile(settingsPath, []byte(existing), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	if _, err := Inject(home, claudeAdapter(), model.PersonaNeutral); err != nil {
+		t.Fatalf("Inject() error = %v", err)
+	}
+
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("rewritten settings is not valid JSON: %v\ncontent: %s", err, data)
+	}
+	if _, present := parsed["outputStyle"]; present {
+		t.Fatalf("Neutral persona left outputStyle in JSONC settings.json: %s", data)
+	}
+	if _, ok := parsed["permissions"]; !ok {
+		t.Fatalf("Neutral persona dropped unrelated 'permissions' key: %s", data)
+	}
+}
+
+func TestInjectClaudeNeutralRemovesGentlemanOutputStyleIsIdempotent(t *testing.T) {
+	home := t.TempDir()
+
+	settingsDir := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(settingsDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	existing := `{"outputStyle": "Gentleman", "permissions": {"allow": ["Read"]}}`
+	settingsPath := filepath.Join(settingsDir, "settings.json")
+	if err := os.WriteFile(settingsPath, []byte(existing), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	// First call removes the stale key.
+	firstResult, err := Inject(home, claudeAdapter(), model.PersonaNeutral)
+	if err != nil {
+		t.Fatalf("first Inject() error = %v", err)
+	}
+	if !firstResult.Changed {
+		t.Fatalf("first Inject() should report Changed=true")
+	}
+	firstBytes, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("ReadFile after first Inject: %v", err)
+	}
+
+	// Second call must be a no-op on settings.json — the key is already gone.
+	secondResult, err := Inject(home, claudeAdapter(), model.PersonaNeutral)
+	if err != nil {
+		t.Fatalf("second Inject() error = %v", err)
+	}
+	secondBytes, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("ReadFile after second Inject: %v", err)
+	}
+	if string(firstBytes) != string(secondBytes) {
+		t.Fatalf("settings.json diverged on second Inject\nfirst:\n%s\nsecond:\n%s", firstBytes, secondBytes)
+	}
+	for _, f := range secondResult.Files {
+		if f == settingsPath {
+			t.Fatalf("second Inject should not list settings.json as changed, got Files=%v", secondResult.Files)
+		}
+	}
+}
+
 func TestInjectCustomClaudeDoesNothing(t *testing.T) {
 	home := t.TempDir()
 

--- a/internal/components/persona/inject_test.go
+++ b/internal/components/persona/inject_test.go
@@ -197,6 +197,78 @@ func TestInjectClaudeNeutralDoesNotWriteOutputStyle(t *testing.T) {
 	}
 }
 
+func TestInjectClaudeNeutralRemovesGentlemanOutputStyleFromSettings(t *testing.T) {
+	home := t.TempDir()
+
+	// Simulate a previous Gentleman install: settings.json already contains
+	// "outputStyle": "Gentleman" alongside unrelated user keys.
+	settingsDir := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(settingsDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	existing := `{"outputStyle": "Gentleman", "permissions": {"allow": ["Read"]}}`
+	settingsPath := filepath.Join(settingsDir, "settings.json")
+	if err := os.WriteFile(settingsPath, []byte(existing), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	if _, err := Inject(home, claudeAdapter(), model.PersonaNeutral); err != nil {
+		t.Fatalf("Inject() error = %v", err)
+	}
+
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("Unmarshal() error = %v\ncontent: %s", err, data)
+	}
+	if _, present := parsed["outputStyle"]; present {
+		t.Fatalf("Neutral persona left outputStyle key in settings.json: %s", data)
+	}
+	// Unrelated keys must be preserved.
+	if _, ok := parsed["permissions"]; !ok {
+		t.Fatalf("Neutral persona dropped unrelated 'permissions' key: %s", data)
+	}
+}
+
+func TestInjectClaudeNeutralPreservesUserCustomOutputStyle(t *testing.T) {
+	home := t.TempDir()
+
+	// User has configured a non-Gentleman output style. The installer must
+	// not clobber it when switching to the Neutral persona.
+	settingsDir := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(settingsDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	existing := `{"outputStyle": "MyCustomStyle"}`
+	settingsPath := filepath.Join(settingsDir, "settings.json")
+	if err := os.WriteFile(settingsPath, []byte(existing), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	if _, err := Inject(home, claudeAdapter(), model.PersonaNeutral); err != nil {
+		t.Fatalf("Inject() error = %v", err)
+	}
+
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("Unmarshal() error = %v\ncontent: %s", err, data)
+	}
+	value, ok := parsed["outputStyle"]
+	if !ok {
+		t.Fatalf("Neutral persona removed user's custom outputStyle: %s", data)
+	}
+	if value != "MyCustomStyle" {
+		t.Fatalf("Neutral persona mutated user's outputStyle: got %v, want MyCustomStyle", value)
+	}
+}
+
 func TestInjectCustomClaudeDoesNothing(t *testing.T) {
 	home := t.TempDir()
 


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #204

## 🏷️ PR Type

- [x] \`type:bug\` — Bug fix (non-breaking change that fixes an issue)

## 📝 Summary

When a user switched from the **Gentleman** persona to **Neutral**, the \`outputStyle: \"Gentleman\"\` entry written to \`~/.claude/settings.json\` by the previous install was never cleaned up. Claude Code kept loading the Gentleman output style (Rioplatense Spanish, voseo, slang) even though the Neutral persona explicitly instructs a warm, professional, region-free tone.

Root cause was already pinpointed in the issue: in \`internal/components/persona/inject.go\`, the output-style merge was only performed for \`PersonaGentleman\`, with no symmetric cleanup path for other personas.

## 🛠️ Fix

\`Inject()\` now strips \`outputStyle\` from settings.json when persona is Neutral and the adapter supports output styles. Key rules:

- Only removes the key when its value is exactly \`\"Gentleman\"\` — any user-configured custom style (e.g. \`\"MyStyle\"\`) is preserved untouched
- Missing files, empty files, and malformed JSON are treated as no-ops, matching the existing tolerant-merge policy in \`filemerge\`
- \`PersonaCustom\` continues to short-circuit at the top of \`Inject()\` — user-managed configs are never touched
- The \`gentleman.md\` file under \`~/.claude/output-styles/\` is intentionally left on disk (harmless, potentially referenced by other tooling)

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| \`internal/components/persona/inject.go\` | Added step 4 in \`Inject()\` + new \`removeGentlemanOutputStyle()\` helper |
| \`internal/components/persona/inject_test.go\` | Two new tests covering the removal path and the custom-style preservation guarantee |

Total: 2 files, +133/-0.

## 🧪 Test Plan

- [x] New tests pass:
  - \`TestInjectClaudeNeutralRemovesGentlemanOutputStyleFromSettings\` — reproduces the bug without the fix, green with it
  - \`TestInjectClaudeNeutralPreservesUserCustomOutputStyle\` — guards against clobbering user-configured output styles
- [x] All 28 persona tests pass (\`go test ./internal/components/persona/\`)
- [x] Full suite pass (\`go test ./...\`)
- [x] \`go vet ./...\` clean
- [ ] E2E tests (\`cd e2e && ./docker-test.sh\`) — not run locally (Docker not available in this environment)

## ✅ Contributor Checklist

- [x] PR is linked to an issue with \`status:approved\` (#204)
- [x] I have added the appropriate \`type:*\` label to this PR
- [x] Unit tests pass (\`go test ./...\`)
- [ ] E2E tests pass — see test plan note
- [x] I have updated documentation if necessary (no user-facing docs change)
- [x] My commits follow Conventional Commits format
- [x] My commits do not include \`Co-Authored-By\` trailers