### PR TITLE
fix: sync Pi persona config

### DIFF
--- a/internal/cli/install_test.go
+++ b/internal/cli/install_test.go
@@ -94,7 +94,7 @@ func TestNormalizeInstallFlagsCustomAcceptsOptionalGentlemanInstallables(t *test
 	}
 }
 
-func TestNormalizeInstallFlagsPiOnlyDefaultsToEngramOnly(t *testing.T) {
+func TestNormalizeInstallFlagsPiOnlyDefaultsToEngramAndPersona(t *testing.T) {
 	input, err := NormalizeInstallFlags(InstallFlags{
 		Agents: []string{string(model.AgentPi)},
 	}, system.DetectionResult{})
@@ -106,7 +106,7 @@ func TestNormalizeInstallFlagsPiOnlyDefaultsToEngramOnly(t *testing.T) {
 	if !reflect.DeepEqual(input.Selection.Agents, wantAgents) {
 		t.Fatalf("agents = %#v, want %#v", input.Selection.Agents, wantAgents)
 	}
-	wantComponents := []model.ComponentID{model.ComponentEngram}
+	wantComponents := []model.ComponentID{model.ComponentEngram, model.ComponentPersona}
 	if !reflect.DeepEqual(input.Selection.Components, wantComponents) {
 		t.Fatalf("components = %#v, want %#v", input.Selection.Components, wantComponents)
 	}

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -589,6 +589,12 @@ func (s componentApplyStep) Run() error {
 		return nil
 	case model.ComponentPersona:
 		for _, adapter := range adapters {
+			if adapter.Agent() == model.AgentPi {
+				if _, err := writePiPersonaConfig(s.homeDir, s.workspaceDir, s.selection.Persona); err != nil {
+					return fmt.Errorf("inject persona for %q: %w", adapter.Agent(), err)
+				}
+				continue
+			}
 			targetDir := componentInjectionDir(s.homeDir, s.workspaceDir, adapter)
 			if _, err := persona.Inject(targetDir, adapter, s.selection.Persona); err != nil {
 				return fmt.Errorf("inject persona for %q: %w", adapter.Agent(), err)
@@ -991,6 +997,10 @@ func componentPathsWithWorkspace(homeDir, workspaceDir string, selection model.S
 			if selection.Persona == model.PersonaCustom {
 				break
 			}
+			if adapter.Agent() == model.AgentPi {
+				paths = append(paths, piPersonaConfigPaths(homeDir, workspaceDir)...)
+				break
+			}
 			if adapter.Agent() == model.AgentOpenClaw {
 				paths = append(paths, filepath.Join(targetDir, "SOUL.md"))
 				break
@@ -1047,6 +1057,41 @@ func componentInjectionDir(homeDir, workspaceDir string, adapter agents.Adapter)
 		return workspaceDir
 	}
 	return homeDir
+}
+
+func piPersonaConfigPaths(homeDir, workspaceDir string) []string {
+	paths := []string{filepath.Join(homeDir, ".pi", "gentle-ai", "persona.json")}
+	if strings.TrimSpace(workspaceDir) != "" && workspaceDir != homeDir {
+		paths = append(paths, filepath.Join(workspaceDir, ".pi", "gentle-ai", "persona.json"))
+	}
+	return paths
+}
+
+func writePiPersonaConfig(homeDir, workspaceDir string, personaID model.PersonaID) (bool, error) {
+	if personaID == model.PersonaCustom {
+		return false, nil
+	}
+	mode := string(personaID)
+	if mode == "" {
+		mode = string(model.PersonaGentleman)
+	}
+	content := []byte(fmt.Sprintf("{\n  \"mode\": \"%s\"\n}\n", mode))
+
+	changed := false
+	for _, path := range piPersonaConfigPaths(homeDir, workspaceDir) {
+		current, err := os.ReadFile(path)
+		if err == nil && string(current) == string(content) {
+			continue
+		}
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			return changed, err
+		}
+		if err := os.WriteFile(path, content, 0o644); err != nil {
+			return changed, err
+		}
+		changed = true
+	}
+	return changed, nil
 }
 
 type openClawWorkspaceConfig struct {

--- a/internal/cli/run_component_paths_test.go
+++ b/internal/cli/run_component_paths_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -122,6 +123,63 @@ func TestComponentPathsWithWorkspaceOpenClawSDDUsesWorkspaceScopedSkills(t *test
 	} {
 		if containsPath(paths, unwanted) {
 			t.Fatalf("componentPathsWithWorkspace(sdd,openclaw) must not include home-scoped SDD skill path %q\npaths=%v", unwanted, paths)
+		}
+	}
+}
+
+func TestComponentPersonaPiIncludesPersonaConfigPaths(t *testing.T) {
+	home := t.TempDir()
+	workspace := t.TempDir()
+	adapters := resolveAdapters([]model.AgentID{model.AgentPi})
+
+	paths := componentPathsWithWorkspace(home, workspace, model.Selection{Persona: model.PersonaNeutral}, adapters, model.ComponentPersona)
+
+	for _, want := range []string{
+		filepath.Join(home, ".pi", "gentle-ai", "persona.json"),
+		filepath.Join(workspace, ".pi", "gentle-ai", "persona.json"),
+	} {
+		if !containsPath(paths, want) {
+			t.Fatalf("componentPathsWithWorkspace(persona,pi) missing Pi persona path %q\npaths=%v", want, paths)
+		}
+	}
+}
+
+func TestSyncPersonaPathsPiIncludesPersonaConfigPaths(t *testing.T) {
+	home := t.TempDir()
+	workspace := t.TempDir()
+	adapters := resolveAdapters([]model.AgentID{model.AgentPi})
+
+	paths := syncPersonaPathsWithWorkspace(home, workspace, model.Selection{Persona: model.PersonaNeutral}, adapters)
+
+	for _, want := range []string{
+		filepath.Join(home, ".pi", "gentle-ai", "persona.json"),
+		filepath.Join(workspace, ".pi", "gentle-ai", "persona.json"),
+	} {
+		if !containsPath(paths, want) {
+			t.Fatalf("syncPersonaPathsWithWorkspace(pi) missing Pi persona path %q\npaths=%v", want, paths)
+		}
+	}
+}
+
+func TestWritePiPersonaConfigWritesNeutralMode(t *testing.T) {
+	home := t.TempDir()
+	workspace := t.TempDir()
+
+	changed, err := writePiPersonaConfig(home, workspace, model.PersonaNeutral)
+	if err != nil {
+		t.Fatalf("writePiPersonaConfig() error = %v", err)
+	}
+	if !changed {
+		t.Fatal("writePiPersonaConfig() changed = false, want true")
+	}
+
+	for _, path := range piPersonaConfigPaths(home, workspace) {
+		content, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("ReadFile(%q) error = %v", path, err)
+		}
+		if got, want := string(content), "{\n  \"mode\": \"neutral\"\n}\n"; got != want {
+			t.Fatalf("persona config %q = %q, want %q", path, got, want)
 		}
 	}
 }

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -492,6 +492,10 @@ func syncPersonaPathsWithWorkspace(homeDir, workspaceDir string, selection model
 	paths := []string{}
 	for _, adapter := range adapters {
 		targetDir := componentInjectionDir(homeDir, workspaceDir, adapter)
+		if adapter.Agent() == model.AgentPi {
+			paths = append(paths, piPersonaConfigPaths(homeDir, workspaceDir)...)
+			continue
+		}
 		if adapter.Agent() == model.AgentOpenClaw {
 			paths = append(paths, filepath.Join(targetDir, "SOUL.md"))
 			continue
@@ -672,6 +676,14 @@ func (s componentSyncStep) Run() error {
 		// merge conflicts with SDD's writes to the same settings file and
 		// remains an install-only concern.
 		for _, adapter := range adapters {
+			if adapter.Agent() == model.AgentPi {
+				changed, err := writePiPersonaConfig(s.homeDir, s.workspaceDir, s.selection.Persona)
+				if err != nil {
+					return fmt.Errorf("sync persona for %q: %w", adapter.Agent(), err)
+				}
+				s.countChanged(boolToInt(changed))
+				continue
+			}
 			targetDir := componentInjectionDir(s.homeDir, s.workspaceDir, adapter)
 			res, err := persona.InjectForSync(targetDir, adapter, s.selection.Persona)
 			if err != nil {

--- a/internal/cli/validate.go
+++ b/internal/cli/validate.go
@@ -232,7 +232,7 @@ func isPiOnlyAgents(agents []model.AgentID) bool {
 }
 
 func piOnlyComponents() []model.ComponentID {
-	return []model.ComponentID{model.ComponentEngram}
+	return []model.ComponentID{model.ComponentEngram, model.ComponentPersona}
 }
 
 func unique[T comparable](items []T) []T {


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #610

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Keeps Pi persona config aligned with the selected Gentle AI persona.
- Writes `.pi/gentle-ai/persona.json` for Pi during install/sync instead of letting Pi fall back when the file is absent.
- Includes the Pi persona config path in managed backup/verification paths.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/cli/validate.go` | Includes persona in the Pi-only default component set. |
| `internal/cli/run.go` | Writes Pi persona config for install and reports the config paths. |
| `internal/cli/sync.go` | Syncs Pi persona config from the persisted Gentle AI persona selection. |
| `internal/cli/*_test.go` | Adds focused coverage for Pi persona config paths and neutral mode JSON. |

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./...
```

**E2E Tests** (Docker required)
```bash
cd e2e && ./docker-test.sh
```

- [x] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [ ] Manually tested locally

---

## ✅ Contributor Checklist

- [ ] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [ ] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] I have updated documentation if necessary
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

Issue #610 needs maintainer approval (`status:approved`) and this PR needs the `type:bug` label before the validation workflow can pass.
