### PR TITLE
fix(sync): regenerate persona block and persist persona selection

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -268,6 +268,7 @@ func tuiExecute(
 			InstalledAgents:        agentIDs,
 			ClaudeModelAssignments: claudeAliasesToStrings(selection.ClaudeModelAssignments),
 			ModelAssignments:       modelAssignmentsToState(selection.ModelAssignments),
+			Persona:                string(selection.Persona),
 		})
 	}
 

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -155,6 +155,7 @@ func RunInstall(args []string, detection system.DetectionResult) (InstallResult,
 		InstalledAgents:        agentIDs,
 		ClaudeModelAssignments: claudeAliasesToStrings(input.Selection.ClaudeModelAssignments),
 		ModelAssignments:       modelAssignmentsToState(input.Selection.ModelAssignments),
+		Persona:                string(input.Selection.Persona),
 	})
 
 	return result, nil

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gentleman-programming/gentle-ai/internal/components/gga"
 	"github.com/gentleman-programming/gentle-ai/internal/components/mcp"
 	"github.com/gentleman-programming/gentle-ai/internal/components/permissions"
+	"github.com/gentleman-programming/gentle-ai/internal/components/persona"
 	"github.com/gentleman-programming/gentle-ai/internal/components/sdd"
 	"github.com/gentleman-programming/gentle-ai/internal/components/skills"
 	"github.com/gentleman-programming/gentle-ai/internal/components/theme"
