### PR TITLE
fix(tui): include OpenCode runtime custom models in picker

### DIFF
--- a/internal/opencode/models.go
+++ b/internal/opencode/models.go
@@ -4,8 +4,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"sort"
+	"strings"
 )
 
 // DefaultCachePath returns the default path to the OpenCode models cache file.
@@ -117,6 +119,32 @@ var envLookup = os.Getenv
 // authPath is a package-level variable for testing.
 var authPath = DefaultAuthPath
 
+// listModelsForProvider returns runtime-visible model IDs for a provider using
+// the installed `opencode` binary. The CLI is the source of truth for custom
+// models that may not appear in ~/.cache/opencode/models.json yet.
+var listModelsForProvider = func(providerID string) ([]string, error) {
+	cmd := exec.Command("opencode", "models", providerID)
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+
+	var models []string
+	for _, line := range strings.Split(string(output), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		parts := strings.SplitN(line, "/", 2)
+		if len(parts) != 2 || parts[0] != providerID || parts[1] == "" {
+			continue
+		}
+		models = append(models, parts[1])
+	}
+
+	return models, nil
+}
+
 // DetectAvailableProviders returns provider IDs that the user has access to and
 // that have at least one model with tool_call support. Detection sources:
 //  1. OAuth credentials in ~/.local/share/opencode/auth.json
@@ -189,6 +217,39 @@ func FilterModelsForSDD(provider Provider) []Model {
 	})
 
 	return models
+}
+
+// EnrichProvidersWithRuntimeModels merges the runtime-visible `opencode models`
+// output into the cached provider catalog. This preserves cache metadata where
+// present while making custom models selectable in the TUI.
+func EnrichProvidersWithRuntimeModels(providers map[string]Provider, providerIDs []string) {
+	for _, providerID := range providerIDs {
+		runtimeIDs, err := listModelsForProvider(providerID)
+		if err != nil || len(runtimeIDs) == 0 {
+			continue
+		}
+
+		provider, ok := providers[providerID]
+		if !ok {
+			provider = Provider{ID: providerID, Name: providerID, Models: map[string]Model{}}
+		}
+		if provider.Models == nil {
+			provider.Models = make(map[string]Model)
+		}
+
+		for _, modelID := range runtimeIDs {
+			if _, exists := provider.Models[modelID]; exists {
+				continue
+			}
+			provider.Models[modelID] = Model{
+				ID:       modelID,
+				Name:     modelID,
+				ToolCall: true,
+			}
+		}
+
+		providers[providerID] = provider
+	}
 }
 
 // SDDPhases returns the ordered list of SDD phase sub-agent names.

--- a/internal/opencode/models_test.go
+++ b/internal/opencode/models_test.go
@@ -308,6 +308,55 @@ func TestFilterModelsForSDD(t *testing.T) {
 	}
 }
 
+func TestEnrichProvidersWithRuntimeModels_MergesMissingCustomModels(t *testing.T) {
+	path := writeFixture(t)
+	providers, err := LoadModels(path)
+	if err != nil {
+		t.Fatalf("LoadModels() error = %v", err)
+	}
+
+	original := listModelsForProvider
+	defer func() { listModelsForProvider = original }()
+
+	listModelsForProvider = func(providerID string) ([]string, error) {
+		switch providerID {
+		case "google":
+			return []string{
+				"gemini-2.5-pro",
+				"antigravity-claude-opus-4-6-thinking",
+				"antigravity-claude-sonnet-4-6",
+			}, nil
+		default:
+			return nil, nil
+		}
+	}
+
+	EnrichProvidersWithRuntimeModels(providers, []string{"google"})
+
+	google, ok := providers["google"]
+	if !ok {
+		t.Fatal("missing google provider after enrichment")
+	}
+
+	for _, modelID := range []string{"gemini-2.5-pro", "antigravity-claude-opus-4-6-thinking", "antigravity-claude-sonnet-4-6"} {
+		model, ok := google.Models[modelID]
+		if !ok {
+			t.Fatalf("google model %q missing after enrichment", modelID)
+		}
+		if !model.ToolCall {
+			t.Fatalf("google model %q ToolCall = false, want true", modelID)
+		}
+	}
+
+	filtered := FilterModelsForSDD(google)
+	if len(filtered) != 3 {
+		t.Fatalf("FilterModelsForSDD(google) len = %d, want 3", len(filtered))
+	}
+	if filtered[0].ID != "antigravity-claude-opus-4-6-thinking" {
+		t.Fatalf("first filtered model = %q, want antigravity-claude-opus-4-6-thinking", filtered[0].ID)
+	}
+}
+
 func TestLoadAuthProviders(t *testing.T) {
 	authPath := writeAuthFixture(t, map[string]bool{
 		"anthropic":      true,

--- a/internal/tui/screens/model_picker.go
+++ b/internal/tui/screens/model_picker.go
@@ -61,6 +61,7 @@ func NewModelPickerState(cachePath string) ModelPickerState {
 	}
 
 	available := opencode.DetectAvailableProviders(providers)
+	opencode.EnrichProvidersWithRuntimeModels(providers, available)
 
 	sddModels := make(map[string][]opencode.Model, len(available))
 	for _, id := range available {


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #357

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Fixes the OpenCode model picker so runtime-visible custom provider models are selectable in the Gentle AI TUI.
- Merges `opencode models <provider>` output into the cached provider catalog before rendering the picker.
- Adds a regression test covering missing custom Google models such as `antigravity-claude-*`.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/opencode/models.go` | Added runtime model enrichment from `opencode models <provider>` and merged missing models into the cached provider catalog. |
| `internal/opencode/models_test.go` | Added regression coverage for custom Google/OpenCode models missing from cache. |
| `internal/tui/screens/model_picker.go` | Enriched providers before filtering/rendering model choices in the TUI picker. |

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./...
```

**E2E Tests** (Docker required)
```bash
cd e2e && ./docker-test.sh
```

- [x] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Manually tested locally

Manual verification:
- reproduced the bug in the real `gentle-ai` TUI before the fix
- ran the local patched binary and confirmed the Google provider model count increased from 27 to 33, consistent with the missing Antigravity entries being included

---

## 🤖 Automated Checks

The following checks run automatically on this PR:

| Check | Status | Description |
|-------|--------|-------------|
| Check Issue Reference | ⏳ | PR body must contain `Closes/Fixes/Resolves #N` |
| Check Issue Has `status:approved` | ⏳ | Linked issue must have been approved before work began |
| Check PR Has `type:*` Label | ⏳ | Exactly one `type:*` label must be applied |
| Unit Tests | ⏳ | `go test ./...` must pass |
| E2E Tests | ⏳ | `cd e2e && ./docker-test.sh` must pass |

---

## ✅ Contributor Checklist

- [ ] PR is linked to an issue with `status:approved`
- [ ] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [ ] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

- I was able to create the issue and PR, but I do not have maintainer permissions to add `status:approved` to the issue or apply the `type:bug` label on the PR.
- The fix is intentionally minimal: it preserves cached model metadata when available and only fills gaps from the OpenCode runtime catalog.
