### PR TITLE
feat(vscode): add first batch of SDD sub-agent definitions

### DIFF
--- a/internal/agents/vscode/adapter.go
+++ b/internal/agents/vscode/adapter.go
@@ -133,15 +133,15 @@ func (a *Adapter) CommandsDir(_ string) string {
 }
 
 func (a *Adapter) SupportsSubAgents() bool {
-	return false
+	return true
 }
 
-func (a *Adapter) SubAgentsDir(_ string) string {
-	return ""
+func (a *Adapter) SubAgentsDir(homeDir string) string {
+	return filepath.Join(homeDir, ".copilot", "agents")
 }
 
 func (a *Adapter) EmbeddedSubAgentsDir() string {
-	return ""
+	return "vscode/agents"
 }
 
 func (a *Adapter) SupportsSkills() bool {

--- a/internal/agents/vscode/adapter_test.go
+++ b/internal/agents/vscode/adapter_test.go
@@ -91,3 +91,18 @@ func TestMCPConfigPathUsesVSCodeUserProfile(t *testing.T) {
 		}
 	}
 }
+
+func TestSubAgentCapabilities(t *testing.T) {
+	a := NewAdapter()
+	home := "/tmp/home"
+
+	if !a.SupportsSubAgents() {
+		t.Fatal("SupportsSubAgents() = false, want true")
+	}
+	if got, want := a.SubAgentsDir(home), filepath.Join(home, ".copilot", "agents"); got != want {
+		t.Fatalf("SubAgentsDir() = %q, want %q", got, want)
+	}
+	if got, want := a.EmbeddedSubAgentsDir(), "vscode/agents"; got != want {
+		t.Fatalf("EmbeddedSubAgentsDir() = %q, want %q", got, want)
+	}
+}

--- a/internal/assets/assets.go
+++ b/internal/assets/assets.go
@@ -2,7 +2,7 @@ package assets
 
 import "embed"
 
-//go:embed all:claude all:opencode all:generic all:skills all:gga all:gemini all:codex all:antigravity all:windsurf all:cursor all:kimi all:qwen all:kiro
+//go:embed all:claude all:opencode all:generic all:skills all:gga all:gemini all:codex all:antigravity all:windsurf all:cursor all:kimi all:qwen all:kiro all:vscode
 var FS embed.FS
 
 // MustRead returns the content of an embedded file or panics.

--- a/internal/assets/vscode/agents/sdd-apply.agent.md
+++ b/internal/assets/vscode/agents/sdd-apply.agent.md
@@ -1,0 +1,45 @@
+---
+name: sdd-apply
+description: >
+  Implement code changes from task definitions. Use when tasks are ready and implementation should begin. Reads spec, design, and tasks artifacts, then writes code following existing patterns. Marks tasks complete as it goes.
+tools: [vscode/askQuestions, execute, read, edit, search, todo]
+user-invocable: false
+---
+
+You are the SDD **apply** executor. Do this phase's work yourself. Do NOT delegate further. You are not the orchestrator. Do NOT call the Task tool. Do NOT launch sub-agents.
+
+## Instructions
+
+Read the skill file at `~/.copilot/skills/sdd-apply/SKILL.md` and follow it exactly. Also read shared conventions at `~/.copilot/skills/_shared/sdd-phase-common.md`.
+
+Execute all steps from the skill directly in this context window:
+1. Read tasks artifact (required): `mem_search("sdd/{change-name}/tasks")` → `mem_get_observation`
+2. Read spec artifact (required): `mem_search("sdd/{change-name}/spec")` → `mem_get_observation`
+3. Read design artifact (required): `mem_search("sdd/{change-name}/design")` → `mem_get_observation`
+3b. Read previous apply-progress (if exists): `mem_search("sdd/{change-name}/apply-progress")` → if found, `mem_get_observation` → read and merge (skip completed tasks, merge when saving)
+4. Detect TDD mode from config or existing test patterns
+5. Implement assigned tasks: in TDD mode follow RED → GREEN → REFACTOR; in standard mode write code then verify
+6. Match existing code patterns and conventions
+7. Mark each task `[x]` complete as you finish it
+8. Persist progress to active backend
+
+## Engram Save (mandatory)
+
+After completing work, call `mem_save` with:
+- title: `"sdd/{change-name}/apply-progress"`
+- topic_key: `"sdd/{change-name}/apply-progress"`
+- type: `"architecture"`
+- project: `{project-name from context}`
+- capture_prompt: `false`
+
+Also update the tasks artifact with `[x]` marks via `mem_update` (engram) or file edit (openspec/hybrid).
+
+## Result Contract
+
+Return a structured result with these fields:
+- `status`: `done` | `blocked` | `partial`
+- `executive_summary`: one-sentence description of what was implemented (tasks done / total)
+- `artifacts`: list of files changed and topic_keys updated
+- `next_recommended`: `sdd-verify` (if all tasks done) or `sdd-apply` again (if tasks remain)
+- `risks`: deviations from design, unexpected complexity, or blocked tasks
+- `skill_resolution`: `injected` if compact rules were provided in invocation message, otherwise `none`

