### PR TITLE
fix(assets): remove bilingual triggers from claude engram-protocol asset

### DIFF
--- a/internal/assets/assets_test.go
+++ b/internal/assets/assets_test.go
@@ -257,6 +257,27 @@ func TestGentlemanLanguageInstructionsDoNotBiasEnglishSessions(t *testing.T) {
 			}
 		})
 	}
+
+	// engram-protocol assets must not ship Spanish trigger examples that bias
+	// English sessions into Spanish replies (same mechanism as #341 / #350).
+	for _, path := range []string{
+		"claude/engram-protocol.md",
+	} {
+		t.Run(path, func(t *testing.T) {
+			content := MustRead(path)
+
+			for _, banned := range []string{
+				`"recordar"`,
+				`"listo"`,
+				`"acordate"`,
+				`"qué hicimos"`,
+			} {
+				if strings.Contains(content, banned) {
+					t.Fatalf("%s still contains Spanish trigger phrase %q that biases English sessions", path, banned)
+				}
+			}
+		})
+	}
 }
 
 // TestPersonasContainContextualSkillLoadingDirective verifies that every

--- a/internal/assets/assets_test.go
+++ b/internal/assets/assets_test.go
@@ -260,8 +260,10 @@ func TestGentlemanLanguageInstructionsDoNotBiasEnglishSessions(t *testing.T) {
 
 	// engram-protocol assets must not ship Spanish trigger examples that bias
 	// English sessions into Spanish replies (same mechanism as #341 / #350).
+	// Covers all agent families that ship a dedicated engram instruction asset.
 	for _, path := range []string{
 		"claude/engram-protocol.md",
+		"codex/engram-instructions.md",
 	} {
 		t.Run(path, func(t *testing.T) {
 			content := MustRead(path)

--- a/internal/assets/claude/engram-protocol.md
+++ b/internal/assets/claude/engram-protocol.md
@@ -49,7 +49,7 @@ Topic update rules:
 
 ### WHEN TO SEARCH MEMORY
 
-On any variation of "remember", "recall", "what did we do", "how did we solve", "recordar", "qué hicimos", or references to past work:
+On any variation of "remember", "recall", "what did we do", "how did we solve", or references to past work (in any language the user writes in):
 1. Call `mem_context` — checks recent session history (fast, cheap)
 2. If not found, call `mem_search` with relevant keywords
 3. If found, use `mem_get_observation` for full untruncated content
@@ -61,7 +61,7 @@ Also search PROACTIVELY when:
 
 ### SESSION CLOSE PROTOCOL (mandatory)
 
-Before ending a session or saying "done" / "listo" / "that's it", call `mem_session_summary`:
+Before ending a session or saying "done" / "that's it" (or the equivalent in the user's language), call `mem_session_summary`:
 
 ## Goal
 [What we were working on this session]

--- a/internal/assets/codex/engram-instructions.md
+++ b/internal/assets/codex/engram-instructions.md
@@ -40,7 +40,7 @@ Topic update rules:
 
 ### WHEN TO SEARCH MEMORY
 
-On any variation of "remember", "recall", "what did we do", "how did we solve", "recordar", "qué hicimos", or references to past work:
+On any variation of "remember", "recall", "what did we do", "how did we solve", or references to past work (in any language the user writes in):
 1. Call mem_context — checks recent session history (fast, cheap)
 2. If not found, call mem_search with relevant keywords
 3. If found, use mem_get_observation for full untruncated content
@@ -52,7 +52,7 @@ Also search PROACTIVELY when:
 
 ### SESSION CLOSE PROTOCOL (mandatory)
 
-Before ending a session or saying "done" / "listo" / "that's it", call mem_session_summary:
+Before ending a session or saying "done" / "that's it" (or the equivalent in the user's language), call mem_session_summary:
 
 ## Goal
 [What we were working on this session]

--- a/testdata/golden/combined-claude-claudemd.golden
+++ b/testdata/golden/combined-claude-claudemd.golden
@@ -409,7 +409,7 @@ Topic update rules:
 
 ### WHEN TO SEARCH MEMORY
 
-On any variation of "remember", "recall", "what did we do", "how did we solve", "recordar", "qué hicimos", or references to past work:
+On any variation of "remember", "recall", "what did we do", "how did we solve", or references to past work (in any language the user writes in):
 1. Call `mem_context` — checks recent session history (fast, cheap)
 2. If not found, call `mem_search` with relevant keywords
 3. If found, use `mem_get_observation` for full untruncated content
@@ -421,7 +421,7 @@ Also search PROACTIVELY when:
 
 ### SESSION CLOSE PROTOCOL (mandatory)
 
-Before ending a session or saying "done" / "listo" / "that's it", call `mem_session_summary`:
+Before ending a session or saying "done" / "that's it" (or the equivalent in the user's language), call `mem_session_summary`:
 
 ## Goal
 [What we were working on this session]

--- a/testdata/golden/combined-windsurf-global-rules.golden
+++ b/testdata/golden/combined-windsurf-global-rules.golden
@@ -459,7 +459,7 @@ Topic update rules:
 
 ### WHEN TO SEARCH MEMORY
 
-On any variation of "remember", "recall", "what did we do", "how did we solve", "recordar", "qué hicimos", or references to past work:
+On any variation of "remember", "recall", "what did we do", "how did we solve", or references to past work (in any language the user writes in):
 1. Call `mem_context` — checks recent session history (fast, cheap)
 2. If not found, call `mem_search` with relevant keywords
 3. If found, use `mem_get_observation` for full untruncated content
@@ -471,7 +471,7 @@ Also search PROACTIVELY when:
 
 ### SESSION CLOSE PROTOCOL (mandatory)
 
-Before ending a session or saying "done" / "listo" / "that's it", call `mem_session_summary`:
+Before ending a session or saying "done" / "that's it" (or the equivalent in the user's language), call `mem_session_summary`:
 
 ## Goal
 [What we were working on this session]

--- a/testdata/golden/engram-antigravity-rulesmd.golden
+++ b/testdata/golden/engram-antigravity-rulesmd.golden
@@ -50,7 +50,7 @@ Topic update rules:
 
 ### WHEN TO SEARCH MEMORY
 
-On any variation of "remember", "recall", "what did we do", "how did we solve", "recordar", "qué hicimos", or references to past work:
+On any variation of "remember", "recall", "what did we do", "how did we solve", or references to past work (in any language the user writes in):
 1. Call `mem_context` — checks recent session history (fast, cheap)
 2. If not found, call `mem_search` with relevant keywords
 3. If found, use `mem_get_observation` for full untruncated content
@@ -62,7 +62,7 @@ Also search PROACTIVELY when:
 
 ### SESSION CLOSE PROTOCOL (mandatory)
 
-Before ending a session or saying "done" / "listo" / "that's it", call `mem_session_summary`:
+Before ending a session or saying "done" / "that's it" (or the equivalent in the user's language), call `mem_session_summary`:
 
 ## Goal
 [What we were working on this session]

--- a/testdata/golden/engram-claude-claudemd.golden
+++ b/testdata/golden/engram-claude-claudemd.golden
@@ -50,7 +50,7 @@ Topic update rules:
 
 ### WHEN TO SEARCH MEMORY
 
-On any variation of "remember", "recall", "what did we do", "how did we solve", "recordar", "qué hicimos", or references to past work:
+On any variation of "remember", "recall", "what did we do", "how did we solve", or references to past work (in any language the user writes in):
 1. Call `mem_context` — checks recent session history (fast, cheap)
 2. If not found, call `mem_search` with relevant keywords
 3. If found, use `mem_get_observation` for full untruncated content
@@ -62,7 +62,7 @@ Also search PROACTIVELY when:
 
 ### SESSION CLOSE PROTOCOL (mandatory)
 
-Before ending a session or saying "done" / "listo" / "that's it", call `mem_session_summary`:
+Before ending a session or saying "done" / "that's it" (or the equivalent in the user's language), call `mem_session_summary`:
 
 ## Goal
 [What we were working on this session]


### PR DESCRIPTION
## Summary
- Removes Spanish trigger phrases (`"recordar"`, `"qué hicimos"`, `"listo"`) from `internal/assets/claude/engram-protocol.md`.
- Replaces them with English-only phrasing plus "or the equivalent in the user's language" language-lock guards, matching the pattern PR #350 applied to persona/output-style assets.
- Extends `TestGentlemanLanguageInstructionsDoNotBiasEnglishSessions` in `internal/assets/assets_test.go` to walk `claude/engram-protocol.md` and assert none of the banned Spanish tokens appear, so the regression cannot return silently.

## Why
`engram-protocol.md` is injected verbatim into the user's `~/.claude/CLAUDE.md` under the `<!-- gentle-ai:engram-protocol -->` marker. Two lines still carried bilingual trigger examples:

- Line 52: `"recordar", "qué hicimos"` alongside English equivalents
- Line 64: `"listo"` in the session-close trigger

The model reads those Spanish phrases as evidence that Spanish is a valid working register, even when the user's first message is in English. That is the same register-leak mechanism acknowledged in PR #350. The fix extends the language-lock pattern from that PR to cover this missed asset.

## Test plan
- [x] `go test ./internal/assets/... -run TestGentlemanLanguageInstructionsDoNotBiasEnglishSessions` fails before fix, passes after
- [x] `go test ./internal/components/persona/... ./internal/assets/...` green

Closes #520