### PR TITLE
fix(skill-registry): normalize CRLF line endings before parsing frontmatter

### DIFF
--- a/internal/skillregistry/registry.go
+++ b/internal/skillregistry/registry.go
@@ -280,6 +280,8 @@ func uniqueExistingDirs(dirs []string) []string {
 }
 
 func parseFrontmatter(source string) (name, description, body string) {
+	source = strings.ReplaceAll(source, "\r\n", "\n")
+	source = strings.ReplaceAll(source, "\r", "\n")
 	if !strings.HasPrefix(source, "---\n") {
 		return "", "", source
 	}

--- a/internal/skillregistry/registry_test.go
+++ b/internal/skillregistry/registry_test.go
@@ -351,6 +351,51 @@ name: go-testing
 	}
 }
 
+func TestParseFrontmatterHandlesCRLF(t *testing.T) {
+	cases := []struct {
+		name     string
+		source   string
+		wantName string
+		wantDesc string
+	}{
+		{
+			name:     "LF baseline",
+			source:   "---\nname: demo\ndescription: ok\n---\n\nBody.\n",
+			wantName: "demo",
+			wantDesc: "ok",
+		},
+		{
+			name:     "CRLF Windows",
+			source:   "---\r\nname: demo\r\ndescription: ok\r\n---\r\n\r\nBody.\r\n",
+			wantName: "demo",
+			wantDesc: "ok",
+		},
+		{
+			name:     "bare CR (legacy Mac)",
+			source:   "---\rname: demo\rdescription: ok\r---\r\rBody.\r",
+			wantName: "demo",
+			wantDesc: "ok",
+		},
+		{
+			name:     "mixed CRLF + LF",
+			source:   "---\r\nname: demo\ndescription: ok\r\n---\n",
+			wantName: "demo",
+			wantDesc: "ok",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotName, gotDesc, _ := parseFrontmatter(tc.source)
+			if gotName != tc.wantName {
+				t.Errorf("name = %q, want %q", gotName, tc.wantName)
+			}
+			if gotDesc != tc.wantDesc {
+				t.Errorf("description = %q, want %q", gotDesc, tc.wantDesc)
+			}
+		})
+	}
+}
+
 func writeSkill(t *testing.T, path, content string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {


### PR DESCRIPTION
## Linked Issue

Closes #678

## PR Type

- [x] `type:bug`

## Summary

`parseFrontmatter` silently failed on SKILL.md files with CRLF line endings — the YAML chunk was either delimited incorrectly (`---\r` not matching `---`) or values were read with trailing `\r`. On Windows with `core.autocrlf=true` (Git for Windows default), every SKILL.md became an empty entry in the generated registry: `name` fell back to the directory name and `description` was rendered as `—`.

Normalizing line endings (`\r\n` → `\n`, bare `\r` → `\n`) at the top of `parseFrontmatter` fixes both cases. The rest of the function already operates on LF-only content.

## Changes

| File | Change |
|------|--------|
| `internal/skillregistry/registry.go` | Normalize CRLF/CR → LF at the top of `parseFrontmatter` |
| `internal/skillregistry/registry_test.go` | Table-driven coverage: LF / CRLF / bare CR / mixed |

## Test Plan

- [x] \`go test ./...\` passes
- [x] \`go vet ./...\` clean
- [x] \`go build\` clean

## Contributor Checklist

- [x] Linked to approved issue (#678)
- [x] Under 400 changed lines
- [x] Conventional Commits format
- [x] No Co-Authored-By trailers