### PR TITLE
fix(tui): target model configurator sync

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -381,7 +381,7 @@ func tuiUpgrade(profile system.PlatformProfile, homeDir string) tui.UpgradeFunc 
 // so that the "Configure Models" TUI flow persists its choices to disk.
 func tuiSync(homeDir string) tui.SyncFunc {
 	return func(overrides *model.SyncOverrides) (int, error) {
-		agentIDs := cli.DiscoverAgents(homeDir)
+		agentIDs := syncAgentIDs(homeDir, overrides)
 		selection := cli.BuildSyncSelection(cli.SyncFlags{}, agentIDs)
 
 		// Load persisted model assignments so a plain sync (no overrides)
@@ -424,6 +424,23 @@ func tuiUninstallWithProfiles(homeDir string) tui.UninstallWithProfilesFunc {
 		}
 		return cli.RunUninstallWithSelectionAndProfiles(homeDir, workspaceDir, agentIDs, componentIDs, profileNames, engramScope)
 	}
+}
+
+func syncAgentIDs(homeDir string, overrides *model.SyncOverrides) []model.AgentID {
+	if overrides == nil || len(overrides.TargetAgents) == 0 {
+		return cli.DiscoverAgents(homeDir)
+	}
+
+	seen := make(map[model.AgentID]bool, len(overrides.TargetAgents))
+	ids := make([]model.AgentID, 0, len(overrides.TargetAgents))
+	for _, id := range overrides.TargetAgents {
+		if id == "" || seen[id] {
+			continue
+		}
+		seen[id] = true
+		ids = append(ids, id)
+	}
+	return ids
 }
 
 // applyOverrides merges non-nil fields from overrides into selection.
@@ -470,6 +487,11 @@ func loadPersistedAssignments(homeDir string, selection *model.Selection) {
 	if len(selection.ClaudeModelAssignments) == 0 && len(s.ClaudeModelAssignments) > 0 {
 		m := make(map[string]model.ClaudeModelAlias, len(s.ClaudeModelAssignments))
 		for k, v := range s.ClaudeModelAssignments {
+			// Claude Code controls the main session/orchestrator model itself.
+			// Keep persisted assignments scoped to Agent tool calls only.
+			if k == "orchestrator" {
+				continue
+			}
 			m[k] = model.ClaudeModelAlias(v)
 		}
 		selection.ClaudeModelAssignments = m
@@ -522,6 +544,11 @@ func claudeAliasesToStrings(m map[string]model.ClaudeModelAlias) map[string]stri
 	}
 	out := make(map[string]string, len(m))
 	for k, v := range m {
+		// Claude Code owns the main session/orchestrator model; do not persist it
+		// as a Gentle AI model assignment.
+		if k == "orchestrator" {
+			continue
+		}
 		out[k] = string(v)
 	}
 	return out

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -315,6 +315,91 @@ func TestTuiSyncStrictTDDNilOverrideNoChange(t *testing.T) {
 
 func boolPtr(b bool) *bool { return &b }
 
+func TestTuiSyncTargetAgentsOverridePersistedInstallState(t *testing.T) {
+	home := t.TempDir()
+	if err := state.Write(home, state.InstallState{InstalledAgents: []string{string(model.AgentOpenCode)}}); err != nil {
+		t.Fatalf("state.Write: %v", err)
+	}
+
+	got := syncAgentIDs(home, &model.SyncOverrides{
+		TargetAgents: []model.AgentID{model.AgentClaudeCode, model.AgentClaudeCode, ""},
+	})
+
+	if len(got) != 1 || got[0] != model.AgentClaudeCode {
+		t.Fatalf("syncAgentIDs() = %v, want [%s]", got, model.AgentClaudeCode)
+	}
+}
+
+func TestTuiSyncTargetAgentsFallsBackToDiscoveredAgents(t *testing.T) {
+	home := t.TempDir()
+	if err := state.Write(home, state.InstallState{InstalledAgents: []string{string(model.AgentOpenCode)}}); err != nil {
+		t.Fatalf("state.Write: %v", err)
+	}
+
+	got := syncAgentIDs(home, nil)
+
+	if len(got) != 1 || got[0] != model.AgentOpenCode {
+		t.Fatalf("syncAgentIDs(nil) = %v, want [%s]", got, model.AgentOpenCode)
+	}
+}
+
+func TestTuiSyncClaudeModelConfigWritesSelectedAssignments(t *testing.T) {
+	home := t.TempDir()
+	if err := state.Write(home, state.InstallState{InstalledAgents: []string{string(model.AgentPi)}}); err != nil {
+		t.Fatalf("state.Write: %v", err)
+	}
+
+	assignments := map[string]model.ClaudeModelAlias{
+		"sdd-explore": model.ClaudeModelHaiku,
+		"sdd-propose": model.ClaudeModelHaiku,
+		"sdd-spec":    model.ClaudeModelHaiku,
+		"sdd-design":  model.ClaudeModelHaiku,
+		"sdd-tasks":   model.ClaudeModelHaiku,
+		"sdd-apply":   model.ClaudeModelHaiku,
+		"sdd-verify":  model.ClaudeModelHaiku,
+		"sdd-archive": model.ClaudeModelHaiku,
+		"default":     model.ClaudeModelHaiku,
+	}
+
+	changed, err := tuiSync(home)(&model.SyncOverrides{
+		TargetAgents:           []model.AgentID{model.AgentClaudeCode},
+		ClaudeModelAssignments: assignments,
+	})
+	if err != nil {
+		t.Fatalf("tuiSync Claude model config error: %v", err)
+	}
+	if changed == 0 {
+		t.Fatal("tuiSync Claude model config changed 0 files, want Claude assets written")
+	}
+
+	applyAgent := filepath.Join(home, ".claude", "agents", "sdd-apply.md")
+	body, err := os.ReadFile(applyAgent)
+	if err != nil {
+		t.Fatalf("ReadFile(%s): %v", applyAgent, err)
+	}
+	if !strings.Contains(string(body), "model: haiku") {
+		t.Fatalf("sdd-apply agent did not receive selected model; got:\n%s", body)
+	}
+
+	claudeMD := filepath.Join(home, ".claude", "CLAUDE.md")
+	body, err = os.ReadFile(claudeMD)
+	if err != nil {
+		t.Fatalf("ReadFile(%s): %v", claudeMD, err)
+	}
+	if strings.Contains(string(body), "| orchestrator |") {
+		t.Fatalf("CLAUDE.md should not expose orchestrator as a configurable model row; got:\n%s", body)
+	}
+	for _, want := range []string{
+		"| sdd-apply | haiku | Implementation |",
+		"| default | haiku | Non-SDD general delegation |",
+		"Gentle AI does not configure the main orchestrator model",
+	} {
+		if !strings.Contains(string(body), want) {
+			t.Fatalf("CLAUDE.md missing %q; got:\n%s", want, body)
+		}
+	}
+}
+
 // TestApplyOverrides_KiroModelAssignments verifies that a non-nil KiroModelAssignments
 // override replaces the entire KiroModelAssignments map in the selection (same
 // replacement semantics as ClaudeModelAssignments — not a key-level merge).
@@ -367,8 +452,8 @@ func TestLoadPersistedAssignmentsPopulatesEmptySelection(t *testing.T) {
 	selection := model.Selection{}
 	loadPersistedAssignments(home, &selection)
 
-	if got := selection.ClaudeModelAssignments["orchestrator"]; got != "opus" {
-		t.Errorf("ClaudeModelAssignments[orchestrator] = %q, want %q", got, "opus")
+	if _, exists := selection.ClaudeModelAssignments["orchestrator"]; exists {
+		t.Errorf("ClaudeModelAssignments should not load persisted orchestrator model: %v", selection.ClaudeModelAssignments)
 	}
 	if got := selection.ClaudeModelAssignments["sdd-apply"]; got != "sonnet" {
 		t.Errorf("ClaudeModelAssignments[sdd-apply] = %q, want %q", got, "sonnet")
@@ -393,7 +478,7 @@ func TestLoadPersistedAssignmentsDoesNotOverrideExisting(t *testing.T) {
 
 	// Seed state with "old" assignments.
 	err := state.Write(home, state.InstallState{
-		ClaudeModelAssignments: map[string]string{"orchestrator": "haiku"},
+		ClaudeModelAssignments: map[string]string{"sdd-apply": "haiku"},
 		ModelAssignments: map[string]state.ModelAssignmentState{
 			"sdd-init": {ProviderID: "google", ModelID: "gemini-pro"},
 		},
@@ -405,7 +490,7 @@ func TestLoadPersistedAssignmentsDoesNotOverrideExisting(t *testing.T) {
 	// Selection already has assignments from the TUI configure flow.
 	selection := model.Selection{
 		ClaudeModelAssignments: map[string]model.ClaudeModelAlias{
-			"orchestrator": "opus",
+			"sdd-apply": "opus",
 		},
 		ModelAssignments: map[string]model.ModelAssignment{
 			"sdd-init": {ProviderID: "anthropic", ModelID: "claude-sonnet-4"},
@@ -414,8 +499,8 @@ func TestLoadPersistedAssignmentsDoesNotOverrideExisting(t *testing.T) {
 	loadPersistedAssignments(home, &selection)
 
 	// Existing values must be preserved, NOT overwritten.
-	if got := selection.ClaudeModelAssignments["orchestrator"]; got != "opus" {
-		t.Errorf("ClaudeModelAssignments[orchestrator] = %q, want %q (should not be overwritten)", got, "opus")
+	if got := selection.ClaudeModelAssignments["sdd-apply"]; got != "opus" {
+		t.Errorf("ClaudeModelAssignments[sdd-apply] = %q, want %q (should not be overwritten)", got, "opus")
 	}
 	ma := selection.ModelAssignments["sdd-init"]
 	if ma.ProviderID != "anthropic" {
@@ -439,6 +524,7 @@ func TestPersistAssignmentsPreservesInstalledAgents(t *testing.T) {
 	selection := model.Selection{
 		ClaudeModelAssignments: map[string]model.ClaudeModelAlias{
 			"orchestrator": "opus",
+			"sdd-apply":    "sonnet",
 		},
 	}
 	persistAssignments(home, selection)
@@ -451,8 +537,11 @@ func TestPersistAssignmentsPreservesInstalledAgents(t *testing.T) {
 	if len(got.InstalledAgents) != 2 {
 		t.Fatalf("InstalledAgents = %v, want [claude-code opencode]", got.InstalledAgents)
 	}
-	if got.ClaudeModelAssignments["orchestrator"] != "opus" {
-		t.Errorf("ClaudeModelAssignments[orchestrator] = %q, want %q", got.ClaudeModelAssignments["orchestrator"], "opus")
+	if _, exists := got.ClaudeModelAssignments["orchestrator"]; exists {
+		t.Errorf("ClaudeModelAssignments should not persist orchestrator model: %v", got.ClaudeModelAssignments)
+	}
+	if got.ClaudeModelAssignments["sdd-apply"] != "sonnet" {
+		t.Errorf("ClaudeModelAssignments[sdd-apply] = %q, want %q", got.ClaudeModelAssignments["sdd-apply"], "sonnet")
 	}
 }
 

--- a/internal/assets/assets_test.go
+++ b/internal/assets/assets_test.go
@@ -472,7 +472,11 @@ func TestSDDOrchestratorAssetsScopedToDedicatedAgent(t *testing.T) {
 			if assetPath == "opencode/sdd-orchestrator.md" {
 				dedicatedAgent = "gentle-orchestrator"
 			}
-			if !strings.Contains(content, "dedicated `"+dedicatedAgent+"`") {
+			if assetPath == "claude/sdd-orchestrator.md" {
+				if !strings.Contains(content, "Claude Code orchestrator rule") {
+					t.Fatalf("%q missing Claude rule scoping note", assetPath)
+				}
+			} else if !strings.Contains(content, "dedicated `"+dedicatedAgent+"`") {
 				t.Fatalf("%q missing dedicated-agent scoping note", assetPath)
 			}
 			if !strings.Contains(content, "Do NOT apply it to executor phase agents") {

--- a/internal/assets/claude/commands/sdd-continue.md
+++ b/internal/assets/claude/commands/sdd-continue.md
@@ -2,10 +2,11 @@
 description: Continue the next SDD phase in the dependency chain
 ---
 
-If the native `sdd-orchestrator` agent is available, delegate this command to it.
-Otherwise, follow the SDD orchestrator workflow inline using the instructions already installed in `~/.claude/CLAUDE.md`.
+Follow the SDD orchestrator workflow inline using the instructions already installed in `~/.claude/CLAUDE.md`.
+The Claude Code session model is controlled by Claude Code; Gentle AI only configures models for Agent tool calls to phase sub-agents.
 
 WORKFLOW:
+
 1. Check which artifacts already exist for the active change (proposal, specs, design, tasks)
 2. Determine the next phase needed based on the dependency graph:
    proposal → [specs ∥ design] → tasks → apply → verify → archive
@@ -13,6 +14,7 @@ WORKFLOW:
 4. Present the result and ask the user to proceed
 
 CONTEXT:
+
 - Working directory: !`echo -n "$(pwd)"`
 - Current project: !`echo -n "$(basename $(pwd))"`
 - Change name: $ARGUMENTS

--- a/internal/assets/claude/commands/sdd-ff.md
+++ b/internal/assets/claude/commands/sdd-ff.md
@@ -2,11 +2,12 @@
 description: Fast-forward all SDD planning phases — proposal through tasks
 ---
 
-If the native `sdd-orchestrator` agent is available, delegate this command to it.
-Otherwise, follow the SDD orchestrator workflow inline using the instructions already installed in `~/.claude/CLAUDE.md`.
+Follow the SDD orchestrator workflow inline using the instructions already installed in `~/.claude/CLAUDE.md`.
+The Claude Code session model is controlled by Claude Code; Gentle AI only configures models for Agent tool calls to phase sub-agents.
 
 WORKFLOW:
 Run these sub-agents in sequence:
+
 1. `sdd-propose` — create the proposal
 2. `sdd-spec` — write specifications
 3. `sdd-design` — create technical design
@@ -15,6 +16,7 @@ Run these sub-agents in sequence:
 Present a combined summary after ALL phases complete (not between each one).
 
 CONTEXT:
+
 - Working directory: !`echo -n "$(pwd)"`
 - Current project: !`echo -n "$(basename $(pwd))"`
 - Change name: $ARGUMENTS

--- a/internal/assets/claude/commands/sdd-new.md
+++ b/internal/assets/claude/commands/sdd-new.md
@@ -2,16 +2,18 @@
 description: Start a new SDD change — runs exploration then creates a proposal
 ---
 
-If the native `sdd-orchestrator` agent is available, delegate this command to it.
-Otherwise, follow the SDD orchestrator workflow inline using the instructions already installed in `~/.claude/CLAUDE.md`.
+Follow the SDD orchestrator workflow inline using the instructions already installed in `~/.claude/CLAUDE.md`.
+The Claude Code session model is controlled by Claude Code; Gentle AI only configures models for Agent tool calls to phase sub-agents.
 
 WORKFLOW:
+
 1. Launch `sdd-explore` to investigate the codebase for this change
 2. Present the exploration summary to the user
 3. Launch `sdd-propose` to create a proposal based on the exploration
 4. Present the proposal summary and ask the user if they want to continue with specs and design
 
 CONTEXT:
+
 - Working directory: !`echo -n "$(pwd)"`
 - Current project: !`echo -n "$(basename $(pwd))"`
 - Change name: $ARGUMENTS

--- a/internal/assets/claude/sdd-orchestrator.md
+++ b/internal/assets/claude/sdd-orchestrator.md
@@ -1,6 +1,6 @@
 # Agent Teams Lite — Orchestrator Instructions
 
-Bind this to the dedicated `sdd-orchestrator` agent or rule only. Do NOT apply it to executor phase agents such as `sdd-apply` or `sdd-verify`.
+Bind this to the Claude Code orchestrator rule only. Do NOT apply it to executor phase agents such as `sdd-apply` or `sdd-verify`.
 
 ## Agent Teams Orchestrator
 
@@ -10,19 +10,20 @@ You are a COORDINATOR, not an executor. Maintain one thin conversation thread, d
 
 Core principle: **does this inflate my context without need?** If yes → delegate. If no → do it inline.
 
-| Action | Inline | Delegate |
-|--------|--------|----------|
-| Read to decide/verify (1-3 files) | ✅ | — |
-| Read to explore/understand (4+ files) | — | ✅ |
-| Read as preparation for writing | — | ✅ together with the write |
-| Write atomic (one file, mechanical, you already know what) | ✅ | — |
-| Write with analysis (multiple files, new logic) | — | ✅ |
-| Bash for state (git, gh) | ✅ | — |
-| Bash for execution (test, build, install) | — | ✅ |
+| Action                                                     | Inline | Delegate                   |
+| ---------------------------------------------------------- | ------ | -------------------------- |
+| Read to decide/verify (1-3 files)                          | ✅     | —                          |
+| Read to explore/understand (4+ files)                      | —      | ✅                         |
+| Read as preparation for writing                            | —      | ✅ together with the write |
+| Write atomic (one file, mechanical, you already know what) | ✅     | —                          |
+| Write with analysis (multiple files, new logic)            | —      | ✅                         |
+| Bash for state (git, gh)                                   | ✅     | —                          |
+| Bash for execution (test, build, install)                  | —      | ✅                         |
 
 delegate (async) is the default for delegated work. Use task (sync) only when you need the result before your next action.
 
 Anti-patterns — these ALWAYS inflate context without need:
+
 - Reading 4+ files to "understand" the codebase inline → delegate an exploration
 - Writing a feature across multiple files inline → delegate
 - Running tests or builds inline → delegate
@@ -48,7 +49,6 @@ These are parent-orchestrator stop rules. Once any trigger fires, the orchestrat
 - Use fresh reviewers after implementation, conflict resolution, or incidents because their value is independent judgment, not token saving.
 - Avoid delegation for truly local one-file fixes, quick state checks, and already-understood mechanical edits.
 
-
 ## SDD Workflow (Spec-Driven Development)
 
 SDD is the structured planning layer for substantial changes.
@@ -63,14 +63,16 @@ SDD is the structured planning layer for substantial changes.
 ### Commands
 
 Skills (appear in autocomplete):
+
 - `/sdd-init` → initialize SDD context; detects stack, bootstraps persistence
 - `/sdd-explore <topic>` → investigate an idea; reads codebase, compares approaches; no files created
 - `/sdd-apply [change]` → implement tasks in batches; checks off items as it goes
 - `/sdd-verify [change]` → validate implementation against specs; reports CRITICAL / WARNING / SUGGESTION
-- `/sdd-archive [change]` → close a change and persist final state in the active artifact store 
+- `/sdd-archive [change]` → close a change and persist final state in the active artifact store
 - `/sdd-onboard` → guided end-to-end walkthrough of SDD using your real codebase
 
 Meta-commands (type directly — orchestrator handles them, won't appear in autocomplete):
+
 - `/sdd-new <change>` → start a new change by delegating exploration + proposal to sub-agents
 - `/sdd-continue [change]` → run the next dependency-ready phase via sub-agent(s)
 - `/sdd-ff <name>` → fast-forward planning: proposal → specs → design → tasks
@@ -86,6 +88,7 @@ Before executing ANY SDD command (`/sdd-new`, `/sdd-ff`, `/sdd-continue`, `/sdd-
 3. If NOT found → run `sdd-init` FIRST (delegate to sdd-init sub-agent), THEN proceed with the requested command
 
 This ensures:
+
 - Testing capabilities are always detected and cached
 - Strict TDD Mode is activated when the project supports it
 - The project context (stack, conventions) is available for all phases
@@ -104,6 +107,7 @@ If the user doesn't specify, default to **Interactive** (safer, gives the user c
 Cache the mode choice for the session — don't ask again unless the user explicitly requests a mode change.
 
 In **Interactive** mode, between phases:
+
 1. Show a concise summary of what the phase produced
 2. List what the next phase will do
 3. Ask: "¿Continuamos? / Continue?" — accept YES/continue, NO/stop, or specific feedback to adjust
@@ -128,6 +132,7 @@ Cache the artifact store choice for the session. Pass it as `artifact_store.mode
 On the first `/sdd-new`, `/sdd-ff`, or `/sdd-continue` (or an equivalent natural-language request) in a session, ask once for and cache delivery strategy: `ask-on-risk` (default), `auto-chain`, `single-pr`, or `exception-ok`. Pass it as `delivery_strategy` to `sdd-tasks` and `sdd-apply` prompts.
 
 ### Dependency Graph
+
 ```
 proposal -> specs --> tasks -> apply -> verify -> archive
              ^
@@ -136,6 +141,7 @@ proposal -> specs --> tasks -> apply -> verify -> archive
 ```
 
 ### Result Contract
+
 Each phase returns: `status`, `executive_summary`, `artifacts`, `next_recommended`, `risks`, `skill_resolution`.
 
 ### Review Workload Guard (MANDATORY)
@@ -152,22 +158,26 @@ If it says `Chained PRs recommended: Yes`, `400-line budget risk: High`, estimat
 Automatic mode does not override this guard. Always pass the resolved delivery strategy to `sdd-apply`.
 
 <!-- gentle-ai:sdd-model-assignments -->
+
 ## Model Assignments
 
 Read this table at session start (or before first delegation), cache it for the session, and pass the mapped alias in every Agent tool call via the `model` parameter. If a phase is missing, use the `default` row. If you lack access to the assigned model, substitute `sonnet` and continue.
 
-| Phase | Default Model | Reason |
-|-------|---------------|--------|
-| orchestrator | opus | Coordinates, makes decisions |
-| sdd-explore | sonnet | Reads code, structural - not architectural |
-| sdd-propose | opus | Architectural decisions |
-| sdd-spec | sonnet | Structured writing |
-| sdd-design | opus | Architecture decisions |
-| sdd-tasks | sonnet | Mechanical breakdown |
-| sdd-apply | sonnet | Implementation |
-| sdd-verify | sonnet | Validation against spec |
-| sdd-archive | haiku | Copy and close |
-| default | sonnet | Non-SDD general delegation |
+The Claude Code session model is controlled by Claude Code itself; Gentle AI does not configure the main orchestrator model. This table applies only to Agent tool calls for SDD phase sub-agents and general delegation.
+
+**Mandatory model gate:** Every Agent tool call MUST include `model`. Calling Agent without `model` is invalid. Before each Agent call, resolve the target phase to an alias from this table; for general/non-SDD delegation use `default`. If you are about to call Agent and have not chosen a `model`, STOP and choose the mapped alias first.
+
+| Phase       | Default Model | Reason                                     |
+| ----------- | ------------- | ------------------------------------------ |
+| sdd-explore | sonnet        | Reads code, structural - not architectural |
+| sdd-propose | opus          | Architectural decisions                    |
+| sdd-spec    | sonnet        | Structured writing                         |
+| sdd-design  | opus          | Architecture decisions                     |
+| sdd-tasks   | sonnet        | Mechanical breakdown                       |
+| sdd-apply   | sonnet        | Implementation                             |
+| sdd-verify  | sonnet        | Validation against spec                    |
+| sdd-archive | haiku         | Copy and close                             |
+| default     | sonnet        | Non-SDD general delegation                 |
 
 <!-- /gentle-ai:sdd-model-assignments -->
 
@@ -175,15 +185,24 @@ Read this table at session start (or before first delegation), cache it for the 
 
 ALL sub-agent launch prompts that involve reading, writing, or reviewing code MUST include pre-resolved **compact rules** from the skill registry. Follow the **Skill Resolver Protocol** (`~/.claude/skills/_shared/skill-resolver.md`).
 
+**Pre-flight before every Agent call (mandatory):**
+
+1. Identify the phase key (`sdd-apply`, `sdd-verify`, etc.) or use `default` for general delegation.
+2. Look up the alias in the Model Assignments table.
+3. Include `model: "<alias>"` in the Agent tool call.
+4. If `model` is absent, do not send the Agent call.
+
 The orchestrator resolves skills from the registry ONCE (at session start or first delegation), caches the compact rules, and injects matching rules into each sub-agent's prompt. Also reads the Model Assignments table once per session, caches `phase → alias`, includes that alias in every Agent tool call via `model`.
 
 Orchestrator skill resolution (do once per session):
+
 1. `mem_search(query: "skill-registry", project: "{project}")` → `mem_get_observation(id)` for full registry content
 2. Fallback: read `.atl/skill-registry.md` if engram not available
 3. Cache the **Compact Rules** section and the **User Skills** trigger table
 4. If no registry exists, warn user and proceed without project-specific standards
 
 For each sub-agent launch:
+
 1. Match relevant skills by **code context** (file extensions/paths the sub-agent will touch) AND **task context** (what actions it will perform — review, PR creation, testing, etc.)
 2. Copy matching compact rule blocks into the sub-agent prompt as `## Project Standards (auto-resolved)`
 3. Inject BEFORE the sub-agent's task-specific instructions
@@ -193,6 +212,7 @@ For each sub-agent launch:
 ### Skill Resolution Feedback
 
 After every delegation that returns a result, check the `skill_resolution` field:
+
 - `injected` → all good, skills were passed correctly
 - `fallback-registry`, `fallback-path`, or `none` → skill cache was lost (likely compaction). Re-read the registry immediately and inject compact rules in all subsequent delegations.
 
@@ -213,16 +233,16 @@ Sub-agents get a fresh context with NO memory. The orchestrator controls context
 
 Each phase has explicit read/write rules:
 
-| Phase | Reads | Writes |
-|-------|-------|--------|
-| `sdd-explore` | nothing | `explore` |
-| `sdd-propose` | exploration (optional) | `proposal` |
-| `sdd-spec` | proposal (required) | `spec` |
-| `sdd-design` | proposal (required) | `design` |
-| `sdd-tasks` | spec + design (required) | `tasks` |
-| `sdd-apply` | tasks + spec + design + **apply-progress (if exists)** | `apply-progress` |
-| `sdd-verify` | spec + tasks + **apply-progress** | `verify-report` |
-| `sdd-archive` | all artifacts | `archive-report` |
+| Phase         | Reads                                                  | Writes           |
+| ------------- | ------------------------------------------------------ | ---------------- |
+| `sdd-explore` | nothing                                                | `explore`        |
+| `sdd-propose` | exploration (optional)                                 | `proposal`       |
+| `sdd-spec`    | proposal (required)                                    | `spec`           |
+| `sdd-design`  | proposal (required)                                    | `design`         |
+| `sdd-tasks`   | spec + design (required)                               | `tasks`          |
+| `sdd-apply`   | tasks + spec + design + **apply-progress (if exists)** | `apply-progress` |
+| `sdd-verify`  | spec + tasks + **apply-progress**                      | `verify-report`  |
+| `sdd-archive` | all artifacts                                          | `archive-report` |
 
 For phases with required dependencies, sub-agent reads directly from the backend — orchestrator passes artifact references (topic keys or file paths), NOT content itself.
 
@@ -250,20 +270,21 @@ This prevents progress loss across batches. The sub-agent is responsible for rea
 
 #### Engram Topic Key Format
 
-| Artifact | Topic Key |
-|----------|-----------|
-| Project context | `sdd-init/{project}` |
-| Exploration | `sdd/{change-name}/explore` |
-| Proposal | `sdd/{change-name}/proposal` |
-| Spec | `sdd/{change-name}/spec` |
-| Design | `sdd/{change-name}/design` |
-| Tasks | `sdd/{change-name}/tasks` |
-| Apply progress | `sdd/{change-name}/apply-progress` |
-| Verify report | `sdd/{change-name}/verify-report` |
-| Archive report | `sdd/{change-name}/archive-report` |
-| DAG state | `sdd/{change-name}/state` |
+| Artifact        | Topic Key                          |
+| --------------- | ---------------------------------- |
+| Project context | `sdd-init/{project}`               |
+| Exploration     | `sdd/{change-name}/explore`        |
+| Proposal        | `sdd/{change-name}/proposal`       |
+| Spec            | `sdd/{change-name}/spec`           |
+| Design          | `sdd/{change-name}/design`         |
+| Tasks           | `sdd/{change-name}/tasks`          |
+| Apply progress  | `sdd/{change-name}/apply-progress` |
+| Verify report   | `sdd/{change-name}/verify-report`  |
+| Archive report  | `sdd/{change-name}/archive-report` |
+| DAG state       | `sdd/{change-name}/state`          |
 
 Sub-agents retrieve full content via two steps:
+
 1. `mem_search(query: "{topic_key}", project: "{project}")` → get observation ID
 2. `mem_get_observation(id: {id})` → full content (REQUIRED — search results are truncated)
 

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1312,6 +1312,11 @@ func claudeAliasesToStrings(m map[string]model.ClaudeModelAlias) map[string]stri
 	}
 	out := make(map[string]string, len(m))
 	for k, v := range m {
+		// Claude Code owns the main session/orchestrator model; do not persist it
+		// as a Gentle AI model assignment.
+		if k == "orchestrator" {
+			continue
+		}
 		out[k] = string(v)
 	}
 	return out

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -801,6 +801,11 @@ func RunSync(args []string) (SyncResult, error) {
 			if len(selection.ClaudeModelAssignments) == 0 && len(s.ClaudeModelAssignments) > 0 {
 				m := make(map[string]model.ClaudeModelAlias, len(s.ClaudeModelAssignments))
 				for k, v := range s.ClaudeModelAssignments {
+					// Claude Code controls the main session/orchestrator model itself.
+					// Keep persisted assignments scoped to Agent tool calls only.
+					if k == "orchestrator" {
+						continue
+					}
 					m[k] = model.ClaudeModelAlias(v)
 				}
 				selection.ClaudeModelAssignments = m

--- a/internal/cli/sync_test.go
+++ b/internal/cli/sync_test.go
@@ -2024,9 +2024,10 @@ func TestRunSyncLoadsPersistedModelAssignments(t *testing.T) {
 		t.Fatalf("RunSync() error = %v", err)
 	}
 
-	// Claude assignments must be loaded.
-	if got := result.Selection.ClaudeModelAssignments["orchestrator"]; got != "opus" {
-		t.Errorf("ClaudeModelAssignments[orchestrator] = %q, want %q", got, "opus")
+	// Claude assignments must be loaded, excluding the main orchestrator model
+	// because Claude Code controls the session model itself.
+	if _, exists := result.Selection.ClaudeModelAssignments["orchestrator"]; exists {
+		t.Errorf("ClaudeModelAssignments should not load persisted orchestrator model: %v", result.Selection.ClaudeModelAssignments)
 	}
 	if got := result.Selection.ClaudeModelAssignments["sdd-apply"]; got != "sonnet" {
 		t.Errorf("ClaudeModelAssignments[sdd-apply] = %q, want %q", got, "sonnet")
@@ -2067,7 +2068,7 @@ func TestRunSyncDoesNotOverridePersistedAssignmentsOnSecondSync(t *testing.T) {
 	err := state.Write(home, state.InstallState{
 		InstalledAgents: []string{"opencode"},
 		ClaudeModelAssignments: map[string]string{
-			"orchestrator": "opus",
+			"sdd-apply": "sonnet",
 		},
 		ModelAssignments: map[string]state.ModelAssignmentState{
 			"sdd-init": {ProviderID: "anthropic", ModelID: "claude-sonnet-4"},
@@ -2089,8 +2090,8 @@ func TestRunSyncDoesNotOverridePersistedAssignmentsOnSecondSync(t *testing.T) {
 		t.Fatalf("RunSync(2) error = %v", err)
 	}
 
-	if got := result.Selection.ClaudeModelAssignments["orchestrator"]; got != "opus" {
-		t.Errorf("After second sync: ClaudeModelAssignments[orchestrator] = %q, want %q", got, "opus")
+	if got := result.Selection.ClaudeModelAssignments["sdd-apply"]; got != "sonnet" {
+		t.Errorf("After second sync: ClaudeModelAssignments[sdd-apply] = %q, want %q", got, "sonnet")
 	}
 	ma := result.Selection.ModelAssignments["sdd-init"]
 	if ma.ProviderID != "anthropic" || ma.ModelID != "claude-sonnet-4" {

--- a/internal/components/sdd/inject.go
+++ b/internal/components/sdd/inject.go
@@ -1578,7 +1578,6 @@ func injectMarkdownSections(homeDir string, adapter agents.Adapter, assignments 
 }
 
 var claudeModelAssignmentRowOrder = []string{
-	"orchestrator",
 	"sdd-explore",
 	"sdd-propose",
 	"sdd-spec",
@@ -1591,16 +1590,15 @@ var claudeModelAssignmentRowOrder = []string{
 }
 
 var claudeModelAssignmentReasons = map[string]string{
-	"orchestrator": "Coordinates, makes decisions",
-	"sdd-explore":  "Reads code, structural - not architectural",
-	"sdd-propose":  "Architectural decisions",
-	"sdd-spec":     "Structured writing",
-	"sdd-design":   "Architecture decisions",
-	"sdd-tasks":    "Mechanical breakdown",
-	"sdd-apply":    "Implementation",
-	"sdd-verify":   "Validation against spec",
-	"sdd-archive":  "Copy and close",
-	"default":      "Non-SDD general delegation",
+	"sdd-explore": "Reads code, structural - not architectural",
+	"sdd-propose": "Architectural decisions",
+	"sdd-spec":    "Structured writing",
+	"sdd-design":  "Architecture decisions",
+	"sdd-tasks":   "Mechanical breakdown",
+	"sdd-apply":   "Implementation",
+	"sdd-verify":  "Validation against spec",
+	"sdd-archive": "Copy and close",
+	"default":     "Non-SDD general delegation",
 }
 
 func injectClaudeModelAssignments(content string, assignments map[string]model.ClaudeModelAlias) (string, error) {
@@ -1646,6 +1644,8 @@ func renderClaudeModelAssignmentsSection(assignments map[string]model.ClaudeMode
 	var b strings.Builder
 	b.WriteString("## Model Assignments\n\n")
 	b.WriteString("Read this table at session start (or before first delegation), cache it for the session, and pass the mapped alias in every Agent tool call via the `model` parameter. If a phase is missing, use the `default` row. If you do not have access to the assigned model (for example, no Opus access), substitute `sonnet` and continue.\n\n")
+	b.WriteString("The Claude Code session model is controlled by Claude Code itself; Gentle AI does not configure the main orchestrator model. This table applies only to Agent tool calls for SDD phase sub-agents and general delegation.\n\n")
+	b.WriteString("**Mandatory model gate:** Every Agent tool call MUST include `model`. Calling Agent without `model` is invalid. Before each Agent call, resolve the target phase to an alias from this table; for general/non-SDD delegation use `default`. If you are about to call Agent and have not chosen a `model`, STOP and choose the mapped alias first.\n\n")
 	b.WriteString("| Phase | Default Model | Reason |\n")
 	b.WriteString("|-------|---------------|--------|\n")
 	for _, key := range claudeModelAssignmentRowOrder {

--- a/internal/components/sdd/inject_test.go
+++ b/internal/components/sdd/inject_test.go
@@ -167,9 +167,8 @@ func TestInjectClaudeCustomModelAssignments(t *testing.T) {
 	home := t.TempDir()
 
 	opts := InjectOptions{ClaudeModelAssignments: map[string]model.ClaudeModelAlias{
-		"orchestrator": model.ClaudeModelSonnet,
-		"sdd-design":   model.ClaudeModelSonnet,
-		"default":      model.ClaudeModelHaiku,
+		"sdd-design": model.ClaudeModelSonnet,
+		"default":    model.ClaudeModelHaiku,
 	}}
 
 	result, err := Inject(home, claudeAdapter(), "", opts)
@@ -186,10 +185,13 @@ func TestInjectClaudeCustomModelAssignments(t *testing.T) {
 	}
 
 	text := string(content)
+	if strings.Contains(text, "| orchestrator |") {
+		t.Fatal("CLAUDE.md should not expose orchestrator as a configurable model row")
+	}
 	for _, want := range []string{
-		"| orchestrator | sonnet | Coordinates, makes decisions |",
 		"| sdd-design | sonnet | Architecture decisions |",
 		"| default | haiku | Non-SDD general delegation |",
+		"Gentle AI does not configure the main orchestrator model",
 	} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("CLAUDE.md missing custom table row %q", want)
@@ -202,13 +204,21 @@ func TestInjectClaudeCustomModelAssignments(t *testing.T) {
 	if !strings.Contains(text, "<!-- /gentle-ai:sdd-model-assignments -->") {
 		t.Fatal("CLAUDE.md missing model assignment close marker")
 	}
+	for _, want := range []string{
+		"Every Agent tool call MUST include `model`",
+		"for general/non-SDD delegation use `default`",
+		"If `model` is absent, do not send the Agent call",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("CLAUDE.md missing mandatory model gate text %q", want)
+		}
+	}
 }
 
 func TestInjectClaudeCustomModelAssignmentsIsIdempotent(t *testing.T) {
 	home := t.TempDir()
 	opts := InjectOptions{ClaudeModelAssignments: map[string]model.ClaudeModelAlias{
-		"orchestrator": model.ClaudeModelSonnet,
-		"sdd-design":   model.ClaudeModelSonnet,
+		"sdd-design": model.ClaudeModelSonnet,
 	}}
 
 	first, err := Inject(home, claudeAdapter(), "", opts)

--- a/internal/model/claude_model.go
+++ b/internal/model/claude_model.go
@@ -36,20 +36,19 @@ func (a ClaudeModelAlias) Valid() bool {
 }
 
 // ClaudeModelPresetBalanced returns the default model assignment table.
-// It balances cost and capability: orchestration and architecture phases use opus;
+// It balances cost and capability for Claude sub-agents: architecture phases use opus;
 // implementation and validation use sonnet; archiving uses haiku.
 func ClaudeModelPresetBalanced() map[string]ClaudeModelAlias {
 	return map[string]ClaudeModelAlias{
-		"orchestrator": ClaudeModelOpus,
-		"sdd-explore":  ClaudeModelSonnet,
-		"sdd-propose":  ClaudeModelOpus,
-		"sdd-spec":     ClaudeModelSonnet,
-		"sdd-design":   ClaudeModelOpus,
-		"sdd-tasks":    ClaudeModelSonnet,
-		"sdd-apply":    ClaudeModelSonnet,
-		"sdd-verify":   ClaudeModelSonnet,
-		"sdd-archive":  ClaudeModelHaiku,
-		"default":      ClaudeModelSonnet,
+		"sdd-explore": ClaudeModelSonnet,
+		"sdd-propose": ClaudeModelOpus,
+		"sdd-spec":    ClaudeModelSonnet,
+		"sdd-design":  ClaudeModelOpus,
+		"sdd-tasks":   ClaudeModelSonnet,
+		"sdd-apply":   ClaudeModelSonnet,
+		"sdd-verify":  ClaudeModelSonnet,
+		"sdd-archive": ClaudeModelHaiku,
+		"default":     ClaudeModelSonnet,
 	}
 }
 
@@ -57,16 +56,15 @@ func ClaudeModelPresetBalanced() map[string]ClaudeModelAlias {
 // output quality. Architecture, planning, and verification phases all use opus.
 func ClaudeModelPresetPerformance() map[string]ClaudeModelAlias {
 	return map[string]ClaudeModelAlias{
-		"orchestrator": ClaudeModelOpus,
-		"sdd-explore":  ClaudeModelSonnet,
-		"sdd-propose":  ClaudeModelOpus,
-		"sdd-spec":     ClaudeModelSonnet,
-		"sdd-design":   ClaudeModelOpus,
-		"sdd-tasks":    ClaudeModelSonnet,
-		"sdd-apply":    ClaudeModelSonnet,
-		"sdd-verify":   ClaudeModelOpus,
-		"sdd-archive":  ClaudeModelHaiku,
-		"default":      ClaudeModelSonnet,
+		"sdd-explore": ClaudeModelSonnet,
+		"sdd-propose": ClaudeModelOpus,
+		"sdd-spec":    ClaudeModelSonnet,
+		"sdd-design":  ClaudeModelOpus,
+		"sdd-tasks":   ClaudeModelSonnet,
+		"sdd-apply":   ClaudeModelSonnet,
+		"sdd-verify":  ClaudeModelOpus,
+		"sdd-archive": ClaudeModelHaiku,
+		"default":     ClaudeModelSonnet,
 	}
 }
 
@@ -74,15 +72,14 @@ func ClaudeModelPresetPerformance() map[string]ClaudeModelAlias {
 // Every phase uses sonnet except archive, which uses haiku.
 func ClaudeModelPresetEconomy() map[string]ClaudeModelAlias {
 	return map[string]ClaudeModelAlias{
-		"orchestrator": ClaudeModelSonnet,
-		"sdd-explore":  ClaudeModelSonnet,
-		"sdd-propose":  ClaudeModelSonnet,
-		"sdd-spec":     ClaudeModelSonnet,
-		"sdd-design":   ClaudeModelSonnet,
-		"sdd-tasks":    ClaudeModelSonnet,
-		"sdd-apply":    ClaudeModelSonnet,
-		"sdd-verify":   ClaudeModelSonnet,
-		"sdd-archive":  ClaudeModelHaiku,
-		"default":      ClaudeModelSonnet,
+		"sdd-explore": ClaudeModelSonnet,
+		"sdd-propose": ClaudeModelSonnet,
+		"sdd-spec":    ClaudeModelSonnet,
+		"sdd-design":  ClaudeModelSonnet,
+		"sdd-tasks":   ClaudeModelSonnet,
+		"sdd-apply":   ClaudeModelSonnet,
+		"sdd-verify":  ClaudeModelSonnet,
+		"sdd-archive": ClaudeModelHaiku,
+		"default":     ClaudeModelSonnet,
 	}
 }

--- a/internal/model/selection.go
+++ b/internal/model/selection.go
@@ -43,6 +43,10 @@ func (s Selection) HasComponent(component ComponentID) bool {
 // Nil fields mean "no override" — the sync uses defaults from BuildSyncSelection.
 // A non-nil but empty map means "reset to defaults" (explicit clear).
 type SyncOverrides struct {
+	// TargetAgents forces TUI sync to run the adapter(s) affected by the
+	// override, even when persisted install state omits them. This is used by
+	// model/profile configurators, where the user picked a concrete target agent.
+	TargetAgents           []AgentID
 	ModelAssignments       map[string]ModelAssignment  // nil = no override; empty map = reset to defaults
 	ClaudeModelAssignments map[string]ClaudeModelAlias // nil = no override; empty map = reset to defaults
 	KiroModelAssignments   map[string]ClaudeModelAlias // nil = no override; empty map = reset to defaults

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -837,6 +837,7 @@ func (m Model) handleKeyPress(key tea.KeyMsg) (tea.Model, tea.Cmd) {
 				if m.ModelConfigMode {
 					m.ModelConfigMode = false
 					m.PendingSyncOverrides = &model.SyncOverrides{
+						TargetAgents:           []model.AgentID{model.AgentClaudeCode},
 						ClaudeModelAssignments: updated,
 					}
 					m = m.withResetSyncState()
@@ -883,6 +884,7 @@ func (m Model) handleKeyPress(key tea.KeyMsg) (tea.Model, tea.Cmd) {
 				if m.ModelConfigMode {
 					m.ModelConfigMode = false
 					m.PendingSyncOverrides = &model.SyncOverrides{
+						TargetAgents:         []model.AgentID{model.AgentKiroIDE},
 						KiroModelAssignments: updated,
 					}
 					m = m.withResetSyncState()
@@ -1599,6 +1601,7 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 			if m.ModelConfigMode {
 				m.ModelConfigMode = false
 				m.PendingSyncOverrides = &model.SyncOverrides{
+					TargetAgents:     []model.AgentID{model.AgentOpenCode},
 					ModelAssignments: m.Selection.ModelAssignments,
 					SDDMode:          model.SDDModeMulti,
 				}
@@ -3399,7 +3402,8 @@ func (m Model) confirmProfileCreate() (tea.Model, tea.Cmd) {
 		case 0: // "Create & Sync" / "Save & Sync"
 			draft := m.ProfileDraft
 			m.PendingSyncOverrides = &model.SyncOverrides{
-				Profiles: []model.Profile{draft},
+				TargetAgents: []model.AgentID{model.AgentOpenCode},
+				Profiles:     []model.Profile{draft},
 			}
 			m = m.withResetSyncState()
 			m.setScreen(ScreenSync)

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -576,8 +576,8 @@ func TestClaudeModelPickerBalancedSelectionStoresAssignments(t *testing.T) {
 	if state.Screen != ScreenStrictTDD {
 		t.Fatalf("screen = %v, want %v (ClaudeCode + SDD goes to StrictTDD first)", state.Screen, ScreenStrictTDD)
 	}
-	if got := state.Selection.ClaudeModelAssignments["orchestrator"]; got != model.ClaudeModelOpus {
-		t.Fatalf("orchestrator = %q, want %q", got, model.ClaudeModelOpus)
+	if _, exists := state.Selection.ClaudeModelAssignments["orchestrator"]; exists {
+		t.Fatalf("orchestrator should not be configurable by Claude model picker: %v", state.Selection.ClaudeModelAssignments)
 	}
 	if got := state.Selection.ClaudeModelAssignments["default"]; got != model.ClaudeModelSonnet {
 		t.Fatalf("default = %q, want %q", got, model.ClaudeModelSonnet)
@@ -2077,19 +2077,46 @@ func TestModelConfig_ClaudePickerTriggersSyncScreen(t *testing.T) {
 	if state.PendingSyncOverrides == nil {
 		t.Fatalf("step2: PendingSyncOverrides should be non-nil after Claude model selection")
 	}
+	if got := state.PendingSyncOverrides.TargetAgents; len(got) != 1 || got[0] != model.AgentClaudeCode {
+		t.Fatalf("step2: TargetAgents = %v, want [%s]", got, model.AgentClaudeCode)
+	}
 	if len(state.PendingSyncOverrides.ClaudeModelAssignments) == 0 {
 		t.Fatalf("step2: PendingSyncOverrides.ClaudeModelAssignments should be non-empty, got: %v",
 			state.PendingSyncOverrides.ClaudeModelAssignments)
 	}
-	// Balanced preset: orchestrator → opus, sdd-archive → haiku.
-	if got := state.PendingSyncOverrides.ClaudeModelAssignments["orchestrator"]; got != model.ClaudeModelOpus {
-		t.Errorf("step2: ClaudeModelAssignments[orchestrator] = %q, want %q", got, model.ClaudeModelOpus)
+	// Balanced preset configures sub-agents/default only; Claude controls the main orchestrator model.
+	if _, exists := state.PendingSyncOverrides.ClaudeModelAssignments["orchestrator"]; exists {
+		t.Errorf("step2: orchestrator should not be configurable by Claude model picker: %v", state.PendingSyncOverrides.ClaudeModelAssignments)
 	}
 }
 
 // TestModelConfig_OpenCodePickerContinueTriggersSyncScreen verifies that pressing
 // "Continue" from ScreenModelPicker while in ModelConfigMode navigates to ScreenSync
 // and populates PendingSyncOverrides with ModelAssignments and SDDMode=multi.
+func TestModelConfig_ProfileSaveTargetsOpenCode(t *testing.T) {
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Screen = ScreenProfileCreate
+	m.ProfileCreateStep = 2
+	m.Cursor = 0
+	m.ProfileDraft = model.Profile{Name: "free"}
+
+	updated, _ := m.confirmProfileCreate()
+	state := updated.(Model)
+
+	if state.Screen != ScreenSync {
+		t.Fatalf("screen = %v, want ScreenSync", state.Screen)
+	}
+	if state.PendingSyncOverrides == nil {
+		t.Fatalf("PendingSyncOverrides should be non-nil after profile Save & Sync")
+	}
+	if got := state.PendingSyncOverrides.TargetAgents; len(got) != 1 || got[0] != model.AgentOpenCode {
+		t.Fatalf("TargetAgents = %v, want [%s]", got, model.AgentOpenCode)
+	}
+	if got := state.PendingSyncOverrides.Profiles; len(got) != 1 || got[0].Name != "free" {
+		t.Fatalf("Profiles = %v, want profile named free", got)
+	}
+}
+
 func TestModelConfig_OpenCodePickerContinueTriggersSyncScreen(t *testing.T) {
 	m := NewModel(system.DetectionResult{}, "dev")
 	m.Screen = ScreenModelPicker
@@ -2121,6 +2148,9 @@ func TestModelConfig_OpenCodePickerContinueTriggersSyncScreen(t *testing.T) {
 	if state.PendingSyncOverrides == nil {
 		t.Fatalf("PendingSyncOverrides should be non-nil after OpenCode model selection")
 	}
+	if got := state.PendingSyncOverrides.TargetAgents; len(got) != 1 || got[0] != model.AgentOpenCode {
+		t.Fatalf("TargetAgents = %v, want [%s]", got, model.AgentOpenCode)
+	}
 	if got := state.PendingSyncOverrides.SDDMode; got != model.SDDModeMulti {
 		t.Errorf("PendingSyncOverrides.SDDMode = %q, want %q", got, model.SDDModeMulti)
 	}
@@ -2142,8 +2172,7 @@ func TestModelConfig_SyncPassesOverridesToSyncFn(t *testing.T) {
 
 	testOverrides := &model.SyncOverrides{
 		ClaudeModelAssignments: map[string]model.ClaudeModelAlias{
-			"orchestrator": model.ClaudeModelOpus,
-			"default":      model.ClaudeModelSonnet,
+			"default": model.ClaudeModelSonnet,
 		},
 	}
 	m.PendingSyncOverrides = testOverrides
@@ -2185,8 +2214,8 @@ func TestModelConfig_SyncPassesOverridesToSyncFn(t *testing.T) {
 	if capturedOverrides == nil {
 		t.Fatalf("SyncFn was not called with overrides — capturedOverrides is nil")
 	}
-	if got := capturedOverrides.ClaudeModelAssignments["orchestrator"]; got != model.ClaudeModelOpus {
-		t.Errorf("captured ClaudeModelAssignments[orchestrator] = %q, want %q", got, model.ClaudeModelOpus)
+	if got := capturedOverrides.ClaudeModelAssignments["default"]; got != model.ClaudeModelSonnet {
+		t.Errorf("captured ClaudeModelAssignments[default] = %q, want %q", got, model.ClaudeModelSonnet)
 	}
 
 	// Feed SyncDoneMsg back through Update to verify end-to-end state cleanup.

--- a/internal/tui/screens/claude_model_picker.go
+++ b/internal/tui/screens/claude_model_picker.go
@@ -36,7 +36,6 @@ var claudePresetOrder = []ClaudeModelPreset{
 
 // claudePhases is the ordered list of model-assignment keys shown in custom mode.
 var claudePhases = []string{
-	"orchestrator",
 	"sdd-explore",
 	"sdd-propose",
 	"sdd-spec",
@@ -50,16 +49,15 @@ var claudePhases = []string{
 
 // claudePhaseLabels are the human-readable labels for each SDD phase.
 var claudePhaseLabels = map[string]string{
-	"orchestrator": "Orchestrator",
-	"sdd-explore":  "Explore",
-	"sdd-propose":  "Propose",
-	"sdd-spec":     "Spec",
-	"sdd-design":   "Design",
-	"sdd-tasks":    "Tasks",
-	"sdd-apply":    "Apply",
-	"sdd-verify":   "Verify",
-	"sdd-archive":  "Archive",
-	"default":      "General delegation",
+	"sdd-explore": "Explore",
+	"sdd-propose": "Propose",
+	"sdd-spec":    "Spec",
+	"sdd-design":  "Design",
+	"sdd-tasks":   "Tasks",
+	"sdd-apply":   "Apply",
+	"sdd-verify":  "Verify",
+	"sdd-archive": "Archive",
+	"default":     "General delegation",
 }
 
 // claudeAliasOrder defines the cycling order when pressing Enter on a phase row.

--- a/internal/tui/screens/kiro_model_picker.go
+++ b/internal/tui/screens/kiro_model_picker.go
@@ -61,7 +61,7 @@ func renderKiroPresetList(state KiroModelPickerState, cursor int) string {
 
 	b.WriteString(styles.TitleStyle.Render("Kiro Model Assignments"))
 	b.WriteString("\n\n")
-	b.WriteString(styles.SubtextStyle.Render("Choose how Kiro models are assigned to each SDD execution phase (explore → apply → archive + orchestrator):"))
+	b.WriteString(styles.SubtextStyle.Render("Choose how Kiro models are assigned to each SDD execution phase (explore → apply → archive):"))
 	b.WriteString("\n\n")
 
 	for idx, preset := range claudePresetOrder {

--- a/testdata/golden/combined-claude-claudemd.golden
+++ b/testdata/golden/combined-claude-claudemd.golden
@@ -58,7 +58,7 @@ Multiple skills can apply at once. Match by file context (extensions, paths) and
 <!-- gentle-ai:sdd-orchestrator -->
 # Agent Teams Lite — Orchestrator Instructions
 
-Bind this to the dedicated `sdd-orchestrator` agent or rule only. Do NOT apply it to executor phase agents such as `sdd-apply` or `sdd-verify`.
+Bind this to the Claude Code orchestrator rule only. Do NOT apply it to executor phase agents such as `sdd-apply` or `sdd-verify`.
 
 ## Agent Teams Orchestrator
 
@@ -68,19 +68,20 @@ You are a COORDINATOR, not an executor. Maintain one thin conversation thread, d
 
 Core principle: **does this inflate my context without need?** If yes → delegate. If no → do it inline.
 
-| Action | Inline | Delegate |
-|--------|--------|----------|
-| Read to decide/verify (1-3 files) | ✅ | — |
-| Read to explore/understand (4+ files) | — | ✅ |
-| Read as preparation for writing | — | ✅ together with the write |
-| Write atomic (one file, mechanical, you already know what) | ✅ | — |
-| Write with analysis (multiple files, new logic) | — | ✅ |
-| Bash for state (git, gh) | ✅ | — |
-| Bash for execution (test, build, install) | — | ✅ |
+| Action                                                     | Inline | Delegate                   |
+| ---------------------------------------------------------- | ------ | -------------------------- |
+| Read to decide/verify (1-3 files)                          | ✅     | —                          |
+| Read to explore/understand (4+ files)                      | —      | ✅                         |
+| Read as preparation for writing                            | —      | ✅ together with the write |
+| Write atomic (one file, mechanical, you already know what) | ✅     | —                          |
+| Write with analysis (multiple files, new logic)            | —      | ✅                         |
+| Bash for state (git, gh)                                   | ✅     | —                          |
+| Bash for execution (test, build, install)                  | —      | ✅                         |
 
 delegate (async) is the default for delegated work. Use task (sync) only when you need the result before your next action.
 
 Anti-patterns — these ALWAYS inflate context without need:
+
 - Reading 4+ files to "understand" the codebase inline → delegate an exploration
 - Writing a feature across multiple files inline → delegate
 - Running tests or builds inline → delegate
@@ -106,7 +107,6 @@ These are parent-orchestrator stop rules. Once any trigger fires, the orchestrat
 - Use fresh reviewers after implementation, conflict resolution, or incidents because their value is independent judgment, not token saving.
 - Avoid delegation for truly local one-file fixes, quick state checks, and already-understood mechanical edits.
 
-
 ## SDD Workflow (Spec-Driven Development)
 
 SDD is the structured planning layer for substantial changes.
@@ -121,14 +121,16 @@ SDD is the structured planning layer for substantial changes.
 ### Commands
 
 Skills (appear in autocomplete):
+
 - `/sdd-init` → initialize SDD context; detects stack, bootstraps persistence
 - `/sdd-explore <topic>` → investigate an idea; reads codebase, compares approaches; no files created
 - `/sdd-apply [change]` → implement tasks in batches; checks off items as it goes
 - `/sdd-verify [change]` → validate implementation against specs; reports CRITICAL / WARNING / SUGGESTION
-- `/sdd-archive [change]` → close a change and persist final state in the active artifact store 
+- `/sdd-archive [change]` → close a change and persist final state in the active artifact store
 - `/sdd-onboard` → guided end-to-end walkthrough of SDD using your real codebase
 
 Meta-commands (type directly — orchestrator handles them, won't appear in autocomplete):
+
 - `/sdd-new <change>` → start a new change by delegating exploration + proposal to sub-agents
 - `/sdd-continue [change]` → run the next dependency-ready phase via sub-agent(s)
 - `/sdd-ff <name>` → fast-forward planning: proposal → specs → design → tasks
@@ -144,6 +146,7 @@ Before executing ANY SDD command (`/sdd-new`, `/sdd-ff`, `/sdd-continue`, `/sdd-
 3. If NOT found → run `sdd-init` FIRST (delegate to sdd-init sub-agent), THEN proceed with the requested command
 
 This ensures:
+
 - Testing capabilities are always detected and cached
 - Strict TDD Mode is activated when the project supports it
 - The project context (stack, conventions) is available for all phases
@@ -162,6 +165,7 @@ If the user doesn't specify, default to **Interactive** (safer, gives the user c
 Cache the mode choice for the session — don't ask again unless the user explicitly requests a mode change.
 
 In **Interactive** mode, between phases:
+
 1. Show a concise summary of what the phase produced
 2. List what the next phase will do
 3. Ask: "¿Continuamos? / Continue?" — accept YES/continue, NO/stop, or specific feedback to adjust
@@ -186,6 +190,7 @@ Cache the artifact store choice for the session. Pass it as `artifact_store.mode
 On the first `/sdd-new`, `/sdd-ff`, or `/sdd-continue` (or an equivalent natural-language request) in a session, ask once for and cache delivery strategy: `ask-on-risk` (default), `auto-chain`, `single-pr`, or `exception-ok`. Pass it as `delivery_strategy` to `sdd-tasks` and `sdd-apply` prompts.
 
 ### Dependency Graph
+
 ```
 proposal -> specs --> tasks -> apply -> verify -> archive
              ^
@@ -194,6 +199,7 @@ proposal -> specs --> tasks -> apply -> verify -> archive
 ```
 
 ### Result Contract
+
 Each phase returns: `status`, `executive_summary`, `artifacts`, `next_recommended`, `risks`, `skill_resolution`.
 
 ### Review Workload Guard (MANDATORY)
@@ -210,22 +216,26 @@ If it says `Chained PRs recommended: Yes`, `400-line budget risk: High`, estimat
 Automatic mode does not override this guard. Always pass the resolved delivery strategy to `sdd-apply`.
 
 <!-- gentle-ai:sdd-model-assignments -->
+
 ## Model Assignments
 
 Read this table at session start (or before first delegation), cache it for the session, and pass the mapped alias in every Agent tool call via the `model` parameter. If a phase is missing, use the `default` row. If you lack access to the assigned model, substitute `sonnet` and continue.
 
-| Phase | Default Model | Reason |
-|-------|---------------|--------|
-| orchestrator | opus | Coordinates, makes decisions |
-| sdd-explore | sonnet | Reads code, structural - not architectural |
-| sdd-propose | opus | Architectural decisions |
-| sdd-spec | sonnet | Structured writing |
-| sdd-design | opus | Architecture decisions |
-| sdd-tasks | sonnet | Mechanical breakdown |
-| sdd-apply | sonnet | Implementation |
-| sdd-verify | sonnet | Validation against spec |
-| sdd-archive | haiku | Copy and close |
-| default | sonnet | Non-SDD general delegation |
+The Claude Code session model is controlled by Claude Code itself; Gentle AI does not configure the main orchestrator model. This table applies only to Agent tool calls for SDD phase sub-agents and general delegation.
+
+**Mandatory model gate:** Every Agent tool call MUST include `model`. Calling Agent without `model` is invalid. Before each Agent call, resolve the target phase to an alias from this table; for general/non-SDD delegation use `default`. If you are about to call Agent and have not chosen a `model`, STOP and choose the mapped alias first.
+
+| Phase       | Default Model | Reason                                     |
+| ----------- | ------------- | ------------------------------------------ |
+| sdd-explore | sonnet        | Reads code, structural - not architectural |
+| sdd-propose | opus          | Architectural decisions                    |
+| sdd-spec    | sonnet        | Structured writing                         |
+| sdd-design  | opus          | Architecture decisions                     |
+| sdd-tasks   | sonnet        | Mechanical breakdown                       |
+| sdd-apply   | sonnet        | Implementation                             |
+| sdd-verify  | sonnet        | Validation against spec                    |
+| sdd-archive | haiku         | Copy and close                             |
+| default     | sonnet        | Non-SDD general delegation                 |
 
 <!-- /gentle-ai:sdd-model-assignments -->
 
@@ -233,15 +243,24 @@ Read this table at session start (or before first delegation), cache it for the 
 
 ALL sub-agent launch prompts that involve reading, writing, or reviewing code MUST include pre-resolved **compact rules** from the skill registry. Follow the **Skill Resolver Protocol** (`~/.claude/skills/_shared/skill-resolver.md`).
 
+**Pre-flight before every Agent call (mandatory):**
+
+1. Identify the phase key (`sdd-apply`, `sdd-verify`, etc.) or use `default` for general delegation.
+2. Look up the alias in the Model Assignments table.
+3. Include `model: "<alias>"` in the Agent tool call.
+4. If `model` is absent, do not send the Agent call.
+
 The orchestrator resolves skills from the registry ONCE (at session start or first delegation), caches the compact rules, and injects matching rules into each sub-agent's prompt. Also reads the Model Assignments table once per session, caches `phase → alias`, includes that alias in every Agent tool call via `model`.
 
 Orchestrator skill resolution (do once per session):
+
 1. `mem_search(query: "skill-registry", project: "{project}")` → `mem_get_observation(id)` for full registry content
 2. Fallback: read `.atl/skill-registry.md` if engram not available
 3. Cache the **Compact Rules** section and the **User Skills** trigger table
 4. If no registry exists, warn user and proceed without project-specific standards
 
 For each sub-agent launch:
+
 1. Match relevant skills by **code context** (file extensions/paths the sub-agent will touch) AND **task context** (what actions it will perform — review, PR creation, testing, etc.)
 2. Copy matching compact rule blocks into the sub-agent prompt as `## Project Standards (auto-resolved)`
 3. Inject BEFORE the sub-agent's task-specific instructions
@@ -251,6 +270,7 @@ For each sub-agent launch:
 ### Skill Resolution Feedback
 
 After every delegation that returns a result, check the `skill_resolution` field:
+
 - `injected` → all good, skills were passed correctly
 - `fallback-registry`, `fallback-path`, or `none` → skill cache was lost (likely compaction). Re-read the registry immediately and inject compact rules in all subsequent delegations.
 
@@ -271,16 +291,16 @@ Sub-agents get a fresh context with NO memory. The orchestrator controls context
 
 Each phase has explicit read/write rules:
 
-| Phase | Reads | Writes |
-|-------|-------|--------|
-| `sdd-explore` | nothing | `explore` |
-| `sdd-propose` | exploration (optional) | `proposal` |
-| `sdd-spec` | proposal (required) | `spec` |
-| `sdd-design` | proposal (required) | `design` |
-| `sdd-tasks` | spec + design (required) | `tasks` |
-| `sdd-apply` | tasks + spec + design + **apply-progress (if exists)** | `apply-progress` |
-| `sdd-verify` | spec + tasks + **apply-progress** | `verify-report` |
-| `sdd-archive` | all artifacts | `archive-report` |
+| Phase         | Reads                                                  | Writes           |
+| ------------- | ------------------------------------------------------ | ---------------- |
+| `sdd-explore` | nothing                                                | `explore`        |
+| `sdd-propose` | exploration (optional)                                 | `proposal`       |
+| `sdd-spec`    | proposal (required)                                    | `spec`           |
+| `sdd-design`  | proposal (required)                                    | `design`         |
+| `sdd-tasks`   | spec + design (required)                               | `tasks`          |
+| `sdd-apply`   | tasks + spec + design + **apply-progress (if exists)** | `apply-progress` |
+| `sdd-verify`  | spec + tasks + **apply-progress**                      | `verify-report`  |
+| `sdd-archive` | all artifacts                                          | `archive-report` |
 
 For phases with required dependencies, sub-agent reads directly from the backend — orchestrator passes artifact references (topic keys or file paths), NOT content itself.
 
@@ -308,20 +328,21 @@ This prevents progress loss across batches. The sub-agent is responsible for rea
 
 #### Engram Topic Key Format
 
-| Artifact | Topic Key |
-|----------|-----------|
-| Project context | `sdd-init/{project}` |
-| Exploration | `sdd/{change-name}/explore` |
-| Proposal | `sdd/{change-name}/proposal` |
-| Spec | `sdd/{change-name}/spec` |
-| Design | `sdd/{change-name}/design` |
-| Tasks | `sdd/{change-name}/tasks` |
-| Apply progress | `sdd/{change-name}/apply-progress` |
-| Verify report | `sdd/{change-name}/verify-report` |
-| Archive report | `sdd/{change-name}/archive-report` |
-| DAG state | `sdd/{change-name}/state` |
+| Artifact        | Topic Key                          |
+| --------------- | ---------------------------------- |
+| Project context | `sdd-init/{project}`               |
+| Exploration     | `sdd/{change-name}/explore`        |
+| Proposal        | `sdd/{change-name}/proposal`       |
+| Spec            | `sdd/{change-name}/spec`           |
+| Design          | `sdd/{change-name}/design`         |
+| Tasks           | `sdd/{change-name}/tasks`          |
+| Apply progress  | `sdd/{change-name}/apply-progress` |
+| Verify report   | `sdd/{change-name}/verify-report`  |
+| Archive report  | `sdd/{change-name}/archive-report` |
+| DAG state       | `sdd/{change-name}/state`          |
 
 Sub-agents retrieve full content via two steps:
+
 1. `mem_search(query: "{topic_key}", project: "{project}")` → get observation ID
 2. `mem_get_observation(id: {id})` → full content (REQUIRED — search results are truncated)
 

--- a/testdata/golden/sdd-claude-claudemd.golden
+++ b/testdata/golden/sdd-claude-claudemd.golden
@@ -1,7 +1,7 @@
 <!-- gentle-ai:sdd-orchestrator -->
 # Agent Teams Lite — Orchestrator Instructions
 
-Bind this to the dedicated `sdd-orchestrator` agent or rule only. Do NOT apply it to executor phase agents such as `sdd-apply` or `sdd-verify`.
+Bind this to the Claude Code orchestrator rule only. Do NOT apply it to executor phase agents such as `sdd-apply` or `sdd-verify`.
 
 ## Agent Teams Orchestrator
 
@@ -11,19 +11,20 @@ You are a COORDINATOR, not an executor. Maintain one thin conversation thread, d
 
 Core principle: **does this inflate my context without need?** If yes → delegate. If no → do it inline.
 
-| Action | Inline | Delegate |
-|--------|--------|----------|
-| Read to decide/verify (1-3 files) | ✅ | — |
-| Read to explore/understand (4+ files) | — | ✅ |
-| Read as preparation for writing | — | ✅ together with the write |
-| Write atomic (one file, mechanical, you already know what) | ✅ | — |
-| Write with analysis (multiple files, new logic) | — | ✅ |
-| Bash for state (git, gh) | ✅ | — |
-| Bash for execution (test, build, install) | — | ✅ |
+| Action                                                     | Inline | Delegate                   |
+| ---------------------------------------------------------- | ------ | -------------------------- |
+| Read to decide/verify (1-3 files)                          | ✅     | —                          |
+| Read to explore/understand (4+ files)                      | —      | ✅                         |
+| Read as preparation for writing                            | —      | ✅ together with the write |
+| Write atomic (one file, mechanical, you already know what) | ✅     | —                          |
+| Write with analysis (multiple files, new logic)            | —      | ✅                         |
+| Bash for state (git, gh)                                   | ✅     | —                          |
+| Bash for execution (test, build, install)                  | —      | ✅                         |
 
 delegate (async) is the default for delegated work. Use task (sync) only when you need the result before your next action.
 
 Anti-patterns — these ALWAYS inflate context without need:
+
 - Reading 4+ files to "understand" the codebase inline → delegate an exploration
 - Writing a feature across multiple files inline → delegate
 - Running tests or builds inline → delegate
@@ -49,7 +50,6 @@ These are parent-orchestrator stop rules. Once any trigger fires, the orchestrat
 - Use fresh reviewers after implementation, conflict resolution, or incidents because their value is independent judgment, not token saving.
 - Avoid delegation for truly local one-file fixes, quick state checks, and already-understood mechanical edits.
 
-
 ## SDD Workflow (Spec-Driven Development)
 
 SDD is the structured planning layer for substantial changes.
@@ -64,14 +64,16 @@ SDD is the structured planning layer for substantial changes.
 ### Commands
 
 Skills (appear in autocomplete):
+
 - `/sdd-init` → initialize SDD context; detects stack, bootstraps persistence
 - `/sdd-explore <topic>` → investigate an idea; reads codebase, compares approaches; no files created
 - `/sdd-apply [change]` → implement tasks in batches; checks off items as it goes
 - `/sdd-verify [change]` → validate implementation against specs; reports CRITICAL / WARNING / SUGGESTION
-- `/sdd-archive [change]` → close a change and persist final state in the active artifact store 
+- `/sdd-archive [change]` → close a change and persist final state in the active artifact store
 - `/sdd-onboard` → guided end-to-end walkthrough of SDD using your real codebase
 
 Meta-commands (type directly — orchestrator handles them, won't appear in autocomplete):
+
 - `/sdd-new <change>` → start a new change by delegating exploration + proposal to sub-agents
 - `/sdd-continue [change]` → run the next dependency-ready phase via sub-agent(s)
 - `/sdd-ff <name>` → fast-forward planning: proposal → specs → design → tasks
@@ -87,6 +89,7 @@ Before executing ANY SDD command (`/sdd-new`, `/sdd-ff`, `/sdd-continue`, `/sdd-
 3. If NOT found → run `sdd-init` FIRST (delegate to sdd-init sub-agent), THEN proceed with the requested command
 
 This ensures:
+
 - Testing capabilities are always detected and cached
 - Strict TDD Mode is activated when the project supports it
 - The project context (stack, conventions) is available for all phases
@@ -105,6 +108,7 @@ If the user doesn't specify, default to **Interactive** (safer, gives the user c
 Cache the mode choice for the session — don't ask again unless the user explicitly requests a mode change.
 
 In **Interactive** mode, between phases:
+
 1. Show a concise summary of what the phase produced
 2. List what the next phase will do
 3. Ask: "¿Continuamos? / Continue?" — accept YES/continue, NO/stop, or specific feedback to adjust
@@ -129,6 +133,7 @@ Cache the artifact store choice for the session. Pass it as `artifact_store.mode
 On the first `/sdd-new`, `/sdd-ff`, or `/sdd-continue` (or an equivalent natural-language request) in a session, ask once for and cache delivery strategy: `ask-on-risk` (default), `auto-chain`, `single-pr`, or `exception-ok`. Pass it as `delivery_strategy` to `sdd-tasks` and `sdd-apply` prompts.
 
 ### Dependency Graph
+
 ```
 proposal -> specs --> tasks -> apply -> verify -> archive
              ^
@@ -137,6 +142,7 @@ proposal -> specs --> tasks -> apply -> verify -> archive
 ```
 
 ### Result Contract
+
 Each phase returns: `status`, `executive_summary`, `artifacts`, `next_recommended`, `risks`, `skill_resolution`.
 
 ### Review Workload Guard (MANDATORY)
@@ -153,22 +159,26 @@ If it says `Chained PRs recommended: Yes`, `400-line budget risk: High`, estimat
 Automatic mode does not override this guard. Always pass the resolved delivery strategy to `sdd-apply`.
 
 <!-- gentle-ai:sdd-model-assignments -->
+
 ## Model Assignments
 
 Read this table at session start (or before first delegation), cache it for the session, and pass the mapped alias in every Agent tool call via the `model` parameter. If a phase is missing, use the `default` row. If you lack access to the assigned model, substitute `sonnet` and continue.
 
-| Phase | Default Model | Reason |
-|-------|---------------|--------|
-| orchestrator | opus | Coordinates, makes decisions |
-| sdd-explore | sonnet | Reads code, structural - not architectural |
-| sdd-propose | opus | Architectural decisions |
-| sdd-spec | sonnet | Structured writing |
-| sdd-design | opus | Architecture decisions |
-| sdd-tasks | sonnet | Mechanical breakdown |
-| sdd-apply | sonnet | Implementation |
-| sdd-verify | sonnet | Validation against spec |
-| sdd-archive | haiku | Copy and close |
-| default | sonnet | Non-SDD general delegation |
+The Claude Code session model is controlled by Claude Code itself; Gentle AI does not configure the main orchestrator model. This table applies only to Agent tool calls for SDD phase sub-agents and general delegation.
+
+**Mandatory model gate:** Every Agent tool call MUST include `model`. Calling Agent without `model` is invalid. Before each Agent call, resolve the target phase to an alias from this table; for general/non-SDD delegation use `default`. If you are about to call Agent and have not chosen a `model`, STOP and choose the mapped alias first.
+
+| Phase       | Default Model | Reason                                     |
+| ----------- | ------------- | ------------------------------------------ |
+| sdd-explore | sonnet        | Reads code, structural - not architectural |
+| sdd-propose | opus          | Architectural decisions                    |
+| sdd-spec    | sonnet        | Structured writing                         |
+| sdd-design  | opus          | Architecture decisions                     |
+| sdd-tasks   | sonnet        | Mechanical breakdown                       |
+| sdd-apply   | sonnet        | Implementation                             |
+| sdd-verify  | sonnet        | Validation against spec                    |
+| sdd-archive | haiku         | Copy and close                             |
+| default     | sonnet        | Non-SDD general delegation                 |
 
 <!-- /gentle-ai:sdd-model-assignments -->
 
@@ -176,15 +186,24 @@ Read this table at session start (or before first delegation), cache it for the 
 
 ALL sub-agent launch prompts that involve reading, writing, or reviewing code MUST include pre-resolved **compact rules** from the skill registry. Follow the **Skill Resolver Protocol** (`~/.claude/skills/_shared/skill-resolver.md`).
 
+**Pre-flight before every Agent call (mandatory):**
+
+1. Identify the phase key (`sdd-apply`, `sdd-verify`, etc.) or use `default` for general delegation.
+2. Look up the alias in the Model Assignments table.
+3. Include `model: "<alias>"` in the Agent tool call.
+4. If `model` is absent, do not send the Agent call.
+
 The orchestrator resolves skills from the registry ONCE (at session start or first delegation), caches the compact rules, and injects matching rules into each sub-agent's prompt. Also reads the Model Assignments table once per session, caches `phase → alias`, includes that alias in every Agent tool call via `model`.
 
 Orchestrator skill resolution (do once per session):
+
 1. `mem_search(query: "skill-registry", project: "{project}")` → `mem_get_observation(id)` for full registry content
 2. Fallback: read `.atl/skill-registry.md` if engram not available
 3. Cache the **Compact Rules** section and the **User Skills** trigger table
 4. If no registry exists, warn user and proceed without project-specific standards
 
 For each sub-agent launch:
+
 1. Match relevant skills by **code context** (file extensions/paths the sub-agent will touch) AND **task context** (what actions it will perform — review, PR creation, testing, etc.)
 2. Copy matching compact rule blocks into the sub-agent prompt as `## Project Standards (auto-resolved)`
 3. Inject BEFORE the sub-agent's task-specific instructions
@@ -194,6 +213,7 @@ For each sub-agent launch:
 ### Skill Resolution Feedback
 
 After every delegation that returns a result, check the `skill_resolution` field:
+
 - `injected` → all good, skills were passed correctly
 - `fallback-registry`, `fallback-path`, or `none` → skill cache was lost (likely compaction). Re-read the registry immediately and inject compact rules in all subsequent delegations.
 
@@ -214,16 +234,16 @@ Sub-agents get a fresh context with NO memory. The orchestrator controls context
 
 Each phase has explicit read/write rules:
 
-| Phase | Reads | Writes |
-|-------|-------|--------|
-| `sdd-explore` | nothing | `explore` |
-| `sdd-propose` | exploration (optional) | `proposal` |
-| `sdd-spec` | proposal (required) | `spec` |
-| `sdd-design` | proposal (required) | `design` |
-| `sdd-tasks` | spec + design (required) | `tasks` |
-| `sdd-apply` | tasks + spec + design + **apply-progress (if exists)** | `apply-progress` |
-| `sdd-verify` | spec + tasks + **apply-progress** | `verify-report` |
-| `sdd-archive` | all artifacts | `archive-report` |
+| Phase         | Reads                                                  | Writes           |
+| ------------- | ------------------------------------------------------ | ---------------- |
+| `sdd-explore` | nothing                                                | `explore`        |
+| `sdd-propose` | exploration (optional)                                 | `proposal`       |
+| `sdd-spec`    | proposal (required)                                    | `spec`           |
+| `sdd-design`  | proposal (required)                                    | `design`         |
+| `sdd-tasks`   | spec + design (required)                               | `tasks`          |
+| `sdd-apply`   | tasks + spec + design + **apply-progress (if exists)** | `apply-progress` |
+| `sdd-verify`  | spec + tasks + **apply-progress**                      | `verify-report`  |
+| `sdd-archive` | all artifacts                                          | `archive-report` |
 
 For phases with required dependencies, sub-agent reads directly from the backend — orchestrator passes artifact references (topic keys or file paths), NOT content itself.
 
@@ -251,20 +271,21 @@ This prevents progress loss across batches. The sub-agent is responsible for rea
 
 #### Engram Topic Key Format
 
-| Artifact | Topic Key |
-|----------|-----------|
-| Project context | `sdd-init/{project}` |
-| Exploration | `sdd/{change-name}/explore` |
-| Proposal | `sdd/{change-name}/proposal` |
-| Spec | `sdd/{change-name}/spec` |
-| Design | `sdd/{change-name}/design` |
-| Tasks | `sdd/{change-name}/tasks` |
-| Apply progress | `sdd/{change-name}/apply-progress` |
-| Verify report | `sdd/{change-name}/verify-report` |
-| Archive report | `sdd/{change-name}/archive-report` |
-| DAG state | `sdd/{change-name}/state` |
+| Artifact        | Topic Key                          |
+| --------------- | ---------------------------------- |
+| Project context | `sdd-init/{project}`               |
+| Exploration     | `sdd/{change-name}/explore`        |
+| Proposal        | `sdd/{change-name}/proposal`       |
+| Spec            | `sdd/{change-name}/spec`           |
+| Design          | `sdd/{change-name}/design`         |
+| Tasks           | `sdd/{change-name}/tasks`          |
+| Apply progress  | `sdd/{change-name}/apply-progress` |
+| Verify report   | `sdd/{change-name}/verify-report`  |
+| Archive report  | `sdd/{change-name}/archive-report` |
+| DAG state       | `sdd/{change-name}/state`          |
 
 Sub-agents retrieve full content via two steps:
+
 1. `mem_search(query: "{topic_key}", project: "{project}")` → get observation ID
 2. `mem_get_observation(id: {id})` → full content (REQUIRED — search results are truncated)
 

--- a/testdata/golden/sdd-claude-cmd-sdd-continue.golden
+++ b/testdata/golden/sdd-claude-cmd-sdd-continue.golden
@@ -2,10 +2,11 @@
 description: Continue the next SDD phase in the dependency chain
 ---
 
-If the native `sdd-orchestrator` agent is available, delegate this command to it.
-Otherwise, follow the SDD orchestrator workflow inline using the instructions already installed in `~/.claude/CLAUDE.md`.
+Follow the SDD orchestrator workflow inline using the instructions already installed in `~/.claude/CLAUDE.md`.
+The Claude Code session model is controlled by Claude Code; Gentle AI only configures models for Agent tool calls to phase sub-agents.
 
 WORKFLOW:
+
 1. Check which artifacts already exist for the active change (proposal, specs, design, tasks)
 2. Determine the next phase needed based on the dependency graph:
    proposal → [specs ∥ design] → tasks → apply → verify → archive
@@ -13,6 +14,7 @@ WORKFLOW:
 4. Present the result and ask the user to proceed
 
 CONTEXT:
+
 - Working directory: !`echo -n "$(pwd)"`
 - Current project: !`echo -n "$(basename $(pwd))"`
 - Change name: $ARGUMENTS

--- a/testdata/golden/sdd-claude-cmd-sdd-ff.golden
+++ b/testdata/golden/sdd-claude-cmd-sdd-ff.golden
@@ -2,11 +2,12 @@
 description: Fast-forward all SDD planning phases — proposal through tasks
 ---
 
-If the native `sdd-orchestrator` agent is available, delegate this command to it.
-Otherwise, follow the SDD orchestrator workflow inline using the instructions already installed in `~/.claude/CLAUDE.md`.
+Follow the SDD orchestrator workflow inline using the instructions already installed in `~/.claude/CLAUDE.md`.
+The Claude Code session model is controlled by Claude Code; Gentle AI only configures models for Agent tool calls to phase sub-agents.
 
 WORKFLOW:
 Run these sub-agents in sequence:
+
 1. `sdd-propose` — create the proposal
 2. `sdd-spec` — write specifications
 3. `sdd-design` — create technical design
@@ -15,6 +16,7 @@ Run these sub-agents in sequence:
 Present a combined summary after ALL phases complete (not between each one).
 
 CONTEXT:
+
 - Working directory: !`echo -n "$(pwd)"`
 - Current project: !`echo -n "$(basename $(pwd))"`
 - Change name: $ARGUMENTS

--- a/testdata/golden/sdd-claude-cmd-sdd-new.golden
+++ b/testdata/golden/sdd-claude-cmd-sdd-new.golden
@@ -2,16 +2,18 @@
 description: Start a new SDD change — runs exploration then creates a proposal
 ---
 
-If the native `sdd-orchestrator` agent is available, delegate this command to it.
-Otherwise, follow the SDD orchestrator workflow inline using the instructions already installed in `~/.claude/CLAUDE.md`.
+Follow the SDD orchestrator workflow inline using the instructions already installed in `~/.claude/CLAUDE.md`.
+The Claude Code session model is controlled by Claude Code; Gentle AI only configures models for Agent tool calls to phase sub-agents.
 
 WORKFLOW:
+
 1. Launch `sdd-explore` to investigate the codebase for this change
 2. Present the exploration summary to the user
 3. Launch `sdd-propose` to create a proposal based on the exploration
 4. Present the proposal summary and ask the user if they want to continue with specs and design
 
 CONTEXT:
+
 - Working directory: !`echo -n "$(pwd)"`
 - Current project: !`echo -n "$(basename $(pwd))"`
 - Change name: $ARGUMENTS


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #524

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Fixes TUI model/profile sync so configurator flows target the selected agent instead of relying on persisted install state.
- Keeps Claude Code model configuration honest: Gentle AI configures sub-agent/default Agent-call models, not the main Claude session model.
- Preserves OpenCode SDD profile model assignment behavior and updates affected Claude/Kiro copy and goldens.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/model/selection.go`, `internal/app/app.go`, `internal/tui/model.go` | Added explicit target-agent sync overrides for model/profile configurator flows. |
| `internal/assets/claude/*`, `internal/components/sdd/inject.go` | Removed Claude main-orchestrator model row and strengthened Agent-call model gate. |
| `internal/cli/*`, `internal/app/*` | Avoid persisting/loading Claude `orchestrator` as a Gentle AI model assignment. |
| `internal/tui/screens/*` | Updated Claude/Kiro model picker behavior/copy to match actual scope. |
| Tests/goldens | Added regression coverage and refreshed generated Claude outputs. |

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./...
```

**E2E Tests** (Docker required)
```bash
cd e2e && ./docker-test.sh
```

- [x] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Manually tested locally

Manual/Judgment evidence:
- OpenCode profile/model focused tests passed.
- Judgment Day Round 2: both judges returned clean.

---

## 🤖 Automated Checks

The following checks run automatically on this PR:

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | PR should stay within 400 changed lines (`additions + deletions`) or use `size:exception` |
| Check Issue Reference | ⏳ | PR body must contain `Closes/Fixes/Resolves #N` |
| Check Issue Has `status:approved` | ⏳ | Linked issue must have been approved before work began |
| Check PR Has `type:*` Label | ⏳ | Exactly one `type:*` label must be applied |
| Unit Tests | ⏳ | `go test ./...` must pass |
| E2E Tests | ⏳ | `cd e2e && ./docker-test.sh` must pass |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

This intentionally does not configure Claude Code's main session model. Claude's configurator now covers only sub-agent/default Agent-call model assignments; the user picks the orchestrator/session model in Claude Code itself.
