### PR TITLE
fix(app): detect missing TTY and print guidance instead of crashing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/mattn/go-isatty v0.0.20
 )
 
 require (
@@ -20,7 +21,6 @@ require (
 	github.com/clipperhouse/uax29/v2 v2.5.0 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/lucasb-eyer/go-colorful v1.3.0 // indirect
-	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.19 // indirect
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/mattn/go-isatty"
+
 	"github.com/gentleman-programming/gentle-ai/internal/backup"
 	"github.com/gentleman-programming/gentle-ai/internal/cli"
 	"github.com/gentleman-programming/gentle-ai/internal/model"
@@ -32,6 +34,21 @@ var (
 	upgradeExecute      = upgrade.Execute
 )
 
+// stdinIsTTY reports whether the process stdin is attached to a real
+// terminal. It is defined as a package-level variable so tests can stub the
+// TTY detection without having to redirect real file descriptors. Cygwin
+// terminals are treated as TTYs on Windows.
+var stdinIsTTY = func() bool {
+	fd := os.Stdin.Fd()
+	return isatty.IsTerminal(fd) || isatty.IsCygwinTerminal(fd)
+}
+
+// errNoInteractiveTerminal is returned when `gentle-ai` is launched without
+// arguments in an environment that has no TTY on stdin (CI, scripts,
+// non-interactive SSH). Callers receive a clean, documented error instead of
+// the opaque Bubbletea panic ("could not open a new TTY").
+var errNoInteractiveTerminal = errors.New("gentle-ai requires a TTY on stdin to launch the interactive TUI")
+
 func Run() error {
 	return RunArgs(os.Args[1:], os.Stdout)
 }
@@ -52,6 +69,15 @@ func RunArgs(args []string, stdout io.Writer) error {
 			printHelp(stdout, Version)
 			return nil
 		}
+	}
+
+	// No-TTY guard: the interactive TUI cannot start without a terminal on
+	// stdin. Detect that case up front and print a helpful message pointing
+	// users at the non-interactive subcommands instead of letting Bubbletea
+	// panic with "could not open a new TTY".
+	if len(args) == 0 && !stdinIsTTY() {
+		printNoTTYGuidance(stdout, Version)
+		return errNoInteractiveTerminal
 	}
 
 	if err := system.EnsureCurrentOSSupported(); err != nil {

--- a/internal/app/help.go
+++ b/internal/app/help.go
@@ -43,7 +43,11 @@ subcommand instead:
   gentle-ai upgrade          Apply updates to managed tools
   gentle-ai install [flags]  Configure AI coding agents
   gentle-ai sync             Re-apply configuration to current version
-  gentle-ai restore [id]     Restore a config backup
+  gentle-ai restore --list   List available config backups
+  gentle-ai restore <id> --yes  Restore a backup non-interactively —
+                               the --yes flag is required, otherwise
+                               'restore' will prompt for confirmation
+                               on stdin and hang in a non-TTY session
 
 `, version)
 }

--- a/internal/app/help.go
+++ b/internal/app/help.go
@@ -27,3 +27,23 @@ Run 'gentle-ai help' for this message.
 Documentation: https://github.com/Gentleman-Programming/gentle-ai
 `, version)
 }
+
+// printNoTTYGuidance tells the user why gentle-ai refused to start and lists
+// the non-interactive subcommands that still work without a terminal.
+func printNoTTYGuidance(w io.Writer, version string) {
+	fmt.Fprintf(w, `gentle-ai %s — no interactive terminal detected.
+
+The interactive TUI requires a TTY on stdin. If you are running from a
+script, CI, or a non-interactive SSH session, use a non-interactive
+subcommand instead:
+
+  gentle-ai --version        Print version and exit
+  gentle-ai --help           Show full command-line help
+  gentle-ai update           Check for available updates
+  gentle-ai upgrade          Apply updates to managed tools
+  gentle-ai install [flags]  Configure AI coding agents
+  gentle-ai sync             Re-apply configuration to current version
+  gentle-ai restore [id]     Restore a config backup
+
+`, version)
+}

