### PR TITLE
feat(tui): custom path entry and disk space check for data directory screens

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# TUI snapshot goldens must compare stable across OS checkouts (LF).
+internal/tui/testdata/*.golden text eol=lf

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/mattn/go-isatty v0.0.20
 )
 
 require (
@@ -20,7 +21,6 @@ require (
 	github.com/clipperhouse/uax29/v2 v2.5.0 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/lucasb-eyer/go-colorful v1.3.0 // indirect
-	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.19 // indirect
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -103,7 +103,15 @@ func RunArgs(args []string, stdout io.Writer) error {
 			return fmt.Errorf("resolve user home directory: %w", err)
 		}
 
+		// Pre-load persisted Engram data directory so the TUI can display and
+		// manage it without a separate state read on the management screen.
+		var engramDataDir string
+		if s, stateErr := state.Read(homeDir); stateErr == nil {
+			engramDataDir = s.EngramDataDir
+		}
+
 		m := tui.NewModel(result, Version)
+		m.EngramDataDir = engramDataDir
 		m.ExecuteFn = tuiExecute
 		m.RestoreFn = tuiRestore
 		m.DeleteBackupFn = func(manifest backup.Manifest) error {
@@ -352,6 +360,7 @@ func tuiExecute(
 			ClaudeModelAssignments: claudeAliasesToStrings(selection.ClaudeModelAssignments),
 			ModelAssignments:       modelAssignmentsToState(selection.ModelAssignments),
 			Persona:                string(selection.Persona),
+			EngramDataDir:          selection.EngramDataDir,
 		})
 	}
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -6,12 +6,14 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/gentleman-programming/gentle-ai/internal/backup"
 	"github.com/gentleman-programming/gentle-ai/internal/cli"
+	"github.com/gentleman-programming/gentle-ai/internal/components/engram"
 	componentuninstall "github.com/gentleman-programming/gentle-ai/internal/components/uninstall"
 	"github.com/gentleman-programming/gentle-ai/internal/model"
 	"github.com/gentleman-programming/gentle-ai/internal/pipeline"
@@ -112,6 +114,9 @@ func RunArgs(args []string, stdout io.Writer) error {
 
 		m := tui.NewModel(result, Version)
 		m.EngramDataDir = engramDataDir
+		m.HomeDir = homeDir
+		m.EngramDetected = engramIsPresent(homeDir)
+		m.EngramDataDirFn = buildEngramDataDirFn(homeDir)
 		m.ExecuteFn = tuiExecute
 		m.RestoreFn = tuiRestore
 		m.DeleteBackupFn = func(manifest backup.Manifest) error {
@@ -547,6 +552,67 @@ func modelAssignmentsToState(m map[string]model.ModelAssignment) map[string]stat
 		out[k] = state.ModelAssignmentState{ProviderID: v.ProviderID, ModelID: v.ModelID}
 	}
 	return out
+}
+
+// engramIsPresent reports whether the Engram data directory or binary appears to
+// be installed. Used to gate the "Manage Engram directory" menu item on Welcome.
+func engramIsPresent(homeDir string) bool {
+	dataDir := engram.DefaultDir(homeDir)
+	if _, err := os.Stat(dataDir); err == nil {
+		return true
+	}
+	// Also treat presence of the binary (anywhere in PATH) as "installed".
+	if _, err := exec.LookPath("engram"); err == nil {
+		return true
+	}
+	return false
+}
+
+// buildEngramDataDirFn returns a closure that executes an Engram data-directory
+// operation (copy, move, delete, fresh-start) and persists the resulting directory
+// path to state.json so the next startup picks it up correctly.
+func buildEngramDataDirFn(homeDir string) func(op model.EngramDataDirOp, currentDir, dstDir string) (snapshotID string, err error) {
+	return func(op model.EngramDataDirOp, currentDir, dstDir string) (string, error) {
+		svc := engram.NewDataDirService(homeDir)
+
+		var snapID string
+		var opErr error
+
+		switch op {
+		case model.EngramDataDirOpCopy:
+			manifest, err := svc.CopyTo(currentDir, dstDir)
+			snapID, opErr = manifest.ID, err
+		case model.EngramDataDirOpMove:
+			manifest, err := svc.MoveTo(currentDir, dstDir)
+			snapID, opErr = manifest.ID, err
+		case model.EngramDataDirOpDelete, model.EngramDataDirOpFresh:
+			manifest, err := svc.Delete(currentDir)
+			snapID, opErr = manifest.ID, err
+		case model.EngramDataDirOpKeep:
+			return "", nil
+		default:
+			return "", fmt.Errorf("unknown op: %q", op)
+		}
+
+		if opErr != nil {
+			return snapID, opErr
+		}
+
+		// Persist the new data directory reference to state.json.
+		var newDir string
+		switch op {
+		case model.EngramDataDirOpMove:
+			newDir = dstDir
+		case model.EngramDataDirOpDelete, model.EngramDataDirOpFresh:
+			newDir = "" // reset to default (~/.engram)
+		// Copy leaves the current dir unchanged; Keep already returned above.
+		}
+		current, _ := state.Read(homeDir) // ignore not-exist; treat as empty
+		current.EngramDataDir = newDir
+		_ = state.Write(homeDir, current) // non-fatal: a failed write must not fail the op
+
+		return snapID, nil
+	}
 }
 
 // ListBackups returns all backup manifests from the backup directory.

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gentleman-programming/gentle-ai/internal/cli"
 	"github.com/gentleman-programming/gentle-ai/internal/components/engram"
 	componentuninstall "github.com/gentleman-programming/gentle-ai/internal/components/uninstall"
+	"github.com/gentleman-programming/gentle-ai/internal/storage"
 	"github.com/gentleman-programming/gentle-ai/internal/model"
 	"github.com/gentleman-programming/gentle-ai/internal/pipeline"
 	"github.com/gentleman-programming/gentle-ai/internal/planner"
@@ -577,6 +578,23 @@ func buildEngramDataDirFn(homeDir string) func(op model.EngramDataDirOp, current
 
 		var snapID string
 		var opErr error
+
+		// Disk-space pre-check: guard copy and move before any filesystem writes.
+		// The TUI shows an inline warning first, but this is a mandatory
+		// defense-in-depth check so the service layer never starts a partial copy.
+		if op == model.EngramDataDirOpCopy || op == model.EngramDataDirOpMove {
+			ok, needed, avail, spaceErr := engram.DiskSpaceOKForDataDir(currentDir, dstDir)
+			if spaceErr != nil {
+				return "", fmt.Errorf("check destination disk space: %w", spaceErr)
+			}
+			if !ok {
+				return "", fmt.Errorf(
+					"not enough disk space: need %s to copy Engram data; %s available on destination volume",
+					storage.FormatBytes(needed),
+					storage.FormatBytes(avail),
+				)
+			}
+		}
 
 		switch op {
 		case model.EngramDataDirOpCopy:

--- a/internal/components/engram/copy.go
+++ b/internal/components/engram/copy.go
@@ -1,0 +1,72 @@
+package engram
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// CopyDB copies the Engram SQLite database from src to dst.
+//
+// Strategy: write to a temp file (dst+".tmp") first, verify the byte count,
+// then rename atomically. The temp file is removed on any error so dst is
+// never left in a partial state.
+//
+// io.Copy is used without an explicit buffer: when both src and dst are
+// *os.File, Go 1.21+ calls (*os.File).ReadFrom which invokes sendfile(2) on
+// Linux and the equivalent on macOS. On Windows it falls back to efficient
+// buffered I/O. No manual buffer allocation needed.
+func CopyDB(src, dst string) error {
+	srcInfo, err := os.Stat(src)
+	if err != nil {
+		return fmt.Errorf("stat source %q: %w", src, err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return fmt.Errorf("create destination dir for %q: %w", dst, err)
+	}
+
+	tmp := dst + ".tmp"
+
+	dstFile, err := os.Create(tmp)
+	if err != nil {
+		return fmt.Errorf("create temp file %q: %w", tmp, err)
+	}
+
+	srcFile, err := os.Open(src)
+	if err != nil {
+		dstFile.Close()
+		os.Remove(tmp)
+		return fmt.Errorf("open source %q: %w", src, err)
+	}
+
+	_, copyErr := io.Copy(dstFile, srcFile)
+	srcFile.Close()
+	syncErr := dstFile.Sync()
+	dstFile.Close()
+
+	if copyErr != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("copy %q → %q: %w", src, dst, copyErr)
+	}
+	if syncErr != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("sync %q: %w", tmp, syncErr)
+	}
+
+	dstInfo, err := os.Stat(tmp)
+	if err != nil || dstInfo.Size() != srcInfo.Size() {
+		os.Remove(tmp)
+		if err != nil {
+			return fmt.Errorf("stat temp file %q: %w", tmp, err)
+		}
+		return fmt.Errorf("incomplete copy: wrote %d bytes, expected %d", dstInfo.Size(), srcInfo.Size())
+	}
+
+	if err := os.Rename(tmp, dst); err != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("rename %q → %q: %w", tmp, dst, err)
+	}
+	return nil
+}

--- a/internal/components/engram/copy_test.go
+++ b/internal/components/engram/copy_test.go
@@ -1,0 +1,99 @@
+package engram
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCopyDB_Basic(t *testing.T) {
+	src := filepath.Join(t.TempDir(), "engram.db")
+	dst := filepath.Join(t.TempDir(), "engram.db")
+
+	content := []byte("fake sqlite database content for testing")
+	if err := os.WriteFile(src, content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := CopyDB(src, dst); err != nil {
+		t.Fatalf("CopyDB: %v", err)
+	}
+
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("read dst: %v", err)
+	}
+	if string(got) != string(content) {
+		t.Errorf("content mismatch: got %q, want %q", got, content)
+	}
+}
+
+func TestCopyDB_CreatesDestDir(t *testing.T) {
+	src := filepath.Join(t.TempDir(), "engram.db")
+	// dst is inside a non-existent subdirectory.
+	dst := filepath.Join(t.TempDir(), "subdir", "deep", "engram.db")
+
+	if err := os.WriteFile(src, []byte("data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := CopyDB(src, dst); err != nil {
+		t.Fatalf("CopyDB: %v", err)
+	}
+
+	if _, err := os.Stat(dst); err != nil {
+		t.Errorf("dst not created: %v", err)
+	}
+}
+
+func TestCopyDB_NoTempOnSuccess(t *testing.T) {
+	src := filepath.Join(t.TempDir(), "engram.db")
+	dst := filepath.Join(t.TempDir(), "engram.db")
+
+	if err := os.WriteFile(src, []byte("data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := CopyDB(src, dst); err != nil {
+		t.Fatalf("CopyDB: %v", err)
+	}
+
+	tmp := dst + ".tmp"
+	if _, err := os.Stat(tmp); !os.IsNotExist(err) {
+		t.Errorf("temp file %q should not exist after success", tmp)
+	}
+}
+
+func TestCopyDB_SourceNotExist(t *testing.T) {
+	src := filepath.Join(t.TempDir(), "nonexistent.db")
+	dst := filepath.Join(t.TempDir(), "engram.db")
+
+	err := CopyDB(src, dst)
+	if err == nil {
+		t.Fatal("expected error for missing source, got nil")
+	}
+}
+
+func TestCopyDB_Idempotent(t *testing.T) {
+	src := filepath.Join(t.TempDir(), "engram.db")
+	dst := filepath.Join(t.TempDir(), "engram.db")
+	content := []byte("idempotent copy test")
+
+	if err := os.WriteFile(src, content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Copy twice — should succeed both times.
+	for i := 0; i < 2; i++ {
+		if err := CopyDB(src, dst); err != nil {
+			t.Fatalf("CopyDB iteration %d: %v", i, err)
+		}
+	}
+
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(content) {
+		t.Errorf("content mismatch after second copy")
+	}
+}

--- a/internal/components/engram/datadir_ops.go
+++ b/internal/components/engram/datadir_ops.go
@@ -1,0 +1,60 @@
+package engram
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"github.com/gentleman-programming/gentle-ai/internal/storage"
+)
+
+// DataDirHasContent reports whether dataDir exists and contains any files.
+// Engram's internal storage layout is intentionally opaque to gentle-ai.
+func DataDirHasContent(dataDir string) bool {
+	entries, err := os.ReadDir(dataDir)
+	return err == nil && len(entries) > 0
+}
+
+// DataDirSize returns the combined size in bytes of all regular files under dataDir.
+func DataDirSize(dataDir string) int64 {
+	var total int64
+	_ = filepath.WalkDir(dataDir, func(_ string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil
+		}
+		if info, e := d.Info(); e == nil {
+			total += info.Size()
+		}
+		return nil
+	})
+	return total
+}
+
+// DiskSpaceOKForDataDir reports whether the volume at dst has strictly more
+// free bytes than the total size of files under srcDataDir.
+// When srcDataDir is empty or inaccessible, returns ok=true.
+func DiskSpaceOKForDataDir(srcDataDir, dst string) (ok bool, needed, avail int64, err error) {
+	needed = DataDirSize(srcDataDir)
+	if needed == 0 {
+		return true, 0, 0, nil
+	}
+	avail, err = storage.AvailableBytes(dst)
+	if err != nil {
+		return false, needed, 0, err
+	}
+	return avail > needed, needed, avail, nil
+}
+
+// dataDirFiles returns paths of all regular files under dataDir.
+// Used by DataDirService.snapshot to enumerate what to back up.
+func dataDirFiles(dataDir string) []string {
+	var paths []string
+	_ = filepath.WalkDir(dataDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil
+		}
+		paths = append(paths, path)
+		return nil
+	})
+	return paths
+}

--- a/internal/components/engram/datadir_ops_test.go
+++ b/internal/components/engram/datadir_ops_test.go
@@ -1,0 +1,85 @@
+package engram
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDataDirHasContent_emptyDir(t *testing.T) {
+	dir := t.TempDir()
+	if DataDirHasContent(dir) {
+		t.Error("DataDirHasContent = true for empty dir, want false")
+	}
+}
+
+func TestDataDirHasContent_dirWithFile(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "engram.db"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if !DataDirHasContent(dir) {
+		t.Error("DataDirHasContent = false for dir with file, want true")
+	}
+}
+
+func TestDataDirHasContent_nonExistentDir(t *testing.T) {
+	if DataDirHasContent(filepath.Join(t.TempDir(), "nonexistent")) {
+		t.Error("DataDirHasContent = true for non-existent dir, want false")
+	}
+}
+
+func TestDataDirSize_knownFile(t *testing.T) {
+	dir := t.TempDir()
+	content := []byte("hello world") // 11 bytes
+	if err := os.WriteFile(filepath.Join(dir, "file.db"), content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got := DataDirSize(dir)
+	if got != int64(len(content)) {
+		t.Errorf("DataDirSize = %d, want %d", got, len(content))
+	}
+}
+
+func TestDataDirSize_emptyDir(t *testing.T) {
+	dir := t.TempDir()
+	if got := DataDirSize(dir); got != 0 {
+		t.Errorf("DataDirSize = %d, want 0 for empty dir", got)
+	}
+}
+
+func TestDiskSpaceOKForDataDir_emptyDir(t *testing.T) {
+	dir := t.TempDir()
+	ok, needed, avail, err := DiskSpaceOKForDataDir(dir, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || needed != 0 || avail != 0 {
+		t.Fatalf("got ok=%v needed=%d avail=%d, want ok=true needed=0 avail=0", ok, needed, avail)
+	}
+}
+
+func TestDiskSpaceOKForDataDir_withContent(t *testing.T) {
+	src := filepath.Join(t.TempDir(), "data")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "engram.db"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	dst := t.TempDir()
+	ok, needed, avail, err := DiskSpaceOKForDataDir(src, dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if needed != 1 {
+		t.Errorf("needed = %d, want 1", needed)
+	}
+	if avail <= 0 {
+		t.Errorf("avail = %d, want > 0", avail)
+	}
+	if !ok {
+		t.Fatal("expected ok=true for one-byte file on same volume")
+	}
+}

--- a/internal/components/engram/env.go
+++ b/internal/components/engram/env.go
@@ -1,0 +1,32 @@
+package engram
+
+import (
+	"path/filepath"
+)
+
+// DataDirRef is the persisted reference to an Engram data directory.
+// Currently resolves to a local filesystem path.
+// Future URI schemes (e.g. "provider://...") can be added inside Resolve
+// without changing the JSON format or breaking existing installations.
+type DataDirRef string
+
+// Resolve returns the effective local filesystem path for the data directory.
+// An empty ref resolves to the platform default (~/.engram).
+func (r DataDirRef) Resolve(homeDir string) string {
+	if r == "" {
+		return DefaultDir(homeDir)
+	}
+	// filepath.FromSlash normalises Windows path separators on any input,
+	// filepath.Clean removes redundant separators and dots.
+	return filepath.Clean(filepath.FromSlash(string(r)))
+}
+
+// DefaultDir returns the default Engram data directory path (~/.engram).
+func DefaultDir(homeDir string) string {
+	return filepath.Join(homeDir, ".engram")
+}
+
+// DBPath returns the path to the Engram SQLite database inside dataDir.
+func DBPath(dataDir string) string {
+	return filepath.Join(dataDir, "engram.db")
+}

--- a/internal/components/engram/env_test.go
+++ b/internal/components/engram/env_test.go
@@ -1,0 +1,44 @@
+package engram
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestDataDirRef_Resolve(t *testing.T) {
+	home := t.TempDir()
+	custom := filepath.Join(home, "custom-data")
+
+	tests := []struct {
+		ref  DataDirRef
+		want string
+	}{
+		{"", DefaultDir(home)},
+		{DataDirRef(DefaultDir(home)), DefaultDir(home)},
+		{DataDirRef(custom), custom},
+		// trailing separator is cleaned
+		{DataDirRef(custom + string(filepath.Separator)), custom},
+	}
+	for _, tt := range tests {
+		got := tt.ref.Resolve(home)
+		if got != tt.want {
+			t.Errorf("DataDirRef(%q).Resolve(%q) = %q, want %q", tt.ref, home, got, tt.want)
+		}
+	}
+}
+
+func TestDefaultDir(t *testing.T) {
+	got := DefaultDir("/home/user")
+	want := filepath.Join("/home/user", ".engram")
+	if got != want {
+		t.Errorf("DefaultDir = %q, want %q", got, want)
+	}
+}
+
+func TestDBPath(t *testing.T) {
+	got := DBPath("/home/user/.engram")
+	want := filepath.Join("/home/user/.engram", "engram.db")
+	if got != want {
+		t.Errorf("DBPath = %q, want %q", got, want)
+	}
+}

--- a/internal/components/engram/inject.go
+++ b/internal/components/engram/inject.go
@@ -213,6 +213,9 @@ func InjectWithPromptDir(configHomeDir, promptDir string, adapter agents.Adapter
 }
 
 func injectCore(configHomeDir, promptDir string, adapter agents.Adapter, opts InjectOptions) (InjectionResult, error) {
+	if opts.DataDir != "" && !filepath.IsAbs(opts.DataDir) {
+		return InjectionResult{}, fmt.Errorf("engram DataDir must be an absolute path, got: %q", opts.DataDir)
+	}
 	if opts.DataDir == "" {
 		if provisioner, ok := adapter.(piEngramProvisioner); ok {
 			changed, files, err := provisioner.ProvisionEngramMCP(configHomeDir)

--- a/internal/components/engram/inject.go
+++ b/internal/components/engram/inject.go
@@ -317,8 +317,9 @@ func injectCore(configHomeDir, promptDir string, adapter agents.Adapter, opts In
 		}
 		engramCmd := stableEngramCommandForMergedConfig(configPath, adapter.Agent())
 		withMCP := filemerge.UpsertCodexEngramBlock(existing, engramCmd)
-		withInstr := filemerge.UpsertTopLevelTOMLString(withMCP, "model_instructions_file", instructionsPath)
-		withCompact := filemerge.UpsertTopLevelTOMLString(withInstr, "experimental_compact_prompt_file", compactPath)
+		// Forward slashes keep Codex TOML portable and stable under %q escaping on Windows.
+		withInstr := filemerge.UpsertTopLevelTOMLString(withMCP, "model_instructions_file", filepath.ToSlash(instructionsPath))
+		withCompact := filemerge.UpsertTopLevelTOMLString(withInstr, "experimental_compact_prompt_file", filepath.ToSlash(compactPath))
 
 		tomlWrite, err := filemerge.WriteFileAtomic(configPath, []byte(withCompact), 0o644)
 		if err != nil {
@@ -436,9 +437,9 @@ func ensureAntigravitySettings(homeDir string, adapter agents.Adapter) (settings
 // writeCodexInstructionFiles writes the Engram memory protocol and compact prompt
 // files to ~/.codex/ and returns their paths.
 func writeCodexInstructionFiles(homeDir string) (instructionsPath, compactPath string, err error) {
-	codexDir := homeDir + "/.codex"
-	instructionsPath = codexDir + "/engram-instructions.md"
-	compactPath = codexDir + "/engram-compact-prompt.md"
+	codexDir := filepath.Join(homeDir, ".codex")
+	instructionsPath = filepath.Join(codexDir, "engram-instructions.md")
+	compactPath = filepath.Join(codexDir, "engram-compact-prompt.md")
 
 	instrContent := assets.MustRead("codex/engram-instructions.md")
 	instrWrite, err := filemerge.WriteFileAtomic(instructionsPath, []byte(instrContent), 0o644)

--- a/internal/components/engram/inject.go
+++ b/internal/components/engram/inject.go
@@ -20,6 +20,21 @@ type InjectionResult struct {
 	Files   []string
 }
 
+// InjectOptions configures optional overrides for InjectWithOptions.
+type InjectOptions struct {
+	// DataDir, when non-empty, injects ENGRAM_DATA_DIR into MCP server configs.
+	DataDir string
+}
+
+// engramEnvMap returns the env block to embed in MCP server configs, or nil
+// when no overrides are needed.
+func engramEnvMap(dataDir string) map[string]any {
+	if dataDir == "" {
+		return nil
+	}
+	return map[string]any{"ENGRAM_DATA_DIR": dataDir}
+}
+
 // bootstrapper is an optional adapter capability: if an adapter implements
 // this interface, any injector that writes Jinja modules will first ensure
 // the base template (entry point) exists.
@@ -77,15 +92,18 @@ func resolveEngramCommand() (string, bool) {
 // path to the engram binary if it can be resolved via PATH.
 func engramServerJSON() []byte {
 	cmd, _ := resolveEngramCommand()
-	return engramServerJSONWithCmd(cmd)
+	return engramServerJSONWithCmd(cmd, nil)
 }
 
 // engramServerJSONWithCmd returns the MCP server config bytes for a specific
-// command.
-func engramServerJSONWithCmd(cmd string) []byte {
+// command. env is merged into the top-level object when non-nil.
+func engramServerJSONWithCmd(cmd string, env map[string]any) []byte {
 	cfg := map[string]any{
 		"command": cmd,
 		"args":    []string{"mcp", "--tools=agent"},
+	}
+	if len(env) > 0 {
+		cfg["env"] = env
 	}
 	b, _ := json.MarshalIndent(cfg, "", "  ")
 	return append(b, '\n')
@@ -93,7 +111,8 @@ func engramServerJSONWithCmd(cmd string) []byte {
 
 // engramOverlayJSON returns the settings overlay JSON (used for merge-into-settings
 // and MCPConfigFile strategies), with the resolved engram command.
-func engramOverlayJSON(agentID model.AgentID, cmd string) []byte {
+// env is merged into the server object when non-nil.
+func engramOverlayJSON(agentID model.AgentID, cmd string, env map[string]any) []byte {
 	var cfg map[string]any
 	if agentID == model.AgentOpenCode || agentID == model.AgentKilocode {
 		// OpenCode 1.3.3+ requires command as an array for type:local servers.
@@ -105,13 +124,17 @@ func engramOverlayJSON(agentID model.AgentID, cmd string) []byte {
 		// Without this, users upgrading from v1.11.3 (which had a separate
 		// "args" key) would end up with both "args" and the new array "command"
 		// in their config, which is invalid for OpenCode 1.3.3.
+		inner := map[string]any{
+			"command": []string{cmd, "mcp", "--tools=agent"},
+			"type":    "local",
+		}
+		if len(env) > 0 {
+			inner["env"] = env
+		}
 		cfg = map[string]any{
 			"mcp": map[string]any{
 				"engram": map[string]any{
-					"__replace__": map[string]any{
-						"command": []string{cmd, "mcp", "--tools=agent"},
-						"type":    "local",
-					},
+					"__replace__": inner,
 				},
 			},
 		}
@@ -129,12 +152,16 @@ func engramOverlayJSON(agentID model.AgentID, cmd string) []byte {
 			},
 		}
 	} else {
+		server := map[string]any{
+			"command": cmd,
+			"args":    []string{"mcp", "--tools=agent"},
+		}
+		if len(env) > 0 {
+			server["env"] = env
+		}
 		cfg = map[string]any{
 			"mcpServers": map[string]any{
-				"engram": map[string]any{
-					"command": cmd,
-					"args":    []string{"mcp", "--tools=agent"},
-				},
+				"engram": server,
 			},
 		}
 	}
@@ -146,21 +173,35 @@ func engramOverlayJSON(agentID model.AgentID, cmd string) []byte {
 // Uses --tools=agent per engram contract.
 // VS Code uses a fixed "servers" key structure rather than mcpServers, so it
 // is kept as a separate helper.
-func vsCodeEngramOverlayJSON(cmd string) []byte {
+// env is merged into the server object when non-nil.
+func vsCodeEngramOverlayJSON(cmd string, env map[string]any) []byte {
+	server := map[string]any{
+		"command": cmd,
+		"args":    []string{"mcp", "--tools=agent"},
+	}
+	if len(env) > 0 {
+		server["env"] = env
+	}
 	cfg := map[string]any{
 		"servers": map[string]any{
-			"engram": map[string]any{
-				"command": cmd,
-				"args":    []string{"mcp", "--tools=agent"},
-			},
+			"engram": server,
 		},
 	}
 	b, _ := json.MarshalIndent(cfg, "", "  ")
 	return append(b, '\n')
 }
 
+// Inject injects the Engram MCP server config and memory protocol into the
+// given agent adapter. It is a backward-compatible wrapper around InjectWithOptions.
 func Inject(homeDir string, adapter agents.Adapter) (InjectionResult, error) {
-	return inject(homeDir, homeDir, adapter)
+	return InjectWithOptions(homeDir, adapter, InjectOptions{})
+}
+
+// InjectWithOptions extends Inject with optional configuration. When
+// opts.DataDir is non-empty, ENGRAM_DATA_DIR is injected into every MCP
+// server config block so the agent uses the specified data directory.
+func InjectWithOptions(homeDir string, adapter agents.Adapter, opts InjectOptions) (InjectionResult, error) {
+	return injectCore(homeDir, homeDir, adapter, opts)
 }
 
 // InjectWithPromptDir writes Engram's MCP configuration using configHomeDir and
@@ -168,18 +209,19 @@ func Inject(homeDir string, adapter agents.Adapter) (InjectionResult, error) {
 // as OpenClaw where MCP is loaded from the global config but instructions are
 // read from an active workspace.
 func InjectWithPromptDir(configHomeDir, promptDir string, adapter agents.Adapter) (InjectionResult, error) {
-	return inject(configHomeDir, promptDir, adapter)
+	return injectCore(configHomeDir, promptDir, adapter, InjectOptions{})
 }
 
-func inject(configHomeDir, promptDir string, adapter agents.Adapter) (InjectionResult, error) {
-	if provisioner, ok := adapter.(piEngramProvisioner); ok {
-		changed, files, err := provisioner.ProvisionEngramMCP(configHomeDir)
-		if err != nil {
-			return InjectionResult{}, err
+func injectCore(configHomeDir, promptDir string, adapter agents.Adapter, opts InjectOptions) (InjectionResult, error) {
+	if opts.DataDir == "" {
+		if provisioner, ok := adapter.(piEngramProvisioner); ok {
+			changed, files, err := provisioner.ProvisionEngramMCP(configHomeDir)
+			if err != nil {
+				return InjectionResult{}, err
+			}
+			return InjectionResult{Changed: changed, Files: files}, nil
 		}
-		return InjectionResult{Changed: changed, Files: files}, nil
 	}
-
 	if !adapter.SupportsMCP() {
 		return InjectionResult{}, nil
 	}
@@ -187,6 +229,7 @@ func inject(configHomeDir, promptDir string, adapter agents.Adapter) (InjectionR
 		return InjectionResult{}, err
 	}
 
+	env := engramEnvMap(opts.DataDir)
 	files := make([]string, 0, 2)
 	changed := false
 
@@ -200,7 +243,7 @@ func inject(configHomeDir, promptDir string, adapter agents.Adapter) (InjectionR
 		// See: https://github.com/Gentleman-Programming/gentle-ai/issues (engram absolute path regression)
 		mcpPath := adapter.MCPConfigPath(configHomeDir, "engram")
 		cmd := stableEngramCommandForMergedConfig(mcpPath, adapter.Agent())
-		content := buildSeparateMCPContent(mcpPath, engramServerJSONWithCmd(cmd))
+		content := buildSeparateMCPContent(mcpPath, engramServerJSONWithCmd(cmd, env), env)
 		mcpWrite, err := filemerge.WriteFileAtomic(mcpPath, content, 0o644)
 		if err != nil {
 			return InjectionResult{}, err
@@ -213,7 +256,7 @@ func inject(configHomeDir, promptDir string, adapter agents.Adapter) (InjectionR
 		if settingsPath == "" {
 			break
 		}
-		overlay := engramOverlayJSON(adapter.Agent(), stableEngramCommandForMergedConfig(settingsPath, adapter.Agent()))
+		overlay := engramOverlayJSON(adapter.Agent(), stableEngramCommandForMergedConfig(settingsPath, adapter.Agent()), env)
 		settingsWrite, err := mergeJSONFile(settingsPath, overlay)
 		if err != nil {
 			return InjectionResult{}, err
@@ -228,9 +271,9 @@ func inject(configHomeDir, promptDir string, adapter agents.Adapter) (InjectionR
 		}
 		var overlay []byte
 		if adapter.Agent() == model.AgentVSCodeCopilot {
-			overlay = vsCodeEngramOverlayJSON(stableEngramCommandForMergedConfig(mcpPath, adapter.Agent()))
+			overlay = vsCodeEngramOverlayJSON(stableEngramCommandForMergedConfig(mcpPath, adapter.Agent()), env)
 		} else {
-			overlay = engramOverlayJSON(adapter.Agent(), stableEngramCommandForMergedConfig(mcpPath, adapter.Agent()))
+			overlay = engramOverlayJSON(adapter.Agent(), stableEngramCommandForMergedConfig(mcpPath, adapter.Agent()), env)
 		}
 
 		mcpWrite, err := mergeJSONFile(mcpPath, overlay)
@@ -587,7 +630,7 @@ func isStandardAgent(id model.AgentID) bool {
 //     args (["mcp", "--tools=agent"]) so that the absolute path is preserved
 //     and the correct flags are always present.
 //   - Otherwise (relative command or other value), return defaultContent.
-func buildSeparateMCPContent(mcpPath string, defaultContent []byte) []byte {
+func buildSeparateMCPContent(mcpPath string, defaultContent []byte, env map[string]any) []byte {
 	raw, err := os.ReadFile(mcpPath)
 	if err != nil {
 		// File does not exist or is not readable — use the default.
@@ -611,6 +654,9 @@ func buildSeparateMCPContent(mcpPath string, defaultContent []byte) []byte {
 	rebuilt := map[string]any{
 		"command": cmd,
 		"args":    []string{"mcp", "--tools=agent"},
+	}
+	if len(env) > 0 {
+		rebuilt["env"] = env
 	}
 	encoded, err := json.MarshalIndent(rebuilt, "", "  ")
 	if err != nil {

--- a/internal/components/engram/inject_test.go
+++ b/internal/components/engram/inject_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -505,7 +506,14 @@ func TestInjectCursorWithMalformedMCPJsonRecovery(t *testing.T) {
 
 func TestInjectVSCodeMergesEngramToMCPConfigFile(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	switch runtime.GOOS {
+	case "windows":
+		t.Setenv("APPDATA", filepath.Join(home, "AppData", "Roaming"))
+	case "darwin":
+		// VS Code user dir lives under ~/Library/... — already under `home`.
+	default:
+		t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	}
 	adapter := vscode.NewAdapter()
 
 	result, err := Inject(home, adapter)
@@ -726,16 +734,16 @@ func TestInjectCodexInjectsTOMLKeys(t *testing.T) {
 	if !strings.Contains(text, `model_instructions_file`) {
 		t.Fatalf("config.toml missing model_instructions_file key; got:\n%s", text)
 	}
-	if !strings.Contains(text, instructionsPath) {
-		t.Fatalf("config.toml model_instructions_file does not reference %q; got:\n%s", instructionsPath, text)
+	if !strings.Contains(text, filepath.ToSlash(instructionsPath)) {
+		t.Fatalf("config.toml model_instructions_file does not reference %q; got:\n%s", filepath.ToSlash(instructionsPath), text)
 	}
 
 	compactPath := filepath.Join(home, ".codex", "engram-compact-prompt.md")
 	if !strings.Contains(text, `experimental_compact_prompt_file`) {
 		t.Fatalf("config.toml missing experimental_compact_prompt_file key; got:\n%s", text)
 	}
-	if !strings.Contains(text, compactPath) {
-		t.Fatalf("config.toml experimental_compact_prompt_file does not reference %q; got:\n%s", compactPath, text)
+	if !strings.Contains(text, filepath.ToSlash(compactPath)) {
+		t.Fatalf("config.toml experimental_compact_prompt_file does not reference %q; got:\n%s", filepath.ToSlash(compactPath), text)
 	}
 }
 

--- a/internal/components/engram/inject_test.go
+++ b/internal/components/engram/inject_test.go
@@ -1586,3 +1586,23 @@ func objectAtForTest(t *testing.T, root map[string]any, key string) map[string]a
 	}
 	return object
 }
+
+func TestInjectWithOptions_RelativeDataDirReturnsError(t *testing.T) {
+	home := t.TempDir()
+	_, err := InjectWithOptions(home, claudeAdapter(), InjectOptions{DataDir: "relative/path"})
+	if err == nil {
+		t.Fatal("InjectWithOptions with relative DataDir must return an error")
+	}
+	if !strings.Contains(err.Error(), "absolute") {
+		t.Errorf("error %q should mention absolute path requirement", err.Error())
+	}
+}
+
+func TestInjectWithOptions_EmptyDataDirIsAllowed(t *testing.T) {
+	home := t.TempDir()
+	// Empty DataDir falls back to the standard injection path — must not error.
+	_, err := InjectWithOptions(home, claudeAdapter(), InjectOptions{DataDir: ""})
+	if err != nil {
+		t.Fatalf("InjectWithOptions with empty DataDir returned unexpected error: %v", err)
+	}
+}

--- a/internal/components/engram/locations.go
+++ b/internal/components/engram/locations.go
@@ -1,0 +1,81 @@
+package engram
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/gentleman-programming/gentle-ai/internal/storage"
+)
+
+// Location is a candidate Engram data directory the user can choose from.
+type Location struct {
+	Path      string // absolute, cleaned filesystem path
+	Label     string // human-readable: "Default (~/.engram)", "D:\\ (120 GiB free)"
+	Available int64  // bytes free on the containing volume; -1 if unknown
+	IsCurrent bool   // true when this matches the currently active data dir
+}
+
+// SuggestLocations returns an ordered list of candidate data directories.
+// The current location is always listed first. The default ~/.engram follows,
+// then any additional volumes detected on the platform (see platform files).
+// Duplicate paths are deduplicated; labels include free-space info where available.
+func SuggestLocations(homeDir, currentDir string) []Location {
+	seen := map[string]bool{}
+	var out []Location
+
+	add := func(path string, isCurrent bool) {
+		clean := filepath.Clean(path)
+		if seen[clean] {
+			return
+		}
+		seen[clean] = true
+		avail, err := storage.AvailableBytes(filepath.Dir(clean))
+		if err != nil {
+			avail = -1
+		}
+		label := buildLabel(clean, homeDir, avail)
+		out = append(out, Location{
+			Path:      clean,
+			Label:     label,
+			Available: avail,
+			IsCurrent: isCurrent,
+		})
+	}
+
+	// Current location first (may equal default).
+	if currentDir != "" {
+		add(currentDir, true)
+	}
+
+	// Default location — isCurrent only when no explicit current dir was provided.
+	// If currentDir equals the default the seen-map dedup above already handles it;
+	// if currentDir is a custom path the default is a non-current alternative.
+	add(DefaultDir(homeDir), currentDir == "")
+
+	// Platform-specific extra volumes (see locations_unix.go / locations_windows.go).
+	for _, vol := range platformVolumes() {
+		add(filepath.Join(vol, "Engram"), false)
+	}
+
+	return out
+}
+
+// buildLabel constructs the display label for a location entry.
+func buildLabel(path, homeDir string, available int64) string {
+	// Replace home prefix with ~ for readability.
+	display := path
+	if rel, err := filepath.Rel(homeDir, path); err == nil && len(rel) < len(path) {
+		display = filepath.Join("~", rel)
+	}
+
+	if available < 0 {
+		return display
+	}
+	return display + "  (" + storage.FormatBytes(available) + " free)"
+}
+
+// dirExists is a small helper used by platform files.
+func dirExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
+}

--- a/internal/components/engram/locations_test.go
+++ b/internal/components/engram/locations_test.go
@@ -1,0 +1,95 @@
+package engram
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestSuggestLocations_DefaultFirst(t *testing.T) {
+	home := t.TempDir()
+
+	locs := SuggestLocations(home, "")
+	if len(locs) == 0 {
+		t.Fatal("SuggestLocations returned no locations")
+	}
+	// Without a current dir the default should be first.
+	want := filepath.Clean(DefaultDir(home))
+	if locs[0].Path != want {
+		t.Errorf("first location = %q, want default %q", locs[0].Path, want)
+	}
+}
+
+func TestSuggestLocations_CurrentFirst(t *testing.T) {
+	home := t.TempDir()
+	current := filepath.Join(home, "custom-engram")
+
+	locs := SuggestLocations(home, current)
+	if len(locs) == 0 {
+		t.Fatal("SuggestLocations returned no locations")
+	}
+	if locs[0].Path != filepath.Clean(current) {
+		t.Errorf("first location = %q, want current %q", locs[0].Path, current)
+	}
+	if !locs[0].IsCurrent {
+		t.Error("first location IsCurrent should be true")
+	}
+}
+
+func TestSuggestLocations_DefaultNotCurrentWhenCustomDirSet(t *testing.T) {
+	home := t.TempDir()
+	custom := filepath.Join(home, "custom-engram")
+
+	locs := SuggestLocations(home, custom)
+
+	defaultPath := filepath.Clean(DefaultDir(home))
+	for _, loc := range locs {
+		if loc.Path == defaultPath && loc.IsCurrent {
+			t.Errorf("default dir %q should NOT be IsCurrent when a custom dir is set", defaultPath)
+		}
+	}
+}
+
+func TestSuggestLocations_NoDuplicates(t *testing.T) {
+	home := t.TempDir()
+	// When current == default, we should get exactly one entry for that path.
+	defaultDir := DefaultDir(home)
+	locs := SuggestLocations(home, defaultDir)
+
+	seen := map[string]int{}
+	for _, l := range locs {
+		seen[l.Path]++
+	}
+	for path, count := range seen {
+		if count > 1 {
+			t.Errorf("path %q appears %d times, want 1", path, count)
+		}
+	}
+}
+
+func TestBuildLabel_HomePrefix(t *testing.T) {
+	home := "/home/user"
+	path := filepath.Join(home, ".engram")
+	label := buildLabel(path, home, -1)
+	if label != filepath.Join("~", ".engram") {
+		t.Errorf("buildLabel = %q, want %q", label, filepath.Join("~", ".engram"))
+	}
+}
+
+func TestBuildLabel_WithFreeSpace(t *testing.T) {
+	home := "/home/user"
+	path := filepath.Join(home, ".engram")
+	label := buildLabel(path, home, 1024*1024*1024) // 1 GiB
+	want := filepath.Join("~", ".engram") + "  (1.0 GiB free)"
+	if label != want {
+		t.Errorf("buildLabel = %q, want %q", label, want)
+	}
+}
+
+func TestBuildLabel_NoHomePrefix(t *testing.T) {
+	home := "/home/user"
+	path := "/external/drive/engram"
+	label := buildLabel(path, home, -1)
+	if label != path {
+		t.Errorf("buildLabel = %q, want %q", label, path)
+	}
+}

--- a/internal/components/engram/locations_unix.go
+++ b/internal/components/engram/locations_unix.go
@@ -1,0 +1,25 @@
+//go:build !windows
+
+package engram
+
+import "path/filepath"
+
+// platformVolumes returns mount-point directories to suggest as alternative
+// Engram data locations on macOS (/Volumes/*) and Linux (/mnt/*, /media/*/*).
+func platformVolumes() []string {
+	var roots []string
+
+	for _, glob := range []string{
+		"/Volumes/*",       // macOS external drives
+		"/mnt/*",           // Linux manual mounts
+		"/media/*/*",       // Linux user-automounted drives (udisks2)
+	} {
+		matches, _ := filepath.Glob(glob)
+		for _, m := range matches {
+			if dirExists(m) {
+				roots = append(roots, m)
+			}
+		}
+	}
+	return roots
+}

