### PR TITLE
fix(windows): skip directory fsync on Windows where the syscall is not supported

### DIFF
--- a/internal/components/filemerge/writer.go
+++ b/internal/components/filemerge/writer.go
@@ -13,6 +13,15 @@ import (
 
 // runtimeGOOS and syncDirFn are package-level vars so tests can override them
 // without spawning a real Windows process.
+//
+// Background: Windows/NTFS does not support fsyncing a directory file
+// descriptor. Calling (*os.File).Sync() on a directory handle returns
+// ERROR_ACCESS_DENIED (syscall 5) regardless of user privileges — even as
+// Administrator. FlushFileBuffers requires GENERIC_WRITE access on the handle,
+// which Windows refuses for directories. The ErrPermission from syncDirFn is
+// therefore silently tolerated when runtimeGOOS() == "windows". On Linux and
+// macOS the full error is propagated so unexpected failures are still surfaced.
+// See issues #293 and #294.
 var runtimeGOOS = func() string { return runtime.GOOS }
 var syncDirFn = func(dir string) error {
 	fd, err := os.Open(dir)


### PR DESCRIPTION
## Linked Issue
Closes #294

## PR Type
- [x] type:bug

## Summary
`gentle-ai install` failed on Windows with `Access is denied` whenever it tried to fsync parent directories after writing files. POSIX-style directory fsync is a Linux/macOS pattern; Windows doesn't expose the equivalent syscall and rejects the operation. The installer's rollback path was triggering on every component write, leaving installs incomplete.

This PR expands the inline documentation on the Windows directory-fsync skip that was partially addressed in #296 (which closed #293). Issue #294 is a separate report of the same root cause and was not explicitly linked.

File-content fsync is unchanged — only the directory-entry sync is no-op on Windows where the syscall isn't supported.

## Trade-off
On Windows we lose the strict directory-entry durability guarantee that the POSIX path gives. That's accepted: the syscall doesn't exist on Windows, and the file content sync still provides reasonable durability for the user-config files this code path writes.

## Changes
| File | Change |
|------|--------|
| `internal/components/filemerge/writer.go` | Expand doc comment on `runtimeGOOS`/`syncDirFn` vars to explain the Windows limitation and reference both issues #293 and #294 |

## Test Plan
- [x] `go test ./internal/components/filemerge/...` passes (all 8 tests including the 3 injectable Windows/Unix/unexpected-error tests)
- [x] `go vet ./...` clean
- [x] `go build ./...` clean

## Contributor Checklist
- [x] Linked to approved issue (#294)
- [x] Under 400 changed lines
- [x] Conventional Commits format
- [x] No Co-Authored-By trailers