### PR TITLE
fix(components/engram): verify SHA256 checksum before installing direct binary

### DIFF
--- a/internal/components/engram/download.go
+++ b/internal/components/engram/download.go
@@ -4,6 +4,9 @@ import (
 	"archive/tar"
 	"archive/zip"
 	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -25,18 +28,24 @@ const (
 
 // Package-level vars for testability.
 var (
-	engramHTTPClient    = &http.Client{Timeout: 5 * time.Minute}
-	engramGitHubBaseURL = "https://github.com"
-	engramInstallDirFn  = engramInstallDir
+	engramHTTPClient       = &http.Client{Timeout: 5 * time.Minute}
+	engramGitHubBaseURL    = "https://github.com"
+	engramInstallDirFn     = engramInstallDir
+	engramChecksumURLFn    = engramChecksumURL
 )
 
 // DownloadLatestBinary fetches the latest engram release from GitHub and
 // installs it to the appropriate directory for the given platform.
 // It returns the full path to the installed binary.
 //
+// Checksum verification is mandatory: the install fails if checksums.txt is
+// unavailable, if the archive is not listed, or if the digest does not match.
+//
 // This is the non-brew installation method for Linux and Windows.
 // On macOS, brew handles engram transitively and this should not be called.
 func DownloadLatestBinary(profile system.PlatformProfile) (string, error) {
+	ctx := context.Background()
+
 	// 1. Fetch the latest version tag from GitHub API.
 	version, err := fetchLatestEngramVersion()
 	if err != nil {
@@ -47,6 +56,8 @@ func DownloadLatestBinary(profile system.PlatformProfile) (string, error) {
 	goos := profile.OS
 	goarch := normalizeArch(runtime.GOARCH)
 	assetURL := engramAssetURL(engramGitHubBaseURL, version, goos, goarch)
+	archiveName := engramArchiveName(version, goos, goarch)
+	checksumURL := engramChecksumURLFn(engramGitHubBaseURL, version)
 
 	// 3. Determine install directory.
 	installDir := engramInstallDirFn(goos)
@@ -54,20 +65,57 @@ func DownloadLatestBinary(profile system.PlatformProfile) (string, error) {
 		return "", fmt.Errorf("create engram install dir %q: %w", installDir, err)
 	}
 
-	// 4. Download and extract binary.
+	// 4. Download archive to a temp dir so we can verify before extracting.
 	binaryName := engramName
 	if goos == "windows" {
 		binaryName = engramName + ".exe"
 	}
 	outPath := filepath.Join(installDir, binaryName)
 
+	tmpDir, err := os.MkdirTemp("", "gentle-ai-engram-*")
+	if err != nil {
+		return "", fmt.Errorf("create temp dir: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	archivePath := filepath.Join(tmpDir, archiveName)
+	actualDigest, err := engramDownloadToFile(ctx, assetURL, archivePath)
+	if err != nil {
+		return "", fmt.Errorf("download engram archive: %w", err)
+	}
+
+	// 5. Verify checksum — fail closed if checksums.txt is unavailable or mismatched.
+	checksumsContent, err := engramFetchChecksums(ctx, checksumURL)
+	if err != nil {
+		return "", fmt.Errorf("checksum verification failed: checksums.txt unavailable: %w", err)
+	}
+	expectedDigest, err := engramExpectedChecksumFor(checksumsContent, archiveName)
+	if err != nil {
+		return "", fmt.Errorf("checksum verification failed: %w", err)
+	}
+	if actualDigest != expectedDigest {
+		return "", fmt.Errorf("checksum mismatch for %s:\n  expected: %s\n  got:      %s",
+			archiveName, expectedDigest, actualDigest)
+	}
+
+	// 6. Extract the verified binary.
+	f, err := os.Open(archivePath)
+	if err != nil {
+		return "", fmt.Errorf("open archive: %w", err)
+	}
+	defer f.Close()
+
 	if strings.HasSuffix(assetURL, ".zip") {
-		if err := downloadAndExtractZip(assetURL, binaryName, outPath); err != nil {
-			return "", fmt.Errorf("download engram zip: %w", err)
+		data, err := io.ReadAll(f)
+		if err != nil {
+			return "", fmt.Errorf("read zip archive: %w", err)
+		}
+		if err := extractZipBinary(data, binaryName, outPath); err != nil {
+			return "", fmt.Errorf("extract engram zip: %w", err)
 		}
 	} else {
-		if err := downloadAndExtractTarGz(assetURL, engramName, outPath); err != nil {
-			return "", fmt.Errorf("download engram tar.gz: %w", err)
+		if err := extractBinaryFromTarGz(f, engramName, outPath); err != nil {
+			return "", fmt.Errorf("extract engram tar.gz: %w", err)
 		}
 	}
 
@@ -254,15 +302,122 @@ func engramAPIBaseURL() string {
 	return "https://api.github.com"
 }
 
-// engramAssetURL constructs the download URL for the engram release asset.
-func engramAssetURL(baseURL, version, goos, goarch string) string {
+// engramArchiveName returns the GoReleaser archive filename for the given
+// version/os/arch combination.
+//
+// Convention: engram_{version}_{os}_{arch}.tar.gz (or .zip on Windows)
+func engramArchiveName(version, goos, goarch string) string {
 	ext := ".tar.gz"
 	if goos == "windows" {
 		ext = ".zip"
 	}
-	filename := fmt.Sprintf("%s_%s_%s_%s%s", engramRepo, version, goos, goarch, ext)
+	return fmt.Sprintf("%s_%s_%s_%s%s", engramRepo, version, goos, goarch, ext)
+}
+
+// engramAssetURL constructs the download URL for the engram release asset.
+func engramAssetURL(baseURL, version, goos, goarch string) string {
+	filename := engramArchiveName(version, goos, goarch)
 	return fmt.Sprintf("%s/%s/%s/releases/download/v%s/%s",
 		baseURL, engramOwner, engramRepo, version, filename)
+}
+
+// engramChecksumURL constructs the GitHub Releases URL for checksums.txt.
+func engramChecksumURL(baseURL, version string) string {
+	return fmt.Sprintf("%s/%s/%s/releases/download/v%s/checksums.txt",
+		baseURL, engramOwner, engramRepo, version)
+}
+
+// engramDownloadToFile downloads the resource at url to outPath and returns
+// the SHA256 hex digest of the downloaded content.
+func engramDownloadToFile(ctx context.Context, url string, outPath string) (hexDigest string, err error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", fmt.Errorf("build request: %w", err)
+	}
+	resp, err := engramHTTPClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("download %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("download %s: HTTP %d", url, resp.StatusCode)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(outPath), 0o755); err != nil {
+		return "", fmt.Errorf("create dir: %w", err)
+	}
+	f, err := os.Create(outPath)
+	if err != nil {
+		return "", fmt.Errorf("create %s: %w", outPath, err)
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	if _, err := io.Copy(io.MultiWriter(f, h), resp.Body); err != nil {
+		return "", fmt.Errorf("write %s: %w", outPath, err)
+	}
+
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// engramFetchChecksums downloads checksums.txt from url and returns its content.
+// Returns an error if the file cannot be fetched or the server returns non-200.
+func engramFetchChecksums(ctx context.Context, url string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", fmt.Errorf("build request: %w", err)
+	}
+	resp, err := engramHTTPClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("fetch checksums.txt: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("checksums.txt: HTTP %d", resp.StatusCode)
+	}
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("read checksums.txt: %w", err)
+	}
+	return string(data), nil
+}
+
+// engramExpectedChecksumFor parses checksums.txt content and returns the SHA256
+// hex digest for filename. Returns an error if the filename is not listed.
+//
+// GoReleaser produces BSD-style checksums.txt: "<digest>  <filename>" per line.
+func engramExpectedChecksumFor(content, filename string) (string, error) {
+	for _, line := range strings.Split(content, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) == 2 && fields[1] == filename {
+			return fields[0], nil
+		}
+	}
+	return "", fmt.Errorf("%q not listed in checksums.txt", filename)
+}
+
+// extractZipBinary extracts the binary named binaryName from the zip data
+// and writes it to outPath.
+func extractZipBinary(data []byte, binaryName, outPath string) error {
+	zr, err := zip.NewReader(&byteReaderAt{data: data}, int64(len(data)))
+	if err != nil {
+		return fmt.Errorf("open zip: %w", err)
+	}
+
+	for _, f := range zr.File {
+		if filepath.Base(f.Name) == binaryName && !f.FileInfo().IsDir() {
+			rc, err := f.Open()
+			if err != nil {
+				return fmt.Errorf("open zip entry %q: %w", f.Name, err)
+			}
+			defer rc.Close()
+			return writeExecutable(rc, outPath)
+		}
+	}
+
+	return fmt.Errorf("binary %q not found in zip archive", binaryName)
 }
 
 // engramInstallDir returns the directory where the engram binary should be installed

--- a/internal/components/engram/download_test.go
+++ b/internal/components/engram/download_test.go
@@ -4,7 +4,10 @@ import (
 	"archive/tar"
 	"archive/zip"
 	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -18,23 +21,48 @@ import (
 
 // --- test helpers ---
 
+// sha256Hex returns the SHA256 hex digest of data.
+func sha256Hex(data []byte) string {
+	h := sha256.Sum256(data)
+	return hex.EncodeToString(h[:])
+}
+
+// makeChecksumsTxt returns a BSD-style checksums.txt entry for the given filename and data.
+func makeChecksumsTxt(filename string, data []byte) string {
+	return fmt.Sprintf("%s  %s\n", sha256Hex(data), filename)
+}
+
 // makeServerWithFakeTarGz returns an httptest.Server that serves:
-//   - GET /releases/latest  → GitHub API JSON with the given version
-//   - GET /releases/download/…  → a real .tar.gz containing "engram" binary
+//   - GET /releases/latest       → GitHub API JSON with the given version
+//   - GET /releases/download/…   → a real .tar.gz containing "engram" binary
+//   - GET /…/checksums.txt       → a valid checksums.txt covering all arches
 func makeServerWithFakeTarGz(t *testing.T, version string) *httptest.Server {
 	t.Helper()
 	tarContent := buildFakeTarGz(t, "engram")
+	// Pre-build a checksums.txt that covers linux/darwin for both amd64 and arm64
+	// so the test is not sensitive to the host architecture.
+	checksums := ""
+	for _, goos := range []string{"linux", "darwin"} {
+		for _, goarch := range []string{"amd64", "arm64"} {
+			name := engramArchiveName(version, goos, goarch)
+			checksums += makeChecksumsTxt(name, tarContent)
+		}
+	}
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.Contains(r.URL.Path, "releases/latest") {
+		switch {
+		case strings.Contains(r.URL.Path, "releases/latest"):
 			payload := map[string]string{"tag_name": "v" + version}
 			w.Header().Set("Content-Type", "application/json")
 			json.NewEncoder(w).Encode(payload)
-			return
+		case strings.HasSuffix(r.URL.Path, "checksums.txt"):
+			w.Header().Set("Content-Type", "text/plain")
+			fmt.Fprint(w, checksums)
+		default:
+			// Binary asset
+			w.Header().Set("Content-Type", "application/octet-stream")
+			w.WriteHeader(http.StatusOK)
+			w.Write(tarContent)
 		}
-		// All other requests → binary asset
-		w.Header().Set("Content-Type", "application/octet-stream")
-		w.WriteHeader(http.StatusOK)
-		w.Write(tarContent)
 	}))
 }
 
@@ -43,16 +71,27 @@ func makeServerWithFakeTarGz(t *testing.T, version string) *httptest.Server {
 func makeServerWithFakeZip(t *testing.T, version string) *httptest.Server {
 	t.Helper()
 	zipContent := buildFakeZip(t, "engram.exe")
+	// Pre-build a checksums.txt that covers windows for both amd64 and arm64
+	// so the test is not sensitive to the host architecture.
+	checksums := ""
+	for _, goarch := range []string{"amd64", "arm64"} {
+		name := engramArchiveName(version, "windows", goarch)
+		checksums += makeChecksumsTxt(name, zipContent)
+	}
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.Contains(r.URL.Path, "releases/latest") {
+		switch {
+		case strings.Contains(r.URL.Path, "releases/latest"):
 			payload := map[string]string{"tag_name": "v" + version}
 			w.Header().Set("Content-Type", "application/json")
 			json.NewEncoder(w).Encode(payload)
-			return
+		case strings.HasSuffix(r.URL.Path, "checksums.txt"):
+			w.Header().Set("Content-Type", "text/plain")
+			fmt.Fprint(w, checksums)
+		default:
+			w.Header().Set("Content-Type", "application/octet-stream")
+			w.WriteHeader(http.StatusOK)
+			w.Write(zipContent)
 		}
-		w.Header().Set("Content-Type", "application/octet-stream")
-		w.WriteHeader(http.StatusOK)
-		w.Write(zipContent)
 	}))
 }
 
@@ -330,6 +369,13 @@ func TestDownloadLatestBinaryAPIError(t *testing.T) {
 func TestDownloadLatestBinarySkipsLatestReleaseWithoutBinaryAssets(t *testing.T) {
 	const binaryVersion = "1.15.13"
 
+	tarContent := buildFakeTarGz(t, "engram")
+	// Build checksums.txt covering all linux arches so the test is arch-agnostic.
+	checksums := ""
+	for _, goarch := range []string{"amd64", "arm64"} {
+		checksums += makeChecksumsTxt(engramArchiveName(binaryVersion, "linux", goarch), tarContent)
+	}
+
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case strings.Contains(r.URL.Path, "releases/latest"):
@@ -357,10 +403,13 @@ func TestDownloadLatestBinarySkipsLatestReleaseWithoutBinaryAssets(t *testing.T)
 					},
 				},
 			})
+		case strings.HasSuffix(r.URL.Path, "checksums.txt"):
+			w.Header().Set("Content-Type", "text/plain")
+			fmt.Fprint(w, checksums)
 		case strings.Contains(r.URL.Path, "/releases/download/v"+binaryVersion+"/engram_"+binaryVersion+"_linux_"):
 			w.Header().Set("Content-Type", "application/octet-stream")
 			w.WriteHeader(http.StatusOK)
-			w.Write(buildFakeTarGz(t, "engram"))
+			w.Write(tarContent)
 		default:
 			t.Fatalf("unexpected request: %s?%s", r.URL.Path, r.URL.RawQuery)
 		}
@@ -396,6 +445,12 @@ func TestDownloadLatestBinaryReleaseListFallsBackToAnonymousWhenTokenGets403(t *
 	const fakeToken = "ci-token"
 	const binaryVersion = "1.15.13"
 
+	tarContent := buildFakeTarGz(t, "engram")
+	checksums := ""
+	for _, goarch := range []string{"amd64", "arm64"} {
+		checksums += makeChecksumsTxt(engramArchiveName(binaryVersion, "linux", goarch), tarContent)
+	}
+
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case strings.Contains(r.URL.Path, "releases/latest"):
@@ -421,10 +476,13 @@ func TestDownloadLatestBinaryReleaseListFallsBackToAnonymousWhenTokenGets403(t *
 					},
 				},
 			})
+		case strings.HasSuffix(r.URL.Path, "checksums.txt"):
+			w.Header().Set("Content-Type", "text/plain")
+			fmt.Fprint(w, checksums)
 		case strings.Contains(r.URL.Path, "/releases/download/v"+binaryVersion+"/engram_"+binaryVersion+"_linux_"):
 			w.Header().Set("Content-Type", "application/octet-stream")
 			w.WriteHeader(http.StatusOK)
-			w.Write(buildFakeTarGz(t, "engram"))
+			w.Write(tarContent)
 		default:
 			t.Fatalf("unexpected request: %s?%s", r.URL.Path, r.URL.RawQuery)
 		}
@@ -463,21 +521,31 @@ func TestDownloadLatestBinaryFallsBackToAnonymousWhenTokenGets403(t *testing.T) 
 	const fakeToken = "ci-token"
 	const version = "1.3.0"
 
+	tarContent := buildFakeTarGz(t, "engram")
+	checksums := ""
+	for _, goos := range []string{"linux", "darwin"} {
+		for _, goarch := range []string{"amd64", "arm64"} {
+			checksums += makeChecksumsTxt(engramArchiveName(version, goos, goarch), tarContent)
+		}
+	}
+
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.Contains(r.URL.Path, "releases/latest") {
+		switch {
+		case strings.Contains(r.URL.Path, "releases/latest"):
 			if r.Header.Get("Authorization") == "Bearer "+fakeToken {
 				w.WriteHeader(http.StatusForbidden)
 				return
 			}
-
 			w.Header().Set("Content-Type", "application/json")
 			json.NewEncoder(w).Encode(map[string]string{"tag_name": "v" + version})
-			return
+		case strings.HasSuffix(r.URL.Path, "checksums.txt"):
+			w.Header().Set("Content-Type", "text/plain")
+			fmt.Fprint(w, checksums)
+		default:
+			w.Header().Set("Content-Type", "application/octet-stream")
+			w.WriteHeader(http.StatusOK)
+			w.Write(tarContent)
 		}
-
-		w.Header().Set("Content-Type", "application/octet-stream")
-		w.WriteHeader(http.StatusOK)
-		w.Write(buildFakeTarGz(t, "engram"))
 	}))
 	defer server.Close()
 
@@ -510,5 +578,177 @@ func TestDownloadLatestBinaryFallsBackToAnonymousWhenTokenGets403(t *testing.T) 
 
 	if _, err := os.Stat(installedPath); err != nil {
 		t.Fatalf("stat installed binary: %v", err)
+	}
+}
+
+// --- TestEngramChecksumVerification ---
+//
+// Table-driven tests covering all checksum verification paths:
+//
+//   - success: valid checksums.txt with correct digest → install succeeds
+//   - missing checksums.txt: server returns 404 → fail closed
+//   - digest mismatch: checksums.txt lists wrong digest → fail closed
+//   - malformed checksums.txt: content has no parseable entries → fail closed
+func TestEngramChecksumVerification(t *testing.T) {
+	const version = "1.0.0"
+
+	// tarContent is a real .tar.gz archive used across sub-tests.
+	tarContent := buildFakeTarGz(t, "engram")
+	correctDigest := sha256Hex(tarContent)
+	archiveName := engramArchiveName(version, "linux", normalizeArch(runtime.GOARCH))
+
+	tests := []struct {
+		name          string
+		checksumBody  string // content served at /…/checksums.txt; empty = serve 404
+		checksumCode  int    // HTTP status for checksums.txt (0 → use 200 when body set)
+		wantErrSubstr string // expected substring in error; empty = success
+	}{
+		{
+			name:         "success: valid checksum passes",
+			checksumBody: fmt.Sprintf("%s  %s\n", correctDigest, archiveName),
+		},
+		{
+			name:          "missing checksums.txt: 404 fails closed",
+			checksumCode:  http.StatusNotFound,
+			wantErrSubstr: "checksums.txt unavailable",
+		},
+		{
+			name:          "digest mismatch: wrong hash fails closed",
+			checksumBody:  fmt.Sprintf("%s  %s\n", strings.Repeat("a", 64), archiveName),
+			wantErrSubstr: "checksum mismatch",
+		},
+		{
+			name:          "malformed checksums.txt: no matching entry fails closed",
+			checksumBody:  "thisisnotavalidchecksumline\n",
+			wantErrSubstr: "not listed in checksums.txt",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case strings.Contains(r.URL.Path, "releases/latest"):
+					w.Header().Set("Content-Type", "application/json")
+					json.NewEncoder(w).Encode(map[string]string{"tag_name": "v" + version})
+
+				case strings.HasSuffix(r.URL.Path, "checksums.txt"):
+					code := tt.checksumCode
+					if code == 0 {
+						code = http.StatusOK
+					}
+					w.WriteHeader(code)
+					if tt.checksumBody != "" {
+						fmt.Fprint(w, tt.checksumBody)
+					}
+
+				default:
+					w.Header().Set("Content-Type", "application/octet-stream")
+					w.WriteHeader(http.StatusOK)
+					w.Write(tarContent)
+				}
+			}))
+			defer server.Close()
+
+			origClient := engramHTTPClient
+			origBaseURL := engramGitHubBaseURL
+			engramHTTPClient = server.Client()
+			engramGitHubBaseURL = server.URL
+			t.Cleanup(func() {
+				engramHTTPClient = origClient
+				engramGitHubBaseURL = origBaseURL
+			})
+
+			tmpDir := t.TempDir()
+			origInstallDirFn := engramInstallDirFn
+			engramInstallDirFn = func(goos string) string { return tmpDir }
+			t.Cleanup(func() { engramInstallDirFn = origInstallDirFn })
+
+			profile := system.PlatformProfile{OS: "linux", PackageManager: "apt"}
+			_, err := DownloadLatestBinary(profile)
+
+			if tt.wantErrSubstr == "" {
+				if err != nil {
+					t.Fatalf("expected success, got error: %v", err)
+				}
+				return
+			}
+
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tt.wantErrSubstr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErrSubstr) {
+				t.Errorf("error = %q, want it to contain %q", err.Error(), tt.wantErrSubstr)
+			}
+		})
+	}
+}
+
+// --- TestEngramExpectedChecksumFor ---
+//
+// Table-driven unit tests for the BSD-style checksums.txt parser.
+func TestEngramExpectedChecksumFor(t *testing.T) {
+	tests := []struct {
+		name          string
+		content       string
+		filename      string
+		wantDigest    string
+		wantErrSubstr string
+	}{
+		{
+			name:       "exact match returns digest",
+			content:    "abc123  engram_1.0.0_linux_amd64.tar.gz\n",
+			filename:   "engram_1.0.0_linux_amd64.tar.gz",
+			wantDigest: "abc123",
+		},
+		{
+			name: "finds correct entry among multiple",
+			content: "aaa111  engram_1.0.0_linux_amd64.tar.gz\n" +
+				"bbb222  engram_1.0.0_linux_arm64.tar.gz\n" +
+				"ccc333  engram_1.0.0_windows_amd64.zip\n",
+			filename:   "engram_1.0.0_linux_arm64.tar.gz",
+			wantDigest: "bbb222",
+		},
+		{
+			name:          "missing filename returns error",
+			content:       "abc123  engram_1.0.0_linux_amd64.tar.gz\n",
+			filename:      "engram_1.0.0_darwin_arm64.tar.gz",
+			wantErrSubstr: "not listed in checksums.txt",
+		},
+		{
+			name:          "empty content returns error",
+			content:       "",
+			filename:      "engram_1.0.0_linux_amd64.tar.gz",
+			wantErrSubstr: "not listed in checksums.txt",
+		},
+		{
+			name:          "malformed lines (single field) are skipped",
+			content:       "justonefield\n",
+			filename:      "justonefield",
+			wantErrSubstr: "not listed in checksums.txt",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := engramExpectedChecksumFor(tt.content, tt.filename)
+
+			if tt.wantErrSubstr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErrSubstr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErrSubstr) {
+					t.Errorf("error = %q, want it to contain %q", err.Error(), tt.wantErrSubstr)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.wantDigest {
+				t.Errorf("got digest %q, want %q", got, tt.wantDigest)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Linked Issue

Closes #539

## PR Type

- [x] `type:bug`

## Summary

The Engram direct binary download path (non-brew Linux/Windows) previously downloaded and installed the GitHub release asset without verifying its integrity, while the `gga` upgrade path was hardened with mandatory SHA256 verification in #245/#269. This PR closes that supply-chain gap.

Now the Engram installer fetches `checksums.txt` from the release tag, computes the SHA256 of the downloaded archive, and **fails closed** if the checksum file is unreachable or the digest doesn't match — same fail-closed policy as the `gga` upgrade path.

## Changes

| File | Change |
|------|--------|
| `internal/components/engram/download.go` | SHA256 verification before extract/install; package-level vars for test injection |
| `internal/components/engram/download_test.go` | Table-driven coverage: success, missing checksums.txt, mismatch, malformed |

## Test Plan

- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [x] `go build` clean

## Notes for Reviewers

- Diff is 461 LOC, slightly over the 400-line cognitive budget — **requesting `size:exception`**. The Go production code is ~140 LOC; the rest is table-driven test coverage that mirrors the established hardened pattern in `internal/update/upgrade/download.go`. Splitting would only churn assets without making review easier.
- Failure semantics mirror `internal/update/upgrade/download.go` exactly (missing checksums.txt → error, mismatch → error).

## Contributor Checklist

- [x] Linked to approved issue (#539 has `status:approved`)
- [ ] Under 400 changed lines — requesting `size:exception`
- [x] Conventional Commits format
- [x] No Co-Authored-By trailers