### PR TITLE
docs(skills): interactive chain strategy selection in chained-pr

### DIFF
--- a/internal/assets/opencode/sdd-orchestrator.md
+++ b/internal/assets/opencode/sdd-orchestrator.md
@@ -105,6 +105,15 @@ When the user invokes `/sdd-new`, `/sdd-ff`, or `/sdd-continue` for the first ti
 
 Cache the delivery strategy for the session. Pass it as `delivery_strategy` to `sdd-tasks` and `sdd-apply` prompts.
 
+### Chain Strategy
+
+When `delivery_strategy` results in chained PRs (either by user choice via `ask-on-risk` or automatically via `auto-chain`), ask the user which chain strategy to use:
+
+- **`stacked-to-main`**: Each PR merges to main in order. Fast iteration, fix on the go. Best for speed-first teams and independent slices.
+- **`feature-branch-chain`**: All PRs merge into a shared branch with a tracker PR. Only the tracker merges to main. Best for rollback control and coordinated releases.
+
+Cache the chain strategy for the session. Pass it as `chain_strategy` to `sdd-tasks` and `sdd-apply` prompts alongside `delivery_strategy`. Do not ask again unless the user changes scope.
+
 ### Dependency Graph
 ```
 proposal -> specs --> tasks -> apply -> verify -> archive
@@ -122,14 +131,14 @@ After `sdd-tasks` completes and before launching `sdd-apply`, inspect the task r
 
 If it says `Chained PRs recommended: Yes`, `400-line budget risk: High`, estimated changed lines exceed 400, or `Decision needed before apply: Yes`, apply the cached `delivery_strategy`:
 
-- **`ask-on-risk`**: STOP and ask whether to split into chained/stacked PRs using work-unit commits or proceed with maintainer-approved `size:exception`.
-- **`auto-chain`**: Do not ask. Pass to `sdd-apply`: implement only the next autonomous chained/stacked PR slice using work-unit commits, with clear start, finish, verification, and rollback boundary.
+- **`ask-on-risk`**: STOP and ask whether to split into chained/stacked PRs or proceed with `size:exception`. If the user chooses chained PRs and `chain_strategy` is not yet cached, also ask which chain strategy to use (stacked-to-main or feature-branch-chain).
+- **`auto-chain`**: Do not ask about splitting. If `chain_strategy` is not yet cached, ask which chain strategy to use. Then pass to `sdd-apply`: implement only the next autonomous slice using work-unit commits, with clear start, finish, verification, and rollback boundary.
 - **`single-pr`**: STOP and require/record maintainer-approved `size:exception` before `sdd-apply`.
 - **`exception-ok`**: Continue, but pass to `sdd-apply` that this run uses maintainer-approved `size:exception`.
 
 Do this even in Automatic mode. Automatic mode does not override reviewer burnout protection.
 
-When launching `sdd-apply`, always include the resolved delivery strategy and any chosen PR boundary/exception in the prompt.
+When launching `sdd-apply`, always include the resolved `delivery_strategy`, `chain_strategy`, and any chosen PR boundary/exception in the prompt.
 
 <!-- gentle-ai:sdd-model-assignments -->
 ## Model Assignments

--- a/internal/assets/skills/sdd-apply/SKILL.md
+++ b/internal/assets/skills/sdd-apply/SKILL.md
@@ -55,11 +55,15 @@ If the forecast says any of the following:
 
 Then you MUST confirm the orchestrator/user provided a resolved delivery path:
 
-1. **`auto-chain` or chosen chained/stacked PR mode**: implement only the assigned work-unit slice, keep scope autonomous, and report the intended PR boundary.
+1. **`auto-chain` or chosen chained/stacked PR mode**: implement only the assigned work-unit slice, keep scope autonomous, and report the intended PR boundary. Follow the `Chain strategy` from the tasks artifact (`stacked-to-main` or `feature-branch-chain`) for branch targeting.
 2. **`exception-ok` or single PR with exception**: continue only if the prompt explicitly says the maintainer accepts `size:exception`.
 3. **`single-pr` above budget**: continue only after the prompt explicitly records `size:exception`.
 
-If neither decision is present, STOP before writing code and return `blocked` with: `Workload decision required before apply: estimated work may exceed 400 changed lines. Ask whether to use chained PRs with work-unit commits or proceed with size:exception.`
+Also check for `Chain strategy` in the tasks artifact. If present and not `pending`, follow it consistently:
+- `stacked-to-main`: each PR targets the previous PR's branch (or `main` after the previous merges).
+- `feature-branch-chain`: each PR targets the tracker/feature branch — never `main` directly.
+
+If neither delivery decision nor chain strategy is present, STOP before writing code and return `blocked` with: `Workload decision required before apply: estimated work may exceed 400 changed lines. Ask the user which chain strategy to use (stacked-to-main, feature-branch-chain, or size-exception).`
 
 #### Step 2b: Read Previous Apply-Progress (if exists)
 

--- a/internal/assets/skills/sdd-tasks/SKILL.md
+++ b/internal/assets/skills/sdd-tasks/SKILL.md
@@ -128,9 +128,13 @@ If the estimate is **High** or likely above 400 lines:
 1. Mark `Chained PRs recommended` as `Yes`.
 2. Split tasks into **work units** that can become chained or stacked PRs.
 3. Each suggested PR must have a clear start, clear finish, verification, and autonomous scope.
-4. Set `Decision needed before apply` from delivery strategy:
+4. **Ask the user which chain strategy to use** (this is a team decision):
+   - **Stacked PRs to main** — each PR merges to main in order. Fast iteration, fix on the go. Best for speed-first teams and independent slices.
+   - **Feature Branch Chain** — all PRs merge into a shared branch with a tracker PR. Only the tracker merges to main. Best for rollback control and coordinated releases.
+   - **size:exception** — keep it as a single PR with maintainer approval. Best for generated code, migrations, or vendor diffs.
+5. Cache the user's choice and set `Decision needed before apply` from delivery strategy:
    - `ask-on-risk`: `Yes` — orchestrator asks before apply.
-   - `auto-chain`: `No` — orchestrator proceeds with the first chained/stacked slice.
+   - `auto-chain`: `No` — orchestrator proceeds with the first slice using the chosen chain strategy.
    - `single-pr`: `Yes` — orchestrator must require `size:exception` before apply.
    - `exception-ok`: `No` — maintainer has accepted `size:exception`.
 
@@ -141,6 +145,7 @@ The forecast MUST include these exact plain-text lines so downstream guards can 
 ```text
 Decision needed before apply: Yes|No
 Chained PRs recommended: Yes|No
+Chain strategy: stacked-to-main|feature-branch-chain|size-exception|pending
 400-line budget risk: Low|Medium|High
 ```
 

--- a/internal/assets/skills/sdd-tasks/SKILL.md
+++ b/internal/assets/skills/sdd-tasks/SKILL.md
@@ -69,9 +69,11 @@ openspec/changes/{change-name}/
 | Chained PRs recommended | Yes / No |
 | Suggested split | <single PR or PR 1 → PR 2 → PR 3> |
 | Delivery strategy | <ask-on-risk / auto-chain / single-pr / exception-ok> |
+| Chain strategy | <stacked-to-main / feature-branch-chain / size-exception / pending> |
 
 Decision needed before apply: <Yes|No>
 Chained PRs recommended: <Yes|No>
+Chain strategy: <stacked-to-main|feature-branch-chain|size-exception|pending>
 400-line budget risk: <Low|Medium|High>
 
 ### Suggested Work Units

--- a/skills/chained-pr/SKILL.md
+++ b/skills/chained-pr/SKILL.md
@@ -37,8 +37,8 @@ Do not use this skill for small fixes or single-purpose changes that fit comfort
 | Exceptions | Use `size:exception` only when a maintainer agrees the large diff is unavoidable |
 | SDD handoff | If SDD forecasts a >400-line workload, honor `delivery_strategy`: ask, auto-chain, or require/record `size:exception` |
 | Visual map | Every chained PR MUST include a dependency diagram that marks the current PR |
-| Tracker PR | Every chain SHOULD have a draft tracker PR that lists every child PR and current status |
-| Tracker targeting | If a tracker PR exists, **no child PR may target `main`** — all must flow through the tracker branch |
+| Tracker PR | If the team chooses Feature Branch Chain, create a draft tracker PR that lists every child PR and current status |
+| Strategy consistency | Once the user picks a chain strategy, follow it for the entire chain — do not mix stacked and feature branch patterns |
 
 The goal is not bureaucracy. The goal is preventing reviewer burnout so maintainers can review with care instead of skimming exhausted. Big PRs create fatigue, hide defects, and slow merge velocity.
 
@@ -54,33 +54,38 @@ Each chained PR must function as a complete review unit:
 
 If a slice cannot meet these rules, split it differently. A chain is not a dumping ground for partial, unreviewable diffs.
 
-## Choosing the Split Strategy
+## Choosing the Chain Strategy
 
-Follow this decision tree — first match wins:
+When the workload exceeds 400 lines and chained PRs are needed, **ask the user** before proceeding:
 
 ```
-1. Is there (or will there be) a tracker PR?
-   YES → Feature Branch Chain (mandatory)
-   NO  ↓
+This work exceeds the 400-line review budget. How do you want to split it?
 
-2. Can every slice land in main independently and stay green?
-   YES → Stacked PRs to main
-   NO  → Feature Branch Chain
+1. Stacked PRs to main
+   Each PR merges to main in order. Fast iteration, fix on the go.
+   Best for: speed-first teams, startups, independent slices.
 
-3. Is the diff pure generated/vendor/migration code?
-   YES → Consider size:exception instead of splitting
+2. Feature Branch Chain (with tracker)
+   All PRs merge into a shared branch. Only the tracker merges to main.
+   Best for: rollback control, integration testing before main, coordinated releases.
+
+3. size:exception
+   Keep it as a single PR with maintainer approval.
+   Best for: generated code, migrations, vendor diffs where splitting adds noise.
 ```
 
-**Hard rule:** If a tracker PR exists, every child PR MUST target the tracker branch (or another child branch that eventually flows into it). No child PR may target `main` directly — otherwise the chain bypasses the tracker and lands in `main` before the chain is complete.
+Cache the user's answer for the rest of the session. Do not ask again unless the user changes scope.
 
-| Scenario | Required approach | Why |
-|----------|-------------------|-----|
-| Tracker PR exists | **Feature Branch Chain** | All work must flow through the tracker before `main` |
-| Slices need integration before main | Feature Branch Chain | Keeps incomplete work away from `main` |
-| API and UI are tightly coupled | Feature Branch Chain | Allows integration before final merge |
-| Each slice can land independently, no tracker | Stacked PRs to `main` | Reduces long-lived branch drift |
-| Backend can ship before UI, no tracker | Stacked PRs | Faster incremental value |
-| Pure generated/vendor/migration diff | `size:exception` | Splitting may add noise without reducing review complexity |
+This is a **team decision**, not a technical one. Both strategies are valid — they reflect different priorities:
+
+| | Stacked PRs to main | Feature Branch Chain |
+|---|---|---|
+| Speed | Each slice ships immediately | Waits until the chain is complete |
+| Rollback | Revert individual PRs from main | Revert the whole feature branch |
+| Risk | Partial features may land in main | Nothing lands until everything is ready |
+| Fix flow | Fix on the go in main | Fix on the integration branch |
+| Complexity | Simpler — rebase and retarget | Needs tracker PR and branch management |
+| Best for | Startups, fast-moving teams | Teams needing coordination and control |
 
 ## Chain Boundaries
 
@@ -142,7 +147,7 @@ When SDD planning produces tasks that may exceed 400 changed lines:
 
 ## Feature Branch Chain
 
-Use this when multiple PRs should integrate together before landing in `main`. **Required when a tracker PR exists.**
+Use this when the user chooses option 2: all PRs integrate in a shared branch before landing in `main`.
 
 ```text
 main
