### PR TITLE
fix(deps): upgrade Go 1.24.2 → 1.25.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: "1.25"
 
       - name: Run unit tests
         run: go test ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version-file: go.mod
 
       - name: Run unit tests
         run: go test ./...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: "1.25"
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version-file: go.mod
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6

--- a/e2e/Dockerfile.fedora
+++ b/e2e/Dockerfile.fedora
@@ -7,11 +7,11 @@ FROM fedora:43
 # System dependencies (includes npm/node for claude-code tests)
 # ---------------------------------------------------------------------------
 RUN dnf install -y \
-        git \
-        curl \
-        sudo \
-        ca-certificates \
-        @development-tools \
+    git \
+    curl \
+    sudo \
+    ca-certificates \
+    @development-tools \
     && dnf clean all
 
 # ---------------------------------------------------------------------------
@@ -23,7 +23,7 @@ RUN curl -fsSL https://rpm.nodesource.com/setup_lts.x | bash - && \
 # ---------------------------------------------------------------------------
 # Install Go (match go.mod version)
 # ---------------------------------------------------------------------------
-ARG GO_VERSION=1.24.2
+ARG GO_VERSION=1.25.9
 RUN curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" \
     | tar -C /usr/local -xz
 ENV PATH="/usr/local/go/bin:${PATH}"

--- a/e2e/Dockerfile.ubuntu
+++ b/e2e/Dockerfile.ubuntu
@@ -12,14 +12,14 @@ ARG DEBIAN_FRONTEND=noninteractive
 # runners live in Azure, so this is LAN-speed and avoids stalls on the default
 # regional mirror lottery (commit 5f6af97 had to extend the CI timeout for that).
 RUN sed -i 's|http://archive.ubuntu.com|http://azure.archive.ubuntu.com|g; \
-            s|http://security.ubuntu.com|http://azure.archive.ubuntu.com|g' \
-            /etc/apt/sources.list && \
+    s|http://security.ubuntu.com|http://azure.archive.ubuntu.com|g' \
+    /etc/apt/sources.list && \
     apt-get update && apt-get install -y --no-install-recommends \
-        git \
-        curl \
-        sudo \
-        ca-certificates \
-        build-essential \
+    git \
+    curl \
+    sudo \
+    ca-certificates \
+    build-essential \
     && rm -rf /var/lib/apt/lists/*
 
 # ---------------------------------------------------------------------------
@@ -31,7 +31,7 @@ RUN curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - && \
 # ---------------------------------------------------------------------------
 # Install Go (match go.mod version)
 # ---------------------------------------------------------------------------
-ARG GO_VERSION=1.24.2
+ARG GO_VERSION=1.25.9
 RUN curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" \
     | tar -C /usr/local -xz
 ENV PATH="/usr/local/go/bin:${PATH}"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gentleman-programming/gentle-ai
 
-go 1.24
+go 1.25.9
 
 require (
 	github.com/charmbracelet/bubbles v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gentleman-programming/gentle-ai
 
-go 1.24.2
+go 1.25.9
 
 require (
 	github.com/charmbracelet/bubbles v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gentleman-programming/gentle-ai
 
-go 1.25.9
+go 1.24
 
 require (
 	github.com/charmbracelet/bubbles v1.0.0

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -2,7 +2,7 @@
 schema: spec-driven
 
 context: |
-  Tech stack: Go 1.24.2, Bubbletea TUI (charmbracelet/bubbletea v1.3.10), lipgloss v1.1.0
+  Tech stack: Go 1.25.9, Bubbletea TUI (charmbracelet/bubbletea v1.3.10), lipgloss v1.1.0
   Architecture: cmd/ entrypoints, internal/ packages (agents, tui, model, pipeline, catalog, system, planner, verify, update, opencode, installcmd, cli, app, components, state, backup, assets, agentbuilder)
   Feature branch: feat/claude-contextual-skill-loading — contextual skill loading from Claude Code
   Agents: multi-agent support (claude, opencode, cursor, codex, gemini, vscode, windsurf, antigravity)


### PR DESCRIPTION
## Motivación
Go 1.24.2 acumula múltiples CVEs activos en su librería estándar. Se actualiza a 1.25.9 que incluye los parches de seguridad correspondientes.

## Cambios
- `go.mod`: go 1.24.2 → 1.25.9
- CI workflows (ci.yml, release.yml): go-version 1.24 → 1.25
- E2E Dockerfiles (ubuntu, fedora): GO_VERSION 1.24.2 → 1.25.9
- `openspec/config.yaml`: contexto actualizado

## Verificación
- [x] `go build ./...` — compila sin errores
- [x] `go vet ./...` — sin warnings
- [x] Tests pasan (fallos preexistentes no relacionados al upgrade)
- [x] Zero breaking changes entre Go 1.24 y 1.25