### PR TITLE
fix(opencode): enforce parent task permissions for delegated sub-agents

### DIFF
--- a/internal/assets/opencode/plugins/background-agents.test.ts
+++ b/internal/assets/opencode/plugins/background-agents.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, mock, test } from "bun:test"
+
+mock.module("@opencode-ai/plugin", () => ({
+  tool: Object.assign(() => ({}), { schema: { string: () => ({ describe: () => ({}) }) } }),
+}))
+
+mock.module("unique-names-generator", () => ({
+  default: {
+    adjectives: [],
+    animals: [],
+    colors: [],
+    uniqueNamesGenerator: () => "mocked-name",
+  },
+}))
+
+const { __testables } = await import("./background-agents")
+
+function createClientWithTaskPermission(
+  permission: Record<string, "ask" | "allow" | "deny"> | undefined,
+) {
+  return {
+    config: {
+      get: async () => ({
+        data: {
+          agent: {
+            "sdd-orchestrator": {
+              permission: permission ? { task: permission } : {},
+            },
+          },
+        },
+      }),
+    },
+  }
+}
+
+describe("resolvePermissionDecision", () => {
+  test("prioritizes exact match over wildcard pattern", () => {
+    const decision = __testables.resolvePermissionDecision(
+      {
+        "*": "deny",
+        "sdd-*": "allow",
+        "sdd-apply-free": "deny",
+      },
+      "sdd-apply-free",
+    )
+
+    expect(decision).toBe("deny")
+  })
+
+  test("matches wildcard patterns", () => {
+    const decision = __testables.resolvePermissionDecision(
+      {
+        "*": "deny",
+        "sdd-*-free": "allow",
+      },
+      "sdd-apply-free",
+    )
+
+    expect(decision).toBe("allow")
+  })
+
+  test("falls back to star rule when nothing else matches", () => {
+    const decision = __testables.resolvePermissionDecision(
+      {
+        "*": "deny",
+      },
+      "sdd-apply",
+    )
+
+    expect(decision).toBe("deny")
+  })
+})
+
+describe("getSuggestedAgentName", () => {
+  test("suggests the matching default-profile agent", () => {
+    const suggestion = __testables.getSuggestedAgentName(
+      {
+        "*": "deny",
+        "sdd-apply": "allow",
+      },
+      "sdd-apply-free",
+    )
+
+    expect(suggestion).toBe("sdd-apply")
+  })
+
+  test("suggests the matching suffixed-profile agent", () => {
+    const suggestion = __testables.getSuggestedAgentName(
+      {
+        "*": "deny",
+        "sdd-apply-free": "allow",
+      },
+      "sdd-apply",
+    )
+
+    expect(suggestion).toBe("sdd-apply-free")
+  })
+})
+
+describe("assertDelegationAllowed", () => {
+  test("allows delegation when target agent is explicitly allowed", async () => {
+    const client = createClientWithTaskPermission({
+      "*": "deny",
+      "sdd-apply": "allow",
+    })
+
+    await expect(
+      __testables.assertDelegationAllowed(
+        client as never,
+        "sdd-orchestrator",
+        "sdd-apply",
+      ),
+    ).resolves.toBeUndefined()
+  })
+
+  test("rejects delegation outside the parent routing policy with suggestion", async () => {
+    const client = createClientWithTaskPermission({
+      "*": "deny",
+      "sdd-apply": "allow",
+    })
+
+    await expect(
+      __testables.assertDelegationAllowed(
+        client as never,
+        "sdd-orchestrator",
+        "sdd-apply-free",
+      ),
+    ).rejects.toThrow('Try "sdd-apply" instead.')
+  })
+
+  test("keeps backward compatibility when parent has no task policy", async () => {
+    const client = createClientWithTaskPermission(undefined)
+
+    await expect(
+      __testables.assertDelegationAllowed(
+        client as never,
+        "sdd-orchestrator",
+        "sdd-apply-free",
+      ),
+    ).resolves.toBeUndefined()
+  })
+})

--- a/internal/assets/opencode/plugins/background-agents.ts
+++ b/internal/assets/opencode/plugins/background-agents.ts
@@ -398,6 +398,14 @@ async function parseAgentMode(
  */
 type PermissionEntry = "ask" | "allow" | "deny" | Record<string, "ask" | "allow" | "deny">
 
+type AgentConfigMap = Record<
+  string,
+  {
+    permission?: Record<string, PermissionEntry>
+    model?: string
+  }
+>
+
 /**
  * Check if a permission entry denies access (Law 4: Fail Fast).
  * Handles both simple values ("deny") and pattern objects ({ "*": "deny" }).
@@ -407,6 +415,80 @@ function isPermissionDenied(entry: PermissionEntry | undefined): boolean {
   if (entry === "deny") return true
   if (typeof entry === "object" && entry["*"] === "deny") return true
   return false
+}
+
+function matchesPermissionPattern(pattern: string, value: string): boolean {
+  const escaped = pattern.replace(/[|\\{}()[\]^$+?.]/g, "\\$&").replace(/\*/g, ".*")
+  return new RegExp(`^${escaped}$`).test(value)
+}
+
+function resolvePermissionDecision(
+  entry: PermissionEntry | undefined,
+  target: string,
+): "ask" | "allow" | "deny" | undefined {
+  if (entry === undefined) return undefined
+  if (typeof entry === "string") return entry
+
+  if (target in entry) return entry[target]
+
+  const patternEntries = Object.entries(entry).filter(([pattern]) => pattern !== "*")
+  for (const [pattern, decision] of patternEntries) {
+    if (matchesPermissionPattern(pattern, target)) {
+      return decision
+    }
+  }
+
+  return entry["*"]
+}
+
+function getSuggestedAgentName(
+  taskPermission: PermissionEntry | undefined,
+  targetAgent: string,
+): string | undefined {
+  if (!taskPermission || typeof taskPermission === "string") return undefined
+
+  const baseName = targetAgent.replace(/-(free|ocgo)$/u, "")
+  const allowedAgents = Object.entries(taskPermission)
+    .filter(([agentName, decision]) => agentName !== "*" && decision === "allow")
+    .map(([agentName]) => agentName)
+
+  return allowedAgents.find((agentName) => agentName === baseName || agentName.startsWith(`${baseName}-`))
+}
+
+async function getAgentConfigs(client: OpencodeClient): Promise<AgentConfigMap> {
+  const config = await client.config.get()
+  const configData = config.data as {
+    agent?: AgentConfigMap
+  } | undefined
+
+  return configData?.agent ?? {}
+}
+
+async function assertDelegationAllowed(
+  client: OpencodeClient,
+  parentAgent: string | undefined,
+  targetAgent: string,
+): Promise<void> {
+  if (!parentAgent) return
+
+  const agentConfigs = await getAgentConfigs(client)
+  const permission = agentConfigs[parentAgent]?.permission
+  const taskDecision = resolvePermissionDecision(permission?.task, targetAgent)
+  const suggestedAgent = getSuggestedAgentName(permission?.task, targetAgent)
+  const suggestionSuffix =
+    suggestedAgent && suggestedAgent !== targetAgent ? ` Try "${suggestedAgent}" instead.` : ""
+
+  if (taskDecision === "deny") {
+    throw new Error(
+      `Agent "${parentAgent}" cannot delegate to "${targetAgent}" because its task permission explicitly denies it.${suggestionSuffix}`,
+    )
+  }
+
+  if (permission?.task && taskDecision !== "allow") {
+    throw new Error(
+      `Agent "${parentAgent}" cannot delegate to "${targetAgent}" because it is outside the allowed task routing policy.${suggestionSuffix}`,
+    )
+  }
 }
 
 /**
@@ -422,16 +504,7 @@ async function parseAgentWriteCapability(
   log: Logger,
 ): Promise<{ isReadOnly: boolean }> {
   try {
-    const config = await client.config.get()
-    const configData = config.data as {
-      agent?: Record<
-        string,
-        {
-          permission?: Record<string, PermissionEntry>
-        }
-      >
-    }
-    const permission = configData?.agent?.[agentName]?.permission ?? {}
+    const permission = (await getAgentConfigs(client))[agentName]?.permission ?? {}
 
     const editDenied = isPermissionDenied(permission.edit)
     const writeDenied = isPermissionDenied(permission.write)
@@ -459,12 +532,7 @@ async function resolveAgentModel(
   log: Logger,
 ): Promise<{ providerID: string; modelID: string } | undefined> {
   try {
-    const config = await client.config.get()
-    const configData = config.data as {
-      agent?: Record<string, { model?: string }>
-    } | undefined
-
-    const modelStr = configData?.agent?.[agentName]?.model
+    const modelStr = (await getAgentConfigs(client))[agentName]?.model
     if (!modelStr) return undefined
 
     const slashIndex = modelStr.indexOf("/")
@@ -577,6 +645,8 @@ class DelegationManager {
         `Agent "${input.agent}" not found.\n\nAvailable agents:\n${available || "(none)"}`,
       )
     }
+
+    await assertDelegationAllowed(this.client, input.parentAgent, input.agent)
 
     // NOTE: Read-only restriction removed — any sub-agent can use delegate.
     // Background delegations run in isolated sessions outside OpenCode's session tree.
@@ -1452,6 +1522,13 @@ export const BackgroundAgents: Plugin = async (ctx) => {
       }
     },
   }
+}
+
+export const __testables = {
+  assertDelegationAllowed,
+  getSuggestedAgentName,
+  matchesPermissionPattern,
+  resolvePermissionDecision,
 }
 
 export default BackgroundAgents


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #278

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Enforces `permission.task` from the parent agent before `delegate()` launches a sub-agent.
- Prevents cross-profile SDD delegation leaks such as `sdd-orchestrator` delegating to `sdd-apply-free`.
- Adds actionable error messages that suggest the matching allowed agent when possible.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/assets/opencode/plugins/background-agents.ts` | Added task-permission resolution, delegation guard, and suggested-agent messaging |
| `internal/assets/opencode/plugins/background-agents.test.ts` | Added isolated Bun tests covering permission matching, enforcement, and suggestions |

---

## 🧪 Test Plan

**Unit Tests**
```bash
bun test internal/assets/opencode/plugins/background-agents.test.ts
```

**E2E Tests** (Docker required)
```bash
cd e2e && ./docker-test.sh
```

- [x] Manually tested locally
- [x] Targeted Bun tests pass for the delegation guard
- [ ] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [ ] I have added the appropriate `type:*` label to this PR
- [ ] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [ ] I have updated documentation if necessary
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

This intentionally focuses on runtime enforcement and guidance only.
It does not include local post-upgrade hardening scripts, which are installation-specific workarounds rather than upstream platform behavior.