### PR TITLE
fix(update): add filesystem fallback for engram + gga detection on stale PATH (Windows)

### DIFF
--- a/internal/update/check_test.go
+++ b/internal/update/check_test.go
@@ -1432,6 +1432,147 @@ func TestInstallMethodFieldsOnRegistry(t *testing.T) {
 	}
 }
 
+// TestBuildExecCmd_Ps1UsesPoershellFile verifies that buildExecCmd wraps a .ps1
+// binary via "powershell -NoProfile -File <path> <args>" instead of passing the
+// .ps1 path as argv[0]. This is a regression test for the Windows gga detection
+// bug (issue #177): exec.Command("gga.ps1", "--version") fails on Windows because
+// CreateProcess cannot launch a .ps1 file directly — it is not an executable image.
+// A regression to direct .ps1 exec causes detectInstalledVersion to always return ""
+// for gga on Windows even when the file exists on disk.
+func TestBuildExecCmd_Ps1UsesPoershellFile(t *testing.T) {
+	ps1Path := `C:\Users\test\bin\gga.ps1`
+
+	gotBin, gotArgs := buildExecCmd(ps1Path, []string{"--version"})
+
+	if gotBin == ps1Path {
+		t.Fatalf("buildExecCmd returned the .ps1 path as argv[0]: %q — "+
+			"exec.Command cannot launch .ps1 directly on Windows (CreateProcess rejects non-PE images). "+
+			"Must be wrapped via powershell -NoProfile -File.", gotBin)
+	}
+
+	// The binary must be the powershell host (or the testable override).
+	// We don't hard-code the exact powershell binary name to allow CI overrides,
+	// but it must NOT be the .ps1 path itself.
+	wantArgs := []string{"-NoProfile", "-File", ps1Path, "--version"}
+	if len(gotArgs) != len(wantArgs) {
+		t.Fatalf("buildExecCmd args len = %d, want %d; args = %v", len(gotArgs), len(wantArgs), gotArgs)
+	}
+	for i, want := range wantArgs {
+		if gotArgs[i] != want {
+			t.Fatalf("buildExecCmd args[%d] = %q, want %q; full args = %v", i, gotArgs[i], want, gotArgs)
+		}
+	}
+}
+
+// TestBuildExecCmd_NonPs1Passthrough verifies that non-.ps1 binaries (real
+// executables, shell scripts on Linux/macOS) are passed through unchanged.
+func TestBuildExecCmd_NonPs1Passthrough(t *testing.T) {
+	cases := []struct {
+		binary string
+		args   []string
+	}{
+		{"/usr/local/bin/engram", []string{"version"}},
+		{`C:\Users\user\AppData\Local\engram\bin\engram.exe`, []string{"version"}},
+		{"/home/user/.local/bin/gga", []string{"--version"}},
+	}
+
+	for _, c := range cases {
+		gotBin, gotArgs := buildExecCmd(c.binary, c.args)
+		if gotBin != c.binary {
+			t.Errorf("buildExecCmd(%q) binary = %q, want passthrough %q", c.binary, gotBin, c.binary)
+		}
+		if len(gotArgs) != len(c.args) {
+			t.Errorf("buildExecCmd(%q) args = %v, want %v", c.binary, gotArgs, c.args)
+			continue
+		}
+		for i := range c.args {
+			if gotArgs[i] != c.args[i] {
+				t.Errorf("buildExecCmd(%q) args[%d] = %q, want %q", c.binary, i, gotArgs[i], c.args[i])
+			}
+		}
+	}
+}
+
+// TestDetectInstalledVersionPs1FallbackInvokesViaPowershell verifies the full
+// integration path: when LookPath fails for gga, the fallback finds a .ps1
+// file on disk, and detectInstalledVersion builds the exec as
+// "powershell -NoProfile -File <path> --version" — NOT as "<path> --version".
+// This is the regression test for issue #177 gga half: the prior implementation
+// passed gga.ps1 as argv[0] to exec.Command which always errors on Windows.
+func TestDetectInstalledVersionPs1FallbackInvokesViaPowershell(t *testing.T) {
+	tmpDir := t.TempDir()
+	ps1Path := filepath.Join(tmpDir, "gga.ps1")
+	if err := os.WriteFile(ps1Path, []byte(""), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	tool := ToolInfo{
+		Name:      "gga",
+		DetectCmd: []string{"gga", "--version"},
+		FallbackPaths: func(homeDir, localAppData string) []string {
+			return []string{ps1Path}
+		},
+	}
+
+	origLookPath := lookPath
+	origExecCommand := execCommand
+	origOsStat := osStat
+	origUserHomeDir := userHomeDir
+	origPowershellPath := powershellPath
+	t.Cleanup(func() {
+		lookPath = origLookPath
+		execCommand = origExecCommand
+		osStat = origOsStat
+		userHomeDir = origUserHomeDir
+		powershellPath = origPowershellPath
+	})
+
+	// Simulate stale PATH: gga not found via LookPath.
+	lookPath = func(string) (string, error) { return "", fmt.Errorf("not found") }
+	osStat = os.Stat // real stat so the .ps1 file is found
+	userHomeDir = func() (string, error) { return t.TempDir(), nil }
+	powershellPath = "echo" // replace powershell with echo so the cmd succeeds and outputs "gga 1.2.3"
+
+	// Capture the binary and args that execCommand was called with.
+	var capturedBinary string
+	var capturedArgs []string
+	execCommand = func(name string, args ...string) *exec.Cmd {
+		capturedBinary = name
+		capturedArgs = append([]string{}, args...)
+		// Return a command that outputs a fake version so detectInstalledVersion succeeds.
+		return mockCmd("echo", "gga 1.2.3")
+	}
+
+	got := detectInstalledVersion(context.Background(), tool, "")
+
+	// Primary assertion: the binary must NOT be the .ps1 path itself.
+	if capturedBinary == ps1Path {
+		t.Fatalf("execCommand was called with the .ps1 path as binary (%q) — "+
+			"this WILL fail on Windows (CreateProcess cannot exec .ps1). "+
+			"Must be wrapped via powershell -NoProfile -File.", capturedBinary)
+	}
+
+	// The first arg must be -NoProfile (powershell wrapping).
+	if len(capturedArgs) == 0 || capturedArgs[0] != "-NoProfile" {
+		t.Fatalf("execCommand args[0] = %q, want \"-NoProfile\"; full args = %v", func() string {
+			if len(capturedArgs) > 0 {
+				return capturedArgs[0]
+			}
+			return "(empty)"
+		}(), capturedArgs)
+	}
+
+	// The -File flag must point to the .ps1 path.
+	if len(capturedArgs) < 3 || capturedArgs[1] != "-File" || capturedArgs[2] != ps1Path {
+		t.Fatalf("expected args [-NoProfile, -File, %q, ...], got %v", ps1Path, capturedArgs)
+	}
+
+	// The version must still be extracted from output.
+	if got != "1.2.3" {
+		t.Fatalf("detectInstalledVersion() = %q, want \"1.2.3\"", got)
+	}
+}
+
 // --- helpers ---
 
 // testTransport redirects all requests to the test server.

--- a/internal/update/check_test.go
+++ b/internal/update/check_test.go
@@ -122,6 +122,110 @@ func TestDetectInstalledVersion(t *testing.T) {
 	}
 }
 
+// TestDetectInstalledVersionFallbackPaths verifies that detectInstalledVersion
+// reports a version when LookPath fails but the binary is present at a known
+// fallback path (the Windows post-install stale-PATH scenario, issue #177).
+func TestDetectInstalledVersionFallbackPaths(t *testing.T) {
+	// Create a real executable in a temp dir to serve as the "known install dir".
+	tmpDir := t.TempDir()
+	binaryName := "mytool"
+	binaryPath := filepath.Join(tmpDir, binaryName)
+	if err := os.WriteFile(binaryPath, []byte("placeholder"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	tool := ToolInfo{
+		Name:          "mytool",
+		DetectCmd:     []string{binaryName, "--version"},
+		FallbackPaths: func(homeDir, localAppData string) []string {
+			return []string{filepath.Join(tmpDir, binaryName)}
+		},
+	}
+
+	origLookPath := lookPath
+	origExecCommand := execCommand
+	origOsStat := osStat
+	origUserHomeDir := userHomeDir
+	t.Cleanup(func() {
+		lookPath = origLookPath
+		execCommand = origExecCommand
+		osStat = origOsStat
+		userHomeDir = origUserHomeDir
+	})
+
+	// Simulate stale PATH: LookPath always fails.
+	lookPath = func(string) (string, error) { return "", fmt.Errorf("not found") }
+
+	// Simulate the detect command succeeding when run with the full binary path.
+	execCommand = func(name string, args ...string) *exec.Cmd {
+		if name == binaryPath {
+			return mockCmd("echo", "mytool 1.2.3")
+		}
+		return mockCmd("false")
+	}
+
+	// osStat must be real so the fallback path check finds the file.
+	osStat = os.Stat
+
+	userHomeDir = func() (string, error) { return t.TempDir(), nil }
+
+	got := detectInstalledVersion(context.Background(), tool, "")
+	if got != "1.2.3" {
+		t.Fatalf("detectInstalledVersion() = %q, want %q (LookPath failed but binary at fallback path)", got, "1.2.3")
+	}
+}
+
+// TestDetectInstalledVersionFallbackPathsNotFoundStillNotInstalled verifies
+// that when LookPath fails AND the binary is not at any fallback path,
+// detectInstalledVersion correctly returns "" (not installed).
+func TestDetectInstalledVersionFallbackPathsNotFoundStillNotInstalled(t *testing.T) {
+	tool := ToolInfo{
+		Name:      "mytool",
+		DetectCmd: []string{"mytool", "--version"},
+		FallbackPaths: func(homeDir, localAppData string) []string {
+			return []string{"/nonexistent/path/to/mytool"}
+		},
+	}
+
+	origLookPath := lookPath
+	origOsStat := osStat
+	origUserHomeDir := userHomeDir
+	t.Cleanup(func() {
+		lookPath = origLookPath
+		osStat = origOsStat
+		userHomeDir = origUserHomeDir
+	})
+
+	lookPath = func(string) (string, error) { return "", fmt.Errorf("not found") }
+	osStat = func(string) (os.FileInfo, error) { return nil, os.ErrNotExist }
+	userHomeDir = func() (string, error) { return t.TempDir(), nil }
+
+	got := detectInstalledVersion(context.Background(), tool, "")
+	if got != "" {
+		t.Fatalf("detectInstalledVersion() = %q, want empty when binary not at any fallback path", got)
+	}
+}
+
+// TestDetectInstalledVersionFallbackPathsNoFallbackDefined verifies backward
+// compatibility: when FallbackPaths is nil, the original behavior is preserved.
+func TestDetectInstalledVersionFallbackPathsNoFallbackDefined(t *testing.T) {
+	tool := ToolInfo{
+		Name:          "mytool",
+		DetectCmd:     []string{"mytool", "--version"},
+		FallbackPaths: nil,
+	}
+
+	origLookPath := lookPath
+	t.Cleanup(func() { lookPath = origLookPath })
+
+	lookPath = func(string) (string, error) { return "", fmt.Errorf("not found") }
+
+	got := detectInstalledVersion(context.Background(), tool, "")
+	if got != "" {
+		t.Fatalf("detectInstalledVersion() = %q, want empty when LookPath fails and no fallback defined", got)
+	}
+}
+
 func TestDetectInstalledVersionFromOpenCodeNodeModulePackageJSON(t *testing.T) {
 	home := t.TempDir()
 	pkgDir := filepath.Join(home, ".config", "opencode", "node_modules", "opencode-sdd-engram-manage")

--- a/internal/update/detect.go
+++ b/internal/update/detect.go
@@ -16,6 +16,8 @@ var (
 	execCommand = exec.Command
 	lookPath    = exec.LookPath
 	userHomeDir = os.UserHomeDir
+	osStat      = os.Stat
+	osGetenv    = os.Getenv
 )
 
 // versionRegexp extracts a semver-like version from command output.
@@ -44,7 +46,16 @@ func detectInstalledVersion(ctx context.Context, tool ToolInfo, currentBuildVers
 
 	binary := tool.DetectCmd[0]
 	if _, err := lookPath(binary); err != nil {
-		return "" // binary not found
+		// LookPath failed — the running process PATH may be stale (common on
+		// Windows immediately after install when AddToUserPath updates the
+		// registry but has not yet been picked up by the current process).
+		// Fall back to checking known install locations on disk.
+		fullPath := findFallbackBinary(tool)
+		if fullPath == "" {
+			return "" // binary not found anywhere
+		}
+		// Use the full filesystem path to invoke the binary directly, bypassing PATH.
+		binary = fullPath
 	}
 
 	// Apply a bounded timeout so a hanging binary (e.g. engram stuck on DB
@@ -52,7 +63,7 @@ func detectInstalledVersion(ctx context.Context, tool ToolInfo, currentBuildVers
 	detectCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
-	cmd := execCommand(tool.DetectCmd[0], tool.DetectCmd[1:]...)
+	cmd := execCommand(binary, tool.DetectCmd[1:]...)
 
 	// Kill the subprocess when the context fires. We use a goroutine because
 	// the testable execCommand var returns a plain *exec.Cmd (not CommandContext).
@@ -74,6 +85,24 @@ func detectInstalledVersion(ctx context.Context, tool ToolInfo, currentBuildVers
 	}
 
 	return parseVersionFromOutput(strings.TrimSpace(string(out)))
+}
+
+// findFallbackBinary checks the tool's FallbackPaths for a binary that exists
+// on disk. It returns the first path that stat succeeds on, or "" if none found.
+// This is used when exec.LookPath fails due to a stale process PATH (e.g.,
+// Windows immediately after install).
+func findFallbackBinary(tool ToolInfo) string {
+	if tool.FallbackPaths == nil {
+		return ""
+	}
+	homeDir, _ := userHomeDir()
+	localAppData := osGetenv("LOCALAPPDATA")
+	for _, path := range tool.FallbackPaths(homeDir, localAppData) {
+		if _, err := osStat(path); err == nil {
+			return path
+		}
+	}
+	return ""
 }
 
 func detectNpmPackageVersion(pkg string) string {

--- a/internal/update/detect.go
+++ b/internal/update/detect.go
@@ -13,11 +13,12 @@ import (
 
 // Package-level vars for testability (swap in tests via t.Cleanup).
 var (
-	execCommand = exec.Command
-	lookPath    = exec.LookPath
-	userHomeDir = os.UserHomeDir
-	osStat      = os.Stat
-	osGetenv    = os.Getenv
+	execCommand    = exec.Command
+	lookPath       = exec.LookPath
+	userHomeDir    = os.UserHomeDir
+	osStat         = os.Stat
+	osGetenv       = os.Getenv
+	powershellPath = "powershell" // overridable in tests
 )
 
 // versionRegexp extracts a semver-like version from command output.
@@ -63,7 +64,13 @@ func detectInstalledVersion(ctx context.Context, tool ToolInfo, currentBuildVers
 	detectCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
-	cmd := execCommand(binary, tool.DetectCmd[1:]...)
+	// On Windows, exec.Command (CreateProcess) cannot execute a .ps1 script
+	// directly — it is not an executable image. Wrap via powershell -File so
+	// the OS can launch the PowerShell host and pass the script to it.
+	// Outside Windows, .ps1 files don't exist in fallback paths, so this
+	// branch is unreachable in practice on Linux/macOS.
+	execBinary, execArgs := buildExecCmd(binary, tool.DetectCmd[1:])
+	cmd := execCommand(execBinary, execArgs...)
 
 	// Kill the subprocess when the context fires. We use a goroutine because
 	// the testable execCommand var returns a plain *exec.Cmd (not CommandContext).
@@ -103,6 +110,26 @@ func findFallbackBinary(tool ToolInfo) string {
 		}
 	}
 	return ""
+}
+
+// buildExecCmd returns the executable name and arguments to use when running a
+// version-detect command. On Windows, PowerShell scripts (.ps1) cannot be
+// passed as argv[0] to CreateProcess — they must be launched via the
+// PowerShell host. For a .ps1 binary we therefore rewrite:
+//
+//	("C:\Users\...\gga.ps1", ["--version"])
+//	→ ("powershell", ["-NoProfile", "-File", "C:\Users\...\gga.ps1", "--version"])
+//
+// For all other binaries (real PE executables on Windows, any file on
+// Linux/macOS), the arguments are returned unchanged.
+func buildExecCmd(binary string, remainingArgs []string) (string, []string) {
+	if strings.EqualFold(filepath.Ext(binary), ".ps1") {
+		args := make([]string, 0, 3+len(remainingArgs))
+		args = append(args, "-NoProfile", "-File", binary)
+		args = append(args, remainingArgs...)
+		return powershellPath, args
+	}
+	return binary, remainingArgs
 }
 
 func detectNpmPackageVersion(pkg string) string {

--- a/internal/update/registry.go
+++ b/internal/update/registry.go
@@ -1,5 +1,9 @@
 package update
 
+import (
+	"path/filepath"
+)
+
 // Tools is the static registry of managed tools that can be checked for updates.
 //
 // InstallMethod controls which upgrade strategy the executor uses:
@@ -29,6 +33,22 @@ var Tools = []ToolInfo{
 		ReleaseTagPattern: `^v[0-9]+\.[0-9]+\.[0-9]+$`,
 		// engram: brew on macOS/Linux-brew, binary download elsewhere.
 		InstallMethod: InstallBinary,
+		// FallbackPaths covers the Windows stale-PATH scenario (and Linux ~/.local/bin
+		// when not yet in PATH): AddToUserPath updates the registry/profile but the
+		// current process does not see the change until a new shell session starts.
+		FallbackPaths: func(homeDir, localAppData string) []string {
+			var paths []string
+			// Windows: %LOCALAPPDATA%\engram\bin\engram.exe
+			if localAppData != "" {
+				paths = append(paths, filepath.Join(localAppData, "engram", "bin", "engram.exe"))
+			}
+			// Linux/macOS: ~/.local/bin/engram (when /usr/local/bin is not writable,
+			// the binary installer places it here, which may not be in PATH yet).
+			if homeDir != "" {
+				paths = append(paths, filepath.Join(homeDir, ".local", "bin", "engram"))
+			}
+			return paths
+		},
 	},
 	{
 		Name:          "gga",
@@ -40,6 +60,21 @@ var Tools = []ToolInfo{
 		// GGA does not publish pre-built release binary assets — only source archives.
 		// Using InstallScript runs curl | bash via the project's install.sh.
 		InstallMethod: InstallScript,
+		// FallbackPaths covers the Windows stale-PATH scenario: gga installs a
+		// PowerShell shim to ~/bin/gga.ps1, and the bash script to ~/.local/bin/gga.
+		// Both locations may not be in PATH immediately after install.
+		FallbackPaths: func(homeDir, localAppData string) []string {
+			var paths []string
+			if homeDir != "" {
+				// Windows: ~/bin/gga.ps1 (PowerShell shim, callable as "gga" in PS)
+				paths = append(paths, filepath.Join(homeDir, "bin", "gga.ps1"))
+				// Linux/macOS: ~/.local/bin/gga
+				paths = append(paths, filepath.Join(homeDir, ".local", "bin", "gga"))
+				// Linux/macOS: ~/bin/gga
+				paths = append(paths, filepath.Join(homeDir, "bin", "gga"))
+			}
+			return paths
+		},
 	},
 	{
 		Name:          "opencode-subagent-statusline",

--- a/internal/update/registry.go
+++ b/internal/update/registry.go
@@ -41,6 +41,10 @@ var Tools = []ToolInfo{
 			// Windows: %LOCALAPPDATA%\engram\bin\engram.exe
 			if localAppData != "" {
 				paths = append(paths, filepath.Join(localAppData, "engram", "bin", "engram.exe"))
+			} else if homeDir != "" {
+				// LOCALAPPDATA is not set (e.g. restricted environment or CI on Windows).
+				// Derive the standard path from homeDir for parity with the installer.
+				paths = append(paths, filepath.Join(homeDir, "AppData", "Local", "engram", "bin", "engram.exe"))
 			}
 			// Linux/macOS: ~/.local/bin/engram (when /usr/local/bin is not writable,
 			// the binary installer places it here, which may not be in PATH yet).

--- a/internal/update/types.go
+++ b/internal/update/types.go
@@ -46,6 +46,16 @@ type ToolInfo struct {
 	InstallMethod     InstallMethod // how this tool is installed (used by upgrade executor)
 	GoImportPath      string        // for go-install tools (e.g. "github.com/.../cmd/engram")
 	NpmPackage        string        // for OpenCode community plugins installed in ~/.config/opencode/node_modules
+
+	// FallbackPaths returns a list of absolute paths to check when exec.LookPath
+	// fails. This covers the Windows scenario where AddToUserPath updates the
+	// registry but the running process PATH is stale after install. When a path
+	// is found on disk, detectInstalledVersion runs the detect command using that
+	// full path rather than the bare binary name.
+	//
+	// The function receives the user home directory and the value of LOCALAPPDATA
+	// (empty on non-Windows). May be nil when no fallback is needed.
+	FallbackPaths func(homeDir, localAppData string) []string
 }
 
 // UpdateResult holds the result of checking a single tool for updates.


### PR DESCRIPTION
## Root cause

Issue #177 had two halves — Engram and GGA both showed "not installed" in the TUI after a Windows install.

On Windows, `AddToUserPath` persists new install dirs to the registry but does **not** refresh the running process PATH. The TUI's update check then calls `detectInstalledVersion` → `exec.LookPath("engram")` / `exec.LookPath("gga")`, which fail on the stale PATH → status "not installed", even though the binaries are present on disk.

## Fix

Added a `FallbackPaths` field to `ToolInfo` and a filesystem fallback in `detectInstalledVersion`: when `LookPath` fails, it checks known install locations and invokes the binary by absolute path, bypassing PATH entirely.

- **Engram**: `%LOCALAPPDATA%\engram\bin\engram.exe` (and `~/AppData/Local/engram/bin\engram.exe` when `LOCALAPPDATA` is unset), `~/.local/bin/engram`. A real PE binary, so absolute-path exec with the `version` subcommand works directly.
- **GGA**: the fallback resolves `~/bin/gga.ps1`. Because `exec.Command` on Windows **cannot execute a `.ps1` directly** (it is not an executable image and PATHEXT is bypassed for absolute paths), a new `buildExecCmd` helper rewrites a `.ps1` invocation to `powershell -NoProfile -File <path> --version`. Non-`.ps1` binaries pass through unchanged.

## Tests

- `TestBuildExecCmd_Ps1UsesPowershellFile` / `_NonPs1Passthrough` — assert the `.ps1` rewrite and passthrough.
- `TestDetectInstalledVersionPs1FallbackInvokesViaPowershell` — regression guard: asserts the `.ps1` is **not** exec'd as `argv[0]` (a regression to direct exec fails the test). This closes the gap where the previous tests passed only because they mocked exec success.
- `go test ./internal/update/... ./internal/components/...`, `go vet`, `go build ./...` — all PASS.

## Known limitation (pre-existing, out of scope)

The `gga.ps1` shim (`internal/assets/gga/gga.ps1`, unchanged here, commit `6aca359`) re-dispatches `gga` by bare name via `& $bash -c "gga $args"`. `bash -c` is non-login/non-interactive and does not source `~/.bash_profile`/`~/.bashrc`, so whether the shim resolves `gga` end-to-end depends on GGA's own installer placing its bin dir on a PATH Git Bash inherits from the Windows environment. This PR fixes the Go-side detection bug it owns and introduces no regression; a follow-up may be needed to make the shim itself PATH-independent.

Closes #177
