### PR TITLE
fix(sdd): require text response after persistence in sub-agents to avoid lost output

### DIFF
--- a/internal/assets/skills/_shared/persistence-contract.md
+++ b/internal/assets/skills/_shared/persistence-contract.md
@@ -137,6 +137,14 @@ If you return without calling mem_save, the next phase CANNOT find your artifact
 
 For SDD artifacts, `capture_prompt: false` is explicit and mandatory when the Engram tool schema supports it. Engram v1.15.3 defaults `capture_prompt` to true for normal human/proactive saves, but automated pipeline artifacts must not capture the user's prompt. Do not infer this from `type` because SDD artifacts and real human architecture decisions both use `architecture`. If an older schema rejects or does not expose `capture_prompt`, omit it rather than failing.
 
+## Sub-Agent Response Ordering
+
+When a sub-agent persists artifacts (via `mem_save` or file writes), the persistence call MUST happen BEFORE the final text response. The sub-agent's absolute last output must be text, never a tool call.
+
+**Why**: The Task tool returns the sub-agent's final output to the parent. If the sub-agent ends with a tool call, the parent receives only the tool result (e.g., `"Observation saved"`) — the sub-agent's text analysis is lost. Always: do your work → save → respond with text envelope.
+
+Sub-agents must NOT call `mem_session_summary` — that's reserved for top-level agents only.
+
 ## Skill Registry
 
 The orchestrator pre-resolves skill paths from the skill registry and injects them as `## Skills to load before work` in your launch prompt. Sub-agents read those exact `SKILL.md` files before task-specific work.

--- a/internal/assets/skills/_shared/sdd-phase-common.md
+++ b/internal/assets/skills/_shared/sdd-phase-common.md
@@ -68,6 +68,8 @@ Return result inline only. Do not write any files or call `mem_save`.
 
 ## D. Return Envelope
 
+> **CRITICAL — Response ordering**: Your FINAL output MUST be text (the return envelope), NOT a tool call. If you need to save to Engram (`mem_save`), do it BEFORE your final text response. Do NOT call `mem_session_summary` — that's for top-level agents only. **Why**: When a sub-agent's last action is a tool call, the parent agent receives only the tool result — your text response (the actual analysis) is lost.
+
 Every phase MUST return a structured envelope to the orchestrator:
 
 - `status`: `success`, `partial`, or `blocked`


### PR DESCRIPTION
## Linked Issue
Closes #387

## PR Type
- [x] type:bug

## Summary
When an SDD sub-agent's last action was a tool call (typically `mem_save`), the Task tool returned the tool result to the parent agent instead of the sub-agent's actual text analysis. The sub-agent's findings were lost; the orchestrator had to either re-launch the sub-agent or guess.

This PR adds explicit ordering guidance in the shared SDD documentation: sub-agents must persist BEFORE returning their final text envelope. The fix is unconditional (applies to all agents, including OpenCode where sub-agents can't detect their own role) by editing the shared `_shared/` markdown files that every agent's bundle pulls from.

## Changes
| File | Change |
|------|--------|
| `internal/assets/skills/_shared/sdd-phase-common.md` | + Critical response-ordering note in Section D |
| `internal/assets/skills/_shared/persistence-contract.md` | + New "Sub-Agent Response Ordering" section |

Note: `engram-convention.md` was investigated as a potential third file but does not document sub-agent return behavior — no edit needed there.

## Test Plan
- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [x] `go build` clean

## Contributor Checklist
- [x] Linked to approved issue (#387)
- [x] Under 400 changed lines
- [x] Conventional Commits format
- [x] No Co-Authored-By trailers