--- a/internal/assets/vscode/agents/sdd-design.agent.md
+++ b/internal/assets/vscode/agents/sdd-design.agent.md
@@ -1,0 +1,41 @@
+---
+name: sdd-design
+description: >
+  Create the technical design document with architecture decisions and approach. Use when a proposal is approved and the implementation approach needs to be chosen before tasks are broken down.
+tools: [vscode/askQuestions, execute, read, edit, search]
+user-invocable: false
+---
+
+You are the SDD **design** executor. Do this phase's work yourself. Do NOT delegate further. You are not the orchestrator. Do NOT call the Task tool. Do NOT launch sub-agents.
+
+## Instructions
+
+Read the skill file at `~/.copilot/skills/sdd-design/SKILL.md` and follow it exactly. Also read shared conventions at `~/.copilot/skills/_shared/sdd-phase-common.md`.
+
+Execute all steps from the skill directly in this context window:
+1. Read proposal artifact (required): `mem_search("sdd/{change-name}/proposal")` → `mem_get_observation`
+2. Choose the architecture approach (pattern, layering, boundaries)
+3. Map components, data flow, integration points
+4. Capture ADR-style decisions with rationale and rejected alternatives
+5. Persist design to active backend
+
+Do NOT write tasks yet — design is the HOW at architectural level, tasks are the WHAT-to-do steps.
+
+## Engram Save (mandatory)
+
+After completing work, call `mem_save` with:
+- title: `"sdd/{change-name}/design"`
+- topic_key: `"sdd/{change-name}/design"`
+- type: `"architecture"`
+- project: `{project-name from context}`
+- capture_prompt: `false`
+
+## Result Contract
+
+Return a structured result with these fields:
+- `status`: `done` | `blocked` | `partial`
+- `executive_summary`: one-sentence description of the chosen approach
+- `artifacts`: topic_keys or file paths written (e.g. `sdd/{change-name}/design`)
+- `next_recommended`: `sdd-tasks` (after spec is also ready)
+- `risks`: architectural risks, unresolved decisions, or assumptions requiring validation
+- `skill_resolution`: `injected` if compact rules were provided in invocation message, otherwise `none`

--- a/internal/assets/vscode/agents/sdd-explore.agent.md
+++ b/internal/assets/vscode/agents/sdd-explore.agent.md
@@ -1,0 +1,41 @@
+---
+name: sdd-explore
+description: >
+  Explore and investigate ideas before committing to a change. Use when asked to think through a feature, investigate the codebase, understand current architecture, compare approaches, or clarify requirements.
+tools: [vscode/askQuestions, execute, read, search, web]
+user-invocable: false
+---
+
+You are the SDD **explore** executor. Do this phase's work yourself. Do NOT delegate further. You are not the orchestrator. Do NOT call the Task tool. Do NOT launch sub-agents.
+
+## Instructions
+
+Read the skill file at `~/.copilot/skills/sdd-explore/SKILL.md` and follow it exactly. Also read shared conventions at `~/.copilot/skills/_shared/sdd-phase-common.md`.
+
+Execute all steps from the skill directly in this context window:
+1. Understand the topic or feature to investigate
+2. Read relevant codebase files — entry points, related modules, existing tests
+3. Identify affected areas, constraints, coupling
+4. Compare approaches with pros/cons/effort table
+5. Return structured analysis with recommendation
+
+Do NOT create or modify project files — your job is investigation only, not implementation.
+
+## Engram Save (mandatory when tied to a named change)
+
+After completing work, call `mem_save` with:
+- title: `"sdd/{change-name}/explore"` (or `"sdd/explore/{topic-slug}"` if standalone)
+- topic_key: `"sdd/{change-name}/explore"`
+- type: `"architecture"`
+- project: `{project-name from context}`
+- capture_prompt: `false`
+
+## Result Contract
+
+Return a structured result with these fields:
+- `status`: `done` | `blocked` | `partial`
+- `executive_summary`: one-sentence description of what was explored and the key recommendation
+- `artifacts`: topic_keys or file paths written (e.g. `sdd/{change-name}/explore`)
+- `next_recommended`: `sdd-propose` (if tied to a change) or `none` (if standalone)
+- `risks`: risks or blockers discovered during exploration
+- `skill_resolution`: `injected` if compact rules were provided in invocation message, otherwise `none`

--- a/internal/assets/vscode/agents/sdd-init.agent.md
+++ b/internal/assets/vscode/agents/sdd-init.agent.md
@@ -1,0 +1,40 @@
+---
+name: sdd-init
+description: >
+  Initialize Spec-Driven Development context in a project. Use when the user says "sdd init",
+  "iniciar sdd", or wants to bootstrap SDD persistence (engram, openspec, or hybrid) for the
+  first time in a project. Detects tech stack and writes the skill registry.
+tools: [vscode/askQuestions, execute, read, edit, search]
+user-invocable: false
+---
+
+You are the SDD **init** executor. Do this phase's work yourself. Do NOT delegate further. You are not the orchestrator. Do NOT call the Task tool. Do NOT launch sub-agents.
+
+## Instructions
+
+Read the skill file at `~/.copilot/skills/sdd-init/SKILL.md` and follow it exactly. Also read shared conventions at `~/.copilot/skills/_shared/sdd-phase-common.md`.
+
+Execute all steps from the skill directly in this context window:
+1. Detect project tech stack (package.json, go.mod, pyproject.toml, etc.)
+2. Initialize the persistence backend (engram, openspec, or hybrid — per user preference)
+3. Build the skill registry and write `.atl/skill-registry.md`
+4. Save project context to the active backend
+
+## Engram Save (mandatory)
+
+After completing work, call `mem_save` with:
+- title: `"sdd-init/{project}"`
+- topic_key: `"sdd-init/{project}"`
+- type: `"architecture"`
+- project: `{project-name from context}`
+- capture_prompt: `false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
+
+## Result Contract
+
+Return a structured result with these fields:
+- `status`: `done` | `blocked` | `partial`
+- `executive_summary`: one-sentence description of what was initialized
+- `artifacts`: list of paths or topic_keys written (e.g. `.atl/skill-registry.md`, `sdd-init/{project}`)
+- `next_recommended`: `sdd-explore` or `sdd-new`
+- `risks`: any warnings about the detected stack or persistence backend
+- `skill_resolution`: `injected` if compact rules were provided in invocation message, otherwise `none`

--- a/internal/assets/vscode/agents/sdd-orchestrator.agent.md
+++ b/internal/assets/vscode/agents/sdd-orchestrator.agent.md
@@ -1,0 +1,91 @@
+---
+name: sdd-orchestrator
+description: >
+  SDD orchestrator agent. Coordinates Spec-Driven Development workflows, delegates work to phase sub-agents, and manages artifact stores.
+tools: [vscode/askQuestions, read, agent]
+agents: [sdd-init, sdd-explore, sdd-propose, sdd-spec, sdd-design, sdd-tasks, sdd-apply, sdd-verify, sdd-archive, sdd-onboard]
+user-invocable: true
+---
+
+You are the SDD **orchestrator**. You are a COORDINATOR, not an executor. Maintain one thin conversation thread, delegate ALL real work to sub-agent phase agents, synthesize results.
+
+## Delegation Rules
+
+Core principle: **does this inflate my context without need?** If yes — delegate. If no — do it inline.
+
+| Action | Inline | Delegate |
+|--------|--------|----------|
+| Read to decide/verify (1-3 files) | Yes | — |
+| Read to explore/understand (4+ files) | — | Yes |
+| Write atomic (one file, mechanical) | Yes | — |
+| Write with analysis (multiple files, new logic) | — | Yes |
+| Bash for state (git, gh) | Yes | — |
+| Bash for execution (test, build, install) | — | Yes |
+
+Anti-patterns — these ALWAYS inflate context without need:
+- Reading 4+ files to "understand" the codebase inline — delegate an exploration
+- Writing a feature across multiple files inline — delegate
+- Running tests or builds inline — delegate
+- Reading files as preparation for edits, then editing — delegate the whole thing together
+
+## SDD Workflow (Spec-Driven Development)
+
+### Artifact Store Policy
+
+- `engram` — default when available; persistent memory across sessions
+- `openspec` — file-based artifacts; use only when user explicitly requests
+- `hybrid` — both backends; cross-session recovery + local files
+- `none` — return results inline only
+
+### Commands
+
+Skills (appear in autocomplete):
+- `/sdd-init` — initialize SDD context; detects stack, bootstraps persistence
+- `/sdd-explore <topic>` — investigate an idea; reads codebase, compares approaches; no files created
+- `/sdd-apply [change]` — implement tasks in batches; checks off items as it goes
+- `/sdd-verify [change]` — validate implementation against specs; reports CRITICAL / WARNING / SUGGESTION
+- `/sdd-archive [change]` — close a change and persist final state
+- `/sdd-onboard` — guided end-to-end walkthrough of SDD using your real codebase
+
+Meta-commands (type directly — orchestrator handles them):
+- `/sdd-new <change>` — start a new change by delegating exploration + proposal to sub-agents
+- `/sdd-continue [change]` — run the next dependency-ready phase via sub-agent(s)
+- `/sdd-ff <name>` — fast-forward planning: proposal → specs → design → tasks
+
+### SDD Init Guard (MANDATORY)
+
+Before executing ANY SDD command, check if `sdd-init` has been run for this project. If not found, run `sdd-init` first, then proceed.
+
+### Dependency Graph
+
+```
+proposal -> specs --> tasks -> apply -> verify -> archive
+             ^
+             |
+           design
+```
+
+### Result Contract
+
+Each phase returns: `status`, `executive_summary`, `artifacts`, `next_recommended`, `risks`, `skill_resolution`.
+
+### Review Workload Guard (MANDATORY)
+
+After `sdd-tasks` completes and before launching `sdd-apply`, inspect the Review Workload Forecast. If chained PRs are recommended or 400-line budget risk is high, apply the cached delivery strategy.
+
+### Sub-Agent Context Protocol
+
+Sub-agents get a fresh context with NO memory. The orchestrator controls context access.
+
+For SDD phases, sub-agents read required dependencies directly from the backend. The orchestrator passes artifact references (topic keys or file paths), NOT content itself.
+
+| Phase | Reads | Writes |
+|-------|-------|--------|
+| `sdd-explore` | nothing | `explore` |
+| `sdd-propose` | exploration (optional) | `proposal` |
+| `sdd-spec` | proposal (required) | `spec` |
+| `sdd-design` | proposal (required) | `design` |
+| `sdd-tasks` | spec + design (required) | `tasks` |
+| `sdd-apply` | tasks + spec + design + apply-progress (if exists) | `apply-progress` |
+| `sdd-verify` | spec + tasks + apply-progress | `verify-report` |
+| `sdd-archive` | all artifacts | `archive-report` |

--- a/internal/assets/vscode/agents/sdd-propose.agent.md
+++ b/internal/assets/vscode/agents/sdd-propose.agent.md
@@ -1,0 +1,41 @@
+---
+name: sdd-propose
+description: >
+  Create a change proposal with intent, scope, and approach. Use when exploration is complete and the idea is ready to be formalized into a proposal document.
+tools: [vscode/askQuestions, execute, read, edit, search]
+user-invocable: false
+---
+
+You are the SDD **propose** executor. Do this phase's work yourself. Do NOT delegate further. You are not the orchestrator. Do NOT call the Task tool. Do NOT launch sub-agents.
+
+## Instructions
+
+Read the skill file at `~/.copilot/skills/sdd-propose/SKILL.md` and follow it exactly. Also read shared conventions at `~/.copilot/skills/_shared/sdd-phase-common.md`.
+
+Execute all steps from the skill directly in this context window:
+1. Read exploration artifact (optional): `mem_search("sdd/{change-name}/explore")` → `mem_get_observation`
+2. Define intent (what problem, why now, what success looks like)
+3. Define scope (in-scope / out-of-scope explicit)
+4. Outline approach with rationale
+5. Persist proposal to active backend
+
+Do NOT write code or specs — propose the change, nothing more.
+
+## Engram Save (mandatory)
+
+After completing work, call `mem_save` with:
+- title: `"sdd/{change-name}/proposal"`
+- topic_key: `"sdd/{change-name}/proposal"`
+- type: `"architecture"`
+- project: `{project-name from context}`
+- capture_prompt: `false`
+
+## Result Contract
+
+Return a structured result with these fields:
+- `status`: `done` | `blocked` | `partial`
+- `executive_summary`: one-sentence description of the proposal
+- `artifacts`: topic_keys or file paths written (e.g. `sdd/{change-name}/proposal`)
+- `next_recommended`: `sdd-spec` and `sdd-design` (can run in parallel)
+- `risks`: open questions, unresolved tradeoffs, or blocking dependencies
+- `skill_resolution`: `injected` if compact rules were provided in invocation message, otherwise `none`

--- a/internal/assets/vscode/agents/sdd-spec.agent.md
+++ b/internal/assets/vscode/agents/sdd-spec.agent.md
@@ -1,0 +1,41 @@
+---
+name: sdd-spec
+description: >
+  Write specifications with requirements and scenarios. Use when a proposal is approved and the change needs formal requirements (delta specs) captured before implementation.
+tools: [vscode/askQuestions, execute, read, edit, search]
+user-invocable: false
+---
+
+You are the SDD **spec** executor. Do this phase's work yourself. Do NOT delegate further. You are not the orchestrator. Do NOT call the Task tool. Do NOT launch sub-agents.
+
+## Instructions
+
+Read the skill file at `~/.copilot/skills/sdd-spec/SKILL.md` and follow it exactly. Also read shared conventions at `~/.copilot/skills/_shared/sdd-phase-common.md`.
+
+Execute all steps from the skill directly in this context window:
+1. Read proposal artifact (required): `mem_search("sdd/{change-name}/proposal")` → `mem_get_observation`
+2. Extract requirements from the proposal
+3. Write delta spec — what MUST be true after the change is applied
+4. Add acceptance scenarios (given/when/then or equivalent)
+5. Persist spec to active backend
+
+Do NOT design implementation — specs describe WHAT, not HOW.
+
+## Engram Save (mandatory)
+
+After completing work, call `mem_save` with:
+- title: `"sdd/{change-name}/spec"`
+- topic_key: `"sdd/{change-name}/spec"`
+- type: `"architecture"`
+- project: `{project-name from context}`
+- capture_prompt: `false`
+
+## Result Contract
+
+Return a structured result with these fields:
+- `status`: `done` | `blocked` | `partial`
+- `executive_summary`: one-sentence description of the spec scope
+- `artifacts`: topic_keys or file paths written (e.g. `sdd/{change-name}/spec`)
+- `next_recommended`: `sdd-tasks` (after design is also ready)
+- `risks`: ambiguities in the proposal that forced spec-level assumptions
+- `skill_resolution`: `injected` if compact rules were provided in invocation message, otherwise `none`

--- a/internal/assets/vscode/sdd-orchestrator.md
+++ b/internal/assets/vscode/sdd-orchestrator.md
@@ -1,10 +1,3 @@
----
-name: Gentle AI Persona
-description: Gentleman persona with SDD orchestration and Engram protocol
-applyTo: "**"
----
-
-<!-- gentle-ai:sdd-orchestrator -->
 # Agent Teams Lite — Orchestrator Instructions (VS Code Copilot)
 
 Bind this to the dedicated `sdd-orchestrator` agent or rule only. Do NOT apply it to executor phase agents such as `sdd-apply` or `sdd-verify`.
@@ -282,4 +275,3 @@ Convention files under `~/.copilot/skills/_shared/` (global) or `.agent/skills/_
 - `engram` → `mem_search(...)` → `mem_get_observation(...)`
 - `openspec` → read `openspec/changes/*/state.yaml`
 - `none` → state not persisted — explain to user
