### PR TITLE
fix(installer): skip Engram releases without binary assets

### DIFF
--- a/internal/components/engram/download.go
+++ b/internal/components/engram/download.go
@@ -135,8 +135,9 @@ func fetchLatestEngramVersionRequest(token string) (string, int, error) {
 
 	// Older tests and non-GitHub-compatible mocks may omit assets entirely; in
 	// that case keep the historical latest-release behavior. GitHub returns an
-	// explicit assets array, so skip releases that do not publish engram binaries
-	// (for example pi-v* package releases in the same repository).
+	// explicit assets array, so skip releases that do not publish core engram
+	// binaries (for example pi-v* gentle-engram package releases, which are
+	// separate from core engram binary releases).
 	if release.Assets != nil && !hasEngramBinaryAsset(*release.Assets) {
 		fallbackVersion, fallbackStatus, err := fetchLatestEngramVersionWithAssets(token)
 		if err == nil {

--- a/internal/components/engram/download.go
+++ b/internal/components/engram/download.go
@@ -121,7 +121,8 @@ func fetchLatestEngramVersionRequest(token string) (string, int, error) {
 	}
 
 	var release struct {
-		TagName string `json:"tag_name"`
+		TagName string             `json:"tag_name"`
+		Assets  *[]json.RawMessage `json:"assets"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
 		return "", resp.StatusCode, fmt.Errorf("decode release JSON: %w", err)
@@ -132,7 +133,89 @@ func fetchLatestEngramVersionRequest(token string) (string, int, error) {
 		return "", resp.StatusCode, fmt.Errorf("empty tag_name in GitHub release response")
 	}
 
+	// Older tests and non-GitHub-compatible mocks may omit assets entirely; in
+	// that case keep the historical latest-release behavior. GitHub returns an
+	// explicit assets array, so skip releases that do not publish engram binaries
+	// (for example pi-v* package releases in the same repository).
+	if release.Assets != nil && !hasEngramBinaryAsset(*release.Assets) {
+		fallbackVersion, fallbackStatus, err := fetchLatestEngramVersionWithAssets(token)
+		if err == nil {
+			return fallbackVersion, resp.StatusCode, nil
+		}
+		if token != "" && (fallbackStatus == http.StatusUnauthorized || fallbackStatus == http.StatusForbidden) {
+			fallbackVersion, _, retryErr := fetchLatestEngramVersionWithAssets("")
+			if retryErr == nil {
+				return fallbackVersion, resp.StatusCode, nil
+			}
+		}
+		return "", resp.StatusCode, err
+	}
+
 	return version, resp.StatusCode, nil
+}
+
+func hasEngramBinaryAsset(assets []json.RawMessage) bool {
+	for _, raw := range assets {
+		var asset struct {
+			Name string `json:"name"`
+		}
+		if err := json.Unmarshal(raw, &asset); err == nil && strings.HasPrefix(asset.Name, engramRepo+"_") {
+			return true
+		}
+	}
+	return false
+}
+
+func fetchLatestEngramVersionWithAssets(token string) (string, int, error) {
+	apiURL := fmt.Sprintf("%s/repos/%s/%s/releases?per_page=20",
+		engramAPIBaseURL(), engramOwner, engramRepo)
+
+	req, err := http.NewRequest(http.MethodGet, apiURL, nil)
+	if err != nil {
+		return "", 0, fmt.Errorf("build releases request: %w", err)
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	resp, err := engramHTTPClient.Do(req)
+	if err != nil {
+		return "", 0, fmt.Errorf("call GitHub releases API: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", resp.StatusCode, fmt.Errorf("GitHub releases API returned HTTP %d", resp.StatusCode)
+	}
+
+	var releases []struct {
+		TagName    string `json:"tag_name"`
+		Draft      bool   `json:"draft"`
+		Prerelease bool   `json:"prerelease"`
+		Assets     []struct {
+			Name string `json:"name"`
+		} `json:"assets"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&releases); err != nil {
+		return "", resp.StatusCode, fmt.Errorf("decode releases JSON: %w", err)
+	}
+
+	for _, release := range releases {
+		if release.Draft || release.Prerelease || len(release.Assets) == 0 {
+			continue
+		}
+		for _, asset := range release.Assets {
+			if strings.HasPrefix(asset.Name, engramRepo+"_") {
+				version := strings.TrimPrefix(release.TagName, "v")
+				if version != "" {
+					return version, resp.StatusCode, nil
+				}
+			}
+		}
+	}
+
+	return "", resp.StatusCode, fmt.Errorf("no engram release with downloadable binary assets found")
 }
 
 // githubToken returns a GitHub API token from the environment, if available.

--- a/internal/components/engram/download_test.go
+++ b/internal/components/engram/download_test.go
@@ -327,6 +327,138 @@ func TestDownloadLatestBinaryAPIError(t *testing.T) {
 	}
 }
 
+func TestDownloadLatestBinarySkipsLatestReleaseWithoutBinaryAssets(t *testing.T) {
+	const binaryVersion = "1.15.13"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "releases/latest"):
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]any{
+				"tag_name": "pi-v0.1.7",
+				"assets":   []any{},
+			})
+		case strings.Contains(r.URL.Path, "releases") && r.URL.RawQuery == "per_page=20":
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode([]map[string]any{
+				{
+					"tag_name":   "pi-v0.1.7",
+					"draft":      false,
+					"prerelease": false,
+					"assets":     []any{},
+				},
+				{
+					"tag_name":   "v" + binaryVersion,
+					"draft":      false,
+					"prerelease": false,
+					"assets": []map[string]string{
+						{"name": "checksums.txt"},
+						{"name": "engram_" + binaryVersion + "_linux_amd64.tar.gz"},
+					},
+				},
+			})
+		case strings.Contains(r.URL.Path, "/releases/download/v"+binaryVersion+"/engram_"+binaryVersion+"_linux_"):
+			w.Header().Set("Content-Type", "application/octet-stream")
+			w.WriteHeader(http.StatusOK)
+			w.Write(buildFakeTarGz(t, "engram"))
+		default:
+			t.Fatalf("unexpected request: %s?%s", r.URL.Path, r.URL.RawQuery)
+		}
+	}))
+	defer server.Close()
+
+	origClient := engramHTTPClient
+	origBaseURL := engramGitHubBaseURL
+	engramHTTPClient = server.Client()
+	engramGitHubBaseURL = server.URL
+	t.Cleanup(func() {
+		engramHTTPClient = origClient
+		engramGitHubBaseURL = origBaseURL
+	})
+
+	tmpDir := t.TempDir()
+	origInstallDirFn := engramInstallDirFn
+	engramInstallDirFn = func(goos string) string { return tmpDir }
+	t.Cleanup(func() { engramInstallDirFn = origInstallDirFn })
+
+	profile := system.PlatformProfile{OS: "linux", PackageManager: "apt"}
+	installedPath, err := DownloadLatestBinary(profile)
+	if err != nil {
+		t.Fatalf("DownloadLatestBinary() error = %v", err)
+	}
+
+	if _, err := os.Stat(installedPath); err != nil {
+		t.Fatalf("stat installed binary: %v", err)
+	}
+}
+
+func TestDownloadLatestBinaryReleaseListFallsBackToAnonymousWhenTokenGets403(t *testing.T) {
+	const fakeToken = "ci-token"
+	const binaryVersion = "1.15.13"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "releases/latest"):
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]any{
+				"tag_name": "pi-v0.1.7",
+				"assets":   []any{},
+			})
+		case strings.Contains(r.URL.Path, "releases") && r.URL.RawQuery == "per_page=20":
+			if r.Header.Get("Authorization") == "Bearer "+fakeToken {
+				w.WriteHeader(http.StatusForbidden)
+				return
+			}
+
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode([]map[string]any{
+				{
+					"tag_name":   "v" + binaryVersion,
+					"draft":      false,
+					"prerelease": false,
+					"assets": []map[string]string{
+						{"name": "engram_" + binaryVersion + "_linux_amd64.tar.gz"},
+					},
+				},
+			})
+		case strings.Contains(r.URL.Path, "/releases/download/v"+binaryVersion+"/engram_"+binaryVersion+"_linux_"):
+			w.Header().Set("Content-Type", "application/octet-stream")
+			w.WriteHeader(http.StatusOK)
+			w.Write(buildFakeTarGz(t, "engram"))
+		default:
+			t.Fatalf("unexpected request: %s?%s", r.URL.Path, r.URL.RawQuery)
+		}
+	}))
+	defer server.Close()
+
+	origClient := engramHTTPClient
+	origBaseURL := engramGitHubBaseURL
+	engramHTTPClient = server.Client()
+	engramGitHubBaseURL = server.URL
+	t.Cleanup(func() {
+		engramHTTPClient = origClient
+		engramGitHubBaseURL = origBaseURL
+	})
+
+	t.Setenv("GITHUB_TOKEN", fakeToken)
+	t.Setenv("GH_TOKEN", "")
+
+	tmpDir := t.TempDir()
+	origInstallDirFn := engramInstallDirFn
+	engramInstallDirFn = func(goos string) string { return tmpDir }
+	t.Cleanup(func() { engramInstallDirFn = origInstallDirFn })
+
+	profile := system.PlatformProfile{OS: "linux", PackageManager: "apt"}
+	installedPath, err := DownloadLatestBinary(profile)
+	if err != nil {
+		t.Fatalf("DownloadLatestBinary() error = %v", err)
+	}
+
+	if _, err := os.Stat(installedPath); err != nil {
+		t.Fatalf("stat installed binary: %v", err)
+	}
+}
+
 func TestDownloadLatestBinaryFallsBackToAnonymousWhenTokenGets403(t *testing.T) {
 	const fakeToken = "ci-token"
 	const version = "1.3.0"


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #578

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Skip Engram GitHub releases that do not publish `engram_*` binary assets.
- Fall back from `pi-v*` `gentle-engram` package releases to the latest core `engram` binary release.
- Preserve anonymous retry behavior for token-scoped GitHub API failures, including the new release-list fallback.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/components/engram/download.go` | Inspect latest release assets and fall back to recent releases with Engram binaries. |
| `internal/components/engram/download.go` | Retry release-list fallback anonymously on token `401/403`. |
| `internal/components/engram/download_test.go` | Add regressions for no-asset latest releases and token fallback on release-list lookup. |

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test -count=1 ./internal/components/engram ./internal/cli ./internal/installcmd
```

**E2E Tests** (Docker required)
```bash
# Not run; targeted installer/downloader unit coverage was added for this regression.
```

- [x] Unit tests pass (`go test -count=1 ./internal/components/engram ./internal/cli ./internal/installcmd`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Manually tested locally

Manual/local validation:
- Confirmed GitHub latest Engram release can be `pi-v0.1.7` with zero assets.
- Confirmed latest binary release contains `engram_*` assets.
- Ran fresh-context reviewer twice; no blockers found.

---

## 🤖 Automated Checks

The following checks run automatically on this PR:

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | PR should stay within 400 changed lines (`additions + deletions`) or use `size:exception` |
| Check Issue Reference | ⏳ | PR body must contain `Closes/Fixes/Resolves #N` |
| Check Issue Has `status:approved` | ⏳ | Linked issue must have been approved before work began |
| Check PR Has `type:*` Label | ⏳ | Exactly one `type:*` label must be applied |
| Unit Tests | ⏳ | `go test ./...` must pass |
| E2E Tests | ⏳ | `cd e2e && ./docker-test.sh` must pass |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

The root cause is release metadata shape, not user environment: `pi-v*` `gentle-engram` package releases for Pi are separate from core `engram` binary releases and may be latest without containing platform binary assets. This PR makes the core binary downloader select releases by asset availability instead of trusting the latest tag alone.
