### PR TITLE
chore(tui): clarify custom persona semantics

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -12,7 +12,7 @@
 | SDD | `sdd` | Spec-Driven Development workflow (9 phases) — the agent handles SDD organically when the task warrants it, or when you ask; you don't need to learn the commands |
 | Skills | `skills` | Curated coding skill library |
 | Context7 | `context7` | MCP server for live framework/library documentation |
-| Persona | `persona` | Gentleman, neutral, or custom behavior mode |
+| Persona | `persona` | Managed Gentleman/neutral persona injection, or unmanaged custom persona mode |
 | Permissions | `permissions` | Security-first defaults and guardrails |
 | GGA | `gga` | Gentleman Guardian Angel — AI provider switcher |
 | Theme | `theme` | Gentleman Kanagawa theme overlay |
@@ -77,4 +77,4 @@ For framework-specific skills (React 19, Angular, TypeScript, Tailwind 4, Zod 4,
 | Full Gentleman | `full-gentleman` | All components (Engram + SDD + Skills + Context7 + GGA + Persona + Permissions + Theme) + all skills + gentleman persona |
 | Ecosystem Only | `ecosystem-only` | Core components (Engram + SDD + Skills + Context7 + GGA) + all skills + gentleman persona |
 | Minimal | `minimal` | Engram + SDD skills only |
-| Custom | `custom` | You pick components, skills, and persona individually |
+| Custom | `custom` | You choose components and skills manually while keeping any existing persona/settings unmanaged |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -10,7 +10,9 @@
 |---------|-----|-------------|
 | Gentleman | `gentleman` | Teaching-oriented mentor persona — pushes back on bad practices, explains the why |
 | Neutral | `neutral` | Same teacher, same philosophy, no regional language — warm and professional |
-| Custom | `custom` | Bring your own persona instructions |
+| Custom | `custom` | Keep your existing persona/config unmanaged — gentle-ai does not inject a persona |
+
+`custom` is a compatibility/ownership choice, not a persona editor. Use it when you already have your own persona instructions and want gentle-ai to leave them alone.
 
 ---
 
@@ -138,8 +140,8 @@ gentle-ai -v
 | `--agent`, `--agents` | Agents to configure (comma-separated) |
 | `--component`, `--components` | Components to install (comma-separated) |
 | `--skill`, `--skills` | Skills to install (comma-separated) |
-| `--persona` | Persona mode: `gentleman`, `neutral`, `custom` |
-| `--preset` | Preset: `full-gentleman`, `ecosystem-only`, `minimal`, `custom` |
+| `--persona` | Persona mode: `gentleman`, `neutral`, `custom` (`custom` keeps your existing persona unmanaged) |
+| `--preset` | Preset: `full-gentleman`, `ecosystem-only`, `minimal`, `custom` (`custom` means manual component/skill selection) |
 | `--dry-run` | Preview the install plan without applying changes |
 
 ## CLI Flags (sync)

--- a/internal/tui/screens/persona.go
+++ b/internal/tui/screens/persona.go
@@ -11,6 +11,12 @@ func PersonaOptions() []model.PersonaID {
 	return []model.PersonaID{model.PersonaGentleman, model.PersonaNeutral, model.PersonaCustom}
 }
 
+var personaDescriptions = map[model.PersonaID]string{
+	model.PersonaGentleman: "Managed Gentleman persona with teaching-first guidance",
+	model.PersonaNeutral:   "Managed neutral persona with the same guidance and less regional tone",
+	model.PersonaCustom:    "Keep your existing persona unmanaged; gentle-ai does not inject a persona",
+}
+
 func RenderPersona(selected model.PersonaID, cursor int) string {
 	var b strings.Builder
 
@@ -23,6 +29,8 @@ func RenderPersona(selected model.PersonaID, cursor int) string {
 		isSelected := persona == selected
 		focused := idx == cursor
 		b.WriteString(renderRadio(string(persona), isSelected, focused))
+		b.WriteString(styles.SubtextStyle.Render("    " + personaDescriptions[persona]))
+		b.WriteString("\n")
 	}
 
 	b.WriteString("\n")

--- a/internal/tui/screens/persona_preset_test.go
+++ b/internal/tui/screens/persona_preset_test.go
@@ -1,0 +1,33 @@
+package screens
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/internal/model"
+)
+
+func TestRenderPersonaClarifiesCustomKeepsExistingPersona(t *testing.T) {
+	out := RenderPersona(model.PersonaCustom, 2)
+
+	if !strings.Contains(out, "custom") {
+		t.Fatalf("RenderPersona missing custom option; output:\n%s", out)
+	}
+	if !strings.Contains(out, "Keep your existing persona unmanaged") {
+		t.Fatalf("RenderPersona missing custom persona clarification; output:\n%s", out)
+	}
+	if strings.Contains(out, "Bring your own persona instructions") {
+		t.Fatalf("RenderPersona still shows old custom persona wording; output:\n%s", out)
+	}
+}
+
+func TestRenderPresetClarifiesCustomManualSelection(t *testing.T) {
+	out := RenderPreset(model.PresetCustom, 3)
+
+	if !strings.Contains(out, "Choose components and skills manually") {
+		t.Fatalf("RenderPreset missing custom preset clarification; output:\n%s", out)
+	}
+	if strings.Contains(out, "Pick individual components yourself") {
+		t.Fatalf("RenderPreset still shows old custom preset wording; output:\n%s", out)
+	}
+}

--- a/internal/tui/screens/preset.go
+++ b/internal/tui/screens/preset.go
@@ -20,7 +20,7 @@ var presetDescriptions = map[model.PresetID]string{
 	model.PresetFullGentleman: "Everything: memory, SDD, skills, docs, persona & security",
 	model.PresetEcosystemOnly: "Core tools only: memory, SDD, skills & docs (no persona/security)",
 	model.PresetMinimal:       "Just Engram persistent memory",
-	model.PresetCustom:        "Pick individual components yourself",
+	model.PresetCustom:        "Choose components and skills manually; keep existing persona/settings unmanaged",
 }
 
 func RenderPreset(selected model.PresetID, cursor int) string {

--- a/internal/tui/screens/review.go
+++ b/internal/tui/screens/review.go
@@ -19,8 +19,8 @@ func RenderReview(payload planner.ReviewPayload, cursor int) string {
 	b.WriteString("\n\n")
 
 	b.WriteString("  " + styles.HeadingStyle.Render("Agents") + "  " + styles.UnselectedStyle.Render(joinIDs(payload.Agents)) + "\n")
-	b.WriteString("  " + styles.HeadingStyle.Render("Persona") + "  " + styles.UnselectedStyle.Render(string(payload.Persona)) + "\n")
-	b.WriteString("  " + styles.HeadingStyle.Render("Preset") + "  " + styles.UnselectedStyle.Render(string(payload.Preset)) + "\n")
+	b.WriteString("  " + styles.HeadingStyle.Render("Persona") + "  " + styles.UnselectedStyle.Render(reviewPersonaLabel(payload.Persona)) + "\n")
+	b.WriteString("  " + styles.HeadingStyle.Render("Preset") + "  " + styles.UnselectedStyle.Render(reviewPresetLabel(payload.Preset)) + "\n")
 	b.WriteString("\n")
 
 	if len(payload.Components) > 0 {
@@ -83,4 +83,20 @@ func joinIDs[T ~string](values []T) string {
 	}
 
 	return strings.Join(parts, ", ")
+}
+
+func reviewPersonaLabel(persona model.PersonaID) string {
+	if persona == model.PersonaCustom {
+		return "keep existing persona unmanaged"
+	}
+
+	return string(persona)
+}
+
+func reviewPresetLabel(preset model.PresetID) string {
+	if preset == model.PresetCustom {
+		return "choose components and skills manually"
+	}
+
+	return string(preset)
 }

--- a/internal/tui/screens/review_test.go
+++ b/internal/tui/screens/review_test.go
@@ -127,3 +127,26 @@ func TestRenderReviewHidesStrictTDDWhenNoSDD(t *testing.T) {
 		t.Errorf("RenderReview should NOT show 'Strict TDD' when HasSDD=false; output:\n%s", out)
 	}
 }
+
+func TestRenderReviewClarifiesCustomPersonaAndPreset(t *testing.T) {
+	payload := planner.ReviewPayload{
+		Agents:  []model.AgentID{model.AgentClaudeCode},
+		Persona: model.PersonaCustom,
+		Preset:  model.PresetCustom,
+	}
+
+	out := RenderReview(payload, 0)
+
+	if !strings.Contains(out, "keep existing persona unmanaged") {
+		t.Fatalf("RenderReview missing custom persona clarification; output:\n%s", out)
+	}
+	if !strings.Contains(out, "choose components and skills manually") {
+		t.Fatalf("RenderReview missing custom preset clarification; output:\n%s", out)
+	}
+	if strings.Contains(out, "Persona  custom") {
+		t.Fatalf("RenderReview should not show raw custom persona label; output:\n%s", out)
+	}
+	if strings.Contains(out, "Preset  custom") {
+		t.Fatalf("RenderReview should not show raw custom preset label; output:\n%s", out)
+	}
+}


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #342

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [ ] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [x] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Clarifies that `custom` means gentle-ai keeps the user's existing persona unmanaged.
- Aligns persona, preset, review, and docs copy without changing runtime injection behavior.
- Adds focused TUI regression tests for the clarified copy.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/tui/screens/persona.go` | Clarified the `custom` persona description |
| `internal/tui/screens/preset.go` | Clarified that the `custom` preset means manual component/skill selection |
| `internal/tui/screens/review.go` | Updated review labels to separate persona ownership from preset choice |
| `docs/usage.md`, `docs/components.md` | Updated docs to match the new UX wording |
| `internal/tui/screens/*test.go` | Added/updated regression coverage for persona/preset/review copy |

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./internal/tui/screens
```

**E2E Tests** (Docker required)
```bash
Not run
```

- [x] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Manually tested locally

---

## 🤖 Automated Checks

The following checks run automatically on this PR:

| Check | Status | Description |
|-------|--------|-------------|
| Check Issue Reference | ⏳ | PR body must contain `Closes/Fixes/Resolves #N` |
| Check Issue Has `status:approved` | ⏳ | Linked issue must have been approved before work began |
| Check PR Has `type:*` Label | ⏳ | Exactly one `type:*` label must be applied |
| Unit Tests | ⏳ | CI will validate the change |
| E2E Tests | ⏳ | CI will validate the change |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [ ] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

- This intentionally keeps `PersonaCustom` as a no-op. The change is about semantics and UX clarity, not about adding a custom persona editor.