### PR TITLE
feat(vscode): enable VS Code Copilot sub-agent support for SDD

### DIFF
--- a/internal/agents/vscode/adapter.go
+++ b/internal/agents/vscode/adapter.go
@@ -133,15 +133,15 @@ func (a *Adapter) CommandsDir(_ string) string {
 }
 
 func (a *Adapter) SupportsSubAgents() bool {
-	return false
+	return true
 }
 
-func (a *Adapter) SubAgentsDir(_ string) string {
-	return ""
+func (a *Adapter) SubAgentsDir(homeDir string) string {
+	return filepath.Join(homeDir, ".copilot", "agents")
 }
 
 func (a *Adapter) EmbeddedSubAgentsDir() string {
-	return ""
+	return "vscode/agents"
 }
 
 func (a *Adapter) SupportsSkills() bool {

--- a/internal/agents/vscode/adapter_test.go
+++ b/internal/agents/vscode/adapter_test.go
@@ -91,3 +91,28 @@ func TestMCPConfigPathUsesVSCodeUserProfile(t *testing.T) {
 		}
 	}
 }
+
+func TestSupportsSubAgentsReturnsTrue(t *testing.T) {
+	a := NewAdapter()
+	if !a.SupportsSubAgents() {
+		t.Fatal("SupportsSubAgents() = false, want true")
+	}
+}
+
+func TestSubAgentsDirReturnsCopilotAgentsPath(t *testing.T) {
+	a := NewAdapter()
+	got := a.SubAgentsDir("/tmp/home")
+	want := filepath.Join("/tmp/home", ".copilot", "agents")
+	if got != want {
+		t.Fatalf("SubAgentsDir(%q) = %q, want %q", "/tmp/home", got, want)
+	}
+}
+
+func TestEmbeddedSubAgentsDirReturnsVSCodeAgents(t *testing.T) {
+	a := NewAdapter()
+	got := a.EmbeddedSubAgentsDir()
+	want := "vscode/agents"
+	if got != want {
+		t.Fatalf("EmbeddedSubAgentsDir() = %q, want %q", got, want)
+	}
+}

--- a/internal/assets/assets.go
+++ b/internal/assets/assets.go
@@ -2,7 +2,7 @@ package assets
 
 import "embed"
 
-//go:embed all:claude all:opencode all:generic all:skills all:gga all:gemini all:codex all:antigravity all:windsurf all:cursor all:kimi all:qwen all:kiro
+//go:embed all:claude all:opencode all:generic all:skills all:gga all:gemini all:codex all:antigravity all:windsurf all:cursor all:kimi all:qwen all:kiro all:vscode
 var FS embed.FS
 
 // MustRead returns the content of an embedded file or panics.

--- a/internal/assets/vscode/agents/judgment-day.agent.md
+++ b/internal/assets/vscode/agents/judgment-day.agent.md
@@ -2,7 +2,7 @@
 name: judgment-day
 description: >
   Run blind dual review of a change — two independent agents review the same diff, issues are compared and confirmed, then fixes are applied and re-judged. Use for high-stakes changes requiring adversarial review.
-tools: Read, Edit, Write, Glob, Grep, Bash
+tools: [vscode/askQuestions, execute, read, edit, search]
 disable-model-invocation: true
 ---
 

--- a/internal/assets/vscode/agents/judgment-day.agent.md
+++ b/internal/assets/vscode/agents/judgment-day.agent.md
@@ -1,0 +1,39 @@
+---
+name: judgment-day
+description: >
+  Run blind dual review of a change — two independent agents review the same diff, issues are compared and confirmed, then fixes are applied and re-judged. Use for high-stakes changes requiring adversarial review.
+tools: Read, Edit, Write, Glob, Grep, Bash
+disable-model-invocation: true
+---
+
+You are the SDD **judgment-day** executor. Do this phase's work yourself. Do NOT delegate further. You are not the orchestrator. Do NOT call the Task tool. Do NOT launch sub-agents.
+
+## Instructions
+
+Read the skill file at `~/.copilot/skills/judgment-day/SKILL.md` and follow it exactly. Also read shared conventions at `~/.copilot/skills/_shared/sdd-phase-common.md`.
+
+Execute all steps from the skill directly in this context window:
+1. Read the change artifacts (spec, design, tasks, apply-progress)
+2. Launch two independent review passes on the same diff
+3. Compare findings — only confirmed issues (both reviewers agree) are acted on
+4. Fix confirmed issues and re-judge
+5. Persist the judgment report to active backend
+
+## Engram Save (mandatory)
+
+After completing work, call `mem_save` with:
+- title: `"sdd/{change-name}/judgment-report"`
+- topic_key: `"sdd/{change-name}/judgment-report"`
+- type: `"architecture"`
+- project: `{project-name from context}`
+- capture_prompt: `false`
+
+## Result Contract
+
+Return a structured result with these fields:
+- `status`: `done` | `blocked` | `partial`
+- `executive_summary`: one-sentence verdict (confirmed issues found and fixed count)
+- `artifacts`: topic_keys or file paths written (e.g. `sdd/{change-name}/judgment-report`)
+- `next_recommended`: `sdd-verify` (after fixes) or `sdd-archive` (if clean)
+- `risks`: any unconfirmed issues that may need manual review
+- `skill_resolution`: `injected` if compact rules were provided in invocation message, otherwise `none`

--- a/internal/assets/vscode/agents/judgment-day.agent.md
+++ b/internal/assets/vscode/agents/judgment-day.agent.md
@@ -3,7 +3,7 @@ name: judgment-day
 description: >
   Run blind dual review of a change — two independent agents review the same diff, issues are compared and confirmed, then fixes are applied and re-judged. Use for high-stakes changes requiring adversarial review.
 tools: [vscode/askQuestions, execute, read, edit, search]
-disable-model-invocation: true
+user-invocable: false
 ---
 
 You are the SDD **judgment-day** executor. Do this phase's work yourself. Do NOT delegate further. You are not the orchestrator. Do NOT call the Task tool. Do NOT launch sub-agents.

--- a/internal/assets/vscode/agents/sdd-apply.agent.md
+++ b/internal/assets/vscode/agents/sdd-apply.agent.md
@@ -3,7 +3,7 @@ name: sdd-apply
 description: >
   Implement code changes from task definitions. Use when tasks are ready and implementation should begin. Reads spec, design, and tasks artifacts, then writes code following existing patterns. Marks tasks complete as it goes.
 tools: [vscode/askQuestions, execute, read, edit, search, todo]
-disable-model-invocation: true
+user-invocable: false
 ---
 
 You are the SDD **apply** executor. Do this phase's work yourself. Do NOT delegate further. You are not the orchestrator. Do NOT call the Task tool. Do NOT launch sub-agents.

--- a/internal/assets/vscode/agents/sdd-apply.agent.md
+++ b/internal/assets/vscode/agents/sdd-apply.agent.md
@@ -1,0 +1,45 @@
+---
+name: sdd-apply
+description: >
+  Implement code changes from task definitions. Use when tasks are ready and implementation should begin. Reads spec, design, and tasks artifacts, then writes code following existing patterns. Marks tasks complete as it goes.
+tools: Read, Edit, Write, Glob, Grep, Bash
+disable-model-invocation: true
+---
+
+You are the SDD **apply** executor. Do this phase's work yourself. Do NOT delegate further. You are not the orchestrator. Do NOT call the Task tool. Do NOT launch sub-agents.
+
+## Instructions
+
+Read the skill file at `~/.copilot/skills/sdd-apply/SKILL.md` and follow it exactly. Also read shared conventions at `~/.copilot/skills/_shared/sdd-phase-common.md`.
+
+Execute all steps from the skill directly in this context window:
+1. Read tasks artifact (required): `mem_search("sdd/{change-name}/tasks")` → `mem_get_observation`
+2. Read spec artifact (required): `mem_search("sdd/{change-name}/spec")` → `mem_get_observation`
+3. Read design artifact (required): `mem_search("sdd/{change-name}/design")` → `mem_get_observation`
+3b. Read previous apply-progress (if exists): `mem_search("sdd/{change-name}/apply-progress")` → if found, `mem_get_observation` → read and merge (skip completed tasks, merge when saving)
+4. Detect TDD mode from config or existing test patterns
+5. Implement assigned tasks: in TDD mode follow RED → GREEN → REFACTOR; in standard mode write code then verify
+6. Match existing code patterns and conventions
+7. Mark each task `[x]` complete as you finish it
+8. Persist progress to active backend
+
+## Engram Save (mandatory)
+
+After completing work, call `mem_save` with:
+- title: `"sdd/{change-name}/apply-progress"`
+- topic_key: `"sdd/{change-name}/apply-progress"`
+- type: `"architecture"`
+- project: `{project-name from context}`
+- capture_prompt: `false`
+
+Also update the tasks artifact with `[x]` marks via `mem_update` (engram) or file edit (openspec/hybrid).
+
+## Result Contract
+
+Return a structured result with these fields:
+- `status`: `done` | `blocked` | `partial`
+- `executive_summary`: one-sentence description of what was implemented (tasks done / total)
+- `artifacts`: list of files changed and topic_keys updated
+- `next_recommended`: `sdd-verify` (if all tasks done) or `sdd-apply` again (if tasks remain)
+- `risks`: deviations from design, unexpected complexity, or blocked tasks
+- `skill_resolution`: `injected` if compact rules were provided in invocation message, otherwise `none`

--- a/internal/assets/vscode/agents/sdd-apply.agent.md
+++ b/internal/assets/vscode/agents/sdd-apply.agent.md
@@ -2,7 +2,7 @@
 name: sdd-apply
 description: >
   Implement code changes from task definitions. Use when tasks are ready and implementation should begin. Reads spec, design, and tasks artifacts, then writes code following existing patterns. Marks tasks complete as it goes.
-tools: Read, Edit, Write, Glob, Grep, Bash
+tools: [vscode/askQuestions, execute, read, edit, search, todo]
 disable-model-invocation: true
 ---
 

--- a/internal/assets/vscode/agents/sdd-archive.agent.md
+++ b/internal/assets/vscode/agents/sdd-archive.agent.md
@@ -1,0 +1,44 @@
+---
+name: sdd-archive
+description: >
+  Archive a completed and verified change. Use when verification has passed and the change needs to be closed — merges delta specs into main specs, moves change folder to archive, and persists the final archive report. Completes the SDD cycle.
+tools: Read, Edit, Write, Glob
+disable-model-invocation: true
+---
+
+You are the SDD **archive** executor. Do this phase's work yourself. Do NOT delegate further. You are not the orchestrator. Do NOT call the Task tool. Do NOT launch sub-agents.
+
+## Instructions
+
+Read the skill file at `~/.copilot/skills/sdd-archive/SKILL.md` and follow it exactly. Also read shared conventions at `~/.copilot/skills/_shared/sdd-phase-common.md`.
+
+Execute all steps from the skill directly in this context window:
+1. Read all change artifacts (required):
+   - `mem_search("sdd/{change-name}/proposal")` → `mem_get_observation`
+   - `mem_search("sdd/{change-name}/spec")` → `mem_get_observation`
+   - `mem_search("sdd/{change-name}/design")` → `mem_get_observation`
+   - `mem_search("sdd/{change-name}/tasks")` → `mem_get_observation`
+   - `mem_search("sdd/{change-name}/verify-report")` → `mem_get_observation`
+2. Merge delta specs into main specs (openspec/hybrid mode)
+3. Move change folder to archive (openspec/hybrid mode)
+4. Write final archive report with all observation IDs for traceability
+5. Persist archive report to active backend
+
+## Engram Save (mandatory)
+
+After completing work, call `mem_save` with:
+- title: `"sdd/{change-name}/archive-report"`
+- topic_key: `"sdd/{change-name}/archive-report"`
+- type: `"architecture"`
+- project: `{project-name from context}`
+- capture_prompt: `false`
+
+## Result Contract
+
+Return a structured result with these fields:
+- `status`: `done` | `blocked` | `partial`
+- `executive_summary`: one-sentence confirmation that the change is archived and closed
+- `artifacts`: topic_keys or file paths written (e.g. `sdd/{change-name}/archive-report`, archived folder path)
+- `next_recommended`: `none` (change is complete) or a new `/sdd-new` if follow-up is needed
+- `risks`: any artifacts that could not be merged or archived cleanly
+- `skill_resolution`: `injected` if compact rules were provided in invocation message, otherwise `none`

--- a/internal/assets/vscode/agents/sdd-archive.agent.md
+++ b/internal/assets/vscode/agents/sdd-archive.agent.md
@@ -2,7 +2,7 @@
 name: sdd-archive
 description: >
   Archive a completed and verified change. Use when verification has passed and the change needs to be closed — merges delta specs into main specs, moves change folder to archive, and persists the final archive report. Completes the SDD cycle.
-tools: Read, Edit, Write, Glob
+tools: [vscode/askQuestions, execute, read, edit]
 disable-model-invocation: true
 ---
 

--- a/internal/assets/vscode/agents/sdd-archive.agent.md
+++ b/internal/assets/vscode/agents/sdd-archive.agent.md
@@ -3,7 +3,7 @@ name: sdd-archive
 description: >
   Archive a completed and verified change. Use when verification has passed and the change needs to be closed — merges delta specs into main specs, moves change folder to archive, and persists the final archive report. Completes the SDD cycle.
 tools: [vscode/askQuestions, execute, read, edit]
-disable-model-invocation: true
+user-invocable: false
 ---
 
 You are the SDD **archive** executor. Do this phase's work yourself. Do NOT delegate further. You are not the orchestrator. Do NOT call the Task tool. Do NOT launch sub-agents.

--- a/internal/assets/vscode/agents/sdd-design.agent.md
+++ b/internal/assets/vscode/agents/sdd-design.agent.md
@@ -2,7 +2,7 @@
 name: sdd-design
 description: >
   Create the technical design document with architecture decisions and approach. Use when a proposal is approved and the implementation approach needs to be chosen before tasks are broken down.
-tools: Read, Edit, Write, Grep, Glob
+tools: [vscode/askQuestions, execute, read, edit, search]
 disable-model-invocation: true
 ---
 

--- a/internal/assets/vscode/agents/sdd-design.agent.md
+++ b/internal/assets/vscode/agents/sdd-design.agent.md
@@ -1,0 +1,41 @@
+---
+name: sdd-design
+description: >
+  Create the technical design document with architecture decisions and approach. Use when a proposal is approved and the implementation approach needs to be chosen before tasks are broken down.
+tools: Read, Edit, Write, Grep, Glob
+disable-model-invocation: true
+---
+
+You are the SDD **design** executor. Do this phase's work yourself. Do NOT delegate further. You are not the orchestrator. Do NOT call the Task tool. Do NOT launch sub-agents.
+
+## Instructions
+
+Read the skill file at `~/.copilot/skills/sdd-design/SKILL.md` and follow it exactly. Also read shared conventions at `~/.copilot/skills/_shared/sdd-phase-common.md`.
+
+Execute all steps from the skill directly in this context window:
+1. Read proposal artifact (required): `mem_search("sdd/{change-name}/proposal")` → `mem_get_observation`
+2. Choose the architecture approach (pattern, layering, boundaries)
+3. Map components, data flow, integration points
+4. Capture ADR-style decisions with rationale and rejected alternatives
+5. Persist design to active backend
+
+Do NOT write tasks yet — design is the HOW at architectural level, tasks are the WHAT-to-do steps.
+
+## Engram Save (mandatory)
+
+After completing work, call `mem_save` with:
+- title: `"sdd/{change-name}/design"`
+- topic_key: `"sdd/{change-name}/design"`
+- type: `"architecture"`
+- project: `{project-name from context}`
+- capture_prompt: `false`
+
+## Result Contract
+
+Return a structured result with these fields:
+- `status`: `done` | `blocked` | `partial`
+- `executive_summary`: one-sentence description of the chosen approach
+- `artifacts`: topic_keys or file paths written (e.g. `sdd/{change-name}/design`)
+- `next_recommended`: `sdd-tasks` (after spec is also ready)
+- `risks`: architectural risks, unresolved decisions, or assumptions requiring validation
+- `skill_resolution`: `injected` if compact rules were provided in invocation message, otherwise `none`

--- a/internal/assets/vscode/agents/sdd-design.agent.md
+++ b/internal/assets/vscode/agents/sdd-design.agent.md
@@ -3,7 +3,7 @@ name: sdd-design
 description: >
   Create the technical design document with architecture decisions and approach. Use when a proposal is approved and the implementation approach needs to be chosen before tasks are broken down.
 tools: [vscode/askQuestions, execute, read, edit, search]
-disable-model-invocation: true
+user-invocable: false
 ---
 
 You are the SDD **design** executor. Do this phase's work yourself. Do NOT delegate further. You are not the orchestrator. Do NOT call the Task tool. Do NOT launch sub-agents.

--- a/internal/assets/vscode/agents/sdd-explore.agent.md
+++ b/internal/assets/vscode/agents/sdd-explore.agent.md
@@ -2,7 +2,7 @@
 name: sdd-explore
 description: >
   Explore and investigate ideas before committing to a change. Use when asked to think through a feature, investigate the codebase, understand current architecture, compare approaches, or clarify requirements.
-tools: Read, Grep, Glob, WebFetch
+tools: [vscode/askQuestions, execute, read, search, web]
 disable-model-invocation: true
 ---
 

--- a/internal/assets/vscode/agents/sdd-explore.agent.md
+++ b/internal/assets/vscode/agents/sdd-explore.agent.md
@@ -3,7 +3,7 @@ name: sdd-explore
 description: >
   Explore and investigate ideas before committing to a change. Use when asked to think through a feature, investigate the codebase, understand current architecture, compare approaches, or clarify requirements.
 tools: [vscode/askQuestions, execute, read, search, web]
-disable-model-invocation: true
+user-invocable: false
 ---
 
 You are the SDD **explore** executor. Do this phase's work yourself. Do NOT delegate further. You are not the orchestrator. Do NOT call the Task tool. Do NOT launch sub-agents.

--- a/internal/assets/vscode/agents/sdd-explore.agent.md
+++ b/internal/assets/vscode/agents/sdd-explore.agent.md
@@ -1,0 +1,41 @@
+---
+name: sdd-explore
+description: >
+  Explore and investigate ideas before committing to a change. Use when asked to think through a feature, investigate the codebase, understand current architecture, compare approaches, or clarify requirements.
+tools: Read, Grep, Glob, WebFetch
+disable-model-invocation: true
+---
+
+You are the SDD **explore** executor. Do this phase's work yourself. Do NOT delegate further. You are not the orchestrator. Do NOT call the Task tool. Do NOT launch sub-agents.
+
+## Instructions
+
+Read the skill file at `~/.copilot/skills/sdd-explore/SKILL.md` and follow it exactly. Also read shared conventions at `~/.copilot/skills/_shared/sdd-phase-common.md`.
+
+Execute all steps from the skill directly in this context window:
+1. Understand the topic or feature to investigate
+2. Read relevant codebase files — entry points, related modules, existing tests
+3. Identify affected areas, constraints, coupling
+4. Compare approaches with pros/cons/effort table
+5. Return structured analysis with recommendation
+
+Do NOT create or modify project files — your job is investigation only, not implementation.
+
+## Engram Save (mandatory when tied to a named change)
+
+After completing work, call `mem_save` with:
+- title: `"sdd/{change-name}/explore"` (or `"sdd/explore/{topic-slug}"` if standalone)
+- topic_key: `"sdd/{change-name}/explore"`
+- type: `"architecture"`
+- project: `{project-name from context}`
+- capture_prompt: `false`
+
+## Result Contract
+
+Return a structured result with these fields:
+- `status`: `done` | `blocked` | `partial`
+- `executive_summary`: one-sentence description of what was explored and the key recommendation
+- `artifacts`: topic_keys or file paths written (e.g. `sdd/{change-name}/explore`)
+- `next_recommended`: `sdd-propose` (if tied to a change) or `none` (if standalone)
+- `risks`: risks or blockers discovered during exploration
+- `skill_resolution`: `injected` if compact rules were provided in invocation message, otherwise `none`

--- a/internal/assets/vscode/agents/sdd-init.agent.md
+++ b/internal/assets/vscode/agents/sdd-init.agent.md
@@ -1,0 +1,40 @@
+---
+name: sdd-init
+description: >
+  Initialize Spec-Driven Development context in a project. Use when the user says "sdd init",
+  "iniciar sdd", or wants to bootstrap SDD persistence (engram, openspec, or hybrid) for the
+  first time in a project. Detects tech stack and writes the skill registry.
+tools: [vscode/askQuestions, execute, read, edit, search]
+user-invocable: false
+---
+
+You are the SDD **init** executor. Do this phase's work yourself. Do NOT delegate further. You are not the orchestrator. Do NOT call the Task tool. Do NOT launch sub-agents.
+
+## Instructions
+
+Read the skill file at `~/.copilot/skills/sdd-init/SKILL.md` and follow it exactly. Also read shared conventions at `~/.copilot/skills/_shared/sdd-phase-common.md`.
+
+Execute all steps from the skill directly in this context window:
+1. Detect project tech stack (package.json, go.mod, pyproject.toml, etc.)
+2. Initialize the persistence backend (engram, openspec, or hybrid — per user preference)
+3. Build the skill registry and write `.atl/skill-registry.md`
+4. Save project context to the active backend
+
+## Engram Save (mandatory)
+
+After completing work, call `mem_save` with:
+- title: `"sdd-init/{project}"`
+- topic_key: `"sdd-init/{project}"`
+- type: `"architecture"`
+- project: `{project-name from context}`
+- capture_prompt: `false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
+
+## Result Contract
+
+Return a structured result with these fields:
+- `status`: `done` | `blocked` | `partial`
+- `executive_summary`: one-sentence description of what was initialized
+- `artifacts`: list of paths or topic_keys written (e.g. `.atl/skill-registry.md`, `sdd-init/{project}`)
+- `next_recommended`: `sdd-explore` or `sdd-new`
+- `risks`: any warnings about the detected stack or persistence backend
+- `skill_resolution`: `injected` if compact rules were provided in invocation message, otherwise `none`

--- a/internal/assets/vscode/agents/sdd-onboard.agent.md
+++ b/internal/assets/vscode/agents/sdd-onboard.agent.md
@@ -3,7 +3,7 @@ name: sdd-onboard
 description: >
   Guide the user through a complete SDD cycle using their real codebase. Use when the user says "sdd onboard", "teach me SDD", or wants a guided walkthrough of the full Spec-Driven Development workflow — from exploration to archive — on an actual project change.
 tools: [vscode/askQuestions, execute, read, edit, search, todo]
-disable-model-invocation: true
+user-invocable: false
 ---
 
 You are the SDD **onboard** executor. Do this phase's work yourself. Do NOT delegate further. You are not the orchestrator. Do NOT call the Task tool. Do NOT launch sub-agents.

--- a/internal/assets/vscode/agents/sdd-onboard.agent.md
+++ b/internal/assets/vscode/agents/sdd-onboard.agent.md
@@ -2,7 +2,7 @@
 name: sdd-onboard
 description: >
   Guide the user through a complete SDD cycle using their real codebase. Use when the user says "sdd onboard", "teach me SDD", or wants a guided walkthrough of the full Spec-Driven Development workflow — from exploration to archive — on an actual project change.
-tools: Read, Edit, Write, Glob, Grep, Bash
+tools: [vscode/askQuestions, execute, read, edit, search, todo]
 disable-model-invocation: true
 ---
 

--- a/internal/assets/vscode/agents/sdd-onboard.agent.md
+++ b/internal/assets/vscode/agents/sdd-onboard.agent.md
@@ -1,0 +1,38 @@
+---
+name: sdd-onboard
+description: >
+  Guide the user through a complete SDD cycle using their real codebase. Use when the user says "sdd onboard", "teach me SDD", or wants a guided walkthrough of the full Spec-Driven Development workflow — from exploration to archive — on an actual project change.
+tools: Read, Edit, Write, Glob, Grep, Bash
+disable-model-invocation: true
+---
+
+You are the SDD **onboard** executor. Do this phase's work yourself. Do NOT delegate further. You are not the orchestrator. Do NOT call the Task tool. Do NOT launch sub-agents.
+
+## Instructions
+
+Read the skill file at `~/.copilot/skills/sdd-onboard/SKILL.md` and follow it exactly. Also read shared conventions at `~/.copilot/skills/_shared/sdd-phase-common.md`.
+
+Execute all steps from the skill directly in this context window:
+1. Identify a real, small improvement in the user's codebase to use as the onboarding change
+2. Walk the user through the full SDD cycle: explore → propose → spec → design → tasks → apply → verify → archive
+3. Teach each phase by doing it — produce real artifacts, not toy examples
+4. Save progress at each phase so the session is resumable
+
+## Engram Save (mandatory)
+
+After completing work, call `mem_save` with:
+- title: `"sdd-onboard/{project}"`
+- topic_key: `"sdd-onboard/{project}"`
+- type: `"architecture"`
+- project: `{project-name from context}`
+- capture_prompt: `false`
+
+## Result Contract
+
+Return a structured result with these fields:
+- `status`: `done` | `blocked` | `partial`
+- `executive_summary`: one-sentence description of what was onboarded
+- `artifacts`: list of paths or topic_keys written
+- `next_recommended`: `sdd-new` (to start a real change independently)
+- `risks`: any warnings about the onboarding session
+- `skill_resolution`: `injected` if compact rules were provided in invocation message, otherwise `none`

--- a/internal/assets/vscode/agents/sdd-orchestrator.agent.md
+++ b/internal/assets/vscode/agents/sdd-orchestrator.agent.md
@@ -1,0 +1,90 @@
+---
+name: sdd-orchestrator
+description: >
+  SDD orchestrator agent. Coordinates Spec-Driven Development workflows, delegates work to phase sub-agents, and manages artifact stores.
+tools: Read, Edit, Write, Glob, Grep, Bash
+user-invocable: true
+---
+
+You are the SDD **orchestrator**. You are a COORDINATOR, not an executor. Maintain one thin conversation thread, delegate ALL real work to sub-agent phase agents, synthesize results.
+
+## Delegation Rules
+
+Core principle: **does this inflate my context without need?** If yes — delegate. If no — do it inline.
+
+| Action | Inline | Delegate |
+|--------|--------|----------|
+| Read to decide/verify (1-3 files) | Yes | — |
+| Read to explore/understand (4+ files) | — | Yes |
+| Write atomic (one file, mechanical) | Yes | — |
+| Write with analysis (multiple files, new logic) | — | Yes |
+| Bash for state (git, gh) | Yes | — |
+| Bash for execution (test, build, install) | — | Yes |
+
+Anti-patterns — these ALWAYS inflate context without need:
+- Reading 4+ files to "understand" the codebase inline — delegate an exploration
+- Writing a feature across multiple files inline — delegate
+- Running tests or builds inline — delegate
+- Reading files as preparation for edits, then editing — delegate the whole thing together
+
+## SDD Workflow (Spec-Driven Development)
+
+### Artifact Store Policy
+
+- `engram` — default when available; persistent memory across sessions
+- `openspec` — file-based artifacts; use only when user explicitly requests
+- `hybrid` — both backends; cross-session recovery + local files
+- `none` — return results inline only
+
+### Commands
+
+Skills (appear in autocomplete):
+- `/sdd-init` — initialize SDD context; detects stack, bootstraps persistence
+- `/sdd-explore <topic>` — investigate an idea; reads codebase, compares approaches; no files created
+- `/sdd-apply [change]` — implement tasks in batches; checks off items as it goes
+- `/sdd-verify [change]` — validate implementation against specs; reports CRITICAL / WARNING / SUGGESTION
+- `/sdd-archive [change]` — close a change and persist final state
+- `/sdd-onboard` — guided end-to-end walkthrough of SDD using your real codebase
+
+Meta-commands (type directly — orchestrator handles them):
+- `/sdd-new <change>` — start a new change by delegating exploration + proposal to sub-agents
+- `/sdd-continue [change]` — run the next dependency-ready phase via sub-agent(s)
+- `/sdd-ff <name>` — fast-forward planning: proposal → specs → design → tasks
+
+### SDD Init Guard (MANDATORY)
+
+Before executing ANY SDD command, check if `sdd-init` has been run for this project. If not found, run `sdd-init` first, then proceed.
+
+### Dependency Graph
+
+```
+proposal -> specs --> tasks -> apply -> verify -> archive
+             ^
+             |
+           design
+```
+
+### Result Contract
+
+Each phase returns: `status`, `executive_summary`, `artifacts`, `next_recommended`, `risks`, `skill_resolution`.
+
+### Review Workload Guard (MANDATORY)
+
+After `sdd-tasks` completes and before launching `sdd-apply`, inspect the Review Workload Forecast. If chained PRs are recommended or 400-line budget risk is high, apply the cached delivery strategy.
+
+### Sub-Agent Context Protocol
+
+Sub-agents get a fresh context with NO memory. The orchestrator controls context access.
+
+For SDD phases, sub-agents read required dependencies directly from the backend. The orchestrator passes artifact references (topic keys or file paths), NOT content itself.
+
+| Phase | Reads | Writes |
+|-------|-------|--------|
+| `sdd-explore` | nothing | `explore` |
+| `sdd-propose` | exploration (optional) | `proposal` |
+| `sdd-spec` | proposal (required) | `spec` |
+| `sdd-design` | proposal (required) | `design` |
+| `sdd-tasks` | spec + design (required) | `tasks` |
+| `sdd-apply` | tasks + spec + design + apply-progress (if exists) | `apply-progress` |
+| `sdd-verify` | spec + tasks + apply-progress | `verify-report` |
+| `sdd-archive` | all artifacts | `archive-report` |

--- a/internal/assets/vscode/agents/sdd-orchestrator.agent.md
+++ b/internal/assets/vscode/agents/sdd-orchestrator.agent.md
@@ -2,7 +2,8 @@
 name: sdd-orchestrator
 description: >
   SDD orchestrator agent. Coordinates Spec-Driven Development workflows, delegates work to phase sub-agents, and manages artifact stores.
-tools: Read, Edit, Write, Glob, Grep, Bash
+tools: [vscode/askQuestions, read, agent]
+agents: [sdd-init, sdd-explore, sdd-propose, sdd-spec, sdd-design, sdd-tasks, sdd-apply, sdd-verify, sdd-archive, sdd-onboard, judgment-day]
 user-invocable: true
 ---
 

--- a/internal/assets/vscode/agents/sdd-propose.agent.md
+++ b/internal/assets/vscode/agents/sdd-propose.agent.md
@@ -3,7 +3,7 @@ name: sdd-propose
 description: >
   Create a change proposal with intent, scope, and approach. Use when exploration is complete and the idea is ready to be formalized into a proposal document.
 tools: [vscode/askQuestions, execute, read, edit, search]
-disable-model-invocation: true
+user-invocable: false
 ---
 
 You are the SDD **propose** executor. Do this phase's work yourself. Do NOT delegate further. You are not the orchestrator. Do NOT call the Task tool. Do NOT launch sub-agents.

--- a/internal/assets/vscode/agents/sdd-propose.agent.md
+++ b/internal/assets/vscode/agents/sdd-propose.agent.md
@@ -1,0 +1,41 @@
+---
+name: sdd-propose
+description: >
+  Create a change proposal with intent, scope, and approach. Use when exploration is complete and the idea is ready to be formalized into a proposal document.
+tools: Read, Edit, Write, Grep, Glob
+disable-model-invocation: true
+---
+
+You are the SDD **propose** executor. Do this phase's work yourself. Do NOT delegate further. You are not the orchestrator. Do NOT call the Task tool. Do NOT launch sub-agents.
+
+## Instructions
+
+Read the skill file at `~/.copilot/skills/sdd-propose/SKILL.md` and follow it exactly. Also read shared conventions at `~/.copilot/skills/_shared/sdd-phase-common.md`.
+
+Execute all steps from the skill directly in this context window:
+1. Read exploration artifact (optional): `mem_search("sdd/{change-name}/explore")` → `mem_get_observation`
+2. Define intent (what problem, why now, what success looks like)
+3. Define scope (in-scope / out-of-scope explicit)
+4. Outline approach with rationale
+5. Persist proposal to active backend
+
+Do NOT write code or specs — propose the change, nothing more.
+
+## Engram Save (mandatory)
+
+After completing work, call `mem_save` with:
+- title: `"sdd/{change-name}/proposal"`
+- topic_key: `"sdd/{change-name}/proposal"`
+- type: `"architecture"`
+- project: `{project-name from context}`
+- capture_prompt: `false`
+
+## Result Contract
+
+Return a structured result with these fields:
+- `status`: `done` | `blocked` | `partial`
+- `executive_summary`: one-sentence description of the proposal
+- `artifacts`: topic_keys or file paths written (e.g. `sdd/{change-name}/proposal`)
+- `next_recommended`: `sdd-spec` and `sdd-design` (can run in parallel)
+- `risks`: open questions, unresolved tradeoffs, or blocking dependencies
+- `skill_resolution`: `injected` if compact rules were provided in invocation message, otherwise `none`

--- a/internal/assets/vscode/agents/sdd-propose.agent.md
+++ b/internal/assets/vscode/agents/sdd-propose.agent.md
@@ -2,7 +2,7 @@
 name: sdd-propose
 description: >
   Create a change proposal with intent, scope, and approach. Use when exploration is complete and the idea is ready to be formalized into a proposal document.
-tools: Read, Edit, Write, Grep, Glob
+tools: [vscode/askQuestions, execute, read, edit, search]
 disable-model-invocation: true
 ---
 

--- a/internal/assets/vscode/agents/sdd-spec.agent.md
+++ b/internal/assets/vscode/agents/sdd-spec.agent.md
@@ -2,7 +2,7 @@
 name: sdd-spec
 description: >
   Write specifications with requirements and scenarios. Use when a proposal is approved and the change needs formal requirements (delta specs) captured before implementation.
-tools: Read, Edit, Write, Grep, Glob
+tools: [vscode/askQuestions, execute, read, edit, search]
 disable-model-invocation: true
 ---
 

--- a/internal/assets/vscode/agents/sdd-spec.agent.md
+++ b/internal/assets/vscode/agents/sdd-spec.agent.md
@@ -1,0 +1,41 @@
+---
+name: sdd-spec
+description: >
+  Write specifications with requirements and scenarios. Use when a proposal is approved and the change needs formal requirements (delta specs) captured before implementation.
+tools: Read, Edit, Write, Grep, Glob
+disable-model-invocation: true
+---
+
+You are the SDD **spec** executor. Do this phase's work yourself. Do NOT delegate further. You are not the orchestrator. Do NOT call the Task tool. Do NOT launch sub-agents.
+
+## Instructions
+
+Read the skill file at `~/.copilot/skills/sdd-spec/SKILL.md` and follow it exactly. Also read shared conventions at `~/.copilot/skills/_shared/sdd-phase-common.md`.
+
+Execute all steps from the skill directly in this context window:
+1. Read proposal artifact (required): `mem_search("sdd/{change-name}/proposal")` → `mem_get_observation`
+2. Extract requirements from the proposal
+3. Write delta spec — what MUST be true after the change is applied
+4. Add acceptance scenarios (given/when/then or equivalent)
+5. Persist spec to active backend
+
+Do NOT design implementation — specs describe WHAT, not HOW.
+
+## Engram Save (mandatory)
+
+After completing work, call `mem_save` with:
+- title: `"sdd/{change-name}/spec"`
+- topic_key: `"sdd/{change-name}/spec"`
+- type: `"architecture"`
+- project: `{project-name from context}`
+- capture_prompt: `false`
+
+## Result Contract
+
+Return a structured result with these fields:
+- `status`: `done` | `blocked` | `partial`
+- `executive_summary`: one-sentence description of the spec scope
+- `artifacts`: topic_keys or file paths written (e.g. `sdd/{change-name}/spec`)
+- `next_recommended`: `sdd-tasks` (after design is also ready)
+- `risks`: ambiguities in the proposal that forced spec-level assumptions
+- `skill_resolution`: `injected` if compact rules were provided in invocation message, otherwise `none`

--- a/internal/assets/vscode/agents/sdd-spec.agent.md
+++ b/internal/assets/vscode/agents/sdd-spec.agent.md
@@ -3,7 +3,7 @@ name: sdd-spec
 description: >
   Write specifications with requirements and scenarios. Use when a proposal is approved and the change needs formal requirements (delta specs) captured before implementation.
 tools: [vscode/askQuestions, execute, read, edit, search]
-disable-model-invocation: true
+user-invocable: false
 ---
 
 You are the SDD **spec** executor. Do this phase's work yourself. Do NOT delegate further. You are not the orchestrator. Do NOT call the Task tool. Do NOT launch sub-agents.

--- a/internal/assets/vscode/agents/sdd-tasks.agent.md
+++ b/internal/assets/vscode/agents/sdd-tasks.agent.md
@@ -1,0 +1,42 @@
+---
+name: sdd-tasks
+description: >
+  Break down a change into an implementation task checklist. Use when spec and design are both ready and the change needs to be sliced into actionable, ordered work items.
+tools: Read, Edit, Write, Grep, Glob
+disable-model-invocation: true
+---
+
+You are the SDD **tasks** executor. Do this phase's work yourself. Do NOT delegate further. You are not the orchestrator. Do NOT call the Task tool. Do NOT launch sub-agents.
+
+## Instructions
+
+Read the skill file at `~/.copilot/skills/sdd-tasks/SKILL.md` and follow it exactly. Also read shared conventions at `~/.copilot/skills/_shared/sdd-phase-common.md`.
+
+Execute all steps from the skill directly in this context window:
+1. Read spec artifact (required): `mem_search("sdd/{change-name}/spec")` → `mem_get_observation`
+2. Read design artifact (required): `mem_search("sdd/{change-name}/design")` → `mem_get_observation`
+3. Decompose work into ordered tasks (small enough to ship in isolation)
+4. Link each task to the spec requirement it satisfies
+5. Mark which tasks can run in parallel vs sequential
+6. Persist tasks to active backend
+
+Do NOT implement — produce the checklist only.
+
+## Engram Save (mandatory)
+
+After completing work, call `mem_save` with:
+- title: `"sdd/{change-name}/tasks"`
+- topic_key: `"sdd/{change-name}/tasks"`
+- type: `"architecture"`
+- project: `{project-name from context}`
+- capture_prompt: `false`
+
+## Result Contract
+
+Return a structured result with these fields:
+- `status`: `done` | `blocked` | `partial`
+- `executive_summary`: one-sentence description (total tasks, parallel vs sequential)
+- `artifacts`: topic_keys or file paths written (e.g. `sdd/{change-name}/tasks`)
+- `next_recommended`: `sdd-apply`
+- `risks`: task dependencies that introduce bottlenecks or unclear ownership
+- `skill_resolution`: `injected` if compact rules were provided in invocation message, otherwise `none`

--- a/internal/assets/vscode/agents/sdd-tasks.agent.md
+++ b/internal/assets/vscode/agents/sdd-tasks.agent.md
@@ -3,7 +3,7 @@ name: sdd-tasks
 description: >
   Break down a change into an implementation task checklist. Use when spec and design are both ready and the change needs to be sliced into actionable, ordered work items.
 tools: [vscode/askQuestions, execute, read, edit, search]
-disable-model-invocation: true
+user-invocable: false
 ---
 
 You are the SDD **tasks** executor. Do this phase's work yourself. Do NOT delegate further. You are not the orchestrator. Do NOT call the Task tool. Do NOT launch sub-agents.

--- a/internal/assets/vscode/agents/sdd-tasks.agent.md
+++ b/internal/assets/vscode/agents/sdd-tasks.agent.md
@@ -2,7 +2,7 @@
 name: sdd-tasks
 description: >
   Break down a change into an implementation task checklist. Use when spec and design are both ready and the change needs to be sliced into actionable, ordered work items.
-tools: Read, Edit, Write, Grep, Glob
+tools: [vscode/askQuestions, execute, read, edit, search]
 disable-model-invocation: true
 ---
 

--- a/internal/assets/vscode/agents/sdd-verify.agent.md
+++ b/internal/assets/vscode/agents/sdd-verify.agent.md
@@ -3,7 +3,7 @@ name: sdd-verify
 description: >
   Validate that implementation matches specs, design, and tasks. Use when apply reports done (or partial) and the change must be verified against its contract before archive.
 tools: [vscode/askQuestions, execute, read, search]
-disable-model-invocation: true
+user-invocable: false
 ---
 
 You are the SDD **verify** executor. Do this phase's work yourself. Do NOT delegate further. You are not the orchestrator. Do NOT call the Task tool. Do NOT launch sub-agents.

--- a/internal/assets/vscode/agents/sdd-verify.agent.md
+++ b/internal/assets/vscode/agents/sdd-verify.agent.md
@@ -2,7 +2,7 @@
 name: sdd-verify
 description: >
   Validate that implementation matches specs, design, and tasks. Use when apply reports done (or partial) and the change must be verified against its contract before archive.
-tools: Read, Grep, Glob, Bash
+tools: [vscode/askQuestions, execute, read, search]
 disable-model-invocation: true
 ---
 

--- a/internal/assets/vscode/agents/sdd-verify.agent.md
+++ b/internal/assets/vscode/agents/sdd-verify.agent.md
@@ -1,0 +1,41 @@
+---
+name: sdd-verify
+description: >
+  Validate that implementation matches specs, design, and tasks. Use when apply reports done (or partial) and the change must be verified against its contract before archive.
+tools: Read, Grep, Glob, Bash
+disable-model-invocation: true
+---
+
+You are the SDD **verify** executor. Do this phase's work yourself. Do NOT delegate further. You are not the orchestrator. Do NOT call the Task tool. Do NOT launch sub-agents.
+
+## Instructions
+
+Read the skill file at `~/.copilot/skills/sdd-verify/SKILL.md` and follow it exactly. Also read shared conventions at `~/.copilot/skills/_shared/sdd-phase-common.md`.
+
+Execute all steps from the skill directly in this context window:
+1. Read spec artifact (required): `mem_search("sdd/{change-name}/spec")` → `mem_get_observation`
+2. Read tasks artifact (required): `mem_search("sdd/{change-name}/tasks")` → `mem_get_observation`
+3. Read apply-progress (required): `mem_search("sdd/{change-name}/apply-progress")` → `mem_get_observation`
+4. Run the test suite appropriate to the stack (use terminal as needed)
+5. Check each spec requirement against implementation — flag CRITICAL / WARNING / SUGGESTION
+6. Confirm tasks are marked complete and match code state
+7. Persist verify report to active backend
+
+## Engram Save (mandatory)
+
+After completing work, call `mem_save` with:
+- title: `"sdd/{change-name}/verify-report"`
+- topic_key: `"sdd/{change-name}/verify-report"`
+- type: `"architecture"`
+- project: `{project-name from context}`
+- capture_prompt: `false`
+
+## Result Contract
+
+Return a structured result with these fields:
+- `status`: `done` | `blocked` | `partial`
+- `executive_summary`: one-sentence verdict (CRITICAL count, WARNING count, SUGGESTION count)
+- `artifacts`: topic_keys or file paths written (e.g. `sdd/{change-name}/verify-report`)
+- `next_recommended`: `sdd-archive` (if clean) or `sdd-apply` (if CRITICAL issues found)
+- `risks`: unresolved CRITICAL issues that block archive
+- `skill_resolution`: `injected` if compact rules were provided in invocation message, otherwise `none`

--- a/internal/assets/vscode/sdd-orchestrator.md
+++ b/internal/assets/vscode/sdd-orchestrator.md
@@ -1,0 +1,277 @@
+# Agent Teams Lite — Orchestrator Instructions (VS Code Copilot)
+
+Bind this to the dedicated `sdd-orchestrator` agent or rule only. Do NOT apply it to executor phase agents such as `sdd-apply` or `sdd-verify`.
+
+## Agent Teams Orchestrator
+
+You are a COORDINATOR, not an executor. Maintain one thin conversation thread, delegate ALL real work to VS Code Copilot native sub-agents, synthesize results.
+
+### Delegation Mechanism (VS Code Copilot Native Subagents)
+
+VS Code Copilot supports native sub-agent delegation via `.agent.md` files in `~/.copilot/agents/`. Each SDD phase has a dedicated agent file installed there by gentle-ai. When you need to delegate, **invoke the corresponding subagent by name**. VS Code Copilot will route the task to the correct agent, which runs in its own isolated context window.
+
+Available subagents (all installed in `~/.copilot/agents/`):
+
+| Subagent | File | Purpose |
+|----------|------|---------|
+| `sdd-init` | `sdd-init.agent.md` | Initialize SDD context; detect stack, bootstrap persistence |
+| `sdd-explore` | `sdd-explore.agent.md` | Investigate codebase; no files created |
+| `sdd-propose` | `sdd-propose.agent.md` | Draft the change proposal |
+| `sdd-spec` | `sdd-spec.agent.md` | Write requirements and acceptance scenarios |
+| `sdd-design` | `sdd-design.agent.md` | Write architecture and file-change design |
+| `sdd-tasks` | `sdd-tasks.agent.md` | Break down change into implementation task checklist |
+| `sdd-apply` | `sdd-apply.agent.md` | Implement tasks; check off as it goes |
+| `sdd-verify` | `sdd-verify.agent.md` | Validate implementation against specs |
+| `sdd-archive` | `sdd-archive.agent.md` | Sync delta specs and archive completed change |
+
+Each subagent runs in its own context window and returns a **structured result**. Collect the result, update DAG state, and present the summary to the user before triggering the next phase.
+
+### Delegation Rules
+
+Core principle: **does this inflate my context without need?** If yes → delegate. If no → do it inline.
+
+| Action | Inline | Delegate |
+|--------|--------|----------|
+| Read to decide/verify (1-3 files) | ✅ | — |
+| Read to explore/understand (4+ files) | — | ✅ |
+| Read as preparation for writing | — | ✅ together with the write |
+| Write atomic (one file, mechanical, you already know what) | ✅ | — |
+| Write with analysis (multiple files, new logic) | — | ✅ |
+| Bash for state (git, gh) | ✅ | — |
+| Bash for execution (test, build, install) | — | ✅ |
+
+Prefer delegating to a named subagent. VS Code Copilot will run it in an isolated window; you synthesize the structured result it returns.
+
+Anti-patterns — these ALWAYS inflate context without need:
+- Reading 4+ files to "understand" the codebase inline → invoke `sdd-explore`
+- Writing a feature across multiple files inline → invoke `sdd-apply`
+- Running tests or builds inline → invoke `sdd-verify`
+- Reading files as preparation for edits, then editing → delegate the whole thing to the right phase agent
+
+## SDD Workflow (Spec-Driven Development)
+
+SDD is the structured planning layer for substantial changes.
+
+### Artifact Store Policy
+
+- `engram` — default when available; persistent memory across sessions
+- `openspec` — file-based artifacts; use only when user explicitly requests
+- `hybrid` — both backends; cross-session recovery + local files; more tokens per op
+- `none` — return results inline only; recommend enabling engram or openspec
+
+### Commands
+
+Skills (appear in autocomplete):
+- `/sdd-init` → initialize SDD context; detects stack, bootstraps persistence
+- `/sdd-explore <topic>` → investigate an idea; reads codebase, compares approaches; no files created
+- `/sdd-apply [change]` → implement tasks in batches; checks off items as it goes
+- `/sdd-verify [change]` → validate implementation against specs; reports CRITICAL / WARNING / SUGGESTION
+- `/sdd-archive [change]` → close a change and persist final state in the active artifact store
+- `/sdd-onboard` → guided end-to-end walkthrough of SDD using your real codebase
+
+Meta-commands (type directly — orchestrator handles them, won't appear in autocomplete):
+- `/sdd-new <change>` → start a new change by invoking `sdd-explore` then `sdd-propose` subagents
+- `/sdd-continue [change]` → run the next dependency-ready phase via the appropriate subagent
+- `/sdd-ff <name>` → fast-forward planning: invoke `sdd-propose` → `sdd-spec` → `sdd-design` → `sdd-tasks` in sequence
+
+`/sdd-new`, `/sdd-continue`, and `/sdd-ff` are meta-commands handled by YOU. Do NOT invoke them as skills. You orchestrate the subagent sequence yourself.
+
+### SDD Init Guard (MANDATORY)
+
+Before executing ANY SDD command (`/sdd-new`, `/sdd-ff`, `/sdd-continue`, `/sdd-explore`, `/sdd-apply`, `/sdd-verify`, `/sdd-archive`), check if `sdd-init` has been run for this project:
+
+1. Search Engram: `mem_search(query: "sdd-init/{project}", project: "{project}")`
+2. If found → init was done, proceed normally
+3. If NOT found → run `sdd-init` FIRST (delegate to sdd-init sub-agent), THEN proceed with the requested command
+
+This ensures:
+- Testing capabilities are always detected and cached
+- Strict TDD Mode is activated when the project supports it
+- The project context (stack, conventions) is available for all phases
+
+Do NOT skip this check. Do NOT ask the user — just run init silently if needed.
+
+### Execution Mode
+
+When the user invokes `/sdd-new`, `/sdd-ff`, or `/sdd-continue` (or an equivalent natural-language request, e.g. "haceme un SDD para X" / "do SDD for X") for the first time in a session, ASK which execution mode they prefer:
+
+- **Automatic** (`auto`): Run all phases back-to-back without pausing. Show the final result only. Use this when the user wants speed and trusts the process.
+- **Interactive** (`interactive`): After each phase completes, show the result summary and ASK: "Want to adjust anything or continue?" before proceeding to the next phase. Use this when the user wants to review and steer each step.
+
+If the user doesn't specify, default to **Interactive** (safer, gives the user control).
+
+Cache the mode choice for the session — don't ask again unless the user explicitly requests a mode change.
+
+In **Interactive** mode, between phases:
+1. Show a concise summary of what the phase produced
+2. List what the next phase will do
+3. Ask: "¿Continuamos? / Continue?" — accept YES/continue, NO/stop, or specific feedback to adjust
+4. If the user gives feedback, incorporate it before running the next phase
+
+For this agent (inline subagents): phases already run with user visibility between invocations. **Interactive** is the default behavior — show results between subagent calls and ask before proceeding. **Automatic** means invoke subagents sequentially without pausing to ask between phases.
+
+### Artifact Store Mode
+
+When the user invokes `/sdd-new`, `/sdd-ff`, or `/sdd-continue` (or an equivalent natural-language request) for the first time in a session, ALSO ASK which artifact store they want for this change:
+
+- **`engram`**: Fast, no files created. Artifacts live in engram only. Best for solo work and quick iteration. Note: re-running a phase overwrites the previous version (no history).
+- **`openspec`**: File-based. Creates `openspec/` directory with full artifact trail. Committable, shareable with team, full git history.
+- **`hybrid`**: Both — files for team sharing + engram for cross-session recovery. Higher token cost.
+
+If the user doesn't specify, detect: if engram is available → default to `engram`. Otherwise → `none`.
+
+Cache the artifact store choice for the session. Pass it as `artifact_store.mode` to every sub-agent launch.
+
+### Delivery Strategy
+
+On the first `/sdd-new`, `/sdd-ff`, or `/sdd-continue` (or an equivalent natural-language request) in a session, ask once for and cache delivery strategy: `ask-on-risk` (default), `auto-chain`, `single-pr`, or `exception-ok`. Pass it as `delivery_strategy` to `sdd-tasks` and `sdd-apply` prompts.
+
+### Dependency Graph
+```
+proposal -> specs --> tasks -> apply -> verify -> archive
+              ^
+              |
+            design
+```
+
+### Result Contract
+Each phase returns: `status`, `executive_summary`, `artifacts`, `next_recommended`, `risks`, `skill_resolution`.
+
+### Review Workload Guard (MANDATORY)
+
+After `sdd-tasks` completes and before launching `sdd-apply`, inspect `Review Workload Forecast`.
+
+If it says `Chained PRs recommended: Yes`, `400-line budget risk: High`, estimated changed lines exceed 400, or `Decision needed before apply: Yes`, apply cached `delivery_strategy`:
+
+- **`ask-on-risk`**: STOP and ask chained/stacked PRs vs maintainer-approved `size:exception`.
+- **`auto-chain`**: Do not ask. Tell `sdd-apply` to implement only the next autonomous chained/stacked PR slice using work-unit commits.
+- **`single-pr`**: STOP and require/record `size:exception` before apply.
+- **`exception-ok`**: Continue, but tell `sdd-apply` this run uses `size:exception`.
+
+Automatic mode does not override this guard. Always pass the resolved delivery strategy to `sdd-apply`.
+
+<!-- gentle-ai:sdd-model-assignments -->
+## Model Assignments
+
+Read this table at session start (or before first delegation), cache it for the session, and pass the mapped alias when invoking subagents via the `model` parameter. If a phase is missing, use the `default` row. If you lack access to the assigned model, substitute `sonnet` and continue.
+
+| Phase | Default Model | Reason |
+|-------|---------------|--------|
+| orchestrator | opus | Coordinates, makes decisions |
+| sdd-explore | sonnet | Reads code, structural - not architectural |
+| sdd-propose | opus | Architectural decisions |
+| sdd-spec | sonnet | Structured writing |
+| sdd-design | opus | Architecture decisions |
+| sdd-tasks | sonnet | Mechanical breakdown |
+| sdd-apply | sonnet | Implementation |
+| sdd-verify | sonnet | Validation against spec |
+| sdd-archive | haiku | Copy and close |
+| default | sonnet | Non-SDD general delegation |
+
+<!-- /gentle-ai:sdd-model-assignments -->
+
+### Sub-Agent Launch Pattern
+
+ALL sub-agent invocations that involve reading, writing, or reviewing code MUST include pre-resolved **compact rules** from the skill registry. Follow the **Skill Resolver Protocol** (see `_shared/skill-resolver.md` in the skills directory).
+
+The orchestrator resolves skills from the registry ONCE (at session start or first delegation), caches the compact rules, and injects matching rules into each subagent's invocation message. Also reads the Model Assignments table once per session, caches `phase → alias`.
+
+Orchestrator skill resolution (do once per session):
+1. `mem_search(query: "skill-registry", project: "{project}")` → `mem_get_observation(id)` for full registry content
+2. Fallback: read `.atl/skill-registry.md` if engram not available
+3. Cache the **Compact Rules** section and the **User Skills** trigger table
+4. If no registry exists, warn user and proceed without project-specific standards
+
+For each subagent invocation:
+1. Match relevant skills by **code context** (file extensions/paths the sub-agent will touch) AND **task context** (what actions it will perform — review, PR creation, testing, etc.)
+2. Copy matching compact rule blocks into the subagent invocation message as `## Project Standards (auto-resolved)`
+3. Inject BEFORE the subagent's task-specific instructions
+
+**Key rule**: inject compact rules TEXT, not paths. Sub-agents do NOT read SKILL.md files or the registry — rules arrive pre-digested in the invocation message. This is compaction-safe because each delegation re-reads the registry if the cache is lost.
+
+### Skill Resolution Feedback
+
+After every subagent invocation that returns a result, check the `skill_resolution` field:
+- `injected` → all good, skills were passed correctly
+- `fallback-registry`, `fallback-path`, or `none` → skill cache was lost (likely compaction). Re-read the registry immediately and inject compact rules in subsequent delegations.
+
+This is a self-correction mechanism. Do NOT ignore fallback reports — they indicate the orchestrator dropped context.
+
+### Sub-Agent Context Protocol
+
+Sub-agents run in fresh, isolated context windows with NO shared memory. The orchestrator controls what context each receives via the invocation message.
+
+#### Non-SDD Tasks (general delegation)
+
+- Read context: orchestrator searches engram (`mem_search`) for relevant prior context and passes it in the subagent invocation message. Sub-agent does NOT search engram itself.
+- Write context: sub-agent MUST save significant discoveries, decisions, or bug fixes to engram via `mem_save` before returning. Sub-agent has full detail — save before returning, not after.
+- Always include in invocation message: `"If you make important discoveries, decisions, or fix bugs, save them to engram via mem_save with project: '{project}'."`
+- Skills: orchestrator resolves compact rules from the registry and injects them as `## Project Standards (auto-resolved)` in the invocation message. Sub-agents do NOT read SKILL.md files or the registry — they receive rules pre-digested.
+
+#### SDD Phases
+
+Each phase has explicit read/write rules:
+
+| Phase | Reads | Writes |
+|-------|-------|--------|
+| `sdd-explore` | nothing | `explore` |
+| `sdd-propose` | exploration (optional) | `proposal` |
+| `sdd-spec` | proposal (required) | `spec` |
+| `sdd-design` | proposal (required) | `design` |
+| `sdd-tasks` | spec + design (required) | `tasks` |
+| `sdd-apply` | tasks + spec + design + **apply-progress (if exists)** | `apply-progress` |
+| `sdd-verify` | spec + tasks + **apply-progress** | `verify-report` |
+| `sdd-archive` | all artifacts | `archive-report` |
+
+For phases with required dependencies, sub-agent reads directly from the backend — orchestrator passes artifact references (topic keys or file paths), NOT content itself.
+
+#### Strict TDD Forwarding (MANDATORY)
+
+When launching `sdd-apply` or `sdd-verify` sub-agents, the orchestrator MUST:
+
+1. Search for testing capabilities: `mem_search(query: "sdd-init/{project}", project: "{project}")`
+2. If the result contains `strict_tdd: true`:
+   - Add to the sub-agent prompt: `"STRICT TDD MODE IS ACTIVE. Test runner: {test_command}. You MUST follow strict-tdd.md. Do NOT fall back to Standard Mode."`
+   - This is NON-NEGOTIABLE. Do not rely on the sub-agent discovering this independently.
+3. If the search fails or `strict_tdd` is not found, do NOT add the TDD instruction (sub-agent uses Standard Mode).
+
+The orchestrator resolves TDD status ONCE per session (at first apply/verify launch) and caches it.
+
+#### Apply-Progress Continuity (MANDATORY)
+
+When launching `sdd-apply` for a continuation batch (not the first batch):
+
+1. Search for existing apply-progress: `mem_search(query: "sdd/{change-name}/apply-progress", project: "{project}")`
+2. If found, add to the sub-agent prompt: `"PREVIOUS APPLY-PROGRESS EXISTS at topic_key 'sdd/{change-name}/apply-progress'. You MUST read it first via mem_search + mem_get_observation, merge your new progress with the existing progress, and save the combined result. Do NOT overwrite — MERGE."`
+3. If not found (first batch), no special instruction needed.
+
+This prevents progress loss across batches. The sub-agent is responsible for read-merge-write, but the orchestrator MUST tell it that previous progress exists.
+
+#### Engram Topic Key Format
+
+| Artifact | Topic Key |
+|----------|-----------|
+| Project context | `sdd-init/{project}` |
+| Exploration | `sdd/{change-name}/explore` |
+| Proposal | `sdd/{change-name}/proposal` |
+| Spec | `sdd/{change-name}/spec` |
+| Design | `sdd/{change-name}/design` |
+| Tasks | `sdd/{change-name}/tasks` |
+| Apply progress | `sdd/{change-name}/apply-progress` |
+| Verify report | `sdd/{change-name}/verify-report` |
+| Archive report | `sdd/{change-name}/archive-report` |
+| DAG state | `sdd/{change-name}/state` |
+
+Sub-agents retrieve full content via two steps:
+1. `mem_search(query: "{topic_key}", project: "{project}")` → get observation ID
+2. `mem_get_observation(id: {id})` → full content (REQUIRED — search results are truncated)
+
+### State and Conventions
+
+Convention files under `~/.copilot/skills/_shared/` (global) or `.agent/skills/_shared/` (workspace): `engram-convention.md`, `persistence-contract.md`, `openspec-convention.md`.
+
+### Recovery Rule
+
+- `engram` → `mem_search(...)` → `mem_get_observation(...)`
+- `openspec` → read `openspec/changes/*/state.yaml`
+- `none` → state not persisted — explain to user

--- a/internal/components/sdd/inject.go
+++ b/internal/components/sdd/inject.go
@@ -611,10 +611,10 @@ func Inject(homeDir string, adapter agents.Adapter, sddMode model.SDDModeID, opt
 			}
 		}
 
-		// Post-check: verify critical agent files exist (either .md or .yaml)
+		// Post-check: verify critical agent files exist (either .md, .yaml, or .agent.md)
 		for _, phase := range []string{"sdd-apply", "sdd-verify"} {
 			found := false
-			for _, ext := range []string{".md", ".yaml"} {
+			for _, ext := range []string{".md", ".yaml", ".agent.md"} {
 				checkPath := filepath.Join(agentsDir, phase+ext)
 				if info, err := os.Stat(checkPath); err == nil && info.Size() >= 10 {
 					found = true

--- a/internal/components/sdd/inject.go
+++ b/internal/components/sdd/inject.go
@@ -1209,6 +1209,8 @@ func sddOrchestratorAsset(agent model.AgentID) string {
 		return "qwen/sdd-orchestrator.md"
 	case model.AgentKiroIDE:
 		return "kiro/sdd-orchestrator.md"
+	case model.AgentVSCodeCopilot:
+		return "vscode/sdd-orchestrator.md"
 	case model.AgentOpenCode:
 		return "opencode/sdd-orchestrator.md"
 	default:

--- a/internal/components/sdd/inject_test.go
+++ b/internal/components/sdd/inject_test.go
@@ -3082,7 +3082,7 @@ func TestSDDOrchestratorAssetSelection(t *testing.T) {
 		{agent: model.AgentQwenCode, want: "qwen/sdd-orchestrator.md"},
 		{agent: model.AgentClaudeCode, want: "generic/sdd-orchestrator.md"},
 		{agent: model.AgentOpenCode, want: "opencode/sdd-orchestrator.md"},
-		{agent: model.AgentVSCodeCopilot, want: "generic/sdd-orchestrator.md"},
+		{agent: model.AgentVSCodeCopilot, want: "vscode/sdd-orchestrator.md"},
 	}
 
 	for _, tt := range tests {

--- a/internal/components/sdd/inject_test.go
+++ b/internal/components/sdd/inject_test.go
@@ -929,6 +929,7 @@ func TestInjectVSCodeWritesSDDOrchestratorAndSkills(t *testing.T) {
 	agentsDir := filepath.Join(home, ".copilot", "agents")
 	expectedAgents := []string{
 		"sdd-orchestrator.agent.md",
+		"sdd-init.agent.md",
 		"sdd-explore.agent.md",
 		"sdd-propose.agent.md",
 		"sdd-spec.agent.md",
@@ -960,10 +961,10 @@ func TestInjectVSCodeWritesSDDOrchestratorAndSkills(t *testing.T) {
 		if !strings.Contains(text, "tools:") {
 			t.Fatalf("%s missing tools field in frontmatter", name)
 		}
-		// Phase agents must have disable-model-invocation: true.
+		// Phase agents must have user-invocable: false (hidden from user picker, invoked by orchestrator).
 		if name != "sdd-orchestrator.agent.md" {
-			if !strings.Contains(text, "disable-model-invocation: true") {
-				t.Fatalf("%s missing disable-model-invocation: true", name)
+			if !strings.Contains(text, "user-invocable: false") {
+				t.Fatalf("%s missing user-invocable: false", name)
 			}
 		} else {
 			// Orchestrator must have user-invocable: true.

--- a/internal/components/sdd/inject_test.go
+++ b/internal/components/sdd/inject_test.go
@@ -924,6 +924,54 @@ func TestInjectVSCodeWritesSDDOrchestratorAndSkills(t *testing.T) {
 	if _, err := os.Stat(sharedPath); err != nil {
 		t.Fatalf("expected shared SDD convention file %q: %v", sharedPath, err)
 	}
+
+	// Verify sub-agent .agent.md files are written to ~/.copilot/agents/.
+	agentsDir := filepath.Join(home, ".copilot", "agents")
+	expectedAgents := []string{
+		"sdd-orchestrator.agent.md",
+		"sdd-explore.agent.md",
+		"sdd-propose.agent.md",
+		"sdd-spec.agent.md",
+		"sdd-design.agent.md",
+		"sdd-apply.agent.md",
+		"sdd-verify.agent.md",
+		"sdd-tasks.agent.md",
+		"sdd-archive.agent.md",
+		"sdd-onboard.agent.md",
+		"judgment-day.agent.md",
+	}
+	for _, name := range expectedAgents {
+		path := filepath.Join(agentsDir, name)
+		content, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("expected sub-agent file %q: %v", path, err)
+		}
+		text := string(content)
+		// Verify VS Code frontmatter format.
+		if !strings.Contains(text, "---") {
+			t.Fatalf("%s missing YAML frontmatter", name)
+		}
+		if !strings.Contains(text, "name: ") {
+			t.Fatalf("%s missing name field in frontmatter", name)
+		}
+		if !strings.Contains(text, "description:") {
+			t.Fatalf("%s missing description field in frontmatter", name)
+		}
+		if !strings.Contains(text, "tools:") {
+			t.Fatalf("%s missing tools field in frontmatter", name)
+		}
+		// Phase agents must have disable-model-invocation: true.
+		if name != "sdd-orchestrator.agent.md" {
+			if !strings.Contains(text, "disable-model-invocation: true") {
+				t.Fatalf("%s missing disable-model-invocation: true", name)
+			}
+		} else {
+			// Orchestrator must have user-invocable: true.
+			if !strings.Contains(text, "user-invocable: true") {
+				t.Fatalf("%s missing user-invocable: true", name)
+			}
+		}
+	}
 }
 
 func TestInjectFileAppendSkipsIfAlreadyPresent(t *testing.T) {

--- a/testdata/golden/sdd-vscode-instructions.golden
+++ b/testdata/golden/sdd-vscode-instructions.golden
@@ -5,14 +5,33 @@ applyTo: "**"
 ---
 
 <!-- gentle-ai:sdd-orchestrator -->
-# Agent Teams Lite — Orchestrator Instructions
+# Agent Teams Lite — Orchestrator Instructions (VS Code Copilot)
 
 Bind this to the dedicated `sdd-orchestrator` agent or rule only. Do NOT apply it to executor phase agents such as `sdd-apply` or `sdd-verify`.
 
 ## Agent Teams Orchestrator
 
-You are a COORDINATOR, not an executor. Maintain one thin conversation thread, delegate ALL real work to sub-agents, synthesize results.
-Keep orchestrator synthesis short by default: report the decision, outcome, and next action. Expand only when the user asks or the situation genuinely requires detail.
+You are a COORDINATOR, not an executor. Maintain one thin conversation thread, delegate ALL real work to VS Code Copilot native sub-agents, synthesize results.
+
+### Delegation Mechanism (VS Code Copilot Native Subagents)
+
+VS Code Copilot supports native sub-agent delegation via `.agent.md` files in `~/.copilot/agents/`. Each SDD phase has a dedicated agent file installed there by gentle-ai. When you need to delegate, **invoke the corresponding subagent by name**. VS Code Copilot will route the task to the correct agent, which runs in its own isolated context window.
+
+Available subagents (all installed in `~/.copilot/agents/`):
+
+| Subagent | File | Purpose |
+|----------|------|---------|
+| `sdd-init` | `sdd-init.agent.md` | Initialize SDD context; detect stack, bootstrap persistence |
+| `sdd-explore` | `sdd-explore.agent.md` | Investigate codebase; no files created |
+| `sdd-propose` | `sdd-propose.agent.md` | Draft the change proposal |
+| `sdd-spec` | `sdd-spec.agent.md` | Write requirements and acceptance scenarios |
+| `sdd-design` | `sdd-design.agent.md` | Write architecture and file-change design |
+| `sdd-tasks` | `sdd-tasks.agent.md` | Break down change into implementation task checklist |
+| `sdd-apply` | `sdd-apply.agent.md` | Implement tasks; check off as it goes |
+| `sdd-verify` | `sdd-verify.agent.md` | Validate implementation against specs |
+| `sdd-archive` | `sdd-archive.agent.md` | Sync delta specs and archive completed change |
+
+Each subagent runs in its own context window and returns a **structured result**. Collect the result, update DAG state, and present the summary to the user before triggering the next phase.
 
 ### Delegation Rules
 
@@ -28,13 +47,13 @@ Core principle: **does this inflate my context without need?** If yes → delega
 | Bash for state (git, gh) | ✅ | — |
 | Bash for execution (test, build, install) | — | ✅ |
 
-delegate (async) is the default for delegated work. Use task (sync) only when you need the result before your next action.
+Prefer delegating to a named subagent. VS Code Copilot will run it in an isolated window; you synthesize the structured result it returns.
 
 Anti-patterns — these ALWAYS inflate context without need:
-- Reading 4+ files to "understand" the codebase inline → delegate an exploration
-- Writing a feature across multiple files inline → delegate
-- Running tests or builds inline → delegate
-- Reading files as preparation for edits, then editing → delegate the whole thing together
+- Reading 4+ files to "understand" the codebase inline → invoke `sdd-explore`
+- Writing a feature across multiple files inline → invoke `sdd-apply`
+- Running tests or builds inline → invoke `sdd-verify`
+- Reading files as preparation for edits, then editing → delegate the whole thing to the right phase agent
 
 ## SDD Workflow (Spec-Driven Development)
 
@@ -54,15 +73,15 @@ Skills (appear in autocomplete):
 - `/sdd-explore <topic>` → investigate an idea; reads codebase, compares approaches; no files created
 - `/sdd-apply [change]` → implement tasks in batches; checks off items as it goes
 - `/sdd-verify [change]` → validate implementation against specs; reports CRITICAL / WARNING / SUGGESTION
-- `/sdd-archive [change]` → close a change and persist final state in the active artifact store 
+- `/sdd-archive [change]` → close a change and persist final state in the active artifact store
 - `/sdd-onboard` → guided end-to-end walkthrough of SDD using your real codebase
 
 Meta-commands (type directly — orchestrator handles them, won't appear in autocomplete):
-- `/sdd-new <change>` → start a new change by delegating exploration + proposal to sub-agents
-- `/sdd-continue [change]` → run the next dependency-ready phase via sub-agent(s)
-- `/sdd-ff <name>` → fast-forward planning: proposal → specs → design → tasks
+- `/sdd-new <change>` → start a new change by invoking `sdd-explore` then `sdd-propose` subagents
+- `/sdd-continue [change]` → run the next dependency-ready phase via the appropriate subagent
+- `/sdd-ff <name>` → fast-forward planning: invoke `sdd-propose` → `sdd-spec` → `sdd-design` → `sdd-tasks` in sequence
 
-`/sdd-new`, `/sdd-continue`, and `/sdd-ff` are meta-commands handled by YOU. Do NOT invoke them as skills.
+`/sdd-new`, `/sdd-continue`, and `/sdd-ff` are meta-commands handled by YOU. Do NOT invoke them as skills. You orchestrate the subagent sequence yourself.
 
 ### SDD Init Guard (MANDATORY)
 
@@ -96,7 +115,7 @@ In **Interactive** mode, between phases:
 3. Ask: "¿Continuamos? / Continue?" — accept YES/continue, NO/stop, or specific feedback to adjust
 4. If the user gives feedback, incorporate it before running the next phase
 
-For this agent (sub-agent delegation): **Automatic** means phases run back-to-back via sub-agents without pausing. **Interactive** means the orchestrator pauses after each delegation returns, shows results, and asks before launching the next.
+For this agent (inline subagents): phases already run with user visibility between invocations. **Interactive** is the default behavior — show results between subagent calls and ask before proceeding. **Automatic** means invoke subagents sequentially without pausing to ask between phases.
 
 ### Artifact Store Mode
 
@@ -117,9 +136,9 @@ On the first `/sdd-new`, `/sdd-ff`, or `/sdd-continue` (or an equivalent natural
 ### Dependency Graph
 ```
 proposal -> specs --> tasks -> apply -> verify -> archive
-             ^
-             |
-           design
+              ^
+              |
+            design
 ```
 
 ### Result Contract
@@ -127,18 +146,21 @@ Each phase returns: `status`, `executive_summary`, `artifacts`, `next_recommende
 
 ### Review Workload Guard (MANDATORY)
 
-After `sdd-tasks` completes and before launching `sdd-apply`, inspect the task result summary for `Review Workload Forecast`.
+After `sdd-tasks` completes and before launching `sdd-apply`, inspect `Review Workload Forecast`.
 
-If it says `Chained PRs recommended: Yes`, `400-line budget risk: High`, estimated changed lines exceed 400, or `Decision needed before apply: Yes`, apply the cached `delivery_strategy`: `ask-on-risk` asks, `auto-chain` applies only the next PR slice, `single-pr` requires `size:exception`, and `exception-ok` records the exception.
+If it says `Chained PRs recommended: Yes`, `400-line budget risk: High`, estimated changed lines exceed 400, or `Decision needed before apply: Yes`, apply cached `delivery_strategy`:
 
-Do this even in Automatic mode. Automatic mode does not override reviewer burnout protection.
+- **`ask-on-risk`**: STOP and ask chained/stacked PRs vs maintainer-approved `size:exception`.
+- **`auto-chain`**: Do not ask. Tell `sdd-apply` to implement only the next autonomous chained/stacked PR slice using work-unit commits.
+- **`single-pr`**: STOP and require/record `size:exception` before apply.
+- **`exception-ok`**: Continue, but tell `sdd-apply` this run uses `size:exception`.
 
-When launching `sdd-apply`, include the resolved delivery strategy and any chosen PR boundary/exception in the prompt.
+Automatic mode does not override this guard. Always pass the resolved delivery strategy to `sdd-apply`.
 
 <!-- gentle-ai:sdd-model-assignments -->
 ## Model Assignments
 
-Read this table at session start (or before first delegation), cache it for the session, and pass the mapped alias in every Agent tool call via the `model` parameter. If a phase is missing, use the `default` row. If you lack access to the assigned model, substitute `sonnet` and continue.
+Read this table at session start (or before first delegation), cache it for the session, and pass the mapped alias when invoking subagents via the `model` parameter. If a phase is missing, use the `default` row. If you lack access to the assigned model, substitute `sonnet` and continue.
 
 | Phase | Default Model | Reason |
 |-------|---------------|--------|
@@ -157,9 +179,9 @@ Read this table at session start (or before first delegation), cache it for the 
 
 ### Sub-Agent Launch Pattern
 
-ALL sub-agent launch prompts that involve reading, writing, or reviewing code MUST include pre-resolved **compact rules** from the skill registry. Follow the **Skill Resolver Protocol** (see `_shared/skill-resolver.md` in the skills directory).
+ALL sub-agent invocations that involve reading, writing, or reviewing code MUST include pre-resolved **compact rules** from the skill registry. Follow the **Skill Resolver Protocol** (see `_shared/skill-resolver.md` in the skills directory).
 
-The orchestrator resolves skills from the registry ONCE (at session start or first delegation), caches the compact rules, and injects matching rules into each sub-agent's prompt. Also reads the Model Assignments table once per session, caches `phase → alias`, includes that alias in every Agent tool call via `model`.
+The orchestrator resolves skills from the registry ONCE (at session start or first delegation), caches the compact rules, and injects matching rules into each subagent's invocation message. Also reads the Model Assignments table once per session, caches `phase → alias`.
 
 Orchestrator skill resolution (do once per session):
 1. `mem_search(query: "skill-registry", project: "{project}")` → `mem_get_observation(id)` for full registry content
@@ -167,31 +189,31 @@ Orchestrator skill resolution (do once per session):
 3. Cache the **Compact Rules** section and the **User Skills** trigger table
 4. If no registry exists, warn user and proceed without project-specific standards
 
-For each sub-agent launch:
+For each subagent invocation:
 1. Match relevant skills by **code context** (file extensions/paths the sub-agent will touch) AND **task context** (what actions it will perform — review, PR creation, testing, etc.)
-2. Copy matching compact rule blocks into the sub-agent prompt as `## Project Standards (auto-resolved)`
-3. Inject BEFORE the sub-agent's task-specific instructions
+2. Copy matching compact rule blocks into the subagent invocation message as `## Project Standards (auto-resolved)`
+3. Inject BEFORE the subagent's task-specific instructions
 
-**Key rule**: inject compact rules TEXT, not paths. Sub-agents do NOT read SKILL.md files or the registry — rules arrive pre-digested. This is compaction-safe because each delegation re-reads the registry if the cache is lost.
+**Key rule**: inject compact rules TEXT, not paths. Sub-agents do NOT read SKILL.md files or the registry — rules arrive pre-digested in the invocation message. This is compaction-safe because each delegation re-reads the registry if the cache is lost.
 
 ### Skill Resolution Feedback
 
-After every delegation that returns a result, check the `skill_resolution` field:
+After every subagent invocation that returns a result, check the `skill_resolution` field:
 - `injected` → all good, skills were passed correctly
-- `fallback-registry`, `fallback-path`, or `none` → skill cache was lost (likely compaction). Re-read the registry immediately and inject compact rules in all subsequent delegations.
+- `fallback-registry`, `fallback-path`, or `none` → skill cache was lost (likely compaction). Re-read the registry immediately and inject compact rules in subsequent delegations.
 
 This is a self-correction mechanism. Do NOT ignore fallback reports — they indicate the orchestrator dropped context.
 
 ### Sub-Agent Context Protocol
 
-Sub-agents get a fresh context with NO memory. The orchestrator controls context access.
+Sub-agents run in fresh, isolated context windows with NO shared memory. The orchestrator controls what context each receives via the invocation message.
 
 #### Non-SDD Tasks (general delegation)
 
-- Read context: orchestrator searches engram (`mem_search`) for relevant prior context and passes it in the sub-agent prompt. Sub-agent does NOT search engram itself.
+- Read context: orchestrator searches engram (`mem_search`) for relevant prior context and passes it in the subagent invocation message. Sub-agent does NOT search engram itself.
 - Write context: sub-agent MUST save significant discoveries, decisions, or bug fixes to engram via `mem_save` before returning. Sub-agent has full detail — save before returning, not after.
-- Always add to sub-agent prompt: `"If you make important discoveries, decisions, or fix bugs, save them to engram via mem_save with project: '{project}'."`
-- Skills: orchestrator resolves compact rules from the registry and injects them as `## Project Standards (auto-resolved)` in the sub-agent prompt. Sub-agents do NOT read SKILL.md files or the registry — they receive rules pre-digested.
+- Always include in invocation message: `"If you make important discoveries, decisions, or fix bugs, save them to engram via mem_save with project: '{project}'."`
+- Skills: orchestrator resolves compact rules from the registry and injects them as `## Project Standards (auto-resolved)` in the invocation message. Sub-agents do NOT read SKILL.md files or the registry — they receive rules pre-digested.
 
 #### SDD Phases
 
@@ -253,7 +275,7 @@ Sub-agents retrieve full content via two steps:
 
 ### State and Conventions
 
-Convention files under the agent's global skills directory (global) or `.agent/skills/_shared/` (workspace): `engram-convention.md`, `persistence-contract.md`, `openspec-convention.md`.
+Convention files under `~/.copilot/skills/_shared/` (global) or `.agent/skills/_shared/` (workspace): `engram-convention.md`, `persistence-contract.md`, `openspec-convention.md`.
 
 ### Recovery Rule
 


### PR DESCRIPTION
## Summary

Enable VS Code Copilot as a TierFull sub-agent adapter, bringing it to parity with Claude Code, Cursor, and Kiro adapters. The VS Code Copilot adapter now supports the SDD orchestrator pattern through native `.agent.md` custom agent files.

### Commits (atomic, reviewable)

1. **`285d95f` feat(vscode): enable sub-agent support in adapter and SDD orchestrator**
   - Flip `SupportsSubAgents()` → `true`
   - Implement `SubAgentsDir()` → `~/.copilot/agents`
   - Implement `EmbeddedSubAgentsDir()` → `vscode/agents`
   - Add `all:vscode` to embed directive
   - Create VS Code-specific `sdd-orchestrator.md`
   - Add `case model.AgentVSCodeCopilot` to `sddOrchestratorAsset()`
   - Add unit tests for all three new methods

2. **`a90bd8b` feat(vscode): add first batch of SDD sub-agent definitions**
   - Create 6 `.agent.md` sub-agent files: orchestrator, apply, explore, propose, spec, design

3. **`1030de3` feat(vscode): add remaining SDD sub-agents and fix injection test**
   - Create 5 remaining `.agent.md` files: verify, tasks, archive, onboard, judgment-day
   - Add `.agent.md` extension to `inject.go` post-check
   - Extend `TestInjectVSCodeWritesSDDOrchestratorAndSkills` to verify all 11 agent files

### Key Changes

| Area | Change |
|------|--------|
| `internal/agents/vscode/adapter.go` | Flip `SupportsSubAgents() → true`, implement `SubAgentsDir()` and `EmbeddedSubAgentsDir()` |
| `internal/assets/assets.go` | Add `all:vscode` to embed directive |
| `internal/assets/vscode/sdd-orchestrator.md` | VS Code-specific orchestrator instructions |
| `internal/assets/vscode/agents/*.agent.md` | 11 sub-agent files for all SDD phases |
| `internal/components/sdd/inject.go` | Add VS Code orchestrator asset case + `.agent.md` extension |
| Tests | Unit tests for 3 adapter methods + extended injection test |

### Testing

All tests pass:
- `internal/agents/vscode/...` ✅
- `internal/assets/...` ✅  
- `internal/components/sdd/...` ✅

Closes #492