### PR TITLE
fix(tui): show effort annotation on JD agent rows and include JD agents in profile model table

### DIFF
--- a/internal/components/sdd/profiles.go
+++ b/internal/components/sdd/profiles.go
@@ -492,6 +492,23 @@ func renderProfileModelAssignmentsSection(profile model.Profile) string {
 		reason := phaseReasons[phase]
 		b.WriteString(fmt.Sprintf("| %s | %s | %s |\n", phase, phaseModel, reason))
 	}
+
+	// JD agents are global (not profile-scoped), but the orchestrator must
+	// know their configured model when delegating judgment-day tasks.
+	jdReasons := map[string]string{
+		"jd-judge-a":   "Adversarial review — blind judge A",
+		"jd-judge-b":   "Adversarial review — blind judge B",
+		"jd-fix-agent": "Surgical fixes from confirmed issues",
+	}
+	for _, jd := range opencode.JDPhases() {
+		jdModel := "global (not profile-scoped)"
+		if m, ok := profile.PhaseAssignments[jd]; ok && m.ProviderID != "" {
+			jdModel = m.FullID()
+		}
+		reason := jdReasons[jd]
+		b.WriteString(fmt.Sprintf("| %s | %s | %s |\n", jd, jdModel, reason))
+	}
+
 	b.WriteString("\n")
 	return b.String()
 }

--- a/internal/components/sdd/profiles_test.go
+++ b/internal/components/sdd/profiles_test.go
@@ -615,6 +615,30 @@ func TestGenerateProfileOverlay_OrchestratorPromptSuffixed(t *testing.T) {
 	}
 }
 
+func TestGenerateProfileOverlay_OrchestratorPromptIncludesJDAgents(t *testing.T) {
+	home := t.TempDir()
+
+	overlay, err := GenerateProfileOverlay(makeHaikuProfile(), home)
+	if err != nil {
+		t.Fatalf("GenerateProfileOverlay() error = %v", err)
+	}
+
+	var root map[string]any
+	if err := json.Unmarshal(overlay, &root); err != nil {
+		t.Fatalf("overlay is not valid JSON: %v", err)
+	}
+	agentMap := root["agent"].(map[string]any)
+	orch := agentMap["sdd-orchestrator-cheap"].(map[string]any)
+	prompt, _ := orch["prompt"].(string)
+
+	// The profile orchestrator prompt model assignment table must include JD agents
+	for _, jd := range []string{"jd-judge-a", "jd-judge-b", "jd-fix-agent"} {
+		if !strings.Contains(prompt, "| "+jd+" |") {
+			t.Errorf("profile orchestrator prompt model assignment table missing JD agent %q; prompt snippet: %q", jd, prompt[:min(500, len(prompt))])
+		}
+	}
+}
+
 // ─── RemoveProfileAgents ─────────────────────────────────────────────────
 
 func buildSettingsWithProfiles(t *testing.T) (path string) {

--- a/internal/tui/screens/model_picker.go
+++ b/internal/tui/screens/model_picker.go
@@ -710,7 +710,7 @@ func renderPhaseList(
 				assignment, ok := assignments[phase]
 				if ok && assignment.ProviderID != "" {
 					provName, modelName := resolveNames(assignment, state)
-					label = fmt.Sprintf("%-20s %s / %s", row, provName, modelName)
+					label = formatAssignmentLabel(row, provName, modelName, assignment.Effort)
 				} else {
 					label = fmt.Sprintf("%-20s (default)", row)
 				}

--- a/internal/tui/screens/model_picker_test.go
+++ b/internal/tui/screens/model_picker_test.go
@@ -913,6 +913,38 @@ func TestRenderPhaseList_NoEffortAnnotationWhenEmpty(t *testing.T) {
 	}
 }
 
+func TestRenderPhaseList_JDAgentEffortAnnotation(t *testing.T) {
+	const providerID = "test-provider"
+	state := ModelPickerState{
+		Providers: map[string]opencode.Provider{
+			providerID: {ID: providerID, Name: "TestProv", Models: map[string]opencode.Model{
+				"model-x": {ID: "model-x", Name: "Model X"},
+			}},
+		},
+		AvailableIDs: []string{providerID},
+		SDDModels: map[string][]opencode.Model{
+			providerID: {{ID: "model-x", Name: "Model X"}},
+		},
+		Mode: ModePhaseList,
+	}
+	jdPhases := opencode.JDPhases()
+	assignments := map[string]model.ModelAssignment{
+		jdPhases[0]: {ProviderID: providerID, ModelID: "model-x", Effort: "max"},
+		jdPhases[1]: {ProviderID: providerID, ModelID: "model-x", Effort: "low"},
+		jdPhases[2]: {ProviderID: providerID, ModelID: "model-x", Effort: ""},
+	}
+
+	rendered := RenderModelPicker(assignments, state, 0)
+
+	// JD agent rows must show effort annotation when set
+	if !strings.Contains(rendered, "[max]") {
+		t.Errorf("rendered JD agent row should contain '[max]' for jd-judge-a; got:\n%s", rendered)
+	}
+	if !strings.Contains(rendered, "[low]") {
+		t.Errorf("rendered JD agent row should contain '[low]' for jd-judge-b; got:\n%s", rendered)
+	}
+}
+
 // ─── TestIndividualPhaseSelectionDoesNotSetAllPhasesModel (unchanged) ──────
 
 // TestIndividualPhaseSelectionDoesNotSetAllPhasesModel verifies that selecting


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #725

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)

