### PR TITLE
fix(filemerge): skip directory fsync on Windows to avoid Access Denied

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,6 +126,22 @@ chmod +x docker-test.sh
 
 > ⚠️ E2E tests spin up containers to simulate real installation environments. They may take a few minutes to complete.
 
+### Windows — Known Test Limitations
+
+Some unit tests require OS-level capabilities that are restricted on Windows by default.
+
+#### Symlink tests (`SeCreateSymbolicLinkPrivilege`)
+
+Tests that create symbolic links (e.g. in `internal/components/filemerge`) will be **skipped automatically** on Windows builds where the process lacks `SeCreateSymbolicLinkPrivilege` (`ERROR_PRIVILEGE_NOT_HELD`, errno 1314). This is a Windows security policy, not a bug in the code.
+
+To run these tests without restrictions, choose one of:
+
+- **Enable Developer Mode** — Settings → System → For developers → Developer Mode. This grants symlink creation to all processes without admin rights.
+- **Run as Administrator** — open your terminal as Administrator before running `go test ./...`.
+- **Grant the privilege explicitly** via Group Policy: `Local Security Policy → User Rights Assignment → Create symbolic links`.
+
+> On Linux and macOS these tests always run without any extra setup.
+
 ---
 
 ## Commit Convention

--- a/internal/components/filemerge/writer.go
+++ b/internal/components/filemerge/writer.go
@@ -7,6 +7,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"runtime"
 )
 
 const maxAtomicFileSize = 16 << 20
@@ -79,8 +80,12 @@ func WriteFileAtomic(path string, content []byte, perm fs.FileMode) (WriteResult
 		return WriteResult{}, fmt.Errorf("open parent directory for %q: %w", path, err)
 	}
 	defer dirFD.Close()
-	if err := dirFD.Sync(); err != nil {
-		return WriteResult{}, fmt.Errorf("sync parent directory for %q: %w", path, err)
+	// Windows does not support fsync on directories (NTFS limitation) — skip it.
+	// On all other platforms, sync the directory to flush the new entry to disk.
+	if runtime.GOOS != "windows" {
+		if err := dirFD.Sync(); err != nil {
+			return WriteResult{}, fmt.Errorf("sync parent directory for %q: %w", path, err)
+		}
 	}
 
 	cleanup = false

--- a/internal/components/filemerge/writer.go
+++ b/internal/components/filemerge/writer.go
@@ -2,6 +2,7 @@ package filemerge
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -9,6 +10,18 @@ import (
 	"path/filepath"
 	"runtime"
 )
+
+// runtimeGOOS and syncDirFn are package-level vars so tests can override them
+// without spawning a real Windows process.
+var runtimeGOOS = func() string { return runtime.GOOS }
+var syncDirFn = func(dir string) error {
+	fd, err := os.Open(dir)
+	if err != nil {
+		return fmt.Errorf("open parent directory %q: %w", dir, err)
+	}
+	defer fd.Close()
+	return fd.Sync()
+}
 
 const maxAtomicFileSize = 16 << 20
 
@@ -75,15 +88,11 @@ func WriteFileAtomic(path string, content []byte, perm fs.FileMode) (WriteResult
 		return WriteResult{}, fmt.Errorf("replace %q atomically: %w", path, err)
 	}
 
-	dirFD, err := os.Open(dir)
-	if err != nil {
-		return WriteResult{}, fmt.Errorf("open parent directory for %q: %w", path, err)
-	}
-	defer dirFD.Close()
-	// Windows does not support fsync on directories (NTFS limitation) — skip it.
-	// On all other platforms, sync the directory to flush the new entry to disk.
-	if runtime.GOOS != "windows" {
-		if err := dirFD.Sync(); err != nil {
+	// Sync the parent directory to flush the new directory entry to disk.
+	// On Windows, NTFS returns ErrPermission when syncing a directory fd — tolerate
+	// that specific error only. Any other error (e.g. disk full) is still fatal.
+	if err := syncDirFn(dir); err != nil {
+		if !(runtimeGOOS() == "windows" && errors.Is(err, os.ErrPermission)) {
 			return WriteResult{}, fmt.Errorf("sync parent directory for %q: %w", path, err)
 		}
 	}

--- a/internal/components/filemerge/writer_test.go
+++ b/internal/components/filemerge/writer_test.go
@@ -6,8 +6,24 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"syscall"
 	"testing"
 )
+
+// isSymlinkPrivilegeError reports whether err is the Windows
+// ERROR_PRIVILEGE_NOT_HELD (1314) error returned by os.Symlink when the
+// process lacks SeCreateSymbolicLinkPrivilege. errors.Is does not map this
+// errno to os.ErrPermission, so we unwrap and check the raw value.
+func isSymlinkPrivilegeError(err error) bool {
+	var le *os.LinkError
+	if errors.As(err, &le) {
+		var errno syscall.Errno
+		if errors.As(le.Err, &errno) {
+			return errno == 1314 // ERROR_PRIVILEGE_NOT_HELD
+		}
+	}
+	return false
+}
 
 func TestWriteFileAtomicReadOnlyDirRelaxesOwnerWritePermission(t *testing.T) {
 	if runtime.GOOS == "windows" {
@@ -77,6 +93,12 @@ func TestWriteFileAtomicRejectsExistingSymlink(t *testing.T) {
 	}
 	path := filepath.Join(dir, "linked.txt")
 	if err := os.Symlink(target, path); err != nil {
+		// On Windows without Developer Mode or admin rights, symlink creation
+		// requires SeCreateSymbolicLinkPrivilege (ERROR_PRIVILEGE_NOT_HELD = 1314).
+		// Skip gracefully — the test infrastructure lacks the privilege, not the code.
+		if isSymlinkPrivilegeError(err) {
+			t.Skipf("skipping: SeCreateSymbolicLinkPrivilege not held on this Windows build: %v", err)
+		}
 		t.Fatalf("Symlink() error = %v", err)
 	}
 
@@ -111,6 +133,12 @@ func TestWriteFileAtomicRejectsSymlinkParentDirectory(t *testing.T) {
 	}
 	linkDir := filepath.Join(base, "linked")
 	if err := os.Symlink(realDir, linkDir); err != nil {
+		// On Windows without Developer Mode or admin rights, symlink creation
+		// requires SeCreateSymbolicLinkPrivilege (ERROR_PRIVILEGE_NOT_HELD = 1314).
+		// Skip gracefully — the test infrastructure lacks the privilege, not the code.
+		if isSymlinkPrivilegeError(err) {
+			t.Skipf("skipping: SeCreateSymbolicLinkPrivilege not held on this Windows build: %v", err)
+		}
 		t.Fatalf("Symlink(linkDir) error = %v", err)
 	}
 

--- a/internal/components/filemerge/writer_test.go
+++ b/internal/components/filemerge/writer_test.go
@@ -1,9 +1,11 @@
 package filemerge
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -116,5 +118,93 @@ func TestWriteFileAtomicRejectsSymlinkParentDirectory(t *testing.T) {
 	_, err := WriteFileAtomic(path, []byte("value\n"), 0o644)
 	if err == nil {
 		t.Fatal("WriteFileAtomic() error = nil, want symlink parent rejection")
+	}
+}
+
+// TestWriteFileAtomicIgnoresPermissionErrorFromSyncDirOnWindows verifies that
+// ErrPermission from syncDirFn is silently tolerated on Windows — NTFS returns
+// ACCESS_DENIED when syncing a directory fd, which must not fail the write.
+func TestWriteFileAtomicIgnoresPermissionErrorFromSyncDirOnWindows(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nested", "config.json")
+	content := []byte("{\"ok\":true}\n")
+
+	origGOOS := runtimeGOOS
+	origSyncDir := syncDirFn
+	t.Cleanup(func() {
+		runtimeGOOS = origGOOS
+		syncDirFn = origSyncDir
+	})
+
+	runtimeGOOS = func() string { return "windows" }
+	syncDirFn = func(string) error { return os.ErrPermission }
+
+	result, err := WriteFileAtomic(path, content, 0o644)
+	if err != nil {
+		t.Fatalf("WriteFileAtomic() error = %v, want nil on windows permission-denied dir sync", err)
+	}
+	if !result.Changed || !result.Created {
+		t.Fatalf("WriteFileAtomic() result = %+v, want Changed=true Created=true", result)
+	}
+	got, readErr := os.ReadFile(path)
+	if readErr != nil {
+		t.Fatalf("ReadFile() error = %v", readErr)
+	}
+	if string(got) != string(content) {
+		t.Fatalf("file content = %q, want %q", string(got), string(content))
+	}
+}
+
+// TestWriteFileAtomicPropagatesSyncDirErrorOnUnix verifies that any syncDirFn
+// error is propagated on non-Windows platforms — no silent swallowing.
+func TestWriteFileAtomicPropagatesSyncDirErrorOnUnix(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nested", "config.json")
+	content := []byte("{\"ok\":true}\n")
+
+	origGOOS := runtimeGOOS
+	origSyncDir := syncDirFn
+	t.Cleanup(func() {
+		runtimeGOOS = origGOOS
+		syncDirFn = origSyncDir
+	})
+
+	runtimeGOOS = func() string { return "linux" }
+	syncDirFn = func(string) error { return os.ErrPermission }
+
+	_, err := WriteFileAtomic(path, content, 0o644)
+	if err == nil {
+		t.Fatal("WriteFileAtomic() error = nil, want sync parent directory failure on unix")
+	}
+	if !strings.Contains(err.Error(), "sync parent directory") {
+		t.Fatalf("WriteFileAtomic() error = %v, want sync parent directory context", err)
+	}
+}
+
+// TestWriteFileAtomicPropagatesUnexpectedSyncDirErrorOnWindows verifies that
+// non-ErrPermission errors from syncDirFn are still propagated on Windows —
+// only the specific NTFS directory-sync permission error is tolerated.
+func TestWriteFileAtomicPropagatesUnexpectedSyncDirErrorOnWindows(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nested", "config.json")
+	content := []byte("{\"ok\":true}\n")
+	boom := errors.New("boom")
+
+	origGOOS := runtimeGOOS
+	origSyncDir := syncDirFn
+	t.Cleanup(func() {
+		runtimeGOOS = origGOOS
+		syncDirFn = origSyncDir
+	})
+
+	runtimeGOOS = func() string { return "windows" }
+	syncDirFn = func(string) error { return boom }
+
+	_, err := WriteFileAtomic(path, content, 0o644)
+	if err == nil {
+		t.Fatal("WriteFileAtomic() error = nil, want unexpected sync dir error on windows")
+	}
+	if !errors.Is(err, boom) {
+		t.Fatalf("WriteFileAtomic() error = %v, want wrapped boom", err)
 	}
 }


### PR DESCRIPTION
Closes #293

## Summary

- Fix `WriteFileAtomic` failing with "Access is denied" on Windows by tolerating only the specific NTFS `ErrPermission` from directory `fsync` — other errors remain fatal
- Add injectable `syncDirFn`/`runtimeGOOS` vars with 3 targeted tests covering Windows toleration, Unix propagation, and unexpected-error propagation
- Add graceful `t.Skip` for symlink tests lacking `SeCreateSymbolicLinkPrivilege` on Windows
- Document Windows symlink privilege requirements in CONTRIBUTING.md

## Changes

| File | Change |
|------|--------|
| `internal/components/filemerge/writer.go` | Tolerate `ErrPermission` from dir sync on Windows only |
| `internal/components/filemerge/writer_test.go` | 3 injectable sync tests + symlink privilege skip |
| `CONTRIBUTING.md` | Windows symlink privilege docs |

## Test Plan

- [x] `go test ./internal/components/filemerge/...` passes
- [x] Injectable tests cover Windows/Unix/unexpected error paths
- [x] Symlink tests skip gracefully on unprivileged Windows

## Contributor Checklist

- [x] Linked approved issue (#293)
- [x] Added `type:bug` label
- [x] Conventional commit format
- [x] Tests cover all changed behavior