### PR TITLE
fix(install): merge --agent install into existing state.json instead of overwriting

### DIFF
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -151,13 +151,25 @@ func RunInstall(args []string, detection system.DetectionResult) (InstallResult,
 	for _, a := range input.Selection.Agents {
 		agentIDs = append(agentIDs, string(a))
 	}
-	// Non-fatal: a state write failure must not break an otherwise successful install.
-	_ = state.Write(homeDir, state.InstallState{
+
+	// When the user ran `gentle-ai install --agent X` (explicit agent flag),
+	// merge into the existing state so that previously installed agents and
+	// model assignments are preserved. A full install (no --agent flag) keeps
+	// overwrite semantics so the TUI selection is the source of truth.
+	newState := state.InstallState{
 		InstalledAgents:        agentIDs,
 		ClaudeModelAssignments: claudeAliasesToStrings(input.Selection.ClaudeModelAssignments),
 		ModelAssignments:       modelAssignmentsToState(input.Selection.ModelAssignments),
 		Persona:                string(input.Selection.Persona),
-	})
+	}
+	if len(flags.Agents) > 0 {
+		existing, readErr := state.Read(homeDir)
+		if readErr == nil {
+			newState = state.MergeAgents(existing, agentIDs)
+		}
+	}
+	// Non-fatal: a state write failure must not break an otherwise successful install.
+	_ = state.Write(homeDir, newState)
 
 	return result, nil
 }

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -65,6 +65,42 @@ func Read(homeDir string) (InstallState, error) {
 	return s, nil
 }
 
+// MergeAgents returns a new InstallState that combines existing with the
+// provided newAgents. The new agents are appended to existing.InstalledAgents
+// with deduplication. All other fields (ModelAssignments,
+// ClaudeModelAssignments, KiroModelAssignments, Persona) are taken from
+// existing and are never overwritten.
+//
+// This is the correct operation for an incremental `--agent X` install: the
+// caller loads the persisted state, calls MergeAgents, and writes the result
+// back. A full TUI install should use Write directly so that the TUI selection
+// is the source of truth.
+func MergeAgents(existing InstallState, newAgents []string) InstallState {
+	seen := make(map[string]struct{}, len(existing.InstalledAgents))
+	merged := make([]string, 0, len(existing.InstalledAgents)+len(newAgents))
+
+	for _, a := range existing.InstalledAgents {
+		if _, ok := seen[a]; !ok {
+			seen[a] = struct{}{}
+			merged = append(merged, a)
+		}
+	}
+	for _, a := range newAgents {
+		if _, ok := seen[a]; !ok {
+			seen[a] = struct{}{}
+			merged = append(merged, a)
+		}
+	}
+
+	return InstallState{
+		InstalledAgents:        merged,
+		ModelAssignments:       existing.ModelAssignments,
+		ClaudeModelAssignments: existing.ClaudeModelAssignments,
+		KiroModelAssignments:   existing.KiroModelAssignments,
+		Persona:                existing.Persona,
+	}
+}
+
 // Write persists the full install state to disk under the given home directory.
 // It creates the .gentle-ai directory if it does not already exist.
 func Write(homeDir string, s InstallState) error {

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -7,6 +7,84 @@ import (
 	"testing"
 )
 
+// TestMergeAgents verifies that MergeAgents appends new agents to existing
+// installed_agents with deduplication and preserves all other fields.
+func TestMergeAgents(t *testing.T) {
+	existingAssignments := map[string]ModelAssignmentState{
+		"sdd-init": {ProviderID: "anthropic", ModelID: "claude-sonnet-4"},
+	}
+	existingClaude := map[string]string{"sdd-explore": "sonnet", "sdd-archive": "haiku"}
+	existingKiro := map[string]string{"sdd-design": "opus"}
+
+	tests := []struct {
+		name      string
+		existing  InstallState
+		newAgents []string
+		wantIDs   []string
+	}{
+		{
+			name:      "empty existing state gets new agent",
+			existing:  InstallState{},
+			newAgents: []string{"pi"},
+			wantIDs:   []string{"pi"},
+		},
+		{
+			name:      "existing single agent plus new agent appended",
+			existing:  InstallState{InstalledAgents: []string{"claude-code"}},
+			newAgents: []string{"opencode"},
+			wantIDs:   []string{"claude-code", "opencode"},
+		},
+		{
+			name:      "duplicate agent is deduped",
+			existing:  InstallState{InstalledAgents: []string{"opencode", "vscode-copilot", "codex"}},
+			newAgents: []string{"opencode"},
+			wantIDs:   []string{"opencode", "vscode-copilot", "codex"},
+		},
+		{
+			name:      "existing multiple agents plus new agent appended",
+			existing:  InstallState{InstalledAgents: []string{"opencode", "vscode-copilot", "codex"}},
+			newAgents: []string{"pi"},
+			wantIDs:   []string{"opencode", "vscode-copilot", "codex", "pi"},
+		},
+		{
+			name: "model_assignments preserved across merge",
+			existing: InstallState{
+				InstalledAgents:        []string{"opencode"},
+				ModelAssignments:       existingAssignments,
+				ClaudeModelAssignments: existingClaude,
+				KiroModelAssignments:   existingKiro,
+				Persona:                "gentleman",
+			},
+			newAgents: []string{"pi"},
+			wantIDs:   []string{"opencode", "pi"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := MergeAgents(tt.existing, tt.newAgents)
+
+			if !reflect.DeepEqual(got.InstalledAgents, tt.wantIDs) {
+				t.Errorf("InstalledAgents = %v, want %v", got.InstalledAgents, tt.wantIDs)
+			}
+
+			// Verify all preserved fields are unchanged.
+			if !reflect.DeepEqual(got.ModelAssignments, tt.existing.ModelAssignments) {
+				t.Errorf("ModelAssignments not preserved: got %v, want %v", got.ModelAssignments, tt.existing.ModelAssignments)
+			}
+			if !reflect.DeepEqual(got.ClaudeModelAssignments, tt.existing.ClaudeModelAssignments) {
+				t.Errorf("ClaudeModelAssignments not preserved: got %v, want %v", got.ClaudeModelAssignments, tt.existing.ClaudeModelAssignments)
+			}
+			if !reflect.DeepEqual(got.KiroModelAssignments, tt.existing.KiroModelAssignments) {
+				t.Errorf("KiroModelAssignments not preserved: got %v, want %v", got.KiroModelAssignments, tt.existing.KiroModelAssignments)
+			}
+			if got.Persona != tt.existing.Persona {
+				t.Errorf("Persona not preserved: got %q, want %q", got.Persona, tt.existing.Persona)
+			}
+		})
+	}
+}
+
 // TestWriteAndRead writes state and reads it back, verifying agents match.
 func TestWriteAndRead(t *testing.T) {
 	home := t.TempDir()


### PR DESCRIPTION
## Linked Issue
Closes #560

## PR Type
- [x] type:bug

## Summary
`gentle-ai install --agent X` overwrote `~/.gentle-ai/state.json` with only the newly selected agent, dropping `installed_agents`, `model_assignments`, `claude_model_assignments`, and other persisted fields. This is data-loss for any user adding a second agent incrementally.

This PR makes the `--agent X` flow merge instead of overwrite: existing agents and model assignments are preserved, the new agent is appended (deduped). Full install (no `--agent` flag) keeps overwrite semantics so the TUI selection remains the source of truth when the user runs a full install.

## Changes

| File | What changed |
|------|-------------|
| `internal/state/state.go` | Added `MergeAgents(existing InstallState, newAgents []string) InstallState` — dedup-appends new agents while preserving all other fields |
| `internal/cli/run.go` | When `flags.Agents` is non-empty (i.e. `--agent X` was used), load existing state, call `MergeAgents`, and write the merged result instead of a fresh overwrite |
| `internal/state/state_test.go` | Table-driven tests for `MergeAgents` covering: empty existing state, single agent + new agent, existing multiple + duplicate add, and model_assignments preservation |

## Test Plan
- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [x] `go build` clean

## Contributor Checklist
- [x] Linked to approved issue (#560)
- [x] Under 400 changed lines
- [x] Conventional Commits format
- [x] No Co-Authored-By trailers