### PR TITLE
fix(agents/pi): use positional pnpm dlx argument to avoid --package misparse

### DIFF
--- a/internal/agents/pi/adapter.go
+++ b/internal/agents/pi/adapter.go
@@ -87,7 +87,7 @@ func (a *Adapter) InstallCommand(system.PlatformProfile) ([][]string, error) {
 
 func (a *Adapter) engramInitCommand() []string {
 	if _, err := a.lookPath("pnpm"); err == nil {
-		return []string{"pnpm", "dlx", "--package", "gentle-engram@" + versions.GentleEngram, "pi-engram", "init"}
+		return []string{"pnpm", "dlx", "gentle-engram@" + versions.GentleEngram, "pi-engram", "init"}
 	}
 	return []string{"npm", "exec", "--yes", "--package", "gentle-engram@" + versions.GentleEngram, "--", "pi-engram", "init"}
 }

--- a/internal/agents/pi/adapter_test.go
+++ b/internal/agents/pi/adapter_test.go
@@ -187,7 +187,7 @@ func TestAdapterInstallCommandSequenceUsesPnpmForEngramInitWhenAvailable(t *test
 		t.Fatalf("InstallCommand() error = %v", err)
 	}
 
-	want := []string{"pnpm", "dlx", "--package", "gentle-engram@" + versions.GentleEngram, "pi-engram", "init"}
+	want := []string{"pnpm", "dlx", "gentle-engram@" + versions.GentleEngram, "pi-engram", "init"}
 	if !reflect.DeepEqual(commands[3], want) {
 		t.Fatalf("InstallCommand()[3] = %#v, want %#v", commands[3], want)
 	}

--- a/internal/cli/run_integration_test.go
+++ b/internal/cli/run_integration_test.go
@@ -49,7 +49,7 @@ func stringSliceContains(items []string, want string) bool {
 
 func engramInitCommandForTest() string {
 	if _, err := exec.LookPath("pnpm"); err == nil {
-		return fmt.Sprintf("pnpm dlx --package gentle-engram@%s pi-engram init", versions.GentleEngram)
+		return fmt.Sprintf("pnpm dlx gentle-engram@%s pi-engram init", versions.GentleEngram)
 	}
 	return fmt.Sprintf("npm exec --yes --package gentle-engram@%s -- pi-engram init", versions.GentleEngram)
 }
@@ -109,7 +109,7 @@ func TestRunInstallEngramForPiAndOpenCodeProvisionsBothMCPTargets(t *testing.T) 
 		commands = append(commands, strings.Join(append([]string{name}, args...), " "))
 		// Simulate pi-engram init writing mcp.json with the new schema.
 		isNpmEngramInit := name == "npm" && len(args) >= 7 && args[5] == "pi-engram" && args[6] == "init"
-		isPnpmEngramInit := name == "pnpm" && len(args) >= 5 && args[3] == "pi-engram" && args[4] == "init"
+		isPnpmEngramInit := name == "pnpm" && len(args) >= 4 && args[2] == "pi-engram" && args[3] == "init"
 		if isNpmEngramInit || isPnpmEngramInit {
 			mcpPath := filepath.Join(home, ".pi", "agent", "mcp.json")
 			if err := os.MkdirAll(filepath.Dir(mcpPath), 0o755); err != nil {
@@ -142,7 +142,7 @@ func TestRunInstallEngramForPiAndOpenCodeProvisionsBothMCPTargets(t *testing.T) 
 		t.Fatalf("commands missing %q; got %v", "pi install npm:pi-mcp-adapter", commands)
 	}
 	if !stringSliceContains(commands, fmt.Sprintf("npm exec --yes --package gentle-engram@%s -- pi-engram init", versions.GentleEngram)) &&
-		!stringSliceContains(commands, fmt.Sprintf("pnpm dlx --package gentle-engram@%s pi-engram init", versions.GentleEngram)) {
+		!stringSliceContains(commands, fmt.Sprintf("pnpm dlx gentle-engram@%s pi-engram init", versions.GentleEngram)) {
 		t.Fatalf("commands missing Engram init command; got %v", commands)
 	}
 }


### PR DESCRIPTION
## Linked Issue

Closes #655

## PR Type

- [x] `type:bug`

## Summary

Some pnpm versions interpret `--package` as a positional package name, causing the `agent:pi` install step to crash with:

```
ERR_PNPM_FETCH_404  GET https://registry.npmjs.org/--package: Not Found - 404
```

This switches the pnpm path to the positional form `pnpm dlx gentle-engram@<version> pi-engram init`, which works on all pnpm versions because `pi-engram` is the binary exposed by the `gentle-engram` npm package. The npm exec path (line 92) is left unchanged — `npm exec --package` parses correctly.

## Changes

| File | Change |
|------|--------|
| `internal/agents/pi/adapter.go` | Drop `--package` flag from pnpm dlx command |
| `internal/agents/pi/adapter_test.go` | Update assertion to match new positional form |
| `internal/cli/run_integration_test.go` | Update helper, assertion, and mock arg indices |

## Test Plan

- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [x] `go build` clean

## Contributor Checklist

- [x] Linked to approved issue (#655 has `status:approved`)
- [x] Under 400 changed lines (5 LOC)
- [x] Conventional Commits format
- [x] No Co-Authored-By trailers