### PR TITLE
fix(installer): align auto-detect order with docs (brew → go-install → binary)

### DIFF
--- a/internal/system/detect.go
+++ b/internal/system/detect.go
@@ -21,6 +21,7 @@ type PlatformProfile struct {
 	LinuxDistro    string
 	PackageManager string
 	NpmWritable    bool // true when npm global prefix is user-writable (nvm/fnm/volta)
+	GoAvailable    bool // true when `go` is found on PATH (used for auto-detect: brew → go-install → binary)
 	Supported      bool
 }
 
@@ -49,7 +50,7 @@ func Detect(ctx context.Context) (DetectionResult, error) {
 		return DetectionResult{}, err
 	}
 
-	tools := DetectTools(ctx, []string{"git", "curl", "brew", "node"})
+	tools := DetectTools(ctx, []string{"git", "curl", "brew", "node", "go"})
 	configs := ScanConfigs(homeDir)
 	osReleaseContent, _ := osReleaseContent(runtime.GOOS)
 
@@ -115,6 +116,11 @@ func osReleaseContent(goos string) (string, error) {
 
 func resolvePlatformProfile(goos, linuxOSRelease string, tools map[string]ToolStatus) PlatformProfile {
 	profile := PlatformProfile{OS: goos}
+
+	// Detect Go availability for the brew → go-install → binary auto-detect order.
+	if go_, ok := tools["go"]; ok && go_.Installed {
+		profile.GoAvailable = true
+	}
 
 	switch goos {
 	case "darwin":

--- a/internal/system/detect_test.go
+++ b/internal/system/detect_test.go
@@ -306,6 +306,47 @@ func TestResolvePlatformProfileMatrix(t *testing.T) {
 	}
 }
 
+// TestGoAvailableInPlatformProfile asserts that GoAvailable in PlatformProfile
+// reflects whether `go` is present in the tools map. This is the detection signal
+// used by effectiveMethod to implement the brew → go-install → binary auto-detect order.
+func TestGoAvailableInPlatformProfile(t *testing.T) {
+	tests := []struct {
+		name         string
+		tools        map[string]ToolStatus
+		wantGoAvail  bool
+	}{
+		{
+			name:        "go in tools and installed → GoAvailable true",
+			tools:       map[string]ToolStatus{"go": {Name: "go", Installed: true}},
+			wantGoAvail: true,
+		},
+		{
+			name:        "go in tools but not installed → GoAvailable false",
+			tools:       map[string]ToolStatus{"go": {Name: "go", Installed: false}},
+			wantGoAvail: false,
+		},
+		{
+			name:        "go not in tools map → GoAvailable false",
+			tools:       map[string]ToolStatus{"brew": {Name: "brew", Installed: true}},
+			wantGoAvail: false,
+		},
+		{
+			name:        "nil tools map → GoAvailable false",
+			tools:       nil,
+			wantGoAvail: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			profile := resolvePlatformProfile("linux", "ID=ubuntu\nID_LIKE=debian\n", tc.tools)
+			if profile.GoAvailable != tc.wantGoAvail {
+				t.Fatalf("GoAvailable = %v, want %v", profile.GoAvailable, tc.wantGoAvail)
+			}
+		})
+	}
+}
+
 func TestDetectFromInputsShellDefaultsToUnknown(t *testing.T) {
 	result := detectFromInputs("darwin", "arm64", "", "", nil, nil)
 	if result.System.Shell != "unknown" {

--- a/internal/update/upgrade/executor.go
+++ b/internal/update/upgrade/executor.go
@@ -582,13 +582,22 @@ func executeOne(ctx context.Context, r update.UpdateResult, profile system.Platf
 }
 
 // effectiveMethod resolves the actual upgrade strategy for a tool on a given platform.
-// On brew-managed platforms, brew takes precedence over the tool's declared method.
+// Priority order matches the documented install hierarchy: brew → go-install → binary.
+//
+//  1. OpenCode plugins are always handled by their own method — never overridden.
+//  2. Brew-managed platforms always use brew regardless of the tool's declared method.
+//  3. When Go is available on PATH and the tool has a GoImportPath, go-install is
+//     preferred over a direct binary download.
+//  4. Otherwise the tool's declared InstallMethod is used as-is.
 func effectiveMethod(tool update.ToolInfo, profile system.PlatformProfile) update.InstallMethod {
 	if tool.InstallMethod == update.InstallOpenCodePlugin {
 		return update.InstallOpenCodePlugin
 	}
 	if profile.PackageManager == "brew" {
 		return update.InstallBrew
+	}
+	if profile.GoAvailable && tool.GoImportPath != "" {
+		return update.InstallGoInstall
 	}
 	return tool.InstallMethod
 }

--- a/internal/update/upgrade/strategy_test.go
+++ b/internal/update/upgrade/strategy_test.go
@@ -266,6 +266,31 @@ func TestEffectiveMethod(t *testing.T) {
 			profile: system.PlatformProfile{PackageManager: "brew"},
 			want:    update.InstallOpenCodePlugin,
 		},
+		// Auto-detect order: brew → go-install → binary (issue #246).
+		{
+			name:    "auto-detect: brew available → brew wins regardless of GoImportPath",
+			tool:    update.ToolInfo{Name: "mytool", InstallMethod: update.InstallBinary, GoImportPath: "github.com/example/mytool/cmd/mytool"},
+			profile: system.PlatformProfile{PackageManager: "brew", GoAvailable: true},
+			want:    update.InstallBrew,
+		},
+		{
+			name:    "auto-detect: brew missing + go available + GoImportPath set → go-install",
+			tool:    update.ToolInfo{Name: "mytool", InstallMethod: update.InstallBinary, GoImportPath: "github.com/example/mytool/cmd/mytool"},
+			profile: system.PlatformProfile{PackageManager: "apt", GoAvailable: true},
+			want:    update.InstallGoInstall,
+		},
+		{
+			name:    "auto-detect: brew missing + go missing + GoImportPath set → binary fallback",
+			tool:    update.ToolInfo{Name: "mytool", InstallMethod: update.InstallBinary, GoImportPath: "github.com/example/mytool/cmd/mytool"},
+			profile: system.PlatformProfile{PackageManager: "apt", GoAvailable: false},
+			want:    update.InstallBinary,
+		},
+		{
+			name:    "auto-detect: go available but GoImportPath empty → binary (no upgrade)",
+			tool:    update.ToolInfo{Name: "mytool", InstallMethod: update.InstallBinary, GoImportPath: ""},
+			profile: system.PlatformProfile{PackageManager: "apt", GoAvailable: true},
+			want:    update.InstallBinary,
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
## Linked Issue

Closes #246

## PR Type

- [x] `type:bug`

## Summary

The installer's PRD (section 9.1) describes auto-detect priority as **brew → go-install → binary**, but `effectiveMethod` in `internal/update/upgrade/executor.go` was using **brew → binary** and never auto-selected `go-install`. The `InstallGoInstall` strategy and `GoImportPath` field already existed as infrastructure — auto-detect just never used them.

**Path A chosen** (code aligns to docs) because:
- Docs were the original spec.
- Users on Linux/dev setups expect `go install` to be tried before downloading a release binary they didn't ask for.
- The infrastructure was already in place; this is closing the loop.

## Changes

| File | Change |
|------|--------|
| `internal/system/detect.go` | Add `GoAvailable bool` to `PlatformProfile`; resolver checks for `go` in detected tools |
| `internal/update/upgrade/executor.go` | `effectiveMethod` priority: OpenCodePlugin → brew → go-install (when `GoAvailable && GoImportPath != ""`) → declared method |
| `internal/system/detect_test.go` | New `TestGoAvailableInPlatformProfile` (4 cases) |
| `internal/update/upgrade/strategy_test.go` | 4 new auto-detect order cases in `TestEffectiveMethod` |

## Test Plan

- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [x] `go build` clean

## Contributor Checklist

- [x] Linked to approved issue (#246)
- [x] Under 400 changed lines (83 LOC)
- [x] Conventional Commits format
- [x] No Co-Authored-By trailers