### PR TITLE
fix(engram): resolve stable semver release instead of blindly using /releases/latest

### DIFF
--- a/internal/components/engram/download.go
+++ b/internal/components/engram/download.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 	"time"
@@ -74,8 +75,14 @@ func DownloadLatestBinary(profile system.PlatformProfile) (string, error) {
 	return outPath, nil
 }
 
-// fetchLatestEngramVersion queries the GitHub Releases API for the latest engram
-// release and returns the version string (without leading "v").
+// semverTagRe matches tags that are stable semver: vX.Y.Z with optional
+// trailing metadata but no pre-release suffix (e.g. "v1.15.13" matches,
+// "v0.1.0-alpha" and "pi-v0.1.7" do not).
+var semverTagRe = regexp.MustCompile(`^v(\d+\.\d+\.\d+)$`)
+
+// fetchLatestEngramVersion queries the GitHub Releases API to find the latest
+// stable semver release of engram with downloadable assets.
+// It ignores non-semver tags (e.g. "pi-v0.1.7") and pre-release/draft releases.
 func fetchLatestEngramVersion() (string, error) {
 	token := githubToken()
 	version, status, err := fetchLatestEngramVersionRequest(token)
@@ -97,8 +104,21 @@ func fetchLatestEngramVersion() (string, error) {
 	return "", err
 }
 
+// githubRelease represents the subset of the GitHub Release API response we need.
+type githubRelease struct {
+	TagName    string `json:"tag_name"`
+	Prerelease bool   `json:"prerelease"`
+	Draft      bool   `json:"draft"`
+	Assets     []struct {
+		Name string `json:"name"`
+	} `json:"assets"`
+}
+
+// fetchLatestEngramVersionRequest lists releases from the GitHub API and returns
+// the version string (without leading "v") of the first stable semver release
+// that has at least one matching engram asset.
 func fetchLatestEngramVersionRequest(token string) (string, int, error) {
-	apiURL := fmt.Sprintf("%s/repos/%s/%s/releases/latest",
+	apiURL := fmt.Sprintf("%s/repos/%s/%s/releases",
 		engramAPIBaseURL(), engramOwner, engramRepo)
 
 	req, err := http.NewRequest(http.MethodGet, apiURL, nil)
@@ -120,19 +140,54 @@ func fetchLatestEngramVersionRequest(token string) (string, int, error) {
 		return "", resp.StatusCode, fmt.Errorf("GitHub API returned HTTP %d", resp.StatusCode)
 	}
 
-	var release struct {
-		TagName string `json:"tag_name"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
-		return "", resp.StatusCode, fmt.Errorf("decode release JSON: %w", err)
+	var releases []githubRelease
+	if err := json.NewDecoder(resp.Body).Decode(&releases); err != nil {
+		return "", resp.StatusCode, fmt.Errorf("decode releases JSON: %w", err)
 	}
 
-	version := strings.TrimPrefix(release.TagName, "v")
-	if version == "" {
-		return "", resp.StatusCode, fmt.Errorf("empty tag_name in GitHub release response")
+	for _, r := range releases {
+		// Skip drafts and pre-releases.
+		if r.Draft || r.Prerelease {
+			continue
+		}
+
+		// Only accept stable semver tags like vX.Y.Z.
+		m := semverTagRe.FindStringSubmatch(r.TagName)
+		if m == nil {
+			continue
+		}
+
+		version := m[1] // capture group: X.Y.Z without leading "v"
+
+		// Verify the release has at least one engram asset.
+		if !hasCompatibleAsset(r.Assets, version) {
+			continue
+		}
+
+		return version, resp.StatusCode, nil
 	}
 
-	return version, resp.StatusCode, nil
+	return "", resp.StatusCode, fmt.Errorf(
+		"no stable engram release with compatible assets found (checked %d releases); "+
+			"ensure the engram repo has a vX.Y.Z release with assets named engram_<version>_<os>_<arch>.(zip|tar.gz)",
+		len(releases))
+}
+
+// hasCompatibleAsset reports whether the assets list contains at least one
+// engram binary asset matching the expected naming convention:
+//
+//	engram_<version>_<os>_<arch>.(zip|tar.gz)
+func hasCompatibleAsset(assets []struct {
+	Name string `json:"name"`
+}, version string) bool {
+	prefix := engramName + "_" + version + "_"
+	for _, a := range assets {
+		if strings.HasPrefix(a.Name, prefix) &&
+			(strings.HasSuffix(a.Name, ".zip") || strings.HasSuffix(a.Name, ".tar.gz")) {
+			return true
+		}
+	}
+	return false
 }
 
 // githubToken returns a GitHub API token from the environment, if available.

--- a/internal/components/engram/download_test.go
+++ b/internal/components/engram/download_test.go
@@ -19,16 +19,18 @@ import (
 // --- test helpers ---
 
 // makeServerWithFakeTarGz returns an httptest.Server that serves:
-//   - GET /releases/latest  → GitHub API JSON with the given version
+//   - GET /releases  → GitHub API JSON array with a stable semver release for the given version
 //   - GET /releases/download/…  → a real .tar.gz containing "engram" binary
 func makeServerWithFakeTarGz(t *testing.T, version string) *httptest.Server {
 	t.Helper()
 	tarContent := buildFakeTarGz(t, "engram")
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.Contains(r.URL.Path, "releases/latest") {
-			payload := map[string]string{"tag_name": "v" + version}
+		if strings.Contains(r.URL.Path, "/releases") && !strings.Contains(r.URL.Path, "/download") {
 			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(payload)
+			json.NewEncoder(w).Encode([]githubRelease{{
+				TagName:    "v" + version,
+				Assets:     []struct{ Name string `json:"name"` }{{Name: "engram_" + version + "_linux_amd64.tar.gz"}},
+			}})
 			return
 		}
 		// All other requests → binary asset
@@ -44,10 +46,12 @@ func makeServerWithFakeZip(t *testing.T, version string) *httptest.Server {
 	t.Helper()
 	zipContent := buildFakeZip(t, "engram.exe")
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.Contains(r.URL.Path, "releases/latest") {
-			payload := map[string]string{"tag_name": "v" + version}
+		if strings.Contains(r.URL.Path, "/releases") && !strings.Contains(r.URL.Path, "/download") {
 			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(payload)
+			json.NewEncoder(w).Encode([]githubRelease{{
+				TagName:    "v" + version,
+				Assets:     []struct{ Name string `json:"name"` }{{Name: "engram_" + version + "_windows_amd64.zip"}},
+			}})
 			return
 		}
 		w.Header().Set("Content-Type", "application/octet-stream")
@@ -332,14 +336,17 @@ func TestDownloadLatestBinaryFallsBackToAnonymousWhenTokenGets403(t *testing.T) 
 	const version = "1.3.0"
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.Contains(r.URL.Path, "releases/latest") {
+		if strings.Contains(r.URL.Path, "/releases") && !strings.Contains(r.URL.Path, "/download") {
 			if r.Header.Get("Authorization") == "Bearer "+fakeToken {
 				w.WriteHeader(http.StatusForbidden)
 				return
 			}
 
 			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(map[string]string{"tag_name": "v" + version})
+			json.NewEncoder(w).Encode([]githubRelease{{
+				TagName: "v" + version,
+				Assets:  []struct{ Name string `json:"name"` }{{Name: "engram_" + version + "_linux_amd64.tar.gz"}},
+			}})
 			return
 		}
 
@@ -378,5 +385,138 @@ func TestDownloadLatestBinaryFallsBackToAnonymousWhenTokenGets403(t *testing.T) 
 
 	if _, err := os.Stat(installedPath); err != nil {
 		t.Fatalf("stat installed binary: %v", err)
+	}
+}
+
+// --- TestSkipsNonSemverTag ---
+
+// TestSkipsNonSemverTag verifies that when the first release has a non-semver tag
+// like "pi-v0.1.7" (without a matching asset) and a subsequent release has a
+// stable semver tag "v1.15.13" with assets, the resolver picks v1.15.13.
+func TestSkipsNonSemverTag(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/releases") && !strings.Contains(r.URL.Path, "/download") {
+			w.Header().Set("Content-Type", "application/json")
+			// First release: pi-v0.1.7 — no semver tag, should be skipped.
+			// Second release: v1.15.13 — stable semver with assets.
+			json.NewEncoder(w).Encode([]githubRelease{
+				{
+					TagName: "pi-v0.1.7",
+					Assets:  []struct{ Name string `json:"name"` }{{Name: "engram"}},
+				},
+				{
+					TagName: "v1.15.13",
+					Assets:  []struct{ Name string `json:"name"` }{{Name: "engram_1.15.13_linux_amd64.tar.gz"}},
+				},
+			})
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.WriteHeader(http.StatusOK)
+		w.Write(buildFakeTarGz(t, "engram"))
+	}))
+	defer server.Close()
+
+	origClient := engramHTTPClient
+	origBaseURL := engramGitHubBaseURL
+	engramHTTPClient = server.Client()
+	engramGitHubBaseURL = server.URL
+	t.Cleanup(func() {
+		engramHTTPClient = origClient
+		engramGitHubBaseURL = origBaseURL
+	})
+
+	version, err := fetchLatestEngramVersion()
+	if err != nil {
+		t.Fatalf("fetchLatestEngramVersion() error = %v", err)
+	}
+	if version != "1.15.13" {
+		t.Errorf("got version %q, want %q", version, "1.15.13")
+	}
+}
+
+// --- TestNoCompatibleAssetsError ---
+
+// TestNoCompatibleAssetsError verifies that when no release has a compatible
+// engram asset, a clear error is returned.
+func TestNoCompatibleAssetsError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/releases") && !strings.Contains(r.URL.Path, "/download") {
+			w.Header().Set("Content-Type", "application/json")
+			// Release with semver tag but no matching assets.
+			json.NewEncoder(w).Encode([]githubRelease{{
+				TagName: "v1.0.0",
+				Assets:  []struct{ Name string `json:"name"` }{{Name: "source.tar.gz"}},
+			}})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	origClient := engramHTTPClient
+	origBaseURL := engramGitHubBaseURL
+	engramHTTPClient = server.Client()
+	engramGitHubBaseURL = server.URL
+	t.Cleanup(func() {
+		engramHTTPClient = origClient
+		engramGitHubBaseURL = origBaseURL
+	})
+
+	_, err := fetchLatestEngramVersion()
+	if err == nil {
+		t.Fatal("expected error when no compatible assets, got nil")
+	}
+	if !strings.Contains(err.Error(), "no stable engram release with compatible assets found") {
+		t.Errorf("error message should explain missing assets, got: %v", err)
+	}
+}
+
+// --- TestSkipsDraftAndPrerelease ---
+
+// TestSkipsDraftAndPrerelease verifies that draft and pre-release entries are
+// skipped even when they have valid semver tags.
+func TestSkipsDraftAndPrerelease(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/releases") && !strings.Contains(r.URL.Path, "/download") {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode([]githubRelease{
+				{
+					TagName:    "v2.0.0",
+					Prerelease: true,
+					Assets:     []struct{ Name string `json:"name"` }{{Name: "engram_2.0.0_linux_amd64.tar.gz"}},
+				},
+				{
+					TagName: "v1.15.13",
+					Draft:   true,
+					Assets:  []struct{ Name string `json:"name"` }{{Name: "engram_1.15.13_linux_amd64.tar.gz"}},
+				},
+				{
+					TagName: "v1.15.12",
+					Assets:  []struct{ Name string `json:"name"` }{{Name: "engram_1.15.12_linux_amd64.tar.gz"}},
+				},
+			})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	origClient := engramHTTPClient
+	origBaseURL := engramGitHubBaseURL
+	engramHTTPClient = server.Client()
+	engramGitHubBaseURL = server.URL
+	t.Cleanup(func() {
+		engramHTTPClient = origClient
+		engramGitHubBaseURL = origBaseURL
+	})
+
+	version, err := fetchLatestEngramVersion()
+	if err != nil {
+		t.Fatalf("fetchLatestEngramVersion() error = %v", err)
+	}
+	if version != "1.15.12" {
+		t.Errorf("got version %q, want %q (should skip prerelease v2.0.0 and draft v1.15.13)", version, "1.15.12")
 	}
 }


### PR DESCRIPTION
## Root Cause

`fetchLatestEngramVersion` used `/releases/latest` which returns whatever GitHub considers latest by date, including non-semver tags like `pi-v0.1.7` that have no engram binary assets. This produced invalid download URLs.

## Changes

- **download.go**: replaced `/releases/latest` with `/releases` list endpoint
- Filter releases by stable semver tag (`vX.Y.Z`), skip drafts/prereleases
- Validate each candidate has assets matching `engram_<version>_<os>_<arch>.(zip|tar.gz)`
- Ignore non-compatible tags like `pi-v0.1.7`
- Improved error message when no compatible release found
- Preserved token + anonymous fallback behavior

## Tests

| Test | Covers |
|---|---|
| `TestSkipsNonSemverTag` | `pi-v0.1.7` present → picks `v1.15.13` |
| `TestNoCompatibleAssetsError` | Clear error when no matching assets |
| `TestSkipsDraftAndPrerelease` | Skips draft/prerelease even with valid semver |
| All existing download tests | Updated to new `/releases` array format |