### PR TITLE
fix(tui): restore Pi-only back navigation

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1802,7 +1802,9 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		// NOTE: Back logic also in goBack() — keep in sync.
-		if m.shouldShowStrictTDDScreen() {
+		if isPiOnlyAgents(m.Selection.Agents) {
+			m.setScreen(ScreenAgents)
+		} else if m.shouldShowStrictTDDScreen() {
 			// StrictTDD screen is between ModelPicker/SDDMode and DependencyTree.
 			m.setScreen(ScreenStrictTDD)
 		} else if m.shouldShowSDDModeScreen() {
@@ -2434,6 +2436,10 @@ func (m Model) goBack() Model {
 	// going back should return to the preset screen (handled by linearRoutes).
 	// NOTE: DependencyTree back logic also in confirmSelection() — keep in sync.
 	if m.Screen == ScreenDependencyTree && m.Selection.Preset != model.PresetCustom {
+		if isPiOnlyAgents(m.Selection.Agents) {
+			m.setScreen(ScreenAgents)
+			return m
+		}
 		if m.shouldShowOpenCodePluginsScreen() {
 			m.setScreen(ScreenOpenCodePlugins)
 			return m

--- a/internal/tui/preset_flow_test.go
+++ b/internal/tui/preset_flow_test.go
@@ -193,6 +193,228 @@ func TestCustomPresetPostComponentFlowMatrix(t *testing.T) {
 	}
 }
 
+func TestInstallNavigationRoundTrips(t *testing.T) {
+	withModelCache := func(t *testing.T) {
+		t.Helper()
+		cacheFile := filepath.Join(t.TempDir(), "models.json")
+		if err := os.WriteFile(cacheFile, []byte(`{}`), 0o644); err != nil {
+			t.Fatalf("WriteFile(models cache) error = %v", err)
+		}
+
+		origStat := osStatModelCache
+		osStatModelCache = func(name string) (os.FileInfo, error) {
+			return os.Stat(cacheFile)
+		}
+		t.Cleanup(func() { osStatModelCache = origStat })
+	}
+
+	continuePluginsCursor := len(opencodepluginDefinitions()) * 2
+	tests := []struct {
+		name           string
+		setup          func(t *testing.T) Model
+		forwardActions []flowAction
+		forwardScreens []Screen
+		reverseScreens []Screen
+	}{
+		{
+			name: "Pi-only agents fast path returns to agent selection",
+			setup: func(t *testing.T) Model {
+				m := NewModel(system.DetectionResult{}, "dev")
+				m.Screen = ScreenAgents
+				m.Selection.Agents = []model.AgentID{model.AgentPi}
+				m.Selection.Components = componentsForPreset(model.PresetFullGentleman)
+				m.Cursor = len(screens.AgentOptions())
+				return m
+			},
+			forwardActions: []flowAction{{key: tea.KeyMsg{Type: tea.KeyEnter}}},
+			forwardScreens: []Screen{ScreenDependencyTree},
+			reverseScreens: []Screen{ScreenAgents},
+		},
+		{
+			name: "non-custom minimal without OpenCode returns from dependency plan to preset",
+			setup: func(t *testing.T) Model {
+				m := NewModel(system.DetectionResult{}, "dev")
+				m.Screen = ScreenPreset
+				m.Selection.Agents = []model.AgentID{model.AgentCursor}
+				m.Cursor = presetCursor(t, model.PresetMinimal)
+				return m
+			},
+			forwardActions: []flowAction{{key: tea.KeyMsg{Type: tea.KeyEnter}}},
+			forwardScreens: []Screen{ScreenDependencyTree},
+			reverseScreens: []Screen{ScreenPreset},
+		},
+		{
+			name: "non-custom minimal with OpenCode returns through plugins to preset",
+			setup: func(t *testing.T) Model {
+				m := NewModel(system.DetectionResult{}, "dev")
+				m.Screen = ScreenPreset
+				m.Selection.Agents = []model.AgentID{model.AgentOpenCode}
+				m.Cursor = presetCursor(t, model.PresetMinimal)
+				return m
+			},
+			forwardActions: []flowAction{
+				{key: tea.KeyMsg{Type: tea.KeyEnter}},
+				{key: tea.KeyMsg{Type: tea.KeyEnter}, cursor: continuePluginsCursor, setCursor: true},
+			},
+			forwardScreens: []Screen{ScreenOpenCodePlugins, ScreenDependencyTree},
+			reverseScreens: []Screen{ScreenOpenCodePlugins, ScreenPreset},
+		},
+		{
+			name: "OpenCode SDD single returns through plugins strict TDD and SDD mode to preset",
+			setup: func(t *testing.T) Model {
+				m := NewModel(system.DetectionResult{}, "dev")
+				m.Screen = ScreenPreset
+				m.Selection.Agents = []model.AgentID{model.AgentOpenCode}
+				m.Cursor = presetCursor(t, model.PresetFullGentleman)
+				return m
+			},
+			forwardActions: []flowAction{
+				{key: tea.KeyMsg{Type: tea.KeyEnter}},
+				{key: tea.KeyMsg{Type: tea.KeyEnter}},
+				{key: tea.KeyMsg{Type: tea.KeyEnter}},
+				{key: tea.KeyMsg{Type: tea.KeyEnter}, cursor: continuePluginsCursor, setCursor: true},
+			},
+			forwardScreens: []Screen{ScreenSDDMode, ScreenStrictTDD, ScreenOpenCodePlugins, ScreenDependencyTree},
+			reverseScreens: []Screen{ScreenOpenCodePlugins, ScreenStrictTDD, ScreenSDDMode, ScreenPreset},
+		},
+		{
+			name: "OpenCode SDD multi with model cache returns through plugins strict TDD model picker and SDD mode",
+			setup: func(t *testing.T) Model {
+				withModelCache(t)
+				m := NewModel(system.DetectionResult{}, "dev")
+				m.Screen = ScreenPreset
+				m.Selection.Agents = []model.AgentID{model.AgentOpenCode}
+				m.Cursor = presetCursor(t, model.PresetFullGentleman)
+				return m
+			},
+			forwardActions: []flowAction{
+				{key: tea.KeyMsg{Type: tea.KeyEnter}},
+				{key: tea.KeyMsg{Type: tea.KeyEnter}, cursor: sddMultiCursor(t), setCursor: true},
+				{key: tea.KeyMsg{Type: tea.KeyEnter}, cursor: len(screens.ModelPickerRows()), setCursor: true},
+				{key: tea.KeyMsg{Type: tea.KeyEnter}},
+				{key: tea.KeyMsg{Type: tea.KeyEnter}, cursor: continuePluginsCursor, setCursor: true},
+			},
+			forwardScreens: []Screen{ScreenSDDMode, ScreenModelPicker, ScreenStrictTDD, ScreenOpenCodePlugins, ScreenDependencyTree},
+			reverseScreens: []Screen{ScreenOpenCodePlugins, ScreenStrictTDD, ScreenModelPicker, ScreenSDDMode, ScreenPreset},
+		},
+		{
+			name: "non-OpenCode SDD returns through strict TDD to preset",
+			setup: func(t *testing.T) Model {
+				m := NewModel(system.DetectionResult{}, "dev")
+				m.Screen = ScreenPreset
+				m.Selection.Agents = []model.AgentID{model.AgentCursor}
+				m.Cursor = presetCursor(t, model.PresetFullGentleman)
+				return m
+			},
+			forwardActions: []flowAction{
+				{key: tea.KeyMsg{Type: tea.KeyEnter}},
+				{key: tea.KeyMsg{Type: tea.KeyEnter}},
+			},
+			forwardScreens: []Screen{ScreenStrictTDD, ScreenDependencyTree},
+			reverseScreens: []Screen{ScreenStrictTDD, ScreenPreset},
+		},
+		{
+			name: "custom SDD skills returns from skill picker through strict TDD to component selector",
+			setup: func(t *testing.T) Model {
+				m := NewModel(system.DetectionResult{}, "dev")
+				m.Screen = ScreenDependencyTree
+				m.Selection.Preset = model.PresetCustom
+				m.Selection.Agents = []model.AgentID{model.AgentCursor}
+				m.Selection.Components = []model.ComponentID{model.ComponentSDD, model.ComponentSkills}
+				m.Cursor = len(screens.AllComponents())
+				return m
+			},
+			forwardActions: []flowAction{
+				{key: tea.KeyMsg{Type: tea.KeyEnter}},
+				{key: tea.KeyMsg{Type: tea.KeyEnter}},
+			},
+			forwardScreens: []Screen{ScreenStrictTDD, ScreenSkillPicker},
+			reverseScreens: []Screen{ScreenStrictTDD, ScreenDependencyTree},
+		},
+		{
+			name: "custom OpenCode SDD skills returns from skill picker through strict TDD and SDD mode to component selector",
+			setup: func(t *testing.T) Model {
+				m := NewModel(system.DetectionResult{}, "dev")
+				m.Screen = ScreenDependencyTree
+				m.Selection.Preset = model.PresetCustom
+				m.Selection.Agents = []model.AgentID{model.AgentOpenCode}
+				m.Selection.Components = []model.ComponentID{model.ComponentSDD, model.ComponentSkills}
+				m.Cursor = len(screens.AllComponents())
+				return m
+			},
+			forwardActions: []flowAction{
+				{key: tea.KeyMsg{Type: tea.KeyEnter}},
+				{key: tea.KeyMsg{Type: tea.KeyEnter}},
+				{key: tea.KeyMsg{Type: tea.KeyEnter}},
+				{key: tea.KeyMsg{Type: tea.KeyEnter}, cursor: continuePluginsCursor, setCursor: true},
+			},
+			forwardScreens: []Screen{ScreenSDDMode, ScreenStrictTDD, ScreenOpenCodePlugins, ScreenSkillPicker},
+			reverseScreens: []Screen{ScreenStrictTDD, ScreenSDDMode, ScreenDependencyTree},
+		},
+		{
+			name: "custom Engram only returns from review to component selector",
+			setup: func(t *testing.T) Model {
+				m := NewModel(system.DetectionResult{}, "dev")
+				m.Screen = ScreenDependencyTree
+				m.Selection.Preset = model.PresetCustom
+				m.Selection.Agents = []model.AgentID{model.AgentCursor}
+				m.Selection.Components = []model.ComponentID{model.ComponentEngram}
+				m.Cursor = len(screens.AllComponents())
+				return m
+			},
+			forwardActions: []flowAction{{key: tea.KeyMsg{Type: tea.KeyEnter}}},
+			forwardScreens: []Screen{ScreenReview},
+			reverseScreens: []Screen{ScreenDependencyTree},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state := tt.setup(t)
+			for idx, action := range tt.forwardActions {
+				state = applyFlowAction(t, state, action)
+				if state.Screen != tt.forwardScreens[idx] {
+					t.Fatalf("forward step %d: screen = %v, want %v", idx+1, state.Screen, tt.forwardScreens[idx])
+				}
+			}
+
+			for idx, want := range tt.reverseScreens {
+				state = applyFlowAction(t, state, flowAction{key: tea.KeyMsg{Type: tea.KeyEsc}})
+				if state.Screen != want {
+					t.Fatalf("reverse step %d: screen = %v, want %v", idx+1, state.Screen, want)
+				}
+			}
+		})
+	}
+}
+
+func TestPiOnlyDependencyTreeBackRowReturnsToAgentSelection(t *testing.T) {
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Screen = ScreenAgents
+	m.Selection.Agents = []model.AgentID{model.AgentPi}
+	m.Selection.Components = componentsForPreset(model.PresetFullGentleman)
+	m.Cursor = len(screens.AgentOptions())
+
+	state := applyFlowAction(t, m, flowAction{key: tea.KeyMsg{Type: tea.KeyEnter}})
+	if state.Screen != ScreenDependencyTree {
+		t.Fatalf("screen = %v, want %v", state.Screen, ScreenDependencyTree)
+	}
+
+	state = applyFlowAction(t, state, flowAction{key: tea.KeyMsg{Type: tea.KeyEnter}, cursor: 1, setCursor: true})
+	if state.Screen != ScreenAgents {
+		t.Fatalf("screen = %v, want %v", state.Screen, ScreenAgents)
+	}
+}
+
+func applyFlowAction(t *testing.T, state Model, action flowAction) Model {
+	t.Helper()
+	if action.setCursor {
+		state.Cursor = action.cursor
+	}
+	updated, _ := state.Update(action.key)
+	return updated.(Model)
+}
+
 func presetCursor(t *testing.T, preset model.PresetID) int {
 	t.Helper()
 	for idx, option := range screens.PresetOptions() {

--- a/internal/tui/preset_flow_test.go
+++ b/internal/tui/preset_flow_test.go
@@ -18,6 +18,7 @@ type flowAction struct {
 	key       tea.KeyMsg
 	cursor    int
 	setCursor bool
+	prepare   func(Model) Model
 }
 
 func TestPresetSelectionNextScreenFlowMatrix(t *testing.T) {
@@ -290,7 +291,18 @@ func TestInstallNavigationRoundTrips(t *testing.T) {
 			forwardActions: []flowAction{
 				{key: tea.KeyMsg{Type: tea.KeyEnter}},
 				{key: tea.KeyMsg{Type: tea.KeyEnter}, cursor: sddMultiCursor(t), setCursor: true},
-				{key: tea.KeyMsg{Type: tea.KeyEnter}, cursor: len(screens.ModelPickerRows()), setCursor: true},
+				{
+					key:       tea.KeyMsg{Type: tea.KeyEnter},
+					cursor:    len(screens.ModelPickerRows()),
+					setCursor: true,
+					prepare: func(state Model) Model {
+						// The round-trip under test is the ModelPicker navigation edge, not
+						// provider cache parsing. CI may not have a real OpenCode cache, so
+						// force the picker into its normal row+Continue mode deterministically.
+						state.ModelPicker.AvailableIDs = []string{"opencode"}
+						return state
+					},
+				},
 				{key: tea.KeyMsg{Type: tea.KeyEnter}},
 				{key: tea.KeyMsg{Type: tea.KeyEnter}, cursor: continuePluginsCursor, setCursor: true},
 			},
@@ -408,6 +420,9 @@ func TestPiOnlyDependencyTreeBackRowReturnsToAgentSelection(t *testing.T) {
 
 func applyFlowAction(t *testing.T, state Model, action flowAction) Model {
 	t.Helper()
+	if action.prepare != nil {
+		state = action.prepare(state)
+	}
 	if action.setCursor {
 		state.Cursor = action.cursor
 	}


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #589

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

Fixes Pi-only installer back navigation. When the user selects only `Pi`, the installer fast-paths from agent selection directly to the dependency plan. Back navigation from that plan now returns to agent selection instead of falling into the generic Gentle AI preset/configuration flow.

This also adds a broad install TUI round-trip matrix so dynamic forward/back paths are validated across Pi-only, OpenCode, SDD, Strict TDD, model picker, plugin picker, custom preset, skills, and review paths.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/tui/model.go` | Added Pi-only reverse-edge handling for `ScreenDependencyTree` Back row and Esc/goBack. |
| `internal/tui/preset_flow_test.go` | Added table-driven install navigation round-trip coverage and Pi-only Back-row regression test. |

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./...
```

**E2E Tests** (Docker required)
```bash
cd e2e && ./docker-test.sh
```

- [x] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [ ] Manually tested locally

Additional validation:

```bash
go test ./internal/tui -run 'TestInstallNavigationRoundTrips|TestPiOnlyDependencyTreeBackRowReturnsToAgentSelection'
go test ./internal/tui
git diff --check
```

---

## 🤖 Automated Checks

The following checks run automatically on this PR:

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | PR should stay within 400 changed lines (`additions + deletions`) or use `size:exception` |
| Check Issue Reference | ⏳ | PR body must contain `Closes/Fixes/Resolves #N` |
| Check Issue Has `status:approved` | ⏳ | Linked issue must have been approved before work began |
| Check PR Has `type:*` Label | ⏳ | Exactly one `type:*` label must be applied |
| Unit Tests | ⏳ | `go test ./...` must pass |
| E2E Tests | ⏳ | `cd e2e && ./docker-test.sh` must pass |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

The behavior fix is intentionally small. Most of the diff is regression coverage for install TUI round-trip navigation.