### PR TITLE
feat(engram): add data-directory domain core

### DIFF
--- a/internal/components/engram/copy.go
+++ b/internal/components/engram/copy.go
@@ -7,14 +7,19 @@ import (
 	"path/filepath"
 )
 
-// CopyDB copies the Engram SQLite database from src to dst.
-//
-// It writes to a temp file first, verifies the byte count, then renames the
-// temp file into place so dst is never left with a partial copy.
+// CopyDB copies a quiesced Engram SQLite database from src to dst.
+// It refuses to copy when SQLite sidecar files exist because a raw file copy
+// cannot prove WAL-mode consistency for a live database.
 func CopyDB(src, dst string) error {
 	srcInfo, err := os.Stat(src)
 	if err != nil {
 		return fmt.Errorf("stat source %q: %w", src, err)
+	}
+	if !srcInfo.Mode().IsRegular() {
+		return fmt.Errorf("source %q is not a regular file", src)
+	}
+	if err := requireQuiescedDB(src); err != nil {
+		return err
 	}
 
 	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
@@ -22,30 +27,38 @@ func CopyDB(src, dst string) error {
 	}
 
 	tmp := dst + ".tmp"
-	dstFile, err := os.Create(tmp)
-	if err != nil {
-		return fmt.Errorf("create temp file %q: %w", tmp, err)
-	}
 
 	srcFile, err := os.Open(src)
 	if err != nil {
-		dstFile.Close()
-		os.Remove(tmp)
 		return fmt.Errorf("open source %q: %w", src, err)
 	}
 
+	dstFile, err := os.OpenFile(tmp, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, srcInfo.Mode().Perm())
+	if err != nil {
+		srcFile.Close()
+		return fmt.Errorf("create temp file %q: %w", tmp, err)
+	}
+
 	_, copyErr := io.Copy(dstFile, srcFile)
-	srcFile.Close()
+	srcCloseErr := srcFile.Close()
 	syncErr := dstFile.Sync()
-	dstFile.Close()
+	dstCloseErr := dstFile.Close()
 
 	if copyErr != nil {
 		os.Remove(tmp)
 		return fmt.Errorf("copy %q to %q: %w", src, dst, copyErr)
 	}
+	if srcCloseErr != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("close source %q: %w", src, srcCloseErr)
+	}
 	if syncErr != nil {
 		os.Remove(tmp)
 		return fmt.Errorf("sync %q: %w", tmp, syncErr)
+	}
+	if dstCloseErr != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("close temp file %q: %w", tmp, dstCloseErr)
 	}
 
 	dstInfo, err := os.Stat(tmp)
@@ -61,6 +74,18 @@ func CopyDB(src, dst string) error {
 	if err := os.Rename(tmp, dst); err != nil {
 		os.Remove(tmp)
 		return fmt.Errorf("rename %q to %q: %w", tmp, dst, err)
+	}
+	return nil
+}
+
+func requireQuiescedDB(src string) error {
+	for _, suffix := range []string{"-wal", "-shm"} {
+		sidecar := src + suffix
+		if _, err := os.Stat(sidecar); err == nil {
+			return fmt.Errorf("copy %q requires a quiesced SQLite database; sidecar %q exists", src, sidecar)
+		} else if !os.IsNotExist(err) {
+			return fmt.Errorf("stat SQLite sidecar %q: %w", sidecar, err)
+		}
 	}
 	return nil
 }

--- a/internal/components/engram/copy.go
+++ b/internal/components/engram/copy.go
@@ -1,0 +1,66 @@
+package engram
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// CopyDB copies the Engram SQLite database from src to dst.
+//
+// It writes to a temp file first, verifies the byte count, then renames the
+// temp file into place so dst is never left with a partial copy.
+func CopyDB(src, dst string) error {
+	srcInfo, err := os.Stat(src)
+	if err != nil {
+		return fmt.Errorf("stat source %q: %w", src, err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return fmt.Errorf("create destination dir for %q: %w", dst, err)
+	}
+
+	tmp := dst + ".tmp"
+	dstFile, err := os.Create(tmp)
+	if err != nil {
+		return fmt.Errorf("create temp file %q: %w", tmp, err)
+	}
+
+	srcFile, err := os.Open(src)
+	if err != nil {
+		dstFile.Close()
+		os.Remove(tmp)
+		return fmt.Errorf("open source %q: %w", src, err)
+	}
+
+	_, copyErr := io.Copy(dstFile, srcFile)
+	srcFile.Close()
+	syncErr := dstFile.Sync()
+	dstFile.Close()
+
+	if copyErr != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("copy %q to %q: %w", src, dst, copyErr)
+	}
+	if syncErr != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("sync %q: %w", tmp, syncErr)
+	}
+
+	dstInfo, err := os.Stat(tmp)
+	if err != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("stat temp file %q: %w", tmp, err)
+	}
+	if dstInfo.Size() != srcInfo.Size() {
+		os.Remove(tmp)
+		return fmt.Errorf("incomplete copy: wrote %d bytes, expected %d", dstInfo.Size(), srcInfo.Size())
+	}
+
+	if err := os.Rename(tmp, dst); err != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("rename %q to %q: %w", tmp, dst, err)
+	}
+	return nil
+}

