### PR TITLE
feat(storage): Engram data-dir disk-space infra

### DIFF
--- a/internal/storage/bytes.go
+++ b/internal/storage/bytes.go
@@ -1,0 +1,23 @@
+package storage
+
+import "fmt"
+
+// FormatBytes formats n bytes as a human-readable string using 1024-based units,
+// consistent with Engram CLI output.
+func FormatBytes(n int64) string {
+	const (
+		kib = 1024
+		mib = 1024 * kib
+		gib = 1024 * mib
+	)
+	switch {
+	case n >= gib:
+		return fmt.Sprintf("%.1f GiB", float64(n)/float64(gib))
+	case n >= mib:
+		return fmt.Sprintf("%.1f MiB", float64(n)/float64(mib))
+	case n >= kib:
+		return fmt.Sprintf("%.1f KiB", float64(n)/float64(kib))
+	default:
+		return fmt.Sprintf("%d B", n)
+	}
+}

--- a/internal/storage/space.go
+++ b/internal/storage/space.go
@@ -1,9 +1,40 @@
 package storage
 
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
 // AvailableBytes returns the number of bytes available to an unprivileged user
 // on the volume containing path. path may be an existing file or directory,
 // or a path that does not yet exist — in which case the nearest existing
 // ancestor is used.
 func AvailableBytes(path string) (int64, error) {
 	return availableBytes(path)
+}
+
+func nearestExistingDir(path string) (string, error) {
+	for {
+		info, err := os.Stat(path)
+		if err == nil {
+			if info.IsDir() {
+				return path, nil
+			}
+			path = filepath.Dir(path)
+			continue
+		}
+		if errors.Is(err, os.ErrPermission) {
+			return "", fmt.Errorf("permission denied checking space at %q", path)
+		}
+		if !os.IsNotExist(err) {
+			return "", fmt.Errorf("stat %q: %w", path, err)
+		}
+		parent := filepath.Dir(path)
+		if parent == path {
+			return "", fmt.Errorf("no existing ancestor found for %q", path)
+		}
+		path = parent
+	}
 }

--- a/internal/storage/space.go
+++ b/internal/storage/space.go
@@ -1,0 +1,9 @@
+package storage
+
+// AvailableBytes returns the number of bytes available to an unprivileged user
+// on the volume containing path. path may be an existing file or directory,
+// or a path that does not yet exist — in which case the nearest existing
+// ancestor is used.
+func AvailableBytes(path string) (int64, error) {
+	return availableBytes(path)
+}

--- a/internal/storage/space_test.go
+++ b/internal/storage/space_test.go
@@ -1,0 +1,98 @@
+package storage_test
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/internal/storage"
+)
+
+func TestAvailableBytes_TempDir(t *testing.T) {
+	dir := t.TempDir()
+	n, err := storage.AvailableBytes(dir)
+	if err != nil {
+		t.Fatalf("AvailableBytes(%q): unexpected error: %v", dir, err)
+	}
+	if n <= 0 {
+		t.Fatalf("AvailableBytes(%q) = %d, want > 0", dir, n)
+	}
+}
+
+func TestAvailableBytes_File(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "space-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+
+	n, err := storage.AvailableBytes(f.Name())
+	if err != nil {
+		t.Fatalf("AvailableBytes(%q): unexpected error: %v", f.Name(), err)
+	}
+	if n <= 0 {
+		t.Fatalf("AvailableBytes(%q) = %d, want > 0", f.Name(), n)
+	}
+}
+
+// TestAvailableBytes_NonExistentChild verifies that a path whose parent exists
+// succeeds by walking up to the nearest existing ancestor. This covers the
+// copy/move preflight check where the destination directory does not exist yet.
+func TestAvailableBytes_NonExistentChild(t *testing.T) {
+	dir := t.TempDir()
+	notYet := filepath.Join(dir, "a", "b", "c", "dest")
+	n, err := storage.AvailableBytes(notYet)
+	if err != nil {
+		t.Fatalf("AvailableBytes(%q): unexpected error: %v", notYet, err)
+	}
+	if n <= 0 {
+		t.Fatalf("AvailableBytes(%q) = %d, want > 0", notYet, n)
+	}
+}
+
+// TestAvailableBytes_PermissionDenied verifies that a chmod-000 directory
+// returns a "permission denied" error, not a misleading space-check failure.
+func TestAvailableBytes_PermissionDenied(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("chmod 000 is not meaningful on Windows")
+	}
+	dir := t.TempDir()
+	restricted := filepath.Join(dir, "restricted")
+	if err := os.Mkdir(restricted, 0o000); err != nil {
+		t.Fatalf("Mkdir: %v", err)
+	}
+	t.Cleanup(func() { os.Chmod(restricted, 0o755) }) // allow cleanup
+
+	_, err := storage.AvailableBytes(restricted)
+	if err == nil {
+		t.Fatal("expected permission error, got nil")
+	}
+	if !strings.Contains(err.Error(), "permission denied") {
+		t.Errorf("error %q should mention 'permission denied'", err)
+	}
+}
+
+func TestFormatBytes(t *testing.T) {
+	tests := []struct {
+		n    int64
+		want string
+	}{
+		{0, "0 B"},
+		{512, "512 B"},
+		{1023, "1023 B"},
+		{1024, "1.0 KiB"},
+		{1536, "1.5 KiB"},
+		{1024 * 1024, "1.0 MiB"},
+		{int64(1.5 * 1024 * 1024), "1.5 MiB"},
+		{1024 * 1024 * 1024, "1.0 GiB"},
+		{int64(2469606195), "2.3 GiB"},
+	}
+	for _, tt := range tests {
+		got := storage.FormatBytes(tt.n)
+		if got != tt.want {
+			t.Errorf("FormatBytes(%d) = %q, want %q", tt.n, got, tt.want)
+		}
+	}
+}

--- a/internal/storage/space_test.go
+++ b/internal/storage/space_test.go
@@ -65,7 +65,7 @@ func TestAvailableBytes_PermissionDenied(t *testing.T) {
 	}
 	t.Cleanup(func() { os.Chmod(restricted, 0o755) }) // allow cleanup
 
-	_, err := storage.AvailableBytes(restricted)
+	_, err := storage.AvailableBytes(filepath.Join(restricted, "child"))
 	if err == nil {
 		t.Fatal("expected permission error, got nil")
 	}

--- a/internal/storage/space_unix.go
+++ b/internal/storage/space_unix.go
@@ -1,0 +1,42 @@
+//go:build !windows
+
+package storage
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+func availableBytes(path string) (int64, error) {
+	// Statfs requires an existing path. Walk up to the nearest existing ancestor
+	// so callers can pass a not-yet-created destination directory (e.g. the copy
+	// target during a data-dir management operation).
+	for {
+		info, err := os.Stat(path)
+		if err == nil {
+			if !info.IsDir() {
+				path = filepath.Dir(path)
+				continue
+			}
+			break // found an existing directory
+		}
+		parent := filepath.Dir(path)
+		if parent == path {
+			return 0, fmt.Errorf("no existing ancestor found for %q", path)
+		}
+		path = parent
+	}
+
+	var stat syscall.Statfs_t
+	if err := syscall.Statfs(path, &stat); err != nil {
+		if errors.Is(err, syscall.EACCES) {
+			return 0, fmt.Errorf("permission denied checking space at %q", path)
+		}
+		return 0, fmt.Errorf("statfs %q: %w", path, err)
+	}
+	// Bavail = blocks available to unprivileged users.
+	return int64(stat.Bavail) * int64(stat.Bsize), nil
+}

