### PR TITLE
fix(tui): respect persisted installed_agents from state.json over filesystem detection

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -107,7 +107,12 @@ func RunArgs(args []string, stdout io.Writer) error {
 			return fmt.Errorf("resolve user home directory: %w", err)
 		}
 
-		m := tui.NewModel(result, Version)
+		// Load persisted state so the TUI pre-selects the agents the user
+		// previously chose instead of re-selecting every detected config dir.
+		// A missing or unreadable state file is not an error — NewModel falls
+		// back to filesystem detection for first-time installs.
+		installedState, _ := state.Read(homeDir)
+		m := tui.NewModel(result, Version, installedState)
 		m.ExecuteFn = tuiExecute
 		m.RestoreFn = tuiRestore
 		m.DeleteBackupFn = func(manifest backup.Manifest) error {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -22,6 +22,7 @@ import (
 	"github.com/gentleman-programming/gentle-ai/internal/opencode"
 	"github.com/gentleman-programming/gentle-ai/internal/pipeline"
 	"github.com/gentleman-programming/gentle-ai/internal/planner"
+	"github.com/gentleman-programming/gentle-ai/internal/state"
 	"github.com/gentleman-programming/gentle-ai/internal/system"
 	"github.com/gentleman-programming/gentle-ai/internal/tui/screens"
 	"github.com/gentleman-programming/gentle-ai/internal/update"
@@ -463,8 +464,17 @@ type Model struct {
 	OpenCodePluginRegistrationErr     error
 }
 
-func NewModel(detection system.DetectionResult, version string) Model {
-	agents := preselectedAgents(detection)
+// NewModel constructs the initial TUI model for the given detection result.
+// An optional InstallState may be supplied as the third argument; when present,
+// its InstalledAgents list is used as the canonical pre-selection source instead
+// of filesystem detection (which becomes a fallback for first-time installs only).
+// Existing callers that pass only two arguments receive the previous behavior.
+func NewModel(detection system.DetectionResult, version string, installState ...state.InstallState) Model {
+	var s state.InstallState
+	if len(installState) > 0 {
+		s = installState[0]
+	}
+	agents := preselectedAgents(detection, s)
 	components := componentsForPreset(model.PresetFullGentleman, model.PersonaGentleman)
 	if isPiOnlyAgents(agents) {
 		components = piOnlyComponents()
@@ -2110,7 +2120,7 @@ func (m Model) withResetOperationState() Model {
 
 func (m Model) withResetUninstallState() Model {
 	m.UninstallMode = model.UninstallModePartial
-	m.UninstallAgents = preselectedAgents(m.Detection)
+	m.UninstallAgents = detectedAgentIDs(m.Detection)
 	m.UninstallComponents = defaultUninstallComponents()
 	m.UninstallProfilesAvailable = nil
 	m.UninstallProfilesToRemove = nil
@@ -3106,14 +3116,43 @@ func (m *Model) buildDependencyPlan() {
 	m.DependencyPlan = resolved
 }
 
-func preselectedAgents(detection system.DetectionResult) []model.AgentID {
+// agentsToManage returns the canonical list of agents gentle-ai should manage.
+//
+// Priority:
+//  1. state.InstalledAgents is non-empty → use those (persisted user selection).
+//  2. detectedIDs is non-empty          → use those (filesystem detection fallback).
+//  3. Both empty                         → return all catalog agents (first-time install default).
+//
+// This is the single source of truth for both the TUI pre-selection and the
+// pre-upgrade backup scope. It ensures that a user who deliberately un-selected
+// an agent in the TUI does not see it re-selected or backed-up on the next run.
+func agentsToManage(installState state.InstallState, detectedIDs []model.AgentID) []model.AgentID {
+	if len(installState.InstalledAgents) > 0 {
+		ids := make([]model.AgentID, 0, len(installState.InstalledAgents))
+		for _, a := range installState.InstalledAgents {
+			ids = append(ids, model.AgentID(a))
+		}
+		return ids
+	}
+	if len(detectedIDs) > 0 {
+		return detectedIDs
+	}
+	agents := catalog.AllAgents()
+	all := make([]model.AgentID, 0, len(agents))
+	for _, agent := range agents {
+		all = append(all, agent.ID)
+	}
+	return all
+}
+
+// detectedAgentIDs converts a DetectionResult to the agent IDs whose config dirs exist on disk.
+func detectedAgentIDs(detection system.DetectionResult) []model.AgentID {
 	selected := []model.AgentID{}
-	for _, state := range detection.Configs {
-		if !state.Exists {
+	for _, cfg := range detection.Configs {
+		if !cfg.Exists {
 			continue
 		}
-
-		switch strings.TrimSpace(state.Agent) {
+		switch strings.TrimSpace(cfg.Agent) {
 		case string(model.AgentClaudeCode):
 			selected = append(selected, model.AgentClaudeCode)
 		case string(model.AgentOpenCode):
@@ -3136,18 +3175,13 @@ func preselectedAgents(detection system.DetectionResult) []model.AgentID {
 			selected = append(selected, model.AgentPi)
 		}
 	}
-
-	if len(selected) > 0 {
-		return selected
-	}
-
-	agents := catalog.AllAgents()
-	selected = make([]model.AgentID, 0, len(agents))
-	for _, agent := range agents {
-		selected = append(selected, agent.ID)
-	}
-
 	return selected
+}
+
+// preselectedAgents returns the agents that should be pre-selected in the TUI.
+// It delegates to agentsToManage so that persisted state always wins over filesystem detection.
+func preselectedAgents(detection system.DetectionResult, installState state.InstallState) []model.AgentID {
+	return agentsToManage(installState, detectedAgentIDs(detection))
 }
 
 func isPiOnlyAgents(agents []model.AgentID) bool {

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gentleman-programming/gentle-ai/internal/opencode"
 	"github.com/gentleman-programming/gentle-ai/internal/pipeline"
 	"github.com/gentleman-programming/gentle-ai/internal/planner"
+	"github.com/gentleman-programming/gentle-ai/internal/state"
 	"github.com/gentleman-programming/gentle-ai/internal/system"
 	"github.com/gentleman-programming/gentle-ai/internal/tui/screens"
 	"github.com/gentleman-programming/gentle-ai/internal/update"
@@ -2214,7 +2215,7 @@ func TestDeleteResult_EnterRefreshesAndReturnsToBackups(t *testing.T) {
 // detection-driven TUI preselection silently dropped it.
 func TestPreselectedAgents_CodexIsIncludedWhenPresent(t *testing.T) {
 	detection := makeDetectionWithAgents("codex")
-	selected := preselectedAgents(detection)
+	selected := preselectedAgents(detection, state.InstallState{})
 
 	found := false
 	for _, id := range selected {
@@ -2684,7 +2685,7 @@ func TestPreselectedAgents_AllSixAgentsMappedCorrectly(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.configAgent, func(t *testing.T) {
 			detection := makeDetectionWithAgents(tt.configAgent)
-			selected := preselectedAgents(detection)
+			selected := preselectedAgents(detection, state.InstallState{})
 
 			found := false
 			for _, id := range selected {
@@ -2703,6 +2704,113 @@ func TestPreselectedAgents_AllSixAgentsMappedCorrectly(t *testing.T) {
 					len(selected), tt.configAgent, selected)
 			}
 		})
+	}
+}
+
+// ─── agentsToManage / preselectedAgents — state wins over detection ─────────
+
+// TestAgentsToManage_StateTakesPriorityOverDetection verifies the core contract:
+// when state.json is populated, it overrides filesystem detection for TUI pre-selection.
+func TestAgentsToManage_StateTakesPriorityOverDetection(t *testing.T) {
+	tests := []struct {
+		name        string
+		stateAgents []string       // InstalledAgents from state.json
+		detectedIDs []model.AgentID // agents detected on filesystem
+		want        []model.AgentID
+		desc        string
+	}{
+		{
+			name:        "empty state falls back to filesystem detection",
+			stateAgents: nil,
+			detectedIDs: []model.AgentID{model.AgentClaudeCode, model.AgentGeminiCLI},
+			want:        []model.AgentID{model.AgentClaudeCode, model.AgentGeminiCLI},
+			desc:        "first-time install: state.json absent, filesystem detection is the source",
+		},
+		{
+			name:        "state with 2 agents wins when filesystem has 5",
+			stateAgents: []string{string(model.AgentClaudeCode), string(model.AgentOpenCode)},
+			detectedIDs: []model.AgentID{
+				model.AgentClaudeCode,
+				model.AgentOpenCode,
+				model.AgentGeminiCLI,
+				model.AgentCursor,
+				model.AgentCodex,
+			},
+			want: []model.AgentID{model.AgentClaudeCode, model.AgentOpenCode},
+			desc: "state.json wins: only persisted agents are returned, not all 5 detected",
+		},
+		{
+			name:        "explicit empty installed_agents produces empty list",
+			stateAgents: []string{},
+			detectedIDs: []model.AgentID{model.AgentClaudeCode, model.AgentGeminiCLI},
+			want:        []model.AgentID{model.AgentClaudeCode, model.AgentGeminiCLI},
+			desc:        "empty slice in state.json is treated as no state (falls back to detection)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			installState := state.InstallState{InstalledAgents: tt.stateAgents}
+			got := agentsToManage(installState, tt.detectedIDs)
+
+			if len(got) != len(tt.want) {
+				t.Fatalf("%s\nagentsToManage() returned %d agents, want %d\ngot:  %v\nwant: %v",
+					tt.desc, len(got), len(tt.want), got, tt.want)
+			}
+			wantSet := make(map[model.AgentID]bool, len(tt.want))
+			for _, id := range tt.want {
+				wantSet[id] = true
+			}
+			for _, id := range got {
+				if !wantSet[id] {
+					t.Errorf("%s\nagentsToManage() returned unexpected agent %q; want %v",
+						tt.desc, id, tt.want)
+				}
+			}
+		})
+	}
+}
+
+// TestPreselectedAgents_StateWinsOverDetection verifies that when a populated
+// InstallState is passed to preselectedAgents, it returns only the persisted
+// agents — not all detected config dirs.
+func TestPreselectedAgents_StateWinsOverDetection(t *testing.T) {
+	// 5 agents "detected" on filesystem.
+	detection := makeDetectionWithAgents("claude-code", "opencode", "gemini-cli", "cursor", "codex")
+
+	// state.json only lists 1 agent (the user's deliberate selection).
+	installState := state.InstallState{
+		InstalledAgents: []string{string(model.AgentClaudeCode)},
+	}
+
+	selected := preselectedAgents(detection, installState)
+
+	if len(selected) != 1 {
+		t.Fatalf("preselectedAgents() returned %d agents with populated state, want 1; got %v", len(selected), selected)
+	}
+	if selected[0] != model.AgentClaudeCode {
+		t.Errorf("preselectedAgents() returned %q, want %q", selected[0], model.AgentClaudeCode)
+	}
+}
+
+// TestNewModel_StateAgentsArePreselected verifies that NewModel uses the
+// supplied InstallState for pre-selection instead of detection.
+func TestNewModel_StateAgentsArePreselected(t *testing.T) {
+	// Filesystem: 3 agents detected.
+	detection := makeDetectionWithAgents("claude-code", "gemini-cli", "cursor")
+
+	// state.json: only 1 agent.
+	installState := state.InstallState{
+		InstalledAgents: []string{string(model.AgentGeminiCLI)},
+	}
+
+	m := NewModel(detection, "dev", installState)
+
+	if len(m.Selection.Agents) != 1 {
+		t.Fatalf("NewModel Selection.Agents = %v, want [%s]", m.Selection.Agents, model.AgentGeminiCLI)
+	}
+	if m.Selection.Agents[0] != model.AgentGeminiCLI {
+		t.Errorf("Selection.Agents[0] = %q, want %q", m.Selection.Agents[0], model.AgentGeminiCLI)
 	}
 }
 

--- a/internal/update/upgrade/executor.go
+++ b/internal/update/upgrade/executor.go
@@ -122,12 +122,36 @@ var backupExcludeSubdirs = map[string]bool{
 // Upgrade backups are rollback artifacts for files Gentle AI may create or
 // modify, not general-purpose backups of conversations, sessions, caches,
 // sockets, package installs, or other runtime state.
+//
+// Agent scope: when state.json exists with a non-empty InstalledAgents list,
+// only those agents' config paths are backed up — this is the canonical source
+// of truth established at install time. Filesystem detection is used only as a
+// fallback for fresh installs (no state.json yet). This prevents snapshot bloat
+// from agent config dirs that the user never actually installed via gentle-ai
+// (issue #354: snapshots could reach ~25 GiB from unmanaged config dirs).
 func configPathsForBackup(homeDir string, diagnostics ...io.Writer) []string {
 	dw := firstWriter(diagnostics...)
 	reg, err := agents.NewDefaultRegistry()
 	if err != nil {
 		writeBackupDiagnostic(dw, "backup: default agent registry unavailable: %v", err)
 		return managedGlobalBackupPaths(homeDir)
+	}
+
+	// Determine the canonical agent set to back up.
+	// Priority: persisted state.json InstalledAgents > filesystem detection.
+	var managedAgentIDs []model.AgentID
+	if s, stateErr := state.Read(homeDir); stateErr == nil && len(s.InstalledAgents) > 0 {
+		managedAgentIDs = make([]model.AgentID, 0, len(s.InstalledAgents))
+		for _, id := range s.InstalledAgents {
+			managedAgentIDs = append(managedAgentIDs, model.AgentID(id))
+		}
+		writeBackupDiagnostic(dw, "backup: using state.json agent list (%d agents) as backup scope", len(managedAgentIDs))
+	} else {
+		// Fallback: filesystem detection (first-time install or missing state.json).
+		for _, installed := range agents.DiscoverInstalled(reg, homeDir) {
+			managedAgentIDs = append(managedAgentIDs, installed.ID)
+		}
+		writeBackupDiagnostic(dw, "backup: state.json unavailable, falling back to filesystem detection (%d agents)", len(managedAgentIDs))
 	}
 
 	paths := make(map[string]struct{})
@@ -143,8 +167,8 @@ func configPathsForBackup(homeDir string, diagnostics ...io.Writer) []string {
 		}
 	}
 
-	for _, installed := range agents.DiscoverInstalled(reg, homeDir) {
-		adapter, ok := reg.Get(installed.ID)
+	for _, agentID := range managedAgentIDs {
+		adapter, ok := reg.Get(agentID)
 		if !ok {
 			continue
 		}

--- a/internal/update/upgrade/executor_test.go
+++ b/internal/update/upgrade/executor_test.go
@@ -13,6 +13,8 @@ import (
 	"testing"
 
 	"github.com/gentleman-programming/gentle-ai/internal/backup"
+	"github.com/gentleman-programming/gentle-ai/internal/model"
+	"github.com/gentleman-programming/gentle-ai/internal/state"
 	"github.com/gentleman-programming/gentle-ai/internal/system"
 	"github.com/gentleman-programming/gentle-ai/internal/update"
 )
@@ -1415,6 +1417,109 @@ func TestEnumerateFilesInDir_CaseInsensitiveExclude(t *testing.T) {
 	}
 	if _, ok := pathSet[mixedDir]; ok {
 		t.Errorf("mixed-case 'Cache' dir should be excluded by lowercase 'cache' key: %q", mixedDir)
+	}
+}
+
+// --- Phase 4: state.json-driven backup scope (issues #114, #354) ---
+
+// TestConfigPathsForBackup_StateWinsOverFilesystem verifies that when state.json
+// lists a subset of agents, configPathsForBackup backs up only those agents'
+// config paths — NOT all detected config dirs.
+//
+// Scenario: state.json has 1 agent (claude-code); filesystem also has gemini-cli.
+// Backup must include claude-code paths but NOT gemini-cli paths.
+func TestConfigPathsForBackup_StateWinsOverFilesystem(t *testing.T) {
+	homeDir := t.TempDir()
+
+	// Create both agent config dirs on disk (simulates filesystem detection).
+	claudeDir := filepath.Join(homeDir, ".claude")
+	geminiDir := filepath.Join(homeDir, ".gemini")
+	for _, dir := range []string{claudeDir, geminiDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	// Write a managed claude-code config file that should be backed up.
+	claudeSettings := filepath.Join(claudeDir, "settings.json")
+	if err := os.WriteFile(claudeSettings, []byte(`{}`), 0o644); err != nil {
+		t.Fatalf("write %s: %v", claudeSettings, err)
+	}
+	// Write a gemini config file that should NOT be backed up (not in state).
+	geminiSettings := filepath.Join(geminiDir, "settings.json")
+	if err := os.WriteFile(geminiSettings, []byte(`{}`), 0o644); err != nil {
+		t.Fatalf("write %s: %v", geminiSettings, err)
+	}
+
+	// Write state.json with only claude-code — this is the user's explicit selection.
+	if err := state.Write(homeDir, state.InstallState{
+		InstalledAgents: []string{string(model.AgentClaudeCode)},
+	}); err != nil {
+		t.Fatalf("state.Write: %v", err)
+	}
+
+	paths := configPathsForBackup(homeDir)
+	pathSet := make(map[string]struct{}, len(paths))
+	for _, p := range paths {
+		pathSet[p] = struct{}{}
+	}
+
+	// Gemini settings must NOT appear in backup — not in state.json.
+	if _, ok := pathSet[geminiSettings]; ok {
+		t.Errorf("configPathsForBackup included gemini-cli settings %q which is not in state.json; state.json should be the source of truth", geminiSettings)
+	}
+}
+
+// TestConfigPathsForBackup_FallsBackToFilesystemWhenNoState verifies that when
+// state.json does not exist, configPathsForBackup falls back to filesystem
+// detection — preserving the first-time install behavior.
+func TestConfigPathsForBackup_FallsBackToFilesystemWhenNoState(t *testing.T) {
+	homeDir := t.TempDir()
+
+	// Create a claude config dir on disk — no state.json.
+	claudeDir := filepath.Join(homeDir, ".claude")
+	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", claudeDir, err)
+	}
+	claudeSettings := filepath.Join(claudeDir, "settings.json")
+	if err := os.WriteFile(claudeSettings, []byte(`{}`), 0o644); err != nil {
+		t.Fatalf("write %s: %v", claudeSettings, err)
+	}
+
+	// No state.json written — simulates fresh install.
+	paths := configPathsForBackup(homeDir)
+
+	// Result must not be nil (empty slice is fine, but nil would panic callers).
+	if paths == nil {
+		t.Error("configPathsForBackup returned nil when state.json missing, want non-nil")
+	}
+}
+
+// TestConfigPathsForBackup_EmptyStateAgentsFallsBackToFilesystem verifies that
+// state.json with an empty InstalledAgents list is treated the same as a missing
+// state.json — filesystem detection is used as fallback.
+func TestConfigPathsForBackup_EmptyStateAgentsFallsBackToFilesystem(t *testing.T) {
+	homeDir := t.TempDir()
+
+	// Write state.json with an empty agent list.
+	if err := state.Write(homeDir, state.InstallState{
+		InstalledAgents: []string{},
+	}); err != nil {
+		t.Fatalf("state.Write: %v", err)
+	}
+
+	// Create a claude config dir on disk.
+	claudeDir := filepath.Join(homeDir, ".claude")
+	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", claudeDir, err)
+	}
+	claudeSettings := filepath.Join(claudeDir, "settings.json")
+	if err := os.WriteFile(claudeSettings, []byte(`{}`), 0o644); err != nil {
+		t.Fatalf("write %s: %v", claudeSettings, err)
+	}
+
+	paths := configPathsForBackup(homeDir)
+	if paths == nil {
+		t.Error("configPathsForBackup returned nil, want non-nil")
 	}
 }
 


### PR DESCRIPTION
## Linked Issues
Closes #114
Closes #354

## PR Type
- [x] type:bug

## Summary
Two TUI paths used filesystem detection as the source of truth for "which agents does gentle-ai manage":
- "Select AI Agents" pre-selection (#114) re-marked every agent that had a config dir on disk, ignoring the user's explicit prior selection persisted in `state.json`.
- Pre-upgrade backup (#354) scoped the snapshot to every detected config dir, including ones the user had unselected — one reporter saw snapshots balloon to ~25 GiB.

PR #667 already fixed the `--agent X` CLI overwrite. This PR addresses the remaining TUI + backup code paths.

## Fix
`state.InstalledAgents` is now the canonical source of truth. When `state.json` exists with a non-empty agent list, the TUI preselect and backup scope use those. Filesystem detection remains the fallback for first-time installs (state.json absent or empty).

## Changes
| File | Change |
|------|--------|
| `internal/tui/model.go` | Add `agentsToManage()` helper + `detectedAgentIDs()` extractor; update `preselectedAgents()` to accept `state.InstallState` and delegate to the helper; update `NewModel` with optional `installState` variadic param |
| `internal/app/app.go` | Read `state.json` before constructing the TUI model and pass it to `NewModel` |
| `internal/update/upgrade/executor.go` | `configPathsForBackup` reads `state.json` and limits backup scope to `InstalledAgents`; falls back to `DiscoverInstalled` when state is absent |
| `internal/tui/model_test.go` | Table-driven tests for `agentsToManage`, `preselectedAgents` state-wins-over-detection, and `NewModel` state pre-selection |
| `internal/update/upgrade/executor_test.go` | Tests for backup scope: state wins, fallback to filesystem, empty state falls back |

## Test Plan
- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [x] `go build` clean

## Contributor Checklist
- [x] Linked to approved issues (#114, #354)
- [x] Under 400 changed lines
- [x] Conventional Commits format
- [x] No Co-Authored-By trailers