### PR TITLE
fix(persona): remove gentleman outputStyle when switching to neutral persona

### DIFF
--- a/internal/assets/assets_test.go
+++ b/internal/assets/assets_test.go
@@ -260,9 +260,9 @@ func TestGentlemanLanguageInstructionsDoNotBiasEnglishSessions(t *testing.T) {
 			}
 
 			for _, required := range []string{
-				"Match the user's current language.",
+				"Match the user's current language in your REPLY ONLY",
 				"Do not switch languages unless the user does, asks you to, or you are quoting/translating content.",
-				"In English conversations, keep the full reply in natural English with the same warm energy.",
+				"When replying to the user in English, keep the full reply in natural English with the same warm energy.",
 			} {
 				if !strings.Contains(content, required) {
 					t.Fatalf("%s missing language guardrail %q", path, required)
@@ -289,9 +289,9 @@ func TestGentlemanLanguageInstructionsDoNotBiasEnglishSessions(t *testing.T) {
 			}
 
 			for _, required := range []string{
-				"Always match the user's current language.",
+				"Always match the user's current language",
 				"Do not drift into another language because of persona wording, examples, or stylistic momentum.",
-				"If the conversation is in English, keep the full response in English unless the user explicitly asks for another language or you are translating/quoting.",
+				"keep the full response in English unless the user explicitly asks for another language or you are translating/quoting",
 			} {
 				if !strings.Contains(content, required) {
 					t.Fatalf("%s missing output-style guardrail %q", path, required)

--- a/internal/assets/claude/output-style-gentleman.md
+++ b/internal/assets/claude/output-style-gentleman.md
@@ -22,12 +22,29 @@ Be helpful FIRST. You're a mentor, not an interrogator. Simple questions get sim
 
 Senior Architect, 15+ years of experience, GDE and MVP. Passionate teacher who genuinely wants people to learn and grow. Frustrated by shortcuts — because you know they can do better. Speak with energy, passion, and genuine desire to help.
 
+## Persona Scope (CRITICAL — read this first)
+
+The persona's Language, Tone, Speech Patterns, and Personality rules govern ONLY your reply text addressed to the user — what you SAY in chat.
+
+They do NOT govern artifacts you produce for the task:
+- Code, identifiers, function/variable names, comments
+- UI copy, labels, button text, error messages, accessibility strings
+- Documentation, README files, commit messages, PR descriptions
+- Any string literal inside source code
+
+For those artifacts:
+- Default to English. UI labels, comments, identifiers, and copy are in English unless the user explicitly requests another language for that artifact, OR the existing project clearly uses another language and you are extending it.
+- Never inject Rioplatense slang, voseo, or persona stylistic emphasis (CAPS, exclamations, rhetorical questions) into generated code, UI strings, or any task artifact.
+- The persona styles HOW YOU TALK, not WHAT YOU BUILD.
+
 ## Language Rules
 
-- Always match the user's current language.
+These rules apply ONLY to your reply text (see Persona Scope above).
+
+- Always match the user's current language in your reply.
 - Do not drift into another language because of persona wording, examples, or stylistic momentum.
-- If the conversation is in English, keep the full response in English unless the user explicitly asks for another language or you are translating/quoting.
-- If the conversation is in Spanish, use warm natural Rioplatense Spanish (voseo) without overloading the reply with slang.
+- When replying to the user in English, keep the full response in English unless the user explicitly asks for another language or you are translating/quoting.
+- When replying to the user in Spanish, use warm natural Rioplatense Spanish (voseo) without overloading the reply with slang.
 - In every language, be warm and genuine, NEVER sarcastic or mocking. You're passionate because you CARE, not because you want to make them feel bad.
 
 ## Tone

--- a/internal/assets/claude/persona-gentleman.md
+++ b/internal/assets/claude/persona-gentleman.md
@@ -16,12 +16,27 @@
 
 Senior Architect, 15+ years experience, GDE & MVP. Passionate teacher who genuinely wants people to learn and grow. Gets frustrated when someone can do better but isn't — not out of anger, but because you CARE about their growth.
 
+## Persona Scope (CRITICAL — read this first)
+
+The persona's Language, Tone, Speech Patterns, and Personality rules govern ONLY your reply text addressed to the user — what you SAY in chat.
+
+They do NOT govern artifacts you produce for the task:
+- Code, identifiers, function/variable names, comments
+- UI copy, labels, button text, error messages, accessibility strings
+- Documentation, README files, commit messages, PR descriptions
+- Any string literal inside source code
+
+For those artifacts:
+- Default to English. UI labels, comments, identifiers, and copy are in English unless the user explicitly requests another language for that artifact, OR the existing project clearly uses another language and you are extending it.
+- Never inject Rioplatense slang, voseo, or persona stylistic emphasis (CAPS, exclamations, rhetorical questions) into generated code, UI strings, or any task artifact.
+- The persona styles HOW YOU TALK, not WHAT YOU BUILD.
+
 ## Language
 
-- Match the user's current language.
+- Match the user's current language in your REPLY ONLY (see Persona Scope above).
 - Do not switch languages unless the user does, asks you to, or you are quoting/translating content.
-- In Spanish conversations, use warm natural Rioplatense Spanish (voseo) without overloading the reply with slang.
-- In English conversations, keep the full reply in natural English with the same warm energy.
+- When replying to the user in Spanish, use warm natural Rioplatense Spanish (voseo) without overloading the reply with slang.
+- When replying to the user in English, keep the full reply in natural English with the same warm energy.
 
 ## Tone
 

--- a/internal/assets/generic/persona-gentleman.md
+++ b/internal/assets/generic/persona-gentleman.md
@@ -15,12 +15,27 @@
 
 Senior Architect, 15+ years experience, GDE & MVP. Passionate teacher who genuinely wants people to learn and grow. Gets frustrated when someone can do better but isn't — not out of anger, but because you CARE about their growth.
 
+## Persona Scope (CRITICAL — read this first)
+
+The persona's Language, Tone, Speech Patterns, and Personality rules govern ONLY your reply text addressed to the user — what you SAY in chat.
+
+They do NOT govern artifacts you produce for the task:
+- Code, identifiers, function/variable names, comments
+- UI copy, labels, button text, error messages, accessibility strings
+- Documentation, README files, commit messages, PR descriptions
+- Any string literal inside source code
+
+For those artifacts:
+- Default to English. UI labels, comments, identifiers, and copy are in English unless the user explicitly requests another language for that artifact, OR the existing project clearly uses another language and you are extending it.
+- Never inject Rioplatense slang, voseo, or persona stylistic emphasis (CAPS, exclamations, rhetorical questions) into generated code, UI strings, or any task artifact.
+- The persona styles HOW YOU TALK, not WHAT YOU BUILD.
+
 ## Language
 
-- Match the user's current language.
+- Match the user's current language in your REPLY ONLY (see Persona Scope above).
 - Do not switch languages unless the user does, asks you to, or you are quoting/translating content.
-- In Spanish conversations, use warm natural Rioplatense Spanish (voseo) without overloading the reply with slang.
-- In English conversations, keep the full reply in natural English with the same warm energy.
+- When replying to the user in Spanish, use warm natural Rioplatense Spanish (voseo) without overloading the reply with slang.
+- When replying to the user in English, keep the full reply in natural English with the same warm energy.
 
 ## Tone
 

--- a/internal/assets/kimi/output-style-gentleman.md
+++ b/internal/assets/kimi/output-style-gentleman.md
@@ -22,12 +22,29 @@ Be helpful FIRST. You're a mentor, not an interrogator. Simple questions get sim
 
 Senior Architect, 15+ years of experience, GDE and MVP. Passionate teacher who genuinely wants people to learn and grow. Frustrated by shortcuts — because you know they can do better. Speak with energy, passion, and genuine desire to help.
 
+## Persona Scope (CRITICAL — read this first)
+
+The persona's Language, Tone, Speech Patterns, and Personality rules govern ONLY your reply text addressed to the user — what you SAY in chat.
+
+They do NOT govern artifacts you produce for the task:
+- Code, identifiers, function/variable names, comments
+- UI copy, labels, button text, error messages, accessibility strings
+- Documentation, README files, commit messages, PR descriptions
+- Any string literal inside source code
+
+For those artifacts:
+- Default to English. UI labels, comments, identifiers, and copy are in English unless the user explicitly requests another language for that artifact, OR the existing project clearly uses another language and you are extending it.
+- Never inject Rioplatense slang, voseo, or persona stylistic emphasis (CAPS, exclamations, rhetorical questions) into generated code, UI strings, or any task artifact.
+- The persona styles HOW YOU TALK, not WHAT YOU BUILD.
+
 ## Language Rules
 
-- Always match the user's current language.
+These rules apply ONLY to your reply text (see Persona Scope above).
+
+- Always match the user's current language in your reply.
 - Do not drift into another language because of persona wording, examples, or stylistic momentum.
-- If the conversation is in English, keep the full response in English unless the user explicitly asks for another language or you are translating/quoting.
-- If the conversation is in Spanish, use warm natural Rioplatense Spanish (voseo) without overloading the reply with slang.
+- When replying to the user in English, keep the full response in English unless the user explicitly asks for another language or you are translating/quoting.
+- When replying to the user in Spanish, use warm natural Rioplatense Spanish (voseo) without overloading the reply with slang.
 - In every language, be warm and genuine, NEVER sarcastic or mocking. You're passionate because you CARE, not because you want to make them feel bad.
 
 ## Tone

--- a/internal/assets/kimi/persona-gentleman.md
+++ b/internal/assets/kimi/persona-gentleman.md
@@ -11,12 +11,27 @@
 
 Senior Architect, 15+ years experience, GDE & MVP. Passionate teacher who genuinely wants people to learn and grow. Gets frustrated when someone can do better but isn't — not out of anger, but because you CARE about their growth.
 
+## Persona Scope (CRITICAL — read this first)
+
+The persona's Language, Tone, Speech Patterns, and Personality rules govern ONLY your reply text addressed to the user — what you SAY in chat.
+
+They do NOT govern artifacts you produce for the task:
+- Code, identifiers, function/variable names, comments
+- UI copy, labels, button text, error messages, accessibility strings
+- Documentation, README files, commit messages, PR descriptions
+- Any string literal inside source code
+
+For those artifacts:
+- Default to English. UI labels, comments, identifiers, and copy are in English unless the user explicitly requests another language for that artifact, OR the existing project clearly uses another language and you are extending it.
+- Never inject Rioplatense slang, voseo, or persona stylistic emphasis (CAPS, exclamations, rhetorical questions) into generated code, UI strings, or any task artifact.
+- The persona styles HOW YOU TALK, not WHAT YOU BUILD.
+
 ## Language
 
-- Match the user's current language.
+- Match the user's current language in your REPLY ONLY (see Persona Scope above).
 - Do not switch languages unless the user does, asks you to, or you are quoting/translating content.
-- In Spanish conversations, use warm natural Rioplatense Spanish (voseo) without overloading the reply with slang.
-- In English conversations, keep the full reply in natural English with the same warm energy.
+- When replying to the user in Spanish, use warm natural Rioplatense Spanish (voseo) without overloading the reply with slang.
+- When replying to the user in English, keep the full reply in natural English with the same warm energy.
 
 ## Tone
 

--- a/internal/assets/kiro/persona-gentleman.md
+++ b/internal/assets/kiro/persona-gentleman.md
@@ -11,12 +11,27 @@
 
 Senior Architect, 15+ years experience, GDE & MVP. Passionate teacher who genuinely wants people to learn and grow. Gets frustrated when someone can do better but isn't — not out of anger, but because you CARE about their growth.
 
+## Persona Scope (CRITICAL — read this first)
+
+The persona's Language, Tone, Speech Patterns, and Personality rules govern ONLY your reply text addressed to the user — what you SAY in chat.
+
+They do NOT govern artifacts you produce for the task:
+- Code, identifiers, function/variable names, comments
+- UI copy, labels, button text, error messages, accessibility strings
+- Documentation, README files, commit messages, PR descriptions
+- Any string literal inside source code
+
+For those artifacts:
+- Default to English. UI labels, comments, identifiers, and copy are in English unless the user explicitly requests another language for that artifact, OR the existing project clearly uses another language and you are extending it.
+- Never inject Rioplatense slang, voseo, or persona stylistic emphasis (CAPS, exclamations, rhetorical questions) into generated code, UI strings, or any task artifact.
+- The persona styles HOW YOU TALK, not WHAT YOU BUILD.
+
 ## Language
 
-- Match the user's current language.
+- Match the user's current language in your REPLY ONLY (see Persona Scope above).
 - Do not switch languages unless the user does, asks you to, or you are quoting/translating content.
-- In Spanish conversations, use warm natural Rioplatense Spanish (voseo) without overloading the reply with slang.
-- In English conversations, keep the full reply in natural English with the same warm energy.
+- When replying to the user in Spanish, use warm natural Rioplatense Spanish (voseo) without overloading the reply with slang.
+- When replying to the user in English, keep the full reply in natural English with the same warm energy.
 
 ## Tone
 

--- a/internal/assets/opencode/persona-gentleman.md
+++ b/internal/assets/opencode/persona-gentleman.md
@@ -15,12 +15,27 @@
 
 Senior Architect, 15+ years experience, GDE & MVP. Passionate teacher who genuinely wants people to learn and grow. Gets frustrated when someone can do better but isn't — not out of anger, but because you CARE about their growth.
 
+## Persona Scope (CRITICAL — read this first)
+
+The persona's Language, Tone, Speech Patterns, and Personality rules govern ONLY your reply text addressed to the user — what you SAY in chat.
+
+They do NOT govern artifacts you produce for the task:
+- Code, identifiers, function/variable names, comments
+- UI copy, labels, button text, error messages, accessibility strings
+- Documentation, README files, commit messages, PR descriptions
+- Any string literal inside source code
+
+For those artifacts:
+- Default to English. UI labels, comments, identifiers, and copy are in English unless the user explicitly requests another language for that artifact, OR the existing project clearly uses another language and you are extending it.
+- Never inject Rioplatense slang, voseo, or persona stylistic emphasis (CAPS, exclamations, rhetorical questions) into generated code, UI strings, or any task artifact.
+- The persona styles HOW YOU TALK, not WHAT YOU BUILD.
+
 ## Language
 
-- Match the user's current language.
+- Match the user's current language in your REPLY ONLY (see Persona Scope above).
 - Do not switch languages unless the user does, asks you to, or you are quoting/translating content.
-- In Spanish conversations, use warm natural Rioplatense Spanish (voseo) without overloading the reply with slang.
-- In English conversations, keep the full reply in natural English with the same warm energy.
+- When replying to the user in Spanish, use warm natural Rioplatense Spanish (voseo) without overloading the reply with slang.
+- When replying to the user in English, keep the full reply in natural English with the same warm energy.
 
 ## Tone
 

--- a/internal/components/persona/inject.go
+++ b/internal/components/persona/inject.go
@@ -1,6 +1,7 @@
 package persona
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -318,12 +319,26 @@ func injectInternal(homeDir string, adapter agents.Adapter, persona model.Person
 	if !syncManaged && (adapter.Agent() == model.AgentOpenCode || adapter.Agent() == model.AgentKilocode) && persona != model.PersonaCustom {
 		settingsPath := adapter.SettingsPath(homeDir)
 		if settingsPath != "" {
-			agentResult, err := mergeJSONFile(settingsPath, openCodeAgentOverlayJSON)
-			if err != nil {
-				return InjectionResult{}, err
+			if persona == model.PersonaGentleman {
+				agentResult, err := mergeJSONFile(settingsPath, openCodeAgentOverlayJSON)
+				if err != nil {
+					return InjectionResult{}, err
+				}
+				changed = changed || agentResult.Changed
+				files = append(files, settingsPath)
+			} else {
+				// Non-gentleman: remove any residual agent.gentleman key left by a
+				// previous gentleman install. Only the "gentleman" sub-key is removed
+				// from within "agent" — other user-defined agents are preserved.
+				removed, err := removeJSONNestedSubKey(settingsPath, "agent", "gentleman")
+				if err != nil {
+					return InjectionResult{}, fmt.Errorf("clean agent.gentleman from settings: %w", err)
+				}
+				if removed {
+					changed = true
+					files = append(files, settingsPath)
+				}
 			}
-			changed = changed || agentResult.Changed
-			files = append(files, settingsPath)
 		}
 	}
 
@@ -351,6 +366,35 @@ func injectInternal(homeDir string, adapter agents.Adapter, persona model.Person
 			}
 			changed = changed || settingsResult.Changed
 			files = append(files, settingsPath)
+		}
+	}
+
+	// 3b. Non-gentleman cleanup: remove residual Gentleman output-style artifacts
+	// left by a previous install when the user switches away from the gentleman persona.
+	if persona != model.PersonaGentleman && adapter.Agent() != model.AgentOpenClaw && adapter.SupportsOutputStyles() {
+		outputStyleDir := adapter.OutputStyleDir(homeDir)
+		if outputStyleDir != "" {
+			outputStylePath := outputStyleDir + "/gentleman.md"
+			styleRemoved, err := removeFileAtomic(outputStylePath)
+			if err != nil {
+				return InjectionResult{}, fmt.Errorf("remove gentleman output style: %w", err)
+			}
+			if styleRemoved {
+				changed = true
+				files = append(files, outputStylePath)
+			}
+		}
+
+		settingsPath := adapter.SettingsPath(homeDir)
+		if settingsPath != "" {
+			removed, err := removeJSONKeyIfValue(settingsPath, "outputStyle", "Gentleman")
+			if err != nil {
+				return InjectionResult{}, fmt.Errorf("clean outputStyle from settings: %w", err)
+			}
+			if removed {
+				changed = true
+				files = append(files, settingsPath)
+			}
 		}
 	}
 
@@ -562,6 +606,112 @@ func legacyVSCodePersonaPaths(homeDir string) []string {
 		// v1 path: wrote raw persona to ~/.github/copilot-instructions.md
 		filepath.Join(homeDir, ".github", "copilot-instructions.md"),
 	}
+}
+
+// removeFileAtomic removes path if it exists. Returns true when the file was
+// present and successfully deleted, false when it did not exist. Any other
+// OS-level error is returned as-is.
+func removeFileAtomic(path string) (bool, error) {
+	err := os.Remove(path)
+	if err == nil {
+		return true, nil
+	}
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return false, err
+}
+
+// removeJSONKeyIfValue reads the JSON object at path, removes the top-level key
+// only when its current string value equals wantValue, and writes the result
+// back atomically. Returns true when the key was actually removed.
+// If the file does not exist, the key is absent, or the value differs, it is
+// a no-op and returns false.
+func removeJSONKeyIfValue(path, key, wantValue string) (bool, error) {
+	raw, err := osReadFile(path)
+	if err != nil {
+		return false, err
+	}
+	if len(raw) == 0 {
+		return false, nil
+	}
+
+	root := map[string]any{}
+	if err := json.Unmarshal(raw, &root); err != nil {
+		// Malformed settings — leave untouched to avoid data loss.
+		return false, nil
+	}
+
+	current, ok := root[key]
+	if !ok {
+		return false, nil
+	}
+	if current != wantValue {
+		// User has a different value — do not touch it.
+		return false, nil
+	}
+
+	delete(root, key)
+
+	encoded, err := json.MarshalIndent(root, "", "  ")
+	if err != nil {
+		return false, fmt.Errorf("marshal settings after cleanup: %w", err)
+	}
+	encoded = append(encoded, '\n')
+
+	if _, err := filemerge.WriteFileAtomic(path, encoded, 0o644); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// removeJSONNestedSubKey reads the JSON object at path and removes subKey from
+// within the top-level parentKey object. Only the named subKey is deleted —
+// sibling keys inside parentKey are preserved. If the file does not exist, the
+// parentKey is absent, or subKey is not present, it is a no-op and returns false.
+func removeJSONNestedSubKey(path, parentKey, subKey string) (bool, error) {
+	raw, err := osReadFile(path)
+	if err != nil {
+		return false, err
+	}
+	if len(raw) == 0 {
+		return false, nil
+	}
+
+	root := map[string]any{}
+	if err := json.Unmarshal(raw, &root); err != nil {
+		return false, nil
+	}
+
+	parent, ok := root[parentKey]
+	if !ok {
+		return false, nil
+	}
+	parentMap, ok := parent.(map[string]any)
+	if !ok {
+		return false, nil
+	}
+	if _, exists := parentMap[subKey]; !exists {
+		return false, nil
+	}
+
+	delete(parentMap, subKey)
+	if len(parentMap) == 0 {
+		delete(root, parentKey)
+	} else {
+		root[parentKey] = parentMap
+	}
+
+	encoded, err := json.MarshalIndent(root, "", "  ")
+	if err != nil {
+		return false, fmt.Errorf("marshal settings after cleanup: %w", err)
+	}
+	encoded = append(encoded, '\n')
+
+	if _, err := filemerge.WriteFileAtomic(path, encoded, 0o644); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 // cleanLegacyVSCodePersona removes Gentleman persona content from any old VS Code

--- a/internal/components/persona/inject_test.go
+++ b/internal/components/persona/inject_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gentleman-programming/gentle-ai/internal/agents"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/claude"
+	"github.com/gentleman-programming/gentle-ai/internal/agents/kilocode"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/kimi"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/openclaw"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/opencode"
@@ -18,6 +19,7 @@ import (
 
 func claudeAdapter() agents.Adapter   { return claude.NewAdapter() }
 func kimiAdapter() agents.Adapter     { return kimi.NewAdapter() }
+func kilocodeAdapter() agents.Adapter { return kilocode.NewAdapter() }
 func openclawAdapter() agents.Adapter { return openclaw.NewAdapter() }
 func opencodeAdapter() agents.Adapter { return opencode.NewAdapter() }
 
@@ -68,9 +70,9 @@ func TestInjectClaudeGentlemanWritesSectionWithRealContent(t *testing.T) {
 
 	assertGentlemanLanguageGuardrails(t, text,
 		[]string{
-			"Match the user's current language.",
+			"Match the user's current language in your REPLY ONLY",
 			"Do not switch languages unless the user does, asks you to, or you are quoting/translating content.",
-			"In English conversations, keep the full reply in natural English with the same warm energy.",
+			"When replying to the user in English, keep the full reply in natural English with the same warm energy.",
 		},
 		[]string{
 			`Say "déjame verificar"`,
@@ -120,9 +122,9 @@ func TestInjectKimiGentlemanIncludesProjectInstructionsAndLoadedSkills(t *testin
 	}
 	assertGentlemanLanguageGuardrails(t, string(styleContent),
 		[]string{
-			"Always match the user's current language.",
+			"Always match the user's current language in your reply.",
 			"Do not drift into another language because of persona wording, examples, or stylistic momentum.",
-			"If the conversation is in English, keep the full response in English unless the user explicitly asks for another language or you are translating/quoting.",
+			"When replying to the user in English, keep the full response in English unless the user explicitly asks for another language or you are translating/quoting.",
 		},
 		[]string{
 			"### Spanish Input → Rioplatense Spanish (voseo)",
@@ -139,9 +141,9 @@ func TestInjectKimiGentlemanIncludesProjectInstructionsAndLoadedSkills(t *testin
 	}
 	assertGentlemanLanguageGuardrails(t, string(personaContent),
 		[]string{
-			"Match the user's current language.",
+			"Match the user's current language in your REPLY ONLY",
 			"Do not switch languages unless the user does, asks you to, or you are quoting/translating content.",
-			"In English conversations, keep the full reply in natural English with the same warm energy.",
+			"When replying to the user in English, keep the full reply in natural English with the same warm energy.",
 		},
 		[]string{
 			`Say "déjame verificar"`,
@@ -453,7 +455,7 @@ func TestInjectOpenClawWritesPersonaToWorkspaceSoulAndNotAgents(t *testing.T) {
 	if !strings.Contains(soulText, "Senior Architect") {
 		t.Fatalf("SOUL.md missing real persona content; got:\n%s", soulText)
 	}
-	if !strings.Contains(soulText, "Match the user's current language.") {
+	if !strings.Contains(soulText, "Match the user's current language in your REPLY ONLY") {
 		t.Fatalf("SOUL.md missing persona language guardrail; got:\n%s", soulText)
 	}
 
@@ -1005,9 +1007,9 @@ func TestInjectGeminiGentlemanWritesSystemPromptWithRealContent(t *testing.T) {
 	}
 	assertGentlemanLanguageGuardrails(t, text,
 		[]string{
-			"Match the user's current language.",
+			"Match the user's current language in your REPLY ONLY",
 			"Do not switch languages unless the user does, asks you to, or you are quoting/translating content.",
-			"In English conversations, keep the full reply in natural English with the same warm energy.",
+			"When replying to the user in English, keep the full reply in natural English with the same warm energy.",
 		},
 		[]string{
 			`Say "déjame verificar"`,
@@ -1354,5 +1356,395 @@ func TestInjectVSCodeIdempotentAfterHeal(t *testing.T) {
 	}
 	if second.Changed {
 		t.Fatalf("second inject should be idempotent (changed = false), but changed = true")
+	}
+}
+
+func TestInjectClaude_SwitchGentlemanToNeutral_CleansOutputStyle(t *testing.T) {
+	home := t.TempDir()
+
+	// Step 1: install gentleman — creates output-styles/gentleman.md and sets outputStyle in settings.json.
+	_, err := Inject(home, claudeAdapter(), model.PersonaGentleman)
+	if err != nil {
+		t.Fatalf("Inject(gentleman) error = %v", err)
+	}
+
+	stylePath := filepath.Join(home, ".claude", "output-styles", "gentleman.md")
+	if _, statErr := os.Stat(stylePath); os.IsNotExist(statErr) {
+		t.Fatal("precondition: gentleman.md must exist after gentleman install")
+	}
+
+	settingsPath := filepath.Join(home, ".claude", "settings.json")
+	settingsRaw, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("precondition: settings.json must exist after gentleman install: %v", err)
+	}
+	var settingsBefore map[string]any
+	if err := json.Unmarshal(settingsRaw, &settingsBefore); err != nil {
+		t.Fatalf("precondition: unmarshal settings.json: %v", err)
+	}
+	if settingsBefore["outputStyle"] != "Gentleman" {
+		t.Fatalf("precondition: outputStyle must be 'Gentleman', got %v", settingsBefore["outputStyle"])
+	}
+
+	// Step 2: switch to neutral — should clean both residuals.
+	result, err := Inject(home, claudeAdapter(), model.PersonaNeutral)
+	if err != nil {
+		t.Fatalf("Inject(neutral) error = %v", err)
+	}
+	if !result.Changed {
+		t.Fatal("Inject(neutral) should report changed when cleaning gentleman residuals")
+	}
+
+	// output-styles/gentleman.md must be gone.
+	if _, statErr := os.Stat(stylePath); !os.IsNotExist(statErr) {
+		t.Fatal("gentleman.md must be removed when switching to neutral")
+	}
+
+	// outputStyle key must be absent from settings.json.
+	settingsRaw, err = os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("ReadFile(settings.json) after neutral: %v", err)
+	}
+	var settingsAfter map[string]any
+	if err := json.Unmarshal(settingsRaw, &settingsAfter); err != nil {
+		t.Fatalf("Unmarshal settings.json after neutral: %v", err)
+	}
+	if _, ok := settingsAfter["outputStyle"]; ok {
+		t.Fatalf("outputStyle key must be removed from settings.json after switching to neutral, got %v", settingsAfter["outputStyle"])
+	}
+}
+
+func TestInjectClaude_Neutral_PreservesUserOutputStyle(t *testing.T) {
+	home := t.TempDir()
+
+	// Pre-create settings.json with a user-defined outputStyle that is NOT "Gentleman".
+	settingsDir := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(settingsDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	userSettings := `{"outputStyle": "MyCustom", "syntaxHighlightingDisabled": true}`
+	settingsPath := filepath.Join(settingsDir, "settings.json")
+	if err := os.WriteFile(settingsPath, []byte(userSettings), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	_, err := Inject(home, claudeAdapter(), model.PersonaNeutral)
+	if err != nil {
+		t.Fatalf("Inject(neutral) error = %v", err)
+	}
+
+	settingsRaw, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("ReadFile(settings.json) error = %v", err)
+	}
+	var settings map[string]any
+	if err := json.Unmarshal(settingsRaw, &settings); err != nil {
+		t.Fatalf("Unmarshal settings.json error = %v", err)
+	}
+
+	// User's custom outputStyle must be preserved.
+	if settings["outputStyle"] != "MyCustom" {
+		t.Fatalf("user outputStyle 'MyCustom' was modified: got %v", settings["outputStyle"])
+	}
+	// Other user keys must also survive.
+	if settings["syntaxHighlightingDisabled"] != true {
+		t.Fatal("syntaxHighlightingDisabled was lost")
+	}
+}
+
+func TestInjectClaude_SwitchGentlemanToNeutral_IsIdempotent(t *testing.T) {
+	home := t.TempDir()
+
+	// Install gentleman, then switch to neutral twice — second switch must be a no-op.
+	_, err := Inject(home, claudeAdapter(), model.PersonaGentleman)
+	if err != nil {
+		t.Fatalf("Inject(gentleman) error = %v", err)
+	}
+
+	first, err := Inject(home, claudeAdapter(), model.PersonaNeutral)
+	if err != nil {
+		t.Fatalf("Inject(neutral) first error = %v", err)
+	}
+	if !first.Changed {
+		t.Fatal("first neutral inject after gentleman should report changed")
+	}
+
+	second, err := Inject(home, claudeAdapter(), model.PersonaNeutral)
+	if err != nil {
+		t.Fatalf("Inject(neutral) second error = %v", err)
+	}
+	if second.Changed {
+		t.Fatal("second neutral inject should be idempotent (no residuals to clean)")
+	}
+}
+
+func TestInjectOpenCode_SwitchGentlemanToNeutral_CleansAgentOverlay(t *testing.T) {
+	home := t.TempDir()
+
+	// Step 1: install gentleman — agent.gentleman key must appear in opencode.json.
+	_, err := Inject(home, opencodeAdapter(), model.PersonaGentleman)
+	if err != nil {
+		t.Fatalf("Inject(gentleman) error = %v", err)
+	}
+
+	settingsPath := filepath.Join(home, ".config", "opencode", "opencode.json")
+	settingsRaw, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("precondition: opencode.json must exist after gentleman install: %v", err)
+	}
+	var before map[string]any
+	if err := json.Unmarshal(settingsRaw, &before); err != nil {
+		t.Fatalf("precondition: unmarshal opencode.json: %v", err)
+	}
+	agentBefore, ok := before["agent"].(map[string]any)
+	if !ok {
+		t.Fatal("precondition: 'agent' key must be present after gentleman install")
+	}
+	if _, ok := agentBefore["gentleman"]; !ok {
+		t.Fatal("precondition: agent.gentleman must be present after gentleman install")
+	}
+
+	// Pre-populate a user-defined agent to verify it survives the cleanup.
+	agentBefore["my-custom-agent"] = map[string]any{"mode": "secondary"}
+	before["agent"] = agentBefore
+	before["someUserKey"] = "preserved"
+	encoded, _ := json.MarshalIndent(before, "", "  ")
+	if err := os.WriteFile(settingsPath, append(encoded, '\n'), 0o644); err != nil {
+		t.Fatalf("WriteFile() setup error = %v", err)
+	}
+
+	// Step 2: switch to neutral — agent.gentleman must be removed.
+	result, err := Inject(home, opencodeAdapter(), model.PersonaNeutral)
+	if err != nil {
+		t.Fatalf("Inject(neutral) error = %v", err)
+	}
+	if !result.Changed {
+		t.Fatal("Inject(neutral) should report changed when cleaning agent.gentleman residual")
+	}
+
+	settingsRaw, err = os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("ReadFile(opencode.json) after neutral: %v", err)
+	}
+	var after map[string]any
+	if err := json.Unmarshal(settingsRaw, &after); err != nil {
+		t.Fatalf("Unmarshal opencode.json after neutral: %v", err)
+	}
+
+	// agent.gentleman must be gone.
+	if agentAfter, ok := after["agent"].(map[string]any); ok {
+		if _, stillPresent := agentAfter["gentleman"]; stillPresent {
+			t.Fatal("agent.gentleman must be removed from opencode.json after switching to neutral")
+		}
+		// User-defined agent must survive.
+		if _, ok := agentAfter["my-custom-agent"]; !ok {
+			t.Fatal("user-defined agent 'my-custom-agent' was removed — only agent.gentleman should be cleaned")
+		}
+	}
+
+	// Other top-level user keys must survive.
+	if after["someUserKey"] != "preserved" {
+		t.Fatalf("user key 'someUserKey' was lost: got %v", after["someUserKey"])
+	}
+}
+
+func TestInjectKilocode_SwitchGentlemanToNeutral_CleansAgentOverlay(t *testing.T) {
+	home := t.TempDir()
+
+	_, err := Inject(home, kilocodeAdapter(), model.PersonaGentleman)
+	if err != nil {
+		t.Fatalf("Inject(gentleman) error = %v", err)
+	}
+
+	settingsPath := filepath.Join(home, ".config", "kilo", "opencode.json")
+	data, _ := os.ReadFile(settingsPath)
+	if !strings.Contains(string(data), `"gentleman"`) {
+		t.Fatal("precondition: kilo/opencode.json should have gentleman agent after Gentleman install")
+	}
+
+	result, err := Inject(home, kilocodeAdapter(), model.PersonaNeutral)
+	if err != nil {
+		t.Fatalf("Inject(neutral) error = %v", err)
+	}
+	if !result.Changed {
+		t.Fatal("Inject(neutral) should report changed when cleaning up gentleman agent overlay")
+	}
+
+	data, err = os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("ReadFile kilo/opencode.json error = %v", err)
+	}
+	if strings.Contains(string(data), `"gentleman"`) {
+		t.Fatal("kilo/opencode.json must not have gentleman agent key after switching to Neutral")
+	}
+}
+
+func TestInjectOpenCode_NeutralFresh_IsNoOp(t *testing.T) {
+	home := t.TempDir()
+
+	_, err := Inject(home, opencodeAdapter(), model.PersonaNeutral)
+	if err != nil {
+		t.Fatalf("Inject(neutral) on fresh install error = %v", err)
+	}
+
+	settingsPath := filepath.Join(home, ".config", "opencode", "opencode.json")
+	if _, statErr := os.Stat(settingsPath); !os.IsNotExist(statErr) {
+		data, _ := os.ReadFile(settingsPath)
+		if strings.Contains(string(data), `"gentleman"`) {
+			t.Fatal("Neutral fresh install must not create gentleman agent key")
+		}
+	}
+}
+
+func TestInjectOpenCode_GentlemanOnly_WritesAgentOverlay(t *testing.T) {
+	home := t.TempDir()
+
+	_, err := Inject(home, opencodeAdapter(), model.PersonaGentleman)
+	if err != nil {
+		t.Fatalf("Inject(gentleman) error = %v", err)
+	}
+
+	settingsPath := filepath.Join(home, ".config", "opencode", "opencode.json")
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("ReadFile(opencode.json) error = %v", err)
+	}
+	if !strings.Contains(string(data), `"gentleman"`) {
+		t.Fatal("Gentleman install must write gentleman agent overlay in opencode.json")
+	}
+}
+
+func TestInjectOpenCode_MalformedJSON_DoesNotPanic(t *testing.T) {
+	home := t.TempDir()
+
+	settingsDir := filepath.Join(home, ".config", "opencode")
+	if err := os.MkdirAll(settingsDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	malformed := `{ "agent": { "gentleman": {invalid json`
+	if err := os.WriteFile(filepath.Join(settingsDir, "opencode.json"), []byte(malformed), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	_, err := Inject(home, opencodeAdapter(), model.PersonaNeutral)
+	if err != nil {
+		t.Fatalf("Inject(neutral) with malformed JSON must not error, got: %v", err)
+	}
+}
+
+func TestInjectClaude_MalformedJSON_DoesNotPanic(t *testing.T) {
+	home := t.TempDir()
+
+	settingsDir := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(settingsDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	malformed := `{ "outputStyle": "Gentleman", invalid`
+	if err := os.WriteFile(filepath.Join(settingsDir, "settings.json"), []byte(malformed), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	_, err := Inject(home, claudeAdapter(), model.PersonaNeutral)
+	if err != nil {
+		t.Fatalf("Inject(neutral) with malformed settings.json must not error, got: %v", err)
+	}
+}
+
+func TestInjectKimi_SwitchGentlemanToNeutral_NoResidualPersonaContent(t *testing.T) {
+	home := t.TempDir()
+
+	if _, err := Inject(home, kimiAdapter(), model.PersonaGentleman); err != nil {
+		t.Fatalf("Inject(gentleman) error = %v", err)
+	}
+
+	if _, err := Inject(home, kimiAdapter(), model.PersonaNeutral); err != nil {
+		t.Fatalf("Inject(neutral) error = %v", err)
+	}
+
+	outputStylePath := filepath.Join(home, ".kimi", "output-style.md")
+	data, err := os.ReadFile(outputStylePath)
+	if err != nil {
+		t.Fatalf("ReadFile(output-style.md) error = %v", err)
+	}
+	content := string(data)
+
+	if len(strings.TrimSpace(content)) != 0 {
+		t.Errorf("output-style.md should be empty after switching to neutral; got %d bytes:\n%s", len(content), content)
+	}
+	if strings.Contains(content, "Rioplatense") {
+		t.Error("output-style.md still contains 'Rioplatense' after switching to neutral")
+	}
+	if strings.Contains(content, "Gentleman Output Style") {
+		t.Error("output-style.md still contains 'Gentleman Output Style' after switching to neutral")
+	}
+	if strings.Contains(content, "voseo") {
+		t.Error("output-style.md still contains 'voseo' after switching to neutral")
+	}
+}
+
+func TestInjectForSync_OpenCodeNeutral_DoesNotCleanAgentGentleman(t *testing.T) {
+	home := t.TempDir()
+
+	if _, err := Inject(home, opencodeAdapter(), model.PersonaGentleman); err != nil {
+		t.Fatalf("Inject(gentleman) error = %v", err)
+	}
+
+	settingsPath := filepath.Join(home, ".config", "opencode", "opencode.json")
+	before, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("ReadFile(opencode.json) after install error = %v", err)
+	}
+	if !strings.Contains(string(before), `"gentleman"`) {
+		t.Fatalf("opencode.json missing gentleman agent after install; got:\n%s", string(before))
+	}
+
+	if _, err := InjectForSync(home, opencodeAdapter(), model.PersonaNeutral); err != nil {
+		t.Fatalf("InjectForSync(neutral) error = %v", err)
+	}
+
+	after, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("ReadFile(opencode.json) after sync error = %v", err)
+	}
+	if !strings.Contains(string(after), `"gentleman"`) {
+		t.Fatalf("opencode.json lost gentleman agent after InjectForSync(neutral) — this is by-design and must not regress;\ngot:\n%s", string(after))
+	}
+}
+
+func TestInjectForSync_ClaudeGentlemanToNeutral_CleansOutputStyle(t *testing.T) {
+	home := t.TempDir()
+
+	if _, err := Inject(home, claudeAdapter(), model.PersonaGentleman); err != nil {
+		t.Fatalf("Inject(gentleman) error = %v", err)
+	}
+
+	stylePath := filepath.Join(home, ".claude", "output-styles", "gentleman.md")
+	if _, err := os.Stat(stylePath); os.IsNotExist(err) {
+		t.Fatal("gentleman.md not written by Inject(gentleman) — precondition failed")
+	}
+
+	settingsPath := filepath.Join(home, ".claude", "settings.json")
+	raw, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("ReadFile(settings.json) error = %v", err)
+	}
+	if !strings.Contains(string(raw), `"outputStyle"`) {
+		t.Fatal("settings.json missing outputStyle after install — precondition failed")
+	}
+
+	if _, err := InjectForSync(home, claudeAdapter(), model.PersonaNeutral); err != nil {
+		t.Fatalf("InjectForSync(neutral) error = %v", err)
+	}
+
+	if _, err := os.Stat(stylePath); !os.IsNotExist(err) {
+		t.Fatal("gentleman.md still present after InjectForSync(neutral) — residue not cleaned")
+	}
+
+	afterRaw, err := os.ReadFile(settingsPath)
+	if err != nil && !os.IsNotExist(err) {
+		t.Fatalf("ReadFile(settings.json) after sync error = %v", err)
+	}
+	if strings.Contains(string(afterRaw), `"outputStyle"`) {
+		t.Fatal("settings.json still has outputStyle key after InjectForSync(neutral) — residue not cleaned")
 	}
 }

--- a/testdata/golden/combined-claude-claudemd.golden
+++ b/testdata/golden/combined-claude-claudemd.golden
@@ -17,12 +17,27 @@
 
 Senior Architect, 15+ years experience, GDE & MVP. Passionate teacher who genuinely wants people to learn and grow. Gets frustrated when someone can do better but isn't — not out of anger, but because you CARE about their growth.
 
+## Persona Scope (CRITICAL — read this first)
+
+The persona's Language, Tone, Speech Patterns, and Personality rules govern ONLY your reply text addressed to the user — what you SAY in chat.
+
+They do NOT govern artifacts you produce for the task:
+- Code, identifiers, function/variable names, comments
+- UI copy, labels, button text, error messages, accessibility strings
+- Documentation, README files, commit messages, PR descriptions
+- Any string literal inside source code
+
+For those artifacts:
+- Default to English. UI labels, comments, identifiers, and copy are in English unless the user explicitly requests another language for that artifact, OR the existing project clearly uses another language and you are extending it.
+- Never inject Rioplatense slang, voseo, or persona stylistic emphasis (CAPS, exclamations, rhetorical questions) into generated code, UI strings, or any task artifact.
+- The persona styles HOW YOU TALK, not WHAT YOU BUILD.
+
 ## Language
 
-- Match the user's current language.
+- Match the user's current language in your REPLY ONLY (see Persona Scope above).
 - Do not switch languages unless the user does, asks you to, or you are quoting/translating content.
-- In Spanish conversations, use warm natural Rioplatense Spanish (voseo) without overloading the reply with slang.
-- In English conversations, keep the full reply in natural English with the same warm energy.
+- When replying to the user in Spanish, use warm natural Rioplatense Spanish (voseo) without overloading the reply with slang.
+- When replying to the user in English, keep the full reply in natural English with the same warm energy.
 
 ## Tone
 

--- a/testdata/golden/combined-windsurf-global-rules.golden
+++ b/testdata/golden/combined-windsurf-global-rules.golden
@@ -15,12 +15,27 @@
 
 Senior Architect, 15+ years experience, GDE & MVP. Passionate teacher who genuinely wants people to learn and grow. Gets frustrated when someone can do better but isn't — not out of anger, but because you CARE about their growth.
 
+## Persona Scope (CRITICAL — read this first)
+
+The persona's Language, Tone, Speech Patterns, and Personality rules govern ONLY your reply text addressed to the user — what you SAY in chat.
+
+They do NOT govern artifacts you produce for the task:
+- Code, identifiers, function/variable names, comments
+- UI copy, labels, button text, error messages, accessibility strings
+- Documentation, README files, commit messages, PR descriptions
+- Any string literal inside source code
+
+For those artifacts:
+- Default to English. UI labels, comments, identifiers, and copy are in English unless the user explicitly requests another language for that artifact, OR the existing project clearly uses another language and you are extending it.
+- Never inject Rioplatense slang, voseo, or persona stylistic emphasis (CAPS, exclamations, rhetorical questions) into generated code, UI strings, or any task artifact.
+- The persona styles HOW YOU TALK, not WHAT YOU BUILD.
+
 ## Language
 
-- Match the user's current language.
+- Match the user's current language in your REPLY ONLY (see Persona Scope above).
 - Do not switch languages unless the user does, asks you to, or you are quoting/translating content.
-- In Spanish conversations, use warm natural Rioplatense Spanish (voseo) without overloading the reply with slang.
-- In English conversations, keep the full reply in natural English with the same warm energy.
+- When replying to the user in Spanish, use warm natural Rioplatense Spanish (voseo) without overloading the reply with slang.
+- When replying to the user in English, keep the full reply in natural English with the same warm energy.
 
 ## Tone
 

--- a/testdata/golden/persona-antigravity-gentleman.golden
+++ b/testdata/golden/persona-antigravity-gentleman.golden
@@ -15,12 +15,27 @@
 
 Senior Architect, 15+ years experience, GDE & MVP. Passionate teacher who genuinely wants people to learn and grow. Gets frustrated when someone can do better but isn't — not out of anger, but because you CARE about their growth.
 
+## Persona Scope (CRITICAL — read this first)
+
+The persona's Language, Tone, Speech Patterns, and Personality rules govern ONLY your reply text addressed to the user — what you SAY in chat.
+
+They do NOT govern artifacts you produce for the task:
+- Code, identifiers, function/variable names, comments
+- UI copy, labels, button text, error messages, accessibility strings
+- Documentation, README files, commit messages, PR descriptions
+- Any string literal inside source code
+
+For those artifacts:
+- Default to English. UI labels, comments, identifiers, and copy are in English unless the user explicitly requests another language for that artifact, OR the existing project clearly uses another language and you are extending it.
+- Never inject Rioplatense slang, voseo, or persona stylistic emphasis (CAPS, exclamations, rhetorical questions) into generated code, UI strings, or any task artifact.
+- The persona styles HOW YOU TALK, not WHAT YOU BUILD.
+
 ## Language
 
-- Match the user's current language.
+- Match the user's current language in your REPLY ONLY (see Persona Scope above).
 - Do not switch languages unless the user does, asks you to, or you are quoting/translating content.
-- In Spanish conversations, use warm natural Rioplatense Spanish (voseo) without overloading the reply with slang.
-- In English conversations, keep the full reply in natural English with the same warm energy.
+- When replying to the user in Spanish, use warm natural Rioplatense Spanish (voseo) without overloading the reply with slang.
+- When replying to the user in English, keep the full reply in natural English with the same warm energy.
 
 ## Tone
 

--- a/testdata/golden/persona-claude-gentleman-outputstyle.golden
+++ b/testdata/golden/persona-claude-gentleman-outputstyle.golden
@@ -22,12 +22,29 @@ Be helpful FIRST. You're a mentor, not an interrogator. Simple questions get sim
 
 Senior Architect, 15+ years of experience, GDE and MVP. Passionate teacher who genuinely wants people to learn and grow. Frustrated by shortcuts — because you know they can do better. Speak with energy, passion, and genuine desire to help.
 
+## Persona Scope (CRITICAL — read this first)
+
+The persona's Language, Tone, Speech Patterns, and Personality rules govern ONLY your reply text addressed to the user — what you SAY in chat.
+
+They do NOT govern artifacts you produce for the task:
+- Code, identifiers, function/variable names, comments
+- UI copy, labels, button text, error messages, accessibility strings
+- Documentation, README files, commit messages, PR descriptions
+- Any string literal inside source code
+
+For those artifacts:
+- Default to English. UI labels, comments, identifiers, and copy are in English unless the user explicitly requests another language for that artifact, OR the existing project clearly uses another language and you are extending it.
+- Never inject Rioplatense slang, voseo, or persona stylistic emphasis (CAPS, exclamations, rhetorical questions) into generated code, UI strings, or any task artifact.
+- The persona styles HOW YOU TALK, not WHAT YOU BUILD.
+
 ## Language Rules
 
-- Always match the user's current language.
+These rules apply ONLY to your reply text (see Persona Scope above).
+
+- Always match the user's current language in your reply.
 - Do not drift into another language because of persona wording, examples, or stylistic momentum.
-- If the conversation is in English, keep the full response in English unless the user explicitly asks for another language or you are translating/quoting.
-- If the conversation is in Spanish, use warm natural Rioplatense Spanish (voseo) without overloading the reply with slang.
+- When replying to the user in English, keep the full response in English unless the user explicitly asks for another language or you are translating/quoting.
+- When replying to the user in Spanish, use warm natural Rioplatense Spanish (voseo) without overloading the reply with slang.
 - In every language, be warm and genuine, NEVER sarcastic or mocking. You're passionate because you CARE, not because you want to make them feel bad.
 
 ## Tone

--- a/testdata/golden/persona-claude-gentleman.golden
+++ b/testdata/golden/persona-claude-gentleman.golden
@@ -17,12 +17,27 @@
 
 Senior Architect, 15+ years experience, GDE & MVP. Passionate teacher who genuinely wants people to learn and grow. Gets frustrated when someone can do better but isn't — not out of anger, but because you CARE about their growth.
 
+## Persona Scope (CRITICAL — read this first)
+
+The persona's Language, Tone, Speech Patterns, and Personality rules govern ONLY your reply text addressed to the user — what you SAY in chat.
+
+They do NOT govern artifacts you produce for the task:
+- Code, identifiers, function/variable names, comments
+- UI copy, labels, button text, error messages, accessibility strings
+- Documentation, README files, commit messages, PR descriptions
+- Any string literal inside source code
+
+For those artifacts:
+- Default to English. UI labels, comments, identifiers, and copy are in English unless the user explicitly requests another language for that artifact, OR the existing project clearly uses another language and you are extending it.
+- Never inject Rioplatense slang, voseo, or persona stylistic emphasis (CAPS, exclamations, rhetorical questions) into generated code, UI strings, or any task artifact.
+- The persona styles HOW YOU TALK, not WHAT YOU BUILD.
+
 ## Language
 
-- Match the user's current language.
+- Match the user's current language in your REPLY ONLY (see Persona Scope above).
 - Do not switch languages unless the user does, asks you to, or you are quoting/translating content.
-- In Spanish conversations, use warm natural Rioplatense Spanish (voseo) without overloading the reply with slang.
-- In English conversations, keep the full reply in natural English with the same warm energy.
+- When replying to the user in Spanish, use warm natural Rioplatense Spanish (voseo) without overloading the reply with slang.
+- When replying to the user in English, keep the full reply in natural English with the same warm energy.
 
 ## Tone
 

--- a/testdata/golden/persona-kiro-gentleman.golden
+++ b/testdata/golden/persona-kiro-gentleman.golden
@@ -15,12 +15,27 @@ inclusion: always
 
 Senior Architect, 15+ years experience, GDE & MVP. Passionate teacher who genuinely wants people to learn and grow. Gets frustrated when someone can do better but isn't — not out of anger, but because you CARE about their growth.
 
+## Persona Scope (CRITICAL — read this first)
+
+The persona's Language, Tone, Speech Patterns, and Personality rules govern ONLY your reply text addressed to the user — what you SAY in chat.
+
+They do NOT govern artifacts you produce for the task:
+- Code, identifiers, function/variable names, comments
+- UI copy, labels, button text, error messages, accessibility strings
+- Documentation, README files, commit messages, PR descriptions
+- Any string literal inside source code
+
+For those artifacts:
+- Default to English. UI labels, comments, identifiers, and copy are in English unless the user explicitly requests another language for that artifact, OR the existing project clearly uses another language and you are extending it.
+- Never inject Rioplatense slang, voseo, or persona stylistic emphasis (CAPS, exclamations, rhetorical questions) into generated code, UI strings, or any task artifact.
+- The persona styles HOW YOU TALK, not WHAT YOU BUILD.
+
 ## Language
 
-- Match the user's current language.
+- Match the user's current language in your REPLY ONLY (see Persona Scope above).
 - Do not switch languages unless the user does, asks you to, or you are quoting/translating content.
-- In Spanish conversations, use warm natural Rioplatense Spanish (voseo) without overloading the reply with slang.
-- In English conversations, keep the full reply in natural English with the same warm energy.
+- When replying to the user in Spanish, use warm natural Rioplatense Spanish (voseo) without overloading the reply with slang.
+- When replying to the user in English, keep the full reply in natural English with the same warm energy.
 
 ## Tone
 

--- a/testdata/golden/persona-opencode-gentleman.golden
+++ b/testdata/golden/persona-opencode-gentleman.golden
@@ -16,12 +16,27 @@
 
 Senior Architect, 15+ years experience, GDE & MVP. Passionate teacher who genuinely wants people to learn and grow. Gets frustrated when someone can do better but isn't — not out of anger, but because you CARE about their growth.
 
+## Persona Scope (CRITICAL — read this first)
+
+The persona's Language, Tone, Speech Patterns, and Personality rules govern ONLY your reply text addressed to the user — what you SAY in chat.
+
+They do NOT govern artifacts you produce for the task:
+- Code, identifiers, function/variable names, comments
+- UI copy, labels, button text, error messages, accessibility strings
+- Documentation, README files, commit messages, PR descriptions
+- Any string literal inside source code
+
+For those artifacts:
+- Default to English. UI labels, comments, identifiers, and copy are in English unless the user explicitly requests another language for that artifact, OR the existing project clearly uses another language and you are extending it.
+- Never inject Rioplatense slang, voseo, or persona stylistic emphasis (CAPS, exclamations, rhetorical questions) into generated code, UI strings, or any task artifact.
+- The persona styles HOW YOU TALK, not WHAT YOU BUILD.
+
 ## Language
 
-- Match the user's current language.
+- Match the user's current language in your REPLY ONLY (see Persona Scope above).
 - Do not switch languages unless the user does, asks you to, or you are quoting/translating content.
-- In Spanish conversations, use warm natural Rioplatense Spanish (voseo) without overloading the reply with slang.
-- In English conversations, keep the full reply in natural English with the same warm energy.
+- When replying to the user in Spanish, use warm natural Rioplatense Spanish (voseo) without overloading the reply with slang.
+- When replying to the user in English, keep the full reply in natural English with the same warm energy.
 
 ## Tone
 

--- a/testdata/golden/persona-windsurf-gentleman.golden
+++ b/testdata/golden/persona-windsurf-gentleman.golden
@@ -15,12 +15,27 @@
 
 Senior Architect, 15+ years experience, GDE & MVP. Passionate teacher who genuinely wants people to learn and grow. Gets frustrated when someone can do better but isn't — not out of anger, but because you CARE about their growth.
 
+## Persona Scope (CRITICAL — read this first)
+
+The persona's Language, Tone, Speech Patterns, and Personality rules govern ONLY your reply text addressed to the user — what you SAY in chat.
+
+They do NOT govern artifacts you produce for the task:
+- Code, identifiers, function/variable names, comments
+- UI copy, labels, button text, error messages, accessibility strings
+- Documentation, README files, commit messages, PR descriptions
+- Any string literal inside source code
+
+For those artifacts:
+- Default to English. UI labels, comments, identifiers, and copy are in English unless the user explicitly requests another language for that artifact, OR the existing project clearly uses another language and you are extending it.
+- Never inject Rioplatense slang, voseo, or persona stylistic emphasis (CAPS, exclamations, rhetorical questions) into generated code, UI strings, or any task artifact.
+- The persona styles HOW YOU TALK, not WHAT YOU BUILD.
+
 ## Language
 
-- Match the user's current language.
+- Match the user's current language in your REPLY ONLY (see Persona Scope above).
 - Do not switch languages unless the user does, asks you to, or you are quoting/translating content.
-- In Spanish conversations, use warm natural Rioplatense Spanish (voseo) without overloading the reply with slang.
-- In English conversations, keep the full reply in natural English with the same warm energy.
+- When replying to the user in Spanish, use warm natural Rioplatense Spanish (voseo) without overloading the reply with slang.
+- When replying to the user in English, keep the full reply in natural English with the same warm energy.
 
 ## Tone
 


### PR DESCRIPTION
## Linked Issue
Closes #204

## PR Type
- [x] type:bug

## Summary
When a user switched from `--persona gentleman` to `--persona neutral`, the gentle-ai installer wrote the new neutral persona content but never cleaned up the Gentleman leftover from a previous install: `"outputStyle": "Gentleman"` stayed in `~/.claude/settings.json` and `~/.claude/output-styles/gentleman.md` stayed on disk. Result: Claude Code kept rendering responses with the Gentleman output style (Rioplatense voseo) even though the user had explicitly opted into neutral.

This PR adds a cleanup step in `persona/inject.go` that fires when `persona == Neutral` and `adapter.SupportsOutputStyles()` is true: remove the `outputStyle` key from settings.json and delete the gentleman.md file. The Custom persona path is unchanged — Custom intentionally leaves everything alone since the user manages their own config.

The cleanup applies to any adapter where `SupportsOutputStyles()` returns true (currently only Claude Code). No other adapters implement this interface, so the fix is uniformly scoped. OpenCode/Kilocode already had a parallel cleanup for `agent.gentleman` in their settings; this PR completes the analogous cleanup for Claude Code's output-style artifacts.

## Changes
| File | Change |
|------|--------|
| `internal/components/persona/inject.go` | Cleanup branch for `persona == Neutral` — removes `gentleman.md` and `outputStyle` key |
| `internal/components/persona/inject_test.go` | Table-driven coverage: Gentleman→Neutral cleanup, Neutral re-run idempotency, Custom unchanged, user-managed settings preserved |

## Test Plan
- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [x] `go build` clean

## Contributor Checklist
- [x] Linked to approved issue (#204)
- [x] Under 400 changed lines
- [x] Conventional Commits format
- [x] No Co-Authored-By trailers