### PR TITLE
fix(skills): unify {project-name} to {project} in SDD templates

### DIFF
--- a/internal/assets/skills/_shared/engram-convention.md
+++ b/internal/assets/skills/_shared/engram-convention.md
@@ -31,7 +31,7 @@ Set `capture_prompt: false` when the Engram tool schema supports it; if an older
 | `archive-report` | sdd-archive | Archive closure with lineage |
 | `state` | orchestrator | DAG state for recovery after compaction |
 
-Exception: `sdd-init` uses `sdd-init/{project-name}` as both title and topic_key.
+
 
 ### State Artifact
 

--- a/internal/assets/skills/sdd-init/SKILL.md
+++ b/internal/assets/skills/sdd-init/SKILL.md
@@ -21,10 +21,10 @@ You are an EXECUTOR for this phase, not the orchestrator. Do the initialization 
   **Save project context**:
   ```
   mem_save(
-    title: "sdd-init/{project-name}",
-    topic_key: "sdd-init/{project-name}",
+    title: "sdd-init/{project}",
+    topic_key: "sdd-init/{project}",
     type: "architecture",
-    project: "{project-name}",
+    project: "{project}",
     capture_prompt: false,
     content: "{detected project context markdown}"
   )
@@ -178,10 +178,10 @@ Persist detected testing capabilities as a separate Engram observation (or secti
 If mode is `engram` or `hybrid`:
 ```
 mem_save(
-  title: "sdd/{project-name}/testing-capabilities",
-  topic_key: "sdd/{project-name}/testing-capabilities",
+  title: "sdd/{project}/testing-capabilities",
+  topic_key: "sdd/{project}/testing-capabilities",
   type: "config",
-  project: "{project-name}",
+  project: "{project}",
   capture_prompt: false,
   content: "{testing capabilities markdown — see format below}"
 )
@@ -239,10 +239,10 @@ See `skills/skill-registry/SKILL.md` for the full registry format and scanning d
 If mode is `engram`:
 ```
 mem_save(
-  title: "sdd-init/{project-name}",
-  topic_key: "sdd-init/{project-name}",
+  title: "sdd-init/{project}",
+  topic_key: "sdd-init/{project}",
   type: "architecture",
-  project: "{project-name}",
+  project: "{project}",
   capture_prompt: false,
   content: "{your detected project context from Steps 1-7}"
 )
@@ -259,7 +259,7 @@ Return a structured summary adapted to the resolved mode:
 
 #### If mode is `engram`:
 
-Persist project context following `skills/_shared/engram-convention.md` with title and topic_key `sdd-init/{project-name}`.
+Persist project context following `skills/_shared/engram-convention.md` with title and topic_key `sdd-init/{project}`.
 
 Return:
 ```
@@ -284,9 +284,9 @@ Return:
 ### Context Saved
 Project context persisted to Engram.
 - **Engram ID**: #{observation-id}
-- **Topic key**: sdd-init/{project-name}
+- **Topic key**: sdd-init/{project}
 - **Capabilities ID**: #{capabilities-observation-id}
-- **Capabilities key**: sdd/{project-name}/testing-capabilities
+- **Capabilities key**: sdd/{project}/testing-capabilities
 
 No project files created.
 

--- a/testdata/golden/sdd-antigravity-skill-sdd-init.golden
+++ b/testdata/golden/sdd-antigravity-skill-sdd-init.golden
@@ -21,10 +21,10 @@ You are an EXECUTOR for this phase, not the orchestrator. Do the initialization 
   **Save project context**:
   ```
   mem_save(
-    title: "sdd-init/{project-name}",
-    topic_key: "sdd-init/{project-name}",
+    title: "sdd-init/{project}",
+    topic_key: "sdd-init/{project}",
     type: "architecture",
-    project: "{project-name}",
+    project: "{project}",
     capture_prompt: false,
     content: "{detected project context markdown}"
   )
@@ -178,10 +178,10 @@ Persist detected testing capabilities as a separate Engram observation (or secti
 If mode is `engram` or `hybrid`:
 ```
 mem_save(
-  title: "sdd/{project-name}/testing-capabilities",
-  topic_key: "sdd/{project-name}/testing-capabilities",
+  title: "sdd/{project}/testing-capabilities",
+  topic_key: "sdd/{project}/testing-capabilities",
   type: "config",
-  project: "{project-name}",
+  project: "{project}",
   capture_prompt: false,
   content: "{testing capabilities markdown — see format below}"
 )
@@ -239,10 +239,10 @@ See `skills/skill-registry/SKILL.md` for the full registry format and scanning d
 If mode is `engram`:
 ```
 mem_save(
-  title: "sdd-init/{project-name}",
-  topic_key: "sdd-init/{project-name}",
+  title: "sdd-init/{project}",
+  topic_key: "sdd-init/{project}",
   type: "architecture",
-  project: "{project-name}",
+  project: "{project}",
   capture_prompt: false,
   content: "{your detected project context from Steps 1-7}"
 )
@@ -259,7 +259,7 @@ Return a structured summary adapted to the resolved mode:
 
 #### If mode is `engram`:
 
-Persist project context following `skills/_shared/engram-convention.md` with title and topic_key `sdd-init/{project-name}`.
+Persist project context following `skills/_shared/engram-convention.md` with title and topic_key `sdd-init/{project}`.
 
 Return:
 ```
@@ -284,9 +284,9 @@ Return:
 ### Context Saved
 Project context persisted to Engram.
 - **Engram ID**: #{observation-id}
-- **Topic key**: sdd-init/{project-name}
+- **Topic key**: sdd-init/{project}
 - **Capabilities ID**: #{capabilities-observation-id}
-- **Capabilities key**: sdd/{project-name}/testing-capabilities
+- **Capabilities key**: sdd/{project}/testing-capabilities
 
 No project files created.
 

--- a/testdata/golden/sdd-codex-skill-sdd-init.golden
+++ b/testdata/golden/sdd-codex-skill-sdd-init.golden
@@ -21,10 +21,10 @@ You are an EXECUTOR for this phase, not the orchestrator. Do the initialization 
   **Save project context**:
   ```
   mem_save(
-    title: "sdd-init/{project-name}",
-    topic_key: "sdd-init/{project-name}",
+    title: "sdd-init/{project}",
+    topic_key: "sdd-init/{project}",
     type: "architecture",
-    project: "{project-name}",
+    project: "{project}",
     capture_prompt: false,
     content: "{detected project context markdown}"
   )
@@ -178,10 +178,10 @@ Persist detected testing capabilities as a separate Engram observation (or secti
 If mode is `engram` or `hybrid`:
 ```
 mem_save(
-  title: "sdd/{project-name}/testing-capabilities",
-  topic_key: "sdd/{project-name}/testing-capabilities",
+  title: "sdd/{project}/testing-capabilities",
+  topic_key: "sdd/{project}/testing-capabilities",
   type: "config",
-  project: "{project-name}",
+  project: "{project}",
   capture_prompt: false,
   content: "{testing capabilities markdown — see format below}"
 )
@@ -239,10 +239,10 @@ See `skills/skill-registry/SKILL.md` for the full registry format and scanning d
 If mode is `engram`:
 ```
 mem_save(
-  title: "sdd-init/{project-name}",
-  topic_key: "sdd-init/{project-name}",
+  title: "sdd-init/{project}",
+  topic_key: "sdd-init/{project}",
   type: "architecture",
-  project: "{project-name}",
+  project: "{project}",
   capture_prompt: false,
   content: "{your detected project context from Steps 1-7}"
 )
@@ -259,7 +259,7 @@ Return a structured summary adapted to the resolved mode:
 
 #### If mode is `engram`:
 
-Persist project context following `skills/_shared/engram-convention.md` with title and topic_key `sdd-init/{project-name}`.
+Persist project context following `skills/_shared/engram-convention.md` with title and topic_key `sdd-init/{project}`.
 
 Return:
 ```
@@ -284,9 +284,9 @@ Return:
 ### Context Saved
 Project context persisted to Engram.
 - **Engram ID**: #{observation-id}
-- **Topic key**: sdd-init/{project-name}
+- **Topic key**: sdd-init/{project}
 - **Capabilities ID**: #{capabilities-observation-id}
-- **Capabilities key**: sdd/{project-name}/testing-capabilities
+- **Capabilities key**: sdd/{project}/testing-capabilities
 
 No project files created.
 

--- a/testdata/golden/sdd-cursor-skill-sdd-init.golden
+++ b/testdata/golden/sdd-cursor-skill-sdd-init.golden
@@ -21,10 +21,10 @@ You are an EXECUTOR for this phase, not the orchestrator. Do the initialization 
   **Save project context**:
   ```
   mem_save(
-    title: "sdd-init/{project-name}",
-    topic_key: "sdd-init/{project-name}",
+    title: "sdd-init/{project}",
+    topic_key: "sdd-init/{project}",
     type: "architecture",
-    project: "{project-name}",
+    project: "{project}",
     capture_prompt: false,
     content: "{detected project context markdown}"
   )
@@ -178,10 +178,10 @@ Persist detected testing capabilities as a separate Engram observation (or secti
 If mode is `engram` or `hybrid`:
 ```
 mem_save(
-  title: "sdd/{project-name}/testing-capabilities",
-  topic_key: "sdd/{project-name}/testing-capabilities",
+  title: "sdd/{project}/testing-capabilities",
+  topic_key: "sdd/{project}/testing-capabilities",
   type: "config",
-  project: "{project-name}",
+  project: "{project}",
   capture_prompt: false,
   content: "{testing capabilities markdown — see format below}"
 )
@@ -239,10 +239,10 @@ See `skills/skill-registry/SKILL.md` for the full registry format and scanning d
 If mode is `engram`:
 ```
 mem_save(
-  title: "sdd-init/{project-name}",
-  topic_key: "sdd-init/{project-name}",
+  title: "sdd-init/{project}",
+  topic_key: "sdd-init/{project}",
   type: "architecture",
-  project: "{project-name}",
+  project: "{project}",
   capture_prompt: false,
   content: "{your detected project context from Steps 1-7}"
 )
@@ -259,7 +259,7 @@ Return a structured summary adapted to the resolved mode:
 
 #### If mode is `engram`:
 
-Persist project context following `skills/_shared/engram-convention.md` with title and topic_key `sdd-init/{project-name}`.
+Persist project context following `skills/_shared/engram-convention.md` with title and topic_key `sdd-init/{project}`.
 
 Return:
 ```
@@ -284,9 +284,9 @@ Return:
 ### Context Saved
 Project context persisted to Engram.
 - **Engram ID**: #{observation-id}
-- **Topic key**: sdd-init/{project-name}
+- **Topic key**: sdd-init/{project}
 - **Capabilities ID**: #{capabilities-observation-id}
-- **Capabilities key**: sdd/{project-name}/testing-capabilities
+- **Capabilities key**: sdd/{project}/testing-capabilities
 
 No project files created.
 

--- a/testdata/golden/sdd-gemini-skill-sdd-init.golden
+++ b/testdata/golden/sdd-gemini-skill-sdd-init.golden
@@ -21,10 +21,10 @@ You are an EXECUTOR for this phase, not the orchestrator. Do the initialization 
   **Save project context**:
   ```
   mem_save(
-    title: "sdd-init/{project-name}",
-    topic_key: "sdd-init/{project-name}",
+    title: "sdd-init/{project}",
+    topic_key: "sdd-init/{project}",
     type: "architecture",
-    project: "{project-name}",
+    project: "{project}",
     capture_prompt: false,
     content: "{detected project context markdown}"
   )
@@ -178,10 +178,10 @@ Persist detected testing capabilities as a separate Engram observation (or secti
 If mode is `engram` or `hybrid`:
 ```
 mem_save(
-  title: "sdd/{project-name}/testing-capabilities",
-  topic_key: "sdd/{project-name}/testing-capabilities",
+  title: "sdd/{project}/testing-capabilities",
+  topic_key: "sdd/{project}/testing-capabilities",
   type: "config",
-  project: "{project-name}",
+  project: "{project}",
   capture_prompt: false,
   content: "{testing capabilities markdown — see format below}"
 )
@@ -239,10 +239,10 @@ See `skills/skill-registry/SKILL.md` for the full registry format and scanning d
 If mode is `engram`:
 ```
 mem_save(
-  title: "sdd-init/{project-name}",
-  topic_key: "sdd-init/{project-name}",
+  title: "sdd-init/{project}",
+  topic_key: "sdd-init/{project}",
   type: "architecture",
-  project: "{project-name}",
+  project: "{project}",
   capture_prompt: false,
   content: "{your detected project context from Steps 1-7}"
 )
@@ -259,7 +259,7 @@ Return a structured summary adapted to the resolved mode:
 
 #### If mode is `engram`:
 
-Persist project context following `skills/_shared/engram-convention.md` with title and topic_key `sdd-init/{project-name}`.
+Persist project context following `skills/_shared/engram-convention.md` with title and topic_key `sdd-init/{project}`.
 
 Return:
 ```
@@ -284,9 +284,9 @@ Return:
 ### Context Saved
 Project context persisted to Engram.
 - **Engram ID**: #{observation-id}
-- **Topic key**: sdd-init/{project-name}
+- **Topic key**: sdd-init/{project}
 - **Capabilities ID**: #{capabilities-observation-id}
-- **Capabilities key**: sdd/{project-name}/testing-capabilities
+- **Capabilities key**: sdd/{project}/testing-capabilities
 
 No project files created.
 

--- a/testdata/golden/sdd-kiro-skill-sdd-init.golden
+++ b/testdata/golden/sdd-kiro-skill-sdd-init.golden
@@ -21,10 +21,10 @@ You are an EXECUTOR for this phase, not the orchestrator. Do the initialization 
   **Save project context**:
   ```
   mem_save(
-    title: "sdd-init/{project-name}",
-    topic_key: "sdd-init/{project-name}",
+    title: "sdd-init/{project}",
+    topic_key: "sdd-init/{project}",
     type: "architecture",
-    project: "{project-name}",
+    project: "{project}",
     capture_prompt: false,
     content: "{detected project context markdown}"
   )
@@ -178,10 +178,10 @@ Persist detected testing capabilities as a separate Engram observation (or secti
 If mode is `engram` or `hybrid`:
 ```
 mem_save(
-  title: "sdd/{project-name}/testing-capabilities",
-  topic_key: "sdd/{project-name}/testing-capabilities",
+  title: "sdd/{project}/testing-capabilities",
+  topic_key: "sdd/{project}/testing-capabilities",
   type: "config",
-  project: "{project-name}",
+  project: "{project}",
   capture_prompt: false,
   content: "{testing capabilities markdown — see format below}"
 )
@@ -239,10 +239,10 @@ See `skills/skill-registry/SKILL.md` for the full registry format and scanning d
 If mode is `engram`:
 ```
 mem_save(
-  title: "sdd-init/{project-name}",
-  topic_key: "sdd-init/{project-name}",
+  title: "sdd-init/{project}",
+  topic_key: "sdd-init/{project}",
   type: "architecture",
-  project: "{project-name}",
+  project: "{project}",
   capture_prompt: false,
   content: "{your detected project context from Steps 1-7}"
 )
@@ -259,7 +259,7 @@ Return a structured summary adapted to the resolved mode:
 
 #### If mode is `engram`:
 
-Persist project context following `skills/_shared/engram-convention.md` with title and topic_key `sdd-init/{project-name}`.
+Persist project context following `skills/_shared/engram-convention.md` with title and topic_key `sdd-init/{project}`.
 
 Return:
 ```
@@ -284,9 +284,9 @@ Return:
 ### Context Saved
 Project context persisted to Engram.
 - **Engram ID**: #{observation-id}
-- **Topic key**: sdd-init/{project-name}
+- **Topic key**: sdd-init/{project}
 - **Capabilities ID**: #{capabilities-observation-id}
-- **Capabilities key**: sdd/{project-name}/testing-capabilities
+- **Capabilities key**: sdd/{project}/testing-capabilities
 
 No project files created.
 

--- a/testdata/golden/sdd-opencode-skill-sdd-init.golden
+++ b/testdata/golden/sdd-opencode-skill-sdd-init.golden
@@ -21,10 +21,10 @@ You are an EXECUTOR for this phase, not the orchestrator. Do the initialization 
   **Save project context**:
   ```
   mem_save(
-    title: "sdd-init/{project-name}",
-    topic_key: "sdd-init/{project-name}",
+    title: "sdd-init/{project}",
+    topic_key: "sdd-init/{project}",
     type: "architecture",
-    project: "{project-name}",
+    project: "{project}",
     capture_prompt: false,
     content: "{detected project context markdown}"
   )
@@ -178,10 +178,10 @@ Persist detected testing capabilities as a separate Engram observation (or secti
 If mode is `engram` or `hybrid`:
 ```
 mem_save(
-  title: "sdd/{project-name}/testing-capabilities",
-  topic_key: "sdd/{project-name}/testing-capabilities",
+  title: "sdd/{project}/testing-capabilities",
+  topic_key: "sdd/{project}/testing-capabilities",
   type: "config",
-  project: "{project-name}",
+  project: "{project}",
   capture_prompt: false,
   content: "{testing capabilities markdown — see format below}"
 )
@@ -239,10 +239,10 @@ See `skills/skill-registry/SKILL.md` for the full registry format and scanning d
 If mode is `engram`:
 ```
 mem_save(
-  title: "sdd-init/{project-name}",
-  topic_key: "sdd-init/{project-name}",
+  title: "sdd-init/{project}",
+  topic_key: "sdd-init/{project}",
   type: "architecture",
-  project: "{project-name}",
+  project: "{project}",
   capture_prompt: false,
   content: "{your detected project context from Steps 1-7}"
 )
@@ -259,7 +259,7 @@ Return a structured summary adapted to the resolved mode:
 
 #### If mode is `engram`:
 
-Persist project context following `skills/_shared/engram-convention.md` with title and topic_key `sdd-init/{project-name}`.
+Persist project context following `skills/_shared/engram-convention.md` with title and topic_key `sdd-init/{project}`.
 
 Return:
 ```
@@ -284,9 +284,9 @@ Return:
 ### Context Saved
 Project context persisted to Engram.
 - **Engram ID**: #{observation-id}
-- **Topic key**: sdd-init/{project-name}
+- **Topic key**: sdd-init/{project}
 - **Capabilities ID**: #{capabilities-observation-id}
-- **Capabilities key**: sdd/{project-name}/testing-capabilities
+- **Capabilities key**: sdd/{project}/testing-capabilities
 
 No project files created.
 

--- a/testdata/golden/sdd-vscode-skill-sdd-init.golden
+++ b/testdata/golden/sdd-vscode-skill-sdd-init.golden
@@ -21,10 +21,10 @@ You are an EXECUTOR for this phase, not the orchestrator. Do the initialization 
   **Save project context**:
   ```
   mem_save(
-    title: "sdd-init/{project-name}",
-    topic_key: "sdd-init/{project-name}",
+    title: "sdd-init/{project}",
+    topic_key: "sdd-init/{project}",
     type: "architecture",
-    project: "{project-name}",
+    project: "{project}",
     capture_prompt: false,
     content: "{detected project context markdown}"
   )
@@ -178,10 +178,10 @@ Persist detected testing capabilities as a separate Engram observation (or secti
 If mode is `engram` or `hybrid`:
 ```
 mem_save(
-  title: "sdd/{project-name}/testing-capabilities",
-  topic_key: "sdd/{project-name}/testing-capabilities",
+  title: "sdd/{project}/testing-capabilities",
+  topic_key: "sdd/{project}/testing-capabilities",
   type: "config",
-  project: "{project-name}",
+  project: "{project}",
   capture_prompt: false,
   content: "{testing capabilities markdown — see format below}"
 )
@@ -239,10 +239,10 @@ See `skills/skill-registry/SKILL.md` for the full registry format and scanning d
 If mode is `engram`:
 ```
 mem_save(
-  title: "sdd-init/{project-name}",
-  topic_key: "sdd-init/{project-name}",
+  title: "sdd-init/{project}",
+  topic_key: "sdd-init/{project}",
   type: "architecture",
-  project: "{project-name}",
+  project: "{project}",
   capture_prompt: false,
   content: "{your detected project context from Steps 1-7}"
 )
@@ -259,7 +259,7 @@ Return a structured summary adapted to the resolved mode:
 
 #### If mode is `engram`:
 
-Persist project context following `skills/_shared/engram-convention.md` with title and topic_key `sdd-init/{project-name}`.
+Persist project context following `skills/_shared/engram-convention.md` with title and topic_key `sdd-init/{project}`.
 
 Return:
 ```
@@ -284,9 +284,9 @@ Return:
 ### Context Saved
 Project context persisted to Engram.
 - **Engram ID**: #{observation-id}
-- **Topic key**: sdd-init/{project-name}
+- **Topic key**: sdd-init/{project}
 - **Capabilities ID**: #{capabilities-observation-id}
-- **Capabilities key**: sdd/{project-name}/testing-capabilities
+- **Capabilities key**: sdd/{project}/testing-capabilities
 
 No project files created.
 

--- a/testdata/golden/sdd-windsurf-skill-sdd-init.golden
+++ b/testdata/golden/sdd-windsurf-skill-sdd-init.golden
@@ -21,10 +21,10 @@ You are an EXECUTOR for this phase, not the orchestrator. Do the initialization 
   **Save project context**:
   ```
   mem_save(
-    title: "sdd-init/{project-name}",
-    topic_key: "sdd-init/{project-name}",
+    title: "sdd-init/{project}",
+    topic_key: "sdd-init/{project}",
     type: "architecture",
-    project: "{project-name}",
+    project: "{project}",
     capture_prompt: false,
     content: "{detected project context markdown}"
   )
@@ -178,10 +178,10 @@ Persist detected testing capabilities as a separate Engram observation (or secti
 If mode is `engram` or `hybrid`:
 ```
 mem_save(
-  title: "sdd/{project-name}/testing-capabilities",
-  topic_key: "sdd/{project-name}/testing-capabilities",
+  title: "sdd/{project}/testing-capabilities",
+  topic_key: "sdd/{project}/testing-capabilities",
   type: "config",
-  project: "{project-name}",
+  project: "{project}",
   capture_prompt: false,
   content: "{testing capabilities markdown — see format below}"
 )
@@ -239,10 +239,10 @@ See `skills/skill-registry/SKILL.md` for the full registry format and scanning d
 If mode is `engram`:
 ```
 mem_save(
-  title: "sdd-init/{project-name}",
-  topic_key: "sdd-init/{project-name}",
+  title: "sdd-init/{project}",
+  topic_key: "sdd-init/{project}",
   type: "architecture",
-  project: "{project-name}",
+  project: "{project}",
   capture_prompt: false,
   content: "{your detected project context from Steps 1-7}"
 )
@@ -259,7 +259,7 @@ Return a structured summary adapted to the resolved mode:
 
 #### If mode is `engram`:
 
-Persist project context following `skills/_shared/engram-convention.md` with title and topic_key `sdd-init/{project-name}`.
+Persist project context following `skills/_shared/engram-convention.md` with title and topic_key `sdd-init/{project}`.
 
 Return:
 ```
@@ -284,9 +284,9 @@ Return:
 ### Context Saved
 Project context persisted to Engram.
 - **Engram ID**: #{observation-id}
-- **Topic key**: sdd-init/{project-name}
+- **Topic key**: sdd-init/{project}
 - **Capabilities ID**: #{capabilities-observation-id}
-- **Capabilities key**: sdd/{project-name}/testing-capabilities
+- **Capabilities key**: sdd/{project}/testing-capabilities
 
 No project files created.
 


### PR DESCRIPTION
Closes #453

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)

---

## 📝 Summary

Hola equipo. Este PR arregla un error silencioso que rompía la cadena de fases SDD cuando el nombre del proyecto se resolvía diferente entre `sdd-init` y el resto del pipeline.

El problema era que `sdd-init` usaba la variable legada `{project-name}` mientras que todas las demás fases usaban `{project}`. Cuando el git remote decía `gentle-ai-code` pero la carpeta era `gentle_ai_code`, `sdd-spec` no encontraba el proposal guardado por `sdd-propose` porque buscaban bajo nombres de proyecto distintos.

El fix es mecánico: unificamos todo a `{project}` y eliminamos la nota de excepción que justificaba la inconsistencia.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/assets/skills/sdd-init/SKILL.md` | Replaced 13 occurrences of `{project-name}` → `{project}` |
| `internal/assets/skills/_shared/engram-convention.md` | Removed exception note about `{project-name}` |
| `testdata/golden/*.golden` (×8) | Regenerated snapshots after template change |

---

## 🧪 Test Plan

- [x] Unit tests pass (`go test ./...`)
- [x] Zero `{project-name}` occurrences remain in skill templates (`grep -r '{project-name}' internal/assets/skills/`)
- [x] Golden files regenerated with `go test ./internal/components/ -update`

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:needs-review` (pending maintainer approval for `status:approved`)
- [x] PR stays within 400 changed lines (~20 lines changed)
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

Este es un cambio puro de normalización. No hay lógica nueva ni cambios de comportamiento, solo consistencia en las plantillas. Los tests golden se regeneraron automáticamente porque el contenido esperado cambió al unificar la variable.
