### PR TITLE
feat(agent): add Conductor workspace orchestrator support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,25 +25,26 @@ Gentle-AI is NOT an AI agent installer. Most agents are easy to install. It is a
 
 **After**: Your agent now has memory, skills, workflow, MCP tools, and a persona that actually teaches you.
 
-### 15 Supported Agents
+### 16 Supported Agents
 
-| Agent               |         Delegation Model         | Key Feature                                                     |
-| ------------------- | :------------------------------: | --------------------------------------------------------------- |
-| **Claude Code**     |         Full (Task tool)         | Sub-agents, output styles                                       |
-| **OpenCode**        |    Full (multi-mode overlay)     | Per-phase model routing                                         |
-| **Kilo Code**       |    Full (multi-mode overlay)     | OpenCode-compatible config in `~/.config/kilo`                  |
-| **Gemini CLI**      |       Full (experimental)        | Custom agents in `~/.gemini/agents/`                            |
-| **Cursor**          |     Full (native subagents)      | 10 SDD agents in `~/.cursor/agents/`                            |
-| **VS Code Copilot** |        Full (runSubagent)        | Parallel execution                                              |
-| **Codex**           |            Solo-agent            | CLI-native, TOML config                                         |
-| **Windsurf**        |            Solo-agent            | Plan Mode, Code Mode, native workflows                          |
-| **Antigravity**     |   Solo-agent + Mission Control   | Built-in Browser/Terminal sub-agents                            |
-| **Kimi Code**       |   Full (native custom agents)    | Modular prompt templates in `~/.kimi`                           |
-| **Kiro IDE**        |     Full (native subagents)      | Native `~/.kiro/agents/` + steering orchestration               |
-| **Qwen Code**       |     Full (native sub-agents)     | Slash commands, `~/.qwen/commands/`, `auto_edit` mode           |
-| **OpenClaw**        |            Solo-agent            | Workspace-first `AGENTS.md` / `SOUL.md` with global MCP config  |
-| **Trae**            |            Solo-agent            | Desktop app by ByteDance; `~/.trae/skills/` + OS-specific rules |
-| **Pi**              | Full (package-managed subagents) | `gentle-pi` harness with persona/model commands + Engram memory |
+| Agent               |         Delegation Model         | Key Feature                                                                  |
+| ------------------- | :------------------------------: | ---------------------------------------------------------------------------- |
+| **Claude Code**     |         Full (Task tool)         | Sub-agents, output styles                                                    |
+| **OpenCode**        |    Full (multi-mode overlay)     | Per-phase model routing                                                      |
+| **Kilo Code**       |    Full (multi-mode overlay)     | OpenCode-compatible config in `~/.config/kilo`                               |
+| **Gemini CLI**      |       Full (experimental)        | Custom agents in `~/.gemini/agents/`                                         |
+| **Cursor**          |     Full (native subagents)      | 10 SDD agents in `~/.cursor/agents/`                                         |
+| **VS Code Copilot** |        Full (runSubagent)        | Parallel execution                                                           |
+| **Codex**           |            Solo-agent            | CLI-native, TOML config                                                      |
+| **Windsurf**        |            Solo-agent            | Plan Mode, Code Mode, native workflows                                       |
+| **Antigravity**     |   Solo-agent + Mission Control   | Built-in Browser/Terminal sub-agents                                         |
+| **Kimi Code**       |   Full (native custom agents)    | Modular prompt templates in `~/.kimi`                                        |
+| **Kiro IDE**        |     Full (native subagents)      | Native `~/.kiro/agents/` + steering orchestration                            |
+| **Qwen Code**       |     Full (native sub-agents)     | Slash commands, `~/.qwen/commands/`, `auto_edit` mode                        |
+| **OpenClaw**        |            Solo-agent            | Workspace-first `AGENTS.md` / `SOUL.md` with global MCP config               |
+| **Trae**            |            Solo-agent            | Desktop app by ByteDance; `~/.trae/skills/` + OS-specific rules              |
+| **Pi**              | Full (package-managed subagents) | `gentle-pi` harness with persona/model commands + Engram memory              |
+| **Conductor**       |       Via Claude Code            | Workspace orchestrator; parallel git worktrees; inherits `~/.claude/` config |
 
 > **Note**: This project supersedes [Agent Teams Lite](https://github.com/Gentleman-Programming/agent-teams-lite) (now archived). Everything ATL provided is included here with better installation, automatic updates, and persistent memory.
 

--- a/internal/agents/conductor/adapter.go
+++ b/internal/agents/conductor/adapter.go
@@ -1,0 +1,109 @@
+package conductor
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	"github.com/gentleman-programming/gentle-ai/internal/model"
+	"github.com/gentleman-programming/gentle-ai/internal/system"
+)
+
+// Adapter implements agents.Adapter for Conductor (conductor.build).
+//
+// Conductor is a macOS workspace orchestrator that runs Claude Code agents in
+// parallel isolated git worktrees. It does not have its own skills, MCP, or
+// system prompt config — all of that flows through the Claude Code adapter
+// (~/.claude/). This adapter exists for detection and catalog purposes only.
+//
+// Detection: ~/.conductor/ is created by Conductor on first launch.
+// No binary appears on PATH (desktop app).
+type Adapter struct {
+	statPath func(string) (os.FileInfo, error)
+}
+
+func NewAdapter() *Adapter {
+	return &Adapter{statPath: os.Stat}
+}
+
+// --- Identity ---
+
+func (a *Adapter) Agent() model.AgentID    { return model.AgentConductor }
+func (a *Adapter) Tier() model.SupportTier { return model.TierFull }
+
+// --- Detection ---
+
+// Detect checks for the ~/.conductor directory, which Conductor creates on first launch.
+// No binary appears on PATH (desktop app).
+func (a *Adapter) Detect(_ context.Context, homeDir string) (bool, string, string, bool, error) {
+	configPath := a.GlobalConfigDir(homeDir)
+	info, err := a.statPath(configPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, "", configPath, false, nil
+		}
+		return false, "", "", false, err
+	}
+	installed := info.IsDir()
+	return installed, "", configPath, installed, nil
+}
+
+// --- Installation ---
+
+func (a *Adapter) SupportsAutoInstall() bool { return false }
+
+func (a *Adapter) InstallCommand(_ system.PlatformProfile) ([][]string, error) {
+	return nil, AgentNotInstallableError{Agent: model.AgentConductor}
+}
+
+// --- Config paths ---
+
+// GlobalConfigDir returns ~/.conductor, the root Conductor config directory.
+func (a *Adapter) GlobalConfigDir(homeDir string) string {
+	return filepath.Join(homeDir, ".conductor")
+}
+
+// Conductor has no standalone system prompt, skills, settings, or MCP config.
+// All config is inherited from the Claude Code adapter (~/.claude/).
+func (a *Adapter) SystemPromptDir(_ string) string  { return "" }
+func (a *Adapter) SystemPromptFile(_ string) string { return "" }
+func (a *Adapter) SkillsDir(_ string) string        { return "" }
+func (a *Adapter) SettingsPath(_ string) string     { return "" }
+
+// --- Config strategies ---
+
+func (a *Adapter) SystemPromptStrategy() model.SystemPromptStrategy {
+	return model.StrategyMarkdownSections
+}
+
+func (a *Adapter) MCPStrategy() model.MCPStrategy {
+	return model.StrategyMCPConfigFile
+}
+
+// --- MCP ---
+
+func (a *Adapter) MCPConfigPath(_ string, _ string) string { return "" }
+
+// --- Optional capabilities ---
+
+// Conductor has no config files of its own — capabilities are all false.
+// Config is inherited from the Claude Code agent (~/.claude/).
+func (a *Adapter) SupportsOutputStyles() bool     { return false }
+func (a *Adapter) OutputStyleDir(_ string) string { return "" }
+func (a *Adapter) SupportsSlashCommands() bool    { return false }
+func (a *Adapter) CommandsDir(_ string) string    { return "" }
+func (a *Adapter) SupportsSubAgents() bool        { return false }
+func (a *Adapter) SubAgentsDir(_ string) string   { return "" }
+func (a *Adapter) EmbeddedSubAgentsDir() string   { return "" }
+func (a *Adapter) SupportsSkills() bool           { return false }
+func (a *Adapter) SupportsSystemPrompt() bool     { return false }
+func (a *Adapter) SupportsMCP() bool              { return false }
+
+// AgentNotInstallableError is returned when InstallCommand is called on a desktop-only agent.
+type AgentNotInstallableError struct {
+	Agent model.AgentID
+}
+
+func (e AgentNotInstallableError) Error() string {
+	return "agent " + string(e.Agent) + " is a desktop app and cannot be installed via CLI"
+}

--- a/internal/agents/conductor/adapter_test.go
+++ b/internal/agents/conductor/adapter_test.go
@@ -1,0 +1,174 @@
+package conductor
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/gentleman-programming/gentle-ai/internal/model"
+	"github.com/gentleman-programming/gentle-ai/internal/system"
+)
+
+const testHome = "/tmp/home"
+
+func TestDetect(t *testing.T) {
+	tests := []struct {
+		name            string
+		statErr         error
+		statIsDir       bool
+		wantInstalled   bool
+		wantConfigPath  string
+		wantConfigFound bool
+		wantErr         bool
+	}{
+		{
+			name:            "config directory found",
+			statIsDir:       true,
+			wantInstalled:   true,
+			wantConfigPath:  filepath.Join(testHome, ".conductor"),
+			wantConfigFound: true,
+		},
+		{
+			name:            "config missing",
+			statErr:         os.ErrNotExist,
+			wantInstalled:   false,
+			wantConfigPath:  filepath.Join(testHome, ".conductor"),
+			wantConfigFound: false,
+		},
+		{
+			name:            "config exists but is a file not a dir",
+			statIsDir:       false,
+			wantInstalled:   false,
+			wantConfigPath:  filepath.Join(testHome, ".conductor"),
+			wantConfigFound: false,
+		},
+		{
+			name:    "stat error bubbles up",
+			statErr: errors.New("permission denied"),
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := &Adapter{
+				statPath: func(string) (os.FileInfo, error) {
+					if tt.statErr != nil {
+						return nil, tt.statErr
+					}
+					return &fakeFileInfo{isDir: tt.statIsDir}, nil
+				},
+			}
+			installed, _, configPath, configFound, err := a.Detect(context.Background(), testHome)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Detect() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if installed != tt.wantInstalled {
+				t.Fatalf("Detect() installed = %v, want %v", installed, tt.wantInstalled)
+			}
+			if configPath != tt.wantConfigPath {
+				t.Fatalf("Detect() configPath = %q, want %q", configPath, tt.wantConfigPath)
+			}
+			if configFound != tt.wantConfigFound {
+				t.Fatalf("Detect() configFound = %v, want %v", configFound, tt.wantConfigFound)
+			}
+		})
+	}
+}
+
+func TestConfigPaths(t *testing.T) {
+	a := NewAdapter()
+
+	wantGlobal := filepath.Join(testHome, ".conductor")
+	if got := a.GlobalConfigDir(testHome); got != wantGlobal {
+		t.Fatalf("GlobalConfigDir() = %q, want %q", got, wantGlobal)
+	}
+
+	if got := a.SystemPromptDir(testHome); got != "" {
+		t.Fatalf("SystemPromptDir() = %q, want empty (no standalone config)", got)
+	}
+	if got := a.SystemPromptFile(testHome); got != "" {
+		t.Fatalf("SystemPromptFile() = %q, want empty (no standalone config)", got)
+	}
+	if got := a.SkillsDir(testHome); got != "" {
+		t.Fatalf("SkillsDir() = %q, want empty (no standalone config)", got)
+	}
+	if got := a.SettingsPath(testHome); got != "" {
+		t.Fatalf("SettingsPath() = %q, want empty (no standalone config)", got)
+	}
+	if got := a.MCPConfigPath(testHome, "any-server"); got != "" {
+		t.Fatalf("MCPConfigPath() = %q, want empty (no standalone config)", got)
+	}
+}
+
+func TestAgentIdentity(t *testing.T) {
+	a := NewAdapter()
+
+	if got := a.Agent(); got != model.AgentConductor {
+		t.Fatalf("Agent() = %v, want %v", got, model.AgentConductor)
+	}
+	if got := a.Tier(); got != model.TierFull {
+		t.Fatalf("Tier() = %v, want %v", got, model.TierFull)
+	}
+}
+
+func TestCapabilities(t *testing.T) {
+	a := NewAdapter()
+
+	if a.SupportsSkills() {
+		t.Fatal("Conductor should NOT support skills (inherited from Claude Code)")
+	}
+	if a.SupportsSystemPrompt() {
+		t.Fatal("Conductor should NOT support system prompt (inherited from Claude Code)")
+	}
+	if a.SupportsMCP() {
+		t.Fatal("Conductor should NOT support MCP (inherited from Claude Code)")
+	}
+	if a.SupportsAutoInstall() {
+		t.Fatal("Conductor should NOT support auto-install (desktop app)")
+	}
+	if a.SupportsOutputStyles() {
+		t.Fatal("Conductor should NOT support output styles")
+	}
+	if a.SupportsSlashCommands() {
+		t.Fatal("Conductor should NOT support slash commands")
+	}
+	if a.SupportsSubAgents() {
+		t.Fatal("Conductor should NOT support sub-agents")
+	}
+}
+
+func TestDesktopAppNotAutoInstallable(t *testing.T) {
+	a := NewAdapter()
+
+	_, err := a.InstallCommand(system.PlatformProfile{})
+	if err == nil {
+		t.Fatal("InstallCommand() should return error for desktop app")
+	}
+
+	notInstallable, ok := err.(AgentNotInstallableError)
+	if !ok {
+		t.Fatalf("InstallCommand() error type = %T, want AgentNotInstallableError", err)
+	}
+	if notInstallable.Agent != model.AgentConductor {
+		t.Fatalf("AgentNotInstallableError.Agent = %v, want %v", notInstallable.Agent, model.AgentConductor)
+	}
+}
+
+// fakeFileInfo implements os.FileInfo for testing.
+type fakeFileInfo struct {
+	isDir bool
+}
+
+func (f *fakeFileInfo) Name() string      { return ".conductor" }
+func (f *fakeFileInfo) Size() int64       { return 0 }
+func (f *fakeFileInfo) Mode() os.FileMode { return 0o755 }
+func (f *fakeFileInfo) ModTime() time.Time { return time.Time{} }
+func (f *fakeFileInfo) IsDir() bool        { return f.isDir }
+func (f *fakeFileInfo) Sys() interface{}   { return nil }

--- a/internal/agents/factory.go
+++ b/internal/agents/factory.go
@@ -6,6 +6,7 @@ import (
 	"github.com/gentleman-programming/gentle-ai/internal/agents/antigravity"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/claude"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/codex"
+	"github.com/gentleman-programming/gentle-ai/internal/agents/conductor"
 	cursoradapter "github.com/gentleman-programming/gentle-ai/internal/agents/cursor"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/gemini"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/kilocode"
@@ -37,6 +38,7 @@ var defaultAgentIDs = []model.AgentID{
 	model.AgentOpenClaw,
 	model.AgentPi,
 	model.AgentTrae,
+	model.AgentConductor,
 }
 
 func NewAdapter(agent model.AgentID) (Adapter, error) {
@@ -71,6 +73,8 @@ func NewAdapter(agent model.AgentID) (Adapter, error) {
 		return pi.NewAdapter(), nil
 	case model.AgentTrae:
 		return trae.NewAdapter(), nil
+	case model.AgentConductor:
+		return conductor.NewAdapter(), nil
 	default:
 		return nil, AgentNotSupportedError{Agent: agent}
 	}

--- a/internal/agents/factory_test.go
+++ b/internal/agents/factory_test.go
@@ -72,6 +72,7 @@ func TestDefaultRegistrySupportedAgentsMatchesFactoryAgents(t *testing.T) {
 		model.AgentAntigravity,
 		model.AgentClaudeCode,
 		model.AgentCodex,
+		model.AgentConductor,
 		model.AgentCursor,
 		model.AgentGeminiCLI,
 		model.AgentKilocode,

--- a/internal/catalog/agents.go
+++ b/internal/catalog/agents.go
@@ -7,6 +7,7 @@ type Agent struct {
 	Name       string
 	Tier       model.SupportTier
 	ConfigPath string
+	Note       string
 }
 
 var allAgents = []Agent{
@@ -25,6 +26,13 @@ var allAgents = []Agent{
 	{ID: model.AgentOpenClaw, Name: "OpenClaw", Tier: model.TierFull, ConfigPath: "~/.openclaw"},
 	{ID: model.AgentPi, Name: "Pi", Tier: model.TierFull, ConfigPath: "~/.pi"},
 	{ID: model.AgentTrae, Name: "Trae IDE", Tier: model.TierFull, ConfigPath: "~/.trae"},
+	{
+		ID:         model.AgentConductor,
+		Name:       "Conductor",
+		Tier:       model.TierFull,
+		ConfigPath: "~/.conductor",
+		Note:       "Conductor workspaces inherit Claude Code config (~/.claude). No additional files are written for this agent.",
+	},
 }
 
 // mvpAgents are the original MVP agents (Claude Code, OpenCode).

--- a/internal/cli/install_test.go
+++ b/internal/cli/install_test.go
@@ -58,7 +58,7 @@ func TestNormalizeInstallFlagsDefaults(t *testing.T) {
 	}
 
 	want := model.Selection{
-		Agents:  []model.AgentID{model.AgentClaudeCode, model.AgentOpenCode, model.AgentKilocode, model.AgentGeminiCLI, model.AgentCodex, model.AgentCursor, model.AgentVSCodeCopilot, model.AgentAntigravity, model.AgentWindsurf, model.AgentKimi, model.AgentQwenCode, model.AgentKiroIDE, model.AgentOpenClaw, model.AgentPi, model.AgentTrae},
+		Agents:  []model.AgentID{model.AgentClaudeCode, model.AgentOpenCode, model.AgentKilocode, model.AgentGeminiCLI, model.AgentCodex, model.AgentCursor, model.AgentVSCodeCopilot, model.AgentAntigravity, model.AgentWindsurf, model.AgentKimi, model.AgentQwenCode, model.AgentKiroIDE, model.AgentOpenClaw, model.AgentPi, model.AgentTrae, model.AgentConductor},
 		Persona: model.PersonaGentleman,
 		Preset:  model.PresetFullGentleman,
 		Components: []model.ComponentID{
@@ -265,7 +265,7 @@ func TestRunInstallDryRunSkipsExecution(t *testing.T) {
 func makeDetectionWithAgents(present ...string) system.DetectionResult {
 	var configs []system.ConfigState
 	// Full canonical agent set — mirrors knownAgentConfigDirs in config_scan.go.
-	known := []string{"claude-code", "opencode", "kilocode", "gemini-cli", "cursor", "vscode-copilot", "codex", "antigravity", "windsurf", "kimi", "qwen-code", "kiro-ide", "openclaw", "pi", "trae-ide"}
+	known := []string{"claude-code", "opencode", "kilocode", "gemini-cli", "cursor", "vscode-copilot", "codex", "antigravity", "windsurf", "kimi", "qwen-code", "kiro-ide", "openclaw", "pi", "trae-ide", "conductor"}
 	presentSet := make(map[string]bool, len(present))
 	for _, p := range present {
 		presentSet[p] = true

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -18,6 +18,7 @@ const (
 	AgentOpenClaw      AgentID = "openclaw"
 	AgentPi            AgentID = "pi"
 	AgentTrae          AgentID = "trae-ide"
+	AgentConductor     AgentID = "conductor"
 )
 
 // SupportTier indicates how fully an agent supports the Gentleman AI ecosystem.

--- a/internal/planner/review.go
+++ b/internal/planner/review.go
@@ -1,6 +1,9 @@
 package planner
 
-import "github.com/gentleman-programming/gentle-ai/internal/model"
+import (
+	"github.com/gentleman-programming/gentle-ai/internal/catalog"
+	"github.com/gentleman-programming/gentle-ai/internal/model"
+)
 
 func BuildReviewPayload(selection model.Selection, resolved ResolvedPlan) ReviewPayload {
 	autoAdded := make(map[model.ComponentID]struct{}, len(resolved.AddedDependencies))
@@ -21,6 +24,8 @@ func BuildReviewPayload(selection model.Selection, resolved ResolvedPlan) Review
 		components = append(components, ComponentAction{ID: component, Action: action})
 	}
 
+	agentNotes := buildAgentNotes(resolved.Agents)
+
 	return ReviewPayload{
 		Agents:            resolved.Agents,
 		UnsupportedAgents: resolved.UnsupportedAgents,
@@ -32,7 +37,30 @@ func BuildReviewPayload(selection model.Selection, resolved ResolvedPlan) Review
 		// Issue #145: pass skills from selection.
 		Skills: selection.Skills,
 		// Issue #149: pass StrictTDD and whether SDD is in plan.
-		StrictTDD: selection.StrictTDD,
-		HasSDD:    hasSDD,
+		StrictTDD:  selection.StrictTDD,
+		HasSDD:     hasSDD,
+		AgentNotes: agentNotes,
 	}
+}
+
+// buildAgentNotes collects catalog notes for the selected agents.
+// Only agents that carry a Note in the catalog are included.
+func buildAgentNotes(agents []model.AgentID) map[model.AgentID]string {
+	notesByID := map[model.AgentID]string{}
+	for _, a := range catalog.AllAgents() {
+		if a.Note != "" {
+			notesByID[a.ID] = a.Note
+		}
+	}
+
+	result := map[model.AgentID]string{}
+	for _, id := range agents {
+		if note, ok := notesByID[id]; ok {
+			result[id] = note
+		}
+	}
+	if len(result) == 0 {
+		return nil
+	}
+	return result
 }

--- a/internal/planner/types.go
+++ b/internal/planner/types.go
@@ -37,6 +37,10 @@ type ReviewPayload struct {
 	// HasSDD is true when the SDD component is present in the resolved plan (Issue #149).
 	// Controls whether the Strict TDD row is shown in the review screen.
 	HasSDD bool
+
+	// AgentNotes holds informational notes for selected agents that have special
+	// behavior (e.g. Conductor inheriting config from Claude Code).
+	AgentNotes map[model.AgentID]string
 }
 
 type PlatformDecision struct {

--- a/internal/system/config_scan.go
+++ b/internal/system/config_scan.go
@@ -44,6 +44,7 @@ func knownAgentConfigDirs(homeDir string) []ConfigState {
 		{Agent: "openclaw", Path: filepath.Join(homeDir, ".openclaw")},
 		{Agent: "pi", Path: filepath.Join(homeDir, ".pi")},
 		{Agent: "trae-ide", Path: filepath.Join(homeDir, ".trae")},
+		{Agent: "conductor", Path: filepath.Join(homeDir, ".conductor")},
 	}
 }
 

--- a/internal/tui/screens/review.go
+++ b/internal/tui/screens/review.go
@@ -60,6 +60,15 @@ func RenderReview(payload planner.ReviewPayload, cursor int) string {
 		b.WriteString("\n")
 	}
 
+	if len(payload.AgentNotes) > 0 {
+		b.WriteString(styles.HeadingStyle.Render("Notes"))
+		b.WriteString("\n")
+		for agentID, note := range payload.AgentNotes {
+			b.WriteString("  " + styles.UnselectedStyle.Render(string(agentID)) + ": " + styles.SubtextStyle.Render(note) + "\n")
+		}
+		b.WriteString("\n")
+	}
+
 	if len(payload.UnsupportedAgents) > 0 {
 		b.WriteString(styles.WarningStyle.Render("Unsupported agents: " + joinIDs(payload.UnsupportedAgents)))
 		b.WriteString("\n\n")


### PR DESCRIPTION
## Summary

- Adds Conductor (conductor.build) as a supported agent — detection via `~/.conductor/`, registration in catalog and factory, entry in system detection scan, and README update (16 agents)
- Adds `Note` field to `catalog.Agent` so agents with special behavior can surface an informational message in the TUI
- Renders a **Notes** section in the Review screen when a selected agent carries a note (e.g. "Conductor workspaces inherit Claude Code config — no additional files written")
- No skills, MCP, or system prompt files are written for Conductor; all config flows through the Claude Code adapter

## Test plan

- [ ] `go test ./...` passes (all packages green)
- [ ] Run `gga` locally: Conductor appears in System Detection as `present`
- [ ] Select Conductor in agent list: Notes section appears in Review screen with the expected message
- [ ] Install completes: `agent:conductor` step succeeds with no errors

Closes #730