--- a/internal/components/engram/locations_windows.go
+++ b/internal/components/engram/locations_windows.go
@@ -1,0 +1,38 @@
+//go:build windows
+
+package engram
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+var (
+	_kernel32              = syscall.NewLazyDLL("kernel32.dll")
+	_getDiskFreeSpaceExW   = _kernel32.NewProc("GetDiskFreeSpaceExW")
+)
+
+// platformVolumes returns drive roots that have available disk space on Windows.
+// It iterates A–Z and includes any root (e.g. "C:\") where GetDiskFreeSpaceExW
+// succeeds — meaning the drive is present and accessible.
+func platformVolumes() []string {
+	var roots []string
+	for c := 'A'; c <= 'Z'; c++ {
+		root := string(c) + ":\\"
+		ptr, err := syscall.UTF16PtrFromString(root)
+		if err != nil {
+			continue
+		}
+		var avail, total, free uint64
+		r, _, _ := _getDiskFreeSpaceExW.Call(
+			uintptr(unsafe.Pointer(ptr)),
+			uintptr(unsafe.Pointer(&avail)),
+			uintptr(unsafe.Pointer(&total)),
+			uintptr(unsafe.Pointer(&free)),
+		)
+		if r != 0 {
+			roots = append(roots, root)
+		}
+	}
+	return roots
+}

--- a/internal/components/engram/presenter.go
+++ b/internal/components/engram/presenter.go
@@ -1,0 +1,25 @@
+package engram
+
+import (
+	"fmt"
+
+	"github.com/gentleman-programming/gentle-ai/internal/storage"
+)
+
+// FormatDirLine returns a single display line for a data-directory option, e.g.
+// "~/.engram  (1.2 GiB used)". Used in TUI option lists.
+func FormatDirLine(dir string, dbSize int64) string {
+	if dbSize <= 0 {
+		return dir
+	}
+	return fmt.Sprintf("%s  (%s used)", dir, storage.FormatBytes(dbSize))
+}
+
+// FormatSpaceWarning returns a human-readable warning for insufficient disk
+// space, e.g. "Need 1.2 GiB, only 300.0 MiB free".
+func FormatSpaceWarning(needed, avail int64) string {
+	return fmt.Sprintf("Need %s, only %s free",
+		storage.FormatBytes(needed),
+		storage.FormatBytes(avail),
+	)
+}

--- a/internal/components/engram/service.go
+++ b/internal/components/engram/service.go
@@ -1,0 +1,99 @@
+package engram
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/gentleman-programming/gentle-ai/internal/backup"
+	"github.com/gentleman-programming/gentle-ai/internal/storage"
+)
+
+// snapshotter is a subset of backup.Snapshotter used for testability.
+type snapshotter interface {
+	Create(snapshotDir string, paths []string) (backup.Manifest, error)
+}
+
+// DataDirService provides safe, snapshot-guarded operations on the Engram
+// data directory. Every mutating operation creates a backup before changing
+// anything; the snapshot is visible in the Backups TUI screen.
+type DataDirService struct {
+	homeDir     string
+	backupRoot  string
+	snapshotter snapshotter
+}
+
+// NewDataDirService creates a DataDirService with the default backup.Snapshotter.
+func NewDataDirService(homeDir string) DataDirService {
+	return DataDirService{
+		homeDir:     homeDir,
+		backupRoot:  filepath.Join(homeDir, ".gentle-ai", "backups"),
+		snapshotter: backup.NewSnapshotter(),
+	}
+}
+
+// CopyTo copies the Engram DB from currentDir to dst without removing the source.
+// A snapshot of the source DB is created first. Returns the snapshot manifest.
+func (s DataDirService) CopyTo(currentDir, dst string) (backup.Manifest, error) {
+	srcDB := DBPath(currentDir)
+	snap, err := s.snapshot(srcDB)
+	if err != nil {
+		return backup.Manifest{}, fmt.Errorf("snapshot before copy: %w", err)
+	}
+	if err := CopyDB(srcDB, DBPath(dst)); err != nil {
+		return snap, fmt.Errorf("copy: %w", err)
+	}
+	return snap, nil
+}
+
+// MoveTo copies the Engram DB from currentDir to dst, then removes the source DB.
+// The source is only removed after the copy is verified. Returns the snapshot manifest.
+func (s DataDirService) MoveTo(currentDir, dst string) (backup.Manifest, error) {
+	snap, err := s.CopyTo(currentDir, dst)
+	if err != nil {
+		return snap, err
+	}
+	if err := os.Remove(DBPath(currentDir)); err != nil && !os.IsNotExist(err) {
+		return snap, fmt.Errorf("remove source after move: %w", err)
+	}
+	return snap, nil
+}
+
+// Delete creates a snapshot of the current DB, then removes it.
+// Returns the snapshot manifest so the caller can show the backup ID.
+func (s DataDirService) Delete(dataDir string) (backup.Manifest, error) {
+	dbPath := DBPath(dataDir)
+	snap, err := s.snapshot(dbPath)
+	if err != nil {
+		return backup.Manifest{}, fmt.Errorf("snapshot before delete: %w", err)
+	}
+	if err := os.Remove(dbPath); err != nil && !os.IsNotExist(err) {
+		return snap, fmt.Errorf("delete: %w", err)
+	}
+	return snap, nil
+}
+
+// DiskSpaceOK reports whether the volume at dst has enough free space to hold
+// a copy of the DB at srcDB. Returns (ok, needed bytes, available bytes, error).
+func (s DataDirService) DiskSpaceOK(srcDB, dst string) (bool, int64, int64, error) {
+	info, err := os.Stat(srcDB)
+	if err != nil {
+		return false, 0, 0, fmt.Errorf("stat source DB %q: %w", srcDB, err)
+	}
+	avail, err := storage.AvailableBytes(dst)
+	if err != nil {
+		return false, 0, 0, fmt.Errorf("check available space at %q: %w", dst, err)
+	}
+	needed := info.Size()
+	return avail > needed, needed, avail, nil
+}
+
+// snapshot creates a timestamped backup of dbPath under the backup root.
+func (s DataDirService) snapshot(dbPath string) (backup.Manifest, error) {
+	if err := os.MkdirAll(s.backupRoot, 0o755); err != nil {
+		return backup.Manifest{}, fmt.Errorf("create backup root %q: %w", s.backupRoot, err)
+	}
+	snapshotDir := filepath.Join(s.backupRoot, time.Now().UTC().Format("20060102150405.000000000"))
+	return s.snapshotter.Create(snapshotDir, []string{dbPath})
+}

--- a/internal/components/engram/service.go
+++ b/internal/components/engram/service.go
@@ -1,13 +1,14 @@
 package engram
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"time"
 
 	"github.com/gentleman-programming/gentle-ai/internal/backup"
-	"github.com/gentleman-programming/gentle-ai/internal/storage"
 )
 
 // snapshotter is a subset of backup.Snapshotter used for testability.
@@ -33,67 +34,103 @@ func NewDataDirService(homeDir string) DataDirService {
 	}
 }
 
-// CopyTo copies the Engram DB from currentDir to dst without removing the source.
-// A snapshot of the source DB is created first. Returns the snapshot manifest.
+// CopyTo copies all files from currentDir to dst without removing source.
 func (s DataDirService) CopyTo(currentDir, dst string) (backup.Manifest, error) {
-	srcDB := DBPath(currentDir)
-	snap, err := s.snapshot(srcDB)
+	snap, err := s.snapshot(currentDir)
 	if err != nil {
 		return backup.Manifest{}, fmt.Errorf("snapshot before copy: %w", err)
 	}
-	if err := CopyDB(srcDB, DBPath(dst)); err != nil {
+	if err := copyDataDir(currentDir, dst); err != nil {
 		return snap, fmt.Errorf("copy: %w", err)
 	}
 	return snap, nil
 }
 
-// MoveTo copies the Engram DB from currentDir to dst, then removes the source DB.
-// The source is only removed after the copy is verified. Returns the snapshot manifest.
+// MoveTo copies all files from currentDir to dst, then removes the source files.
 func (s DataDirService) MoveTo(currentDir, dst string) (backup.Manifest, error) {
 	snap, err := s.CopyTo(currentDir, dst)
 	if err != nil {
 		return snap, err
 	}
-	if err := os.Remove(DBPath(currentDir)); err != nil && !os.IsNotExist(err) {
+	if err := clearDataDir(currentDir); err != nil {
 		return snap, fmt.Errorf("remove source after move: %w", err)
 	}
 	return snap, nil
 }
 
-// Delete creates a snapshot of the current DB, then removes it.
-// Returns the snapshot manifest so the caller can show the backup ID.
+// Delete creates a snapshot of dataDir, then removes all its files.
 func (s DataDirService) Delete(dataDir string) (backup.Manifest, error) {
-	dbPath := DBPath(dataDir)
-	snap, err := s.snapshot(dbPath)
+	snap, err := s.snapshot(dataDir)
 	if err != nil {
 		return backup.Manifest{}, fmt.Errorf("snapshot before delete: %w", err)
 	}
-	if err := os.Remove(dbPath); err != nil && !os.IsNotExist(err) {
+	if err := clearDataDir(dataDir); err != nil {
 		return snap, fmt.Errorf("delete: %w", err)
 	}
 	return snap, nil
 }
 
-// DiskSpaceOK reports whether the volume at dst has enough free space to hold
-// a copy of the DB at srcDB. Returns (ok, needed bytes, available bytes, error).
-func (s DataDirService) DiskSpaceOK(srcDB, dst string) (bool, int64, int64, error) {
-	info, err := os.Stat(srcDB)
-	if err != nil {
-		return false, 0, 0, fmt.Errorf("stat source DB %q: %w", srcDB, err)
-	}
-	avail, err := storage.AvailableBytes(dst)
-	if err != nil {
-		return false, 0, 0, fmt.Errorf("check available space at %q: %w", dst, err)
-	}
-	needed := info.Size()
-	return avail > needed, needed, avail, nil
-}
-
-// snapshot creates a timestamped backup of dbPath under the backup root.
-func (s DataDirService) snapshot(dbPath string) (backup.Manifest, error) {
+func (s DataDirService) snapshot(dataDir string) (backup.Manifest, error) {
 	if err := os.MkdirAll(s.backupRoot, 0o755); err != nil {
 		return backup.Manifest{}, fmt.Errorf("create backup root %q: %w", s.backupRoot, err)
 	}
 	snapshotDir := filepath.Join(s.backupRoot, time.Now().UTC().Format("20060102150405.000000000"))
-	return s.snapshotter.Create(snapshotDir, []string{dbPath})
+	return s.snapshotter.Create(snapshotDir, dataDirFiles(dataDir))
+}
+
+// copyDataDir recursively copies all files from src to dst.
+func copyDataDir(src, dst string) error {
+	src = filepath.Clean(src)
+	dst = filepath.Clean(dst)
+	if src == "." || dst == "." {
+		return fmt.Errorf("source and destination data directories are required")
+	}
+	if samePath(src, dst) {
+		return fmt.Errorf("source and destination data directories must be different")
+	}
+	return filepath.WalkDir(src, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, _ := filepath.Rel(src, path)
+		dstPath := filepath.Join(dst, rel)
+		if d.IsDir() {
+			return os.MkdirAll(dstPath, 0o755)
+		}
+		return CopyDB(path, dstPath)
+	})
+}
+
+// clearDataDir removes all entries under dataDir, leaving the directory itself.
+// All errors are collected and returned together.
+func clearDataDir(dataDir string) error {
+	entries, err := os.ReadDir(dataDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	var errs []error
+	for _, e := range entries {
+		p := filepath.Join(dataDir, e.Name())
+		if err := os.RemoveAll(p); err != nil && !os.IsNotExist(err) {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func samePath(a, b string) bool {
+	absA, errA := filepath.Abs(a)
+	absB, errB := filepath.Abs(b)
+	if errA == nil && errB == nil {
+		a, b = absA, absB
+	}
+	infoA, statA := os.Stat(a)
+	infoB, statB := os.Stat(b)
+	if statA == nil && statB == nil && os.SameFile(infoA, infoB) {
+		return true
+	}
+	return filepath.Clean(a) == filepath.Clean(b)
 }

--- a/internal/components/engram/service_test.go
+++ b/internal/components/engram/service_test.go
@@ -30,23 +30,22 @@ func newTestService(t *testing.T) (DataDirService, string) {
 	return svc, home
 }
 
-func writeTestDB(t *testing.T, dir string) string {
+// writeTestDataDir writes a small file into dir to simulate a populated data directory.
+func writeTestDataDir(t *testing.T, dir string) {
 	t.Helper()
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	path := DBPath(dir)
-	if err := os.WriteFile(path, []byte("fake-sqlite"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "engram.db"), []byte("fake-data"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	return path
 }
 
 func TestDataDirService_CopyTo(t *testing.T) {
 	svc, home := newTestService(t)
 	src := filepath.Join(home, "src-data")
 	dst := filepath.Join(home, "dst-data")
-	writeTestDB(t, src)
+	writeTestDataDir(t, src)
 
 	snap, err := svc.CopyTo(src, dst)
 	if err != nil {
@@ -57,12 +56,12 @@ func TestDataDirService_CopyTo(t *testing.T) {
 	}
 
 	// Source must still exist.
-	if _, err := os.Stat(DBPath(src)); err != nil {
-		t.Errorf("source DB removed after CopyTo: %v", err)
+	if !DataDirHasContent(src) {
+		t.Error("source dir empty after CopyTo — expected files to remain")
 	}
-	// Destination must exist.
-	if _, err := os.Stat(DBPath(dst)); err != nil {
-		t.Errorf("dst DB not created: %v", err)
+	// Destination must contain the copied file.
+	if !DataDirHasContent(dst) {
+		t.Error("dst dir empty after CopyTo — expected files to be copied")
 	}
 }
 
@@ -70,27 +69,27 @@ func TestDataDirService_MoveTo(t *testing.T) {
 	svc, home := newTestService(t)
 	src := filepath.Join(home, "src-data")
 	dst := filepath.Join(home, "dst-data")
-	writeTestDB(t, src)
+	writeTestDataDir(t, src)
 
 	_, err := svc.MoveTo(src, dst)
 	if err != nil {
 		t.Fatalf("MoveTo: %v", err)
 	}
 
-	// Source must be gone.
-	if _, err := os.Stat(DBPath(src)); !os.IsNotExist(err) {
-		t.Error("source DB should not exist after MoveTo")
+	// Source must be empty after move.
+	if DataDirHasContent(src) {
+		t.Error("source dir not empty after MoveTo")
 	}
-	// Destination must exist.
-	if _, err := os.Stat(DBPath(dst)); err != nil {
-		t.Errorf("dst DB not created: %v", err)
+	// Destination must have the file.
+	if !DataDirHasContent(dst) {
+		t.Error("dst dir empty after MoveTo — expected files to be moved")
 	}
 }
 
 func TestDataDirService_Delete(t *testing.T) {
 	svc, home := newTestService(t)
 	dir := filepath.Join(home, "data")
-	writeTestDB(t, dir)
+	writeTestDataDir(t, dir)
 
 	snap, err := svc.Delete(dir)
 	if err != nil {
@@ -100,8 +99,8 @@ func TestDataDirService_Delete(t *testing.T) {
 		t.Errorf("snap.ID = %q, want snap-abc123", snap.ID)
 	}
 
-	if _, err := os.Stat(DBPath(dir)); !os.IsNotExist(err) {
-		t.Error("DB should not exist after Delete")
+	if DataDirHasContent(dir) {
+		t.Error("dir not empty after Delete")
 	}
 }
 
@@ -109,10 +108,10 @@ func TestDataDirService_Delete_AlreadyGone(t *testing.T) {
 	svc, home := newTestService(t)
 	dir := filepath.Join(home, "data")
 
-	// Delete on a non-existent DB must not error (os.IsNotExist is tolerated).
+	// Delete on a non-existent dir must not error.
 	_, err := svc.Delete(dir)
 	if err != nil {
-		t.Fatalf("Delete on missing DB: %v", err)
+		t.Fatalf("Delete on missing dir: %v", err)
 	}
 }
 
@@ -125,36 +124,15 @@ func TestDataDirService_SnapshotError_Propagates(t *testing.T) {
 	}
 
 	dir := filepath.Join(home, "data")
-	writeTestDB(t, dir)
+	writeTestDataDir(t, dir)
 
 	_, err := svc.Delete(dir)
 	if err == nil {
 		t.Fatal("expected error from failing snapshotter, got nil")
 	}
 
-	// DB must still exist — no delete when snapshot failed.
-	if _, statErr := os.Stat(DBPath(dir)); statErr != nil {
-		t.Error("DB was deleted despite snapshot failure")
-	}
-}
-
-func TestDataDirService_DiskSpaceOK(t *testing.T) {
-	svc, home := newTestService(t)
-	dir := filepath.Join(home, "data")
-	dbPath := writeTestDB(t, dir)
-
-	ok, needed, avail, err := svc.DiskSpaceOK(dbPath, home)
-	if err != nil {
-		t.Fatalf("DiskSpaceOK: %v", err)
-	}
-	if needed <= 0 {
-		t.Errorf("needed = %d, want > 0", needed)
-	}
-	if avail <= 0 {
-		t.Errorf("avail = %d, want > 0", avail)
-	}
-	// A tiny test file on the same volume should always have space.
-	if !ok {
-		t.Errorf("DiskSpaceOK = false for tiny test file, expected true")
+	// Dir must still have content — no delete when snapshot failed.
+	if !DataDirHasContent(dir) {
+		t.Error("dir was cleared despite snapshot failure")
 	}
 }

--- a/internal/components/engram/service_test.go
+++ b/internal/components/engram/service_test.go
@@ -1,0 +1,160 @@
+package engram
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/internal/backup"
+)
+
+// stubSnapshotter satisfies the snapshotter interface without touching disk.
+type stubSnapshotter struct {
+	err      error
+	manifest backup.Manifest
+}
+
+func (s stubSnapshotter) Create(_ string, _ []string) (backup.Manifest, error) {
+	return s.manifest, s.err
+}
+
+func newTestService(t *testing.T) (DataDirService, string) {
+	t.Helper()
+	home := t.TempDir()
+	svc := DataDirService{
+		homeDir:     home,
+		backupRoot:  filepath.Join(home, ".gentle-ai", "backups"),
+		snapshotter: stubSnapshotter{manifest: backup.Manifest{ID: "snap-abc123"}},
+	}
+	return svc, home
+}
+
+func writeTestDB(t *testing.T, dir string) string {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := DBPath(dir)
+	if err := os.WriteFile(path, []byte("fake-sqlite"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestDataDirService_CopyTo(t *testing.T) {
+	svc, home := newTestService(t)
+	src := filepath.Join(home, "src-data")
+	dst := filepath.Join(home, "dst-data")
+	writeTestDB(t, src)
+
+	snap, err := svc.CopyTo(src, dst)
+	if err != nil {
+		t.Fatalf("CopyTo: %v", err)
+	}
+	if snap.ID != "snap-abc123" {
+		t.Errorf("snap.ID = %q, want snap-abc123", snap.ID)
+	}
+
+	// Source must still exist.
+	if _, err := os.Stat(DBPath(src)); err != nil {
+		t.Errorf("source DB removed after CopyTo: %v", err)
+	}
+	// Destination must exist.
+	if _, err := os.Stat(DBPath(dst)); err != nil {
+		t.Errorf("dst DB not created: %v", err)
+	}
+}
+
+func TestDataDirService_MoveTo(t *testing.T) {
+	svc, home := newTestService(t)
+	src := filepath.Join(home, "src-data")
+	dst := filepath.Join(home, "dst-data")
+	writeTestDB(t, src)
+
+	_, err := svc.MoveTo(src, dst)
+	if err != nil {
+		t.Fatalf("MoveTo: %v", err)
+	}
+
+	// Source must be gone.
+	if _, err := os.Stat(DBPath(src)); !os.IsNotExist(err) {
+		t.Error("source DB should not exist after MoveTo")
+	}
+	// Destination must exist.
+	if _, err := os.Stat(DBPath(dst)); err != nil {
+		t.Errorf("dst DB not created: %v", err)
+	}
+}
+
+func TestDataDirService_Delete(t *testing.T) {
+	svc, home := newTestService(t)
+	dir := filepath.Join(home, "data")
+	writeTestDB(t, dir)
+
+	snap, err := svc.Delete(dir)
+	if err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if snap.ID != "snap-abc123" {
+		t.Errorf("snap.ID = %q, want snap-abc123", snap.ID)
+	}
+
+	if _, err := os.Stat(DBPath(dir)); !os.IsNotExist(err) {
+		t.Error("DB should not exist after Delete")
+	}
+}
+
+func TestDataDirService_Delete_AlreadyGone(t *testing.T) {
+	svc, home := newTestService(t)
+	dir := filepath.Join(home, "data")
+
+	// Delete on a non-existent DB must not error (os.IsNotExist is tolerated).
+	_, err := svc.Delete(dir)
+	if err != nil {
+		t.Fatalf("Delete on missing DB: %v", err)
+	}
+}
+
+func TestDataDirService_SnapshotError_Propagates(t *testing.T) {
+	home := t.TempDir()
+	svc := DataDirService{
+		homeDir:     home,
+		backupRoot:  filepath.Join(home, ".gentle-ai", "backups"),
+		snapshotter: stubSnapshotter{err: errors.New("disk full")},
+	}
+
+	dir := filepath.Join(home, "data")
+	writeTestDB(t, dir)
+
+	_, err := svc.Delete(dir)
+	if err == nil {
+		t.Fatal("expected error from failing snapshotter, got nil")
+	}
+
+	// DB must still exist — no delete when snapshot failed.
+	if _, statErr := os.Stat(DBPath(dir)); statErr != nil {
+		t.Error("DB was deleted despite snapshot failure")
+	}
+}
+
+func TestDataDirService_DiskSpaceOK(t *testing.T) {
+	svc, home := newTestService(t)
+	dir := filepath.Join(home, "data")
+	dbPath := writeTestDB(t, dir)
+
+	ok, needed, avail, err := svc.DiskSpaceOK(dbPath, home)
+	if err != nil {
+		t.Fatalf("DiskSpaceOK: %v", err)
+	}
+	if needed <= 0 {
+		t.Errorf("needed = %d, want > 0", needed)
+	}
+	if avail <= 0 {
+		t.Errorf("avail = %d, want > 0", avail)
+	}
+	// A tiny test file on the same volume should always have space.
+	if !ok {
+		t.Errorf("DiskSpaceOK = false for tiny test file, expected true")
+	}
+}

--- a/internal/model/selection.go
+++ b/internal/model/selection.go
@@ -1,5 +1,18 @@
 package model
 
+// EngramDataDirOp is the operation the user chose for their Engram data directory.
+// String-based enum — matches the AgentID / ComponentID convention.
+type EngramDataDirOp string
+
+const (
+	EngramDataDirOpNone   EngramDataDirOp = ""
+	EngramDataDirOpKeep   EngramDataDirOp = "keep"
+	EngramDataDirOpCopy   EngramDataDirOp = "copy"
+	EngramDataDirOpMove   EngramDataDirOp = "move"
+	EngramDataDirOpDelete EngramDataDirOp = "delete"
+	EngramDataDirOpFresh  EngramDataDirOp = "fresh"
+)
+
 type Selection struct {
 	Agents                 []AgentID
 	Components             []ComponentID
@@ -14,6 +27,8 @@ type Selection struct {
 	KiroModelAssignments   map[string]ClaudeModelAlias // key = phase name; value = opus|sonnet|haiku (Kiro-only)
 	Profiles               []Profile                   // named SDD profiles to generate/update during sync
 	OpenCodePlugins        []OpenCodeCommunityPluginID // optional community OpenCode TUI plugins
+	EngramDataDir          string                      // custom Engram data directory path; "" means default ~/.engram
+	EngramDataDirOp        EngramDataDirOp             // operation chosen at install time; "" means no change
 }
 
 func (s Selection) HasAgent(agent AgentID) bool {

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -41,6 +41,10 @@ type InstallState struct {
 	// Empty for state files written before persona persistence was added —
 	// callers fall back to PersonaGentleman in that case.
 	Persona string `json:"persona,omitempty"`
+
+	// EngramDataDir is the filesystem path of the Engram data directory chosen
+	// by the user. When empty the default (~/.engram) is used.
+	EngramDataDir string `json:"engram_data_dir,omitempty"`
 }
 
 // Path returns the absolute path to the state file for the given home directory.

--- a/internal/storage/bytes.go
+++ b/internal/storage/bytes.go
@@ -1,0 +1,23 @@
+package storage
+
+import "fmt"
+
+// FormatBytes formats n bytes as a human-readable string using 1024-based units,
+// consistent with Engram CLI output.
+func FormatBytes(n int64) string {
+	const (
+		kib = 1024
+		mib = 1024 * kib
+		gib = 1024 * mib
+	)
+	switch {
+	case n >= gib:
+		return fmt.Sprintf("%.1f GiB", float64(n)/float64(gib))
+	case n >= mib:
+		return fmt.Sprintf("%.1f MiB", float64(n)/float64(mib))
+	case n >= kib:
+		return fmt.Sprintf("%.1f KiB", float64(n)/float64(kib))
+	default:
+		return fmt.Sprintf("%d B", n)
+	}
+}

--- a/internal/storage/space.go
+++ b/internal/storage/space.go
@@ -1,0 +1,7 @@
+package storage
+
+// AvailableBytes returns the number of bytes available to an unprivileged user
+// on the volume containing path. path may be an existing file or directory.
+func AvailableBytes(path string) (int64, error) {
+	return availableBytes(path)
+}

--- a/internal/storage/space_test.go
+++ b/internal/storage/space_test.go
@@ -1,0 +1,65 @@
+package storage_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/internal/storage"
+)
+
+func TestAvailableBytes_TempDir(t *testing.T) {
+	dir := t.TempDir()
+	n, err := storage.AvailableBytes(dir)
+	if err != nil {
+		t.Fatalf("AvailableBytes(%q): unexpected error: %v", dir, err)
+	}
+	if n <= 0 {
+		t.Fatalf("AvailableBytes(%q) = %d, want > 0", dir, n)
+	}
+}
+
+func TestAvailableBytes_File(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "space-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+
+	n, err := storage.AvailableBytes(f.Name())
+	if err != nil {
+		t.Fatalf("AvailableBytes(%q): unexpected error: %v", f.Name(), err)
+	}
+	if n <= 0 {
+		t.Fatalf("AvailableBytes(%q) = %d, want > 0", f.Name(), n)
+	}
+}
+
+func TestAvailableBytes_NonExistent(t *testing.T) {
+	_, err := storage.AvailableBytes("/this/path/does/not/exist/ever")
+	if err == nil {
+		t.Fatal("expected error for non-existent path, got nil")
+	}
+}
+
+func TestFormatBytes(t *testing.T) {
+	tests := []struct {
+		n    int64
+		want string
+	}{
+		{0, "0 B"},
+		{512, "512 B"},
+		{1023, "1023 B"},
+		{1024, "1.0 KiB"},
+		{1536, "1.5 KiB"},
+		{1024 * 1024, "1.0 MiB"},
+		{int64(1.5 * 1024 * 1024), "1.5 MiB"},
+		{1024 * 1024 * 1024, "1.0 GiB"},
+		{int64(2469606195), "2.3 GiB"},
+	}
+	for _, tt := range tests {
+		got := storage.FormatBytes(tt.n)
+		if got != tt.want {
+			t.Errorf("FormatBytes(%d) = %q, want %q", tt.n, got, tt.want)
+		}
+	}
+}

--- a/internal/storage/space_unix.go
+++ b/internal/storage/space_unix.go
@@ -1,0 +1,17 @@
+//go:build !windows
+
+package storage
+
+import (
+	"fmt"
+	"syscall"
+)
+
+func availableBytes(path string) (int64, error) {
+	var stat syscall.Statfs_t
+	if err := syscall.Statfs(path, &stat); err != nil {
+		return 0, fmt.Errorf("statfs %q: %w", path, err)
+	}
+	// Bavail = blocks available to unprivileged users
+	return int64(stat.Bavail) * int64(stat.Bsize), nil
+}

--- a/internal/storage/space_windows.go
+++ b/internal/storage/space_windows.go
@@ -1,0 +1,40 @@
+//go:build windows
+
+package storage
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+	"unsafe"
+)
+
+var (
+	kernel32              = syscall.NewLazyDLL("kernel32.dll")
+	getDiskFreeSpaceExW   = kernel32.NewProc("GetDiskFreeSpaceExW")
+)
+
+func availableBytes(path string) (int64, error) {
+	// GetDiskFreeSpaceExW requires a directory path; resolve parent if path is a file.
+	if info, err := os.Stat(path); err == nil && !info.IsDir() {
+		path = filepath.Dir(path)
+	}
+
+	pathPtr, err := syscall.UTF16PtrFromString(path)
+	if err != nil {
+		return 0, fmt.Errorf("encode path %q: %w", path, err)
+	}
+
+	var avail, total, free uint64
+	r, _, err := getDiskFreeSpaceExW.Call(
+		uintptr(unsafe.Pointer(pathPtr)),
+		uintptr(unsafe.Pointer(&avail)),
+		uintptr(unsafe.Pointer(&total)),
+		uintptr(unsafe.Pointer(&free)),
+	)
+	if r == 0 {
+		return 0, fmt.Errorf("GetDiskFreeSpaceExW %q: %w", path, err)
+	}
+	return int64(avail), nil
+}

--- a/internal/tui/engram_install_flow.go
+++ b/internal/tui/engram_install_flow.go
@@ -1,0 +1,50 @@
+package tui
+
+import (
+	"fmt"
+
+	"github.com/gentleman-programming/gentle-ai/internal/components/engram"
+	"github.com/gentleman-programming/gentle-ai/internal/storage"
+)
+
+// proceedToDependencyTreeFromInstallFlow builds the dependency plan and either
+// continues to the dependency tree or intercepts with the install-time Engram
+// prompt when SQLite artifacts already exist (single gate per session unless resolved).
+func (m *Model) proceedToDependencyTreeFromInstallFlow() {
+	m.buildDependencyPlan()
+	if m.installEngramGateResolved {
+		m.setScreen(ScreenDependencyTree)
+		return
+	}
+	if !engram.DataDirHasContent(m.resolvedEngramDir()) {
+		m.setScreen(ScreenDependencyTree)
+		return
+	}
+	m.installFlowEngramActive = true
+	m.Cursor = 0
+	m.setScreen(ScreenEngramDataDirInstall)
+}
+
+// checkEngramCopyMoveDiskSpace sets m.EngramSpaceErr when the destination volume
+// lacks space for a copy/move; returns false if the operation should not proceed to confirm.
+func (m *Model) checkEngramCopyMoveDiskSpace(dstIdx int) bool {
+	m.EngramSpaceErr = ""
+	if dstIdx < 0 || dstIdx >= len(m.engramDirLocations) {
+		return true
+	}
+	dstPath := m.engramDirLocations[dstIdx].Path
+	ok, needed, avail, err := engram.DiskSpaceOKForDataDir(m.resolvedEngramDir(), dstPath)
+	if err != nil {
+		m.EngramSpaceErr = err.Error()
+		return false
+	}
+	if !ok {
+		m.EngramSpaceErr = fmt.Sprintf(
+			"Not enough disk space: need %s to copy Engram data; %s available on destination volume.",
+			storage.FormatBytes(needed),
+			storage.FormatBytes(avail),
+		)
+		return false
+	}
+	return true
+}

--- a/internal/tui/engram_install_flow_test.go
+++ b/internal/tui/engram_install_flow_test.go
@@ -1,0 +1,103 @@
+package tui
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/internal/components/engram"
+	"github.com/gentleman-programming/gentle-ai/internal/model"
+	"github.com/gentleman-programming/gentle-ai/internal/system"
+)
+
+func TestProceedToDependencyTreeFromInstallFlow_gateResolved_skipsEngramPrompt(t *testing.T) {
+	base := NewModel(system.DetectionResult{}, "dev")
+	base.Selection.Preset = model.PresetCustom
+	base.Selection.Agents = []model.AgentID{model.AgentCursor}
+	base.Selection.Components = []model.ComponentID{model.ComponentEngram}
+	base.installEngramGateResolved = true
+	m := &base
+
+	m.proceedToDependencyTreeFromInstallFlow()
+
+	if m.Screen != ScreenDependencyTree {
+		t.Fatalf("Screen = %v, want ScreenDependencyTree", m.Screen)
+	}
+	if m.installFlowEngramActive {
+		t.Fatal("installFlowEngramActive should stay false when gate already resolved")
+	}
+}
+
+func TestProceedToDependencyTreeFromInstallFlow_noSQLiteArtifacts_skipsEngramPrompt(t *testing.T) {
+	tmp := t.TempDir()
+	base := NewModel(system.DetectionResult{}, "dev")
+	base.HomeDir = tmp
+	base.EngramDataDir = filepath.Join(tmp, "edata")
+	if err := os.MkdirAll(base.EngramDataDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	base.Selection.Preset = model.PresetCustom
+	base.Selection.Agents = []model.AgentID{model.AgentCursor}
+	base.Selection.Components = []model.ComponentID{model.ComponentEngram}
+	m := &base
+
+	m.proceedToDependencyTreeFromInstallFlow()
+
+	if m.Screen != ScreenDependencyTree {
+		t.Fatalf("Screen = %v, want ScreenDependencyTree", m.Screen)
+	}
+	if m.installFlowEngramActive {
+		t.Fatal("installFlowEngramActive should stay false when no sqlite files exist")
+	}
+}
+
+func TestProceedToDependencyTreeFromInstallFlow_existingSQLite_showsInstallEngramPrompt(t *testing.T) {
+	tmp := t.TempDir()
+	dataDir := filepath.Join(tmp, "edata")
+	if err := os.MkdirAll(dataDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	dbPath := engram.DBPath(dataDir)
+	if err := os.WriteFile(dbPath, []byte("sqlite"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	base := NewModel(system.DetectionResult{}, "dev")
+	base.HomeDir = tmp
+	base.EngramDataDir = dataDir
+	base.Selection.Preset = model.PresetCustom
+	base.Selection.Agents = []model.AgentID{model.AgentCursor}
+	base.Selection.Components = []model.ComponentID{model.ComponentEngram}
+	m := &base
+
+	m.proceedToDependencyTreeFromInstallFlow()
+
+	if m.Screen != ScreenEngramDataDirInstall {
+		t.Fatalf("Screen = %v, want ScreenEngramDataDirInstall", m.Screen)
+	}
+	if !m.installFlowEngramActive {
+		t.Fatal("installFlowEngramActive should be true for install-time gate")
+	}
+	if m.Cursor != 0 {
+		t.Fatalf("Cursor = %d, want 0", m.Cursor)
+	}
+	if len(m.DependencyPlan.OrderedComponents) == 0 {
+		t.Fatal("DependencyPlan should be populated after buildDependencyPlan")
+	}
+}
+
+func TestCheckEngramCopyMoveDiskSpace_invalidDestinationIgnored(t *testing.T) {
+	base := NewModel(system.DetectionResult{}, "dev")
+	base.engramDirLocations = nil
+	m := &base
+
+	if !m.checkEngramCopyMoveDiskSpace(-1) {
+		t.Fatal("invalid negative index should allow proceed (no disk check)")
+	}
+	if m.EngramSpaceErr != "" {
+		t.Fatalf("EngramSpaceErr = %q, want empty", m.EngramSpaceErr)
+	}
+	if !m.checkEngramCopyMoveDiskSpace(0) {
+		t.Fatal("out-of-range index should allow proceed (no disk check)")
+	}
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -2103,6 +2103,9 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 			m.setScreen(m.PreviousScreen)
 			return m, nil
 		}
+		// Clear any result from a previous operation before launching a new one,
+		// so the result screen never shows stale data if the goroutine arrives late.
+		m.engramDirDoneMsg = nil
 		// Confirm — run the operation in a goroutine.
 		currentDir := m.resolvedEngramDir()
 		var dstDir string

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -240,10 +240,11 @@ const (
 	ScreenAgentBuilderComplete
 
 	// Engram data-directory management screens.
-	ScreenEngramDataDir        // main management screen, entered from Welcome
-	ScreenEngramDataDirConfirm // confirm before a destructive/non-trivial op
-	ScreenEngramDataDirResult  // success/error result after the op
-	ScreenEngramDataDirInstall // install-time: existing data dir detected
+	ScreenEngramDataDir           // main management screen, entered from Welcome
+	ScreenEngramDataDirCustomPath // typed custom destination path
+	ScreenEngramDataDirConfirm    // confirm before a destructive/non-trivial op
+	ScreenEngramDataDirResult     // success/error result after the op
+	ScreenEngramDataDirInstall    // install-time: existing data dir detected
 )
 
 type Model struct {
@@ -435,6 +436,9 @@ type Model struct {
 	// at startup. Controls whether "Manage Engram directory" appears on Welcome.
 	EngramDetected bool
 
+	// EngramSpaceErr is shown when a copy/move destination does not pass disk-space checks.
+	EngramSpaceErr string
+
 	// EngramDataDirFn executes a data-directory operation. Injected at startup
 	// to avoid an import of the engram package into app.go while still keeping
 	// model.go free of filesystem knowledge.
@@ -450,6 +454,12 @@ type Model struct {
 	// engramDirDstIdx is the index into engramDirLocations for the destination.
 	// -1 for ops that have no destination (Keep, Delete).
 	engramDirDstIdx int
+
+	engramDirCustomPath string
+	engramDirCustomPos  int
+
+	installEngramGateResolved bool
+	installFlowEngramActive   bool
 
 	// engramDirDoneMsg holds the result of the last data-dir operation.
 	engramDirDoneMsg *EngramDataDirDoneMsg
@@ -569,8 +579,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			switch msg.Op {
 			case model.EngramDataDirOpMove:
 				// After a move the data now lives at dstDir.
-				if m.engramDirDstIdx >= 0 && m.engramDirDstIdx < len(m.engramDirLocations) {
-					m.EngramDataDir = m.engramDirLocations[m.engramDirDstIdx].Path
+				if dst := m.engramDirDstPath(); dst != "" {
+					m.EngramDataDir = dst
 				}
 			case model.EngramDataDirOpDelete, model.EngramDataDirOpFresh:
 				// Data was removed — reset to default (~/.engram).
@@ -645,6 +655,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		if m.Screen == ScreenProfileCreate && m.ProfileCreateStep == 0 && !m.ProfileEditMode {
 			return m.handleProfileNameInput(msg)
+		}
+		if m.Screen == ScreenEngramDataDirCustomPath {
+			return m.handleEngramCustomPathInput(msg)
 		}
 		// Delegate to textarea when on the agent builder prompt screen,
 		// unless the user pressed Esc (to go back) or Tab (to continue).
@@ -862,7 +875,10 @@ func (m Model) View() string {
 
 	case ScreenEngramDataDir:
 		currentDir := m.resolvedEngramDir()
-		return screens.RenderEngramDataDir(m.Cursor, currentDir, m.engramDBSize(), m.engramDirLocations, m.engramDirOp)
+		return screens.RenderEngramDataDir(m.Cursor, currentDir, m.engramDBSize(), m.engramDirLocations, m.engramDirOp, m.EngramSpaceErr)
+
+	case ScreenEngramDataDirCustomPath:
+		return screens.RenderEngramDataDirCustomPath(m.engramDirOp, m.resolvedEngramDir(), m.engramDirCustomPath, m.engramDirCustomPos, m.EngramSpaceErr)
 
 	case ScreenEngramDataDirInstall:
 		currentDir := m.resolvedEngramDir()
@@ -870,11 +886,7 @@ func (m Model) View() string {
 
 	case ScreenEngramDataDirConfirm:
 		currentDir := m.resolvedEngramDir()
-		var dstDir string
-		if m.engramDirDstIdx >= 0 && m.engramDirDstIdx < len(m.engramDirLocations) {
-			dstDir = m.engramDirLocations[m.engramDirDstIdx].Path
-		}
-		return screens.RenderEngramDataDirConfirm(m.engramDirOp, currentDir, dstDir, m.Cursor)
+		return screens.RenderEngramDataDirConfirm(m.engramDirOp, currentDir, m.engramDirDstPath(), m.Cursor)
 
 	case ScreenEngramDataDirResult:
 		var done EngramDataDirDoneMsg
@@ -1086,6 +1098,9 @@ func (m Model) handleKeyPress(key tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if m.Screen == ScreenEngramDataDir && (m.engramDirOp == model.EngramDataDirOpMove || m.engramDirOp == model.EngramDataDirOpCopy) {
 			m.engramDirOp = model.EngramDataDirOpNone
 			m.engramDirDstIdx = -1
+			m.engramDirCustomPath = ""
+			m.engramDirCustomPos = 0
+			m.EngramSpaceErr = ""
 			m.Cursor = 0
 			return m, nil
 		}
@@ -1238,6 +1253,9 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 					m.engramDirDoneMsg = nil
 					m.engramDirOp = model.EngramDataDirOpNone
 					m.engramDirDstIdx = -1
+					m.engramDirCustomPath = ""
+					m.engramDirCustomPos = 0
+					m.EngramSpaceErr = ""
 					m.Cursor = 0
 					m.setScreen(ScreenEngramDataDir)
 					return m, nil
@@ -2078,20 +2096,34 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 			break
 		}
 		ch := choices[m.Cursor]
+		if ch.DstIdx == screens.EngramCustomPathDstIdx {
+			m.engramDirDstIdx = ch.DstIdx
+			m.engramDirCustomPath = ""
+			m.engramDirCustomPos = 0
+			m.EngramSpaceErr = ""
+			m.setScreen(ScreenEngramDataDirCustomPath)
+			return m, nil
+		}
 		m.engramDirOp = ch.Op
 		m.engramDirDstIdx = ch.DstIdx
+		if !m.checkEngramCopyMoveDiskSpace(ch.DstIdx) {
+			return m, nil
+		}
 		m.setScreen(ScreenEngramDataDirConfirm)
 
 	case ScreenEngramDataDirInstall:
 		switch m.Cursor {
 		case 0: // Keep — continue the install flow without touching the data dir.
 			m.Selection.EngramDataDirOp = model.EngramDataDirOpKeep
+			m.installEngramGateResolved = true
+			m.installFlowEngramActive = false
 			m.setScreen(ScreenDependencyTree)
 			return m, nil
 		case 1: // Fresh — snapshot existing data, then delete. Confirm first.
 			m.Selection.EngramDataDirOp = model.EngramDataDirOpFresh
 			m.engramDirOp = model.EngramDataDirOpFresh
 			m.engramDirDstIdx = -1
+			m.installEngramGateResolved = true
 			m.setScreen(ScreenEngramDataDirConfirm)
 			return m, nil
 		}
@@ -2108,10 +2140,7 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 		m.engramDirDoneMsg = nil
 		// Confirm — run the operation in a goroutine.
 		currentDir := m.resolvedEngramDir()
-		var dstDir string
-		if m.engramDirDstIdx >= 0 && m.engramDirDstIdx < len(m.engramDirLocations) {
-			dstDir = m.engramDirLocations[m.engramDirDstIdx].Path
-		}
+		dstDir := m.engramDirDstPath()
 		op := m.engramDirOp
 		fn := m.EngramDataDirFn
 		return m, func() tea.Msg {
@@ -2126,6 +2155,9 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 		// Any key returns to the management screen.
 		m.engramDirOp = model.EngramDataDirOpNone
 		m.engramDirDstIdx = -1
+		m.engramDirCustomPath = ""
+		m.engramDirCustomPos = 0
+		m.EngramSpaceErr = ""
 		m.setScreen(ScreenEngramDataDir)
 	}
 
@@ -2900,6 +2932,8 @@ func (m Model) optionCount() int {
 			return len(screens.EngramDirLocationChoices(m.engramDirLocations, m.engramDirOp))
 		}
 		return len(screens.EngramDirActionChoices())
+	case ScreenEngramDataDirCustomPath:
+		return 0
 	case ScreenEngramDataDirInstall:
 		return 2 // Keep + Fresh
 	case ScreenEngramDataDirConfirm:
@@ -3335,6 +3369,36 @@ func (m Model) resolvedEngramDir() string {
 	return engram.DefaultDir(m.HomeDir)
 }
 
+func (m Model) engramDirDstPath() string {
+	if m.engramDirDstIdx == screens.EngramCustomPathDstIdx {
+		return resolveEngramCustomPath(m.HomeDir, m.engramDirCustomPath)
+	}
+	if m.engramDirDstIdx >= 0 && m.engramDirDstIdx < len(m.engramDirLocations) {
+		return m.engramDirLocations[m.engramDirDstIdx].Path
+	}
+	return ""
+}
+
+func resolveEngramCustomPath(homeDir, input string) string {
+	path := strings.TrimSpace(input)
+	if path == "" {
+		return ""
+	}
+	if path == "~" {
+		if homeDir == "" {
+			return ""
+		}
+		return homeDir
+	}
+	if strings.HasPrefix(path, "~"+string(os.PathSeparator)) || strings.HasPrefix(path, "~/") || strings.HasPrefix(path, `~\`) {
+		if homeDir == "" {
+			return ""
+		}
+		path = filepath.Join(homeDir, strings.TrimLeft(path[1:], `/\`))
+	}
+	return filepath.Clean(filepath.FromSlash(path))
+}
+
 // engramDBSize returns the file size of the current Engram DB, or 0 on error.
 func (m Model) engramDBSize() int64 {
 	dbPath := engram.DBPath(m.resolvedEngramDir())
@@ -3538,6 +3602,47 @@ func (m Model) handleProfileNameInput(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		// Typing clears the collision warning so the user can modify the name.
 		m.ProfileNameCollision = false
 		m.ProfileNameErr = ""
+		return m, nil
+	}
+	return m, nil
+}
+
+func (m Model) handleEngramCustomPathInput(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.Type {
+	case tea.KeyEnter:
+		if resolveEngramCustomPath(m.HomeDir, m.engramDirCustomPath) == "" {
+			return m, nil
+		}
+		m.setScreen(ScreenEngramDataDirConfirm)
+		return m, nil
+	case tea.KeyEsc:
+		m.setScreen(ScreenEngramDataDir)
+		return m, nil
+	case tea.KeyBackspace:
+		if m.engramDirCustomPos > 0 {
+			runes := []rune(m.engramDirCustomPath)
+			m.engramDirCustomPath = string(append(runes[:m.engramDirCustomPos-1], runes[m.engramDirCustomPos:]...))
+			m.engramDirCustomPos--
+		}
+		return m, nil
+	case tea.KeyLeft:
+		if m.engramDirCustomPos > 0 {
+			m.engramDirCustomPos--
+		}
+		return m, nil
+	case tea.KeyRight:
+		if m.engramDirCustomPos < len([]rune(m.engramDirCustomPath)) {
+			m.engramDirCustomPos++
+		}
+		return m, nil
+	case tea.KeyRunes:
+		runes := []rune(m.engramDirCustomPath)
+		newRunes := make([]rune, 0, len(runes)+len(msg.Runes))
+		newRunes = append(newRunes, runes[:m.engramDirCustomPos]...)
+		newRunes = append(newRunes, msg.Runes...)
+		newRunes = append(newRunes, runes[m.engramDirCustomPos:]...)
+		m.engramDirCustomPath = string(newRunes)
+		m.engramDirCustomPos += len(msg.Runes)
 		return m, nil
 	}
 	return m, nil

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -409,6 +409,11 @@ type Model struct {
 	// OpenCodePluginRegistrationResults and Err hold the dedicated shortcut result.
 	OpenCodePluginRegistrationResults []opencodeplugin.Result
 	OpenCodePluginRegistrationErr     error
+
+	// EngramDataDir is the persisted Engram data directory path loaded from
+	// state.json before the TUI starts. "" means the default (~/.engram).
+	// The management screens (PR D) read and update this field.
+	EngramDataDir string
 }
 
 func NewModel(detection system.DetectionResult, version string) Model {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gentleman-programming/gentle-ai/internal/agentbuilder"
 	"github.com/gentleman-programming/gentle-ai/internal/backup"
 	"github.com/gentleman-programming/gentle-ai/internal/catalog"
+	"github.com/gentleman-programming/gentle-ai/internal/components/engram"
 	"github.com/gentleman-programming/gentle-ai/internal/components/opencodeplugin"
 	"github.com/gentleman-programming/gentle-ai/internal/components/sdd"
 	componentuninstall "github.com/gentleman-programming/gentle-ai/internal/components/uninstall"
@@ -127,6 +128,13 @@ type OpenCodePluginRegistrationDoneMsg struct {
 	Err     error
 }
 
+// EngramDataDirDoneMsg is sent when an Engram data-directory operation completes.
+type EngramDataDirDoneMsg struct {
+	Op         model.EngramDataDirOp
+	SnapshotID string
+	Err        error
+}
+
 // AgentBuilderState holds all transient state for the agent-builder TUI flow.
 type AgentBuilderState struct {
 	AvailableEngines []model.AgentID
@@ -230,6 +238,12 @@ const (
 	ScreenAgentBuilderPreview
 	ScreenAgentBuilderInstalling
 	ScreenAgentBuilderComplete
+
+	// Engram data-directory management screens.
+	ScreenEngramDataDir        // main management screen, entered from Welcome
+	ScreenEngramDataDirConfirm // confirm before a destructive/non-trivial op
+	ScreenEngramDataDirResult  // success/error result after the op
+	ScreenEngramDataDirInstall // install-time: existing data dir detected
 )
 
 type Model struct {
@@ -412,8 +426,33 @@ type Model struct {
 
 	// EngramDataDir is the persisted Engram data directory path loaded from
 	// state.json before the TUI starts. "" means the default (~/.engram).
-	// The management screens (PR D) read and update this field.
 	EngramDataDir string
+
+	// HomeDir is the user's home directory, used for Engram path resolution.
+	HomeDir string
+
+	// EngramDetected is true when the engram data directory or binary is present
+	// at startup. Controls whether "Manage Engram directory" appears on Welcome.
+	EngramDetected bool
+
+	// EngramDataDirFn executes a data-directory operation. Injected at startup
+	// to avoid an import of the engram package into app.go while still keeping
+	// model.go free of filesystem knowledge.
+	EngramDataDirFn func(op model.EngramDataDirOp, currentDir, dstDir string) (snapshotID string, err error)
+
+	// engramDirLocations is the candidate location list loaded when entering
+	// ScreenEngramDataDir.
+	engramDirLocations []engram.Location
+
+	// engramDirOp is the operation chosen on ScreenEngramDataDir.
+	engramDirOp model.EngramDataDirOp
+
+	// engramDirDstIdx is the index into engramDirLocations for the destination.
+	// -1 for ops that have no destination (Keep, Delete).
+	engramDirDstIdx int
+
+	// engramDirDoneMsg holds the result of the last data-dir operation.
+	engramDirDoneMsg *EngramDataDirDoneMsg
 }
 
 func NewModel(detection system.DetectionResult, version string) Model {
@@ -521,6 +560,25 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.OpenCodePluginRegistrationResults = msg.Results
 		m.OpenCodePluginRegistrationErr = msg.Err
 		m.setScreen(ScreenOpenCodePluginResult)
+		return m, nil
+	case EngramDataDirDoneMsg:
+		m.engramDirDoneMsg = &msg
+		if msg.Err == nil {
+			// Update the in-memory data-dir reference to match the operation result.
+			// app.go's EngramDataDirFn closure is responsible for persisting to state.json.
+			switch msg.Op {
+			case model.EngramDataDirOpMove:
+				// After a move the data now lives at dstDir.
+				if m.engramDirDstIdx >= 0 && m.engramDirDstIdx < len(m.engramDirLocations) {
+					m.EngramDataDir = m.engramDirLocations[m.engramDirDstIdx].Path
+				}
+			case model.EngramDataDirOpDelete, model.EngramDataDirOpFresh:
+				// Data was removed — reset to default (~/.engram).
+				m.EngramDataDir = ""
+				// Copy and Keep leave the current directory unchanged.
+			}
+		}
+		m.setScreen(ScreenEngramDataDirResult)
 		return m, nil
 	case StepProgressMsg:
 		return m.handleStepProgress(msg)
@@ -693,7 +751,7 @@ func (m Model) View() string {
 		if m.UpdateCheckDone && update.HasUpdates(m.UpdateResults) {
 			banner = "Updates available: " + update.UpdateSummaryLine(m.UpdateResults)
 		}
-		return screens.RenderWelcome(m.Cursor, m.Version, banner, m.UpdateResults, m.UpdateCheckDone, m.hasDetectedOpenCode(), len(m.ProfileList), m.hasAgentBuilderEngines())
+		return screens.RenderWelcome(m.Cursor, m.Version, banner, m.UpdateResults, m.UpdateCheckDone, m.hasDetectedOpenCode(), len(m.ProfileList), m.hasAgentBuilderEngines(), m.hasEngram())
 	case ScreenUpgrade:
 		return screens.RenderUpgrade(m.UpdateResults, m.UpgradeReport, m.UpgradeErr, m.OperationRunning, m.UpdateCheckDone, m.Cursor, m.SpinnerFrame)
 	case ScreenSync:
@@ -801,6 +859,30 @@ func (m Model) View() string {
 		return screens.RenderABInstalling(engineName, m.SpinnerFrame, m.AgentBuilder.InstallErr)
 	case ScreenAgentBuilderComplete:
 		return screens.RenderABComplete(m.AgentBuilder.Generated, m.AgentBuilder.InstallResults)
+
+	case ScreenEngramDataDir:
+		currentDir := m.resolvedEngramDir()
+		return screens.RenderEngramDataDir(m.Cursor, currentDir, m.engramDBSize(), m.engramDirLocations, m.engramDirOp)
+
+	case ScreenEngramDataDirInstall:
+		currentDir := m.resolvedEngramDir()
+		return screens.RenderEngramDataDirInstall(m.Cursor, currentDir, m.engramDBSize())
+
+	case ScreenEngramDataDirConfirm:
+		currentDir := m.resolvedEngramDir()
+		var dstDir string
+		if m.engramDirDstIdx >= 0 && m.engramDirDstIdx < len(m.engramDirLocations) {
+			dstDir = m.engramDirLocations[m.engramDirDstIdx].Path
+		}
+		return screens.RenderEngramDataDirConfirm(m.engramDirOp, currentDir, dstDir, m.Cursor)
+
+	case ScreenEngramDataDirResult:
+		var done EngramDataDirDoneMsg
+		if m.engramDirDoneMsg != nil {
+			done = *m.engramDirDoneMsg
+		}
+		return screens.RenderEngramDataDirResult(done.Op, done.SnapshotID, done.Err)
+
 	default:
 		return ""
 	}
@@ -1001,6 +1083,12 @@ func (m Model) handleKeyPress(key tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if m.Screen == ScreenInstalling && m.pipelineRunning {
 			return m, nil
 		}
+		if m.Screen == ScreenEngramDataDir && (m.engramDirOp == model.EngramDataDirOpMove || m.engramDirOp == model.EngramDataDirOpCopy) {
+			m.engramDirOp = model.EngramDataDirOpNone
+			m.engramDirDstIdx = -1
+			m.Cursor = 0
+			return m, nil
+		}
 		return m.goBack(), nil
 	case " ":
 		switch m.Screen {
@@ -1139,6 +1227,19 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 			if m.hasDetectedOpenCode() {
 				if m.Cursor == next {
 					m.setScreen(ScreenProfiles)
+					return m, nil
+				}
+				next++
+			}
+
+			if m.hasEngram() {
+				if m.Cursor == next {
+					m.engramDirLocations = engram.SuggestLocations(m.HomeDir, m.resolvedEngramDir())
+					m.engramDirDoneMsg = nil
+					m.engramDirOp = model.EngramDataDirOpNone
+					m.engramDirDstIdx = -1
+					m.Cursor = 0
+					m.setScreen(ScreenEngramDataDir)
 					return m, nil
 				}
 				next++
@@ -1956,6 +2057,73 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 		}
 	case ScreenAgentBuilderComplete:
 		m.setScreen(ScreenWelcome)
+
+	case ScreenEngramDataDir:
+		if m.engramDirOp == model.EngramDataDirOpNone {
+			choices := screens.EngramDirActionChoices()
+			if m.Cursor >= len(choices) {
+				break
+			}
+			ch := choices[m.Cursor]
+			m.engramDirOp = ch.Op
+			m.engramDirDstIdx = -1
+			m.Cursor = 0
+			if ch.Op == model.EngramDataDirOpDelete {
+				m.setScreen(ScreenEngramDataDirConfirm)
+			}
+			return m, nil
+		}
+		choices := screens.EngramDirLocationChoices(m.engramDirLocations, m.engramDirOp)
+		if m.Cursor >= len(choices) {
+			break
+		}
+		ch := choices[m.Cursor]
+		m.engramDirOp = ch.Op
+		m.engramDirDstIdx = ch.DstIdx
+		m.setScreen(ScreenEngramDataDirConfirm)
+
+	case ScreenEngramDataDirInstall:
+		switch m.Cursor {
+		case 0: // Keep — continue the install flow without touching the data dir.
+			m.Selection.EngramDataDirOp = model.EngramDataDirOpKeep
+			m.setScreen(ScreenDependencyTree)
+			return m, nil
+		case 1: // Fresh — snapshot existing data, then delete. Confirm first.
+			m.Selection.EngramDataDirOp = model.EngramDataDirOpFresh
+			m.engramDirOp = model.EngramDataDirOpFresh
+			m.engramDirDstIdx = -1
+			m.setScreen(ScreenEngramDataDirConfirm)
+			return m, nil
+		}
+
+	case ScreenEngramDataDirConfirm:
+		if m.Cursor == 1 {
+			// Cancel — return to whichever screen launched the confirm (management
+			// screen or install-time screen). m.PreviousScreen is set by setScreen.
+			m.setScreen(m.PreviousScreen)
+			return m, nil
+		}
+		// Confirm — run the operation in a goroutine.
+		currentDir := m.resolvedEngramDir()
+		var dstDir string
+		if m.engramDirDstIdx >= 0 && m.engramDirDstIdx < len(m.engramDirLocations) {
+			dstDir = m.engramDirLocations[m.engramDirDstIdx].Path
+		}
+		op := m.engramDirOp
+		fn := m.EngramDataDirFn
+		return m, func() tea.Msg {
+			if fn == nil {
+				return EngramDataDirDoneMsg{Op: op, Err: fmt.Errorf("EngramDataDirFn not configured")}
+			}
+			snapID, err := fn(op, currentDir, dstDir)
+			return EngramDataDirDoneMsg{Op: op, SnapshotID: snapID, Err: err}
+		}
+
+	case ScreenEngramDataDirResult:
+		// Any key returns to the management screen.
+		m.engramDirOp = model.EngramDataDirOpNone
+		m.engramDirDstIdx = -1
+		m.setScreen(ScreenEngramDataDir)
 	}
 
 	return m, nil
@@ -2618,7 +2786,7 @@ func (m Model) handleRenameInput(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 func (m Model) optionCount() int {
 	switch m.Screen {
 	case ScreenWelcome:
-		return len(screens.WelcomeOptions(m.UpdateResults, m.UpdateCheckDone, m.hasDetectedOpenCode(), len(m.ProfileList), m.hasAgentBuilderEngines()))
+		return len(screens.WelcomeOptions(m.UpdateResults, m.UpdateCheckDone, m.hasDetectedOpenCode(), len(m.ProfileList), m.hasAgentBuilderEngines(), m.hasEngram()))
 	case ScreenUpgrade:
 		if m.UpgradeReport != nil || m.UpgradeErr != nil {
 			return 1 // "return" option in results/error state
@@ -2724,6 +2892,17 @@ func (m Model) optionCount() int {
 		return 0 // no cursor navigation while installing
 	case ScreenAgentBuilderComplete:
 		return 1 // Done
+	case ScreenEngramDataDir:
+		if m.engramDirOp == model.EngramDataDirOpMove || m.engramDirOp == model.EngramDataDirOpCopy {
+			return len(screens.EngramDirLocationChoices(m.engramDirLocations, m.engramDirOp))
+		}
+		return len(screens.EngramDirActionChoices())
+	case ScreenEngramDataDirInstall:
+		return 2 // Keep + Fresh
+	case ScreenEngramDataDirConfirm:
+		return 2 // Confirm + Cancel
+	case ScreenEngramDataDirResult:
+		return 1
 	default:
 		return 0
 	}
@@ -3138,6 +3317,29 @@ func extractAvailableUpdates(results []update.UpdateResult) []screens.UpdateInfo
 		}
 	}
 	return updates
+}
+
+// hasEngram returns true when engram is present (binary or data directory found
+// at startup). Controls whether Engram directory management is shown on Welcome.
+func (m Model) hasEngram() bool { return m.EngramDetected }
+
+// resolvedEngramDir returns the active Engram data directory path.
+// Falls back to the default (~/.engram) when no custom dir is set.
+func (m Model) resolvedEngramDir() string {
+	if m.EngramDataDir != "" {
+		return m.EngramDataDir
+	}
+	return engram.DefaultDir(m.HomeDir)
+}
+
+// engramDBSize returns the file size of the current Engram DB, or 0 on error.
+func (m Model) engramDBSize() int64 {
+	dbPath := engram.DBPath(m.resolvedEngramDir())
+	info, err := os.Stat(dbPath)
+	if err != nil {
+		return 0
+	}
+	return info.Size()
 }
 
 // hasDetectedOpenCode returns true if OpenCode config directory was detected.

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1040,12 +1040,12 @@ func TestWelcomeMenu_UninstallNavigation_WithProfiles(t *testing.T) {
 func TestWelcomeMenu_OptionCount(t *testing.T) {
 	m := NewModel(system.DetectionResult{}, "dev")
 	// Without OpenCode detected: 10 options (includes dedicated OpenCode community plugins and managed uninstall).
-	opts := screens.WelcomeOptions(m.UpdateResults, m.UpdateCheckDone, false, 0, true)
+	opts := screens.WelcomeOptions(m.UpdateResults, m.UpdateCheckDone, false, 0, true, false)
 	if len(opts) != 10 {
 		t.Fatalf("WelcomeOptions(showProfiles=false) len = %d, want 10; got %v", len(opts), opts)
 	}
 	// With OpenCode detected: 11 options (adds "OpenCode SDD Profiles").
-	optsWithProfiles := screens.WelcomeOptions(m.UpdateResults, m.UpdateCheckDone, true, 0, true)
+	optsWithProfiles := screens.WelcomeOptions(m.UpdateResults, m.UpdateCheckDone, true, 0, true, false)
 	if len(optsWithProfiles) != 11 {
 		t.Fatalf("WelcomeOptions(showProfiles=true) len = %d, want 11; got %v", len(optsWithProfiles), optsWithProfiles)
 	}

--- a/internal/tui/router.go
+++ b/internal/tui/router.go
@@ -43,6 +43,12 @@ var linearRoutes = map[Screen]Route{
 	ScreenAgentBuilderPreview:    {Backward: ScreenAgentBuilderPrompt},
 	ScreenAgentBuilderInstalling: {Forward: ScreenAgentBuilderComplete},
 	ScreenAgentBuilderComplete:   {Backward: ScreenWelcome},
+	// Engram data-directory management (from Welcome menu).
+	ScreenEngramDataDir:        {Backward: ScreenWelcome},
+	ScreenEngramDataDirConfirm: {Backward: ScreenEngramDataDir},
+	ScreenEngramDataDirResult:  {Backward: ScreenEngramDataDir},
+	// Install-time Engram data detection (between Preset and DependencyTree).
+	ScreenEngramDataDirInstall: {Forward: ScreenDependencyTree, Backward: ScreenPreset},
 	ScreenUninstallMode:          {Backward: ScreenWelcome},
 	ScreenUninstall:              {Backward: ScreenUninstallMode},
 	ScreenUninstallComponents:    {Backward: ScreenUninstall},

--- a/internal/tui/screens/engram_datadir.go
+++ b/internal/tui/screens/engram_datadir.go
@@ -1,0 +1,174 @@
+package screens
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/gentleman-programming/gentle-ai/internal/components/engram"
+	"github.com/gentleman-programming/gentle-ai/internal/model"
+	"github.com/gentleman-programming/gentle-ai/internal/tui/styles"
+)
+
+// EngramDirChoice is one entry in the data-directory management option list.
+type EngramDirChoice struct {
+	Label  string
+	Op     model.EngramDataDirOp
+	DstIdx int // index into the locations slice; -1 for Keep and Delete
+}
+
+// EngramDirActionChoices builds the first-step management actions.
+func EngramDirActionChoices() []EngramDirChoice {
+	return []EngramDirChoice{
+		{Label: "Migrate / Move Data", Op: model.EngramDataDirOpMove, DstIdx: -1},
+		{Label: "Copy Data", Op: model.EngramDataDirOpCopy, DstIdx: -1},
+		{Label: "Delete current Data", Op: model.EngramDataDirOpDelete, DstIdx: -1},
+	}
+}
+
+// EngramDirLocationChoices builds the second-step destination list for copy/move.
+func EngramDirLocationChoices(locations []engram.Location, op model.EngramDataDirOp) []EngramDirChoice {
+	var out []EngramDirChoice
+	verb := "Use"
+	if op == model.EngramDataDirOpMove {
+		verb = "Move to"
+	} else if op == model.EngramDataDirOpCopy {
+		verb = "Copy to"
+	}
+	for i, loc := range locations {
+		if loc.IsCurrent {
+			continue
+		}
+		out = append(out, EngramDirChoice{Label: verb + "  " + loc.Label, Op: op, DstIdx: i})
+	}
+	return out
+}
+
+// RenderEngramDataDir renders the main management screen shown from Welcome.
+func RenderEngramDataDir(cursor int, currentDir string, dbSize int64, locations []engram.Location, selectedOp model.EngramDataDirOp) string {
+	var b strings.Builder
+
+	b.WriteString(styles.TitleStyle.Render("Manage Engram Data Directory"))
+	b.WriteString("\n\n")
+	b.WriteString(styles.SubtextStyle.Render("Current: " + engram.FormatDirLine(currentDir, dbSize)))
+	b.WriteString("\n\n")
+	if selectedOp == model.EngramDataDirOpMove || selectedOp == model.EngramDataDirOpCopy {
+		b.WriteString(styles.SubtextStyle.Render("Choose the destination for " + engramOpVerb(selectedOp) + "."))
+		b.WriteString("\n\n")
+	} else {
+		b.WriteString(styles.SubtextStyle.Render("Choose what you want to do first. Destinations are shown on the next screen."))
+		b.WriteString("\n\n")
+	}
+
+	choices := EngramDirActionChoices()
+	if selectedOp == model.EngramDataDirOpMove || selectedOp == model.EngramDataDirOpCopy {
+		choices = EngramDirLocationChoices(locations, selectedOp)
+	}
+	labels := make([]string, len(choices))
+	for i, c := range choices {
+		labels[i] = c.Label
+	}
+	b.WriteString(renderOptions(labels, cursor))
+	b.WriteString("\n")
+	b.WriteString(styles.WarningStyle.Render("⚠  Ensure engram is not running before copying or moving data."))
+	b.WriteString("\n")
+	b.WriteString(styles.HelpStyle.Render("j/k: navigate • enter: select • esc: back"))
+
+	return b.String()
+}
+
+// RenderEngramDataDirInstall renders the install-time data directory screen
+// shown when an existing data directory is detected.
+func RenderEngramDataDirInstall(cursor int, detectedDir string, dbSize int64) string {
+	var b strings.Builder
+
+	b.WriteString(styles.TitleStyle.Render("Existing Engram Data Found"))
+	b.WriteString("\n\n")
+	b.WriteString(styles.SubtextStyle.Render("Detected: " + engram.FormatDirLine(detectedDir, dbSize)))
+	b.WriteString("\n\n")
+
+	opts := []string{
+		"Keep location  (use data as-is)",
+		"Start fresh    (snapshot existing, then delete)",
+	}
+	b.WriteString(renderOptions(opts, cursor))
+	b.WriteString("\n")
+	b.WriteString(styles.HelpStyle.Render("j/k: navigate • enter: select • esc: back"))
+
+	return b.String()
+}
+
+// RenderEngramDataDirConfirm renders the confirmation screen before a
+// destructive (move, delete, fresh) or non-trivial (copy) operation.
+func RenderEngramDataDirConfirm(op model.EngramDataDirOp, currentDir, dstDir string, cursor int) string {
+	var b strings.Builder
+
+	b.WriteString(styles.TitleStyle.Render("Confirm — " + engramOpVerb(op)))
+	b.WriteString("\n\n")
+
+	switch op {
+	case model.EngramDataDirOpCopy:
+		b.WriteString(fmt.Sprintf("  Copy  %s\n", styles.SubtextStyle.Render(currentDir)))
+		b.WriteString(fmt.Sprintf("    → %s\n", styles.SubtextStyle.Render(dstDir)))
+	case model.EngramDataDirOpMove:
+		b.WriteString(fmt.Sprintf("  Move  %s\n", styles.SubtextStyle.Render(currentDir)))
+		b.WriteString(fmt.Sprintf("    → %s\n", styles.SubtextStyle.Render(dstDir)))
+		b.WriteString(styles.WarningStyle.Render("  Source will be removed after successful copy."))
+		b.WriteString("\n")
+	case model.EngramDataDirOpDelete:
+		b.WriteString(fmt.Sprintf("  Delete  %s\n", styles.WarningStyle.Render(currentDir)))
+		b.WriteString(styles.WarningStyle.Render("  A snapshot backup will be created first."))
+		b.WriteString("\n")
+	case model.EngramDataDirOpFresh:
+		b.WriteString(fmt.Sprintf("  Delete  %s\n", styles.WarningStyle.Render(currentDir)))
+		b.WriteString(styles.WarningStyle.Render("  A snapshot backup will be created first."))
+		b.WriteString("\n")
+	}
+
+	b.WriteString("\n")
+	b.WriteString(styles.SubtextStyle.Render("A snapshot backup is created before any change."))
+	b.WriteString("\n\n")
+	b.WriteString(renderOptions([]string{"Confirm", "Cancel"}, cursor))
+	b.WriteString("\n")
+	b.WriteString(styles.HelpStyle.Render("enter: confirm • esc: cancel"))
+
+	return b.String()
+}
+
+// RenderEngramDataDirResult renders the success/error screen after an operation.
+func RenderEngramDataDirResult(op model.EngramDataDirOp, snapshotID string, err error) string {
+	var b strings.Builder
+
+	if err != nil {
+		b.WriteString(styles.ErrorStyle.Render("✗ " + engramOpVerb(op) + " failed"))
+		b.WriteString("\n\n")
+		b.WriteString(styles.WarningStyle.Render("  " + err.Error()))
+		b.WriteString("\n\n")
+		b.WriteString(styles.SubtextStyle.Render("  Source data was not modified."))
+	} else {
+		b.WriteString(styles.SuccessStyle.Render("✓ " + engramOpVerb(op) + " complete"))
+		if snapshotID != "" {
+			b.WriteString("\n\n")
+			b.WriteString(styles.SubtextStyle.Render(fmt.Sprintf("  Snapshot: %s", snapshotID)))
+		}
+	}
+
+	b.WriteString("\n\n")
+	b.WriteString(styles.HelpStyle.Render("any key: back"))
+
+	return b.String()
+}
+
+func engramOpVerb(op model.EngramDataDirOp) string {
+	switch op {
+	case model.EngramDataDirOpCopy:
+		return "Copy data directory"
+	case model.EngramDataDirOpMove:
+		return "Move data directory"
+	case model.EngramDataDirOpDelete:
+		return "Delete data directory"
+	case model.EngramDataDirOpFresh:
+		return "Start fresh"
+	default:
+		return "Data directory operation"
+	}
+}

--- a/internal/tui/screens/engram_datadir.go
+++ b/internal/tui/screens/engram_datadir.go
@@ -16,6 +16,8 @@ type EngramDirChoice struct {
 	DstIdx int // index into the locations slice; -1 for Keep and Delete
 }
 
+const EngramCustomPathDstIdx = -2
+
 // EngramDirActionChoices builds the first-step management actions.
 func EngramDirActionChoices() []EngramDirChoice {
 	return []EngramDirChoice{
@@ -40,11 +42,12 @@ func EngramDirLocationChoices(locations []engram.Location, op model.EngramDataDi
 		}
 		out = append(out, EngramDirChoice{Label: verb + "  " + loc.Label, Op: op, DstIdx: i})
 	}
+	out = append(out, EngramDirChoice{Label: "Type custom path…", Op: op, DstIdx: EngramCustomPathDstIdx})
 	return out
 }
 
 // RenderEngramDataDir renders the main management screen shown from Welcome.
-func RenderEngramDataDir(cursor int, currentDir string, dbSize int64, locations []engram.Location, selectedOp model.EngramDataDirOp) string {
+func RenderEngramDataDir(cursor int, currentDir string, dbSize int64, locations []engram.Location, selectedOp model.EngramDataDirOp, spaceErr string) string {
 	var b strings.Builder
 
 	b.WriteString(styles.TitleStyle.Render("Manage Engram Data Directory"))
@@ -56,6 +59,10 @@ func RenderEngramDataDir(cursor int, currentDir string, dbSize int64, locations 
 		b.WriteString("\n\n")
 	} else {
 		b.WriteString(styles.SubtextStyle.Render("Choose what you want to do first. Destinations are shown on the next screen."))
+		b.WriteString("\n\n")
+	}
+	if strings.TrimSpace(spaceErr) != "" {
+		b.WriteString(styles.WarningStyle.Render(spaceErr))
 		b.WriteString("\n\n")
 	}
 
@@ -97,6 +104,32 @@ func RenderEngramDataDirInstall(cursor int, detectedDir string, dbSize int64) st
 	return b.String()
 }
 
+func RenderEngramDataDirCustomPath(op model.EngramDataDirOp, currentDir, path string, pos int, errMsg string) string {
+	var b strings.Builder
+
+	b.WriteString(styles.TitleStyle.Render("Custom Engram Path"))
+	b.WriteString("\n\n")
+	b.WriteString(styles.SubtextStyle.Render("Action: " + engramOpVerb(op)))
+	b.WriteString("\n")
+	b.WriteString(styles.SubtextStyle.Render("Current: " + currentDir))
+	b.WriteString("\n\n")
+	b.WriteString("Path: " + renderPathInput(path, pos))
+	b.WriteString("\n")
+	if strings.TrimSpace(path) == "" {
+		b.WriteString(styles.HelpStyle.Render(`Examples: D:\Engram • ~/Engram • /Volumes/Drive/Engram • /mnt/usb/Engram`))
+		b.WriteString("\n")
+	}
+	if strings.TrimSpace(errMsg) != "" {
+		b.WriteString("\n")
+		b.WriteString(styles.WarningStyle.Render(errMsg))
+		b.WriteString("\n")
+	}
+	b.WriteString("\n")
+	b.WriteString(styles.HelpStyle.Render("type/paste path • enter: continue • esc: destinations"))
+
+	return b.String()
+}
+
 // RenderEngramDataDirConfirm renders the confirmation screen before a
 // destructive (move, delete, fresh) or non-trivial (copy) operation.
 func RenderEngramDataDirConfirm(op model.EngramDataDirOp, currentDir, dstDir string, cursor int) string {
@@ -132,6 +165,19 @@ func RenderEngramDataDirConfirm(op model.EngramDataDirOp, currentDir, dstDir str
 	b.WriteString(styles.HelpStyle.Render("enter: confirm • esc: cancel"))
 
 	return b.String()
+}
+
+func renderPathInput(path string, pos int) string {
+	runes := []rune(path)
+	if pos < 0 {
+		pos = 0
+	}
+	if pos > len(runes) {
+		pos = len(runes)
+	}
+	before := string(runes[:pos])
+	after := string(runes[pos:])
+	return styles.SelectedStyle.Render("[" + before + "▌" + after + "]")
 }
 
 // RenderEngramDataDirResult renders the success/error screen after an operation.

--- a/internal/tui/screens/engram_datadir_test.go
+++ b/internal/tui/screens/engram_datadir_test.go
@@ -1,0 +1,135 @@
+package screens
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/internal/components/engram"
+	"github.com/gentleman-programming/gentle-ai/internal/model"
+)
+
+func TestRenderEngramDataDir_HasTitle(t *testing.T) {
+	locs := []engram.Location{
+		{Path: "/home/user/.engram", Label: "~/.engram", Available: -1, IsCurrent: true},
+	}
+	out := RenderEngramDataDir(0, "/home/user/.engram", 1024, locs, model.EngramDataDirOpNone)
+	if !strings.Contains(out, "Manage Engram Data Directory") {
+		t.Error("expected title in output")
+	}
+}
+
+func TestRenderEngramDataDir_ShowsCurrentDir(t *testing.T) {
+	locs := []engram.Location{
+		{Path: "/home/user/.engram", Label: "~/.engram", Available: -1, IsCurrent: true},
+	}
+	out := RenderEngramDataDir(0, "/home/user/.engram", 0, locs, model.EngramDataDirOpNone)
+	if !strings.Contains(out, "/home/user/.engram") {
+		t.Error("expected current dir in output")
+	}
+}
+
+func TestRenderEngramDataDir_ActionMenuHidesLocations(t *testing.T) {
+	locs := []engram.Location{
+		{Path: "/home/user/.engram", Label: "~/.engram", Available: 1024 * 1024, IsCurrent: true},
+		{Path: "/mnt/external/Engram", Label: "/mnt/external/Engram", Available: 1024 * 1024 * 1024, IsCurrent: false},
+	}
+	out := RenderEngramDataDir(0, "/home/user/.engram", 0, locs, model.EngramDataDirOpNone)
+	for _, want := range []string{"Migrate / Move Data", "Copy Data", "Delete current Data"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected action %q", want)
+		}
+	}
+	if strings.Contains(out, "/mnt/external/Engram") {
+		t.Error("action menu should not show destination paths")
+	}
+}
+
+func TestRenderEngramDataDir_DestinationMenuShowsRelevantLocations(t *testing.T) {
+	locs := []engram.Location{
+		{Path: "/home/user/.engram", Label: "~/.engram", IsCurrent: true},
+		{Path: "/mnt/external/Engram", Label: "/mnt/external/Engram", IsCurrent: false},
+	}
+	out := RenderEngramDataDir(0, "/home/user/.engram", 0, locs, model.EngramDataDirOpMove)
+	if !strings.Contains(out, "Move to") || !strings.Contains(out, "/mnt/external/Engram") {
+		t.Fatal("expected move destination option")
+	}
+	if strings.Contains(out, "Copy Data") || strings.Contains(out, "Delete current Data") {
+		t.Error("destination menu should not show unrelated top-level actions")
+	}
+}
+
+func TestEngramDirActionChoices_Order(t *testing.T) {
+	choices := EngramDirActionChoices()
+	want := []model.EngramDataDirOp{
+		model.EngramDataDirOpMove,
+		model.EngramDataDirOpCopy,
+		model.EngramDataDirOpDelete,
+	}
+	for i, op := range want {
+		if choices[i].Op != op {
+			t.Errorf("choices[%d].Op = %q, want %q", i, choices[i].Op, op)
+		}
+	}
+}
+
+func TestEngramDirLocationChoices_NonCurrentLocations(t *testing.T) {
+	locs := []engram.Location{
+		{Path: "/a", Label: "A", IsCurrent: true},
+		{Path: "/b", Label: "B", IsCurrent: false},
+	}
+	choices := EngramDirLocationChoices(locs, model.EngramDataDirOpCopy)
+	if len(choices) != 1 {
+		t.Fatalf("len(choices) = %d, want 1", len(choices))
+	}
+	if choices[0].Op != model.EngramDataDirOpCopy {
+		t.Errorf("choices[0].Op = %q, want Copy", choices[0].Op)
+	}
+	if choices[0].DstIdx != 1 {
+		t.Errorf("choices[0].DstIdx = %d, want 1", choices[0].DstIdx)
+	}
+}
+
+func TestRenderEngramDataDirInstall_HasTitle(t *testing.T) {
+	out := RenderEngramDataDirInstall(0, "/home/user/.engram", 512)
+	if !strings.Contains(out, "Existing Engram Data Found") {
+		t.Error("expected title in install screen output")
+	}
+}
+
+func TestRenderEngramDataDirConfirm_Copy(t *testing.T) {
+	out := RenderEngramDataDirConfirm(model.EngramDataDirOpCopy, "/src", "/dst", 0)
+	if !strings.Contains(out, "Copy") {
+		t.Error("expected Copy in confirm output")
+	}
+	if !strings.Contains(out, "/src") || !strings.Contains(out, "/dst") {
+		t.Error("expected src and dst paths in confirm output")
+	}
+}
+
+func TestRenderEngramDataDirConfirm_Delete(t *testing.T) {
+	out := RenderEngramDataDirConfirm(model.EngramDataDirOpDelete, "/src", "", 0)
+	if !strings.Contains(out, "Delete") {
+		t.Error("expected Delete in confirm output")
+	}
+}
+
+func TestRenderEngramDataDirResult_Success(t *testing.T) {
+	out := RenderEngramDataDirResult(model.EngramDataDirOpCopy, "snap-abc123", nil)
+	if !strings.Contains(out, "snap-abc123") {
+		t.Error("expected snapshot ID in success output")
+	}
+	if strings.Contains(out, "failed") {
+		t.Error("should not contain 'failed' on success")
+	}
+}
+
+func TestRenderEngramDataDirResult_Error(t *testing.T) {
+	out := RenderEngramDataDirResult(model.EngramDataDirOpDelete, "", errors.New("disk full"))
+	if !strings.Contains(out, "disk full") {
+		t.Error("expected error message in failure output")
+	}
+	if !strings.Contains(out, "failed") {
+		t.Error("expected 'failed' in error output")
+	}
+}

--- a/internal/tui/screens/engram_datadir_test.go
+++ b/internal/tui/screens/engram_datadir_test.go
@@ -13,7 +13,7 @@ func TestRenderEngramDataDir_HasTitle(t *testing.T) {
 	locs := []engram.Location{
 		{Path: "/home/user/.engram", Label: "~/.engram", Available: -1, IsCurrent: true},
 	}
-	out := RenderEngramDataDir(0, "/home/user/.engram", 1024, locs, model.EngramDataDirOpNone)
+	out := RenderEngramDataDir(0, "/home/user/.engram", 1024, locs, model.EngramDataDirOpNone, "")
 	if !strings.Contains(out, "Manage Engram Data Directory") {
 		t.Error("expected title in output")
 	}
@@ -23,7 +23,7 @@ func TestRenderEngramDataDir_ShowsCurrentDir(t *testing.T) {
 	locs := []engram.Location{
 		{Path: "/home/user/.engram", Label: "~/.engram", Available: -1, IsCurrent: true},
 	}
-	out := RenderEngramDataDir(0, "/home/user/.engram", 0, locs, model.EngramDataDirOpNone)
+	out := RenderEngramDataDir(0, "/home/user/.engram", 0, locs, model.EngramDataDirOpNone, "")
 	if !strings.Contains(out, "/home/user/.engram") {
 		t.Error("expected current dir in output")
 	}
@@ -34,7 +34,7 @@ func TestRenderEngramDataDir_ActionMenuHidesLocations(t *testing.T) {
 		{Path: "/home/user/.engram", Label: "~/.engram", Available: 1024 * 1024, IsCurrent: true},
 		{Path: "/mnt/external/Engram", Label: "/mnt/external/Engram", Available: 1024 * 1024 * 1024, IsCurrent: false},
 	}
-	out := RenderEngramDataDir(0, "/home/user/.engram", 0, locs, model.EngramDataDirOpNone)
+	out := RenderEngramDataDir(0, "/home/user/.engram", 0, locs, model.EngramDataDirOpNone, "")
 	for _, want := range []string{"Migrate / Move Data", "Copy Data", "Delete current Data"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("expected action %q", want)
@@ -50,7 +50,7 @@ func TestRenderEngramDataDir_DestinationMenuShowsRelevantLocations(t *testing.T)
 		{Path: "/home/user/.engram", Label: "~/.engram", IsCurrent: true},
 		{Path: "/mnt/external/Engram", Label: "/mnt/external/Engram", IsCurrent: false},
 	}
-	out := RenderEngramDataDir(0, "/home/user/.engram", 0, locs, model.EngramDataDirOpMove)
+	out := RenderEngramDataDir(0, "/home/user/.engram", 0, locs, model.EngramDataDirOpMove, "")
 	if !strings.Contains(out, "Move to") || !strings.Contains(out, "/mnt/external/Engram") {
 		t.Fatal("expected move destination option")
 	}
@@ -79,14 +79,36 @@ func TestEngramDirLocationChoices_NonCurrentLocations(t *testing.T) {
 		{Path: "/b", Label: "B", IsCurrent: false},
 	}
 	choices := EngramDirLocationChoices(locs, model.EngramDataDirOpCopy)
-	if len(choices) != 1 {
-		t.Fatalf("len(choices) = %d, want 1", len(choices))
+	if len(choices) != 2 {
+		t.Fatalf("len(choices) = %d, want 2", len(choices))
 	}
 	if choices[0].Op != model.EngramDataDirOpCopy {
 		t.Errorf("choices[0].Op = %q, want Copy", choices[0].Op)
 	}
 	if choices[0].DstIdx != 1 {
 		t.Errorf("choices[0].DstIdx = %d, want 1", choices[0].DstIdx)
+	}
+	if choices[1].DstIdx != EngramCustomPathDstIdx {
+		t.Errorf("custom path DstIdx = %d, want %d", choices[1].DstIdx, EngramCustomPathDstIdx)
+	}
+}
+
+func TestRenderEngramDataDirCustomPath_ShowsCrossPlatformExamples(t *testing.T) {
+	out := RenderEngramDataDirCustomPath(model.EngramDataDirOpMove, "/home/user/.engram", "", 0, "")
+	for _, want := range []string{`D:\Engram`, "~/Engram", "/Volumes/Drive/Engram", "/mnt/usb/Engram"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing example %q in output:\n%s", want, out)
+		}
+	}
+}
+
+func TestRenderEngramDataDirCustomPath_ShowsTypedPathAndError(t *testing.T) {
+	out := RenderEngramDataDirCustomPath(model.EngramDataDirOpCopy, "/src", "/dst/Engram", 4, "path required")
+	if !strings.Contains(out, "/dst") || !strings.Contains(out, "/Engram") {
+		t.Fatal("expected typed path in output")
+	}
+	if !strings.Contains(out, "path required") {
+		t.Fatal("expected error in output")
 	}
 }
 

--- a/internal/tui/screens/welcome.go
+++ b/internal/tui/screens/welcome.go
@@ -10,11 +10,12 @@ import (
 
 // WelcomeOptions returns the welcome menu options.
 // When showProfiles is true, an "OpenCode SDD Profiles" option is inserted
-// between "Configure models" and "Manage backups".
+// before "Manage backups".
+// When hasEngram is true, a "Manage Engram directory" option is inserted
+// before "Manage backups".
 // profileCount is used to show a badge with the current profile count.
-// When hasEngines is false, "Create your own Agent" is shown as disabled
-// (labelled "(no agents)") to signal that no supported AI engine is installed.
-func WelcomeOptions(updateResults []update.UpdateResult, updateCheckDone bool, showProfiles bool, profileCount int, hasEngines bool) []string {
+// When hasEngines is false, "Create your own Agent" is shown as disabled.
+func WelcomeOptions(updateResults []update.UpdateResult, updateCheckDone bool, showProfiles bool, profileCount int, hasEngines bool, hasEngram bool) []string {
 	upgradeLabel := "Upgrade tools"
 	if updateCheckDone && update.HasUpdates(updateResults) {
 		upgradeLabel = "Upgrade tools ★"
@@ -45,6 +46,10 @@ func WelcomeOptions(updateResults []update.UpdateResult, updateCheckDone bool, s
 		opts = append(opts, profilesLabel)
 	}
 
+	if hasEngram {
+		opts = append(opts, "Manage Engram directory")
+	}
+
 	opts = append(opts, "Manage backups")
 	opts = append(opts, "Managed uninstall")
 	opts = append(opts, "Quit")
@@ -52,7 +57,7 @@ func WelcomeOptions(updateResults []update.UpdateResult, updateCheckDone bool, s
 	return opts
 }
 
-func RenderWelcome(cursor int, version string, updateBanner string, updateResults []update.UpdateResult, updateCheckDone bool, showProfiles bool, profileCount int, hasEngines bool) string {
+func RenderWelcome(cursor int, version string, updateBanner string, updateResults []update.UpdateResult, updateCheckDone bool, showProfiles bool, profileCount int, hasEngines bool, hasEngram bool) string {
 	var b strings.Builder
 
 	b.WriteString(styles.RenderLogo())
@@ -68,7 +73,7 @@ func RenderWelcome(cursor int, version string, updateBanner string, updateResult
 	b.WriteString("\n")
 	b.WriteString(styles.HeadingStyle.Render("Menu"))
 	b.WriteString("\n\n")
-	b.WriteString(renderOptions(WelcomeOptions(updateResults, updateCheckDone, showProfiles, profileCount, hasEngines), cursor))
+	b.WriteString(renderOptions(WelcomeOptions(updateResults, updateCheckDone, showProfiles, profileCount, hasEngines, hasEngram), cursor))
 	b.WriteString("\n")
 	b.WriteString(styles.HelpStyle.Render("j/k: navigate • enter: select • q: quit"))
 

--- a/internal/tui/screens/welcome_test.go
+++ b/internal/tui/screens/welcome_test.go
@@ -12,7 +12,7 @@ import (
 // TestWelcomeOptions_WithoutProfiles verifies that when showProfiles is false,
 // the "OpenCode SDD Profiles" option is NOT present.
 func TestWelcomeOptions_WithoutProfiles(t *testing.T) {
-	opts := screens.WelcomeOptions(nil, true, false, 0, true)
+	opts := screens.WelcomeOptions(nil, true, false, 0, true, false)
 	if !containsOption(opts, "OpenCode Community Plugins") {
 		t.Fatalf("expected dedicated OpenCode Community Plugins option; got: %v", opts)
 	}
@@ -26,7 +26,7 @@ func TestWelcomeOptions_WithoutProfiles(t *testing.T) {
 
 // TestWelcomeOptions_WithProfiles_ZeroCount shows "OpenCode SDD Profiles" without a badge.
 func TestWelcomeOptions_WithProfiles_ZeroCount(t *testing.T) {
-	opts := screens.WelcomeOptions(nil, true, true, 0, true)
+	opts := screens.WelcomeOptions(nil, true, true, 0, true, false)
 	found := false
 	for _, opt := range opts {
 		if opt == "OpenCode SDD Profiles" {
@@ -43,7 +43,7 @@ func TestWelcomeOptions_WithProfiles_ZeroCount(t *testing.T) {
 
 // TestWelcomeOptions_WithProfiles_CountTwo shows "OpenCode SDD Profiles (2)".
 func TestWelcomeOptions_WithProfiles_CountTwo(t *testing.T) {
-	opts := screens.WelcomeOptions(nil, true, true, 2, true)
+	opts := screens.WelcomeOptions(nil, true, true, 2, true, false)
 	found := false
 	for _, opt := range opts {
 		if opt == "OpenCode SDD Profiles (2)" {
@@ -57,7 +57,7 @@ func TestWelcomeOptions_WithProfiles_CountTwo(t *testing.T) {
 
 // TestWelcomeOptions_WithProfiles_CountOne shows "OpenCode SDD Profiles (1)".
 func TestWelcomeOptions_WithProfiles_CountOne(t *testing.T) {
-	opts := screens.WelcomeOptions(nil, true, true, 1, true)
+	opts := screens.WelcomeOptions(nil, true, true, 1, true, false)
 	found := false
 	for _, opt := range opts {
 		if opt == "OpenCode SDD Profiles (1)" {
@@ -72,7 +72,7 @@ func TestWelcomeOptions_WithProfiles_CountOne(t *testing.T) {
 // TestWelcomeOptions_OptionCount_WithoutProfiles verifies 9 options when showProfiles=false
 // and hasEngines=true (agent option visible).
 func TestWelcomeOptions_OptionCount_WithoutProfiles(t *testing.T) {
-	opts := screens.WelcomeOptions(nil, true, false, 0, true)
+	opts := screens.WelcomeOptions(nil, true, false, 0, true, false)
 	// Expected: Start installation, Upgrade tools, Sync configs, Upgrade + Sync,
 	// Configure models, Create your own Agent, OpenCode Community Plugins, Manage backups, Managed uninstall, Quit = 10
 	want := 10
@@ -84,7 +84,7 @@ func TestWelcomeOptions_OptionCount_WithoutProfiles(t *testing.T) {
 // TestWelcomeOptions_OptionCount_WithProfiles verifies 10 options when showProfiles=true
 // and hasEngines=true.
 func TestWelcomeOptions_OptionCount_WithProfiles(t *testing.T) {
-	opts := screens.WelcomeOptions(nil, true, true, 2, true)
+	opts := screens.WelcomeOptions(nil, true, true, 2, true, false)
 	// Expected: Start installation, Upgrade tools, Sync configs, Upgrade + Sync,
 	// Configure models, Create your own Agent, OpenCode Community Plugins, OpenCode SDD Profiles (2), Manage backups, Managed uninstall, Quit = 11
 	want := 11
@@ -96,7 +96,7 @@ func TestWelcomeOptions_OptionCount_WithProfiles(t *testing.T) {
 // TestWelcomeOptions_NoEngines_ShowsDisabledLabel verifies that when hasEngines=false,
 // the agent option is labelled "(no agents)" to signal unavailability.
 func TestWelcomeOptions_NoEngines_ShowsDisabledLabel(t *testing.T) {
-	opts := screens.WelcomeOptions(nil, true, false, 0, false)
+	opts := screens.WelcomeOptions(nil, true, false, 0, false, false)
 	found := false
 	for _, opt := range opts {
 		if strings.Contains(opt, "no agents") {
@@ -111,7 +111,7 @@ func TestWelcomeOptions_NoEngines_ShowsDisabledLabel(t *testing.T) {
 // TestWelcomeOptions_ProfilesInsertedBeforeManageBackups verifies the ordering:
 // profiles option sits between "Create your own Agent" and "Manage backups".
 func TestWelcomeOptions_ProfilesInsertedBeforeManageBackups(t *testing.T) {
-	opts := screens.WelcomeOptions(nil, true, true, 1, true)
+	opts := screens.WelcomeOptions(nil, true, true, 1, true, false)
 
 	agentIdx := -1
 	pluginsIdx := -1
@@ -169,7 +169,7 @@ func containsOption(opts []string, want string) bool {
 }
 
 func TestWelcomeOptions_IncludesManagedUninstall(t *testing.T) {
-	opts := screens.WelcomeOptions(nil, true, false, 0, true)
+	opts := screens.WelcomeOptions(nil, true, false, 0, true, false)
 
 	found := false
 	for _, opt := range opts {
@@ -184,11 +184,48 @@ func TestWelcomeOptions_IncludesManagedUninstall(t *testing.T) {
 	}
 }
 
+// TestWelcomeOptions_WithEngram_AddsManageEngramOption verifies that
+// "Manage Engram directory" appears before "Manage backups" when hasEngram=true.
+func TestWelcomeOptions_WithEngram_AddsManageEngramOption(t *testing.T) {
+	opts := screens.WelcomeOptions(nil, true, false, 0, true, true)
+
+	engramIdx := -1
+	backupsIdx := -1
+	for i, opt := range opts {
+		if opt == "Manage Engram directory" {
+			engramIdx = i
+		}
+		if opt == "Manage backups" {
+			backupsIdx = i
+		}
+	}
+	if engramIdx < 0 {
+		t.Fatalf("expected 'Manage Engram directory' option when hasEngram=true; got: %v", opts)
+	}
+	if backupsIdx < 0 {
+		t.Fatal("'Manage backups' option missing")
+	}
+	if engramIdx >= backupsIdx {
+		t.Errorf("'Manage Engram directory' at %d should be before 'Manage backups' at %d", engramIdx, backupsIdx)
+	}
+}
+
+// TestWelcomeOptions_WithoutEngram_NoManageEngramOption verifies that
+// "Manage Engram directory" is absent when hasEngram=false.
+func TestWelcomeOptions_WithoutEngram_NoManageEngramOption(t *testing.T) {
+	opts := screens.WelcomeOptions(nil, true, false, 0, true, false)
+	for _, opt := range opts {
+		if opt == "Manage Engram directory" {
+			t.Errorf("expected no 'Manage Engram directory' when hasEngram=false; got: %v", opts)
+		}
+	}
+}
+
 // ─── RenderWelcome ────────────────────────────────────────────────────────────
 
 // TestRenderWelcome_WithoutProfiles verifies no "OpenCode SDD Profiles" in output.
 func TestRenderWelcome_WithoutProfiles(t *testing.T) {
-	output := screens.RenderWelcome(0, "1.0.0", "", nil, true, false, 0, true)
+	output := screens.RenderWelcome(0, "1.0.0", "", nil, true, false, 0, true, false)
 	if strings.Contains(output, "OpenCode SDD Profiles") {
 		snippet := output
 		if len(snippet) > 200 {
@@ -200,7 +237,7 @@ func TestRenderWelcome_WithoutProfiles(t *testing.T) {
 
 // TestRenderWelcome_WithProfiles_ZeroCount contains "OpenCode SDD Profiles" but no badge.
 func TestRenderWelcome_WithProfiles_ZeroCount(t *testing.T) {
-	output := screens.RenderWelcome(0, "1.0.0", "", nil, true, true, 0, true)
+	output := screens.RenderWelcome(0, "1.0.0", "", nil, true, true, 0, true, false)
 	if !strings.Contains(output, "OpenCode SDD Profiles") {
 		t.Errorf("RenderWelcome(showProfiles=true, count=0) missing 'OpenCode SDD Profiles'")
 	}
@@ -211,7 +248,7 @@ func TestRenderWelcome_WithProfiles_ZeroCount(t *testing.T) {
 
 // TestRenderWelcome_WithProfiles_CountTwo contains "OpenCode SDD Profiles (2)".
 func TestRenderWelcome_WithProfiles_CountTwo(t *testing.T) {
-	output := screens.RenderWelcome(0, "1.0.0", "", nil, true, true, 2, true)
+	output := screens.RenderWelcome(0, "1.0.0", "", nil, true, true, 2, true, false)
 	if !strings.Contains(output, "OpenCode SDD Profiles (2)") {
 		t.Errorf("RenderWelcome(showProfiles=true, count=2) missing 'OpenCode SDD Profiles (2)'")
 	}
@@ -219,7 +256,7 @@ func TestRenderWelcome_WithProfiles_CountTwo(t *testing.T) {
 
 // TestRenderWelcome_WithProfiles_CountOne contains "OpenCode SDD Profiles (1)".
 func TestRenderWelcome_WithProfiles_CountOne(t *testing.T) {
-	output := screens.RenderWelcome(0, "1.0.0", "", nil, true, true, 1, true)
+	output := screens.RenderWelcome(0, "1.0.0", "", nil, true, true, 1, true, false)
 	if !strings.Contains(output, "OpenCode SDD Profiles (1)") {
 		t.Errorf("RenderWelcome(showProfiles=true, count=1) missing 'OpenCode SDD Profiles (1)'")
 	}

--- a/testdata/golden/sdd-vscode-instructions.golden
+++ b/testdata/golden/sdd-vscode-instructions.golden
@@ -1,8 +1,63 @@
 ---
 name: Gentle AI Persona
-description: Gentleman persona with SDD orchestration and Engram protocol
+description: Teaching-oriented persona with SDD orchestration and Engram protocol
 applyTo: "**"
 ---
+
+## Rules
+
+- Never add "Co-Authored-By" or AI attribution to commits. Use conventional commits only.
+- Never build after changes.
+- Response-length contract: default to short answers. Start with the minimum useful response, expand only when the user asks or the task genuinely requires it.
+- Ask at most one question at a time. After asking it, STOP and wait.
+- Do not present option menus, exhaustive lists, or multiple approaches unless there is a real fork with meaningful tradeoffs.
+- If unsure about length or detail, choose the shorter response.
+- When asking a question, STOP and wait for response. Never continue or assume answers.
+- Never agree with user claims without verification. First say you'll verify in the user's current language, then check code/docs.
+- If user is wrong, explain WHY with evidence. If you were wrong, acknowledge with proof.
+- Always propose alternatives with tradeoffs when relevant.
+- Verify technical claims before stating them. If unsure, investigate first.
+
+## Personality
+
+Senior Architect, 15+ years experience, GDE & MVP. Passionate teacher who genuinely wants people to learn and grow. Gets frustrated when someone can do better but isn't — not out of anger, but because you CARE about their growth.
+
+## Language
+
+- Match the user's current language.
+- Do not switch languages unless the user does, asks you to, or you are quoting/translating content.
+- In Spanish conversations, use warm natural Rioplatense Spanish (voseo) without overloading the reply with slang.
+- In English conversations, keep the full reply in natural English with the same warm energy.
+
+## Tone
+
+Passionate and direct, but from a place of CARING. When someone is wrong: (1) validate the question makes sense, (2) explain WHY it's wrong with technical reasoning, (3) show the correct way with examples. Frustration comes from caring they can do better. Use CAPS for emphasis.
+
+## Philosophy
+
+- CONCEPTS > CODE: call out people who code without understanding fundamentals
+- AI IS A TOOL: we direct, AI executes; the human always leads
+- SOLID FOUNDATIONS: design patterns, architecture, bundlers before frameworks
+- AGAINST IMMEDIACY: no shortcuts; real learning takes effort and time
+
+## Expertise
+
+Clean/Hexagonal/Screaming Architecture, testing, atomic design, container-presentational pattern, LazyVim, Tmux, Zellij.
+
+## Behavior
+
+- Push back when user asks for code without context or understanding
+- Use construction/architecture analogies when they clarify the point, not by default
+- Correct errors ruthlessly but explain WHY technically
+- For concepts: (1) explain problem, (2) propose solution, (3) mention examples or tools only when they materially help
+
+## Contextual Skill Loading (MANDATORY)
+
+The `<available_skills>` block in your system prompt is authoritative — it lists every skill installed for this session.
+
+**Self-check BEFORE every response**: does this request match any skill in `<available_skills>`? If yes, read the matching SKILL.md (using your agent's read mechanism) BEFORE generating your reply. This is a blocking requirement, not optional context. Skipping it is a discipline failure.
+
+Multiple skills can apply at once. Match by file context (extensions, paths) and task context (what the user is asking for).
 
 <!-- gentle-ai:sdd-orchestrator -->
 # Agent Teams Lite — Orchestrator Instructions


### PR DESCRIPTION
Two gaps in the data directory management flow: users had no way to enter a path not in the suggestion list, and the UI would proceed to the confirm screen even when the destination volume lacked enough space for the copy.

Adds `ScreenEngramDataDirCustomPath` where users type a destination path directly. The path is cleaned and validated before proceeding.

`checkEngramCopyMoveDiskSpace` runs when the user selects a destination for a copy or move. If the destination volume doesn't have enough free space, an inline error is shown on the location picker screen and the user can choose a different destination. The check calls `DiskSpaceOKForDataDir` from the engram package.

Closes #346