### PR TITLE
fix(plugin): write model-variants cache directly instead of atomic rename on Windows

### DIFF
--- a/internal/assets/assets_test.go
+++ b/internal/assets/assets_test.go
@@ -184,8 +184,12 @@ func TestModelVariantsPluginContract(t *testing.T) {
 	src := string(source)
 
 	// Atomic write: must import rename and write to a .tmp file before renaming.
+	// Must also unlink before rename for Windows compatibility.
 	if !strings.Contains(src, "rename") {
 		t.Errorf("model-variants.ts must use rename() for atomic write")
+	}
+	if !strings.Contains(src, "unlink") {
+		t.Errorf("model-variants.ts must unlink() before rename() for Windows compatibility")
 	}
 	if !strings.Contains(src, ".tmp") {
 		t.Errorf("model-variants.ts must write to a .tmp file before rename()")

--- a/internal/assets/assets_test.go
+++ b/internal/assets/assets_test.go
@@ -183,16 +183,13 @@ func TestModelVariantsPluginContract(t *testing.T) {
 	}
 	src := string(source)
 
-	// Atomic write: must import rename and write to a .tmp file before renaming.
-	// Must also unlink before rename for Windows compatibility.
-	if !strings.Contains(src, "rename") {
-		t.Errorf("model-variants.ts must use rename() for atomic write")
+	// Windows-safe write: must use writeFile for the cache, not rename().
+	// rename() is fragile on Windows with OneDrive-synced directories.
+	if !strings.Contains(src, "writeFile") {
+		t.Errorf("model-variants.ts must use writeFile() for cache persistence")
 	}
-	if !strings.Contains(src, "unlink") {
-		t.Errorf("model-variants.ts must unlink() before rename() for Windows compatibility")
-	}
-	if !strings.Contains(src, ".tmp") {
-		t.Errorf("model-variants.ts must write to a .tmp file before rename()")
+	if strings.Contains(src, "rename") {
+		t.Errorf("model-variants.ts must not use rename() — fragile on Windows with synced directories")
 	}
 
 	// Always-write semantics: the cache must be written unconditionally so an

--- a/internal/assets/opencode/plugins/model-variants.ts
+++ b/internal/assets/opencode/plugins/model-variants.ts
@@ -9,7 +9,7 @@
  */
 
 import type { Plugin } from "@opencode-ai/plugin"
-import { writeFile, mkdir, rename, unlink } from "fs/promises"
+import { writeFile, mkdir } from "fs/promises"
 import { homedir } from "os"
 import path from "path"
 
@@ -34,21 +34,10 @@ export const ModelVariantsPlugin: Plugin = async (input) => {
       const cacheDir = path.join(homedir(), ".gentle-ai", "cache")
       await mkdir(cacheDir, { recursive: true })
 
-      // Atomic write: write to .tmp then rename. rename() is atomic on POSIX,
-      // so concurrent readers (e.g. `gentle-ai sync`) never see a partial JSON.
-      // Always write — even when empty — to avoid leaving a stale cache from
-      // a previous run alive after providers stop reporting variants.
-      const finalPath = path.join(cacheDir, "model-variants.json")
-      const tmpPath = finalPath + ".tmp"
-      await writeFile(tmpPath, JSON.stringify(variants, null, 2))
-      // On Windows, rename() cannot overwrite an existing file. Unlink first
-      // so the atomic rename always succeeds across platforms.
-      try {
-        await unlink(finalPath)
-      } catch (_) {
-        // file may not exist — safe to ignore
-      }
-      await rename(tmpPath, finalPath)
+      // Write directly. On Windows, rename() is fragile with OneDrive-synced
+      // directories — the .tmp file can vanish between write and rename.
+      // The Go-side reader already handles a missing/incomplete cache gracefully.
+      await writeFile(path.join(cacheDir, "model-variants.json"), JSON.stringify(variants, null, 2))
     } catch (err) {
       console.error("[model-variants] cache refresh failed:", err)
     }

--- a/internal/assets/opencode/plugins/model-variants.ts
+++ b/internal/assets/opencode/plugins/model-variants.ts
@@ -9,7 +9,7 @@
  */
 
 import type { Plugin } from "@opencode-ai/plugin"
-import { writeFile, mkdir, rename } from "fs/promises"
+import { writeFile, mkdir, rename, unlink } from "fs/promises"
 import { homedir } from "os"
 import path from "path"
 
@@ -41,6 +41,13 @@ export const ModelVariantsPlugin: Plugin = async (input) => {
       const finalPath = path.join(cacheDir, "model-variants.json")
       const tmpPath = finalPath + ".tmp"
       await writeFile(tmpPath, JSON.stringify(variants, null, 2))
+      // On Windows, rename() cannot overwrite an existing file. Unlink first
+      // so the atomic rename always succeeds across platforms.
+      try {
+        await unlink(finalPath)
+      } catch (_) {
+        // file may not exist — safe to ignore
+      }
       await rename(tmpPath, finalPath)
     } catch (err) {
       console.error("[model-variants] cache refresh failed:", err)


### PR DESCRIPTION
### Issue for this PR

Closes #599

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The model-variants plugin used an atomic write pattern (write to `.tmp`, then `rename` to final) that works on POSIX but fails reliably on Windows. Two independent failure modes were found during testing:

1. **`rename()` can't overwrite existing files on Windows** (first theory, wrong)
2. **Bun loses the `.tmp` file between `writeFile` and `rename` on Windows with OneDrive-synced directories** (real root cause — confirmed by testing on a Windows 11 machine with OneDrive)

The fix: write directly to `model-variants.json` instead of the atomic rename pattern. The Go-side `LoadVariants()` already handles a missing or partially-written cache gracefully.

### How did you verify your code works?

- Replaced the binary, ran `gentle-ai sync`, opened `opencode web` — no `ENOENT` error
- Cache was written correctly on fresh install (deleted `~/.gentle-ai/cache/` before testing)
- Same fix works on Linux/WSL (tested on Debian WSL) — no regression since POSIX `writeFile` is already reliable

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR