### PR TITLE
fix(mcp): replace stale Context7 config entries

### DIFF
--- a/internal/components/mcp/context7.go
+++ b/internal/components/mcp/context7.go
@@ -6,7 +6,9 @@ var defaultContext7OverlayJSON = []byte("{\n  \"mcpServers\": {\n    \"context7\
 
 // openCodeContext7OverlayJSON is the opencode.json overlay using the new MCP format.
 // Context7 is a remote MCP server — no npx needed.
-var openCodeContext7OverlayJSON = []byte("{\n  \"mcp\": {\n    \"context7\": {\n      \"type\": \"remote\",\n      \"url\": \"https://mcp.context7.com/mcp\",\n      \"enabled\": true\n    }\n  }\n}\n")
+// The context7 entry must replace atomically so legacy local keys do not survive
+// deep merge into OpenCode/KiloCode's strict MCP schema.
+var openCodeContext7OverlayJSON = []byte("{\n  \"mcp\": {\n    \"context7\": {\n      \"__replace__\": {\n        \"type\": \"remote\",\n        \"url\": \"https://mcp.context7.com/mcp\",\n        \"enabled\": true\n      }\n    }\n  }\n}\n")
 
 // openClawContext7OverlayJSON is the OpenClaw openclaw.json overlay.
 // OpenClaw rejects top-level mcpServers and expects MCP entries under
@@ -18,11 +20,15 @@ var vsCodeContext7OverlayJSON = []byte("{\n  \"servers\": {\n    \"context7\": {
 
 // antigravityContext7OverlayJSON is the Antigravity mcp_config.json overlay.
 // Uses mcpServers key (same schema as Claude Code) with serverUrl for HTTP remote.
-var antigravityContext7OverlayJSON = []byte("{\n  \"mcpServers\": {\n    \"context7\": {\n      \"serverUrl\": \"https://mcp.context7.com/mcp\"\n    }\n  }\n}\n")
+// The context7 entry must replace atomically so legacy local keys do not survive
+// deep merge into this managed MCP server entry.
+var antigravityContext7OverlayJSON = []byte("{\n  \"mcpServers\": {\n    \"context7\": {\n      \"__replace__\": {\n        \"serverUrl\": \"https://mcp.context7.com/mcp\"\n      }\n    }\n  }\n}\n")
 
 // kimiContext7OverlayJSON follows Kimi's documented mcp.json "well-known MCP
 // config format", using mcpServers + explicit http transport for Context7.
-var kimiContext7OverlayJSON = []byte("{\n  \"mcpServers\": {\n    \"context7\": {\n      \"transport\": \"http\",\n      \"url\": \"https://mcp.context7.com/mcp\"\n    }\n  }\n}\n")
+// The context7 entry must replace atomically so legacy local keys do not survive
+// deep merge into this managed MCP server entry.
+var kimiContext7OverlayJSON = []byte("{\n  \"mcpServers\": {\n    \"context7\": {\n      \"__replace__\": {\n        \"transport\": \"http\",\n        \"url\": \"https://mcp.context7.com/mcp\"\n      }\n    }\n  }\n}\n")
 
 func DefaultContext7ServerJSON() []byte {
 	content := make([]byte, len(defaultContext7ServerJSON))

--- a/internal/components/mcp/inject_test.go
+++ b/internal/components/mcp/inject_test.go
@@ -1,14 +1,17 @@
 package mcp
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/gentleman-programming/gentle-ai/internal/agents"
+	"github.com/gentleman-programming/gentle-ai/internal/agents/antigravity"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/claude"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/codex"
+	"github.com/gentleman-programming/gentle-ai/internal/agents/kilocode"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/kimi"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/openclaw"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/opencode"
@@ -24,10 +27,140 @@ func cursorAdapter(t *testing.T) agents.Adapter {
 	return adapter
 }
 
-func claudeAdapter() agents.Adapter   { return claude.NewAdapter() }
-func kimiAdapter() agents.Adapter     { return kimi.NewAdapter() }
-func openclawAdapter() agents.Adapter { return openclaw.NewAdapter() }
-func opencodeAdapter() agents.Adapter { return opencode.NewAdapter() }
+func antigravityAdapter() agents.Adapter { return antigravity.NewAdapter() }
+func claudeAdapter() agents.Adapter      { return claude.NewAdapter() }
+func kilocodeAdapter() agents.Adapter    { return kilocode.NewAdapter() }
+func kimiAdapter() agents.Adapter        { return kimi.NewAdapter() }
+func openclawAdapter() agents.Adapter    { return openclaw.NewAdapter() }
+func opencodeAdapter() agents.Adapter    { return opencode.NewAdapter() }
+
+func assertOnlyKeys(t *testing.T, path string, object map[string]any, keys ...string) {
+	t.Helper()
+
+	want := make(map[string]struct{}, len(keys))
+	for _, key := range keys {
+		want[key] = struct{}{}
+	}
+
+	for _, key := range keys {
+		if _, exists := object[key]; !exists {
+			t.Fatalf("%q missing expected key %q; got %#v", path, key, object)
+		}
+	}
+
+	for key := range object {
+		if _, expected := want[key]; !expected {
+			t.Fatalf("%q contains unexpected key %q; want only %v; got %#v", path, key, keys, object)
+		}
+	}
+}
+
+// readOpenCodeContext7Entry reads the mcp.context7 object from an OpenCode/KiloCode
+// opencode.json config file. Navigates parsed["mcp"]["context7"].
+func readOpenCodeContext7Entry(t *testing.T, path string) map[string]any {
+	t.Helper()
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", path, err)
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal(content, &parsed); err != nil {
+		t.Fatalf("Unmarshal(%q) error = %v", path, err)
+	}
+
+	mcp, ok := parsed["mcp"].(map[string]any)
+	if !ok {
+		t.Fatalf("%q missing object key mcp; got %#v", path, parsed["mcp"])
+	}
+
+	context7, ok := mcp["context7"].(map[string]any)
+	if !ok {
+		t.Fatalf("%q missing object key mcp.context7; got %#v", path, mcp["context7"])
+	}
+
+	return context7
+}
+
+// assertOpenCodeRemoteContext7Schema asserts the mcp.context7 entry in an
+// OpenCode/KiloCode opencode.json is a valid remote entry with no legacy local keys.
+func assertOpenCodeRemoteContext7Schema(t *testing.T, path string) {
+	t.Helper()
+
+	context7 := readOpenCodeContext7Entry(t, path)
+
+	if got := context7["type"]; got != "remote" {
+		t.Fatalf("%q mcp.context7.type = %#v; want %q", path, got, "remote")
+	}
+	if got := context7["url"]; got != "https://mcp.context7.com/mcp" {
+		t.Fatalf("%q mcp.context7.url = %#v; want context7 remote URL", path, got)
+	}
+	if got := context7["enabled"]; got != true {
+		t.Fatalf("%q mcp.context7.enabled = %#v; want true", path, got)
+	}
+
+	assertOnlyKeys(t, path, context7, "type", "url", "enabled")
+}
+
+// readMCPServersContext7Entry reads the mcpServers.context7 object used by
+// agents that store Context7 under an mcpServers-based config file.
+func readMCPServersContext7Entry(t *testing.T, path string) map[string]any {
+	t.Helper()
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", path, err)
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal(content, &parsed); err != nil {
+		t.Fatalf("Unmarshal(%q) error = %v", path, err)
+	}
+
+	mcpServers, ok := parsed["mcpServers"].(map[string]any)
+	if !ok {
+		t.Fatalf("%q missing object key mcpServers; got %#v", path, parsed["mcpServers"])
+	}
+
+	context7, ok := mcpServers["context7"].(map[string]any)
+	if !ok {
+		t.Fatalf("%q missing object key mcpServers.context7; got %#v", path, mcpServers["context7"])
+	}
+
+	return context7
+}
+
+// assertAntigravityContext7Schema asserts the mcpServers.context7 entry in an
+// Antigravity mcp_config.json is a valid remote entry with no legacy local keys.
+func assertAntigravityContext7Schema(t *testing.T, path string) {
+	t.Helper()
+
+	context7 := readMCPServersContext7Entry(t, path)
+
+	if got := context7["serverUrl"]; got != "https://mcp.context7.com/mcp" {
+		t.Fatalf("%q mcpServers.context7.serverUrl = %#v; want context7 remote URL", path, got)
+	}
+
+	assertOnlyKeys(t, path, context7, "serverUrl")
+}
+
+// assertKimiContext7Schema asserts the mcpServers.context7 entry in a Kimi
+// mcp.json is the documented remote HTTP config with no legacy local keys.
+func assertKimiContext7Schema(t *testing.T, path string) {
+	t.Helper()
+
+	context7 := readMCPServersContext7Entry(t, path)
+
+	if got := context7["transport"]; got != "http" {
+		t.Fatalf("%q mcpServers.context7.transport = %#v; want %q", path, got, "http")
+	}
+	if got := context7["url"]; got != "https://mcp.context7.com/mcp" {
+		t.Fatalf("%q mcpServers.context7.url = %#v; want context7 remote URL", path, got)
+	}
+
+	assertOnlyKeys(t, path, context7, "transport", "url")
+}
 
 func TestInjectOpenCodeMergesContext7AndIsIdempotent(t *testing.T) {
 	home := t.TempDir()
@@ -57,6 +190,8 @@ func TestInjectOpenCodeMergesContext7AndIsIdempotent(t *testing.T) {
 	if len(config) == 0 {
 		t.Fatalf("opencode.json is empty")
 	}
+
+	assertOpenCodeRemoteContext7Schema(t, configPath)
 
 	text := string(config)
 	if !strings.Contains(text, `"mcp"`) {
@@ -137,6 +272,161 @@ func TestInjectOpenClawMergesContext7UnderMCPDotServersAndMigratesLegacyMCPServe
 	}
 	if !strings.Contains(text, `"context7"`) || !strings.Contains(text, `"@upstash/context7-mcp"`) {
 		t.Fatalf("openclaw.json missing context7 under mcp.servers; got:\n%s", text)
+	}
+}
+
+func TestInjectOpenCodeReplacesLegacyContext7LocalConfig(t *testing.T) {
+	home := t.TempDir()
+	adapter := opencodeAdapter()
+	configPath := adapter.SettingsPath(home)
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll error = %v", err)
+	}
+
+	legacy := `{
+	  "mcp": {
+	    "context7": {
+	      "type": "local",
+	      "command": ["npx", "-y", "@upstash/context7-mcp"],
+	      "args": ["legacy"],
+	      "env": {"TOKEN": "x"},
+	      "environment": {"TOKEN": "y"},
+	      "headers": {"Authorization": "Bearer old"},
+	      "enabled": false
+	    }
+	  }
+	}`
+	if err := os.WriteFile(configPath, []byte(legacy), 0o644); err != nil {
+		t.Fatalf("WriteFile(opencode.json) error = %v", err)
+	}
+
+	first, err := Inject(home, adapter)
+	if err != nil {
+		t.Fatalf("Inject() first error = %v", err)
+	}
+	if !first.Changed {
+		t.Fatalf("Inject() first changed = false; expected migration to rewrite legacy context7")
+	}
+
+	assertOpenCodeRemoteContext7Schema(t, configPath)
+
+	second, err := Inject(home, adapter)
+	if err != nil {
+		t.Fatalf("Inject() second error = %v", err)
+	}
+	if second.Changed {
+		t.Fatalf("Inject() second changed = true; expected idempotent context7 rewrite")
+	}
+
+	assertOpenCodeRemoteContext7Schema(t, configPath)
+}
+
+func TestInjectKilocodeReplacesLegacyContext7LocalConfig(t *testing.T) {
+	home := t.TempDir()
+	adapter := kilocodeAdapter()
+	configPath := adapter.SettingsPath(home)
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll error = %v", err)
+	}
+
+	legacy := `{
+	  "mcp": {
+	    "context7": {
+	      "type": "local",
+	      "command": ["npx", "-y", "@upstash/context7-mcp"],
+	      "args": ["legacy"],
+	      "env": {"TOKEN": "x"},
+	      "environment": {"TOKEN": "y"},
+	      "headers": {"Authorization": "Bearer old"},
+	      "enabled": false
+	    }
+	  }
+	}`
+	if err := os.WriteFile(configPath, []byte(legacy), 0o644); err != nil {
+		t.Fatalf("WriteFile(kilo opencode.json) error = %v", err)
+	}
+
+	first, err := Inject(home, adapter)
+	if err != nil {
+		t.Fatalf("Inject() first error = %v", err)
+	}
+	if !first.Changed {
+		t.Fatalf("Inject() first changed = false; expected migration to rewrite legacy context7")
+	}
+
+	assertOpenCodeRemoteContext7Schema(t, configPath)
+
+	second, err := Inject(home, adapter)
+	if err != nil {
+		t.Fatalf("Inject() second error = %v", err)
+	}
+	if second.Changed {
+		t.Fatalf("Inject() second changed = true; expected idempotent context7 rewrite")
+	}
+
+	assertOpenCodeRemoteContext7Schema(t, configPath)
+}
+
+func TestInjectOpenCodePreservesOtherMCPEntriesWhenReplacingContext7(t *testing.T) {
+	home := t.TempDir()
+	adapter := opencodeAdapter()
+	configPath := adapter.SettingsPath(home)
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll error = %v", err)
+	}
+
+	legacy := `{
+	  "mcp": {
+	    "context7": {
+	      "type": "local",
+	      "command": ["npx", "-y", "@upstash/context7-mcp"],
+	      "args": ["legacy"],
+	      "env": {"TOKEN": "x"},
+	      "enabled": false
+	    },
+	    "engram": {
+	      "type": "local",
+	      "command": ["engram-server"],
+	      "args": ["--port", "9000"]
+	    }
+	  }
+	}`
+	if err := os.WriteFile(configPath, []byte(legacy), 0o644); err != nil {
+		t.Fatalf("WriteFile(opencode.json) error = %v", err)
+	}
+
+	_, err := Inject(home, adapter)
+	if err != nil {
+		t.Fatalf("Inject() error = %v", err)
+	}
+
+	assertOpenCodeRemoteContext7Schema(t, configPath)
+
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("ReadFile(opencode.json) error = %v", err)
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal(content, &parsed); err != nil {
+		t.Fatalf("Unmarshal(opencode.json) error = %v", err)
+	}
+
+	mcp, ok := parsed["mcp"].(map[string]any)
+	if !ok {
+		t.Fatalf("opencode.json missing object key mcp; got %#v", parsed["mcp"])
+	}
+
+	engram, ok := mcp["engram"].(map[string]any)
+	if !ok {
+		t.Fatalf("opencode.json mcp.engram missing after inject; got %#v", mcp["engram"])
+	}
+	if engram["type"] != "local" {
+		t.Fatalf("mcp.engram.type = %#v; want %q", engram["type"], "local")
+	}
+	cmd, _ := engram["command"].([]any)
+	if len(cmd) == 0 || cmd[0] != "engram-server" {
+		t.Fatalf("mcp.engram.command = %#v; want [engram-server ...]", engram["command"])
 	}
 }
 
@@ -267,6 +557,48 @@ func TestInjectVSCodeWritesContext7ToMCPConfigFile(t *testing.T) {
 	}
 }
 
+func TestInjectAntigravityReplacesLegacyContext7LocalConfig(t *testing.T) {
+	home := t.TempDir()
+	adapter := antigravityAdapter()
+	configPath := adapter.MCPConfigPath(home, "context7")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll error = %v", err)
+	}
+
+	legacy := `{
+	  "mcpServers": {
+	    "context7": {
+	      "command": "npx",
+	      "args": ["-y", "@upstash/context7-mcp"],
+	      "env": {"TOKEN": "x"}
+	    }
+	  }
+	}`
+	if err := os.WriteFile(configPath, []byte(legacy), 0o644); err != nil {
+		t.Fatalf("WriteFile(mcp_config.json) error = %v", err)
+	}
+
+	first, err := Inject(home, adapter)
+	if err != nil {
+		t.Fatalf("Inject() first error = %v", err)
+	}
+	if !first.Changed {
+		t.Fatalf("Inject() first changed = false; expected migration to rewrite legacy context7")
+	}
+
+	assertAntigravityContext7Schema(t, configPath)
+
+	second, err := Inject(home, adapter)
+	if err != nil {
+		t.Fatalf("Inject() second error = %v", err)
+	}
+	if second.Changed {
+		t.Fatalf("Inject() second changed = true; expected idempotent context7 rewrite")
+	}
+
+	assertAntigravityContext7Schema(t, configPath)
+}
+
 func TestInjectKimiWritesContext7ToMCPConfigFile(t *testing.T) {
 	home := t.TempDir()
 
@@ -305,4 +637,46 @@ func TestInjectKimiWritesContext7ToMCPConfigFile(t *testing.T) {
 	if !strings.Contains(text, `"url": "https://mcp.context7.com/mcp"`) {
 		t.Fatal("kimi mcp.json should use the documented remote MCP URL for context7")
 	}
+}
+
+func TestInjectKimiReplacesLegacyContext7LocalConfig(t *testing.T) {
+	home := t.TempDir()
+	adapter := kimiAdapter()
+	configPath := adapter.MCPConfigPath(home, "context7")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll error = %v", err)
+	}
+
+	legacy := `{
+	  "mcpServers": {
+	    "context7": {
+	      "command": "npx",
+	      "args": ["-y", "@upstash/context7-mcp"],
+	      "env": {"TOKEN": "x"}
+	    }
+	  }
+	}`
+	if err := os.WriteFile(configPath, []byte(legacy), 0o644); err != nil {
+		t.Fatalf("WriteFile(kimi mcp.json) error = %v", err)
+	}
+
+	first, err := Inject(home, adapter)
+	if err != nil {
+		t.Fatalf("Inject(kimi) first error = %v", err)
+	}
+	if !first.Changed {
+		t.Fatalf("Inject(kimi) first changed = false; expected migration to rewrite legacy context7")
+	}
+
+	assertKimiContext7Schema(t, configPath)
+
+	second, err := Inject(home, adapter)
+	if err != nil {
+		t.Fatalf("Inject(kimi) second error = %v", err)
+	}
+	if second.Changed {
+		t.Fatalf("Inject(kimi) second changed = true; expected idempotent context7 rewrite")
+	}
+
+	assertKimiContext7Schema(t, configPath)
 }


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #57

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Replaces managed Context7 MCP entries atomically so stale local fields cannot survive deep merges.
- Fixes OpenCode/KiloCode upgrade paths where legacy `mcp.context7` fields like `command`, `args`, or `env` break strict schema validation.
- Adds regression coverage for idempotent migration and sibling MCP entry preservation.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/components/mcp/context7.go` | Wraps managed Context7 overlay entries in `__replace__`, including OpenCode/KiloCode strict-schema config. |
| `internal/components/mcp/inject_test.go` | Adds structured regression tests for OpenCode/KiloCode stale field replacement, idempotency, and managed Context7 entries. |

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./internal/components/mcp ./internal/components/filemerge ./internal/components/engram
go test ./...
```

**E2E Tests**
```bash
cd e2e && ./docker-test.sh
```

- [x] Unit tests pass (`go test ./...`)
- [x] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Manually tested locally

Additional local verification used Fedora Podman as a Docker-compatible shim:

```bash
docker(){ podman "$@"; }; export -f docker; cd e2e && ./docker-test.sh
```

Result: Ubuntu, Arch, and Fedora E2E platforms passed (`PASSED 3/3`).

---

## 🤖 Automated Checks

The following checks run automatically on this PR:

| Check | Status | Description |
|-------|--------|-------------|
| Check Issue Reference | ⏳ | PR body must contain `Closes/Fixes/Resolves #N` |
| Check Issue Has `status:approved` | ⏳ | Linked issue must have been approved before work began |
| Check PR Has `type:*` Label | ⏳ | Exactly one `type:*` label must be applied |
| Unit Tests | ⏳ | `go test ./...` must pass |
| E2E Tests | ⏳ | `cd e2e && ./docker-test.sh` must pass |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] Maintainer needs to add the `type:bug` label
- [x] Unit tests pass (`go test ./...`)
- [x] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

This keeps the existing deep-merge behavior globally and uses the repository's existing `__replace__` sentinel only for managed Context7 server entries. That preserves unrelated user MCP entries while preventing stale fields from contaminating OpenCode/KiloCode's strict `mcp.context7` schema.

Because this PR is opened from a fork, I cannot add labels to the upstream PR. Maintainer action needed: please add `type:bug`.