### PR TITLE
fix(upgrade): pin install.sh download URL to release tag instead of main

### DIFF
--- a/internal/update/upgrade/strategy.go
+++ b/internal/update/upgrade/strategy.go
@@ -383,16 +383,21 @@ func downloadAndReplace(ctx context.Context, r update.UpdateResult, profile syst
 	return Download(ctx, r, profile)
 }
 
-// installScriptURLFn builds the raw GitHub URL for the project's install.sh.
+// installScriptURLFn builds the raw GitHub URL for the project's install.sh,
+// pinned to the given release tag (e.g. "1.31.0" → ref "v1.31.0").
 // Package-level var for testability.
-var installScriptURLFn = func(owner, repo string) string {
-	return fmt.Sprintf("https://raw.githubusercontent.com/%s/%s/main/install.sh",
-		owner, repo)
+var installScriptURLFn = func(owner, repo, version string) (string, error) {
+	if strings.TrimSpace(version) == "" {
+		return "", fmt.Errorf("install script URL: target version must not be empty")
+	}
+	return fmt.Sprintf("https://raw.githubusercontent.com/%s/%s/v%s/install.sh",
+		owner, repo, version), nil
 }
 
-// installScriptURL builds the raw GitHub URL for the project's install.sh.
-func installScriptURL(owner, repo string) string {
-	return installScriptURLFn(owner, repo)
+// installScriptURL builds the raw GitHub URL for the project's install.sh,
+// pinned to the given release tag so the upgrade path never pulls from main.
+func installScriptURL(owner, repo, version string) (string, error) {
+	return installScriptURLFn(owner, repo, version)
 }
 
 // scriptUpgrade downloads and executes the project's install.sh via curl | bash.
@@ -413,7 +418,11 @@ func scriptUpgrade(ctx context.Context, r update.UpdateResult, profile system.Pl
 		}
 	}
 
-	url := installScriptURL(r.Tool.Owner, r.Tool.Repo)
+	url, err := installScriptURL(r.Tool.Owner, r.Tool.Repo, r.LatestVersion)
+	if err != nil {
+		return fmt.Errorf("download install.sh: %w", err)
+	}
+	fmt.Fprintf(os.Stderr, "INFO: downloading install script from %s\n", url)
 
 	// Download install.sh content.
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
@@ -495,9 +504,13 @@ func ggaScriptUpgradeForOS(ctx context.Context, r update.UpdateResult, osName st
 	}
 	defer os.RemoveAll(tmpDir)
 
-	// Clone the full repository — install.sh needs the entire repo context.
+	// Clone the full repository at the target release tag so the install.sh
+	// executed here matches the version the user is upgrading TO, not whatever
+	// is on main at the moment of the upgrade. This prevents a race where a
+	// commit lands on main between the release and the user's upgrade run.
+	targetTag := "v" + r.LatestVersion
 	repoURL := fmt.Sprintf("https://github.com/%s/%s.git", r.Tool.Owner, r.Tool.Repo)
-	cloneCmd := execCommand("git", "clone", repoURL, tmpDir)
+	cloneCmd := execCommand("git", "clone", "--depth=1", "--branch", targetTag, repoURL, tmpDir)
 	cloneCmd.Stdin = nil
 	if out, err := cloneCmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("git clone %s: %w (output: %s)", r.Tool.Repo, err, strings.TrimSpace(string(out)))

--- a/internal/update/upgrade/strategy_test.go
+++ b/internal/update/upgrade/strategy_test.go
@@ -775,8 +775,8 @@ func TestRunStrategy_ScriptUpgradeSuccess(t *testing.T) {
 	scriptHTTPClient = server.Client()
 
 	// Override installScriptURL to point to our test server.
-	installScriptURLFn = func(owner, repo string) string {
-		return server.URL + "/install.sh"
+	installScriptURLFn = func(owner, repo, version string) (string, error) {
+		return server.URL + "/install.sh", nil
 	}
 
 	var gotScriptContent string
@@ -825,8 +825,8 @@ func TestRunStrategy_ScriptUpgradeDownloadFailure(t *testing.T) {
 	}))
 	defer server.Close()
 	scriptHTTPClient = server.Client()
-	installScriptURLFn = func(owner, repo string) string {
-		return server.URL + "/install.sh"
+	installScriptURLFn = func(owner, repo, version string) (string, error) {
+		return server.URL + "/install.sh", nil
 	}
 
 	r := update.UpdateResult{
@@ -882,9 +882,11 @@ func TestRunStrategy_ScriptUpgradeWindowsManualFallback(t *testing.T) {
 // --- TestGGAScriptUpgradeUsesGitClone ---
 
 // TestGGAScriptUpgradeUsesGitClone verifies that ggaScriptUpgrade:
-// 1. First calls `git clone <repo-url> /tmp/gentleman-guardian-angel`
-// 2. Then calls `bash /tmp/gentleman-guardian-angel/install.sh`
+// 1. First calls `git clone --depth=1 --branch v<version> <repo-url> <tmpDir>`
+// 2. Then calls `bash <path-to-install.sh>`
 // — not `bash -c <script-content>` like the generic scriptUpgrade.
+// The clone is pinned to the target release tag so that install.sh matches the
+// version being upgraded to, not whatever is on main at upgrade time.
 func TestGGAScriptUpgradeUsesGitClone(t *testing.T) {
 	origExecCommand := execCommand
 	origDetectOS := detectOS
@@ -932,17 +934,23 @@ func TestGGAScriptUpgradeUsesGitClone(t *testing.T) {
 	if len(calls[0].args) == 0 || calls[0].args[0] != "clone" {
 		t.Errorf("first exec args[0] = %q, want %q", calls[0].args[0], "clone")
 	}
-	// The clone URL must reference the correct repo.
+	// The clone args must include the target tag via --branch.
 	cloneArgs := calls[0].args
 	foundRepoURL := false
-	for _, a := range cloneArgs {
+	foundTag := false
+	for i, a := range cloneArgs {
 		if containsAny(a, "gentleman-guardian-angel") {
 			foundRepoURL = true
-			break
+		}
+		if a == "--branch" && i+1 < len(cloneArgs) && cloneArgs[i+1] == "v2.8.0" {
+			foundTag = true
 		}
 	}
 	if !foundRepoURL {
 		t.Errorf("git clone args %v should include the repo URL (gentleman-guardian-angel)", cloneArgs)
+	}
+	if !foundTag {
+		t.Errorf("git clone args %v should include --branch v2.8.0 to pin to the release tag", cloneArgs)
 	}
 
 	// Second call must be `bash <path-to-install.sh>` (not bash -c <content>).
@@ -1052,9 +1060,67 @@ func TestRunStrategy_GGAUsesGitClone(t *testing.T) {
 // --- TestInstallScriptURL ---
 
 func TestInstallScriptURL(t *testing.T) {
-	url := installScriptURL("Gentleman-Programming", "gentleman-guardian-angel")
-	if url != "https://raw.githubusercontent.com/Gentleman-Programming/gentleman-guardian-angel/main/install.sh" {
-		t.Errorf("installScriptURL = %q, want correct raw GitHub URL", url)
+	tests := []struct {
+		name        string
+		owner       string
+		repo        string
+		version     string
+		wantURL     string
+		wantErr     bool
+		wantContain string
+	}{
+		{
+			name:        "pins to release tag",
+			owner:       "Gentleman-Programming",
+			repo:        "gentleman-guardian-angel",
+			version:     "1.31.0",
+			wantURL:     "https://raw.githubusercontent.com/Gentleman-Programming/gentleman-guardian-angel/v1.31.0/install.sh",
+			wantContain: "v1.31.0",
+		},
+		{
+			name:    "empty version returns error",
+			owner:   "Gentleman-Programming",
+			repo:    "gentle-ai",
+			version: "",
+			wantErr: true,
+		},
+		{
+			name:    "whitespace-only version returns error",
+			owner:   "Gentleman-Programming",
+			repo:    "gentle-ai",
+			version: "   ",
+			wantErr: true,
+		},
+		{
+			name:        "does not reference main",
+			owner:       "Gentleman-Programming",
+			repo:        "gentle-ai",
+			version:     "2.0.0",
+			wantContain: "v2.0.0",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			url, err := installScriptURL(tc.owner, tc.repo, tc.version)
+			if tc.wantErr {
+				if err == nil {
+					t.Errorf("installScriptURL(%q, %q, %q): want error, got nil (url=%q)", tc.owner, tc.repo, tc.version, url)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("installScriptURL(%q, %q, %q): unexpected error: %v", tc.owner, tc.repo, tc.version, err)
+			}
+			if tc.wantURL != "" && url != tc.wantURL {
+				t.Errorf("installScriptURL = %q, want %q", url, tc.wantURL)
+			}
+			if tc.wantContain != "" && !containsAny(url, tc.wantContain) {
+				t.Errorf("installScriptURL = %q, want it to contain %q", url, tc.wantContain)
+			}
+			if containsAny(url, "/main/") {
+				t.Errorf("installScriptURL = %q must NOT reference /main/", url)
+			}
+		})
 	}
 }
 
@@ -1174,8 +1240,8 @@ func TestRunStrategy_ScriptUpgradeExecFailure(t *testing.T) {
 	}))
 	defer server.Close()
 	scriptHTTPClient = server.Client()
-	installScriptURLFn = func(owner, repo string) string {
-		return server.URL + "/install.sh"
+	installScriptURLFn = func(owner, repo, version string) (string, error) {
+		return server.URL + "/install.sh", nil
 	}
 
 	execCommand = func(name string, args ...string) *exec.Cmd {


### PR DESCRIPTION
## Linked Issue

Closes #247

## PR Type

- [x] `type:bug`

## Summary

The upgrade path downloaded `scripts/install.sh` from the repo's `main` branch and executed it directly. Any commit landing on `main` between a release and a user's upgrade run could be executed at upgrade time before any version gate or verification.

This PR pins the script download to the TARGET release tag (e.g. `v1.31.0`) instead of `main`:
- `installScriptURLFn` resolves to `https://raw.githubusercontent.com/.../v{version}/scripts/install.sh`
- GGA git clone path uses `--depth=1 --branch v{version}` to fetch exactly the tagged scripts
- Resolved URL is logged at upgrade start so the user can see what's about to execute

## Changes

| File | Change |
|------|--------|
| `internal/update/upgrade/strategy.go` | Pin install.sh URL + GGA git clone to `v<target-version>` tag; log resolved URL |
| `internal/update/upgrade/strategy_test.go` | Mock signature updates; `TestInstallScriptURL` table-driven (4 cases); `TestGGAScriptUpgradeUsesGitClone` verifies `--branch v2.8.0` |

## Test Plan

- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [x] `go build` clean

## Contributor Checklist

- [x] Linked to approved issue (#247)
- [x] Under 400 changed lines (127 LOC)
- [x] Conventional Commits format
- [x] No Co-Authored-By trailers