### PR TITLE
feat(opencode): show delegation progress in Desktop

### DIFF
--- a/internal/assets/assets_test.go
+++ b/internal/assets/assets_test.go
@@ -616,8 +616,39 @@ func TestPersonasContainContextualSkillLoadingDirective(t *testing.T) {
 	}
 }
 
-// TestMustReadPanicsOnMissingFile verifies that MustRead panics for a
-// nonexistent file, confirming the safety mechanism works.
+// TestOpenCodeSDDOrchestratorDelegationVisibility verifies that the OpenCode
+// SDD orchestrator prompt instructs the orchestrator to emit one-line status
+// messages before and after each delegate/task call so Desktop users see
+// progress in the conversation.
+func TestOpenCodeSDDOrchestratorDelegationVisibility(t *testing.T) {
+	content := MustRead("opencode/sdd-orchestrator.md")
+
+	for _, required := range []string{
+		"#### Delegation Visibility",
+		"`delegate` or `task`",
+		"Delegating",
+		"completed",
+		"⏳",
+		"✅",
+	} {
+		if !strings.Contains(content, required) {
+			t.Fatalf("opencode/sdd-orchestrator.md missing delegation visibility wording %q", required)
+		}
+	}
+
+	// Triangulate: token budget constraint must be present to satisfy spec
+	// requirement that messages stay ≤15 tokens pre, ≤25 tokens post.
+	if !strings.Contains(content, "tokens") {
+		t.Fatal("opencode/sdd-orchestrator.md delegation visibility section must mention token constraint")
+	}
+
+	visibilityIndex := strings.Index(content, "#### Delegation Visibility")
+	workflowIndex := strings.Index(content, "## SDD Workflow")
+	if visibilityIndex == -1 || workflowIndex == -1 || visibilityIndex > workflowIndex {
+		t.Fatal("opencode/sdd-orchestrator.md delegation visibility section must appear before SDD workflow")
+	}
+}
+
 func TestMustReadPanicsOnMissingFile(t *testing.T) {
 	defer func() {
 		r := recover()

--- a/internal/assets/opencode/sdd-orchestrator.md
+++ b/internal/assets/opencode/sdd-orchestrator.md
@@ -49,6 +49,23 @@ These are parent-orchestrator stop rules. Once any trigger fires, the orchestrat
 - Use fresh reviewers after implementation, conflict resolution, or incidents because their value is independent judgment, not token saving.
 - Avoid delegation for truly local one-file fixes, quick state checks, and already-understood mechanical edits.
 
+#### Delegation Visibility
+
+Before every `delegate` or `task` call, output one line so Desktop and TUI users see progress:
+
+```
+⏳ Delegating {phase} to {agent-name}...
+```
+
+After the call returns, output one line with the outcome:
+
+```
+✅ {agent-name} completed — {status from envelope}
+⚠️ {agent-name} returned {status} — {executive_summary}
+```
+
+Keep each message ≤15 tokens (pre) and ≤25 tokens (post). Do not add multi-line output, structured blocks, or emoji beyond the prefixes shown above.
+
 ## SDD Workflow (Spec-Driven Development)
 
 SDD is the structured planning layer for substantial changes.


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #633

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [ ] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [x] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Adds OpenCode SDD orchestrator guidance to emit concise status lines before and after delegation.
- Makes OpenCode Desktop show sub-agent progress through normal assistant-visible messages.
- Adds asset coverage so the delegation visibility guidance is not accidentally removed.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/assets/opencode/sdd-orchestrator.md` | Added Delegation Visibility guidance for `delegate`/`task` calls |
| `internal/assets/assets_test.go` | Added asset test covering required delegation visibility wording and placement |

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./...
```

**E2E Tests** (Docker required)
```bash
cd e2e && ./docker-test.sh
```

- [ ] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Focused asset tests pass (`go test ./internal/assets/...`)
- [x] Focused delegation visibility test passes (`go test ./internal/assets/... -run TestOpenCodeSDDOrchestratorDelegationVisibility -v`)
- [x] Static checks pass (`go vet ./...`, `git diff --check`)

Full `go test ./...` was attempted locally. It currently fails on golden fixture comparisons outside this PR scope, so I am not marking the full unit-test checkbox as passed.

---

## 🤖 Automated Checks

The following checks run automatically on this PR:

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | PR should stay within 400 changed lines (`additions + deletions`) or use `size:exception` |
| Check Issue Reference | ⏳ | PR body must contain `Closes/Fixes/Resolves #N` |
| Check Issue Has `status:approved` | ⏳ | Linked issue must have been approved before work began |
| Check PR Has `type:*` Label | ⏳ | Exactly one `type:*` label must be applied |
| Unit Tests | ⏳ | `go test ./...` must pass |
| E2E Tests | ⏳ | `cd e2e && ./docker-test.sh` must pass |

---

## ✅ Contributor Checklist

- [ ] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [ ] I have added the appropriate `type:*` label to this PR
- [ ] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Focused tests and static checks pass
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

This intentionally avoids an OpenCode Desktop plugin or upstream OpenCode change. The first step is a low-risk Gentle AI prompt improvement: Desktop can render these as normal assistant messages, while TUI keeps its existing behavior.

Repository permissions prevent me from applying `status:approved` to #633 or `type:feature` to this PR. Docker is unavailable in this environment, so E2E should run in CI or a Docker-capable local setup.