### PR TITLE
fix(agents/antigravity): resolve CLI and Desktop config paths dynamically

### DIFF
--- a/internal/agents/antigravity/adapter.go
+++ b/internal/agents/antigravity/adapter.go
@@ -24,6 +24,16 @@ func NewAdapter() *Adapter {
 	}
 }
 
+// antigravityVariantDir returns the resolved variant directory under ~/.gemini.
+// Prefers "antigravity-desktop" when it exists, falls back to "antigravity-cli".
+func (a *Adapter) antigravityVariantDir(homeDir string) string {
+	desktop := filepath.Join(homeDir, ".gemini", "antigravity-desktop")
+	if stat := a.statPath(desktop); stat.err == nil {
+		return desktop
+	}
+	return filepath.Join(homeDir, ".gemini", "antigravity-cli")
+}
+
 // --- Identity ---
 
 func (a *Adapter) Agent() model.AgentID {
@@ -37,7 +47,7 @@ func (a *Adapter) Tier() model.SupportTier {
 // --- Detection ---
 
 func (a *Adapter) Detect(_ context.Context, homeDir string) (bool, string, string, bool, error) {
-	configPath := filepath.Join(homeDir, ".gemini", "antigravity-cli")
+	configPath := a.antigravityVariantDir(homeDir)
 
 	stat := a.statPath(configPath)
 	if stat.err != nil {
@@ -63,7 +73,7 @@ func (a *Adapter) InstallCommand(_ system.PlatformProfile) ([][]string, error) {
 // --- Config paths ---
 
 func (a *Adapter) GlobalConfigDir(homeDir string) string {
-	return filepath.Join(homeDir, ".gemini", "antigravity-cli")
+	return a.antigravityVariantDir(homeDir)
 }
 
 func (a *Adapter) SystemPromptDir(homeDir string) string {
@@ -75,11 +85,11 @@ func (a *Adapter) SystemPromptFile(homeDir string) string {
 }
 
 func (a *Adapter) SkillsDir(homeDir string) string {
-	return filepath.Join(homeDir, ".gemini", "antigravity-cli", "skills")
+	return filepath.Join(a.antigravityVariantDir(homeDir), "skills")
 }
 
 func (a *Adapter) SettingsPath(homeDir string) string {
-	return filepath.Join(homeDir, ".gemini", "antigravity-cli", "settings.json")
+	return filepath.Join(a.antigravityVariantDir(homeDir), "settings.json")
 }
 
 // --- Config strategies ---
@@ -95,7 +105,7 @@ func (a *Adapter) MCPStrategy() model.MCPStrategy {
 // --- MCP ---
 
 func (a *Adapter) MCPConfigPath(homeDir string, _ string) string {
-	return filepath.Join(homeDir, ".gemini", "antigravity-cli", "mcp_config.json")
+	return filepath.Join(a.antigravityVariantDir(homeDir), "mcp_config.json")
 }
 
 // --- Optional capabilities ---

--- a/internal/agents/antigravity/adapter_test.go
+++ b/internal/agents/antigravity/adapter_test.go
@@ -11,10 +11,78 @@ import (
 	"github.com/gentleman-programming/gentle-ai/internal/system"
 )
 
+// makeStatFn returns a statPath function that reports the given paths as existing
+// directories. Any path not in the set returns os.ErrNotExist.
+func makeStatFn(existingDirs ...string) func(string) statResult {
+	set := make(map[string]struct{}, len(existingDirs))
+	for _, d := range existingDirs {
+		set[d] = struct{}{}
+	}
+	return func(path string) statResult {
+		if _, ok := set[path]; ok {
+			return statResult{isDir: true}
+		}
+		return statResult{err: os.ErrNotExist}
+	}
+}
+
+// --- antigravityVariantDir ---
+
+func TestAntigravityVariantDir(t *testing.T) {
+	home := t.TempDir()
+	cliDir := filepath.Join(home, ".gemini", "antigravity-cli")
+	desktopDir := filepath.Join(home, ".gemini", "antigravity-desktop")
+
+	tests := []struct {
+		name         string
+		existingDirs []string
+		wantSuffix   string // last two path segments expected
+	}{
+		{
+			name:         "only CLI dir exists resolves to CLI",
+			existingDirs: []string{cliDir},
+			wantSuffix:   filepath.Join(".gemini", "antigravity-cli"),
+		},
+		{
+			name:         "only Desktop dir exists resolves to Desktop",
+			existingDirs: []string{desktopDir},
+			wantSuffix:   filepath.Join(".gemini", "antigravity-desktop"),
+		},
+		{
+			name:         "both exist prefers Desktop",
+			existingDirs: []string{cliDir, desktopDir},
+			wantSuffix:   filepath.Join(".gemini", "antigravity-desktop"),
+		},
+		{
+			name:         "neither exists falls back to CLI",
+			existingDirs: []string{},
+			wantSuffix:   filepath.Join(".gemini", "antigravity-cli"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := &Adapter{statPath: makeStatFn(tt.existingDirs...)}
+			got := a.antigravityVariantDir(home)
+			want := filepath.Join(home, tt.wantSuffix)
+			if got != want {
+				t.Fatalf("antigravityVariantDir() = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+// --- Detect ---
+
 func TestDetect(t *testing.T) {
+	home := t.TempDir()
+	cliDir := filepath.Join(home, ".gemini", "antigravity-cli")
+	desktopDir := filepath.Join(home, ".gemini", "antigravity-desktop")
+
 	tests := []struct {
 		name            string
-		stat            statResult
+		existingDirs    []string
+		overrideStat    func(string) statResult // optional; overrides makeStatFn when set
 		wantInstalled   bool
 		wantBinaryPath  string
 		wantConfigPath  string
@@ -22,41 +90,54 @@ func TestDetect(t *testing.T) {
 		wantErr         bool
 	}{
 		{
-			name:            "config directory found",
-			stat:            statResult{isDir: true},
+			name:            "CLI dir found, no Desktop",
+			existingDirs:    []string{cliDir},
 			wantInstalled:   true,
-			wantBinaryPath:  "",
-			wantConfigPath:  filepath.Join("/tmp/home", ".gemini", "antigravity-cli"),
+			wantConfigPath:  cliDir,
 			wantConfigFound: true,
 		},
 		{
-			name:            "config directory missing",
-			stat:            statResult{err: os.ErrNotExist},
+			name:            "Desktop dir found, no CLI",
+			existingDirs:    []string{desktopDir},
+			wantInstalled:   true,
+			wantConfigPath:  desktopDir,
+			wantConfigFound: true,
+		},
+		{
+			name:            "both exist, prefers Desktop",
+			existingDirs:    []string{cliDir, desktopDir},
+			wantInstalled:   true,
+			wantConfigPath:  desktopDir,
+			wantConfigFound: true,
+		},
+		{
+			name:            "neither exists, falls back to CLI path",
+			existingDirs:    []string{},
 			wantInstalled:   false,
-			wantBinaryPath:  "",
-			wantConfigPath:  filepath.Join("/tmp/home", ".gemini", "antigravity-cli"),
+			wantConfigPath:  cliDir,
 			wantConfigFound: false,
 		},
 		{
-			name:    "stat error bubbles up",
-			stat:    statResult{err: errors.New("permission denied")},
+			name: "stat error bubbles up",
+			overrideStat: func(string) statResult {
+				return statResult{err: errors.New("permission denied")}
+			},
 			wantErr: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			a := &Adapter{
-				statPath: func(string) statResult {
-					return tt.stat
-				},
+			statFn := makeStatFn(tt.existingDirs...)
+			if tt.overrideStat != nil {
+				statFn = tt.overrideStat
 			}
+			a := &Adapter{statPath: statFn}
 
-			installed, binaryPath, configPath, configFound, err := a.Detect(context.Background(), "/tmp/home")
+			installed, binaryPath, configPath, configFound, err := a.Detect(context.Background(), home)
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("Detect() error = %v, wantErr %v", err, tt.wantErr)
 			}
-
 			if tt.wantErr {
 				return
 			}
@@ -64,21 +145,97 @@ func TestDetect(t *testing.T) {
 			if installed != tt.wantInstalled {
 				t.Fatalf("Detect() installed = %v, want %v", installed, tt.wantInstalled)
 			}
-
 			if binaryPath != tt.wantBinaryPath {
 				t.Fatalf("Detect() binaryPath = %q, want %q", binaryPath, tt.wantBinaryPath)
 			}
-
 			if configPath != tt.wantConfigPath {
 				t.Fatalf("Detect() configPath = %q, want %q", configPath, tt.wantConfigPath)
 			}
-
 			if configFound != tt.wantConfigFound {
 				t.Fatalf("Detect() configFound = %v, want %v", configFound, tt.wantConfigFound)
 			}
 		})
 	}
 }
+
+// --- Config paths ---
+
+func TestConfigPathsCLIOnly(t *testing.T) {
+	home := t.TempDir()
+	cliDir := filepath.Join(home, ".gemini", "antigravity-cli")
+	a := &Adapter{statPath: makeStatFn(cliDir)}
+
+	if got := a.GlobalConfigDir(home); got != cliDir {
+		t.Fatalf("GlobalConfigDir() = %q, want %q", got, cliDir)
+	}
+	if got := a.SkillsDir(home); got != filepath.Join(cliDir, "skills") {
+		t.Fatalf("SkillsDir() = %q, want %q", got, filepath.Join(cliDir, "skills"))
+	}
+	if got := a.SettingsPath(home); got != filepath.Join(cliDir, "settings.json") {
+		t.Fatalf("SettingsPath() = %q, want %q", got, filepath.Join(cliDir, "settings.json"))
+	}
+	if got := a.MCPConfigPath(home, "ctx7"); got != filepath.Join(cliDir, "mcp_config.json") {
+		t.Fatalf("MCPConfigPath() = %q, want %q", got, filepath.Join(cliDir, "mcp_config.json"))
+	}
+}
+
+func TestConfigPathsDesktopOnly(t *testing.T) {
+	home := t.TempDir()
+	desktopDir := filepath.Join(home, ".gemini", "antigravity-desktop")
+	a := &Adapter{statPath: makeStatFn(desktopDir)}
+
+	if got := a.GlobalConfigDir(home); got != desktopDir {
+		t.Fatalf("GlobalConfigDir() = %q, want %q", got, desktopDir)
+	}
+	if got := a.SkillsDir(home); got != filepath.Join(desktopDir, "skills") {
+		t.Fatalf("SkillsDir() = %q, want %q", got, filepath.Join(desktopDir, "skills"))
+	}
+	if got := a.SettingsPath(home); got != filepath.Join(desktopDir, "settings.json") {
+		t.Fatalf("SettingsPath() = %q, want %q", got, filepath.Join(desktopDir, "settings.json"))
+	}
+	if got := a.MCPConfigPath(home, "ctx7"); got != filepath.Join(desktopDir, "mcp_config.json") {
+		t.Fatalf("MCPConfigPath() = %q, want %q", got, filepath.Join(desktopDir, "mcp_config.json"))
+	}
+}
+
+func TestConfigPathsBothExistPrefersDesktop(t *testing.T) {
+	home := t.TempDir()
+	cliDir := filepath.Join(home, ".gemini", "antigravity-cli")
+	desktopDir := filepath.Join(home, ".gemini", "antigravity-desktop")
+	a := &Adapter{statPath: makeStatFn(cliDir, desktopDir)}
+
+	if got := a.GlobalConfigDir(home); got != desktopDir {
+		t.Fatalf("GlobalConfigDir() = %q, want %q (should prefer Desktop)", got, desktopDir)
+	}
+	if got := a.SkillsDir(home); got != filepath.Join(desktopDir, "skills") {
+		t.Fatalf("SkillsDir() = %q, want %q", got, filepath.Join(desktopDir, "skills"))
+	}
+}
+
+func TestConfigPathsNeitherExistsFallsBackToCLI(t *testing.T) {
+	home := t.TempDir()
+	cliDir := filepath.Join(home, ".gemini", "antigravity-cli")
+	a := &Adapter{statPath: makeStatFn()}
+
+	if got := a.GlobalConfigDir(home); got != cliDir {
+		t.Fatalf("GlobalConfigDir() = %q, want %q (should fall back to CLI)", got, cliDir)
+	}
+}
+
+func TestConfigPathsStaticPaths(t *testing.T) {
+	// SystemPromptDir and SystemPromptFile are not variant-dependent.
+	a := NewAdapter()
+	home := "/tmp/home"
+
+	if got := a.SystemPromptDir(home); got != filepath.Join(home, ".gemini") {
+		t.Fatalf("SystemPromptDir() = %q, want %q", got, filepath.Join(home, ".gemini"))
+	}
+	if got := a.SystemPromptFile(home); got != filepath.Join(home, ".gemini", "GEMINI.md") {
+		t.Fatalf("SystemPromptFile() = %q, want %q", got, filepath.Join(home, ".gemini", "GEMINI.md"))
+	}
+}
+
+// --- Installation ---
 
 func TestInstallCommand(t *testing.T) {
 	a := NewAdapter()
@@ -106,34 +263,7 @@ func TestSupportsAutoInstall(t *testing.T) {
 	}
 }
 
-func TestConfigPathsCrossPlatform(t *testing.T) {
-	a := NewAdapter()
-	home := "/tmp/home"
-
-	if got := a.GlobalConfigDir(home); got != filepath.Join(home, ".gemini", "antigravity-cli") {
-		t.Fatalf("GlobalConfigDir() = %q, want %q", got, filepath.Join(home, ".gemini", "antigravity-cli"))
-	}
-
-	if got := a.SkillsDir(home); got != filepath.Join(home, ".gemini", "antigravity-cli", "skills") {
-		t.Fatalf("SkillsDir() = %q, want %q", got, filepath.Join(home, ".gemini", "antigravity-cli", "skills"))
-	}
-
-	if got := a.MCPConfigPath(home, "ctx7"); got != filepath.Join(home, ".gemini", "antigravity-cli", "mcp_config.json") {
-		t.Fatalf("MCPConfigPath() = %q, want %q", got, filepath.Join(home, ".gemini", "antigravity-cli", "mcp_config.json"))
-	}
-
-	if got := a.SystemPromptFile(home); got != filepath.Join(home, ".gemini", "GEMINI.md") {
-		t.Fatalf("SystemPromptFile() = %q, want %q", got, filepath.Join(home, ".gemini", "GEMINI.md"))
-	}
-
-	if got := a.SettingsPath(home); got != filepath.Join(home, ".gemini", "antigravity-cli", "settings.json") {
-		t.Fatalf("SettingsPath() = %q, want %q", got, filepath.Join(home, ".gemini", "antigravity-cli", "settings.json"))
-	}
-
-	if got := a.SystemPromptDir(home); got != filepath.Join(home, ".gemini") {
-		t.Fatalf("SystemPromptDir() = %q, want %q", got, filepath.Join(home, ".gemini"))
-	}
-}
+// --- Capabilities ---
 
 func TestCapabilities(t *testing.T) {
 	a := NewAdapter()
@@ -141,43 +271,36 @@ func TestCapabilities(t *testing.T) {
 	if !a.SupportsSkills() {
 		t.Fatal("SupportsSkills() = false, want true")
 	}
-
 	if !a.SupportsSystemPrompt() {
 		t.Fatal("SupportsSystemPrompt() = false, want true")
 	}
-
 	if !a.SupportsMCP() {
 		t.Fatal("SupportsMCP() = false, want true")
 	}
-
 	if a.SupportsOutputStyles() {
 		t.Fatal("SupportsOutputStyles() = true, want false")
 	}
-
 	if a.SupportsSlashCommands() {
 		t.Fatal("SupportsSlashCommands() = true, want false")
 	}
-
 	if a.SupportsSubAgents() {
 		t.Fatal("SupportsSubAgents() = true, want false")
 	}
-
 	if got := a.OutputStyleDir("/tmp/home"); got != "" {
 		t.Fatalf("OutputStyleDir() = %q, want empty string", got)
 	}
-
 	if got := a.CommandsDir("/tmp/home"); got != "" {
 		t.Fatalf("CommandsDir() = %q, want empty string", got)
 	}
-
 	if got := a.SubAgentsDir("/tmp/home"); got != "" {
 		t.Fatalf("SubAgentsDir() = %q, want empty string", got)
 	}
-
 	if got := a.EmbeddedSubAgentsDir(); got != "" {
 		t.Fatalf("EmbeddedSubAgentsDir() = %q, want empty string", got)
 	}
 }
+
+// --- Strategies ---
 
 func TestStrategies(t *testing.T) {
 	a := NewAdapter()
@@ -185,11 +308,12 @@ func TestStrategies(t *testing.T) {
 	if got := a.SystemPromptStrategy(); got != model.StrategyAppendToFile {
 		t.Fatalf("SystemPromptStrategy() = %v, want StrategyAppendToFile", got)
 	}
-
 	if got := a.MCPStrategy(); got != model.StrategyMCPConfigFile {
 		t.Fatalf("MCPStrategy() = %v, want StrategyMCPConfigFile", got)
 	}
 }
+
+// --- Identity ---
 
 func TestIdentity(t *testing.T) {
 	a := NewAdapter()
@@ -197,7 +321,6 @@ func TestIdentity(t *testing.T) {
 	if got := a.Agent(); got != model.AgentAntigravity {
 		t.Fatalf("Agent() = %q, want %q", got, model.AgentAntigravity)
 	}
-
 	if got := a.Tier(); got != model.TierFull {
 		t.Fatalf("Tier() = %q, want %q", got, model.TierFull)
 	}


### PR DESCRIPTION
## Linked Issue

Closes #604

## PR Type

- [x] `type:bug`

## Summary

The Antigravity adapter previously hardcoded `~/.gemini/antigravity-cli` for every config-related path (`Detect`, `GlobalConfigDir`, `SkillsDir`, `SettingsPath`, `MCPConfigPath`). When a user installed Antigravity Desktop — which uses `~/.gemini/antigravity-desktop` — every path returned the wrong directory and all integration features failed.

This PR introduces a dynamic resolver that prefers Desktop when its directory exists and falls back to CLI otherwise. All adapter functions now delegate to the resolver.

**Scope:** Antigravity CLI and Antigravity Desktop only. Antigravity IDE is intentionally out of scope.

## Changes

| File | Change |
|------|--------|
| `internal/agents/antigravity/adapter.go` | New `antigravityVariantDir` resolver; all path functions delegate to it |
| `internal/agents/antigravity/adapter_test.go` | Table-driven coverage for CLI-only / Desktop-only / both / neither |

## Test Plan

- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [x] `go build` clean

## Contributor Checklist

- [x] Linked to approved issue (#604 has `status:approved`)
- [x] Under 400 changed lines
- [x] Conventional Commits format
- [x] No Co-Authored-By trailers