### PR TITLE
fix(opencode): forward agent variant in background delegation

### DIFF
--- a/internal/assets/assets_test.go
+++ b/internal/assets/assets_test.go
@@ -216,6 +216,48 @@ func TestModelVariantsPluginContract(t *testing.T) {
 	}
 }
 
+// TestBackgroundAgentsVariantForwarding verifies that background-agents.ts reads
+// the "variant" field from the agent config and forwards it as a top-level
+// sibling of "model" in the session.prompt body (issue #606).
+//
+// Contract rules:
+//  1. resolveAgentModel must read variant from the agent config entry.
+//  2. The session.prompt call must spread variant at the body's top level,
+//     NOT nest it inside the model object.
+//  3. The model object must only contain providerID and modelID.
+func TestBackgroundAgentsVariantForwarding(t *testing.T) {
+	source, err := Read("opencode/plugins/background-agents.ts")
+	if err != nil {
+		t.Fatalf("Read(background-agents.ts) error = %v", err)
+	}
+	src := string(source)
+
+	// resolveAgentModel must read variant from the agent config object.
+	if !strings.Contains(src, `variant?: string`) {
+		t.Errorf("background-agents.ts resolveAgentModel must declare variant in the agent config type")
+	}
+	if !strings.Contains(src, `variant`) {
+		t.Errorf("background-agents.ts must reference variant")
+	}
+
+	// The return type of resolveAgentModel must carry variant.
+	if !strings.Contains(src, "AgentModelResolution") {
+		t.Errorf("background-agents.ts must use a named resolution type (AgentModelResolution) that includes variant")
+	}
+
+	// variant must be forwarded at the TOP LEVEL of the session.prompt body,
+	// not nested inside the model object.
+	if !strings.Contains(src, `variant: agentModel.variant`) {
+		t.Errorf("background-agents.ts must spread variant as a top-level body field (variant: agentModel.variant)")
+	}
+
+	// The model object in session.prompt must only contain providerID and modelID —
+	// variant must NOT be nested inside it.
+	if strings.Contains(src, `model: agentModel`) {
+		t.Errorf("background-agents.ts must not spread agentModel directly into model — variant must remain top-level, not nested in model")
+	}
+}
+
 func TestClaudeEmbeddedAssetLayout(t *testing.T) {
 	entries, err := FS.ReadDir("claude")
 	if err != nil {

--- a/internal/assets/opencode/plugins/background-agents.ts
+++ b/internal/assets/opencode/plugins/background-agents.ts
@@ -467,20 +467,27 @@ async function parseAgentWriteCapability(
   }
 }
 
+interface AgentModelResolution {
+  providerID: string
+  modelID: string
+  variant?: string
+}
+
 /**
- * Resolve the model configured for a given agent.
+ * Resolve the model and variant configured for a given agent.
  * Parses the "provider/model-id" format into the shape session.prompt() expects.
+ * Also reads the optional "variant" (effort level) field from the agent config.
  * Returns undefined when no model is configured (caller falls back to default).
  */
 async function resolveAgentModel(
   client: OpencodeClient,
   agentName: string,
   log: Logger,
-): Promise<{ providerID: string; modelID: string } | undefined> {
+): Promise<AgentModelResolution | undefined> {
   try {
     const config = await client.config.get()
     const configData = config.data as {
-      agent?: Record<string, { model?: string }>
+      agent?: Record<string, { model?: string; variant?: string }>
     } | undefined
 
     const modelStr = configData?.agent?.[agentName]?.model
@@ -492,8 +499,10 @@ async function resolveAgentModel(
     const providerID = modelStr.substring(0, slashIndex)
     const modelID = modelStr.substring(slashIndex + 1)
 
-    await log.info(`resolveAgentModel: ${agentName} → ${providerID}/${modelID}`)
-    return { providerID, modelID }
+    const variant = configData?.agent?.[agentName]?.variant || undefined
+
+    await log.info(`resolveAgentModel: ${agentName} → ${providerID}/${modelID}${variant ? ` (variant: ${variant})` : ""}`)
+    return { providerID, modelID, variant }
   } catch {
     return undefined
   }
@@ -671,7 +680,8 @@ class DelegationManager {
         path: { id: delegation.sessionID },
         body: {
           agent: input.agent,
-          ...(agentModel && { model: agentModel }),
+          ...(agentModel && { model: { providerID: agentModel.providerID, modelID: agentModel.modelID } }),
+          ...(agentModel?.variant && { variant: agentModel.variant }),
           parts: [{ type: "text", text: input.prompt }],
           tools: {
             task: false,


### PR DESCRIPTION
## Root cause

`resolveAgentModel` in `internal/assets/opencode/plugins/background-agents.ts` read the agent's `model` config but ignored `variant` (effort level). The `session.prompt` call site then spread the whole `agentModel` object into `model:`, so even adding variant to the resolution would have silently nested it **inside** `model` — structurally wrong.

Variants are supported everywhere else (#429/#440: discovery, TUI selection, persisted in `opencode.json`); only the background-delegation path dropped them.

## Fix

- New `AgentModelResolution` interface (`providerID`, `modelID`, optional `variant`).
- `resolveAgentModel` reads `config.data.agent[name].variant` (a plain top-level string, matching `read_assignments.go`'s `defMap["variant"]`).
- `session.prompt` now destructures explicitly: `model: { providerID, modelID }` + a **top-level** `variant`, gated by `...(agentModel?.variant && { variant })` so variant-less agents emit nothing (clean backward compat).

## Verified shape

OpenCode v2 SDK (`@opencode-ai/sdk dist/v2/gen/types.gen.d.ts:5295`) confirms `variant?: string` is a top-level sibling of `model` in the `SessionPromptData` body — **not** nested inside `model`.

## Test

`TestBackgroundAgentsVariantForwarding` (Go contract test in `internal/assets/assets_test.go`) pins the top-level `variant: agentModel.variant` emission and asserts against the nested `model: agentModel` form — fails under both the original drop bug and a nesting regression. There is no TS test runner for the embedded plugins; this is the repo's existing validation layer.

`go build ./...` and `go test ./...` (29 packages) pass.

Thanks @MzaGuille for the exceptionally detailed report. 🙏

Closes #606
