### PR TITLE
fix(agents/codex): write AGENTS.md with correct uppercase case

### DIFF
--- a/internal/agents/codex/adapter.go
+++ b/internal/agents/codex/adapter.go
@@ -86,7 +86,7 @@ func (a *Adapter) SystemPromptDir(homeDir string) string {
 }
 
 func (a *Adapter) SystemPromptFile(homeDir string) string {
-	return filepath.Join(homeDir, ".codex", "agents.md")
+	return filepath.Join(homeDir, ".codex", "AGENTS.md")
 }
 
 func (a *Adapter) SkillsDir(homeDir string) string {

--- a/internal/agents/codex/adapter_test.go
+++ b/internal/agents/codex/adapter_test.go
@@ -145,8 +145,8 @@ func TestConfigPathsCrossPlatform(t *testing.T) {
 		t.Fatalf("SkillsDir() = %q, want %q", got, filepath.Join(home, ".codex", "skills"))
 	}
 
-	if got := a.SystemPromptFile(home); got != filepath.Join(home, ".codex", "agents.md") {
-		t.Fatalf("SystemPromptFile() = %q, want %q", got, filepath.Join(home, ".codex", "agents.md"))
+	if got := a.SystemPromptFile(home); got != filepath.Join(home, ".codex", "AGENTS.md") {
+		t.Fatalf("SystemPromptFile() = %q, want %q", got, filepath.Join(home, ".codex", "AGENTS.md"))
 	}
 
 	// Codex has no settings path.
@@ -162,6 +162,19 @@ func TestConfigPathsCrossPlatform(t *testing.T) {
 	// Server name argument is ignored — always returns config.toml.
 	if got := a.MCPConfigPath(home, "ctx7"); got != want {
 		t.Fatalf("MCPConfigPath(ctx7) = %q, want %q (server name should be ignored)", got, want)
+	}
+}
+
+// TestAdapterSystemPromptFile_UsesUppercaseAGENTSmd asserts that the system
+// prompt file path uses the exact uppercase filename "AGENTS.md" that the
+// codex CLI expects. Lowercase "agents.md" causes the file to be silently
+// ignored on case-sensitive filesystems (Linux) — regression for #299.
+func TestAdapterSystemPromptFile_UsesUppercaseAGENTSmd(t *testing.T) {
+	a := NewAdapter()
+	got := a.SystemPromptFile("/home/user")
+	const want = "AGENTS.md"
+	if filepath.Base(got) != want {
+		t.Fatalf("SystemPromptFile() base = %q, want %q (codex CLI requires uppercase AGENTS.md)", filepath.Base(got), want)
 	}
 }
 

--- a/internal/components/golden_test.go
+++ b/internal/components/golden_test.go
@@ -304,8 +304,8 @@ func TestGoldenSDD_Codex(t *testing.T) {
 		t.Fatalf("sdd.Inject(codex) changed = false")
 	}
 
-	// Codex writes SDD orchestrator to ~/.codex/agents.md.
-	agentsMD := readTestFile(t, filepath.Join(home, ".codex", "agents.md"))
+	// Codex writes SDD orchestrator to ~/.codex/AGENTS.md.
+	agentsMD := readTestFile(t, filepath.Join(home, ".codex", "AGENTS.md"))
 	assertGolden(t, "sdd-codex-agentsmd.golden", agentsMD)
 
 	// Golden-check a representative SDD skill file.

--- a/internal/components/sdd/inject_test.go
+++ b/internal/components/sdd/inject_test.go
@@ -3460,8 +3460,8 @@ func TestInjectCodexWritesSDDOrchestratorAndSkills(t *testing.T) {
 		t.Fatal("Inject(codex) changed = false")
 	}
 
-	// Verify SDD orchestrator was injected into agents.md.
-	promptPath := filepath.Join(home, ".codex", "agents.md")
+	// Verify SDD orchestrator was injected into AGENTS.md.
+	promptPath := filepath.Join(home, ".codex", "AGENTS.md")
 	content, readErr := os.ReadFile(promptPath)
 	if readErr != nil {
 		t.Fatalf("ReadFile(%q) error = %v", promptPath, readErr)

--- a/internal/update/upgrade/executor_test.go
+++ b/internal/update/upgrade/executor_test.go
@@ -878,7 +878,8 @@ func TestConfigPathsForBackup_CoversRegistryAgentsNotInOldList(t *testing.T) {
 	homeDir := t.TempDir()
 
 	// Create a file under codex config dir — not in old hardcoded list.
-	codexFile := filepath.Join(homeDir, ".codex", "agents.md")
+	// Use uppercase AGENTS.md to match the codex CLI convention (fix for #299).
+	codexFile := filepath.Join(homeDir, ".codex", "AGENTS.md")
 	if err := os.MkdirAll(filepath.Dir(codexFile), 0o755); err != nil {
 		t.Fatalf("MkdirAll: %v", err)
 	}


### PR DESCRIPTION
## Linked Issue
Closes #299

## PR Type
- [x] type:bug

## Summary
The codex adapter wrote `agents.md` (all lowercase) as the system-prompt file path, causing codex's CLI to not find the file on case-sensitive filesystems (Linux). The codex CLI documents the file as `AGENTS.md` (uppercase) — the adapter now matches.

## Cross-agent note
Codex-specific. Other agents use their own filename conventions (Claude → `CLAUDE.md`, OpenCode → `AGENTS.md` already correct, etc.) — those are unchanged.

## Changes
| File | Change |
|------|--------|
| `internal/agents/codex/adapter.go` | Use `AGENTS.md` (uppercase) for system prompt file path |
| `internal/agents/codex/adapter_test.go` | Update existing assertion + add `TestAdapterSystemPromptFile_UsesUppercaseAGENTSmd` regression test |
| `internal/update/upgrade/executor_test.go` | Update golden fixture to match corrected uppercase filename |

## Test Plan
- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [x] `go build` clean

## Contributor Checklist
- [x] Linked to approved issue (#299)
- [x] Under 400 changed lines
- [x] Conventional Commits format
- [x] No Co-Authored-By trailers