### PR TITLE
fix(upgrade): tap Gentleman-Programming/homebrew-tap before brew upgrade

### DIFF
--- a/internal/update/upgrade/strategy.go
+++ b/internal/update/upgrade/strategy.go
@@ -291,6 +291,15 @@ func openCodePluginRegisteredPendingHint(pkg string) string {
 // network), the upgrade is still attempted using the existing cache — a stale
 // cache is better than no upgrade at all.
 func brewUpgrade(ctx context.Context, toolName string) error {
+	// Ensure the Gentleman-Programming homebrew tap is present before upgrading.
+	// Non-fatal: brew tap is a no-op when already present; if it fails for any other
+	// reason, the subsequent brew upgrade will surface the real error. See issue #455:
+	// without this, a lost tap (untap, machine swap, brew cleanup) makes upgrades fail
+	// with "No available formula" for engram/gga/gentle-ai.
+	tapCmd := execCommand("brew", "tap", "Gentleman-Programming/homebrew-tap")
+	tapCmd.Stdin = nil
+	_ = tapCmd.Run()
+
 	// Update Homebrew formula cache before upgrading.
 	// Non-fatal: if update fails (e.g. no network), attempt upgrade with existing cache.
 	updateCmd := execCommand("brew", "update")

--- a/internal/update/upgrade/strategy_test.go
+++ b/internal/update/upgrade/strategy_test.go
@@ -619,15 +619,15 @@ func TestBrewUpgrade_RunsUpdateBeforeUpgrade(t *testing.T) {
 		t.Fatalf("brewUpgrade: unexpected error: %v", err)
 	}
 
-	// Must have called brew update AND brew upgrade — in that order.
-	if len(callOrder) < 2 {
-		t.Fatalf("expected 2 brew calls (update, upgrade), got %d: %v", len(callOrder), callOrder)
+	// Must have called brew tap, brew update AND brew upgrade — in that order.
+	if len(callOrder) < 3 {
+		t.Fatalf("expected 3 brew calls (tap, update, upgrade), got %d: %v", len(callOrder), callOrder)
 	}
-	if callOrder[0] != "update" {
-		t.Errorf("first brew call = %q, want %q", callOrder[0], "update")
+	if callOrder[1] != "update" {
+		t.Errorf("second brew call = %q, want %q", callOrder[1], "update")
 	}
-	if callOrder[1] != "upgrade" {
-		t.Errorf("second brew call = %q, want %q", callOrder[1], "upgrade")
+	if callOrder[2] != "upgrade" {
+		t.Errorf("third brew call = %q, want %q", callOrder[2], "upgrade")
 	}
 }
 
@@ -658,15 +658,62 @@ func TestBrewUpgrade_UpdateFailureIsNonFatal(t *testing.T) {
 		t.Errorf("expected success when brew update fails but brew upgrade succeeds, got: %v", err)
 	}
 
-	// Both brew update and brew upgrade must have been called.
-	if len(callArgs) < 2 {
-		t.Fatalf("expected 2 brew calls, got %d: %v", len(callArgs), callArgs)
+	// Both brew update and brew upgrade must have been called (after the tap).
+	if len(callArgs) < 3 {
+		t.Fatalf("expected 3 brew calls, got %d: %v", len(callArgs), callArgs)
 	}
-	if callArgs[0] != "update" {
-		t.Errorf("first brew call = %q, want %q", callArgs[0], "update")
+	if callArgs[1] != "update" {
+		t.Errorf("second brew call = %q, want %q", callArgs[1], "update")
 	}
-	if callArgs[1] != "upgrade" {
-		t.Errorf("second brew call = %q, want %q", callArgs[1], "upgrade")
+	if callArgs[2] != "upgrade" {
+		t.Errorf("third brew call = %q, want %q", callArgs[2], "upgrade")
+	}
+}
+
+// --- TestBrewUpgrade_TapsBeforeUpdateAndUpgrade ---
+
+// TestBrewUpgrade_TapsBeforeUpdateAndUpgrade verifies that brewUpgrade calls
+// `brew tap Gentleman-Programming/homebrew-tap` BEFORE `brew update` and
+// `brew upgrade <toolName>`. This makes the upgrade idempotent when a user
+// has lost the tap (untap, machine swap, brew cleanup). See issue #455.
+func TestBrewUpgrade_TapsBeforeUpdateAndUpgrade(t *testing.T) {
+	origExecCommand := execCommand
+	t.Cleanup(func() { execCommand = origExecCommand })
+
+	type call struct {
+		subcommand string
+		arg        string
+	}
+	var calls []call
+	execCommand = func(name string, args ...string) *exec.Cmd {
+		if name == "brew" && len(args) > 0 {
+			c := call{subcommand: args[0]}
+			if len(args) > 1 {
+				c.arg = args[1]
+			}
+			calls = append(calls, c)
+		}
+		return exec.Command("echo", "ok")
+	}
+
+	if err := brewUpgrade(context.Background(), "engram"); err != nil {
+		t.Fatalf("brewUpgrade: unexpected error: %v", err)
+	}
+
+	if len(calls) < 3 {
+		t.Fatalf("expected 3 brew calls (tap, update, upgrade), got %d: %+v", len(calls), calls)
+	}
+	if calls[0].subcommand != "tap" {
+		t.Errorf("first brew call subcommand = %q, want %q", calls[0].subcommand, "tap")
+	}
+	if calls[0].arg != "Gentleman-Programming/homebrew-tap" {
+		t.Errorf("first brew call arg = %q, want %q", calls[0].arg, "Gentleman-Programming/homebrew-tap")
+	}
+	if calls[1].subcommand != "update" {
+		t.Errorf("second brew call = %q, want %q", calls[1].subcommand, "update")
+	}
+	if calls[2].subcommand != "upgrade" {
+		t.Errorf("third brew call = %q, want %q", calls[2].subcommand, "upgrade")
 	}
 }
 


### PR DESCRIPTION
Closes #455

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)

---

## 📝 Summary

`brewUpgrade` assumed the `Gentleman-Programming/homebrew-tap` was already present on the user's machine. When the tap was lost (untap, machine swap, brew cleanup, etc.), every `brew upgrade <tool>` for engram/gga/gentle-ai failed with `Error: No available formula with the name "engram". Did you mean enigma?`. The error message gave the user no path forward.

This patch makes the upgrade idempotent by re-tapping before `brew update` + `brew upgrade`. `brew tap` is a no-op when the tap is already present, so the change is invisible to users with intact state and rescues users who lost it.

Reported by @adrianmoris on Arch/Manjaro Linux running gentle-ai 1.26.1 with linuxbrew.

---

## 📂 Changes

| File | What Changed |
|------|--------------|
| `internal/update/upgrade/strategy.go` | `brewUpgrade` now runs `brew tap Gentleman-Programming/homebrew-tap` before `brew update`. Failure is non-fatal. |
| `internal/update/upgrade/strategy_test.go` | New test `TestBrewUpgrade_TapsBeforeUpdateAndUpgrade` asserts call order tap → update → upgrade. Existing tests adjusted to account for the new tap call. |

---

## 🧪 Test Plan

- [x] Unit tests pass (`go test ./internal/update/upgrade/...`)
- [x] `go vet ./...` clean
- [x] `go build ./...` clean

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved` (#455)
- [x] PR stays well within 400 changed lines
- [x] Unit tests pass
- [x] Conventional Commits format
- [x] No `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

Defensive idempotent fix. The tap call is unconditional because all three tools that use `brewUpgrade` (gentle-ai, engram, gga) come from the same tap, and `brew tap` is cheap when the tap is already present.