### PR TITLE
fix(install): add --scope flag to install into workspace instead of global ~/.claude

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -330,7 +330,7 @@ func tuiExecute(
 	profile := cli.ResolveInstallProfile(detection)
 	resolved.PlatformDecision = planner.PlatformDecisionFromProfile(profile)
 
-	stagePlan, err := cli.BuildRealStagePlan(homeDir, selection, resolved, profile)
+	stagePlan, err := cli.BuildRealStagePlan(homeDir, cli.ScopeGlobal, selection, resolved, profile)
 	if err != nil {
 		return pipeline.ExecutionResult{Err: fmt.Errorf("build stage plan: %w", err)}
 	}

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -13,6 +13,7 @@ type InstallFlags struct {
 	Persona    string
 	Preset     string
 	SDDMode    string
+	Scope      string
 	DryRun     bool
 }
 
@@ -30,6 +31,7 @@ func ParseInstallFlags(args []string) (InstallFlags, error) {
 	fs.StringVar(&opts.Persona, "persona", "", "persona to apply")
 	fs.StringVar(&opts.Preset, "preset", "", "preset to apply")
 	fs.StringVar(&opts.SDDMode, "sdd-mode", "", "SDD orchestrator mode: single or multi (default: single)")
+	fs.StringVar(&opts.Scope, "scope", "", "install scope: global (default) or workspace — env: GENTLE_AI_INSTALL_SCOPE")
 	fs.BoolVar(&opts.DryRun, "dry-run", false, "preview plan without executing")
 
 	if err := fs.Parse(args); err != nil {

--- a/internal/cli/openclaw_orchestration_test.go
+++ b/internal/cli/openclaw_orchestration_test.go
@@ -179,7 +179,7 @@ func TestInstallRuntimeOpenClawUsesConfiguredActiveWorkspace(t *testing.T) {
 		Agents:            []model.AgentID{model.AgentOpenClaw},
 		OrderedComponents: selection.Components,
 	}
-	rt, err := newInstallRuntime(home, selection, resolved, system.PlatformProfile{PackageManager: "brew"})
+	rt, err := newInstallRuntime(home, ScopeGlobal, selection, resolved, system.PlatformProfile{PackageManager: "brew"})
 	if err != nil {
 		t.Fatalf("newInstallRuntime() error = %v", err)
 	}

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -117,7 +117,14 @@ func RunInstall(args []string, detection system.DetectionResult) (InstallResult,
 		return result, fmt.Errorf("resolve user home directory: %w", err)
 	}
 
-	runtime, err := newInstallRuntime(homeDir, input.Selection, resolved, profile)
+	if input.Scope == ScopeGlobal {
+		fmt.Fprintf(os.Stderr,
+			"WARNING: installing with --scope=global (default). Agent config files (CLAUDE.md, skills/, agents/, etc.)\n"+
+				"will be written to ~/.claude/ and will affect ALL Claude Code workspaces on this machine.\n"+
+				"To install only into the current workspace, rerun with --scope=workspace.\n\n")
+	}
+
+	runtime, err := newInstallRuntime(homeDir, input.Scope, input.Selection, resolved, profile)
 	if err != nil {
 		return result, err
 	}
@@ -139,7 +146,7 @@ func RunInstall(args []string, detection system.DetectionResult) (InstallResult,
 		return result, fmt.Errorf("execute install pipeline: %w", result.Execution.Err)
 	}
 
-	result.Verify = runPostApplyVerification(homeDir, runtime.workspaceDir, input.Selection, resolved)
+	result.Verify = runPostApplyVerification(homeDir, runtime.workspaceDir, input.Scope, input.Selection, resolved)
 	result.Verify = withPostInstallNotes(result.Verify, resolved)
 	if !result.Verify.Ready {
 		return result, fmt.Errorf("post-apply verification failed:\n%s", verify.RenderReport(result.Verify))
@@ -243,6 +250,7 @@ func buildStagePlan(selection model.Selection, resolved planner.ResolvedPlan) pi
 type installRuntime struct {
 	homeDir      string
 	workspaceDir string
+	scope        InstallScope
 	selection    model.Selection
 	resolved     planner.ResolvedPlan
 	profile      system.PlatformProfile
@@ -254,7 +262,7 @@ type runtimeState struct {
 	manifest backup.Manifest
 }
 
-func newInstallRuntime(homeDir string, selection model.Selection, resolved planner.ResolvedPlan, profile system.PlatformProfile) (*installRuntime, error) {
+func newInstallRuntime(homeDir string, scope InstallScope, selection model.Selection, resolved planner.ResolvedPlan, profile system.PlatformProfile) (*installRuntime, error) {
 	backupRoot := filepath.Join(homeDir, ".gentle-ai", "backups")
 	if err := os.MkdirAll(backupRoot, 0o755); err != nil {
 		return nil, fmt.Errorf("create backup root directory %q: %w", backupRoot, err)
@@ -266,6 +274,7 @@ func newInstallRuntime(homeDir string, selection model.Selection, resolved plann
 	return &installRuntime{
 		homeDir:      homeDir,
 		workspaceDir: workspaceDir,
+		scope:        scope,
 		selection:    selection,
 		resolved:     resolved,
 		profile:      profile,
@@ -275,7 +284,7 @@ func newInstallRuntime(homeDir string, selection model.Selection, resolved plann
 }
 
 func (r *installRuntime) stagePlan() pipeline.StagePlan {
-	targets := backupTargets(r.homeDir, r.workspaceDir, r.selection, r.resolved)
+	targets := backupTargets(r.homeDir, r.workspaceDir, r.scope, r.selection, r.resolved)
 	prepare := []pipeline.Step{
 		checkDependenciesStep{id: "prepare:check-dependencies", profile: r.profile, homeDir: r.homeDir, selection: r.selection},
 		prepareBackupStep{
@@ -319,6 +328,7 @@ func (r *installRuntime) stagePlan() pipeline.StagePlan {
 			component:    component,
 			homeDir:      r.homeDir,
 			workspaceDir: r.workspaceDir,
+			scope:        r.scope,
 			agents:       r.resolved.Agents,
 			selection:    r.selection,
 			profile:      r.profile,
@@ -498,6 +508,7 @@ type componentApplyStep struct {
 	component    model.ComponentID
 	homeDir      string
 	workspaceDir string
+	scope        InstallScope
 	agents       []model.AgentID
 	selection    model.Selection
 	profile      system.PlatformProfile
@@ -572,7 +583,7 @@ func (s componentApplyStep) Run() error {
 			if adapter.Agent() == model.AgentOpenClaw {
 				_, err = engram.InjectWithPromptDir(s.homeDir, s.workspaceDir, adapter)
 			} else {
-				targetDir := componentInjectionDir(s.homeDir, s.workspaceDir, adapter)
+				targetDir := componentInjectionDirScoped(s.homeDir, s.workspaceDir, s.scope, adapter)
 				_, err = engram.Inject(targetDir, adapter)
 			}
 			if err != nil {
@@ -589,7 +600,7 @@ func (s componentApplyStep) Run() error {
 		return nil
 	case model.ComponentPersona:
 		for _, adapter := range adapters {
-			targetDir := componentInjectionDir(s.homeDir, s.workspaceDir, adapter)
+			targetDir := componentInjectionDirScoped(s.homeDir, s.workspaceDir, s.scope, adapter)
 			if _, err := persona.Inject(targetDir, adapter, s.selection.Persona); err != nil {
 				return fmt.Errorf("inject persona for %q: %w", adapter.Agent(), err)
 			}
@@ -604,7 +615,7 @@ func (s componentApplyStep) Run() error {
 		return nil
 	case model.ComponentSDD:
 		for _, adapter := range adapters {
-			targetDir := componentInjectionDir(s.homeDir, s.workspaceDir, adapter)
+			targetDir := componentInjectionDirScoped(s.homeDir, s.workspaceDir, s.scope, adapter)
 			opts := sdd.InjectOptions{
 				OpenCodeModelAssignments: s.selection.ModelAssignments,
 				ClaudeModelAssignments:   s.selection.ClaudeModelAssignments,
@@ -623,7 +634,8 @@ func (s componentApplyStep) Run() error {
 			return nil
 		}
 		for _, adapter := range adapters {
-			if _, err := skills.Inject(s.homeDir, adapter, skillIDs); err != nil {
+			targetDir := componentInjectionDirScoped(s.homeDir, s.workspaceDir, s.scope, adapter)
+			if _, err := skills.Inject(targetDir, adapter, skillIDs); err != nil {
 				return fmt.Errorf("inject skills for %q: %w", adapter.Agent(), err)
 			}
 		}
@@ -733,13 +745,14 @@ func windowsGoCandidates() []string {
 
 // BuildRealStagePlan creates a StagePlan with real backup, agent install, and component apply steps.
 // It is used by both the CLI and TUI paths.
-func BuildRealStagePlan(homeDir string, selection model.Selection, resolved planner.ResolvedPlan, profile system.PlatformProfile) (pipeline.StagePlan, error) {
+// scope controls where agent config files are written (ScopeGlobal writes to homeDir, ScopeWorkspace writes to cwd).
+func BuildRealStagePlan(homeDir string, scope InstallScope, selection model.Selection, resolved planner.ResolvedPlan, profile system.PlatformProfile) (pipeline.StagePlan, error) {
 	backupRoot := filepath.Join(homeDir, ".gentle-ai", "backups")
 	if err := os.MkdirAll(backupRoot, 0o755); err != nil {
 		return pipeline.StagePlan{}, fmt.Errorf("create backup root directory %q: %w", backupRoot, err)
 	}
 
-	runtime, err := newInstallRuntime(homeDir, selection, resolved, profile)
+	runtime, err := newInstallRuntime(homeDir, scope, selection, resolved, profile)
 	if err != nil {
 		return pipeline.StagePlan{}, err
 	}
@@ -851,12 +864,12 @@ func selectedSkillIDs(selection model.Selection) []model.SkillID {
 	return skills.SkillsForPreset(selection.Preset)
 }
 
-func backupTargets(homeDir, workspaceDir string, selection model.Selection, resolved planner.ResolvedPlan) []string {
+func backupTargets(homeDir, workspaceDir string, scope InstallScope, selection model.Selection, resolved planner.ResolvedPlan) []string {
 	paths := map[string]struct{}{}
 	adapters := resolveAdapters(resolved.Agents)
 
 	for _, component := range resolved.OrderedComponents {
-		for _, path := range componentPathsWithWorkspace(homeDir, workspaceDir, selection, adapters, component) {
+		for _, path := range componentPathsWithWorkspaceScoped(homeDir, workspaceDir, scope, selection, adapters, component) {
 			paths[path] = struct{}{}
 		}
 	}
@@ -874,9 +887,13 @@ func componentPaths(homeDir string, selection model.Selection, adapters []agents
 }
 
 func componentPathsWithWorkspace(homeDir, workspaceDir string, selection model.Selection, adapters []agents.Adapter, component model.ComponentID) []string {
+	return componentPathsWithWorkspaceScoped(homeDir, workspaceDir, ScopeGlobal, selection, adapters, component)
+}
+
+func componentPathsWithWorkspaceScoped(homeDir, workspaceDir string, scope InstallScope, selection model.Selection, adapters []agents.Adapter, component model.ComponentID) []string {
 	paths := []string{}
 	for _, adapter := range adapters {
-		targetDir := componentPathDir(homeDir, workspaceDir, adapter, component)
+		targetDir := componentPathDirScoped(homeDir, workspaceDir, scope, adapter, component)
 		switch component {
 		case model.ComponentEngram:
 			switch adapter.MCPStrategy() {
@@ -1043,10 +1060,18 @@ func componentPathsWithWorkspace(homeDir, workspaceDir string, selection model.S
 }
 
 func componentInjectionDir(homeDir, workspaceDir string, adapter agents.Adapter) string {
+	return componentInjectionDirScoped(homeDir, workspaceDir, ScopeGlobal, adapter)
+}
+
+// componentInjectionDirScoped returns the directory to inject component files for the given adapter,
+// taking the install scope into account. When scope is ScopeWorkspace, Claude Code
+// writes to workspaceDir (e.g. <cwd>/.claude/) instead of homeDir (~/.claude/).
+// OpenClaw always uses workspaceDir when set, independent of scope.
+func componentInjectionDirScoped(homeDir, workspaceDir string, scope InstallScope, adapter agents.Adapter) string {
 	if adapter.Agent() == model.AgentOpenClaw && strings.TrimSpace(workspaceDir) != "" {
 		return workspaceDir
 	}
-	return homeDir
+	return ResolveAgentConfigDir(scope, homeDir, workspaceDir)
 }
 
 type openClawWorkspaceConfig struct {
@@ -1088,9 +1113,13 @@ func resolveOpenClawWorkspaceDir(homeDir, fallback string, agentIDs []model.Agen
 }
 
 func componentPathDir(homeDir, workspaceDir string, adapter agents.Adapter, component model.ComponentID) string {
+	return componentPathDirScoped(homeDir, workspaceDir, ScopeGlobal, adapter, component)
+}
+
+func componentPathDirScoped(homeDir, workspaceDir string, scope InstallScope, adapter agents.Adapter, component model.ComponentID) string {
 	switch component {
-	case model.ComponentEngram, model.ComponentSDD, model.ComponentPersona:
-		return componentInjectionDir(homeDir, workspaceDir, adapter)
+	case model.ComponentEngram, model.ComponentSDD, model.ComponentPersona, model.ComponentSkills:
+		return componentInjectionDirScoped(homeDir, workspaceDir, scope, adapter)
 	default:
 		return homeDir
 	}
@@ -1117,14 +1146,14 @@ func sddSubAgentPaths(homeDir string, adapter agents.Adapter) []string {
 	return paths
 }
 
-func runPostApplyVerification(homeDir, workspaceDir string, selection model.Selection, resolved planner.ResolvedPlan) verify.Report {
+func runPostApplyVerification(homeDir, workspaceDir string, scope InstallScope, selection model.Selection, resolved planner.ResolvedPlan) verify.Report {
 	checks := make([]verify.Check, 0)
 	adapters := resolveAdapters(resolved.Agents)
 
 	seenPath := make(map[string]struct{})
 	var uniqueFilePaths []string
 	for _, component := range resolved.OrderedComponents {
-		for _, path := range componentPathsWithWorkspace(homeDir, workspaceDir, selection, adapters, component) {
+		for _, path := range componentPathsWithWorkspaceScoped(homeDir, workspaceDir, scope, selection, adapters, component) {
 			if path == "" {
 				continue
 			}

--- a/internal/cli/scope.go
+++ b/internal/cli/scope.go
@@ -1,0 +1,55 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// InstallScope controls where agent config files (CLAUDE.md, skills/, agents/, etc.) are written.
+// ScopeGlobal writes to the user's home agent config dir (e.g. ~/.claude/).
+// ScopeWorkspace writes to the current workspace's agent config dir (e.g. <cwd>/.claude/).
+type InstallScope string
+
+const (
+	// ScopeGlobal writes to the global agent config dir (default, backward-compatible).
+	ScopeGlobal InstallScope = "global"
+	// ScopeWorkspace writes to the current workspace's agent config dir.
+	ScopeWorkspace InstallScope = "workspace"
+
+	// scopeEnvVar is the environment variable that controls install scope.
+	scopeEnvVar = "GENTLE_AI_INSTALL_SCOPE"
+)
+
+// ResolveInstallScope resolves the install scope from the flag value and env var.
+// Priority: explicit flag > env var > default (global).
+// An empty flagValue means the flag was not set.
+func ResolveInstallScope(flagValue string) (InstallScope, error) {
+	raw := strings.TrimSpace(flagValue)
+	if raw == "" {
+		raw = strings.TrimSpace(os.Getenv(scopeEnvVar))
+	}
+	if raw == "" {
+		return ScopeGlobal, nil
+	}
+	return parseInstallScope(raw)
+}
+
+func parseInstallScope(raw string) (InstallScope, error) {
+	switch InstallScope(raw) {
+	case ScopeGlobal, ScopeWorkspace:
+		return InstallScope(raw), nil
+	default:
+		return "", fmt.Errorf("unsupported scope %q (valid: global, workspace)", raw)
+	}
+}
+
+// ResolveAgentConfigDir returns the directory to use as the agent config root.
+// When scope is ScopeWorkspace, workspaceDir is returned; otherwise homeDir is used.
+// Both homeDir and workspaceDir must be non-empty absolute paths.
+func ResolveAgentConfigDir(scope InstallScope, homeDir, workspaceDir string) string {
+	if scope == ScopeWorkspace && strings.TrimSpace(workspaceDir) != "" {
+		return workspaceDir
+	}
+	return homeDir
+}

--- a/internal/cli/scope_test.go
+++ b/internal/cli/scope_test.go
@@ -1,0 +1,136 @@
+package cli
+
+import (
+	"os"
+	"testing"
+)
+
+func TestResolveInstallScope(t *testing.T) {
+	tests := []struct {
+		name      string
+		flagValue string
+		envValue  string
+		want      InstallScope
+		wantErr   bool
+	}{
+		{
+			name:      "empty flag and no env defaults to global",
+			flagValue: "",
+			envValue:  "",
+			want:      ScopeGlobal,
+		},
+		{
+			name:      "flag global returns global",
+			flagValue: "global",
+			envValue:  "",
+			want:      ScopeGlobal,
+		},
+		{
+			name:      "flag workspace returns workspace",
+			flagValue: "workspace",
+			envValue:  "",
+			want:      ScopeWorkspace,
+		},
+		{
+			name:      "env global returns global",
+			flagValue: "",
+			envValue:  "global",
+			want:      ScopeGlobal,
+		},
+		{
+			name:      "env workspace returns workspace",
+			flagValue: "",
+			envValue:  "workspace",
+			want:      ScopeWorkspace,
+		},
+		{
+			name:      "flag takes precedence over env",
+			flagValue: "workspace",
+			envValue:  "global",
+			want:      ScopeWorkspace,
+		},
+		{
+			name:      "invalid flag value returns error",
+			flagValue: "project",
+			wantErr:   true,
+		},
+		{
+			name:     "invalid env value returns error",
+			envValue: "local",
+			wantErr:  true,
+		},
+		{
+			name:      "whitespace-only flag treated as unset",
+			flagValue: "   ",
+			envValue:  "",
+			want:      ScopeGlobal,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.envValue != "" {
+				t.Setenv(scopeEnvVar, tt.envValue)
+			} else {
+				os.Unsetenv(scopeEnvVar)
+			}
+
+			got, err := ResolveInstallScope(tt.flagValue)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ResolveInstallScope(%q) error = %v, wantErr %v", tt.flagValue, err, tt.wantErr)
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Fatalf("ResolveInstallScope(%q) = %q, want %q", tt.flagValue, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveAgentConfigDir(t *testing.T) {
+	tests := []struct {
+		name         string
+		scope        InstallScope
+		homeDir      string
+		workspaceDir string
+		want         string
+	}{
+		{
+			name:         "global scope uses homeDir",
+			scope:        ScopeGlobal,
+			homeDir:      "/home/user",
+			workspaceDir: "/projects/myapp",
+			want:         "/home/user",
+		},
+		{
+			name:         "workspace scope uses workspaceDir",
+			scope:        ScopeWorkspace,
+			homeDir:      "/home/user",
+			workspaceDir: "/projects/myapp",
+			want:         "/projects/myapp",
+		},
+		{
+			name:         "workspace scope with empty workspaceDir falls back to homeDir",
+			scope:        ScopeWorkspace,
+			homeDir:      "/home/user",
+			workspaceDir: "",
+			want:         "/home/user",
+		},
+		{
+			name:         "workspace scope with whitespace-only workspaceDir falls back to homeDir",
+			scope:        ScopeWorkspace,
+			homeDir:      "/home/user",
+			workspaceDir: "   ",
+			want:         "/home/user",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ResolveAgentConfigDir(tt.scope, tt.homeDir, tt.workspaceDir)
+			if got != tt.want {
+				t.Fatalf("ResolveAgentConfigDir(%q, %q, %q) = %q, want %q",
+					tt.scope, tt.homeDir, tt.workspaceDir, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/cli/validate.go
+++ b/internal/cli/validate.go
@@ -11,6 +11,7 @@ import (
 
 type InstallInput struct {
 	Selection model.Selection
+	Scope     InstallScope
 	DryRun    bool
 }
 
@@ -57,7 +58,12 @@ func NormalizeInstallFlags(flags InstallFlags, detection system.DetectionResult)
 	}
 	selection.SDDMode = sddMode
 
-	return InstallInput{Selection: selection, DryRun: flags.DryRun}, nil
+	scope, err := ResolveInstallScope(flags.Scope)
+	if err != nil {
+		return InstallInput{}, err
+	}
+
+	return InstallInput{Selection: selection, Scope: scope, DryRun: flags.DryRun}, nil
 }
 
 func normalizePersona(value string) (model.PersonaID, error) {


### PR DESCRIPTION
## Linked Issue

Closes #461

## PR Type

- [x] `type:bug`

## Summary

`gentle-ai install` writes persona, output style, skills, and agents into the global `~/.claude/` directory. Pre-existing Claude Code workspaces that never opted in inherit the Gentleman stack — they start replying in Rioplatense voseo and suggesting SDD flows unexpectedly.

This PR adds an opt-in workspace-scoped install path:

- **New CLI flag:** `--scope=global|workspace` (default: `global` — backward-compatible)
- **New env var:** `GENTLE_AI_INSTALL_SCOPE=global|workspace`
- **Centralized scope resolver** at `internal/cli/scope.go`. All install destinations now compute from the resolved scope via `ResolveAgentConfigDir()`.
- **Install-start warning** when scope is `global`, recommending `--scope=workspace` for users who don't want stack-wide effects.

## Cross-agent audit

The scope mechanism is wired through the unified `componentInjectionDirScoped` / `componentPathDirScoped` helpers, so it works for every agent that goes through the standard injection pipeline (Claude Code, OpenCode, Cursor, Kiro, Kimi, etc.). Agents that compute their own paths (e.g. Antigravity uses `~/.gemini/antigravity-*` outside the standard `~/.claude/` tree) are unaffected and continue using their own directory layout — that's correct because their files don't contaminate the Claude workspace.

## Changes

| File | Change |
|------|--------|
| `internal/cli/scope.go` (new) | `InstallScope` type, `ResolveInstallScope()`, `ResolveAgentConfigDir()` |
| `internal/cli/scope_test.go` (new) | Table-driven coverage: flag > env > default, fallbacks, invalid values |
| `internal/cli/install.go` | Add `Scope` field to `InstallFlags`, register `--scope` |
| `internal/cli/validate.go` | Add `Scope` to `InstallInput`, wire `ResolveInstallScope` in `NormalizeInstallFlags` |
| `internal/cli/run.go` | Plumb `scope` through `installRuntime`/`componentApplyStep`; scoped helpers; global-scope warning |
| `internal/app/app.go` | Update `BuildRealStagePlan` call (TUI path) with `cli.ScopeGlobal` default |
| `internal/cli/openclaw_orchestration_test.go` | Adjust test to new signature |

## Backward compatibility

Default remains `global` so no existing automated install changes behavior. Users who want isolation opt in via `--scope=workspace` or `GENTLE_AI_INSTALL_SCOPE=workspace`. A subsequent PR (separate issue) can flip the default once enough users have migrated and we want a true breaking change.

## Test Plan

- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [x] `go build` clean

## Contributor Checklist

- [x] Linked to approved issue (#461 has \`status:approved\`)
- [x] Under 400 changed lines (270 LOC)
- [x] Conventional Commits format
- [x] No Co-Authored-By trailers