### PR TITLE
fix(upgrade): keep backup diagnostics out of progress

### DIFF
--- a/internal/update/upgrade/executor.go
+++ b/internal/update/upgrade/executor.go
@@ -245,7 +245,6 @@ func Execute(ctx context.Context, results []update.UpdateResult, profile system.
 	options := ExecuteOptions{}
 	if len(progress) > 0 && progress[0] != nil {
 		options.Progress = progress[0]
-		options.BackupDiagnostics = progress[0]
 	}
 	return ExecuteWithOptions(ctx, results, profile, homeDir, dryRun, options)
 }

--- a/internal/update/upgrade/executor_test.go
+++ b/internal/update/upgrade/executor_test.go
@@ -243,6 +243,45 @@ func TestExecute_BackupBeforeExecution(t *testing.T) {
 	}
 }
 
+func TestExecuteProgressDoesNotIncludeBackupExclusionDiagnostics(t *testing.T) {
+	origExecCommand := execCommand
+	t.Cleanup(func() { execCommand = origExecCommand })
+	execCommand = func(name string, args ...string) *exec.Cmd {
+		return exec.Command("echo", "ok")
+	}
+
+	home := t.TempDir()
+	configFile := filepath.Join(home, ".claude", "CLAUDE.md")
+	excludedFile := filepath.Join(home, ".claude", "projects", "session.json")
+	for _, f := range []string{configFile, excludedFile} {
+		if err := os.MkdirAll(filepath.Dir(f), 0o755); err != nil {
+			t.Fatalf("MkdirAll: %v", err)
+		}
+		if err := os.WriteFile(f, []byte("data"), 0o644); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+	}
+
+	results := []update.UpdateResult{
+		makeResult("engram", update.UpdateAvailable, "0.3.0", "0.4.0", update.InstallGoInstall),
+	}
+	results[0].Tool.GoImportPath = "github.com/Gentleman-Programming/engram/cmd/engram"
+
+	var progress bytes.Buffer
+	report := Execute(context.Background(), results, linuxProfile(), home, false, &progress)
+	if report.BackupID == "" {
+		t.Fatal("BackupID should be populated before upgrade execution")
+	}
+
+	got := progress.String()
+	if strings.Contains(got, "backup: excluding directory") {
+		t.Fatalf("progress output leaked backup exclusion diagnostics:\n%s", got)
+	}
+	if !strings.Contains(got, "Creating pre-upgrade backup") {
+		t.Fatalf("progress output should still show user-visible backup progress, got:\n%s", got)
+	}
+}
+
 // --- TestExecute_DryRunNeverExecs ---
 
 // TestExecute_DryRunNeverExecs verifies that when dryRun=true, no exec is called


### PR DESCRIPTION
Closes #420

## Type
- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Stops normal upgrade progress output from receiving verbose backup exclusion diagnostics.
- Keeps high-level backup progress visible while preserving explicit diagnostic output for callers that opt into it.
- Adds regression coverage so excluded backup directories do not spam progress output again.

## Changes

| File | Change |
|------|--------|
| `internal/update/upgrade/executor.go` | Stops wiring `BackupDiagnostics` to the progress writer by default. |
| `internal/update/upgrade/executor_test.go` | Adds regression coverage for progress output without backup exclusion diagnostics. |

## Test Plan
- [x] `go test ./internal/update/upgrade`

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran relevant checks
- [x] Skills tested in at least one agent, or not applicable
- [x] Docs updated if behavior changed, or not needed
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers