### PR TITLE
feat(agents): add OpenClaw support

### DIFF
--- a/internal/agents/factory.go
+++ b/internal/agents/factory.go
@@ -11,12 +11,29 @@ import (
 	"github.com/gentleman-programming/gentle-ai/internal/agents/kilocode"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/kimi"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/kiro"
+	"github.com/gentleman-programming/gentle-ai/internal/agents/openclaw"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/opencode"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/qwen"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/vscode"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/windsurf"
 	"github.com/gentleman-programming/gentle-ai/internal/model"
 )
+
+var defaultAgentIDs = []model.AgentID{
+	model.AgentClaudeCode,
+	model.AgentOpenCode,
+	model.AgentKilocode,
+	model.AgentGeminiCLI,
+	model.AgentCursor,
+	model.AgentVSCodeCopilot,
+	model.AgentCodex,
+	model.AgentAntigravity,
+	model.AgentWindsurf,
+	model.AgentKimi,
+	model.AgentQwenCode,
+	model.AgentKiroIDE,
+	model.AgentOpenClaw,
+}
 
 func NewAdapter(agent model.AgentID) (Adapter, error) {
 	switch agent {
@@ -44,28 +61,17 @@ func NewAdapter(agent model.AgentID) (Adapter, error) {
 		return qwen.NewAdapter(), nil
 	case model.AgentKiroIDE:
 		return kiro.NewAdapter(), nil
+	case model.AgentOpenClaw:
+		return openclaw.NewAdapter(), nil
 	default:
 		return nil, AgentNotSupportedError{Agent: agent}
 	}
 }
 
 func NewDefaultRegistry() (*Registry, error) {
-	adapters := make([]Adapter, 0, 12)
+	adapters := make([]Adapter, 0, len(defaultAgentIDs))
 
-	for _, agent := range []model.AgentID{
-		model.AgentClaudeCode,
-		model.AgentOpenCode,
-		model.AgentKilocode,
-		model.AgentGeminiCLI,
-		model.AgentCursor,
-		model.AgentVSCodeCopilot,
-		model.AgentCodex,
-		model.AgentAntigravity,
-		model.AgentWindsurf,
-		model.AgentKimi,
-		model.AgentQwenCode,
-		model.AgentKiroIDE,
-	} {
+	for _, agent := range defaultAgentIDs {
 		adapter, err := NewAdapter(agent)
 		if err != nil {
 			return nil, fmt.Errorf("create %s adapter: %w", agent, err)

--- a/internal/agents/factory_test.go
+++ b/internal/agents/factory_test.go
@@ -1,0 +1,74 @@
+package agents
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/internal/model"
+)
+
+func TestFactoryResolvesOpenClawAdapter(t *testing.T) {
+	adapter, err := NewAdapter(model.AgentOpenClaw)
+	if err != nil {
+		t.Fatalf("NewAdapter(%q) returned error: %v", model.AgentOpenClaw, err)
+	}
+
+	if got := adapter.Agent(); got != model.AgentOpenClaw {
+		t.Fatalf("adapter.Agent() = %q, want %q", got, model.AgentOpenClaw)
+	}
+}
+
+func TestDefaultRegistryIncludesOpenClaw(t *testing.T) {
+	registry, err := NewDefaultRegistry()
+	if err != nil {
+		t.Fatalf("NewDefaultRegistry() returned error: %v", err)
+	}
+
+	adapter, ok := registry.Get(model.AgentOpenClaw)
+	if !ok {
+		t.Fatalf("registry missing %s adapter", model.AgentOpenClaw)
+	}
+
+	if got := adapter.Agent(); got != model.AgentOpenClaw {
+		t.Fatalf("registry adapter.Agent() = %q, want %q", got, model.AgentOpenClaw)
+	}
+}
+
+func TestDefaultRegistrySupportedAgentsMatchesFactoryAgents(t *testing.T) {
+	registry, err := NewDefaultRegistry()
+	if err != nil {
+		t.Fatalf("NewDefaultRegistry() returned error: %v", err)
+	}
+
+	want := []model.AgentID{
+		model.AgentAntigravity,
+		model.AgentClaudeCode,
+		model.AgentCodex,
+		model.AgentCursor,
+		model.AgentGeminiCLI,
+		model.AgentKilocode,
+		model.AgentKimi,
+		model.AgentKiroIDE,
+		model.AgentOpenClaw,
+		model.AgentOpenCode,
+		model.AgentQwenCode,
+		model.AgentVSCodeCopilot,
+		model.AgentWindsurf,
+	}
+
+	if got := registry.SupportedAgents(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("SupportedAgents() = %v, want %v", got, want)
+	}
+}
+
+func TestFactoryRejectsUnsupportedOpenClawLookalike(t *testing.T) {
+	_, err := NewAdapter(model.AgentID("openclaw-beta"))
+	if err == nil {
+		t.Fatalf("NewAdapter() expected unsupported agent error")
+	}
+
+	if !errors.Is(err, ErrAgentNotSupported) {
+		t.Fatalf("NewAdapter() error = %v, want ErrAgentNotSupported", err)
+	}
+}

--- a/internal/agents/openclaw/adapter.go
+++ b/internal/agents/openclaw/adapter.go
@@ -1,0 +1,171 @@
+package openclaw
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/gentleman-programming/gentle-ai/internal/model"
+	"github.com/gentleman-programming/gentle-ai/internal/system"
+)
+
+var LookPathOverride = exec.LookPath
+
+type statResult struct {
+	isDir bool
+	err   error
+}
+
+type Adapter struct {
+	lookPath func(string) (string, error)
+	statPath func(string) statResult
+}
+
+func NewAdapter() *Adapter {
+	return &Adapter{
+		lookPath: LookPathOverride,
+		statPath: defaultStat,
+	}
+}
+
+// --- Identity ---
+
+func (a *Adapter) Agent() model.AgentID {
+	return model.AgentOpenClaw
+}
+
+func (a *Adapter) Tier() model.SupportTier {
+	return model.TierFull
+}
+
+// --- Detection ---
+
+func (a *Adapter) Detect(_ context.Context, homeDir string) (bool, string, string, bool, error) {
+	configPath := ConfigPath(homeDir)
+
+	binaryPath, err := a.lookPath("openclaw")
+	installed := err == nil
+
+	stat := a.statPath(configPath)
+	if stat.err != nil {
+		if os.IsNotExist(stat.err) {
+			return installed, binaryPath, configPath, false, nil
+		}
+		return false, "", "", false, stat.err
+	}
+
+	return installed, binaryPath, configPath, stat.isDir, nil
+}
+
+// --- Installation ---
+
+func (a *Adapter) SupportsAutoInstall() bool {
+	return false
+}
+
+func (a *Adapter) InstallCommand(_ system.PlatformProfile) ([][]string, error) {
+	return nil, AgentNotInstallableError{Agent: a.Agent()}
+}
+
+// --- Config paths ---
+
+func (a *Adapter) GlobalConfigDir(homeDir string) string {
+	return ConfigPath(homeDir)
+}
+
+func (a *Adapter) SystemPromptDir(homeDir string) string {
+	return homeDir
+}
+
+func (a *Adapter) SystemPromptFile(homeDir string) string {
+	return filepath.Join(homeDir, "AGENTS.md")
+}
+
+func (a *Adapter) SkillsDir(homeDir string) string {
+	return filepath.Join(ConfigPath(homeDir), "skills")
+}
+
+func (a *Adapter) SettingsPath(homeDir string) string {
+	return filepath.Join(ConfigPath(homeDir), "openclaw.json")
+}
+
+// --- Config strategies ---
+
+func (a *Adapter) SystemPromptStrategy() model.SystemPromptStrategy {
+	return model.StrategyMarkdownSections
+}
+
+func (a *Adapter) MCPStrategy() model.MCPStrategy {
+	return model.StrategyMergeIntoSettings
+}
+
+// --- MCP ---
+
+func (a *Adapter) MCPConfigPath(homeDir string, _ string) string {
+	return filepath.Join(ConfigPath(homeDir), "openclaw.json")
+}
+
+// --- Optional capabilities ---
+
+func (a *Adapter) SupportsOutputStyles() bool {
+	return true
+}
+
+func (a *Adapter) OutputStyleDir(homeDir string) string {
+	return homeDir
+}
+
+func (a *Adapter) SupportsSlashCommands() bool {
+	return false
+}
+
+func (a *Adapter) CommandsDir(_ string) string {
+	return ""
+}
+
+func (a *Adapter) SupportsSubAgents() bool {
+	return false
+}
+
+func (a *Adapter) SubAgentsDir(_ string) string {
+	return ""
+}
+
+func (a *Adapter) EmbeddedSubAgentsDir() string {
+	return ""
+}
+
+func (a *Adapter) SupportsSkills() bool {
+	return true
+}
+
+func (a *Adapter) SupportsSystemPrompt() bool {
+	return true
+}
+
+func (a *Adapter) SupportsMCP() bool {
+	return true
+}
+
+func defaultStat(path string) statResult {
+	info, err := os.Stat(path)
+	if err != nil {
+		return statResult{err: err}
+	}
+
+	return statResult{isDir: info.IsDir()}
+}
+
+func ConfigPath(homeDir string) string {
+	return filepath.Join(homeDir, ".openclaw")
+}
+
+type AgentNotInstallableError struct {
+	Agent model.AgentID
+}
+
+func (e AgentNotInstallableError) Error() string {
+	return fmt.Sprintf("agent %q does not support auto-install", e.Agent)
+}

--- a/internal/agents/openclaw/adapter.go
+++ b/internal/agents/openclaw/adapter.go
@@ -110,11 +110,11 @@ func (a *Adapter) MCPConfigPath(homeDir string, _ string) string {
 // --- Optional capabilities ---
 
 func (a *Adapter) SupportsOutputStyles() bool {
-	return true
+	return false
 }
 
-func (a *Adapter) OutputStyleDir(homeDir string) string {
-	return homeDir
+func (a *Adapter) OutputStyleDir(_ string) string {
+	return ""
 }
 
 func (a *Adapter) SupportsSlashCommands() bool {
@@ -167,5 +167,5 @@ type AgentNotInstallableError struct {
 }
 
 func (e AgentNotInstallableError) Error() string {
-	return fmt.Sprintf("agent %q does not support auto-install", e.Agent)
+	return fmt.Sprintf("agent %q must be installed manually before Gentle AI can configure it", e.Agent)
 }

--- a/internal/agents/openclaw/adapter_test.go
+++ b/internal/agents/openclaw/adapter_test.go
@@ -5,9 +5,11 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/gentleman-programming/gentle-ai/internal/model"
+	"github.com/gentleman-programming/gentle-ai/internal/system"
 )
 
 func TestAdapterIdentityAndStrategies(t *testing.T) {
@@ -38,16 +40,31 @@ func TestAdapterIdentityAndStrategies(t *testing.T) {
 		t.Fatalf("SupportsMCP() = false, want true")
 	}
 
-	if !a.SupportsOutputStyles() {
-		t.Fatalf("SupportsOutputStyles() = false, want true for SOUL.md persona injection")
+	if a.SupportsOutputStyles() {
+		t.Fatalf("SupportsOutputStyles() = true, want false because OpenClaw uses SOUL.md instead of output-style files")
 	}
 
 	if got := a.SystemPromptFile(homeDir); got != filepath.Join(homeDir, "AGENTS.md") {
 		t.Fatalf("SystemPromptFile() = %q, want workspace AGENTS.md", got)
 	}
 
-	if got := a.OutputStyleDir(homeDir); got != homeDir {
-		t.Fatalf("OutputStyleDir() = %q, want workspace root for SOUL.md", got)
+	if got := a.OutputStyleDir(homeDir); got != "" {
+		t.Fatalf("OutputStyleDir() = %q, want empty because OpenClaw persona injection targets SOUL.md", got)
+	}
+}
+
+func TestInstallCommandRequiresManualInstall(t *testing.T) {
+	a := NewAdapter()
+
+	commands, err := a.InstallCommand(system.PlatformProfile{})
+	if err == nil {
+		t.Fatalf("InstallCommand() error = nil, want manual install error")
+	}
+	if commands != nil {
+		t.Fatalf("InstallCommand() commands = %v, want nil", commands)
+	}
+	if got := err.Error(); !strings.Contains(got, "must be installed manually") {
+		t.Fatalf("InstallCommand() error = %q, want actionable manual install message", got)
 	}
 }
 

--- a/internal/agents/openclaw/adapter_test.go
+++ b/internal/agents/openclaw/adapter_test.go
@@ -1,0 +1,157 @@
+package openclaw
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/internal/model"
+)
+
+func TestAdapterIdentityAndStrategies(t *testing.T) {
+	a := NewAdapter()
+	homeDir := filepath.Join(string(filepath.Separator), "tmp", "home")
+
+	if got := a.Agent(); got != model.AgentOpenClaw {
+		t.Fatalf("Agent() = %q, want %q", got, model.AgentOpenClaw)
+	}
+
+	if got := a.Tier(); got != model.TierFull {
+		t.Fatalf("Tier() = %q, want %q", got, model.TierFull)
+	}
+
+	if got := a.SystemPromptStrategy(); got != model.StrategyMarkdownSections {
+		t.Fatalf("SystemPromptStrategy() = %v, want %v", got, model.StrategyMarkdownSections)
+	}
+
+	if got := a.MCPStrategy(); got != model.StrategyMergeIntoSettings {
+		t.Fatalf("MCPStrategy() = %v, want %v", got, model.StrategyMergeIntoSettings)
+	}
+
+	if !a.SupportsSystemPrompt() {
+		t.Fatalf("SupportsSystemPrompt() = false, want true")
+	}
+
+	if !a.SupportsMCP() {
+		t.Fatalf("SupportsMCP() = false, want true")
+	}
+
+	if !a.SupportsOutputStyles() {
+		t.Fatalf("SupportsOutputStyles() = false, want true for SOUL.md persona injection")
+	}
+
+	if got := a.SystemPromptFile(homeDir); got != filepath.Join(homeDir, "AGENTS.md") {
+		t.Fatalf("SystemPromptFile() = %q, want workspace AGENTS.md", got)
+	}
+
+	if got := a.OutputStyleDir(homeDir); got != homeDir {
+		t.Fatalf("OutputStyleDir() = %q, want workspace root for SOUL.md", got)
+	}
+}
+
+func TestAdapterConfigPaths(t *testing.T) {
+	a := NewAdapter()
+	homeDir := filepath.Join(string(filepath.Separator), "tmp", "home")
+	configDir := filepath.Join(homeDir, ".openclaw")
+	configPath := filepath.Join(configDir, "openclaw.json")
+
+	paths := map[string]string{
+		"GlobalConfigDir": a.GlobalConfigDir(homeDir),
+		"SettingsPath":    a.SettingsPath(homeDir),
+		"MCPConfigPath":   a.MCPConfigPath(homeDir, "engram"),
+		"SkillsDir":       a.SkillsDir(homeDir),
+	}
+
+	if got := paths["GlobalConfigDir"]; got != configDir {
+		t.Fatalf("GlobalConfigDir() = %q, want %q", got, configDir)
+	}
+
+	if got := paths["SettingsPath"]; got != configPath {
+		t.Fatalf("SettingsPath() = %q, want %q", got, configPath)
+	}
+
+	if got := paths["MCPConfigPath"]; got != configPath {
+		t.Fatalf("MCPConfigPath() = %q, want %q", got, configPath)
+	}
+
+	if got := paths["SkillsDir"]; got != filepath.Join(configDir, "skills") {
+		t.Fatalf("SkillsDir() = %q, want OpenClaw skills dir", got)
+	}
+}
+
+func TestDetect(t *testing.T) {
+	tests := []struct {
+		name            string
+		lookPathPath    string
+		lookPathErr     error
+		stat            statResult
+		wantInstalled   bool
+		wantBinaryPath  string
+		wantConfigFound bool
+		wantErr         bool
+	}{
+		{
+			name:            "binary and config directory found",
+			lookPathPath:    "/opt/homebrew/bin/openclaw",
+			stat:            statResult{isDir: true},
+			wantInstalled:   true,
+			wantBinaryPath:  "/opt/homebrew/bin/openclaw",
+			wantConfigFound: true,
+		},
+		{
+			name:            "binary missing and config missing",
+			lookPathErr:     errors.New("missing"),
+			stat:            statResult{err: os.ErrNotExist},
+			wantInstalled:   false,
+			wantBinaryPath:  "",
+			wantConfigFound: false,
+		},
+		{
+			name:    "stat error bubbles up",
+			stat:    statResult{err: errors.New("permission denied")},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := &Adapter{
+				lookPath: func(string) (string, error) {
+					return tt.lookPathPath, tt.lookPathErr
+				},
+				statPath: func(string) statResult {
+					return tt.stat
+				},
+			}
+			homeDir := filepath.Join(string(filepath.Separator), "tmp", "home")
+
+			installed, binaryPath, configPath, configFound, err := a.Detect(context.Background(), homeDir)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Detect() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if tt.wantErr {
+				return
+			}
+
+			if installed != tt.wantInstalled {
+				t.Fatalf("Detect() installed = %v, want %v", installed, tt.wantInstalled)
+			}
+
+			if binaryPath != tt.wantBinaryPath {
+				t.Fatalf("Detect() binaryPath = %q, want %q", binaryPath, tt.wantBinaryPath)
+			}
+
+			wantConfigPath := filepath.Join(homeDir, ".openclaw")
+			if configPath != wantConfigPath {
+				t.Fatalf("Detect() configPath = %q, want %q", configPath, wantConfigPath)
+			}
+
+			if configFound != tt.wantConfigFound {
+				t.Fatalf("Detect() configFound = %v, want %v", configFound, tt.wantConfigFound)
+			}
+		})
+	}
+}

--- a/internal/catalog/agents.go
+++ b/internal/catalog/agents.go
@@ -22,6 +22,7 @@ var allAgents = []Agent{
 	{ID: model.AgentKimi, Name: "Kimi Code", Tier: model.TierFull, ConfigPath: "~/.kimi"},
 	{ID: model.AgentQwenCode, Name: "Qwen Code", Tier: model.TierFull, ConfigPath: "~/.qwen"},
 	{ID: model.AgentKiroIDE, Name: "Kiro IDE", Tier: model.TierFull, ConfigPath: "~/.kiro"},
+	{ID: model.AgentOpenClaw, Name: "OpenClaw", Tier: model.TierFull, ConfigPath: "~/.openclaw"},
 }
 
 // mvpAgents are the original MVP agents (Claude Code, OpenCode).

--- a/internal/catalog/agents_test.go
+++ b/internal/catalog/agents_test.go
@@ -1,0 +1,39 @@
+package catalog
+
+import (
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/internal/model"
+)
+
+func TestAllAgentsIncludesOpenClaw(t *testing.T) {
+	agents := AllAgents()
+
+	for _, agent := range agents {
+		if agent.ID != model.AgentOpenClaw {
+			continue
+		}
+
+		if agent.Name != "OpenClaw" {
+			t.Fatalf("OpenClaw Name = %q, want OpenClaw", agent.Name)
+		}
+
+		if agent.Tier != model.TierFull {
+			t.Fatalf("OpenClaw Tier = %q, want %q", agent.Tier, model.TierFull)
+		}
+
+		if agent.ConfigPath != "~/.openclaw" {
+			t.Fatalf("OpenClaw ConfigPath = %q, want ~/.openclaw", agent.ConfigPath)
+		}
+
+		return
+	}
+
+	t.Fatalf("AllAgents() missing %s", model.AgentOpenClaw)
+}
+
+func TestIsSupportedAgentAcceptsOpenClaw(t *testing.T) {
+	if !IsSupportedAgent(model.AgentOpenClaw) {
+		t.Fatalf("IsSupportedAgent(%q) = false, want true", model.AgentOpenClaw)
+	}
+}

--- a/internal/cli/install_test.go
+++ b/internal/cli/install_test.go
@@ -200,7 +200,7 @@ func TestRunInstallDryRunSkipsExecution(t *testing.T) {
 func makeDetectionWithAgents(present ...string) system.DetectionResult {
 	var configs []system.ConfigState
 	// Full canonical agent set — mirrors knownAgentConfigDirs in config_scan.go.
-	known := []string{"claude-code", "opencode", "kilocode", "gemini-cli", "cursor", "vscode-copilot", "codex", "antigravity", "windsurf", "kimi", "qwen-code", "kiro-ide"}
+	known := []string{"claude-code", "opencode", "kilocode", "gemini-cli", "cursor", "vscode-copilot", "codex", "antigravity", "windsurf", "kimi", "qwen-code", "kiro-ide", "openclaw"}
 	presentSet := make(map[string]bool, len(present))
 	for _, p := range present {
 		presentSet[p] = true
@@ -257,6 +257,7 @@ func TestDefaultAgentsFromDetection_AllAgentsMappedCorrectly(t *testing.T) {
 		{"kimi", model.AgentKimi},
 		{"qwen-code", model.AgentQwenCode},
 		{"kiro-ide", model.AgentKiroIDE},
+		{"openclaw", model.AgentOpenClaw},
 	}
 
 	for _, tt := range tests {

--- a/internal/cli/install_test.go
+++ b/internal/cli/install_test.go
@@ -43,7 +43,7 @@ func TestNormalizeInstallFlagsDefaults(t *testing.T) {
 	}
 
 	want := model.Selection{
-		Agents:  []model.AgentID{model.AgentClaudeCode, model.AgentOpenCode, model.AgentKilocode, model.AgentGeminiCLI, model.AgentCodex, model.AgentCursor, model.AgentVSCodeCopilot, model.AgentAntigravity, model.AgentWindsurf, model.AgentKimi, model.AgentQwenCode, model.AgentKiroIDE},
+		Agents:  []model.AgentID{model.AgentClaudeCode, model.AgentOpenCode, model.AgentKilocode, model.AgentGeminiCLI, model.AgentCodex, model.AgentCursor, model.AgentVSCodeCopilot, model.AgentAntigravity, model.AgentWindsurf, model.AgentKimi, model.AgentQwenCode, model.AgentKiroIDE, model.AgentOpenClaw},
 		Persona: model.PersonaGentleman,
 		Preset:  model.PresetFullGentleman,
 		Components: []model.ComponentID{

--- a/internal/cli/openclaw_orchestration_test.go
+++ b/internal/cli/openclaw_orchestration_test.go
@@ -1,0 +1,144 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/internal/model"
+	"github.com/gentleman-programming/gentle-ai/internal/system"
+)
+
+func TestComponentApplyStepOpenClawWorkspaceScopedInjections(t *testing.T) {
+	home := t.TempDir()
+	workspace := t.TempDir()
+
+	restoreLookPath := cmdLookPath
+	t.Cleanup(func() { cmdLookPath = restoreLookPath })
+	cmdLookPath = func(name string) (string, error) {
+		return filepath.Join(home, "bin", name), nil
+	}
+
+	tests := []struct {
+		name          string
+		component     model.ComponentID
+		workspaceFile string
+		homeFile      string
+		marker        string
+	}{
+		{
+			name:          "engram writes protocol to workspace AGENTS",
+			component:     model.ComponentEngram,
+			workspaceFile: filepath.Join(workspace, "AGENTS.md"),
+			homeFile:      filepath.Join(home, "AGENTS.md"),
+			marker:        "<!-- gentle-ai:engram-protocol -->",
+		},
+		{
+			name:          "persona writes soul to workspace",
+			component:     model.ComponentPersona,
+			workspaceFile: filepath.Join(workspace, "SOUL.md"),
+			homeFile:      filepath.Join(home, "SOUL.md"),
+			marker:        "<!-- gentle-ai:persona -->",
+		},
+		{
+			name:          "sdd writes protocol to workspace AGENTS",
+			component:     model.ComponentSDD,
+			workspaceFile: filepath.Join(workspace, "AGENTS.md"),
+			homeFile:      filepath.Join(home, "AGENTS.md"),
+			marker:        "<!-- gentle-ai:sdd-orchestrator -->",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			step := componentApplyStep{
+				id:           "component:" + string(tt.component),
+				component:    tt.component,
+				homeDir:      home,
+				workspaceDir: workspace,
+				agents:       []model.AgentID{model.AgentOpenClaw},
+				selection:    model.Selection{Persona: model.PersonaGentleman},
+				profile:      system.PlatformProfile{PackageManager: "brew"},
+			}
+
+			if err := step.Run(); err != nil {
+				t.Fatalf("componentApplyStep.Run() error = %v", err)
+			}
+
+			body, err := os.ReadFile(tt.workspaceFile)
+			if err != nil {
+				t.Fatalf("ReadFile(%q): %v", tt.workspaceFile, err)
+			}
+			if !strings.Contains(string(body), tt.marker) {
+				t.Fatalf("workspace file missing marker %q; got:\n%s", tt.marker, string(body))
+			}
+			if _, err := os.Stat(tt.homeFile); !os.IsNotExist(err) {
+				t.Fatalf("OpenClaw orchestration must not write %q; stat err=%v", tt.homeFile, err)
+			}
+		})
+	}
+}
+
+func TestComponentSyncStepOpenClawWorkspaceScopedInjections(t *testing.T) {
+	home := t.TempDir()
+	workspace := t.TempDir()
+
+	tests := []struct {
+		name          string
+		component     model.ComponentID
+		workspaceFile string
+		homeFile      string
+		marker        string
+	}{
+		{
+			name:          "engram sync writes protocol to workspace AGENTS",
+			component:     model.ComponentEngram,
+			workspaceFile: filepath.Join(workspace, "AGENTS.md"),
+			homeFile:      filepath.Join(home, "AGENTS.md"),
+			marker:        "<!-- gentle-ai:engram-protocol -->",
+		},
+		{
+			name:          "persona sync writes soul to workspace",
+			component:     model.ComponentPersona,
+			workspaceFile: filepath.Join(workspace, "SOUL.md"),
+			homeFile:      filepath.Join(home, "SOUL.md"),
+			marker:        "<!-- gentle-ai:persona -->",
+		},
+		{
+			name:          "sdd sync writes protocol to workspace AGENTS",
+			component:     model.ComponentSDD,
+			workspaceFile: filepath.Join(workspace, "AGENTS.md"),
+			homeFile:      filepath.Join(home, "AGENTS.md"),
+			marker:        "<!-- gentle-ai:sdd-orchestrator -->",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			step := componentSyncStep{
+				id:           "sync:component:" + string(tt.component),
+				component:    tt.component,
+				homeDir:      home,
+				workspaceDir: workspace,
+				agents:       []model.AgentID{model.AgentOpenClaw},
+				selection:    model.Selection{Persona: model.PersonaGentleman},
+			}
+
+			if err := step.Run(); err != nil {
+				t.Fatalf("componentSyncStep.Run() error = %v", err)
+			}
+
+			body, err := os.ReadFile(tt.workspaceFile)
+			if err != nil {
+				t.Fatalf("ReadFile(%q): %v", tt.workspaceFile, err)
+			}
+			if !strings.Contains(string(body), tt.marker) {
+				t.Fatalf("workspace file missing marker %q; got:\n%s", tt.marker, string(body))
+			}
+			if _, err := os.Stat(tt.homeFile); !os.IsNotExist(err) {
+				t.Fatalf("OpenClaw sync must not write %q; stat err=%v", tt.homeFile, err)
+			}
+		})
+	}
+}

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -138,7 +138,7 @@ func RunInstall(args []string, detection system.DetectionResult) (InstallResult,
 		return result, fmt.Errorf("execute install pipeline: %w", result.Execution.Err)
 	}
 
-	result.Verify = runPostApplyVerification(homeDir, input.Selection, resolved)
+	result.Verify = runPostApplyVerification(homeDir, runtime.workspaceDir, input.Selection, resolved)
 	result.Verify = withPostInstallNotes(result.Verify, resolved)
 	if !result.Verify.Ready {
 		return result, fmt.Errorf("post-apply verification failed:\n%s", verify.RenderReport(result.Verify))
@@ -273,7 +273,7 @@ func newInstallRuntime(homeDir string, selection model.Selection, resolved plann
 }
 
 func (r *installRuntime) stagePlan() pipeline.StagePlan {
-	targets := backupTargets(r.homeDir, r.selection, r.resolved)
+	targets := backupTargets(r.homeDir, r.workspaceDir, r.selection, r.resolved)
 	prepare := []pipeline.Step{
 		checkDependenciesStep{id: "prepare:check-dependencies", profile: r.profile, homeDir: r.homeDir, selection: r.selection},
 		prepareBackupStep{
@@ -566,7 +566,8 @@ func (s componentApplyStep) Run() error {
 					attemptedSlugs[slug] = struct{}{}
 				}
 			}
-			if _, err := engram.Inject(s.homeDir, adapter); err != nil {
+			targetDir := componentInjectionDir(s.homeDir, s.workspaceDir, adapter)
+			if _, err := engram.Inject(targetDir, adapter); err != nil {
 				return fmt.Errorf("inject engram for %q: %w", adapter.Agent(), err)
 			}
 		}
@@ -580,7 +581,8 @@ func (s componentApplyStep) Run() error {
 		return nil
 	case model.ComponentPersona:
 		for _, adapter := range adapters {
-			if _, err := persona.Inject(s.homeDir, adapter, s.selection.Persona); err != nil {
+			targetDir := componentInjectionDir(s.homeDir, s.workspaceDir, adapter)
+			if _, err := persona.Inject(targetDir, adapter, s.selection.Persona); err != nil {
 				return fmt.Errorf("inject persona for %q: %w", adapter.Agent(), err)
 			}
 		}
@@ -594,6 +596,7 @@ func (s componentApplyStep) Run() error {
 		return nil
 	case model.ComponentSDD:
 		for _, adapter := range adapters {
+			targetDir := componentInjectionDir(s.homeDir, s.workspaceDir, adapter)
 			opts := sdd.InjectOptions{
 				OpenCodeModelAssignments: s.selection.ModelAssignments,
 				ClaudeModelAssignments:   s.selection.ClaudeModelAssignments,
@@ -601,7 +604,7 @@ func (s componentApplyStep) Run() error {
 				WorkspaceDir:             s.workspaceDir,
 				StrictTDD:                s.selection.StrictTDD,
 			}
-			if _, err := sdd.Inject(s.homeDir, adapter, s.selection.SDDMode, opts); err != nil {
+			if _, err := sdd.Inject(targetDir, adapter, s.selection.SDDMode, opts); err != nil {
 				return fmt.Errorf("inject sdd for %q: %w", adapter.Agent(), err)
 			}
 		}
@@ -840,12 +843,12 @@ func selectedSkillIDs(selection model.Selection) []model.SkillID {
 	return skills.SkillsForPreset(selection.Preset)
 }
 
-func backupTargets(homeDir string, selection model.Selection, resolved planner.ResolvedPlan) []string {
+func backupTargets(homeDir, workspaceDir string, selection model.Selection, resolved planner.ResolvedPlan) []string {
 	paths := map[string]struct{}{}
 	adapters := resolveAdapters(resolved.Agents)
 
 	for _, component := range resolved.OrderedComponents {
-		for _, path := range componentPaths(homeDir, selection, adapters, component) {
+		for _, path := range componentPathsWithWorkspace(homeDir, workspaceDir, selection, adapters, component) {
 			paths[path] = struct{}{}
 		}
 	}
@@ -859,19 +862,24 @@ func backupTargets(homeDir string, selection model.Selection, resolved planner.R
 }
 
 func componentPaths(homeDir string, selection model.Selection, adapters []agents.Adapter, component model.ComponentID) []string {
+	return componentPathsWithWorkspace(homeDir, "", selection, adapters, component)
+}
+
+func componentPathsWithWorkspace(homeDir, workspaceDir string, selection model.Selection, adapters []agents.Adapter, component model.ComponentID) []string {
 	paths := []string{}
 	for _, adapter := range adapters {
+		targetDir := componentPathDir(homeDir, workspaceDir, adapter, component)
 		switch component {
 		case model.ComponentEngram:
 			switch adapter.MCPStrategy() {
 			case model.StrategySeparateMCPFiles:
-				paths = append(paths, adapter.MCPConfigPath(homeDir, "engram"))
+				paths = append(paths, adapter.MCPConfigPath(targetDir, "engram"))
 			case model.StrategyMergeIntoSettings:
-				if p := adapter.SettingsPath(homeDir); p != "" {
+				if p := adapter.SettingsPath(targetDir); p != "" {
 					paths = append(paths, p)
 				}
 			case model.StrategyMCPConfigFile:
-				if p := adapter.MCPConfigPath(homeDir, "engram"); p != "" {
+				if p := adapter.MCPConfigPath(targetDir, "engram"); p != "" {
 					paths = append(paths, p)
 				}
 				if adapter.Agent() == model.AgentAntigravity {
@@ -880,18 +888,18 @@ func componentPaths(homeDir string, selection model.Selection, adapters []agents
 					}
 				}
 			case model.StrategyTOMLFile:
-				if p := adapter.MCPConfigPath(homeDir, "engram"); p != "" {
+				if p := adapter.MCPConfigPath(targetDir, "engram"); p != "" {
 					paths = append(paths, p)
 				}
 			}
 			if adapter.SystemPromptStrategy() == model.StrategyMarkdownSections {
-				paths = append(paths, adapter.SystemPromptFile(homeDir))
+				paths = append(paths, adapter.SystemPromptFile(targetDir))
 			}
 		case model.ComponentSDD:
 			// Jinja modular hubs (e.g. Kimi KIMI.md) are appended once below so SDD+Persona
 			// do not duplicate the same system prompt path.
 			if adapter.SupportsSystemPrompt() && adapter.SystemPromptStrategy() != model.StrategyJinjaModules {
-				paths = append(paths, adapter.SystemPromptFile(homeDir))
+				paths = append(paths, adapter.SystemPromptFile(targetDir))
 			}
 			if adapter.SupportsSlashCommands() {
 				for _, command := range sdd.OpenCodeCommands() {
@@ -964,13 +972,17 @@ func componentPaths(homeDir string, selection model.Selection, adapters []agents
 			if selection.Persona == model.PersonaCustom {
 				break
 			}
+			if adapter.Agent() == model.AgentOpenClaw {
+				paths = append(paths, filepath.Join(targetDir, "SOUL.md"))
+				break
+			}
 			if adapter.SupportsSystemPrompt() && adapter.SystemPromptStrategy() != model.StrategyJinjaModules {
-				paths = append(paths, adapter.SystemPromptFile(homeDir))
+				paths = append(paths, adapter.SystemPromptFile(targetDir))
 			}
 			if selection.Persona == model.PersonaGentleman {
 				if adapter.SupportsOutputStyles() {
-					paths = append(paths, adapter.OutputStyleDir(homeDir)+"/gentleman.md")
-					if p := adapter.SettingsPath(homeDir); p != "" {
+					paths = append(paths, adapter.OutputStyleDir(targetDir)+"/gentleman.md")
+					if p := adapter.SettingsPath(targetDir); p != "" {
 						paths = append(paths, p)
 					}
 				}
@@ -1011,6 +1023,22 @@ func componentPaths(homeDir string, selection model.Selection, adapters []agents
 	return paths
 }
 
+func componentInjectionDir(homeDir, workspaceDir string, adapter agents.Adapter) string {
+	if adapter.Agent() == model.AgentOpenClaw && strings.TrimSpace(workspaceDir) != "" {
+		return workspaceDir
+	}
+	return homeDir
+}
+
+func componentPathDir(homeDir, workspaceDir string, adapter agents.Adapter, component model.ComponentID) string {
+	switch component {
+	case model.ComponentEngram, model.ComponentSDD, model.ComponentPersona:
+		return componentInjectionDir(homeDir, workspaceDir, adapter)
+	default:
+		return homeDir
+	}
+}
+
 func sddSubAgentPaths(homeDir string, adapter agents.Adapter) []string {
 	if !adapter.SupportsSubAgents() {
 		return nil
@@ -1032,14 +1060,14 @@ func sddSubAgentPaths(homeDir string, adapter agents.Adapter) []string {
 	return paths
 }
 
-func runPostApplyVerification(homeDir string, selection model.Selection, resolved planner.ResolvedPlan) verify.Report {
+func runPostApplyVerification(homeDir, workspaceDir string, selection model.Selection, resolved planner.ResolvedPlan) verify.Report {
 	checks := make([]verify.Check, 0)
 	adapters := resolveAdapters(resolved.Agents)
 
 	seenPath := make(map[string]struct{})
 	var uniqueFilePaths []string
 	for _, component := range resolved.OrderedComponents {
-		for _, path := range componentPaths(homeDir, selection, adapters, component) {
+		for _, path := range componentPathsWithWorkspace(homeDir, workspaceDir, selection, adapters, component) {
 			if path == "" {
 				continue
 			}

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -399,7 +399,7 @@ func newSyncRuntime(homeDir string, selection model.Selection) (*syncRuntime, er
 
 func (r *syncRuntime) stagePlan() pipeline.StagePlan {
 	adapters := resolveAdapters(r.agentIDs)
-	targets := syncBackupTargets(r.homeDir, r.selection, adapters)
+	targets := syncBackupTargets(r.homeDir, r.workspaceDir, r.selection, adapters)
 
 	prepare := []pipeline.Step{
 		prepareBackupStep{
@@ -438,10 +438,10 @@ func (r *syncRuntime) stagePlan() pipeline.StagePlan {
 // before sync executes. Uses syncComponentPaths so that the backup/verify
 // contract matches the actual files sync touches (which differ from install
 // for ComponentPersona — see syncComponentPaths).
-func syncBackupTargets(homeDir string, selection model.Selection, adapters []agents.Adapter) []string {
+func syncBackupTargets(homeDir, workspaceDir string, selection model.Selection, adapters []agents.Adapter) []string {
 	paths := map[string]struct{}{}
 	for _, component := range selection.Components {
-		for _, path := range syncComponentPaths(homeDir, selection, adapters, component) {
+		for _, path := range syncComponentPathsWithWorkspace(homeDir, workspaceDir, selection, adapters, component) {
 			paths[path] = struct{}{}
 		}
 	}
@@ -462,10 +462,14 @@ func syncBackupTargets(homeDir string, selection model.Selection, adapters []age
 // same file). Sync therefore must NOT declare those JSON paths or the post-sync
 // verification will look for files sync never promised to write.
 func syncComponentPaths(homeDir string, selection model.Selection, adapters []agents.Adapter, component model.ComponentID) []string {
+	return syncComponentPathsWithWorkspace(homeDir, "", selection, adapters, component)
+}
+
+func syncComponentPathsWithWorkspace(homeDir, workspaceDir string, selection model.Selection, adapters []agents.Adapter, component model.ComponentID) []string {
 	if component == model.ComponentPersona {
-		return syncPersonaPaths(homeDir, selection, adapters)
+		return syncPersonaPathsWithWorkspace(homeDir, workspaceDir, selection, adapters)
 	}
-	return componentPaths(homeDir, selection, adapters, component)
+	return componentPathsWithWorkspace(homeDir, workspaceDir, selection, adapters, component)
 }
 
 // syncPersonaPaths returns the file paths that ComponentPersona writes during
@@ -477,20 +481,29 @@ func syncComponentPaths(homeDir string, selection model.Selection, adapters []ag
 // Step 2 (OpenCode/Kilocode agent definition in opencode.json) is install-only
 // and intentionally NOT declared here.
 func syncPersonaPaths(homeDir string, selection model.Selection, adapters []agents.Adapter) []string {
+	return syncPersonaPathsWithWorkspace(homeDir, "", selection, adapters)
+}
+
+func syncPersonaPathsWithWorkspace(homeDir, workspaceDir string, selection model.Selection, adapters []agents.Adapter) []string {
 	if selection.Persona == model.PersonaCustom {
 		return nil
 	}
 	paths := []string{}
 	for _, adapter := range adapters {
+		targetDir := componentInjectionDir(homeDir, workspaceDir, adapter)
+		if adapter.Agent() == model.AgentOpenClaw {
+			paths = append(paths, filepath.Join(targetDir, "SOUL.md"))
+			continue
+		}
 		if !adapter.SupportsSystemPrompt() {
 			continue
 		}
 		if adapter.SystemPromptStrategy() != model.StrategyJinjaModules {
-			paths = append(paths, adapter.SystemPromptFile(homeDir))
+			paths = append(paths, adapter.SystemPromptFile(targetDir))
 		}
 		if selection.Persona == model.PersonaGentleman && adapter.SupportsOutputStyles() {
-			paths = append(paths, adapter.OutputStyleDir(homeDir)+"/gentleman.md")
-			if p := adapter.SettingsPath(homeDir); p != "" {
+			paths = append(paths, adapter.OutputStyleDir(targetDir)+"/gentleman.md")
+			if p := adapter.SettingsPath(targetDir); p != "" {
 				paths = append(paths, p)
 			}
 		}
@@ -527,7 +540,8 @@ func (s componentSyncStep) Run() error {
 		// Sync: inject MCP config + system prompt protocol only.
 		// NO binary install. NO engram setup.
 		for _, adapter := range adapters {
-			res, err := engram.Inject(s.homeDir, adapter)
+			targetDir := componentInjectionDir(s.homeDir, s.workspaceDir, adapter)
+			res, err := engram.Inject(targetDir, adapter)
 			if err != nil {
 				return fmt.Errorf("sync engram for %q: %w", adapter.Agent(), err)
 			}
@@ -581,6 +595,7 @@ func (s componentSyncStep) Run() error {
 		}
 
 		for _, adapter := range adapters {
+			targetDir := componentInjectionDir(s.homeDir, s.workspaceDir, adapter)
 			opts := sdd.InjectOptions{
 				OpenCodeModelAssignments:           s.selection.ModelAssignments,
 				ClaudeModelAssignments:             s.selection.ClaudeModelAssignments,
@@ -590,7 +605,7 @@ func (s componentSyncStep) Run() error {
 				PreserveOpenCodeOrchestratorPrompt: profileStrategy == model.SDDProfileStrategyExternalSingleActive,
 				Profiles:                           profiles,
 			}
-			res, err := sdd.Inject(s.homeDir, adapter, sddMode, opts)
+			res, err := sdd.Inject(targetDir, adapter, sddMode, opts)
 			if err != nil {
 				return fmt.Errorf("sync sdd for %q: %w", adapter.Agent(), err)
 			}
@@ -650,7 +665,8 @@ func (s componentSyncStep) Run() error {
 		// merge conflicts with SDD's writes to the same settings file and
 		// remains an install-only concern.
 		for _, adapter := range adapters {
-			res, err := persona.InjectForSync(s.homeDir, adapter, s.selection.Persona)
+			targetDir := componentInjectionDir(s.homeDir, s.workspaceDir, adapter)
+			res, err := persona.InjectForSync(targetDir, adapter, s.selection.Persona)
 			if err != nil {
 				return fmt.Errorf("sync persona for %q: %w", adapter.Agent(), err)
 			}
@@ -736,7 +752,7 @@ func RunSyncWithSelection(homeDir string, selection model.Selection) (SyncResult
 	}
 
 	// Post-apply verification reuses the same component paths as install.
-	result.Verify = runPostSyncVerification(homeDir, selection)
+	result.Verify = runPostSyncVerification(homeDir, rt.workspaceDir, selection)
 	if !result.Verify.Ready {
 		return result, fmt.Errorf("post-sync verification failed:\n%s", verify.RenderReport(result.Verify))
 	}
@@ -892,12 +908,12 @@ func RenderSyncReport(result SyncResult) string {
 }
 
 // runPostSyncVerification verifies that managed files exist after sync.
-func runPostSyncVerification(homeDir string, selection model.Selection) verify.Report {
+func runPostSyncVerification(homeDir, workspaceDir string, selection model.Selection) verify.Report {
 	checks := make([]verify.Check, 0)
 	adapters := resolveAdapters(selection.Agents)
 
 	for _, component := range selection.Components {
-		for _, path := range syncComponentPaths(homeDir, selection, adapters, component) {
+		for _, path := range syncComponentPathsWithWorkspace(homeDir, workspaceDir, selection, adapters, component) {
 			currentPath := path
 			checks = append(checks, verify.Check{
 				ID:          "verify:sync:file:" + currentPath,

--- a/internal/cli/validate.go
+++ b/internal/cli/validate.go
@@ -195,6 +195,8 @@ func defaultAgentsFromDetection(detection system.DetectionResult) []model.AgentI
 			agents = append(agents, model.AgentQwenCode)
 		case string(model.AgentKiroIDE):
 			agents = append(agents, model.AgentKiroIDE)
+		case string(model.AgentOpenClaw):
+			agents = append(agents, model.AgentOpenClaw)
 		}
 	}
 

--- a/internal/components/engram/inject.go
+++ b/internal/components/engram/inject.go
@@ -111,6 +111,19 @@ func engramOverlayJSON(agentID model.AgentID, cmd string) []byte {
 				},
 			},
 		}
+	} else if agentID == model.AgentOpenClaw {
+		cfg = map[string]any{
+			"mcp": map[string]any{
+				"servers": map[string]any{
+					"engram": map[string]any{
+						"__replace__": map[string]any{
+							"command": cmd,
+							"args":    []string{"mcp", "--tools=agent"},
+						},
+					},
+				},
+			},
+		}
 	} else {
 		cfg = map[string]any{
 			"mcpServers": map[string]any{
@@ -145,6 +158,9 @@ func vsCodeEngramOverlayJSON(cmd string) []byte {
 func Inject(homeDir string, adapter agents.Adapter) (InjectionResult, error) {
 	if !adapter.SupportsMCP() {
 		return InjectionResult{}, nil
+	}
+	if err := validateOpenClawWorkspacePath(homeDir, adapter); err != nil {
+		return InjectionResult{}, err
 	}
 
 	files := make([]string, 0, 2)
@@ -309,6 +325,13 @@ func Inject(homeDir string, adapter agents.Adapter) (InjectionResult, error) {
 	return InjectionResult{Changed: changed, Files: files}, nil
 }
 
+func validateOpenClawWorkspacePath(workspaceDir string, adapter agents.Adapter) error {
+	if adapter.Agent() == model.AgentOpenClaw && strings.TrimSpace(workspaceDir) == "" {
+		return fmt.Errorf("openclaw workspace path is required for workspace-first injection")
+	}
+	return nil
+}
+
 type settingsBootstrapResult struct {
 	Changed bool
 	Path    string
@@ -462,6 +485,16 @@ func existingMergedEngramCommand(raw []byte, agentID model.AgentID) (string, boo
 			return "", false
 		}
 		server = mcp["engram"]
+	case model.AgentOpenClaw:
+		mcp, ok := root["mcp"].(map[string]any)
+		if !ok {
+			return "", false
+		}
+		servers, ok := mcp["servers"].(map[string]any)
+		if !ok {
+			return "", false
+		}
+		server = servers["engram"]
 	case model.AgentVSCodeCopilot:
 		servers, ok := root["servers"].(map[string]any)
 		if !ok {
@@ -507,7 +540,7 @@ func executableFromCommandValue(command any) (string, bool) {
 
 func isStandardAgent(id model.AgentID) bool {
 	switch id {
-	case model.AgentOpenCode, model.AgentQwenCode, model.AgentCodex, model.AgentGeminiCLI, model.AgentAntigravity, model.AgentClaudeCode:
+	case model.AgentOpenCode, model.AgentQwenCode, model.AgentCodex, model.AgentGeminiCLI, model.AgentAntigravity, model.AgentClaudeCode, model.AgentOpenClaw:
 		return true
 	default:
 		return false

--- a/internal/components/engram/inject_test.go
+++ b/internal/components/engram/inject_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gentleman-programming/gentle-ai/internal/agents/claude"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/codex"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/gemini"
+	"github.com/gentleman-programming/gentle-ai/internal/agents/openclaw"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/opencode"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/qwen"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/vscode"
@@ -23,6 +24,7 @@ func opencodeAdapter() agents.Adapter { return opencode.NewAdapter() }
 func codexAdapter() agents.Adapter    { return codex.NewAdapter() }
 func geminiAdapter() agents.Adapter   { return gemini.NewAdapter() }
 func qwenAdapter() agents.Adapter     { return qwen.NewAdapter() }
+func openclawAdapter() agents.Adapter { return openclaw.NewAdapter() }
 func antigravityAdapter() agents.Adapter {
 	return antigravity.NewAdapter()
 }
@@ -1087,4 +1089,268 @@ func TestQwenEngramIdempotency(t *testing.T) {
 	if string(content1) != string(content2) {
 		t.Errorf("Idempotency failure! Settings changed between runs despite engram command being stable-relative.\nRun 1:\n%s\nRun 2:\n%s", string(content1), string(content2))
 	}
+}
+
+func TestInjectOpenClawMergesEngramIntoMCPServersPreservingStdioAndRemoteFields(t *testing.T) {
+	home := t.TempDir()
+	adapter := openclawAdapter()
+	configPath := adapter.SettingsPath(home)
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+
+	existing := `{
+  "mcp": {
+    "sessionIdleTtlMs": 120000,
+    "servers": {
+      "filesystem": {
+        "command": "npx",
+        "args": ["-y", "@modelcontextprotocol/server-filesystem"],
+        "env": {"ROOT": "/workspace"},
+        "unknownStdioField": true
+      },
+      "linear": {
+        "url": "https://mcp.linear.app/sse",
+        "transport": "sse",
+        "headers": {"Authorization": "Bearer existing-token"},
+        "unknownRemoteField": "preserve-me"
+      }
+    }
+  },
+  "theme": "kanagawa"
+}`
+	if err := os.WriteFile(configPath, []byte(existing), 0o644); err != nil {
+		t.Fatalf("WriteFile(openclaw.json) error = %v", err)
+	}
+
+	result, err := Inject(home, adapter)
+	if err != nil {
+		t.Fatalf("Inject(openclaw) error = %v", err)
+	}
+	if !result.Changed {
+		t.Fatal("Inject(openclaw) changed = false")
+	}
+
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("ReadFile(openclaw.json) error = %v", err)
+	}
+	root := unmarshalObjectForTest(t, content)
+	mcp := objectAtForTest(t, root, "mcp")
+	if got := mcp["sessionIdleTtlMs"]; got != float64(120000) {
+		t.Fatalf("mcp.sessionIdleTtlMs = %v, want preserved 120000", got)
+	}
+	servers := objectAtForTest(t, mcp, "servers")
+
+	filesystem := objectAtForTest(t, servers, "filesystem")
+	if got := filesystem["command"]; got != "npx" {
+		t.Fatalf("filesystem.command = %v, want npx", got)
+	}
+	if got := filesystem["unknownStdioField"]; got != true {
+		t.Fatalf("filesystem.unknownStdioField = %v, want true", got)
+	}
+	args, ok := filesystem["args"].([]any)
+	if !ok || len(args) != 2 || args[1] != "@modelcontextprotocol/server-filesystem" {
+		t.Fatalf("filesystem.args = %#v, want preserved stdio args", filesystem["args"])
+	}
+
+	linear := objectAtForTest(t, servers, "linear")
+	if got := linear["url"]; got != "https://mcp.linear.app/sse" {
+		t.Fatalf("linear.url = %v, want preserved remote url", got)
+	}
+	if got := linear["transport"]; got != "sse" {
+		t.Fatalf("linear.transport = %v, want sse", got)
+	}
+	headers := objectAtForTest(t, linear, "headers")
+	if got := headers["Authorization"]; got != "Bearer existing-token" {
+		t.Fatalf("linear Authorization header = %v, want preserved token", got)
+	}
+	if got := linear["unknownRemoteField"]; got != "preserve-me" {
+		t.Fatalf("linear.unknownRemoteField = %v, want preserve-me", got)
+	}
+
+	engram := objectAtForTest(t, servers, "engram")
+	if got := engram["command"]; got != "engram" {
+		t.Fatalf("engram.command = %v, want engram", got)
+	}
+	engramArgs, ok := engram["args"].([]any)
+	if !ok || len(engramArgs) != 2 || engramArgs[0] != "mcp" || engramArgs[1] != "--tools=agent" {
+		t.Fatalf("engram.args = %#v, want [mcp --tools=agent]", engram["args"])
+	}
+	if _, hasMCPServers := root["mcpServers"]; hasMCPServers {
+		t.Fatal("OpenClaw config must use mcp.servers, not top-level mcpServers")
+	}
+}
+
+func TestInjectOpenClawHandlesJSON5ConfigAndMissingConfigPath(t *testing.T) {
+	t.Run("preserves JSON5 compatible config content as normalized JSON", func(t *testing.T) {
+		home := t.TempDir()
+		adapter := openclawAdapter()
+		configPath := adapter.SettingsPath(home)
+		if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+			t.Fatalf("MkdirAll() error = %v", err)
+		}
+
+		existing := `{
+  // OpenClaw user config with JSON5-style comments.
+  "ui": {
+    "theme": "kanagawa", // trailing comma survives via normalization
+  },
+  "mcp": {
+    "servers": {
+      "remoteDocs": {
+        "url": "https://docs.example/mcp",
+        "transport": "http",
+      },
+    },
+  },
+}`
+		if err := os.WriteFile(configPath, []byte(existing), 0o644); err != nil {
+			t.Fatalf("WriteFile(openclaw.json) error = %v", err)
+		}
+
+		if _, err := Inject(home, adapter); err != nil {
+			t.Fatalf("Inject(openclaw) error = %v", err)
+		}
+
+		content, err := os.ReadFile(configPath)
+		if err != nil {
+			t.Fatalf("ReadFile(openclaw.json) error = %v", err)
+		}
+		root := unmarshalObjectForTest(t, content)
+		ui := objectAtForTest(t, root, "ui")
+		if got := ui["theme"]; got != "kanagawa" {
+			t.Fatalf("ui.theme = %v, want preserved kanagawa", got)
+		}
+		servers := objectAtForTest(t, objectAtForTest(t, root, "mcp"), "servers")
+		remoteDocs := objectAtForTest(t, servers, "remoteDocs")
+		if got := remoteDocs["transport"]; got != "http" {
+			t.Fatalf("remoteDocs.transport = %v, want preserved http", got)
+		}
+		if _, ok := servers["engram"]; !ok {
+			t.Fatal("mcp.servers.engram missing after JSON5 merge")
+		}
+	})
+
+	t.Run("creates canonical OpenClaw config when missing", func(t *testing.T) {
+		home := t.TempDir()
+		adapter := openclawAdapter()
+		configPath := filepath.Join(home, ".openclaw", "openclaw.json")
+
+		if _, err := os.Stat(configPath); !os.IsNotExist(err) {
+			t.Fatalf("expected missing OpenClaw config before inject, got err=%v", err)
+		}
+		if _, err := Inject(home, adapter); err != nil {
+			t.Fatalf("Inject(openclaw) error = %v", err)
+		}
+		content, err := os.ReadFile(configPath)
+		if err != nil {
+			t.Fatalf("ReadFile(created openclaw.json) error = %v", err)
+		}
+		servers := objectAtForTest(t, objectAtForTest(t, unmarshalObjectForTest(t, content), "mcp"), "servers")
+		if _, ok := servers["engram"]; !ok {
+			t.Fatal("created OpenClaw config missing mcp.servers.engram")
+		}
+	})
+}
+
+func TestInjectOpenClawWritesEngramProtocolToWorkspaceAgentsOnly(t *testing.T) {
+	workspace := t.TempDir()
+	adapter := openclawAdapter()
+	toolsPath := filepath.Join(workspace, "TOOLS.md")
+	if err := os.WriteFile(toolsPath, []byte("# Tool guidance\n\nUser-owned tool notes.\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(TOOLS.md) error = %v", err)
+	}
+
+	first, err := Inject(workspace, adapter)
+	if err != nil {
+		t.Fatalf("Inject(openclaw) first error = %v", err)
+	}
+	if !first.Changed {
+		t.Fatal("Inject(openclaw) first changed = false")
+	}
+
+	agentsPath := filepath.Join(workspace, "AGENTS.md")
+	agentsContent, err := os.ReadFile(agentsPath)
+	if err != nil {
+		t.Fatalf("ReadFile(AGENTS.md) error = %v", err)
+	}
+	agentsText := string(agentsContent)
+	for _, want := range []string{
+		"<!-- gentle-ai:engram-protocol -->",
+		"<!-- /gentle-ai:engram-protocol -->",
+		"mem_save",
+	} {
+		if !strings.Contains(agentsText, want) {
+			t.Fatalf("OpenClaw AGENTS.md missing Engram protocol content %q; got:\n%s", want, agentsText)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(workspace, ".openclaw", "AGENTS.md")); !os.IsNotExist(err) {
+		t.Fatalf("OpenClaw Engram injection must not write global .openclaw/AGENTS.md; stat err=%v", err)
+	}
+
+	toolsContent, err := os.ReadFile(toolsPath)
+	if err != nil {
+		t.Fatalf("ReadFile(TOOLS.md) error = %v", err)
+	}
+	toolsText := string(toolsContent)
+	if strings.Contains(toolsText, "gentle-ai:engram-protocol") || strings.Contains(toolsText, "mem_save") {
+		t.Fatalf("TOOLS.md must not receive Engram protocol sections; got:\n%s", toolsText)
+	}
+	if !strings.Contains(toolsText, "User-owned tool notes.") {
+		t.Fatalf("TOOLS.md user content was modified; got:\n%s", toolsText)
+	}
+
+	second, err := Inject(workspace, adapter)
+	if err != nil {
+		t.Fatalf("Inject(openclaw) second error = %v", err)
+	}
+	if second.Changed {
+		t.Fatal("OpenClaw Engram injection should be idempotent")
+	}
+	updated, err := os.ReadFile(agentsPath)
+	if err != nil {
+		t.Fatalf("ReadFile(AGENTS.md) second error = %v", err)
+	}
+	if count := strings.Count(string(updated), "<!-- gentle-ai:engram-protocol -->"); count != 1 {
+		t.Fatalf("AGENTS.md has %d Engram protocol markers, want exactly 1", count)
+	}
+}
+
+func TestInjectOpenClawRejectsAmbiguousWorkspacePath(t *testing.T) {
+	cwd := t.TempDir()
+	t.Chdir(cwd)
+
+	result, err := Inject("", openclawAdapter())
+	if err == nil {
+		t.Fatalf("Inject(openclaw, empty workspace) error = nil, want deterministic ambiguity error; result=%+v", result)
+	}
+	if _, statErr := os.Stat(filepath.Join(cwd, ".openclaw", "openclaw.json")); !os.IsNotExist(statErr) {
+		t.Fatalf("ambiguous OpenClaw workspace must not create relative config; stat err=%v", statErr)
+	}
+	if _, statErr := os.Stat(filepath.Join(cwd, "AGENTS.md")); !os.IsNotExist(statErr) {
+		t.Fatalf("ambiguous OpenClaw workspace must not create relative AGENTS.md; stat err=%v", statErr)
+	}
+}
+
+func unmarshalObjectForTest(t *testing.T, content []byte) map[string]any {
+	t.Helper()
+	var root map[string]any
+	if err := json.Unmarshal(content, &root); err != nil {
+		t.Fatalf("Unmarshal JSON error = %v; content:\n%s", err, content)
+	}
+	return root
+}
+
+func objectAtForTest(t *testing.T, root map[string]any, key string) map[string]any {
+	t.Helper()
+	value, ok := root[key]
+	if !ok {
+		t.Fatalf("missing object key %q in %#v", key, root)
+	}
+	object, ok := value.(map[string]any)
+	if !ok {
+		t.Fatalf("key %q has type %T, want object", key, value)
+	}
+	return object
 }

--- a/internal/components/openclaw_integration_test.go
+++ b/internal/components/openclaw_integration_test.go
@@ -1,0 +1,125 @@
+package components_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/internal/agents"
+	"github.com/gentleman-programming/gentle-ai/internal/components/engram"
+	"github.com/gentleman-programming/gentle-ai/internal/components/persona"
+	"github.com/gentleman-programming/gentle-ai/internal/components/sdd"
+	"github.com/gentleman-programming/gentle-ai/internal/model"
+)
+
+func TestOpenClawSelectedAdapterRoutesToExpectedInjectors(t *testing.T) {
+	workspace := t.TempDir()
+	adapter, err := agents.NewAdapter(model.AgentOpenClaw)
+	if err != nil {
+		t.Fatalf("NewAdapter(openclaw) error = %v", err)
+	}
+
+	if _, err := engram.Inject(workspace, adapter); err != nil {
+		t.Fatalf("engram.Inject(openclaw) error = %v", err)
+	}
+	if _, err := sdd.Inject(workspace, adapter, model.SDDModeSingle, sdd.InjectOptions{StrictTDD: true, WorkspaceDir: workspace}); err != nil {
+		t.Fatalf("sdd.Inject(openclaw) error = %v", err)
+	}
+	if _, err := persona.Inject(workspace, adapter, model.PersonaGentleman); err != nil {
+		t.Fatalf("persona.Inject(openclaw) error = %v", err)
+	}
+
+	config := readText(t, filepath.Join(workspace, ".openclaw", "openclaw.json"))
+	var root map[string]any
+	if err := json.Unmarshal([]byte(config), &root); err != nil {
+		t.Fatalf("Unmarshal openclaw.json error = %v; content:\n%s", err, config)
+	}
+	servers := objectAt(t, objectAt(t, root, "mcp"), "servers")
+	engramServer := objectAt(t, servers, "engram")
+	if got := engramServer["command"]; got != "engram" {
+		t.Fatalf("OpenClaw Engram command = %v, want engram", got)
+	}
+
+	agentsText := readText(t, filepath.Join(workspace, "AGENTS.md"))
+	for _, want := range []string{"gentle-ai:engram-protocol", "gentle-ai:sdd-orchestrator", "gentle-ai:strict-tdd-mode"} {
+		if !strings.Contains(agentsText, want) {
+			t.Fatalf("OpenClaw AGENTS.md missing %q; got:\n%s", want, agentsText)
+		}
+	}
+	if strings.Contains(agentsText, "Senior Architect") {
+		t.Fatalf("OpenClaw AGENTS.md must not receive persona content; got:\n%s", agentsText)
+	}
+
+	soulText := readText(t, filepath.Join(workspace, "SOUL.md"))
+	if !strings.Contains(soulText, "gentle-ai:persona") || !strings.Contains(soulText, "Senior Architect") {
+		t.Fatalf("OpenClaw SOUL.md missing managed persona content; got:\n%s", soulText)
+	}
+	if _, err := os.Stat(filepath.Join(workspace, "TOOLS.md")); !os.IsNotExist(err) {
+		t.Fatalf("OpenClaw injector chain must not create TOOLS.md for protocols; stat err=%v", err)
+	}
+}
+
+func TestOpenClawInjectorChainRerunIsIdempotent(t *testing.T) {
+	workspace := t.TempDir()
+	adapter, err := agents.NewAdapter(model.AgentOpenClaw)
+	if err != nil {
+		t.Fatalf("NewAdapter(openclaw) error = %v", err)
+	}
+
+	runOpenClawInjectorChain(t, workspace, adapter)
+	beforeAgents := readText(t, filepath.Join(workspace, "AGENTS.md"))
+	beforeSoul := readText(t, filepath.Join(workspace, "SOUL.md"))
+	beforeConfig := readText(t, filepath.Join(workspace, ".openclaw", "openclaw.json"))
+
+	runOpenClawInjectorChain(t, workspace, adapter)
+	afterAgents := readText(t, filepath.Join(workspace, "AGENTS.md"))
+	afterSoul := readText(t, filepath.Join(workspace, "SOUL.md"))
+	afterConfig := readText(t, filepath.Join(workspace, ".openclaw", "openclaw.json"))
+
+	if beforeAgents != afterAgents {
+		t.Fatalf("OpenClaw AGENTS.md changed on rerun\nbefore:\n%s\nafter:\n%s", beforeAgents, afterAgents)
+	}
+	if beforeSoul != afterSoul {
+		t.Fatalf("OpenClaw SOUL.md changed on rerun\nbefore:\n%s\nafter:\n%s", beforeSoul, afterSoul)
+	}
+	if beforeConfig != afterConfig {
+		t.Fatalf("OpenClaw config changed on rerun\nbefore:\n%s\nafter:\n%s", beforeConfig, afterConfig)
+	}
+}
+
+func runOpenClawInjectorChain(t *testing.T, workspace string, adapter agents.Adapter) {
+	t.Helper()
+	if _, err := engram.Inject(workspace, adapter); err != nil {
+		t.Fatalf("engram.Inject(openclaw) error = %v", err)
+	}
+	if _, err := sdd.Inject(workspace, adapter, model.SDDModeSingle, sdd.InjectOptions{StrictTDD: true, WorkspaceDir: workspace}); err != nil {
+		t.Fatalf("sdd.Inject(openclaw) error = %v", err)
+	}
+	if _, err := persona.Inject(workspace, adapter, model.PersonaGentleman); err != nil {
+		t.Fatalf("persona.Inject(openclaw) error = %v", err)
+	}
+}
+
+func readText(t *testing.T, path string) string {
+	t.Helper()
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", path, err)
+	}
+	return string(content)
+}
+
+func objectAt(t *testing.T, root map[string]any, key string) map[string]any {
+	t.Helper()
+	value, ok := root[key]
+	if !ok {
+		t.Fatalf("missing object key %q in %#v", key, root)
+	}
+	object, ok := value.(map[string]any)
+	if !ok {
+		t.Fatalf("key %q has type %T, want object", key, value)
+	}
+	return object
+}

--- a/internal/components/openclaw_integration_test.go
+++ b/internal/components/openclaw_integration_test.go
@@ -38,8 +38,12 @@ func TestOpenClawSelectedAdapterRoutesToExpectedInjectors(t *testing.T) {
 	}
 	servers := objectAt(t, objectAt(t, root, "mcp"), "servers")
 	engramServer := objectAt(t, servers, "engram")
-	if got := engramServer["command"]; got != "engram" {
-		t.Fatalf("OpenClaw Engram command = %v, want engram", got)
+	command, ok := engramServer["command"].(string)
+	if !ok {
+		t.Fatalf("OpenClaw Engram command = %#v, want string", engramServer["command"])
+	}
+	if got := filepath.Base(command); got != "engram" {
+		t.Fatalf("OpenClaw Engram command = %q, want executable named engram", command)
 	}
 
 	agentsText := readText(t, filepath.Join(workspace, "AGENTS.md"))

--- a/internal/components/persona/inject.go
+++ b/internal/components/persona/inject.go
@@ -60,6 +60,9 @@ func injectInternal(homeDir string, adapter agents.Adapter, persona model.Person
 	if !adapter.SupportsSystemPrompt() {
 		return InjectionResult{}, nil
 	}
+	if err := validateOpenClawWorkspacePath(homeDir, adapter); err != nil {
+		return InjectionResult{}, err
+	}
 
 	// Custom persona does nothing — user keeps their own config.
 	if persona == model.PersonaCustom {
@@ -75,6 +78,10 @@ func injectInternal(homeDir string, adapter agents.Adapter, persona model.Person
 	}
 
 	// 1. Inject persona content based on system prompt strategy.
+	if adapter.Agent() == model.AgentOpenClaw {
+		return injectOpenClawSoulPersona(homeDir, content)
+	}
+
 	switch adapter.SystemPromptStrategy() {
 	case model.StrategyMarkdownSections:
 		promptPath := adapter.SystemPromptFile(homeDir)
@@ -321,7 +328,7 @@ func injectInternal(homeDir string, adapter agents.Adapter, persona model.Person
 	}
 
 	// 3. Gentleman-only: write output style + merge into settings (if agent supports it).
-	if persona == model.PersonaGentleman && adapter.SupportsOutputStyles() {
+	if persona == model.PersonaGentleman && adapter.Agent() != model.AgentOpenClaw && adapter.SupportsOutputStyles() {
 		outputStyleDir := adapter.OutputStyleDir(homeDir)
 		if outputStyleDir != "" {
 			outputStylePath := outputStyleDir + "/gentleman.md"
@@ -348,6 +355,32 @@ func injectInternal(homeDir string, adapter agents.Adapter, persona model.Person
 	}
 
 	return InjectionResult{Changed: changed, Files: files}, nil
+}
+
+func validateOpenClawWorkspacePath(workspaceDir string, adapter agents.Adapter) error {
+	if adapter.Agent() == model.AgentOpenClaw && strings.TrimSpace(workspaceDir) == "" {
+		return fmt.Errorf("openclaw workspace path is required for workspace-first injection")
+	}
+	return nil
+}
+
+func injectOpenClawSoulPersona(workspaceDir, content string) (InjectionResult, error) {
+	soulPath := filepath.Join(workspaceDir, "SOUL.md")
+	existing, err := readFileOrEmpty(soulPath)
+	if err != nil {
+		return InjectionResult{}, err
+	}
+
+	healed := filemerge.StripLegacyPersonaBlock(existing)
+	healed = filemerge.StripLegacyATLBlock(healed)
+	updated := filemerge.InjectMarkdownSection(healed, "persona", content)
+
+	writeResult, err := filemerge.WriteFileAtomic(soulPath, []byte(updated), 0o644)
+	if err != nil {
+		return InjectionResult{}, err
+	}
+
+	return InjectionResult{Changed: writeResult.Changed, Files: []string{soulPath}}, nil
 }
 
 // shouldStripManagedLegacyPersona returns true ONLY when the existing file

--- a/internal/components/persona/inject_test.go
+++ b/internal/components/persona/inject_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gentleman-programming/gentle-ai/internal/agents"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/claude"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/kimi"
+	"github.com/gentleman-programming/gentle-ai/internal/agents/openclaw"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/opencode"
 	"github.com/gentleman-programming/gentle-ai/internal/assets"
 	"github.com/gentleman-programming/gentle-ai/internal/model"
@@ -17,6 +18,7 @@ import (
 
 func claudeAdapter() agents.Adapter   { return claude.NewAdapter() }
 func kimiAdapter() agents.Adapter     { return kimi.NewAdapter() }
+func openclawAdapter() agents.Adapter { return openclaw.NewAdapter() }
 func opencodeAdapter() agents.Adapter { return opencode.NewAdapter() }
 
 func assertGentlemanLanguageGuardrails(t *testing.T, text string, required []string, banned []string) {
@@ -420,6 +422,103 @@ func TestInjectOpenCodePreservesUserContentInsteadOfOverwriting(t *testing.T) {
 	}
 	if !strings.Contains(text, "<!-- gentle-ai:persona -->") {
 		t.Fatal("AGENTS.md missing managed persona section after inject")
+	}
+}
+
+func TestInjectOpenClawWritesPersonaToWorkspaceSoulAndNotAgents(t *testing.T) {
+	workspace := t.TempDir()
+	adapter := openclawAdapter()
+	agentsPath := filepath.Join(workspace, "AGENTS.md")
+	if err := os.WriteFile(agentsPath, []byte("# Existing agent protocols\n\nKeep SDD here.\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(AGENTS.md) error = %v", err)
+	}
+
+	result, err := Inject(workspace, adapter, model.PersonaGentleman)
+	if err != nil {
+		t.Fatalf("Inject(openclaw) error = %v", err)
+	}
+	if !result.Changed {
+		t.Fatal("Inject(openclaw) changed = false")
+	}
+
+	soulPath := filepath.Join(workspace, "SOUL.md")
+	soulContent, err := os.ReadFile(soulPath)
+	if err != nil {
+		t.Fatalf("ReadFile(SOUL.md) error = %v", err)
+	}
+	soulText := string(soulContent)
+	if !strings.Contains(soulText, "<!-- gentle-ai:persona -->") {
+		t.Fatalf("SOUL.md missing managed persona marker; got:\n%s", soulText)
+	}
+	if !strings.Contains(soulText, "Senior Architect") {
+		t.Fatalf("SOUL.md missing real persona content; got:\n%s", soulText)
+	}
+	if !strings.Contains(soulText, "Match the user's current language.") {
+		t.Fatalf("SOUL.md missing persona language guardrail; got:\n%s", soulText)
+	}
+
+	agentsContent, err := os.ReadFile(agentsPath)
+	if err != nil {
+		t.Fatalf("ReadFile(AGENTS.md) error = %v", err)
+	}
+	agentsText := string(agentsContent)
+	if !strings.Contains(agentsText, "Keep SDD here.") {
+		t.Fatalf("AGENTS.md user protocol content was modified; got:\n%s", agentsText)
+	}
+	if strings.Contains(agentsText, "<!-- gentle-ai:persona -->") || strings.Contains(agentsText, "Senior Architect") {
+		t.Fatalf("OpenClaw persona must not be written to AGENTS.md; got:\n%s", agentsText)
+	}
+}
+
+func TestInjectOpenClawSoulPersonaIsIdempotentAndPreservesUserContent(t *testing.T) {
+	workspace := t.TempDir()
+	soulPath := filepath.Join(workspace, "SOUL.md")
+	if err := os.WriteFile(soulPath, []byte("# Custom soul\n\nKeep my tone note.\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(SOUL.md) error = %v", err)
+	}
+
+	adapter := openclawAdapter()
+	first, err := Inject(workspace, adapter, model.PersonaGentleman)
+	if err != nil {
+		t.Fatalf("Inject(openclaw) first error = %v", err)
+	}
+	if !first.Changed {
+		t.Fatal("Inject(openclaw) first changed = false")
+	}
+	second, err := Inject(workspace, adapter, model.PersonaGentleman)
+	if err != nil {
+		t.Fatalf("Inject(openclaw) second error = %v", err)
+	}
+	if second.Changed {
+		t.Fatal("OpenClaw SOUL.md persona injection should be idempotent")
+	}
+
+	content, err := os.ReadFile(soulPath)
+	if err != nil {
+		t.Fatalf("ReadFile(SOUL.md) error = %v", err)
+	}
+	text := string(content)
+	if !strings.Contains(text, "Keep my tone note.") {
+		t.Fatalf("SOUL.md user content was lost; got:\n%s", text)
+	}
+	if count := strings.Count(text, "<!-- gentle-ai:persona -->"); count != 1 {
+		t.Fatalf("SOUL.md has %d persona markers, want exactly 1", count)
+	}
+}
+
+func TestInjectOpenClawRejectsAmbiguousWorkspacePath(t *testing.T) {
+	cwd := t.TempDir()
+	t.Chdir(cwd)
+
+	result, err := Inject("", openclawAdapter(), model.PersonaGentleman)
+	if err == nil {
+		t.Fatalf("Inject(openclaw, empty workspace) error = nil, want deterministic ambiguity error; result=%+v", result)
+	}
+	if _, statErr := os.Stat(filepath.Join(cwd, "SOUL.md")); !os.IsNotExist(statErr) {
+		t.Fatalf("ambiguous OpenClaw workspace must not create relative SOUL.md; stat err=%v", statErr)
+	}
+	if _, statErr := os.Stat(filepath.Join(cwd, "AGENTS.md")); !os.IsNotExist(statErr) {
+		t.Fatalf("ambiguous OpenClaw workspace must not create relative AGENTS.md; stat err=%v", statErr)
 	}
 }
 

--- a/internal/components/sdd/inject.go
+++ b/internal/components/sdd/inject.go
@@ -197,6 +197,9 @@ func Inject(homeDir string, adapter agents.Adapter, sddMode model.SDDModeID, opt
 	if !adapter.SupportsSystemPrompt() {
 		return InjectionResult{}, nil
 	}
+	if err := validateOpenClawWorkspacePath(homeDir, adapter); err != nil {
+		return InjectionResult{}, err
+	}
 
 	var opts InjectOptions
 	if len(options) > 0 {
@@ -706,6 +709,13 @@ func Inject(homeDir string, adapter agents.Adapter, sddMode model.SDDModeID, opt
 	}
 
 	return InjectionResult{Changed: changed, Files: files}, nil
+}
+
+func validateOpenClawWorkspacePath(workspaceDir string, adapter agents.Adapter) error {
+	if adapter.Agent() == model.AgentOpenClaw && strings.TrimSpace(workspaceDir) == "" {
+		return fmt.Errorf("openclaw workspace path is required for workspace-first injection")
+	}
+	return nil
 }
 
 func inlineOpenCodeSDDPrompts(overlayBytes []byte, homeDir, settingsPath string, preserveExistingOrchestratorPrompt bool) ([]byte, error) {

--- a/internal/components/sdd/inject_test.go
+++ b/internal/components/sdd/inject_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gentleman-programming/gentle-ai/internal/agents"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/claude"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/kimi"
+	"github.com/gentleman-programming/gentle-ai/internal/agents/openclaw"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/opencode"
 	windsurfagent "github.com/gentleman-programming/gentle-ai/internal/agents/windsurf"
 	"github.com/gentleman-programming/gentle-ai/internal/assets"
@@ -22,6 +23,7 @@ import (
 
 func claudeAdapter() agents.Adapter   { return claude.NewAdapter() }
 func kimiAdapter() agents.Adapter     { return kimi.NewAdapter() }
+func openclawAdapter() agents.Adapter { return openclaw.NewAdapter() }
 func opencodeAdapter() agents.Adapter { return opencode.NewAdapter() }
 func windsurfAdapter() agents.Adapter { return windsurfagent.NewAdapter() }
 
@@ -1621,6 +1623,110 @@ func TestInjectClaudeDeduplicatesBareOrchestratorAtEndOfFile(t *testing.T) {
 	}
 	if !strings.Contains(text, "Be excellent.") {
 		t.Fatal("user content outside orchestrator section was lost")
+	}
+}
+
+func TestInjectOpenClawWritesWorkspaceAgentsProtocolSectionsAndNoToolsProtocol(t *testing.T) {
+	workspace := t.TempDir()
+	adapter := openclawAdapter()
+	toolsPath := filepath.Join(workspace, "TOOLS.md")
+	if err := os.WriteFile(toolsPath, []byte("# User tool notes\n\nKeep this.\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(TOOLS.md) error = %v", err)
+	}
+
+	result, err := Inject(workspace, adapter, model.SDDModeSingle, InjectOptions{StrictTDD: true, WorkspaceDir: workspace})
+	if err != nil {
+		t.Fatalf("Inject(openclaw) error = %v", err)
+	}
+	if !result.Changed {
+		t.Fatal("Inject(openclaw) changed = false")
+	}
+
+	agentsPath := filepath.Join(workspace, "AGENTS.md")
+	content, err := os.ReadFile(agentsPath)
+	if err != nil {
+		t.Fatalf("ReadFile(AGENTS.md) error = %v", err)
+	}
+	text := string(content)
+	for _, want := range []string{
+		"<!-- gentle-ai:sdd-orchestrator -->",
+		"<!-- /gentle-ai:sdd-orchestrator -->",
+		"<!-- gentle-ai:strict-tdd-mode -->",
+		"Strict TDD Mode: enabled",
+		"Spec-Driven Development",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("OpenClaw AGENTS.md missing %q; got:\n%s", want, text)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(workspace, ".openclaw", "AGENTS.md")); !os.IsNotExist(err) {
+		t.Fatalf("OpenClaw SDD injection must not write global .openclaw/AGENTS.md; stat err=%v", err)
+	}
+
+	toolsContent, err := os.ReadFile(toolsPath)
+	if err != nil {
+		t.Fatalf("ReadFile(TOOLS.md) error = %v", err)
+	}
+	toolsText := string(toolsContent)
+	if strings.Contains(toolsText, "gentle-ai:sdd-orchestrator") || strings.Contains(toolsText, "Strict TDD Mode") {
+		t.Fatalf("TOOLS.md must not receive OpenClaw protocol sections; got:\n%s", toolsText)
+	}
+	if !strings.Contains(toolsText, "Keep this.") {
+		t.Fatalf("TOOLS.md user content was modified; got:\n%s", toolsText)
+	}
+
+	second, err := Inject(workspace, adapter, model.SDDModeSingle, InjectOptions{StrictTDD: true, WorkspaceDir: workspace})
+	if err != nil {
+		t.Fatalf("Inject(openclaw) second error = %v", err)
+	}
+	if second.Changed {
+		t.Fatal("OpenClaw SDD injection should be idempotent on second run")
+	}
+	updated, err := os.ReadFile(agentsPath)
+	if err != nil {
+		t.Fatalf("ReadFile(AGENTS.md) second error = %v", err)
+	}
+	if count := strings.Count(string(updated), "<!-- gentle-ai:sdd-orchestrator -->"); count != 1 {
+		t.Fatalf("AGENTS.md has %d SDD markers, want exactly 1", count)
+	}
+}
+
+func TestInjectOpenClawPreservesWorkspaceAgentsUserContent(t *testing.T) {
+	workspace := t.TempDir()
+	agentsPath := filepath.Join(workspace, "AGENTS.md")
+	if err := os.WriteFile(agentsPath, []byte("# Project Rules\n\nDo not delete workspace instructions.\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(AGENTS.md) error = %v", err)
+	}
+
+	if _, err := Inject(workspace, openclawAdapter(), model.SDDModeSingle); err != nil {
+		t.Fatalf("Inject(openclaw) error = %v", err)
+	}
+	content, err := os.ReadFile(agentsPath)
+	if err != nil {
+		t.Fatalf("ReadFile(AGENTS.md) error = %v", err)
+	}
+	text := string(content)
+	if !strings.Contains(text, "Do not delete workspace instructions.") {
+		t.Fatalf("OpenClaw workspace AGENTS.md user content was lost; got:\n%s", text)
+	}
+	if !strings.Contains(text, "<!-- gentle-ai:sdd-orchestrator -->") {
+		t.Fatalf("OpenClaw workspace AGENTS.md missing managed SDD section; got:\n%s", text)
+	}
+}
+
+func TestInjectOpenClawRejectsAmbiguousWorkspacePath(t *testing.T) {
+	cwd := t.TempDir()
+	t.Chdir(cwd)
+
+	result, err := Inject("", openclawAdapter(), model.SDDModeSingle, InjectOptions{StrictTDD: true})
+	if err == nil {
+		t.Fatalf("Inject(openclaw, empty workspace) error = nil, want deterministic ambiguity error; result=%+v", result)
+	}
+	if _, statErr := os.Stat(filepath.Join(cwd, "AGENTS.md")); !os.IsNotExist(statErr) {
+		t.Fatalf("ambiguous OpenClaw workspace must not create relative AGENTS.md; stat err=%v", statErr)
+	}
+	if _, statErr := os.Stat(filepath.Join(cwd, "TOOLS.md")); !os.IsNotExist(statErr) {
+		t.Fatalf("ambiguous OpenClaw workspace must not create relative TOOLS.md; stat err=%v", statErr)
 	}
 }
 

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -15,6 +15,7 @@ const (
 	AgentKimi          AgentID = "kimi"
 	AgentQwenCode      AgentID = "qwen-code"
 	AgentKiroIDE       AgentID = "kiro-ide"
+	AgentOpenClaw      AgentID = "openclaw"
 )
 
 // SupportTier indicates how fully an agent supports the Gentleman AI ecosystem.


### PR DESCRIPTION
## 🚀 Feature Complete - Chained PRs

Closes #469

This PR tracks the `feat/469-openclaw-support` feature branch for OpenClaw support.

### Included PRs

| # | PR | Sub-task | Status |
|---|----|----------|--------|
| 1 | #471 | OpenClaw foundation | 🟡 Open |
| 2 | #472 | Engram and prompt integration | 🟡 Open |
| 3 | #473 | Hardening and idempotency | 🟡 Open |

### Dependency Diagram

```text
feat/469-openclaw-support
  └── PR1 foundation (#471)
        └── PR2 integration (#472)
              └── PR3 hardening (#473)
```

---

### Context

OpenClaw should be a first-class Gentle AI target with adapter registration, Engram MCP integration, and OpenClaw-native prompt surfaces.

---

### Description

**Key Changes:**

- Register OpenClaw as a supported agent.
- Install Engram MCP into OpenClaw `mcp.servers`.
- Inject system protocols into `AGENTS.md` and persona/output style into `SOUL.md`.
- Preserve idempotency and workspace-first safety.

---

### Steps to review

1. Review individual chained PRs first: #471 → #472 → #473.
2. Confirm each PR targets the expected chain branch.
3. Confirm final verification report is PASS in Engram.

---

### Checklist

- [x] Code is covered by tests
- [x] Documentation updated (if applicable)
- [x] CHANGELOG updated (if applicable)
- [x] No unresolved merge conflicts
- [x] CI/CD pipeline passes
- [x] Self-reviewed the diff before requesting review