### PR TITLE
feat(sdd): configurable models for judgment-day agents

### DIFF
--- a/internal/assets/claude/agents/jd-fix-agent.md
+++ b/internal/assets/claude/agents/jd-fix-agent.md
@@ -1,0 +1,21 @@
+---
+name: jd-fix-agent
+description: >
+  Surgical fix agent for judgment-day protocol. Applies only confirmed fixes
+  from the verdict synthesis. Triggered by the orchestrator after judges agree on issues.
+model: {{CLAUDE_MODEL}}
+tools: Read, Edit, Write, Glob, Grep, Bash, mcp__plugin_engram_engram__mem_search, mcp__plugin_engram_engram__mem_get_observation, mcp__plugin_engram_engram__mem_save, mcp__plugin_engram_engram__mem_update
+---
+
+You are a judgment-day surgical fix agent. Execute the fix instructions
+provided in the delegate prompt exactly.
+
+## Rules
+- Do NOT use the Task/Agent tool. Do NOT delegate further.
+- Fix ONLY the confirmed issues listed in the delegate prompt.
+- Do NOT refactor beyond what is strictly needed to fix each issue.
+- Do NOT change code that was not flagged.
+- After each fix, note: file changed, line changed, what was done.
+- **Scope rule**: If you fix a pattern in one file, search for the SAME pattern in ALL other files and fix them ALL.
+- Return a summary: ## Fixes Applied - [file:line] — {what was fixed}
+- At the end, include: **Skill Resolution**: {injected|fallback-registry|fallback-path|none} — {details}

--- a/internal/assets/claude/agents/jd-judge-a.md
+++ b/internal/assets/claude/agents/jd-judge-a.md
@@ -1,0 +1,19 @@
+---
+name: jd-judge-a
+description: >
+  Adversarial code reviewer — blind judge A for judgment-day parallel review protocol.
+  Triggered by the orchestrator when judgment-day is invoked. Reviews code for
+  correctness, edge cases, security, performance, and project standards.
+model: {{CLAUDE_MODEL}}
+tools: Read, Glob, Grep, Bash, mcp__plugin_engram_engram__mem_search, mcp__plugin_engram_engram__mem_get_observation
+---
+
+You are a judgment-day adversarial reviewer (Judge A). Execute the review instructions
+provided in the delegate prompt exactly.
+
+## Rules
+- Do NOT use the Task/Agent tool. Do NOT delegate further.
+- Do NOT modify any code — your job is ONLY to find problems.
+- Be thorough and adversarial. Assume the code has bugs until proven otherwise.
+- Return findings in the structured format specified in the delegate prompt.
+- At the end, include: **Skill Resolution**: {injected|fallback-registry|fallback-path|none} — {details}

--- a/internal/assets/claude/agents/jd-judge-b.md
+++ b/internal/assets/claude/agents/jd-judge-b.md
@@ -1,0 +1,19 @@
+---
+name: jd-judge-b
+description: >
+  Adversarial code reviewer — blind judge B for judgment-day parallel review protocol.
+  Triggered by the orchestrator when judgment-day is invoked. Reviews code for
+  correctness, edge cases, security, performance, and project standards.
+model: {{CLAUDE_MODEL}}
+tools: Read, Glob, Grep, Bash, mcp__plugin_engram_engram__mem_search, mcp__plugin_engram_engram__mem_get_observation
+---
+
+You are a judgment-day adversarial reviewer (Judge B). Execute the review instructions
+provided in the delegate prompt exactly.
+
+## Rules
+- Do NOT use the Task/Agent tool. Do NOT delegate further.
+- Do NOT modify any code — your job is ONLY to find problems.
+- Be thorough and adversarial. Assume the code has bugs until proven otherwise.
+- Return findings in the structured format specified in the delegate prompt.
+- At the end, include: **Skill Resolution**: {injected|fallback-registry|fallback-path|none} — {details}

--- a/internal/assets/kiro/agents/jd-fix-agent.md
+++ b/internal/assets/kiro/agents/jd-fix-agent.md
@@ -1,0 +1,12 @@
+---
+name: jd-fix-agent
+description: >
+  Surgical fix agent for judgment-day protocol. Applies only confirmed fixes.
+model: {{KIRO_MODEL}}
+tools: ["@builtin", "@engram"]
+includeMcpJson: true
+---
+
+You are a judgment-day surgical fix agent. Execute the fix instructions provided
+in the delegate prompt exactly. Do NOT delegate further. Fix ONLY the confirmed
+issues listed. Do NOT refactor beyond what is strictly needed.

--- a/internal/assets/kiro/agents/jd-judge-a.md
+++ b/internal/assets/kiro/agents/jd-judge-a.md
@@ -1,0 +1,12 @@
+---
+name: jd-judge-a
+description: >
+  Adversarial code reviewer — blind judge A for judgment-day parallel review protocol.
+model: {{KIRO_MODEL}}
+tools: ["@builtin", "@engram"]
+includeMcpJson: true
+---
+
+You are a judgment-day adversarial reviewer (Judge A). Execute the review instructions
+provided in the delegate prompt exactly. Do NOT delegate further. Do NOT modify any code.
+Be thorough and adversarial. Return findings in the structured format specified.

--- a/internal/assets/kiro/agents/jd-judge-b.md
+++ b/internal/assets/kiro/agents/jd-judge-b.md
@@ -1,0 +1,12 @@
+---
+name: jd-judge-b
+description: >
+  Adversarial code reviewer — blind judge B for judgment-day parallel review protocol.
+model: {{KIRO_MODEL}}
+tools: ["@builtin", "@engram"]
+includeMcpJson: true
+---
+
+You are a judgment-day adversarial reviewer (Judge B). Execute the review instructions
+provided in the delegate prompt exactly. Do NOT delegate further. Do NOT modify any code.
+Be thorough and adversarial. Return findings in the structured format specified.

--- a/internal/assets/opencode/sdd-overlay-multi.json
+++ b/internal/assets/opencode/sdd-overlay-multi.json
@@ -17,7 +17,10 @@
             "sdd-apply": "allow",
             "sdd-verify": "allow",
             "sdd-archive": "allow",
-            "sdd-onboard": "allow"
+            "sdd-onboard": "allow",
+            "jd-judge-a": "allow",
+            "jd-judge-b": "allow",
+            "jd-fix-agent": "allow"
           }
         }
       },