--- a/internal/storage/space_unix.go
+++ b/internal/storage/space_unix.go
@@ -5,37 +5,21 @@ package storage
 import (
 	"errors"
 	"fmt"
-	"os"
-	"path/filepath"
 	"syscall"
 )
 
 func availableBytes(path string) (int64, error) {
-	// Statfs requires an existing path. Walk up to the nearest existing ancestor
-	// so callers can pass a not-yet-created destination directory (e.g. the copy
-	// target during a data-dir management operation).
-	for {
-		info, err := os.Stat(path)
-		if err == nil {
-			if !info.IsDir() {
-				path = filepath.Dir(path)
-				continue
-			}
-			break // found an existing directory
-		}
-		parent := filepath.Dir(path)
-		if parent == path {
-			return 0, fmt.Errorf("no existing ancestor found for %q", path)
-		}
-		path = parent
+	dir, err := nearestExistingDir(path)
+	if err != nil {
+		return 0, err
 	}
 
 	var stat syscall.Statfs_t
-	if err := syscall.Statfs(path, &stat); err != nil {
+	if err := syscall.Statfs(dir, &stat); err != nil {
 		if errors.Is(err, syscall.EACCES) {
-			return 0, fmt.Errorf("permission denied checking space at %q", path)
+			return 0, fmt.Errorf("permission denied checking space at %q", dir)
 		}
-		return 0, fmt.Errorf("statfs %q: %w", path, err)
+		return 0, fmt.Errorf("statfs %q: %w", dir, err)
 	}
 	// Bavail = blocks available to unprivileged users.
 	return int64(stat.Bavail) * int64(stat.Bsize), nil

--- a/internal/storage/space_windows.go
+++ b/internal/storage/space_windows.go
@@ -5,8 +5,6 @@ package storage
 import (
 	"errors"
 	"fmt"
-	"os"
-	"path/filepath"
 	"syscall"
 	"unsafe"
 )
@@ -17,29 +15,14 @@ var (
 )
 
 func availableBytes(path string) (int64, error) {
-	// GetDiskFreeSpaceExW requires an existing directory. Walk up to the nearest
-	// existing ancestor so callers can pass a not-yet-created destination directory
-	// (e.g. the copy target during a data-dir management operation).
-	for {
-		info, err := os.Stat(path)
-		if err == nil {
-			if !info.IsDir() {
-				path = filepath.Dir(path)
-				continue
-			}
-			break // found an existing directory
-		}
-		parent := filepath.Dir(path)
-		if parent == path {
-			// Reached the filesystem root and it doesn't exist (e.g. unmounted drive).
-			return 0, fmt.Errorf("no existing ancestor found for %q", path)
-		}
-		path = parent
+	dir, err := nearestExistingDir(path)
+	if err != nil {
+		return 0, err
 	}
 
-	pathPtr, err := syscall.UTF16PtrFromString(path)
+	pathPtr, err := syscall.UTF16PtrFromString(dir)
 	if err != nil {
-		return 0, fmt.Errorf("encode path %q: %w", path, err)
+		return 0, fmt.Errorf("encode path %q: %w", dir, err)
 	}
 
 	var avail, total, free uint64
@@ -51,9 +34,9 @@ func availableBytes(path string) (int64, error) {
 	)
 	if r == 0 {
 		if errors.Is(lastErr, syscall.ERROR_ACCESS_DENIED) {
-			return 0, fmt.Errorf("permission denied checking space at %q", path)
+			return 0, fmt.Errorf("permission denied checking space at %q", dir)
 		}
-		return 0, fmt.Errorf("GetDiskFreeSpaceExW %q: %w", path, lastErr)
+		return 0, fmt.Errorf("GetDiskFreeSpaceExW %q: %w", dir, lastErr)
 	}
 	return int64(avail), nil
 }

--- a/internal/storage/space_windows.go
+++ b/internal/storage/space_windows.go
@@ -1,0 +1,59 @@
+//go:build windows
+
+package storage
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+	"unsafe"
+)
+
+var (
+	kernel32            = syscall.NewLazyDLL("kernel32.dll")
+	getDiskFreeSpaceExW = kernel32.NewProc("GetDiskFreeSpaceExW")
+)
+
+func availableBytes(path string) (int64, error) {
+	// GetDiskFreeSpaceExW requires an existing directory. Walk up to the nearest
+	// existing ancestor so callers can pass a not-yet-created destination directory
+	// (e.g. the copy target during a data-dir management operation).
+	for {
+		info, err := os.Stat(path)
+		if err == nil {
+			if !info.IsDir() {
+				path = filepath.Dir(path)
+				continue
+			}
+			break // found an existing directory
+		}
+		parent := filepath.Dir(path)
+		if parent == path {
+			// Reached the filesystem root and it doesn't exist (e.g. unmounted drive).
+			return 0, fmt.Errorf("no existing ancestor found for %q", path)
+		}
+		path = parent
+	}
+
+	pathPtr, err := syscall.UTF16PtrFromString(path)
+	if err != nil {
+		return 0, fmt.Errorf("encode path %q: %w", path, err)
+	}
+
+	var avail, total, free uint64
+	r, _, lastErr := getDiskFreeSpaceExW.Call(
+		uintptr(unsafe.Pointer(pathPtr)),
+		uintptr(unsafe.Pointer(&avail)),
+		uintptr(unsafe.Pointer(&total)),
+		uintptr(unsafe.Pointer(&free)),
+	)
+	if r == 0 {
+		if errors.Is(lastErr, syscall.ERROR_ACCESS_DENIED) {
+			return 0, fmt.Errorf("permission denied checking space at %q", path)
+		}
+		return 0, fmt.Errorf("GetDiskFreeSpaceExW %q: %w", path, lastErr)
+	}
+	return int64(avail), nil
+}


### PR DESCRIPTION
## Linked Issue

Closes #346

## PR Type

- [x] `type:feature` - Engram data-dir feature slice

Maintainer action required: add the `type:feature` label. GitHub rejected label updates from `tonyblu331` with `AddLabelsToLabelable` permission errors.

## Summary

Adds cross-platform disk-space utilities needed before moving Engram data safely.

The `feat(...)` title marks new feature capability for the Engram data-dir chain.

This is the first ready-for-review slice of the first-class Engram data-directory work. The previous attempt to open all follow-up slices against `main` was closed because it produced accumulated diffs above the 400-line review budget. Follow-up slices should be opened only when their immediate base exists in `Gentleman-Programming/gentle-ai`, or after the prior slice lands on `main`.

## Changes

| Area | What changed |
|---|---|
| `internal/storage` | Adds byte formatting and available-space checks with ancestor walking. |
| Tests | Covers formatting, missing-path ancestors, and platform space checks. |

## Test Plan

```bash
GOCACHE=G:\codex-go-tmp\gocache GOTMPDIR=G:\codex-go-tmp\gotmp TEMP=G:\codex-go-tmp\tmp TMP=G:\codex-go-tmp\tmp APPDATA=G:\codex-go-tmp\appdata XDG_CONFIG_HOME=G:\codex-go-tmp\xdg go test -count=1 ./...
```

- [x] Unit tests pass
- [x] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Manually tested locally

## Chain Context

| Field | Value |
|---|---|
| Chain strategy | Sequential upstream slices unless a maintainer creates upstream chain branches |
| Chain start | `feat/engram-dd-1-infra` |
| Chain end | `fix/engram-dd-15-operation-consistency` |
| Current slice | `feat/engram-dd-1-infra` |
| Prior dependency | none |
| Follow-up branch | `feat/engram-dd-2-domain-core` after this base exists upstream |
| Review budget | 231 changed lines |
| Out of scope | Other Engram DD slices and unrelated cleanup |

Planned review order by branch:

```text
main -> 📍 feat/engram-dd-1-infra -> feat/engram-dd-2-domain-core -> feat/engram-dd-3-domain-service -> feat/engram-dd-4-domain-locations -> feat/engram-dd-5-model-screens -> feat/engram-dd-6-tui-flow-consolidated -> fix/engram-dd-7-service-hardening -> feat/engram-dd-8-app-wiring-consolidated -> fix/engram-dd-9-test-stabilization -> fix/engram-dd-10-mcp-env-sync -> fix/engram-dd-11-data-dir-consistency -> fix/engram-dd-12-rollback-consistency -> fix/engram-dd-13-mcp-config-preservation -> test/engram-dd-14-mcp-config-preservation -> fix/engram-dd-15-operation-consistency
```

Logical slice budgets, verified against each immediate parent branch:

| Slice | Logical review budget |
|---|---:|
| `feat/engram-dd-1-infra` | 231 |
| `feat/engram-dd-2-domain-core` | 278 |
| `feat/engram-dd-3-domain-service` | 235 |
| `feat/engram-dd-4-domain-locations` | 286 |
| `feat/engram-dd-5-model-screens` | 325 |
| `feat/engram-dd-6-tui-flow-consolidated` | 349 |
| `fix/engram-dd-7-service-hardening` | 379 |
| `feat/engram-dd-8-app-wiring-consolidated` | 267 |
| `fix/engram-dd-9-test-stabilization` | 294 |
| `fix/engram-dd-10-mcp-env-sync` | 386 |
| `fix/engram-dd-11-data-dir-consistency` | 277 |
| `fix/engram-dd-12-rollback-consistency` | 289 |
| `fix/engram-dd-13-mcp-config-preservation` | 253 |
| `test/engram-dd-14-mcp-config-preservation` | 195 |
| `fix/engram-dd-15-operation-consistency` | 268 |

## Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [ ] Exactly one `type:*` label is applied (`type:feature`, maintainer action required)
- [x] Unit tests pass
- [x] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Manually tested locally
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers
