### PR TITLE
feat(opencode): support external profile sync strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,10 @@ engram tui                    # Visual memory browser
 
 This project exists because of the community. See [CONTRIBUTORS.md](CONTRIBUTORS.md) for the full list.
 
+### Community Integrations
+
+- [sdd-engram-plugin](https://github.com/j0k3r-dev-rgl/sdd-engram-plugin) — external OpenCode SDD profile manager with runtime profile activation.
+
 <a href="https://github.com/Gentleman-Programming/gentle-ai/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=Gentleman-Programming/gentle-ai" />
 </a>

--- a/README.md
+++ b/README.md
@@ -175,13 +175,19 @@ engram tui                    # Visual memory browser
 
 ---
 
-## Contributors
+## Community Highlights
 
-This project exists because of the community. See [CONTRIBUTORS.md](CONTRIBUTORS.md) for the full list.
+This project gets better when the community builds on top of it.
 
 ### Community Integrations
 
-- [sdd-engram-plugin](https://github.com/j0k3r-dev-rgl/sdd-engram-plugin) — external OpenCode SDD profile manager with runtime profile activation.
+- [sdd-engram-plugin](https://github.com/j0k3r-dev-rgl/sdd-engram-plugin) — manage OpenCode SDD profiles and browse Engram memories directly from OpenCode, with runtime profile activation and no restart required.
+
+Using a tool like this? Gentle AI now supports a safer OpenCode sync compatibility path for external single-active profile managers.
+
+## Contributors
+
+This project exists because of the community. See [CONTRIBUTORS.md](CONTRIBUTORS.md) for the full list.
 
 <a href="https://github.com/Gentleman-Programming/gentle-ai/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=Gentleman-Programming/gentle-ai" />

--- a/docs/intended-usage.md
+++ b/docs/intended-usage.md
@@ -68,6 +68,8 @@ If you want multi-mode in OpenCode:
 
 You can create multiple profiles (e.g., "cheap" for experimentation, "premium" for production) and switch between them freely.
 
+If you prefer a **runtime profile manager** that keeps profiles outside `opencode.json`, gentle-ai now supports that too. During sync, OpenCode can auto-detect external profile files under `~/.config/opencode/profiles/*.json` and switch to a safer compatibility path that preserves the active `sdd-orchestrator` prompt instead of overwriting it.
+
 **Full step-by-step guide**: [OpenCode SDD Profiles](opencode-profiles.md)
 
 ---

--- a/docs/opencode-profiles.md
+++ b/docs/opencode-profiles.md
@@ -6,7 +6,12 @@
 
 You configured your SDD models once, and now every task -- cheap or expensive, experimental or battle-tested -- runs through the same orchestrator. Profiles fix that: **create named model configurations and switch between them with Tab inside OpenCode.**
 
-Each profile generates its own `sdd-orchestrator` (plus all 10 sub-agents) in `opencode.json`. One profile for heavy architectural work with Opus, another for quick fixes with Haiku, a third to test Gemini -- all coexisting, switchable in a keystroke.
+Gentle AI supports **two ways** of working with OpenCode profiles:
+
+1. **Generated multi-profile mode** -- the classic Gentle AI flow. Each named profile generates its own `sdd-orchestrator-{name}` plus 10 suffixed sub-agents in `opencode.json`, and you switch between them with **Tab**.
+2. **External single-active mode** -- for community tools that keep profile files outside `opencode.json` and activate one runtime profile at a time.
+
+That means you can stay with the built-in multi-profile overlay, or plug Gentle AI into an external profile manager without the two systems fighting each other.
 
 ---
 
@@ -48,9 +53,47 @@ gentle-ai sync \
 
 This creates a "cheap" profile where everything runs on Haiku except `sdd-apply`, which uses Sonnet.
 
+## External Profile Managers
+
+If you're using a community tool that stores profiles under `~/.config/opencode/profiles/*.json` and activates them at runtime, Gentle AI can now sync OpenCode in a compatibility mode.
+
+### Auto-detection
+
+On `gentle-ai sync`, if OpenCode profile files exist under:
+
+```text
+~/.config/opencode/profiles/*.json
+```
+
+Gentle AI automatically switches to **`external-single-active`** strategy for OpenCode sync.
+
+### Manual override
+
+You can also force the strategy explicitly:
+
+```bash
+gentle-ai sync --agent opencode --sdd-profile-strategy external-single-active
+```
+
+Or force the classic generated overlay behavior:
+
+```bash
+gentle-ai sync --agent opencode --sdd-profile-strategy generated-multi
+```
+
+### What compatibility mode does
+
+In `external-single-active` mode, Gentle AI:
+
+- keeps writing the base OpenCode SDD assets and shared prompt files
+- **does not** auto-regenerate suffixed named profiles from `opencode.json`
+- **preserves the current `sdd-orchestrator` prompt** during sync so external tools can keep their runtime policy / fallback blocks intact
+
+This is the important bit: Gentle AI still maintains the SDD foundation, but it stops acting like `opencode.json` is the source of truth for every profile.
+
 ## Using Profiles in OpenCode
 
-After creating profiles, each one appears as a selectable orchestrator in OpenCode:
+After creating profiles in generated multi-profile mode, each one appears as a selectable orchestrator in OpenCode:
 
 | What you see in Tab | What it runs |
 |---|---|
@@ -59,6 +102,8 @@ After creating profiles, each one appears as a selectable orchestrator in OpenCo
 | `sdd-orchestrator-premium` | "premium" profile -- Opus everywhere |
 
 Press **Tab** to cycle between orchestrators. All SDD slash commands (`/sdd-new`, `/sdd-ff`, `/sdd-explore`, etc.) run against whichever orchestrator is currently selected. The orchestrator delegates to its own suffixed sub-agents (e.g., `sdd-apply-cheap`), so profiles never interfere with each other.
+
+If you're using an external single-active manager instead, you typically keep working with the base `sdd-orchestrator` while the external tool swaps its active model assignments at runtime.
 
 ## Managing Profiles
 
@@ -87,11 +132,14 @@ The `default` profile (the unsuffixed `sdd-orchestrator`) can be edited but not 
 <details>
 <summary><strong>How It Works</strong></summary>
 
-Each profile generates 11 agent entries in `opencode.json`: one orchestrator (`sdd-orchestrator-{name}`, mode `primary`) and 10 sub-agents (`sdd-{phase}-{name}`, mode `subagent`, hidden). The orchestrator's permissions are scoped so it can only delegate to its own suffixed sub-agents.
+In generated multi-profile mode, each profile generates 11 agent entries in `opencode.json`: one orchestrator (`sdd-orchestrator-{name}`, mode `primary`) and 10 sub-agents (`sdd-{phase}-{name}`, mode `subagent`, hidden). The orchestrator's permissions are scoped so it can only delegate to its own suffixed sub-agents.
 
 Sub-agent prompts are shared across all profiles as files under `~/.config/opencode/prompts/sdd/` (e.g., `sdd-apply.md`). Each agent entry references the shared file via `{file:~/.config/opencode/prompts/sdd/sdd-apply.md}` -- only the `model` field differs between profiles. Orchestrator prompts are inlined per-profile because they contain profile-specific model assignment tables and sub-agent references.
 
-During sync or update, the installer detects existing profiles by scanning for `sdd-orchestrator-*` keys, updates shared prompt files, regenerates orchestrator prompts, and preserves your model assignments.
+During sync or update, Gentle AI now uses one of two strategies:
+
+- **`generated-multi`** -- scan `opencode.json` for `sdd-orchestrator-*`, update shared prompts, regenerate profile orchestrators, preserve model assignments
+- **`external-single-active`** -- detect external profile files, keep the shared SDD assets current, and preserve the existing base orchestrator prompt instead of overwriting external runtime extensions
 
 </details>
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -150,6 +150,7 @@ gentle-ai -v
 | `--component` | Sync a specific component only: `sdd`, `engram`, `context7`, `skills`, `gga`, `permissions`, `theme` |
 | `--profile` | Create or update an SDD profile: `name:provider/model` (sets the default model for all phases) |
 | `--profile-phase` | Override a specific phase in a profile: `name:phase:provider/model` |
+| `--sdd-profile-strategy` | OpenCode profile sync strategy: `generated-multi` or `external-single-active` |
 | `--include-permissions` | Include permissions sync (opt-in) |
 | `--include-theme` | Include theme sync (opt-in) |
 
@@ -166,6 +167,9 @@ gentle-ai sync --profile-phase cheap:sdd-design:anthropic/claude-sonnet-4-202505
 gentle-ai sync \
   --profile cheap:openrouter/qwen/qwen3-30b-a3b:free \
   --profile premium:anthropic/claude-sonnet-4-20250514
+
+# Use compatibility mode with an external OpenCode profile manager
+gentle-ai sync --agent opencode --sdd-profile-strategy external-single-active
 ```
 
 See [OpenCode SDD Profiles](opencode-profiles.md) for the full guide.

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -30,6 +30,7 @@ type SyncFlags struct {
 	Agents             []string
 	Skills             []string
 	SDDMode            string
+	SDDProfileStrategy string
 	StrictTDD          bool
 	IncludePermissions bool
 	IncludeTheme       bool
@@ -72,6 +73,7 @@ func ParseSyncFlags(args []string) (SyncFlags, error) {
 	registerListFlag(fs, "skill", &opts.Skills)
 	registerListFlag(fs, "skills", &opts.Skills)
 	fs.StringVar(&opts.SDDMode, "sdd-mode", "", "SDD orchestrator mode: single or multi (default: single)")
+	fs.StringVar(&opts.SDDProfileStrategy, "sdd-profile-strategy", "", "OpenCode SDD profile sync strategy: generated-multi or external-single-active (default: auto-detect)")
 	fs.BoolVar(&opts.StrictTDD, "strict-tdd", false, "enable strict TDD mode for SDD agents (RED → GREEN → REFACTOR)")
 	fs.BoolVar(&opts.IncludePermissions, "include-permissions", false, "include permissions component in sync")
 	fs.BoolVar(&opts.IncludeTheme, "include-theme", false, "include theme component in sync")
@@ -87,6 +89,12 @@ func ParseSyncFlags(args []string) (SyncFlags, error) {
 		return SyncFlags{}, fmt.Errorf("unexpected sync argument %q", fs.Arg(0))
 	}
 
+	strategy, err := parseProfileSyncStrategy(opts.SDDProfileStrategy)
+	if err != nil {
+		return SyncFlags{}, err
+	}
+	opts.SDDProfileStrategy = string(strategy)
+
 	// Parse --profile flags into model.Profile values.
 	if len(opts.rawProfiles) > 0 || len(opts.rawProfilePhases) > 0 {
 		profiles, err := parseProfileFlags(opts.rawProfiles, opts.rawProfilePhases)
@@ -97,6 +105,20 @@ func ParseSyncFlags(args []string) (SyncFlags, error) {
 	}
 
 	return opts, nil
+}
+
+func parseProfileSyncStrategy(raw string) (model.SDDProfileStrategyID, error) {
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		return "", nil
+	}
+
+	switch model.SDDProfileStrategyID(value) {
+	case model.SDDProfileStrategyGeneratedMulti, model.SDDProfileStrategyExternalSingleActive:
+		return model.SDDProfileStrategyID(value), nil
+	default:
+		return "", fmt.Errorf("unsupported sdd-profile-strategy %q (valid: generated-multi, external-single-active)", raw)
+	}
 }
 
 // parseProfileFlags converts the raw --profile and --profile-phase string values
@@ -271,12 +293,13 @@ func BuildSyncSelection(flags SyncFlags, agentIDs []model.AgentID) model.Selecti
 	}
 
 	return model.Selection{
-		Agents:     agentIDs,
-		Components: components,
-		SDDMode:    sddMode,
-		StrictTDD:  flags.StrictTDD,
-		Skills:     skillIDs,
-		Profiles:   flags.Profiles,
+		Agents:             agentIDs,
+		Components:         components,
+		SDDMode:            sddMode,
+		SDDProfileStrategy: model.SDDProfileStrategyID(flags.SDDProfileStrategy),
+		StrictTDD:          flags.StrictTDD,
+		Skills:             skillIDs,
+		Profiles:           flags.Profiles,
 		// Preset is set to full-gentleman so selectedSkillIDs() returns the
 		// correct default skill set when no explicit skills are provided.
 		Preset: model.PresetFullGentleman,
@@ -458,13 +481,15 @@ func (s componentSyncStep) Run() error {
 		return nil
 
 	case model.ComponentSDD:
+		profileStrategy := sdd.ResolveProfileStrategy(s.homeDir, s.selection.SDDProfileStrategy)
+
 		// Resolve profiles for injection:
 		// - When profiles are explicitly provided (TUI/CLI), use them directly.
 		// - On a regular sync (no explicit profiles), detect existing named profiles
 		//   from disk so their orchestrator prompts are refreshed from updated embedded
 		//   assets while model assignments are preserved.
 		profiles := s.selection.Profiles
-		if len(profiles) == 0 {
+		if len(profiles) == 0 && profileStrategy != model.SDDProfileStrategyExternalSingleActive {
 			settingsPath := ""
 			for _, adapter := range adapters {
 				if adapter.Agent() == model.AgentOpenCode {
@@ -484,18 +509,21 @@ func (s componentSyncStep) Run() error {
 		// If profiles exist (explicit or detected), SDDModeMulti is required:
 		// shared prompt files must be written and {file:...} refs must resolve.
 		sddMode := s.selection.SDDMode
-		if len(profiles) > 0 && sddMode == "" {
+		if profileStrategy == model.SDDProfileStrategyExternalSingleActive {
+			sddMode = model.SDDModeMulti
+		} else if len(profiles) > 0 && sddMode == "" {
 			sddMode = model.SDDModeMulti
 		}
 
 		for _, adapter := range adapters {
 			opts := sdd.InjectOptions{
-				OpenCodeModelAssignments: s.selection.ModelAssignments,
-				ClaudeModelAssignments:   s.selection.ClaudeModelAssignments,
-				KiroModelAssignments:     s.selection.KiroModelAssignments,
-				WorkspaceDir:             s.workspaceDir,
-				StrictTDD:                s.selection.StrictTDD,
-				Profiles:                 profiles,
+				OpenCodeModelAssignments:           s.selection.ModelAssignments,
+				ClaudeModelAssignments:             s.selection.ClaudeModelAssignments,
+				KiroModelAssignments:               s.selection.KiroModelAssignments,
+				WorkspaceDir:                       s.workspaceDir,
+				StrictTDD:                          s.selection.StrictTDD,
+				PreserveOpenCodeOrchestratorPrompt: profileStrategy == model.SDDProfileStrategyExternalSingleActive,
+				Profiles:                           profiles,
 			}
 			res, err := sdd.Inject(s.homeDir, adapter, sddMode, opts)
 			if err != nil {

--- a/internal/cli/sync_test.go
+++ b/internal/cli/sync_test.go
@@ -97,6 +97,51 @@ func TestParseSyncFlagsSDDMode(t *testing.T) {
 	}
 }
 
+func TestParseSyncFlagsSDDProfileStrategy(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "absent defaults to empty(auto)",
+			args: []string{},
+			want: "",
+		},
+		{
+			name: "generated-multi",
+			args: []string{"--sdd-profile-strategy", "generated-multi"},
+			want: "generated-multi",
+		},
+		{
+			name: "external-single-active",
+			args: []string{"--sdd-profile-strategy", "external-single-active"},
+			want: "external-single-active",
+		},
+		{
+			name:    "invalid returns error",
+			args:    []string{"--sdd-profile-strategy", "invalid"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			flags, err := ParseSyncFlags(tt.args)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ParseSyncFlags() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if flags.SDDProfileStrategy != tt.want {
+				t.Errorf("SDDProfileStrategy = %q, want %q", flags.SDDProfileStrategy, tt.want)
+			}
+		})
+	}
+}
+
 func TestParseSyncFlagsIncludePermissionsAndTheme(t *testing.T) {
 	flags, err := ParseSyncFlags([]string{"--include-permissions", "--include-theme"})
 	if err != nil {
@@ -1219,6 +1264,82 @@ func TestRunSyncDetectsExistingProfilesOnRegularSync(t *testing.T) {
 	_ = result2 // result2 may or may not be no-op depending on whether profile overlay is idempotent
 }
 
+func TestRunSyncExternalSingleActiveSkipsDetectAndPreservesOrchestratorPrompt(t *testing.T) {
+	home := t.TempDir()
+	restoreCommand := runCommand
+	restoreLookPath := cmdLookPath
+	t.Cleanup(func() {
+		runCommand = restoreCommand
+		cmdLookPath = restoreLookPath
+	})
+	runCommand = func(string, ...string) error { return nil }
+	cmdLookPath = func(name string) (string, error) { return "/usr/local/bin/" + name, nil }
+
+	// Pre-create package directory to avoid npm/bun install attempts in tests.
+	if err := os.MkdirAll(filepath.Join(home, ".config", "opencode", "node_modules", "unique-names-generator"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(node_modules): %v", err)
+	}
+
+	// External profile marker to mirror real integrations.
+	profilesDir := filepath.Join(home, ".config", "opencode", "profiles")
+	if err := os.MkdirAll(profilesDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(profiles): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(profilesDir, "active.json"), []byte(`{"name":"cheap"}`), 0o644); err != nil {
+		t.Fatalf("WriteFile(active profile): %v", err)
+	}
+
+	settingsPath := filepath.Join(home, ".config", "opencode", "opencode.json")
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(settings dir): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".config", "opencode", "AGENTS.md"), []byte("# Existing custom AGENTS\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(AGENTS.md): %v", err)
+	}
+
+	const customPrompt = "EXTERNAL-RUNTIME-ORCHESTRATOR-PROMPT"
+	seed := `{
+  "agent": {
+    "sdd-orchestrator": {"mode": "primary", "prompt": "` + customPrompt + `"},
+    "sdd-orchestrator-cheap": {"mode": "primary", "model": "anthropic:claude-haiku-3-5"},
+    "sdd-init-cheap": {"mode": "subagent", "model": "anthropic:claude-haiku-3-5"}
+  }
+}`
+	if err := os.WriteFile(settingsPath, []byte(seed), 0o644); err != nil {
+		t.Fatalf("WriteFile(settings): %v", err)
+	}
+
+	sel := model.Selection{
+		Agents:             []model.AgentID{model.AgentOpenCode},
+		Components:         []model.ComponentID{model.ComponentSDD},
+		SDDMode:            model.SDDModeSingle,
+		SDDProfileStrategy: model.SDDProfileStrategyExternalSingleActive,
+	}
+
+	if _, err := RunSyncWithSelection(home, sel); err != nil {
+		t.Fatalf("RunSyncWithSelection() error = %v", err)
+	}
+
+	settingsData, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("ReadFile(settings) error = %v", err)
+	}
+	settingsText := string(settingsData)
+
+	if !strings.Contains(settingsText, customPrompt) {
+		t.Fatalf("expected sdd-orchestrator prompt to be preserved in external-single-active mode")
+	}
+	if strings.Contains(settingsText, "\"sdd-onboard-cheap\"") {
+		t.Fatalf("external-single-active should not auto-detect/regenerate suffixed profiles")
+	}
+
+	// external-single-active forces multi-mode assets so shared prompts exist.
+	promptPath := filepath.Join(home, ".config", "opencode", "prompts", "sdd", "sdd-apply.md")
+	if _, err := os.Stat(promptPath); err != nil {
+		t.Fatalf("expected shared prompt file %q to exist (forced multi mode): %v", promptPath, err)
+	}
+}
+
 // containsAny returns true if s contains any of the given substrings (case-insensitive).
 func containsAny(s string, subs ...string) bool {
 	lower := strings.ToLower(s)
@@ -1769,6 +1890,14 @@ func TestBuildSyncSelectionProfilesForwarded(t *testing.T) {
 	}
 	if sel.Profiles[0].Name != "cheap" {
 		t.Errorf("Selection.Profiles[0].Name = %q, want %q", sel.Profiles[0].Name, "cheap")
+	}
+}
+
+func TestBuildSyncSelectionSDDProfileStrategyForwarded(t *testing.T) {
+	flags := SyncFlags{SDDProfileStrategy: string(model.SDDProfileStrategyExternalSingleActive)}
+	sel := BuildSyncSelection(flags, []model.AgentID{model.AgentOpenCode})
+	if sel.SDDProfileStrategy != model.SDDProfileStrategyExternalSingleActive {
+		t.Fatalf("Selection.SDDProfileStrategy = %q, want %q", sel.SDDProfileStrategy, model.SDDProfileStrategyExternalSingleActive)
 	}
 }
 

--- a/internal/components/sdd/inject.go
+++ b/internal/components/sdd/inject.go
@@ -39,6 +39,12 @@ type InjectOptions struct {
 	// OpenCode settings file. The default profile (Name="" or Name="default")
 	// is skipped — it is handled by the existing flow.
 	Profiles []model.Profile
+
+	// PreserveOpenCodeOrchestratorPrompt keeps the existing
+	// opencode.json agent.sdd-orchestrator.prompt value during sync.
+	// Used by external-single-active profile strategy integrations where
+	// external tools extend orchestrator policy/prompt at runtime.
+	PreserveOpenCodeOrchestratorPrompt bool
 }
 
 // workflowInjector is an optional adapter capability: if an adapter
@@ -315,7 +321,7 @@ func Inject(homeDir string, adapter agents.Adapter, sddMode model.SDDModeID, opt
 				changed = changed || promptsChanged
 			}
 
-			overlayBytes, err = inlineOpenCodeSDDPrompts(overlayBytes, homeDir)
+			overlayBytes, err = inlineOpenCodeSDDPrompts(overlayBytes, homeDir, settingsPath, opts.PreserveOpenCodeOrchestratorPrompt)
 			if err != nil {
 				return InjectionResult{}, fmt.Errorf("inline OpenCode SDD prompts: %w", err)
 			}
@@ -632,7 +638,7 @@ func Inject(homeDir string, adapter agents.Adapter, sddMode model.SDDModeID, opt
 	return InjectionResult{Changed: changed, Files: files}, nil
 }
 
-func inlineOpenCodeSDDPrompts(overlayBytes []byte, homeDir string) ([]byte, error) {
+func inlineOpenCodeSDDPrompts(overlayBytes []byte, homeDir, settingsPath string, preserveExistingOrchestratorPrompt bool) ([]byte, error) {
 	var overlay map[string]any
 	if err := json.Unmarshal(overlayBytes, &overlay); err != nil {
 		return nil, fmt.Errorf("unmarshal OpenCode SDD overlay: %w", err)
@@ -647,7 +653,8 @@ func inlineOpenCodeSDDPrompts(overlayBytes []byte, homeDir string) ([]byte, erro
 		return overlayBytes, nil
 	}
 
-	// Inline the orchestrator prompt (always inlined, not a file reference).
+	// Inline the orchestrator prompt (always inlined, not a file reference),
+	// unless an external strategy requested preserving the existing prompt.
 	orchestratorRaw, ok := agentsMap["sdd-orchestrator"]
 	if !ok {
 		return overlayBytes, nil
@@ -656,7 +663,19 @@ func inlineOpenCodeSDDPrompts(overlayBytes []byte, homeDir string) ([]byte, erro
 	if !ok {
 		return overlayBytes, nil
 	}
-	orchestratorMap["prompt"] = assets.MustRead("generic/sdd-orchestrator.md")
+	if preserveExistingOrchestratorPrompt {
+		existingPrompt, err := readOpenCodeAgentPrompt(settingsPath, "sdd-orchestrator")
+		if err != nil {
+			return nil, err
+		}
+		if existingPrompt != "" {
+			orchestratorMap["prompt"] = existingPrompt
+		} else {
+			orchestratorMap["prompt"] = assets.MustRead("generic/sdd-orchestrator.md")
+		}
+	} else {
+		orchestratorMap["prompt"] = assets.MustRead("generic/sdd-orchestrator.md")
+	}
 
 	// Replace sub-agent prompt placeholders with {file:<absolutePath>} references.
 	// The placeholder format is __PROMPT_FILE_{phase}__ where {phase} is the agent name.
@@ -684,6 +703,44 @@ func inlineOpenCodeSDDPrompts(overlayBytes []byte, homeDir string) ([]byte, erro
 	}
 
 	return append(result, '\n'), nil
+}
+
+func readOpenCodeAgentPrompt(settingsPath, agentKey string) (string, error) {
+	if strings.TrimSpace(settingsPath) == "" || strings.TrimSpace(agentKey) == "" {
+		return "", nil
+	}
+
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", fmt.Errorf("read OpenCode settings %q: %w", settingsPath, err)
+	}
+
+	var root map[string]any
+	if err := json.Unmarshal(data, &root); err != nil {
+		return "", nil
+	}
+
+	agentsRaw, ok := root["agent"]
+	if !ok {
+		return "", nil
+	}
+	agentsMap, ok := agentsRaw.(map[string]any)
+	if !ok {
+		return "", nil
+	}
+	agentRaw, ok := agentsMap[agentKey]
+	if !ok {
+		return "", nil
+	}
+	agentMap, ok := agentRaw.(map[string]any)
+	if !ok {
+		return "", nil
+	}
+	prompt, _ := agentMap["prompt"].(string)
+	return prompt, nil
 }
 
 // installOpenCodePlugins copies the background-agents plugin and installs its

--- a/internal/components/sdd/inject_test.go
+++ b/internal/components/sdd/inject_test.go
@@ -256,6 +256,84 @@ func TestInjectOpenCodeIsIdempotent(t *testing.T) {
 	}
 }
 
+func TestInjectOpenCodePreservesExistingOrchestratorPromptWhenRequested(t *testing.T) {
+	home := t.TempDir()
+	mockNoPackageManager(t)
+
+	settingsPath := filepath.Join(home, ".config", "opencode", "opencode.json")
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(settings dir) error = %v", err)
+	}
+
+	const customPrompt = "EXTERNAL_PROFILE_MANAGER_CUSTOM_PROMPT_DO_NOT_OVERWRITE"
+	seed := `{
+  "agent": {
+    "sdd-orchestrator": {
+      "mode": "primary",
+      "prompt": "` + customPrompt + `"
+    }
+  }
+}`
+	if err := os.WriteFile(settingsPath, []byte(seed), 0o644); err != nil {
+		t.Fatalf("WriteFile(opencode.json) error = %v", err)
+	}
+
+	_, err := Inject(home, opencodeAdapter(), model.SDDModeMulti, InjectOptions{
+		PreserveOpenCodeOrchestratorPrompt: true,
+	})
+	if err != nil {
+		t.Fatalf("Inject() error = %v", err)
+	}
+
+	settingsBytes, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("ReadFile(opencode.json) error = %v", err)
+	}
+	if !strings.Contains(string(settingsBytes), customPrompt) {
+		t.Fatalf("expected preserved custom orchestrator prompt %q in opencode.json", customPrompt)
+	}
+}
+
+func TestInjectOpenCodeOverwritesOrchestratorPromptByDefault(t *testing.T) {
+	home := t.TempDir()
+	mockNoPackageManager(t)
+
+	settingsPath := filepath.Join(home, ".config", "opencode", "opencode.json")
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(settings dir) error = %v", err)
+	}
+
+	const customPrompt = "EXTERNAL_PROFILE_MANAGER_CUSTOM_PROMPT_DO_NOT_OVERWRITE"
+	seed := `{
+  "agent": {
+    "sdd-orchestrator": {
+      "mode": "primary",
+      "prompt": "` + customPrompt + `"
+    }
+  }
+}`
+	if err := os.WriteFile(settingsPath, []byte(seed), 0o644); err != nil {
+		t.Fatalf("WriteFile(opencode.json) error = %v", err)
+	}
+
+	_, err := Inject(home, opencodeAdapter(), model.SDDModeMulti)
+	if err != nil {
+		t.Fatalf("Inject() error = %v", err)
+	}
+
+	settingsBytes, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("ReadFile(opencode.json) error = %v", err)
+	}
+	text := string(settingsBytes)
+	if strings.Contains(text, customPrompt) {
+		t.Fatalf("expected default sync to overwrite custom orchestrator prompt")
+	}
+	if !strings.Contains(text, "Spec-Driven Development") {
+		t.Fatalf("expected default orchestrator prompt content after sync")
+	}
+}
+
 func TestInjectOpenCodeMigratesLegacyAgentsKey(t *testing.T) {
 	home := t.TempDir()
 

--- a/internal/components/sdd/profiles.go
+++ b/internal/components/sdd/profiles.go
@@ -63,6 +63,45 @@ func ProfilePhaseOrder() []string {
 	return append([]string(nil), profilePhaseOrder...)
 }
 
+// ResolveProfileStrategy resolves the sync profile strategy with this order:
+//  1. explicit (non-empty)
+//  2. auto-detect external-single-active when ~/.config/opencode/profiles/*.json exists
+//  3. fallback to generated-multi
+func ResolveProfileStrategy(homeDir string, explicit model.SDDProfileStrategyID) model.SDDProfileStrategyID {
+	if explicit != "" {
+		return explicit
+	}
+	if HasExternalProfileFiles(homeDir) {
+		return model.SDDProfileStrategyExternalSingleActive
+	}
+	return model.SDDProfileStrategyGeneratedMulti
+}
+
+// HasExternalProfileFiles returns true when the external OpenCode profiles
+// directory exists and contains at least one *.json profile file.
+func HasExternalProfileFiles(homeDir string) bool {
+	if strings.TrimSpace(homeDir) == "" {
+		return false
+	}
+
+	profilesDir := filepath.Join(homeDir, ".config", "opencode", "profiles")
+	entries, err := os.ReadDir(profilesDir)
+	if err != nil {
+		return false
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		if strings.HasSuffix(strings.ToLower(entry.Name()), ".json") {
+			return true
+		}
+	}
+
+	return false
+}
+
 // ProfileAgentKeys returns the 11 agent keys for the given profile name.
 // When name is empty, it returns the default (unsuffixed) keys.
 // When name is non-empty, each key is suffixed with "-{name}".

--- a/internal/components/sdd/profiles_test.go
+++ b/internal/components/sdd/profiles_test.go
@@ -11,6 +11,49 @@ import (
 	"github.com/gentleman-programming/gentle-ai/internal/model"
 )
 
+func TestResolveProfileStrategy_ExplicitWins(t *testing.T) {
+	home := t.TempDir()
+
+	profilesDir := filepath.Join(home, ".config", "opencode", "profiles")
+	if err := os.MkdirAll(profilesDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(profiles): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(profilesDir, "active.json"), []byte(`{"name":"external"}`), 0o644); err != nil {
+		t.Fatalf("WriteFile(active.json): %v", err)
+	}
+
+	got := ResolveProfileStrategy(home, model.SDDProfileStrategyGeneratedMulti)
+	if got != model.SDDProfileStrategyGeneratedMulti {
+		t.Fatalf("ResolveProfileStrategy(explicit) = %q, want %q", got, model.SDDProfileStrategyGeneratedMulti)
+	}
+}
+
+func TestResolveProfileStrategy_AutoDetectsExternalProfiles(t *testing.T) {
+	home := t.TempDir()
+
+	profilesDir := filepath.Join(home, ".config", "opencode", "profiles")
+	if err := os.MkdirAll(profilesDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(profiles): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(profilesDir, "cheap.json"), []byte(`{"name":"cheap"}`), 0o644); err != nil {
+		t.Fatalf("WriteFile(cheap.json): %v", err)
+	}
+
+	got := ResolveProfileStrategy(home, "")
+	if got != model.SDDProfileStrategyExternalSingleActive {
+		t.Fatalf("ResolveProfileStrategy(auto) = %q, want %q", got, model.SDDProfileStrategyExternalSingleActive)
+	}
+}
+
+func TestResolveProfileStrategy_DefaultsGeneratedMultiWithoutExternalProfiles(t *testing.T) {
+	home := t.TempDir()
+
+	got := ResolveProfileStrategy(home, "")
+	if got != model.SDDProfileStrategyGeneratedMulti {
+		t.Fatalf("ResolveProfileStrategy(no external profiles) = %q, want %q", got, model.SDDProfileStrategyGeneratedMulti)
+	}
+}
+
 // ─── ValidateProfileName ───────────────────────────────────────────────────
 
 func TestValidateProfileName_Valid(t *testing.T) {

--- a/internal/model/selection.go
+++ b/internal/model/selection.go
@@ -7,6 +7,7 @@ type Selection struct {
 	Persona                PersonaID
 	Preset                 PresetID
 	SDDMode                SDDModeID
+	SDDProfileStrategy     SDDProfileStrategyID
 	StrictTDD              bool
 	ModelAssignments       map[string]ModelAssignment  // key = sub-agent name (e.g., "sdd-init")
 	ClaudeModelAssignments map[string]ClaudeModelAlias // key = phase name; value = opus|sonnet|haiku
@@ -45,6 +46,7 @@ type SyncOverrides struct {
 	ClaudeModelAssignments map[string]ClaudeModelAlias // nil = no override; empty map = reset to defaults
 	KiroModelAssignments   map[string]ClaudeModelAlias // nil = no override; empty map = reset to defaults
 	SDDMode                SDDModeID                   // "" = no override; when non-empty, overrides the sync's default SDD mode
+	SDDProfileStrategy     SDDProfileStrategyID        // "" = auto; otherwise explicit sync profile strategy
 	StrictTDD              *bool                       // nil = no override; non-nil = override strict TDD mode
 	Profiles               []Profile                   // NEW: profile creation/updates during sync
 }

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -130,6 +130,20 @@ const (
 	SDDModeMulti  SDDModeID = "multi"
 )
 
+// SDDProfileStrategyID defines how sync handles OpenCode SDD profiles.
+type SDDProfileStrategyID string
+
+const (
+	// SDDProfileStrategyGeneratedMulti is the default/backward-compatible mode:
+	// named profiles coexist in opencode.json as suffixed agents and are detected
+	// from sdd-orchestrator-{name} keys during regular sync.
+	SDDProfileStrategyGeneratedMulti SDDProfileStrategyID = "generated-multi"
+	// SDDProfileStrategyExternalSingleActive supports external profile managers
+	// that keep profile state outside opencode.json and activate one runtime
+	// profile without requiring a restart.
+	SDDProfileStrategyExternalSingleActive SDDProfileStrategyID = "external-single-active"
+)
+
 // Profile represents a named SDD orchestrator configuration with model assignments.
 // The default profile (Name="" or Name="default") maps to the base sdd-orchestrator.
 // Named profiles generate sdd-orchestrator-{Name} + suffixed sub-agents.


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #319

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [ ] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [x] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Add an OpenCode SDD profile sync strategy so gentle-ai can distinguish between generated multi-profile overlays and externally managed single-active runtime profiles.
- Auto-detect external profile managers from `~/.config/opencode/profiles/*.json`, skip suffixed profile refresh in that mode, and preserve the existing `sdd-orchestrator` prompt during sync.
- Document the community `sdd-engram-plugin` integration in the README.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/model/types.go` | Added `SDDProfileStrategyID` constants for generated-multi and external-single-active. |
| `internal/model/selection.go` | Forwarded the selected profile sync strategy through sync selection and overrides. |
| `internal/cli/sync.go` | Added `--sdd-profile-strategy`, strategy parsing, auto-resolution, and external-single-active sync behavior. |
| `internal/components/sdd/profiles.go` | Added external profile file auto-detection and strategy resolution helper. |
| `internal/components/sdd/inject.go` | Preserved the existing OpenCode orchestrator prompt when syncing in external-single-active mode. |
| `internal/cli/sync_test.go` | Added coverage for strategy parsing, forwarding, and external-single-active sync behavior. |
| `internal/components/sdd/inject_test.go` | Added prompt preservation regression tests. |
| `internal/components/sdd/profiles_test.go` | Added strategy auto-detection tests. |
| `README.md` | Added a Community Integrations entry for `sdd-engram-plugin`. |

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./...
```

**E2E Tests** (Docker required)
```bash
cd e2e && ./docker-test.sh
```

- [x] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Manually tested locally

Manual coverage:
- Verified `go test ./internal/components/sdd` and `go test ./internal/cli` while iterating.
- Verified `go test ./...` passes after the final commit.

---

## 🤖 Automated Checks

The following checks run automatically on this PR:

| Check | Status | Description |
|-------|--------|-------------|
| Check Issue Reference | ⏳ | PR body must contain `Closes/Fixes/Resolves #N` |
| Check Issue Has `status:approved` | ⏳ | Linked issue must have been approved before work began |
| Check PR Has `type:*` Label | ⏳ | Exactly one `type:*` label must be applied |
| Unit Tests | ⏳ | `go test ./...` must pass |
| E2E Tests | ⏳ | `cd e2e && ./docker-test.sh` must pass |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [ ] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

This keeps the existing generated-multi behavior as the default, and only switches to the safer compatibility path when the strategy is explicitly selected or external OpenCode profile files are detected.