### PR TITLE
feat(vscode): enable sub-agent support and SDD orchestrator

### DIFF
--- a/internal/agents/vscode/adapter.go
+++ b/internal/agents/vscode/adapter.go
@@ -133,15 +133,15 @@ func (a *Adapter) CommandsDir(_ string) string {
 }
 
 func (a *Adapter) SupportsSubAgents() bool {
-	return false
+	return true
 }
 
-func (a *Adapter) SubAgentsDir(_ string) string {
-	return ""
+func (a *Adapter) SubAgentsDir(homeDir string) string {
+	return filepath.Join(homeDir, ".copilot", "agents")
 }
 
 func (a *Adapter) EmbeddedSubAgentsDir() string {
-	return ""
+	return "vscode/agents"
 }
 
 func (a *Adapter) SupportsSkills() bool {

--- a/internal/agents/vscode/adapter_test.go
+++ b/internal/agents/vscode/adapter_test.go
@@ -91,3 +91,18 @@ func TestMCPConfigPathUsesVSCodeUserProfile(t *testing.T) {
 		}
 	}
 }
+
+func TestSubAgentCapabilities(t *testing.T) {
+	a := NewAdapter()
+	home := "/tmp/home"
+
+	if !a.SupportsSubAgents() {
+		t.Fatal("SupportsSubAgents() = false, want true")
+	}
+	if got, want := a.SubAgentsDir(home), filepath.Join(home, ".copilot", "agents"); got != want {
+		t.Fatalf("SubAgentsDir() = %q, want %q", got, want)
+	}
+	if got, want := a.EmbeddedSubAgentsDir(), "vscode/agents"; got != want {
+		t.Fatalf("EmbeddedSubAgentsDir() = %q, want %q", got, want)
+	}
+}

--- a/internal/assets/assets.go
+++ b/internal/assets/assets.go
@@ -2,7 +2,7 @@ package assets
 
 import "embed"
 
-//go:embed all:claude all:opencode all:generic all:skills all:gga all:gemini all:codex all:antigravity all:windsurf all:cursor all:kimi all:qwen all:kiro
+//go:embed all:claude all:opencode all:generic all:skills all:gga all:gemini all:codex all:antigravity all:windsurf all:cursor all:kimi all:qwen all:kiro all:vscode
 var FS embed.FS
 
 // MustRead returns the content of an embedded file or panics.

--- a/internal/assets/vscode/sdd-orchestrator.md
+++ b/internal/assets/vscode/sdd-orchestrator.md
@@ -1,10 +1,3 @@
----
-name: Gentle AI Persona
-description: Gentleman persona with SDD orchestration and Engram protocol
-applyTo: "**"
----
-
-<!-- gentle-ai:sdd-orchestrator -->
 # Agent Teams Lite — Orchestrator Instructions (VS Code Copilot)
 
 Bind this to the dedicated `sdd-orchestrator` agent or rule only. Do NOT apply it to executor phase agents such as `sdd-apply` or `sdd-verify`.
@@ -282,4 +275,3 @@ Convention files under `~/.copilot/skills/_shared/` (global) or `.agent/skills/_
 - `engram` → `mem_search(...)` → `mem_get_observation(...)`
 - `openspec` → read `openspec/changes/*/state.yaml`
 - `none` → state not persisted — explain to user
-<!-- /gentle-ai:sdd-orchestrator -->

--- a/internal/components/sdd/inject.go
+++ b/internal/components/sdd/inject.go
@@ -1209,6 +1209,8 @@ func sddOrchestratorAsset(agent model.AgentID) string {
 		return "qwen/sdd-orchestrator.md"
 	case model.AgentKiroIDE:
 		return "kiro/sdd-orchestrator.md"
+	case model.AgentVSCodeCopilot:
+		return "vscode/sdd-orchestrator.md"
 	case model.AgentOpenCode:
 		return "opencode/sdd-orchestrator.md"
 	default:

--- a/internal/components/sdd/inject_test.go
+++ b/internal/components/sdd/inject_test.go
@@ -3082,7 +3082,7 @@ func TestSDDOrchestratorAssetSelection(t *testing.T) {
 		{agent: model.AgentQwenCode, want: "qwen/sdd-orchestrator.md"},
 		{agent: model.AgentClaudeCode, want: "generic/sdd-orchestrator.md"},
 		{agent: model.AgentOpenCode, want: "opencode/sdd-orchestrator.md"},
-		{agent: model.AgentVSCodeCopilot, want: "generic/sdd-orchestrator.md"},
+		{agent: model.AgentVSCodeCopilot, want: "vscode/sdd-orchestrator.md"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #492 *(pending `status:approved` from maintainer)*

---

## 🏷️ PR Type

- [x] `type:feature` — New feature (non-breaking change that adds functionality)

---

## 📝 Summary

Enables VS Code Copilot as a sub-agent capable adapter and adds the VS Code-specific SDD orchestrator instructions.

This is **PR 1 of 3** in a chained approach to split the original #493 (962 additions) into reviewable slices under 400 lines.

---

## 📂 Changes

| File | Change |
|------|--------|
| `internal/agents/vscode/adapter.go` | Flip `SupportsSubAgents() → true`, implement `SubAgentsDir()` and `EmbeddedSubAgentsDir()` |
| `internal/agents/vscode/adapter_test.go` | Unit tests for the three new adapter methods |
| `internal/assets/assets.go` | Add `all:vscode` to embed directive |
| `internal/assets/vscode/sdd-orchestrator.md` | VS Code-specific orchestrator instructions |
| `internal/components/sdd/inject.go` | Add VS Code orchestrator asset case |
| `internal/components/sdd/inject_test.go` | Update assertion: VSCode → `vscode/sdd-orchestrator.md` |
| `testdata/golden/sdd-vscode-instructions.golden` | Updated golden file |

---

## 🧪 Test Plan

- [x] Unit tests pass (`go test ./internal/agents/vscode/... ./internal/components/sdd/...`)
- [x] Adapter methods return correct paths
- [x] Golden file matches new orchestrator content

---

## ✅ Contributor Checklist

- [ ] PR is linked to an issue with `status:approved` *(pending maintainer approval — see note above)*
- [x] I have added the appropriate `type:*` label to this PR *(needs maintainer)*
- [x] Unit tests pass (`go test ./...`)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] My commits do not include `Co-Authored-By` trailers
- [x] PR stays within 400 changed lines (398 / 400)

---

## Chain Context

| Field | Value |
|-------|-------|
| Chain | VS Code Copilot SDD Sub-Agents (#492) |
| Tracker PR | Not needed (stacked to main) |
| Position | 1 of 3 |
| Base | `main` |
| Depends on | None |
| Follow-up | PR 2: First batch sub-agents |
| Review budget | 398 / 400 (additions + deletions) |
| Starts at | Current main |
| Ends with | VS Code adapter is sub-agent capable + orchestrator instructions ready |

### Chain Overview

```text
main
 └── 📍 This PR (adapter + orchestrator)
      └── PR 2 (first 7 sub-agent files)
           └── PR 3 (remaining 5 sub-agents + injection wiring)
```

### Scope
- Includes: Adapter flip, orchestrator instructions, embed directive, injection hook
- Excludes: Sub-agent .agent.md files (PR 2 & 3), injection verification test (PR 3)

### Autonomy
- [x] This PR has one deliverable scope
- [x] This PR can be rolled back without unrelated changes
- [x] Tests cover all new behaviors