### PR TITLE
feat(engram): data directory service and injection options

### DIFF
--- a/internal/components/engram/copy.go
+++ b/internal/components/engram/copy.go
@@ -1,0 +1,72 @@
+package engram
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// CopyDB copies the Engram SQLite database from src to dst.
+//
+// Strategy: write to a temp file (dst+".tmp") first, verify the byte count,
+// then rename atomically. The temp file is removed on any error so dst is
+// never left in a partial state.
+//
+// io.Copy is used without an explicit buffer: when both src and dst are
+// *os.File, Go 1.21+ calls (*os.File).ReadFrom which invokes sendfile(2) on
+// Linux and the equivalent on macOS. On Windows it falls back to efficient
+// buffered I/O. No manual buffer allocation needed.
+func CopyDB(src, dst string) error {
+	srcInfo, err := os.Stat(src)
+	if err != nil {
+		return fmt.Errorf("stat source %q: %w", src, err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return fmt.Errorf("create destination dir for %q: %w", dst, err)
+	}
+
+	tmp := dst + ".tmp"
+
+	dstFile, err := os.Create(tmp)
+	if err != nil {
+		return fmt.Errorf("create temp file %q: %w", tmp, err)
+	}
+
+	srcFile, err := os.Open(src)
+	if err != nil {
+		dstFile.Close()
+		os.Remove(tmp)
+		return fmt.Errorf("open source %q: %w", src, err)
+	}
+
+	_, copyErr := io.Copy(dstFile, srcFile)
+	srcFile.Close()
+	syncErr := dstFile.Sync()
+	dstFile.Close()
+
+	if copyErr != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("copy %q → %q: %w", src, dst, copyErr)
+	}
+	if syncErr != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("sync %q: %w", tmp, syncErr)
+	}
+
+	dstInfo, err := os.Stat(tmp)
+	if err != nil || dstInfo.Size() != srcInfo.Size() {
+		os.Remove(tmp)
+		if err != nil {
+			return fmt.Errorf("stat temp file %q: %w", tmp, err)
+		}
+		return fmt.Errorf("incomplete copy: wrote %d bytes, expected %d", dstInfo.Size(), srcInfo.Size())
+	}
+
+	if err := os.Rename(tmp, dst); err != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("rename %q → %q: %w", tmp, dst, err)
+	}
+	return nil
+}

--- a/internal/components/engram/copy_test.go
+++ b/internal/components/engram/copy_test.go
@@ -1,0 +1,99 @@
+package engram
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCopyDB_Basic(t *testing.T) {
+	src := filepath.Join(t.TempDir(), "engram.db")
+	dst := filepath.Join(t.TempDir(), "engram.db")
+
+	content := []byte("fake sqlite database content for testing")
+	if err := os.WriteFile(src, content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := CopyDB(src, dst); err != nil {
+		t.Fatalf("CopyDB: %v", err)
+	}
+
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("read dst: %v", err)
+	}
+	if string(got) != string(content) {
+		t.Errorf("content mismatch: got %q, want %q", got, content)
+	}
+}
+
+func TestCopyDB_CreatesDestDir(t *testing.T) {
+	src := filepath.Join(t.TempDir(), "engram.db")
+	// dst is inside a non-existent subdirectory.
+	dst := filepath.Join(t.TempDir(), "subdir", "deep", "engram.db")
+
+	if err := os.WriteFile(src, []byte("data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := CopyDB(src, dst); err != nil {
+		t.Fatalf("CopyDB: %v", err)
+	}
+
+	if _, err := os.Stat(dst); err != nil {
+		t.Errorf("dst not created: %v", err)
+	}
+}
+
+func TestCopyDB_NoTempOnSuccess(t *testing.T) {
+	src := filepath.Join(t.TempDir(), "engram.db")
+	dst := filepath.Join(t.TempDir(), "engram.db")
+
+	if err := os.WriteFile(src, []byte("data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := CopyDB(src, dst); err != nil {
+		t.Fatalf("CopyDB: %v", err)
+	}
+
+	tmp := dst + ".tmp"
+	if _, err := os.Stat(tmp); !os.IsNotExist(err) {
+		t.Errorf("temp file %q should not exist after success", tmp)
+	}
+}
+
+func TestCopyDB_SourceNotExist(t *testing.T) {
+	src := filepath.Join(t.TempDir(), "nonexistent.db")
+	dst := filepath.Join(t.TempDir(), "engram.db")
+
+	err := CopyDB(src, dst)
+	if err == nil {
+		t.Fatal("expected error for missing source, got nil")
+	}
+}
+
+func TestCopyDB_Idempotent(t *testing.T) {
+	src := filepath.Join(t.TempDir(), "engram.db")
+	dst := filepath.Join(t.TempDir(), "engram.db")
+	content := []byte("idempotent copy test")
+
+	if err := os.WriteFile(src, content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Copy twice — should succeed both times.
+	for i := 0; i < 2; i++ {
+		if err := CopyDB(src, dst); err != nil {
+			t.Fatalf("CopyDB iteration %d: %v", i, err)
+		}
+	}
+
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(content) {
+		t.Errorf("content mismatch after second copy")
+	}
+}

--- a/internal/components/engram/env.go
+++ b/internal/components/engram/env.go
@@ -1,0 +1,32 @@
+package engram
+
+import (
+	"path/filepath"
+)
+
+// DataDirRef is the persisted reference to an Engram data directory.
+// Currently resolves to a local filesystem path.
+// Future URI schemes (e.g. "provider://...") can be added inside Resolve
+// without changing the JSON format or breaking existing installations.
+type DataDirRef string
+
+// Resolve returns the effective local filesystem path for the data directory.
+// An empty ref resolves to the platform default (~/.engram).
+func (r DataDirRef) Resolve(homeDir string) string {
+	if r == "" {
+		return DefaultDir(homeDir)
+	}
+	// filepath.FromSlash normalises Windows path separators on any input,
+	// filepath.Clean removes redundant separators and dots.
+	return filepath.Clean(filepath.FromSlash(string(r)))
+}
+
+// DefaultDir returns the default Engram data directory path (~/.engram).
+func DefaultDir(homeDir string) string {
+	return filepath.Join(homeDir, ".engram")
+}
+
+// DBPath returns the path to the Engram SQLite database inside dataDir.
+func DBPath(dataDir string) string {
+	return filepath.Join(dataDir, "engram.db")
+}

--- a/internal/components/engram/env_test.go
+++ b/internal/components/engram/env_test.go
@@ -1,0 +1,44 @@
+package engram
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestDataDirRef_Resolve(t *testing.T) {
+	home := t.TempDir()
+	custom := filepath.Join(home, "custom-data")
+
+	tests := []struct {
+		ref  DataDirRef
+		want string
+	}{
+		{"", DefaultDir(home)},
+		{DataDirRef(DefaultDir(home)), DefaultDir(home)},
+		{DataDirRef(custom), custom},
+		// trailing separator is cleaned
+		{DataDirRef(custom + string(filepath.Separator)), custom},
+	}
+	for _, tt := range tests {
+		got := tt.ref.Resolve(home)
+		if got != tt.want {
+			t.Errorf("DataDirRef(%q).Resolve(%q) = %q, want %q", tt.ref, home, got, tt.want)
+		}
+	}
+}
+
+func TestDefaultDir(t *testing.T) {
+	got := DefaultDir("/home/user")
+	want := filepath.Join("/home/user", ".engram")
+	if got != want {
+		t.Errorf("DefaultDir = %q, want %q", got, want)
+	}
+}
+
+func TestDBPath(t *testing.T) {
+	got := DBPath("/home/user/.engram")
+	want := filepath.Join("/home/user/.engram", "engram.db")
+	if got != want {
+		t.Errorf("DBPath = %q, want %q", got, want)
+	}
+}

--- a/internal/components/engram/inject.go
+++ b/internal/components/engram/inject.go
@@ -20,6 +20,21 @@ type InjectionResult struct {
 	Files   []string
 }
 
+// InjectOptions configures optional overrides for InjectWithOptions.
+type InjectOptions struct {
+	// DataDir, when non-empty, injects ENGRAM_DATA_DIR into MCP server configs.
+	DataDir string
+}
+
+// engramEnvMap returns the env block to embed in MCP server configs, or nil
+// when no overrides are needed.
+func engramEnvMap(dataDir string) map[string]any {
+	if dataDir == "" {
+		return nil
+	}
+	return map[string]any{"ENGRAM_DATA_DIR": dataDir}
+}
+
 // bootstrapper is an optional adapter capability: if an adapter implements
 // this interface, any injector that writes Jinja modules will first ensure
 // the base template (entry point) exists.
@@ -77,15 +92,18 @@ func resolveEngramCommand() (string, bool) {
 // path to the engram binary if it can be resolved via PATH.
 func engramServerJSON() []byte {
 	cmd, _ := resolveEngramCommand()
-	return engramServerJSONWithCmd(cmd)
+	return engramServerJSONWithCmd(cmd, nil)
 }
 
 // engramServerJSONWithCmd returns the MCP server config bytes for a specific
-// command.
-func engramServerJSONWithCmd(cmd string) []byte {
+// command. env is merged into the top-level object when non-nil.
+func engramServerJSONWithCmd(cmd string, env map[string]any) []byte {
 	cfg := map[string]any{
 		"command": cmd,
 		"args":    []string{"mcp", "--tools=agent"},
+	}
+	if len(env) > 0 {
+		cfg["env"] = env
 	}
 	b, _ := json.MarshalIndent(cfg, "", "  ")
 	return append(b, '\n')
@@ -93,7 +111,8 @@ func engramServerJSONWithCmd(cmd string) []byte {
 
 // engramOverlayJSON returns the settings overlay JSON (used for merge-into-settings
 // and MCPConfigFile strategies), with the resolved engram command.
-func engramOverlayJSON(agentID model.AgentID, cmd string) []byte {
+// env is merged into the server object when non-nil.
+func engramOverlayJSON(agentID model.AgentID, cmd string, env map[string]any) []byte {
 	var cfg map[string]any
 	if agentID == model.AgentOpenCode || agentID == model.AgentKilocode {
 		// OpenCode 1.3.3+ requires command as an array for type:local servers.
@@ -105,13 +124,17 @@ func engramOverlayJSON(agentID model.AgentID, cmd string) []byte {
 		// Without this, users upgrading from v1.11.3 (which had a separate
 		// "args" key) would end up with both "args" and the new array "command"
 		// in their config, which is invalid for OpenCode 1.3.3.
+		inner := map[string]any{
+			"command": []string{cmd, "mcp", "--tools=agent"},
+			"type":    "local",
+		}
+		if len(env) > 0 {
+			inner["env"] = env
+		}
 		cfg = map[string]any{
 			"mcp": map[string]any{
 				"engram": map[string]any{
-					"__replace__": map[string]any{
-						"command": []string{cmd, "mcp", "--tools=agent"},
-						"type":    "local",
-					},
+					"__replace__": inner,
 				},
 			},
 		}
@@ -129,12 +152,16 @@ func engramOverlayJSON(agentID model.AgentID, cmd string) []byte {
 			},
 		}
 	} else {
+		server := map[string]any{
+			"command": cmd,
+			"args":    []string{"mcp", "--tools=agent"},
+		}
+		if len(env) > 0 {
+			server["env"] = env
+		}
 		cfg = map[string]any{
 			"mcpServers": map[string]any{
-				"engram": map[string]any{
-					"command": cmd,
-					"args":    []string{"mcp", "--tools=agent"},
-				},
+				"engram": server,
 			},
 		}
 	}
@@ -146,21 +173,35 @@ func engramOverlayJSON(agentID model.AgentID, cmd string) []byte {
 // Uses --tools=agent per engram contract.
 // VS Code uses a fixed "servers" key structure rather than mcpServers, so it
 // is kept as a separate helper.
-func vsCodeEngramOverlayJSON(cmd string) []byte {
+// env is merged into the server object when non-nil.
+func vsCodeEngramOverlayJSON(cmd string, env map[string]any) []byte {
+	server := map[string]any{
+		"command": cmd,
+		"args":    []string{"mcp", "--tools=agent"},
+	}
+	if len(env) > 0 {
+		server["env"] = env
+	}
 	cfg := map[string]any{
 		"servers": map[string]any{
-			"engram": map[string]any{
-				"command": cmd,
-				"args":    []string{"mcp", "--tools=agent"},
-			},
+			"engram": server,
 		},
 	}
 	b, _ := json.MarshalIndent(cfg, "", "  ")
 	return append(b, '\n')
 }
 
+// Inject injects the Engram MCP server config and memory protocol into the
+// given agent adapter. It is a backward-compatible wrapper around InjectWithOptions.
 func Inject(homeDir string, adapter agents.Adapter) (InjectionResult, error) {
-	return inject(homeDir, homeDir, adapter)
+	return InjectWithOptions(homeDir, adapter, InjectOptions{})
+}
+
+// InjectWithOptions extends Inject with optional configuration. When
+// opts.DataDir is non-empty, ENGRAM_DATA_DIR is injected into every MCP
+// server config block so the agent uses the specified data directory.
+func InjectWithOptions(homeDir string, adapter agents.Adapter, opts InjectOptions) (InjectionResult, error) {
+	return injectCore(homeDir, homeDir, adapter, opts)
 }
 
 // InjectWithPromptDir writes Engram's MCP configuration using configHomeDir and
@@ -168,18 +209,19 @@ func Inject(homeDir string, adapter agents.Adapter) (InjectionResult, error) {
 // as OpenClaw where MCP is loaded from the global config but instructions are
 // read from an active workspace.
 func InjectWithPromptDir(configHomeDir, promptDir string, adapter agents.Adapter) (InjectionResult, error) {
-	return inject(configHomeDir, promptDir, adapter)
+	return injectCore(configHomeDir, promptDir, adapter, InjectOptions{})
 }
 
-func inject(configHomeDir, promptDir string, adapter agents.Adapter) (InjectionResult, error) {
-	if provisioner, ok := adapter.(piEngramProvisioner); ok {
-		changed, files, err := provisioner.ProvisionEngramMCP(configHomeDir)
-		if err != nil {
-			return InjectionResult{}, err
+func injectCore(configHomeDir, promptDir string, adapter agents.Adapter, opts InjectOptions) (InjectionResult, error) {
+	if opts.DataDir == "" {
+		if provisioner, ok := adapter.(piEngramProvisioner); ok {
+			changed, files, err := provisioner.ProvisionEngramMCP(configHomeDir)
+			if err != nil {
+				return InjectionResult{}, err
+			}
+			return InjectionResult{Changed: changed, Files: files}, nil
 		}
-		return InjectionResult{Changed: changed, Files: files}, nil
 	}
-
 	if !adapter.SupportsMCP() {
 		return InjectionResult{}, nil
 	}
@@ -187,6 +229,7 @@ func inject(configHomeDir, promptDir string, adapter agents.Adapter) (InjectionR
 		return InjectionResult{}, err
 	}
 
+	env := engramEnvMap(opts.DataDir)
 	files := make([]string, 0, 2)
 	changed := false
 
@@ -200,7 +243,7 @@ func inject(configHomeDir, promptDir string, adapter agents.Adapter) (InjectionR
 		// See: https://github.com/Gentleman-Programming/gentle-ai/issues (engram absolute path regression)
 		mcpPath := adapter.MCPConfigPath(configHomeDir, "engram")
 		cmd := stableEngramCommandForMergedConfig(mcpPath, adapter.Agent())
-		content := buildSeparateMCPContent(mcpPath, engramServerJSONWithCmd(cmd))
+		content := buildSeparateMCPContent(mcpPath, engramServerJSONWithCmd(cmd, env), env)
 		mcpWrite, err := filemerge.WriteFileAtomic(mcpPath, content, 0o644)
 		if err != nil {
 			return InjectionResult{}, err
@@ -213,7 +256,7 @@ func inject(configHomeDir, promptDir string, adapter agents.Adapter) (InjectionR
 		if settingsPath == "" {
 			break
 		}
-		overlay := engramOverlayJSON(adapter.Agent(), stableEngramCommandForMergedConfig(settingsPath, adapter.Agent()))
+		overlay := engramOverlayJSON(adapter.Agent(), stableEngramCommandForMergedConfig(settingsPath, adapter.Agent()), env)
 		settingsWrite, err := mergeJSONFile(settingsPath, overlay)
 		if err != nil {
 			return InjectionResult{}, err
@@ -228,9 +271,9 @@ func inject(configHomeDir, promptDir string, adapter agents.Adapter) (InjectionR
 		}
 		var overlay []byte
 		if adapter.Agent() == model.AgentVSCodeCopilot {
-			overlay = vsCodeEngramOverlayJSON(stableEngramCommandForMergedConfig(mcpPath, adapter.Agent()))
+			overlay = vsCodeEngramOverlayJSON(stableEngramCommandForMergedConfig(mcpPath, adapter.Agent()), env)
 		} else {
-			overlay = engramOverlayJSON(adapter.Agent(), stableEngramCommandForMergedConfig(mcpPath, adapter.Agent()))
+			overlay = engramOverlayJSON(adapter.Agent(), stableEngramCommandForMergedConfig(mcpPath, adapter.Agent()), env)
 		}
 
 		mcpWrite, err := mergeJSONFile(mcpPath, overlay)
@@ -587,7 +630,7 @@ func isStandardAgent(id model.AgentID) bool {
 //     args (["mcp", "--tools=agent"]) so that the absolute path is preserved
 //     and the correct flags are always present.
 //   - Otherwise (relative command or other value), return defaultContent.
-func buildSeparateMCPContent(mcpPath string, defaultContent []byte) []byte {
+func buildSeparateMCPContent(mcpPath string, defaultContent []byte, env map[string]any) []byte {
 	raw, err := os.ReadFile(mcpPath)
 	if err != nil {
 		// File does not exist or is not readable — use the default.
@@ -611,6 +654,9 @@ func buildSeparateMCPContent(mcpPath string, defaultContent []byte) []byte {
 	rebuilt := map[string]any{
 		"command": cmd,
 		"args":    []string{"mcp", "--tools=agent"},
+	}
+	if len(env) > 0 {
+		rebuilt["env"] = env
 	}
 	encoded, err := json.MarshalIndent(rebuilt, "", "  ")
 	if err != nil {

--- a/internal/components/engram/locations.go
+++ b/internal/components/engram/locations.go
@@ -1,0 +1,81 @@
+package engram
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/gentleman-programming/gentle-ai/internal/storage"
+)
+
+// Location is a candidate Engram data directory the user can choose from.
+type Location struct {
+	Path      string // absolute, cleaned filesystem path
+	Label     string // human-readable: "Default (~/.engram)", "D:\\ (120 GiB free)"
+	Available int64  // bytes free on the containing volume; -1 if unknown
+	IsCurrent bool   // true when this matches the currently active data dir
+}
+
+// SuggestLocations returns an ordered list of candidate data directories.
+// The current location is always listed first. The default ~/.engram follows,
+// then any additional volumes detected on the platform (see platform files).
+// Duplicate paths are deduplicated; labels include free-space info where available.
+func SuggestLocations(homeDir, currentDir string) []Location {
+	seen := map[string]bool{}
+	var out []Location
+
+	add := func(path string, isCurrent bool) {
+		clean := filepath.Clean(path)
+		if seen[clean] {
+			return
+		}
+		seen[clean] = true
+		avail, err := storage.AvailableBytes(filepath.Dir(clean))
+		if err != nil {
+			avail = -1
+		}
+		label := buildLabel(clean, homeDir, avail)
+		out = append(out, Location{
+			Path:      clean,
+			Label:     label,
+			Available: avail,
+			IsCurrent: isCurrent,
+		})
+	}
+
+	// Current location first (may equal default).
+	if currentDir != "" {
+		add(currentDir, true)
+	}
+
+	// Default location — isCurrent only when no explicit current dir was provided.
+	// If currentDir equals the default the seen-map dedup above already handles it;
+	// if currentDir is a custom path the default is a non-current alternative.
+	add(DefaultDir(homeDir), currentDir == "")
+
+	// Platform-specific extra volumes (see locations_unix.go / locations_windows.go).
+	for _, vol := range platformVolumes() {
+		add(filepath.Join(vol, "Engram"), false)
+	}
+
+	return out
+}
+
+// buildLabel constructs the display label for a location entry.
+func buildLabel(path, homeDir string, available int64) string {
+	// Replace home prefix with ~ for readability.
+	display := path
+	if rel, err := filepath.Rel(homeDir, path); err == nil && len(rel) < len(path) {
+		display = filepath.Join("~", rel)
+	}
+
+	if available < 0 {
+		return display
+	}
+	return display + "  (" + storage.FormatBytes(available) + " free)"
+}
+
+// dirExists is a small helper used by platform files.
+func dirExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
+}

--- a/internal/components/engram/locations_test.go
+++ b/internal/components/engram/locations_test.go
@@ -1,0 +1,95 @@
+package engram
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestSuggestLocations_DefaultFirst(t *testing.T) {
+	home := t.TempDir()
+
+	locs := SuggestLocations(home, "")
+	if len(locs) == 0 {
+		t.Fatal("SuggestLocations returned no locations")
+	}
+	// Without a current dir the default should be first.
+	want := filepath.Clean(DefaultDir(home))
+	if locs[0].Path != want {
+		t.Errorf("first location = %q, want default %q", locs[0].Path, want)
+	}
+}
+
+func TestSuggestLocations_CurrentFirst(t *testing.T) {
+	home := t.TempDir()
+	current := filepath.Join(home, "custom-engram")
+
+	locs := SuggestLocations(home, current)
+	if len(locs) == 0 {
+		t.Fatal("SuggestLocations returned no locations")
+	}
+	if locs[0].Path != filepath.Clean(current) {
+		t.Errorf("first location = %q, want current %q", locs[0].Path, current)
+	}
+	if !locs[0].IsCurrent {
+		t.Error("first location IsCurrent should be true")
+	}
+}
+
+func TestSuggestLocations_DefaultNotCurrentWhenCustomDirSet(t *testing.T) {
+	home := t.TempDir()
+	custom := filepath.Join(home, "custom-engram")
+
+	locs := SuggestLocations(home, custom)
+
+	defaultPath := filepath.Clean(DefaultDir(home))
+	for _, loc := range locs {
+		if loc.Path == defaultPath && loc.IsCurrent {
+			t.Errorf("default dir %q should NOT be IsCurrent when a custom dir is set", defaultPath)
+		}
+	}
+}
+
+func TestSuggestLocations_NoDuplicates(t *testing.T) {
+	home := t.TempDir()
+	// When current == default, we should get exactly one entry for that path.
+	defaultDir := DefaultDir(home)
+	locs := SuggestLocations(home, defaultDir)
+
+	seen := map[string]int{}
+	for _, l := range locs {
+		seen[l.Path]++
+	}
+	for path, count := range seen {
+		if count > 1 {
+			t.Errorf("path %q appears %d times, want 1", path, count)
+		}
+	}
+}
+
+func TestBuildLabel_HomePrefix(t *testing.T) {
+	home := "/home/user"
+	path := filepath.Join(home, ".engram")
+	label := buildLabel(path, home, -1)
+	if label != filepath.Join("~", ".engram") {
+		t.Errorf("buildLabel = %q, want %q", label, filepath.Join("~", ".engram"))
+	}
+}
+
+func TestBuildLabel_WithFreeSpace(t *testing.T) {
+	home := "/home/user"
+	path := filepath.Join(home, ".engram")
+	label := buildLabel(path, home, 1024*1024*1024) // 1 GiB
+	want := filepath.Join("~", ".engram") + "  (1.0 GiB free)"
+	if label != want {
+		t.Errorf("buildLabel = %q, want %q", label, want)
+	}
+}
+
+func TestBuildLabel_NoHomePrefix(t *testing.T) {
+	home := "/home/user"
+	path := "/external/drive/engram"
+	label := buildLabel(path, home, -1)
+	if label != path {
+		t.Errorf("buildLabel = %q, want %q", label, path)
+	}
+}

--- a/internal/components/engram/locations_unix.go
+++ b/internal/components/engram/locations_unix.go
@@ -1,0 +1,25 @@
+//go:build !windows
+
+package engram
+
+import "path/filepath"
+
+// platformVolumes returns mount-point directories to suggest as alternative
+// Engram data locations on macOS (/Volumes/*) and Linux (/mnt/*, /media/*/*).
+func platformVolumes() []string {
+	var roots []string
+
+	for _, glob := range []string{
+		"/Volumes/*",       // macOS external drives
+		"/mnt/*",           // Linux manual mounts
+		"/media/*/*",       // Linux user-automounted drives (udisks2)
+	} {
+		matches, _ := filepath.Glob(glob)
+		for _, m := range matches {
+			if dirExists(m) {
+				roots = append(roots, m)
+			}
+		}
+	}
+	return roots
+}

--- a/internal/components/engram/locations_windows.go
+++ b/internal/components/engram/locations_windows.go
@@ -1,0 +1,38 @@
+//go:build windows
+
+package engram
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+var (
+	_kernel32              = syscall.NewLazyDLL("kernel32.dll")
+	_getDiskFreeSpaceExW   = _kernel32.NewProc("GetDiskFreeSpaceExW")
+)
+
+// platformVolumes returns drive roots that have available disk space on Windows.
+// It iterates A–Z and includes any root (e.g. "C:\") where GetDiskFreeSpaceExW
+// succeeds — meaning the drive is present and accessible.
+func platformVolumes() []string {
+	var roots []string
+	for c := 'A'; c <= 'Z'; c++ {
+		root := string(c) + ":\\"
+		ptr, err := syscall.UTF16PtrFromString(root)
+		if err != nil {
+			continue
+		}
+		var avail, total, free uint64
+		r, _, _ := _getDiskFreeSpaceExW.Call(
+			uintptr(unsafe.Pointer(ptr)),
+			uintptr(unsafe.Pointer(&avail)),
+			uintptr(unsafe.Pointer(&total)),
+			uintptr(unsafe.Pointer(&free)),
+		)
+		if r != 0 {
+			roots = append(roots, root)
+		}
+	}
+	return roots
+}

--- a/internal/components/engram/presenter.go
+++ b/internal/components/engram/presenter.go
@@ -1,0 +1,25 @@
+package engram
+
+import (
+	"fmt"
+
+	"github.com/gentleman-programming/gentle-ai/internal/storage"
+)
+
+// FormatDirLine returns a single display line for a data-directory option, e.g.
+// "~/.engram  (1.2 GiB used)". Used in TUI option lists.
+func FormatDirLine(dir string, dbSize int64) string {
+	if dbSize <= 0 {
+		return dir
+	}
+	return fmt.Sprintf("%s  (%s used)", dir, storage.FormatBytes(dbSize))
+}
+
+// FormatSpaceWarning returns a human-readable warning for insufficient disk
+// space, e.g. "Need 1.2 GiB, only 300.0 MiB free".
+func FormatSpaceWarning(needed, avail int64) string {
+	return fmt.Sprintf("Need %s, only %s free",
+		storage.FormatBytes(needed),
+		storage.FormatBytes(avail),
+	)
+}

--- a/internal/components/engram/service.go
+++ b/internal/components/engram/service.go
@@ -1,0 +1,99 @@
+package engram
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/gentleman-programming/gentle-ai/internal/backup"
+	"github.com/gentleman-programming/gentle-ai/internal/storage"
+)
+
+// snapshotter is a subset of backup.Snapshotter used for testability.
+type snapshotter interface {
+	Create(snapshotDir string, paths []string) (backup.Manifest, error)
+}
+
+// DataDirService provides safe, snapshot-guarded operations on the Engram
+// data directory. Every mutating operation creates a backup before changing
+// anything; the snapshot is visible in the Backups TUI screen.
+type DataDirService struct {
+	homeDir     string
+	backupRoot  string
+	snapshotter snapshotter
+}
+
+// NewDataDirService creates a DataDirService with the default backup.Snapshotter.
+func NewDataDirService(homeDir string) DataDirService {
+	return DataDirService{
+		homeDir:     homeDir,
+		backupRoot:  filepath.Join(homeDir, ".gentle-ai", "backups"),
+		snapshotter: backup.NewSnapshotter(),
+	}
+}
+
+// CopyTo copies the Engram DB from currentDir to dst without removing the source.
+// A snapshot of the source DB is created first. Returns the snapshot manifest.
+func (s DataDirService) CopyTo(currentDir, dst string) (backup.Manifest, error) {
+	srcDB := DBPath(currentDir)
+	snap, err := s.snapshot(srcDB)
+	if err != nil {
+		return backup.Manifest{}, fmt.Errorf("snapshot before copy: %w", err)
+	}
+	if err := CopyDB(srcDB, DBPath(dst)); err != nil {
+		return snap, fmt.Errorf("copy: %w", err)
+	}
+	return snap, nil
+}
+
+// MoveTo copies the Engram DB from currentDir to dst, then removes the source DB.
+// The source is only removed after the copy is verified. Returns the snapshot manifest.
+func (s DataDirService) MoveTo(currentDir, dst string) (backup.Manifest, error) {
+	snap, err := s.CopyTo(currentDir, dst)
+	if err != nil {
+		return snap, err
+	}
+	if err := os.Remove(DBPath(currentDir)); err != nil && !os.IsNotExist(err) {
+		return snap, fmt.Errorf("remove source after move: %w", err)
+	}
+	return snap, nil
+}
+
+// Delete creates a snapshot of the current DB, then removes it.
+// Returns the snapshot manifest so the caller can show the backup ID.
+func (s DataDirService) Delete(dataDir string) (backup.Manifest, error) {
+	dbPath := DBPath(dataDir)
+	snap, err := s.snapshot(dbPath)
+	if err != nil {
+		return backup.Manifest{}, fmt.Errorf("snapshot before delete: %w", err)
+	}
+	if err := os.Remove(dbPath); err != nil && !os.IsNotExist(err) {
+		return snap, fmt.Errorf("delete: %w", err)
+	}
+	return snap, nil
+}
+
+// DiskSpaceOK reports whether the volume at dst has enough free space to hold
+// a copy of the DB at srcDB. Returns (ok, needed bytes, available bytes, error).
+func (s DataDirService) DiskSpaceOK(srcDB, dst string) (bool, int64, int64, error) {
+	info, err := os.Stat(srcDB)
+	if err != nil {
+		return false, 0, 0, fmt.Errorf("stat source DB %q: %w", srcDB, err)
+	}
+	avail, err := storage.AvailableBytes(dst)
+	if err != nil {
+		return false, 0, 0, fmt.Errorf("check available space at %q: %w", dst, err)
+	}
+	needed := info.Size()
+	return avail > needed, needed, avail, nil
+}
+
+// snapshot creates a timestamped backup of dbPath under the backup root.
+func (s DataDirService) snapshot(dbPath string) (backup.Manifest, error) {
+	if err := os.MkdirAll(s.backupRoot, 0o755); err != nil {
+		return backup.Manifest{}, fmt.Errorf("create backup root %q: %w", s.backupRoot, err)
+	}
+	snapshotDir := filepath.Join(s.backupRoot, time.Now().UTC().Format("20060102150405.000000000"))
+	return s.snapshotter.Create(snapshotDir, []string{dbPath})
+}

--- a/internal/components/engram/service_test.go
+++ b/internal/components/engram/service_test.go
@@ -1,0 +1,160 @@
+package engram
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/internal/backup"
+)
+
+// stubSnapshotter satisfies the snapshotter interface without touching disk.
+type stubSnapshotter struct {
+	err      error
+	manifest backup.Manifest
+}
+
+func (s stubSnapshotter) Create(_ string, _ []string) (backup.Manifest, error) {
+	return s.manifest, s.err
+}
+
+func newTestService(t *testing.T) (DataDirService, string) {
+	t.Helper()
+	home := t.TempDir()
+	svc := DataDirService{
+		homeDir:     home,
+		backupRoot:  filepath.Join(home, ".gentle-ai", "backups"),
+		snapshotter: stubSnapshotter{manifest: backup.Manifest{ID: "snap-abc123"}},
+	}
+	return svc, home
+}
+
+func writeTestDB(t *testing.T, dir string) string {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := DBPath(dir)
+	if err := os.WriteFile(path, []byte("fake-sqlite"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestDataDirService_CopyTo(t *testing.T) {
+	svc, home := newTestService(t)
+	src := filepath.Join(home, "src-data")
+	dst := filepath.Join(home, "dst-data")
+	writeTestDB(t, src)
+
+	snap, err := svc.CopyTo(src, dst)
+	if err != nil {
+		t.Fatalf("CopyTo: %v", err)
+	}
+	if snap.ID != "snap-abc123" {
+		t.Errorf("snap.ID = %q, want snap-abc123", snap.ID)
+	}
+
+	// Source must still exist.
+	if _, err := os.Stat(DBPath(src)); err != nil {
+		t.Errorf("source DB removed after CopyTo: %v", err)
+	}
+	// Destination must exist.
+	if _, err := os.Stat(DBPath(dst)); err != nil {
+		t.Errorf("dst DB not created: %v", err)
+	}
+}
+
+func TestDataDirService_MoveTo(t *testing.T) {
+	svc, home := newTestService(t)
+	src := filepath.Join(home, "src-data")
+	dst := filepath.Join(home, "dst-data")
+	writeTestDB(t, src)
+
+	_, err := svc.MoveTo(src, dst)
+	if err != nil {
+		t.Fatalf("MoveTo: %v", err)
+	}
+
+	// Source must be gone.
+	if _, err := os.Stat(DBPath(src)); !os.IsNotExist(err) {
+		t.Error("source DB should not exist after MoveTo")
+	}
+	// Destination must exist.
+	if _, err := os.Stat(DBPath(dst)); err != nil {
+		t.Errorf("dst DB not created: %v", err)
+	}
+}
+
+func TestDataDirService_Delete(t *testing.T) {
+	svc, home := newTestService(t)
+	dir := filepath.Join(home, "data")
+	writeTestDB(t, dir)
+
+	snap, err := svc.Delete(dir)
+	if err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if snap.ID != "snap-abc123" {
+		t.Errorf("snap.ID = %q, want snap-abc123", snap.ID)
+	}
+
+	if _, err := os.Stat(DBPath(dir)); !os.IsNotExist(err) {
+		t.Error("DB should not exist after Delete")
+	}
+}
+
+func TestDataDirService_Delete_AlreadyGone(t *testing.T) {
+	svc, home := newTestService(t)
+	dir := filepath.Join(home, "data")
+
+	// Delete on a non-existent DB must not error (os.IsNotExist is tolerated).
+	_, err := svc.Delete(dir)
+	if err != nil {
+		t.Fatalf("Delete on missing DB: %v", err)
+	}
+}
+
+func TestDataDirService_SnapshotError_Propagates(t *testing.T) {
+	home := t.TempDir()
+	svc := DataDirService{
+		homeDir:     home,
+		backupRoot:  filepath.Join(home, ".gentle-ai", "backups"),
+		snapshotter: stubSnapshotter{err: errors.New("disk full")},
+	}
+
+	dir := filepath.Join(home, "data")
+	writeTestDB(t, dir)
+
+	_, err := svc.Delete(dir)
+	if err == nil {
+		t.Fatal("expected error from failing snapshotter, got nil")
+	}
+
+	// DB must still exist — no delete when snapshot failed.
+	if _, statErr := os.Stat(DBPath(dir)); statErr != nil {
+		t.Error("DB was deleted despite snapshot failure")
+	}
+}
+
+func TestDataDirService_DiskSpaceOK(t *testing.T) {
+	svc, home := newTestService(t)
+	dir := filepath.Join(home, "data")
+	dbPath := writeTestDB(t, dir)
+
+	ok, needed, avail, err := svc.DiskSpaceOK(dbPath, home)
+	if err != nil {
+		t.Fatalf("DiskSpaceOK: %v", err)
+	}
+	if needed <= 0 {
+		t.Errorf("needed = %d, want > 0", needed)
+	}
+	if avail <= 0 {
+		t.Errorf("avail = %d, want > 0", avail)
+	}
+	// A tiny test file on the same volume should always have space.
+	if !ok {
+		t.Errorf("DiskSpaceOK = false for tiny test file, expected true")
+	}
+}

--- a/internal/storage/bytes.go
+++ b/internal/storage/bytes.go
@@ -1,0 +1,23 @@
+package storage
+
+import "fmt"
+
+// FormatBytes formats n bytes as a human-readable string using 1024-based units,
+// consistent with Engram CLI output.
+func FormatBytes(n int64) string {
+	const (
+		kib = 1024
+		mib = 1024 * kib
+		gib = 1024 * mib
+	)
+	switch {
+	case n >= gib:
+		return fmt.Sprintf("%.1f GiB", float64(n)/float64(gib))
+	case n >= mib:
+		return fmt.Sprintf("%.1f MiB", float64(n)/float64(mib))
+	case n >= kib:
+		return fmt.Sprintf("%.1f KiB", float64(n)/float64(kib))
+	default:
+		return fmt.Sprintf("%d B", n)
+	}
+}

--- a/internal/storage/space.go
+++ b/internal/storage/space.go
@@ -1,0 +1,7 @@
+package storage
+
+// AvailableBytes returns the number of bytes available to an unprivileged user
+// on the volume containing path. path may be an existing file or directory.
+func AvailableBytes(path string) (int64, error) {
+	return availableBytes(path)
+}

--- a/internal/storage/space_test.go
+++ b/internal/storage/space_test.go
@@ -1,0 +1,65 @@
+package storage_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/internal/storage"
+)
+
+func TestAvailableBytes_TempDir(t *testing.T) {
+	dir := t.TempDir()
+	n, err := storage.AvailableBytes(dir)
+	if err != nil {
+		t.Fatalf("AvailableBytes(%q): unexpected error: %v", dir, err)
+	}
+	if n <= 0 {
+		t.Fatalf("AvailableBytes(%q) = %d, want > 0", dir, n)
+	}
+}
+
+func TestAvailableBytes_File(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "space-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+
+	n, err := storage.AvailableBytes(f.Name())
+	if err != nil {
+		t.Fatalf("AvailableBytes(%q): unexpected error: %v", f.Name(), err)
+	}
+	if n <= 0 {
+		t.Fatalf("AvailableBytes(%q) = %d, want > 0", f.Name(), n)
+	}
+}
+
+func TestAvailableBytes_NonExistent(t *testing.T) {
+	_, err := storage.AvailableBytes("/this/path/does/not/exist/ever")
+	if err == nil {
+		t.Fatal("expected error for non-existent path, got nil")
+	}
+}
+
+func TestFormatBytes(t *testing.T) {
+	tests := []struct {
+		n    int64
+		want string
+	}{
+		{0, "0 B"},
+		{512, "512 B"},
+		{1023, "1023 B"},
+		{1024, "1.0 KiB"},
+		{1536, "1.5 KiB"},
+		{1024 * 1024, "1.0 MiB"},
+		{int64(1.5 * 1024 * 1024), "1.5 MiB"},
+		{1024 * 1024 * 1024, "1.0 GiB"},
+		{int64(2469606195), "2.3 GiB"},
+	}
+	for _, tt := range tests {
+		got := storage.FormatBytes(tt.n)
+		if got != tt.want {
+			t.Errorf("FormatBytes(%d) = %q, want %q", tt.n, got, tt.want)
+		}
+	}
+}

--- a/internal/storage/space_unix.go
+++ b/internal/storage/space_unix.go
@@ -1,0 +1,17 @@
+//go:build !windows
+
+package storage
+
+import (
+	"fmt"
+	"syscall"
+)
+
+func availableBytes(path string) (int64, error) {
+	var stat syscall.Statfs_t
+	if err := syscall.Statfs(path, &stat); err != nil {
+		return 0, fmt.Errorf("statfs %q: %w", path, err)
+	}
+	// Bavail = blocks available to unprivileged users
+	return int64(stat.Bavail) * int64(stat.Bsize), nil
+}

--- a/internal/storage/space_windows.go
+++ b/internal/storage/space_windows.go
@@ -1,0 +1,40 @@
+//go:build windows
+
+package storage
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+	"unsafe"
+)
+
+var (
+	kernel32              = syscall.NewLazyDLL("kernel32.dll")
+	getDiskFreeSpaceExW   = kernel32.NewProc("GetDiskFreeSpaceExW")
+)
+
+func availableBytes(path string) (int64, error) {
+	// GetDiskFreeSpaceExW requires a directory path; resolve parent if path is a file.
+	if info, err := os.Stat(path); err == nil && !info.IsDir() {
+		path = filepath.Dir(path)
+	}
+
+	pathPtr, err := syscall.UTF16PtrFromString(path)
+	if err != nil {
+		return 0, fmt.Errorf("encode path %q: %w", path, err)
+	}
+
+	var avail, total, free uint64
+	r, _, err := getDiskFreeSpaceExW.Call(
+		uintptr(unsafe.Pointer(pathPtr)),
+		uintptr(unsafe.Pointer(&avail)),
+		uintptr(unsafe.Pointer(&total)),
+		uintptr(unsafe.Pointer(&free)),
+	)
+	if r == 0 {
+		return 0, fmt.Errorf("GetDiskFreeSpaceExW %q: %w", path, err)
+	}
+	return int64(avail), nil
+}


### PR DESCRIPTION
Orchestrates the copy, move, and delete operations on an engram data directory, and extends the MCP injection path to carry a custom data directory into agent configs.

`DataDirService` wraps each mutating operation with a snapshot before writing. Copy and move check available disk space upfront. Delete clears all files under the directory, accumulating any removal errors with `errors.Join` rather than stopping at the first failure.

`InjectWithOptions` extends the existing `Inject` function with an `InjectOptions` struct. When `InjectOptions.DataDir` is non-empty, the `ENGRAM_DATA_DIR` environment variable is included in the generated MCP server config. `Inject` becomes a one-line wrapper with zero-value options, so existing call sites are unaffected.

`datadir_ops.go` adds `DataDirHasContent`, `DataDirSize`, and `DiskSpaceOKForDataDir` — storage-agnostic queries that work on any directory, not just SQLite databases.

Closes #346