### PR TITLE
chore(ci): pin GitHub Actions to immutable commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version-file: go.mod
 
@@ -41,13 +41,13 @@ jobs:
             dockerfile: Dockerfile.fedora
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
 
       - name: Build E2E image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7.2.0
         with:
           context: .
           file: e2e/${{ matrix.platform.dockerfile }}

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Verify PR stays within review budget
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7.1.0
         with:
           script: |
             const limit = 400;
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Verify PR body references an issue
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7.1.0
         with:
           script: |
             const body = context.payload.pull_request.body || '';
@@ -73,7 +73,7 @@ jobs:
     needs: check-issue-reference
     steps:
       - name: Verify linked issue(s) have status:approved label
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7.1.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -128,7 +128,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Verify PR has exactly one type:* label
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7.1.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,17 +13,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version-file: go.mod
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89  # v7.2.2
         with:
           version: "~> v2"
           args: release --clean


### PR DESCRIPTION
## Linked Issue
Closes #361

## PR Type
- [x] type:chore

## Summary
GitHub Actions workflows used floating tags (`@v4`, `@v5`, `@v6`, `@v7`) which widen the supply-chain blast radius — a moved tag executes new code on every CI run. This PR pins every action to its immutable commit SHA at this PR's time, keeping the version tag as a comment for readability.

## Pattern
```yaml
- uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
```

## Changes
| File | Actions pinned |
|------|----------------|
| `.github/workflows/ci.yml` | `actions/checkout@v5` (×2), `actions/setup-go@v6`, `docker/setup-buildx-action@v4`, `docker/build-push-action@v7` |
| `.github/workflows/pr-check.yml` | `actions/github-script@v7` (×4) |
| `.github/workflows/release.yml` | `actions/checkout@v5`, `actions/setup-go@v6`, `goreleaser/goreleaser-action@v7` |

## Follow-up
Dependabot/Renovate can be configured to track SHA bumps automatically — recommend opening a separate issue if not already configured.

## Test Plan
- [x] All workflow YAML still parses
- [x] No Go code changed