### PR TITLE
fix(sync): tolerate per-agent failures in component pipeline

### DIFF
--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -2,8 +2,10 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -515,6 +517,7 @@ func (s componentSyncStep) Run() error {
 			sddMode = model.SDDModeMulti
 		}
 
+		var sddErrs []error
 		for _, adapter := range adapters {
 			opts := sdd.InjectOptions{
 				OpenCodeModelAssignments:           s.selection.ModelAssignments,
@@ -527,25 +530,28 @@ func (s componentSyncStep) Run() error {
 			}
 			res, err := sdd.Inject(s.homeDir, adapter, sddMode, opts)
 			if err != nil {
-				return fmt.Errorf("sync sdd for %q: %w", adapter.Agent(), err)
+				sddErrs = append(sddErrs, fmt.Errorf("sync sdd for %q: %w", adapter.Agent(), err))
+				continue
 			}
 			s.countChanged(boolToInt(res.Changed))
 		}
-		return nil
+		return reportPerAgentErrors(sddErrs, len(adapters))
 
 	case model.ComponentSkills:
 		skillIDs := selectedSkillIDs(s.selection)
 		if len(skillIDs) == 0 {
 			return nil
 		}
+		var skillErrs []error
 		for _, adapter := range adapters {
 			res, err := skills.Inject(s.homeDir, adapter, skillIDs)
 			if err != nil {
-				return fmt.Errorf("sync skills for %q: %w", adapter.Agent(), err)
+				skillErrs = append(skillErrs, fmt.Errorf("sync skills for %q: %w", adapter.Agent(), err))
+				continue
 			}
 			s.countChanged(boolToInt(res.Changed))
 		}
-		return nil
+		return reportPerAgentErrors(skillErrs, len(adapters))
 
 	case model.ComponentGGA:
 		// Sync: ensure runtime assets are current and inject config.
@@ -568,25 +574,29 @@ func (s componentSyncStep) Run() error {
 
 	case model.ComponentPermission:
 		// Opt-in only — reached when --include-permissions is set.
+		var permErrs []error
 		for _, adapter := range adapters {
 			res, err := permissions.Inject(s.homeDir, adapter)
 			if err != nil {
-				return fmt.Errorf("sync permissions for %q: %w", adapter.Agent(), err)
+				permErrs = append(permErrs, fmt.Errorf("sync permissions for %q: %w", adapter.Agent(), err))
+				continue
 			}
 			s.countChanged(boolToInt(res.Changed))
 		}
-		return nil
+		return reportPerAgentErrors(permErrs, len(adapters))
 
 	case model.ComponentTheme:
 		// Opt-in only — reached when --include-theme is set.
+		var themeErrs []error
 		for _, adapter := range adapters {
 			res, err := theme.Inject(s.homeDir, adapter)
 			if err != nil {
-				return fmt.Errorf("sync theme for %q: %w", adapter.Agent(), err)
+				themeErrs = append(themeErrs, fmt.Errorf("sync theme for %q: %w", adapter.Agent(), err))
+				continue
 			}
 			s.countChanged(boolToInt(res.Changed))
 		}
-		return nil
+		return reportPerAgentErrors(themeErrs, len(adapters))
 
 	default:
 		// Persona and any unknown components are out of sync scope.
@@ -607,6 +617,34 @@ func boolToInt(b bool) int {
 		return 1
 	}
 	return 0
+}
+
+// reportPerAgentErrors decides whether per-agent failures collected during
+// a component's sync iteration should abort the pipeline.
+//
+// Behavior:
+//   - No errors             → returns nil.
+//   - Some errors but not all → emits each as a non-fatal warning via log
+//     and returns nil so the pipeline keeps running for the remaining
+//     components and the agents that did succeed.
+//   - Every agent failed    → joins the errors and returns them so the
+//     orchestrator can surface a real failure (and roll back when the
+//     policy demands it). This preserves "all-or-nothing" semantics only
+//     when truly nothing worked.
+//
+// totalAgents is the size of the adapter slice the caller iterated over;
+// when it is zero the function trivially returns nil.
+func reportPerAgentErrors(errs []error, totalAgents int) error {
+	if len(errs) == 0 {
+		return nil
+	}
+	for _, e := range errs {
+		log.Printf("sync: warning: %v", e)
+	}
+	if totalAgents > 0 && len(errs) >= totalAgents {
+		return errors.Join(errs...)
+	}
+	return nil
 }
 
 // RunSyncWithSelection is the programmatic entry point for sync.


### PR DESCRIPTION
## Summary

`componentSyncStep.Run` aborts the entire sync pipeline as soon as **any** managed agent fails its write step (sdd, skills, permissions or theme components). The user is left with a fatal `execute sync pipeline: ...` error even when only one agent had a problem and every other agent would have synced cleanly.

This PR makes per-agent failures non-fatal by default, while preserving the original failure semantics when **every** agent fails.

## Motivation — real-world reproduction

A user with five managed agents (`claude-code`, `gemini-cli`, `cursor`, `codex`, `antigravity`) hit a permission-denied while sync tried to create `~/.gemini/antigravity/skills/_shared/SKILL.md`. That single permission issue killed the entire sync — `claude-code`, `cursor` and `codex` were never touched, even though their writes would have succeeded.

The only recovery is `gentle-ai sync --agents <list-without-the-broken-one>`, which requires the user to know in advance which agent will break the run. That is unfriendly and surprising — `sync` is supposed to be the recovery command, not the one that demands you already know what's wrong.

## Changes

Single commit, one file, +46/-8.

* New helper `reportPerAgentErrors(errs, totalAgents)` in `internal/cli/sync.go`:
  * No errors → returns `nil`.
  * Some agents failed, at least one succeeded → each error is logged as a warning (`sync: warning: ...`) and the function returns `nil` so the pipeline continues.
  * **Every** agent failed → errors are joined with `errors.Join` and returned, preserving the existing fail-and-rollback behavior.
* The four iteration sites (`ComponentSDD`, `ComponentSkills`, `ComponentPermission`, `ComponentTheme`) now collect errors instead of returning the first one, then call the helper.
* No change to `ComponentGGA` (it is not a per-adapter loop).
* No change to public APIs, no change to the TUI dispatcher, no change to flag parsing.

## Why this is the right shape

* Mirrors the convention already used by `backup.Prune`: housekeeping / partial failures are non-fatal warnings, true failures escalate.
* Keeps "all-or-nothing" semantics intact when truly nothing worked — operators who script around exit codes still get a non-zero exit when the sync produced no useful effect.
* Single-agent runs (the TUI's typical case, `--agents <one>`) behave exactly as before — there is no observable change unless the user has multiple agents and one of them fails.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./...` — full suite passes (39 packages green; cli, tui, app, components/sdd all run on the modified code path)
- [x] Manual: with multiple agents, simulate a write failure on one agent; the pipeline now completes with a `sync: warning: ...` line on stderr and a non-zero `FilesChanged` from the others.
- [ ] Maintainer can reproduce by `chown root` on `~/.gemini/antigravity/skills/_shared/` and running `gentle-ai sync` (multi-agent install).

## Out of scope

* Surfacing per-agent warnings inside `SyncResult` and `RenderSyncReport` so they appear in the user-facing report (currently they go to `log.Printf`/stderr only). That is a UX improvement worth doing in a follow-up PR with reviewer input on the report shape.
* Refining `backupExcludeSubdirs` / sync's permission-denial recovery (separate concern, separate discussion).