### PR TITLE
fix(upgrade): exclude antigravity tmp from backups

### DIFF
--- a/internal/update/upgrade/executor.go
+++ b/internal/update/upgrade/executor.go
@@ -89,6 +89,7 @@ var backupExcludeSubdirs = map[string]bool{
 	"conversations":               true, // Gemini conversation history
 	"context_state":               true, // Gemini context state
 	"html_artifacts":              true, // generated HTML artifacts
+	"tmp":                         true, // Antigravity temporary runtime artifacts
 }
 
 // configPathsForBackup returns the agent config file paths that the backup

--- a/internal/update/upgrade/executor_test.go
+++ b/internal/update/upgrade/executor_test.go
@@ -1020,6 +1020,16 @@ func TestConfigPathsForBackup_ExcludesRuntimeDirs(t *testing.T) {
 		}
 	}
 
+	// Gemini Antigravity temp dir is nested under antigravity/ and must also be excluded.
+	geminiAntigravityTmpFile := filepath.Join(homeDir, ".gemini", "antigravity", "tmp", "artifact.json")
+	if err := os.MkdirAll(filepath.Dir(geminiAntigravityTmpFile), 0o755); err != nil {
+		t.Fatalf("MkdirAll gemini antigravity tmp: %v", err)
+	}
+	if err := os.WriteFile(geminiAntigravityTmpFile, []byte("temp runtime data"), 0o644); err != nil {
+		t.Fatalf("WriteFile gemini antigravity tmp: %v", err)
+	}
+	excludedFiles = append(excludedFiles, geminiAntigravityTmpFile)
+
 	paths := configPathsForBackup(homeDir)
 	pathSet := make(map[string]struct{}, len(paths))
 	for _, p := range paths {


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #345

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Excludes `~/.gemini/antigravity/tmp/` from recursive upgrade backup snapshots.
- Adds focused regression coverage for nested Antigravity runtime paths.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/update/upgrade/executor.go` | Added `tmp` to the backup exclusion map used during upgrade backups |
| `internal/update/upgrade/executor_test.go` | Covered the nested Gemini/Antigravity `tmp` path in the runtime-dir exclusion test |

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./internal/update/upgrade -run 'TestConfigPathsForBackup_ExcludesRuntimeDirs|TestEnumerateFilesInDir_ExcludesSubdirs'
```

**E2E Tests** (Docker required)
```bash
Not run
```

- [x] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Manually tested locally

---

## 🤖 Automated Checks

The following checks run automatically on this PR:

| Check | Status | Description |
|-------|--------|-------------|
| Check Issue Reference | ⏳ | PR body must contain `Closes/Fixes/Resolves #N` |
| Check Issue Has `status:approved` | ⏳ | Linked issue must have been approved before work began |
| Check PR Has `type:*` Label | ⏳ | Exactly one `type:*` label must be applied |
| Unit Tests | ⏳ | CI will validate the change |
| E2E Tests | ⏳ | CI will validate the change |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [ ] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [ ] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

- The issue mentions install/sync/upgrade, but the recursive config-tree walk that captures `antigravity/tmp` is in the upgrade backup path.