### PR TITLE
fix(antigravity): support new config paths and resolve directories dynamically

### DIFF
--- a/internal/agents/antigravity/adapter.go
+++ b/internal/agents/antigravity/adapter.go
@@ -37,17 +37,29 @@ func (a *Adapter) Tier() model.SupportTier {
 // --- Detection ---
 
 func (a *Adapter) Detect(_ context.Context, homeDir string) (bool, string, string, bool, error) {
-	configPath := filepath.Join(homeDir, ".gemini", "antigravity-cli")
-
-	stat := a.statPath(configPath)
-	if stat.err != nil {
-		if os.IsNotExist(stat.err) {
-			return false, "", configPath, false, nil
-		}
-		return false, "", "", false, stat.err
+	// Attempt to detect the new antigravity-ide directory first, then fallback to antigravity-cli
+	paths := []string{
+		filepath.Join(homeDir, ".gemini", "antigravity-ide"),
+		filepath.Join(homeDir, ".gemini", "antigravity-cli"),
 	}
 
-	return stat.isDir, "", configPath, stat.isDir, nil
+	for _, configPath := range paths {
+		stat := a.statPath(configPath)
+		if stat.err != nil {
+			if !os.IsNotExist(stat.err) {
+				// Propagate critical errors immediately
+				return false, "", "", false, stat.err
+			}
+			continue
+		}
+		if stat.isDir {
+			return true, "", configPath, true, nil
+		}
+	}
+
+	// Default path for fresh installations
+	defaultPath := filepath.Join(homeDir, ".gemini", "antigravity-ide")
+	return false, "", defaultPath, false, nil
 }
 
 // --- Installation ---
@@ -62,8 +74,24 @@ func (a *Adapter) InstallCommand(_ system.PlatformProfile) ([][]string, error) {
 
 // --- Config paths ---
 
+func (a *Adapter) resolveConfigDir(homeDir string) string {
+	ideDir := filepath.Join(homeDir, ".gemini", "antigravity-ide")
+	stat := a.statPath(ideDir)
+	if stat.err == nil && stat.isDir {
+		return ideDir
+	}
+
+	cliDir := filepath.Join(homeDir, ".gemini", "antigravity-cli")
+	stat = a.statPath(cliDir)
+	if stat.err == nil && stat.isDir {
+		return cliDir
+	}
+
+	return ideDir // default fallback
+}
+
 func (a *Adapter) GlobalConfigDir(homeDir string) string {
-	return filepath.Join(homeDir, ".gemini", "antigravity-cli")
+	return a.resolveConfigDir(homeDir)
 }
 
 func (a *Adapter) SystemPromptDir(homeDir string) string {
@@ -75,11 +103,11 @@ func (a *Adapter) SystemPromptFile(homeDir string) string {
 }
 
 func (a *Adapter) SkillsDir(homeDir string) string {
-	return filepath.Join(homeDir, ".gemini", "antigravity-cli", "skills")
+	return filepath.Join(a.resolveConfigDir(homeDir), "skills")
 }
 
 func (a *Adapter) SettingsPath(homeDir string) string {
-	return filepath.Join(homeDir, ".gemini", "antigravity-cli", "settings.json")
+	return filepath.Join(a.resolveConfigDir(homeDir), "settings.json")
 }
 
 // --- Config strategies ---
@@ -95,7 +123,7 @@ func (a *Adapter) MCPStrategy() model.MCPStrategy {
 // --- MCP ---
 
 func (a *Adapter) MCPConfigPath(homeDir string, _ string) string {
-	return filepath.Join(homeDir, ".gemini", "antigravity-cli", "mcp_config.json")
+	return filepath.Join(a.resolveConfigDir(homeDir), "mcp_config.json")
 }
 
 // --- Optional capabilities ---

--- a/internal/agents/antigravity/adapter.go
+++ b/internal/agents/antigravity/adapter.go
@@ -24,6 +24,14 @@ func NewAdapter() *Adapter {
 	}
 }
 
+func (a *Adapter) antigravityVariantDir(homeDir string) string {
+	desktop := filepath.Join(homeDir, ".gemini", "antigravity-desktop")
+	if stat := a.statPath(desktop); stat.err == nil {
+		return desktop
+	}
+	return filepath.Join(homeDir, ".gemini", "antigravity-cli")
+}
+
 // --- Identity ---
 
 func (a *Adapter) Agent() model.AgentID {
@@ -37,29 +45,17 @@ func (a *Adapter) Tier() model.SupportTier {
 // --- Detection ---
 
 func (a *Adapter) Detect(_ context.Context, homeDir string) (bool, string, string, bool, error) {
-	// Attempt to detect the new antigravity-ide directory first, then fallback to antigravity-cli
-	paths := []string{
-		filepath.Join(homeDir, ".gemini", "antigravity-ide"),
-		filepath.Join(homeDir, ".gemini", "antigravity-cli"),
-	}
+	configPath := a.antigravityVariantDir(homeDir)
 
-	for _, configPath := range paths {
-		stat := a.statPath(configPath)
-		if stat.err != nil {
-			if !os.IsNotExist(stat.err) {
-				// Propagate critical errors immediately
-				return false, "", "", false, stat.err
-			}
-			continue
+	stat := a.statPath(configPath)
+	if stat.err != nil {
+		if !os.IsNotExist(stat.err) {
+			// Propagate critical errors immediately
+			return false, "", "", false, stat.err
 		}
-		if stat.isDir {
-			return true, "", configPath, true, nil
-		}
+		return false, "", configPath, false, nil
 	}
-
-	// Default path for fresh installations
-	defaultPath := filepath.Join(homeDir, ".gemini", "antigravity-ide")
-	return false, "", defaultPath, false, nil
+	return true, "", configPath, true, nil
 }
 
 // --- Installation ---
@@ -74,24 +70,8 @@ func (a *Adapter) InstallCommand(_ system.PlatformProfile) ([][]string, error) {
 
 // --- Config paths ---
 
-func (a *Adapter) resolveConfigDir(homeDir string) string {
-	ideDir := filepath.Join(homeDir, ".gemini", "antigravity-ide")
-	stat := a.statPath(ideDir)
-	if stat.err == nil && stat.isDir {
-		return ideDir
-	}
-
-	cliDir := filepath.Join(homeDir, ".gemini", "antigravity-cli")
-	stat = a.statPath(cliDir)
-	if stat.err == nil && stat.isDir {
-		return cliDir
-	}
-
-	return ideDir // default fallback
-}
-
 func (a *Adapter) GlobalConfigDir(homeDir string) string {
-	return a.resolveConfigDir(homeDir)
+	return a.antigravityVariantDir(homeDir)
 }
 
 func (a *Adapter) SystemPromptDir(homeDir string) string {
@@ -103,11 +83,11 @@ func (a *Adapter) SystemPromptFile(homeDir string) string {
 }
 
 func (a *Adapter) SkillsDir(homeDir string) string {
-	return filepath.Join(a.resolveConfigDir(homeDir), "skills")
+	return filepath.Join(a.antigravityVariantDir(homeDir), "skills")
 }
 
 func (a *Adapter) SettingsPath(homeDir string) string {
-	return filepath.Join(a.resolveConfigDir(homeDir), "settings.json")
+	return filepath.Join(a.antigravityVariantDir(homeDir), "settings.json")
 }
 
 // --- Config strategies ---
@@ -123,7 +103,7 @@ func (a *Adapter) MCPStrategy() model.MCPStrategy {
 // --- MCP ---
 
 func (a *Adapter) MCPConfigPath(homeDir string, _ string) string {
-	return filepath.Join(a.resolveConfigDir(homeDir), "mcp_config.json")
+	return filepath.Join(a.antigravityVariantDir(homeDir), "mcp_config.json")
 }
 
 // --- Optional capabilities ---

--- a/internal/agents/antigravity/adapter_test.go
+++ b/internal/agents/antigravity/adapter_test.go
@@ -14,32 +14,44 @@ import (
 func TestDetect(t *testing.T) {
 	tests := []struct {
 		name            string
-		stat            statResult
+		existingDirs    map[string]bool
+		statErr         error
 		wantInstalled   bool
-		wantBinaryPath  string
 		wantConfigPath  string
 		wantConfigFound bool
 		wantErr         bool
 	}{
 		{
-			name:            "config directory found",
-			stat:            statResult{isDir: true},
+			name:            "config directory antigravity-ide found",
+			existingDirs:    map[string]bool{"/tmp/home/.gemini/antigravity-ide": true},
 			wantInstalled:   true,
-			wantBinaryPath:  "",
+			wantConfigPath:  filepath.Join("/tmp/home", ".gemini", "antigravity-ide"),
+			wantConfigFound: true,
+		},
+		{
+			name:            "config directory antigravity-cli found",
+			existingDirs:    map[string]bool{"/tmp/home/.gemini/antigravity-cli": true},
+			wantInstalled:   true,
 			wantConfigPath:  filepath.Join("/tmp/home", ".gemini", "antigravity-cli"),
 			wantConfigFound: true,
 		},
 		{
+			name:            "both directories found - prefers ide",
+			existingDirs:    map[string]bool{"/tmp/home/.gemini/antigravity-ide": true, "/tmp/home/.gemini/antigravity-cli": true},
+			wantInstalled:   true,
+			wantConfigPath:  filepath.Join("/tmp/home", ".gemini", "antigravity-ide"),
+			wantConfigFound: true,
+		},
+		{
 			name:            "config directory missing",
-			stat:            statResult{err: os.ErrNotExist},
+			existingDirs:    map[string]bool{},
 			wantInstalled:   false,
-			wantBinaryPath:  "",
-			wantConfigPath:  filepath.Join("/tmp/home", ".gemini", "antigravity-cli"),
+			wantConfigPath:  filepath.Join("/tmp/home", ".gemini", "antigravity-ide"),
 			wantConfigFound: false,
 		},
 		{
 			name:    "stat error bubbles up",
-			stat:    statResult{err: errors.New("permission denied")},
+			statErr: errors.New("permission denied"),
 			wantErr: true,
 		},
 	}
@@ -47,8 +59,14 @@ func TestDetect(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			a := &Adapter{
-				statPath: func(string) statResult {
-					return tt.stat
+				statPath: func(path string) statResult {
+					if tt.statErr != nil {
+						return statResult{err: tt.statErr}
+					}
+					if tt.existingDirs[path] {
+						return statResult{isDir: true}
+					}
+					return statResult{err: os.ErrNotExist}
 				},
 			}
 
@@ -65,8 +83,8 @@ func TestDetect(t *testing.T) {
 				t.Fatalf("Detect() installed = %v, want %v", installed, tt.wantInstalled)
 			}
 
-			if binaryPath != tt.wantBinaryPath {
-				t.Fatalf("Detect() binaryPath = %q, want %q", binaryPath, tt.wantBinaryPath)
+			if binaryPath != "" {
+				t.Fatalf("Detect() binaryPath = %q, want empty string", binaryPath)
 			}
 
 			if configPath != tt.wantConfigPath {
@@ -107,32 +125,81 @@ func TestSupportsAutoInstall(t *testing.T) {
 }
 
 func TestConfigPathsCrossPlatform(t *testing.T) {
-	a := NewAdapter()
 	home := "/tmp/home"
 
-	if got := a.GlobalConfigDir(home); got != filepath.Join(home, ".gemini", "antigravity-cli") {
-		t.Fatalf("GlobalConfigDir() = %q, want %q", got, filepath.Join(home, ".gemini", "antigravity-cli"))
-	}
+	t.Run("resolves to antigravity-ide when ide folder exists", func(t *testing.T) {
+		a := &Adapter{
+			statPath: func(path string) statResult {
+				if path == filepath.Join(home, ".gemini", "antigravity-ide") {
+					return statResult{isDir: true}
+				}
+				return statResult{err: os.ErrNotExist}
+			},
+		}
 
-	if got := a.SkillsDir(home); got != filepath.Join(home, ".gemini", "antigravity-cli", "skills") {
-		t.Fatalf("SkillsDir() = %q, want %q", got, filepath.Join(home, ".gemini", "antigravity-cli", "skills"))
-	}
+		if got := a.GlobalConfigDir(home); got != filepath.Join(home, ".gemini", "antigravity-ide") {
+			t.Fatalf("GlobalConfigDir() = %q, want %q", got, filepath.Join(home, ".gemini", "antigravity-ide"))
+		}
 
-	if got := a.MCPConfigPath(home, "ctx7"); got != filepath.Join(home, ".gemini", "antigravity-cli", "mcp_config.json") {
-		t.Fatalf("MCPConfigPath() = %q, want %q", got, filepath.Join(home, ".gemini", "antigravity-cli", "mcp_config.json"))
-	}
+		if got := a.SkillsDir(home); got != filepath.Join(home, ".gemini", "antigravity-ide", "skills") {
+			t.Fatalf("SkillsDir() = %q, want %q", got, filepath.Join(home, ".gemini", "antigravity-ide", "skills"))
+		}
 
-	if got := a.SystemPromptFile(home); got != filepath.Join(home, ".gemini", "GEMINI.md") {
-		t.Fatalf("SystemPromptFile() = %q, want %q", got, filepath.Join(home, ".gemini", "GEMINI.md"))
-	}
+		if got := a.MCPConfigPath(home, "ctx7"); got != filepath.Join(home, ".gemini", "antigravity-ide", "mcp_config.json") {
+			t.Fatalf("MCPConfigPath() = %q, want %q", got, filepath.Join(home, ".gemini", "antigravity-ide", "mcp_config.json"))
+		}
 
-	if got := a.SettingsPath(home); got != filepath.Join(home, ".gemini", "antigravity-cli", "settings.json") {
-		t.Fatalf("SettingsPath() = %q, want %q", got, filepath.Join(home, ".gemini", "antigravity-cli", "settings.json"))
-	}
+		if got := a.SystemPromptFile(home); got != filepath.Join(home, ".gemini", "GEMINI.md") {
+			t.Fatalf("SystemPromptFile() = %q, want %q", got, filepath.Join(home, ".gemini", "GEMINI.md"))
+		}
 
-	if got := a.SystemPromptDir(home); got != filepath.Join(home, ".gemini") {
-		t.Fatalf("SystemPromptDir() = %q, want %q", got, filepath.Join(home, ".gemini"))
-	}
+		if got := a.SettingsPath(home); got != filepath.Join(home, ".gemini", "antigravity-ide", "settings.json") {
+			t.Fatalf("SettingsPath() = %q, want %q", got, filepath.Join(home, ".gemini", "antigravity-ide", "settings.json"))
+		}
+
+		if got := a.SystemPromptDir(home); got != filepath.Join(home, ".gemini") {
+			t.Fatalf("SystemPromptDir() = %q, want %q", got, filepath.Join(home, ".gemini"))
+		}
+	})
+
+	t.Run("resolves to antigravity-cli when only cli folder exists", func(t *testing.T) {
+		a := &Adapter{
+			statPath: func(path string) statResult {
+				if path == filepath.Join(home, ".gemini", "antigravity-cli") {
+					return statResult{isDir: true}
+				}
+				return statResult{err: os.ErrNotExist}
+			},
+		}
+
+		if got := a.GlobalConfigDir(home); got != filepath.Join(home, ".gemini", "antigravity-cli") {
+			t.Fatalf("GlobalConfigDir() = %q, want %q", got, filepath.Join(home, ".gemini", "antigravity-cli"))
+		}
+
+		if got := a.SkillsDir(home); got != filepath.Join(home, ".gemini", "antigravity-cli", "skills") {
+			t.Fatalf("SkillsDir() = %q, want %q", got, filepath.Join(home, ".gemini", "antigravity-cli", "skills"))
+		}
+
+		if got := a.MCPConfigPath(home, "ctx7"); got != filepath.Join(home, ".gemini", "antigravity-cli", "mcp_config.json") {
+			t.Fatalf("MCPConfigPath() = %q, want %q", got, filepath.Join(home, ".gemini", "antigravity-cli", "mcp_config.json"))
+		}
+
+		if got := a.SettingsPath(home); got != filepath.Join(home, ".gemini", "antigravity-cli", "settings.json") {
+			t.Fatalf("SettingsPath() = %q, want %q", got, filepath.Join(home, ".gemini", "antigravity-cli", "settings.json"))
+		}
+	})
+
+	t.Run("default fallback when neither folder exists", func(t *testing.T) {
+		a := &Adapter{
+			statPath: func(path string) statResult {
+				return statResult{err: os.ErrNotExist}
+			},
+		}
+
+		if got := a.GlobalConfigDir(home); got != filepath.Join(home, ".gemini", "antigravity-ide") {
+			t.Fatalf("GlobalConfigDir() = %q, want %q", got, filepath.Join(home, ".gemini", "antigravity-ide"))
+		}
+	})
 }
 
 func TestCapabilities(t *testing.T) {

--- a/internal/agents/antigravity/adapter_test.go
+++ b/internal/agents/antigravity/adapter_test.go
@@ -11,66 +11,133 @@ import (
 	"github.com/gentleman-programming/gentle-ai/internal/system"
 )
 
+// makeStatFn returns a statPath function that reports the given paths as existing
+// directories. Any path not in the set returns os.ErrNotExist.
+func makeStatFn(existingDirs ...string) func(string) statResult {
+	set := make(map[string]struct{}, len(existingDirs))
+	for _, d := range existingDirs {
+		set[d] = struct{}{}
+	}
+	return func(path string) statResult {
+		if _, ok := set[path]; ok {
+			return statResult{isDir: true}
+		}
+		return statResult{err: os.ErrNotExist}
+	}
+}
+
+// --- antigravityVariantDir ---
+
+func TestAntigravityVariantDir(t *testing.T) {
+	home := t.TempDir()
+	cliDir := filepath.Join(home, ".gemini", "antigravity-cli")
+	desktopDir := filepath.Join(home, ".gemini", "antigravity-desktop")
+
+	tests := []struct {
+		name         string
+		existingDirs []string
+		wantSuffix   string // last two path segments expected
+	}{
+		{
+			name:         "only CLI dir exists resolves to CLI",
+			existingDirs: []string{cliDir},
+			wantSuffix:   filepath.Join(".gemini", "antigravity-cli"),
+		},
+		{
+			name:         "only Desktop dir exists resolves to Desktop",
+			existingDirs: []string{desktopDir},
+			wantSuffix:   filepath.Join(".gemini", "antigravity-desktop"),
+		},
+		{
+			name:         "both exist prefers Desktop",
+			existingDirs: []string{cliDir, desktopDir},
+			wantSuffix:   filepath.Join(".gemini", "antigravity-desktop"),
+		},
+		{
+			name:         "neither exists falls back to CLI",
+			existingDirs: []string{},
+			wantSuffix:   filepath.Join(".gemini", "antigravity-cli"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := &Adapter{statPath: makeStatFn(tt.existingDirs...)}
+			got := a.antigravityVariantDir(home)
+			want := filepath.Join(home, tt.wantSuffix)
+			if got != want {
+				t.Fatalf("antigravityVariantDir() = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+// --- Detect ---
+
 func TestDetect(t *testing.T) {
+	home := t.TempDir()
+	cliDir := filepath.Join(home, ".gemini", "antigravity-cli")
+	desktopDir := filepath.Join(home, ".gemini", "antigravity-desktop")
+
 	tests := []struct {
 		name            string
-		existingDirs    map[string]bool
-		statErr         error
+		existingDirs    []string
+		overrideStat    func(string) statResult // optional; overrides makeStatFn when set
 		wantInstalled   bool
+		wantBinaryPath  string
 		wantConfigPath  string
 		wantConfigFound bool
 		wantErr         bool
 	}{
 		{
-			name:            "config directory antigravity-ide found",
-			existingDirs:    map[string]bool{"/tmp/home/.gemini/antigravity-ide": true},
+			name:            "CLI dir found, no Desktop",
+			existingDirs:    []string{cliDir},
 			wantInstalled:   true,
-			wantConfigPath:  filepath.Join("/tmp/home", ".gemini", "antigravity-ide"),
+			wantConfigPath:  cliDir,
 			wantConfigFound: true,
 		},
 		{
-			name:            "config directory antigravity-cli found",
-			existingDirs:    map[string]bool{"/tmp/home/.gemini/antigravity-cli": true},
+			name:            "Desktop dir found, no CLI",
+			existingDirs:    []string{desktopDir},
 			wantInstalled:   true,
-			wantConfigPath:  filepath.Join("/tmp/home", ".gemini", "antigravity-cli"),
+			wantConfigPath:  desktopDir,
 			wantConfigFound: true,
 		},
 		{
-			name:            "both directories found - prefers ide",
-			existingDirs:    map[string]bool{"/tmp/home/.gemini/antigravity-ide": true, "/tmp/home/.gemini/antigravity-cli": true},
+			name:            "both exist, prefers Desktop",
+			existingDirs:    []string{cliDir, desktopDir},
 			wantInstalled:   true,
-			wantConfigPath:  filepath.Join("/tmp/home", ".gemini", "antigravity-ide"),
+			wantConfigPath:  desktopDir,
 			wantConfigFound: true,
 		},
 		{
-			name:            "config directory missing",
-			existingDirs:    map[string]bool{},
+			name:            "neither exists, falls back to CLI path",
+			existingDirs:    []string{},
 			wantInstalled:   false,
-			wantConfigPath:  filepath.Join("/tmp/home", ".gemini", "antigravity-ide"),
+			wantConfigPath:  cliDir,
 			wantConfigFound: false,
 		},
 		{
-			name:    "stat error bubbles up",
-			statErr: errors.New("permission denied"),
+			name: "stat error bubbles up",
+			overrideStat: func(string) statResult {
+				return statResult{err: errors.New("permission denied")}
+			},
 			wantErr: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			a := &Adapter{
-				statPath: func(path string) statResult {
-					if tt.statErr != nil {
-						return statResult{err: tt.statErr}
-					}
-					if tt.existingDirs[path] {
-						return statResult{isDir: true}
-					}
-					return statResult{err: os.ErrNotExist}
-				},
+			var statFn func(string) statResult
+			if tt.overrideStat != nil {
+				statFn = tt.overrideStat
+			} else {
+				statFn = makeStatFn(tt.existingDirs...)
 			}
 
-			installed, binaryPath, configPath, configFound, err := a.Detect(context.Background(), "/tmp/home")
+			a := &Adapter{statPath: statFn}
+
+			installed, binaryPath, configPath, configFound, err := a.Detect(context.Background(), home)
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("Detect() error = %v, wantErr %v", err, tt.wantErr)
 			}
@@ -98,6 +165,8 @@ func TestDetect(t *testing.T) {
 	}
 }
 
+// --- Installation ---
+
 func TestInstallCommand(t *testing.T) {
 	a := NewAdapter()
 
@@ -124,83 +193,65 @@ func TestSupportsAutoInstall(t *testing.T) {
 	}
 }
 
-func TestConfigPathsCrossPlatform(t *testing.T) {
+// --- Config paths ---
+
+func TestConfigPathsDesktopOnly(t *testing.T) {
+	home := t.TempDir()
+	desktopDir := filepath.Join(home, ".gemini", "antigravity-desktop")
+	a := &Adapter{statPath: makeStatFn(desktopDir)}
+
+	if got := a.GlobalConfigDir(home); got != desktopDir {
+		t.Fatalf("GlobalConfigDir() = %q, want %q", got, desktopDir)
+	}
+	if got := a.SkillsDir(home); got != filepath.Join(desktopDir, "skills") {
+		t.Fatalf("SkillsDir() = %q, want %q", got, filepath.Join(desktopDir, "skills"))
+	}
+	if got := a.SettingsPath(home); got != filepath.Join(desktopDir, "settings.json") {
+		t.Fatalf("SettingsPath() = %q, want %q", got, filepath.Join(desktopDir, "settings.json"))
+	}
+	if got := a.MCPConfigPath(home, "ctx7"); got != filepath.Join(desktopDir, "mcp_config.json") {
+		t.Fatalf("MCPConfigPath() = %q, want %q", got, filepath.Join(desktopDir, "mcp_config.json"))
+	}
+}
+
+func TestConfigPathsBothExistPrefersDesktop(t *testing.T) {
+	home := t.TempDir()
+	cliDir := filepath.Join(home, ".gemini", "antigravity-cli")
+	desktopDir := filepath.Join(home, ".gemini", "antigravity-desktop")
+	a := &Adapter{statPath: makeStatFn(cliDir, desktopDir)}
+
+	if got := a.GlobalConfigDir(home); got != desktopDir {
+		t.Fatalf("GlobalConfigDir() = %q, want %q (should prefer Desktop)", got, desktopDir)
+	}
+	if got := a.SkillsDir(home); got != filepath.Join(desktopDir, "skills") {
+		t.Fatalf("SkillsDir() = %q, want %q", got, filepath.Join(desktopDir, "skills"))
+	}
+}
+
+func TestConfigPathsNeitherExistsFallsBackToCLI(t *testing.T) {
+	home := t.TempDir()
+	cliDir := filepath.Join(home, ".gemini", "antigravity-cli")
+	a := &Adapter{statPath: makeStatFn()}
+
+	if got := a.GlobalConfigDir(home); got != cliDir {
+		t.Fatalf("GlobalConfigDir() = %q, want %q (should fall back to CLI)", got, cliDir)
+	}
+}
+
+func TestConfigPathsStaticPaths(t *testing.T) {
+	// SystemPromptDir and SystemPromptFile are not variant-dependent.
+	a := NewAdapter()
 	home := "/tmp/home"
 
-	t.Run("resolves to antigravity-ide when ide folder exists", func(t *testing.T) {
-		a := &Adapter{
-			statPath: func(path string) statResult {
-				if path == filepath.Join(home, ".gemini", "antigravity-ide") {
-					return statResult{isDir: true}
-				}
-				return statResult{err: os.ErrNotExist}
-			},
-		}
-
-		if got := a.GlobalConfigDir(home); got != filepath.Join(home, ".gemini", "antigravity-ide") {
-			t.Fatalf("GlobalConfigDir() = %q, want %q", got, filepath.Join(home, ".gemini", "antigravity-ide"))
-		}
-
-		if got := a.SkillsDir(home); got != filepath.Join(home, ".gemini", "antigravity-ide", "skills") {
-			t.Fatalf("SkillsDir() = %q, want %q", got, filepath.Join(home, ".gemini", "antigravity-ide", "skills"))
-		}
-
-		if got := a.MCPConfigPath(home, "ctx7"); got != filepath.Join(home, ".gemini", "antigravity-ide", "mcp_config.json") {
-			t.Fatalf("MCPConfigPath() = %q, want %q", got, filepath.Join(home, ".gemini", "antigravity-ide", "mcp_config.json"))
-		}
-
-		if got := a.SystemPromptFile(home); got != filepath.Join(home, ".gemini", "GEMINI.md") {
-			t.Fatalf("SystemPromptFile() = %q, want %q", got, filepath.Join(home, ".gemini", "GEMINI.md"))
-		}
-
-		if got := a.SettingsPath(home); got != filepath.Join(home, ".gemini", "antigravity-ide", "settings.json") {
-			t.Fatalf("SettingsPath() = %q, want %q", got, filepath.Join(home, ".gemini", "antigravity-ide", "settings.json"))
-		}
-
-		if got := a.SystemPromptDir(home); got != filepath.Join(home, ".gemini") {
-			t.Fatalf("SystemPromptDir() = %q, want %q", got, filepath.Join(home, ".gemini"))
-		}
-	})
-
-	t.Run("resolves to antigravity-cli when only cli folder exists", func(t *testing.T) {
-		a := &Adapter{
-			statPath: func(path string) statResult {
-				if path == filepath.Join(home, ".gemini", "antigravity-cli") {
-					return statResult{isDir: true}
-				}
-				return statResult{err: os.ErrNotExist}
-			},
-		}
-
-		if got := a.GlobalConfigDir(home); got != filepath.Join(home, ".gemini", "antigravity-cli") {
-			t.Fatalf("GlobalConfigDir() = %q, want %q", got, filepath.Join(home, ".gemini", "antigravity-cli"))
-		}
-
-		if got := a.SkillsDir(home); got != filepath.Join(home, ".gemini", "antigravity-cli", "skills") {
-			t.Fatalf("SkillsDir() = %q, want %q", got, filepath.Join(home, ".gemini", "antigravity-cli", "skills"))
-		}
-
-		if got := a.MCPConfigPath(home, "ctx7"); got != filepath.Join(home, ".gemini", "antigravity-cli", "mcp_config.json") {
-			t.Fatalf("MCPConfigPath() = %q, want %q", got, filepath.Join(home, ".gemini", "antigravity-cli", "mcp_config.json"))
-		}
-
-		if got := a.SettingsPath(home); got != filepath.Join(home, ".gemini", "antigravity-cli", "settings.json") {
-			t.Fatalf("SettingsPath() = %q, want %q", got, filepath.Join(home, ".gemini", "antigravity-cli", "settings.json"))
-		}
-	})
-
-	t.Run("default fallback when neither folder exists", func(t *testing.T) {
-		a := &Adapter{
-			statPath: func(path string) statResult {
-				return statResult{err: os.ErrNotExist}
-			},
-		}
-
-		if got := a.GlobalConfigDir(home); got != filepath.Join(home, ".gemini", "antigravity-ide") {
-			t.Fatalf("GlobalConfigDir() = %q, want %q", got, filepath.Join(home, ".gemini", "antigravity-ide"))
-		}
-	})
+	if got := a.SystemPromptDir(home); got != filepath.Join(home, ".gemini") {
+		t.Fatalf("SystemPromptDir() = %q, want %q", got, filepath.Join(home, ".gemini"))
+	}
+	if got := a.SystemPromptFile(home); got != filepath.Join(home, ".gemini", "GEMINI.md") {
+		t.Fatalf("SystemPromptFile() = %q, want %q", got, filepath.Join(home, ".gemini", "GEMINI.md"))
+	}
 }
+
+// --- Capabilities ---
 
 func TestCapabilities(t *testing.T) {
 	a := NewAdapter()
@@ -208,43 +259,36 @@ func TestCapabilities(t *testing.T) {
 	if !a.SupportsSkills() {
 		t.Fatal("SupportsSkills() = false, want true")
 	}
-
 	if !a.SupportsSystemPrompt() {
 		t.Fatal("SupportsSystemPrompt() = false, want true")
 	}
-
 	if !a.SupportsMCP() {
 		t.Fatal("SupportsMCP() = false, want true")
 	}
-
 	if a.SupportsOutputStyles() {
 		t.Fatal("SupportsOutputStyles() = true, want false")
 	}
-
 	if a.SupportsSlashCommands() {
 		t.Fatal("SupportsSlashCommands() = true, want false")
 	}
-
 	if a.SupportsSubAgents() {
 		t.Fatal("SupportsSubAgents() = true, want false")
 	}
-
 	if got := a.OutputStyleDir("/tmp/home"); got != "" {
 		t.Fatalf("OutputStyleDir() = %q, want empty string", got)
 	}
-
 	if got := a.CommandsDir("/tmp/home"); got != "" {
 		t.Fatalf("CommandsDir() = %q, want empty string", got)
 	}
-
 	if got := a.SubAgentsDir("/tmp/home"); got != "" {
 		t.Fatalf("SubAgentsDir() = %q, want empty string", got)
 	}
-
 	if got := a.EmbeddedSubAgentsDir(); got != "" {
 		t.Fatalf("EmbeddedSubAgentsDir() = %q, want empty string", got)
 	}
 }
+
+// --- Strategies ---
 
 func TestStrategies(t *testing.T) {
 	a := NewAdapter()
@@ -252,11 +296,12 @@ func TestStrategies(t *testing.T) {
 	if got := a.SystemPromptStrategy(); got != model.StrategyAppendToFile {
 		t.Fatalf("SystemPromptStrategy() = %v, want StrategyAppendToFile", got)
 	}
-
 	if got := a.MCPStrategy(); got != model.StrategyMCPConfigFile {
 		t.Fatalf("MCPStrategy() = %v, want StrategyMCPConfigFile", got)
 	}
 }
+
+// --- Identity ---
 
 func TestIdentity(t *testing.T) {
 	a := NewAdapter()
@@ -264,7 +309,6 @@ func TestIdentity(t *testing.T) {
 	if got := a.Agent(); got != model.AgentAntigravity {
 		t.Fatalf("Agent() = %q, want %q", got, model.AgentAntigravity)
 	}
-
 	if got := a.Tier(); got != model.TierFull {
 		t.Fatalf("Tier() = %q, want %q", got, model.TierFull)
 	}


### PR DESCRIPTION
This PR addresses the configuration path changes introduced in recent Antigravity updates (Issue #604) by refactoring the Antigravity adapter to dynamically resolve configuration and setting paths for both Antigravity Desktop and Antigravity CLI.

### What this PR does:

1. Dynamic Config Resolution: Updates `Detect`, `GlobalConfigDir`, `SkillsDir`, `SettingsPath`, and `MCPConfigPath` to dynamically scan for the existence of `~/.gemini/antigravity-desktop` (the Desktop path) and fallback to `~/.gemini/antigravity-cli` (the CLI path).
2. Robust Path Fallbacks: Avoids breaking existing configurations or CLI settings while fully enabling Desktop integration pathways.
3. Comprehensive Unit Tests: Adds mock filesystem testing within `adapter_test.go` to assert correct resolution across multiple scenarios: only CLI exists, only Desktop exists, both exist, and neither exists.
4. Error Handling: Hardens error propagation in the `Detect` function to bubble up critical errors immediately while gracefully ignoring normal file-missing checks.

Closes #604