@@ -161,12 +166,13 @@ main
 5. Merge child PRs into the feature branch as they pass review.
 6. Only merge the tracker PR into `main` after all children are merged and integrated.
 
-### Anti-pattern: child PR targeting main
+### Common mistake: child PR targeting main
+
+If you chose this strategy, no child PR should target `main` — otherwise it bypasses the tracker and lands in `main` before the chain is complete.
 
 ```text
-# WRONG — child bypasses tracker and lands in main directly
+# WRONG — child bypasses tracker
 main ← #101 (base: main) ← #102 ← #103
-              ↑ this skips the tracker
 
 # CORRECT — all children flow through the tracker branch
 main ← tracker (#105)
@@ -174,8 +180,6 @@ main ← tracker (#105)
          ├── #102 (base: tracker branch)
          └── #103 (base: tracker branch)
 ```
-
-If any child PR has `base: main` while a tracker PR exists, the chain is broken. The child will merge into `main` before the tracker, defeating the purpose of the chain.
 
 ### Tracker PR Expectations
 

--- a/skills/chained-pr/SKILL.md
+++ b/skills/chained-pr/SKILL.md
@@ -38,6 +38,7 @@ Do not use this skill for small fixes or single-purpose changes that fit comfort
 | SDD handoff | If SDD forecasts a >400-line workload, honor `delivery_strategy`: ask, auto-chain, or require/record `size:exception` |
 | Visual map | Every chained PR MUST include a dependency diagram that marks the current PR |
 | Tracker PR | Every chain SHOULD have a draft tracker PR that lists every child PR and current status |
+| Tracker targeting | If a tracker PR exists, **no child PR may target `main`** — all must flow through the tracker branch |
 
 The goal is not bureaucracy. The goal is preventing reviewer burnout so maintainers can review with care instead of skimming exhausted. Big PRs create fatigue, hide defects, and slow merge velocity.
 
@@ -55,12 +56,30 @@ If a slice cannot meet these rules, split it differently. A chain is not a dumpi
 
 ## Choosing the Split Strategy
 
-| Scenario | Recommended approach | Why |
-|----------|----------------------|-----|
-| Feature needs isolated integration before main | Feature branch chain | Keeps incomplete work away from `main` |
-| Each slice can land independently | Stacked PRs to `main` | Reduces long-lived branch drift |
-| API and UI are tightly coupled | Feature branch chain | Allows integration before final merge |
-| Backend can ship before UI | Stacked PRs | Faster incremental value |
+Follow this decision tree — first match wins:
+
+```
+1. Is there (or will there be) a tracker PR?
+   YES → Feature Branch Chain (mandatory)
+   NO  ↓
+
+2. Can every slice land in main independently and stay green?
+   YES → Stacked PRs to main
+   NO  → Feature Branch Chain
+
+3. Is the diff pure generated/vendor/migration code?
+   YES → Consider size:exception instead of splitting
+```
+
+**Hard rule:** If a tracker PR exists, every child PR MUST target the tracker branch (or another child branch that eventually flows into it). No child PR may target `main` directly — otherwise the chain bypasses the tracker and lands in `main` before the chain is complete.
+
+| Scenario | Required approach | Why |
+|----------|-------------------|-----|
+| Tracker PR exists | **Feature Branch Chain** | All work must flow through the tracker before `main` |
+| Slices need integration before main | Feature Branch Chain | Keeps incomplete work away from `main` |
+| API and UI are tightly coupled | Feature Branch Chain | Allows integration before final merge |
+| Each slice can land independently, no tracker | Stacked PRs to `main` | Reduces long-lived branch drift |
+| Backend can ship before UI, no tracker | Stacked PRs | Faster incremental value |
 | Pure generated/vendor/migration diff | `size:exception` | Splitting may add noise without reducing review complexity |
 
 ## Chain Boundaries
@@ -123,11 +142,11 @@ When SDD planning produces tasks that may exceed 400 changed lines:
 
 ## Feature Branch Chain
 
-Use this when multiple PRs should integrate together before landing in `main`.
+Use this when multiple PRs should integrate together before landing in `main`. **Required when a tracker PR exists.**
 
 ```text
 main
- └── feat/my-feature              # integration branch
+ └── feat/my-feature              # tracker PR targets main
       ├── feat/my-feature-01-core # PR targets feat/my-feature
       ├── feat/my-feature-02-cli  # PR targets feat/my-feature
       └── feat/my-feature-03-docs # PR targets feat/my-feature
@@ -135,11 +154,28 @@ main
 
 ### Steps
 
-1. Create the feature branch from `main`.
-2. Open a main/tracker PR from the feature branch to `main` early and mark it as draft/no-merge.
-3. Create each implementation branch from the feature branch.
-4. Target each chained PR back to the feature branch.
-5. Merge the final feature branch to `main` only after all chained PRs are merged and tested together.
+1. Create the feature/tracker branch from `main`.
+2. Open the tracker PR from the feature branch to `main` — mark it draft with `no-merge`.
+3. Create each child branch from the feature branch.
+4. **Every child PR MUST target the feature/tracker branch** — never `main`.
+5. Merge child PRs into the feature branch as they pass review.
+6. Only merge the tracker PR into `main` after all children are merged and integrated.
+
+### Anti-pattern: child PR targeting main
+
+```text
+# WRONG — child bypasses tracker and lands in main directly
+main ← #101 (base: main) ← #102 ← #103
+              ↑ this skips the tracker
+
+# CORRECT — all children flow through the tracker branch
+main ← tracker (#105)
+         ├── #101 (base: tracker branch)
+         ├── #102 (base: tracker branch)
+         └── #103 (base: tracker branch)
+```
+
+If any child PR has `base: main` while a tracker PR exists, the chain is broken. The child will merge into `main` before the tracker, defeating the purpose of the chain.
 
 ### Tracker PR Expectations
 


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #423

## 🏷️ PR Type

- [x] `type:docs` — Documentation only

## 📝 Summary

- Replaces the rigid decision tree in chained-pr skill with an interactive question that asks the user to choose between Stacked PRs to main (fast, startup-friendly) and Feature Branch Chain (controlled, rollback-friendly)
- Adds tradeoff comparison table so the team can make an informed decision
- Caches `chain_strategy` in the SDD session alongside `delivery_strategy` through orchestrator → sdd-tasks → sdd-apply

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `skills/chained-pr/SKILL.md` | Interactive strategy question, tradeoff table, anti-pattern docs |
| `internal/assets/skills/sdd-tasks/SKILL.md` | Added `Chain strategy` to workload forecast artifact |
| `internal/assets/skills/sdd-apply/SKILL.md` | Reads and enforces cached `chain_strategy` for branch targeting |
| `internal/assets/opencode/sdd-orchestrator.md` | Asks and caches `chain_strategy` in session like `delivery_strategy` |

## 🧪 Test Plan

- [x] Manual review of skill content and SDD pipeline flow
- [ ] Unit tests pass (`go test ./...`) — docs/instructions only, no Go code changed
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — docs/instructions only, no Go code changed

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines (83 additions, 23 deletions)
- [x] I have added the appropriate `type:*` label to this PR
- [x] I have updated documentation if necessary
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers

---
_Generated by [Claude Code](https://claude.ai/code/session_01PsNuGFhZ13MdA1Rx9dCxkT)_