### PR TITLE
feat: Add Pi coding agent support

### DIFF
--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,110 @@
+# feat: Add Pi coding agent support
+
+## Summary
+
+This PR adds first-class MVP support for **Pi coding agent** (`pi-coding-agent`) as the 14th supported agent in the Gentle-AI ecosystem.
+
+Pi is intentionally integrated as a **solo-agent** (no native sub-agents or MCP in the core), which is the correct abstraction given Pi's architecture: it ships with prompt templates, Agent Skills, and extensions — but not built-in sub-agent delegation or MCP config surfaces.
+
+## What changed
+
+### New files (11)
+
+| File | Purpose |
+|------|---------|
+| `internal/agents/pi/adapter.go` | Pi adapter: detection (`pi` binary + `~/.pi/agent`), npm auto-install, config paths, honest capability flags |
+| `internal/agents/pi/adapter_test.go` | Table-driven tests following the exact style of `codex/` and `qwen/` adapters |
+| `internal/assets/pi/sdd-orchestrator.md` | Solo-agent SDD orchestrator tailored for Pi (no `mem_*` MCP calls, `openspec` as safe default) |
+| `internal/assets/pi/prompts/sdd-init.md` | Pi prompt template: initialize SDD context |
+| `internal/assets/pi/prompts/sdd-explore.md` | Pi prompt template: explore a topic |
+| `internal/assets/pi/prompts/sdd-apply.md` | Pi prompt template: implement tasks |
+| `internal/assets/pi/prompts/sdd-verify.md` | Pi prompt template: validate implementation |
+| `internal/assets/pi/prompts/sdd-archive.md` | Pi prompt template: archive change |
+| `internal/assets/pi/prompts/sdd-onboard.md` | Pi prompt template: guided walkthrough |
+| `internal/assets/pi/prompts/sdd-new.md` | Pi prompt template: start a new change |
+| `internal/assets/pi/prompts/sdd-continue.md` | Pi prompt template: continue next phase |
+| `internal/assets/pi/prompts/sdd-ff.md` | Pi prompt template: fast-forward planning |
+
+### Modified files (25)
+
+**Core model & wiring:**
+- `internal/model/types.go` — Added `AgentPiCodingAgent` and `TierPartial` support tier
+- `internal/agents/factory.go` — Registered Pi adapter in `NewAdapter` and `defaultAgentIDs`
+- `internal/catalog/agents.go` — Added Pi to `allAgents` with `TierPartial`, config path `~/.pi/agent`
+- `internal/system/config_scan.go` — Added `~/.pi/agent` to `knownAgentConfigDirs` (also backfilled missing `openclaw`)
+- `internal/cli/validate.go` — Added `pi-coding-agent` to `defaultAgentsFromDetection` switch
+- `internal/tui/model.go` — Added Pi to `preselectedAgents` (also backfilled missing `kilocode`, `kimi`, `kiro-ide`, `openclaw`)
+
+**Asset embedding & routing:**
+- `internal/assets/assets.go` — Added `all:pi` to `//go:embed`
+- `internal/assets/commands.go` — Routed `AgentPiCodingAgent` → `"pi/prompts"` for SDD slash commands
+- `internal/components/sdd/inject.go` — Routed `sddOrchestratorAsset` to `"pi/sdd-orchestrator.md"`; fixed `injectMarkdownSections` to use agent-specific asset (also fixed missing `AgentClaudeCode` case)
+
+**Safety guards (no fake MCP/Engram/Theme):**
+- `internal/cli/run.go` — Added `SupportsMCP()` guards for `ComponentEngram` and `ComponentContext7`; skips `ComponentTheme` for Pi until a theme asset exists
+- `internal/components/theme/inject.go` — Returns no-op for Pi with explanatory comment
+
+**Tests:**
+- `internal/agents/factory_test.go` — Added Pi to registry and factory resolution tests
+- `internal/agents/registry_test.go` — Added Pi to `TestDefaultRegistryIncludesAllAgents`
+- `internal/catalog/agents_test.go` — Added `TestAllAgentsIncludesPiCodingAgent` and `TestIsSupportedAgentAcceptsPiCodingAgent`
+- `internal/system/config_scan_test.go` — Updated agent count from 12 → 14
+- `internal/cli/install_test.go` — Updated default agent list and `makeDetectionWithAgents`
+- `internal/cli/run_component_paths_test.go` — Added Pi-specific path assertions (system prompt, prompts, skills; rejects MCP/theme paths)
+- `internal/components/sdd/inject_test.go` — Added `TestInjectPiWritesPromptTemplatesAndSkills` + fixed `TestSDDOrchestratorAssetSelection` expectations
+- `internal/components/theme/inject_test.go` — Added `TestInjectSkipsPiUntilThemeAssetExists`
+- `internal/assets/assets_test.go` — Added Pi files to expected list + `TestPiEmbeddedAssetLayout`
+- `internal/tui/model_test.go` — Updated `knownAgents` map and preselection tests
+
+**Docs & E2E:**
+- `README.md` — "13 Supported Agents" → "14 Supported Agents"; added Pi row
+- `docs/agents.md` — Added Pi matrix row (Skills: Yes, MCP: No, Delegation: Solo-agent, Slash Commands: Yes via prompt templates); added honest "Agent Notes" section
+- `docs/platforms.md` — Added Pi config path
+- `e2e/lib.sh` — Added `rm -rf "$HOME/.pi"` to `cleanup_test_env()`
+
+## Design decisions
+
+### Why solo-agent / `SupportsSubAgents=false`?
+
+Pi core intentionally does not include sub-agents or plan mode. The optional `pi-subagents` package exists but is not auto-installed by Gentle-AI. Claiming full delegation would be misleading.
+
+### Why `SupportsMCP=false`?
+
+Pi has no native MCP config surface (no `mcpServers` key in settings, no dedicated MCP JSON file). MCP integration would require a Pi extension, which is out of scope for this MVP.
+
+### Why no sudo on unknown Linux?
+
+Termux and other unknown Linux profiles often lack `sudo`. The install command only uses `sudo` on known distros (Ubuntu/Debian/Arch/Fedora) with non-writable global npm.
+
+### Why `APPEND_SYSTEM.md` instead of `AGENTS.md`?
+
+Pi separates context files (`AGENTS.md`) from system prompt files (`SYSTEM.md` / `APPEND_SYSTEM.md`). Using `APPEND_SYSTEM.md` keeps Gentle-AI's managed instructions in the proper layer without clobbering user context files.
+
+## Testing
+
+```bash
+go build ./cmd/gentle-ai
+go test ./...
+```
+
+**Result:** ✅ All tests pass. The only pre-existing failure (`TestWithPostInstallNotesDoesNotChangeNonGGA` in `internal/cli`) also fails on clean `main` in this Termux environment and is unrelated to Pi.
+
+## Checklist
+
+- [x] Adapter follows existing patterns (codex/qwen/openclaw)
+- [x] Table-driven tests for adapter identity, detection, install, paths, capabilities, strategies
+- [x] No fake MCP/Engram/Context7 config generated for Pi
+- [x] Theme injection safely skipped for Pi
+- [x] All hardcoded agent counts updated (14 agents)
+- [x] TUI preselection + CLI detection synced
+- [x] Docs updated with honest capability matrix
+- [x] E2E cleanup includes Pi config dir
+- [x] `go build` passes
+- [x] `go test ./...` passes (except 1 pre-existing unrelated failure)
+
+## Follow-up ideas (not in this PR)
+
+- Optional `pi-subagents` package integration for full SDD delegation
+- Pi extension-based MCP/Engram bridge
+- Pi-specific theme asset (`gentleman-kanagawa` for Pi)
+- `PI_CODING_AGENT_DIR` override support

--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@
 
 ## What It Does
 
-Gentle-AI is NOT an AI agent installer. Most agents are easy to install. It is an **ecosystem configurator** -- it takes whatever AI coding agent(s) you use and supercharges them with persistent memory, Spec-Driven Development workflows, curated coding skills, MCP servers, an AI provider switcher, a teaching-oriented persona with security-first permissions, and per-phase model assignment so each SDD step can run on a different model.
+Gentle-AI is NOT an AI agent installer. Most agents are easy to install. It is an **ecosystem configurator** -- it takes whatever AI coding agent(s) you use and supercharges them with persistent memory, Spec-Driven Development workflows, curated coding skills, MCP servers where supported, an AI provider switcher, a teaching-oriented persona with security-first permissions, and per-phase model assignment so each SDD step can run on a different model.
 
 **Before**: "I installed Claude Code / OpenCode / Cursor, but it's just a chatbot that writes code."
 
 **After**: Your agent now has memory, skills, workflow, MCP tools, and a persona that actually teaches you.
 
-### 13 Supported Agents
+### 14 Supported Agents
 
 | Agent | Delegation Model | Key Feature |
 |-------|:---:|---|
@@ -42,6 +42,7 @@ Gentle-AI is NOT an AI agent installer. Most agents are easy to install. It is a
 | **Kiro IDE** | Full (native subagents) | Native `~/.kiro/agents/` + steering orchestration |
 | **Qwen Code** | Full (native sub-agents) | Slash commands, `~/.qwen/commands/`, `auto_edit` mode |
 | **OpenClaw** | Solo-agent | Workspace-first `AGENTS.md` / `SOUL.md` with global MCP config |
+| **Pi coding agent** | Solo-agent | Pi prompt templates + Agent Skills |
 
 > **Note**: This project supersedes [Agent Teams Lite](https://github.com/Gentleman-Programming/agent-teams-lite) (now archived). Everything ATL provided is included here with better installation, automatic updates, and persistent memory.
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -21,8 +21,11 @@
 | Qwen Code       | `qwen-code`      | Yes          | Yes | Full (native sub-agents)     | No            | Yes            | `~/.qwen`                           |
 | Kiro IDE        | `kiro-ide`       | Yes          | Yes | Full (native subagents)      | No            | No             | `~/.kiro`                           |
 | OpenClaw        | `openclaw`       | Yes          | Yes | Solo-agent                   | No            | No             | `~/.openclaw`                       |
+| Pi coding agent | `pi-coding-agent`| Yes          | No  | Solo-agent                   | No            | Yes (via prompt templates) | `~/.pi/agent`                       |
 
 All agents receive the **full SDD orchestrator** policy, plus skill files written to their skills directory. Most agents receive it through their system prompt; OpenCode and Kilo Code receive it through the OpenCode-compatible `opencode.json` agent overlay. The agent handles SDD automatically when the task is large enough, or when the user explicitly asks for it — no manual setup required.
+
+> **Note:** MCP servers, Engram, Context7, and theme configuration are injected where the agent's native integration surface supports them. The Pi coding agent currently receives the SDD orchestrator and skills, but not MCP, Engram, Context7, or theme assets.
 
 ---
 
@@ -31,7 +34,7 @@ All agents receive the **full SDD orchestrator** policy, plus skill files writte
 | Model                 | How It Works                                                                                                                         | Agents                                                           |
 | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------- |
 | **Full (sub-agents)** | Each SDD phase runs in an isolated context window via native sub-agent delegation or an OpenCode-compatible overlay. The orchestrator coordinates; sub-agents execute. | Claude Code, OpenCode, Kilo Code, Gemini CLI, Cursor, VS Code Copilot, Kimi Code, Kiro IDE, Qwen Code |
-| **Solo-agent**        | All SDD phases run inline in the same conversation. The orchestrator IS the executor. Engram provides cross-phase persistence.       | Codex, Windsurf, Antigravity, OpenClaw                           |
+| **Solo-agent**        | All SDD phases run inline in the same conversation. The orchestrator IS the executor. Engram provides cross-phase persistence where supported. | Codex, Windsurf, Antigravity, OpenClaw, Pi coding agent                           |
 
 ### Cursor Native Subagents
 
@@ -66,11 +69,11 @@ Kiro uses native custom agents in `~/.kiro/agents/`. `gentle-ai` writes 10 phase
 
 ## SDD Mode Support
 
-| Feature | Claude Code | OpenCode | Kilo Code | Gemini CLI | Cursor | VS Code Copilot | Codex | Windsurf | Antigravity | Kiro IDE | Qwen Code | OpenClaw |
-|---------|:-----------:|:--------:|:---------:|:----------:|:------:|:---------------:|:-----:|:--------:|:-----------:|:--------:|:---------:|:--------:|
-| SDD orchestrator | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
-| Single-mode SDD | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
-| Multi-mode SDD | — | Yes | Yes | — | — | — | — | — | — | Yes* | — | — |
+| Feature | Claude Code | OpenCode | Kilo Code | Gemini CLI | Cursor | VS Code Copilot | Codex | Windsurf | Antigravity | Kiro IDE | Qwen Code | OpenClaw | Pi coding agent |
+|---------|:-----------:|:--------:|:---------:|:----------:|:------:|:---------------:|:-----:|:--------:|:-----------:|:--------:|:---------:|:--------:|:---------------:|
+| SDD orchestrator | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| Single-mode SDD | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| Multi-mode SDD | — | Yes | Yes | — | — | — | — | — | — | Yes* | — | — | — |
 
 **Multi-mode** (assigning different AI models to each SDD phase) is supported by **OpenCode** and **Kilo Code** through the OpenCode-compatible multi-mode overlay, and by **Kiro IDE** through native subagent `model:` frontmatter. All other agents run in **single-mode** — the orchestrator manages everything using whatever model the agent is already running.
 
@@ -181,3 +184,14 @@ Kiro uses native custom agents in `~/.kiro/agents/`. `gentle-ai` writes 10 phase
 - **Instructions**: Engram and SDD protocols are injected into workspace `AGENTS.md`; persona is injected into workspace `SOUL.md`.
 - **MCP config**: Engram and Context7 are merged into global `~/.openclaw/openclaw.json` under `mcp.servers`; legacy root `mcpServers` entries are migrated.
 - **Skills**: SDD phase skills are workspace-scoped at `<workspace>/.openclaw/skills/sdd-*`; portable skills remain global at `~/.openclaw/skills/`.
+
+### Pi coding agent
+
+- **Detection**: gentle-ai detects Pi from the `pi` binary on `PATH` and its config root at `~/.pi/agent`.
+- **Install**: supported via npm — `npm install -g @earendil-works/pi-coding-agent` (uses `sudo` on known Linux distros where global npm is not user-writable).
+- **System prompt**: appended to `~/.pi/agent/APPEND_SYSTEM.md` as managed markdown sections.
+- **Skills**: installed to `~/.pi/agent/skills/` (including `_shared/sdd-phase-common.md` and SDD phase skills).
+- **Prompt templates**: SDD commands are exposed as Pi prompt templates in `~/.pi/agent/prompts/*.md` (e.g., `sdd-init.md`, `sdd-verify.md`).
+- **Settings**: `~/.pi/agent/settings.json`
+- **MCP / Engram / Context7**: not supported — Pi does not expose an MCP integration surface, so these components are skipped during install.
+- **Theme**: not supported yet — Gentle-AI does not ship a Pi theme asset.

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -62,3 +62,4 @@ If the hash matches `checksums.txt`, the file is authentic for that release.
 | Antigravity | `%USERPROFILE%\.gemini\antigravity\` |
 | Kiro IDE | `%USERPROFILE%\.kiro\steering\` (prompts) + `%USERPROFILE%\.kiro\skills\` (skills) + `%USERPROFILE%\.kiro\agents\` (SDD agents) + `%APPDATA%\kiro\User\settings.json` (settings) + `%USERPROFILE%\.kiro\settings\mcp.json` (MCP) |
 | OpenClaw | `%USERPROFILE%\.openclaw\openclaw.json` (global MCP/settings) + active workspace from `agents.defaults.workspace` for `AGENTS.md` / `SOUL.md` / workspace-scoped SDD skills |
+| Pi coding agent | `%USERPROFILE%\.pi\agent\` (system prompt, skills, prompt templates) |

--- a/e2e/lib.sh
+++ b/e2e/lib.sh
@@ -78,6 +78,7 @@ cleanup_test_env() {
     rm -rf "$HOME/.qwen" 2>/dev/null || true
     rm -rf "$HOME/.kiro" 2>/dev/null || true
     rm -rf "$HOME/.kimi" 2>/dev/null || true
+    rm -rf "$HOME/.pi" 2>/dev/null || true
     mkdir -p "$HOME/.config"
 }
 

--- a/internal/agents/factory.go
+++ b/internal/agents/factory.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gentleman-programming/gentle-ai/internal/agents/kiro"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/openclaw"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/opencode"
+	"github.com/gentleman-programming/gentle-ai/internal/agents/pi"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/qwen"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/vscode"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/windsurf"
@@ -33,6 +34,7 @@ var defaultAgentIDs = []model.AgentID{
 	model.AgentQwenCode,
 	model.AgentKiroIDE,
 	model.AgentOpenClaw,
+	model.AgentPiCodingAgent,
 }
 
 func NewAdapter(agent model.AgentID) (Adapter, error) {
@@ -63,6 +65,8 @@ func NewAdapter(agent model.AgentID) (Adapter, error) {
 		return kiro.NewAdapter(), nil
 	case model.AgentOpenClaw:
 		return openclaw.NewAdapter(), nil
+	case model.AgentPiCodingAgent:
+		return pi.NewAdapter(), nil
 	default:
 		return nil, AgentNotSupportedError{Agent: agent}
 	}

--- a/internal/agents/factory_test.go
+++ b/internal/agents/factory_test.go
@@ -19,6 +19,17 @@ func TestFactoryResolvesOpenClawAdapter(t *testing.T) {
 	}
 }
 
+func TestFactoryResolvesPiCodingAgentAdapter(t *testing.T) {
+	adapter, err := NewAdapter(model.AgentPiCodingAgent)
+	if err != nil {
+		t.Fatalf("NewAdapter(%q) returned error: %v", model.AgentPiCodingAgent, err)
+	}
+
+	if got := adapter.Agent(); got != model.AgentPiCodingAgent {
+		t.Fatalf("adapter.Agent() = %q, want %q", got, model.AgentPiCodingAgent)
+	}
+}
+
 func TestDefaultRegistryIncludesOpenClaw(t *testing.T) {
 	registry, err := NewDefaultRegistry()
 	if err != nil {
@@ -32,6 +43,22 @@ func TestDefaultRegistryIncludesOpenClaw(t *testing.T) {
 
 	if got := adapter.Agent(); got != model.AgentOpenClaw {
 		t.Fatalf("registry adapter.Agent() = %q, want %q", got, model.AgentOpenClaw)
+	}
+}
+
+func TestDefaultRegistryIncludesPiCodingAgent(t *testing.T) {
+	registry, err := NewDefaultRegistry()
+	if err != nil {
+		t.Fatalf("NewDefaultRegistry() returned error: %v", err)
+	}
+
+	adapter, ok := registry.Get(model.AgentPiCodingAgent)
+	if !ok {
+		t.Fatalf("registry missing %s adapter", model.AgentPiCodingAgent)
+	}
+
+	if got := adapter.Agent(); got != model.AgentPiCodingAgent {
+		t.Fatalf("registry adapter.Agent() = %q, want %q", got, model.AgentPiCodingAgent)
 	}
 }
 
@@ -52,6 +79,7 @@ func TestDefaultRegistrySupportedAgentsMatchesFactoryAgents(t *testing.T) {
 		model.AgentKiroIDE,
 		model.AgentOpenClaw,
 		model.AgentOpenCode,
+		model.AgentPiCodingAgent,
 		model.AgentQwenCode,
 		model.AgentVSCodeCopilot,
 		model.AgentWindsurf,

--- a/internal/agents/pi/adapter.go
+++ b/internal/agents/pi/adapter.go
@@ -1,0 +1,180 @@
+package pi
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/gentleman-programming/gentle-ai/internal/model"
+	"github.com/gentleman-programming/gentle-ai/internal/system"
+)
+
+var LookPathOverride = exec.LookPath
+
+type statResult struct {
+	isDir bool
+	err   error
+}
+
+// Adapter implements agents.Adapter for Pi coding agent.
+//
+// Pi uses ~/.pi/agent as its global configuration root. Gentle-AI writes its
+// managed system prompt sections to APPEND_SYSTEM.md, installs Agent Skills in
+// skills/, and exposes SDD commands as Pi prompt templates in prompts/.
+type Adapter struct {
+	lookPath func(string) (string, error)
+	statPath func(string) statResult
+}
+
+func NewAdapter() *Adapter {
+	return &Adapter{
+		lookPath: LookPathOverride,
+		statPath: defaultStat,
+	}
+}
+
+// --- Identity ---
+
+func (a *Adapter) Agent() model.AgentID {
+	return model.AgentPiCodingAgent
+}
+
+func (a *Adapter) Tier() model.SupportTier {
+	return model.TierPartial
+}
+
+// --- Detection ---
+
+func (a *Adapter) Detect(_ context.Context, homeDir string) (bool, string, string, bool, error) {
+	configPath := filepath.Join(homeDir, ".pi", "agent")
+
+	binaryPath, err := a.lookPath("pi")
+	installed := err == nil
+
+	stat := a.statPath(configPath)
+	if stat.err != nil {
+		if os.IsNotExist(stat.err) {
+			return installed, binaryPath, configPath, false, nil
+		}
+		return false, "", "", false, stat.err
+	}
+
+	return installed, binaryPath, configPath, stat.isDir, nil
+}
+
+// --- Installation ---
+
+func (a *Adapter) SupportsAutoInstall() bool {
+	return true
+}
+
+func (a *Adapter) InstallCommand(profile system.PlatformProfile) ([][]string, error) {
+	// Pi installs via npm. Only use sudo on known Linux distro profiles where
+	// global npm is not user-writable. Unknown/Termux-like environments should
+	// not receive sudo by default.
+	if profile.OS == "linux" && !profile.NpmWritable && isKnownLinuxDistro(profile.LinuxDistro) {
+		return [][]string{{"sudo", "npm", "install", "-g", "@earendil-works/pi-coding-agent"}}, nil
+	}
+	return [][]string{{"npm", "install", "-g", "@earendil-works/pi-coding-agent"}}, nil
+}
+
+func isKnownLinuxDistro(distro string) bool {
+	switch distro {
+	case system.LinuxDistroUbuntu, system.LinuxDistroDebian, system.LinuxDistroArch, system.LinuxDistroFedora:
+		return true
+	default:
+		return false
+	}
+}
+
+// --- Config paths ---
+
+func (a *Adapter) GlobalConfigDir(homeDir string) string {
+	return filepath.Join(homeDir, ".pi", "agent")
+}
+
+func (a *Adapter) SystemPromptDir(homeDir string) string {
+	return filepath.Join(homeDir, ".pi", "agent")
+}
+
+func (a *Adapter) SystemPromptFile(homeDir string) string {
+	return filepath.Join(homeDir, ".pi", "agent", "APPEND_SYSTEM.md")
+}
+
+func (a *Adapter) SkillsDir(homeDir string) string {
+	return filepath.Join(homeDir, ".pi", "agent", "skills")
+}
+
+func (a *Adapter) SettingsPath(homeDir string) string {
+	return filepath.Join(homeDir, ".pi", "agent", "settings.json")
+}
+
+// --- Config strategies ---
+
+func (a *Adapter) SystemPromptStrategy() model.SystemPromptStrategy {
+	return model.StrategyMarkdownSections
+}
+
+func (a *Adapter) MCPStrategy() model.MCPStrategy {
+	return model.StrategyMCPConfigFile
+}
+
+// --- MCP ---
+
+func (a *Adapter) MCPConfigPath(_ string, _ string) string {
+	return ""
+}
+
+// --- Optional capabilities ---
+
+func (a *Adapter) SupportsOutputStyles() bool {
+	return false
+}
+
+func (a *Adapter) OutputStyleDir(_ string) string {
+	return ""
+}
+
+// SupportsSlashCommands returns true because Pi exposes prompt templates as
+// slash commands from ~/.pi/agent/prompts/*.md.
+func (a *Adapter) SupportsSlashCommands() bool {
+	return true
+}
+
+func (a *Adapter) CommandsDir(homeDir string) string {
+	return filepath.Join(homeDir, ".pi", "agent", "prompts")
+}
+
+func (a *Adapter) SupportsSubAgents() bool {
+	return false
+}
+
+func (a *Adapter) SubAgentsDir(_ string) string {
+	return ""
+}
+
+func (a *Adapter) EmbeddedSubAgentsDir() string {
+	return ""
+}
+
+func (a *Adapter) SupportsSkills() bool {
+	return true
+}
+
+func (a *Adapter) SupportsSystemPrompt() bool {
+	return true
+}
+
+func (a *Adapter) SupportsMCP() bool {
+	return false
+}
+
+func defaultStat(path string) statResult {
+	info, err := os.Stat(path)
+	if err != nil {
+		return statResult{err: err}
+	}
+
+	return statResult{isDir: info.IsDir()}
+}

--- a/internal/agents/pi/adapter_test.go
+++ b/internal/agents/pi/adapter_test.go
@@ -1,0 +1,269 @@
+package pi
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/internal/model"
+	"github.com/gentleman-programming/gentle-ai/internal/system"
+)
+
+func TestDetect(t *testing.T) {
+	tests := []struct {
+		name            string
+		lookPathPath    string
+		lookPathErr     error
+		stat            statResult
+		wantInstalled   bool
+		wantBinaryPath  string
+		wantConfigPath  string
+		wantConfigFound bool
+		wantErr         bool
+	}{
+		{
+			name:            "binary and config directory found",
+			lookPathPath:    "/usr/local/bin/pi",
+			stat:            statResult{isDir: true},
+			wantInstalled:   true,
+			wantBinaryPath:  "/usr/local/bin/pi",
+			wantConfigPath:  filepath.Join("/tmp/home", ".pi", "agent"),
+			wantConfigFound: true,
+		},
+		{
+			name:            "binary missing and config missing",
+			lookPathErr:     errors.New("missing"),
+			stat:            statResult{err: os.ErrNotExist},
+			wantInstalled:   false,
+			wantBinaryPath:  "",
+			wantConfigPath:  filepath.Join("/tmp/home", ".pi", "agent"),
+			wantConfigFound: false,
+		},
+		{
+			name:    "stat error bubbles up",
+			stat:    statResult{err: errors.New("permission denied")},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := &Adapter{
+				lookPath: func(string) (string, error) {
+					return tt.lookPathPath, tt.lookPathErr
+				},
+				statPath: func(string) statResult {
+					return tt.stat
+				},
+			}
+
+			installed, binaryPath, configPath, configFound, err := a.Detect(context.Background(), "/tmp/home")
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Detect() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if tt.wantErr {
+				return
+			}
+
+			if installed != tt.wantInstalled {
+				t.Fatalf("Detect() installed = %v, want %v", installed, tt.wantInstalled)
+			}
+
+			if binaryPath != tt.wantBinaryPath {
+				t.Fatalf("Detect() binaryPath = %q, want %q", binaryPath, tt.wantBinaryPath)
+			}
+
+			if configPath != tt.wantConfigPath {
+				t.Fatalf("Detect() configPath = %q, want %q", configPath, tt.wantConfigPath)
+			}
+
+			if configFound != tt.wantConfigFound {
+				t.Fatalf("Detect() configFound = %v, want %v", configFound, tt.wantConfigFound)
+			}
+		})
+	}
+}
+
+func TestInstallCommand(t *testing.T) {
+	a := NewAdapter()
+
+	tests := []struct {
+		name    string
+		profile system.PlatformProfile
+		want    [][]string
+	}{
+		{
+			name:    "darwin uses npm without sudo",
+			profile: system.PlatformProfile{OS: "darwin", PackageManager: "brew"},
+			want:    [][]string{{"npm", "install", "-g", "@earendil-works/pi-coding-agent"}},
+		},
+		{
+			name:    "known linux system npm uses sudo",
+			profile: system.PlatformProfile{OS: "linux", LinuxDistro: system.LinuxDistroUbuntu, PackageManager: "apt"},
+			want:    [][]string{{"sudo", "npm", "install", "-g", "@earendil-works/pi-coding-agent"}},
+		},
+		{
+			name:    "linux nvm skips sudo",
+			profile: system.PlatformProfile{OS: "linux", LinuxDistro: system.LinuxDistroUbuntu, PackageManager: "apt", NpmWritable: true},
+			want:    [][]string{{"npm", "install", "-g", "@earendil-works/pi-coding-agent"}},
+		},
+		{
+			name:    "unknown linux skips sudo",
+			profile: system.PlatformProfile{OS: "linux", LinuxDistro: system.LinuxDistroUnknown, PackageManager: ""},
+			want:    [][]string{{"npm", "install", "-g", "@earendil-works/pi-coding-agent"}},
+		},
+		{
+			name:    "windows uses npm without sudo",
+			profile: system.PlatformProfile{OS: "windows", PackageManager: "winget", NpmWritable: true},
+			want:    [][]string{{"npm", "install", "-g", "@earendil-works/pi-coding-agent"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			command, err := a.InstallCommand(tt.profile)
+			if err != nil {
+				t.Fatalf("InstallCommand() returned error: %v", err)
+			}
+
+			if !reflect.DeepEqual(command, tt.want) {
+				t.Fatalf("InstallCommand() = %v, want %v", command, tt.want)
+			}
+		})
+	}
+}
+
+func TestConfigPathsCrossPlatform(t *testing.T) {
+	a := NewAdapter()
+	home := "/tmp/home"
+
+	tests := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{
+			name: "GlobalConfigDir",
+			got:  a.GlobalConfigDir(home),
+			want: filepath.Join(home, ".pi", "agent"),
+		},
+		{
+			name: "SystemPromptDir",
+			got:  a.SystemPromptDir(home),
+			want: filepath.Join(home, ".pi", "agent"),
+		},
+		{
+			name: "SystemPromptFile",
+			got:  a.SystemPromptFile(home),
+			want: filepath.Join(home, ".pi", "agent", "APPEND_SYSTEM.md"),
+		},
+		{
+			name: "SkillsDir",
+			got:  a.SkillsDir(home),
+			want: filepath.Join(home, ".pi", "agent", "skills"),
+		},
+		{
+			name: "SettingsPath",
+			got:  a.SettingsPath(home),
+			want: filepath.Join(home, ".pi", "agent", "settings.json"),
+		},
+		{
+			name: "CommandsDir",
+			got:  a.CommandsDir(home),
+			want: filepath.Join(home, ".pi", "agent", "prompts"),
+		},
+		{
+			name: "MCPConfigPath",
+			got:  a.MCPConfigPath(home, "ctx7"),
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.got != tt.want {
+				t.Errorf("%s() = %q, want %q", tt.name, tt.got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCapabilities(t *testing.T) {
+	a := NewAdapter()
+
+	tests := []struct {
+		name string
+		got  bool
+		want bool
+	}{
+		{"SupportsAutoInstall", a.SupportsAutoInstall(), true},
+		{"SupportsSkills", a.SupportsSkills(), true},
+		{"SupportsSystemPrompt", a.SupportsSystemPrompt(), true},
+		{"SupportsMCP", a.SupportsMCP(), false},
+		{"SupportsSlashCommands", a.SupportsSlashCommands(), true},
+		{"SupportsOutputStyles", a.SupportsOutputStyles(), false},
+		{"SupportsSubAgents", a.SupportsSubAgents(), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.got != tt.want {
+				t.Errorf("%s() = %v, want %v", tt.name, tt.got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAdapterIdentity(t *testing.T) {
+	a := NewAdapter()
+
+	tests := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{"Agent", string(a.Agent()), string(model.AgentPiCodingAgent)},
+		{"Tier", string(a.Tier()), string(model.TierPartial)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.got != tt.want {
+				t.Errorf("%s() = %q, want %q", tt.name, tt.got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAdapterStrategies(t *testing.T) {
+	a := NewAdapter()
+
+	tests := []struct {
+		name string
+		got  int
+		want int
+	}{
+		{
+			name: "SystemPromptStrategy",
+			got:  int(a.SystemPromptStrategy()),
+			want: int(model.StrategyMarkdownSections),
+		},
+		{
+			name: "MCPStrategy",
+			got:  int(a.MCPStrategy()),
+			want: int(model.StrategyMCPConfigFile),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.got != tt.want {
+				t.Errorf("%s() = %v, want %v", tt.name, tt.got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/agents/registry_test.go
+++ b/internal/agents/registry_test.go
@@ -94,13 +94,18 @@ func TestDefaultRegistryIncludesAllAgents(t *testing.T) {
 	for _, agent := range []model.AgentID{
 		model.AgentClaudeCode,
 		model.AgentOpenCode,
+		model.AgentKilocode,
 		model.AgentGeminiCLI,
 		model.AgentCursor,
 		model.AgentVSCodeCopilot,
 		model.AgentCodex,
 		model.AgentAntigravity,
 		model.AgentWindsurf,
+		model.AgentKimi,
 		model.AgentQwenCode,
+		model.AgentKiroIDE,
+		model.AgentOpenClaw,
+		model.AgentPiCodingAgent,
 	} {
 		if _, ok := registry.Get(agent); !ok {
 			t.Fatalf("registry missing %s adapter", agent)

--- a/internal/assets/assets.go
+++ b/internal/assets/assets.go
@@ -2,7 +2,7 @@ package assets
 
 import "embed"
 
-//go:embed all:claude all:opencode all:generic all:skills all:gga all:gemini all:codex all:antigravity all:windsurf all:cursor all:kimi all:qwen all:kiro
+//go:embed all:claude all:opencode all:generic all:skills all:gga all:gemini all:codex all:antigravity all:windsurf all:cursor all:kimi all:qwen all:kiro all:pi
 var FS embed.FS
 
 // MustRead returns the content of an embedded file or panics.

--- a/internal/assets/assets_test.go
+++ b/internal/assets/assets_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/internal/model"
 )
 
 // TestAllEmbeddedAssetsAreReadable verifies that every expected embedded file
@@ -86,6 +88,18 @@ func TestAllEmbeddedAssetsAreReadable(t *testing.T) {
 		"kimi/agents/sdd-archive.md",
 		"kimi/agents/sdd-onboard.md",
 
+		// Pi coding agent files
+		"pi/sdd-orchestrator.md",
+		"pi/prompts/sdd-apply.md",
+		"pi/prompts/sdd-archive.md",
+		"pi/prompts/sdd-continue.md",
+		"pi/prompts/sdd-explore.md",
+		"pi/prompts/sdd-ff.md",
+		"pi/prompts/sdd-init.md",
+		"pi/prompts/sdd-new.md",
+		"pi/prompts/sdd-onboard.md",
+		"pi/prompts/sdd-verify.md",
+
 		// SDD skills
 		"skills/sdd-init/SKILL.md",
 		"skills/sdd-init/references/init-details.md",
@@ -131,6 +145,12 @@ func TestAllEmbeddedAssetsAreReadable(t *testing.T) {
 	}
 }
 
+func TestSDDCommandsAssetDirRoutesPiToPrompts(t *testing.T) {
+	if got := SDDCommandsAssetDir(model.AgentPiCodingAgent); got != "pi/prompts" {
+		t.Fatalf("SDDCommandsAssetDir(pi) = %q, want pi/prompts", got)
+	}
+}
+
 func TestOpenCodeEmbeddedAssetLayout(t *testing.T) {
 	entries, err := FS.ReadDir("opencode")
 	if err != nil {
@@ -165,6 +185,32 @@ func TestOpenCodeEmbeddedAssetLayout(t *testing.T) {
 	}
 	if pluginEntries[0].Name() != "background-agents.ts" {
 		t.Fatalf("plugin entry = %q, want background-agents.ts", pluginEntries[0].Name())
+	}
+}
+
+func TestPiEmbeddedAssetLayout(t *testing.T) {
+	entries, err := FS.ReadDir("pi")
+	if err != nil {
+		t.Fatalf("ReadDir(pi) error = %v", err)
+	}
+
+	seen := map[string]bool{}
+	for _, entry := range entries {
+		seen[entry.Name()] = true
+	}
+
+	for _, name := range []string{"prompts", "sdd-orchestrator.md"} {
+		if !seen[name] {
+			t.Fatalf("pi embedded assets missing %q", name)
+		}
+	}
+
+	promptEntries, err := FS.ReadDir("pi/prompts")
+	if err != nil {
+		t.Fatalf("ReadDir(pi/prompts) error = %v", err)
+	}
+	if len(promptEntries) != 9 {
+		t.Fatalf("pi prompts count = %d, want 9", len(promptEntries))
 	}
 }
 

--- a/internal/assets/commands.go
+++ b/internal/assets/commands.go
@@ -3,12 +3,14 @@ package assets
 import "github.com/gentleman-programming/gentle-ai/internal/model"
 
 // SDDCommandsAssetDir returns the embedded slash-command asset directory for an
-// agent. Claude uses Claude-native frontmatter under claude/commands; agents
-// without a dedicated command set fall back to the OpenCode-compatible assets.
+// agent. Claude uses Claude-native frontmatter, Pi uses prompt templates, and
+// agents without a dedicated command set fall back to OpenCode-compatible assets.
 func SDDCommandsAssetDir(agent model.AgentID) string {
 	switch agent {
 	case model.AgentClaudeCode:
 		return "claude/commands"
+	case model.AgentPiCodingAgent:
+		return "pi/prompts"
 	default:
 		return "opencode/commands"
 	}

--- a/internal/assets/pi/prompts/sdd-apply.md
+++ b/internal/assets/pi/prompts/sdd-apply.md
@@ -1,0 +1,23 @@
+---
+description: Implement SDD tasks following specs and design
+argument-hint: "[change]"
+---
+
+Read `~/.pi/agent/skills/sdd-apply/SKILL.md` first, then follow it inline.
+
+Change: $ARGUMENTS
+
+Pi MVP defaults:
+- Artifact store mode: `openspec` unless the user asks for `none` or confirms Engram tools are available.
+- Do not call Engram/MCP tools unless they are visible and verified in this Pi session.
+
+Before editing:
+1. Ensure `/sdd-init` has run.
+2. Read the active proposal/spec/design/tasks artifacts.
+3. Check the review workload guard and delivery strategy.
+4. Check Strict TDD status.
+
+Task:
+Implement the next incomplete task batch. If Strict TDD is active, write a failing test first, implement the minimum, then refactor. Update task/progress artifacts.
+
+Return: status, executive_summary, detailed_report with files changed, artifacts, next_recommended, risks, and skill_resolution.

--- a/internal/assets/pi/prompts/sdd-archive.md
+++ b/internal/assets/pi/prompts/sdd-archive.md
@@ -1,0 +1,17 @@
+---
+description: Archive a completed SDD change
+argument-hint: "[change]"
+---
+
+Read `~/.pi/agent/skills/sdd-archive/SKILL.md` first, then follow it inline.
+
+Change: $ARGUMENTS
+
+Pi MVP defaults:
+- Artifact store mode: `openspec` unless the user asks for `none` or confirms Engram tools are available.
+- Do not call Engram/MCP tools unless they are visible and verified in this Pi session.
+
+Task:
+Confirm the verification report shows the change is ready. Then archive the active SDD change according to the active artifact store, preserving traceability to proposal/spec/design/tasks/apply/verify artifacts.
+
+Return: status, executive_summary, artifacts, next_recommended, risks, and skill_resolution.

--- a/internal/assets/pi/prompts/sdd-continue.md
+++ b/internal/assets/pi/prompts/sdd-continue.md
@@ -1,0 +1,18 @@
+---
+description: Continue the next SDD phase in the dependency chain
+argument-hint: "[change]"
+---
+
+Use the SDD orchestrator instructions installed in `~/.pi/agent/APPEND_SYSTEM.md`. Work inline; do not assume native sub-agents.
+
+Change: $ARGUMENTS
+
+Workflow:
+1. Ensure `/sdd-init` has run.
+2. Inspect existing artifacts for the active or named change.
+3. Determine the next dependency-ready phase:
+   proposal → [spec + design] → tasks → apply → verify → archive.
+4. Read the matching phase skill from `~/.pi/agent/skills/` and execute it inline.
+5. In interactive mode, summarize and ask before the next phase.
+
+Do not call Engram/MCP tools unless they are visible and verified in this Pi session.

--- a/internal/assets/pi/prompts/sdd-explore.md
+++ b/internal/assets/pi/prompts/sdd-explore.md
@@ -1,0 +1,17 @@
+---
+description: Explore and investigate an idea or feature without edits
+argument-hint: "<topic>"
+---
+
+Read `~/.pi/agent/skills/sdd-explore/SKILL.md` first, then follow it inline.
+
+Topic: $ARGUMENTS
+
+Pi MVP defaults:
+- Artifact store mode: `openspec` unless the user asks for `none` or confirms Engram tools are available.
+- Do not call Engram/MCP tools unless they are visible and verified in this Pi session.
+
+Task:
+Explore `$ARGUMENTS` in this codebase. Read relevant files, identify affected areas, compare approaches, and recommend a path. Do not edit code.
+
+Return: status, executive_summary, detailed_report, artifacts, next_recommended, risks, and skill_resolution.

--- a/internal/assets/pi/prompts/sdd-ff.md
+++ b/internal/assets/pi/prompts/sdd-ff.md
@@ -1,0 +1,18 @@
+---
+description: Fast-forward SDD planning phases through tasks
+argument-hint: "<change>"
+---
+
+Use the SDD orchestrator instructions installed in `~/.pi/agent/APPEND_SYSTEM.md`. Work inline; do not assume native sub-agents.
+
+Change: $ARGUMENTS
+
+Workflow:
+1. Ensure `/sdd-init` has run.
+2. Create/update proposal.
+3. Create/update specs.
+4. Create/update design.
+5. Create/update tasks with review workload forecast.
+6. Present one combined summary and the next recommended apply step.
+
+Artifact store defaults to `openspec` for Pi unless the user asks otherwise. Do not call Engram/MCP tools unless they are visible and verified in this Pi session.

--- a/internal/assets/pi/prompts/sdd-init.md
+++ b/internal/assets/pi/prompts/sdd-init.md
@@ -1,0 +1,14 @@
+---
+description: Initialize SDD context — detects project stack and bootstraps persistence
+---
+
+Read `~/.pi/agent/skills/sdd-init/SKILL.md` first, then follow it inline.
+
+Pi MVP defaults:
+- Artifact store mode: `openspec` unless the user asks for `none` or confirms Engram tools are available.
+- Do not call Engram/MCP tools unless they are visible and verified in this Pi session.
+
+Task:
+Initialize Spec-Driven Development in this project. Detect stack, testing, conventions, architecture patterns, Strict TDD status, and skill registry. Persist results according to the chosen mode.
+
+Return: status, executive_summary, artifacts, next_recommended, risks, and skill_resolution.

--- a/internal/assets/pi/prompts/sdd-new.md
+++ b/internal/assets/pi/prompts/sdd-new.md
@@ -1,0 +1,21 @@
+---
+description: Start a new SDD change with exploration and proposal
+argument-hint: "<change>"
+---
+
+Use the SDD orchestrator instructions installed in `~/.pi/agent/APPEND_SYSTEM.md`. Work inline; do not assume native sub-agents.
+
+Change: $ARGUMENTS
+
+First ask/cache if not already chosen:
+- Execution mode: `interactive` (default) or `auto`.
+- Artifact store: `openspec` (Pi default), `none`, or confirmed `engram`/`hybrid`.
+- Delivery strategy: `ask-on-risk` (default), `auto-chain`, `single-pr`, or `exception-ok`.
+
+Workflow:
+1. Ensure `/sdd-init` has run.
+2. Run exploration for `$ARGUMENTS` using the `sdd-explore` skill.
+3. Create a proposal using the appropriate SDD skill/conventions.
+4. In interactive mode, summarize and ask before continuing to spec/design.
+
+Do not call Engram/MCP tools unless they are visible and verified in this Pi session.

--- a/internal/assets/pi/prompts/sdd-onboard.md
+++ b/internal/assets/pi/prompts/sdd-onboard.md
@@ -1,0 +1,14 @@
+---
+description: Guided SDD walkthrough using the current codebase
+---
+
+Read `~/.pi/agent/skills/sdd-onboard/SKILL.md` first, then follow it inline.
+
+Pi MVP defaults:
+- Artifact store mode: `openspec` unless the user asks for `none` or confirms Engram tools are available.
+- Do not call Engram/MCP tools unless they are visible and verified in this Pi session.
+
+Task:
+Guide the user through a complete SDD cycle using their real codebase. Teach by doing: initialize, explore, propose, spec, design, tasks, apply, verify, and archive. Pause at decision points unless the user chooses automatic mode.
+
+Return: status, executive_summary, artifacts, next_recommended, risks, and skill_resolution.

--- a/internal/assets/pi/prompts/sdd-verify.md
+++ b/internal/assets/pi/prompts/sdd-verify.md
@@ -1,0 +1,17 @@
+---
+description: Validate implementation against specs, design, and tasks
+argument-hint: "[change]"
+---
+
+Read `~/.pi/agent/skills/sdd-verify/SKILL.md` first, then follow it inline.
+
+Change: $ARGUMENTS
+
+Pi MVP defaults:
+- Artifact store mode: `openspec` unless the user asks for `none` or confirms Engram tools are available.
+- Do not call Engram/MCP tools unless they are visible and verified in this Pi session.
+
+Task:
+Read the proposal/spec/design/tasks/apply-progress artifacts for the active change. Check completeness, correctness, design coherence, tests, build, and spec compliance. Run the focused validation commands that are safe and available.
+
+Return a structured verification report with: status, executive_summary, detailed_report, artifacts, next_recommended, risks, and skill_resolution.

--- a/internal/assets/pi/sdd-orchestrator.md
+++ b/internal/assets/pi/sdd-orchestrator.md
@@ -1,0 +1,133 @@
+# Gentle-AI SDD Orchestrator for Pi coding agent
+
+These instructions are installed into `~/.pi/agent/APPEND_SYSTEM.md` and apply to Pi's main session.
+
+## Operating model
+
+Pi support is a solo-agent MVP:
+
+- Do SDD work inline in this Pi session.
+- Do not claim native sub-agent delegation is available.
+- Do not call MCP tools such as `mem_search`, `mem_save`, or `mem_get_observation` unless the user has separately installed and verified an extension that provides them.
+- Use Pi Agent Skills from `~/.pi/agent/skills/` and Pi prompt templates from `~/.pi/agent/prompts/`.
+- Keep summaries short by default: decision, result, next action. Expand only when useful.
+
+If the optional `pi-subagents` package is installed, do not assume Gentle-AI configured SDD sub-agents for it. Ask before using that optional delegation path.
+
+## SDD workflow
+
+Spec-Driven Development (SDD) is for substantial changes. Small requests can be done directly.
+
+Core phases:
+
+```text
+explore -> propose -> [spec + design] -> tasks -> apply -> verify -> archive
+```
+
+Pi prompt templates:
+
+- `/sdd-init` — detect stack, tests, conventions, and initialize persistence.
+- `/sdd-explore <topic>` — investigate a feature or problem without edits.
+- `/sdd-new <change>` — start a change with exploration and proposal.
+- `/sdd-ff <change>` — fast-forward planning through tasks.
+- `/sdd-continue [change]` — continue the next dependency-ready phase.
+- `/sdd-apply [change]` — implement incomplete tasks.
+- `/sdd-verify [change]` — validate implementation against specs/design/tasks.
+- `/sdd-archive [change]` — archive a verified change.
+- `/sdd-onboard` — guided walkthrough.
+
+## Artifact store policy for Pi
+
+Pi MVP does not configure Engram MCP. Use one of these modes:
+
+- `openspec` — recommended default for Pi. Writes reviewable project files under `openspec/`.
+- `none` — return artifacts inline only; use for quick or low-ceremony work.
+- `engram` or `hybrid` — only if the user confirms Engram tools are available in this Pi session.
+
+On the first `/sdd-new`, `/sdd-ff`, or `/sdd-continue` in a session, ask once for:
+
+1. Execution mode: `interactive` (default) or `auto`.
+2. Artifact store: `openspec` (default), `none`, or confirmed `engram`/`hybrid`.
+3. Delivery strategy: `ask-on-risk` (default), `auto-chain`, `single-pr`, or `exception-ok`.
+
+Cache these choices for the session.
+
+## Initialization guard
+
+Before any SDD phase, ensure `/sdd-init` has run for this project.
+
+Check in this order:
+
+1. `openspec/config.yaml` or related project SDD files.
+2. `.atl/skill-registry.md` and testing capability notes.
+3. If confirmed Engram tools exist, search Engram.
+
+If init is missing, run `/sdd-init` inline first. Do not pretend Engram exists; choose `openspec` or `none` when tools are absent.
+
+## Skill resolver protocol
+
+Use installed skills directly:
+
+- Shared conventions: `~/.pi/agent/skills/_shared/`.
+- Phase skills: `~/.pi/agent/skills/sdd-*/SKILL.md`.
+- Project registry: `.atl/skill-registry.md`.
+
+For each phase:
+
+1. Read the matching `SKILL.md` first.
+2. Read relevant shared references when the skill points to them.
+3. Read `.atl/skill-registry.md` when project-specific standards may apply.
+4. Apply matching compact rules inline.
+
+## Phase contracts
+
+Each phase returns:
+
+- `status`
+- `executive_summary`
+- `artifacts` (file paths or inline section names)
+- `next_recommended`
+- `risks`
+- `skill_resolution`
+
+Phase dependencies:
+
+| Phase | Reads | Writes |
+|---|---|---|
+| `sdd-explore` | project files | exploration |
+| `sdd-propose` | exploration when available | proposal |
+| `sdd-spec` | proposal | spec |
+| `sdd-design` | proposal | design |
+| `sdd-tasks` | spec + design | tasks |
+| `sdd-apply` | tasks + spec + design + progress | code + apply progress |
+| `sdd-verify` | spec + tasks + apply progress | verify report |
+| `sdd-archive` | all artifacts | archive report |
+
+## Review workload guard
+
+After tasks and before apply, inspect the forecast.
+
+Stop and ask if any is true:
+
+- chained PRs recommended;
+- estimated diff exceeds 400 lines;
+- 400-line budget risk is high;
+- a product/architecture decision is unresolved.
+
+Use the cached delivery strategy to decide whether to ask, split, require an exception, or continue with a recorded exception.
+
+## Strict TDD forwarding
+
+Before apply or verify:
+
+1. Read testing capabilities from `openspec/config.yaml`, SDD init output, or `.atl/skill-registry.md`.
+2. If `strict_tdd: true`, follow strict TDD: failing test first, minimal implementation, refactor.
+3. If no runner exists, explain that Strict TDD is unavailable and use standard validation.
+
+## Recovery
+
+- `openspec`: read `openspec/changes/*/state.yaml` and related artifact files.
+- `none`: recover from the current conversation only.
+- confirmed Engram/hybrid: use Engram tools only if they exist in this Pi session.
+
+Never invent missing tools or configuration.

--- a/internal/catalog/agents.go
+++ b/internal/catalog/agents.go
@@ -23,6 +23,7 @@ var allAgents = []Agent{
 	{ID: model.AgentQwenCode, Name: "Qwen Code", Tier: model.TierFull, ConfigPath: "~/.qwen"},
 	{ID: model.AgentKiroIDE, Name: "Kiro IDE", Tier: model.TierFull, ConfigPath: "~/.kiro"},
 	{ID: model.AgentOpenClaw, Name: "OpenClaw", Tier: model.TierFull, ConfigPath: "~/.openclaw"},
+	{ID: model.AgentPiCodingAgent, Name: "Pi coding agent", Tier: model.TierPartial, ConfigPath: "~/.pi/agent"},
 }
 
 // mvpAgents are the original MVP agents (Claude Code, OpenCode).

--- a/internal/catalog/agents_test.go
+++ b/internal/catalog/agents_test.go
@@ -32,8 +32,40 @@ func TestAllAgentsIncludesOpenClaw(t *testing.T) {
 	t.Fatalf("AllAgents() missing %s", model.AgentOpenClaw)
 }
 
+func TestAllAgentsIncludesPiCodingAgent(t *testing.T) {
+	agents := AllAgents()
+
+	for _, agent := range agents {
+		if agent.ID != model.AgentPiCodingAgent {
+			continue
+		}
+
+		if agent.Name != "Pi coding agent" {
+			t.Fatalf("Pi Name = %q, want Pi coding agent", agent.Name)
+		}
+
+		if agent.Tier != model.TierPartial {
+			t.Fatalf("Pi Tier = %q, want %q", agent.Tier, model.TierPartial)
+		}
+
+		if agent.ConfigPath != "~/.pi/agent" {
+			t.Fatalf("Pi ConfigPath = %q, want ~/.pi/agent", agent.ConfigPath)
+		}
+
+		return
+	}
+
+	t.Fatalf("AllAgents() missing %s", model.AgentPiCodingAgent)
+}
+
 func TestIsSupportedAgentAcceptsOpenClaw(t *testing.T) {
 	if !IsSupportedAgent(model.AgentOpenClaw) {
 		t.Fatalf("IsSupportedAgent(%q) = false, want true", model.AgentOpenClaw)
+	}
+}
+
+func TestIsSupportedAgentAcceptsPiCodingAgent(t *testing.T) {
+	if !IsSupportedAgent(model.AgentPiCodingAgent) {
+		t.Fatalf("IsSupportedAgent(%q) = false, want true", model.AgentPiCodingAgent)
 	}
 }

--- a/internal/cli/install_test.go
+++ b/internal/cli/install_test.go
@@ -43,7 +43,7 @@ func TestNormalizeInstallFlagsDefaults(t *testing.T) {
 	}
 
 	want := model.Selection{
-		Agents:  []model.AgentID{model.AgentClaudeCode, model.AgentOpenCode, model.AgentKilocode, model.AgentGeminiCLI, model.AgentCodex, model.AgentCursor, model.AgentVSCodeCopilot, model.AgentAntigravity, model.AgentWindsurf, model.AgentKimi, model.AgentQwenCode, model.AgentKiroIDE, model.AgentOpenClaw},
+		Agents:  []model.AgentID{model.AgentClaudeCode, model.AgentOpenCode, model.AgentKilocode, model.AgentGeminiCLI, model.AgentCodex, model.AgentCursor, model.AgentVSCodeCopilot, model.AgentAntigravity, model.AgentWindsurf, model.AgentKimi, model.AgentQwenCode, model.AgentKiroIDE, model.AgentOpenClaw, model.AgentPiCodingAgent},
 		Persona: model.PersonaGentleman,
 		Preset:  model.PresetFullGentleman,
 		Components: []model.ComponentID{
@@ -200,7 +200,7 @@ func TestRunInstallDryRunSkipsExecution(t *testing.T) {
 func makeDetectionWithAgents(present ...string) system.DetectionResult {
 	var configs []system.ConfigState
 	// Full canonical agent set — mirrors knownAgentConfigDirs in config_scan.go.
-	known := []string{"claude-code", "opencode", "kilocode", "gemini-cli", "cursor", "vscode-copilot", "codex", "antigravity", "windsurf", "kimi", "qwen-code", "kiro-ide", "openclaw"}
+	known := []string{"claude-code", "opencode", "kilocode", "gemini-cli", "cursor", "vscode-copilot", "codex", "antigravity", "windsurf", "kimi", "qwen-code", "kiro-ide", "openclaw", "pi-coding-agent"}
 	presentSet := make(map[string]bool, len(present))
 	for _, p := range present {
 		presentSet[p] = true
@@ -258,6 +258,7 @@ func TestDefaultAgentsFromDetection_AllAgentsMappedCorrectly(t *testing.T) {
 		{"qwen-code", model.AgentQwenCode},
 		{"kiro-ide", model.AgentKiroIDE},
 		{"openclaw", model.AgentOpenClaw},
+		{"pi-coding-agent", model.AgentPiCodingAgent},
 	}
 
 	for _, tt := range tests {

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -879,6 +879,9 @@ func componentPathsWithWorkspace(homeDir, workspaceDir string, selection model.S
 		targetDir := componentPathDir(homeDir, workspaceDir, adapter, component)
 		switch component {
 		case model.ComponentEngram:
+			if !adapter.SupportsMCP() {
+				break
+			}
 			switch adapter.MCPStrategy() {
 			case model.StrategySeparateMCPFiles:
 				paths = append(paths, adapter.MCPConfigPath(targetDir, "engram"))
@@ -964,6 +967,9 @@ func componentPathsWithWorkspace(homeDir, workspaceDir string, selection model.S
 				}
 			}
 		case model.ComponentContext7:
+			if !adapter.SupportsMCP() {
+				break
+			}
 			switch adapter.MCPStrategy() {
 			case model.StrategySeparateMCPFiles:
 				paths = append(paths, adapter.MCPConfigPath(homeDir, "context7"))
@@ -1006,6 +1012,9 @@ func componentPathsWithWorkspace(homeDir, workspaceDir string, selection model.S
 			paths = append(paths, gga.ConfigPath(homeDir))
 			paths = append(paths, gga.AgentsTemplatePath(homeDir))
 		case model.ComponentTheme:
+			if adapter.Agent() == model.AgentPiCodingAgent {
+				break
+			}
 			if p := adapter.SettingsPath(homeDir); p != "" {
 				paths = append(paths, p)
 			}

--- a/internal/cli/run_component_paths_test.go
+++ b/internal/cli/run_component_paths_test.go
@@ -173,6 +173,48 @@ func TestComponentPathsSDDKimiIncludesAgentFilesAndGlobalSkills(t *testing.T) {
 	}
 }
 
+func TestComponentPathsSDDPiUsesPiPromptSkillPaths(t *testing.T) {
+	home := t.TempDir()
+	adapters := resolveAdapters([]model.AgentID{model.AgentPiCodingAgent})
+
+	paths := componentPaths(home, model.Selection{}, adapters, model.ComponentSDD)
+
+	for _, want := range []string{
+		filepath.Join(home, ".pi", "agent", "APPEND_SYSTEM.md"),
+		filepath.Join(home, ".pi", "agent", "prompts", "sdd-init.md"),
+		filepath.Join(home, ".pi", "agent", "prompts", "sdd-verify.md"),
+		filepath.Join(home, ".pi", "agent", "skills", "_shared", "sdd-phase-common.md"),
+		filepath.Join(home, ".pi", "agent", "skills", "sdd-init", "SKILL.md"),
+		filepath.Join(home, ".pi", "agent", "skills", "sdd-verify", "SKILL.md"),
+	} {
+		if !containsPath(paths, want) {
+			t.Fatalf("componentPaths(sdd,pi) missing %q\npaths=%v", want, paths)
+		}
+	}
+
+	for _, unwanted := range []string{
+		filepath.Join(home, ".pi", "agent", "agents", "sdd-apply.md"),
+		filepath.Join(home, ".pi", "agent", "chains", "sdd.chain.md"),
+		filepath.Join(home, ".pi", "agent", "settings.json"),
+	} {
+		if containsPath(paths, unwanted) {
+			t.Fatalf("componentPaths(sdd,pi) must not include unsupported path %q\npaths=%v", unwanted, paths)
+		}
+	}
+}
+
+func TestComponentPathsPiSkipsMCPBackedComponents(t *testing.T) {
+	home := t.TempDir()
+	adapters := resolveAdapters([]model.AgentID{model.AgentPiCodingAgent})
+
+	for _, component := range []model.ComponentID{model.ComponentEngram, model.ComponentContext7, model.ComponentTheme} {
+		paths := componentPaths(home, model.Selection{}, adapters, component)
+		if len(paths) != 0 {
+			t.Fatalf("componentPaths(%s,pi) = %v, want no paths", component, paths)
+		}
+	}
+}
+
 func TestComponentPathsContext7KimiIncludesMCPConfig(t *testing.T) {
 	home := t.TempDir()
 	adapters := resolveAdapters([]model.AgentID{model.AgentKimi})

--- a/internal/cli/validate.go
+++ b/internal/cli/validate.go
@@ -197,6 +197,8 @@ func defaultAgentsFromDetection(detection system.DetectionResult) []model.AgentI
 			agents = append(agents, model.AgentKiroIDE)
 		case string(model.AgentOpenClaw):
 			agents = append(agents, model.AgentOpenClaw)
+		case string(model.AgentPiCodingAgent):
+			agents = append(agents, model.AgentPiCodingAgent)
 		}
 	}
 

--- a/internal/components/sdd/inject.go
+++ b/internal/components/sdd/inject.go
@@ -1209,8 +1209,12 @@ func sddOrchestratorAsset(agent model.AgentID) string {
 		return "qwen/sdd-orchestrator.md"
 	case model.AgentKiroIDE:
 		return "kiro/sdd-orchestrator.md"
+	case model.AgentPiCodingAgent:
+		return "pi/sdd-orchestrator.md"
 	case model.AgentOpenCode:
 		return "opencode/sdd-orchestrator.md"
+	case model.AgentClaudeCode:
+		return "claude/sdd-orchestrator.md"
 	default:
 		return "generic/sdd-orchestrator.md"
 	}
@@ -1428,8 +1432,8 @@ func stripBareOrchestratorSection(content string) string {
 
 func injectMarkdownSections(homeDir string, adapter agents.Adapter, assignments map[string]model.ClaudeModelAlias) (InjectionResult, error) {
 	promptPath := adapter.SystemPromptFile(homeDir)
-	content := assets.MustRead("claude/sdd-orchestrator.md")
-	if len(assignments) > 0 {
+	content := assets.MustRead(sddOrchestratorAsset(adapter.Agent()))
+	if adapter.Agent() == model.AgentClaudeCode && len(assignments) > 0 {
 		var err error
 		content, err = injectClaudeModelAssignments(content, assignments)
 		if err != nil {

--- a/internal/components/sdd/inject_test.go
+++ b/internal/components/sdd/inject_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gentleman-programming/gentle-ai/internal/agents/kimi"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/openclaw"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/opencode"
+	"github.com/gentleman-programming/gentle-ai/internal/agents/pi"
 	windsurfagent "github.com/gentleman-programming/gentle-ai/internal/agents/windsurf"
 	"github.com/gentleman-programming/gentle-ai/internal/assets"
 	"github.com/gentleman-programming/gentle-ai/internal/model"
@@ -25,6 +26,7 @@ func claudeAdapter() agents.Adapter   { return claude.NewAdapter() }
 func kimiAdapter() agents.Adapter     { return kimi.NewAdapter() }
 func openclawAdapter() agents.Adapter { return openclaw.NewAdapter() }
 func opencodeAdapter() agents.Adapter { return opencode.NewAdapter() }
+func piAdapter() agents.Adapter       { return pi.NewAdapter() }
 func windsurfAdapter() agents.Adapter { return windsurfagent.NewAdapter() }
 
 func mockNoPackageManager(t *testing.T) {
@@ -284,6 +286,73 @@ func TestInjectOpenCodeWritesCommandFiles(t *testing.T) {
 
 	if !strings.Contains(string(skillContent), "sdd-init") {
 		t.Fatal("SDD skill file missing expected content")
+	}
+}
+
+func TestInjectPiWritesPromptTemplatesAndSkills(t *testing.T) {
+	home := t.TempDir()
+
+	result, err := Inject(home, piAdapter(), "")
+	if err != nil {
+		t.Fatalf("Inject() error = %v", err)
+	}
+	if !result.Changed {
+		t.Fatalf("Inject() first changed = false")
+	}
+
+	promptPath := filepath.Join(home, ".pi", "agent", "APPEND_SYSTEM.md")
+	content, err := os.ReadFile(promptPath)
+	if err != nil {
+		t.Fatalf("ReadFile(APPEND_SYSTEM.md) error = %v", err)
+	}
+
+	text := string(content)
+	if !strings.Contains(text, "<!-- gentle-ai:sdd-orchestrator -->") {
+		t.Fatal("APPEND_SYSTEM.md missing open marker for sdd-orchestrator")
+	}
+	if !strings.Contains(text, "solo-agent MVP") {
+		t.Fatal("APPEND_SYSTEM.md missing Pi-specific solo-agent guidance")
+	}
+	if strings.Contains(text, "MUST call mem_search") {
+		t.Fatal("APPEND_SYSTEM.md should not require Pi MVP to call Engram MCP tools")
+	}
+
+	commandPath := filepath.Join(home, ".pi", "agent", "prompts", "sdd-init.md")
+	commandContent, err := os.ReadFile(commandPath)
+	if err != nil {
+		t.Fatalf("ReadFile(pi sdd-init.md) error = %v", err)
+	}
+	commandText := string(commandContent)
+	if !strings.Contains(commandText, "description:") {
+		t.Fatal("Pi sdd-init.md missing prompt-template description")
+	}
+	if strings.Contains(commandText, "agent:") {
+		t.Fatal("Pi sdd-init.md contains non-Pi agent frontmatter")
+	}
+	if strings.Contains(commandText, "!`") {
+		t.Fatal("Pi sdd-init.md contains OpenCode/Claude shell interpolation")
+	}
+	if !strings.Contains(commandText, "~/.pi/agent/skills/sdd-init/SKILL.md") {
+		t.Fatal("Pi sdd-init.md missing Pi skill path")
+	}
+
+	for _, want := range []string{
+		filepath.Join(home, ".pi", "agent", "skills", "_shared", "sdd-phase-common.md"),
+		filepath.Join(home, ".pi", "agent", "skills", "sdd-init", "SKILL.md"),
+		filepath.Join(home, ".pi", "agent", "skills", "sdd-verify", "SKILL.md"),
+	} {
+		if _, err := os.Stat(want); err != nil {
+			t.Fatalf("expected Pi SDD skill path %q: %v", want, err)
+		}
+	}
+
+	for _, unwanted := range []string{
+		filepath.Join(home, ".pi", "agent", "agents", "sdd-apply.md"),
+		filepath.Join(home, ".pi", "agent", "chains", "sdd.chain.md"),
+	} {
+		if _, err := os.Stat(unwanted); err == nil {
+			t.Fatalf("Pi MVP should not write subagent artifact %q", unwanted)
+		}
 	}
 }
 
@@ -3080,7 +3149,10 @@ func TestSDDOrchestratorAssetSelection(t *testing.T) {
 		{agent: model.AgentWindsurf, want: "windsurf/sdd-orchestrator.md"},
 		{agent: model.AgentCursor, want: "cursor/sdd-orchestrator.md"},
 		{agent: model.AgentQwenCode, want: "qwen/sdd-orchestrator.md"},
-		{agent: model.AgentClaudeCode, want: "generic/sdd-orchestrator.md"},
+		{agent: model.AgentKiroIDE, want: "kiro/sdd-orchestrator.md"},
+		{agent: model.AgentOpenClaw, want: "generic/sdd-orchestrator.md"},
+		{agent: model.AgentPiCodingAgent, want: "pi/sdd-orchestrator.md"},
+		{agent: model.AgentClaudeCode, want: "claude/sdd-orchestrator.md"},
 		{agent: model.AgentOpenCode, want: "opencode/sdd-orchestrator.md"},
 		{agent: model.AgentVSCodeCopilot, want: "generic/sdd-orchestrator.md"},
 	}

--- a/internal/components/theme/inject.go
+++ b/internal/components/theme/inject.go
@@ -40,6 +40,12 @@ var gentlemanClaudeTheme = claudeTheme{
 }
 
 func Inject(homeDir string, adapter agents.Adapter) (InjectionResult, error) {
+	// Pi supports themes, but Gentle-AI does not ship a Pi theme asset yet. Avoid
+	// setting a theme name that Pi cannot resolve.
+	if adapter.Agent() == model.AgentPiCodingAgent {
+		return InjectionResult{}, nil
+	}
+
 	settingsPath := adapter.SettingsPath(homeDir)
 	if settingsPath == "" {
 		return InjectionResult{}, nil

--- a/internal/components/theme/inject_test.go
+++ b/internal/components/theme/inject_test.go
@@ -9,10 +9,12 @@ import (
 	"github.com/gentleman-programming/gentle-ai/internal/agents"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/claude"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/opencode"
+	"github.com/gentleman-programming/gentle-ai/internal/agents/pi"
 )
 
 func claudeAdapter() agents.Adapter   { return claude.NewAdapter() }
 func opencodeAdapter() agents.Adapter { return opencode.NewAdapter() }
+func piAdapter() agents.Adapter       { return pi.NewAdapter() }
 
 func TestInjectMergesThemeOverlayIntoAdapterSettings(t *testing.T) {
 	home := t.TempDir()
@@ -94,6 +96,21 @@ func TestInjectCreatesAdapterSettingsWhenMissing(t *testing.T) {
 	}
 	if root.Theme != "gentleman-kanagawa" {
 		t.Fatalf("theme = %q, want gentleman-kanagawa", root.Theme)
+	}
+}
+
+func TestInjectSkipsPiUntilThemeAssetExists(t *testing.T) {
+	home := t.TempDir()
+
+	result, err := Inject(home, piAdapter())
+	if err != nil {
+		t.Fatalf("Inject() error = %v", err)
+	}
+	if result.Changed || len(result.Files) != 0 {
+		t.Fatalf("Inject() = %#v, want no-op for Pi", result)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".pi", "agent", "settings.json")); !os.IsNotExist(err) {
+		t.Fatalf("Inject() should not write Pi settings.json; stat error = %v", err)
 	}
 }
 

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -16,17 +16,22 @@ const (
 	AgentQwenCode      AgentID = "qwen-code"
 	AgentKiroIDE       AgentID = "kiro-ide"
 	AgentOpenClaw      AgentID = "openclaw"
+	AgentPiCodingAgent AgentID = "pi-coding-agent"
 )
 
 // SupportTier indicates how fully an agent supports the Gentleman AI ecosystem.
-// All current agents receive the full SDD orchestrator, skill files, MCP config,
-// and system prompt injection. The tier is kept as metadata for display purposes.
+// It is metadata for display and product guidance; capability flags on each
+// adapter remain the source of truth for what is actually injected.
 type SupportTier string
 
 const (
-	// TierFull — the agent receives all ecosystem features: SDD orchestrator,
-	// skill files, MCP servers, system prompt, and sub-agent delegation.
+	// TierFull — the agent receives the full supported ecosystem for its native
+	// integration surface, including SDD, skills, prompt/system instructions, and
+	// MCP/sub-agent integration where the agent exposes those capabilities.
 	TierFull SupportTier = "full"
+	// TierPartial — the agent receives a supported subset because its native
+	// integration surface does not currently expose every ecosystem feature.
+	TierPartial SupportTier = "partial"
 )
 
 type ComponentID string

--- a/internal/system/config_scan.go
+++ b/internal/system/config_scan.go
@@ -41,6 +41,8 @@ func knownAgentConfigDirs(homeDir string) []ConfigState {
 		{Agent: "kimi", Path: filepath.Join(homeDir, ".kimi")},
 		{Agent: "qwen-code", Path: filepath.Join(homeDir, ".qwen")},
 		{Agent: "kiro-ide", Path: filepath.Join(homeDir, ".kiro")},
+		{Agent: "openclaw", Path: filepath.Join(homeDir, ".openclaw")},
+		{Agent: "pi-coding-agent", Path: filepath.Join(homeDir, ".pi", "agent")},
 	}
 }
 

--- a/internal/system/config_scan_test.go
+++ b/internal/system/config_scan_test.go
@@ -25,11 +25,10 @@ func TestScanConfigs_ReturnsAllKnownAgentsWithExistsFlag(t *testing.T) {
 	configs := ScanConfigs(home)
 
 	// Must return at least as many entries as the registry has adapters with
-	// a non-empty GlobalConfigDir. Currently 12 agents are supported.
-	if len(configs) < 12 {
-		t.Fatalf("ScanConfigs() returned %d entries, want >= 12; got %v", len(configs), configs)
+	// a non-empty GlobalConfigDir. Currently 14 agents are supported.
+	if len(configs) < 14 {
+		t.Fatalf("ScanConfigs() returned %d entries, want >= 14; got %v", len(configs), configs)
 	}
-
 
 	// Find claude — must be Exists=true.
 	var claudeState *ConfigState
@@ -82,8 +81,9 @@ func TestScanConfigs_AgentFieldMatchesModelAgentID(t *testing.T) {
 		"kimi":           false,
 		"qwen-code":      false,
 		"kiro-ide":       false,
+		"openclaw":       false,
+		"pi-coding-agent": false,
 	}
-
 
 	for _, c := range configs {
 		if _, known := knownAgents[c.Agent]; known {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -3027,6 +3027,8 @@ func preselectedAgents(detection system.DetectionResult) []model.AgentID {
 			selected = append(selected, model.AgentClaudeCode)
 		case string(model.AgentOpenCode):
 			selected = append(selected, model.AgentOpenCode)
+		case string(model.AgentKilocode):
+			selected = append(selected, model.AgentKilocode)
 		case string(model.AgentGeminiCLI):
 			selected = append(selected, model.AgentGeminiCLI)
 		case string(model.AgentCursor):
@@ -3039,8 +3041,16 @@ func preselectedAgents(detection system.DetectionResult) []model.AgentID {
 			selected = append(selected, model.AgentAntigravity)
 		case string(model.AgentWindsurf):
 			selected = append(selected, model.AgentWindsurf)
+		case string(model.AgentKimi):
+			selected = append(selected, model.AgentKimi)
 		case string(model.AgentQwenCode):
 			selected = append(selected, model.AgentQwenCode)
+		case string(model.AgentKiroIDE):
+			selected = append(selected, model.AgentKiroIDE)
+		case string(model.AgentOpenClaw):
+			selected = append(selected, model.AgentOpenClaw)
+		case string(model.AgentPiCodingAgent):
+			selected = append(selected, model.AgentPiCodingAgent)
 		}
 	}
 

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1599,7 +1599,7 @@ func TestModelConfig_OpenCodePickerBackReturnsToModelConfig(t *testing.T) {
 // makeDetectionWithAgents builds a DetectionResult with the specified agents
 // marked as Exists=true. All other agents are absent.
 func makeDetectionWithAgents(present ...string) system.DetectionResult {
-	known := []string{"claude-code", "opencode", "gemini-cli", "cursor", "vscode-copilot", "codex", "antigravity", "windsurf", "qwen-code"}
+	known := []string{"claude-code", "opencode", "kilocode", "gemini-cli", "cursor", "vscode-copilot", "codex", "antigravity", "windsurf", "kimi", "qwen-code", "kiro-ide", "openclaw", "pi-coding-agent"}
 	presentSet := make(map[string]bool, len(present))
 	for _, p := range present {
 		presentSet[p] = true
@@ -2293,21 +2293,29 @@ func TestModelConfig_EscFromPickersReturnsToModelConfig(t *testing.T) {
 	}
 }
 
-// TestPreselectedAgents_AllSixAgentsMappedCorrectly verifies every canonical
+// TestPreselectedAgents_AllAgentsMappedCorrectly verifies every canonical
 // agent string maps to its model.AgentID constant in preselectedAgents.
 // This prevents silent drops when new agents are added to ScanConfigs without
 // updating the TUI switch statement.
-func TestPreselectedAgents_AllSixAgentsMappedCorrectly(t *testing.T) {
+func TestPreselectedAgents_AllAgentsMappedCorrectly(t *testing.T) {
 	tests := []struct {
 		configAgent string
 		wantID      model.AgentID
 	}{
 		{"claude-code", model.AgentClaudeCode},
 		{"opencode", model.AgentOpenCode},
+		{"kilocode", model.AgentKilocode},
 		{"gemini-cli", model.AgentGeminiCLI},
 		{"cursor", model.AgentCursor},
 		{"vscode-copilot", model.AgentVSCodeCopilot},
 		{"codex", model.AgentCodex},
+		{"antigravity", model.AgentAntigravity},
+		{"windsurf", model.AgentWindsurf},
+		{"kimi", model.AgentKimi},
+		{"qwen-code", model.AgentQwenCode},
+		{"kiro-ide", model.AgentKiroIDE},
+		{"openclaw", model.AgentOpenClaw},
+		{"pi-coding-agent", model.AgentPiCodingAgent},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Closes #479

# feat: Add Pi coding agent support

## Summary

This PR adds first-class MVP support for **Pi coding agent** (`pi-coding-agent`) as the 14th supported agent in the Gentle-AI ecosystem.

Pi is intentionally integrated as a **solo-agent** (no native sub-agents or MCP in the core), which is the correct abstraction given Pi's architecture: it ships with prompt templates, Agent Skills, and extensions — but not built-in sub-agent delegation or MCP config surfaces.

## What changed

### New files (11)

| File | Purpose |
|------|---------|
| `internal/agents/pi/adapter.go` | Pi adapter: detection (`pi` binary + `~/.pi/agent`), npm auto-install, config paths, honest capability flags |
| `internal/agents/pi/adapter_test.go` | Table-driven tests following the exact style of `codex/` and `qwen/` adapters |
| `internal/assets/pi/sdd-orchestrator.md` | Solo-agent SDD orchestrator tailored for Pi (no `mem_*` MCP calls, `openspec` as safe default) |
| `internal/assets/pi/prompts/sdd-init.md` | Pi prompt template: initialize SDD context |
| `internal/assets/pi/prompts/sdd-explore.md` | Pi prompt template: explore a topic |
| `internal/assets/pi/prompts/sdd-apply.md` | Pi prompt template: implement tasks |
| `internal/assets/pi/prompts/sdd-verify.md` | Pi prompt template: validate implementation |
| `internal/assets/pi/prompts/sdd-archive.md` | Pi prompt template: archive change |
| `internal/assets/pi/prompts/sdd-onboard.md` | Pi prompt template: guided walkthrough |
| `internal/assets/pi/prompts/sdd-new.md` | Pi prompt template: start a new change |
| `internal/assets/pi/prompts/sdd-continue.md` | Pi prompt template: continue next phase |
| `internal/assets/pi/prompts/sdd-ff.md` | Pi prompt template: fast-forward planning |

### Modified files (25)

**Core model & wiring:**
- `internal/model/types.go` — Added `AgentPiCodingAgent` and `TierPartial` support tier
- `internal/agents/factory.go` — Registered Pi adapter in `NewAdapter` and `defaultAgentIDs`
- `internal/catalog/agents.go` — Added Pi to `allAgents` with `TierPartial`, config path `~/.pi/agent`
- `internal/system/config_scan.go` — Added `~/.pi/agent` to `knownAgentConfigDirs` (also backfilled missing `openclaw`)
- `internal/cli/validate.go` — Added `pi-coding-agent` to `defaultAgentsFromDetection` switch
- `internal/tui/model.go` — Added Pi to `preselectedAgents` (also backfilled missing `kilocode`, `kimi`, `kiro-ide`, `openclaw`)

**Asset embedding & routing:**
- `internal/assets/assets.go` — Added `all:pi` to `//go:embed`
- `internal/assets/commands.go` — Routed `AgentPiCodingAgent` → `"pi/prompts"` for SDD slash commands
- `internal/components/sdd/inject.go` — Routed `sddOrchestratorAsset` to `"pi/sdd-orchestrator.md"`; fixed `injectMarkdownSections` to use agent-specific asset (also fixed missing `AgentClaudeCode` case)

**Safety guards (no fake MCP/Engram/Theme):**
- `internal/cli/run.go` — Added `SupportsMCP()` guards for `ComponentEngram` and `ComponentContext7`; skips `ComponentTheme` for Pi until a theme asset exists
- `internal/components/theme/inject.go` — Returns no-op for Pi with explanatory comment

**Tests:**
- `internal/agents/factory_test.go` — Added Pi to registry and factory resolution tests
- `internal/agents/registry_test.go` — Added Pi to `TestDefaultRegistryIncludesAllAgents`
- `internal/catalog/agents_test.go` — Added `TestAllAgentsIncludesPiCodingAgent` and `TestIsSupportedAgentAcceptsPiCodingAgent`
- `internal/system/config_scan_test.go` — Updated agent count from 12 → 14
- `internal/cli/install_test.go` — Updated default agent list and `makeDetectionWithAgents`
- `internal/cli/run_component_paths_test.go` — Added Pi-specific path assertions (system prompt, prompts, skills; rejects MCP/theme paths)
- `internal/components/sdd/inject_test.go` — Added `TestInjectPiWritesPromptTemplatesAndSkills` + fixed `TestSDDOrchestratorAssetSelection` expectations
- `internal/components/theme/inject_test.go` — Added `TestInjectSkipsPiUntilThemeAssetExists`
- `internal/assets/assets_test.go` — Added Pi files to expected list + `TestPiEmbeddedAssetLayout`
- `internal/tui/model_test.go` — Updated `knownAgents` map and preselection tests

**Docs & E2E:**
- `README.md` — "13 Supported Agents" → "14 Supported Agents"; added Pi row
- `docs/agents.md` — Added Pi matrix row (Skills: Yes, MCP: No, Delegation: Solo-agent, Slash Commands: Yes via prompt templates); added honest "Agent Notes" section
- `docs/platforms.md` — Added Pi config path
- `e2e/lib.sh` — Added `rm -rf "$HOME/.pi"` to `cleanup_test_env()`

## Design decisions

### Why solo-agent / `SupportsSubAgents=false`?

Pi core intentionally does not include sub-agents or plan mode. The optional `pi-subagents` package exists but is not auto-installed by Gentle-AI. Claiming full delegation would be misleading.

### Why `SupportsMCP=false`?

Pi has no native MCP config surface (no `mcpServers` key in settings, no dedicated MCP JSON file). MCP integration would require a Pi extension, which is out of scope for this MVP.

### Why no sudo on unknown Linux?

Termux and other unknown Linux profiles often lack `sudo`. The install command only uses `sudo` on known distros (Ubuntu/Debian/Arch/Fedora) with non-writable global npm.

### Why `APPEND_SYSTEM.md` instead of `AGENTS.md`?

Pi separates context files (`AGENTS.md`) from system prompt files (`SYSTEM.md` / `APPEND_SYSTEM.md`). Using `APPEND_SYSTEM.md` keeps Gentle-AI's managed instructions in the proper layer without clobbering user context files.

## Testing

```bash
go build ./cmd/gentle-ai
go test ./...
```

**Result:** ✅ All tests pass. The only pre-existing failure (`TestWithPostInstallNotesDoesNotChangeNonGGA` in `internal/cli`) also fails on clean `main` in this Termux environment and is unrelated to Pi.

## Checklist

- [x] Adapter follows existing patterns (codex/qwen/openclaw)
- [x] Table-driven tests for adapter identity, detection, install, paths, capabilities, strategies
- [x] No fake MCP/Engram/Context7 config generated for Pi
- [x] Theme injection safely skipped for Pi
- [x] All hardcoded agent counts updated (14 agents)
- [x] TUI preselection + CLI detection synced
- [x] Docs updated with honest capability matrix
- [x] E2E cleanup includes Pi config dir
- [x] `go build` passes
- [x] `go test ./...` passes (except 1 pre-existing unrelated failure)

## Follow-up ideas (not in this PR)

- Optional `pi-subagents` package integration for full SDD delegation
- Pi extension-based MCP/Engram bridge
- Pi-specific theme asset (`gentleman-kanagawa` for Pi)
- `PI_CODING_AGENT_DIR` override support
