### PR TITLE
fix(pi): bump gentle-engram pin to 0.1.4 and cede mcp.json ownership

### DIFF
--- a/internal/agents/pi/adapter.go
+++ b/internal/agents/pi/adapter.go
@@ -22,7 +22,6 @@ const (
 	piMCPAdapterDependency   = "pi-mcp-adapter"
 	piMCPAdapterVersion      = "2.6.0"
 	piMCPAdapterVersionRange = "^2.6.0"
-	piEngramMCPActiveServer  = "engram"
 	piEngramMCPConfigFile    = "mcp.json"
 	piSettingsFile           = "settings.json"
 	piNPMDirectory           = "npm"
@@ -134,33 +133,23 @@ func ConfigPath(homeDir string) string { return filepath.Join(homeDir, ".pi") }
 // AgentConfigPath returns Pi's current agent-owned config directory path.
 func AgentConfigPath(homeDir string) string { return filepath.Join(ConfigPath(homeDir), "agent") }
 
-// ProvisionEngramMCP declares and wires pi-mcp-adapter so Pi exposes the
-// Engram MCP server through /mcp. It is invoked by ComponentEngram; keeping it
-// here lets Pi own the exact config shape without teaching the generic Engram
-// injector about Pi internals.
+// ProvisionEngramMCP declares pi-mcp-adapter in Pi's settings.json and
+// package.json. It is invoked by ComponentEngram; keeping it here lets Pi
+// own the exact config shape without teaching the generic Engram injector
+// about Pi internals.
+//
+// mcp.json is NOT written here. pi-engram init (invoked by InstallCommand)
+// is the sole writer of that file and owns its schema.
 func (a *Adapter) ProvisionEngramMCP(homeDir string) (bool, []string, error) {
 	paths := []string{
 		a.SettingsPath(homeDir),
 		filepath.Join(ConfigPath(homeDir), piNPMDirectory, piNPMPackageFile),
-		a.MCPConfigPath(homeDir, piEngramMCPActiveServer),
 	}
 	overlays := [][]byte{
 		nil,
 		mustJSON(map[string]any{
 			"dependencies": map[string]any{
 				piMCPAdapterDependency: piMCPAdapterVersionRange,
-			},
-		}),
-		mustJSON(map[string]any{
-			"activeMCP": piEngramMCPActiveServer,
-			"mcpServers": map[string]any{
-				piEngramMCPActiveServer: map[string]any{
-					"__replace__": map[string]any{
-						"command":     "engram",
-						"args":        []string{"mcp", "--tools=agent"},
-						"directTools": true,
-					},
-				},
 			},
 		}),
 	}

--- a/internal/cli/run_integration_test.go
+++ b/internal/cli/run_integration_test.go
@@ -100,6 +100,16 @@ func TestRunInstallEngramForPiAndOpenCodeProvisionsBothMCPTargets(t *testing.T) 
 	var commands []string
 	runCommand = func(name string, args ...string) error {
 		commands = append(commands, strings.Join(append([]string{name}, args...), " "))
+		// Simulate pi-engram init writing mcp.json with the new schema.
+		if name == "npm" && len(args) >= 7 && args[5] == "pi-engram" && args[6] == "init" {
+			mcpPath := filepath.Join(home, ".pi", "agent", "mcp.json")
+			if err := os.MkdirAll(filepath.Dir(mcpPath), 0o755); err != nil {
+				return err
+			}
+			if err := os.WriteFile(mcpPath, []byte(`{"activeMCP":"engram","mcpServers":{"engram":{"command":"node","args":["--eval","require('child_process').spawn('engram',['mcp','--tools=agent'],{stdio:'inherit'})"]}}}`+"\n"), 0o644); err != nil {
+				return err
+			}
+		}
 		return nil
 	}
 
@@ -117,7 +127,6 @@ func TestRunInstallEngramForPiAndOpenCodeProvisionsBothMCPTargets(t *testing.T) 
 
 	assertFileContains(t, filepath.Join(home, ".pi", "agent", "settings.json"), "npm:pi-mcp-adapter")
 	assertFileContains(t, filepath.Join(home, ".pi", "npm", "package.json"), "pi-mcp-adapter")
-	assertFileContains(t, filepath.Join(home, ".pi", "agent", "mcp.json"), "directTools")
 	assertFileContains(t, filepath.Join(home, ".config", "opencode", "opencode.json"), "engram")
 
 	for _, want := range []string{"pi install npm:pi-mcp-adapter", fmt.Sprintf("npm exec --yes --package gentle-engram@%s -- pi-engram init", versions.GentleEngram)} {

--- a/internal/components/engram/inject_test.go
+++ b/internal/components/engram/inject_test.go
@@ -236,19 +236,12 @@ func TestInjectPiProvisioningCreatesMissingMCPAdapterFiles(t *testing.T) {
 
 	npmPackage := readJSONFile(t, filepath.Join(home, ".pi", "npm", "package.json"))
 	assertNestedString(t, npmPackage, "^2.6.0", "dependencies", "pi-mcp-adapter")
-
-	mcp := readJSONFile(t, filepath.Join(home, ".pi", "agent", "mcp.json"))
-	assertNestedString(t, mcp, "engram", "activeMCP")
-	assertNestedString(t, mcp, "engram", "mcpServers", "engram", "command")
-	assertNestedStrings(t, mcp, []string{"mcp", "--tools=agent"}, "mcpServers", "engram", "args")
-	assertNestedBool(t, mcp, true, "mcpServers", "engram", "directTools")
 }
 
 func TestInjectPiProvisioningPreservesUnrelatedContent(t *testing.T) {
 	home := t.TempDir()
 	writeFile(t, filepath.Join(home, ".pi", "agent", "settings.json"), `{"theme":"kanagawa","packages":["npm:other@1.0.0"]}`)
 	writeFile(t, filepath.Join(home, ".pi", "npm", "package.json"), `{"name":"pi-user","dependencies":{"left-pad":"^1.0.0"},"devDependencies":{"vitest":"^1.0.0"}}`)
-	writeFile(t, filepath.Join(home, ".pi", "agent", "mcp.json"), `{"activeMCP":"other","mcpServers":{"other":{"command":"other-mcp"}},"metadata":{"owner":"user"}}`)
 
 	_, err := Inject(home, piAdapter())
 	if err != nil {
@@ -264,19 +257,12 @@ func TestInjectPiProvisioningPreservesUnrelatedContent(t *testing.T) {
 	assertNestedString(t, npmPackage, "^1.0.0", "dependencies", "left-pad")
 	assertNestedString(t, npmPackage, "^2.6.0", "dependencies", "pi-mcp-adapter")
 	assertNestedString(t, npmPackage, "^1.0.0", "devDependencies", "vitest")
-
-	mcp := readJSONFile(t, filepath.Join(home, ".pi", "agent", "mcp.json"))
-	assertNestedString(t, mcp, "engram", "activeMCP")
-	assertNestedString(t, mcp, "other-mcp", "mcpServers", "other", "command")
-	assertNestedString(t, mcp, "user", "metadata", "owner")
-	assertNestedString(t, mcp, "engram", "mcpServers", "engram", "command")
 }
 
 func TestInjectPiProvisioningCanonicalizesExistingEntriesAndIsIdempotent(t *testing.T) {
 	home := t.TempDir()
 	writeFile(t, filepath.Join(home, ".pi", "agent", "settings.json"), `{"packages":["npm:pi-mcp-adapter@2.0.0"]}`)
 	writeFile(t, filepath.Join(home, ".pi", "npm", "package.json"), `{"dependencies":{"pi-mcp-adapter":"^2.0.0"}}`)
-	writeFile(t, filepath.Join(home, ".pi", "agent", "mcp.json"), `{"activeMCP":"legacy","mcpServers":{"engram":{"command":"old-engram","args":["mcp"],"directTools":false,"env":{"STALE":"1"}}}}`)
 
 	first, err := Inject(home, piAdapter())
 	if err != nil {
@@ -290,12 +276,6 @@ func TestInjectPiProvisioningCanonicalizesExistingEntriesAndIsIdempotent(t *test
 	assertNestedStrings(t, settings, []string{"npm:pi-mcp-adapter"}, "packages")
 	npmPackage := readJSONFile(t, filepath.Join(home, ".pi", "npm", "package.json"))
 	assertNestedString(t, npmPackage, "^2.6.0", "dependencies", "pi-mcp-adapter")
-	mcp := readJSONFile(t, filepath.Join(home, ".pi", "agent", "mcp.json"))
-	assertNestedString(t, mcp, "engram", "activeMCP")
-	assertNestedString(t, mcp, "engram", "mcpServers", "engram", "command")
-	assertNestedStrings(t, mcp, []string{"mcp", "--tools=agent"}, "mcpServers", "engram", "args")
-	assertNestedBool(t, mcp, true, "mcpServers", "engram", "directTools")
-	assertNestedMissing(t, mcp, "mcpServers", "engram", "env")
 
 	second, err := Inject(home, piAdapter())
 	if err != nil {

--- a/internal/versions/versions.go
+++ b/internal/versions/versions.go
@@ -26,4 +26,4 @@ const GeminiCLI = "0.41.2"
 const Context7MCP = "2.2.5"
 
 // renovate: datasource=npm depName=gentle-engram
-const GentleEngram = "0.1.2"
+const GentleEngram = "0.1.4"


### PR DESCRIPTION
## Summary
- Bumps `gentle-engram` pin from `0.1.2` to `0.1.4`.
- Stops `ProvisionEngramMCP` from writing `~/.pi/agent/mcp.json` directly. `pi-engram init` (invoked by `InstallCommand`) is now the sole writer, owning the schema.

## Why
Pi 0.74.x changed `command` resolution in `mcp.json`. A bare `"engram"` no longer resolves through PATH, so Pi fails to spawn the MCP server (`0/1`). `gentle-engram@0.1.4` already addresses this by switching to `command: "node"` + an inline launcher that spawns engram via Node's `child_process.spawn`, which still resolves PATH. Today gentle-ai pins `0.1.2` and force-overwrites `mcp.json` with the old schema via `__replace__`, shadowing the fixed `pi-engram init`.

## Test plan
- [ ] `go test ./internal/agents/pi/... ./internal/versions/...` passes
- [ ] Manual: run `gentle-ai install --agent pi` against a clean `~/.pi/`, then `cat ~/.pi/agent/mcp.json` shows `command: "node"` (not `engram`) and Pi reports MCP `1/1`

Fixes #512