--- a/internal/app/parity_test.go
+++ b/internal/app/parity_test.go
@@ -200,6 +200,8 @@ func TestRunArgsNoTTYReturnsGuidance(t *testing.T) {
 		"gentle-ai --version",
 		"gentle-ai --help",
 		"gentle-ai install",
+		"gentle-ai restore --list",
+		"--yes",
 	}
 	for _, frag := range wantFragments {
 		if !strings.Contains(out, frag) {

--- a/internal/app/parity_test.go
+++ b/internal/app/parity_test.go
@@ -164,14 +164,69 @@ func TestRunArgsNoCommandLaunchesTUI(t *testing.T) {
 	var buf bytes.Buffer
 	err := RunArgs(nil, &buf)
 	// With no args, RunArgs now launches the TUI via Bubbletea.
-	// In a headless/test environment without a TTY, this returns an error
-	// about opening /dev/tty. That's expected — the TUI requires a terminal.
+	// In a headless/test environment without a TTY, RunArgs short-circuits
+	// with errNoInteractiveTerminal and prints guidance on stdout instead of
+	// letting Bubbletea panic. Either outcome is acceptable here.
 	if err == nil {
 		// If no error, we're somehow in a TTY — that's fine too.
 		return
 	}
-	if !strings.Contains(err.Error(), "TTY") && !strings.Contains(err.Error(), "tty") {
+	if !errors.Is(err, errNoInteractiveTerminal) &&
+		!strings.Contains(err.Error(), "TTY") &&
+		!strings.Contains(err.Error(), "tty") {
 		t.Fatalf("RunArgs(nil) unexpected error = %v; want TTY-related error or nil", err)
+	}
+}
+
+// TestRunArgsNoTTYReturnsGuidance verifies the no-TTY short-circuit: when
+// stdin is not a terminal and no subcommand is given, RunArgs must print
+// user-facing guidance on stdout and return errNoInteractiveTerminal without
+// attempting to launch Bubbletea.
+func TestRunArgsNoTTYReturnsGuidance(t *testing.T) {
+	original := stdinIsTTY
+	t.Cleanup(func() { stdinIsTTY = original })
+	stdinIsTTY = func() bool { return false }
+
+	var buf bytes.Buffer
+	err := RunArgs(nil, &buf)
+	if !errors.Is(err, errNoInteractiveTerminal) {
+		t.Fatalf("RunArgs(nil) without TTY returned err = %v; want errNoInteractiveTerminal", err)
+	}
+
+	out := buf.String()
+	wantFragments := []string{
+		"no interactive terminal detected",
+		"non-interactive",
+		"gentle-ai --version",
+		"gentle-ai --help",
+		"gentle-ai install",
+	}
+	for _, frag := range wantFragments {
+		if !strings.Contains(out, frag) {
+			t.Errorf("guidance output missing %q\ngot:\n%s", frag, out)
+		}
+	}
+}
+
+// TestRunArgsInfoCommandsBypassTTYCheck ensures that --version and --help keep
+// working even when stdin is not a terminal. These paths never touch the TUI
+// and must remain usable from scripts and CI.
+func TestRunArgsInfoCommandsBypassTTYCheck(t *testing.T) {
+	original := stdinIsTTY
+	t.Cleanup(func() { stdinIsTTY = original })
+	stdinIsTTY = func() bool { return false }
+
+	for _, arg := range []string{"--version", "-v", "version", "--help", "-h", "help"} {
+		arg := arg
+		t.Run(arg, func(t *testing.T) {
+			var buf bytes.Buffer
+			if err := RunArgs([]string{arg}, &buf); err != nil {
+				t.Fatalf("RunArgs(%q) error = %v; want nil", arg, err)
+			}
+			if buf.Len() == 0 {
+				t.Fatalf("RunArgs(%q) produced no output", arg)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #95

## 🏷️ PR Type

- [x] \`type:bug\` — Bug fix (non-breaking change that fixes an issue)

## 📝 Summary

Launching \`gentle-ai\` with no args in an environment that has no TTY on stdin — scripts, CI, non-interactive SSH — made Bubbletea panic with:

\`\`\`
Error: could not open a new TTY: open /dev/tty: device not configured
\`\`\`

…and gave no hint about what to do instead.

\`RunArgs\` now checks \`isatty\` on stdin right after the info-command short-circuits. When no subcommand was requested and no TTY is present, it prints a short message pointing at the non-interactive subcommands and returns a sentinel error, causing a clean non-zero exit.

## 🛠️ Fix

- New early guard inside \`RunArgs\`:
  \`\`\`go
  if len(args) == 0 && !stdinIsTTY() {
      printNoTTYGuidance(stdout, Version)
      return errNoInteractiveTerminal
  }
  \`\`\`
- \`stdinIsTTY\` is a package-level variable backed by \`go-isatty\` (covers Cygwin on Windows). Tests stub it without juggling real file descriptors.
- \`--version\`, \`-v\`, \`version\`, \`--help\`, \`-h\`, and \`help\` keep working without a TTY — they short-circuit before the guard.
- \`go-isatty\` moves from indirect to direct dependency. No new module is added to \`go.sum\`.

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| \`internal/app/app.go\` | Added \`stdinIsTTY\` var, \`errNoInteractiveTerminal\`, and the no-TTY guard in \`RunArgs\` |
| \`internal/app/help.go\` | New \`printNoTTYGuidance\` helper listing available non-interactive subcommands |
| \`internal/app/parity_test.go\` | Updated \`TestRunArgsNoCommandLaunchesTUI\` to accept the new sentinel; added \`TestRunArgsNoTTYReturnsGuidance\` and \`TestRunArgsInfoCommandsBypassTTYCheck\` |
| \`go.mod\` | \`github.com/mattn/go-isatty\` promoted from indirect to direct |

Total: 4 files, +105/-4.

## 🧪 Test Plan

- [x] New tests pass:
  - \`TestRunArgsNoTTYReturnsGuidance\` — verifies stdout guidance + returned error when stdin is not a terminal
  - \`TestRunArgsInfoCommandsBypassTTYCheck\` — table test for \`--version\`, \`-v\`, \`version\`, \`--help\`, \`-h\`, \`help\` without a TTY
  - \`TestRunArgsNoCommandLaunchesTUI\` — updated to recognise the new sentinel
- [x] \`go test ./internal/app/ -run TestRunArgs\` passes for all TTY-related tests
- [x] \`go vet ./...\` clean
- [ ] E2E tests (\`cd e2e && ./docker-test.sh\`) — not run locally (Docker not available)

**Note on pre-existing Windows test flakes:** five unrelated tests in \`internal/app/\` and many tests in \`internal/components/\` already fail on a clean checkout of \`main\` on Windows (tracked in #103 / #197). They are not affected by this change — verified by running \`go test\` with my changes stashed. This PR adds no new failures.

## ✅ Contributor Checklist

- [x] PR is linked to an issue with \`status:approved\` (#95)
- [x] I have added the appropriate \`type:*\` label to this PR
- [x] Unit tests pass (for the affected package)
- [ ] E2E tests pass — see note above
- [x] I have updated documentation if necessary (user-visible guidance lives in-app)
- [x] My commits follow Conventional Commits format
- [x] My commits do not include \`Co-Authored-By\` trailers