### PR TITLE
fix(skill-creator): do not hardcode author in template and docs

### DIFF
--- a/internal/assets/skills/skill-creator/SKILL.md
+++ b/internal/assets/skills/skill-creator/SKILL.md
@@ -49,7 +49,7 @@ description: >
   Trigger: {When the AI should load this skill}.
 license: Apache-2.0
 metadata:
-  author: gentleman-programming
+  author: "{your-github-username}"
   version: "1.0"
 ---
 
@@ -111,7 +111,7 @@ Link to external guides?    → references/ (with local path)
 | `name` | Yes | Skill identifier (lowercase, hyphens) |
 | `description` | Yes | What + Trigger in one block |
 | `license` | Yes | Always `Apache-2.0` |
-| `metadata.author` | Yes | `gentleman-programming` |
+| `metadata.author` | Yes | Author's GitHub username — infer from `git config user.name` or ask the user. Do NOT hardcode. |
 | `metadata.version` | Yes | Semantic version as string |
 
 ---

--- a/internal/assets/skills/skill-creator/SKILL.md
+++ b/internal/assets/skills/skill-creator/SKILL.md
@@ -58,7 +58,7 @@ name: {skill-name}
 description: "Trigger: {essential trigger words users or agents will say}. {What this skill does}."
 license: Apache-2.0
 metadata:
-  author: gentleman-programming
+  author: "{your-github-username}"
   version: "1.0"
 ---
 ```

--- a/testdata/golden/skills-claude-skill-creator.golden
+++ b/testdata/golden/skills-claude-skill-creator.golden
@@ -49,7 +49,7 @@ description: >
   Trigger: {When the AI should load this skill}.
 license: Apache-2.0
 metadata:
-  author: gentleman-programming
+  author: "{your-github-username}"
   version: "1.0"
 ---
 
@@ -111,7 +111,7 @@ Link to external guides?    → references/ (with local path)
 | `name` | Yes | Skill identifier (lowercase, hyphens) |
 | `description` | Yes | What + Trigger in one block |
 | `license` | Yes | Always `Apache-2.0` |
-| `metadata.author` | Yes | `gentleman-programming` |
+| `metadata.author` | Yes | Author's GitHub username — infer from `git config user.name` or ask the user. Do NOT hardcode. |
 | `metadata.version` | Yes | Semantic version as string |
 
 ---

--- a/testdata/golden/skills-claude-skill-creator.golden
+++ b/testdata/golden/skills-claude-skill-creator.golden
@@ -58,7 +58,7 @@ name: {skill-name}
 description: "Trigger: {essential trigger words users or agents will say}. {What this skill does}."
 license: Apache-2.0
 metadata:
-  author: gentleman-programming
+  author: "{your-github-username}"
   version: "1.0"
 ---
 ```

--- a/testdata/golden/skills-kiro-skill-creator.golden
+++ b/testdata/golden/skills-kiro-skill-creator.golden
@@ -49,7 +49,7 @@ description: >
   Trigger: {When the AI should load this skill}.
 license: Apache-2.0
 metadata:
-  author: gentleman-programming
+  author: "{your-github-username}"
   version: "1.0"
 ---
 
@@ -111,7 +111,7 @@ Link to external guides?    → references/ (with local path)
 | `name` | Yes | Skill identifier (lowercase, hyphens) |
 | `description` | Yes | What + Trigger in one block |
 | `license` | Yes | Always `Apache-2.0` |
-| `metadata.author` | Yes | `gentleman-programming` |
+| `metadata.author` | Yes | Author's GitHub username — infer from `git config user.name` or ask the user. Do NOT hardcode. |
 | `metadata.version` | Yes | Semantic version as string |
 
 ---

--- a/testdata/golden/skills-kiro-skill-creator.golden
+++ b/testdata/golden/skills-kiro-skill-creator.golden
@@ -58,7 +58,7 @@ name: {skill-name}
 description: "Trigger: {essential trigger words users or agents will say}. {What this skill does}."
 license: Apache-2.0
 metadata:
-  author: gentleman-programming
+  author: "{your-github-username}"
   version: "1.0"
 ---
 ```

--- a/testdata/golden/skills-opencode-skill-creator.golden
+++ b/testdata/golden/skills-opencode-skill-creator.golden
@@ -49,7 +49,7 @@ description: >
   Trigger: {When the AI should load this skill}.
 license: Apache-2.0
 metadata:
-  author: gentleman-programming
+  author: "{your-github-username}"
   version: "1.0"
 ---
 
@@ -111,7 +111,7 @@ Link to external guides?    → references/ (with local path)
 | `name` | Yes | Skill identifier (lowercase, hyphens) |
 | `description` | Yes | What + Trigger in one block |
 | `license` | Yes | Always `Apache-2.0` |
-| `metadata.author` | Yes | `gentleman-programming` |
+| `metadata.author` | Yes | Author's GitHub username — infer from `git config user.name` or ask the user. Do NOT hardcode. |
 | `metadata.version` | Yes | Semantic version as string |
 
 ---

--- a/testdata/golden/skills-opencode-skill-creator.golden
+++ b/testdata/golden/skills-opencode-skill-creator.golden
@@ -58,7 +58,7 @@ name: {skill-name}
 description: "Trigger: {essential trigger words users or agents will say}. {What this skill does}."
 license: Apache-2.0
 metadata:
-  author: gentleman-programming
+  author: "{your-github-username}"
   version: "1.0"
 ---
 ```

--- a/testdata/golden/skills-windsurf-skill-creator.golden
+++ b/testdata/golden/skills-windsurf-skill-creator.golden
@@ -49,7 +49,7 @@ description: >
   Trigger: {When the AI should load this skill}.
 license: Apache-2.0
 metadata:
-  author: gentleman-programming
+  author: "{your-github-username}"
   version: "1.0"
 ---
 
@@ -111,7 +111,7 @@ Link to external guides?    → references/ (with local path)
 | `name` | Yes | Skill identifier (lowercase, hyphens) |
 | `description` | Yes | What + Trigger in one block |
 | `license` | Yes | Always `Apache-2.0` |
-| `metadata.author` | Yes | `gentleman-programming` |
+| `metadata.author` | Yes | Author's GitHub username — infer from `git config user.name` or ask the user. Do NOT hardcode. |
 | `metadata.version` | Yes | Semantic version as string |
 
 ---

--- a/testdata/golden/skills-windsurf-skill-creator.golden
+++ b/testdata/golden/skills-windsurf-skill-creator.golden
@@ -58,7 +58,7 @@ name: {skill-name}
 description: "Trigger: {essential trigger words users or agents will say}. {What this skill does}."
 license: Apache-2.0
 metadata:
-  author: gentleman-programming
+  author: "{your-github-username}"
   version: "1.0"
 ---
 ```


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #98

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)

## 📝 Summary

The `skill-creator` SKILL.md template and the Frontmatter Fields documentation table both hardcoded `metadata.author: gentleman-programming`. As a result, every skill generated by the AI through this skill inherited the wrong author. The reporter mentioned 17 skills mis-attributed before noticing.

Following your approval comment (use a placeholder or read from `git config user.name`):

- **Template** (line ~49): `author: gentleman-programming` → `author: "{your-github-username}"`
- **Docs table** (line ~111): value row replaced with an instruction for the AI to infer the author from `git config user.name` or ask the user — never hardcode
- Associated golden snapshots for Claude, OpenCode, Windsurf, and Kiro are updated to reflect the asset change

## 🏛️ Architectural decision (pinged you in the issue)

The issue lists 3 locations. This PR touches **2** (template + docs table) and intentionally keeps the skill-creator's own frontmatter (line ~8) as `author: gentleman-programming`, because the skill-creator IS your official skill — changing it to a placeholder would be false. The bug is that GENERATED skills inherit the wrong author, not the upstream skill itself.

Asked you in the [issue comment](https://github.com/Gentleman-Programming/gentle-ai/issues/98#issuecomment-4311515317) to confirm this reading. Happy to extend to the 3rd location if you prefer.

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/assets/skills/skill-creator/SKILL.md` | Template placeholder + docs row replaced |
| `testdata/golden/skills-claude-skill-creator.golden` | Mirror of asset change |
| `testdata/golden/skills-opencode-skill-creator.golden` | Mirror of asset change |
| `testdata/golden/skills-windsurf-skill-creator.golden` | Mirror of asset change |
| `testdata/golden/skills-kiro-skill-creator.golden` | Mirror of asset change |

Total: 5 files, +10/-10 lines.

## 🧪 Test Plan

**Unit Tests (ran locally)**
```bash
go test ./internal/components/ -run TestGoldenSkills
```

- [x] `TestGoldenSkills_Claude` — PASS
- [x] `TestGoldenSkills_OpenCode` — PASS
- [x] `TestGoldenSkills_Windsurf` — PASS
- [x] `TestGoldenSkills_Kiro` — PASS
- [x] `go vet ./...` clean on touched packages

**E2E Tests** (Docker required)
```bash
Not run
```

**Pre-existing Windows unit test failures (NOT introduced by this PR)**: `TestSkillPathForAgent` (path separator), `TestGoldenEngram_Antigravity` (snapshot drift on main), and several `TestInjectOpenCode*` tests requiring `bun add unique-names-generator` in test temp dirs. Verified these fail identically on a clean `origin/main` checkout.

## ✅ Contributor Checklist

- [x] PR is linked to an approved issue (#98, `status:approved`)
- [x] Unit tests pass for the affected tests (4/4 skill-creator golden snapshots)
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers
- [x] Branch name matches required regex

## ⏳ Pending maintainer actions

- Apply `type:bug` label to this PR (contributor cannot self-apply; CI validation blocks merge until then)
- Confirm the 2-vs-3-locations architectural decision in the [issue comment](https://github.com/Gentleman-Programming/gentle-ai/issues/98#issuecomment-4311515317)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the skill creator template to use a customizable placeholder for the author metadata field, making it clearer which values require personalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->