### PR TITLE
fix(self-update): skip auto-upgrade on TUI entry

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -95,7 +95,10 @@ func RunArgs(args []string, stdout io.Writer) error {
 
 	// Self-update: check for a newer gentle-ai release and apply it before
 	// CLI/TUI dispatch. Errors are non-fatal — logged and swallowed.
-	if !isExplicitUpdateFlow(args) {
+	// Skip auto-upgrade on TUI entry (len(args) == 0) to avoid silently
+	// replacing the binary while the user expects a clean TUI launch (#696).
+	isTUIFlow := len(args) == 0
+	if !isTUIFlow && !isExplicitUpdateFlow(args) {
 		if err := selfUpdateFn(context.Background(), Version, resolveProfile(), stdout); err != nil {
 			_, _ = fmt.Fprintf(stdout, "Warning: self-update failed: %v\n", err)
 		}

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/gentleman-programming/gentle-ai/internal/backup"
 	"github.com/gentleman-programming/gentle-ai/internal/model"
 	"github.com/gentleman-programming/gentle-ai/internal/state"
@@ -760,6 +761,50 @@ func TestRunArgs_UpgradeSkipsSelfUpdate(t *testing.T) {
 	}
 	if selfUpdateCalled != 0 {
 		t.Fatalf("selfUpdate should be skipped for explicit upgrade flow; got %d call(s)", selfUpdateCalled)
+	}
+}
+
+func TestRunArgs_TUISkipsSelfUpdate(t *testing.T) {
+	// NOTE: modifies package-level vars; must not run in parallel.
+	origSelfUpdate := selfUpdateFn
+	origDetect := detectSystem
+	origEnsure := ensureCurrentOSSupported
+	origRunTUI := runTUI
+	t.Cleanup(func() {
+		selfUpdateFn = origSelfUpdate
+		detectSystem = origDetect
+		ensureCurrentOSSupported = origEnsure
+		runTUI = origRunTUI
+	})
+
+	ensureCurrentOSSupported = func() error { return nil }
+	detectSystem = func(context.Context) (system.DetectionResult, error) {
+		return system.DetectionResult{System: system.SystemInfo{Supported: true}}, nil
+	}
+
+	// Return the same model to avoid nil dereference if RunArgs inspects it.
+	tuiCalled := 0
+	runTUI = func(m tea.Model, _ ...tea.ProgramOption) (tea.Model, error) {
+		tuiCalled++
+		return m, nil
+	}
+
+	selfUpdateCalled := 0
+	selfUpdateFn = func(context.Context, string, system.PlatformProfile, io.Writer) error {
+		selfUpdateCalled++
+		return nil
+	}
+
+	var buf bytes.Buffer
+	err := RunArgs([]string{}, &buf)
+	if err != nil {
+		t.Fatalf("RunArgs(empty args) error = %v", err)
+	}
+	if selfUpdateCalled != 0 {
+		t.Fatalf("selfUpdate should be skipped for TUI flow; got %d call(s)", selfUpdateCalled)
+	}
+	if tuiCalled != 1 {
+		t.Fatalf("runTUI should be called exactly once for TUI flow; got %d call(s)", tuiCalled)
 	}
 }
 


### PR DESCRIPTION
Fixes #696

## Summary
- Skip auto-upgrade when gentle-ai is launched without arguments (TUI entry point)
- Prevents silent binary replacement and confusing post-TUI upgrade messages
- TUI already has its own background update check and notifies users via "Upgrade tools ★"

## Changes
| File | Change |
|------|--------|
| `internal/app/app.go` | Skip self-update on TUI entry (len(args) == 0) with inline comment referencing #696 |
| `internal/app/app_test.go` | Add `TestRunArgs_TUISkipsSelfUpdate` with dual validation (selfUpdate skipped + TUI called) |

## Test Plan
- [x] `go build ./...` passes
- [x] `go vet ./internal/app/...` passes
- [x] `go test ./internal/app/... -run "TestRunArgs_" -v` passes (including new test)
- [x] `go test ./internal/app/... -run "TestSelfUpdate_" -v` passes (all existing tests)
- [x] `go test ./internal/app/... -race -count=1` passes (no data races)

## Note on flag-only invocations
`--help`, `--version` and similar flag-only invocations retain the existing self-update behavior. Only the zero-arg TUI entry point is fixed.

## Contributor Checklist
- [x] Linked an approved issue (Fixes #696)
- [x] Added exactly one `type:*` label
- [x] Ran build and vet
- [x] Tests pass with race detector
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers