### PR TITLE
fix(sdd): parse model spec at first separator and consolidate duplicated parsers

### DIFF
--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -241,22 +241,9 @@ func parseProfilePhaseFlag(raw string) (name, phase string, assignment model.Mod
 // parseModelSpec parses a "provider/model" or "provider:model" string into a
 // ModelAssignment. Returns an error if the spec is empty or has no separator.
 func parseModelSpec(spec string) (model.ModelAssignment, error) {
-	// Try slash separator first (common CLI format: anthropic/claude-haiku-3-5),
-	// then colon (opencode internal format: anthropic:claude-haiku-3-5).
-	sep := -1
-	for i, c := range spec {
-		if c == '/' || c == ':' {
-			sep = i
-			break
-		}
-	}
-	if sep <= 0 {
+	providerID, modelID, ok := model.SplitProviderModel(spec)
+	if !ok {
 		return model.ModelAssignment{}, fmt.Errorf("invalid model spec %q: expected provider/model or provider:model", spec)
-	}
-	providerID := spec[:sep]
-	modelID := spec[sep+1:]
-	if providerID == "" || modelID == "" {
-		return model.ModelAssignment{}, fmt.Errorf("invalid model spec %q: provider and model must both be non-empty", spec)
 	}
 	return model.ModelAssignment{ProviderID: providerID, ModelID: modelID}, nil
 }

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -248,22 +248,9 @@ func parseProfilePhaseFlag(raw string) (name, phase string, assignment model.Mod
 // parseModelSpec parses a "provider/model" or "provider:model" string into a
 // ModelAssignment. Returns an error if the spec is empty or has no separator.
 func parseModelSpec(spec string) (model.ModelAssignment, error) {
-	// Try slash separator first (common CLI format: anthropic/claude-haiku-3-5),
-	// then colon (opencode internal format: anthropic:claude-haiku-3-5).
-	sep := -1
-	for i, c := range spec {
-		if c == '/' || c == ':' {
-			sep = i
-			break
-		}
-	}
-	if sep <= 0 {
+	providerID, modelID, ok := model.SplitProviderModel(spec)
+	if !ok {
 		return model.ModelAssignment{}, fmt.Errorf("invalid model spec %q: expected provider/model or provider:model", spec)
-	}
-	providerID := spec[:sep]
-	modelID := spec[sep+1:]
-	if providerID == "" || modelID == "" {
-		return model.ModelAssignment{}, fmt.Errorf("invalid model spec %q: provider and model must both be non-empty", spec)
 	}
 	return model.ModelAssignment{ProviderID: providerID, ModelID: modelID}, nil
 }

--- a/internal/components/sdd/profiles.go
+++ b/internal/components/sdd/profiles.go
@@ -205,23 +205,8 @@ func extractModelFromAgent(agentMap map[string]any) model.ModelAssignment {
 	if modelStr == "" {
 		return model.ModelAssignment{}
 	}
-
-	// Find the FIRST occurrence of either '/' or ':' (whichever comes first).
-	// This correctly handles OpenRouter free models like "openrouter/qwen/qwen3.6-plus:free"
-	// where the provider is "openrouter" and the model is "qwen/qwen3.6-plus:free".
-	idx := -1
-	for i, c := range modelStr {
-		if c == '/' || c == ':' {
-			idx = i
-			break
-		}
-	}
-	if idx <= 0 {
-		return model.ModelAssignment{}
-	}
-	providerID := modelStr[:idx]
-	modelID := modelStr[idx+1:]
-	if modelID == "" {
+	providerID, modelID, ok := model.SplitProviderModel(modelStr)
+	if !ok {
 		return model.ModelAssignment{}
 	}
 	return model.ModelAssignment{ProviderID: providerID, ModelID: modelID}

--- a/internal/components/sdd/profiles.go
+++ b/internal/components/sdd/profiles.go
@@ -206,10 +206,15 @@ func extractModelFromAgent(agentMap map[string]any) model.ModelAssignment {
 		return model.ModelAssignment{}
 	}
 
-	// Try colon separator first (standard: "anthropic:claude-sonnet-4"), then slash.
-	idx := strings.Index(modelStr, ":")
-	if idx <= 0 {
-		idx = strings.Index(modelStr, "/")
+	// Find the FIRST occurrence of either '/' or ':' (whichever comes first).
+	// This correctly handles OpenRouter free models like "openrouter/qwen/qwen3.6-plus:free"
+	// where the provider is "openrouter" and the model is "qwen/qwen3.6-plus:free".
+	idx := -1
+	for i, c := range modelStr {
+		if c == '/' || c == ':' {
+			idx = i
+			break
+		}
 	}
 	if idx <= 0 {
 		return model.ModelAssignment{}

--- a/internal/components/sdd/profiles.go
+++ b/internal/components/sdd/profiles.go
@@ -215,23 +215,8 @@ func extractModelFromAgent(agentMap map[string]any) model.ModelAssignment {
 	if modelStr == "" {
 		return model.ModelAssignment{}
 	}
-
-	// Find the FIRST occurrence of either '/' or ':' (whichever comes first).
-	// This correctly handles OpenRouter free models like "openrouter/qwen/qwen3.6-plus:free"
-	// where the provider is "openrouter" and the model is "qwen/qwen3.6-plus:free".
-	idx := -1
-	for i, c := range modelStr {
-		if c == '/' || c == ':' {
-			idx = i
-			break
-		}
-	}
-	if idx <= 0 {
-		return model.ModelAssignment{}
-	}
-	providerID := modelStr[:idx]
-	modelID := modelStr[idx+1:]
-	if modelID == "" {
+	providerID, modelID, ok := model.SplitProviderModel(modelStr)
+	if !ok {
 		return model.ModelAssignment{}
 	}
 	effort, _ := agentMap["variant"].(string)

--- a/internal/components/sdd/profiles.go
+++ b/internal/components/sdd/profiles.go
@@ -216,10 +216,15 @@ func extractModelFromAgent(agentMap map[string]any) model.ModelAssignment {
 		return model.ModelAssignment{}
 	}
 
-	// Try colon separator first (standard: "anthropic:claude-sonnet-4"), then slash.
-	idx := strings.Index(modelStr, ":")
-	if idx <= 0 {
-		idx = strings.Index(modelStr, "/")
+	// Find the FIRST occurrence of either '/' or ':' (whichever comes first).
+	// This correctly handles OpenRouter free models like "openrouter/qwen/qwen3.6-plus:free"
+	// where the provider is "openrouter" and the model is "qwen/qwen3.6-plus:free".
+	idx := -1
+	for i, c := range modelStr {
+		if c == '/' || c == ':' {
+			idx = i
+			break
+		}
 	}
 	if idx <= 0 {
 		return model.ModelAssignment{}

--- a/internal/components/sdd/profiles_test.go
+++ b/internal/components/sdd/profiles_test.go
@@ -724,6 +724,75 @@ func TestRemoveProfileAgents_CannotRemoveDefaultByName(t *testing.T) {
 	}
 }
 
+// TestExtractModelFromAgent covers the model-spec parsing path used by
+// DetectProfiles. Includes regression coverage for issue #260: OpenRouter
+// free models such as "openrouter/qwen/qwen3.6-plus:free" must split at the
+// first separator (the leading '/'), not at ':'.
+func TestExtractModelFromAgent(t *testing.T) {
+	tests := []struct {
+		name     string
+		agentMap map[string]any
+		want     model.ModelAssignment
+	}{
+		{
+			name:     "nil map",
+			agentMap: nil,
+			want:     model.ModelAssignment{},
+		},
+		{
+			name:     "missing model field",
+			agentMap: map[string]any{"prompt": "hello"},
+			want:     model.ModelAssignment{},
+		},
+		{
+			name:     "model field not a string",
+			agentMap: map[string]any{"model": 42},
+			want:     model.ModelAssignment{},
+		},
+		{
+			name:     "empty model string",
+			agentMap: map[string]any{"model": ""},
+			want:     model.ModelAssignment{},
+		},
+		{
+			name:     "model with no separator",
+			agentMap: map[string]any{"model": "no-separator-here"},
+			want:     model.ModelAssignment{},
+		},
+		{
+			name:     "colon separator",
+			agentMap: map[string]any{"model": "anthropic:claude-sonnet-4-20250514"},
+			want:     model.ModelAssignment{ProviderID: "anthropic", ModelID: "claude-sonnet-4-20250514"},
+		},
+		{
+			name:     "slash separator",
+			agentMap: map[string]any{"model": "zai-coding-plan/glm-5-turbo"},
+			want:     model.ModelAssignment{ProviderID: "zai-coding-plan", ModelID: "glm-5-turbo"},
+		},
+		// Regression #260: OpenRouter free models contain both '/' and ':'.
+		// Must split at the first '/' so the colon stays inside the modelID.
+		{
+			name:     "openrouter free suffix",
+			agentMap: map[string]any{"model": "openrouter/qwen/qwen3.6-plus:free"},
+			want:     model.ModelAssignment{ProviderID: "openrouter", ModelID: "qwen/qwen3.6-plus:free"},
+		},
+		{
+			name:     "openrouter paid with multiple slashes",
+			agentMap: map[string]any{"model": "openrouter/anthropic/claude-sonnet-4"},
+			want:     model.ModelAssignment{ProviderID: "openrouter", ModelID: "anthropic/claude-sonnet-4"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractModelFromAgent(tt.agentMap)
+			if got != tt.want {
+				t.Errorf("extractModelFromAgent() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
 // helper
 func keysOf(m map[string]any) []string {
 	keys := make([]string, 0, len(m))

--- a/internal/components/sdd/profiles_test.go
+++ b/internal/components/sdd/profiles_test.go
@@ -734,6 +734,75 @@ func TestRemoveProfileAgents_CannotRemoveDefaultByName(t *testing.T) {
 	}
 }
 
+// TestExtractModelFromAgent covers the model-spec parsing path used by
+// DetectProfiles. Includes regression coverage for issue #260: OpenRouter
+// free models such as "openrouter/qwen/qwen3.6-plus:free" must split at the
+// first separator (the leading '/'), not at ':'.
+func TestExtractModelFromAgent(t *testing.T) {
+	tests := []struct {
+		name     string
+		agentMap map[string]any
+		want     model.ModelAssignment
+	}{
+		{
+			name:     "nil map",
+			agentMap: nil,
+			want:     model.ModelAssignment{},
+		},
+		{
+			name:     "missing model field",
+			agentMap: map[string]any{"prompt": "hello"},
+			want:     model.ModelAssignment{},
+		},
+		{
+			name:     "model field not a string",
+			agentMap: map[string]any{"model": 42},
+			want:     model.ModelAssignment{},
+		},
+		{
+			name:     "empty model string",
+			agentMap: map[string]any{"model": ""},
+			want:     model.ModelAssignment{},
+		},
+		{
+			name:     "model with no separator",
+			agentMap: map[string]any{"model": "no-separator-here"},
+			want:     model.ModelAssignment{},
+		},
+		{
+			name:     "colon separator",
+			agentMap: map[string]any{"model": "anthropic:claude-sonnet-4-20250514"},
+			want:     model.ModelAssignment{ProviderID: "anthropic", ModelID: "claude-sonnet-4-20250514"},
+		},
+		{
+			name:     "slash separator",
+			agentMap: map[string]any{"model": "zai-coding-plan/glm-5-turbo"},
+			want:     model.ModelAssignment{ProviderID: "zai-coding-plan", ModelID: "glm-5-turbo"},
+		},
+		// Regression #260: OpenRouter free models contain both '/' and ':'.
+		// Must split at the first '/' so the colon stays inside the modelID.
+		{
+			name:     "openrouter free suffix",
+			agentMap: map[string]any{"model": "openrouter/qwen/qwen3.6-plus:free"},
+			want:     model.ModelAssignment{ProviderID: "openrouter", ModelID: "qwen/qwen3.6-plus:free"},
+		},
+		{
+			name:     "openrouter paid with multiple slashes",
+			agentMap: map[string]any{"model": "openrouter/anthropic/claude-sonnet-4"},
+			want:     model.ModelAssignment{ProviderID: "openrouter", ModelID: "anthropic/claude-sonnet-4"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractModelFromAgent(tt.agentMap)
+			if got != tt.want {
+				t.Errorf("extractModelFromAgent() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
 // helper
 func keysOf(m map[string]any) []string {
 	keys := make([]string, 0, len(m))

--- a/internal/components/sdd/read_assignments.go
+++ b/internal/components/sdd/read_assignments.go
@@ -3,7 +3,6 @@ package sdd
 import (
 	"encoding/json"
 	"os"
-	"strings"
 
 	"github.com/gentleman-programming/gentle-ai/internal/model"
 	"github.com/gentleman-programming/gentle-ai/internal/opencode"
@@ -77,11 +76,15 @@ func ReadCurrentModelAssignments(settingsPath string) (map[string]model.ModelAss
 		if !ok || modelStr == "" {
 			continue
 		}
-		// Try colon first (standard: "anthropic:claude-sonnet-4"), then slash
-		// ("zai-coding-plan/glm-5-turbo") for custom providers (issue #152).
-		idx := strings.Index(modelStr, ":")
-		if idx <= 0 {
-			idx = strings.Index(modelStr, "/")
+		// Find the FIRST occurrence of either '/' or ':' (whichever comes first).
+		// This correctly handles OpenRouter free models like "openrouter/qwen/qwen3.6-plus:free"
+		// where the provider is "openrouter" and the model is "qwen/qwen3.6-plus:free".
+		idx := -1
+		for i, c := range modelStr {
+			if c == '/' || c == ':' {
+				idx = i
+				break
+			}
 		}
 		if idx <= 0 {
 			// No separator or separator is the first character — skip malformed value.

--- a/internal/components/sdd/read_assignments.go
+++ b/internal/components/sdd/read_assignments.go
@@ -76,23 +76,8 @@ func ReadCurrentModelAssignments(settingsPath string) (map[string]model.ModelAss
 		if !ok || modelStr == "" {
 			continue
 		}
-		// Find the FIRST occurrence of either '/' or ':' (whichever comes first).
-		// This correctly handles OpenRouter free models like "openrouter/qwen/qwen3.6-plus:free"
-		// where the provider is "openrouter" and the model is "qwen/qwen3.6-plus:free".
-		idx := -1
-		for i, c := range modelStr {
-			if c == '/' || c == ':' {
-				idx = i
-				break
-			}
-		}
-		if idx <= 0 {
-			// No separator or separator is the first character — skip malformed value.
-			continue
-		}
-		providerID := modelStr[:idx]
-		modelID := modelStr[idx+1:]
-		if modelID == "" {
+		providerID, modelID, ok := model.SplitProviderModel(modelStr)
+		if !ok {
 			continue
 		}
 		result[name] = model.ModelAssignment{

--- a/internal/components/sdd/read_assignments.go
+++ b/internal/components/sdd/read_assignments.go
@@ -78,23 +78,8 @@ func ReadCurrentModelAssignments(settingsPath string) (map[string]model.ModelAss
 		if !ok || modelStr == "" {
 			continue
 		}
-		// Find the FIRST occurrence of either '/' or ':' (whichever comes first).
-		// This correctly handles OpenRouter free models like "openrouter/qwen/qwen3.6-plus:free"
-		// where the provider is "openrouter" and the model is "qwen/qwen3.6-plus:free".
-		idx := -1
-		for i, c := range modelStr {
-			if c == '/' || c == ':' {
-				idx = i
-				break
-			}
-		}
-		if idx <= 0 {
-			// No separator or separator is the first character — skip malformed value.
-			continue
-		}
-		providerID := modelStr[:idx]
-		modelID := modelStr[idx+1:]
-		if modelID == "" {
+		providerID, modelID, ok := model.SplitProviderModel(modelStr)
+		if !ok {
 			continue
 		}
 		assignmentKey := name

--- a/internal/components/sdd/read_assignments.go
+++ b/internal/components/sdd/read_assignments.go
@@ -3,7 +3,6 @@ package sdd
 import (
 	"encoding/json"
 	"os"
-	"strings"
 
 	"github.com/gentleman-programming/gentle-ai/internal/model"
 	"github.com/gentleman-programming/gentle-ai/internal/opencode"
@@ -79,11 +78,15 @@ func ReadCurrentModelAssignments(settingsPath string) (map[string]model.ModelAss
 		if !ok || modelStr == "" {
 			continue
 		}
-		// Try colon first (standard: "anthropic:claude-sonnet-4"), then slash
-		// ("zai-coding-plan/glm-5-turbo") for custom providers (issue #152).
-		idx := strings.Index(modelStr, ":")
-		if idx <= 0 {
-			idx = strings.Index(modelStr, "/")
+		// Find the FIRST occurrence of either '/' or ':' (whichever comes first).
+		// This correctly handles OpenRouter free models like "openrouter/qwen/qwen3.6-plus:free"
+		// where the provider is "openrouter" and the model is "qwen/qwen3.6-plus:free".
+		idx := -1
+		for i, c := range modelStr {
+			if c == '/' || c == ':' {
+				idx = i
+				break
+			}
 		}
 		if idx <= 0 {
 			// No separator or separator is the first character — skip malformed value.

--- a/internal/components/sdd/read_assignments_test.go
+++ b/internal/components/sdd/read_assignments_test.go
@@ -237,3 +237,53 @@ func TestReadCurrentModelAssignmentsMixedSeparators(t *testing.T) {
 		}
 	}
 }
+
+// TestReadCurrentModelAssignmentsOpenRouterFreeSuffix is a regression test
+// for issue #260: OpenRouter free models have the form
+// "openrouter/qwen/qwen3.6-plus:free" — they contain BOTH '/' and ':'.
+// The parser must split on the FIRST separator (the leading '/'), producing
+// providerID="openrouter" and modelID="qwen/qwen3.6-plus:free". Splitting
+// on ':' first would mis-attribute "openrouter/qwen/qwen3.6-plus" to the
+// provider, which breaks OpenCode model resolution.
+func TestReadCurrentModelAssignmentsOpenRouterFreeSuffix(t *testing.T) {
+	dir := t.TempDir()
+	settingsPath := filepath.Join(dir, "opencode.json")
+
+	content := `{
+  "agent": {
+    "sdd-orchestrator": { "model": "openrouter/qwen/qwen3.6-plus:free" },
+    "sdd-apply":        { "model": "openrouter/anthropic/claude-sonnet-4" }
+  }
+}`
+	if err := os.WriteFile(settingsPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write settings: %v", err)
+	}
+
+	got, err := ReadCurrentModelAssignments(settingsPath)
+	if err != nil {
+		t.Fatalf("ReadCurrentModelAssignments() error = %v", err)
+	}
+
+	tests := []struct {
+		phase      string
+		providerID string
+		modelID    string
+	}{
+		{"sdd-orchestrator", "openrouter", "qwen/qwen3.6-plus:free"},
+		{"sdd-apply", "openrouter", "anthropic/claude-sonnet-4"},
+	}
+
+	for _, tt := range tests {
+		a, ok := got[tt.phase]
+		if !ok {
+			t.Errorf("phase %q missing from result", tt.phase)
+			continue
+		}
+		if a.ProviderID != tt.providerID {
+			t.Errorf("phase %q: ProviderID = %q, want %q", tt.phase, a.ProviderID, tt.providerID)
+		}
+		if a.ModelID != tt.modelID {
+			t.Errorf("phase %q: ModelID = %q, want %q", tt.phase, a.ModelID, tt.modelID)
+		}
+	}
+}

--- a/internal/components/sdd/read_assignments_test.go
+++ b/internal/components/sdd/read_assignments_test.go
@@ -305,6 +305,11 @@ func TestReadCurrentModelAssignmentsMixedSeparators(t *testing.T) {
 // providerID="openrouter" and modelID="qwen/qwen3.6-plus:free". Splitting
 // on ':' first would mis-attribute "openrouter/qwen/qwen3.6-plus" to the
 // provider, which breaks OpenCode model resolution.
+//
+// The fixture intentionally uses the legacy "sdd-orchestrator" key (the
+// real-world config shape from issue #260, before the user re-syncs) and
+// asserts the result lands under "gentle-orchestrator" — exercising both
+// the first-separator split and the legacy alias normalization together.
 func TestReadCurrentModelAssignmentsOpenRouterFreeSuffix(t *testing.T) {
 	dir := t.TempDir()
 	settingsPath := filepath.Join(dir, "opencode.json")
@@ -329,7 +334,8 @@ func TestReadCurrentModelAssignmentsOpenRouterFreeSuffix(t *testing.T) {
 		providerID string
 		modelID    string
 	}{
-		{"sdd-orchestrator", "openrouter", "qwen/qwen3.6-plus:free"},
+		// Legacy "sdd-orchestrator" fixture key normalizes to "gentle-orchestrator".
+		{"gentle-orchestrator", "openrouter", "qwen/qwen3.6-plus:free"},
 		{"sdd-apply", "openrouter", "anthropic/claude-sonnet-4"},
 	}
 

--- a/internal/components/sdd/read_assignments_test.go
+++ b/internal/components/sdd/read_assignments_test.go
@@ -297,3 +297,53 @@ func TestReadCurrentModelAssignmentsMixedSeparators(t *testing.T) {
 		}
 	}
 }
+
+// TestReadCurrentModelAssignmentsOpenRouterFreeSuffix is a regression test
+// for issue #260: OpenRouter free models have the form
+// "openrouter/qwen/qwen3.6-plus:free" — they contain BOTH '/' and ':'.
+// The parser must split on the FIRST separator (the leading '/'), producing
+// providerID="openrouter" and modelID="qwen/qwen3.6-plus:free". Splitting
+// on ':' first would mis-attribute "openrouter/qwen/qwen3.6-plus" to the
+// provider, which breaks OpenCode model resolution.
+func TestReadCurrentModelAssignmentsOpenRouterFreeSuffix(t *testing.T) {
+	dir := t.TempDir()
+	settingsPath := filepath.Join(dir, "opencode.json")
+
+	content := `{
+  "agent": {
+    "sdd-orchestrator": { "model": "openrouter/qwen/qwen3.6-plus:free" },
+    "sdd-apply":        { "model": "openrouter/anthropic/claude-sonnet-4" }
+  }
+}`
+	if err := os.WriteFile(settingsPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write settings: %v", err)
+	}
+
+	got, err := ReadCurrentModelAssignments(settingsPath)
+	if err != nil {
+		t.Fatalf("ReadCurrentModelAssignments() error = %v", err)
+	}
+
+	tests := []struct {
+		phase      string
+		providerID string
+		modelID    string
+	}{
+		{"sdd-orchestrator", "openrouter", "qwen/qwen3.6-plus:free"},
+		{"sdd-apply", "openrouter", "anthropic/claude-sonnet-4"},
+	}
+
+	for _, tt := range tests {
+		a, ok := got[tt.phase]
+		if !ok {
+			t.Errorf("phase %q missing from result", tt.phase)
+			continue
+		}
+		if a.ProviderID != tt.providerID {
+			t.Errorf("phase %q: ProviderID = %q, want %q", tt.phase, a.ProviderID, tt.providerID)
+		}
+		if a.ModelID != tt.modelID {
+			t.Errorf("phase %q: ModelID = %q, want %q", tt.phase, a.ModelID, tt.modelID)
+		}
+	}
+}

--- a/internal/model/split.go
+++ b/internal/model/split.go
@@ -1,0 +1,29 @@
+package model
+
+// SplitProviderModel splits a model spec string into its provider and model
+// components at the FIRST occurrence of '/' or ':'. Splitting on the first
+// separator correctly handles compound model identifiers such as OpenRouter
+// free models — e.g. "openrouter/qwen/qwen3.6-plus:free" is split into
+// providerID="openrouter" and modelID="qwen/qwen3.6-plus:free".
+//
+// Returns (providerID, modelID, true) when both parts are non-empty.
+// Returns ("", "", false) when the input is empty, has no separator, starts
+// with a separator, or has an empty model part.
+func SplitProviderModel(spec string) (providerID, modelID string, ok bool) {
+	sep := -1
+	for i, c := range spec {
+		if c == '/' || c == ':' {
+			sep = i
+			break
+		}
+	}
+	if sep <= 0 {
+		return "", "", false
+	}
+	providerID = spec[:sep]
+	modelID = spec[sep+1:]
+	if providerID == "" || modelID == "" {
+		return "", "", false
+	}
+	return providerID, modelID, true
+}

--- a/internal/model/split_test.go
+++ b/internal/model/split_test.go
@@ -1,0 +1,101 @@
+package model
+
+import "testing"
+
+func TestSplitProviderModel(t *testing.T) {
+	tests := []struct {
+		name       string
+		spec       string
+		wantProv   string
+		wantModel  string
+		wantOK     bool
+	}{
+		{
+			name:      "colon separator",
+			spec:      "anthropic:claude-sonnet-4-20250514",
+			wantProv:  "anthropic",
+			wantModel: "claude-sonnet-4-20250514",
+			wantOK:    true,
+		},
+		{
+			name:      "slash separator",
+			spec:      "zai-coding-plan/glm-5-turbo",
+			wantProv:  "zai-coding-plan",
+			wantModel: "glm-5-turbo",
+			wantOK:    true,
+		},
+		// Regression #260: OpenRouter free models contain BOTH '/' and ':'.
+		// The provider is the first segment; the rest (slashes and colons
+		// included) is the model. Splitting on ':' first would mis-attribute
+		// "openrouter/qwen/qwen3.6-plus" to the provider.
+		{
+			name:      "openrouter free suffix — slash before colon",
+			spec:      "openrouter/qwen/qwen3.6-plus:free",
+			wantProv:  "openrouter",
+			wantModel: "qwen/qwen3.6-plus:free",
+			wantOK:    true,
+		},
+		{
+			name:      "openrouter paid — multiple slashes, no colon",
+			spec:      "openrouter/anthropic/claude-sonnet-4",
+			wantProv:  "openrouter",
+			wantModel: "anthropic/claude-sonnet-4",
+			wantOK:    true,
+		},
+		{
+			name:      "colon appears before slash in model id",
+			spec:      "provider:model/variant",
+			wantProv:  "provider",
+			wantModel: "model/variant",
+			wantOK:    true,
+		},
+		{
+			name:   "empty spec",
+			spec:   "",
+			wantOK: false,
+		},
+		{
+			name:   "no separator",
+			spec:   "just-a-string",
+			wantOK: false,
+		},
+		{
+			name:   "leading slash",
+			spec:   "/model-id",
+			wantOK: false,
+		},
+		{
+			name:   "leading colon",
+			spec:   ":model-id",
+			wantOK: false,
+		},
+		{
+			name:   "trailing slash with empty model",
+			spec:   "provider/",
+			wantOK: false,
+		},
+		{
+			name:   "trailing colon with empty model",
+			spec:   "provider:",
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotProv, gotModel, gotOK := SplitProviderModel(tt.spec)
+			if gotOK != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", gotOK, tt.wantOK)
+			}
+			if !tt.wantOK {
+				return
+			}
+			if gotProv != tt.wantProv {
+				t.Errorf("providerID = %q, want %q", gotProv, tt.wantProv)
+			}
+			if gotModel != tt.wantModel {
+				t.Errorf("modelID = %q, want %q", gotModel, tt.wantModel)
+			}
+		})
+	}
+}

--- a/internal/model/split_test.go
+++ b/internal/model/split_test.go
@@ -4,11 +4,11 @@ import "testing"
 
 func TestSplitProviderModel(t *testing.T) {
 	tests := []struct {
-		name       string
-		spec       string
-		wantProv   string
-		wantModel  string
-		wantOK     bool
+		name      string
+		spec      string
+		wantProv  string
+		wantModel string
+		wantOK    bool
 	}{
 		{
 			name:      "colon separator",


### PR DESCRIPTION
<!-- ⚠️ READ BEFORE SUBMITTING
  Every PR must be linked to an issue that has the "status:approved" label.
  PRs without a linked approved issue will be automatically rejected by CI.
  See CONTRIBUTING.md for the full contribution workflow.
-->

## 🔗 Linked Issue

Closes #802 (read-path parse bug — scoped per review)

Refs #260 (the catalog/provider write path that produces the wrong prefix remains open there)

---

## 🔄 Continuation Notice

This PR **continues and supersedes #242** by @ACDPDEV, who explicitly handed off the work in https://github.com/Gentleman-Programming/gentle-ai/pull/242#issuecomment-4312507805 (university commitments prevented him from landing the review suggestions himself).

Full credit for the original fix goes to @ACDPDEV — his commit `28c3378` is preserved verbatim with original author metadata intact. This PR applies @Alan-TheGentleman's two review suggestions from #242 on top:

1. **Shared `SplitProviderModel` helper** — consolidates three identical copies of the first-separator logic. This matches @ACDPDEV's final ask in the handoff: *"abstraer lo que se repite en una función"*.
2. **Regression test for OpenRouter `/free` format** + dedicated coverage for `extractModelFromAgent`, which previously had no direct tests.

Once this PR lands, **#242 can be closed** — the full contribution (with review feedback applied) lives here.

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature`
- [ ] `type:docs`
- [ ] `type:refactor`
- [ ] `type:chore`
- [ ] `type:breaking-change`

---

## 📝 Summary

- Fixes OpenRouter free-model parsing where `openrouter/qwen/qwen3.6-plus:free` was split at `:` before the leading `/`, producing a broken `ProviderID=openrouter/qwen/qwen3.6-plus`, `ModelID=free`.
- Consolidates three identical copies of the provider/model split logic into a single exported `SplitProviderModel` helper in the `model` package.
- Adds regression coverage for the OpenRouter format and fills the coverage gap around `extractModelFromAgent`.

---

## 📂 Changes

| File / Area | What Changed |
|---|---|
| `internal/model/split.go` | **New**: exported `SplitProviderModel(spec) (provider, model, ok)` helper |
| `internal/model/split_test.go` | **New**: 11 cases including OpenRouter regression and malformed inputs |
| `internal/cli/sync.go` | `parseModelSpec` now delegates to the shared helper |
| `internal/components/sdd/profiles.go` | `extractModelFromAgent` now delegates to the shared helper |
| `internal/components/sdd/read_assignments.go` | Inline parser replaced with a call to the shared helper |
| `internal/components/sdd/profiles_test.go` | Adds `TestExtractModelFromAgent` — no previous coverage |
| `internal/components/sdd/read_assignments_test.go` | Adds `TestReadCurrentModelAssignmentsOpenRouterFreeSuffix` regression test |

Net: +255 / −41, 7 files. No behavior change in the happy path — existing `TestReadCurrentModelAssignments*` suite still passes unchanged.

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./internal/model/... ./internal/cli/... ./internal/components/sdd/...
```

**E2E Tests** (Docker required)
```bash
Not run
```

Pre-existing test failures in the Windows sandbox around `unique-names-generator` / `bun install` are unrelated to this PR — they're tracked in a separate PR (#372).

- [x] Unit tests pass on affected packages
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Parsing logic verified via new unit tests across edge cases

---

## 🤖 Automated Checks

| Check | Status | Description |
|-------|--------|-------------|
| Check Issue Reference | ⏳ | `Closes #802 (read-path parse bug — scoped per review)

Refs #260 (the catalog/provider write path that produces the wrong prefix remains open there)` |
| Check Issue Has `status:approved` | ⏳ | Verified: #260 carries `status:approved` |
| Check PR Has `type:*` Label | ⏳ | Requesting `type:bug` |
| Unit Tests | ⏳ | CI will validate |
| E2E Tests | ⏳ | CI matrix will validate |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved` (#260)
- [ ] I have added the appropriate `type:*` label to this PR (pending maintainer — external contributors cannot apply labels)
- [x] Unit tests pass
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

- **Original author preserved**: first commit (`28c3378`) is @ACDPDEV's verbatim, author metadata intact. GitHub should surface him as a co-contributor via commit history.
- Two new commits on top apply @Alan-TheGentleman's review from #242: `refactor(model): extract SplitProviderModel helper...` and `test(sdd): add OpenRouter free suffix regression coverage`.
- **Helper placement**: chose `internal/model` because `ModelAssignment` already lives there and both `cli` and `sdd` packages import it — zero import-cycle risk.
- **Closing #242**: once this lands, #242 is safe to close. Thanks to @ACDPDEV for the clean original fix and for trusting the continuation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized provider/model identifier parsing for consistent handling across the system.
  * Improved parsing robustness for complex and legacy model specification formats.

* **Tests**
  * Added unit and regression tests covering valid, invalid, and uncommon model identifier formats to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

