### PR TITLE
fix(selfupdate): resolve false-negative terminal output by splitting SLA timeouts

### DIFF
--- a/internal/app/selfupdate.go
+++ b/internal/app/selfupdate.go
@@ -24,8 +24,26 @@ const (
 	envSelfUpdateDone = "GENTLE_AI_SELF_UPDATE_DONE"
 )
 
-// selfUpdateTimeout is the maximum time allowed for the update check + upgrade.
-const selfUpdateTimeout = 7 * time.Second
+// Self-update timeouts are split into two phases with distinct SLAs:
+//
+//   - Check phase (API round-trip): must be fast to avoid delaying CLI startup.
+//     5 seconds is generous for a single HTTPS GET to api.github.com — if the
+//     network is unreachable, the TCP handshake fails well before this.
+//
+//   - Execution phase (backup + binary download): needs real time for I/O.
+//     The gentle-ai tarball is ~9 MB. At 1 Mbps (a slow mobile connection),
+//     that takes ~72 seconds. 60 seconds covers most real-world connections
+//     while still bounding the worst case.
+//
+// Previously a single 7-second timeout covered both phases, which caused the
+// download to be cancelled mid-stream on slower connections. The binary was
+// sometimes partially or fully written to disk before the context fired,
+// resulting in a successful upgrade that was falsely reported as failed.
+// See: https://github.com/Gentleman-Programming/gentle-ai/issues/230
+const (
+	selfUpdateCheckTimeout = 5 * time.Second
+	selfUpdateExecTimeout  = 60 * time.Second
+)
 
 // reExec is swappable for testing — prevents actual syscall.Exec in tests.
 var reExec = func(argv0 string, argv []string, envv []string) error {
@@ -59,12 +77,13 @@ func selfUpdate(ctx context.Context, version string, profile system.PlatformProf
 		return nil
 	}
 
-	// Apply timeout to the entire check+upgrade cycle.
-	ctx, cancel := context.WithTimeout(ctx, selfUpdateTimeout)
-	defer cancel()
+	// Phase 1: Check for updates (only gentle-ai).
+	// Short timeout — fail fast if the network is unreachable so CLI startup
+	// is not delayed for users who are offline or behind a slow proxy.
+	checkCtx, checkCancel := context.WithTimeout(ctx, selfUpdateCheckTimeout)
+	defer checkCancel()
 
-	// Check for updates (only gentle-ai).
-	results := updateCheckFiltered(ctx, version, profile, []string{"gentle-ai"})
+	results := updateCheckFiltered(checkCtx, version, profile, []string{"gentle-ai"})
 
 	// Find the gentle-ai result.
 	var target *update.UpdateResult
@@ -80,14 +99,20 @@ func selfUpdate(ctx context.Context, version string, profile system.PlatformProf
 		return nil
 	}
 
-	// Run upgrade (backup + strategy execution).
+	// Phase 2: Run upgrade (backup + strategy execution).
+	// Independent context with a generous timeout — binary downloads need real
+	// time on slower connections. This context is derived from the original
+	// parent (not from checkCtx) so the check timeout does not bleed into it.
+	execCtx, execCancel := context.WithTimeout(ctx, selfUpdateExecTimeout)
+	defer execCancel()
+
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		_, _ = fmt.Fprintf(stdout, "self-update: cannot resolve home directory: %v\n", err)
 		return nil // non-fatal
 	}
 
-	report := upgradeExecute(ctx, results, profile, homeDir, false, stdout)
+	report := upgradeExecute(execCtx, results, profile, homeDir, false, stdout)
 
 	// Check if upgrade succeeded.
 	var succeeded bool


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #230

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

Resolves a false-negative UI failure where the pre-flight `selfUpdate` routine printed a red `✗` on the terminal, even though the binary successfully updated. 

**Root Cause:**
`internal/app/selfupdate.go` applied a shared 7-second context timeout to the entire upgrade flow (API ping + Backup + 9MB tarball download). On moderate-latency networks, the download exceeded the budget. The context cancelled, propagating an error to `spinner.Finish(false)` and printing `✗` to `stdout`. Meanwhile, the OS buffer allowed the atomic `os.Rename` to succeed in the background. Because `tea.WithAltScreen()` hid the original terminal buffer, the user only saw the spurious `✗` after exiting the TUI.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/app/selfupdate.go` | Replaced monolithic 7s timeout with independent SLAs: 5s for API discovery (`selfUpdateCheckTimeout`) and 60s for execution (`selfUpdateExecTimeout`). Separated context lifecycle for each phase. |

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./...
```
**E2E Tests** (Docker required)
```bash
cd e2e && ./docker-test.sh
```

- [x] Unit tests pass (go test ./...)
- [x] E2E tests pass (cd e2e && ./docker-test.sh)
- [x] Manually tested locally

Manual Verification Details:
Simulated a 15s download delay in upgrade_test.go confirming the success signal. Also tested manually on Ubuntu 22.04 using tc qdisc netem delay to prove the green checkmark renders correctly under network stress.

---

## 🤖 Automated Checks

The following checks run automatically on this PR:

| Check | Status | Description |
|-------|--------|-------------|
| Check Issue Reference | ⏳ | PR body must contain `Closes/Fixes/Resolves #N` |
| Check Issue Has `status:approved` | ⏳ | Linked issue must have been approved before work began |
| Check PR Has `type:*` Label | ⏳ | Exactly one `type:*` label must be applied |
| Unit Tests | ⏳ | `go test ./...` must pass |
| E2E Tests | ⏳ | `cd e2e && ./docker-test.sh` must pass |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with status:approved
- [x] I have added the appropriate type:* label to this PR
- [x] Unit tests pass (go test ./...)
- [x] E2E tests pass (cd e2e && ./docker-test.sh)
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] My commits do not include Co-Authored-By trailers

---

## 💬 Notes for Reviewers

Risk Assessment:
- TUI rendering: None. Bubble Tea and tea.WithAltScreen() are untouched.
- Platform behaviour: Low. os.Rename and context.WithTimeout are consistent across Linux, macOS, and WSL.
- Blast radius: Confined to the timeout constants and context propagation inside selfupdate.go. Squash and merge with confidence.