### PR TITLE
docs(engram): support prompt capture controls

### DIFF
--- a/docs/engram.md
+++ b/docs/engram.md
@@ -78,7 +78,7 @@ These are the tools the AI agent uses behind the scenes. You never call them dir
 | `mem_get_observation` | Retrieves full untruncated content of a specific observation by ID |
 | `mem_save_prompt` | Saves the user's prompt and feeds session activity so a later `mem_save` can capture/dedupe it |
 
-`mem_save` accepts optional `capture_prompt`. Leave it unset for normal human/proactive saves. Use `capture_prompt: false` only for automated artifacts such as SDD proposal/spec/design/tasks/apply/verify/archive/init reports or skill-registry output. If the MCP server has no prompt context, `mem_save` still succeeds and does not invent prompt text.
+`mem_save` accepts optional `capture_prompt`. Leave it unset for normal human/proactive saves. Use `capture_prompt: false` only for automated artifacts such as SDD proposal/spec/design/tasks/apply/verify/archive/init reports, testing-capabilities caches, onboarding/state artifacts, or skill-registry output. If the MCP server has no prompt context, `mem_save` still succeeds and does not invent prompt text.
 
 Agents or plugin hooks that can observe the user's prompt should call `mem_save_prompt` before any derived `mem_save` calls so Engram can attach and dedupe the real prompt context.
 

--- a/docs/engram.md
+++ b/docs/engram.md
@@ -71,12 +71,16 @@ These are the tools the AI agent uses behind the scenes. You never call them dir
 
 | Tool | What it does |
 |------|--------------|
-| `mem_save` | Saves a decision, bug fix, discovery, or convention to memory |
+| `mem_save` | Saves a decision, bug fix, discovery, or convention to memory. Engram v1.15.3+ captures the user prompt best-effort by default when prompt context was already fed for the same project/session |
 | `mem_search` | Searches memory by keywords -- returns matching observations |
 | `mem_context` | Gets recent session history (called at session start) |
 | `mem_session_summary` | Saves an end-of-session summary so the next session has context |
 | `mem_get_observation` | Retrieves full untruncated content of a specific observation by ID |
-| `mem_save_prompt` | Saves the user's prompt for additional context |
+| `mem_save_prompt` | Saves the user's prompt and feeds session activity so a later `mem_save` can capture/dedupe it |
+
+`mem_save` accepts optional `capture_prompt`. Leave it unset for normal human/proactive saves. Use `capture_prompt: false` only for automated artifacts such as SDD proposal/spec/design/tasks/apply/verify/archive/init reports or skill-registry output. If the MCP server has no prompt context, `mem_save` still succeeds and does not invent prompt text.
+
+Agents or plugin hooks that can observe the user's prompt should call `mem_save_prompt` before any derived `mem_save` calls so Engram can attach and dedupe the real prompt context.
 
 ### Advanced Tools
 

--- a/internal/assets/claude/agents/sdd-apply.md
+++ b/internal/assets/claude/agents/sdd-apply.md
@@ -34,6 +34,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd/{change-name}/apply-progress"`
 - type: `"architecture"`
 - project: `{project-name from context}`
+- capture_prompt: `false`
 
 Also update the tasks artifact with `[x]` marks via `mem_update` (engram) or file edit (openspec/hybrid).
 

--- a/internal/assets/claude/agents/sdd-apply.md
+++ b/internal/assets/claude/agents/sdd-apply.md
@@ -34,7 +34,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd/{change-name}/apply-progress"`
 - type: `"architecture"`
 - project: `{project-name from context}`
-- capture_prompt: `false`
+- capture_prompt: `false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 Also update the tasks artifact with `[x]` marks via `mem_update` (engram) or file edit (openspec/hybrid).
 

--- a/internal/assets/claude/agents/sdd-archive.md
+++ b/internal/assets/claude/agents/sdd-archive.md
@@ -35,7 +35,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd/{change-name}/archive-report"`
 - type: `"architecture"`
 - project: `{project-name from context}`
-- capture_prompt: `false`
+- capture_prompt: `false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 ## Result Contract
 

--- a/internal/assets/claude/agents/sdd-archive.md
+++ b/internal/assets/claude/agents/sdd-archive.md
@@ -35,6 +35,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd/{change-name}/archive-report"`
 - type: `"architecture"`
 - project: `{project-name from context}`
+- capture_prompt: `false`
 
 ## Result Contract
 

--- a/internal/assets/claude/agents/sdd-design.md
+++ b/internal/assets/claude/agents/sdd-design.md
@@ -32,6 +32,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd/{change-name}/design"`
 - type: `"architecture"`
 - project: `{project-name from context}`
+- capture_prompt: `false`
 
 ## Result Contract
 

--- a/internal/assets/claude/agents/sdd-design.md
+++ b/internal/assets/claude/agents/sdd-design.md
@@ -32,7 +32,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd/{change-name}/design"`
 - type: `"architecture"`
 - project: `{project-name from context}`
-- capture_prompt: `false`
+- capture_prompt: `false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 ## Result Contract
 

--- a/internal/assets/claude/agents/sdd-explore.md
+++ b/internal/assets/claude/agents/sdd-explore.md
@@ -32,6 +32,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd/{change-name}/explore"`
 - type: `"architecture"`
 - project: `{project-name from context}`
+- capture_prompt: `false`
 
 ## Result Contract
 

--- a/internal/assets/claude/agents/sdd-explore.md
+++ b/internal/assets/claude/agents/sdd-explore.md
@@ -32,7 +32,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd/{change-name}/explore"`
 - type: `"architecture"`
 - project: `{project-name from context}`
-- capture_prompt: `false`
+- capture_prompt: `false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 ## Result Contract
 

--- a/internal/assets/claude/agents/sdd-propose.md
+++ b/internal/assets/claude/agents/sdd-propose.md
@@ -31,7 +31,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd/{change-name}/proposal"`
 - type: `"architecture"`
 - project: `{project-name from context}`
-- capture_prompt: `false`
+- capture_prompt: `false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 ## Result Contract
 

--- a/internal/assets/claude/agents/sdd-propose.md
+++ b/internal/assets/claude/agents/sdd-propose.md
@@ -31,6 +31,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd/{change-name}/proposal"`
 - type: `"architecture"`
 - project: `{project-name from context}`
+- capture_prompt: `false`
 
 ## Result Contract
 

--- a/internal/assets/claude/agents/sdd-spec.md
+++ b/internal/assets/claude/agents/sdd-spec.md
@@ -31,7 +31,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd/{change-name}/spec"`
 - type: `"architecture"`
 - project: `{project-name from context}`
-- capture_prompt: `false`
+- capture_prompt: `false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 ## Result Contract
 

--- a/internal/assets/claude/agents/sdd-spec.md
+++ b/internal/assets/claude/agents/sdd-spec.md
@@ -31,6 +31,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd/{change-name}/spec"`
 - type: `"architecture"`
 - project: `{project-name from context}`
+- capture_prompt: `false`
 
 ## Result Contract
 

--- a/internal/assets/claude/agents/sdd-tasks.md
+++ b/internal/assets/claude/agents/sdd-tasks.md
@@ -32,7 +32,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd/{change-name}/tasks"`
 - type: `"architecture"`
 - project: `{project-name from context}`
-- capture_prompt: `false`
+- capture_prompt: `false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 ## Result Contract
 

--- a/internal/assets/claude/agents/sdd-tasks.md
+++ b/internal/assets/claude/agents/sdd-tasks.md
@@ -32,6 +32,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd/{change-name}/tasks"`
 - type: `"architecture"`
 - project: `{project-name from context}`
+- capture_prompt: `false`
 
 ## Result Contract
 

--- a/internal/assets/claude/agents/sdd-verify.md
+++ b/internal/assets/claude/agents/sdd-verify.md
@@ -31,6 +31,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd/{change-name}/verify-report"`
 - type: `"architecture"`
 - project: `{project-name from context}`
+- capture_prompt: `false`
 
 ## Result Contract
 

--- a/internal/assets/claude/agents/sdd-verify.md
+++ b/internal/assets/claude/agents/sdd-verify.md
@@ -31,7 +31,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd/{change-name}/verify-report"`
 - type: `"architecture"`
 - project: `{project-name from context}`
-- capture_prompt: `false`
+- capture_prompt: `false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 ## Result Contract
 

--- a/internal/assets/claude/commands/sdd-apply.md
+++ b/internal/assets/claude/commands/sdd-apply.md
@@ -32,7 +32,7 @@ STEP B — RETRIEVE FULL CONTENT (mandatory):
 Update tasks as you complete them:
   mem_update(id: {tasks-observation-id}, content: "{updated tasks with [x] marks}")
 Save progress:
-  mem_save(title: "sdd/{change-name}/apply-progress", topic_key: "sdd/{change-name}/apply-progress", type: "architecture", project: "{project}", content: "{progress report}")
+  mem_save(title: "sdd/{change-name}/apply-progress", topic_key: "sdd/{change-name}/apply-progress", type: "architecture", project: "{project}", capture_prompt: false, content: "{progress report}")
 
 For each task:
 1. Read the relevant spec scenarios (acceptance criteria)

--- a/internal/assets/claude/commands/sdd-apply.md
+++ b/internal/assets/claude/commands/sdd-apply.md
@@ -33,6 +33,7 @@ Update tasks as you complete them:
   mem_update(id: {tasks-observation-id}, content: "{updated tasks with [x] marks}")
 Save progress:
   mem_save(title: "sdd/{change-name}/apply-progress", topic_key: "sdd/{change-name}/apply-progress", type: "architecture", project: "{project}", capture_prompt: false, content: "{progress report}")
+  Set capture_prompt: false when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 For each task:
 1. Read the relevant spec scenarios (acceptance criteria)

--- a/internal/assets/claude/commands/sdd-archive.md
+++ b/internal/assets/claude/commands/sdd-archive.md
@@ -30,6 +30,7 @@ STEP B — RETRIEVE FULL CONTENT (mandatory):
 Record all observation IDs in the archive report for traceability.
 Save:
   mem_save(title: "sdd/{change-name}/archive-report", topic_key: "sdd/{change-name}/archive-report", type: "architecture", project: "{project}", capture_prompt: false, content: "{archive report with observation IDs}")
+  Set capture_prompt: false when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 Then:
 1. Sync delta specs into main specs (source of truth)

--- a/internal/assets/claude/commands/sdd-archive.md
+++ b/internal/assets/claude/commands/sdd-archive.md
@@ -29,7 +29,7 @@ STEP B — RETRIEVE FULL CONTENT (mandatory):
   mem_get_observation(id: verify_id) → full verification report
 Record all observation IDs in the archive report for traceability.
 Save:
-  mem_save(title: "sdd/{change-name}/archive-report", topic_key: "sdd/{change-name}/archive-report", type: "architecture", project: "{project}", content: "{archive report with observation IDs}")
+  mem_save(title: "sdd/{change-name}/archive-report", topic_key: "sdd/{change-name}/archive-report", type: "architecture", project: "{project}", capture_prompt: false, content: "{archive report with observation IDs}")
 
 Then:
 1. Sync delta specs into main specs (source of truth)

--- a/internal/assets/claude/commands/sdd-explore.md
+++ b/internal/assets/claude/commands/sdd-explore.md
@@ -18,7 +18,7 @@ ENGRAM PERSISTENCE (artifact store mode: engram):
 Read project context (optional):
   mem_search(query: "sdd-init/{project}", project: "{project}") → if found, mem_get_observation(id) for full content
 Save exploration:
-  mem_save(title: "sdd/$ARGUMENTS/explore", topic_key: "sdd/$ARGUMENTS/explore", type: "architecture", project: "{project}", content: "{exploration}")
+  mem_save(title: "sdd/$ARGUMENTS/explore", topic_key: "sdd/$ARGUMENTS/explore", type: "architecture", project: "{project}", capture_prompt: false, content: "{exploration}")
 
 This is an exploration only — do NOT create any files or modify code. Just research and return your analysis.
 

--- a/internal/assets/claude/commands/sdd-explore.md
+++ b/internal/assets/claude/commands/sdd-explore.md
@@ -19,6 +19,7 @@ Read project context (optional):
   mem_search(query: "sdd-init/{project}", project: "{project}") → if found, mem_get_observation(id) for full content
 Save exploration:
   mem_save(title: "sdd/$ARGUMENTS/explore", topic_key: "sdd/$ARGUMENTS/explore", type: "architecture", project: "{project}", capture_prompt: false, content: "{exploration}")
+  Set capture_prompt: false when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 This is an exploration only — do NOT create any files or modify code. Just research and return your analysis.
 

--- a/internal/assets/claude/commands/sdd-init.md
+++ b/internal/assets/claude/commands/sdd-init.md
@@ -15,7 +15,7 @@ Initialize Spec-Driven Development in this project. Detect the tech stack, exist
 
 ENGRAM PERSISTENCE (artifact store mode: engram):
 After detecting the project context, save it:
-  mem_save(title: "sdd-init/{project}", topic_key: "sdd-init/{project}", type: "architecture", project: "{project}", content: "{detected context}")
+  mem_save(title: "sdd-init/{project}", topic_key: "sdd-init/{project}", type: "architecture", project: "{project}", capture_prompt: false, content: "{detected context}")
 topic_key enables upserts — re-running init updates, not duplicates.
 
 Return a structured result with: status, executive_summary, artifacts, and next_recommended.

--- a/internal/assets/claude/commands/sdd-init.md
+++ b/internal/assets/claude/commands/sdd-init.md
@@ -16,6 +16,7 @@ Initialize Spec-Driven Development in this project. Detect the tech stack, exist
 ENGRAM PERSISTENCE (artifact store mode: engram):
 After detecting the project context, save it:
   mem_save(title: "sdd-init/{project}", topic_key: "sdd-init/{project}", type: "architecture", project: "{project}", capture_prompt: false, content: "{detected context}")
+  Set capture_prompt: false when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 topic_key enables upserts — re-running init updates, not duplicates.
 
 Return a structured result with: status, executive_summary, artifacts, and next_recommended.

--- a/internal/assets/claude/commands/sdd-onboard.md
+++ b/internal/assets/claude/commands/sdd-onboard.md
@@ -16,6 +16,7 @@ Guide the user through a complete SDD cycle using their actual codebase. This is
 ENGRAM PERSISTENCE (artifact store mode: engram):
 Save onboarding progress as you go:
   mem_save(title: "sdd-onboard/{project}", topic_key: "sdd-onboard/{project}", type: "architecture", project: "{project}", capture_prompt: false, content: "{onboarding state}")
+  Set capture_prompt: false when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 topic_key enables upserts — re-running updates, not duplicates.
 
 Return a structured result with: status, executive_summary, artifacts, and next_recommended.

--- a/internal/assets/claude/commands/sdd-onboard.md
+++ b/internal/assets/claude/commands/sdd-onboard.md
@@ -15,7 +15,7 @@ Guide the user through a complete SDD cycle using their actual codebase. This is
 
 ENGRAM PERSISTENCE (artifact store mode: engram):
 Save onboarding progress as you go:
-  mem_save(title: "sdd-onboard/{project}", topic_key: "sdd-onboard/{project}", type: "architecture", project: "{project}", content: "{onboarding state}")
+  mem_save(title: "sdd-onboard/{project}", topic_key: "sdd-onboard/{project}", type: "architecture", project: "{project}", capture_prompt: false, content: "{onboarding state}")
 topic_key enables upserts — re-running updates, not duplicates.
 
 Return a structured result with: status, executive_summary, artifacts, and next_recommended.

--- a/internal/assets/claude/commands/sdd-verify.md
+++ b/internal/assets/claude/commands/sdd-verify.md
@@ -25,6 +25,7 @@ STEP B — RETRIEVE FULL CONTENT (mandatory):
   mem_get_observation(id: tasks_id) → full tasks
 Save report:
   mem_save(title: "sdd/{change-name}/verify-report", topic_key: "sdd/{change-name}/verify-report", type: "architecture", project: "{project}", capture_prompt: false, content: "{verification report}")
+  Set capture_prompt: false when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 Then:
 1. Check completeness — are all tasks done?

--- a/internal/assets/claude/commands/sdd-verify.md
+++ b/internal/assets/claude/commands/sdd-verify.md
@@ -24,7 +24,7 @@ STEP B — RETRIEVE FULL CONTENT (mandatory):
   mem_get_observation(id: design_id) → full design
   mem_get_observation(id: tasks_id) → full tasks
 Save report:
-  mem_save(title: "sdd/{change-name}/verify-report", topic_key: "sdd/{change-name}/verify-report", type: "architecture", project: "{project}", content: "{verification report}")
+  mem_save(title: "sdd/{change-name}/verify-report", topic_key: "sdd/{change-name}/verify-report", type: "architecture", project: "{project}", capture_prompt: false, content: "{verification report}")
 
 Then:
 1. Check completeness — are all tasks done?

--- a/internal/assets/claude/engram-protocol.md
+++ b/internal/assets/claude/engram-protocol.md
@@ -26,11 +26,20 @@ Format for `mem_save`:
 - **type**: bugfix | decision | architecture | discovery | pattern | config | preference
 - **scope**: `project` (default) | `personal`
 - **topic_key** (recommended for evolving topics): stable key like `architecture/auth-model`
+- **capture_prompt**: optional; default `true`. Do not set this for normal human/proactive saves. Set `false` only for automated artifacts such as SDD proposal/spec/design/tasks/apply/verify/archive/init reports or skill-registry output.
 - **content**:
   - **What**: One sentence — what was done
   - **Why**: What motivated it (user request, bug, performance, etc.)
   - **Where**: Files or paths affected
   - **Learned**: Gotchas, edge cases, things that surprised you (omit if none)
+
+Prompt capture behavior (Engram v1.15.3+):
+- `mem_save` captures the user prompt best-effort when the MCP process already has prompt context for the same `project + session_id`.
+- `mem_save` never invents prompt text. If no prompt context exists, the save still succeeds without prompt capture.
+- `mem_save_prompt` records the prompt and feeds SessionActivity so later `mem_save` calls can capture and dedupe it.
+- If an agent/plugin hook can observe the user's prompt before derived memory saves happen, it should call `mem_save_prompt` first.
+- Do not decide prompt capture by `type`; SDD artifacts also use `architecture`, and human decisions can too. Use explicit `capture_prompt: false` for automated artifacts.
+- If an older Engram tool schema does not expose `capture_prompt`, omit the field rather than failing.
 
 Topic update rules:
 - Different topics MUST NOT overwrite each other

--- a/internal/assets/claude/engram-protocol.md
+++ b/internal/assets/claude/engram-protocol.md
@@ -26,7 +26,7 @@ Format for `mem_save`:
 - **type**: bugfix | decision | architecture | discovery | pattern | config | preference
 - **scope**: `project` (default) | `personal`
 - **topic_key** (recommended for evolving topics): stable key like `architecture/auth-model`
-- **capture_prompt**: optional; default `true`. Do not set this for normal human/proactive saves. Set `false` only for automated artifacts such as SDD proposal/spec/design/tasks/apply/verify/archive/init reports or skill-registry output.
+- **capture_prompt**: optional; default `true`. Do not set this for normal human/proactive saves. Set `false` only for automated artifacts such as SDD proposal/spec/design/tasks/apply/verify/archive/init reports, testing-capabilities caches, onboarding/state artifacts, or skill-registry output.
 - **content**:
   - **What**: One sentence — what was done
   - **Why**: What motivated it (user request, bug, performance, etc.)

--- a/internal/assets/codex/engram-instructions.md
+++ b/internal/assets/codex/engram-instructions.md
@@ -17,7 +17,7 @@ Format for mem_save:
 - **type**: bugfix | decision | architecture | discovery | pattern | config | preference
 - **scope**: project (default) | personal
 - **topic_key** (optional, recommended for evolving decisions): stable key like architecture/auth-model
-- **capture_prompt**: optional; default true. Do not set it for normal human/proactive saves. Set false only for automated artifacts such as SDD proposal/spec/design/tasks/apply/verify/archive/init reports or skill-registry output.
+- **capture_prompt**: optional; default true. Do not set it for normal human/proactive saves. Set false only for automated artifacts such as SDD proposal/spec/design/tasks/apply/verify/archive/init reports, testing-capabilities caches, onboarding/state artifacts, or skill-registry output.
 - **content**:
   - **What**: One sentence — what was done
   - **Why**: What motivated it (user request, bug, performance, etc.)

--- a/internal/assets/codex/engram-instructions.md
+++ b/internal/assets/codex/engram-instructions.md
@@ -17,11 +17,20 @@ Format for mem_save:
 - **type**: bugfix | decision | architecture | discovery | pattern | config | preference
 - **scope**: project (default) | personal
 - **topic_key** (optional, recommended for evolving decisions): stable key like architecture/auth-model
+- **capture_prompt**: optional; default true. Do not set it for normal human/proactive saves. Set false only for automated artifacts such as SDD proposal/spec/design/tasks/apply/verify/archive/init reports or skill-registry output.
 - **content**:
   - **What**: One sentence — what was done
   - **Why**: What motivated it (user request, bug, performance, etc.)
   - **Where**: Files or paths affected
   - **Learned**: Gotchas, edge cases, things that surprised you (omit if none)
+
+Prompt capture behavior (Engram v1.15.3+):
+- mem_save captures the user prompt best-effort when the MCP process already has prompt context for the same project + session_id.
+- mem_save never invents prompt text. If no prompt context exists, the save still succeeds without prompt capture.
+- mem_save_prompt records the prompt and feeds SessionActivity so later mem_save calls can capture and dedupe it.
+- If an agent/plugin hook can observe the user's prompt before derived memory saves happen, it should call mem_save_prompt first.
+- Do not decide prompt capture by type; SDD artifacts also use architecture, and human decisions can too. Use explicit capture_prompt=false for automated artifacts.
+- If an older Engram tool schema does not expose capture_prompt, omit the field rather than failing.
 
 Topic update rules:
 - Different topics must not overwrite each other

--- a/internal/assets/cursor/agents/sdd-apply.md
+++ b/internal/assets/cursor/agents/sdd-apply.md
@@ -35,6 +35,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd/{change-name}/apply-progress"`
 - type: `"architecture"`
 - project: `{project-name from context}`
+- capture_prompt: `false`
 
 Also update the tasks artifact with `[x]` marks via `mem_update` (engram) or file edit (openspec/hybrid).
 

--- a/internal/assets/cursor/agents/sdd-apply.md
+++ b/internal/assets/cursor/agents/sdd-apply.md
@@ -35,7 +35,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd/{change-name}/apply-progress"`
 - type: `"architecture"`
 - project: `{project-name from context}`
-- capture_prompt: `false`
+- capture_prompt: `false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 Also update the tasks artifact with `[x]` marks via `mem_update` (engram) or file edit (openspec/hybrid).
 

--- a/internal/assets/cursor/agents/sdd-archive.md
+++ b/internal/assets/cursor/agents/sdd-archive.md
@@ -36,7 +36,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd/{change-name}/archive-report"`
 - type: `"architecture"`
 - project: `{project-name from context}`
-- capture_prompt: `false`
+- capture_prompt: `false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 ## Result Contract
 

--- a/internal/assets/cursor/agents/sdd-archive.md
+++ b/internal/assets/cursor/agents/sdd-archive.md
@@ -36,6 +36,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd/{change-name}/archive-report"`
 - type: `"architecture"`
 - project: `{project-name from context}`
+- capture_prompt: `false`
 
 ## Result Contract
 

--- a/internal/assets/cursor/agents/sdd-design.md
+++ b/internal/assets/cursor/agents/sdd-design.md
@@ -32,6 +32,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd/{change-name}/design"`
 - type: `"architecture"`
 - project: `{project-name from context}`
+- capture_prompt: `false`
 
 ## Result Contract
 

--- a/internal/assets/cursor/agents/sdd-design.md
+++ b/internal/assets/cursor/agents/sdd-design.md
@@ -32,7 +32,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd/{change-name}/design"`
 - type: `"architecture"`
 - project: `{project-name from context}`
-- capture_prompt: `false`
+- capture_prompt: `false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 ## Result Contract
 

--- a/internal/assets/cursor/agents/sdd-explore.md
+++ b/internal/assets/cursor/agents/sdd-explore.md
@@ -34,7 +34,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd/{change-name}/explore"`
 - type: `"architecture"`
 - project: `{project-name from context}`
-- capture_prompt: `false`
+- capture_prompt: `false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 ## Result Contract
 

--- a/internal/assets/cursor/agents/sdd-explore.md
+++ b/internal/assets/cursor/agents/sdd-explore.md
@@ -34,6 +34,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd/{change-name}/explore"`
 - type: `"architecture"`
 - project: `{project-name from context}`
+- capture_prompt: `false`
 
 ## Result Contract
 

--- a/internal/assets/cursor/agents/sdd-init.md
+++ b/internal/assets/cursor/agents/sdd-init.md
@@ -30,6 +30,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd-init/{project}"`
 - type: `"architecture"`
 - project: `{project-name from context}`
+- capture_prompt: `false`
 
 ## Result Contract
 

--- a/internal/assets/cursor/agents/sdd-init.md
+++ b/internal/assets/cursor/agents/sdd-init.md
@@ -30,7 +30,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd-init/{project}"`
 - type: `"architecture"`
 - project: `{project-name from context}`
-- capture_prompt: `false`
+- capture_prompt: `false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 ## Result Contract
 

--- a/internal/assets/cursor/agents/sdd-onboard.md
+++ b/internal/assets/cursor/agents/sdd-onboard.md
@@ -30,6 +30,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd-onboard/{project}"`
 - type: `"architecture"`
 - project: `{project-name from context}`
+- capture_prompt: `false`
 
 ## Result Contract
 

--- a/internal/assets/cursor/agents/sdd-onboard.md
+++ b/internal/assets/cursor/agents/sdd-onboard.md
@@ -30,7 +30,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd-onboard/{project}"`
 - type: `"architecture"`
 - project: `{project-name from context}`
-- capture_prompt: `false`
+- capture_prompt: `false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 ## Result Contract
 

--- a/internal/assets/cursor/agents/sdd-propose.md
+++ b/internal/assets/cursor/agents/sdd-propose.md
@@ -29,6 +29,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd/{change-name}/proposal"`
 - type: `"architecture"`
 - project: `{project-name from context}`
+- capture_prompt: `false`
 
 ## Result Contract
 

--- a/internal/assets/cursor/agents/sdd-propose.md
+++ b/internal/assets/cursor/agents/sdd-propose.md
@@ -29,7 +29,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd/{change-name}/proposal"`
 - type: `"architecture"`
 - project: `{project-name from context}`
-- capture_prompt: `false`
+- capture_prompt: `false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 ## Result Contract
 

--- a/internal/assets/cursor/agents/sdd-spec.md
+++ b/internal/assets/cursor/agents/sdd-spec.md
@@ -30,7 +30,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd/{change-name}/spec"`
 - type: `"architecture"`
 - project: `{project-name from context}`
-- capture_prompt: `false`
+- capture_prompt: `false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 ## Result Contract
 

--- a/internal/assets/cursor/agents/sdd-spec.md
+++ b/internal/assets/cursor/agents/sdd-spec.md
@@ -30,6 +30,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd/{change-name}/spec"`
 - type: `"architecture"`
 - project: `{project-name from context}`
+- capture_prompt: `false`
 
 ## Result Contract
 

--- a/internal/assets/cursor/agents/sdd-tasks.md
+++ b/internal/assets/cursor/agents/sdd-tasks.md
@@ -32,7 +32,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd/{change-name}/tasks"`
 - type: `"architecture"`
 - project: `{project-name from context}`
-- capture_prompt: `false`
+- capture_prompt: `false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 ## Result Contract
 

--- a/internal/assets/cursor/agents/sdd-tasks.md
+++ b/internal/assets/cursor/agents/sdd-tasks.md
@@ -32,6 +32,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd/{change-name}/tasks"`
 - type: `"architecture"`
 - project: `{project-name from context}`
+- capture_prompt: `false`
 
 ## Result Contract
 

--- a/internal/assets/cursor/agents/sdd-verify.md
+++ b/internal/assets/cursor/agents/sdd-verify.md
@@ -38,7 +38,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd/{change-name}/verify-report"`
 - type: `"architecture"`
 - project: `{project-name from context}`
-- capture_prompt: `false`
+- capture_prompt: `false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 ## Result Contract
 

--- a/internal/assets/cursor/agents/sdd-verify.md
+++ b/internal/assets/cursor/agents/sdd-verify.md
@@ -38,6 +38,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd/{change-name}/verify-report"`
 - type: `"architecture"`
 - project: `{project-name from context}`
+- capture_prompt: `false`
 
 ## Result Contract
 

--- a/internal/assets/kimi/agents/sdd-apply.md
+++ b/internal/assets/kimi/agents/sdd-apply.md
@@ -34,6 +34,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd/{change-name}/apply-progress"`
 - type: `"architecture"`
 - project: `{project-name from context}`
+- capture_prompt: `false`
 
 Also update the tasks artifact with `[x]` marks via `mem_update` (engram) or file edit (openspec/hybrid).
 

--- a/internal/assets/kimi/agents/sdd-apply.md
+++ b/internal/assets/kimi/agents/sdd-apply.md
@@ -34,7 +34,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd/{change-name}/apply-progress"`
 - type: `"architecture"`
 - project: `{project-name from context}`
-- capture_prompt: `false`
+- capture_prompt: `false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 Also update the tasks artifact with `[x]` marks via `mem_update` (engram) or file edit (openspec/hybrid).
 

--- a/internal/assets/kimi/agents/sdd-archive.md
+++ b/internal/assets/kimi/agents/sdd-archive.md
@@ -35,7 +35,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd/{change-name}/archive-report"`
 - type: `"architecture"`
 - project: `{project-name from context}`
-- capture_prompt: `false`
+- capture_prompt: `false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 ## Result Contract
 

--- a/internal/assets/kimi/agents/sdd-archive.md
+++ b/internal/assets/kimi/agents/sdd-archive.md
@@ -35,6 +35,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd/{change-name}/archive-report"`
 - type: `"architecture"`
 - project: `{project-name from context}`
+- capture_prompt: `false`
 
 ## Result Contract
 

--- a/internal/assets/kimi/agents/sdd-design.md
+++ b/internal/assets/kimi/agents/sdd-design.md
@@ -32,6 +32,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd/{change-name}/design"`
 - type: `"architecture"`
 - project: `{project-name from context}`
+- capture_prompt: `false`
 
 ## Result Contract
 

--- a/internal/assets/kimi/agents/sdd-design.md
+++ b/internal/assets/kimi/agents/sdd-design.md
@@ -32,7 +32,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd/{change-name}/design"`
 - type: `"architecture"`
 - project: `{project-name from context}`
-- capture_prompt: `false`
+- capture_prompt: `false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 ## Result Contract
 

--- a/internal/assets/kimi/agents/sdd-explore.md
+++ b/internal/assets/kimi/agents/sdd-explore.md
@@ -32,6 +32,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd/{change-name}/explore"`
 - type: `"architecture"`
 - project: `{project-name from context}`
+- capture_prompt: `false`
 
 ## Result Contract
 

--- a/internal/assets/kimi/agents/sdd-explore.md
+++ b/internal/assets/kimi/agents/sdd-explore.md
@@ -32,7 +32,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd/{change-name}/explore"`
 - type: `"architecture"`
 - project: `{project-name from context}`
-- capture_prompt: `false`
+- capture_prompt: `false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 ## Result Contract
 

--- a/internal/assets/kimi/agents/sdd-init.md
+++ b/internal/assets/kimi/agents/sdd-init.md
@@ -29,7 +29,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd-init/{project}"`
 - type: `"architecture"`
 - project: `{project-name from context}`
-- capture_prompt: `false`
+- capture_prompt: `false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 ## Result Contract
 

--- a/internal/assets/kimi/agents/sdd-init.md
+++ b/internal/assets/kimi/agents/sdd-init.md
@@ -29,6 +29,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd-init/{project}"`
 - type: `"architecture"`
 - project: `{project-name from context}`
+- capture_prompt: `false`
 
 ## Result Contract
 

--- a/internal/assets/kimi/agents/sdd-onboard.md
+++ b/internal/assets/kimi/agents/sdd-onboard.md
@@ -30,6 +30,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd-onboard/{project}"`
 - type: `"architecture"`
 - project: `{project-name from context}`
+- capture_prompt: `false`
 
 ## Result Contract
 

--- a/internal/assets/kimi/agents/sdd-onboard.md
+++ b/internal/assets/kimi/agents/sdd-onboard.md
@@ -30,7 +30,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd-onboard/{project}"`
 - type: `"architecture"`
 - project: `{project-name from context}`
-- capture_prompt: `false`
+- capture_prompt: `false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 ## Result Contract
 

--- a/internal/assets/kimi/agents/sdd-propose.md
+++ b/internal/assets/kimi/agents/sdd-propose.md
@@ -28,7 +28,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd/{change-name}/proposal"`
 - type: `"architecture"`
 - project: `{project-name from context}`
-- capture_prompt: `false`
+- capture_prompt: `false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 ## Result Contract
 

--- a/internal/assets/kimi/agents/sdd-propose.md
+++ b/internal/assets/kimi/agents/sdd-propose.md
@@ -28,6 +28,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd/{change-name}/proposal"`
 - type: `"architecture"`
 - project: `{project-name from context}`
+- capture_prompt: `false`
 
 ## Result Contract
 

--- a/internal/assets/kimi/agents/sdd-spec.md
+++ b/internal/assets/kimi/agents/sdd-spec.md
@@ -29,6 +29,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd/{change-name}/spec"`
 - type: `"architecture"`
 - project: `{project-name from context}`
+- capture_prompt: `false`
 
 ## Result Contract
 

--- a/internal/assets/kimi/agents/sdd-spec.md
+++ b/internal/assets/kimi/agents/sdd-spec.md
@@ -29,7 +29,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd/{change-name}/spec"`
 - type: `"architecture"`
 - project: `{project-name from context}`
-- capture_prompt: `false`
+- capture_prompt: `false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 ## Result Contract
 

--- a/internal/assets/kimi/agents/sdd-tasks.md
+++ b/internal/assets/kimi/agents/sdd-tasks.md
@@ -31,6 +31,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd/{change-name}/tasks"`
 - type: `"architecture"`
 - project: `{project-name from context}`
+- capture_prompt: `false`
 
 ## Result Contract
 

--- a/internal/assets/kimi/agents/sdd-tasks.md
+++ b/internal/assets/kimi/agents/sdd-tasks.md
@@ -31,7 +31,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd/{change-name}/tasks"`
 - type: `"architecture"`
 - project: `{project-name from context}`
-- capture_prompt: `false`
+- capture_prompt: `false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 ## Result Contract
 

--- a/internal/assets/kimi/agents/sdd-verify.md
+++ b/internal/assets/kimi/agents/sdd-verify.md
@@ -36,7 +36,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd/{change-name}/verify-report"`
 - type: `"architecture"`
 - project: `{project-name from context}`
-- capture_prompt: `false`
+- capture_prompt: `false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 ## Result Contract
 

--- a/internal/assets/kimi/agents/sdd-verify.md
+++ b/internal/assets/kimi/agents/sdd-verify.md
@@ -36,6 +36,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd/{change-name}/verify-report"`
 - type: `"architecture"`
 - project: `{project-name from context}`
+- capture_prompt: `false`
 
 ## Result Contract
 

--- a/internal/assets/kiro/agents/sdd-apply.md
+++ b/internal/assets/kiro/agents/sdd-apply.md
@@ -40,6 +40,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd/{change-name}/apply-progress"`
 - type: `"architecture"`
 - project: `{project-name from context}`
+- capture_prompt: `false`
 
 Also update the tasks artifact with `[x]` marks via `mem_update` (engram) or file edit (openspec/hybrid).
 

--- a/internal/assets/kiro/agents/sdd-apply.md
+++ b/internal/assets/kiro/agents/sdd-apply.md
@@ -40,7 +40,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd/{change-name}/apply-progress"`
 - type: `"architecture"`
 - project: `{project-name from context}`
-- capture_prompt: `false`
+- capture_prompt: `false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 Also update the tasks artifact with `[x]` marks via `mem_update` (engram) or file edit (openspec/hybrid).
 

--- a/internal/assets/kiro/agents/sdd-archive.md
+++ b/internal/assets/kiro/agents/sdd-archive.md
@@ -41,6 +41,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd/{change-name}/archive-report"`
 - type: `"architecture"`
 - project: `{project-name from context}`
+- capture_prompt: `false`
 
 ## Result Contract
 

--- a/internal/assets/kiro/agents/sdd-archive.md
+++ b/internal/assets/kiro/agents/sdd-archive.md
@@ -41,7 +41,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd/{change-name}/archive-report"`
 - type: `"architecture"`
 - project: `{project-name from context}`
-- capture_prompt: `false`
+- capture_prompt: `false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 ## Result Contract
 

--- a/internal/assets/kiro/agents/sdd-design.md
+++ b/internal/assets/kiro/agents/sdd-design.md
@@ -37,7 +37,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd/{change-name}/design"`
 - type: `"architecture"`
 - project: `{project-name from context}`
-- capture_prompt: `false`
+- capture_prompt: `false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 ## Result Contract
 

--- a/internal/assets/kiro/agents/sdd-design.md
+++ b/internal/assets/kiro/agents/sdd-design.md
@@ -37,6 +37,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd/{change-name}/design"`
 - type: `"architecture"`
 - project: `{project-name from context}`
+- capture_prompt: `false`
 
 ## Result Contract
 

--- a/internal/assets/kiro/agents/sdd-explore.md
+++ b/internal/assets/kiro/agents/sdd-explore.md
@@ -38,6 +38,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd/{change-name}/explore"`
 - type: `"architecture"`
 - project: `{project-name from context}`
+- capture_prompt: `false`
 
 ## Result Contract
 

--- a/internal/assets/kiro/agents/sdd-explore.md
+++ b/internal/assets/kiro/agents/sdd-explore.md
@@ -38,7 +38,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd/{change-name}/explore"`
 - type: `"architecture"`
 - project: `{project-name from context}`
-- capture_prompt: `false`
+- capture_prompt: `false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 ## Result Contract
 

--- a/internal/assets/kiro/agents/sdd-init.md
+++ b/internal/assets/kiro/agents/sdd-init.md
@@ -35,7 +35,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd-init/{project}"`
 - type: `"architecture"`
 - project: `{project-name from context}`
-- capture_prompt: `false`
+- capture_prompt: `false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 ## Result Contract
 

--- a/internal/assets/kiro/agents/sdd-init.md
+++ b/internal/assets/kiro/agents/sdd-init.md
@@ -35,6 +35,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd-init/{project}"`
 - type: `"architecture"`
 - project: `{project-name from context}`
+- capture_prompt: `false`
 
 ## Result Contract
 

--- a/internal/assets/kiro/agents/sdd-onboard.md
+++ b/internal/assets/kiro/agents/sdd-onboard.md
@@ -35,7 +35,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd-onboard/{project}"`
 - type: `"architecture"`
 - project: `{project-name from context}`
-- capture_prompt: `false`
+- capture_prompt: `false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 ## Result Contract
 

--- a/internal/assets/kiro/agents/sdd-onboard.md
+++ b/internal/assets/kiro/agents/sdd-onboard.md
@@ -35,6 +35,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd-onboard/{project}"`
 - type: `"architecture"`
 - project: `{project-name from context}`
+- capture_prompt: `false`
 
 ## Result Contract
 

--- a/internal/assets/kiro/agents/sdd-propose.md
+++ b/internal/assets/kiro/agents/sdd-propose.md
@@ -34,6 +34,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd/{change-name}/proposal"`
 - type: `"architecture"`
 - project: `{project-name from context}`
+- capture_prompt: `false`
 
 ## Result Contract
 

--- a/internal/assets/kiro/agents/sdd-propose.md
+++ b/internal/assets/kiro/agents/sdd-propose.md
@@ -34,7 +34,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd/{change-name}/proposal"`
 - type: `"architecture"`
 - project: `{project-name from context}`
-- capture_prompt: `false`
+- capture_prompt: `false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 ## Result Contract
 

--- a/internal/assets/kiro/agents/sdd-spec.md
+++ b/internal/assets/kiro/agents/sdd-spec.md
@@ -35,7 +35,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd/{change-name}/spec"`
 - type: `"architecture"`
 - project: `{project-name from context}`
-- capture_prompt: `false`
+- capture_prompt: `false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 ## Result Contract
 

--- a/internal/assets/kiro/agents/sdd-spec.md
+++ b/internal/assets/kiro/agents/sdd-spec.md
@@ -35,6 +35,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd/{change-name}/spec"`
 - type: `"architecture"`
 - project: `{project-name from context}`
+- capture_prompt: `false`
 
 ## Result Contract
 

--- a/internal/assets/kiro/agents/sdd-tasks.md
+++ b/internal/assets/kiro/agents/sdd-tasks.md
@@ -37,6 +37,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd/{change-name}/tasks"`
 - type: `"architecture"`
 - project: `{project-name from context}`
+- capture_prompt: `false`
 
 ## Result Contract
 

--- a/internal/assets/kiro/agents/sdd-tasks.md
+++ b/internal/assets/kiro/agents/sdd-tasks.md
@@ -37,7 +37,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd/{change-name}/tasks"`
 - type: `"architecture"`
 - project: `{project-name from context}`
-- capture_prompt: `false`
+- capture_prompt: `false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 ## Result Contract
 

--- a/internal/assets/kiro/agents/sdd-verify.md
+++ b/internal/assets/kiro/agents/sdd-verify.md
@@ -42,7 +42,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd/{change-name}/verify-report"`
 - type: `"architecture"`
 - project: `{project-name from context}`
-- capture_prompt: `false`
+- capture_prompt: `false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 ## Result Contract
 

--- a/internal/assets/kiro/agents/sdd-verify.md
+++ b/internal/assets/kiro/agents/sdd-verify.md
@@ -42,6 +42,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd/{change-name}/verify-report"`
 - type: `"architecture"`
 - project: `{project-name from context}`
+- capture_prompt: `false`
 
 ## Result Contract
 

--- a/internal/assets/opencode/commands/sdd-apply.md
+++ b/internal/assets/opencode/commands/sdd-apply.md
@@ -34,6 +34,7 @@ Update tasks as you complete them:
   mem_update(id: {tasks-observation-id}, content: "{updated tasks with [x] marks}")
 Save progress:
   mem_save(title: "sdd/{change-name}/apply-progress", topic_key: "sdd/{change-name}/apply-progress", type: "architecture", project: "{project}", capture_prompt: false, content: "{progress report}")
+  Set capture_prompt: false when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 For each task:
 1. Read the relevant spec scenarios (acceptance criteria)

--- a/internal/assets/opencode/commands/sdd-apply.md
+++ b/internal/assets/opencode/commands/sdd-apply.md
@@ -33,7 +33,7 @@ STEP B — RETRIEVE FULL CONTENT (mandatory):
 Update tasks as you complete them:
   mem_update(id: {tasks-observation-id}, content: "{updated tasks with [x] marks}")
 Save progress:
-  mem_save(title: "sdd/{change-name}/apply-progress", topic_key: "sdd/{change-name}/apply-progress", type: "architecture", project: "{project}", content: "{progress report}")
+  mem_save(title: "sdd/{change-name}/apply-progress", topic_key: "sdd/{change-name}/apply-progress", type: "architecture", project: "{project}", capture_prompt: false, content: "{progress report}")
 
 For each task:
 1. Read the relevant spec scenarios (acceptance criteria)

--- a/internal/assets/opencode/commands/sdd-archive.md
+++ b/internal/assets/opencode/commands/sdd-archive.md
@@ -30,7 +30,7 @@ STEP B — RETRIEVE FULL CONTENT (mandatory):
   mem_get_observation(id: verify_id) → full verification report
 Record all observation IDs in the archive report for traceability.
 Save:
-  mem_save(title: "sdd/{change-name}/archive-report", topic_key: "sdd/{change-name}/archive-report", type: "architecture", project: "{project}", content: "{archive report with observation IDs}")
+  mem_save(title: "sdd/{change-name}/archive-report", topic_key: "sdd/{change-name}/archive-report", type: "architecture", project: "{project}", capture_prompt: false, content: "{archive report with observation IDs}")
 
 Then:
 1. Sync delta specs into main specs (source of truth)

--- a/internal/assets/opencode/commands/sdd-archive.md
+++ b/internal/assets/opencode/commands/sdd-archive.md
@@ -31,6 +31,7 @@ STEP B — RETRIEVE FULL CONTENT (mandatory):
 Record all observation IDs in the archive report for traceability.
 Save:
   mem_save(title: "sdd/{change-name}/archive-report", topic_key: "sdd/{change-name}/archive-report", type: "architecture", project: "{project}", capture_prompt: false, content: "{archive report with observation IDs}")
+  Set capture_prompt: false when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 Then:
 1. Sync delta specs into main specs (source of truth)

--- a/internal/assets/opencode/commands/sdd-explore.md
+++ b/internal/assets/opencode/commands/sdd-explore.md
@@ -19,7 +19,7 @@ ENGRAM PERSISTENCE (artifact store mode: engram):
 Read project context (optional):
   mem_search(query: "sdd-init/{project}", project: "{project}") → if found, mem_get_observation(id) for full content
 Save exploration:
-  mem_save(title: "sdd/$ARGUMENTS/explore", topic_key: "sdd/$ARGUMENTS/explore", type: "architecture", project: "{project}", content: "{exploration}")
+  mem_save(title: "sdd/$ARGUMENTS/explore", topic_key: "sdd/$ARGUMENTS/explore", type: "architecture", project: "{project}", capture_prompt: false, content: "{exploration}")
 
 This is an exploration only — do NOT create any files or modify code. Just research and return your analysis.
 

--- a/internal/assets/opencode/commands/sdd-explore.md
+++ b/internal/assets/opencode/commands/sdd-explore.md
@@ -20,6 +20,7 @@ Read project context (optional):
   mem_search(query: "sdd-init/{project}", project: "{project}") → if found, mem_get_observation(id) for full content
 Save exploration:
   mem_save(title: "sdd/$ARGUMENTS/explore", topic_key: "sdd/$ARGUMENTS/explore", type: "architecture", project: "{project}", capture_prompt: false, content: "{exploration}")
+  Set capture_prompt: false when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 This is an exploration only — do NOT create any files or modify code. Just research and return your analysis.
 

--- a/internal/assets/opencode/commands/sdd-init.md
+++ b/internal/assets/opencode/commands/sdd-init.md
@@ -17,6 +17,7 @@ Initialize Spec-Driven Development in this project. Detect the tech stack, exist
 ENGRAM PERSISTENCE (artifact store mode: engram):
 After detecting the project context, save it:
   mem_save(title: "sdd-init/{project}", topic_key: "sdd-init/{project}", type: "architecture", project: "{project}", capture_prompt: false, content: "{detected context}")
+  Set capture_prompt: false when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 topic_key enables upserts — re-running init updates, not duplicates.
 
 Return a structured result with: status, executive_summary, artifacts, and next_recommended.

--- a/internal/assets/opencode/commands/sdd-init.md
+++ b/internal/assets/opencode/commands/sdd-init.md
@@ -16,7 +16,7 @@ Initialize Spec-Driven Development in this project. Detect the tech stack, exist
 
 ENGRAM PERSISTENCE (artifact store mode: engram):
 After detecting the project context, save it:
-  mem_save(title: "sdd-init/{project}", topic_key: "sdd-init/{project}", type: "architecture", project: "{project}", content: "{detected context}")
+  mem_save(title: "sdd-init/{project}", topic_key: "sdd-init/{project}", type: "architecture", project: "{project}", capture_prompt: false, content: "{detected context}")
 topic_key enables upserts — re-running init updates, not duplicates.
 
 Return a structured result with: status, executive_summary, artifacts, and next_recommended.

--- a/internal/assets/opencode/commands/sdd-onboard.md
+++ b/internal/assets/opencode/commands/sdd-onboard.md
@@ -16,7 +16,7 @@ Guide the user through a complete SDD cycle using their actual codebase. This is
 
 ENGRAM PERSISTENCE (artifact store mode: engram):
 Save onboarding progress as you go:
-  mem_save(title: "sdd-onboard/{project}", topic_key: "sdd-onboard/{project}", type: "architecture", project: "{project}", content: "{onboarding state}")
+  mem_save(title: "sdd-onboard/{project}", topic_key: "sdd-onboard/{project}", type: "architecture", project: "{project}", capture_prompt: false, content: "{onboarding state}")
 topic_key enables upserts — re-running updates, not duplicates.
 
 Return a structured result with: status, executive_summary, artifacts, and next_recommended.

--- a/internal/assets/opencode/commands/sdd-onboard.md
+++ b/internal/assets/opencode/commands/sdd-onboard.md
@@ -17,6 +17,7 @@ Guide the user through a complete SDD cycle using their actual codebase. This is
 ENGRAM PERSISTENCE (artifact store mode: engram):
 Save onboarding progress as you go:
   mem_save(title: "sdd-onboard/{project}", topic_key: "sdd-onboard/{project}", type: "architecture", project: "{project}", capture_prompt: false, content: "{onboarding state}")
+  Set capture_prompt: false when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 topic_key enables upserts — re-running updates, not duplicates.
 
 Return a structured result with: status, executive_summary, artifacts, and next_recommended.

--- a/internal/assets/opencode/commands/sdd-verify.md
+++ b/internal/assets/opencode/commands/sdd-verify.md
@@ -26,6 +26,7 @@ STEP B — RETRIEVE FULL CONTENT (mandatory):
   mem_get_observation(id: tasks_id) → full tasks
 Save report:
   mem_save(title: "sdd/{change-name}/verify-report", topic_key: "sdd/{change-name}/verify-report", type: "architecture", project: "{project}", capture_prompt: false, content: "{verification report}")
+  Set capture_prompt: false when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 Then:
 1. Check completeness — are all tasks done?

--- a/internal/assets/opencode/commands/sdd-verify.md
+++ b/internal/assets/opencode/commands/sdd-verify.md
@@ -25,7 +25,7 @@ STEP B — RETRIEVE FULL CONTENT (mandatory):
   mem_get_observation(id: design_id) → full design
   mem_get_observation(id: tasks_id) → full tasks
 Save report:
-  mem_save(title: "sdd/{change-name}/verify-report", topic_key: "sdd/{change-name}/verify-report", type: "architecture", project: "{project}", content: "{verification report}")
+  mem_save(title: "sdd/{change-name}/verify-report", topic_key: "sdd/{change-name}/verify-report", type: "architecture", project: "{project}", capture_prompt: false, content: "{verification report}")
 
 Then:
 1. Check completeness — are all tasks done?

--- a/internal/assets/skills/_shared/engram-convention.md
+++ b/internal/assets/skills/_shared/engram-convention.md
@@ -15,6 +15,8 @@ scope:     project
 capture_prompt: false
 ```
 
+Set `capture_prompt: false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
+
 ### Artifact Types
 
 | Artifact Type | Produced By | Description |
@@ -99,7 +101,7 @@ mem_save(
 )
 ```
 
-`capture_prompt: false` is REQUIRED for SDD artifacts. Engram v1.15.3 captures user prompts by default for human/proactive saves, but SDD artifacts are automated pipeline outputs. Do not infer this from `type` because both SDD artifacts and human architecture decisions use `architecture`.
+`capture_prompt: false` is REQUIRED for SDD artifacts when the Engram tool schema supports it. Engram v1.15.3 captures user prompts by default for human/proactive saves, but SDD artifacts are automated pipeline outputs. Do not infer this from `type` because both SDD artifacts and human architecture decisions use `architecture`. If an older schema rejects or does not expose `capture_prompt`, omit it rather than failing.
 
 Update existing artifact (when you have the observation ID):
 ```

--- a/internal/assets/skills/_shared/engram-convention.md
+++ b/internal/assets/skills/_shared/engram-convention.md
@@ -12,6 +12,7 @@ topic_key: sdd/{change-name}/{artifact-type}
 type:      architecture
 project:   {detected or current project name}
 scope:     project
+capture_prompt: false
 ```
 
 ### Artifact Types
@@ -38,6 +39,7 @@ mem_save(
   topic_key: "sdd/{change-name}/state",
   type: "architecture",
   project: "{project}",
+  capture_prompt: false,
   content: "change: {change-name}\nphase: {last-phase}\nartifact_store: engram\nartifacts:\n  proposal: true\n  specs: true\n  design: false\n  tasks: false\ntasks_progress:\n  completed: []\n  pending: []\nlast_updated: {ISO date}"
 )
 ```
@@ -80,6 +82,7 @@ mem_save(
   topic_key: "sdd/{change-name}/{artifact-type}",
   type: "architecture",
   project: "{project}",
+  capture_prompt: false,
   content: "{full markdown content}"
 )
 ```
@@ -91,9 +94,12 @@ mem_save(
   topic_key: "sdd/add-dark-mode/proposal",
   type: "architecture",
   project: "my-app",
+  capture_prompt: false,
   content: "## Proposal\n\nAdd dark mode toggle..."
 )
 ```
+
+`capture_prompt: false` is REQUIRED for SDD artifacts. Engram v1.15.3 captures user prompts by default for human/proactive saves, but SDD artifacts are automated pipeline outputs. Do not infer this from `type` because both SDD artifacts and human architecture decisions use `architecture`.
 
 Update existing artifact (when you have the observation ID):
 ```

--- a/internal/assets/skills/_shared/persistence-contract.md
+++ b/internal/assets/skills/_shared/persistence-contract.md
@@ -110,6 +110,7 @@ After completing your work, you MUST call:
     topic_key: "sdd/{change-name}/{artifact-type}",
     type: "architecture",
     project: "{project}",
+    capture_prompt: false,
     content: "{your full artifact markdown}"
   )
 If you return without calling mem_save, the next phase CANNOT find your artifact and the pipeline BREAKS.
@@ -126,10 +127,13 @@ After completing your work, you MUST call:
     topic_key: "sdd/{change-name}/{artifact-type}",
     type: "architecture",
     project: "{project}",
+    capture_prompt: false,
     content: "{your full artifact markdown}"
   )
 If you return without calling mem_save, the next phase CANNOT find your artifact and the pipeline BREAKS.
 ```
+
+For SDD artifacts, `capture_prompt: false` is explicit and mandatory. Engram v1.15.3 defaults `capture_prompt` to true for normal human/proactive saves, but automated pipeline artifacts must not capture the user's prompt. Do not infer this from `type` because SDD artifacts and real human architecture decisions both use `architecture`.
 
 ## Skill Registry
 

--- a/internal/assets/skills/_shared/persistence-contract.md
+++ b/internal/assets/skills/_shared/persistence-contract.md
@@ -57,10 +57,12 @@ The orchestrator persists DAG state after each phase transition to enable SDD re
 
 | Mode | Persist State | Recover State |
 |------|--------------|---------------|
-| `engram` | `mem_save(topic_key: "sdd/{change-name}/state")` | `mem_search("sdd/*/state")` → `mem_get_observation(id)` |
+| `engram` | `mem_save(topic_key: "sdd/{change-name}/state", capture_prompt: false*)` | `mem_search("sdd/*/state")` → `mem_get_observation(id)` |
 | `openspec` | Write `openspec/changes/{change-name}/state.yaml` | Read `openspec/changes/{change-name}/state.yaml` |
 | `hybrid` | Both: `mem_save` AND write `state.yaml` | Engram first; filesystem fallback |
 | `none` | Not possible — warn user | Not possible |
+
+*For state automated artifacts, set `capture_prompt: false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 ## Common Rules
 
@@ -133,7 +135,7 @@ After completing your work, you MUST call:
 If you return without calling mem_save, the next phase CANNOT find your artifact and the pipeline BREAKS.
 ```
 
-For SDD artifacts, `capture_prompt: false` is explicit and mandatory. Engram v1.15.3 defaults `capture_prompt` to true for normal human/proactive saves, but automated pipeline artifacts must not capture the user's prompt. Do not infer this from `type` because SDD artifacts and real human architecture decisions both use `architecture`.
+For SDD artifacts, `capture_prompt: false` is explicit and mandatory when the Engram tool schema supports it. Engram v1.15.3 defaults `capture_prompt` to true for normal human/proactive saves, but automated pipeline artifacts must not capture the user's prompt. Do not infer this from `type` because SDD artifacts and real human architecture decisions both use `architecture`. If an older schema rejects or does not expose `capture_prompt`, omit it rather than failing.
 
 ## Skill Registry
 

--- a/internal/assets/skills/_shared/sdd-phase-common.md
+++ b/internal/assets/skills/_shared/sdd-phase-common.md
@@ -46,11 +46,13 @@ mem_save(
   topic_key: "sdd/{change-name}/{artifact-type}",
   type: "architecture",
   project: "{project}",
+  capture_prompt: false,
   content: "{your full artifact markdown}"
 )
 ```
 
 `topic_key` enables upserts — saving again updates, not duplicates.
+`capture_prompt: false` is mandatory for SDD artifacts because they are automated pipeline outputs, not human/proactive memory saves.
 
 ### OpenSpec mode
 

--- a/internal/assets/skills/_shared/sdd-phase-common.md
+++ b/internal/assets/skills/_shared/sdd-phase-common.md
@@ -52,7 +52,7 @@ mem_save(
 ```
 
 `topic_key` enables upserts — saving again updates, not duplicates.
-`capture_prompt: false` is mandatory for SDD artifacts because they are automated pipeline outputs, not human/proactive memory saves.
+`capture_prompt: false` is mandatory for SDD artifacts because they are automated pipeline outputs, not human/proactive memory saves. Set it when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 ### OpenSpec mode
 

--- a/internal/assets/skills/sdd-init/SKILL.md
+++ b/internal/assets/skills/sdd-init/SKILL.md
@@ -27,6 +27,7 @@ You are an EXECUTOR for this phase, not the orchestrator. Do the initialization 
     topic_key: "sdd-init/{project-name}",
     type: "architecture",
     project: "{project-name}",
+    capture_prompt: false,
     content: "{detected project context markdown}"
   )
   ```
@@ -182,6 +183,7 @@ mem_save(
   topic_key: "sdd/{project-name}/testing-capabilities",
   type: "config",
   project: "{project-name}",
+  capture_prompt: false,
   content: "{testing capabilities markdown — see format below}"
 )
 ```
@@ -226,7 +228,7 @@ Follow the same logic as the `skill-registry` skill (`skills/skill-registry/SKIL
 1. Scan user skills: glob `*/SKILL.md` across ALL known skill directories. **User-level**: `~/.claude/skills/`, `~/.config/opencode/skills/`, `~/.gemini/skills/`, `~/.cursor/skills/`, `~/.copilot/skills/`, parent of this skill file. **Project-level**: `.claude/skills/`, `.gemini/skills/`, `.agent/skills/`, `skills/`. Skip `sdd-*`, `_shared`, `skill-registry`. Deduplicate by name (project-level wins). Read frontmatter triggers.
 2. Scan project conventions: check for `agents.md`, `AGENTS.md`, `CLAUDE.md` (project-level), `.cursorrules`, `GEMINI.md`, `copilot-instructions.md` in the project root. If an index file is found (e.g., `agents.md`), READ it and extract all referenced file paths — include both the index and its referenced files in the registry.
 3. **ALWAYS write `.atl/skill-registry.md`** in the project root (create `.atl/` if needed). This file is mode-independent — it's infrastructure, not an SDD artifact.
-4. If engram is available, **ALSO save to engram**: `mem_save(title: "skill-registry", topic_key: "skill-registry", type: "config", project: "{project}", content: "{registry markdown}")`
+4. If engram is available, **ALSO save to engram**: `mem_save(title: "skill-registry", topic_key: "skill-registry", type: "config", project: "{project}", capture_prompt: false, content: "{registry markdown}")`
 
 See `skills/skill-registry/SKILL.md` for the full registry format and scanning details.
 
@@ -241,6 +243,7 @@ mem_save(
   topic_key: "sdd-init/{project-name}",
   type: "architecture",
   project: "{project-name}",
+  capture_prompt: false,
   content: "{your detected project context from Steps 1-7}"
 )
 ```

--- a/internal/assets/skills/sdd-init/SKILL.md
+++ b/internal/assets/skills/sdd-init/SKILL.md
@@ -32,6 +32,7 @@ You are an EXECUTOR for this phase, not the orchestrator. Do the initialization 
   )
   ```
   `topic_key` enables upserts — re-running init updates the existing context, not duplicates.
+  Set `capture_prompt: false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
   (See `skills/_shared/engram-convention.md` for full naming conventions.)
 - If mode is `openspec`: Read and follow `skills/_shared/openspec-convention.md`. Run full bootstrap.
@@ -187,6 +188,7 @@ mem_save(
   content: "{testing capabilities markdown — see format below}"
 )
 ```
+Set `capture_prompt: false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 **Testing Capabilities format**:
 
@@ -228,7 +230,7 @@ Follow the same logic as the `skill-registry` skill (`skills/skill-registry/SKIL
 1. Scan user skills: glob `*/SKILL.md` across ALL known skill directories. **User-level**: `~/.claude/skills/`, `~/.config/opencode/skills/`, `~/.gemini/skills/`, `~/.cursor/skills/`, `~/.copilot/skills/`, parent of this skill file. **Project-level**: `.claude/skills/`, `.gemini/skills/`, `.agent/skills/`, `skills/`. Skip `sdd-*`, `_shared`, `skill-registry`. Deduplicate by name (project-level wins). Read frontmatter triggers.
 2. Scan project conventions: check for `agents.md`, `AGENTS.md`, `CLAUDE.md` (project-level), `.cursorrules`, `GEMINI.md`, `copilot-instructions.md` in the project root. If an index file is found (e.g., `agents.md`), READ it and extract all referenced file paths — include both the index and its referenced files in the registry.
 3. **ALWAYS write `.atl/skill-registry.md`** in the project root (create `.atl/` if needed). This file is mode-independent — it's infrastructure, not an SDD artifact.
-4. If engram is available, **ALSO save to engram**: `mem_save(title: "skill-registry", topic_key: "skill-registry", type: "config", project: "{project}", capture_prompt: false, content: "{registry markdown}")`
+4. If engram is available, **ALSO save to engram**: `mem_save(title: "skill-registry", topic_key: "skill-registry", type: "config", project: "{project}", capture_prompt: false, content: "{registry markdown}")`. Set `capture_prompt: false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 See `skills/skill-registry/SKILL.md` for the full registry format and scanning details.
 
@@ -247,6 +249,7 @@ mem_save(
   content: "{your detected project context from Steps 1-7}"
 )
 ```
+Set `capture_prompt: false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 If mode is `openspec` or `hybrid`: the config was already written in Step 5.
 

--- a/internal/assets/skills/skill-registry/SKILL.md
+++ b/internal/assets/skills/skill-registry/SKILL.md
@@ -158,9 +158,12 @@ mem_save(
   topic_key: "skill-registry",
   type: "config",
   project: "{project}",
+  capture_prompt: false,
   content: "{registry markdown from Step 3}"
 )
 ```
+
+`capture_prompt: false` is required because the skill registry is an automated artifact, not a human/proactive memory save.
 
 `topic_key` ensures upserts — running again updates the same observation.
 

--- a/internal/assets/skills/skill-registry/SKILL.md
+++ b/internal/assets/skills/skill-registry/SKILL.md
@@ -163,7 +163,7 @@ mem_save(
 )
 ```
 
-`capture_prompt: false` is required because the skill registry is an automated artifact, not a human/proactive memory save.
+`capture_prompt: false` is required because the skill registry is an automated artifact, not a human/proactive memory save. Set it when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 `topic_key` ensures upserts — running again updates the same observation.
 

--- a/testdata/golden/combined-claude-claudemd.golden
+++ b/testdata/golden/combined-claude-claudemd.golden
@@ -348,11 +348,20 @@ Format for `mem_save`:
 - **type**: bugfix | decision | architecture | discovery | pattern | config | preference
 - **scope**: `project` (default) | `personal`
 - **topic_key** (recommended for evolving topics): stable key like `architecture/auth-model`
+- **capture_prompt**: optional; default `true`. Do not set this for normal human/proactive saves. Set `false` only for automated artifacts such as SDD proposal/spec/design/tasks/apply/verify/archive/init reports, testing-capabilities caches, onboarding/state artifacts, or skill-registry output.
 - **content**:
   - **What**: One sentence — what was done
   - **Why**: What motivated it (user request, bug, performance, etc.)
   - **Where**: Files or paths affected
   - **Learned**: Gotchas, edge cases, things that surprised you (omit if none)
+
+Prompt capture behavior (Engram v1.15.3+):
+- `mem_save` captures the user prompt best-effort when the MCP process already has prompt context for the same `project + session_id`.
+- `mem_save` never invents prompt text. If no prompt context exists, the save still succeeds without prompt capture.
+- `mem_save_prompt` records the prompt and feeds SessionActivity so later `mem_save` calls can capture and dedupe it.
+- If an agent/plugin hook can observe the user's prompt before derived memory saves happen, it should call `mem_save_prompt` first.
+- Do not decide prompt capture by `type`; SDD artifacts also use `architecture`, and human decisions can too. Use explicit `capture_prompt: false` for automated artifacts.
+- If an older Engram tool schema does not expose `capture_prompt`, omit the field rather than failing.
 
 Topic update rules:
 - Different topics MUST NOT overwrite each other

--- a/testdata/golden/combined-windsurf-global-rules.golden
+++ b/testdata/golden/combined-windsurf-global-rules.golden
@@ -419,11 +419,20 @@ Format for `mem_save`:
 - **type**: bugfix | decision | architecture | discovery | pattern | config | preference
 - **scope**: `project` (default) | `personal`
 - **topic_key** (recommended for evolving topics): stable key like `architecture/auth-model`
+- **capture_prompt**: optional; default `true`. Do not set this for normal human/proactive saves. Set `false` only for automated artifacts such as SDD proposal/spec/design/tasks/apply/verify/archive/init reports, testing-capabilities caches, onboarding/state artifacts, or skill-registry output.
 - **content**:
   - **What**: One sentence — what was done
   - **Why**: What motivated it (user request, bug, performance, etc.)
   - **Where**: Files or paths affected
   - **Learned**: Gotchas, edge cases, things that surprised you (omit if none)
+
+Prompt capture behavior (Engram v1.15.3+):
+- `mem_save` captures the user prompt best-effort when the MCP process already has prompt context for the same `project + session_id`.
+- `mem_save` never invents prompt text. If no prompt context exists, the save still succeeds without prompt capture.
+- `mem_save_prompt` records the prompt and feeds SessionActivity so later `mem_save` calls can capture and dedupe it.
+- If an agent/plugin hook can observe the user's prompt before derived memory saves happen, it should call `mem_save_prompt` first.
+- Do not decide prompt capture by `type`; SDD artifacts also use `architecture`, and human decisions can too. Use explicit `capture_prompt: false` for automated artifacts.
+- If an older Engram tool schema does not expose `capture_prompt`, omit the field rather than failing.
 
 Topic update rules:
 - Different topics MUST NOT overwrite each other

--- a/testdata/golden/engram-antigravity-rulesmd.golden
+++ b/testdata/golden/engram-antigravity-rulesmd.golden
@@ -27,11 +27,20 @@ Format for `mem_save`:
 - **type**: bugfix | decision | architecture | discovery | pattern | config | preference
 - **scope**: `project` (default) | `personal`
 - **topic_key** (recommended for evolving topics): stable key like `architecture/auth-model`
+- **capture_prompt**: optional; default `true`. Do not set this for normal human/proactive saves. Set `false` only for automated artifacts such as SDD proposal/spec/design/tasks/apply/verify/archive/init reports, testing-capabilities caches, onboarding/state artifacts, or skill-registry output.
 - **content**:
   - **What**: One sentence — what was done
   - **Why**: What motivated it (user request, bug, performance, etc.)
   - **Where**: Files or paths affected
   - **Learned**: Gotchas, edge cases, things that surprised you (omit if none)
+
+Prompt capture behavior (Engram v1.15.3+):
+- `mem_save` captures the user prompt best-effort when the MCP process already has prompt context for the same `project + session_id`.
+- `mem_save` never invents prompt text. If no prompt context exists, the save still succeeds without prompt capture.
+- `mem_save_prompt` records the prompt and feeds SessionActivity so later `mem_save` calls can capture and dedupe it.
+- If an agent/plugin hook can observe the user's prompt before derived memory saves happen, it should call `mem_save_prompt` first.
+- Do not decide prompt capture by `type`; SDD artifacts also use `architecture`, and human decisions can too. Use explicit `capture_prompt: false` for automated artifacts.
+- If an older Engram tool schema does not expose `capture_prompt`, omit the field rather than failing.
 
 Topic update rules:
 - Different topics MUST NOT overwrite each other

--- a/testdata/golden/engram-claude-claudemd.golden
+++ b/testdata/golden/engram-claude-claudemd.golden
@@ -27,11 +27,20 @@ Format for `mem_save`:
 - **type**: bugfix | decision | architecture | discovery | pattern | config | preference
 - **scope**: `project` (default) | `personal`
 - **topic_key** (recommended for evolving topics): stable key like `architecture/auth-model`
+- **capture_prompt**: optional; default `true`. Do not set this for normal human/proactive saves. Set `false` only for automated artifacts such as SDD proposal/spec/design/tasks/apply/verify/archive/init reports, testing-capabilities caches, onboarding/state artifacts, or skill-registry output.
 - **content**:
   - **What**: One sentence — what was done
   - **Why**: What motivated it (user request, bug, performance, etc.)
   - **Where**: Files or paths affected
   - **Learned**: Gotchas, edge cases, things that surprised you (omit if none)
+
+Prompt capture behavior (Engram v1.15.3+):
+- `mem_save` captures the user prompt best-effort when the MCP process already has prompt context for the same `project + session_id`.
+- `mem_save` never invents prompt text. If no prompt context exists, the save still succeeds without prompt capture.
+- `mem_save_prompt` records the prompt and feeds SessionActivity so later `mem_save` calls can capture and dedupe it.
+- If an agent/plugin hook can observe the user's prompt before derived memory saves happen, it should call `mem_save_prompt` first.
+- Do not decide prompt capture by `type`; SDD artifacts also use `architecture`, and human decisions can too. Use explicit `capture_prompt: false` for automated artifacts.
+- If an older Engram tool schema does not expose `capture_prompt`, omit the field rather than failing.
 
 Topic update rules:
 - Different topics MUST NOT overwrite each other

--- a/testdata/golden/sdd-antigravity-skill-sdd-init.golden
+++ b/testdata/golden/sdd-antigravity-skill-sdd-init.golden
@@ -27,10 +27,12 @@ You are an EXECUTOR for this phase, not the orchestrator. Do the initialization 
     topic_key: "sdd-init/{project-name}",
     type: "architecture",
     project: "{project-name}",
+    capture_prompt: false,
     content: "{detected project context markdown}"
   )
   ```
   `topic_key` enables upserts — re-running init updates the existing context, not duplicates.
+  Set `capture_prompt: false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
   (See `skills/_shared/engram-convention.md` for full naming conventions.)
 - If mode is `openspec`: Read and follow `skills/_shared/openspec-convention.md`. Run full bootstrap.
@@ -182,9 +184,11 @@ mem_save(
   topic_key: "sdd/{project-name}/testing-capabilities",
   type: "config",
   project: "{project-name}",
+  capture_prompt: false,
   content: "{testing capabilities markdown — see format below}"
 )
 ```
+Set `capture_prompt: false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 **Testing Capabilities format**:
 
@@ -226,7 +230,7 @@ Follow the same logic as the `skill-registry` skill (`skills/skill-registry/SKIL
 1. Scan user skills: glob `*/SKILL.md` across ALL known skill directories. **User-level**: `~/.claude/skills/`, `~/.config/opencode/skills/`, `~/.gemini/skills/`, `~/.cursor/skills/`, `~/.copilot/skills/`, parent of this skill file. **Project-level**: `.claude/skills/`, `.gemini/skills/`, `.agent/skills/`, `skills/`. Skip `sdd-*`, `_shared`, `skill-registry`. Deduplicate by name (project-level wins). Read frontmatter triggers.
 2. Scan project conventions: check for `agents.md`, `AGENTS.md`, `CLAUDE.md` (project-level), `.cursorrules`, `GEMINI.md`, `copilot-instructions.md` in the project root. If an index file is found (e.g., `agents.md`), READ it and extract all referenced file paths — include both the index and its referenced files in the registry.
 3. **ALWAYS write `.atl/skill-registry.md`** in the project root (create `.atl/` if needed). This file is mode-independent — it's infrastructure, not an SDD artifact.
-4. If engram is available, **ALSO save to engram**: `mem_save(title: "skill-registry", topic_key: "skill-registry", type: "config", project: "{project}", content: "{registry markdown}")`
+4. If engram is available, **ALSO save to engram**: `mem_save(title: "skill-registry", topic_key: "skill-registry", type: "config", project: "{project}", capture_prompt: false, content: "{registry markdown}")`. Set `capture_prompt: false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 See `skills/skill-registry/SKILL.md` for the full registry format and scanning details.
 
@@ -241,9 +245,11 @@ mem_save(
   topic_key: "sdd-init/{project-name}",
   type: "architecture",
   project: "{project-name}",
+  capture_prompt: false,
   content: "{your detected project context from Steps 1-7}"
 )
 ```
+Set `capture_prompt: false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 If mode is `openspec` or `hybrid`: the config was already written in Step 5.
 

--- a/testdata/golden/sdd-claude-agent-sdd-apply.golden
+++ b/testdata/golden/sdd-claude-agent-sdd-apply.golden
@@ -34,6 +34,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd/{change-name}/apply-progress"`
 - type: `"architecture"`
 - project: `{project-name from context}`
+- capture_prompt: `false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 Also update the tasks artifact with `[x]` marks via `mem_update` (engram) or file edit (openspec/hybrid).
 

--- a/testdata/golden/sdd-claude-agent-sdd-archive.golden
+++ b/testdata/golden/sdd-claude-agent-sdd-archive.golden
@@ -35,6 +35,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd/{change-name}/archive-report"`
 - type: `"architecture"`
 - project: `{project-name from context}`
+- capture_prompt: `false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 ## Result Contract
 

--- a/testdata/golden/sdd-claude-agent-sdd-design.golden
+++ b/testdata/golden/sdd-claude-agent-sdd-design.golden
@@ -32,6 +32,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd/{change-name}/design"`
 - type: `"architecture"`
 - project: `{project-name from context}`
+- capture_prompt: `false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 ## Result Contract
 

--- a/testdata/golden/sdd-claude-agent-sdd-explore.golden
+++ b/testdata/golden/sdd-claude-agent-sdd-explore.golden
@@ -32,6 +32,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd/{change-name}/explore"`
 - type: `"architecture"`
 - project: `{project-name from context}`
+- capture_prompt: `false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 ## Result Contract
 

--- a/testdata/golden/sdd-claude-agent-sdd-propose.golden
+++ b/testdata/golden/sdd-claude-agent-sdd-propose.golden
@@ -31,6 +31,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd/{change-name}/proposal"`
 - type: `"architecture"`
 - project: `{project-name from context}`
+- capture_prompt: `false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 ## Result Contract
 

--- a/testdata/golden/sdd-claude-agent-sdd-spec.golden
+++ b/testdata/golden/sdd-claude-agent-sdd-spec.golden
@@ -31,6 +31,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd/{change-name}/spec"`
 - type: `"architecture"`
 - project: `{project-name from context}`
+- capture_prompt: `false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 ## Result Contract
 

--- a/testdata/golden/sdd-claude-agent-sdd-tasks.golden
+++ b/testdata/golden/sdd-claude-agent-sdd-tasks.golden
@@ -32,6 +32,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd/{change-name}/tasks"`
 - type: `"architecture"`
 - project: `{project-name from context}`
+- capture_prompt: `false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 ## Result Contract
 

--- a/testdata/golden/sdd-claude-agent-sdd-verify.golden
+++ b/testdata/golden/sdd-claude-agent-sdd-verify.golden
@@ -31,6 +31,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd/{change-name}/verify-report"`
 - type: `"architecture"`
 - project: `{project-name from context}`
+- capture_prompt: `false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 ## Result Contract
 

--- a/testdata/golden/sdd-claude-cmd-sdd-apply.golden
+++ b/testdata/golden/sdd-claude-cmd-sdd-apply.golden
@@ -32,7 +32,8 @@ STEP B — RETRIEVE FULL CONTENT (mandatory):
 Update tasks as you complete them:
   mem_update(id: {tasks-observation-id}, content: "{updated tasks with [x] marks}")
 Save progress:
-  mem_save(title: "sdd/{change-name}/apply-progress", topic_key: "sdd/{change-name}/apply-progress", type: "architecture", project: "{project}", content: "{progress report}")
+  mem_save(title: "sdd/{change-name}/apply-progress", topic_key: "sdd/{change-name}/apply-progress", type: "architecture", project: "{project}", capture_prompt: false, content: "{progress report}")
+  Set capture_prompt: false when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 For each task:
 1. Read the relevant spec scenarios (acceptance criteria)

--- a/testdata/golden/sdd-claude-cmd-sdd-archive.golden
+++ b/testdata/golden/sdd-claude-cmd-sdd-archive.golden
@@ -29,7 +29,8 @@ STEP B — RETRIEVE FULL CONTENT (mandatory):
   mem_get_observation(id: verify_id) → full verification report
 Record all observation IDs in the archive report for traceability.
 Save:
-  mem_save(title: "sdd/{change-name}/archive-report", topic_key: "sdd/{change-name}/archive-report", type: "architecture", project: "{project}", content: "{archive report with observation IDs}")
+  mem_save(title: "sdd/{change-name}/archive-report", topic_key: "sdd/{change-name}/archive-report", type: "architecture", project: "{project}", capture_prompt: false, content: "{archive report with observation IDs}")
+  Set capture_prompt: false when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 Then:
 1. Sync delta specs into main specs (source of truth)

--- a/testdata/golden/sdd-claude-cmd-sdd-explore.golden
+++ b/testdata/golden/sdd-claude-cmd-sdd-explore.golden
@@ -18,7 +18,8 @@ ENGRAM PERSISTENCE (artifact store mode: engram):
 Read project context (optional):
   mem_search(query: "sdd-init/{project}", project: "{project}") → if found, mem_get_observation(id) for full content
 Save exploration:
-  mem_save(title: "sdd/$ARGUMENTS/explore", topic_key: "sdd/$ARGUMENTS/explore", type: "architecture", project: "{project}", content: "{exploration}")
+  mem_save(title: "sdd/$ARGUMENTS/explore", topic_key: "sdd/$ARGUMENTS/explore", type: "architecture", project: "{project}", capture_prompt: false, content: "{exploration}")
+  Set capture_prompt: false when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 This is an exploration only — do NOT create any files or modify code. Just research and return your analysis.
 

--- a/testdata/golden/sdd-claude-cmd-sdd-init.golden
+++ b/testdata/golden/sdd-claude-cmd-sdd-init.golden
@@ -15,7 +15,8 @@ Initialize Spec-Driven Development in this project. Detect the tech stack, exist
 
 ENGRAM PERSISTENCE (artifact store mode: engram):
 After detecting the project context, save it:
-  mem_save(title: "sdd-init/{project}", topic_key: "sdd-init/{project}", type: "architecture", project: "{project}", content: "{detected context}")
+  mem_save(title: "sdd-init/{project}", topic_key: "sdd-init/{project}", type: "architecture", project: "{project}", capture_prompt: false, content: "{detected context}")
+  Set capture_prompt: false when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 topic_key enables upserts — re-running init updates, not duplicates.
 
 Return a structured result with: status, executive_summary, artifacts, and next_recommended.

--- a/testdata/golden/sdd-claude-cmd-sdd-onboard.golden
+++ b/testdata/golden/sdd-claude-cmd-sdd-onboard.golden
@@ -15,7 +15,8 @@ Guide the user through a complete SDD cycle using their actual codebase. This is
 
 ENGRAM PERSISTENCE (artifact store mode: engram):
 Save onboarding progress as you go:
-  mem_save(title: "sdd-onboard/{project}", topic_key: "sdd-onboard/{project}", type: "architecture", project: "{project}", content: "{onboarding state}")
+  mem_save(title: "sdd-onboard/{project}", topic_key: "sdd-onboard/{project}", type: "architecture", project: "{project}", capture_prompt: false, content: "{onboarding state}")
+  Set capture_prompt: false when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 topic_key enables upserts — re-running updates, not duplicates.
 
 Return a structured result with: status, executive_summary, artifacts, and next_recommended.

--- a/testdata/golden/sdd-claude-cmd-sdd-verify.golden
+++ b/testdata/golden/sdd-claude-cmd-sdd-verify.golden
@@ -24,7 +24,8 @@ STEP B — RETRIEVE FULL CONTENT (mandatory):
   mem_get_observation(id: design_id) → full design
   mem_get_observation(id: tasks_id) → full tasks
 Save report:
-  mem_save(title: "sdd/{change-name}/verify-report", topic_key: "sdd/{change-name}/verify-report", type: "architecture", project: "{project}", content: "{verification report}")
+  mem_save(title: "sdd/{change-name}/verify-report", topic_key: "sdd/{change-name}/verify-report", type: "architecture", project: "{project}", capture_prompt: false, content: "{verification report}")
+  Set capture_prompt: false when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 Then:
 1. Check completeness — are all tasks done?

--- a/testdata/golden/sdd-codex-skill-sdd-init.golden
+++ b/testdata/golden/sdd-codex-skill-sdd-init.golden
@@ -27,10 +27,12 @@ You are an EXECUTOR for this phase, not the orchestrator. Do the initialization 
     topic_key: "sdd-init/{project-name}",
     type: "architecture",
     project: "{project-name}",
+    capture_prompt: false,
     content: "{detected project context markdown}"
   )
   ```
   `topic_key` enables upserts — re-running init updates the existing context, not duplicates.
+  Set `capture_prompt: false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
   (See `skills/_shared/engram-convention.md` for full naming conventions.)
 - If mode is `openspec`: Read and follow `skills/_shared/openspec-convention.md`. Run full bootstrap.
@@ -182,9 +184,11 @@ mem_save(
   topic_key: "sdd/{project-name}/testing-capabilities",
   type: "config",
   project: "{project-name}",
+  capture_prompt: false,
   content: "{testing capabilities markdown — see format below}"
 )
 ```
+Set `capture_prompt: false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 **Testing Capabilities format**:
 
@@ -226,7 +230,7 @@ Follow the same logic as the `skill-registry` skill (`skills/skill-registry/SKIL
 1. Scan user skills: glob `*/SKILL.md` across ALL known skill directories. **User-level**: `~/.claude/skills/`, `~/.config/opencode/skills/`, `~/.gemini/skills/`, `~/.cursor/skills/`, `~/.copilot/skills/`, parent of this skill file. **Project-level**: `.claude/skills/`, `.gemini/skills/`, `.agent/skills/`, `skills/`. Skip `sdd-*`, `_shared`, `skill-registry`. Deduplicate by name (project-level wins). Read frontmatter triggers.
 2. Scan project conventions: check for `agents.md`, `AGENTS.md`, `CLAUDE.md` (project-level), `.cursorrules`, `GEMINI.md`, `copilot-instructions.md` in the project root. If an index file is found (e.g., `agents.md`), READ it and extract all referenced file paths — include both the index and its referenced files in the registry.
 3. **ALWAYS write `.atl/skill-registry.md`** in the project root (create `.atl/` if needed). This file is mode-independent — it's infrastructure, not an SDD artifact.
-4. If engram is available, **ALSO save to engram**: `mem_save(title: "skill-registry", topic_key: "skill-registry", type: "config", project: "{project}", content: "{registry markdown}")`
+4. If engram is available, **ALSO save to engram**: `mem_save(title: "skill-registry", topic_key: "skill-registry", type: "config", project: "{project}", capture_prompt: false, content: "{registry markdown}")`. Set `capture_prompt: false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 See `skills/skill-registry/SKILL.md` for the full registry format and scanning details.
 
@@ -241,9 +245,11 @@ mem_save(
   topic_key: "sdd-init/{project-name}",
   type: "architecture",
   project: "{project-name}",
+  capture_prompt: false,
   content: "{your detected project context from Steps 1-7}"
 )
 ```
+Set `capture_prompt: false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 If mode is `openspec` or `hybrid`: the config was already written in Step 5.
 

--- a/testdata/golden/sdd-cursor-skill-sdd-init.golden
+++ b/testdata/golden/sdd-cursor-skill-sdd-init.golden
@@ -27,10 +27,12 @@ You are an EXECUTOR for this phase, not the orchestrator. Do the initialization 
     topic_key: "sdd-init/{project-name}",
     type: "architecture",
     project: "{project-name}",
+    capture_prompt: false,
     content: "{detected project context markdown}"
   )
   ```
   `topic_key` enables upserts — re-running init updates the existing context, not duplicates.
+  Set `capture_prompt: false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
   (See `skills/_shared/engram-convention.md` for full naming conventions.)
 - If mode is `openspec`: Read and follow `skills/_shared/openspec-convention.md`. Run full bootstrap.
@@ -182,9 +184,11 @@ mem_save(
   topic_key: "sdd/{project-name}/testing-capabilities",
   type: "config",
   project: "{project-name}",
+  capture_prompt: false,
   content: "{testing capabilities markdown — see format below}"
 )
 ```
+Set `capture_prompt: false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 **Testing Capabilities format**:
 
@@ -226,7 +230,7 @@ Follow the same logic as the `skill-registry` skill (`skills/skill-registry/SKIL
 1. Scan user skills: glob `*/SKILL.md` across ALL known skill directories. **User-level**: `~/.claude/skills/`, `~/.config/opencode/skills/`, `~/.gemini/skills/`, `~/.cursor/skills/`, `~/.copilot/skills/`, parent of this skill file. **Project-level**: `.claude/skills/`, `.gemini/skills/`, `.agent/skills/`, `skills/`. Skip `sdd-*`, `_shared`, `skill-registry`. Deduplicate by name (project-level wins). Read frontmatter triggers.
 2. Scan project conventions: check for `agents.md`, `AGENTS.md`, `CLAUDE.md` (project-level), `.cursorrules`, `GEMINI.md`, `copilot-instructions.md` in the project root. If an index file is found (e.g., `agents.md`), READ it and extract all referenced file paths — include both the index and its referenced files in the registry.
 3. **ALWAYS write `.atl/skill-registry.md`** in the project root (create `.atl/` if needed). This file is mode-independent — it's infrastructure, not an SDD artifact.
-4. If engram is available, **ALSO save to engram**: `mem_save(title: "skill-registry", topic_key: "skill-registry", type: "config", project: "{project}", content: "{registry markdown}")`
+4. If engram is available, **ALSO save to engram**: `mem_save(title: "skill-registry", topic_key: "skill-registry", type: "config", project: "{project}", capture_prompt: false, content: "{registry markdown}")`. Set `capture_prompt: false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 See `skills/skill-registry/SKILL.md` for the full registry format and scanning details.
 
@@ -241,9 +245,11 @@ mem_save(
   topic_key: "sdd-init/{project-name}",
   type: "architecture",
   project: "{project-name}",
+  capture_prompt: false,
   content: "{your detected project context from Steps 1-7}"
 )
 ```
+Set `capture_prompt: false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 If mode is `openspec` or `hybrid`: the config was already written in Step 5.
 

--- a/testdata/golden/sdd-gemini-skill-sdd-init.golden
+++ b/testdata/golden/sdd-gemini-skill-sdd-init.golden
@@ -27,10 +27,12 @@ You are an EXECUTOR for this phase, not the orchestrator. Do the initialization 
     topic_key: "sdd-init/{project-name}",
     type: "architecture",
     project: "{project-name}",
+    capture_prompt: false,
     content: "{detected project context markdown}"
   )
   ```
   `topic_key` enables upserts — re-running init updates the existing context, not duplicates.
+  Set `capture_prompt: false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
   (See `skills/_shared/engram-convention.md` for full naming conventions.)
 - If mode is `openspec`: Read and follow `skills/_shared/openspec-convention.md`. Run full bootstrap.
@@ -182,9 +184,11 @@ mem_save(
   topic_key: "sdd/{project-name}/testing-capabilities",
   type: "config",
   project: "{project-name}",
+  capture_prompt: false,
   content: "{testing capabilities markdown — see format below}"
 )
 ```
+Set `capture_prompt: false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 **Testing Capabilities format**:
 
@@ -226,7 +230,7 @@ Follow the same logic as the `skill-registry` skill (`skills/skill-registry/SKIL
 1. Scan user skills: glob `*/SKILL.md` across ALL known skill directories. **User-level**: `~/.claude/skills/`, `~/.config/opencode/skills/`, `~/.gemini/skills/`, `~/.cursor/skills/`, `~/.copilot/skills/`, parent of this skill file. **Project-level**: `.claude/skills/`, `.gemini/skills/`, `.agent/skills/`, `skills/`. Skip `sdd-*`, `_shared`, `skill-registry`. Deduplicate by name (project-level wins). Read frontmatter triggers.
 2. Scan project conventions: check for `agents.md`, `AGENTS.md`, `CLAUDE.md` (project-level), `.cursorrules`, `GEMINI.md`, `copilot-instructions.md` in the project root. If an index file is found (e.g., `agents.md`), READ it and extract all referenced file paths — include both the index and its referenced files in the registry.
 3. **ALWAYS write `.atl/skill-registry.md`** in the project root (create `.atl/` if needed). This file is mode-independent — it's infrastructure, not an SDD artifact.
-4. If engram is available, **ALSO save to engram**: `mem_save(title: "skill-registry", topic_key: "skill-registry", type: "config", project: "{project}", content: "{registry markdown}")`
+4. If engram is available, **ALSO save to engram**: `mem_save(title: "skill-registry", topic_key: "skill-registry", type: "config", project: "{project}", capture_prompt: false, content: "{registry markdown}")`. Set `capture_prompt: false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 See `skills/skill-registry/SKILL.md` for the full registry format and scanning details.
 
@@ -241,9 +245,11 @@ mem_save(
   topic_key: "sdd-init/{project-name}",
   type: "architecture",
   project: "{project-name}",
+  capture_prompt: false,
   content: "{your detected project context from Steps 1-7}"
 )
 ```
+Set `capture_prompt: false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 If mode is `openspec` or `hybrid`: the config was already written in Step 5.
 

--- a/testdata/golden/sdd-kiro-agent-sdd-apply.golden
+++ b/testdata/golden/sdd-kiro-agent-sdd-apply.golden
@@ -40,6 +40,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd/{change-name}/apply-progress"`
 - type: `"architecture"`
 - project: `{project-name from context}`
+- capture_prompt: `false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 Also update the tasks artifact with `[x]` marks via `mem_update` (engram) or file edit (openspec/hybrid).
 

--- a/testdata/golden/sdd-kiro-agent-sdd-archive.golden
+++ b/testdata/golden/sdd-kiro-agent-sdd-archive.golden
@@ -41,6 +41,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd/{change-name}/archive-report"`
 - type: `"architecture"`
 - project: `{project-name from context}`
+- capture_prompt: `false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 ## Result Contract
 

--- a/testdata/golden/sdd-kiro-agent-sdd-design.golden
+++ b/testdata/golden/sdd-kiro-agent-sdd-design.golden
@@ -37,6 +37,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd/{change-name}/design"`
 - type: `"architecture"`
 - project: `{project-name from context}`
+- capture_prompt: `false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 ## Result Contract
 

--- a/testdata/golden/sdd-kiro-agent-sdd-explore.golden
+++ b/testdata/golden/sdd-kiro-agent-sdd-explore.golden
@@ -38,6 +38,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd/{change-name}/explore"`
 - type: `"architecture"`
 - project: `{project-name from context}`
+- capture_prompt: `false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 ## Result Contract
 

--- a/testdata/golden/sdd-kiro-agent-sdd-init.golden
+++ b/testdata/golden/sdd-kiro-agent-sdd-init.golden
@@ -35,6 +35,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd-init/{project}"`
 - type: `"architecture"`
 - project: `{project-name from context}`
+- capture_prompt: `false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 ## Result Contract
 

--- a/testdata/golden/sdd-kiro-agent-sdd-onboard.golden
+++ b/testdata/golden/sdd-kiro-agent-sdd-onboard.golden
@@ -35,6 +35,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd-onboard/{project}"`
 - type: `"architecture"`
 - project: `{project-name from context}`
+- capture_prompt: `false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 ## Result Contract
 

--- a/testdata/golden/sdd-kiro-agent-sdd-propose.golden
+++ b/testdata/golden/sdd-kiro-agent-sdd-propose.golden
@@ -34,6 +34,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd/{change-name}/proposal"`
 - type: `"architecture"`
 - project: `{project-name from context}`
+- capture_prompt: `false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 ## Result Contract
 

--- a/testdata/golden/sdd-kiro-agent-sdd-spec.golden
+++ b/testdata/golden/sdd-kiro-agent-sdd-spec.golden
@@ -35,6 +35,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd/{change-name}/spec"`
 - type: `"architecture"`
 - project: `{project-name from context}`
+- capture_prompt: `false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 ## Result Contract
 

--- a/testdata/golden/sdd-kiro-agent-sdd-tasks.golden
+++ b/testdata/golden/sdd-kiro-agent-sdd-tasks.golden
@@ -37,6 +37,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd/{change-name}/tasks"`
 - type: `"architecture"`
 - project: `{project-name from context}`
+- capture_prompt: `false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 ## Result Contract
 

--- a/testdata/golden/sdd-kiro-agent-sdd-verify.golden
+++ b/testdata/golden/sdd-kiro-agent-sdd-verify.golden
@@ -42,6 +42,7 @@ After completing work, call `mem_save` with:
 - topic_key: `"sdd/{change-name}/verify-report"`
 - type: `"architecture"`
 - project: `{project-name from context}`
+- capture_prompt: `false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 ## Result Contract
 

--- a/testdata/golden/sdd-kiro-skill-sdd-init.golden
+++ b/testdata/golden/sdd-kiro-skill-sdd-init.golden
@@ -27,10 +27,12 @@ You are an EXECUTOR for this phase, not the orchestrator. Do the initialization 
     topic_key: "sdd-init/{project-name}",
     type: "architecture",
     project: "{project-name}",
+    capture_prompt: false,
     content: "{detected project context markdown}"
   )
   ```
   `topic_key` enables upserts — re-running init updates the existing context, not duplicates.
+  Set `capture_prompt: false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
   (See `skills/_shared/engram-convention.md` for full naming conventions.)
 - If mode is `openspec`: Read and follow `skills/_shared/openspec-convention.md`. Run full bootstrap.
@@ -182,9 +184,11 @@ mem_save(
   topic_key: "sdd/{project-name}/testing-capabilities",
   type: "config",
   project: "{project-name}",
+  capture_prompt: false,
   content: "{testing capabilities markdown — see format below}"
 )
 ```
+Set `capture_prompt: false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 **Testing Capabilities format**:
 
@@ -226,7 +230,7 @@ Follow the same logic as the `skill-registry` skill (`skills/skill-registry/SKIL
 1. Scan user skills: glob `*/SKILL.md` across ALL known skill directories. **User-level**: `~/.claude/skills/`, `~/.config/opencode/skills/`, `~/.gemini/skills/`, `~/.cursor/skills/`, `~/.copilot/skills/`, parent of this skill file. **Project-level**: `.claude/skills/`, `.gemini/skills/`, `.agent/skills/`, `skills/`. Skip `sdd-*`, `_shared`, `skill-registry`. Deduplicate by name (project-level wins). Read frontmatter triggers.
 2. Scan project conventions: check for `agents.md`, `AGENTS.md`, `CLAUDE.md` (project-level), `.cursorrules`, `GEMINI.md`, `copilot-instructions.md` in the project root. If an index file is found (e.g., `agents.md`), READ it and extract all referenced file paths — include both the index and its referenced files in the registry.
 3. **ALWAYS write `.atl/skill-registry.md`** in the project root (create `.atl/` if needed). This file is mode-independent — it's infrastructure, not an SDD artifact.
-4. If engram is available, **ALSO save to engram**: `mem_save(title: "skill-registry", topic_key: "skill-registry", type: "config", project: "{project}", content: "{registry markdown}")`
+4. If engram is available, **ALSO save to engram**: `mem_save(title: "skill-registry", topic_key: "skill-registry", type: "config", project: "{project}", capture_prompt: false, content: "{registry markdown}")`. Set `capture_prompt: false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 See `skills/skill-registry/SKILL.md` for the full registry format and scanning details.
 
@@ -241,9 +245,11 @@ mem_save(
   topic_key: "sdd-init/{project-name}",
   type: "architecture",
   project: "{project-name}",
+  capture_prompt: false,
   content: "{your detected project context from Steps 1-7}"
 )
 ```
+Set `capture_prompt: false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 If mode is `openspec` or `hybrid`: the config was already written in Step 5.
 

--- a/testdata/golden/sdd-opencode-cmd-sdd-init.golden
+++ b/testdata/golden/sdd-opencode-cmd-sdd-init.golden
@@ -16,7 +16,8 @@ Initialize Spec-Driven Development in this project. Detect the tech stack, exist
 
 ENGRAM PERSISTENCE (artifact store mode: engram):
 After detecting the project context, save it:
-  mem_save(title: "sdd-init/{project}", topic_key: "sdd-init/{project}", type: "architecture", project: "{project}", content: "{detected context}")
+  mem_save(title: "sdd-init/{project}", topic_key: "sdd-init/{project}", type: "architecture", project: "{project}", capture_prompt: false, content: "{detected context}")
+  Set capture_prompt: false when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 topic_key enables upserts — re-running init updates, not duplicates.
 
 Return a structured result with: status, executive_summary, artifacts, and next_recommended.

--- a/testdata/golden/sdd-opencode-skill-sdd-init.golden
+++ b/testdata/golden/sdd-opencode-skill-sdd-init.golden
@@ -27,10 +27,12 @@ You are an EXECUTOR for this phase, not the orchestrator. Do the initialization 
     topic_key: "sdd-init/{project-name}",
     type: "architecture",
     project: "{project-name}",
+    capture_prompt: false,
     content: "{detected project context markdown}"
   )
   ```
   `topic_key` enables upserts — re-running init updates the existing context, not duplicates.
+  Set `capture_prompt: false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
   (See `skills/_shared/engram-convention.md` for full naming conventions.)
 - If mode is `openspec`: Read and follow `skills/_shared/openspec-convention.md`. Run full bootstrap.
@@ -182,9 +184,11 @@ mem_save(
   topic_key: "sdd/{project-name}/testing-capabilities",
   type: "config",
   project: "{project-name}",
+  capture_prompt: false,
   content: "{testing capabilities markdown — see format below}"
 )
 ```
+Set `capture_prompt: false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 **Testing Capabilities format**:
 
@@ -226,7 +230,7 @@ Follow the same logic as the `skill-registry` skill (`skills/skill-registry/SKIL
 1. Scan user skills: glob `*/SKILL.md` across ALL known skill directories. **User-level**: `~/.claude/skills/`, `~/.config/opencode/skills/`, `~/.gemini/skills/`, `~/.cursor/skills/`, `~/.copilot/skills/`, parent of this skill file. **Project-level**: `.claude/skills/`, `.gemini/skills/`, `.agent/skills/`, `skills/`. Skip `sdd-*`, `_shared`, `skill-registry`. Deduplicate by name (project-level wins). Read frontmatter triggers.
 2. Scan project conventions: check for `agents.md`, `AGENTS.md`, `CLAUDE.md` (project-level), `.cursorrules`, `GEMINI.md`, `copilot-instructions.md` in the project root. If an index file is found (e.g., `agents.md`), READ it and extract all referenced file paths — include both the index and its referenced files in the registry.
 3. **ALWAYS write `.atl/skill-registry.md`** in the project root (create `.atl/` if needed). This file is mode-independent — it's infrastructure, not an SDD artifact.
-4. If engram is available, **ALSO save to engram**: `mem_save(title: "skill-registry", topic_key: "skill-registry", type: "config", project: "{project}", content: "{registry markdown}")`
+4. If engram is available, **ALSO save to engram**: `mem_save(title: "skill-registry", topic_key: "skill-registry", type: "config", project: "{project}", capture_prompt: false, content: "{registry markdown}")`. Set `capture_prompt: false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 See `skills/skill-registry/SKILL.md` for the full registry format and scanning details.
 
@@ -241,9 +245,11 @@ mem_save(
   topic_key: "sdd-init/{project-name}",
   type: "architecture",
   project: "{project-name}",
+  capture_prompt: false,
   content: "{your detected project context from Steps 1-7}"
 )
 ```
+Set `capture_prompt: false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 If mode is `openspec` or `hybrid`: the config was already written in Step 5.
 

--- a/testdata/golden/sdd-vscode-skill-sdd-init.golden
+++ b/testdata/golden/sdd-vscode-skill-sdd-init.golden
@@ -27,10 +27,12 @@ You are an EXECUTOR for this phase, not the orchestrator. Do the initialization 
     topic_key: "sdd-init/{project-name}",
     type: "architecture",
     project: "{project-name}",
+    capture_prompt: false,
     content: "{detected project context markdown}"
   )
   ```
   `topic_key` enables upserts — re-running init updates the existing context, not duplicates.
+  Set `capture_prompt: false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
   (See `skills/_shared/engram-convention.md` for full naming conventions.)
 - If mode is `openspec`: Read and follow `skills/_shared/openspec-convention.md`. Run full bootstrap.
@@ -182,9 +184,11 @@ mem_save(
   topic_key: "sdd/{project-name}/testing-capabilities",
   type: "config",
   project: "{project-name}",
+  capture_prompt: false,
   content: "{testing capabilities markdown — see format below}"
 )
 ```
+Set `capture_prompt: false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 **Testing Capabilities format**:
 
@@ -226,7 +230,7 @@ Follow the same logic as the `skill-registry` skill (`skills/skill-registry/SKIL
 1. Scan user skills: glob `*/SKILL.md` across ALL known skill directories. **User-level**: `~/.claude/skills/`, `~/.config/opencode/skills/`, `~/.gemini/skills/`, `~/.cursor/skills/`, `~/.copilot/skills/`, parent of this skill file. **Project-level**: `.claude/skills/`, `.gemini/skills/`, `.agent/skills/`, `skills/`. Skip `sdd-*`, `_shared`, `skill-registry`. Deduplicate by name (project-level wins). Read frontmatter triggers.
 2. Scan project conventions: check for `agents.md`, `AGENTS.md`, `CLAUDE.md` (project-level), `.cursorrules`, `GEMINI.md`, `copilot-instructions.md` in the project root. If an index file is found (e.g., `agents.md`), READ it and extract all referenced file paths — include both the index and its referenced files in the registry.
 3. **ALWAYS write `.atl/skill-registry.md`** in the project root (create `.atl/` if needed). This file is mode-independent — it's infrastructure, not an SDD artifact.
-4. If engram is available, **ALSO save to engram**: `mem_save(title: "skill-registry", topic_key: "skill-registry", type: "config", project: "{project}", content: "{registry markdown}")`
+4. If engram is available, **ALSO save to engram**: `mem_save(title: "skill-registry", topic_key: "skill-registry", type: "config", project: "{project}", capture_prompt: false, content: "{registry markdown}")`. Set `capture_prompt: false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 See `skills/skill-registry/SKILL.md` for the full registry format and scanning details.
 
@@ -241,9 +245,11 @@ mem_save(
   topic_key: "sdd-init/{project-name}",
   type: "architecture",
   project: "{project-name}",
+  capture_prompt: false,
   content: "{your detected project context from Steps 1-7}"
 )
 ```
+Set `capture_prompt: false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 If mode is `openspec` or `hybrid`: the config was already written in Step 5.
 

--- a/testdata/golden/sdd-windsurf-skill-sdd-init.golden
+++ b/testdata/golden/sdd-windsurf-skill-sdd-init.golden
@@ -27,10 +27,12 @@ You are an EXECUTOR for this phase, not the orchestrator. Do the initialization 
     topic_key: "sdd-init/{project-name}",
     type: "architecture",
     project: "{project-name}",
+    capture_prompt: false,
     content: "{detected project context markdown}"
   )
   ```
   `topic_key` enables upserts — re-running init updates the existing context, not duplicates.
+  Set `capture_prompt: false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
   (See `skills/_shared/engram-convention.md` for full naming conventions.)
 - If mode is `openspec`: Read and follow `skills/_shared/openspec-convention.md`. Run full bootstrap.
@@ -182,9 +184,11 @@ mem_save(
   topic_key: "sdd/{project-name}/testing-capabilities",
   type: "config",
   project: "{project-name}",
+  capture_prompt: false,
   content: "{testing capabilities markdown — see format below}"
 )
 ```
+Set `capture_prompt: false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 **Testing Capabilities format**:
 
@@ -226,7 +230,7 @@ Follow the same logic as the `skill-registry` skill (`skills/skill-registry/SKIL
 1. Scan user skills: glob `*/SKILL.md` across ALL known skill directories. **User-level**: `~/.claude/skills/`, `~/.config/opencode/skills/`, `~/.gemini/skills/`, `~/.cursor/skills/`, `~/.copilot/skills/`, parent of this skill file. **Project-level**: `.claude/skills/`, `.gemini/skills/`, `.agent/skills/`, `skills/`. Skip `sdd-*`, `_shared`, `skill-registry`. Deduplicate by name (project-level wins). Read frontmatter triggers.
 2. Scan project conventions: check for `agents.md`, `AGENTS.md`, `CLAUDE.md` (project-level), `.cursorrules`, `GEMINI.md`, `copilot-instructions.md` in the project root. If an index file is found (e.g., `agents.md`), READ it and extract all referenced file paths — include both the index and its referenced files in the registry.
 3. **ALWAYS write `.atl/skill-registry.md`** in the project root (create `.atl/` if needed). This file is mode-independent — it's infrastructure, not an SDD artifact.
-4. If engram is available, **ALSO save to engram**: `mem_save(title: "skill-registry", topic_key: "skill-registry", type: "config", project: "{project}", content: "{registry markdown}")`
+4. If engram is available, **ALSO save to engram**: `mem_save(title: "skill-registry", topic_key: "skill-registry", type: "config", project: "{project}", capture_prompt: false, content: "{registry markdown}")`. Set `capture_prompt: false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 See `skills/skill-registry/SKILL.md` for the full registry format and scanning details.
 
@@ -241,9 +245,11 @@ mem_save(
   topic_key: "sdd-init/{project-name}",
   type: "architecture",
   project: "{project-name}",
+  capture_prompt: false,
   content: "{your detected project context from Steps 1-7}"
 )
 ```
+Set `capture_prompt: false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
 
 If mode is `openspec` or `hybrid`: the config was already written in Step 5.
 


### PR DESCRIPTION
Closes #425

## PR Type
- [ ] Bug fix
- [ ] New feature
- [x] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Document Engram v1.15.3 `capture_prompt` behavior for Claude, Codex, and user-facing Engram docs.
- Mark automated SDD and skill-registry artifacts with explicit `capture_prompt: false`.
- Clarify that prompt capture must be explicit for automation and must not rely on `type` heuristics.

## Changes

| File | Change |
|------|--------|
| `internal/assets/claude/engram-protocol.md` | Adds prompt capture behavior, defaults, schema compatibility, and `mem_save_prompt` guidance |
| `internal/assets/codex/engram-instructions.md` | Mirrors Engram v1.15.3 prompt capture instructions for Codex |
| `internal/assets/skills/_shared/*.md` | Updates SDD persistence contracts with `capture_prompt: false` for artifacts |
| `internal/assets/*/agents/sdd-*.md` | Marks generated SDD phase agent save instructions as automated artifacts |
| `internal/assets/{claude,opencode}/commands/sdd-*.md` | Updates SDD slash command save examples |
| `internal/assets/skills/{sdd-init,skill-registry}/SKILL.md` | Marks init, testing capabilities, and skill registry saves as automated artifacts |
| `docs/engram.md` | Documents MCP tool behavior for prompt capture and `mem_save_prompt` |

## Test Plan
- [x] `go test ./internal/components/engram ./internal/components/sdd`
- [x] Verified SDD automated saves include `capture_prompt: false`
- [x] Verified human/proactive protocol keeps default prompt capture behavior

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran shellcheck on modified scripts (not applicable; no shell scripts changed)
- [x] Skills tested in at least one agent via asset injection tests
- [x] Docs updated if behavior changed
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers