### PR TITLE
feat(permissions): deny agent access to sensitive paths (.ssh, .credentials, Keychains, .pem, .key)

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -1289,7 +1289,7 @@ The completion screen MUST show:
 - R-SEC-02: The curl installer script MUST be verifiable (checksum)
 - R-SEC-03: All downloads MUST use HTTPS
 - R-SEC-04: The installer MUST NOT require root/sudo except for specific system operations (e.g., `chsh`), and MUST explain WHY when it does
-- R-SEC-05: Default agent permissions MUST block access to `.env` files and credentials paths
+- R-SEC-05: Default agent permissions MUST block access to `.env` files, credentials paths, SSH keys (`.ssh/`), macOS keychains (`Library/Keychains/`), and private key files (`.pem`, `.key`)
 
 ### 12.3 Reliability
 - R-REL-01: Every installation step MUST be idempotent (safe to re-run)

--- a/internal/components/permissions/inject.go
+++ b/internal/components/permissions/inject.go
@@ -27,7 +27,13 @@ var claudeCodeOverlayJSON = []byte(`{
       "Read(.env)",
       "Read(.env.*)",
       "Edit(.env)",
-      "Edit(.env.*)"
+      "Edit(.env.*)",
+      "Read(.ssh/*)",
+      "Edit(.ssh/*)",
+      "Read(.credentials/*)",
+      "Edit(.credentials/*)",
+      "Read(*.pem)",
+      "Read(*.key)"
     ]
   }
 }
@@ -52,7 +58,11 @@ var openCodeOverlayJSON = []byte(`{
       "**/.env": "deny",
       "**/.env.*": "deny",
       "**/secrets/**": "deny",
-      "**/credentials.json": "deny"
+      "**/credentials.json": "deny",
+      "**/.ssh/**": "deny",
+      "**/.credentials/**": "deny",
+      "**/Library/Keychains/**": "deny",
+      "**/*.pem": "deny"
     }
   }
 }

--- a/internal/components/permissions/inject_test.go
+++ b/internal/components/permissions/inject_test.go
@@ -70,7 +70,7 @@ func TestInjectOpenCodeIsIdempotent(t *testing.T) {
 	}
 }
 
-func TestInjectAddsEnvToDenyList(t *testing.T) {
+func TestInjectClaudeCodeDenyListIncludesSensitivePaths(t *testing.T) {
 	home := t.TempDir()
 
 	if _, err := Inject(home, claudeAdapter()); err != nil {
@@ -98,13 +98,75 @@ func TestInjectAddsEnvToDenyList(t *testing.T) {
 		t.Fatalf("deny list missing or invalid: %#v", permissionsNode["deny"])
 	}
 
+	denySet := make(map[string]bool)
 	for _, entry := range denyList {
-		if value, ok := entry.(string); ok && value == "Read(.env)" {
-			return
+		if value, ok := entry.(string); ok {
+			denySet[value] = true
 		}
 	}
 
-	t.Fatalf("deny list missing explicit .env rule: %#v", denyList)
+	required := []string{
+		"Read(.env)",
+		"Read(.ssh/*)",
+		"Edit(.ssh/*)",
+		"Read(.credentials/*)",
+		"Edit(.credentials/*)",
+		"Read(*.pem)",
+		"Read(*.key)",
+	}
+	for _, pattern := range required {
+		if !denySet[pattern] {
+			t.Errorf("deny list missing %q: %#v", pattern, denyList)
+		}
+	}
+}
+
+func TestInjectOpenCodeDenyListIncludesSensitivePaths(t *testing.T) {
+	home := t.TempDir()
+
+	if _, err := Inject(home, opencodeAdapter()); err != nil {
+		t.Fatalf("Inject() error = %v", err)
+	}
+
+	settingsPath := filepath.Join(home, ".config", "opencode", "opencode.json")
+	content, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("read settings file %q: %v", settingsPath, err)
+	}
+
+	var settings map[string]any
+	if err := json.Unmarshal(content, &settings); err != nil {
+		t.Fatalf("unmarshal settings json: %v", err)
+	}
+
+	permNode, ok := settings["permission"].(map[string]any)
+	if !ok {
+		t.Fatalf("permission node missing or invalid: %#v", settings["permission"])
+	}
+
+	readNode, ok := permNode["read"].(map[string]any)
+	if !ok {
+		t.Fatalf("read node missing or invalid: %#v", permNode["read"])
+	}
+
+	required := []string{
+		"**/.ssh/**",
+		"**/.credentials/**",
+		"**/Library/Keychains/**",
+		"**/*.pem",
+		"**/.env",
+		"**/credentials.json",
+	}
+	for _, pattern := range required {
+		val, exists := readNode[pattern]
+		if !exists {
+			t.Errorf("read deny list missing %q: %#v", pattern, readNode)
+			continue
+		}
+		if val != "deny" {
+			t.Errorf("read deny list %q = %q, want %q", pattern, val, "deny")
+		}
+	}
 }
 
 func TestInjectClaudeCodeUsesBypassPermissions(t *testing.T) {


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #566

---

## 🏷️ PR Type

- [x] type:feature — New feature (non-breaking change that adds functionality)

---

## 📝 Summary

- Expande las deny lists de permisos para OpenCode/Kilocode y Claude Code para bloquear paths sensibles que actualmente quedaban expuestos
- Agrega proteccion para ~/.ssh/, ~/.credentials/, ~/Library/Keychains/, y archivos .pem/.key
- Actualiza R-SEC-05 en el PRD para reflejar el scope ampliado

---

## 📂 Changes

| File | Change |
|------|--------|
| internal/components/permissions/inject.go | Agrega 4 deny patterns en openCodeOverlayJSON y 6 en claudeCodeOverlayJSON |
| internal/components/permissions/inject_test.go | Test de Claude Code expandido + nuevo test para deny patterns de OpenCode |
| PRD.md | Expande R-SEC-05: SSH keys, macOS keychains, .pem/.key |

---

## 🧪 Test Plan

- [x] Unit tests pass (go test ./internal/components/permissions/ -v)
- [ ] E2E tests pass
- [x] Manually tested locally

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with status:approved (#566)
- [x] PR stays within 400 changed lines (86 lines)
- [x] type:feature label added
- [x] Unit tests pass
- [x] Conventional Commits format
- [x] No Co-Authored-By trailers

---

## 💬 Notes for Reviewers

- Pi agent queda fuera de scope — no tiene modelo de deny list declarativo. Se evaluara en otra iteracion.
- Se descarto **/id_* porque **/.ssh/** ya cubre el directorio completo y id_* es demasiado amplio.