### PR TITLE
fix(update,persona,cli): resolve issues #286, #280, #285

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -27,9 +27,11 @@ import (
 var Version = "dev"
 
 var (
-	updateCheckAll      = update.CheckAll
-	updateCheckFiltered = update.CheckFiltered
-	upgradeExecute      = upgrade.Execute
+	updateCheckAll           = update.CheckAll
+	updateCheckFiltered      = update.CheckFiltered
+	upgradeExecute           = upgrade.Execute
+	ensureCurrentOSSupported = system.EnsureCurrentOSSupported
+	detectSystem             = system.Detect
 )
 
 func Run() error {
@@ -51,14 +53,16 @@ func RunArgs(args []string, stdout io.Writer) error {
 		case "help", "--help", "-h":
 			printHelp(stdout, Version)
 			return nil
+		case "uninstall":
+			return cli.RunUninstall(args[1:], stdout)
 		}
 	}
 
-	if err := system.EnsureCurrentOSSupported(); err != nil {
+	if err := ensureCurrentOSSupported(); err != nil {
 		return err
 	}
 
-	result, err := system.Detect(context.Background())
+	result, err := detectSystem(context.Background())
 	if err != nil {
 		return fmt.Errorf("detect system: %w", err)
 	}

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -200,6 +200,50 @@ func TestRunArgsRestoreUnknownIDReturnsError(t *testing.T) {
 	}
 }
 
+func TestRunArgsUninstallDryRunIsDispatched(t *testing.T) {
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, ".gentle-ai", "backups"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	origHome := os.Getenv("HOME")
+	t.Cleanup(func() { os.Setenv("HOME", origHome) })
+	os.Setenv("HOME", home)
+
+	var buf bytes.Buffer
+	err := RunArgs([]string{"uninstall", "--dry-run", "--force"}, &buf)
+	if err != nil {
+		t.Fatalf("RunArgs(uninstall --dry-run --force) error = %v", err)
+	}
+	if !strings.Contains(buf.String(), "Uninstall (dry-run)") {
+		t.Fatalf("unexpected uninstall output:\n%s", buf.String())
+	}
+}
+
+func TestRunArgsUninstallBypassesPlatformValidation(t *testing.T) {
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, ".gentle-ai", "backups"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	origHome := os.Getenv("HOME")
+	t.Cleanup(func() { os.Setenv("HOME", origHome) })
+	os.Setenv("HOME", home)
+
+	origEnsure := ensureCurrentOSSupported
+	t.Cleanup(func() { ensureCurrentOSSupported = origEnsure })
+	ensureCurrentOSSupported = func() error {
+		return fmt.Errorf("unsupported platform")
+	}
+
+	var buf bytes.Buffer
+	err := RunArgs([]string{"uninstall", "--dry-run", "--force"}, &buf)
+	if err != nil {
+		t.Fatalf("RunArgs(uninstall --dry-run --force) error = %v", err)
+	}
+	if !strings.Contains(buf.String(), "Uninstall (dry-run)") {
+		t.Fatalf("unexpected uninstall output:\n%s", buf.String())
+	}
+}
+
 // TestListBackupsFallsBackGracefullyForOldManifests verifies that old manifests
 // without Source/Description are still returned (not skipped) and can be displayed
 // via DisplayLabel without panicking.

--- a/internal/app/help.go
+++ b/internal/app/help.go
@@ -14,6 +14,7 @@ USAGE
 
 COMMANDS
   install      Configure AI coding agents on this machine
+  uninstall    Remove Gentle AI managed files from this machine
   sync         Sync agent configs and skills to current version
   update       Check for available updates
   upgrade      Apply updates to managed tools

--- a/internal/app/help_test.go
+++ b/internal/app/help_test.go
@@ -11,7 +11,7 @@ func TestHelpContainsAllCommands(t *testing.T) {
 	printHelp(&buf, "v1.0.0-test")
 	output := buf.String()
 
-	commands := []string{"install", "sync", "update", "upgrade", "restore", "version"}
+	commands := []string{"install", "uninstall", "sync", "update", "upgrade", "restore", "version"}
 	for _, cmd := range commands {
 		if !strings.Contains(output, cmd) {
 			t.Errorf("help output missing command %q", cmd)
@@ -24,5 +24,13 @@ func TestHelpContainsVersion(t *testing.T) {
 	printHelp(&buf, "v1.2.3")
 	if !strings.Contains(buf.String(), "v1.2.3") {
 		t.Error("help output should contain the version string")
+	}
+}
+
+func TestHelpCommandsHeadingIsAligned(t *testing.T) {
+	var buf bytes.Buffer
+	printHelp(&buf, "v1.2.3")
+	if !strings.Contains(buf.String(), "\nCOMMANDS\n  install") {
+		t.Fatalf("help output has inconsistent command indentation:\n%s", buf.String())
 	}
 }

--- a/internal/cli/uninstall.go
+++ b/internal/cli/uninstall.go
@@ -1,0 +1,332 @@
+package cli
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/gentleman-programming/gentle-ai/internal/agents"
+	"github.com/gentleman-programming/gentle-ai/internal/components/gga"
+	"github.com/gentleman-programming/gentle-ai/internal/model"
+)
+
+type UninstallFlags struct {
+	DryRun      bool
+	Force       bool
+	PurgeMemory bool
+	KeepBackups bool
+}
+
+type UninstallTarget struct {
+	Path        string
+	Description string
+}
+
+type UninstallResult struct {
+	DryRun    bool
+	Cancelled bool
+	Targets   []UninstallTarget
+	Removed   []string
+	Notes     []string
+}
+
+var osExecutable = os.Executable
+
+func ParseUninstallFlags(args []string) (UninstallFlags, error) {
+	var opts UninstallFlags
+
+	fs := flag.NewFlagSet("uninstall", flag.ContinueOnError)
+	fs.SetOutput(ioDiscard{})
+	fs.BoolVar(&opts.DryRun, "dry-run", false, "show what would be removed without executing")
+	fs.BoolVar(&opts.Force, "force", false, "skip confirmation prompt")
+	fs.BoolVar(&opts.PurgeMemory, "purge-memory", false, "also delete ~/.engram")
+	fs.BoolVar(&opts.KeepBackups, "keep-backups", false, "preserve ~/.gentle-ai/backups")
+
+	if err := fs.Parse(args); err != nil {
+		return UninstallFlags{}, err
+	}
+
+	if fs.NArg() > 0 {
+		return UninstallFlags{}, fmt.Errorf("unexpected uninstall argument %q", fs.Arg(0))
+	}
+
+	return opts, nil
+}
+
+func RunUninstall(args []string, stdout io.Writer) error {
+	homeDir, err := osUserHomeDir()
+	if err != nil {
+		return fmt.Errorf("resolve home directory: %w", err)
+	}
+
+	result, err := runUninstallWithHomeDir(args, stdout, os.Stdin, homeDir)
+	if err != nil {
+		return err
+	}
+
+	_, _ = fmt.Fprint(stdout, RenderUninstallReport(result))
+	return nil
+}
+
+func runUninstallWithHomeDir(args []string, stdout io.Writer, stdin io.Reader, homeDir string) (UninstallResult, error) {
+	flags, err := ParseUninstallFlags(args)
+	if err != nil {
+		return UninstallResult{}, err
+	}
+
+	result := planUninstall(homeDir, flags)
+	if len(result.Targets) == 0 {
+		return result, nil
+	}
+
+	if !flags.DryRun && !flags.Force {
+		confirmed, err := promptUninstallConfirm(stdin, stdout)
+		if err != nil {
+			return UninstallResult{}, err
+		}
+		if !confirmed {
+			result.Cancelled = true
+			return result, nil
+		}
+	}
+
+	if flags.DryRun {
+		return result, nil
+	}
+
+	for _, target := range result.Targets {
+		if err := os.RemoveAll(target.Path); err != nil {
+			return UninstallResult{}, fmt.Errorf("remove %s: %w", target.Path, err)
+		}
+		result.Removed = append(result.Removed, target.Path)
+	}
+
+	return result, nil
+}
+
+func planUninstall(homeDir string, flags UninstallFlags) UninstallResult {
+	result := UninstallResult{DryRun: flags.DryRun}
+	seen := map[string]bool{}
+	add := func(path, description string) {
+		if path == "" || seen[path] {
+			return
+		}
+		if _, err := os.Stat(path); err != nil {
+			return
+		}
+		seen[path] = true
+		result.Targets = append(result.Targets, UninstallTarget{Path: path, Description: description})
+	}
+
+	gentleAIStateDir := filepath.Join(homeDir, ".gentle-ai")
+	if flags.KeepBackups {
+		add(filepath.Join(gentleAIStateDir, "state.json"), "gentle-ai state file")
+	} else {
+		add(filepath.Join(gentleAIStateDir, "state.json"), "gentle-ai state file")
+		add(filepath.Join(gentleAIStateDir, "backups"), "gentle-ai backups")
+	}
+
+	if flags.PurgeMemory {
+		add(filepath.Join(homeDir, ".engram"), "Engram memory database")
+	}
+
+	add(filepath.Join(homeDir, ".config", "gentle-ai"), "gentle-ai config directory")
+	add(gga.ConfigPath(homeDir), "GGA global config")
+	add(gga.AgentsTemplatePath(homeDir), "GGA AGENTS template")
+	add(gga.RuntimePRModePath(homeDir), "GGA runtime library")
+	add(gga.RuntimePS1Path(homeDir), "GGA PowerShell shim")
+	add(filepath.Join(homeDir, ".local", "bin", "engram"), "managed engram binary")
+	add(filepath.Join(homeDir, ".local", "bin", "engram.exe"), "managed engram binary")
+
+	for _, target := range managedAgentTargets(homeDir) {
+		add(target.Path, target.Description)
+	}
+
+	if !flags.PurgeMemory {
+		result.Notes = append(result.Notes, "Engram memory at ~/.engram is preserved by default (use --purge-memory to delete it)")
+	}
+
+	result.Notes = append(result.Notes, uninstallNotes(homeDir)...)
+	return result
+}
+
+func managedAgentTargets(homeDir string) []UninstallTarget {
+	ids := DiscoverAgents(homeDir)
+	reg, err := agents.NewDefaultRegistry()
+	if err != nil {
+		return nil
+	}
+
+	targets := make([]UninstallTarget, 0)
+	for _, id := range ids {
+		adapter, ok := reg.Get(model.AgentID(id))
+		if !ok {
+			continue
+		}
+		if adapter.SupportsSkills() {
+			targets = append(targets, managedSkillTargets(adapter.SkillsDir(homeDir), string(id))...)
+		}
+		if adapter.SupportsSlashCommands() {
+			targets = append(targets, managedCommandTargets(adapter.CommandsDir(homeDir), string(id))...)
+		}
+		if adapter.SupportsOutputStyles() {
+			styleDir := adapter.OutputStyleDir(homeDir)
+			if styleDir != "" {
+				targets = append(targets, UninstallTarget{Path: filepath.Join(styleDir, "gentleman.md"), Description: fmt.Sprintf("%s Gentleman output style", id)})
+			}
+		}
+	}
+
+	return targets
+}
+
+func managedSkillTargets(skillDir, agentID string) []UninstallTarget {
+	if skillDir == "" {
+		return nil
+	}
+
+	sharedFiles := []string{
+		"engram-convention.md",
+		"openspec-convention.md",
+		"persistence-contract.md",
+		"sdd-phase-common.md",
+		"skill-resolver.md",
+	}
+	skillDirs := []string{
+		"branch-pr",
+		"go-testing",
+		"issue-creation",
+		"judgment-day",
+		"sdd-apply",
+		"sdd-archive",
+		"sdd-design",
+		"sdd-explore",
+		"sdd-init",
+		"sdd-onboard",
+		"sdd-propose",
+		"sdd-spec",
+		"sdd-tasks",
+		"sdd-verify",
+		"skill-creator",
+		"skill-registry",
+	}
+
+	targets := make([]UninstallTarget, 0, len(sharedFiles)+len(skillDirs))
+	for _, fileName := range sharedFiles {
+		targets = append(targets, UninstallTarget{
+			Path:        filepath.Join(skillDir, "_shared", fileName),
+			Description: fmt.Sprintf("%s managed shared skill file", agentID),
+		})
+	}
+	for _, dirName := range skillDirs {
+		targets = append(targets, UninstallTarget{
+			Path:        filepath.Join(skillDir, dirName),
+			Description: fmt.Sprintf("%s managed skill %s", agentID, dirName),
+		})
+	}
+
+	return targets
+}
+
+func managedCommandTargets(commandsDir, agentID string) []UninstallTarget {
+	if commandsDir == "" {
+		return nil
+	}
+
+	commandFiles := []string{
+		"sdd-apply.md",
+		"sdd-archive.md",
+		"sdd-continue.md",
+		"sdd-explore.md",
+		"sdd-ff.md",
+		"sdd-init.md",
+		"sdd-new.md",
+		"sdd-onboard.md",
+		"sdd-verify.md",
+	}
+
+	targets := make([]UninstallTarget, 0, len(commandFiles))
+	for _, fileName := range commandFiles {
+		targets = append(targets, UninstallTarget{
+			Path:        filepath.Join(commandsDir, fileName),
+			Description: fmt.Sprintf("%s managed slash command %s", agentID, fileName),
+		})
+	}
+
+	return targets
+}
+
+func uninstallNotes(homeDir string) []string {
+	notes := []string{}
+
+	if exe, err := osExecutable(); err == nil && exe != "" {
+		switch {
+		case strings.Contains(exe, "/Cellar/") || strings.Contains(exe, "/Homebrew/"):
+			notes = append(notes, "Remove the running gentle-ai binary manually after this command exits: brew uninstall gentle-ai")
+		case strings.HasPrefix(exe, filepath.Join(homeDir, ".local", "bin")) || strings.HasPrefix(exe, filepath.Join(homeDir, "bin")) || strings.HasPrefix(exe, "/usr/local/bin"):
+			notes = append(notes, fmt.Sprintf("Remove the running gentle-ai binary manually after this command exits: rm %q", exe))
+		default:
+			notes = append(notes, fmt.Sprintf("Current gentle-ai binary still exists at %q and may need manual removal", exe))
+		}
+	}
+
+	notes = append(notes, "Agent-specific settings overlays (for example JSON settings entries) may still need manual cleanup if you customized them by hand")
+	return notes
+}
+
+func promptUninstallConfirm(stdin io.Reader, stdout io.Writer) (bool, error) {
+	_, _ = fmt.Fprint(stdout, "This will remove Gentle AI managed files from your home directory. Type 'yes' to confirm: ")
+	scanner := bufio.NewScanner(stdin)
+	if !scanner.Scan() {
+		if err := scanner.Err(); err != nil {
+			return false, fmt.Errorf("read confirmation input: %w", err)
+		}
+		return false, fmt.Errorf("no confirmation provided (use --force to skip prompt)")
+	}
+	return strings.EqualFold(strings.TrimSpace(scanner.Text()), "yes"), nil
+}
+
+func RenderUninstallReport(result UninstallResult) string {
+	var b strings.Builder
+
+	if result.Cancelled {
+		b.WriteString("Uninstall cancelled.\n")
+		return b.String()
+	}
+
+	if result.DryRun {
+		b.WriteString("Uninstall (dry-run)\n")
+	} else {
+		b.WriteString("Uninstall\n")
+	}
+	b.WriteString("=========\n\n")
+
+	if len(result.Targets) == 0 {
+		b.WriteString("  No managed files were found.\n")
+	} else {
+		b.WriteString("  Targets:\n")
+		for _, target := range result.Targets {
+			fmt.Fprintf(&b, "  - %s — %s\n", target.Path, target.Description)
+		}
+	}
+
+	if !result.DryRun && len(result.Removed) > 0 {
+		b.WriteString("\n  Removed:\n")
+		for _, path := range result.Removed {
+			fmt.Fprintf(&b, "  - %s\n", path)
+		}
+	}
+
+	if len(result.Notes) > 0 {
+		b.WriteString("\n  Notes:\n")
+		for _, note := range result.Notes {
+			fmt.Fprintf(&b, "  - %s\n", note)
+		}
+	}
+
+	return b.String()
+}

--- a/internal/cli/uninstall_test.go
+++ b/internal/cli/uninstall_test.go
@@ -1,0 +1,188 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParseUninstallFlags(t *testing.T) {
+	flags, err := ParseUninstallFlags([]string{"--dry-run", "--force", "--purge-memory", "--keep-backups"})
+	if err != nil {
+		t.Fatalf("ParseUninstallFlags() error = %v", err)
+	}
+	if !flags.DryRun || !flags.Force || !flags.PurgeMemory || !flags.KeepBackups {
+		t.Fatalf("unexpected parsed flags: %+v", flags)
+	}
+}
+
+func TestRunUninstallDryRunReportsTargets(t *testing.T) {
+	home := t.TempDir()
+	engramDir := filepath.Join(home, ".engram")
+	if err := os.MkdirAll(engramDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(home, ".gentle-ai", "backups"), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+
+	var buf bytes.Buffer
+	result, err := runUninstallWithHomeDir([]string{"--dry-run", "--force"}, &buf, strings.NewReader(""), home)
+	if err != nil {
+		t.Fatalf("runUninstallWithHomeDir() error = %v", err)
+	}
+	if !result.DryRun {
+		t.Fatal("DryRun = false, want true")
+	}
+	if len(result.Targets) == 0 {
+		t.Fatal("expected uninstall targets in dry-run")
+	}
+	if _, err := os.Stat(engramDir); err != nil {
+		t.Fatalf("dry-run removed engram dir unexpectedly: %v", err)
+	}
+	output := RenderUninstallReport(result)
+	if !strings.Contains(output, "Uninstall (dry-run)") {
+		t.Fatalf("dry-run report missing header:\n%s", output)
+	}
+}
+
+func TestRunUninstallRemovesManagedPaths(t *testing.T) {
+	home := t.TempDir()
+	paths := []string{
+		filepath.Join(home, ".gentle-ai", "state.json"),
+		filepath.Join(home, ".config", "gga", "config"),
+		filepath.Join(home, ".config", "gga", "AGENTS.md"),
+		filepath.Join(home, ".local", "share", "gga", "lib", "pr_mode.sh"),
+		filepath.Join(home, ".config", "opencode", "commands", "sdd-init.md"),
+		filepath.Join(home, ".config", "opencode", "skills", "sdd-init", "SKILL.md"),
+		filepath.Join(home, ".local", "bin", "engram"),
+	}
+	for _, path := range paths {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("MkdirAll(%q) error = %v", path, err)
+		}
+		if err := os.WriteFile(path, []byte("x"), 0o644); err != nil {
+			t.Fatalf("WriteFile(%q) error = %v", path, err)
+		}
+	}
+
+	result, err := runUninstallWithHomeDir([]string{"--force"}, ioDiscard{}, strings.NewReader(""), home)
+	if err != nil {
+		t.Fatalf("runUninstallWithHomeDir() error = %v", err)
+	}
+	if len(result.Removed) == 0 {
+		t.Fatal("expected removed paths")
+	}
+	for _, path := range []string{
+		filepath.Join(home, ".gentle-ai", "state.json"),
+		filepath.Join(home, ".config", "gga", "config"),
+		filepath.Join(home, ".config", "gga", "AGENTS.md"),
+		filepath.Join(home, ".local", "share", "gga", "lib", "pr_mode.sh"),
+		filepath.Join(home, ".config", "opencode", "commands", "sdd-init.md"),
+		filepath.Join(home, ".config", "opencode", "skills", "sdd-init"),
+		filepath.Join(home, ".local", "bin", "engram"),
+	} {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("expected %q to be removed, stat err = %v", path, err)
+		}
+	}
+}
+
+func TestRunUninstallPreservesMemoryByDefault(t *testing.T) {
+	home := t.TempDir()
+	backupsDir := filepath.Join(home, ".gentle-ai", "backups")
+	memoryDir := filepath.Join(home, ".engram")
+	sharedSkillsDir := filepath.Join(home, ".config", "opencode", "skills")
+	if err := os.MkdirAll(backupsDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(backups) error = %v", err)
+	}
+	if err := os.MkdirAll(memoryDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(memory) error = %v", err)
+	}
+	if err := os.MkdirAll(sharedSkillsDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(shared skills) error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".gentle-ai", "state.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatalf("WriteFile(state) error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(memoryDir, "engram.db"), []byte("memory"), 0o644); err != nil {
+		t.Fatalf("WriteFile(memory) error = %v", err)
+	}
+	userSkill := filepath.Join(sharedSkillsDir, "my-custom-skill", "SKILL.md")
+	if err := os.MkdirAll(filepath.Dir(userSkill), 0o755); err != nil {
+		t.Fatalf("MkdirAll(userSkill) error = %v", err)
+	}
+	if err := os.WriteFile(userSkill, []byte("custom"), 0o644); err != nil {
+		t.Fatalf("WriteFile(userSkill) error = %v", err)
+	}
+
+	result, err := runUninstallWithHomeDir([]string{"--force", "--keep-backups"}, ioDiscard{}, strings.NewReader(""), home)
+	if err != nil {
+		t.Fatalf("runUninstallWithHomeDir() error = %v", err)
+	}
+	if _, err := os.Stat(backupsDir); err != nil {
+		t.Fatalf("backups should be preserved: %v", err)
+	}
+	if _, err := os.Stat(memoryDir); err != nil {
+		t.Fatalf("memory should be preserved: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".gentle-ai", "state.json")); !os.IsNotExist(err) {
+		t.Fatalf("state.json should be removed when keeping backups, stat err = %v", err)
+	}
+	if _, err := os.Stat(userSkill); err != nil {
+		t.Fatalf("user-authored skill should be preserved: %v", err)
+	}
+	if !strings.Contains(RenderUninstallReport(result), "--purge-memory") {
+		t.Fatalf("uninstall report should explain memory preservation opt-in:\n%s", RenderUninstallReport(result))
+	}
+}
+
+func TestRunUninstallCancelledShowsCancelledMessage(t *testing.T) {
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, ".gentle-ai", "backups"), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+
+	// User types "no" at the confirmation prompt.
+	var buf bytes.Buffer
+	result, err := runUninstallWithHomeDir([]string{}, &buf, strings.NewReader("no\n"), home)
+	if err != nil {
+		t.Fatalf("runUninstallWithHomeDir() error = %v", err)
+	}
+	if !result.Cancelled {
+		t.Fatal("Cancelled = false, want true")
+	}
+	output := RenderUninstallReport(result)
+	if !strings.Contains(output, "cancelled") {
+		t.Fatalf("cancelled report should say 'cancelled', got:\n%s", output)
+	}
+	// Targets should still be populated (planned but not executed).
+	if len(result.Targets) == 0 {
+		t.Fatal("cancelled result should still contain planned targets")
+	}
+	// Nothing should have been removed.
+	if len(result.Removed) > 0 {
+		t.Fatalf("cancelled result should not have removed paths, got: %v", result.Removed)
+	}
+}
+
+func TestRunUninstallPurgeMemoryDeletesEngram(t *testing.T) {
+	home := t.TempDir()
+	memoryDir := filepath.Join(home, ".engram")
+	if err := os.MkdirAll(memoryDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(memory) error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(memoryDir, "engram.db"), []byte("memory"), 0o644); err != nil {
+		t.Fatalf("WriteFile(memory) error = %v", err)
+	}
+
+	_, err := runUninstallWithHomeDir([]string{"--force", "--purge-memory"}, ioDiscard{}, strings.NewReader(""), home)
+	if err != nil {
+		t.Fatalf("runUninstallWithHomeDir() error = %v", err)
+	}
+	if _, err := os.Stat(memoryDir); !os.IsNotExist(err) {
+		t.Fatalf("memory should be removed with --purge-memory, stat err = %v", err)
+	}
+}

--- a/internal/components/persona/inject.go
+++ b/internal/components/persona/inject.go
@@ -53,9 +53,11 @@ func Inject(homeDir string, adapter agents.Adapter, persona model.PersonaID) (In
 		}
 
 		// Auto-heal: strip any legacy free-text Gentleman persona block that was
-		// written before the marker-based injection system existed. This prevents
-		// duplicate persona content when users re-run the installer after an old
-		// install placed the persona as raw text above the <!-- gentle-ai: --> markers.
+		// written before the marker-based injection system existed. This is safe
+		// for StrategyMarkdownSections because InjectMarkdownSection preserves
+		// all existing marker sections — only the unmarked free-text preamble is
+		// removed, and StripLegacyPersonaBlock requires ALL three fingerprints
+		// to be present in the pre-marker zone before stripping.
 		healed := filemerge.StripLegacyPersonaBlock(existing)
 
 		// Also strip legacy Agent Teams Lite block (standalone ATL installer leftover).
@@ -72,6 +74,37 @@ func Inject(homeDir string, adapter agents.Adapter, persona model.PersonaID) (In
 
 	case model.StrategyFileReplace:
 		promptPath := adapter.SystemPromptFile(homeDir)
+
+		if adapter.Agent() == model.AgentOpenCode {
+			existing, err := readFileOrEmpty(promptPath)
+			if err != nil {
+				return InjectionResult{}, err
+			}
+
+			healed := existing
+
+			// Only strip legacy persona when a managed persona section already
+			// exists — that is the only strong proof the pre-marker content is
+			// stale installer output, not user-authored content.
+			if shouldStripManagedLegacyPersona(existing) {
+				healed = filemerge.StripLegacyPersonaBlock(existing)
+			} else if isExactLegacyPersonaAsset(existing) {
+				// The file is byte-for-byte the old installer asset with no
+				// markers. Safe to replace entirely — no user content to lose.
+				healed = ""
+			}
+
+			healed = filemerge.StripLegacyATLBlock(healed)
+			updated := filemerge.InjectMarkdownSection(healed, "persona", content)
+
+			writeResult, err := filemerge.WriteFileAtomic(promptPath, []byte(updated), 0o644)
+			if err != nil {
+				return InjectionResult{}, err
+			}
+			changed = changed || writeResult.Changed
+			files = append(files, promptPath)
+			break
+		}
 
 		// For non-Gentleman personas (e.g. neutral), the content is just a short
 		// one-liner. Writing ONLY that content would destroy any SDD/engram
@@ -219,6 +252,40 @@ func Inject(homeDir string, adapter agents.Adapter, persona model.PersonaID) (In
 	return InjectionResult{Changed: changed, Files: files}, nil
 }
 
+// shouldStripManagedLegacyPersona returns true ONLY when the existing file
+// already contains a <!-- gentle-ai:persona --> section. That is the strongest
+// evidence that the pre-marker persona content is stale legacy text written by
+// an older installer, not user-authored content that happens to share headings.
+//
+// We intentionally do NOT trigger on ATL markers, engram markers, sdd markers,
+// or any other managed marker — their presence does not prove that the
+// pre-marker content is installer-owned.
+// isExactLegacyPersonaAsset returns true when the file content is an exact
+// match of one of the known persona assets (gentleman or neutral). This handles
+// the case where an old installer wrote the asset as the entire file with no
+// markers — we can safely replace it because there is zero user content.
+func isExactLegacyPersonaAsset(existing string) bool {
+	trimmed := strings.TrimSpace(existing)
+	if trimmed == "" {
+		return false
+	}
+	for _, assetPath := range []string{
+		"opencode/persona-gentleman.md",
+		"generic/persona-gentleman.md",
+		"generic/persona-neutral.md",
+	} {
+		asset := strings.TrimSpace(assets.MustRead(assetPath))
+		if trimmed == asset {
+			return true
+		}
+	}
+	return false
+}
+
+func shouldStripManagedLegacyPersona(existing string) bool {
+	return strings.Contains(existing, "<!-- gentle-ai:persona -->")
+}
+
 func personaContent(agent model.AgentID, persona model.PersonaID) string {
 	switch persona {
 	case model.PersonaNeutral:
@@ -317,26 +384,29 @@ func wrapInstructionsFile(content string) string {
 	return frontmatter + content
 }
 
-// isLegacyUnwrappedPersona reports whether content looks like a Gentleman persona
-// file that was written without YAML frontmatter by an older installer version.
-// It returns true when the content carries known persona fingerprints but does NOT
-// start with the YAML front-matter block ("---\n").
+// isLegacyUnwrappedPersona reports whether content is a Gentleman persona
+// file written by an older installer version without YAML frontmatter.
+// Requires ALL fingerprints to match (not just one) to reduce false positives.
+// This is only used for legacy path cleanup (e.g. ~/.github/copilot-instructions.md)
+// where the file is at a known old installer path — the combination of legacy
+// path + all fingerprints is strong enough evidence of installer ownership.
 func isLegacyUnwrappedPersona(content string) bool {
 	if strings.HasPrefix(content, "---\n") {
 		// Already has YAML frontmatter — not a legacy file.
 		return false
 	}
-	// Must contain at least one characteristic persona fingerprint.
+	// Require ALL fingerprints — a user is unlikely to have all of these
+	// exact strings in a hand-written file at the old legacy path.
 	personaFingerprints := []string{
 		"## Personality",
 		"Senior Architect",
 	}
 	for _, fp := range personaFingerprints {
-		if strings.Contains(content, fp) {
-			return true
+		if !strings.Contains(content, fp) {
+			return false
 		}
 	}
-	return false
+	return true
 }
 
 // legacyVSCodePersonaPaths returns the old VS Code persona file paths that may

--- a/internal/components/persona/inject_test.go
+++ b/internal/components/persona/inject_test.go
@@ -260,6 +260,180 @@ func TestInjectOpenCodeGentlemanWritesAgentsFile(t *testing.T) {
 	if !strings.Contains(text, "Senior Architect") {
 		t.Fatal("AGENTS.md missing real persona content")
 	}
+	if !strings.Contains(text, "<!-- gentle-ai:persona -->") {
+		t.Fatal("AGENTS.md missing persona marker")
+	}
+}
+
+func TestInjectOpenCodePreservesUserContentInsteadOfOverwriting(t *testing.T) {
+	home := t.TempDir()
+	path := filepath.Join(home, ".config", "opencode", "AGENTS.md")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+
+	userContent := "# My custom rules\n\nDo not overwrite this file.\n"
+	if err := os.WriteFile(path, []byte(userContent), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	_, err := Inject(home, opencodeAdapter(), model.PersonaGentleman)
+	if err != nil {
+		t.Fatalf("Inject() error = %v", err)
+	}
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+
+	text := string(content)
+	if !strings.Contains(text, "Do not overwrite this file.") {
+		t.Fatal("AGENTS.md user content was overwritten")
+	}
+	if !strings.Contains(text, "<!-- gentle-ai:persona -->") {
+		t.Fatal("AGENTS.md missing managed persona section after inject")
+	}
+}
+
+func TestInjectOpenCodeDoesNotStripLookalikeUserContent(t *testing.T) {
+	home := t.TempDir()
+	path := filepath.Join(home, ".config", "opencode", "AGENTS.md")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+
+	lookalike := "## Rules\n\n- Team rules.\n\n## Personality\n\nSenior Architect for my org.\n\nDo not delete this custom preface.\n"
+	if err := os.WriteFile(path, []byte(lookalike), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	_, err := Inject(home, opencodeAdapter(), model.PersonaGentleman)
+	if err != nil {
+		t.Fatalf("Inject() error = %v", err)
+	}
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	text := string(content)
+
+	if !strings.Contains(text, "Do not delete this custom preface.") {
+		t.Fatal("OpenCode AGENTS.md lookalike user content was stripped")
+	}
+	if !strings.Contains(text, "<!-- gentle-ai:persona -->") {
+		t.Fatal("AGENTS.md missing managed persona section after inject")
+	}
+}
+
+func TestInjectOpenCodePreservesUserPrefaceAboveATLBlock(t *testing.T) {
+	home := t.TempDir()
+	path := filepath.Join(home, ".config", "opencode", "AGENTS.md")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+
+	// User has custom content with fingerprint-like headings ABOVE an old ATL block.
+	// ATL markers must NOT trigger persona legacy stripping.
+	existing := "## Rules\n\n- My team's custom rules.\n\n## Personality\n\nSenior Architect in my org.\n\n" +
+		"<!-- BEGIN:agent-teams-lite -->\nOld ATL content.\n<!-- END:agent-teams-lite -->\n"
+	if err := os.WriteFile(path, []byte(existing), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	_, err := Inject(home, opencodeAdapter(), model.PersonaGentleman)
+	if err != nil {
+		t.Fatalf("Inject() error = %v", err)
+	}
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+
+	text := string(content)
+	if !strings.Contains(text, "My team's custom rules.") {
+		t.Fatal("user preface above ATL block was stripped — ATL should not enable persona stripping")
+	}
+	if strings.Contains(text, "BEGIN:agent-teams-lite") {
+		t.Fatal("ATL block should have been stripped by StripLegacyATLBlock")
+	}
+	if !strings.Contains(text, "<!-- gentle-ai:persona -->") {
+		t.Fatal("AGENTS.md missing managed persona section")
+	}
+}
+
+func TestInjectOpenCodeReplacesExactLegacyAssetWithoutDuplication(t *testing.T) {
+	home := t.TempDir()
+	path := filepath.Join(home, ".config", "opencode", "AGENTS.md")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+
+	// Write the exact legacy asset (no markers) — simulates old installer output.
+	legacyContent := assets.MustRead("opencode/persona-gentleman.md")
+	if err := os.WriteFile(path, []byte(legacyContent), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	_, err := Inject(home, opencodeAdapter(), model.PersonaGentleman)
+	if err != nil {
+		t.Fatalf("Inject() error = %v", err)
+	}
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+
+	text := string(content)
+	// Must have exactly ONE persona marker — no duplication.
+	if strings.Count(text, "<!-- gentle-ai:persona -->") != 1 {
+		t.Fatalf("expected exactly 1 persona marker, got %d — legacy asset was not replaced cleanly",
+			strings.Count(text, "<!-- gentle-ai:persona -->"))
+	}
+	if !strings.Contains(text, "Senior Architect") {
+		t.Fatal("persona content missing after replacing legacy asset")
+	}
+}
+
+func TestInjectOpenCodePreservesUserPrefaceAboveManagedMarkers(t *testing.T) {
+	home := t.TempDir()
+	path := filepath.Join(home, ".config", "opencode", "AGENTS.md")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+
+	// Simulate: user has custom content with fingerprint-like headings ABOVE
+	// existing managed markers. This is the exact scenario where aggressive
+	// legacy stripping would destroy user content.
+	existing := "## Rules\n\n- My team's custom rules.\n\n## Personality\n\nSenior Architect in my org.\n\n" +
+		"<!-- gentle-ai:engram-protocol -->\nEngram protocol here.\n<!-- /gentle-ai:engram-protocol -->\n"
+	if err := os.WriteFile(path, []byte(existing), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	_, err := Inject(home, opencodeAdapter(), model.PersonaGentleman)
+	if err != nil {
+		t.Fatalf("Inject() error = %v", err)
+	}
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+
+	text := string(content)
+	if !strings.Contains(text, "My team's custom rules.") {
+		t.Fatal("user preface above managed markers was stripped — should be preserved")
+	}
+	if !strings.Contains(text, "<!-- gentle-ai:persona -->") {
+		t.Fatal("AGENTS.md missing managed persona section after inject")
+	}
+	if !strings.Contains(text, "<!-- gentle-ai:engram-protocol -->") {
+		t.Fatal("existing engram section was lost")
+	}
 }
 
 func TestInjectOpenCodeNeutralPreservesManagedSections(t *testing.T) {

--- a/internal/update/check_test.go
+++ b/internal/update/check_test.go
@@ -47,6 +47,17 @@ func TestDetectInstalledVersion(t *testing.T) {
 			wantVersion: "0.3.2",
 		},
 		{
+			name: "engram dev output is preserved as dev sentinel",
+			tool: ToolInfo{Name: "engram", DetectCmd: []string{"engram", "version"}},
+			lookPathFn: func(string) (string, error) {
+				return "/usr/local/bin/engram", nil
+			},
+			execCommandFn: func(name string, args ...string) *exec.Cmd {
+				return exec.Command("echo", "engram dev")
+			},
+			wantVersion: "dev",
+		},
+		{
 			name: "gga not installed",
 			tool: ToolInfo{Name: "gga", DetectCmd: []string{"gga", "--version"}},
 			lookPathFn: func(string) (string, error) {
@@ -104,6 +115,12 @@ func TestDetectInstalledVersion(t *testing.T) {
 				t.Fatalf("detectInstalledVersion() = %q, want %q", got, tc.wantVersion)
 			}
 		})
+	}
+}
+
+func TestParseVersionFromOutput_DevSentinel(t *testing.T) {
+	if got := parseVersionFromOutput("engram dev"); got != "dev" {
+		t.Fatalf("parseVersionFromOutput(engram dev) = %q, want %q", got, "dev")
 	}
 }
 

--- a/internal/update/detect.go
+++ b/internal/update/detect.go
@@ -5,6 +5,7 @@ import (
 	"os/exec"
 	"regexp"
 	"strings"
+	"time"
 )
 
 // Package-level vars for testability (swap in tests via t.Cleanup).
@@ -16,6 +17,10 @@ var (
 // versionRegexp extracts a semver-like version from command output.
 // Same pattern as internal/system/deps.go for consistency.
 var versionRegexp = regexp.MustCompile(`(\d+\.\d+(?:\.\d+)?)`)
+
+// devVersionRegexp matches common unversioned source-build output like
+// "engram dev" or "version: dev".
+var devVersionRegexp = regexp.MustCompile(`(?i)(?:^|\s)dev(?:$|\s)`)
 
 // detectInstalledVersion determines the installed version of a tool.
 // For tools with nil DetectCmd (gentle-ai), returns currentBuildVersion.
@@ -34,10 +39,30 @@ func detectInstalledVersion(ctx context.Context, tool ToolInfo, currentBuildVers
 		return "" // binary not found
 	}
 
+	// Apply a bounded timeout so a hanging binary (e.g. engram stuck on DB
+	// lock) cannot block update/upgrade flows forever.
+	detectCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
 	cmd := execCommand(tool.DetectCmd[0], tool.DetectCmd[1:]...)
+
+	// Kill the subprocess when the context fires. We use a goroutine because
+	// the testable execCommand var returns a plain *exec.Cmd (not CommandContext).
+	done := make(chan struct{})
+	go func() {
+		select {
+		case <-detectCtx.Done():
+			if cmd.Process != nil {
+				_ = cmd.Process.Kill()
+			}
+		case <-done:
+		}
+	}()
+
 	out, err := cmd.Output()
+	close(done)
 	if err != nil {
-		return "" // command failed — binary exists but version unknown
+		return "" // command failed or timed out — binary exists but version unknown
 	}
 
 	return parseVersionFromOutput(strings.TrimSpace(string(out)))
@@ -47,6 +72,10 @@ func detectInstalledVersion(ctx context.Context, tool ToolInfo, currentBuildVers
 func parseVersionFromOutput(output string) string {
 	if output == "" {
 		return ""
+	}
+
+	if devVersionRegexp.MatchString(output) {
+		return "dev"
 	}
 
 	match := versionRegexp.FindStringSubmatch(output)

--- a/internal/update/upgrade/executor.go
+++ b/internal/update/upgrade/executor.go
@@ -205,7 +205,8 @@ func enumerateFilesInDir(dir string, excludeDirNames map[string]bool) ([]string,
 // Reporting rules:
 //   - Status UpdateAvailable → attempt upgrade; report Succeeded/Failed/Skipped(manual)
 //   - Status DevBuild → report as UpgradeSkipped with ManualHint (dev/source build)
-//   - Status UpToDate, NotInstalled, CheckFailed, VersionUnknown → omitted from report
+//   - Status VersionUnknown → report as UpgradeSkipped with ManualHint (manual attention required)
+//   - Status UpToDate, NotInstalled, CheckFailed → omitted from report
 //   - dryRun=true → no exec; eligible tools reported as UpgradeSkipped
 //
 // The backup snapshot is created before any exec call — this is the architectural
@@ -216,22 +217,26 @@ func Execute(ctx context.Context, results []update.UpdateResult, profile system.
 	if len(progress) > 0 && progress[0] != nil {
 		pw = progress[0]
 	}
-	// Separate tools into executable (UpdateAvailable) and dev-build (DevBuild).
-	// DevBuild tools are included in the report as UpgradeSkipped with a clear hint.
+	// Separate tools into executable (UpdateAvailable), dev-build (DevBuild), and
+	// version-unknown tools. Non-actionable but user-visible states are included in
+	// the report as UpgradeSkipped so the upgrade flow never fails silently.
 	var executable []update.UpdateResult
 	var devBuilds []update.UpdateResult
+	var versionUnknowns []update.UpdateResult
 	for _, r := range results {
 		switch r.Status {
 		case update.UpdateAvailable:
 			executable = append(executable, r)
 		case update.DevBuild:
 			devBuilds = append(devBuilds, r)
-			// UpToDate, NotInstalled, CheckFailed, VersionUnknown → omit from report
+		case update.VersionUnknown:
+			versionUnknowns = append(versionUnknowns, r)
+			// UpToDate, NotInstalled, CheckFailed → omit from report
 		}
 	}
 
-	// If nothing is executable or dev-built, return empty report.
-	if len(executable) == 0 && len(devBuilds) == 0 {
+	// If nothing is executable, dev-built, or version-unknown, return empty report.
+	if len(executable) == 0 && len(devBuilds) == 0 && len(versionUnknowns) == 0 {
 		return UpgradeReport{DryRun: dryRun}
 	}
 
@@ -263,7 +268,7 @@ func Execute(ctx context.Context, results []update.UpdateResult, profile system.
 	}
 
 	// Build results slice: dev-build skips first (no exec), then executable tools.
-	toolResults := make([]ToolUpgradeResult, 0, len(executable)+len(devBuilds))
+	toolResults := make([]ToolUpgradeResult, 0, len(executable)+len(devBuilds)+len(versionUnknowns))
 
 	// Dev-build tools: always UpgradeSkipped with a source-build hint.
 	for _, r := range devBuilds {
@@ -274,6 +279,19 @@ func Execute(ctx context.Context, results []update.UpdateResult, profile system.
 			Method:     effectiveMethod(r.Tool, profile),
 			Status:     UpgradeSkipped,
 			ManualHint: fmt.Sprintf("source build — upgrade manually or install a release binary from https://github.com/Gentleman-Programming/%s/releases", r.Tool.Repo),
+		})
+	}
+
+	// VersionUnknown tools: surface them as skipped so the user gets a clear hint
+	// instead of a silent omission from the upgrade report.
+	for _, r := range versionUnknowns {
+		toolResults = append(toolResults, ToolUpgradeResult{
+			ToolName:   r.Tool.Name,
+			OldVersion: r.InstalledVersion,
+			NewVersion: r.LatestVersion,
+			Method:     effectiveMethod(r.Tool, profile),
+			Status:     UpgradeSkipped,
+			ManualHint: fmt.Sprintf("installed binary was found but its version could not be determined — check `%s` and reinstall if it is a stale source/dev build", detectCommandHint(r.Tool)),
 		})
 	}
 
@@ -302,6 +320,14 @@ func Execute(ctx context.Context, results []update.UpdateResult, profile system.
 		Results:       toolResults,
 		DryRun:        dryRun,
 	}
+}
+
+func detectCommandHint(tool update.ToolInfo) string {
+	if len(tool.DetectCmd) == 0 {
+		return tool.Name
+	}
+
+	return strings.Join(tool.DetectCmd, " ")
 }
 
 // executeOne runs the upgrade for a single tool.

--- a/internal/update/upgrade/executor_test.go
+++ b/internal/update/upgrade/executor_test.go
@@ -106,6 +106,51 @@ func TestExecute_DevBuildOnlyNoBackupCreated(t *testing.T) {
 	}
 }
 
+func TestExecute_VersionUnknownIsSurfacedAsSkipped(t *testing.T) {
+	results := []update.UpdateResult{
+		makeResult("engram", update.VersionUnknown, "", "1.2.0", update.InstallBinary),
+	}
+	results[0].Tool.DetectCmd = []string{"engram", "version"}
+
+	report := Execute(context.Background(), results, linuxProfile(), t.TempDir(), false)
+
+	if len(report.Results) != 1 {
+		t.Fatalf("len(Results) = %d, want 1", len(report.Results))
+	}
+	if report.Results[0].Status != UpgradeSkipped {
+		t.Fatalf("status = %q, want %q", report.Results[0].Status, UpgradeSkipped)
+	}
+	if report.Results[0].ManualHint == "" {
+		t.Fatal("ManualHint must be populated for version-unknown tools")
+	}
+	if !strings.Contains(report.Results[0].ManualHint, "`engram version`") {
+		t.Fatalf("ManualHint = %q, want detect command hint", report.Results[0].ManualHint)
+	}
+	if report.BackupID != "" {
+		t.Fatalf("BackupID = %q, want empty when nothing is executed", report.BackupID)
+	}
+}
+
+// --- TestRenderUpgradeReport_DryRunManualHintNotCountedAsPending ---
+
+func TestRenderUpgradeReport_DryRunManualHintNotCountedAsPending(t *testing.T) {
+	report := UpgradeReport{
+		DryRun: true,
+		Results: []ToolUpgradeResult{
+			{ToolName: "engram", Status: UpgradeSkipped, ManualHint: "source build — upgrade manually"},
+		},
+	}
+
+	output := RenderUpgradeReport(report)
+
+	if strings.Contains(output, "upgrade(s) pending") {
+		t.Fatalf("manual-hint skips must NOT be counted as pending upgrades in dry-run:\n%s", output)
+	}
+	if !strings.Contains(output, "manual") {
+		t.Fatalf("dry-run output should mention manual attention:\n%s", output)
+	}
+}
+
 // --- TestExecute_BackupBeforeExecution ---
 
 // TestExecute_BackupBeforeExecution verifies the architectural invariant:

--- a/internal/update/upgrade/render.go
+++ b/internal/update/upgrade/render.go
@@ -46,10 +46,10 @@ func RenderUpgradeReport(report UpgradeReport) string {
 			fmt.Fprintf(&b, "  FAILED: %s\n", errMsg)
 			failed++
 		case UpgradeSkipped:
-			if report.DryRun {
-				fmt.Fprintf(&b, "  %s → %s  (dry-run)\n", r.OldVersion, r.NewVersion)
-			} else if r.ManualHint != "" {
+			if r.ManualHint != "" {
 				fmt.Fprintf(&b, "  manual update required: %s\n", r.ManualHint)
+			} else if report.DryRun {
+				fmt.Fprintf(&b, "  %s → %s  (dry-run)\n", r.OldVersion, r.NewVersion)
 			} else {
 				fmt.Fprintf(&b, "  skipped\n")
 			}
@@ -67,7 +67,24 @@ func RenderUpgradeReport(report UpgradeReport) string {
 	}
 
 	if report.DryRun {
-		fmt.Fprintf(&b, "  %d upgrade(s) pending. Run without --dry-run to apply.\n", len(report.Results))
+		// Count only actionable upgrades (no ManualHint) as pending.
+		// Manual-hint items (DevBuild, VersionUnknown) will not run even
+		// without --dry-run, so counting them as "pending" is misleading.
+		actionable := 0
+		for _, r := range report.Results {
+			if r.Status == UpgradeSkipped && r.ManualHint == "" {
+				actionable++
+			}
+		}
+		if actionable > 0 {
+			fmt.Fprintf(&b, "  %d upgrade(s) pending. Run without --dry-run to apply.\n", actionable)
+		}
+		if skipped-actionable > 0 {
+			fmt.Fprintf(&b, "  %d tool(s) require manual attention (see hints above).\n", skipped-actionable)
+		}
+		if actionable == 0 && skipped == 0 {
+			b.WriteString("  No actionable upgrades found.\n")
+		}
 	} else {
 		fmt.Fprintf(&b, "  %d succeeded, %d failed, %d skipped.\n", succeeded, failed, skipped)
 	}

--- a/testdata/golden/persona-opencode-gentleman.golden
+++ b/testdata/golden/persona-opencode-gentleman.golden
@@ -1,3 +1,4 @@
+<!-- gentle-ai:persona -->
 ## Rules
 
 - Never add "Co-Authored-By" or AI attribution to commits. Use conventional commits only.
@@ -49,3 +50,4 @@ When you detect any of these contexts, IMMEDIATELY load the corresponding skill 
 | Creating new AI skills | skill-creator |
 
 Load skills BEFORE writing code. Apply ALL patterns. Multiple skills can apply simultaneously.
+<!-- /gentle-ai:persona -->

--- a/testdata/golden/persona-opencode-neutral.golden
+++ b/testdata/golden/persona-opencode-neutral.golden
@@ -1,3 +1,4 @@
+<!-- gentle-ai:persona -->
 ## Rules
 
 - Never add "Co-Authored-By" or AI attribution to commits. Use conventional commits only.
@@ -49,3 +50,4 @@ When you detect any of these contexts, IMMEDIATELY load the corresponding skill 
 | Creating new AI skills | skill-creator |
 
 Load skills BEFORE writing code. Apply ALL patterns. Multiple skills can apply simultaneously.
+<!-- /gentle-ai:persona -->


### PR DESCRIPTION
Closes #286
Closes #280
Closes #285

## Summary

- **#286**: Surface dev builds and version-unknown tools in upgrade report instead of silently omitting them. Add 10s context timeout to version detection subprocess.
- **#280**: Preserve user content in OpenCode `AGENTS.md` via marker-based section injection instead of full-file replacement. Harden legacy persona stripping across all agents.
- **#285**: Add `gentle-ai uninstall` command with `--dry-run`, `--force`, `--purge-memory`, and `--keep-backups` flags. Removes only known managed files, preserves memory by default.

## Changes

| File | Change |
|------|--------|
| `internal/update/detect.go` | Recognize `dev` sentinel in version output; add 10s context timeout |
| `internal/update/upgrade/executor.go` | Surface `VersionUnknown` tools as `UpgradeSkipped` with manual hints |
| `internal/update/upgrade/render.go` | ManualHint takes priority over dry-run label; fix pending count |
| `internal/update/check_test.go` | Tests for dev sentinel parsing |
| `internal/update/upgrade/executor_test.go` | Tests for VersionUnknown surfacing and dry-run count |
| `internal/components/persona/inject.go` | OpenCode uses marker-based injection; exact-asset legacy detection; hardened VS Code cleanup |
| `internal/components/persona/inject_test.go` | Regression tests for user content preservation, ATL block, legacy asset replacement |
| `internal/cli/uninstall.go` | New managed uninstall command |
| `internal/cli/uninstall_test.go` | Tests for dry-run, force, keep flags, cancellation |
| `internal/app/app.go` | Dispatch `uninstall` before platform validation |
| `internal/app/app_test.go` | Tests for uninstall dispatch |
| `internal/app/help.go` | Add `uninstall` to help text |
| `internal/app/help_test.go` | Help output includes `uninstall` |
| `testdata/golden/persona-opencode-*.golden` | Updated with persona markers |

## Test Plan

- [x] `go test ./...` passes (all packages green)
- [x] Adversarial review (Judgment Day) — 3 rounds, both judges clean
- [x] Regression tests for user content preservation in all agent strategies
- [x] Regression tests for legacy asset replacement without duplication
- [x] Regression tests for dry-run manual-hint count accuracy

## Contributor Checklist

- [x] Linked approved issues
- [x] Added `type:bug` label
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
- [x] Tests cover all changed behavior