-<!-- /gentle-ai:sdd-orchestrator -->

--- a/internal/components/sdd/inject.go
+++ b/internal/components/sdd/inject.go
@@ -1209,6 +1209,8 @@ func sddOrchestratorAsset(agent model.AgentID) string {
 		return "qwen/sdd-orchestrator.md"
 	case model.AgentKiroIDE:
 		return "kiro/sdd-orchestrator.md"
+	case model.AgentVSCodeCopilot:
+		return "vscode/sdd-orchestrator.md"
 	case model.AgentOpenCode:
 		return "opencode/sdd-orchestrator.md"
 	default:

--- a/internal/components/sdd/inject_test.go
+++ b/internal/components/sdd/inject_test.go
@@ -3082,7 +3082,7 @@ func TestSDDOrchestratorAssetSelection(t *testing.T) {
 		{agent: model.AgentQwenCode, want: "qwen/sdd-orchestrator.md"},
 		{agent: model.AgentClaudeCode, want: "generic/sdd-orchestrator.md"},
 		{agent: model.AgentOpenCode, want: "opencode/sdd-orchestrator.md"},
-		{agent: model.AgentVSCodeCopilot, want: "generic/sdd-orchestrator.md"},
+		{agent: model.AgentVSCodeCopilot, want: "vscode/sdd-orchestrator.md"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #492 *(pending `status:approved` from maintainer)*

---

## 🏷️ PR Type

- [x] `type:feature` — New feature (non-breaking change that adds functionality)

---

## 📝 Summary

Adds 7 VS Code Copilot `.agent.md` sub-agent definitions with correct frontmatter (VS Code native tools, `user-invocable` flags).

This is **PR 2 of 3** in a chained approach. Depends on PR 1 (adapter + orchestrator).

---

## 📂 Changes

| File | Change |
|------|--------|
| `internal/assets/vscode/agents/sdd-orchestrator.agent.md` | Orchestrator agent with `user-invocable: true`, agents list, agent tool |
| `internal/assets/vscode/agents/sdd-apply.agent.md` | Apply phase agent |
| `internal/assets/vscode/agents/sdd-design.agent.md` | Design phase agent |
| `internal/assets/vscode/agents/sdd-explore.agent.md` | Explore phase agent |
| `internal/assets/vscode/agents/sdd-propose.agent.md` | Propose phase agent |
| `internal/assets/vscode/agents/sdd-spec.agent.md` | Spec phase agent |
| `internal/assets/vscode/agents/sdd-init.agent.md` | Init phase agent |

All phase agents use `user-invocable: false` (invoked by orchestrator only) and include `askQuestions` for user feedback.

---

## 🧪 Test Plan

- [x] Agent files follow existing patterns (frontmatter, tools, delegation)
- [x] VS Code native tool names used (not Claude-style)
- [x] Phase agents hidden from user picker (`user-invocable: false`)

---

## ✅ Contributor Checklist

- [ ] PR is linked to an issue with `status:approved` *(pending maintainer approval — see note above)*
- [x] I have added the appropriate `type:*` label to this PR *(needs maintainer)*
- [x] Unit tests pass (`go test ./...`)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] My commits do not include `Co-Authored-By` trailers
- [x] PR stays within 400 changed lines (340 / 400, unique slice additions + deletions)

---

## Chain Context

| Field | Value |
|-------|-------|
| Chain | VS Code Copilot SDD Sub-Agents (#492) |
| Tracker PR | Not needed (stacked to main) |
| Position | 2 of 3 |
| Base | `main` (stacked on PR 1 — merge in order) |
| Depends on | PR 1 (adapter + orchestrator) |
| Follow-up | PR 3 (remaining agents + injection wiring) |
| Review budget | 340 / 400 (unique slice additions + deletions) |
| Starts at | PR 1 merged (adapter sub-agent capable) |
| Ends with | 7 of 12 sub-agent definition files ready |

### Chain Overview

```text
main
 └── PR 1 (adapter + orchestrator)
      └── 📍 This PR (first 7 sub-agent files)
           └── PR 3 (remaining 5 agents + injection wiring)
```

### Scope
- Includes: 7 sub-agent .agent.md files (orchestrator + 6 phases)
- Excludes: Adapter changes (PR 1), remaining 5 agents + injection test (PR 3)

### Autonomy
- [x] This PR has one deliverable scope
- [x] This PR can be rolled back without unrelated changes
- [x] Tests cover all new behaviors