---

## 📝 Summary

Fixes two bugs from the JD configurable models feature (#475/#476/#477):

1. **Cosmetic**: JD agent rows in the TUI model picker now display the reasoning effort annotation (e.g. `[max]`)
2. **Functional (quota impact)**: Named profile orchestrator now includes JD agents in its model assignment table, so it delegates with the correct model instead of falling back to its own — preserving diversity of perspective and respecting user's cost configuration

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/tui/screens/model_picker.go` | JD agent label rendering now uses `formatAssignmentLabel()` with effort parameter instead of bare `fmt.Sprintf` |
| `internal/tui/screens/model_picker_test.go` | New test `TestRenderPhaseList_JDAgentEffortAnnotation` validates effort brackets appear for JD rows |
| `internal/components/sdd/profiles.go` | `renderProfileModelAssignmentsSection()` now appends JD agents to the model assignment table after SDD phases |
| `internal/components/sdd/profiles_test.go` | New test `TestGenerateProfileOverlay_OrchestratorPromptIncludesJDAgents` validates JD agents appear in profile prompt |

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./internal/tui/screens/ ./internal/components/sdd/
```

- [x] Unit tests pass
- [x] New test validates JD effort annotation renders correctly
- [x] New test validates JD agents appear in profile orchestrator prompt
- [x] Manually verified: profile orchestrator prompt contains JD agents with `global (not profile-scoped)` marker

---

## 🤖 Automated Checks

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ✅ | 75 changed lines (within 400-line budget) |
| Check Issue Reference | ✅ | `Closes #725` |
| Check Issue Has `status:approved` | ⏳ | Linked issue needs `status:approved` label |
| Check PR Has `type:*` Label | ⏳ | Needs `type:bug` label from maintainer |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue
- [x] PR stays within 400 changed lines (75 lines)
- [x] Unit tests pass
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

### Why Bug 2 matters (quota impact)

The Diversity preset assigns:
- Judge A → Opus (deep reasoning, expensive)
- Judge B → Haiku (fast pattern matching, cheap)
- Fix → Sonnet (balanced)

Without this fix, when using a named profile, **all 3 JD agents fall back to the orchestrator's model**. If the orchestrator runs Opus:
- Judge B consumes Opus quota instead of Haiku (3-10x more expensive)
- Judge A and Judge B use the same model → diversity of perspective is lost
- Users who configured cheap models for JD agents pay for expensive ones

### Root Cause

Two oversights in the JD chain (#475/#476/#477):

1. **model_picker.go line 713**: JD rows used `fmt.Sprintf` without effort, while SDD phases used `formatAssignmentLabel` with effort
2. **profiles.go `renderProfileModelAssignmentsSection()`**: Only iterated `profilePhaseOrder` (SDD), not `JDPhases()` — so the profile orchestrator's model table had no JD entries

### Size

74 additions, 1 deletion across 4 files (2 source + 2 test). Well within the 400-line review budget.

### Note

I don't have write access to add the `type:bug` label or get `status:approved` on the issue. Would appreciate a maintainer adding those.