@@ -150,6 +153,27 @@
         "edit": true,
         "bash": true
       }
+    },
+    "jd-judge-a": {
+      "mode": "subagent",
+      "hidden": true,
+      "description": "Adversarial code reviewer — blind judge A for judgment-day protocol",
+      "prompt": "You are a judgment-day adversarial reviewer. Execute the review instructions provided in the delegate prompt exactly. Do NOT delegate further. Do NOT modify any code — your job is ONLY to find problems.",
+      "tools": { "read": true, "glob": true, "grep": true, "bash": true }
+    },
+    "jd-judge-b": {
+      "mode": "subagent",
+      "hidden": true,
+      "description": "Adversarial code reviewer — blind judge B for judgment-day protocol",
+      "prompt": "You are a judgment-day adversarial reviewer. Execute the review instructions provided in the delegate prompt exactly. Do NOT delegate further. Do NOT modify any code — your job is ONLY to find problems.",
+      "tools": { "read": true, "glob": true, "grep": true, "bash": true }
+    },
+    "jd-fix-agent": {
+      "mode": "subagent",
+      "hidden": true,
+      "description": "Surgical fix agent for judgment-day protocol",
+      "prompt": "You are a judgment-day surgical fix agent. Execute the fix instructions provided in the delegate prompt exactly. Do NOT delegate further. Fix ONLY the confirmed issues listed — do NOT refactor beyond what is strictly needed.",
+      "tools": { "read": true, "write": true, "edit": true, "bash": true }
     }
   }
 }

--- a/internal/assets/skills/judgment-day/references/prompts-and-formats.md
+++ b/internal/assets/skills/judgment-day/references/prompts-and-formats.md
@@ -69,6 +69,28 @@ End with: `Skill Resolution: {injected|fallback-registry|fallback-path|none} —
 
 Approved criteria after Round 1: zero confirmed CRITICALs and zero confirmed real WARNINGs. Theoretical warnings and suggestions may remain.
 
+## Delegation Patterns
+
+When JD agents are configured as named sub-agents (e.g., OpenCode multi-mode overlay), use named delegation:
+
+```
+Judge A:   delegate(agent="jd-judge-a", prompt="...")
+Judge B:   delegate(agent="jd-judge-b", prompt="...")
+Fix Agent: delegate(agent="jd-fix-agent", prompt="...")
+```
+
+Each named agent uses its configured model from the Model Assignments table.
+
+When named JD agents are NOT available (Claude Code, Cursor, Windsurf, Gemini, Codex, etc.):
+
+```
+Judge A:   delegate(prompt="...")   // generic async delegate
+Judge B:   delegate(prompt="...")   // generic async delegate
+Fix Agent: delegate(prompt="...")   // generic async delegate
+```
+
+The model is controlled by the agent's native model switching mechanism. Pass the model alias from the Model Assignments table if the agent supports per-call model parameters.
+
 ## Language Snippets
 
 - Spanish: “Juicio iniciado”, “Los jueces trabajan en paralelo”, “Los jueces coinciden”, “Juicio terminado — Aprobado”, “Escalado — necesita revisión humana”.

--- a/internal/components/sdd/inject.go
+++ b/internal/components/sdd/inject.go
@@ -1472,6 +1472,9 @@ var claudeModelAssignmentRowOrder = []string{
 	"sdd-apply",
 	"sdd-verify",
 	"sdd-archive",
+	"jd-judge-a",
+	"jd-judge-b",
+	"jd-fix-agent",
 	"default",
 }
 
@@ -1485,6 +1488,9 @@ var claudeModelAssignmentReasons = map[string]string{
 	"sdd-apply":    "Implementation",
 	"sdd-verify":   "Validation against spec",
 	"sdd-archive":  "Copy and close",
+	"jd-judge-a":   "Adversarial review — blind judge A",
+	"jd-judge-b":   "Adversarial review — blind judge B",
+	"jd-fix-agent": "Surgical fixes from confirmed issues",
 	"default":      "Non-SDD general delegation",
 }
 

--- a/internal/components/sdd/inject.go
+++ b/internal/components/sdd/inject.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gentleman-programming/gentle-ai/internal/assets"
 	"github.com/gentleman-programming/gentle-ai/internal/components/filemerge"
 	"github.com/gentleman-programming/gentle-ai/internal/model"
+	"github.com/gentleman-programming/gentle-ai/internal/opencode"
 )
 
 type InjectionResult struct {
@@ -1550,6 +1551,18 @@ func renderClaudeModelAssignmentsSection(assignments map[string]model.ClaudeMode
 	return b.String()
 }
 
+// isJDAgent reports whether the agent name is a judgment-day workflow agent.
+// JD agents are excluded from root model fallback to preserve independent
+// model configuration for diversity of perspective between judges.
+func isJDAgent(name string) bool {
+	for _, jd := range opencode.JDPhases() {
+		if name == jd {
+			return true
+		}
+	}
+	return false
+}
+
 // injectModelAssignments injects "model" fields into sub-agent definitions
 // within the overlay JSON before it is merged into the settings file.
 //
@@ -1595,8 +1608,12 @@ func injectModelAssignments(overlayBytes []byte, assignments map[string]model.Mo
 			// 2. Agent already exists in user's config — let merge preserve whatever they have
 			// (don't touch the overlay for this agent's model)
 		case rootModelID != "":
-			// 3. Fresh install or new agent: use root model as default to break inheritance
-			agentMap["model"] = rootModelID
+			// 3. Fresh install or new agent: use root model as default to break inheritance.
+			// Exception: JD agents are excluded from root model propagation to support
+			// independent model configuration and diversity of perspective between judges.
+			if !isJDAgent(phase) {
+				agentMap["model"] = rootModelID
+			}
 		}
 	}
 

--- a/internal/components/sdd/inject_test.go
+++ b/internal/components/sdd/inject_test.go
@@ -1186,9 +1186,9 @@ func TestInjectOpenCodeMultiMode(t *testing.T) {
 		t.Fatalf("agent key has unexpected type: %T", agentRaw)
 	}
 
-	// Multi overlay must contain gentle-orchestrator + 10 sub-agents = 11 agents.
-	if len(agentMap) != 11 {
-		t.Fatalf("agent count = %d, want 11", len(agentMap))
+	// Multi overlay must contain gentle-orchestrator + 10 sub-agents + 3 JD agents = 14 agents.
+	if len(agentMap) != 14 {
+		t.Fatalf("agent count = %d, want 14", len(agentMap))
 	}
 
 	// Verify gentle-orchestrator is present.

--- a/internal/components/sdd/profiles.go
+++ b/internal/components/sdd/profiles.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gentleman-programming/gentle-ai/internal/assets"
 	"github.com/gentleman-programming/gentle-ai/internal/components/filemerge"
 	"github.com/gentleman-programming/gentle-ai/internal/model"
+	"github.com/gentleman-programming/gentle-ai/internal/opencode"
 )
 
 // profileNameRegex matches valid profile name slugs: lowercase alphanumeric + hyphens,
@@ -252,6 +253,11 @@ func GenerateProfileOverlay(profile model.Profile, homeDir string) ([]byte, erro
 	}
 	for _, phase := range profilePhaseOrder {
 		taskPerms[phase+suffix] = "allow"
+	}
+	// Add JD agent permissions (global, not profile-scoped).
+	// JD agents are workflow-level and shared across profiles.
+	for _, jd := range opencode.JDPhases() {
+		taskPerms[jd] = "allow"
 	}
 
 	orchEntry := map[string]any{

--- a/internal/components/sdd/profiles.go
+++ b/internal/components/sdd/profiles.go
@@ -23,6 +23,9 @@ var profileNameRegex = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`)
 var reservedProfileNames = map[string]bool{
 	"default":          true,
 	"sdd-orchestrator": true,
+	"jd-judge-a":      true,
+	"jd-judge-b":      true,
+	"jd-fix-agent":    true,
 }
 
 // ValidateProfileName returns an error if the profile name is not a valid

--- a/internal/components/sdd/profiles.go
+++ b/internal/components/sdd/profiles.go
@@ -20,13 +20,18 @@ import (
 var profileNameRegex = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`)
 
 // reservedProfileNames are names that may not be used as profile names.
-var reservedProfileNames = map[string]bool{
-	"default":          true,
-	"sdd-orchestrator": true,
-	"jd-judge-a":      true,
-	"jd-judge-b":      true,
-	"jd-fix-agent":    true,
-}
+// JD agent names are derived from opencode.JDPhases() to avoid drift
+// when agents are renamed or added.
+var reservedProfileNames = func() map[string]bool {
+	names := map[string]bool{
+		"default":          true,
+		"sdd-orchestrator": true,
+	}
+	for _, name := range opencode.JDPhases() {
+		names[name] = true
+	}
+	return names
+}()
 
 // ValidateProfileName returns an error if the profile name is not a valid
 // slug (lowercase alphanumeric + hyphens, no underscores, no spaces, non-empty,

--- a/internal/components/sdd/profiles_test.go
+++ b/internal/components/sdd/profiles_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gentleman-programming/gentle-ai/internal/assets"
 	"github.com/gentleman-programming/gentle-ai/internal/model"
+	"github.com/gentleman-programming/gentle-ai/internal/opencode"
 )
 
 func TestResolveProfileStrategy_ExplicitWins(t *testing.T) {
@@ -471,9 +472,10 @@ func TestDefaultOverlayTaskPermissions_ExplicitAllowlist(t *testing.T) {
 	tests := []struct {
 		name      string
 		assetPath string
+		includeJD bool // multi overlay includes JD agents; single does not
 	}{
-		{name: "single", assetPath: "opencode/sdd-overlay-single.json"},
-		{name: "multi", assetPath: "opencode/sdd-overlay-multi.json"},
+		{name: "single", assetPath: "opencode/sdd-overlay-single.json", includeJD: false},
+		{name: "multi", assetPath: "opencode/sdd-overlay-multi.json", includeJD: true},
 	}
 
 	for _, tt := range tests {
@@ -493,7 +495,14 @@ func TestDefaultOverlayTaskPermissions_ExplicitAllowlist(t *testing.T) {
 				t.Fatal("task block must use __replace__ sentinel to discard stale wildcards on sync")
 			}
 
-			assertExactTaskPermissions(t, taskMap, expectedTaskPermissions(""))
+			expected := expectedTaskPermissions("")
+			if !tt.includeJD {
+				// Single overlay does not include JD agent permissions.
+				for _, jd := range opencode.JDPhases() {
+					delete(expected, jd)
+				}
+			}
+			assertExactTaskPermissions(t, taskMap, expected)
 		})
 	}
 }
@@ -740,6 +749,10 @@ func expectedTaskPermissions(suffix string) map[string]any {
 	}
 	for _, phase := range profilePhaseOrder {
 		permissions[phase+suffix] = "allow"
+	}
+	// JD agents are global (not profile-scoped) — always unsuffixed.
+	for _, jd := range opencode.JDPhases() {
+		permissions[jd] = "allow"
 	}
 	return permissions
 }

--- a/internal/components/sdd/read_assignments.go
+++ b/internal/components/sdd/read_assignments.go
@@ -9,9 +9,9 @@ import (
 	"github.com/gentleman-programming/gentle-ai/internal/opencode"
 )
 
-// sddPhaseSet is the set of valid agent names that may appear in
+// configurableAgentSet is the set of valid agent names that may appear in
 // opencode.json. It includes SDD phases, JD agents, and the gentle-orchestrator coordinator.
-var sddPhaseSet = buildConfigurableAgentSet()
+var configurableAgentSet = buildConfigurableAgentSet()
 
 func buildConfigurableAgentSet() map[string]bool {
 	phases := opencode.ConfigurableAgentPhases() // SDD + JD phases
@@ -68,7 +68,7 @@ func ReadCurrentModelAssignments(settingsPath string) (map[string]model.ModelAss
 
 	result := make(map[string]model.ModelAssignment)
 	for name, defRaw := range agentMap {
-		if !sddPhaseSet[name] {
+		if !configurableAgentSet[name] {
 			continue
 		}
 		defMap, ok := defRaw.(map[string]any)

--- a/internal/components/sdd/read_assignments.go
+++ b/internal/components/sdd/read_assignments.go
@@ -9,12 +9,12 @@ import (
 	"github.com/gentleman-programming/gentle-ai/internal/opencode"
 )
 
-// sddPhaseSet is the set of valid base SDD agent names that may appear in
-// opencode.json. It includes the sub-agent phases plus the gentle-orchestrator coordinator.
-var sddPhaseSet = buildSDDPhaseSet()
+// sddPhaseSet is the set of valid agent names that may appear in
+// opencode.json. It includes SDD phases, JD agents, and the gentle-orchestrator coordinator.
+var sddPhaseSet = buildConfigurableAgentSet()
 
-func buildSDDPhaseSet() map[string]bool {
-	phases := opencode.SDDPhases()
+func buildConfigurableAgentSet() map[string]bool {
+	phases := opencode.ConfigurableAgentPhases() // SDD + JD phases
 	set := make(map[string]bool, len(phases)+1)
 	for _, p := range phases {
 		set[p] = true

--- a/internal/components/sdd/read_assignments.go
+++ b/internal/components/sdd/read_assignments.go
@@ -33,12 +33,11 @@ func ReadCurrentProfiles(settingsPath string) ([]model.Profile, error) {
 }
 
 // ReadCurrentModelAssignments reads the agent definitions from opencode.json
-// at settingsPath and extracts the "model" field for each SDD phase agent.
+// at settingsPath and extracts the "model" field for each configurable agent.
 //
-// Only agents whose names match an SDD phase (from opencode.SDDPhases()) or
-// "gentle-orchestrator" are included. Legacy "sdd-orchestrator" entries are read as
-// "gentle-orchestrator" until the next sync migrates the config. Agents without a "model" field, or with a
-// malformed model value (not in "provider:model-id" format), are silently
+// Only agents whose names match a configurable agent phase (SDD phases, JD agents
+// via opencode.ConfigurableAgentPhases()) or "gentle-orchestrator" are included.
+// Agents without a "model" field, or with a malformed model value, are silently
 // skipped.
 //
 // Returns an empty map (no error) when the file does not exist, contains no

--- a/internal/components/uninstall/service.go
+++ b/internal/components/uninstall/service.go
@@ -109,6 +109,9 @@ var (
 		"sdd-verify",
 		"sdd-archive",
 		"sdd-onboard",
+		"jd-judge-a",
+		"jd-judge-b",
+		"jd-fix-agent",
 	}
 	sddSkillPhaseIDs = sddPhaseAgents[1:]
 )

--- a/internal/model/claude_model.go
+++ b/internal/model/claude_model.go
@@ -49,6 +49,9 @@ func ClaudeModelPresetBalanced() map[string]ClaudeModelAlias {
 		"sdd-apply":    ClaudeModelSonnet,
 		"sdd-verify":   ClaudeModelSonnet,
 		"sdd-archive":  ClaudeModelHaiku,
+		"jd-judge-a":   ClaudeModelSonnet,
+		"jd-judge-b":   ClaudeModelSonnet,
+		"jd-fix-agent": ClaudeModelSonnet,
 		"default":      ClaudeModelSonnet,
 	}
 }
@@ -66,6 +69,9 @@ func ClaudeModelPresetPerformance() map[string]ClaudeModelAlias {
 		"sdd-apply":    ClaudeModelSonnet,
 		"sdd-verify":   ClaudeModelOpus,
 		"sdd-archive":  ClaudeModelHaiku,
+		"jd-judge-a":   ClaudeModelOpus,
+		"jd-judge-b":   ClaudeModelOpus,
+		"jd-fix-agent": ClaudeModelOpus,
 		"default":      ClaudeModelSonnet,
 	}
 }
@@ -83,6 +89,21 @@ func ClaudeModelPresetEconomy() map[string]ClaudeModelAlias {
 		"sdd-apply":    ClaudeModelSonnet,
 		"sdd-verify":   ClaudeModelSonnet,
 		"sdd-archive":  ClaudeModelHaiku,
+		"jd-judge-a":   ClaudeModelHaiku,
+		"jd-judge-b":   ClaudeModelHaiku,
+		"jd-fix-agent": ClaudeModelHaiku,
 		"default":      ClaudeModelSonnet,
 	}
+}
+
+// ClaudeModelPresetDiversity returns a model assignment table optimised for
+// perspective diversity in judgment-day reviews. Judge A uses opus for deep
+// architectural reasoning, Judge B uses haiku for fast pattern matching,
+// and the fix agent uses sonnet for balanced implementation.
+func ClaudeModelPresetDiversity() map[string]ClaudeModelAlias {
+	base := ClaudeModelPresetBalanced()
+	base["jd-judge-a"] = ClaudeModelOpus
+	base["jd-judge-b"] = ClaudeModelHaiku
+	base["jd-fix-agent"] = ClaudeModelSonnet
+	return base
 }

--- a/internal/opencode/models.go
+++ b/internal/opencode/models.go
@@ -205,3 +205,24 @@ func SDDPhases() []string {
 		"sdd-archive",
 	}
 }
+
+// JDPhases returns the ordered list of judgment-day sub-agent names.
+// These are workflow-level agents (not SDD phases) used by the
+// judgment-day skill for parallel adversarial review.
+// They support independent model configuration for diversity of perspective.
+func JDPhases() []string {
+	return []string{
+		"jd-judge-a",
+		"jd-judge-b",
+		"jd-fix-agent",
+	}
+}
+
+// ConfigurableAgentPhases returns all agent names that support per-agent
+// model configuration. This includes SDD phases + JD agents.
+// Used by the TUI model picker and ReadCurrentModelAssignments.
+func ConfigurableAgentPhases() []string {
+	phases := SDDPhases()
+	phases = append(phases, JDPhases()...)
+	return phases
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -932,6 +932,10 @@ func (m Model) handleKeyPress(key tea.KeyMsg) (tea.Model, tea.Cmd) {
 				m.BackupScroll = m.Cursor
 			}
 		}
+		// Skip separator row in model picker — it is not selectable.
+		if m.Screen == ScreenModelPicker && !m.ModelPicker.ForProfile && m.Cursor == screens.SeparatorRowIdx() && m.Cursor > 0 {
+			m.Cursor--
+		}
 		return m, nil
 	case "down":
 		// On the preview screen, down arrow scrolls content down.
@@ -952,6 +956,12 @@ func (m Model) handleKeyPress(key tea.KeyMsg) (tea.Model, tea.Cmd) {
 				m.BackupScroll = m.Cursor - screens.BackupMaxVisible + 1
 			}
 		}
+		// Skip separator row in model picker — it is not selectable.
+		if m.Screen == ScreenModelPicker && !m.ModelPicker.ForProfile && m.Cursor == screens.SeparatorRowIdx() {
+			if m.Cursor+1 < count {
+				m.Cursor++
+			}
+		}
 		return m, nil
 	case "k":
 		count := m.optionCount()
@@ -969,6 +979,10 @@ func (m Model) handleKeyPress(key tea.KeyMsg) (tea.Model, tea.Cmd) {
 				m.BackupScroll = m.Cursor
 			}
 		}
+		// Skip separator row in model picker — it is not selectable.
+		if m.Screen == ScreenModelPicker && !m.ModelPicker.ForProfile && m.Cursor == screens.SeparatorRowIdx() && m.Cursor > 0 {
+			m.Cursor--
+		}
 		return m, nil
 	case "j":
 		count := m.optionCount()
@@ -982,6 +996,12 @@ func (m Model) handleKeyPress(key tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if m.Screen == ScreenBackups {
 			if m.Cursor >= m.BackupScroll+screens.BackupMaxVisible {
 				m.BackupScroll = m.Cursor - screens.BackupMaxVisible + 1
+			}
+		}
+		// Skip separator row in model picker — it is not selectable.
+		if m.Screen == ScreenModelPicker && !m.ModelPicker.ForProfile && m.Cursor == screens.SeparatorRowIdx() {
+			if m.Cursor+1 < count {
+				m.Cursor++
 			}
 		}
 		return m, nil
@@ -1574,6 +1594,10 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 		}
 		rows := screens.ModelPickerRows()
 		if m.Cursor < len(rows) {
+			// Skip separator row — it is not actionable.
+			if !m.ModelPicker.ForProfile && m.Cursor == screens.SeparatorRowIdx() {
+				return m, nil
+			}
 			// Enter sub-selection: pick provider then model.
 			m.ModelPicker.SelectedPhaseIdx = m.Cursor
 			m.ModelPicker.Mode = screens.ModeProviderSelect

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -3269,6 +3269,7 @@ func (m Model) handleProfileNameInput(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		} else {
 			m.ModelPicker = screens.ModelPickerState{}
 		}
+		m.ModelPicker.ForProfile = true
 		m.Cursor = 0
 		return m, nil
 	case tea.KeyEsc:
@@ -3326,13 +3327,15 @@ func (m Model) confirmProfileCreate() (tea.Model, tea.Cmd) {
 			} else {
 				m.ModelPicker = screens.ModelPickerState{}
 			}
+			m.ModelPicker.ForProfile = true
 			m.Cursor = 0
 		}
 		return m, nil
 	case 1:
 		// Model assignment picker: orchestrator + all sub-agent phases in one screen.
 		// Reuse the same enter-on-row logic as ScreenModelPicker.
-		rows := screens.ModelPickerRows()
+		// Profile creation uses filtered rows (no JD agents).
+		rows := screens.ModelPickerRowsForProfile()
 		if m.Cursor < len(rows) {
 			// Enter sub-selection: pick provider then model.
 			m.ModelPicker.SelectedPhaseIdx = m.Cursor

--- a/internal/tui/screens/claude_model_picker.go
+++ b/internal/tui/screens/claude_model_picker.go
@@ -25,7 +25,7 @@ var claudePresetDescriptions = map[ClaudeModelPreset]string{
 	ClaudePresetPerformance: "Maximum quality: opus for architecture, planning & verification phases",
 	ClaudePresetEconomy:     "Cost-optimised: sonnet for all phases, haiku for archiving",
 	ClaudePresetDiversity:   "Diversity: Opus for Judge A, Haiku for Judge B, Sonnet for fixes",
-	ClaudePresetCustom:      "Pick the model alias for each SDD phase individually",
+	ClaudePresetCustom:      "Pick the model alias for each SDD phase, JD agent, and general delegation entry individually",
 }
 
 // claudePresetOrder is the display order for presets.

--- a/internal/tui/screens/claude_model_picker.go
+++ b/internal/tui/screens/claude_model_picker.go
@@ -15,6 +15,7 @@ const (
 	ClaudePresetBalanced    ClaudeModelPreset = "balanced"
 	ClaudePresetPerformance ClaudeModelPreset = "performance"
 	ClaudePresetEconomy     ClaudeModelPreset = "economy"
+	ClaudePresetDiversity   ClaudeModelPreset = "diversity"
 	ClaudePresetCustom      ClaudeModelPreset = "custom"
 )
 
@@ -23,6 +24,7 @@ var claudePresetDescriptions = map[ClaudeModelPreset]string{
 	ClaudePresetBalanced:    "Smart defaults: opus for architecture, sonnet for most phases, haiku for archiving",
 	ClaudePresetPerformance: "Maximum quality: opus for architecture, planning & verification phases",
 	ClaudePresetEconomy:     "Cost-optimised: sonnet for all phases, haiku for archiving",
+	ClaudePresetDiversity:   "Diversity: Opus for Judge A, Haiku for Judge B, Sonnet for fixes",
 	ClaudePresetCustom:      "Pick the model alias for each SDD phase individually",
 }
 
@@ -31,6 +33,7 @@ var claudePresetOrder = []ClaudeModelPreset{
 	ClaudePresetBalanced,
 	ClaudePresetPerformance,
 	ClaudePresetEconomy,
+	ClaudePresetDiversity,
 	ClaudePresetCustom,
 }
 
@@ -103,6 +106,7 @@ var presetConstructors = map[ClaudeModelPreset]func() map[string]model.ClaudeMod
 	ClaudePresetBalanced:    model.ClaudeModelPresetBalanced,
 	ClaudePresetPerformance: model.ClaudeModelPresetPerformance,
 	ClaudePresetEconomy:     model.ClaudeModelPresetEconomy,
+	ClaudePresetDiversity:   model.ClaudeModelPresetDiversity,
 }
 
 // HandleClaudeModelPickerNav processes a key press on the Claude model picker screen.

--- a/internal/tui/screens/claude_model_picker.go
+++ b/internal/tui/screens/claude_model_picker.go
@@ -45,6 +45,9 @@ var claudePhases = []string{
 	"sdd-apply",
 	"sdd-verify",
 	"sdd-archive",
+	"jd-judge-a",
+	"jd-judge-b",
+	"jd-fix-agent",
 	"default",
 }
 
@@ -59,6 +62,9 @@ var claudePhaseLabels = map[string]string{
 	"sdd-apply":    "Apply",
 	"sdd-verify":   "Verify",
 	"sdd-archive":  "Archive",
+	"jd-judge-a":   "JD Judge A",
+	"jd-judge-b":   "JD Judge B",
+	"jd-fix-agent": "JD Fix Agent",
 	"default":      "General delegation",
 }
 

--- a/internal/tui/screens/model_picker.go
+++ b/internal/tui/screens/model_picker.go
@@ -87,7 +87,7 @@ const SDDOrchestratorPhase = "gentle-orchestrator"
 // Row 0 is "gentle-orchestrator" (coordinator), row 1 is "Set all phases",
 // rows 2-10 are the 9 SDD sub-agent phases, then a separator and JD agents.
 func ModelPickerRows() []string {
-	rows := make([]string, 0, 15)
+	rows := make([]string, 0, 2+len(opencode.SDDPhases())+1+len(opencode.JDPhases()))
 	rows = append(rows, SDDOrchestratorPhase)
 	rows = append(rows, "Set all phases")
 	rows = append(rows, opencode.SDDPhases()...)
@@ -99,11 +99,23 @@ func ModelPickerRows() []string {
 // ModelPickerRowsForProfile returns model picker rows for profile creation.
 // JD agents are excluded because they are global (not profile-scoped).
 func ModelPickerRowsForProfile() []string {
-	rows := make([]string, 0, 11)
+	rows := make([]string, 0, 2+len(opencode.SDDPhases()))
 	rows = append(rows, SDDOrchestratorPhase)
 	rows = append(rows, "Set all phases")
 	rows = append(rows, opencode.SDDPhases()...)
 	return rows
+}
+
+// SeparatorRowIdx returns the index of the "--- Judgment Day ---" separator
+// row in ModelPickerRows(). Returns -1 if there are no JD phases (and thus
+// no separator). This is used by the TUI to skip the separator during
+// cursor navigation and model selection.
+func SeparatorRowIdx() int {
+	jd := opencode.JDPhases()
+	if len(jd) == 0 {
+		return -1
+	}
+	return 2 + len(opencode.SDDPhases())
 }
 
 // ProviderEntries returns sorted provider entries with display names and model counts.

--- a/internal/tui/screens/model_picker.go
+++ b/internal/tui/screens/model_picker.go
@@ -80,12 +80,14 @@ const SDDOrchestratorPhase = "gentle-orchestrator"
 
 // ModelPickerRows returns the row labels for the model picker screen.
 // Row 0 is "gentle-orchestrator" (coordinator), row 1 is "Set all phases",
-// rows 2-10 are the 9 SDD sub-agent phases.
+// rows 2-10 are the 9 SDD sub-agent phases, then a separator and JD agents.
 func ModelPickerRows() []string {
-	rows := make([]string, 0, 11)
+	rows := make([]string, 0, 15)
 	rows = append(rows, SDDOrchestratorPhase)
 	rows = append(rows, "Set all phases")
 	rows = append(rows, opencode.SDDPhases()...)
+	rows = append(rows, "--- Judgment Day ---")
+	rows = append(rows, opencode.JDPhases()...)
 	return rows
 }
 
@@ -200,6 +202,9 @@ func handleModelNav(
 		}
 
 		phases := opencode.SDDPhases()
+		jdPhases := opencode.JDPhases()
+		// separatorIdx is the index of the "--- Judgment Day ---" row.
+		separatorIdx := 2 + len(phases)
 		switch {
 		case state.SelectedPhaseIdx == 0:
 			// "gentle-orchestrator" row — assign only to the base orchestrator key
@@ -212,8 +217,16 @@ func handleModelNav(
 				assignments[phase] = assignment
 			}
 			state.AllPhasesModel = assignment
+		case state.SelectedPhaseIdx == separatorIdx:
+			// Separator row ("--- Judgment Day ---") — no action, skip.
+		case state.SelectedPhaseIdx > separatorIdx:
+			// JD agent rows: map to JDPhases() after separator.
+			jdIdx := state.SelectedPhaseIdx - separatorIdx - 1
+			if jdIdx < len(jdPhases) {
+				assignments[jdPhases[jdIdx]] = assignment
+			}
 		default:
-			// Sub-agent rows start at idx 2; phases[idx-2] is the correct phase.
+			// SDD sub-agent rows start at idx 2; phases[idx-2] is the correct phase.
 			// Individual selection intentionally does NOT update AllPhasesModel (Issue #146).
 			phaseIdx := state.SelectedPhaseIdx - 2
 			if phaseIdx < len(phases) {
@@ -281,6 +294,8 @@ func renderPhaseList(
 
 	rows := ModelPickerRows()
 	phases := opencode.SDDPhases()
+	jdPhases := opencode.JDPhases()
+	separatorIdx := 2 + len(phases)
 
 	for idx, row := range rows {
 		focused := idx == cursor
@@ -306,8 +321,25 @@ func renderPhaseList(
 			} else {
 				label = fmt.Sprintf("%-20s (not set)", row)
 			}
+		case idx == separatorIdx:
+			// Separator row — render as a visual divider, not selectable but shown.
+			b.WriteString(styles.SubtextStyle.Render("  " + row) + "\n")
+			continue
+		case idx > separatorIdx:
+			// JD agent rows
+			jdIdx := idx - separatorIdx - 1
+			if jdIdx < len(jdPhases) {
+				phase := jdPhases[jdIdx]
+				assignment, ok := assignments[phase]
+				if ok && assignment.ProviderID != "" {
+					provName, modelName := resolveNames(assignment, state)
+					label = fmt.Sprintf("%-20s %s / %s", row, provName, modelName)
+				} else {
+					label = fmt.Sprintf("%-20s (default)", row)
+				}
+			}
 		default:
-			// Sub-agent rows start at idx 2; phases[idx-2] maps to the correct phase
+			// SDD sub-agent rows start at idx 2; phases[idx-2] maps to the correct phase
 			phase := phases[idx-2]
 			assignment, ok := assignments[phase]
 			if ok && assignment.ProviderID != "" {

--- a/internal/tui/screens/model_picker.go
+++ b/internal/tui/screens/model_picker.go
@@ -51,6 +51,11 @@ type ModelPickerState struct {
 	// label from changing when the user picks a model for a single phase.
 	// Issue #146.
 	AllPhasesModel model.ModelAssignment
+
+	// ForProfile is true when the picker is used for profile creation/editing.
+	// When true, JD agents and the separator are excluded from the row list
+	// because JD agents are global (not profile-scoped).
+	ForProfile bool
 }
 
 // NewModelPickerState initializes the picker state from the models cache.
@@ -88,6 +93,16 @@ func ModelPickerRows() []string {
 	rows = append(rows, opencode.SDDPhases()...)
 	rows = append(rows, "--- Judgment Day ---")
 	rows = append(rows, opencode.JDPhases()...)
+	return rows
+}
+
+// ModelPickerRowsForProfile returns model picker rows for profile creation.
+// JD agents are excluded because they are global (not profile-scoped).
+func ModelPickerRowsForProfile() []string {
+	rows := make([]string, 0, 11)
+	rows = append(rows, SDDOrchestratorPhase)
+	rows = append(rows, "Set all phases")
+	rows = append(rows, opencode.SDDPhases()...)
 	return rows
 }
 
@@ -292,7 +307,12 @@ func renderPhaseList(
 	b.WriteString(styles.SubtextStyle.Render("Current assignments:"))
 	b.WriteString("\n\n")
 
-	rows := ModelPickerRows()
+	var rows []string
+	if state.ForProfile {
+		rows = ModelPickerRowsForProfile()
+	} else {
+		rows = ModelPickerRows()
+	}
 	phases := opencode.SDDPhases()
 	jdPhases := opencode.JDPhases()
 	separatorIdx := 2 + len(phases)
@@ -322,8 +342,12 @@ func renderPhaseList(
 				label = fmt.Sprintf("%-20s (not set)", row)
 			}
 		case idx == separatorIdx:
-			// Separator row — render as a visual divider, not selectable but shown.
-			b.WriteString(styles.SubtextStyle.Render("  " + row) + "\n")
+			// Separator row — render as a visual divider with subtle indicator when focused.
+			if focused {
+				b.WriteString(styles.SubtextStyle.Render("▸ " + row) + "\n")
+			} else {
+				b.WriteString(styles.SubtextStyle.Render("  " + row) + "\n")
+			}
 			continue
 		case idx > separatorIdx:
 			// JD agent rows

--- a/internal/tui/screens/model_picker_test.go
+++ b/internal/tui/screens/model_picker_test.go
@@ -28,8 +28,8 @@ func makeTestState(phaseIdx int) *ModelPickerState {
 
 func TestModelPickerRows_Count(t *testing.T) {
 	rows := ModelPickerRows()
-	// 1 orchestrator + 1 "Set all" + 9 sub-agents = 11
-	want := 11
+	// 1 orchestrator + 1 "Set all" + 9 sub-agents + 1 separator + 3 JD agents = 15
+	want := 15
 	if len(rows) != want {
 		t.Fatalf("ModelPickerRows() len = %d, want %d; rows = %v", len(rows), want, rows)
 	}

--- a/internal/tui/screens/model_picker_test.go
+++ b/internal/tui/screens/model_picker_test.go
@@ -302,3 +302,122 @@ func TestIndividualPhaseSelectionDoesNotSetAllPhasesModel(t *testing.T) {
 		})
 	}
 }
+
+// ─── Separator row (non-selectable) ────────────────────────────────────────
+
+func TestSeparatorRowIdx_Value(t *testing.T) {
+	got := SeparatorRowIdx()
+	want := 2 + len(opencode.SDDPhases()) // after orchestrator + "Set all" + 9 SDD phases
+	if got != want {
+		t.Fatalf("SeparatorRowIdx() = %d, want %d", got, want)
+	}
+}
+
+func TestHandleModelNav_SeparatorRow_NoAssignment(t *testing.T) {
+	sepIdx := SeparatorRowIdx()
+	state := makeTestState(sepIdx)
+	assignments := make(map[string]model.ModelAssignment)
+
+	handled, updated := handleModelNav("enter", state, assignments)
+
+	if !handled {
+		t.Fatal("handleModelNav should return handled=true on enter for separator")
+	}
+
+	// Separator should produce NO assignments at all.
+	if len(updated) != 0 {
+		t.Fatalf("separator row should produce no assignments; got: %v", updated)
+	}
+
+	// State should return to phase list.
+	if state.Mode != ModePhaseList {
+		t.Fatalf("expected ModePhaseList after separator enter, got %d", state.Mode)
+	}
+}
+
+// ─── JD agent rows ─────────────────────────────────────────────────────────
+
+func TestHandleModelNav_JDAgentRows_AssignCorrectly(t *testing.T) {
+	jdPhases := opencode.JDPhases()
+	sepIdx := SeparatorRowIdx()
+
+	for i, expectedPhase := range jdPhases {
+		t.Run(expectedPhase, func(t *testing.T) {
+			state := makeTestState(sepIdx + 1 + i) // JD rows start after separator
+			assignments := make(map[string]model.ModelAssignment)
+
+			handled, updated := handleModelNav("enter", state, assignments)
+
+			if !handled {
+				t.Fatal("handleModelNav should return handled=true on enter")
+			}
+
+			// The target JD phase must be assigned.
+			a, ok := updated[expectedPhase]
+			if !ok || a.ProviderID == "" {
+				t.Errorf("JD phase %q should be assigned; assignments: %v", expectedPhase, updated)
+			}
+			if a.ProviderID != "test-provider" {
+				t.Errorf("JD phase %q ProviderID = %q, want %q", expectedPhase, a.ProviderID, "test-provider")
+			}
+			if a.ModelID != "model-alpha" {
+				t.Errorf("JD phase %q ModelID = %q, want %q", expectedPhase, a.ModelID, "model-alpha")
+			}
+
+			// No other JD phase must be assigned.
+			for _, other := range jdPhases {
+				if other == expectedPhase {
+					continue
+				}
+				if _, exists := updated[other]; exists {
+					t.Errorf("unrelated JD phase %q should not be assigned; assignments: %v", other, updated)
+				}
+			}
+
+			// No SDD phase or orchestrator must be assigned.
+			for _, sdd := range opencode.SDDPhases() {
+				if _, exists := updated[sdd]; exists {
+					t.Errorf("SDD phase %q should not be assigned by JD row; assignments: %v", sdd, updated)
+				}
+			}
+			if _, exists := updated[SDDOrchestratorPhase]; exists {
+				t.Errorf("orchestrator should not be assigned by JD row; assignments: %v", updated)
+			}
+		})
+	}
+}
+
+func TestHandleModelNav_JDFirstRow(t *testing.T) {
+	// Verify the FIRST JD row (right after separator) maps to jd-judge-a.
+	jdPhases := opencode.JDPhases()
+	if len(jdPhases) == 0 {
+		t.Skip("no JD phases defined")
+	}
+	sepIdx := SeparatorRowIdx()
+	state := makeTestState(sepIdx + 1)
+	assignments := make(map[string]model.ModelAssignment)
+
+	_, updated := handleModelNav("enter", state, assignments)
+
+	if _, ok := updated[jdPhases[0]]; !ok {
+		t.Fatalf("first JD row should assign %q; got: %v", jdPhases[0], updated)
+	}
+}
+
+func TestHandleModelNav_JDLastRow(t *testing.T) {
+	// Verify the LAST JD row maps to the last JD phase.
+	jdPhases := opencode.JDPhases()
+	if len(jdPhases) == 0 {
+		t.Skip("no JD phases defined")
+	}
+	sepIdx := SeparatorRowIdx()
+	state := makeTestState(sepIdx + len(jdPhases))
+	assignments := make(map[string]model.ModelAssignment)
+
+	_, updated := handleModelNav("enter", state, assignments)
+
+	lastPhase := jdPhases[len(jdPhases)-1]
+	if _, ok := updated[lastPhase]; !ok {
+		t.Fatalf("last JD row should assign %q; got: %v", lastPhase, updated)
+	}
+}

--- a/internal/tui/screens/profile_create.go
+++ b/internal/tui/screens/profile_create.go
@@ -175,7 +175,7 @@ func ProfileCreateOptionCount(step int, picker ModelPickerState) int {
 		if len(picker.AvailableIDs) == 0 {
 			return 1 // only "Back"
 		}
-		return len(ModelPickerRows()) + 2 // rows + Continue + Back
+		return len(ModelPickerRowsForProfile()) + 2 // rows + Continue + Back (JD excluded for profiles)
 	default:
 		return 2 // "Create & Sync" / "Save & Sync" + "Cancel"
 	}


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #208

---

## 🏷️ PR Type

- [x] `type:feature` — New feature (non-breaking change that adds functionality)

---

## 📝 Summary

Adds 3 configurable judgment-day agents (`jd-judge-a`, `jd-judge-b`, `jd-fix-agent`) to the OpenCode overlay system, enabling users to assign different models per JD agent through the TUI model picker.

Key design decisions:
- **Named agents in SDD overlay** — JD agents live in `sdd-overlay-multi.json` alongside SDD phases, since the JD skill is distributed with SDD
- **Root model exclusion** — JD agents are intentionally excluded from inheriting the root model, enabling **diversity of perspective** between judges (different models = different viewpoints)
- **4 presets**: Sonnet, Opus, Haiku, and Diversity (Judge A=Opus, Judge B=Haiku, Fix=Sonnet)
- **Profile-safe** — JD agents are excluded from profile flows (they're global workflow agents, not SDD phases)

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/assets/opencode/sdd-overlay-multi.json` | 3 JD agent definitions + orchestrator delegation permissions |
| `internal/opencode/models.go` | `JDPhases()` and `ConfigurableAgentPhases()` for dynamic agent discovery |
| `internal/components/sdd/inject.go` | Model assignment rows, reasons, `isJDAgent()` helper, root model exclusion |
| `internal/model/claude_model.go` | JD entries in 3 presets + `ClaudeModelPresetDiversity()` |
| `internal/components/sdd/read_assignments.go` | `buildConfigurableAgentSet()` using `ConfigurableAgentPhases()` |
| `internal/components/sdd/profiles.go` | JD global permissions in `GenerateProfileOverlay()`, reserved profile names |
| `internal/tui/screens/model_picker.go` | JD rows, separator with focus indicator, `ModelPickerRowsForProfile()` |
| `internal/tui/screens/claude_model_picker.go` | JD in `claudePhases`/labels, Diversity preset wired in |
| `internal/tui/screens/profile_create.go` | Uses `ModelPickerRowsForProfile()` to exclude JD from profiles |
| `internal/tui/model.go` | `ForProfile` flag for profile create/edit flows |
| `internal/assets/skills/judgment-day/SKILL.md` | Conditional delegation (named agents for OpenCode, ad-hoc for others) |
| `internal/assets/claude/agents/jd-*.md` | 3 Claude agent files with `{{CLAUDE_MODEL}}` sentinel |
| `internal/assets/kiro/agents/jd-*.md` | 3 Kiro agent files with `{{KIRO_MODEL}}` sentinel |
| `internal/components/uninstall/service.go` | JD agents in `sddPhaseAgents` cleanup list |

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./...
```

**E2E Tests** (Docker required)
```bash
cd e2e && ./docker-test.sh
```

- [x] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Manually tested locally — full integration test with temp HOME:
  - Built binary from branch, ran `sync --sdd-mode multi` against temp config
  - Verified 15 agents in output (build + 11 SDD + 3 JD)
  - Verified JD agents: `mode=subagent`, `hidden=true`, no model inherited from root
  - Verified orchestrator permissions: `jd-judge-a: allow`, `jd-judge-b: allow`, `jd-fix-agent: allow`
  - Verified TUI model picker shows JD rows with separator
  - Verified presets (Sonnet, Opus, Haiku, Diversity) assign models correctly

---

## 🤖 Automated Checks

The following checks run automatically on this PR:

| Check | Status | Description |
|-------|--------|-------------|
| Check Issue Reference | ⏳ | PR body must contain `Closes/Fixes/Resolves #N` |
| Check Issue Has `status:approved` | ⏳ | Linked issue must have been approved before work began |
| Check PR Has `type:*` Label | ⏳ | Exactly one `type:*` label must be applied |
| Unit Tests | ⏳ | `go test ./...` must pass |
| E2E Tests | ⏳ | `cd e2e && ./docker-test.sh` must pass |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

- The 9 commits are organized in dependency order — each builds on the previous one
- A judgment-day adversarial review was run on both the proposal AND the implementation (0 criticals)
- The `Diversity` preset (Opus for deep reasoning on Judge A, Haiku for fast pattern matching on Judge B, Sonnet for Fix) is the recommended default for perspective diversity
- No changes to single-mode overlay — JD delegation contradicts single-mode's "Do NOT delegate" instruction