### PR TITLE
ci(e2e): split coverage — Tier 1 on PR, full on main + nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches:
       - main
+  schedule:
+    # 03:00 UTC daily — full Tier 1+2+3 across all platforms as a safety net
+    - cron: "0 3 * * *"
 
 jobs:
   unit-tests:
@@ -53,13 +56,19 @@ jobs:
           cache-from: type=gha,scope=e2e-${{ matrix.platform.name }}
           cache-to: type=gha,mode=max,scope=e2e-${{ matrix.platform.name }}
 
+      # PR runs Tier 1 only (binary + dry-run); push to main and the nightly
+      # schedule run the full Tier 1+2+3 suite. The ruleset still requires all
+      # 3 platform checks, so the matrix runs everywhere — only the test scope
+      # changes by event.
       - name: Run E2E tests
         timeout-minutes: 30
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_FULL_E2E: ${{ (github.event_name == 'push' || github.event_name == 'schedule') && '1' || '0' }}
+          RUN_BACKUP_TESTS: ${{ (github.event_name == 'push' || github.event_name == 'schedule') && '1' || '0' }}
         run: |
           docker run --rm \
-            -e RUN_FULL_E2E=1 \
-            -e RUN_BACKUP_TESTS=1 \
+            -e RUN_FULL_E2E \
+            -e RUN_BACKUP_TESTS \
             -e GITHUB_TOKEN \
             gentle-ai-e2e-${{ matrix.platform.name }}:ci


### PR DESCRIPTION
Closes #433

### PR Type

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [x] Maintenance/tooling
- [ ] Breaking change

### Summary

- PRs now run the existing 3-platform matrix at **Tier 1 only** (binary + dry-run). The matrix still produces all 3 `E2E Tests (ubuntu/arch/fedora)` checks so the `pr - main` ruleset stays satisfied, but `RUN_FULL_E2E` and `RUN_BACKUP_TESTS` are forced to `0` for `pull_request` events.
- Push to `main` keeps running the **full Tier 1+2+3** suite — same coverage as today.
- New daily `schedule` trigger at `03:00 UTC` runs the full suite on `main` as a safety net so Tier 2/3 regressions are caught within 24h even when no merges happen.

The conditional uses `github.event_name` to flip the env vars; `docker run -e VAR` forwards by name, so the existing tier guards inside `e2e_test.sh` see the right values.

### Changes

| File | Change |
|------|--------|
| `.github/workflows/ci.yml` | Add `schedule` trigger (cron `0 3 * * *`). Make `RUN_FULL_E2E` and `RUN_BACKUP_TESTS` conditional on `github.event_name` — `'1'` on `push`/`schedule`, `'0'` on `pull_request`. Switch `docker run` to forwarding env by name (`-e VAR`) instead of inline `VAR=1`. |

### Test Plan

- [x] Workflow YAML parses, conditional expressions are valid GHA expression syntax.
- [x] Conventional commit format respected (`ci(e2e): ...`).
- [ ] CI runs on this PR — expect Ubuntu/Arch/Fedora to all report green at **Tier 1 only** (so noticeably faster than recent main runs).
- [ ] Once merged, the `push` to `main` will trigger a full-tier run — should match the wall-clock of the previous baseline (~3-4m).
- [ ] Nightly schedule will fire tomorrow at 03:00 UTC — visible under Actions \> CI runs filtered by `event:schedule`.

### Notes for Reviewer

- **Ruleset stays unchanged** for this PR. Both `pr` (id `13932547`, non-main branches, currently requires only `E2E Tests (ubuntu)`) and `pr - main` (id `15960894`, default branch, requires all 3) keep working as configured. Optional follow-up: align `pr` with `pr - main` (require all 3) for consistency, since the workflow always produces all 3 contexts now. Not blocking.
- **What this PR does not do**: change which platforms run, change the ruleset, change the build/cache pipeline. Pure event-conditional test scope.

### Contributor Checklist

- [x] Linked an approved issue (#433, `status:approved`)
- [x] Added exactly one `type:*` label (`type:chore`)
- [x] No shell scripts modified — `shellcheck` not applicable
- [x] CI workflow change does not modify test logic
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers