### PR TITLE
docs: sync user-facing docs with v1.31.0 + v1.32.0 changes

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -453,12 +453,12 @@ curl -sL get.gentleman.ai/ai | sh
      ┌─────────────────────────────────┐
      │  Select Ecosystem Preset         │
      │                                  │
-     │  ★ Full Gentleman                │  ← Everything: Engram + SDD + Skills
+     │  ★ Dev Stack + Polish             │  ← Everything: Engram + SDD + Skills
      │     (Engram + SDD + All Skills   │     + MCP + Theme + Permissions
      │      + MCP + Theme)              │
      │                                  │
-     │  ○ Ecosystem Only                │  ← Tools without persona
-     │  ○ Minimal                       │  ← Just Engram + basics
+     │  ○ Dev Stack                     │  ← Tools without persona
+     │  ○ Memory Only                   │  ← Just Engram + basics
      │  ○ Custom                        │  ← Pick each component
      └──────────┬──────────────────────┘
                 │
@@ -557,7 +557,7 @@ gentle-ai install \
 | System Detection | Show detected OS, existing tools, existing configs, installed dependencies |
 | Agent Selection | Multi-select AI agents to install/configure |
 | Persona Selection | "Your own Gentleman!" / Neutral / Custom |
-| Preset Selection | Full Gentleman / Ecosystem Only / Minimal / Custom |
+| Preset Selection | Dev Stack + Polish / Dev Stack / Memory Only / Custom |
 | MCP Server Selection | Which MCP integrations to enable (Custom mode) |
 | Skills Selection | Which coding skills to install (Custom mode) |
 | Config Customization | Theme, permissions, editor mode (Custom mode) |
@@ -1081,8 +1081,8 @@ gentle-ai/
 │   │   ├── skills.go               # Skills library install
 │   │   └── config.go               # Persona, theme, permissions, etc.
 │   ├── presets/
-│   │   ├── gentleman.go            # Full Gentleman preset definition
-│   │   ├── minimal.go              # Minimal preset definition
+│   │   ├── gentleman.go            # Dev Stack + Polish preset definition (`full-gentleman`)
+│   │   ├── minimal.go              # Memory Only preset definition (`minimal`)
 │   │   └── preset.go               # Preset interface
 │   ├── backup/
 │   │   └── backup.go               # Config backup & restore
@@ -1166,12 +1166,14 @@ type Preset struct {
 
 **Predefined presets:**
 
-| Preset | What's Included | Persona | Description |
-|--------|----------------|---------|-------------|
-| `full-gentleman` | All agents detected + Engram + SDD + all skills + MCP + theme | "Your own Gentleman!" | The complete experience. Everything configured, Gentleman persona, dark theme, the works. |
-| `ecosystem-only` | Engram + SDD + skills + MCP for selected agents | Neutral (no persona) | All the tools and workflow, zero personality. For developers who want the ecosystem but prefer their agent's default behavior. |
-| `minimal` | Engram + basic skills for selected agents | Neutral | Just memory and essential skills. Quick and lean. |
-| `custom` | User picks each component | User picks | Full control over every aspect. |
+Persona is selected separately on the Persona screen and applied independently of the preset.
+
+| Preset | Display Label | What's Included | Description |
+|--------|--------------|-----------------|-------------|
+| `full-gentleman` | Dev Stack + Polish | All agents detected + Engram + SDD + all skills + MCP + theme | The complete experience. Everything configured, dark theme, the works. |
+| `ecosystem-only` | Dev Stack | Engram + SDD + skills + MCP for selected agents | All the tools and workflow. For developers who want the ecosystem without opinionated defaults. |
+| `minimal` | Memory Only | Engram + basic skills for selected agents | Just memory and essential skills. Quick and lean. |
+| `custom` | Custom | User picks each component | Full control over every aspect. |
 
 ---
 
@@ -1232,7 +1234,7 @@ type Preset struct {
 
 ### 11.1 What the User Gets After Installation
 
-When the installer completes with "Full Gentleman" preset + Claude Code + OpenCode:
+When the installer completes with "Dev Stack + Polish" (`full-gentleman`) preset + Claude Code + OpenCode:
 
 **Claude Code:**
 - `~/.claude/CLAUDE.md` — Gentleman persona with SDD orchestrator
@@ -1383,10 +1385,10 @@ These are NOT requirements for v1 but should inform architectural decisions:
 ## Appendix B: Example Non-Interactive Commands
 
 ```bash
-# Full Gentleman preset with Claude Code + OpenCode
+# Dev Stack + Polish preset with Claude Code + OpenCode
 gentle-ai install --preset gentleman --agents claude-code,opencode
 
-# Minimal setup, just Claude Code with basic security
+# Memory Only setup, just Claude Code with basic security
 gentle-ai install --preset minimal --agents claude-code
 
 # Team provisioning from shared profile

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Gentle-AI is NOT an AI agent installer. Most agents are easy to install. It is a
 
 **After**: Your agent now has memory, skills, workflow, MCP tools, and a persona that actually teaches you.
 
-### 13 Supported Agents
+### 14 Supported Agents
 
 | Agent               |         Delegation Model         | Key Feature                                                     |
 | ------------------- | :------------------------------: | --------------------------------------------------------------- |
@@ -42,6 +42,7 @@ Gentle-AI is NOT an AI agent installer. Most agents are easy to install. It is a
 | **Kiro IDE**        |     Full (native subagents)      | Native `~/.kiro/agents/` + steering orchestration               |
 | **Qwen Code**       |     Full (native sub-agents)     | Slash commands, `~/.qwen/commands/`, `auto_edit` mode           |
 | **OpenClaw**        |            Solo-agent            | Workspace-first `AGENTS.md` / `SOUL.md` with global MCP config  |
+| **Trae**            |            Solo-agent            | Desktop app by ByteDance; `~/.trae/skills/` + OS-specific rules |
 | **Pi**              | Full (package-managed subagents) | `gentle-pi` harness with persona/model commands + Engram memory |
 
 > **Note**: This project supersedes [Agent Teams Lite](https://github.com/Gentleman-Programming/agent-teams-lite) (now archived). Everything ATL provided is included here with better installation, automatic updates, and persistent memory.
@@ -88,6 +89,8 @@ Once your agents are configured, open your AI agent in a project and run these t
 | `gentle-ai skill-registry refresh` | Scans installed skills and project conventions, builds the registry         | After installing/removing skills, or first time in a new project               |
 
 These are **not required** for basic usage. The SDD orchestrator runs `/sdd-init` automatically if it detects no context. Startup hooks normally keep the skill registry fresh for agents that support hooks, including Pi through `gentle-pi`. If you start Pi with `pi -ns`, startup skill loading/hooks are skipped, so run the registry refresh manually when you need updated project rules.
+
+Run `gentle-ai doctor` at any time for a read-only health check of your ecosystem (tool binaries, `state.json`, Engram reachability, disk space).
 
 ---
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -21,6 +21,7 @@
 | Qwen Code       | `qwen-code`      | Yes          | Yes | Full (native sub-agents)         | No            | Yes            | `~/.qwen`                           |
 | Kiro IDE        | `kiro-ide`       | Yes          | Yes | Full (native subagents)          | No            | No             | `~/.kiro`                           |
 | OpenClaw        | `openclaw`       | Yes          | Yes | Solo-agent                       | No            | No             | `~/.openclaw`                       |
+| Trae            | `trae`           | Yes          | Yes | Solo-agent                       | No            | No             | `~/.trae`                           |
 | Pi              | `pi`             | Yes          | Yes | Full (package-managed subagents) | No            | Yes            | `~/.pi`                             |
 
 Most agents receive the **full SDD orchestrator** policy, plus skill files written to their skills directory. Most receive it through their system prompt; OpenCode and Kilo Code receive it through the OpenCode-compatible `opencode.json` agent overlay. Pi is the exception: Gentle AI installs Pi packages, and `gentle-pi` owns Pi skills, prompts, SDD agents, and chains at runtime. The agent handles SDD automatically when the task is large enough, or when the user explicitly asks for it — no manual setup required.
@@ -32,7 +33,7 @@ Most agents receive the **full SDD orchestrator** policy, plus skill files writt
 | Model                 | How It Works                                                                                                                                                                                       | Agents                                                                                                    |
 | --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
 | **Full (sub-agents)** | Each SDD phase runs in an isolated context window via native sub-agent delegation, package-managed subagents, or an OpenCode-compatible overlay. The orchestrator coordinates; sub-agents execute. | Claude Code, OpenCode, Kilo Code, Gemini CLI, Cursor, VS Code Copilot, Kimi Code, Kiro IDE, Qwen Code, Pi |
-| **Solo-agent**        | All SDD phases run inline in the same conversation. The orchestrator IS the executor. Engram provides cross-phase persistence.                                                                     | Codex, Windsurf, Antigravity, OpenClaw                                                                    |
+| **Solo-agent**        | All SDD phases run inline in the same conversation. The orchestrator IS the executor. Engram provides cross-phase persistence.                                                                     | Codex, Windsurf, Antigravity, OpenClaw, Trae                                                              |
 
 ### Cursor Native Subagents
 
@@ -67,11 +68,11 @@ Kiro uses native custom agents in `~/.kiro/agents/`. `gentle-ai` writes 10 phase
 
 ## SDD Mode Support
 
-| Feature          | Claude Code | OpenCode | Kilo Code | Gemini CLI | Cursor | VS Code Copilot | Codex | Windsurf | Antigravity | Kiro IDE | Qwen Code | OpenClaw |   Pi    |
-| ---------------- | :---------: | :------: | :-------: | :--------: | :----: | :-------------: | :---: | :------: | :---------: | :------: | :-------: | :------: | :-----: |
-| SDD orchestrator |     Yes     |   Yes    |    Yes    |    Yes     |  Yes   |       Yes       |  Yes  |   Yes    |     Yes     |   Yes    |    Yes    |   Yes    |   Yes   |
-| Single-mode SDD  |     Yes     |   Yes    |    Yes    |    Yes     |  Yes   |       Yes       |  Yes  |   Yes    |     Yes     |   Yes    |    Yes    |   Yes    |   Yes   |
-| Multi-mode SDD   |      —      |   Yes    |    Yes    |     —      |   —    |        —        |   —   |    —     |      —      |  Yes\*   |     —     |    —     | Yes\*\* |
+| Feature          | Claude Code | OpenCode | Kilo Code | Gemini CLI | Cursor | VS Code Copilot | Codex | Windsurf | Antigravity | Kiro IDE | Qwen Code | OpenClaw | Trae |   Pi    |
+| ---------------- | :---------: | :------: | :-------: | :--------: | :----: | :-------------: | :---: | :------: | :---------: | :------: | :-------: | :------: | :--: | :-----: |
+| SDD orchestrator |     Yes     |   Yes    |    Yes    |    Yes     |  Yes   |       Yes       |  Yes  |   Yes    |     Yes     |   Yes    |    Yes    |   Yes    | Yes  |   Yes   |
+| Single-mode SDD  |     Yes     |   Yes    |    Yes    |    Yes     |  Yes   |       Yes       |  Yes  |   Yes    |     Yes     |   Yes    |    Yes    |   Yes    | Yes  |   Yes   |
+| Multi-mode SDD   |      —      |   Yes    |    Yes    |     —      |   —    |        —        |   —   |    —     |      —      |  Yes\*   |     —     |    —     |  —   | Yes\*\* |
 
 **Multi-mode** (assigning different AI models to each SDD phase) is supported by **OpenCode** and **Kilo Code** through the OpenCode-compatible multi-mode overlay, and by **Kiro IDE** through native subagent `model:` frontmatter. All other agents run in **single-mode** — the orchestrator manages everything using whatever model the agent is already running.
 
@@ -130,7 +131,7 @@ Kiro uses native custom agents in `~/.kiro/agents/`. `gentle-ai` writes 10 phase
 
 - CLI-native agent with TOML config at `~/.codex/config.toml`
 - Skills at `~/.codex/skills/`
-- System prompt at `~/.codex/agents.md`
+- System prompt at `~/.codex/AGENTS.md`
 - Engram instruction files at `~/.codex/engram-instructions.md`
 
 ### Windsurf
@@ -188,6 +189,18 @@ Kiro uses native custom agents in `~/.kiro/agents/`. `gentle-ai` writes 10 phase
 - **Instructions**: Engram and SDD protocols are injected into workspace `AGENTS.md`; persona is injected into workspace `SOUL.md`.
 - **MCP config**: Engram and Context7 are merged into global `~/.openclaw/openclaw.json` under `mcp.servers`; legacy root `mcpServers` entries are migrated.
 - **Skills**: SDD phase skills are workspace-scoped at `<workspace>/.openclaw/skills/sdd-*`; portable skills remain global at `~/.openclaw/skills/`.
+
+### Trae
+
+- **Detection**: gentle-ai detects Trae from `~/.trae` (desktop app — no binary on PATH)
+- **Global config root**: `~/.trae/` (cross-platform)
+- **Skills**: `~/.trae/skills/`
+- **System prompt / rules**: injected via `StrategyMarkdownSections` into the OS-specific `user_rules.md`
+  - macOS: `~/Library/Application Support/Trae/User/user_rules.md`
+  - Linux: `~/.config/Trae/User/user_rules.md` (respects `XDG_CONFIG_HOME`)
+  - Windows: `%APPDATA%\Trae\User\user_rules.md`
+- **MCP config**: same OS-specific dir → `mcp.json` (Cursor-compatible `mcpServers` object format)
+- **Install**: desktop app only — manual install required; no `--auto-install` support
 
 ### Pi
 

--- a/docs/antigravity-sdd-workaround.md
+++ b/docs/antigravity-sdd-workaround.md
@@ -1,7 +1,7 @@
-# Antigravity IDE: SDD Single-Agent Workaround
+# Antigravity: SDD Single-Agent Workaround
 
 ## El Problema
-Antigravity IDE actualmente no soporta la invocación nativa de subagentes en background (multi-threading de LLMs). Todas las fases de Spec-Driven Development (SDD) deben ejecutarse secuencialmente en el mismo hilo de conversación.
+Antigravity (CLI y Desktop) actualmente no soporta la invocación nativa de subagentes en background (multi-threading de LLMs). Todas las fases de Spec-Driven Development (SDD) deben ejecutarse secuencialmente en el mismo hilo de conversación.
 Esto genera un alto riesgo de **degradación de contexto y alucinaciones**, ya que el LLM empieza a mezclar instrucciones de skills anteriores y pierde el hilo de la arquitectura.
 
 ## La Solución: Artifact-Driven State Machine

--- a/docs/components.md
+++ b/docs/components.md
@@ -13,7 +13,7 @@
 | Skills | `skills` | Curated coding skill library |
 | Context7 | `context7` | MCP server for live framework/library documentation |
 | Persona | `persona` | Managed Gentleman/neutral persona injection, or unmanaged custom persona mode |
-| Permissions | `permissions` | Security-first defaults and guardrails |
+| Permissions | `permissions` | Security-first defaults and guardrails. Applied to Claude Code and OpenCode (the two adapters with permissions overlay support). Default sensitive-paths deny list: `~/.ssh/*`, `~/.ssh/**/*`, `**/*.pem`, `**/*.key`, `**/.env*`, `~/.credentials/*`, `~/.aws/credentials`, `~/.config/gh/hosts.yml`, `~/Library/Keychains/*`, `**/secrets/*`, `**/*.p12`, `**/*.pfx` |
 | GGA | `gga` | Gentleman Guardian Angel — AI provider switcher |
 | Theme | `theme` | Gentleman Kanagawa theme overlay |
 
@@ -68,7 +68,7 @@ gga install
 | Comment Writer | `comment-writer` | Draft warm, direct collaboration comments and review replies |
 | Work Unit Commits | `work-unit-commits` | Split implementation into reviewable work units |
 
-These foundation skills are installed by default with both `full-gentleman` and `ecosystem-only` presets.
+These foundation skills are installed by default with both the `full-gentleman` (Dev Stack + Polish) and `ecosystem-only` (Dev Stack) presets.
 
 ### Coding Skills (separate repository)
 
@@ -80,7 +80,9 @@ For framework-specific skills (React 19, Angular, TypeScript, Tailwind 4, Zod 4,
 
 | Preset | ID | What's Included |
 |--------|-----|-----------------|
-| Full Gentleman | `full-gentleman` | All components (Engram + SDD + Skills + Context7 + GGA + Persona + Permissions + Theme) + all skills + gentleman persona |
-| Ecosystem Only | `ecosystem-only` | Core components (Engram + SDD + Skills + Context7 + GGA) + all skills + gentleman persona |
-| Minimal | `minimal` | Engram + SDD skills only |
+| Dev Stack + Polish | `full-gentleman` | All components (Engram + SDD + Skills + Context7 + GGA + Permissions + Theme) + all skills |
+| Dev Stack | `ecosystem-only` | Core components (Engram + SDD + Skills + Context7 + GGA) + all skills |
+| Memory Only | `minimal` | Engram + SDD skills only |
 | Custom | `custom` | You choose components and skills manually while keeping any existing persona/settings unmanaged |
+
+Persona is selected separately on the Persona screen and applied independently of the preset.

--- a/docs/non-interactive.md
+++ b/docs/non-interactive.md
@@ -15,7 +15,14 @@ go run ./cmd/gentle-ai install [flags]
 - `--skill`, `--skills`: comma-separated and repeatable.
 - `--persona`: explicit persona id.
 - `--preset`: explicit preset id.
+- `--scope`: `global` (default) or `workspace` (writes to project root `./`).
 - `--dry-run`: render plan without executing.
+
+## Environment variables
+
+| Variable | Values | Description |
+|----------|--------|-------------|
+| `GENTLE_AI_INSTALL_SCOPE` | `global` \| `workspace` | Sets the install scope without a flag. Useful in CI. Equivalent to `--scope`. Default: `global`. |
 
 ## Platform behavior
 

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -43,4 +43,5 @@ Release artifacts are produced by CI, but Windows users should install through S
 | Antigravity | `%USERPROFILE%\.gemini\antigravity\` |
 | Kiro IDE | `%USERPROFILE%\.kiro\steering\` (prompts) + `%USERPROFILE%\.kiro\skills\` (skills) + `%USERPROFILE%\.kiro\agents\` (SDD agents) + `%APPDATA%\kiro\User\settings.json` (settings) + `%USERPROFILE%\.kiro\settings\mcp.json` (MCP) |
 | OpenClaw | `%USERPROFILE%\.openclaw\openclaw.json` (global MCP/settings) + active workspace from `agents.defaults.workspace` for `AGENTS.md` / `SOUL.md` / workspace-scoped SDD skills |
+| Trae | `%USERPROFILE%\.trae\` (skills) + `%APPDATA%\Trae\User\user_rules.md` (rules) + `%APPDATA%\Trae\User\mcp.json` (MCP) |
 | Pi | `%USERPROFILE%\.pi\` (Pi config, project agents/chains, Gentle AI support assets) |

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -72,11 +72,15 @@ When checks pass, installer reports:
 
 `You're ready. Run 'claude' or 'opencode' and start building.`
 
+If something looks wrong after install, run `gentle-ai doctor` for a read-only health check. It verifies tool binaries, `state.json` validity, Engram MCP reachability, and disk space — each check reports pass/warn/fail with a remedy hint.
+
 For a Pi-only install, the plan shows the Pi package stack instead of Gentle AI components. It installs `gentle-pi`, `gentle-engram`, and `pi-mcp-adapter`, runs `pi-engram init` through the pinned `gentle-engram` package, then installs `pi-subagents`, `pi-intercom`, `@juicesharp/rpiv-ask-user-question`, `pi-web-access`, `pi-lens`, `@juicesharp/rpiv-todo`, and `pi-btw`.
 
 ## Hardening recommendations for users
 
-Gentle AI pins versions and disables postinstall scripts on every npm install it generates. For broader protection across npm packages you install yourself, set these once on your machine:
+Gentle AI pins versions and disables postinstall scripts on every npm install it generates. When you install the `permissions` component, a sensitive-paths deny list is applied to Claude Code and OpenCode blocking access to `~/.ssh/*`, `**/*.pem`, `**/*.key`, `**/.env*`, `~/.aws/credentials`, and other credential paths. See [Components](../docs/components.md) for the full list.
+
+For broader protection across npm packages you install yourself, set these once on your machine:
 
 - `npm config set ignore-scripts true` — blocks postinstall scripts globally; the primary supply-chain attack vector.
 - `npm config set min-release-age 3` — skip packages published in the last 3 days; catches malicious typosquats before you install them.

--- a/docs/rollback.md
+++ b/docs/rollback.md
@@ -17,6 +17,8 @@ Every time you run `gentle-ai install`, `sync`, or `upgrade`, the system:
 - `snapshot.tar.gz` — compressed archive of all backed-up files
 - For paths that did not exist before the operation, the manifest tracks `existed=false`
 
+> **Backup scope**: pre-upgrade and pre-sync snapshots cover only the agents listed in `state.InstalledAgents` (`~/.gentle-ai/state.json`). Config directories for agents you installed outside of gentle-ai are not included in the snapshot.
+
 Legacy (pre-v1.16) backups use a `files/` directory with plain copies instead of a tar.gz archive. Both formats are fully supported for restore.
 
 ## Retention policy

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -38,7 +38,7 @@ Before any managed file is modified, `gentle-ai` creates a backup snapshot so th
 
 ### install
 
-First-time setup — detects your tools, configures agents, injects all components:
+First-time setup — detects your tools, configures agents, injects all components. When installing a single agent with `--agent X`, gentle-ai **merges** the new agent into the existing `installed_agents` list in `state.json` and **preserves** any existing `model_assignments` — it does not overwrite the full state.
 
 ```bash
 # Full ecosystem for multiple agents
@@ -148,7 +148,7 @@ If no `--component` flag is provided for a partial uninstall, `gentle-ai` remove
 
 ### update / upgrade
 
-Check for and install new versions of `gentle-ai` itself:
+Check for and install new versions of `gentle-ai` itself. The pre-upgrade backup snapshot covers only the agents recorded in `state.InstalledAgents` (`~/.gentle-ai/state.json`) — not every agent config directory that exists on your machine.
 
 ```bash
 # Check if a newer version is available
@@ -161,6 +161,27 @@ gentle-ai upgrade
 After upgrading, run `gentle-ai sync` to refresh all managed assets to the new version's content.
 
 If GitHub rate-limits update checks, export `GITHUB_TOKEN` or `GH_TOKEN` before running `gentle-ai update`/`upgrade`.
+
+Set `GENTLE_AI_CONFIRM_UPDATE=1` to have `gentle-ai` prompt for confirmation (`y/N`) before applying a self-update. Default behavior (no env var) applies the update without an interactive prompt.
+
+### doctor
+
+Read-only ecosystem health diagnostics — no changes made to your configuration:
+
+```bash
+gentle-ai doctor
+```
+
+Checks performed:
+
+| Check | What it verifies |
+|-------|-----------------|
+| Tool binaries | Required tools present on `PATH`; shadow detection (wrong binary resolves first) |
+| `state.json` validity | Parses `~/.gentle-ai/state.json` and reports any schema/corruption issues |
+| Engram MCP reachability | Confirms the Engram MCP server responds |
+| Disk space | Warns when available space is critically low |
+
+Each check reports **pass**, **warn**, or **fail** with an optional remedy hint. Run `doctor` first when troubleshooting an unexpected install or sync result.
 
 ### version
 
@@ -181,6 +202,7 @@ gentle-ai -v
 | `--skill`, `--skills`         | Skills to install (comma-separated)                                                                               |
 | `--persona`                   | Persona mode: `gentleman`, `neutral`, `custom` (`custom` keeps your existing persona unmanaged)                   |
 | `--preset`                    | Preset: `full-gentleman`, `ecosystem-only`, `minimal`, `custom` (`custom` means manual component/skill selection) |
+| `--scope`                     | Install scope: `global` (default, writes to `~`) or `workspace` (writes to `./`, project root). Also settable via `GENTLE_AI_INSTALL_SCOPE` env var for CI/non-interactive use. |
 | `--dry-run`                   | Preview the install plan without applying changes                                                                 |
 
 ## CLI Flags (sync)


### PR DESCRIPTION
## Linked Issue

Closes #694

## PR Type

- [x] `type:docs`

## Summary

Syncs user-facing documentation with the state of `main` after the v1.31.0 and v1.32.0 releases (~28 PRs touching install, upgrade, persona/preset, agents, permissions).

## Stale references fixed

| File | Change |
|------|--------|
| `docs/components.md` | Preset labels (Full Gentleman → Dev Stack + Polish, Ecosystem Only → Dev Stack); decoupled persona from preset description |
| `docs/agents.md` | Codex `AGENTS.md` uppercase (per #686) |
| `docs/antigravity-sdd-workaround.md` | Removed "IDE" — Antigravity is CLI + Desktop only (per #661) |
| `PRD.md` | 6 occurrences of old preset labels updated |

## New features documented

| File | Feature |
|------|---------|
| `docs/usage.md` | `gentle-ai doctor` (#690), `--scope=workspace` flag (#666), `GENTLE_AI_CONFIRM_UPDATE` env var (#663), state.json merge for `--agent X` (#667), backup scope respects state.json (#684) |
| `docs/non-interactive.md` | `GENTLE_AI_INSTALL_SCOPE` env var |
| `docs/quickstart.md` | doctor reference + hardening note for sensitive-paths deny |
| `docs/agents.md` + `docs/platforms.md` + `README.md` | Trae IDE agent row (#532) |
| `docs/components.md` | Default sensitive-paths deny list (#689) |
| `docs/rollback.md` | Backup scope behavior post-#684 |

## Changes

10 files, +89 / -33 = **56 net LOC**.

## Test Plan

- [x] All markdown still renders (no broken tables / code fences)
- [x] No Go code touched

## Contributor Checklist

- [x] Linked to approved issue (#694)
- [x] Under 400 changed lines
- [x] Conventional Commits format
- [x] No Co-Authored-By trailers