### PR TITLE
fix(opencode): include sdd-onboard in SDD phase list

### DIFF
--- a/internal/opencode/models.go
+++ b/internal/opencode/models.go
@@ -361,6 +361,7 @@ func SDDPhases() []string {
 		"sdd-apply",
 		"sdd-verify",
 		"sdd-archive",
+		"sdd-onboard",
 	}
 }
 


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #699

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)

## 📝 Summary

Fixes missing `sdd-onboard` in OpenCode SDD multi phase/model assignment flow by adding it to the canonical SDD phase list used by the runtime/TUI model picker plumbing.

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/opencode/models.go` | Added `sdd-onboard` to `SDDPhases()` |

## 🧪 Test Plan

- [ ] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Manually tested locally

Manual validation (Windows, OpenCode):
- Built branch binary and ran installer flow.
- Reproduced path: OpenCode -> SDD mode `multi` -> phase model assignment list.
- Confirmed `sdd-onboard` is now present alongside `sdd-init`, `sdd-explore`, ..., and JD agents.

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [ ] I have added the appropriate `type:*` label to this PR
- [ ] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [ ] I have updated documentation if necessary
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers
