### PR TITLE
feat(assets): propagate session ID in engram protocol for global agents like Antigravity

### DIFF
--- a/internal/assets/claude/engram-protocol.md
+++ b/internal/assets/claude/engram-protocol.md
@@ -3,6 +3,17 @@
 You have access to Engram, a persistent memory system that survives across sessions and compactions.
 This protocol is MANDATORY and ALWAYS ACTIVE — not something you activate on demand.
 
+### SESSION START & PROJECT DETECTION PROTOCOL (mandatory)
+
+At the very beginning of the session, if you have an active workspace directory:
+1. **Detect Project Name**: Call `mem_current_project` sending the absolute path of the workspace directory in the `cwd` (or `directory`) parameter.
+2. **Start Session**: Call `mem_session_start` with:
+   - **id**: A unique session ID (e.g., `session-` + conversation ID)
+   - **directory**: The absolute path of the workspace directory.
+3. **Persist State**: Store the resolved project name and the session ID in your active context. You MUST:
+   - Use the session ID for all mutation tools (`mem_save`, `mem_session_summary`, `mem_session_end`, `mem_capture_passive`).
+   - Use the project name for all read/search/diagnostic tools (`mem_search`, `mem_context`, `mem_doctor`).
+
 ### PROACTIVE SAVE TRIGGERS (mandatory — do NOT wait for user to ask)
 
 Call `mem_save` IMMEDIATELY and WITHOUT BEING ASKED after any of these:
@@ -22,6 +33,7 @@ Call `mem_save` IMMEDIATELY and WITHOUT BEING ASKED after any of these:
 Self-check after EVERY task: "Did I make a decision, fix a bug, learn something non-obvious, or establish a convention? If yes, call mem_save NOW."
 
 Format for `mem_save`:
+- **session_id**: The active session ID created at the start (required to associate memory with the correct project)
 - **title**: Verb + what — short, searchable (e.g. "Fixed N+1 query in UserList")
 - **type**: bugfix | decision | architecture | discovery | pattern | config | preference
 - **scope**: `project` (default) | `personal`

--- a/testdata/golden/combined-claude-claudemd.golden
+++ b/testdata/golden/combined-claude-claudemd.golden
@@ -389,6 +389,17 @@ Convention files under the agent's global skills directory (global) or `.agent/s
 You have access to Engram, a persistent memory system that survives across sessions and compactions.
 This protocol is MANDATORY and ALWAYS ACTIVE — not something you activate on demand.
 
+### SESSION START & PROJECT DETECTION PROTOCOL (mandatory)
+
+At the very beginning of the session, if you have an active workspace directory:
+1. **Detect Project Name**: Call `mem_current_project` sending the absolute path of the workspace directory in the `cwd` (or `directory`) parameter.
+2. **Start Session**: Call `mem_session_start` with:
+   - **id**: A unique session ID (e.g., `session-` + conversation ID)
+   - **directory**: The absolute path of the workspace directory.
+3. **Persist State**: Store the resolved project name and the session ID in your active context. You MUST:
+   - Use the session ID for all mutation tools (`mem_save`, `mem_session_summary`, `mem_session_end`, `mem_capture_passive`).
+   - Use the project name for all read/search/diagnostic tools (`mem_search`, `mem_context`, `mem_doctor`).
+
 ### PROACTIVE SAVE TRIGGERS (mandatory — do NOT wait for user to ask)
 
 Call `mem_save` IMMEDIATELY and WITHOUT BEING ASKED after any of these:
@@ -408,6 +419,7 @@ Call `mem_save` IMMEDIATELY and WITHOUT BEING ASKED after any of these:
 Self-check after EVERY task: "Did I make a decision, fix a bug, learn something non-obvious, or establish a convention? If yes, call mem_save NOW."
 
 Format for `mem_save`:
+- **session_id**: The active session ID created at the start (required to associate memory with the correct project)
 - **title**: Verb + what — short, searchable (e.g. "Fixed N+1 query in UserList")
 - **type**: bugfix | decision | architecture | discovery | pattern | config | preference
 - **scope**: `project` (default) | `personal`

--- a/testdata/golden/combined-windsurf-global-rules.golden
+++ b/testdata/golden/combined-windsurf-global-rules.golden
@@ -441,6 +441,17 @@ DAG state is tracked in Engram under `sdd/{change-name}/state`. Update it after 
 You have access to Engram, a persistent memory system that survives across sessions and compactions.
 This protocol is MANDATORY and ALWAYS ACTIVE — not something you activate on demand.
 
+### SESSION START & PROJECT DETECTION PROTOCOL (mandatory)
+
+At the very beginning of the session, if you have an active workspace directory:
+1. **Detect Project Name**: Call `mem_current_project` sending the absolute path of the workspace directory in the `cwd` (or `directory`) parameter.
+2. **Start Session**: Call `mem_session_start` with:
+   - **id**: A unique session ID (e.g., `session-` + conversation ID)
+   - **directory**: The absolute path of the workspace directory.
+3. **Persist State**: Store the resolved project name and the session ID in your active context. You MUST:
+   - Use the session ID for all mutation tools (`mem_save`, `mem_session_summary`, `mem_session_end`, `mem_capture_passive`).
+   - Use the project name for all read/search/diagnostic tools (`mem_search`, `mem_context`, `mem_doctor`).
+
 ### PROACTIVE SAVE TRIGGERS (mandatory — do NOT wait for user to ask)
 
 Call `mem_save` IMMEDIATELY and WITHOUT BEING ASKED after any of these:
@@ -460,6 +471,7 @@ Call `mem_save` IMMEDIATELY and WITHOUT BEING ASKED after any of these:
 Self-check after EVERY task: "Did I make a decision, fix a bug, learn something non-obvious, or establish a convention? If yes, call mem_save NOW."
 
 Format for `mem_save`:
+- **session_id**: The active session ID created at the start (required to associate memory with the correct project)
 - **title**: Verb + what — short, searchable (e.g. "Fixed N+1 query in UserList")
 - **type**: bugfix | decision | architecture | discovery | pattern | config | preference
 - **scope**: `project` (default) | `personal`

--- a/testdata/golden/engram-antigravity-rulesmd.golden
+++ b/testdata/golden/engram-antigravity-rulesmd.golden
@@ -4,6 +4,17 @@
 You have access to Engram, a persistent memory system that survives across sessions and compactions.
 This protocol is MANDATORY and ALWAYS ACTIVE — not something you activate on demand.
 
+### SESSION START & PROJECT DETECTION PROTOCOL (mandatory)
+
+At the very beginning of the session, if you have an active workspace directory:
+1. **Detect Project Name**: Call `mem_current_project` sending the absolute path of the workspace directory in the `cwd` (or `directory`) parameter.
+2. **Start Session**: Call `mem_session_start` with:
+   - **id**: A unique session ID (e.g., `session-` + conversation ID)
+   - **directory**: The absolute path of the workspace directory.
+3. **Persist State**: Store the resolved project name and the session ID in your active context. You MUST:
+   - Use the session ID for all mutation tools (`mem_save`, `mem_session_summary`, `mem_session_end`, `mem_capture_passive`).
+   - Use the project name for all read/search/diagnostic tools (`mem_search`, `mem_context`, `mem_doctor`).
+
 ### PROACTIVE SAVE TRIGGERS (mandatory — do NOT wait for user to ask)
 
 Call `mem_save` IMMEDIATELY and WITHOUT BEING ASKED after any of these:
@@ -23,6 +34,7 @@ Call `mem_save` IMMEDIATELY and WITHOUT BEING ASKED after any of these:
 Self-check after EVERY task: "Did I make a decision, fix a bug, learn something non-obvious, or establish a convention? If yes, call mem_save NOW."
 
 Format for `mem_save`:
+- **session_id**: The active session ID created at the start (required to associate memory with the correct project)
 - **title**: Verb + what — short, searchable (e.g. "Fixed N+1 query in UserList")
 - **type**: bugfix | decision | architecture | discovery | pattern | config | preference
 - **scope**: `project` (default) | `personal`

--- a/testdata/golden/engram-claude-claudemd.golden
+++ b/testdata/golden/engram-claude-claudemd.golden
@@ -4,6 +4,17 @@
 You have access to Engram, a persistent memory system that survives across sessions and compactions.
 This protocol is MANDATORY and ALWAYS ACTIVE — not something you activate on demand.
 
+### SESSION START & PROJECT DETECTION PROTOCOL (mandatory)
+
+At the very beginning of the session, if you have an active workspace directory:
+1. **Detect Project Name**: Call `mem_current_project` sending the absolute path of the workspace directory in the `cwd` (or `directory`) parameter.
+2. **Start Session**: Call `mem_session_start` with:
+   - **id**: A unique session ID (e.g., `session-` + conversation ID)
+   - **directory**: The absolute path of the workspace directory.
+3. **Persist State**: Store the resolved project name and the session ID in your active context. You MUST:
+   - Use the session ID for all mutation tools (`mem_save`, `mem_session_summary`, `mem_session_end`, `mem_capture_passive`).
+   - Use the project name for all read/search/diagnostic tools (`mem_search`, `mem_context`, `mem_doctor`).
+
 ### PROACTIVE SAVE TRIGGERS (mandatory — do NOT wait for user to ask)
 
 Call `mem_save` IMMEDIATELY and WITHOUT BEING ASKED after any of these:
@@ -23,6 +34,7 @@ Call `mem_save` IMMEDIATELY and WITHOUT BEING ASKED after any of these:
 Self-check after EVERY task: "Did I make a decision, fix a bug, learn something non-obvious, or establish a convention? If yes, call mem_save NOW."
 
 Format for `mem_save`:
+- **session_id**: The active session ID created at the start (required to associate memory with the correct project)
 - **title**: Verb + what — short, searchable (e.g. "Fixed N+1 query in UserList")
 - **type**: bugfix | decision | architecture | discovery | pattern | config | preference
 - **scope**: `project` (default) | `personal`


### PR DESCRIPTION
## 🔗 Linked Issue



---

## 🏷️ PR Type

- [ ] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [x] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Updated the agent prompt instructions (`engram-protocol.md`) to establish a clear project detection and session start cycle.
- Mandated the usage of `mem_current_project` (passing the client directory) and `mem_session_start` at the start of any conversation workspace.
- Instructed the agent to save the session ID in context and propagate `session_id` to all subsequent `mem_save`, `mem_session_summary`, and `mem_session_end` calls.
- This ensures global hosts (like Antigravity) route SQLite entries to the correct project space.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/assets/claude/engram-protocol.md` | Added project detection lifecycle and mandated session ID propagation. |

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./...