### PR TITLE
feat(tui): merge custom providers from opencode.json into model picker

### DIFF
--- a/internal/opencode/models.go
+++ b/internal/opencode/models.go
@@ -307,8 +307,9 @@ func LoadConfigProviders(path string) (map[string]ConfigProvider, error) {
 
 // MergeCustomProviders merges custom providers from opencode.json into the cache-loaded
 // providers map. Custom models use the tool_call value from opencode.json, defaulting to false
-// when omitted. Cache models win on ID collision. Returns the original providers map unchanged
-// when config is empty; otherwise returns a merged copy without mutating the input.
+// when omitted. Custom entries win on ID collision (user-managed beats cached catalog).
+// Returns the original providers map unchanged when config is empty; otherwise returns a
+// merged copy without mutating the input.
 func MergeCustomProviders(providers map[string]Provider, config map[string]ConfigProvider) map[string]Provider {
 	if len(config) == 0 {
 		return providers
@@ -325,7 +326,7 @@ func MergeCustomProviders(providers map[string]Provider, config map[string]Confi
 
 	for id, cp := range config {
 		// Provider-level collision: when a provider ID already exists in the cache,
-		// we keep the cache's Name/Env and only merge in the config's models below.
+		// we keep the cache's Name/Env and merge in the config's models below.
 		// The config's provider Name is silently ignored in that case.
 		existing, ok := merged[id]
 		if !ok {
@@ -335,13 +336,12 @@ func MergeCustomProviders(providers map[string]Provider, config map[string]Confi
 			existing.Models = make(map[string]Model, len(cp.Models))
 		}
 		for mid, cm := range cp.Models {
-			if _, exists := existing.Models[mid]; !exists {
-				name := cm.Name
-				if name == "" {
-					name = mid
-				}
-				existing.Models[mid] = Model{ID: mid, Name: name, ToolCall: cm.ToolCall}
+			// Custom entry wins on model ID collision (user-managed beats cached catalog).
+			name := cm.Name
+			if name == "" {
+				name = mid
 			}
+			existing.Models[mid] = Model{ID: mid, Name: name, ToolCall: cm.ToolCall}
 		}
 		merged[id] = existing
 	}

--- a/internal/opencode/models_test.go
+++ b/internal/opencode/models_test.go
@@ -645,25 +645,25 @@ func TestMergeCustomProvidersDefaultsToolCallToFalse(t *testing.T) {
 	}
 }
 
-func TestMergeCustomProvidersModelCollisionCacheWins(t *testing.T) {
+func TestMergeCustomProvidersModelCollisionCustomWins(t *testing.T) {
 	providers := map[string]Provider{
 		"lmstudio": {ID: "lmstudio", Name: "LMStudio", Models: map[string]Model{
-			"shared-model": {ID: "shared-model", Name: "Cache Name", ToolCall: true, Cost: ModelCost{Input: 5.0}},
+			"shared-model": {ID: "shared-model", Name: "Cache Name", ToolCall: false, Cost: ModelCost{Input: 5.0}},
 		}},
 	}
 	config := map[string]ConfigProvider{
 		"lmstudio": {Models: map[string]ConfigModel{
-			"shared-model": {Name: "Config Name"},
+			"shared-model": {Name: "Config Name", ToolCall: true},
 		}},
 	}
 
 	merged := MergeCustomProviders(providers, config)
 	m := merged["lmstudio"].Models["shared-model"]
-	if m.Name != "Cache Name" {
-		t.Fatalf("model name = %q, want %q (cache should win)", m.Name, "Cache Name")
+	if m.Name != "Config Name" {
+		t.Fatalf("model name = %q, want %q (custom should win)", m.Name, "Config Name")
 	}
-	if m.Cost.Input != 5.0 {
-		t.Fatal("cache cost metadata should be preserved on collision")
+	if !m.ToolCall {
+		t.Fatal("custom ToolCall=true should win over cache ToolCall=false on collision")
 	}
 }
 

--- a/internal/tui/screens/model_picker_test.go
+++ b/internal/tui/screens/model_picker_test.go
@@ -1,6 +1,8 @@
 package screens
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -942,4 +944,182 @@ func TestIndividualPhaseSelectionDoesNotSetAllPhasesModel(t *testing.T) {
 			}
 		})
 	}
+}
+
+// ─── NewModelPickerState: custom provider merging ─────────────────────────────
+
+// catalogJSON is a minimal OpenCode models cache with one built-in provider.
+const catalogJSON = `{
+  "built-in": {
+    "id": "built-in",
+    "name": "Built-In Provider",
+    "env": ["BUILTIN_API_KEY"],
+    "models": {
+      "builtin-model": {
+        "id": "builtin-model",
+        "name": "Built-In Model",
+        "tool_call": true
+      }
+    }
+  }
+}`
+
+// writeTempFile writes content to a file in a temp dir and returns the path.
+func writeTempFile(t *testing.T, name, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write temp file %q: %v", path, err)
+	}
+	return path
+}
+
+func TestNewModelPickerState(t *testing.T) {
+	tests := []struct {
+		name              string
+		cacheContent      string   // non-empty means write a cache file; empty means skip
+		settingsContent   string   // non-empty means write settings file; empty means use missing path
+		wantProviderIDs   []string // provider IDs that must appear in Providers map
+		wantAvailable     int      // minimum number of AvailableIDs (custom providers always count)
+		wantConfigWarning bool     // whether ConfigWarning must be non-empty
+	}{
+		{
+			name:            "missing opencode.json falls back to catalog only",
+			cacheContent:    catalogJSON,
+			settingsContent: "", // no file written → path points to nonexistent file
+			wantProviderIDs: []string{"built-in"},
+			wantAvailable:   0, // no env var set → built-in not available; just checking providers map
+			wantConfigWarning: false,
+		},
+		{
+			name:            "opencode.json with no provider key gives catalog only",
+			cacheContent:    catalogJSON,
+			settingsContent: `{"agent": {}}`,
+			wantProviderIDs: []string{"built-in"},
+			wantAvailable:   0,
+			wantConfigWarning: false,
+		},
+		{
+			name:         "opencode.json with 2 custom providers adds both to picker",
+			cacheContent: catalogJSON,
+			settingsContent: `{
+				"provider": {
+					"custom-a": {
+						"name": "Custom A",
+						"models": {"model-a1": {"name": "Model A1", "tool_call": true}}
+					},
+					"custom-b": {
+						"name": "Custom B",
+						"models": {"model-b1": {"name": "Model B1", "tool_call": true}}
+					}
+				}
+			}`,
+			wantProviderIDs: []string{"built-in", "custom-a", "custom-b"},
+			wantAvailable:   2, // custom-a and custom-b are always available as custom providers
+			wantConfigWarning: false,
+		},
+		{
+			name:         "name collision: custom provider wins over catalog",
+			cacheContent: catalogJSON,
+			settingsContent: `{
+				"provider": {
+					"built-in": {
+						"name": "My Override",
+						"models": {
+							"builtin-model": {"name": "Custom Override Name", "tool_call": true}
+						}
+					}
+				}
+			}`,
+			wantProviderIDs: []string{"built-in"},
+			wantAvailable:   1, // "built-in" now treated as custom → always available
+			wantConfigWarning: false,
+		},
+		{
+			name:            "malformed opencode.json produces config warning",
+			cacheContent:    catalogJSON,
+			settingsContent: `{"provider":`, // truncated / invalid JSON
+			wantProviderIDs: []string{"built-in"},
+			wantAvailable:   0,
+			wantConfigWarning: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Write the cache file.
+			cachePath := writeTempFile(t, "models.json", tt.cacheContent)
+
+			// Determine settings path — missing when settingsContent is empty.
+			var settingsPath string
+			if tt.settingsContent != "" {
+				settingsPath = writeTempFile(t, "opencode.json", tt.settingsContent)
+			} else {
+				settingsPath = filepath.Join(t.TempDir(), "nonexistent.json")
+			}
+
+			state := NewModelPickerState(cachePath, settingsPath)
+
+			// All expected provider IDs must appear in the Providers map.
+			for _, id := range tt.wantProviderIDs {
+				if _, ok := state.Providers[id]; !ok {
+					t.Errorf("Providers missing %q; got keys: %v", id, providerKeys(state.Providers))
+				}
+			}
+
+			// AvailableIDs count must meet the minimum.
+			if len(state.AvailableIDs) < tt.wantAvailable {
+				t.Errorf("AvailableIDs = %v (count %d), want at least %d",
+					state.AvailableIDs, len(state.AvailableIDs), tt.wantAvailable)
+			}
+
+			// ConfigWarning check.
+			if tt.wantConfigWarning && state.ConfigWarning == "" {
+				t.Error("expected ConfigWarning to be set, got empty string")
+			}
+			if !tt.wantConfigWarning && state.ConfigWarning != "" {
+				t.Errorf("expected no ConfigWarning, got %q", state.ConfigWarning)
+			}
+		})
+	}
+}
+
+// TestNewModelPickerStateCollisionCustomWins verifies that when a model ID exists
+// in both the catalog cache and opencode.json, the custom entry takes precedence.
+func TestNewModelPickerStateCollisionCustomWins(t *testing.T) {
+	cachePath := writeTempFile(t, "models.json", catalogJSON)
+	settingsPath := writeTempFile(t, "opencode.json", `{
+		"provider": {
+			"built-in": {
+				"name": "Built-In Provider",
+				"models": {
+					"builtin-model": {"name": "Custom Override Name", "tool_call": true}
+				}
+			}
+		}
+	}`)
+
+	state := NewModelPickerState(cachePath, settingsPath)
+
+	p, ok := state.Providers["built-in"]
+	if !ok {
+		t.Fatal("expected built-in provider in state")
+	}
+	m, ok := p.Models["builtin-model"]
+	if !ok {
+		t.Fatal("expected builtin-model in built-in provider")
+	}
+	if m.Name != "Custom Override Name" {
+		t.Errorf("model name = %q, want %q (custom should win on collision)", m.Name, "Custom Override Name")
+	}
+}
+
+// providerKeys returns the keys of a Provider map for test error messages.
+func providerKeys(providers map[string]opencode.Provider) []string {
+	keys := make([]string, 0, len(providers))
+	for k := range providers {
+		keys = append(keys, k)
+	}
+	return keys
 }


### PR DESCRIPTION
## Linked Issue

Closes #392

## PR Type

- [x] `type:feature`

## Summary

The TUI model picker loaded providers only from the cached opencode catalog (`~/.cache/opencode/models.json`), ignoring custom providers declared in the user's `opencode.json`. Result: the picker showed FEWER providers than the user's own `opencode /models` command.

This PR merges custom providers from `opencode.json` into the picker source. On model-ID collision, the **custom entry wins** (user-managed beats cached catalog) — that's the right policy because users declare custom providers precisely to override defaults.

## Cross-agent note

OpenCode-specific (custom providers are an OpenCode feature). Other adapters don't have an equivalent extension mechanism — left unchanged.

## Changes

| File | Change |
|------|--------|
| `internal/opencode/models.go` | `MergeCustomProviders` collision policy: custom wins over cached catalog |
| `internal/opencode/models_test.go` | Renamed + updated collision test to assert custom-wins |
| `internal/tui/screens/model_picker_test.go` | 5 new table-driven tests + dedicated collision test for `NewModelPickerState` |

## Test Plan

- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [x] `go build` clean

## Contributor Checklist

- [x] Linked to approved issue (#392)
- [x] Under 400 changed lines (196 LOC)
- [x] Conventional Commits format
- [x] No Co-Authored-By trailers