### PR TITLE
feat(tui): add Engram data-dir model and screens

### DIFF
--- a/internal/components/engram/copy.go
+++ b/internal/components/engram/copy.go
@@ -1,0 +1,66 @@
+package engram
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// CopyDB copies the Engram SQLite database from src to dst.
+//
+// It writes to a temp file first, verifies the byte count, then renames the
+// temp file into place so dst is never left with a partial copy.
+func CopyDB(src, dst string) error {
+	srcInfo, err := os.Stat(src)
+	if err != nil {
+		return fmt.Errorf("stat source %q: %w", src, err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return fmt.Errorf("create destination dir for %q: %w", dst, err)
+	}
+
+	tmp := dst + ".tmp"
+	dstFile, err := os.Create(tmp)
+	if err != nil {
+		return fmt.Errorf("create temp file %q: %w", tmp, err)
+	}
+
+	srcFile, err := os.Open(src)
+	if err != nil {
+		dstFile.Close()
+		os.Remove(tmp)
+		return fmt.Errorf("open source %q: %w", src, err)
+	}
+
+	_, copyErr := io.Copy(dstFile, srcFile)
+	srcFile.Close()
+	syncErr := dstFile.Sync()
+	dstFile.Close()
+
+	if copyErr != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("copy %q to %q: %w", src, dst, copyErr)
+	}
+	if syncErr != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("sync %q: %w", tmp, syncErr)
+	}
+
+	dstInfo, err := os.Stat(tmp)
+	if err != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("stat temp file %q: %w", tmp, err)
+	}
+	if dstInfo.Size() != srcInfo.Size() {
+		os.Remove(tmp)
+		return fmt.Errorf("incomplete copy: wrote %d bytes, expected %d", dstInfo.Size(), srcInfo.Size())
+	}
+
+	if err := os.Rename(tmp, dst); err != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("rename %q to %q: %w", tmp, dst, err)
+	}
+	return nil
+}

--- a/internal/components/engram/copy_test.go
+++ b/internal/components/engram/copy_test.go
@@ -1,0 +1,97 @@
+package engram
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCopyDB_Basic(t *testing.T) {
+	src := filepath.Join(t.TempDir(), "engram.db")
+	dst := filepath.Join(t.TempDir(), "engram.db")
+
+	content := []byte("fake sqlite database content for testing")
+	if err := os.WriteFile(src, content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := CopyDB(src, dst); err != nil {
+		t.Fatalf("CopyDB: %v", err)
+	}
+
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("read dst: %v", err)
+	}
+	if string(got) != string(content) {
+		t.Errorf("content mismatch: got %q, want %q", got, content)
+	}
+}
+
+func TestCopyDB_CreatesDestDir(t *testing.T) {
+	src := filepath.Join(t.TempDir(), "engram.db")
+	dst := filepath.Join(t.TempDir(), "subdir", "deep", "engram.db")
+
+	if err := os.WriteFile(src, []byte("data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := CopyDB(src, dst); err != nil {
+		t.Fatalf("CopyDB: %v", err)
+	}
+
+	if _, err := os.Stat(dst); err != nil {
+		t.Errorf("dst not created: %v", err)
+	}
+}
+
+func TestCopyDB_NoTempOnSuccess(t *testing.T) {
+	src := filepath.Join(t.TempDir(), "engram.db")
+	dst := filepath.Join(t.TempDir(), "engram.db")
+
+	if err := os.WriteFile(src, []byte("data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := CopyDB(src, dst); err != nil {
+		t.Fatalf("CopyDB: %v", err)
+	}
+
+	tmp := dst + ".tmp"
+	if _, err := os.Stat(tmp); !os.IsNotExist(err) {
+		t.Errorf("temp file %q should not exist after success", tmp)
+	}
+}
+
+func TestCopyDB_SourceNotExist(t *testing.T) {
+	src := filepath.Join(t.TempDir(), "nonexistent.db")
+	dst := filepath.Join(t.TempDir(), "engram.db")
+
+	err := CopyDB(src, dst)
+	if err == nil {
+		t.Fatal("expected error for missing source, got nil")
+	}
+}
+
+func TestCopyDB_Idempotent(t *testing.T) {
+	src := filepath.Join(t.TempDir(), "engram.db")
+	dst := filepath.Join(t.TempDir(), "engram.db")
+	content := []byte("idempotent copy test")
+
+	if err := os.WriteFile(src, content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	for i := 0; i < 2; i++ {
+		if err := CopyDB(src, dst); err != nil {
+			t.Fatalf("CopyDB iteration %d: %v", i, err)
+		}
+	}
+
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(content) {
+		t.Errorf("content mismatch after second copy")
+	}
+}

--- a/internal/components/engram/datadir_ops.go
+++ b/internal/components/engram/datadir_ops.go
@@ -1,0 +1,43 @@
+package engram
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"github.com/gentleman-programming/gentle-ai/internal/storage"
+)
+
+// DataDirHasContent reports whether dataDir exists and contains any files.
+func DataDirHasContent(dataDir string) bool {
+	entries, err := os.ReadDir(dataDir)
+	return err == nil && len(entries) > 0
+}
+
+// DataDirSize returns the combined size of all regular files under dataDir.
+func DataDirSize(dataDir string) int64 {
+	var total int64
+	_ = filepath.WalkDir(dataDir, func(_ string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil
+		}
+		if info, infoErr := d.Info(); infoErr == nil {
+			total += info.Size()
+		}
+		return nil
+	})
+	return total
+}
+
+// DiskSpaceOKForDataDir reports whether dst has enough free bytes for dataDir.
+func DiskSpaceOKForDataDir(srcDataDir, dst string) (ok bool, needed, avail int64, err error) {
+	needed = DataDirSize(srcDataDir)
+	if needed == 0 {
+		return true, 0, 0, nil
+	}
+	avail, err = storage.AvailableBytes(dst)
+	if err != nil {
+		return false, needed, 0, err
+	}
+	return avail > needed, needed, avail, nil
+}

--- a/internal/components/engram/datadir_ops_test.go
+++ b/internal/components/engram/datadir_ops_test.go
@@ -1,0 +1,47 @@
+package engram
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDataDirHasContent(t *testing.T) {
+	dir := t.TempDir()
+	if DataDirHasContent(dir) {
+		t.Fatal("empty dir should not have content")
+	}
+	if err := os.WriteFile(filepath.Join(dir, "engram.db"), []byte("db"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if !DataDirHasContent(dir) {
+		t.Fatal("dir with file should have content")
+	}
+}
+
+func TestDataDirSize(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "a"), []byte("abc"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sub := filepath.Join(dir, "sub")
+	if err := os.Mkdir(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sub, "b"), []byte("de"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := DataDirSize(dir); got != 5 {
+		t.Errorf("DataDirSize = %d, want 5", got)
+	}
+}
+
+func TestDiskSpaceOKForDataDir_EmptySource(t *testing.T) {
+	ok, needed, avail, err := DiskSpaceOKForDataDir(t.TempDir(), t.TempDir())
+	if err != nil {
+		t.Fatalf("DiskSpaceOKForDataDir: %v", err)
+	}
+	if !ok || needed != 0 || avail != 0 {
+		t.Fatalf("got ok=%v needed=%d avail=%d, want true/0/0", ok, needed, avail)
+	}
+}

--- a/internal/components/engram/env.go
+++ b/internal/components/engram/env.go
@@ -1,0 +1,26 @@
+package engram
+
+import "path/filepath"
+
+// DataDirRef is the persisted reference to an Engram data directory.
+// Currently resolves to a local filesystem path.
+type DataDirRef string
+
+// Resolve returns the effective local filesystem path for the data directory.
+// An empty ref resolves to the platform default (~/.engram).
+func (r DataDirRef) Resolve(homeDir string) string {
+	if r == "" {
+		return DefaultDir(homeDir)
+	}
+	return filepath.Clean(filepath.FromSlash(string(r)))
+}
+
+// DefaultDir returns the default Engram data directory path (~/.engram).
+func DefaultDir(homeDir string) string {
+	return filepath.Join(homeDir, ".engram")
+}
+
+// DBPath returns the path to the Engram SQLite database inside dataDir.
+func DBPath(dataDir string) string {
+	return filepath.Join(dataDir, "engram.db")
+}

--- a/internal/components/engram/env_test.go
+++ b/internal/components/engram/env_test.go
@@ -1,0 +1,43 @@
+package engram
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestDataDirRef_Resolve(t *testing.T) {
+	home := t.TempDir()
+	custom := filepath.Join(home, "custom-data")
+
+	tests := []struct {
+		ref  DataDirRef
+		want string
+	}{
+		{"", DefaultDir(home)},
+		{DataDirRef(DefaultDir(home)), DefaultDir(home)},
+		{DataDirRef(custom), custom},
+		{DataDirRef(custom + string(filepath.Separator)), custom},
+	}
+	for _, tt := range tests {
+		got := tt.ref.Resolve(home)
+		if got != tt.want {
+			t.Errorf("DataDirRef(%q).Resolve(%q) = %q, want %q", tt.ref, home, got, tt.want)
+		}
+	}
+}
+
+func TestDefaultDir(t *testing.T) {
+	got := DefaultDir("/home/user")
+	want := filepath.Join("/home/user", ".engram")
+	if got != want {
+		t.Errorf("DefaultDir = %q, want %q", got, want)
+	}
+}
+
+func TestDBPath(t *testing.T) {
+	got := DBPath("/home/user/.engram")
+	want := filepath.Join("/home/user/.engram", "engram.db")
+	if got != want {
+		t.Errorf("DBPath = %q, want %q", got, want)
+	}
+}

--- a/internal/components/engram/locations.go
+++ b/internal/components/engram/locations.go
@@ -1,0 +1,73 @@
+package engram
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/gentleman-programming/gentle-ai/internal/storage"
+)
+
+// Location is a candidate Engram data directory the user can choose from.
+type Location struct {
+	Path      string
+	Label     string
+	Available int64
+	IsCurrent bool
+}
+
+// SuggestLocations returns ordered candidate data directories.
+func SuggestLocations(homeDir, currentDir string) []Location {
+	return SuggestLocationsWithKnown(homeDir, currentDir, nil)
+}
+
+// SuggestLocationsWithKnown adds remembered non-active dirs after the default.
+func SuggestLocationsWithKnown(homeDir, currentDir string, knownDirs []string) []Location {
+	seen := map[string]bool{}
+	var out []Location
+
+	add := func(path string, isCurrent bool) {
+		clean := filepath.Clean(path)
+		if seen[clean] {
+			return
+		}
+		seen[clean] = true
+		avail, err := storage.AvailableBytes(filepath.Dir(clean))
+		if err != nil {
+			avail = -1
+		}
+		out = append(out, Location{
+			Path:      clean,
+			Label:     buildLabel(clean, homeDir, avail),
+			Available: avail,
+			IsCurrent: isCurrent,
+		})
+	}
+
+	if currentDir != "" {
+		add(currentDir, true)
+	}
+	add(DefaultDir(homeDir), currentDir == "")
+	for _, dir := range knownDirs {
+		add(dir, false)
+	}
+	for _, vol := range platformVolumes() {
+		add(filepath.Join(vol, "Engram"), false)
+	}
+	return out
+}
+
+func buildLabel(path, homeDir string, available int64) string {
+	display := path
+	if rel, err := filepath.Rel(homeDir, path); err == nil && len(rel) < len(path) {
+		display = filepath.Join("~", rel)
+	}
+	if available < 0 {
+		return display
+	}
+	return display + "  (" + storage.FormatBytes(available) + " free)"
+}
+
+func dirExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
+}

--- a/internal/components/engram/locations_test.go
+++ b/internal/components/engram/locations_test.go
@@ -1,0 +1,70 @@
+package engram
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestSuggestLocations_DefaultFirst(t *testing.T) {
+	home := t.TempDir()
+
+	locs := SuggestLocations(home, "")
+	if len(locs) == 0 {
+		t.Fatal("SuggestLocations returned no locations")
+	}
+	want := filepath.Clean(DefaultDir(home))
+	if locs[0].Path != want {
+		t.Errorf("first location = %q, want default %q", locs[0].Path, want)
+	}
+}
+
+func TestSuggestLocations_CurrentFirst(t *testing.T) {
+	home := t.TempDir()
+	current := filepath.Join(home, "custom-engram")
+
+	locs := SuggestLocations(home, current)
+	if len(locs) == 0 {
+		t.Fatal("SuggestLocations returned no locations")
+	}
+	if locs[0].Path != filepath.Clean(current) {
+		t.Errorf("first location = %q, want current %q", locs[0].Path, current)
+	}
+	if !locs[0].IsCurrent {
+		t.Error("first location IsCurrent should be true")
+	}
+}
+
+func TestSuggestLocationsWithKnown_NoDuplicates(t *testing.T) {
+	home := t.TempDir()
+	defaultDir := DefaultDir(home)
+	locs := SuggestLocationsWithKnown(home, defaultDir, []string{defaultDir})
+
+	seen := map[string]int{}
+	for _, loc := range locs {
+		seen[loc.Path]++
+	}
+	for path, count := range seen {
+		if count > 1 {
+			t.Errorf("path %q appears %d times, want 1", path, count)
+		}
+	}
+}
+
+func TestBuildLabel_HomePrefix(t *testing.T) {
+	home := "/home/user"
+	path := filepath.Join(home, ".engram")
+	label := buildLabel(path, home, -1)
+	if label != filepath.Join("~", ".engram") {
+		t.Errorf("buildLabel = %q, want %q", label, filepath.Join("~", ".engram"))
+	}
+}
+
+func TestBuildLabel_WithFreeSpace(t *testing.T) {
+	home := "/home/user"
+	path := filepath.Join(home, ".engram")
+	label := buildLabel(path, home, 1024*1024*1024)
+	want := filepath.Join("~", ".engram") + "  (1.0 GiB free)"
+	if label != want {
+		t.Errorf("buildLabel = %q, want %q", label, want)
+	}
+}

--- a/internal/components/engram/locations_unix.go
+++ b/internal/components/engram/locations_unix.go
@@ -1,0 +1,18 @@
+//go:build !windows
+
+package engram
+
+import "path/filepath"
+
+func platformVolumes() []string {
+	var roots []string
+	for _, glob := range []string{"/Volumes/*", "/mnt/*", "/media/*/*"} {
+		matches, _ := filepath.Glob(glob)
+		for _, m := range matches {
+			if dirExists(m) {
+				roots = append(roots, m)
+			}
+		}
+	}
+	return roots
+}

--- a/internal/components/engram/locations_windows.go
+++ b/internal/components/engram/locations_windows.go
@@ -1,0 +1,35 @@
+//go:build windows
+
+package engram
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+var (
+	_kernel32            = syscall.NewLazyDLL("kernel32.dll")
+	_getDiskFreeSpaceExW = _kernel32.NewProc("GetDiskFreeSpaceExW")
+)
+
+func platformVolumes() []string {
+	var roots []string
+	for c := 'A'; c <= 'Z'; c++ {
+		root := string(c) + ":\\"
+		ptr, err := syscall.UTF16PtrFromString(root)
+		if err != nil {
+			continue
+		}
+		var avail, total, free uint64
+		r, _, _ := _getDiskFreeSpaceExW.Call(
+			uintptr(unsafe.Pointer(ptr)),
+			uintptr(unsafe.Pointer(&avail)),
+			uintptr(unsafe.Pointer(&total)),
+			uintptr(unsafe.Pointer(&free)),
+		)
+		if r != 0 {
+			roots = append(roots, root)
+		}
+	}
+	return roots
+}

--- a/internal/components/engram/presenter.go
+++ b/internal/components/engram/presenter.go
@@ -1,0 +1,20 @@
+package engram
+
+import (
+	"fmt"
+
+	"github.com/gentleman-programming/gentle-ai/internal/storage"
+)
+
+// FormatDirLine returns a single display line for a data-directory option.
+func FormatDirLine(dir string, dbSize int64) string {
+	if dbSize <= 0 {
+		return dir
+	}
+	return fmt.Sprintf("%s  (%s used)", dir, storage.FormatBytes(dbSize))
+}
+
+// FormatSpaceWarning returns a human-readable warning for insufficient disk.
+func FormatSpaceWarning(needed, avail int64) string {
+	return fmt.Sprintf("Need %s, only %s free", storage.FormatBytes(needed), storage.FormatBytes(avail))
+}

--- a/internal/components/engram/presenter_test.go
+++ b/internal/components/engram/presenter_test.go
@@ -1,0 +1,26 @@
+package engram
+
+import "testing"
+
+func TestFormatDirLine_NoSize(t *testing.T) {
+	got := FormatDirLine("/home/user/.engram", 0)
+	if got != "/home/user/.engram" {
+		t.Errorf("got %q, want path-only when dbSize=0", got)
+	}
+}
+
+func TestFormatDirLine_WithSize(t *testing.T) {
+	got := FormatDirLine("/home/user/.engram", 1024*1024*1024)
+	want := "/home/user/.engram  (1.0 GiB used)"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFormatSpaceWarning(t *testing.T) {
+	got := FormatSpaceWarning(1024*1024*1024, 300*1024*1024)
+	want := "Need 1.0 GiB, only 300.0 MiB free"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}

--- a/internal/components/engram/service.go
+++ b/internal/components/engram/service.go
@@ -1,0 +1,91 @@
+package engram
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/gentleman-programming/gentle-ai/internal/backup"
+	"github.com/gentleman-programming/gentle-ai/internal/storage"
+)
+
+type snapshotter interface {
+	Create(snapshotDir string, paths []string) (backup.Manifest, error)
+}
+
+// DataDirService provides snapshot-guarded operations on the Engram data dir.
+type DataDirService struct {
+	homeDir     string
+	backupRoot  string
+	snapshotter snapshotter
+}
+
+// NewDataDirService creates a DataDirService with the default snapshotter.
+func NewDataDirService(homeDir string) DataDirService {
+	return DataDirService{
+		homeDir:     homeDir,
+		backupRoot:  filepath.Join(homeDir, ".gentle-ai", "backups"),
+		snapshotter: backup.NewSnapshotter(),
+	}
+}
+
+// CopyTo snapshots the current DB, then copies it to dst.
+func (s DataDirService) CopyTo(currentDir, dst string) (backup.Manifest, error) {
+	srcDB := DBPath(currentDir)
+	snap, err := s.snapshot(srcDB)
+	if err != nil {
+		return backup.Manifest{}, fmt.Errorf("snapshot before copy: %w", err)
+	}
+	if err := CopyDB(srcDB, DBPath(dst)); err != nil {
+		return snap, fmt.Errorf("copy: %w", err)
+	}
+	return snap, nil
+}
+
+// MoveTo snapshots the current DB, copies it to dst, then removes the source.
+func (s DataDirService) MoveTo(currentDir, dst string) (backup.Manifest, error) {
+	snap, err := s.CopyTo(currentDir, dst)
+	if err != nil {
+		return snap, err
+	}
+	if err := os.Remove(DBPath(currentDir)); err != nil && !os.IsNotExist(err) {
+		return snap, fmt.Errorf("remove source after move: %w", err)
+	}
+	return snap, nil
+}
+
+// Delete snapshots the current DB, then removes it.
+func (s DataDirService) Delete(dataDir string) (backup.Manifest, error) {
+	dbPath := DBPath(dataDir)
+	snap, err := s.snapshot(dbPath)
+	if err != nil {
+		return backup.Manifest{}, fmt.Errorf("snapshot before delete: %w", err)
+	}
+	if err := os.Remove(dbPath); err != nil && !os.IsNotExist(err) {
+		return snap, fmt.Errorf("delete: %w", err)
+	}
+	return snap, nil
+}
+
+// DiskSpaceOK reports whether dst has enough free space for srcDB.
+func (s DataDirService) DiskSpaceOK(srcDB, dst string) (bool, int64, int64, error) {
+	info, err := os.Stat(srcDB)
+	if err != nil {
+		return false, 0, 0, fmt.Errorf("stat source DB %q: %w", srcDB, err)
+	}
+	avail, err := storage.AvailableBytes(dst)
+	if err != nil {
+		return false, 0, 0, fmt.Errorf("check available space at %q: %w", dst, err)
+	}
+	needed := info.Size()
+	return avail > needed, needed, avail, nil
+}
+
+func (s DataDirService) snapshot(dbPath string) (backup.Manifest, error) {
+	if err := os.MkdirAll(s.backupRoot, 0o755); err != nil {
+		return backup.Manifest{}, fmt.Errorf("create backup root %q: %w", s.backupRoot, err)
+	}
+	snapshotDir := filepath.Join(s.backupRoot, time.Now().UTC().Format("20060102150405.000000000"))
+	return s.snapshotter.Create(snapshotDir, []string{dbPath})
+}

--- a/internal/components/engram/service_test.go
+++ b/internal/components/engram/service_test.go
@@ -1,0 +1,144 @@
+package engram
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/internal/backup"
+)
+
+type stubSnapshotter struct {
+	err      error
+	manifest backup.Manifest
+}
+
+func (s stubSnapshotter) Create(_ string, _ []string) (backup.Manifest, error) {
+	return s.manifest, s.err
+}
+
+func newTestService(t *testing.T) (DataDirService, string) {
+	t.Helper()
+	home := t.TempDir()
+	svc := DataDirService{
+		homeDir:     home,
+		backupRoot:  filepath.Join(home, ".gentle-ai", "backups"),
+		snapshotter: stubSnapshotter{manifest: backup.Manifest{ID: "snap-abc123"}},
+	}
+	return svc, home
+}
+
+func writeTestDB(t *testing.T, dir string) string {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := DBPath(dir)
+	if err := os.WriteFile(path, []byte("fake-sqlite"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestDataDirService_CopyTo(t *testing.T) {
+	svc, home := newTestService(t)
+	src := filepath.Join(home, "src-data")
+	dst := filepath.Join(home, "dst-data")
+	writeTestDB(t, src)
+
+	snap, err := svc.CopyTo(src, dst)
+	if err != nil {
+		t.Fatalf("CopyTo: %v", err)
+	}
+	if snap.ID != "snap-abc123" {
+		t.Errorf("snap.ID = %q, want snap-abc123", snap.ID)
+	}
+	if _, err := os.Stat(DBPath(src)); err != nil {
+		t.Errorf("source DB removed after CopyTo: %v", err)
+	}
+	if _, err := os.Stat(DBPath(dst)); err != nil {
+		t.Errorf("dst DB not created: %v", err)
+	}
+}
+
+func TestDataDirService_MoveTo(t *testing.T) {
+	svc, home := newTestService(t)
+	src := filepath.Join(home, "src-data")
+	dst := filepath.Join(home, "dst-data")
+	writeTestDB(t, src)
+
+	if _, err := svc.MoveTo(src, dst); err != nil {
+		t.Fatalf("MoveTo: %v", err)
+	}
+	if _, err := os.Stat(DBPath(src)); !os.IsNotExist(err) {
+		t.Error("source DB should not exist after MoveTo")
+	}
+	if _, err := os.Stat(DBPath(dst)); err != nil {
+		t.Errorf("dst DB not created: %v", err)
+	}
+}
+
+func TestDataDirService_Delete(t *testing.T) {
+	svc, home := newTestService(t)
+	dir := filepath.Join(home, "data")
+	writeTestDB(t, dir)
+
+	snap, err := svc.Delete(dir)
+	if err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if snap.ID != "snap-abc123" {
+		t.Errorf("snap.ID = %q, want snap-abc123", snap.ID)
+	}
+	if _, err := os.Stat(DBPath(dir)); !os.IsNotExist(err) {
+		t.Error("DB should not exist after Delete")
+	}
+}
+
+func TestDataDirService_Delete_AlreadyGone(t *testing.T) {
+	svc, home := newTestService(t)
+	dir := filepath.Join(home, "data")
+
+	if _, err := svc.Delete(dir); err != nil {
+		t.Fatalf("Delete on missing DB: %v", err)
+	}
+}
+
+func TestDataDirService_SnapshotError_Propagates(t *testing.T) {
+	home := t.TempDir()
+	svc := DataDirService{
+		homeDir:     home,
+		backupRoot:  filepath.Join(home, ".gentle-ai", "backups"),
+		snapshotter: stubSnapshotter{err: errors.New("disk full")},
+	}
+	dir := filepath.Join(home, "data")
+	writeTestDB(t, dir)
+
+	if _, err := svc.Delete(dir); err == nil {
+		t.Fatal("expected error from failing snapshotter, got nil")
+	}
+	if _, statErr := os.Stat(DBPath(dir)); statErr != nil {
+		t.Error("DB was deleted despite snapshot failure")
+	}
+}
+
+func TestDataDirService_DiskSpaceOK(t *testing.T) {
+	svc, home := newTestService(t)
+	dir := filepath.Join(home, "data")
+	dbPath := writeTestDB(t, dir)
+
+	ok, needed, avail, err := svc.DiskSpaceOK(dbPath, home)
+	if err != nil {
+		t.Fatalf("DiskSpaceOK: %v", err)
+	}
+	if needed <= 0 {
+		t.Errorf("needed = %d, want > 0", needed)
+	}
+	if avail <= 0 {
+		t.Errorf("avail = %d, want > 0", avail)
+	}
+	if !ok {
+		t.Errorf("DiskSpaceOK = false for tiny test file, expected true")
+	}
+}

--- a/internal/model/selection.go
+++ b/internal/model/selection.go
@@ -1,5 +1,18 @@
 package model
 
+// EngramDataDirOp is the operation the user chose for their Engram data dir.
+type EngramDataDirOp string
+
+const (
+	EngramDataDirOpNone   EngramDataDirOp = ""
+	EngramDataDirOpKeep   EngramDataDirOp = "keep"
+	EngramDataDirOpCopy   EngramDataDirOp = "copy"
+	EngramDataDirOpMove   EngramDataDirOp = "move"
+	EngramDataDirOpSet    EngramDataDirOp = "set"
+	EngramDataDirOpDelete EngramDataDirOp = "delete"
+	EngramDataDirOpFresh  EngramDataDirOp = "fresh"
+)
+
 type Selection struct {
 	Agents                 []AgentID
 	Components             []ComponentID
@@ -14,6 +27,8 @@ type Selection struct {
 	KiroModelAssignments   map[string]ClaudeModelAlias // key = phase name; value = opus|sonnet|haiku (Kiro-only)
 	Profiles               []Profile                   // named SDD profiles to generate/update during sync
 	OpenCodePlugins        []OpenCodeCommunityPluginID // optional community OpenCode TUI plugins
+	EngramDataDir          string                      // custom Engram data directory path; "" means default ~/.engram
+	EngramDataDirOp        EngramDataDirOp             // operation chosen at install time; "" means no change
 }
 
 func (s Selection) HasAgent(agent AgentID) bool {

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -8,6 +8,7 @@ import (
 
 const stateDir = ".gentle-ai"
 const stateFile = "state.json"
+const maxEngramKnownDataDirs = 50
 
 // ModelAssignmentState is the JSON-serialisable form of a provider+model pair
 // used by OpenCode-style model assignments. It mirrors model.ModelAssignment
@@ -44,6 +45,14 @@ type InstallState struct {
 	// Empty for state files written before persona persistence was added —
 	// callers fall back to PersonaGentleman in that case.
 	Persona string `json:"persona,omitempty"`
+
+	// EngramDataDir is the filesystem path of the Engram data directory chosen
+	// by the user. When empty the default (~/.engram) is used.
+	EngramDataDir string `json:"engram_data_dir,omitempty"`
+
+	// EngramKnownDataDirs records non-active directories created or selected by
+	// data-dir management so users can later make a copied directory active.
+	EngramKnownDataDirs []string `json:"engram_known_data_dirs,omitempty"`
 }
 
 // Path returns the absolute path to the state file for the given home directory.
@@ -61,6 +70,9 @@ func Read(homeDir string) (InstallState, error) {
 	var s InstallState
 	if err := json.Unmarshal(data, &s); err != nil {
 		return InstallState{}, err
+	}
+	if len(s.EngramKnownDataDirs) > maxEngramKnownDataDirs {
+		s.EngramKnownDataDirs = s.EngramKnownDataDirs[len(s.EngramKnownDataDirs)-maxEngramKnownDataDirs:]
 	}
 	return s, nil
 }

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -1,6 +1,7 @@
 package state
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -23,6 +24,28 @@ func TestWriteAndRead(t *testing.T) {
 
 	if !reflect.DeepEqual(s.InstalledAgents, agents) {
 		t.Errorf("InstalledAgents = %v, want %v", s.InstalledAgents, agents)
+	}
+}
+
+func TestRead_CapsEngramKnownDataDirs(t *testing.T) {
+	home := t.TempDir()
+	var dirs []string
+	for i := 0; i < 55; i++ {
+		dirs = append(dirs, filepath.Join(home, "engram", fmt.Sprintf("%02d", i)))
+	}
+	if err := Write(home, InstallState{EngramKnownDataDirs: dirs}); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := Read(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.EngramKnownDataDirs) != maxEngramKnownDataDirs {
+		t.Fatalf("len(EngramKnownDataDirs) = %d, want %d", len(got.EngramKnownDataDirs), maxEngramKnownDataDirs)
+	}
+	if got.EngramKnownDataDirs[0] != dirs[5] {
+		t.Fatalf("first retained dir = %q, want %q", got.EngramKnownDataDirs[0], dirs[5])
 	}
 }
 

--- a/internal/storage/bytes.go
+++ b/internal/storage/bytes.go
@@ -1,0 +1,23 @@
+package storage
+
+import "fmt"
+
+// FormatBytes formats n bytes as a human-readable string using 1024-based units,
+// consistent with Engram CLI output.
+func FormatBytes(n int64) string {
+	const (
+		kib = 1024
+		mib = 1024 * kib
+		gib = 1024 * mib
+	)
+	switch {
+	case n >= gib:
+		return fmt.Sprintf("%.1f GiB", float64(n)/float64(gib))
+	case n >= mib:
+		return fmt.Sprintf("%.1f MiB", float64(n)/float64(mib))
+	case n >= kib:
+		return fmt.Sprintf("%.1f KiB", float64(n)/float64(kib))
+	default:
+		return fmt.Sprintf("%d B", n)
+	}
+}

--- a/internal/storage/space.go
+++ b/internal/storage/space.go
@@ -1,0 +1,9 @@
+package storage
+
+// AvailableBytes returns the number of bytes available to an unprivileged user
+// on the volume containing path. path may be an existing file or directory,
+// or a path that does not yet exist — in which case the nearest existing
+// ancestor is used.
+func AvailableBytes(path string) (int64, error) {
+	return availableBytes(path)
+}

--- a/internal/storage/space_test.go
+++ b/internal/storage/space_test.go
@@ -1,0 +1,98 @@
+package storage_test
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/internal/storage"
+)
+
+func TestAvailableBytes_TempDir(t *testing.T) {
+	dir := t.TempDir()
+	n, err := storage.AvailableBytes(dir)
+	if err != nil {
+		t.Fatalf("AvailableBytes(%q): unexpected error: %v", dir, err)
+	}
+	if n <= 0 {
+		t.Fatalf("AvailableBytes(%q) = %d, want > 0", dir, n)
+	}
+}
+
+func TestAvailableBytes_File(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "space-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+
+	n, err := storage.AvailableBytes(f.Name())
+	if err != nil {
+		t.Fatalf("AvailableBytes(%q): unexpected error: %v", f.Name(), err)
+	}
+	if n <= 0 {
+		t.Fatalf("AvailableBytes(%q) = %d, want > 0", f.Name(), n)
+	}
+}
+
+// TestAvailableBytes_NonExistentChild verifies that a path whose parent exists
+// succeeds by walking up to the nearest existing ancestor. This covers the
+// copy/move preflight check where the destination directory does not exist yet.
+func TestAvailableBytes_NonExistentChild(t *testing.T) {
+	dir := t.TempDir()
+	notYet := filepath.Join(dir, "a", "b", "c", "dest")
+	n, err := storage.AvailableBytes(notYet)
+	if err != nil {
+		t.Fatalf("AvailableBytes(%q): unexpected error: %v", notYet, err)
+	}
+	if n <= 0 {
+		t.Fatalf("AvailableBytes(%q) = %d, want > 0", notYet, n)
+	}
+}
+
+// TestAvailableBytes_PermissionDenied verifies that a chmod-000 directory
+// returns a "permission denied" error, not a misleading space-check failure.
+func TestAvailableBytes_PermissionDenied(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("chmod 000 is not meaningful on Windows")
+	}
+	dir := t.TempDir()
+	restricted := filepath.Join(dir, "restricted")
+	if err := os.Mkdir(restricted, 0o000); err != nil {
+		t.Fatalf("Mkdir: %v", err)
+	}
+	t.Cleanup(func() { os.Chmod(restricted, 0o755) }) // allow cleanup
+
+	_, err := storage.AvailableBytes(restricted)
+	if err == nil {
+		t.Fatal("expected permission error, got nil")
+	}
+	if !strings.Contains(err.Error(), "permission denied") {
+		t.Errorf("error %q should mention 'permission denied'", err)
+	}
+}
+
+func TestFormatBytes(t *testing.T) {
+	tests := []struct {
+		n    int64
+		want string
+	}{
+		{0, "0 B"},
+		{512, "512 B"},
+		{1023, "1023 B"},
+		{1024, "1.0 KiB"},
+		{1536, "1.5 KiB"},
+		{1024 * 1024, "1.0 MiB"},
+		{int64(1.5 * 1024 * 1024), "1.5 MiB"},
+		{1024 * 1024 * 1024, "1.0 GiB"},
+		{int64(2469606195), "2.3 GiB"},
+	}
+	for _, tt := range tests {
+		got := storage.FormatBytes(tt.n)
+		if got != tt.want {
+			t.Errorf("FormatBytes(%d) = %q, want %q", tt.n, got, tt.want)
+		}
+	}
+}

--- a/internal/storage/space_unix.go
+++ b/internal/storage/space_unix.go
@@ -1,0 +1,42 @@
+//go:build !windows
+
+package storage
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+func availableBytes(path string) (int64, error) {
+	// Statfs requires an existing path. Walk up to the nearest existing ancestor
+	// so callers can pass a not-yet-created destination directory (e.g. the copy
+	// target during a data-dir management operation).
+	for {
+		info, err := os.Stat(path)
+		if err == nil {
+			if !info.IsDir() {
+				path = filepath.Dir(path)
+				continue
+			}
+			break // found an existing directory
+		}
+		parent := filepath.Dir(path)
+		if parent == path {
+			return 0, fmt.Errorf("no existing ancestor found for %q", path)
+		}
+		path = parent
+	}
+
+	var stat syscall.Statfs_t
+	if err := syscall.Statfs(path, &stat); err != nil {
+		if errors.Is(err, syscall.EACCES) {
+			return 0, fmt.Errorf("permission denied checking space at %q", path)
+		}
+		return 0, fmt.Errorf("statfs %q: %w", path, err)
+	}
+	// Bavail = blocks available to unprivileged users.
+	return int64(stat.Bavail) * int64(stat.Bsize), nil
+}

--- a/internal/storage/space_windows.go
+++ b/internal/storage/space_windows.go
@@ -1,0 +1,59 @@
+//go:build windows
+
+package storage
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+	"unsafe"
+)
+
+var (
+	kernel32            = syscall.NewLazyDLL("kernel32.dll")
+	getDiskFreeSpaceExW = kernel32.NewProc("GetDiskFreeSpaceExW")
+)
+
+func availableBytes(path string) (int64, error) {
+	// GetDiskFreeSpaceExW requires an existing directory. Walk up to the nearest
+	// existing ancestor so callers can pass a not-yet-created destination directory
+	// (e.g. the copy target during a data-dir management operation).
+	for {
+		info, err := os.Stat(path)
+		if err == nil {
+			if !info.IsDir() {
+				path = filepath.Dir(path)
+				continue
+			}
+			break // found an existing directory
+		}
+		parent := filepath.Dir(path)
+		if parent == path {
+			// Reached the filesystem root and it doesn't exist (e.g. unmounted drive).
+			return 0, fmt.Errorf("no existing ancestor found for %q", path)
+		}
+		path = parent
+	}
+
+	pathPtr, err := syscall.UTF16PtrFromString(path)
+	if err != nil {
+		return 0, fmt.Errorf("encode path %q: %w", path, err)
+	}
+
+	var avail, total, free uint64
+	r, _, lastErr := getDiskFreeSpaceExW.Call(
+		uintptr(unsafe.Pointer(pathPtr)),
+		uintptr(unsafe.Pointer(&avail)),
+		uintptr(unsafe.Pointer(&total)),
+		uintptr(unsafe.Pointer(&free)),
+	)
+	if r == 0 {
+		if errors.Is(lastErr, syscall.ERROR_ACCESS_DENIED) {
+			return 0, fmt.Errorf("permission denied checking space at %q", path)
+		}
+		return 0, fmt.Errorf("GetDiskFreeSpaceExW %q: %w", path, lastErr)
+	}
+	return int64(avail), nil
+}

--- a/internal/tui/screens/engram_datadir.go
+++ b/internal/tui/screens/engram_datadir.go
@@ -1,0 +1,206 @@
+package screens
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/gentleman-programming/gentle-ai/internal/components/engram"
+	"github.com/gentleman-programming/gentle-ai/internal/model"
+	"github.com/gentleman-programming/gentle-ai/internal/tui/styles"
+)
+
+const EngramCustomPathDstIdx = -2
+
+// EngramDirChoice is one entry in an Engram data-directory option list.
+type EngramDirChoice struct {
+	Label  string
+	Op     model.EngramDataDirOp
+	DstIdx int
+}
+
+func EngramDirActionChoices() []EngramDirChoice {
+	return []EngramDirChoice{
+		{Label: "Migrate / Move Data", Op: model.EngramDataDirOpMove, DstIdx: -1},
+		{Label: "Copy Data", Op: model.EngramDataDirOpCopy, DstIdx: -1},
+		{Label: "Set Active Directory", Op: model.EngramDataDirOpSet, DstIdx: -1},
+		{Label: "Delete current Data", Op: model.EngramDataDirOpDelete, DstIdx: -1},
+	}
+}
+
+func EngramDirLocationChoices(locations []engram.Location, op model.EngramDataDirOp) []EngramDirChoice {
+	verb := "Use"
+	if op == model.EngramDataDirOpMove {
+		verb = "Move to"
+	}
+	if op == model.EngramDataDirOpCopy {
+		verb = "Copy to"
+	}
+
+	var out []EngramDirChoice
+	for i, loc := range locations {
+		if loc.IsCurrent && op != model.EngramDataDirOpSet {
+			continue
+		}
+		label := verb + "  " + loc.Label
+		if loc.IsCurrent {
+			label += " " + styles.SuccessStyle.Render("(ACTIVE)")
+		}
+		out = append(out, EngramDirChoice{Label: label, Op: op, DstIdx: i})
+	}
+	if op != model.EngramDataDirOpSet {
+		out = append(out, EngramDirChoice{Label: "Type custom path...", Op: op, DstIdx: EngramCustomPathDstIdx})
+	}
+	return out
+}
+
+func EngramDirInstallLocationChoices(locations []engram.Location) []EngramDirChoice {
+	out := make([]EngramDirChoice, 0, len(locations)+1)
+	for i, loc := range locations {
+		out = append(out, EngramDirChoice{Label: "Use  " + loc.Label, Op: model.EngramDataDirOpSet, DstIdx: i})
+	}
+	out = append(out, EngramDirChoice{Label: "Type custom path...", Op: model.EngramDataDirOpSet, DstIdx: EngramCustomPathDstIdx})
+	return out
+}
+
+func RenderEngramDataDir(cursor int, currentDir string, dbSize int64, locations []engram.Location, selectedOp model.EngramDataDirOp, spaceErr string) string {
+	var b strings.Builder
+	b.WriteString(styles.TitleStyle.Render("Manage Engram Data Directory"))
+	b.WriteString("\n\n")
+	b.WriteString(styles.SubtextStyle.Render("Current: " + engram.FormatDirLine(currentDir, dbSize)))
+	b.WriteString("\n\n")
+	if strings.TrimSpace(spaceErr) != "" {
+		b.WriteString(styles.WarningStyle.Render(spaceErr))
+		b.WriteString("\n\n")
+	}
+
+	choices := EngramDirActionChoices()
+	if EngramDirOpNeedsLocation(selectedOp) {
+		b.WriteString(styles.SubtextStyle.Render("Choose the destination for " + engramOpVerb(selectedOp) + "."))
+		b.WriteString("\n\n")
+		choices = EngramDirLocationChoices(locations, selectedOp)
+	}
+	labels := make([]string, len(choices))
+	for i, choice := range choices {
+		labels[i] = choice.Label
+	}
+	b.WriteString(renderOptions(labels, cursor))
+	b.WriteString("\n")
+	b.WriteString(styles.WarningStyle.Render("Ensure engram is not running before copying or moving data."))
+	b.WriteString("\n")
+	b.WriteString(styles.HelpStyle.Render("j/k: navigate • enter: select • esc: back"))
+	return b.String()
+}
+
+func RenderEngramDataDirInstall(cursor int, detectedDir string, dbSize int64, locations []engram.Location, existingData bool, spaceErr string) string {
+	var b strings.Builder
+	if existingData {
+		b.WriteString(styles.TitleStyle.Render("Existing Engram Data Found"))
+		b.WriteString("\n\n")
+		b.WriteString(styles.SubtextStyle.Render("Detected: " + engram.FormatDirLine(detectedDir, dbSize)))
+		b.WriteString("\n\n")
+		b.WriteString(renderOptions([]string{"Keep location  (use data as-is)", "Start fresh    (snapshot existing, then delete)"}, cursor))
+		return b.String()
+	}
+
+	b.WriteString(styles.TitleStyle.Render("Choose Engram Data Directory"))
+	b.WriteString("\n\n")
+	if strings.TrimSpace(spaceErr) != "" {
+		b.WriteString(styles.WarningStyle.Render(spaceErr))
+		b.WriteString("\n\n")
+	}
+	choices := EngramDirInstallLocationChoices(locations)
+	labels := make([]string, len(choices))
+	for i, choice := range choices {
+		labels[i] = choice.Label
+	}
+	b.WriteString(renderOptions(labels, cursor))
+	return b.String()
+}
+
+func RenderEngramDataDirCustomPath(op model.EngramDataDirOp, currentDir, path string, pos int, errMsg string) string {
+	var b strings.Builder
+	b.WriteString(styles.TitleStyle.Render("Custom Engram Path"))
+	b.WriteString("\n\n")
+	b.WriteString(styles.SubtextStyle.Render("Action: " + engramOpVerb(op)))
+	b.WriteString("\n")
+	b.WriteString(styles.SubtextStyle.Render("Current: " + currentDir))
+	b.WriteString("\n\n")
+	b.WriteString("Path: " + renderPathInput(path, pos))
+	if strings.TrimSpace(errMsg) != "" {
+		b.WriteString("\n\n")
+		b.WriteString(styles.WarningStyle.Render(errMsg))
+	}
+	b.WriteString("\n\n")
+	b.WriteString(styles.HelpStyle.Render("type path • enter: continue • esc: back"))
+	return b.String()
+}
+
+func RenderEngramDataDirConfirm(op model.EngramDataDirOp, currentDir, dstDir, backupRoot string, cursor int) string {
+	var b strings.Builder
+	b.WriteString(styles.TitleStyle.Render("Confirm - " + engramOpVerb(op)))
+	b.WriteString("\n\n")
+	switch op {
+	case model.EngramDataDirOpCopy, model.EngramDataDirOpMove, model.EngramDataDirOpSet:
+		b.WriteString(fmt.Sprintf("  %s\n    -> %s\n", styles.SubtextStyle.Render(currentDir), styles.SubtextStyle.Render(dstDir)))
+	case model.EngramDataDirOpDelete, model.EngramDataDirOpFresh:
+		b.WriteString(fmt.Sprintf("  Delete  %s\n", styles.WarningStyle.Render(currentDir)))
+	}
+	if strings.TrimSpace(backupRoot) != "" && op != model.EngramDataDirOpSet {
+		b.WriteString("\n")
+		b.WriteString(styles.SubtextStyle.Render("Backup: " + backupRoot))
+		b.WriteString("\n")
+	}
+	b.WriteString("\n")
+	b.WriteString(renderOptions([]string{"Confirm", "Cancel"}, cursor))
+	return b.String()
+}
+
+func RenderEngramDataDirResult(op model.EngramDataDirOp, snapshotID, backupRoot string, err error) string {
+	if err != nil {
+		return styles.ErrorStyle.Render(engramOpVerb(op)+" failed") + "\n\n" + styles.WarningStyle.Render(err.Error())
+	}
+	var b strings.Builder
+	b.WriteString(styles.SuccessStyle.Render(engramOpVerb(op) + " complete"))
+	if snapshotID != "" {
+		b.WriteString("\n\n")
+		b.WriteString(styles.SubtextStyle.Render("Backup snapshot: " + snapshotID))
+		if strings.TrimSpace(backupRoot) != "" {
+			b.WriteString("\n")
+			b.WriteString(styles.SubtextStyle.Render("Location: " + filepath.Join(backupRoot, snapshotID)))
+		}
+	}
+	return b.String()
+}
+
+func renderPathInput(path string, pos int) string {
+	runes := []rune(path)
+	if pos < 0 {
+		pos = 0
+	}
+	if pos > len(runes) {
+		pos = len(runes)
+	}
+	return styles.SelectedStyle.Render("[" + string(runes[:pos]) + "|" + string(runes[pos:]) + "]")
+}
+
+func EngramDirOpNeedsLocation(op model.EngramDataDirOp) bool {
+	return op == model.EngramDataDirOpMove || op == model.EngramDataDirOpCopy || op == model.EngramDataDirOpSet
+}
+
+func engramOpVerb(op model.EngramDataDirOp) string {
+	switch op {
+	case model.EngramDataDirOpCopy:
+		return "Copy data directory"
+	case model.EngramDataDirOpMove:
+		return "Move data directory"
+	case model.EngramDataDirOpSet:
+		return "Set active data directory"
+	case model.EngramDataDirOpDelete:
+		return "Delete data directory"
+	case model.EngramDataDirOpFresh:
+		return "Start fresh"
+	default:
+		return "Data directory operation"
+	}
+}

--- a/internal/tui/screens/engram_datadir_test.go
+++ b/internal/tui/screens/engram_datadir_test.go
@@ -1,0 +1,69 @@
+package screens
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/internal/components/engram"
+	"github.com/gentleman-programming/gentle-ai/internal/model"
+)
+
+func TestRenderEngramDataDir_ShowsTitleAndCurrentDir(t *testing.T) {
+	locs := []engram.Location{{Path: "/home/user/.engram", Label: "~/.engram", IsCurrent: true}}
+	out := RenderEngramDataDir(0, "/home/user/.engram", 0, locs, model.EngramDataDirOpNone, "")
+	if !strings.Contains(out, "Manage Engram Data Directory") {
+		t.Fatal("missing title")
+	}
+	if !strings.Contains(out, "/home/user/.engram") {
+		t.Fatal("missing current dir")
+	}
+}
+
+func TestRenderEngramDataDir_LocationMode(t *testing.T) {
+	locs := []engram.Location{
+		{Path: "/home/user/.engram", Label: "~/.engram", IsCurrent: true},
+		{Path: "/mnt/Engram", Label: "/mnt/Engram"},
+	}
+	out := RenderEngramDataDir(0, "/home/user/.engram", 0, locs, model.EngramDataDirOpCopy, "")
+	if !strings.Contains(out, "Copy to") {
+		t.Fatal("missing copy location option")
+	}
+	if !strings.Contains(out, "Type custom path") {
+		t.Fatal("missing custom path option")
+	}
+}
+
+func TestRenderEngramDataDirInstall_Modes(t *testing.T) {
+	locs := []engram.Location{{Path: "/home/user/.engram", Label: "~/.engram"}}
+	noData := RenderEngramDataDirInstall(0, "/home/user/.engram", 0, locs, false, "")
+	if !strings.Contains(noData, "Choose Engram Data Directory") {
+		t.Fatal("missing no-data title")
+	}
+	existing := RenderEngramDataDirInstall(0, "/home/user/.engram", 0, locs, true, "")
+	if !strings.Contains(existing, "Existing Engram Data Found") {
+		t.Fatal("missing existing-data title")
+	}
+}
+
+func TestRenderEngramDataDirCustomPath_ShowsError(t *testing.T) {
+	out := RenderEngramDataDirCustomPath(model.EngramDataDirOpMove, "/src", "relative", 8, "Use an absolute path.")
+	if !strings.Contains(out, "Use an absolute path") {
+		t.Fatal("missing inline error")
+	}
+}
+
+func TestRenderEngramDataDirConfirmAndResult(t *testing.T) {
+	confirm := RenderEngramDataDirConfirm(model.EngramDataDirOpDelete, "/src", "", "/backups", 0)
+	if !strings.Contains(confirm, "Delete") {
+		t.Fatal("missing delete text")
+	}
+	success := RenderEngramDataDirResult(model.EngramDataDirOpCopy, "snap-1", "/backups", nil)
+	if !strings.Contains(success, "snap-1") {
+		t.Fatal("missing snapshot ID")
+	}
+	failed := RenderEngramDataDirResult(model.EngramDataDirOpMove, "", "", errors.New("disk full"))
+	if !strings.Contains(failed, "disk full") {
+		t.Fatal("missing error text")
+	}
+}


### PR DESCRIPTION
## Linked Issue

Closes #346

## PR Type

- [x] `type:feature` - Engram data-dir feature slice

## Summary

Adds model/state fields and render-only TUI screens for Engram data-dir management.

The `feat(...)` title marks new feature capability for the Engram data-dir chain.

This PR is part of the first-class Engram data-directory feature chain. Review it in chain order so each slice is evaluated against its immediate base.

## Changes

| Area | What changed |
|---|---|
| `internal/model`, `internal/state` | Persists active and known Engram data dirs. |
| `internal/tui/screens` | Adds render-only data-dir management screens. |
| Tests | Covers state capping and screen rendering. |

## Test Plan

```bash
GOCACHE=G:\codex-go-tmp\gocache GOTMPDIR=G:\codex-go-tmp\gotmp TEMP=G:\codex-go-tmp\tmp TMP=G:\codex-go-tmp\tmp APPDATA=G:\codex-go-tmp\appdata XDG_CONFIG_HOME=G:\codex-go-tmp\xdg go test -count=1 ./...
```

- [x] Unit tests pass
- [x] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Manually tested locally

## Chain Context

| Field | Value |
|---|---|
| Chain start | `feat/engram-dd-1-infra` |
| Chain end | `fix/engram-dd-15-operation-consistency` |
| Current slice | #18 `feat/engram-dd-5-model-screens` |
| Prior dependency | #4 `feat/engram-dd-4-domain-locations` |
| Follow-up work | #19 `feat/engram-dd-6-tui-flow-consolidated` |
| Review budget | 325 changed lines |
| Out of scope | Other Engram DD slices and unrelated cleanup |

Review order: #1 -> #2 -> #3 -> #4 -> #18 -> #19 -> #20 -> #21 -> #22 -> #23 -> #24 -> #25 -> #26 -> #27 -> #28

```text
#4 -> 📍 #18 -> #19
```

## Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [x] Exactly one `type:*` label is applied
- [x] Unit tests pass
- [x] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Manually tested locally
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers

