### PR TITLE
fix(vscode): keep engram available at session start

### DIFF
--- a/internal/agents/vscode/adapter.go
+++ b/internal/agents/vscode/adapter.go
@@ -95,6 +95,10 @@ func (a *Adapter) MCPConfigPath(homeDir string, _ string) string {
 	return filepath.Join(a.vscodeUserDir(homeDir), "mcp.json")
 }
 
+func (a *Adapter) WorkspaceMCPConfigPath(workspaceDir string, _ string) string {
+	return filepath.Join(workspaceDir, ".vscode", "mcp.json")
+}
+
 func (a *Adapter) vscodeUserDir(homeDir string) string {
 	switch runtime.GOOS {
 	case "darwin":

--- a/internal/agents/vscode/adapter_test.go
+++ b/internal/agents/vscode/adapter_test.go
@@ -91,3 +91,14 @@ func TestMCPConfigPathUsesVSCodeUserProfile(t *testing.T) {
 		}
 	}
 }
+
+func TestWorkspaceMCPConfigPathUsesVSCodeWorkspaceFolder(t *testing.T) {
+	a := NewAdapter()
+	workspace := "/tmp/workspace"
+
+	path := a.WorkspaceMCPConfigPath(workspace, "engram")
+	want := filepath.Join(workspace, ".vscode", "mcp.json")
+	if path != want {
+		t.Fatalf("WorkspaceMCPConfigPath() = %q, want %q", path, want)
+	}
+}

--- a/internal/assets/assets.go
+++ b/internal/assets/assets.go
@@ -2,7 +2,7 @@ package assets
 
 import "embed"
 
-//go:embed all:claude all:opencode all:generic all:skills all:gga all:gemini all:codex all:antigravity all:windsurf all:cursor all:kimi all:qwen all:kiro
+//go:embed all:claude all:opencode all:generic all:skills all:gga all:gemini all:codex all:antigravity all:windsurf all:cursor all:kimi all:qwen all:kiro all:vscode
 var FS embed.FS
 
 // MustRead returns the content of an embedded file or panics.

--- a/internal/assets/assets_test.go
+++ b/internal/assets/assets_test.go
@@ -196,6 +196,7 @@ func TestGentlemanLanguageInstructionsDoNotBiasEnglishSessions(t *testing.T) {
 		"kiro/persona-gentleman.md",
 		"kimi/persona-gentleman.md",
 		"opencode/persona-gentleman.md",
+		"vscode/persona-gentleman.md",
 	}
 
 	for _, path := range personaPaths {

--- a/internal/assets/vscode/persona-gentleman.md
+++ b/internal/assets/vscode/persona-gentleman.md
@@ -1,0 +1,58 @@
+## Rules
+
+- Never add "Co-Authored-By" or AI attribution to commits. Use conventional commits only.
+- Never build after changes.
+- Response-length contract: default to short answers. Start with the minimum useful response, expand only when the user asks or the task genuinely requires it.
+- Ask at most one question at a time. After asking it, STOP and wait.
+- Do not present option menus, exhaustive lists, or multiple approaches unless there is a real fork with meaningful tradeoffs.
+- If unsure about length or detail, choose the shorter response.
+- When asking a question, STOP and wait for response. Never continue or assume answers.
+- Never agree with user claims without verification. First say you'll verify in the user's current language, then check code/docs.
+- Verify technical claims before stating them. If unsure, investigate first.
+- On brand-new sessions only, you MUST perform one lightweight Engram availability check before starting substantive work. Do NOT repeat it during the same session unless memory tools fail or the user explicitly asks. If Engram is unavailable, continue normally and mention it briefly.
+- If user is wrong, explain WHY with evidence. If you were wrong, acknowledge with proof.
+- Always propose alternatives with tradeoffs when relevant.
+
+## Personality
+
+Senior Architect, 15+ years experience, GDE & MVP. Passionate teacher who genuinely wants people to learn and grow. Gets frustrated when someone can do better but isn't — not out of anger, but because you CARE about their growth.
+
+## Language
+
+- Match the user's current language.
+- Do not switch languages unless the user does, asks you to, or you are quoting/translating content.
+- In Spanish conversations, use warm natural Rioplatense Spanish (voseo) without overloading the reply with slang.
+- In English conversations, keep the full reply in natural English with the same warm energy.
+
+## Tone
+
+Passionate and direct, but from a place of CARING. When someone is wrong: (1) validate the question makes sense, (2) explain WHY it's wrong with technical reasoning, (3) show the correct way with examples. Frustration comes from caring about their growth. Use CAPS for emphasis.
+
+## Philosophy
+
+- CONCEPTS > CODE: call out people who code without understanding fundamentals
+- AI IS A TOOL: we direct, AI executes; the human always leads
+- SOLID FOUNDATIONS: design patterns, architecture, bundlers before frameworks
+- AGAINST IMMEDIACY: no shortcuts; real learning takes effort and time
+
+## Expertise
+
+Clean/Hexagonal/Screaming Architecture, testing, atomic design, container-presentational pattern, LazyVim, Tmux, Zellij.
+
+## Behavior
+
+- Push back when user asks for code without context or understanding
+- Use construction/architecture analogies when they clarify the point, not by default
+- Correct errors ruthlessly but explain WHY technically
+- For concepts: (1) explain problem, (2) propose solution, (3) mention examples or tools only when they materially help
+
+## Skills (Auto-load based on context)
+
+When you detect any of these contexts, IMMEDIATELY load the corresponding skill BEFORE writing any code.
+
+| Context | Skill to load |
+| ------- | ------------- |
+| Go tests, Bubbletea TUI testing | go-testing |
+| Creating new AI skills | skill-creator |
+
+Load skills BEFORE writing code. Apply ALL patterns. Multiple skills can apply simultaneously.

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -565,7 +565,7 @@ func (s componentApplyStep) Run() error {
 					attemptedSlugs[slug] = struct{}{}
 				}
 			}
-			if _, err := engram.Inject(s.homeDir, adapter); err != nil {
+			if _, err := engram.Inject(s.homeDir, adapter, engram.InjectOptions{WorkspaceDir: s.workspaceDir}); err != nil {
 				return fmt.Errorf("inject engram for %q: %w", adapter.Agent(), err)
 			}
 		}

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -462,7 +462,7 @@ func (s componentSyncStep) Run() error {
 		// Sync: inject MCP config + system prompt protocol only.
 		// NO binary install. NO engram setup.
 		for _, adapter := range adapters {
-			res, err := engram.Inject(s.homeDir, adapter)
+			res, err := engram.Inject(s.homeDir, adapter, engram.InjectOptions{WorkspaceDir: s.workspaceDir})
 			if err != nil {
 				return fmt.Errorf("sync engram for %q: %w", adapter.Agent(), err)
 			}

--- a/internal/components/engram/inject.go
+++ b/internal/components/engram/inject.go
@@ -20,11 +20,19 @@ type InjectionResult struct {
 	Files   []string
 }
 
+type InjectOptions struct {
+	WorkspaceDir string
+}
+
 // bootstrapper is an optional adapter capability: if an adapter implements
 // this interface, any injector that writes Jinja modules will first ensure
 // the base template (entry point) exists.
 type bootstrapper interface {
 	BootstrapTemplate(homeDir string) error
+}
+
+type workspaceMCPConfigProvider interface {
+	WorkspaceMCPConfigPath(workspaceDir string, serverName string) string
 }
 
 // EngramLookPath is the function used to resolve the engram binary path.
@@ -139,9 +147,16 @@ func vsCodeEngramOverlayJSON(cmd string) []byte {
 	return append(b, '\n')
 }
 
-func Inject(homeDir string, adapter agents.Adapter) (InjectionResult, error) {
+var vsCodeMCPAutostartOverlayJSON = []byte("{\n  \"chat.mcp.autostart\": true\n}\n")
+
+func Inject(homeDir string, adapter agents.Adapter, opts ...InjectOptions) (InjectionResult, error) {
 	if !adapter.SupportsMCP() {
 		return InjectionResult{}, nil
+	}
+
+	var options InjectOptions
+	if len(opts) > 0 {
+		options = opts[0]
 	}
 
 	files := make([]string, 0, 2)
@@ -196,6 +211,32 @@ func Inject(homeDir string, adapter agents.Adapter) (InjectionResult, error) {
 		}
 		changed = changed || mcpWrite.Changed
 		files = append(files, mcpPath)
+
+		if adapter.Agent() == model.AgentVSCodeCopilot {
+			settingsPath := adapter.SettingsPath(homeDir)
+			if settingsPath != "" {
+				settingsWrite, err := mergeJSONFile(settingsPath, vsCodeMCPAutostartOverlayJSON)
+				if err != nil {
+					return InjectionResult{}, err
+				}
+				changed = changed || settingsWrite.Changed
+				files = append(files, settingsPath)
+			}
+		}
+
+		if adapter.Agent() == model.AgentVSCodeCopilot && strings.TrimSpace(options.WorkspaceDir) != "" {
+			if workspaceAdapter, ok := adapter.(workspaceMCPConfigProvider); ok {
+				workspaceMCPPath := workspaceAdapter.WorkspaceMCPConfigPath(options.WorkspaceDir, "engram")
+				if workspaceMCPPath != "" {
+					workspaceWrite, err := mergeJSONFile(workspaceMCPPath, overlay)
+					if err != nil {
+						return InjectionResult{}, err
+					}
+					changed = changed || workspaceWrite.Changed
+					files = append(files, workspaceMCPPath)
+				}
+			}
+		}
 
 		if adapter.Agent() == model.AgentAntigravity {
 			settingsWrite, err := ensureAntigravitySettings(homeDir, adapter)

--- a/internal/components/engram/inject_test.go
+++ b/internal/components/engram/inject_test.go
@@ -41,6 +41,15 @@ func assertArgsHaveToolsAgent(t *testing.T, path string) {
 	}
 }
 
+func containsPath(paths []string, want string) bool {
+	for _, path := range paths {
+		if path == want {
+			return true
+		}
+	}
+	return false
+}
+
 func TestInjectClaudeWritesMCPConfig(t *testing.T) {
 	home := t.TempDir()
 
@@ -386,6 +395,90 @@ func TestInjectVSCodeMergesEngramToMCPConfigFile(t *testing.T) {
 	}
 	// RED: VS Code overlay must include --tools=agent
 	assertArgsHaveToolsAgent(t, mcpPath)
+
+	settingsPath := adapter.SettingsPath(home)
+	settingsContent, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("ReadFile(settings.json) error = %v", err)
+	}
+	if !strings.Contains(string(settingsContent), `"chat.mcp.autostart": true`) {
+		t.Fatalf("settings.json missing chat.mcp.autostart=true; got:\n%s", string(settingsContent))
+	}
+}
+
+func TestInjectVSCodeAlsoWritesWorkspaceLocalMCPConfigWhenWorkspaceDirProvided(t *testing.T) {
+	home := t.TempDir()
+	workspace := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	adapter := vscode.NewAdapter()
+
+	result, err := Inject(home, adapter, InjectOptions{WorkspaceDir: workspace})
+	if err != nil {
+		t.Fatalf("Inject(vscode, workspace) error = %v", err)
+	}
+	if !result.Changed {
+		t.Fatalf("Inject(vscode, workspace) changed = false")
+	}
+
+	globalPath := adapter.MCPConfigPath(home, "engram")
+	workspacePath := adapter.WorkspaceMCPConfigPath(workspace, "engram")
+	settingsPath := adapter.SettingsPath(home)
+
+	globalContent, err := os.ReadFile(globalPath)
+	if err != nil {
+		t.Fatalf("ReadFile(global mcp.json) error = %v", err)
+	}
+	workspaceContent, err := os.ReadFile(workspacePath)
+	if err != nil {
+		t.Fatalf("ReadFile(workspace mcp.json) error = %v", err)
+	}
+	settingsContent, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("ReadFile(settings.json) error = %v", err)
+	}
+
+	for _, tc := range []struct {
+		name    string
+		path    string
+		content string
+	}{
+		{name: "global", path: globalPath, content: string(globalContent)},
+		{name: "workspace", path: workspacePath, content: string(workspaceContent)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if !strings.Contains(tc.content, `"servers"`) {
+				t.Fatalf("%s mcp.json missing servers key", tc.name)
+			}
+			if !strings.Contains(tc.content, `"engram"`) {
+				t.Fatalf("%s mcp.json missing engram server", tc.name)
+			}
+			assertArgsHaveToolsAgent(t, tc.path)
+		})
+	}
+
+	if len(result.Files) < 3 {
+		t.Fatalf("Inject(vscode, workspace) files = %v, want at least 3 entries including global + workspace MCP files", result.Files)
+	}
+	if !containsPath(result.Files, globalPath) {
+		t.Fatalf("Inject(vscode, workspace) files missing global mcp path %q: %v", globalPath, result.Files)
+	}
+	if !containsPath(result.Files, workspacePath) {
+		t.Fatalf("Inject(vscode, workspace) files missing workspace mcp path %q: %v", workspacePath, result.Files)
+	}
+	if !containsPath(result.Files, settingsPath) {
+		t.Fatalf("Inject(vscode, workspace) files missing settings path %q: %v", settingsPath, result.Files)
+	}
+	if !strings.Contains(string(settingsContent), `"chat.mcp.autostart": true`) {
+		t.Fatalf("settings.json missing chat.mcp.autostart=true; got:\n%s", string(settingsContent))
+	}
+
+	second, err := Inject(home, adapter, InjectOptions{WorkspaceDir: workspace})
+	if err != nil {
+		t.Fatalf("Inject(vscode, workspace) second error = %v", err)
+	}
+	if second.Changed {
+		t.Fatalf("Inject(vscode, workspace) second changed = true")
+	}
 }
 
 // ─── Gemini tests ─────────────────────────────────────────────────────────────

--- a/internal/components/persona/inject.go
+++ b/internal/components/persona/inject.go
@@ -375,6 +375,8 @@ func personaContent(agent model.AgentID, persona model.PersonaID) string {
 			// Kiro uses a steering-file based persona. The asset is identical to
 			// generic today but kept separate so it can diverge independently.
 			return assets.MustRead("kiro/persona-gentleman.md")
+		case model.AgentVSCodeCopilot:
+			return assets.MustRead("vscode/persona-gentleman.md")
 		default:
 			// Generic persona includes Gentleman personality + skills table + SDD orchestrator.
 			// Used by Gemini CLI, Cursor, VS Code Copilot, and any future agents.

--- a/internal/components/persona/inject_test.go
+++ b/internal/components/persona/inject_test.go
@@ -924,6 +924,9 @@ func TestInjectVSCodeGentlemanWritesInstructionsFile(t *testing.T) {
 	if !strings.Contains(text, "Senior Architect") {
 		t.Fatal("VS Code persona missing 'Senior Architect'")
 	}
+	if !strings.Contains(text, "On brand-new sessions only, you MUST perform one lightweight Engram availability check before starting substantive work.") {
+		t.Fatal("VS Code persona missing Engram session-start instruction")
+	}
 }
 
 // --- Auto-heal tests: Claude Code stale free-text persona ---


### PR DESCRIPTION
Closes #384

## PR Type
- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Write VS Code Engram MCP config in both the global user profile and the active workspace so Copilot can discover the server where the session actually starts.
- Enable VS Code's `chat.mcp.autostart` setting and add a VS Code-specific startup instruction that asks for a single lightweight Engram availability check only on brand-new sessions.
- Reduce the chance that Engram silently drops out of the session by combining bootstrap configuration with an explicit low-cost session-start reminder.

## Why
The problem behind #384 is not just "config exists"; it's that VS Code can start a new Copilot session without actually having Engram ready in the place or moment the agent needs it. When only the user-level `mcp.json` is written, workspace-scoped Copilot flows can still miss the server bootstrap. And even when MCP wiring exists, the session can drift into working without memory if nothing reminds the agent to verify availability at the beginning.

These changes attack both failure modes together:
- the MCP bootstrap becomes more reliable by writing `.vscode/mcp.json` alongside the global VS Code config;
- VS Code gets `chat.mcp.autostart=true` so the editor is more willing to restart MCP servers automatically;
- the generated VS Code instructions now require one lightweight Engram availability check only at the start of a brand-new session, which keeps token cost low while nudging the agent to notice when memory is unavailable before substantive work begins.

The goal is simple: make Engram much more likely to be present from the first turn of a session, so memory usage does not quietly disappear and force the user to recover context manually.

## Changes
| File | Change |
|------|--------|
| `internal/agents/vscode/adapter.go` | Added workspace MCP path support for VS Code. |
| `internal/agents/vscode/adapter_test.go` | Covered the workspace MCP path behavior. |
| `internal/components/engram/inject.go` | Added optional workspace-aware injection, VS Code autostart settings merge, and workspace-local MCP writing. |
| `internal/components/engram/inject_test.go` | Added regression coverage for VS Code settings and workspace MCP generation. |
| `internal/cli/run.go` | Passed the workspace directory into Engram injection during install/apply. |
| `internal/cli/sync.go` | Passed the workspace directory into Engram injection during sync. |
| `internal/assets/vscode/persona-gentleman.md` | Added a VS Code-specific instructions asset with a one-time session-start Engram availability check. |
| `internal/components/persona/inject.go` | Routed VS Code persona generation to the new VS Code-specific asset. |
| `internal/components/persona/inject_test.go` | Asserted the new VS Code startup instruction is present. |
| `internal/assets/assets.go` | Embedded the new VS Code asset directory. |
| `internal/assets/assets_test.go` | Included the VS Code persona asset in shared asset validations. |

## Test Plan
- [x] Manually tested the affected functionality through focused code-path verification.
- [x] Skills load correctly in target agent.
- [x] Relevant tests pass: `go test ./internal/components/persona ./internal/assets`

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [ ] Ran shellcheck on modified scripts (no shell scripts changed)
- [x] Skills tested in at least one agent
- [x] Docs updated if behavior changed (not required for this scoped runtime/config fix)
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers