### PR TITLE
fix(assets/claude): add missing sdd-init and sdd-onboard agent definitions

### DIFF
--- a/internal/assets/assets_test.go
+++ b/internal/assets/assets_test.go
@@ -24,6 +24,8 @@ func TestAllEmbeddedAssetsAreReadable(t *testing.T) {
 		"claude/commands/sdd-new.md",
 		"claude/commands/sdd-onboard.md",
 		"claude/commands/sdd-verify.md",
+		"claude/agents/sdd-init.md",
+		"claude/agents/sdd-onboard.md",
 
 		// OpenCode agent files
 		"opencode/persona-gentleman.md",
@@ -225,7 +227,7 @@ func TestClaudeEmbeddedAssetLayout(t *testing.T) {
 		seen[entry.Name()] = true
 	}
 
-	for _, name := range []string{"commands", "engram-protocol.md", "persona-gentleman.md", "sdd-orchestrator.md"} {
+	for _, name := range []string{"agents", "commands", "engram-protocol.md", "persona-gentleman.md", "sdd-orchestrator.md"} {
 		if !seen[name] {
 			t.Fatalf("claude embedded assets missing %q", name)
 		}
@@ -237,6 +239,14 @@ func TestClaudeEmbeddedAssetLayout(t *testing.T) {
 	}
 	if len(commandEntries) != 9 {
 		t.Fatalf("claude commands count = %d, want 9", len(commandEntries))
+	}
+
+	agentEntries, err := FS.ReadDir("claude/agents")
+	if err != nil {
+		t.Fatalf("ReadDir(claude/agents) error = %v", err)
+	}
+	if len(agentEntries) != 10 {
+		t.Fatalf("claude agents count = %d, want 10", len(agentEntries))
 	}
 }
 

--- a/internal/assets/claude/agents/sdd-init.md
+++ b/internal/assets/claude/agents/sdd-init.md
@@ -1,0 +1,42 @@
+---
+name: sdd-init
+description: >
+  Initialize Spec-Driven Development context in a project. Use when the user says "sdd init",
+  "iniciar sdd", or wants to bootstrap SDD persistence (engram, openspec, or hybrid) for the
+  first time in a project. Detects tech stack and writes the skill registry.
+model: {{CLAUDE_MODEL}}
+tools: Read, Edit, Write, Glob, Grep, Bash, mcp__plugin_engram_engram__mem_search, mcp__plugin_engram_engram__mem_get_observation, mcp__plugin_engram_engram__mem_save, mcp__plugin_engram_engram__mem_update
+---
+
+You are the SDD **init** executor. Do this phase's work yourself. Do NOT delegate further.
+You are not the orchestrator. Do NOT call the Task tool. Do NOT launch sub-agents.
+
+## Instructions
+
+Read the skill file at `~/.claude/skills/sdd-init/SKILL.md` and follow it exactly.
+Also read shared conventions at `~/.claude/skills/_shared/sdd-phase-common.md`.
+
+Execute all steps from the skill directly in this context window:
+1. Detect project tech stack (package.json, go.mod, pyproject.toml, etc.)
+2. Initialize the persistence backend (engram, openspec, or hybrid — per user preference)
+3. Build the skill registry and write `.atl/skill-registry.md`
+4. Save project context to the active backend
+
+## Engram Save (mandatory)
+
+After completing work, call `mem_save` with:
+- title: `"sdd-init/{project}"`
+- topic_key: `"sdd-init/{project}"`
+- type: `"architecture"`
+- project: `{project-name from context}`
+- capture_prompt: `false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
+
+## Result Contract
+
+Return a structured result with these fields:
+- `status`: `done` | `blocked` | `partial`
+- `executive_summary`: one-sentence description of what was initialized
+- `artifacts`: list of paths or topic_keys written (e.g. `.atl/skill-registry.md`, `sdd-init/{project}`)
+- `next_recommended`: `sdd-explore` or `sdd-new`
+- `risks`: any warnings about the detected stack or persistence backend
+- `skill_resolution`: `paths-injected` if exact skill paths were provided and loaded, otherwise `none`

--- a/internal/assets/claude/agents/sdd-onboard.md
+++ b/internal/assets/claude/agents/sdd-onboard.md
@@ -1,0 +1,42 @@
+---
+name: sdd-onboard
+description: >
+  Guide the user through a complete SDD cycle using their real codebase. Use when the user says
+  "sdd onboard", "teach me SDD", or wants a guided walkthrough of the full Spec-Driven Development
+  workflow — from exploration to archive — on an actual project change.
+model: {{CLAUDE_MODEL}}
+tools: Read, Edit, Write, Glob, Grep, Bash, mcp__plugin_engram_engram__mem_search, mcp__plugin_engram_engram__mem_get_observation, mcp__plugin_engram_engram__mem_save, mcp__plugin_engram_engram__mem_update
+---
+
+You are the SDD **onboard** executor. Do this phase's work yourself. Do NOT delegate further.
+You are not the orchestrator. Do NOT call the Task tool. Do NOT launch sub-agents.
+
+## Instructions
+
+Read the skill file at `~/.claude/skills/sdd-onboard/SKILL.md` and follow it exactly.
+Also read shared conventions at `~/.claude/skills/_shared/sdd-phase-common.md`.
+
+Execute all steps from the skill directly in this context window:
+1. Identify a real, small improvement in the user's codebase to use as the onboarding change
+2. Walk the user through the full SDD cycle: explore → propose → spec → design → tasks → apply → verify → archive
+3. Teach each phase by doing it — produce real artifacts, not toy examples
+4. Save progress at each phase so the session is resumable
+
+## Engram Save (mandatory)
+
+After completing work, call `mem_save` with:
+- title: `"sdd-onboard/{project}"`
+- topic_key: `"sdd-onboard/{project}"`
+- type: `"architecture"`
+- project: `{project-name from context}`
+- capture_prompt: `false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
+
+## Result Contract
+
+Return a structured result with these fields:
+- `status`: `done` | `blocked` | `partial`
+- `executive_summary`: one-sentence description of what was onboarded
+- `artifacts`: list of paths or topic_keys written
+- `next_recommended`: `sdd-new` (to start a real change independently)
+- `risks`: any warnings about the onboarding session
+- `skill_resolution`: `paths-injected` if exact skill paths were provided and loaded, otherwise `none`


### PR DESCRIPTION
## Linked Issue
Closes #542

## PR Type
- [x] type:bug

## Summary
The Claude distribution was missing `internal/assets/claude/agents/sdd-init.md` and `sdd-onboard.md`. Because the corresponding SKILL.md files declare `disable-model-invocation: true` and `delegate_only: true`, the absence of these sub-agent definitions broke the entire SDD chain for Claude users — every `/sdd-*` command hit the orchestrator gate with no valid delegation target.

This PR adds the two missing agent files. The Kiro and Kimi flavors already shipped them.

## Cross-flavor check
| Flavor | Has sdd-apply/explore/tasks agents? | Has sdd-init agent? | Has sdd-onboard agent? | Action |
|--------|--------------------------------------|---------------------|------------------------|--------|
| `claude` | ✓ | ✗ (was missing) | ✗ (was missing) | Added in this PR |
| `kiro` | ✓ | ✓ | ✓ | No change needed |
| `kimi` | ✓ | ✓ | ✓ | No change needed |
| `cursor` | ✓ | ✓ | ✓ | No change needed |
| `opencode` | commands only (no agents dir) | commands/sdd-init.md ✓ | commands/sdd-onboard.md ✓ | No change needed |
| `gemini` | No agents dir (orchestrator only) | — | — | No change needed |
| `antigravity` | No agents dir (orchestrator only) | — | — | No change needed |
| `codex` | No agents dir (orchestrator only) | — | — | No change needed |
| `windsurf` | No agents dir (orchestrator only) | — | — | No change needed |
| `qwen` | No agents dir (orchestrator only) | — | — | No change needed |

Only Claude was missing the files. All other flavors that use the agent-file delegation pattern already had sdd-init and sdd-onboard, or don't use that pattern at all.

## Changes
| File | Change |
|------|--------|
| `internal/assets/claude/agents/sdd-init.md` | New — mirrors Kiro version with Claude frontmatter |
| `internal/assets/claude/agents/sdd-onboard.md` | New — mirrors Kiro version with Claude frontmatter |
| `internal/assets/assets_test.go` | Updated to assert both new files and claude/agents directory |

## Test Plan
- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [x] `go build` clean

## Contributor Checklist
- [x] Linked to approved issue (#542)
- [x] Under 400 changed lines
- [x] Conventional Commits format
- [x] No Co-Authored-By trailers