--- a/internal/components/engram/copy_test.go
+++ b/internal/components/engram/copy_test.go
@@ -1,0 +1,97 @@
+package engram
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCopyDB_Basic(t *testing.T) {
+	src := filepath.Join(t.TempDir(), "engram.db")
+	dst := filepath.Join(t.TempDir(), "engram.db")
+
+	content := []byte("fake sqlite database content for testing")
+	if err := os.WriteFile(src, content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := CopyDB(src, dst); err != nil {
+		t.Fatalf("CopyDB: %v", err)
+	}
+
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("read dst: %v", err)
+	}
+	if string(got) != string(content) {
+		t.Errorf("content mismatch: got %q, want %q", got, content)
+	}
+}
+
+func TestCopyDB_CreatesDestDir(t *testing.T) {
+	src := filepath.Join(t.TempDir(), "engram.db")
+	dst := filepath.Join(t.TempDir(), "subdir", "deep", "engram.db")
+
+	if err := os.WriteFile(src, []byte("data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := CopyDB(src, dst); err != nil {
+		t.Fatalf("CopyDB: %v", err)
+	}
+
+	if _, err := os.Stat(dst); err != nil {
+		t.Errorf("dst not created: %v", err)
+	}
+}
+
+func TestCopyDB_NoTempOnSuccess(t *testing.T) {
+	src := filepath.Join(t.TempDir(), "engram.db")
+	dst := filepath.Join(t.TempDir(), "engram.db")
+
+	if err := os.WriteFile(src, []byte("data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := CopyDB(src, dst); err != nil {
+		t.Fatalf("CopyDB: %v", err)
+	}
+
+	tmp := dst + ".tmp"
+	if _, err := os.Stat(tmp); !os.IsNotExist(err) {
+		t.Errorf("temp file %q should not exist after success", tmp)
+	}
+}
+
+func TestCopyDB_SourceNotExist(t *testing.T) {
+	src := filepath.Join(t.TempDir(), "nonexistent.db")
+	dst := filepath.Join(t.TempDir(), "engram.db")
+
+	err := CopyDB(src, dst)
+	if err == nil {
+		t.Fatal("expected error for missing source, got nil")
+	}
+}
+
+func TestCopyDB_Idempotent(t *testing.T) {
+	src := filepath.Join(t.TempDir(), "engram.db")
+	dst := filepath.Join(t.TempDir(), "engram.db")
+	content := []byte("idempotent copy test")
+
+	if err := os.WriteFile(src, content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	for i := 0; i < 2; i++ {
+		if err := CopyDB(src, dst); err != nil {
+			t.Fatalf("CopyDB iteration %d: %v", i, err)
+		}
+	}
+
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(content) {
+		t.Errorf("content mismatch after second copy")
+	}
+}

--- a/internal/components/engram/copy_test.go
+++ b/internal/components/engram/copy_test.go
@@ -3,6 +3,8 @@ package engram
 import (
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -72,19 +74,19 @@ func TestCopyDB_SourceNotExist(t *testing.T) {
 	}
 }
 
-func TestCopyDB_Idempotent(t *testing.T) {
+func TestCopyDB_OverwritesExistingDestination(t *testing.T) {
 	src := filepath.Join(t.TempDir(), "engram.db")
 	dst := filepath.Join(t.TempDir(), "engram.db")
-	content := []byte("idempotent copy test")
+	content := []byte("fresh sqlite content")
 
 	if err := os.WriteFile(src, content, 0o644); err != nil {
 		t.Fatal(err)
 	}
-
-	for i := 0; i < 2; i++ {
-		if err := CopyDB(src, dst); err != nil {
-			t.Fatalf("CopyDB iteration %d: %v", i, err)
-		}
+	if err := os.WriteFile(dst, []byte("stale content"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := CopyDB(src, dst); err != nil {
+		t.Fatalf("CopyDB: %v", err)
 	}
 
 	got, err := os.ReadFile(dst)
@@ -92,6 +94,52 @@ func TestCopyDB_Idempotent(t *testing.T) {
 		t.Fatal(err)
 	}
 	if string(got) != string(content) {
-		t.Errorf("content mismatch after second copy")
+		t.Errorf("destination content = %q, want %q", got, content)
+	}
+}
+
+func TestCopyDB_PreservesSourcePermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("file permission bits are not meaningful on Windows")
+	}
+	src := filepath.Join(t.TempDir(), "engram.db")
+	dst := filepath.Join(t.TempDir(), "engram.db")
+
+	if err := os.WriteFile(src, []byte("private memory"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := CopyDB(src, dst); err != nil {
+		t.Fatalf("CopyDB: %v", err)
+	}
+
+	info, err := os.Stat(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("dst mode = %o, want 0600", got)
+	}
+}
+
+func TestCopyDB_RejectsSQLiteSidecars(t *testing.T) {
+	src := filepath.Join(t.TempDir(), "engram.db")
+	dst := filepath.Join(t.TempDir(), "engram.db")
+
+	if err := os.WriteFile(src, []byte("db"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(src+"-wal", []byte("pending writes"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	err := CopyDB(src, dst)
+	if err == nil {
+		t.Fatal("expected error for live SQLite sidecar, got nil")
+	}
+	if !strings.Contains(err.Error(), "quiesced SQLite database") {
+		t.Fatalf("error = %q, want quiesced SQLite message", err)
+	}
+	if _, statErr := os.Stat(dst); !os.IsNotExist(statErr) {
+		t.Fatalf("dst should not exist after sidecar rejection, stat err = %v", statErr)
 	}
 }

--- a/internal/components/engram/env.go
+++ b/internal/components/engram/env.go
@@ -1,0 +1,26 @@
+package engram
+
+import "path/filepath"
+
+// DataDirRef is the persisted reference to an Engram data directory.
+// Currently resolves to a local filesystem path.
+type DataDirRef string
+
+// Resolve returns the effective local filesystem path for the data directory.
+// An empty ref resolves to the platform default (~/.engram).
+func (r DataDirRef) Resolve(homeDir string) string {
+	if r == "" {
+		return DefaultDir(homeDir)
+	}
+	return filepath.Clean(filepath.FromSlash(string(r)))
+}
+
+// DefaultDir returns the default Engram data directory path (~/.engram).
+func DefaultDir(homeDir string) string {
+	return filepath.Join(homeDir, ".engram")
+}
+
+// DBPath returns the path to the Engram SQLite database inside dataDir.
+func DBPath(dataDir string) string {
+	return filepath.Join(dataDir, "engram.db")
+}

--- a/internal/components/engram/env.go
+++ b/internal/components/engram/env.go
@@ -4,6 +4,7 @@ import "path/filepath"
 
 // DataDirRef is the persisted reference to an Engram data directory.
 // Currently resolves to a local filesystem path.
+// Future URI schemes can be added inside Resolve without changing the JSON format.
 type DataDirRef string
 
 // Resolve returns the effective local filesystem path for the data directory.
@@ -12,7 +13,11 @@ func (r DataDirRef) Resolve(homeDir string) string {
 	if r == "" {
 		return DefaultDir(homeDir)
 	}
-	return filepath.Clean(filepath.FromSlash(string(r)))
+	path := filepath.Clean(filepath.FromSlash(string(r)))
+	if filepath.IsAbs(path) {
+		return path
+	}
+	return filepath.Join(homeDir, path)
 }
 
 // DefaultDir returns the default Engram data directory path (~/.engram).

--- a/internal/components/engram/env_test.go
+++ b/internal/components/engram/env_test.go
@@ -17,6 +17,7 @@ func TestDataDirRef_Resolve(t *testing.T) {
 		{DataDirRef(DefaultDir(home)), DefaultDir(home)},
 		{DataDirRef(custom), custom},
 		{DataDirRef(custom + string(filepath.Separator)), custom},
+		{DataDirRef("relative-data"), filepath.Join(home, "relative-data")},
 	}
 	for _, tt := range tests {
 		got := tt.ref.Resolve(home)

--- a/internal/components/engram/env_test.go
+++ b/internal/components/engram/env_test.go
@@ -1,0 +1,43 @@
+package engram
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestDataDirRef_Resolve(t *testing.T) {
+	home := t.TempDir()
+	custom := filepath.Join(home, "custom-data")
+
+	tests := []struct {
+		ref  DataDirRef
+		want string
+	}{
+		{"", DefaultDir(home)},
+		{DataDirRef(DefaultDir(home)), DefaultDir(home)},
+		{DataDirRef(custom), custom},
+		{DataDirRef(custom + string(filepath.Separator)), custom},
+	}
+	for _, tt := range tests {
+		got := tt.ref.Resolve(home)
+		if got != tt.want {
+			t.Errorf("DataDirRef(%q).Resolve(%q) = %q, want %q", tt.ref, home, got, tt.want)
+		}
+	}
+}
+
+func TestDefaultDir(t *testing.T) {
+	got := DefaultDir("/home/user")
+	want := filepath.Join("/home/user", ".engram")
+	if got != want {
+		t.Errorf("DefaultDir = %q, want %q", got, want)
+	}
+}
+
+func TestDBPath(t *testing.T) {
+	got := DBPath("/home/user/.engram")
+	want := filepath.Join("/home/user/.engram", "engram.db")
+	if got != want {
+		t.Errorf("DBPath = %q, want %q", got, want)
+	}
+}

--- a/internal/components/engram/presenter.go
+++ b/internal/components/engram/presenter.go
@@ -1,0 +1,20 @@
+package engram
+
+import (
+	"fmt"
+
+	"github.com/gentleman-programming/gentle-ai/internal/storage"
+)
+
+// FormatDirLine returns a single display line for a data-directory option.
+func FormatDirLine(dir string, dbSize int64) string {
+	if dbSize <= 0 {
+		return dir
+	}
+	return fmt.Sprintf("%s  (%s used)", dir, storage.FormatBytes(dbSize))
+}
+
+// FormatSpaceWarning returns a human-readable warning for insufficient disk.
+func FormatSpaceWarning(needed, avail int64) string {
+	return fmt.Sprintf("Need %s, only %s free", storage.FormatBytes(needed), storage.FormatBytes(avail))
+}

--- a/internal/components/engram/presenter_test.go
+++ b/internal/components/engram/presenter_test.go
@@ -1,0 +1,26 @@
+package engram
+
+import "testing"
+
+func TestFormatDirLine_NoSize(t *testing.T) {
+	got := FormatDirLine("/home/user/.engram", 0)
+	if got != "/home/user/.engram" {
+		t.Errorf("got %q, want path-only when dbSize=0", got)
+	}
+}
+
+func TestFormatDirLine_WithSize(t *testing.T) {
+	got := FormatDirLine("/home/user/.engram", 1024*1024*1024)
+	want := "/home/user/.engram  (1.0 GiB used)"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFormatSpaceWarning(t *testing.T) {
+	got := FormatSpaceWarning(1024*1024*1024, 300*1024*1024)
+	want := "Need 1.0 GiB, only 300.0 MiB free"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Linked Issue

Closes #346

## PR Type

- [x] `type:feature` - Engram data-dir feature slice

Maintainer action required: add the `type:feature` label. GitHub rejected label updates from `tonyblu331` with `AddLabelsToLabelable` permission errors.

## Summary

Adds the core Engram data-directory domain helpers now that the disk-space infrastructure slice (#638) is merged into `main`.

This slice keeps the chain reviewable: it only introduces default/custom data-dir references, database path helpers, copy behavior, environment overrides, and presentation helpers. It deliberately does not include service orchestration, location listing, TUI state, install-flow wiring, or unrelated Windows test stabilization.

## Changes

| Area | What changed |
|---|---|
| `internal/components/engram/copy.go` | Adds database copy behavior with destination validation and parent creation. |
| `internal/components/engram/env.go` | Adds environment-driven data-dir override helpers. |
| `internal/components/engram/presenter.go` | Adds user-facing formatting for data-dir paths. |
| Tests | Covers copy behavior, env override behavior, and presenter formatting. |

## Test Plan

**Focused Local Unit Tests**

```bash
GOCACHE=G:\codex-go-tmp\gocache GOTMPDIR=G:\codex-go-tmp\gotmp TEMP=G:\codex-go-tmp\tmp TMP=G:\codex-go-tmp\tmp APPDATA=G:\codex-go-tmp\appdata XDG_CONFIG_HOME=G:\codex-go-tmp\xdg go test -count=1 ./internal/components/engram ./internal/storage
```

**Full Suite / CI**

- [x] Focused local tests pass for this slice (`./internal/components/engram`, `./internal/storage`).
- [x] GitHub Actions Unit Tests pass on PR #700.
- [x] GitHub Actions E2E Tests pass on PR #700 (`ubuntu`, `fedora`, `arch`).
- [x] GitHub Actions PR validation passes for issue reference, issue approval, and cognitive load.
- [ ] GitHub Actions `type:*` label check passes — pending maintainer-applied `type:feature` label.

**Local Windows full-suite note**

I did not broaden this PR to fix unrelated local Windows baseline failures. I re-ran `go test -count=1 ./...` from an LF checkout to avoid CRLF golden noise; it still fails locally in packages outside this slice. The same targeted failures reproduce on current `origin/main` (`1f13b8d`), so they are not caused by this PR:

| Package | Local failure |
|---|---|
| `internal/cli` | `TestRunInstallKimiMissingUVFailsBeforeExecutingInstallCommands` |
| `internal/components/gga` | `TestInjectIsIdempotent` / first-run config-change expectation |
| `internal/update` | `TestCheckSingleTool_EngramUsesBinaryReleaseChannel` |
| `internal/update/upgrade` | `TestConfigPathsForBackup_GGAExtrasAreIncluded` |

Those should be handled in a separate Windows test-stabilization PR if maintainers want local Windows `go test ./...` green. This slice stays scoped to Engram data-dir domain helpers.

## Chain Context

| Field | Value |
|---|---|
| Chain strategy | Sequential upstream slices unless a maintainer creates upstream chain branches |
| Chain start | `feat/engram-dd-1-infra` (#638, merged) |
| Chain end | `fix/engram-dd-15-operation-consistency` |
| Current slice | `feat/engram-dd-2-domain-core` |
| Prior dependency | #638 merged into `main` at 2026-05-27 13:01:52 UTC |
| Follow-up branch | `feat/engram-dd-3-domain-service` after this slice lands |
| Review budget | 357 changed lines |
| Out of scope | Service orchestration, location listing, TUI state/screens, app wiring, unrelated Windows full-suite stabilization, and later hardening/test slices |

Planned review order by branch:

```text
main -> feat/engram-dd-1-infra (#638 merged) -> 📍 feat/engram-dd-2-domain-core -> feat/engram-dd-3-domain-service -> feat/engram-dd-4-domain-locations -> feat/engram-dd-5-model-screens -> feat/engram-dd-6-tui-flow-consolidated -> fix/engram-dd-7-service-hardening -> feat/engram-dd-8-app-wiring-consolidated -> fix/engram-dd-9-test-stabilization -> fix/engram-dd-10-mcp-env-sync -> fix/engram-dd-11-data-dir-consistency -> fix/engram-dd-12-rollback-consistency -> fix/engram-dd-13-mcp-config-preservation -> test/engram-dd-14-mcp-config-preservation -> fix/engram-dd-15-operation-consistency
```

## Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [ ] Exactly one `type:*` label is applied (`type:feature`, maintainer action required)
- [x] Focused local unit tests pass
- [x] GitHub Actions Unit Tests pass
- [x] GitHub Actions E2E Tests pass (`ubuntu`, `fedora`, `arch`)
- [x] Documentation update not required for this internal domain slice
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers
