### PR TITLE
docs(engram-protocol): tighten save format — closed type table, manda…

### DIFF
--- a/internal/assets/claude/engram-protocol.md
+++ b/internal/assets/claude/engram-protocol.md
@@ -12,53 +12,119 @@ Call `mem_save` IMMEDIATELY and WITHOUT BEING ASKED after any of these:
 - Tool or library choice made with tradeoffs
 - Bug fix completed (include root cause)
 - Feature implemented with non-obvious approach
-- Notion/Jira/GitHub artifact created or updated with significant content
 - Configuration change or environment setup done
-- Non-obvious discovery about the codebase
-- Gotcha, edge case, or unexpected behavior found
+- Non-obvious discovery, gotcha, or edge case
 - Pattern established (naming, structure, convention)
 - User preference or constraint learned
 
 Self-check after EVERY task: "Did I make a decision, fix a bug, learn something non-obvious, or establish a convention? If yes, call mem_save NOW."
 
-Format for `mem_save`:
-- **title**: Verb + what — short, searchable (e.g. "Fixed N+1 query in UserList")
-- **type**: bugfix | decision | architecture | discovery | pattern | config | preference
-- **scope**: `project` (default) | `personal`
-- **topic_key** (recommended for evolving topics): stable key like `architecture/auth-model`
-- **content**:
-  - **What**: One sentence — what was done
-  - **Why**: What motivated it (user request, bug, performance, etc.)
-  - **Where**: Files or paths affected
-  - **Learned**: Gotchas, edge cases, things that surprised you (omit if none)
+### MANDATORY SAVE FORMAT
 
-Topic update rules:
-- Different topics MUST NOT overwrite each other
-- Same topic evolving → use same `topic_key` (upsert)
-- Unsure about key → call `mem_suggest_topic_key` first
-- Know exact ID to fix → use `mem_update`
+Saved observations are only useful if `mem_search` finds them later. Every step below is mandatory — do NOT improvise.
+
+#### 1. Dedupe before save
+
+Call `mem_search` with the candidate `topic_key` first. If a hit exists → `mem_update`. Otherwise continue.
+
+If unsure which key to use → call `mem_suggest_topic_key`.
+
+#### 2. `type` — closed table
+
+| `type`            | Title prefix     | When                                              |
+|-------------------|------------------|---------------------------------------------------|
+| `bugfix`          | `Bugfix:`        | Bug fixed, with root cause                        |
+| `decision`        | `Decision:`      | Choice between alternatives with tradeoff         |
+| `pattern`         | `Pattern:`       | Reusable convention or pattern                    |
+| `config`          | `Config:`        | Setup, install, tooling configuration             |
+| `discovery`       | `Discovery:`     | Non-obvious finding or gotcha                     |
+| `preference`      | `Preference:`    | User preference or constraint                     |
+| `proposal`        | `Proposal:`      | SDD proposal phase                                |
+| `spec`            | `Spec:`          | SDD spec phase                                    |
+| `design`          | `Design:`        | SDD design phase                                  |
+| `tasks`           | `Tasks:`         | SDD tasks phase                                   |
+| `apply-progress`  | `Apply:`         | SDD apply phase (implementation log)              |
+| `verify-report`   | `Verify:`        | SDD verify phase                                  |
+| `archive-report`  | `Archive:`       | SDD archive phase                                 |
+| `session_summary` | `Session:`       | End-of-session summary                            |
+
+Do NOT invent new types. The legacy `architecture` type is REMOVED — SDD artifacts use the dedicated phase types; non-SDD architectural decisions go under `decision`. If content fits no row, it should not be saved.
+
+#### 3. `title` — fixed format
+
+```
+<Prefix>: <ticket-id?> <subject> — <qualifier?>
+```
+
+- Prefix MUST come from the table.
+- `ticket-id` immediately after the prefix when applicable.
+- `subject` MUST be in **English**, even if the conversation is in another language. Search runs cross-project; English is the common denominator. Body language is free.
+- No emojis, no decorative quotes. Under 80 chars.
+
+Examples: `Bugfix: TICKET-42 null check in user profile loader`, `Pattern: cache invalidation on write-through`, `Decision: chose Postgres over MySQL for analytics`, `Session: 2025-01-15 auth refactor planning`.
+
+#### 4. `topic_key` — MANDATORY
+
+Path-style, lowercase, kebab-case: `<domain>/<scope>/<slug>`.
+
+| Case             | Pattern                                  |
+|------------------|------------------------------------------|
+| SDD artifact     | `sdd/<change-name>/<phase>`              |
+| Bug fix          | `bugfix/<module>/<short-slug>`           |
+| Pattern          | `pattern/<area>/<short-slug>`            |
+| Config           | `config/<tool>/<short-slug>`             |
+| Decision         | `decision/<area>/<short-slug>`           |
+| Discovery        | `discovery/<area>/<short-slug>`          |
+| Preference       | `preference/<area>/<short-slug>`         |
+| Session summary  | `session/<yyyy-mm-dd>/<topic-slug>`      |
+
+Same topic evolving → reuse the key (upsert). Different topics MUST NOT overwrite each other.
+
+#### 5. `content` — fixed structure
+
+```
+**What**: <one sentence — what was done>
+**Why**: <motivation — request, bug, perf, deadline, etc.>
+**Where**: <files / paths / URLs>
+**Learned**: <gotchas, edge cases — omit if none>
+```
+
+No `Tags` field — `topic_key` plus a normalized title cover findability.
+
+#### 6. `scope`
+
+`project` (default) | `personal` (truly cross-project preferences/patterns only).
+
+#### Pre-save self-check
+
+- [ ] Did I `mem_search` the topic_key first?
+- [ ] Is `type` in the closed table?
+- [ ] Title prefix matches the type, subject is English, under 80 chars?
+- [ ] `topic_key` set and path-style?
+- [ ] Body has What / Why / Where?
+
+Any "no" → fix before saving.
+
+#### Migration
+
+Existing observations are NOT bulk-migrated; they stay searchable via full-text. Convention applies to new saves and to `mem_update` of existing ones (also fix their `type` and `topic_key` on update).
 
 ### WHEN TO SEARCH MEMORY
 
-On any variation of "remember", "recall", "what did we do", "how did we solve", "recordar", "qué hicimos", or references to past work:
-1. Call `mem_context` — checks recent session history (fast, cheap)
-2. If not found, call `mem_search` with relevant keywords
-3. If found, use `mem_get_observation` for full untruncated content
+On any variation of "remember", "recall", "what did we do", "how did we solve", or references to past work:
+1. `mem_context` — recent session history (fast, cheap)
+2. If not found, `mem_search` with relevant keywords
+3. `mem_get_observation` for full untruncated content
 
-Also search PROACTIVELY when:
-- Starting work on something that might have been done before
-- User mentions a topic you have no context on
-- User's FIRST message references the project, a feature, or a problem — call `mem_search` with keywords from their message to check for prior work before responding
+Also search PROACTIVELY when starting work that might have been done before, when the user mentions a topic you have no context on, or when their FIRST message references a project/feature/problem.
 
 ### SESSION CLOSE PROTOCOL (mandatory)
 
-Before ending a session or saying "done" / "listo" / "that's it", call `mem_session_summary`:
+Before ending a session or saying "done" / "listo", call `mem_session_summary` with:
 
+```
 ## Goal
 [What we were working on this session]
-
-## Instructions
-[User preferences or constraints discovered — skip if none]
 
 ## Discoveries
 - [Technical findings, gotchas, non-obvious learnings]
@@ -67,18 +133,19 @@ Before ending a session or saying "done" / "listo" / "that's it", call `mem_sess
 - [Completed items with key details]
 
 ## Next Steps
-- [What remains to be done — for the next session]
+- [What remains for the next session]
 
 ## Relevant Files
 - path/to/file — [what it does or what changed]
+```
 
 This is NOT optional. If you skip this, the next session starts blind.
 
 ### AFTER COMPACTION
 
 If you see a compaction message or "FIRST ACTION REQUIRED":
-1. IMMEDIATELY call `mem_session_summary` with the compacted summary content — this persists what was done before compaction
-2. Call `mem_context` to recover additional context from previous sessions
-3. Only THEN continue working
+1. IMMEDIATELY call `mem_session_summary` with the compacted summary content — persists what was done before compaction
+2. Call `mem_context` to recover additional context
+3. Only THEN continue
 
-Do not skip step 1. Without it, everything done before compaction is lost from memory.
+Skipping step 1 loses everything done before compaction.


### PR DESCRIPTION
 ## 🏷️  PR Type                                                                                                                                     
   
  - [x] `type:docs` — Documentation only                                                                                                                                                                     
  ---                                                                                                                                               
                                                               
  ## 📝 Summary                                             

  Tighten the Engram memory protocol so saved observations are actually findable
  across sessions and projects. Upstream left `topic_key` optional, the `type`                                                                      
  field open-ended, and the `title` free-form — which produced duplicates,                                                                          
  collisions, and titles in mixed languages that broke cross-project search.                                                                        
                                                                                                                                                    
  This change introduces a strict naming convention as a **local override** that                                                                    
  replaces only the `Format for mem_save` section of the upstream block. The rest                                                                   
  of the protocol (triggers, search rules, session-close, after-compaction) stays                                                                   
  untouched.                                                                                                                                        
                                                            
  Key rules now enforced:                                                                                                                           
                                                               
  - **`topic_key` is MANDATORY** (was "recommended"), path-style                                                                                    
    `<domain>/<scope>/<slug>`, with a table of canonical patterns per case
    (SDD, bugfix, pattern, config, decision, discovery, preference, session).                                                                       
  - **`title` subject MUST be in English**, even when the conversation is in
    another language — search runs cross-project, English is the common                                                                             
    denominator. Body content stays in whatever language the conversation uses.                                                                     
  - **`type` is a CLOSED table** of 14 values. Legacy `architecture` is REMOVED                                                                     
    (SDD artifacts use the dedicated phase types; non-SDD architectural                                                                             
    decisions go under `decision`).                                                                                                                 
  - **`title` follows a fixed format**: `<Prefix>: <ticket-id?> <subject> — <qualifier?>`,                                                          
    prefix bound to the type (`Bugfix:`, `Decision:`, `Pattern:`, `Spec:`, etc.).                                                                   
  - **Pre-save dedupe is MANDATORY**: call `mem_search` on the candidate                                                                            
    `topic_key` before `mem_save`. On hit → `mem_update`, never duplicate.                                                                          
  - **`content` structure**: `What` / `Why` / `Where` / `Learned`. No `Tags`                                                                        
    field — `topic_key` plus the normalized title cover findability.                                                                                
  - Pre-save self-check checklist added so each save is verifiable before commit.                                                                   
                                                                                                                                                    
  The override declares its own precedence (`THIS section wins` over the                                                                            
  upstream block when they conflict) and lives outside the `gentle-ai sync`                                                                         
  markers, so future syncs of the upstream protocol will not overwrite it.                                                                          
                                                                                                                                                    
  ---                                                                                                                                               
                                                                                                                                                    
  ## 📂 Changes                                                
                                                                                                                                                    
  | File / Area | What Changed |
  |-------------|-------------|                                                                                                                     
  | `engram-naming-override.md` | New strict convention: mandatory `topic_key`, closed `type` table, fixed title format, English subject rule, 
  mandatory dedupe, pre-save self-check |                                                                                                           
  | `CLAUDE.md` (override block) | Added LOCAL OVERRIDE section pointing to the spec, with hard-rule summary and precedence note |
                                                                                                                                                    
  ---                                                          
                                                                                                                                                    
  ## 🧪 Test Plan                                              
                                                            
  This PR is documentation/convention only — no Go code changes.
                                                                                                                                                    
  - [x] Manually walked through the 6-step pre-save self-check on three sample saves (bugfix / SDD spec / session summary) — all produced valid, 
  dedupe-safe records                                                                                                                               
  - [x] Verified the override sits OUTSIDE `<!-- gentle-ai:engram-protocol -->` markers, so `gentle-ai sync` will not touch it
  - [x] Confirmed all 14 `type` values map 1:1 to a `Prefix` and a `topic_key` pattern                                                              
  - [ ] Unit tests pass (`go test ./...`) — N/A, no code changes                                                                                    
  - [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — N/A, no code changes                                                                        
                                                                                                                                                    
  If this PR is paired with validation code that enforces the rules at                                                                              
  `mem_save` time, run the full suite there.                                                                                                        
                                                               
  ---                                                                                                                                               
                                                               
  ## ✅ Contributor Checklist                               
                                                                                                                                                    
  - [x] PR is linked to an issue with `status:approved`
  - [x] I have added the appropriate `type:*` label to this PR                                                                                      
  - [x] I have updated documentation (this PR IS the documentation)                                                                                 
  - [x] My commits follow Conventional Commits (`docs(engram): …`)                                                                                  
  - [x] My commits do not include `Co-Authored-By` trailers                                                                                         
                                                                                                                                                    
  ---                                                                                                                                               
                                                                                                                                                    
  ## 💬 Notes for Reviewers                                    
                                                            
  - The override is intentionally a **superset** of upstream, not a fork. Sections
    not mentioned (triggers, search, session-close, after-compaction) are left                                                                      
    untouched on purpose — please flag if you find a case where they conflict.                                                                      
  - The removal of `architecture` from the `type` table is the most                                                                                 
    user-visible breaking change. Migration note is included: existing records                                                                      
    stay searchable via full-text; convention applies to NEW saves and to                                                                           
    `mem_update` of old ones.                                                                                                                       
  - `title` examples in the spec are all English on purpose — they double as                                                                        
    the canonical format reference. 