### PR TITLE
docs: add Qwen Code to supported agents documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This is NOT an AI agent installer. Most agents are easy to install. This is an *
 
 **After**: Your agent now has memory, skills, workflow, MCP tools, and a persona that actually teaches you.
 
-### 9 Supported Agents
+### 10 Supported Agents
 
 | Agent | Delegation Model | Key Feature |
 |-------|:---:|---|
@@ -38,6 +38,7 @@ This is NOT an AI agent installer. Most agents are easy to install. This is an *
 | **Windsurf** | Solo-agent | Plan Mode, Code Mode, native workflows |
 | **Antigravity** | Solo-agent + Mission Control | Built-in Browser/Terminal sub-agents |
 | **Kiro IDE** | Full (native subagents) | Native `~/.kiro/agents/` + steering orchestration |
+| **Qwen Code** | Full (native sub-agents) | Slash commands, `~/.qwen/commands/`, `auto_edit` mode |
 
 > **Note**: This project supersedes [Agent Teams Lite](https://github.com/Gentleman-Programming/agent-teams-lite) (now archived). Everything ATL provided is included here with better installation, automatic updates, and persistent memory.
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -17,6 +17,7 @@
 | Windsurf | `windsurf` | Yes (native) | Yes | Solo-agent | No | No | `~/.codeium/windsurf` |
 | Antigravity | `antigravity` | Yes (native) | Yes | Solo-agent + Mission Control | No | No | `~/.gemini/antigravity` |
 | Kiro IDE | `kiro-ide` | Yes | Yes | Full (native subagents) | No | No | `~/.kiro` |
+| Qwen Code | `qwen-code` | Yes | Yes | Full (native sub-agents) | No | Yes | `~/.qwen` |
 
 All agents receive the **full SDD orchestrator** injected into their system prompt, plus skill files written to their skills directory. The agent handles SDD automatically when the task is large enough, or when the user explicitly asks for it — no manual setup required.
 
@@ -26,7 +27,7 @@ All agents receive the **full SDD orchestrator** injected into their system prom
 
 | Model | How It Works | Agents |
 |-------|-------------|--------|
-| **Full (sub-agents)** | Each SDD phase runs in an isolated context window via native sub-agent delegation. The orchestrator coordinates; sub-agents execute. | Claude Code, OpenCode, Gemini CLI, Cursor, VS Code Copilot |
+| **Full (sub-agents)** | Each SDD phase runs in an isolated context window via native sub-agent delegation. The orchestrator coordinates; sub-agents execute. | Claude Code, OpenCode, Gemini CLI, Cursor, VS Code Copilot, Qwen Code |
 | **Solo-agent** | All SDD phases run inline in the same conversation. The orchestrator IS the executor. Engram provides cross-phase persistence. | Codex, Windsurf, Antigravity |
 
 ### Cursor Native Subagents
@@ -62,11 +63,11 @@ Kiro uses native custom agents in `~/.kiro/agents/`. `gentle-ai` writes 10 phase
 
 ## SDD Mode Support
 
-| Feature | Claude Code | OpenCode | Gemini CLI | Cursor | VS Code Copilot | Codex | Windsurf | Antigravity | Kiro IDE |
-|---------|:-----------:|:--------:|:----------:|:------:|:---------------:|:-----:|:--------:|:-----------:|:--------:|
-| SDD orchestrator | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
-| Single-mode SDD | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
-| Multi-mode SDD | — | Yes | — | — | — | — | — | — | Yes* |
+| Feature | Claude Code | OpenCode | Gemini CLI | Cursor | VS Code Copilot | Codex | Windsurf | Antigravity | Kiro IDE | Qwen Code |
+|---------|:-----------:|:--------:|:----------:|:------:|:---------------:|:-----:|:--------:|:-----------:|:--------:|:---------:|
+| SDD orchestrator | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| Single-mode SDD | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| Multi-mode SDD | — | Yes | — | — | — | — | — | — | Yes* | — |
 
 **Multi-mode** (assigning different AI models to each SDD phase) is natively supported by **OpenCode** (via its provider system) and **Kiro IDE** (via native subagent `model:` frontmatter — each phase agent runs with its own model ID). All other agents run in **single-mode** — the orchestrator manages everything using whatever model the agent is already running.
 
@@ -132,3 +133,15 @@ Kiro uses native custom agents in `~/.kiro/agents/`. `gentle-ai` writes 10 phase
 - Native Kiro specs workflow: `.kiro/specs/<feature>/requirements.md`, `design.md`, `tasks.md` — with approval gates before apply and archive phases
 - Manual install only — download from [kiro.dev/downloads](https://kiro.dev/downloads)
 - See [docs/kiro.md](kiro.md) for full path reference and SDD behavior details
+
+### Qwen Code
+- **Detection**: gentle-ai detects Qwen Code from its config root (`~/.qwen`) and checks for `qwen` binary on `PATH`
+- **Config root**: `~/.qwen/` (cross-platform)
+- **System prompt**: `~/.qwen/QWEN.md` (managed via `StrategyFileReplace`)
+- **Skills**: `~/.qwen/skills/`
+- **MCP config**: `~/.qwen/settings.json` (managed via `StrategyMergeIntoSettings` with `mcpServers` key)
+- **Slash commands**: `~/.qwen/commands/*.md` — supports custom namespaced slash commands (e.g., `commands/sdd/init.md` → `/sdd:init`)
+- **Permissions**: `auto_edit` mode — auto-approves file edits, manual approval for shell commands
+- **Install**: via npm — `npm install -g @qwen-code/qwen-code@latest`
+- **Engram slug**: `"qwen-code"` for `engram setup` integration
+- **SDD orchestrator**: `internal/assets/qwen/sdd-orchestrator.md` with Qwen-specific path references


### PR DESCRIPTION
## Summary
Complement PR #263 (qwen-code-integration) by adding Qwen Code to the public-facing agent documentation. The code implementation is complete in PR #263, but the README and docs/agents.md still show "9 Supported Agents" and don't mention Qwen Code anywhere in the public docs.

## Changes

### README.md
- Updated "9 Supported Agents" → "10 Supported Agents"
- Added Qwen Code row to the agents table:
  - **Delegation Model**: Full (native sub-agents)
  - **Key Feature**: Slash commands, `~/.qwen/commands/`, `auto_edit` mode

### docs/agents.md
- **Agent Matrix table**: Added Qwen Code with ID `qwen-code`, Full delegation, Yes for slash commands, config path `~/.qwen`
- **Delegation Models table**: Added Qwen Code to the "Full (sub-agents)" row alongside Claude Code, OpenCode, Gemini CLI, Cursor, VS Code Copilot
- **SDD Mode Support table**: Added Qwen Code column with Yes for SDD orchestrator and single-mode SDD
- **Agent Notes section**: Added comprehensive "### Qwen Code" section covering detection, config paths, slash commands, permissions, install method, engram slug, and SDD orchestrator

## Related
- Complements PR #263: `feat: add Qwen Code agent integration`
- Closes issue #281

## Notes
This PR does NOT include any code changes — only documentation updates to reflect the Qwen Code support that was implemented in PR #263.
