### PR TITLE
feat(gga): add REASONING placeholder to generated config

### DIFF
--- a/internal/components/gga/config.go
+++ b/internal/components/gga/config.go
@@ -87,6 +87,11 @@ func BuildConfig(provider string) []byte {
 	b.WriteString("\n")
 	b.WriteString("# Review timeout in seconds\n")
 	b.WriteString("TIMEOUT=\"300\"\n")
+	b.WriteString("\n")
+	b.WriteString("# Reasoning effort across all providers (minimal, low, medium, high, max)\n")
+	b.WriteString("# ✅ opencode, codex, ollama  ⚠️ github  ❌ claude, gemini\n")
+	b.WriteString("# Leave empty to use provider defaults\n")
+	b.WriteString("REASONING=\"\"\n")
 	return []byte(b.String())
 }
 


### PR DESCRIPTION
Add REASONING env var with support matrix and value docs to the shell-sourced .gga config generated by BuildConfig(). All 24 Go tests pass.