@@ -263,14 +264,26 @@ func parseModelSpec(spec string) (model.ModelAssignment, error) {
 
 // BuildSyncSelection builds a model.Selection for the sync command.
 //
-// Default sync scope: SDD, Engram, Context7, GGA, Skills.
-// Excluded by default: Persona, Permissions, Theme (user-config-adjacent).
+// Default sync scope: SDD, Engram, Context7, GGA, Skills, Persona.
+// Excluded by default: Permissions, Theme (no markers; managed via JSON
+// overlays where user customization cannot be safely diff-merged).
 // Permissions and Theme can be opted-in via flags.
+//
+// Persona is included because its content lives between
+// <!-- gentle-ai:persona --> markers — that block is harness-managed and
+// must propagate embedded-asset changes across versions. Content outside
+// the markers (user-authored sections) is preserved by InjectMarkdownSection.
 //
 // This is the reusable managed-asset sync contract. A future `upgrade --sync`
 // flow can call this function to get the same managed-only selection semantics.
 func BuildSyncSelection(flags SyncFlags, agentIDs []model.AgentID) model.Selection {
+	// Order matters: Persona must run BEFORE SDD/Engram/MCP because those
+	// components inject content with substrings (e.g. "## Personality",
+	// "Senior Architect") that overlap with persona's legacy-block fingerprints.
+	// Running persona last would cause its StripLegacyPersonaBlock pass to
+	// detect the just-written managed sections as legacy and strip them.
 	components := []model.ComponentID{
+		model.ComponentPersona,
 		model.ComponentSDD,
 		model.ComponentEngram,
 		model.ComponentContext7,
@@ -303,6 +316,11 @@ func BuildSyncSelection(flags SyncFlags, agentIDs []model.AgentID) model.Selecti
 		// Preset is set to full-gentleman so selectedSkillIDs() returns the
 		// correct default skill set when no explicit skills are provided.
 		Preset: model.PresetFullGentleman,
+		// Persona is left as zero-value here. RunSync resolves it from
+		// state.json (the user's installed choice); only when state has no
+		// recorded persona — i.e. an old install — does it fall back to
+		// PersonaGentleman. This avoids regenerating a Gentleman persona on
+		// top of a user who installed neutral.
 	}
 }
 
@@ -417,11 +435,13 @@ func (r *syncRuntime) stagePlan() pipeline.StagePlan {
 }
 
 // syncBackupTargets returns the file paths that need to be backed up
-// before sync executes. Uses the same componentPaths logic as install.
+// before sync executes. Uses syncComponentPaths so that the backup/verify
+// contract matches the actual files sync touches (which differ from install
+// for ComponentPersona — see syncComponentPaths).
 func syncBackupTargets(homeDir string, selection model.Selection, adapters []agents.Adapter) []string {
 	paths := map[string]struct{}{}
 	for _, component := range selection.Components {
-		for _, path := range componentPaths(homeDir, selection, adapters, component) {
+		for _, path := range syncComponentPaths(homeDir, selection, adapters, component) {
 			paths[path] = struct{}{}
 		}
 	}
@@ -431,6 +451,51 @@ func syncBackupTargets(homeDir string, selection model.Selection, adapters []age
 		targets = append(targets, path)
 	}
 	return targets
+}
+
+// syncComponentPaths declares the file paths sync writes for a given component.
+//
+// For most components the contract is identical to install (componentPaths).
+// ComponentPersona is the exception: sync calls persona.InjectForSync which
+// skips the OpenCode/Kilocode agent definition in opencode.json (those JSON
+// merges remain install-only because they conflict with SDD's writes to the
+// same file). Sync therefore must NOT declare those JSON paths or the post-sync
+// verification will look for files sync never promised to write.
+func syncComponentPaths(homeDir string, selection model.Selection, adapters []agents.Adapter, component model.ComponentID) []string {
+	if component == model.ComponentPersona {
+		return syncPersonaPaths(homeDir, selection, adapters)
+	}
+	return componentPaths(homeDir, selection, adapters, component)
+}
+
+// syncPersonaPaths returns the file paths that ComponentPersona writes during
+// sync. Mirrors persona.InjectForSync:
+//   - Step 1: SystemPromptFile (the marker-bound markdown block — CLAUDE.md /
+//     AGENTS.md / equivalent).
+//   - Step 3: Gentleman output-style overlay (only when the agent supports it).
+//
+// Step 2 (OpenCode/Kilocode agent definition in opencode.json) is install-only
+// and intentionally NOT declared here.
+func syncPersonaPaths(homeDir string, selection model.Selection, adapters []agents.Adapter) []string {
+	if selection.Persona == model.PersonaCustom {
+		return nil
+	}
+	paths := []string{}
+	for _, adapter := range adapters {
+		if !adapter.SupportsSystemPrompt() {
+			continue
+		}
+		if adapter.SystemPromptStrategy() != model.StrategyJinjaModules {
+			paths = append(paths, adapter.SystemPromptFile(homeDir))
+		}
+		if selection.Persona == model.PersonaGentleman && adapter.SupportsOutputStyles() {
+			paths = append(paths, adapter.OutputStyleDir(homeDir)+"/gentleman.md")
+			if p := adapter.SettingsPath(homeDir); p != "" {
+				paths = append(paths, p)
+			}
+		}
+	}
+	return paths
 }
 
 // componentSyncStep is the sync-specific apply step.
@@ -577,6 +642,22 @@ func (s componentSyncStep) Run() error {
 		}
 		return nil
 
+	case model.ComponentPersona:
+		// Sync regenerates the persona block between
+		// <!-- gentle-ai:persona --> markers and (when supported) refreshes
+		// the Gentleman output-style overlay. We deliberately skip the
+		// OpenCode/Kilocode agent definition in opencode.json — that JSON
+		// merge conflicts with SDD's writes to the same settings file and
+		// remains an install-only concern.
+		for _, adapter := range adapters {
+			res, err := persona.InjectForSync(s.homeDir, adapter, s.selection.Persona)
+			if err != nil {
+				return fmt.Errorf("sync persona for %q: %w", adapter.Agent(), err)
+			}
+			s.countChanged(boolToInt(res.Changed))
+		}
+		return nil
+
 	case model.ComponentTheme:
 		// Opt-in only — reached when --include-theme is set.
 		for _, adapter := range adapters {
@@ -688,10 +769,10 @@ func RunSync(args []string) (SyncResult, error) {
 
 	selection := BuildSyncSelection(flags, agentIDs)
 
-	// Load persisted model assignments from state when not provided via flags.
-	// This is the key fix: without this, every CLI sync falls back to the
-	// "balanced" preset and silently overwrites the user's model choices.
-	if len(selection.ClaudeModelAssignments) == 0 || len(selection.ModelAssignments) == 0 {
+	// Load persisted model assignments and persona from state when not provided
+	// via flags. Without this, every CLI sync falls back to defaults and would
+	// silently overwrite the user's model choices and persona selection.
+	if len(selection.ClaudeModelAssignments) == 0 || len(selection.ModelAssignments) == 0 || selection.Persona == "" {
 		s, readErr := state.Read(homeDir)
 		if readErr == nil {
 			if len(selection.ClaudeModelAssignments) == 0 && len(s.ClaudeModelAssignments) > 0 {
@@ -708,7 +789,15 @@ func RunSync(args []string) (SyncResult, error) {
 				}
 				selection.ModelAssignments = m
 			}
+			if selection.Persona == "" && s.Persona != "" {
+				selection.Persona = model.PersonaID(s.Persona)
+			}
 		}
+	}
+	// Backward-compat fallback: state files written before persona persistence
+	// have no Persona field. Default to Gentleman so sync still has a target.
+	if selection.Persona == "" {
+		selection.Persona = model.PersonaGentleman
 	}
 
 	if flags.DryRun {
@@ -808,7 +897,7 @@ func runPostSyncVerification(homeDir string, selection model.Selection) verify.R
 	adapters := resolveAdapters(selection.Agents)
 
 	for _, component := range selection.Components {
-		for _, path := range componentPaths(homeDir, selection, adapters, component) {
+		for _, path := range syncComponentPaths(homeDir, selection, adapters, component) {
 			currentPath := path
 			checks = append(checks, verify.Check{
 				ID:          "verify:sync:file:" + currentPath,

--- a/internal/cli/sync_test.go
+++ b/internal/cli/sync_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gentleman-programming/gentle-ai/internal/agents"
+	"github.com/gentleman-programming/gentle-ai/internal/backup"
 	"github.com/gentleman-programming/gentle-ai/internal/model"
 	"github.com/gentleman-programming/gentle-ai/internal/state"
 )
@@ -193,13 +195,18 @@ func TestBuildSyncSelectionDefaultScopeIncludesManagedComponents(t *testing.T) {
 
 	sel := BuildSyncSelection(flags, agents)
 
-	// Default sync must include: SDD, Engram, Context7, GGA, Skills
+	// Default sync must include: SDD, Engram, Context7, GGA, Skills, Persona.
+	// Persona is included because the content between <!-- gentle-ai:persona -->
+	// markers is harness-managed; sync must propagate embedded-asset changes to
+	// users who already have a persona installed. Content outside the markers
+	// is preserved by InjectMarkdownSection.
 	mandatoryComponents := []model.ComponentID{
 		model.ComponentSDD,
 		model.ComponentEngram,
 		model.ComponentContext7,
 		model.ComponentGGA,
 		model.ComponentSkills,
+		model.ComponentPersona,
 	}
 
 	for _, want := range mandatoryComponents {
@@ -216,14 +223,13 @@ func TestBuildSyncSelectionDefaultScopeIncludesManagedComponents(t *testing.T) {
 	}
 }
 
-func TestBuildSyncSelectionDefaultExcludesPersonaPermissionsTheme(t *testing.T) {
+func TestBuildSyncSelectionDefaultExcludesPermissionsTheme(t *testing.T) {
 	agents := []model.AgentID{model.AgentOpenCode}
 	flags := SyncFlags{}
 
 	sel := BuildSyncSelection(flags, agents)
 
 	excluded := []model.ComponentID{
-		model.ComponentPersona,
 		model.ComponentPermission,
 		model.ComponentTheme,
 	}
@@ -464,22 +470,46 @@ func TestComponentSyncStepSkipsEngramBinaryInstall(t *testing.T) {
 	}
 }
 
-func TestComponentSyncStepSkipsPersonaByDefault(t *testing.T) {
-	// The sync step should never inject persona — it is not in the sync scope.
-	// We verify by confirming ComponentPersona is not handled and returns error.
+func TestComponentSyncStepRunsPersonaInjectForSync(t *testing.T) {
+	// The sync step regenerates the marker-bound persona block (markdown only).
+	// It must NOT touch the OpenCode agent definition in opencode.json (those
+	// JSON merges are install-only — running them in sync would conflict with
+	// SDD's settings writes and break idempotency).
 	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, ".config", "opencode"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
 
 	step := componentSyncStep{
 		id:        "sync:persona",
 		component: model.ComponentPersona,
 		homeDir:   home,
 		agents:    []model.AgentID{model.AgentOpenCode},
-		selection: model.Selection{},
+		selection: model.Selection{Persona: model.PersonaGentleman},
 	}
 
-	err := step.Run()
-	if err == nil {
-		t.Fatalf("componentSyncStep.Run() with ComponentPersona should return error (out of sync scope)")
+	if err := step.Run(); err != nil {
+		t.Fatalf("componentSyncStep.Run() with ComponentPersona = %v, want nil", err)
+	}
+
+	// Persona block in AGENTS.md must exist after the sync step.
+	agentsMD := filepath.Join(home, ".config", "opencode", "AGENTS.md")
+	body, err := os.ReadFile(agentsMD)
+	if err != nil {
+		t.Fatalf("ReadFile AGENTS.md: %v", err)
+	}
+	if !strings.Contains(string(body), "<!-- gentle-ai:persona -->") {
+		t.Errorf("AGENTS.md missing persona open marker after sync; got:\n%s", string(body))
+	}
+
+	// opencode.json must NOT have been touched by the sync persona step
+	// (that JSON merge belongs to install). Either absent or empty is fine.
+	settings := filepath.Join(home, ".config", "opencode", "opencode.json")
+	if _, err := os.Stat(settings); err == nil {
+		raw, _ := os.ReadFile(settings)
+		if strings.Contains(string(raw), "gentleman") {
+			t.Errorf("opencode.json should NOT contain gentleman agent after sync; got:\n%s", string(raw))
+		}
 	}
 }
 
@@ -559,15 +589,18 @@ func TestComponentSyncStepRunsGGAInjectWithoutBinaryInstall(t *testing.T) {
 func TestRunSyncAppliesManagedFilesystemChanges(t *testing.T) {
 	home := t.TempDir()
 	restoreHome := osUserHomeDir
+	restoreBackupHome := backup.UserHomeDirFn
 	restoreCommand := runCommand
 	restoreLookPath := cmdLookPath
 	t.Cleanup(func() {
 		osUserHomeDir = restoreHome
+		backup.UserHomeDirFn = restoreBackupHome
 		runCommand = restoreCommand
 		cmdLookPath = restoreLookPath
 	})
 
 	osUserHomeDir = func() (string, error) { return home, nil }
+	backup.UserHomeDirFn = func() (string, error) { return home, nil }
 	runCommand = func(string, ...string) error { return nil }
 	cmdLookPath = func(name string) (string, error) { return "/usr/local/bin/" + name, nil }
 
@@ -671,15 +704,18 @@ func TestRunSyncPreservesUnmanagedAdjacentFiles(t *testing.T) {
 	}
 
 	restoreHome := osUserHomeDir
+	restoreBackupHome := backup.UserHomeDirFn
 	restoreCommand := runCommand
 	restoreLookPath := cmdLookPath
 	t.Cleanup(func() {
 		osUserHomeDir = restoreHome
+		backup.UserHomeDirFn = restoreBackupHome
 		runCommand = restoreCommand
 		cmdLookPath = restoreLookPath
 	})
 
 	osUserHomeDir = func() (string, error) { return home, nil }
+	backup.UserHomeDirFn = func() (string, error) { return home, nil }
 	runCommand = func(string, ...string) error { return nil }
 	cmdLookPath = func(name string) (string, error) { return "/usr/local/bin/" + name, nil }
 
@@ -701,15 +737,18 @@ func TestRunSyncPreservesUnmanagedAdjacentFiles(t *testing.T) {
 func TestRunSyncDryRunDoesNotWriteFiles(t *testing.T) {
 	home := t.TempDir()
 	restoreHome := osUserHomeDir
+	restoreBackupHome := backup.UserHomeDirFn
 	restoreCommand := runCommand
 	restoreLookPath := cmdLookPath
 	t.Cleanup(func() {
 		osUserHomeDir = restoreHome
+		backup.UserHomeDirFn = restoreBackupHome
 		runCommand = restoreCommand
 		cmdLookPath = restoreLookPath
 	})
 
 	osUserHomeDir = func() (string, error) { return home, nil }
+	backup.UserHomeDirFn = func() (string, error) { return home, nil }
 	runCommand = func(string, ...string) error { return nil }
 	cmdLookPath = func(name string) (string, error) { return "/usr/local/bin/" + name, nil }
 
@@ -736,15 +775,18 @@ func TestRunSyncDryRunDoesNotWriteFiles(t *testing.T) {
 func TestRunSyncIsIdempotent(t *testing.T) {
 	home := t.TempDir()
 	restoreHome := osUserHomeDir
+	restoreBackupHome := backup.UserHomeDirFn
 	restoreCommand := runCommand
 	restoreLookPath := cmdLookPath
 	t.Cleanup(func() {
 		osUserHomeDir = restoreHome
+		backup.UserHomeDirFn = restoreBackupHome
 		runCommand = restoreCommand
 		cmdLookPath = restoreLookPath
 	})
 
 	osUserHomeDir = func() (string, error) { return home, nil }
+	backup.UserHomeDirFn = func() (string, error) { return home, nil }
 	runCommand = func(string, ...string) error { return nil }
 	cmdLookPath = func(name string) (string, error) { return "/usr/local/bin/" + name, nil }
 
@@ -836,15 +878,18 @@ func TestRunSyncNoOpWhenNoAgentsDiscovered(t *testing.T) {
 func TestRenderSyncReportIncludesManagedActions(t *testing.T) {
 	home := t.TempDir()
 	restoreHome := osUserHomeDir
+	restoreBackupHome := backup.UserHomeDirFn
 	restoreCommand := runCommand
 	restoreLookPath := cmdLookPath
 	t.Cleanup(func() {
 		osUserHomeDir = restoreHome
+		backup.UserHomeDirFn = restoreBackupHome
 		runCommand = restoreCommand
 		cmdLookPath = restoreLookPath
 	})
 
 	osUserHomeDir = func() (string, error) { return home, nil }
+	backup.UserHomeDirFn = func() (string, error) { return home, nil }
 	runCommand = func(string, ...string) error { return nil }
 	cmdLookPath = func(name string) (string, error) { return "/usr/bin/" + name, nil }
 
@@ -892,15 +937,18 @@ func TestRunSyncExcludesUnmanagedLookalikeFile(t *testing.T) {
 	}
 
 	restoreHome := osUserHomeDir
+	restoreBackupHome := backup.UserHomeDirFn
 	restoreCommand := runCommand
 	restoreLookPath := cmdLookPath
 	t.Cleanup(func() {
 		osUserHomeDir = restoreHome
+		backup.UserHomeDirFn = restoreBackupHome
 		runCommand = restoreCommand
 		cmdLookPath = restoreLookPath
 	})
 
 	osUserHomeDir = func() (string, error) { return home, nil }
+	backup.UserHomeDirFn = func() (string, error) { return home, nil }
 	runCommand = func(string, ...string) error { return nil }
 	cmdLookPath = func(name string) (string, error) { return "/usr/bin/" + name, nil }
 
@@ -936,15 +984,18 @@ func TestRunSyncExcludesUnmanagedLookalikeFile(t *testing.T) {
 func TestRunSyncNoOpWhenAssetsAlreadyCurrent(t *testing.T) {
 	home := t.TempDir()
 	restoreHome := osUserHomeDir
+	restoreBackupHome := backup.UserHomeDirFn
 	restoreCommand := runCommand
 	restoreLookPath := cmdLookPath
 	t.Cleanup(func() {
 		osUserHomeDir = restoreHome
+		backup.UserHomeDirFn = restoreBackupHome
 		runCommand = restoreCommand
 		cmdLookPath = restoreLookPath
 	})
 
 	osUserHomeDir = func() (string, error) { return home, nil }
+	backup.UserHomeDirFn = func() (string, error) { return home, nil }
 	runCommand = func(string, ...string) error { return nil }
 	cmdLookPath = func(name string) (string, error) { return "/usr/bin/" + name, nil }
 
@@ -990,15 +1041,18 @@ func TestRunSyncNoOpWhenAssetsAlreadyCurrent(t *testing.T) {
 func TestSyncActionsExecutedReflectsChangedFiles(t *testing.T) {
 	home := t.TempDir()
 	restoreHome := osUserHomeDir
+	restoreBackupHome := backup.UserHomeDirFn
 	restoreCommand := runCommand
 	restoreLookPath := cmdLookPath
 	t.Cleanup(func() {
 		osUserHomeDir = restoreHome
+		backup.UserHomeDirFn = restoreBackupHome
 		runCommand = restoreCommand
 		cmdLookPath = restoreLookPath
 	})
 
 	osUserHomeDir = func() (string, error) { return home, nil }
+	backup.UserHomeDirFn = func() (string, error) { return home, nil }
 	runCommand = func(string, ...string) error { return nil }
 	cmdLookPath = func(name string) (string, error) { return "/usr/bin/" + name, nil }
 
@@ -1930,15 +1984,18 @@ func TestBuildSyncSelectionSDDProfileStrategyForwarded(t *testing.T) {
 func TestRunSyncLoadsPersistedModelAssignments(t *testing.T) {
 	home := t.TempDir()
 	restoreHome := osUserHomeDir
+	restoreBackupHome := backup.UserHomeDirFn
 	restoreCommand := runCommand
 	restoreLookPath := cmdLookPath
 	t.Cleanup(func() {
 		osUserHomeDir = restoreHome
+		backup.UserHomeDirFn = restoreBackupHome
 		runCommand = restoreCommand
 		cmdLookPath = restoreLookPath
 	})
 
 	osUserHomeDir = func() (string, error) { return home, nil }
+	backup.UserHomeDirFn = func() (string, error) { return home, nil }
 	runCommand = func(string, ...string) error { return nil }
 	cmdLookPath = func(name string) (string, error) { return "/usr/local/bin/" + name, nil }
 
@@ -1988,15 +2045,18 @@ func TestRunSyncLoadsPersistedModelAssignments(t *testing.T) {
 func TestRunSyncDoesNotOverridePersistedAssignmentsOnSecondSync(t *testing.T) {
 	home := t.TempDir()
 	restoreHome := osUserHomeDir
+	restoreBackupHome := backup.UserHomeDirFn
 	restoreCommand := runCommand
 	restoreLookPath := cmdLookPath
 	t.Cleanup(func() {
 		osUserHomeDir = restoreHome
+		backup.UserHomeDirFn = restoreBackupHome
 		runCommand = restoreCommand
 		cmdLookPath = restoreLookPath
 	})
 
 	osUserHomeDir = func() (string, error) { return home, nil }
+	backup.UserHomeDirFn = func() (string, error) { return home, nil }
 	runCommand = func(string, ...string) error { return nil }
 	cmdLookPath = func(name string) (string, error) { return "/usr/local/bin/" + name, nil }
 
@@ -2043,15 +2103,18 @@ func TestRunSyncDoesNotOverridePersistedAssignmentsOnSecondSync(t *testing.T) {
 func TestRunSyncWithNoPersistedAssignmentsDoesNotPanic(t *testing.T) {
 	home := t.TempDir()
 	restoreHome := osUserHomeDir
+	restoreBackupHome := backup.UserHomeDirFn
 	restoreCommand := runCommand
 	restoreLookPath := cmdLookPath
 	t.Cleanup(func() {
 		osUserHomeDir = restoreHome
+		backup.UserHomeDirFn = restoreBackupHome
 		runCommand = restoreCommand
 		cmdLookPath = restoreLookPath
 	})
 
 	osUserHomeDir = func() (string, error) { return home, nil }
+	backup.UserHomeDirFn = func() (string, error) { return home, nil }
 	runCommand = func(string, ...string) error { return nil }
 	cmdLookPath = func(name string) (string, error) { return "/usr/local/bin/" + name, nil }
 
@@ -2074,5 +2137,150 @@ func TestRunSyncWithNoPersistedAssignmentsDoesNotPanic(t *testing.T) {
 	// Should work fine — empty maps, no panic.
 	if len(result.Selection.ClaudeModelAssignments) != 0 {
 		t.Errorf("expected empty ClaudeModelAssignments, got %v", result.Selection.ClaudeModelAssignments)
+	}
+}
+
+// ─── Phase 2: Persona-in-sync regression tests ─────────────────────────────
+
+func setSyncTestHome(t *testing.T, home string) {
+	t.Helper()
+	rOSHome := osUserHomeDir
+	rBackup := backup.UserHomeDirFn
+	rRun := runCommand
+	rLook := cmdLookPath
+	t.Cleanup(func() {
+		osUserHomeDir = rOSHome
+		backup.UserHomeDirFn = rBackup
+		runCommand = rRun
+		cmdLookPath = rLook
+	})
+	osUserHomeDir = func() (string, error) { return home, nil }
+	backup.UserHomeDirFn = func() (string, error) { return home, nil }
+	runCommand = func(string, ...string) error { return nil }
+	cmdLookPath = func(name string) (string, error) { return "/usr/local/bin/" + name, nil }
+}
+
+// TestBuildSyncSelectionDoesNotHardcodePersona verifies that BuildSyncSelection
+// leaves Persona empty so RunSync can resolve it from state.
+func TestBuildSyncSelectionDoesNotHardcodePersona(t *testing.T) {
+	sel := BuildSyncSelection(SyncFlags{}, []model.AgentID{model.AgentOpenCode})
+	if sel.Persona != "" {
+		t.Errorf("BuildSyncSelection().Persona = %q, want empty (state-resolved)", sel.Persona)
+	}
+}
+
+// TestSyncPersonaPathsExcludeOpenCodeAgentJson verifies the install/sync
+// contract split: syncPersonaPaths must NOT declare opencode.json (that JSON
+// merge is install-only because it conflicts with SDD).
+func TestSyncPersonaPathsExcludeOpenCodeAgentJson(t *testing.T) {
+	home := t.TempDir()
+	reg, _ := agents.NewDefaultRegistry()
+	a, _ := reg.Get(model.AgentOpenCode)
+
+	paths := syncPersonaPaths(home, model.Selection{Persona: model.PersonaGentleman}, []agents.Adapter{a})
+
+	settingsPath := filepath.Join(home, ".config", "opencode", "opencode.json")
+	for _, p := range paths {
+		if p == settingsPath {
+			t.Errorf("syncPersonaPaths should NOT declare opencode.json (install-only); got %v", paths)
+		}
+	}
+}
+
+// TestRunSyncRegeneratesPersonaBlockBetweenMarkers verifies the core fix:
+// when an old persona block lives between markers, sync replaces it with the
+// embedded asset for the current version.
+func TestRunSyncRegeneratesPersonaBlockBetweenMarkers(t *testing.T) {
+	home := t.TempDir()
+	setSyncTestHome(t, home)
+
+	if err := os.MkdirAll(filepath.Join(home, ".claude"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	// Write a stale managed persona block — what an older version of gentle-ai
+	// would have emitted. The sync must replace this with the v1.26 directive.
+	stalePersona := "# pre-existing notes by user\n\n" +
+		"<!-- gentle-ai:persona -->\n" +
+		"## Skills (Auto-load based on context)\n\nstale 2-row table here.\n" +
+		"<!-- /gentle-ai:persona -->\n"
+	claudeMD := filepath.Join(home, ".claude", "CLAUDE.md")
+	if err := os.WriteFile(claudeMD, []byte(stalePersona), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if err := state.Write(home, state.InstallState{
+		InstalledAgents: []string{"claude-code"},
+		Persona:         "gentleman",
+	}); err != nil {
+		t.Fatalf("state.Write: %v", err)
+	}
+
+	if _, err := RunSync([]string{"--agents", "claude-code", "--sdd-mode", "single"}); err != nil {
+		t.Fatalf("RunSync() error = %v", err)
+	}
+
+	body, err := os.ReadFile(claudeMD)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	got := string(body)
+	if !strings.Contains(got, "# pre-existing notes by user") {
+		t.Errorf("CLAUDE.md content outside markers was not preserved; got:\n%s", got)
+	}
+	if strings.Contains(got, "Skills (Auto-load based on context)") {
+		t.Errorf("CLAUDE.md still contains the stale Auto-load table; got:\n%s", got)
+	}
+	if !strings.Contains(got, "Contextual Skill Loading (MANDATORY)") {
+		t.Errorf("CLAUDE.md missing the new Contextual Skill Loading directive; got:\n%s", got)
+	}
+}
+
+// TestRunSyncReadsPersonaFromState verifies that sync uses the persona the
+// user installed (from state.json) rather than always defaulting to Gentleman.
+func TestRunSyncReadsPersonaFromState(t *testing.T) {
+	home := t.TempDir()
+	setSyncTestHome(t, home)
+
+	if err := os.MkdirAll(filepath.Join(home, ".claude"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := state.Write(home, state.InstallState{
+		InstalledAgents: []string{"claude-code"},
+		Persona:         "neutral",
+	}); err != nil {
+		t.Fatalf("state.Write: %v", err)
+	}
+
+	res, err := RunSync([]string{"--agents", "claude-code", "--sdd-mode", "single"})
+	if err != nil {
+		t.Fatalf("RunSync() error = %v", err)
+	}
+	if got, want := res.Selection.Persona, model.PersonaNeutral; got != want {
+		t.Errorf("Selection.Persona = %q, want %q (read from state.json)", got, want)
+	}
+}
+
+// TestRunSyncFallsBackToGentlemanWhenStateLacksPersona verifies the backward
+// compatibility path: state files written before persona persistence still
+// produce a working sync.
+func TestRunSyncFallsBackToGentlemanWhenStateLacksPersona(t *testing.T) {
+	home := t.TempDir()
+	setSyncTestHome(t, home)
+
+	if err := os.MkdirAll(filepath.Join(home, ".claude"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := state.Write(home, state.InstallState{
+		InstalledAgents: []string{"claude-code"},
+		// No Persona field — pre-feature state.
+	}); err != nil {
+		t.Fatalf("state.Write: %v", err)
+	}
+
+	res, err := RunSync([]string{"--agents", "claude-code", "--sdd-mode", "single"})
+	if err != nil {
+		t.Fatalf("RunSync() error = %v", err)
+	}
+	if got, want := res.Selection.Persona, model.PersonaGentleman; got != want {
+		t.Errorf("Selection.Persona = %q, want %q (fallback for pre-feature state)", got, want)
 	}
 }

--- a/internal/components/persona/inject.go
+++ b/internal/components/persona/inject.go
@@ -32,7 +32,31 @@ var outputStyleOverlayJSON = []byte("{\n  \"outputStyle\": \"Gentleman\"\n}\n")
 // persona injection must not create legacy SDD conductor keys.
 var openCodeAgentOverlayJSON = []byte("{\n  \"agent\": {\n    \"gentleman\": {\n      \"mode\": \"primary\",\n      \"description\": \"Senior Architect mentor - helpful first, challenging when it matters\",\n      \"prompt\": \"{file:./AGENTS.md}\",\n      \"tools\": {\n        \"write\": true,\n        \"edit\": true\n      }\n    }\n  }\n}\n")
 
+// Inject performs a full persona injection: the marker-bound markdown block,
+// the OpenCode/Kilocode `gentleman` agent definition in settings JSON, AND
+// the Claude Code output-style overlay. Used by `gentle-ai install`.
 func Inject(homeDir string, adapter agents.Adapter, persona model.PersonaID) (InjectionResult, error) {
+	return injectInternal(homeDir, adapter, persona, false)
+}
+
+// InjectForSync regenerates the persona assets that `gentle-ai sync` is
+// allowed to touch. It writes:
+//   - The marker-bound persona block in the agent's prompt file (markdown).
+//   - The Gentleman output-style file + outputStyle settings overlay (Claude
+//     Code only — no conflict with other components).
+//
+// It deliberately skips the OpenCode/Kilocode `gentleman` agent definition in
+// opencode.json/kilocode.json: that JSON merge shares the "agent" key with
+// SDD's gentle-orchestrator overlay, so running both in the same sync clobbers
+// each other's entries and breaks idempotency. That overlay remains an
+// install-only concern.
+func InjectForSync(homeDir string, adapter agents.Adapter, persona model.PersonaID) (InjectionResult, error) {
+	return injectInternal(homeDir, adapter, persona, true)
+}
+
+// syncManaged is the internal flag previously called `markdownOnly`.
+// When true the OpenCode/Kilocode agent overlay is skipped (see InjectForSync).
+func injectInternal(homeDir string, adapter agents.Adapter, persona model.PersonaID, syncManaged bool) (InjectionResult, error) {
 	if !adapter.SupportsSystemPrompt() {
 		return InjectionResult{}, nil
 	}
@@ -280,7 +304,11 @@ func Inject(homeDir string, adapter agents.Adapter, persona model.PersonaID) (In
 	}
 
 	// 2. OpenCode/Kilocode agent definitions — Tab-switchable agents in settings.
-	if (adapter.Agent() == model.AgentOpenCode || adapter.Agent() == model.AgentKilocode) && persona != model.PersonaCustom {
+	// Skipped under syncManaged because this overlay shares the "agent" key in
+	// opencode.json with SDD's gentle-orchestrator overlay; running both in the
+	// same sync (in either order) makes them clobber each other's entries and
+	// breaks idempotency. Install handles this overlay once at install time.
+	if !syncManaged && (adapter.Agent() == model.AgentOpenCode || adapter.Agent() == model.AgentKilocode) && persona != model.PersonaCustom {
 		settingsPath := adapter.SettingsPath(homeDir)
 		if settingsPath != "" {
 			agentResult, err := mergeJSONFile(settingsPath, openCodeAgentOverlayJSON)

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -34,6 +34,13 @@ type InstallState struct {
 
 	// ModelAssignments maps sub-agent names to provider/model pairs (OpenCode).
 	ModelAssignments map[string]ModelAssignmentState `json:"model_assignments,omitempty"`
+
+	// Persona records the persona the user installed ("gentleman", "neutral",
+	// "custom"). Persisted so that `gentle-ai sync` regenerates the same persona
+	// the user originally chose instead of defaulting to Gentleman every time.
+	// Empty for state files written before persona persistence was added —
+	// callers fall back to PersonaGentleman in that case.
+	Persona string `json:"persona,omitempty"`
 }
 
 // Path returns the absolute path to the state file for the given home directory.

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -26,6 +26,49 @@ func TestWriteAndRead(t *testing.T) {
 	}
 }
 
+// TestPersonaRoundTrip verifies the Persona field round-trips through
+// Write/Read. Both `gentle-ai install` (CLI in run.go) and the TUI app
+// (internal/app/app.go) write this field after a successful install so that
+// `gentle-ai sync` regenerates the persona the user actually selected — not a
+// hard-coded default.
+func TestPersonaRoundTrip(t *testing.T) {
+	for _, persona := range []string{"gentleman", "neutral", "custom"} {
+		t.Run(persona, func(t *testing.T) {
+			home := t.TempDir()
+			if err := Write(home, InstallState{
+				InstalledAgents: []string{"claude-code"},
+				Persona:         persona,
+			}); err != nil {
+				t.Fatalf("Write() error = %v", err)
+			}
+			s, err := Read(home)
+			if err != nil {
+				t.Fatalf("Read() error = %v", err)
+			}
+			if s.Persona != persona {
+				t.Errorf("Persona = %q, want %q", s.Persona, persona)
+			}
+		})
+	}
+}
+
+// TestPersonaBackwardCompat verifies that state files written before persona
+// persistence (no `persona` JSON field) still read cleanly with an empty
+// Persona, allowing the sync fallback to take over.
+func TestPersonaBackwardCompat(t *testing.T) {
+	home := t.TempDir()
+	if err := Write(home, InstallState{InstalledAgents: []string{"claude-code"}}); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	s, err := Read(home)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if s.Persona != "" {
+		t.Errorf("Persona = %q, want empty for pre-feature state", s.Persona)
+	}
+}
+
 // TestWriteCreatesStateDir verifies that Write creates the .gentle-ai directory
 // when it does not exist yet.
 func TestWriteCreatesStateDir(t *testing.T) {


### PR DESCRIPTION
Closes #437

## Type

- [x] Bug fix

## Summary

- \`gentle-ai sync\` now regenerates the marker-bound persona block on every run, so \`brew upgrade gentle-ai && gentle-ai sync\` actually propagates v1.26 persona changes to users instead of leaving them with the deprecated v1.25 block.
- Introduces \`persona.InjectForSync\` as the sync-safe entry point: writes the marker-bound markdown plus the Claude output-style overlay, but skips the OpenCode/Kilocode agent overlay in opencode.json (write-conflict with SDD's \`gentle-orchestrator\` overlay broke idempotency).
- Persists the user-selected persona in \`state.InstallState\` from both CLI and TUI install paths so sync regenerates the actual choice (Gentleman / Neutral) instead of always defaulting to Gentleman.

## Changes

| File | Change |
|------|--------|
| \`internal/cli/sync.go\` | \`ComponentPersona\` in default scope; \`syncComponentPaths\` / \`syncPersonaPaths\` separated from install paths; reads \`state.Persona\` with Gentleman fallback for pre-feature state |
| \`internal/components/persona/inject.go\` | New \`InjectForSync\` (sync-safe) alongside existing \`Inject\` (full install); shared \`injectInternal\` with \`syncManaged\` flag |
| \`internal/cli/run.go\` | CLI install writes \`Persona\` to state |
| \`internal/app/app.go\` | TUI install writes \`Persona\` to state |
| \`internal/state/state.go\` | New \`Persona string\` field on \`InstallState\` |
| \`internal/cli/sync_test.go\` | New tests: regenerate-block, opencode.json-exclusion, state-driven persona, fallback, no-hardcoded persona; updated existing test to match the new behavior |
| \`internal/state/state_test.go\` | \`TestPersonaRoundTrip\` (gentleman/neutral/custom) + \`TestPersonaBackwardCompat\` |

## Test plan

- [x] \`go test ./...\` green
- [x] \`go vet ./...\` green
- [x] Manual smoke: stale block between \`<!-- gentle-ai:persona -->\` markers + user content outside markers → after \`gentle-ai sync\`, user content preserved verbatim, stale block replaced with the v1.26 directive, no \`opencode.json\` mutation.

## Contributor checklist

- [x] Linked an approved issue (#437)
- [x] Added exactly one \`type:*\` label (\`type:bug\`)
- [x] Conventional commit
- [x] No \`Co-Authored-By\` trailers
- [x] Within 400-line cognitive review budget (397 changed lines)
- [x] No unrelated files in the diff (worktree-only artifacts excluded)