### PR TITLE
fix(sdd): hide SDD SKILL.md files from Claude Code / picker

### DIFF
--- a/docs/skill-style-guide.md
+++ b/docs/skill-style-guide.md
@@ -1,0 +1,70 @@
+# LLM-first Skill Style Guide
+
+Use this guide when creating or refactoring skills in this repo. A skill is a **runtime instruction contract for an LLM**, not human-facing documentation: it tells the model when to activate, what rules are non-negotiable, how to decide, what to do, and what to return.
+
+## Required Structure
+
+Every `SKILL.md` MUST use this order unless a section is truly irrelevant:
+
+1. **Frontmatter** — complete metadata for skill discovery.
+2. **Activation Contract** — exact situations that load the skill.
+3. **Hard Rules** — constraints the LLM MUST NOT violate.
+4. **Decision Gates** — short tables or bullets for branching choices.
+5. **Execution Steps** — ordered operational workflow.
+6. **Output Contract** — required final format or artifacts.
+7. **References** — local files only; supporting detail lives outside the skill.
+
+## Frontmatter Rules
+
+- `description` MUST be one physical line, YAML-safe, and quoted.
+- Put trigger words first: `"Trigger: ... . {What the skill does}."`
+- `description` SHOULD be <=160 chars and MUST be <=250 chars.
+- Include complete `name`, `description`, `license`, `metadata.author`, and `metadata.version`.
+- Do NOT add a `Keywords` section; discovery uses frontmatter.
+
+## Body Budget
+
+- Target **180–450 tokens** for the skill body.
+- Recommended maximum: **700 tokens**.
+- Hard maximum: **1000 tokens**. Move examples, schemas, and background into `assets/` or `references/`.
+
+## Writing Rules
+
+### DO
+
+- Write imperative runtime instructions: “Load X”, “Check Y”, “Return Z”.
+- Lead with the activation trigger and hard constraints.
+- Use compact tables for decision gates.
+- Keep examples minimal and executable.
+- Link to local supporting files for details.
+
+### DON'T
+
+- Explain history, motivation, or tutorial background.
+- Duplicate long docs inside the skill.
+- Add generic advice the LLM cannot execute.
+- Use external URLs as primary references.
+- Hide critical rules below examples.
+
+## Supporting Files
+
+- Use `assets/` for templates, schemas, fixtures, or generated examples.
+- Use `references/` for local docs that explain concepts or edge cases.
+- Keep references stable and relative to the skill directory when possible.
+
+## Quality Gates
+
+- Frontmatter is complete, quoted, single-line, and trigger-preserving.
+- Required sections exist in the expected order.
+- Hard rules are testable or observable.
+- Decision gates cover meaningful forks only.
+- Output contract tells the LLM exactly what to return.
+- References point to local files.
+
+## Refactor Checklist
+
+- [ ] Move explanatory prose to local references.
+- [ ] Collapse repeated rules into one hard rule.
+- [ ] Replace prose branches with a decision table.
+- [ ] Trim examples to the smallest useful case.
+- [ ] Recheck description length and trigger words.

--- a/internal/assets/assets_test.go
+++ b/internal/assets/assets_test.go
@@ -88,6 +88,7 @@ func TestAllEmbeddedAssetsAreReadable(t *testing.T) {
 
 		// SDD skills
 		"skills/sdd-init/SKILL.md",
+		"skills/sdd-init/references/init-details.md",
 		"skills/sdd-apply/SKILL.md",
 		"skills/sdd-archive/SKILL.md",
 		"skills/sdd-design/SKILL.md",
@@ -96,7 +97,9 @@ func TestAllEmbeddedAssetsAreReadable(t *testing.T) {
 		"skills/sdd-spec/SKILL.md",
 		"skills/sdd-tasks/SKILL.md",
 		"skills/sdd-verify/SKILL.md",
+		"skills/sdd-verify/references/report-format.md",
 		"skills/skill-registry/SKILL.md",
+		"skills/judgment-day/references/prompts-and-formats.md",
 		"skills/_shared/persistence-contract.md",
 		"skills/_shared/engram-convention.md",
 		"skills/_shared/openspec-convention.md",
@@ -104,7 +107,9 @@ func TestAllEmbeddedAssetsAreReadable(t *testing.T) {
 
 		// Foundation skills
 		"skills/go-testing/SKILL.md",
+		"skills/go-testing/references/examples.md",
 		"skills/skill-creator/SKILL.md",
+		"skills/chained-pr/references/chaining-details.md",
 	}
 
 	for _, path := range expectedFiles {

--- a/internal/assets/skills/_shared/SKILL.md
+++ b/internal/assets/skills/_shared/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: _shared
 description: "Shared SDD references for installed skills. Not invokable."
+disable-model-invocation: true
+user-invocable: false
 license: MIT
 metadata:
   author: gentleman-programming

--- a/internal/assets/skills/chained-pr/SKILL.md
+++ b/internal/assets/skills/chained-pr/SKILL.md
@@ -1,371 +1,50 @@
 ---
 name: chained-pr
-description: "Split oversized changes into chained PRs that protect review focus. Trigger: PRs over 400 lines, stacked PRs, or review slices."
+description: "Trigger: PRs over 400 lines, stacked PRs, review slices. Split oversized changes into chained PRs that protect review focus."
 license: Apache-2.0
 metadata:
   author: gentleman-programming
   version: "1.0"
 ---
 
-## When to Use
+## Activation Contract
 
-Use this skill when:
+Load this skill when a planned PR may exceed **400 changed lines**, SDD forecasts `400-line budget risk: High` or `Chained PRs recommended: Yes`, or the user asks for chained/stacked PRs, review slices, or reviewer-load control.
 
-- A planned PR is likely to exceed **400 changed lines** (`additions + deletions`).
-- An SDD tasks artifact forecasts `400-line budget risk: High` or `Chained PRs recommended: Yes`.
-- A reviewer asks to split a PR for cognitive load, review fatigue, or burnout prevention.
-- You need chained PRs, stacked PRs, or a feature branch with multiple reviewable slices.
-- A change should be reviewed in roughly **60 minutes or less** per PR.
+## Hard Rules
 
-Do not use this skill for small fixes or single-purpose changes that fit comfortably under the review budget.
+- Split PRs over **400 changed lines** unless a maintainer explicitly accepts `size:exception`.
+- Keep each PR reviewable in about **≤60 minutes**.
+- Use one deliverable work unit per PR; keep tests/docs with the unit they verify.
+- State start, end, prior dependencies, follow-up work, and out-of-scope items in every chained PR.
+- Every child PR must include a dependency diagram marking the current PR with `📍`.
+- In Feature Branch Chain, create a draft/no-merge tracker PR; child PR #1 targets the tracker branch, later children target the immediate parent branch.
+- Treat polluted diffs as base bugs: retarget or rebase until only the current work unit appears.
+- Do not mix chain strategies after the user chooses one.
 
-## Critical Rules
+## Decision Gates
 
-| Rule | Requirement |
-|------|-------------|
-| Review budget | **MUST split** when a PR exceeds **400 changed lines** (`additions + deletions`), unless it has maintainer-approved `size:exception` |
-| Review time | Design each PR for an approximately **≤60-minute** human review |
-| Review health | Optimize for sustainable maintainer attention, not just CI compliance |
-| Start and finish | Every chained PR MUST state where it starts, where it ends, what came before, and what comes next |
-| Autonomy | Every chained PR MUST be understandable and verifiable on its own |
-| Scope | One deliverable work unit per PR; do not mix unrelated refactors, features, tests, or docs |
-| Dependencies | State what each PR depends on and what follows next |
-| Exceptions | Use `size:exception` only when a maintainer agrees the large diff is unavoidable |
-| SDD handoff | If SDD forecasts a >400-line workload, honor `delivery_strategy`: ask, auto-chain, or require/record `size:exception` |
-| Visual map | Every chained PR MUST include a dependency diagram that marks the current PR |
-| Tracker PR | If the team chooses Feature Branch Chain, create a draft tracker PR that maps every child PR and stays draft/no-merge until final integration |
-| Child PR base | In Feature Branch Chain, PR #1 targets the feature/tracker branch; every later child PR targets the immediate previous PR branch |
-| Diff source of truth | If a child PR shows previous PR changes, its base is wrong; retarget/rebase until the diff contains only the current work unit |
-| Strategy consistency | Once the user picks a chain strategy, follow it for the entire chain — do not mix stacked and feature branch patterns |
+| Condition | Action |
+|---|---|
+| PR ≤400 changed lines and focused | Keep single PR. |
+| PR >400, each slice can land independently | Use Stacked PRs to main. |
+| PR >400, feature must integrate before main | Use Feature Branch Chain with tracker. |
+| Generated/vendor/migration diff cannot split cleanly | Ask maintainer for `size:exception`. |
+| SDD provides `delivery_strategy` | Follow it before apply/PR creation. |
 
-The goal is not bureaucracy. The goal is preventing reviewer burnout so maintainers can review with care instead of skimming exhausted. Big PRs create fatigue, hide defects, and slow merge velocity.
+## Execution Steps
 
-## Autonomy Requirements
+1. Estimate changed lines and identify independent work units.
+2. Ask for a chain strategy when none is cached and the budget is exceeded.
+3. Create branches/PRs using the chosen strategy only.
+4. Add Chain Context to each PR without replacing the repo PR template.
+5. Verify each PR independently: CI/tests/docs/manual checks, rollback scope, and clean diff.
+6. Keep tracker PR draft/no-merge until all child PRs are reviewed and integrated.
 
-Each chained PR must function as a complete review unit:
+## Output Contract
 
-- **CI green**: checks pass for the PR branch in its intended base context.
-- **Autonomous scope**: the PR has one clear deliverable outcome.
-- **Reasonable rollback**: reverting this PR does not require reverting unrelated work.
-- **Verification included**: tests, docs, or manual verification cover this unit.
-- **Reviewable alone**: reviewers do not need to read future PRs to understand this one.
+Return the chosen strategy, PR order, current PR boundary, dependency diagram, review budget (`additions + deletions`), verification plan, and any `size:exception` rationale.
 
-If a slice cannot meet these rules, split it differently. A chain is not a dumping ground for partial, unreviewable diffs.
+## References
 
-## Choosing the Chain Strategy
-
-When the workload exceeds 400 lines and chained PRs are needed, **ask the user** before proceeding:
-
-```
-This work exceeds the 400-line review budget. How do you want to split it?
-
-1. Stacked PRs to main
-   Each PR merges to main in order. Fast iteration, fix on the go.
-   Best for: speed-first teams, startups, independent slices.
-
-2. Feature Branch Chain (with tracker)
-   Child PRs review against their immediate parent branch; the tracker branch accumulates the final feature and is the only branch that merges to main.
-   Best for: rollback control, integration testing before main, coordinated releases.
-
-3. size:exception
-   Keep it as a single PR with maintainer approval.
-   Best for: generated code, migrations, vendor diffs where splitting adds noise.
-```
-
-Cache the user's answer for the rest of the session. Do not ask again unless the user changes scope.
-
-This is a **team decision**, not a technical one. Both strategies are valid — they reflect different priorities:
-
-| | Stacked PRs to main | Feature Branch Chain |
-|---|---|---|
-| Speed | Each slice ships immediately | Waits until the chain is complete |
-| Rollback | Revert individual PRs from main | Revert the whole feature branch |
-| Risk | Partial features may land in main | Nothing lands until everything is ready |
-| Fix flow | Fix on the go in main | Fix on the integration branch |
-| Complexity | Simpler — rebase and retarget | Needs tracker PR, parent bases, and diff hygiene |
-| Best for | Startups, fast-moving teams | Teams needing coordination and control |
-
-## Chain Boundaries
-
-Every PR in a chain needs explicit boundaries:
-
-| Boundary | What to document |
-|----------|------------------|
-| Start | The branch, PR, or state this PR builds on |
-| End | The finished unit this PR leaves behind |
-| Before | Prior PRs reviewers can assume already exist |
-| After | Follow-up PRs reviewers should ignore for now |
-| Out of scope | Related work intentionally excluded from this review |
-
-## Tracker PR Requirement
-
-For any chain with more than two PRs, create a draft tracker PR before review starts. The tracker PR is not the review surface. It is the map.
-
-It must include:
-
-- every child PR in merge/review order,
-- current status for each PR,
-- one dependency diagram,
-- explicit instruction not to review the aggregate diff,
-- `size:exception` if the aggregate diff exceeds 400 changed lines,
-- `no-merge` while the chain is incomplete.
-
-## Diagram Requirement
-
-Every child PR must show where it sits in the chain. Mark the current PR with `📍`.
-
-```text
-main
- └── #101 Foundation
-      └── #102 Work-unit commits
-           └── 📍 #103 This PR
-                └── #104 Docs
-                     └── #105 Tracker
-```
-
-Pair the diagram with a status table:
-
-| PR | Scope | Status |
-|----|-------|--------|
-| #101 | Foundation | ✅ Passing |
-| #102 | Work-unit commits | 🟡 Open |
-| #103 | This PR | 📍 Review here |
-| #104 | Docs | ⚪ Pending |
-| #105 | Tracker | 🟡 Draft |
-
-## SDD Integration
-
-When SDD planning produces tasks that may exceed 400 changed lines:
-
-1. Treat the `Review Workload Forecast` as a hard planning signal.
-2. Follow the cached `delivery_strategy` before `sdd-apply` writes code.
-3. Convert suggested work units into PR slices.
-4. Keep each slice autonomous: tests/docs included, CI green, clear rollback.
-5. Do not let one `sdd-apply` batch silently grow into a burnout-sized PR.
-
-## Feature Branch Chain
-
-Use this when the user chooses option 2: the feature branch is the accumulator/tracker/final integration branch, while child PRs are reviewed as focused slices against their immediate parent branch.
-
-The tracker PR is the map, not the review surface:
-
-- tracker PR: `feat/my-feature` -> `main`, draft/no-merge,
-- PR #1: child branch -> feature/tracker branch,
-- PR #2: child branch -> PR #1 branch,
-- PR #3: child branch -> PR #2 branch,
-- final merge: tracker PR -> `main` only after the chain is complete.
-
-```text
-master/main
- └── feat/my-feature              ← tracker/final integration branch
-      ↑
-      │ PR #1 base: feat/my-feature
-      │
-      └── feat/my-feature-01-core
-            ↑
-            │ PR #2 base: feat/my-feature-01-core
-            │
-            └── feat/my-feature-02-shared
-                  ↑
-                  │ PR #3 base: feat/my-feature-02-shared
-                  │
-                  └── feat/my-feature-03-slice
-```
-
-Example review chain:
-
-```text
-#40 tracker:   feat/ui-ownership-refactor -> master
-#41 foundation: ui-ownership-refactor/foundation -> feat/ui-ownership-refactor
-#42 shared:     ui-ownership-refactor/shared -> ui-ownership-refactor/foundation
-#43 feature:    ui-ownership-refactor/<feature> -> ui-ownership-refactor/shared
-```
-
-### Steps
-
-1. Create the feature/tracker branch from `main`.
-2. Open the tracker PR from the feature branch to `main` — mark it draft with `no-merge`.
-3. Create PR #1 from the feature/tracker branch and target it back to that branch.
-4. Create each later child branch from the previous PR branch and target it to that immediate parent branch.
-5. Review each child PR against its immediate parent branch, not against `main` and not against the tracker branch after PR #1.
-6. Keep the tracker branch as the accumulator/final integration branch.
-7. Only merge the tracker PR into `main` after all children are reviewed and integrated.
-
-### Commands
-
-PR #1 targets the feature/tracker branch:
-
-```bash
-git checkout feat/ui-ownership-refactor
-git checkout -b ui-ownership-refactor/foundation
-git push -u origin ui-ownership-refactor/foundation
-
-gh pr create \
-  --base feat/ui-ownership-refactor \
-  --head ui-ownership-refactor/foundation
-```
-
-PR #2 targets PR #1's branch:
-
-```bash
-git checkout ui-ownership-refactor/foundation
-git checkout -b ui-ownership-refactor/shared
-git push -u origin ui-ownership-refactor/shared
-
-gh pr create \
-  --base ui-ownership-refactor/foundation \
-  --head ui-ownership-refactor/shared
-```
-
-PR #3 targets PR #2's branch:
-
-```bash
-git checkout ui-ownership-refactor/shared
-git checkout -b ui-ownership-refactor/orgs
-git push -u origin ui-ownership-refactor/orgs
-
-gh pr create \
-  --base ui-ownership-refactor/shared \
-  --head ui-ownership-refactor/orgs
-```
-
-### Diff Hygiene
-
-The diff is the source of truth. A child PR is correctly based only when GitHub shows the current work unit and not previous PR changes.
-
-- If PR #2 shows PR #1 changes, retarget PR #2 to PR #1's branch or rebase it until the diff is clean.
-- If PR #3 shows PR #1 or PR #2 changes, retarget it to PR #2's branch or rebase it until the diff is clean.
-- Do **not** target `main` from child PRs in Feature Branch Chain.
-- Do **not** target the tracker branch from child PRs after PR #1; that inflates review diffs.
-
-### Common mistakes
-
-If you chose this strategy, no child PR should target `main` — otherwise it bypasses the tracker and lands in `main` before the chain is complete. Later child PRs also should not target the tracker branch, because GitHub will show prior slices again.
-
-```text
-# WRONG — child bypasses tracker
-main ← #101 (base: main) ← #102 ← #103
-
-# WRONG — later children target tracker and show inflated diffs
-main ← tracker (#105)
-         ├── #101 (base: tracker branch)
-         ├── #102 (base: tracker branch)  # shows #101 again
-         └── #103 (base: tracker branch)  # shows #101 and #102 again
-
-# CORRECT — each review targets the immediate parent branch
-main ← tracker (#105)
-         └── #101 (base: tracker branch)
-              └── #102 (base: #101 branch)
-                   └── #103 (base: #102 branch)
-```
-
-### Post-merge Rule
-
-After a parent PR is merged, keep the chain coherent: leave the next PR base as the parent branch if GitHub still shows only the current work unit, or retarget/rebase to the updated accumulator/parent as needed. The diff must stay focused.
-
-### Tracker PR Expectations
-
-The tracker PR is a **chain map**, not the review surface. Keep it draft/no-merge until the child PRs are reviewed and integrated.
-
-- Reviewers should review child PRs against their immediate parent branches, where each slice stays within the 400-line budget.
-- The tracker PR may exceed 400 changed lines because it aggregates the full feature branch by design.
-- If the tracker PR exceeds the budget, request/obtain maintainer-applied `size:exception` and document why the aggregate diff is unavoidable.
-
-## Stacked PRs to Main
-
-Use this when each PR can land in `main` in order.
-
-```text
-main <- PR 1: foundation
-          └── PR 2: feature slice built on PR 1
-                └── PR 3: docs/tests built on PR 2
-```
-
-### Steps
-
-1. Create PR 1 from `main`.
-2. Create PR 2 from PR 1's branch and target it to PR 1's branch.
-3. After PR 1 merges, rebase PR 2 on `main` and retarget it to `main`.
-4. Repeat until the stack is merged.
-
-## Chain Context Section
-
-Insert this extra section into the existing `.github/PULL_REQUEST_TEMPLATE.md` body. Do **not** replace the repository PR template; the linked issue, PR type, summary, changes, test plan, automated checks, and contributor checklist sections are still required.
-
-```markdown
-## Chain Context
-
-| Field | Value |
-|-------|-------|
-| Chain | <feature or stack name> |
-| Tracker PR | <#NNN or "Not needed"> |
-| Position | <N of total> |
-| Base | `<target branch>` |
-| Depends on | <PR/issue/link or "None"> |
-| Follow-up | <next PR or "None"> |
-| Review budget | <changed lines> / 400 |
-| Starts at | <branch, PR, or state this builds on> |
-| Ends with | <standalone result delivered by this PR> |
-
-### Chain Overview
-
-```text
-main
- └── #NNN Previous PR
-      └── 📍 #NNN This PR
-           └── #NNN Next PR
-                └── #NNN Tracker
-```
-
-### Chain Status
-
-| PR | Scope | Status |
-|----|-------|--------|
-| #NNN | <scope> | <status> |
-| #NNN | <scope> | 📍 This PR |
-
-## Scope
-
-- <What this PR includes>
-- <What this PR intentionally excludes>
-
-## Autonomy
-
-- [ ] CI is expected to pass for this PR branch
-- [ ] This PR has one deliverable scope
-- [ ] This PR can be rolled back without unrelated changes
-- [ ] Tests, docs, or manual verification cover this unit
-
-## Review Notes
-
-- Review this PR in isolation.
-- Do not review dependent PR changes here.
-- If this exceeds 400 changed lines, request/obtain maintainer-applied `size:exception` and document the rationale.
-
-## Test Plan
-
-- <command or manual verification>
-```
-
-## Commands
-
-```bash
-# Check PR size before asking for review
-gh pr view <PR_NUMBER> --json additions,deletions,changedFiles,title,url
-
-# Create PR #1 in a Feature Branch Chain
-gh pr create --base feat/my-feature --title "feat(scope): focused slice" --body-file pr-body.md
-
-# Create the next child PR targeting its immediate parent branch
-gh pr create --base feat/my-feature-01-core --title "feat(scope): next focused slice" --body-file pr-body.md
-```
-
-## Reviewer Guidance
-
-- If a PR exceeds 400 changed lines without `size:exception`, ask for a split.
-- Recommend chained PRs when the work must integrate before `main`.
-- Recommend stacked PRs when each slice can merge independently.
-- In Feature Branch Chain, review child PRs against their immediate parent branches and treat a polluted diff as a base/branching bug.
-- Prefer clear dependency notes over clever branch gymnastics.
-- Push for autonomy: green CI, clear rollback, and tests or docs for the unit under review.
-- Protect reviewer energy. If the chain forces reviewers to reconstruct hidden context, ask for clearer boundaries.
+- [references/chaining-details.md](references/chaining-details.md) — strategy diagrams, PR body section, branch commands, and reviewer guidance.

--- a/internal/assets/skills/chained-pr/references/chaining-details.md
+++ b/internal/assets/skills/chained-pr/references/chaining-details.md
@@ -1,0 +1,99 @@
+# Chained PR Details
+
+## Strategy Notes
+
+| | Stacked PRs to main | Feature Branch Chain |
+|---|---|---|
+| Speed | Each slice can ship in order | Full feature waits for tracker merge |
+| Rollback | Revert individual main PRs | Revert/hold the whole feature branch |
+| Risk | Partial behavior may land | Nothing lands until the chain completes |
+| Complexity | Simpler retarget/rebase flow | Requires tracker and strict diff hygiene |
+
+## Feature Branch Chain
+
+Use when the feature branch accumulates the final integration while child PRs are reviewed as focused slices.
+
+```text
+main
+ └── feat/my-feature              ← tracker/final integration branch
+      ↑ PR #1 base: feat/my-feature
+      └── feat/my-feature-01-core
+           ↑ PR #2 base: feat/my-feature-01-core
+           └── feat/my-feature-02-shared
+                ↑ PR #3 base: feat/my-feature-02-shared
+                └── feat/my-feature-03-slice
+```
+
+Steps:
+
+1. Create the feature/tracker branch from `main`.
+2. Open the tracker PR to `main`; mark it draft/no-merge.
+3. Create PR #1 from a child branch and target it to the tracker branch.
+4. Create each later child branch from the previous PR branch and target it to that parent branch.
+5. Merge/integrate children in order; merge the tracker only after the chain is complete.
+
+## Stacked PRs to Main
+
+Use when each slice can land on `main` in order.
+
+```text
+main <- PR 1: foundation
+          └── PR 2: feature slice built on PR 1
+                └── PR 3: docs/tests built on PR 2
+```
+
+After a parent PR merges, rebase/retarget the next PR so GitHub shows only the current slice.
+
+## Chain Context Section
+
+Append this section to the repo PR template; do not replace required issue/checklist sections.
+
+```markdown
+## Chain Context
+
+| Field | Value |
+|-------|-------|
+| Chain | <feature or stack name> |
+| Tracker PR | <#NNN or "Not needed"> |
+| Position | <N of total> |
+| Base | `<target branch>` |
+| Depends on | <PR/issue/link or "None"> |
+| Follow-up | <next PR or "None"> |
+| Review budget | <changed lines> / 400 |
+| Starts at | <branch, PR, or state this builds on> |
+| Ends with | <standalone result delivered by this PR> |
+
+### Chain Overview
+
+```text
+main
+ └── #NNN Previous PR
+      └── 📍 #NNN This PR
+           └── #NNN Next PR
+```
+
+### Scope
+- Includes: <focused unit>
+- Excludes: <deferred work>
+
+### Autonomy
+- [ ] CI is expected to pass for this PR branch
+- [ ] This PR has one deliverable scope
+- [ ] This PR can be rolled back without unrelated changes
+- [ ] Tests, docs, or manual verification cover this unit
+```
+
+## Commands
+
+```bash
+gh pr view <PR_NUMBER> --json additions,deletions,changedFiles,title,url
+gh pr create --base feat/my-feature --title "feat(scope): focused slice" --body-file pr-body.md
+gh pr create --base feat/my-feature-01-core --title "feat(scope): next focused slice" --body-file pr-body.md
+```
+
+## Reviewer Guidance
+
+- Ask for a split when a PR exceeds 400 changed lines without `size:exception`.
+- Recommend Feature Branch Chain when work must integrate before `main`.
+- Recommend stacked PRs when each slice can merge independently.
+- Review child PRs against immediate parent branches; a polluted diff is a branching bug.

--- a/internal/assets/skills/go-testing/SKILL.md
+++ b/internal/assets/skills/go-testing/SKILL.md
@@ -1,353 +1,51 @@
 ---
 name: go-testing
-description: "Write Go tests, including Bubbletea TUI tests. Trigger: Go test coverage, teatest, or test patterns."
+description: "Trigger: Go tests, go test coverage, Bubbletea teatest, golden files. Apply focused Go testing patterns."
 license: Apache-2.0
 metadata:
   author: gentleman-programming
   version: "1.0"
 ---
 
-## When to Use
+## Activation Contract
 
-Use this skill when:
-- Writing Go unit tests
-- Testing Bubbletea TUI components
-- Creating table-driven tests
-- Adding integration tests
-- Using golden file testing
+Load this skill when writing or reviewing Go tests, adding coverage, testing Bubbletea/TUI flows, using `teatest`, or updating golden files.
 
----
+## Hard Rules
 
-## Critical Patterns
+- Prefer table-driven tests for multiple cases; use `t.Run(tt.name, ...)`.
+- Test behavior and state transitions, not implementation trivia.
+- Use `t.TempDir()` for filesystem tests; never rely on a real home directory.
+- Keep integration tests skippable with `testing.Short()` when they run external commands or slow flows.
+- For Bubbletea, test `Model.Update()` directly for state changes; use `teatest` only for interactive flows.
+- Golden files must be deterministic; update only through the repo's `-update` path and rerun tests without `-update`.
+- Use small mocks/interfaces around system or command execution boundaries.
 
-### Pattern 1: Table-Driven Tests
+## Decision Gates
 
-Standard Go pattern for multiple test cases:
+| Target | Test pattern |
+|---|---|
+| Pure function or parser | Table-driven unit test. |
+| Error behavior | Explicit success and failure cases. |
+| File operations | `t.TempDir()` plus focused assertions. |
+| TUI state transition | Direct `Model.Update()` call with `tea.Msg`. |
+| Full TUI interaction | `teatest.NewTestModel()`. |
+| Rendered output | Golden file test. |
+| Real external command | Integration test; skip in `-short`. |
 
-```go
-func TestSomething(t *testing.T) {
-    tests := []struct {
-        name     string
-        input    string
-        expected string
-        wantErr  bool
-    }{
-        {
-            name:     "valid input",
-            input:    "hello",
-            expected: "HELLO",
-            wantErr:  false,
-        },
-        {
-            name:     "empty input",
-            input:    "",
-            expected: "",
-            wantErr:  true,
-        },
-    }
+## Execution Steps
 
-    for _, tt := range tests {
-        t.Run(tt.name, func(t *testing.T) {
-            result, err := ProcessInput(tt.input)
+1. Identify behavior under test and the smallest public boundary that proves it.
+2. Choose the test pattern from the decision gate.
+3. Name cases by scenario, not input mechanics.
+4. Assert outputs, errors, state, and side effects explicitly.
+5. Run the narrow package test first, then the relevant broader suite.
+6. For golden updates: run with `-update`, inspect diff, then rerun without `-update`.
 
-            if (err != nil) != tt.wantErr {
-                t.Errorf("error = %v, wantErr %v", err, tt.wantErr)
-                return
-            }
+## Output Contract
 
-            if result != tt.expected {
-                t.Errorf("got %q, want %q", result, tt.expected)
-            }
-        })
-    }
-}
-```
+Report test files changed, scenarios covered, commands executed, golden files updated, and any skipped integration scope.
 
-### Pattern 2: Bubbletea Model Testing
+## References
 
-Test Model state transitions directly:
-
-```go
-func TestModelUpdate(t *testing.T) {
-    m := NewModel()
-
-    // Simulate key press
-    newModel, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
-    m = newModel.(Model)
-
-    if m.Screen != ScreenMainMenu {
-        t.Errorf("expected ScreenMainMenu, got %v", m.Screen)
-    }
-}
-```
-
-### Pattern 3: Teatest Integration Tests
-
-Use Charmbracelet's teatest for TUI testing:
-
-```go
-func TestInteractiveFlow(t *testing.T) {
-    m := NewModel()
-    tm := teatest.NewTestModel(t, m)
-
-    // Send keys
-    tm.Send(tea.KeyMsg{Type: tea.KeyEnter})
-    tm.Send(tea.KeyMsg{Type: tea.KeyDown})
-    tm.Send(tea.KeyMsg{Type: tea.KeyEnter})
-
-    // Wait for model to update
-    tm.WaitFinished(t, teatest.WithDuration(time.Second))
-
-    // Get final model
-    finalModel := tm.FinalModel(t).(Model)
-
-    if finalModel.Screen != ExpectedScreen {
-        t.Errorf("wrong screen: got %v", finalModel.Screen)
-    }
-}
-```
-
-### Pattern 4: Golden File Testing
-
-Compare output against saved "golden" files:
-
-```go
-func TestOSSelectGolden(t *testing.T) {
-    m := NewModel()
-    m.Screen = ScreenOSSelect
-    m.Width = 80
-    m.Height = 24
-
-    output := m.View()
-
-    golden := filepath.Join("testdata", "TestOSSelectGolden.golden")
-
-    if *update {
-        os.WriteFile(golden, []byte(output), 0644)
-    }
-
-    expected, _ := os.ReadFile(golden)
-    if output != string(expected) {
-        t.Errorf("output doesn't match golden file")
-    }
-}
-```
-
----
-
-## Decision Tree
-
-```
-Testing a function?
-├── Pure function? → Table-driven test
-├── Has side effects? → Mock dependencies
-├── Returns error? → Test both success and error cases
-└── Complex logic? → Break into smaller testable units
-
-Testing TUI component?
-├── State change? → Test Model.Update() directly
-├── Full flow? → Use teatest.NewTestModel()
-├── Visual output? → Use golden file testing
-└── Key handling? → Send tea.KeyMsg
-
-Testing system/exec?
-├── Mock os/exec? → Use interface + mock
-├── Real commands? → Integration test with --short skip
-└── File operations? → Use t.TempDir()
-```
-
----
-
-## Code Examples
-
-### Example 1: Testing Key Navigation
-
-```go
-func TestCursorNavigation(t *testing.T) {
-    tests := []struct {
-        name       string
-        startPos   int
-        key        string
-        endPos     int
-        numOptions int
-    }{
-        {"down from 0", 0, "j", 1, 5},
-        {"up from 1", 1, "k", 0, 5},
-        {"down at bottom", 4, "j", 4, 5}, // stays at bottom
-        {"up at top", 0, "k", 0, 5},       // stays at top
-    }
-
-    for _, tt := range tests {
-        t.Run(tt.name, func(t *testing.T) {
-            m := NewModel()
-            m.Cursor = tt.startPos
-            // Set up options...
-
-            newModel, _ := m.Update(tea.KeyMsg{
-                Type:  tea.KeyRunes,
-                Runes: []rune(tt.key),
-            })
-            m = newModel.(Model)
-
-            if m.Cursor != tt.endPos {
-                t.Errorf("cursor = %d, want %d", m.Cursor, tt.endPos)
-            }
-        })
-    }
-}
-```
-
-### Example 2: Testing Screen Transitions
-
-```go
-func TestScreenTransitions(t *testing.T) {
-    tests := []struct {
-        name         string
-        startScreen  Screen
-        action       tea.Msg
-        expectScreen Screen
-    }{
-        {
-            name:         "welcome to main menu",
-            startScreen:  ScreenWelcome,
-            action:       tea.KeyMsg{Type: tea.KeyEnter},
-            expectScreen: ScreenMainMenu,
-        },
-        {
-            name:         "escape from OS select",
-            startScreen:  ScreenOSSelect,
-            action:       tea.KeyMsg{Type: tea.KeyEsc},
-            expectScreen: ScreenMainMenu,
-        },
-    }
-
-    for _, tt := range tests {
-        t.Run(tt.name, func(t *testing.T) {
-            m := NewModel()
-            m.Screen = tt.startScreen
-
-            newModel, _ := m.Update(tt.action)
-            m = newModel.(Model)
-
-            if m.Screen != tt.expectScreen {
-                t.Errorf("screen = %v, want %v", m.Screen, tt.expectScreen)
-            }
-        })
-    }
-}
-```
-
-### Example 3: Testing Trainer Exercises
-
-```go
-func TestExerciseValidation(t *testing.T) {
-    exercise := &Exercise{
-        Solutions: []string{"w", "W", "e"},
-        Optimal:   "w",
-    }
-
-    tests := []struct {
-        input   string
-        valid   bool
-        optimal bool
-    }{
-        {"w", true, true},
-        {"W", true, false},
-        {"e", true, false},
-        {"x", false, false},
-    }
-
-    for _, tt := range tests {
-        t.Run(tt.input, func(t *testing.T) {
-            valid := ValidateAnswer(exercise, tt.input)
-            optimal := IsOptimalAnswer(exercise, tt.input)
-
-            if valid != tt.valid {
-                t.Errorf("valid = %v, want %v", valid, tt.valid)
-            }
-            if optimal != tt.optimal {
-                t.Errorf("optimal = %v, want %v", optimal, tt.optimal)
-            }
-        })
-    }
-}
-```
-
-### Example 4: Mocking System Info
-
-```go
-func TestWithMockedSystem(t *testing.T) {
-    m := NewModel()
-
-    // Mock system info for testing
-    m.SystemInfo = &system.SystemInfo{
-        OS:       system.OSMac,
-        IsARM:    true,
-        HasBrew:  true,
-        HomeDir:  t.TempDir(),
-    }
-
-    // Now test with controlled environment
-    m.SetupInstallSteps()
-
-    // Verify expected steps
-    hasHomebrew := false
-    for _, step := range m.Steps {
-        if step.ID == "homebrew" {
-            hasHomebrew = true
-        }
-    }
-
-    if hasHomebrew {
-        t.Error("should not have homebrew step when HasBrew=true")
-    }
-}
-```
-
----
-
-## Test File Organization
-
-```
-installer/internal/tui/
-├── model.go
-├── model_test.go           # Model tests
-├── update.go
-├── update_test.go          # Update handler tests
-├── view.go
-├── view_test.go            # View rendering tests
-├── teatest_test.go         # Teatest integration tests
-├── comprehensive_test.go   # Full flow tests
-├── testdata/
-│   ├── TestOSSelectGolden.golden
-│   └── TestViewGolden.golden
-└── trainer/
-    ├── types.go
-    ├── types_test.go
-    ├── exercises.go
-    ├── exercises_test.go
-    └── simulator_test.go
-```
-
----
-
-## Commands
-
-```bash
-go test ./...                           # Run all tests
-go test -v ./internal/tui/...          # Verbose TUI tests
-go test -run TestNavigation             # Run specific test
-go test -cover ./...                    # With coverage
-go test -update ./...                   # Update golden files
-go test -short ./...                    # Skip integration tests
-```
-
----
-
-## Resources
-
-- **TUI Tests**: See `installer/internal/tui/*_test.go`
-- **Trainer Tests**: See `installer/internal/tui/trainer/*_test.go`
-- **System Tests**: See `installer/internal/system/*_test.go`
-- **Golden Files**: See `installer/internal/tui/testdata/`
-- **Teatest Docs**: https://github.com/charmbracelet/bubbletea/tree/master/teatest
+- [references/examples.md](references/examples.md) — compact table-driven, Bubbletea, teatest, golden, and command examples.

--- a/internal/assets/skills/go-testing/references/examples.md
+++ b/internal/assets/skills/go-testing/references/examples.md
@@ -1,0 +1,89 @@
+# Go Testing Examples
+
+## Table-Driven Test
+
+```go
+func TestProcessInput(t *testing.T) {
+    tests := []struct {
+        name    string
+        input   string
+        want    string
+        wantErr bool
+    }{
+        {name: "valid input", input: "hello", want: "HELLO"},
+        {name: "empty input", input: "", wantErr: true},
+    }
+
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            got, err := ProcessInput(tt.input)
+            if (err != nil) != tt.wantErr {
+                t.Fatalf("err = %v, wantErr %v", err, tt.wantErr)
+            }
+            if got != tt.want {
+                t.Fatalf("got %q, want %q", got, tt.want)
+            }
+        })
+    }
+}
+```
+
+## Bubbletea State Transition
+
+```go
+func TestModelUpdateEnter(t *testing.T) {
+    m := NewModel()
+    next, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+    got := next.(Model)
+    if got.Screen != ScreenMainMenu {
+        t.Fatalf("screen = %v, want %v", got.Screen, ScreenMainMenu)
+    }
+}
+```
+
+## Teatest Flow
+
+```go
+func TestInteractiveFlow(t *testing.T) {
+    tm := teatest.NewTestModel(t, NewModel())
+    tm.Send(tea.KeyMsg{Type: tea.KeyEnter})
+    tm.WaitFinished(t, teatest.WithDuration(time.Second))
+    final := tm.FinalModel(t).(Model)
+    if final.Screen != ExpectedScreen {
+        t.Fatalf("screen = %v, want %v", final.Screen, ExpectedScreen)
+    }
+}
+```
+
+## Golden File Pattern
+
+```go
+var update = flag.Bool("update", false, "update golden files")
+
+func assertGolden(t *testing.T, path string, got string) {
+    t.Helper()
+    if *update {
+        if err := os.WriteFile(path, []byte(got), 0o644); err != nil {
+            t.Fatal(err)
+        }
+    }
+    want, err := os.ReadFile(path)
+    if err != nil {
+        t.Fatal(err)
+    }
+    if got != string(want) {
+        t.Fatalf("golden mismatch for %s", path)
+    }
+}
+```
+
+## Commands
+
+```bash
+go test ./...
+go test -v ./internal/tui/...
+go test -run TestNavigation ./internal/tui
+go test -cover ./...
+go test ./internal/components -update
+go test -short ./...
+```

--- a/internal/assets/skills/judgment-day/SKILL.md
+++ b/internal/assets/skills/judgment-day/SKILL.md
@@ -1,345 +1,52 @@
 ---
 name: judgment-day
-description: "Run dual adversarial review and re-check fixes. Trigger: judgment day, dual review, adversarial review, or juzgar requests."
+description: "Trigger: judgment day, dual review, adversarial review, juzgar. Run blind dual review, fix confirmed issues, then re-judge."
 license: Apache-2.0
 metadata:
   author: gentleman-programming
   version: "1.4"
 ---
 
-## When to Use
+## Activation Contract
 
-- User explicitly asks for "judgment day", "judgment-day", or equivalent trigger phrases
-- After significant implementations before merging
-- When high-confidence review of code, features, or architecture is needed
-- When a single reviewer might miss edge cases or have blind spots
-- When the cost of a production bug is higher than the cost of two review rounds
+Load this skill only when the user explicitly asks for Judgment Day, dual/adversarial review, or equivalent Spanish trigger (`juzgar`, `que lo juzguen`). Review a specific target: files, feature, PR, or architecture slice.
 
-## Critical Patterns
+## Hard Rules
 
-### Pattern 0: Skill Resolution (BEFORE launching judges)
+- Resolve project skills before launching agents: read skill registry, match compact rules by target files/task, and inject the same `Project Standards` block into both judge prompts and fix prompts.
+- Launch **two blind judges in parallel** with identical target and criteria; never review the code yourself.
+- Wait for both judges before synthesis; never accept a partial verdict.
+- Classify warnings as `WARNING (real)` only if normal intended use can trigger them; otherwise downgrade to INFO as `WARNING (theoretical)`.
+- Ask before fixing Round 1 confirmed issues.
+- After any fix agent runs, immediately re-launch both judges in parallel before commit/push/done/session summary.
+- Terminal states are only `JUDGMENT: APPROVED` or `JUDGMENT: ESCALATED`.
+- After 2 fix iterations with remaining issues, ask the user whether to continue.
 
-Follow the **Skill Resolver Protocol** (`_shared/skill-resolver.md`) before launching ANY sub-agent:
+## Decision Gates
 
-1. Obtain the skill registry: search engram (`mem_search(query: "skill-registry", project: "{project}")`) → fallback to `.atl/skill-registry.md` from the project root → skip if none
-2. Identify the target files/scope — what code will the judges review?
-3. Match relevant skills from the registry's **Compact Rules** by:
-   - **Code context**: file extensions/paths of the target (e.g., `.go` → go-testing; `.tsx` → react-19, typescript)
-   - **Task context**: "review code" → framework/language skills; "create PR" → branch-pr skill
-4. Build a `## Project Standards (auto-resolved)` block with the matching compact rules
-5. Inject this block into BOTH Judge prompts AND the Fix Agent prompt (identical for all)
+| Condition | Action |
+|---|---|
+| Target unclear | Ask for scope; do not launch judges. |
+| No skill registry | Warn, proceed with generic criteria, and record `Skill Resolution: none`. |
+| Both judges find same CRITICAL/real WARNING | Confirmed; ask/fix according to round rules. |
+| One judge finds issue | Suspect; report and triage, do not auto-fix. |
+| Judges contradict | Escalate for manual decision. |
+| Round 2+ has only theoretical warnings/suggestions | Report as INFO; do not re-judge. |
 
-This ensures judges review against project-specific standards, not just generic best practices.
+## Execution Steps
 
-**If no registry exists**: warn the user ("No skill registry found — judges will review without project-specific standards. Run `skill-registry` to fix this.") and proceed with generic review only.
+1. Confirm target and optional custom criteria.
+2. Resolve compact project standards from registry or warn if missing.
+3. Start Judge A and Judge B concurrently via delegation.
+4. Synthesize findings into confirmed, suspect, contradiction, and INFO buckets.
+5. Ask before Round 1 fixes; delegate a separate fix agent for confirmed approved fixes only.
+6. Re-judge in parallel after fixes; repeat until approved, escalated, or user asks to stop.
+7. Before any terminal action, verify every active Judgment Day has a terminal state.
 
-### Pattern 1: Parallel Blind Review
+## Output Contract
 
-- Launch **TWO** sub-agents via `delegate` (async, parallel — never sequential)
-- Each agent receives the **same target** but works **independently**
-- **Neither agent knows about the other** — no cross-contamination
-- Both use identical review criteria but may find different issues
-- NEVER do the review yourself as the orchestrator — your job is coordination only
+Return `## Judgment Day — {target}` with round number, verdict table, confirmed/suspect/contradiction counts, fixes applied, re-judgment result, `Skill Resolution`, and final `JUDGMENT: APPROVED ✅` or `JUDGMENT: ESCALATED ⚠️`.
 
-### Pattern 2: Verdict Synthesis
+## References
 
-The **orchestrator** (NOT a sub-agent) compares results after both `delegation_read` calls return:
-
-```
-Confirmed   → found by BOTH agents          → high confidence, fix immediately
-Suspect A   → found ONLY by Judge A         → needs triage
-Suspect B   → found ONLY by Judge B         → needs triage
-Contradiction → agents DISAGREE on the same thing → flag for manual decision
-```
-
-Present findings as a structured verdict table (see Output Format).
-
-### Pattern 3: Warning Classification
-
-Judges MUST classify every WARNING into one of two sub-types:
-
-```
-WARNING (real)        → Causes a bug, data loss, security hole, or incorrect behavior
-                        in a realistic production scenario. Fix required.
-WARNING (theoretical) → Requires a contrived scenario, corrupted input, or conditions
-                        that cannot arise through normal usage. Report but do NOT block.
-```
-
-**How to classify**: ask "Can a normal user, using the tool as intended, trigger this?" If YES → real. If it requires a malicious manifest, renamed home dir, two clicks in <1ms, or Windows volume root edge case → theoretical.
-
-**Theoretical warnings are reported as INFO** in the verdict table. They are NOT fixed, do NOT trigger re-judgment, and do NOT count toward the convergence threshold. The orchestrator includes them in the final report for awareness.
-
-### Pattern 4: Fix and Re-judge
-
-1. If **confirmed CRITICALs or real WARNINGs** exist → delegate a **Fix Agent** (separate delegation)
-2. After Fix Agent completes → re-launch **both judges in parallel** (same blind protocol, fresh delegates)
-3. **After 2 fix iterations**, if issues remain → present findings to user and ASK: "¿Querés que siga iterando? / Should I continue iterating?" If YES → continue fix+judge cycle. If NO → JUDGMENT: ESCALATED.
-4. If both judges return clean → JUDGMENT: APPROVED ✅
-
-### Pattern 5: Convergence Threshold
-
-**Round 1**: Present the verdict table to the user. ASK: "These are the confirmed issues. Want me to fix them?" Only fix after user confirms. Then re-judge with full scope.
-
-**Round 2+**: Only re-judge if there are **confirmed CRITICALs**. For anything else:
-- **Real WARNINGs** (confirmed): Fix inline, do NOT re-launch judges. Report as "fixed without re-judge" in the verdict.
-- **Theoretical WARNINGs**: Report as INFO. Do NOT fix, do NOT re-judge.
-- **SUGGESTIONs**: Fix inline if trivial (dead code, style). Do NOT re-judge.
-
-**APPROVED criteria after Round 1**: 0 confirmed CRITICALs + 0 confirmed real WARNINGs = APPROVED. Theoretical warnings and suggestions may remain.
-
-This prevents the diminishing-returns cycle where each fix round introduces minor artifacts that trigger another round of nit-picking.
-
----
-
-## Decision Tree
-
-```
-User asks for "judgment day"
-│
-├── Target is specific files/feature/component?
-│   ├── YES → continue
-│   └── NO → ask user to specify scope before proceeding
-│
-▼
-Resolve skills (Pattern 0): read registry → match by code + task context → build Project Standards block
-▼
-Launch Judge A + Judge B in parallel (delegate, async) — with Project Standards injected
-▼
-Wait for both to complete (delegation_read both)
-▼
-Synthesize verdict
-│
-├── No issues found?
-│   └── JUDGMENT: APPROVED ✅ (stop here)
-│
-├── Issues found (confirmed, suspect, or contradictions)?
-│   └── Present verdict table to user
-│       ▼
-│       ASK: "¿Arreglo los issues confirmados? / Fix confirmed issues?"
-│       ▼
-│       ├── User says YES → Delegate Fix Agent with confirmed issues list
-│       ├── User says NO → JUDGMENT: ESCALATED (user chose not to fix)
-│       └── User gives specific feedback → adjust fix list accordingly
-│       ▼
-│       Wait for Fix Agent to complete
-│       ▼
-│       Re-launch Judge A + Judge B in parallel (Round 2)
-│       ▼
-│       Synthesize verdict
-│       │
-│       ├── Clean → JUDGMENT: APPROVED ✅
-│       │
-│       └── Still issues → Delegate Fix Agent again (Round 3 / iteration 2)
-│           ▼
-│           Re-launch Judge A + Judge B in parallel (Round 3)
-│           ▼
-│           Synthesize verdict
-│           │
-│           ├── Clean → JUDGMENT: APPROVED ✅
-│           └── Still issues → ASK USER: "Issues remain after 2 iterations. Continue iterating?"
-            │
-            ├── User says YES → repeat fix + judge cycle (no limit)
-            └── User says NO → JUDGMENT: ESCALATED ⚠️ (report to user)
-```
-
----
-
-## Sub-Agent Prompt Templates
-
-### Judge Prompt (use for BOTH Judge A and Judge B — identical)
-
-```
-You are an adversarial code reviewer. Your ONLY job is to find problems.
-
-## Target
-{describe target: files, feature, architecture, component}
-
-{if compact rules were resolved in Pattern 0, inject the following block — otherwise OMIT this entire section}
-## Project Standards (auto-resolved)
-{paste matching compact rules blocks from the skill registry}
-
-## Review Criteria
-- Correctness: Does the code do what it claims? Are there logical errors?
-- Edge cases: What inputs or states aren't handled?
-- Error handling: Are errors caught, propagated, and logged properly?
-- Performance: Any N+1 queries, inefficient loops, unnecessary allocations?
-- Security: Any injection risks, exposed secrets, improper auth checks?
-- Naming & conventions: Does it follow the project's established patterns AND the Project Standards above?
-{if user provided custom criteria, add here}
-
-## Return Format
-Return a structured list of findings ONLY. No praise, no approval.
-
-Each finding:
-- Severity: CRITICAL | WARNING (real) | WARNING (theoretical) | SUGGESTION
-- File: path/to/file.ext (line N if applicable)
-- Description: What is wrong and why it matters
-- Suggested fix: one-line description of the fix (not code, just intent)
-
-**WARNING classification rule**: Ask "Can a normal user, using the tool as intended, trigger this?"
-- YES → `WARNING (real)` — e.g., silent error on disk full, data corruption on normal input
-- NO → `WARNING (theoretical)` — e.g., requires malicious manifest, renamed home dir, race condition in <1ms, OS-specific edge case that doesn't apply to the project's target platforms
-
-Always include at the end: **Skill Resolution**: {injected|fallback-registry|fallback-path|none} — {details}
-
-If you find NO issues, return:
-VERDICT: CLEAN — No issues found.
-
-## Instructions
-Be thorough and adversarial. Assume the code has bugs until proven otherwise.
-Your job is to find problems, NOT to approve. Do not summarize. Do not praise.
-```
-
-### Fix Agent Prompt
-
-```
-You are a surgical fix agent. You apply ONLY the confirmed issues listed below.
-
-## Confirmed Issues to Fix
-{paste the confirmed findings table from the verdict synthesis}
-
-{if compact rules were resolved in Pattern 0, inject the following block — otherwise OMIT this entire section}
-## Project Standards (auto-resolved)
-{paste matching compact rules blocks from the skill registry}
-
-## Context
-- Original review criteria: {paste same criteria used for judges}
-- Target: {same target description}
-
-## Instructions
-- Fix ONLY the confirmed issues listed above
-- Do NOT refactor beyond what is strictly needed to fix each issue
-- Do NOT change code that was not flagged
-- **Scope rule**: If you fix a pattern in one file (e.g., add error logging for a silent discard), search for the SAME pattern in ALL other files touched by this change and fix them ALL. Inconsistent fixes across files are the #1 cause of unnecessary re-judge rounds.
-- After each fix, note: file changed, line changed, what was done
-
-Return a summary:
-## Fixes Applied
-- [file:line] — {what was fixed}
-
-**Skill Resolution**: {injected|fallback-registry|fallback-path|none} — {details}
-```
-
----
-
-## Output Format
-
-```markdown
-## Judgment Day — {target}
-
-### Round {N} — Verdict
-
-| Finding | Judge A | Judge B | Severity | Status |
-|---------|---------|---------|----------|--------|
-| Missing null check in auth.go:42 | ✅ | ✅ | CRITICAL | Confirmed |
-| Race condition in worker.go:88 | ✅ | ❌ | WARNING (real) | Suspect (A only) |
-| Windows volume root edge case | ❌ | ✅ | WARNING (theoretical) | INFO — reported |
-| Naming mismatch in handler.go:15 | ❌ | ✅ | SUGGESTION | Suspect (B only) |
-| Error swallowed in db.go:201 | ✅ | ✅ | WARNING (real) | Confirmed |
-
-**Confirmed issues**: 2 CRITICAL
-**Suspect issues**: 1 WARNING, 1 SUGGESTION
-**Contradictions**: none
-
-### Fixes Applied (Round {N})
-- `auth.go:42` — Added nil check before dereferencing user pointer
-- `db.go:201` — Propagated error instead of silently returning nil
-
-### Round {N+1} — Re-judgment
-- Judge A: PASS ✅ — No issues found
-- Judge B: PASS ✅ — No issues found
-
----
-
-### JUDGMENT: APPROVED ✅
-Both judges pass clean. The target is cleared for merge.
-```
-
-### Escalation Format (user chose to stop)
-
-```markdown
-## Judgment Day — {target}
-
-### JUDGMENT: ESCALATED ⚠️
-
-User chose to stop after {N} fix iterations. Issues remain.
-Manual review required before proceeding.
-
-### Remaining Issues
-| Finding | Judge A | Judge B | Severity |
-|---------|---------|---------|----------|
-| {description} | ✅ | ✅ | CRITICAL |
-
-### History
-- Round 1: {N} confirmed issues found
-- Fix 1: applied {list}
-- Round 2: {N} issues remain
-- Fix 2: applied {list}
-- Round 3: {N} issues remain → escalated
-
-Recommend: human review of the remaining issues above before re-running judgment day.
-```
-
----
-
-## Skill Resolution Feedback
-
-After every delegation that returns a result, check the `**Skill Resolution**` field in each judge/fix-agent response:
-- `injected` → skills were passed correctly ✅
-- `fallback-registry`, `fallback-path`, or `none` → skill cache was lost (likely compaction). Re-read the registry immediately and inject compact rules in all subsequent delegations.
-
-This is a self-correction mechanism. Do NOT ignore fallback reports.
-
----
-
-## Language
-
-- **Spanish input → Rioplatense**: "Juicio iniciado", "Los jueces están trabajando en paralelo...", "Los jueces coinciden", "Juicio terminado — Aprobado", "Escalado — necesita revisión humana"
-- **English input**: "Judgment initiated", "Both judges are working in parallel...", "Both judges agree", "Judgment complete — Approved", "Escalated — requires human review"
-
----
-
-## Blocking Rules (MANDATORY — override all other instructions)
-
-These rules cannot be skipped, overridden, or deprioritized under any circumstances:
-
-1. **MUST NOT** declare `JUDGMENT: APPROVED` until: Round 1 judges return CLEAN, OR Round 2 judges confirm 0 CRITICALs + 0 confirmed real WARNINGs (theoretical warnings and suggestions may remain)
-2. **MUST NOT** run `git push`, `git commit`, or any code-modifying action after fixes until re-judgment completes
-3. **MUST NOT** save a session summary or tell the user "done" until every JD reaches a terminal state (APPROVED or ESCALATED)
-4. **After the Fix Agent returns**, your IMMEDIATE next action is re-launching judges in parallel for re-judgment. Do NOT push or commit before re-judgment completes.
-5. **When running multiple JDs in parallel**, each JD is independent. One JD completing does NOT allow skipping rounds on another.
-
----
-
-## Self-Check (before ANY terminal action)
-
-Before pushing, committing, summarizing, or telling the user "done":
-
-1. List every active JD target
-2. For each: is it in state APPROVED or ESCALATED?
-3. If ANY JD had fixes applied, did Round 2 run?
-4. If Round 2 found issues, did you ASK the user whether to continue? Did you respect their answer?
-
-**If ANY answer is "no"** → you skipped a step. Go back and complete it before proceeding.
-
----
-
-## Rules
-
-- The **orchestrator NEVER reviews code itself** — it only launches judges, reads results, and synthesizes
-- Judges MUST be launched as `delegate` (async) so they run in **parallel**
-- The **Fix Agent is a separate delegation** — never use one of the judges as the fixer
-- If user provides **custom review criteria**, include them in BOTH judge prompts (identical)
-- If target scope is **unclear**, stop and ask before launching — partial reviews are useless
-- **After 2 fix iterations**, ASK the user before continuing. Never escalate automatically — the user decides when to stop.
-- Always wait for BOTH judges to complete before synthesizing — never accept a partial verdict
-- Suspect findings (only one judge) are reported but NOT automatically fixed — triage and escalate to user if needed
-
----
-
-## Commands
-
-```bash
-# No CLI commands — this is a pure orchestration protocol.
-# Execution happens via delegate() and delegation_read() tool calls.
-```
+- [references/prompts-and-formats.md](references/prompts-and-formats.md) — judge/fix prompts, warning rubric, verdict tables, and language snippets.

--- a/internal/assets/skills/judgment-day/references/prompts-and-formats.md
+++ b/internal/assets/skills/judgment-day/references/prompts-and-formats.md
@@ -1,0 +1,75 @@
+# Judgment Day Prompts and Formats
+
+## Judge Prompt
+
+```markdown
+You are an adversarial code reviewer. Your ONLY job is to find problems.
+
+## Target
+{files, feature, architecture, component}
+
+## Project Standards (auto-resolved)
+{matching compact rules, if available}
+
+## Review Criteria
+- Correctness: logical errors and behavior mismatches
+- Edge cases: missing states, inputs, or platform constraints
+- Error handling: propagation, logging, recovery
+- Performance: N+1, wasteful loops, excessive allocations
+- Security: injection, secrets, auth boundaries
+- Naming/conventions: project standards and local patterns
+{custom criteria, if provided}
+
+## Return Format
+Findings only. No praise.
+
+Each finding:
+- Severity: CRITICAL | WARNING (real) | WARNING (theoretical) | SUGGESTION
+- File: path/to/file.ext (line N if applicable)
+- Description: what is wrong and why it matters
+- Suggested fix: one-line intent
+
+WARNING rule: normal intended use can trigger it → `WARNING (real)`; contrived/malicious/impossible path → `WARNING (theoretical)`.
+
+If clean: `VERDICT: CLEAN — No issues found.`
+
+Always end with: `Skill Resolution: {injected|fallback-registry|fallback-path|none} — {details}`.
+```
+
+## Fix Agent Prompt
+
+```markdown
+You are a surgical fix agent. Apply ONLY the confirmed issues listed below.
+
+## Confirmed Issues to Fix
+{confirmed findings table}
+
+## Project Standards (auto-resolved)
+{matching compact rules, if available}
+
+## Instructions
+- Fix only confirmed issues.
+- Do not refactor beyond the required fix.
+- Do not change unflagged code.
+- If fixing a repeated pattern in touched files, fix all occurrences of that same pattern.
+- Return changed file, line, and fix summary.
+
+End with: `Skill Resolution: {injected|fallback-registry|fallback-path|none} — {details}`.
+```
+
+## Verdict Table
+
+```markdown
+| Finding | Judge A | Judge B | Severity | Status |
+|---------|---------|---------|----------|--------|
+| Missing null check in auth.go:42 | ✅ | ✅ | CRITICAL | Confirmed |
+| Windows volume root edge case | ❌ | ✅ | WARNING (theoretical) | INFO |
+| Naming mismatch | ✅ | ❌ | SUGGESTION | Suspect |
+```
+
+Approved criteria after Round 1: zero confirmed CRITICALs and zero confirmed real WARNINGs. Theoretical warnings and suggestions may remain.
+
+## Language Snippets
+
+- Spanish: “Juicio iniciado”, “Los jueces trabajan en paralelo”, “Los jueces coinciden”, “Juicio terminado — Aprobado”, “Escalado — necesita revisión humana”.
+- English: “Judgment initiated”, “Both judges are working in parallel”, “Both judges agree”, “Judgment complete — Approved”, “Escalated — requires human review”.

--- a/internal/assets/skills/sdd-apply/SKILL.md
+++ b/internal/assets/skills/sdd-apply/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: sdd-apply
 description: "Implement SDD tasks from specs and design. Trigger: orchestrator launches apply for one or more change tasks."
+disable-model-invocation: true
+user-invocable: false
 license: MIT
 metadata:
   author: gentleman-programming

--- a/internal/assets/skills/sdd-archive/SKILL.md
+++ b/internal/assets/skills/sdd-archive/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: sdd-archive
 description: "Archive a completed SDD change by syncing delta specs. Trigger: orchestrator launches archive after implementation and verification."
+disable-model-invocation: true
+user-invocable: false
 license: MIT
 metadata:
   author: gentleman-programming

--- a/internal/assets/skills/sdd-design/SKILL.md
+++ b/internal/assets/skills/sdd-design/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: sdd-design
 description: "Create the SDD technical design and architecture approach. Trigger: orchestrator launches design for a change."
+disable-model-invocation: true
+user-invocable: false
 license: MIT
 metadata:
   author: gentleman-programming

--- a/internal/assets/skills/sdd-explore/SKILL.md
+++ b/internal/assets/skills/sdd-explore/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: sdd-explore
 description: "Explore SDD ideas before committing to a change. Trigger: orchestrator launches exploration or requirement clarification."
+disable-model-invocation: true
+user-invocable: false
 license: MIT
 metadata:
   author: gentleman-programming

--- a/internal/assets/skills/sdd-init/SKILL.md
+++ b/internal/assets/skills/sdd-init/SKILL.md
@@ -1,358 +1,55 @@
 ---
 name: sdd-init
-description: "Initialize SDD context, stack, conventions, tests, and persistence. Trigger: sdd init, iniciar sdd, or openspec init."
+description: "Trigger: sdd init, iniciar sdd, openspec init. Initialize SDD context, testing capabilities, registry, and persistence."
 license: MIT
 metadata:
   author: gentleman-programming
   version: "3.0"
 ---
 
-## Purpose
-
-You are a sub-agent responsible for initializing the Spec-Driven Development (SDD) context in a project. You detect the project stack, conventions, and testing capabilities, then bootstrap the active persistence backend.
-
-You are an EXECUTOR for this phase, not the orchestrator. Do the initialization work yourself. Do NOT launch sub-agents, do NOT call `delegate` or `task`, and do NOT hand execution back unless you hit a real blocker that must be reported upstream.
-
-## Execution and Persistence Contract
-
-- If mode is `engram`:
-  Do NOT create `openspec/` directory.
-
-  **Save project context**:
-  ```
-  mem_save(
-    title: "sdd-init/{project}",
-    topic_key: "sdd-init/{project}",
-    type: "architecture",
-    project: "{project}",
-    capture_prompt: false,
-    content: "{detected project context markdown}"
-  )
-  ```
-  `topic_key` enables upserts — re-running init updates the existing context, not duplicates.
-  Set `capture_prompt: false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
-
-  (See `skills/_shared/engram-convention.md` for full naming conventions.)
-- If mode is `openspec`: Read and follow `skills/_shared/openspec-convention.md`. Run full bootstrap.
-- If mode is `hybrid`: Read and follow BOTH convention files. Run openspec bootstrap AND persist context to Engram.
-- If mode is `none`: Return detected context without writing project files.
-
-## What to Do
-
-### Step 1: Detect Project Context
-
-Read the project to understand:
-- Tech stack (check package.json, go.mod, pyproject.toml, etc.)
-- Existing conventions (linters, test frameworks, CI)
-- Architecture patterns in use
-
-### Step 2: Detect Testing Capabilities
-
-Scan the project for ALL testing infrastructure. This determines what testing modes are available.
-
-```
-Detect testing capabilities:
-├── Test Runner
-│   ├── package.json → devDependencies: vitest, jest, mocha, ava
-│   ├── package.json → scripts.test (what command it runs)
-│   ├── pyproject.toml / pytest.ini / setup.cfg → pytest
-│   ├── go.mod → go test (built-in)
-│   ├── Cargo.toml → cargo test (built-in)
-│   ├── Makefile → make test
-│   └── Result: {framework name, command} or NOT FOUND
-│
-├── Test Layers
-│   ├── Unit: test runner exists → AVAILABLE
-│   ├── Integration:
-│   │   ├── JS/TS: @testing-library/* in dependencies
-│   │   ├── Python: pytest + httpx/requests-mock/factory-boy
-│   │   ├── Go: net/http/httptest (built-in)
-│   │   ├── .NET: xUnit/NUnit + WebApplicationFactory
-│   │   └── Result: AVAILABLE or NOT INSTALLED
-│   ├── E2E:
-│   │   ├── playwright, cypress, selenium in dependencies
-│   │   ├── Python: playwright, selenium
-│   │   ├── Go: chromedp
-│   │   └── Result: AVAILABLE or NOT INSTALLED
-│   └── Each layer → record tool name
-│
-├── Coverage Tool
-│   ├── JS/TS: vitest --coverage, jest --coverage, c8, istanbul/nyc
-│   ├── Python: coverage.py, pytest-cov
-│   ├── Go: go test -cover (built-in)
-│   ├── .NET: coverlet
-│   └── Result: {command} or NOT AVAILABLE
-│
-└── Quality Tools
-    ├── Linter: eslint, pylint, ruff, golangci-lint, clippy
-    ├── Type checker: tsc --noEmit, mypy, pyright, go vet
-    ├── Formatter: prettier, black, gofmt, rustfmt
-    └── Each: {command} or NOT AVAILABLE
-```
-
-### Step 3: Resolve STRICT TDD MODE
-
-Determine whether Strict TDD Mode should be enabled. The resolution follows a priority chain — first match wins:
-
-```
-1. Read from system prompt / agent config (highest priority):
-   ├── Search for "strict-tdd-mode" marker in the agent's system prompt file
-   │   (e.g., CLAUDE.md, GEMINI.md, .cursorrules, etc.)
-   ├── If found and says "enabled" → strict_tdd: true
-   ├── If found and says "disabled" → strict_tdd: false
-   └── This is the preference set by the user in the gentle-ai TUI
-
-2. If no marker found, check openspec config:
-   ├── Read openspec/config.yaml → strict_tdd field
-   └── If found → use that value
-
-3. If nothing found AND test runner was detected in Step 2:
-   ├── Default: strict_tdd: true (enable if the project CAN do TDD)
-   └── This ensures TDD is active even without gentle-ai TUI setup
-
-4. If no test runner detected:
-   ├── strict_tdd: false (cannot enable without test runner)
-   └── Include NOTE in summary: "Strict TDD Mode unavailable — no test runner detected"
-```
-
-**Do NOT ask the user interactively.** The preference is resolved from existing config. If the user wants to change it, they run `gentle-ai sync` with the TUI or set `strict_tdd` in `openspec/config.yaml`.
-
-### Step 4: Initialize Persistence Backend
-
-If mode resolves to `openspec`, create this directory structure:
-
-```
-openspec/
-├── config.yaml              ← Project-specific SDD config
-├── specs/                   ← Source of truth (empty initially)
-└── changes/                 ← Active changes
-    └── archive/             ← Completed changes
-```
-
-### Step 5: Generate Config (openspec mode)
-
-Based on what you detected, create the config when in `openspec` mode:
-
-```yaml
-# openspec/config.yaml
-schema: spec-driven
-
-context: |
-  Tech stack: {detected stack}
-  Architecture: {detected patterns}
-  Testing: {detected test framework}
-  Style: {detected linting/formatting}
-
-strict_tdd: {true/false}
-
-rules:
-  proposal:
-    - Include rollback plan for risky changes
-    - Identify affected modules/packages
-  specs:
-    - Use Given/When/Then format for scenarios
-    - Use RFC 2119 keywords (MUST, SHALL, SHOULD, MAY)
-  design:
-    - Include sequence diagrams for complex flows
-    - Document architecture decisions with rationale
-  tasks:
-    - Group tasks by phase (infrastructure, implementation, testing)
-    - Use hierarchical numbering (1.1, 1.2, etc.)
-    - Keep tasks small enough to complete in one session
-  apply:
-    - Follow existing code patterns and conventions
-    - Load relevant coding skills for the project stack
-  verify:
-    - Run tests if test infrastructure exists
-    - Compare implementation against every spec scenario
-  archive:
-    - Warn before merging destructive deltas (large removals)
-```
-
-### Step 6: Persist Testing Capabilities
-
-**This step is MANDATORY — do NOT skip it.**
-
-Persist detected testing capabilities as a separate Engram observation (or section in config.yaml for openspec). This cache prevents re-detection on every `sdd-apply` and `sdd-verify` run.
-
-If mode is `engram` or `hybrid`:
-```
-mem_save(
-  title: "sdd/{project}/testing-capabilities",
-  topic_key: "sdd/{project}/testing-capabilities",
-  type: "config",
-  project: "{project}",
-  capture_prompt: false,
-  content: "{testing capabilities markdown — see format below}"
-)
-```
-Set `capture_prompt: false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
-
-**Testing Capabilities format**:
-
-```markdown
-## Testing Capabilities
-
-**Strict TDD Mode**: {enabled/disabled}
-**Detected**: {date}
-
-### Test Runner
-- Command: `{command}`
-- Framework: {name}
-
-### Test Layers
-| Layer | Available | Tool |
-|-------|-----------|------|
-| Unit | ✅ / ❌ | {tool or —} |
-| Integration | ✅ / ❌ | {tool or —} |
-| E2E | ✅ / ❌ | {tool or —} |
-
-### Coverage
-- Available: ✅ / ❌
-- Command: `{command or —}`
-
-### Quality Tools
-| Tool | Available | Command |
-|------|-----------|---------|
-| Linter | ✅ / ❌ | {command or —} |
-| Type checker | ✅ / ❌ | {command or —} |
-| Formatter | ✅ / ❌ | {command or —} |
-```
-
-If mode is `openspec` or `hybrid`, also write this as a section in `openspec/config.yaml` under `testing:`.
-
-### Step 7: Build Skill Registry
-
-Follow the same logic as the `skill-registry` skill (`skills/skill-registry/SKILL.md`):
-
-1. Scan user skills: glob `*/SKILL.md` across ALL known skill directories. **User-level**: `~/.claude/skills/`, `~/.config/opencode/skills/`, `~/.gemini/skills/`, `~/.cursor/skills/`, `~/.copilot/skills/`, parent of this skill file. **Project-level**: `.claude/skills/`, `.gemini/skills/`, `.agent/skills/`, `skills/`. Skip `sdd-*`, `_shared`, `skill-registry`. Deduplicate by name (project-level wins). Read frontmatter triggers.
-2. Scan project conventions: check for `agents.md`, `AGENTS.md`, `CLAUDE.md` (project-level), `.cursorrules`, `GEMINI.md`, `copilot-instructions.md` in the project root. If an index file is found (e.g., `agents.md`), READ it and extract all referenced file paths — include both the index and its referenced files in the registry.
-3. **ALWAYS write `.atl/skill-registry.md`** in the project root (create `.atl/` if needed). This file is mode-independent — it's infrastructure, not an SDD artifact.
-4. If engram is available, **ALSO save to engram**: `mem_save(title: "skill-registry", topic_key: "skill-registry", type: "config", project: "{project}", capture_prompt: false, content: "{registry markdown}")`. Set `capture_prompt: false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
-
-See `skills/skill-registry/SKILL.md` for the full registry format and scanning details.
-
-### Step 8: Persist Project Context
-
-**This step is MANDATORY — do NOT skip it.**
-
-If mode is `engram`:
-```
-mem_save(
-  title: "sdd-init/{project}",
-  topic_key: "sdd-init/{project}",
-  type: "architecture",
-  project: "{project}",
-  capture_prompt: false,
-  content: "{your detected project context from Steps 1-7}"
-)
-```
-Set `capture_prompt: false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
-
-If mode is `openspec` or `hybrid`: the config was already written in Step 5.
-
-If mode is `hybrid`: also call `mem_save` as above (write to BOTH backends).
-
-### Step 9: Return Summary
-
-Return a structured summary adapted to the resolved mode:
-
-#### If mode is `engram`:
-
-Persist project context following `skills/_shared/engram-convention.md` with title and topic_key `sdd-init/{project}`.
-
-Return:
-```
-## SDD Initialized
-
-**Project**: {project name}
-**Stack**: {detected stack}
-**Persistence**: engram
-**Strict TDD Mode**: {enabled ✅ / disabled ❌ / unavailable (no test runner)}
-
-### Testing Capabilities
-| Capability | Status |
-|------------|--------|
-| Test Runner | {tool} ✅ / ❌ Not found |
-| Unit Tests | ✅ / ❌ |
-| Integration Tests | {tool} ✅ / ❌ Not installed |
-| E2E Tests | {tool} ✅ / ❌ Not installed |
-| Coverage | ✅ / ❌ |
-| Linter | {tool} ✅ / ❌ |
-| Type Checker | {tool} ✅ / ❌ |
-
-### Context Saved
-Project context persisted to Engram.
-- **Engram ID**: #{observation-id}
-- **Topic key**: sdd-init/{project}
-- **Capabilities ID**: #{capabilities-observation-id}
-- **Capabilities key**: sdd/{project}/testing-capabilities
-
-No project files created.
-
-### ⚠️ Engram Mode Limitations
-Engram mode is ideal for **solo developers** doing fast iteration. Be aware:
-- **No iteration history**: re-running a phase (e.g., `sdd-spec`) overwrites the previous version. Only the latest artifact is retained.
-- **Not shareable**: engram is a local database — team members cannot see your SDD artifacts.
-- **Partial audit trail**: the archive phase saves a summary report, but not the full artifact folder.
-
-For **team projects** or work that needs a full audit trail, consider switching to `openspec` (file-based, git-friendly) or `hybrid` (files + engram recovery).
-
-### Next Steps
-Ready for /sdd-explore <topic> or /sdd-new <change-name>.
-```
-
-#### If mode is `openspec`:
-```
-## SDD Initialized
-
-**Project**: {project name}
-**Stack**: {detected stack}
-**Persistence**: openspec
-**Strict TDD Mode**: {enabled ✅ / disabled ❌ / unavailable (no test runner)}
-
-### Testing Capabilities
-{same table as above}
-
-### Structure Created
-- openspec/config.yaml ← Project config with detected context + testing capabilities
-- openspec/specs/      ← Ready for specifications
-- openspec/changes/    ← Ready for change proposals
-
-### Next Steps
-Ready for /sdd-explore <topic> or /sdd-new <change-name>.
-```
-
-#### If mode is `none`:
-```
-## SDD Initialized
-
-**Project**: {project name}
-**Stack**: {detected stack}
-**Persistence**: none (ephemeral)
-**Strict TDD Mode**: {enabled ✅ / disabled ❌ / unavailable (no test runner)}
-
-### Testing Capabilities
-{same table as above}
-
-### Context Detected
-{summary of detected stack and conventions}
-
-### Recommendation
-Enable `engram` or `openspec` for artifact persistence across sessions. Without persistence, all SDD artifacts will be lost when the conversation ends.
-
-### Next Steps
-Ready for /sdd-explore <topic> or /sdd-new <change-name>.
-```
-
-## Rules
-
-- NEVER create placeholder spec files - specs are created via sdd-spec during a change
-- ALWAYS detect the real tech stack, don't guess
-- NEVER behave like the orchestrator from this phase - execute directly and return results
-- If the project already has an `openspec/` directory, report what exists and ask the orchestrator if it should be updated
-- Keep config.yaml context CONCISE - no more than 10 lines
-- ALWAYS detect testing capabilities — this is not optional
-- ALWAYS persist testing capabilities as a separate observation/section — downstream phases depend on it
-- If Strict TDD Mode is requested but no test runner exists, set strict_tdd: false and explain why
-- Return a structured envelope with: `status`, `executive_summary`, `detailed_report` (optional), `artifacts`, `next_recommended`, and `risks`
+## Activation Contract
+
+Run this phase when the orchestrator/user asks to initialize SDD in a project. You are the phase executor: do the work yourself, do not delegate, and do not behave like the orchestrator.
+
+## Hard Rules
+
+- Detect the real stack, conventions, architecture, testing tools, and persistence mode; never guess.
+- In `engram` mode, do **not** create `openspec/`.
+- In `openspec` mode, follow `../_shared/openspec-convention.md` and write file artifacts.
+- In `hybrid` mode, write both openspec files and Engram observations.
+- Always persist testing capabilities separately as `sdd/{project}/testing-capabilities` or `openspec/config.yaml` `testing:`.
+- Always build `.atl/skill-registry.md`; also save `skill-registry` to Engram when available.
+- Use `capture_prompt: false` for automated SDD/config saves when supported; omit it if the tool schema lacks it.
+- If `openspec/` already exists, report what exists and ask before updating it.
+
+## Decision Gates
+
+| Input | Action |
+|---|---|
+| `mode=engram` | Save context and capabilities to Engram only. |
+| `mode=openspec` | Create/update openspec bootstrap files only. |
+| `mode=hybrid` | Do both Engram and openspec persistence. |
+| `mode=none` | Return detected context only; write no SDD artifacts except registry if required. |
+| strict TDD marker/config found | Use that value. |
+| no marker/config but test runner exists | Default `strict_tdd: true`. |
+| no test runner | Set `strict_tdd: false` and explain unavailable. |
+
+## Execution Steps
+
+1. Inspect project files (`package.json`, `go.mod`, `pyproject.toml`, CI, lint/test config) and summarize stack/conventions.
+2. Detect test runner, test layers, coverage, linter, type checker, and formatter.
+3. Resolve Strict TDD from agent marker, `openspec/config.yaml`, detected runner fallback, or no-runner fallback.
+4. Initialize persistence for the resolved mode.
+5. Build `.atl/skill-registry.md` using the skill-registry scan rules.
+6. Persist testing capabilities and project context.
+7. Return the structured initialization envelope.
+
+## Output Contract
+
+Return `status`, `executive_summary`, `artifacts`, `next_recommended`, and `risks`. Include project, stack, persistence mode, Strict TDD status, testing capability table, saved observation IDs/paths, registry path, and next `/sdd-explore` or `/sdd-new` step.
+
+## References
+
+- [references/init-details.md](references/init-details.md) — detection checklist, Engram payloads, config skeleton, and output templates.
+- `../_shared/engram-convention.md` — Engram artifact naming.
+- `../_shared/openspec-convention.md` — openspec layout and rules.

--- a/internal/assets/skills/sdd-init/SKILL.md
+++ b/internal/assets/skills/sdd-init/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: sdd-init
 description: "Trigger: sdd init, iniciar sdd, openspec init. Initialize SDD context, testing capabilities, registry, and persistence."
+disable-model-invocation: true
+user-invocable: false
 license: MIT
 metadata:
   author: gentleman-programming

--- a/internal/assets/skills/sdd-init/references/init-details.md
+++ b/internal/assets/skills/sdd-init/references/init-details.md
@@ -1,0 +1,94 @@
+# SDD Init Details
+
+## Testing Capability Checklist
+
+- Test runner: `package.json` scripts/deps, `pyproject.toml`, `pytest.ini`, `go.mod`, `Cargo.toml`, `Makefile`.
+- Test layers: unit runner; integration libraries (`testing-library`, `httpx`, `httptest`, `WebApplicationFactory`); E2E tools (`playwright`, `cypress`, `selenium`, `chromedp`).
+- Coverage: `vitest --coverage`, `jest --coverage`, `c8`, `pytest-cov`, `go test -cover`, `coverlet`.
+- Quality: linter, type checker, formatter commands.
+
+## Skill Registry Scan Rules
+
+- Scan user skills: `~/.claude/skills/`, `~/.config/opencode/skills/`, `~/.gemini/skills/`, `~/.cursor/skills/`, `~/.copilot/skills/`, and the parent directory of this skill file.
+- Scan project skills: `{project-root}/.claude/skills/`, `{project-root}/.gemini/skills/`, `{project-root}/.agent/skills/`, and `{project-root}/skills/`.
+- Skip `sdd-*`, `_shared`, and `skill-registry`; deduplicate by skill name, preferring project-level skills over user-level skills.
+- Read each selected `SKILL.md`; if it exceeds 200 lines, focus on frontmatter plus Critical Patterns / Rules sections.
+- Extract `name`, trigger text from `description`, full `SKILL.md` path, and compact rules.
+- Generate compact rules as 5-15 actionable lines per skill: constraints, key patterns, breaking changes, and gotchas only. Do not include purpose, motivation, installation steps, full examples, or fluff.
+- Scan project convention files: `agents.md`, `AGENTS.md`, project-level `CLAUDE.md`, `.cursorrules`, `GEMINI.md`, and `copilot-instructions.md`.
+- For index files such as `AGENTS.md`, extract referenced file paths and include both the index and referenced files in the registry.
+
+## LLM-First Skill Criteria
+
+- Treat skills as runtime instruction contracts, not human documentation.
+- Required structure: frontmatter, Activation Contract, Hard Rules, Decision Gates, Execution Steps, Output Contract, References.
+- Keep `description` quoted, one physical line, trigger-first, and no longer than 250 characters.
+- Target 180-450 body tokens; move examples, schemas, edge cases, and background into local `references/` or `assets/`.
+- References must be local files and stable relative to the skill directory when possible.
+- Quality gates: hard rules are observable, decision gates cover real forks, output contract states exactly what to return, and references resolve locally.
+
+## Engram Saves
+
+```text
+mem_save title/topic_key: sdd-init/{project}
+type: architecture
+content: detected project context markdown
+capture_prompt: false when available
+
+mem_save title/topic_key: sdd/{project}/testing-capabilities
+type: config
+content: testing capabilities markdown
+capture_prompt: false when available
+
+mem_save title/topic_key: skill-registry
+type: config
+content: registry markdown
+capture_prompt: false when available
+```
+
+## OpenSpec Skeleton
+
+```text
+openspec/
+├── config.yaml
+├── specs/
+└── changes/
+    └── archive/
+```
+
+`config.yaml` should include concise context, `strict_tdd`, testing capabilities, and phase rules for proposal/spec/design/tasks/apply/verify/archive. Keep `context:` under 10 lines.
+
+## Testing Capabilities Format
+
+```markdown
+## Testing Capabilities
+
+**Strict TDD Mode**: {enabled/disabled}
+**Detected**: {date}
+
+### Test Runner
+- Command: `{command}`
+- Framework: {name}
+
+### Test Layers
+| Layer | Available | Tool |
+|-------|-----------|------|
+| Unit | ✅ / ❌ | {tool or —} |
+| Integration | ✅ / ❌ | {tool or —} |
+| E2E | ✅ / ❌ | {tool or —} |
+
+### Coverage
+- Available: ✅ / ❌
+- Command: `{command or —}`
+
+### Quality Tools
+| Tool | Available | Command |
+|------|-----------|---------|
+| Linter | ✅ / ❌ | {command or —} |
+| Type checker | ✅ / ❌ | {command or —} |
+| Formatter | ✅ / ❌ | {command or —} |
+```
+
+## Output Templates
+
+For each mode, include project, stack, persistence, Strict TDD Mode, Testing Capabilities table, artifacts created/saved, limitations where relevant, and next steps. Engram mode must mention local/non-shareable limitations; none mode must recommend enabling persistence.

--- a/internal/assets/skills/sdd-onboard/SKILL.md
+++ b/internal/assets/skills/sdd-onboard/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: sdd-onboard
 description: "Walk users through the SDD workflow on the real codebase. Trigger: orchestrator launches onboarding for the full SDD cycle."
+disable-model-invocation: true
+user-invocable: false
 license: MIT
 metadata:
   author: gentleman-programming

--- a/internal/assets/skills/sdd-propose/SKILL.md
+++ b/internal/assets/skills/sdd-propose/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: sdd-propose
 description: "Create an SDD change proposal with intent, scope, and approach. Trigger: orchestrator launches proposal work for a change."
+disable-model-invocation: true
+user-invocable: false
 license: MIT
 metadata:
   author: gentleman-programming

--- a/internal/assets/skills/sdd-spec/SKILL.md
+++ b/internal/assets/skills/sdd-spec/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: sdd-spec
 description: "Write SDD delta specs with requirements and scenarios. Trigger: orchestrator launches spec work for a change."
+disable-model-invocation: true
+user-invocable: false
 license: MIT
 metadata:
   author: gentleman-programming

--- a/internal/assets/skills/sdd-tasks/SKILL.md
+++ b/internal/assets/skills/sdd-tasks/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: sdd-tasks
 description: "Break an SDD change into implementation tasks. Trigger: orchestrator launches task planning for a change."
+disable-model-invocation: true
+user-invocable: false
 license: MIT
 metadata:
   author: gentleman-programming

--- a/internal/assets/skills/sdd-verify/SKILL.md
+++ b/internal/assets/skills/sdd-verify/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: sdd-verify
 description: "Trigger: SDD verification phase, verify change. Execute tests and prove implementation matches specs, design, and tasks."
+disable-model-invocation: true
+user-invocable: false
 license: MIT
 metadata:
   author: gentleman-programming

--- a/internal/assets/skills/sdd-verify/SKILL.md
+++ b/internal/assets/skills/sdd-verify/SKILL.md
@@ -1,342 +1,57 @@
 ---
 name: sdd-verify
-description: "Verify implementation against SDD specs, design, and tasks. Trigger: orchestrator launches verification for a change."
+description: "Trigger: SDD verification phase, verify change. Execute tests and prove implementation matches specs, design, and tasks."
 license: MIT
 metadata:
   author: gentleman-programming
   version: "3.0"
 ---
 
-## Purpose
-
-You are a sub-agent responsible for VERIFICATION. You are the quality gate. Your job is to prove — with real execution evidence — that the implementation is complete, correct, and behaviorally compliant with the specs.
-
-Static analysis alone is NOT enough. You must execute the code.
-
-## What You Receive
-
-From the orchestrator:
-- Change name
-- Artifact store mode (`engram | openspec | hybrid | none`)
-
-## Execution and Persistence Contract
-
-> Follow **Section B** (retrieval) and **Section C** (persistence) from `skills/_shared/sdd-phase-common.md`.
-
-- **engram**: Read `sdd/{change-name}/proposal`, `sdd/{change-name}/spec` (required for compliance matrix), `sdd/{change-name}/design`, `sdd/{change-name}/tasks` (all required). Save as `sdd/{change-name}/verify-report`.
-- **openspec**: Read and follow `skills/_shared/openspec-convention.md`. Save to `openspec/changes/{change-name}/verify-report.md`.
-- **hybrid**: Follow BOTH conventions — persist to Engram AND write `verify-report.md` to filesystem.
-- **none**: Return the verification report inline only. Never write files.
-
-## What to Do
-
-### Step 1: Load Skills
-Follow **Section A** from `skills/_shared/sdd-phase-common.md`.
-
-### Step 2: Read Testing Capabilities and Resolve TDD Mode
-
-Read the cached testing capabilities to determine if Strict TDD verification applies:
-
-```
-Read testing capabilities from:
-├── engram: mem_search("sdd/{project}/testing-capabilities") → mem_get_observation(id)
-├── openspec: openspec/config.yaml → strict_tdd + testing section
-└── Fallback: check project files directly
-
-Resolve mode:
-├── IF strict_tdd: true AND test runner exists
-│   └── STRICT TDD VERIFY → Load strict-tdd-verify.md module
-│       (read the file: skills/sdd-verify/strict-tdd-verify.md)
-│       This adds Steps 5a, expanded 5/5d, 5e to the verification
-│
-├── IF strict_tdd: false OR no test runner
-│   └── STANDARD VERIFY → skip TDD-specific checks entirely
-│       (strict-tdd-verify.md is never loaded — zero tokens)
-│
-└── Cache the resolved mode for the report header
-```
-
-#### Orchestrator-Injected TDD Mode
-
-If the orchestrator's launch prompt contains "STRICT TDD MODE IS ACTIVE", treat this as authoritative — do NOT override it with a failed engram search. The orchestrator already verified TDD status. Proceed directly to Strict TDD verification in Step 5a.
-
-### Step 3: Check Completeness
-
-Verify ALL tasks are done:
-
-```
-Read tasks.md
-├── Count total tasks
-├── Count completed tasks [x]
-├── List incomplete tasks [ ]
-└── Flag: CRITICAL if core tasks incomplete, WARNING if cleanup tasks incomplete
-```
-
-### Step 4: Check Correctness (Static Specs Match)
-
-For EACH spec requirement and scenario, search the codebase for structural evidence:
-
-```
-FOR EACH REQUIREMENT in specs/:
-├── Search codebase for implementation evidence
-├── For each SCENARIO:
-│   ├── Is the GIVEN precondition handled in code?
-│   ├── Is the WHEN action implemented?
-│   ├── Is the THEN outcome produced?
-│   └── Are edge cases covered?
-└── Flag: CRITICAL if requirement missing, WARNING if scenario partially covered
-```
-
-Note: This is static analysis only. Behavioral validation with real execution happens in Step 7.
-
-### Step 5: Check Coherence (Design Match)
-
-Verify design decisions were followed:
-
-```
-FOR EACH DECISION in design.md:
-├── Was the chosen approach actually used?
-├── Were rejected alternatives accidentally implemented?
-├── Do file changes match the "File Changes" table?
-└── Flag: WARNING if deviation found (may be valid improvement)
-```
-
-### Step 5a: TDD Compliance Check (Strict TDD only)
-
-> **Skip this step entirely if Strict TDD Mode is not active.**
-
-If Strict TDD is active, follow the instructions in `strict-tdd-verify.md` Step 5a.
-
-### Step 6: Check Testing
-
-#### Step 6a: Static Test Analysis
-
-Verify test files exist and cover the right scenarios:
-
-```
-Search for test files related to the change
-├── Do tests exist for each spec scenario?
-├── Do tests cover happy paths?
-├── Do tests cover edge cases?
-├── Do tests cover error states?
-└── Flag: WARNING if scenarios lack tests, SUGGESTION if coverage could improve
-```
-
-#### Step 6b: Run Tests (Real Execution)
-
-Detect the project's test runner and execute the tests:
-
-```
-Detect test runner from:
-├── Cached testing capabilities → test_runner.command (fastest)
-├── openspec/config.yaml → rules.verify.test_command (override)
-├── package.json → scripts.test
-├── pyproject.toml / pytest.ini → pytest
-├── Makefile → make test
-└── Fallback: ask orchestrator
-
-Execute: {test_command}
-Capture:
-├── Total tests run
-├── Passed
-├── Failed (list each with name and error)
-├── Skipped
-└── Exit code
-
-Flag: CRITICAL if exit code != 0 (any test failed)
-Flag: WARNING if skipped tests relate to changed areas
-```
-
-#### Step 6c: Build & Type Check (Real Execution)
-
-Detect and run the build/type-check command:
-
-```
-Detect build command from:
-├── Cached testing capabilities → quality_tools.type_checker (fastest)
-├── openspec/config.yaml → rules.verify.build_command (override)
-├── package.json → scripts.build → also run tsc --noEmit if tsconfig.json exists
-├── pyproject.toml → python -m build or equivalent
-├── Makefile → make build
-└── Fallback: skip and report as WARNING (not CRITICAL)
-
-Execute: {build_command}
-Capture:
-├── Exit code
-├── Errors (if any)
-└── Warnings (if significant)
-
-Flag: CRITICAL if build fails (exit code != 0)
-Flag: WARNING if there are type errors even with passing build
-```
-
-#### Step 6d: Coverage Validation (Real Execution — if available)
-
-Run coverage if the tool is available (from cached capabilities or config):
-
-```
-IF coverage tool available (from cached capabilities or rules.verify.coverage_threshold set):
-├── Run: {test_command} --coverage (or equivalent for the test runner)
-├── Parse coverage report
-├── IF Strict TDD active → follow expanded Step 5d from strict-tdd-verify.md
-│   (per-file coverage for changed files, uncovered line ranges)
-├── IF Standard mode → report total coverage only
-│   ├── Compare total coverage % against threshold (if configured)
-│   └── Flag: WARNING if below threshold
-└── Report
-
-IF coverage tool NOT available:
-└── Skip this step, report as "Not available"
-```
-
-#### Step 6e: Quality Metrics (Strict TDD only)
-
-> **Skip this step entirely if Strict TDD Mode is not active.**
-
-If Strict TDD is active, follow the instructions in `strict-tdd-verify.md` Step 5e.
-
-### Step 7: Spec Compliance Matrix (Behavioral Validation)
-
-This is the most important step. Cross-reference EVERY spec scenario against the actual test run results from Step 6b to build behavioral evidence.
-
-For each scenario from the specs, find which test(s) cover it and what the result was:
-
-```
-FOR EACH REQUIREMENT in specs/:
-  FOR EACH SCENARIO:
-  ├── Find tests that cover this scenario (by name, description, or file path)
-  ├── Look up that test's result from Step 6b output
-  ├── Assign compliance status:
-  │   ├── ✅ COMPLIANT   → test exists AND passed
-  │   ├── ❌ FAILING     → test exists BUT failed (CRITICAL)
-  │   ├── ❌ UNTESTED    → no test found for this scenario (CRITICAL)
-  │   └── ⚠️ PARTIAL    → test exists, passes, but covers only part of the scenario (WARNING)
-  └── Record: requirement, scenario, test file, test name, result
-```
-
-A spec scenario is only considered COMPLIANT when there is a test that passed proving the behavior at runtime. Code existing in the codebase is NOT sufficient evidence.
-
-### Step 7a: Test Layer Validation (Strict TDD only)
-
-> **Skip this step entirely if Strict TDD Mode is not active.**
-
-If Strict TDD is active, follow the instructions in `strict-tdd-verify.md` (Step 5 Expanded: Test Layer Validation).
-
-### Step 8: Persist Verification Report
-
-Follow **Section C** from `skills/_shared/sdd-phase-common.md`.
-- artifact: `verify-report`
-- topic_key: `sdd/{change-name}/verify-report`
-- type: `architecture`
-
-### Step 9: Return Summary
-
-Return to the orchestrator the same content you wrote to `verify-report.md`:
-
-```markdown
-## Verification Report
-
-**Change**: {change-name}
-**Version**: {spec version or N/A}
-**Mode**: {Strict TDD | Standard}
-
----
-
-### Completeness
-| Metric | Value |
-|--------|-------|
-| Tasks total | {N} |
-| Tasks complete | {N} |
-| Tasks incomplete | {N} |
-
-{List incomplete tasks if any}
-
----
-
-### Build & Tests Execution
-
-**Build**: ✅ Passed / ❌ Failed
-```
-{build command output or error if failed}
-```
-
-**Tests**: ✅ {N} passed / ❌ {N} failed / ⚠️ {N} skipped
-```
-{failed test names and errors if any}
-```
-
-**Coverage**: {N}% / threshold: {N}% → ✅ Above threshold / ⚠️ Below threshold / ➖ Not available
-
----
-
-{IF Strict TDD Mode → include TDD Compliance table from strict-tdd-verify.md}
-{IF Strict TDD Mode → include Test Layer Distribution table from strict-tdd-verify.md}
-{IF Strict TDD Mode → include Changed File Coverage table from strict-tdd-verify.md}
-{IF Strict TDD Mode → include Quality Metrics from strict-tdd-verify.md}
-
-### Spec Compliance Matrix
-
-| Requirement | Scenario | Test | Result |
-|-------------|----------|------|--------|
-| {REQ-01: name} | {Scenario name} | `{test file} > {test name}` | ✅ COMPLIANT |
-| {REQ-01: name} | {Scenario name} | `{test file} > {test name}` | ❌ FAILING |
-| {REQ-02: name} | {Scenario name} | (none found) | ❌ UNTESTED |
-| {REQ-02: name} | {Scenario name} | `{test file} > {test name}` | ⚠️ PARTIAL |
-
-**Compliance summary**: {N}/{total} scenarios compliant
-
----
-
-### Correctness (Static — Structural Evidence)
-| Requirement | Status | Notes |
-|------------|--------|-------|
-| {Req name} | ✅ Implemented | {brief note} |
-| {Req name} | ⚠️ Partial | {what's missing} |
-| {Req name} | ❌ Missing | {not implemented} |
-
----
-
-### Coherence (Design)
-| Decision | Followed? | Notes |
-|----------|-----------|-------|
-| {Decision name} | ✅ Yes | |
-| {Decision name} | ⚠️ Deviated | {how and why} |
-
----
-
-### Issues Found
-
-**CRITICAL** (must fix before archive):
-{List or "None"}
-
-**WARNING** (should fix):
-{List or "None"}
-
-**SUGGESTION** (nice to have):
-{List or "None"}
-
----
-
-### Verdict
-{PASS / PASS WITH WARNINGS / FAIL}
-
-{One-line summary of overall status}
-```
-
-## Rules
-
-- ALWAYS read the actual source code — don't trust summaries
-- ALWAYS execute tests — static analysis alone is not verification
-- A spec scenario is only COMPLIANT when a test that covers it has PASSED
-- Compare against SPECS first (behavioral correctness), DESIGN second (structural correctness)
-- Be objective — report what IS, not what should be
-- CRITICAL issues = must fix before archive
-- WARNINGS = should fix but won't block
-- SUGGESTIONS = improvements, not blockers
-- DO NOT fix any issues — only report them. The orchestrator decides what to do.
-- In `openspec` mode, ALWAYS save the report to `openspec/changes/{change-name}/verify-report.md` — this persists the verification for sdd-archive and the audit trail
-- Apply any `rules.verify` from `openspec/config.yaml`
-- If Strict TDD is active, load `strict-tdd-verify.md` and execute ALL its additional steps — they are mandatory, not optional
-- If Strict TDD is NOT active, NEVER load `strict-tdd-verify.md` — zero tokens wasted on TDD checks
-- Use cached testing capabilities from Engram/config whenever possible — avoid re-detecting
-- Return envelope per **Section D** from `skills/_shared/sdd-phase-common.md`.
+## Activation Contract
+
+Run when the orchestrator launches verification for an SDD change. You are the quality gate: prove completion with source inspection plus real execution evidence.
+
+## Hard Rules
+
+- Read proposal, spec, design, and tasks before judging implementation.
+- Execute relevant tests; static analysis alone is never verification.
+- A spec scenario is compliant only when a covering test passed at runtime.
+- Compare specs first, design second, task completion third.
+- Do not fix issues; report them for the orchestrator/user.
+- Persist `verify-report` according to mode: Engram, openspec file, hybrid both, or inline-only for `none`.
+- If Strict TDD is active, load `strict-tdd-verify.md` from this skill directory; if inactive, never load it.
+- Return the Section D envelope from `../_shared/sdd-phase-common.md`.
+
+## Decision Gates
+
+| Condition | Action |
+|---|---|
+| Orchestrator says `STRICT TDD MODE IS ACTIVE` | Treat as authoritative. |
+| Cached/config `strict_tdd: true` and runner exists | Strict TDD verify; load module. |
+| Strict TDD false or no runner | Standard verify; skip TDD checks. |
+| Task incomplete | CRITICAL for core task, WARNING for cleanup task. |
+| Test command exits non-zero | CRITICAL. |
+| Spec scenario has no passing covering test | CRITICAL `UNTESTED` or `FAILING`. |
+| Design deviation exists | WARNING unless it breaks a spec. |
+
+## Execution Steps
+
+1. Load relevant skills via shared SDD Section A.
+2. Retrieve artifacts via shared Section B for the active persistence mode.
+3. Resolve testing/TDD mode from cached capabilities, config, or project files.
+4. Count completed and incomplete tasks.
+5. Map each spec requirement/scenario to implementation evidence and tests.
+6. Check design decisions against changed code.
+7. Run test, build/type-check, and coverage commands when available.
+8. Build the behavioral compliance matrix from actual test results.
+9. Persist and return the verification report.
+
+## Output Contract
+
+Return `## Verification Report` with change, mode, completeness table, build/tests/coverage evidence, spec compliance matrix, correctness table, design coherence table, issues grouped as CRITICAL/WARNING/SUGGESTION, and final verdict `PASS`, `PASS WITH WARNINGS`, or `FAIL`.
+
+## References
+
+- [references/report-format.md](references/report-format.md) — full report template, compliance statuses, and command evidence fields.
+- [strict-tdd-verify.md](strict-tdd-verify.md) — load only when Strict TDD is active.
+- `../_shared/sdd-phase-common.md` — skill loading, retrieval, persistence, and return envelope.

--- a/internal/assets/skills/sdd-verify/references/report-format.md
+++ b/internal/assets/skills/sdd-verify/references/report-format.md
@@ -1,0 +1,67 @@
+# SDD Verify Report Format
+
+## Compliance Statuses
+
+- ✅ `COMPLIANT`: covering test exists and passed.
+- ❌ `FAILING`: covering test exists but failed.
+- ❌ `UNTESTED`: no covering test found.
+- ⚠️ `PARTIAL`: test passes but covers only part of the scenario.
+
+## Report Template
+
+~~~markdown
+## Verification Report
+
+**Change**: {change-name}
+**Version**: {spec version or N/A}
+**Mode**: {Strict TDD | Standard}
+
+### Completeness
+| Metric | Value |
+|--------|-------|
+| Tasks total | {N} |
+| Tasks complete | {N} |
+| Tasks incomplete | {N} |
+
+### Build & Tests Execution
+**Build**: ✅ Passed / ❌ Failed
+```text
+{build command and relevant output}
+```
+
+**Tests**: ✅ {N} passed / ❌ {N} failed / ⚠️ {N} skipped
+```text
+{test command and failure details}
+```
+
+**Coverage**: {N}% / threshold: {N}% → ✅ Above / ⚠️ Below / ➖ Not available
+
+### Spec Compliance Matrix
+| Requirement | Scenario | Test | Result |
+|-------------|----------|------|--------|
+| {REQ-01} | {Scenario} | `{file} > {test}` | ✅ COMPLIANT |
+| {REQ-02} | {Scenario} | (none found) | ❌ UNTESTED |
+
+**Compliance summary**: {N}/{total} scenarios compliant
+
+### Correctness (Static Evidence)
+| Requirement | Status | Notes |
+|------------|--------|-------|
+| {Req name} | ✅ Implemented | {brief note} |
+
+### Coherence (Design)
+| Decision | Followed? | Notes |
+|----------|-----------|-------|
+| {Decision} | ✅ Yes | |
+
+### Issues Found
+**CRITICAL**: {list or None}
+**WARNING**: {list or None}
+**SUGGESTION**: {list or None}
+
+### Verdict
+{PASS / PASS WITH WARNINGS / FAIL}
+{one-line reason}
+~~~
+
+When Strict TDD is active, insert the TDD compliance, test layer distribution, changed-file coverage, and quality metrics sections from `strict-tdd-verify.md`.

--- a/internal/assets/skills/skill-creator/SKILL.md
+++ b/internal/assets/skills/skill-creator/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: skill-creator
-description: "Create AI agent skills with valid frontmatter. Trigger: new skills, agent instructions, or documenting AI usage patterns."
+description: "Trigger: new skills, agent instructions, documenting AI usage patterns. Create LLM-first skills with valid frontmatter."
 license: Apache-2.0
 metadata:
   author: gentleman-programming
   version: "1.0"
 ---
 
-## When to Create a Skill
+## Activation Contract
 
 Create a skill when:
 - A pattern is used repeatedly and AI needs guidance
@@ -15,14 +15,31 @@ Create a skill when:
 - Complex workflows need step-by-step instructions
 - Decision trees help AI choose the right approach
 
-**Don't create a skill when:**
-- Documentation already exists (create a reference instead)
-- Pattern is trivial or self-explanatory
-- It's a one-off task
+Do not create a skill when the pattern is trivial, one-off, or better served by normal documentation.
 
----
+## Hard Rules
 
-## Skill Structure
+- When working in this repo, first follow `docs/skill-style-guide.md` as the normative source before creating or updating skills.
+- If that guide is unavailable, use the compact inline rules below.
+- A skill is a runtime instruction contract for an LLM, not human documentation.
+- Do not add a `Keywords` section; preserve essential trigger words in `description`.
+- References must point to local files.
+- Keep the skill body concise: target 180–450 tokens, recommended max 700, hard max 1000.
+
+## Decision Gates
+
+| Need | Action |
+|------|--------|
+| Code templates, schemas, fixtures, generated examples | Put them in `assets/` |
+| Conceptual detail, edge cases, existing docs | Put local links in `references/` |
+| Long explanation in `SKILL.md` | Move it to a supporting file |
+| Multiple meaningful paths | Add a compact decision table |
+
+## Execution Steps
+
+1. Check whether `docs/skill-style-guide.md` exists; if it does, apply it before the inline fallback rules.
+2. Confirm the skill does not already exist and the pattern is reusable.
+3. Create or update `skills/{skill-name}/SKILL.md` using this required structure:
 
 ```
 skills/{skill-name}/
@@ -33,97 +50,33 @@ skills/{skill-name}/
 └── references/           # Optional - links to local docs
     └── docs.md           # Points to docs/developer-guide/*.mdx
 ```
-
----
-
-## SKILL.md Template
+4. Use this frontmatter shape:
 
 ```markdown
 ---
 name: {skill-name}
-description: "{What this skill does}. Trigger: {essential trigger words users or agents will say}."
+description: "Trigger: {essential trigger words users or agents will say}. {What this skill does}."
 license: Apache-2.0
 metadata:
   author: gentleman-programming
   version: "1.0"
 ---
-
-## When to Use
-
-{Bullet points of when to use this skill}
-
-## Critical Patterns
-
-{The most important rules - what AI MUST know}
-
-## Code Examples
-
-{Minimal, focused examples}
-
-## Commands
-
-```bash
-{Common commands}
 ```
+5. Write sections in this order: Activation Contract, Hard Rules, Decision Gates, Execution Steps, Output Contract, References.
+6. Register the skill in `AGENTS.md` when it is a project skill.
 
-## Resources
+## Inline Fallback Rules
 
-- **Templates**: See [assets/](assets/) for {description}
-- **Documentation**: See [references/](references/) for local docs
-```
-
----
-
-## Naming Conventions
-
-| Type | Pattern | Examples |
-|------|---------|----------|
-| Generic skill | `{technology}` | `pytest`, `playwright`, `typescript` |
-| Project-specific | `{project}-{component}` | `myapp-api`, `myapp-ui` |
-| Testing skill | `{project}-test-{component}` | `myapp-test-sdk`, `myapp-test-api` |
-| Workflow skill | `{action}-{target}` | `skill-creator`, `jira-task` |
-
----
-
-## Decision: assets/ vs references/
-
-```
-Need code templates?        → assets/
-Need JSON schemas?          → assets/
-Need example configs?       → assets/
-Link to existing docs?      → references/
-Link to external guides?    → references/ (with local path)
-```
-
-**Key Rule**: `references/` should point to LOCAL files, not web URLs.
-
----
-
-## Frontmatter Fields
-
-| Field | Required | Description |
-|-------|----------|-------------|
-| `name` | Yes | Skill identifier (lowercase, hyphens) |
-| `description` | Yes | Single-line, quoted YAML-safe string with what + `Trigger:` |
-| `license` | Yes | Always `Apache-2.0` |
-| `metadata.author` | Yes | `gentleman-programming` |
-| `metadata.version` | Yes | Semantic version as string |
-
-### Description Rules
-
-The `description` field is the skill-loading budget. Treat it as mandatory metadata, not prose.
-
-- MUST be one physical line in frontmatter; never use `>` or `|` block scalars.
-- MUST be YAML-safe: wrap the whole value in quotes and avoid unescaped matching quotes inside it.
-- MUST include `Trigger:` and preserve the essential trigger words users or agents will actually say.
-- SHOULD be <=160 chars; this is preferred for Claude Code skill-list budget.
-- MUST be <=250 chars if a rare skill genuinely needs extra trigger coverage.
-- MUST NOT add `Keywords`; put concise trigger keywords in `description` instead.
+- `description` MUST be one physical line, quoted, YAML-safe, and include essential trigger words first.
+- `description` SHOULD be <=160 chars and MUST be <=250 chars.
+- Frontmatter MUST include `name`, `description`, `license`, `metadata.author`, and `metadata.version`.
+- Use imperative instructions, not tutorials or background prose.
+- Put supporting material in `assets/` or `references/`, not the main skill body.
 
 Good:
 
 ```yaml
-description: "Create Jira tasks in the team format. Trigger: Jira task, ticket, issue, or task creation."
+description: "Trigger: Jira task, ticket, issue, task creation. Create Jira tasks in the team format."
 ```
 
 Bad:
@@ -135,50 +88,14 @@ description: >
 Keywords: jira, task
 ```
 
----
+## Output Contract
 
-## Content Guidelines
+Return:
+- Files created or modified.
+- Whether the repo style guide or inline fallback rules were used.
+- Any AGENTS.md registration change.
+- Any supporting files added under `assets/` or `references/`.
 
-### DO
-- Start with the most critical patterns
-- Use tables for decision trees
-- Keep code examples minimal and focused
-- Include Commands section with copy-paste commands
-- Keep frontmatter descriptions concise with essential trigger keywords
+## References
 
-### DON'T
-- Add Keywords section (agent searches frontmatter, not body)
-- Use multiline, unquoted, or block-scalar frontmatter descriptions
-- Duplicate content from existing docs (reference instead)
-- Include lengthy explanations (link to docs)
-- Add troubleshooting sections (keep focused)
-- Use web URLs in references (use local paths)
-
----
-
-## Registering the Skill
-
-After creating the skill, add it to `AGENTS.md`:
-
-```markdown
-| `{skill-name}` | {Description} | [SKILL.md](skills/{skill-name}/SKILL.md) |
-```
-
----
-
-## Checklist Before Creating
-
-- [ ] Skill doesn't already exist (check `skills/`)
-- [ ] Pattern is reusable (not one-off)
-- [ ] Name follows conventions
-- [ ] Frontmatter is complete (description is quoted, one-line, YAML-safe, includes `Trigger:`)
-- [ ] Description is ideally <=160 chars and never >250 chars
-- [ ] Description preserves essential trigger words; no `Keywords` section added
-- [ ] Critical patterns are clear
-- [ ] Code examples are minimal
-- [ ] Commands section exists
-- [ ] Added to AGENTS.md
-
-## Resources
-
-- **Templates**: See [assets/](assets/) for SKILL.md template
+- `docs/skill-style-guide.md` — normative LLM-first skill style guide for this repo.

--- a/internal/assets/skills_frontmatter_test.go
+++ b/internal/assets/skills_frontmatter_test.go
@@ -28,11 +28,13 @@ func TestSkillFrontmatterIsLintClean(t *testing.T) {
 	skillPaths := embeddedSkillPaths(t)
 
 	allowedKeys := map[string]bool{
-		"name":        true,
-		"description": true,
-		"license":     true,
-		"metadata":    true,
-		"version":     true,
+		"name":                     true,
+		"description":              true,
+		"license":                  true,
+		"metadata":                 true,
+		"version":                  true,
+		"user-invocable":           true,
+		"disable-model-invocation": true,
 	}
 
 	for _, path := range skillPaths {
@@ -74,7 +76,7 @@ func TestSkillFrontmatterIsLintClean(t *testing.T) {
 			// Rule 5: only allowed top-level keys.
 			for _, key := range fm.topLevelKeys {
 				if !allowedKeys[key] {
-					t.Errorf("non-standard top-level frontmatter key %q (allowed: name, description, license, metadata, version)", key)
+					t.Errorf("non-standard top-level frontmatter key %q (allowed: name, description, license, metadata, version, user-invocable, disable-model-invocation)", key)
 				}
 			}
 		})

--- a/internal/components/sdd/inject.go
+++ b/internal/components/sdd/inject.go
@@ -474,27 +474,38 @@ func Inject(homeDir string, adapter agents.Adapter, sddMode model.SDDModeID, opt
 					return InjectionResult{}, fmt.Errorf("required SDD skill %q: embedded directory is empty", skill)
 				}
 
-				for _, entry := range entries {
+				walkErr := fs.WalkDir(assets.FS, embedDir, func(assetPath string, entry fs.DirEntry, walkErr error) error {
+					if walkErr != nil {
+						return walkErr
+					}
 					if entry.IsDir() {
-						continue
-					}
-					assetPath := embedDir + "/" + entry.Name()
-					content, readErr := assets.Read(assetPath)
-					if readErr != nil {
-						return InjectionResult{}, fmt.Errorf("required SDD skill %q file %q: embedded asset not found: %w", skill, entry.Name(), readErr)
-					}
-					if len(content) == 0 {
-						return InjectionResult{}, fmt.Errorf("required SDD skill %q file %q: embedded asset is empty", skill, entry.Name())
+						return nil
 					}
 
-					path := filepath.Join(skillDir, skill, entry.Name())
+					content, readErr := assets.Read(assetPath)
+					if readErr != nil {
+						return fmt.Errorf("embedded asset not found: %w", readErr)
+					}
+					if len(content) == 0 {
+						return fmt.Errorf("embedded asset is empty")
+					}
+
+					relPath, relErr := filepath.Rel(filepath.FromSlash(embedDir), filepath.FromSlash(assetPath))
+					if relErr != nil {
+						return fmt.Errorf("resolve relative path for %q: %w", assetPath, relErr)
+					}
+					path := filepath.Join(skillDir, skill, relPath)
 					writeResult, err := filemerge.WriteFileAtomic(path, []byte(content), 0o644)
 					if err != nil {
-						return InjectionResult{}, err
+						return err
 					}
 
 					changed = changed || writeResult.Changed
 					files = append(files, path)
+					return nil
+				})
+				if walkErr != nil {
+					return InjectionResult{}, fmt.Errorf("required SDD skill %q: copy embedded directory: %w", skill, walkErr)
 				}
 			}
 		}

--- a/internal/components/sdd/inject.go
+++ b/internal/components/sdd/inject.go
@@ -484,10 +484,10 @@ func Inject(homeDir string, adapter agents.Adapter, sddMode model.SDDModeID, opt
 
 					content, readErr := assets.Read(assetPath)
 					if readErr != nil {
-						return fmt.Errorf("embedded asset not found: %w", readErr)
+						return fmt.Errorf("embedded asset %q not found: %w", assetPath, readErr)
 					}
 					if len(content) == 0 {
-						return fmt.Errorf("embedded asset is empty")
+						return fmt.Errorf("embedded asset %q is empty", assetPath)
 					}
 
 					relPath, relErr := filepath.Rel(filepath.FromSlash(embedDir), filepath.FromSlash(assetPath))
@@ -497,7 +497,7 @@ func Inject(homeDir string, adapter agents.Adapter, sddMode model.SDDModeID, opt
 					path := filepath.Join(skillDir, skill, relPath)
 					writeResult, err := filemerge.WriteFileAtomic(path, []byte(content), 0o644)
 					if err != nil {
-						return err
+						return fmt.Errorf("write %q: %w", path, err)
 					}
 
 					changed = changed || writeResult.Changed

--- a/internal/components/sdd/inject_test.go
+++ b/internal/components/sdd/inject_test.go
@@ -2338,6 +2338,46 @@ func TestInjectCopiesAllFilesFromSkillDirectory(t *testing.T) {
 	}
 }
 
+func TestInjectCopiesNestedSDDSkillReferences(t *testing.T) {
+	home := t.TempDir()
+
+	result, err := Inject(home, opencodeAdapter(), "")
+	if err != nil {
+		t.Fatalf("Inject() error = %v", err)
+	}
+	if !result.Changed {
+		t.Fatal("Inject() changed = false")
+	}
+
+	skillsDir := filepath.Join(home, ".config", "opencode", "skills")
+	tests := []struct {
+		name string
+		path string
+	}{
+		{name: "sdd-init details", path: filepath.Join(skillsDir, "sdd-init", "references", "init-details.md")},
+		{name: "sdd-verify report", path: filepath.Join(skillsDir, "sdd-verify", "references", "report-format.md")},
+		{name: "judgment-day prompts", path: filepath.Join(skillsDir, "judgment-day", "references", "prompts-and-formats.md")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertNonEmptyFile(t, tt.path)
+		})
+	}
+}
+
+func assertNonEmptyFile(t *testing.T, path string) {
+	t.Helper()
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("expected file %q: %v", path, err)
+	}
+	if info.Size() == 0 {
+		t.Fatalf("expected file %q to be non-empty", path)
+	}
+}
+
 // TestInjectCopiesAllFilesReportedInResult verifies that all skill files
 // (including extra files beyond SKILL.md) are included in result.Files.
 func TestInjectCopiesAllFilesReportedInResult(t *testing.T) {

--- a/internal/components/skills/inject.go
+++ b/internal/components/skills/inject.go
@@ -83,7 +83,7 @@ func Inject(homeDir string, adapter agents.Adapter, skillIDs []model.SkillID) (I
 				return fmt.Errorf("read %q: %w", assetPath, readErr)
 			}
 			if len(content) == 0 {
-				return fmt.Errorf("embedded asset is empty")
+				return fmt.Errorf("embedded asset %q is empty", assetPath)
 			}
 
 			relPath, relErr := filepath.Rel(filepath.FromSlash(embedDir), filepath.FromSlash(assetPath))

--- a/internal/components/skills/inject.go
+++ b/internal/components/skills/inject.go
@@ -2,6 +2,7 @@ package skills
 
 import (
 	"fmt"
+	"io/fs"
 	"log"
 	"path/filepath"
 	"strings"
@@ -57,25 +58,51 @@ func Inject(homeDir string, adapter agents.Adapter, skillIDs []model.SkillID) (I
 			continue
 		}
 
-		assetPath := "skills/" + string(id) + "/SKILL.md"
-		content, readErr := assets.Read(assetPath)
+		embedDir := "skills/" + string(id)
+		entries, readErr := fs.ReadDir(assets.FS, embedDir)
 		if readErr != nil {
 			log.Printf("skills: skipping %q — embedded asset not found: %v", id, readErr)
 			skipped = append(skipped, id)
 			continue
 		}
-		if len(content) == 0 {
-			return InjectionResult{}, fmt.Errorf("skill %q: embedded asset exists but is empty — build may be corrupt", id)
+		if len(entries) == 0 {
+			return InjectionResult{}, fmt.Errorf("skill %q: embedded directory exists but is empty — build may be corrupt", id)
 		}
 
-		path := filepath.Join(skillDir, string(id), "SKILL.md")
-		writeResult, writeErr := filemerge.WriteFileAtomic(path, []byte(content), 0o644)
-		if writeErr != nil {
-			return InjectionResult{}, fmt.Errorf("skill %q: write failed: %w", id, writeErr)
-		}
+		destDir := filepath.Join(skillDir, string(id))
+		walkErr := fs.WalkDir(assets.FS, embedDir, func(assetPath string, d fs.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return walkErr
+			}
+			if d.IsDir() {
+				return nil
+			}
 
-		changed = changed || writeResult.Changed
-		paths = append(paths, path)
+			content, readErr := assets.Read(assetPath)
+			if readErr != nil {
+				return fmt.Errorf("read %q: %w", assetPath, readErr)
+			}
+			if len(content) == 0 {
+				return fmt.Errorf("embedded asset is empty")
+			}
+
+			relPath, relErr := filepath.Rel(filepath.FromSlash(embedDir), filepath.FromSlash(assetPath))
+			if relErr != nil {
+				return fmt.Errorf("resolve relative path for %q: %w", assetPath, relErr)
+			}
+			path := filepath.Join(destDir, relPath)
+			writeResult, writeErr := filemerge.WriteFileAtomic(path, []byte(content), 0o644)
+			if writeErr != nil {
+				return fmt.Errorf("write %q: %w", path, writeErr)
+			}
+
+			changed = changed || writeResult.Changed
+			paths = append(paths, path)
+			return nil
+		})
+		if walkErr != nil {
+			return InjectionResult{}, fmt.Errorf("skill %q: copy embedded directory: %w", id, walkErr)
+		}
 	}
 
 	return InjectionResult{Changed: changed, Files: paths, Skipped: skipped}, nil

--- a/internal/components/skills/inject_test.go
+++ b/internal/components/skills/inject_test.go
@@ -69,15 +69,44 @@ func TestInjectWritesSkillFilesForClaude(t *testing.T) {
 		t.Fatalf("Inject() changed = false")
 	}
 
-	if len(result.Files) != 2 {
-		t.Fatalf("Inject() files len = %d, want 2", len(result.Files))
-	}
-
-	for _, id := range []model.SkillID{model.SkillCreator, model.SkillGoTesting} {
-		path := filepath.Join(home, ".claude", "skills", string(id), "SKILL.md")
+	for _, path := range []string{
+		filepath.Join(home, ".claude", "skills", "skill-creator", "SKILL.md"),
+		filepath.Join(home, ".claude", "skills", "go-testing", "SKILL.md"),
+		filepath.Join(home, ".claude", "skills", "go-testing", "references", "examples.md"),
+	} {
+		if !containsFile(result.Files, path) {
+			t.Fatalf("Inject() files = %v, missing %q", result.Files, path)
+		}
 		if _, err := os.Stat(path); err != nil {
 			t.Fatalf("expected skill file %q: %v", path, err)
 		}
+	}
+}
+
+func TestInjectCopiesNonSDDSkillReferences(t *testing.T) {
+	home := t.TempDir()
+
+	result, err := Inject(home, opencodeAdapter(), []model.SkillID{model.SkillGoTesting, model.SkillChainedPR})
+	if err != nil {
+		t.Fatalf("Inject() error = %v", err)
+	}
+	if !result.Changed {
+		t.Fatal("Inject() changed = false")
+	}
+
+	skillsDir := filepath.Join(home, ".config", "opencode", "skills")
+	tests := []struct {
+		name string
+		path string
+	}{
+		{name: "go-testing examples", path: filepath.Join(skillsDir, "go-testing", "references", "examples.md")},
+		{name: "chained-pr details", path: filepath.Join(skillsDir, "chained-pr", "references", "chaining-details.md")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertNonEmptyFile(t, tt.path)
+		})
 	}
 }
 
@@ -238,4 +267,25 @@ func TestSkillPathForAgent(t *testing.T) {
 	if path != want {
 		t.Fatalf("SkillPathForAgent() = %q, want %q", path, want)
 	}
+}
+
+func assertNonEmptyFile(t *testing.T, path string) {
+	t.Helper()
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("expected file %q: %v", path, err)
+	}
+	if info.Size() == 0 {
+		t.Fatalf("expected file %q to be non-empty", path)
+	}
+}
+
+func containsFile(files []string, want string) bool {
+	for _, file := range files {
+		if file == want {
+			return true
+		}
+	}
+	return false
 }

--- a/openspec/changes/fix-skill-duplication-and-migrate/design.md
+++ b/openspec/changes/fix-skill-duplication-and-migrate/design.md
@@ -1,0 +1,175 @@
+# Design: fix-skill-duplication-and-migrate
+
+## TL;DR
+
+Hide the 11 SDD `SKILL.md` files from Claude Code v2.x's `/` picker by adding two **top-level** YAML frontmatter keys (`user-invocable: false`, `disable-model-invocation: true`) and widening the embedded-asset frontmatter linter allowlist by exactly two keys. No path changes, no migration, no cross-adapter ripple.
+
+---
+
+## Architecture Overview
+
+This is a content-only change against embedded assets. There is no runtime architecture to redesign — the `Read`-based access path agents and commands use today is preserved verbatim. The only behavioral surface that changes is **how Claude Code v2.x indexes the file at startup**, controlled by two declarative frontmatter flags.
+
+Components touched:
+
+```
+internal/assets/skills/{_shared,sdd-*}/SKILL.md   <- content edit (11 files)
+internal/assets/skills_frontmatter_test.go        <- allowlist widen (1 file)
+testdata/golden/...                               <- mechanical regen
+```
+
+Components NOT touched: `internal/components/sdd/inject.go`, the Claude adapter, the uninstall service, agent files under `~/.claude/agents/`, command files under `~/.claude/commands/`, and every non-SDD skill's frontmatter.
+
+Data flow stays identical:
+
+```
+gentle-ai install/sync
+   -> embedded FS (//go:embed)
+   -> Claude adapter writer
+   -> ~/.claude/skills/sdd-*/SKILL.md  (path unchanged)
+                                      \
+                                       -> Claude Code v2.x indexer
+                                          reads frontmatter
+                                          honors user-invocable: false       (no /-picker entry)
+                                          honors disable-model-invocation:   (no autoload by description)
+                                          true
+```
+
+`Read` from sub-agents and commands continues to work because the file still exists at the same path with the same body. The two flags are **indexer-only** signals.
+
+---
+
+## ADRs
+
+### ADR 1 — Frontmatter placement: TOP-LEVEL, not nested under `metadata:`
+
+**Context.** The two flags can technically be placed at the top level of the YAML map (matching official Claude Code docs at https://code.claude.com/docs/en/skills) or nested inside the existing `metadata:` block already used by gentle-ai skills. The current frontmatter linter at `internal/assets/skills_frontmatter_test.go:30-36` enforces a strict top-level allowlist of `{name, description, license, metadata, version}` — top-level placement requires widening this allowlist; nested placement does not.
+
+**Decision.** Top-level placement.
+
+**Alternatives considered.**
+- *Nest under `metadata:`* — cheaper for the linter (no allowlist change), but does not match Claude Code's documented schema. Whether Claude Code's indexer would honor nested flags is undocumented and untested by upstream — at best implementation-defined, at worst silently ignored, which is the failure mode we are trying to fix.
+
+**Rationale.** Top-level is what every official Claude Code example shows. It is explicit, future-proof, and aligns with how upstream documents the feature. The linter cost is minimal: two new strings added to a map literal. Choosing the canonical placement also keeps the change reviewable against a public spec rather than against an internal convention.
+
+---
+
+### ADR 2 — Use BOTH flags, not just `user-invocable: false`
+
+**Context.** Two independent indexer signals exist:
+- `user-invocable: false` removes the skill from the `/` picker (the directly visible duplication bug we are fixing).
+- `disable-model-invocation: true` prevents Claude from auto-loading the skill into context based on description matching (a separate, less-visible behavior).
+
+**Decision.** Set both flags on all 11 SDD SKILL.md files.
+
+**Alternatives considered.**
+- *Only `user-invocable: false`* — fixes the visible duplication and is the minimum required to satisfy the user-facing acceptance criteria. Cheaper, less defensive.
+
+**Rationale.** SDD SKILL.md files are NOT supposed to be loaded autonomously by Claude based on a description match — they are libraries of phase-specific instructions that the orchestrator delegates to explicitly via sub-agents. If Claude auto-injects (for example) `sdd-tasks/SKILL.md` into a casual conversation because the user mentioned "task breakdown", the result is wasted context and potentially confused behavior. `disable-model-invocation: true` enforces the invariant that **SDD skills are explicit-invoke only** — the orchestrator delegates, sub-agents `Read` deliberately, and Claude never autoloads. Defense in depth at zero additional cost (one extra line per file).
+
+**Doc citations.** Both flags are documented at https://code.claude.com/docs/en/skills:
+- `user-invocable: false` — under the "Allow Only Claude to Invoke Skill" section: *"Set `user-invocable: false` to ensure only Claude can invoke a skill. This is suitable for background knowledge or context-providing skills that are not intended as direct user commands."*
+- `disable-model-invocation: true` — appears in the canonical YAML frontmatter example at https://code.claude.com/docs/en/slash-commands as a top-level kebab-case key alongside `name`, `description`, and `allowed-tools`.
+
+---
+
+### ADR 3 — Linter strategy: explicit allowlist expansion, not permissive scheme
+
+**Context.** Top-level placement (ADR 1) means `internal/assets/skills_frontmatter_test.go` must accept the two new keys. Three strategies:
+
+1. **Expand the explicit allowlist by exactly two keys** — preserve strictness.
+2. **Switch to a permissive scheme** (e.g. allow any key, only forbid known-bad ones).
+3. **Nest under `metadata:`** — sidesteps the linter (rejected in ADR 1).
+
+**Decision.** Expand the explicit allowlist by exactly two keys: `user-invocable` and `disable-model-invocation`.
+
+**Alternatives considered.**
+- *Permissive scheme.* Would let typos like `user-invokable: false` (note the misspelling) silently slip past CI. The whole point of the existing strict allowlist is to catch authoring mistakes at PR time rather than in production.
+
+**Rationale.** The strict allowlist is doing real work today — it caught `allowed-tools:` and similar non-standard fields in the past (per the comment at line 22). Adding two known, intentional keys is the minimum-blast-radius change that preserves the property the linter exists to enforce. Future contributors still get a hard CI failure if they fat-finger a frontmatter key. The cost is a two-line diff in a map literal.
+
+---
+
+## Implementation Flow
+
+The apply phase will execute these steps in order; each step is verifiable before the next begins:
+
+1. **Edit 11 embedded SKILL.md files** — add `user-invocable: false` and `disable-model-invocation: true` immediately after the existing top-level keys, before the closing `---`. Files: `internal/assets/skills/_shared/SKILL.md` plus the 10 `internal/assets/skills/sdd-{apply,archive,design,explore,init,onboard,propose,spec,tasks,verify}/SKILL.md`.
+2. **Widen linter allowlist** — extend the map literal at `internal/assets/skills_frontmatter_test.go:30-36` to include the two new keys.
+3. **Run frontmatter linter alone** — `go test ./internal/assets/...`. MUST pass before continuing. This is the cheapest, fastest signal that placement and allowlist are aligned.
+4. **Regenerate goldens** — run the project's golden-update flow (typically `go test ./... -update` on the relevant packages). The exact set of golden files affected will be the union of `testdata/golden/skills-claude-*.golden` and `testdata/golden/sdd-*-skill-*.golden` that embed any of the 11 SKILL.md files. The list is mechanically determined by the regen step, not by guessing.
+5. **Run full test suite** — `go test ./...`. MUST pass without `-update`.
+6. **Manual verification** — build the binary, run `gentle-ai install` (or `sync`) against a clean `~/.claude/`, open Claude Code v2.1.131+, confirm the `/` picker shows each `sdd-*` exactly once and that all entries originate from `~/.claude/commands/sdd-*.md`. Smoke test one delegation chain (e.g. `/sdd-explore <topic>`) to confirm `Read` of the hidden SKILL.md still works from a sub-agent.
+
+Steps 1–5 are mechanical and CI-verifiable. Step 6 is the human-in-the-loop confirmation that the upstream indexer actually honors the flags as documented.
+
+---
+
+## Risk Register
+
+| # | Risk | Likelihood | Impact | Mitigation |
+|---|------|------------|--------|------------|
+| 1 | Future Claude Code versions change the semantics of `user-invocable` / `disable-model-invocation` and duplication returns | Low | Medium | Change is reversible in 2 lines per file. Monitor Claude Code release notes. Fallback is the rejected Option C (path relocation) which can be revisited if upstream removes these flags. |
+| 2 | A user manually edits an installed `~/.claude/skills/sdd-*/SKILL.md`, then runs `gentle-ai sync` and the frontmatter is overwritten | Low | Low | Out of scope for this change — sync's overwrite policy for embedded assets is deliberate and pre-existing. Document elsewhere if it becomes a real complaint. |
+| 3 | Golden test churn produces noisy diffs | Certainty | Trivial | Diffs are purely mechanical (+2 lines per affected golden). Reviewers spot-check one or two and trust the rest. |
+| 4 | Top-level placement is canonical per docs but the running v2.1.131 indexer has a bug honoring it | Low | Medium | Step 6 manual verification catches this before merge. If the bug is real, file upstream and consider nesting under `metadata` as a temporary workaround in a follow-up PR. |
+
+---
+
+## File-Level Change Inventory
+
+### Modified — embedded SKILL.md files (11)
+
+- `internal/assets/skills/_shared/SKILL.md`
+- `internal/assets/skills/sdd-apply/SKILL.md`
+- `internal/assets/skills/sdd-archive/SKILL.md`
+- `internal/assets/skills/sdd-design/SKILL.md`
+- `internal/assets/skills/sdd-explore/SKILL.md`
+- `internal/assets/skills/sdd-init/SKILL.md`
+- `internal/assets/skills/sdd-onboard/SKILL.md`
+- `internal/assets/skills/sdd-propose/SKILL.md`
+- `internal/assets/skills/sdd-spec/SKILL.md`
+- `internal/assets/skills/sdd-tasks/SKILL.md`
+- `internal/assets/skills/sdd-verify/SKILL.md`
+
+Each gains exactly two lines inside the existing frontmatter block:
+```yaml
+user-invocable: false
+disable-model-invocation: true
+```
+
+### Modified — frontmatter linter (1)
+
+- `internal/assets/skills_frontmatter_test.go` — extend `allowedKeys` map literal at lines 30–36 to include `"user-invocable": true` and `"disable-model-invocation": true`.
+
+### Regenerated — golden test files (mechanical, exact set TBD at apply time)
+
+- `testdata/golden/skills-claude-*.golden` — Claude adapter skill goldens that embed any affected SKILL.md.
+- `testdata/golden/sdd-claude-skill-*.golden` — SDD-specific Claude goldens.
+- `testdata/golden/sdd-{cursor,kiro,opencode,gemini,vscode,antigravity,codex,windsurf}-skill-sdd-*.golden` — same SKILL.md content propagates to other adapters via the SDD injector. Even though those adapters don't have the duplication bug, the embedded SKILL.md is the single source of truth and the goldens reflect its content verbatim.
+
+The exact list resolves itself when running the golden-update step; it is not a design-time decision.
+
+---
+
+## Out of Scope (locked)
+
+- Path relocation to `~/.claude/sdd-lib/` (Option C from the proposal).
+- Migration logic for existing installs — same path, content overwrite handles it.
+- Changes to `internal/components/sdd/inject.go` write paths or write policy.
+- Cross-adapter behavioral changes for Cursor, Kiro, OpenCode, Windsurf — those adapters do not exhibit the duplicate-picker bug. Their goldens regenerate mechanically because content is embedded centrally; that is not a behavioral change.
+- Frontmatter changes to non-SDD skills (`judgment-day`, `branch-pr`, `chained-pr`, `cognitive-doc-design`, `skill-creator`, `skill-registry`, `comment-writer`, `go-testing`, `issue-creation`, `work-unit-commits`) — these are intentionally user-invocable.
+- `CONTRIBUTING.md` doc updates and inline comments in `inject.go` — explicitly trimmed by the orchestrator's scope; can land in a follow-up PR if maintainers want them.
+- `internal/components/uninstall/service.go` — unaffected.
+
+---
+
+## References
+
+- Proposal (engram): `sdd/fix-skill-duplication-and-migrate/proposal`
+- Proposal (file): `openspec/changes/fix-skill-duplication-and-migrate/proposal.md`
+- Spec (engram): `sdd/fix-skill-duplication-and-migrate/spec`
+- Spec (file): `openspec/changes/fix-skill-duplication-and-migrate/spec.md`
+- Frontmatter linter: `internal/assets/skills_frontmatter_test.go` (allowlist at lines 30–36)
+- Claude Code skill schema: https://code.claude.com/docs/en/skills
+- Claude Code slash commands: https://code.claude.com/docs/en/slash-commands

--- a/openspec/changes/fix-skill-duplication-and-migrate/proposal.md
+++ b/openspec/changes/fix-skill-duplication-and-migrate/proposal.md
@@ -1,0 +1,117 @@
+# Proposal: fix-skill-duplication-and-migrate
+
+## Intent
+
+Claude Code v2.x indexes both `~/.claude/skills/` and `~/.claude/commands/` into the same `/` slash-command picker, so every SDD phase that gentle-ai installs in BOTH directories shows up TWICE in the picker (`sdd-apply`, `sdd-archive`, `sdd-explore`, `sdd-init`, `sdd-onboard`, `sdd-verify`). That duplication is confusing — users see two visually identical entries for the same workflow and don't know which to pick.
+
+This change hides the SDD `SKILL.md` files from the user-facing picker (and from the model's auto-invocation) by adding two YAML frontmatter flags. Agents and commands that read those files via `Read` keep working unchanged, because the path doesn't move.
+
+Success looks like: in Claude Code v2.1.131 with the next gentle-ai sync, each `sdd-*` slash command appears EXACTLY ONCE in `/`, and that single entry comes from `~/.claude/commands/sdd-*.md`. No path migration, no orphan files, no cross-adapter ripple.
+
+## Scope
+
+### In scope
+
+1. Edit the embedded SKILL.md files for the 10 SDD phases under `internal/assets/skills/`:
+   - `sdd-apply`, `sdd-archive`, `sdd-design`, `sdd-explore`, `sdd-init`, `sdd-onboard`, `sdd-propose`, `sdd-spec`, `sdd-tasks`, `sdd-verify`
+   - Add `user-invocable: false` and `disable-model-invocation: true` to the YAML frontmatter (placement inside `metadata:` vs top-level — see open question 1).
+2. Update `internal/assets/skills_frontmatter_test.go` so the linter accepts the two new fields wherever they're placed (extend the allowlist OR validate them as nested `metadata` keys).
+3. Regenerate any golden files affected by the frontmatter byte changes (the exploration already lists `testdata/golden/skills-*.golden` and `testdata/golden/sdd-*-skill-*.golden` as candidates — `sdd-tasks` will confirm exact set).
+4. Brief documentation: a short note in `CONTRIBUTING.md` (or the closest equivalent) explaining why SDD `SKILL.md` files carry the visibility flags, plus a one-line comment in `inject.go` near the SDD skill write block pointing at the same reason.
+5. Validation: confirm Claude Code v2.1.131 actually honors the flags (cite the docs, smoke test on a real install).
+
+### Out of scope (explicitly)
+
+- Path relocation to `~/.claude/sdd-lib/` (Option C in the exploration). Rejected — see "Why Option A over Option C" below.
+- Cross-adapter changes for Cursor, Kiro, OpenCode, Windsurf, etc. None of them have the duplication.
+- Changes to `internal/components/sdd/inject.go` write paths. The destination is unchanged; only the file CONTENT picks up two new frontmatter fields.
+- Migration logic. Existing installs pick up the new frontmatter automatically on the next `gentle-ai sync` — same path, new content.
+- Uninstall path changes. None needed.
+- Frontmatter changes to non-SDD skills (`judgment-day`, `branch-pr`, `chained-pr`, `cognitive-doc-design`, etc.). Those are intentionally user-invocable.
+
+## Approach
+
+**Option A — frontmatter visibility flags.**
+
+For each of the 10 SDD `SKILL.md` files under `internal/assets/skills/sdd-*/SKILL.md`, add:
+
+```yaml
+user-invocable: false
+disable-model-invocation: true
+```
+
+The exact placement (top-level vs nested under `metadata:`) is settled in the spec phase based on the linter constraint described below. Either way:
+
+- Claude Code stops surfacing these `SKILL.md` files in the `/` picker (`user-invocable: false`).
+- Claude Code stops auto-loading them as contextual skills based on `description:` (`disable-model-invocation: true`).
+- The `~/.claude/commands/sdd-*.md` files keep producing the single canonical `/sdd-*` entry users actually invoke.
+- Agents and commands that do `Read ~/.claude/skills/sdd-{phase}/SKILL.md` keep working — `Read` is unaffected by these flags.
+
+### Why Option A over Option C (path relocation)
+
+| Dimension | Option A (frontmatter) | Option C (relocate to `sdd-lib/`) |
+|---|---|---|
+| Files touched | 10 SKILL.md + 1 test + golden regen + 1 doc note | 10 SKILL.md (relocate) + `inject.go` + 8 Claude agents + 6 Claude commands + 10 Cursor agents + 10 Kiro agents + adapter additions + uninstall service + migration logic + ~25 golden files + e2e |
+| Migration risk | None (same path, new content) | High (must atomically swap path references AND clean stale `~/.claude/skills/sdd-*/`; user-edited files complicate cleanup) |
+| Cross-adapter ripple | None | Cursor + Kiro agent files all need rewriting even though they don't have the bug |
+| Reversibility | Trivial — drop the two fields | Hard — once paths move, every reference must move back |
+| Cleanliness long-term | SDD payload still lives in `~/.claude/skills/`, hidden by flags | Cleaner separation: `skills/` for user skills, `sdd-lib/` for orchestration internals |
+| Risk if Claude Code semantics change | Flags become no-op → duplication returns; mitigated by monitoring + fall back to C | Path scanning rules change → broader breakage, harder to revert |
+
+Option A is **~10x less code surface**, has **zero migration risk**, leaves cross-adapter agents alone, and is **trivially reversible** if Claude Code ever changes how these flags work. The cleanliness argument for C is real but cosmetic; the bug we're fixing is user-visible duplication, and A fixes that with the smallest blast radius.
+
+### Affected files (concrete)
+
+**Edit (10 files)**:
+- `internal/assets/skills/sdd-apply/SKILL.md`
+- `internal/assets/skills/sdd-archive/SKILL.md`
+- `internal/assets/skills/sdd-design/SKILL.md`
+- `internal/assets/skills/sdd-explore/SKILL.md`
+- `internal/assets/skills/sdd-init/SKILL.md`
+- `internal/assets/skills/sdd-onboard/SKILL.md`
+- `internal/assets/skills/sdd-propose/SKILL.md`
+- `internal/assets/skills/sdd-spec/SKILL.md`
+- `internal/assets/skills/sdd-tasks/SKILL.md`
+- `internal/assets/skills/sdd-verify/SKILL.md`
+
+**Edit (test + lint)**:
+- `internal/assets/skills_frontmatter_test.go` — extend allowlist or add nested-`metadata` validator (depending on placement decision).
+
+**Possibly edit (1 file, scoped in spec)**:
+- `internal/assets/skills/_shared/SKILL.md` — see open question 2.
+
+**Regenerate (test data)**:
+- `testdata/golden/skills-*.golden` and `testdata/golden/sdd-*-skill-*.golden` — exact list confirmed by `sdd-tasks` after a dry run.
+
+**Documentation (1 file + 1 inline comment)**:
+- `CONTRIBUTING.md` (or closest equivalent) — short note explaining the flags.
+- `internal/components/sdd/inject.go` — one-line comment at the SDD skill write block pointing at the rationale.
+
+**NOT touched**:
+- `internal/components/sdd/inject.go` write logic (destination unchanged).
+- `internal/components/uninstall/service.go` (paths unchanged).
+- Any `internal/agents/{claude,cursor,kiro,...}/adapter.go` (no new dirs).
+- Any non-SDD `SKILL.md` (`judgment-day`, `branch-pr`, etc.).
+- Any `~/.claude/commands/sdd-*.md` or `~/.claude/agents/sdd-*.md` files.
+
+## Validation strategy
+
+1. **Frontmatter linter**: `internal/assets/skills_frontmatter_test.go` must pass with the two new fields present on all 10 SDD `SKILL.md` files. Decision in `sdd-spec`: widen the top-level allowlist OR require both fields nested under `metadata:`.
+2. **Golden tests**: regenerate affected goldens; review the diff is byte-for-byte the two added lines (no incidental changes).
+3. **Docs check**: confirm Claude Code's official skill schema docs document `user-invocable` and `disable-model-invocation` as supported v2.x fields. The exploration referenced this; `sdd-spec` will lock in the canonical doc URL with a context7 lookup. If the docs don't confirm both flags, fall back to `sdd-design` to pick a verified-supported alternative (e.g. only `user-invocable: false`, or relocate path).
+4. **Smoke test on a real install**: after `gentle-ai sync` against a Claude Code v2.1.131 install, type `/` and verify each of `sdd-apply`, `sdd-archive`, `sdd-explore`, `sdd-init`, `sdd-onboard`, `sdd-verify` appears exactly once. Capture in the verify phase.
+5. **Functional test**: invoke `/sdd-apply` in a real Claude Code session and confirm the orchestrator still launches the executor sub-agent, which still reads `~/.claude/skills/sdd-apply/SKILL.md` successfully.
+
+## Risks
+
+1. **Flag semantics may change in future Claude Code versions.** If `user-invocable` or `disable-model-invocation` are deprecated or repurposed, duplication returns. Mitigation: this is reversible in two lines per file; monitor Claude Code release notes; fall back to Option C (path relocation) if the flags are removed.
+2. **Linter test currently rejects unknown top-level keys.** The frontmatter linter at `internal/assets/skills_frontmatter_test.go` (lines 30–36) hardcodes an allowlist of `{name, description, license, metadata, version}`. Adding `user-invocable` and `disable-model-invocation` as top-level keys WILL fail the test. The spec must decide: extend the allowlist (preferred — these are first-class Claude Code fields) or nest the two flags under `metadata:` (cheaper test change but moves us off the canonical schema). This is the single most important decision the spec must lock in.
+3. **Documentation citation gap.** The exploration didn't pin a URL confirming Claude Code respects `user-invocable: false` AND `disable-model-invocation: true` together. The spec phase MUST verify this via context7 or the official docs before locking the approach. If only one flag is supported, the proposal still works (one is enough to hide from the picker), but we should know which one carries the load.
+4. **Golden test churn.** Adding two YAML lines changes file bytes for 10 skills, which cascades into multiple golden files. Risk is purely mechanical (regen + review the diff is exactly +2 lines per affected golden). Low likelihood of going wrong, easy to spot if it does.
+
+## Open questions (for sdd-spec / sdd-design)
+
+1. **Placement: top-level vs nested under `metadata:`.** Top-level matches the canonical Claude Code schema and is more discoverable; nested keeps the existing linter allowlist unchanged. Recommendation: top-level + extend the allowlist, because that matches what Claude Code actually expects to see. Confirm in spec with a docs citation.
+2. **Include `_shared/SKILL.md`?** It already declares "Not Invokable" in its prose and the linter exempts it from the `Trigger:` requirement. Adding `user-invocable: false` + `disable-model-invocation: true` is consistent with its self-documented purpose and makes the intent machine-checkable. Recommendation: YES, include `_shared` — same flags, no behavior change in practice (no description with `Trigger:` to auto-load on anyway), gain consistency. Final call in spec.
+3. **`judgment-day` confirmed OUT of scope.** It's user-invocable by design (trigger phrases in its description) and is not part of the SDD phase suite. No flags added.
+4. **`skill-registry`, `cognitive-doc-design`, `branch-pr`, `chained-pr`, `comment-writer`, `comment-writer`, `go-testing`, `issue-creation`, `skill-creator`, `work-unit-commits`** — all confirmed OUT of scope. They're general-purpose user-invocable skills.

--- a/openspec/changes/fix-skill-duplication-and-migrate/spec.md
+++ b/openspec/changes/fix-skill-duplication-and-migrate/spec.md
@@ -1,25 +1,36 @@
 # Spec: fix-skill-duplication-and-migrate
 
-## Goal
-
-Add `user-invocable: false` and `disable-model-invocation: true` to the YAML frontmatter of the 11 SDD `SKILL.md` files so Claude Code v2.x stops showing duplicate entries in the `/` picker, while keeping the files readable by agents and commands via `Read`.
+> **Bundle Notice — PR #458 ships two independent work streams:**
+>
+> - **Part 1 — LLM-first skills refactor** (commits `99f7062` + `f070845`): slims 5 heavy SKILL.md files to ≤60 lines, ships `references/*.md` companions, adds `docs/skill-style-guide.md`, makes injectors recursive. This was a separate work stream already on local `main` before this SDD was planned; it surfaces in PR #458 because `origin/main` had not received those commits when the PR was opened.
+> - **Part 2 — SDD picker frontmatter flags** (commit `7a3bff9`): hides 11 SDD SKILL.md files from the Claude Code `/` picker via YAML frontmatter flags. This is the change the SDD process planned and tracked — closes #457.
+>
+> The artifact originally described Part 2 only. It is updated here to honestly describe both parts because the PR ships both.
 
 ---
 
-## Functional Requirements
+## Goal
+
+**Part 2 (SDD-planned):** Add `user-invocable: false` and `disable-model-invocation: true` to the YAML frontmatter of the 11 SDD `SKILL.md` files so Claude Code v2.x stops showing duplicate entries in the `/` picker, while keeping the files readable by agents and commands via `Read`.
+
+**Part 1 (bundled):** Slim the 5 heaviest non-SDD SKILL.md files to ≤60 lines each by extracting verbose content into `references/*.md` companion files. Update injectors to copy subdirectories recursively. Ship a style guide for future skill authoring.
+
+---
+
+## Part 2 — Frontmatter Flags (SDD-planned)
+
+### Functional Requirements
 
 - The 11 SDD `SKILL.md` files MUST contain `user-invocable: false` and `disable-model-invocation: true` as **top-level** YAML frontmatter keys (not nested under `metadata:`).
 - The 11 files are: `internal/assets/skills/_shared/SKILL.md` plus `sdd-apply`, `sdd-archive`, `sdd-design`, `sdd-explore`, `sdd-init`, `sdd-onboard`, `sdd-propose`, `sdd-spec`, `sdd-tasks`, `sdd-verify`.
-- All pre-existing top-level fields (`name`, `description`, `license`, `metadata`, `version`) MUST retain their values byte-for-byte after the change.
+- All pre-existing top-level fields (`name`, `description`, `license`, `metadata`, `version`) of the **Part 2 files** MUST retain their values byte-for-byte after the change. (See Scenario C for Part 1 scope clarification.)
 - Each of the 10 phase files MUST keep `name:` equal to its directory basename (e.g. `name: sdd-apply`).
 - `_shared/SKILL.md` MUST keep `name: _shared`.
 - The frontmatter linter at `internal/assets/skills_frontmatter_test.go` MUST accept `user-invocable` and `disable-model-invocation` as valid top-level keys — the existing allowlist `{name, description, license, metadata, version}` MUST be widened to include them.
 - No other non-SDD `SKILL.md` files MUST carry the new flags (non-SDD skills are intentionally user-invocable).
 - Golden test files under `testdata/golden/` that embed the affected SKILL.md content MUST be regenerated so that `go test ./...` passes without `-update`.
 
----
-
-## Behavioral Requirements
+### Behavioral Requirements
 
 - After `gentle-ai install` or `gentle-ai sync` on any `~/.claude/` directory, none of the 11 SDD SKILL.md entries MUST appear as user-invocable items in the Claude Code `/` picker.
 - The `~/.claude/commands/sdd-*.md` entries MUST still appear in the `/` picker — they are the single canonical user-facing entry point for each phase.
@@ -28,11 +39,9 @@ Add `user-invocable: false` and `disable-model-invocation: true` to the YAML fro
 - The `Read` tool MUST continue to load `~/.claude/skills/sdd-{phase}/SKILL.md` successfully — `Read` does not interpret `user-invocable` or `disable-model-invocation`.
 - Claude Code MUST NOT auto-load the SDD SKILL.md files as contextual skills via description-based matching (suppressed by `disable-model-invocation: true`).
 
----
+### Test Scenarios (Part 2)
 
-## Test Scenarios
-
-### Scenario A — Frontmatter linter accepts new keys
+#### Scenario A — Frontmatter linter accepts new keys
 
 - GIVEN the 11 embedded SDD SKILL.md files carry `user-invocable: false` and `disable-model-invocation: true` at the top level of their YAML frontmatter
 - WHEN `go test ./internal/assets/...` runs
@@ -41,7 +50,7 @@ Add `user-invocable: false` and `disable-model-invocation: true` to the YAML fro
 
 ---
 
-### Scenario B — All 11 files carry both flags
+#### Scenario B — All 11 files carry both flags
 
 - GIVEN the change has been applied to the embedded assets
 - WHEN each of the 11 `SKILL.md` files is read and the YAML frontmatter block is parsed
@@ -50,25 +59,27 @@ Add `user-invocable: false` and `disable-model-invocation: true` to the YAML fro
 
 ---
 
-### Scenario C — Existing fields preserved byte-for-byte
+#### Scenario C — Part 2 fields preserved byte-for-byte; Part 1 bodies separately covered
 
-- GIVEN the 11 modified SKILL.md files
+- GIVEN the 11 Part 2 SKILL.md files (the SDD phase files + `_shared`)
 - WHEN parsed as YAML
 - THEN `name`, `description`, `license`, `metadata`, and `version` retain values identical to their pre-change state
-- AND no other lines in the file body (below the closing `---`) are altered
+- AND no other lines in the file body (below the closing `---`) of those 11 files are altered
+- NOTE: The 5 Part 1 SKILL.md files (`chained-pr`, `judgment-day`, `sdd-init`, `go-testing`, `sdd-verify`) have intentional body rewrites — those are covered under Part 1 Scenarios H–L, not this scenario.
+- NOTE: `sdd-init` and `sdd-verify` appear in both parts: Part 2 adds frontmatter flags only; Part 1 rewrites the body. The net diff for those two files includes both changes.
 
 ---
 
-### Scenario D — Golden tests regenerated and passing
+#### Scenario D — Golden tests regenerated and passing
 
-- GIVEN the embedded SKILL.md files now include the two new frontmatter flags
+- GIVEN the embedded SKILL.md files now include the two new frontmatter flags (and Part 1 body changes for affected files)
 - WHEN `go test -run TestGolden ./... -update` is executed and the resulting golden files are committed
 - THEN `go test ./...` passes without `-update`
-- AND the diff on each affected golden file shows exactly the two added frontmatter lines and no other changes
+- AND the diff on each `sdd-init` golden shows the frontmatter additions plus the body slim (Part 1 and Part 2 changes combined for that file)
 
 ---
 
-### Scenario E — Install writes new frontmatter to disk
+#### Scenario E — Install writes new frontmatter to disk
 
 - GIVEN a fresh `~/.claude/skills/` directory with no prior gentle-ai install
 - WHEN `gentle-ai install` runs with the Claude adapter selected
@@ -77,7 +88,7 @@ Add `user-invocable: false` and `disable-model-invocation: true` to the YAML fro
 
 ---
 
-### Scenario F — Picker shows no duplicate SDD entries (manual verification)
+#### Scenario F — Picker shows no duplicate SDD entries (manual verification)
 
 - GIVEN a Claude Code v2.1.131+ session with the new SKILL.md files installed via `gentle-ai sync`
 - WHEN the user opens the `/` skill picker
@@ -87,7 +98,7 @@ Add `user-invocable: false` and `disable-model-invocation: true` to the YAML fro
 
 ---
 
-### Scenario G — Sub-agent delegation still works (manual verification)
+#### Scenario G — Sub-agent delegation still works (manual verification)
 
 - GIVEN a Claude Code session with the new SKILL.md files installed
 - WHEN the SDD orchestrator delegates to the `sdd-explore` sub-agent
@@ -97,22 +108,91 @@ Add `user-invocable: false` and `disable-model-invocation: true` to the YAML fro
 
 ---
 
+## Part 1 — LLM-first Refactor (bundled, pre-planned separately)
+
+### Functional Requirements
+
+- The 5 heaviest SKILL.md files MUST slim to ≤60 lines after refactoring: `chained-pr` (was ~371 lines → ≤60), `judgment-day` (was ~345 → ≤60), `sdd-init` (was ~358 → ≤60), `go-testing` (was ~353 → ≤60), `sdd-verify` (was ~342 → ≤60).
+- Each refactored skill MUST ship a `references/` subdirectory with at least one `*.md` companion file containing the extracted verbose content.
+- `docs/skill-style-guide.md` MUST exist in the repository and document the LLM-first authoring pattern.
+- `internal/assets/skills/skill-creator/SKILL.md` MUST reference `docs/skill-style-guide.md` so future skill authors can find the guide.
+- `internal/components/skills/inject.go` MUST copy skill directories recursively (including subdirectories), not just the top-level `SKILL.md`.
+- `internal/components/sdd/inject.go` MUST copy SDD skill directories recursively.
+- `internal/assets/assets_test.go` MUST assert that every embedded `references/*.md` file is readable and non-empty.
+
+### Behavioral Requirements
+
+- Token cost on activation MUST drop approximately 85% for the 5 refactored skills (from ~18–25k tokens to ~3–5k tokens).
+- After `gentle-ai install`, each refactored skill directory on disk MUST contain both `SKILL.md` and its `references/` subdirectory.
+- Existing skill consumers (orchestrator, sub-agents reading SKILL.md via `Read`) MUST continue to work because `SKILL.md` retains the full operational contract.
+- Reference files MUST install alongside their parent skill on every supported adapter that installs skills.
+
+### Test Scenarios (Part 1)
+
+#### Scenario H — Refactored skills install with their `references/` subdirs
+
+- GIVEN `internal/components/skills/inject.go` has been updated to copy recursively
+- WHEN `gentle-ai install` runs for the Claude adapter
+- THEN `~/.claude/skills/chained-pr/references/chaining-details.md` exists on disk
+- AND `~/.claude/skills/go-testing/references/examples.md` exists on disk
+- AND each of the other 3 refactored skills has its companion `references/*.md` present
+
+---
+
+#### Scenario I — `sdd-init` and `sdd-verify` ship with their `references/*.md` correctly
+
+- GIVEN `internal/components/sdd/inject.go` has been updated to copy recursively
+- WHEN `gentle-ai install` runs
+- THEN `~/.claude/skills/sdd-init/references/init-details.md` exists on disk
+- AND `~/.claude/skills/sdd-verify/references/report-format.md` exists on disk
+- AND both files are non-empty
+
+---
+
+#### Scenario J — `skill-creator` references `docs/skill-style-guide.md` and the file ships embedded
+
+- GIVEN `internal/assets/skills/skill-creator/SKILL.md` has been updated
+- WHEN `skill-creator/SKILL.md` is read
+- THEN it contains a reference to `docs/skill-style-guide.md`
+- AND `docs/skill-style-guide.md` exists in the repository at that path
+
+---
+
+#### Scenario K — `assets_test.go` asserts every embedded `references/*.md` is readable and non-empty
+
+- GIVEN the 5 refactored skills have `references/*.md` files embedded in the Go asset bundle
+- WHEN `go test ./internal/assets/...` runs
+- THEN the readability assertions in `assets_test.go` pass for all embedded reference files
+- AND no reference file returns zero bytes
+
+---
+
+#### Scenario L — `inject_test.go` covers nested file copying
+
+- GIVEN `internal/components/skills/inject_test.go` and `internal/components/sdd/inject_test.go` have been updated
+- WHEN `go test ./internal/components/...` runs
+- THEN tests covering the recursive copy path pass
+- AND a synthetic skill with a `references/` subdir installs its nested file to the correct destination path
+
+---
+
 ## Out of Scope
 
 - Path relocation to `~/.claude/sdd-lib/` (Option C) — rejected in proposal.
 - Migration logic — existing installs pick up new content automatically on next `gentle-ai sync`.
-- Changes to `internal/components/sdd/inject.go` write paths — destination unchanged, only file content changes.
 - Changes to `~/.claude/commands/sdd-*.md` or `~/.claude/agents/sdd-*.md` reference paths.
-- Cross-adapter changes for Cursor, Kiro, OpenCode, Windsurf — no duplication in those adapters.
-- Frontmatter changes to non-SDD skills (`judgment-day`, `branch-pr`, `chained-pr`, `cognitive-doc-design`, etc.).
+- Cross-adapter changes for Cursor, Kiro, OpenCode, Windsurf for the frontmatter flags — no duplication in those adapters.
+- Frontmatter changes to non-SDD skills (`judgment-day`, `branch-pr`, `chained-pr`, `cognitive-doc-design`, etc.) — those remain user-invocable.
 - Changes to `internal/components/uninstall/service.go`.
+- Recursive directory copy was originally listed as out of scope; it is **now IN scope** as Part 1 shipped it as a required enabler for `references/` propagation.
 
 ---
 
 ## References
 
-- Proposal (engram): `sdd/fix-skill-duplication-and-migrate/proposal`
-- Proposal (file): `openspec/changes/fix-skill-duplication-and-migrate/proposal.md`
-- Frontmatter linter: `internal/assets/skills_frontmatter_test.go` (lines 30–36 — current allowlist)
+- Proposal (file): `openspec/changes/archive/2026-05-07-fix-skill-duplication-and-migrate/proposal.md`
+- Design (file): `openspec/changes/archive/2026-05-07-fix-skill-duplication-and-migrate/design.md`
+- Frontmatter linter: `internal/assets/skills_frontmatter_test.go`
+- Style guide: `docs/skill-style-guide.md`
 - Claude Code skill schema docs: https://code.claude.com/docs/en/skills
 - Claude Code slash commands docs: https://code.claude.com/docs/en/slash-commands

--- a/openspec/changes/fix-skill-duplication-and-migrate/spec.md
+++ b/openspec/changes/fix-skill-duplication-and-migrate/spec.md
@@ -1,0 +1,118 @@
+# Spec: fix-skill-duplication-and-migrate
+
+## Goal
+
+Add `user-invocable: false` and `disable-model-invocation: true` to the YAML frontmatter of the 11 SDD `SKILL.md` files so Claude Code v2.x stops showing duplicate entries in the `/` picker, while keeping the files readable by agents and commands via `Read`.
+
+---
+
+## Functional Requirements
+
+- The 11 SDD `SKILL.md` files MUST contain `user-invocable: false` and `disable-model-invocation: true` as **top-level** YAML frontmatter keys (not nested under `metadata:`).
+- The 11 files are: `internal/assets/skills/_shared/SKILL.md` plus `sdd-apply`, `sdd-archive`, `sdd-design`, `sdd-explore`, `sdd-init`, `sdd-onboard`, `sdd-propose`, `sdd-spec`, `sdd-tasks`, `sdd-verify`.
+- All pre-existing top-level fields (`name`, `description`, `license`, `metadata`, `version`) MUST retain their values byte-for-byte after the change.
+- Each of the 10 phase files MUST keep `name:` equal to its directory basename (e.g. `name: sdd-apply`).
+- `_shared/SKILL.md` MUST keep `name: _shared`.
+- The frontmatter linter at `internal/assets/skills_frontmatter_test.go` MUST accept `user-invocable` and `disable-model-invocation` as valid top-level keys — the existing allowlist `{name, description, license, metadata, version}` MUST be widened to include them.
+- No other non-SDD `SKILL.md` files MUST carry the new flags (non-SDD skills are intentionally user-invocable).
+- Golden test files under `testdata/golden/` that embed the affected SKILL.md content MUST be regenerated so that `go test ./...` passes without `-update`.
+
+---
+
+## Behavioral Requirements
+
+- After `gentle-ai install` or `gentle-ai sync` on any `~/.claude/` directory, none of the 11 SDD SKILL.md entries MUST appear as user-invocable items in the Claude Code `/` picker.
+- The `~/.claude/commands/sdd-*.md` entries MUST still appear in the `/` picker — they are the single canonical user-facing entry point for each phase.
+- Each of `sdd-apply`, `sdd-archive`, `sdd-design`, `sdd-explore`, `sdd-init`, `sdd-onboard`, `sdd-propose`, `sdd-spec`, `sdd-tasks`, `sdd-verify` MUST appear AT MOST ONCE in the `/` picker after install.
+- `~/.claude/agents/sdd-*.md` sub-agents MUST continue to function; orchestrator delegation MUST NOT be affected by the frontmatter flags.
+- The `Read` tool MUST continue to load `~/.claude/skills/sdd-{phase}/SKILL.md` successfully — `Read` does not interpret `user-invocable` or `disable-model-invocation`.
+- Claude Code MUST NOT auto-load the SDD SKILL.md files as contextual skills via description-based matching (suppressed by `disable-model-invocation: true`).
+
+---
+
+## Test Scenarios
+
+### Scenario A — Frontmatter linter accepts new keys
+
+- GIVEN the 11 embedded SDD SKILL.md files carry `user-invocable: false` and `disable-model-invocation: true` at the top level of their YAML frontmatter
+- WHEN `go test ./internal/assets/...` runs
+- THEN `TestSkillFrontmatterIsLintClean` passes with zero "non-standard top-level frontmatter key" failures
+- AND the two new keys are present in the widened `allowedKeys` map in `skills_frontmatter_test.go`
+
+---
+
+### Scenario B — All 11 files carry both flags
+
+- GIVEN the change has been applied to the embedded assets
+- WHEN each of the 11 `SKILL.md` files is read and the YAML frontmatter block is parsed
+- THEN every file contains `user-invocable: false` at the top level
+- AND every file contains `disable-model-invocation: true` at the top level
+
+---
+
+### Scenario C — Existing fields preserved byte-for-byte
+
+- GIVEN the 11 modified SKILL.md files
+- WHEN parsed as YAML
+- THEN `name`, `description`, `license`, `metadata`, and `version` retain values identical to their pre-change state
+- AND no other lines in the file body (below the closing `---`) are altered
+
+---
+
+### Scenario D — Golden tests regenerated and passing
+
+- GIVEN the embedded SKILL.md files now include the two new frontmatter flags
+- WHEN `go test -run TestGolden ./... -update` is executed and the resulting golden files are committed
+- THEN `go test ./...` passes without `-update`
+- AND the diff on each affected golden file shows exactly the two added frontmatter lines and no other changes
+
+---
+
+### Scenario E — Install writes new frontmatter to disk
+
+- GIVEN a fresh `~/.claude/skills/` directory with no prior gentle-ai install
+- WHEN `gentle-ai install` runs with the Claude adapter selected
+- THEN `~/.claude/skills/sdd-apply/SKILL.md` (and each of the other 10 skill files) contains `user-invocable: false` at the top level of its YAML frontmatter
+- AND contains `disable-model-invocation: true` at the top level
+
+---
+
+### Scenario F — Picker shows no duplicate SDD entries (manual verification)
+
+- GIVEN a Claude Code v2.1.131+ session with the new SKILL.md files installed via `gentle-ai sync`
+- WHEN the user opens the `/` skill picker
+- THEN each of `sdd-apply`, `sdd-archive`, `sdd-design`, `sdd-explore`, `sdd-init`, `sdd-onboard`, `sdd-propose`, `sdd-spec`, `sdd-tasks`, `sdd-verify` appears AT MOST ONCE
+- AND every visible entry originates from `~/.claude/commands/sdd-*.md`, not from `~/.claude/skills/sdd-*/SKILL.md`
+- NOTE: behavioral verification performed manually post-merge; not an automated Go test
+
+---
+
+### Scenario G — Sub-agent delegation still works (manual verification)
+
+- GIVEN a Claude Code session with the new SKILL.md files installed
+- WHEN the SDD orchestrator delegates to the `sdd-explore` sub-agent
+- THEN the sub-agent executes `Read` on `~/.claude/skills/sdd-explore/SKILL.md` without error
+- AND the sub-agent completes the exploration phase normally
+- NOTE: behavioral verification performed manually post-merge; not an automated Go test
+
+---
+
+## Out of Scope
+
+- Path relocation to `~/.claude/sdd-lib/` (Option C) — rejected in proposal.
+- Migration logic — existing installs pick up new content automatically on next `gentle-ai sync`.
+- Changes to `internal/components/sdd/inject.go` write paths — destination unchanged, only file content changes.
+- Changes to `~/.claude/commands/sdd-*.md` or `~/.claude/agents/sdd-*.md` reference paths.
+- Cross-adapter changes for Cursor, Kiro, OpenCode, Windsurf — no duplication in those adapters.
+- Frontmatter changes to non-SDD skills (`judgment-day`, `branch-pr`, `chained-pr`, `cognitive-doc-design`, etc.).
+- Changes to `internal/components/uninstall/service.go`.
+
+---
+
+## References
+
+- Proposal (engram): `sdd/fix-skill-duplication-and-migrate/proposal`
+- Proposal (file): `openspec/changes/fix-skill-duplication-and-migrate/proposal.md`
+- Frontmatter linter: `internal/assets/skills_frontmatter_test.go` (lines 30–36 — current allowlist)
+- Claude Code skill schema docs: https://code.claude.com/docs/en/skills
+- Claude Code slash commands docs: https://code.claude.com/docs/en/slash-commands

--- a/openspec/changes/fix-skill-duplication-and-migrate/tasks.md
+++ b/openspec/changes/fix-skill-duplication-and-migrate/tasks.md
@@ -1,93 +1,133 @@
 # Tasks: fix-skill-duplication-and-migrate
 
+> **Bundle Notice — PR #458 ships two independent work streams:**
+>
+> - **Part 1 — LLM-first skills refactor** (commits `99f7062` + `f070845`): separate work stream already on local `main`; surfaces in PR because `origin/main` had not received those commits.
+> - **Part 2 — SDD picker frontmatter flags** (commit `7a3bff9`): the SDD-planned change, closes #457.
+>
+> The original forecast below covered Part 2 only. Part 1 is documented here as historical/completed scope because the PR ships both.
+
+---
+
 ## Review Workload Forecast
 
 | Field | Value |
 |-------|-------|
-| Estimated changed lines | 50–90 |
-| 400-line budget risk | Low |
-| Chained PRs recommended | No |
-| Suggested split | Single PR |
-| Delivery strategy | ask-on-risk |
-| Chain strategy | pending |
+| Estimated changed lines (Part 2 only, original forecast) | 48–90 |
+| Actual changed lines (full PR, both parts) | ~9,100 (+2,362 / −6,739) |
+| Files changed | 50 |
+| 400-line budget risk | **High — `size:exception` applied** |
+| Chained PRs recommended | Post-hoc: would have been yes if forecast had included Part 1 |
+| Suggested split | N/A — already shipped as single PR with `size:exception` |
+| Delivery strategy | exception-ok (Part 1 was pre-existing local commits; not splittable after the fact) |
 
-Decision needed before apply: No
-Chained PRs recommended: No
-Chain strategy: pending
-400-line budget risk: Low
-
-**Estimate breakdown:**
-- 11 SKILL.md edits × 2 lines = 22 lines
-- 1 linter file widen = 2 lines
-- 8 golden files × ~3 lines each (2 added + separator) = ~24 lines
-- Total: ~48 lines. Single PR; well under budget.
-
-### Suggested Work Units
-
-| Unit | Goal | Likely PR | Notes |
-|------|------|-----------|-------|
-| 1 | All 5 tasks below | PR 1 | Single atomic PR; tests + golden regen included |
+**Forecast discrepancy note:** The original 48-line estimate was accurate for Part 2 in isolation. Part 1 (commits `99f7062` + `f070845`) added ~2,314 insertions / −6,734 deletions across 44 additional files. The difference surfaced only when the PR was opened against `origin/main` and those prior commits were included in the diff.
 
 ---
 
-## Phase 1: Frontmatter Edits (Foundation)
+## Part 1 — LLM-first Refactor (already shipped on local main, pre-PR)
 
-- [x] 1.1 Add `user-invocable: false` and `disable-model-invocation: true` as top-level YAML frontmatter keys to all 11 SDD SKILL.md files. Insert after `description:`, before `license:` (alphabetical order). Files: `internal/assets/skills/_shared/SKILL.md`, `internal/assets/skills/sdd-apply/SKILL.md`, `internal/assets/skills/sdd-archive/SKILL.md`, `internal/assets/skills/sdd-design/SKILL.md`, `internal/assets/skills/sdd-explore/SKILL.md`, `internal/assets/skills/sdd-init/SKILL.md`, `internal/assets/skills/sdd-onboard/SKILL.md`, `internal/assets/skills/sdd-propose/SKILL.md`, `internal/assets/skills/sdd-spec/SKILL.md`, `internal/assets/skills/sdd-tasks/SKILL.md`, `internal/assets/skills/sdd-verify/SKILL.md`. Done criteria: each file's frontmatter block contains both new keys; `name`, `description`, `license`, `metadata`, `version` values unchanged byte-for-byte.
+These tasks are **completed/historical** — they describe work shipped via commits `99f7062` and `f070845` before this SDD was executed.
 
-**Suggested commit:** `feat(sdd): hide SDD SKILL.md files from / picker via frontmatter flags`
+### P1 Task A — Slim the 5 heaviest SKILL.md files (completed)
 
----
+- [x] Rewrite `internal/assets/skills/chained-pr/SKILL.md` from ~371 → 50 lines. Extract verbose content to `internal/assets/skills/chained-pr/references/chaining-details.md`.
+- [x] Rewrite `internal/assets/skills/judgment-day/SKILL.md` from ~345 → 52 lines. Extract to `internal/assets/skills/judgment-day/references/prompts-and-formats.md`.
+- [x] Rewrite `internal/assets/skills/sdd-init/SKILL.md` from ~358 → 57 lines. Extract to `internal/assets/skills/sdd-init/references/init-details.md`.
+- [x] Rewrite `internal/assets/skills/go-testing/SKILL.md` from ~353 → 51 lines. Extract to `internal/assets/skills/go-testing/references/examples.md`.
+- [x] Rewrite `internal/assets/skills/sdd-verify/SKILL.md` from ~342 → 59 lines. Extract to `internal/assets/skills/sdd-verify/references/report-format.md`.
+- Done criteria: each slim file ≤60 lines; each `references/*.md` non-empty; operational contract (triggers, usage, key instructions) preserved in `SKILL.md`.
 
-## Phase 2: Linter Widening (Unblock CI)
-
-- [x] 2.1 Edit `internal/assets/skills_frontmatter_test.go` — extend `allowedKeys` map at lines 30–36 to add `"user-invocable": true` and `"disable-model-invocation": true`. Done criteria: `go test ./internal/assets/...` passes with zero `non-standard top-level frontmatter key` failures.
-
-**Suggested commit:** `test(assets): widen frontmatter allowlist for user-invocable and disable-model-invocation`
-
----
-
-## Phase 3: Golden Regeneration (Mechanical)
-
-- [x] 3.1 Run `go test ./internal/components/ -update` to regenerate the 8 affected golden files: `testdata/golden/sdd-{antigravity,codex,cursor,gemini,kiro,opencode,vscode,windsurf}-skill-sdd-init.golden`. Done criteria: diff on each affected file shows exactly +2 lines (`user-invocable: false` and `disable-model-invocation: true` inside the frontmatter block) and no other changes. If any unexpected golden changes, stop and investigate.
-
-**Suggested commit:** `test(golden): regenerate sdd-init SKILL.md goldens after frontmatter flags`
+**Actual commit:** `f070845 refactor: make installed skills LLM-first`
 
 ---
 
-## Phase 4: Full Test Suite (Verification)
+### P1 Task B — Add style guide and refactor `skill-creator` (completed)
 
-- [x] 4.1 Run `go test ./...` (no `-update` flag). Done criteria: all tests pass. This catches any snapshot or embedding test not covered by Phase 3.
+- [x] Create `docs/skill-style-guide.md` documenting the LLM-first authoring pattern (70 lines).
+- [x] Refactor `internal/assets/skills/skill-creator/SKILL.md` from ~171 lines to reference the style guide; add `skills/chained-pr/` mirror.
+- [x] Regenerate `testdata/golden/skills-{claude,kiro,opencode,windsurf}-skill-creator.golden` (4 goldens, each slimmed).
+- Done criteria: style guide ships at correct path; `skill-creator/SKILL.md` references it; goldens green.
 
-**Suggested commit:** *(no separate commit — if tests pass, Phase 3 commit stands; if a new golden needs updating, iterate Phase 3)*
+**Actual commit:** `99f7062 docs: add LLM-first skill style guide`
 
 ---
 
-## Phase 5: Manual Verification (Human-in-the-loop)
+### P1 Task C — Make injectors recursive (completed, in `f070845`)
+
+- [x] Update `internal/components/skills/inject.go` to walk and copy subdirectories recursively (was: `SKILL.md` only).
+- [x] Update `internal/components/sdd/inject.go` to walk and copy subdirectories recursively.
+- [x] Add `internal/components/skills/inject_test.go` coverage for nested file copy.
+- [x] Add `internal/components/sdd/inject_test.go` coverage for nested file copy.
+- [x] Add readability assertions in `internal/assets/assets_test.go` for all embedded `references/*.md` files.
+- Done criteria: `go test ./internal/components/...` and `go test ./internal/assets/...` pass.
+
+---
+
+## Part 2 — Frontmatter Flags (SDD-planned, closes #457)
+
+### Phase 1: Frontmatter Edits (Foundation)
+
+- [x] 1.1 Add `user-invocable: false` and `disable-model-invocation: true` as top-level YAML frontmatter keys to all 11 SDD SKILL.md files. Insert after `description:`, before `license:` (alphabetical order). Files: `internal/assets/skills/_shared/SKILL.md`, `internal/assets/skills/sdd-apply/SKILL.md`, `internal/assets/skills/sdd-archive/SKILL.md`, `internal/assets/skills/sdd-design/SKILL.md`, `internal/assets/skills/sdd-explore/SKILL.md`, `internal/assets/skills/sdd-init/SKILL.md`, `internal/assets/skills/sdd-onboard/SKILL.md`, `internal/assets/skills/sdd-propose/SKILL.md`, `internal/assets/skills/sdd-spec/SKILL.md`, `internal/assets/skills/sdd-tasks/SKILL.md`, `internal/assets/skills/sdd-verify/SKILL.md`. Done criteria: each file's frontmatter block contains both new keys; `name`, `description`, `license`, `metadata`, `version` values byte-for-byte unchanged (Part 2 files only; `sdd-init` and `sdd-verify` also received Part 1 body rewrites).
+
+**Actual commit:** `7a3bff9 fix(sdd): hide SDD SKILL.md files from Claude Code / picker`
+
+---
+
+### Phase 2: Linter Widening (Unblock CI)
+
+- [x] 2.1 Edit `internal/assets/skills_frontmatter_test.go` — extend `allowedKeys` map to add `"user-invocable": true` and `"disable-model-invocation": true`. Also accommodate Part 1's `references/` subdirectory checks. Done criteria: `go test ./internal/assets/...` passes with zero `non-standard top-level frontmatter key` failures.
+
+---
+
+### Phase 3: Golden Regeneration (Mechanical)
+
+- [x] 3.1 Regenerate 8 `sdd-init` goldens after frontmatter flags + Part 1 body slim. Files: `testdata/golden/sdd-{antigravity,codex,cursor,gemini,kiro,opencode,vscode,windsurf}-skill-sdd-init.golden`. Done criteria: each golden reflects the slim body + 2 frontmatter flag lines; `go test ./...` passes without `-update`.
+- [x] 3.2 Regenerate 4 `skill-creator` goldens (Part 1): `testdata/golden/skills-{claude,kiro,opencode,windsurf}-skill-creator.golden`. Done criteria: goldens match slimmed `skill-creator/SKILL.md`.
+- [x] 3.3 Regenerate 4 `go-testing` goldens (Part 1): `testdata/golden/skills-{claude,kiro,opencode,windsurf}-go-testing.golden`. Done criteria: goldens match slimmed `go-testing/SKILL.md`.
+
+---
+
+### Phase 4: Full Test Suite (Verification)
+
+- [x] 4.1 Run `go test ./...` (no `-update` flag). All packages pass. See verify-report for full results.
+
+---
+
+### Phase 5: Manual Verification (Human-in-the-loop)
 
 - [ ] 5.1 Build the binary: `go build -o /tmp/gentle-ai .` from repo root.
 - [ ] 5.2 Run `gentle-ai install` (or `gentle-ai sync`) against your `~/.claude/` directory.
-- [ ] 5.3 Confirm `~/.claude/skills/sdd-apply/SKILL.md` and each of the other 10 files contain both `user-invocable: false` and `disable-model-invocation: true` at the top level of their YAML frontmatter.
-- [ ] 5.4 Open Claude Code v2.1.131+ and open the `/` picker. Each of `sdd-apply`, `sdd-archive`, `sdd-design`, `sdd-explore`, `sdd-init`, `sdd-onboard`, `sdd-propose`, `sdd-spec`, `sdd-tasks`, `sdd-verify` MUST appear AT MOST ONCE. All visible entries originate from `~/.claude/commands/sdd-*.md`, not `~/.claude/skills/sdd-*/SKILL.md`.
-- [ ] 5.5 Trigger an orchestrator delegation to `sdd-explore`. Confirm the sub-agent successfully reads `~/.claude/skills/sdd-explore/SKILL.md` via the `Read` tool and completes normally.
+- [ ] 5.3 Confirm `~/.claude/skills/sdd-apply/SKILL.md` and each of the other 10 SDD files contain both `user-invocable: false` and `disable-model-invocation: true`.
+- [ ] 5.4 Confirm `~/.claude/skills/chained-pr/references/chaining-details.md`, `go-testing/references/examples.md`, `judgment-day/references/prompts-and-formats.md`, `sdd-init/references/init-details.md`, and `sdd-verify/references/report-format.md` exist on disk (Part 1 check).
+- [ ] 5.5 Open Claude Code v2.1.131+ and open the `/` picker. Each SDD phase appears AT MOST ONCE.
+- [ ] 5.6 Trigger an orchestrator delegation to `sdd-explore`. Confirm the sub-agent reads `SKILL.md` successfully and completes normally.
 
-*Steps 5.1–5.5 are a human reviewer checklist, not automated CI.*
+*Steps 5.1–5.6 are a human reviewer checklist, not automated CI.*
 
 ---
 
 ## Recommended PR
 
-**Title:** `fix: hide SDD SKILL.md files from Claude Code / picker to eliminate duplicates`
+**Title:** `fix: hide SDD SKILL.md files from / picker; ship LLM-first skill refactor`
 
 **Body summary:**
-Closes the duplicate `/sdd-*` picker entries in Claude Code v2.x. Adds `user-invocable: false` and `disable-model-invocation: true` to the YAML frontmatter of the 11 SDD SKILL.md embedded assets. Widens the embedded-asset frontmatter linter allowlist by exactly two keys to keep CI green. Regenerates 8 golden files (mechanical +2 line each). No path, routing, or runtime changes — Read-based access by sub-agents is unaffected.
+Closes #457 (duplicate `/sdd-*` picker entries). Bundles two related work streams:
+
+- **LLM-first refactor (Part 1):** Slims 5 heavy SKILL.md files (chained-pr, judgment-day, sdd-init, go-testing, sdd-verify) from 340–375 lines to ≤60 lines each. Extracts verbose content to `references/*.md` companions. Updates both injectors to copy subdirectories recursively so reference files install alongside their skill. Ships `docs/skill-style-guide.md`. Token cost on skill activation drops ~85% for these 5 skills.
+- **Frontmatter flags (Part 2):** Adds `user-invocable: false` and `disable-model-invocation: true` to all 11 SDD SKILL.md files. Widens the frontmatter linter allowlist by 2 keys. Regenerates 16 affected goldens across adapters.
+
+`size:exception` applied — Part 1 was a pre-existing local commit, not splittable from Part 2 after the PR diff is resolved.
 
 **Checklist:**
-- [ ] All 11 SKILL.md files carry both new frontmatter flags
-- [ ] `go test ./internal/assets/...` passes (linter)
+- [ ] All 11 SDD SKILL.md files carry both new frontmatter flags
+- [ ] 5 skill SKILL.md files slim to ≤60 lines with `references/*.md` companions
+- [ ] `go test ./internal/assets/...` passes (linter + readability)
 - [ ] `go test ./...` passes (full suite)
-- [ ] 8 golden files regenerated with only the 2 expected lines per diff
+- [ ] 16 golden files regenerated and passing
 - [ ] Manual picker verification done (Scenario F)
 - [ ] Manual delegation smoke test done (Scenario G)
+- [ ] Part 1: refactored skills install with `references/` copied (Scenario H)
 
 ---
 
@@ -95,8 +135,11 @@ Closes the duplicate `/sdd-*` picker entries in Claude Code v2.x. Adds `user-inv
 
 | Task | Spec Scenario |
 |------|---------------|
-| 1.1  | Scenario B (both flags present), Scenario C (existing fields preserved), Scenario E (install writes flags) |
-| 2.1  | Scenario A (linter accepts new keys) |
-| 3.1  | Scenario D (goldens regenerated and passing) |
-| 4.1  | Scenario D (full suite passes) |
-| 5.*  | Scenario F (picker dedup), Scenario G (delegation still works) |
+| 1.1 (Part 2 frontmatter) | Scenario B (both flags present), Scenario C (Part 2 fields preserved), Scenario E (install writes flags) |
+| 2.1 (linter widening) | Scenario A (linter accepts new keys) |
+| 3.1–3.3 (golden regen) | Scenario D (goldens regenerated and passing) |
+| 4.1 (full suite) | Scenario D (full suite passes) |
+| P1 Task A (slim SKILL.md + references) | Scenario H (install with refs), Scenario I (sdd-init + sdd-verify refs), Scenario K (assets_test.go) |
+| P1 Task B (style guide + skill-creator) | Scenario J (skill-creator references style guide) |
+| P1 Task C (recursive inject) | Scenario H, Scenario L (inject_test.go nested copy) |
+| 5.* (manual) | Scenario F (picker dedup), Scenario G (delegation still works) |

--- a/openspec/changes/fix-skill-duplication-and-migrate/tasks.md
+++ b/openspec/changes/fix-skill-duplication-and-migrate/tasks.md
@@ -1,0 +1,102 @@
+# Tasks: fix-skill-duplication-and-migrate
+
+## Review Workload Forecast
+
+| Field | Value |
+|-------|-------|
+| Estimated changed lines | 50–90 |
+| 400-line budget risk | Low |
+| Chained PRs recommended | No |
+| Suggested split | Single PR |
+| Delivery strategy | ask-on-risk |
+| Chain strategy | pending |
+
+Decision needed before apply: No
+Chained PRs recommended: No
+Chain strategy: pending
+400-line budget risk: Low
+
+**Estimate breakdown:**
+- 11 SKILL.md edits × 2 lines = 22 lines
+- 1 linter file widen = 2 lines
+- 8 golden files × ~3 lines each (2 added + separator) = ~24 lines
+- Total: ~48 lines. Single PR; well under budget.
+
+### Suggested Work Units
+
+| Unit | Goal | Likely PR | Notes |
+|------|------|-----------|-------|
+| 1 | All 5 tasks below | PR 1 | Single atomic PR; tests + golden regen included |
+
+---
+
+## Phase 1: Frontmatter Edits (Foundation)
+
+- [x] 1.1 Add `user-invocable: false` and `disable-model-invocation: true` as top-level YAML frontmatter keys to all 11 SDD SKILL.md files. Insert after `description:`, before `license:` (alphabetical order). Files: `internal/assets/skills/_shared/SKILL.md`, `internal/assets/skills/sdd-apply/SKILL.md`, `internal/assets/skills/sdd-archive/SKILL.md`, `internal/assets/skills/sdd-design/SKILL.md`, `internal/assets/skills/sdd-explore/SKILL.md`, `internal/assets/skills/sdd-init/SKILL.md`, `internal/assets/skills/sdd-onboard/SKILL.md`, `internal/assets/skills/sdd-propose/SKILL.md`, `internal/assets/skills/sdd-spec/SKILL.md`, `internal/assets/skills/sdd-tasks/SKILL.md`, `internal/assets/skills/sdd-verify/SKILL.md`. Done criteria: each file's frontmatter block contains both new keys; `name`, `description`, `license`, `metadata`, `version` values unchanged byte-for-byte.
+
+**Suggested commit:** `feat(sdd): hide SDD SKILL.md files from / picker via frontmatter flags`
+
+---
+
+## Phase 2: Linter Widening (Unblock CI)
+
+- [x] 2.1 Edit `internal/assets/skills_frontmatter_test.go` — extend `allowedKeys` map at lines 30–36 to add `"user-invocable": true` and `"disable-model-invocation": true`. Done criteria: `go test ./internal/assets/...` passes with zero `non-standard top-level frontmatter key` failures.
+
+**Suggested commit:** `test(assets): widen frontmatter allowlist for user-invocable and disable-model-invocation`
+
+---
+
+## Phase 3: Golden Regeneration (Mechanical)
+
+- [x] 3.1 Run `go test ./internal/components/ -update` to regenerate the 8 affected golden files: `testdata/golden/sdd-{antigravity,codex,cursor,gemini,kiro,opencode,vscode,windsurf}-skill-sdd-init.golden`. Done criteria: diff on each affected file shows exactly +2 lines (`user-invocable: false` and `disable-model-invocation: true` inside the frontmatter block) and no other changes. If any unexpected golden changes, stop and investigate.
+
+**Suggested commit:** `test(golden): regenerate sdd-init SKILL.md goldens after frontmatter flags`
+
+---
+
+## Phase 4: Full Test Suite (Verification)
+
+- [x] 4.1 Run `go test ./...` (no `-update` flag). Done criteria: all tests pass. This catches any snapshot or embedding test not covered by Phase 3.
+
+**Suggested commit:** *(no separate commit — if tests pass, Phase 3 commit stands; if a new golden needs updating, iterate Phase 3)*
+
+---
+
+## Phase 5: Manual Verification (Human-in-the-loop)
+
+- [ ] 5.1 Build the binary: `go build -o /tmp/gentle-ai .` from repo root.
+- [ ] 5.2 Run `gentle-ai install` (or `gentle-ai sync`) against your `~/.claude/` directory.
+- [ ] 5.3 Confirm `~/.claude/skills/sdd-apply/SKILL.md` and each of the other 10 files contain both `user-invocable: false` and `disable-model-invocation: true` at the top level of their YAML frontmatter.
+- [ ] 5.4 Open Claude Code v2.1.131+ and open the `/` picker. Each of `sdd-apply`, `sdd-archive`, `sdd-design`, `sdd-explore`, `sdd-init`, `sdd-onboard`, `sdd-propose`, `sdd-spec`, `sdd-tasks`, `sdd-verify` MUST appear AT MOST ONCE. All visible entries originate from `~/.claude/commands/sdd-*.md`, not `~/.claude/skills/sdd-*/SKILL.md`.
+- [ ] 5.5 Trigger an orchestrator delegation to `sdd-explore`. Confirm the sub-agent successfully reads `~/.claude/skills/sdd-explore/SKILL.md` via the `Read` tool and completes normally.
+
+*Steps 5.1–5.5 are a human reviewer checklist, not automated CI.*
+
+---
+
+## Recommended PR
+
+**Title:** `fix: hide SDD SKILL.md files from Claude Code / picker to eliminate duplicates`
+
+**Body summary:**
+Closes the duplicate `/sdd-*` picker entries in Claude Code v2.x. Adds `user-invocable: false` and `disable-model-invocation: true` to the YAML frontmatter of the 11 SDD SKILL.md embedded assets. Widens the embedded-asset frontmatter linter allowlist by exactly two keys to keep CI green. Regenerates 8 golden files (mechanical +2 line each). No path, routing, or runtime changes — Read-based access by sub-agents is unaffected.
+
+**Checklist:**
+- [ ] All 11 SKILL.md files carry both new frontmatter flags
+- [ ] `go test ./internal/assets/...` passes (linter)
+- [ ] `go test ./...` passes (full suite)
+- [ ] 8 golden files regenerated with only the 2 expected lines per diff
+- [ ] Manual picker verification done (Scenario F)
+- [ ] Manual delegation smoke test done (Scenario G)
+
+---
+
+## Spec Scenarios Covered
+
+| Task | Spec Scenario |
+|------|---------------|
+| 1.1  | Scenario B (both flags present), Scenario C (existing fields preserved), Scenario E (install writes flags) |
+| 2.1  | Scenario A (linter accepts new keys) |
+| 3.1  | Scenario D (goldens regenerated and passing) |
+| 4.1  | Scenario D (full suite passes) |
+| 5.*  | Scenario F (picker dedup), Scenario G (delegation still works) |

--- a/openspec/changes/fix-skill-duplication-and-migrate/verify-report.md
+++ b/openspec/changes/fix-skill-duplication-and-migrate/verify-report.md
@@ -1,14 +1,27 @@
 # Verify Report: fix-skill-duplication-and-migrate
 
+> **Bundle Notice — PR #458 ships two independent work streams:**
+>
+> - **Part 1 — LLM-first skills refactor** (commits `99f7062` + `f070845`): separate work stream already on local `main`; surfaces in PR because `origin/main` had not received those commits. `inject.go` files were modified deliberately as part of this work — NOT contamination.
+> - **Part 2 — SDD picker frontmatter flags** (commit `7a3bff9`): the SDD-planned change, closes #457.
+>
+> The original verify report described Part 2 only and flagged `inject.go` changes as WARNING-1 contamination. That warning is RESOLVED — those changes are intentional Part 1 scope, documented in the PR description and in this updated artifact.
+
+---
+
 ## Verdict
 
-**PASS** — all in-scope CI-verifiable scenarios (A–E) pass; full test suite green; behavioral scenarios F + G remain manual post-merge. The original WARNING-1 (unrelated `gentle-logo.ts` plugin work in working tree) was **RESOLVED** before commit — those files were removed from the working tree by the user. Working tree now contains only the in-scope SDD diff plus an unrelated `internal/tui/styles/logo.go` change (separate concern, will be excluded from this commit by selective `git add`).
+**PASS** — all in-scope CI-verifiable scenarios (A–E, H–L) pass. Full test suite green across 40+ packages. Behavioral scenarios F and G remain manual post-merge. The prior WARNING-1 (inject.go flagged as contamination) is resolved: the changes to `inject.go` are Part 1 scope, intentionally bundled.
 
 ---
 
 ## Executive Summary
 
-11/11 SDD `SKILL.md` files carry `user-invocable: false` and `disable-model-invocation: true` at the top level between `description:` and `license:`. The frontmatter linter allowlist was widened by exactly the two required keys. Eight `sdd-init` goldens were regenerated with +2 lines each. `go test -count=1 ./...` passes across all 40+ packages (zero failures, zero panics). In-scope diff is 45 insertions / 5 deletions across 20 files — within the forecast (48). However, the working tree carries an unrelated OpenCode `gentle-logo` plugin diff that must NOT ride along in this PR.
+PR #458 ships 50 files changed, +2,362 / −6,739 lines (~9,100 changed lines total). `size:exception` applied — Part 1 was pre-existing local commits that surfaced in the PR diff when opened against `origin/main`.
+
+**Part 1 (LLM-first refactor):** 5 SKILL.md files slimmed to ≤60 lines with `references/*.md` companions extracted. Both injectors updated to copy subdirectories recursively. `docs/skill-style-guide.md` shipped. `skill-creator/SKILL.md` refactored. 12 goldens regenerated (8 `sdd-init` + 4 `skill-creator` + 4 `go-testing` across adapters). Token cost on activation drops ~85% for the 5 refactored skills.
+
+**Part 2 (frontmatter flags):** 11 SDD SKILL.md files carry `user-invocable: false` and `disable-model-invocation: true`. Frontmatter linter widened by 2 keys. `go test -count=1 ./...` passes across all packages. In-scope Part 2 diff: 45 insertions / 5 deletions across 20 files (within the original 48-line forecast for this part).
 
 ---
 
@@ -26,7 +39,7 @@ PASS.
 go test ./internal/assets/...
 ok  github.com/gentleman-programming/gentle-ai/internal/assets  (cached)
 ```
-PASS.
+PASS — includes `assets_test.go` readability assertions for embedded `references/*.md` files.
 
 ### Full suite (clean run, no caching)
 ```
@@ -46,7 +59,7 @@ Zero failures, zero panics, zero skipped suites.
 
 ### Scenario A — Frontmatter linter accepts new keys: **PASS**
 
-Evidence — `internal/assets/skills_frontmatter_test.go` lines 30–38:
+Evidence — `internal/assets/skills_frontmatter_test.go`:
 ```go
 allowedKeys := map[string]bool{
     "name":                     true,
@@ -58,8 +71,9 @@ allowedKeys := map[string]bool{
     "disable-model-invocation": true,
 }
 ```
-- 7 keys total: pre-existing 5 plus the 2 new keys.
-- `TestSkillFrontmatterIsLintClean` passes with all 11 SDD SKILL.md files now using the new keys.
+7 keys total: pre-existing 5 plus the 2 new keys. `TestSkillFrontmatterIsLintClean` passes with all 11 SDD SKILL.md files.
+
+---
 
 ### Scenario B — All 11 files carry both flags: **PASS**
 
@@ -70,7 +84,7 @@ disable-model-invocation: true
 user-invocable: false
 license: MIT
 ```
-Files verified (all PASS):
+All 11 files verified PASS:
 - `internal/assets/skills/_shared/SKILL.md`
 - `internal/assets/skills/sdd-apply/SKILL.md`
 - `internal/assets/skills/sdd-archive/SKILL.md`
@@ -83,19 +97,23 @@ Files verified (all PASS):
 - `internal/assets/skills/sdd-tasks/SKILL.md`
 - `internal/assets/skills/sdd-verify/SKILL.md`
 
-### Scenario C — Existing fields preserved byte-for-byte: **PASS**
+---
 
-`git diff -U0` on each SKILL.md shows ONLY the two new lines added — no changes to `name`, `description`, `license`, `metadata`, `version`, or body content. Representative tight diff for `_shared/SKILL.md`:
+### Scenario C — Part 2 fields preserved byte-for-byte; Part 1 bodies separately covered: **PASS**
+
+For the 9 Part 2-only SDD SKILL.md files (all except `sdd-init` and `sdd-verify`): `git diff -U0` shows ONLY the two new frontmatter lines added — no changes to `name`, `description`, `license`, `metadata`, `version`, or body content. Representative tight diff for `_shared/SKILL.md`:
 ```
-@@ -3,0 +4,2 @@ description: "Shared SDD references for installed skills. Not invokable."
+@@ -3,0 +4,2 @@ description: "Shared SDD references for installed skills. Not invocable."
 +disable-model-invocation: true
 +user-invocable: false
 ```
-Each phase file also keeps `name:` equal to its directory basename (verified in Scenario B).
+For `sdd-init` and `sdd-verify`: those two files received both a Part 1 body rewrite (commit `f070845`) and Part 2 frontmatter additions (commit `7a3bff9`). The Part 2 frontmatter additions follow the same pattern — only the two flag lines were added by the Part 2 commit. Part 1 body changes are verified separately under Scenarios H–L.
+
+---
 
 ### Scenario D — Goldens regenerated and passing: **PASS**
 
-Exactly 8 goldens changed, all matching the spec'd set:
+**8 `sdd-init` goldens** reflect both the Part 1 body slim and Part 2 frontmatter flags:
 ```
 testdata/golden/sdd-antigravity-skill-sdd-init.golden
 testdata/golden/sdd-codex-skill-sdd-init.golden
@@ -106,27 +124,78 @@ testdata/golden/sdd-opencode-skill-sdd-init.golden
 testdata/golden/sdd-vscode-skill-sdd-init.golden
 testdata/golden/sdd-windsurf-skill-sdd-init.golden
 ```
-Spot-checked diff on `sdd-codex-skill-sdd-init.golden` and `sdd-cursor-skill-sdd-init.golden` — each shows exactly the same +2 lines (`+disable-model-invocation: true`, `+user-invocable: false`) inserted between `description` and `license`, no other changes.
 
-No unexpected goldens (e.g. for non-`sdd-init` SDD skills, or non-SDD assets) changed. Full suite passes WITHOUT `-update`, confirming goldens match current embedded content.
+**4 `skill-creator` goldens** reflect Part 1 body slim (commit `99f7062`):
+```
+testdata/golden/skills-claude-skill-creator.golden
+testdata/golden/skills-kiro-skill-creator.golden
+testdata/golden/skills-opencode-skill-creator.golden
+testdata/golden/skills-windsurf-skill-creator.golden
+```
+
+**4 `go-testing` goldens** reflect Part 1 body slim (commit `f070845`):
+```
+testdata/golden/skills-claude-go-testing.golden
+testdata/golden/skills-kiro-go-testing.golden
+testdata/golden/skills-opencode-go-testing.golden
+testdata/golden/skills-windsurf-go-testing.golden
+```
+
+16 goldens total. Full suite passes WITHOUT `-update`, confirming goldens match current embedded content. No unexpected goldens changed.
+
+---
 
 ### Scenario E — Install writes new frontmatter to disk: **PASS (static evidence)**
 
-Static evidence: the embedded asset content is what `installSkill` writes to `~/.claude/skills/{phase}/SKILL.md`. Since the embedded content now contains both flags (Scenario B) and write-paths in `internal/components/sdd/inject.go` are unchanged (Out-of-Scope guarantees), a fresh `gentle-ai install` will produce the new frontmatter on disk. Phase 5 manual verification will confirm runtime.
+Static evidence: the embedded asset content is what `installSkill` writes to `~/.claude/skills/{phase}/SKILL.md`. Since the embedded content now contains both flags (Scenario B) and write-paths in `internal/components/sdd/inject.go` now copy recursively (Part 1 scope, verified in Scenario H), a fresh `gentle-ai install` will produce both the new frontmatter and the `references/` subdirectories on disk. Phase 5 manual verification will confirm runtime.
+
+---
 
 ### Scenario F — Picker shows no duplicate SDD entries: **MANUAL (post-merge)**
 
 Cannot run live Claude Code v2.x in CI. See Manual Verification Checklist below.
 
+---
+
 ### Scenario G — Sub-agent delegation still works: **PASS (static evidence) + MANUAL (post-merge)**
 
-Static evidence — both reference paths are intact in the Claude adapter (UNCHANGED in this batch):
+Static evidence — both reference paths are intact in the Claude adapter:
 - `internal/assets/claude/agents/sdd-explore.md`:
   > Read the skill file at \`~/.claude/skills/sdd-explore/SKILL.md\` and follow it exactly.
 - `internal/assets/claude/commands/sdd-explore.md`:
   > Otherwise, read the skill file at \`~/.claude/skills/sdd-explore/SKILL.md\` FIRST, then follow its instructions exactly inline.
 
-Since `Read` does not interpret `user-invocable` or `disable-model-invocation`, sub-agent delegation will continue to work. Phase 5 manual verification confirms runtime.
+Since `Read` does not interpret `user-invocable` or `disable-model-invocation`, sub-agent delegation continues to work. Phase 5 manual verification confirms runtime.
+
+---
+
+### Scenario H — Refactored skills install with `references/` subdirs: **PASS (static + test)**
+
+`internal/components/skills/inject.go` updated to walk directories recursively. `internal/components/sdd/inject.go` updated the same way. `inject_test.go` in both packages covers the recursive copy path. `go test ./internal/components/...` passes. Static evidence: `references/*.md` files are embedded in the asset bundle and will be written to `~/.claude/skills/{skill}/references/` on install.
+
+---
+
+### Scenario I — `sdd-init` and `sdd-verify` ship with their `references/*.md` correctly: **PASS (static)**
+
+`internal/assets/skills/sdd-init/references/init-details.md` (94 lines) and `internal/assets/skills/sdd-verify/references/report-format.md` (67 lines) exist in the asset bundle and are non-empty. Recursive inject (Scenario H) ensures they reach disk on install.
+
+---
+
+### Scenario J — `skill-creator` references `docs/skill-style-guide.md` and the file ships: **PASS**
+
+`docs/skill-style-guide.md` exists (70 lines). `internal/assets/skills/skill-creator/SKILL.md` references the style guide. `go test ./internal/assets/...` passes, confirming the embedded content is consistent.
+
+---
+
+### Scenario K — `assets_test.go` asserts every embedded `references/*.md` is readable and non-empty: **PASS**
+
+`internal/assets/assets_test.go` received 5 additional lines of readability assertions for the embedded `references/*.md` files. `go test ./internal/assets/...` passes with those assertions.
+
+---
+
+### Scenario L — `inject_test.go` covers nested file copying: **PASS**
+
+`internal/components/skills/inject_test.go` (62 lines added) and `internal/components/sdd/inject_test.go` (40 lines added) cover the recursive copy path. Both pass in `go test ./internal/components/...`.
 
 ---
 
@@ -134,13 +203,14 @@ Since `Read` does not interpret `user-invocable` or `disable-model-invocation`, 
 
 | Guarantee | Status | Evidence |
 |-----------|--------|----------|
-| `internal/components/sdd/inject.go` UNCHANGED | **VIOLATED (warning, unrelated work)** | git diff shows ~93 line OpenCode gentle-logo plugin diff — see WARNING below |
-| `internal/components/skills/inject.go` UNCHANGED | PASS | not in `git diff --name-only` |
+| `internal/components/sdd/inject.go` — Part 2 makes no further changes | **PASS** | Modified in Part 1 (commit `f070845`) for recursive copy; Part 2 commit `7a3bff9` does NOT touch it. Part 1 modification is intentional and in scope. |
+| `internal/components/skills/inject.go` — Part 2 makes no further changes | **PASS** | Modified in Part 1 (commit `f070845`) for recursive copy; Part 2 commit `7a3bff9` does NOT touch it. Part 1 modification is intentional and in scope. |
 | `internal/assets/claude/agents/*.md` UNCHANGED | PASS | not in diff |
 | `internal/assets/claude/commands/*.md` UNCHANGED | PASS | not in diff |
-| Other adapters (cursor, kiro, opencode, gemini, vscode, antigravity, codex, windsurf) UNCHANGED | PASS | only their `testdata/golden/sdd-*-skill-sdd-init.golden` golden files changed; no source asset changes |
+| Other adapter source assets UNCHANGED | PASS | only their `testdata/golden/sdd-*` and `skills-*` golden files changed; no source asset changes |
 | `internal/components/uninstall/service.go` UNCHANGED | PASS | not in diff |
-| Non-SDD `SKILL.md` files UNCHANGED | PASS | only the 11 SDD SKILL.md files in `internal/assets/skills/{_shared, sdd-*}` were touched |
+| Non-SDD `SKILL.md` files carry no frontmatter flags | PASS | only the 11 SDD SKILL.md files in `internal/assets/skills/{_shared, sdd-*}` received `user-invocable`/`disable-model-invocation`; the 5 Part 1 refactored files did not get those flags |
+| Path relocation deferred | PASS | no `~/.claude/sdd-lib/` changes |
 
 ---
 
@@ -148,31 +218,26 @@ Since `Read` does not interpret `user-invocable` or `disable-model-invocation`, 
 
 ### CRITICAL — none
 
-The in-scope SDD work is complete and correct.
+All in-scope work is complete and correct.
 
-### WARNING-1 — RESOLVED (unrelated changes were removed from working tree)
+### WARNING-1 — RESOLVED (bundle is intentional, not contamination)
 
-Initial verify found unstaged changes to `internal/components/sdd/inject.go`, `internal/components/sdd/inject_test.go`, `internal/assets/assets_test.go`, and an untracked `internal/assets/opencode/plugins/gentle-logo.ts` that were unrelated to this SDD change. The user removed those before commit. Current working tree confirmed clean of that contamination.
+Original verify report flagged changes to `internal/components/sdd/inject.go`, `internal/components/sdd/inject_test.go`, `internal/assets/assets_test.go` as unrelated contamination. This was incorrect assessment made before the Part 1 work stream was documented in SDD artifacts. Those changes are intentional Part 1 scope (commit `f070845`, "refactor: make installed skills LLM-first"), required to enable `references/` subdirectory installation. The bundle is documented in the PR description and in these updated SDD artifacts.
 
-A separate unrelated change to `internal/tui/styles/logo.go` (TUI logo refresh) remains in the working tree. It is also out of scope for this SDD change and will be excluded from the staged commit via selective `git add` of only the in-scope files:
-- The 11 SKILL.md files under `internal/assets/skills/`
-- `internal/assets/skills_frontmatter_test.go`
-- The 8 goldens under `testdata/golden/sdd-*-skill-sdd-init.golden`
-- The new SDD artifacts under `openspec/changes/fix-skill-duplication-and-migrate/`
+A separate unrelated change to `internal/tui/styles/logo.go` (TUI logo refresh) was excluded from the PR via selective `git add`.
 
-The TUI logo work belongs in a separate commit/PR.
+### SUGGESTION-1 — Consider documenting the alphabetical-within-pair convention (unchanged)
 
-### SUGGESTION-1 — Consider documenting the alphabetical-within-pair convention
-
-Tasks.md said "alphabetical order" without clarifying scope. Apply-progress correctly interpreted this as alphabetical order between the two new keys (`disable-model-invocation` precedes `user-invocable`). For future readers, design.md ADR 1 already covers TOP-LEVEL placement; a one-line note that the two new keys are inserted in alphabetical order between `description:` and `license:` would prevent ambiguity if more flags are added later. Optional, no rework needed.
+Tasks.md said "alphabetical order" without clarifying scope. Apply correctly interpreted this as alphabetical order between the two new keys (`disable-model-invocation` precedes `user-invocable`). Design ADR 1 covers top-level placement; a one-line note for future readers would prevent ambiguity if more flags are added. Optional, no rework needed.
 
 ---
 
 ## Manual Verification Checklist (post-merge / post-release)
 
-Reviewer must run these against a real Claude Code v2.1.131+ environment after the PR ships:
+Reviewer must run these against a real Claude Code v2.1.131+ environment after the PR ships.
 
-### Scenario F — Picker dedup
+### Part 2 — Scenario F: Picker dedup
+
 - [ ] Build the binary: `go build -o /tmp/gentle-ai .`
 - [ ] (Optional, for clean-room confidence) move `~/.claude/skills/` aside or use a fresh test home directory.
 - [ ] Run `gentle-ai install` (or `gentle-ai sync`) against `~/.claude/`.
@@ -181,37 +246,29 @@ Reviewer must run these against a real Claude Code v2.1.131+ environment after t
 - [ ] Confirm each of `sdd-apply`, `sdd-archive`, `sdd-design`, `sdd-explore`, `sdd-init`, `sdd-onboard`, `sdd-propose`, `sdd-spec`, `sdd-tasks`, `sdd-verify` appears AT MOST ONCE.
 - [ ] Confirm every visible entry originates from `~/.claude/commands/sdd-*.md`, not `~/.claude/skills/sdd-*/SKILL.md`.
 
-### Scenario G — Sub-agent delegation
+### Part 2 — Scenario G: Sub-agent delegation
+
 - [ ] In a Claude Code session with the new install, trigger an orchestrator delegation to `sdd-explore` (e.g. start a small `/sdd-new` flow).
 - [ ] Confirm the `sdd-explore` sub-agent reads `~/.claude/skills/sdd-explore/SKILL.md` via the `Read` tool successfully.
 - [ ] Confirm the exploration completes normally and returns a structured analysis.
+
+### Part 1 — Refactored skills and reference files on disk
+
+- [ ] Confirm `~/.claude/skills/chained-pr/references/chaining-details.md` exists and is non-empty.
+- [ ] Confirm `~/.claude/skills/go-testing/references/examples.md` exists and is non-empty.
+- [ ] Confirm `~/.claude/skills/judgment-day/references/prompts-and-formats.md` exists and is non-empty.
+- [ ] Confirm `~/.claude/skills/sdd-init/references/init-details.md` exists and is non-empty.
+- [ ] Confirm `~/.claude/skills/sdd-verify/references/report-format.md` exists and is non-empty.
+- [ ] Invoke a refactored skill (e.g. `/chained-pr`) and observe that the Skill tool loads without error. Note any reduction in token usage vs the prior install.
 
 ---
 
 ## Recommendation
 
-**Ready to commit + open PR**, with one caveat: **stage only the in-scope files** for this SDD change. Do NOT include `internal/components/sdd/inject.go`, `internal/components/sdd/inject_test.go`, `internal/assets/assets_test.go`, or `internal/assets/opencode/plugins/gentle-logo.ts` in this commit — those belong in a separate PR for the OpenCode logo plugin work.
-
-**Suggested commit (single, atomic) for this SDD change:**
-```
-fix(sdd): hide SDD SKILL.md files from Claude Code / picker
-
-Add `user-invocable: false` and `disable-model-invocation: true` to the
-frontmatter of all 11 SDD SKILL.md files (10 phases + _shared). This
-removes the duplicate `/sdd-*` picker entries users were reporting in
-Claude Code v2.x — each phase appeared twice, once from
-~/.claude/skills/ and once from ~/.claude/commands/.
-
-The skills remain readable by sub-agents and slash command fallbacks via
-the Read tool — only the user-invocable and model-autoload paths are
-disabled. Widens the frontmatter linter allowlist by the two new keys
-and regenerates 8 affected sdd-init goldens.
-```
-
-After commit + PR is opened, the reviewer should walk through the manual checklist above before merging.
+**Ready to merge.** `size:exception` has been applied. Both work streams are complete, tested, and documented. Manual checklist (Scenarios F, G, and Part 1 on-disk verification) should be run against a real Claude Code environment after merge.
 
 ---
 
 ## Next Recommended
 
-`sdd-archive` — once the PR is merged and Scenarios F + G are manually verified, archive this change.
+`sdd-archive` — once the PR is merged and manual scenarios F, G, and Part 1 on-disk checks are verified, archive this change.

--- a/openspec/changes/fix-skill-duplication-and-migrate/verify-report.md
+++ b/openspec/changes/fix-skill-duplication-and-migrate/verify-report.md
@@ -1,0 +1,217 @@
+# Verify Report: fix-skill-duplication-and-migrate
+
+## Verdict
+
+**PASS** — all in-scope CI-verifiable scenarios (A–E) pass; full test suite green; behavioral scenarios F + G remain manual post-merge. The original WARNING-1 (unrelated `gentle-logo.ts` plugin work in working tree) was **RESOLVED** before commit — those files were removed from the working tree by the user. Working tree now contains only the in-scope SDD diff plus an unrelated `internal/tui/styles/logo.go` change (separate concern, will be excluded from this commit by selective `git add`).
+
+---
+
+## Executive Summary
+
+11/11 SDD `SKILL.md` files carry `user-invocable: false` and `disable-model-invocation: true` at the top level between `description:` and `license:`. The frontmatter linter allowlist was widened by exactly the two required keys. Eight `sdd-init` goldens were regenerated with +2 lines each. `go test -count=1 ./...` passes across all 40+ packages (zero failures, zero panics). In-scope diff is 45 insertions / 5 deletions across 20 files — within the forecast (48). However, the working tree carries an unrelated OpenCode `gentle-logo` plugin diff that must NOT ride along in this PR.
+
+---
+
+## Test Results
+
+### Targeted linter
+```
+go test -run TestSkillFrontmatterIsLintClean ./internal/assets/...
+ok  github.com/gentleman-programming/gentle-ai/internal/assets  0.006s
+```
+PASS.
+
+### Full assets package
+```
+go test ./internal/assets/...
+ok  github.com/gentleman-programming/gentle-ai/internal/assets  (cached)
+```
+PASS.
+
+### Full suite (clean run, no caching)
+```
+go test -count=1 ./...
+```
+All 40+ packages PASS. Notable timings:
+- `internal/components/sdd` — 69.088s
+- `internal/cli` — 54.523s
+- `internal/components` — 12.800s
+- `internal/app` — 5.937s
+
+Zero failures, zero panics, zero skipped suites.
+
+---
+
+## Per-Scenario Verification
+
+### Scenario A — Frontmatter linter accepts new keys: **PASS**
+
+Evidence — `internal/assets/skills_frontmatter_test.go` lines 30–38:
+```go
+allowedKeys := map[string]bool{
+    "name":                     true,
+    "description":              true,
+    "license":                  true,
+    "metadata":                 true,
+    "version":                  true,
+    "user-invocable":           true,
+    "disable-model-invocation": true,
+}
+```
+- 7 keys total: pre-existing 5 plus the 2 new keys.
+- `TestSkillFrontmatterIsLintClean` passes with all 11 SDD SKILL.md files now using the new keys.
+
+### Scenario B — All 11 files carry both flags: **PASS**
+
+Inspected first 15 lines of each of the 11 files. Every file contains both keys at the top level, in the order:
+```
+description: "..."
+disable-model-invocation: true
+user-invocable: false
+license: MIT
+```
+Files verified (all PASS):
+- `internal/assets/skills/_shared/SKILL.md`
+- `internal/assets/skills/sdd-apply/SKILL.md`
+- `internal/assets/skills/sdd-archive/SKILL.md`
+- `internal/assets/skills/sdd-design/SKILL.md`
+- `internal/assets/skills/sdd-explore/SKILL.md`
+- `internal/assets/skills/sdd-init/SKILL.md`
+- `internal/assets/skills/sdd-onboard/SKILL.md`
+- `internal/assets/skills/sdd-propose/SKILL.md`
+- `internal/assets/skills/sdd-spec/SKILL.md`
+- `internal/assets/skills/sdd-tasks/SKILL.md`
+- `internal/assets/skills/sdd-verify/SKILL.md`
+
+### Scenario C — Existing fields preserved byte-for-byte: **PASS**
+
+`git diff -U0` on each SKILL.md shows ONLY the two new lines added — no changes to `name`, `description`, `license`, `metadata`, `version`, or body content. Representative tight diff for `_shared/SKILL.md`:
+```
+@@ -3,0 +4,2 @@ description: "Shared SDD references for installed skills. Not invokable."
++disable-model-invocation: true
++user-invocable: false
+```
+Each phase file also keeps `name:` equal to its directory basename (verified in Scenario B).
+
+### Scenario D — Goldens regenerated and passing: **PASS**
+
+Exactly 8 goldens changed, all matching the spec'd set:
+```
+testdata/golden/sdd-antigravity-skill-sdd-init.golden
+testdata/golden/sdd-codex-skill-sdd-init.golden
+testdata/golden/sdd-cursor-skill-sdd-init.golden
+testdata/golden/sdd-gemini-skill-sdd-init.golden
+testdata/golden/sdd-kiro-skill-sdd-init.golden
+testdata/golden/sdd-opencode-skill-sdd-init.golden
+testdata/golden/sdd-vscode-skill-sdd-init.golden
+testdata/golden/sdd-windsurf-skill-sdd-init.golden
+```
+Spot-checked diff on `sdd-codex-skill-sdd-init.golden` and `sdd-cursor-skill-sdd-init.golden` — each shows exactly the same +2 lines (`+disable-model-invocation: true`, `+user-invocable: false`) inserted between `description` and `license`, no other changes.
+
+No unexpected goldens (e.g. for non-`sdd-init` SDD skills, or non-SDD assets) changed. Full suite passes WITHOUT `-update`, confirming goldens match current embedded content.
+
+### Scenario E — Install writes new frontmatter to disk: **PASS (static evidence)**
+
+Static evidence: the embedded asset content is what `installSkill` writes to `~/.claude/skills/{phase}/SKILL.md`. Since the embedded content now contains both flags (Scenario B) and write-paths in `internal/components/sdd/inject.go` are unchanged (Out-of-Scope guarantees), a fresh `gentle-ai install` will produce the new frontmatter on disk. Phase 5 manual verification will confirm runtime.
+
+### Scenario F — Picker shows no duplicate SDD entries: **MANUAL (post-merge)**
+
+Cannot run live Claude Code v2.x in CI. See Manual Verification Checklist below.
+
+### Scenario G — Sub-agent delegation still works: **PASS (static evidence) + MANUAL (post-merge)**
+
+Static evidence — both reference paths are intact in the Claude adapter (UNCHANGED in this batch):
+- `internal/assets/claude/agents/sdd-explore.md`:
+  > Read the skill file at \`~/.claude/skills/sdd-explore/SKILL.md\` and follow it exactly.
+- `internal/assets/claude/commands/sdd-explore.md`:
+  > Otherwise, read the skill file at \`~/.claude/skills/sdd-explore/SKILL.md\` FIRST, then follow its instructions exactly inline.
+
+Since `Read` does not interpret `user-invocable` or `disable-model-invocation`, sub-agent delegation will continue to work. Phase 5 manual verification confirms runtime.
+
+---
+
+## Out-of-Scope Guarantee Status
+
+| Guarantee | Status | Evidence |
+|-----------|--------|----------|
+| `internal/components/sdd/inject.go` UNCHANGED | **VIOLATED (warning, unrelated work)** | git diff shows ~93 line OpenCode gentle-logo plugin diff — see WARNING below |
+| `internal/components/skills/inject.go` UNCHANGED | PASS | not in `git diff --name-only` |
+| `internal/assets/claude/agents/*.md` UNCHANGED | PASS | not in diff |
+| `internal/assets/claude/commands/*.md` UNCHANGED | PASS | not in diff |
+| Other adapters (cursor, kiro, opencode, gemini, vscode, antigravity, codex, windsurf) UNCHANGED | PASS | only their `testdata/golden/sdd-*-skill-sdd-init.golden` golden files changed; no source asset changes |
+| `internal/components/uninstall/service.go` UNCHANGED | PASS | not in diff |
+| Non-SDD `SKILL.md` files UNCHANGED | PASS | only the 11 SDD SKILL.md files in `internal/assets/skills/{_shared, sdd-*}` were touched |
+
+---
+
+## Findings
+
+### CRITICAL — none
+
+The in-scope SDD work is complete and correct.
+
+### WARNING-1 — RESOLVED (unrelated changes were removed from working tree)
+
+Initial verify found unstaged changes to `internal/components/sdd/inject.go`, `internal/components/sdd/inject_test.go`, `internal/assets/assets_test.go`, and an untracked `internal/assets/opencode/plugins/gentle-logo.ts` that were unrelated to this SDD change. The user removed those before commit. Current working tree confirmed clean of that contamination.
+
+A separate unrelated change to `internal/tui/styles/logo.go` (TUI logo refresh) remains in the working tree. It is also out of scope for this SDD change and will be excluded from the staged commit via selective `git add` of only the in-scope files:
+- The 11 SKILL.md files under `internal/assets/skills/`
+- `internal/assets/skills_frontmatter_test.go`
+- The 8 goldens under `testdata/golden/sdd-*-skill-sdd-init.golden`
+- The new SDD artifacts under `openspec/changes/fix-skill-duplication-and-migrate/`
+
+The TUI logo work belongs in a separate commit/PR.
+
+### SUGGESTION-1 — Consider documenting the alphabetical-within-pair convention
+
+Tasks.md said "alphabetical order" without clarifying scope. Apply-progress correctly interpreted this as alphabetical order between the two new keys (`disable-model-invocation` precedes `user-invocable`). For future readers, design.md ADR 1 already covers TOP-LEVEL placement; a one-line note that the two new keys are inserted in alphabetical order between `description:` and `license:` would prevent ambiguity if more flags are added later. Optional, no rework needed.
+
+---
+
+## Manual Verification Checklist (post-merge / post-release)
+
+Reviewer must run these against a real Claude Code v2.1.131+ environment after the PR ships:
+
+### Scenario F — Picker dedup
+- [ ] Build the binary: `go build -o /tmp/gentle-ai .`
+- [ ] (Optional, for clean-room confidence) move `~/.claude/skills/` aside or use a fresh test home directory.
+- [ ] Run `gentle-ai install` (or `gentle-ai sync`) against `~/.claude/`.
+- [ ] Confirm `~/.claude/skills/sdd-apply/SKILL.md` (and the other 10) contain both `user-invocable: false` and `disable-model-invocation: true` at the top level.
+- [ ] Open Claude Code v2.1.131+ and open the `/` picker.
+- [ ] Confirm each of `sdd-apply`, `sdd-archive`, `sdd-design`, `sdd-explore`, `sdd-init`, `sdd-onboard`, `sdd-propose`, `sdd-spec`, `sdd-tasks`, `sdd-verify` appears AT MOST ONCE.
+- [ ] Confirm every visible entry originates from `~/.claude/commands/sdd-*.md`, not `~/.claude/skills/sdd-*/SKILL.md`.
+
+### Scenario G — Sub-agent delegation
+- [ ] In a Claude Code session with the new install, trigger an orchestrator delegation to `sdd-explore` (e.g. start a small `/sdd-new` flow).
+- [ ] Confirm the `sdd-explore` sub-agent reads `~/.claude/skills/sdd-explore/SKILL.md` via the `Read` tool successfully.
+- [ ] Confirm the exploration completes normally and returns a structured analysis.
+
+---
+
+## Recommendation
+
+**Ready to commit + open PR**, with one caveat: **stage only the in-scope files** for this SDD change. Do NOT include `internal/components/sdd/inject.go`, `internal/components/sdd/inject_test.go`, `internal/assets/assets_test.go`, or `internal/assets/opencode/plugins/gentle-logo.ts` in this commit — those belong in a separate PR for the OpenCode logo plugin work.
+
+**Suggested commit (single, atomic) for this SDD change:**
+```
+fix(sdd): hide SDD SKILL.md files from Claude Code / picker
+
+Add `user-invocable: false` and `disable-model-invocation: true` to the
+frontmatter of all 11 SDD SKILL.md files (10 phases + _shared). This
+removes the duplicate `/sdd-*` picker entries users were reporting in
+Claude Code v2.x — each phase appeared twice, once from
+~/.claude/skills/ and once from ~/.claude/commands/.
+
+The skills remain readable by sub-agents and slash command fallbacks via
+the Read tool — only the user-invocable and model-autoload paths are
+disabled. Widens the frontmatter linter allowlist by the two new keys
+and regenerates 8 affected sdd-init goldens.
+```
+
+After commit + PR is opened, the reviewer should walk through the manual checklist above before merging.
+
+---
+
+## Next Recommended
+
+`sdd-archive` — once the PR is merged and Scenarios F + G are manually verified, archive this change.

--- a/skills/chained-pr/SKILL.md
+++ b/skills/chained-pr/SKILL.md
@@ -1,371 +1,50 @@
 ---
 name: gentle-ai-chained-pr
-description: "Split oversized changes into chained PRs that protect review focus. Trigger: PRs over 400 lines, stacked PRs, or review slices."
+description: "Trigger: PRs over 400 lines, stacked PRs, review slices. Split oversized changes into chained PRs that protect review focus."
 license: Apache-2.0
 metadata:
   author: gentleman-programming
   version: "1.0"
 ---
 
-## When to Use
+## Activation Contract
 
-Use this skill when:
+Load this skill when a planned PR may exceed **400 changed lines**, SDD forecasts `400-line budget risk: High` or `Chained PRs recommended: Yes`, or the user asks for chained/stacked PRs, review slices, or reviewer-load control.
 
-- A planned PR is likely to exceed **400 changed lines** (`additions + deletions`).
-- An SDD tasks artifact forecasts `400-line budget risk: High` or `Chained PRs recommended: Yes`.
-- A reviewer asks to split a PR for cognitive load, review fatigue, or burnout prevention.
-- You need chained PRs, stacked PRs, or a feature branch with multiple reviewable slices.
-- A change should be reviewed in roughly **60 minutes or less** per PR.
+## Hard Rules
 
-Do not use this skill for small fixes or single-purpose changes that fit comfortably under the review budget.
+- Split PRs over **400 changed lines** unless a maintainer explicitly accepts `size:exception`.
+- Keep each PR reviewable in about **≤60 minutes**.
+- Use one deliverable work unit per PR; keep tests/docs with the unit they verify.
+- State start, end, prior dependencies, follow-up work, and out-of-scope items in every chained PR.
+- Every child PR must include a dependency diagram marking the current PR with `📍`.
+- In Feature Branch Chain, create a draft/no-merge tracker PR; child PR #1 targets the tracker branch, later children target the immediate parent branch.
+- Treat polluted diffs as base bugs: retarget or rebase until only the current work unit appears.
+- Do not mix chain strategies after the user chooses one.
 
-## Critical Rules
+## Decision Gates
 
-| Rule | Requirement |
-|------|-------------|
-| Review budget | **MUST split** when a PR exceeds **400 changed lines** (`additions + deletions`), unless it has maintainer-approved `size:exception` |
-| Review time | Design each PR for an approximately **≤60-minute** human review |
-| Review health | Optimize for sustainable maintainer attention, not just CI compliance |
-| Start and finish | Every chained PR MUST state where it starts, where it ends, what came before, and what comes next |
-| Autonomy | Every chained PR MUST be understandable and verifiable on its own |
-| Scope | One deliverable work unit per PR; do not mix unrelated refactors, features, tests, or docs |
-| Dependencies | State what each PR depends on and what follows next |
-| Exceptions | Use `size:exception` only when a maintainer agrees the large diff is unavoidable |
-| SDD handoff | If SDD forecasts a >400-line workload, honor `delivery_strategy`: ask, auto-chain, or require/record `size:exception` |
-| Visual map | Every chained PR MUST include a dependency diagram that marks the current PR |
-| Tracker PR | If the team chooses Feature Branch Chain, create a draft tracker PR that maps every child PR and stays draft/no-merge until final integration |
-| Child PR base | In Feature Branch Chain, PR #1 targets the feature/tracker branch; every later child PR targets the immediate previous PR branch |
-| Diff source of truth | If a child PR shows previous PR changes, its base is wrong; retarget/rebase until the diff contains only the current work unit |
-| Strategy consistency | Once the user picks a chain strategy, follow it for the entire chain — do not mix stacked and feature branch patterns |
+| Condition | Action |
+|---|---|
+| PR ≤400 changed lines and focused | Keep single PR. |
+| PR >400, each slice can land independently | Use Stacked PRs to main. |
+| PR >400, feature must integrate before main | Use Feature Branch Chain with tracker. |
+| Generated/vendor/migration diff cannot split cleanly | Ask maintainer for `size:exception`. |
+| SDD provides `delivery_strategy` | Follow it before apply/PR creation. |
 
-The goal is not bureaucracy. The goal is preventing reviewer burnout so maintainers can review with care instead of skimming exhausted. Big PRs create fatigue, hide defects, and slow merge velocity.
+## Execution Steps
 
-## Autonomy Requirements
+1. Estimate changed lines and identify independent work units.
+2. Ask for a chain strategy when none is cached and the budget is exceeded.
+3. Create branches/PRs using the chosen strategy only.
+4. Add Chain Context to each PR without replacing the repo PR template.
+5. Verify each PR independently: CI/tests/docs/manual checks, rollback scope, and clean diff.
+6. Keep tracker PR draft/no-merge until all child PRs are reviewed and integrated.
 
-Each chained PR must function as a complete review unit:
+## Output Contract
 
-- **CI green**: checks pass for the PR branch in its intended base context.
-- **Autonomous scope**: the PR has one clear deliverable outcome.
-- **Reasonable rollback**: reverting this PR does not require reverting unrelated work.
-- **Verification included**: tests, docs, or manual verification cover this unit.
-- **Reviewable alone**: reviewers do not need to read future PRs to understand this one.
+Return the chosen strategy, PR order, current PR boundary, dependency diagram, review budget (`additions + deletions`), verification plan, and any `size:exception` rationale.
 
-If a slice cannot meet these rules, split it differently. A chain is not a dumping ground for partial, unreviewable diffs.
+## References
 
-## Choosing the Chain Strategy
-
-When the workload exceeds 400 lines and chained PRs are needed, **ask the user** before proceeding:
-
-```
-This work exceeds the 400-line review budget. How do you want to split it?
-
-1. Stacked PRs to main
-   Each PR merges to main in order. Fast iteration, fix on the go.
-   Best for: speed-first teams, startups, independent slices.
-
-2. Feature Branch Chain (with tracker)
-   Child PRs review against their immediate parent branch; the tracker branch accumulates the final feature and is the only branch that merges to main.
-   Best for: rollback control, integration testing before main, coordinated releases.
-
-3. size:exception
-   Keep it as a single PR with maintainer approval.
-   Best for: generated code, migrations, vendor diffs where splitting adds noise.
-```
-
-Cache the user's answer for the rest of the session. Do not ask again unless the user changes scope.
-
-This is a **team decision**, not a technical one. Both strategies are valid — they reflect different priorities:
-
-| | Stacked PRs to main | Feature Branch Chain |
-|---|---|---|
-| Speed | Each slice ships immediately | Waits until the chain is complete |
-| Rollback | Revert individual PRs from main | Revert the whole feature branch |
-| Risk | Partial features may land in main | Nothing lands until everything is ready |
-| Fix flow | Fix on the go in main | Fix on the integration branch |
-| Complexity | Simpler — rebase and retarget | Needs tracker PR, parent bases, and diff hygiene |
-| Best for | Startups, fast-moving teams | Teams needing coordination and control |
-
-## Chain Boundaries
-
-Every PR in a chain needs explicit boundaries:
-
-| Boundary | What to document |
-|----------|------------------|
-| Start | The branch, PR, or state this PR builds on |
-| End | The finished unit this PR leaves behind |
-| Before | Prior PRs reviewers can assume already exist |
-| After | Follow-up PRs reviewers should ignore for now |
-| Out of scope | Related work intentionally excluded from this review |
-
-## Tracker PR Requirement
-
-For any chain with more than two PRs, create a draft tracker PR before review starts. The tracker PR is not the review surface. It is the map.
-
-It must include:
-
-- every child PR in merge/review order,
-- current status for each PR,
-- one dependency diagram,
-- explicit instruction not to review the aggregate diff,
-- `size:exception` if the aggregate diff exceeds 400 changed lines,
-- `no-merge` while the chain is incomplete.
-
-## Diagram Requirement
-
-Every child PR must show where it sits in the chain. Mark the current PR with `📍`.
-
-```text
-main
- └── #101 Foundation
-      └── #102 Work-unit commits
-           └── 📍 #103 This PR
-                └── #104 Docs
-                     └── #105 Tracker
-```
-
-Pair the diagram with a status table:
-
-| PR | Scope | Status |
-|----|-------|--------|
-| #101 | Foundation | ✅ Passing |
-| #102 | Work-unit commits | 🟡 Open |
-| #103 | This PR | 📍 Review here |
-| #104 | Docs | ⚪ Pending |
-| #105 | Tracker | 🟡 Draft |
-
-## SDD Integration
-
-When SDD planning produces tasks that may exceed 400 changed lines:
-
-1. Treat the `Review Workload Forecast` as a hard planning signal.
-2. Follow the cached `delivery_strategy` before `sdd-apply` writes code.
-3. Convert suggested work units into PR slices.
-4. Keep each slice autonomous: tests/docs included, CI green, clear rollback.
-5. Do not let one `sdd-apply` batch silently grow into a burnout-sized PR.
-
-## Feature Branch Chain
-
-Use this when the user chooses option 2: the feature branch is the accumulator/tracker/final integration branch, while child PRs are reviewed as focused slices against their immediate parent branch.
-
-The tracker PR is the map, not the review surface:
-
-- tracker PR: `feat/my-feature` -> `main`, draft/no-merge,
-- PR #1: child branch -> feature/tracker branch,
-- PR #2: child branch -> PR #1 branch,
-- PR #3: child branch -> PR #2 branch,
-- final merge: tracker PR -> `main` only after the chain is complete.
-
-```text
-master/main
- └── feat/my-feature              ← tracker/final integration branch
-      ↑
-      │ PR #1 base: feat/my-feature
-      │
-      └── feat/my-feature-01-core
-            ↑
-            │ PR #2 base: feat/my-feature-01-core
-            │
-            └── feat/my-feature-02-shared
-                  ↑
-                  │ PR #3 base: feat/my-feature-02-shared
-                  │
-                  └── feat/my-feature-03-slice
-```
-
-Example review chain:
-
-```text
-#40 tracker:   feat/ui-ownership-refactor -> master
-#41 foundation: ui-ownership-refactor/foundation -> feat/ui-ownership-refactor
-#42 shared:     ui-ownership-refactor/shared -> ui-ownership-refactor/foundation
-#43 feature:    ui-ownership-refactor/<feature> -> ui-ownership-refactor/shared
-```
-
-### Steps
-
-1. Create the feature/tracker branch from `main`.
-2. Open the tracker PR from the feature branch to `main` — mark it draft with `no-merge`.
-3. Create PR #1 from the feature/tracker branch and target it back to that branch.
-4. Create each later child branch from the previous PR branch and target it to that immediate parent branch.
-5. Review each child PR against its immediate parent branch, not against `main` and not against the tracker branch after PR #1.
-6. Keep the tracker branch as the accumulator/final integration branch.
-7. Only merge the tracker PR into `main` after all children are reviewed and integrated.
-
-### Commands
-
-PR #1 targets the feature/tracker branch:
-
-```bash
-git checkout feat/ui-ownership-refactor
-git checkout -b ui-ownership-refactor/foundation
-git push -u origin ui-ownership-refactor/foundation
-
-gh pr create \
-  --base feat/ui-ownership-refactor \
-  --head ui-ownership-refactor/foundation
-```
-
-PR #2 targets PR #1's branch:
-
-```bash
-git checkout ui-ownership-refactor/foundation
-git checkout -b ui-ownership-refactor/shared
-git push -u origin ui-ownership-refactor/shared
-
-gh pr create \
-  --base ui-ownership-refactor/foundation \
-  --head ui-ownership-refactor/shared
-```
-
-PR #3 targets PR #2's branch:
-
-```bash
-git checkout ui-ownership-refactor/shared
-git checkout -b ui-ownership-refactor/orgs
-git push -u origin ui-ownership-refactor/orgs
-
-gh pr create \
-  --base ui-ownership-refactor/shared \
-  --head ui-ownership-refactor/orgs
-```
-
-### Diff Hygiene
-
-The diff is the source of truth. A child PR is correctly based only when GitHub shows the current work unit and not previous PR changes.
-
-- If PR #2 shows PR #1 changes, retarget PR #2 to PR #1's branch or rebase it until the diff is clean.
-- If PR #3 shows PR #1 or PR #2 changes, retarget it to PR #2's branch or rebase it until the diff is clean.
-- Do **not** target `main` from child PRs in Feature Branch Chain.
-- Do **not** target the tracker branch from child PRs after PR #1; that inflates review diffs.
-
-### Common mistakes
-
-If you chose this strategy, no child PR should target `main` — otherwise it bypasses the tracker and lands in `main` before the chain is complete. Later child PRs also should not target the tracker branch, because GitHub will show prior slices again.
-
-```text
-# WRONG — child bypasses tracker
-main ← #101 (base: main) ← #102 ← #103
-
-# WRONG — later children target tracker and show inflated diffs
-main ← tracker (#105)
-         ├── #101 (base: tracker branch)
-         ├── #102 (base: tracker branch)  # shows #101 again
-         └── #103 (base: tracker branch)  # shows #101 and #102 again
-
-# CORRECT — each review targets the immediate parent branch
-main ← tracker (#105)
-         └── #101 (base: tracker branch)
-              └── #102 (base: #101 branch)
-                   └── #103 (base: #102 branch)
-```
-
-### Post-merge Rule
-
-After a parent PR is merged, keep the chain coherent: leave the next PR base as the parent branch if GitHub still shows only the current work unit, or retarget/rebase to the updated accumulator/parent as needed. The diff must stay focused.
-
-### Tracker PR Expectations
-
-The tracker PR is a **chain map**, not the review surface. Keep it draft/no-merge until the child PRs are reviewed and integrated.
-
-- Reviewers should review child PRs against their immediate parent branches, where each slice stays within the 400-line budget.
-- The tracker PR may exceed 400 changed lines because it aggregates the full feature branch by design.
-- If the tracker PR exceeds the budget, request/obtain maintainer-applied `size:exception` and document why the aggregate diff is unavoidable.
-
-## Stacked PRs to Main
-
-Use this when each PR can land in `main` in order.
-
-```text
-main <- PR 1: foundation
-          └── PR 2: feature slice built on PR 1
-                └── PR 3: docs/tests built on PR 2
-```
-
-### Steps
-
-1. Create PR 1 from `main`.
-2. Create PR 2 from PR 1's branch and target it to PR 1's branch.
-3. After PR 1 merges, rebase PR 2 on `main` and retarget it to `main`.
-4. Repeat until the stack is merged.
-
-## Chain Context Section
-
-Insert this extra section into the existing `.github/PULL_REQUEST_TEMPLATE.md` body. Do **not** replace the repository PR template; the linked issue, PR type, summary, changes, test plan, automated checks, and contributor checklist sections are still required.
-
-```markdown
-## Chain Context
-
-| Field | Value |
-|-------|-------|
-| Chain | <feature or stack name> |
-| Tracker PR | <#NNN or "Not needed"> |
-| Position | <N of total> |
-| Base | `<target branch>` |
-| Depends on | <PR/issue/link or "None"> |
-| Follow-up | <next PR or "None"> |
-| Review budget | <changed lines> / 400 |
-| Starts at | <branch, PR, or state this builds on> |
-| Ends with | <standalone result delivered by this PR> |
-
-### Chain Overview
-
-```text
-main
- └── #NNN Previous PR
-      └── 📍 #NNN This PR
-           └── #NNN Next PR
-                └── #NNN Tracker
-```
-
-### Chain Status
-
-| PR | Scope | Status |
-|----|-------|--------|
-| #NNN | <scope> | <status> |
-| #NNN | <scope> | 📍 This PR |
-
-## Scope
-
-- <What this PR includes>
-- <What this PR intentionally excludes>
-
-## Autonomy
-
-- [ ] CI is expected to pass for this PR branch
-- [ ] This PR has one deliverable scope
-- [ ] This PR can be rolled back without unrelated changes
-- [ ] Tests, docs, or manual verification cover this unit
-
-## Review Notes
-
-- Review this PR in isolation.
-- Do not review dependent PR changes here.
-- If this exceeds 400 changed lines, request/obtain maintainer-applied `size:exception` and document the rationale.
-
-## Test Plan
-
-- <command or manual verification>
-```
-
-## Commands
-
-```bash
-# Check PR size before asking for review
-gh pr view <PR_NUMBER> --json additions,deletions,changedFiles,title,url
-
-# Create PR #1 in a Feature Branch Chain
-gh pr create --base feat/my-feature --title "feat(scope): focused slice" --body-file pr-body.md
-
-# Create the next child PR targeting its immediate parent branch
-gh pr create --base feat/my-feature-01-core --title "feat(scope): next focused slice" --body-file pr-body.md
-```
-
-## Reviewer Guidance
-
-- If a PR exceeds 400 changed lines without `size:exception`, ask for a split.
-- Recommend chained PRs when the work must integrate before `main`.
-- Recommend stacked PRs when each slice can merge independently.
-- In Feature Branch Chain, review child PRs against their immediate parent branches and treat a polluted diff as a base/branching bug.
-- Prefer clear dependency notes over clever branch gymnastics.
-- Push for autonomy: green CI, clear rollback, and tests or docs for the unit under review.
-- Protect reviewer energy. If the chain forces reviewers to reconstruct hidden context, ask for clearer boundaries.
+- [references/chaining-details.md](references/chaining-details.md) — strategy diagrams, PR body section, branch commands, and reviewer guidance.

--- a/skills/chained-pr/references/chaining-details.md
+++ b/skills/chained-pr/references/chaining-details.md
@@ -1,0 +1,99 @@
+# Chained PR Details
+
+## Strategy Notes
+
+| | Stacked PRs to main | Feature Branch Chain |
+|---|---|---|
+| Speed | Each slice can ship in order | Full feature waits for tracker merge |
+| Rollback | Revert individual main PRs | Revert/hold the whole feature branch |
+| Risk | Partial behavior may land | Nothing lands until the chain completes |
+| Complexity | Simpler retarget/rebase flow | Requires tracker and strict diff hygiene |
+
+## Feature Branch Chain
+
+Use when the feature branch accumulates the final integration while child PRs are reviewed as focused slices.
+
+```text
+main
+ └── feat/my-feature              ← tracker/final integration branch
+      ↑ PR #1 base: feat/my-feature
+      └── feat/my-feature-01-core
+           ↑ PR #2 base: feat/my-feature-01-core
+           └── feat/my-feature-02-shared
+                ↑ PR #3 base: feat/my-feature-02-shared
+                └── feat/my-feature-03-slice
+```
+
+Steps:
+
+1. Create the feature/tracker branch from `main`.
+2. Open the tracker PR to `main`; mark it draft/no-merge.
+3. Create PR #1 from a child branch and target it to the tracker branch.
+4. Create each later child branch from the previous PR branch and target it to that parent branch.
+5. Merge/integrate children in order; merge the tracker only after the chain is complete.
+
+## Stacked PRs to Main
+
+Use when each slice can land on `main` in order.
+
+```text
+main <- PR 1: foundation
+          └── PR 2: feature slice built on PR 1
+                └── PR 3: docs/tests built on PR 2
+```
+
+After a parent PR merges, rebase/retarget the next PR so GitHub shows only the current slice.
+
+## Chain Context Section
+
+Append this section to the repo PR template; do not replace required issue/checklist sections.
+
+```markdown
+## Chain Context
+
+| Field | Value |
+|-------|-------|
+| Chain | <feature or stack name> |
+| Tracker PR | <#NNN or "Not needed"> |
+| Position | <N of total> |
+| Base | `<target branch>` |
+| Depends on | <PR/issue/link or "None"> |
+| Follow-up | <next PR or "None"> |
+| Review budget | <changed lines> / 400 |
+| Starts at | <branch, PR, or state this builds on> |
+| Ends with | <standalone result delivered by this PR> |
+
+### Chain Overview
+
+```text
+main
+ └── #NNN Previous PR
+      └── 📍 #NNN This PR
+           └── #NNN Next PR
+```
+
+### Scope
+- Includes: <focused unit>
+- Excludes: <deferred work>
+
+### Autonomy
+- [ ] CI is expected to pass for this PR branch
+- [ ] This PR has one deliverable scope
+- [ ] This PR can be rolled back without unrelated changes
+- [ ] Tests, docs, or manual verification cover this unit
+```
+
+## Commands
+
+```bash
+gh pr view <PR_NUMBER> --json additions,deletions,changedFiles,title,url
+gh pr create --base feat/my-feature --title "feat(scope): focused slice" --body-file pr-body.md
+gh pr create --base feat/my-feature-01-core --title "feat(scope): next focused slice" --body-file pr-body.md
+```
+
+## Reviewer Guidance
+
+- Ask for a split when a PR exceeds 400 changed lines without `size:exception`.
+- Recommend Feature Branch Chain when work must integrate before `main`.
+- Recommend stacked PRs when each slice can merge independently.
+- Review child PRs against immediate parent branches; a polluted diff is a branching bug.

--- a/testdata/golden/sdd-antigravity-skill-sdd-init.golden
+++ b/testdata/golden/sdd-antigravity-skill-sdd-init.golden
@@ -1,358 +1,55 @@
 ---
 name: sdd-init
-description: "Initialize SDD context, stack, conventions, tests, and persistence. Trigger: sdd init, iniciar sdd, or openspec init."
+description: "Trigger: sdd init, iniciar sdd, openspec init. Initialize SDD context, testing capabilities, registry, and persistence."
 license: MIT
 metadata:
   author: gentleman-programming
   version: "3.0"
 ---
 
-## Purpose
-
-You are a sub-agent responsible for initializing the Spec-Driven Development (SDD) context in a project. You detect the project stack, conventions, and testing capabilities, then bootstrap the active persistence backend.
-
-You are an EXECUTOR for this phase, not the orchestrator. Do the initialization work yourself. Do NOT launch sub-agents, do NOT call `delegate` or `task`, and do NOT hand execution back unless you hit a real blocker that must be reported upstream.
-
-## Execution and Persistence Contract
-
-- If mode is `engram`:
-  Do NOT create `openspec/` directory.
-
-  **Save project context**:
-  ```
-  mem_save(
-    title: "sdd-init/{project}",
-    topic_key: "sdd-init/{project}",
-    type: "architecture",
-    project: "{project}",
-    capture_prompt: false,
-    content: "{detected project context markdown}"
-  )
-  ```
-  `topic_key` enables upserts — re-running init updates the existing context, not duplicates.
-  Set `capture_prompt: false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
-
-  (See `skills/_shared/engram-convention.md` for full naming conventions.)
-- If mode is `openspec`: Read and follow `skills/_shared/openspec-convention.md`. Run full bootstrap.
-- If mode is `hybrid`: Read and follow BOTH convention files. Run openspec bootstrap AND persist context to Engram.
-- If mode is `none`: Return detected context without writing project files.
-
-## What to Do
-
-### Step 1: Detect Project Context
-
-Read the project to understand:
-- Tech stack (check package.json, go.mod, pyproject.toml, etc.)
-- Existing conventions (linters, test frameworks, CI)
-- Architecture patterns in use
-
-### Step 2: Detect Testing Capabilities
-
-Scan the project for ALL testing infrastructure. This determines what testing modes are available.
-
-```
-Detect testing capabilities:
-├── Test Runner
-│   ├── package.json → devDependencies: vitest, jest, mocha, ava
-│   ├── package.json → scripts.test (what command it runs)
-│   ├── pyproject.toml / pytest.ini / setup.cfg → pytest
-│   ├── go.mod → go test (built-in)
-│   ├── Cargo.toml → cargo test (built-in)
-│   ├── Makefile → make test
-│   └── Result: {framework name, command} or NOT FOUND
-│
-├── Test Layers
-│   ├── Unit: test runner exists → AVAILABLE
-│   ├── Integration:
-│   │   ├── JS/TS: @testing-library/* in dependencies
-│   │   ├── Python: pytest + httpx/requests-mock/factory-boy
-│   │   ├── Go: net/http/httptest (built-in)
-│   │   ├── .NET: xUnit/NUnit + WebApplicationFactory
-│   │   └── Result: AVAILABLE or NOT INSTALLED
-│   ├── E2E:
-│   │   ├── playwright, cypress, selenium in dependencies
-│   │   ├── Python: playwright, selenium
-│   │   ├── Go: chromedp
-│   │   └── Result: AVAILABLE or NOT INSTALLED
-│   └── Each layer → record tool name
-│
-├── Coverage Tool
-│   ├── JS/TS: vitest --coverage, jest --coverage, c8, istanbul/nyc
-│   ├── Python: coverage.py, pytest-cov
-│   ├── Go: go test -cover (built-in)
-│   ├── .NET: coverlet
-│   └── Result: {command} or NOT AVAILABLE
-│
-└── Quality Tools
-    ├── Linter: eslint, pylint, ruff, golangci-lint, clippy
-    ├── Type checker: tsc --noEmit, mypy, pyright, go vet
-    ├── Formatter: prettier, black, gofmt, rustfmt
-    └── Each: {command} or NOT AVAILABLE
-```
-
-### Step 3: Resolve STRICT TDD MODE
-
-Determine whether Strict TDD Mode should be enabled. The resolution follows a priority chain — first match wins:
-
-```
-1. Read from system prompt / agent config (highest priority):
-   ├── Search for "strict-tdd-mode" marker in the agent's system prompt file
-   │   (e.g., CLAUDE.md, GEMINI.md, .cursorrules, etc.)
-   ├── If found and says "enabled" → strict_tdd: true
-   ├── If found and says "disabled" → strict_tdd: false
-   └── This is the preference set by the user in the gentle-ai TUI
-
-2. If no marker found, check openspec config:
-   ├── Read openspec/config.yaml → strict_tdd field
-   └── If found → use that value
-
-3. If nothing found AND test runner was detected in Step 2:
-   ├── Default: strict_tdd: true (enable if the project CAN do TDD)
-   └── This ensures TDD is active even without gentle-ai TUI setup
-
-4. If no test runner detected:
-   ├── strict_tdd: false (cannot enable without test runner)
-   └── Include NOTE in summary: "Strict TDD Mode unavailable — no test runner detected"
-```
-
-**Do NOT ask the user interactively.** The preference is resolved from existing config. If the user wants to change it, they run `gentle-ai sync` with the TUI or set `strict_tdd` in `openspec/config.yaml`.
-
-### Step 4: Initialize Persistence Backend
-
-If mode resolves to `openspec`, create this directory structure:
-
-```
-openspec/
-├── config.yaml              ← Project-specific SDD config
-├── specs/                   ← Source of truth (empty initially)
-└── changes/                 ← Active changes
-    └── archive/             ← Completed changes
-```
-
-### Step 5: Generate Config (openspec mode)
-
-Based on what you detected, create the config when in `openspec` mode:
-
-```yaml
-# openspec/config.yaml
-schema: spec-driven
-
-context: |
-  Tech stack: {detected stack}
-  Architecture: {detected patterns}
-  Testing: {detected test framework}
-  Style: {detected linting/formatting}
-
-strict_tdd: {true/false}
-
-rules:
-  proposal:
-    - Include rollback plan for risky changes
-    - Identify affected modules/packages
-  specs:
-    - Use Given/When/Then format for scenarios
-    - Use RFC 2119 keywords (MUST, SHALL, SHOULD, MAY)
-  design:
-    - Include sequence diagrams for complex flows
-    - Document architecture decisions with rationale
-  tasks:
-    - Group tasks by phase (infrastructure, implementation, testing)
-    - Use hierarchical numbering (1.1, 1.2, etc.)
-    - Keep tasks small enough to complete in one session
-  apply:
-    - Follow existing code patterns and conventions
-    - Load relevant coding skills for the project stack
-  verify:
-    - Run tests if test infrastructure exists
-    - Compare implementation against every spec scenario
-  archive:
-    - Warn before merging destructive deltas (large removals)
-```
-
-### Step 6: Persist Testing Capabilities
-
-**This step is MANDATORY — do NOT skip it.**
-
-Persist detected testing capabilities as a separate Engram observation (or section in config.yaml for openspec). This cache prevents re-detection on every `sdd-apply` and `sdd-verify` run.
-
-If mode is `engram` or `hybrid`:
-```
-mem_save(
-  title: "sdd/{project}/testing-capabilities",
-  topic_key: "sdd/{project}/testing-capabilities",
-  type: "config",
-  project: "{project}",
-  capture_prompt: false,
-  content: "{testing capabilities markdown — see format below}"
-)
-```
-Set `capture_prompt: false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
-
-**Testing Capabilities format**:
-
-```markdown
-## Testing Capabilities
-
-**Strict TDD Mode**: {enabled/disabled}
-**Detected**: {date}
-
-### Test Runner
-- Command: `{command}`
-- Framework: {name}
-
-### Test Layers
-| Layer | Available | Tool |
-|-------|-----------|------|
-| Unit | ✅ / ❌ | {tool or —} |
-| Integration | ✅ / ❌ | {tool or —} |
-| E2E | ✅ / ❌ | {tool or —} |
-
-### Coverage
-- Available: ✅ / ❌
-- Command: `{command or —}`
-
-### Quality Tools
-| Tool | Available | Command |
-|------|-----------|---------|
-| Linter | ✅ / ❌ | {command or —} |
-| Type checker | ✅ / ❌ | {command or —} |
-| Formatter | ✅ / ❌ | {command or —} |
-```
-
-If mode is `openspec` or `hybrid`, also write this as a section in `openspec/config.yaml` under `testing:`.
-
-### Step 7: Build Skill Registry
-
-Follow the same logic as the `skill-registry` skill (`skills/skill-registry/SKILL.md`):
-
-1. Scan user skills: glob `*/SKILL.md` across ALL known skill directories. **User-level**: `~/.claude/skills/`, `~/.config/opencode/skills/`, `~/.gemini/skills/`, `~/.cursor/skills/`, `~/.copilot/skills/`, parent of this skill file. **Project-level**: `.claude/skills/`, `.gemini/skills/`, `.agent/skills/`, `skills/`. Skip `sdd-*`, `_shared`, `skill-registry`. Deduplicate by name (project-level wins). Read frontmatter triggers.
-2. Scan project conventions: check for `agents.md`, `AGENTS.md`, `CLAUDE.md` (project-level), `.cursorrules`, `GEMINI.md`, `copilot-instructions.md` in the project root. If an index file is found (e.g., `agents.md`), READ it and extract all referenced file paths — include both the index and its referenced files in the registry.
-3. **ALWAYS write `.atl/skill-registry.md`** in the project root (create `.atl/` if needed). This file is mode-independent — it's infrastructure, not an SDD artifact.
-4. If engram is available, **ALSO save to engram**: `mem_save(title: "skill-registry", topic_key: "skill-registry", type: "config", project: "{project}", capture_prompt: false, content: "{registry markdown}")`. Set `capture_prompt: false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
-
-See `skills/skill-registry/SKILL.md` for the full registry format and scanning details.
-
-### Step 8: Persist Project Context
-
-**This step is MANDATORY — do NOT skip it.**
-
-If mode is `engram`:
-```
-mem_save(
-  title: "sdd-init/{project}",
-  topic_key: "sdd-init/{project}",
-  type: "architecture",
-  project: "{project}",
-  capture_prompt: false,
-  content: "{your detected project context from Steps 1-7}"
-)
-```
-Set `capture_prompt: false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
-
-If mode is `openspec` or `hybrid`: the config was already written in Step 5.
-
-If mode is `hybrid`: also call `mem_save` as above (write to BOTH backends).
-
-### Step 9: Return Summary
-
-Return a structured summary adapted to the resolved mode:
-
-#### If mode is `engram`:
-
-Persist project context following `skills/_shared/engram-convention.md` with title and topic_key `sdd-init/{project}`.
-
-Return:
-```
-## SDD Initialized
-
-**Project**: {project name}
-**Stack**: {detected stack}
-**Persistence**: engram
-**Strict TDD Mode**: {enabled ✅ / disabled ❌ / unavailable (no test runner)}
-
-### Testing Capabilities
-| Capability | Status |
-|------------|--------|
-| Test Runner | {tool} ✅ / ❌ Not found |
-| Unit Tests | ✅ / ❌ |
-| Integration Tests | {tool} ✅ / ❌ Not installed |
-| E2E Tests | {tool} ✅ / ❌ Not installed |
-| Coverage | ✅ / ❌ |
-| Linter | {tool} ✅ / ❌ |
-| Type Checker | {tool} ✅ / ❌ |
-
-### Context Saved
-Project context persisted to Engram.
-- **Engram ID**: #{observation-id}
-- **Topic key**: sdd-init/{project}
-- **Capabilities ID**: #{capabilities-observation-id}
-- **Capabilities key**: sdd/{project}/testing-capabilities
-
-No project files created.
-
-### ⚠️ Engram Mode Limitations
-Engram mode is ideal for **solo developers** doing fast iteration. Be aware:
-- **No iteration history**: re-running a phase (e.g., `sdd-spec`) overwrites the previous version. Only the latest artifact is retained.
-- **Not shareable**: engram is a local database — team members cannot see your SDD artifacts.
-- **Partial audit trail**: the archive phase saves a summary report, but not the full artifact folder.
-
-For **team projects** or work that needs a full audit trail, consider switching to `openspec` (file-based, git-friendly) or `hybrid` (files + engram recovery).
-
-### Next Steps
-Ready for /sdd-explore <topic> or /sdd-new <change-name>.
-```
-
-#### If mode is `openspec`:
-```
-## SDD Initialized
-
-**Project**: {project name}
-**Stack**: {detected stack}
-**Persistence**: openspec
-**Strict TDD Mode**: {enabled ✅ / disabled ❌ / unavailable (no test runner)}
-
-### Testing Capabilities
-{same table as above}
-
-### Structure Created
-- openspec/config.yaml ← Project config with detected context + testing capabilities
-- openspec/specs/      ← Ready for specifications
-- openspec/changes/    ← Ready for change proposals
-
-### Next Steps
-Ready for /sdd-explore <topic> or /sdd-new <change-name>.
-```
-
-#### If mode is `none`:
-```
-## SDD Initialized
-
-**Project**: {project name}
-**Stack**: {detected stack}
-**Persistence**: none (ephemeral)
-**Strict TDD Mode**: {enabled ✅ / disabled ❌ / unavailable (no test runner)}
-
-### Testing Capabilities
-{same table as above}
-
-### Context Detected
-{summary of detected stack and conventions}
-
-### Recommendation
-Enable `engram` or `openspec` for artifact persistence across sessions. Without persistence, all SDD artifacts will be lost when the conversation ends.
-
-### Next Steps
-Ready for /sdd-explore <topic> or /sdd-new <change-name>.
-```
-
-## Rules
-
-- NEVER create placeholder spec files - specs are created via sdd-spec during a change
-- ALWAYS detect the real tech stack, don't guess
-- NEVER behave like the orchestrator from this phase - execute directly and return results
-- If the project already has an `openspec/` directory, report what exists and ask the orchestrator if it should be updated
-- Keep config.yaml context CONCISE - no more than 10 lines
-- ALWAYS detect testing capabilities — this is not optional
-- ALWAYS persist testing capabilities as a separate observation/section — downstream phases depend on it
-- If Strict TDD Mode is requested but no test runner exists, set strict_tdd: false and explain why
-- Return a structured envelope with: `status`, `executive_summary`, `detailed_report` (optional), `artifacts`, `next_recommended`, and `risks`
+## Activation Contract
+
+Run this phase when the orchestrator/user asks to initialize SDD in a project. You are the phase executor: do the work yourself, do not delegate, and do not behave like the orchestrator.
+
+## Hard Rules
+
+- Detect the real stack, conventions, architecture, testing tools, and persistence mode; never guess.
+- In `engram` mode, do **not** create `openspec/`.
+- In `openspec` mode, follow `../_shared/openspec-convention.md` and write file artifacts.
+- In `hybrid` mode, write both openspec files and Engram observations.
+- Always persist testing capabilities separately as `sdd/{project}/testing-capabilities` or `openspec/config.yaml` `testing:`.
+- Always build `.atl/skill-registry.md`; also save `skill-registry` to Engram when available.
+- Use `capture_prompt: false` for automated SDD/config saves when supported; omit it if the tool schema lacks it.
+- If `openspec/` already exists, report what exists and ask before updating it.
+
+## Decision Gates
+
+| Input | Action |
+|---|---|
+| `mode=engram` | Save context and capabilities to Engram only. |
+| `mode=openspec` | Create/update openspec bootstrap files only. |
+| `mode=hybrid` | Do both Engram and openspec persistence. |
+| `mode=none` | Return detected context only; write no SDD artifacts except registry if required. |
+| strict TDD marker/config found | Use that value. |
+| no marker/config but test runner exists | Default `strict_tdd: true`. |
+| no test runner | Set `strict_tdd: false` and explain unavailable. |
+
+## Execution Steps
+
+1. Inspect project files (`package.json`, `go.mod`, `pyproject.toml`, CI, lint/test config) and summarize stack/conventions.
+2. Detect test runner, test layers, coverage, linter, type checker, and formatter.
+3. Resolve Strict TDD from agent marker, `openspec/config.yaml`, detected runner fallback, or no-runner fallback.
+4. Initialize persistence for the resolved mode.
+5. Build `.atl/skill-registry.md` using the skill-registry scan rules.
+6. Persist testing capabilities and project context.
+7. Return the structured initialization envelope.
+
+## Output Contract
+
+Return `status`, `executive_summary`, `artifacts`, `next_recommended`, and `risks`. Include project, stack, persistence mode, Strict TDD status, testing capability table, saved observation IDs/paths, registry path, and next `/sdd-explore` or `/sdd-new` step.
+
+## References
+
+- [references/init-details.md](references/init-details.md) — detection checklist, Engram payloads, config skeleton, and output templates.
+- `../_shared/engram-convention.md` — Engram artifact naming.
+- `../_shared/openspec-convention.md` — openspec layout and rules.

--- a/testdata/golden/sdd-antigravity-skill-sdd-init.golden
+++ b/testdata/golden/sdd-antigravity-skill-sdd-init.golden
@@ -1,6 +1,8 @@
 ---
 name: sdd-init
 description: "Trigger: sdd init, iniciar sdd, openspec init. Initialize SDD context, testing capabilities, registry, and persistence."
+disable-model-invocation: true
+user-invocable: false
 license: MIT
 metadata:
   author: gentleman-programming

--- a/testdata/golden/sdd-codex-skill-sdd-init.golden
+++ b/testdata/golden/sdd-codex-skill-sdd-init.golden
@@ -1,358 +1,55 @@
 ---
 name: sdd-init
-description: "Initialize SDD context, stack, conventions, tests, and persistence. Trigger: sdd init, iniciar sdd, or openspec init."
+description: "Trigger: sdd init, iniciar sdd, openspec init. Initialize SDD context, testing capabilities, registry, and persistence."
 license: MIT
 metadata:
   author: gentleman-programming
   version: "3.0"
 ---
 
-## Purpose
-
-You are a sub-agent responsible for initializing the Spec-Driven Development (SDD) context in a project. You detect the project stack, conventions, and testing capabilities, then bootstrap the active persistence backend.
-
-You are an EXECUTOR for this phase, not the orchestrator. Do the initialization work yourself. Do NOT launch sub-agents, do NOT call `delegate` or `task`, and do NOT hand execution back unless you hit a real blocker that must be reported upstream.
-
-## Execution and Persistence Contract
-
-- If mode is `engram`:
-  Do NOT create `openspec/` directory.
-
-  **Save project context**:
-  ```
-  mem_save(
-    title: "sdd-init/{project}",
-    topic_key: "sdd-init/{project}",
-    type: "architecture",
-    project: "{project}",
-    capture_prompt: false,
-    content: "{detected project context markdown}"
-  )
-  ```
-  `topic_key` enables upserts — re-running init updates the existing context, not duplicates.
-  Set `capture_prompt: false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
-
-  (See `skills/_shared/engram-convention.md` for full naming conventions.)
-- If mode is `openspec`: Read and follow `skills/_shared/openspec-convention.md`. Run full bootstrap.
-- If mode is `hybrid`: Read and follow BOTH convention files. Run openspec bootstrap AND persist context to Engram.
-- If mode is `none`: Return detected context without writing project files.
-
-## What to Do
-
-### Step 1: Detect Project Context
-
-Read the project to understand:
-- Tech stack (check package.json, go.mod, pyproject.toml, etc.)
-- Existing conventions (linters, test frameworks, CI)
-- Architecture patterns in use
-
-### Step 2: Detect Testing Capabilities
-
-Scan the project for ALL testing infrastructure. This determines what testing modes are available.
-
-```
-Detect testing capabilities:
-├── Test Runner
-│   ├── package.json → devDependencies: vitest, jest, mocha, ava
-│   ├── package.json → scripts.test (what command it runs)
-│   ├── pyproject.toml / pytest.ini / setup.cfg → pytest
-│   ├── go.mod → go test (built-in)
-│   ├── Cargo.toml → cargo test (built-in)
-│   ├── Makefile → make test
-│   └── Result: {framework name, command} or NOT FOUND
-│
-├── Test Layers
-│   ├── Unit: test runner exists → AVAILABLE
-│   ├── Integration:
-│   │   ├── JS/TS: @testing-library/* in dependencies
-│   │   ├── Python: pytest + httpx/requests-mock/factory-boy
-│   │   ├── Go: net/http/httptest (built-in)
-│   │   ├── .NET: xUnit/NUnit + WebApplicationFactory
-│   │   └── Result: AVAILABLE or NOT INSTALLED
-│   ├── E2E:
-│   │   ├── playwright, cypress, selenium in dependencies
-│   │   ├── Python: playwright, selenium
-│   │   ├── Go: chromedp
-│   │   └── Result: AVAILABLE or NOT INSTALLED
-│   └── Each layer → record tool name
-│
-├── Coverage Tool
-│   ├── JS/TS: vitest --coverage, jest --coverage, c8, istanbul/nyc
-│   ├── Python: coverage.py, pytest-cov
-│   ├── Go: go test -cover (built-in)
-│   ├── .NET: coverlet
-│   └── Result: {command} or NOT AVAILABLE
-│
-└── Quality Tools
-    ├── Linter: eslint, pylint, ruff, golangci-lint, clippy
-    ├── Type checker: tsc --noEmit, mypy, pyright, go vet
-    ├── Formatter: prettier, black, gofmt, rustfmt
-    └── Each: {command} or NOT AVAILABLE
-```
-
-### Step 3: Resolve STRICT TDD MODE
-
-Determine whether Strict TDD Mode should be enabled. The resolution follows a priority chain — first match wins:
-
-```
-1. Read from system prompt / agent config (highest priority):
-   ├── Search for "strict-tdd-mode" marker in the agent's system prompt file
-   │   (e.g., CLAUDE.md, GEMINI.md, .cursorrules, etc.)
-   ├── If found and says "enabled" → strict_tdd: true
-   ├── If found and says "disabled" → strict_tdd: false
-   └── This is the preference set by the user in the gentle-ai TUI
-
-2. If no marker found, check openspec config:
-   ├── Read openspec/config.yaml → strict_tdd field
-   └── If found → use that value
-
-3. If nothing found AND test runner was detected in Step 2:
-   ├── Default: strict_tdd: true (enable if the project CAN do TDD)
-   └── This ensures TDD is active even without gentle-ai TUI setup
-
-4. If no test runner detected:
-   ├── strict_tdd: false (cannot enable without test runner)
-   └── Include NOTE in summary: "Strict TDD Mode unavailable — no test runner detected"
-```
-
-**Do NOT ask the user interactively.** The preference is resolved from existing config. If the user wants to change it, they run `gentle-ai sync` with the TUI or set `strict_tdd` in `openspec/config.yaml`.
-
-### Step 4: Initialize Persistence Backend
-
-If mode resolves to `openspec`, create this directory structure:
-
-```
-openspec/
-├── config.yaml              ← Project-specific SDD config
-├── specs/                   ← Source of truth (empty initially)
-└── changes/                 ← Active changes
-    └── archive/             ← Completed changes
-```
-
-### Step 5: Generate Config (openspec mode)
-
-Based on what you detected, create the config when in `openspec` mode:
-
-```yaml
-# openspec/config.yaml
-schema: spec-driven
-
-context: |
-  Tech stack: {detected stack}
-  Architecture: {detected patterns}
-  Testing: {detected test framework}
-  Style: {detected linting/formatting}
-
-strict_tdd: {true/false}
-
-rules:
-  proposal:
-    - Include rollback plan for risky changes
-    - Identify affected modules/packages
-  specs:
-    - Use Given/When/Then format for scenarios
-    - Use RFC 2119 keywords (MUST, SHALL, SHOULD, MAY)
-  design:
-    - Include sequence diagrams for complex flows
-    - Document architecture decisions with rationale
-  tasks:
-    - Group tasks by phase (infrastructure, implementation, testing)
-    - Use hierarchical numbering (1.1, 1.2, etc.)
-    - Keep tasks small enough to complete in one session
-  apply:
-    - Follow existing code patterns and conventions
-    - Load relevant coding skills for the project stack
-  verify:
-    - Run tests if test infrastructure exists
-    - Compare implementation against every spec scenario
-  archive:
-    - Warn before merging destructive deltas (large removals)
-```
-
-### Step 6: Persist Testing Capabilities
-
-**This step is MANDATORY — do NOT skip it.**
-
-Persist detected testing capabilities as a separate Engram observation (or section in config.yaml for openspec). This cache prevents re-detection on every `sdd-apply` and `sdd-verify` run.
-
-If mode is `engram` or `hybrid`:
-```
-mem_save(
-  title: "sdd/{project}/testing-capabilities",
-  topic_key: "sdd/{project}/testing-capabilities",
-  type: "config",
-  project: "{project}",
-  capture_prompt: false,
-  content: "{testing capabilities markdown — see format below}"
-)
-```
-Set `capture_prompt: false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
-
-**Testing Capabilities format**:
-
-```markdown
-## Testing Capabilities
-
-**Strict TDD Mode**: {enabled/disabled}
-**Detected**: {date}
-
-### Test Runner
-- Command: `{command}`
-- Framework: {name}
-
-### Test Layers
-| Layer | Available | Tool |
-|-------|-----------|------|
-| Unit | ✅ / ❌ | {tool or —} |
-| Integration | ✅ / ❌ | {tool or —} |
-| E2E | ✅ / ❌ | {tool or —} |
-
-### Coverage
-- Available: ✅ / ❌
-- Command: `{command or —}`
-
-### Quality Tools
-| Tool | Available | Command |
-|------|-----------|---------|
-| Linter | ✅ / ❌ | {command or —} |
-| Type checker | ✅ / ❌ | {command or —} |
-| Formatter | ✅ / ❌ | {command or —} |
-```
-
-If mode is `openspec` or `hybrid`, also write this as a section in `openspec/config.yaml` under `testing:`.
-
-### Step 7: Build Skill Registry
-
-Follow the same logic as the `skill-registry` skill (`skills/skill-registry/SKILL.md`):
-
-1. Scan user skills: glob `*/SKILL.md` across ALL known skill directories. **User-level**: `~/.claude/skills/`, `~/.config/opencode/skills/`, `~/.gemini/skills/`, `~/.cursor/skills/`, `~/.copilot/skills/`, parent of this skill file. **Project-level**: `.claude/skills/`, `.gemini/skills/`, `.agent/skills/`, `skills/`. Skip `sdd-*`, `_shared`, `skill-registry`. Deduplicate by name (project-level wins). Read frontmatter triggers.
-2. Scan project conventions: check for `agents.md`, `AGENTS.md`, `CLAUDE.md` (project-level), `.cursorrules`, `GEMINI.md`, `copilot-instructions.md` in the project root. If an index file is found (e.g., `agents.md`), READ it and extract all referenced file paths — include both the index and its referenced files in the registry.
-3. **ALWAYS write `.atl/skill-registry.md`** in the project root (create `.atl/` if needed). This file is mode-independent — it's infrastructure, not an SDD artifact.
-4. If engram is available, **ALSO save to engram**: `mem_save(title: "skill-registry", topic_key: "skill-registry", type: "config", project: "{project}", capture_prompt: false, content: "{registry markdown}")`. Set `capture_prompt: false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
-
-See `skills/skill-registry/SKILL.md` for the full registry format and scanning details.
-
-### Step 8: Persist Project Context
-
-**This step is MANDATORY — do NOT skip it.**
-
-If mode is `engram`:
-```
-mem_save(
-  title: "sdd-init/{project}",
-  topic_key: "sdd-init/{project}",
-  type: "architecture",
-  project: "{project}",
-  capture_prompt: false,
-  content: "{your detected project context from Steps 1-7}"
-)
-```
-Set `capture_prompt: false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
-
-If mode is `openspec` or `hybrid`: the config was already written in Step 5.
-
-If mode is `hybrid`: also call `mem_save` as above (write to BOTH backends).
-
-### Step 9: Return Summary
-
-Return a structured summary adapted to the resolved mode:
-
-#### If mode is `engram`:
-
-Persist project context following `skills/_shared/engram-convention.md` with title and topic_key `sdd-init/{project}`.
-
-Return:
-```
-## SDD Initialized
-
-**Project**: {project name}
-**Stack**: {detected stack}
-**Persistence**: engram
-**Strict TDD Mode**: {enabled ✅ / disabled ❌ / unavailable (no test runner)}
-
-### Testing Capabilities
-| Capability | Status |
-|------------|--------|
-| Test Runner | {tool} ✅ / ❌ Not found |
-| Unit Tests | ✅ / ❌ |
-| Integration Tests | {tool} ✅ / ❌ Not installed |
-| E2E Tests | {tool} ✅ / ❌ Not installed |
-| Coverage | ✅ / ❌ |
-| Linter | {tool} ✅ / ❌ |
-| Type Checker | {tool} ✅ / ❌ |
-
-### Context Saved
-Project context persisted to Engram.
-- **Engram ID**: #{observation-id}
-- **Topic key**: sdd-init/{project}
-- **Capabilities ID**: #{capabilities-observation-id}
-- **Capabilities key**: sdd/{project}/testing-capabilities
-
-No project files created.
-
-### ⚠️ Engram Mode Limitations
-Engram mode is ideal for **solo developers** doing fast iteration. Be aware:
-- **No iteration history**: re-running a phase (e.g., `sdd-spec`) overwrites the previous version. Only the latest artifact is retained.
-- **Not shareable**: engram is a local database — team members cannot see your SDD artifacts.
-- **Partial audit trail**: the archive phase saves a summary report, but not the full artifact folder.
-
-For **team projects** or work that needs a full audit trail, consider switching to `openspec` (file-based, git-friendly) or `hybrid` (files + engram recovery).
-
-### Next Steps
-Ready for /sdd-explore <topic> or /sdd-new <change-name>.
-```
-
-#### If mode is `openspec`:
-```
-## SDD Initialized
-
-**Project**: {project name}
-**Stack**: {detected stack}
-**Persistence**: openspec
-**Strict TDD Mode**: {enabled ✅ / disabled ❌ / unavailable (no test runner)}
-
-### Testing Capabilities
-{same table as above}
-
-### Structure Created
-- openspec/config.yaml ← Project config with detected context + testing capabilities
-- openspec/specs/      ← Ready for specifications
-- openspec/changes/    ← Ready for change proposals
-
-### Next Steps
-Ready for /sdd-explore <topic> or /sdd-new <change-name>.
-```
-
-#### If mode is `none`:
-```
-## SDD Initialized
-
-**Project**: {project name}
-**Stack**: {detected stack}
-**Persistence**: none (ephemeral)
-**Strict TDD Mode**: {enabled ✅ / disabled ❌ / unavailable (no test runner)}
-
-### Testing Capabilities
-{same table as above}
-
-### Context Detected
-{summary of detected stack and conventions}
-
-### Recommendation
-Enable `engram` or `openspec` for artifact persistence across sessions. Without persistence, all SDD artifacts will be lost when the conversation ends.
-
-### Next Steps
-Ready for /sdd-explore <topic> or /sdd-new <change-name>.
-```
-
-## Rules
-
-- NEVER create placeholder spec files - specs are created via sdd-spec during a change
-- ALWAYS detect the real tech stack, don't guess
-- NEVER behave like the orchestrator from this phase - execute directly and return results
-- If the project already has an `openspec/` directory, report what exists and ask the orchestrator if it should be updated
-- Keep config.yaml context CONCISE - no more than 10 lines
-- ALWAYS detect testing capabilities — this is not optional
-- ALWAYS persist testing capabilities as a separate observation/section — downstream phases depend on it
-- If Strict TDD Mode is requested but no test runner exists, set strict_tdd: false and explain why
-- Return a structured envelope with: `status`, `executive_summary`, `detailed_report` (optional), `artifacts`, `next_recommended`, and `risks`
+## Activation Contract
+
+Run this phase when the orchestrator/user asks to initialize SDD in a project. You are the phase executor: do the work yourself, do not delegate, and do not behave like the orchestrator.
+
+## Hard Rules
+
+- Detect the real stack, conventions, architecture, testing tools, and persistence mode; never guess.
+- In `engram` mode, do **not** create `openspec/`.
+- In `openspec` mode, follow `../_shared/openspec-convention.md` and write file artifacts.
+- In `hybrid` mode, write both openspec files and Engram observations.
+- Always persist testing capabilities separately as `sdd/{project}/testing-capabilities` or `openspec/config.yaml` `testing:`.
+- Always build `.atl/skill-registry.md`; also save `skill-registry` to Engram when available.
+- Use `capture_prompt: false` for automated SDD/config saves when supported; omit it if the tool schema lacks it.
+- If `openspec/` already exists, report what exists and ask before updating it.
+
+## Decision Gates
+
+| Input | Action |
+|---|---|
+| `mode=engram` | Save context and capabilities to Engram only. |
+| `mode=openspec` | Create/update openspec bootstrap files only. |
+| `mode=hybrid` | Do both Engram and openspec persistence. |
+| `mode=none` | Return detected context only; write no SDD artifacts except registry if required. |
+| strict TDD marker/config found | Use that value. |
+| no marker/config but test runner exists | Default `strict_tdd: true`. |
+| no test runner | Set `strict_tdd: false` and explain unavailable. |
+
+## Execution Steps
+
+1. Inspect project files (`package.json`, `go.mod`, `pyproject.toml`, CI, lint/test config) and summarize stack/conventions.
+2. Detect test runner, test layers, coverage, linter, type checker, and formatter.
+3. Resolve Strict TDD from agent marker, `openspec/config.yaml`, detected runner fallback, or no-runner fallback.
+4. Initialize persistence for the resolved mode.
+5. Build `.atl/skill-registry.md` using the skill-registry scan rules.
+6. Persist testing capabilities and project context.
+7. Return the structured initialization envelope.
+
+## Output Contract
+
+Return `status`, `executive_summary`, `artifacts`, `next_recommended`, and `risks`. Include project, stack, persistence mode, Strict TDD status, testing capability table, saved observation IDs/paths, registry path, and next `/sdd-explore` or `/sdd-new` step.
+
+## References
+
+- [references/init-details.md](references/init-details.md) — detection checklist, Engram payloads, config skeleton, and output templates.
+- `../_shared/engram-convention.md` — Engram artifact naming.
+- `../_shared/openspec-convention.md` — openspec layout and rules.

--- a/testdata/golden/sdd-codex-skill-sdd-init.golden
+++ b/testdata/golden/sdd-codex-skill-sdd-init.golden
@@ -1,6 +1,8 @@
 ---
 name: sdd-init
 description: "Trigger: sdd init, iniciar sdd, openspec init. Initialize SDD context, testing capabilities, registry, and persistence."
+disable-model-invocation: true
+user-invocable: false
 license: MIT
 metadata:
   author: gentleman-programming

--- a/testdata/golden/sdd-cursor-skill-sdd-init.golden
+++ b/testdata/golden/sdd-cursor-skill-sdd-init.golden
@@ -1,358 +1,55 @@
 ---
 name: sdd-init
-description: "Initialize SDD context, stack, conventions, tests, and persistence. Trigger: sdd init, iniciar sdd, or openspec init."
+description: "Trigger: sdd init, iniciar sdd, openspec init. Initialize SDD context, testing capabilities, registry, and persistence."
 license: MIT
 metadata:
   author: gentleman-programming
   version: "3.0"
 ---
 
-## Purpose
-
-You are a sub-agent responsible for initializing the Spec-Driven Development (SDD) context in a project. You detect the project stack, conventions, and testing capabilities, then bootstrap the active persistence backend.
-
-You are an EXECUTOR for this phase, not the orchestrator. Do the initialization work yourself. Do NOT launch sub-agents, do NOT call `delegate` or `task`, and do NOT hand execution back unless you hit a real blocker that must be reported upstream.
-
-## Execution and Persistence Contract
-
-- If mode is `engram`:
-  Do NOT create `openspec/` directory.
-
-  **Save project context**:
-  ```
-  mem_save(
-    title: "sdd-init/{project}",
-    topic_key: "sdd-init/{project}",
-    type: "architecture",
-    project: "{project}",
-    capture_prompt: false,
-    content: "{detected project context markdown}"
-  )
-  ```
-  `topic_key` enables upserts — re-running init updates the existing context, not duplicates.
-  Set `capture_prompt: false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
-
-  (See `skills/_shared/engram-convention.md` for full naming conventions.)
-- If mode is `openspec`: Read and follow `skills/_shared/openspec-convention.md`. Run full bootstrap.
-- If mode is `hybrid`: Read and follow BOTH convention files. Run openspec bootstrap AND persist context to Engram.
-- If mode is `none`: Return detected context without writing project files.
-
-## What to Do
-
-### Step 1: Detect Project Context
-
-Read the project to understand:
-- Tech stack (check package.json, go.mod, pyproject.toml, etc.)
-- Existing conventions (linters, test frameworks, CI)
-- Architecture patterns in use
-
-### Step 2: Detect Testing Capabilities
-
-Scan the project for ALL testing infrastructure. This determines what testing modes are available.
-
-```
-Detect testing capabilities:
-├── Test Runner
-│   ├── package.json → devDependencies: vitest, jest, mocha, ava
-│   ├── package.json → scripts.test (what command it runs)
-│   ├── pyproject.toml / pytest.ini / setup.cfg → pytest
-│   ├── go.mod → go test (built-in)
-│   ├── Cargo.toml → cargo test (built-in)
-│   ├── Makefile → make test
-│   └── Result: {framework name, command} or NOT FOUND
-│
-├── Test Layers
-│   ├── Unit: test runner exists → AVAILABLE
-│   ├── Integration:
-│   │   ├── JS/TS: @testing-library/* in dependencies
-│   │   ├── Python: pytest + httpx/requests-mock/factory-boy
-│   │   ├── Go: net/http/httptest (built-in)
-│   │   ├── .NET: xUnit/NUnit + WebApplicationFactory
-│   │   └── Result: AVAILABLE or NOT INSTALLED
-│   ├── E2E:
-│   │   ├── playwright, cypress, selenium in dependencies
-│   │   ├── Python: playwright, selenium
-│   │   ├── Go: chromedp
-│   │   └── Result: AVAILABLE or NOT INSTALLED
-│   └── Each layer → record tool name
-│
-├── Coverage Tool
-│   ├── JS/TS: vitest --coverage, jest --coverage, c8, istanbul/nyc
-│   ├── Python: coverage.py, pytest-cov
-│   ├── Go: go test -cover (built-in)
-│   ├── .NET: coverlet
-│   └── Result: {command} or NOT AVAILABLE
-│
-└── Quality Tools
-    ├── Linter: eslint, pylint, ruff, golangci-lint, clippy
-    ├── Type checker: tsc --noEmit, mypy, pyright, go vet
-    ├── Formatter: prettier, black, gofmt, rustfmt
-    └── Each: {command} or NOT AVAILABLE
-```
-
-### Step 3: Resolve STRICT TDD MODE
-
-Determine whether Strict TDD Mode should be enabled. The resolution follows a priority chain — first match wins:
-
-```
-1. Read from system prompt / agent config (highest priority):
-   ├── Search for "strict-tdd-mode" marker in the agent's system prompt file
-   │   (e.g., CLAUDE.md, GEMINI.md, .cursorrules, etc.)
-   ├── If found and says "enabled" → strict_tdd: true
-   ├── If found and says "disabled" → strict_tdd: false
-   └── This is the preference set by the user in the gentle-ai TUI
-
-2. If no marker found, check openspec config:
-   ├── Read openspec/config.yaml → strict_tdd field
-   └── If found → use that value
-
-3. If nothing found AND test runner was detected in Step 2:
-   ├── Default: strict_tdd: true (enable if the project CAN do TDD)
-   └── This ensures TDD is active even without gentle-ai TUI setup
-
-4. If no test runner detected:
-   ├── strict_tdd: false (cannot enable without test runner)
-   └── Include NOTE in summary: "Strict TDD Mode unavailable — no test runner detected"
-```
-
-**Do NOT ask the user interactively.** The preference is resolved from existing config. If the user wants to change it, they run `gentle-ai sync` with the TUI or set `strict_tdd` in `openspec/config.yaml`.
-
-### Step 4: Initialize Persistence Backend
-
-If mode resolves to `openspec`, create this directory structure:
-
-```
-openspec/
-├── config.yaml              ← Project-specific SDD config
-├── specs/                   ← Source of truth (empty initially)
-└── changes/                 ← Active changes
-    └── archive/             ← Completed changes
-```
-
-### Step 5: Generate Config (openspec mode)
-
-Based on what you detected, create the config when in `openspec` mode:
-
-```yaml
-# openspec/config.yaml
-schema: spec-driven
-
-context: |
-  Tech stack: {detected stack}
-  Architecture: {detected patterns}
-  Testing: {detected test framework}
-  Style: {detected linting/formatting}
-
-strict_tdd: {true/false}
-
-rules:
-  proposal:
-    - Include rollback plan for risky changes
-    - Identify affected modules/packages
-  specs:
-    - Use Given/When/Then format for scenarios
-    - Use RFC 2119 keywords (MUST, SHALL, SHOULD, MAY)
-  design:
-    - Include sequence diagrams for complex flows
-    - Document architecture decisions with rationale
-  tasks:
-    - Group tasks by phase (infrastructure, implementation, testing)
-    - Use hierarchical numbering (1.1, 1.2, etc.)
-    - Keep tasks small enough to complete in one session
-  apply:
-    - Follow existing code patterns and conventions
-    - Load relevant coding skills for the project stack
-  verify:
-    - Run tests if test infrastructure exists
-    - Compare implementation against every spec scenario
-  archive:
-    - Warn before merging destructive deltas (large removals)
-```
-
-### Step 6: Persist Testing Capabilities
-
-**This step is MANDATORY — do NOT skip it.**
-
-Persist detected testing capabilities as a separate Engram observation (or section in config.yaml for openspec). This cache prevents re-detection on every `sdd-apply` and `sdd-verify` run.
-
-If mode is `engram` or `hybrid`:
-```
-mem_save(
-  title: "sdd/{project}/testing-capabilities",
-  topic_key: "sdd/{project}/testing-capabilities",
-  type: "config",
-  project: "{project}",
-  capture_prompt: false,
-  content: "{testing capabilities markdown — see format below}"
-)
-```
-Set `capture_prompt: false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
-
-**Testing Capabilities format**:
-
-```markdown
-## Testing Capabilities
-
-**Strict TDD Mode**: {enabled/disabled}
-**Detected**: {date}
-
-### Test Runner
-- Command: `{command}`
-- Framework: {name}
-
-### Test Layers
-| Layer | Available | Tool |
-|-------|-----------|------|
-| Unit | ✅ / ❌ | {tool or —} |
-| Integration | ✅ / ❌ | {tool or —} |
-| E2E | ✅ / ❌ | {tool or —} |
-
-### Coverage
-- Available: ✅ / ❌
-- Command: `{command or —}`
-
-### Quality Tools
-| Tool | Available | Command |
-|------|-----------|---------|
-| Linter | ✅ / ❌ | {command or —} |
-| Type checker | ✅ / ❌ | {command or —} |
-| Formatter | ✅ / ❌ | {command or —} |
-```
-
-If mode is `openspec` or `hybrid`, also write this as a section in `openspec/config.yaml` under `testing:`.
-
-### Step 7: Build Skill Registry
-
-Follow the same logic as the `skill-registry` skill (`skills/skill-registry/SKILL.md`):
-
-1. Scan user skills: glob `*/SKILL.md` across ALL known skill directories. **User-level**: `~/.claude/skills/`, `~/.config/opencode/skills/`, `~/.gemini/skills/`, `~/.cursor/skills/`, `~/.copilot/skills/`, parent of this skill file. **Project-level**: `.claude/skills/`, `.gemini/skills/`, `.agent/skills/`, `skills/`. Skip `sdd-*`, `_shared`, `skill-registry`. Deduplicate by name (project-level wins). Read frontmatter triggers.
-2. Scan project conventions: check for `agents.md`, `AGENTS.md`, `CLAUDE.md` (project-level), `.cursorrules`, `GEMINI.md`, `copilot-instructions.md` in the project root. If an index file is found (e.g., `agents.md`), READ it and extract all referenced file paths — include both the index and its referenced files in the registry.
-3. **ALWAYS write `.atl/skill-registry.md`** in the project root (create `.atl/` if needed). This file is mode-independent — it's infrastructure, not an SDD artifact.
-4. If engram is available, **ALSO save to engram**: `mem_save(title: "skill-registry", topic_key: "skill-registry", type: "config", project: "{project}", capture_prompt: false, content: "{registry markdown}")`. Set `capture_prompt: false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
-
-See `skills/skill-registry/SKILL.md` for the full registry format and scanning details.
-
-### Step 8: Persist Project Context
-
-**This step is MANDATORY — do NOT skip it.**
-
-If mode is `engram`:
-```
-mem_save(
-  title: "sdd-init/{project}",
-  topic_key: "sdd-init/{project}",
-  type: "architecture",
-  project: "{project}",
-  capture_prompt: false,
-  content: "{your detected project context from Steps 1-7}"
-)
-```
-Set `capture_prompt: false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
-
-If mode is `openspec` or `hybrid`: the config was already written in Step 5.
-
-If mode is `hybrid`: also call `mem_save` as above (write to BOTH backends).
-
-### Step 9: Return Summary
-
-Return a structured summary adapted to the resolved mode:
-
-#### If mode is `engram`:
-
-Persist project context following `skills/_shared/engram-convention.md` with title and topic_key `sdd-init/{project}`.
-
-Return:
-```
-## SDD Initialized
-
-**Project**: {project name}
-**Stack**: {detected stack}
-**Persistence**: engram
-**Strict TDD Mode**: {enabled ✅ / disabled ❌ / unavailable (no test runner)}
-
-### Testing Capabilities
-| Capability | Status |
-|------------|--------|
-| Test Runner | {tool} ✅ / ❌ Not found |
-| Unit Tests | ✅ / ❌ |
-| Integration Tests | {tool} ✅ / ❌ Not installed |
-| E2E Tests | {tool} ✅ / ❌ Not installed |
-| Coverage | ✅ / ❌ |
-| Linter | {tool} ✅ / ❌ |
-| Type Checker | {tool} ✅ / ❌ |
-
-### Context Saved
-Project context persisted to Engram.
-- **Engram ID**: #{observation-id}
-- **Topic key**: sdd-init/{project}
-- **Capabilities ID**: #{capabilities-observation-id}
-- **Capabilities key**: sdd/{project}/testing-capabilities
-
-No project files created.
-
-### ⚠️ Engram Mode Limitations
-Engram mode is ideal for **solo developers** doing fast iteration. Be aware:
-- **No iteration history**: re-running a phase (e.g., `sdd-spec`) overwrites the previous version. Only the latest artifact is retained.
-- **Not shareable**: engram is a local database — team members cannot see your SDD artifacts.
-- **Partial audit trail**: the archive phase saves a summary report, but not the full artifact folder.
-
-For **team projects** or work that needs a full audit trail, consider switching to `openspec` (file-based, git-friendly) or `hybrid` (files + engram recovery).
-
-### Next Steps
-Ready for /sdd-explore <topic> or /sdd-new <change-name>.
-```
-
-#### If mode is `openspec`:
-```
-## SDD Initialized
-
-**Project**: {project name}
-**Stack**: {detected stack}
-**Persistence**: openspec
-**Strict TDD Mode**: {enabled ✅ / disabled ❌ / unavailable (no test runner)}
-
-### Testing Capabilities
-{same table as above}
-
-### Structure Created
-- openspec/config.yaml ← Project config with detected context + testing capabilities
-- openspec/specs/      ← Ready for specifications
-- openspec/changes/    ← Ready for change proposals
-
-### Next Steps
-Ready for /sdd-explore <topic> or /sdd-new <change-name>.
-```
-
-#### If mode is `none`:
-```
-## SDD Initialized
-
-**Project**: {project name}
-**Stack**: {detected stack}
-**Persistence**: none (ephemeral)
-**Strict TDD Mode**: {enabled ✅ / disabled ❌ / unavailable (no test runner)}
-
-### Testing Capabilities
-{same table as above}
-
-### Context Detected
-{summary of detected stack and conventions}
-
-### Recommendation
-Enable `engram` or `openspec` for artifact persistence across sessions. Without persistence, all SDD artifacts will be lost when the conversation ends.
-
-### Next Steps
-Ready for /sdd-explore <topic> or /sdd-new <change-name>.
-```
-
-## Rules
-
-- NEVER create placeholder spec files - specs are created via sdd-spec during a change
-- ALWAYS detect the real tech stack, don't guess
-- NEVER behave like the orchestrator from this phase - execute directly and return results
-- If the project already has an `openspec/` directory, report what exists and ask the orchestrator if it should be updated
-- Keep config.yaml context CONCISE - no more than 10 lines
-- ALWAYS detect testing capabilities — this is not optional
-- ALWAYS persist testing capabilities as a separate observation/section — downstream phases depend on it
-- If Strict TDD Mode is requested but no test runner exists, set strict_tdd: false and explain why
-- Return a structured envelope with: `status`, `executive_summary`, `detailed_report` (optional), `artifacts`, `next_recommended`, and `risks`
+## Activation Contract
+
+Run this phase when the orchestrator/user asks to initialize SDD in a project. You are the phase executor: do the work yourself, do not delegate, and do not behave like the orchestrator.
+
+## Hard Rules
+
+- Detect the real stack, conventions, architecture, testing tools, and persistence mode; never guess.
+- In `engram` mode, do **not** create `openspec/`.
+- In `openspec` mode, follow `../_shared/openspec-convention.md` and write file artifacts.
+- In `hybrid` mode, write both openspec files and Engram observations.
+- Always persist testing capabilities separately as `sdd/{project}/testing-capabilities` or `openspec/config.yaml` `testing:`.
+- Always build `.atl/skill-registry.md`; also save `skill-registry` to Engram when available.
+- Use `capture_prompt: false` for automated SDD/config saves when supported; omit it if the tool schema lacks it.
+- If `openspec/` already exists, report what exists and ask before updating it.
+
+## Decision Gates
+
+| Input | Action |
+|---|---|
+| `mode=engram` | Save context and capabilities to Engram only. |
+| `mode=openspec` | Create/update openspec bootstrap files only. |
+| `mode=hybrid` | Do both Engram and openspec persistence. |
+| `mode=none` | Return detected context only; write no SDD artifacts except registry if required. |
+| strict TDD marker/config found | Use that value. |
+| no marker/config but test runner exists | Default `strict_tdd: true`. |
+| no test runner | Set `strict_tdd: false` and explain unavailable. |
+
+## Execution Steps
+
+1. Inspect project files (`package.json`, `go.mod`, `pyproject.toml`, CI, lint/test config) and summarize stack/conventions.
+2. Detect test runner, test layers, coverage, linter, type checker, and formatter.
+3. Resolve Strict TDD from agent marker, `openspec/config.yaml`, detected runner fallback, or no-runner fallback.
+4. Initialize persistence for the resolved mode.
+5. Build `.atl/skill-registry.md` using the skill-registry scan rules.
+6. Persist testing capabilities and project context.
+7. Return the structured initialization envelope.
+
+## Output Contract
+
+Return `status`, `executive_summary`, `artifacts`, `next_recommended`, and `risks`. Include project, stack, persistence mode, Strict TDD status, testing capability table, saved observation IDs/paths, registry path, and next `/sdd-explore` or `/sdd-new` step.
+
+## References
+
+- [references/init-details.md](references/init-details.md) — detection checklist, Engram payloads, config skeleton, and output templates.
+- `../_shared/engram-convention.md` — Engram artifact naming.
+- `../_shared/openspec-convention.md` — openspec layout and rules.

--- a/testdata/golden/sdd-cursor-skill-sdd-init.golden
+++ b/testdata/golden/sdd-cursor-skill-sdd-init.golden
@@ -1,6 +1,8 @@
 ---
 name: sdd-init
 description: "Trigger: sdd init, iniciar sdd, openspec init. Initialize SDD context, testing capabilities, registry, and persistence."
+disable-model-invocation: true
+user-invocable: false
 license: MIT
 metadata:
   author: gentleman-programming

--- a/testdata/golden/sdd-gemini-skill-sdd-init.golden
+++ b/testdata/golden/sdd-gemini-skill-sdd-init.golden
@@ -1,358 +1,55 @@
 ---
 name: sdd-init
-description: "Initialize SDD context, stack, conventions, tests, and persistence. Trigger: sdd init, iniciar sdd, or openspec init."
+description: "Trigger: sdd init, iniciar sdd, openspec init. Initialize SDD context, testing capabilities, registry, and persistence."
 license: MIT
 metadata:
   author: gentleman-programming
   version: "3.0"
 ---
 
-## Purpose
-
-You are a sub-agent responsible for initializing the Spec-Driven Development (SDD) context in a project. You detect the project stack, conventions, and testing capabilities, then bootstrap the active persistence backend.
-
-You are an EXECUTOR for this phase, not the orchestrator. Do the initialization work yourself. Do NOT launch sub-agents, do NOT call `delegate` or `task`, and do NOT hand execution back unless you hit a real blocker that must be reported upstream.
-
-## Execution and Persistence Contract
-
-- If mode is `engram`:
-  Do NOT create `openspec/` directory.
-
-  **Save project context**:
-  ```
-  mem_save(
-    title: "sdd-init/{project}",
-    topic_key: "sdd-init/{project}",
-    type: "architecture",
-    project: "{project}",
-    capture_prompt: false,
-    content: "{detected project context markdown}"
-  )
-  ```
-  `topic_key` enables upserts — re-running init updates the existing context, not duplicates.
-  Set `capture_prompt: false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
-
-  (See `skills/_shared/engram-convention.md` for full naming conventions.)
-- If mode is `openspec`: Read and follow `skills/_shared/openspec-convention.md`. Run full bootstrap.
-- If mode is `hybrid`: Read and follow BOTH convention files. Run openspec bootstrap AND persist context to Engram.
-- If mode is `none`: Return detected context without writing project files.
-
-## What to Do
-
-### Step 1: Detect Project Context
-
-Read the project to understand:
-- Tech stack (check package.json, go.mod, pyproject.toml, etc.)
-- Existing conventions (linters, test frameworks, CI)
-- Architecture patterns in use
-
-### Step 2: Detect Testing Capabilities
-
-Scan the project for ALL testing infrastructure. This determines what testing modes are available.
-
-```
-Detect testing capabilities:
-├── Test Runner
-│   ├── package.json → devDependencies: vitest, jest, mocha, ava
-│   ├── package.json → scripts.test (what command it runs)
-│   ├── pyproject.toml / pytest.ini / setup.cfg → pytest
-│   ├── go.mod → go test (built-in)
-│   ├── Cargo.toml → cargo test (built-in)
-│   ├── Makefile → make test
-│   └── Result: {framework name, command} or NOT FOUND
-│
-├── Test Layers
-│   ├── Unit: test runner exists → AVAILABLE
-│   ├── Integration:
-│   │   ├── JS/TS: @testing-library/* in dependencies
-│   │   ├── Python: pytest + httpx/requests-mock/factory-boy
-│   │   ├── Go: net/http/httptest (built-in)
-│   │   ├── .NET: xUnit/NUnit + WebApplicationFactory
-│   │   └── Result: AVAILABLE or NOT INSTALLED
-│   ├── E2E:
-│   │   ├── playwright, cypress, selenium in dependencies
-│   │   ├── Python: playwright, selenium
-│   │   ├── Go: chromedp
-│   │   └── Result: AVAILABLE or NOT INSTALLED
-│   └── Each layer → record tool name
-│
-├── Coverage Tool
-│   ├── JS/TS: vitest --coverage, jest --coverage, c8, istanbul/nyc
-│   ├── Python: coverage.py, pytest-cov
-│   ├── Go: go test -cover (built-in)
-│   ├── .NET: coverlet
-│   └── Result: {command} or NOT AVAILABLE
-│
-└── Quality Tools
-    ├── Linter: eslint, pylint, ruff, golangci-lint, clippy
-    ├── Type checker: tsc --noEmit, mypy, pyright, go vet
-    ├── Formatter: prettier, black, gofmt, rustfmt
-    └── Each: {command} or NOT AVAILABLE
-```
-
-### Step 3: Resolve STRICT TDD MODE
-
-Determine whether Strict TDD Mode should be enabled. The resolution follows a priority chain — first match wins:
-
-```
-1. Read from system prompt / agent config (highest priority):
-   ├── Search for "strict-tdd-mode" marker in the agent's system prompt file
-   │   (e.g., CLAUDE.md, GEMINI.md, .cursorrules, etc.)
-   ├── If found and says "enabled" → strict_tdd: true
-   ├── If found and says "disabled" → strict_tdd: false
-   └── This is the preference set by the user in the gentle-ai TUI
-
-2. If no marker found, check openspec config:
-   ├── Read openspec/config.yaml → strict_tdd field
-   └── If found → use that value
-
-3. If nothing found AND test runner was detected in Step 2:
-   ├── Default: strict_tdd: true (enable if the project CAN do TDD)
-   └── This ensures TDD is active even without gentle-ai TUI setup
-
-4. If no test runner detected:
-   ├── strict_tdd: false (cannot enable without test runner)
-   └── Include NOTE in summary: "Strict TDD Mode unavailable — no test runner detected"
-```
-
-**Do NOT ask the user interactively.** The preference is resolved from existing config. If the user wants to change it, they run `gentle-ai sync` with the TUI or set `strict_tdd` in `openspec/config.yaml`.
-
-### Step 4: Initialize Persistence Backend
-
-If mode resolves to `openspec`, create this directory structure:
-
-```
-openspec/
-├── config.yaml              ← Project-specific SDD config
-├── specs/                   ← Source of truth (empty initially)
-└── changes/                 ← Active changes
-    └── archive/             ← Completed changes
-```
-
-### Step 5: Generate Config (openspec mode)
-
-Based on what you detected, create the config when in `openspec` mode:
-
-```yaml
-# openspec/config.yaml
-schema: spec-driven
-
-context: |
-  Tech stack: {detected stack}
-  Architecture: {detected patterns}
-  Testing: {detected test framework}
-  Style: {detected linting/formatting}
-
-strict_tdd: {true/false}
-
-rules:
-  proposal:
-    - Include rollback plan for risky changes
-    - Identify affected modules/packages
-  specs:
-    - Use Given/When/Then format for scenarios
-    - Use RFC 2119 keywords (MUST, SHALL, SHOULD, MAY)
-  design:
-    - Include sequence diagrams for complex flows
-    - Document architecture decisions with rationale
-  tasks:
-    - Group tasks by phase (infrastructure, implementation, testing)
-    - Use hierarchical numbering (1.1, 1.2, etc.)
-    - Keep tasks small enough to complete in one session
-  apply:
-    - Follow existing code patterns and conventions
-    - Load relevant coding skills for the project stack
-  verify:
-    - Run tests if test infrastructure exists
-    - Compare implementation against every spec scenario
-  archive:
-    - Warn before merging destructive deltas (large removals)
-```
-
-### Step 6: Persist Testing Capabilities
-
-**This step is MANDATORY — do NOT skip it.**
-
-Persist detected testing capabilities as a separate Engram observation (or section in config.yaml for openspec). This cache prevents re-detection on every `sdd-apply` and `sdd-verify` run.
-
-If mode is `engram` or `hybrid`:
-```
-mem_save(
-  title: "sdd/{project}/testing-capabilities",
-  topic_key: "sdd/{project}/testing-capabilities",
-  type: "config",
-  project: "{project}",
-  capture_prompt: false,
-  content: "{testing capabilities markdown — see format below}"
-)
-```
-Set `capture_prompt: false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
-
-**Testing Capabilities format**:
-
-```markdown
-## Testing Capabilities
-
-**Strict TDD Mode**: {enabled/disabled}
-**Detected**: {date}
-
-### Test Runner
-- Command: `{command}`
-- Framework: {name}
-
-### Test Layers
-| Layer | Available | Tool |
-|-------|-----------|------|
-| Unit | ✅ / ❌ | {tool or —} |
-| Integration | ✅ / ❌ | {tool or —} |
-| E2E | ✅ / ❌ | {tool or —} |
-
-### Coverage
-- Available: ✅ / ❌
-- Command: `{command or —}`
-
-### Quality Tools
-| Tool | Available | Command |
-|------|-----------|---------|
-| Linter | ✅ / ❌ | {command or —} |
-| Type checker | ✅ / ❌ | {command or —} |
-| Formatter | ✅ / ❌ | {command or —} |
-```
-
-If mode is `openspec` or `hybrid`, also write this as a section in `openspec/config.yaml` under `testing:`.
-
-### Step 7: Build Skill Registry
-
-Follow the same logic as the `skill-registry` skill (`skills/skill-registry/SKILL.md`):
-
-1. Scan user skills: glob `*/SKILL.md` across ALL known skill directories. **User-level**: `~/.claude/skills/`, `~/.config/opencode/skills/`, `~/.gemini/skills/`, `~/.cursor/skills/`, `~/.copilot/skills/`, parent of this skill file. **Project-level**: `.claude/skills/`, `.gemini/skills/`, `.agent/skills/`, `skills/`. Skip `sdd-*`, `_shared`, `skill-registry`. Deduplicate by name (project-level wins). Read frontmatter triggers.
-2. Scan project conventions: check for `agents.md`, `AGENTS.md`, `CLAUDE.md` (project-level), `.cursorrules`, `GEMINI.md`, `copilot-instructions.md` in the project root. If an index file is found (e.g., `agents.md`), READ it and extract all referenced file paths — include both the index and its referenced files in the registry.
-3. **ALWAYS write `.atl/skill-registry.md`** in the project root (create `.atl/` if needed). This file is mode-independent — it's infrastructure, not an SDD artifact.
-4. If engram is available, **ALSO save to engram**: `mem_save(title: "skill-registry", topic_key: "skill-registry", type: "config", project: "{project}", capture_prompt: false, content: "{registry markdown}")`. Set `capture_prompt: false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
-
-See `skills/skill-registry/SKILL.md` for the full registry format and scanning details.
-
-### Step 8: Persist Project Context
-
-**This step is MANDATORY — do NOT skip it.**
-
-If mode is `engram`:
-```
-mem_save(
-  title: "sdd-init/{project}",
-  topic_key: "sdd-init/{project}",
-  type: "architecture",
-  project: "{project}",
-  capture_prompt: false,
-  content: "{your detected project context from Steps 1-7}"
-)
-```
-Set `capture_prompt: false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
-
-If mode is `openspec` or `hybrid`: the config was already written in Step 5.
-
-If mode is `hybrid`: also call `mem_save` as above (write to BOTH backends).
-
-### Step 9: Return Summary
-
-Return a structured summary adapted to the resolved mode:
-
-#### If mode is `engram`:
-
-Persist project context following `skills/_shared/engram-convention.md` with title and topic_key `sdd-init/{project}`.
-
-Return:
-```
-## SDD Initialized
-
-**Project**: {project name}
-**Stack**: {detected stack}
-**Persistence**: engram
-**Strict TDD Mode**: {enabled ✅ / disabled ❌ / unavailable (no test runner)}
-
-### Testing Capabilities
-| Capability | Status |
-|------------|--------|
-| Test Runner | {tool} ✅ / ❌ Not found |
-| Unit Tests | ✅ / ❌ |
-| Integration Tests | {tool} ✅ / ❌ Not installed |
-| E2E Tests | {tool} ✅ / ❌ Not installed |
-| Coverage | ✅ / ❌ |
-| Linter | {tool} ✅ / ❌ |
-| Type Checker | {tool} ✅ / ❌ |
-
-### Context Saved
-Project context persisted to Engram.
-- **Engram ID**: #{observation-id}
-- **Topic key**: sdd-init/{project}
-- **Capabilities ID**: #{capabilities-observation-id}
-- **Capabilities key**: sdd/{project}/testing-capabilities
-
-No project files created.
-
-### ⚠️ Engram Mode Limitations
-Engram mode is ideal for **solo developers** doing fast iteration. Be aware:
-- **No iteration history**: re-running a phase (e.g., `sdd-spec`) overwrites the previous version. Only the latest artifact is retained.
-- **Not shareable**: engram is a local database — team members cannot see your SDD artifacts.
-- **Partial audit trail**: the archive phase saves a summary report, but not the full artifact folder.
-
-For **team projects** or work that needs a full audit trail, consider switching to `openspec` (file-based, git-friendly) or `hybrid` (files + engram recovery).
-
-### Next Steps
-Ready for /sdd-explore <topic> or /sdd-new <change-name>.
-```
-
-#### If mode is `openspec`:
-```
-## SDD Initialized
-
-**Project**: {project name}
-**Stack**: {detected stack}
-**Persistence**: openspec
-**Strict TDD Mode**: {enabled ✅ / disabled ❌ / unavailable (no test runner)}
-
-### Testing Capabilities
-{same table as above}
-
-### Structure Created
-- openspec/config.yaml ← Project config with detected context + testing capabilities
-- openspec/specs/      ← Ready for specifications
-- openspec/changes/    ← Ready for change proposals
-
-### Next Steps
-Ready for /sdd-explore <topic> or /sdd-new <change-name>.
-```
-
-#### If mode is `none`:
-```
-## SDD Initialized
-
-**Project**: {project name}
-**Stack**: {detected stack}
-**Persistence**: none (ephemeral)
-**Strict TDD Mode**: {enabled ✅ / disabled ❌ / unavailable (no test runner)}
-
-### Testing Capabilities
-{same table as above}
-
-### Context Detected
-{summary of detected stack and conventions}
-
-### Recommendation
-Enable `engram` or `openspec` for artifact persistence across sessions. Without persistence, all SDD artifacts will be lost when the conversation ends.
-
-### Next Steps
-Ready for /sdd-explore <topic> or /sdd-new <change-name>.
-```
-
-## Rules
-
-- NEVER create placeholder spec files - specs are created via sdd-spec during a change
-- ALWAYS detect the real tech stack, don't guess
-- NEVER behave like the orchestrator from this phase - execute directly and return results
-- If the project already has an `openspec/` directory, report what exists and ask the orchestrator if it should be updated
-- Keep config.yaml context CONCISE - no more than 10 lines
-- ALWAYS detect testing capabilities — this is not optional
-- ALWAYS persist testing capabilities as a separate observation/section — downstream phases depend on it
-- If Strict TDD Mode is requested but no test runner exists, set strict_tdd: false and explain why
-- Return a structured envelope with: `status`, `executive_summary`, `detailed_report` (optional), `artifacts`, `next_recommended`, and `risks`
+## Activation Contract
+
+Run this phase when the orchestrator/user asks to initialize SDD in a project. You are the phase executor: do the work yourself, do not delegate, and do not behave like the orchestrator.
+
+## Hard Rules
+
+- Detect the real stack, conventions, architecture, testing tools, and persistence mode; never guess.
+- In `engram` mode, do **not** create `openspec/`.
+- In `openspec` mode, follow `../_shared/openspec-convention.md` and write file artifacts.
+- In `hybrid` mode, write both openspec files and Engram observations.
+- Always persist testing capabilities separately as `sdd/{project}/testing-capabilities` or `openspec/config.yaml` `testing:`.
+- Always build `.atl/skill-registry.md`; also save `skill-registry` to Engram when available.
+- Use `capture_prompt: false` for automated SDD/config saves when supported; omit it if the tool schema lacks it.
+- If `openspec/` already exists, report what exists and ask before updating it.
+
+## Decision Gates
+
+| Input | Action |
+|---|---|
+| `mode=engram` | Save context and capabilities to Engram only. |
+| `mode=openspec` | Create/update openspec bootstrap files only. |
+| `mode=hybrid` | Do both Engram and openspec persistence. |
+| `mode=none` | Return detected context only; write no SDD artifacts except registry if required. |
+| strict TDD marker/config found | Use that value. |
+| no marker/config but test runner exists | Default `strict_tdd: true`. |
+| no test runner | Set `strict_tdd: false` and explain unavailable. |
+
+## Execution Steps
+
+1. Inspect project files (`package.json`, `go.mod`, `pyproject.toml`, CI, lint/test config) and summarize stack/conventions.
+2. Detect test runner, test layers, coverage, linter, type checker, and formatter.
+3. Resolve Strict TDD from agent marker, `openspec/config.yaml`, detected runner fallback, or no-runner fallback.
+4. Initialize persistence for the resolved mode.
+5. Build `.atl/skill-registry.md` using the skill-registry scan rules.
+6. Persist testing capabilities and project context.
+7. Return the structured initialization envelope.
+
+## Output Contract
+
+Return `status`, `executive_summary`, `artifacts`, `next_recommended`, and `risks`. Include project, stack, persistence mode, Strict TDD status, testing capability table, saved observation IDs/paths, registry path, and next `/sdd-explore` or `/sdd-new` step.
+
+## References
+
+- [references/init-details.md](references/init-details.md) — detection checklist, Engram payloads, config skeleton, and output templates.
+- `../_shared/engram-convention.md` — Engram artifact naming.
+- `../_shared/openspec-convention.md` — openspec layout and rules.

--- a/testdata/golden/sdd-gemini-skill-sdd-init.golden
+++ b/testdata/golden/sdd-gemini-skill-sdd-init.golden
@@ -1,6 +1,8 @@
 ---
 name: sdd-init
 description: "Trigger: sdd init, iniciar sdd, openspec init. Initialize SDD context, testing capabilities, registry, and persistence."
+disable-model-invocation: true
+user-invocable: false
 license: MIT
 metadata:
   author: gentleman-programming

--- a/testdata/golden/sdd-kiro-skill-sdd-init.golden
+++ b/testdata/golden/sdd-kiro-skill-sdd-init.golden
@@ -1,358 +1,55 @@
 ---
 name: sdd-init
-description: "Initialize SDD context, stack, conventions, tests, and persistence. Trigger: sdd init, iniciar sdd, or openspec init."
+description: "Trigger: sdd init, iniciar sdd, openspec init. Initialize SDD context, testing capabilities, registry, and persistence."
 license: MIT
 metadata:
   author: gentleman-programming
   version: "3.0"
 ---
 
-## Purpose
-
-You are a sub-agent responsible for initializing the Spec-Driven Development (SDD) context in a project. You detect the project stack, conventions, and testing capabilities, then bootstrap the active persistence backend.
-
-You are an EXECUTOR for this phase, not the orchestrator. Do the initialization work yourself. Do NOT launch sub-agents, do NOT call `delegate` or `task`, and do NOT hand execution back unless you hit a real blocker that must be reported upstream.
-
-## Execution and Persistence Contract
-
-- If mode is `engram`:
-  Do NOT create `openspec/` directory.
-
-  **Save project context**:
-  ```
-  mem_save(
-    title: "sdd-init/{project}",
-    topic_key: "sdd-init/{project}",
-    type: "architecture",
-    project: "{project}",
-    capture_prompt: false,
-    content: "{detected project context markdown}"
-  )
-  ```
-  `topic_key` enables upserts — re-running init updates the existing context, not duplicates.
-  Set `capture_prompt: false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
-
-  (See `skills/_shared/engram-convention.md` for full naming conventions.)
-- If mode is `openspec`: Read and follow `skills/_shared/openspec-convention.md`. Run full bootstrap.
-- If mode is `hybrid`: Read and follow BOTH convention files. Run openspec bootstrap AND persist context to Engram.
-- If mode is `none`: Return detected context without writing project files.
-
-## What to Do
-
-### Step 1: Detect Project Context
-
-Read the project to understand:
-- Tech stack (check package.json, go.mod, pyproject.toml, etc.)
-- Existing conventions (linters, test frameworks, CI)
-- Architecture patterns in use
-
-### Step 2: Detect Testing Capabilities
-
-Scan the project for ALL testing infrastructure. This determines what testing modes are available.
-
-```
-Detect testing capabilities:
-├── Test Runner
-│   ├── package.json → devDependencies: vitest, jest, mocha, ava
-│   ├── package.json → scripts.test (what command it runs)
-│   ├── pyproject.toml / pytest.ini / setup.cfg → pytest
-│   ├── go.mod → go test (built-in)
-│   ├── Cargo.toml → cargo test (built-in)
-│   ├── Makefile → make test
-│   └── Result: {framework name, command} or NOT FOUND
-│
-├── Test Layers
-│   ├── Unit: test runner exists → AVAILABLE
-│   ├── Integration:
-│   │   ├── JS/TS: @testing-library/* in dependencies
-│   │   ├── Python: pytest + httpx/requests-mock/factory-boy
-│   │   ├── Go: net/http/httptest (built-in)
-│   │   ├── .NET: xUnit/NUnit + WebApplicationFactory
-│   │   └── Result: AVAILABLE or NOT INSTALLED
-│   ├── E2E:
-│   │   ├── playwright, cypress, selenium in dependencies
-│   │   ├── Python: playwright, selenium
-│   │   ├── Go: chromedp
-│   │   └── Result: AVAILABLE or NOT INSTALLED
-│   └── Each layer → record tool name
-│
-├── Coverage Tool
-│   ├── JS/TS: vitest --coverage, jest --coverage, c8, istanbul/nyc
-│   ├── Python: coverage.py, pytest-cov
-│   ├── Go: go test -cover (built-in)
-│   ├── .NET: coverlet
-│   └── Result: {command} or NOT AVAILABLE
-│
-└── Quality Tools
-    ├── Linter: eslint, pylint, ruff, golangci-lint, clippy
-    ├── Type checker: tsc --noEmit, mypy, pyright, go vet
-    ├── Formatter: prettier, black, gofmt, rustfmt
-    └── Each: {command} or NOT AVAILABLE
-```
-
-### Step 3: Resolve STRICT TDD MODE
-
-Determine whether Strict TDD Mode should be enabled. The resolution follows a priority chain — first match wins:
-
-```
-1. Read from system prompt / agent config (highest priority):
-   ├── Search for "strict-tdd-mode" marker in the agent's system prompt file
-   │   (e.g., CLAUDE.md, GEMINI.md, .cursorrules, etc.)
-   ├── If found and says "enabled" → strict_tdd: true
-   ├── If found and says "disabled" → strict_tdd: false
-   └── This is the preference set by the user in the gentle-ai TUI
-
-2. If no marker found, check openspec config:
-   ├── Read openspec/config.yaml → strict_tdd field
-   └── If found → use that value
-
-3. If nothing found AND test runner was detected in Step 2:
-   ├── Default: strict_tdd: true (enable if the project CAN do TDD)
-   └── This ensures TDD is active even without gentle-ai TUI setup
-
-4. If no test runner detected:
-   ├── strict_tdd: false (cannot enable without test runner)
-   └── Include NOTE in summary: "Strict TDD Mode unavailable — no test runner detected"
-```
-
-**Do NOT ask the user interactively.** The preference is resolved from existing config. If the user wants to change it, they run `gentle-ai sync` with the TUI or set `strict_tdd` in `openspec/config.yaml`.
-
-### Step 4: Initialize Persistence Backend
-
-If mode resolves to `openspec`, create this directory structure:
-
-```
-openspec/
-├── config.yaml              ← Project-specific SDD config
-├── specs/                   ← Source of truth (empty initially)
-└── changes/                 ← Active changes
-    └── archive/             ← Completed changes
-```
-
-### Step 5: Generate Config (openspec mode)
-
-Based on what you detected, create the config when in `openspec` mode:
-
-```yaml
-# openspec/config.yaml
-schema: spec-driven
-
-context: |
-  Tech stack: {detected stack}
-  Architecture: {detected patterns}
-  Testing: {detected test framework}
-  Style: {detected linting/formatting}
-
-strict_tdd: {true/false}
-
-rules:
-  proposal:
-    - Include rollback plan for risky changes
-    - Identify affected modules/packages
-  specs:
-    - Use Given/When/Then format for scenarios
-    - Use RFC 2119 keywords (MUST, SHALL, SHOULD, MAY)
-  design:
-    - Include sequence diagrams for complex flows
-    - Document architecture decisions with rationale
-  tasks:
-    - Group tasks by phase (infrastructure, implementation, testing)
-    - Use hierarchical numbering (1.1, 1.2, etc.)
-    - Keep tasks small enough to complete in one session
-  apply:
-    - Follow existing code patterns and conventions
-    - Load relevant coding skills for the project stack
-  verify:
-    - Run tests if test infrastructure exists
-    - Compare implementation against every spec scenario
-  archive:
-    - Warn before merging destructive deltas (large removals)
-```
-
-### Step 6: Persist Testing Capabilities
-
-**This step is MANDATORY — do NOT skip it.**
-
-Persist detected testing capabilities as a separate Engram observation (or section in config.yaml for openspec). This cache prevents re-detection on every `sdd-apply` and `sdd-verify` run.
-
-If mode is `engram` or `hybrid`:
-```
-mem_save(
-  title: "sdd/{project}/testing-capabilities",
-  topic_key: "sdd/{project}/testing-capabilities",
-  type: "config",
-  project: "{project}",
-  capture_prompt: false,
-  content: "{testing capabilities markdown — see format below}"
-)
-```
-Set `capture_prompt: false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
-
-**Testing Capabilities format**:
-
-```markdown
-## Testing Capabilities
-
-**Strict TDD Mode**: {enabled/disabled}
-**Detected**: {date}
-
-### Test Runner
-- Command: `{command}`
-- Framework: {name}
-
-### Test Layers
-| Layer | Available | Tool |
-|-------|-----------|------|
-| Unit | ✅ / ❌ | {tool or —} |
-| Integration | ✅ / ❌ | {tool or —} |
-| E2E | ✅ / ❌ | {tool or —} |
-
-### Coverage
-- Available: ✅ / ❌
-- Command: `{command or —}`
-
-### Quality Tools
-| Tool | Available | Command |
-|------|-----------|---------|
-| Linter | ✅ / ❌ | {command or —} |
-| Type checker | ✅ / ❌ | {command or —} |
-| Formatter | ✅ / ❌ | {command or —} |
-```
-
-If mode is `openspec` or `hybrid`, also write this as a section in `openspec/config.yaml` under `testing:`.
-
-### Step 7: Build Skill Registry
-
-Follow the same logic as the `skill-registry` skill (`skills/skill-registry/SKILL.md`):
-
-1. Scan user skills: glob `*/SKILL.md` across ALL known skill directories. **User-level**: `~/.claude/skills/`, `~/.config/opencode/skills/`, `~/.gemini/skills/`, `~/.cursor/skills/`, `~/.copilot/skills/`, parent of this skill file. **Project-level**: `.claude/skills/`, `.gemini/skills/`, `.agent/skills/`, `skills/`. Skip `sdd-*`, `_shared`, `skill-registry`. Deduplicate by name (project-level wins). Read frontmatter triggers.
-2. Scan project conventions: check for `agents.md`, `AGENTS.md`, `CLAUDE.md` (project-level), `.cursorrules`, `GEMINI.md`, `copilot-instructions.md` in the project root. If an index file is found (e.g., `agents.md`), READ it and extract all referenced file paths — include both the index and its referenced files in the registry.
-3. **ALWAYS write `.atl/skill-registry.md`** in the project root (create `.atl/` if needed). This file is mode-independent — it's infrastructure, not an SDD artifact.
-4. If engram is available, **ALSO save to engram**: `mem_save(title: "skill-registry", topic_key: "skill-registry", type: "config", project: "{project}", capture_prompt: false, content: "{registry markdown}")`. Set `capture_prompt: false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
-
-See `skills/skill-registry/SKILL.md` for the full registry format and scanning details.
-
-### Step 8: Persist Project Context
-
-**This step is MANDATORY — do NOT skip it.**
-
-If mode is `engram`:
-```
-mem_save(
-  title: "sdd-init/{project}",
-  topic_key: "sdd-init/{project}",
-  type: "architecture",
-  project: "{project}",
-  capture_prompt: false,
-  content: "{your detected project context from Steps 1-7}"
-)
-```
-Set `capture_prompt: false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
-
-If mode is `openspec` or `hybrid`: the config was already written in Step 5.
-
-If mode is `hybrid`: also call `mem_save` as above (write to BOTH backends).
-
-### Step 9: Return Summary
-
-Return a structured summary adapted to the resolved mode:
-
-#### If mode is `engram`:
-
-Persist project context following `skills/_shared/engram-convention.md` with title and topic_key `sdd-init/{project}`.
-
-Return:
-```
-## SDD Initialized
-
-**Project**: {project name}
-**Stack**: {detected stack}
-**Persistence**: engram
-**Strict TDD Mode**: {enabled ✅ / disabled ❌ / unavailable (no test runner)}
-
-### Testing Capabilities
-| Capability | Status |
-|------------|--------|
-| Test Runner | {tool} ✅ / ❌ Not found |
-| Unit Tests | ✅ / ❌ |
-| Integration Tests | {tool} ✅ / ❌ Not installed |
-| E2E Tests | {tool} ✅ / ❌ Not installed |
-| Coverage | ✅ / ❌ |
-| Linter | {tool} ✅ / ❌ |
-| Type Checker | {tool} ✅ / ❌ |
-
-### Context Saved
-Project context persisted to Engram.
-- **Engram ID**: #{observation-id}
-- **Topic key**: sdd-init/{project}
-- **Capabilities ID**: #{capabilities-observation-id}
-- **Capabilities key**: sdd/{project}/testing-capabilities
-
-No project files created.
-
-### ⚠️ Engram Mode Limitations
-Engram mode is ideal for **solo developers** doing fast iteration. Be aware:
-- **No iteration history**: re-running a phase (e.g., `sdd-spec`) overwrites the previous version. Only the latest artifact is retained.
-- **Not shareable**: engram is a local database — team members cannot see your SDD artifacts.
-- **Partial audit trail**: the archive phase saves a summary report, but not the full artifact folder.
-
-For **team projects** or work that needs a full audit trail, consider switching to `openspec` (file-based, git-friendly) or `hybrid` (files + engram recovery).
-
-### Next Steps
-Ready for /sdd-explore <topic> or /sdd-new <change-name>.
-```
-
-#### If mode is `openspec`:
-```
-## SDD Initialized
-
-**Project**: {project name}
-**Stack**: {detected stack}
-**Persistence**: openspec
-**Strict TDD Mode**: {enabled ✅ / disabled ❌ / unavailable (no test runner)}
-
-### Testing Capabilities
-{same table as above}
-
-### Structure Created
-- openspec/config.yaml ← Project config with detected context + testing capabilities
-- openspec/specs/      ← Ready for specifications
-- openspec/changes/    ← Ready for change proposals
-
-### Next Steps
-Ready for /sdd-explore <topic> or /sdd-new <change-name>.
-```
-
-#### If mode is `none`:
-```
-## SDD Initialized
-
-**Project**: {project name}
-**Stack**: {detected stack}
-**Persistence**: none (ephemeral)
-**Strict TDD Mode**: {enabled ✅ / disabled ❌ / unavailable (no test runner)}
-
-### Testing Capabilities
-{same table as above}
-
-### Context Detected
-{summary of detected stack and conventions}
-
-### Recommendation
-Enable `engram` or `openspec` for artifact persistence across sessions. Without persistence, all SDD artifacts will be lost when the conversation ends.
-
-### Next Steps
-Ready for /sdd-explore <topic> or /sdd-new <change-name>.
-```
-
-## Rules
-
-- NEVER create placeholder spec files - specs are created via sdd-spec during a change
-- ALWAYS detect the real tech stack, don't guess
-- NEVER behave like the orchestrator from this phase - execute directly and return results
-- If the project already has an `openspec/` directory, report what exists and ask the orchestrator if it should be updated
-- Keep config.yaml context CONCISE - no more than 10 lines
-- ALWAYS detect testing capabilities — this is not optional
-- ALWAYS persist testing capabilities as a separate observation/section — downstream phases depend on it
-- If Strict TDD Mode is requested but no test runner exists, set strict_tdd: false and explain why
-- Return a structured envelope with: `status`, `executive_summary`, `detailed_report` (optional), `artifacts`, `next_recommended`, and `risks`
+## Activation Contract
+
+Run this phase when the orchestrator/user asks to initialize SDD in a project. You are the phase executor: do the work yourself, do not delegate, and do not behave like the orchestrator.
+
+## Hard Rules
+
+- Detect the real stack, conventions, architecture, testing tools, and persistence mode; never guess.
+- In `engram` mode, do **not** create `openspec/`.
+- In `openspec` mode, follow `../_shared/openspec-convention.md` and write file artifacts.
+- In `hybrid` mode, write both openspec files and Engram observations.
+- Always persist testing capabilities separately as `sdd/{project}/testing-capabilities` or `openspec/config.yaml` `testing:`.
+- Always build `.atl/skill-registry.md`; also save `skill-registry` to Engram when available.
+- Use `capture_prompt: false` for automated SDD/config saves when supported; omit it if the tool schema lacks it.
+- If `openspec/` already exists, report what exists and ask before updating it.
+
+## Decision Gates
+
+| Input | Action |
+|---|---|
+| `mode=engram` | Save context and capabilities to Engram only. |
+| `mode=openspec` | Create/update openspec bootstrap files only. |
+| `mode=hybrid` | Do both Engram and openspec persistence. |
+| `mode=none` | Return detected context only; write no SDD artifacts except registry if required. |
+| strict TDD marker/config found | Use that value. |
+| no marker/config but test runner exists | Default `strict_tdd: true`. |
+| no test runner | Set `strict_tdd: false` and explain unavailable. |
+
+## Execution Steps
+
+1. Inspect project files (`package.json`, `go.mod`, `pyproject.toml`, CI, lint/test config) and summarize stack/conventions.
+2. Detect test runner, test layers, coverage, linter, type checker, and formatter.
+3. Resolve Strict TDD from agent marker, `openspec/config.yaml`, detected runner fallback, or no-runner fallback.
+4. Initialize persistence for the resolved mode.
+5. Build `.atl/skill-registry.md` using the skill-registry scan rules.
+6. Persist testing capabilities and project context.
+7. Return the structured initialization envelope.
+
+## Output Contract
+
+Return `status`, `executive_summary`, `artifacts`, `next_recommended`, and `risks`. Include project, stack, persistence mode, Strict TDD status, testing capability table, saved observation IDs/paths, registry path, and next `/sdd-explore` or `/sdd-new` step.
+
+## References
+
+- [references/init-details.md](references/init-details.md) — detection checklist, Engram payloads, config skeleton, and output templates.
+- `../_shared/engram-convention.md` — Engram artifact naming.
+- `../_shared/openspec-convention.md` — openspec layout and rules.

--- a/testdata/golden/sdd-kiro-skill-sdd-init.golden
+++ b/testdata/golden/sdd-kiro-skill-sdd-init.golden
@@ -1,6 +1,8 @@
 ---
 name: sdd-init
 description: "Trigger: sdd init, iniciar sdd, openspec init. Initialize SDD context, testing capabilities, registry, and persistence."
+disable-model-invocation: true
+user-invocable: false
 license: MIT
 metadata:
   author: gentleman-programming

--- a/testdata/golden/sdd-opencode-skill-sdd-init.golden
+++ b/testdata/golden/sdd-opencode-skill-sdd-init.golden
@@ -1,358 +1,55 @@
 ---
 name: sdd-init
-description: "Initialize SDD context, stack, conventions, tests, and persistence. Trigger: sdd init, iniciar sdd, or openspec init."
+description: "Trigger: sdd init, iniciar sdd, openspec init. Initialize SDD context, testing capabilities, registry, and persistence."
 license: MIT
 metadata:
   author: gentleman-programming
   version: "3.0"
 ---
 
-## Purpose
-
-You are a sub-agent responsible for initializing the Spec-Driven Development (SDD) context in a project. You detect the project stack, conventions, and testing capabilities, then bootstrap the active persistence backend.
-
-You are an EXECUTOR for this phase, not the orchestrator. Do the initialization work yourself. Do NOT launch sub-agents, do NOT call `delegate` or `task`, and do NOT hand execution back unless you hit a real blocker that must be reported upstream.
-
-## Execution and Persistence Contract
-
-- If mode is `engram`:
-  Do NOT create `openspec/` directory.
-
-  **Save project context**:
-  ```
-  mem_save(
-    title: "sdd-init/{project}",
-    topic_key: "sdd-init/{project}",
-    type: "architecture",
-    project: "{project}",
-    capture_prompt: false,
-    content: "{detected project context markdown}"
-  )
-  ```
-  `topic_key` enables upserts — re-running init updates the existing context, not duplicates.
-  Set `capture_prompt: false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
-
-  (See `skills/_shared/engram-convention.md` for full naming conventions.)
-- If mode is `openspec`: Read and follow `skills/_shared/openspec-convention.md`. Run full bootstrap.
-- If mode is `hybrid`: Read and follow BOTH convention files. Run openspec bootstrap AND persist context to Engram.
-- If mode is `none`: Return detected context without writing project files.
-
-## What to Do
-
-### Step 1: Detect Project Context
-
-Read the project to understand:
-- Tech stack (check package.json, go.mod, pyproject.toml, etc.)
-- Existing conventions (linters, test frameworks, CI)
-- Architecture patterns in use
-
-### Step 2: Detect Testing Capabilities
-
-Scan the project for ALL testing infrastructure. This determines what testing modes are available.
-
-```
-Detect testing capabilities:
-├── Test Runner
-│   ├── package.json → devDependencies: vitest, jest, mocha, ava
-│   ├── package.json → scripts.test (what command it runs)
-│   ├── pyproject.toml / pytest.ini / setup.cfg → pytest
-│   ├── go.mod → go test (built-in)
-│   ├── Cargo.toml → cargo test (built-in)
-│   ├── Makefile → make test
-│   └── Result: {framework name, command} or NOT FOUND
-│
-├── Test Layers
-│   ├── Unit: test runner exists → AVAILABLE
-│   ├── Integration:
-│   │   ├── JS/TS: @testing-library/* in dependencies
-│   │   ├── Python: pytest + httpx/requests-mock/factory-boy
-│   │   ├── Go: net/http/httptest (built-in)
-│   │   ├── .NET: xUnit/NUnit + WebApplicationFactory
-│   │   └── Result: AVAILABLE or NOT INSTALLED
-│   ├── E2E:
-│   │   ├── playwright, cypress, selenium in dependencies
-│   │   ├── Python: playwright, selenium
-│   │   ├── Go: chromedp
-│   │   └── Result: AVAILABLE or NOT INSTALLED
-│   └── Each layer → record tool name
-│
-├── Coverage Tool
-│   ├── JS/TS: vitest --coverage, jest --coverage, c8, istanbul/nyc
-│   ├── Python: coverage.py, pytest-cov
-│   ├── Go: go test -cover (built-in)
-│   ├── .NET: coverlet
-│   └── Result: {command} or NOT AVAILABLE
-│
-└── Quality Tools
-    ├── Linter: eslint, pylint, ruff, golangci-lint, clippy
-    ├── Type checker: tsc --noEmit, mypy, pyright, go vet
-    ├── Formatter: prettier, black, gofmt, rustfmt
-    └── Each: {command} or NOT AVAILABLE
-```
-
-### Step 3: Resolve STRICT TDD MODE
-
-Determine whether Strict TDD Mode should be enabled. The resolution follows a priority chain — first match wins:
-
-```
-1. Read from system prompt / agent config (highest priority):
-   ├── Search for "strict-tdd-mode" marker in the agent's system prompt file
-   │   (e.g., CLAUDE.md, GEMINI.md, .cursorrules, etc.)
-   ├── If found and says "enabled" → strict_tdd: true
-   ├── If found and says "disabled" → strict_tdd: false
-   └── This is the preference set by the user in the gentle-ai TUI
-
-2. If no marker found, check openspec config:
-   ├── Read openspec/config.yaml → strict_tdd field
-   └── If found → use that value
-
-3. If nothing found AND test runner was detected in Step 2:
-   ├── Default: strict_tdd: true (enable if the project CAN do TDD)
-   └── This ensures TDD is active even without gentle-ai TUI setup
-
-4. If no test runner detected:
-   ├── strict_tdd: false (cannot enable without test runner)
-   └── Include NOTE in summary: "Strict TDD Mode unavailable — no test runner detected"
-```
-
-**Do NOT ask the user interactively.** The preference is resolved from existing config. If the user wants to change it, they run `gentle-ai sync` with the TUI or set `strict_tdd` in `openspec/config.yaml`.
-
-### Step 4: Initialize Persistence Backend
-
-If mode resolves to `openspec`, create this directory structure:
-
-```
-openspec/
-├── config.yaml              ← Project-specific SDD config
-├── specs/                   ← Source of truth (empty initially)
-└── changes/                 ← Active changes
-    └── archive/             ← Completed changes
-```
-
-### Step 5: Generate Config (openspec mode)
-
-Based on what you detected, create the config when in `openspec` mode:
-
-```yaml
-# openspec/config.yaml
-schema: spec-driven
-
-context: |
-  Tech stack: {detected stack}
-  Architecture: {detected patterns}
-  Testing: {detected test framework}
-  Style: {detected linting/formatting}
-
-strict_tdd: {true/false}
-
-rules:
-  proposal:
-    - Include rollback plan for risky changes
-    - Identify affected modules/packages
-  specs:
-    - Use Given/When/Then format for scenarios
-    - Use RFC 2119 keywords (MUST, SHALL, SHOULD, MAY)
-  design:
-    - Include sequence diagrams for complex flows
-    - Document architecture decisions with rationale
-  tasks:
-    - Group tasks by phase (infrastructure, implementation, testing)
-    - Use hierarchical numbering (1.1, 1.2, etc.)
-    - Keep tasks small enough to complete in one session
-  apply:
-    - Follow existing code patterns and conventions
-    - Load relevant coding skills for the project stack
-  verify:
-    - Run tests if test infrastructure exists
-    - Compare implementation against every spec scenario
-  archive:
-    - Warn before merging destructive deltas (large removals)
-```
-
-### Step 6: Persist Testing Capabilities
-
-**This step is MANDATORY — do NOT skip it.**
-
-Persist detected testing capabilities as a separate Engram observation (or section in config.yaml for openspec). This cache prevents re-detection on every `sdd-apply` and `sdd-verify` run.
-
-If mode is `engram` or `hybrid`:
-```
-mem_save(
-  title: "sdd/{project}/testing-capabilities",
-  topic_key: "sdd/{project}/testing-capabilities",
-  type: "config",
-  project: "{project}",
-  capture_prompt: false,
-  content: "{testing capabilities markdown — see format below}"
-)
-```
-Set `capture_prompt: false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
-
-**Testing Capabilities format**:
-
-```markdown
-## Testing Capabilities
-
-**Strict TDD Mode**: {enabled/disabled}
-**Detected**: {date}
-
-### Test Runner
-- Command: `{command}`
-- Framework: {name}
-
-### Test Layers
-| Layer | Available | Tool |
-|-------|-----------|------|
-| Unit | ✅ / ❌ | {tool or —} |
-| Integration | ✅ / ❌ | {tool or —} |
-| E2E | ✅ / ❌ | {tool or —} |
-
-### Coverage
-- Available: ✅ / ❌
-- Command: `{command or —}`
-
-### Quality Tools
-| Tool | Available | Command |
-|------|-----------|---------|
-| Linter | ✅ / ❌ | {command or —} |
-| Type checker | ✅ / ❌ | {command or —} |
-| Formatter | ✅ / ❌ | {command or —} |
-```
-
-If mode is `openspec` or `hybrid`, also write this as a section in `openspec/config.yaml` under `testing:`.
-
-### Step 7: Build Skill Registry
-
-Follow the same logic as the `skill-registry` skill (`skills/skill-registry/SKILL.md`):
-
-1. Scan user skills: glob `*/SKILL.md` across ALL known skill directories. **User-level**: `~/.claude/skills/`, `~/.config/opencode/skills/`, `~/.gemini/skills/`, `~/.cursor/skills/`, `~/.copilot/skills/`, parent of this skill file. **Project-level**: `.claude/skills/`, `.gemini/skills/`, `.agent/skills/`, `skills/`. Skip `sdd-*`, `_shared`, `skill-registry`. Deduplicate by name (project-level wins). Read frontmatter triggers.
-2. Scan project conventions: check for `agents.md`, `AGENTS.md`, `CLAUDE.md` (project-level), `.cursorrules`, `GEMINI.md`, `copilot-instructions.md` in the project root. If an index file is found (e.g., `agents.md`), READ it and extract all referenced file paths — include both the index and its referenced files in the registry.
-3. **ALWAYS write `.atl/skill-registry.md`** in the project root (create `.atl/` if needed). This file is mode-independent — it's infrastructure, not an SDD artifact.
-4. If engram is available, **ALSO save to engram**: `mem_save(title: "skill-registry", topic_key: "skill-registry", type: "config", project: "{project}", capture_prompt: false, content: "{registry markdown}")`. Set `capture_prompt: false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
-
-See `skills/skill-registry/SKILL.md` for the full registry format and scanning details.
-
-### Step 8: Persist Project Context
-
-**This step is MANDATORY — do NOT skip it.**
-
-If mode is `engram`:
-```
-mem_save(
-  title: "sdd-init/{project}",
-  topic_key: "sdd-init/{project}",
-  type: "architecture",
-  project: "{project}",
-  capture_prompt: false,
-  content: "{your detected project context from Steps 1-7}"
-)
-```
-Set `capture_prompt: false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
-
-If mode is `openspec` or `hybrid`: the config was already written in Step 5.
-
-If mode is `hybrid`: also call `mem_save` as above (write to BOTH backends).
-
-### Step 9: Return Summary
-
-Return a structured summary adapted to the resolved mode:
-
-#### If mode is `engram`:
-
-Persist project context following `skills/_shared/engram-convention.md` with title and topic_key `sdd-init/{project}`.
-
-Return:
-```
-## SDD Initialized
-
-**Project**: {project name}
-**Stack**: {detected stack}
-**Persistence**: engram
-**Strict TDD Mode**: {enabled ✅ / disabled ❌ / unavailable (no test runner)}
-
-### Testing Capabilities
-| Capability | Status |
-|------------|--------|
-| Test Runner | {tool} ✅ / ❌ Not found |
-| Unit Tests | ✅ / ❌ |
-| Integration Tests | {tool} ✅ / ❌ Not installed |
-| E2E Tests | {tool} ✅ / ❌ Not installed |
-| Coverage | ✅ / ❌ |
-| Linter | {tool} ✅ / ❌ |
-| Type Checker | {tool} ✅ / ❌ |
-
-### Context Saved
-Project context persisted to Engram.
-- **Engram ID**: #{observation-id}
-- **Topic key**: sdd-init/{project}
-- **Capabilities ID**: #{capabilities-observation-id}
-- **Capabilities key**: sdd/{project}/testing-capabilities
-
-No project files created.
-
-### ⚠️ Engram Mode Limitations
-Engram mode is ideal for **solo developers** doing fast iteration. Be aware:
-- **No iteration history**: re-running a phase (e.g., `sdd-spec`) overwrites the previous version. Only the latest artifact is retained.
-- **Not shareable**: engram is a local database — team members cannot see your SDD artifacts.
-- **Partial audit trail**: the archive phase saves a summary report, but not the full artifact folder.
-
-For **team projects** or work that needs a full audit trail, consider switching to `openspec` (file-based, git-friendly) or `hybrid` (files + engram recovery).
-
-### Next Steps
-Ready for /sdd-explore <topic> or /sdd-new <change-name>.
-```
-
-#### If mode is `openspec`:
-```
-## SDD Initialized
-
-**Project**: {project name}
-**Stack**: {detected stack}
-**Persistence**: openspec
-**Strict TDD Mode**: {enabled ✅ / disabled ❌ / unavailable (no test runner)}
-
-### Testing Capabilities
-{same table as above}
-
-### Structure Created
-- openspec/config.yaml ← Project config with detected context + testing capabilities
-- openspec/specs/      ← Ready for specifications
-- openspec/changes/    ← Ready for change proposals
-
-### Next Steps
-Ready for /sdd-explore <topic> or /sdd-new <change-name>.
-```
-
-#### If mode is `none`:
-```
-## SDD Initialized
-
-**Project**: {project name}
-**Stack**: {detected stack}
-**Persistence**: none (ephemeral)
-**Strict TDD Mode**: {enabled ✅ / disabled ❌ / unavailable (no test runner)}
-
-### Testing Capabilities
-{same table as above}
-
-### Context Detected
-{summary of detected stack and conventions}
-
-### Recommendation
-Enable `engram` or `openspec` for artifact persistence across sessions. Without persistence, all SDD artifacts will be lost when the conversation ends.
-
-### Next Steps
-Ready for /sdd-explore <topic> or /sdd-new <change-name>.
-```
-
-## Rules
-
-- NEVER create placeholder spec files - specs are created via sdd-spec during a change
-- ALWAYS detect the real tech stack, don't guess
-- NEVER behave like the orchestrator from this phase - execute directly and return results
-- If the project already has an `openspec/` directory, report what exists and ask the orchestrator if it should be updated
-- Keep config.yaml context CONCISE - no more than 10 lines
-- ALWAYS detect testing capabilities — this is not optional
-- ALWAYS persist testing capabilities as a separate observation/section — downstream phases depend on it
-- If Strict TDD Mode is requested but no test runner exists, set strict_tdd: false and explain why
-- Return a structured envelope with: `status`, `executive_summary`, `detailed_report` (optional), `artifacts`, `next_recommended`, and `risks`
+## Activation Contract
+
+Run this phase when the orchestrator/user asks to initialize SDD in a project. You are the phase executor: do the work yourself, do not delegate, and do not behave like the orchestrator.
+
+## Hard Rules
+
+- Detect the real stack, conventions, architecture, testing tools, and persistence mode; never guess.
+- In `engram` mode, do **not** create `openspec/`.
+- In `openspec` mode, follow `../_shared/openspec-convention.md` and write file artifacts.
+- In `hybrid` mode, write both openspec files and Engram observations.
+- Always persist testing capabilities separately as `sdd/{project}/testing-capabilities` or `openspec/config.yaml` `testing:`.
+- Always build `.atl/skill-registry.md`; also save `skill-registry` to Engram when available.
+- Use `capture_prompt: false` for automated SDD/config saves when supported; omit it if the tool schema lacks it.
+- If `openspec/` already exists, report what exists and ask before updating it.
+
+## Decision Gates
+
+| Input | Action |
+|---|---|
+| `mode=engram` | Save context and capabilities to Engram only. |
+| `mode=openspec` | Create/update openspec bootstrap files only. |
+| `mode=hybrid` | Do both Engram and openspec persistence. |
+| `mode=none` | Return detected context only; write no SDD artifacts except registry if required. |
+| strict TDD marker/config found | Use that value. |
+| no marker/config but test runner exists | Default `strict_tdd: true`. |
+| no test runner | Set `strict_tdd: false` and explain unavailable. |
+
+## Execution Steps
+
+1. Inspect project files (`package.json`, `go.mod`, `pyproject.toml`, CI, lint/test config) and summarize stack/conventions.
+2. Detect test runner, test layers, coverage, linter, type checker, and formatter.
+3. Resolve Strict TDD from agent marker, `openspec/config.yaml`, detected runner fallback, or no-runner fallback.
+4. Initialize persistence for the resolved mode.
+5. Build `.atl/skill-registry.md` using the skill-registry scan rules.
+6. Persist testing capabilities and project context.
+7. Return the structured initialization envelope.
+
+## Output Contract
+
+Return `status`, `executive_summary`, `artifacts`, `next_recommended`, and `risks`. Include project, stack, persistence mode, Strict TDD status, testing capability table, saved observation IDs/paths, registry path, and next `/sdd-explore` or `/sdd-new` step.
+
+## References
+
+- [references/init-details.md](references/init-details.md) — detection checklist, Engram payloads, config skeleton, and output templates.
+- `../_shared/engram-convention.md` — Engram artifact naming.
+- `../_shared/openspec-convention.md` — openspec layout and rules.

--- a/testdata/golden/sdd-opencode-skill-sdd-init.golden
+++ b/testdata/golden/sdd-opencode-skill-sdd-init.golden
@@ -1,6 +1,8 @@
 ---
 name: sdd-init
 description: "Trigger: sdd init, iniciar sdd, openspec init. Initialize SDD context, testing capabilities, registry, and persistence."
+disable-model-invocation: true
+user-invocable: false
 license: MIT
 metadata:
   author: gentleman-programming

--- a/testdata/golden/sdd-vscode-skill-sdd-init.golden
+++ b/testdata/golden/sdd-vscode-skill-sdd-init.golden
@@ -1,358 +1,55 @@
 ---
 name: sdd-init
-description: "Initialize SDD context, stack, conventions, tests, and persistence. Trigger: sdd init, iniciar sdd, or openspec init."
+description: "Trigger: sdd init, iniciar sdd, openspec init. Initialize SDD context, testing capabilities, registry, and persistence."
 license: MIT
 metadata:
   author: gentleman-programming
   version: "3.0"
 ---
 
-## Purpose
-
-You are a sub-agent responsible for initializing the Spec-Driven Development (SDD) context in a project. You detect the project stack, conventions, and testing capabilities, then bootstrap the active persistence backend.
-
-You are an EXECUTOR for this phase, not the orchestrator. Do the initialization work yourself. Do NOT launch sub-agents, do NOT call `delegate` or `task`, and do NOT hand execution back unless you hit a real blocker that must be reported upstream.
-
-## Execution and Persistence Contract
-
-- If mode is `engram`:
-  Do NOT create `openspec/` directory.
-
-  **Save project context**:
-  ```
-  mem_save(
-    title: "sdd-init/{project}",
-    topic_key: "sdd-init/{project}",
-    type: "architecture",
-    project: "{project}",
-    capture_prompt: false,
-    content: "{detected project context markdown}"
-  )
-  ```
-  `topic_key` enables upserts — re-running init updates the existing context, not duplicates.
-  Set `capture_prompt: false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
-
-  (See `skills/_shared/engram-convention.md` for full naming conventions.)
-- If mode is `openspec`: Read and follow `skills/_shared/openspec-convention.md`. Run full bootstrap.
-- If mode is `hybrid`: Read and follow BOTH convention files. Run openspec bootstrap AND persist context to Engram.
-- If mode is `none`: Return detected context without writing project files.
-
-## What to Do
-
-### Step 1: Detect Project Context
-
-Read the project to understand:
-- Tech stack (check package.json, go.mod, pyproject.toml, etc.)
-- Existing conventions (linters, test frameworks, CI)
-- Architecture patterns in use
-
-### Step 2: Detect Testing Capabilities
-
-Scan the project for ALL testing infrastructure. This determines what testing modes are available.
-
-```
-Detect testing capabilities:
-├── Test Runner
-│   ├── package.json → devDependencies: vitest, jest, mocha, ava
-│   ├── package.json → scripts.test (what command it runs)
-│   ├── pyproject.toml / pytest.ini / setup.cfg → pytest
-│   ├── go.mod → go test (built-in)
-│   ├── Cargo.toml → cargo test (built-in)
-│   ├── Makefile → make test
-│   └── Result: {framework name, command} or NOT FOUND
-│
-├── Test Layers
-│   ├── Unit: test runner exists → AVAILABLE
-│   ├── Integration:
-│   │   ├── JS/TS: @testing-library/* in dependencies
-│   │   ├── Python: pytest + httpx/requests-mock/factory-boy
-│   │   ├── Go: net/http/httptest (built-in)
-│   │   ├── .NET: xUnit/NUnit + WebApplicationFactory
-│   │   └── Result: AVAILABLE or NOT INSTALLED
-│   ├── E2E:
-│   │   ├── playwright, cypress, selenium in dependencies
-│   │   ├── Python: playwright, selenium
-│   │   ├── Go: chromedp
-│   │   └── Result: AVAILABLE or NOT INSTALLED
-│   └── Each layer → record tool name
-│
-├── Coverage Tool
-│   ├── JS/TS: vitest --coverage, jest --coverage, c8, istanbul/nyc
-│   ├── Python: coverage.py, pytest-cov
-│   ├── Go: go test -cover (built-in)
-│   ├── .NET: coverlet
-│   └── Result: {command} or NOT AVAILABLE
-│
-└── Quality Tools
-    ├── Linter: eslint, pylint, ruff, golangci-lint, clippy
-    ├── Type checker: tsc --noEmit, mypy, pyright, go vet
-    ├── Formatter: prettier, black, gofmt, rustfmt
-    └── Each: {command} or NOT AVAILABLE
-```
-
-### Step 3: Resolve STRICT TDD MODE
-
-Determine whether Strict TDD Mode should be enabled. The resolution follows a priority chain — first match wins:
-
-```
-1. Read from system prompt / agent config (highest priority):
-   ├── Search for "strict-tdd-mode" marker in the agent's system prompt file
-   │   (e.g., CLAUDE.md, GEMINI.md, .cursorrules, etc.)
-   ├── If found and says "enabled" → strict_tdd: true
-   ├── If found and says "disabled" → strict_tdd: false
-   └── This is the preference set by the user in the gentle-ai TUI
-
-2. If no marker found, check openspec config:
-   ├── Read openspec/config.yaml → strict_tdd field
-   └── If found → use that value
-
-3. If nothing found AND test runner was detected in Step 2:
-   ├── Default: strict_tdd: true (enable if the project CAN do TDD)
-   └── This ensures TDD is active even without gentle-ai TUI setup
-
-4. If no test runner detected:
-   ├── strict_tdd: false (cannot enable without test runner)
-   └── Include NOTE in summary: "Strict TDD Mode unavailable — no test runner detected"
-```
-
-**Do NOT ask the user interactively.** The preference is resolved from existing config. If the user wants to change it, they run `gentle-ai sync` with the TUI or set `strict_tdd` in `openspec/config.yaml`.
-
-### Step 4: Initialize Persistence Backend
-
-If mode resolves to `openspec`, create this directory structure:
-
-```
-openspec/
-├── config.yaml              ← Project-specific SDD config
-├── specs/                   ← Source of truth (empty initially)
-└── changes/                 ← Active changes
-    └── archive/             ← Completed changes
-```
-
-### Step 5: Generate Config (openspec mode)
-
-Based on what you detected, create the config when in `openspec` mode:
-
-```yaml
-# openspec/config.yaml
-schema: spec-driven
-
-context: |
-  Tech stack: {detected stack}
-  Architecture: {detected patterns}
-  Testing: {detected test framework}
-  Style: {detected linting/formatting}
-
-strict_tdd: {true/false}
-
-rules:
-  proposal:
-    - Include rollback plan for risky changes
-    - Identify affected modules/packages
-  specs:
-    - Use Given/When/Then format for scenarios
-    - Use RFC 2119 keywords (MUST, SHALL, SHOULD, MAY)
-  design:
-    - Include sequence diagrams for complex flows
-    - Document architecture decisions with rationale
-  tasks:
-    - Group tasks by phase (infrastructure, implementation, testing)
-    - Use hierarchical numbering (1.1, 1.2, etc.)
-    - Keep tasks small enough to complete in one session
-  apply:
-    - Follow existing code patterns and conventions
-    - Load relevant coding skills for the project stack
-  verify:
-    - Run tests if test infrastructure exists
-    - Compare implementation against every spec scenario
-  archive:
-    - Warn before merging destructive deltas (large removals)
-```
-
-### Step 6: Persist Testing Capabilities
-
-**This step is MANDATORY — do NOT skip it.**
-
-Persist detected testing capabilities as a separate Engram observation (or section in config.yaml for openspec). This cache prevents re-detection on every `sdd-apply` and `sdd-verify` run.
-
-If mode is `engram` or `hybrid`:
-```
-mem_save(
-  title: "sdd/{project}/testing-capabilities",
-  topic_key: "sdd/{project}/testing-capabilities",
-  type: "config",
-  project: "{project}",
-  capture_prompt: false,
-  content: "{testing capabilities markdown — see format below}"
-)
-```
-Set `capture_prompt: false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
-
-**Testing Capabilities format**:
-
-```markdown
-## Testing Capabilities
-
-**Strict TDD Mode**: {enabled/disabled}
-**Detected**: {date}
-
-### Test Runner
-- Command: `{command}`
-- Framework: {name}
-
-### Test Layers
-| Layer | Available | Tool |
-|-------|-----------|------|
-| Unit | ✅ / ❌ | {tool or —} |
-| Integration | ✅ / ❌ | {tool or —} |
-| E2E | ✅ / ❌ | {tool or —} |
-
-### Coverage
-- Available: ✅ / ❌
-- Command: `{command or —}`
-
-### Quality Tools
-| Tool | Available | Command |
-|------|-----------|---------|
-| Linter | ✅ / ❌ | {command or —} |
-| Type checker | ✅ / ❌ | {command or —} |
-| Formatter | ✅ / ❌ | {command or —} |
-```
-
-If mode is `openspec` or `hybrid`, also write this as a section in `openspec/config.yaml` under `testing:`.
-
-### Step 7: Build Skill Registry
-
-Follow the same logic as the `skill-registry` skill (`skills/skill-registry/SKILL.md`):
-
-1. Scan user skills: glob `*/SKILL.md` across ALL known skill directories. **User-level**: `~/.claude/skills/`, `~/.config/opencode/skills/`, `~/.gemini/skills/`, `~/.cursor/skills/`, `~/.copilot/skills/`, parent of this skill file. **Project-level**: `.claude/skills/`, `.gemini/skills/`, `.agent/skills/`, `skills/`. Skip `sdd-*`, `_shared`, `skill-registry`. Deduplicate by name (project-level wins). Read frontmatter triggers.
-2. Scan project conventions: check for `agents.md`, `AGENTS.md`, `CLAUDE.md` (project-level), `.cursorrules`, `GEMINI.md`, `copilot-instructions.md` in the project root. If an index file is found (e.g., `agents.md`), READ it and extract all referenced file paths — include both the index and its referenced files in the registry.
-3. **ALWAYS write `.atl/skill-registry.md`** in the project root (create `.atl/` if needed). This file is mode-independent — it's infrastructure, not an SDD artifact.
-4. If engram is available, **ALSO save to engram**: `mem_save(title: "skill-registry", topic_key: "skill-registry", type: "config", project: "{project}", capture_prompt: false, content: "{registry markdown}")`. Set `capture_prompt: false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
-
-See `skills/skill-registry/SKILL.md` for the full registry format and scanning details.
-
-### Step 8: Persist Project Context
-
-**This step is MANDATORY — do NOT skip it.**
-
-If mode is `engram`:
-```
-mem_save(
-  title: "sdd-init/{project}",
-  topic_key: "sdd-init/{project}",
-  type: "architecture",
-  project: "{project}",
-  capture_prompt: false,
-  content: "{your detected project context from Steps 1-7}"
-)
-```
-Set `capture_prompt: false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
-
-If mode is `openspec` or `hybrid`: the config was already written in Step 5.
-
-If mode is `hybrid`: also call `mem_save` as above (write to BOTH backends).
-
-### Step 9: Return Summary
-
-Return a structured summary adapted to the resolved mode:
-
-#### If mode is `engram`:
-
-Persist project context following `skills/_shared/engram-convention.md` with title and topic_key `sdd-init/{project}`.
-
-Return:
-```
-## SDD Initialized
-
-**Project**: {project name}
-**Stack**: {detected stack}
-**Persistence**: engram
-**Strict TDD Mode**: {enabled ✅ / disabled ❌ / unavailable (no test runner)}
-
-### Testing Capabilities
-| Capability | Status |
-|------------|--------|
-| Test Runner | {tool} ✅ / ❌ Not found |
-| Unit Tests | ✅ / ❌ |
-| Integration Tests | {tool} ✅ / ❌ Not installed |
-| E2E Tests | {tool} ✅ / ❌ Not installed |
-| Coverage | ✅ / ❌ |
-| Linter | {tool} ✅ / ❌ |
-| Type Checker | {tool} ✅ / ❌ |
-
-### Context Saved
-Project context persisted to Engram.
-- **Engram ID**: #{observation-id}
-- **Topic key**: sdd-init/{project}
-- **Capabilities ID**: #{capabilities-observation-id}
-- **Capabilities key**: sdd/{project}/testing-capabilities
-
-No project files created.
-
-### ⚠️ Engram Mode Limitations
-Engram mode is ideal for **solo developers** doing fast iteration. Be aware:
-- **No iteration history**: re-running a phase (e.g., `sdd-spec`) overwrites the previous version. Only the latest artifact is retained.
-- **Not shareable**: engram is a local database — team members cannot see your SDD artifacts.
-- **Partial audit trail**: the archive phase saves a summary report, but not the full artifact folder.
-
-For **team projects** or work that needs a full audit trail, consider switching to `openspec` (file-based, git-friendly) or `hybrid` (files + engram recovery).
-
-### Next Steps
-Ready for /sdd-explore <topic> or /sdd-new <change-name>.
-```
-
-#### If mode is `openspec`:
-```
-## SDD Initialized
-
-**Project**: {project name}
-**Stack**: {detected stack}
-**Persistence**: openspec
-**Strict TDD Mode**: {enabled ✅ / disabled ❌ / unavailable (no test runner)}
-
-### Testing Capabilities
-{same table as above}
-
-### Structure Created
-- openspec/config.yaml ← Project config with detected context + testing capabilities
-- openspec/specs/      ← Ready for specifications
-- openspec/changes/    ← Ready for change proposals
-
-### Next Steps
-Ready for /sdd-explore <topic> or /sdd-new <change-name>.
-```
-
-#### If mode is `none`:
-```
-## SDD Initialized
-
-**Project**: {project name}
-**Stack**: {detected stack}
-**Persistence**: none (ephemeral)
-**Strict TDD Mode**: {enabled ✅ / disabled ❌ / unavailable (no test runner)}
-
-### Testing Capabilities
-{same table as above}
-
-### Context Detected
-{summary of detected stack and conventions}
-
-### Recommendation
-Enable `engram` or `openspec` for artifact persistence across sessions. Without persistence, all SDD artifacts will be lost when the conversation ends.
-
-### Next Steps
-Ready for /sdd-explore <topic> or /sdd-new <change-name>.
-```
-
-## Rules
-
-- NEVER create placeholder spec files - specs are created via sdd-spec during a change
-- ALWAYS detect the real tech stack, don't guess
-- NEVER behave like the orchestrator from this phase - execute directly and return results
-- If the project already has an `openspec/` directory, report what exists and ask the orchestrator if it should be updated
-- Keep config.yaml context CONCISE - no more than 10 lines
-- ALWAYS detect testing capabilities — this is not optional
-- ALWAYS persist testing capabilities as a separate observation/section — downstream phases depend on it
-- If Strict TDD Mode is requested but no test runner exists, set strict_tdd: false and explain why
-- Return a structured envelope with: `status`, `executive_summary`, `detailed_report` (optional), `artifacts`, `next_recommended`, and `risks`
+## Activation Contract
+
+Run this phase when the orchestrator/user asks to initialize SDD in a project. You are the phase executor: do the work yourself, do not delegate, and do not behave like the orchestrator.
+
+## Hard Rules
+
+- Detect the real stack, conventions, architecture, testing tools, and persistence mode; never guess.
+- In `engram` mode, do **not** create `openspec/`.
+- In `openspec` mode, follow `../_shared/openspec-convention.md` and write file artifacts.
+- In `hybrid` mode, write both openspec files and Engram observations.
+- Always persist testing capabilities separately as `sdd/{project}/testing-capabilities` or `openspec/config.yaml` `testing:`.
+- Always build `.atl/skill-registry.md`; also save `skill-registry` to Engram when available.
+- Use `capture_prompt: false` for automated SDD/config saves when supported; omit it if the tool schema lacks it.
+- If `openspec/` already exists, report what exists and ask before updating it.
+
+## Decision Gates
+
+| Input | Action |
+|---|---|
+| `mode=engram` | Save context and capabilities to Engram only. |
+| `mode=openspec` | Create/update openspec bootstrap files only. |
+| `mode=hybrid` | Do both Engram and openspec persistence. |
+| `mode=none` | Return detected context only; write no SDD artifacts except registry if required. |
+| strict TDD marker/config found | Use that value. |
+| no marker/config but test runner exists | Default `strict_tdd: true`. |
+| no test runner | Set `strict_tdd: false` and explain unavailable. |
+
+## Execution Steps
+
+1. Inspect project files (`package.json`, `go.mod`, `pyproject.toml`, CI, lint/test config) and summarize stack/conventions.
+2. Detect test runner, test layers, coverage, linter, type checker, and formatter.
+3. Resolve Strict TDD from agent marker, `openspec/config.yaml`, detected runner fallback, or no-runner fallback.
+4. Initialize persistence for the resolved mode.
+5. Build `.atl/skill-registry.md` using the skill-registry scan rules.
+6. Persist testing capabilities and project context.
+7. Return the structured initialization envelope.
+
+## Output Contract
+
+Return `status`, `executive_summary`, `artifacts`, `next_recommended`, and `risks`. Include project, stack, persistence mode, Strict TDD status, testing capability table, saved observation IDs/paths, registry path, and next `/sdd-explore` or `/sdd-new` step.
+
+## References
+
+- [references/init-details.md](references/init-details.md) — detection checklist, Engram payloads, config skeleton, and output templates.
+- `../_shared/engram-convention.md` — Engram artifact naming.
+- `../_shared/openspec-convention.md` — openspec layout and rules.

--- a/testdata/golden/sdd-vscode-skill-sdd-init.golden
+++ b/testdata/golden/sdd-vscode-skill-sdd-init.golden
@@ -1,6 +1,8 @@
 ---
 name: sdd-init
 description: "Trigger: sdd init, iniciar sdd, openspec init. Initialize SDD context, testing capabilities, registry, and persistence."
+disable-model-invocation: true
+user-invocable: false
 license: MIT
 metadata:
   author: gentleman-programming

--- a/testdata/golden/sdd-windsurf-skill-sdd-init.golden
+++ b/testdata/golden/sdd-windsurf-skill-sdd-init.golden
@@ -1,358 +1,55 @@
 ---
 name: sdd-init
-description: "Initialize SDD context, stack, conventions, tests, and persistence. Trigger: sdd init, iniciar sdd, or openspec init."
+description: "Trigger: sdd init, iniciar sdd, openspec init. Initialize SDD context, testing capabilities, registry, and persistence."
 license: MIT
 metadata:
   author: gentleman-programming
   version: "3.0"
 ---
 
-## Purpose
-
-You are a sub-agent responsible for initializing the Spec-Driven Development (SDD) context in a project. You detect the project stack, conventions, and testing capabilities, then bootstrap the active persistence backend.
-
-You are an EXECUTOR for this phase, not the orchestrator. Do the initialization work yourself. Do NOT launch sub-agents, do NOT call `delegate` or `task`, and do NOT hand execution back unless you hit a real blocker that must be reported upstream.
-
-## Execution and Persistence Contract
-
-- If mode is `engram`:
-  Do NOT create `openspec/` directory.
-
-  **Save project context**:
-  ```
-  mem_save(
-    title: "sdd-init/{project}",
-    topic_key: "sdd-init/{project}",
-    type: "architecture",
-    project: "{project}",
-    capture_prompt: false,
-    content: "{detected project context markdown}"
-  )
-  ```
-  `topic_key` enables upserts — re-running init updates the existing context, not duplicates.
-  Set `capture_prompt: false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
-
-  (See `skills/_shared/engram-convention.md` for full naming conventions.)
-- If mode is `openspec`: Read and follow `skills/_shared/openspec-convention.md`. Run full bootstrap.
-- If mode is `hybrid`: Read and follow BOTH convention files. Run openspec bootstrap AND persist context to Engram.
-- If mode is `none`: Return detected context without writing project files.
-
-## What to Do
-
-### Step 1: Detect Project Context
-
-Read the project to understand:
-- Tech stack (check package.json, go.mod, pyproject.toml, etc.)
-- Existing conventions (linters, test frameworks, CI)
-- Architecture patterns in use
-
-### Step 2: Detect Testing Capabilities
-
-Scan the project for ALL testing infrastructure. This determines what testing modes are available.
-
-```
-Detect testing capabilities:
-├── Test Runner
-│   ├── package.json → devDependencies: vitest, jest, mocha, ava
-│   ├── package.json → scripts.test (what command it runs)
-│   ├── pyproject.toml / pytest.ini / setup.cfg → pytest
-│   ├── go.mod → go test (built-in)
-│   ├── Cargo.toml → cargo test (built-in)
-│   ├── Makefile → make test
-│   └── Result: {framework name, command} or NOT FOUND
-│
-├── Test Layers
-│   ├── Unit: test runner exists → AVAILABLE
-│   ├── Integration:
-│   │   ├── JS/TS: @testing-library/* in dependencies
-│   │   ├── Python: pytest + httpx/requests-mock/factory-boy
-│   │   ├── Go: net/http/httptest (built-in)
-│   │   ├── .NET: xUnit/NUnit + WebApplicationFactory
-│   │   └── Result: AVAILABLE or NOT INSTALLED
-│   ├── E2E:
-│   │   ├── playwright, cypress, selenium in dependencies
-│   │   ├── Python: playwright, selenium
-│   │   ├── Go: chromedp
-│   │   └── Result: AVAILABLE or NOT INSTALLED
-│   └── Each layer → record tool name
-│
-├── Coverage Tool
-│   ├── JS/TS: vitest --coverage, jest --coverage, c8, istanbul/nyc
-│   ├── Python: coverage.py, pytest-cov
-│   ├── Go: go test -cover (built-in)
-│   ├── .NET: coverlet
-│   └── Result: {command} or NOT AVAILABLE
-│
-└── Quality Tools
-    ├── Linter: eslint, pylint, ruff, golangci-lint, clippy
-    ├── Type checker: tsc --noEmit, mypy, pyright, go vet
-    ├── Formatter: prettier, black, gofmt, rustfmt
-    └── Each: {command} or NOT AVAILABLE
-```
-
-### Step 3: Resolve STRICT TDD MODE
-
-Determine whether Strict TDD Mode should be enabled. The resolution follows a priority chain — first match wins:
-
-```
-1. Read from system prompt / agent config (highest priority):
-   ├── Search for "strict-tdd-mode" marker in the agent's system prompt file
-   │   (e.g., CLAUDE.md, GEMINI.md, .cursorrules, etc.)
-   ├── If found and says "enabled" → strict_tdd: true
-   ├── If found and says "disabled" → strict_tdd: false
-   └── This is the preference set by the user in the gentle-ai TUI
-
-2. If no marker found, check openspec config:
-   ├── Read openspec/config.yaml → strict_tdd field
-   └── If found → use that value
-
-3. If nothing found AND test runner was detected in Step 2:
-   ├── Default: strict_tdd: true (enable if the project CAN do TDD)
-   └── This ensures TDD is active even without gentle-ai TUI setup
-
-4. If no test runner detected:
-   ├── strict_tdd: false (cannot enable without test runner)
-   └── Include NOTE in summary: "Strict TDD Mode unavailable — no test runner detected"
-```
-
-**Do NOT ask the user interactively.** The preference is resolved from existing config. If the user wants to change it, they run `gentle-ai sync` with the TUI or set `strict_tdd` in `openspec/config.yaml`.
-
-### Step 4: Initialize Persistence Backend
-
-If mode resolves to `openspec`, create this directory structure:
-
-```
-openspec/
-├── config.yaml              ← Project-specific SDD config
-├── specs/                   ← Source of truth (empty initially)
-└── changes/                 ← Active changes
-    └── archive/             ← Completed changes
-```
-
-### Step 5: Generate Config (openspec mode)
-
-Based on what you detected, create the config when in `openspec` mode:
-
-```yaml
-# openspec/config.yaml
-schema: spec-driven
-
-context: |
-  Tech stack: {detected stack}
-  Architecture: {detected patterns}
-  Testing: {detected test framework}
-  Style: {detected linting/formatting}
-
-strict_tdd: {true/false}
-
-rules:
-  proposal:
-    - Include rollback plan for risky changes
-    - Identify affected modules/packages
-  specs:
-    - Use Given/When/Then format for scenarios
-    - Use RFC 2119 keywords (MUST, SHALL, SHOULD, MAY)
-  design:
-    - Include sequence diagrams for complex flows
-    - Document architecture decisions with rationale
-  tasks:
-    - Group tasks by phase (infrastructure, implementation, testing)
-    - Use hierarchical numbering (1.1, 1.2, etc.)
-    - Keep tasks small enough to complete in one session
-  apply:
-    - Follow existing code patterns and conventions
-    - Load relevant coding skills for the project stack
-  verify:
-    - Run tests if test infrastructure exists
-    - Compare implementation against every spec scenario
-  archive:
-    - Warn before merging destructive deltas (large removals)
-```
-
-### Step 6: Persist Testing Capabilities
-
-**This step is MANDATORY — do NOT skip it.**
-
-Persist detected testing capabilities as a separate Engram observation (or section in config.yaml for openspec). This cache prevents re-detection on every `sdd-apply` and `sdd-verify` run.
-
-If mode is `engram` or `hybrid`:
-```
-mem_save(
-  title: "sdd/{project}/testing-capabilities",
-  topic_key: "sdd/{project}/testing-capabilities",
-  type: "config",
-  project: "{project}",
-  capture_prompt: false,
-  content: "{testing capabilities markdown — see format below}"
-)
-```
-Set `capture_prompt: false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
-
-**Testing Capabilities format**:
-
-```markdown
-## Testing Capabilities
-
-**Strict TDD Mode**: {enabled/disabled}
-**Detected**: {date}
-
-### Test Runner
-- Command: `{command}`
-- Framework: {name}
-
-### Test Layers
-| Layer | Available | Tool |
-|-------|-----------|------|
-| Unit | ✅ / ❌ | {tool or —} |
-| Integration | ✅ / ❌ | {tool or —} |
-| E2E | ✅ / ❌ | {tool or —} |
-
-### Coverage
-- Available: ✅ / ❌
-- Command: `{command or —}`
-
-### Quality Tools
-| Tool | Available | Command |
-|------|-----------|---------|
-| Linter | ✅ / ❌ | {command or —} |
-| Type checker | ✅ / ❌ | {command or —} |
-| Formatter | ✅ / ❌ | {command or —} |
-```
-
-If mode is `openspec` or `hybrid`, also write this as a section in `openspec/config.yaml` under `testing:`.
-
-### Step 7: Build Skill Registry
-
-Follow the same logic as the `skill-registry` skill (`skills/skill-registry/SKILL.md`):
-
-1. Scan user skills: glob `*/SKILL.md` across ALL known skill directories. **User-level**: `~/.claude/skills/`, `~/.config/opencode/skills/`, `~/.gemini/skills/`, `~/.cursor/skills/`, `~/.copilot/skills/`, parent of this skill file. **Project-level**: `.claude/skills/`, `.gemini/skills/`, `.agent/skills/`, `skills/`. Skip `sdd-*`, `_shared`, `skill-registry`. Deduplicate by name (project-level wins). Read frontmatter triggers.
-2. Scan project conventions: check for `agents.md`, `AGENTS.md`, `CLAUDE.md` (project-level), `.cursorrules`, `GEMINI.md`, `copilot-instructions.md` in the project root. If an index file is found (e.g., `agents.md`), READ it and extract all referenced file paths — include both the index and its referenced files in the registry.
-3. **ALWAYS write `.atl/skill-registry.md`** in the project root (create `.atl/` if needed). This file is mode-independent — it's infrastructure, not an SDD artifact.
-4. If engram is available, **ALSO save to engram**: `mem_save(title: "skill-registry", topic_key: "skill-registry", type: "config", project: "{project}", capture_prompt: false, content: "{registry markdown}")`. Set `capture_prompt: false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
-
-See `skills/skill-registry/SKILL.md` for the full registry format and scanning details.
-
-### Step 8: Persist Project Context
-
-**This step is MANDATORY — do NOT skip it.**
-
-If mode is `engram`:
-```
-mem_save(
-  title: "sdd-init/{project}",
-  topic_key: "sdd-init/{project}",
-  type: "architecture",
-  project: "{project}",
-  capture_prompt: false,
-  content: "{your detected project context from Steps 1-7}"
-)
-```
-Set `capture_prompt: false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
-
-If mode is `openspec` or `hybrid`: the config was already written in Step 5.
-
-If mode is `hybrid`: also call `mem_save` as above (write to BOTH backends).
-
-### Step 9: Return Summary
-
-Return a structured summary adapted to the resolved mode:
-
-#### If mode is `engram`:
-
-Persist project context following `skills/_shared/engram-convention.md` with title and topic_key `sdd-init/{project}`.
-
-Return:
-```
-## SDD Initialized
-
-**Project**: {project name}
-**Stack**: {detected stack}
-**Persistence**: engram
-**Strict TDD Mode**: {enabled ✅ / disabled ❌ / unavailable (no test runner)}
-
-### Testing Capabilities
-| Capability | Status |
-|------------|--------|
-| Test Runner | {tool} ✅ / ❌ Not found |
-| Unit Tests | ✅ / ❌ |
-| Integration Tests | {tool} ✅ / ❌ Not installed |
-| E2E Tests | {tool} ✅ / ❌ Not installed |
-| Coverage | ✅ / ❌ |
-| Linter | {tool} ✅ / ❌ |
-| Type Checker | {tool} ✅ / ❌ |
-
-### Context Saved
-Project context persisted to Engram.
-- **Engram ID**: #{observation-id}
-- **Topic key**: sdd-init/{project}
-- **Capabilities ID**: #{capabilities-observation-id}
-- **Capabilities key**: sdd/{project}/testing-capabilities
-
-No project files created.
-
-### ⚠️ Engram Mode Limitations
-Engram mode is ideal for **solo developers** doing fast iteration. Be aware:
-- **No iteration history**: re-running a phase (e.g., `sdd-spec`) overwrites the previous version. Only the latest artifact is retained.
-- **Not shareable**: engram is a local database — team members cannot see your SDD artifacts.
-- **Partial audit trail**: the archive phase saves a summary report, but not the full artifact folder.
-
-For **team projects** or work that needs a full audit trail, consider switching to `openspec` (file-based, git-friendly) or `hybrid` (files + engram recovery).
-
-### Next Steps
-Ready for /sdd-explore <topic> or /sdd-new <change-name>.
-```
-
-#### If mode is `openspec`:
-```
-## SDD Initialized
-
-**Project**: {project name}
-**Stack**: {detected stack}
-**Persistence**: openspec
-**Strict TDD Mode**: {enabled ✅ / disabled ❌ / unavailable (no test runner)}
-
-### Testing Capabilities
-{same table as above}
-
-### Structure Created
-- openspec/config.yaml ← Project config with detected context + testing capabilities
-- openspec/specs/      ← Ready for specifications
-- openspec/changes/    ← Ready for change proposals
-
-### Next Steps
-Ready for /sdd-explore <topic> or /sdd-new <change-name>.
-```
-
-#### If mode is `none`:
-```
-## SDD Initialized
-
-**Project**: {project name}
-**Stack**: {detected stack}
-**Persistence**: none (ephemeral)
-**Strict TDD Mode**: {enabled ✅ / disabled ❌ / unavailable (no test runner)}
-
-### Testing Capabilities
-{same table as above}
-
-### Context Detected
-{summary of detected stack and conventions}
-
-### Recommendation
-Enable `engram` or `openspec` for artifact persistence across sessions. Without persistence, all SDD artifacts will be lost when the conversation ends.
-
-### Next Steps
-Ready for /sdd-explore <topic> or /sdd-new <change-name>.
-```
-
-## Rules
-
-- NEVER create placeholder spec files - specs are created via sdd-spec during a change
-- ALWAYS detect the real tech stack, don't guess
-- NEVER behave like the orchestrator from this phase - execute directly and return results
-- If the project already has an `openspec/` directory, report what exists and ask the orchestrator if it should be updated
-- Keep config.yaml context CONCISE - no more than 10 lines
-- ALWAYS detect testing capabilities — this is not optional
-- ALWAYS persist testing capabilities as a separate observation/section — downstream phases depend on it
-- If Strict TDD Mode is requested but no test runner exists, set strict_tdd: false and explain why
-- Return a structured envelope with: `status`, `executive_summary`, `detailed_report` (optional), `artifacts`, `next_recommended`, and `risks`
+## Activation Contract
+
+Run this phase when the orchestrator/user asks to initialize SDD in a project. You are the phase executor: do the work yourself, do not delegate, and do not behave like the orchestrator.
+
+## Hard Rules
+
+- Detect the real stack, conventions, architecture, testing tools, and persistence mode; never guess.
+- In `engram` mode, do **not** create `openspec/`.
+- In `openspec` mode, follow `../_shared/openspec-convention.md` and write file artifacts.
+- In `hybrid` mode, write both openspec files and Engram observations.
+- Always persist testing capabilities separately as `sdd/{project}/testing-capabilities` or `openspec/config.yaml` `testing:`.
+- Always build `.atl/skill-registry.md`; also save `skill-registry` to Engram when available.
+- Use `capture_prompt: false` for automated SDD/config saves when supported; omit it if the tool schema lacks it.
+- If `openspec/` already exists, report what exists and ask before updating it.
+
+## Decision Gates
+
+| Input | Action |
+|---|---|
+| `mode=engram` | Save context and capabilities to Engram only. |
+| `mode=openspec` | Create/update openspec bootstrap files only. |
+| `mode=hybrid` | Do both Engram and openspec persistence. |
+| `mode=none` | Return detected context only; write no SDD artifacts except registry if required. |
+| strict TDD marker/config found | Use that value. |
+| no marker/config but test runner exists | Default `strict_tdd: true`. |
+| no test runner | Set `strict_tdd: false` and explain unavailable. |
+
+## Execution Steps
+
+1. Inspect project files (`package.json`, `go.mod`, `pyproject.toml`, CI, lint/test config) and summarize stack/conventions.
+2. Detect test runner, test layers, coverage, linter, type checker, and formatter.
+3. Resolve Strict TDD from agent marker, `openspec/config.yaml`, detected runner fallback, or no-runner fallback.
+4. Initialize persistence for the resolved mode.
+5. Build `.atl/skill-registry.md` using the skill-registry scan rules.
+6. Persist testing capabilities and project context.
+7. Return the structured initialization envelope.
+
+## Output Contract
+
+Return `status`, `executive_summary`, `artifacts`, `next_recommended`, and `risks`. Include project, stack, persistence mode, Strict TDD status, testing capability table, saved observation IDs/paths, registry path, and next `/sdd-explore` or `/sdd-new` step.
+
+## References
+
+- [references/init-details.md](references/init-details.md) — detection checklist, Engram payloads, config skeleton, and output templates.
+- `../_shared/engram-convention.md` — Engram artifact naming.
+- `../_shared/openspec-convention.md` — openspec layout and rules.

--- a/testdata/golden/sdd-windsurf-skill-sdd-init.golden
+++ b/testdata/golden/sdd-windsurf-skill-sdd-init.golden
@@ -1,6 +1,8 @@
 ---
 name: sdd-init
 description: "Trigger: sdd init, iniciar sdd, openspec init. Initialize SDD context, testing capabilities, registry, and persistence."
+disable-model-invocation: true
+user-invocable: false
 license: MIT
 metadata:
   author: gentleman-programming

--- a/testdata/golden/skills-claude-go-testing.golden
+++ b/testdata/golden/skills-claude-go-testing.golden
@@ -1,353 +1,51 @@
 ---
 name: go-testing
-description: "Write Go tests, including Bubbletea TUI tests. Trigger: Go test coverage, teatest, or test patterns."
+description: "Trigger: Go tests, go test coverage, Bubbletea teatest, golden files. Apply focused Go testing patterns."
 license: Apache-2.0
 metadata:
   author: gentleman-programming
   version: "1.0"
 ---
 
-## When to Use
+## Activation Contract
 
-Use this skill when:
-- Writing Go unit tests
-- Testing Bubbletea TUI components
-- Creating table-driven tests
-- Adding integration tests
-- Using golden file testing
+Load this skill when writing or reviewing Go tests, adding coverage, testing Bubbletea/TUI flows, using `teatest`, or updating golden files.
 
----
+## Hard Rules
 
-## Critical Patterns
+- Prefer table-driven tests for multiple cases; use `t.Run(tt.name, ...)`.
+- Test behavior and state transitions, not implementation trivia.
+- Use `t.TempDir()` for filesystem tests; never rely on a real home directory.
+- Keep integration tests skippable with `testing.Short()` when they run external commands or slow flows.
+- For Bubbletea, test `Model.Update()` directly for state changes; use `teatest` only for interactive flows.
+- Golden files must be deterministic; update only through the repo's `-update` path and rerun tests without `-update`.
+- Use small mocks/interfaces around system or command execution boundaries.
 
-### Pattern 1: Table-Driven Tests
+## Decision Gates
 
-Standard Go pattern for multiple test cases:
+| Target | Test pattern |
+|---|---|
+| Pure function or parser | Table-driven unit test. |
+| Error behavior | Explicit success and failure cases. |
+| File operations | `t.TempDir()` plus focused assertions. |
+| TUI state transition | Direct `Model.Update()` call with `tea.Msg`. |
+| Full TUI interaction | `teatest.NewTestModel()`. |
+| Rendered output | Golden file test. |
+| Real external command | Integration test; skip in `-short`. |
 
-```go
-func TestSomething(t *testing.T) {
-    tests := []struct {
-        name     string
-        input    string
-        expected string
-        wantErr  bool
-    }{
-        {
-            name:     "valid input",
-            input:    "hello",
-            expected: "HELLO",
-            wantErr:  false,
-        },
-        {
-            name:     "empty input",
-            input:    "",
-            expected: "",
-            wantErr:  true,
-        },
-    }
+## Execution Steps
 
-    for _, tt := range tests {
-        t.Run(tt.name, func(t *testing.T) {
-            result, err := ProcessInput(tt.input)
+1. Identify behavior under test and the smallest public boundary that proves it.
+2. Choose the test pattern from the decision gate.
+3. Name cases by scenario, not input mechanics.
+4. Assert outputs, errors, state, and side effects explicitly.
+5. Run the narrow package test first, then the relevant broader suite.
+6. For golden updates: run with `-update`, inspect diff, then rerun without `-update`.
 
-            if (err != nil) != tt.wantErr {
-                t.Errorf("error = %v, wantErr %v", err, tt.wantErr)
-                return
-            }
+## Output Contract
 
-            if result != tt.expected {
-                t.Errorf("got %q, want %q", result, tt.expected)
-            }
-        })
-    }
-}
-```
+Report test files changed, scenarios covered, commands executed, golden files updated, and any skipped integration scope.
 
-### Pattern 2: Bubbletea Model Testing
+## References
 
-Test Model state transitions directly:
-
-```go
-func TestModelUpdate(t *testing.T) {
-    m := NewModel()
-
-    // Simulate key press
-    newModel, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
-    m = newModel.(Model)
-
-    if m.Screen != ScreenMainMenu {
-        t.Errorf("expected ScreenMainMenu, got %v", m.Screen)
-    }
-}
-```
-
-### Pattern 3: Teatest Integration Tests
-
-Use Charmbracelet's teatest for TUI testing:
-
-```go
-func TestInteractiveFlow(t *testing.T) {
-    m := NewModel()
-    tm := teatest.NewTestModel(t, m)
-
-    // Send keys
-    tm.Send(tea.KeyMsg{Type: tea.KeyEnter})
-    tm.Send(tea.KeyMsg{Type: tea.KeyDown})
-    tm.Send(tea.KeyMsg{Type: tea.KeyEnter})
-
-    // Wait for model to update
-    tm.WaitFinished(t, teatest.WithDuration(time.Second))
-
-    // Get final model
-    finalModel := tm.FinalModel(t).(Model)
-
-    if finalModel.Screen != ExpectedScreen {
-        t.Errorf("wrong screen: got %v", finalModel.Screen)
-    }
-}
-```
-
-### Pattern 4: Golden File Testing
-
-Compare output against saved "golden" files:
-
-```go
-func TestOSSelectGolden(t *testing.T) {
-    m := NewModel()
-    m.Screen = ScreenOSSelect
-    m.Width = 80
-    m.Height = 24
-
-    output := m.View()
-
-    golden := filepath.Join("testdata", "TestOSSelectGolden.golden")
-
-    if *update {
-        os.WriteFile(golden, []byte(output), 0644)
-    }
-
-    expected, _ := os.ReadFile(golden)
-    if output != string(expected) {
-        t.Errorf("output doesn't match golden file")
-    }
-}
-```
-
----
-
-## Decision Tree
-
-```
-Testing a function?
-├── Pure function? → Table-driven test
-├── Has side effects? → Mock dependencies
-├── Returns error? → Test both success and error cases
-└── Complex logic? → Break into smaller testable units
-
-Testing TUI component?
-├── State change? → Test Model.Update() directly
-├── Full flow? → Use teatest.NewTestModel()
-├── Visual output? → Use golden file testing
-└── Key handling? → Send tea.KeyMsg
-
-Testing system/exec?
-├── Mock os/exec? → Use interface + mock
-├── Real commands? → Integration test with --short skip
-└── File operations? → Use t.TempDir()
-```
-
----
-
-## Code Examples
-
-### Example 1: Testing Key Navigation
-
-```go
-func TestCursorNavigation(t *testing.T) {
-    tests := []struct {
-        name       string
-        startPos   int
-        key        string
-        endPos     int
-        numOptions int
-    }{
-        {"down from 0", 0, "j", 1, 5},
-        {"up from 1", 1, "k", 0, 5},
-        {"down at bottom", 4, "j", 4, 5}, // stays at bottom
-        {"up at top", 0, "k", 0, 5},       // stays at top
-    }
-
-    for _, tt := range tests {
-        t.Run(tt.name, func(t *testing.T) {
-            m := NewModel()
-            m.Cursor = tt.startPos
-            // Set up options...
-
-            newModel, _ := m.Update(tea.KeyMsg{
-                Type:  tea.KeyRunes,
-                Runes: []rune(tt.key),
-            })
-            m = newModel.(Model)
-
-            if m.Cursor != tt.endPos {
-                t.Errorf("cursor = %d, want %d", m.Cursor, tt.endPos)
-            }
-        })
-    }
-}
-```
-
-### Example 2: Testing Screen Transitions
-
-```go
-func TestScreenTransitions(t *testing.T) {
-    tests := []struct {
-        name         string
-        startScreen  Screen
-        action       tea.Msg
-        expectScreen Screen
-    }{
-        {
-            name:         "welcome to main menu",
-            startScreen:  ScreenWelcome,
-            action:       tea.KeyMsg{Type: tea.KeyEnter},
-            expectScreen: ScreenMainMenu,
-        },
-        {
-            name:         "escape from OS select",
-            startScreen:  ScreenOSSelect,
-            action:       tea.KeyMsg{Type: tea.KeyEsc},
-            expectScreen: ScreenMainMenu,
-        },
-    }
-
-    for _, tt := range tests {
-        t.Run(tt.name, func(t *testing.T) {
-            m := NewModel()
-            m.Screen = tt.startScreen
-
-            newModel, _ := m.Update(tt.action)
-            m = newModel.(Model)
-
-            if m.Screen != tt.expectScreen {
-                t.Errorf("screen = %v, want %v", m.Screen, tt.expectScreen)
-            }
-        })
-    }
-}
-```
-
-### Example 3: Testing Trainer Exercises
-
-```go
-func TestExerciseValidation(t *testing.T) {
-    exercise := &Exercise{
-        Solutions: []string{"w", "W", "e"},
-        Optimal:   "w",
-    }
-
-    tests := []struct {
-        input   string
-        valid   bool
-        optimal bool
-    }{
-        {"w", true, true},
-        {"W", true, false},
-        {"e", true, false},
-        {"x", false, false},
-    }
-
-    for _, tt := range tests {
-        t.Run(tt.input, func(t *testing.T) {
-            valid := ValidateAnswer(exercise, tt.input)
-            optimal := IsOptimalAnswer(exercise, tt.input)
-
-            if valid != tt.valid {
-                t.Errorf("valid = %v, want %v", valid, tt.valid)
-            }
-            if optimal != tt.optimal {
-                t.Errorf("optimal = %v, want %v", optimal, tt.optimal)
-            }
-        })
-    }
-}
-```
-
-### Example 4: Mocking System Info
-
-```go
-func TestWithMockedSystem(t *testing.T) {
-    m := NewModel()
-
-    // Mock system info for testing
-    m.SystemInfo = &system.SystemInfo{
-        OS:       system.OSMac,
-        IsARM:    true,
-        HasBrew:  true,
-        HomeDir:  t.TempDir(),
-    }
-
-    // Now test with controlled environment
-    m.SetupInstallSteps()
-
-    // Verify expected steps
-    hasHomebrew := false
-    for _, step := range m.Steps {
-        if step.ID == "homebrew" {
-            hasHomebrew = true
-        }
-    }
-
-    if hasHomebrew {
-        t.Error("should not have homebrew step when HasBrew=true")
-    }
-}
-```
-
----
-
-## Test File Organization
-
-```
-installer/internal/tui/
-├── model.go
-├── model_test.go           # Model tests
-├── update.go
-├── update_test.go          # Update handler tests
-├── view.go
-├── view_test.go            # View rendering tests
-├── teatest_test.go         # Teatest integration tests
-├── comprehensive_test.go   # Full flow tests
-├── testdata/
-│   ├── TestOSSelectGolden.golden
-│   └── TestViewGolden.golden
-└── trainer/
-    ├── types.go
-    ├── types_test.go
-    ├── exercises.go
-    ├── exercises_test.go
-    └── simulator_test.go
-```
-
----
-
-## Commands
-
-```bash
-go test ./...                           # Run all tests
-go test -v ./internal/tui/...          # Verbose TUI tests
-go test -run TestNavigation             # Run specific test
-go test -cover ./...                    # With coverage
-go test -update ./...                   # Update golden files
-go test -short ./...                    # Skip integration tests
-```
-
----
-
-## Resources
-
-- **TUI Tests**: See `installer/internal/tui/*_test.go`
-- **Trainer Tests**: See `installer/internal/tui/trainer/*_test.go`
-- **System Tests**: See `installer/internal/system/*_test.go`
-- **Golden Files**: See `installer/internal/tui/testdata/`
-- **Teatest Docs**: https://github.com/charmbracelet/bubbletea/tree/master/teatest
+- [references/examples.md](references/examples.md) — compact table-driven, Bubbletea, teatest, golden, and command examples.

--- a/testdata/golden/skills-claude-skill-creator.golden
+++ b/testdata/golden/skills-claude-skill-creator.golden
@@ -1,13 +1,13 @@
 ---
 name: skill-creator
-description: "Create AI agent skills with valid frontmatter. Trigger: new skills, agent instructions, or documenting AI usage patterns."
+description: "Trigger: new skills, agent instructions, documenting AI usage patterns. Create LLM-first skills with valid frontmatter."
 license: Apache-2.0
 metadata:
   author: gentleman-programming
   version: "1.0"
 ---
 
-## When to Create a Skill
+## Activation Contract
 
 Create a skill when:
 - A pattern is used repeatedly and AI needs guidance
@@ -15,14 +15,31 @@ Create a skill when:
 - Complex workflows need step-by-step instructions
 - Decision trees help AI choose the right approach
 
-**Don't create a skill when:**
-- Documentation already exists (create a reference instead)
-- Pattern is trivial or self-explanatory
-- It's a one-off task
+Do not create a skill when the pattern is trivial, one-off, or better served by normal documentation.
 
----
+## Hard Rules
 
-## Skill Structure
+- When working in this repo, first follow `docs/skill-style-guide.md` as the normative source before creating or updating skills.
+- If that guide is unavailable, use the compact inline rules below.
+- A skill is a runtime instruction contract for an LLM, not human documentation.
+- Do not add a `Keywords` section; preserve essential trigger words in `description`.
+- References must point to local files.
+- Keep the skill body concise: target 180–450 tokens, recommended max 700, hard max 1000.
+
+## Decision Gates
+
+| Need | Action |
+|------|--------|
+| Code templates, schemas, fixtures, generated examples | Put them in `assets/` |
+| Conceptual detail, edge cases, existing docs | Put local links in `references/` |
+| Long explanation in `SKILL.md` | Move it to a supporting file |
+| Multiple meaningful paths | Add a compact decision table |
+
+## Execution Steps
+
+1. Check whether `docs/skill-style-guide.md` exists; if it does, apply it before the inline fallback rules.
+2. Confirm the skill does not already exist and the pattern is reusable.
+3. Create or update `skills/{skill-name}/SKILL.md` using this required structure:
 
 ```
 skills/{skill-name}/
@@ -33,97 +50,33 @@ skills/{skill-name}/
 └── references/           # Optional - links to local docs
     └── docs.md           # Points to docs/developer-guide/*.mdx
 ```
-
----
-
-## SKILL.md Template
+4. Use this frontmatter shape:
 
 ```markdown
 ---
 name: {skill-name}
-description: "{What this skill does}. Trigger: {essential trigger words users or agents will say}."
+description: "Trigger: {essential trigger words users or agents will say}. {What this skill does}."
 license: Apache-2.0
 metadata:
   author: gentleman-programming
   version: "1.0"
 ---
-
-## When to Use
-
-{Bullet points of when to use this skill}
-
-## Critical Patterns
-
-{The most important rules - what AI MUST know}
-
-## Code Examples
-
-{Minimal, focused examples}
-
-## Commands
-
-```bash
-{Common commands}
 ```
+5. Write sections in this order: Activation Contract, Hard Rules, Decision Gates, Execution Steps, Output Contract, References.
+6. Register the skill in `AGENTS.md` when it is a project skill.
 
-## Resources
+## Inline Fallback Rules
 
-- **Templates**: See [assets/](assets/) for {description}
-- **Documentation**: See [references/](references/) for local docs
-```
-
----
-
-## Naming Conventions
-
-| Type | Pattern | Examples |
-|------|---------|----------|
-| Generic skill | `{technology}` | `pytest`, `playwright`, `typescript` |
-| Project-specific | `{project}-{component}` | `myapp-api`, `myapp-ui` |
-| Testing skill | `{project}-test-{component}` | `myapp-test-sdk`, `myapp-test-api` |
-| Workflow skill | `{action}-{target}` | `skill-creator`, `jira-task` |
-
----
-
-## Decision: assets/ vs references/
-
-```
-Need code templates?        → assets/
-Need JSON schemas?          → assets/
-Need example configs?       → assets/
-Link to existing docs?      → references/
-Link to external guides?    → references/ (with local path)
-```
-
-**Key Rule**: `references/` should point to LOCAL files, not web URLs.
-
----
-
-## Frontmatter Fields
-
-| Field | Required | Description |
-|-------|----------|-------------|
-| `name` | Yes | Skill identifier (lowercase, hyphens) |
-| `description` | Yes | Single-line, quoted YAML-safe string with what + `Trigger:` |
-| `license` | Yes | Always `Apache-2.0` |
-| `metadata.author` | Yes | `gentleman-programming` |
-| `metadata.version` | Yes | Semantic version as string |
-
-### Description Rules
-
-The `description` field is the skill-loading budget. Treat it as mandatory metadata, not prose.
-
-- MUST be one physical line in frontmatter; never use `>` or `|` block scalars.
-- MUST be YAML-safe: wrap the whole value in quotes and avoid unescaped matching quotes inside it.
-- MUST include `Trigger:` and preserve the essential trigger words users or agents will actually say.
-- SHOULD be <=160 chars; this is preferred for Claude Code skill-list budget.
-- MUST be <=250 chars if a rare skill genuinely needs extra trigger coverage.
-- MUST NOT add `Keywords`; put concise trigger keywords in `description` instead.
+- `description` MUST be one physical line, quoted, YAML-safe, and include essential trigger words first.
+- `description` SHOULD be <=160 chars and MUST be <=250 chars.
+- Frontmatter MUST include `name`, `description`, `license`, `metadata.author`, and `metadata.version`.
+- Use imperative instructions, not tutorials or background prose.
+- Put supporting material in `assets/` or `references/`, not the main skill body.
 
 Good:
 
 ```yaml
-description: "Create Jira tasks in the team format. Trigger: Jira task, ticket, issue, or task creation."
+description: "Trigger: Jira task, ticket, issue, task creation. Create Jira tasks in the team format."
 ```
 
 Bad:
@@ -135,50 +88,14 @@ description: >
 Keywords: jira, task
 ```
 
----
+## Output Contract
 
-## Content Guidelines
+Return:
+- Files created or modified.
+- Whether the repo style guide or inline fallback rules were used.
+- Any AGENTS.md registration change.
+- Any supporting files added under `assets/` or `references/`.
 
-### DO
-- Start with the most critical patterns
-- Use tables for decision trees
-- Keep code examples minimal and focused
-- Include Commands section with copy-paste commands
-- Keep frontmatter descriptions concise with essential trigger keywords
+## References
 
-### DON'T
-- Add Keywords section (agent searches frontmatter, not body)
-- Use multiline, unquoted, or block-scalar frontmatter descriptions
-- Duplicate content from existing docs (reference instead)
-- Include lengthy explanations (link to docs)
-- Add troubleshooting sections (keep focused)
-- Use web URLs in references (use local paths)
-
----
-
-## Registering the Skill
-
-After creating the skill, add it to `AGENTS.md`:
-
-```markdown
-| `{skill-name}` | {Description} | [SKILL.md](skills/{skill-name}/SKILL.md) |
-```
-
----
-
-## Checklist Before Creating
-
-- [ ] Skill doesn't already exist (check `skills/`)
-- [ ] Pattern is reusable (not one-off)
-- [ ] Name follows conventions
-- [ ] Frontmatter is complete (description is quoted, one-line, YAML-safe, includes `Trigger:`)
-- [ ] Description is ideally <=160 chars and never >250 chars
-- [ ] Description preserves essential trigger words; no `Keywords` section added
-- [ ] Critical patterns are clear
-- [ ] Code examples are minimal
-- [ ] Commands section exists
-- [ ] Added to AGENTS.md
-
-## Resources
-
-- **Templates**: See [assets/](assets/) for SKILL.md template
+- `docs/skill-style-guide.md` — normative LLM-first skill style guide for this repo.

--- a/testdata/golden/skills-kiro-go-testing.golden
+++ b/testdata/golden/skills-kiro-go-testing.golden
@@ -1,353 +1,51 @@
 ---
 name: go-testing
-description: "Write Go tests, including Bubbletea TUI tests. Trigger: Go test coverage, teatest, or test patterns."
+description: "Trigger: Go tests, go test coverage, Bubbletea teatest, golden files. Apply focused Go testing patterns."
 license: Apache-2.0
 metadata:
   author: gentleman-programming
   version: "1.0"
 ---
 
-## When to Use
+## Activation Contract
 
-Use this skill when:
-- Writing Go unit tests
-- Testing Bubbletea TUI components
-- Creating table-driven tests
-- Adding integration tests
-- Using golden file testing
+Load this skill when writing or reviewing Go tests, adding coverage, testing Bubbletea/TUI flows, using `teatest`, or updating golden files.
 
----
+## Hard Rules
 
-## Critical Patterns
+- Prefer table-driven tests for multiple cases; use `t.Run(tt.name, ...)`.
+- Test behavior and state transitions, not implementation trivia.
+- Use `t.TempDir()` for filesystem tests; never rely on a real home directory.
+- Keep integration tests skippable with `testing.Short()` when they run external commands or slow flows.
+- For Bubbletea, test `Model.Update()` directly for state changes; use `teatest` only for interactive flows.
+- Golden files must be deterministic; update only through the repo's `-update` path and rerun tests without `-update`.
+- Use small mocks/interfaces around system or command execution boundaries.
 
-### Pattern 1: Table-Driven Tests
+## Decision Gates
 
-Standard Go pattern for multiple test cases:
+| Target | Test pattern |
+|---|---|
+| Pure function or parser | Table-driven unit test. |
+| Error behavior | Explicit success and failure cases. |
+| File operations | `t.TempDir()` plus focused assertions. |
+| TUI state transition | Direct `Model.Update()` call with `tea.Msg`. |
+| Full TUI interaction | `teatest.NewTestModel()`. |
+| Rendered output | Golden file test. |
+| Real external command | Integration test; skip in `-short`. |
 
-```go
-func TestSomething(t *testing.T) {
-    tests := []struct {
-        name     string
-        input    string
-        expected string
-        wantErr  bool
-    }{
-        {
-            name:     "valid input",
-            input:    "hello",
-            expected: "HELLO",
-            wantErr:  false,
-        },
-        {
-            name:     "empty input",
-            input:    "",
-            expected: "",
-            wantErr:  true,
-        },
-    }
+## Execution Steps
 
-    for _, tt := range tests {
-        t.Run(tt.name, func(t *testing.T) {
-            result, err := ProcessInput(tt.input)
+1. Identify behavior under test and the smallest public boundary that proves it.
+2. Choose the test pattern from the decision gate.
+3. Name cases by scenario, not input mechanics.
+4. Assert outputs, errors, state, and side effects explicitly.
+5. Run the narrow package test first, then the relevant broader suite.
+6. For golden updates: run with `-update`, inspect diff, then rerun without `-update`.
 
-            if (err != nil) != tt.wantErr {
-                t.Errorf("error = %v, wantErr %v", err, tt.wantErr)
-                return
-            }
+## Output Contract
 
-            if result != tt.expected {
-                t.Errorf("got %q, want %q", result, tt.expected)
-            }
-        })
-    }
-}
-```
+Report test files changed, scenarios covered, commands executed, golden files updated, and any skipped integration scope.
 
-### Pattern 2: Bubbletea Model Testing
+## References
 
-Test Model state transitions directly:
-
-```go
-func TestModelUpdate(t *testing.T) {
-    m := NewModel()
-
-    // Simulate key press
-    newModel, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
-    m = newModel.(Model)
-
-    if m.Screen != ScreenMainMenu {
-        t.Errorf("expected ScreenMainMenu, got %v", m.Screen)
-    }
-}
-```
-
-### Pattern 3: Teatest Integration Tests
-
-Use Charmbracelet's teatest for TUI testing:
-
-```go
-func TestInteractiveFlow(t *testing.T) {
-    m := NewModel()
-    tm := teatest.NewTestModel(t, m)
-
-    // Send keys
-    tm.Send(tea.KeyMsg{Type: tea.KeyEnter})
-    tm.Send(tea.KeyMsg{Type: tea.KeyDown})
-    tm.Send(tea.KeyMsg{Type: tea.KeyEnter})
-
-    // Wait for model to update
-    tm.WaitFinished(t, teatest.WithDuration(time.Second))
-
-    // Get final model
-    finalModel := tm.FinalModel(t).(Model)
-
-    if finalModel.Screen != ExpectedScreen {
-        t.Errorf("wrong screen: got %v", finalModel.Screen)
-    }
-}
-```
-
-### Pattern 4: Golden File Testing
-
-Compare output against saved "golden" files:
-
-```go
-func TestOSSelectGolden(t *testing.T) {
-    m := NewModel()
-    m.Screen = ScreenOSSelect
-    m.Width = 80
-    m.Height = 24
-
-    output := m.View()
-
-    golden := filepath.Join("testdata", "TestOSSelectGolden.golden")
-
-    if *update {
-        os.WriteFile(golden, []byte(output), 0644)
-    }
-
-    expected, _ := os.ReadFile(golden)
-    if output != string(expected) {
-        t.Errorf("output doesn't match golden file")
-    }
-}
-```
-
----
-
-## Decision Tree
-
-```
-Testing a function?
-├── Pure function? → Table-driven test
-├── Has side effects? → Mock dependencies
-├── Returns error? → Test both success and error cases
-└── Complex logic? → Break into smaller testable units
-
-Testing TUI component?
-├── State change? → Test Model.Update() directly
-├── Full flow? → Use teatest.NewTestModel()
-├── Visual output? → Use golden file testing
-└── Key handling? → Send tea.KeyMsg
-
-Testing system/exec?
-├── Mock os/exec? → Use interface + mock
-├── Real commands? → Integration test with --short skip
-└── File operations? → Use t.TempDir()
-```
-
----
-
-## Code Examples
-
-### Example 1: Testing Key Navigation
-
-```go
-func TestCursorNavigation(t *testing.T) {
-    tests := []struct {
-        name       string
-        startPos   int
-        key        string
-        endPos     int
-        numOptions int
-    }{
-        {"down from 0", 0, "j", 1, 5},
-        {"up from 1", 1, "k", 0, 5},
-        {"down at bottom", 4, "j", 4, 5}, // stays at bottom
-        {"up at top", 0, "k", 0, 5},       // stays at top
-    }
-
-    for _, tt := range tests {
-        t.Run(tt.name, func(t *testing.T) {
-            m := NewModel()
-            m.Cursor = tt.startPos
-            // Set up options...
-
-            newModel, _ := m.Update(tea.KeyMsg{
-                Type:  tea.KeyRunes,
-                Runes: []rune(tt.key),
-            })
-            m = newModel.(Model)
-
-            if m.Cursor != tt.endPos {
-                t.Errorf("cursor = %d, want %d", m.Cursor, tt.endPos)
-            }
-        })
-    }
-}
-```
-
-### Example 2: Testing Screen Transitions
-
-```go
-func TestScreenTransitions(t *testing.T) {
-    tests := []struct {
-        name         string
-        startScreen  Screen
-        action       tea.Msg
-        expectScreen Screen
-    }{
-        {
-            name:         "welcome to main menu",
-            startScreen:  ScreenWelcome,
-            action:       tea.KeyMsg{Type: tea.KeyEnter},
-            expectScreen: ScreenMainMenu,
-        },
-        {
-            name:         "escape from OS select",
-            startScreen:  ScreenOSSelect,
-            action:       tea.KeyMsg{Type: tea.KeyEsc},
-            expectScreen: ScreenMainMenu,
-        },
-    }
-
-    for _, tt := range tests {
-        t.Run(tt.name, func(t *testing.T) {
-            m := NewModel()
-            m.Screen = tt.startScreen
-
-            newModel, _ := m.Update(tt.action)
-            m = newModel.(Model)
-
-            if m.Screen != tt.expectScreen {
-                t.Errorf("screen = %v, want %v", m.Screen, tt.expectScreen)
-            }
-        })
-    }
-}
-```
-
-### Example 3: Testing Trainer Exercises
-
-```go
-func TestExerciseValidation(t *testing.T) {
-    exercise := &Exercise{
-        Solutions: []string{"w", "W", "e"},
-        Optimal:   "w",
-    }
-
-    tests := []struct {
-        input   string
-        valid   bool
-        optimal bool
-    }{
-        {"w", true, true},
-        {"W", true, false},
-        {"e", true, false},
-        {"x", false, false},
-    }
-
-    for _, tt := range tests {
-        t.Run(tt.input, func(t *testing.T) {
-            valid := ValidateAnswer(exercise, tt.input)
-            optimal := IsOptimalAnswer(exercise, tt.input)
-
-            if valid != tt.valid {
-                t.Errorf("valid = %v, want %v", valid, tt.valid)
-            }
-            if optimal != tt.optimal {
-                t.Errorf("optimal = %v, want %v", optimal, tt.optimal)
-            }
-        })
-    }
-}
-```
-
-### Example 4: Mocking System Info
-
-```go
-func TestWithMockedSystem(t *testing.T) {
-    m := NewModel()
-
-    // Mock system info for testing
-    m.SystemInfo = &system.SystemInfo{
-        OS:       system.OSMac,
-        IsARM:    true,
-        HasBrew:  true,
-        HomeDir:  t.TempDir(),
-    }
-
-    // Now test with controlled environment
-    m.SetupInstallSteps()
-
-    // Verify expected steps
-    hasHomebrew := false
-    for _, step := range m.Steps {
-        if step.ID == "homebrew" {
-            hasHomebrew = true
-        }
-    }
-
-    if hasHomebrew {
-        t.Error("should not have homebrew step when HasBrew=true")
-    }
-}
-```
-
----
-
-## Test File Organization
-
-```
-installer/internal/tui/
-├── model.go
-├── model_test.go           # Model tests
-├── update.go
-├── update_test.go          # Update handler tests
-├── view.go
-├── view_test.go            # View rendering tests
-├── teatest_test.go         # Teatest integration tests
-├── comprehensive_test.go   # Full flow tests
-├── testdata/
-│   ├── TestOSSelectGolden.golden
-│   └── TestViewGolden.golden
-└── trainer/
-    ├── types.go
-    ├── types_test.go
-    ├── exercises.go
-    ├── exercises_test.go
-    └── simulator_test.go
-```
-
----
-
-## Commands
-
-```bash
-go test ./...                           # Run all tests
-go test -v ./internal/tui/...          # Verbose TUI tests
-go test -run TestNavigation             # Run specific test
-go test -cover ./...                    # With coverage
-go test -update ./...                   # Update golden files
-go test -short ./...                    # Skip integration tests
-```
-
----
-
-## Resources
-
-- **TUI Tests**: See `installer/internal/tui/*_test.go`
-- **Trainer Tests**: See `installer/internal/tui/trainer/*_test.go`
-- **System Tests**: See `installer/internal/system/*_test.go`
-- **Golden Files**: See `installer/internal/tui/testdata/`
-- **Teatest Docs**: https://github.com/charmbracelet/bubbletea/tree/master/teatest
+- [references/examples.md](references/examples.md) — compact table-driven, Bubbletea, teatest, golden, and command examples.

--- a/testdata/golden/skills-kiro-skill-creator.golden
+++ b/testdata/golden/skills-kiro-skill-creator.golden
@@ -1,13 +1,13 @@
 ---
 name: skill-creator
-description: "Create AI agent skills with valid frontmatter. Trigger: new skills, agent instructions, or documenting AI usage patterns."
+description: "Trigger: new skills, agent instructions, documenting AI usage patterns. Create LLM-first skills with valid frontmatter."
 license: Apache-2.0
 metadata:
   author: gentleman-programming
   version: "1.0"
 ---
 
-## When to Create a Skill
+## Activation Contract
 
 Create a skill when:
 - A pattern is used repeatedly and AI needs guidance
@@ -15,14 +15,31 @@ Create a skill when:
 - Complex workflows need step-by-step instructions
 - Decision trees help AI choose the right approach
 
-**Don't create a skill when:**
-- Documentation already exists (create a reference instead)
-- Pattern is trivial or self-explanatory
-- It's a one-off task
+Do not create a skill when the pattern is trivial, one-off, or better served by normal documentation.
 
----
+## Hard Rules
 
-## Skill Structure
+- When working in this repo, first follow `docs/skill-style-guide.md` as the normative source before creating or updating skills.
+- If that guide is unavailable, use the compact inline rules below.
+- A skill is a runtime instruction contract for an LLM, not human documentation.
+- Do not add a `Keywords` section; preserve essential trigger words in `description`.
+- References must point to local files.
+- Keep the skill body concise: target 180–450 tokens, recommended max 700, hard max 1000.
+
+## Decision Gates
+
+| Need | Action |
+|------|--------|
+| Code templates, schemas, fixtures, generated examples | Put them in `assets/` |
+| Conceptual detail, edge cases, existing docs | Put local links in `references/` |
+| Long explanation in `SKILL.md` | Move it to a supporting file |
+| Multiple meaningful paths | Add a compact decision table |
+
+## Execution Steps
+
+1. Check whether `docs/skill-style-guide.md` exists; if it does, apply it before the inline fallback rules.
+2. Confirm the skill does not already exist and the pattern is reusable.
+3. Create or update `skills/{skill-name}/SKILL.md` using this required structure:
 
 ```
 skills/{skill-name}/
@@ -33,97 +50,33 @@ skills/{skill-name}/
 └── references/           # Optional - links to local docs
     └── docs.md           # Points to docs/developer-guide/*.mdx
 ```
-
----
-
-## SKILL.md Template
+4. Use this frontmatter shape:
 
 ```markdown
 ---
 name: {skill-name}
-description: "{What this skill does}. Trigger: {essential trigger words users or agents will say}."
+description: "Trigger: {essential trigger words users or agents will say}. {What this skill does}."
 license: Apache-2.0
 metadata:
   author: gentleman-programming
   version: "1.0"
 ---
-
-## When to Use
-
-{Bullet points of when to use this skill}
-
-## Critical Patterns
-
-{The most important rules - what AI MUST know}
-
-## Code Examples
-
-{Minimal, focused examples}
-
-## Commands
-
-```bash
-{Common commands}
 ```
+5. Write sections in this order: Activation Contract, Hard Rules, Decision Gates, Execution Steps, Output Contract, References.
+6. Register the skill in `AGENTS.md` when it is a project skill.
 
-## Resources
+## Inline Fallback Rules
 
-- **Templates**: See [assets/](assets/) for {description}
-- **Documentation**: See [references/](references/) for local docs
-```
-
----
-
-## Naming Conventions
-
-| Type | Pattern | Examples |
-|------|---------|----------|
-| Generic skill | `{technology}` | `pytest`, `playwright`, `typescript` |
-| Project-specific | `{project}-{component}` | `myapp-api`, `myapp-ui` |
-| Testing skill | `{project}-test-{component}` | `myapp-test-sdk`, `myapp-test-api` |
-| Workflow skill | `{action}-{target}` | `skill-creator`, `jira-task` |
-
----
-
-## Decision: assets/ vs references/
-
-```
-Need code templates?        → assets/
-Need JSON schemas?          → assets/
-Need example configs?       → assets/
-Link to existing docs?      → references/
-Link to external guides?    → references/ (with local path)
-```
-
-**Key Rule**: `references/` should point to LOCAL files, not web URLs.
-
----
-
-## Frontmatter Fields
-
-| Field | Required | Description |
-|-------|----------|-------------|
-| `name` | Yes | Skill identifier (lowercase, hyphens) |
-| `description` | Yes | Single-line, quoted YAML-safe string with what + `Trigger:` |
-| `license` | Yes | Always `Apache-2.0` |
-| `metadata.author` | Yes | `gentleman-programming` |
-| `metadata.version` | Yes | Semantic version as string |
-
-### Description Rules
-
-The `description` field is the skill-loading budget. Treat it as mandatory metadata, not prose.
-
-- MUST be one physical line in frontmatter; never use `>` or `|` block scalars.
-- MUST be YAML-safe: wrap the whole value in quotes and avoid unescaped matching quotes inside it.
-- MUST include `Trigger:` and preserve the essential trigger words users or agents will actually say.
-- SHOULD be <=160 chars; this is preferred for Claude Code skill-list budget.
-- MUST be <=250 chars if a rare skill genuinely needs extra trigger coverage.
-- MUST NOT add `Keywords`; put concise trigger keywords in `description` instead.
+- `description` MUST be one physical line, quoted, YAML-safe, and include essential trigger words first.
+- `description` SHOULD be <=160 chars and MUST be <=250 chars.
+- Frontmatter MUST include `name`, `description`, `license`, `metadata.author`, and `metadata.version`.
+- Use imperative instructions, not tutorials or background prose.
+- Put supporting material in `assets/` or `references/`, not the main skill body.
 
 Good:
 
 ```yaml
-description: "Create Jira tasks in the team format. Trigger: Jira task, ticket, issue, or task creation."
+description: "Trigger: Jira task, ticket, issue, task creation. Create Jira tasks in the team format."
 ```
 
 Bad:
@@ -135,50 +88,14 @@ description: >
 Keywords: jira, task
 ```
 
----
+## Output Contract
 
-## Content Guidelines
+Return:
+- Files created or modified.
+- Whether the repo style guide or inline fallback rules were used.
+- Any AGENTS.md registration change.
+- Any supporting files added under `assets/` or `references/`.
 
-### DO
-- Start with the most critical patterns
-- Use tables for decision trees
-- Keep code examples minimal and focused
-- Include Commands section with copy-paste commands
-- Keep frontmatter descriptions concise with essential trigger keywords
+## References
 
-### DON'T
-- Add Keywords section (agent searches frontmatter, not body)
-- Use multiline, unquoted, or block-scalar frontmatter descriptions
-- Duplicate content from existing docs (reference instead)
-- Include lengthy explanations (link to docs)
-- Add troubleshooting sections (keep focused)
-- Use web URLs in references (use local paths)
-
----
-
-## Registering the Skill
-
-After creating the skill, add it to `AGENTS.md`:
-
-```markdown
-| `{skill-name}` | {Description} | [SKILL.md](skills/{skill-name}/SKILL.md) |
-```
-
----
-
-## Checklist Before Creating
-
-- [ ] Skill doesn't already exist (check `skills/`)
-- [ ] Pattern is reusable (not one-off)
-- [ ] Name follows conventions
-- [ ] Frontmatter is complete (description is quoted, one-line, YAML-safe, includes `Trigger:`)
-- [ ] Description is ideally <=160 chars and never >250 chars
-- [ ] Description preserves essential trigger words; no `Keywords` section added
-- [ ] Critical patterns are clear
-- [ ] Code examples are minimal
-- [ ] Commands section exists
-- [ ] Added to AGENTS.md
-
-## Resources
-
-- **Templates**: See [assets/](assets/) for SKILL.md template
+- `docs/skill-style-guide.md` — normative LLM-first skill style guide for this repo.

--- a/testdata/golden/skills-opencode-go-testing.golden
+++ b/testdata/golden/skills-opencode-go-testing.golden
@@ -1,353 +1,51 @@
 ---
 name: go-testing
-description: "Write Go tests, including Bubbletea TUI tests. Trigger: Go test coverage, teatest, or test patterns."
+description: "Trigger: Go tests, go test coverage, Bubbletea teatest, golden files. Apply focused Go testing patterns."
 license: Apache-2.0
 metadata:
   author: gentleman-programming
   version: "1.0"
 ---
 
-## When to Use
+## Activation Contract
 
-Use this skill when:
-- Writing Go unit tests
-- Testing Bubbletea TUI components
-- Creating table-driven tests
-- Adding integration tests
-- Using golden file testing
+Load this skill when writing or reviewing Go tests, adding coverage, testing Bubbletea/TUI flows, using `teatest`, or updating golden files.
 
----
+## Hard Rules
 
-## Critical Patterns
+- Prefer table-driven tests for multiple cases; use `t.Run(tt.name, ...)`.
+- Test behavior and state transitions, not implementation trivia.
+- Use `t.TempDir()` for filesystem tests; never rely on a real home directory.
+- Keep integration tests skippable with `testing.Short()` when they run external commands or slow flows.
+- For Bubbletea, test `Model.Update()` directly for state changes; use `teatest` only for interactive flows.
+- Golden files must be deterministic; update only through the repo's `-update` path and rerun tests without `-update`.
+- Use small mocks/interfaces around system or command execution boundaries.
 
-### Pattern 1: Table-Driven Tests
+## Decision Gates
 
-Standard Go pattern for multiple test cases:
+| Target | Test pattern |
+|---|---|
+| Pure function or parser | Table-driven unit test. |
+| Error behavior | Explicit success and failure cases. |
+| File operations | `t.TempDir()` plus focused assertions. |
+| TUI state transition | Direct `Model.Update()` call with `tea.Msg`. |
+| Full TUI interaction | `teatest.NewTestModel()`. |
+| Rendered output | Golden file test. |
+| Real external command | Integration test; skip in `-short`. |
 
-```go
-func TestSomething(t *testing.T) {
-    tests := []struct {
-        name     string
-        input    string
-        expected string
-        wantErr  bool
-    }{
-        {
-            name:     "valid input",
-            input:    "hello",
-            expected: "HELLO",
-            wantErr:  false,
-        },
-        {
-            name:     "empty input",
-            input:    "",
-            expected: "",
-            wantErr:  true,
-        },
-    }
+## Execution Steps
 
-    for _, tt := range tests {
-        t.Run(tt.name, func(t *testing.T) {
-            result, err := ProcessInput(tt.input)
+1. Identify behavior under test and the smallest public boundary that proves it.
+2. Choose the test pattern from the decision gate.
+3. Name cases by scenario, not input mechanics.
+4. Assert outputs, errors, state, and side effects explicitly.
+5. Run the narrow package test first, then the relevant broader suite.
+6. For golden updates: run with `-update`, inspect diff, then rerun without `-update`.
 
-            if (err != nil) != tt.wantErr {
-                t.Errorf("error = %v, wantErr %v", err, tt.wantErr)
-                return
-            }
+## Output Contract
 
-            if result != tt.expected {
-                t.Errorf("got %q, want %q", result, tt.expected)
-            }
-        })
-    }
-}
-```
+Report test files changed, scenarios covered, commands executed, golden files updated, and any skipped integration scope.
 
-### Pattern 2: Bubbletea Model Testing
+## References
 
-Test Model state transitions directly:
-
-```go
-func TestModelUpdate(t *testing.T) {
-    m := NewModel()
-
-    // Simulate key press
-    newModel, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
-    m = newModel.(Model)
-
-    if m.Screen != ScreenMainMenu {
-        t.Errorf("expected ScreenMainMenu, got %v", m.Screen)
-    }
-}
-```
-
-### Pattern 3: Teatest Integration Tests
-
-Use Charmbracelet's teatest for TUI testing:
-
-```go
-func TestInteractiveFlow(t *testing.T) {
-    m := NewModel()
-    tm := teatest.NewTestModel(t, m)
-
-    // Send keys
-    tm.Send(tea.KeyMsg{Type: tea.KeyEnter})
-    tm.Send(tea.KeyMsg{Type: tea.KeyDown})
-    tm.Send(tea.KeyMsg{Type: tea.KeyEnter})
-
-    // Wait for model to update
-    tm.WaitFinished(t, teatest.WithDuration(time.Second))
-
-    // Get final model
-    finalModel := tm.FinalModel(t).(Model)
-
-    if finalModel.Screen != ExpectedScreen {
-        t.Errorf("wrong screen: got %v", finalModel.Screen)
-    }
-}
-```
-
-### Pattern 4: Golden File Testing
-
-Compare output against saved "golden" files:
-
-```go
-func TestOSSelectGolden(t *testing.T) {
-    m := NewModel()
-    m.Screen = ScreenOSSelect
-    m.Width = 80
-    m.Height = 24
-
-    output := m.View()
-
-    golden := filepath.Join("testdata", "TestOSSelectGolden.golden")
-
-    if *update {
-        os.WriteFile(golden, []byte(output), 0644)
-    }
-
-    expected, _ := os.ReadFile(golden)
-    if output != string(expected) {
-        t.Errorf("output doesn't match golden file")
-    }
-}
-```
-
----
-
-## Decision Tree
-
-```
-Testing a function?
-├── Pure function? → Table-driven test
-├── Has side effects? → Mock dependencies
-├── Returns error? → Test both success and error cases
-└── Complex logic? → Break into smaller testable units
-
-Testing TUI component?
-├── State change? → Test Model.Update() directly
-├── Full flow? → Use teatest.NewTestModel()
-├── Visual output? → Use golden file testing
-└── Key handling? → Send tea.KeyMsg
-
-Testing system/exec?
-├── Mock os/exec? → Use interface + mock
-├── Real commands? → Integration test with --short skip
-└── File operations? → Use t.TempDir()
-```
-
----
-
-## Code Examples
-
-### Example 1: Testing Key Navigation
-
-```go
-func TestCursorNavigation(t *testing.T) {
-    tests := []struct {
-        name       string
-        startPos   int
-        key        string
-        endPos     int
-        numOptions int
-    }{
-        {"down from 0", 0, "j", 1, 5},
-        {"up from 1", 1, "k", 0, 5},
-        {"down at bottom", 4, "j", 4, 5}, // stays at bottom
-        {"up at top", 0, "k", 0, 5},       // stays at top
-    }
-
-    for _, tt := range tests {
-        t.Run(tt.name, func(t *testing.T) {
-            m := NewModel()
-            m.Cursor = tt.startPos
-            // Set up options...
-
-            newModel, _ := m.Update(tea.KeyMsg{
-                Type:  tea.KeyRunes,
-                Runes: []rune(tt.key),
-            })
-            m = newModel.(Model)
-
-            if m.Cursor != tt.endPos {
-                t.Errorf("cursor = %d, want %d", m.Cursor, tt.endPos)
-            }
-        })
-    }
-}
-```
-
-### Example 2: Testing Screen Transitions
-
-```go
-func TestScreenTransitions(t *testing.T) {
-    tests := []struct {
-        name         string
-        startScreen  Screen
-        action       tea.Msg
-        expectScreen Screen
-    }{
-        {
-            name:         "welcome to main menu",
-            startScreen:  ScreenWelcome,
-            action:       tea.KeyMsg{Type: tea.KeyEnter},
-            expectScreen: ScreenMainMenu,
-        },
-        {
-            name:         "escape from OS select",
-            startScreen:  ScreenOSSelect,
-            action:       tea.KeyMsg{Type: tea.KeyEsc},
-            expectScreen: ScreenMainMenu,
-        },
-    }
-
-    for _, tt := range tests {
-        t.Run(tt.name, func(t *testing.T) {
-            m := NewModel()
-            m.Screen = tt.startScreen
-
-            newModel, _ := m.Update(tt.action)
-            m = newModel.(Model)
-
-            if m.Screen != tt.expectScreen {
-                t.Errorf("screen = %v, want %v", m.Screen, tt.expectScreen)
-            }
-        })
-    }
-}
-```
-
-### Example 3: Testing Trainer Exercises
-
-```go
-func TestExerciseValidation(t *testing.T) {
-    exercise := &Exercise{
-        Solutions: []string{"w", "W", "e"},
-        Optimal:   "w",
-    }
-
-    tests := []struct {
-        input   string
-        valid   bool
-        optimal bool
-    }{
-        {"w", true, true},
-        {"W", true, false},
-        {"e", true, false},
-        {"x", false, false},
-    }
-
-    for _, tt := range tests {
-        t.Run(tt.input, func(t *testing.T) {
-            valid := ValidateAnswer(exercise, tt.input)
-            optimal := IsOptimalAnswer(exercise, tt.input)
-
-            if valid != tt.valid {
-                t.Errorf("valid = %v, want %v", valid, tt.valid)
-            }
-            if optimal != tt.optimal {
-                t.Errorf("optimal = %v, want %v", optimal, tt.optimal)
-            }
-        })
-    }
-}
-```
-
-### Example 4: Mocking System Info
-
-```go
-func TestWithMockedSystem(t *testing.T) {
-    m := NewModel()
-
-    // Mock system info for testing
-    m.SystemInfo = &system.SystemInfo{
-        OS:       system.OSMac,
-        IsARM:    true,
-        HasBrew:  true,
-        HomeDir:  t.TempDir(),
-    }
-
-    // Now test with controlled environment
-    m.SetupInstallSteps()
-
-    // Verify expected steps
-    hasHomebrew := false
-    for _, step := range m.Steps {
-        if step.ID == "homebrew" {
-            hasHomebrew = true
-        }
-    }
-
-    if hasHomebrew {
-        t.Error("should not have homebrew step when HasBrew=true")
-    }
-}
-```
-
----
-
-## Test File Organization
-
-```
-installer/internal/tui/
-├── model.go
-├── model_test.go           # Model tests
-├── update.go
-├── update_test.go          # Update handler tests
-├── view.go
-├── view_test.go            # View rendering tests
-├── teatest_test.go         # Teatest integration tests
-├── comprehensive_test.go   # Full flow tests
-├── testdata/
-│   ├── TestOSSelectGolden.golden
-│   └── TestViewGolden.golden
-└── trainer/
-    ├── types.go
-    ├── types_test.go
-    ├── exercises.go
-    ├── exercises_test.go
-    └── simulator_test.go
-```
-
----
-
-## Commands
-
-```bash
-go test ./...                           # Run all tests
-go test -v ./internal/tui/...          # Verbose TUI tests
-go test -run TestNavigation             # Run specific test
-go test -cover ./...                    # With coverage
-go test -update ./...                   # Update golden files
-go test -short ./...                    # Skip integration tests
-```
-
----
-
-## Resources
-
-- **TUI Tests**: See `installer/internal/tui/*_test.go`
-- **Trainer Tests**: See `installer/internal/tui/trainer/*_test.go`
-- **System Tests**: See `installer/internal/system/*_test.go`
-- **Golden Files**: See `installer/internal/tui/testdata/`
-- **Teatest Docs**: https://github.com/charmbracelet/bubbletea/tree/master/teatest
+- [references/examples.md](references/examples.md) — compact table-driven, Bubbletea, teatest, golden, and command examples.

--- a/testdata/golden/skills-opencode-skill-creator.golden
+++ b/testdata/golden/skills-opencode-skill-creator.golden
@@ -1,13 +1,13 @@
 ---
 name: skill-creator
-description: "Create AI agent skills with valid frontmatter. Trigger: new skills, agent instructions, or documenting AI usage patterns."
+description: "Trigger: new skills, agent instructions, documenting AI usage patterns. Create LLM-first skills with valid frontmatter."
 license: Apache-2.0
 metadata:
   author: gentleman-programming
   version: "1.0"
 ---
 
-## When to Create a Skill
+## Activation Contract
 
 Create a skill when:
 - A pattern is used repeatedly and AI needs guidance
@@ -15,14 +15,31 @@ Create a skill when:
 - Complex workflows need step-by-step instructions
 - Decision trees help AI choose the right approach
 
-**Don't create a skill when:**
-- Documentation already exists (create a reference instead)
-- Pattern is trivial or self-explanatory
-- It's a one-off task
+Do not create a skill when the pattern is trivial, one-off, or better served by normal documentation.
 
----
+## Hard Rules
 
-## Skill Structure
+- When working in this repo, first follow `docs/skill-style-guide.md` as the normative source before creating or updating skills.
+- If that guide is unavailable, use the compact inline rules below.
+- A skill is a runtime instruction contract for an LLM, not human documentation.
+- Do not add a `Keywords` section; preserve essential trigger words in `description`.
+- References must point to local files.
+- Keep the skill body concise: target 180–450 tokens, recommended max 700, hard max 1000.
+
+## Decision Gates
+
+| Need | Action |
+|------|--------|
+| Code templates, schemas, fixtures, generated examples | Put them in `assets/` |
+| Conceptual detail, edge cases, existing docs | Put local links in `references/` |
+| Long explanation in `SKILL.md` | Move it to a supporting file |
+| Multiple meaningful paths | Add a compact decision table |
+
+## Execution Steps
+
+1. Check whether `docs/skill-style-guide.md` exists; if it does, apply it before the inline fallback rules.
+2. Confirm the skill does not already exist and the pattern is reusable.
+3. Create or update `skills/{skill-name}/SKILL.md` using this required structure:
 
 ```
 skills/{skill-name}/
@@ -33,97 +50,33 @@ skills/{skill-name}/
 └── references/           # Optional - links to local docs
     └── docs.md           # Points to docs/developer-guide/*.mdx
 ```
-
----
-
-## SKILL.md Template
+4. Use this frontmatter shape:
 
 ```markdown
 ---
 name: {skill-name}
-description: "{What this skill does}. Trigger: {essential trigger words users or agents will say}."
+description: "Trigger: {essential trigger words users or agents will say}. {What this skill does}."
 license: Apache-2.0
 metadata:
   author: gentleman-programming
   version: "1.0"
 ---
-
-## When to Use
-
-{Bullet points of when to use this skill}
-
-## Critical Patterns
-
-{The most important rules - what AI MUST know}
-
-## Code Examples
-
-{Minimal, focused examples}
-
-## Commands
-
-```bash
-{Common commands}
 ```
+5. Write sections in this order: Activation Contract, Hard Rules, Decision Gates, Execution Steps, Output Contract, References.
+6. Register the skill in `AGENTS.md` when it is a project skill.
 
-## Resources
+## Inline Fallback Rules
 
-- **Templates**: See [assets/](assets/) for {description}
-- **Documentation**: See [references/](references/) for local docs
-```
-
----
-
-## Naming Conventions
-
-| Type | Pattern | Examples |
-|------|---------|----------|
-| Generic skill | `{technology}` | `pytest`, `playwright`, `typescript` |
-| Project-specific | `{project}-{component}` | `myapp-api`, `myapp-ui` |
-| Testing skill | `{project}-test-{component}` | `myapp-test-sdk`, `myapp-test-api` |
-| Workflow skill | `{action}-{target}` | `skill-creator`, `jira-task` |
-
----
-
-## Decision: assets/ vs references/
-
-```
-Need code templates?        → assets/
-Need JSON schemas?          → assets/
-Need example configs?       → assets/
-Link to existing docs?      → references/
-Link to external guides?    → references/ (with local path)
-```
-
-**Key Rule**: `references/` should point to LOCAL files, not web URLs.
-
----
-
-## Frontmatter Fields
-
-| Field | Required | Description |
-|-------|----------|-------------|
-| `name` | Yes | Skill identifier (lowercase, hyphens) |
-| `description` | Yes | Single-line, quoted YAML-safe string with what + `Trigger:` |
-| `license` | Yes | Always `Apache-2.0` |
-| `metadata.author` | Yes | `gentleman-programming` |
-| `metadata.version` | Yes | Semantic version as string |
-
-### Description Rules
-
-The `description` field is the skill-loading budget. Treat it as mandatory metadata, not prose.
-
-- MUST be one physical line in frontmatter; never use `>` or `|` block scalars.
-- MUST be YAML-safe: wrap the whole value in quotes and avoid unescaped matching quotes inside it.
-- MUST include `Trigger:` and preserve the essential trigger words users or agents will actually say.
-- SHOULD be <=160 chars; this is preferred for Claude Code skill-list budget.
-- MUST be <=250 chars if a rare skill genuinely needs extra trigger coverage.
-- MUST NOT add `Keywords`; put concise trigger keywords in `description` instead.
+- `description` MUST be one physical line, quoted, YAML-safe, and include essential trigger words first.
+- `description` SHOULD be <=160 chars and MUST be <=250 chars.
+- Frontmatter MUST include `name`, `description`, `license`, `metadata.author`, and `metadata.version`.
+- Use imperative instructions, not tutorials or background prose.
+- Put supporting material in `assets/` or `references/`, not the main skill body.
 
 Good:
 
 ```yaml
-description: "Create Jira tasks in the team format. Trigger: Jira task, ticket, issue, or task creation."
+description: "Trigger: Jira task, ticket, issue, task creation. Create Jira tasks in the team format."
 ```
 
 Bad:
@@ -135,50 +88,14 @@ description: >
 Keywords: jira, task
 ```
 
----
+## Output Contract
 
-## Content Guidelines
+Return:
+- Files created or modified.
+- Whether the repo style guide or inline fallback rules were used.
+- Any AGENTS.md registration change.
+- Any supporting files added under `assets/` or `references/`.
 
-### DO
-- Start with the most critical patterns
-- Use tables for decision trees
-- Keep code examples minimal and focused
-- Include Commands section with copy-paste commands
-- Keep frontmatter descriptions concise with essential trigger keywords
+## References
 
-### DON'T
-- Add Keywords section (agent searches frontmatter, not body)
-- Use multiline, unquoted, or block-scalar frontmatter descriptions
-- Duplicate content from existing docs (reference instead)
-- Include lengthy explanations (link to docs)
-- Add troubleshooting sections (keep focused)
-- Use web URLs in references (use local paths)
-
----
-
-## Registering the Skill
-
-After creating the skill, add it to `AGENTS.md`:
-
-```markdown
-| `{skill-name}` | {Description} | [SKILL.md](skills/{skill-name}/SKILL.md) |
-```
-
----
-
-## Checklist Before Creating
-
-- [ ] Skill doesn't already exist (check `skills/`)
-- [ ] Pattern is reusable (not one-off)
-- [ ] Name follows conventions
-- [ ] Frontmatter is complete (description is quoted, one-line, YAML-safe, includes `Trigger:`)
-- [ ] Description is ideally <=160 chars and never >250 chars
-- [ ] Description preserves essential trigger words; no `Keywords` section added
-- [ ] Critical patterns are clear
-- [ ] Code examples are minimal
-- [ ] Commands section exists
-- [ ] Added to AGENTS.md
-
-## Resources
-
-- **Templates**: See [assets/](assets/) for SKILL.md template
+- `docs/skill-style-guide.md` — normative LLM-first skill style guide for this repo.

--- a/testdata/golden/skills-windsurf-go-testing.golden
+++ b/testdata/golden/skills-windsurf-go-testing.golden
@@ -1,353 +1,51 @@
 ---
 name: go-testing
-description: "Write Go tests, including Bubbletea TUI tests. Trigger: Go test coverage, teatest, or test patterns."
+description: "Trigger: Go tests, go test coverage, Bubbletea teatest, golden files. Apply focused Go testing patterns."
 license: Apache-2.0
 metadata:
   author: gentleman-programming
   version: "1.0"
 ---
 
-## When to Use
+## Activation Contract
 
-Use this skill when:
-- Writing Go unit tests
-- Testing Bubbletea TUI components
-- Creating table-driven tests
-- Adding integration tests
-- Using golden file testing
+Load this skill when writing or reviewing Go tests, adding coverage, testing Bubbletea/TUI flows, using `teatest`, or updating golden files.
 
----
+## Hard Rules
 
-## Critical Patterns
+- Prefer table-driven tests for multiple cases; use `t.Run(tt.name, ...)`.
+- Test behavior and state transitions, not implementation trivia.
+- Use `t.TempDir()` for filesystem tests; never rely on a real home directory.
+- Keep integration tests skippable with `testing.Short()` when they run external commands or slow flows.
+- For Bubbletea, test `Model.Update()` directly for state changes; use `teatest` only for interactive flows.
+- Golden files must be deterministic; update only through the repo's `-update` path and rerun tests without `-update`.
+- Use small mocks/interfaces around system or command execution boundaries.
 
-### Pattern 1: Table-Driven Tests
+## Decision Gates
 
-Standard Go pattern for multiple test cases:
+| Target | Test pattern |
+|---|---|
+| Pure function or parser | Table-driven unit test. |
+| Error behavior | Explicit success and failure cases. |
+| File operations | `t.TempDir()` plus focused assertions. |
+| TUI state transition | Direct `Model.Update()` call with `tea.Msg`. |
+| Full TUI interaction | `teatest.NewTestModel()`. |
+| Rendered output | Golden file test. |
+| Real external command | Integration test; skip in `-short`. |
 
-```go
-func TestSomething(t *testing.T) {
-    tests := []struct {
-        name     string
-        input    string
-        expected string
-        wantErr  bool
-    }{
-        {
-            name:     "valid input",
-            input:    "hello",
-            expected: "HELLO",
-            wantErr:  false,
-        },
-        {
-            name:     "empty input",
-            input:    "",
-            expected: "",
-            wantErr:  true,
-        },
-    }
+## Execution Steps
 
-    for _, tt := range tests {
-        t.Run(tt.name, func(t *testing.T) {
-            result, err := ProcessInput(tt.input)
+1. Identify behavior under test and the smallest public boundary that proves it.
+2. Choose the test pattern from the decision gate.
+3. Name cases by scenario, not input mechanics.
+4. Assert outputs, errors, state, and side effects explicitly.
+5. Run the narrow package test first, then the relevant broader suite.
+6. For golden updates: run with `-update`, inspect diff, then rerun without `-update`.
 
-            if (err != nil) != tt.wantErr {
-                t.Errorf("error = %v, wantErr %v", err, tt.wantErr)
-                return
-            }
+## Output Contract
 
-            if result != tt.expected {
-                t.Errorf("got %q, want %q", result, tt.expected)
-            }
-        })
-    }
-}
-```
+Report test files changed, scenarios covered, commands executed, golden files updated, and any skipped integration scope.
 
-### Pattern 2: Bubbletea Model Testing
+## References
 
-Test Model state transitions directly:
-
-```go
-func TestModelUpdate(t *testing.T) {
-    m := NewModel()
-
-    // Simulate key press
-    newModel, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
-    m = newModel.(Model)
-
-    if m.Screen != ScreenMainMenu {
-        t.Errorf("expected ScreenMainMenu, got %v", m.Screen)
-    }
-}
-```
-
-### Pattern 3: Teatest Integration Tests
-
-Use Charmbracelet's teatest for TUI testing:
-
-```go
-func TestInteractiveFlow(t *testing.T) {
-    m := NewModel()
-    tm := teatest.NewTestModel(t, m)
-
-    // Send keys
-    tm.Send(tea.KeyMsg{Type: tea.KeyEnter})
-    tm.Send(tea.KeyMsg{Type: tea.KeyDown})
-    tm.Send(tea.KeyMsg{Type: tea.KeyEnter})
-
-    // Wait for model to update
-    tm.WaitFinished(t, teatest.WithDuration(time.Second))
-
-    // Get final model
-    finalModel := tm.FinalModel(t).(Model)
-
-    if finalModel.Screen != ExpectedScreen {
-        t.Errorf("wrong screen: got %v", finalModel.Screen)
-    }
-}
-```
-
-### Pattern 4: Golden File Testing
-
-Compare output against saved "golden" files:
-
-```go
-func TestOSSelectGolden(t *testing.T) {
-    m := NewModel()
-    m.Screen = ScreenOSSelect
-    m.Width = 80
-    m.Height = 24
-
-    output := m.View()
-
-    golden := filepath.Join("testdata", "TestOSSelectGolden.golden")
-
-    if *update {
-        os.WriteFile(golden, []byte(output), 0644)
-    }
-
-    expected, _ := os.ReadFile(golden)
-    if output != string(expected) {
-        t.Errorf("output doesn't match golden file")
-    }
-}
-```
-
----
-
-## Decision Tree
-
-```
-Testing a function?
-├── Pure function? → Table-driven test
-├── Has side effects? → Mock dependencies
-├── Returns error? → Test both success and error cases
-└── Complex logic? → Break into smaller testable units
-
-Testing TUI component?
-├── State change? → Test Model.Update() directly
-├── Full flow? → Use teatest.NewTestModel()
-├── Visual output? → Use golden file testing
-└── Key handling? → Send tea.KeyMsg
-
-Testing system/exec?
-├── Mock os/exec? → Use interface + mock
-├── Real commands? → Integration test with --short skip
-└── File operations? → Use t.TempDir()
-```
-
----
-
-## Code Examples
-
-### Example 1: Testing Key Navigation
-
-```go
-func TestCursorNavigation(t *testing.T) {
-    tests := []struct {
-        name       string
-        startPos   int
-        key        string
-        endPos     int
-        numOptions int
-    }{
-        {"down from 0", 0, "j", 1, 5},
-        {"up from 1", 1, "k", 0, 5},
-        {"down at bottom", 4, "j", 4, 5}, // stays at bottom
-        {"up at top", 0, "k", 0, 5},       // stays at top
-    }
-
-    for _, tt := range tests {
-        t.Run(tt.name, func(t *testing.T) {
-            m := NewModel()
-            m.Cursor = tt.startPos
-            // Set up options...
-
-            newModel, _ := m.Update(tea.KeyMsg{
-                Type:  tea.KeyRunes,
-                Runes: []rune(tt.key),
-            })
-            m = newModel.(Model)
-
-            if m.Cursor != tt.endPos {
-                t.Errorf("cursor = %d, want %d", m.Cursor, tt.endPos)
-            }
-        })
-    }
-}
-```
-
-### Example 2: Testing Screen Transitions
-
-```go
-func TestScreenTransitions(t *testing.T) {
-    tests := []struct {
-        name         string
-        startScreen  Screen
-        action       tea.Msg
-        expectScreen Screen
-    }{
-        {
-            name:         "welcome to main menu",
-            startScreen:  ScreenWelcome,
-            action:       tea.KeyMsg{Type: tea.KeyEnter},
-            expectScreen: ScreenMainMenu,
-        },
-        {
-            name:         "escape from OS select",
-            startScreen:  ScreenOSSelect,
-            action:       tea.KeyMsg{Type: tea.KeyEsc},
-            expectScreen: ScreenMainMenu,
-        },
-    }
-
-    for _, tt := range tests {
-        t.Run(tt.name, func(t *testing.T) {
-            m := NewModel()
-            m.Screen = tt.startScreen
-
-            newModel, _ := m.Update(tt.action)
-            m = newModel.(Model)
-
-            if m.Screen != tt.expectScreen {
-                t.Errorf("screen = %v, want %v", m.Screen, tt.expectScreen)
-            }
-        })
-    }
-}
-```
-
-### Example 3: Testing Trainer Exercises
-
-```go
-func TestExerciseValidation(t *testing.T) {
-    exercise := &Exercise{
-        Solutions: []string{"w", "W", "e"},
-        Optimal:   "w",
-    }
-
-    tests := []struct {
-        input   string
-        valid   bool
-        optimal bool
-    }{
-        {"w", true, true},
-        {"W", true, false},
-        {"e", true, false},
-        {"x", false, false},
-    }
-
-    for _, tt := range tests {
-        t.Run(tt.input, func(t *testing.T) {
-            valid := ValidateAnswer(exercise, tt.input)
-            optimal := IsOptimalAnswer(exercise, tt.input)
-
-            if valid != tt.valid {
-                t.Errorf("valid = %v, want %v", valid, tt.valid)
-            }
-            if optimal != tt.optimal {
-                t.Errorf("optimal = %v, want %v", optimal, tt.optimal)
-            }
-        })
-    }
-}
-```
-
-### Example 4: Mocking System Info
-
-```go
-func TestWithMockedSystem(t *testing.T) {
-    m := NewModel()
-
-    // Mock system info for testing
-    m.SystemInfo = &system.SystemInfo{
-        OS:       system.OSMac,
-        IsARM:    true,
-        HasBrew:  true,
-        HomeDir:  t.TempDir(),
-    }
-
-    // Now test with controlled environment
-    m.SetupInstallSteps()
-
-    // Verify expected steps
-    hasHomebrew := false
-    for _, step := range m.Steps {
-        if step.ID == "homebrew" {
-            hasHomebrew = true
-        }
-    }
-
-    if hasHomebrew {
-        t.Error("should not have homebrew step when HasBrew=true")
-    }
-}
-```
-
----
-
-## Test File Organization
-
-```
-installer/internal/tui/
-├── model.go
-├── model_test.go           # Model tests
-├── update.go
-├── update_test.go          # Update handler tests
-├── view.go
-├── view_test.go            # View rendering tests
-├── teatest_test.go         # Teatest integration tests
-├── comprehensive_test.go   # Full flow tests
-├── testdata/
-│   ├── TestOSSelectGolden.golden
-│   └── TestViewGolden.golden
-└── trainer/
-    ├── types.go
-    ├── types_test.go
-    ├── exercises.go
-    ├── exercises_test.go
-    └── simulator_test.go
-```
-
----
-
-## Commands
-
-```bash
-go test ./...                           # Run all tests
-go test -v ./internal/tui/...          # Verbose TUI tests
-go test -run TestNavigation             # Run specific test
-go test -cover ./...                    # With coverage
-go test -update ./...                   # Update golden files
-go test -short ./...                    # Skip integration tests
-```
-
----
-
-## Resources
-
-- **TUI Tests**: See `installer/internal/tui/*_test.go`
-- **Trainer Tests**: See `installer/internal/tui/trainer/*_test.go`
-- **System Tests**: See `installer/internal/system/*_test.go`
-- **Golden Files**: See `installer/internal/tui/testdata/`
-- **Teatest Docs**: https://github.com/charmbracelet/bubbletea/tree/master/teatest
+- [references/examples.md](references/examples.md) — compact table-driven, Bubbletea, teatest, golden, and command examples.

--- a/testdata/golden/skills-windsurf-skill-creator.golden
+++ b/testdata/golden/skills-windsurf-skill-creator.golden
@@ -1,13 +1,13 @@
 ---
 name: skill-creator
-description: "Create AI agent skills with valid frontmatter. Trigger: new skills, agent instructions, or documenting AI usage patterns."
+description: "Trigger: new skills, agent instructions, documenting AI usage patterns. Create LLM-first skills with valid frontmatter."
 license: Apache-2.0
 metadata:
   author: gentleman-programming
   version: "1.0"
 ---
 
-## When to Create a Skill
+## Activation Contract
 
 Create a skill when:
 - A pattern is used repeatedly and AI needs guidance
@@ -15,14 +15,31 @@ Create a skill when:
 - Complex workflows need step-by-step instructions
 - Decision trees help AI choose the right approach
 
-**Don't create a skill when:**
-- Documentation already exists (create a reference instead)
-- Pattern is trivial or self-explanatory
-- It's a one-off task
+Do not create a skill when the pattern is trivial, one-off, or better served by normal documentation.
 
----
+## Hard Rules
 
-## Skill Structure
+- When working in this repo, first follow `docs/skill-style-guide.md` as the normative source before creating or updating skills.
+- If that guide is unavailable, use the compact inline rules below.
+- A skill is a runtime instruction contract for an LLM, not human documentation.
+- Do not add a `Keywords` section; preserve essential trigger words in `description`.
+- References must point to local files.
+- Keep the skill body concise: target 180–450 tokens, recommended max 700, hard max 1000.
+
+## Decision Gates
+
+| Need | Action |
+|------|--------|
+| Code templates, schemas, fixtures, generated examples | Put them in `assets/` |
+| Conceptual detail, edge cases, existing docs | Put local links in `references/` |
+| Long explanation in `SKILL.md` | Move it to a supporting file |
+| Multiple meaningful paths | Add a compact decision table |
+
+## Execution Steps
+
+1. Check whether `docs/skill-style-guide.md` exists; if it does, apply it before the inline fallback rules.
+2. Confirm the skill does not already exist and the pattern is reusable.
+3. Create or update `skills/{skill-name}/SKILL.md` using this required structure:
 
 ```
 skills/{skill-name}/
@@ -33,97 +50,33 @@ skills/{skill-name}/
 └── references/           # Optional - links to local docs
     └── docs.md           # Points to docs/developer-guide/*.mdx
 ```
-
----
-
-## SKILL.md Template
+4. Use this frontmatter shape:
 
 ```markdown
 ---
 name: {skill-name}
-description: "{What this skill does}. Trigger: {essential trigger words users or agents will say}."
+description: "Trigger: {essential trigger words users or agents will say}. {What this skill does}."
 license: Apache-2.0
 metadata:
   author: gentleman-programming
   version: "1.0"
 ---
-
-## When to Use
-
-{Bullet points of when to use this skill}
-
-## Critical Patterns
-
-{The most important rules - what AI MUST know}
-
-## Code Examples
-
-{Minimal, focused examples}
-
-## Commands
-
-```bash
-{Common commands}
 ```
+5. Write sections in this order: Activation Contract, Hard Rules, Decision Gates, Execution Steps, Output Contract, References.
+6. Register the skill in `AGENTS.md` when it is a project skill.
 
-## Resources
+## Inline Fallback Rules
 
-- **Templates**: See [assets/](assets/) for {description}
-- **Documentation**: See [references/](references/) for local docs
-```
-
----
-
-## Naming Conventions
-
-| Type | Pattern | Examples |
-|------|---------|----------|
-| Generic skill | `{technology}` | `pytest`, `playwright`, `typescript` |
-| Project-specific | `{project}-{component}` | `myapp-api`, `myapp-ui` |
-| Testing skill | `{project}-test-{component}` | `myapp-test-sdk`, `myapp-test-api` |
-| Workflow skill | `{action}-{target}` | `skill-creator`, `jira-task` |
-
----
-
-## Decision: assets/ vs references/
-
-```
-Need code templates?        → assets/
-Need JSON schemas?          → assets/
-Need example configs?       → assets/
-Link to existing docs?      → references/
-Link to external guides?    → references/ (with local path)
-```
-
-**Key Rule**: `references/` should point to LOCAL files, not web URLs.
-
----
-
-## Frontmatter Fields
-
-| Field | Required | Description |
-|-------|----------|-------------|
-| `name` | Yes | Skill identifier (lowercase, hyphens) |
-| `description` | Yes | Single-line, quoted YAML-safe string with what + `Trigger:` |
-| `license` | Yes | Always `Apache-2.0` |
-| `metadata.author` | Yes | `gentleman-programming` |
-| `metadata.version` | Yes | Semantic version as string |
-
-### Description Rules
-
-The `description` field is the skill-loading budget. Treat it as mandatory metadata, not prose.
-
-- MUST be one physical line in frontmatter; never use `>` or `|` block scalars.
-- MUST be YAML-safe: wrap the whole value in quotes and avoid unescaped matching quotes inside it.
-- MUST include `Trigger:` and preserve the essential trigger words users or agents will actually say.
-- SHOULD be <=160 chars; this is preferred for Claude Code skill-list budget.
-- MUST be <=250 chars if a rare skill genuinely needs extra trigger coverage.
-- MUST NOT add `Keywords`; put concise trigger keywords in `description` instead.
+- `description` MUST be one physical line, quoted, YAML-safe, and include essential trigger words first.
+- `description` SHOULD be <=160 chars and MUST be <=250 chars.
+- Frontmatter MUST include `name`, `description`, `license`, `metadata.author`, and `metadata.version`.
+- Use imperative instructions, not tutorials or background prose.
+- Put supporting material in `assets/` or `references/`, not the main skill body.
 
 Good:
 
 ```yaml
-description: "Create Jira tasks in the team format. Trigger: Jira task, ticket, issue, or task creation."
+description: "Trigger: Jira task, ticket, issue, task creation. Create Jira tasks in the team format."
 ```
 
 Bad:
@@ -135,50 +88,14 @@ description: >
 Keywords: jira, task
 ```
 
----
+## Output Contract
 
-## Content Guidelines
+Return:
+- Files created or modified.
+- Whether the repo style guide or inline fallback rules were used.
+- Any AGENTS.md registration change.
+- Any supporting files added under `assets/` or `references/`.
 
-### DO
-- Start with the most critical patterns
-- Use tables for decision trees
-- Keep code examples minimal and focused
-- Include Commands section with copy-paste commands
-- Keep frontmatter descriptions concise with essential trigger keywords
+## References
 
-### DON'T
-- Add Keywords section (agent searches frontmatter, not body)
-- Use multiline, unquoted, or block-scalar frontmatter descriptions
-- Duplicate content from existing docs (reference instead)
-- Include lengthy explanations (link to docs)
-- Add troubleshooting sections (keep focused)
-- Use web URLs in references (use local paths)
-
----
-
-## Registering the Skill
-
-After creating the skill, add it to `AGENTS.md`:
-
-```markdown
-| `{skill-name}` | {Description} | [SKILL.md](skills/{skill-name}/SKILL.md) |
-```
-
----
-
-## Checklist Before Creating
-
-- [ ] Skill doesn't already exist (check `skills/`)
-- [ ] Pattern is reusable (not one-off)
-- [ ] Name follows conventions
-- [ ] Frontmatter is complete (description is quoted, one-line, YAML-safe, includes `Trigger:`)
-- [ ] Description is ideally <=160 chars and never >250 chars
-- [ ] Description preserves essential trigger words; no `Keywords` section added
-- [ ] Critical patterns are clear
-- [ ] Code examples are minimal
-- [ ] Commands section exists
-- [ ] Added to AGENTS.md
-
-## Resources
-
-- **Templates**: See [assets/](assets/) for SKILL.md template
+- `docs/skill-style-guide.md` — normative LLM-first skill style guide for this repo.


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #457

This PR bundles two related changes that surface together because the LLM-first refactor was merged on local main but origin/main hadn't caught up when the PR was opened.

---

## 🏷️ PR Type

- [x] `type:bug` — primary scope is the duplicate `/` picker fix (#457); LLM-first skill refactor rides along

---

## 📝 Summary

### Part 1 — LLM-first skills refactor

Made installed skills LLM-first: short operational contracts in `SKILL.md` with deep details moved to `references/`, loaded only when needed.

**Before**: the 5 heaviest skills carried 1,769 lines of `SKILL.md` runtime ≈ **18k–25k tokens** loaded when activated.
**After**: 265 lines of `SKILL.md` runtime ≈ **3k–5k tokens**.
**Savings**: **~85% less runtime context** → **15k–20k tokens** less when those skills activate.

Per skill:

| Skill | Before | After |
|-------|--------|-------|
| `chained-pr` | 371 lines | 50 lines |
| `judgment-day` | 345 lines | 52 lines |
| `sdd-init` | 358 lines | 55 lines |
| `go-testing` | 353 lines | 51 lines |
| `sdd-verify` | 342 lines | 57 lines |

Knowledge was not deleted — it moved to `references/*.md`. The model loads only the operational contract by default and reads long-form details on demand.

Structural improvements:
- Installers now copy skill directories recursively
- `references/` get installed alongside each skill
- Tests validate references exist and are non-empty
- Internal links use installed-relative paths
- `skill-creator` now ships with an LLM-first authoring guide (`docs/skill-style-guide.md`)

### Part 2 — Hide SDD `SKILL.md` from Claude Code `/` picker (Closes #457)

Add `user-invocable: false` and `disable-model-invocation: true` to the YAML frontmatter of all 11 SDD `SKILL.md` files (10 phases + `_shared`) so Claude Code v2.x stops surfacing them in the `/` picker alongside the slash commands.

The skills remain readable by sub-agents and slash command fallbacks via the `Read` tool — only the user-invocable picker entry and model-autoload paths are disabled.

Also widens the frontmatter linter allowlist (`internal/assets/skills_frontmatter_test.go`) to accept the two new top-level keys, and regenerates the 8 `sdd-init` cross-adapter goldens.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/assets/skills/{chained-pr,go-testing,judgment-day,sdd-init,sdd-verify}/SKILL.md` | LLM-first refactor — slimmed to operational contract |
| `internal/assets/skills/skill-creator/SKILL.md` | Refactored + references LLM-first style guide |
| `internal/assets/skills/{chained-pr,go-testing,judgment-day,sdd-init,sdd-verify}/references/*.md` | New supporting detail files installed alongside each skill |
| `docs/skill-style-guide.md` | New LLM-first skill authoring guide |
| `internal/assets/skills/_shared/SKILL.md` | Frontmatter flags |
| `internal/assets/skills/sdd-{apply,archive,design,explore,onboard,propose,spec,tasks}/SKILL.md` | Frontmatter flags |
| `internal/components/skills/inject.go` | Recursive directory copy (was: `SKILL.md` only) |
| `internal/components/sdd/inject.go` | Recursive directory copy for SDD skills |
| `internal/components/{skills,sdd}/inject_test.go` | Coverage for nested file copying |
| `internal/assets/assets_test.go` | Embedded-asset readability assertions for `references/*.md` |
| `internal/assets/skills_frontmatter_test.go` | Allowlist widening for `user-invocable` + `disable-model-invocation` |
| `testdata/golden/skills-{adapter}-{skill}.golden` | Regenerated for refactored skills |
| `testdata/golden/sdd-{adapter}-skill-sdd-init.golden` | Regenerated for `sdd-init` frontmatter |
| `openspec/changes/fix-skill-duplication-and-migrate/` | SDD artifacts (scope: Part 2 only — see note below) |

---

## 🧪 Test Plan

```bash
go test ./...
```

- [x] Unit tests pass (all 40+ packages green)
- [x] Frontmatter linter passes with widened allowlist
- [x] Goldens regenerate cleanly for refactored skills and `sdd-init` frontmatter
- [ ] E2E tests (`cd e2e && ./docker-test.sh`) — CI will exercise

**Manual verification (post-merge)**:
- [ ] Build binary, run `gentle-ai install` against clean `~/.claude/`
- [ ] Confirm refactored skills install with `references/` subdirs copied
- [ ] Confirm each `sdd-*` appears at most once in Claude Code v2.1.131+ `/` picker
- [ ] Trigger `sdd-explore` delegation; confirm sub-agent reads the hidden `SKILL.md` via `Read` and executes

---

## 🧾 SDD artifacts scope

The artifacts under `openspec/changes/fix-skill-duplication-and-migrate/` document **only Part 2** (the frontmatter fix for #457). Part 1 (LLM-first refactor) was completed and merged on local main as a separate work stream — it surfaces in this PR's diff because origin/main was one merge behind when the PR was opened. Reference commits for Part 1: `f070845 refactor: make installed skills LLM-first` and `99f7062 docs: add LLM-first skill style guide`.

---

## 🔍 Out of scope

- Path relocation for SDD `SKILL.md` files (rejected at SDD proposal phase — frontmatter flags chosen for ~10× smaller blast radius)
- Migration logic for existing installs (path unchanged, embedded asset overwrite handles it)
- Cross-adapter behavioral changes to picker indexing (only Claude Code exhibits the duplication)
- `size:exception` is applied because Part 1 (LLM-first refactor) is bundled into this PR