### PR TITLE
fix(opencode): preserve subagent model variant

### DIFF
--- a/internal/assets/assets_test.go
+++ b/internal/assets/assets_test.go
@@ -211,6 +211,31 @@ func TestModelVariantsPluginContract(t *testing.T) {
 	}
 }
 
+// TestBackgroundAgentsPluginPreservesAgentVariant verifies that background
+// delegation keeps OpenCode's config-level `variant` field when resolving an
+// agent model. OpenCode expects `variant` as a top-level session.prompt field,
+// not nested inside the model object.
+func TestBackgroundAgentsPluginPreservesAgentVariant(t *testing.T) {
+	source, err := Read("opencode/plugins/background-agents.ts")
+	if err != nil {
+		t.Fatalf("Read(background-agents.ts) error = %v", err)
+	}
+	src := string(source)
+
+	checks := map[string]string{
+		"agent config includes variant":  "agent?: Record<string, { model?: string; variant?: string }>",
+		"variant returned from resolver": "return { providerID, modelID, variant: agentConfig.variant }",
+		"model excludes variant":         "model: {\n              providerID: agentModel.providerID,\n              modelID: agentModel.modelID,\n            }",
+		"variant passed top-level":       "...(agentModel?.variant && { variant: agentModel.variant })",
+	}
+
+	for name, want := range checks {
+		if !strings.Contains(src, want) {
+			t.Errorf("background-agents.ts missing %s contract: %s", name, want)
+		}
+	}
+}
+
 func TestClaudeEmbeddedAssetLayout(t *testing.T) {
 	entries, err := FS.ReadDir("claude")
 	if err != nil {

--- a/internal/assets/opencode/plugins/background-agents.ts
+++ b/internal/assets/opencode/plugins/background-agents.ts
@@ -471,19 +471,22 @@ async function parseAgentWriteCapability(
  * Resolve the model configured for a given agent.
  * Parses the "provider/model-id" format into the shape session.prompt() expects.
  * Returns undefined when no model is configured (caller falls back to default).
+ * The variant is sent separately because OpenCode's session.prompt API models
+ * it as a top-level parameter, not as part of the model object.
  */
 async function resolveAgentModel(
   client: OpencodeClient,
   agentName: string,
   log: Logger,
-): Promise<{ providerID: string; modelID: string } | undefined> {
+): Promise<{ providerID: string; modelID: string; variant?: string } | undefined> {
   try {
     const config = await client.config.get()
     const configData = config.data as {
-      agent?: Record<string, { model?: string }>
+      agent?: Record<string, { model?: string; variant?: string }>
     } | undefined
 
-    const modelStr = configData?.agent?.[agentName]?.model
+    const agentConfig = configData?.agent?.[agentName]
+    const modelStr = agentConfig?.model
     if (!modelStr) return undefined
 
     const slashIndex = modelStr.indexOf("/")
@@ -492,8 +495,10 @@ async function resolveAgentModel(
     const providerID = modelStr.substring(0, slashIndex)
     const modelID = modelStr.substring(slashIndex + 1)
 
-    await log.info(`resolveAgentModel: ${agentName} → ${providerID}/${modelID}`)
-    return { providerID, modelID }
+    await log.info(
+      `resolveAgentModel: ${agentName} → ${providerID}/${modelID}${agentConfig.variant ? ` (${agentConfig.variant})` : ""}`,
+    )
+    return { providerID, modelID, variant: agentConfig.variant }
   } catch {
     return undefined
   }
@@ -671,7 +676,13 @@ class DelegationManager {
         path: { id: delegation.sessionID },
         body: {
           agent: input.agent,
-          ...(agentModel && { model: agentModel }),
+          ...(agentModel && {
+            model: {
+              providerID: agentModel.providerID,
+              modelID: agentModel.modelID,
+            },
+          }),
+          ...(agentModel?.variant && { variant: agentModel.variant }),
           parts: [{ type: "text", text: input.prompt }],
           tools: {
             task: false,


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #606

> Note: #606 is currently pending maintainer review. Opening this PR early because the change is intentionally small, directly linked, and ready for review.

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change

## 📝 Summary

- Preserves an OpenCode agent's configured `variant` when launching delegated background subagents.
- Passes `variant` to `session.prompt` as a top-level field, matching OpenCode's SDK/API shape.
- Adds an embedded asset contract test so future changes do not drop variant propagation.

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/assets/opencode/plugins/background-agents.ts` | Reads `agent.variant`, returns it from model resolution, and forwards it top-level to `session.prompt` |
| `internal/assets/assets_test.go` | Adds a contract test for background agent variant preservation |

## 🧪 Test Plan

**TypeScript asset check**
```bash
bun --check internal/assets/opencode/plugins/background-agents.ts
```

**Focused Go tests**
```bash
go test ./internal/assets
```

**Full Go test suite**
```bash
go test ./...
```

- [x] TypeScript asset check passes (`bun --check internal/assets/opencode/plugins/background-agents.ts`)
- [x] Focused tests pass (`go test ./internal/assets`)
- [x] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — not run locally for this small embedded plugin fix
- [x] Manually reviewed the OpenCode SDK shape: `variant` is a sibling field of `model` in `session.prompt`

## ✅ Contributor Checklist

- [x] PR is linked to an issue
- [x] PR stays within 400 changed lines (48 changed lines total)
- [x] I have added / requested the appropriate `type:*` label (`type:bug`)
- [x] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — not run locally
- [x] I have updated documentation if necessary (not needed; this fixes existing documented variant behavior)
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers

## Notes for Reviewers

#429 / #440 added OpenCode variant discovery, TUI selection, persistence, and config injection. This PR closes the remaining gap in the background delegation path: the embedded `background-agents.ts` plugin previously forwarded only `{ providerID, modelID }` and dropped the configured `agent.variant`.

The fix keeps `variant` out of the nested `model` object and sends it as a top-level `session.prompt` field, which is the shape exposed by the OpenCode SDK.
