### PR TITLE
fix(update): filter engram binary release channel

### DIFF
--- a/internal/update/check.go
+++ b/internal/update/check.go
@@ -75,7 +75,7 @@ func checkSingleTool(ctx context.Context, tool ToolInfo, currentBuildVersion str
 
 	go func() {
 		defer wg.Done()
-		release, fetchErr = fetchLatestRelease(ctx, tool.Owner, tool.Repo)
+		release, fetchErr = fetchLatestReleaseForTool(ctx, tool)
 	}()
 
 	wg.Wait()
@@ -134,6 +134,13 @@ func checkSingleTool(ctx context.Context, tool ToolInfo, currentBuildVersion str
 	// Compare versions.
 	result.Status = compareVersions(normalizedLocal, result.LatestVersion)
 	return result
+}
+
+func fetchLatestReleaseForTool(ctx context.Context, tool ToolInfo) (githubRelease, error) {
+	if pattern := strings.TrimSpace(tool.ReleaseTagPattern); pattern != "" {
+		return fetchLatestReleaseMatchingPattern(ctx, tool.Owner, tool.Repo, pattern)
+	}
+	return fetchLatestRelease(ctx, tool.Owner, tool.Repo)
 }
 
 // normalizeVersion strips a leading "v" and extracts a semver pattern.

--- a/internal/update/check_test.go
+++ b/internal/update/check_test.go
@@ -299,6 +299,76 @@ func TestFetchLatestRelease(t *testing.T) {
 	}
 }
 
+func TestFetchLatestReleaseMatchingPatternSkipsPiChannel(t *testing.T) {
+	var serverURL string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/repos/Gentleman-Programming/engram/releases" {
+			t.Fatalf("unexpected path: %s", r.URL.String())
+		}
+		if r.URL.Query().Get("per_page") != "100" {
+			t.Fatalf("per_page = %q, want 100", r.URL.Query().Get("per_page"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Query().Get("page") {
+		case "":
+			w.Header().Set("Link", fmt.Sprintf(`<%s/repos/Gentleman-Programming/engram/releases?per_page=100&page=2>; rel="next"`, serverURL))
+			json.NewEncoder(w).Encode([]githubRelease{
+				{TagName: "pi-v0.1.7", HTMLURL: "https://github.com/Gentleman-Programming/engram/releases/tag/pi-v0.1.7"},
+			})
+		case "2":
+			json.NewEncoder(w).Encode([]githubRelease{
+				{TagName: "v1.15.13", HTMLURL: "https://github.com/Gentleman-Programming/engram/releases/tag/v1.15.13"},
+			})
+		default:
+			t.Fatalf("unexpected page: %s", r.URL.Query().Get("page"))
+		}
+	}))
+	serverURL = server.URL
+	defer server.Close()
+
+	origClient := httpClient
+	t.Cleanup(func() { httpClient = origClient })
+	httpClient = server.Client()
+	httpClient.Transport = &testTransport{server: server}
+
+	release, err := fetchLatestReleaseMatchingPattern(context.Background(), "Gentleman-Programming", "engram", `^v[0-9]+\.[0-9]+\.[0-9]+$`)
+	if err != nil {
+		t.Fatalf("fetchLatestReleaseMatchingPattern() error = %v", err)
+	}
+	if release.TagName != "v1.15.13" {
+		t.Fatalf("TagName = %q, want v1.15.13", release.TagName)
+	}
+}
+
+func TestFetchLatestReleaseMatchingPatternRejectsPaginationLoop(t *testing.T) {
+	var serverURL string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Link", fmt.Sprintf(`<%s/repos/Gentleman-Programming/engram/releases?per_page=100>; rel="next"`, serverURL))
+		json.NewEncoder(w).Encode([]githubRelease{{TagName: "pi-v0.1.7"}})
+	}))
+	serverURL = server.URL
+	defer server.Close()
+
+	origClient := httpClient
+	t.Cleanup(func() { httpClient = origClient })
+	httpClient = server.Client()
+	httpClient.Transport = &testTransport{server: server}
+
+	_, err := fetchLatestReleaseMatchingPattern(context.Background(), "Gentleman-Programming", "engram", `^v[0-9]+\.[0-9]+\.[0-9]+$`)
+	if err == nil || !strings.Contains(err.Error(), "pagination loop detected") {
+		t.Fatalf("expected pagination loop error, got %v", err)
+	}
+}
+
+func TestNextGitHubPageFindsRelAfterOtherParameters(t *testing.T) {
+	got := nextGitHubPage(`<https://api.github.com/repos/o/r/releases?per_page=100&page=2>; type="application/json"; rel="next"`)
+	want := "https://api.github.com/repos/o/r/releases?per_page=100&page=2"
+	if got != want {
+		t.Fatalf("nextGitHubPage() = %q, want %q", got, want)
+	}
+}
+
 // TestFetchLatestRelease_Timeout verifies timeout handling.
 func TestFetchLatestRelease_Timeout(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -467,6 +537,52 @@ func TestCheckAll(t *testing.T) {
 	assertResult(t, results[2], "gga", NotInstalled, "", "2.0.0")
 	assertResult(t, results[3], "opencode-subagent-statusline", NotInstalled, "", "0.4.0")
 	assertResult(t, results[4], "opencode-sdd-engram-manage", NotInstalled, "", "1.1.7")
+}
+
+func TestCheckSingleTool_EngramUsesBinaryReleaseChannel(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/repos/Gentleman-Programming/engram/releases":
+			json.NewEncoder(w).Encode([]githubRelease{
+				{TagName: "pi-v0.1.7", HTMLURL: "https://github.com/Gentleman-Programming/engram/releases/tag/pi-v0.1.7"},
+				{TagName: "v1.15.13", HTMLURL: "https://github.com/Gentleman-Programming/engram/releases/tag/v1.15.13"},
+			})
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.String())
+		}
+	}))
+	defer server.Close()
+
+	origClient := httpClient
+	origLookPath := lookPath
+	origExecCommand := execCommand
+	t.Cleanup(func() {
+		httpClient = origClient
+		lookPath = origLookPath
+		execCommand = origExecCommand
+	})
+
+	httpClient = server.Client()
+	httpClient.Transport = &testTransport{server: server}
+	lookPath = func(name string) (string, error) {
+		if name == "engram" {
+			return "/usr/local/bin/engram", nil
+		}
+		return "", fmt.Errorf("not found")
+	}
+	execCommand = func(name string, args ...string) *exec.Cmd {
+		if name == "engram" {
+			return exec.Command("echo", "engram 1.15.13")
+		}
+		return exec.Command("false")
+	}
+
+	result := checkSingleTool(context.Background(), Tools[1], "dev", system.PlatformProfile{OS: "darwin", PackageManager: "brew", Supported: true})
+	assertResult(t, result, "engram", UpToDate, "1.15.13", "1.15.13")
+	if result.ReleaseURL != "https://github.com/Gentleman-Programming/engram/releases/tag/v1.15.13" {
+		t.Fatalf("ReleaseURL = %q, want binary channel release", result.ReleaseURL)
+	}
 }
 
 func TestCheckAll_NetworkError(t *testing.T) {
@@ -795,6 +911,9 @@ func TestRegistryContents(t *testing.T) {
 	// engram and gga must have non-nil DetectCmd.
 	if Tools[1].DetectCmd == nil {
 		t.Fatalf("engram DetectCmd should not be nil")
+	}
+	if Tools[1].ReleaseTagPattern != `^v[0-9]+\.[0-9]+\.[0-9]+$` {
+		t.Fatalf("engram ReleaseTagPattern = %q, want binary v* channel pattern", Tools[1].ReleaseTagPattern)
 	}
 	if Tools[2].DetectCmd == nil {
 		t.Fatalf("gga DetectCmd should not be nil")

--- a/internal/update/github.go
+++ b/internal/update/github.go
@@ -5,9 +5,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
+	"regexp"
 	"strings"
 	"time"
 )
@@ -21,8 +24,10 @@ var ghLookPath = exec.LookPath
 
 // githubRelease represents the subset of GitHub's release response we need.
 type githubRelease struct {
-	TagName string `json:"tag_name"`
-	HTMLURL string `json:"html_url"`
+	TagName    string `json:"tag_name"`
+	HTMLURL    string `json:"html_url"`
+	Draft      bool   `json:"draft"`
+	Prerelease bool   `json:"prerelease"`
 }
 
 // resolveGitHubToken returns a GitHub token for API auth, trying in order:
@@ -55,9 +60,122 @@ func resolveGitHubToken() string {
 func fetchLatestRelease(ctx context.Context, owner, repo string) (githubRelease, error) {
 	url := fmt.Sprintf("https://api.github.com/repos/%s/%s/releases/latest", owner, repo)
 
+	resp, err := doGitHubRequest(ctx, url)
+	if err != nil {
+		return githubRelease{}, err
+	}
+	defer resp.Body.Close()
+
+	if err := checkGitHubResponse(resp, owner, repo); err != nil {
+		return githubRelease{}, err
+	}
+
+	var release githubRelease
+	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+		return githubRelease{}, fmt.Errorf("decode github release: %w", err)
+	}
+
+	return release, nil
+}
+
+// fetchLatestReleaseMatchingPattern fetches releases and returns the newest non-draft,
+// non-prerelease release whose tag matches tagPattern. Use this for repositories with
+// multiple release channels where GitHub's /latest endpoint can point at the wrong channel.
+func fetchLatestReleaseMatchingPattern(ctx context.Context, owner, repo, tagPattern string) (githubRelease, error) {
+	pattern, err := regexp.Compile(tagPattern)
+	if err != nil {
+		return githubRelease{}, fmt.Errorf("compile release tag pattern for %s/%s: %w", owner, repo, err)
+	}
+
+	releasesURL := fmt.Sprintf("https://api.github.com/repos/%s/%s/releases?per_page=100", owner, repo)
+	seenPages := make(map[string]struct{})
+	for releasesURL != "" {
+		if _, seen := seenPages[releasesURL]; seen {
+			return githubRelease{}, fmt.Errorf("github releases pagination loop detected for %s/%s", owner, repo)
+		}
+		seenPages[releasesURL] = struct{}{}
+
+		resp, err := doGitHubRequest(ctx, releasesURL)
+		if err != nil {
+			return githubRelease{}, err
+		}
+
+		body, readErr := readSuccessfulGitHubBody(resp, owner, repo, "github releases")
+		if readErr != nil {
+			return githubRelease{}, readErr
+		}
+
+		releases, err := decodeGitHubReleases(body)
+		if err != nil {
+			return githubRelease{}, err
+		}
+		for _, release := range releases {
+			if release.Draft || release.Prerelease {
+				continue
+			}
+			if pattern.MatchString(strings.TrimSpace(release.TagName)) {
+				return release, nil
+			}
+		}
+		releasesURL = nextGitHubPage(resp.Header.Get("Link"))
+	}
+	return githubRelease{}, fmt.Errorf("no release matching %q found for %s/%s", tagPattern, owner, repo)
+}
+
+func readSuccessfulGitHubBody(resp *http.Response, owner, repo, bodyName string) ([]byte, error) {
+	defer resp.Body.Close()
+	if err := checkGitHubResponse(resp, owner, repo); err != nil {
+		return nil, err
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", bodyName, err)
+	}
+	return body, nil
+}
+
+func decodeGitHubReleases(body []byte) ([]githubRelease, error) {
+	var releases []githubRelease
+	if err := json.Unmarshal(body, &releases); err != nil {
+		var release githubRelease
+		if singleErr := json.Unmarshal(body, &release); singleErr != nil {
+			return nil, fmt.Errorf("decode github releases: %w", err)
+		}
+		releases = []githubRelease{release}
+	}
+	return releases, nil
+}
+
+func nextGitHubPage(linkHeader string) string {
+	for _, part := range strings.Split(linkHeader, ",") {
+		sections := strings.Split(part, ";")
+		if len(sections) < 2 {
+			continue
+		}
+		hasNextRel := false
+		for _, section := range sections[1:] {
+			if strings.TrimSpace(section) == `rel="next"` {
+				hasNextRel = true
+				break
+			}
+		}
+		if !hasNextRel {
+			continue
+		}
+		rawURL := strings.Trim(strings.TrimSpace(sections[0]), "<>")
+		parsed, err := url.Parse(rawURL)
+		if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+			continue
+		}
+		return parsed.String()
+	}
+	return ""
+}
+
+func doGitHubRequest(ctx context.Context, url string) (*http.Response, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
-		return githubRelease{}, fmt.Errorf("build github request: %w", err)
+		return nil, fmt.Errorf("build github request: %w", err)
 	}
 
 	req.Header.Set("Accept", "application/vnd.github+json")
@@ -69,25 +187,20 @@ func fetchLatestRelease(ctx context.Context, owner, repo string) (githubRelease,
 
 	resp, err := httpClient.Do(req)
 	if err != nil {
-		return githubRelease{}, fmt.Errorf("github API request failed: %w", err)
+		return nil, fmt.Errorf("github API request failed: %w", err)
 	}
-	defer resp.Body.Close()
+	return resp, nil
+}
 
+func checkGitHubResponse(resp *http.Response, owner, repo string) error {
 	switch resp.StatusCode {
 	case http.StatusOK:
-		// success — decode below
+		return nil
 	case http.StatusForbidden:
-		return githubRelease{}, fmt.Errorf("github API rate limit exceeded (HTTP 403)")
+		return fmt.Errorf("github API rate limit exceeded (HTTP 403)")
 	case http.StatusNotFound:
-		return githubRelease{}, fmt.Errorf("no releases found for %s/%s (HTTP 404)", owner, repo)
+		return fmt.Errorf("no releases found for %s/%s (HTTP 404)", owner, repo)
 	default:
-		return githubRelease{}, fmt.Errorf("github API returned HTTP %d for %s/%s", resp.StatusCode, owner, repo)
+		return fmt.Errorf("github API returned HTTP %d for %s/%s", resp.StatusCode, owner, repo)
 	}
-
-	var release githubRelease
-	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
-		return githubRelease{}, fmt.Errorf("decode github release: %w", err)
-	}
-
-	return release, nil
 }

--- a/internal/update/registry.go
+++ b/internal/update/registry.go
@@ -21,11 +21,12 @@ var Tools = []ToolInfo{
 		InstallMethod: InstallBinary,
 	},
 	{
-		Name:          "engram",
-		Owner:         "Gentleman-Programming",
-		Repo:          "engram",
-		DetectCmd:     []string{"engram", "version"},
-		VersionPrefix: "v",
+		Name:              "engram",
+		Owner:             "Gentleman-Programming",
+		Repo:              "engram",
+		DetectCmd:         []string{"engram", "version"},
+		VersionPrefix:     "v",
+		ReleaseTagPattern: `^v[0-9]+\.[0-9]+\.[0-9]+$`,
 		// engram: brew on macOS/Linux-brew, binary download elsewhere.
 		InstallMethod: InstallBinary,
 	},

--- a/internal/update/types.go
+++ b/internal/update/types.go
@@ -37,14 +37,15 @@ const (
 
 // ToolInfo describes a managed tool that can be checked for updates.
 type ToolInfo struct {
-	Name          string        // human-readable name (e.g., "gentle-ai")
-	Owner         string        // GitHub repository owner
-	Repo          string        // GitHub repository name
-	DetectCmd     []string      // command to detect installed version; nil = use build var
-	VersionPrefix string        // prefix to strip from version output (e.g., "v")
-	InstallMethod InstallMethod // how this tool is installed (used by upgrade executor)
-	GoImportPath  string        // for go-install tools (e.g. "github.com/.../cmd/engram")
-	NpmPackage    string        // for OpenCode community plugins installed in ~/.config/opencode/node_modules
+	Name              string        // human-readable name (e.g., "gentle-ai")
+	Owner             string        // GitHub repository owner
+	Repo              string        // GitHub repository name
+	DetectCmd         []string      // command to detect installed version; nil = use build var
+	VersionPrefix     string        // prefix to strip from version output (e.g., "v")
+	ReleaseTagPattern string        // optional regexp for selecting the correct GitHub release channel
+	InstallMethod     InstallMethod // how this tool is installed (used by upgrade executor)
+	GoImportPath      string        // for go-install tools (e.g. "github.com/.../cmd/engram")
+	NpmPackage        string        // for OpenCode community plugins installed in ~/.config/opencode/node_modules
 }
 
 // UpdateResult holds the result of checking a single tool for updates.


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #587

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change

## 📝 Summary

Fixes the Engram update check so `gentle-ai update` compares the local Engram binary against the `v*` binary release channel instead of newer `pi-v*` package releases.

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/update/types.go` | Adds optional `ReleaseTagPattern` metadata for release-channel selection. |
| `internal/update/registry.go` | Configures Engram to use the `vX.Y.Z` binary release channel. |
| `internal/update/check.go` | Routes tools with a release tag pattern through channel-aware release lookup. |
| `internal/update/github.go` | Adds paginated GitHub release lookup, draft/prerelease skipping, Link parsing, and loop detection. |
| `internal/update/check_test.go` | Adds regressions for `pi-v*` filtering, pagination, loop detection, and Link parameter ordering. |

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./...
```

**E2E Tests** (Docker required)
```bash
cd e2e && ./docker-test.sh
```

- [x] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Manually tested locally via focused update package tests and Judgment Day review

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] I have updated documentation if necessary
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers
