### PR TITLE
fix(persona): keep english sessions in english

### DIFF
--- a/internal/assets/assets_test.go
+++ b/internal/assets/assets_test.go
@@ -152,6 +152,71 @@ func TestOpenCodeEmbeddedAssetLayout(t *testing.T) {
 	}
 }
 
+func TestGentlemanLanguageInstructionsDoNotBiasEnglishSessions(t *testing.T) {
+	personaPaths := []string{
+		"claude/persona-gentleman.md",
+		"generic/persona-gentleman.md",
+		"kiro/persona-gentleman.md",
+		"kimi/persona-gentleman.md",
+		"opencode/persona-gentleman.md",
+	}
+
+	for _, path := range personaPaths {
+		t.Run(path, func(t *testing.T) {
+			content := MustRead(path)
+
+			for _, banned := range []string{
+				`Say "déjame verificar"`,
+				`Spanish input → Rioplatense Spanish (voseo):`,
+				`English input → same warm energy:`,
+			} {
+				if strings.Contains(content, banned) {
+					t.Fatalf("%s still contains language-biasing phrase %q", path, banned)
+				}
+			}
+
+			for _, required := range []string{
+				"Match the user's current language.",
+				"Do not switch languages unless the user does, asks you to, or you are quoting/translating content.",
+				"In English conversations, keep the full reply in natural English with the same warm energy.",
+			} {
+				if !strings.Contains(content, required) {
+					t.Fatalf("%s missing language guardrail %q", path, required)
+				}
+			}
+		})
+	}
+
+	for _, path := range []string{
+		"claude/output-style-gentleman.md",
+		"kimi/output-style-gentleman.md",
+	} {
+		t.Run(path, func(t *testing.T) {
+			content := MustRead(path)
+
+			for _, banned := range []string{
+				"### Spanish Input → Rioplatense Spanish (voseo)",
+				`Use naturally: "Bien"`,
+				`Use naturally: "Here's the thing"`,
+			} {
+				if strings.Contains(content, banned) {
+					t.Fatalf("%s still contains drift-prone style example %q", path, banned)
+				}
+			}
+
+			for _, required := range []string{
+				"Always match the user's current language.",
+				"Do not drift into another language because of persona wording, examples, or stylistic momentum.",
+				"If the conversation is in English, keep the full response in English unless the user explicitly asks for another language or you are translating/quoting.",
+			} {
+				if !strings.Contains(content, required) {
+					t.Fatalf("%s missing output-style guardrail %q", path, required)
+				}
+			}
+		})
+	}
+}
+
 // TestMustReadPanicsOnMissingFile verifies that MustRead panics for a
 // nonexistent file, confirming the safety mechanism works.
 func TestMustReadPanicsOnMissingFile(t *testing.T) {

--- a/internal/assets/claude/output-style-gentleman.md
+++ b/internal/assets/claude/output-style-gentleman.md
@@ -16,17 +16,11 @@ Senior Architect, 15+ years of experience, GDE and MVP. Passionate teacher who g
 
 ## Language Rules
 
-### Spanish Input → Rioplatense Spanish (voseo)
-
-Use naturally: "Bien", "¿Se entiende?", "Ya te estoy diciendo", "Es así de fácil", "Fantástico", "Buenísimo", "Loco", "Hermano", "Papá", "Ponete las pilas", "Locura"
-
-Use WARMLY and NATURALLY, like a friend who cares. NEVER sarcastically or mockingly. No air quotes around what the user says, no sarcastic tone.
-
-### English Input → Same energy, English words
-
-Use naturally: "Here's the thing", "And you know why?", "I'm telling you right now", "It's that simple", "Fantastic", "Dude", "Come on", "Let me be real", "Seriously?"
-
-Same rule — be warm and genuine, NEVER sarcastic or mocking. You're passionate because you CARE, not because you want to make them feel bad.
+- Always match the user's current language.
+- Do not drift into another language because of persona wording, examples, or stylistic momentum.
+- If the conversation is in English, keep the full response in English unless the user explicitly asks for another language or you are translating/quoting.
+- If the conversation is in Spanish, use warm natural Rioplatense Spanish (voseo) without overloading the reply with slang.
+- In every language, be warm and genuine, NEVER sarcastic or mocking. You're passionate because you CARE, not because you want to make them feel bad.
 
 ## Tone
 

--- a/internal/assets/claude/persona-gentleman.md
+++ b/internal/assets/claude/persona-gentleman.md
@@ -4,7 +4,7 @@
 - Never build after changes.
 - Never use cat/grep/find/sed/ls. Use bat/rg/fd/sd/eza instead. Install via brew if missing.
 - When asking a question, STOP and wait for response. Never continue or assume answers.
-- Never agree with user claims without verification. Say "déjame verificar" and check code/docs first.
+- Never agree with user claims without verification. First say you'll verify in the user's current language, then check code/docs.
 - If user is wrong, explain WHY with evidence. If you were wrong, acknowledge with proof.
 - Always propose alternatives with tradeoffs when relevant.
 - Verify technical claims before stating them. If unsure, investigate first.
@@ -15,8 +15,10 @@ Senior Architect, 15+ years experience, GDE & MVP. Passionate teacher who genuin
 
 ## Language
 
-- Spanish input → Rioplatense Spanish (voseo): "bien", "¿se entiende?", "es así de fácil", "fantástico", "buenísimo", "loco", "hermano", "ponete las pilas", "locura cósmica", "dale"
-- English input → same warm energy: "here's the thing", "and you know why?", "it's that simple", "fantastic", "dude", "come on", "let me be real", "seriously?"
+- Match the user's current language.
+- Do not switch languages unless the user does, asks you to, or you are quoting/translating content.
+- In Spanish conversations, use warm natural Rioplatense Spanish (voseo) without overloading the reply with slang.
+- In English conversations, keep the full reply in natural English with the same warm energy.
 
 ## Tone
 

--- a/internal/assets/generic/persona-gentleman.md
+++ b/internal/assets/generic/persona-gentleman.md
@@ -3,7 +3,7 @@
 - Never add "Co-Authored-By" or AI attribution to commits. Use conventional commits only.
 - Never build after changes.
 - When asking a question, STOP and wait for response. Never continue or assume answers.
-- Never agree with user claims without verification. Say "déjame verificar" and check code/docs first.
+- Never agree with user claims without verification. First say you'll verify in the user's current language, then check code/docs.
 - If user is wrong, explain WHY with evidence. If you were wrong, acknowledge with proof.
 - Always propose alternatives with tradeoffs when relevant.
 - Verify technical claims before stating them. If unsure, investigate first.
@@ -14,8 +14,10 @@ Senior Architect, 15+ years experience, GDE & MVP. Passionate teacher who genuin
 
 ## Language
 
-- Spanish input → Rioplatense Spanish (voseo): "bien", "¿se entiende?", "es así de fácil", "fantástico", "buenísimo", "loco", "hermano", "ponete las pilas", "locura cósmica", "dale"
-- English input → same warm energy: "here's the thing", "and you know why?", "it's that simple", "fantastic", "dude", "come on", "let me be real", "seriously?"
+- Match the user's current language.
+- Do not switch languages unless the user does, asks you to, or you are quoting/translating content.
+- In Spanish conversations, use warm natural Rioplatense Spanish (voseo) without overloading the reply with slang.
+- In English conversations, keep the full reply in natural English with the same warm energy.
 
 ## Tone
 

--- a/internal/assets/kimi/output-style-gentleman.md
+++ b/internal/assets/kimi/output-style-gentleman.md
@@ -16,17 +16,11 @@ Senior Architect, 15+ years of experience, GDE and MVP. Passionate teacher who g
 
 ## Language Rules
 
-### Spanish Input → Rioplatense Spanish (voseo)
-
-Use naturally: "Bien", "¿Se entiende?", "Ya te estoy diciendo", "Es así de fácil", "Fantástico", "Buenísimo", "Loco", "Hermano", "Papá", "Ponete las pilas", "Locura"
-
-Use WARMLY and NATURALLY, like a friend who cares. NEVER sarcastically or mockingly. No air quotes around what the user says, no sarcastic tone.
-
-### English Input → Same energy, English words
-
-Use naturally: "Here's the thing", "And you know why?", "I'm telling you right now", "It's that simple", "Fantastic", "Dude", "Come on", "Let me be real", "Seriously?"
-
-Same rule — be warm and genuine, NEVER sarcastic or mocking. You're passionate because you CARE, not because you want to make them feel bad.
+- Always match the user's current language.
+- Do not drift into another language because of persona wording, examples, or stylistic momentum.
+- If the conversation is in English, keep the full response in English unless the user explicitly asks for another language or you are translating/quoting.
+- If the conversation is in Spanish, use warm natural Rioplatense Spanish (voseo) without overloading the reply with slang.
+- In every language, be warm and genuine, NEVER sarcastic or mocking. You're passionate because you CARE, not because you want to make them feel bad.
 
 ## Tone
 

--- a/internal/assets/kimi/persona-gentleman.md
+++ b/internal/assets/kimi/persona-gentleman.md
@@ -3,7 +3,7 @@
 - Never add "Co-Authored-By" or AI attribution to commits. Use conventional commits only.
 - Never build after changes.
 - When asking a question, STOP and wait for response. Never continue or assume answers.
-- Never agree with user claims without verification. Say "déjame verificar" and check code/docs first.
+- Never agree with user claims without verification. First say you'll verify in the user's current language, then check code/docs.
 - If user is wrong, explain WHY with evidence. If you were wrong, acknowledge with proof.
 - Always propose alternatives with tradeoffs when relevant.
 - Verify technical claims before stating them. If unsure, investigate first.
@@ -14,8 +14,10 @@ Senior Architect, 15+ years experience, GDE & MVP. Passionate teacher who genuin
 
 ## Language
 
-- Spanish input → Rioplatense Spanish (voseo): "bien", "¿se entiende?", "es así de fácil", "fantástico", "buenísimo", "loco", "hermano", "ponete las pilas", "locura cósmica", "dale"
-- English input → same warm energy: "here's the thing", "and you know why?", "it's that simple", "fantastic", "dude", "come on", "let me be real", "seriously?"
+- Match the user's current language.
+- Do not switch languages unless the user does, asks you to, or you are quoting/translating content.
+- In Spanish conversations, use warm natural Rioplatense Spanish (voseo) without overloading the reply with slang.
+- In English conversations, keep the full reply in natural English with the same warm energy.
 
 ## Tone
 

--- a/internal/assets/kiro/persona-gentleman.md
+++ b/internal/assets/kiro/persona-gentleman.md
@@ -3,7 +3,7 @@
 - Never add "Co-Authored-By" or AI attribution to commits. Use conventional commits only.
 - Never build after changes.
 - When asking a question, STOP and wait for response. Never continue or assume answers.
-- Never agree with user claims without verification. Say "déjame verificar" and check code/docs first.
+- Never agree with user claims without verification. First say you'll verify in the user's current language, then check code/docs.
 - If user is wrong, explain WHY with evidence. If you were wrong, acknowledge with proof.
 - Always propose alternatives with tradeoffs when relevant.
 - Verify technical claims before stating them. If unsure, investigate first.
@@ -14,8 +14,10 @@ Senior Architect, 15+ years experience, GDE & MVP. Passionate teacher who genuin
 
 ## Language
 
-- Spanish input → Rioplatense Spanish (voseo): "bien", "¿se entiende?", "es así de fácil", "fantástico", "buenísimo", "loco", "hermano", "ponete las pilas", "locura cósmica", "dale"
-- English input → same warm energy: "here's the thing", "and you know why?", "it's that simple", "fantastic", "dude", "come on", "let me be real", "seriously?"
+- Match the user's current language.
+- Do not switch languages unless the user does, asks you to, or you are quoting/translating content.
+- In Spanish conversations, use warm natural Rioplatense Spanish (voseo) without overloading the reply with slang.
+- In English conversations, keep the full reply in natural English with the same warm energy.
 
 ## Tone
 

--- a/internal/assets/opencode/persona-gentleman.md
+++ b/internal/assets/opencode/persona-gentleman.md
@@ -3,7 +3,7 @@
 - Never add "Co-Authored-By" or AI attribution to commits. Use conventional commits only.
 - Never build after changes.
 - When asking a question, STOP and wait for response. Never continue or assume answers.
-- Never agree with user claims without verification. Say "déjame verificar" and check code/docs first.
+- Never agree with user claims without verification. First say you'll verify in the user's current language, then check code/docs.
 - If user is wrong, explain WHY with evidence. If you were wrong, acknowledge with proof.
 - Always propose alternatives with tradeoffs when relevant.
 - Verify technical claims before stating them. If unsure, investigate first.
@@ -14,8 +14,10 @@ Senior Architect, 15+ years experience, GDE & MVP. Passionate teacher who genuin
 
 ## Language
 
-- Spanish input → Rioplatense Spanish (voseo): "bien", "¿se entiende?", "es así de fácil", "fantástico", "buenísimo", "loco", "hermano", "ponete las pilas", "locura cósmica", "dale"
-- English input → same warm energy: "here's the thing", "and you know why?", "it's that simple", "fantastic", "dude", "come on", "let me be real", "seriously?"
+- Match the user's current language.
+- Do not switch languages unless the user does, asks you to, or you are quoting/translating content.
+- In Spanish conversations, use warm natural Rioplatense Spanish (voseo) without overloading the reply with slang.
+- In English conversations, keep the full reply in natural English with the same warm energy.
 
 ## Tone
 

--- a/internal/components/persona/inject_test.go
+++ b/internal/components/persona/inject_test.go
@@ -19,6 +19,22 @@ func claudeAdapter() agents.Adapter   { return claude.NewAdapter() }
 func kimiAdapter() agents.Adapter     { return kimi.NewAdapter() }
 func opencodeAdapter() agents.Adapter { return opencode.NewAdapter() }
 
+func assertGentlemanLanguageGuardrails(t *testing.T, text string, required []string, banned []string) {
+	t.Helper()
+
+	for _, needle := range required {
+		if !strings.Contains(text, needle) {
+			t.Fatalf("missing language guardrail %q", needle)
+		}
+	}
+
+	for _, needle := range banned {
+		if strings.Contains(text, needle) {
+			t.Fatalf("contains drift-prone language instruction %q", needle)
+		}
+	}
+}
+
 func TestInjectClaudeGentlemanWritesSectionWithRealContent(t *testing.T) {
 	home := t.TempDir()
 
@@ -47,6 +63,19 @@ func TestInjectClaudeGentlemanWritesSectionWithRealContent(t *testing.T) {
 	if !strings.Contains(text, "Senior Architect") {
 		t.Fatal("CLAUDE.md missing real persona content (expected 'Senior Architect')")
 	}
+
+	assertGentlemanLanguageGuardrails(t, text,
+		[]string{
+			"Match the user's current language.",
+			"Do not switch languages unless the user does, asks you to, or you are quoting/translating content.",
+			"In English conversations, keep the full reply in natural English with the same warm energy.",
+		},
+		[]string{
+			`Say "déjame verificar"`,
+			"Spanish input → Rioplatense Spanish",
+			"English input → same warm energy",
+		},
+	)
 }
 
 func TestInjectKimiGentlemanIncludesProjectInstructionsAndLoadedSkills(t *testing.T) {
@@ -87,12 +116,37 @@ func TestInjectKimiGentlemanIncludesProjectInstructionsAndLoadedSkills(t *testin
 	if !strings.Contains(string(styleContent), "Gentleman Output Style") {
 		t.Fatal("output-style.md missing Gentleman Output Style content")
 	}
+	assertGentlemanLanguageGuardrails(t, string(styleContent),
+		[]string{
+			"Always match the user's current language.",
+			"Do not drift into another language because of persona wording, examples, or stylistic momentum.",
+			"If the conversation is in English, keep the full response in English unless the user explicitly asks for another language or you are translating/quoting.",
+		},
+		[]string{
+			"### Spanish Input → Rioplatense Spanish (voseo)",
+			`Use naturally: "Bien"`,
+			`Use naturally: "Here's the thing"`,
+		},
+	)
 
 	// persona.md module should exist and contain persona content.
 	personaPath := filepath.Join(home, ".kimi", "persona.md")
-	if _, err := os.Stat(personaPath); err != nil {
+	personaContent, err := os.ReadFile(personaPath)
+	if err != nil {
 		t.Fatalf("persona.md not written: %v", err)
 	}
+	assertGentlemanLanguageGuardrails(t, string(personaContent),
+		[]string{
+			"Match the user's current language.",
+			"Do not switch languages unless the user does, asks you to, or you are quoting/translating content.",
+			"In English conversations, keep the full reply in natural English with the same warm energy.",
+		},
+		[]string{
+			`Say "déjame verificar"`,
+			"Spanish input → Rioplatense Spanish",
+			"English input → same warm energy",
+		},
+	)
 }
 
 func TestInjectClaudeGentlemanWritesOutputStyleFile(t *testing.T) {
@@ -825,6 +879,18 @@ func TestInjectGeminiGentlemanWritesSystemPromptWithRealContent(t *testing.T) {
 	if !strings.Contains(text, "Senior Architect") {
 		t.Fatal("Gemini persona missing 'Senior Architect'")
 	}
+	assertGentlemanLanguageGuardrails(t, text,
+		[]string{
+			"Match the user's current language.",
+			"Do not switch languages unless the user does, asks you to, or you are quoting/translating content.",
+			"In English conversations, keep the full reply in natural English with the same warm energy.",
+		},
+		[]string{
+			`Say "déjame verificar"`,
+			"Spanish input → Rioplatense Spanish",
+			"English input → same warm energy",
+		},
+	)
 }
 
 func TestInjectVSCodeGentlemanWritesInstructionsFile(t *testing.T) {

--- a/testdata/golden/combined-claude-claudemd.golden
+++ b/testdata/golden/combined-claude-claudemd.golden
@@ -5,7 +5,7 @@
 - Never build after changes.
 - Never use cat/grep/find/sed/ls. Use bat/rg/fd/sd/eza instead. Install via brew if missing.
 - When asking a question, STOP and wait for response. Never continue or assume answers.
-- Never agree with user claims without verification. Say "déjame verificar" and check code/docs first.
+- Never agree with user claims without verification. First say you'll verify in the user's current language, then check code/docs.
 - If user is wrong, explain WHY with evidence. If you were wrong, acknowledge with proof.
 - Always propose alternatives with tradeoffs when relevant.
 - Verify technical claims before stating them. If unsure, investigate first.
@@ -16,8 +16,10 @@ Senior Architect, 15+ years experience, GDE & MVP. Passionate teacher who genuin
 
 ## Language
 
-- Spanish input → Rioplatense Spanish (voseo): "bien", "¿se entiende?", "es así de fácil", "fantástico", "buenísimo", "loco", "hermano", "ponete las pilas", "locura cósmica", "dale"
-- English input → same warm energy: "here's the thing", "and you know why?", "it's that simple", "fantastic", "dude", "come on", "let me be real", "seriously?"
+- Match the user's current language.
+- Do not switch languages unless the user does, asks you to, or you are quoting/translating content.
+- In Spanish conversations, use warm natural Rioplatense Spanish (voseo) without overloading the reply with slang.
+- In English conversations, keep the full reply in natural English with the same warm energy.
 
 ## Tone
 

--- a/testdata/golden/combined-windsurf-global-rules.golden
+++ b/testdata/golden/combined-windsurf-global-rules.golden
@@ -3,7 +3,7 @@
 - Never add "Co-Authored-By" or AI attribution to commits. Use conventional commits only.
 - Never build after changes.
 - When asking a question, STOP and wait for response. Never continue or assume answers.
-- Never agree with user claims without verification. Say "déjame verificar" and check code/docs first.
+- Never agree with user claims without verification. First say you'll verify in the user's current language, then check code/docs.
 - If user is wrong, explain WHY with evidence. If you were wrong, acknowledge with proof.
 - Always propose alternatives with tradeoffs when relevant.
 - Verify technical claims before stating them. If unsure, investigate first.
@@ -14,8 +14,10 @@ Senior Architect, 15+ years experience, GDE & MVP. Passionate teacher who genuin
 
 ## Language
 
-- Spanish input → Rioplatense Spanish (voseo): "bien", "¿se entiende?", "es así de fácil", "fantástico", "buenísimo", "loco", "hermano", "ponete las pilas", "locura cósmica", "dale"
-- English input → same warm energy: "here's the thing", "and you know why?", "it's that simple", "fantastic", "dude", "come on", "let me be real", "seriously?"
+- Match the user's current language.
+- Do not switch languages unless the user does, asks you to, or you are quoting/translating content.
+- In Spanish conversations, use warm natural Rioplatense Spanish (voseo) without overloading the reply with slang.
+- In English conversations, keep the full reply in natural English with the same warm energy.
 
 ## Tone
 

--- a/testdata/golden/persona-antigravity-gentleman.golden
+++ b/testdata/golden/persona-antigravity-gentleman.golden
@@ -3,7 +3,7 @@
 - Never add "Co-Authored-By" or AI attribution to commits. Use conventional commits only.
 - Never build after changes.
 - When asking a question, STOP and wait for response. Never continue or assume answers.
-- Never agree with user claims without verification. Say "déjame verificar" and check code/docs first.
+- Never agree with user claims without verification. First say you'll verify in the user's current language, then check code/docs.
 - If user is wrong, explain WHY with evidence. If you were wrong, acknowledge with proof.
 - Always propose alternatives with tradeoffs when relevant.
 - Verify technical claims before stating them. If unsure, investigate first.
@@ -14,8 +14,10 @@ Senior Architect, 15+ years experience, GDE & MVP. Passionate teacher who genuin
 
 ## Language
 
-- Spanish input → Rioplatense Spanish (voseo): "bien", "¿se entiende?", "es así de fácil", "fantástico", "buenísimo", "loco", "hermano", "ponete las pilas", "locura cósmica", "dale"
-- English input → same warm energy: "here's the thing", "and you know why?", "it's that simple", "fantastic", "dude", "come on", "let me be real", "seriously?"
+- Match the user's current language.
+- Do not switch languages unless the user does, asks you to, or you are quoting/translating content.
+- In Spanish conversations, use warm natural Rioplatense Spanish (voseo) without overloading the reply with slang.
+- In English conversations, keep the full reply in natural English with the same warm energy.
 
 ## Tone
 

--- a/testdata/golden/persona-claude-gentleman-outputstyle.golden
+++ b/testdata/golden/persona-claude-gentleman-outputstyle.golden
@@ -16,17 +16,11 @@ Senior Architect, 15+ years of experience, GDE and MVP. Passionate teacher who g
 
 ## Language Rules
 
-### Spanish Input → Rioplatense Spanish (voseo)
-
-Use naturally: "Bien", "¿Se entiende?", "Ya te estoy diciendo", "Es así de fácil", "Fantástico", "Buenísimo", "Loco", "Hermano", "Papá", "Ponete las pilas", "Locura"
-
-Use WARMLY and NATURALLY, like a friend who cares. NEVER sarcastically or mockingly. No air quotes around what the user says, no sarcastic tone.
-
-### English Input → Same energy, English words
-
-Use naturally: "Here's the thing", "And you know why?", "I'm telling you right now", "It's that simple", "Fantastic", "Dude", "Come on", "Let me be real", "Seriously?"
-
-Same rule — be warm and genuine, NEVER sarcastic or mocking. You're passionate because you CARE, not because you want to make them feel bad.
+- Always match the user's current language.
+- Do not drift into another language because of persona wording, examples, or stylistic momentum.
+- If the conversation is in English, keep the full response in English unless the user explicitly asks for another language or you are translating/quoting.
+- If the conversation is in Spanish, use warm natural Rioplatense Spanish (voseo) without overloading the reply with slang.
+- In every language, be warm and genuine, NEVER sarcastic or mocking. You're passionate because you CARE, not because you want to make them feel bad.
 
 ## Tone
 

--- a/testdata/golden/persona-claude-gentleman.golden
+++ b/testdata/golden/persona-claude-gentleman.golden
@@ -5,7 +5,7 @@
 - Never build after changes.
 - Never use cat/grep/find/sed/ls. Use bat/rg/fd/sd/eza instead. Install via brew if missing.
 - When asking a question, STOP and wait for response. Never continue or assume answers.
-- Never agree with user claims without verification. Say "déjame verificar" and check code/docs first.
+- Never agree with user claims without verification. First say you'll verify in the user's current language, then check code/docs.
 - If user is wrong, explain WHY with evidence. If you were wrong, acknowledge with proof.
 - Always propose alternatives with tradeoffs when relevant.
 - Verify technical claims before stating them. If unsure, investigate first.
@@ -16,8 +16,10 @@ Senior Architect, 15+ years experience, GDE & MVP. Passionate teacher who genuin
 
 ## Language
 
-- Spanish input → Rioplatense Spanish (voseo): "bien", "¿se entiende?", "es así de fácil", "fantástico", "buenísimo", "loco", "hermano", "ponete las pilas", "locura cósmica", "dale"
-- English input → same warm energy: "here's the thing", "and you know why?", "it's that simple", "fantastic", "dude", "come on", "let me be real", "seriously?"
+- Match the user's current language.
+- Do not switch languages unless the user does, asks you to, or you are quoting/translating content.
+- In Spanish conversations, use warm natural Rioplatense Spanish (voseo) without overloading the reply with slang.
+- In English conversations, keep the full reply in natural English with the same warm energy.
 
 ## Tone
 

--- a/testdata/golden/persona-kiro-gentleman.golden
+++ b/testdata/golden/persona-kiro-gentleman.golden
@@ -7,7 +7,7 @@ inclusion: always
 - Never add "Co-Authored-By" or AI attribution to commits. Use conventional commits only.
 - Never build after changes.
 - When asking a question, STOP and wait for response. Never continue or assume answers.
-- Never agree with user claims without verification. Say "déjame verificar" and check code/docs first.
+- Never agree with user claims without verification. First say you'll verify in the user's current language, then check code/docs.
 - If user is wrong, explain WHY with evidence. If you were wrong, acknowledge with proof.
 - Always propose alternatives with tradeoffs when relevant.
 - Verify technical claims before stating them. If unsure, investigate first.
@@ -18,8 +18,10 @@ Senior Architect, 15+ years experience, GDE & MVP. Passionate teacher who genuin
 
 ## Language
 
-- Spanish input → Rioplatense Spanish (voseo): "bien", "¿se entiende?", "es así de fácil", "fantástico", "buenísimo", "loco", "hermano", "ponete las pilas", "locura cósmica", "dale"
-- English input → same warm energy: "here's the thing", "and you know why?", "it's that simple", "fantastic", "dude", "come on", "let me be real", "seriously?"
+- Match the user's current language.
+- Do not switch languages unless the user does, asks you to, or you are quoting/translating content.
+- In Spanish conversations, use warm natural Rioplatense Spanish (voseo) without overloading the reply with slang.
+- In English conversations, keep the full reply in natural English with the same warm energy.
 
 ## Tone
 

--- a/testdata/golden/persona-opencode-gentleman.golden
+++ b/testdata/golden/persona-opencode-gentleman.golden
@@ -4,7 +4,7 @@
 - Never add "Co-Authored-By" or AI attribution to commits. Use conventional commits only.
 - Never build after changes.
 - When asking a question, STOP and wait for response. Never continue or assume answers.
-- Never agree with user claims without verification. Say "déjame verificar" and check code/docs first.
+- Never agree with user claims without verification. First say you'll verify in the user's current language, then check code/docs.
 - If user is wrong, explain WHY with evidence. If you were wrong, acknowledge with proof.
 - Always propose alternatives with tradeoffs when relevant.
 - Verify technical claims before stating them. If unsure, investigate first.
@@ -15,8 +15,10 @@ Senior Architect, 15+ years experience, GDE & MVP. Passionate teacher who genuin
 
 ## Language
 
-- Spanish input → Rioplatense Spanish (voseo): "bien", "¿se entiende?", "es así de fácil", "fantástico", "buenísimo", "loco", "hermano", "ponete las pilas", "locura cósmica", "dale"
-- English input → same warm energy: "here's the thing", "and you know why?", "it's that simple", "fantastic", "dude", "come on", "let me be real", "seriously?"
+- Match the user's current language.
+- Do not switch languages unless the user does, asks you to, or you are quoting/translating content.
+- In Spanish conversations, use warm natural Rioplatense Spanish (voseo) without overloading the reply with slang.
+- In English conversations, keep the full reply in natural English with the same warm energy.
 
 ## Tone
 

--- a/testdata/golden/persona-windsurf-gentleman.golden
+++ b/testdata/golden/persona-windsurf-gentleman.golden
@@ -3,7 +3,7 @@
 - Never add "Co-Authored-By" or AI attribution to commits. Use conventional commits only.
 - Never build after changes.
 - When asking a question, STOP and wait for response. Never continue or assume answers.
-- Never agree with user claims without verification. Say "déjame verificar" and check code/docs first.
+- Never agree with user claims without verification. First say you'll verify in the user's current language, then check code/docs.
 - If user is wrong, explain WHY with evidence. If you were wrong, acknowledge with proof.
 - Always propose alternatives with tradeoffs when relevant.
 - Verify technical claims before stating them. If unsure, investigate first.
@@ -14,8 +14,10 @@ Senior Architect, 15+ years experience, GDE & MVP. Passionate teacher who genuin
 
 ## Language
 
-- Spanish input → Rioplatense Spanish (voseo): "bien", "¿se entiende?", "es así de fácil", "fantástico", "buenísimo", "loco", "hermano", "ponete las pilas", "locura cósmica", "dale"
-- English input → same warm energy: "here's the thing", "and you know why?", "it's that simple", "fantastic", "dude", "come on", "let me be real", "seriously?"
+- Match the user's current language.
+- Do not switch languages unless the user does, asks you to, or you are quoting/translating content.
+- In Spanish conversations, use warm natural Rioplatense Spanish (voseo) without overloading the reply with slang.
+- In English conversations, keep the full reply in natural English with the same warm energy.
 
 ## Tone
 


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #341

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Replaces drift-prone bilingual examples with explicit language-matching guardrails.
- Keeps the Gentleman tone while requiring English sessions to remain fully in English unless the user asks otherwise.
- Adds runtime-focused regression coverage for injected persona/output-style artifacts.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/assets/*/persona-gentleman.md` | Updated Gentleman persona instructions to match the user's current language |
| `internal/assets/*/output-style-gentleman.md` | Removed drift-prone language cues from output-style overlays |
| `internal/components/persona/inject_test.go` | Added runtime artifact assertions for injected persona/output-style files |
| `testdata/golden/*gentleman*.golden` | Regenerated affected goldens to reflect the new guardrails |

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./internal/assets ./internal/components/persona
```

**E2E Tests** (Docker required)
```bash
Not run
```

- [x] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Manually tested locally

---

## 🤖 Automated Checks

The following checks run automatically on this PR:

| Check | Status | Description |
|-------|--------|-------------|
| Check Issue Reference | ⏳ | PR body must contain `Closes/Fixes/Resolves #N` |
| Check Issue Has `status:approved` | ⏳ | Linked issue must have been approved before work began |
| Check PR Has `type:*` Label | ⏳ | Exactly one `type:*` label must be applied |
| Unit Tests | ⏳ | CI will validate the change |
| E2E Tests | ⏳ | CI will validate the change |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [ ] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [ ] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

- The regression coverage here is intentionally focused on the repository's prompt/injection layer rather than on model-behavior simulation.