### PR TITLE
feat(engram): add DataDirRef type, location suggestions, and presenter helpers

### DIFF
--- a/internal/components/engram/env.go
+++ b/internal/components/engram/env.go
@@ -1,0 +1,32 @@
+package engram
+
+import (
+	"path/filepath"
+)
+
+// DataDirRef is the persisted reference to an Engram data directory.
+// Currently resolves to a local filesystem path.
+// Future URI schemes (e.g. "provider://...") can be added inside Resolve
+// without changing the JSON format or breaking existing installations.
+type DataDirRef string
+
+// Resolve returns the effective local filesystem path for the data directory.
+// An empty ref resolves to the platform default (~/.engram).
+func (r DataDirRef) Resolve(homeDir string) string {
+	if r == "" {
+		return DefaultDir(homeDir)
+	}
+	// filepath.FromSlash normalises Windows path separators on any input,
+	// filepath.Clean removes redundant separators and dots.
+	return filepath.Clean(filepath.FromSlash(string(r)))
+}
+
+// DefaultDir returns the default Engram data directory path (~/.engram).
+func DefaultDir(homeDir string) string {
+	return filepath.Join(homeDir, ".engram")
+}
+
+// DBPath returns the path to the Engram SQLite database inside dataDir.
+func DBPath(dataDir string) string {
+	return filepath.Join(dataDir, "engram.db")
+}

--- a/internal/components/engram/env_test.go
+++ b/internal/components/engram/env_test.go
@@ -1,0 +1,44 @@
+package engram
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestDataDirRef_Resolve(t *testing.T) {
+	home := t.TempDir()
+	custom := filepath.Join(home, "custom-data")
+
+	tests := []struct {
+		ref  DataDirRef
+		want string
+	}{
+		{"", DefaultDir(home)},
+		{DataDirRef(DefaultDir(home)), DefaultDir(home)},
+		{DataDirRef(custom), custom},
+		// trailing separator is cleaned
+		{DataDirRef(custom + string(filepath.Separator)), custom},
+	}
+	for _, tt := range tests {
+		got := tt.ref.Resolve(home)
+		if got != tt.want {
+			t.Errorf("DataDirRef(%q).Resolve(%q) = %q, want %q", tt.ref, home, got, tt.want)
+		}
+	}
+}
+
+func TestDefaultDir(t *testing.T) {
+	got := DefaultDir("/home/user")
+	want := filepath.Join("/home/user", ".engram")
+	if got != want {
+		t.Errorf("DefaultDir = %q, want %q", got, want)
+	}
+}
+
+func TestDBPath(t *testing.T) {
+	got := DBPath("/home/user/.engram")
+	want := filepath.Join("/home/user/.engram", "engram.db")
+	if got != want {
+		t.Errorf("DBPath = %q, want %q", got, want)
+	}
+}

--- a/internal/components/engram/locations.go
+++ b/internal/components/engram/locations.go
@@ -1,0 +1,81 @@
+package engram
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/gentleman-programming/gentle-ai/internal/storage"
+)
+
+// Location is a candidate Engram data directory the user can choose from.
+type Location struct {
+	Path      string // absolute, cleaned filesystem path
+	Label     string // human-readable: "Default (~/.engram)", "D:\\ (120 GiB free)"
+	Available int64  // bytes free on the containing volume; -1 if unknown
+	IsCurrent bool   // true when this matches the currently active data dir
+}
+
+// SuggestLocations returns an ordered list of candidate data directories.
+// The current location is always listed first. The default ~/.engram follows,
+// then any additional volumes detected on the platform (see platform files).
+// Duplicate paths are deduplicated; labels include free-space info where available.
+func SuggestLocations(homeDir, currentDir string) []Location {
+	seen := map[string]bool{}
+	var out []Location
+
+	add := func(path string, isCurrent bool) {
+		clean := filepath.Clean(path)
+		if seen[clean] {
+			return
+		}
+		seen[clean] = true
+		avail, err := storage.AvailableBytes(filepath.Dir(clean))
+		if err != nil {
+			avail = -1
+		}
+		label := buildLabel(clean, homeDir, avail)
+		out = append(out, Location{
+			Path:      clean,
+			Label:     label,
+			Available: avail,
+			IsCurrent: isCurrent,
+		})
+	}
+
+	// Current location first (may equal default).
+	if currentDir != "" {
+		add(currentDir, true)
+	}
+
+	// Default location — isCurrent only when no explicit current dir was provided.
+	// If currentDir equals the default the seen-map dedup above already handles it;
+	// if currentDir is a custom path the default is a non-current alternative.
+	add(DefaultDir(homeDir), currentDir == "")
+
+	// Platform-specific extra volumes (see locations_unix.go / locations_windows.go).
+	for _, vol := range platformVolumes() {
+		add(filepath.Join(vol, "Engram"), false)
+	}
+
+	return out
+}
+
+// buildLabel constructs the display label for a location entry.
+func buildLabel(path, homeDir string, available int64) string {
+	// Replace home prefix with ~ for readability.
+	display := path
+	if rel, err := filepath.Rel(homeDir, path); err == nil && len(rel) < len(path) {
+		display = filepath.Join("~", rel)
+	}
+
+	if available < 0 {
+		return display
+	}
+	return display + "  (" + storage.FormatBytes(available) + " free)"
+}
+
+// dirExists is a small helper used by platform files.
+func dirExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
+}

--- a/internal/components/engram/locations_test.go
+++ b/internal/components/engram/locations_test.go
@@ -1,0 +1,95 @@
+package engram
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestSuggestLocations_DefaultFirst(t *testing.T) {
+	home := t.TempDir()
+
+	locs := SuggestLocations(home, "")
+	if len(locs) == 0 {
+		t.Fatal("SuggestLocations returned no locations")
+	}
+	// Without a current dir the default should be first.
+	want := filepath.Clean(DefaultDir(home))
+	if locs[0].Path != want {
+		t.Errorf("first location = %q, want default %q", locs[0].Path, want)
+	}
+}
+
+func TestSuggestLocations_CurrentFirst(t *testing.T) {
+	home := t.TempDir()
+	current := filepath.Join(home, "custom-engram")
+
+	locs := SuggestLocations(home, current)
+	if len(locs) == 0 {
+		t.Fatal("SuggestLocations returned no locations")
+	}
+	if locs[0].Path != filepath.Clean(current) {
+		t.Errorf("first location = %q, want current %q", locs[0].Path, current)
+	}
+	if !locs[0].IsCurrent {
+		t.Error("first location IsCurrent should be true")
+	}
+}
+
+func TestSuggestLocations_DefaultNotCurrentWhenCustomDirSet(t *testing.T) {
+	home := t.TempDir()
+	custom := filepath.Join(home, "custom-engram")
+
+	locs := SuggestLocations(home, custom)
+
+	defaultPath := filepath.Clean(DefaultDir(home))
+	for _, loc := range locs {
+		if loc.Path == defaultPath && loc.IsCurrent {
+			t.Errorf("default dir %q should NOT be IsCurrent when a custom dir is set", defaultPath)
+		}
+	}
+}
+
+func TestSuggestLocations_NoDuplicates(t *testing.T) {
+	home := t.TempDir()
+	// When current == default, we should get exactly one entry for that path.
+	defaultDir := DefaultDir(home)
+	locs := SuggestLocations(home, defaultDir)
+
+	seen := map[string]int{}
+	for _, l := range locs {
+		seen[l.Path]++
+	}
+	for path, count := range seen {
+		if count > 1 {
+			t.Errorf("path %q appears %d times, want 1", path, count)
+		}
+	}
+}
+
+func TestBuildLabel_HomePrefix(t *testing.T) {
+	home := "/home/user"
+	path := filepath.Join(home, ".engram")
+	label := buildLabel(path, home, -1)
+	if label != filepath.Join("~", ".engram") {
+		t.Errorf("buildLabel = %q, want %q", label, filepath.Join("~", ".engram"))
+	}
+}
+
+func TestBuildLabel_WithFreeSpace(t *testing.T) {
+	home := "/home/user"
+	path := filepath.Join(home, ".engram")
+	label := buildLabel(path, home, 1024*1024*1024) // 1 GiB
+	want := filepath.Join("~", ".engram") + "  (1.0 GiB free)"
+	if label != want {
+		t.Errorf("buildLabel = %q, want %q", label, want)
+	}
+}
+
+func TestBuildLabel_NoHomePrefix(t *testing.T) {
+	home := "/home/user"
+	path := "/external/drive/engram"
+	label := buildLabel(path, home, -1)
+	if label != path {
+		t.Errorf("buildLabel = %q, want %q", label, path)
+	}
+}

--- a/internal/components/engram/locations_unix.go
+++ b/internal/components/engram/locations_unix.go
@@ -1,0 +1,25 @@
+//go:build !windows
+
+package engram
+
+import "path/filepath"
+
+// platformVolumes returns mount-point directories to suggest as alternative
+// Engram data locations on macOS (/Volumes/*) and Linux (/mnt/*, /media/*/*).
+func platformVolumes() []string {
+	var roots []string
+
+	for _, glob := range []string{
+		"/Volumes/*",       // macOS external drives
+		"/mnt/*",           // Linux manual mounts
+		"/media/*/*",       // Linux user-automounted drives (udisks2)
+	} {
+		matches, _ := filepath.Glob(glob)
+		for _, m := range matches {
+			if dirExists(m) {
+				roots = append(roots, m)
+			}
+		}
+	}
+	return roots
+}

--- a/internal/components/engram/locations_windows.go
+++ b/internal/components/engram/locations_windows.go
@@ -1,0 +1,38 @@
+//go:build windows
+
+package engram
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+var (
+	_kernel32              = syscall.NewLazyDLL("kernel32.dll")
+	_getDiskFreeSpaceExW   = _kernel32.NewProc("GetDiskFreeSpaceExW")
+)
+
+// platformVolumes returns drive roots that have available disk space on Windows.
+// It iterates A–Z and includes any root (e.g. "C:\") where GetDiskFreeSpaceExW
+// succeeds — meaning the drive is present and accessible.
+func platformVolumes() []string {
+	var roots []string
+	for c := 'A'; c <= 'Z'; c++ {
+		root := string(c) + ":\\"
+		ptr, err := syscall.UTF16PtrFromString(root)
+		if err != nil {
+			continue
+		}
+		var avail, total, free uint64
+		r, _, _ := _getDiskFreeSpaceExW.Call(
+			uintptr(unsafe.Pointer(ptr)),
+			uintptr(unsafe.Pointer(&avail)),
+			uintptr(unsafe.Pointer(&total)),
+			uintptr(unsafe.Pointer(&free)),
+		)
+		if r != 0 {
+			roots = append(roots, root)
+		}
+	}
+	return roots
+}

--- a/internal/components/engram/presenter.go
+++ b/internal/components/engram/presenter.go
@@ -1,0 +1,25 @@
+package engram
+
+import (
+	"fmt"
+
+	"github.com/gentleman-programming/gentle-ai/internal/storage"
+)
+
+// FormatDirLine returns a single display line for a data-directory option, e.g.
+// "~/.engram  (1.2 GiB used)". Used in TUI option lists.
+func FormatDirLine(dir string, dbSize int64) string {
+	if dbSize <= 0 {
+		return dir
+	}
+	return fmt.Sprintf("%s  (%s used)", dir, storage.FormatBytes(dbSize))
+}
+
+// FormatSpaceWarning returns a human-readable warning for insufficient disk
+// space, e.g. "Need 1.2 GiB, only 300.0 MiB free".
+func FormatSpaceWarning(needed, avail int64) string {
+	return fmt.Sprintf("Need %s, only %s free",
+		storage.FormatBytes(needed),
+		storage.FormatBytes(avail),
+	)
+}

--- a/internal/storage/bytes.go
+++ b/internal/storage/bytes.go
@@ -1,0 +1,23 @@
+package storage
+
+import "fmt"
+
+// FormatBytes formats n bytes as a human-readable string using 1024-based units,
+// consistent with Engram CLI output.
+func FormatBytes(n int64) string {
+	const (
+		kib = 1024
+		mib = 1024 * kib
+		gib = 1024 * mib
+	)
+	switch {
+	case n >= gib:
+		return fmt.Sprintf("%.1f GiB", float64(n)/float64(gib))
+	case n >= mib:
+		return fmt.Sprintf("%.1f MiB", float64(n)/float64(mib))
+	case n >= kib:
+		return fmt.Sprintf("%.1f KiB", float64(n)/float64(kib))
+	default:
+		return fmt.Sprintf("%d B", n)
+	}
+}

--- a/internal/storage/space.go
+++ b/internal/storage/space.go
@@ -1,0 +1,7 @@
+package storage
+
+// AvailableBytes returns the number of bytes available to an unprivileged user
+// on the volume containing path. path may be an existing file or directory.
+func AvailableBytes(path string) (int64, error) {
+	return availableBytes(path)
+}

--- a/internal/storage/space_test.go
+++ b/internal/storage/space_test.go
@@ -1,0 +1,65 @@
+package storage_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/internal/storage"
+)
+
+func TestAvailableBytes_TempDir(t *testing.T) {
+	dir := t.TempDir()
+	n, err := storage.AvailableBytes(dir)
+	if err != nil {
+		t.Fatalf("AvailableBytes(%q): unexpected error: %v", dir, err)
+	}
+	if n <= 0 {
+		t.Fatalf("AvailableBytes(%q) = %d, want > 0", dir, n)
+	}
+}
+
+func TestAvailableBytes_File(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "space-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+
+	n, err := storage.AvailableBytes(f.Name())
+	if err != nil {
+		t.Fatalf("AvailableBytes(%q): unexpected error: %v", f.Name(), err)
+	}
+	if n <= 0 {
+		t.Fatalf("AvailableBytes(%q) = %d, want > 0", f.Name(), n)
+	}
+}
+
+func TestAvailableBytes_NonExistent(t *testing.T) {
+	_, err := storage.AvailableBytes("/this/path/does/not/exist/ever")
+	if err == nil {
+		t.Fatal("expected error for non-existent path, got nil")
+	}
+}
+
+func TestFormatBytes(t *testing.T) {
+	tests := []struct {
+		n    int64
+		want string
+	}{
+		{0, "0 B"},
+		{512, "512 B"},
+		{1023, "1023 B"},
+		{1024, "1.0 KiB"},
+		{1536, "1.5 KiB"},
+		{1024 * 1024, "1.0 MiB"},
+		{int64(1.5 * 1024 * 1024), "1.5 MiB"},
+		{1024 * 1024 * 1024, "1.0 GiB"},
+		{int64(2469606195), "2.3 GiB"},
+	}
+	for _, tt := range tests {
+		got := storage.FormatBytes(tt.n)
+		if got != tt.want {
+			t.Errorf("FormatBytes(%d) = %q, want %q", tt.n, got, tt.want)
+		}
+	}
+}

--- a/internal/storage/space_unix.go
+++ b/internal/storage/space_unix.go
@@ -1,0 +1,17 @@
+//go:build !windows
+
+package storage
+
+import (
+	"fmt"
+	"syscall"
+)
+
+func availableBytes(path string) (int64, error) {
+	var stat syscall.Statfs_t
+	if err := syscall.Statfs(path, &stat); err != nil {
+		return 0, fmt.Errorf("statfs %q: %w", path, err)
+	}
+	// Bavail = blocks available to unprivileged users
+	return int64(stat.Bavail) * int64(stat.Bsize), nil
+}

--- a/internal/storage/space_windows.go
+++ b/internal/storage/space_windows.go
@@ -1,0 +1,40 @@
+//go:build windows
+
+package storage
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+	"unsafe"
+)
+
+var (
+	kernel32              = syscall.NewLazyDLL("kernel32.dll")
+	getDiskFreeSpaceExW   = kernel32.NewProc("GetDiskFreeSpaceExW")
+)
+
+func availableBytes(path string) (int64, error) {
+	// GetDiskFreeSpaceExW requires a directory path; resolve parent if path is a file.
+	if info, err := os.Stat(path); err == nil && !info.IsDir() {
+		path = filepath.Dir(path)
+	}
+
+	pathPtr, err := syscall.UTF16PtrFromString(path)
+	if err != nil {
+		return 0, fmt.Errorf("encode path %q: %w", path, err)
+	}
+
+	var avail, total, free uint64
+	r, _, err := getDiskFreeSpaceExW.Call(
+		uintptr(unsafe.Pointer(pathPtr)),
+		uintptr(unsafe.Pointer(&avail)),
+		uintptr(unsafe.Pointer(&total)),
+		uintptr(unsafe.Pointer(&free)),
+	)
+	if r == 0 {
+		return 0, fmt.Errorf("GetDiskFreeSpaceExW %q: %w", path, err)
+	}
+	return int64(avail), nil
+}


### PR DESCRIPTION
## Summary  Introduces the foundational types and location-discovery layer for Engram data-directory management (issue #346, PR B1 of B1+B2+B3):  - **`DataDirRef`** ΓÇö future-proof path type with `Resolve(homeDir)`, plus `DefaultDir` and `DBPath` helpers - **`SuggestLocations`** ΓÇö ordered, deduplicated candidate list with free-space labels; returns `[]Location` with `IsCurrent` flag - **Platform-specific volume discovery** ΓÇö `Statfs` on Unix, `GetDiskFreeSpaceEx` on Windows via `syscall.NewLazyDLL` - **`FormatDirLine` / `FormatSpaceWarning`** ΓÇö presenter helpers for TUI display (no Bubbletea dep)  **Bug fixed:** `IsCurrent` was incorrectly set on the default location when a custom dir was active.  ## Changes  | File | Type | Lines | |------|------|-------| | `internal/components/engram/env.go` + `env_test.go` | New | +76 | | `internal/components/engram/locations.go` + test + platform files | New | +239 | | `internal/components/engram/presenter.go` | New | +25 | | **Total** | | **+340 / budget: 400** Γ£à |  ## Test plan  - [x] `go test ./internal/components/engram/... -run "TestDataDirRef|TestDefault|TestDBPath|TestSuggest|TestBuildLabel"` ΓÇö 10 tests, all pass - [x] `go build ./...` ΓÇö clean build - [x] **Full repo** `go test ./...` ΓÇö Γ£à Pass (CI) - [x] **E2E** `cd e2e && ./docker-test.sh` (ubuntu / arch / fedora) ΓÇö Γ£à Pass (CI)  ## PR Chain ΓÇö Closes #346  | # | PR | Lines | |---|----|-------| | A | #465 | 152 Γ£à | | **B1** | **this PR** | **340 Γ£à** | | B2 | #485 | 171 Γ£à | | B3 | #486 | 370 Γ£à | | C | #487 | 33 Γ£à | | D1 | #488 | 282 Γ£à | | D2 | #489 | 340 Γ£à |  ---  ## CI status (GitHub Actions)  **Checks:** https://github.com/Gentleman-Programming/gentle-ai/pull/484/checks  | Gate | Status | |------|--------| | Unit Tests (`go test ./...`) | Γ£à Pass | | E2E Tests (ubuntu / arch / fedora) | Γ£à Pass | | Issue reference (`Closes #346`) + `status:approved` | Γ£à Pass | | PR cognitive load vs `main` | ΓÜá∩╕Å May fail while **#465** is unmerged ΓÇö GitHub diffs the **full stack** vs `main`; **this PRΓÇÖs own diff is Γëñ400 lines** Γ£à | | Exactly one `type:*` label | ΓÜá∩╕Å Maintainer applies |  ```bash go test ./... cd e2e && ./docker-test.sh ```  ≡ƒñû Generated with [Claude Code](https://claude.com/claude-code)  
---

## Chain Context (SDD - stacked PRs targeting main)

| Field | Value |
|-------|-------|
| Chain | Engram data-directory (#346) |
| Strategy | Stacked branches; each PR opens vs **main** - upstream typically has no intermediate GitHub base branches, so merge **#465 .. #489** in order; branch ancestry carries predecessor commits. |
| Tracker PR | none (feature-branch tracker not used). |
| **This PR** | **#484** |
| Base | Gentleman-Programming/gentle-ai **main** |
| Cognitive load (GitHub vs **main**) | **+492/-0 = 492** changed lines |
| CI budget (400-line gate) | EXCEEDS 400 vs main (additions + deletions). CI requires maintainer-applied size:exception, OR retarget this PR to the previous branch once those bases exist upstream so GitHub shows only the slice diff. |

The **Summary / Changes** tables above describe the scoped review unit for this numbered PR. **GitHub diff vs main is cumulative** while every PR still targets **main**, so totals grow down-chain even though each PR narrative stays slice-focused.

### Merge-order diagram

`
main -> PR #465 -> [THIS] PR #484 -> PR #485 -> PR #486 -> PR #487 -> PR #488 -> PR #489
`

### Autonomy

- [x] Single numbered deliverable (Summary).
- [x] Line totals above match GitHub Files changed aggregation vs **main** for this PR head.
