### PR TITLE
fix(update): detect GGA PowerShell shim on Windows

### DIFF
--- a/internal/update/check_test.go
+++ b/internal/update/check_test.go
@@ -121,6 +121,61 @@ func TestDetectInstalledVersion(t *testing.T) {
 	}
 }
 
+func TestDetectInstalledVersion_WindowsGGAPowerShellShim(t *testing.T) {
+	home := t.TempDir()
+	shimPath := filepath.Join(home, "bin", "gga.ps1")
+	if err := os.MkdirAll(filepath.Dir(shimPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(shimPath, []byte("# shim"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	origLookPath := lookPath
+	origExecCommand := execCommand
+	origUserHomeDir := userHomeDir
+	origRuntimeGOOS := runtimeGOOS
+	t.Cleanup(func() {
+		lookPath = origLookPath
+		execCommand = origExecCommand
+		userHomeDir = origUserHomeDir
+		runtimeGOOS = origRuntimeGOOS
+	})
+
+	runtimeGOOS = "windows"
+	userHomeDir = func() (string, error) { return home, nil }
+	lookPath = func(name string) (string, error) {
+		switch name {
+		case "gga":
+			return "", fmt.Errorf("not found")
+		case "powershell.exe":
+			return "powershell.exe", nil
+		default:
+			return "", fmt.Errorf("unexpected lookup: %s", name)
+		}
+	}
+
+	var gotName string
+	var gotArgs []string
+	execCommand = func(name string, args ...string) *exec.Cmd {
+		gotName = name
+		gotArgs = append([]string(nil), args...)
+		return exec.Command("echo", "gga v2.8.1")
+	}
+
+	tool := ToolInfo{Name: "gga", DetectCmd: []string{"gga", "--version"}}
+	if got := detectInstalledVersion(context.Background(), tool, "dev"); got != "2.8.1" {
+		t.Fatalf("detectInstalledVersion() = %q, want 2.8.1", got)
+	}
+	if gotName != "powershell.exe" {
+		t.Fatalf("exec command = %q, want powershell.exe", gotName)
+	}
+	wantArgs := []string{"-NoProfile", "-ExecutionPolicy", "Bypass", "-File", shimPath, "--version"}
+	if strings.Join(gotArgs, "\x00") != strings.Join(wantArgs, "\x00") {
+		t.Fatalf("exec args = %#v, want %#v", gotArgs, wantArgs)
+	}
+}
+
 func TestDetectInstalledVersionFromOpenCodeNodeModulePackageJSON(t *testing.T) {
 	home := t.TempDir()
 	pkgDir := filepath.Join(home, ".config", "opencode", "node_modules", "opencode-sdd-engram-manage")

--- a/internal/update/check_test.go
+++ b/internal/update/check_test.go
@@ -160,7 +160,7 @@ func TestDetectInstalledVersion_WindowsGGAPowerShellShim(t *testing.T) {
 	execCommand = func(name string, args ...string) *exec.Cmd {
 		gotName = name
 		gotArgs = append([]string(nil), args...)
-		return exec.Command("echo", "gga v2.8.1")
+		return fakeVersionCommand("gga v2.8.1")
 	}
 
 	tool := ToolInfo{Name: "gga", DetectCmd: []string{"gga", "--version"}}
@@ -174,6 +174,25 @@ func TestDetectInstalledVersion_WindowsGGAPowerShellShim(t *testing.T) {
 	if strings.Join(gotArgs, "\x00") != strings.Join(wantArgs, "\x00") {
 		t.Fatalf("exec args = %#v, want %#v", gotArgs, wantArgs)
 	}
+}
+
+func fakeVersionCommand(output string) *exec.Cmd {
+	cmd := exec.Command(os.Args[0], "-test.run=TestFakeVersionCommand", "--", output)
+	cmd.Env = append(os.Environ(), "GO_WANT_FAKE_VERSION_COMMAND=1")
+	return cmd
+}
+
+func TestFakeVersionCommand(t *testing.T) {
+	if os.Getenv("GO_WANT_FAKE_VERSION_COMMAND") != "1" {
+		return
+	}
+	for i, arg := range os.Args {
+		if arg == "--" && i+1 < len(os.Args) {
+			fmt.Fprintln(os.Stdout, os.Args[i+1])
+			os.Exit(0)
+		}
+	}
+	os.Exit(1)
 }
 
 func TestDetectInstalledVersionFromOpenCodeNodeModulePackageJSON(t *testing.T) {

--- a/internal/update/detect.go
+++ b/internal/update/detect.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strings"
 	"time"
 )
@@ -16,6 +17,7 @@ var (
 	execCommand = exec.Command
 	lookPath    = exec.LookPath
 	userHomeDir = os.UserHomeDir
+	runtimeGOOS = runtime.GOOS
 )
 
 // versionRegexp extracts a semver-like version from command output.
@@ -44,15 +46,44 @@ func detectInstalledVersion(ctx context.Context, tool ToolInfo, currentBuildVers
 
 	binary := tool.DetectCmd[0]
 	if _, err := lookPath(binary); err != nil {
+		if version := detectWindowsGGAShimVersion(ctx, tool); version != "" {
+			return version
+		}
 		return "" // binary not found
 	}
 
+	return runDetectCommand(ctx, tool.DetectCmd[0], tool.DetectCmd[1:]...)
+}
+
+func detectWindowsGGAShimVersion(ctx context.Context, tool ToolInfo) string {
+	if runtimeGOOS != "windows" || tool.Name != "gga" {
+		return ""
+	}
+	if _, err := lookPath("powershell.exe"); err != nil {
+		return ""
+	}
+
+	home, err := userHomeDir()
+	if err != nil || strings.TrimSpace(home) == "" {
+		return ""
+	}
+
+	shimPath := filepath.Join(home, "bin", "gga.ps1")
+	if _, err := os.Stat(shimPath); err != nil {
+		return ""
+	}
+
+	args := append([]string{"-NoProfile", "-ExecutionPolicy", "Bypass", "-File", shimPath}, tool.DetectCmd[1:]...)
+	return runDetectCommand(ctx, "powershell.exe", args...)
+}
+
+func runDetectCommand(ctx context.Context, name string, args ...string) string {
 	// Apply a bounded timeout so a hanging binary (e.g. engram stuck on DB
 	// lock) cannot block update/upgrade flows forever.
 	detectCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
-	cmd := execCommand(tool.DetectCmd[0], tool.DetectCmd[1:]...)
+	cmd := execCommand(name, args...)
 
 	// Kill the subprocess when the context fires. We use a goroutine because
 	// the testable execCommand var returns a plain *exec.Cmd (not CommandContext).


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #177

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Detects GGA on Windows when it is available through Gentle AI's PowerShell shim instead of a native executable.
- Keeps the existing detection path unchanged for macOS, Linux, and non-GGA tools.
- Adds a focused unit test that simulates the Windows shim fallback without requiring Windows.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/update/detect.go` | Adds a Windows-only GGA fallback that runs `~/bin/gga.ps1 --version` via `powershell.exe` when `LookPath(gga)` fails. |
| `internal/update/check_test.go` | Covers the PowerShell shim fallback with mocked OS, PATH, home directory, and command execution. |

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./internal/update -run TestDetectInstalledVersion_WindowsGGAPowerShellShim -count=1
go vet ./...
```

- [x] Focused unit test passes (`go test ./internal/update -run TestDetectInstalledVersion_WindowsGGAPowerShellShim -count=1`)
- [x] Vet passes (`go vet ./...`)
- [ ] Full unit suite passes (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [ ] Manually tested locally

Additional checks performed:
- [x] Diff size kept small: 2 files, 106 insertions / 1 deletion
- [x] Whitespace check: `git diff --check`

Note: On Windows, broader `internal/update` tests currently fail both on this branch and on `main` because existing tests use non-native command stubs such as `exec.Command(echo, ...)` / `exec.Command(false)`. This PR keeps the new test cross-platform by using a Go helper subprocess.

---

## 🤖 Automated Checks

The following checks run automatically on this PR:

| Check | Status | Description |
|-------|--------|-------------|
| Check Issue Reference | ⏳ | PR body must contain `Closes/Fixes/Resolves #N` |
| Check Issue Has `status:approved` | ⏳ | Linked issue must have been approved before work began |
| Check PR Has `type:*` Label | ⏳ | Exactly one `type:*` label must be applied |
| Unit Tests | ⏳ | `go test ./...` must pass |
| E2E Tests | ⏳ | `cd e2e && ./docker-test.sh` must pass |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [ ] I have added the appropriate `type:*` label to this PR
- [ ] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] I have updated documentation if necessary (not needed; no user-facing config or commands changed)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

This intentionally does not change GGA installation or config-path behavior. It only fixes the Windows update detection false negative for the existing PowerShell shim.

I cannot apply labels on this repository from my fork, so a maintainer needs to apply exactly one label: `type:bug`.