### PR TITLE
docs(skills): clarify sub-agent skill consumption

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -70,6 +70,16 @@ gga install
 
 These foundation skills are installed by default with both `full-gentleman` and `ecosystem-only` presets.
 
+### Skill consumption contract
+
+SDD sub-agents use two sources of skill context:
+
+1. **Assigned executor/phase skill** — the sub-agent reads its own SDD skill, such as `sdd-explore/SKILL.md` or `sdd-apply/SKILL.md`, to know how to run that phase.
+2. **Project/user skill standards** — the orchestrator resolves matching project or user skills from the skill registry and injects their compact rules into the sub-agent prompt as `## Project Standards (auto-resolved)`.
+
+During normal runtime, sub-agents should not independently discover or load additional project/user `SKILL.md` files. If the orchestrator fails to inject Project Standards, explicit `fallback-registry` or `fallback-path` loading is degraded self-healing and must be reported in the phase result's `skill_resolution` field.
+
+
 ### Coding Skills (separate repository)
 
 For framework-specific skills (React 19, Angular, TypeScript, Tailwind 4, Zod 4, Playwright, etc.), see [Gentleman-Programming/Gentleman-Skills](https://github.com/Gentleman-Programming/Gentleman-Skills). These are maintained by the community and installed separately by cloning the repo and copying skills to your agent's skills directory.

--- a/internal/assets/claude/agents/sdd-apply.md
+++ b/internal/assets/claude/agents/sdd-apply.md
@@ -46,4 +46,4 @@ Return a structured result with these fields:
 - `artifacts`: list of files changed and topic_keys updated
 - `next_recommended`: `sdd-verify` (if all tasks done) or `sdd-apply` again (if tasks remain)
 - `risks`: deviations from design, unexpected complexity, or blocked tasks
-- `skill_resolution`: `injected` if compact rules were provided in invocation message, otherwise `none`
+- `skill_resolution`: `injected` if compact rules were provided in the invocation message; `fallback-registry` or `fallback-path` only when explicitly self-healing from a missing Project Standards block; otherwise `none`

--- a/internal/assets/claude/agents/sdd-archive.md
+++ b/internal/assets/claude/agents/sdd-archive.md
@@ -45,4 +45,4 @@ Return a structured result with these fields:
 - `artifacts`: topic_keys or file paths written (e.g. `sdd/{change-name}/archive-report`, archived folder path)
 - `next_recommended`: `none` (change is complete) or a new `/sdd-new` if follow-up is needed
 - `risks`: any artifacts that could not be merged or archived cleanly
-- `skill_resolution`: `injected` if compact rules were provided in invocation message, otherwise `none`
+- `skill_resolution`: `injected` if compact rules were provided in the invocation message; `fallback-registry` or `fallback-path` only when explicitly self-healing from a missing Project Standards block; otherwise `none`

--- a/internal/assets/claude/agents/sdd-design.md
+++ b/internal/assets/claude/agents/sdd-design.md
@@ -42,4 +42,4 @@ Return a structured result with these fields:
 - `artifacts`: topic_keys or file paths written (e.g. `sdd/{change-name}/design`)
 - `next_recommended`: `sdd-tasks` (after spec is also ready)
 - `risks`: architectural risks, unresolved decisions, or assumptions requiring validation
-- `skill_resolution`: `injected` if compact rules were provided in invocation message, otherwise `none`
+- `skill_resolution`: `injected` if compact rules were provided in the invocation message; `fallback-registry` or `fallback-path` only when explicitly self-healing from a missing Project Standards block; otherwise `none`

--- a/internal/assets/claude/agents/sdd-explore.md
+++ b/internal/assets/claude/agents/sdd-explore.md
@@ -42,4 +42,4 @@ Return a structured result with these fields:
 - `artifacts`: topic_keys or file paths written (e.g. `sdd/{change-name}/explore`)
 - `next_recommended`: `sdd-propose` (if tied to a change) or `none` (if standalone)
 - `risks`: risks or blockers discovered during exploration
-- `skill_resolution`: `injected` if compact rules were provided in invocation message, otherwise `none`
+- `skill_resolution`: `injected` if compact rules were provided in the invocation message; `fallback-registry` or `fallback-path` only when explicitly self-healing from a missing Project Standards block; otherwise `none`

--- a/internal/assets/claude/agents/sdd-propose.md
+++ b/internal/assets/claude/agents/sdd-propose.md
@@ -41,4 +41,4 @@ Return a structured result with these fields:
 - `artifacts`: topic_keys or file paths written (e.g. `sdd/{change-name}/proposal`)
 - `next_recommended`: `sdd-spec` and `sdd-design` (can run in parallel)
 - `risks`: open questions, unresolved tradeoffs, or blocking dependencies
-- `skill_resolution`: `injected` if compact rules were provided in invocation message, otherwise `none`
+- `skill_resolution`: `injected` if compact rules were provided in the invocation message; `fallback-registry` or `fallback-path` only when explicitly self-healing from a missing Project Standards block; otherwise `none`

--- a/internal/assets/claude/agents/sdd-spec.md
+++ b/internal/assets/claude/agents/sdd-spec.md
@@ -41,4 +41,4 @@ Return a structured result with these fields:
 - `artifacts`: topic_keys or file paths written (e.g. `sdd/{change-name}/spec`)
 - `next_recommended`: `sdd-tasks` (after design is also ready)
 - `risks`: ambiguities in the proposal that forced spec-level assumptions
-- `skill_resolution`: `injected` if compact rules were provided in invocation message, otherwise `none`
+- `skill_resolution`: `injected` if compact rules were provided in the invocation message; `fallback-registry` or `fallback-path` only when explicitly self-healing from a missing Project Standards block; otherwise `none`

--- a/internal/assets/claude/agents/sdd-tasks.md
+++ b/internal/assets/claude/agents/sdd-tasks.md
@@ -42,4 +42,4 @@ Return a structured result with these fields:
 - `artifacts`: topic_keys or file paths written (e.g. `sdd/{change-name}/tasks`)
 - `next_recommended`: `sdd-apply`
 - `risks`: task dependencies that introduce bottlenecks or unclear ownership
-- `skill_resolution`: `injected` if compact rules were provided in invocation message, otherwise `none`
+- `skill_resolution`: `injected` if compact rules were provided in the invocation message; `fallback-registry` or `fallback-path` only when explicitly self-healing from a missing Project Standards block; otherwise `none`

--- a/internal/assets/claude/agents/sdd-verify.md
+++ b/internal/assets/claude/agents/sdd-verify.md
@@ -41,4 +41,4 @@ Return a structured result with these fields:
 - `artifacts`: topic_keys or file paths written (e.g. `sdd/{change-name}/verify-report`)
 - `next_recommended`: `sdd-archive` (if clean) or `sdd-apply` (if CRITICAL issues found)
 - `risks`: unresolved CRITICAL issues that block archive
-- `skill_resolution`: `injected` if compact rules were provided in invocation message, otherwise `none`
+- `skill_resolution`: `injected` if compact rules were provided in the invocation message; `fallback-registry` or `fallback-path` only when explicitly self-healing from a missing Project Standards block; otherwise `none`

--- a/internal/assets/claude/sdd-orchestrator.md
+++ b/internal/assets/claude/sdd-orchestrator.md
@@ -167,7 +167,7 @@ For each sub-agent launch:
 2. Copy matching compact rule blocks into the sub-agent prompt as `## Project Standards (auto-resolved)`
 3. Inject BEFORE the sub-agent's task-specific instructions
 
-**Key rule**: inject compact rules TEXT, not paths. Sub-agents do NOT read SKILL.md files or the registry — rules arrive pre-digested. This is compaction-safe because each delegation re-reads the registry if the cache is lost.
+**Key rule**: inject compact rules TEXT, not paths. Sub-agents still read their assigned executor/phase skill. During normal runtime, they do NOT independently discover or load additional project/user SKILL.md files or the registry — those rules arrive pre-digested. This is compaction-safe because each delegation re-reads the registry if the cache is lost.
 
 ### Skill Resolution Feedback
 
@@ -186,7 +186,7 @@ Sub-agents get a fresh context with NO memory. The orchestrator controls context
 - Read context: orchestrator searches engram (`mem_search`) for relevant prior context and passes it in the sub-agent prompt. Sub-agent does NOT search engram itself.
 - Write context: sub-agent MUST save significant discoveries, decisions, or bug fixes to engram via `mem_save` before returning. Sub-agent has full detail — save before returning, not after.
 - Always add to sub-agent prompt: `"If you make important discoveries, decisions, or fix bugs, save them to engram via mem_save with project: '{project}'."`
-- Skills: orchestrator resolves compact rules from the registry and injects them as `## Project Standards (auto-resolved)` in the sub-agent prompt. Sub-agents do NOT read SKILL.md files or the registry — they receive rules pre-digested.
+- Skills: orchestrator resolves compact rules from the registry and injects them as `## Project Standards (auto-resolved)` in the sub-agent prompt. Sub-agents still read their assigned executor/phase skill. During normal runtime, they do NOT independently discover or load additional project/user SKILL.md files or the registry — those rules arrive pre-digested.
 
 #### SDD Phases
 

--- a/internal/assets/codex/sdd-orchestrator.md
+++ b/internal/assets/codex/sdd-orchestrator.md
@@ -147,7 +147,7 @@ For each sub-agent launch:
 2. Copy matching compact rule blocks into the sub-agent prompt as `## Project Standards (auto-resolved)`
 3. Inject BEFORE the sub-agent's task-specific instructions
 
-**Key rule**: inject compact rules TEXT, not paths. Sub-agents do NOT read SKILL.md files or the registry — rules arrive pre-digested. This is compaction-safe because each delegation re-reads the registry if the cache is lost.
+**Key rule**: inject compact rules TEXT, not paths. Sub-agents still read their assigned executor/phase skill. During normal runtime, they do NOT independently discover or load additional project/user SKILL.md files or the registry — those rules arrive pre-digested. This is compaction-safe because each delegation re-reads the registry if the cache is lost.
 
 ### Skill Resolution Feedback
 
@@ -166,7 +166,7 @@ Sub-agents get a fresh context with NO memory. The orchestrator controls context
 - Read context: orchestrator searches engram (`mem_search`) for relevant prior context and passes it in the sub-agent prompt. Sub-agent does NOT search engram itself.
 - Write context: sub-agent MUST save significant discoveries, decisions, or bug fixes to engram via `mem_save` before returning. Sub-agent has full detail — save before returning, not after.
 - Always add to sub-agent prompt: `"If you make important discoveries, decisions, or fix bugs, save them to engram via mem_save with project: '{project}'."`
-- Skills: orchestrator resolves compact rules from the registry and injects them as `## Project Standards (auto-resolved)` in the sub-agent prompt. Sub-agents do NOT read SKILL.md files or the registry — they receive rules pre-digested.
+- Skills: orchestrator resolves compact rules from the registry and injects them as `## Project Standards (auto-resolved)` in the sub-agent prompt. Sub-agents still read their assigned executor/phase skill. During normal runtime, they do NOT independently discover or load additional project/user SKILL.md files or the registry — those rules arrive pre-digested.
 
 #### SDD Phases
 

--- a/internal/assets/cursor/agents/sdd-apply.md
+++ b/internal/assets/cursor/agents/sdd-apply.md
@@ -47,4 +47,4 @@ Return a structured result with these fields:
 - `artifacts`: list of files changed and topic_keys updated
 - `next_recommended`: `sdd-verify` (if all tasks done) or `sdd-apply` again (if tasks remain)
 - `risks`: deviations from design, unexpected complexity, or blocked tasks
-- `skill_resolution`: `injected` if compact rules were provided in invocation message, otherwise `none`
+- `skill_resolution`: `injected` if compact rules were provided in the invocation message; `fallback-registry` or `fallback-path` only when explicitly self-healing from a missing Project Standards block; otherwise `none`

--- a/internal/assets/cursor/agents/sdd-archive.md
+++ b/internal/assets/cursor/agents/sdd-archive.md
@@ -46,4 +46,4 @@ Return a structured result with these fields:
 - `artifacts`: topic_keys or file paths written (e.g. `sdd/{change-name}/archive-report`, archived folder path)
 - `next_recommended`: `none` (change is complete) or a new `/sdd-new` if follow-up is needed
 - `risks`: any artifacts that could not be merged or archived cleanly
-- `skill_resolution`: `injected` if compact rules were provided in invocation message, otherwise `none`
+- `skill_resolution`: `injected` if compact rules were provided in the invocation message; `fallback-registry` or `fallback-path` only when explicitly self-healing from a missing Project Standards block; otherwise `none`

--- a/internal/assets/cursor/agents/sdd-design.md
+++ b/internal/assets/cursor/agents/sdd-design.md
@@ -42,4 +42,4 @@ Return a structured result with these fields:
 - `artifacts`: topic_keys or file paths written (e.g. `sdd/{change-name}/design`)
 - `next_recommended`: `sdd-tasks` (once spec is also done)
 - `risks`: architectural risks, open decisions, or patterns that deviate from existing codebase
-- `skill_resolution`: `injected` if compact rules were provided in invocation message, otherwise `none`
+- `skill_resolution`: `injected` if compact rules were provided in the invocation message; `fallback-registry` or `fallback-path` only when explicitly self-healing from a missing Project Standards block; otherwise `none`

--- a/internal/assets/cursor/agents/sdd-explore.md
+++ b/internal/assets/cursor/agents/sdd-explore.md
@@ -44,4 +44,4 @@ Return a structured result with these fields:
 - `artifacts`: topic_keys or file paths written (e.g. `sdd/{change-name}/explore`)
 - `next_recommended`: `sdd-propose` (if tied to a change) or `none` (if standalone)
 - `risks`: risks or blockers discovered during exploration
-- `skill_resolution`: `injected` if compact rules were provided in invocation message, otherwise `none`
+- `skill_resolution`: `injected` if compact rules were provided in the invocation message; `fallback-registry` or `fallback-path` only when explicitly self-healing from a missing Project Standards block; otherwise `none`

--- a/internal/assets/cursor/agents/sdd-init.md
+++ b/internal/assets/cursor/agents/sdd-init.md
@@ -40,4 +40,4 @@ Return a structured result with these fields:
 - `artifacts`: list of paths or topic_keys written (e.g. `.atl/skill-registry.md`, `sdd-init/{project}`)
 - `next_recommended`: `sdd-explore` or `sdd-new`
 - `risks`: any warnings about the detected stack or persistence backend
-- `skill_resolution`: `injected` if compact rules were provided in invocation message, otherwise `none`
+- `skill_resolution`: `injected` if compact rules were provided in the invocation message; `fallback-registry` or `fallback-path` only when explicitly self-healing from a missing Project Standards block; otherwise `none`

--- a/internal/assets/cursor/agents/sdd-onboard.md
+++ b/internal/assets/cursor/agents/sdd-onboard.md
@@ -40,4 +40,4 @@ Return a structured result with these fields:
 - `artifacts`: list of paths or topic_keys written
 - `next_recommended`: `sdd-new` (to start a real change independently)
 - `risks`: any warnings about the onboarding session
-- `skill_resolution`: `injected` if compact rules were provided in invocation message, otherwise `none`
+- `skill_resolution`: `injected` if compact rules were provided in the invocation message; `fallback-registry` or `fallback-path` only when explicitly self-healing from a missing Project Standards block; otherwise `none`

--- a/internal/assets/cursor/agents/sdd-propose.md
+++ b/internal/assets/cursor/agents/sdd-propose.md
@@ -39,4 +39,4 @@ Return a structured result with these fields:
 - `artifacts`: topic_keys or file paths written (e.g. `sdd/{change-name}/proposal`)
 - `next_recommended`: `sdd-spec` and `sdd-design` (can run in parallel)
 - `risks`: architectural risks or open questions identified during proposal
-- `skill_resolution`: `injected` if compact rules were provided in invocation message, otherwise `none`
+- `skill_resolution`: `injected` if compact rules were provided in the invocation message; `fallback-registry` or `fallback-path` only when explicitly self-healing from a missing Project Standards block; otherwise `none`

--- a/internal/assets/cursor/agents/sdd-spec.md
+++ b/internal/assets/cursor/agents/sdd-spec.md
@@ -40,4 +40,4 @@ Return a structured result with these fields:
 - `artifacts`: topic_keys or file paths written (e.g. `sdd/{change-name}/spec`)
 - `next_recommended`: `sdd-tasks` (once design is also done)
 - `risks`: any ambiguous requirements or missing acceptance criteria
-- `skill_resolution`: `injected` if compact rules were provided in invocation message, otherwise `none`
+- `skill_resolution`: `injected` if compact rules were provided in the invocation message; `fallback-registry` or `fallback-path` only when explicitly self-healing from a missing Project Standards block; otherwise `none`

--- a/internal/assets/cursor/agents/sdd-tasks.md
+++ b/internal/assets/cursor/agents/sdd-tasks.md
@@ -42,4 +42,4 @@ Return a structured result with these fields:
 - `artifacts`: topic_keys or file paths written (e.g. `sdd/{change-name}/tasks`)
 - `next_recommended`: `sdd-apply`
 - `risks`: tasks that are large or have hidden dependencies, phases that may need splitting
-- `skill_resolution`: `injected` if compact rules were provided in invocation message, otherwise `none`
+- `skill_resolution`: `injected` if compact rules were provided in the invocation message; `fallback-registry` or `fallback-path` only when explicitly self-healing from a missing Project Standards block; otherwise `none`

--- a/internal/assets/cursor/agents/sdd-verify.md
+++ b/internal/assets/cursor/agents/sdd-verify.md
@@ -48,4 +48,4 @@ Return a structured result with these fields:
 - `artifacts`: topic_keys or file paths written (e.g. `sdd/{change-name}/verify-report`)
 - `next_recommended`: `sdd-archive` (if PASS) or `sdd-apply` (if FAIL/blockers found)
 - `risks`: CRITICAL issues (must fix) and WARNINGs (should fix)
-- `skill_resolution`: `injected` if compact rules were provided in invocation message, otherwise `none`
+- `skill_resolution`: `injected` if compact rules were provided in the invocation message; `fallback-registry` or `fallback-path` only when explicitly self-healing from a missing Project Standards block; otherwise `none`

--- a/internal/assets/cursor/sdd-orchestrator.md
+++ b/internal/assets/cursor/sdd-orchestrator.md
@@ -187,7 +187,7 @@ For each subagent invocation:
 2. Copy matching compact rule blocks into the subagent invocation message as `## Project Standards (auto-resolved)`
 3. Inject BEFORE the subagent's task-specific instructions
 
-**Key rule**: inject compact rules TEXT, not paths. Sub-agents do NOT read SKILL.md files or the registry — rules arrive pre-digested in the invocation message. This is compaction-safe because each delegation re-reads the registry if the cache is lost.
+**Key rule**: inject compact rules TEXT, not paths. Sub-agents still read their assigned executor/phase skill. During normal runtime, they do NOT independently discover or load additional project/user SKILL.md files or the registry — those rules arrive pre-digested in the invocation message. This is compaction-safe because each delegation re-reads the registry if the cache is lost.
 
 ### Skill Resolution Feedback
 
@@ -206,7 +206,7 @@ Sub-agents run in fresh, isolated context windows with NO shared memory. The orc
 - Read context: orchestrator searches engram (`mem_search`) for relevant prior context and passes it in the subagent invocation message. Sub-agent does NOT search engram itself.
 - Write context: sub-agent MUST save significant discoveries, decisions, or bug fixes to engram via `mem_save` before returning. Sub-agent has full detail — save before returning, not after.
 - Always include in invocation message: `"If you make important discoveries, decisions, or fix bugs, save them to engram via mem_save with project: '{project}'."`
-- Skills: orchestrator resolves compact rules from the registry and injects them as `## Project Standards (auto-resolved)` in the invocation message. Sub-agents do NOT read SKILL.md files or the registry — they receive rules pre-digested.
+- Skills: orchestrator resolves compact rules from the registry and injects them as `## Project Standards (auto-resolved)` in the invocation message. Sub-agents still read their assigned executor/phase skill. During normal runtime, they do NOT independently discover or load additional project/user SKILL.md files or the registry — those rules arrive pre-digested.
 
 #### SDD Phases
 

--- a/internal/assets/gemini/sdd-orchestrator.md
+++ b/internal/assets/gemini/sdd-orchestrator.md
@@ -147,7 +147,7 @@ For each sub-agent launch:
 2. Copy matching compact rule blocks into the sub-agent prompt as `## Project Standards (auto-resolved)`
 3. Inject BEFORE the sub-agent's task-specific instructions
 
-**Key rule**: inject compact rules TEXT, not paths. Sub-agents do NOT read SKILL.md files or the registry — rules arrive pre-digested. This is compaction-safe because each delegation re-reads the registry if the cache is lost.
+**Key rule**: inject compact rules TEXT, not paths. Sub-agents still read their assigned executor/phase skill. During normal runtime, they do NOT independently discover or load additional project/user SKILL.md files or the registry — those rules arrive pre-digested. This is compaction-safe because each delegation re-reads the registry if the cache is lost.
 
 ### Skill Resolution Feedback
 
@@ -166,7 +166,7 @@ Sub-agents get a fresh context with NO memory. The orchestrator controls context
 - Read context: orchestrator searches engram (`mem_search`) for relevant prior context and passes it in the sub-agent prompt. Sub-agent does NOT search engram itself.
 - Write context: sub-agent MUST save significant discoveries, decisions, or bug fixes to engram via `mem_save` before returning. Sub-agent has full detail — save before returning, not after.
 - Always add to sub-agent prompt: `"If you make important discoveries, decisions, or fix bugs, save them to engram via mem_save with project: '{project}'."`
-- Skills: orchestrator resolves compact rules from the registry and injects them as `## Project Standards (auto-resolved)` in the sub-agent prompt. Sub-agents do NOT read SKILL.md files or the registry — they receive rules pre-digested.
+- Skills: orchestrator resolves compact rules from the registry and injects them as `## Project Standards (auto-resolved)` in the sub-agent prompt. Sub-agents still read their assigned executor/phase skill. During normal runtime, they do NOT independently discover or load additional project/user SKILL.md files or the registry — those rules arrive pre-digested.
 
 #### SDD Phases
 

--- a/internal/assets/generic/sdd-orchestrator.md
+++ b/internal/assets/generic/sdd-orchestrator.md
@@ -165,7 +165,7 @@ For each sub-agent launch:
 2. Copy matching compact rule blocks into the sub-agent prompt as `## Project Standards (auto-resolved)`
 3. Inject BEFORE the sub-agent's task-specific instructions
 
-**Key rule**: inject compact rules TEXT, not paths. Sub-agents do NOT read SKILL.md files or the registry — rules arrive pre-digested. This is compaction-safe because each delegation re-reads the registry if the cache is lost.
+**Key rule**: inject compact rules TEXT, not paths. Sub-agents still read their assigned executor/phase skill. During normal runtime, they do NOT independently discover or load additional project/user SKILL.md files or the registry — those rules arrive pre-digested. This is compaction-safe because each delegation re-reads the registry if the cache is lost.
 
 ### Skill Resolution Feedback
 
@@ -184,7 +184,7 @@ Sub-agents get a fresh context with NO memory. The orchestrator controls context
 - Read context: orchestrator searches engram (`mem_search`) for relevant prior context and passes it in the sub-agent prompt. Sub-agent does NOT search engram itself.
 - Write context: sub-agent MUST save significant discoveries, decisions, or bug fixes to engram via `mem_save` before returning. Sub-agent has full detail — save before returning, not after.
 - Always add to sub-agent prompt: `"If you make important discoveries, decisions, or fix bugs, save them to engram via mem_save with project: '{project}'."`
-- Skills: orchestrator resolves compact rules from the registry and injects them as `## Project Standards (auto-resolved)` in the sub-agent prompt. Sub-agents do NOT read SKILL.md files or the registry — they receive rules pre-digested.
+- Skills: orchestrator resolves compact rules from the registry and injects them as `## Project Standards (auto-resolved)` in the sub-agent prompt. Sub-agents still read their assigned executor/phase skill. During normal runtime, they do NOT independently discover or load additional project/user SKILL.md files or the registry — those rules arrive pre-digested.
 
 #### SDD Phases
 

--- a/internal/assets/kimi/agents/sdd-apply.md
+++ b/internal/assets/kimi/agents/sdd-apply.md
@@ -46,4 +46,4 @@ Return a structured result with these fields:
 - `artifacts`: list of files changed and topic_keys updated
 - `next_recommended`: `sdd-verify` (if all tasks are done) or `sdd-apply` again
 - `risks`: deviations from design, unexpected complexity, or blocked tasks
-- `skill_resolution`: `injected` if compact rules were provided in invocation message, otherwise `none`
+- `skill_resolution`: `injected` if compact rules were provided in the invocation message; `fallback-registry` or `fallback-path` only when explicitly self-healing from a missing Project Standards block; otherwise `none`

--- a/internal/assets/kimi/agents/sdd-archive.md
+++ b/internal/assets/kimi/agents/sdd-archive.md
@@ -45,4 +45,4 @@ Return a structured result with these fields:
 - `artifacts`: topic_keys or file paths written
 - `next_recommended`: `none`
 - `risks`: any artifacts that could not be merged or archived cleanly
-- `skill_resolution`: `injected` if compact rules were provided in invocation message, otherwise `none`
+- `skill_resolution`: `injected` if compact rules were provided in the invocation message; `fallback-registry` or `fallback-path` only when explicitly self-healing from a missing Project Standards block; otherwise `none`

--- a/internal/assets/kimi/agents/sdd-design.md
+++ b/internal/assets/kimi/agents/sdd-design.md
@@ -42,4 +42,4 @@ Return a structured result with these fields:
 - `artifacts`: topic_keys or file paths written
 - `next_recommended`: `sdd-tasks` (once spec is also done)
 - `risks`: architectural risks, open decisions, or patterns that deviate from the existing codebase
-- `skill_resolution`: `injected` if compact rules were provided in invocation message, otherwise `none`
+- `skill_resolution`: `injected` if compact rules were provided in the invocation message; `fallback-registry` or `fallback-path` only when explicitly self-healing from a missing Project Standards block; otherwise `none`

--- a/internal/assets/kimi/agents/sdd-explore.md
+++ b/internal/assets/kimi/agents/sdd-explore.md
@@ -42,4 +42,4 @@ Return a structured result with these fields:
 - `artifacts`: topic_keys or file paths written
 - `next_recommended`: `sdd-propose` or `none`
 - `risks`: risks or blockers discovered during exploration
-- `skill_resolution`: `injected` if compact rules were provided in invocation message, otherwise `none`
+- `skill_resolution`: `injected` if compact rules were provided in the invocation message; `fallback-registry` or `fallback-path` only when explicitly self-healing from a missing Project Standards block; otherwise `none`

--- a/internal/assets/kimi/agents/sdd-init.md
+++ b/internal/assets/kimi/agents/sdd-init.md
@@ -39,4 +39,4 @@ Return a structured result with these fields:
 - `artifacts`: list of paths or topic_keys written
 - `next_recommended`: `sdd-explore` or `sdd-new`
 - `risks`: any warnings about the detected stack or persistence backend
-- `skill_resolution`: `injected` if compact rules were provided in invocation message, otherwise `none`
+- `skill_resolution`: `injected` if compact rules were provided in the invocation message; `fallback-registry` or `fallback-path` only when explicitly self-healing from a missing Project Standards block; otherwise `none`

--- a/internal/assets/kimi/agents/sdd-onboard.md
+++ b/internal/assets/kimi/agents/sdd-onboard.md
@@ -40,4 +40,4 @@ Return a structured result with these fields:
 - `artifacts`: list of paths or topic_keys written
 - `next_recommended`: `sdd-new` (to start a real change independently)
 - `risks`: any warnings about the onboarding session
-- `skill_resolution`: `injected` if compact rules were provided in invocation message, otherwise `none`
+- `skill_resolution`: `injected` if compact rules were provided in the invocation message; `fallback-registry` or `fallback-path` only when explicitly self-healing from a missing Project Standards block; otherwise `none`

--- a/internal/assets/kimi/agents/sdd-propose.md
+++ b/internal/assets/kimi/agents/sdd-propose.md
@@ -38,4 +38,4 @@ Return a structured result with these fields:
 - `artifacts`: topic_keys or file paths written
 - `next_recommended`: `sdd-spec` and `sdd-design`
 - `risks`: architectural risks or open questions identified during proposal
-- `skill_resolution`: `injected` if compact rules were provided in invocation message, otherwise `none`
+- `skill_resolution`: `injected` if compact rules were provided in the invocation message; `fallback-registry` or `fallback-path` only when explicitly self-healing from a missing Project Standards block; otherwise `none`

--- a/internal/assets/kimi/agents/sdd-spec.md
+++ b/internal/assets/kimi/agents/sdd-spec.md
@@ -39,4 +39,4 @@ Return a structured result with these fields:
 - `artifacts`: topic_keys or file paths written
 - `next_recommended`: `sdd-tasks` (once design is also done)
 - `risks`: any ambiguous requirements or missing acceptance criteria
-- `skill_resolution`: `injected` if compact rules were provided in invocation message, otherwise `none`
+- `skill_resolution`: `injected` if compact rules were provided in the invocation message; `fallback-registry` or `fallback-path` only when explicitly self-healing from a missing Project Standards block; otherwise `none`

--- a/internal/assets/kimi/agents/sdd-tasks.md
+++ b/internal/assets/kimi/agents/sdd-tasks.md
@@ -41,4 +41,4 @@ Return a structured result with these fields:
 - `artifacts`: topic_keys or file paths written
 - `next_recommended`: `sdd-apply`
 - `risks`: tasks that are large or have hidden dependencies
-- `skill_resolution`: `injected` if compact rules were provided in invocation message, otherwise `none`
+- `skill_resolution`: `injected` if compact rules were provided in the invocation message; `fallback-registry` or `fallback-path` only when explicitly self-healing from a missing Project Standards block; otherwise `none`

--- a/internal/assets/kimi/agents/sdd-verify.md
+++ b/internal/assets/kimi/agents/sdd-verify.md
@@ -46,4 +46,4 @@ Return a structured result with these fields:
 - `artifacts`: topic_keys or file paths written
 - `next_recommended`: `sdd-archive` (if PASS) or `sdd-apply` (if FAIL/blockers found)
 - `risks`: CRITICAL issues and WARNINGs
-- `skill_resolution`: `injected` if compact rules were provided in invocation message, otherwise `none`
+- `skill_resolution`: `injected` if compact rules were provided in the invocation message; `fallback-registry` or `fallback-path` only when explicitly self-healing from a missing Project Standards block; otherwise `none`

--- a/internal/assets/kiro/agents/sdd-apply.md
+++ b/internal/assets/kiro/agents/sdd-apply.md
@@ -52,4 +52,4 @@ Return a structured result with these fields:
 - `artifacts`: list of files changed and topic_keys updated
 - `next_recommended`: `sdd-verify` (if all tasks done) or `sdd-apply` again (if tasks remain)
 - `risks`: deviations from design, unexpected complexity, or blocked tasks
-- `skill_resolution`: `injected` if compact rules were provided in invocation message, otherwise `none`
+- `skill_resolution`: `injected` if compact rules were provided in the invocation message; `fallback-registry` or `fallback-path` only when explicitly self-healing from a missing Project Standards block; otherwise `none`

--- a/internal/assets/kiro/agents/sdd-archive.md
+++ b/internal/assets/kiro/agents/sdd-archive.md
@@ -51,4 +51,4 @@ Return a structured result with these fields:
 - `artifacts`: topic_keys or file paths written (e.g. `sdd/{change-name}/archive-report`, archived folder path)
 - `next_recommended`: `none` (change is complete) or a new `/sdd-new` if follow-up is needed
 - `risks`: any artifacts that could not be merged or archived cleanly
-- `skill_resolution`: `injected` if compact rules were provided in invocation message, otherwise `none`
+- `skill_resolution`: `injected` if compact rules were provided in the invocation message; `fallback-registry` or `fallback-path` only when explicitly self-healing from a missing Project Standards block; otherwise `none`

--- a/internal/assets/kiro/agents/sdd-design.md
+++ b/internal/assets/kiro/agents/sdd-design.md
@@ -47,4 +47,4 @@ Return a structured result with these fields:
 - `artifacts`: topic_keys or file paths written (e.g. `sdd/{change-name}/design`)
 - `next_recommended`: `sdd-tasks` (once spec is also done)
 - `risks`: architectural risks, open decisions, or patterns that deviate from existing codebase
-- `skill_resolution`: `injected` if compact rules were provided in invocation message, otherwise `none`
+- `skill_resolution`: `injected` if compact rules were provided in the invocation message; `fallback-registry` or `fallback-path` only when explicitly self-healing from a missing Project Standards block; otherwise `none`

--- a/internal/assets/kiro/agents/sdd-explore.md
+++ b/internal/assets/kiro/agents/sdd-explore.md
@@ -48,4 +48,4 @@ Return a structured result with these fields:
 - `artifacts`: topic_keys or file paths written (e.g. `sdd/{change-name}/explore`)
 - `next_recommended`: `sdd-propose` (if tied to a change) or `none` (if standalone)
 - `risks`: risks or blockers discovered during exploration
-- `skill_resolution`: `injected` if compact rules were provided in invocation message, otherwise `none`
+- `skill_resolution`: `injected` if compact rules were provided in the invocation message; `fallback-registry` or `fallback-path` only when explicitly self-healing from a missing Project Standards block; otherwise `none`

--- a/internal/assets/kiro/agents/sdd-init.md
+++ b/internal/assets/kiro/agents/sdd-init.md
@@ -45,4 +45,4 @@ Return a structured result with these fields:
 - `artifacts`: list of paths or topic_keys written (e.g. `.atl/skill-registry.md`, `sdd-init/{project}`)
 - `next_recommended`: `sdd-explore` or `sdd-new`
 - `risks`: any warnings about the detected stack or persistence backend
-- `skill_resolution`: `injected` if compact rules were provided in invocation message, otherwise `none`
+- `skill_resolution`: `injected` if compact rules were provided in the invocation message; `fallback-registry` or `fallback-path` only when explicitly self-healing from a missing Project Standards block; otherwise `none`

--- a/internal/assets/kiro/agents/sdd-onboard.md
+++ b/internal/assets/kiro/agents/sdd-onboard.md
@@ -45,4 +45,4 @@ Return a structured result with these fields:
 - `artifacts`: list of paths or topic_keys written
 - `next_recommended`: `sdd-new` (to start a real change independently)
 - `risks`: any warnings about the onboarding session
-- `skill_resolution`: `injected` if compact rules were provided in invocation message, otherwise `none`
+- `skill_resolution`: `injected` if compact rules were provided in the invocation message; `fallback-registry` or `fallback-path` only when explicitly self-healing from a missing Project Standards block; otherwise `none`

--- a/internal/assets/kiro/agents/sdd-propose.md
+++ b/internal/assets/kiro/agents/sdd-propose.md
@@ -44,4 +44,4 @@ Return a structured result with these fields:
 - `artifacts`: topic_keys or file paths written (e.g. `sdd/{change-name}/proposal`)
 - `next_recommended`: `sdd-spec` and `sdd-design` (can run in parallel)
 - `risks`: architectural risks or open questions identified during proposal
-- `skill_resolution`: `injected` if compact rules were provided in invocation message, otherwise `none`
+- `skill_resolution`: `injected` if compact rules were provided in the invocation message; `fallback-registry` or `fallback-path` only when explicitly self-healing from a missing Project Standards block; otherwise `none`

--- a/internal/assets/kiro/agents/sdd-spec.md
+++ b/internal/assets/kiro/agents/sdd-spec.md
@@ -45,4 +45,4 @@ Return a structured result with these fields:
 - `artifacts`: topic_keys or file paths written (e.g. `sdd/{change-name}/spec`)
 - `next_recommended`: `sdd-tasks` (once design is also done)
 - `risks`: any ambiguous requirements or missing acceptance criteria
-- `skill_resolution`: `injected` if compact rules were provided in invocation message, otherwise `none`
+- `skill_resolution`: `injected` if compact rules were provided in the invocation message; `fallback-registry` or `fallback-path` only when explicitly self-healing from a missing Project Standards block; otherwise `none`

--- a/internal/assets/kiro/agents/sdd-tasks.md
+++ b/internal/assets/kiro/agents/sdd-tasks.md
@@ -47,4 +47,4 @@ Return a structured result with these fields:
 - `artifacts`: topic_keys or file paths written (e.g. `sdd/{change-name}/tasks`)
 - `next_recommended`: `sdd-apply`
 - `risks`: tasks that are large or have hidden dependencies, phases that may need splitting
-- `skill_resolution`: `injected` if compact rules were provided in invocation message, otherwise `none`
+- `skill_resolution`: `injected` if compact rules were provided in the invocation message; `fallback-registry` or `fallback-path` only when explicitly self-healing from a missing Project Standards block; otherwise `none`

--- a/internal/assets/kiro/agents/sdd-verify.md
+++ b/internal/assets/kiro/agents/sdd-verify.md
@@ -52,4 +52,4 @@ Return a structured result with these fields:
 - `artifacts`: topic_keys or file paths written (e.g. `sdd/{change-name}/verify-report`)
 - `next_recommended`: `sdd-archive` (if PASS) or `sdd-apply` (if FAIL/blockers found)
 - `risks`: CRITICAL issues (must fix) and WARNINGs (should fix)
-- `skill_resolution`: `injected` if compact rules were provided in invocation message, otherwise `none`
+- `skill_resolution`: `injected` if compact rules were provided in the invocation message; `fallback-registry` or `fallback-path` only when explicitly self-healing from a missing Project Standards block; otherwise `none`

--- a/internal/assets/qwen/sdd-orchestrator.md
+++ b/internal/assets/qwen/sdd-orchestrator.md
@@ -147,7 +147,7 @@ For each sub-agent launch:
 2. Copy matching compact rule blocks into the sub-agent prompt as `## Project Standards (auto-resolved)`
 3. Inject BEFORE the sub-agent's task-specific instructions
 
-**Key rule**: inject compact rules TEXT, not paths. Sub-agents do NOT read SKILL.md files or the registry — rules arrive pre-digested. This is compaction-safe because each delegation re-reads the registry if the cache is lost.
+**Key rule**: inject compact rules TEXT, not paths. Sub-agents still read their assigned executor/phase skill. During normal runtime, they do NOT independently discover or load additional project/user SKILL.md files or the registry — those rules arrive pre-digested. This is compaction-safe because each delegation re-reads the registry if the cache is lost.
 
 ### Skill Resolution Feedback
 
@@ -166,7 +166,7 @@ Sub-agents get a fresh context with NO memory. The orchestrator controls context
 - Read context: orchestrator searches engram (`mem_search`) for relevant prior context and passes it in the sub-agent prompt. Sub-agent does NOT search engram itself.
 - Write context: sub-agent MUST save significant discoveries, decisions, or bug fixes to engram via `mem_save` before returning. Sub-agent has full detail — save before returning, not after.
 - Always add to sub-agent prompt: `"If you make important discoveries, decisions, or fix bugs, save them to engram via mem_save with project: '{project}'."`
-- Skills: orchestrator resolves compact rules from the registry and injects them as `## Project Standards (auto-resolved)` in the sub-agent prompt. Sub-agents do NOT read SKILL.md files or the registry — they receive rules pre-digested.
+- Skills: orchestrator resolves compact rules from the registry and injects them as `## Project Standards (auto-resolved)` in the sub-agent prompt. Sub-agents still read their assigned executor/phase skill. During normal runtime, they do NOT independently discover or load additional project/user SKILL.md files or the registry — those rules arrive pre-digested.
 
 #### SDD Phases
 

--- a/internal/assets/skills/_shared/persistence-contract.md
+++ b/internal/assets/skills/_shared/persistence-contract.md
@@ -139,11 +139,11 @@ For SDD artifacts, `capture_prompt: false` is explicit and mandatory when the En
 
 ## Skill Registry
 
-The orchestrator pre-resolves compact rules from the skill registry and injects them as `## Project Standards (auto-resolved)` in your launch prompt. Sub-agents do NOT read the registry or individual SKILL.md files — rules arrive pre-digested.
+The orchestrator pre-resolves compact rules from the skill registry and injects them as `## Project Standards (auto-resolved)` in your launch prompt. Sub-agents still read their assigned executor/phase skill. They do NOT independently discover or load additional project/user SKILL.md files or the registry during normal runtime — rules arrive pre-digested.
 
 To generate/update: run the `skill-registry` skill, or run `sdd-init`.
 
-Sub-agent skill loading: check for a `## Project Standards (auto-resolved)` block in your prompt — if present, follow those rules. If not present, check for `SKILL: Load` instructions as a fallback. If neither exists, proceed without — this is not an error.
+Sub-agent skill loading: check for a `## Project Standards (auto-resolved)` block in your prompt — if present, follow those rules. If not present, check for `SKILL: Load` instructions as an explicit self-healing fallback and report `fallback-path`. If neither exists, proceed without project/user skills and report `none` — this is degraded but not an execution error.
 
 ## Detail Level
 

--- a/internal/assets/skills/_shared/sdd-phase-common.md
+++ b/internal/assets/skills/_shared/sdd-phase-common.md
@@ -6,7 +6,7 @@ Executor boundary: every SDD phase agent is an EXECUTOR, not an orchestrator. Do
 
 ## A. Skill Loading
 
-1. Check if the orchestrator injected a `## Project Standards (auto-resolved)` block in your launch prompt. If yes, follow those rules — they are pre-digested compact rules from the skill registry. **Do NOT read any SKILL.md files.**
+1. Check if the orchestrator injected a `## Project Standards (auto-resolved)` block in your launch prompt. If yes, follow those rules — they are pre-digested compact rules from the skill registry. **Do NOT independently discover or load additional project/user SKILL.md files.** Continue to follow your assigned executor/phase skill.
 2. If no Project Standards block was provided, check for `SKILL: Load` instructions. If present, load those exact skill files.
 3. If neither was provided, search for the skill registry as a fallback:
    a. `mem_search(query: "skill-registry", project: "{project}")` — if found, `mem_get_observation(id)` for full content
@@ -14,7 +14,7 @@ Executor boundary: every SDD phase agent is an EXECUTOR, not an orchestrator. Do
    c. From the registry's **Compact Rules** section, apply rules whose triggers match your current task.
 4. If no registry exists, proceed with your phase skill only.
 
-NOTE: the preferred path is (1) — compact rules pre-injected by the orchestrator. Paths (2) and (3) are fallbacks for backwards compatibility. Searching the registry is SKILL LOADING, not delegation. If `## Project Standards` is present, IGNORE any `SKILL: Load` instructions — they are redundant.
+NOTE: the preferred path is (1) — compact rules pre-injected by the orchestrator. Paths (2) and (3) are explicit self-healing fallbacks for backwards compatibility when the orchestrator failed to provide Project Standards. Treat them as degraded-but-auditable behavior: report `fallback-path` or `fallback-registry` in `skill_resolution`. Searching the registry is SKILL LOADING, not delegation. If `## Project Standards` is present, IGNORE any `SKILL: Load` instructions — they are redundant.
 
 ## B. Artifact Retrieval (Engram Mode)
 
@@ -76,7 +76,7 @@ Every phase MUST return a structured envelope to the orchestrator:
 - `artifacts`: list of artifact keys/paths written
 - `next_recommended`: the next SDD phase to run, or "none"
 - `risks`: risks discovered, or "None"
-- `skill_resolution`: how skills were loaded — `injected` (received Project Standards from orchestrator), `fallback-registry` (self-loaded from registry), `fallback-path` (loaded via SKILL: Load path), or `none` (no skills loaded)
+- `skill_resolution`: how project/user skills were loaded — `injected` (received Project Standards from orchestrator), `fallback-registry` (self-loaded compact rules from registry because Project Standards were missing), `fallback-path` (loaded explicit SKILL: Load paths because Project Standards were missing), or `none` (no project/user skills loaded)
 
 Example:
 

--- a/internal/assets/skills/_shared/skill-resolver.md
+++ b/internal/assets/skills/_shared/skill-resolver.md
@@ -62,7 +62,7 @@ From the registry's **Compact Rules** section, copy the matching skill blocks di
 
 This goes BEFORE the sub-agent's task-specific instructions, so standards are loaded before work begins.
 
-**Key rule**: inject the COMPACT RULES text, not paths. The sub-agent should NOT read any SKILL.md files — the rules arrive pre-digested in its prompt.
+**Key rule**: inject the COMPACT RULES text, not paths. The sub-agent still reads its assigned executor/phase skill, but should NOT independently discover or load additional project/user SKILL.md files during normal runtime — those rules arrive pre-digested in its prompt.
 
 ### Step 4: Include Project Conventions
 
@@ -95,8 +95,8 @@ This protocol is compaction-safe because:
 Sub-agents MUST report their skill resolution status in their return envelope:
 
 - `injected` — received `## Project Standards (auto-resolved)` from the orchestrator (ideal path)
-- `fallback-registry` — no standards received, self-loaded from skill registry
-- `fallback-path` — no standards received, loaded via `SKILL: Load` path
+- `fallback-registry` — no standards received, self-loaded compact rules from the skill registry as a degraded self-healing fallback
+- `fallback-path` — no standards received, loaded explicit `SKILL: Load` paths as a degraded self-healing fallback
 - `none` — no skills loaded at all
 
 **Orchestrator self-correction rule**: if a sub-agent reports anything other than `injected`, the orchestrator MUST:

--- a/internal/assets/skills/skill-registry/SKILL.md
+++ b/internal/assets/skills/skill-registry/SKILL.md
@@ -9,7 +9,7 @@ metadata:
 
 ## Purpose
 
-You generate or update the **skill registry** — a catalog of all available skills with **compact rules** (pre-digested, 5-15 line summaries) that any delegator injects directly into sub-agent prompts. Sub-agents do NOT read the registry or individual SKILL.md files — they receive compact rules pre-resolved in their launch prompt.
+You generate or update the **skill registry** — a catalog of all available skills with **compact rules** (pre-digested, 5-15 line summaries) that any delegator injects directly into sub-agent prompts. Sub-agents still read their assigned executor/phase skill. During normal runtime, they do NOT independently discover or load additional project/user SKILL.md files or the registry — they receive compact rules pre-resolved in their launch prompt.
 
 This is the foundation of the **Skill Resolver Protocol** (see `_shared/skill-resolver.md`). The registry is built ONCE (expensive), then read cheaply at every delegation.
 
@@ -98,7 +98,7 @@ Build the registry markdown:
 ```markdown
 # Skill Registry
 
-**Delegator use only.** Any agent that launches sub-agents reads this registry to resolve compact rules, then injects them directly into sub-agent prompts. Sub-agents do NOT read this registry or individual SKILL.md files.
+**Delegator use only.** Any agent that launches sub-agents reads this registry to resolve compact rules, then injects them directly into sub-agent prompts. Sub-agents still read their assigned executor/phase skill. During normal runtime, they do NOT independently discover or load additional project/user SKILL.md files or this registry; explicit fallback loading is degraded self-healing and must be reported in `skill_resolution`.
 
 See `_shared/skill-resolver.md` for the full resolution protocol.
 
@@ -186,7 +186,7 @@ mem_save(
 | {file} | {path} |
 
 ### Next Steps
-The orchestrator reads this registry once per session and passes pre-resolved skill paths to sub-agents via their launch prompts.
+The orchestrator reads this registry once per session and passes pre-resolved compact rules to sub-agents via their launch prompts.
 To update after installing/removing skills, run this again.
 ```
 

--- a/testdata/golden/combined-claude-claudemd.golden
+++ b/testdata/golden/combined-claude-claudemd.golden
@@ -225,7 +225,7 @@ For each sub-agent launch:
 2. Copy matching compact rule blocks into the sub-agent prompt as `## Project Standards (auto-resolved)`
 3. Inject BEFORE the sub-agent's task-specific instructions
 
-**Key rule**: inject compact rules TEXT, not paths. Sub-agents do NOT read SKILL.md files or the registry — rules arrive pre-digested. This is compaction-safe because each delegation re-reads the registry if the cache is lost.
+**Key rule**: inject compact rules TEXT, not paths. Sub-agents still read their assigned executor/phase skill. During normal runtime, they do NOT independently discover or load additional project/user SKILL.md files or the registry — those rules arrive pre-digested. This is compaction-safe because each delegation re-reads the registry if the cache is lost.
 
 ### Skill Resolution Feedback
 
@@ -244,7 +244,7 @@ Sub-agents get a fresh context with NO memory. The orchestrator controls context
 - Read context: orchestrator searches engram (`mem_search`) for relevant prior context and passes it in the sub-agent prompt. Sub-agent does NOT search engram itself.
 - Write context: sub-agent MUST save significant discoveries, decisions, or bug fixes to engram via `mem_save` before returning. Sub-agent has full detail — save before returning, not after.
 - Always add to sub-agent prompt: `"If you make important discoveries, decisions, or fix bugs, save them to engram via mem_save with project: '{project}'."`
-- Skills: orchestrator resolves compact rules from the registry and injects them as `## Project Standards (auto-resolved)` in the sub-agent prompt. Sub-agents do NOT read SKILL.md files or the registry — they receive rules pre-digested.
+- Skills: orchestrator resolves compact rules from the registry and injects them as `## Project Standards (auto-resolved)` in the sub-agent prompt. Sub-agents still read their assigned executor/phase skill. During normal runtime, they do NOT independently discover or load additional project/user SKILL.md files or the registry — those rules arrive pre-digested.
 
 #### SDD Phases
 

--- a/testdata/golden/sdd-claude-agent-sdd-apply.golden
+++ b/testdata/golden/sdd-claude-agent-sdd-apply.golden
@@ -46,4 +46,4 @@ Return a structured result with these fields:
 - `artifacts`: list of files changed and topic_keys updated
 - `next_recommended`: `sdd-verify` (if all tasks done) or `sdd-apply` again (if tasks remain)
 - `risks`: deviations from design, unexpected complexity, or blocked tasks
-- `skill_resolution`: `injected` if compact rules were provided in invocation message, otherwise `none`
+- `skill_resolution`: `injected` if compact rules were provided in the invocation message; `fallback-registry` or `fallback-path` only when explicitly self-healing from a missing Project Standards block; otherwise `none`

--- a/testdata/golden/sdd-claude-agent-sdd-archive.golden
+++ b/testdata/golden/sdd-claude-agent-sdd-archive.golden
@@ -45,4 +45,4 @@ Return a structured result with these fields:
 - `artifacts`: topic_keys or file paths written (e.g. `sdd/{change-name}/archive-report`, archived folder path)
 - `next_recommended`: `none` (change is complete) or a new `/sdd-new` if follow-up is needed
 - `risks`: any artifacts that could not be merged or archived cleanly
-- `skill_resolution`: `injected` if compact rules were provided in invocation message, otherwise `none`
+- `skill_resolution`: `injected` if compact rules were provided in the invocation message; `fallback-registry` or `fallback-path` only when explicitly self-healing from a missing Project Standards block; otherwise `none`

--- a/testdata/golden/sdd-claude-agent-sdd-design.golden
+++ b/testdata/golden/sdd-claude-agent-sdd-design.golden
@@ -42,4 +42,4 @@ Return a structured result with these fields:
 - `artifacts`: topic_keys or file paths written (e.g. `sdd/{change-name}/design`)
 - `next_recommended`: `sdd-tasks` (after spec is also ready)
 - `risks`: architectural risks, unresolved decisions, or assumptions requiring validation
-- `skill_resolution`: `injected` if compact rules were provided in invocation message, otherwise `none`
+- `skill_resolution`: `injected` if compact rules were provided in the invocation message; `fallback-registry` or `fallback-path` only when explicitly self-healing from a missing Project Standards block; otherwise `none`

--- a/testdata/golden/sdd-claude-agent-sdd-explore.golden
+++ b/testdata/golden/sdd-claude-agent-sdd-explore.golden
@@ -42,4 +42,4 @@ Return a structured result with these fields:
 - `artifacts`: topic_keys or file paths written (e.g. `sdd/{change-name}/explore`)
 - `next_recommended`: `sdd-propose` (if tied to a change) or `none` (if standalone)
 - `risks`: risks or blockers discovered during exploration
-- `skill_resolution`: `injected` if compact rules were provided in invocation message, otherwise `none`
+- `skill_resolution`: `injected` if compact rules were provided in the invocation message; `fallback-registry` or `fallback-path` only when explicitly self-healing from a missing Project Standards block; otherwise `none`

--- a/testdata/golden/sdd-claude-agent-sdd-propose.golden
+++ b/testdata/golden/sdd-claude-agent-sdd-propose.golden
@@ -41,4 +41,4 @@ Return a structured result with these fields:
 - `artifacts`: topic_keys or file paths written (e.g. `sdd/{change-name}/proposal`)
 - `next_recommended`: `sdd-spec` and `sdd-design` (can run in parallel)
 - `risks`: open questions, unresolved tradeoffs, or blocking dependencies
-- `skill_resolution`: `injected` if compact rules were provided in invocation message, otherwise `none`
+- `skill_resolution`: `injected` if compact rules were provided in the invocation message; `fallback-registry` or `fallback-path` only when explicitly self-healing from a missing Project Standards block; otherwise `none`

--- a/testdata/golden/sdd-claude-agent-sdd-spec.golden
+++ b/testdata/golden/sdd-claude-agent-sdd-spec.golden
@@ -41,4 +41,4 @@ Return a structured result with these fields:
 - `artifacts`: topic_keys or file paths written (e.g. `sdd/{change-name}/spec`)
 - `next_recommended`: `sdd-tasks` (after design is also ready)
 - `risks`: ambiguities in the proposal that forced spec-level assumptions
-- `skill_resolution`: `injected` if compact rules were provided in invocation message, otherwise `none`
+- `skill_resolution`: `injected` if compact rules were provided in the invocation message; `fallback-registry` or `fallback-path` only when explicitly self-healing from a missing Project Standards block; otherwise `none`

--- a/testdata/golden/sdd-claude-agent-sdd-tasks.golden
+++ b/testdata/golden/sdd-claude-agent-sdd-tasks.golden
@@ -42,4 +42,4 @@ Return a structured result with these fields:
 - `artifacts`: topic_keys or file paths written (e.g. `sdd/{change-name}/tasks`)
 - `next_recommended`: `sdd-apply`
 - `risks`: task dependencies that introduce bottlenecks or unclear ownership
-- `skill_resolution`: `injected` if compact rules were provided in invocation message, otherwise `none`
+- `skill_resolution`: `injected` if compact rules were provided in the invocation message; `fallback-registry` or `fallback-path` only when explicitly self-healing from a missing Project Standards block; otherwise `none`

--- a/testdata/golden/sdd-claude-agent-sdd-verify.golden
+++ b/testdata/golden/sdd-claude-agent-sdd-verify.golden
@@ -41,4 +41,4 @@ Return a structured result with these fields:
 - `artifacts`: topic_keys or file paths written (e.g. `sdd/{change-name}/verify-report`)
 - `next_recommended`: `sdd-archive` (if clean) or `sdd-apply` (if CRITICAL issues found)
 - `risks`: unresolved CRITICAL issues that block archive
-- `skill_resolution`: `injected` if compact rules were provided in invocation message, otherwise `none`
+- `skill_resolution`: `injected` if compact rules were provided in the invocation message; `fallback-registry` or `fallback-path` only when explicitly self-healing from a missing Project Standards block; otherwise `none`

--- a/testdata/golden/sdd-claude-claudemd.golden
+++ b/testdata/golden/sdd-claude-claudemd.golden
@@ -168,7 +168,7 @@ For each sub-agent launch:
 2. Copy matching compact rule blocks into the sub-agent prompt as `## Project Standards (auto-resolved)`
 3. Inject BEFORE the sub-agent's task-specific instructions
 
-**Key rule**: inject compact rules TEXT, not paths. Sub-agents do NOT read SKILL.md files or the registry — rules arrive pre-digested. This is compaction-safe because each delegation re-reads the registry if the cache is lost.
+**Key rule**: inject compact rules TEXT, not paths. Sub-agents still read their assigned executor/phase skill. During normal runtime, they do NOT independently discover or load additional project/user SKILL.md files or the registry — those rules arrive pre-digested. This is compaction-safe because each delegation re-reads the registry if the cache is lost.
 
 ### Skill Resolution Feedback
 
@@ -187,7 +187,7 @@ Sub-agents get a fresh context with NO memory. The orchestrator controls context
 - Read context: orchestrator searches engram (`mem_search`) for relevant prior context and passes it in the sub-agent prompt. Sub-agent does NOT search engram itself.
 - Write context: sub-agent MUST save significant discoveries, decisions, or bug fixes to engram via `mem_save` before returning. Sub-agent has full detail — save before returning, not after.
 - Always add to sub-agent prompt: `"If you make important discoveries, decisions, or fix bugs, save them to engram via mem_save with project: '{project}'."`
-- Skills: orchestrator resolves compact rules from the registry and injects them as `## Project Standards (auto-resolved)` in the sub-agent prompt. Sub-agents do NOT read SKILL.md files or the registry — they receive rules pre-digested.
+- Skills: orchestrator resolves compact rules from the registry and injects them as `## Project Standards (auto-resolved)` in the sub-agent prompt. Sub-agents still read their assigned executor/phase skill. During normal runtime, they do NOT independently discover or load additional project/user SKILL.md files or the registry — those rules arrive pre-digested.
 
 #### SDD Phases
 

--- a/testdata/golden/sdd-codex-agentsmd.golden
+++ b/testdata/golden/sdd-codex-agentsmd.golden
@@ -148,7 +148,7 @@ For each sub-agent launch:
 2. Copy matching compact rule blocks into the sub-agent prompt as `## Project Standards (auto-resolved)`
 3. Inject BEFORE the sub-agent's task-specific instructions
 
-**Key rule**: inject compact rules TEXT, not paths. Sub-agents do NOT read SKILL.md files or the registry — rules arrive pre-digested. This is compaction-safe because each delegation re-reads the registry if the cache is lost.
+**Key rule**: inject compact rules TEXT, not paths. Sub-agents still read their assigned executor/phase skill. During normal runtime, they do NOT independently discover or load additional project/user SKILL.md files or the registry — those rules arrive pre-digested. This is compaction-safe because each delegation re-reads the registry if the cache is lost.
 
 ### Skill Resolution Feedback
 
@@ -167,7 +167,7 @@ Sub-agents get a fresh context with NO memory. The orchestrator controls context
 - Read context: orchestrator searches engram (`mem_search`) for relevant prior context and passes it in the sub-agent prompt. Sub-agent does NOT search engram itself.
 - Write context: sub-agent MUST save significant discoveries, decisions, or bug fixes to engram via `mem_save` before returning. Sub-agent has full detail — save before returning, not after.
 - Always add to sub-agent prompt: `"If you make important discoveries, decisions, or fix bugs, save them to engram via mem_save with project: '{project}'."`
-- Skills: orchestrator resolves compact rules from the registry and injects them as `## Project Standards (auto-resolved)` in the sub-agent prompt. Sub-agents do NOT read SKILL.md files or the registry — they receive rules pre-digested.
+- Skills: orchestrator resolves compact rules from the registry and injects them as `## Project Standards (auto-resolved)` in the sub-agent prompt. Sub-agents still read their assigned executor/phase skill. During normal runtime, they do NOT independently discover or load additional project/user SKILL.md files or the registry — those rules arrive pre-digested.
 
 #### SDD Phases
 

--- a/testdata/golden/sdd-cursor-rules.golden
+++ b/testdata/golden/sdd-cursor-rules.golden
@@ -188,7 +188,7 @@ For each subagent invocation:
 2. Copy matching compact rule blocks into the subagent invocation message as `## Project Standards (auto-resolved)`
 3. Inject BEFORE the subagent's task-specific instructions
 
-**Key rule**: inject compact rules TEXT, not paths. Sub-agents do NOT read SKILL.md files or the registry — rules arrive pre-digested in the invocation message. This is compaction-safe because each delegation re-reads the registry if the cache is lost.
+**Key rule**: inject compact rules TEXT, not paths. Sub-agents still read their assigned executor/phase skill. During normal runtime, they do NOT independently discover or load additional project/user SKILL.md files or the registry — those rules arrive pre-digested in the invocation message. This is compaction-safe because each delegation re-reads the registry if the cache is lost.
 
 ### Skill Resolution Feedback
 
@@ -207,7 +207,7 @@ Sub-agents run in fresh, isolated context windows with NO shared memory. The orc
 - Read context: orchestrator searches engram (`mem_search`) for relevant prior context and passes it in the subagent invocation message. Sub-agent does NOT search engram itself.
 - Write context: sub-agent MUST save significant discoveries, decisions, or bug fixes to engram via `mem_save` before returning. Sub-agent has full detail — save before returning, not after.
 - Always include in invocation message: `"If you make important discoveries, decisions, or fix bugs, save them to engram via mem_save with project: '{project}'."`
-- Skills: orchestrator resolves compact rules from the registry and injects them as `## Project Standards (auto-resolved)` in the invocation message. Sub-agents do NOT read SKILL.md files or the registry — they receive rules pre-digested.
+- Skills: orchestrator resolves compact rules from the registry and injects them as `## Project Standards (auto-resolved)` in the invocation message. Sub-agents still read their assigned executor/phase skill. During normal runtime, they do NOT independently discover or load additional project/user SKILL.md files or the registry — those rules arrive pre-digested.
 
 #### SDD Phases
 

--- a/testdata/golden/sdd-gemini-geminimd.golden
+++ b/testdata/golden/sdd-gemini-geminimd.golden
@@ -148,7 +148,7 @@ For each sub-agent launch:
 2. Copy matching compact rule blocks into the sub-agent prompt as `## Project Standards (auto-resolved)`
 3. Inject BEFORE the sub-agent's task-specific instructions
 
-**Key rule**: inject compact rules TEXT, not paths. Sub-agents do NOT read SKILL.md files or the registry — rules arrive pre-digested. This is compaction-safe because each delegation re-reads the registry if the cache is lost.
+**Key rule**: inject compact rules TEXT, not paths. Sub-agents still read their assigned executor/phase skill. During normal runtime, they do NOT independently discover or load additional project/user SKILL.md files or the registry — those rules arrive pre-digested. This is compaction-safe because each delegation re-reads the registry if the cache is lost.
 
 ### Skill Resolution Feedback
 
@@ -167,7 +167,7 @@ Sub-agents get a fresh context with NO memory. The orchestrator controls context
 - Read context: orchestrator searches engram (`mem_search`) for relevant prior context and passes it in the sub-agent prompt. Sub-agent does NOT search engram itself.
 - Write context: sub-agent MUST save significant discoveries, decisions, or bug fixes to engram via `mem_save` before returning. Sub-agent has full detail — save before returning, not after.
 - Always add to sub-agent prompt: `"If you make important discoveries, decisions, or fix bugs, save them to engram via mem_save with project: '{project}'."`
-- Skills: orchestrator resolves compact rules from the registry and injects them as `## Project Standards (auto-resolved)` in the sub-agent prompt. Sub-agents do NOT read SKILL.md files or the registry — they receive rules pre-digested.
+- Skills: orchestrator resolves compact rules from the registry and injects them as `## Project Standards (auto-resolved)` in the sub-agent prompt. Sub-agents still read their assigned executor/phase skill. During normal runtime, they do NOT independently discover or load additional project/user SKILL.md files or the registry — those rules arrive pre-digested.
 
 #### SDD Phases
 

--- a/testdata/golden/sdd-kiro-agent-sdd-apply.golden
+++ b/testdata/golden/sdd-kiro-agent-sdd-apply.golden
@@ -52,4 +52,4 @@ Return a structured result with these fields:
 - `artifacts`: list of files changed and topic_keys updated
 - `next_recommended`: `sdd-verify` (if all tasks done) or `sdd-apply` again (if tasks remain)
 - `risks`: deviations from design, unexpected complexity, or blocked tasks
-- `skill_resolution`: `injected` if compact rules were provided in invocation message, otherwise `none`
+- `skill_resolution`: `injected` if compact rules were provided in the invocation message; `fallback-registry` or `fallback-path` only when explicitly self-healing from a missing Project Standards block; otherwise `none`

--- a/testdata/golden/sdd-kiro-agent-sdd-archive.golden
+++ b/testdata/golden/sdd-kiro-agent-sdd-archive.golden
@@ -51,4 +51,4 @@ Return a structured result with these fields:
 - `artifacts`: topic_keys or file paths written (e.g. `sdd/{change-name}/archive-report`, archived folder path)
 - `next_recommended`: `none` (change is complete) or a new `/sdd-new` if follow-up is needed
 - `risks`: any artifacts that could not be merged or archived cleanly
-- `skill_resolution`: `injected` if compact rules were provided in invocation message, otherwise `none`
+- `skill_resolution`: `injected` if compact rules were provided in the invocation message; `fallback-registry` or `fallback-path` only when explicitly self-healing from a missing Project Standards block; otherwise `none`

--- a/testdata/golden/sdd-kiro-agent-sdd-design.golden
+++ b/testdata/golden/sdd-kiro-agent-sdd-design.golden
@@ -47,4 +47,4 @@ Return a structured result with these fields:
 - `artifacts`: topic_keys or file paths written (e.g. `sdd/{change-name}/design`)
 - `next_recommended`: `sdd-tasks` (once spec is also done)
 - `risks`: architectural risks, open decisions, or patterns that deviate from existing codebase
-- `skill_resolution`: `injected` if compact rules were provided in invocation message, otherwise `none`
+- `skill_resolution`: `injected` if compact rules were provided in the invocation message; `fallback-registry` or `fallback-path` only when explicitly self-healing from a missing Project Standards block; otherwise `none`

--- a/testdata/golden/sdd-kiro-agent-sdd-explore.golden
+++ b/testdata/golden/sdd-kiro-agent-sdd-explore.golden
@@ -48,4 +48,4 @@ Return a structured result with these fields:
 - `artifacts`: topic_keys or file paths written (e.g. `sdd/{change-name}/explore`)
 - `next_recommended`: `sdd-propose` (if tied to a change) or `none` (if standalone)
 - `risks`: risks or blockers discovered during exploration
-- `skill_resolution`: `injected` if compact rules were provided in invocation message, otherwise `none`
+- `skill_resolution`: `injected` if compact rules were provided in the invocation message; `fallback-registry` or `fallback-path` only when explicitly self-healing from a missing Project Standards block; otherwise `none`

--- a/testdata/golden/sdd-kiro-agent-sdd-init.golden
+++ b/testdata/golden/sdd-kiro-agent-sdd-init.golden
@@ -45,4 +45,4 @@ Return a structured result with these fields:
 - `artifacts`: list of paths or topic_keys written (e.g. `.atl/skill-registry.md`, `sdd-init/{project}`)
 - `next_recommended`: `sdd-explore` or `sdd-new`
 - `risks`: any warnings about the detected stack or persistence backend
-- `skill_resolution`: `injected` if compact rules were provided in invocation message, otherwise `none`
+- `skill_resolution`: `injected` if compact rules were provided in the invocation message; `fallback-registry` or `fallback-path` only when explicitly self-healing from a missing Project Standards block; otherwise `none`

--- a/testdata/golden/sdd-kiro-agent-sdd-onboard.golden
+++ b/testdata/golden/sdd-kiro-agent-sdd-onboard.golden
@@ -45,4 +45,4 @@ Return a structured result with these fields:
 - `artifacts`: list of paths or topic_keys written
 - `next_recommended`: `sdd-new` (to start a real change independently)
 - `risks`: any warnings about the onboarding session
-- `skill_resolution`: `injected` if compact rules were provided in invocation message, otherwise `none`
+- `skill_resolution`: `injected` if compact rules were provided in the invocation message; `fallback-registry` or `fallback-path` only when explicitly self-healing from a missing Project Standards block; otherwise `none`

--- a/testdata/golden/sdd-kiro-agent-sdd-propose.golden
+++ b/testdata/golden/sdd-kiro-agent-sdd-propose.golden
@@ -44,4 +44,4 @@ Return a structured result with these fields:
 - `artifacts`: topic_keys or file paths written (e.g. `sdd/{change-name}/proposal`)
 - `next_recommended`: `sdd-spec` and `sdd-design` (can run in parallel)
 - `risks`: architectural risks or open questions identified during proposal
-- `skill_resolution`: `injected` if compact rules were provided in invocation message, otherwise `none`
+- `skill_resolution`: `injected` if compact rules were provided in the invocation message; `fallback-registry` or `fallback-path` only when explicitly self-healing from a missing Project Standards block; otherwise `none`

--- a/testdata/golden/sdd-kiro-agent-sdd-spec.golden
+++ b/testdata/golden/sdd-kiro-agent-sdd-spec.golden
@@ -45,4 +45,4 @@ Return a structured result with these fields:
 - `artifacts`: topic_keys or file paths written (e.g. `sdd/{change-name}/spec`)
 - `next_recommended`: `sdd-tasks` (once design is also done)
 - `risks`: any ambiguous requirements or missing acceptance criteria
-- `skill_resolution`: `injected` if compact rules were provided in invocation message, otherwise `none`
+- `skill_resolution`: `injected` if compact rules were provided in the invocation message; `fallback-registry` or `fallback-path` only when explicitly self-healing from a missing Project Standards block; otherwise `none`

--- a/testdata/golden/sdd-kiro-agent-sdd-tasks.golden
+++ b/testdata/golden/sdd-kiro-agent-sdd-tasks.golden
@@ -47,4 +47,4 @@ Return a structured result with these fields:
 - `artifacts`: topic_keys or file paths written (e.g. `sdd/{change-name}/tasks`)
 - `next_recommended`: `sdd-apply`
 - `risks`: tasks that are large or have hidden dependencies, phases that may need splitting
-- `skill_resolution`: `injected` if compact rules were provided in invocation message, otherwise `none`
+- `skill_resolution`: `injected` if compact rules were provided in the invocation message; `fallback-registry` or `fallback-path` only when explicitly self-healing from a missing Project Standards block; otherwise `none`

--- a/testdata/golden/sdd-kiro-agent-sdd-verify.golden
+++ b/testdata/golden/sdd-kiro-agent-sdd-verify.golden
@@ -52,4 +52,4 @@ Return a structured result with these fields:
 - `artifacts`: topic_keys or file paths written (e.g. `sdd/{change-name}/verify-report`)
 - `next_recommended`: `sdd-archive` (if PASS) or `sdd-apply` (if FAIL/blockers found)
 - `risks`: CRITICAL issues (must fix) and WARNINGs (should fix)
-- `skill_resolution`: `injected` if compact rules were provided in invocation message, otherwise `none`
+- `skill_resolution`: `injected` if compact rules were provided in the invocation message; `fallback-registry` or `fallback-path` only when explicitly self-healing from a missing Project Standards block; otherwise `none`

--- a/testdata/golden/sdd-vscode-instructions.golden
+++ b/testdata/golden/sdd-vscode-instructions.golden
@@ -172,7 +172,7 @@ For each sub-agent launch:
 2. Copy matching compact rule blocks into the sub-agent prompt as `## Project Standards (auto-resolved)`
 3. Inject BEFORE the sub-agent's task-specific instructions
 
-**Key rule**: inject compact rules TEXT, not paths. Sub-agents do NOT read SKILL.md files or the registry — rules arrive pre-digested. This is compaction-safe because each delegation re-reads the registry if the cache is lost.
+**Key rule**: inject compact rules TEXT, not paths. Sub-agents still read their assigned executor/phase skill. During normal runtime, they do NOT independently discover or load additional project/user SKILL.md files or the registry — those rules arrive pre-digested. This is compaction-safe because each delegation re-reads the registry if the cache is lost.
 
 ### Skill Resolution Feedback
 
@@ -191,7 +191,7 @@ Sub-agents get a fresh context with NO memory. The orchestrator controls context
 - Read context: orchestrator searches engram (`mem_search`) for relevant prior context and passes it in the sub-agent prompt. Sub-agent does NOT search engram itself.
 - Write context: sub-agent MUST save significant discoveries, decisions, or bug fixes to engram via `mem_save` before returning. Sub-agent has full detail — save before returning, not after.
 - Always add to sub-agent prompt: `"If you make important discoveries, decisions, or fix bugs, save them to engram via mem_save with project: '{project}'."`
-- Skills: orchestrator resolves compact rules from the registry and injects them as `## Project Standards (auto-resolved)` in the sub-agent prompt. Sub-agents do NOT read SKILL.md files or the registry — they receive rules pre-digested.
+- Skills: orchestrator resolves compact rules from the registry and injects them as `## Project Standards (auto-resolved)` in the sub-agent prompt. Sub-agents still read their assigned executor/phase skill. During normal runtime, they do NOT independently discover or load additional project/user SKILL.md files or the registry — those rules arrive pre-digested.
 
 #### SDD Phases
 


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #503

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [ ] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [x] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Clarifies that SDD sub-agents still read their assigned executor/phase skill.
- Defines orchestrator-injected compact rules as the normal path for project/user skills.
- Documents `fallback-registry` and `fallback-path` as degraded self-healing behavior that must be reported via `skill_resolution`.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `docs/components.md` | Added the public skill consumption contract. |
| `internal/assets/skills/skill-registry/SKILL.md` | Clarified delegator-only registry use and compact-rule injection contract. |
| `internal/assets/skills/_shared/*.md` | Aligned shared resolver, phase, and persistence docs around phase skills vs project/user skills. |
| `internal/assets/*/sdd-orchestrator.md` | Updated orchestrator instructions across providers. |
| `internal/assets/{claude,cursor,kiro,kimi}/agents/sdd-*.md` | Aligned `skill_resolution` reporting language. |
| `testdata/golden/*.golden` | Regenerated expected assets for changed documentation text. |

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./...
```

**E2E Tests** (Docker required)
```bash
cd e2e && ./docker-test.sh
```

- [x] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Manually tested locally

E2E was attempted locally but Docker daemon was unavailable:

```text
Cannot connect to the Docker daemon at unix:///Users/alanbuscaglia/.docker/run/docker.sock. Is the docker daemon running?
```

---

## 🤖 Automated Checks

The following checks run automatically on this PR:

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | PR should stay within 400 changed lines (`additions + deletions`) or use `size:exception` |
| Check Issue Reference | ⏳ | PR body must contain `Closes/Fixes/Resolves #N` |
| Check Issue Has `status:approved` | ⏳ | Linked issue must have been approved before work began |
| Check PR Has `type:*` Label | ⏳ | Exactly one `type:*` label must be applied |
| Unit Tests | ⏳ | `go test ./...` must pass |
| E2E Tests | ⏳ | `cd e2e && ./docker-test.sh` must pass |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

This keeps the intended two-part model explicit: phase/executor skills are still read by the assigned sub-agent, while project/user skills are normally consumed as orchestrator-digested compact rules.
