### PR TITLE
feat(sdd-skills): add orchestrator gate and delegate_only flag to phase skills

### DIFF
--- a/internal/assets/skills/sdd-apply/SKILL.md
+++ b/internal/assets/skills/sdd-apply/SKILL.md
@@ -7,7 +7,14 @@ license: MIT
 metadata:
   author: gentleman-programming
   version: "3.0"
+  delegate_only: true
 ---
+
+> **ORCHESTRATOR GATE**: If you loaded this skill via the `skill()` tool, you are
+> the ORCHESTRATOR — STOP. Do NOT execute these instructions inline. Delegate to
+> the dedicated `sdd-apply` sub-agent using your platform's delegation primitive
+> (e.g., `task(...)`, sub-agent invocation, etc.). This skill is for EXECUTORS
+> only.
 
 ## Purpose
 

--- a/internal/assets/skills/sdd-archive/SKILL.md
+++ b/internal/assets/skills/sdd-archive/SKILL.md
@@ -7,7 +7,14 @@ license: MIT
 metadata:
   author: gentleman-programming
   version: "2.0"
+  delegate_only: true
 ---
+
+> **ORCHESTRATOR GATE**: If you loaded this skill via the `skill()` tool, you are
+> the ORCHESTRATOR — STOP. Do NOT execute these instructions inline. Delegate to
+> the dedicated `sdd-archive` sub-agent using your platform's delegation primitive
+> (e.g., `task(...)`, sub-agent invocation, etc.). This skill is for EXECUTORS
+> only.
 
 ## Purpose
 

--- a/internal/assets/skills/sdd-design/SKILL.md
+++ b/internal/assets/skills/sdd-design/SKILL.md
@@ -7,7 +7,14 @@ license: MIT
 metadata:
   author: gentleman-programming
   version: "2.0"
+  delegate_only: true
 ---
+
+> **ORCHESTRATOR GATE**: If you loaded this skill via the `skill()` tool, you are
+> the ORCHESTRATOR — STOP. Do NOT execute these instructions inline. Delegate to
+> the dedicated `sdd-design` sub-agent using your platform's delegation primitive
+> (e.g., `task(...)`, sub-agent invocation, etc.). This skill is for EXECUTORS
+> only.
 
 ## Purpose
 

--- a/internal/assets/skills/sdd-explore/SKILL.md
+++ b/internal/assets/skills/sdd-explore/SKILL.md
@@ -7,7 +7,14 @@ license: MIT
 metadata:
   author: gentleman-programming
   version: "2.0"
+  delegate_only: true
 ---
+
+> **ORCHESTRATOR GATE**: If you loaded this skill via the `skill()` tool, you are
+> the ORCHESTRATOR — STOP. Do NOT execute these instructions inline. Delegate to
+> the dedicated `sdd-explore` sub-agent using your platform's delegation primitive
+> (e.g., `task(...)`, sub-agent invocation, etc.). This skill is for EXECUTORS
+> only.
 
 ## Purpose
 

--- a/internal/assets/skills/sdd-init/SKILL.md
+++ b/internal/assets/skills/sdd-init/SKILL.md
@@ -7,7 +7,14 @@ license: MIT
 metadata:
   author: gentleman-programming
   version: "3.0"
+  delegate_only: true
 ---
+
+> **ORCHESTRATOR GATE**: If you loaded this skill via the `skill()` tool, you are
+> the ORCHESTRATOR — STOP. Do NOT execute these instructions inline. Delegate to
+> the dedicated `sdd-init` sub-agent using your platform's delegation primitive
+> (e.g., `task(...)`, sub-agent invocation, etc.). This skill is for EXECUTORS
+> only.
 
 ## Activation Contract
 

--- a/internal/assets/skills/sdd-onboard/SKILL.md
+++ b/internal/assets/skills/sdd-onboard/SKILL.md
@@ -7,7 +7,12 @@ license: MIT
 metadata:
   author: gentleman-programming
   version: "1.0"
+  delegate_only: false
 ---
+
+> **ORCHESTRATOR NOTE**: This skill is designed to be executed INLINE by the
+> orchestrator. It is an interactive walkthrough — no sub-agent delegation
+> needed.
 
 ## Purpose
 

--- a/internal/assets/skills/sdd-propose/SKILL.md
+++ b/internal/assets/skills/sdd-propose/SKILL.md
@@ -7,7 +7,14 @@ license: MIT
 metadata:
   author: gentleman-programming
   version: "2.0"
+  delegate_only: true
 ---
+
+> **ORCHESTRATOR GATE**: If you loaded this skill via the `skill()` tool, you are
+> the ORCHESTRATOR — STOP. Do NOT execute these instructions inline. Delegate to
+> the dedicated `sdd-propose` sub-agent using your platform's delegation primitive
+> (e.g., `task(...)`, sub-agent invocation, etc.). This skill is for EXECUTORS
+> only.
 
 ## Purpose
 

--- a/internal/assets/skills/sdd-spec/SKILL.md
+++ b/internal/assets/skills/sdd-spec/SKILL.md
@@ -7,7 +7,14 @@ license: MIT
 metadata:
   author: gentleman-programming
   version: "2.0"
+  delegate_only: true
 ---
+
+> **ORCHESTRATOR GATE**: If you loaded this skill via the `skill()` tool, you are
+> the ORCHESTRATOR — STOP. Do NOT execute these instructions inline. Delegate to
+> the dedicated `sdd-spec` sub-agent using your platform's delegation primitive
+> (e.g., `task(...)`, sub-agent invocation, etc.). This skill is for EXECUTORS
+> only.
 
 ## Purpose
 

--- a/internal/assets/skills/sdd-tasks/SKILL.md
+++ b/internal/assets/skills/sdd-tasks/SKILL.md
@@ -7,7 +7,14 @@ license: MIT
 metadata:
   author: gentleman-programming
   version: "2.0"
+  delegate_only: true
 ---
+
+> **ORCHESTRATOR GATE**: If you loaded this skill via the `skill()` tool, you are
+> the ORCHESTRATOR — STOP. Do NOT execute these instructions inline. Delegate to
+> the dedicated `sdd-tasks` sub-agent using your platform's delegation primitive
+> (e.g., `task(...)`, sub-agent invocation, etc.). This skill is for EXECUTORS
+> only.
 
 ## Purpose
 

--- a/internal/assets/skills/sdd-verify/SKILL.md
+++ b/internal/assets/skills/sdd-verify/SKILL.md
@@ -7,7 +7,14 @@ license: MIT
 metadata:
   author: gentleman-programming
   version: "3.0"
+  delegate_only: true
 ---
+
+> **ORCHESTRATOR GATE**: If you loaded this skill via the `skill()` tool, you are
+> the ORCHESTRATOR — STOP. Do NOT execute these instructions inline. Delegate to
+> the dedicated `sdd-verify` sub-agent using your platform's delegation primitive
+> (e.g., `task(...)`, sub-agent invocation, etc.). This skill is for EXECUTORS
+> only.
 
 ## Activation Contract
 

--- a/testdata/golden/sdd-antigravity-skill-sdd-init.golden
+++ b/testdata/golden/sdd-antigravity-skill-sdd-init.golden
@@ -7,7 +7,14 @@ license: MIT
 metadata:
   author: gentleman-programming
   version: "3.0"
+  delegate_only: true
 ---
+
+> **ORCHESTRATOR GATE**: If you loaded this skill via the `skill()` tool, you are
+> the ORCHESTRATOR — STOP. Do NOT execute these instructions inline. Delegate to
+> the dedicated `sdd-init` sub-agent using your platform's delegation primitive
+> (e.g., `task(...)`, sub-agent invocation, etc.). This skill is for EXECUTORS
+> only.
 
 ## Activation Contract
 

--- a/testdata/golden/sdd-codex-skill-sdd-init.golden
+++ b/testdata/golden/sdd-codex-skill-sdd-init.golden
@@ -7,7 +7,14 @@ license: MIT
 metadata:
   author: gentleman-programming
   version: "3.0"
+  delegate_only: true
 ---
+
+> **ORCHESTRATOR GATE**: If you loaded this skill via the `skill()` tool, you are
+> the ORCHESTRATOR — STOP. Do NOT execute these instructions inline. Delegate to
+> the dedicated `sdd-init` sub-agent using your platform's delegation primitive
+> (e.g., `task(...)`, sub-agent invocation, etc.). This skill is for EXECUTORS
+> only.
 
 ## Activation Contract
 

--- a/testdata/golden/sdd-cursor-skill-sdd-init.golden
+++ b/testdata/golden/sdd-cursor-skill-sdd-init.golden
@@ -7,7 +7,14 @@ license: MIT
 metadata:
   author: gentleman-programming
   version: "3.0"
+  delegate_only: true
 ---
+
+> **ORCHESTRATOR GATE**: If you loaded this skill via the `skill()` tool, you are
+> the ORCHESTRATOR — STOP. Do NOT execute these instructions inline. Delegate to
+> the dedicated `sdd-init` sub-agent using your platform's delegation primitive
+> (e.g., `task(...)`, sub-agent invocation, etc.). This skill is for EXECUTORS
+> only.
 
 ## Activation Contract
 

--- a/testdata/golden/sdd-gemini-skill-sdd-init.golden
+++ b/testdata/golden/sdd-gemini-skill-sdd-init.golden
@@ -7,7 +7,14 @@ license: MIT
 metadata:
   author: gentleman-programming
   version: "3.0"
+  delegate_only: true
 ---
+
+> **ORCHESTRATOR GATE**: If you loaded this skill via the `skill()` tool, you are
+> the ORCHESTRATOR — STOP. Do NOT execute these instructions inline. Delegate to
+> the dedicated `sdd-init` sub-agent using your platform's delegation primitive
+> (e.g., `task(...)`, sub-agent invocation, etc.). This skill is for EXECUTORS
+> only.
 
 ## Activation Contract
 

--- a/testdata/golden/sdd-kiro-skill-sdd-init.golden
+++ b/testdata/golden/sdd-kiro-skill-sdd-init.golden
@@ -7,7 +7,14 @@ license: MIT
 metadata:
   author: gentleman-programming
   version: "3.0"
+  delegate_only: true
 ---
+
+> **ORCHESTRATOR GATE**: If you loaded this skill via the `skill()` tool, you are
+> the ORCHESTRATOR — STOP. Do NOT execute these instructions inline. Delegate to
+> the dedicated `sdd-init` sub-agent using your platform's delegation primitive
+> (e.g., `task(...)`, sub-agent invocation, etc.). This skill is for EXECUTORS
+> only.
 
 ## Activation Contract
 

--- a/testdata/golden/sdd-opencode-skill-sdd-init.golden
+++ b/testdata/golden/sdd-opencode-skill-sdd-init.golden
@@ -7,7 +7,14 @@ license: MIT
 metadata:
   author: gentleman-programming
   version: "3.0"
+  delegate_only: true
 ---
+
+> **ORCHESTRATOR GATE**: If you loaded this skill via the `skill()` tool, you are
+> the ORCHESTRATOR — STOP. Do NOT execute these instructions inline. Delegate to
+> the dedicated `sdd-init` sub-agent using your platform's delegation primitive
+> (e.g., `task(...)`, sub-agent invocation, etc.). This skill is for EXECUTORS
+> only.
 
 ## Activation Contract
 

--- a/testdata/golden/sdd-vscode-skill-sdd-init.golden
+++ b/testdata/golden/sdd-vscode-skill-sdd-init.golden
@@ -7,7 +7,14 @@ license: MIT
 metadata:
   author: gentleman-programming
   version: "3.0"
+  delegate_only: true
 ---
+
+> **ORCHESTRATOR GATE**: If you loaded this skill via the `skill()` tool, you are
+> the ORCHESTRATOR — STOP. Do NOT execute these instructions inline. Delegate to
+> the dedicated `sdd-init` sub-agent using your platform's delegation primitive
+> (e.g., `task(...)`, sub-agent invocation, etc.). This skill is for EXECUTORS
+> only.
 
 ## Activation Contract
 

--- a/testdata/golden/sdd-windsurf-skill-sdd-init.golden
+++ b/testdata/golden/sdd-windsurf-skill-sdd-init.golden
@@ -7,7 +7,14 @@ license: MIT
 metadata:
   author: gentleman-programming
   version: "3.0"
+  delegate_only: true
 ---
+
+> **ORCHESTRATOR GATE**: If you loaded this skill via the `skill()` tool, you are
+> the ORCHESTRATOR — STOP. Do NOT execute these instructions inline. Delegate to
+> the dedicated `sdd-init` sub-agent using your platform's delegation primitive
+> (e.g., `task(...)`, sub-agent invocation, etc.). This skill is for EXECUTORS
+> only.
 
 ## Activation Contract
 


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #401

Refs #324 (the original problem report by @glats — same root cause, this PR resolves both with a single change).

---

## 🏷️ PR Type

- [ ] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [x] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

Adds a structural **ORCHESTRATOR GATE** blockquote and a machine-readable `metadata.delegate_only` flag to every SDD phase `SKILL.md`, so the orchestrator can no longer accidentally execute phase instructions inline when it loads a skill via the `skill()` tool.

The 9 executor phases (`sdd-init`, `sdd-explore`, `sdd-propose`, `sdd-spec`, `sdd-design`, `sdd-tasks`, `sdd-apply`, `sdd-verify`, `sdd-archive`) get a STOP-style **GATE** + `delegate_only: true`. The phase name is hardcoded per file (no templated placeholder) so the orchestrator reads a literal directive, not a value to resolve.

`sdd-onboard` is the inline-by-design exception (interactive walkthrough). It receives an **ORCHESTRATOR NOTE** blockquote (no STOP) and `delegate_only: false`, making the structural distinction obvious to both humans and future tooling.

`sdd-init` keeps its existing executor sentence inside `## Purpose` intact. The new orchestrator gate stacks **above** it — two gates, two audiences (orchestrator vs. delegated sub-agent), no contradiction.

The 8 `sdd-init` skill goldens are regenerated to mirror the source. Other surfaces (Claude/OpenCode command files, Kiro agent files, `_shared/sdd-phase-common.md`) are intentionally untouched — they're either out of scope (PR #370 territory) or not effective placements for an orchestrator gate.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|--------------|
| `internal/assets/skills/sdd-{init,explore,propose,spec,design,tasks,apply,verify,archive}/SKILL.md` | Added `metadata.delegate_only: true` and 5-line ORCHESTRATOR GATE blockquote (with hardcoded phase name) immediately after the closing `---` of frontmatter. |
| `internal/assets/skills/sdd-onboard/SKILL.md` | Added `metadata.delegate_only: false` and 3-line ORCHESTRATOR NOTE blockquote (inline-by-design wording — no STOP). |
| `testdata/golden/sdd-{antigravity,codex,cursor,gemini,kiro,opencode,vscode,windsurf}-skill-sdd-init.golden` | Regenerated via `go test ./internal/components/... -update -run TestGoldenSDD` to reflect the source change (8 files, identical diff). |

**Diff stats**: 18 files changed, +124 / −0 lines, zero `.go` modifications.

---

## 🧪 Test Plan

**Unit tests**

```bash
go test ./...
```

- [x] Unit tests pass (`go test ./...`) — exit 0, 43 packages pass.
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — not run locally (Docker required); CI will execute.
- [x] Manually tested locally — see "Manual verification" below.

**Manual verification**

1. Loaded each of the 10 modified `SKILL.md` files visually and confirmed the ORCHESTRATOR GATE/NOTE is the **first non-empty content** after the closing `---`.
2. `sdd-init/SKILL.md`: confirmed the line-23 executor sentence ("You are an EXECUTOR for this phase, not the orchestrator…") is preserved verbatim and the new GATE stacks above it.
3. `sdd-onboard/SKILL.md`: confirmed the NOTE block does **not** contain the word "STOP" (the only `STOP` in that file is in the unrelated body text at line 215, untouched).
4. YAML frontmatter parses correctly via `yaml.safe_load` — `delegate_only` decodes as Python `bool` (matches Go `yaml.v3` `bool` decoding), not a string.
5. All 8 regenerated `sdd-init` skill goldens carry an **identical** 7-line addition (verified by `md5sum` of the per-file diff content — single hash across all 8).
6. Out-of-scope guardrails verified via `git diff --name-only`: zero `.go` files, zero `internal/assets/claude/commands/sdd-*.md`, zero `_shared/sdd-phase-common.md`, total 18 files exactly.

---

## 🤖 Automated Checks

| Check | Status | Description |
|-------|--------|-------------|
| Check Issue Reference | ⏳ | PR body contains `Closes #401` |
| Check Issue Has `status:approved` | ⏳ | Awaiting maintainer review on #401 |
| Check PR Has `type:*` Label | ⏳ | `type:feature` requested |
| Unit Tests | ⏳ | `go test ./...` passes locally |
| E2E Tests | ⏳ | Will run via CI |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue (#401) — awaiting `status:approved`
- [x] I have requested the appropriate `type:*` label (`type:feature`)
- [x] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — Docker not available locally; CI will validate
- [x] Documentation update not required — the change is self-documenting via the blockquote and the new flag
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

A few decisions are spelled out explicitly in #401's "Alternatives Considered" section, but worth surfacing here in case they come up during review:

1. **Why hardcode the phase name in each file instead of using `sdd-{phase}` as a template?** A placeholder invites the orchestrator to interpret it as a value to resolve at runtime. Hardcoded literal names are unambiguous, grep-verifiable, and one less thing for the orchestrator to "interpret".

2. **Why a `delegate_only` boolean flag in addition to the prose blockquote?** Prose alone has no anchor for future tooling. The flag adds 1 line per file and unblocks future `gentle-ai doctor` / lint checks without requiring this PR to also ship validators. The flag is also the structural source of truth that distinguishes pure executors (`true`) from orchestrator-executable skills (`false`, only `sdd-onboard` today).

3. **Why not also reinforce the gate in `_shared/sdd-phase-common.md`?** That file is referenced from inside execution instructions (Sections A/B/C). By the time the orchestrator reads the shared file, it has already started executing inline. Per-file gate at the top of each `SKILL.md` is the only effective placement.

4. **Why not enumerate every agent's delegation primitive (Claude `task()`, OpenCode subagent, Codex syntax, etc.)?** gentle-ai supports many agents, and enumerating them in 9 files would be unmaintainable as new agents land. The phrase *"your platform's delegation primitive (e.g., `task(...)`, sub-agent invocation, etc.)"* is intentionally generic — it stays correct for new agents without edits.

5. **Why isn't `metadata.version` bumped?** This is an orthogonal metadata addition + advisory blockquote. The skill's executor behavior contract is unchanged. Bumping every version generates noise in changelogs and downstream caches without communicating a real consumer-facing semantic change. If/when actual execution semantics change, the version bump goes there.

6. **Why are Kiro agent files (`testdata/golden/sdd-kiro-agent-*.golden`) untouched?** They're a different surface — Kiro sub-agent definitions reference `SKILL.md` by path, not by embedding. They already carry their own executor-side gate ("Do NOT delegate further. You are not the orchestrator…"). Touching them would be out of scope and conflate two different gating concerns.

7. **Relationship to PR #370.** PR #370 fixes a parser-compat bug in `internal/assets/claude/commands/sdd-*.md` (slash command files) on Claude Code v2.1.113+. That's a different surface than the skill files this PR modifies — there is no overlap. Both PRs can land independently in any order.

A natural follow-up (not in this PR) would be to add a `gentle-ai doctor` check that asserts every `delegate_only: true` skill contains the literal `> **ORCHESTRATOR GATE**:` blockquote. Happy to open a follow-up issue for that if maintainers want it after this lands.
