### PR TITLE
feat(pi): add first-class PI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,13 @@ This is NOT an AI agent installer. Most agents are easy to install. This is an *
 
 **After**: Your agent now has memory, skills, workflow, MCP tools, and a persona that actually teaches you.
 
-### 10 Supported Agents
+### 11 Supported Agents
 
 | Agent | Delegation Model | Key Feature |
 |-------|:---:|---|
 | **Claude Code** | Full (Task tool) | Sub-agents, output styles |
 | **OpenCode** | Full (multi-mode overlay) | Per-phase model routing |
+| **PI Coding Agent** | Base support (non-parity) | Experimental adapter boundary (no OpenCode parity claims) |
 | **Gemini CLI** | Full (experimental) | Custom agents in `~/.gemini/agents/` |
 | **Cursor** | Full (native subagents) | 9 SDD agents in `~/.cursor/agents/` |
 | **VS Code Copilot** | Full (runSubagent) | Parallel execution |
@@ -41,6 +42,8 @@ This is NOT an AI agent installer. Most agents are easy to install. This is an *
 | **Qwen Code** | Full (native sub-agents) | Slash commands, `~/.qwen/commands/`, `auto_edit` mode |
 
 > **Note**: This project supersedes [Agent Teams Lite](https://github.com/Gentleman-Programming/agent-teams-lite) (now archived). Everything ATL provided is included here with better installation, automatic updates, and persistent memory.
+
+> **PI support status**: PI is **base-supported, conditional multi-model**. Root path precedence is `PI_CODING_AGENT_DIR` → `~/.pi/agent`, with legacy `~/.config/pi-coding-agent` used only for compatibility detection. PI uses the existing **PI→Engram extension** contract as baseline integration, accepting either explicit `engram.extension.path` or package-based installs in `packages[]` (for example `../../Documents/repos/pi-engram` or `npm:pi-engram`). MCP/Context7 out of scope for this iteration (non-blocking). PI multi-model is enabled only when `pi-subagents` is installed (`pi install npm:pi-subagents`). See capability details: [docs/pi-compatibility.md](docs/pi-compatibility.md).
 
 ---
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -10,6 +10,7 @@
 | --------------- | ---------------- | ------------ | --- | ---------------------------- | ------------- | -------------- | ----------------------------------- |
 | Claude Code     | `claude-code`    | Yes          | Yes | Full (Task tool)             | Yes           | No             | `~/.claude`                         |
 | OpenCode        | `opencode`       | Yes          | Yes | Full (multi-mode overlay)    | No            | Yes            | `~/.config/opencode`                |
+| PI Coding Agent | `pi-coding-agent`| Yes          | Yes*| Base support + conditional multi-mode | No            | No             | `~/.config/pi-coding-agent`         |
 | Gemini CLI      | `gemini-cli`     | Yes          | Yes | Full (experimental)          | No            | No             | `~/.gemini`                         |
 | Cursor          | `cursor`         | Yes          | Yes | Full (native subagents)      | No            | No             | `~/.cursor`                         |
 | VS Code Copilot | `vscode-copilot` | Yes          | Yes | Full (runSubagent)           | No            | No             | `~/.copilot` + VS Code User profile |
@@ -21,6 +22,8 @@
 | Kiro IDE        | `kiro-ide`       | Yes          | Yes | Full (native subagents)      | No            | No             | `~/.kiro`                           |
 
 All agents receive the **full SDD orchestrator** injected into their system prompt, plus skill files written to their skills directory. The agent handles SDD automatically when the task is large enough, or when the user explicitly asks for it — no manual setup required.
+
+\* PI support is base single-mode by default. Multi-model is unlocked only when `pi-subagents` is installed.
 
 ---
 
@@ -64,15 +67,25 @@ Kiro uses native custom agents in `~/.kiro/agents/`. `gentle-ai` writes 10 phase
 
 ## SDD Mode Support
 
-| Feature | Claude Code | OpenCode | Gemini CLI | Cursor | VS Code Copilot | Codex | Windsurf | Antigravity | Kiro IDE | Qwen Code |
-|---------|:-----------:|:--------:|:----------:|:------:|:---------------:|:-----:|:--------:|:-----------:|:--------:|:---------:|
-| SDD orchestrator | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
-| Single-mode SDD | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
-| Multi-mode SDD | — | Yes | — | — | — | — | — | — | Yes* | — |
+| Feature | Claude Code | OpenCode | PI Coding Agent | Gemini CLI | Cursor | VS Code Copilot | Codex | Windsurf | Antigravity | Kiro IDE | Qwen Code |
+|---------|:-----------:|:--------:|:---------------:|:----------:|:------:|:---------------:|:-----:|:--------:|:-----------:|:--------:|:---------:|
+| SDD orchestrator | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| Single-mode SDD | Yes | Yes | Yes (base) | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| Multi-mode SDD | — | Yes | Yes** | — | — | — | — | — | — | Yes* | — |
 
 **Multi-mode** (assigning different AI models to each SDD phase) is natively supported by **OpenCode** (via its provider system) and **Kiro IDE** (via native subagent `model:` frontmatter — each phase agent runs with its own model ID). All other agents run in **single-mode** — the orchestrator manages everything using whatever model the agent is already running.
 
+For **PI Coding Agent**, support is conditional by runtime capability:
+
+- Without `pi-subagents` installed: PI remains single-mode and fail-closed (`profiles=false`, `modelPicker=false`, `generatedMulti=false`).
+- With `pi-subagents` installed: PI multi-model SDD is enabled and `.pi/agents/*.md` + `.pi/agents/sdd.chain.md` artifacts are generated.
+- Install/remediation command: `pi install npm:pi-subagents`
+
+PI conditional capability evidence and verify checklist are tracked in [docs/pi-compatibility.md](pi-compatibility.md).
+
 > \* **Kiro multi-mode** assigns models per phase through `KiroModelAssignments` (configured via *Configure Models → Configure Kiro models* in the TUI). The selected alias (`opus|sonnet|haiku`) is resolved to a Kiro-native model ID and stamped into each `~/.kiro/agents/sdd-{phase}.md` at sync time.
+>
+> \** **PI multi-mode** requires `pi-subagents`. PI base mode does not infer Claude aliases (`opus|sonnet|haiku`) as PI base model configuration; PI multi-model assignments must be explicit `provider/model` values.
 
 ---
 
@@ -91,6 +104,17 @@ Kiro uses native custom agents in `~/.kiro/agents/`. `gentle-ai` writes 10 phase
 - Slash commands for SDD phases (`/sdd-new`, `/sdd-explore`, etc.)
 - Background-agents plugin for parallel execution
 - Multi-mode prerequisite: connect your AI providers first, then run `opencode models --refresh`
+
+### PI Coding Agent
+
+- Config root: `~/.config/pi-coding-agent`
+- Current support tier: **base support + conditional multi-model**
+- Base path (no extension): PI remains single-mode with guardrails:
+  - `profiles=false`
+  - `modelPicker=false`
+  - `generatedMulti=false`
+- Multi-model prerequisite: install `pi-subagents` with `pi install npm:pi-subagents`
+- PI multi-model model assignments use explicit `provider/model` values (no Claude alias fallback for PI base config).
 
 ### Gemini CLI
 

--- a/docs/pi-compatibility.md
+++ b/docs/pi-compatibility.md
@@ -1,0 +1,59 @@
+# PI Compatibility (Gap-Closure Scope)
+
+This document tracks the current PI contract in gentle-ai after `pi-support-gap-closure`.
+
+## Contract Summary
+
+- PI root resolution uses `PI_CODING_AGENT_DIR` first, then defaults to `~/.pi/agent`.
+- Global PI root stores settings/prompt/skills (`<resolved-root>`), while PI generated multi-agent SDD artifacts are written to project-root `.pi/agents/*`.
+- Legacy `~/.config/pi-coding-agent` remains detection-only compatibility.
+- PI uses the existing **PI→Engram extension** contract as the integration baseline.
+- Contract can come from explicit `engram.extension.path` + `engram.extension.enabled=true`, or from `packages[]` entries that identify PI Engram (`../../.../pi-engram`, `npm:pi-engram`, scoped variants).
+- MCP and Context7 are out of scope for this iteration and are NOT blockers for PI support.
+- Generated `.pi/agents/sdd.chain.md` uses native `pi-subagents` chain syntax: frontmatter + `## <agent-name>` step headings (`sdd-init` → `sdd-archive`).
+- `sdd-onboard` remains an optional standalone agent (not part of the default linear chain).
+
+PI multi-model SDD remains enabled only when `pi-subagents` is detected.
+
+Prerequisite/remediation command:
+
+```bash
+pi install npm:pi-subagents
+```
+
+- Canonical preflight message when unavailable:
+
+> PI multi-model requires installing the `pi-subagents` extension.
+
+## Capability Matrix
+
+| PI Runtime State | `profiles` | `modelPicker` | `generatedMulti` | Behavior |
+|---|:---:|:---:|:---:|---|
+| PI without `pi-subagents` | false | false | false | Base single-mode only; multi-mode requests fail with canonical message |
+| PI with `pi-subagents` | true | true | true | Multi-model SDD enabled; `.pi/agents/*.md` + `sdd.chain.md` generated |
+
+## Guardrails
+
+- PI multi-model assignments must be explicit `provider/model` values.
+- PI phases must not fabricate `openai/gpt-5` when no explicit assignment exists.
+- OpenCode and Claude/Kiro behavior must remain unchanged by PI-specific changes.
+- MCP and Context7 are out of scope for this iteration.
+
+## Regression Evidence (OpenCode Safety)
+
+Run these focused suites when touching PI capability gating, sync/preflight, or SDD injection:
+
+```bash
+go test ./internal/tui -run "TestAgentsViewWithPISelectionShowsCapabilityWarning|TestRenderModelPicker_EmptyStateIncludesCapabilityGatedWarning|TestRenderModelPicker_PIEnabledOmitsLegacyOpenCodeOnlyWarning|TestRenderModelPicker_PIUnsupportedBlocksMultiModelControlsWithCanonicalWarning"
+go test ./internal/cli -run "TestValidatePiMultiModelPreflightFailsWithoutPiSubagents|TestValidatePiMultiModelPreflightAllowsWhenPiSubagentsPresent|TestValidatePiMultiModelPreflightNoopForOpenCodeRegressionSafety"
+go test ./internal/components/sdd -run "TestInjectOpenCode|TestInjectPI"
+go test ./...
+```
+
+## Final Verify Checklist
+
+- [ ] Resolver matrix passes (PI detected/absent/ambiguous fail-closed).
+- [ ] TUI PI gating matches capabilities (single-mode fallback without extension, multi-mode when present).
+- [ ] CLI/preflight emits exact canonical message + install remediation command.
+- [ ] PI `.pi/agents` artifacts are generated only when capability is enabled.
+- [ ] OpenCode regression suites pass unchanged.

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -61,3 +61,10 @@ If the hash matches `checksums.txt`, the file is authentic for that release.
 | Kimi | `%USERPROFILE%\.kimi\` (includes `config.toml`, system prompt, agents, MCP) |
 | Antigravity | `%USERPROFILE%\.gemini\antigravity\` |
 | Kiro IDE | `%USERPROFILE%\.kiro\steering\` (prompts) + `%USERPROFILE%\.kiro\skills\` (skills) + `%USERPROFILE%\.kiro\agents\` (SDD agents) + `%APPDATA%\kiro\User\settings.json` (settings) + `%USERPROFILE%\.kiro\settings\mcp.json` (MCP) |
+
+## PI Notes
+
+- PI root path precedence: `PI_CODING_AGENT_DIR` → `~/.pi/agent`.
+- PI support integrates through the existing **PI→Engram extension** contract.
+- PI contract validation accepts explicit `engram.extension.path` and package-based installs in `packages[]` (for example `../../Documents/repos/pi-engram` or `npm:pi-engram`).
+- MCP/Context7 out of scope for this iteration (non-blocking for PI support).

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -32,6 +32,32 @@ The uninstall flow is also available from the TUI menu. It lets you:
 
 Before any managed file is modified, `gentle-ai` creates a backup snapshot so the configuration can be restored later if needed.
 
+### PI Support Guardrails (current)
+
+PI (`pi-coding-agent`) is **base-supported with conditional multi-model**.
+
+- Capability source: [PI Compatibility](pi-compatibility.md)
+- Base PI (no extension): single-mode + fail-closed guardrails
+  - `profiles=false`
+  - `modelPicker=false`
+  - `generatedMulti=false`
+- PI multi-model prerequisite/remediation: `pi install npm:pi-subagents`
+- PI multi-model assignments must be explicit `provider/model` values (do not use Claude alias defaults for PI base config).
+
+#### Regression pass criteria for PI-related changes
+
+When touching PI adapter, injection, or TUI gating, OpenCode behavior must remain unchanged and green:
+
+```bash
+# OpenCode regression suites (must pass)
+go test ./internal/components/sdd ./internal/components/mcp ./internal/components/engram ./internal/tui
+
+# Full project safety check under strict TDD runner
+go test ./...
+```
+
+Additionally, existing OpenCode fixtures/goldens used by those suites must not be rewritten as part of PI-only changes unless explicitly scoped as an OpenCode change.
+
 ---
 
 ## CLI Commands

--- a/internal/agents/capabilities/resolver.go
+++ b/internal/agents/capabilities/resolver.go
@@ -1,0 +1,86 @@
+package capabilities
+
+import (
+	"fmt"
+
+	"github.com/gentleman-programming/gentle-ai/internal/agents/pi"
+	"github.com/gentleman-programming/gentle-ai/internal/model"
+)
+
+const PiMultiModelRequiresPiSubagentsMessage = "PI multi-model requires installing the `pi-subagents` extension."
+
+const RequirementPiSubagentsInstalled RuntimeRequirementID = "pi-subagents-installed"
+
+type RuntimeRequirementID string
+
+type RuntimeRequirement struct {
+	ID      RuntimeRequirementID
+	Message string
+	Reason  string
+}
+
+type ResolvedCapabilities struct {
+	SupportsSDDMultiMode   bool
+	SupportsModelPicker    bool
+	SupportsGeneratedMulti bool
+	Requires               []RuntimeRequirement
+}
+
+type PiSubagentsDetector interface {
+	DetectPiSubagents(homeDir string, workspaceDir string) (bool, error)
+}
+
+type Resolver struct {
+	piDetector PiSubagentsDetector
+}
+
+func NewResolver(piDetector PiSubagentsDetector) *Resolver {
+	if piDetector == nil {
+		piDetector = pi.NewAdapter()
+	}
+
+	return &Resolver{piDetector: piDetector}
+}
+
+func (r *Resolver) Resolve(homeDir string, workspaceDir string, agentID model.AgentID) (ResolvedCapabilities, error) {
+	switch agentID {
+	case model.AgentOpenCode:
+		return enabledMultiModelCapabilities(), nil
+	case model.AgentPiCodingAgent:
+		detected, err := r.piDetector.DetectPiSubagents(homeDir, workspaceDir)
+		if err != nil {
+			return disabledPiCapabilities(fmt.Sprintf("pi-subagents detection failed: %v", err)), nil
+		}
+		if !detected {
+			return disabledPiCapabilities("pi-subagents extension not detected"), nil
+		}
+		return enabledMultiModelCapabilities(), nil
+	default:
+		return ResolvedCapabilities{}, nil
+	}
+}
+
+func enabledMultiModelCapabilities() ResolvedCapabilities {
+	return ResolvedCapabilities{
+		SupportsSDDMultiMode:   true,
+		SupportsModelPicker:    true,
+		SupportsGeneratedMulti: true,
+	}
+}
+
+func disabledPiCapabilities(reason string) ResolvedCapabilities {
+	return ResolvedCapabilities{
+		SupportsSDDMultiMode:   false,
+		SupportsModelPicker:    false,
+		SupportsGeneratedMulti: false,
+		Requires:               []RuntimeRequirement{piSubagentsRequirement(reason)},
+	}
+}
+
+func piSubagentsRequirement(reason string) RuntimeRequirement {
+	return RuntimeRequirement{
+		ID:      RequirementPiSubagentsInstalled,
+		Message: PiMultiModelRequiresPiSubagentsMessage,
+		Reason:  reason,
+	}
+}

--- a/internal/agents/capabilities/resolver_test.go
+++ b/internal/agents/capabilities/resolver_test.go
@@ -1,0 +1,143 @@
+package capabilities
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/internal/model"
+)
+
+type fakePiDetector struct {
+	detected bool
+	err      error
+}
+
+func TestResolverResolveFailsClosedWhenPiSettingsMalformed(t *testing.T) {
+	homeDir := t.TempDir()
+	workspaceDir := t.TempDir()
+
+	settingsPath := filepath.Join(homeDir, ".pi", "agent", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q) error = %v", filepath.Dir(settingsPath), err)
+	}
+
+	if err := os.WriteFile(settingsPath, []byte(`{"packages":["npm:pi-subagents"`), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q) error = %v", settingsPath, err)
+	}
+
+	resolver := NewResolver(nil)
+
+	got, err := resolver.Resolve(homeDir, workspaceDir, model.AgentPiCodingAgent)
+	if err != nil {
+		t.Fatalf("Resolve() error = %v, want nil", err)
+	}
+
+	if got.SupportsSDDMultiMode {
+		t.Fatal("Resolve().SupportsSDDMultiMode = true, want false")
+	}
+
+	if got.SupportsModelPicker {
+		t.Fatal("Resolve().SupportsModelPicker = true, want false")
+	}
+
+	if got.SupportsGeneratedMulti {
+		t.Fatal("Resolve().SupportsGeneratedMulti = true, want false")
+	}
+
+	if len(got.Requires) != 1 {
+		t.Fatalf("Resolve().Requires length = %d, want 1", len(got.Requires))
+	}
+
+	if got.Requires[0].Message != PiMultiModelRequiresPiSubagentsMessage {
+		t.Fatalf("Resolve().Requires[0].Message = %q, want %q", got.Requires[0].Message, PiMultiModelRequiresPiSubagentsMessage)
+	}
+}
+
+func (f fakePiDetector) DetectPiSubagents(_ string, _ string) (bool, error) {
+	return f.detected, f.err
+}
+
+func TestResolverResolve(t *testing.T) {
+	tests := []struct {
+		name                    string
+		agent                   model.AgentID
+		detector                fakePiDetector
+		wantSupportsSDDMulti    bool
+		wantSupportsModelPicker bool
+		wantSupportsGenerated   bool
+		wantRequirements        int
+		wantErr                 bool
+	}{
+		{
+			name:                    "pi with pi-subagents detected enables multi-model capabilities",
+			agent:                   model.AgentPiCodingAgent,
+			detector:                fakePiDetector{detected: true},
+			wantSupportsSDDMulti:    true,
+			wantSupportsModelPicker: true,
+			wantSupportsGenerated:   true,
+			wantRequirements:        0,
+		},
+		{
+			name:                    "pi without pi-subagents stays single-mode with requirement",
+			agent:                   model.AgentPiCodingAgent,
+			detector:                fakePiDetector{detected: false},
+			wantSupportsSDDMulti:    false,
+			wantSupportsModelPicker: false,
+			wantSupportsGenerated:   false,
+			wantRequirements:        1,
+		},
+		{
+			name:                    "pi detector error fails closed and returns requirement",
+			agent:                   model.AgentPiCodingAgent,
+			detector:                fakePiDetector{err: errors.New("permission denied")},
+			wantSupportsSDDMulti:    false,
+			wantSupportsModelPicker: false,
+			wantSupportsGenerated:   false,
+			wantRequirements:        1,
+		},
+		{
+			name:                    "opencode remains multi-model capable",
+			agent:                   model.AgentOpenCode,
+			detector:                fakePiDetector{detected: false},
+			wantSupportsSDDMulti:    true,
+			wantSupportsModelPicker: true,
+			wantSupportsGenerated:   true,
+			wantRequirements:        0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resolver := NewResolver(tt.detector)
+
+			got, err := resolver.Resolve("/tmp/home", "/tmp/workspace", tt.agent)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Resolve() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if got.SupportsSDDMultiMode != tt.wantSupportsSDDMulti {
+				t.Fatalf("Resolve().SupportsSDDMultiMode = %v, want %v", got.SupportsSDDMultiMode, tt.wantSupportsSDDMulti)
+			}
+
+			if got.SupportsModelPicker != tt.wantSupportsModelPicker {
+				t.Fatalf("Resolve().SupportsModelPicker = %v, want %v", got.SupportsModelPicker, tt.wantSupportsModelPicker)
+			}
+
+			if got.SupportsGeneratedMulti != tt.wantSupportsGenerated {
+				t.Fatalf("Resolve().SupportsGeneratedMulti = %v, want %v", got.SupportsGeneratedMulti, tt.wantSupportsGenerated)
+			}
+
+			if len(got.Requires) != tt.wantRequirements {
+				t.Fatalf("Resolve().Requires length = %d, want %d", len(got.Requires), tt.wantRequirements)
+			}
+
+			if tt.wantRequirements > 0 {
+				if got.Requires[0].Message != PiMultiModelRequiresPiSubagentsMessage {
+					t.Fatalf("Resolve().Requires[0].Message = %q, want %q", got.Requires[0].Message, PiMultiModelRequiresPiSubagentsMessage)
+				}
+			}
+		})
+	}
+}

--- a/internal/agents/discovery_test.go
+++ b/internal/agents/discovery_test.go
@@ -284,6 +284,36 @@ func TestDiscoverInstalled_WithDefaultRegistryAndRealFS(t *testing.T) {
 	}
 }
 
+// TestDiscoverInstalled_WithDefaultRegistryFindsPiConfig verifies PI appears in
+// discovery when its config root exists, proving default registry wiring.
+func TestDiscoverInstalled_WithDefaultRegistryFindsPiConfig(t *testing.T) {
+	home := t.TempDir()
+
+	piDir := filepath.Join(home, ".pi", "agent")
+	if err := os.MkdirAll(piDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	reg, err := NewDefaultRegistry()
+	if err != nil {
+		t.Fatalf("NewDefaultRegistry: %v", err)
+	}
+
+	got := DiscoverInstalled(reg, home)
+
+	if len(got) != 1 {
+		t.Fatalf("DiscoverInstalled() returned %d agents, want 1; got %v", len(got), got)
+	}
+
+	if got[0].ID != model.AgentPiCodingAgent {
+		t.Fatalf("DiscoverInstalled() agent = %q, want %q", got[0].ID, model.AgentPiCodingAgent)
+	}
+
+	if got[0].ConfigDir != piDir {
+		t.Fatalf("DiscoverInstalled() ConfigDir = %q, want %q", got[0].ConfigDir, piDir)
+	}
+}
+
 // TestConfigRootsForBackup_WithDefaultRegistryCoversCreatedDirs verifies that
 // ConfigRootsForBackup returns exactly the dirs created on disk.
 func TestConfigRootsForBackup_WithDefaultRegistryCoversCreatedDirs(t *testing.T) {

--- a/internal/agents/factory.go
+++ b/internal/agents/factory.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gentleman-programming/gentle-ai/internal/agents/kimi"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/kiro"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/opencode"
+	"github.com/gentleman-programming/gentle-ai/internal/agents/pi"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/qwen"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/vscode"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/windsurf"
@@ -24,6 +25,8 @@ func NewAdapter(agent model.AgentID) (Adapter, error) {
 		return claude.NewAdapter(), nil
 	case model.AgentOpenCode:
 		return opencode.NewAdapter(), nil
+	case model.AgentPiCodingAgent:
+		return pi.NewAdapter(), nil
 	case model.AgentKilocode:
 		return kilocode.NewAdapter(), nil
 	case model.AgentGeminiCLI:
@@ -50,11 +53,12 @@ func NewAdapter(agent model.AgentID) (Adapter, error) {
 }
 
 func NewDefaultRegistry() (*Registry, error) {
-	adapters := make([]Adapter, 0, 12)
+	adapters := make([]Adapter, 0, 13)
 
 	for _, agent := range []model.AgentID{
 		model.AgentClaudeCode,
 		model.AgentOpenCode,
+		model.AgentPiCodingAgent,
 		model.AgentKilocode,
 		model.AgentGeminiCLI,
 		model.AgentCursor,

--- a/internal/agents/pi/adapter.go
+++ b/internal/agents/pi/adapter.go
@@ -1,0 +1,185 @@
+package pi
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/gentleman-programming/gentle-ai/internal/model"
+	"github.com/gentleman-programming/gentle-ai/internal/system"
+)
+
+var LookPathOverride = exec.LookPath
+
+type statResult struct {
+	isDir bool
+	err   error
+}
+
+// Adapter implements agents.Adapter for PI Coding Agent.
+//
+// Phase 1 scope is an explicit boundary with conservative defaults:
+// - Config paths stay isolated in ~/.pi/agent, with legacy detection only
+// - Auto-install is disabled until install contracts are validated
+// - Profiles/model picker/generated multi are explicitly unsupported
+type Adapter struct {
+	lookPath func(string) (string, error)
+	statPath func(string) statResult
+}
+
+func NewAdapter() *Adapter {
+	return &Adapter{
+		lookPath: LookPathOverride,
+		statPath: defaultStat,
+	}
+}
+
+func (a *Adapter) Agent() model.AgentID {
+	return model.AgentPiCodingAgent
+}
+
+func (a *Adapter) Tier() model.SupportTier {
+	return model.TierFull
+}
+
+func (a *Adapter) Detect(_ context.Context, homeDir string) (bool, string, string, bool, error) {
+	paths := ResolvePaths(homeDir, os.Getenv)
+	configPath := paths.Root
+
+	binaryPath, err := a.lookPath("pi")
+	installed := err == nil
+
+	configFound, err := a.detectConfigPresence(paths)
+	if err != nil {
+		return false, "", "", false, err
+	}
+
+	return installed, binaryPath, configPath, configFound, nil
+}
+
+func (a *Adapter) detectConfigPresence(paths Paths) (bool, error) {
+	for _, candidate := range detectionConfigCandidates(paths) {
+		stat := a.statPath(candidate)
+		if stat.err == nil {
+			return stat.isDir, nil
+		}
+
+		if os.IsNotExist(stat.err) {
+			continue
+		}
+
+		return false, stat.err
+	}
+
+	return false, nil
+}
+
+func (a *Adapter) SupportsAutoInstall() bool {
+	return false
+}
+
+func (a *Adapter) InstallCommand(_ system.PlatformProfile) ([][]string, error) {
+	return nil, AgentNotInstallableError{Agent: model.AgentPiCodingAgent}
+}
+
+func (a *Adapter) GlobalConfigDir(homeDir string) string {
+	return ResolvePaths(homeDir, os.Getenv).Root
+}
+
+func (a *Adapter) SystemPromptDir(homeDir string) string {
+	return a.GlobalConfigDir(homeDir)
+}
+
+func (a *Adapter) SystemPromptFile(homeDir string) string {
+	return filepath.Join(a.SystemPromptDir(homeDir), "AGENTS.md")
+}
+
+func (a *Adapter) SkillsDir(homeDir string) string {
+	return filepath.Join(a.GlobalConfigDir(homeDir), "skills")
+}
+
+func (a *Adapter) SettingsPath(homeDir string) string {
+	return ResolvePaths(homeDir, os.Getenv).SettingsPath
+}
+
+func (a *Adapter) SystemPromptStrategy() model.SystemPromptStrategy {
+	return model.StrategyFileReplace
+}
+
+func (a *Adapter) MCPStrategy() model.MCPStrategy {
+	return model.StrategyMergeIntoSettings
+}
+
+func (a *Adapter) MCPConfigPath(homeDir string, _ string) string {
+	return a.SettingsPath(homeDir)
+}
+
+func (a *Adapter) SupportsOutputStyles() bool {
+	return false
+}
+
+func (a *Adapter) OutputStyleDir(_ string) string {
+	return ""
+}
+
+func (a *Adapter) SupportsSlashCommands() bool {
+	return false
+}
+
+func (a *Adapter) CommandsDir(homeDir string) string {
+	return filepath.Join(a.GlobalConfigDir(homeDir), "commands")
+}
+
+func (a *Adapter) SupportsSubAgents() bool {
+	return false
+}
+
+func (a *Adapter) SubAgentsDir(_ string) string {
+	return ""
+}
+
+func (a *Adapter) EmbeddedSubAgentsDir() string {
+	return ""
+}
+
+func (a *Adapter) SupportsSkills() bool {
+	return true
+}
+
+func (a *Adapter) SupportsSystemPrompt() bool {
+	return true
+}
+
+func (a *Adapter) SupportsMCP() bool {
+	return true
+}
+
+func (a *Adapter) SupportsProfiles() bool {
+	return false
+}
+
+func (a *Adapter) SupportsModelPicker() bool {
+	return false
+}
+
+func (a *Adapter) SupportsGeneratedMultiProfiles() bool {
+	return false
+}
+
+type AgentNotInstallableError struct {
+	Agent model.AgentID
+}
+
+func (e AgentNotInstallableError) Error() string {
+	return "agent " + string(e.Agent) + " auto-install is disabled until PI install contracts are validated"
+}
+
+func defaultStat(path string) statResult {
+	info, err := os.Stat(path)
+	if err != nil {
+		return statResult{err: err}
+	}
+
+	return statResult{isDir: info.IsDir()}
+}

--- a/internal/agents/pi/adapter_test.go
+++ b/internal/agents/pi/adapter_test.go
@@ -1,0 +1,201 @@
+package pi
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/internal/model"
+	"github.com/gentleman-programming/gentle-ai/internal/system"
+)
+
+func TestDetect(t *testing.T) {
+	tests := []struct {
+		name            string
+		lookPathPath    string
+		lookPathErr     error
+		stat            statResult
+		wantInstalled   bool
+		wantBinaryPath  string
+		wantConfigPath  string
+		wantConfigFound bool
+		wantErr         bool
+	}{
+		{
+			name:            "binary and config directory found",
+			lookPathPath:    "/usr/local/bin/pi",
+			stat:            statResult{isDir: true},
+			wantInstalled:   true,
+			wantBinaryPath:  "/usr/local/bin/pi",
+			wantConfigPath:  filepath.Join("/tmp/home", ".pi", "agent"),
+			wantConfigFound: true,
+		},
+		{
+			name:            "binary missing and config missing",
+			lookPathErr:     errors.New("missing"),
+			stat:            statResult{err: os.ErrNotExist},
+			wantInstalled:   false,
+			wantBinaryPath:  "",
+			wantConfigPath:  filepath.Join("/tmp/home", ".pi", "agent"),
+			wantConfigFound: false,
+		},
+		{
+			name:    "stat error bubbles up",
+			stat:    statResult{err: errors.New("permission denied")},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := &Adapter{
+				lookPath: func(string) (string, error) {
+					return tt.lookPathPath, tt.lookPathErr
+				},
+				statPath: func(string) statResult {
+					return tt.stat
+				},
+			}
+
+			installed, binaryPath, configPath, configFound, err := a.Detect(context.Background(), "/tmp/home")
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Detect() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if tt.wantErr {
+				return
+			}
+
+			if installed != tt.wantInstalled {
+				t.Fatalf("Detect() installed = %v, want %v", installed, tt.wantInstalled)
+			}
+
+			if binaryPath != tt.wantBinaryPath {
+				t.Fatalf("Detect() binaryPath = %q, want %q", binaryPath, tt.wantBinaryPath)
+			}
+
+			if configPath != tt.wantConfigPath {
+				t.Fatalf("Detect() configPath = %q, want %q", configPath, tt.wantConfigPath)
+			}
+
+			if configFound != tt.wantConfigFound {
+				t.Fatalf("Detect() configFound = %v, want %v", configFound, tt.wantConfigFound)
+			}
+		})
+	}
+}
+
+func TestInstallCommandReturnsNotInstallableError(t *testing.T) {
+	a := NewAdapter()
+
+	_, err := a.InstallCommand(system.PlatformProfile{OS: "linux", PackageManager: "apt"})
+	if err == nil {
+		t.Fatal("InstallCommand() error = nil, want error")
+	}
+
+	var notInstallable AgentNotInstallableError
+	if !errors.As(err, &notInstallable) {
+		t.Fatalf("InstallCommand() error = %T, want AgentNotInstallableError", err)
+	}
+}
+
+func TestAdapterBoundaryPathsAndCapabilities(t *testing.T) {
+	homeDir := t.TempDir()
+	a := NewAdapter()
+
+	if got := a.Agent(); got != model.AgentPiCodingAgent {
+		t.Fatalf("Agent() = %q, want %q", got, model.AgentPiCodingAgent)
+	}
+
+	if got := a.GlobalConfigDir(homeDir); got != filepath.Join(homeDir, ".pi", "agent") {
+		t.Fatalf("GlobalConfigDir() = %q, want %q", got, filepath.Join(homeDir, ".pi", "agent"))
+	}
+
+	if got := a.SettingsPath(homeDir); got != filepath.Join(homeDir, ".pi", "agent", "settings.json") {
+		t.Fatalf("SettingsPath() = %q, want %q", got, filepath.Join(homeDir, ".pi", "agent", "settings.json"))
+	}
+
+	if got := a.SkillsDir(homeDir); got != filepath.Join(homeDir, ".pi", "agent", "skills") {
+		t.Fatalf("SkillsDir() = %q, want %q", got, filepath.Join(homeDir, ".pi", "agent", "skills"))
+	}
+
+	if got := a.CommandsDir(homeDir); got != filepath.Join(homeDir, ".pi", "agent", "commands") {
+		t.Fatalf("CommandsDir() = %q, want %q", got, filepath.Join(homeDir, ".pi", "agent", "commands"))
+	}
+
+	if got := a.MCPStrategy(); got != model.StrategyMergeIntoSettings {
+		t.Fatalf("MCPStrategy() = %v, want %v", got, model.StrategyMergeIntoSettings)
+	}
+
+	if a.SupportsAutoInstall() {
+		t.Fatal("SupportsAutoInstall() = true, want false")
+	}
+
+	if a.SupportsSlashCommands() {
+		t.Fatal("SupportsSlashCommands() = true, want false")
+	}
+
+	if a.SupportsSubAgents() {
+		t.Fatal("SupportsSubAgents() = true, want false")
+	}
+
+	if a.SupportsOutputStyles() {
+		t.Fatal("SupportsOutputStyles() = true, want false")
+	}
+
+	if !a.SupportsSkills() {
+		t.Fatal("SupportsSkills() = false, want true")
+	}
+
+	if !a.SupportsSystemPrompt() {
+		t.Fatal("SupportsSystemPrompt() = false, want true")
+	}
+
+	if !a.SupportsMCP() {
+		t.Fatal("SupportsMCP() = false, want true")
+	}
+
+	if got := a.SupportsProfiles(); got {
+		t.Fatal("SupportsProfiles() = true, want false")
+	}
+
+	if got := a.SupportsModelPicker(); got {
+		t.Fatal("SupportsModelPicker() = true, want false")
+	}
+
+	if got := a.SupportsGeneratedMultiProfiles(); got {
+		t.Fatal("SupportsGeneratedMultiProfiles() = true, want false")
+	}
+}
+
+func TestDetectMarksConfigFoundWhenLegacyDirectoryExists(t *testing.T) {
+	a := &Adapter{
+		lookPath: func(string) (string, error) { return "", errors.New("missing") },
+		statPath: func(path string) statResult {
+			switch path {
+			case filepath.Join("/tmp/home", ".pi", "agent"):
+				return statResult{err: os.ErrNotExist}
+			case filepath.Join("/tmp/home", ".config", "pi-coding-agent"):
+				return statResult{isDir: true}
+			default:
+				return statResult{err: os.ErrNotExist}
+			}
+		},
+	}
+
+	installed, _, configPath, configFound, err := a.Detect(context.Background(), "/tmp/home")
+	if err != nil {
+		t.Fatalf("Detect() error = %v, want nil", err)
+	}
+	if installed {
+		t.Fatal("Detect() installed = true, want false")
+	}
+	if configPath != filepath.Join("/tmp/home", ".pi", "agent") {
+		t.Fatalf("Detect() configPath = %q, want %q", configPath, filepath.Join("/tmp/home", ".pi", "agent"))
+	}
+	if !configFound {
+		t.Fatal("Detect() configFound = false, want true when legacy dir exists")
+	}
+}

--- a/internal/agents/pi/compatibility_matrix.go
+++ b/internal/agents/pi/compatibility_matrix.go
@@ -1,0 +1,80 @@
+package pi
+
+type Contract string
+
+const (
+	ContractBinaryInstallMethod Contract = "binary-install-method"
+	ContractConfigRoot          Contract = "config-root"
+	ContractSettingsSchema      Contract = "settings-schema"
+	ContractMCPShape            Contract = "mcp-shape"
+	ContractCommandPromptLayout Contract = "command-prompt-layout"
+	ContractModelCacheAuth      Contract = "model-cache-auth"
+	ContractProfileSupport      Contract = "profile-support"
+)
+
+var requiredContracts = []Contract{
+	ContractBinaryInstallMethod,
+	ContractConfigRoot,
+	ContractSettingsSchema,
+	ContractMCPShape,
+	ContractCommandPromptLayout,
+	ContractModelCacheAuth,
+	ContractProfileSupport,
+}
+
+type ContractStatus string
+
+const (
+	ContractStatusPass    ContractStatus = "pass"
+	ContractStatusFail    ContractStatus = "fail"
+	ContractStatusUnknown ContractStatus = "unknown"
+)
+
+type ContractCheck struct {
+	Contract Contract
+	Status   ContractStatus
+	Reason   string
+}
+
+type RolloutReadiness struct {
+	Ready    bool
+	Blockers []ContractCheck
+}
+
+func EvaluateRolloutReadiness(matrix map[Contract]ContractStatus) RolloutReadiness {
+	result := RolloutReadiness{Ready: true}
+
+	for _, contract := range requiredContracts {
+		status, ok := matrix[contract]
+		if !ok {
+			result.Ready = false
+			result.Blockers = append(result.Blockers, ContractCheck{
+				Contract: contract,
+				Status:   ContractStatusUnknown,
+				Reason:   "missing evidence for required contract",
+			})
+			continue
+		}
+
+		switch status {
+		case ContractStatusPass:
+			continue
+		case ContractStatusFail:
+			result.Ready = false
+			result.Blockers = append(result.Blockers, ContractCheck{
+				Contract: contract,
+				Status:   ContractStatusFail,
+				Reason:   "status fail blocks rollout",
+			})
+		default:
+			result.Ready = false
+			result.Blockers = append(result.Blockers, ContractCheck{
+				Contract: contract,
+				Status:   ContractStatusUnknown,
+				Reason:   "status unknown blocks rollout",
+			})
+		}
+	}
+
+	return result
+}

--- a/internal/agents/pi/compatibility_matrix_test.go
+++ b/internal/agents/pi/compatibility_matrix_test.go
@@ -1,0 +1,172 @@
+package pi
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestEvaluateRolloutReadiness(t *testing.T) {
+	tests := []struct {
+		name         string
+		matrix       map[Contract]ContractStatus
+		wantReady    bool
+		wantBlockers []ContractCheck
+	}{
+		{
+			name: "all required contracts pass",
+			matrix: map[Contract]ContractStatus{
+				ContractBinaryInstallMethod: ContractStatusPass,
+				ContractConfigRoot:          ContractStatusPass,
+				ContractSettingsSchema:      ContractStatusPass,
+				ContractMCPShape:            ContractStatusPass,
+				ContractCommandPromptLayout: ContractStatusPass,
+				ContractModelCacheAuth:      ContractStatusPass,
+				ContractProfileSupport:      ContractStatusPass,
+			},
+			wantReady: true,
+		},
+		{
+			name: "fail status blocks rollout",
+			matrix: map[Contract]ContractStatus{
+				ContractBinaryInstallMethod: ContractStatusPass,
+				ContractConfigRoot:          ContractStatusFail,
+				ContractSettingsSchema:      ContractStatusPass,
+				ContractMCPShape:            ContractStatusPass,
+				ContractCommandPromptLayout: ContractStatusPass,
+				ContractModelCacheAuth:      ContractStatusPass,
+				ContractProfileSupport:      ContractStatusPass,
+			},
+			wantReady: false,
+			wantBlockers: []ContractCheck{
+				{Contract: ContractConfigRoot, Status: ContractStatusFail, Reason: "status fail blocks rollout"},
+			},
+		},
+		{
+			name: "unknown status blocks rollout",
+			matrix: map[Contract]ContractStatus{
+				ContractBinaryInstallMethod: ContractStatusPass,
+				ContractConfigRoot:          ContractStatusPass,
+				ContractSettingsSchema:      ContractStatusUnknown,
+				ContractMCPShape:            ContractStatusPass,
+				ContractCommandPromptLayout: ContractStatusPass,
+				ContractModelCacheAuth:      ContractStatusPass,
+				ContractProfileSupport:      ContractStatusPass,
+			},
+			wantReady: false,
+			wantBlockers: []ContractCheck{
+				{Contract: ContractSettingsSchema, Status: ContractStatusUnknown, Reason: "status unknown blocks rollout"},
+			},
+		},
+		{
+			name: "missing contract becomes unknown blocker with deterministic order",
+			matrix: map[Contract]ContractStatus{
+				ContractSettingsSchema:      ContractStatusPass,
+				ContractMCPShape:            ContractStatusPass,
+				ContractCommandPromptLayout: ContractStatusFail,
+				ContractProfileSupport:      ContractStatusUnknown,
+			},
+			wantReady: false,
+			wantBlockers: []ContractCheck{
+				{Contract: ContractBinaryInstallMethod, Status: ContractStatusUnknown, Reason: "missing evidence for required contract"},
+				{Contract: ContractConfigRoot, Status: ContractStatusUnknown, Reason: "missing evidence for required contract"},
+				{Contract: ContractCommandPromptLayout, Status: ContractStatusFail, Reason: "status fail blocks rollout"},
+				{Contract: ContractModelCacheAuth, Status: ContractStatusUnknown, Reason: "missing evidence for required contract"},
+				{Contract: ContractProfileSupport, Status: ContractStatusUnknown, Reason: "status unknown blocks rollout"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := EvaluateRolloutReadiness(tt.matrix)
+
+			if got.Ready != tt.wantReady {
+				t.Fatalf("EvaluateRolloutReadiness().Ready = %v, want %v", got.Ready, tt.wantReady)
+			}
+
+			if len(got.Blockers) != len(tt.wantBlockers) {
+				t.Fatalf("EvaluateRolloutReadiness().Blockers length = %d, want %d, got=%v", len(got.Blockers), len(tt.wantBlockers), got.Blockers)
+			}
+
+			for i := range tt.wantBlockers {
+				if got.Blockers[i] != tt.wantBlockers[i] {
+					t.Fatalf("EvaluateRolloutReadiness().Blockers[%d] = %+v, want %+v", i, got.Blockers[i], tt.wantBlockers[i])
+				}
+			}
+		})
+	}
+}
+
+func TestPICompatibilityDocDocumentsConditionalCapabilityContract(t *testing.T) {
+	root := projectRootFromThisFile(t)
+
+	docPath := filepath.Join(root, "docs", "pi-compatibility.md")
+	assertFileContains(t, docPath, "Capability Matrix")
+	assertFileContains(t, docPath, "pi install npm:pi-subagents")
+	assertFileContains(t, docPath, "profiles")
+	assertFileContains(t, docPath, "modelPicker")
+	assertFileContains(t, docPath, "generatedMulti")
+	assertFileContains(t, docPath, "PI multi-model requires installing the `pi-subagents` extension.")
+
+	settingsFixture := filepath.Join(root, "testdata", "pi", "settings.sample.json")
+	mcpFixture := filepath.Join(root, "testdata", "pi", "mcp.sample.json")
+	commandFixture := filepath.Join(root, "testdata", "pi", "command.sample.md")
+	unknownFixture := filepath.Join(root, "testdata", "pi", "unknown-fields.md")
+
+	assertFileContains(t, settingsFixture, "_meta")
+	assertFileContains(t, mcpFixture, "mcpServers")
+	assertFileContains(t, commandFixture, "sdd-apply")
+	assertFileContains(t, unknownFixture, "unknown")
+	assertFileContains(t, unknownFixture, "unsupported")
+}
+
+func TestPIDocumentationDriftGuardsForAmendedScope(t *testing.T) {
+	root := projectRootFromThisFile(t)
+
+	assertFileContains(t, filepath.Join(root, "docs", "pi-compatibility.md"), "PI_CODING_AGENT_DIR")
+	assertFileContains(t, filepath.Join(root, "docs", "pi-compatibility.md"), "~/.pi/agent")
+	assertFileContains(t, filepath.Join(root, "docs", "pi-compatibility.md"), "Global PI root stores settings/prompt/skills")
+	assertFileContains(t, filepath.Join(root, "docs", "pi-compatibility.md"), "project-root `.pi/agents/*`")
+	assertFileContains(t, filepath.Join(root, "docs", "pi-compatibility.md"), "MCP and Context7 are out of scope")
+	assertFileContains(t, filepath.Join(root, "docs", "pi-compatibility.md"), "packages")
+	assertFileContains(t, filepath.Join(root, "docs", "pi-compatibility.md"), "npm:pi-engram")
+	assertFileContains(t, filepath.Join(root, "docs", "pi-compatibility.md"), "frontmatter + `## <agent-name>` step headings")
+	assertFileContains(t, filepath.Join(root, "docs", "pi-compatibility.md"), "`sdd-onboard` remains an optional standalone agent")
+
+	assertFileContains(t, filepath.Join(root, "docs", "platforms.md"), "PI_CODING_AGENT_DIR")
+	assertFileContains(t, filepath.Join(root, "docs", "platforms.md"), "PI→Engram extension")
+	assertFileContains(t, filepath.Join(root, "docs", "platforms.md"), "MCP/Context7 out of scope")
+	assertFileContains(t, filepath.Join(root, "docs", "platforms.md"), "packages")
+
+	assertFileContains(t, filepath.Join(root, "README.md"), "PI_CODING_AGENT_DIR")
+	assertFileContains(t, filepath.Join(root, "README.md"), "PI→Engram extension")
+	assertFileContains(t, filepath.Join(root, "README.md"), "MCP/Context7 out of scope")
+	assertFileContains(t, filepath.Join(root, "README.md"), "npm:pi-engram")
+}
+
+func projectRootFromThisFile(t *testing.T) string {
+	t.Helper()
+
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", "..", ".."))
+}
+
+func assertFileContains(t *testing.T, path string, want string) {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+
+	if !strings.Contains(string(data), want) {
+		t.Fatalf("%s does not contain %q", path, want)
+	}
+}

--- a/internal/agents/pi/detector.go
+++ b/internal/agents/pi/detector.go
@@ -1,0 +1,148 @@
+package pi
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func (a *Adapter) DetectPiSubagents(homeDir string, workspaceDir string) (bool, error) {
+	// Prefer authoritative PI settings package declarations first.
+	// Legacy footprint checks remain as a fallback for older layouts.
+	for _, settingsPath := range a.piSettingsPaths(homeDir, workspaceDir) {
+		detected, err := detectPiSubagentsFromSettings(settingsPath)
+		if err != nil {
+			return false, err
+		}
+
+		if detected {
+			return true, nil
+		}
+	}
+
+	for _, footprint := range a.PiSubagentsFootprints(homeDir, workspaceDir) {
+		stat := a.detectStat(footprint)
+		if stat.err == nil {
+			return true, nil
+		}
+
+		if isNotExist(stat.err) {
+			continue
+		}
+
+		return false, stat.err
+	}
+
+	return false, nil
+}
+
+func (a *Adapter) PiSubagentsFootprints(homeDir string, workspaceDir string) []string {
+	paths := ResolvePaths(homeDir, os.Getenv)
+	footprints := []string{
+		filepath.Join(paths.Root, "extensions", "pi-subagents"),
+		filepath.Join(paths.Root, "extensions", "pi-subagents.json"),
+		filepath.Join(paths.LegacyConfigDir, "extensions", "pi-subagents"),
+		filepath.Join(paths.LegacyConfigDir, "extensions", "pi-subagents.json"),
+	}
+	for _, base := range workspaceCandidates(workspaceDir) {
+		footprints = append(footprints,
+			filepath.Join(base, ".pi", "extensions", "pi-subagents"),
+			filepath.Join(base, ".pi", "extensions", "pi-subagents.json"),
+		)
+	}
+	return footprints
+}
+
+func (a *Adapter) detectStat(path string) statResult {
+	if a != nil && a.statPath != nil {
+		return a.statPath(path)
+	}
+
+	return defaultStat(path)
+}
+
+func isNotExist(err error) bool {
+	return os.IsNotExist(err)
+}
+
+func (a *Adapter) piSettingsPaths(homeDir string, workspaceDir string) []string {
+	paths := ResolvePaths(homeDir, os.Getenv)
+	settings := []string{
+		paths.SettingsPath,
+	}
+	for _, base := range workspaceCandidates(workspaceDir) {
+		settings = append(settings, filepath.Join(base, ".pi", "settings.json"))
+	}
+	return settings
+}
+
+func workspaceCandidates(workspaceDir string) []string {
+	if strings.TrimSpace(workspaceDir) == "" {
+		return nil
+	}
+	out := make([]string, 0, 8)
+	seen := map[string]struct{}{}
+	current := filepath.Clean(workspaceDir)
+	for i := 0; i < 64; i++ {
+		if _, ok := seen[current]; !ok {
+			out = append(out, current)
+			seen[current] = struct{}{}
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			break
+		}
+		current = parent
+	}
+	return out
+}
+
+type piSettings struct {
+	Packages []string `json:"packages"`
+}
+
+func detectPiSubagentsFromSettings(path string) (bool, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		if isNotExist(err) {
+			return false, nil
+		}
+
+		return false, err
+	}
+
+	var settings piSettings
+	if err := json.Unmarshal(content, &settings); err != nil {
+		return false, err
+	}
+
+	for _, spec := range settings.Packages {
+		if packageSpecName(spec) == "pi-subagents" {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func packageSpecName(spec string) string {
+	normalized := strings.TrimSpace(spec)
+	normalized = strings.TrimPrefix(normalized, "npm:")
+
+	if strings.HasPrefix(normalized, "@") {
+		lastAt := strings.LastIndex(normalized, "@")
+		slash := strings.Index(normalized, "/")
+		if lastAt > slash {
+			normalized = normalized[:lastAt]
+		}
+
+		return normalized
+	}
+
+	if at := strings.Index(normalized, "@"); at > 0 {
+		normalized = normalized[:at]
+	}
+
+	return normalized
+}

--- a/internal/agents/pi/detector_test.go
+++ b/internal/agents/pi/detector_test.go
@@ -1,0 +1,221 @@
+package pi
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDetectPiSubagents(t *testing.T) {
+	tests := []struct {
+		name         string
+		setup        func(t *testing.T, adapter *Adapter, homeDir string, workspaceDir string)
+		wantDetected bool
+		wantErr      bool
+	}{
+		{
+			name: "detects extension from home config footprint",
+			setup: func(t *testing.T, adapter *Adapter, homeDir string, workspaceDir string) {
+				t.Helper()
+				footprints := adapter.PiSubagentsFootprints(homeDir, workspaceDir)
+				if err := os.MkdirAll(footprints[0], 0o755); err != nil {
+					t.Fatalf("MkdirAll(%q) error = %v", footprints[0], err)
+				}
+			},
+			wantDetected: true,
+		},
+		{
+			name:         "returns false when all footprints are absent",
+			setup:        func(t *testing.T, _ *Adapter, _ string, _ string) {},
+			wantDetected: false,
+		},
+		{
+			name: "returns error when footprint lookup is ambiguous",
+			setup: func(t *testing.T, _ *Adapter, homeDir string, _ string) {
+				t.Helper()
+				blockingPath := filepath.Join(homeDir, ".config", "pi-coding-agent", "extensions")
+				if err := os.MkdirAll(filepath.Dir(blockingPath), 0o755); err != nil {
+					t.Fatalf("MkdirAll(%q) error = %v", filepath.Dir(blockingPath), err)
+				}
+				if err := os.WriteFile(blockingPath, []byte("not-a-dir"), 0o644); err != nil {
+					t.Fatalf("WriteFile(%q) error = %v", blockingPath, err)
+				}
+			},
+			wantErr: true,
+		},
+		{
+			name: "detects extension from global pi settings packages",
+			setup: func(t *testing.T, _ *Adapter, homeDir string, _ string) {
+				t.Helper()
+				settingsPath := filepath.Join(homeDir, ".pi", "agent", "settings.json")
+				writeSettingsJSON(t, settingsPath, `{"packages":["npm:pi-btw","npm:pi-subagents"]}`)
+			},
+			wantDetected: true,
+		},
+		{
+			name: "detects extension from workspace pi settings packages",
+			setup: func(t *testing.T, _ *Adapter, _ string, workspaceDir string) {
+				t.Helper()
+				settingsPath := filepath.Join(workspaceDir, ".pi", "settings.json")
+				writeSettingsJSON(t, settingsPath, `{"packages":["npm:pi-subagents"]}`)
+			},
+			wantDetected: true,
+		},
+		{
+			name: "settings package absent stays undetected without footprint",
+			setup: func(t *testing.T, _ *Adapter, homeDir string, _ string) {
+				t.Helper()
+				settingsPath := filepath.Join(homeDir, ".pi", "agent", "settings.json")
+				writeSettingsJSON(t, settingsPath, `{"packages":["npm:pi-btw","npm:@plannotator/pi-extension"]}`)
+			},
+			wantDetected: false,
+		},
+		{
+			name: "settings package absent still detects via legacy footprint",
+			setup: func(t *testing.T, adapter *Adapter, homeDir string, workspaceDir string) {
+				t.Helper()
+				settingsPath := filepath.Join(homeDir, ".pi", "agent", "settings.json")
+				writeSettingsJSON(t, settingsPath, `{"packages":["npm:pi-btw"]}`)
+
+				footprints := adapter.PiSubagentsFootprints(homeDir, workspaceDir)
+				if err := os.MkdirAll(footprints[0], 0o755); err != nil {
+					t.Fatalf("MkdirAll(%q) error = %v", footprints[0], err)
+				}
+			},
+			wantDetected: true,
+		},
+		{
+			name: "malformed settings returns error",
+			setup: func(t *testing.T, _ *Adapter, homeDir string, _ string) {
+				t.Helper()
+				settingsPath := filepath.Join(homeDir, ".pi", "agent", "settings.json")
+				writeSettingsJSON(t, settingsPath, `{"packages":["npm:pi-subagents"`)
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			homeDir := t.TempDir()
+			workspaceDir := t.TempDir()
+			adapter := NewAdapter()
+
+			tt.setup(t, adapter, homeDir, workspaceDir)
+
+			detected, err := adapter.DetectPiSubagents(homeDir, workspaceDir)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("DetectPiSubagents() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if detected != tt.wantDetected {
+				t.Fatalf("DetectPiSubagents() detected = %v, want %v", detected, tt.wantDetected)
+			}
+		})
+	}
+}
+
+func writeSettingsJSON(t *testing.T, path string, content string) {
+	t.Helper()
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q) error = %v", filepath.Dir(path), err)
+	}
+
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q) error = %v", path, err)
+	}
+}
+
+func TestPiSubagentsFootprints(t *testing.T) {
+	homeDir := t.TempDir()
+	workspaceDir := t.TempDir()
+
+	adapter := NewAdapter()
+	got := adapter.PiSubagentsFootprints(homeDir, workspaceDir)
+
+	want := []string{
+		filepath.Join(homeDir, ".pi", "agent", "extensions", "pi-subagents"),
+		filepath.Join(homeDir, ".pi", "agent", "extensions", "pi-subagents.json"),
+		filepath.Join(homeDir, ".config", "pi-coding-agent", "extensions", "pi-subagents"),
+		filepath.Join(homeDir, ".config", "pi-coding-agent", "extensions", "pi-subagents.json"),
+		filepath.Join(workspaceDir, ".pi", "extensions", "pi-subagents"),
+		filepath.Join(workspaceDir, ".pi", "extensions", "pi-subagents.json"),
+	}
+
+	for _, expected := range want {
+		if !containsString(got, expected) {
+			t.Fatalf("PiSubagentsFootprints() missing %q in %v", expected, got)
+		}
+	}
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+func TestDetectPiSubagentsFailsClosedOnDetectorErrors(t *testing.T) {
+	adapter := &Adapter{
+		statPath: func(string) statResult {
+			return statResult{err: errors.New("permission denied")}
+		},
+	}
+
+	detected, err := adapter.DetectPiSubagents("/tmp/home", "/tmp/workspace")
+	if err == nil {
+		t.Fatal("DetectPiSubagents() error = nil, want error")
+	}
+
+	if detected {
+		t.Fatal("DetectPiSubagents() detected = true, want false")
+	}
+}
+
+func TestDetectPiSubagentsUsesSettingsBeforeLegacyFootprints(t *testing.T) {
+	homeDir := t.TempDir()
+	workspaceDir := t.TempDir()
+
+	settingsPath := filepath.Join(homeDir, ".pi", "agent", "settings.json")
+	writeSettingsJSON(t, settingsPath, `{"packages":["npm:pi-subagents"]}`)
+
+	adapter := &Adapter{
+		statPath: func(string) statResult {
+			return statResult{err: errors.New("permission denied")}
+		},
+	}
+
+	detected, err := adapter.DetectPiSubagents(homeDir, workspaceDir)
+	if err != nil {
+		t.Fatalf("DetectPiSubagents() error = %v, want nil", err)
+	}
+
+	if !detected {
+		t.Fatal("DetectPiSubagents() detected = false, want true")
+	}
+}
+
+func TestDetectPiSubagentsFindsWorkspaceSettingsFromNestedDirectory(t *testing.T) {
+	homeDir := t.TempDir()
+	projectRoot := t.TempDir()
+	workspaceDir := filepath.Join(projectRoot, "services", "billing")
+
+	if err := os.MkdirAll(workspaceDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(workspaceDir) error = %v", err)
+	}
+	writeSettingsJSON(t, filepath.Join(projectRoot, ".pi", "settings.json"), `{"packages":["npm:pi-subagents"]}`)
+
+	adapter := NewAdapter()
+	detected, err := adapter.DetectPiSubagents(homeDir, workspaceDir)
+	if err != nil {
+		t.Fatalf("DetectPiSubagents() error = %v", err)
+	}
+	if !detected {
+		t.Fatal("DetectPiSubagents() detected = false, want true for ancestor .pi/settings.json")
+	}
+}

--- a/internal/agents/pi/engram_extension.go
+++ b/internal/agents/pi/engram_extension.go
@@ -1,0 +1,189 @@
+package pi
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type EngramExtensionStatus struct {
+	Configured    bool
+	ExtensionPath string
+	Source        string
+	PackageName   string
+	Message       string
+}
+
+func ValidateEngramExtension(paths Paths) (EngramExtensionStatus, error) {
+	data, err := os.ReadFile(paths.SettingsPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return EngramExtensionStatus{}, fmt.Errorf("missing PI→Engram extension contract at %s (MCP/Context7 are out of scope for this iteration)", paths.SettingsPath)
+		}
+		return EngramExtensionStatus{}, fmt.Errorf("read PI settings %q: %w", paths.SettingsPath, err)
+	}
+
+	var root map[string]any
+	if err := json.Unmarshal(data, &root); err != nil {
+		return EngramExtensionStatus{}, fmt.Errorf("parse PI settings %q: %w", paths.SettingsPath, err)
+	}
+	if status, ok, err := validateExplicitContract(root, paths.SettingsPath); ok || err != nil {
+		return status, err
+	}
+
+	status, ok, err := validatePackagesContract(root, paths)
+	if ok || err != nil {
+		return status, err
+	}
+
+	return EngramExtensionStatus{}, fmt.Errorf("missing PI→Engram extension contract in %s (expected engram.extension.path or packages[] entry like ../../Documents/repos/pi-engram or npm:pi-engram)", paths.SettingsPath)
+}
+
+func validateExplicitContract(root map[string]any, settingsPath string) (EngramExtensionStatus, bool, error) {
+	engramRaw, ok := root["engram"].(map[string]any)
+	if !ok {
+		return EngramExtensionStatus{}, false, nil
+	}
+
+	extensionRaw, ok := engramRaw["extension"].(map[string]any)
+	if !ok {
+		return EngramExtensionStatus{}, false, nil
+	}
+
+	pathRaw, pathOK := extensionRaw["path"]
+	pathValue, isString := pathRaw.(string)
+	if !pathOK || !isString {
+		return EngramExtensionStatus{}, true, fmt.Errorf("malformed PI→Engram extension contract in %s (engram.extension.path must be a non-empty string)", settingsPath)
+	}
+
+	extensionPath := strings.TrimSpace(pathValue)
+	if extensionPath == "" {
+		return EngramExtensionStatus{}, true, fmt.Errorf("missing PI→Engram extension contract in %s (expected engram.extension.path)", settingsPath)
+	}
+
+	enabled, ok := extensionRaw["enabled"].(bool)
+	if !ok || !enabled {
+		return EngramExtensionStatus{}, true, fmt.Errorf("malformed PI→Engram extension contract in %s (engram.extension.enabled must be true)", settingsPath)
+	}
+
+	return EngramExtensionStatus{
+		Configured:    true,
+		ExtensionPath: extensionPath,
+		Source:        "explicit",
+		Message:       "PI Engram extension contract validated",
+	}, true, nil
+}
+
+func validatePackagesContract(root map[string]any, paths Paths) (EngramExtensionStatus, bool, error) {
+	packagesRaw, exists := root["packages"]
+	if !exists {
+		return EngramExtensionStatus{}, false, nil
+	}
+
+	packages, ok := packagesRaw.([]any)
+	if !ok {
+		return EngramExtensionStatus{}, true, fmt.Errorf("malformed PI→Engram extension contract in %s (packages must be an array)", paths.SettingsPath)
+	}
+
+	for _, item := range packages {
+		entry, ok := item.(string)
+		if !ok {
+			continue
+		}
+
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+
+		if pkgName, match := normalizeNpmEngramPackage(entry); match {
+			return EngramExtensionStatus{
+				Configured:    true,
+				ExtensionPath: "npm:" + pkgName,
+				Source:        "package-npm",
+				PackageName:   pkgName,
+				Message:       "PI Engram extension resolved from packages[] npm entry",
+			}, true, nil
+		}
+
+		if isLocalPathLike(entry) && looksLikeEngramPath(entry) {
+			resolved := resolvePackagePath(paths.Root, entry)
+			if _, err := os.Stat(resolved); err != nil {
+				if os.IsNotExist(err) {
+					return EngramExtensionStatus{}, true, fmt.Errorf("missing PI→Engram extension contract in %s (packages[] local entry %q resolves to %q, but it does not exist or is not readable)", paths.SettingsPath, entry, resolved)
+				}
+				return EngramExtensionStatus{}, true, fmt.Errorf("read PI→Engram extension local path %q: %w", resolved, err)
+			}
+			return EngramExtensionStatus{
+				Configured:    true,
+				ExtensionPath: resolved,
+				Source:        "package-local",
+				PackageName:   filepath.Base(filepath.Clean(resolved)),
+				Message:       "PI Engram extension resolved from packages[] local path",
+			}, true, nil
+		}
+	}
+
+	return EngramExtensionStatus{}, false, nil
+}
+
+func normalizeNpmEngramPackage(entry string) (string, bool) {
+	if !strings.HasPrefix(strings.ToLower(entry), "npm:") {
+		return "", false
+	}
+
+	pkgName := strings.TrimSpace(entry[len("npm:"):])
+	if pkgName == "" {
+		return "", false
+	}
+
+	if !looksLikeEngramPackageName(pkgName) {
+		return "", false
+	}
+
+	return pkgName, true
+}
+
+func looksLikeEngramPackageName(name string) bool {
+	lower := strings.ToLower(strings.TrimSpace(name))
+	if lower == "" {
+		return false
+	}
+
+	return strings.Contains(lower, "pi-engram") || (strings.Contains(lower, "engram") && strings.Contains(lower, "pi"))
+}
+
+func looksLikeEngramPath(pathValue string) bool {
+	base := strings.ToLower(filepath.Base(filepath.Clean(pathValue)))
+	return strings.Contains(base, "pi-engram") || (strings.Contains(base, "engram") && strings.Contains(base, "pi"))
+}
+
+func isLocalPathLike(entry string) bool {
+	if filepath.IsAbs(entry) {
+		return true
+	}
+
+	if strings.HasPrefix(entry, "./") || strings.HasPrefix(entry, "../") || strings.HasPrefix(entry, "~/") {
+		return true
+	}
+
+	return strings.Contains(entry, "/") || strings.Contains(entry, `\\`)
+}
+
+func resolvePackagePath(piRoot string, entry string) string {
+	if filepath.IsAbs(entry) {
+		return filepath.Clean(entry)
+	}
+
+	if strings.HasPrefix(entry, "~/") {
+		homeDir, err := os.UserHomeDir()
+		if err == nil && strings.TrimSpace(homeDir) != "" {
+			return filepath.Clean(filepath.Join(homeDir, strings.TrimPrefix(entry, "~/")))
+		}
+		return filepath.Clean(entry)
+	}
+
+	return filepath.Clean(filepath.Join(piRoot, entry))
+}

--- a/internal/agents/pi/engram_extension_test.go
+++ b/internal/agents/pi/engram_extension_test.go
@@ -1,0 +1,179 @@
+package pi
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestValidateEngramExtension(t *testing.T) {
+	tests := []struct {
+		name                 string
+		settings             string
+		setup                func(t *testing.T, paths Paths)
+		wantOK               bool
+		wantErrSub           string
+		wantSource           string
+		wantPackageName      string
+		wantPathSuffix       string
+		wantExactPath        string
+		wantResolvedFromRoot string
+	}{
+		{
+			name:           "configured extension contract passes",
+			settings:       `{"engram":{"extension":{"path":"/opt/pi/extensions/pi-engram","enabled":true}}}`,
+			wantOK:         true,
+			wantSource:     "explicit",
+			wantPathSuffix: "pi-engram",
+		},
+		{
+			name:                 "local packages entry resolves from pi root",
+			settings:             `{"packages":["../../Documents/repos/pi-engram"]}`,
+			setup: func(t *testing.T, paths Paths) {
+				t.Helper()
+				fixtureDir := filepath.Clean(filepath.Join(paths.Root, "../../Documents/repos/pi-engram"))
+				if err := os.MkdirAll(fixtureDir, 0o755); err != nil {
+					t.Fatalf("MkdirAll(local package fixture) error = %v", err)
+				}
+			},
+			wantOK:               true,
+			wantSource:           "package-local",
+			wantPathSuffix:       filepath.Join("Documents", "repos", "pi-engram"),
+			wantResolvedFromRoot: "../../Documents/repos/pi-engram",
+		},
+		{
+			name:                 "tilde local packages entry expands to home",
+			settings:             `{"packages":["~/Documents/repos/pi-engram"]}`,
+			setup: func(t *testing.T, _ Paths) {
+				t.Helper()
+				homeDir := t.TempDir()
+				t.Setenv("HOME", homeDir)
+				fixtureDir := filepath.Join(homeDir, "Documents", "repos", "pi-engram")
+				if err := os.MkdirAll(fixtureDir, 0o755); err != nil {
+					t.Fatalf("MkdirAll(tilde package fixture) error = %v", err)
+				}
+			},
+			wantOK:               true,
+			wantSource:           "package-local",
+			wantPathSuffix:       filepath.Join("Documents", "repos", "pi-engram"),
+			wantExactPath:        "",
+			wantResolvedFromRoot: "",
+		},
+		{
+			name:       "local packages entry fails when path does not exist",
+			settings:   `{"packages":["../../Documents/repos/pi-engram"]}`,
+			wantErrSub: "does not exist or is not readable",
+		},
+		{
+			name:            "npm package entry passes",
+			settings:        `{"packages":["npm:pi-engram"]}`,
+			wantOK:          true,
+			wantSource:      "package-npm",
+			wantPackageName: "pi-engram",
+			wantExactPath:   "npm:pi-engram",
+		},
+		{
+			name:            "scoped npm package entry passes",
+			settings:        `{"packages":["npm:@gentleman-programming/pi-engram"]}`,
+			wantOK:          true,
+			wantSource:      "package-npm",
+			wantPackageName: "@gentleman-programming/pi-engram",
+			wantExactPath:   "npm:@gentleman-programming/pi-engram",
+		},
+		{
+			name:       "missing extension contract fails",
+			settings:   `{}`,
+			wantErrSub: "expected engram.extension.path or packages[]",
+		},
+		{
+			name:       "malformed extension path fails",
+			settings:   `{"engram":{"extension":{"path":123}}}`,
+			wantErrSub: "malformed PI→Engram extension contract",
+		},
+		{
+			name:       "malformed packages type fails",
+			settings:   `{"packages":{}}`,
+			wantErrSub: "packages must be an array",
+		},
+		{
+			name:       "unrelated packages entry fails closed",
+			settings:   `{"packages":["npm:random-package","../../plugins/not-engram"]}`,
+			wantErrSub: "expected engram.extension.path or packages[]",
+		},
+		{
+			name:       "invalid settings json fails",
+			settings:   `{"engram":`,
+			wantErrSub: "parse PI settings",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home := t.TempDir()
+			paths := ResolvePaths(home, func(string) string { return "" })
+			if tt.setup != nil {
+				tt.setup(t, paths)
+			}
+			if err := os.MkdirAll(filepath.Dir(paths.SettingsPath), 0o755); err != nil {
+				t.Fatalf("MkdirAll(settings dir) error = %v", err)
+			}
+			if err := os.WriteFile(paths.SettingsPath, []byte(tt.settings), 0o644); err != nil {
+				t.Fatalf("WriteFile(settings) error = %v", err)
+			}
+
+			status, err := ValidateEngramExtension(paths)
+
+			if tt.wantErrSub != "" {
+				if err == nil {
+					t.Fatalf("ValidateEngramExtension() error = nil, want containing %q", tt.wantErrSub)
+				}
+				if !strings.Contains(err.Error(), tt.wantErrSub) {
+					t.Fatalf("ValidateEngramExtension() error = %q, want substring %q", err.Error(), tt.wantErrSub)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("ValidateEngramExtension() error = %v, want nil", err)
+			}
+			if status.Configured != tt.wantOK {
+				t.Fatalf("ValidateEngramExtension().Configured = %v, want %v", status.Configured, tt.wantOK)
+			}
+			if status.ExtensionPath == "" {
+				t.Fatal("ValidateEngramExtension().ExtensionPath = empty, want non-empty")
+			}
+			if tt.wantSource != "" && status.Source != tt.wantSource {
+				t.Fatalf("ValidateEngramExtension().Source = %q, want %q", status.Source, tt.wantSource)
+			}
+			if tt.wantPackageName != "" && status.PackageName != tt.wantPackageName {
+				t.Fatalf("ValidateEngramExtension().PackageName = %q, want %q", status.PackageName, tt.wantPackageName)
+			}
+			if tt.wantExactPath != "" && status.ExtensionPath != tt.wantExactPath {
+				t.Fatalf("ValidateEngramExtension().ExtensionPath = %q, want exact %q", status.ExtensionPath, tt.wantExactPath)
+			}
+			if tt.wantPathSuffix != "" && !strings.HasSuffix(filepath.Clean(status.ExtensionPath), filepath.Clean(tt.wantPathSuffix)) {
+				t.Fatalf("ValidateEngramExtension().ExtensionPath = %q, want suffix %q", status.ExtensionPath, tt.wantPathSuffix)
+			}
+			if tt.wantResolvedFromRoot != "" {
+				wantPath := filepath.Clean(filepath.Join(paths.Root, tt.wantResolvedFromRoot))
+				if filepath.Clean(status.ExtensionPath) != wantPath {
+					t.Fatalf("ValidateEngramExtension().ExtensionPath = %q, want resolved %q", status.ExtensionPath, wantPath)
+				}
+			}
+		})
+	}
+}
+
+func TestValidateEngramExtensionMissingSettingsFile(t *testing.T) {
+	home := t.TempDir()
+	paths := ResolvePaths(home, func(string) string { return "" })
+
+	_, err := ValidateEngramExtension(paths)
+	if err == nil {
+		t.Fatal("ValidateEngramExtension() error = nil, want missing contract error")
+	}
+	if !strings.Contains(err.Error(), "missing PI→Engram extension contract") {
+		t.Fatalf("ValidateEngramExtension() error = %q, want missing contract message", err.Error())
+	}
+}

--- a/internal/agents/pi/paths.go
+++ b/internal/agents/pi/paths.go
@@ -1,0 +1,35 @@
+package pi
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+const piCodingAgentDirEnv = "PI_CODING_AGENT_DIR"
+
+type Paths struct {
+	Root            string
+	AgentsDir       string
+	SettingsPath    string
+	LegacyConfigDir string
+}
+
+func ResolvePaths(homeDir string, getenv func(string) string) Paths {
+	root := strings.TrimSpace(getenv(piCodingAgentDirEnv))
+	if root == "" {
+		root = filepath.Join(homeDir, ".pi", "agent")
+	}
+
+	legacy := filepath.Join(homeDir, ".config", "pi-coding-agent")
+
+	return Paths{
+		Root:            root,
+		AgentsDir:       filepath.Join(root, "agents"),
+		SettingsPath:    filepath.Join(root, "settings.json"),
+		LegacyConfigDir: legacy,
+	}
+}
+
+func detectionConfigCandidates(paths Paths) []string {
+	return []string{paths.Root, paths.LegacyConfigDir}
+}

--- a/internal/agents/pi/paths_test.go
+++ b/internal/agents/pi/paths_test.go
@@ -1,0 +1,86 @@
+package pi
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestResolvePaths(t *testing.T) {
+	tests := []struct {
+		name         string
+		homeDir      string
+		envValue     string
+		wantRoot     string
+		wantAgents   string
+		wantSettings string
+	}{
+		{
+			name:         "environment override takes precedence",
+			homeDir:      "/home/tester",
+			envValue:     "/tmp/custom-pi",
+			wantRoot:     "/tmp/custom-pi",
+			wantAgents:   "/tmp/custom-pi/agents",
+			wantSettings: "/tmp/custom-pi/settings.json",
+		},
+		{
+			name:         "default path used when override missing",
+			homeDir:      "/home/tester",
+			envValue:     "",
+			wantRoot:     filepath.Join("/home/tester", ".pi", "agent"),
+			wantAgents:   filepath.Join("/home/tester", ".pi", "agent", "agents"),
+			wantSettings: filepath.Join("/home/tester", ".pi", "agent", "settings.json"),
+		},
+		{
+			name:         "blank override falls back to default",
+			homeDir:      "/home/tester",
+			envValue:     "   ",
+			wantRoot:     filepath.Join("/home/tester", ".pi", "agent"),
+			wantAgents:   filepath.Join("/home/tester", ".pi", "agent", "agents"),
+			wantSettings: filepath.Join("/home/tester", ".pi", "agent", "settings.json"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			paths := ResolvePaths(tt.homeDir, func(key string) string {
+				if key != piCodingAgentDirEnv {
+					t.Fatalf("ResolvePaths() requested env key %q, want %q", key, piCodingAgentDirEnv)
+				}
+				return tt.envValue
+			})
+
+			if paths.Root != tt.wantRoot {
+				t.Fatalf("ResolvePaths().Root = %q, want %q", paths.Root, tt.wantRoot)
+			}
+
+			if paths.AgentsDir != tt.wantAgents {
+				t.Fatalf("ResolvePaths().AgentsDir = %q, want %q", paths.AgentsDir, tt.wantAgents)
+			}
+
+			if paths.SettingsPath != tt.wantSettings {
+				t.Fatalf("ResolvePaths().SettingsPath = %q, want %q", paths.SettingsPath, tt.wantSettings)
+			}
+		})
+	}
+}
+
+func TestResolvePathsDetectionCandidatesIncludeLegacyCompatibility(t *testing.T) {
+	homeDir := "/home/tester"
+	paths := ResolvePaths(homeDir, func(string) string { return "" })
+
+	got := detectionConfigCandidates(paths)
+	want := []string{
+		filepath.Join(homeDir, ".pi", "agent"),
+		filepath.Join(homeDir, ".config", "pi-coding-agent"),
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("detectionConfigCandidates() len = %d, want %d (%v)", len(got), len(want), got)
+	}
+
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("detectionConfigCandidates()[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}

--- a/internal/agents/pi/rpc_models.go
+++ b/internal/agents/pi/rpc_models.go
@@ -1,0 +1,248 @@
+package pi
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/gentleman-programming/gentle-ai/internal/modelcatalog"
+)
+
+var piRPCCommandFactory = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+	return exec.CommandContext(ctx, name, args...)
+}
+
+var defaultPiRPCCommand = []string{"pi", "--mode", "rpc"}
+
+// PI RPC startup can emit extension/UI events before model catalog response.
+// Allow extra time so startup noise does not cause premature process kill.
+const defaultPiRPCModelsTimeout = 30 * time.Second
+
+// UserFacingRPCModelLoadError returns an actionable message suitable for TUI
+// rendering when PI model loading via RPC fails.
+func UserFacingRPCModelLoadError(err error) string {
+	if err == nil {
+		return ""
+	}
+
+	msg := err.Error()
+	if errors.Is(err, context.DeadlineExceeded) || strings.Contains(msg, "signal: killed") {
+		return "PI RPC process was terminated before it returned models. Gentle AI waits for PI extension startup and model-catalog response; Run `pi --mode rpc` manually to verify it responds, then check PI auth/runtime provider setup and retry."
+	}
+
+	if errors.Is(err, exec.ErrNotFound) {
+		return "PI binary was not found on PATH. Install PI or make sure `pi` is available in your shell, then retry."
+	}
+
+	if errors.Is(err, os.ErrPermission) {
+		return "PI binary is not executable due to permissions. Fix execute permissions for `pi`, then retry."
+	}
+
+	if strings.Contains(msg, "did not return model catalog") || strings.Contains(msg, "extension UI events only") {
+		return "PI RPC started but did not return a model catalog; extensions emitted UI events only. Try disabling noisy extensions, then run `pi --mode rpc get_available_models` manually to confirm your PI build/protocol returns model catalogs."
+	}
+
+	return fmt.Sprintf("PI RPC call failed: %v. Run `pi --mode rpc` manually and verify provider/auth configuration.", err)
+}
+
+// LoadModelCatalogRPC loads PI models through `pi --mode rpc` get_available_models.
+func LoadModelCatalogRPC(ctx context.Context, command []string) (modelcatalog.Catalog, error) {
+	cmdline := command
+	if len(cmdline) == 0 {
+		cmdline = append([]string(nil), defaultPiRPCCommand...)
+	}
+
+	if len(cmdline) == 0 || strings.TrimSpace(cmdline[0]) == "" {
+		return modelcatalog.Catalog{}, errors.New("pi RPC command is empty")
+	}
+
+	if _, ok := ctx.Deadline(); !ok {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, defaultPiRPCModelsTimeout)
+		defer cancel()
+	}
+
+	cmd := piRPCCommandFactory(ctx, cmdline[0], cmdline[1:]...)
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return modelcatalog.Catalog{}, fmt.Errorf("open PI RPC stdin: %w", err)
+	}
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return modelcatalog.Catalog{}, fmt.Errorf("open PI RPC stdout: %w", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		return modelcatalog.Catalog{}, fmt.Errorf("start PI RPC command: %w", err)
+	}
+
+	request := map[string]string{
+		"id":   "gentle-ai-model-picker",
+		"type": "get_available_models",
+	}
+	if err := json.NewEncoder(stdin).Encode(request); err != nil {
+		_ = stdin.Close()
+		_ = cmd.Wait()
+		return modelcatalog.Catalog{}, fmt.Errorf("write get_available_models RPC request: %w", err)
+	}
+	_ = stdin.Close()
+
+	models, err := parseGetAvailableModelsResponse(stdout)
+	waitErr := cmd.Wait()
+	if err != nil {
+		if waitErr != nil {
+			return modelcatalog.Catalog{}, fmt.Errorf("PI RPC parse error (%v), process error: %w", err, waitErr)
+		}
+		return modelcatalog.Catalog{}, err
+	}
+	if waitErr != nil {
+		return modelcatalog.Catalog{}, fmt.Errorf("PI RPC command failed: %w", waitErr)
+	}
+
+	return buildCatalogFromPIModels(models), nil
+}
+
+type piRPCEnvelope struct {
+	Type    string         `json:"type"`
+	Command string         `json:"command"`
+	Success bool           `json:"success"`
+	Error   string         `json:"error"`
+	Data    piRPCModelData `json:"data"`
+}
+
+type piRPCModelData struct {
+	Models []piRPCModel `json:"models"`
+}
+
+type piRPCModel struct {
+	Provider      string         `json:"provider"`
+	ID            string         `json:"id"`
+	Name          string         `json:"name"`
+	Reasoning     bool           `json:"reasoning"`
+	Input         []string       `json:"input"`
+	ContextWindow int            `json:"contextWindow"`
+	MaxTokens     int            `json:"maxTokens"`
+	Cost          piRPCModelCost `json:"cost"`
+}
+
+type piRPCModelCost struct {
+	Input      float64 `json:"input"`
+	Output     float64 `json:"output"`
+	CacheRead  float64 `json:"cacheRead"`
+	CacheWrite float64 `json:"cacheWrite"`
+}
+
+func parseGetAvailableModelsResponse(stdout io.Reader) ([]piRPCModel, error) {
+	scanner := bufio.NewScanner(stdout)
+	buf := make([]byte, 0, 64*1024)
+	scanner.Buffer(buf, 10*1024*1024)
+
+	receivedExtensionUIEvents := false
+
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+
+		var envelope piRPCEnvelope
+		if err := json.Unmarshal([]byte(line), &envelope); err != nil {
+			continue
+		}
+
+		if envelope.Type != "response" || envelope.Command != "get_available_models" {
+			if envelope.Type == "extension_ui_request" {
+				receivedExtensionUIEvents = true
+			}
+			continue
+		}
+
+		if !envelope.Success {
+			if envelope.Error == "" {
+				return nil, errors.New("PI RPC returned get_available_models failure")
+			}
+			return nil, errors.New(envelope.Error)
+		}
+
+		return envelope.Data.Models, nil
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("read PI RPC output: %w", err)
+	}
+
+	if receivedExtensionUIEvents {
+		return nil, errors.New("PI RPC did not return model catalog; received extension UI events only")
+	}
+
+	return nil, errors.New("PI RPC get_available_models response not found")
+}
+
+func buildCatalogFromPIModels(models []piRPCModel) modelcatalog.Catalog {
+	providers := map[string]modelcatalog.Provider{}
+	available := []string{}
+	sddModels := map[string][]modelcatalog.Model{}
+
+	for _, item := range models {
+		providerID := strings.TrimSpace(item.Provider)
+		modelID := strings.TrimSpace(item.ID)
+		if providerID == "" || modelID == "" {
+			continue
+		}
+
+		provider := providers[providerID]
+		if provider.ID == "" {
+			provider = modelcatalog.Provider{
+				ID:     providerID,
+				Name:   providerID,
+				Models: map[string]modelcatalog.Model{},
+			}
+			available = append(available, providerID)
+		}
+
+		modelName := strings.TrimSpace(item.Name)
+		if modelName == "" {
+			modelName = modelID
+		}
+
+		normalized := modelcatalog.Model{
+			ID:            modelID,
+			Name:          modelName,
+			Reasoning:     item.Reasoning,
+			ContextWindow: item.ContextWindow,
+			MaxTokens:     item.MaxTokens,
+			Cost: modelcatalog.ModelCost{
+				Input:      item.Cost.Input,
+				Output:     item.Cost.Output,
+				CacheRead:  item.Cost.CacheRead,
+				CacheWrite: item.Cost.CacheWrite,
+			},
+		}
+
+		provider.Models[modelID] = normalized
+		providers[providerID] = provider
+		sddModels[providerID] = append(sddModels[providerID], normalized)
+	}
+
+	sort.Strings(available)
+	for providerID := range sddModels {
+		sort.Slice(sddModels[providerID], func(i, j int) bool {
+			return sddModels[providerID][i].Name < sddModels[providerID][j].Name
+		})
+	}
+
+	return modelcatalog.Catalog{
+		Providers:            providers,
+		AvailableProviderIDs: available,
+		SDDModels:            sddModels,
+	}
+}

--- a/internal/agents/pi/rpc_models_test.go
+++ b/internal/agents/pi/rpc_models_test.go
@@ -1,0 +1,178 @@
+package pi
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestParseGetAvailableModelsResponse_IgnoresUnrelatedEvents(t *testing.T) {
+	jsonl := strings.NewReader(strings.Join([]string{
+		`{"type":"event","name":"boot"}`,
+		`{"type":"response","command":"other","success":true,"data":{}}`,
+		`{"type":"response","command":"get_available_models","success":true,"data":{"models":[{"provider":"openai","id":"gpt-5","name":"GPT-5","reasoning":true,"input":["text","image"],"contextWindow":200000,"maxTokens":32000,"cost":{"input":1.25,"output":10.00,"cacheRead":0.10,"cacheWrite":1.00}}]}}`,
+	}, "\n"))
+
+	models, err := parseGetAvailableModelsResponse(jsonl)
+	if err != nil {
+		t.Fatalf("parseGetAvailableModelsResponse() error = %v", err)
+	}
+
+	if len(models) != 1 {
+		t.Fatalf("len(models) = %d, want 1", len(models))
+	}
+	if models[0].Provider != "openai" || models[0].ID != "gpt-5" {
+		t.Fatalf("unexpected model parsed: %+v", models[0])
+	}
+	if len(models[0].Input) != 2 || models[0].Input[0] != "text" || models[0].Input[1] != "image" {
+		t.Fatalf("unexpected input modalities: %+v", models[0].Input)
+	}
+}
+
+func TestParseGetAvailableModelsResponse_CommandFailure(t *testing.T) {
+	jsonl := strings.NewReader(`{"type":"response","command":"get_available_models","success":false,"error":"unauthorized"}`)
+
+	_, err := parseGetAvailableModelsResponse(jsonl)
+	if err == nil {
+		t.Fatal("expected error for unsuccessful get_available_models response")
+	}
+	if !strings.Contains(err.Error(), "unauthorized") {
+		t.Fatalf("error = %q, want to contain %q", err.Error(), "unauthorized")
+	}
+}
+
+func TestParseGetAvailableModelsResponse_ExtensionUIOnlyRealOutput(t *testing.T) {
+	jsonl := strings.NewReader(strings.Join([]string{
+		"mise WARN  missing: go@1.26.2 python@3.14.4",
+		`{"type":"extension_ui_request","id":"84d7b971-0b9a-4659-b500-b7f0c7e4ed24","method":"setWidget","widgetKey":"btw"}`,
+		`{"type":"extension_ui_request","id":"058ed9ae-be3a-4a3f-bb5a-8ea4131b2178","method":"setStatus","statusKey":"plannotator"}`,
+		`{"type":"extension_ui_request","id":"d9f33feb-47be-42f2-bde0-d738a4aa0017","method":"setWidget","widgetKey":"plannotator-progress"}`,
+		`{"type":"extension_ui_request","id":"54d7e574-5340-44da-856c-1906e809e931","method":"setWidget","widgetKey":"subagent-async"}`,
+		`{"type":"extension_ui_request","id":"7fb5773d-d499-4b0d-b710-98314cb58111","method":"setStatus","statusKey":"engram","statusText":"..."}`,
+		`{"type":"extension_ui_request","id":"633c3ee0-e596-4f99-a2e0-eb31ef01d89c","method":"setStatus","statusKey":"engram","statusText":"..."}`,
+		`{"type":"extension_ui_request","id":"5538e567-185d-46a1-ac9b-cb39bee147b3","method":"notify","message":"Engram has relevant memory for this project. Use mem_context or mem_search when useful.","notifyType":"info"}`,
+	}, "\n"))
+
+	_, err := parseGetAvailableModelsResponse(jsonl)
+	if err == nil {
+		t.Fatal("expected error when only extension UI events are emitted")
+	}
+	if !strings.Contains(err.Error(), "did not return model catalog") {
+		t.Fatalf("error = %q, want to contain %q", err.Error(), "did not return model catalog")
+	}
+}
+
+func TestParseGetAvailableModelsResponse_ExtensionEventsBeforeCatalogResponse(t *testing.T) {
+	jsonl := strings.NewReader(strings.Join([]string{
+		"mise WARN  missing: go@1.26.2 python@3.14.4",
+		`{"type":"extension_ui_request","id":"84d7b971-0b9a-4659-b500-b7f0c7e4ed24","method":"setWidget","widgetKey":"btw"}`,
+		`{"type":"response","command":"get_available_models","success":true,"data":{"models":[{"provider":"openai","id":"gpt-5","name":"GPT-5"}]}}`,
+	}, "\n"))
+
+	models, err := parseGetAvailableModelsResponse(jsonl)
+	if err != nil {
+		t.Fatalf("parseGetAvailableModelsResponse() error = %v", err)
+	}
+	if len(models) != 1 {
+		t.Fatalf("len(models) = %d, want 1", len(models))
+	}
+	if models[0].Provider != "openai" || models[0].ID != "gpt-5" {
+		t.Fatalf("unexpected model parsed: %+v", models[0])
+	}
+}
+
+func TestDefaultPiRPCModelsTimeout_AllowsExtensionStartupNoise(t *testing.T) {
+	if defaultPiRPCModelsTimeout < 20*time.Second {
+		t.Fatalf("defaultPiRPCModelsTimeout = %v, want >= 20s to tolerate extension startup noise", defaultPiRPCModelsTimeout)
+	}
+}
+
+func TestBuildCatalogFromPIModels_NormalizesProvidersAndCosts(t *testing.T) {
+	catalog := buildCatalogFromPIModels([]piRPCModel{
+		{
+			Provider:      "openai",
+			ID:            "gpt-5",
+			Name:          "GPT-5",
+			Reasoning:     true,
+			ContextWindow: 200000,
+			MaxTokens:     32000,
+			Cost: piRPCModelCost{
+				Input:      1.25,
+				Output:     10.00,
+				CacheRead:  0.10,
+				CacheWrite: 1.00,
+			},
+		},
+		{
+			Provider: "anthropic",
+			ID:       "claude-sonnet-4",
+			Name:     "Claude Sonnet 4",
+			Cost: piRPCModelCost{
+				Input:  3,
+				Output: 15,
+			},
+		},
+	})
+
+	if len(catalog.AvailableProviderIDs) != 2 {
+		t.Fatalf("len(AvailableProviderIDs) = %d, want 2", len(catalog.AvailableProviderIDs))
+	}
+	if _, ok := catalog.Providers["openai"]; !ok {
+		t.Fatal("expected openai provider in catalog")
+	}
+
+	openAIModel := catalog.Providers["openai"].Models["gpt-5"]
+	if openAIModel.Cost.CacheRead != 0.10 || openAIModel.Cost.CacheWrite != 1.00 {
+		t.Fatalf("cache costs not normalized: %+v", openAIModel.Cost)
+	}
+	if openAIModel.ContextWindow != 200000 || openAIModel.MaxTokens != 32000 {
+		t.Fatalf("limits not normalized: %+v", openAIModel)
+	}
+}
+
+func TestUserFacingRPCModelLoadError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{
+			name: "killed process is actionable",
+			err:  errors.New("PI RPC command failed: signal: killed"),
+			want: "terminated before it returned models",
+		},
+		{
+			name: "deadline exceeded is actionable",
+			err:  context.DeadlineExceeded,
+			want: "terminated before it returned models",
+		},
+		{
+			name: "missing pi binary guidance",
+			err:  exec.ErrNotFound,
+			want: "not found on PATH",
+		},
+		{
+			name: "permission guidance",
+			err:  os.ErrPermission,
+			want: "not executable due to permissions",
+		},
+		{
+			name: "extension-only rpc output guidance",
+			err:  errors.New("PI RPC did not return model catalog; received extension UI events only"),
+			want: "extensions emitted UI events only",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := UserFacingRPCModelLoadError(tt.err)
+			if !strings.Contains(got, tt.want) {
+				t.Fatalf("UserFacingRPCModelLoadError() = %q, want to contain %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/agents/registry_test.go
+++ b/internal/agents/registry_test.go
@@ -94,6 +94,7 @@ func TestDefaultRegistryIncludesAllAgents(t *testing.T) {
 	for _, agent := range []model.AgentID{
 		model.AgentClaudeCode,
 		model.AgentOpenCode,
+		model.AgentPiCodingAgent,
 		model.AgentGeminiCLI,
 		model.AgentCursor,
 		model.AgentVSCodeCopilot,
@@ -105,6 +106,17 @@ func TestDefaultRegistryIncludesAllAgents(t *testing.T) {
 		if _, ok := registry.Get(agent); !ok {
 			t.Fatalf("registry missing %s adapter", agent)
 		}
+	}
+}
+
+func TestFactoryReturnsPiAdapter(t *testing.T) {
+	adapter, err := NewAdapter(model.AgentPiCodingAgent)
+	if err != nil {
+		t.Fatalf("NewAdapter() returned error: %v", err)
+	}
+
+	if got := adapter.Agent(); got != model.AgentPiCodingAgent {
+		t.Fatalf("adapter.Agent() = %q, want %q", got, model.AgentPiCodingAgent)
 	}
 }
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -33,6 +33,11 @@ var (
 	upgradeExecute           = upgrade.Execute
 	ensureCurrentOSSupported = system.EnsureCurrentOSSupported
 	detectSystem             = system.Detect
+	runTUIProgram            = func(m tui.Model) error {
+		p := tea.NewProgram(m, tea.WithAltScreen())
+		_, err := p.Run()
+		return err
+	}
 )
 
 func Run() error {
@@ -104,9 +109,7 @@ func RunArgs(args []string, stdout io.Writer) error {
 		m.SyncFn = tuiSync(homeDir)
 		m.UninstallFn = tuiUninstall(homeDir)
 		m.UninstallWithProfilesFn = tuiUninstallWithProfiles(homeDir)
-		p := tea.NewProgram(m, tea.WithAltScreen())
-		_, err = p.Run()
-		return err
+		return runTUIProgram(m)
 	}
 
 	switch args[0] {
@@ -259,19 +262,28 @@ func tuiExecute(
 	if execResult.Err == nil {
 		// Persist the user's agent selection and model assignments so that future
 		// `sync` runs target only the installed agents and preserve model choices.
-		agentIDs := make([]string, 0, len(selection.Agents))
-		for _, a := range selection.Agents {
-			agentIDs = append(agentIDs, string(a))
-		}
 		// Non-fatal: a state write failure must not break an otherwise successful install.
-		_ = state.Write(homeDir, state.InstallState{
-			InstalledAgents:        agentIDs,
-			ClaudeModelAssignments: claudeAliasesToStrings(selection.ClaudeModelAssignments),
-			ModelAssignments:       modelAssignmentsToState(selection.ModelAssignments),
-		})
+		_ = state.Write(homeDir, installStateFromSelection(selection))
 	}
 
 	return execResult
+}
+
+// installStateFromSelection converts a TUI install Selection into the persisted
+// InstallState payload written to ~/.gentle-ai/state.json.
+func installStateFromSelection(selection model.Selection) state.InstallState {
+	agentIDs := make([]string, 0, len(selection.Agents))
+	for _, a := range selection.Agents {
+		agentIDs = append(agentIDs, string(a))
+	}
+
+	return state.InstallState{
+		InstalledAgents:        agentIDs,
+		ClaudeModelAssignments: claudeAliasesToStrings(selection.ClaudeModelAssignments),
+		KiroModelAssignments:   claudeAliasesToStrings(selection.KiroModelAssignments),
+		ModelAssignments:       modelAssignmentsToState(selection.ModelAssignments),
+		PIModelAssignments:     modelAssignmentsToState(selection.PIModelAssignments),
+	}
 }
 
 // tuiRestore restores a backup from its manifest.
@@ -351,6 +363,9 @@ func applyOverrides(selection *model.Selection, overrides *model.SyncOverrides) 
 	if overrides.ModelAssignments != nil {
 		selection.ModelAssignments = overrides.ModelAssignments
 	}
+	if overrides.PIModelAssignments != nil {
+		selection.PIModelAssignments = overrides.PIModelAssignments
+	}
 	if overrides.ClaudeModelAssignments != nil {
 		selection.ClaudeModelAssignments = overrides.ClaudeModelAssignments
 	}
@@ -383,34 +398,15 @@ func loadPersistedAssignments(homeDir string, selection *model.Selection) {
 	if err != nil {
 		return
 	}
-	if len(selection.ClaudeModelAssignments) == 0 && len(s.ClaudeModelAssignments) > 0 {
-		m := make(map[string]model.ClaudeModelAlias, len(s.ClaudeModelAssignments))
-		for k, v := range s.ClaudeModelAssignments {
-			m[k] = model.ClaudeModelAlias(v)
-		}
-		selection.ClaudeModelAssignments = m
-	}
-	if len(selection.KiroModelAssignments) == 0 && len(s.KiroModelAssignments) > 0 {
-		m := make(map[string]model.ClaudeModelAlias, len(s.KiroModelAssignments))
-		for k, v := range s.KiroModelAssignments {
-			m[k] = model.ClaudeModelAlias(v)
-		}
-		selection.KiroModelAssignments = m
-	}
-	if len(selection.ModelAssignments) == 0 && len(s.ModelAssignments) > 0 {
-		m := make(map[string]model.ModelAssignment, len(s.ModelAssignments))
-		for k, v := range s.ModelAssignments {
-			m[k] = model.ModelAssignment{ProviderID: v.ProviderID, ModelID: v.ModelID}
-		}
-		selection.ModelAssignments = m
-	}
+	piAssignmentsInScope := selection.HasAgent(model.AgentPiCodingAgent) && selection.HasComponent(model.ComponentSDD)
+	state.HydrateSelectionAssignments(selection, s, piAssignmentsInScope)
 }
 
 // persistAssignments writes the model assignments from selection back to
 // state.json using a read-merge-write pattern so that other fields
 // (InstalledAgents) are not lost.
 func persistAssignments(homeDir string, selection model.Selection) {
-	if len(selection.ClaudeModelAssignments) == 0 && len(selection.KiroModelAssignments) == 0 && len(selection.ModelAssignments) == 0 {
+	if selection.ClaudeModelAssignments == nil && selection.KiroModelAssignments == nil && selection.ModelAssignments == nil && selection.PIModelAssignments == nil {
 		return
 	}
 	current, err := state.Read(homeDir)
@@ -418,14 +414,17 @@ func persistAssignments(homeDir string, selection model.Selection) {
 		// State file may not exist yet (e.g. pre-state users).
 		current = state.InstallState{}
 	}
-	if len(selection.ClaudeModelAssignments) > 0 {
+	if selection.ClaudeModelAssignments != nil {
 		current.ClaudeModelAssignments = claudeAliasesToStrings(selection.ClaudeModelAssignments)
 	}
-	if len(selection.KiroModelAssignments) > 0 {
+	if selection.KiroModelAssignments != nil {
 		current.KiroModelAssignments = claudeAliasesToStrings(selection.KiroModelAssignments)
 	}
-	if len(selection.ModelAssignments) > 0 {
+	if selection.ModelAssignments != nil {
 		current.ModelAssignments = modelAssignmentsToState(selection.ModelAssignments)
+	}
+	if selection.PIModelAssignments != nil {
+		current.PIModelAssignments = modelAssignmentsToState(selection.PIModelAssignments)
 	}
 	_ = state.Write(homeDir, current)
 }
@@ -433,7 +432,7 @@ func persistAssignments(homeDir string, selection model.Selection) {
 // claudeAliasesToStrings converts a typed ClaudeModelAlias map to plain strings
 // for JSON serialisation in state.json.
 func claudeAliasesToStrings(m map[string]model.ClaudeModelAlias) map[string]string {
-	if len(m) == 0 {
+	if m == nil {
 		return nil
 	}
 	out := make(map[string]string, len(m))
@@ -446,7 +445,7 @@ func claudeAliasesToStrings(m map[string]model.ClaudeModelAlias) map[string]stri
 // modelAssignmentsToState converts model.ModelAssignment maps to the
 // state-serialisable form.
 func modelAssignmentsToState(m map[string]model.ModelAssignment) map[string]state.ModelAssignmentState {
-	if len(m) == 0 {
+	if m == nil {
 		return nil
 	}
 	out := make(map[string]state.ModelAssignmentState, len(m))

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -380,6 +380,54 @@ func TestLoadPersistedAssignmentsPopulatesEmptySelection(t *testing.T) {
 	}
 }
 
+func TestLoadPersistedAssignmentsPIAssignmentsScopeGating(t *testing.T) {
+	tests := []struct {
+		name          string
+		agents        []model.AgentID
+		components    []model.ComponentID
+		wantPIHydrate bool
+	}{
+		{
+			name:          "does not hydrate PI assignments when PI agent not selected",
+			agents:        []model.AgentID{model.AgentOpenCode},
+			components:    []model.ComponentID{model.ComponentSDD},
+			wantPIHydrate: false,
+		},
+		{
+			name:          "hydrates PI assignments when PI agent and SDD are in scope",
+			agents:        []model.AgentID{model.AgentPiCodingAgent},
+			components:    []model.ComponentID{model.ComponentSDD},
+			wantPIHydrate: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home := t.TempDir()
+
+			err := state.Write(home, state.InstallState{
+				PIModelAssignments: map[string]state.ModelAssignmentState{
+					"sdd-apply": {ProviderID: "openai", ModelID: "gpt-5-mini"},
+				},
+			})
+			if err != nil {
+				t.Fatalf("state.Write: %v", err)
+			}
+
+			selection := model.Selection{
+				Agents:     tt.agents,
+				Components: tt.components,
+			}
+			loadPersistedAssignments(home, &selection)
+
+			_, gotPIAssignment := selection.PIModelAssignments["sdd-apply"]
+			if gotPIAssignment != tt.wantPIHydrate {
+				t.Fatalf("PIModelAssignments hydrated = %v, want %v", gotPIAssignment, tt.wantPIHydrate)
+			}
+		})
+	}
+}
+
 // TestLoadPersistedAssignmentsDoesNotOverrideExisting verifies that when the
 // selection already has assignments (e.g. from TUI overrides), persisted
 // state does NOT clobber them.
@@ -501,6 +549,75 @@ func TestPersistAssignmentsNoOpWhenEmpty(t *testing.T) {
 	infoAfter, _ := os.Stat(statePath)
 	if infoAfter.ModTime() != infoBefore.ModTime() {
 		t.Errorf("persistAssignments() modified state.json when selection had no assignments")
+	}
+}
+
+// TestPersistAssignmentsPersistsExplicitEmptyModelMaps verifies that non-nil
+// empty maps are treated as explicit clears (per SyncOverrides docs) and are
+// written to state.json instead of being ignored.
+func TestPersistAssignmentsPersistsExplicitEmptyModelMaps(t *testing.T) {
+	home := t.TempDir()
+
+	err := state.Write(home, state.InstallState{
+		InstalledAgents: []string{"opencode", "pi-coding-agent"},
+		ModelAssignments: map[string]state.ModelAssignmentState{
+			"sdd-apply": {ProviderID: "anthropic", ModelID: "claude-sonnet-4"},
+		},
+		PIModelAssignments: map[string]state.ModelAssignmentState{
+			"sdd-apply": {ProviderID: "openai", ModelID: "gpt-5"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("state.Write: %v", err)
+	}
+
+	selection := model.Selection{
+		ModelAssignments:   map[string]model.ModelAssignment{},
+		PIModelAssignments: map[string]model.ModelAssignment{},
+	}
+	persistAssignments(home, selection)
+
+	got, err := state.Read(home)
+	if err != nil {
+		t.Fatalf("state.Read: %v", err)
+	}
+	if got.ModelAssignments == nil || len(got.ModelAssignments) != 0 {
+		t.Fatalf("ModelAssignments should persist as explicit empty map, got: %v", got.ModelAssignments)
+	}
+	if got.PIModelAssignments == nil || len(got.PIModelAssignments) != 0 {
+		t.Fatalf("PIModelAssignments should persist as explicit empty map, got: %v", got.PIModelAssignments)
+	}
+}
+
+// TestInstallStateFromSelectionPersistsOpenCodeAndPISeparately verifies that
+// install-time state payload includes both maps without cross-over.
+func TestInstallStateFromSelectionPersistsOpenCodeAndPISeparately(t *testing.T) {
+	selection := model.Selection{
+		Agents: []model.AgentID{model.AgentOpenCode, model.AgentPiCodingAgent},
+		ModelAssignments: map[string]model.ModelAssignment{
+			"sdd-orchestrator": {ProviderID: "anthropic", ModelID: "claude-sonnet-4"},
+		},
+		PIModelAssignments: map[string]model.ModelAssignment{
+			"sdd-apply": {ProviderID: "openai", ModelID: "gpt-5"},
+		},
+	}
+
+	got := installStateFromSelection(selection)
+
+	if len(got.InstalledAgents) != 2 {
+		t.Fatalf("InstalledAgents len = %d, want 2", len(got.InstalledAgents))
+	}
+	if got.ModelAssignments["sdd-orchestrator"].ProviderID != "anthropic" {
+		t.Fatalf("ModelAssignments[sdd-orchestrator].ProviderID = %q, want %q", got.ModelAssignments["sdd-orchestrator"].ProviderID, "anthropic")
+	}
+	if got.PIModelAssignments["sdd-apply"].ProviderID != "openai" {
+		t.Fatalf("PIModelAssignments[sdd-apply].ProviderID = %q, want %q", got.PIModelAssignments["sdd-apply"].ProviderID, "openai")
+	}
+	if _, exists := got.PIModelAssignments["sdd-orchestrator"]; exists {
+		t.Fatal("PIModelAssignments should not contain OpenCode assignment keys")
+	}
+	if _, exists := got.ModelAssignments["sdd-apply"]; exists {
+		t.Fatal("ModelAssignments should not contain PI assignment keys")
 	}
 }
 

--- a/internal/app/parity_test.go
+++ b/internal/app/parity_test.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"reflect"
 	"strings"
@@ -161,17 +162,33 @@ func TestGuardFlowLinuxDryRunPropagatesDecision(t *testing.T) {
 }
 
 func TestRunArgsNoCommandLaunchesTUI(t *testing.T) {
+	origEnsure := ensureCurrentOSSupported
+	origDetect := detectSystem
+	origRunTUIProgram := runTUIProgram
+	t.Cleanup(func() {
+		ensureCurrentOSSupported = origEnsure
+		detectSystem = origDetect
+		runTUIProgram = origRunTUIProgram
+	})
+
+	ensureCurrentOSSupported = func() error { return nil }
+	detectSystem = func(_ context.Context) (system.DetectionResult, error) {
+		return system.DetectionResult{System: system.SystemInfo{Supported: true}}, nil
+	}
+
+	called := false
+	runTUIProgram = func(_ tui.Model) error {
+		called = true
+		return nil
+	}
+
 	var buf bytes.Buffer
 	err := RunArgs(nil, &buf)
-	// With no args, RunArgs now launches the TUI via Bubbletea.
-	// In a headless/test environment without a TTY, this returns an error
-	// about opening /dev/tty. That's expected — the TUI requires a terminal.
-	if err == nil {
-		// If no error, we're somehow in a TTY — that's fine too.
-		return
+	if err != nil {
+		t.Fatalf("RunArgs(nil) unexpected error = %v", err)
 	}
-	if !strings.Contains(err.Error(), "TTY") && !strings.Contains(err.Error(), "tty") {
-		t.Fatalf("RunArgs(nil) unexpected error = %v; want TTY-related error or nil", err)
+	if !called {
+		t.Fatal("RunArgs(nil) did not invoke runTUIProgram")
 	}
 }
 

--- a/internal/assets/assets.go
+++ b/internal/assets/assets.go
@@ -2,7 +2,7 @@ package assets
 
 import "embed"
 
-//go:embed all:claude all:opencode all:generic all:skills all:gga all:gemini all:codex all:antigravity all:windsurf all:cursor all:kimi all:qwen all:kiro
+//go:embed all:claude all:opencode all:generic all:skills all:gga all:gemini all:codex all:antigravity all:windsurf all:cursor all:kimi all:qwen all:kiro all:pi
 var FS embed.FS
 
 // MustRead returns the content of an embedded file or panics.

--- a/internal/assets/pi/agents/sdd-apply.md
+++ b/internal/assets/pi/agents/sdd-apply.md
@@ -1,0 +1,27 @@
+---
+name: sdd-apply
+description: Implement the selected SDD tasks in strict TDD order.
+model: {{MODEL}}
+---
+
+## Project Context Inheritance
+
+- Inherit project metadata, workspace root, and change name from the orchestrator prompt.
+
+## Skills Inheritance Rule
+
+- Apply injected `## Project Standards (auto-resolved)` rules first.
+- Load additional skills only when the phase prompt explicitly requires them.
+
+## Phase Prompt
+
+Execute the `sdd-apply` phase end-to-end and persist `sdd/{change-name}/apply-progress`.
+
+## Result Contract
+
+- status
+- executive_summary
+- artifacts
+- next_recommended
+- risks
+- skill_resolution

--- a/internal/assets/pi/agents/sdd-archive.md
+++ b/internal/assets/pi/agents/sdd-archive.md
@@ -1,0 +1,27 @@
+---
+name: sdd-archive
+description: Archive completed SDD changes and sync final artifacts.
+model: {{MODEL}}
+---
+
+## Project Context Inheritance
+
+- Inherit project metadata, workspace root, and change name from the orchestrator prompt.
+
+## Skills Inheritance Rule
+
+- Apply injected `## Project Standards (auto-resolved)` rules first.
+- Load additional skills only when the phase prompt explicitly requires them.
+
+## Phase Prompt
+
+Execute the `sdd-archive` phase end-to-end and persist `sdd/{change-name}/archive-report`.
+
+## Result Contract
+
+- status
+- executive_summary
+- artifacts
+- next_recommended
+- risks
+- skill_resolution

--- a/internal/assets/pi/agents/sdd-design.md
+++ b/internal/assets/pi/agents/sdd-design.md
@@ -1,0 +1,27 @@
+---
+name: sdd-design
+description: Produce technical design decisions for the active change.
+model: {{MODEL}}
+---
+
+## Project Context Inheritance
+
+- Inherit project metadata, workspace root, and change name from the orchestrator prompt.
+
+## Skills Inheritance Rule
+
+- Apply injected `## Project Standards (auto-resolved)` rules first.
+- Load additional skills only when the phase prompt explicitly requires them.
+
+## Phase Prompt
+
+Execute the `sdd-design` phase end-to-end and persist `sdd/{change-name}/design`.
+
+## Result Contract
+
+- status
+- executive_summary
+- artifacts
+- next_recommended
+- risks
+- skill_resolution

--- a/internal/assets/pi/agents/sdd-explore.md
+++ b/internal/assets/pi/agents/sdd-explore.md
@@ -1,0 +1,27 @@
+---
+name: sdd-explore
+description: Explore requirements and constraints before proposing changes.
+model: {{MODEL}}
+---
+
+## Project Context Inheritance
+
+- Inherit project metadata, workspace root, and change name from the orchestrator prompt.
+
+## Skills Inheritance Rule
+
+- Apply injected `## Project Standards (auto-resolved)` rules first.
+- Load additional skills only when the phase prompt explicitly requires them.
+
+## Phase Prompt
+
+Execute the `sdd-explore` phase end-to-end and persist `sdd/{change-name}/explore`.
+
+## Result Contract
+
+- status
+- executive_summary
+- artifacts
+- next_recommended
+- risks
+- skill_resolution

--- a/internal/assets/pi/agents/sdd-init.md
+++ b/internal/assets/pi/agents/sdd-init.md
@@ -1,0 +1,27 @@
+---
+name: sdd-init
+description: Initialize SDD context for the current project.
+model: {{MODEL}}
+---
+
+## Project Context Inheritance
+
+- Inherit project metadata, workspace root, and change name from the orchestrator prompt.
+
+## Skills Inheritance Rule
+
+- Apply injected `## Project Standards (auto-resolved)` rules first.
+- Load additional skills only when the phase prompt explicitly requires them.
+
+## Phase Prompt
+
+Execute the `sdd-init` phase end-to-end and persist `sdd/{project}/testing-capabilities` and initialization context artifacts.
+
+## Result Contract
+
+- status
+- executive_summary
+- artifacts
+- next_recommended
+- risks
+- skill_resolution

--- a/internal/assets/pi/agents/sdd-onboard.md
+++ b/internal/assets/pi/agents/sdd-onboard.md
@@ -1,0 +1,27 @@
+---
+name: sdd-onboard
+description: Guide users through the complete SDD workflow for this project.
+model: {{MODEL}}
+---
+
+## Project Context Inheritance
+
+- Inherit project metadata, workspace root, and change name from the orchestrator prompt.
+
+## Skills Inheritance Rule
+
+- Apply injected `## Project Standards (auto-resolved)` rules first.
+- Load additional skills only when the phase prompt explicitly requires them.
+
+## Phase Prompt
+
+Execute the `sdd-onboard` phase end-to-end and persist onboarding guidance artifacts.
+
+## Result Contract
+
+- status
+- executive_summary
+- artifacts
+- next_recommended
+- risks
+- skill_resolution

--- a/internal/assets/pi/agents/sdd-propose.md
+++ b/internal/assets/pi/agents/sdd-propose.md
@@ -1,0 +1,27 @@
+---
+name: sdd-propose
+description: Propose an SDD change with clear scope and intent.
+model: {{MODEL}}
+---
+
+## Project Context Inheritance
+
+- Inherit project metadata, workspace root, and change name from the orchestrator prompt.
+
+## Skills Inheritance Rule
+
+- Apply injected `## Project Standards (auto-resolved)` rules first.
+- Load additional skills only when the phase prompt explicitly requires them.
+
+## Phase Prompt
+
+Execute the `sdd-propose` phase end-to-end and persist `sdd/{change-name}/proposal`.
+
+## Result Contract
+
+- status
+- executive_summary
+- artifacts
+- next_recommended
+- risks
+- skill_resolution

--- a/internal/assets/pi/agents/sdd-spec.md
+++ b/internal/assets/pi/agents/sdd-spec.md
@@ -1,0 +1,27 @@
+---
+name: sdd-spec
+description: Write requirement scenarios for the active change.
+model: {{MODEL}}
+---
+
+## Project Context Inheritance
+
+- Inherit project metadata, workspace root, and change name from the orchestrator prompt.
+
+## Skills Inheritance Rule
+
+- Apply injected `## Project Standards (auto-resolved)` rules first.
+- Load additional skills only when the phase prompt explicitly requires them.
+
+## Phase Prompt
+
+Execute the `sdd-spec` phase end-to-end and persist `sdd/{change-name}/spec`.
+
+## Result Contract
+
+- status
+- executive_summary
+- artifacts
+- next_recommended
+- risks
+- skill_resolution

--- a/internal/assets/pi/agents/sdd-tasks.md
+++ b/internal/assets/pi/agents/sdd-tasks.md
@@ -1,0 +1,27 @@
+---
+name: sdd-tasks
+description: Break the change into dependency-ordered implementation tasks.
+model: {{MODEL}}
+---
+
+## Project Context Inheritance
+
+- Inherit project metadata, workspace root, and change name from the orchestrator prompt.
+
+## Skills Inheritance Rule
+
+- Apply injected `## Project Standards (auto-resolved)` rules first.
+- Load additional skills only when the phase prompt explicitly requires them.
+
+## Phase Prompt
+
+Execute the `sdd-tasks` phase end-to-end and persist `sdd/{change-name}/tasks`.
+
+## Result Contract
+
+- status
+- executive_summary
+- artifacts
+- next_recommended
+- risks
+- skill_resolution

--- a/internal/assets/pi/agents/sdd-verify.md
+++ b/internal/assets/pi/agents/sdd-verify.md
@@ -1,0 +1,27 @@
+---
+name: sdd-verify
+description: Verify implementation against specs, design, and completed tasks.
+model: {{MODEL}}
+---
+
+## Project Context Inheritance
+
+- Inherit project metadata, workspace root, and change name from the orchestrator prompt.
+
+## Skills Inheritance Rule
+
+- Apply injected `## Project Standards (auto-resolved)` rules first.
+- Load additional skills only when the phase prompt explicitly requires them.
+
+## Phase Prompt
+
+Execute the `sdd-verify` phase end-to-end and persist `sdd/{change-name}/verify-report`.
+
+## Result Contract
+
+- status
+- executive_summary
+- artifacts
+- next_recommended
+- risks
+- skill_resolution

--- a/internal/assets/pi/agents/sdd.chain.md
+++ b/internal/assets/pi/agents/sdd.chain.md
@@ -1,0 +1,56 @@
+---
+name: sdd
+description: Executable PI SDD chain for pi-subagents.
+---
+
+This file follows the native `pi-subagents` chain format.
+Each `## <agent-name>` heading is an executable step.
+
+## sdd-init
+{{MODEL_LINE_sdd-init}}
+
+Initialize SDD for this project when needed, or confirm existing SDD context and continue with the next phase for task: {task}
+
+## sdd-explore
+{{MODEL_LINE_sdd-explore}}
+
+Explore and validate the problem/constraints using prior context from {previous}. Return the standard SDD result contract.
+
+## sdd-propose
+{{MODEL_LINE_sdd-propose}}
+
+Create or refine the change proposal from {previous}. Return the standard SDD result contract.
+
+## sdd-spec
+{{MODEL_LINE_sdd-spec}}
+
+Write or update the delta spec based on {previous}. Return the standard SDD result contract.
+
+## sdd-design
+{{MODEL_LINE_sdd-design}}
+
+Produce/update technical design decisions from {previous}. Return the standard SDD result contract.
+
+## sdd-tasks
+{{MODEL_LINE_sdd-tasks}}
+
+Break implementation into explicit checklist tasks from {previous}. Return the standard SDD result contract.
+
+## sdd-apply
+{{MODEL_LINE_sdd-apply}}
+
+Implement the approved tasks from {previous} and report progress with the standard SDD result contract.
+
+## sdd-verify
+{{MODEL_LINE_sdd-verify}}
+
+Verify implementation against proposal/spec/design/tasks from {previous}. Return the standard SDD result contract.
+
+## sdd-archive
+{{MODEL_LINE_sdd-archive}}
+
+Archive completed change artifacts after successful verification from {previous}. Return the standard SDD result contract.
+
+### Phase model summary (informational)
+
+{{CHAIN_MODELS}}

--- a/internal/catalog/agents.go
+++ b/internal/catalog/agents.go
@@ -3,15 +3,17 @@ package catalog
 import "github.com/gentleman-programming/gentle-ai/internal/model"
 
 type Agent struct {
-	ID         model.AgentID
-	Name       string
-	Tier       model.SupportTier
-	ConfigPath string
+	ID               model.AgentID
+	Name             string
+	Tier             model.SupportTier
+	ConfigPath       string
+	CapabilityLabels []string
 }
 
 var allAgents = []Agent{
 	{ID: model.AgentClaudeCode, Name: "Claude Code", Tier: model.TierFull, ConfigPath: "~/.claude"},
 	{ID: model.AgentOpenCode, Name: "OpenCode", Tier: model.TierFull, ConfigPath: "~/.config/opencode"},
+	{ID: model.AgentPiCodingAgent, Name: "PI Coding Agent", Tier: model.TierFull, ConfigPath: "~/.pi/agent", CapabilityLabels: []string{"experimental", "non-parity"}},
 	{ID: model.AgentKilocode, Name: "Kilo Code", Tier: model.TierFull, ConfigPath: "~/.config/kilo"},
 	{ID: model.AgentGeminiCLI, Name: "Gemini CLI", Tier: model.TierFull, ConfigPath: "~/.gemini"},
 	{ID: model.AgentCodex, Name: "Codex", Tier: model.TierFull, ConfigPath: "~/.codex"},

--- a/internal/catalog/agents_test.go
+++ b/internal/catalog/agents_test.go
@@ -1,0 +1,45 @@
+package catalog
+
+import (
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/internal/model"
+)
+
+func TestAllAgentsIncludesPIWithNonParityLabels(t *testing.T) {
+	agents := AllAgents()
+
+	var pi *Agent
+	for i := range agents {
+		if agents[i].ID == model.AgentPiCodingAgent {
+			pi = &agents[i]
+			break
+		}
+	}
+
+	if pi == nil {
+		t.Fatalf("AllAgents() missing %q", model.AgentPiCodingAgent)
+	}
+
+	if pi.ConfigPath != "~/.pi/agent" {
+		t.Fatalf("PI ConfigPath = %q, want %q", pi.ConfigPath, "~/.pi/agent")
+	}
+
+	wantLabels := []string{"experimental", "non-parity"}
+	if len(pi.CapabilityLabels) != len(wantLabels) {
+		t.Fatalf("PI CapabilityLabels len = %d, want %d (%v)", len(pi.CapabilityLabels), len(wantLabels), wantLabels)
+	}
+	for idx, want := range wantLabels {
+		if pi.CapabilityLabels[idx] != want {
+			t.Fatalf("PI CapabilityLabels[%d] = %q, want %q", idx, pi.CapabilityLabels[idx], want)
+		}
+	}
+}
+
+func TestMVPAgentsDoNotIncludePI(t *testing.T) {
+	for _, agent := range MVPAgents() {
+		if agent.ID == model.AgentPiCodingAgent {
+			t.Fatalf("MVPAgents() should not include %q", model.AgentPiCodingAgent)
+		}
+	}
+}

--- a/internal/cli/dryrun_test.go
+++ b/internal/cli/dryrun_test.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -31,4 +33,165 @@ func TestRenderDryRunIncludesPlatformDecision(t *testing.T) {
 	if !strings.Contains(output, want) {
 		t.Fatalf("RenderDryRun() missing platform decision\noutput=%s", output)
 	}
+}
+
+func TestPlannedSyncPathsIncludesPiArtifactsWhenPiSubagentsPresent(t *testing.T) {
+	home := t.TempDir()
+	workspace := t.TempDir()
+
+	if err := os.MkdirAll(filepath.Join(home, ".config", "pi-coding-agent"), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(workspace, ".pi", "extensions", "pi-subagents"), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+
+	selection := model.Selection{
+		Agents:     []model.AgentID{model.AgentPiCodingAgent},
+		Components: []model.ComponentID{model.ComponentSDD},
+		SDDMode:    model.SDDModeMulti,
+	}
+
+	planned, err := plannedSyncPaths(home, workspace, selection)
+	if err != nil {
+		t.Fatalf("plannedSyncPaths() error = %v", err)
+	}
+
+	if !containsPathSuffix(planned, filepath.Join(".pi", "agents", "sdd-apply.md")) {
+		t.Fatalf("plannedSyncPaths() missing .pi/agents/sdd-apply.md\npaths=%v", planned)
+	}
+	if !containsPathSuffix(planned, filepath.Join(".pi", "agents", "sdd.chain.md")) {
+		t.Fatalf("plannedSyncPaths() missing .pi/agents/sdd.chain.md\npaths=%v", planned)
+	}
+}
+
+func TestPlannedSyncPathsUsesProjectRootForPiArtifactsWhenWorkspaceNested(t *testing.T) {
+	home := t.TempDir()
+	projectRoot := t.TempDir()
+	workspace := filepath.Join(projectRoot, "pkg", "feature")
+
+	if err := os.MkdirAll(filepath.Join(home, ".config", "pi-coding-agent"), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(projectRoot, ".git"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(.git) error = %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(projectRoot, ".pi", "extensions", "pi-subagents"), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.MkdirAll(workspace, 0o755); err != nil {
+		t.Fatalf("MkdirAll(workspace) error = %v", err)
+	}
+
+	selection := model.Selection{
+		Agents:     []model.AgentID{model.AgentPiCodingAgent},
+		Components: []model.ComponentID{model.ComponentSDD},
+		SDDMode:    model.SDDModeMulti,
+	}
+
+	planned, err := plannedSyncPaths(home, workspace, selection)
+	if err != nil {
+		t.Fatalf("plannedSyncPaths() error = %v", err)
+	}
+
+	if !containsPathSuffix(planned, filepath.Join(projectRoot, ".pi", "agents", "sdd-apply.md")) {
+		t.Fatalf("plannedSyncPaths() missing project-root PI artifact path\npaths=%v", planned)
+	}
+	if containsPathSuffix(planned, filepath.Join(workspace, ".pi", "agents", "sdd-apply.md")) {
+		t.Fatalf("plannedSyncPaths() should not use nested workspace path for PI artifacts\npaths=%v", planned)
+	}
+}
+
+func TestPlannedSyncPathsUsesMonorepoRootMarkersForPiArtifacts(t *testing.T) {
+	home := t.TempDir()
+	projectRoot := t.TempDir()
+	workspace := filepath.Join(projectRoot, "apps", "web")
+
+	if err := os.MkdirAll(filepath.Join(home, ".config", "pi-coding-agent"), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(projectRoot, "turbo.json"), []byte("{}\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(turbo.json) error = %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(projectRoot, ".pi", "extensions", "pi-subagents"), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.MkdirAll(workspace, 0o755); err != nil {
+		t.Fatalf("MkdirAll(workspace) error = %v", err)
+	}
+
+	selection := model.Selection{
+		Agents:     []model.AgentID{model.AgentPiCodingAgent},
+		Components: []model.ComponentID{model.ComponentSDD},
+		SDDMode:    model.SDDModeMulti,
+	}
+
+	planned, err := plannedSyncPaths(home, workspace, selection)
+	if err != nil {
+		t.Fatalf("plannedSyncPaths() error = %v", err)
+	}
+
+	if !containsPathSuffix(planned, filepath.Join(projectRoot, ".pi", "agents", "sdd-apply.md")) {
+		t.Fatalf("plannedSyncPaths() missing project-root PI artifact path for monorepo marker\npaths=%v", planned)
+	}
+	if containsPathSuffix(planned, filepath.Join(workspace, ".pi", "agents", "sdd-apply.md")) {
+		t.Fatalf("plannedSyncPaths() should not use nested workspace path when monorepo marker exists\npaths=%v", planned)
+	}
+}
+
+func TestPlannedSyncPathsExcludesPiArtifactsWhenPiSubagentsAbsent(t *testing.T) {
+	home := t.TempDir()
+	workspace := t.TempDir()
+
+	if err := os.MkdirAll(filepath.Join(home, ".config", "pi-coding-agent"), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+
+	selection := model.Selection{
+		Agents:     []model.AgentID{model.AgentPiCodingAgent},
+		Components: []model.ComponentID{model.ComponentSDD},
+		SDDMode:    model.SDDModeMulti,
+	}
+
+	planned, err := plannedSyncPaths(home, workspace, selection)
+	if err == nil {
+		t.Fatal("plannedSyncPaths() expected error when PI multi-mode is requested without pi-subagents")
+	}
+
+	if containsPathSuffix(planned, filepath.Join(".pi", "agents", "sdd-apply.md")) {
+		t.Fatalf("plannedSyncPaths() should not include PI artifacts when pi-subagents is absent\npaths=%v", planned)
+	}
+}
+
+func TestRenderSyncReportDryRunIncludesPlannedPaths(t *testing.T) {
+	report := RenderSyncReport(SyncResult{
+		DryRun: true,
+		Agents: []model.AgentID{model.AgentPiCodingAgent},
+		Selection: model.Selection{
+			Components: []model.ComponentID{model.ComponentSDD},
+		},
+		PlannedFiles: []string{
+			"/tmp/work/.pi/agents/sdd-apply.md",
+			"/tmp/work/.pi/agents/sdd.chain.md",
+		},
+	})
+
+	if !strings.Contains(report, "Planned paths:") {
+		t.Fatalf("RenderSyncReport() missing planned paths header\nreport=%s", report)
+	}
+	if !strings.Contains(report, ".pi/agents/sdd-apply.md") {
+		t.Fatalf("RenderSyncReport() missing planned PI agent path\nreport=%s", report)
+	}
+	if !strings.Contains(report, ".pi/agents/sdd.chain.md") {
+		t.Fatalf("RenderSyncReport() missing planned PI chain path\nreport=%s", report)
+	}
+}
+
+func containsPathSuffix(paths []string, suffix string) bool {
+	for _, path := range paths {
+		if strings.HasSuffix(path, suffix) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/cli/install_test.go
+++ b/internal/cli/install_test.go
@@ -43,7 +43,7 @@ func TestNormalizeInstallFlagsDefaults(t *testing.T) {
 	}
 
 	want := model.Selection{
-		Agents:  []model.AgentID{model.AgentClaudeCode, model.AgentOpenCode, model.AgentKilocode, model.AgentGeminiCLI, model.AgentCodex, model.AgentCursor, model.AgentVSCodeCopilot, model.AgentAntigravity, model.AgentWindsurf, model.AgentKimi, model.AgentQwenCode, model.AgentKiroIDE},
+		Agents:  []model.AgentID{model.AgentClaudeCode, model.AgentOpenCode, model.AgentPiCodingAgent, model.AgentKilocode, model.AgentGeminiCLI, model.AgentCodex, model.AgentCursor, model.AgentVSCodeCopilot, model.AgentAntigravity, model.AgentWindsurf, model.AgentKimi, model.AgentQwenCode, model.AgentKiroIDE},
 		Persona: model.PersonaGentleman,
 		Preset:  model.PresetFullGentleman,
 		Components: []model.ComponentID{
@@ -183,7 +183,7 @@ func TestRunInstallDryRunSkipsExecution(t *testing.T) {
 func makeDetectionWithAgents(present ...string) system.DetectionResult {
 	var configs []system.ConfigState
 	// Full canonical agent set — mirrors knownAgentConfigDirs in config_scan.go.
-	known := []string{"claude-code", "opencode", "kilocode", "gemini-cli", "cursor", "vscode-copilot", "codex", "antigravity", "windsurf", "kimi", "qwen-code", "kiro-ide"}
+	known := []string{"claude-code", "opencode", "kilocode", "gemini-cli", "cursor", "vscode-copilot", "codex", "antigravity", "windsurf", "kimi", "qwen-code", "kiro-ide", "pi-coding-agent"}
 	presentSet := make(map[string]bool, len(present))
 	for _, p := range present {
 		presentSet[p] = true
@@ -240,6 +240,7 @@ func TestDefaultAgentsFromDetection_AllAgentsMappedCorrectly(t *testing.T) {
 		{"kimi", model.AgentKimi},
 		{"qwen-code", model.AgentQwenCode},
 		{"kiro-ide", model.AgentKiroIDE},
+		{"pi-coding-agent", model.AgentPiCodingAgent},
 	}
 
 	for _, tt := range tests {

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -155,6 +155,7 @@ func RunInstall(args []string, detection system.DetectionResult) (InstallResult,
 		InstalledAgents:        agentIDs,
 		ClaudeModelAssignments: claudeAliasesToStrings(input.Selection.ClaudeModelAssignments),
 		ModelAssignments:       modelAssignmentsToState(input.Selection.ModelAssignments),
+		PIModelAssignments:     modelAssignmentsToState(input.Selection.PIModelAssignments),
 	})
 
 	return result, nil
@@ -595,6 +596,7 @@ func (s componentApplyStep) Run() error {
 		for _, adapter := range adapters {
 			opts := sdd.InjectOptions{
 				OpenCodeModelAssignments: s.selection.ModelAssignments,
+				PIModelAssignments:       s.selection.PIModelAssignments,
 				ClaudeModelAssignments:   s.selection.ClaudeModelAssignments,
 				KiroModelAssignments:     s.selection.KiroModelAssignments,
 				WorkspaceDir:             s.workspaceDir,

--- a/internal/cli/run_path_guidance_test.go
+++ b/internal/cli/run_path_guidance_test.go
@@ -26,6 +26,9 @@ func TestEngramPathGuidanceZsh(t *testing.T) {
 }
 
 func TestEngramPathGuidanceDefault(t *testing.T) {
+	t.Setenv("GOBIN", "")
+	t.Setenv("GOPATH", "")
+
 	msg := engramPathGuidance("")
 	if want := "go/bin"; !strings.Contains(msg, want) {
 		t.Fatalf("engramPathGuidance(default) missing %q: %s", want, msg)

--- a/internal/cli/run_preflight_test.go
+++ b/internal/cli/run_preflight_test.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -58,3 +60,61 @@ func TestCheckDependenciesStepDoesNotRequireUVForOtherAgents(t *testing.T) {
 type errNotFound struct{}
 
 func (errNotFound) Error() string { return "not found" }
+
+func TestValidatePiMultiModelPreflightFailsWithoutPiSubagents(t *testing.T) {
+	home := t.TempDir()
+	workspace := t.TempDir()
+
+	selection := model.Selection{
+		Agents:     []model.AgentID{model.AgentPiCodingAgent},
+		Components: []model.ComponentID{model.ComponentSDD},
+		SDDMode:    model.SDDModeMulti,
+	}
+
+	err := validatePiMultiModelPreflight(home, workspace, selection)
+	if err == nil {
+		t.Fatal("validatePiMultiModelPreflight() expected error when pi-subagents is absent")
+	}
+
+	if !strings.Contains(err.Error(), "PI multi-model requires installing the `pi-subagents` extension.") {
+		t.Fatalf("validatePiMultiModelPreflight() error = %q, expected canonical PI requirement", err.Error())
+	}
+
+	if !strings.Contains(err.Error(), "pi install npm:pi-subagents") {
+		t.Fatalf("validatePiMultiModelPreflight() error = %q, expected install command guidance", err.Error())
+	}
+}
+
+func TestValidatePiMultiModelPreflightAllowsWhenPiSubagentsPresent(t *testing.T) {
+	home := t.TempDir()
+	workspace := t.TempDir()
+
+	if err := os.MkdirAll(filepath.Join(workspace, ".pi", "extensions", "pi-subagents"), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+
+	selection := model.Selection{
+		Agents:     []model.AgentID{model.AgentPiCodingAgent},
+		Components: []model.ComponentID{model.ComponentSDD},
+		SDDMode:    model.SDDModeMulti,
+	}
+
+	if err := validatePiMultiModelPreflight(home, workspace, selection); err != nil {
+		t.Fatalf("validatePiMultiModelPreflight() unexpected error = %v", err)
+	}
+}
+
+func TestValidatePiMultiModelPreflightNoopForOpenCodeRegressionSafety(t *testing.T) {
+	home := t.TempDir()
+	workspace := t.TempDir()
+
+	selection := model.Selection{
+		Agents:     []model.AgentID{model.AgentOpenCode},
+		Components: []model.ComponentID{model.ComponentSDD},
+		SDDMode:    model.SDDModeMulti,
+	}
+
+	if err := validatePiMultiModelPreflight(home, workspace, selection); err != nil {
+		t.Fatalf("validatePiMultiModelPreflight() should ignore non-PI selection, got err = %v", err)
+	}
+}

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -2,15 +2,19 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	"time"
 
 	"github.com/gentleman-programming/gentle-ai/internal/agents"
+	"github.com/gentleman-programming/gentle-ai/internal/agents/capabilities"
+	"github.com/gentleman-programming/gentle-ai/internal/assets"
 	"github.com/gentleman-programming/gentle-ai/internal/backup"
 	"github.com/gentleman-programming/gentle-ai/internal/components/engram"
 	"github.com/gentleman-programming/gentle-ai/internal/components/gga"
@@ -53,6 +57,8 @@ type SyncResult struct {
 	Execution pipeline.ExecutionResult
 	Verify    verify.Report
 	DryRun    bool
+	// PlannedFiles are rendered for dry-run visibility.
+	PlannedFiles []string
 	// NoOp is true when no managed asset changes were needed:
 	// either no agents were discovered/provided, or all managed assets
 	// were already current (idempotent re-sync).
@@ -60,6 +66,96 @@ type SyncResult struct {
 	// FilesChanged is the number of managed files actually written or updated
 	// during this sync. Zero means all assets were already current.
 	FilesChanged int
+}
+
+const piSubagentsInstallCommand = "pi install npm:pi-subagents"
+
+var osGetwdSync = os.Getwd
+
+func piSubagentsInstallMessage() string {
+	return fmt.Sprintf("%s Install it with: %s", capabilities.PiMultiModelRequiresPiSubagentsMessage, piSubagentsInstallCommand)
+}
+
+func validatePiMultiModelPreflight(homeDir, workspaceDir string, selection model.Selection) error {
+	if !requiresPiMultiModelPreflight(selection) {
+		return nil
+	}
+
+	resolved, err := capabilities.NewResolver(nil).Resolve(homeDir, workspaceDir, model.AgentPiCodingAgent)
+	if err != nil || !resolved.SupportsSDDMultiMode {
+		return errors.New(piSubagentsInstallMessage())
+	}
+
+	return nil
+}
+
+func requiresPiMultiModelPreflight(selection model.Selection) bool {
+	return syncPIArtifactsEnabled(selection)
+}
+
+func syncPIArtifactsEnabled(selection model.Selection) bool {
+	if !selection.HasAgent(model.AgentPiCodingAgent) || !selection.HasComponent(model.ComponentSDD) {
+		return false
+	}
+	if selection.SDDMode == model.SDDModeMulti {
+		return true
+	}
+	return selection.SDDProfileStrategy == model.SDDProfileStrategyGeneratedMulti
+}
+
+func syncPIArtifactsDir(workspaceDir string) string {
+	if projectRoot, ok := sdd.ResolvePIArtifactsProjectRoot(workspaceDir); ok {
+		return filepath.Join(projectRoot, ".pi", "agents")
+	}
+	return filepath.Join(workspaceDir, ".pi", "agents")
+}
+
+func plannedSyncPaths(homeDir, workspaceDir string, selection model.Selection) ([]string, error) {
+	if err := validatePiMultiModelPreflight(homeDir, workspaceDir, selection); err != nil {
+		return nil, err
+	}
+
+	adapters := resolveAdapters(selection.Agents)
+	paths := make([]string, 0)
+
+	for _, component := range selection.Components {
+		paths = append(paths, componentPaths(homeDir, selection, adapters, component)...)
+	}
+
+	if syncPIArtifactsEnabled(selection) {
+		entries, err := assets.FS.ReadDir("pi/agents")
+		if err != nil {
+			return nil, fmt.Errorf("read embedded pi agents: %w", err)
+		}
+		piAgentsDir := syncPIArtifactsDir(workspaceDir)
+
+		for _, entry := range entries {
+			if entry.IsDir() {
+				continue
+			}
+			paths = append(paths, filepath.Join(piAgentsDir, entry.Name()))
+		}
+	}
+
+	paths = uniqueStrings(paths)
+	slices.Sort(paths)
+	return paths, nil
+}
+
+func uniqueStrings(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		if value == "" {
+			continue
+		}
+		if _, exists := seen[value]; exists {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	return out
 }
 
 // ParseSyncFlags parses the CLI arguments for the sync subcommand.
@@ -420,9 +516,25 @@ func (r *syncRuntime) stagePlan() pipeline.StagePlan {
 // before sync executes. Uses the same componentPaths logic as install.
 func syncBackupTargets(homeDir string, selection model.Selection, adapters []agents.Adapter) []string {
 	paths := map[string]struct{}{}
+	workspaceDir, err := osGetwdSync()
+	if err != nil {
+		return nil
+	}
 	for _, component := range selection.Components {
 		for _, path := range componentPaths(homeDir, selection, adapters, component) {
 			paths[path] = struct{}{}
+		}
+	}
+	if syncPIArtifactsEnabled(selection) {
+		entries, err := assets.FS.ReadDir("pi/agents")
+		if err == nil {
+			piAgentsDir := syncPIArtifactsDir(workspaceDir)
+			for _, entry := range entries {
+				if entry.IsDir() {
+					continue
+				}
+				paths[filepath.Join(piAgentsDir, entry.Name())] = struct{}{}
+			}
 		}
 	}
 
@@ -518,6 +630,7 @@ func (s componentSyncStep) Run() error {
 		for _, adapter := range adapters {
 			opts := sdd.InjectOptions{
 				OpenCodeModelAssignments:           s.selection.ModelAssignments,
+				PIModelAssignments:                 s.selection.PIModelAssignments,
 				ClaudeModelAssignments:             s.selection.ClaudeModelAssignments,
 				KiroModelAssignments:               s.selection.KiroModelAssignments,
 				WorkspaceDir:                       s.workspaceDir,
@@ -629,6 +742,14 @@ func RunSyncWithSelection(homeDir string, selection model.Selection) (SyncResult
 		return result, nil
 	}
 
+	workspaceDir, err := os.Getwd()
+	if err != nil {
+		return result, fmt.Errorf("resolve workspace directory: %w", err)
+	}
+	if err := validatePiMultiModelPreflight(homeDir, workspaceDir, selection); err != nil {
+		return result, err
+	}
+
 	rt, err := newSyncRuntime(homeDir, selection)
 	if err != nil {
 		return result, err
@@ -687,36 +808,34 @@ func RunSync(args []string) (SyncResult, error) {
 	agentIDs = unique(agentIDs)
 
 	selection := BuildSyncSelection(flags, agentIDs)
+	workspaceDir, err := os.Getwd()
+	if err != nil {
+		return SyncResult{}, fmt.Errorf("resolve workspace directory: %w", err)
+	}
 
 	// Load persisted model assignments from state when not provided via flags.
 	// This is the key fix: without this, every CLI sync falls back to the
 	// "balanced" preset and silently overwrites the user's model choices.
-	if len(selection.ClaudeModelAssignments) == 0 || len(selection.ModelAssignments) == 0 {
+	piAssignmentsInScope := selection.HasAgent(model.AgentPiCodingAgent) && selection.HasComponent(model.ComponentSDD)
+	if len(selection.ClaudeModelAssignments) == 0 || len(selection.KiroModelAssignments) == 0 || len(selection.ModelAssignments) == 0 || (piAssignmentsInScope && len(selection.PIModelAssignments) == 0) {
 		s, readErr := state.Read(homeDir)
 		if readErr == nil {
-			if len(selection.ClaudeModelAssignments) == 0 && len(s.ClaudeModelAssignments) > 0 {
-				m := make(map[string]model.ClaudeModelAlias, len(s.ClaudeModelAssignments))
-				for k, v := range s.ClaudeModelAssignments {
-					m[k] = model.ClaudeModelAlias(v)
-				}
-				selection.ClaudeModelAssignments = m
-			}
-			if len(selection.ModelAssignments) == 0 && len(s.ModelAssignments) > 0 {
-				m := make(map[string]model.ModelAssignment, len(s.ModelAssignments))
-				for k, v := range s.ModelAssignments {
-					m[k] = model.ModelAssignment{ProviderID: v.ProviderID, ModelID: v.ModelID}
-				}
-				selection.ModelAssignments = m
-			}
+			state.HydrateSelectionAssignments(&selection, s, piAssignmentsInScope)
 		}
 	}
 
 	if flags.DryRun {
+		plannedFiles, err := plannedSyncPaths(homeDir, workspaceDir, selection)
+		if err != nil {
+			return SyncResult{}, err
+		}
+
 		// Build the plan for inspection, skip execution.
 		result := SyncResult{
-			Agents:    agentIDs,
-			Selection: selection,
-			DryRun:    true,
+			Agents:       agentIDs,
+			Selection:    selection,
+			DryRun:       true,
+			PlannedFiles: plannedFiles,
 		}
 		if len(agentIDs) == 0 {
 			result.NoOp = true
@@ -774,6 +893,12 @@ func RenderSyncReport(result SyncResult) string {
 		}
 		fmt.Fprintf(&b, "Prepare steps: %d\n", len(result.Plan.Prepare))
 		fmt.Fprintf(&b, "Apply steps: %d\n", len(result.Plan.Apply))
+		if len(result.PlannedFiles) > 0 {
+			fmt.Fprintln(&b, "Planned paths:")
+			for _, path := range result.PlannedFiles {
+				fmt.Fprintf(&b, "- %s\n", path)
+			}
+		}
 		return strings.TrimRight(b.String(), "\n")
 	}
 
@@ -806,6 +931,15 @@ func RenderSyncReport(result SyncResult) string {
 func runPostSyncVerification(homeDir string, selection model.Selection) verify.Report {
 	checks := make([]verify.Check, 0)
 	adapters := resolveAdapters(selection.Agents)
+	workspaceDir, err := osGetwdSync()
+	if err != nil {
+		return verify.BuildReport([]verify.CheckResult{{
+			ID:          "verify:sync:workspace",
+			Description: "resolve workspace directory",
+			Status:      verify.CheckStatusFailed,
+			Error:       err.Error(),
+		}})
+	}
 
 	for _, component := range selection.Components {
 		for _, path := range componentPaths(homeDir, selection, adapters, component) {
@@ -820,6 +954,27 @@ func runPostSyncVerification(homeDir string, selection model.Selection) verify.R
 					return nil
 				},
 			})
+		}
+	}
+
+	if syncPIArtifactsEnabled(selection) {
+		if entries, err := assets.FS.ReadDir("pi/agents"); err == nil {
+			for _, entry := range entries {
+				if entry.IsDir() {
+					continue
+				}
+				currentPath := filepath.Join(syncPIArtifactsDir(workspaceDir), entry.Name())
+				checks = append(checks, verify.Check{
+					ID:          "verify:sync:file:" + currentPath,
+					Description: "synced file exists",
+					Run: func(context.Context) error {
+						if _, err := os.Stat(currentPath); err != nil {
+							return err
+						}
+						return nil
+					},
+				})
+			}
 		}
 	}
 

--- a/internal/cli/sync_test.go
+++ b/internal/cli/sync_test.go
@@ -7,8 +7,14 @@ import (
 	"strings"
 	"testing"
 
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/gentleman-programming/gentle-ai/internal/agents/capabilities"
+	"github.com/gentleman-programming/gentle-ai/internal/agents/pi"
+	"github.com/gentleman-programming/gentle-ai/internal/components/sdd"
 	"github.com/gentleman-programming/gentle-ai/internal/model"
 	"github.com/gentleman-programming/gentle-ai/internal/state"
+	"github.com/gentleman-programming/gentle-ai/internal/system"
+	"github.com/gentleman-programming/gentle-ai/internal/tui"
 )
 
 // ─── Phase 1: ParseSyncFlags ───────────────────────────────────────────────
@@ -732,6 +738,188 @@ func TestRunSyncDryRunDoesNotWriteFiles(t *testing.T) {
 	}
 }
 
+func TestRunSyncRejectsPiMultiModeWhenPiSubagentsMissing(t *testing.T) {
+	home := t.TempDir()
+	workspace := t.TempDir()
+
+	if err := os.MkdirAll(filepath.Join(home, ".config", "pi-coding-agent"), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+
+	restoreHome := osUserHomeDir
+	t.Cleanup(func() {
+		osUserHomeDir = restoreHome
+	})
+	osUserHomeDir = func() (string, error) { return home, nil }
+
+	t.Chdir(workspace)
+
+	_, err := RunSync([]string{"--agents", "pi-coding-agent", "--sdd-mode", "multi"})
+	if err == nil {
+		t.Fatal("RunSync() expected error when PI multi-mode is requested without pi-subagents")
+	}
+
+	if !strings.Contains(err.Error(), "PI multi-model requires installing the `pi-subagents` extension.") {
+		t.Fatalf("RunSync() error = %q, expected canonical PI requirement message", err.Error())
+	}
+
+	if !strings.Contains(err.Error(), "pi install npm:pi-subagents") {
+		t.Fatalf("RunSync() error = %q, expected install command guidance", err.Error())
+	}
+}
+
+func TestRequiresPiMultiModelPreflight(t *testing.T) {
+	tests := []struct {
+		name      string
+		selection model.Selection
+		want      bool
+	}{
+		{
+			name: "pi + sdd + multi requires preflight",
+			selection: model.Selection{
+				Agents:     []model.AgentID{model.AgentPiCodingAgent},
+				Components: []model.ComponentID{model.ComponentSDD},
+				SDDMode:    model.SDDModeMulti,
+			},
+			want: true,
+		},
+		{
+			name: "pi + sdd + single does not require preflight",
+			selection: model.Selection{
+				Agents:     []model.AgentID{model.AgentPiCodingAgent},
+				Components: []model.ComponentID{model.ComponentSDD},
+				SDDMode:    model.SDDModeSingle,
+			},
+			want: false,
+		},
+		{
+			name: "pi + non-sdd + multi does not require preflight",
+			selection: model.Selection{
+				Agents:     []model.AgentID{model.AgentPiCodingAgent},
+				Components: []model.ComponentID{model.ComponentEngram},
+				SDDMode:    model.SDDModeMulti,
+			},
+			want: false,
+		},
+		{
+			name: "non-pi + sdd + multi does not require preflight",
+			selection: model.Selection{
+				Agents:     []model.AgentID{model.AgentOpenCode},
+				Components: []model.ComponentID{model.ComponentSDD},
+				SDDMode:    model.SDDModeMulti,
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := requiresPiMultiModelPreflight(tt.selection)
+			if got != tt.want {
+				t.Fatalf("requiresPiMultiModelPreflight() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPiCapabilityContractAcrossResolverTUIAndSyncInject(t *testing.T) {
+	tests := []struct {
+		name                 string
+		installPiSubagents   bool
+		wantResolverEnabled  bool
+		wantTUIScreen        tui.Screen
+		wantPreflightErr     bool
+		wantInjectPiArtifacts bool
+	}{
+		{
+			name:                 "pi-subagents absent fails closed across all surfaces",
+			installPiSubagents:   false,
+			wantResolverEnabled:  false,
+			wantTUIScreen:        tui.ScreenStrictTDD,
+			wantPreflightErr:     true,
+			wantInjectPiArtifacts: false,
+		},
+		{
+			name:                 "pi-subagents present enables multi-model across all surfaces",
+			installPiSubagents:   true,
+			wantResolverEnabled:  true,
+			wantTUIScreen:        tui.ScreenSDDMode,
+			wantPreflightErr:     false,
+			wantInjectPiArtifacts: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home := t.TempDir()
+			workspace := t.TempDir()
+
+			if tt.installPiSubagents {
+				if err := os.MkdirAll(filepath.Join(workspace, ".pi", "extensions", "pi-subagents"), 0o755); err != nil {
+					t.Fatalf("MkdirAll(pi-subagents) error = %v", err)
+				}
+			}
+
+			resolver := capabilities.NewResolver(nil)
+			resolved, err := resolver.Resolve(home, workspace, model.AgentPiCodingAgent)
+			if err != nil {
+				t.Fatalf("resolver.Resolve() error = %v", err)
+			}
+			if resolved.SupportsSDDMultiMode != tt.wantResolverEnabled {
+				t.Fatalf("resolver.SupportsSDDMultiMode = %v, want %v", resolved.SupportsSDDMultiMode, tt.wantResolverEnabled)
+			}
+
+			selection := model.Selection{
+				Agents:     []model.AgentID{model.AgentPiCodingAgent},
+				Components: []model.ComponentID{model.ComponentSDD},
+				SDDMode:    model.SDDModeMulti,
+			}
+
+			preflightErr := validatePiMultiModelPreflight(home, workspace, selection)
+			if (preflightErr != nil) != tt.wantPreflightErr {
+				t.Fatalf("validatePiMultiModelPreflight() err = %v, wantErr %v", preflightErr, tt.wantPreflightErr)
+			}
+
+			t.Setenv("HOME", home)
+			prevWD, err := os.Getwd()
+			if err != nil {
+				t.Fatalf("Getwd() error = %v", err)
+			}
+			if chdirErr := os.Chdir(workspace); chdirErr != nil {
+				t.Fatalf("Chdir(workspace) error = %v", chdirErr)
+			}
+			t.Cleanup(func() {
+				_ = os.Chdir(prevWD)
+			})
+
+			m := tui.NewModel(system.DetectionResult{}, "dev")
+			m.Screen = tui.ScreenPreset
+			m.Selection.Agents = []model.AgentID{model.AgentPiCodingAgent}
+			m.Cursor = 0
+			updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+			state := updated.(tui.Model)
+			if state.Screen != tt.wantTUIScreen {
+				t.Fatalf("TUI screen after preset Enter = %v, want %v", state.Screen, tt.wantTUIScreen)
+			}
+
+			injectResult, injectErr := sdd.Inject(home, pi.NewAdapter(), model.SDDModeMulti, sdd.InjectOptions{WorkspaceDir: workspace})
+			if injectErr != nil {
+				t.Fatalf("sdd.Inject() error = %v", injectErr)
+			}
+			gotPiArtifacts := false
+			for _, path := range injectResult.Files {
+				if strings.Contains(path, string(filepath.Separator)+".pi"+string(filepath.Separator)+"agents"+string(filepath.Separator)) {
+					gotPiArtifacts = true
+					break
+				}
+			}
+			if gotPiArtifacts != tt.wantInjectPiArtifacts {
+				t.Fatalf("PI artifact generation = %v, want %v", gotPiArtifacts, tt.wantInjectPiArtifacts)
+			}
+		})
+	}
+}
+
 func TestRunSyncIsIdempotent(t *testing.T) {
 	home := t.TempDir()
 	restoreHome := osUserHomeDir
@@ -978,6 +1166,213 @@ func TestRunSyncNoOpWhenAssetsAlreadyCurrent(t *testing.T) {
 	report := RenderSyncReport(result2)
 	if !containsAny(report, "no managed", "no sync", "nothing to sync", "0 actions", "already current", "up to date") {
 		t.Errorf("RenderSyncReport() should indicate no changes on second run; got:\n%s", report)
+	}
+}
+
+func TestRunSyncPIAliasStaleSharedSkillIsManagedSyncAction(t *testing.T) {
+	home := t.TempDir()
+	restoreCommand := runCommand
+	restoreLookPath := cmdLookPath
+	t.Cleanup(func() {
+		runCommand = restoreCommand
+		cmdLookPath = restoreLookPath
+	})
+
+	runCommand = func(string, ...string) error { return nil }
+	cmdLookPath = func(name string) (string, error) { return "/usr/bin/" + name, nil }
+
+	stalePath := filepath.Join(home, ".pi", "agent", "skills", "_shared", "SKILL.md")
+	if err := os.MkdirAll(filepath.Dir(stalePath), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(stalePath, []byte("stale invalid shared skill"), 0o644); err != nil {
+		t.Fatalf("WriteFile(stalePath) error = %v", err)
+	}
+
+	sel := model.Selection{
+		Agents:     []model.AgentID{model.AgentPiCodingAgent},
+		Components: []model.ComponentID{model.ComponentSDD, model.ComponentSkills},
+		SDDMode:    model.SDDModeSingle,
+	}
+
+	result, err := RunSyncWithSelection(home, sel)
+	if err != nil {
+		t.Fatalf("RunSyncWithSelection() error = %v", err)
+	}
+
+	if result.NoOp {
+		t.Fatalf("SyncResult.NoOp = true, want false when stale PI _shared/SKILL.md exists")
+	}
+	if result.FilesChanged == 0 {
+		t.Fatalf("FilesChanged = 0, want > 0 when stale PI _shared/SKILL.md is removed")
+	}
+	if _, statErr := os.Stat(stalePath); !os.IsNotExist(statErr) {
+		t.Fatalf("expected stale PI shared skill %q to be removed, stat err = %v", stalePath, statErr)
+	}
+}
+
+func TestRunSyncPIAliasRemainsNoOpWhenAlreadyCurrentAndNoStaleSharedSkill(t *testing.T) {
+	home := t.TempDir()
+	restoreCommand := runCommand
+	restoreLookPath := cmdLookPath
+	t.Cleanup(func() {
+		runCommand = restoreCommand
+		cmdLookPath = restoreLookPath
+	})
+
+	runCommand = func(string, ...string) error { return nil }
+	cmdLookPath = func(name string) (string, error) { return "/usr/bin/" + name, nil }
+
+	sel := model.Selection{
+		Agents:     []model.AgentID{model.AgentPiCodingAgent},
+		Components: []model.ComponentID{model.ComponentSDD, model.ComponentSkills},
+		SDDMode:    model.SDDModeSingle,
+	}
+
+	first, err := RunSyncWithSelection(home, sel)
+	if err != nil {
+		t.Fatalf("RunSyncWithSelection() first error = %v", err)
+	}
+	if first.NoOp {
+		t.Fatalf("first sync NoOp = true, want false for initial managed PI sync")
+	}
+
+	second, err := RunSyncWithSelection(home, sel)
+	if err != nil {
+		t.Fatalf("RunSyncWithSelection() second error = %v", err)
+	}
+	if !second.NoOp {
+		t.Fatalf("second sync NoOp = false, want true when assets are already current and stale file is absent")
+	}
+	if second.FilesChanged != 0 {
+		t.Fatalf("second sync FilesChanged = %d, want 0", second.FilesChanged)
+	}
+}
+
+func TestAsAgentIDsNormalizesPIAlias(t *testing.T) {
+	tests := []struct {
+		name  string
+		in    []string
+		want  []model.AgentID
+	}{
+		{
+			name: "pi alias maps to canonical id",
+			in:   []string{"pi"},
+			want: []model.AgentID{model.AgentPiCodingAgent},
+		},
+		{
+			name: "pi alias maps case-insensitively",
+			in:   []string{"PI", "Pi"},
+			want: []model.AgentID{model.AgentPiCodingAgent, model.AgentPiCodingAgent},
+		},
+		{
+			name: "canonical id remains unchanged",
+			in:   []string{"pi-coding-agent"},
+			want: []model.AgentID{model.AgentPiCodingAgent},
+		},
+		{
+			name: "non-pi ids are trimmed and preserved",
+			in:   []string{" opencode "},
+			want: []model.AgentID{model.AgentOpenCode},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := asAgentIDs(tt.in)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("asAgentIDs(%v) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRunPostSyncVerificationIncludesPiProjectArtifacts(t *testing.T) {
+	home := t.TempDir()
+	projectRoot := t.TempDir()
+	workspace := filepath.Join(projectRoot, "apps", "api")
+
+	if err := os.MkdirAll(filepath.Join(home, ".config", "pi-coding-agent"), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(projectRoot, ".git"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(.git) error = %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(projectRoot, ".pi", "extensions", "pi-subagents"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(pi-subagents) error = %v", err)
+	}
+	if err := os.MkdirAll(workspace, 0o755); err != nil {
+		t.Fatalf("MkdirAll(workspace) error = %v", err)
+	}
+
+	selection := model.Selection{
+		Agents:     []model.AgentID{model.AgentPiCodingAgent},
+		Components: []model.ComponentID{model.ComponentSDD},
+		SDDMode:    model.SDDModeMulti,
+	}
+
+	prevWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd() error = %v", err)
+	}
+	if err := os.Chdir(workspace); err != nil {
+		t.Fatalf("Chdir(workspace) error = %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(prevWD) })
+
+	result, err := RunSyncWithSelection(home, selection)
+	if err != nil {
+		t.Fatalf("RunSyncWithSelection() error = %v", err)
+	}
+	if !result.Verify.Ready {
+		t.Fatalf("expected initial sync verification to be ready, got report=%+v", result.Verify)
+	}
+
+	missing := filepath.Join(projectRoot, ".pi", "agents", "sdd-apply.md")
+	if err := os.Remove(missing); err != nil {
+		t.Fatalf("Remove(%q) error = %v", missing, err)
+	}
+
+	report := runPostSyncVerification(home, selection)
+	if report.Ready {
+		t.Fatalf("runPostSyncVerification() Ready = true, want false when %q is missing", missing)
+	}
+}
+
+func TestSyncBackupTargetsReturnsEmptyOnGetwdError(t *testing.T) {
+	origGetwd := osGetwdSync
+	osGetwdSync = func() (string, error) { return "", os.ErrPermission }
+	t.Cleanup(func() { osGetwdSync = origGetwd })
+
+	selection := model.Selection{
+		Agents:     []model.AgentID{model.AgentPiCodingAgent},
+		Components: []model.ComponentID{model.ComponentSDD},
+		SDDMode:    model.SDDModeMulti,
+	}
+
+	targets := syncBackupTargets(t.TempDir(), selection, resolveAdapters(selection.Agents))
+	if len(targets) != 0 {
+		t.Fatalf("syncBackupTargets() = %v, want empty when getwd fails", targets)
+	}
+}
+
+func TestRunPostSyncVerificationFailsClosedOnGetwdError(t *testing.T) {
+	origGetwd := osGetwdSync
+	osGetwdSync = func() (string, error) { return "", os.ErrPermission }
+	t.Cleanup(func() { osGetwdSync = origGetwd })
+
+	selection := model.Selection{
+		Agents:     []model.AgentID{model.AgentPiCodingAgent},
+		Components: []model.ComponentID{model.ComponentSDD},
+		SDDMode:    model.SDDModeMulti,
+	}
+
+	report := runPostSyncVerification(t.TempDir(), selection)
+	if report.Ready {
+		t.Fatal("runPostSyncVerification() Ready = true, want false when getwd fails")
+	}
+	if len(report.Checks) == 0 || report.Checks[0].Error == "" {
+		t.Fatalf("runPostSyncVerification() expected getwd error in report, got %#v", report.Checks)
 	}
 }
 
@@ -1932,8 +2327,14 @@ func TestRunSyncLoadsPersistedModelAssignments(t *testing.T) {
 			"orchestrator": "opus",
 			"sdd-apply":    "sonnet",
 		},
+		KiroModelAssignments: map[string]string{
+			"sdd-design": "haiku",
+		},
 		ModelAssignments: map[string]state.ModelAssignmentState{
 			"sdd-init": {ProviderID: "anthropic", ModelID: "claude-sonnet-4"},
+		},
+		PIModelAssignments: map[string]state.ModelAssignmentState{
+			"sdd-apply": {ProviderID: "openai", ModelID: "gpt-5"},
 		},
 	})
 	if err != nil {
@@ -1954,11 +2355,18 @@ func TestRunSyncLoadsPersistedModelAssignments(t *testing.T) {
 	if got := result.Selection.ClaudeModelAssignments["sdd-apply"]; got != "sonnet" {
 		t.Errorf("ClaudeModelAssignments[sdd-apply] = %q, want %q", got, "sonnet")
 	}
+	if got := result.Selection.KiroModelAssignments["sdd-design"]; got != model.ClaudeModelHaiku {
+		t.Errorf("KiroModelAssignments[sdd-design] = %q, want %q", got, model.ClaudeModelHaiku)
+	}
 
 	// OpenCode assignments must be loaded.
 	ma := result.Selection.ModelAssignments["sdd-init"]
 	if ma.ProviderID != "anthropic" || ma.ModelID != "claude-sonnet-4" {
 		t.Errorf("ModelAssignments[sdd-init] = %+v, want anthropic/claude-sonnet-4", ma)
+	}
+
+	if len(result.Selection.PIModelAssignments) != 0 {
+		t.Errorf("PIModelAssignments should not hydrate when PI is not selected, got: %v", result.Selection.PIModelAssignments)
 	}
 }
 
@@ -1992,6 +2400,9 @@ func TestRunSyncDoesNotOverridePersistedAssignmentsOnSecondSync(t *testing.T) {
 		ModelAssignments: map[string]state.ModelAssignmentState{
 			"sdd-init": {ProviderID: "anthropic", ModelID: "claude-sonnet-4"},
 		},
+		PIModelAssignments: map[string]state.ModelAssignmentState{
+			"sdd-apply": {ProviderID: "openai", ModelID: "gpt-5-mini"},
+		},
 	})
 	if err != nil {
 		t.Fatalf("state.Write: %v", err)
@@ -2015,6 +2426,48 @@ func TestRunSyncDoesNotOverridePersistedAssignmentsOnSecondSync(t *testing.T) {
 	ma := result.Selection.ModelAssignments["sdd-init"]
 	if ma.ProviderID != "anthropic" || ma.ModelID != "claude-sonnet-4" {
 		t.Errorf("After second sync: ModelAssignments[sdd-init] = %+v, want anthropic/claude-sonnet-4", ma)
+	}
+	if len(result.Selection.PIModelAssignments) != 0 {
+		t.Errorf("PIModelAssignments should not hydrate when PI is not selected, got: %v", result.Selection.PIModelAssignments)
+	}
+}
+
+func TestRunSyncLoadsPersistedPIAssignmentsWhenPISelected(t *testing.T) {
+	home := t.TempDir()
+	restoreHome := osUserHomeDir
+	restoreCommand := runCommand
+	restoreLookPath := cmdLookPath
+	t.Cleanup(func() {
+		osUserHomeDir = restoreHome
+		runCommand = restoreCommand
+		cmdLookPath = restoreLookPath
+	})
+
+	osUserHomeDir = func() (string, error) { return home, nil }
+	runCommand = func(string, ...string) error { return nil }
+	cmdLookPath = func(name string) (string, error) { return "/usr/local/bin/" + name, nil }
+
+	if err := os.MkdirAll(filepath.Join(home, ".config", "opencode"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	err := state.Write(home, state.InstallState{
+		InstalledAgents: []string{"pi-coding-agent"},
+		PIModelAssignments: map[string]state.ModelAssignmentState{
+			"sdd-apply": {ProviderID: "openai", ModelID: "gpt-5-mini"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("state.Write: %v", err)
+	}
+
+	result, err := RunSync([]string{"--agents", "pi-coding-agent", "--sdd-mode", "single", "--dry-run"})
+	if err != nil {
+		t.Fatalf("RunSync() error = %v", err)
+	}
+
+	pi := result.Selection.PIModelAssignments["sdd-apply"]
+	if pi.ProviderID != "openai" || pi.ModelID != "gpt-5-mini" {
+		t.Errorf("PIModelAssignments[sdd-apply] = %+v, want openai/gpt-5-mini", pi)
 	}
 }
 

--- a/internal/cli/validate.go
+++ b/internal/cli/validate.go
@@ -193,6 +193,8 @@ func defaultAgentsFromDetection(detection system.DetectionResult) []model.AgentI
 			agents = append(agents, model.AgentQwenCode)
 		case string(model.AgentKiroIDE):
 			agents = append(agents, model.AgentKiroIDE)
+		case string(model.AgentPiCodingAgent):
+			agents = append(agents, model.AgentPiCodingAgent)
 		}
 	}
 
@@ -212,7 +214,13 @@ func defaultAgentsFromDetection(detection system.DetectionResult) []model.AgentI
 func asAgentIDs(values []string) []model.AgentID {
 	agents := make([]model.AgentID, 0, len(values))
 	for _, value := range values {
-		agents = append(agents, model.AgentID(value))
+		normalized := strings.ToLower(strings.TrimSpace(value))
+		switch normalized {
+		case "pi":
+			agents = append(agents, model.AgentPiCodingAgent)
+		default:
+			agents = append(agents, model.AgentID(strings.TrimSpace(value)))
+		}
 	}
 
 	return agents

--- a/internal/components/engram/inject.go
+++ b/internal/components/engram/inject.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/gentleman-programming/gentle-ai/internal/agents"
+	"github.com/gentleman-programming/gentle-ai/internal/agents/pi"
 	"github.com/gentleman-programming/gentle-ai/internal/assets"
 	"github.com/gentleman-programming/gentle-ai/internal/components/filemerge"
 	"github.com/gentleman-programming/gentle-ai/internal/model"
@@ -125,6 +126,50 @@ func engramOverlayJSON(agentID model.AgentID, cmd string) []byte {
 	return append(b, '\n')
 }
 
+func piEngramOverlayConfig(cmd string, status pi.EngramExtensionStatus) map[string]any {
+	extension := map[string]any{
+		"path":         status.ExtensionPath,
+		"enabled":      true,
+		"validated_by": "gentle-ai",
+		"command":      cmd,
+	}
+
+	if status.Source != "" {
+		extension["source"] = status.Source
+	}
+	if status.PackageName != "" {
+		extension["package_name"] = status.PackageName
+	}
+
+	return map[string]any{
+		"engram": map[string]any{
+			"extension": extension,
+		},
+	}
+}
+
+func piEngramOverlayJSON(homeDir string, cmd string) ([]byte, error) {
+	status, err := pi.ValidateEngramExtension(pi.ResolvePaths(homeDir, os.Getenv))
+	if err != nil {
+		return nil, err
+	}
+
+	overlayBytes, err := json.MarshalIndent(piEngramOverlayConfig(cmd, status), "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshal PI Engram extension overlay: %w", err)
+	}
+
+	return append(overlayBytes, '\n'), nil
+}
+
+func engramSettingsOverlayJSON(homeDir string, agentID model.AgentID, cmd string) ([]byte, error) {
+	if agentID == model.AgentPiCodingAgent {
+		return piEngramOverlayJSON(homeDir, cmd)
+	}
+
+	return engramOverlayJSON(agentID, cmd), nil
+}
+
 // vsCodeEngramOverlayJSON is the VS Code mcp.json overlay using the "servers" key.
 // Uses --tools=agent per engram contract.
 // VS Code uses a fixed "servers" key structure rather than mcpServers, so it
@@ -173,7 +218,11 @@ func Inject(homeDir string, adapter agents.Adapter) (InjectionResult, error) {
 		if settingsPath == "" {
 			break
 		}
-		overlay := engramOverlayJSON(adapter.Agent(), stableEngramCommandForMergedConfig(settingsPath, adapter.Agent()))
+		engramCmd := stableEngramCommandForMergedConfig(settingsPath, adapter.Agent())
+		overlay, err := engramSettingsOverlayJSON(homeDir, adapter.Agent(), engramCmd)
+		if err != nil {
+			return InjectionResult{}, err
+		}
 		settingsWrite, err := mergeJSONFile(settingsPath, overlay)
 		if err != nil {
 			return InjectionResult{}, err

--- a/internal/components/engram/inject_test.go
+++ b/internal/components/engram/inject_test.go
@@ -14,8 +14,10 @@ import (
 	"github.com/gentleman-programming/gentle-ai/internal/agents/codex"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/gemini"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/opencode"
+	"github.com/gentleman-programming/gentle-ai/internal/agents/pi"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/qwen"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/vscode"
+	"github.com/gentleman-programming/gentle-ai/internal/testutil"
 )
 
 func claudeAdapter() agents.Adapter   { return claude.NewAdapter() }
@@ -23,6 +25,7 @@ func opencodeAdapter() agents.Adapter { return opencode.NewAdapter() }
 func codexAdapter() agents.Adapter    { return codex.NewAdapter() }
 func geminiAdapter() agents.Adapter   { return gemini.NewAdapter() }
 func qwenAdapter() agents.Adapter     { return qwen.NewAdapter() }
+func piAdapter() agents.Adapter       { return pi.NewAdapter() }
 func antigravityAdapter() agents.Adapter {
 	return antigravity.NewAdapter()
 }
@@ -212,6 +215,215 @@ func TestInjectOpenCodeIsIdempotent(t *testing.T) {
 	}
 	if second.Changed {
 		t.Fatalf("Inject() second changed = true")
+	}
+}
+
+func TestInjectPIWritesEngramOverlayGolden(t *testing.T) {
+	home := t.TempDir()
+	mockEngramLookPath(t, "", "not found")
+	settingsPath := filepath.Join(home, ".pi", "agent", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(settings) error = %v", err)
+	}
+	if err := os.WriteFile(settingsPath, []byte(`{"engram":{"extension":{"path":"/opt/pi/extensions/pi-engram","enabled":true}}}`), 0o644); err != nil {
+		t.Fatalf("WriteFile(settings) error = %v", err)
+	}
+
+	result, err := Inject(home, piAdapter())
+	if err != nil {
+		t.Fatalf("Inject(pi) error = %v", err)
+	}
+	if !result.Changed {
+		t.Fatal("Inject(pi) changed = false, want true")
+	}
+
+	content, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("ReadFile(settings.json) error = %v", err)
+	}
+
+	goldenPath := filepath.Join("testdata", "pi_engram_overlay.golden.json")
+	testutil.AssertJSONGolden(t, content, goldenPath)
+}
+
+func TestInjectPIFailsWhenEngramExtensionContractMissing(t *testing.T) {
+	home := t.TempDir()
+	mockEngramLookPath(t, "", "not found")
+
+	_, err := Inject(home, piAdapter())
+	if err == nil {
+		t.Fatal("Inject(pi) error = nil, want missing extension contract error")
+	}
+	if !strings.Contains(err.Error(), "missing PI→Engram extension contract") {
+		t.Fatalf("Inject(pi) error = %q, want missing contract message", err.Error())
+	}
+}
+
+func TestInjectPIFailsWhenEngramExtensionContractMalformed(t *testing.T) {
+	home := t.TempDir()
+	mockEngramLookPath(t, "", "not found")
+	settingsPath := filepath.Join(home, ".pi", "agent", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(settings) error = %v", err)
+	}
+	if err := os.WriteFile(settingsPath, []byte(`{"engram":{"extension":{"path":7}}}`), 0o644); err != nil {
+		t.Fatalf("WriteFile(settings) error = %v", err)
+	}
+
+	_, err := Inject(home, piAdapter())
+	if err == nil {
+		t.Fatal("Inject(pi) error = nil, want malformed extension contract error")
+	}
+	if !strings.Contains(err.Error(), "malformed PI→Engram extension contract") {
+		t.Fatalf("Inject(pi) error = %q, want malformed contract message", err.Error())
+	}
+}
+
+func TestInjectPIAcceptsLocalPackageContractAndNormalizesPath(t *testing.T) {
+	home := t.TempDir()
+	mockEngramLookPath(t, "", "not found")
+	paths := pi.ResolvePaths(home, func(string) string { return "" })
+	localPkg := filepath.Clean(filepath.Join(paths.Root, "../../Documents/repos/pi-engram"))
+	if err := os.MkdirAll(localPkg, 0o755); err != nil {
+		t.Fatalf("MkdirAll(local package fixture) error = %v", err)
+	}
+	settingsPath := filepath.Join(home, ".pi", "agent", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(settings) error = %v", err)
+	}
+	if err := os.WriteFile(settingsPath, []byte(`{"packages":["../../Documents/repos/pi-engram"]}`), 0o644); err != nil {
+		t.Fatalf("WriteFile(settings) error = %v", err)
+	}
+
+	if _, err := Inject(home, piAdapter()); err != nil {
+		t.Fatalf("Inject(pi) error = %v", err)
+	}
+
+	content, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("ReadFile(settings) error = %v", err)
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal(content, &parsed); err != nil {
+		t.Fatalf("Unmarshal(settings) error = %v", err)
+	}
+
+	engramCfg, _ := parsed["engram"].(map[string]any)
+	extensionCfg, _ := engramCfg["extension"].(map[string]any)
+	pathValue, _ := extensionCfg["path"].(string)
+	if pathValue == "" {
+		t.Fatal("settings engram.extension.path = empty, want normalized local package path")
+	}
+	if !strings.HasSuffix(filepath.Clean(pathValue), filepath.Join("Documents", "repos", "pi-engram")) {
+		t.Fatalf("settings engram.extension.path = %q, want suffix %q", pathValue, filepath.Join("Documents", "repos", "pi-engram"))
+	}
+	if src, _ := extensionCfg["source"].(string); src != "package-local" {
+		t.Fatalf("settings engram.extension.source = %q, want %q", src, "package-local")
+	}
+}
+
+func TestInjectPIAcceptsNpmPackageContractAndPreservesPackageName(t *testing.T) {
+	home := t.TempDir()
+	mockEngramLookPath(t, "", "not found")
+	settingsPath := filepath.Join(home, ".pi", "agent", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(settings) error = %v", err)
+	}
+	if err := os.WriteFile(settingsPath, []byte(`{"packages":["npm:@gentleman-programming/pi-engram"]}`), 0o644); err != nil {
+		t.Fatalf("WriteFile(settings) error = %v", err)
+	}
+
+	if _, err := Inject(home, piAdapter()); err != nil {
+		t.Fatalf("Inject(pi) error = %v", err)
+	}
+
+	content, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("ReadFile(settings) error = %v", err)
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal(content, &parsed); err != nil {
+		t.Fatalf("Unmarshal(settings) error = %v", err)
+	}
+
+	engramCfg, _ := parsed["engram"].(map[string]any)
+	extensionCfg, _ := engramCfg["extension"].(map[string]any)
+	if got, _ := extensionCfg["path"].(string); got != "npm:@gentleman-programming/pi-engram" {
+		t.Fatalf("settings engram.extension.path = %q, want %q", got, "npm:@gentleman-programming/pi-engram")
+	}
+	if src, _ := extensionCfg["source"].(string); src != "package-npm" {
+		t.Fatalf("settings engram.extension.source = %q, want %q", src, "package-npm")
+	}
+	if pkg, _ := extensionCfg["package_name"].(string); pkg != "@gentleman-programming/pi-engram" {
+		t.Fatalf("settings engram.extension.package_name = %q, want %q", pkg, "@gentleman-programming/pi-engram")
+	}
+}
+
+func TestInjectPIEngramCommandCompatibility_MergedHomebrewInputs(t *testing.T) {
+	tests := []struct {
+		name        string
+		lookPath    string
+		lookPathErr string
+		wantCommand string
+	}{
+		{
+			name:        "versioned cellar command normalizes to relative stable command",
+			lookPath:    "/opt/homebrew/Cellar/engram/1.14.1/bin/engram",
+			wantCommand: "engram",
+		},
+		{
+			name:        "stable homebrew symlink remains stable absolute command",
+			lookPath:    "/opt/homebrew/bin/engram",
+			wantCommand: "/opt/homebrew/bin/engram",
+		},
+		{
+			name:        "relative fallback when engram is not discoverable",
+			lookPathErr: "not found",
+			wantCommand: "engram",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home := t.TempDir()
+			mockEngramLookPath(t, tt.lookPath, tt.lookPathErr)
+			settingsPath := filepath.Join(home, ".pi", "agent", "settings.json")
+			if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+				t.Fatalf("MkdirAll(settings) error = %v", err)
+			}
+			if err := os.WriteFile(settingsPath, []byte(`{"engram":{"extension":{"path":"/opt/pi/extensions/pi-engram","enabled":true}}}`), 0o644); err != nil {
+				t.Fatalf("WriteFile(settings) error = %v", err)
+			}
+
+			if _, err := Inject(home, piAdapter()); err != nil {
+				t.Fatalf("Inject(pi) error = %v", err)
+			}
+
+			content, err := os.ReadFile(settingsPath)
+			if err != nil {
+				t.Fatalf("ReadFile(settings) error = %v", err)
+			}
+
+			var parsed map[string]any
+			if err := json.Unmarshal(content, &parsed); err != nil {
+				t.Fatalf("Unmarshal(settings) error = %v", err)
+			}
+
+			engramCfg, _ := parsed["engram"].(map[string]any)
+			extensionCfg, _ := engramCfg["extension"].(map[string]any)
+			gotCommand, _ := extensionCfg["command"].(string)
+			if gotCommand != tt.wantCommand {
+				t.Fatalf("engram.extension.command = %q, want %q", gotCommand, tt.wantCommand)
+			}
+			if validatedBy, _ := extensionCfg["validated_by"].(string); validatedBy != "gentle-ai" {
+				t.Fatalf("engram.extension.validated_by = %q, want %q", validatedBy, "gentle-ai")
+			}
+			if enabled, _ := extensionCfg["enabled"].(bool); !enabled {
+				t.Fatal("engram.extension.enabled = false, want true")
+			}
+		})
 	}
 }
 

--- a/internal/components/engram/testdata/pi_engram_overlay.golden.json
+++ b/internal/components/engram/testdata/pi_engram_overlay.golden.json
@@ -1,0 +1,11 @@
+{
+  "engram": {
+    "extension": {
+      "path": "/opt/pi/extensions/pi-engram",
+      "enabled": true,
+      "validated_by": "gentle-ai",
+      "command": "engram",
+      "source": "explicit"
+    }
+  }
+}

--- a/internal/components/mcp/inject.go
+++ b/internal/components/mcp/inject.go
@@ -53,9 +53,9 @@ func injectMergeIntoSettings(homeDir string, adapter agents.Adapter) (InjectionR
 		return InjectionResult{}, nil
 	}
 
-	overlay := DefaultContext7OverlayJSON()
-	if adapter.Agent() == model.AgentOpenCode || adapter.Agent() == model.AgentKilocode {
-		overlay = OpenCodeContext7OverlayJSON()
+	overlay := context7OverlayForAgent(adapter.Agent())
+	if len(overlay) == 0 {
+		return InjectionResult{}, nil
 	}
 
 	settingsWrite, err := mergeJSONFile(settingsPath, overlay)
@@ -64,6 +64,17 @@ func injectMergeIntoSettings(homeDir string, adapter agents.Adapter) (InjectionR
 	}
 
 	return InjectionResult{Changed: settingsWrite.Changed, Files: []string{settingsPath}}, nil
+}
+
+func context7OverlayForAgent(agentID model.AgentID) []byte {
+	switch agentID {
+	case model.AgentOpenCode, model.AgentKilocode:
+		return OpenCodeContext7OverlayJSON()
+	case model.AgentPiCodingAgent:
+		return nil
+	default:
+		return DefaultContext7OverlayJSON()
+	}
 }
 
 // injectMCPConfigFile writes to a dedicated mcp.json config file (Cursor pattern).

--- a/internal/components/mcp/inject_test.go
+++ b/internal/components/mcp/inject_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gentleman-programming/gentle-ai/internal/agents/codex"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/kimi"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/opencode"
+	"github.com/gentleman-programming/gentle-ai/internal/agents/pi"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/vscode"
 )
 
@@ -26,6 +27,7 @@ func cursorAdapter(t *testing.T) agents.Adapter {
 func claudeAdapter() agents.Adapter   { return claude.NewAdapter() }
 func kimiAdapter() agents.Adapter     { return kimi.NewAdapter() }
 func opencodeAdapter() agents.Adapter { return opencode.NewAdapter() }
+func piAdapter() agents.Adapter       { return pi.NewAdapter() }
 
 func TestInjectOpenCodeMergesContext7AndIsIdempotent(t *testing.T) {
 	home := t.TempDir()
@@ -232,5 +234,25 @@ func TestInjectKimiWritesContext7ToMCPConfigFile(t *testing.T) {
 	}
 	if !strings.Contains(text, `"url": "https://mcp.context7.com/mcp"`) {
 		t.Fatal("kimi mcp.json should use the documented remote MCP URL for context7")
+	}
+}
+
+func TestInjectPISkipsContext7AsOutOfScope(t *testing.T) {
+	home := t.TempDir()
+
+	result, err := Inject(home, piAdapter())
+	if err != nil {
+		t.Fatalf("Inject(pi) error = %v", err)
+	}
+	if result.Changed {
+		t.Fatal("Inject(pi) changed = true, want false")
+	}
+	if len(result.Files) != 0 {
+		t.Fatalf("Inject(pi) files = %v, want none", result.Files)
+	}
+
+	settingsPath := filepath.Join(home, ".pi", "agent", "settings.json")
+	if _, err := os.Stat(settingsPath); !os.IsNotExist(err) {
+		t.Fatalf("expected PI settings to remain untouched by MCP injector, stat error = %v", err)
 	}
 }

--- a/internal/components/sdd/inject.go
+++ b/internal/components/sdd/inject.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/gentleman-programming/gentle-ai/internal/agents"
+	"github.com/gentleman-programming/gentle-ai/internal/agents/capabilities"
 	"github.com/gentleman-programming/gentle-ai/internal/assets"
 	"github.com/gentleman-programming/gentle-ai/internal/components/filemerge"
 	"github.com/gentleman-programming/gentle-ai/internal/model"
@@ -22,6 +23,7 @@ type InjectionResult struct {
 
 type InjectOptions struct {
 	OpenCodeModelAssignments map[string]model.ModelAssignment
+	PIModelAssignments       map[string]model.ModelAssignment
 	ClaudeModelAssignments   map[string]model.ClaudeModelAlias
 	KiroModelAssignments     map[string]model.ClaudeModelAlias
 
@@ -172,6 +174,17 @@ func findProjectRoot(dir string) (string, bool) {
 	return "", false
 }
 
+// ResolvePIArtifactsProjectRoot resolves the canonical project root used for
+// PI .pi/agents artifact placement across planning, backup/verify, and writes.
+// Returns (cleaned workspaceDir, false) when no root markers are found.
+func ResolvePIArtifactsProjectRoot(workspaceDir string) (string, bool) {
+	projectRoot, found := findProjectRoot(workspaceDir)
+	if found {
+		return projectRoot, true
+	}
+	return filepath.Clean(workspaceDir), false
+}
+
 var (
 	npmLookPath = exec.LookPath
 	npmRun      = func(dir string, args ...string) ([]byte, error) {
@@ -180,6 +193,9 @@ var (
 		// CombinedOutput captures stdout+stderr so we can surface actionable
 		// error messages on failure. Do not set Stdout/Stderr separately.
 		return cmd.CombinedOutput()
+	}
+	resolveSDDCapabilitiesFn = func(homeDir string, workspaceDir string, agentID model.AgentID) (capabilities.ResolvedCapabilities, error) {
+		return capabilities.NewResolver(nil).Resolve(homeDir, workspaceDir, agentID)
 	}
 )
 
@@ -191,6 +207,176 @@ func overlayAssetPath(sddMode model.SDDModeID) string {
 		return "opencode/sdd-overlay-multi.json"
 	}
 	return "opencode/sdd-overlay-single.json"
+}
+
+func piSDDOverlayJSON(resolved capabilities.ResolvedCapabilities) []byte {
+	requirementMessage := ""
+	if len(resolved.Requires) > 0 {
+		requirementMessage = resolved.Requires[0].Message
+	}
+
+	overlay := map[string]any{
+		"features": map[string]any{
+			"profiles":       resolved.SupportsSDDMultiMode,
+			"modelPicker":    resolved.SupportsModelPicker,
+			"generatedMulti": resolved.SupportsGeneratedMulti,
+		},
+		"sdd": map[string]any{
+			"capabilities": []string{"experimental", "non-parity"},
+			"multiModel": map[string]any{
+				"enabled":             resolved.SupportsGeneratedMulti,
+				"requirement_message": requirementMessage,
+			},
+		},
+	}
+
+	b, _ := json.MarshalIndent(overlay, "", "  ")
+	return append(b, '\n')
+}
+
+func piSubagentsRequirementForOverlay() capabilities.RuntimeRequirement {
+	return capabilities.RuntimeRequirement{
+		ID:      capabilities.RequirementPiSubagentsInstalled,
+		Message: capabilities.PiMultiModelRequiresPiSubagentsMessage,
+	}
+}
+
+func piModelForPhase(assignments map[string]model.ModelAssignment, phase string) (string, bool) {
+	for _, key := range phaseModelLookupKeys(phase) {
+		if assignment, ok := assignments[key]; ok && assignment.ProviderID != "" && assignment.ModelID != "" {
+			return assignment.FullID(), true
+		}
+	}
+	return "", false
+}
+
+func phaseModelLookupKeys(phase string) []string {
+	return []string{phase, "default", "sdd-orchestrator"}
+}
+
+func renderPiChainModels(assignments map[string]model.ModelAssignment) string {
+	var b strings.Builder
+	for _, phase := range ProfilePhaseOrder() {
+		phaseModel, ok := piModelForPhase(assignments, phase)
+		if !ok {
+			continue
+		}
+		b.WriteString("- ")
+		b.WriteString(phase)
+		b.WriteString(": ")
+		b.WriteString(phaseModel)
+		b.WriteString("\n")
+	}
+	return strings.TrimSuffix(b.String(), "\n")
+}
+
+func renderPiChainContent(content string, assignments map[string]model.ModelAssignment) string {
+	for _, phase := range ProfilePhaseOrder() {
+		placeholder := "{{MODEL_LINE_" + phase + "}}"
+		phaseModel, ok := piModelForPhase(assignments, phase)
+		if !ok {
+			content = strings.ReplaceAll(content, placeholder, "")
+			continue
+		}
+		content = strings.ReplaceAll(content, placeholder, "model: "+phaseModel)
+	}
+
+	chainModels := renderPiChainModels(assignments)
+	if strings.TrimSpace(chainModels) == "" {
+		chainModels = "- none (agent defaults apply)"
+	}
+
+	return strings.ReplaceAll(content, "{{CHAIN_MODELS}}", chainModels)
+}
+
+func renderPiSubagentContent(fileName string, assignments map[string]model.ModelAssignment) string {
+	content := assets.MustRead("pi/agents/" + fileName)
+	if strings.HasSuffix(fileName, ".chain.md") {
+		return renderPiChainContent(content, assignments)
+	}
+
+	phase := strings.TrimSuffix(fileName, ".md")
+	phaseModel, ok := piModelForPhase(assignments, phase)
+	if ok {
+		return strings.ReplaceAll(content, "model: {{MODEL}}", "model: "+phaseModel)
+	}
+
+	content = strings.ReplaceAll(content, "model: {{MODEL}}\n", "")
+	return strings.ReplaceAll(content, "model: {{MODEL}}", "")
+}
+
+func writePiSubagentArtifacts(workspaceDir string, assignments map[string]model.ModelAssignment) (InjectionResult, error) {
+	if strings.TrimSpace(workspaceDir) == "" {
+		return InjectionResult{}, nil
+	}
+
+	projectRoot, _ := ResolvePIArtifactsProjectRoot(workspaceDir)
+
+	agentsDir := filepath.Join(projectRoot, ".pi", "agents")
+	if err := os.MkdirAll(agentsDir, 0o755); err != nil {
+		return InjectionResult{}, fmt.Errorf("create PI agents dir: %w", err)
+	}
+
+	entries, err := fs.ReadDir(assets.FS, "pi/agents")
+	if err != nil {
+		return InjectionResult{}, fmt.Errorf("read embedded pi agents: %w", err)
+	}
+
+	changed := false
+	files := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+
+		content := renderPiSubagentContent(entry.Name(), assignments)
+
+		path := filepath.Join(agentsDir, entry.Name())
+		writeResult, writeErr := filemerge.WriteFileAtomic(path, []byte(content), 0o644)
+		if writeErr != nil {
+			return InjectionResult{}, fmt.Errorf("write PI agent %q: %w", entry.Name(), writeErr)
+		}
+
+		changed = changed || writeResult.Changed
+		files = append(files, path)
+	}
+
+	return InjectionResult{Changed: changed, Files: files}, nil
+}
+
+func injectPiSDD(homeDir string, adapter agents.Adapter, opts InjectOptions) (InjectionResult, []byte, error) {
+	settingsPath := adapter.SettingsPath(homeDir)
+	if settingsPath == "" {
+		return InjectionResult{}, nil, nil
+	}
+
+	resolvedCapabilities, capErr := resolveSDDCapabilitiesFn(homeDir, opts.WorkspaceDir, adapter.Agent())
+	if capErr != nil {
+		resolvedCapabilities = capabilities.ResolvedCapabilities{
+			Requires: []capabilities.RuntimeRequirement{piSubagentsRequirementForOverlay()},
+		}
+	}
+
+	mergeResult, err := mergeJSONFile(settingsPath, piSDDOverlayJSON(resolvedCapabilities))
+	if err != nil {
+		return InjectionResult{}, nil, fmt.Errorf("merge PI SDD capability overlay: %w", err)
+	}
+
+	result := InjectionResult{Changed: mergeResult.writeResult.Changed, Files: []string{settingsPath}}
+	if !resolvedCapabilities.SupportsGeneratedMulti {
+		return result, mergeResult.merged, nil
+	}
+
+	assignments := opts.PIModelAssignments
+
+	artifactsResult, err := writePiSubagentArtifacts(opts.WorkspaceDir, assignments)
+	if err != nil {
+		return InjectionResult{}, nil, err
+	}
+
+	result.Changed = result.Changed || artifactsResult.Changed
+	result.Files = append(result.Files, artifactsResult.Files...)
+	return result, mergeResult.merged, nil
 }
 
 func Inject(homeDir string, adapter agents.Adapter, sddMode model.SDDModeID, options ...InjectOptions) (InjectionResult, error) {
@@ -226,7 +412,7 @@ func Inject(homeDir string, adapter agents.Adapter, sddMode model.SDDModeID, opt
 			// custom persona, the SDD content must still be injected. We append the
 			// SDD orchestrator section to the existing system prompt file so it is
 			// always present regardless of persona choice.
-			result, err := injectFileAppend(homeDir, adapter)
+			result, err := injectFileAppend(homeDir, adapter, opts.OpenCodeModelAssignments)
 			if err != nil {
 				return InjectionResult{}, err
 			}
@@ -425,17 +611,30 @@ func Inject(homeDir string, adapter agents.Adapter, sddMode model.SDDModeID, opt
 		}
 	}
 
+	if adapter.Agent() == model.AgentPiCodingAgent {
+		piResult, merged, err := injectPiSDD(homeDir, adapter, opts)
+		if err != nil {
+			return InjectionResult{}, err
+		}
+		changed = changed || piResult.Changed
+		mergedSettingsBytes = merged
+		files = append(files, piResult.Files...)
+	}
+
 	// 3. Write SDD skill files (if the agent supports skills).
 	if adapter.SupportsSkills() {
 		skillDir := adapter.SkillsDir(homeDir)
 		if skillDir != "" {
+			isPI := adapter.Agent() == model.AgentPiCodingAgent
 			sharedFiles := []string{
-				"SKILL.md",
 				"persistence-contract.md",
 				"engram-convention.md",
 				"openspec-convention.md",
 				"sdd-phase-common.md",
 				"skill-resolver.md",
+			}
+			if !isPI {
+				sharedFiles = append([]string{"SKILL.md"}, sharedFiles...)
 			}
 
 			for _, fileName := range sharedFiles {
@@ -456,6 +655,15 @@ func Inject(homeDir string, adapter agents.Adapter, sddMode model.SDDModeID, opt
 
 				changed = changed || writeResult.Changed
 				files = append(files, path)
+			}
+
+			if isPI {
+				staleSharedSkillPath := filepath.Join(skillDir, "_shared", "SKILL.md")
+				if err := os.Remove(staleSharedSkillPath); err != nil && !os.IsNotExist(err) {
+					return InjectionResult{}, err
+				} else if err == nil {
+					changed = true
+				}
 			}
 
 			sddSkills := []string{
@@ -1022,7 +1230,7 @@ func sddOrchestratorAsset(agent model.AgentID) string {
 	}
 }
 
-func injectFileAppend(homeDir string, adapter agents.Adapter) (InjectionResult, error) {
+func injectFileAppend(homeDir string, adapter agents.Adapter, assignments map[string]model.ModelAssignment) (InjectionResult, error) {
 	promptPath := adapter.SystemPromptFile(homeDir)
 
 	existing, err := readFileOrEmpty(promptPath)
@@ -1040,6 +1248,13 @@ func injectFileAppend(homeDir string, adapter agents.Adapter) (InjectionResult, 
 
 	// Use agent-specific SDD orchestrator content when available; fall back to generic.
 	content := assets.MustRead(sddOrchestratorAsset(adapter.Agent()))
+	if adapter.Agent() == model.AgentPiCodingAgent {
+		var err error
+		content, err = injectConcreteModelAssignments(content, assignments)
+		if err != nil {
+			return InjectionResult{}, err
+		}
+	}
 
 	// If there is a bare (un-marked) legacy orchestrator block, strip it first
 	// so InjectMarkdownSection can re-inject the current canonical content.
@@ -1292,6 +1507,50 @@ var claudeModelAssignmentReasons = map[string]string{
 	"sdd-verify":   "Validation against spec",
 	"sdd-archive":  "Copy and close",
 	"default":      "Non-SDD general delegation",
+}
+
+func concreteModelForPhase(assignments map[string]model.ModelAssignment, phase string) string {
+	if len(assignments) == 0 {
+		return ""
+	}
+	key := phase
+	if phase == "orchestrator" {
+		key = "sdd-orchestrator"
+	}
+	for _, lookupKey := range phaseModelLookupKeys(key) {
+		if assignment, ok := assignments[lookupKey]; ok && assignment.ProviderID != "" && assignment.ModelID != "" {
+			return assignment.FullID()
+		}
+	}
+	return ""
+}
+
+func injectConcreteModelAssignments(content string, assignments map[string]model.ModelAssignment) (string, error) {
+	const openMarker = "<!-- gentle-ai:sdd-model-assignments -->"
+	const closeMarker = "<!-- /gentle-ai:sdd-model-assignments -->"
+
+	start := strings.Index(content, openMarker)
+	end := strings.Index(content, closeMarker)
+	if start == -1 || end == -1 || end < start {
+		return "", fmt.Errorf("sdd orchestrator asset missing model assignment markers")
+	}
+
+	var b strings.Builder
+	b.WriteString("## Model Assignments\n\n")
+	b.WriteString("Read this table at session start (or before first delegation), cache it for the session, and pass the mapped model ID in every Agent tool call via the `model` parameter. If a phase is missing, use the `default` row. If a configured model is unavailable in your PI environment, substitute a compatible model ID and continue.\n\n")
+	b.WriteString("| Phase | Default Model | Reason |\n")
+	b.WriteString("|-------|---------------|--------|\n")
+	for _, key := range claudeModelAssignmentRowOrder {
+		modelID := concreteModelForPhase(assignments, key)
+		if modelID == "" {
+			modelID = "anthropic/claude-sonnet-4-20250514"
+		}
+		b.WriteString(fmt.Sprintf("| %s | %s | %s |\n", key, modelID, claudeModelAssignmentReasons[key]))
+	}
+	b.WriteString("\n")
+
+	start += len(openMarker)
+	return content[:start] + "\n" + b.String() + content[end:], nil
 }
 
 func injectClaudeModelAssignments(content string, assignments map[string]model.ClaudeModelAlias) (string, error) {

--- a/internal/components/sdd/inject_test.go
+++ b/internal/components/sdd/inject_test.go
@@ -10,18 +10,22 @@ import (
 	"time"
 
 	"github.com/gentleman-programming/gentle-ai/internal/agents"
+	"github.com/gentleman-programming/gentle-ai/internal/agents/capabilities"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/claude"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/kimi"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/opencode"
+	"github.com/gentleman-programming/gentle-ai/internal/agents/pi"
 	windsurfagent "github.com/gentleman-programming/gentle-ai/internal/agents/windsurf"
 	"github.com/gentleman-programming/gentle-ai/internal/assets"
 	"github.com/gentleman-programming/gentle-ai/internal/model"
+	"github.com/gentleman-programming/gentle-ai/internal/testutil"
 	// agents/cursor, agents/gemini, agents/vscode used via agents.NewAdapter()
 )
 
 func claudeAdapter() agents.Adapter   { return claude.NewAdapter() }
 func kimiAdapter() agents.Adapter     { return kimi.NewAdapter() }
 func opencodeAdapter() agents.Adapter { return opencode.NewAdapter() }
+func piAdapter() agents.Adapter       { return pi.NewAdapter() }
 func windsurfAdapter() agents.Adapter { return windsurfagent.NewAdapter() }
 
 func mockNoPackageManager(t *testing.T) {
@@ -298,6 +302,512 @@ func TestInjectOpenCodeIsIdempotent(t *testing.T) {
 	}
 	if second.Changed {
 		t.Fatalf("Inject() second changed = true")
+	}
+}
+
+func TestInjectPIWritesCapabilityOverlayWithoutTouchingOpenCode(t *testing.T) {
+	home := t.TempDir()
+
+	result, err := Inject(home, piAdapter(), "")
+	if err != nil {
+		t.Fatalf("Inject(pi) error = %v", err)
+	}
+	if !result.Changed {
+		t.Fatal("Inject(pi) changed = false, want true")
+	}
+
+	piSettings := piAdapter().SettingsPath(home)
+	piRaw, err := os.ReadFile(piSettings)
+	if err != nil {
+		t.Fatalf("ReadFile(pi settings) error = %v", err)
+	}
+	testutil.AssertJSONGolden(t, piRaw, filepath.Join("testdata", "pi_sdd_overlay.golden.json"))
+
+	openCodeSettings := filepath.Join(home, ".config", "opencode", "opencode.json")
+	if _, statErr := os.Stat(openCodeSettings); !os.IsNotExist(statErr) {
+		t.Fatalf("expected OpenCode settings to remain untouched for PI inject, stat err = %v", statErr)
+	}
+}
+
+func TestInjectPISharedSupportFilesExcludeSharedSkillDefinition(t *testing.T) {
+	home := t.TempDir()
+
+	result, err := Inject(home, piAdapter(), "")
+	if err != nil {
+		t.Fatalf("Inject(pi) error = %v", err)
+	}
+
+	sharedDir := filepath.Join(home, ".pi", "agent", "skills", "_shared")
+	for _, sharedFile := range []string{
+		"persistence-contract.md",
+		"engram-convention.md",
+		"openspec-convention.md",
+		"sdd-phase-common.md",
+		"skill-resolver.md",
+	} {
+		path := filepath.Join(sharedDir, sharedFile)
+		if _, statErr := os.Stat(path); statErr != nil {
+			t.Fatalf("expected PI shared support file %q: %v", path, statErr)
+		}
+	}
+
+	staleSkillPath := filepath.Join(sharedDir, "SKILL.md")
+	if _, statErr := os.Stat(staleSkillPath); !os.IsNotExist(statErr) {
+		t.Fatalf("expected PI injection to omit invalid %q, stat err = %v", staleSkillPath, statErr)
+	}
+
+	for _, f := range result.Files {
+		if f == staleSkillPath {
+			t.Fatalf("result.Files should not include %q", staleSkillPath)
+		}
+	}
+}
+
+func TestInjectPICleansStaleSharedSkillDefinition(t *testing.T) {
+	home := t.TempDir()
+	sharedDir := filepath.Join(home, ".pi", "agent", "skills", "_shared")
+	if err := os.MkdirAll(sharedDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(sharedDir) error = %v", err)
+	}
+
+	staleSkillPath := filepath.Join(sharedDir, "SKILL.md")
+	if err := os.WriteFile(staleSkillPath, []byte("stale invalid shared skill"), 0o644); err != nil {
+		t.Fatalf("WriteFile(stale SKILL.md) error = %v", err)
+	}
+
+	if _, err := Inject(home, piAdapter(), ""); err != nil {
+		t.Fatalf("Inject(pi) first error = %v", err)
+	}
+
+	if _, statErr := os.Stat(staleSkillPath); !os.IsNotExist(statErr) {
+		t.Fatalf("expected stale %q to be removed after first inject, stat err = %v", staleSkillPath, statErr)
+	}
+
+	second, err := Inject(home, piAdapter(), "")
+	if err != nil {
+		t.Fatalf("Inject(pi) second error = %v", err)
+	}
+	if second.Changed {
+		t.Fatal("Inject(pi) second changed = true, want false (stale cleanup must be idempotent)")
+	}
+}
+
+func TestInjectPIWithoutSubagentsStaysFailClosedAndSkipsPIArtifacts(t *testing.T) {
+	home := t.TempDir()
+	workspace := t.TempDir()
+
+	result, err := Inject(home, piAdapter(), model.SDDModeMulti, InjectOptions{WorkspaceDir: workspace})
+	if err != nil {
+		t.Fatalf("Inject(pi, multi) error = %v", err)
+	}
+	if !result.Changed {
+		t.Fatal("Inject(pi, multi) changed = false, want true")
+	}
+
+	piSettings := piAdapter().SettingsPath(home)
+	piRaw, err := os.ReadFile(piSettings)
+	if err != nil {
+		t.Fatalf("ReadFile(pi settings) error = %v", err)
+	}
+	testutil.AssertJSONGolden(t, piRaw, filepath.Join("testdata", "pi_sdd_overlay_absent.golden.json"))
+
+	agentsDir := filepath.Join(workspace, ".pi", "agents")
+	if _, statErr := os.Stat(agentsDir); !os.IsNotExist(statErr) {
+		t.Fatalf("expected %q to be absent when pi-subagents is unavailable, stat err = %v", agentsDir, statErr)
+	}
+}
+
+func TestInjectPIWithSubagentsWritesPIArtifactsAndEnabledOverlay(t *testing.T) {
+	home := t.TempDir()
+	workspace := t.TempDir()
+
+	extensionDir := filepath.Join(piAdapter().GlobalConfigDir(home), "extensions", "pi-subagents")
+	if err := os.MkdirAll(extensionDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(extensionDir) error = %v", err)
+	}
+
+	assignments := map[string]model.ModelAssignment{
+		"sdd-apply": {ProviderID: "openai", ModelID: "gpt-5"},
+		"default":   {ProviderID: "anthropic", ModelID: "claude-sonnet-4-5"},
+	}
+
+	result, err := Inject(home, piAdapter(), model.SDDModeMulti, InjectOptions{
+		WorkspaceDir:       workspace,
+		PIModelAssignments: assignments,
+	})
+	if err != nil {
+		t.Fatalf("Inject(pi, multi) error = %v", err)
+	}
+	if !result.Changed {
+		t.Fatal("Inject(pi, multi) changed = false, want true")
+	}
+
+	piSettings := piAdapter().SettingsPath(home)
+	piRaw, err := os.ReadFile(piSettings)
+	if err != nil {
+		t.Fatalf("ReadFile(pi settings) error = %v", err)
+	}
+	testutil.AssertJSONGolden(t, piRaw, filepath.Join("testdata", "pi_sdd_overlay_present.golden.json"))
+
+	applyAgentPath := filepath.Join(workspace, ".pi", "agents", "sdd-apply.md")
+	applyAgentRaw, err := os.ReadFile(applyAgentPath)
+	if err != nil {
+		t.Fatalf("ReadFile(sdd-apply.md) error = %v", err)
+	}
+	testutil.AssertTextGolden(t, string(applyAgentRaw), filepath.Join("testdata", "pi_sdd_apply_agent.golden.md"))
+
+	chainPath := filepath.Join(workspace, ".pi", "agents", "sdd.chain.md")
+	chainRaw, err := os.ReadFile(chainPath)
+	if err != nil {
+		t.Fatalf("ReadFile(sdd.chain.md) error = %v", err)
+	}
+	testutil.AssertTextGolden(t, string(chainRaw), filepath.Join("testdata", "pi_sdd_chain.golden.md"))
+
+	openCodeSettings := filepath.Join(home, ".config", "opencode", "opencode.json")
+	if _, statErr := os.Stat(openCodeSettings); !os.IsNotExist(statErr) {
+		t.Fatalf("expected OpenCode settings untouched for PI inject, stat err = %v", statErr)
+	}
+}
+
+func TestInjectPIWithoutSubagentsUsesCanonicalRequirementMessage(t *testing.T) {
+	home := t.TempDir()
+	workspace := t.TempDir()
+
+	result, err := Inject(home, piAdapter(), model.SDDModeMulti, InjectOptions{WorkspaceDir: workspace})
+	if err != nil {
+		t.Fatalf("Inject(pi, multi) error = %v", err)
+	}
+	if !result.Changed {
+		t.Fatal("Inject(pi, multi) changed = false, want true")
+	}
+
+	piSettings := piAdapter().SettingsPath(home)
+	raw, err := os.ReadFile(piSettings)
+	if err != nil {
+		t.Fatalf("ReadFile(pi settings) error = %v", err)
+	}
+
+	if !strings.Contains(string(raw), capabilities.PiMultiModelRequiresPiSubagentsMessage) {
+		t.Fatalf("pi settings missing canonical requirement message %q\n%s", capabilities.PiMultiModelRequiresPiSubagentsMessage, string(raw))
+	}
+}
+
+func TestInjectPIResolverErrorFallsBackToCanonicalRequirementAndSkipsArtifacts(t *testing.T) {
+	home := t.TempDir()
+	workspace := t.TempDir()
+
+	origResolver := resolveSDDCapabilitiesFn
+	t.Cleanup(func() { resolveSDDCapabilitiesFn = origResolver })
+	resolveSDDCapabilitiesFn = func(_, _ string, _ model.AgentID) (capabilities.ResolvedCapabilities, error) {
+		return capabilities.ResolvedCapabilities{}, fmt.Errorf("resolver failed")
+	}
+
+	result, err := Inject(home, piAdapter(), model.SDDModeMulti, InjectOptions{WorkspaceDir: workspace})
+	if err != nil {
+		t.Fatalf("Inject(pi, multi) error = %v", err)
+	}
+
+	for _, path := range result.Files {
+		if strings.Contains(path, string(filepath.Separator)+".pi"+string(filepath.Separator)+"agents"+string(filepath.Separator)) {
+			t.Fatalf("Inject(pi, multi) should skip PI artifacts on resolver error, got file %q", path)
+		}
+	}
+
+	piSettings := piAdapter().SettingsPath(home)
+	raw, err := os.ReadFile(piSettings)
+	if err != nil {
+		t.Fatalf("ReadFile(pi settings) error = %v", err)
+	}
+
+	if !strings.Contains(string(raw), capabilities.PiMultiModelRequiresPiSubagentsMessage) {
+		t.Fatalf("pi settings missing canonical requirement message after resolver error %q\n%s", capabilities.PiMultiModelRequiresPiSubagentsMessage, string(raw))
+	}
+}
+
+func TestInjectPIChainContainsOrderedExecutablePhases(t *testing.T) {
+	home := t.TempDir()
+	workspace := t.TempDir()
+
+	extensionDir := filepath.Join(piAdapter().GlobalConfigDir(home), "extensions", "pi-subagents")
+	if err := os.MkdirAll(extensionDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(extensionDir) error = %v", err)
+	}
+
+	if _, err := Inject(home, piAdapter(), model.SDDModeMulti, InjectOptions{WorkspaceDir: workspace}); err != nil {
+		t.Fatalf("Inject(pi, multi) error = %v", err)
+	}
+
+	chainPath := filepath.Join(workspace, ".pi", "agents", "sdd.chain.md")
+	chainRaw, err := os.ReadFile(chainPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", chainPath, err)
+	}
+
+	chain := string(chainRaw)
+	assertOrderedContains(t, chain, []string{
+		"## sdd-init",
+		"## sdd-explore",
+		"## sdd-propose",
+		"## sdd-spec",
+		"## sdd-design",
+		"## sdd-tasks",
+		"## sdd-apply",
+		"## sdd-verify",
+		"## sdd-archive",
+	})
+
+	for _, stepHeading := range []string{
+		"## sdd-init", "## sdd-explore", "## sdd-propose", "## sdd-spec", "## sdd-design",
+		"## sdd-tasks", "## sdd-apply", "## sdd-verify", "## sdd-archive",
+	} {
+		if strings.Count(chain, stepHeading) != 1 {
+			t.Fatalf("chain should contain heading %q exactly once\n%s", stepHeading, chain)
+		}
+	}
+
+	for _, invalidHeading := range []string{"## Steps", "## Phase Models"} {
+		if strings.Contains(chain, invalidHeading) {
+			t.Fatalf("chain should not contain non-agent heading %q because pi-subagents parses every ## heading as a step\n%s", invalidHeading, chain)
+		}
+	}
+
+	if !strings.Contains(chain, "name: sdd") || !strings.Contains(chain, "description:") {
+		t.Fatalf("chain missing required frontmatter fields\n%s", chain)
+	}
+}
+
+func TestInjectPIPreservesUserSubagentsSettingsDuringOverlayMerge(t *testing.T) {
+	home := t.TempDir()
+
+	settingsPath := piAdapter().SettingsPath(home)
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(settings dir) error = %v", err)
+	}
+
+	original := `{
+	  "subagents": {
+	    "agentOverrides": {
+	      "reviewer": {
+	        "model": "anthropic/claude-sonnet-4"
+	      }
+	    }
+	  }
+	}`
+	if err := os.WriteFile(settingsPath, []byte(original), 0o644); err != nil {
+		t.Fatalf("WriteFile(settings) error = %v", err)
+	}
+
+	if _, err := Inject(home, piAdapter(), model.SDDModeMulti); err != nil {
+		t.Fatalf("Inject(pi, multi) error = %v", err)
+	}
+
+	mergedRaw, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("ReadFile(settings) error = %v", err)
+	}
+
+	if !strings.Contains(string(mergedRaw), `"subagents"`) {
+		t.Fatalf("merged settings should preserve existing subagents key\n%s", string(mergedRaw))
+	}
+	if !strings.Contains(string(mergedRaw), `"agentOverrides"`) {
+		t.Fatalf("merged settings should preserve existing subagents.agentOverrides key\n%s", string(mergedRaw))
+	}
+	if !strings.Contains(string(mergedRaw), `"reviewer"`) {
+		t.Fatalf("merged settings should preserve existing subagents reviewer override\n%s", string(mergedRaw))
+	}
+}
+
+func TestPIPhaseAssetsContainContextSkillsPromptAndResultContract(t *testing.T) {
+	phases := []string{
+		"sdd-propose", "sdd-spec", "sdd-design", "sdd-tasks", "sdd-apply",
+		"sdd-verify", "sdd-archive", "sdd-explore", "sdd-init", "sdd-onboard",
+	}
+
+	for _, phase := range phases {
+		t.Run(phase, func(t *testing.T) {
+			content := assets.MustRead(filepath.Join("pi", "agents", phase+".md"))
+
+			mustContain := []string{
+				"## Project Context Inheritance",
+				"## Skills Inheritance Rule",
+				"## Phase Prompt",
+				"## Result Contract",
+				"status",
+				"executive_summary",
+				"artifacts",
+				"next_recommended",
+				"risks",
+				"skill_resolution",
+			}
+
+			for _, token := range mustContain {
+				if !strings.Contains(content, token) {
+					t.Fatalf("%s asset missing %q\n%s", phase, token, content)
+				}
+			}
+		})
+	}
+}
+
+func TestInjectPIArtifactsOmitModelWhenUnassigned(t *testing.T) {
+	home := t.TempDir()
+	workspace := t.TempDir()
+
+	extensionDir := filepath.Join(piAdapter().GlobalConfigDir(home), "extensions", "pi-subagents")
+	if err := os.MkdirAll(extensionDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(extensionDir) error = %v", err)
+	}
+
+	if _, err := Inject(home, piAdapter(), model.SDDModeMulti, InjectOptions{WorkspaceDir: workspace}); err != nil {
+		t.Fatalf("Inject(pi, multi) error = %v", err)
+	}
+
+	for _, phase := range []string{"sdd-apply", "sdd-spec"} {
+		path := filepath.Join(workspace, ".pi", "agents", phase+".md")
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("ReadFile(%q) error = %v", path, err)
+		}
+		if strings.Contains(string(raw), "model:") {
+			t.Fatalf("%s should omit model when unassigned\n%s", phase, string(raw))
+		}
+		if strings.Contains(string(raw), "openai/gpt-5") {
+			t.Fatalf("%s contains fabricated openai/gpt-5 model\n%s", phase, string(raw))
+		}
+	}
+}
+
+func TestInjectPIArtifactsKeepExplicitModelAssignmentUnchanged(t *testing.T) {
+	home := t.TempDir()
+	workspace := t.TempDir()
+
+	extensionDir := filepath.Join(piAdapter().GlobalConfigDir(home), "extensions", "pi-subagents")
+	if err := os.MkdirAll(extensionDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(extensionDir) error = %v", err)
+	}
+
+	assignments := map[string]model.ModelAssignment{
+		"sdd-apply": {ProviderID: "anthropic", ModelID: "claude-opus-4-6"},
+	}
+
+	if _, err := Inject(home, piAdapter(), model.SDDModeMulti, InjectOptions{WorkspaceDir: workspace, PIModelAssignments: assignments}); err != nil {
+		t.Fatalf("Inject(pi, multi) error = %v", err)
+	}
+
+	applyPath := filepath.Join(workspace, ".pi", "agents", "sdd-apply.md")
+	applyRaw, err := os.ReadFile(applyPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", applyPath, err)
+	}
+	if !strings.Contains(string(applyRaw), "model: anthropic/claude-opus-4-6") {
+		t.Fatalf("sdd-apply missing explicit model assignment\n%s", string(applyRaw))
+	}
+}
+
+func TestInjectUsesSeparateAssignmentsForOpenCodeAndPIArtifacts(t *testing.T) {
+	tests := []struct {
+		name                    string
+		openCodeAssignments     map[string]model.ModelAssignment
+		piAssignments           map[string]model.ModelAssignment
+		wantOpenCodeApplyModel  string
+		wantPIApplyModel        string
+	}{
+		{
+			name: "mixed OpenCode + PI uses source-specific maps",
+			openCodeAssignments: map[string]model.ModelAssignment{
+				"sdd-apply": {ProviderID: "anthropic", ModelID: "claude-sonnet-4-20250514"},
+			},
+			piAssignments: map[string]model.ModelAssignment{
+				"sdd-apply": {ProviderID: "openai", ModelID: "gpt-5"},
+			},
+			wantOpenCodeApplyModel: "anthropic/claude-sonnet-4-20250514",
+			wantPIApplyModel:       "openai/gpt-5",
+		},
+		{
+			name:                "pi-only uses pi assignments for pi artifacts",
+			openCodeAssignments: nil,
+			piAssignments: map[string]model.ModelAssignment{
+				"sdd-apply": {ProviderID: "openai", ModelID: "gpt-5-mini"},
+			},
+			wantOpenCodeApplyModel: "",
+			wantPIApplyModel:       "openai/gpt-5-mini",
+		},
+		{
+			name: "openCode-only remains unchanged",
+			openCodeAssignments: map[string]model.ModelAssignment{
+				"sdd-apply": {ProviderID: "anthropic", ModelID: "claude-opus-4-1"},
+			},
+			piAssignments:          nil,
+			wantOpenCodeApplyModel: "anthropic/claude-opus-4-1",
+			wantPIApplyModel:       "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home := t.TempDir()
+			workspace := t.TempDir()
+
+			extensionDir := filepath.Join(piAdapter().GlobalConfigDir(home), "extensions", "pi-subagents")
+			if err := os.MkdirAll(extensionDir, 0o755); err != nil {
+				t.Fatalf("MkdirAll(extensionDir) error = %v", err)
+			}
+
+			opts := InjectOptions{
+				WorkspaceDir:             workspace,
+				OpenCodeModelAssignments: tt.openCodeAssignments,
+				PIModelAssignments:       tt.piAssignments,
+			}
+
+			if _, err := Inject(home, opencodeAdapter(), model.SDDModeMulti, opts); err != nil {
+				t.Fatalf("Inject(opencode, multi) error = %v", err)
+			}
+			if _, err := Inject(home, piAdapter(), model.SDDModeMulti, opts); err != nil {
+				t.Fatalf("Inject(pi, multi) error = %v", err)
+			}
+
+			opencodePath := filepath.Join(home, ".config", "opencode", "opencode.json")
+			opencodeRaw, err := os.ReadFile(opencodePath)
+			if err != nil {
+				t.Fatalf("ReadFile(opencode.json) error = %v", err)
+			}
+			opencodeText := string(opencodeRaw)
+
+			if tt.wantOpenCodeApplyModel == "" {
+				if strings.Contains(opencodeText, `"sdd-apply": {"mode": "subagent", "model":`) {
+					t.Fatalf("OpenCode overlay unexpectedly contains explicit sdd-apply model\n%s", opencodeText)
+				}
+			} else if !strings.Contains(opencodeText, tt.wantOpenCodeApplyModel) {
+				t.Fatalf("OpenCode overlay missing model %q\n%s", tt.wantOpenCodeApplyModel, opencodeText)
+			}
+
+			piApplyPath := filepath.Join(workspace, ".pi", "agents", "sdd-apply.md")
+			piApplyRaw, err := os.ReadFile(piApplyPath)
+			if err != nil {
+				t.Fatalf("ReadFile(sdd-apply.md) error = %v", err)
+			}
+			piApplyText := string(piApplyRaw)
+			if tt.wantPIApplyModel == "" {
+				if strings.Contains(piApplyText, "model:") {
+					t.Fatalf("PI artifact should not contain an explicit model when PI assignments are absent\n%s", piApplyText)
+				}
+			} else if !strings.Contains(piApplyText, "model: "+tt.wantPIApplyModel) {
+				t.Fatalf("PI artifact missing model %q\n%s", tt.wantPIApplyModel, piApplyText)
+			}
+		})
+	}
+}
+
+func assertOrderedContains(t *testing.T, text string, ordered []string) {
+	t.Helper()
+
+	pos := 0
+	for _, token := range ordered {
+		idx := strings.Index(text[pos:], token)
+		if idx < 0 {
+			t.Fatalf("text does not contain ordered token %q after index %d\n%s", token, pos, text)
+		}
+		pos += idx + len(token)
 	}
 }
 

--- a/internal/components/sdd/pi_agents_prompt_test.go
+++ b/internal/components/sdd/pi_agents_prompt_test.go
@@ -1,0 +1,57 @@
+package sdd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/internal/agents/pi"
+	"github.com/gentleman-programming/gentle-ai/internal/model"
+)
+
+func TestInjectPIAgentsPromptUsesConcreteModelIDs(t *testing.T) {
+	home := t.TempDir()
+	workspace := t.TempDir()
+
+	if err := os.MkdirAll(filepath.Join(workspace, ".pi", "extensions", "pi-subagents"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(pi-subagents) error = %v", err)
+	}
+
+	assignments := map[string]model.ModelAssignment{
+		"sdd-design":  {ProviderID: "anthropic", ModelID: "claude-opus-4-1"},
+		"sdd-archive": {ProviderID: "anthropic", ModelID: "claude-haiku-3-5-20241022"},
+		"default":     {ProviderID: "anthropic", ModelID: "claude-sonnet-4-20250514"},
+	}
+
+	_, err := Inject(home, pi.NewAdapter(), model.SDDModeMulti, InjectOptions{
+		WorkspaceDir:             workspace,
+		OpenCodeModelAssignments: assignments,
+	})
+	if err != nil {
+		t.Fatalf("Inject() error = %v", err)
+	}
+
+	agentsPath := filepath.Join(home, ".pi", "agent", "AGENTS.md")
+	raw, err := os.ReadFile(agentsPath)
+	if err != nil {
+		t.Fatalf("ReadFile(AGENTS.md) error = %v", err)
+	}
+	text := string(raw)
+
+	for _, alias := range []string{"| orchestrator | opus |", "| sdd-explore | sonnet |", "| sdd-archive | haiku |"} {
+		if strings.Contains(text, alias) {
+			t.Fatalf("AGENTS.md contains Claude alias row %q; want concrete model IDs", alias)
+		}
+	}
+
+	for _, expected := range []string{
+		"| orchestrator | anthropic/claude-sonnet-4-20250514 |",
+		"| sdd-design | anthropic/claude-opus-4-1 |",
+		"| sdd-archive | anthropic/claude-haiku-3-5-20241022 |",
+	} {
+		if !strings.Contains(text, expected) {
+			t.Fatalf("AGENTS.md missing concrete model assignment row %q", expected)
+		}
+	}
+}

--- a/internal/components/sdd/pi_assets_test.go
+++ b/internal/components/sdd/pi_assets_test.go
@@ -1,0 +1,27 @@
+package sdd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/internal/assets"
+)
+
+func TestPIPhaseAssetsUseReportArtifactKeys(t *testing.T) {
+	tests := []struct {
+		file string
+		want string
+	}{
+		{file: "pi/agents/sdd-verify.md", want: "sdd/{change-name}/verify-report"},
+		{file: "pi/agents/sdd-archive.md", want: "sdd/{change-name}/archive-report"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.file, func(t *testing.T) {
+			content := string(assets.MustRead(tt.file))
+			if !strings.Contains(content, tt.want) {
+				t.Fatalf("%s missing required artifact key %q", tt.file, tt.want)
+			}
+		})
+	}
+}

--- a/internal/components/sdd/profiles_test.go
+++ b/internal/components/sdd/profiles_test.go
@@ -55,6 +55,23 @@ func TestResolveProfileStrategy_DefaultsGeneratedMultiWithoutExternalProfiles(t 
 	}
 }
 
+func TestRenderPiChainModelsOmitsUnassignedPhases(t *testing.T) {
+	assignments := map[string]model.ModelAssignment{
+		"sdd-apply": {ProviderID: "anthropic", ModelID: "claude-opus-4-6"},
+	}
+
+	chainModels := renderPiChainModels(assignments)
+	if strings.Contains(chainModels, "openai/gpt-5") {
+		t.Fatalf("renderPiChainModels() fabricated fallback model\n%s", chainModels)
+	}
+	if !strings.Contains(chainModels, "sdd-apply: anthropic/claude-opus-4-6") {
+		t.Fatalf("renderPiChainModels() missing explicit assignment\n%s", chainModels)
+	}
+	if strings.Contains(chainModels, "sdd-spec:") {
+		t.Fatalf("renderPiChainModels() should omit unassigned phase entries\n%s", chainModels)
+	}
+}
+
 // ─── ValidateProfileName ───────────────────────────────────────────────────
 
 func TestValidateProfileName_Valid(t *testing.T) {

--- a/internal/components/sdd/read_assignments_test.go
+++ b/internal/components/sdd/read_assignments_test.go
@@ -237,3 +237,21 @@ func TestReadCurrentModelAssignmentsMixedSeparators(t *testing.T) {
 		}
 	}
 }
+
+func TestReadCurrentModelAssignmentsDoesNotFabricateFromRootModel(t *testing.T) {
+	dir := t.TempDir()
+	settingsPath := filepath.Join(dir, "opencode.json")
+
+	content := `{"model":"openai/gpt-5","agent":{"gentleman":{"model":"openai/gpt-5"}}}`
+	if err := os.WriteFile(settingsPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write settings: %v", err)
+	}
+
+	got, err := ReadCurrentModelAssignments(settingsPath)
+	if err != nil {
+		t.Fatalf("ReadCurrentModelAssignments() error = %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("ReadCurrentModelAssignments() fabricated SDD assignments from root model: %v", got)
+	}
+}

--- a/internal/components/sdd/testdata/pi_sdd_apply_agent.golden.md
+++ b/internal/components/sdd/testdata/pi_sdd_apply_agent.golden.md
@@ -1,0 +1,27 @@
+---
+name: sdd-apply
+description: Implement the selected SDD tasks in strict TDD order.
+model: openai/gpt-5
+---
+
+## Project Context Inheritance
+
+- Inherit project metadata, workspace root, and change name from the orchestrator prompt.
+
+## Skills Inheritance Rule
+
+- Apply injected `## Project Standards (auto-resolved)` rules first.
+- Load additional skills only when the phase prompt explicitly requires them.
+
+## Phase Prompt
+
+Execute the `sdd-apply` phase end-to-end and persist `sdd/{change-name}/apply-progress`.
+
+## Result Contract
+
+- status
+- executive_summary
+- artifacts
+- next_recommended
+- risks
+- skill_resolution

--- a/internal/components/sdd/testdata/pi_sdd_chain.golden.md
+++ b/internal/components/sdd/testdata/pi_sdd_chain.golden.md
@@ -1,0 +1,65 @@
+---
+name: sdd
+description: Executable PI SDD chain for pi-subagents.
+---
+
+This file follows the native `pi-subagents` chain format.
+Each `## <agent-name>` heading is an executable step.
+
+## sdd-init
+model: anthropic/claude-sonnet-4-5
+
+Initialize SDD for this project when needed, or confirm existing SDD context and continue with the next phase for task: {task}
+
+## sdd-explore
+model: anthropic/claude-sonnet-4-5
+
+Explore and validate the problem/constraints using prior context from {previous}. Return the standard SDD result contract.
+
+## sdd-propose
+model: anthropic/claude-sonnet-4-5
+
+Create or refine the change proposal from {previous}. Return the standard SDD result contract.
+
+## sdd-spec
+model: anthropic/claude-sonnet-4-5
+
+Write or update the delta spec based on {previous}. Return the standard SDD result contract.
+
+## sdd-design
+model: anthropic/claude-sonnet-4-5
+
+Produce/update technical design decisions from {previous}. Return the standard SDD result contract.
+
+## sdd-tasks
+model: anthropic/claude-sonnet-4-5
+
+Break implementation into explicit checklist tasks from {previous}. Return the standard SDD result contract.
+
+## sdd-apply
+model: openai/gpt-5
+
+Implement the approved tasks from {previous} and report progress with the standard SDD result contract.
+
+## sdd-verify
+model: anthropic/claude-sonnet-4-5
+
+Verify implementation against proposal/spec/design/tasks from {previous}. Return the standard SDD result contract.
+
+## sdd-archive
+model: anthropic/claude-sonnet-4-5
+
+Archive completed change artifacts after successful verification from {previous}. Return the standard SDD result contract.
+
+### Phase model summary (informational)
+
+- sdd-init: anthropic/claude-sonnet-4-5
+- sdd-explore: anthropic/claude-sonnet-4-5
+- sdd-propose: anthropic/claude-sonnet-4-5
+- sdd-spec: anthropic/claude-sonnet-4-5
+- sdd-design: anthropic/claude-sonnet-4-5
+- sdd-tasks: anthropic/claude-sonnet-4-5
+- sdd-apply: openai/gpt-5
+- sdd-verify: anthropic/claude-sonnet-4-5
+- sdd-archive: anthropic/claude-sonnet-4-5
+- sdd-onboard: anthropic/claude-sonnet-4-5

--- a/internal/components/sdd/testdata/pi_sdd_overlay.golden.json
+++ b/internal/components/sdd/testdata/pi_sdd_overlay.golden.json
@@ -1,0 +1,17 @@
+{
+  "features": {
+    "profiles": false,
+    "modelPicker": false,
+    "generatedMulti": false
+  },
+  "sdd": {
+    "capabilities": [
+      "experimental",
+      "non-parity"
+    ],
+    "multiModel": {
+      "enabled": false,
+      "requirement_message": "PI multi-model requires installing the `pi-subagents` extension."
+    }
+  }
+}

--- a/internal/components/sdd/testdata/pi_sdd_overlay_absent.golden.json
+++ b/internal/components/sdd/testdata/pi_sdd_overlay_absent.golden.json
@@ -1,0 +1,17 @@
+{
+  "features": {
+    "profiles": false,
+    "modelPicker": false,
+    "generatedMulti": false
+  },
+  "sdd": {
+    "capabilities": [
+      "experimental",
+      "non-parity"
+    ],
+    "multiModel": {
+      "enabled": false,
+      "requirement_message": "PI multi-model requires installing the `pi-subagents` extension."
+    }
+  }
+}

--- a/internal/components/sdd/testdata/pi_sdd_overlay_present.golden.json
+++ b/internal/components/sdd/testdata/pi_sdd_overlay_present.golden.json
@@ -1,0 +1,17 @@
+{
+  "features": {
+    "profiles": true,
+    "modelPicker": true,
+    "generatedMulti": true
+  },
+  "sdd": {
+    "capabilities": [
+      "experimental",
+      "non-parity"
+    ],
+    "multiModel": {
+      "enabled": true,
+      "requirement_message": ""
+    }
+  }
+}

--- a/internal/components/uninstall/service.go
+++ b/internal/components/uninstall/service.go
@@ -641,6 +641,9 @@ func context7Operations(adapter agents.Adapter, homeDir string) []operation {
 		if adapter.Agent() == model.AgentOpenCode {
 			return []operation{rewriteJSONFile(path, jsonPath{"mcp", "context7"})}
 		}
+		if adapter.Agent() == model.AgentPiCodingAgent {
+			return []operation{rewriteJSONFile(path, jsonPath{"mcpServers", "context7"})}
+		}
 		return []operation{rewriteJSONFile(path, jsonPath{"mcpServers", "context7"})}
 	case model.StrategyMCPConfigFile:
 		path := adapter.MCPConfigPath(homeDir, "context7")
@@ -685,6 +688,9 @@ func engramOperations(adapter agents.Adapter, homeDir string) []operation {
 		path := adapter.SettingsPath(homeDir)
 		if adapter.Agent() == model.AgentOpenCode {
 			return []operation{rewriteJSONFile(path, jsonPath{"mcp", "engram"})}
+		}
+		if adapter.Agent() == model.AgentPiCodingAgent {
+			return []operation{rewriteJSONFile(path, jsonPath{"mcpServers", "engram"})}
 		}
 		return []operation{rewriteJSONFile(path, jsonPath{"mcpServers", "engram"})}
 	case model.StrategyMCPConfigFile:

--- a/internal/components/uninstall/service_test.go
+++ b/internal/components/uninstall/service_test.go
@@ -405,3 +405,65 @@ func TestComponentOperationsEngram_GlobalScopeKeepsWorkspaceProjectData(t *testi
 		t.Fatalf("global engram config should be removed in global scope, got: %s", string(raw))
 	}
 }
+
+func TestComponentOperationsEngram_PIOnlyCleanupDoesNotTouchOpenCodeState(t *testing.T) {
+	homeDir := t.TempDir()
+	workspaceDir := t.TempDir()
+
+	svc, err := NewService(homeDir, workspaceDir, "dev")
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+
+	piAdapter, ok := svc.registry.Get(model.AgentPiCodingAgent)
+	if !ok {
+		t.Fatal("pi adapter not found in registry")
+	}
+	opencodeAdapter, ok := svc.registry.Get(model.AgentOpenCode)
+	if !ok {
+		t.Fatal("openCode adapter not found in registry")
+	}
+
+	piSettingsPath := piAdapter.SettingsPath(homeDir)
+	if err := os.MkdirAll(filepath.Dir(piSettingsPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(pi settings dir) error = %v", err)
+	}
+	if err := os.WriteFile(piSettingsPath, []byte(`{"mcpServers":{"engram":{"command":"engram","args":["mcp","--tools=agent"]}}}`), 0o644); err != nil {
+		t.Fatalf("WriteFile(pi settings) error = %v", err)
+	}
+
+	opencodeSettingsPath := opencodeAdapter.SettingsPath(homeDir)
+	if err := os.MkdirAll(filepath.Dir(opencodeSettingsPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(opencode settings dir) error = %v", err)
+	}
+	if err := os.WriteFile(opencodeSettingsPath, []byte(`{"mcp":{"engram":{"command":["engram","mcp","--tools=agent"],"type":"local"}}}`), 0o644); err != nil {
+		t.Fatalf("WriteFile(opencode settings) error = %v", err)
+	}
+
+	ops, _, err := svc.componentOperations(piAdapter, model.ComponentEngram)
+	if err != nil {
+		t.Fatalf("componentOperations() error = %v", err)
+	}
+	for _, op := range ops {
+		if _, _, err := op.apply(op.path); err != nil {
+			t.Fatalf("op.apply(%q) error = %v", op.path, err)
+		}
+	}
+
+	piRaw, err := os.ReadFile(piSettingsPath)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			t.Fatalf("ReadFile(pi settings) error = %v", err)
+		}
+	} else if strings.Contains(string(piRaw), `"engram"`) {
+		t.Fatalf("PI settings should remove engram entry, got: %s", string(piRaw))
+	}
+
+	opencodeRaw, err := os.ReadFile(opencodeSettingsPath)
+	if err != nil {
+		t.Fatalf("ReadFile(opencode settings) error = %v", err)
+	}
+	if !strings.Contains(string(opencodeRaw), `"engram"`) {
+		t.Fatalf("OpenCode settings must be untouched during PI engram cleanup, got: %s", string(opencodeRaw))
+	}
+}

--- a/internal/installcmd/resolver.go
+++ b/internal/installcmd/resolver.go
@@ -45,6 +45,8 @@ func (profileResolver) ResolveAgentInstall(profile system.PlatformProfile, agent
 		return resolveOpenCodeInstall(profile)
 	case model.AgentKilocode:
 		return resolveKilocodeInstall(profile), nil
+	case model.AgentPiCodingAgent:
+		return nil, piInstallCompatibilityGateError()
 	case model.AgentKimi:
 		return resolveKimiInstall(profile)
 	default:
@@ -90,11 +92,17 @@ func resolveKimiInstall(profile system.PlatformProfile) (CommandSequence, error)
 // exist before running installation commands.
 func ValidateAgentInstallPreflight(profile system.PlatformProfile, agent model.AgentID) error {
 	switch agent {
+	case model.AgentPiCodingAgent:
+		return piInstallCompatibilityGateError()
 	case model.AgentKimi:
 		return validateKimiInstallPreflight(profile)
 	default:
 		return nil
 	}
+}
+
+func piInstallCompatibilityGateError() error {
+	return fmt.Errorf("agent %q auto-install is disabled until PI install contracts are validated", model.AgentPiCodingAgent)
 }
 
 func validateKimiInstallPreflight(profile system.PlatformProfile) error {

--- a/internal/installcmd/resolver_test.go
+++ b/internal/installcmd/resolver_test.go
@@ -387,6 +387,12 @@ func TestResolveAgentInstall(t *testing.T) {
 			agent:   model.AgentKimi,
 			wantErr: true,
 		},
+		{
+			name:    "pi coding agent returns deterministic not installable error",
+			profile: system.PlatformProfile{OS: "linux", LinuxDistro: system.LinuxDistroUbuntu, PackageManager: "apt", Supported: true},
+			agent:   model.AgentPiCodingAgent,
+			wantErr: true,
+		},
 
 		{
 			name:    "unsupported agent returns error",
@@ -404,6 +410,9 @@ func TestResolveAgentInstall(t *testing.T) {
 			}
 
 			if tt.wantErr {
+				if tt.agent == model.AgentPiCodingAgent && !strings.Contains(err.Error(), "auto-install is disabled until PI install contracts are validated") {
+					t.Fatalf("ResolveAgentInstall() PI error = %q, want compatibility-gate message", err.Error())
+				}
 				return
 			}
 
@@ -467,6 +476,16 @@ func TestValidateAgentInstallPreflight(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name:    "pi preflight returns compatibility gate error without uv lookup",
+			profile: system.PlatformProfile{OS: "darwin", PackageManager: "brew", Supported: true},
+			agent:   model.AgentPiCodingAgent,
+			lookPath: func(file string) (string, error) {
+				return "", fmt.Errorf("should not be called")
+			},
+			wantErr:     true,
+			errContains: "auto-install is disabled until PI install contracts are validated",
+		},
 	}
 
 	for _, tt := range tests {
@@ -498,6 +517,9 @@ func TestValidateAgentInstallPreflight(t *testing.T) {
 
 			if tt.name == "kimi on unsupported platform returns unsupported error before uv lookup" && calls != 0 {
 				t.Fatalf("ValidateAgentInstallPreflight() called uv lookup %d times on unsupported platform, want 0", calls)
+			}
+			if tt.name == "pi preflight returns compatibility gate error without uv lookup" && calls != 0 {
+				t.Fatalf("ValidateAgentInstallPreflight() called lookup %d times for PI compatibility gate, want 0", calls)
 			}
 		})
 	}

--- a/internal/model/selection.go
+++ b/internal/model/selection.go
@@ -10,6 +10,7 @@ type Selection struct {
 	SDDProfileStrategy     SDDProfileStrategyID
 	StrictTDD              bool
 	ModelAssignments       map[string]ModelAssignment  // key = sub-agent name (e.g., "sdd-init")
+	PIModelAssignments     map[string]ModelAssignment  // key = sub-agent name (e.g., "sdd-init") for PI agent
 	ClaudeModelAssignments map[string]ClaudeModelAlias // key = phase name; value = opus|sonnet|haiku
 	KiroModelAssignments   map[string]ClaudeModelAlias // key = phase name; value = opus|sonnet|haiku (Kiro-only)
 	Profiles               []Profile                   // named SDD profiles to generate/update during sync
@@ -44,6 +45,7 @@ func (s Selection) HasComponent(component ComponentID) bool {
 // A non-nil but empty map means "reset to defaults" (explicit clear).
 type SyncOverrides struct {
 	ModelAssignments       map[string]ModelAssignment  // nil = no override; empty map = reset to defaults
+	PIModelAssignments     map[string]ModelAssignment  // nil = no override; empty map = reset to defaults
 	ClaudeModelAssignments map[string]ClaudeModelAlias // nil = no override; empty map = reset to defaults
 	KiroModelAssignments   map[string]ClaudeModelAlias // nil = no override; empty map = reset to defaults
 	SDDMode                SDDModeID                   // "" = no override; when non-empty, overrides the sync's default SDD mode

--- a/internal/model/selection_test.go
+++ b/internal/model/selection_test.go
@@ -1,6 +1,9 @@
 package model
 
-import "testing"
+import (
+	"encoding/json"
+	"testing"
+)
 
 // TestSelectionHasStrictTDDField verifies that the Selection struct has a
 // StrictTDD bool field.
@@ -36,5 +39,39 @@ func TestSyncOverridesHasStrictTDDPointer(t *testing.T) {
 	o.StrictTDD = &disabled
 	if o.StrictTDD == nil || *o.StrictTDD {
 		t.Fatal("SyncOverrides.StrictTDD pointer set to false but read back incorrectly")
+	}
+}
+
+func TestSelectionHasPiCodingAgentInAgentList(t *testing.T) {
+	s := Selection{Agents: []AgentID{AgentPiCodingAgent, AgentOpenCode}}
+
+	if !s.HasAgent(AgentPiCodingAgent) {
+		t.Fatal("Selection.HasAgent(AgentPiCodingAgent) = false, want true")
+	}
+
+	if s.HasAgent(AgentClaudeCode) {
+		t.Fatal("Selection.HasAgent(AgentClaudeCode) = true, want false")
+	}
+}
+
+func TestSelectionPiCodingAgentJSONRoundTrip(t *testing.T) {
+	original := Selection{Agents: []AgentID{AgentPiCodingAgent}}
+
+	raw, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+
+	decoded := Selection{}
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+
+	if len(decoded.Agents) != 1 {
+		t.Fatalf("decoded agents length = %d, want 1", len(decoded.Agents))
+	}
+
+	if decoded.Agents[0] != AgentPiCodingAgent {
+		t.Fatalf("decoded agent = %q, want %q", decoded.Agents[0], AgentPiCodingAgent)
 	}
 }

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -5,6 +5,7 @@ type AgentID string
 const (
 	AgentClaudeCode    AgentID = "claude-code"
 	AgentOpenCode      AgentID = "opencode"
+	AgentPiCodingAgent AgentID = "pi-coding-agent"
 	AgentKilocode      AgentID = "kilocode"
 	AgentGeminiCLI     AgentID = "gemini-cli"
 	AgentCursor        AgentID = "cursor"

--- a/internal/modelcatalog/types.go
+++ b/internal/modelcatalog/types.go
@@ -1,0 +1,33 @@
+package modelcatalog
+
+// ModelCost contains per-million-token pricing metadata.
+type ModelCost struct {
+	Input      float64
+	Output     float64
+	CacheRead  float64
+	CacheWrite float64
+}
+
+// Model represents a model entry from any picker source.
+type Model struct {
+	ID            string
+	Name          string
+	Reasoning     bool
+	ContextWindow int
+	MaxTokens     int
+	Cost          ModelCost
+}
+
+// Provider represents a provider and its models.
+type Provider struct {
+	ID     string
+	Name   string
+	Models map[string]Model
+}
+
+// Catalog is the normalized model picker catalog independent of source.
+type Catalog struct {
+	Providers            map[string]Provider
+	AvailableProviderIDs []string
+	SDDModels            map[string][]Model
+}

--- a/internal/opencode/catalog.go
+++ b/internal/opencode/catalog.go
@@ -1,0 +1,63 @@
+package opencode
+
+import "github.com/gentleman-programming/gentle-ai/internal/modelcatalog"
+
+// LoadCatalog builds a normalized model picker catalog from OpenCode cache data.
+func LoadCatalog(cachePath string) (modelcatalog.Catalog, error) {
+	providers, err := LoadModels(cachePath)
+	if err != nil {
+		return modelcatalog.Catalog{}, err
+	}
+
+	available := DetectAvailableProviders(providers)
+	sddModels := make(map[string][]modelcatalog.Model, len(available))
+	normalizedProviders := make(map[string]modelcatalog.Provider, len(providers))
+
+	for providerID, provider := range providers {
+		normalizedModels := make(map[string]modelcatalog.Model, len(provider.Models))
+		for modelID, m := range provider.Models {
+			normalizedModels[modelID] = modelcatalog.Model{
+				ID:        m.ID,
+				Name:      m.Name,
+				Reasoning: m.Reasoning,
+				Cost: modelcatalog.ModelCost{
+					Input:  m.Cost.Input,
+					Output: m.Cost.Output,
+				},
+				ContextWindow: m.Limit.Context,
+				MaxTokens:     m.Limit.Output,
+			}
+		}
+
+		normalizedProviders[providerID] = modelcatalog.Provider{
+			ID:     providerID,
+			Name:   provider.Name,
+			Models: normalizedModels,
+		}
+	}
+
+	for _, providerID := range available {
+		filtered := FilterModelsForSDD(providers[providerID])
+		normalized := make([]modelcatalog.Model, 0, len(filtered))
+		for _, m := range filtered {
+			normalized = append(normalized, modelcatalog.Model{
+				ID:        m.ID,
+				Name:      m.Name,
+				Reasoning: m.Reasoning,
+				Cost: modelcatalog.ModelCost{
+					Input:  m.Cost.Input,
+					Output: m.Cost.Output,
+				},
+				ContextWindow: m.Limit.Context,
+				MaxTokens:     m.Limit.Output,
+			})
+		}
+		sddModels[providerID] = normalized
+	}
+
+	return modelcatalog.Catalog{
+		Providers:            normalizedProviders,
+		AvailableProviderIDs: available,
+		SDDModels:            sddModels,
+	}, nil
+}

--- a/internal/opencode/models.go
+++ b/internal/opencode/models.go
@@ -73,6 +73,20 @@ func LoadModels(cachePath string) (map[string]Provider, error) {
 		return nil, fmt.Errorf("read models cache %q: %w", cachePath, err)
 	}
 
+	// Newer OpenCode catalogs wrap providers under a top-level "providers" key.
+	// Keep backward compatibility with the legacy flat map format.
+	var wrapped struct {
+		Providers map[string]Provider `json:"providers"`
+	}
+	if err := json.Unmarshal(data, &wrapped); err == nil && len(wrapped.Providers) > 0 {
+		providers := make(map[string]Provider, len(wrapped.Providers))
+		for id, p := range wrapped.Providers {
+			p.ID = id
+			providers[id] = p
+		}
+		return providers, nil
+	}
+
 	var raw map[string]json.RawMessage
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return nil, fmt.Errorf("parse models cache: %w", err)

--- a/internal/opencode/models_test.go
+++ b/internal/opencode/models_test.go
@@ -98,12 +98,59 @@ const fixtureJSON = `{
   }
 }`
 
+const wrappedFixtureJSON = `{
+  "providers": {
+    "anthropic": {
+      "id": "anthropic",
+      "env": ["ANTHROPIC_API_KEY"],
+      "name": "Anthropic",
+      "models": {
+        "claude-sonnet-4-20250514": {
+          "id": "claude-sonnet-4-20250514",
+          "name": "Claude Sonnet 4",
+          "family": "claude",
+          "tool_call": true,
+          "reasoning": false,
+          "cost": {"input": 3.0, "output": 15.0},
+          "limit": {"context": 200000, "output": 8192}
+        }
+      }
+    },
+    "openai": {
+      "id": "openai",
+      "env": ["OPENAI_API_KEY"],
+      "name": "OpenAI",
+      "models": {
+        "gpt-4o": {
+          "id": "gpt-4o",
+          "name": "GPT-4o",
+          "family": "gpt",
+          "tool_call": true,
+          "reasoning": false,
+          "cost": {"input": 2.5, "output": 10.0},
+          "limit": {"context": 128000, "output": 4096}
+        }
+      }
+    }
+  }
+}`
+
 func writeFixture(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "models.json")
 	if err := os.WriteFile(path, []byte(fixtureJSON), 0o644); err != nil {
 		t.Fatalf("write fixture: %v", err)
+	}
+	return path
+}
+
+func writeWrappedFixture(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "models.json")
+	if err := os.WriteFile(path, []byte(wrappedFixtureJSON), 0o644); err != nil {
+		t.Fatalf("write wrapped fixture: %v", err)
 	}
 	return path
 }
@@ -147,6 +194,26 @@ func TestLoadModels(t *testing.T) {
 	}
 	if len(anthropic.Env) != 1 || anthropic.Env[0] != "ANTHROPIC_API_KEY" {
 		t.Fatalf("anthropic env = %v", anthropic.Env)
+	}
+}
+
+func TestLoadModelsWrappedProvidersCatalog(t *testing.T) {
+	path := writeWrappedFixture(t)
+
+	providers, err := LoadModels(path)
+	if err != nil {
+		t.Fatalf("LoadModels() error = %v", err)
+	}
+
+	if len(providers) != 2 {
+		t.Fatalf("provider count = %d, want 2", len(providers))
+	}
+
+	if _, ok := providers["anthropic"]; !ok {
+		t.Fatal("missing anthropic provider")
+	}
+	if _, ok := providers["openai"]; !ok {
+		t.Fatal("missing openai provider")
 	}
 }
 

--- a/internal/state/hydration.go
+++ b/internal/state/hydration.go
@@ -1,0 +1,46 @@
+package state
+
+import "github.com/gentleman-programming/gentle-ai/internal/model"
+
+// HydrateSelectionAssignments copies persisted assignment maps into selection
+// only when the current selection maps are empty and persisted maps have data.
+//
+// includePI controls whether PI assignments are in scope for hydration.
+// Callers should pass true only when PI agent and SDD component are selected.
+func HydrateSelectionAssignments(selection *model.Selection, persisted InstallState, includePI bool) {
+	if selection == nil {
+		return
+	}
+
+	if len(selection.ClaudeModelAssignments) == 0 && len(persisted.ClaudeModelAssignments) > 0 {
+		selection.ClaudeModelAssignments = claudeAssignmentsFromState(persisted.ClaudeModelAssignments)
+	}
+
+	if len(selection.KiroModelAssignments) == 0 && len(persisted.KiroModelAssignments) > 0 {
+		selection.KiroModelAssignments = claudeAssignmentsFromState(persisted.KiroModelAssignments)
+	}
+
+	if len(selection.ModelAssignments) == 0 && len(persisted.ModelAssignments) > 0 {
+		selection.ModelAssignments = modelAssignmentsFromState(persisted.ModelAssignments)
+	}
+
+	if includePI && len(selection.PIModelAssignments) == 0 && len(persisted.PIModelAssignments) > 0 {
+		selection.PIModelAssignments = modelAssignmentsFromState(persisted.PIModelAssignments)
+	}
+}
+
+func claudeAssignmentsFromState(input map[string]string) map[string]model.ClaudeModelAlias {
+	out := make(map[string]model.ClaudeModelAlias, len(input))
+	for key, value := range input {
+		out[key] = model.ClaudeModelAlias(value)
+	}
+	return out
+}
+
+func modelAssignmentsFromState(input map[string]ModelAssignmentState) map[string]model.ModelAssignment {
+	out := make(map[string]model.ModelAssignment, len(input))
+	for key, value := range input {
+		out[key] = model.ModelAssignment{ProviderID: value.ProviderID, ModelID: value.ModelID}
+	}
+	return out
+}

--- a/internal/state/hydration_test.go
+++ b/internal/state/hydration_test.go
@@ -1,0 +1,90 @@
+package state
+
+import (
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/internal/model"
+)
+
+func TestHydrateSelectionAssignmentsOpenCodeHydratesNilOrEmpty(t *testing.T) {
+	persisted := InstallState{
+		ModelAssignments: map[string]ModelAssignmentState{
+			"sdd-apply": {ProviderID: "anthropic", ModelID: "claude-sonnet-4"},
+		},
+	}
+
+	t.Run("nil map", func(t *testing.T) {
+		selection := model.Selection{}
+		HydrateSelectionAssignments(&selection, persisted, false)
+
+		got := selection.ModelAssignments["sdd-apply"]
+		if got.ProviderID != "anthropic" || got.ModelID != "claude-sonnet-4" {
+			t.Fatalf("ModelAssignments[sdd-apply] = %+v, want anthropic/claude-sonnet-4", got)
+		}
+	})
+
+	t.Run("empty but non-nil map", func(t *testing.T) {
+		selection := model.Selection{ModelAssignments: map[string]model.ModelAssignment{}}
+		HydrateSelectionAssignments(&selection, persisted, false)
+
+		got := selection.ModelAssignments["sdd-apply"]
+		if got.ProviderID != "anthropic" || got.ModelID != "claude-sonnet-4" {
+			t.Fatalf("ModelAssignments[sdd-apply] = %+v, want anthropic/claude-sonnet-4", got)
+		}
+	})
+}
+
+func TestHydrateSelectionAssignmentsDoesNotOverwriteNonEmptyMaps(t *testing.T) {
+	selection := model.Selection{
+		ModelAssignments: map[string]model.ModelAssignment{
+			"sdd-apply": {ProviderID: "openai", ModelID: "gpt-5"},
+		},
+		ClaudeModelAssignments: map[string]model.ClaudeModelAlias{
+			"orchestrator": model.ClaudeModelOpus,
+		},
+	}
+
+	persisted := InstallState{
+		ModelAssignments: map[string]ModelAssignmentState{
+			"sdd-apply": {ProviderID: "anthropic", ModelID: "claude-sonnet-4"},
+		},
+		ClaudeModelAssignments: map[string]string{
+			"orchestrator": "haiku",
+		},
+	}
+
+	HydrateSelectionAssignments(&selection, persisted, false)
+
+	gotModel := selection.ModelAssignments["sdd-apply"]
+	if gotModel.ProviderID != "openai" || gotModel.ModelID != "gpt-5" {
+		t.Fatalf("ModelAssignments[sdd-apply] overwritten = %+v, want openai/gpt-5", gotModel)
+	}
+	if gotClaude := selection.ClaudeModelAssignments["orchestrator"]; gotClaude != model.ClaudeModelOpus {
+		t.Fatalf("ClaudeModelAssignments[orchestrator] overwritten = %q, want %q", gotClaude, model.ClaudeModelOpus)
+	}
+}
+
+func TestHydrateSelectionAssignmentsPIGatedByScope(t *testing.T) {
+	persisted := InstallState{
+		PIModelAssignments: map[string]ModelAssignmentState{
+			"sdd-apply": {ProviderID: "openai", ModelID: "gpt-5-mini"},
+		},
+	}
+
+	t.Run("out of scope", func(t *testing.T) {
+		selection := model.Selection{}
+		HydrateSelectionAssignments(&selection, persisted, false)
+		if len(selection.PIModelAssignments) != 0 {
+			t.Fatalf("PIModelAssignments hydrated out of scope: %+v", selection.PIModelAssignments)
+		}
+	})
+
+	t.Run("in scope", func(t *testing.T) {
+		selection := model.Selection{}
+		HydrateSelectionAssignments(&selection, persisted, true)
+		got := selection.PIModelAssignments["sdd-apply"]
+		if got.ProviderID != "openai" || got.ModelID != "gpt-5-mini" {
+			t.Fatalf("PIModelAssignments[sdd-apply] = %+v, want openai/gpt-5-mini", got)
+		}
+	})
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -33,7 +33,12 @@ type InstallState struct {
 	KiroModelAssignments map[string]string `json:"kiro_model_assignments,omitempty"`
 
 	// ModelAssignments maps sub-agent names to provider/model pairs (OpenCode).
-	ModelAssignments map[string]ModelAssignmentState `json:"model_assignments,omitempty"`
+	ModelAssignments map[string]ModelAssignmentState `json:"model_assignments"`
+
+	// PIModelAssignments maps sub-agent names to provider/model pairs used for
+	// PI-generated .pi/agents artifacts. Persisted independently so PI choices do
+	// not overwrite OpenCode assignments and vice versa.
+	PIModelAssignments map[string]ModelAssignmentState `json:"pi_model_assignments"`
 }
 
 // Path returns the absolute path to the state file for the given home directory.

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -1,6 +1,7 @@
 package state
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -144,6 +145,9 @@ func TestModelAssignmentsRoundTrip(t *testing.T) {
 		ModelAssignments: map[string]ModelAssignmentState{
 			"sdd-init": {ProviderID: "anthropic", ModelID: "claude-sonnet-4"},
 		},
+		PIModelAssignments: map[string]ModelAssignmentState{
+			"sdd-apply": {ProviderID: "openai", ModelID: "gpt-5"},
+		},
 	}
 
 	if err := Write(home, want); err != nil {
@@ -163,6 +167,59 @@ func TestModelAssignmentsRoundTrip(t *testing.T) {
 	}
 	if !reflect.DeepEqual(got.ModelAssignments, want.ModelAssignments) {
 		t.Errorf("ModelAssignments = %v, want %v", got.ModelAssignments, want.ModelAssignments)
+	}
+	if !reflect.DeepEqual(got.PIModelAssignments, want.PIModelAssignments) {
+		t.Errorf("PIModelAssignments = %v, want %v", got.PIModelAssignments, want.PIModelAssignments)
+	}
+}
+
+func TestStateJSONPersistsPIAssignmentsUnderCanonicalKey(t *testing.T) {
+	home := t.TempDir()
+
+	st := InstallState{
+		InstalledAgents: []string{"pi-coding-agent"},
+		PIModelAssignments: map[string]ModelAssignmentState{
+			"sdd-apply": {ProviderID: "openai", ModelID: "gpt-5"},
+		},
+	}
+
+	if err := Write(home, st); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+
+	raw, err := os.ReadFile(Path(home))
+	if err != nil {
+		t.Fatalf("ReadFile(state.json) error = %v", err)
+	}
+
+	if !bytes.Contains(raw, []byte(`"pi_model_assignments"`)) {
+		t.Fatalf("state.json should persist PI assignments under \"pi_model_assignments\", got:\n%s", string(raw))
+	}
+}
+
+func TestStateJSONPersistsExplicitEmptyAssignmentMaps(t *testing.T) {
+	home := t.TempDir()
+
+	st := InstallState{
+		InstalledAgents:     []string{"opencode"},
+		ModelAssignments:    map[string]ModelAssignmentState{},
+		PIModelAssignments:  map[string]ModelAssignmentState{},
+	}
+
+	if err := Write(home, st); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+
+	raw, err := os.ReadFile(Path(home))
+	if err != nil {
+		t.Fatalf("ReadFile(state.json) error = %v", err)
+	}
+
+	if !bytes.Contains(raw, []byte(`"model_assignments": {}`)) {
+		t.Fatalf("state.json should persist explicit empty model_assignments map, got:\n%s", string(raw))
+	}
+	if !bytes.Contains(raw, []byte(`"pi_model_assignments": {}`)) {
+		t.Fatalf("state.json should persist explicit empty pi_model_assignments map, got:\n%s", string(raw))
 	}
 }
 

--- a/internal/system/config_scan.go
+++ b/internal/system/config_scan.go
@@ -3,6 +3,7 @@ package system
 import (
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 // ConfigState records the filesystem presence of an agent's global config directory.
@@ -31,6 +32,7 @@ func knownAgentConfigDirs(homeDir string) []ConfigState {
 	return []ConfigState{
 		{Agent: "claude-code", Path: filepath.Join(homeDir, ".claude")},
 		{Agent: "opencode", Path: filepath.Join(homeDir, ".config", "opencode")},
+		piConfigState(homeDir),
 		{Agent: "kilocode", Path: filepath.Join(homeDir, ".config", "kilo")},
 		{Agent: "gemini-cli", Path: filepath.Join(homeDir, ".gemini")},
 		{Agent: "cursor", Path: filepath.Join(homeDir, ".cursor")},
@@ -42,6 +44,34 @@ func knownAgentConfigDirs(homeDir string) []ConfigState {
 		{Agent: "qwen-code", Path: filepath.Join(homeDir, ".qwen")},
 		{Agent: "kiro-ide", Path: filepath.Join(homeDir, ".kiro")},
 	}
+}
+
+func piConfigState(homeDir string) ConfigState {
+	piRoot, piLegacy := resolvePiPaths(homeDir)
+	state := ConfigState{Agent: "pi-coding-agent", Path: piRoot}
+
+	for _, candidate := range []string{piRoot, piLegacy} {
+		info, err := os.Stat(candidate)
+		if err != nil {
+			continue
+		}
+
+		state.Exists = true
+		state.IsDirectory = info.IsDir()
+		return state
+	}
+
+	return state
+}
+
+func resolvePiPaths(homeDir string) (root string, legacy string) {
+	root = strings.TrimSpace(os.Getenv("PI_CODING_AGENT_DIR"))
+	if root == "" {
+		root = filepath.Join(homeDir, ".pi", "agent")
+	}
+
+	legacy = filepath.Join(homeDir, ".config", "pi-coding-agent")
+	return root, legacy
 }
 
 // vscodeCopilotGlobalConfigDir returns ~/.copilot, the GlobalConfigDir used by
@@ -60,6 +90,10 @@ func ScanConfigs(homeDir string) []ConfigState {
 	states := knownAgentConfigDirs(homeDir)
 
 	for idx := range states {
+		if states[idx].Agent == "pi-coding-agent" && states[idx].Exists {
+			continue
+		}
+
 		info, err := os.Stat(states[idx].Path)
 		if err != nil {
 			continue

--- a/internal/system/config_scan_test.go
+++ b/internal/system/config_scan_test.go
@@ -25,9 +25,9 @@ func TestScanConfigs_ReturnsAllKnownAgentsWithExistsFlag(t *testing.T) {
 	configs := ScanConfigs(home)
 
 	// Must return at least as many entries as the registry has adapters with
-	// a non-empty GlobalConfigDir. Currently 12 agents are supported.
-	if len(configs) < 12 {
-		t.Fatalf("ScanConfigs() returned %d entries, want >= 12; got %v", len(configs), configs)
+	// a non-empty GlobalConfigDir. PI support adds a 13th managed agent.
+	if len(configs) < 13 {
+		t.Fatalf("ScanConfigs() returned %d entries, want >= 13; got %v", len(configs), configs)
 	}
 
 
@@ -82,6 +82,7 @@ func TestScanConfigs_AgentFieldMatchesModelAgentID(t *testing.T) {
 		"kimi":           false,
 		"qwen-code":      false,
 		"kiro-ide":       false,
+		"pi-coding-agent": false,
 	}
 
 
@@ -132,8 +133,8 @@ func TestScanConfigs_ExistsFalseWhenDirAbsent(t *testing.T) {
 func TestScanConfigs_IsDirectorySetForExistingDirs(t *testing.T) {
 	home := t.TempDir()
 
-	// Create two agent dirs.
-	for _, rel := range []string{".claude", ".config/opencode"} {
+	// Create three agent dirs.
+	for _, rel := range []string{".claude", ".config/opencode", ".pi/agent"} {
 		if err := os.MkdirAll(filepath.Join(home, rel), 0o755); err != nil {
 			t.Fatalf("MkdirAll(%q): %v", rel, err)
 		}
@@ -141,7 +142,7 @@ func TestScanConfigs_IsDirectorySetForExistingDirs(t *testing.T) {
 
 	configs := ScanConfigs(home)
 
-	claudeFound, opencodeFound := false, false
+	claudeFound, opencodeFound, piFound := false, false, false
 	for _, c := range configs {
 		switch c.Agent {
 		case "claude-code":
@@ -154,6 +155,11 @@ func TestScanConfigs_IsDirectorySetForExistingDirs(t *testing.T) {
 			if !c.Exists || !c.IsDirectory {
 				t.Errorf("opencode: Exists=%v IsDirectory=%v, want both true", c.Exists, c.IsDirectory)
 			}
+		case "pi-coding-agent":
+			piFound = true
+			if !c.Exists || !c.IsDirectory {
+				t.Errorf("pi-coding-agent: Exists=%v IsDirectory=%v, want both true", c.Exists, c.IsDirectory)
+			}
 		}
 	}
 
@@ -163,6 +169,37 @@ func TestScanConfigs_IsDirectorySetForExistingDirs(t *testing.T) {
 	if !opencodeFound {
 		t.Error("ScanConfigs() missing opencode entry")
 	}
+	if !piFound {
+		t.Error("ScanConfigs() missing pi-coding-agent entry")
+	}
+}
+
+func TestScanConfigs_PILegacyPathMarksCurrentEntryAsPresent(t *testing.T) {
+	home := t.TempDir()
+	legacyPath := filepath.Join(home, ".config", "pi-coding-agent")
+	if err := os.MkdirAll(legacyPath, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q): %v", legacyPath, err)
+	}
+
+	configs := ScanConfigs(home)
+
+	for _, c := range configs {
+		if c.Agent != "pi-coding-agent" {
+			continue
+		}
+
+		if c.Path != filepath.Join(home, ".pi", "agent") {
+			t.Fatalf("pi-coding-agent path = %q, want %q", c.Path, filepath.Join(home, ".pi", "agent"))
+		}
+
+		if !c.Exists || !c.IsDirectory {
+			t.Fatalf("pi-coding-agent legacy compatibility not honored: Exists=%v IsDirectory=%v", c.Exists, c.IsDirectory)
+		}
+
+		return
+	}
+
+	t.Fatal("ScanConfigs() missing pi-coding-agent entry")
 }
 
 // agentNames extracts agent name strings for error messages.

--- a/internal/testutil/golden.go
+++ b/internal/testutil/golden.go
@@ -1,0 +1,50 @@
+package testutil
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+)
+
+func AssertJSONGolden(t *testing.T, actual []byte, goldenPath string) {
+	t.Helper()
+
+	var actualObj any
+	if err := json.Unmarshal(actual, &actualObj); err != nil {
+		t.Fatalf("actual JSON unmarshal error: %v\n%s", err, string(actual))
+	}
+	normalizedActual, err := json.MarshalIndent(actualObj, "", "  ")
+	if err != nil {
+		t.Fatalf("actual JSON marshal error: %v", err)
+	}
+
+	goldenRaw, err := os.ReadFile(goldenPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", goldenPath, err)
+	}
+	var goldenObj any
+	if err := json.Unmarshal(goldenRaw, &goldenObj); err != nil {
+		t.Fatalf("golden JSON unmarshal error: %v\n%s", err, string(goldenRaw))
+	}
+	normalizedGolden, err := json.MarshalIndent(goldenObj, "", "  ")
+	if err != nil {
+		t.Fatalf("golden JSON marshal error: %v", err)
+	}
+
+	if string(normalizedActual) != string(normalizedGolden) {
+		t.Fatalf("JSON mismatch with golden %s\nactual:\n%s\n\nexpected:\n%s", goldenPath, string(normalizedActual), string(normalizedGolden))
+	}
+}
+
+func AssertTextGolden(t *testing.T, actual string, goldenPath string) {
+	t.Helper()
+
+	goldenRaw, err := os.ReadFile(goldenPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", goldenPath, err)
+	}
+
+	if actual != string(goldenRaw) {
+		t.Fatalf("text mismatch with golden %s\nactual:\n%s\n\nexpected:\n%s", goldenPath, actual, string(goldenRaw))
+	}
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -6,22 +6,28 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/charmbracelet/bubbles/textarea"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/gentleman-programming/gentle-ai/internal/agentbuilder"
+	"github.com/gentleman-programming/gentle-ai/internal/agents/capabilities"
+	"github.com/gentleman-programming/gentle-ai/internal/agents/pi"
 	"github.com/gentleman-programming/gentle-ai/internal/backup"
 	"github.com/gentleman-programming/gentle-ai/internal/catalog"
 	"github.com/gentleman-programming/gentle-ai/internal/components/opencodeplugin"
 	"github.com/gentleman-programming/gentle-ai/internal/components/sdd"
 	componentuninstall "github.com/gentleman-programming/gentle-ai/internal/components/uninstall"
 	"github.com/gentleman-programming/gentle-ai/internal/model"
+	"github.com/gentleman-programming/gentle-ai/internal/modelcatalog"
 	"github.com/gentleman-programming/gentle-ai/internal/opencode"
 	"github.com/gentleman-programming/gentle-ai/internal/pipeline"
 	"github.com/gentleman-programming/gentle-ai/internal/planner"
+	"github.com/gentleman-programming/gentle-ai/internal/state"
 	"github.com/gentleman-programming/gentle-ai/internal/system"
 	"github.com/gentleman-programming/gentle-ai/internal/tui/screens"
 	"github.com/gentleman-programming/gentle-ai/internal/update"
@@ -33,15 +39,60 @@ import (
 var osStatModelCache = os.Stat
 var osStatPathFn = os.Stat
 var osGetwdFn = os.Getwd
+var osUserHomeDirFn = os.UserHomeDir
 var osExecutableFn = os.Executable
 var osRemoveFn = os.Remove
+var resolveAgentCapabilitiesFn = func(homeDir string, workspaceDir string, agentID model.AgentID) (capabilities.ResolvedCapabilities, error) {
+	return capabilities.NewResolver(nil).Resolve(homeDir, workspaceDir, agentID)
+}
 var execCommandFn = exec.Command
+var loadPIModelCatalogFn = func(ctx context.Context) (modelcatalog.Catalog, error) {
+	return pi.LoadModelCatalogRPC(ctx, nil)
+}
+
+type cachedAgentCapabilities struct {
+	homeDir      string
+	workspaceDir string
+	resolverPtr  uintptr
+	resolved     capabilities.ResolvedCapabilities
+}
+
+var agentCapabilitiesCache = map[model.AgentID]cachedAgentCapabilities{}
+var agentCapabilitiesCacheMu sync.Mutex
+
+func clearAgentCapabilitiesCache() {
+	agentCapabilitiesCacheMu.Lock()
+	defer agentCapabilitiesCacheMu.Unlock()
+	agentCapabilitiesCache = map[model.AgentID]cachedAgentCapabilities{}
+}
 
 // readCurrentAssignmentsFn is a package-level variable so tests can override
 // how current model assignments are read from opencode.json. It wraps
 // sdd.ReadCurrentModelAssignments and is only called during ModelConfigMode.
 var readCurrentAssignmentsFn = func(settingsPath string) (map[string]model.ModelAssignment, error) {
 	return sdd.ReadCurrentModelAssignments(settingsPath)
+}
+
+// readPersistedPIAssignmentsFn is a package-level variable so tests can
+// override how persisted PI model assignments are read from state.json.
+var readPersistedPIAssignmentsFn = func(homeDir string) (map[string]model.ModelAssignment, error) {
+	s, err := state.Read(homeDir)
+	if err != nil {
+		return nil, err
+	}
+	if len(s.PIModelAssignments) == 0 {
+		return nil, nil
+	}
+
+	assignments := make(map[string]model.ModelAssignment, len(s.PIModelAssignments))
+	for phase, assignment := range s.PIModelAssignments {
+		assignments[phase] = model.ModelAssignment{
+			ProviderID: assignment.ProviderID,
+			ModelID:    assignment.ModelID,
+		}
+	}
+
+	return assignments, nil
 }
 
 // readProfilesFn is a package-level variable so tests can override how profiles
@@ -688,7 +739,7 @@ func (m Model) View() string {
 	case ScreenSync:
 		return screens.RenderSync(m.SyncFilesChanged, m.SyncErr, m.OperationRunning, m.HasSyncRun, m.SpinnerFrame)
 	case ScreenModelConfig:
-		return screens.RenderModelConfig(m.Cursor)
+		return screens.RenderModelConfigWithCapabilities(m.Cursor, m.shouldShowPIModelConfigOption(), m.modelConfigCapabilityWarning())
 	case ScreenProfiles:
 		return screens.RenderProfiles(m.ProfileList, m.Cursor, m.ProfileDeleteErr)
 	case ScreenProfileCreate:
@@ -722,7 +773,7 @@ func (m Model) View() string {
 	case ScreenDetection:
 		return screens.RenderDetection(m.Detection, m.Cursor)
 	case ScreenAgents:
-		return screens.RenderAgents(m.Selection.Agents, m.Cursor)
+		return screens.RenderAgents(m.Selection.Agents, m.Cursor, m.agentSelectionWarnings())
 	case ScreenPersona:
 		return screens.RenderPersona(m.Selection.Persona, m.Cursor)
 	case ScreenPreset:
@@ -740,7 +791,7 @@ func (m Model) View() string {
 	case ScreenOpenCodePluginResult:
 		return screens.RenderOpenCodePluginResult(m.OpenCodePluginRegistrationResults, m.OpenCodePluginRegistrationErr)
 	case ScreenModelPicker:
-		return screens.RenderModelPicker(m.Selection.ModelAssignments, m.ModelPicker, m.Cursor)
+		return screens.RenderModelPicker(m.modelPickerAssignments(), m.ModelPicker, m.Cursor)
 	case ScreenDependencyTree:
 		return screens.RenderDependencyTree(m.DependencyPlan, m.Selection, m.Cursor)
 	case ScreenSkillPicker:
@@ -800,9 +851,9 @@ func (m Model) handleKeyPress(key tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	// When the model picker is in a sub-mode, delegate navigation there first.
 	if m.Screen == ScreenModelPicker && m.ModelPicker.Mode != screens.ModePhaseList {
-		handled, updated := screens.HandleModelPickerNav(keyStr, &m.ModelPicker, m.Selection.ModelAssignments)
+		handled, updated := screens.HandleModelPickerNav(keyStr, &m.ModelPicker, m.modelPickerAssignments())
 		if handled {
-			m.Selection.ModelAssignments = updated
+			m.setModelPickerAssignments(updated)
 			return m, nil
 		}
 	}
@@ -1378,19 +1429,20 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 	case ScreenModelConfig:
-		switch m.Cursor {
-		case 0: // Configure Claude models
+		options := screens.ModelConfigOptionsForCapabilities(m.shouldShowPIModelConfigOption())
+		if m.Cursor >= len(options)-1 {
+			m.setScreen(ScreenWelcome)
+			return m, nil
+		}
+
+		switch options[m.Cursor] {
+		case screens.ModelConfigOptionClaude:
 			m.ModelConfigMode = true
 			m.ClaudeModelPicker = screens.NewClaudeModelPickerState()
 			m.setScreen(ScreenClaudeModelPicker)
-		case 1: // Configure OpenCode models
+		case screens.ModelConfigOptionOpenCode:
 			m.ModelConfigMode = true
-			cachePath := opencode.DefaultCachePath()
-			if _, err := osStatModelCache(cachePath); err == nil {
-				m.ModelPicker = screens.NewModelPickerState(cachePath)
-			} else {
-				m.ModelPicker = screens.ModelPickerState{}
-			}
+			m.initOpenCodeModelPicker()
 			// Pre-populate with existing assignments from opencode.json.
 			// Only when there are no in-session assignments yet — the nil guard
 			// ensures we don't overwrite changes the user already made this session.
@@ -1401,11 +1453,19 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 				}
 			}
 			m.setScreen(ScreenModelPicker)
-		case 2: // Configure Kiro models
+		case screens.ModelConfigOptionKiro:
 			m.ModelConfigMode = true
 			m.KiroModelPicker = screens.NewKiroModelPickerState()
 			m.setScreen(ScreenKiroModelPicker)
-		default: // Back
+		case screens.ModelConfigOptionPI:
+			m.ModelConfigMode = true
+			if m.piSupportsModelPicker() {
+				m.initPIModelPicker()
+			} else {
+				m.setBlockedPIModelPicker(capabilities.PiMultiModelRequiresPiSubagentsMessage)
+			}
+			m.setScreen(ScreenModelPicker)
+		default:
 			m.setScreen(ScreenWelcome)
 		}
 		return m, nil
@@ -1502,22 +1562,16 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 		if m.Cursor < len(options) {
 			m.Selection.SDDMode = options[m.Cursor]
 			if m.Selection.SDDMode == model.SDDModeMulti {
-				cachePath := opencode.DefaultCachePath()
-				if _, err := osStatModelCache(cachePath); err == nil {
-					// Cache exists — OpenCode has been run at least once.
-					// Show the model picker so the user can assign models.
-					m.ModelPicker = screens.NewModelPickerState(cachePath)
+				if m.initSDDModelPicker() {
 					m.Selection.ModelAssignments = nil
+					m.Selection.PIModelAssignments = nil
 					m.setScreen(ScreenModelPicker)
 					return m, nil
 				}
-				// Cache missing — OpenCode hasn't been run yet on this machine.
-				// Skip the model picker; models will use OpenCode defaults.
-				// The picker empty-state message explains what to do after install.
-				m.ModelPicker = screens.ModelPickerState{}
 			}
 			// Clear assignments for both single mode and multi-no-cache paths.
 			m.Selection.ModelAssignments = nil
+			m.Selection.PIModelAssignments = nil
 			// Show StrictTDD screen when OpenCode + SDD are selected.
 			// This is the next step before the dependency tree.
 			if m.shouldShowSDDModeScreen() {
@@ -1586,12 +1640,21 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 			// In ModelConfigMode, persist model assignments via sync.
 			if m.ModelConfigMode {
 				m.ModelConfigMode = false
-				m.PendingSyncOverrides = &model.SyncOverrides{
-					ModelAssignments: m.Selection.ModelAssignments,
-					SDDMode:          model.SDDModeMulti,
+				overrides := &model.SyncOverrides{SDDMode: model.SDDModeMulti}
+				if m.ModelPicker.Source == "pi" {
+					overrides.PIModelAssignments = m.Selection.PIModelAssignments
+				} else {
+					overrides.ModelAssignments = m.Selection.ModelAssignments
 				}
+				m.PendingSyncOverrides = overrides
 				m = m.withResetSyncState()
 				m.setScreen(ScreenSync)
+				return m, nil
+			}
+			if m.shouldRunPIModelPickerAfterOpenCode() {
+				m.initPIModelPicker()
+				m.Cursor = 0
+				m.ModelPicker.Mode = screens.ModePhaseList
 				return m, nil
 			}
 			if m.Selection.Preset == model.PresetCustom {
@@ -1658,12 +1721,9 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 		// Back — depends on which flow brought us here.
 		if m.shouldShowSDDModeScreen() {
 			// OpenCode path: ModelPicker (if multi + cache) or SDDMode.
-			if m.Selection.SDDMode == model.SDDModeMulti {
-				cachePath := opencode.DefaultCachePath()
-				if _, err := osStatModelCache(cachePath); err == nil {
-					m.setScreen(ScreenModelPicker)
-					return m, nil
-				}
+			if m.canNavigateBackToModelPicker() {
+				m.setScreen(ScreenModelPicker)
+				return m, nil
 			}
 			m.setScreen(ScreenSDDMode)
 		} else if m.shouldShowClaudeModelPickerScreen() {
@@ -1734,13 +1794,8 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 			// StrictTDD screen is between ModelPicker/SDDMode and DependencyTree.
 			m.setScreen(ScreenStrictTDD)
 		} else if m.shouldShowSDDModeScreen() {
-			if m.Selection.SDDMode == model.SDDModeMulti {
-				cachePath := opencode.DefaultCachePath()
-				if _, err := osStatModelCache(cachePath); err == nil {
-					m.setScreen(ScreenModelPicker)
-				} else {
-					m.setScreen(ScreenSDDMode)
-				}
+			if m.canNavigateBackToModelPicker() {
+				m.setScreen(ScreenModelPicker)
 			} else {
 				m.setScreen(ScreenSDDMode)
 			}
@@ -1766,13 +1821,8 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 				if m.shouldShowStrictTDDScreen() {
 					m.setScreen(ScreenStrictTDD)
 				} else if m.shouldShowSDDModeScreen() {
-					if m.Selection.SDDMode == model.SDDModeMulti {
-						cachePath := opencode.DefaultCachePath()
-						if _, err := osStatModelCache(cachePath); err == nil {
-							m.setScreen(ScreenModelPicker)
-						} else {
-							m.setScreen(ScreenSDDMode)
-						}
+					if m.canNavigateBackToModelPicker() {
+						m.setScreen(ScreenModelPicker)
 					} else {
 						m.setScreen(ScreenSDDMode)
 					}
@@ -1799,13 +1849,8 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 			} else if m.shouldShowStrictTDDScreen() {
 				m.setScreen(ScreenStrictTDD)
 			} else if m.shouldShowSDDModeScreen() {
-				if m.Selection.SDDMode == model.SDDModeMulti {
-					cachePath := opencode.DefaultCachePath()
-					if _, err := osStatModelCache(cachePath); err == nil {
-						m.setScreen(ScreenModelPicker)
-					} else {
-						m.setScreen(ScreenSDDMode)
-					}
+				if m.canNavigateBackToModelPicker() {
+					m.setScreen(ScreenModelPicker)
 				} else {
 					m.setScreen(ScreenSDDMode)
 				}
@@ -2333,13 +2378,8 @@ func (m Model) goBack() Model {
 			if m.shouldShowStrictTDDScreen() {
 				m.setScreen(ScreenStrictTDD)
 			} else if m.shouldShowSDDModeScreen() {
-				if m.Selection.SDDMode == model.SDDModeMulti {
-					cachePath := opencode.DefaultCachePath()
-					if _, err := osStatModelCache(cachePath); err == nil {
-						m.setScreen(ScreenModelPicker)
-					} else {
-						m.setScreen(ScreenSDDMode)
-					}
+				if m.canNavigateBackToModelPicker() {
+					m.setScreen(ScreenModelPicker)
 				} else {
 					m.setScreen(ScreenSDDMode)
 				}
@@ -2385,12 +2425,9 @@ func (m Model) goBack() Model {
 	if m.Screen == ScreenStrictTDD {
 		if m.shouldShowSDDModeScreen() {
 			// OpenCode path: ModelPicker (if multi + cache) or SDDMode.
-			if m.Selection.SDDMode == model.SDDModeMulti {
-				cachePath := opencode.DefaultCachePath()
-				if _, err := osStatModelCache(cachePath); err == nil {
-					m.setScreen(ScreenModelPicker)
-					return m
-				}
+			if m.canNavigateBackToModelPicker() {
+				m.setScreen(ScreenModelPicker)
+				return m
 			}
 			m.setScreen(ScreenSDDMode)
 			return m
@@ -2483,13 +2520,8 @@ func (m Model) goBack() Model {
 			return m
 		}
 		if m.shouldShowSDDModeScreen() {
-			if m.Selection.SDDMode == model.SDDModeMulti {
-				cachePath := opencode.DefaultCachePath()
-				if _, err := osStatModelCache(cachePath); err == nil {
-					m.setScreen(ScreenModelPicker)
-				} else {
-					m.setScreen(ScreenSDDMode)
-				}
+			if m.canNavigateBackToModelPicker() {
+				m.setScreen(ScreenModelPicker)
 			} else {
 				m.setScreen(ScreenSDDMode)
 			}
@@ -2615,7 +2647,7 @@ func (m Model) optionCount() int {
 	case ScreenUpgradeSync:
 		return 1
 	case ScreenModelConfig:
-		return len(screens.ModelConfigOptions())
+		return len(screens.ModelConfigOptionsForCapabilities(m.shouldShowPIModelConfigOption()))
 	case ScreenUninstallMode:
 		return len(screens.UninstallModeOptions()) + 1
 	case ScreenUninstall:
@@ -3023,6 +3055,8 @@ func preselectedAgents(detection system.DetectionResult) []model.AgentID {
 			selected = append(selected, model.AgentVSCodeCopilot)
 		case string(model.AgentCodex):
 			selected = append(selected, model.AgentCodex)
+		case string(model.AgentPiCodingAgent):
+			selected = append(selected, model.AgentPiCodingAgent)
 		case string(model.AgentAntigravity):
 			selected = append(selected, model.AgentAntigravity)
 		case string(model.AgentWindsurf):
@@ -3111,9 +3145,235 @@ func (m Model) hasDetectedOpenCode() bool {
 	return false
 }
 
+func (m Model) agentSelectionWarnings() []string {
+	if m.Selection.HasAgent(model.AgentPiCodingAgent) {
+		return []string{"PI is experimental and non-parity: multi-model is enabled only when `pi-subagents` is installed."}
+	}
+	return nil
+}
+
 func (m Model) shouldShowSDDModeScreen() bool {
-	return m.Selection.HasAgent(model.AgentOpenCode) &&
-		hasSelectedComponent(m.Selection.Components, model.ComponentSDD)
+	if !hasSelectedComponent(m.Selection.Components, model.ComponentSDD) {
+		return false
+	}
+
+	for _, agentID := range m.Selection.Agents {
+		caps := m.resolveAgentCapabilities(agentID)
+		if caps.SupportsSDDMultiMode {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (m Model) resolveAgentCapabilities(agentID model.AgentID) capabilities.ResolvedCapabilities {
+	resolverPtr := reflect.ValueOf(resolveAgentCapabilitiesFn).Pointer()
+
+	homeDir, err := osUserHomeDirFn()
+	if err != nil {
+		homeDir = ""
+	}
+
+	workspaceDir, err := osGetwdFn()
+	if err != nil {
+		workspaceDir = ""
+	}
+
+	agentCapabilitiesCacheMu.Lock()
+	if cached, ok := agentCapabilitiesCache[agentID]; ok && cached.homeDir == homeDir && cached.workspaceDir == workspaceDir && cached.resolverPtr == resolverPtr {
+		agentCapabilitiesCacheMu.Unlock()
+		return cached.resolved
+	}
+	agentCapabilitiesCacheMu.Unlock()
+
+	resolved, err := resolveAgentCapabilitiesFn(homeDir, workspaceDir, agentID)
+	if err != nil {
+		return capabilities.ResolvedCapabilities{}
+	}
+
+	agentCapabilitiesCacheMu.Lock()
+	agentCapabilitiesCache[agentID] = cachedAgentCapabilities{
+		homeDir:      homeDir,
+		workspaceDir: workspaceDir,
+		resolverPtr:  resolverPtr,
+		resolved:     resolved,
+	}
+	agentCapabilitiesCacheMu.Unlock()
+
+	return resolved
+}
+
+func (m Model) piSupportsMultiModel() bool {
+	state := m.piModelConfigState()
+	return state.selectedOrDetected && state.supportsMultiModel
+}
+
+func (m Model) piSupportsModelPicker() bool {
+	return m.piModelConfigState().supportsModelPicker
+}
+
+func (m Model) hasDetectedAgent(agentID model.AgentID) bool {
+	for _, cfg := range m.Detection.Configs {
+		if cfg.Agent == string(agentID) && cfg.Exists {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (m Model) shouldShowPIModelConfigOption() bool {
+	state := m.piModelConfigState()
+	return state.selectedOrDetected || state.supportsMultiModel || state.supportsModelPicker
+}
+
+func (m Model) modelConfigCapabilityWarning() string {
+	state := m.piModelConfigState()
+	if !state.selectedOrDetected && !state.supportsMultiModel && !state.supportsModelPicker {
+		return ""
+	}
+
+	if state.supportsMultiModel || state.supportsModelPicker {
+		return ""
+	}
+
+	return capabilities.PiMultiModelRequiresPiSubagentsMessage
+}
+
+type piModelConfigState struct {
+	selectedOrDetected  bool
+	supportsMultiModel  bool
+	supportsModelPicker bool
+}
+
+func (m Model) piModelConfigState() piModelConfigState {
+	resolved := m.resolveAgentCapabilities(model.AgentPiCodingAgent)
+	selectedForInstall := m.Selection.HasAgent(model.AgentPiCodingAgent) || m.planHasAgent(model.AgentPiCodingAgent)
+	return piModelConfigState{
+		selectedOrDetected:  selectedForInstall || m.hasDetectedAgent(model.AgentPiCodingAgent),
+		supportsMultiModel:  resolved.SupportsSDDMultiMode,
+		supportsModelPicker: resolved.SupportsModelPicker,
+	}
+}
+
+func (m Model) planHasAgent(agentID model.AgentID) bool {
+	for _, planned := range m.DependencyPlan.Agents {
+		if planned == agentID {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (m *Model) setBlockedPIModelPicker(message string) {
+	m.ModelPicker = screens.ModelPickerState{
+		Source:            "pi",
+		CapabilityBlocked: true,
+		CapabilityMessage: message,
+	}
+}
+
+func (m *Model) initOpenCodeModelPicker() bool {
+	cachePath := opencode.DefaultCachePath()
+	if _, err := osStatModelCache(cachePath); err == nil {
+		m.ModelPicker = screens.NewModelPickerState(cachePath)
+		m.ModelPicker.Source = "opencode"
+		m.ModelPicker.EmptyStateHint = "For OpenCode, run 'opencode' once, then re-run 'gentle-ai sync' to assign models."
+		return true
+	}
+
+	m.ModelPicker = screens.ModelPickerState{
+		Source:         "opencode",
+		EmptyStateHint: "For OpenCode, run 'opencode' once, then re-run 'gentle-ai sync' to assign models.",
+	}
+	return false
+}
+
+func (m *Model) initPIModelPicker() {
+	catalog, err := loadPIModelCatalogFn(context.Background())
+	if err != nil {
+		m.setBlockedPIModelPicker(pi.UserFacingRPCModelLoadError(err))
+		return
+	}
+
+	m.ModelPicker = screens.NewModelPickerStateFromCatalog(catalog)
+	m.ModelPicker.Source = "pi"
+	m.ModelPicker.EmptyStateHint = "PI returned no available models via RPC. Verify PI auth/runtime providers, then retry."
+
+	if m.Selection.PIModelAssignments == nil {
+		homeDir, err := osUserHomeDirFn()
+		if err == nil {
+			if current, err := readPersistedPIAssignmentsFn(homeDir); err == nil && len(current) > 0 {
+				m.Selection.PIModelAssignments = current
+			}
+		}
+	}
+}
+
+func (m *Model) initSDDModelPicker() bool {
+	if m.shouldUsePIModelPicker() {
+		m.initPIModelPicker()
+		return true
+	}
+
+	return m.initOpenCodeModelPicker()
+}
+
+func (m Model) modelPickerAssignments() map[string]model.ModelAssignment {
+	if m.ModelPicker.Source == "pi" {
+		return m.Selection.PIModelAssignments
+	}
+
+	return m.Selection.ModelAssignments
+}
+
+func (m *Model) setModelPickerAssignments(assignments map[string]model.ModelAssignment) {
+	if m.ModelPicker.Source == "pi" {
+		m.Selection.PIModelAssignments = assignments
+		return
+	}
+
+	m.Selection.ModelAssignments = assignments
+}
+
+func (m Model) shouldRunPIModelPickerAfterOpenCode() bool {
+	if m.ModelPicker.Source != "opencode" {
+		return false
+	}
+
+	if !m.Selection.HasAgent(model.AgentOpenCode) || !m.Selection.HasAgent(model.AgentPiCodingAgent) {
+		return false
+	}
+
+	if !m.piSupportsModelPicker() {
+		return false
+	}
+
+	return m.Selection.SDDMode == model.SDDModeMulti
+}
+
+func (m Model) shouldUsePIModelPicker() bool {
+	if !m.Selection.HasAgent(model.AgentPiCodingAgent) || m.Selection.HasAgent(model.AgentOpenCode) {
+		return false
+	}
+
+	return m.piSupportsModelPicker()
+}
+
+func (m Model) canNavigateBackToModelPicker() bool {
+	if m.Selection.SDDMode != model.SDDModeMulti {
+		return false
+	}
+
+	if m.ModelPicker.Source == "pi" {
+		return true
+	}
+
+	cachePath := opencode.DefaultCachePath()
+	_, err := osStatModelCache(cachePath)
+	return err == nil
 }
 
 // shouldShowStrictTDDScreen reports whether the Strict TDD Mode screen should
@@ -3249,12 +3509,7 @@ func (m Model) handleProfileNameInput(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.ProfileDraft.Name = name
 		m.ProfileCreateStep = 1
 		// Initialize model picker for orchestrator step.
-		cachePath := opencode.DefaultCachePath()
-		if _, err := osStatModelCache(cachePath); err == nil {
-			m.ModelPicker = screens.NewModelPickerState(cachePath)
-		} else {
-			m.ModelPicker = screens.ModelPickerState{}
-		}
+		m.initOpenCodeModelPicker()
 		m.Cursor = 0
 		return m, nil
 	case tea.KeyEsc:
@@ -3306,12 +3561,7 @@ func (m Model) confirmProfileCreate() (tea.Model, tea.Cmd) {
 		// Edit mode: step 0 shows read-only name, enter advances to step 1.
 		if m.ProfileEditMode {
 			m.ProfileCreateStep = 1
-			cachePath := opencode.DefaultCachePath()
-			if _, err := osStatModelCache(cachePath); err == nil {
-				m.ModelPicker = screens.NewModelPickerState(cachePath)
-			} else {
-				m.ModelPicker = screens.ModelPickerState{}
-			}
+			m.initOpenCodeModelPicker()
 			m.Cursor = 0
 		}
 		return m, nil

--- a/internal/tui/model_pi_model_source_test.go
+++ b/internal/tui/model_pi_model_source_test.go
@@ -1,0 +1,304 @@
+package tui
+
+import (
+	"context"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/gentleman-programming/gentle-ai/internal/agents/capabilities"
+	"github.com/gentleman-programming/gentle-ai/internal/model"
+	"github.com/gentleman-programming/gentle-ai/internal/modelcatalog"
+	"github.com/gentleman-programming/gentle-ai/internal/system"
+	"github.com/gentleman-programming/gentle-ai/internal/tui/screens"
+)
+
+func modelConfigOptionCursor(t *testing.T, opts []string, target string) int {
+	t.Helper()
+	for i, opt := range opts {
+		if opt == target {
+			return i
+		}
+	}
+	t.Fatalf("option %q not found in %v", target, opts)
+	return -1
+}
+
+func TestModelConfig_PIOptionLoadsPickerFromPIRPC(t *testing.T) {
+	origResolve := resolveAgentCapabilitiesFn
+	resolveAgentCapabilitiesFn = func(_, _ string, agentID model.AgentID) (capabilities.ResolvedCapabilities, error) {
+		if agentID == model.AgentPiCodingAgent {
+			return capabilities.ResolvedCapabilities{SupportsSDDMultiMode: true, SupportsModelPicker: true}, nil
+		}
+		return capabilities.ResolvedCapabilities{}, nil
+	}
+	t.Cleanup(func() { resolveAgentCapabilitiesFn = origResolve })
+
+	origLoader := loadPIModelCatalogFn
+	loadPIModelCatalogFn = func(context.Context) (modelcatalog.Catalog, error) {
+		return modelcatalog.Catalog{
+			Providers: map[string]modelcatalog.Provider{
+				"openai": {
+					ID:   "openai",
+					Name: "OpenAI",
+					Models: map[string]modelcatalog.Model{
+						"gpt-5": {ID: "gpt-5", Name: "GPT-5"},
+					},
+				},
+			},
+			AvailableProviderIDs: []string{"openai"},
+			SDDModels: map[string][]modelcatalog.Model{
+				"openai": {{ID: "gpt-5", Name: "GPT-5"}},
+			},
+		}, nil
+	}
+	t.Cleanup(func() { loadPIModelCatalogFn = origLoader })
+
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Selection.Agents = []model.AgentID{model.AgentPiCodingAgent}
+	m.Screen = ScreenModelConfig
+	m.Cursor = modelConfigOptionCursor(t, screens.ModelConfigOptionsForCapabilities(true), screens.ModelConfigOptionPI)
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	state := updated.(Model)
+
+	if state.Screen != ScreenModelPicker {
+		t.Fatalf("screen = %v, want ScreenModelPicker", state.Screen)
+	}
+	if state.ModelPicker.Source != "pi" {
+		t.Fatalf("ModelPicker.Source = %q, want %q", state.ModelPicker.Source, "pi")
+	}
+	if len(state.ModelPicker.AvailableIDs) != 1 || state.ModelPicker.AvailableIDs[0] != "openai" {
+		t.Fatalf("unexpected PI picker providers: %v", state.ModelPicker.AvailableIDs)
+	}
+}
+
+func TestModelConfig_PIOptionRPCFailureBlocksPicker(t *testing.T) {
+	origResolve := resolveAgentCapabilitiesFn
+	resolveAgentCapabilitiesFn = func(_, _ string, agentID model.AgentID) (capabilities.ResolvedCapabilities, error) {
+		if agentID == model.AgentPiCodingAgent {
+			return capabilities.ResolvedCapabilities{SupportsSDDMultiMode: true, SupportsModelPicker: true}, nil
+		}
+		return capabilities.ResolvedCapabilities{}, nil
+	}
+	t.Cleanup(func() { resolveAgentCapabilitiesFn = origResolve })
+
+	origLoader := loadPIModelCatalogFn
+	loadPIModelCatalogFn = func(context.Context) (modelcatalog.Catalog, error) {
+		return modelcatalog.Catalog{}, errors.New("rpc unavailable")
+	}
+	t.Cleanup(func() { loadPIModelCatalogFn = origLoader })
+
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Selection.Agents = []model.AgentID{model.AgentPiCodingAgent}
+	m.Screen = ScreenModelConfig
+	m.Cursor = modelConfigOptionCursor(t, screens.ModelConfigOptionsForCapabilities(true), screens.ModelConfigOptionPI)
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	state := updated.(Model)
+
+	if !state.ModelPicker.CapabilityBlocked {
+		t.Fatal("expected PI picker to be blocked when RPC model load fails")
+	}
+	if strings.Contains(state.ModelPicker.CapabilityMessage, "signal: killed") {
+		t.Fatalf("CapabilityMessage should hide raw process signal details, got %q", state.ModelPicker.CapabilityMessage)
+	}
+	if !strings.Contains(state.ModelPicker.CapabilityMessage, "Run `pi --mode rpc` manually") {
+		t.Fatalf("CapabilityMessage should include actionable manual verification guidance, got %q", state.ModelPicker.CapabilityMessage)
+	}
+}
+
+func TestModelConfig_PIOptionRPCFailureKilled_ShowsActionableMessage(t *testing.T) {
+	origResolve := resolveAgentCapabilitiesFn
+	resolveAgentCapabilitiesFn = func(_, _ string, agentID model.AgentID) (capabilities.ResolvedCapabilities, error) {
+		if agentID == model.AgentPiCodingAgent {
+			return capabilities.ResolvedCapabilities{SupportsSDDMultiMode: true, SupportsModelPicker: true}, nil
+		}
+		return capabilities.ResolvedCapabilities{}, nil
+	}
+	t.Cleanup(func() { resolveAgentCapabilitiesFn = origResolve })
+
+	origLoader := loadPIModelCatalogFn
+	loadPIModelCatalogFn = func(context.Context) (modelcatalog.Catalog, error) {
+		return modelcatalog.Catalog{}, errors.New("PI RPC command failed: signal: killed")
+	}
+	t.Cleanup(func() { loadPIModelCatalogFn = origLoader })
+
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Selection.Agents = []model.AgentID{model.AgentPiCodingAgent}
+	m.Screen = ScreenModelConfig
+	m.Cursor = modelConfigOptionCursor(t, screens.ModelConfigOptionsForCapabilities(true), screens.ModelConfigOptionPI)
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	state := updated.(Model)
+
+	if !state.ModelPicker.CapabilityBlocked {
+		t.Fatal("expected PI picker to be blocked when RPC model load fails")
+	}
+	if strings.Contains(state.ModelPicker.CapabilityMessage, "signal: killed") {
+		t.Fatalf("expected actionable message without raw signal details, got %q", state.ModelPicker.CapabilityMessage)
+	}
+	if !strings.Contains(state.ModelPicker.CapabilityMessage, "Run `pi --mode rpc` manually") {
+		t.Fatalf("expected manual verification guidance, got %q", state.ModelPicker.CapabilityMessage)
+	}
+}
+
+func TestModelConfig_PIUnsupportedCapabilityShowsCanonicalBlockedMessage(t *testing.T) {
+	origResolve := resolveAgentCapabilitiesFn
+	clearAgentCapabilitiesCache()
+	resolveAgentCapabilitiesFn = func(_, _ string, agentID model.AgentID) (capabilities.ResolvedCapabilities, error) {
+		if agentID == model.AgentPiCodingAgent {
+			return capabilities.ResolvedCapabilities{}, nil
+		}
+		return capabilities.ResolvedCapabilities{}, nil
+	}
+	t.Cleanup(func() {
+		resolveAgentCapabilitiesFn = origResolve
+		clearAgentCapabilitiesCache()
+	})
+
+	origLoader := loadPIModelCatalogFn
+	loadPIModelCatalogFn = func(context.Context) (modelcatalog.Catalog, error) {
+		t.Fatal("PI RPC loader should not run when capability is blocked")
+		return modelcatalog.Catalog{}, nil
+	}
+	t.Cleanup(func() { loadPIModelCatalogFn = origLoader })
+
+	m := NewModel(system.DetectionResult{
+		Configs: []system.ConfigState{{Agent: string(model.AgentPiCodingAgent), Exists: true, IsDirectory: true}},
+	}, "dev")
+	m.Selection.Agents = nil // regression guard: detected PI must still expose model config option
+	m.Screen = ScreenModelConfig
+	m.Cursor = modelConfigOptionCursor(t, screens.ModelConfigOptionsForCapabilities(true), screens.ModelConfigOptionPI)
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	state := updated.(Model)
+
+	if state.Screen != ScreenModelPicker {
+		t.Fatalf("screen = %v, want ScreenModelPicker", state.Screen)
+	}
+	if state.ModelPicker.Source != "pi" {
+		t.Fatalf("ModelPicker.Source = %q, want %q", state.ModelPicker.Source, "pi")
+	}
+	if !state.ModelPicker.CapabilityBlocked {
+		t.Fatal("expected PI model picker to be blocked when capability is unsupported")
+	}
+	if state.ModelPicker.CapabilityMessage != capabilities.PiMultiModelRequiresPiSubagentsMessage {
+		t.Fatalf("CapabilityMessage = %q, want %q", state.ModelPicker.CapabilityMessage, capabilities.PiMultiModelRequiresPiSubagentsMessage)
+	}
+}
+
+func TestSDDModeMulti_MixedAgentsKeepsOpenCodeSource(t *testing.T) {
+	origLoader := loadPIModelCatalogFn
+	loadPIModelCatalogFn = func(context.Context) (modelcatalog.Catalog, error) {
+		t.Fatal("PI loader must not be called when OpenCode is selected")
+		return modelcatalog.Catalog{}, nil
+	}
+	t.Cleanup(func() { loadPIModelCatalogFn = origLoader })
+
+	origStat := osStatModelCache
+	osStatModelCache = func(string) (os.FileInfo, error) { return nil, nil }
+	t.Cleanup(func() { osStatModelCache = origStat })
+
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Screen = ScreenSDDMode
+	m.Selection.Agents = []model.AgentID{model.AgentOpenCode, model.AgentPiCodingAgent}
+	m.Selection.Components = []model.ComponentID{model.ComponentSDD}
+	m.Cursor = 1 // multi
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	state := updated.(Model)
+
+	if state.Screen != ScreenModelPicker {
+		t.Fatalf("screen = %v, want ScreenModelPicker", state.Screen)
+	}
+	if state.ModelPicker.Source != "opencode" {
+		t.Fatalf("ModelPicker.Source = %q, want %q", state.ModelPicker.Source, "opencode")
+	}
+}
+
+func TestSDDModeMulti_ModelSourceMatrix(t *testing.T) {
+	tests := []struct {
+		name       string
+		agents     []model.AgentID
+		wantSource string
+		piLoads    int
+	}{
+		{
+			name:       "mixed opencode+pi prefers opencode model source",
+			agents:     []model.AgentID{model.AgentOpenCode, model.AgentPiCodingAgent},
+			wantSource: "opencode",
+			piLoads:    0,
+		},
+		{
+			name:       "pi-only uses pi rpc model source",
+			agents:     []model.AgentID{model.AgentPiCodingAgent},
+			wantSource: "pi",
+			piLoads:    1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			origResolve := resolveAgentCapabilitiesFn
+			clearAgentCapabilitiesCache()
+			resolveAgentCapabilitiesFn = func(_, _ string, agentID model.AgentID) (capabilities.ResolvedCapabilities, error) {
+				if agentID == model.AgentPiCodingAgent {
+					return capabilities.ResolvedCapabilities{SupportsSDDMultiMode: true, SupportsModelPicker: true}, nil
+				}
+				if agentID == model.AgentOpenCode {
+					return capabilities.ResolvedCapabilities{SupportsSDDMultiMode: true}, nil
+				}
+				return capabilities.ResolvedCapabilities{}, nil
+			}
+			t.Cleanup(func() {
+				resolveAgentCapabilitiesFn = origResolve
+				clearAgentCapabilitiesCache()
+			})
+
+			piLoadCalls := 0
+			origLoader := loadPIModelCatalogFn
+			loadPIModelCatalogFn = func(context.Context) (modelcatalog.Catalog, error) {
+				piLoadCalls++
+				return modelcatalog.Catalog{
+					Providers: map[string]modelcatalog.Provider{
+						"openai": {
+							ID:   "openai",
+							Name: "OpenAI",
+							Models: map[string]modelcatalog.Model{
+								"gpt-5": {ID: "gpt-5", Name: "GPT-5"},
+							},
+						},
+					},
+					AvailableProviderIDs: []string{"openai"},
+				}, nil
+			}
+			t.Cleanup(func() { loadPIModelCatalogFn = origLoader })
+
+			origStat := osStatModelCache
+			osStatModelCache = func(string) (os.FileInfo, error) { return nil, nil }
+			t.Cleanup(func() { osStatModelCache = origStat })
+
+			m := NewModel(system.DetectionResult{}, "dev")
+			m.Screen = ScreenSDDMode
+			m.Selection.Agents = tt.agents
+			m.Selection.Components = []model.ComponentID{model.ComponentSDD}
+			m.Cursor = 1 // multi
+
+			updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+			state := updated.(Model)
+
+			if state.Screen != ScreenModelPicker {
+				t.Fatalf("screen = %v, want %v", state.Screen, ScreenModelPicker)
+			}
+			if state.ModelPicker.Source != tt.wantSource {
+				t.Fatalf("ModelPicker.Source = %q, want %q", state.ModelPicker.Source, tt.wantSource)
+			}
+			if piLoadCalls != tt.piLoads {
+				t.Fatalf("PI model catalog calls = %d, want %d", piLoadCalls, tt.piLoads)
+			}
+		})
+	}
+}

--- a/internal/tui/model_pi_opencode_dual_picker_test.go
+++ b/internal/tui/model_pi_opencode_dual_picker_test.go
@@ -1,0 +1,180 @@
+package tui
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/gentleman-programming/gentle-ai/internal/agents/capabilities"
+	"github.com/gentleman-programming/gentle-ai/internal/model"
+	"github.com/gentleman-programming/gentle-ai/internal/modelcatalog"
+	"github.com/gentleman-programming/gentle-ai/internal/system"
+	"github.com/gentleman-programming/gentle-ai/internal/tui/screens"
+)
+
+func TestSDDModeMulti_MixedAgentsShowsOpenCodeThenPIModelPicker(t *testing.T) {
+	origResolve := resolveAgentCapabilitiesFn
+	clearAgentCapabilitiesCache()
+	resolveAgentCapabilitiesFn = func(_, _ string, agentID model.AgentID) (capabilities.ResolvedCapabilities, error) {
+		if agentID == model.AgentPiCodingAgent {
+			return capabilities.ResolvedCapabilities{SupportsSDDMultiMode: true, SupportsModelPicker: true}, nil
+		}
+		if agentID == model.AgentOpenCode {
+			return capabilities.ResolvedCapabilities{SupportsSDDMultiMode: true, SupportsModelPicker: true}, nil
+		}
+		return capabilities.ResolvedCapabilities{}, nil
+	}
+	t.Cleanup(func() {
+		resolveAgentCapabilitiesFn = origResolve
+		clearAgentCapabilitiesCache()
+	})
+
+	origPILoader := loadPIModelCatalogFn
+	loadPIModelCatalogFn = func(context.Context) (modelcatalog.Catalog, error) {
+		return modelcatalog.Catalog{
+			Providers: map[string]modelcatalog.Provider{"openai": {ID: "openai", Name: "OpenAI"}},
+			AvailableProviderIDs: []string{"openai"},
+			SDDModels: map[string][]modelcatalog.Model{"openai": {{ID: "gpt-5", Name: "GPT-5"}}},
+		}, nil
+	}
+	t.Cleanup(func() { loadPIModelCatalogFn = origPILoader })
+
+	origStat := osStatModelCache
+	osStatModelCache = func(string) (os.FileInfo, error) { return nil, nil }
+	t.Cleanup(func() { osStatModelCache = origStat })
+
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Screen = ScreenSDDMode
+	m.Selection.Agents = []model.AgentID{model.AgentOpenCode, model.AgentPiCodingAgent}
+	m.Selection.Components = []model.ComponentID{model.ComponentEngram, model.ComponentSDD}
+	m.Cursor = sddMultiCursor(t)
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	state := updated.(Model)
+	if state.Screen != ScreenModelPicker || state.ModelPicker.Source != "opencode" {
+		t.Fatalf("first picker = (%v, %q), want (ScreenModelPicker, opencode)", state.Screen, state.ModelPicker.Source)
+	}
+
+	state.Cursor = len(screens.ModelPickerRows())
+	updated, _ = state.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	state = updated.(Model)
+	if state.Screen != ScreenModelPicker || state.ModelPicker.Source != "pi" {
+		t.Fatalf("second picker = (%v, %q), want (ScreenModelPicker, pi)", state.Screen, state.ModelPicker.Source)
+	}
+
+	state.Cursor = len(screens.ModelPickerRows())
+	updated, _ = state.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	state = updated.(Model)
+	if state.Screen != ScreenStrictTDD {
+		t.Fatalf("after second picker continue: screen = %v, want %v", state.Screen, ScreenStrictTDD)
+	}
+}
+
+func TestSDDModeMulti_MixedAssignmentsAreSeparatedBetweenOpenCodeAndPI(t *testing.T) {
+	origResolve := resolveAgentCapabilitiesFn
+	clearAgentCapabilitiesCache()
+	resolveAgentCapabilitiesFn = func(_, _ string, agentID model.AgentID) (capabilities.ResolvedCapabilities, error) {
+		if agentID == model.AgentPiCodingAgent || agentID == model.AgentOpenCode {
+			return capabilities.ResolvedCapabilities{SupportsSDDMultiMode: true, SupportsModelPicker: true}, nil
+		}
+		return capabilities.ResolvedCapabilities{}, nil
+	}
+	t.Cleanup(func() {
+		resolveAgentCapabilitiesFn = origResolve
+		clearAgentCapabilitiesCache()
+	})
+
+	origPILoader := loadPIModelCatalogFn
+	loadPIModelCatalogFn = func(context.Context) (modelcatalog.Catalog, error) {
+		return modelcatalog.Catalog{
+			Providers:            map[string]modelcatalog.Provider{"openai": {ID: "openai", Name: "OpenAI"}},
+			AvailableProviderIDs: []string{"openai"},
+			SDDModels:            map[string][]modelcatalog.Model{"openai": {{ID: "gpt-5", Name: "GPT-5"}}},
+		}, nil
+	}
+	t.Cleanup(func() { loadPIModelCatalogFn = origPILoader })
+
+	origStat := osStatModelCache
+	osStatModelCache = func(string) (os.FileInfo, error) { return nil, nil }
+	t.Cleanup(func() { osStatModelCache = origStat })
+
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Screen = ScreenSDDMode
+	m.Selection.Agents = []model.AgentID{model.AgentOpenCode, model.AgentPiCodingAgent}
+	m.Selection.Components = []model.ComponentID{model.ComponentSDD}
+	m.Cursor = sddMultiCursor(t)
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	state := updated.(Model)
+
+	state.Selection.ModelAssignments = map[string]model.ModelAssignment{
+		"sdd-apply": {ProviderID: "anthropic", ModelID: "claude-sonnet-4"},
+	}
+	state.Cursor = len(screens.ModelPickerRows())
+	updated, _ = state.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	state = updated.(Model)
+
+	state.ModelPicker.Mode = screens.ModeModelSelect
+	state.ModelPicker.SelectedProvider = "openai"
+	state.ModelPicker.SelectedPhaseIdx = 2 // sdd-init
+	updated, _ = state.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	state = updated.(Model)
+
+	if got := state.Selection.ModelAssignments["sdd-apply"].FullID(); got != "anthropic/claude-sonnet-4" {
+		t.Fatalf("OpenCode assignment overwritten: got %q", got)
+	}
+	if got := state.Selection.PIModelAssignments["sdd-init"].FullID(); got != "openai/gpt-5" {
+		t.Fatalf("PI assignment missing/wrong: got %q, want %q", got, "openai/gpt-5")
+	}
+}
+
+func TestSDDModeMulti_PIOnlyStillUsesPIPicker(t *testing.T) {
+	origResolve := resolveAgentCapabilitiesFn
+	clearAgentCapabilitiesCache()
+	resolveAgentCapabilitiesFn = func(_, _ string, agentID model.AgentID) (capabilities.ResolvedCapabilities, error) {
+		if agentID == model.AgentPiCodingAgent {
+			return capabilities.ResolvedCapabilities{SupportsSDDMultiMode: true, SupportsModelPicker: true}, nil
+		}
+		return capabilities.ResolvedCapabilities{}, nil
+	}
+	t.Cleanup(func() {
+		resolveAgentCapabilitiesFn = origResolve
+		clearAgentCapabilitiesCache()
+	})
+	origPILoader := loadPIModelCatalogFn
+	loadPIModelCatalogFn = func(context.Context) (modelcatalog.Catalog, error) {
+		return modelcatalog.Catalog{AvailableProviderIDs: []string{"openai"}}, nil
+	}
+	t.Cleanup(func() { loadPIModelCatalogFn = origPILoader })
+
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Screen = ScreenSDDMode
+	m.Selection.Agents = []model.AgentID{model.AgentPiCodingAgent}
+	m.Selection.Components = []model.ComponentID{model.ComponentSDD}
+	m.Cursor = sddMultiCursor(t)
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	state := updated.(Model)
+	if state.ModelPicker.Source != "pi" {
+		t.Fatalf("source = %q, want pi", state.ModelPicker.Source)
+	}
+}
+
+func TestSDDModeMulti_OpenCodeOnlyStillUsesOpenCodePicker(t *testing.T) {
+	origStat := osStatModelCache
+	osStatModelCache = func(string) (os.FileInfo, error) { return nil, nil }
+	t.Cleanup(func() { osStatModelCache = origStat })
+
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Screen = ScreenSDDMode
+	m.Selection.Agents = []model.AgentID{model.AgentOpenCode}
+	m.Selection.Components = []model.ComponentID{model.ComponentSDD}
+	m.Cursor = sddMultiCursor(t)
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	state := updated.(Model)
+	if state.ModelPicker.Source != "opencode" {
+		t.Fatalf("source = %q, want opencode", state.ModelPicker.Source)
+	}
+}

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -9,9 +10,11 @@ import (
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/gentleman-programming/gentle-ai/internal/agents/capabilities"
 	"github.com/gentleman-programming/gentle-ai/internal/backup"
 	componentuninstall "github.com/gentleman-programming/gentle-ai/internal/components/uninstall"
 	"github.com/gentleman-programming/gentle-ai/internal/model"
+	"github.com/gentleman-programming/gentle-ai/internal/modelcatalog"
 	"github.com/gentleman-programming/gentle-ai/internal/pipeline"
 	"github.com/gentleman-programming/gentle-ai/internal/planner"
 	"github.com/gentleman-programming/gentle-ai/internal/system"
@@ -296,6 +299,19 @@ func TestBackupRestoreMsgHandledGracefully(t *testing.T) {
 }
 
 func TestShouldShowSDDModeScreen(t *testing.T) {
+	origResolver := resolveAgentCapabilitiesFn
+	clearAgentCapabilitiesCache()
+	resolveAgentCapabilitiesFn = func(_ string, _ string, agentID model.AgentID) (capabilities.ResolvedCapabilities, error) {
+		if agentID == model.AgentOpenCode {
+			return capabilities.ResolvedCapabilities{SupportsSDDMultiMode: true}, nil
+		}
+		return capabilities.ResolvedCapabilities{}, nil
+	}
+	t.Cleanup(func() {
+		resolveAgentCapabilitiesFn = origResolver
+		clearAgentCapabilitiesCache()
+	})
+
 	tests := []struct {
 		name       string
 		agents     []model.AgentID
@@ -311,6 +327,12 @@ func TestShouldShowSDDModeScreen(t *testing.T) {
 		{
 			name:       "Claude only + SDD = false",
 			agents:     []model.AgentID{model.AgentClaudeCode},
+			components: []model.ComponentID{model.ComponentEngram, model.ComponentSDD},
+			want:       false,
+		},
+		{
+			name:       "PI only + SDD = false (OpenCode-only screen)",
+			agents:     []model.AgentID{model.AgentPiCodingAgent},
 			components: []model.ComponentID{model.ComponentEngram, model.ComponentSDD},
 			want:       false,
 		},
@@ -349,6 +371,210 @@ func TestShouldShowSDDModeScreen(t *testing.T) {
 			got := m.shouldShowSDDModeScreen()
 			if got != tt.want {
 				t.Fatalf("shouldShowSDDModeScreen() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPresetFlowWithPIAgentSkipsOpenCodeScreens(t *testing.T) {
+	origResolver := resolveAgentCapabilitiesFn
+	clearAgentCapabilitiesCache()
+	resolveAgentCapabilitiesFn = func(_, _ string, agentID model.AgentID) (capabilities.ResolvedCapabilities, error) {
+		if agentID == model.AgentPiCodingAgent {
+			return capabilities.ResolvedCapabilities{SupportsSDDMultiMode: false}, nil
+		}
+		return capabilities.ResolvedCapabilities{}, nil
+	}
+	t.Cleanup(func() {
+		resolveAgentCapabilitiesFn = origResolver
+		clearAgentCapabilitiesCache()
+	})
+
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Screen = ScreenPreset
+	m.Selection.Agents = []model.AgentID{model.AgentPiCodingAgent}
+	m.Cursor = 0 // PresetFullGentleman includes SDD
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	state := updated.(Model)
+
+	if state.Screen != ScreenStrictTDD {
+		t.Fatalf("screen = %v, want %v", state.Screen, ScreenStrictTDD)
+	}
+}
+
+func TestPresetFlow_PIExtensionCapabilityGatesSDDModeScreen(t *testing.T) {
+	tests := []struct {
+		name               string
+		resolvedCaps       capabilities.ResolvedCapabilities
+		wantScreenAfterSDD Screen
+	}{
+		{
+			name: "pi without pi-subagents skips SDD mode and goes strict tdd",
+			resolvedCaps: capabilities.ResolvedCapabilities{
+				SupportsSDDMultiMode: false,
+			},
+			wantScreenAfterSDD: ScreenStrictTDD,
+		},
+		{
+			name: "pi with pi-subagents enters sdd mode screen",
+			resolvedCaps: capabilities.ResolvedCapabilities{
+				SupportsSDDMultiMode: true,
+			},
+			wantScreenAfterSDD: ScreenSDDMode,
+		},
+	}
+
+	origResolver := resolveAgentCapabilitiesFn
+	clearAgentCapabilitiesCache()
+	t.Cleanup(func() {
+		resolveAgentCapabilitiesFn = origResolver
+		clearAgentCapabilitiesCache()
+	})
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clearAgentCapabilitiesCache()
+			resolveAgentCapabilitiesFn = func(_ string, _ string, agentID model.AgentID) (capabilities.ResolvedCapabilities, error) {
+				if agentID == model.AgentPiCodingAgent {
+					return tt.resolvedCaps, nil
+				}
+				if agentID == model.AgentOpenCode {
+					return capabilities.ResolvedCapabilities{SupportsSDDMultiMode: true}, nil
+				}
+				return capabilities.ResolvedCapabilities{}, nil
+			}
+
+			m := NewModel(system.DetectionResult{}, "dev")
+			m.Screen = ScreenPreset
+			m.Selection.Agents = []model.AgentID{model.AgentPiCodingAgent}
+			m.Cursor = 0 // PresetFullGentleman includes SDD
+
+			updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+			state := updated.(Model)
+
+			if state.Screen != tt.wantScreenAfterSDD {
+				t.Fatalf("screen = %v, want %v", state.Screen, tt.wantScreenAfterSDD)
+			}
+		})
+	}
+}
+
+func TestPresetFlow_PISettingsPackageDetectionEntersSDDMode(t *testing.T) {
+	homeDir := t.TempDir()
+	workspaceDir := t.TempDir()
+
+	settingsPath := filepath.Join(homeDir, ".pi", "agent", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q) error = %v", filepath.Dir(settingsPath), err)
+	}
+
+	if err := os.WriteFile(settingsPath, []byte(`{"packages":["npm:pi-subagents"]}`), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q) error = %v", settingsPath, err)
+	}
+
+	origHome := osUserHomeDirFn
+	origGetwd := osGetwdFn
+	origResolver := resolveAgentCapabilitiesFn
+	t.Cleanup(func() {
+		osUserHomeDirFn = origHome
+		osGetwdFn = origGetwd
+		resolveAgentCapabilitiesFn = origResolver
+	})
+
+	osUserHomeDirFn = func() (string, error) { return homeDir, nil }
+	osGetwdFn = func() (string, error) { return workspaceDir, nil }
+	resolveAgentCapabilitiesFn = func(homeDir string, workspaceDir string, agentID model.AgentID) (capabilities.ResolvedCapabilities, error) {
+		return capabilities.NewResolver(nil).Resolve(homeDir, workspaceDir, agentID)
+	}
+
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Screen = ScreenPreset
+	m.Selection.Agents = []model.AgentID{model.AgentPiCodingAgent}
+	m.Cursor = 0 // PresetFullGentleman includes SDD
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	state := updated.(Model)
+
+	if state.Screen != ScreenSDDMode {
+		t.Fatalf("screen = %v, want %v", state.Screen, ScreenSDDMode)
+	}
+}
+
+func TestAgentsViewWithPISelectionShowsCapabilityWarning(t *testing.T) {
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Screen = ScreenAgents
+	m.Selection.Agents = []model.AgentID{model.AgentPiCodingAgent}
+
+	view := m.View()
+	if !strings.Contains(view, "multi-model is enabled only when `pi-subagents` is installed") {
+		t.Fatalf("expected PI capability warning in agents screen view")
+	}
+}
+
+func TestModelConfigCapabilityWarning_WiresPIResolverState(t *testing.T) {
+	origResolver := resolveAgentCapabilitiesFn
+	clearAgentCapabilitiesCache()
+	t.Cleanup(func() {
+		resolveAgentCapabilitiesFn = origResolver
+		clearAgentCapabilitiesCache()
+	})
+
+	tests := []struct {
+		name       string
+		agents     []model.AgentID
+		caps       capabilities.ResolvedCapabilities
+		resolveErr error
+		want       string
+	}{
+		{
+			name:   "no pi selected returns no warning",
+			agents: []model.AgentID{model.AgentOpenCode},
+			want:   "",
+		},
+		{
+			name:   "pi selected without capability shows canonical warning",
+			agents: []model.AgentID{model.AgentPiCodingAgent},
+			caps: capabilities.ResolvedCapabilities{
+				SupportsSDDMultiMode: false,
+			},
+			want: capabilities.PiMultiModelRequiresPiSubagentsMessage,
+		},
+		{
+			name:   "pi selected with capability shows no warning",
+			agents: []model.AgentID{model.AgentPiCodingAgent},
+			caps: capabilities.ResolvedCapabilities{
+				SupportsSDDMultiMode: true,
+			},
+			want: "",
+		},
+		{
+			name:       "resolver error fails closed with canonical warning",
+			agents:     []model.AgentID{model.AgentPiCodingAgent},
+			resolveErr: fmt.Errorf("resolver unavailable"),
+			want:       capabilities.PiMultiModelRequiresPiSubagentsMessage,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clearAgentCapabilitiesCache()
+			resolveAgentCapabilitiesFn = func(_, _ string, agentID model.AgentID) (capabilities.ResolvedCapabilities, error) {
+				if agentID != model.AgentPiCodingAgent {
+					return capabilities.ResolvedCapabilities{}, nil
+				}
+				if tt.resolveErr != nil {
+					return capabilities.ResolvedCapabilities{}, tt.resolveErr
+				}
+				return tt.caps, nil
+			}
+
+			m := NewModel(system.DetectionResult{}, "dev")
+			m.Selection.Agents = tt.agents
+
+			got := m.modelConfigCapabilityWarning()
+			if got != tt.want {
+				t.Fatalf("modelConfigCapabilityWarning() = %q, want %q", got, tt.want)
 			}
 		})
 	}
@@ -466,6 +692,12 @@ func TestSDDModeMultiSkipModelPickerWhenCacheMissing(t *testing.T) {
 	m.Screen = ScreenSDDMode
 	m.Selection.Agents = []model.AgentID{model.AgentOpenCode}
 	m.Selection.Components = []model.ComponentID{model.ComponentEngram, model.ComponentSDD}
+	m.Selection.ModelAssignments = map[string]model.ModelAssignment{
+		"sdd-apply": {ProviderID: "anthropic", ModelID: "claude-sonnet-4"},
+	}
+	m.Selection.PIModelAssignments = map[string]model.ModelAssignment{
+		"sdd-apply": {ProviderID: "openai", ModelID: "gpt-5"},
+	}
 	m.Cursor = sddMultiCursor(t)
 
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
@@ -477,6 +709,12 @@ func TestSDDModeMultiSkipModelPickerWhenCacheMissing(t *testing.T) {
 	}
 	if len(state.ModelPicker.AvailableIDs) != 0 {
 		t.Fatalf("ModelPicker.AvailableIDs should be empty when cache missing, got: %v", state.ModelPicker.AvailableIDs)
+	}
+	if state.Selection.ModelAssignments != nil {
+		t.Fatalf("ModelAssignments should be cleared when skipping picker, got: %v", state.Selection.ModelAssignments)
+	}
+	if state.Selection.PIModelAssignments != nil {
+		t.Fatalf("PIModelAssignments should be cleared when skipping picker, got: %v", state.Selection.PIModelAssignments)
 	}
 }
 
@@ -509,6 +747,116 @@ func TestSDDModeMultiShowsModelPickerWhenCacheExists(t *testing.T) {
 	if state.Screen != ScreenModelPicker {
 		t.Fatalf("screen = %v, want ScreenModelPicker (cache present → show picker)", state.Screen)
 	}
+}
+
+func TestStrictTDDForwardNavigation_OpenCodePluginVisibilityMatrix(t *testing.T) {
+	origResolver := resolveAgentCapabilitiesFn
+	clearAgentCapabilitiesCache()
+	resolveAgentCapabilitiesFn = func(_, _ string, agentID model.AgentID) (capabilities.ResolvedCapabilities, error) {
+		if agentID == model.AgentPiCodingAgent {
+			return capabilities.ResolvedCapabilities{SupportsSDDMultiMode: true, SupportsModelPicker: true}, nil
+		}
+		if agentID == model.AgentOpenCode {
+			return capabilities.ResolvedCapabilities{SupportsSDDMultiMode: true, SupportsModelPicker: true}, nil
+		}
+		return capabilities.ResolvedCapabilities{}, nil
+	}
+	t.Cleanup(func() {
+		resolveAgentCapabilitiesFn = origResolver
+		clearAgentCapabilitiesCache()
+	})
+
+	tests := []struct {
+		name       string
+		agents     []model.AgentID
+		wantScreen Screen
+	}{
+		{name: "pi-only skips plugin screen", agents: []model.AgentID{model.AgentPiCodingAgent}, wantScreen: ScreenDependencyTree},
+		{name: "opencode-only shows plugin screen", agents: []model.AgentID{model.AgentOpenCode}, wantScreen: ScreenOpenCodePlugins},
+		{name: "opencode+pi mixed shows plugin screen", agents: []model.AgentID{model.AgentOpenCode, model.AgentPiCodingAgent}, wantScreen: ScreenOpenCodePlugins},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := NewModel(system.DetectionResult{}, "dev")
+			m.Screen = ScreenStrictTDD
+			m.Selection.Preset = model.PresetFullGentleman
+			m.Selection.Components = []model.ComponentID{model.ComponentEngram, model.ComponentSDD}
+			m.Selection.Agents = tt.agents
+			m.Cursor = screens.StrictTDDOptionEnable
+
+			updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+			state := updated.(Model)
+
+			if state.Screen != tt.wantScreen {
+				t.Fatalf("screen = %v, want %v", state.Screen, tt.wantScreen)
+			}
+		})
+	}
+}
+
+func TestBackNavigation_PIMergeStackIntegrity(t *testing.T) {
+	origResolver := resolveAgentCapabilitiesFn
+	clearAgentCapabilitiesCache()
+	resolveAgentCapabilitiesFn = func(_, _ string, agentID model.AgentID) (capabilities.ResolvedCapabilities, error) {
+		if agentID == model.AgentPiCodingAgent {
+			return capabilities.ResolvedCapabilities{SupportsSDDMultiMode: true, SupportsModelPicker: true}, nil
+		}
+		if agentID == model.AgentOpenCode {
+			return capabilities.ResolvedCapabilities{SupportsSDDMultiMode: true, SupportsModelPicker: true}, nil
+		}
+		return capabilities.ResolvedCapabilities{}, nil
+	}
+	t.Cleanup(func() {
+		resolveAgentCapabilitiesFn = origResolver
+		clearAgentCapabilitiesCache()
+	})
+
+	t.Run("pi-only back from strict tdd returns to sdd mode without plugin insertion", func(t *testing.T) {
+		m := NewModel(system.DetectionResult{}, "dev")
+		m.Screen = ScreenStrictTDD
+		m.Selection.Preset = model.PresetFullGentleman
+		m.Selection.Components = []model.ComponentID{model.ComponentEngram, model.ComponentSDD}
+		m.Selection.Agents = []model.AgentID{model.AgentPiCodingAgent}
+		m.Selection.SDDMode = model.SDDModeSingle
+
+		updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+		state := updated.(Model)
+		if state.Screen != ScreenSDDMode {
+			t.Fatalf("screen = %v, want %v", state.Screen, ScreenSDDMode)
+		}
+	})
+
+	t.Run("mixed opencode+pi multi-agent back stack preserves plugin->strict->picker order", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		cacheFile := tmpDir + "/models.json"
+		if err := os.WriteFile(cacheFile, []byte(`{}`), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		origStat := osStatModelCache
+		osStatModelCache = func(string) (os.FileInfo, error) { return os.Stat(cacheFile) }
+		t.Cleanup(func() { osStatModelCache = origStat })
+
+		m := NewModel(system.DetectionResult{}, "dev")
+		m.Screen = ScreenOpenCodePlugins
+		m.Selection.Preset = model.PresetFullGentleman
+		m.Selection.Components = []model.ComponentID{model.ComponentEngram, model.ComponentSDD}
+		m.Selection.Agents = []model.AgentID{model.AgentOpenCode, model.AgentPiCodingAgent}
+		m.Selection.SDDMode = model.SDDModeMulti
+		m.ModelPicker.Source = "opencode"
+
+		updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+		state := updated.(Model)
+		if state.Screen != ScreenStrictTDD {
+			t.Fatalf("first back screen = %v, want %v", state.Screen, ScreenStrictTDD)
+		}
+
+		updated, _ = state.Update(tea.KeyMsg{Type: tea.KeyEsc})
+		state = updated.(Model)
+		if state.Screen != ScreenModelPicker {
+			t.Fatalf("second back screen = %v, want %v", state.Screen, ScreenModelPicker)
+		}
+	})
 }
 
 func screensAgentOptions() []model.AgentID {
@@ -1473,18 +1821,27 @@ func TestModelConfig_OpenCodePickerNavigation(t *testing.T) {
 	}
 }
 
-// TestModelConfig_BackNavigation verifies that selecting cursor 3 (Back) from
+// TestModelConfig_BackNavigation verifies that selecting Back from
 // ScreenModelConfig returns to ScreenWelcome.
 func TestModelConfig_BackNavigation(t *testing.T) {
+	origResolver := resolveAgentCapabilitiesFn
+	resolveAgentCapabilitiesFn = func(_, _ string, agentID model.AgentID) (capabilities.ResolvedCapabilities, error) {
+		if agentID == model.AgentPiCodingAgent {
+			return capabilities.ResolvedCapabilities{SupportsSDDMultiMode: false}, nil
+		}
+		return capabilities.ResolvedCapabilities{}, nil
+	}
+	t.Cleanup(func() { resolveAgentCapabilitiesFn = origResolver })
+
 	m := NewModel(system.DetectionResult{}, "dev")
 	m.Screen = ScreenModelConfig
-	m.Cursor = 3
+	m.Cursor = len(screens.ModelConfigOptionsForCapabilities(m.shouldShowPIModelConfigOption())) - 1
 
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	state := updated.(Model)
 
 	if state.Screen != ScreenWelcome {
-		t.Fatalf("ModelConfig cursor=3 (Back): screen = %v, want %v", state.Screen, ScreenWelcome)
+		t.Fatalf("ModelConfig Back: screen = %v, want %v", state.Screen, ScreenWelcome)
 	}
 }
 
@@ -1500,6 +1857,93 @@ func TestModelConfig_EscReturnsToWelcome(t *testing.T) {
 	if state.Screen != ScreenWelcome {
 		t.Fatalf("ModelConfig esc: screen = %v, want %v", state.Screen, ScreenWelcome)
 	}
+}
+
+func TestModelConfig_PIOptionVisibility_InstallSelectionPaths(t *testing.T) {
+	origResolve := resolveAgentCapabilitiesFn
+	clearAgentCapabilitiesCache()
+	resolveAgentCapabilitiesFn = func(_, _ string, agentID model.AgentID) (capabilities.ResolvedCapabilities, error) {
+		if agentID == model.AgentPiCodingAgent {
+			// Regression target: PI option must be visible even when unsupported.
+			return capabilities.ResolvedCapabilities{}, nil
+		}
+		return capabilities.ResolvedCapabilities{}, nil
+	}
+	t.Cleanup(func() {
+		resolveAgentCapabilitiesFn = origResolve
+		clearAgentCapabilitiesCache()
+	})
+
+	t.Run("direct model config with PI in selection shows PI option", func(t *testing.T) {
+		m := NewModel(system.DetectionResult{}, "dev")
+		m.Selection.Agents = []model.AgentID{model.AgentPiCodingAgent}
+		m.Screen = ScreenModelConfig
+
+		if !m.shouldShowPIModelConfigOption() {
+			t.Fatal("expected PI model config option to be visible when PI is selected")
+		}
+
+		view := m.View()
+		if !strings.Contains(view, screens.ModelConfigOptionPI) {
+			t.Fatalf("expected model config view to contain %q; got: %s", screens.ModelConfigOptionPI, view)
+		}
+	})
+
+	t.Run("agent selection flow toggle PI then navigate to model config still shows PI option", func(t *testing.T) {
+		m := NewModel(system.DetectionResult{}, "dev")
+		m.Screen = ScreenAgents
+		m.Selection.Agents = nil
+
+		agentOptions := screens.AgentOptions()
+		piCursor := -1
+		for i, agent := range agentOptions {
+			if agent == model.AgentPiCodingAgent {
+				piCursor = i
+				break
+			}
+		}
+		if piCursor == -1 {
+			t.Fatal("pi agent not found in agent options")
+		}
+
+		// Toggle PI in install flow.
+		m.Cursor = piCursor
+		updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+		state := updated.(Model)
+
+		if !state.Selection.HasAgent(model.AgentPiCodingAgent) {
+			t.Fatal("expected PI to remain selected after toggling in agent selection")
+		}
+
+		// Navigate back to welcome (agents -> detection -> welcome), then open model config.
+		updated, _ = state.Update(tea.KeyMsg{Type: tea.KeyEsc})
+		state = updated.(Model)
+		if state.Screen != ScreenDetection {
+			t.Fatalf("screen after esc from agents = %v, want %v", state.Screen, ScreenDetection)
+		}
+
+		updated, _ = state.Update(tea.KeyMsg{Type: tea.KeyEsc})
+		state = updated.(Model)
+		if state.Screen != ScreenWelcome {
+			t.Fatalf("screen after esc from detection = %v, want %v", state.Screen, ScreenWelcome)
+		}
+
+		state.Cursor = 4 // Configure Models
+		updated, _ = state.Update(tea.KeyMsg{Type: tea.KeyEnter})
+		state = updated.(Model)
+		if state.Screen != ScreenModelConfig {
+			t.Fatalf("screen = %v, want %v", state.Screen, ScreenModelConfig)
+		}
+
+		if !state.shouldShowPIModelConfigOption() {
+			t.Fatal("expected PI model config option to remain visible after install-flow navigation")
+		}
+
+		view := state.View()
+		if !strings.Contains(view, screens.ModelConfigOptionPI) {
+			t.Fatalf("expected model config view to contain %q after install-flow navigation", screens.ModelConfigOptionPI)
+		}
+	})
 }
 
 // TestModelConfig_ClaudePickerBackReturnsToModelConfig verifies that pressing
@@ -1599,7 +2043,7 @@ func TestModelConfig_OpenCodePickerBackReturnsToModelConfig(t *testing.T) {
 // makeDetectionWithAgents builds a DetectionResult with the specified agents
 // marked as Exists=true. All other agents are absent.
 func makeDetectionWithAgents(present ...string) system.DetectionResult {
-	known := []string{"claude-code", "opencode", "gemini-cli", "cursor", "vscode-copilot", "codex", "antigravity", "windsurf", "qwen-code"}
+	known := []string{"claude-code", "opencode", "pi-coding-agent", "gemini-cli", "cursor", "vscode-copilot", "codex", "antigravity", "windsurf", "qwen-code"}
 	presentSet := make(map[string]bool, len(present))
 	for _, p := range present {
 		presentSet[p] = true
@@ -1983,6 +2427,54 @@ func TestModelConfig_OpenCodePickerContinueTriggersSyncScreen(t *testing.T) {
 	}
 }
 
+// TestModelConfig_PIModelPickerContinueTriggersSyncScreen verifies that pressing
+// "Continue" from ScreenModelPicker while in ModelConfigMode and PI source
+// routes to ScreenSync with PIModelAssignments overrides (not OpenCode ones).
+func TestModelConfig_PIModelPickerContinueTriggersSyncScreen(t *testing.T) {
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Screen = ScreenModelPicker
+	m.ModelConfigMode = true
+
+	// Populate AvailableIDs so ModelPicker shows rows (not just "Back").
+	m.ModelPicker = screens.ModelPickerState{
+		Source:       "pi",
+		AvailableIDs: []string{"openai"},
+	}
+
+	m.Selection.PIModelAssignments = map[string]model.ModelAssignment{
+		"sdd-apply": {ProviderID: "openai", ModelID: "gpt-5"},
+	}
+	// Keep OpenCode assignments present to ensure PI flow does not write there.
+	m.Selection.ModelAssignments = map[string]model.ModelAssignment{
+		"sdd-apply": {ProviderID: "anthropic", ModelID: "claude-sonnet-4"},
+	}
+
+	continueIdx := len(screens.ModelPickerRows())
+	m.Cursor = continueIdx
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	state := updated.(Model)
+
+	if state.Screen != ScreenSync {
+		t.Fatalf("screen = %v, want ScreenSync (ModelConfigMode Continue should redirect to sync)", state.Screen)
+	}
+	if state.PendingSyncOverrides == nil {
+		t.Fatal("PendingSyncOverrides should be non-nil after PI model selection")
+	}
+	if got := state.PendingSyncOverrides.SDDMode; got != model.SDDModeMulti {
+		t.Errorf("PendingSyncOverrides.SDDMode = %q, want %q", got, model.SDDModeMulti)
+	}
+	if len(state.PendingSyncOverrides.PIModelAssignments) == 0 {
+		t.Fatalf("PendingSyncOverrides.PIModelAssignments should be non-empty, got: %v", state.PendingSyncOverrides.PIModelAssignments)
+	}
+	if got := state.PendingSyncOverrides.PIModelAssignments["sdd-apply"]; got.ProviderID != "openai" {
+		t.Errorf("PIModelAssignments[sdd-apply].ProviderID = %q, want %q", got.ProviderID, "openai")
+	}
+	if state.PendingSyncOverrides.ModelAssignments != nil {
+		t.Fatalf("PendingSyncOverrides.ModelAssignments should remain nil for PI source, got: %v", state.PendingSyncOverrides.ModelAssignments)
+	}
+}
+
 // TestModelConfig_SyncPassesOverridesToSyncFn verifies that when ScreenSync is
 // entered with PendingSyncOverrides set, pressing enter launches the sync and the
 // SyncFn receives the pending overrides (not nil).
@@ -2293,17 +2785,18 @@ func TestModelConfig_EscFromPickersReturnsToModelConfig(t *testing.T) {
 	}
 }
 
-// TestPreselectedAgents_AllSixAgentsMappedCorrectly verifies every canonical
+// TestPreselectedAgents_AllMappedAgents verifies every canonical
 // agent string maps to its model.AgentID constant in preselectedAgents.
 // This prevents silent drops when new agents are added to ScanConfigs without
 // updating the TUI switch statement.
-func TestPreselectedAgents_AllSixAgentsMappedCorrectly(t *testing.T) {
+func TestPreselectedAgents_AllMappedAgents(t *testing.T) {
 	tests := []struct {
 		configAgent string
 		wantID      model.AgentID
 	}{
 		{"claude-code", model.AgentClaudeCode},
 		{"opencode", model.AgentOpenCode},
+		{"pi-coding-agent", model.AgentPiCodingAgent},
 		{"gemini-cli", model.AgentGeminiCLI},
 		{"cursor", model.AgentCursor},
 		{"vscode-copilot", model.AgentVSCodeCopilot},
@@ -2330,6 +2823,124 @@ func TestPreselectedAgents_AllSixAgentsMappedCorrectly(t *testing.T) {
 			if len(selected) != 1 {
 				t.Errorf("preselectedAgents() returned %d agents, want 1 (only %q detected); got %v",
 					len(selected), tt.configAgent, selected)
+			}
+		})
+	}
+}
+
+func TestModelConfigOptionCount_ShowsPIWhenDetectedEvenIfUnselected(t *testing.T) {
+	origResolve := resolveAgentCapabilitiesFn
+	resolveAgentCapabilitiesFn = func(_, _ string, agentID model.AgentID) (capabilities.ResolvedCapabilities, error) {
+		if agentID == model.AgentPiCodingAgent {
+			return capabilities.ResolvedCapabilities{}, nil
+		}
+		return capabilities.ResolvedCapabilities{}, nil
+	}
+	t.Cleanup(func() { resolveAgentCapabilitiesFn = origResolve })
+
+	m := NewModel(system.DetectionResult{
+		Configs: []system.ConfigState{{Agent: string(model.AgentPiCodingAgent), Exists: true, IsDirectory: true}},
+	}, "dev")
+	m.Screen = ScreenModelConfig
+	m.Selection.Agents = nil
+
+	want := len(screens.ModelConfigOptionsForCapabilities(true))
+	if got := m.optionCount(); got != want {
+		t.Fatalf("optionCount() = %d, want %d (ModelConfigOptionsForCapabilities(true))", got, want)
+	}
+}
+
+func TestPIModelConfigVisibilityAndWarningMatrix(t *testing.T) {
+	tests := []struct {
+		name             string
+		selectedPI       bool
+		detectedPI       bool
+		plannedPI        bool
+		supportsMulti    bool
+		supportsPicker   bool
+		wantShowOption   bool
+		wantWarningShown bool
+	}{
+		{
+			name:             "no selected/detected/capability keeps PI option hidden",
+			wantShowOption:   false,
+			wantWarningShown: false,
+		},
+		{
+			name:             "selected PI shows option and warning when unsupported",
+			selectedPI:       true,
+			wantShowOption:   true,
+			wantWarningShown: true,
+		},
+		{
+			name:             "detected PI shows option and warning when unsupported",
+			detectedPI:       true,
+			wantShowOption:   true,
+			wantWarningShown: true,
+		},
+		{
+			name:             "planned install PI shows option and warning when unsupported",
+			plannedPI:        true,
+			wantShowOption:   true,
+			wantWarningShown: true,
+		},
+		{
+			name:             "capability alone can expose PI option without warning",
+			supportsPicker:   true,
+			wantShowOption:   true,
+			wantWarningShown: false,
+		},
+		{
+			name:             "selected PI with supported multi-model suppresses warning",
+			selectedPI:       true,
+			supportsMulti:    true,
+			wantShowOption:   true,
+			wantWarningShown: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			origResolve := resolveAgentCapabilitiesFn
+			clearAgentCapabilitiesCache()
+			resolveAgentCapabilitiesFn = func(_, _ string, agentID model.AgentID) (capabilities.ResolvedCapabilities, error) {
+				if agentID != model.AgentPiCodingAgent {
+					return capabilities.ResolvedCapabilities{}, nil
+				}
+				return capabilities.ResolvedCapabilities{
+					SupportsSDDMultiMode: tt.supportsMulti,
+					SupportsModelPicker:  tt.supportsPicker,
+				}, nil
+			}
+			t.Cleanup(func() {
+				resolveAgentCapabilitiesFn = origResolve
+				clearAgentCapabilitiesCache()
+			})
+
+			detection := system.DetectionResult{}
+			if tt.detectedPI {
+				detection.Configs = []system.ConfigState{{Agent: string(model.AgentPiCodingAgent), Exists: true, IsDirectory: true}}
+			}
+
+			m := NewModel(detection, "dev")
+			m.Selection.Agents = nil
+			if tt.selectedPI {
+				m.Selection.Agents = []model.AgentID{model.AgentPiCodingAgent}
+			}
+			if tt.plannedPI {
+				m.DependencyPlan = planner.ResolvedPlan{Agents: []model.AgentID{model.AgentPiCodingAgent}}
+			}
+
+			if got := m.shouldShowPIModelConfigOption(); got != tt.wantShowOption {
+				t.Fatalf("shouldShowPIModelConfigOption() = %v, want %v", got, tt.wantShowOption)
+			}
+
+			warning := m.modelConfigCapabilityWarning()
+			if got := warning != ""; got != tt.wantWarningShown {
+				t.Fatalf("warning shown = %v (warning=%q), want %v", got, warning, tt.wantWarningShown)
+			}
+			if tt.wantWarningShown && warning != capabilities.PiMultiModelRequiresPiSubagentsMessage {
+				t.Fatalf("warning = %q, want %q", warning, capabilities.PiMultiModelRequiresPiSubagentsMessage)
 			}
 		})
 	}
@@ -3245,6 +3856,277 @@ func TestModelConfigOpenCodeNoPrePopulationWhenFileEmpty(t *testing.T) {
 	}
 }
 
+func TestModelConfigOpenCodeWrappedCacheShowsProvidersAndModels(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	cacheDir := filepath.Join(home, ".cache", "opencode")
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(cacheDir) error = %v", err)
+	}
+
+	cacheJSON := `{
+		"providers": {
+			"opencode": {
+				"name": "OpenCode",
+				"models": {
+					"gpt-5-codex": {"id": "gpt-5-codex", "name": "GPT-5 Codex", "tool_call": true}
+				}
+			}
+		}
+	}`
+	if err := os.WriteFile(filepath.Join(cacheDir, "models.json"), []byte(cacheJSON), 0o644); err != nil {
+		t.Fatalf("WriteFile(models.json) error = %v", err)
+	}
+
+	origRead := readCurrentAssignmentsFn
+	readCurrentAssignmentsFn = func(string) (map[string]model.ModelAssignment, error) {
+		return nil, nil
+	}
+	t.Cleanup(func() { readCurrentAssignmentsFn = origRead })
+
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Screen = ScreenModelConfig
+	m.Cursor = 1 // Configure OpenCode models
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	state := updated.(Model)
+
+	if state.Screen != ScreenModelPicker {
+		t.Fatalf("screen = %v, want ScreenModelPicker", state.Screen)
+	}
+	if state.ModelPicker.Source != "opencode" {
+		t.Fatalf("ModelPicker.Source = %q, want opencode", state.ModelPicker.Source)
+	}
+	if len(state.ModelPicker.AvailableIDs) != 1 || state.ModelPicker.AvailableIDs[0] != "opencode" {
+		t.Fatalf("ModelPicker.AvailableIDs = %v, want [opencode]", state.ModelPicker.AvailableIDs)
+	}
+
+	state.Cursor = 0 // sdd-orchestrator row
+	updated, _ = state.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	state = updated.(Model)
+	if state.ModelPicker.Mode != screens.ModeProviderSelect {
+		t.Fatalf("ModelPicker.Mode = %v, want ModeProviderSelect", state.ModelPicker.Mode)
+	}
+
+	providerView := screens.RenderModelPicker(state.Selection.ModelAssignments, state.ModelPicker, state.Cursor)
+	if !strings.Contains(providerView, "OpenCode") {
+		t.Fatalf("provider picker should render OpenCode provider, got:\n%s", providerView)
+	}
+}
+
+func TestModelConfigPIPrePopulatesAssignmentsFromPersistedState(t *testing.T) {
+	origResolve := resolveAgentCapabilitiesFn
+	resolveAgentCapabilitiesFn = func(_, _ string, agentID model.AgentID) (capabilities.ResolvedCapabilities, error) {
+		if agentID == model.AgentPiCodingAgent {
+			return capabilities.ResolvedCapabilities{SupportsSDDMultiMode: true, SupportsModelPicker: true}, nil
+		}
+		return capabilities.ResolvedCapabilities{}, nil
+	}
+	t.Cleanup(func() { resolveAgentCapabilitiesFn = origResolve })
+
+	origLoader := loadPIModelCatalogFn
+	loadPIModelCatalogFn = func(context.Context) (modelcatalog.Catalog, error) {
+		return modelcatalog.Catalog{
+			Providers: map[string]modelcatalog.Provider{"openai": {ID: "openai", Name: "OpenAI"}},
+			AvailableProviderIDs: []string{"openai"},
+			SDDModels:            map[string][]modelcatalog.Model{"openai": {{ID: "gpt-5", Name: "GPT-5"}}},
+		}, nil
+	}
+	t.Cleanup(func() { loadPIModelCatalogFn = origLoader })
+
+	persisted := map[string]model.ModelAssignment{
+		"sdd-apply": {ProviderID: "openai", ModelID: "gpt-5"},
+	}
+	origReadPersisted := readPersistedPIAssignmentsFn
+	readPersistedPIAssignmentsFn = func(string) (map[string]model.ModelAssignment, error) {
+		return persisted, nil
+	}
+	t.Cleanup(func() { readPersistedPIAssignmentsFn = origReadPersisted })
+
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Selection.Agents = []model.AgentID{model.AgentPiCodingAgent}
+	m.Screen = ScreenModelConfig
+	m.Cursor = modelConfigOptionCursor(t, screens.ModelConfigOptionsForCapabilities(true), screens.ModelConfigOptionPI)
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	state := updated.(Model)
+
+	if state.Screen != ScreenModelPicker {
+		t.Fatalf("screen = %v, want ScreenModelPicker", state.Screen)
+	}
+	if state.ModelPicker.Source != "pi" {
+		t.Fatalf("ModelPicker.Source = %q, want pi", state.ModelPicker.Source)
+	}
+	if got := state.Selection.PIModelAssignments["sdd-apply"]; got.FullID() != "openai/gpt-5" {
+		t.Fatalf("PIModelAssignments[sdd-apply] = %q, want %q", got.FullID(), "openai/gpt-5")
+	}
+
+	view := state.View()
+	if !strings.Contains(view, "sdd-apply") || !strings.Contains(view, "OpenAI / gpt-5") {
+		t.Fatalf("PI picker view should show persisted sdd-apply selection; got:\n%s", view)
+	}
+}
+
+func TestModelConfigMixedOpenCodeAndPIPrePopulationRemainSeparated(t *testing.T) {
+	origResolve := resolveAgentCapabilitiesFn
+	resolveAgentCapabilitiesFn = func(_, _ string, agentID model.AgentID) (capabilities.ResolvedCapabilities, error) {
+		if agentID == model.AgentPiCodingAgent {
+			return capabilities.ResolvedCapabilities{SupportsSDDMultiMode: true, SupportsModelPicker: true}, nil
+		}
+		if agentID == model.AgentOpenCode {
+			return capabilities.ResolvedCapabilities{SupportsSDDMultiMode: true, SupportsModelPicker: true}, nil
+		}
+		return capabilities.ResolvedCapabilities{}, nil
+	}
+	t.Cleanup(func() { resolveAgentCapabilitiesFn = origResolve })
+
+	origStat := osStatModelCache
+	osStatModelCache = func(string) (os.FileInfo, error) { return nil, nil }
+	t.Cleanup(func() { osStatModelCache = origStat })
+
+	origReadOpenCode := readCurrentAssignmentsFn
+	readCurrentAssignmentsFn = func(string) (map[string]model.ModelAssignment, error) {
+		return map[string]model.ModelAssignment{
+			"sdd-orchestrator": {ProviderID: "anthropic", ModelID: "claude-sonnet-4"},
+		}, nil
+	}
+	t.Cleanup(func() { readCurrentAssignmentsFn = origReadOpenCode })
+
+	origLoader := loadPIModelCatalogFn
+	loadPIModelCatalogFn = func(context.Context) (modelcatalog.Catalog, error) {
+		return modelcatalog.Catalog{
+			Providers: map[string]modelcatalog.Provider{"openai": {ID: "openai", Name: "OpenAI"}},
+			AvailableProviderIDs: []string{"openai"},
+			SDDModels:            map[string][]modelcatalog.Model{"openai": {{ID: "gpt-5-mini", Name: "GPT-5 Mini"}}},
+		}, nil
+	}
+	t.Cleanup(func() { loadPIModelCatalogFn = origLoader })
+
+	origReadPersisted := readPersistedPIAssignmentsFn
+	readPersistedPIAssignmentsFn = func(string) (map[string]model.ModelAssignment, error) {
+		return map[string]model.ModelAssignment{
+			"sdd-apply": {ProviderID: "openai", ModelID: "gpt-5-mini"},
+		}, nil
+	}
+	t.Cleanup(func() { readPersistedPIAssignmentsFn = origReadPersisted })
+
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Selection.Agents = []model.AgentID{model.AgentOpenCode, model.AgentPiCodingAgent}
+	m.Screen = ScreenModelConfig
+
+	m.Cursor = modelConfigOptionCursor(t, screens.ModelConfigOptionsForCapabilities(true), screens.ModelConfigOptionOpenCode)
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	state := updated.(Model)
+
+	if got := state.Selection.ModelAssignments["sdd-orchestrator"]; got.FullID() != "anthropic/claude-sonnet-4" {
+		t.Fatalf("ModelAssignments[sdd-orchestrator] = %q, want %q", got.FullID(), "anthropic/claude-sonnet-4")
+	}
+	if state.Selection.PIModelAssignments != nil {
+		t.Fatalf("PIModelAssignments should still be nil before PI picker, got %v", state.Selection.PIModelAssignments)
+	}
+
+	updated, _ = state.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	state = updated.(Model)
+	if state.Screen != ScreenModelConfig {
+		t.Fatalf("screen after esc = %v, want ScreenModelConfig", state.Screen)
+	}
+
+	state.Cursor = modelConfigOptionCursor(t, screens.ModelConfigOptionsForCapabilities(true), screens.ModelConfigOptionPI)
+	updated, _ = state.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	state = updated.(Model)
+
+	if got := state.Selection.ModelAssignments["sdd-orchestrator"]; got.FullID() != "anthropic/claude-sonnet-4" {
+		t.Fatalf("ModelAssignments changed after PI picker init: got %q", got.FullID())
+	}
+	if got := state.Selection.PIModelAssignments["sdd-apply"]; got.FullID() != "openai/gpt-5-mini" {
+		t.Fatalf("PIModelAssignments[sdd-apply] = %q, want %q", got.FullID(), "openai/gpt-5-mini")
+	}
+
+	view := state.View()
+	if !strings.Contains(view, "sdd-orchestrator") || !strings.Contains(view, "(default)") {
+		t.Fatalf("PI picker view should not render OpenCode assignment rows as non-default; got:\n%s", view)
+	}
+	if !strings.Contains(view, "sdd-apply") || !strings.Contains(view, "OpenAI / gpt-5-mini") {
+		t.Fatalf("PI picker view should render persisted PI sdd-apply selection; got:\n%s", view)
+	}
+}
+
+func TestModelConfig_PIOptionUnsupportedCapabilityShowsBlockedPickerFromInstallSelection(t *testing.T) {
+	origResolve := resolveAgentCapabilitiesFn
+	clearAgentCapabilitiesCache()
+	resolveAgentCapabilitiesFn = func(_, _ string, agentID model.AgentID) (capabilities.ResolvedCapabilities, error) {
+		if agentID == model.AgentPiCodingAgent {
+			return capabilities.ResolvedCapabilities{}, nil
+		}
+		return capabilities.ResolvedCapabilities{}, nil
+	}
+	t.Cleanup(func() {
+		resolveAgentCapabilitiesFn = origResolve
+		clearAgentCapabilitiesCache()
+	})
+
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Selection.Agents = []model.AgentID{model.AgentPiCodingAgent}
+	m.Screen = ScreenModelConfig
+
+	view := m.View()
+	if !strings.Contains(view, screens.ModelConfigOptionPI) {
+		t.Fatalf("model config should render %q for PI-selected install flow", screens.ModelConfigOptionPI)
+	}
+
+	m.Cursor = modelConfigOptionCursor(t, screens.ModelConfigOptionsForCapabilities(true), screens.ModelConfigOptionPI)
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	state := updated.(Model)
+
+	if state.Screen != ScreenModelPicker || !state.ModelPicker.CapabilityBlocked {
+		t.Fatalf("PI option should open blocked PI picker, got screen=%v blocked=%v", state.Screen, state.ModelPicker.CapabilityBlocked)
+	}
+	if state.ModelPicker.CapabilityMessage != capabilities.PiMultiModelRequiresPiSubagentsMessage {
+		t.Fatalf("CapabilityMessage = %q, want canonical warning %q", state.ModelPicker.CapabilityMessage, capabilities.PiMultiModelRequiresPiSubagentsMessage)
+	}
+
+	blockedView := state.View()
+	if !strings.Contains(blockedView, capabilities.PiMultiModelRequiresPiSubagentsMessage) {
+		t.Fatalf("blocked PI picker view missing canonical warning; got:\n%s", blockedView)
+	}
+}
+
+func TestModelConfig_PIRPCDeadlineExceededShowsActionableBlockedMessage(t *testing.T) {
+	origResolve := resolveAgentCapabilitiesFn
+	resolveAgentCapabilitiesFn = func(_, _ string, agentID model.AgentID) (capabilities.ResolvedCapabilities, error) {
+		if agentID == model.AgentPiCodingAgent {
+			return capabilities.ResolvedCapabilities{SupportsSDDMultiMode: true, SupportsModelPicker: true}, nil
+		}
+		return capabilities.ResolvedCapabilities{}, nil
+	}
+	t.Cleanup(func() { resolveAgentCapabilitiesFn = origResolve })
+
+	origLoader := loadPIModelCatalogFn
+	loadPIModelCatalogFn = func(context.Context) (modelcatalog.Catalog, error) {
+		return modelcatalog.Catalog{}, context.DeadlineExceeded
+	}
+	t.Cleanup(func() { loadPIModelCatalogFn = origLoader })
+
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Selection.Agents = []model.AgentID{model.AgentPiCodingAgent}
+	m.Screen = ScreenModelConfig
+	m.Cursor = modelConfigOptionCursor(t, screens.ModelConfigOptionsForCapabilities(true), screens.ModelConfigOptionPI)
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	state := updated.(Model)
+
+	if !state.ModelPicker.CapabilityBlocked {
+		t.Fatal("expected PI picker to be blocked on deadline exceeded")
+	}
+	if strings.Contains(state.ModelPicker.CapabilityMessage, fmt.Sprint(context.DeadlineExceeded)) {
+		t.Fatalf("blocked message should be actionable and hide raw deadline error, got %q", state.ModelPicker.CapabilityMessage)
+	}
+	if !strings.Contains(state.ModelPicker.CapabilityMessage, "terminated before it returned models") {
+		t.Fatalf("blocked message should explain timeout/termination cause, got %q", state.ModelPicker.CapabilityMessage)
+	}
+}
+
 // TestCustomSkillPickerBackGoesToStrictTDD verifies that in the custom preset,
 // with OpenCode + SDD + Skills, pressing Back on ScreenSkillPicker goes to ScreenStrictTDD
 // and NOT directly to ScreenSDDMode. StrictTDD must come before SDDMode in the back chain.
@@ -3434,5 +4316,56 @@ func TestPinErrClearedOnScreenReentry(t *testing.T) {
 	// PinErr must be cleared on re-entry.
 	if afterReturn.PinErr != nil {
 		t.Fatalf("PinErr should be nil after returning to ScreenBackups, got: %v", afterReturn.PinErr)
+	}
+}
+
+func TestResolveAgentCapabilitiesCachesAndInvalidatesByWorkspaceAndAgent(t *testing.T) {
+	origHome := osUserHomeDirFn
+	origGetwd := osGetwdFn
+	origResolve := resolveAgentCapabilitiesFn
+	clearAgentCapabilitiesCache()
+	t.Cleanup(func() {
+		osUserHomeDirFn = origHome
+		osGetwdFn = origGetwd
+		resolveAgentCapabilitiesFn = origResolve
+		clearAgentCapabilitiesCache()
+	})
+
+	home := t.TempDir()
+	workspace := filepath.Join(home, "workspace")
+	if err := os.MkdirAll(workspace, 0o755); err != nil {
+		t.Fatalf("MkdirAll(workspace) error = %v", err)
+	}
+
+	osUserHomeDirFn = func() (string, error) { return home, nil }
+	currentWorkspace := workspace
+	osGetwdFn = func() (string, error) { return currentWorkspace, nil }
+
+	resolveCalls := 0
+	resolveAgentCapabilitiesFn = func(_, _ string, _ model.AgentID) (capabilities.ResolvedCapabilities, error) {
+		resolveCalls++
+		return capabilities.ResolvedCapabilities{SupportsSDDMultiMode: true}, nil
+	}
+
+	m := NewModel(system.DetectionResult{}, "dev")
+
+	_ = m.resolveAgentCapabilities(model.AgentPiCodingAgent)
+	_ = m.resolveAgentCapabilities(model.AgentPiCodingAgent)
+	if resolveCalls != 1 {
+		t.Fatalf("resolver calls for repeated same-agent same-workspace = %d, want 1", resolveCalls)
+	}
+
+	_ = m.resolveAgentCapabilities(model.AgentOpenCode)
+	if resolveCalls != 2 {
+		t.Fatalf("resolver calls after agent change = %d, want 2", resolveCalls)
+	}
+
+	currentWorkspace = filepath.Join(home, "other-workspace")
+	if err := os.MkdirAll(currentWorkspace, 0o755); err != nil {
+		t.Fatalf("MkdirAll(other-workspace) error = %v", err)
+	}
+	_ = m.resolveAgentCapabilities(model.AgentPiCodingAgent)
+	if resolveCalls != 3 {
+		t.Fatalf("resolver calls after workspace change = %d, want 3", resolveCalls)
 	}
 }

--- a/internal/tui/screens/agents.go
+++ b/internal/tui/screens/agents.go
@@ -1,6 +1,7 @@
 package screens
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/gentleman-programming/gentle-ai/internal/catalog"
@@ -17,7 +18,7 @@ func AgentOptions() []model.AgentID {
 	return ids
 }
 
-func RenderAgents(selected []model.AgentID, cursor int) string {
+func RenderAgents(selected []model.AgentID, cursor int, warnings []string) string {
 	var b strings.Builder
 
 	b.WriteString(styles.TitleStyle.Render("Select AI Agents"))
@@ -31,10 +32,31 @@ func RenderAgents(selected []model.AgentID, cursor int) string {
 	}
 
 	agents := AgentOptions()
+	agentMeta := make(map[model.AgentID]catalog.Agent, len(catalog.AllAgents()))
+	for _, info := range catalog.AllAgents() {
+		agentMeta[info.ID] = info
+	}
+
 	for idx, agent := range agents {
 		_, checked := selectedSet[agent]
 		focused := idx == cursor
-		b.WriteString(renderCheckbox(string(agent), checked, focused))
+		label := string(agent)
+		if info, ok := agentMeta[agent]; ok {
+			label = info.Name
+			if len(info.CapabilityLabels) > 0 {
+				label = fmt.Sprintf("%s [%s]", label, strings.Join(info.CapabilityLabels, ", "))
+			}
+		}
+		b.WriteString(renderCheckbox(label, checked, focused))
+	}
+
+	for _, warning := range warnings {
+		if strings.TrimSpace(warning) == "" {
+			continue
+		}
+		b.WriteString("\n")
+		b.WriteString(styles.WarningStyle.Render(warning))
+		b.WriteString("\n")
 	}
 
 	b.WriteString("\n")

--- a/internal/tui/screens/agents_test.go
+++ b/internal/tui/screens/agents_test.go
@@ -1,0 +1,57 @@
+package screens_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/internal/model"
+	"github.com/gentleman-programming/gentle-ai/internal/tui/screens"
+)
+
+func TestRenderAgents_PICapabilityWarningGolden(t *testing.T) {
+	out := screens.RenderAgents([]model.AgentID{model.AgentPiCodingAgent}, 2, []string{"PI is experimental and non-parity: multi-model is enabled only when `pi-subagents` is installed."})
+	snippet := extractLinesContaining(out, []string{"pi-coding-agent", "multi-model is enabled only"})
+	assertGoldenString(t, "agents_pi_warning.golden.txt", snippet)
+}
+
+func TestRenderAgents_ShowsPICapabilityLabels(t *testing.T) {
+	out := screens.RenderAgents([]model.AgentID{model.AgentPiCodingAgent}, 0, []string{"PI is experimental and non-parity: multi-model is enabled only when `pi-subagents` is installed."})
+	if !strings.Contains(out, "experimental") {
+		t.Fatalf("expected PI capability label 'experimental' in output")
+	}
+	if !strings.Contains(out, "non-parity") {
+		t.Fatalf("expected PI capability label 'non-parity' in output")
+	}
+	if !strings.Contains(out, "multi-model is enabled only when `pi-subagents` is installed") {
+		t.Fatalf("expected PI warning about conditional multi-model requirement")
+	}
+}
+
+func assertGoldenString(t *testing.T, name, got string) {
+	t.Helper()
+	goldenPath := filepath.Join("testdata", name)
+	wantBytes, err := os.ReadFile(goldenPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", goldenPath, err)
+	}
+	want := string(wantBytes)
+	if strings.TrimSpace(got) != strings.TrimSpace(want) {
+		t.Fatalf("golden mismatch %s\n--- got ---\n%s\n--- want ---\n%s", name, got, want)
+	}
+}
+
+func extractLinesContaining(text string, needles []string) string {
+	lines := strings.Split(text, "\n")
+	kept := make([]string, 0, len(lines))
+	for _, line := range lines {
+		for _, needle := range needles {
+			if strings.Contains(line, needle) {
+				kept = append(kept, strings.TrimSpace(line))
+				break
+			}
+		}
+	}
+	return strings.Join(kept, "\n")
+}

--- a/internal/tui/screens/model_config.go
+++ b/internal/tui/screens/model_config.go
@@ -6,32 +6,66 @@ import (
 	"github.com/gentleman-programming/gentle-ai/internal/tui/styles"
 )
 
+const (
+	ModelConfigOptionClaude   = "Configure Claude models"
+	ModelConfigOptionOpenCode = "Configure OpenCode models"
+	ModelConfigOptionKiro     = "Configure Kiro models"
+	ModelConfigOptionPI       = "Configure PI models"
+	ModelConfigOptionBack     = "Back"
+)
+
 // ModelConfigOptions returns the ordered list of options shown on the model config screen.
 func ModelConfigOptions() []string {
-	return []string{
-		"Configure Claude models",
-		"Configure OpenCode models",
-		"Configure Kiro models",
-		"Back",
-	}
+	return ModelConfigOptionsForCapabilities(false)
 }
 
-// RenderModelConfig renders the model configuration entry screen.
-// It shows a 4-option menu: Claude models, OpenCode models, Kiro models, Back.
-// cursor indicates which option is currently highlighted.
-func RenderModelConfig(cursor int) string {
+// ModelConfigOptionsForCapabilities returns model config options with PI
+// multi-model controls shown only when capability support is enabled.
+func ModelConfigOptionsForCapabilities(piSupportsMultiModel bool) []string {
+	options := []string{
+		ModelConfigOptionClaude,
+		ModelConfigOptionOpenCode,
+		ModelConfigOptionKiro,
+	}
+
+	if piSupportsMultiModel {
+		options = append(options, ModelConfigOptionPI)
+	}
+
+	options = append(options, ModelConfigOptionBack)
+
+	return options
+}
+
+// RenderModelConfigWithCapabilities renders the model configuration entry
+// screen with optional PI capability controls and warning message.
+func RenderModelConfigWithCapabilities(cursor int, piSupportsMultiModel bool, warning string) string {
+	options := ModelConfigOptionsForCapabilities(piSupportsMultiModel)
+
 	var b strings.Builder
 
 	b.WriteString(styles.TitleStyle.Render("Model Configuration"))
 	b.WriteString("\n\n")
 
 	b.WriteString(styles.SubtextStyle.Render("Choose which AI model to configure:"))
+	b.WriteString("\n")
+	if warning != "" {
+		b.WriteString("\n")
+		b.WriteString(styles.WarningStyle.Render(warning))
+	}
 	b.WriteString("\n\n")
 
-	b.WriteString(renderOptions(ModelConfigOptions(), cursor))
+	b.WriteString(renderOptions(options, cursor))
 
 	b.WriteString("\n")
 	b.WriteString(styles.HelpStyle.Render("j/k: navigate • enter: select • esc: back • q: quit"))
 
 	return styles.FrameStyle.Render(b.String())
+}
+
+// RenderModelConfig renders the model configuration entry screen.
+// It shows a 4-option menu: Claude models, OpenCode models, Kiro models, Back.
+// cursor indicates which option is currently highlighted.
+func RenderModelConfig(cursor int) string {
+	return RenderModelConfigWithCapabilities(cursor, false, "")
 }

--- a/internal/tui/screens/model_config_test.go
+++ b/internal/tui/screens/model_config_test.go
@@ -86,6 +86,37 @@ func TestRenderModelConfig_ContainsNavigationHint(t *testing.T) {
 	}
 }
 
+func TestModelConfigOptionsForCapabilities_PIUnsupportedHidesMultiModelOption(t *testing.T) {
+	opts := ModelConfigOptionsForCapabilities(false)
+	for _, opt := range opts {
+		if strings.Contains(opt, "PI") {
+			t.Fatalf("unexpected PI model option when PI multi-model is unsupported: %v", opts)
+		}
+	}
+}
+
+func TestModelConfigOptionsForCapabilities_PISupportedShowsMultiModelOption(t *testing.T) {
+	opts := ModelConfigOptionsForCapabilities(true)
+	found := false
+	for _, opt := range opts {
+		if strings.Contains(opt, "PI") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected PI model option when PI multi-model is supported; got: %v", opts)
+	}
+}
+
+func TestRenderModelConfigWithCapabilities_ShowsCanonicalPIRequirementWarning(t *testing.T) {
+	warning := "PI multi-model requires installing the `pi-subagents` extension."
+	out := RenderModelConfigWithCapabilities(0, false, warning)
+	if !strings.Contains(out, warning) {
+		t.Fatalf("expected canonical PI requirement warning in model config render")
+	}
+}
+
 // stripStyleArtifacts returns a simplified plain-text version of a string for
 // comparison when style codes may wrap the content. We check for key words
 // contained in the original string.

--- a/internal/tui/screens/model_picker.go
+++ b/internal/tui/screens/model_picker.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/gentleman-programming/gentle-ai/internal/model"
+	"github.com/gentleman-programming/gentle-ai/internal/modelcatalog"
 	"github.com/gentleman-programming/gentle-ai/internal/opencode"
 	"github.com/gentleman-programming/gentle-ai/internal/tui/styles"
 )
@@ -32,9 +33,13 @@ type ProviderEntry struct {
 // ModelPickerState holds the available providers and models for the picker screen,
 // plus navigation state for the two-step sub-selection modes.
 type ModelPickerState struct {
-	Providers    map[string]opencode.Provider
-	AvailableIDs []string                    // provider IDs with tool_call-capable models
-	SDDModels    map[string][]opencode.Model // provider ID -> SDD-capable models
+	Providers         map[string]modelcatalog.Provider
+	AvailableIDs      []string                        // provider IDs with tool_call-capable models
+	SDDModels         map[string][]modelcatalog.Model // provider ID -> SDD-capable models
+	Source            string
+	EmptyStateHint    string
+	CapabilityBlocked bool
+	CapabilityMessage string
 
 	Mode             ModelPickerMode
 	SelectedPhaseIdx int    // which phase row was selected (0 = "Set all")
@@ -55,22 +60,22 @@ type ModelPickerState struct {
 
 // NewModelPickerState initializes the picker state from the models cache.
 func NewModelPickerState(cachePath string) ModelPickerState {
-	providers, err := opencode.LoadModels(cachePath)
+	catalog, err := opencode.LoadCatalog(cachePath)
 	if err != nil {
 		return ModelPickerState{}
 	}
+	state := NewModelPickerStateFromCatalog(catalog)
+	state.Source = "opencode"
+	state.EmptyStateHint = "For OpenCode, run 'opencode' once, then re-run 'gentle-ai sync' to assign models."
+	return state
+}
 
-	available := opencode.DetectAvailableProviders(providers)
-
-	sddModels := make(map[string][]opencode.Model, len(available))
-	for _, id := range available {
-		sddModels[id] = opencode.FilterModelsForSDD(providers[id])
-	}
-
+// NewModelPickerStateFromCatalog initializes picker state from a normalized catalog.
+func NewModelPickerStateFromCatalog(catalog modelcatalog.Catalog) ModelPickerState {
 	return ModelPickerState{
-		Providers:    providers,
-		AvailableIDs: available,
-		SDDModels:    sddModels,
+		Providers:    catalog.Providers,
+		AvailableIDs: catalog.AvailableProviderIDs,
+		SDDModels:    catalog.SDDModels,
 		Mode:         ModePhaseList,
 	}
 }
@@ -262,11 +267,31 @@ func renderPhaseList(
 
 	b.WriteString(styles.TitleStyle.Render("Assign Models to SDD Phases"))
 	b.WriteString("\n\n")
+	b.WriteString(styles.WarningStyle.Render("Model picker availability is capability-gated per agent."))
+	b.WriteString("\n\n")
+
+	if state.CapabilityBlocked {
+		message := state.CapabilityMessage
+		if message == "" {
+			message = "Multi-model picker is unavailable for this agent setup."
+		}
+
+		b.WriteString(styles.WarningStyle.Render(message))
+		b.WriteString("\n\n")
+		b.WriteString(renderOptions([]string{"← Back to SDD mode"}, cursor))
+		b.WriteString("\n")
+		b.WriteString(styles.HelpStyle.Render("enter/esc: go back"))
+		return b.String()
+	}
 
 	if len(state.AvailableIDs) == 0 {
-		b.WriteString(styles.WarningStyle.Render("OpenCode has not been run yet — model cache not found."))
+		b.WriteString(styles.WarningStyle.Render("No compatible provider/model cache was detected for this agent."))
 		b.WriteString("\n")
-		b.WriteString(styles.SubtextStyle.Render("Run 'opencode' once, then re-run 'gentle-ai sync' to assign models."))
+		hint := state.EmptyStateHint
+		if hint == "" {
+			hint = "For OpenCode, run 'opencode' once, then re-run 'gentle-ai sync' to assign models."
+		}
+		b.WriteString(styles.SubtextStyle.Render(hint))
 		b.WriteString("\n")
 		b.WriteString(styles.SubtextStyle.Render("Using default model assignments for now."))
 		b.WriteString("\n\n")

--- a/internal/tui/screens/model_picker_test.go
+++ b/internal/tui/screens/model_picker_test.go
@@ -1,9 +1,11 @@
 package screens
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/gentleman-programming/gentle-ai/internal/model"
+	"github.com/gentleman-programming/gentle-ai/internal/modelcatalog"
 	"github.com/gentleman-programming/gentle-ai/internal/opencode"
 )
 
@@ -11,7 +13,7 @@ import (
 // so that handleModelNav can reach the "enter" branch.
 func makeTestState(phaseIdx int) *ModelPickerState {
 	const providerID = "test-provider"
-	testModels := []opencode.Model{
+	testModels := []modelcatalog.Model{
 		{ID: "model-alpha", Name: "Alpha Model"},
 		{ID: "model-beta", Name: "Beta Model"},
 	}
@@ -19,7 +21,7 @@ func makeTestState(phaseIdx int) *ModelPickerState {
 		Mode:             ModeModelSelect,
 		SelectedPhaseIdx: phaseIdx,
 		SelectedProvider: providerID,
-		SDDModels:        map[string][]opencode.Model{providerID: testModels},
+		SDDModels:        map[string][]modelcatalog.Model{providerID: testModels},
 		ModelCursor:      0, // always pick the first model for simplicity
 	}
 }
@@ -205,7 +207,7 @@ func TestSDDOrchestratorPhaseConstant(t *testing.T) {
 // Closes #146.
 func TestSetAllPhasesLabelSeparateFromIndividualPhases(t *testing.T) {
 	const providerID = "test-provider"
-	testModels := []opencode.Model{
+	testModels := []modelcatalog.Model{
 		{ID: "model-alpha", Name: "Alpha"},
 		{ID: "model-beta", Name: "Beta"},
 	}
@@ -215,7 +217,7 @@ func TestSetAllPhasesLabelSeparateFromIndividualPhases(t *testing.T) {
 		Mode:             ModeModelSelect,
 		SelectedPhaseIdx: 1, // "Set all phases" row
 		SelectedProvider: providerID,
-		SDDModels:        map[string][]opencode.Model{providerID: testModels},
+		SDDModels:        map[string][]modelcatalog.Model{providerID: testModels},
 		ModelCursor:      0, // alpha
 	}
 	assignments := make(map[string]model.ModelAssignment)
@@ -232,7 +234,7 @@ func TestSetAllPhasesLabelSeparateFromIndividualPhases(t *testing.T) {
 		Mode:             ModeModelSelect,
 		SelectedPhaseIdx: 2, // sub-agent row idx 2 → phases[0]
 		SelectedProvider: providerID,
-		SDDModels:        map[string][]opencode.Model{providerID: testModels},
+		SDDModels:        map[string][]modelcatalog.Model{providerID: testModels},
 		ModelCursor:      1, // beta — different from what "Set all" used
 	}
 	_, assignments = handleModelNav("enter", individualState, assignments)
@@ -250,7 +252,7 @@ func TestSetAllPhasesLabelSeparateFromIndividualPhases(t *testing.T) {
 // Closes #146.
 func TestSetAllPhasesSetsAllPhasesModelField(t *testing.T) {
 	const providerID = "test-provider"
-	testModels := []opencode.Model{
+	testModels := []modelcatalog.Model{
 		{ID: "model-alpha", Name: "Alpha"},
 	}
 
@@ -258,7 +260,7 @@ func TestSetAllPhasesSetsAllPhasesModelField(t *testing.T) {
 		Mode:             ModeModelSelect,
 		SelectedPhaseIdx: 1, // "Set all phases"
 		SelectedProvider: providerID,
-		SDDModels:        map[string][]opencode.Model{providerID: testModels},
+		SDDModels:        map[string][]modelcatalog.Model{providerID: testModels},
 		ModelCursor:      0,
 	}
 	assignments := make(map[string]model.ModelAssignment)
@@ -278,7 +280,7 @@ func TestSetAllPhasesSetsAllPhasesModelField(t *testing.T) {
 // Closes #146.
 func TestIndividualPhaseSelectionDoesNotSetAllPhasesModel(t *testing.T) {
 	const providerID = "test-provider"
-	testModels := []opencode.Model{
+	testModels := []modelcatalog.Model{
 		{ID: "model-alpha", Name: "Alpha"},
 	}
 	phases := opencode.SDDPhases()
@@ -289,7 +291,7 @@ func TestIndividualPhaseSelectionDoesNotSetAllPhasesModel(t *testing.T) {
 				Mode:             ModeModelSelect,
 				SelectedPhaseIdx: i + 2, // sub-agent rows start at idx 2
 				SelectedProvider: providerID,
-				SDDModels:        map[string][]opencode.Model{providerID: testModels},
+				SDDModels:        map[string][]modelcatalog.Model{providerID: testModels},
 				ModelCursor:      0,
 			}
 			assignments := make(map[string]model.ModelAssignment)
@@ -300,5 +302,106 @@ func TestIndividualPhaseSelectionDoesNotSetAllPhasesModel(t *testing.T) {
 					phase, state.AllPhasesModel)
 			}
 		})
+	}
+}
+
+func TestProviderEntries_SortsByDisplayName(t *testing.T) {
+	state := ModelPickerState{
+		AvailableIDs: []string{"z", "a"},
+		Providers: map[string]modelcatalog.Provider{
+			"z": {ID: "z", Name: "Zulu", Models: map[string]modelcatalog.Model{"m1": {ID: "m1"}}},
+			"a": {ID: "a", Name: "Alpha", Models: map[string]modelcatalog.Model{"m2": {ID: "m2"}, "m3": {ID: "m3"}}},
+		},
+		SDDModels: map[string][]modelcatalog.Model{
+			"z": {{ID: "m1"}},
+			"a": {{ID: "m2"}, {ID: "m3"}},
+		},
+	}
+
+	entries := ProviderEntries(state)
+	if len(entries) != 2 {
+		t.Fatalf("ProviderEntries() len = %d, want 2", len(entries))
+	}
+	if entries[0].Name != "Alpha" || entries[1].Name != "Zulu" {
+		t.Fatalf("ProviderEntries() names = [%s, %s], want [Alpha, Zulu]", entries[0].Name, entries[1].Name)
+	}
+	if entries[0].ModelCount != 2 {
+		t.Fatalf("ProviderEntries()[0].ModelCount = %d, want 2", entries[0].ModelCount)
+	}
+}
+
+func TestHandleProviderNav_TransitionsBetweenModes(t *testing.T) {
+	state := &ModelPickerState{
+		Mode:         ModeProviderSelect,
+		AvailableIDs: []string{"openai"},
+		Providers: map[string]modelcatalog.Provider{
+			"openai": {ID: "openai", Name: "OpenAI"},
+		},
+		SDDModels: map[string][]modelcatalog.Model{"openai": {{ID: "gpt-5", Name: "GPT-5"}}},
+	}
+
+	handled, _ := HandleModelPickerNav("enter", state, nil)
+	if !handled {
+		t.Fatal("HandleModelPickerNav(enter) should be handled in provider mode")
+	}
+	if state.Mode != ModeModelSelect || state.SelectedProvider != "openai" {
+		t.Fatalf("provider enter should switch to model mode with selected provider, got mode=%v provider=%q", state.Mode, state.SelectedProvider)
+	}
+
+	handled, _ = HandleModelPickerNav("esc", state, nil)
+	if !handled {
+		t.Fatal("HandleModelPickerNav(esc) should be handled in model mode")
+	}
+	if state.Mode != ModeProviderSelect {
+		t.Fatalf("model esc should return to provider mode, got %v", state.Mode)
+	}
+}
+
+func TestRenderProviderAndModelSelect_ShowsListContent(t *testing.T) {
+	state := ModelPickerState{
+		Mode:             ModeProviderSelect,
+		AvailableIDs:     []string{"openai"},
+		ProviderCursor:   0,
+		SelectedProvider: "openai",
+		Providers: map[string]modelcatalog.Provider{
+			"openai": {
+				ID:   "openai",
+				Name: "OpenAI",
+				Models: map[string]modelcatalog.Model{
+					"gpt-5": {ID: "gpt-5", Name: "GPT-5"},
+				},
+			},
+		},
+		SDDModels: map[string][]modelcatalog.Model{"openai": {{ID: "gpt-5", Name: "GPT-5"}}},
+	}
+
+	providerOut := RenderModelPicker(nil, state, 0)
+	if !strings.Contains(providerOut, "Select provider:") || !strings.Contains(providerOut, "OpenAI") {
+		t.Fatalf("provider render missing expected content:\n%s", providerOut)
+	}
+
+	state.Mode = ModeModelSelect
+	modelOut := RenderModelPicker(nil, state, 0)
+	if !strings.Contains(modelOut, "Select model (OpenAI):") || !strings.Contains(modelOut, "GPT-5") {
+		t.Fatalf("model render missing expected content:\n%s", modelOut)
+	}
+}
+
+func TestResolveNames_UsesDisplayNamesWhenAvailable(t *testing.T) {
+	state := ModelPickerState{
+		Providers: map[string]modelcatalog.Provider{
+			"openai": {
+				ID:   "openai",
+				Name: "OpenAI",
+				Models: map[string]modelcatalog.Model{
+					"gpt-5": {ID: "gpt-5", Name: "GPT-5"},
+				},
+			},
+		},
+	}
+
+	provName, modelName := resolveNames(model.ModelAssignment{ProviderID: "openai", ModelID: "gpt-5"}, state)
+	if provName != "OpenAI" || modelName != "GPT-5" {
+		t.Fatalf("resolveNames() = (%q, %q), want (%q, %q)", provName, modelName, "OpenAI", "GPT-5")
 	}
 }

--- a/internal/tui/screens/model_picker_warning_test.go
+++ b/internal/tui/screens/model_picker_warning_test.go
@@ -1,0 +1,81 @@
+package screens
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRenderModelPicker_EmptyStateIncludesCapabilityGatedWarning(t *testing.T) {
+	out := RenderModelPicker(nil, ModelPickerState{}, 0)
+	if !strings.Contains(out, "capability-gated per agent") {
+		t.Fatalf("expected capability-gated warning in model picker empty state")
+	}
+	snippet := extractModelPickerLines(out)
+	assertGoldenModelPicker(t, "model_picker_empty_warning.golden.txt", snippet)
+}
+
+func TestRenderModelPicker_PIEnabledOmitsLegacyOpenCodeOnlyWarning(t *testing.T) {
+	state := ModelPickerState{
+		AvailableIDs: []string{"openai"},
+	}
+
+	out := RenderModelPicker(nil, state, 0)
+
+	if strings.Contains(out, "OpenCode-only") {
+		t.Fatalf("did not expect legacy OpenCode-only warning when picker is capability-enabled")
+	}
+}
+
+func TestRenderModelPicker_PIUnsupportedBlocksMultiModelControlsWithCanonicalWarning(t *testing.T) {
+	state := ModelPickerState{
+		CapabilityBlocked: true,
+		CapabilityMessage: "PI multi-model requires installing the `pi-subagents` extension.",
+	}
+	out := RenderModelPicker(nil, state, 0)
+
+	if !strings.Contains(out, state.CapabilityMessage) {
+		t.Fatalf("expected canonical PI warning in blocked model picker render")
+	}
+
+	if strings.Contains(out, "Set all phases") {
+		t.Fatalf("unexpected multi-model controls when picker is capability blocked")
+	}
+}
+
+func TestRenderModelPicker_CapabilityBlockedWithoutCustomMessageUsesFallback(t *testing.T) {
+	out := RenderModelPicker(nil, ModelPickerState{CapabilityBlocked: true}, 0)
+
+	if !strings.Contains(out, "Multi-model picker is unavailable for this agent setup.") {
+		t.Fatalf("expected fallback blocked message when capability message is empty")
+	}
+
+	if !strings.Contains(out, "← Back to SDD mode") {
+		t.Fatalf("expected back option when picker is capability blocked")
+	}
+}
+
+func assertGoldenModelPicker(t *testing.T, name, got string) {
+	t.Helper()
+	goldenPath := filepath.Join("testdata", name)
+	wantBytes, err := os.ReadFile(goldenPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", goldenPath, err)
+	}
+	want := string(wantBytes)
+	if strings.TrimSpace(got) != strings.TrimSpace(want) {
+		t.Fatalf("golden mismatch %s\n--- got ---\n%s\n--- want ---\n%s", name, got, want)
+	}
+}
+
+func extractModelPickerLines(out string) string {
+	lines := strings.Split(out, "\n")
+	var kept []string
+	for _, line := range lines {
+		if strings.Contains(line, "capability-gated per agent") || strings.Contains(line, "run 'opencode' once") {
+			kept = append(kept, strings.TrimSpace(line))
+		}
+	}
+	return strings.Join(kept, "\n")
+}

--- a/internal/tui/screens/profiles.go
+++ b/internal/tui/screens/profiles.go
@@ -17,6 +17,8 @@ func RenderProfiles(profiles []model.Profile, cursor int, deleteErr error) strin
 	b.WriteString(styles.TitleStyle.Render("OpenCode SDD Profiles"))
 	b.WriteString("\n\n")
 	b.WriteString(styles.SubtextStyle.Render("Your SDD model profiles for OpenCode. Each profile creates its own orchestrator (visible with Tab)."))
+	b.WriteString("\n")
+	b.WriteString(styles.WarningStyle.Render("OpenCode-only: PI profile parity is not validated yet."))
 	b.WriteString("\n\n")
 
 	if deleteErr != nil {

--- a/internal/tui/screens/profiles_warning_test.go
+++ b/internal/tui/screens/profiles_warning_test.go
@@ -1,0 +1,15 @@
+package screens_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/internal/tui/screens"
+)
+
+func TestRenderProfiles_IncludesOpenCodeOnlyWarning(t *testing.T) {
+	out := screens.RenderProfiles(nil, 0, nil)
+	if !strings.Contains(out, "OpenCode-only") {
+		t.Fatalf("expected OpenCode-only warning in profiles screen")
+	}
+}

--- a/internal/tui/screens/testdata/agents_pi_warning.golden.txt
+++ b/internal/tui/screens/testdata/agents_pi_warning.golden.txt
@@ -1,0 +1,1 @@
+PI is experimental and non-parity: multi-model is enabled only when `pi-subagents` is installed.

--- a/internal/tui/screens/testdata/model_picker_empty_warning.golden.txt
+++ b/internal/tui/screens/testdata/model_picker_empty_warning.golden.txt
@@ -1,0 +1,2 @@
+Model picker availability is capability-gated per agent.
+For OpenCode, run 'opencode' once, then re-run 'gentle-ai sync' to assign models.

--- a/testdata/pi/command.sample.md
+++ b/testdata/pi/command.sample.md
@@ -1,0 +1,9 @@
+# PI command fixture (Phase 0)
+
+This artifact captures a candidate slash-command layout for PI.
+
+```text
+/sdd-apply --change "revisemos como soportar soportar el tui pi" --mode strict-tdd
+```
+
+Status: `unknown` (layout may differ in upstream pi-tui).

--- a/testdata/pi/mcp.sample.json
+++ b/testdata/pi/mcp.sample.json
@@ -1,0 +1,13 @@
+{
+  "_meta": {
+    "source": "phase-0-spike",
+    "status": "unknown",
+    "note": "mcpServers envelope is hypothesis until runtime validation"
+  },
+  "mcpServers": {
+    "context7": {
+      "command": "npx",
+      "args": ["-y", "@upstash/context7-mcp"]
+    }
+  }
+}

--- a/testdata/pi/settings.sample.json
+++ b/testdata/pi/settings.sample.json
@@ -1,0 +1,17 @@
+{
+  "_meta": {
+    "source": "phase-0-spike",
+    "status": "unknown",
+    "note": "candidate schema only; do not treat as GA contract"
+  },
+  "agent": {
+    "name": "pi-coding-agent",
+    "model": "gpt-5",
+    "temperature": 0.2
+  },
+  "features": {
+    "profiles": false,
+    "modelPicker": false,
+    "generatedMulti": false
+  }
+}

--- a/testdata/pi/unknown-fields.md
+++ b/testdata/pi/unknown-fields.md
@@ -1,0 +1,14 @@
+# PI unknown / unsupported fields (Phase 0)
+
+## Unknown
+
+- Exact settings schema versioning contract.
+- Canonical config root and per-OS path behavior.
+- Model cache/auth persistence keys and token lifecycle.
+- Native profile representation and runtime switching semantics.
+
+## Unsupported (until validated)
+
+- `profiles=true`
+- `modelPicker=true`
+- `generatedMulti=true`


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #363

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [ ] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [x] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Adds first-class PI agent support, including detection, install/sync planning, generated PI SDD assets, and compatibility documentation.
- Adds PI model picker support with separate PI/OpenCode assignment persistence, preselection from state, and source-specific sync/injection plumbing.
- Hardens PI RPC model loading for noisy extension startup output and adds regression coverage for mixed PI/OpenCode flows.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/agents/pi/*` | Adds PI adapter, detection, paths, compatibility checks, Engram extension validation, and RPC model catalog loading. |
| `internal/assets/pi/agents/*` | Adds PI-native SDD subagent and chain assets. |
| `internal/components/sdd/*` | Adds PI SDD injection paths, PI-specific model assignment handling, and golden/regression coverage. |
| `internal/tui/*` | Adds PI model configuration flow, dual OpenCode+PI picker sequencing, PI assignment preselection, and UI warnings. |
| `internal/state/*`, `internal/app/*`, `internal/cli/*` | Persists and hydrates PI model assignments separately from OpenCode; wires install/sync flows. |
| `internal/opencode/*`, `internal/modelcatalog/*` | Adds normalized model catalog support and wrapped OpenCode provider parsing. |
| `docs/pi-compatibility.md`, `docs/*`, `README.md` | Documents PI compatibility and platform behavior. |
| `testdata/pi/*` | Adds PI sample config fixtures. |

---

## 🧪 Test Plan

**Unit Tests**
```bash
timeout 8m go test -count=1 -timeout=6m ./...
```

**E2E Tests** (Docker required)
```bash
cd e2e && ./docker-test.sh
```

- [x] Unit tests pass (`go test ./...`) — pending final local/CI validation before marking ready for review
- [x] E2E tests pass (`cd e2e && ./docker-test.sh`) — pending
- [x] Manually tested locally

Additional focused validations already run during development:

```bash
go test ./internal/tui ./internal/app ./internal/state ./internal/cli
go test ./internal/agents/pi ./internal/tui
go test ./internal/app ./internal/cli ./internal/state ./internal/model
go test ./internal/tui ./internal/components/sdd ./internal/state
```

Manual checks performed:
- PI install flow reaches PI model picker.
- PI RPC model loading works via stdin request to `pi --mode rpc` despite extension UI events.
- PI model assignments persist to `~/.gentle-ai/state.json` under `pi_model_assignments`.
- Re-opening PI model configuration preselects assignments from state.

---

## 🤖 Automated Checks

The following checks run automatically on this PR:

| Check | Status | Description |
|-------|--------|-------------|
| Check Issue Reference | ⏳ | PR body must contain `Closes/Fixes/Resolves #N` |
| Check Issue Has `status:approved` | ⏳ | Linked issue must have been approved before work began |
| Check PR Has `type:*` Label | ⏳ | Exactly one `type:*` label must be applied |
| Unit Tests | ⏳ | `go test ./...` must pass |
| E2E Tests | ⏳ | `cd e2e && ./docker-test.sh` must pass |

---

## ✅ Contributor Checklist

- [ ] PR is linked to an issue with `status:approved` — draft pending issue approval (`#363` currently needs approval)
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`) — pending final validation
- [x] E2E tests pass (`cd e2e && ./docker-test.sh`) — pending
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

Draft PR while we complete final validation and wait for `#363` to receive `status:approved`.

Areas worth reviewing closely:
- PI/OpenCode model assignment separation (`model_assignments` vs `pi_model_assignments`).
- PI RPC model loading behavior with extension UI events before catalog response.
- Sync/install state hydration and PI SDD artifact generation.