### PR TITLE
feat(cli): add gentle-ai doctor command for ecosystem health diagnostics

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -12,7 +12,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/gentleman-programming/gentle-ai/internal/backup"
 	"github.com/gentleman-programming/gentle-ai/internal/cli"
-	componentuninstall "github.com/gentleman-programming/gentle-ai/internal/components/uninstall" // ← 1a. NUEVO
+	componentuninstall "github.com/gentleman-programming/gentle-ai/internal/components/uninstall"
 	"github.com/gentleman-programming/gentle-ai/internal/doctor"
 	"github.com/gentleman-programming/gentle-ai/internal/model"
 	"github.com/gentleman-programming/gentle-ai/internal/pipeline"
@@ -100,8 +100,8 @@ func RunArgs(args []string, stdout io.Writer) error {
 		case "uninstall":
 			_, err := cli.RunUninstall(args[1:], stdout)
 			return err
-		case "doctor": // <-- ADD THIS
-			return runDoctor(args[1:], stdout) // <-- ADD THIS
+		case "doctor":
+			return runDoctor(args[1:], stdout)
 		}
 	}
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -12,7 +12,8 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/gentleman-programming/gentle-ai/internal/backup"
 	"github.com/gentleman-programming/gentle-ai/internal/cli"
-	componentuninstall "github.com/gentleman-programming/gentle-ai/internal/components/uninstall"
+	componentuninstall "github.com/gentleman-programming/gentle-ai/internal/components/uninstall" // ← 1a. NUEVO
+	"github.com/gentleman-programming/gentle-ai/internal/doctor"
 	"github.com/gentleman-programming/gentle-ai/internal/model"
 	"github.com/gentleman-programming/gentle-ai/internal/pipeline"
 	"github.com/gentleman-programming/gentle-ai/internal/planner"
@@ -33,10 +34,52 @@ var (
 	upgradeExecute           = upgrade.Execute
 	ensureCurrentOSSupported = system.EnsureCurrentOSSupported
 	detectSystem             = system.Detect
+	findAllBinaries          = system.FindAllBinaryCopies
 )
 
 func Run() error {
 	return RunArgs(os.Args[1:], os.Stdout)
+}
+
+func runDoctor(args []string, stdout io.Writer) error {
+	opts := doctor.Options{
+		Timeout: doctor.DefaultTimeout,
+	}
+
+	// Manual arg-loop: same pattern as runUpgrade (no flag package).
+	for i := 0; i < len(args); i++ {
+		switch {
+		case args[i] == "--json":
+			opts.JSON = true
+		case args[i] == "--verbose":
+			opts.Verbose = true
+		case args[i] == "--category" && i+1 < len(args):
+			i++
+			opts.Category = args[i]
+		case strings.HasPrefix(args[i], "-"):
+			return fmt.Errorf("unknown flag %q — run 'gentle-ai help' for usage", args[i])
+		}
+	}
+
+	// Wire dependency injection.
+	doctor.SetFindAllBinaries(findAllBinaries)
+
+	checks := doctor.AllChecks()
+	report := doctor.RunChecks(context.Background(), checks, opts)
+
+	if opts.JSON {
+		if err := doctor.RenderJSON(stdout, report); err != nil {
+			return fmt.Errorf("render JSON: %w", err)
+		}
+	} else {
+		_, _ = fmt.Fprint(stdout, doctor.RenderReport(report))
+	}
+
+	if !report.Healthy {
+		return fmt.Errorf("doctor found %d failing check(s)", report.Failed)
+	}
+
+	return nil
 }
 
 func RunArgs(args []string, stdout io.Writer) error {
@@ -57,6 +100,8 @@ func RunArgs(args []string, stdout io.Writer) error {
 		case "uninstall":
 			_, err := cli.RunUninstall(args[1:], stdout)
 			return err
+		case "doctor": // <-- ADD THIS
+			return runDoctor(args[1:], stdout) // <-- ADD THIS
 		}
 	}
 

--- a/internal/app/help.go
+++ b/internal/app/help.go
@@ -19,6 +19,7 @@ COMMANDS
   update       Check for available updates
   upgrade      Apply updates to managed tools
   restore      Restore a config backup
+  doctor       Run a read-only health check of the ecosystem
   version      Print version
 
 FLAGS

--- a/internal/doctor/deps.go
+++ b/internal/doctor/deps.go
@@ -1,0 +1,116 @@
+package doctor
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gentleman-programming/gentle-ai/internal/verify"
+)
+
+// managedBinaries lists the binaries that gentle-ai manages.
+var managedBinaries = []string{"gentle-ai", "engram", "gga"}
+
+// findAllBinaries is the function used to locate all copies of a binary in PATH.
+// In production this is set to system.FindAllBinaryCopies by the CLI layer.
+// Tests override it directly (same package).
+var findAllBinaries func(string) []string
+
+// SetFindAllBinaries wires the binary lookup function from the CLI layer.
+// This must be called before RunChecks to enable dependency health checks.
+func SetFindAllBinaries(fn func(string) []string) {
+	findAllBinaries = fn
+}
+
+// NewDepsChecks creates the dependency health checks.
+// For the MVP, this only includes duplicate binary detection.
+// Future: version comparison (update.CheckFiltered), engram HTTP health, GGA assets.
+func NewDepsChecks() []Check {
+	checks := make([]Check, 0, len(managedBinaries))
+	for _, bin := range managedBinaries {
+		bin := bin // capture loop variable
+		checks = append(checks, Check{
+			ID:          "binary-" + bin,
+			Category:    "deps",
+			Description: bin + " binary on PATH",
+			Run:         duplicateBinaryCheck(bin),
+		})
+	}
+	return checks
+}
+
+// duplicateBinaryCheck returns a check function that detects whether a managed
+// binary exists in PATH and whether multiple copies shadow each other.
+func duplicateBinaryCheck(name string) func(context.Context) CheckResult {
+	return func(ctx context.Context) CheckResult {
+		if ctx.Err() != nil {
+			return CheckResult{
+				ID:       "binary-" + name,
+				Category: "deps",
+				Status:   verify.CheckStatusSkipped,
+				Message:  "skipped: context cancelled",
+			}
+		}
+
+		if findAllBinaries == nil {
+			return CheckResult{
+				ID:       "binary-" + name,
+				Category: "deps",
+				Status:   verify.CheckStatusSkipped,
+				Message:  "skipped: binary lookup not configured",
+			}
+		}
+
+		copies := findAllBinaries(name)
+
+		switch len(copies) {
+		case 0:
+			return CheckResult{
+				ID:       "binary-" + name,
+				Category: "deps",
+				Status:   verify.CheckStatusWarning,
+				Message:  fmt.Sprintf("%s not found in PATH", name),
+				Details:  []string{"Install with: gentle-ai install (or check your PATH)"},
+			}
+
+		case 1:
+			return CheckResult{
+				ID:       "binary-" + name,
+				Category: "deps",
+				Status:   verify.CheckStatusPassed,
+				Message:  fmt.Sprintf("%s — single copy at %s", name, copies[0]),
+			}
+
+		default:
+			details := make([]string, 0, len(copies)+2)
+			details = append(details, fmt.Sprintf("found %d copies:", len(copies)))
+			for i, p := range copies {
+				if i == 0 {
+					details = append(details, fmt.Sprintf("  %s (active — resolves first)", p))
+				} else {
+					details = append(details, fmt.Sprintf("  %s (shadowed)", p))
+				}
+			}
+			details = append(details, "Fix: remove duplicates, keep only the one managed by your package manager")
+
+			return CheckResult{
+				ID:       "binary-" + name,
+				Category: "deps",
+				Status:   verify.CheckStatusWarning,
+				Message:  fmt.Sprintf("%s has %d copies in PATH — possible shadowing", name, len(copies)),
+				Details:  details,
+			}
+		}
+	}
+}
+
+// AllChecks returns every check the doctor knows about.
+// The CLI layer calls this to build the full check set.
+func AllChecks() []Check {
+	var all []Check
+	all = append(all, NewDepsChecks()...)
+	// Future phases:
+	// all = append(all, NewPlatformChecks()...)
+	// all = append(all, NewAgentChecks()...)
+	// all = append(all, NewEnvChecks()...)
+	return all
+}

--- a/internal/doctor/deps_test.go
+++ b/internal/doctor/deps_test.go
@@ -1,0 +1,136 @@
+package doctor
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/internal/verify"
+)
+
+func TestDuplicateBinaryCheck(t *testing.T) {
+	tests := []struct {
+		name       string
+		binary     string
+		fakePaths  []string
+		wantStatus verify.CheckStatus
+		wantSubstr string // expected substring in Message
+	}{
+		{
+			name:       "single copy healthy",
+			binary:     "engram",
+			fakePaths:  []string{"/usr/local/bin/engram"},
+			wantStatus: verify.CheckStatusPassed,
+			wantSubstr: "single copy",
+		},
+		{
+			name:       "not found warning",
+			binary:     "engram",
+			fakePaths:  []string{},
+			wantStatus: verify.CheckStatusWarning,
+			wantSubstr: "not found",
+		},
+		{
+			name:       "two copies shadowing",
+			binary:     "engram",
+			fakePaths:  []string{"/usr/local/bin/engram", "/home/user/go/bin/engram"},
+			wantStatus: verify.CheckStatusWarning,
+			wantSubstr: "2 copies",
+		},
+		{
+			name:       "three copies shadowing",
+			binary:     "gga",
+			fakePaths:  []string{"/a/gga", "/b/gga", "/c/gga"},
+			wantStatus: verify.CheckStatusWarning,
+			wantSubstr: "3 copies",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			original := findAllBinaries
+			findAllBinaries = func(name string) []string {
+				if name == tt.binary {
+					return tt.fakePaths
+				}
+				return nil
+			}
+			defer func() { findAllBinaries = original }()
+
+			check := duplicateBinaryCheck(tt.binary)
+			result := check(context.Background())
+
+			if result.Status != tt.wantStatus {
+				t.Errorf("Status = %q, want %q", result.Status, tt.wantStatus)
+			}
+			if !strings.Contains(result.Message, tt.wantSubstr) {
+				t.Errorf("Message = %q, want substring %q", result.Message, tt.wantSubstr)
+			}
+		})
+	}
+}
+
+func TestDuplicateBinaryCheckRespectsContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	findAllBinaries = func(string) []string {
+		t.Fatal("should not be called when context is cancelled")
+		return nil
+	}
+	defer func() { findAllBinaries = nil }()
+
+	check := duplicateBinaryCheck("engram")
+	result := check(ctx)
+
+	if result.Status != verify.CheckStatusSkipped {
+		t.Errorf("Status = %q, want skipped on cancelled context", result.Status)
+	}
+}
+
+func TestDuplicateBinaryCheckNilLookup(t *testing.T) {
+	original := findAllBinaries
+	findAllBinaries = nil
+	defer func() { findAllBinaries = original }()
+
+	check := duplicateBinaryCheck("engram")
+	result := check(context.Background())
+
+	if result.Status != verify.CheckStatusSkipped {
+		t.Errorf("Status = %q, want skipped when lookup not configured", result.Status)
+	}
+}
+
+func TestDuplicateBinaryCheckDetailsMarkActiveShadowed(t *testing.T) {
+	findAllBinaries = func(string) []string {
+		return []string{"/usr/local/bin/engram", "/home/user/go/bin/engram"}
+	}
+	defer func() { findAllBinaries = nil }()
+
+	check := duplicateBinaryCheck("engram")
+	result := check(context.Background())
+
+	if len(result.Details) == 0 {
+		t.Fatal("expected details for duplicate binary")
+	}
+
+	joined := strings.Join(result.Details, "\n")
+	if !strings.Contains(joined, "active") {
+		t.Errorf("details should mark first copy as active:\n%s", joined)
+	}
+	if !strings.Contains(joined, "shadowed") {
+		t.Errorf("details should mark extra copies as shadowed:\n%s", joined)
+	}
+}
+
+func TestNewDepsChecks(t *testing.T) {
+	checks := NewDepsChecks()
+	if len(checks) != len(managedBinaries) {
+		t.Fatalf("len(checks) = %d, want %d", len(checks), len(managedBinaries))
+	}
+	for i, c := range checks {
+		if c.Category != "deps" {
+			t.Errorf("checks[%d].Category = %q, want deps", i, c.Category)
+		}
+	}
+}

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -1,0 +1,132 @@
+package doctor
+
+import (
+	"context"
+	"runtime"
+	"sync"
+	"time"
+
+	"github.com/gentleman-programming/gentle-ai/internal/verify"
+)
+
+// Check represents a single doctor diagnostic. The struct mirrors verify.Check
+// but returns a richer CheckResult instead of a plain error, since doctor needs
+// to surface details (paths, fix commands) beyond pass/fail.
+type Check struct {
+	ID          string
+	Category    string // "deps", "platform", "agents", "env"
+	Description string
+	Run         func(context.Context) CheckResult
+}
+
+// CheckResult holds the outcome of a single diagnostic.
+type CheckResult struct {
+	ID          string              `json:"id"`
+	Category    string              `json:"category"`
+	Description string              `json:"description"`
+	Status      verify.CheckStatus  `json:"status"`
+	Message     string              `json:"message"`
+	Details     []string            `json:"details,omitempty"`
+}
+
+// Report aggregates results from all checks in a single doctor run.
+type Report struct {
+	Checks   []CheckResult
+	Passed   int
+	Failed   int
+	Skipped  int
+	Warnings int
+	Healthy  bool
+	Duration time.Duration
+}
+
+// Options configures a doctor run.
+type Options struct {
+	Category string        // filter to a single category (empty = all)
+	JSON     bool          // machine-readable output
+	Verbose  bool          // extended detail
+	Timeout  time.Duration // global timeout (default 10s)
+}
+
+// DefaultTimeout is the global timeout for all doctor checks.
+const DefaultTimeout = 10 * time.Second
+
+// RunChecks executes all provided checks concurrently, bounded by a semaphore
+// sized to runtime.NumCPU(). The context carries the global timeout.
+//
+// Doctor checks are read-only by contract: no check may write files, modify
+// configs, or start services.
+func RunChecks(ctx context.Context, checks []Check, opts Options) Report {
+	start := time.Now()
+
+	timeout := opts.Timeout
+	if timeout == 0 {
+		timeout = DefaultTimeout
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	// Filter by category if requested.
+	var filtered []Check
+	for _, c := range checks {
+		if opts.Category == "" || c.Category == opts.Category {
+			filtered = append(filtered, c)
+		}
+	}
+
+	results := make([]CheckResult, len(filtered))
+
+	var wg sync.WaitGroup
+	sem := make(chan struct{}, runtime.NumCPU())
+
+	for i, check := range filtered {
+		wg.Add(1)
+		go func(idx int, c Check) {
+			defer wg.Done()
+
+			sem <- struct{}{}        // acquire
+			defer func() { <-sem }() // release
+
+			if ctx.Err() != nil {
+				results[idx] = CheckResult{
+					ID:       c.ID,
+					Category: c.Category,
+					Status:   verify.CheckStatusSkipped,
+					Message:  "skipped: timeout exceeded",
+				}
+				return
+			}
+
+			results[idx] = c.Run(ctx)
+		}(i, check)
+	}
+
+	wg.Wait()
+
+	return BuildReport(results, time.Since(start))
+}
+
+// BuildReport aggregates check results into a Report with summary counts.
+func BuildReport(results []CheckResult, duration time.Duration) Report {
+	report := Report{
+		Checks:   results,
+		Duration: duration,
+	}
+
+	for _, r := range results {
+		switch r.Status {
+		case verify.CheckStatusPassed:
+			report.Passed++
+		case verify.CheckStatusFailed:
+			report.Failed++
+		case verify.CheckStatusSkipped:
+			report.Skipped++
+		case verify.CheckStatusWarning:
+			report.Warnings++
+		}
+	}
+
+	report.Healthy = report.Failed == 0
+	return report
+}

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -1,0 +1,168 @@
+package doctor
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/gentleman-programming/gentle-ai/internal/verify"
+)
+
+func TestRunChecksAllExecute(t *testing.T) {
+	checks := []Check{
+		{
+			ID: "check-a", Category: "deps", Description: "first check",
+			Run: func(context.Context) CheckResult {
+				return CheckResult{ID: "check-a", Category: "deps", Status: verify.CheckStatusPassed, Message: "ok"}
+			},
+		},
+		{
+			ID: "check-b", Category: "env", Description: "second check",
+			Run: func(context.Context) CheckResult {
+				return CheckResult{ID: "check-b", Category: "env", Status: verify.CheckStatusFailed, Message: "missing"}
+			},
+		},
+	}
+
+	report := RunChecks(context.Background(), checks, Options{})
+
+	if len(report.Checks) != 2 {
+		t.Fatalf("Checks = %d, want 2", len(report.Checks))
+	}
+	if report.Passed != 1 {
+		t.Errorf("Passed = %d, want 1", report.Passed)
+	}
+	if report.Failed != 1 {
+		t.Errorf("Failed = %d, want 1", report.Failed)
+	}
+	if report.Healthy {
+		t.Errorf("Healthy = true, want false when failures present")
+	}
+}
+
+func TestRunChecksFiltersByCategory(t *testing.T) {
+	checks := []Check{
+		{ID: "dep-1", Category: "deps", Run: func(context.Context) CheckResult {
+			return CheckResult{ID: "dep-1", Category: "deps", Status: verify.CheckStatusPassed}
+		}},
+		{ID: "env-1", Category: "env", Run: func(context.Context) CheckResult {
+			return CheckResult{ID: "env-1", Category: "env", Status: verify.CheckStatusPassed}
+		}},
+		{ID: "dep-2", Category: "deps", Run: func(context.Context) CheckResult {
+			return CheckResult{ID: "dep-2", Category: "deps", Status: verify.CheckStatusWarning}
+		}},
+	}
+
+	report := RunChecks(context.Background(), checks, Options{Category: "deps"})
+
+	if len(report.Checks) != 2 {
+		t.Fatalf("Checks = %d, want 2 (only deps)", len(report.Checks))
+	}
+	for _, r := range report.Checks {
+		if r.Category != "deps" {
+			t.Errorf("unexpected category %q in filtered results", r.Category)
+		}
+	}
+}
+
+func TestRunChecksRespectsTimeout(t *testing.T) {
+	checks := []Check{
+		{
+			ID: "slow", Category: "deps",
+			Run: func(ctx context.Context) CheckResult {
+				select {
+				case <-time.After(5 * time.Second):
+					return CheckResult{ID: "slow", Status: verify.CheckStatusPassed}
+				case <-ctx.Done():
+					return CheckResult{ID: "slow", Status: verify.CheckStatusSkipped, Message: "cancelled"}
+				}
+			},
+		},
+	}
+
+	report := RunChecks(context.Background(), checks, Options{Timeout: 100 * time.Millisecond})
+
+	if len(report.Checks) != 1 {
+		t.Fatalf("Checks = %d, want 1", len(report.Checks))
+	}
+	if report.Checks[0].Status != verify.CheckStatusSkipped {
+		t.Errorf("Status = %q, want skipped due to timeout", report.Checks[0].Status)
+	}
+}
+
+func TestRunChecksConcurrentExecution(t *testing.T) {
+	const n = 10
+	checks := make([]Check, n)
+	for i := range checks {
+		id := string(rune('a' + i))
+		checks[i] = Check{
+			ID: "check-" + id, Category: "deps",
+			Run: func(ctx context.Context) CheckResult {
+				time.Sleep(50 * time.Millisecond)
+				return CheckResult{ID: "check-" + id, Status: verify.CheckStatusPassed}
+			},
+		}
+	}
+
+	start := time.Now()
+	report := RunChecks(context.Background(), checks, Options{})
+	elapsed := time.Since(start)
+
+	if len(report.Checks) != n {
+		t.Fatalf("Checks = %d, want %d", len(report.Checks), n)
+	}
+
+	// Sequential: 10 * 50ms = 500ms. Concurrent should be well under that.
+	if elapsed > 400*time.Millisecond {
+		t.Errorf("checks appear sequential: took %v (expected < 400ms)", elapsed)
+	}
+}
+
+func TestBuildReportSummaryCounts(t *testing.T) {
+	results := []CheckResult{
+		{Status: verify.CheckStatusPassed},
+		{Status: verify.CheckStatusPassed},
+		{Status: verify.CheckStatusFailed},
+		{Status: verify.CheckStatusWarning},
+		{Status: verify.CheckStatusSkipped},
+	}
+
+	report := BuildReport(results, 42*time.Millisecond)
+
+	if report.Passed != 2 {
+		t.Errorf("Passed = %d, want 2", report.Passed)
+	}
+	if report.Failed != 1 {
+		t.Errorf("Failed = %d, want 1", report.Failed)
+	}
+	if report.Warnings != 1 {
+		t.Errorf("Warnings = %d, want 1", report.Warnings)
+	}
+	if report.Skipped != 1 {
+		t.Errorf("Skipped = %d, want 1", report.Skipped)
+	}
+	if report.Healthy {
+		t.Errorf("Healthy = true, want false")
+	}
+}
+
+func TestBuildReportHealthyWhenNoFailures(t *testing.T) {
+	results := []CheckResult{
+		{Status: verify.CheckStatusPassed},
+		{Status: verify.CheckStatusWarning},
+	}
+
+	report := BuildReport(results, 0)
+
+	if !report.Healthy {
+		t.Errorf("Healthy = false, want true (warnings are non-blocking)")
+	}
+}
+
+func TestBuildReportEmptyIsHealthy(t *testing.T) {
+	report := BuildReport(nil, 0)
+
+	if !report.Healthy {
+		t.Errorf("Healthy = false, want true for empty check list")
+	}
+}

--- a/internal/doctor/render.go
+++ b/internal/doctor/render.go
@@ -1,0 +1,112 @@
+package doctor
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/gentleman-programming/gentle-ai/internal/verify"
+)
+
+// categoryOrder defines the display order for grouped output.
+var categoryOrder = []string{"deps", "platform", "agents", "env"}
+
+// categoryLabel maps category IDs to human-readable section headers.
+var categoryLabel = map[string]string{
+	"deps":     "Dependency Health",
+	"platform": "Platform Recommendations",
+	"agents":   "Agent Config Health",
+	"env":      "System Environment",
+}
+
+// statusIcon maps check statuses to terminal icons.
+// Matches the icons already used in verify.RenderReport.
+var statusIcon = map[verify.CheckStatus]string{
+	verify.CheckStatusPassed:  "[ok]",
+	verify.CheckStatusFailed:  "[!!]",
+	verify.CheckStatusWarning: "[??]",
+	verify.CheckStatusSkipped: "[--]",
+}
+
+// RenderReport formats a doctor report for human consumption.
+func RenderReport(report Report) string {
+	var b strings.Builder
+
+	b.WriteString("gentle-ai doctor — system health check\n")
+	b.WriteString(strings.Repeat("=", 39))
+	b.WriteString("\n\n")
+
+	grouped := groupByCategory(report.Checks)
+
+	for _, cat := range categoryOrder {
+		results, ok := grouped[cat]
+		if !ok {
+			continue
+		}
+
+		label := categoryLabel[cat]
+		fmt.Fprintf(&b, "[%s] %s\n", cat, label)
+
+		for _, r := range results {
+			icon := statusIcon[r.Status]
+			fmt.Fprintf(&b, "  %s %s - %s\n", icon, r.ID, r.Message)
+
+			for _, d := range r.Details {
+				fmt.Fprintf(&b, "        %s\n", d)
+			}
+		}
+
+		b.WriteString("\n")
+	}
+
+	fmt.Fprintf(&b, "Summary: %d passed, %d failed, %d warnings, %d skipped\n",
+		report.Passed, report.Failed, report.Warnings, report.Skipped)
+
+	if !report.Healthy {
+		b.WriteString("Status: unhealthy\n")
+	} else if report.Warnings > 0 {
+		b.WriteString("Status: healthy (with warnings)\n")
+	} else {
+		b.WriteString("Status: healthy\n")
+	}
+
+	return b.String()
+}
+
+// RenderJSON writes the report as machine-readable JSON.
+// Used with --json for CI pipelines.
+func RenderJSON(w io.Writer, report Report) error {
+	type jsonReport struct {
+		Checks   []CheckResult `json:"checks"`
+		Passed   int           `json:"passed"`
+		Failed   int           `json:"failed"`
+		Warnings int           `json:"warnings"`
+		Skipped  int           `json:"skipped"`
+		Healthy  bool          `json:"healthy"`
+		Duration string        `json:"duration"`
+	}
+
+	jr := jsonReport{
+		Checks:   report.Checks,
+		Passed:   report.Passed,
+		Failed:   report.Failed,
+		Warnings: report.Warnings,
+		Skipped:  report.Skipped,
+		Healthy:  report.Healthy,
+		Duration: report.Duration.String(),
+	}
+
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(jr)
+}
+
+// groupByCategory organizes results by their category for section rendering.
+func groupByCategory(results []CheckResult) map[string][]CheckResult {
+	grouped := make(map[string][]CheckResult)
+	for _, r := range results {
+		grouped[r.Category] = append(grouped[r.Category], r)
+	}
+	return grouped
+}

--- a/internal/doctor/render_test.go
+++ b/internal/doctor/render_test.go
@@ -1,0 +1,146 @@
+package doctor
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gentleman-programming/gentle-ai/internal/verify"
+)
+
+func TestRenderReportHealthy(t *testing.T) {
+	report := Report{
+		Checks: []CheckResult{
+			{ID: "binary-engram", Category: "deps", Status: verify.CheckStatusPassed, Message: "single copy at /usr/local/bin/engram"},
+			{ID: "binary-gga", Category: "deps", Status: verify.CheckStatusPassed, Message: "single copy at /usr/local/bin/gga"},
+		},
+		Passed:  2,
+		Healthy: true,
+	}
+
+	rendered := RenderReport(report)
+
+	if !strings.Contains(rendered, "gentle-ai doctor") {
+		t.Error("missing header")
+	}
+	if !strings.Contains(rendered, "[deps] Dependency Health") {
+		t.Error("missing deps section header")
+	}
+	if !strings.Contains(rendered, "[ok]") {
+		t.Error("missing [ok] icon")
+	}
+	if !strings.Contains(rendered, "2 passed, 0 failed") {
+		t.Errorf("unexpected summary:\n%s", rendered)
+	}
+	if !strings.Contains(rendered, "Status: healthy") {
+		t.Error("expected healthy status")
+	}
+}
+
+func TestRenderReportUnhealthy(t *testing.T) {
+	report := Report{
+		Checks: []CheckResult{
+			{ID: "binary-engram", Category: "deps", Status: verify.CheckStatusFailed, Message: "binary missing"},
+		},
+		Failed: 1,
+	}
+
+	rendered := RenderReport(report)
+
+	if !strings.Contains(rendered, "[!!]") {
+		t.Error("missing [!!] icon for failure")
+	}
+	if !strings.Contains(rendered, "Status: unhealthy") {
+		t.Error("expected unhealthy status")
+	}
+}
+
+func TestRenderReportWithWarnings(t *testing.T) {
+	report := Report{
+		Checks: []CheckResult{
+			{ID: "binary-engram", Category: "deps", Status: verify.CheckStatusPassed, Message: "ok"},
+			{
+				ID: "binary-gga", Category: "deps", Status: verify.CheckStatusWarning,
+				Message: "gga has 2 copies in PATH",
+				Details: []string{"  /usr/local/bin/gga (active)", "  /home/user/go/bin/gga (shadowed)"},
+			},
+		},
+		Passed:   1,
+		Warnings: 1,
+		Healthy:  true,
+	}
+
+	rendered := RenderReport(report)
+
+	if !strings.Contains(rendered, "[??]") {
+		t.Error("missing [??] icon for warning")
+	}
+	if !strings.Contains(rendered, "shadowed") {
+		t.Error("details should contain shadowed path")
+	}
+	if !strings.Contains(rendered, "healthy (with warnings)") {
+		t.Error("expected 'healthy (with warnings)' status")
+	}
+}
+
+func TestRenderJSONStructure(t *testing.T) {
+	report := Report{
+		Checks: []CheckResult{
+			{ID: "binary-engram", Category: "deps", Status: verify.CheckStatusPassed, Message: "ok"},
+			{ID: "binary-gga", Category: "deps", Status: verify.CheckStatusWarning, Message: "duplicate"},
+		},
+		Passed:   1,
+		Warnings: 1,
+		Healthy:  true,
+		Duration: 50 * time.Millisecond,
+	}
+
+	var buf bytes.Buffer
+	if err := RenderJSON(&buf, report); err != nil {
+		t.Fatalf("RenderJSON error: %v", err)
+	}
+
+	var parsed struct {
+		Checks  []struct{ ID string } `json:"checks"`
+		Passed  int                   `json:"passed"`
+		Healthy bool                  `json:"healthy"`
+	}
+
+	if err := json.Unmarshal(buf.Bytes(), &parsed); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, buf.String())
+	}
+
+	if len(parsed.Checks) != 2 {
+		t.Errorf("checks = %d, want 2", len(parsed.Checks))
+	}
+	if parsed.Passed != 1 {
+		t.Errorf("passed = %d, want 1", parsed.Passed)
+	}
+	if !parsed.Healthy {
+		t.Error("healthy = false, want true (warnings are non-blocking)")
+	}
+}
+
+func TestRenderJSONUnhealthy(t *testing.T) {
+	report := Report{
+		Checks: []CheckResult{{Status: verify.CheckStatusFailed}},
+		Failed: 1,
+	}
+
+	var buf bytes.Buffer
+	if err := RenderJSON(&buf, report); err != nil {
+		t.Fatalf("RenderJSON error: %v", err)
+	}
+
+	var parsed struct {
+		Healthy bool `json:"healthy"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &parsed); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if parsed.Healthy {
+		t.Error("healthy = true, want false for failed check")
+	}
+}

--- a/internal/system/binaries_test.go
+++ b/internal/system/binaries_test.go
@@ -1,0 +1,161 @@
+package system
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestFindAllBinaryCopies(t *testing.T) {
+	makeBin := func(t *testing.T, dir, name string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("#!/bin/sh\n"), 0o755); err != nil {
+			t.Fatalf("create fake binary: %v", err)
+		}
+	}
+
+	binaryName := func(name string) string {
+		if runtime.GOOS == "windows" {
+			return name + ".exe"
+		}
+		return name
+	}
+
+	tests := []struct {
+		name      string
+		binary    string
+		setupDirs int
+		binIn     []int // which dirs (0-indexed) get the binary
+		wantCount int
+	}{
+		{
+			name:      "single copy found",
+			binary:    "engram",
+			setupDirs: 3,
+			binIn:     []int{1},
+			wantCount: 1,
+		},
+		{
+			name:      "duplicate copies in two dirs",
+			binary:    "engram",
+			setupDirs: 3,
+			binIn:     []int{0, 2},
+			wantCount: 2,
+		},
+		{
+			name:      "not found anywhere",
+			binary:    "engram",
+			setupDirs: 2,
+			binIn:     []int{},
+			wantCount: 0,
+		},
+		{
+			name:      "present in every dir",
+			binary:    "gentle-ai",
+			setupDirs: 3,
+			binIn:     []int{0, 1, 2},
+			wantCount: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var dirs []string
+			for i := 0; i < tt.setupDirs; i++ {
+				dirs = append(dirs, t.TempDir())
+			}
+
+			for _, idx := range tt.binIn {
+				makeBin(t, dirs[idx], binaryName(tt.binary))
+			}
+
+			t.Setenv("PATH", joinPathList(dirs))
+
+			got := FindAllBinaryCopies(tt.binary)
+			if len(got) != tt.wantCount {
+				t.Errorf("FindAllBinaryCopies(%q) = %d results, want %d\n  got: %v",
+					tt.binary, len(got), tt.wantCount, got)
+			}
+		})
+	}
+}
+
+func TestFindAllBinaryCopiesDeduplicatesSymlinks(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink dedup test requires Unix")
+	}
+
+	dir1 := t.TempDir()
+	dir2 := t.TempDir()
+
+	realBin := filepath.Join(dir1, "engram")
+	if err := os.WriteFile(realBin, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("create real binary: %v", err)
+	}
+
+	if err := os.Symlink(realBin, filepath.Join(dir2, "engram")); err != nil {
+		t.Fatalf("create symlink: %v", err)
+	}
+
+	t.Setenv("PATH", joinPathList([]string{dir1, dir2}))
+
+	got := FindAllBinaryCopies("engram")
+	if len(got) != 1 {
+		t.Errorf("expected 1 result (symlink deduplicated), got %d: %v", len(got), got)
+	}
+}
+
+func TestFindAllBinaryCopiesSkipsDirectories(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.Mkdir(filepath.Join(dir, "engram"), 0o755); err != nil {
+		t.Fatalf("create directory: %v", err)
+	}
+
+	t.Setenv("PATH", dir)
+
+	got := FindAllBinaryCopies("engram")
+	if len(got) != 0 {
+		t.Errorf("expected 0 results for directory entry, got %d: %v", len(got), got)
+	}
+}
+
+func TestFindAllBinaryCopiesSkipsNonExecutable(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("executable bit not meaningful on Windows")
+	}
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "engram"), []byte("data"), 0o644); err != nil {
+		t.Fatalf("create non-executable file: %v", err)
+	}
+
+	t.Setenv("PATH", dir)
+
+	got := FindAllBinaryCopies("engram")
+	if len(got) != 0 {
+		t.Errorf("expected 0 results for non-executable, got %d: %v", len(got), got)
+	}
+}
+
+func TestFindAllBinaryCopiesEmptyPath(t *testing.T) {
+	t.Setenv("PATH", "")
+
+	got := FindAllBinaryCopies("engram")
+	if got != nil {
+		t.Errorf("expected nil for empty PATH, got %v", got)
+	}
+}
+
+// joinPathList builds a PATH string using the OS-appropriate separator.
+func joinPathList(dirs []string) string {
+	sep := string(os.PathListSeparator)
+	result := ""
+	for i, d := range dirs {
+		if i > 0 {
+			result += sep
+		}
+		result += d
+	}
+	return result
+}

--- a/internal/system/path.go
+++ b/internal/system/path.go
@@ -54,7 +54,7 @@ func AddToUserPath(dir string) error {
 }
 
 // escapePowerShellString escapes a string for safe use inside a PowerShell
-// single-quoted string literal by replacing each ' with ” (PowerShell's escape
+// single-quoted string literal by replacing each ' with '' (PowerShell's escape
 // sequence for a literal single quote within single-quoted strings).
 func escapePowerShellString(s string) string {
 	return strings.ReplaceAll(s, "'", "''")
@@ -78,6 +78,16 @@ func addToProcessPath(dir string) error {
 	return os.Setenv("PATH", dir+string(os.PathListSeparator)+currentPath)
 }
 
+// FindAllBinaryCopies walks every directory in PATH and returns all absolute
+// paths where a binary named name exists. Unlike exec.LookPath, which stops
+// at the first match, this iterates the entire PATH to detect shadowed binaries.
+//
+// Results are ordered by PATH precedence (first entry = highest priority).
+// Symlinks are resolved for deduplication: if two PATH entries point to the
+// same real file, only the first is returned. On Windows, common executable
+// extensions (.exe, .cmd, .bat) are checked automatically.
+//
+// Returns nil when PATH is empty or the binary is not found.
 func FindAllBinaryCopies(name string) []string {
 	pathEnv := os.Getenv("PATH")
 	if pathEnv == "" {

--- a/internal/system/path.go
+++ b/internal/system/path.go
@@ -54,7 +54,7 @@ func AddToUserPath(dir string) error {
 }
 
 // escapePowerShellString escapes a string for safe use inside a PowerShell
-// single-quoted string literal by replacing each ' with '' (PowerShell's escape
+// single-quoted string literal by replacing each ' with ” (PowerShell's escape
 // sequence for a literal single quote within single-quoted strings).
 func escapePowerShellString(s string) string {
 	return strings.ReplaceAll(s, "'", "''")
@@ -76,4 +76,59 @@ func addToProcessPath(dir string) error {
 		return os.Setenv("PATH", dir)
 	}
 	return os.Setenv("PATH", dir+string(os.PathListSeparator)+currentPath)
+}
+
+func FindAllBinaryCopies(name string) []string {
+	pathEnv := os.Getenv("PATH")
+	if pathEnv == "" {
+		return nil
+	}
+
+	dirs := filepath.SplitList(pathEnv)
+	seen := make(map[string]bool)
+	var results []string
+
+	candidates := []string{name}
+	if runtime.GOOS == "windows" && filepath.Ext(name) == "" {
+		candidates = append(candidates, name+".exe", name+".cmd", name+".bat")
+	}
+
+	for _, dir := range dirs {
+		if dir == "" {
+			continue
+		}
+		for _, candidate := range candidates {
+			fullPath := filepath.Join(dir, candidate)
+
+			// Resolve symlinks for deduplication.
+			resolved, err := filepath.EvalSymlinks(fullPath)
+			if err != nil {
+				continue // file doesn't exist or broken symlink
+			}
+
+			info, err := os.Stat(resolved)
+			if err != nil || info.IsDir() {
+				continue
+			}
+
+			// On Unix, the file must be executable.
+			if runtime.GOOS != "windows" && info.Mode()&0111 == 0 {
+				continue
+			}
+
+			// Deduplicate by resolved path (case-insensitive on Windows).
+			key := resolved
+			if runtime.GOOS == "windows" {
+				key = strings.ToLower(resolved)
+			}
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+
+			results = append(results, fullPath)
+		}
+	}
+
+	return results
 }


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #302

---

## 🏷️ PR Type

- [ ] `type:bug`
- [x] `type:feature`
- [ ] `type:docs`
- [ ] `type:refactor`
- [ ] `type:chore`
- [ ] `type:breaking-change`

---

## 📝 Summary

Implements the MVP foundation for `gentle-ai doctor` — a read-only diagnostic command that scans the ecosystem and reports health status. This PR establishes the architecture (Check struct, concurrent runner, rendering) and ships the first check category: duplicate binary detection across PATH.

The command detects shadowed binaries (e.g., engram installed via both Homebrew AND go install), which is the root cause behind issues like #114, #177, and #246.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/system/path.go` | Added `FindAllBinaryCopies()` — walks all PATH entries, resolves symlinks, deduplicates |
| `internal/system/binaries_test.go` | Table-driven tests: duplicates, symlink dedup, directories, non-executable, empty PATH |
| `internal/doctor/doctor.go` | Core types (`Check`, `CheckResult`, `Report`, `Options`) and concurrent runner with bounded semaphore |
| `internal/doctor/doctor_test.go` | Runner tests: execution, category filter, timeout, concurrency, report summary |
| `internal/doctor/deps.go` | `DuplicateBinaryCheck` for gentle-ai/engram/gga + `AllChecks()` entry point + DI setter |
| `internal/doctor/deps_test.go` | Check tests with injected fakes: single/none/duplicate copies, context cancellation, nil lookup |
| `internal/doctor/render.go` | Human-readable + JSON rendering, grouped by category |
| `internal/doctor/render_test.go` | Render tests: healthy/unhealthy/warnings states, JSON structure |
| `internal/app/app.go` | Added `case "doctor"` dispatch (first switch block) + `runDoctor` handler + DI wiring |
| `internal/app/help.go` | Added `doctor` to COMMANDS list |

---

## 🧪 Test Plan

**Unit Tests**

```bash
go test ./internal/system/ -run TestFindAllBinaryCopies -v
go test ./internal/doctor/ -v
go test -race ./internal/system/ ./internal/doctor/
go test ./internal/app/ ./internal/verify/
```

**Manual Tests**

```bash
go build -o gentle-ai ./cmd/gentle-ai
./gentle-ai doctor              # human-readable output
./gentle-ai doctor --json       # machine-readable JSON
./gentle-ai doctor --category deps  # filtered by category
./gentle-ai help                # doctor appears in command list
```

- [x] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Manually tested locally

---

## 🤖 Automated Checks

| Check | Status | Description |
|-------|--------|-------------|
| Check Issue Reference | ⏳ | PR body must contain `Closes/Fixes/Resolves #N` |
| Check Issue Has `status:approved` | ⏳ | Linked issue must have been approved before work began |
| Check PR Has `type:*` Label | ⏳ | Exactly one `type:*` label must be applied |
| Unit Tests | ⏳ | `go test ./...` must pass |
| E2E Tests | ⏳ | `cd e2e && ./docker-test.sh` must pass |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [ ] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

This is the MVP foundation — intentionally scoped to one check category (deps: duplicate binary detection) to keep the PR reviewable. The architecture supports incremental addition of the remaining categories from the spec:

- **deps** (future): version comparison via `update.CheckFiltered`, engram HTTP health, GGA assets
- **platform**: PM recommendation, `DetectScoop()`, npm writability
- **agents**: three-way cross-reference (state.json × config dir × binary)
- **env**: Node.js >= 18, git/curl, PATH coherence

Design follows existing project patterns: DI via package-level vars (like `updateCheckAll`), reuses `verify.CheckStatus` constants, `Check` struct mirrors `verify.Check`, concurrent runner matches `deps.go` WaitGroup pattern.

28 test cases across 2 packages, all pass with `-race`.