### PR TITLE
fix(components/gga): write Windows config to %APPDATA% to match GGA's read path

### DIFF
--- a/internal/components/gga/config.go
+++ b/internal/components/gga/config.go
@@ -2,13 +2,40 @@ package gga
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/gentleman-programming/gentle-ai/internal/assets"
 	"github.com/gentleman-programming/gentle-ai/internal/components/filemerge"
 	"github.com/gentleman-programming/gentle-ai/internal/model"
 )
+
+// ggaConfigDir returns the platform-appropriate directory that GGA reads its
+// global config from.
+//
+// On Windows, GGA reads from %APPDATA%\gga (i.e. AppData\Roaming\gga).
+// On Linux and macOS, GGA follows the XDG convention and reads from
+// ~/.config/gga.
+//
+// gentle-ai must write to the same location that GGA reads from; using
+// %USERPROFILE%\.config on Windows is incorrect and results in `gga config`
+// reporting no provider even when the config file was generated.
+//
+// goos is injected so unit tests can override runtime.GOOS without build tags.
+func ggaConfigDir(homeDir string, goos string) string {
+	if goos == "windows" {
+		appData := os.Getenv("APPDATA")
+		if appData == "" {
+			// Fallback: APPDATA should always be set on Windows, but guard
+			// defensively so we never produce an empty path.
+			appData = filepath.Join(homeDir, "AppData", "Roaming")
+		}
+		return filepath.Join(appData, "gga")
+	}
+	return filepath.Join(homeDir, ".config", "gga")
+}
 
 // InjectionResult describes all files written by the GGA config injection.
 type InjectionResult struct {
@@ -92,12 +119,12 @@ func BuildConfig(provider string) []byte {
 
 // ConfigPath returns the GGA global config file path.
 func ConfigPath(homeDir string) string {
-	return filepath.Join(homeDir, ".config", "gga", "config")
+	return filepath.Join(ggaConfigDir(homeDir, runtime.GOOS), "config")
 }
 
 // AgentsTemplatePath returns the starter AGENTS.md template path.
 func AgentsTemplatePath(homeDir string) string {
-	return filepath.Join(homeDir, ".config", "gga", "AGENTS.md")
+	return filepath.Join(ggaConfigDir(homeDir, runtime.GOOS), "AGENTS.md")
 }
 
 // Inject writes the GGA global config and starter AGENTS.md template.

--- a/internal/components/gga/config_test.go
+++ b/internal/components/gga/config_test.go
@@ -181,23 +181,99 @@ func TestInjectIsIdempotent(t *testing.T) {
 }
 
 func TestConfigPath(t *testing.T) {
+	// On non-Windows hosts the path follows XDG convention.
 	path := ConfigPath("/home/testuser")
-	expected := filepath.Join("/home/testuser", ".config", "gga", "config")
-	if path != expected {
-		t.Fatalf("ConfigPath() = %q, want %q", path, expected)
-	}
 
 	// Must NOT have .json extension (shell-sourced, no extension).
 	if strings.HasSuffix(path, ".json") {
 		t.Error("ConfigPath() should NOT end with .json")
 	}
+	// Must end with the filename "config".
+	if filepath.Base(path) != "config" {
+		t.Fatalf("ConfigPath() base = %q, want \"config\"", filepath.Base(path))
+	}
 }
 
 func TestAgentsTemplatePath(t *testing.T) {
 	path := AgentsTemplatePath("/home/testuser")
-	expected := filepath.Join("/home/testuser", ".config", "gga", "AGENTS.md")
-	if path != expected {
-		t.Fatalf("AgentsTemplatePath() = %q, want %q", path, expected)
+	if filepath.Base(path) != "AGENTS.md" {
+		t.Fatalf("AgentsTemplatePath() base = %q, want \"AGENTS.md\"", filepath.Base(path))
+	}
+}
+
+func TestGGAConfigDirLinux(t *testing.T) {
+	tests := []struct {
+		name    string
+		homeDir string
+		want    string
+	}{
+		{
+			name:    "standard home dir",
+			homeDir: "/home/user",
+			want:    filepath.Join("/home/user", ".config", "gga"),
+		},
+		{
+			name:    "root home dir",
+			homeDir: "/root",
+			want:    filepath.Join("/root", ".config", "gga"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ggaConfigDir(tt.homeDir, "linux")
+			if got != tt.want {
+				t.Fatalf("ggaConfigDir(%q, \"linux\") = %q, want %q", tt.homeDir, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGGAConfigDirDarwin(t *testing.T) {
+	got := ggaConfigDir("/Users/testuser", "darwin")
+	want := filepath.Join("/Users/testuser", ".config", "gga")
+	if got != want {
+		t.Fatalf("ggaConfigDir(%q, \"darwin\") = %q, want %q", "/Users/testuser", got, want)
+	}
+}
+
+func TestGGAConfigDirWindows(t *testing.T) {
+	tests := []struct {
+		name        string
+		homeDir     string
+		appDataEnv  string
+		wantSuffix  string
+	}{
+		{
+			name:       "APPDATA set to standard roaming path",
+			homeDir:    `C:\Users\testuser`,
+			appDataEnv: `C:\Users\testuser\AppData\Roaming`,
+			wantSuffix: filepath.Join(`C:\Users\testuser\AppData\Roaming`, "gga"),
+		},
+		{
+			name:       "APPDATA set to custom path",
+			homeDir:    `C:\Users\other`,
+			appDataEnv: `D:\custom\appdata`,
+			wantSuffix: filepath.Join(`D:\custom\appdata`, "gga"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("APPDATA", tt.appDataEnv)
+			got := ggaConfigDir(tt.homeDir, "windows")
+			if got != tt.wantSuffix {
+				t.Fatalf("ggaConfigDir(%q, \"windows\") = %q, want %q", tt.homeDir, got, tt.wantSuffix)
+			}
+		})
+	}
+}
+
+func TestGGAConfigDirWindowsNoAPPDATA(t *testing.T) {
+	// When APPDATA is unset, the fallback must be derived from homeDir.
+	t.Setenv("APPDATA", "")
+	got := ggaConfigDir(`C:\Users\testuser`, "windows")
+	want := filepath.Join(`C:\Users\testuser`, "AppData", "Roaming", "gga")
+	if got != want {
+		t.Fatalf("ggaConfigDir fallback = %q, want %q", got, want)
 	}
 }
 


### PR DESCRIPTION
## Linked Issue

Closes #382

## PR Type

- [x] `type:bug`

## Summary

On Windows, gentle-ai was writing the GGA global config to `%USERPROFILE%\.config\gga\config`, but GGA reads from `%APPDATA%\gga\config` (`AppData\Roaming`). This caused `gga config` to report no provider even though gentle-ai had generated one for users running presets like `full-gentleman` or `ecosystem-only`.

Introduces `ggaConfigDir(homeDir, goos)` which returns `%APPDATA%\gga` on Windows and `~/.config/gga` on Linux/macOS, keeping existing behavior on non-Windows platforms. `ConfigPath` and `AgentsTemplatePath` now delegate to this helper via `runtime.GOOS`.

## Cross-agent note

This fix is GGA-specific. Other agents (Claude Code, OpenCode, Kiro, etc.) write to their own adapter-controlled paths and are unaffected.

## Changes

| File | Change |
|------|--------|
| `internal/components/gga/config.go` | Platform-aware `ggaConfigDir` helper; `ConfigPath` and `AgentsTemplatePath` delegate |
| `internal/components/gga/config_test.go` | Table-driven coverage: Windows (APPDATA set/unset), Linux, macOS |

## Test Plan

- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [x] `go build` clean

## Contributor Checklist

- [x] Linked to approved issue (#382 has \`status:approved\`)
- [x] Under 400 changed lines (121 LOC)
- [x] Conventional Commits format
- [x] No Co-Authored-By trailers