### PR TITLE
feat(pi): add first-class pi support and pi-native resource sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This is NOT an AI agent installer. Most agents are easy to install. This is an *
 
 **After**: Your agent now has memory, skills, workflow, MCP tools, and a persona that actually teaches you.
 
-### 10 Supported Agents
+### 11 Supported Agents
 
 | Agent | Delegation Model | Key Feature |
 |-------|:---:|---|
@@ -39,6 +39,7 @@ This is NOT an AI agent installer. Most agents are easy to install. This is an *
 | **Antigravity** | Solo-agent + Mission Control | Built-in Browser/Terminal sub-agents |
 | **Kiro IDE** | Full (native subagents) | Native `~/.kiro/agents/` + steering orchestration |
 | **Qwen Code** | Full (native sub-agents) | Slash commands, `~/.qwen/commands/`, `auto_edit` mode |
+| **pi** | Solo-agent | Native `~/.pi/agent` resources (AGENTS + skills) |
 
 > **Note**: This project supersedes [Agent Teams Lite](https://github.com/Gentleman-Programming/agent-teams-lite) (now archived). Everything ATL provided is included here with better installation, automatic updates, and persistent memory.
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -19,6 +19,7 @@
 | Kimi            | `kimi`           | Yes          | Yes | Full (native custom agents)  | No            | No             | `~/.kimi`                           |
 | Qwen Code       | `qwen-code`      | Yes          | Yes | Full (native sub-agents)     | No            | Yes            | `~/.qwen`                           |
 | Kiro IDE        | `kiro-ide`       | Yes          | Yes | Full (native subagents)      | No            | No             | `~/.kiro`                           |
+| pi              | `pi`             | Yes          | No  | Solo-agent                   | No            | No             | `~/.pi/agent`                       |
 
 All agents receive the **full SDD orchestrator** injected into their system prompt, plus skill files written to their skills directory. The agent handles SDD automatically when the task is large enough, or when the user explicitly asks for it — no manual setup required.
 
@@ -29,7 +30,7 @@ All agents receive the **full SDD orchestrator** injected into their system prom
 | Model                 | How It Works                                                                                                                         | Agents                                                           |
 | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------- |
 | **Full (sub-agents)** | Each SDD phase runs in an isolated context window via native sub-agent delegation. The orchestrator coordinates; sub-agents execute. | Claude Code, OpenCode, Gemini CLI, Cursor, VS Code Copilot, Kimi, Kiro IDE, Qwen Code |
-| **Solo-agent**        | All SDD phases run inline in the same conversation. The orchestrator IS the executor. Engram provides cross-phase persistence.       | Codex, Windsurf, Antigravity                                     |
+| **Solo-agent**        | All SDD phases run inline in the same conversation. The orchestrator IS the executor. Engram provides cross-phase persistence.       | Codex, Windsurf, Antigravity, pi                                |
 
 ### Cursor Native Subagents
 
@@ -64,11 +65,11 @@ Kiro uses native custom agents in `~/.kiro/agents/`. `gentle-ai` writes 10 phase
 
 ## SDD Mode Support
 
-| Feature | Claude Code | OpenCode | Gemini CLI | Cursor | VS Code Copilot | Codex | Windsurf | Antigravity | Kiro IDE | Qwen Code |
-|---------|:-----------:|:--------:|:----------:|:------:|:---------------:|:-----:|:--------:|:-----------:|:--------:|:---------:|
-| SDD orchestrator | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
-| Single-mode SDD | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
-| Multi-mode SDD | — | Yes | — | — | — | — | — | — | Yes* | — |
+| Feature | Claude Code | OpenCode | Gemini CLI | Cursor | VS Code Copilot | Codex | Windsurf | Antigravity | Kiro IDE | Qwen Code | pi |
+|---------|:-----------:|:--------:|:----------:|:------:|:---------------:|:-----:|:--------:|:-----------:|:--------:|:---------:|:--:|
+| SDD orchestrator | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| Single-mode SDD | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| Multi-mode SDD | — | Yes | — | — | — | — | — | — | Yes* | — | — |
 
 **Multi-mode** (assigning different AI models to each SDD phase) is natively supported by **OpenCode** (via its provider system) and **Kiro IDE** (via native subagent `model:` frontmatter — each phase agent runs with its own model ID). All other agents run in **single-mode** — the orchestrator manages everything using whatever model the agent is already running.
 
@@ -162,3 +163,16 @@ Kiro uses native custom agents in `~/.kiro/agents/`. `gentle-ai` writes 10 phase
 - **Install**: via npm — `npm install -g @qwen-code/qwen-code@latest`
 - **Engram slug**: `"qwen-code"` for `engram setup` integration
 - **SDD orchestrator**: `internal/assets/qwen/sdd-orchestrator.md` with Qwen-specific path references
+
+### pi
+- **Detection**: gentle-ai detects pi from `~/.pi/agent` and checks for `pi` binary on `PATH`
+- **Config root**: `~/.pi/agent/`
+- **System prompt**: `~/.pi/agent/AGENTS.md` (managed via markdown-section strategy)
+- **Skills**: `~/.pi/agent/skills/`
+- **pi-native resources**:
+  - Extensions templates: `~/.pi/agent/extensions/context7-tools.ts`, `~/.pi/agent/extensions/engram-tools.ts`
+  - Prompt templates: `~/.pi/agent/prompts/sdd-*.md`
+  - Theme asset (when theme component is selected): `~/.pi/agent/themes/gentleman-kanagawa.json`
+  - Managed package metadata: `~/.pi/agent/settings.json` (`gentleAI.managedPackages.pi-gentle-ai`)
+- **MCP**: not injected directly by this adapter; integrations are represented as pi-native extension resources
+- **Install**: manual (no auto-install command in gentle-ai yet)

--- a/internal/agents/factory.go
+++ b/internal/agents/factory.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gentleman-programming/gentle-ai/internal/agents/kimi"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/kiro"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/opencode"
+	"github.com/gentleman-programming/gentle-ai/internal/agents/pi"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/qwen"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/vscode"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/windsurf"
@@ -44,13 +45,15 @@ func NewAdapter(agent model.AgentID) (Adapter, error) {
 		return qwen.NewAdapter(), nil
 	case model.AgentKiroIDE:
 		return kiro.NewAdapter(), nil
+	case model.AgentPi:
+		return pi.NewAdapter(), nil
 	default:
 		return nil, AgentNotSupportedError{Agent: agent}
 	}
 }
 
 func NewDefaultRegistry() (*Registry, error) {
-	adapters := make([]Adapter, 0, 12)
+	adapters := make([]Adapter, 0, 13)
 
 	for _, agent := range []model.AgentID{
 		model.AgentClaudeCode,
@@ -65,6 +68,7 @@ func NewDefaultRegistry() (*Registry, error) {
 		model.AgentKimi,
 		model.AgentQwenCode,
 		model.AgentKiroIDE,
+		model.AgentPi,
 	} {
 		adapter, err := NewAdapter(agent)
 		if err != nil {

--- a/internal/agents/interface.go
+++ b/internal/agents/interface.go
@@ -54,3 +54,29 @@ type Adapter interface {
 	SupportsSystemPrompt() bool
 	SupportsMCP() bool
 }
+
+// ExtendedResourceAdapter is an optional capability for agents that expose
+// additional first-class resource directories beyond the baseline Adapter
+// contract (extensions, prompt templates, themes, package metadata).
+//
+// Callers must feature-detect with a type assertion:
+//
+//	ext, ok := adapter.(agents.ExtendedResourceAdapter)
+//
+// and only use these paths when ok==true.
+//
+// This keeps the core Adapter stable while enabling incremental support for
+// resource-native runtimes such as pi.
+type ExtendedResourceAdapter interface {
+	SupportsExtensions() bool
+	ExtensionsDir(homeDir string) string
+
+	SupportsPromptTemplates() bool
+	PromptsDir(homeDir string) string
+
+	SupportsThemes() bool
+	ThemesDir(homeDir string) string
+
+	SupportsPackages() bool
+	PackagesStatePath(homeDir string) string
+}

--- a/internal/agents/pi/adapter.go
+++ b/internal/agents/pi/adapter.go
@@ -1,0 +1,200 @@
+package pi
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/gentleman-programming/gentle-ai/internal/model"
+	"github.com/gentleman-programming/gentle-ai/internal/system"
+)
+
+var LookPathOverride = exec.LookPath
+
+type statResult struct {
+	isDir bool
+	err   error
+}
+
+// Adapter implements agents.Adapter for pi.
+//
+// pi stores user-level resources under ~/.pi/agent/ (AGENTS.md, skills,
+// settings). gentle-ai integrates with those filesystem primitives directly.
+//
+// MCP injection is intentionally disabled for pi in this first-class adapter.
+// Context7/Engram are expected to be handled by pi-native extensions/packages.
+type Adapter struct {
+	lookPath func(string) (string, error)
+	statPath func(string) statResult
+}
+
+func NewAdapter() *Adapter {
+	return &Adapter{
+		lookPath: LookPathOverride,
+		statPath: defaultStat,
+	}
+}
+
+// --- Identity ---
+
+func (a *Adapter) Agent() model.AgentID {
+	return model.AgentPi
+}
+
+func (a *Adapter) Tier() model.SupportTier {
+	return model.TierFull
+}
+
+// --- Detection ---
+
+func (a *Adapter) Detect(_ context.Context, homeDir string) (bool, string, string, bool, error) {
+	configPath := filepath.Join(homeDir, ".pi", "agent")
+
+	binaryPath, err := a.lookPath("pi")
+	installed := err == nil
+
+	stat := a.statPath(configPath)
+	if stat.err != nil {
+		if os.IsNotExist(stat.err) {
+			return installed, binaryPath, configPath, false, nil
+		}
+		return false, "", "", false, stat.err
+	}
+
+	return installed, binaryPath, configPath, stat.isDir, nil
+}
+
+// --- Installation ---
+
+func (a *Adapter) SupportsAutoInstall() bool {
+	return false
+}
+
+func (a *Adapter) InstallCommand(_ system.PlatformProfile) ([][]string, error) {
+	return nil, AgentNotInstallableError{Agent: model.AgentPi}
+}
+
+// --- Config paths ---
+
+func (a *Adapter) GlobalConfigDir(homeDir string) string {
+	return filepath.Join(homeDir, ".pi", "agent")
+}
+
+func (a *Adapter) SystemPromptDir(homeDir string) string {
+	return filepath.Join(homeDir, ".pi", "agent")
+}
+
+func (a *Adapter) SystemPromptFile(homeDir string) string {
+	return filepath.Join(homeDir, ".pi", "agent", "AGENTS.md")
+}
+
+func (a *Adapter) SkillsDir(homeDir string) string {
+	return filepath.Join(homeDir, ".pi", "agent", "skills")
+}
+
+func (a *Adapter) SettingsPath(homeDir string) string {
+	return filepath.Join(homeDir, ".pi", "agent", "settings.json")
+}
+
+// --- Config strategies ---
+
+func (a *Adapter) SystemPromptStrategy() model.SystemPromptStrategy {
+	return model.StrategyMarkdownSections
+}
+
+func (a *Adapter) MCPStrategy() model.MCPStrategy {
+	return model.StrategyMergeIntoSettings
+}
+
+// --- MCP ---
+
+func (a *Adapter) MCPConfigPath(homeDir string, _ string) string {
+	return filepath.Join(homeDir, ".pi", "agent", "settings.json")
+}
+
+// --- Optional capabilities ---
+
+func (a *Adapter) SupportsOutputStyles() bool {
+	return false
+}
+
+func (a *Adapter) OutputStyleDir(_ string) string {
+	return ""
+}
+
+func (a *Adapter) SupportsSlashCommands() bool {
+	return false
+}
+
+func (a *Adapter) CommandsDir(_ string) string {
+	return ""
+}
+
+func (a *Adapter) SupportsSkills() bool {
+	return true
+}
+
+func (a *Adapter) SupportsSystemPrompt() bool {
+	return true
+}
+
+func (a *Adapter) SupportsMCP() bool {
+	return false
+}
+
+// --- Extended resources (optional interface) ---
+
+func (a *Adapter) SupportsExtensions() bool {
+	return true
+}
+
+func (a *Adapter) ExtensionsDir(homeDir string) string {
+	return filepath.Join(homeDir, ".pi", "agent", "extensions")
+}
+
+func (a *Adapter) SupportsPromptTemplates() bool {
+	return true
+}
+
+func (a *Adapter) PromptsDir(homeDir string) string {
+	return filepath.Join(homeDir, ".pi", "agent", "prompts")
+}
+
+func (a *Adapter) SupportsThemes() bool {
+	return true
+}
+
+func (a *Adapter) ThemesDir(homeDir string) string {
+	return filepath.Join(homeDir, ".pi", "agent", "themes")
+}
+
+func (a *Adapter) SupportsPackages() bool {
+	return false
+}
+
+func (a *Adapter) PackagesStatePath(homeDir string) string {
+	return filepath.Join(homeDir, ".pi", "agent", "settings.json")
+}
+
+func defaultStat(path string) statResult {
+	info, err := os.Stat(path)
+	if err != nil {
+		return statResult{err: err}
+	}
+
+	return statResult{isDir: info.IsDir()}
+}
+
+// AgentNotInstallableError is returned when pi cannot be installed automatically.
+//
+// gentle-ai currently treats pi as manual-install for safety: users should
+// install/upgrade pi via its official distribution channel.
+type AgentNotInstallableError struct {
+	Agent model.AgentID
+}
+
+func (e AgentNotInstallableError) Error() string {
+	return fmt.Sprintf("agent %q cannot be auto-installed; install pi first", e.Agent)
+}

--- a/internal/agents/pi/adapter_test.go
+++ b/internal/agents/pi/adapter_test.go
@@ -1,0 +1,278 @@
+package pi
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/internal/model"
+	"github.com/gentleman-programming/gentle-ai/internal/system"
+)
+
+func TestDetect(t *testing.T) {
+	tests := []struct {
+		name            string
+		lookPathPath    string
+		lookPathErr     error
+		stat            statResult
+		wantInstalled   bool
+		wantBinaryPath  string
+		wantConfigPath  string
+		wantConfigFound bool
+		wantErr         bool
+	}{
+		{
+			name:            "binary and config directory found",
+			lookPathPath:    "/usr/local/bin/pi",
+			stat:            statResult{isDir: true},
+			wantInstalled:   true,
+			wantBinaryPath:  "/usr/local/bin/pi",
+			wantConfigPath:  filepath.Join("/tmp/home", ".pi", "agent"),
+			wantConfigFound: true,
+		},
+		{
+			name:            "binary missing and config missing",
+			lookPathErr:     errors.New("missing"),
+			stat:            statResult{err: os.ErrNotExist},
+			wantInstalled:   false,
+			wantBinaryPath:  "",
+			wantConfigPath:  filepath.Join("/tmp/home", ".pi", "agent"),
+			wantConfigFound: false,
+		},
+		{
+			name:    "stat error bubbles up",
+			stat:    statResult{err: errors.New("permission denied")},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := &Adapter{
+				lookPath: func(string) (string, error) {
+					return tt.lookPathPath, tt.lookPathErr
+				},
+				statPath: func(string) statResult {
+					return tt.stat
+				},
+			}
+
+			installed, binaryPath, configPath, configFound, err := a.Detect(context.Background(), "/tmp/home")
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Detect() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if tt.wantErr {
+				return
+			}
+
+			if installed != tt.wantInstalled {
+				t.Fatalf("Detect() installed = %v, want %v", installed, tt.wantInstalled)
+			}
+
+			if binaryPath != tt.wantBinaryPath {
+				t.Fatalf("Detect() binaryPath = %q, want %q", binaryPath, tt.wantBinaryPath)
+			}
+
+			if configPath != tt.wantConfigPath {
+				t.Fatalf("Detect() configPath = %q, want %q", configPath, tt.wantConfigPath)
+			}
+
+			if configFound != tt.wantConfigFound {
+				t.Fatalf("Detect() configFound = %v, want %v", configFound, tt.wantConfigFound)
+			}
+		})
+	}
+}
+
+func TestInstallCommand(t *testing.T) {
+	a := NewAdapter()
+
+	commands, err := a.InstallCommand(system.PlatformProfile{OS: "darwin"})
+	if err == nil {
+		t.Fatal("InstallCommand() expected error for manual-install adapter")
+	}
+	if commands != nil {
+		t.Fatalf("InstallCommand() commands = %v, want nil", commands)
+	}
+}
+
+func TestConfigPaths(t *testing.T) {
+	a := NewAdapter()
+	home := "/tmp/home"
+
+	tests := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{
+			name: "GlobalConfigDir",
+			got:  a.GlobalConfigDir(home),
+			want: filepath.Join(home, ".pi", "agent"),
+		},
+		{
+			name: "SystemPromptFile",
+			got:  a.SystemPromptFile(home),
+			want: filepath.Join(home, ".pi", "agent", "AGENTS.md"),
+		},
+		{
+			name: "SkillsDir",
+			got:  a.SkillsDir(home),
+			want: filepath.Join(home, ".pi", "agent", "skills"),
+		},
+		{
+			name: "SettingsPath",
+			got:  a.SettingsPath(home),
+			want: filepath.Join(home, ".pi", "agent", "settings.json"),
+		},
+		{
+			name: "MCPConfigPath",
+			got:  a.MCPConfigPath(home, "context7"),
+			want: filepath.Join(home, ".pi", "agent", "settings.json"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.got != tt.want {
+				t.Errorf("%s() = %q, want %q", tt.name, tt.got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCapabilities(t *testing.T) {
+	a := NewAdapter()
+
+	tests := []struct {
+		name string
+		got  bool
+		want bool
+	}{
+		{"SupportsAutoInstall", a.SupportsAutoInstall(), false},
+		{"SupportsSkills", a.SupportsSkills(), true},
+		{"SupportsSystemPrompt", a.SupportsSystemPrompt(), true},
+		{"SupportsMCP", a.SupportsMCP(), false},
+		{"SupportsSlashCommands", a.SupportsSlashCommands(), false},
+		{"SupportsOutputStyles", a.SupportsOutputStyles(), false},
+		{"SupportsExtensions", a.SupportsExtensions(), true},
+		{"SupportsPromptTemplates", a.SupportsPromptTemplates(), true},
+		{"SupportsThemes", a.SupportsThemes(), true},
+		{"SupportsPackages", a.SupportsPackages(), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.got != tt.want {
+				t.Errorf("%s() = %v, want %v", tt.name, tt.got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAdapterIdentity(t *testing.T) {
+	a := NewAdapter()
+
+	tests := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{"Agent", string(a.Agent()), string(model.AgentPi)},
+		{"Tier", string(a.Tier()), string(model.TierFull)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.got != tt.want {
+				t.Errorf("%s() = %q, want %q", tt.name, tt.got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAdapterStrategies(t *testing.T) {
+	a := NewAdapter()
+
+	tests := []struct {
+		name string
+		got  int
+		want int
+	}{
+		{
+			name: "SystemPromptStrategy",
+			got:  int(a.SystemPromptStrategy()),
+			want: int(model.StrategyMarkdownSections),
+		},
+		{
+			name: "MCPStrategy",
+			got:  int(a.MCPStrategy()),
+			want: int(model.StrategyMergeIntoSettings),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.got != tt.want {
+				t.Errorf("%s() = %v, want %v", tt.name, tt.got, tt.want)
+			}
+		})
+	}
+}
+
+func TestInstallCommandErrorType(t *testing.T) {
+	a := NewAdapter()
+
+	_, err := a.InstallCommand(system.PlatformProfile{})
+	if err == nil {
+		t.Fatal("InstallCommand() expected error")
+	}
+
+	if !reflect.DeepEqual(err.Error(), AgentNotInstallableError{Agent: model.AgentPi}.Error()) {
+		t.Fatalf("InstallCommand() error = %q, want %q", err.Error(), AgentNotInstallableError{Agent: model.AgentPi}.Error())
+	}
+}
+
+func TestExtendedResourcePaths(t *testing.T) {
+	a := NewAdapter()
+	home := "/tmp/home"
+
+	tests := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{
+			name: "ExtensionsDir",
+			got:  a.ExtensionsDir(home),
+			want: filepath.Join(home, ".pi", "agent", "extensions"),
+		},
+		{
+			name: "PromptsDir",
+			got:  a.PromptsDir(home),
+			want: filepath.Join(home, ".pi", "agent", "prompts"),
+		},
+		{
+			name: "ThemesDir",
+			got:  a.ThemesDir(home),
+			want: filepath.Join(home, ".pi", "agent", "themes"),
+		},
+		{
+			name: "PackagesStatePath",
+			got:  a.PackagesStatePath(home),
+			want: filepath.Join(home, ".pi", "agent", "settings.json"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.got != tt.want {
+				t.Errorf("%s() = %q, want %q", tt.name, tt.got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/agents/registry_test.go
+++ b/internal/agents/registry_test.go
@@ -91,13 +91,17 @@ func TestDefaultRegistryIncludesAllAgents(t *testing.T) {
 	for _, agent := range []model.AgentID{
 		model.AgentClaudeCode,
 		model.AgentOpenCode,
+		model.AgentKilocode,
 		model.AgentGeminiCLI,
 		model.AgentCursor,
 		model.AgentVSCodeCopilot,
 		model.AgentCodex,
 		model.AgentAntigravity,
 		model.AgentWindsurf,
+		model.AgentKimi,
 		model.AgentQwenCode,
+		model.AgentKiroIDE,
+		model.AgentPi,
 	} {
 		if _, ok := registry.Get(agent); !ok {
 			t.Fatalf("registry missing %s adapter", agent)
@@ -113,5 +117,27 @@ func TestFactoryRejectsUnsupportedAgent(t *testing.T) {
 
 	if !errors.Is(err, ErrAgentNotSupported) {
 		t.Fatalf("NewAdapter() error = %v, want ErrAgentNotSupported", err)
+	}
+}
+
+func TestPiAdapterImplementsExtendedResourceAdapter(t *testing.T) {
+	adapter, err := NewAdapter(model.AgentPi)
+	if err != nil {
+		t.Fatalf("NewAdapter(pi) error = %v", err)
+	}
+
+	ext, ok := adapter.(ExtendedResourceAdapter)
+	if !ok {
+		t.Fatalf("pi adapter does not implement ExtendedResourceAdapter")
+	}
+
+	if !ext.SupportsExtensions() {
+		t.Fatalf("pi SupportsExtensions() = false, want true")
+	}
+	if !ext.SupportsPromptTemplates() {
+		t.Fatalf("pi SupportsPromptTemplates() = false, want true")
+	}
+	if !ext.SupportsThemes() {
+		t.Fatalf("pi SupportsThemes() = false, want true")
 	}
 }

--- a/internal/assets/assets.go
+++ b/internal/assets/assets.go
@@ -2,7 +2,7 @@ package assets
 
 import "embed"
 
-//go:embed all:claude all:opencode all:generic all:skills all:gga all:gemini all:codex all:antigravity all:windsurf all:cursor all:kimi all:qwen all:kiro
+//go:embed all:claude all:opencode all:generic all:skills all:gga all:gemini all:codex all:antigravity all:windsurf all:cursor all:kimi all:qwen all:kiro all:pi
 var FS embed.FS
 
 // MustRead returns the content of an embedded file or panics.

--- a/internal/assets/assets_test.go
+++ b/internal/assets/assets_test.go
@@ -75,6 +75,26 @@ func TestAllEmbeddedAssetsAreReadable(t *testing.T) {
 		"kimi/agents/sdd-archive.md",
 		"kimi/agents/sdd-onboard.md",
 
+		// pi agent files
+		"pi/persona-gentleman.md",
+		"pi/sdd-orchestrator.md",
+		"pi/extensions/engram-tools.ts",
+		"pi/extensions/context7-tools.ts",
+		"pi/prompts/sdd-new.md",
+		"pi/prompts/sdd-continue.md",
+		"pi/prompts/sdd-ff.md",
+		"pi/prompts/sdd-init.md",
+		"pi/prompts/sdd-explore.md",
+		"pi/prompts/sdd-propose.md",
+		"pi/prompts/sdd-spec.md",
+		"pi/prompts/sdd-design.md",
+		"pi/prompts/sdd-tasks.md",
+		"pi/prompts/sdd-apply.md",
+		"pi/prompts/sdd-verify.md",
+		"pi/prompts/sdd-archive.md",
+		"pi/prompts/sdd-onboard.md",
+		"pi/themes/gentleman-kanagawa.json",
+
 		// SDD skills
 		"skills/sdd-init/SKILL.md",
 		"skills/sdd-apply/SKILL.md",

--- a/internal/assets/pi/extensions/context7-tools.ts
+++ b/internal/assets/pi/extensions/context7-tools.ts
@@ -1,0 +1,10 @@
+// gentle-ai managed template for pi
+// This file documents the expected Context7 bridge entrypoint for pi.
+// Replace with your package implementation if you maintain a custom bridge.
+
+export default function registerContext7Tools() {
+  return {
+    backend: "context7-mcp",
+    tools: ["resolve-library-id", "get-library-docs", "query-docs"],
+  };
+}

--- a/internal/assets/pi/extensions/engram-tools.ts
+++ b/internal/assets/pi/extensions/engram-tools.ts
@@ -1,0 +1,10 @@
+// gentle-ai managed template for pi
+// This file documents the expected Engram bridge entrypoint for pi.
+// Replace with your package implementation if you maintain a custom bridge.
+
+export default function registerEngramTools() {
+  return {
+    backend: "engram-mcp",
+    tools: ["mem_save", "mem_search", "mem_update", "mem_delete"],
+  };
+}

--- a/internal/assets/pi/persona-gentleman.md
+++ b/internal/assets/pi/persona-gentleman.md
@@ -1,0 +1,25 @@
+# Gentleman Persona for pi
+
+## Core rules
+
+- Verify technical claims before agreeing with them.
+- If you need evidence, say "déjame verificar" and inspect code/docs first.
+- If the user is wrong, explain why with concrete evidence.
+- If you are wrong, acknowledge it clearly and correct it.
+- Never add AI attribution or `Co-Authored-By` trailers to commits.
+- For high-risk or multi-file changes, propose a short execution plan before editing.
+
+## Personality
+
+You are a senior architect and teacher: direct, warm, and practical.
+
+## Language
+
+- Spanish input → Rioplatense Spanish with voseo.
+- English input → same direct/warm teaching style.
+
+## pi-native workflow
+
+- Prefer pi-native primitives: AGENTS.md, skills, extensions, prompt templates, themes.
+- Do not assume MCP as the primary mechanism.
+- Do not assume sub-agents; default to inline orchestration unless explicitly available.

--- a/internal/assets/pi/prompts/sdd-apply.md
+++ b/internal/assets/pi/prompts/sdd-apply.md
@@ -1,0 +1,4 @@
+Apply the approved SDD tasks in small, verifiable batches.
+
+- Respect strict TDD when enabled.
+- Update progress artifacts after each batch.

--- a/internal/assets/pi/prompts/sdd-archive.md
+++ b/internal/assets/pi/prompts/sdd-archive.md
@@ -1,0 +1,5 @@
+Archive this SDD change.
+
+- Summarize outcomes
+- Record unresolved risks
+- Capture follow-up items and ownership

--- a/internal/assets/pi/prompts/sdd-continue.md
+++ b/internal/assets/pi/prompts/sdd-continue.md
@@ -1,0 +1,5 @@
+Continue the current SDD change from the latest completed phase.
+
+- Inspect previous artifacts.
+- Select next dependency-ready phase.
+- Execute only one phase unless user asked fast-forward.

--- a/internal/assets/pi/prompts/sdd-design.md
+++ b/internal/assets/pi/prompts/sdd-design.md
@@ -1,0 +1,5 @@
+Design the solution from the approved spec.
+
+- Architecture and boundaries
+- Data flow and interfaces
+- Migration and rollback notes

--- a/internal/assets/pi/prompts/sdd-explore.md
+++ b/internal/assets/pi/prompts/sdd-explore.md
@@ -1,0 +1,5 @@
+Explore the problem space before proposing solutions.
+
+- Gather constraints from code and repo docs.
+- List risks and unknowns.
+- Keep output concise and evidence-based.

--- a/internal/assets/pi/prompts/sdd-ff.md
+++ b/internal/assets/pi/prompts/sdd-ff.md
@@ -1,0 +1,4 @@
+Fast-forward SDD planning for a change.
+
+- proposal -> spec -> design -> tasks
+- Keep artifacts concise and implementation-ready.

--- a/internal/assets/pi/prompts/sdd-init.md
+++ b/internal/assets/pi/prompts/sdd-init.md
@@ -1,0 +1,5 @@
+Initialize SDD context for this repository.
+
+- Detect stack and test runner.
+- Register persistence backend.
+- Confirm strict TDD mode when supported.

--- a/internal/assets/pi/prompts/sdd-new.md
+++ b/internal/assets/pi/prompts/sdd-new.md
@@ -1,0 +1,5 @@
+Start a new SDD change using the pi inline workflow.
+
+- Define change name and objective.
+- Run explore -> propose as first pass.
+- Persist artifacts in the active backend.

--- a/internal/assets/pi/prompts/sdd-onboard.md
+++ b/internal/assets/pi/prompts/sdd-onboard.md
@@ -1,0 +1,5 @@
+Run an end-to-end SDD onboarding walkthrough for this repository.
+
+- Explain each phase briefly
+- Execute a small sample change
+- Show where artifacts are persisted

--- a/internal/assets/pi/prompts/sdd-propose.md
+++ b/internal/assets/pi/prompts/sdd-propose.md
@@ -1,0 +1,5 @@
+Propose one primary approach and alternatives.
+
+- Include trade-offs.
+- Define decision rationale.
+- Record assumptions explicitly.

--- a/internal/assets/pi/prompts/sdd-spec.md
+++ b/internal/assets/pi/prompts/sdd-spec.md
@@ -1,0 +1,5 @@
+Produce implementation-ready specs.
+
+- Functional requirements
+- Non-functional constraints
+- Acceptance criteria

--- a/internal/assets/pi/prompts/sdd-tasks.md
+++ b/internal/assets/pi/prompts/sdd-tasks.md
@@ -1,0 +1,5 @@
+Break design into executable tasks.
+
+- Dependency order
+- Batch size suitable for fast verification
+- Explicit done criteria per task

--- a/internal/assets/pi/prompts/sdd-verify.md
+++ b/internal/assets/pi/prompts/sdd-verify.md
@@ -1,0 +1,4 @@
+Verify implementation against specs, tasks, and risks.
+
+- Classify findings as CRITICAL/WARNING/SUGGESTION.
+- Include concrete reproduction steps for failures.

--- a/internal/assets/pi/sdd-orchestrator.md
+++ b/internal/assets/pi/sdd-orchestrator.md
@@ -1,0 +1,35 @@
+# SDD Lite for pi
+
+## Spec-Driven Development (SDD)
+
+Use an inline, phase-based SDD flow compatible with pi runtime constraints.
+
+### Core rules
+
+- Do not assume sub-agents or MCP.
+- Prefer small, verifiable batches.
+- Keep artifacts concise and actionable.
+- If memory tooling is present, use it; otherwise rely on repository artifacts.
+
+### Recommended phase flow
+
+1. `sdd-init` (once per project)
+2. `sdd-explore`
+3. `sdd-propose`
+4. `sdd-spec`
+5. `sdd-design`
+6. `sdd-tasks`
+7. `sdd-apply`
+8. `sdd-verify`
+9. `sdd-archive`
+
+### Persistence policy
+
+- Prefer durable memory backend when available.
+- Fallback to project files (`openspec`-style artifacts) when memory is unavailable.
+
+### Execution discipline
+
+- Show assumptions explicitly.
+- Validate with tests before closing `sdd-verify`.
+- Archive with outcomes, risks, and follow-ups.

--- a/internal/assets/pi/themes/gentleman-kanagawa.json
+++ b/internal/assets/pi/themes/gentleman-kanagawa.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://pi.dev/theme.schema.json",
+  "name": "gentleman-kanagawa",
+  "extends": "kanagawa",
+  "tokens": {
+    "accent": "#7E9CD8",
+    "success": "#98BB6C",
+    "warning": "#FFA066"
+  }
+}

--- a/internal/catalog/agents.go
+++ b/internal/catalog/agents.go
@@ -22,6 +22,7 @@ var allAgents = []Agent{
 	{ID: model.AgentKimi, Name: "Kimi Code", Tier: model.TierFull, ConfigPath: "~/.kimi"},
 	{ID: model.AgentQwenCode, Name: "Qwen Code", Tier: model.TierFull, ConfigPath: "~/.qwen"},
 	{ID: model.AgentKiroIDE, Name: "Kiro IDE", Tier: model.TierFull, ConfigPath: "~/.kiro"},
+	{ID: model.AgentPi, Name: "pi", Tier: model.TierFull, ConfigPath: "~/.pi/agent"},
 }
 
 // mvpAgents are the original MVP agents (Claude Code, OpenCode).

--- a/internal/cli/install_test.go
+++ b/internal/cli/install_test.go
@@ -43,7 +43,7 @@ func TestNormalizeInstallFlagsDefaults(t *testing.T) {
 	}
 
 	want := model.Selection{
-		Agents:  []model.AgentID{model.AgentClaudeCode, model.AgentOpenCode, model.AgentKilocode, model.AgentGeminiCLI, model.AgentCodex, model.AgentCursor, model.AgentVSCodeCopilot, model.AgentAntigravity, model.AgentWindsurf, model.AgentKimi, model.AgentQwenCode, model.AgentKiroIDE},
+		Agents:  []model.AgentID{model.AgentClaudeCode, model.AgentOpenCode, model.AgentKilocode, model.AgentGeminiCLI, model.AgentCodex, model.AgentCursor, model.AgentVSCodeCopilot, model.AgentAntigravity, model.AgentWindsurf, model.AgentKimi, model.AgentQwenCode, model.AgentKiroIDE, model.AgentPi},
 		Persona: model.PersonaGentleman,
 		Preset:  model.PresetFullGentleman,
 		Components: []model.ComponentID{
@@ -183,7 +183,7 @@ func TestRunInstallDryRunSkipsExecution(t *testing.T) {
 func makeDetectionWithAgents(present ...string) system.DetectionResult {
 	var configs []system.ConfigState
 	// Full canonical agent set — mirrors knownAgentConfigDirs in config_scan.go.
-	known := []string{"claude-code", "opencode", "kilocode", "gemini-cli", "cursor", "vscode-copilot", "codex", "antigravity", "windsurf", "kimi", "qwen-code", "kiro-ide"}
+	known := []string{"claude-code", "opencode", "kilocode", "gemini-cli", "cursor", "vscode-copilot", "codex", "antigravity", "windsurf", "kimi", "qwen-code", "kiro-ide", "pi"}
 	presentSet := make(map[string]bool, len(present))
 	for _, p := range present {
 		presentSet[p] = true
@@ -240,6 +240,7 @@ func TestDefaultAgentsFromDetection_AllAgentsMappedCorrectly(t *testing.T) {
 		{"kimi", model.AgentKimi},
 		{"qwen-code", model.AgentQwenCode},
 		{"kiro-ide", model.AgentKiroIDE},
+		{"pi", model.AgentPi},
 	}
 
 	for _, tt := range tests {

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -20,6 +20,7 @@ import (
 	"github.com/gentleman-programming/gentle-ai/internal/components/mcp"
 	"github.com/gentleman-programming/gentle-ai/internal/components/permissions"
 	"github.com/gentleman-programming/gentle-ai/internal/components/persona"
+	"github.com/gentleman-programming/gentle-ai/internal/components/piresources"
 	"github.com/gentleman-programming/gentle-ai/internal/components/sdd"
 	"github.com/gentleman-programming/gentle-ai/internal/components/skills"
 	"github.com/gentleman-programming/gentle-ai/internal/components/theme"
@@ -548,12 +549,18 @@ func (s componentApplyStep) Run() error {
 			if _, err := engram.Inject(s.homeDir, adapter); err != nil {
 				return fmt.Errorf("inject engram for %q: %w", adapter.Agent(), err)
 			}
+			if _, err := piresources.Inject(s.homeDir, adapter, model.ComponentEngram); err != nil {
+				return fmt.Errorf("inject pi engram resources for %q: %w", adapter.Agent(), err)
+			}
 		}
 		return nil
 	case model.ComponentContext7:
 		for _, adapter := range adapters {
 			if _, err := mcp.Inject(s.homeDir, adapter); err != nil {
 				return fmt.Errorf("inject context7 for %q: %w", adapter.Agent(), err)
+			}
+			if _, err := piresources.Inject(s.homeDir, adapter, model.ComponentContext7); err != nil {
+				return fmt.Errorf("inject pi context7 resources for %q: %w", adapter.Agent(), err)
 			}
 		}
 		return nil
@@ -582,6 +589,9 @@ func (s componentApplyStep) Run() error {
 			}
 			if _, err := sdd.Inject(s.homeDir, adapter, s.selection.SDDMode, opts); err != nil {
 				return fmt.Errorf("inject sdd for %q: %w", adapter.Agent(), err)
+			}
+			if _, err := piresources.Inject(s.homeDir, adapter, model.ComponentSDD); err != nil {
+				return fmt.Errorf("inject pi sdd resources for %q: %w", adapter.Agent(), err)
 			}
 		}
 		return nil
@@ -642,6 +652,9 @@ func (s componentApplyStep) Run() error {
 		for _, adapter := range adapters {
 			if _, err := theme.Inject(s.homeDir, adapter); err != nil {
 				return fmt.Errorf("inject theme for %q: %w", adapter.Agent(), err)
+			}
+			if _, err := piresources.Inject(s.homeDir, adapter, model.ComponentTheme); err != nil {
+				return fmt.Errorf("inject pi theme resources for %q: %w", adapter.Agent(), err)
 			}
 		}
 		return nil
@@ -828,6 +841,7 @@ func backupTargets(homeDir string, selection model.Selection, resolved planner.R
 func componentPaths(homeDir string, selection model.Selection, adapters []agents.Adapter, component model.ComponentID) []string {
 	paths := []string{}
 	for _, adapter := range adapters {
+		paths = append(paths, piresources.PathsForComponent(homeDir, adapter, component)...)
 		switch component {
 		case model.ComponentEngram:
 			switch adapter.MCPStrategy() {

--- a/internal/cli/run_component_paths_test.go
+++ b/internal/cli/run_component_paths_test.go
@@ -143,6 +143,37 @@ func TestComponentPathsEngramCodexIncludesConfigTOML(t *testing.T) {
 	}
 }
 
+func TestComponentPathsPiIncludesPiNativeResources(t *testing.T) {
+	home := t.TempDir()
+	adapters := resolveAdapters([]model.AgentID{model.AgentPi})
+
+	sddPaths := componentPaths(home, model.Selection{}, adapters, model.ComponentSDD)
+	for _, want := range []string{
+		filepath.Join(home, ".pi", "agent", "prompts", "sdd-new.md"),
+		filepath.Join(home, ".pi", "agent", "prompts", "sdd-continue.md"),
+		filepath.Join(home, ".pi", "agent", "settings.json"),
+	} {
+		if !containsPath(sddPaths, want) {
+			t.Fatalf("componentPaths(sdd,pi) missing %q\npaths=%v", want, sddPaths)
+		}
+	}
+
+	engramPaths := componentPaths(home, model.Selection{}, adapters, model.ComponentEngram)
+	if want := filepath.Join(home, ".pi", "agent", "extensions", "engram-tools.ts"); !containsPath(engramPaths, want) {
+		t.Fatalf("componentPaths(engram,pi) missing %q\npaths=%v", want, engramPaths)
+	}
+
+	context7Paths := componentPaths(home, model.Selection{}, adapters, model.ComponentContext7)
+	if want := filepath.Join(home, ".pi", "agent", "extensions", "context7-tools.ts"); !containsPath(context7Paths, want) {
+		t.Fatalf("componentPaths(context7,pi) missing %q\npaths=%v", want, context7Paths)
+	}
+
+	themePaths := componentPaths(home, model.Selection{}, adapters, model.ComponentTheme)
+	if want := filepath.Join(home, ".pi", "agent", "themes", "gentleman-kanagawa.json"); !containsPath(themePaths, want) {
+		t.Fatalf("componentPaths(theme,pi) missing %q\npaths=%v", want, themePaths)
+	}
+}
+
 func containsPath(paths []string, want string) bool {
 	for _, p := range paths {
 		if p == want {

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gentleman-programming/gentle-ai/internal/components/gga"
 	"github.com/gentleman-programming/gentle-ai/internal/components/mcp"
 	"github.com/gentleman-programming/gentle-ai/internal/components/permissions"
+	"github.com/gentleman-programming/gentle-ai/internal/components/piresources"
 	"github.com/gentleman-programming/gentle-ai/internal/components/sdd"
 	"github.com/gentleman-programming/gentle-ai/internal/components/skills"
 	"github.com/gentleman-programming/gentle-ai/internal/components/theme"
@@ -467,6 +468,12 @@ func (s componentSyncStep) Run() error {
 				return fmt.Errorf("sync engram for %q: %w", adapter.Agent(), err)
 			}
 			s.countChanged(boolToInt(res.Changed))
+
+			piRes, err := piresources.Inject(s.homeDir, adapter, model.ComponentEngram)
+			if err != nil {
+				return fmt.Errorf("sync pi engram resources for %q: %w", adapter.Agent(), err)
+			}
+			s.countChanged(boolToInt(piRes.Changed))
 		}
 		return nil
 
@@ -477,6 +484,12 @@ func (s componentSyncStep) Run() error {
 				return fmt.Errorf("sync context7 for %q: %w", adapter.Agent(), err)
 			}
 			s.countChanged(boolToInt(res.Changed))
+
+			piRes, err := piresources.Inject(s.homeDir, adapter, model.ComponentContext7)
+			if err != nil {
+				return fmt.Errorf("sync pi context7 resources for %q: %w", adapter.Agent(), err)
+			}
+			s.countChanged(boolToInt(piRes.Changed))
 		}
 		return nil
 
@@ -530,6 +543,12 @@ func (s componentSyncStep) Run() error {
 				return fmt.Errorf("sync sdd for %q: %w", adapter.Agent(), err)
 			}
 			s.countChanged(boolToInt(res.Changed))
+
+			piRes, err := piresources.Inject(s.homeDir, adapter, model.ComponentSDD)
+			if err != nil {
+				return fmt.Errorf("sync pi sdd resources for %q: %w", adapter.Agent(), err)
+			}
+			s.countChanged(boolToInt(piRes.Changed))
 		}
 		return nil
 
@@ -585,6 +604,12 @@ func (s componentSyncStep) Run() error {
 				return fmt.Errorf("sync theme for %q: %w", adapter.Agent(), err)
 			}
 			s.countChanged(boolToInt(res.Changed))
+
+			piRes, err := piresources.Inject(s.homeDir, adapter, model.ComponentTheme)
+			if err != nil {
+				return fmt.Errorf("sync pi theme resources for %q: %w", adapter.Agent(), err)
+			}
+			s.countChanged(boolToInt(piRes.Changed))
 		}
 		return nil
 

--- a/internal/cli/validate.go
+++ b/internal/cli/validate.go
@@ -193,6 +193,8 @@ func defaultAgentsFromDetection(detection system.DetectionResult) []model.AgentI
 			agents = append(agents, model.AgentQwenCode)
 		case string(model.AgentKiroIDE):
 			agents = append(agents, model.AgentKiroIDE)
+		case string(model.AgentPi):
+			agents = append(agents, model.AgentPi)
 		}
 	}
 

--- a/internal/components/persona/inject.go
+++ b/internal/components/persona/inject.go
@@ -375,6 +375,8 @@ func personaContent(agent model.AgentID, persona model.PersonaID) string {
 			// Kiro uses a steering-file based persona. The asset is identical to
 			// generic today but kept separate so it can diverge independently.
 			return assets.MustRead("kiro/persona-gentleman.md")
+		case model.AgentPi:
+			return assets.MustRead("pi/persona-gentleman.md")
 		default:
 			// Generic persona includes Gentleman personality + skills table + SDD orchestrator.
 			// Used by Gemini CLI, Cursor, VS Code Copilot, and any future agents.

--- a/internal/components/persona/inject_test.go
+++ b/internal/components/persona/inject_test.go
@@ -1167,3 +1167,33 @@ func TestInjectVSCodeIdempotentAfterHeal(t *testing.T) {
 		t.Fatalf("second inject should be idempotent (changed = false), but changed = true")
 	}
 }
+
+func TestInjectPiUsesPiSpecificPersonaAsset(t *testing.T) {
+	home := t.TempDir()
+
+	piAdapter, err := agents.NewAdapter("pi")
+	if err != nil {
+		t.Fatalf("NewAdapter(pi) error = %v", err)
+	}
+
+	result, err := Inject(home, piAdapter, model.PersonaGentleman)
+	if err != nil {
+		t.Fatalf("Inject(pi) error = %v", err)
+	}
+	if !result.Changed {
+		t.Fatal("Inject(pi) changed = false, want true")
+	}
+
+	path := filepath.Join(home, ".pi", "agent", "AGENTS.md")
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", path, err)
+	}
+	text := string(content)
+	if !strings.Contains(text, "# Gentleman Persona for pi") {
+		t.Fatalf("pi AGENTS.md missing pi-specific persona heading; content:\n%s", text)
+	}
+	if !strings.Contains(text, "pi-native workflow") {
+		t.Fatalf("pi AGENTS.md missing pi-native workflow section; content:\n%s", text)
+	}
+}

--- a/internal/components/piresources/inject.go
+++ b/internal/components/piresources/inject.go
@@ -1,0 +1,229 @@
+package piresources
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/gentleman-programming/gentle-ai/internal/agents"
+	"github.com/gentleman-programming/gentle-ai/internal/assets"
+	"github.com/gentleman-programming/gentle-ai/internal/components/filemerge"
+	"github.com/gentleman-programming/gentle-ai/internal/model"
+)
+
+const managedPackageKey = "pi-gentle-ai"
+
+var managedPackageOverlayJSON = []byte(`{
+  "gentleAI": {
+    "managedPackages": {
+      "pi-gentle-ai": {
+        "managedBy": "gentle-ai",
+        "source": "internal-assets"
+      }
+    }
+  }
+}
+`)
+
+type InjectionResult struct {
+	Changed bool
+	Files   []string
+}
+
+func extendedPiAdapter(adapter agents.Adapter) (agents.ExtendedResourceAdapter, bool) {
+	if adapter == nil || adapter.Agent() != model.AgentPi {
+		return nil, false
+	}
+	ext, ok := adapter.(agents.ExtendedResourceAdapter)
+	if !ok {
+		return nil, false
+	}
+	return ext, true
+}
+
+// PathsForComponent returns the expected pi-native managed resource paths for
+// a component. Non-pi adapters return nil.
+func PathsForComponent(homeDir string, adapter agents.Adapter, component model.ComponentID) []string {
+	ext, ok := extendedPiAdapter(adapter)
+	if !ok {
+		return nil
+	}
+
+	switch component {
+	case model.ComponentEngram:
+		if !ext.SupportsExtensions() {
+			return nil
+		}
+		return []string{filepath.Join(ext.ExtensionsDir(homeDir), "engram-tools.ts")}
+	case model.ComponentContext7:
+		if !ext.SupportsExtensions() {
+			return nil
+		}
+		return []string{filepath.Join(ext.ExtensionsDir(homeDir), "context7-tools.ts")}
+	case model.ComponentSDD:
+		if !ext.SupportsPromptTemplates() {
+			return nil
+		}
+		paths := promptPaths(ext.PromptsDir(homeDir))
+		if settings := adapter.SettingsPath(homeDir); settings != "" {
+			paths = append(paths, settings)
+		}
+		return paths
+	case model.ComponentTheme:
+		if !ext.SupportsThemes() {
+			return nil
+		}
+		return []string{filepath.Join(ext.ThemesDir(homeDir), "gentleman-kanagawa.json")}
+	default:
+		return nil
+	}
+}
+
+func promptPaths(promptDir string) []string {
+	entries, err := assets.FS.ReadDir("pi/prompts")
+	if err != nil {
+		return nil
+	}
+	paths := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		paths = append(paths, filepath.Join(promptDir, entry.Name()))
+	}
+	sort.Strings(paths)
+	return paths
+}
+
+// Inject writes pi-native resources for the given component.
+// Non-pi adapters are a no-op.
+func Inject(homeDir string, adapter agents.Adapter, component model.ComponentID) (InjectionResult, error) {
+	ext, ok := extendedPiAdapter(adapter)
+	if !ok {
+		return InjectionResult{}, nil
+	}
+
+	result := InjectionResult{Files: []string{}}
+
+	switch component {
+	case model.ComponentEngram:
+		if !ext.SupportsExtensions() {
+			return result, nil
+		}
+		changed, path, err := writeAssetFile("pi/extensions/engram-tools.ts", filepath.Join(ext.ExtensionsDir(homeDir), "engram-tools.ts"))
+		if err != nil {
+			return InjectionResult{}, err
+		}
+		result.Changed = result.Changed || changed
+		result.Files = append(result.Files, path)
+		return result, nil
+
+	case model.ComponentContext7:
+		if !ext.SupportsExtensions() {
+			return result, nil
+		}
+		changed, path, err := writeAssetFile("pi/extensions/context7-tools.ts", filepath.Join(ext.ExtensionsDir(homeDir), "context7-tools.ts"))
+		if err != nil {
+			return InjectionResult{}, err
+		}
+		result.Changed = result.Changed || changed
+		result.Files = append(result.Files, path)
+		return result, nil
+
+	case model.ComponentSDD:
+		if ext.SupportsPromptTemplates() {
+			changed, files, err := writeAssetDir("pi/prompts", ext.PromptsDir(homeDir))
+			if err != nil {
+				return InjectionResult{}, err
+			}
+			result.Changed = result.Changed || changed
+			result.Files = append(result.Files, files...)
+		}
+		if settingsPath := adapter.SettingsPath(homeDir); settingsPath != "" {
+			writeResult, err := mergeJSONFile(settingsPath, managedPackageOverlayJSON)
+			if err != nil {
+				return InjectionResult{}, err
+			}
+			result.Changed = result.Changed || writeResult.Changed
+			result.Files = append(result.Files, settingsPath)
+		}
+		return result, nil
+
+	case model.ComponentTheme:
+		if !ext.SupportsThemes() {
+			return result, nil
+		}
+		changed, path, err := writeAssetFile("pi/themes/gentleman-kanagawa.json", filepath.Join(ext.ThemesDir(homeDir), "gentleman-kanagawa.json"))
+		if err != nil {
+			return InjectionResult{}, err
+		}
+		result.Changed = result.Changed || changed
+		result.Files = append(result.Files, path)
+		return result, nil
+	}
+
+	return result, nil
+}
+
+func writeAssetDir(assetDir, outDir string) (bool, []string, error) {
+	entries, err := assets.FS.ReadDir(assetDir)
+	if err != nil {
+		return false, nil, fmt.Errorf("read embedded dir %q: %w", assetDir, err)
+	}
+	changed := false
+	files := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		assetPath := filepath.Join(assetDir, entry.Name())
+		outPath := filepath.Join(outDir, entry.Name())
+		fileChanged, _, err := writeAssetFile(assetPath, outPath)
+		if err != nil {
+			return false, nil, err
+		}
+		changed = changed || fileChanged
+		files = append(files, outPath)
+	}
+	sort.Strings(files)
+	return changed, files, nil
+}
+
+func writeAssetFile(assetPath, outPath string) (bool, string, error) {
+	content, err := assets.Read(assetPath)
+	if err != nil {
+		return false, "", fmt.Errorf("read embedded asset %q: %w", assetPath, err)
+	}
+	result, err := filemerge.WriteFileAtomic(outPath, []byte(content), 0o644)
+	if err != nil {
+		return false, "", err
+	}
+	return result.Changed, outPath, nil
+}
+
+func mergeJSONFile(path string, overlay []byte) (filemerge.WriteResult, error) {
+	baseJSON, err := osReadFile(path)
+	if err != nil {
+		return filemerge.WriteResult{}, err
+	}
+
+	merged, err := filemerge.MergeJSONObjects(baseJSON, overlay)
+	if err != nil {
+		return filemerge.WriteResult{}, err
+	}
+
+	return filemerge.WriteFileAtomic(path, merged, 0o644)
+}
+
+var osReadFile = func(path string) ([]byte, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read json file %q: %w", path, err)
+	}
+
+	return content, nil
+}

--- a/internal/components/piresources/inject_test.go
+++ b/internal/components/piresources/inject_test.go
@@ -1,0 +1,109 @@
+package piresources
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/internal/agents"
+	"github.com/gentleman-programming/gentle-ai/internal/model"
+)
+
+func TestPathsForComponentPi(t *testing.T) {
+	home := t.TempDir()
+	adapter, err := agents.NewAdapter(model.AgentPi)
+	if err != nil {
+		t.Fatalf("NewAdapter(pi) error = %v", err)
+	}
+
+	sddPaths := PathsForComponent(home, adapter, model.ComponentSDD)
+	if len(sddPaths) == 0 {
+		t.Fatal("PathsForComponent(sdd, pi) returned empty paths")
+	}
+
+	wantPrompt := filepath.Join(home, ".pi", "agent", "prompts", "sdd-new.md")
+	if !containsPath(sddPaths, wantPrompt) {
+		t.Fatalf("PathsForComponent(sdd, pi) missing %q; got %v", wantPrompt, sddPaths)
+	}
+
+	wantSettings := filepath.Join(home, ".pi", "agent", "settings.json")
+	if !containsPath(sddPaths, wantSettings) {
+		t.Fatalf("PathsForComponent(sdd, pi) missing settings path %q; got %v", wantSettings, sddPaths)
+	}
+
+	ctxPaths := PathsForComponent(home, adapter, model.ComponentContext7)
+	wantCtx := filepath.Join(home, ".pi", "agent", "extensions", "context7-tools.ts")
+	if !containsPath(ctxPaths, wantCtx) {
+		t.Fatalf("PathsForComponent(context7, pi) missing %q; got %v", wantCtx, ctxPaths)
+	}
+
+	themePaths := PathsForComponent(home, adapter, model.ComponentTheme)
+	wantTheme := filepath.Join(home, ".pi", "agent", "themes", "gentleman-kanagawa.json")
+	if !containsPath(themePaths, wantTheme) {
+		t.Fatalf("PathsForComponent(theme, pi) missing %q; got %v", wantTheme, themePaths)
+	}
+}
+
+func TestInjectSDDWritesPromptsAndManagedPackageState(t *testing.T) {
+	home := t.TempDir()
+	adapter, err := agents.NewAdapter(model.AgentPi)
+	if err != nil {
+		t.Fatalf("NewAdapter(pi) error = %v", err)
+	}
+
+	result, err := Inject(home, adapter, model.ComponentSDD)
+	if err != nil {
+		t.Fatalf("Inject(sdd,pi) error = %v", err)
+	}
+	if !result.Changed {
+		t.Fatalf("Inject(sdd,pi) changed = false")
+	}
+
+	promptPath := filepath.Join(home, ".pi", "agent", "prompts", "sdd-new.md")
+	if _, err := os.Stat(promptPath); err != nil {
+		t.Fatalf("expected prompt file %q: %v", promptPath, err)
+	}
+
+	settingsPath := filepath.Join(home, ".pi", "agent", "settings.json")
+	raw, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("expected settings file %q: %v", settingsPath, err)
+	}
+	if !strings.Contains(string(raw), "\"managedPackages\"") || !strings.Contains(string(raw), "\"pi-gentle-ai\"") {
+		t.Fatalf("settings missing managed package metadata, got: %s", string(raw))
+	}
+
+	second, err := Inject(home, adapter, model.ComponentSDD)
+	if err != nil {
+		t.Fatalf("Inject(sdd,pi) second error = %v", err)
+	}
+	if second.Changed {
+		t.Fatalf("Inject(sdd,pi) second changed = true, want false")
+	}
+}
+
+func TestInjectNonPiIsNoop(t *testing.T) {
+	home := t.TempDir()
+	adapter, err := agents.NewAdapter(model.AgentClaudeCode)
+	if err != nil {
+		t.Fatalf("NewAdapter(claude) error = %v", err)
+	}
+
+	result, err := Inject(home, adapter, model.ComponentSDD)
+	if err != nil {
+		t.Fatalf("Inject(sdd,claude) error = %v", err)
+	}
+	if result.Changed || len(result.Files) != 0 {
+		t.Fatalf("Inject(sdd,claude) = %+v, want no-op", result)
+	}
+}
+
+func containsPath(paths []string, want string) bool {
+	for _, p := range paths {
+		if p == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/components/sdd/inject.go
+++ b/internal/components/sdd/inject.go
@@ -1012,6 +1012,8 @@ func sddOrchestratorAsset(agent model.AgentID) string {
 		return "qwen/sdd-orchestrator.md"
 	case model.AgentKiroIDE:
 		return "kiro/sdd-orchestrator.md"
+	case model.AgentPi:
+		return "pi/sdd-orchestrator.md"
 	default:
 		return "generic/sdd-orchestrator.md"
 	}

--- a/internal/components/sdd/inject_test.go
+++ b/internal/components/sdd/inject_test.go
@@ -2619,6 +2619,7 @@ func TestSDDOrchestratorAssetSelection(t *testing.T) {
 		{agent: model.AgentWindsurf, want: "windsurf/sdd-orchestrator.md"},
 		{agent: model.AgentCursor, want: "cursor/sdd-orchestrator.md"},
 		{agent: model.AgentQwenCode, want: "qwen/sdd-orchestrator.md"},
+		{agent: model.AgentPi, want: "pi/sdd-orchestrator.md"},
 		{agent: model.AgentClaudeCode, want: "generic/sdd-orchestrator.md"},
 		{agent: model.AgentOpenCode, want: "generic/sdd-orchestrator.md"},
 		{agent: model.AgentVSCodeCopilot, want: "generic/sdd-orchestrator.md"},

--- a/internal/components/uninstall/service.go
+++ b/internal/components/uninstall/service.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gentleman-programming/gentle-ai/internal/backup"
 	"github.com/gentleman-programming/gentle-ai/internal/components/filemerge"
 	"github.com/gentleman-programming/gentle-ai/internal/components/gga"
+	"github.com/gentleman-programming/gentle-ai/internal/components/piresources"
 	"github.com/gentleman-programming/gentle-ai/internal/components/sdd"
 	"github.com/gentleman-programming/gentle-ai/internal/model"
 	"github.com/gentleman-programming/gentle-ai/internal/state"
@@ -452,6 +453,9 @@ func (s *Service) componentOperations(adapter agents.Adapter, componentID model.
 	case model.ComponentContext7:
 		targets = append(targets, context7Targets(adapter, homeDir)...)
 		ops = append(ops, context7Operations(adapter, homeDir)...)
+		piOps, piTargets := piResourceComponentOperations(adapter, homeDir, model.ComponentContext7)
+		targets = append(targets, piTargets...)
+		ops = append(ops, piOps...)
 	case model.ComponentEngram:
 		if s.engramUninstallScope == model.EngramUninstallScopeProject {
 			projectDataPath := filepath.Join(s.workspaceDir, ".engram")
@@ -459,6 +463,9 @@ func (s *Service) componentOperations(adapter agents.Adapter, componentID model.
 				targets = append(targets, projectDataPath)
 				ops = append(ops, removeTree(projectDataPath))
 			}
+			piOps, piTargets := piResourceComponentOperations(adapter, homeDir, model.ComponentEngram)
+			targets = append(targets, piTargets...)
+			ops = append(ops, piOps...)
 			break
 		}
 
@@ -471,6 +478,9 @@ func (s *Service) componentOperations(adapter agents.Adapter, componentID model.
 				return removeMarkdownSections(content, "engram-protocol")
 			}))
 		}
+		piOps, piTargets := piResourceComponentOperations(adapter, homeDir, model.ComponentEngram)
+		targets = append(targets, piTargets...)
+		ops = append(ops, piOps...)
 	case model.ComponentPermission:
 		if path := adapter.SettingsPath(homeDir); path != "" {
 			targets = append(targets, path)
@@ -490,6 +500,9 @@ func (s *Service) componentOperations(adapter agents.Adapter, componentID model.
 			targets = append(targets, path)
 			ops = append(ops, rewriteJSONFile(path, jsonPath{"theme"}))
 		}
+		piOps, piTargets := piResourceComponentOperations(adapter, homeDir, model.ComponentTheme)
+		targets = append(targets, piTargets...)
+		ops = append(ops, piOps...)
 	case model.ComponentSkills:
 		if !adapter.SupportsSkills() {
 			break
@@ -612,6 +625,9 @@ func (s *Service) componentOperations(adapter agents.Adapter, componentID model.
 			}
 			ops = append(ops, removeDirIfEmpty(agentsDir))
 		}
+		piOps, piTargets := piResourceComponentOperations(adapter, homeDir, model.ComponentSDD)
+		targets = append(targets, piTargets...)
+		ops = append(ops, piOps...)
 	case model.ComponentGGA:
 		for _, path := range globalBackupTargets(homeDir) {
 			targets = append(targets, path)
@@ -623,6 +639,28 @@ func (s *Service) componentOperations(adapter agents.Adapter, componentID model.
 	}
 
 	return ops, targets, nil
+}
+
+func piResourceComponentOperations(adapter agents.Adapter, homeDir string, component model.ComponentID) ([]operation, []string) {
+	paths := piresources.PathsForComponent(homeDir, adapter, component)
+	if len(paths) == 0 {
+		return nil, nil
+	}
+
+	targets := make([]string, 0, len(paths))
+	ops := make([]operation, 0, len(paths)*2)
+	settingsPath := adapter.SettingsPath(homeDir)
+
+	for _, path := range paths {
+		targets = append(targets, path)
+		if path == settingsPath && component == model.ComponentSDD {
+			ops = append(ops, rewriteJSONFile(path, jsonPath{"gentleAI", "managedPackages", "pi-gentle-ai"}))
+			continue
+		}
+		ops = append(ops, removeFile(path), removeDirIfEmpty(filepath.Dir(path)))
+	}
+
+	return ops, targets
 }
 
 func context7Targets(adapter agents.Adapter, homeDir string) []string {

--- a/internal/components/uninstall/service_test.go
+++ b/internal/components/uninstall/service_test.go
@@ -352,3 +352,97 @@ func TestComponentOperationsEngram_GlobalScopeKeepsWorkspaceProjectData(t *testi
 		t.Fatalf("global engram config should be removed in global scope, got: %s", string(raw))
 	}
 }
+
+func TestComponentOperationsSDD_PiRemovesPromptsAndManagedPackageState(t *testing.T) {
+	homeDir := t.TempDir()
+	workspaceDir := t.TempDir()
+
+	svc, err := NewService(homeDir, workspaceDir, "dev")
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+
+	adapter, ok := svc.registry.Get(model.AgentPi)
+	if !ok {
+		t.Fatal("pi adapter not found in registry")
+	}
+
+	promptDir := filepath.Join(homeDir, ".pi", "agent", "prompts")
+	if err := os.MkdirAll(promptDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(promptDir) error = %v", err)
+	}
+	promptPath := filepath.Join(promptDir, "sdd-new.md")
+	if err := os.WriteFile(promptPath, []byte("prompt"), 0o644); err != nil {
+		t.Fatalf("WriteFile(prompt) error = %v", err)
+	}
+
+	settingsPath := filepath.Join(homeDir, ".pi", "agent", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(settings dir) error = %v", err)
+	}
+	if err := os.WriteFile(settingsPath, []byte(`{"gentleAI":{"managedPackages":{"pi-gentle-ai":{"managedBy":"gentle-ai"}}},"user":"keep"}`), 0o644); err != nil {
+		t.Fatalf("WriteFile(settings) error = %v", err)
+	}
+
+	ops, _, err := svc.componentOperations(adapter, model.ComponentSDD)
+	if err != nil {
+		t.Fatalf("componentOperations() error = %v", err)
+	}
+	for _, op := range ops {
+		if _, _, err := op.apply(op.path); err != nil {
+			t.Fatalf("op.apply(%q) error = %v", op.path, err)
+		}
+	}
+
+	if _, err := os.Stat(promptPath); !os.IsNotExist(err) {
+		t.Fatalf("pi sdd prompt should be removed; err=%v", err)
+	}
+
+	raw, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("ReadFile(settings) error = %v", err)
+	}
+	if strings.Contains(string(raw), `"pi-gentle-ai"`) {
+		t.Fatalf("managed package state should be removed, got: %s", string(raw))
+	}
+	if !strings.Contains(string(raw), `"user"`) {
+		t.Fatalf("unrelated user settings should be preserved, got: %s", string(raw))
+	}
+}
+
+func TestComponentOperationsContext7_PiRemovesManagedExtensionFile(t *testing.T) {
+	homeDir := t.TempDir()
+	workspaceDir := t.TempDir()
+
+	svc, err := NewService(homeDir, workspaceDir, "dev")
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+
+	adapter, ok := svc.registry.Get(model.AgentPi)
+	if !ok {
+		t.Fatal("pi adapter not found in registry")
+	}
+
+	extPath := filepath.Join(homeDir, ".pi", "agent", "extensions", "context7-tools.ts")
+	if err := os.MkdirAll(filepath.Dir(extPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(extension dir) error = %v", err)
+	}
+	if err := os.WriteFile(extPath, []byte("export default {}"), 0o644); err != nil {
+		t.Fatalf("WriteFile(extension) error = %v", err)
+	}
+
+	ops, _, err := svc.componentOperations(adapter, model.ComponentContext7)
+	if err != nil {
+		t.Fatalf("componentOperations() error = %v", err)
+	}
+	for _, op := range ops {
+		if _, _, err := op.apply(op.path); err != nil {
+			t.Fatalf("op.apply(%q) error = %v", op.path, err)
+		}
+	}
+
+	if _, err := os.Stat(extPath); !os.IsNotExist(err) {
+		t.Fatalf("pi context7 extension should be removed; err=%v", err)
+	}
+}

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -15,6 +15,7 @@ const (
 	AgentKimi          AgentID = "kimi"
 	AgentQwenCode      AgentID = "qwen-code"
 	AgentKiroIDE       AgentID = "kiro-ide"
+	AgentPi            AgentID = "pi"
 )
 
 // SupportTier indicates how fully an agent supports the Gentleman AI ecosystem.

--- a/internal/system/config_scan.go
+++ b/internal/system/config_scan.go
@@ -41,6 +41,7 @@ func knownAgentConfigDirs(homeDir string) []ConfigState {
 		{Agent: "kimi", Path: filepath.Join(homeDir, ".kimi")},
 		{Agent: "qwen-code", Path: filepath.Join(homeDir, ".qwen")},
 		{Agent: "kiro-ide", Path: filepath.Join(homeDir, ".kiro")},
+		{Agent: "pi", Path: filepath.Join(homeDir, ".pi", "agent")},
 	}
 }
 

--- a/internal/system/config_scan_test.go
+++ b/internal/system/config_scan_test.go
@@ -25,11 +25,10 @@ func TestScanConfigs_ReturnsAllKnownAgentsWithExistsFlag(t *testing.T) {
 	configs := ScanConfigs(home)
 
 	// Must return at least as many entries as the registry has adapters with
-	// a non-empty GlobalConfigDir. Currently 12 agents are supported.
-	if len(configs) < 12 {
-		t.Fatalf("ScanConfigs() returned %d entries, want >= 12; got %v", len(configs), configs)
+	// a non-empty GlobalConfigDir. Currently 13 agents are supported.
+	if len(configs) < 13 {
+		t.Fatalf("ScanConfigs() returned %d entries, want >= 13; got %v", len(configs), configs)
 	}
-
 
 	// Find claude — must be Exists=true.
 	var claudeState *ConfigState
@@ -82,8 +81,8 @@ func TestScanConfigs_AgentFieldMatchesModelAgentID(t *testing.T) {
 		"kimi":           false,
 		"qwen-code":      false,
 		"kiro-ide":       false,
+		"pi":             false,
 	}
-
 
 	for _, c := range configs {
 		if _, known := knownAgents[c.Agent]; known {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -2799,6 +2799,8 @@ func preselectedAgents(detection system.DetectionResult) []model.AgentID {
 			selected = append(selected, model.AgentClaudeCode)
 		case string(model.AgentOpenCode):
 			selected = append(selected, model.AgentOpenCode)
+		case string(model.AgentKilocode):
+			selected = append(selected, model.AgentKilocode)
 		case string(model.AgentGeminiCLI):
 			selected = append(selected, model.AgentGeminiCLI)
 		case string(model.AgentCursor):
@@ -2811,8 +2813,14 @@ func preselectedAgents(detection system.DetectionResult) []model.AgentID {
 			selected = append(selected, model.AgentAntigravity)
 		case string(model.AgentWindsurf):
 			selected = append(selected, model.AgentWindsurf)
+		case string(model.AgentKimi):
+			selected = append(selected, model.AgentKimi)
 		case string(model.AgentQwenCode):
 			selected = append(selected, model.AgentQwenCode)
+		case string(model.AgentKiroIDE):
+			selected = append(selected, model.AgentKiroIDE)
+		case string(model.AgentPi):
+			selected = append(selected, model.AgentPi)
 		}
 	}
 

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1513,7 +1513,7 @@ func TestModelConfig_OpenCodePickerBackReturnsToModelConfig(t *testing.T) {
 // makeDetectionWithAgents builds a DetectionResult with the specified agents
 // marked as Exists=true. All other agents are absent.
 func makeDetectionWithAgents(present ...string) system.DetectionResult {
-	known := []string{"claude-code", "opencode", "gemini-cli", "cursor", "vscode-copilot", "codex", "antigravity", "windsurf", "qwen-code"}
+	known := []string{"claude-code", "opencode", "kilocode", "gemini-cli", "cursor", "vscode-copilot", "codex", "antigravity", "windsurf", "kimi", "qwen-code", "kiro-ide", "pi"}
 	presentSet := make(map[string]bool, len(present))
 	for _, p := range present {
 		presentSet[p] = true
@@ -2207,21 +2207,28 @@ func TestModelConfig_EscFromPickersReturnsToModelConfig(t *testing.T) {
 	}
 }
 
-// TestPreselectedAgents_AllSixAgentsMappedCorrectly verifies every canonical
+// TestPreselectedAgents_AllAgentsMappedCorrectly verifies every canonical
 // agent string maps to its model.AgentID constant in preselectedAgents.
 // This prevents silent drops when new agents are added to ScanConfigs without
 // updating the TUI switch statement.
-func TestPreselectedAgents_AllSixAgentsMappedCorrectly(t *testing.T) {
+func TestPreselectedAgents_AllAgentsMappedCorrectly(t *testing.T) {
 	tests := []struct {
 		configAgent string
 		wantID      model.AgentID
 	}{
 		{"claude-code", model.AgentClaudeCode},
 		{"opencode", model.AgentOpenCode},
+		{"kilocode", model.AgentKilocode},
 		{"gemini-cli", model.AgentGeminiCLI},
 		{"cursor", model.AgentCursor},
 		{"vscode-copilot", model.AgentVSCodeCopilot},
 		{"codex", model.AgentCodex},
+		{"antigravity", model.AgentAntigravity},
+		{"windsurf", model.AgentWindsurf},
+		{"kimi", model.AgentKimi},
+		{"qwen-code", model.AgentQwenCode},
+		{"kiro-ide", model.AgentKiroIDE},
+		{"pi", model.AgentPi},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Closes #331

## Summary
This PR adds first-class `pi` support to gentle-ai and integrates pi-native resources into install/sync/uninstall flows.

### Included
- new `pi` adapter + model/catalog/discovery wiring
- optional adapter extension contract for resource-native runtimes
- pi-specific persona + SDD orchestrator assets
- pi-native managed resources:
  - `~/.pi/agent/extensions/{engram-tools.ts,context7-tools.ts}`
  - `~/.pi/agent/prompts/sdd-*.md`
  - `~/.pi/agent/themes/gentleman-kanagawa.json`
  - managed package metadata in `~/.pi/agent/settings.json`
- backup/verification/uninstall coverage for pi resources
- tests and docs updates

## Validation
- `go test ./...`
- local smoke with sandbox HOME:
  - `gentle-ai sync --agent pi`
  - `gentle-ai sync --agent pi --include-theme`
  - `gentle-ai uninstall --agent pi --yes`

## Notes
- `pi` remains manual-install (no auto-install command in this PR).
