### PR TITLE
fix(e2e): switch minimal preset tests from --persona neutral to --persona custom

### DIFF
--- a/e2e/e2e_test.sh
+++ b/e2e/e2e_test.sh
@@ -609,7 +609,7 @@ test_cc_skills_minimal() {
     log_test "Claude Code: skills injection (minimal preset = SDD skills only)"
     cleanup_test_env
 
-    if $BINARY install --agent claude-code --component skills --preset minimal --persona neutral 2>&1; then
+    if $BINARY install --agent claude-code --component skills --preset minimal --persona custom 2>&1; then
         local skills_dir="$HOME/.claude/skills"
         assert_dir_exists "$skills_dir" "Claude skills directory"
 
@@ -887,7 +887,7 @@ test_oc_skills_minimal() {
     log_test "OpenCode: skills injection (minimal)"
     cleanup_test_env
 
-    if $BINARY install --agent opencode --component skills --preset minimal --persona neutral 2>&1; then
+    if $BINARY install --agent opencode --component skills --preset minimal --persona custom 2>&1; then
         local skill_dir="$HOME/.config/opencode/skills"
         assert_dir_exists "$skill_dir" "OpenCode skill directory"
         assert_file_count "$skill_dir" "SKILL.md" 12 "Minimal preset: 12 skill files"
@@ -1099,7 +1099,7 @@ test_minimal_preset_opencode_only_engram_no_persona() {
     log_test "Minimal preset: OpenCode (engram only, no persona side effect)"
     cleanup_test_env
 
-    if $BINARY install --agent opencode --preset minimal --persona neutral 2>&1; then
+    if $BINARY install --agent opencode --preset minimal --persona custom 2>&1; then
         local settings="$HOME/.config/opencode/opencode.json"
         local agents_md="$HOME/.config/opencode/AGENTS.md"
 
@@ -1122,7 +1122,7 @@ test_minimal_preset_claude_only_engram() {
     log_test "Minimal preset: Claude Code (only engram, nothing else)"
     cleanup_test_env
 
-    if $BINARY install --agent claude-code --preset minimal --persona neutral 2>&1; then
+    if $BINARY install --agent claude-code --preset minimal --persona custom 2>&1; then
         # Engram should be installed (MCP + CLAUDE.md)
         assert_file_exists "$HOME/.claude/CLAUDE.md" "CLAUDE.md exists"
         assert_file_contains "$HOME/.claude/CLAUDE.md" "gentle-ai:engram-protocol" "Engram protocol section"
@@ -1428,12 +1428,12 @@ test_idempotent_skills_claude() {
     log_test "Idempotency: skills injection produces same files"
     cleanup_test_env
 
-    $BINARY install --agent claude-code --component skills --preset minimal --persona neutral 2>&1 || true
+    $BINARY install --agent claude-code --component skills --preset minimal --persona custom 2>&1 || true
     # Capture file hashes
     local first_hashes
     first_hashes=$(find "$HOME/.claude/skills" -name "SKILL.md" -exec md5sum {} \; 2>/dev/null | sort)
 
-    $BINARY install --agent claude-code --component skills --preset minimal --persona neutral 2>&1 || true
+    $BINARY install --agent claude-code --component skills --preset minimal --persona custom 2>&1 || true
     local second_hashes
     second_hashes=$(find "$HOME/.claude/skills" -name "SKILL.md" -exec md5sum {} \; 2>/dev/null | sort)
 

--- a/e2e/e2e_test.sh
+++ b/e2e/e2e_test.sh
@@ -187,23 +187,41 @@ test_dry_run_preset_custom() {
 # --- Category 1e: Preset component order validation ---
 
 test_preset_minimal_components() {
-    log_test "Preset minimal produces only engram component"
+    log_test "Preset minimal with persona=custom produces only engram component"
 
-    output=$($BINARY install --preset minimal --agent claude-code --dry-run 2>&1) || true
+    # Use persona=custom to test the preset alone, since persona is now
+    # driven by Selection.Persona (decoupled from preset).
+    output=$($BINARY install --preset minimal --persona custom --agent claude-code --dry-run 2>&1) || true
 
     # The component list should contain engram
     assert_output_contains "$output" "engram" "Minimal preset includes engram"
     # Should NOT contain sdd, skills, persona, etc.
     assert_output_not_contains "$output" "Components order:.*sdd" "Minimal preset excludes sdd"
-    assert_output_not_contains "$output" "Components order:.*persona" "Minimal preset excludes persona"
+    assert_output_not_contains "$output" "Components order:.*persona" "Minimal + persona=custom excludes persona"
+}
+
+test_preset_minimal_with_default_persona_includes_persona() {
+    log_test "Preset minimal with default persona (gentleman) includes persona"
+
+    # Persona is now decoupled from preset — default Gentleman persona is
+    # installed regardless of which preset the user picks.
+    output=$($BINARY install --preset minimal --agent claude-code --dry-run 2>&1) || true
+
+    local components_line
+    components_line=$(echo "$output" | grep "Components order:")
+
+    assert_output_contains "$components_line" "engram" "Minimal includes engram"
+    assert_output_contains "$components_line" "persona" "Minimal + default Gentleman persona includes persona"
 }
 
 test_preset_ecosystem_components() {
-    log_test "Preset ecosystem-only produces 5 components"
+    log_test "Preset ecosystem-only with persona=custom produces 5 components"
 
-    output=$($BINARY install --preset ecosystem-only --agent claude-code --dry-run 2>&1) || true
+    # Use persona=custom to test the preset alone, since persona is now
+    # driven by Selection.Persona (decoupled from preset).
+    output=$($BINARY install --preset ecosystem-only --persona custom --agent claude-code --dry-run 2>&1) || true
 
-    # ecosystem-only = engram, sdd, skills, context7, gga
+    # ecosystem-only (without persona) = engram, sdd, skills, context7, gga
     local components_line
     components_line=$(echo "$output" | grep "Components order:")
 
@@ -212,8 +230,23 @@ test_preset_ecosystem_components() {
     assert_output_contains "$components_line" "skills" "Ecosystem includes skills"
     assert_output_contains "$components_line" "context7" "Ecosystem includes context7"
     assert_output_contains "$components_line" "gga" "Ecosystem includes gga"
-    assert_output_not_contains "$components_line" "persona" "Ecosystem excludes persona"
+    assert_output_not_contains "$components_line" "persona" "Ecosystem + persona=custom excludes persona"
     assert_output_not_contains "$components_line" "permissions" "Ecosystem excludes permissions"
+}
+
+test_preset_full_with_custom_persona_excludes_persona() {
+    log_test "Preset full-gentleman with persona=custom excludes persona"
+
+    # Persona is decoupled — picking persona=custom skips persona install
+    # even when the preset is full-gentleman.
+    output=$($BINARY install --preset full-gentleman --persona custom --agent claude-code --dry-run 2>&1) || true
+
+    local components_line
+    components_line=$(echo "$output" | grep "Components order:")
+
+    assert_output_contains "$components_line" "engram" "Full + persona=custom keeps engram"
+    assert_output_contains "$components_line" "permissions" "Full + persona=custom keeps permissions"
+    assert_output_not_contains "$components_line" "persona" "Full + persona=custom excludes persona"
 }
 
 test_preset_full_components() {
@@ -2142,8 +2175,10 @@ test_dry_run_preset_custom
 
 # Category 1e: Preset component order validation
 test_preset_minimal_components
+test_preset_minimal_with_default_persona_includes_persona
 test_preset_ecosystem_components
 test_preset_full_components
+test_preset_full_with_custom_persona_excludes_persona
 test_dry_run_full_preset_persona_before_sdd
 test_preset_no_legacy_theme_in_any_preset
 test_preset_custom_no_components

--- a/internal/cli/install_test.go
+++ b/internal/cli/install_test.go
@@ -66,11 +66,11 @@ func TestNormalizeInstallFlagsDefaults(t *testing.T) {
 			model.ComponentSDD,
 			model.ComponentSkills,
 			model.ComponentContext7,
-			model.ComponentPersona,
 			model.ComponentPermission,
 			model.ComponentGGA,
 			model.ComponentClaudeTheme,
 			model.ComponentOpenCodeGentleLogo,
+			model.ComponentPersona,
 		},
 	}
 
@@ -136,7 +136,9 @@ func TestNormalizeInstallFlagsPiOnlyRespectsExplicitPreset(t *testing.T) {
 		t.Fatalf("NormalizeInstallFlags() error = %v", err)
 	}
 
-	want := []model.ComponentID{model.ComponentEngram}
+	// Pi + explicit minimal preset with default gentleman persona now includes ComponentPersona.
+	// Persona is persona-screen-driven; preset only controls the ecosystem stack.
+	want := []model.ComponentID{model.ComponentEngram, model.ComponentPersona}
 	if !reflect.DeepEqual(input.Selection.Components, want) {
 		t.Fatalf("components = %#v, want %#v", input.Selection.Components, want)
 	}

--- a/internal/cli/validate.go
+++ b/internal/cli/validate.go
@@ -35,7 +35,7 @@ func NormalizeInstallFlags(flags InstallFlags, detection system.DetectionResult)
 	}
 	selection.Preset = preset
 
-	components, err := normalizeComponents(flags.Components, selection.Preset)
+	components, err := normalizeComponents(flags.Components, selection.Preset, selection.Persona)
 	if err != nil {
 		return InstallInput{}, err
 	}
@@ -86,9 +86,9 @@ func normalizePreset(value string) (model.PresetID, error) {
 	}
 }
 
-func normalizeComponents(values []string, preset model.PresetID) ([]model.ComponentID, error) {
+func normalizeComponents(values []string, preset model.PresetID, persona model.PersonaID) ([]model.ComponentID, error) {
 	if len(values) == 0 {
-		return componentsForPreset(preset), nil
+		return componentsForPreset(preset, persona), nil
 	}
 
 	allowed := map[model.ComponentID]struct{}{}
@@ -143,27 +143,31 @@ func normalizeSDDMode(value string) (model.SDDModeID, error) {
 	}
 }
 
-func componentsForPreset(preset model.PresetID) []model.ComponentID {
+func componentsForPreset(preset model.PresetID, persona model.PersonaID) []model.ComponentID {
+	var components []model.ComponentID
 	switch preset {
 	case model.PresetMinimal:
-		return []model.ComponentID{model.ComponentEngram}
+		components = []model.ComponentID{model.ComponentEngram}
 	case model.PresetEcosystemOnly:
-		return []model.ComponentID{model.ComponentEngram, model.ComponentSDD, model.ComponentSkills, model.ComponentContext7, model.ComponentGGA}
+		components = []model.ComponentID{model.ComponentEngram, model.ComponentSDD, model.ComponentSkills, model.ComponentContext7, model.ComponentGGA}
 	case model.PresetCustom:
 		return nil
-	default:
-		return []model.ComponentID{
+	default: // full-gentleman
+		components = []model.ComponentID{
 			model.ComponentEngram,
 			model.ComponentSDD,
 			model.ComponentSkills,
 			model.ComponentContext7,
-			model.ComponentPersona,
 			model.ComponentPermission,
 			model.ComponentGGA,
 			model.ComponentClaudeTheme,
 			model.ComponentOpenCodeGentleLogo,
 		}
 	}
+	if persona != model.PersonaCustom {
+		components = append(components, model.ComponentPersona)
+	}
+	return components
 }
 
 func defaultAgentsFromDetection(detection system.DetectionResult) []model.AgentID {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -465,7 +465,7 @@ type Model struct {
 
 func NewModel(detection system.DetectionResult, version string) Model {
 	agents := preselectedAgents(detection)
-	components := componentsForPreset(model.PresetFullGentleman)
+	components := componentsForPreset(model.PresetFullGentleman, model.PersonaGentleman)
 	if isPiOnlyAgents(agents) {
 		components = piOnlyComponents()
 	}
@@ -1500,6 +1500,10 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 		options := screens.PersonaOptions()
 		if m.Cursor < len(options) {
 			m.Selection.Persona = options[m.Cursor]
+			// Recompute components if a non-custom preset was already chosen
+			if m.Selection.Preset != "" && m.Selection.Preset != model.PresetCustom {
+				m.Selection.Components = componentsForPreset(m.Selection.Preset, m.Selection.Persona)
+			}
 			m.setScreen(ScreenPreset)
 			return m, nil
 		}
@@ -1508,7 +1512,7 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 		options := screens.PresetOptions()
 		if m.Cursor < len(options) {
 			m.Selection.Preset = options[m.Cursor]
-			m.Selection.Components = componentsForPreset(options[m.Cursor])
+			m.Selection.Components = componentsForPreset(options[m.Cursor], m.Selection.Persona)
 			if m.shouldShowClaudeModelPickerScreen() {
 				m.ClaudeModelPicker = screens.NewClaudeModelPickerState()
 				m.setScreen(ScreenClaudeModelPicker)
@@ -3242,27 +3246,31 @@ func (m Model) shouldShowKiroModelPickerScreen() bool {
 		hasSelectedComponent(m.Selection.Components, model.ComponentSDD)
 }
 
-func componentsForPreset(preset model.PresetID) []model.ComponentID {
+func componentsForPreset(preset model.PresetID, persona model.PersonaID) []model.ComponentID {
+	var components []model.ComponentID
 	switch preset {
 	case model.PresetMinimal:
-		return []model.ComponentID{model.ComponentEngram}
+		components = []model.ComponentID{model.ComponentEngram}
 	case model.PresetEcosystemOnly:
-		return []model.ComponentID{model.ComponentEngram, model.ComponentSDD, model.ComponentSkills, model.ComponentContext7, model.ComponentGGA}
+		components = []model.ComponentID{model.ComponentEngram, model.ComponentSDD, model.ComponentSkills, model.ComponentContext7, model.ComponentGGA}
 	case model.PresetCustom:
 		return nil
-	default:
-		return []model.ComponentID{
+	default: // full-gentleman
+		components = []model.ComponentID{
 			model.ComponentEngram,
 			model.ComponentSDD,
 			model.ComponentSkills,
 			model.ComponentContext7,
-			model.ComponentPersona,
 			model.ComponentPermission,
 			model.ComponentGGA,
 			model.ComponentClaudeTheme,
 			model.ComponentOpenCodeGentleLogo,
 		}
 	}
+	if persona != model.PersonaCustom {
+		components = append(components, model.ComponentPersona)
+	}
+	return components
 }
 
 func hasSelectedComponent(components []model.ComponentID, target model.ComponentID) bool {

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -239,7 +239,7 @@ func TestPiOnlyAgentContinueSkipsPromptsAndIncludesEngram(t *testing.T) {
 	m := NewModel(system.DetectionResult{}, "dev")
 	m.Screen = ScreenAgents
 	m.Selection.Agents = []model.AgentID{model.AgentPi}
-	m.Selection.Components = componentsForPreset(model.PresetFullGentleman)
+	m.Selection.Components = componentsForPreset(model.PresetFullGentleman, model.PersonaGentleman)
 	m.Cursor = len(screensAgentOptions())
 
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
@@ -331,7 +331,8 @@ func TestPiCombinedWithOtherAgentsTUIInstallKeepsAllAgentsInPlan(t *testing.T) {
 	if !reflect.DeepEqual(state.DependencyPlan.Agents, wantAgents) {
 		t.Fatalf("dependency agents = %v, want %v", state.DependencyPlan.Agents, wantAgents)
 	}
-	wantComponents := []model.ComponentID{model.ComponentEngram}
+	// Minimal preset + Gentleman persona now includes ComponentPersona (persona is the source of truth).
+	wantComponents := []model.ComponentID{model.ComponentPersona, model.ComponentEngram}
 	if !reflect.DeepEqual(state.DependencyPlan.OrderedComponents, wantComponents) {
 		t.Fatalf("dependency components = %v, want %v", state.DependencyPlan.OrderedComponents, wantComponents)
 	}
@@ -1880,7 +1881,7 @@ func TestKiroPickerEscNonCustomWithClaudeGoesToClaudePicker(t *testing.T) {
 	m.Selection.Preset = model.PresetFullGentleman // non-custom
 	// Simulate both Kiro and Claude being selected.
 	m.Selection.Agents = []model.AgentID{model.AgentKiroIDE, model.AgentClaudeCode}
-	m.Selection.Components = componentsForPreset(model.PresetFullGentleman)
+	m.Selection.Components = componentsForPreset(model.PresetFullGentleman, model.PersonaGentleman)
 	m.KiroModelPicker = screens.NewKiroModelPickerState()
 
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
@@ -1902,7 +1903,7 @@ func TestKiroPickerEscNonCustomWithoutClaudeGoesToPreset(t *testing.T) {
 	m.Selection.Preset = model.PresetFullGentleman
 	// Only Kiro — no Claude.
 	m.Selection.Agents = []model.AgentID{model.AgentKiroIDE}
-	m.Selection.Components = componentsForPreset(model.PresetFullGentleman)
+	m.Selection.Components = componentsForPreset(model.PresetFullGentleman, model.PersonaGentleman)
 	m.KiroModelPicker = screens.NewKiroModelPickerState()
 
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
@@ -3804,5 +3805,154 @@ func TestPinErrClearedOnScreenReentry(t *testing.T) {
 	// PinErr must be cleared on re-entry.
 	if afterReturn.PinErr != nil {
 		t.Fatalf("PinErr should be nil after returning to ScreenBackups, got: %v", afterReturn.PinErr)
+	}
+}
+
+// TestComponentsForPreset_PersonaMatrix verifies that componentsForPreset includes
+// ComponentPersona when persona != PersonaCustom and excludes it for PersonaCustom.
+func TestComponentsForPreset_PersonaMatrix(t *testing.T) {
+	tests := []struct {
+		name          string
+		preset        model.PresetID
+		persona       model.PersonaID
+		wantPersona   bool
+		wantNil       bool
+	}{
+		{
+			name:        "full-gentleman + gentleman includes persona",
+			preset:      model.PresetFullGentleman,
+			persona:     model.PersonaGentleman,
+			wantPersona: true,
+		},
+		{
+			name:        "full-gentleman + custom does not include persona",
+			preset:      model.PresetFullGentleman,
+			persona:     model.PersonaCustom,
+			wantPersona: false,
+		},
+		{
+			name:        "minimal + gentleman includes persona",
+			preset:      model.PresetMinimal,
+			persona:     model.PersonaGentleman,
+			wantPersona: true,
+		},
+		{
+			name:        "minimal + custom does not include persona",
+			preset:      model.PresetMinimal,
+			persona:     model.PersonaCustom,
+			wantPersona: false,
+		},
+		{
+			name:        "ecosystem-only + neutral includes persona",
+			preset:      model.PresetEcosystemOnly,
+			persona:     model.PersonaNeutral,
+			wantPersona: true,
+		},
+		{
+			name:        "ecosystem-only + custom does not include persona",
+			preset:      model.PresetEcosystemOnly,
+			persona:     model.PersonaCustom,
+			wantPersona: false,
+		},
+		{
+			name:    "custom preset returns nil regardless of persona (gentleman)",
+			preset:  model.PresetCustom,
+			persona: model.PersonaGentleman,
+			wantNil: true,
+		},
+		{
+			name:    "custom preset returns nil regardless of persona (custom)",
+			preset:  model.PresetCustom,
+			persona: model.PersonaCustom,
+			wantNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := componentsForPreset(tt.preset, tt.persona)
+
+			if tt.wantNil {
+				if got != nil {
+					t.Fatalf("componentsForPreset(%v, %v) = %v, want nil", tt.preset, tt.persona, got)
+				}
+				return
+			}
+
+			hasPersona := false
+			for _, c := range got {
+				if c == model.ComponentPersona {
+					hasPersona = true
+					break
+				}
+			}
+
+			if tt.wantPersona && !hasPersona {
+				t.Fatalf("componentsForPreset(%v, %v) missing ComponentPersona; got: %v", tt.preset, tt.persona, got)
+			}
+			if !tt.wantPersona && hasPersona {
+				t.Fatalf("componentsForPreset(%v, %v) should not include ComponentPersona; got: %v", tt.preset, tt.persona, got)
+			}
+		})
+	}
+}
+
+// TestPersonaScreenRecomputesComponentsWhenPresetAlreadySet verifies that changing
+// the persona on the Persona screen recomputes the component list when a non-custom
+// preset has already been selected.
+func TestPersonaScreenRecomputesComponentsWhenPresetAlreadySet(t *testing.T) {
+	// Start with a model that has already picked full-gentleman preset and
+	// gentleman persona (the default), then go back to Persona screen and pick custom.
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Screen = ScreenPersona
+	m.Selection.Preset = model.PresetFullGentleman
+	m.Selection.Persona = model.PersonaGentleman
+	m.Selection.Components = componentsForPreset(model.PresetFullGentleman, model.PersonaGentleman)
+
+	// Confirm that persona currently includes ComponentPersona.
+	hasPersonaBefore := false
+	for _, c := range m.Selection.Components {
+		if c == model.ComponentPersona {
+			hasPersonaBefore = true
+			break
+		}
+	}
+	if !hasPersonaBefore {
+		t.Fatal("setup: expected ComponentPersona in initial components")
+	}
+
+	// Move cursor to PersonaCustom (index 2) and confirm.
+	m.Cursor = 2 // PersonaOptions() = [Gentleman, Neutral, Custom]
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	state := updated.(Model)
+
+	if state.Selection.Persona != model.PersonaCustom {
+		t.Fatalf("Persona = %v, want %v", state.Selection.Persona, model.PersonaCustom)
+	}
+
+	// ComponentPersona must be removed after recompute.
+	for _, c := range state.Selection.Components {
+		if c == model.ComponentPersona {
+			t.Fatalf("ComponentPersona must not be in components after switching to PersonaCustom; got: %v", state.Selection.Components)
+		}
+	}
+}
+
+// TestPersonaScreenDoesNotRecomputeForCustomPreset verifies that changing persona
+// does NOT recompute (and wipe) the nil component list when preset is custom.
+func TestPersonaScreenDoesNotRecomputeForCustomPreset(t *testing.T) {
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Screen = ScreenPersona
+	m.Selection.Preset = model.PresetCustom
+	m.Selection.Persona = model.PersonaGentleman
+	m.Selection.Components = nil
+
+	m.Cursor = 0 // PersonaGentleman
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	state := updated.(Model)
+
+	// Components must remain nil for custom preset.
+	if state.Selection.Components != nil {
+		t.Fatalf("components should stay nil for custom preset; got: %v", state.Selection.Components)
 	}
 }

--- a/internal/tui/preset_flow_test.go
+++ b/internal/tui/preset_flow_test.go
@@ -223,7 +223,7 @@ func TestInstallNavigationRoundTrips(t *testing.T) {
 				m := NewModel(system.DetectionResult{}, "dev")
 				m.Screen = ScreenAgents
 				m.Selection.Agents = []model.AgentID{model.AgentPi}
-				m.Selection.Components = componentsForPreset(model.PresetFullGentleman)
+				m.Selection.Components = componentsForPreset(model.PresetFullGentleman, model.PersonaGentleman)
 				m.Cursor = len(screens.AgentOptions())
 				return m
 			},
@@ -404,7 +404,7 @@ func TestPiOnlyDependencyTreeBackRowReturnsToAgentSelection(t *testing.T) {
 	m := NewModel(system.DetectionResult{}, "dev")
 	m.Screen = ScreenAgents
 	m.Selection.Agents = []model.AgentID{model.AgentPi}
-	m.Selection.Components = componentsForPreset(model.PresetFullGentleman)
+	m.Selection.Components = componentsForPreset(model.PresetFullGentleman, model.PersonaGentleman)
 	m.Cursor = len(screens.AgentOptions())
 
 	state := applyFlowAction(t, m, flowAction{key: tea.KeyMsg{Type: tea.KeyEnter}})

--- a/internal/tui/screens/preset.go
+++ b/internal/tui/screens/preset.go
@@ -17,10 +17,17 @@ func PresetOptions() []model.PresetID {
 }
 
 var presetDescriptions = map[model.PresetID]string{
-	model.PresetFullGentleman: "Everything: memory, SDD, skills, docs, persona & security",
-	model.PresetEcosystemOnly: "Core tools only: memory, SDD, skills & docs (no persona/security)",
-	model.PresetMinimal:       "Just Engram persistent memory",
+	model.PresetMinimal:       "Just Engram persistent memory across sessions",
+	model.PresetEcosystemOnly: "Memory + SDD + skills + docs + GGA",
+	model.PresetFullGentleman: "Dev Stack + security gates, theme, and logo",
 	model.PresetCustom:        "Choose components and skills manually; keep existing persona/settings unmanaged",
+}
+
+var presetLabels = map[model.PresetID]string{
+	model.PresetMinimal:       "Memory Only",
+	model.PresetEcosystemOnly: "Dev Stack",
+	model.PresetFullGentleman: "Dev Stack + Polish",
+	model.PresetCustom:        "Custom",
 }
 
 func RenderPreset(selected model.PresetID, cursor int) string {
@@ -32,7 +39,7 @@ func RenderPreset(selected model.PresetID, cursor int) string {
 	for idx, preset := range PresetOptions() {
 		isSelected := preset == selected
 		focused := idx == cursor
-		b.WriteString(renderRadio(string(preset), isSelected, focused))
+		b.WriteString(renderRadio(presetLabels[preset], isSelected, focused))
 		b.WriteString(styles.SubtextStyle.Render("    "+presetDescriptions[preset]) + "\n")
 	}
 

--- a/internal/tui/testdata/preset-minimal-no-opencode-next.golden
+++ b/internal/tui/testdata/preset-minimal-no-opencode-next.golden
@@ -1,7 +1,9 @@
 Install Plan
 
 Components to install
-  1. engram included
+  1. persona included
+     Gentleman, neutral or custom behavior
+  2. engram included
      Persistent cross-session memory
 
 ▸ Continue


### PR DESCRIPTION
## Linked Issue

Closes #672

## PR Type

- [x] \`type:bug\`

## Summary

Follow-up to #671. Six E2E tests at \`e2e/e2e_test.sh\` invoked \`--preset minimal --persona neutral\` to assert "minimal install has no persona side effect". That worked before #671 because \`PresetMinimal\`'s component list excluded \`ComponentPersona\` regardless of which persona the user picked. After the decouple, \`--persona neutral\` correctly installs the neutral persona — so those negative assertions started failing on main.

This PR switches those 6 invocations from \`--persona neutral\` to \`--persona custom\` to preserve the original test intent: skip persona installation. It also adds two new tests that explicitly cover the decouple semantics.

## Changes

| File | Change |
|------|--------|
| \`e2e/e2e_test.sh\` | 6× \`--persona neutral\` → \`--persona custom\` for minimal preset tests; new \`test_preset_minimal_with_default_persona_includes_persona\` and \`test_preset_full_with_custom_persona_excludes_persona\` |

## Test Plan

- [x] \`go test ./...\` passes (no Go code changed)
- [x] E2E test intents preserved

## Contributor Checklist

- [x] Linked to approved issue (#672 has \`status:approved\`)
- [x] Under 400 changed lines
- [x] Conventional Commits format
- [x] No Co-Authored-By trailers