### PR TITLE
fix(upgrade): prune old backups + add --no-backup flag

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -173,12 +173,15 @@ func runUpdate(ctx context.Context, currentVersion string, profile system.Platfo
 //   - Falls back to manual guidance for unsafe platforms (Windows binary self-replace)
 func runUpgrade(ctx context.Context, args []string, detection system.DetectionResult, stdout io.Writer) error {
 	dryRun := false
+	noBackup := false
 	var toolFilter []string
 
 	for _, arg := range args {
 		switch {
 		case arg == "--dry-run" || arg == "-n":
 			dryRun = true
+		case arg == "--no-backup":
+			noBackup = true
 		case !strings.HasPrefix(arg, "-"):
 			toolFilter = append(toolFilter, arg)
 		}
@@ -202,7 +205,14 @@ func runUpgrade(ctx context.Context, args []string, detection system.DetectionRe
 	}
 
 	// Execute upgrades (no-op if nothing is UpdateAvailable).
-	report := upgradeExecute(ctx, checkResults, profile, homeDir, dryRun, stdout)
+	// Use ExecuteWithOptions directly so CLI-only flags (e.g. --no-backup) can
+	// be wired through without expanding the upgradeExecute test seam used by
+	// the TUI dispatcher (see tuiUpgrade below).
+	report := upgrade.ExecuteWithOptions(ctx, checkResults, profile, homeDir, dryRun, upgrade.ExecuteOptions{
+		Progress:          stdout,
+		BackupDiagnostics: stdout,
+		SkipBackup:        noBackup,
+	})
 
 	_, _ = fmt.Fprint(stdout, upgrade.RenderUpgradeReport(report))
 

--- a/internal/update/upgrade/executor.go
+++ b/internal/update/upgrade/executor.go
@@ -44,13 +44,20 @@ var snapshotCreator = func(snapshotDir string, paths []string) (backup.Manifest,
 // Default "dev" matches the ldflags default in app.Version.
 var AppVersion = "dev"
 
-// ExecuteOptions controls optional upgrade executor output streams.
+// ExecuteOptions controls optional upgrade executor behavior.
+//
 // Progress is for user-visible spinner/status output. BackupDiagnostics is for
 // verbose backup walk diagnostics; nil keeps backup enumeration silent, which
 // prevents background TUI jobs from writing over the Bubble Tea screen.
+//
+// SkipBackup, when true, skips both creating a pre-upgrade backup snapshot
+// AND retention pruning of the backup directory. Use this when the user
+// explicitly opts out of backup behavior for a single run (CLI: --no-backup).
+// The default (false) preserves the original safe-by-default behavior.
 type ExecuteOptions struct {
 	Progress          io.Writer
 	BackupDiagnostics io.Writer
+	SkipBackup        bool
 }
 
 // backupExcludeSubdirs lists subdirectory base names that should be skipped
@@ -277,9 +284,11 @@ func ExecuteWithOptions(ctx context.Context, results []update.UpdateResult, prof
 	}
 
 	// Create backup snapshot BEFORE any execution (only when there are executables).
+	// When SkipBackup is set the entire backup subsystem is bypassed for this run:
+	// no snapshot, no retention pruning, the backups directory is left untouched.
 	backupID := ""
 	backupWarning := ""
-	if !dryRun && len(executable) > 0 {
+	if !dryRun && len(executable) > 0 && !options.SkipBackup {
 		sp := NewSpinner(pw, "Creating pre-upgrade backup")
 		snapshotDir := filepath.Join(homeDir, ".gentle-ai", "backups",
 			fmt.Sprintf("upgrade-%s", time.Now().UTC().Format("20060102T150405Z")))

--- a/internal/update/upgrade/executor.go
+++ b/internal/update/upgrade/executor.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -299,6 +300,16 @@ func ExecuteWithOptions(ctx context.Context, results []update.UpdateResult, prof
 				sp.Finish(true)
 			}
 			backupID = manifest.ID
+		}
+
+		// Retention pruning: remove oldest unpinned backups beyond the limit.
+		// This runs whether or not the snapshot itself succeeded — when the
+		// snapshot fails due to disk pressure caused by prior accumulated
+		// backups, pruning is the recovery path. Non-fatal: a prune failure
+		// must not prevent the upgrade from completing.
+		backupRoot := filepath.Join(homeDir, ".gentle-ai", "backups")
+		if _, pruneErr := backup.Prune(backupRoot, backup.DefaultRetentionCount); pruneErr != nil {
+			log.Printf("backup: prune: %v", pruneErr)
 		}
 	}
 


### PR DESCRIPTION
## Summary

The `gentle-ai upgrade` command silently accumulates pre-upgrade backup snapshots under `~/.gentle-ai/backups/` because the upgrade executor never invokes `backup.Prune`. Over many upgrades this fills the disk and breaks subsequent upgrades with `no space left on device` errors during snapshot creation.

This PR fixes that, and adds a `--no-backup` opt-out for users who want to bypass the backup subsystem for a single run.

Real-world impact (the report that motivated this PR): a user accumulated **24 upgrade backups totalling ~98 GB** before discovering it. Each recent backup was ~15 GB because agent config roots like `~/.gemini/antigravity/` walk into runtime data not fully covered by `backupExcludeSubdirs`.

Closes #185. Refs #368.

## Changes

Two semantic commits, intentionally split for clean bisect/revert:

### 1. `fix(upgrade): prune old backups after pre-upgrade snapshot`

* `internal/update/upgrade/executor.go::ExecuteWithOptions` now invokes `backup.Prune(backupRoot, backup.DefaultRetentionCount)` after the snapshot block, mirroring exactly the pattern already used by `internal/cli/run.go::prepareBackupStep.Run` for install/sync.
* Pruning runs even when the snapshot itself failed — that is the recovery path when the failure was caused by accumulated backups exhausting disk space.
* Pinned backups are unaffected (existing `Prune` semantics).

### 2. `feat(upgrade): add --no-backup flag`

* New `SkipBackup bool` field on `ExecuteOptions` (zero-value preserves original behavior — no breaking change for existing callers, including the TUI dispatcher).
* `app.runUpgrade` recognizes `--no-backup` and routes through `upgrade.ExecuteWithOptions` directly. When set, both snapshot creation and retention pruning are skipped (`~/.gentle-ai/backups/` is left entirely untouched).
* The `upgradeExecute` test seam used by `tuiUpgrade` is unchanged.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./...` — full suite passes (all 39 packages green)
- [x] Manual: existing `--dry-run` path unchanged
- [x] Manual: `--no-backup` parses correctly alongside `--dry-run` and tool filters
- [ ] Maintainer can verify against a stuffed `~/.gentle-ai/backups/` to see retention enforcement

## Backward compatibility

* Default behavior is preserved end-to-end. Users who do nothing get the same upgrade flow plus retention enforcement that was already in place for install/sync.
* No new exported APIs beyond `ExecuteOptions.SkipBackup`. No dependency changes.

## Out of scope (deliberately)

* Refining `backupExcludeSubdirs` to fully exclude non-config payloads under agent roots (root cause of why each backup is GB-sized — relates to issues #345 / #203). That is a separate discussion about the inclusion strategy and deserves its own PR with reviewer input.