### PR TITLE
fix(opencode): migrate preserved orchestrator prompts

### DIFF
--- a/.engram/config.json
+++ b/.engram/config.json
@@ -1,0 +1,3 @@
+{
+  "project_name": "gentle-ai"
+}

--- a/internal/cli/sync_test.go
+++ b/internal/cli/sync_test.go
@@ -1302,6 +1302,7 @@ func TestRunSyncExternalSingleActiveSkipsDetectAndPreservesOrchestratorPrompt(t 
 	seed := `{
   "agent": {
     "sdd-orchestrator": {"mode": "primary", "prompt": ` + strconv.Quote(customPrompt) + `},
+    "gentleman": {"mode": "primary", "description": "revoked OpenCode persona", "prompt": "REVOKED_GENTLEMAN_PROMPT_SHOULD_NOT_SURVIVE"},
     "sdd-orchestrator-cheap": {"mode": "primary", "model": "anthropic:claude-haiku-3-5"},
     "sdd-init-cheap": {"mode": "subagent", "model": "anthropic:claude-haiku-3-5"}
   }
@@ -1344,6 +1345,12 @@ func TestRunSyncExternalSingleActiveSkipsDetectAndPreservesOrchestratorPrompt(t 
 	}
 	if strings.Contains(settingsText, "\"sdd-onboard-cheap\"") {
 		t.Fatalf("external-single-active should not auto-detect/regenerate suffixed profiles")
+	}
+	if strings.Contains(settingsText, "\"gentleman\"") {
+		t.Fatalf("external-single-active sync should delete revoked gentleman agent")
+	}
+	if strings.Contains(settingsText, "REVOKED_GENTLEMAN_PROMPT_SHOULD_NOT_SURVIVE") {
+		t.Fatalf("external-single-active sync preserved revoked gentleman prompt")
 	}
 
 	// external-single-active forces multi-mode assets so shared prompts exist.

--- a/internal/cli/sync_test.go
+++ b/internal/cli/sync_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -1297,10 +1298,10 @@ func TestRunSyncExternalSingleActiveSkipsDetectAndPreservesOrchestratorPrompt(t 
 		t.Fatalf("WriteFile(AGENTS.md): %v", err)
 	}
 
-	const customPrompt = "EXTERNAL-RUNTIME-ORCHESTRATOR-PROMPT"
+	const customPrompt = "EXTERNAL-RUNTIME-ORCHESTRATOR-PROMPT\nBind this to the dedicated `sdd-orchestrator` agent only.\n- Treat `agent.sdd-orchestrator.model` as authoritative when it is set."
 	seed := `{
   "agent": {
-    "sdd-orchestrator": {"mode": "primary", "prompt": "` + customPrompt + `"},
+    "sdd-orchestrator": {"mode": "primary", "prompt": ` + strconv.Quote(customPrompt) + `},
     "sdd-orchestrator-cheap": {"mode": "primary", "model": "anthropic:claude-haiku-3-5"},
     "sdd-init-cheap": {"mode": "subagent", "model": "anthropic:claude-haiku-3-5"}
   }
@@ -1326,8 +1327,20 @@ func TestRunSyncExternalSingleActiveSkipsDetectAndPreservesOrchestratorPrompt(t 
 	}
 	settingsText := string(settingsData)
 
-	if !strings.Contains(settingsText, customPrompt) {
-		t.Fatalf("expected sdd-orchestrator prompt to be preserved in external-single-active mode")
+	if !strings.Contains(settingsText, "EXTERNAL-RUNTIME-ORCHESTRATOR-PROMPT") {
+		t.Fatalf("expected external runtime orchestrator prompt marker to be preserved in external-single-active mode")
+	}
+	if strings.Contains(settingsText, "Bind this to the dedicated `sdd-orchestrator` agent only.") {
+		t.Fatalf("external-single-active sync preserved stale sdd-orchestrator binding text")
+	}
+	if strings.Contains(settingsText, "agent.sdd-orchestrator.model") {
+		t.Fatalf("external-single-active sync preserved stale sdd-orchestrator model assignment key")
+	}
+	if !strings.Contains(settingsText, "Bind this to the dedicated `gentle-orchestrator` agent only.") {
+		t.Fatalf("external-single-active sync did not migrate binding text to gentle-orchestrator")
+	}
+	if !strings.Contains(settingsText, "agent.gentle-orchestrator.model") {
+		t.Fatalf("external-single-active sync did not migrate model assignment key to gentle-orchestrator")
 	}
 	if strings.Contains(settingsText, "\"sdd-onboard-cheap\"") {
 		t.Fatalf("external-single-active should not auto-detect/regenerate suffixed profiles")

--- a/internal/components/sdd/inject.go
+++ b/internal/components/sdd/inject.go
@@ -1002,8 +1002,10 @@ func mergeJSONFile(path string, overlay []byte) (mergeJSONResult, error) {
 // base OpenCode SDD conductor agents. The base SDD coordinator is now the
 // gentle-orchestrator primary agent; named profile agents such as
 // sdd-orchestrator-cheap intentionally remain untouched because they are
-// generated profile-specific coordinators. A real persona named "gentleman" is
-// preserved unless its definition clearly looks like the bad SDD conductor key.
+// generated profile-specific coordinators. The old OpenCode "gentleman" agent
+// key is revoked and is removed during sync; if it clearly contains the old SDD
+// conductor prompt and no gentle-orchestrator exists yet, its prompt is migrated
+// before the revoked key is deleted.
 func migrateLegacyOpenCodeSDDOrchestrator(baseJSON []byte) ([]byte, error) {
 	if len(strings.TrimSpace(string(baseJSON))) == 0 {
 		return baseJSON, nil
@@ -1024,22 +1026,21 @@ func migrateLegacyOpenCodeSDDOrchestrator(baseJSON []byte) ([]byte, error) {
 	}
 
 	legacy, hasLegacy := agentsMap["sdd-orchestrator"]
-	misnamedGentleman, hasMisnamedGentleman := agentsMap["gentleman"]
-	if hasMisnamedGentleman && !looksLikeOpenCodeSDDConductor(misnamedGentleman) {
-		hasMisnamedGentleman = false
-	}
-	if !hasLegacy && !hasMisnamedGentleman {
+	revokedGentleman, hasRevokedGentleman := agentsMap["gentleman"]
+	gentlemanLooksLikeConductor := hasRevokedGentleman && looksLikeOpenCodeSDDConductor(revokedGentleman)
+	if !hasLegacy && !hasRevokedGentleman {
 		return baseJSON, nil
 	}
-	if !hasLegacy {
-		legacy = misnamedGentleman
+	if !hasLegacy && gentlemanLooksLikeConductor {
+		legacy = revokedGentleman
+		hasLegacy = true
 	}
 
-	if _, hasGentleOrchestrator := agentsMap["gentle-orchestrator"]; !hasGentleOrchestrator {
+	if _, hasGentleOrchestrator := agentsMap["gentle-orchestrator"]; !hasGentleOrchestrator && hasLegacy {
 		agentsMap["gentle-orchestrator"] = legacy
 	}
 	delete(agentsMap, "sdd-orchestrator")
-	if hasMisnamedGentleman {
+	if hasRevokedGentleman {
 		delete(agentsMap, "gentleman")
 	}
 

--- a/internal/components/sdd/inject.go
+++ b/internal/components/sdd/inject.go
@@ -740,7 +740,7 @@ func inlineOpenCodeSDDPrompts(overlayBytes []byte, homeDir, settingsPath string,
 			}
 		}
 		if existingPrompt != "" {
-			orchestratorMap["prompt"] = existingPrompt
+			orchestratorMap["prompt"] = migratePreservedOpenCodeOrchestratorPrompt(existingPrompt)
 		} else {
 			orchestratorMap["prompt"] = assets.MustRead(sddOrchestratorAsset(model.AgentOpenCode))
 		}
@@ -774,6 +774,20 @@ func inlineOpenCodeSDDPrompts(overlayBytes []byte, homeDir, settingsPath string,
 	}
 
 	return append(result, '\n'), nil
+}
+
+func migratePreservedOpenCodeOrchestratorPrompt(prompt string) string {
+	if prompt == "" {
+		return prompt
+	}
+
+	replacer := strings.NewReplacer(
+		"Bind this to the dedicated `sdd-orchestrator` agent only.",
+		"Bind this to the dedicated `gentle-orchestrator` agent only.",
+		"agent.sdd-orchestrator.model",
+		"agent.gentle-orchestrator.model",
+	)
+	return replacer.Replace(prompt)
 }
 
 func readOpenCodeAgentPrompt(settingsPath, agentKey string) (string, error) {

--- a/internal/components/sdd/inject_test.go
+++ b/internal/components/sdd/inject_test.go
@@ -548,6 +548,63 @@ func TestInjectOpenCodeMigratesMisnamedGentlemanSDDOrchestrator(t *testing.T) {
 	}
 }
 
+func TestInjectOpenCodeDeletesRevokedGentlemanAgent(t *testing.T) {
+	home := t.TempDir()
+	mockNoPackageManager(t)
+
+	settingsPath := filepath.Join(home, ".config", "opencode", "opencode.json")
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(settings dir) error = %v", err)
+	}
+
+	seed := `{
+  "agent": {
+    "gentleman": {
+      "mode": "primary",
+      "description": "Senior Architect mentor - revoked OpenCode persona",
+      "prompt": "REVOKED_GENTLEMAN_PROMPT_SHOULD_NOT_SURVIVE"
+    },
+    "gentle-orchestrator": {
+      "mode": "primary",
+      "prompt": "CURRENT_GENTLE_ORCHESTRATOR_PROMPT"
+    }
+  }
+}`
+	if err := os.WriteFile(settingsPath, []byte(seed), 0o644); err != nil {
+		t.Fatalf("WriteFile(opencode.json) error = %v", err)
+	}
+
+	_, err := Inject(home, opencodeAdapter(), model.SDDModeMulti, InjectOptions{
+		PreserveOpenCodeOrchestratorPrompt: true,
+	})
+	if err != nil {
+		t.Fatalf("Inject() error = %v", err)
+	}
+
+	settingsBytes, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("ReadFile(opencode.json) error = %v", err)
+	}
+	root := map[string]any{}
+	if err := json.Unmarshal(settingsBytes, &root); err != nil {
+		t.Fatalf("Unmarshal(opencode.json) error = %v", err)
+	}
+	agentMap, ok := root["agent"].(map[string]any)
+	if !ok {
+		t.Fatal("opencode.json missing agent map")
+	}
+	if _, exists := agentMap["gentleman"]; exists {
+		t.Fatal("revoked gentleman agent should be removed")
+	}
+	gentleOrchestratorAgent, ok := agentMap["gentle-orchestrator"].(map[string]any)
+	if !ok {
+		t.Fatal("gentle-orchestrator agent not found or wrong type")
+	}
+	if prompt, _ := gentleOrchestratorAgent["prompt"].(string); prompt != "CURRENT_GENTLE_ORCHESTRATOR_PROMPT" {
+		t.Fatalf("gentle-orchestrator prompt = %q, want preserved current prompt", prompt)
+	}
+}
+
 func TestInjectOpenCodeOverwritesOrchestratorPromptByDefault(t *testing.T) {
 	home := t.TempDir()
 	mockNoPackageManager(t)

--- a/internal/components/sdd/inject_test.go
+++ b/internal/components/sdd/inject_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -379,6 +380,58 @@ func TestInjectOpenCodePreservesExistingOrchestratorPromptWhenRequested(t *testi
 	}
 	if !strings.Contains(string(settingsBytes), customPrompt) {
 		t.Fatalf("expected preserved custom orchestrator prompt %q in opencode.json", customPrompt)
+	}
+}
+
+func TestInjectOpenCodeMigratesPreservedLegacyOrchestratorPromptReferences(t *testing.T) {
+	home := t.TempDir()
+	mockNoPackageManager(t)
+
+	settingsPath := filepath.Join(home, ".config", "opencode", "opencode.json")
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(settings dir) error = %v", err)
+	}
+
+	const stalePrompt = "# Gentle AI — SDD Orchestrator Instructions\n\nBind this to the dedicated `sdd-orchestrator` agent only.\n\n- Treat `agent.sdd-orchestrator.model` as authoritative when it is set.\n"
+	seed := `{
+  "agent": {
+    "gentle-orchestrator": {
+      "mode": "primary",
+      "prompt": ` + strconv.Quote(stalePrompt) + `
+    }
+  }
+}`
+	if err := os.WriteFile(settingsPath, []byte(seed), 0o644); err != nil {
+		t.Fatalf("WriteFile(opencode.json) error = %v", err)
+	}
+
+	_, err := Inject(home, opencodeAdapter(), model.SDDModeMulti, InjectOptions{
+		PreserveOpenCodeOrchestratorPrompt: true,
+	})
+	if err != nil {
+		t.Fatalf("Inject() error = %v", err)
+	}
+
+	settingsBytes, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("ReadFile(opencode.json) error = %v", err)
+	}
+	text := string(settingsBytes)
+	for _, unwanted := range []string{
+		"Bind this to the dedicated `sdd-orchestrator` agent only.",
+		"agent.sdd-orchestrator.model",
+	} {
+		if strings.Contains(text, unwanted) {
+			t.Fatalf("opencode.json still contains stale preserved prompt reference %q", unwanted)
+		}
+	}
+	for _, wanted := range []string{
+		"Bind this to the dedicated `gentle-orchestrator` agent only.",
+		"agent.gentle-orchestrator.model",
+	} {
+		if !strings.Contains(text, wanted) {
+			t.Fatalf("opencode.json missing migrated preserved prompt reference %q", wanted)
+		}
 	}
 }
 


### PR DESCRIPTION
Closes #418

## Type
- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Migrates known legacy `sdd-orchestrator` references inside preserved OpenCode `gentle-orchestrator` prompts.
- Removes revoked OpenCode `gentleman` agent entries during sync while preserving valid named profile agents.
- Adds regression coverage for direct injection and external-single-active TUI sync behavior.
- Adds repo-local Engram project-name config so writes lock to `gentle-ai`.

## Changes

| File | Change |
|------|--------|
| `internal/components/sdd/inject.go` | Applies targeted prompt migration before preserving existing OpenCode orchestrator prompts and deletes revoked `gentleman` entries. |
| `internal/components/sdd/inject_test.go` | Covers preserved stale prompt references and revoked `gentleman` removal during OpenCode SDD injection. |
| `internal/cli/sync_test.go` | Covers external-single-active sync preserving custom prompt content while migrating legacy references and removing revoked `gentleman`. |
| `.engram/config.json` | Locks Engram project detection for this repo to `gentle-ai`. |

## Test Plan
- [x] `go test ./internal/components/sdd ./internal/cli`
- [x] Ran local fixed sync with `go run ./cmd/gentle-ai sync`
- [x] Verified `~/.config/opencode/opencode.json` has `gentle-orchestrator` binding/model references and no stale base `sdd-orchestrator` prompt references
- [x] Verified `~/.config/opencode/opencode.json` does not contain revoked `gentleman` agent
- [x] Verified Claude Code still has Delivery Strategy and Review Workload Guard installed
- [x] Verified Engram config file format against Engram docs: `.engram/config.json` with `project_name`

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran relevant checks
- [x] Skills tested in at least one agent
- [x] Docs updated if behavior changed, or not needed
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers