### PR TITLE
fix(openclaw): verify canonical openclaw.json path

### DIFF
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -883,7 +883,12 @@ func componentPathsWithWorkspace(homeDir, workspaceDir string, selection model.S
 			case model.StrategySeparateMCPFiles:
 				paths = append(paths, adapter.MCPConfigPath(targetDir, "engram"))
 			case model.StrategyMergeIntoSettings:
-				if p := adapter.SettingsPath(targetDir); p != "" {
+				// MCP settings are always merged into the global config file, not the
+				// workspace-scoped directory. For OpenClaw, SettingsPath(targetDir)
+				// would yield <workspace>/.openclaw/openclaw.json, but engram injection
+				// writes to the canonical ~/.openclaw/openclaw.json (homeDir). Use
+				// homeDir here so the verification path matches the actual write target.
+				if p := adapter.SettingsPath(homeDir); p != "" {
 					paths = append(paths, p)
 				}
 			case model.StrategyMCPConfigFile:

--- a/internal/cli/run_component_paths_test.go
+++ b/internal/cli/run_component_paths_test.go
@@ -199,6 +199,32 @@ func TestComponentPathsEngramCodexIncludesConfigTOML(t *testing.T) {
 	}
 }
 
+// TestComponentPathsEngramOpenClawUsesCanonicalSettingsPath asserts that the
+// engram component path for OpenClaw always resolves to the canonical
+// ~/.openclaw/openclaw.json and never to a workspace-scoped copy.
+//
+// This is a regression test for issue #522: the verifier used to call
+// SettingsPath(workspaceDir) which produced
+// <workspace>/.openclaw/openclaw.json, causing post-sync verification to
+// fail even when the file at the canonical path existed.
+func TestComponentPathsEngramOpenClawUsesCanonicalSettingsPath(t *testing.T) {
+	home := t.TempDir()
+	workspace := t.TempDir()
+	adapters := resolveAdapters([]model.AgentID{model.AgentOpenClaw})
+
+	paths := componentPathsWithWorkspace(home, workspace, model.Selection{}, adapters, model.ComponentEngram)
+
+	canonical := filepath.Join(home, ".openclaw", "openclaw.json")
+	if !containsPath(paths, canonical) {
+		t.Fatalf("componentPathsWithWorkspace(engram,openclaw) missing canonical path %q\npaths=%v", canonical, paths)
+	}
+
+	wrongPath := filepath.Join(workspace, ".openclaw", "openclaw.json")
+	if containsPath(paths, wrongPath) {
+		t.Fatalf("componentPathsWithWorkspace(engram,openclaw) must not include workspace-scoped path %q\npaths=%v", wrongPath, paths)
+	}
+}
+
 func containsPath(paths []string, want string) bool {
 	for _, p := range paths {
 		if p == want {


### PR DESCRIPTION
## Summary

- `componentPathsWithWorkspace` called `SettingsPath(targetDir)` for the `StrategyMergeIntoSettings` engram case. For OpenClaw, `targetDir` resolves to the workspace directory, producing `<workspace>/.openclaw/openclaw.json`.
- `engram.InjectWithPromptDir` always writes to the canonical `~/.openclaw/openclaw.json` (using `homeDir`), so the post-sync verification check was looking at a path that was never written.
- Changed the `StrategyMergeIntoSettings` engram branch to use `homeDir` instead of `targetDir`. For all non-OpenClaw agents, `targetDir == homeDir`, so the change is a no-op for them.
- Added `TestComponentPathsEngramOpenClawUsesCanonicalSettingsPath` to pin the expected path and prevent this from regressing.

## Test plan

- [ ] `go test ./internal/cli/...` passes including the new regression test
- [ ] `go test ./internal/verify/... ./internal/components/...` passes with no regressions
- [ ] On a real OpenClaw install with workspace at `~/.openclaw/workspace`, `gentle-ai sync` should complete verification successfully when `~/.openclaw/openclaw.json` exists

Closes #522