### PR TITLE
fix(tui): show current Claude model preset in picker instead of defaulting to balanced

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1441,7 +1441,7 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 		switch m.Cursor {
 		case 0: // Configure Claude models
 			m.ModelConfigMode = true
-			m.ClaudeModelPicker = screens.NewClaudeModelPickerState()
+			m.ClaudeModelPicker = screens.NewClaudeModelPickerStateFromAssignments(m.Selection.ClaudeModelAssignments)
 			m.setScreen(ScreenClaudeModelPicker)
 		case 1: // Configure OpenCode models
 			m.ModelConfigMode = true
@@ -1514,7 +1514,7 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 			m.Selection.Preset = options[m.Cursor]
 			m.Selection.Components = componentsForPreset(options[m.Cursor], m.Selection.Persona)
 			if m.shouldShowClaudeModelPickerScreen() {
-				m.ClaudeModelPicker = screens.NewClaudeModelPickerState()
+				m.ClaudeModelPicker = screens.NewClaudeModelPickerStateFromAssignments(m.Selection.ClaudeModelAssignments)
 				m.setScreen(ScreenClaudeModelPicker)
 				return m, nil
 			}
@@ -1778,7 +1778,7 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 				m.buildDependencyPlan()
 				// Show model picker screens if needed (components are now set).
 				if m.shouldShowClaudeModelPickerScreen() {
-					m.ClaudeModelPicker = screens.NewClaudeModelPickerState()
+					m.ClaudeModelPicker = screens.NewClaudeModelPickerStateFromAssignments(m.Selection.ClaudeModelAssignments)
 					m.setScreen(ScreenClaudeModelPicker)
 					return m, nil
 				}

--- a/internal/tui/screens/claude_model_picker.go
+++ b/internal/tui/screens/claude_model_picker.go
@@ -90,6 +90,52 @@ func NewClaudeModelPickerState() ClaudeModelPickerState {
 	}
 }
 
+// NewClaudeModelPickerStateFromAssignments returns the picker state initialized
+// from previously persisted Claude model assignments. If the assignments match
+// a known preset (Balanced/Performance/Economy), that preset is preselected.
+// Otherwise the picker opens in Custom mode preserving the user's exact assignments.
+// When assignments is empty or nil, it falls back to the balanced default.
+func NewClaudeModelPickerStateFromAssignments(assignments map[string]model.ClaudeModelAlias) ClaudeModelPickerState {
+	if len(assignments) == 0 {
+		return NewClaudeModelPickerState()
+	}
+	for preset, constructor := range presetConstructors {
+		if assignmentsEqual(constructor(), assignments) {
+			return ClaudeModelPickerState{
+				Preset:            preset,
+				CustomAssignments: copyAssignments(assignments),
+				InCustomMode:      false,
+			}
+		}
+	}
+	// Doesn't match any built-in preset → custom.
+	return ClaudeModelPickerState{
+		Preset:            ClaudePresetCustom,
+		CustomAssignments: copyAssignments(assignments),
+		InCustomMode:      false,
+	}
+}
+
+func assignmentsEqual(a, b map[string]model.ClaudeModelAlias) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if b[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
+func copyAssignments(m map[string]model.ClaudeModelAlias) map[string]model.ClaudeModelAlias {
+	out := make(map[string]model.ClaudeModelAlias, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
+}
+
 // presetConstructors maps preset IDs to their constructor functions.
 var presetConstructors = map[ClaudeModelPreset]func() map[string]model.ClaudeModelAlias{
 	ClaudePresetBalanced:    model.ClaudeModelPresetBalanced,
@@ -208,6 +254,8 @@ func renderPresetList(state ClaudeModelPickerState, cursor int) string {
 	var b strings.Builder
 
 	b.WriteString(styles.TitleStyle.Render("Claude Model Assignments"))
+	b.WriteString("\n")
+	b.WriteString(styles.SubtextStyle.Render("Current: " + string(state.Preset)))
 	b.WriteString("\n\n")
 	b.WriteString(styles.SubtextStyle.Render("Choose how Claude models are assigned to each SDD phase:"))
 	b.WriteString("\n\n")

--- a/internal/tui/screens/claude_model_picker_test.go
+++ b/internal/tui/screens/claude_model_picker_test.go
@@ -1,0 +1,113 @@
+package screens
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/internal/model"
+)
+
+func TestNewClaudeModelPickerStateFromAssignments(t *testing.T) {
+	cases := []struct {
+		name        string
+		assignments map[string]model.ClaudeModelAlias
+		wantPreset  ClaudeModelPreset
+	}{
+		{
+			name:        "nil → balanced default",
+			assignments: nil,
+			wantPreset:  ClaudePresetBalanced,
+		},
+		{
+			name:        "empty → balanced default",
+			assignments: map[string]model.ClaudeModelAlias{},
+			wantPreset:  ClaudePresetBalanced,
+		},
+		{
+			name:        "balanced match",
+			assignments: model.ClaudeModelPresetBalanced(),
+			wantPreset:  ClaudePresetBalanced,
+		},
+		{
+			name:        "performance match",
+			assignments: model.ClaudeModelPresetPerformance(),
+			wantPreset:  ClaudePresetPerformance,
+		},
+		{
+			name:        "economy match",
+			assignments: model.ClaudeModelPresetEconomy(),
+			wantPreset:  ClaudePresetEconomy,
+		},
+		{
+			name:        "custom assignment",
+			assignments: map[string]model.ClaudeModelAlias{"sdd-apply": model.ClaudeModelHaiku},
+			wantPreset:  ClaudePresetCustom,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			state := NewClaudeModelPickerStateFromAssignments(tc.assignments)
+			if state.Preset != tc.wantPreset {
+				t.Errorf("Preset = %q, want %q", state.Preset, tc.wantPreset)
+			}
+			if state.InCustomMode {
+				t.Error("InCustomMode should be false on initial state")
+			}
+			if state.CustomAssignments == nil {
+				t.Error("CustomAssignments should not be nil")
+			}
+		})
+	}
+}
+
+func TestNewClaudeModelPickerStateFromAssignments_CopiesMap(t *testing.T) {
+	original := model.ClaudeModelPresetBalanced()
+	state := NewClaudeModelPickerStateFromAssignments(original)
+
+	// Mutating original should not affect state.
+	original["sdd-apply"] = model.ClaudeModelOpus
+
+	if state.CustomAssignments["sdd-apply"] == model.ClaudeModelOpus {
+		t.Error("CustomAssignments shares memory with the input map — expected a defensive copy")
+	}
+}
+
+func TestRenderClaudeModelPicker_ShowsCurrentPreset(t *testing.T) {
+	cases := []struct {
+		name        string
+		assignments map[string]model.ClaudeModelAlias
+		wantLabel   string
+	}{
+		{
+			name:        "balanced default shows balanced",
+			assignments: nil,
+			wantLabel:   "Current: balanced",
+		},
+		{
+			name:        "performance preset shows performance",
+			assignments: model.ClaudeModelPresetPerformance(),
+			wantLabel:   "Current: performance",
+		},
+		{
+			name:        "economy preset shows economy",
+			assignments: model.ClaudeModelPresetEconomy(),
+			wantLabel:   "Current: economy",
+		},
+		{
+			name:        "custom assignments shows custom",
+			assignments: map[string]model.ClaudeModelAlias{"sdd-apply": model.ClaudeModelHaiku},
+			wantLabel:   "Current: custom",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			state := NewClaudeModelPickerStateFromAssignments(tc.assignments)
+			out := RenderClaudeModelPicker(state, 0)
+			if !strings.Contains(out, tc.wantLabel) {
+				t.Errorf("expected %q in render output, got:\n%s", tc.wantLabel, out)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Linked Issue

Closes #675

## PR Type

- [x] `type:bug`

## Summary

The TUI "Configure Claude models" picker always opened with `balanced` selected, regardless of the user's persisted configuration in `~/.gentle-ai/state.json`. Users with custom assignments or non-balanced presets had no way to see at a glance what was active — they had to inspect the state file by hand.

This PR makes the picker initialize from persisted state. When the saved assignments match a known preset (Balanced/Performance/Economy), that preset is preselected. When they don't match any preset, the picker opens with Custom selected and preserves the exact assignments. A "Current: <preset>" hint is added below the title so the active preset is visible immediately.

## Changes

| File | Change |
|------|--------|
| `internal/tui/screens/claude_model_picker.go` | New `NewClaudeModelPickerStateFromAssignments` constructor + preset detection helpers + "Current:" render hint |
| `internal/tui/model.go` | Wire 3 picker entry points to pass `m.Selection.ClaudeModelAssignments` |
| `internal/tui/screens/claude_model_picker_test.go` | Table-driven coverage: nil/empty/balanced/performance/economy/custom + map copy safety + render hint |

## Test Plan

- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [x] `go build` clean

## Contributor Checklist

- [x] Linked to approved issue (#675)
- [x] Under 400 changed lines (164 LOC)
- [x] Conventional Commits format
- [x] No Co-Authored-By trailers