### PR TITLE
feat(engram): add data-directory domain core

### DIFF
--- a/internal/components/engram/copy.go
+++ b/internal/components/engram/copy.go
@@ -1,0 +1,66 @@
+package engram
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// CopyDB copies the Engram SQLite database from src to dst.
+//
+// It writes to a temp file first, verifies the byte count, then renames the
+// temp file into place so dst is never left with a partial copy.
+func CopyDB(src, dst string) error {
+	srcInfo, err := os.Stat(src)
+	if err != nil {
+		return fmt.Errorf("stat source %q: %w", src, err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return fmt.Errorf("create destination dir for %q: %w", dst, err)
+	}
+
+	tmp := dst + ".tmp"
+	dstFile, err := os.Create(tmp)
+	if err != nil {
+		return fmt.Errorf("create temp file %q: %w", tmp, err)
+	}
+
+	srcFile, err := os.Open(src)
+	if err != nil {
+		dstFile.Close()
+		os.Remove(tmp)
+		return fmt.Errorf("open source %q: %w", src, err)
+	}
+
+	_, copyErr := io.Copy(dstFile, srcFile)
+	srcFile.Close()
+	syncErr := dstFile.Sync()
+	dstFile.Close()
+
+	if copyErr != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("copy %q to %q: %w", src, dst, copyErr)
+	}
+	if syncErr != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("sync %q: %w", tmp, syncErr)
+	}
+
+	dstInfo, err := os.Stat(tmp)
+	if err != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("stat temp file %q: %w", tmp, err)
+	}
+	if dstInfo.Size() != srcInfo.Size() {
+		os.Remove(tmp)
+		return fmt.Errorf("incomplete copy: wrote %d bytes, expected %d", dstInfo.Size(), srcInfo.Size())
+	}
+
+	if err := os.Rename(tmp, dst); err != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("rename %q to %q: %w", tmp, dst, err)
+	}
+	return nil
+}

--- a/internal/components/engram/copy_test.go
+++ b/internal/components/engram/copy_test.go
@@ -1,0 +1,97 @@
+package engram
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCopyDB_Basic(t *testing.T) {
+	src := filepath.Join(t.TempDir(), "engram.db")
+	dst := filepath.Join(t.TempDir(), "engram.db")
+
+	content := []byte("fake sqlite database content for testing")
+	if err := os.WriteFile(src, content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := CopyDB(src, dst); err != nil {
+		t.Fatalf("CopyDB: %v", err)
+	}
+
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("read dst: %v", err)
+	}
+	if string(got) != string(content) {
+		t.Errorf("content mismatch: got %q, want %q", got, content)
+	}
+}
+
+func TestCopyDB_CreatesDestDir(t *testing.T) {
+	src := filepath.Join(t.TempDir(), "engram.db")
+	dst := filepath.Join(t.TempDir(), "subdir", "deep", "engram.db")
+
+	if err := os.WriteFile(src, []byte("data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := CopyDB(src, dst); err != nil {
+		t.Fatalf("CopyDB: %v", err)
+	}
+
+	if _, err := os.Stat(dst); err != nil {
+		t.Errorf("dst not created: %v", err)
+	}
+}
+
+func TestCopyDB_NoTempOnSuccess(t *testing.T) {
+	src := filepath.Join(t.TempDir(), "engram.db")
+	dst := filepath.Join(t.TempDir(), "engram.db")
+
+	if err := os.WriteFile(src, []byte("data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := CopyDB(src, dst); err != nil {
+		t.Fatalf("CopyDB: %v", err)
+	}
+
+	tmp := dst + ".tmp"
+	if _, err := os.Stat(tmp); !os.IsNotExist(err) {
+		t.Errorf("temp file %q should not exist after success", tmp)
+	}
+}
+
+func TestCopyDB_SourceNotExist(t *testing.T) {
+	src := filepath.Join(t.TempDir(), "nonexistent.db")
+	dst := filepath.Join(t.TempDir(), "engram.db")
+
+	err := CopyDB(src, dst)
+	if err == nil {
+		t.Fatal("expected error for missing source, got nil")
+	}
+}
+
+func TestCopyDB_Idempotent(t *testing.T) {
+	src := filepath.Join(t.TempDir(), "engram.db")
+	dst := filepath.Join(t.TempDir(), "engram.db")
+	content := []byte("idempotent copy test")
+
+	if err := os.WriteFile(src, content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	for i := 0; i < 2; i++ {
+		if err := CopyDB(src, dst); err != nil {
+			t.Fatalf("CopyDB iteration %d: %v", i, err)
+		}
+	}
+
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(content) {
+		t.Errorf("content mismatch after second copy")
+	}
+}

--- a/internal/components/engram/env.go
+++ b/internal/components/engram/env.go
@@ -1,0 +1,26 @@
+package engram
+
+import "path/filepath"
+
+// DataDirRef is the persisted reference to an Engram data directory.
+// Currently resolves to a local filesystem path.
+type DataDirRef string
+
+// Resolve returns the effective local filesystem path for the data directory.
+// An empty ref resolves to the platform default (~/.engram).
+func (r DataDirRef) Resolve(homeDir string) string {
+	if r == "" {
+		return DefaultDir(homeDir)
+	}
+	return filepath.Clean(filepath.FromSlash(string(r)))
+}
+
+// DefaultDir returns the default Engram data directory path (~/.engram).
+func DefaultDir(homeDir string) string {
+	return filepath.Join(homeDir, ".engram")
+}
+
+// DBPath returns the path to the Engram SQLite database inside dataDir.
+func DBPath(dataDir string) string {
+	return filepath.Join(dataDir, "engram.db")
+}

--- a/internal/components/engram/env_test.go
+++ b/internal/components/engram/env_test.go
@@ -1,0 +1,43 @@
+package engram
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestDataDirRef_Resolve(t *testing.T) {
+	home := t.TempDir()
+	custom := filepath.Join(home, "custom-data")
+
+	tests := []struct {
+		ref  DataDirRef
+		want string
+	}{
+		{"", DefaultDir(home)},
+		{DataDirRef(DefaultDir(home)), DefaultDir(home)},
+		{DataDirRef(custom), custom},
+		{DataDirRef(custom + string(filepath.Separator)), custom},
+	}
+	for _, tt := range tests {
+		got := tt.ref.Resolve(home)
+		if got != tt.want {
+			t.Errorf("DataDirRef(%q).Resolve(%q) = %q, want %q", tt.ref, home, got, tt.want)
+		}
+	}
+}
+
+func TestDefaultDir(t *testing.T) {
+	got := DefaultDir("/home/user")
+	want := filepath.Join("/home/user", ".engram")
+	if got != want {
+		t.Errorf("DefaultDir = %q, want %q", got, want)
+	}
+}
+
+func TestDBPath(t *testing.T) {
+	got := DBPath("/home/user/.engram")
+	want := filepath.Join("/home/user/.engram", "engram.db")
+	if got != want {
+		t.Errorf("DBPath = %q, want %q", got, want)
+	}
+}

--- a/internal/components/engram/presenter.go
+++ b/internal/components/engram/presenter.go
@@ -1,0 +1,20 @@
+package engram
+
+import (
+	"fmt"
+
+	"github.com/gentleman-programming/gentle-ai/internal/storage"
+)
+
+// FormatDirLine returns a single display line for a data-directory option.
+func FormatDirLine(dir string, dbSize int64) string {
+	if dbSize <= 0 {
+		return dir
+	}
+	return fmt.Sprintf("%s  (%s used)", dir, storage.FormatBytes(dbSize))
+}
+
+// FormatSpaceWarning returns a human-readable warning for insufficient disk.
+func FormatSpaceWarning(needed, avail int64) string {
+	return fmt.Sprintf("Need %s, only %s free", storage.FormatBytes(needed), storage.FormatBytes(avail))
+}

--- a/internal/components/engram/presenter_test.go
+++ b/internal/components/engram/presenter_test.go
@@ -1,0 +1,26 @@
+package engram
+
+import "testing"
+
+func TestFormatDirLine_NoSize(t *testing.T) {
+	got := FormatDirLine("/home/user/.engram", 0)
+	if got != "/home/user/.engram" {
+		t.Errorf("got %q, want path-only when dbSize=0", got)
+	}
+}
+
+func TestFormatDirLine_WithSize(t *testing.T) {
+	got := FormatDirLine("/home/user/.engram", 1024*1024*1024)
+	want := "/home/user/.engram  (1.0 GiB used)"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFormatSpaceWarning(t *testing.T) {
+	got := FormatSpaceWarning(1024*1024*1024, 300*1024*1024)
+	want := "Need 1.0 GiB, only 300.0 MiB free"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}

--- a/internal/storage/bytes.go
+++ b/internal/storage/bytes.go
@@ -1,0 +1,23 @@
+package storage
+
+import "fmt"
+
+// FormatBytes formats n bytes as a human-readable string using 1024-based units,
+// consistent with Engram CLI output.
+func FormatBytes(n int64) string {
+	const (
+		kib = 1024
+		mib = 1024 * kib
+		gib = 1024 * mib
+	)
+	switch {
+	case n >= gib:
+		return fmt.Sprintf("%.1f GiB", float64(n)/float64(gib))
+	case n >= mib:
+		return fmt.Sprintf("%.1f MiB", float64(n)/float64(mib))
+	case n >= kib:
+		return fmt.Sprintf("%.1f KiB", float64(n)/float64(kib))
+	default:
+		return fmt.Sprintf("%d B", n)
+	}
+}

--- a/internal/storage/space.go
+++ b/internal/storage/space.go
@@ -1,0 +1,9 @@
+package storage
+
+// AvailableBytes returns the number of bytes available to an unprivileged user
+// on the volume containing path. path may be an existing file or directory,
+// or a path that does not yet exist — in which case the nearest existing
+// ancestor is used.
+func AvailableBytes(path string) (int64, error) {
+	return availableBytes(path)
+}

--- a/internal/storage/space_test.go
+++ b/internal/storage/space_test.go
@@ -1,0 +1,98 @@
+package storage_test
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/internal/storage"
+)
+
+func TestAvailableBytes_TempDir(t *testing.T) {
+	dir := t.TempDir()
+	n, err := storage.AvailableBytes(dir)
+	if err != nil {
+		t.Fatalf("AvailableBytes(%q): unexpected error: %v", dir, err)
+	}
+	if n <= 0 {
+		t.Fatalf("AvailableBytes(%q) = %d, want > 0", dir, n)
+	}
+}
+
+func TestAvailableBytes_File(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "space-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+
+	n, err := storage.AvailableBytes(f.Name())
+	if err != nil {
+		t.Fatalf("AvailableBytes(%q): unexpected error: %v", f.Name(), err)
+	}
+	if n <= 0 {
+		t.Fatalf("AvailableBytes(%q) = %d, want > 0", f.Name(), n)
+	}
+}
+
+// TestAvailableBytes_NonExistentChild verifies that a path whose parent exists
+// succeeds by walking up to the nearest existing ancestor. This covers the
+// copy/move preflight check where the destination directory does not exist yet.
+func TestAvailableBytes_NonExistentChild(t *testing.T) {
+	dir := t.TempDir()
+	notYet := filepath.Join(dir, "a", "b", "c", "dest")
+	n, err := storage.AvailableBytes(notYet)
+	if err != nil {
+		t.Fatalf("AvailableBytes(%q): unexpected error: %v", notYet, err)
+	}
+	if n <= 0 {
+		t.Fatalf("AvailableBytes(%q) = %d, want > 0", notYet, n)
+	}
+}
+
+// TestAvailableBytes_PermissionDenied verifies that a chmod-000 directory
+// returns a "permission denied" error, not a misleading space-check failure.
+func TestAvailableBytes_PermissionDenied(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("chmod 000 is not meaningful on Windows")
+	}
+	dir := t.TempDir()
+	restricted := filepath.Join(dir, "restricted")
+	if err := os.Mkdir(restricted, 0o000); err != nil {
+		t.Fatalf("Mkdir: %v", err)
+	}
+	t.Cleanup(func() { os.Chmod(restricted, 0o755) }) // allow cleanup
+
+	_, err := storage.AvailableBytes(restricted)
+	if err == nil {
+		t.Fatal("expected permission error, got nil")
+	}
+	if !strings.Contains(err.Error(), "permission denied") {
+		t.Errorf("error %q should mention 'permission denied'", err)
+	}
+}
+
+func TestFormatBytes(t *testing.T) {
+	tests := []struct {
+		n    int64
+		want string
+	}{
+		{0, "0 B"},
+		{512, "512 B"},
+		{1023, "1023 B"},
+		{1024, "1.0 KiB"},
+		{1536, "1.5 KiB"},
+		{1024 * 1024, "1.0 MiB"},
+		{int64(1.5 * 1024 * 1024), "1.5 MiB"},
+		{1024 * 1024 * 1024, "1.0 GiB"},
+		{int64(2469606195), "2.3 GiB"},
+	}
+	for _, tt := range tests {
+		got := storage.FormatBytes(tt.n)
+		if got != tt.want {
+			t.Errorf("FormatBytes(%d) = %q, want %q", tt.n, got, tt.want)
+		}
+	}
+}

--- a/internal/storage/space_unix.go
+++ b/internal/storage/space_unix.go
@@ -1,0 +1,42 @@
+//go:build !windows
+
+package storage
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+func availableBytes(path string) (int64, error) {
+	// Statfs requires an existing path. Walk up to the nearest existing ancestor
+	// so callers can pass a not-yet-created destination directory (e.g. the copy
+	// target during a data-dir management operation).
+	for {
+		info, err := os.Stat(path)
+		if err == nil {
+			if !info.IsDir() {
+				path = filepath.Dir(path)
+				continue
+			}
+			break // found an existing directory
+		}
+		parent := filepath.Dir(path)
+		if parent == path {
+			return 0, fmt.Errorf("no existing ancestor found for %q", path)
+		}
+		path = parent
+	}
+
+	var stat syscall.Statfs_t
+	if err := syscall.Statfs(path, &stat); err != nil {
+		if errors.Is(err, syscall.EACCES) {
+			return 0, fmt.Errorf("permission denied checking space at %q", path)
+		}
+		return 0, fmt.Errorf("statfs %q: %w", path, err)
+	}
+	// Bavail = blocks available to unprivileged users.
+	return int64(stat.Bavail) * int64(stat.Bsize), nil
+}

--- a/internal/storage/space_windows.go
+++ b/internal/storage/space_windows.go
@@ -1,0 +1,59 @@
+//go:build windows
+
+package storage
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+	"unsafe"
+)
+
+var (
+	kernel32            = syscall.NewLazyDLL("kernel32.dll")
+	getDiskFreeSpaceExW = kernel32.NewProc("GetDiskFreeSpaceExW")
+)
+
+func availableBytes(path string) (int64, error) {
+	// GetDiskFreeSpaceExW requires an existing directory. Walk up to the nearest
+	// existing ancestor so callers can pass a not-yet-created destination directory
+	// (e.g. the copy target during a data-dir management operation).
+	for {
+		info, err := os.Stat(path)
+		if err == nil {
+			if !info.IsDir() {
+				path = filepath.Dir(path)
+				continue
+			}
+			break // found an existing directory
+		}
+		parent := filepath.Dir(path)
+		if parent == path {
+			// Reached the filesystem root and it doesn't exist (e.g. unmounted drive).
+			return 0, fmt.Errorf("no existing ancestor found for %q", path)
+		}
+		path = parent
+	}
+
+	pathPtr, err := syscall.UTF16PtrFromString(path)
+	if err != nil {
+		return 0, fmt.Errorf("encode path %q: %w", path, err)
+	}
+
+	var avail, total, free uint64
+	r, _, lastErr := getDiskFreeSpaceExW.Call(
+		uintptr(unsafe.Pointer(pathPtr)),
+		uintptr(unsafe.Pointer(&avail)),
+		uintptr(unsafe.Pointer(&total)),
+		uintptr(unsafe.Pointer(&free)),
+	)
+	if r == 0 {
+		if errors.Is(lastErr, syscall.ERROR_ACCESS_DENIED) {
+			return 0, fmt.Errorf("permission denied checking space at %q", path)
+		}
+		return 0, fmt.Errorf("GetDiskFreeSpaceExW %q: %w", path, lastErr)
+	}
+	return int64(avail), nil
+}


### PR DESCRIPTION
## Linked Issue

Closes #346

## PR Type

- [x] `type:feature` - Engram data-dir feature slice

## Summary

Adds core Engram data-dir helpers, default paths, DB paths, copy primitive, and display formatting.

The `feat(...)` title marks new feature capability for the Engram data-dir chain.

This PR is part of the first-class Engram data-directory feature chain. Review it in chain order so each slice is evaluated against its immediate base.

## Changes

| Area | What changed |
|---|---|
| `internal/components/engram` | Adds data-dir refs, default path resolution, DB copy, and presenter helpers. |
| Tests | Covers default/custom dirs, copy behavior, and display formatting. |

## Test Plan

```bash
GOCACHE=G:\codex-go-tmp\gocache GOTMPDIR=G:\codex-go-tmp\gotmp TEMP=G:\codex-go-tmp\tmp TMP=G:\codex-go-tmp\tmp APPDATA=G:\codex-go-tmp\appdata XDG_CONFIG_HOME=G:\codex-go-tmp\xdg go test -count=1 ./...
```

- [x] Unit tests pass
- [x] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Manually tested locally

## Chain Context

| Field | Value |
|---|---|
| Chain start | `feat/engram-dd-1-infra` |
| Chain end | `fix/engram-dd-15-operation-consistency` |
| Current slice | #2 `feat/engram-dd-2-domain-core` |
| Prior dependency | #1 `feat/engram-dd-1-infra` |
| Follow-up work | #3 `feat/engram-dd-3-domain-service` |
| Review budget | 278 changed lines |
| Out of scope | Other Engram DD slices and unrelated cleanup |

Review order: #1 -> #2 -> #3 -> #4 -> #18 -> #19 -> #20 -> #21 -> #22 -> #23 -> #24 -> #25 -> #26 -> #27 -> #28

```text
#1 -> 📍 #2 -> #3
```

## Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [x] Exactly one `type:*` label is applied
- [x] Unit tests pass
- [x] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Manually tested locally
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers

