### PR TITLE
fix(skills/comment-writer): remove hardcoded Rioplatense, defer regional tone to persona

### DIFF
--- a/internal/assets/skills/comment-writer/SKILL.md
+++ b/internal/assets/skills/comment-writer/SKILL.md
@@ -27,7 +27,7 @@ Use it for:
 | Keep it short | Prefer 1 to 3 short paragraphs or a tight bullet list. |
 | Explain why | Give the technical reason when asking for a change. |
 | Avoid pile-ons | Comment on the highest-value issue, not every tiny preference. |
-| Match thread language | Write in the thread/user language. If writing in Spanish, use Rioplatense Spanish/voseo: `podés`, `tenés`, `fijate`, `dale`. |
+| Match thread language | Write in the same language the thread uses. For regional tone and style, defer to the active persona — do not inject regional expressions (e.g. voseo) on your own. |
 | No em dashes | Use commas, periods, or parentheses instead. |
 
 ## Comment Formula
@@ -45,25 +45,25 @@ Use it for:
 ### Request change
 
 ```markdown
-Buenísimo el enfoque. Acá separaría este cambio en otro commit porque mezcla la validación con el wiring de UI.
+Good approach overall. I'd split this into a separate commit because it mixes validation logic with UI wiring.
 
-Eso le baja carga al reviewer y hace que el rollback sea más claro si falla la integración.
+That keeps the reviewer's focus narrower and makes rollback cleaner if the integration fails.
 ```
 
 ### Approve with a note
 
 ```markdown
-Está bien encaminado y el scope se entiende rápido.
+Approved. The scope is clear and the change is well-contained.
 
-Dejo aprobado. Para el próximo PR, agregá el link al anterior y al siguiente así la cadena queda navegable.
+For the next PR, add links to the previous and following PRs so the chain stays navigable.
 ```
 
 ### Ask for split
 
 ```markdown
-Este PR supera el presupuesto de 400 líneas cambiadas, así que necesitamos dividirlo o justificar `size:exception`.
+This PR exceeds the 400-line budget, so we need to split it or justify `size:exception`.
 
-Mi sugerencia: primero foundation + tests, después integración, después docs. Así cada review tiene inicio y fin claros.
+Suggested order: foundation + tests first, then integration, then docs. That gives each review a clear start and end.
 ```
 
 ## Commands


### PR DESCRIPTION
## Linked Issue

Closes #674

## PR Type

- [x] `type:bug`

## Summary

The `comment-writer` skill at `internal/assets/skills/comment-writer/SKILL.md` previously hardcoded a "If writing in Spanish, use Rioplatense Spanish (voseo: podés, tenés, fijate, dale)" rule and shipped all examples in voseo. That contradicted the persona contract (`R-CONFIG-07`: regional expressions belong to the Gentleman persona only) and bypassed the user's `--persona neutral` choice.

This PR makes the skill language-neutral: it now instructs the agent to match the thread's language and defer regional tone to the active persona, with examples that don't lean on voseo. Users who picked `--persona gentleman` still get Rioplatense via the persona itself; users who picked `--persona neutral` are no longer pushed into voseo by this skill.

## Changes

| File | Change |
|------|--------|
| `internal/assets/skills/comment-writer/SKILL.md` | Remove "use Rioplatense" rule; replace voseo examples; add "defer regional tone to persona" rule |

## Test Plan

- [x] \`go test ./...\` passes
- [x] \`go vet ./...\` clean
- [x] \`go build\` clean

## Contributor Checklist

- [x] Linked to approved issue (#674)
- [x] Under 400 changed lines (14 LOC)
- [x] Conventional Commits format
- [x] No Co-Authored-By trailers