### PR TITLE
fix(vscode): harden Copilot agent install

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,14 @@ After creating a profile, open OpenCode and press **Tab** to switch between `gen
 
 **Full guide**: [OpenCode SDD Profiles](docs/opencode-profiles.md)
 
+### VS Code Copilot SDD Agents
+
+Gentle-AI installs three VS Code layers: global instructions/rules in `Code/User/prompts/gentle-ai.instructions.md`, native custom agents in `~/.copilot/agents`, and SDD skills/shared conventions in `~/.copilot/skills`.
+
+When a VS Code model assignment is missing, invalid, or unvalidated, generated agents omit `model` and inherit the parent chat model instead of failing sync.
+
+If VS Code also discovers Gentle-AI's Claude-format internal agents, sync marks those managed `sdd-*` and `jd-*` files `user-invocable: false` so the visible picker stays focused on `sdd-orchestrator`.
+
 ### Engram (Persistent Memory)
 
 Your AI agent automatically remembers decisions, bugs, and context across sessions. You don't need to do anything -- but when you do:

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ After creating a profile, open OpenCode and press **Tab** to switch between `gen
 
 ### VS Code Copilot SDD Agents
 
-Gentle-AI installs three VS Code layers: global instructions/rules in `Code/User/prompts/gentle-ai.instructions.md`, native custom agents in `~/.copilot/agents`, and SDD skills/shared conventions in `~/.copilot/skills`.
+Gentle-AI installs three VS Code layers: global instructions/rules in the VS Code user prompts folder (e.g. `%APPDATA%/Code/User/prompts/gentle-ai.instructions.md` on Windows, `~/Library/Application Support/Code/User/prompts/gentle-ai.instructions.md` on macOS, or `~/.config/Code/User/prompts/gentle-ai.instructions.md` on Linux), native custom agents in `~/.copilot/agents`, and SDD skills/shared conventions in `~/.copilot/skills`.
 
 When a VS Code model assignment is missing, invalid, or unvalidated, generated agents omit `model` and inherit the parent chat model instead of failing sync.
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -130,10 +130,13 @@ Kiro uses native custom agents in `~/.kiro/agents/`. `gentle-ai` writes phase ag
 
 ### VS Code Copilot
 
-- Uses the `runSubagent` tool with support for parallel execution
-- Skills at `~/.copilot/skills/`
-- System prompt at `Code/User/prompts/gentle-ai.instructions.md`
+- Native custom agents at `~/.copilot/agents/*.agent.md`: one user-invocable `sdd-orchestrator` coordinator plus hidden SDD phase agents
+- Delegates through VS Code Copilot's native sub-agent / `runSubagent` flow
+- Skills and shared SDD conventions at `~/.copilot/skills/`
+- Global instructions/rules at `Code/User/prompts/gentle-ai.instructions.md`
 - MCP config at `Code/User/mcp.json`
+- Missing, invalid, or unvalidated model assignments omit `model` and inherit the parent chat model
+- VS Code may also discover Claude-format agents in `~/.claude/agents`; Gentle-AI marks its managed internal `sdd-*` and `jd-*` Claude agents `user-invocable: false` so the picker stays focused on `sdd-orchestrator`
 
 ### Codex
 

--- a/internal/agents/vscode/adapter.go
+++ b/internal/agents/vscode/adapter.go
@@ -73,6 +73,7 @@ func (a *Adapter) InstallCommand(_ system.PlatformProfile) ([][]string, error) {
 // VS Code Copilot reads .instructions.md files from the VS Code User prompts folder.
 // Skills are loaded from ~/.copilot/skills/ (global), .github/skills/ (workspace),
 // ~/.claude/skills/, and .claude/skills/. We target ~/.copilot/skills/ for global reach.
+// Native agent files are installed globally under ~/.copilot/agents/.
 
 func (a *Adapter) GlobalConfigDir(homeDir string) string {
 	return filepath.Join(homeDir, ".copilot")
@@ -149,15 +150,15 @@ func (a *Adapter) CommandsDir(_ string) string {
 }
 
 func (a *Adapter) SupportsSubAgents() bool {
-	return false
+	return true
 }
 
-func (a *Adapter) SubAgentsDir(_ string) string {
-	return ""
+func (a *Adapter) SubAgentsDir(homeDir string) string {
+	return filepath.Join(homeDir, ".copilot", "agents")
 }
 
 func (a *Adapter) EmbeddedSubAgentsDir() string {
-	return ""
+	return "vscode/agents"
 }
 
 func (a *Adapter) SupportsSkills() bool {

--- a/internal/agents/vscode/adapter_test.go
+++ b/internal/agents/vscode/adapter_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/gentleman-programming/gentle-ai/internal/model"
@@ -131,5 +132,27 @@ func TestMCPConfigPathUsesVSCodeUserProfile(t *testing.T) {
 		if path != want {
 			t.Fatalf("MCPConfigPath() = %q, want %q", path, want)
 		}
+	}
+}
+
+func TestSubAgentSupportUsesCopilotUserAgentsDir(t *testing.T) {
+	a := NewAdapter()
+	home := "/tmp/home"
+
+	if !a.SupportsSubAgents() {
+		t.Fatal("VS Code adapter must advertise native sub-agent support")
+	}
+
+	got := a.SubAgentsDir(home)
+	want := filepath.Join(home, ".copilot", "agents")
+	if got != want {
+		t.Fatalf("SubAgentsDir() = %q, want %q", got, want)
+	}
+	if got == filepath.Join(home, ".github", "agents") || strings.Contains(got, string(filepath.Separator)+".github"+string(filepath.Separator)) {
+		t.Fatalf("SubAgentsDir() must not target workspace .github/agents, got %q", got)
+	}
+
+	if got := a.EmbeddedSubAgentsDir(); got != "vscode/agents" {
+		t.Fatalf("EmbeddedSubAgentsDir() = %q, want %q", got, "vscode/agents")
 	}
 }

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -810,7 +810,7 @@ func loadPersistedAssignments(homeDir string, selection *model.Selection) {
 		selection.ModelAssignments = m
 	}
 	if len(selection.VSCodeModelAssignments) == 0 && len(s.VSCodeModelAssignments) > 0 {
-		selection.VSCodeModelAssignments = stateModelAssignmentsToModel(s.VSCodeModelAssignments)
+		selection.VSCodeModelAssignments = cli.StateModelAssignmentsToModel(s.VSCodeModelAssignments)
 	}
 }
 
@@ -909,17 +909,6 @@ func persistAssignments(homeDir string, selection model.Selection) error {
 		}
 	}
 	return state.Write(homeDir, current)
-}
-
-func stateModelAssignmentsToModel(m map[string]state.ModelAssignmentState) map[string]model.ModelAssignment {
-	if len(m) == 0 {
-		return nil
-	}
-	out := make(map[string]model.ModelAssignment, len(m))
-	for k, v := range m {
-		out[k] = model.ModelAssignment{ProviderID: v.ProviderID, ModelID: v.ModelID, Effort: v.Effort}
-	}
-	return out
 }
 
 // claudeAliasesToStrings converts a typed ClaudeModelAlias map to plain strings

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -901,8 +901,12 @@ func persistAssignments(homeDir string, selection model.Selection) error {
 			current.ModelAssignments = nil
 		}
 	}
-	if len(selection.VSCodeModelAssignments) > 0 {
-		current.VSCodeModelAssignments = modelAssignmentsToState(selection.VSCodeModelAssignments)
+	if selection.VSCodeModelAssignments != nil {
+		if len(selection.VSCodeModelAssignments) > 0 {
+			current.VSCodeModelAssignments = modelAssignmentsToState(selection.VSCodeModelAssignments)
+		} else {
+			current.VSCodeModelAssignments = nil
+		}
 	}
 	return state.Write(homeDir, current)
 }

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -549,6 +549,7 @@ func tuiExecute(
 			CodexCarrilModelAssignments: selection.CodexCarrilModelAssignments,
 			CodexPhaseModelAssignments:  selection.CodexPhaseModelAssignments,
 			ModelAssignments:            modelAssignmentsToState(selection.ModelAssignments),
+			VSCodeModelAssignments:      modelAssignmentsToState(selection.VSCodeModelAssignments),
 			Persona:                     string(selection.Persona),
 		}
 		installState.SetSelection(selection)
@@ -690,6 +691,9 @@ func applyOverrides(selection *model.Selection, overrides *model.SyncOverrides) 
 	if overrides.ModelAssignments != nil {
 		selection.ModelAssignments = overrides.ModelAssignments
 	}
+	if overrides.VSCodeModelAssignments != nil {
+		selection.VSCodeModelAssignments = overrides.VSCodeModelAssignments
+	}
 	if overrides.ClaudeModelAssignments != nil {
 		selection.ClaudeModelAssignments = overrides.ClaudeModelAssignments
 	}
@@ -805,6 +809,9 @@ func loadPersistedAssignments(homeDir string, selection *model.Selection) {
 		}
 		selection.ModelAssignments = m
 	}
+	if len(selection.VSCodeModelAssignments) == 0 && len(s.VSCodeModelAssignments) > 0 {
+		selection.VSCodeModelAssignments = stateModelAssignmentsToModel(s.VSCodeModelAssignments)
+	}
 }
 
 // persistAssignments writes the model assignments from selection back to
@@ -820,12 +827,13 @@ func persistAssignments(homeDir string, selection model.Selection) error {
 		selection.ClaudePhaseAssignments != nil ||
 		selection.KiroModelAssignments != nil ||
 		selection.ModelAssignments != nil ||
+		selection.VSCodeModelAssignments != nil ||
 		selection.CodexModelAssignments != nil ||
 		selection.CodexOrchestratorAssignment != nil ||
 		selection.ClearCodexOrchestratorAssignment ||
 		selection.CodexCarrilModelAssignments != nil ||
 		selection.CodexPhaseModelAssignments != nil
-	if len(selection.ClaudeModelAssignments) == 0 && len(selection.ClaudePhaseAssignments) == 0 && len(selection.KiroModelAssignments) == 0 && len(selection.ModelAssignments) == 0 && len(selection.CodexModelAssignments) == 0 && len(selection.CodexCarrilModelAssignments) == 0 && len(selection.CodexPhaseModelAssignments) == 0 && !hasAssignmentSignal {
+	if len(selection.ClaudeModelAssignments) == 0 && len(selection.ClaudePhaseAssignments) == 0 && len(selection.KiroModelAssignments) == 0 && len(selection.ModelAssignments) == 0 && len(selection.VSCodeModelAssignments) == 0 && len(selection.CodexModelAssignments) == 0 && len(selection.CodexCarrilModelAssignments) == 0 && len(selection.CodexPhaseModelAssignments) == 0 && !hasAssignmentSignal {
 		return nil
 	}
 	current, err := state.Read(homeDir)
@@ -893,7 +901,21 @@ func persistAssignments(homeDir string, selection model.Selection) error {
 			current.ModelAssignments = nil
 		}
 	}
+	if len(selection.VSCodeModelAssignments) > 0 {
+		current.VSCodeModelAssignments = modelAssignmentsToState(selection.VSCodeModelAssignments)
+	}
 	return state.Write(homeDir, current)
+}
+
+func stateModelAssignmentsToModel(m map[string]state.ModelAssignmentState) map[string]model.ModelAssignment {
+	if len(m) == 0 {
+		return nil
+	}
+	out := make(map[string]model.ModelAssignment, len(m))
+	for k, v := range m {
+		out[k] = model.ModelAssignment{ProviderID: v.ProviderID, ModelID: v.ModelID, Effort: v.Effort}
+	}
+	return out
 }
 
 // claudeAliasesToStrings converts a typed ClaudeModelAlias map to plain strings

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -483,6 +483,34 @@ func TestTuiSyncSDDProfileStrategyEmptyOverrideNoChange(t *testing.T) {
 	}
 }
 
+func TestApplyOverridesVSCodeModelAssignments(t *testing.T) {
+	selection := model.Selection{
+		VSCodeModelAssignments: map[string]model.ModelAssignment{
+			"sdd-apply": {ProviderID: "github-copilot", ModelID: "gpt-4.1"},
+		},
+		ModelAssignments: map[string]model.ModelAssignment{
+			"sdd-apply": {ProviderID: "anthropic", ModelID: "claude-opus-4"},
+		},
+	}
+	overrides := &model.SyncOverrides{
+		VSCodeModelAssignments: map[string]model.ModelAssignment{
+			"sdd-design": {ProviderID: "github-copilot", ModelID: "claude-sonnet-4"},
+		},
+	}
+
+	applyOverrides(&selection, overrides)
+
+	if _, exists := selection.VSCodeModelAssignments["sdd-apply"]; exists {
+		t.Fatal("VSCodeModelAssignments should be replaced as a whole map, not merged key-by-key")
+	}
+	if got := selection.VSCodeModelAssignments["sdd-design"].ProviderID; got != "github-copilot" {
+		t.Fatalf("VSCodeModelAssignments[sdd-design].ProviderID = %q, want github-copilot", got)
+	}
+	if got := selection.ModelAssignments["sdd-apply"].ProviderID; got != "anthropic" {
+		t.Fatalf("OpenCode ModelAssignments changed after VS Code override: provider = %q", got)
+	}
+}
+
 func boolPtr(b bool) *bool { return &b }
 
 func TestTuiSyncTargetAgentsOverridePersistedInstallState(t *testing.T) {
@@ -945,6 +973,9 @@ func TestLoadPersistedAssignmentsPopulatesEmptySelection(t *testing.T) {
 		ModelAssignments: map[string]state.ModelAssignmentState{
 			"sdd-init": {ProviderID: "anthropic", ModelID: "claude-sonnet-4"},
 		},
+		VSCodeModelAssignments: map[string]state.ModelAssignmentState{
+			"sdd-apply": {ProviderID: "github-copilot", ModelID: "gpt-4.1"},
+		},
 	})
 	if err != nil {
 		t.Fatalf("state.Write: %v", err)
@@ -969,6 +1000,10 @@ func TestLoadPersistedAssignmentsPopulatesEmptySelection(t *testing.T) {
 	if ma.ProviderID != "anthropic" || ma.ModelID != "claude-sonnet-4" {
 		t.Errorf("ModelAssignments[sdd-init] = %+v, want anthropic/claude-sonnet-4", ma)
 	}
+	vs := selection.VSCodeModelAssignments["sdd-apply"]
+	if vs.ProviderID != "github-copilot" || vs.ModelID != "gpt-4.1" {
+		t.Errorf("VSCodeModelAssignments[sdd-apply] = %+v, want github-copilot/gpt-4.1", vs)
+	}
 }
 
 // TestLoadPersistedAssignmentsDoesNotOverrideExisting verifies that when the
@@ -983,6 +1018,9 @@ func TestLoadPersistedAssignmentsDoesNotOverrideExisting(t *testing.T) {
 		ModelAssignments: map[string]state.ModelAssignmentState{
 			"sdd-init": {ProviderID: "google", ModelID: "gemini-pro"},
 		},
+		VSCodeModelAssignments: map[string]state.ModelAssignmentState{
+			"sdd-apply": {ProviderID: "github-copilot", ModelID: "old-model"},
+		},
 	})
 	if err != nil {
 		t.Fatalf("state.Write: %v", err)
@@ -996,6 +1034,9 @@ func TestLoadPersistedAssignmentsDoesNotOverrideExisting(t *testing.T) {
 		ModelAssignments: map[string]model.ModelAssignment{
 			"sdd-init": {ProviderID: "anthropic", ModelID: "claude-sonnet-4"},
 		},
+		VSCodeModelAssignments: map[string]model.ModelAssignment{
+			"sdd-apply": {ProviderID: "github-copilot", ModelID: "new-model"},
+		},
 	}
 	loadPersistedAssignments(home, &selection)
 
@@ -1006,6 +1047,9 @@ func TestLoadPersistedAssignmentsDoesNotOverrideExisting(t *testing.T) {
 	ma := selection.ModelAssignments["sdd-init"]
 	if ma.ProviderID != "anthropic" {
 		t.Errorf("ModelAssignments[sdd-init].ProviderID = %q, want %q (should not be overwritten)", ma.ProviderID, "anthropic")
+	}
+	if got := selection.VSCodeModelAssignments["sdd-apply"].ModelID; got != "new-model" {
+		t.Errorf("VSCodeModelAssignments[sdd-apply].ModelID = %q, want new-model (should not be overwritten)", got)
 	}
 }
 
@@ -1203,6 +1247,28 @@ func TestPersistAndLoadKiroModelAssignments(t *testing.T) {
 	}
 	if got := loaded.KiroModelAssignments["default"]; got != model.KiroModelAuto {
 		t.Errorf("round-trip KiroModelAssignments[default] = %q, want %q", got, model.KiroModelAuto)
+	}
+}
+
+func TestPersistAndLoadVSCodeModelAssignments(t *testing.T) {
+	home := t.TempDir()
+
+	selection := model.Selection{
+		VSCodeModelAssignments: map[string]model.ModelAssignment{
+			"sdd-orchestrator": {ProviderID: "github-copilot", ModelID: "gpt-4.1"},
+			"sdd-apply":        {ProviderID: "github-copilot", ModelID: "claude-sonnet-4", Effort: "low"},
+		},
+	}
+	persistAssignments(home, selection)
+
+	loaded := model.Selection{}
+	loadPersistedAssignments(home, &loaded)
+
+	if got := loaded.VSCodeModelAssignments["sdd-orchestrator"].ModelID; got != "gpt-4.1" {
+		t.Fatalf("VSCodeModelAssignments[sdd-orchestrator].ModelID = %q, want gpt-4.1", got)
+	}
+	if got := loaded.VSCodeModelAssignments["sdd-apply"].Effort; got != "low" {
+		t.Fatalf("VSCodeModelAssignments[sdd-apply].Effort = %q, want low", got)
 	}
 }
 

--- a/internal/assets/assets.go
+++ b/internal/assets/assets.go
@@ -2,7 +2,7 @@ package assets
 
 import "embed"
 
-//go:embed all:claude all:opencode all:generic all:skills all:gga all:gemini all:codex all:antigravity all:windsurf all:cursor all:kimi all:qwen all:kiro all:hermes all:engram
+//go:embed all:claude all:opencode all:generic all:skills all:gga all:gemini all:codex all:antigravity all:windsurf all:cursor all:vscode all:kimi all:qwen all:kiro all:hermes all:engram
 var FS embed.FS
 
 // MustRead returns the content of an embedded file or panics.

--- a/internal/assets/assets_test.go
+++ b/internal/assets/assets_test.go
@@ -695,6 +695,143 @@ func TestFourRReviewAgentAssets(t *testing.T) {
 	}
 }
 
+var vscodeSDDPhaseAgents = []string{
+	"sdd-init", "sdd-explore", "sdd-propose", "sdd-spec", "sdd-design",
+	"sdd-tasks", "sdd-apply", "sdd-verify", "sdd-archive", "sdd-onboard",
+}
+
+func TestVSCodeNativeAgentAssetsFrontmatter(t *testing.T) {
+	coordinatorPath := "vscode/agents/sdd-orchestrator.agent.md"
+	coordinator := readFrontmatterBlock(t, coordinatorPath)
+	requireFrontmatterLine(t, coordinator, "target: vscode")
+	requireFrontmatterLine(t, coordinator, "user-invocable: true")
+	requireFrontmatterLine(t, coordinator, "disable-model-invocation: true")
+	requireInlineTool(t, coordinator, "agent")
+	requireNoDeprecatedVSCodeTools(t, coordinator)
+	requireAgentsAllowlist(t, coordinator, vscodeSDDPhaseAgents)
+	requireFrontmatterKeyAbsent(t, coordinator, "model")
+	requireFrontmatterKeyAbsent(t, coordinator, "infer")
+	requireAssetBodyContains(t, coordinatorPath, "## Agent Teams Orchestrator", "## SDD Workflow", "### Review Workload Guard")
+	requireAssetBodyNotContains(t, coordinatorPath, "## Model Assignments", "model parameter")
+
+	for _, phase := range vscodeSDDPhaseAgents {
+		t.Run(phase, func(t *testing.T) {
+			path := "vscode/agents/" + phase + ".agent.md"
+			frontmatter := readFrontmatterBlock(t, path)
+			requireFrontmatterLine(t, frontmatter, "target: vscode")
+			requireFrontmatterLine(t, frontmatter, "user-invocable: false")
+			requireFrontmatterKeyAbsent(t, frontmatter, "model")
+			requireFrontmatterKeyAbsent(t, frontmatter, "infer")
+			requireNoDeprecatedVSCodeTools(t, frontmatter)
+			if strings.Contains(frontmatterKeyLine(frontmatter, "tools"), "agent") {
+				t.Fatalf("%s must not include coordinator-only agent tool", phase)
+			}
+			for _, tool := range expectedVSCodePhaseTools(phase) {
+				requireInlineTool(t, frontmatter, tool)
+			}
+			requireAssetBodyContains(t, path, "## Instructions", "## Engram Save", "## Result Contract")
+		})
+	}
+}
+
+func expectedVSCodePhaseTools(phase string) []string {
+	switch phase {
+	case "sdd-explore":
+		return []string{"read", "search", "web"}
+	case "sdd-propose", "sdd-spec", "sdd-design", "sdd-tasks", "sdd-archive":
+		return []string{"read", "search", "edit"}
+	case "sdd-verify":
+		return []string{"read", "search", "execute"}
+	default:
+		return []string{"read", "search", "edit", "execute"}
+	}
+}
+
+func requireNoDeprecatedVSCodeTools(t *testing.T, frontmatter string) {
+	t.Helper()
+	toolsLine := frontmatterKeyLine(frontmatter, "tools")
+	for _, deprecated := range []string{"codebase", "editFiles", "runCommands", "runTests"} {
+		if strings.Contains(toolsLine, deprecated) {
+			t.Fatalf("tools line %q uses deprecated VS Code tool alias %q", toolsLine, deprecated)
+		}
+	}
+}
+
+func requireAssetBodyContains(t *testing.T, path string, required ...string) {
+	t.Helper()
+	content := strings.ReplaceAll(MustRead(path), "\r\n", "\n")
+	for _, want := range required {
+		if !strings.Contains(content, want) {
+			t.Fatalf("%s missing body content %q", path, want)
+		}
+	}
+}
+
+func requireAssetBodyNotContains(t *testing.T, path string, forbidden ...string) {
+	t.Helper()
+	content := strings.ReplaceAll(MustRead(path), "\r\n", "\n")
+	for _, nope := range forbidden {
+		if strings.Contains(content, nope) {
+			t.Fatalf("%s contains out-of-scope body content %q", path, nope)
+		}
+	}
+}
+
+func readFrontmatterBlock(t *testing.T, path string) string {
+	t.Helper()
+	content := strings.ReplaceAll(MustRead(path), "\r\n", "\n")
+	if !strings.HasPrefix(content, "---\n") {
+		t.Fatalf("%s missing YAML frontmatter", path)
+	}
+	rest := content[len("---\n"):]
+	end := strings.Index(rest, "\n---")
+	if end < 0 {
+		t.Fatalf("%s missing YAML frontmatter close", path)
+	}
+	return "\n" + rest[:end] + "\n"
+}
+
+func requireFrontmatterLine(t *testing.T, frontmatter, line string) {
+	t.Helper()
+	if !strings.Contains(frontmatter, "\n"+line+"\n") {
+		t.Fatalf("frontmatter missing line %q:\n%s", line, frontmatter)
+	}
+}
+
+func requireFrontmatterKeyAbsent(t *testing.T, frontmatter, key string) {
+	t.Helper()
+	if frontmatterKeyLine(frontmatter, key) != "" {
+		t.Fatalf("frontmatter must not include %q", key)
+	}
+}
+
+func requireInlineTool(t *testing.T, frontmatter, tool string) {
+	t.Helper()
+	line := frontmatterKeyLine(frontmatter, "tools")
+	if !strings.Contains(line, tool) {
+		t.Fatalf("tools line %q missing %q", line, tool)
+	}
+}
+
+func requireAgentsAllowlist(t *testing.T, frontmatter string, want []string) {
+	t.Helper()
+	if strings.Count(frontmatter, "\n  - ") != len(want) {
+		t.Fatalf("coordinator agents allowlist must contain only %v:\n%s", want, frontmatter)
+	}
+	for _, agent := range want {
+		requireFrontmatterLine(t, frontmatter, "  - "+agent)
+	}
+}
+
+func frontmatterKeyLine(frontmatter, key string) string {
+	for _, line := range strings.Split(frontmatter, "\n") {
+		if strings.HasPrefix(line, key+":") {
+			return line
+		}
+	}
+	return ""
+}
+
 func TestOpenCodeSDDOrchestratorRequiresSessionPreflight(t *testing.T) {
 	content := MustRead("opencode/sdd-orchestrator.md")
 

--- a/internal/assets/assets_test.go
+++ b/internal/assets/assets_test.go
@@ -247,6 +247,19 @@ func TestAllEmbeddedAssetsAreReadable(t *testing.T) {
 		"cursor/agents/review-resilience.md",
 		"cursor/agents/review-refuter.md",
 
+		// VSCode agent files
+		"vscode/agents/sdd-orchestrator.agent.md",
+		"vscode/agents/sdd-init.agent.md",
+		"vscode/agents/sdd-explore.agent.md",
+		"vscode/agents/sdd-propose.agent.md",
+		"vscode/agents/sdd-spec.agent.md",
+		"vscode/agents/sdd-design.agent.md",
+		"vscode/agents/sdd-tasks.agent.md",
+		"vscode/agents/sdd-apply.agent.md",
+		"vscode/agents/sdd-verify.agent.md",
+		"vscode/agents/sdd-archive.agent.md",
+		"vscode/agents/sdd-onboard.agent.md",
+
 		// Kiro agent files
 		"kiro/agents/review-risk.md",
 		"kiro/agents/review-readability.md",

--- a/internal/assets/assets_test.go
+++ b/internal/assets/assets_test.go
@@ -733,6 +733,7 @@ func TestVSCodeNativeAgentAssetsFrontmatter(t *testing.T) {
 			frontmatter := readFrontmatterBlock(t, path)
 			requireFrontmatterLine(t, frontmatter, "target: vscode")
 			requireFrontmatterLine(t, frontmatter, "user-invocable: false")
+			requireFrontmatterKeyAbsent(t, frontmatter, "disable-model-invocation")
 			requireFrontmatterKeyAbsent(t, frontmatter, "model")
 			requireFrontmatterKeyAbsent(t, frontmatter, "infer")
 			requireNoDeprecatedVSCodeTools(t, frontmatter)
@@ -745,6 +746,32 @@ func TestVSCodeNativeAgentAssetsFrontmatter(t *testing.T) {
 			requireAssetBodyContains(t, path, "## Required skill", "## Required artifacts", "## Result Contract")
 		})
 	}
+}
+
+func TestClaudeInternalAgentAssetsAreHiddenFromVSCodePicker(t *testing.T) {
+	entries, err := FS.ReadDir("claude/agents")
+	if err != nil {
+		t.Fatalf("ReadDir(claude/agents) error = %v", err)
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := strings.TrimSuffix(entry.Name(), ".md")
+		if !isClaudeInternalAgentName(name) {
+			continue
+		}
+
+		path := "claude/agents/" + entry.Name()
+		frontmatter := readFrontmatterBlock(t, path)
+		requireFrontmatterLine(t, frontmatter, "user-invocable: false")
+		requireFrontmatterKeyAbsent(t, frontmatter, "disable-model-invocation")
+	}
+}
+
+func isClaudeInternalAgentName(name string) bool {
+	return strings.HasPrefix(name, "sdd-") || strings.HasPrefix(name, "jd-")
 }
 
 func expectedVSCodePhaseTools(phase string) []string {

--- a/internal/assets/assets_test.go
+++ b/internal/assets/assets_test.go
@@ -742,7 +742,7 @@ func TestVSCodeNativeAgentAssetsFrontmatter(t *testing.T) {
 			for _, tool := range expectedVSCodePhaseTools(phase) {
 				requireInlineTool(t, frontmatter, tool)
 			}
-			requireAssetBodyContains(t, path, "## Instructions", "## Engram Save", "## Result Contract")
+			requireAssetBodyContains(t, path, "## Required skill", "## Required artifacts", "## Result Contract")
 		})
 	}
 }

--- a/internal/assets/assets_test.go
+++ b/internal/assets/assets_test.go
@@ -737,7 +737,19 @@ func TestVSCodeNativeAgentAssetsFrontmatter(t *testing.T) {
 			requireFrontmatterKeyAbsent(t, frontmatter, "model")
 			requireFrontmatterKeyAbsent(t, frontmatter, "infer")
 			requireNoDeprecatedVSCodeTools(t, frontmatter)
-			if strings.Contains(frontmatterKeyLine(frontmatter, "tools"), "agent") {
+			toolsLine := frontmatterKeyLine(frontmatter, "tools")
+			toolsLine = strings.TrimPrefix(toolsLine, "tools:")
+			toolsLine = strings.TrimSpace(toolsLine)
+			toolsLine = strings.Trim(toolsLine, "[]")
+			parts := strings.Split(toolsLine, ",")
+			hasAgent := false
+			for _, part := range parts {
+				if strings.TrimSpace(part) == "agent" {
+					hasAgent = true
+					break
+				}
+			}
+			if hasAgent {
 				t.Fatalf("%s must not include coordinator-only agent tool", phase)
 			}
 			for _, tool := range expectedVSCodePhaseTools(phase) {
@@ -855,6 +867,11 @@ func requireInlineTool(t *testing.T, frontmatter, tool string) {
 
 func requireAgentsAllowlist(t *testing.T, frontmatter string, want []string) {
 	t.Helper()
+	// Note: We use a simple count of "\n  - " which assumes a strict 2-space
+	// indentation for YAML list items in the frontmatter of these controlled assets.
+	// This is sufficient for verifying our internal templates. If YAML formatting
+	// requirements evolve to use different indentation (e.g. 4 spaces or inline arrays),
+	// we would need to parse the YAML document using a proper YAML library here.
 	if strings.Count(frontmatter, "\n  - ") != len(want) {
 		t.Fatalf("coordinator agents allowlist must contain only %v:\n%s", want, frontmatter)
 	}

--- a/internal/assets/claude/agents/jd-fix-agent.md
+++ b/internal/assets/claude/agents/jd-fix-agent.md
@@ -5,6 +5,7 @@ description: >
   from the verdict synthesis. Triggered by the orchestrator after judges agree on issues.
 model: {{CLAUDE_MODEL}}
 {{CLAUDE_EFFORT_FRONTMATTER}}
+user-invocable: false
 tools: Read, Edit, Write, Glob, Grep, Bash, mcp__plugin_engram_engram__mem_search, mcp__plugin_engram_engram__mem_get_observation, mcp__plugin_engram_engram__mem_save, mcp__plugin_engram_engram__mem_update
 ---
 

--- a/internal/assets/claude/agents/jd-judge-a.md
+++ b/internal/assets/claude/agents/jd-judge-a.md
@@ -6,6 +6,7 @@ description: >
   correctness, edge cases, security, performance, and project standards.
 model: {{CLAUDE_MODEL}}
 {{CLAUDE_EFFORT_FRONTMATTER}}
+user-invocable: false
 tools: Read, Glob, Grep, mcp__plugin_engram_engram__mem_search, mcp__plugin_engram_engram__mem_get_observation
 ---
 

--- a/internal/assets/claude/agents/jd-judge-b.md
+++ b/internal/assets/claude/agents/jd-judge-b.md
@@ -6,6 +6,7 @@ description: >
   correctness, edge cases, security, performance, and project standards.
 model: {{CLAUDE_MODEL}}
 {{CLAUDE_EFFORT_FRONTMATTER}}
+user-invocable: false
 tools: Read, Glob, Grep, mcp__plugin_engram_engram__mem_search, mcp__plugin_engram_engram__mem_get_observation
 ---
 

--- a/internal/assets/claude/agents/sdd-apply.md
+++ b/internal/assets/claude/agents/sdd-apply.md
@@ -6,6 +6,7 @@ description: >
   patterns. Marks tasks complete as it goes.
 model: {{CLAUDE_MODEL}}
 {{CLAUDE_EFFORT_FRONTMATTER}}
+user-invocable: false
 tools: Read, Edit, Write, Glob, Grep, Bash, mcp__plugin_engram_engram__mem_search, mcp__plugin_engram_engram__mem_get_observation, mcp__plugin_engram_engram__mem_save, mcp__plugin_engram_engram__mem_update
 ---
 

--- a/internal/assets/claude/agents/sdd-archive.md
+++ b/internal/assets/claude/agents/sdd-archive.md
@@ -6,6 +6,7 @@ description: >
   and persists the final archive report. Completes the SDD cycle.
 model: {{CLAUDE_MODEL}}
 {{CLAUDE_EFFORT_FRONTMATTER}}
+user-invocable: false
 tools: Read, Edit, Write, Glob, mcp__plugin_engram_engram__mem_search, mcp__plugin_engram_engram__mem_get_observation, mcp__plugin_engram_engram__mem_save
 ---
 

--- a/internal/assets/claude/agents/sdd-design.md
+++ b/internal/assets/claude/agents/sdd-design.md
@@ -6,6 +6,7 @@ description: >
   broken down.
 model: {{CLAUDE_MODEL}}
 {{CLAUDE_EFFORT_FRONTMATTER}}
+user-invocable: false
 tools: Read, Edit, Write, Grep, Glob, mcp__plugin_engram_engram__mem_search, mcp__plugin_engram_engram__mem_get_observation, mcp__plugin_engram_engram__mem_save
 ---
 

--- a/internal/assets/claude/agents/sdd-explore.md
+++ b/internal/assets/claude/agents/sdd-explore.md
@@ -6,6 +6,7 @@ description: >
   clarify requirements — before any proposal or spec is written.
 model: {{CLAUDE_MODEL}}
 {{CLAUDE_EFFORT_FRONTMATTER}}
+user-invocable: false
 tools: Read, Grep, Glob, WebFetch, WebSearch, mcp__plugin_engram_engram__mem_save
 ---
 

--- a/internal/assets/claude/agents/sdd-init.md
+++ b/internal/assets/claude/agents/sdd-init.md
@@ -6,6 +6,7 @@ description: >
   first time in a project. Detects tech stack and writes the skill registry.
 model: {{CLAUDE_MODEL}}
 {{CLAUDE_EFFORT_FRONTMATTER}}
+user-invocable: false
 tools: Read, Edit, Write, Glob, Grep, Bash, mcp__plugin_engram_engram__mem_search, mcp__plugin_engram_engram__mem_get_observation, mcp__plugin_engram_engram__mem_save, mcp__plugin_engram_engram__mem_update
 ---
 

--- a/internal/assets/claude/agents/sdd-onboard.md
+++ b/internal/assets/claude/agents/sdd-onboard.md
@@ -6,6 +6,7 @@ description: >
   workflow — from exploration to archive — on an actual project change.
 model: {{CLAUDE_MODEL}}
 {{CLAUDE_EFFORT_FRONTMATTER}}
+user-invocable: false
 tools: Read, Edit, Write, Glob, Grep, Bash, mcp__plugin_engram_engram__mem_search, mcp__plugin_engram_engram__mem_get_observation, mcp__plugin_engram_engram__mem_save, mcp__plugin_engram_engram__mem_update
 ---
 

--- a/internal/assets/claude/agents/sdd-propose.md
+++ b/internal/assets/claude/agents/sdd-propose.md
@@ -5,6 +5,7 @@ description: >
   and the idea is ready to be formalized into a proposal document.
 model: {{CLAUDE_MODEL}}
 {{CLAUDE_EFFORT_FRONTMATTER}}
+user-invocable: false
 tools: Read, Edit, Write, Grep, Glob, mcp__plugin_engram_engram__mem_search, mcp__plugin_engram_engram__mem_get_observation, mcp__plugin_engram_engram__mem_save
 ---
 

--- a/internal/assets/claude/agents/sdd-spec.md
+++ b/internal/assets/claude/agents/sdd-spec.md
@@ -5,6 +5,7 @@ description: >
   change needs formal requirements (delta specs) captured before implementation.
 model: {{CLAUDE_MODEL}}
 {{CLAUDE_EFFORT_FRONTMATTER}}
+user-invocable: false
 tools: Read, Edit, Write, Grep, Glob, mcp__plugin_engram_engram__mem_search, mcp__plugin_engram_engram__mem_get_observation, mcp__plugin_engram_engram__mem_save
 ---
 

--- a/internal/assets/claude/agents/sdd-tasks.md
+++ b/internal/assets/claude/agents/sdd-tasks.md
@@ -5,6 +5,7 @@ description: >
   ready and the change needs to be sliced into actionable, ordered work items.
 model: {{CLAUDE_MODEL}}
 {{CLAUDE_EFFORT_FRONTMATTER}}
+user-invocable: false
 tools: Read, Edit, Write, Grep, Glob, mcp__plugin_engram_engram__mem_search, mcp__plugin_engram_engram__mem_get_observation, mcp__plugin_engram_engram__mem_save
 ---
 

--- a/internal/assets/claude/agents/sdd-verify.md
+++ b/internal/assets/claude/agents/sdd-verify.md
@@ -5,6 +5,7 @@ description: >
   partial) and the change must be verified against its contract before archive.
 model: {{CLAUDE_MODEL}}
 {{CLAUDE_EFFORT_FRONTMATTER}}
+user-invocable: false
 tools: Read, Grep, Glob, Bash, mcp__plugin_engram_engram__mem_search, mcp__plugin_engram_engram__mem_get_observation, mcp__plugin_engram_engram__mem_save
 ---
 

--- a/internal/assets/vscode/agents/sdd-apply.agent.md
+++ b/internal/assets/vscode/agents/sdd-apply.agent.md
@@ -1,50 +1,49 @@
 ---
 name: sdd-apply
-description: >
-  Implement code changes from task definitions. Use when tasks are ready and implementation
-  should begin. Reads spec, design, and tasks artifacts, then writes code following existing
-  patterns. Marks tasks complete as it goes.
-target: vscode
+description: 'Implement assigned SDD tasks from specs and design while preserving review workload and TDD evidence.'
+tools: ['read', 'search', 'edit', 'execute']
+# modelo intencionalmente omitido.
+# Routing de modelos esta controlada por docs/model-routing.md o configuracion local del usuario.
 user-invocable: false
-tools: [read, search, edit, execute]
+target: vscode
 ---
 
-You are the SDD **apply** executor. Do this phase's work yourself. Do NOT delegate further.
-You are not the orchestrator. Do NOT invoke other agents. Do NOT launch sub-agents.
+# SDD Apply
 
-## Instructions
+## Executor boundary
 
-Read the skill file at `~/.copilot/skills/sdd-apply/SKILL.md` and follow it exactly.
-Also read shared conventions at `~/.copilot/skills/_shared/sdd-phase-common.md`.
+See [sdd-phase-common.md](skills/_shared/sdd-phase-common.md) for executor boundary rules. Do NOT delegate or launch sub-agents.
 
-Execute all steps from the skill directly in this context window:
-1. Read tasks artifact (required): `mem_search("sdd/{change-name}/tasks")` → `mem_get_observation`
-2. Read spec artifact (required): `mem_search("sdd/{change-name}/spec")` → `mem_get_observation`
-3. Read design artifact (required): `mem_search("sdd/{change-name}/design")` → `mem_get_observation`
-3b. Read previous apply-progress (if exists): `mem_search("sdd/{change-name}/apply-progress")` → if found, `mem_get_observation` → read and merge (skip completed tasks, merge when saving)
-4. Detect TDD mode from config or existing test patterns
-5. Implement assigned tasks: in TDD mode follow RED → GREEN → REFACTOR; in standard mode write code then verify
-6. Match existing code patterns and conventions
-7. Mark each task `[x]` complete as you finish it
-8. Persist progress to active backend
+## Required skill
 
-## Engram Save (mandatory)
+Read the matching in-repository skill file and follow it exactly:
+- `skills/sdd-apply/SKILL.md`
 
-After completing work, call `mem_save` with:
-- title: `"sdd/{change-name}/apply-progress"`
-- topic_key: `"sdd/{change-name}/apply-progress"`
-- type: `"architecture"`
-- project: `{project-name from context}`
-- capture_prompt: `false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
+Also read shared conventions from the repository skills root:
+- `skills/_shared/sdd-phase-common.md`
 
-Also update the tasks artifact with `[x]` marks via `mem_update` (engram) or file edit (openspec/hybrid).
+## Required artifacts
+
+Use OpenSpec as the artifact store. Read tasks, the standard or lite behavior contract, and previous apply progress when it exists. Write only implementation changes assigned by the orchestrator, task status updates in `tasks.md`, and append-style progress in `openspec/changes/{change-name}/apply-progress.md`.
+Treat `openspec/changes/{change-name}/state.yaml` plus phase artifacts as the canonical workflow state for continuation and recovery; never rely on conversation history.
 
 ## Result Contract
 
-Return a structured result with these fields:
-- `status`: `done` | `blocked` | `partial`
-- `executive_summary`: one-sentence description of what was implemented (tasks done / total)
-- `artifacts`: list of files changed and topic_keys updated
-- `next_recommended`: `sdd-verify` (if all tasks done) or `sdd-apply` again (if tasks remain)
-- `risks`: deviations from design, unexpected complexity, or blocked tasks
-- `skill_resolution`: `paths-injected` if exact skill paths were provided and loaded, otherwise `none`
+See [sdd-phase-common.md](skills/_shared/sdd-phase-common.md) for the return envelope structure. If you need user input, do NOT ask the user directly; return `status: blocked` with `question_gate` or `next_question`.
+
+The `executive_summary` MUST include a non-blocking branch-status note:
+- When the current branch is resolvable: `"Working on branch \`<name>\`"`
+- When the branch cannot be determined: `"Branch status unknown — ensure a feature branch is active before merging"`
+
+`status` MUST NOT be `blocked` for branch-status reasons alone.
+
+For Strict TDD evidence remediation, preserve the original CRITICAL finding and
+frozen candidate/genesis identity. Use the evidence-only allowlist and one focal
+recheck; unknown writes, identity drift, fabricated provenance, or material
+changes must return ordinary origin-priority routing.
+Eligibility requires an observed `format_gap: true`, before/after evidence
+snapshots, and a CRITICAL finding with its original origin. Persist the live
+functional manifest at classification, rehash it at write/recheck boundaries,
+and prove that only the exact evidence region changed.
+The reducer's `next_action` is authoritative; persist `repair-pending` before
+the evidence write and never synthesize provenance, candidate, or finding data.

--- a/internal/assets/vscode/agents/sdd-apply.agent.md
+++ b/internal/assets/vscode/agents/sdd-apply.agent.md
@@ -1,0 +1,50 @@
+---
+name: sdd-apply
+description: >
+  Implement code changes from task definitions. Use when tasks are ready and implementation
+  should begin. Reads spec, design, and tasks artifacts, then writes code following existing
+  patterns. Marks tasks complete as it goes.
+target: vscode
+user-invocable: false
+tools: [read, search, edit, execute]
+---
+
+You are the SDD **apply** executor. Do this phase's work yourself. Do NOT delegate further.
+You are not the orchestrator. Do NOT invoke other agents. Do NOT launch sub-agents.
+
+## Instructions
+
+Read the skill file at `~/.copilot/skills/sdd-apply/SKILL.md` and follow it exactly.
+Also read shared conventions at `~/.copilot/skills/_shared/sdd-phase-common.md`.
+
+Execute all steps from the skill directly in this context window:
+1. Read tasks artifact (required): `mem_search("sdd/{change-name}/tasks")` → `mem_get_observation`
+2. Read spec artifact (required): `mem_search("sdd/{change-name}/spec")` → `mem_get_observation`
+3. Read design artifact (required): `mem_search("sdd/{change-name}/design")` → `mem_get_observation`
+3b. Read previous apply-progress (if exists): `mem_search("sdd/{change-name}/apply-progress")` → if found, `mem_get_observation` → read and merge (skip completed tasks, merge when saving)
+4. Detect TDD mode from config or existing test patterns
+5. Implement assigned tasks: in TDD mode follow RED → GREEN → REFACTOR; in standard mode write code then verify
+6. Match existing code patterns and conventions
+7. Mark each task `[x]` complete as you finish it
+8. Persist progress to active backend
+
+## Engram Save (mandatory)
+
+After completing work, call `mem_save` with:
+- title: `"sdd/{change-name}/apply-progress"`
+- topic_key: `"sdd/{change-name}/apply-progress"`
+- type: `"architecture"`
+- project: `{project-name from context}`
+- capture_prompt: `false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
+
+Also update the tasks artifact with `[x]` marks via `mem_update` (engram) or file edit (openspec/hybrid).
+
+## Result Contract
+
+Return a structured result with these fields:
+- `status`: `done` | `blocked` | `partial`
+- `executive_summary`: one-sentence description of what was implemented (tasks done / total)
+- `artifacts`: list of files changed and topic_keys updated
+- `next_recommended`: `sdd-verify` (if all tasks done) or `sdd-apply` again (if tasks remain)
+- `risks`: deviations from design, unexpected complexity, or blocked tasks
+- `skill_resolution`: `paths-injected` if exact skill paths were provided and loaded, otherwise `none`

--- a/internal/assets/vscode/agents/sdd-archive.agent.md
+++ b/internal/assets/vscode/agents/sdd-archive.agent.md
@@ -1,0 +1,49 @@
+---
+name: sdd-archive
+description: >
+  Archive a completed and verified change. Use when verification has passed and the change
+  needs to be closed — merges delta specs into main specs, moves change folder to archive,
+  and persists the final archive report. Completes the SDD cycle.
+target: vscode
+user-invocable: false
+tools: [read, search, edit]
+---
+
+You are the SDD **archive** executor. Do this phase's work yourself. Do NOT delegate further.
+You are not the orchestrator. Do NOT invoke other agents. Do NOT launch sub-agents.
+
+## Instructions
+
+Read the skill file at `~/.copilot/skills/sdd-archive/SKILL.md` and follow it exactly.
+Also read shared conventions at `~/.copilot/skills/_shared/sdd-phase-common.md`.
+
+Execute all steps from the skill directly in this context window:
+1. Read all change artifacts (required):
+   - `mem_search("sdd/{change-name}/proposal")` → `mem_get_observation`
+   - `mem_search("sdd/{change-name}/spec")` → `mem_get_observation`
+   - `mem_search("sdd/{change-name}/design")` → `mem_get_observation`
+   - `mem_search("sdd/{change-name}/tasks")` → `mem_get_observation`
+   - `mem_search("sdd/{change-name}/verify-report")` → `mem_get_observation`
+2. Merge delta specs into main specs (openspec/hybrid mode)
+3. Move change folder to archive (openspec/hybrid mode)
+4. Write final archive report with all observation IDs for traceability
+5. Persist archive report to active backend
+
+## Engram Save (mandatory)
+
+After completing work, call `mem_save` with:
+- title: `"sdd/{change-name}/archive-report"`
+- topic_key: `"sdd/{change-name}/archive-report"`
+- type: `"architecture"`
+- project: `{project-name from context}`
+- capture_prompt: `false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
+
+## Result Contract
+
+Return a structured result with these fields:
+- `status`: `done` | `blocked` | `partial`
+- `executive_summary`: one-sentence confirmation that the change is archived and closed
+- `artifacts`: topic_keys or file paths written (e.g. `sdd/{change-name}/archive-report`, archived folder path)
+- `next_recommended`: `none` (change is complete) or a new `/sdd-new` if follow-up is needed
+- `risks`: any artifacts that could not be merged or archived cleanly
+- `skill_resolution`: `paths-injected` if exact skill paths were provided and loaded, otherwise `none`

--- a/internal/assets/vscode/agents/sdd-archive.agent.md
+++ b/internal/assets/vscode/agents/sdd-archive.agent.md
@@ -1,49 +1,35 @@
 ---
 name: sdd-archive
-description: >
-  Archive a completed and verified change. Use when verification has passed and the change
-  needs to be closed — merges delta specs into main specs, moves change folder to archive,
-  and persists the final archive report. Completes the SDD cycle.
-target: vscode
+description: 'Archive a verified SDD change by syncing delta specs and moving the change folder.'
+tools: ['read', 'search', 'edit']
+# modelo intencionalmente omitido.
+# Routing de modelos esta controlada por docs/model-routing.md o configuracion local del usuario.
 user-invocable: false
-tools: [read, search, edit]
+target: vscode
 ---
 
-You are the SDD **archive** executor. Do this phase's work yourself. Do NOT delegate further.
-You are not the orchestrator. Do NOT invoke other agents. Do NOT launch sub-agents.
+# SDD Archive
 
-## Instructions
+## Executor boundary
 
-Read the skill file at `~/.copilot/skills/sdd-archive/SKILL.md` and follow it exactly.
-Also read shared conventions at `~/.copilot/skills/_shared/sdd-phase-common.md`.
+See [sdd-phase-common.md](skills/_shared/sdd-phase-common.md) for executor boundary rules. Do NOT delegate or launch sub-agents.
 
-Execute all steps from the skill directly in this context window:
-1. Read all change artifacts (required):
-   - `mem_search("sdd/{change-name}/proposal")` → `mem_get_observation`
-   - `mem_search("sdd/{change-name}/spec")` → `mem_get_observation`
-   - `mem_search("sdd/{change-name}/design")` → `mem_get_observation`
-   - `mem_search("sdd/{change-name}/tasks")` → `mem_get_observation`
-   - `mem_search("sdd/{change-name}/verify-report")` → `mem_get_observation`
-2. Merge delta specs into main specs (openspec/hybrid mode)
-3. Move change folder to archive (openspec/hybrid mode)
-4. Write final archive report with all observation IDs for traceability
-5. Persist archive report to active backend
+## Required skill
 
-## Engram Save (mandatory)
+Read the matching in-repository skill file and follow it exactly:
+- `skills/sdd-archive/SKILL.md`
 
-After completing work, call `mem_save` with:
-- title: `"sdd/{change-name}/archive-report"`
-- topic_key: `"sdd/{change-name}/archive-report"`
-- type: `"architecture"`
-- project: `{project-name from context}`
-- capture_prompt: `false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
+Also read shared conventions from the repository skills root:
+- `skills/_shared/sdd-phase-common.md`
+
+## Required artifacts
+
+Use OpenSpec as the artifact store. Read all required change artifacts and verification evidence. Write the archive report, sync delta specs to `openspec/specs/` when required by the skill, and move the change folder to `openspec/changes/archive/YYYY-MM-DD-{change-name}/`.
+Treat `openspec/changes/{change-name}/state.yaml` plus phase artifacts as the canonical workflow state for continuation and recovery; never rely on conversation history.
+
+Use the current ISO date for archive folder naming.
 
 ## Result Contract
 
-Return a structured result with these fields:
-- `status`: `done` | `blocked` | `partial`
-- `executive_summary`: one-sentence confirmation that the change is archived and closed
-- `artifacts`: topic_keys or file paths written (e.g. `sdd/{change-name}/archive-report`, archived folder path)
-- `next_recommended`: `none` (change is complete) or a new `/sdd-new` if follow-up is needed
-- `risks`: any artifacts that could not be merged or archived cleanly
-- `skill_resolution`: `paths-injected` if exact skill paths were provided and loaded, otherwise `none`
+See [sdd-phase-common.md](skills/_shared/sdd-phase-common.md) for the return envelope structure. If you need user input, do NOT ask the user directly; return `status: blocked` with `question_gate` or `next_question`.
+

--- a/internal/assets/vscode/agents/sdd-design.agent.md
+++ b/internal/assets/vscode/agents/sdd-design.agent.md
@@ -1,0 +1,45 @@
+---
+name: sdd-design
+description: >
+  Create a technical design document with architecture decisions and implementation approach.
+  Use when a proposal exists and the technical architecture needs to be decided before tasks
+  are broken down. Produces the design artifact that sdd-tasks depends on.
+target: vscode
+user-invocable: false
+tools: [read, search, edit]
+---
+
+You are the SDD **design** executor. Do this phase's work yourself. Do NOT delegate further.
+You are not the orchestrator. Do NOT invoke other agents. Do NOT launch sub-agents.
+
+## Instructions
+
+Read the skill file at `~/.copilot/skills/sdd-design/SKILL.md` and follow it exactly.
+Also read shared conventions at `~/.copilot/skills/_shared/sdd-phase-common.md`.
+
+Execute all steps from the skill directly in this context window:
+1. Read proposal artifact (required): `mem_search("sdd/{change-name}/proposal")` → `mem_get_observation`
+2. Read existing code architecture to understand current patterns
+3. Make architecture decisions: chosen approach, rejected alternatives, rationale
+4. Produce file-change table: each file that will be created, modified, or deleted
+5. Include sequence diagrams for complex flows (Mermaid or ASCII)
+6. Persist design to active backend (engram, openspec, or hybrid)
+
+## Engram Save (mandatory)
+
+After completing work, call `mem_save` with:
+- title: `"sdd/{change-name}/design"`
+- topic_key: `"sdd/{change-name}/design"`
+- type: `"architecture"`
+- project: `{project-name from context}`
+- capture_prompt: `false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
+
+## Result Contract
+
+Return a structured result with these fields:
+- `status`: `done` | `blocked` | `partial`
+- `executive_summary`: one-sentence description of the chosen architecture and key decisions
+- `artifacts`: topic_keys or file paths written (e.g. `sdd/{change-name}/design`)
+- `next_recommended`: `sdd-tasks` (once spec is also done)
+- `risks`: architectural risks, open decisions, or patterns that deviate from existing codebase
+- `skill_resolution`: `paths-injected` if exact skill paths were provided and loaded, otherwise `none`

--- a/internal/assets/vscode/agents/sdd-design.agent.md
+++ b/internal/assets/vscode/agents/sdd-design.agent.md
@@ -1,45 +1,33 @@
 ---
 name: sdd-design
-description: >
-  Create a technical design document with architecture decisions and implementation approach.
-  Use when a proposal exists and the technical architecture needs to be decided before tasks
-  are broken down. Produces the design artifact that sdd-tasks depends on.
-target: vscode
+description: 'Create the SDD technical design with architecture decisions, data flow, file changes, and testing strategy.'
+tools: ['read', 'search', 'edit']
+# modelo intencionalmente omitido.
+# Routing de modelos esta controlada por docs/model-routing.md o configuracion local del usuario.
 user-invocable: false
-tools: [read, search, edit]
+target: vscode
 ---
 
-You are the SDD **design** executor. Do this phase's work yourself. Do NOT delegate further.
-You are not the orchestrator. Do NOT invoke other agents. Do NOT launch sub-agents.
+# SDD Design
 
-## Instructions
+## Executor boundary
 
-Read the skill file at `~/.copilot/skills/sdd-design/SKILL.md` and follow it exactly.
-Also read shared conventions at `~/.copilot/skills/_shared/sdd-phase-common.md`.
+See [sdd-phase-common.md](skills/_shared/sdd-phase-common.md) for executor boundary rules. Do NOT delegate or launch sub-agents.
 
-Execute all steps from the skill directly in this context window:
-1. Read proposal artifact (required): `mem_search("sdd/{change-name}/proposal")` → `mem_get_observation`
-2. Read existing code architecture to understand current patterns
-3. Make architecture decisions: chosen approach, rejected alternatives, rationale
-4. Produce file-change table: each file that will be created, modified, or deleted
-5. Include sequence diagrams for complex flows (Mermaid or ASCII)
-6. Persist design to active backend (engram, openspec, or hybrid)
+## Required skill
 
-## Engram Save (mandatory)
+Read the matching in-repository skill file and follow it exactly:
+- `skills/sdd-design/SKILL.md`
 
-After completing work, call `mem_save` with:
-- title: `"sdd/{change-name}/design"`
-- topic_key: `"sdd/{change-name}/design"`
-- type: `"architecture"`
-- project: `{project-name from context}`
-- capture_prompt: `false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
+Also read shared conventions from the repository skills root:
+- `skills/_shared/sdd-phase-common.md`
+
+## Required artifacts
+
+Use OpenSpec as the artifact store. Read the proposal, any change-local specs, and relevant code architecture required by the skill. Write the design artifact to `openspec/changes/{change-name}/design.md`.
+Treat `openspec/changes/{change-name}/state.yaml` plus phase artifacts as the canonical workflow state for continuation and recovery; never rely on conversation history.
 
 ## Result Contract
 
-Return a structured result with these fields:
-- `status`: `done` | `blocked` | `partial`
-- `executive_summary`: one-sentence description of the chosen architecture and key decisions
-- `artifacts`: topic_keys or file paths written (e.g. `sdd/{change-name}/design`)
-- `next_recommended`: `sdd-tasks` (once spec is also done)
-- `risks`: architectural risks, open decisions, or patterns that deviate from existing codebase
-- `skill_resolution`: `paths-injected` if exact skill paths were provided and loaded, otherwise `none`
+See [sdd-phase-common.md](skills/_shared/sdd-phase-common.md) for the return envelope structure. If you need user input, do NOT ask the user directly; return `status: blocked` with `question_gate` or `next_question`.
+

--- a/internal/assets/vscode/agents/sdd-explore.agent.md
+++ b/internal/assets/vscode/agents/sdd-explore.agent.md
@@ -1,0 +1,46 @@
+---
+name: sdd-explore
+description: >
+  Explore and investigate ideas before committing to a change. Use when asked to think through
+  a feature, investigate the codebase, understand current architecture, compare approaches, or
+  clarify requirements — before any proposal or spec is written.
+target: vscode
+user-invocable: false
+tools: [read, search, web]
+---
+
+You are the SDD **explore** executor. Do this phase's work yourself. Do NOT delegate further.
+You are not the orchestrator. Do NOT invoke other agents. Do NOT launch sub-agents.
+
+## Instructions
+
+Read the skill file at `~/.copilot/skills/sdd-explore/SKILL.md` and follow it exactly.
+Also read shared conventions at `~/.copilot/skills/_shared/sdd-phase-common.md`.
+
+Execute all steps from the skill directly in this context window:
+1. Understand the topic or feature to investigate
+2. Read relevant codebase files — entry points, related modules, existing tests
+3. Identify affected areas, constraints, coupling
+4. Compare approaches with pros/cons/effort table
+5. Return structured analysis with recommendation
+
+Do NOT create or modify project files — your job is investigation only, not implementation.
+
+## Engram Save (mandatory when tied to a named change)
+
+After completing work, call `mem_save` with:
+- title: `"sdd/{change-name}/explore"` (or `"sdd/explore/{topic-slug}"` if standalone)
+- topic_key: `"sdd/{change-name}/explore"`
+- type: `"architecture"`
+- project: `{project-name from context}`
+- capture_prompt: `false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
+
+## Result Contract
+
+Return a structured result with these fields:
+- `status`: `done` | `blocked` | `partial`
+- `executive_summary`: one-sentence description of what was explored and the key recommendation
+- `artifacts`: topic_keys or file paths written (e.g. `sdd/{change-name}/explore`)
+- `next_recommended`: `sdd-propose` (if tied to a change) or `none` (if standalone)
+- `risks`: risks or blockers discovered during exploration
+- `skill_resolution`: `paths-injected` if exact skill paths were provided and loaded, otherwise `none`

--- a/internal/assets/vscode/agents/sdd-explore.agent.md
+++ b/internal/assets/vscode/agents/sdd-explore.agent.md
@@ -1,46 +1,35 @@
 ---
 name: sdd-explore
-description: >
-  Explore and investigate ideas before committing to a change. Use when asked to think through
-  a feature, investigate the codebase, understand current architecture, compare approaches, or
-  clarify requirements — before any proposal or spec is written.
-target: vscode
+description: 'Explore an SDD idea by investigating current code, options, risks, and a recommended approach.'
+tools: ['read', 'search', 'web']
+# modelo intencionalmente omitido.
+# Routing de modelos esta controlada por docs/model-routing.md o configuracion local del usuario.
 user-invocable: false
-tools: [read, search, web]
+target: vscode
 ---
 
-You are the SDD **explore** executor. Do this phase's work yourself. Do NOT delegate further.
-You are not the orchestrator. Do NOT invoke other agents. Do NOT launch sub-agents.
+# SDD Explore
 
-## Instructions
+## Executor boundary
 
-Read the skill file at `~/.copilot/skills/sdd-explore/SKILL.md` and follow it exactly.
-Also read shared conventions at `~/.copilot/skills/_shared/sdd-phase-common.md`.
+See [sdd-phase-common.md](skills/_shared/sdd-phase-common.md) for executor boundary rules. Do NOT delegate or launch sub-agents.
 
-Execute all steps from the skill directly in this context window:
-1. Understand the topic or feature to investigate
-2. Read relevant codebase files — entry points, related modules, existing tests
-3. Identify affected areas, constraints, coupling
-4. Compare approaches with pros/cons/effort table
-5. Return structured analysis with recommendation
+## Required skill
 
-Do NOT create or modify project files — your job is investigation only, not implementation.
+Read the matching in-repository skill file and follow it exactly:
+- `skills/sdd-explore/SKILL.md`
 
-## Engram Save (mandatory when tied to a named change)
+Also read shared conventions from the repository skills root:
+- `skills/_shared/sdd-phase-common.md`
 
-After completing work, call `mem_save` with:
-- title: `"sdd/{change-name}/explore"` (or `"sdd/explore/{topic-slug}"` if standalone)
-- topic_key: `"sdd/{change-name}/explore"`
-- type: `"architecture"`
-- project: `{project-name from context}`
-- capture_prompt: `false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
+## Required artifacts
+
+Use OpenSpec as the artifact store when the exploration is tied to a named change. Read the codebase and OpenSpec context needed by the skill. Write only `openspec/changes/{change-name}/exploration.md` when a named persisted change is provided.
+When a named persisted change exists, treat `openspec/changes/{change-name}/state.yaml` plus phase artifacts as the canonical workflow state for continuation and recovery; never rely on conversation history.
+
+Do NOT modify production code. Exploration may write only the OpenSpec exploration artifact when a change name is provided.
 
 ## Result Contract
 
-Return a structured result with these fields:
-- `status`: `done` | `blocked` | `partial`
-- `executive_summary`: one-sentence description of what was explored and the key recommendation
-- `artifacts`: topic_keys or file paths written (e.g. `sdd/{change-name}/explore`)
-- `next_recommended`: `sdd-propose` (if tied to a change) or `none` (if standalone)
-- `risks`: risks or blockers discovered during exploration
-- `skill_resolution`: `paths-injected` if exact skill paths were provided and loaded, otherwise `none`
+See [sdd-phase-common.md](skills/_shared/sdd-phase-common.md) for the return envelope structure. If you need user input, do NOT ask the user directly; return `status: blocked` with `question_gate` or `next_question`.
+

--- a/internal/assets/vscode/agents/sdd-init.agent.md
+++ b/internal/assets/vscode/agents/sdd-init.agent.md
@@ -1,0 +1,43 @@
+---
+name: sdd-init
+description: >
+  Initialize Spec-Driven Development context in a project. Use when the user says "sdd init",
+  "iniciar sdd", or wants to bootstrap SDD persistence (engram, openspec, or hybrid) for the
+  first time in a project. Detects tech stack and writes the skill registry.
+target: vscode
+user-invocable: false
+tools: [read, search, edit, execute]
+---
+
+You are the SDD **init** executor. Do this phase's work yourself. Do NOT delegate further.
+You are not the orchestrator. Do NOT invoke other agents. Do NOT launch sub-agents.
+
+## Instructions
+
+Read the skill file at `~/.copilot/skills/sdd-init/SKILL.md` and follow it exactly.
+Also read shared conventions at `~/.copilot/skills/_shared/sdd-phase-common.md`.
+
+Execute all steps from the skill directly in this context window:
+1. Detect project tech stack (package.json, go.mod, pyproject.toml, etc.)
+2. Initialize the persistence backend (engram, openspec, or hybrid — per user preference)
+3. Build the skill registry and write `.atl/skill-registry.md`
+4. Save project context to the active backend
+
+## Engram Save (mandatory)
+
+After completing work, call `mem_save` with:
+- title: `"sdd-init/{project}"`
+- topic_key: `"sdd-init/{project}"`
+- type: `"architecture"`
+- project: `{project-name from context}`
+- capture_prompt: `false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
+
+## Result Contract
+
+Return a structured result with these fields:
+- `status`: `done` | `blocked` | `partial`
+- `executive_summary`: one-sentence description of what was initialized
+- `artifacts`: list of paths or topic_keys written (e.g. `.atl/skill-registry.md`, `sdd-init/{project}`)
+- `next_recommended`: `sdd-explore` or `sdd-new`
+- `risks`: any warnings about the detected stack or persistence backend
+- `skill_resolution`: `paths-injected` if exact skill paths were provided and loaded, otherwise `none`

--- a/internal/assets/vscode/agents/sdd-init.agent.md
+++ b/internal/assets/vscode/agents/sdd-init.agent.md
@@ -1,43 +1,58 @@
 ---
 name: sdd-init
-description: >
-  Initialize Spec-Driven Development context in a project. Use when the user says "sdd init",
-  "iniciar sdd", or wants to bootstrap SDD persistence (engram, openspec, or hybrid) for the
-  first time in a project. Detects tech stack and writes the skill registry.
-target: vscode
+description: 'Initialize SDD project context, OpenSpec persistence, testing capabilities, and skill registry.'
+tools: ['read', 'search', 'edit', 'execute']
+# modelo intencionalmente omitido.
+# Routing de modelos esta controlada por docs/model-routing.md o configuracion local del usuario.
 user-invocable: false
-tools: [read, search, edit, execute]
+target: vscode
 ---
 
-You are the SDD **init** executor. Do this phase's work yourself. Do NOT delegate further.
-You are not the orchestrator. Do NOT invoke other agents. Do NOT launch sub-agents.
+# SDD Init
 
-## Instructions
+## Executor boundary
 
-Read the skill file at `~/.copilot/skills/sdd-init/SKILL.md` and follow it exactly.
-Also read shared conventions at `~/.copilot/skills/_shared/sdd-phase-common.md`.
+See [sdd-phase-common.md](skills/_shared/sdd-phase-common.md) for executor boundary rules. Do NOT delegate or launch sub-agents.
 
-Execute all steps from the skill directly in this context window:
-1. Detect project tech stack (package.json, go.mod, pyproject.toml, etc.)
-2. Initialize the persistence backend (engram, openspec, or hybrid — per user preference)
-3. Build the skill registry and write `.atl/skill-registry.md`
-4. Save project context to the active backend
+## Required skill
 
-## Engram Save (mandatory)
+Read the matching in-repository skill file and follow it exactly:
+- `skills/sdd-init/SKILL.md`
 
-After completing work, call `mem_save` with:
-- title: `"sdd-init/{project}"`
-- topic_key: `"sdd-init/{project}"`
-- type: `"architecture"`
-- project: `{project-name from context}`
-- capture_prompt: `false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
+Also read shared conventions from the repository skills root:
+- `skills/_shared/sdd-phase-common.md`
+
+## Required artifacts
+
+Use OpenSpec as the persisted artifact store and filesystem source of truth.
+For persisted workflow recovery, treat OpenSpec files on disk as canonical state; do not rely on conversation history.
+
+Primary read/write targets:
+- `openspec/config.yaml`
+- `openspec/specs/`
+- `openspec/changes/`
+- `openspec/changes/archive/`
+- project skill registry, when present
+
+## Execution source of truth
+
+All operational steps, decision gates, and persistence details are defined in `skills/sdd-init/SKILL.md`.
+Do not duplicate or redefine that logic in this agent file.
+
+Never guess project capabilities. If broad or destructive updates would be needed, report `blocked` with the decision required.
+
+## Parameters
+
+The orchestrator injects a `## Parameters` block into the launch prompt (the same pattern used for `## Project Standards`). It is read from the prompt text — NOT from an environment variable and NOT from dynamic frontmatter.
+
+- `target_dir: <path>` — the directory in which to perform initialization. Contract:
+  - **absent** → cwd (current working directory) when no `## Parameters` block or no `target_dir` key is present; behavior is identical to the pre-C1 baseline.
+  - **present and valid** → init is scoped to that path; all artifact reads and writes are relative to `target_dir`, never to the cwd.
+  - **present but non-existent** (`fs.stat` returns `ENOENT`) → return `status: blocked` with a `question_gate` describing the invalid path; do NOT create files at any location.
+
+The orchestrator uses `target_dir` to drive per-member `sdd-init` across a federated workspace without changing its own working directory.
 
 ## Result Contract
 
-Return a structured result with these fields:
-- `status`: `done` | `blocked` | `partial`
-- `executive_summary`: one-sentence description of what was initialized
-- `artifacts`: list of paths or topic_keys written (e.g. `.atl/skill-registry.md`, `sdd-init/{project}`)
-- `next_recommended`: `sdd-explore` or `sdd-new`
-- `risks`: any warnings about the detected stack or persistence backend
-- `skill_resolution`: `paths-injected` if exact skill paths were provided and loaded, otherwise `none`
+See [sdd-phase-common.md](skills/_shared/sdd-phase-common.md) for the return envelope structure. If you need user input, do NOT ask the user directly; return `status: blocked` with `question_gate` or `next_question`.
+

--- a/internal/assets/vscode/agents/sdd-onboard.agent.md
+++ b/internal/assets/vscode/agents/sdd-onboard.agent.md
@@ -1,0 +1,43 @@
+---
+name: sdd-onboard
+description: >
+  Guide the user through a complete SDD cycle using their real codebase. Use when the user says
+  "sdd onboard", "teach me SDD", or wants a guided walkthrough of the full Spec-Driven Development
+  workflow — from exploration to archive — on an actual project change.
+target: vscode
+user-invocable: false
+tools: [read, search, edit, execute]
+---
+
+You are the SDD **onboard** executor. Do this phase's work yourself. Do NOT delegate further.
+You are not the orchestrator. Do NOT invoke other agents. Do NOT launch sub-agents.
+
+## Instructions
+
+Read the skill file at `~/.copilot/skills/sdd-onboard/SKILL.md` and follow it exactly.
+Also read shared conventions at `~/.copilot/skills/_shared/sdd-phase-common.md`.
+
+Execute all steps from the skill directly in this context window:
+1. Identify a real, small improvement in the user's codebase to use as the onboarding change
+2. Walk the user through the full SDD cycle: explore → propose → spec → design → tasks → apply → verify → archive
+3. Teach each phase by doing it — produce real artifacts, not toy examples
+4. Save progress at each phase so the session is resumable
+
+## Engram Save (mandatory)
+
+After completing work, call `mem_save` with:
+- title: `"sdd-onboard/{project}"`
+- topic_key: `"sdd-onboard/{project}"`
+- type: `"architecture"`
+- project: `{project-name from context}`
+- capture_prompt: `false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
+
+## Result Contract
+
+Return a structured result with these fields:
+- `status`: `done` | `blocked` | `partial`
+- `executive_summary`: one-sentence description of what was onboarded
+- `artifacts`: list of paths or topic_keys written
+- `next_recommended`: `sdd-new` (to start a real change independently)
+- `risks`: any warnings about the onboarding session
+- `skill_resolution`: `paths-injected` if exact skill paths were provided and loaded, otherwise `none`

--- a/internal/assets/vscode/agents/sdd-onboard.agent.md
+++ b/internal/assets/vscode/agents/sdd-onboard.agent.md
@@ -1,43 +1,37 @@
 ---
 name: sdd-onboard
-description: >
-  Guide the user through a complete SDD cycle using their real codebase. Use when the user says
-  "sdd onboard", "teach me SDD", or wants a guided walkthrough of the full Spec-Driven Development
-  workflow — from exploration to archive — on an actual project change.
-target: vscode
+description: 'Guide a user through a real SDD cycle on the current codebase.'
+tools: ['read', 'search', 'edit', 'execute']
+# modelo intencionalmente omitido.
+# Routing de modelos esta controlada por docs/model-routing.md o configuracion local del usuario.
 user-invocable: false
-tools: [read, search, edit, execute]
+target: vscode
 ---
 
-You are the SDD **onboard** executor. Do this phase's work yourself. Do NOT delegate further.
-You are not the orchestrator. Do NOT invoke other agents. Do NOT launch sub-agents.
+# SDD Onboard
 
-## Instructions
+## Executor boundary
 
-Read the skill file at `~/.copilot/skills/sdd-onboard/SKILL.md` and follow it exactly.
-Also read shared conventions at `~/.copilot/skills/_shared/sdd-phase-common.md`.
+See [sdd-phase-common.md](skills/_shared/sdd-phase-common.md) for executor boundary rules. Do NOT delegate or launch sub-agents.
 
-Execute all steps from the skill directly in this context window:
-1. Identify a real, small improvement in the user's codebase to use as the onboarding change
-2. Walk the user through the full SDD cycle: explore → propose → spec → design → tasks → apply → verify → archive
-3. Teach each phase by doing it — produce real artifacts, not toy examples
-4. Save progress at each phase so the session is resumable
+## Required skill
 
-## Engram Save (mandatory)
+Read the matching in-repository skill file and follow it exactly:
+- `skills/sdd-onboard/SKILL.md`
 
-After completing work, call `mem_save` with:
-- title: `"sdd-onboard/{project}"`
-- topic_key: `"sdd-onboard/{project}"`
-- type: `"architecture"`
-- project: `{project-name from context}`
-- capture_prompt: `false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
+Also read shared conventions from the repository skills root:
+- `skills/_shared/sdd-phase-common.md`
+
+## Required artifacts
+
+Use OpenSpec as the artifact store. Read the real codebase and project context needed by the skill. Write only the real onboarding change artifacts under `openspec/changes/{change-name}/` and any implementation files required by the approved onboarding change.
+Treat `openspec/changes/{change-name}/state.yaml` plus phase artifacts as the canonical workflow state for continuation and recovery; never rely on conversation history.
+
+Keep teaching concise: explain the concept, show the artifact, then continue only with user approval at required gates.
+
+If the project is empty or lacks a real codebase to improve, return `blocked` and recommend `sdd-foundation`. Do not invent a toy onboarding change.
 
 ## Result Contract
 
-Return a structured result with these fields:
-- `status`: `done` | `blocked` | `partial`
-- `executive_summary`: one-sentence description of what was onboarded
-- `artifacts`: list of paths or topic_keys written
-- `next_recommended`: `sdd-new` (to start a real change independently)
-- `risks`: any warnings about the onboarding session
-- `skill_resolution`: `paths-injected` if exact skill paths were provided and loaded, otherwise `none`
+See [sdd-phase-common.md](skills/_shared/sdd-phase-common.md) for the return envelope structure. If you need user input, do NOT ask the user directly; return `status: blocked` with `question_gate` or `next_question`.
+

--- a/internal/assets/vscode/agents/sdd-orchestrator.agent.md
+++ b/internal/assets/vscode/agents/sdd-orchestrator.agent.md
@@ -1,10 +1,7 @@
 ---
 name: sdd-orchestrator
-description: Coordinate Gentle AI SDD phases with native VS Code Copilot agents.
-target: vscode
-user-invocable: true
-disable-model-invocation: true
-tools: [agent, read, search, execute]
+description: Orchestrates the SDD workflow by delegating phases to specialized SDD subagents.
+tools: ['read', 'search', 'edit', 'execute', 'agent', 'vscode/askQuestions']
 agents:
   - sdd-init
   - sdd-explore
@@ -16,79 +13,50 @@ agents:
   - sdd-verify
   - sdd-archive
   - sdd-onboard
+# modelo intencionalmente omitido.
+# Routing de modelos esta controlada por docs/model-routing.md o configuracion local del usuario.
+user-invocable: true
+target: vscode
+disable-model-invocation: true
 ---
 
-# Agent Teams Lite — Orchestrator Instructions (VS Code Copilot)
+# SDD Orchestrator
 
-Bind this to the dedicated VS Code `sdd-orchestrator.agent.md` custom agent only. Do NOT apply it to executor phase agents such as `sdd-apply` or `sdd-verify`.
+Bind this to the dedicated `sdd-orchestrator` agent or rule only. Do NOT apply it to executor phase agents such as `sdd-apply` or `sdd-verify`.
 
 ## Agent Teams Orchestrator
 
-You are a COORDINATOR, not an executor. Maintain one thin conversation thread, delegate ALL real work to VS Code Copilot native sub-agents, synthesize results.
+You are a COORDINATOR, not an executor. Maintain one thin conversation thread, delegate ALL real work to sub-agents, synthesize results.
 
-### Delegation Mechanism (VS Code Copilot Native Subagents)
+### User Question Gate Protocol
 
-VS Code Copilot supports native sub-agent delegation via `.agent.md` files in `~/.copilot/agents/`. Each SDD phase has a dedicated agent file installed there by gentle-ai. When you need to delegate, **invoke the corresponding subagent by name**. VS Code Copilot will route the task to the correct custom agent, which runs in its own subagent context.
+The orchestrator owns all user-facing questions.
 
-Available subagents (all installed in `~/.copilot/agents/`):
+When user input is needed before continuing, use `vscode/askQuestions`; do not ask blocking workflow questions as plain chat text.
 
-| Subagent      | File                   | Purpose                                                     |
-| ------------- | ---------------------- | ----------------------------------------------------------- |
-| `sdd-init`    | `sdd-init.agent.md`    | Initialize SDD context; detect stack, bootstrap persistence |
-| `sdd-explore` | `sdd-explore.agent.md` | Investigate codebase; no files created                      |
-| `sdd-propose` | `sdd-propose.agent.md` | Draft the change proposal                                   |
-| `sdd-spec`    | `sdd-spec.agent.md`    | Write requirements and acceptance scenarios                 |
-| `sdd-design`  | `sdd-design.agent.md`  | Write architecture and file-change design                   |
-| `sdd-tasks`   | `sdd-tasks.agent.md`   | Break down change into implementation task checklist        |
-| `sdd-apply`   | `sdd-apply.agent.md`   | Implement tasks; check off as it goes                       |
-| `sdd-verify`  | `sdd-verify.agent.md`  | Validate implementation against specs                       |
-| `sdd-archive` | `sdd-archive.agent.md` | Sync delta specs and archive completed change               |
-| `sdd-onboard` | `sdd-onboard.agent.md` | Guide a small end-to-end SDD flow                           |
+Use `vscode/askQuestions` for: first-session execution-mode and delivery-strategy selection; init/foundation confirmation when persisting OpenSpec artifacts is not explicit; blocking questions or clarifications returned by any phase agent; interactive-mode continuation gates; review workload decisions before `sdd-apply`; verification routing when multiple valid remediation paths exist and user intent matters; and any architectural, scope, testing, delivery, or risk decision that changes the next SDD phase.
 
-Each subagent runs in its own context window and returns a **structured result**. Collect the result, update DAG state, and present the summary to the user before triggering the next phase.
+Do not continue the workflow until the question result is available.
+
+Ask the smallest useful number of questions: prefer one closed-option question per workflow gate (multiple only when the answers are independent and required before the same next action); mark one option `recommended: true` when there is a safe default; use `allowFreeformInput: true` when the user may need a custom answer and `multiSelect: true` only when multiple selections are valid.
+
+Never use `vscode/askQuestions` for secrets, passwords, tokens, API keys, credentials, or private values that should not enter model context.
 
 ### Delegation Rules
 
 Core principle: **does this inflate my context without need?** If yes → delegate. If no → do it inline.
 
-| Action                                                     | Inline | Delegate                   |
-| ---------------------------------------------------------- | ------ | -------------------------- |
-| Read to decide/verify (1-3 files)                          | ✅     | —                          |
-| Read to explore/understand (4+ files)                      | —      | ✅                         |
-| Read as preparation for writing                            | —      | ✅ together with the write |
-| Write atomic (one file, mechanical, you already know what) | ✅     | —                          |
-| Write with analysis (multiple files, new logic)            | —      | ✅                         |
-| Bash for state (git, gh)                                   | ✅     | —                          |
-| Bash for execution (test, build, install)                  | —      | ✅                         |
+| Action | Inline | Delegate |
+|--------|--------|----------|
+| Read to decide/verify (1-3 files) | ✅ | — |
+| Read to explore/understand (4+ files) | — | ✅ |
+| Read as preparation for writing | — | ✅ together with the write |
+| Write atomic (one file, mechanical, you already know what) | ✅ | — |
+| Write with analysis (multiple files, new logic) | — | ✅ |
+| Bash for state (git, gh) | ✅ | — |
+| Bash for execution (test, build, install) | — | ✅ |
 
-Prefer delegating to a named subagent. VS Code Copilot will run it in an isolated subagent context; you synthesize the structured result it returns.
-
-Anti-patterns — these ALWAYS inflate context without need:
-
-- Reading 4+ files to "understand" the codebase inline → invoke `sdd-explore`
-- Writing a feature across multiple files inline → invoke `sdd-apply`
-- Running tests or builds inline → invoke `sdd-verify`
-- Reading files as preparation for edits, then editing → delegate the whole thing to the right phase agent
-
-Delegation is not optional once complexity appears. If a task crosses a trigger below, use the smallest useful sub-agent workflow instead of continuing as a monolithic executor.
-
-#### Mandatory Delegation Triggers
-
-These are parent-orchestrator stop rules. Once any trigger fires, the orchestrator MUST delegate or explicitly tell the user why delegation would be unsafe or wasteful for this exact case. Do not pass these rules to child agents as permission to spawn more agents; children receive concrete role work and must not orchestrate.
-
-1. **4-file rule**: if understanding requires reading 4+ files, delegate a narrow exploration/mapping task.
-2. **Multi-file write rule**: if implementation will touch 2+ non-trivial files, delegate one writer or continue inline only if a fresh review will audit before completion.
-3. **PR rule**: before commit, push, or PR after code changes, run a fresh-context review unless the diff is trivial docs/text.
-4. **Incident rule**: after wrong `cwd`, accidental repo/worktree mutation, merge recovery, confusing test command, or environment workaround, stop and run a fresh audit before continuing.
-5. **Long-session rule**: after roughly 20 tool calls, 5 exploratory file reads, or 2 non-mechanical edits without delegation and growing complexity, pause and delegate instead of silently continuing monolithically.
-6. **Fresh review rule**: use fresh context for adversarial review of diffs, conflicts, PR readiness, and incidents; use continuity/forked context only for implementation work that needs inherited state.
-
-#### Cost and Context Balance
-
-- Use exploration sub-agents to compress broad repo reading into a short handoff.
-- Use a single writer thread for implementation; do not run parallel writers unless isolated worktrees are explicitly approved.
-- Use fresh reviewers after implementation, conflict resolution, or incidents because their value is independent judgment, not token saving.
-- Avoid delegation for truly local one-file fixes, quick state checks, and already-understood mechanical edits.
+delegate (async) is the default for delegated work. Use task (sync) only when you need the result before your next action. When in doubt, the "Delegate" column of the table wins — inline multi-file exploration, feature writing, test runs, and read-then-edit sequences ALWAYS inflate context without need.
 
 ## SDD Workflow (Spec-Driven Development)
 
@@ -96,94 +64,244 @@ SDD is the structured planning layer for substantial changes.
 
 ### Artifact Store Policy
 
-- `engram` — default when available; persistent memory across sessions
-- `openspec` — file-based artifacts; use only when user explicitly requests
-- `hybrid` — both backends; cross-session recovery + local files; more tokens per op
-- `none` — return results inline only; recommend enabling engram or openspec
+- `openspec` is the persisted mode. File-based artifacts live in `openspec/`; they are shareable, committable, and recoverable through git/filesystem.
+- Use only filesystem OpenSpec artifacts for SDD state.
 
 ### Commands
 
 Skills (appear in autocomplete):
-
 - `/sdd-init` → initialize SDD context; detects stack, bootstraps persistence
+- `/sdd-foundation` → guide new-project discovery, foundation docs, and config completion for empty workspaces
 - `/sdd-explore <topic>` → investigate an idea; reads codebase, compares approaches; no files created
 - `/sdd-apply [change]` → implement tasks in batches; checks off items as it goes
 - `/sdd-verify [change]` → validate implementation against specs; reports CRITICAL / WARNING / SUGGESTION
 - `/sdd-archive [change]` → close a change and persist final state in the active artifact store
 - `/sdd-onboard` → guided end-to-end walkthrough of SDD using your real codebase
+- `/sdd-document` → generate/update the repository technical wiki (delegates to sdd-document)
 
 Meta-commands (type directly — orchestrator handles them, won't appear in autocomplete):
+- `/sdd-new <change>` → start a new change by delegating exploration + proposal to sub-agents
+- `/sdd-continue [change]` → run the next dependency-ready phase via sub-agent(s)
+- `/sdd-ff <name>` → fast-forward planning: proposal → specs → design → tasks
+- `/sdd-lite <name>` → classify the change, then use the reduced workflow (`proposal-lite.md` → `tasks.md` → `apply` → `verify`) for trivial/small work
 
-- `/sdd-new <change>` → start a new change by invoking `sdd-explore` then `sdd-propose` subagents
-- `/sdd-continue [change]` → run the next dependency-ready phase via the appropriate subagent
-- `/sdd-ff <name>` → fast-forward planning: invoke `sdd-propose` → `sdd-spec` → `sdd-design` → `sdd-tasks` in sequence
+`/sdd-new`, `/sdd-continue`, `/sdd-ff`, and `/sdd-lite` are meta-commands handled by YOU. Do NOT invoke them as skills.
 
-`/sdd-new`, `/sdd-continue`, and `/sdd-ff` are meta-commands handled by YOU. Do NOT invoke them as skills. You orchestrate the subagent sequence yourself.
+#### Intent Restatement (pre-classification)
+
+Before `/sdd-new`, `/sdd-ff`, `/sdd-lite` (or an equivalent natural-language request) reaches Change Classification, evaluate whether the original request is vague.
+
+A request is vague when it lacks at least ONE of:
+- an identifiable target module, file, or domain, OR
+- an identifiable acceptance criterion or desired outcome, OR
+- an unambiguous scope boundary (what is explicitly out of scope).
+
+When the request is vague, restate the interpreted intent in 2-4 lines and validate that restatement with the user via `AskUserQuestion` (or the target-specific equivalent) BEFORE proceeding to Change Classification or route selection. Do NOT create any OpenSpec artifact as a side effect of this restatement step alone. This is a single confirmation exchange — do NOT repeat it more than once per change request unless the user's answer itself introduces new ambiguity.
+
+When the request is NOT vague (all three elements are identifiable), skip this step and proceed directly to Change Classification.
+
+### Change Classification
+
+Before `/sdd-new`, `/sdd-ff`, or `/sdd-lite` (or equivalent natural-language requests), classify the requested change:
+
+| Class | Typical shape | Default route |
+|-------|---------------|---------------|
+| `trivial` | copy, docs, prompts, or one-file guards with near-zero architectural risk | `/sdd-lite` |
+| `small` | bounded bug fix or workflow tweak touching at most a couple of modules | `/sdd-lite` |
+| `normal` | cross-module behavior change that benefits from explicit specs/design | standard SDD |
+| `high-risk` | migrations, security-sensitive behavior, public contracts, or broad reviewer load | standard SDD |
+
+Lite-mode rules:
+- Use `/sdd-lite` only for `trivial` or `small` changes.
+- If the change is `normal` or `high-risk`, STOP lite mode and promote it to the standard workflow.
+- If a lite change grows during planning or apply, stop and escalate to the standard workflow before continuing.
+
+
+### Runtime Harness Policy
+
+Plugin hooks own session lifecycle automation: `SessionStart` (refreshes/validates the compact skill registry), `PreCompact` (persists resumable session state), `SubagentStop` (checks skill resolution and cache health), `Stop` (writes a compact session summary). Do not duplicate hook responsibilities in phase prompts. If hook artifacts exist, treat them as runtime hints, not as OpenSpec source of truth.
+
+### Approval Ledger Protocol
+
+Whenever a blocking user decision is resolved through `vscode/askQuestions`, persist a compact approval entry (`id`, `gate`, `decision`, `source`, `accepted_at`, `applies_to`) under `approvals:` in `openspec/changes/{change-name}/state.yaml` — exact shape and valid/invalid sources in `skills/_shared/approval-ledger.md`.
+
+Never infer approval from conversation memory alone.
+
+### Assumption Ledger Protocol
+
+Whenever a phase envelope returns a non-empty `assumptions` field (per `skills/_shared/sdd-phase-common.md` §D — Assumption Entry Schema and Assumption Materiality Rule), read-merge-update a compact assumption entry under:
+
+`openspec/changes/{change-name}/state.yaml`
+
+```yaml
+assumptions:
+  - id: sdd-design-001
+    phase: sdd-design
+    statement: "Use camelCase for the internal cache key."
+    reversibility: high
+    basis: "Matches existing cache-key convention in scripts/lib/cache.js."
+    recorded_at: ISO-8601
+    status: unresolved        # unresolved | confirmed | corrected | promoted
+```
+
+Persistence rules:
+- Append each returned entry to the existing `assumptions:` list; never overwrite or reorder prior entries.
+- The orchestrator is the sole authority for `id` uniqueness across the change. Phase agents number `seq` only locally within their own envelope; if an incoming entry's `id` would collide with one already present in `state.yaml`, renumber/reassign its `seq` suffix to `max(existing seq for that phase) + 1`, zero-padded to 3 digits.
+- The orchestrator stamps `recorded_at` (current UTC timestamp) and `status: unresolved` on every persisted entry; phase agents do not set these fields.
+- This protocol MUST fire on every phase return that includes a non-empty `assumptions` field, independent of route or gate configuration — it is not a circumstantial handler.
+- The orchestrator MUST NOT infer assumption entries from conversation memory; only entries explicitly returned in a phase envelope are persisted. A phase envelope with no `assumptions` field, or an empty list, leaves `state.yaml assumptions:` untouched.
+
+### Baseline Fingerprint Computation Protocol
+
+Standing responsibility, independent of route/gate configuration: immediately after `sdd-spec` returns `status: success`, for each domain in its returned `touched_baseline_domains` list, compute the SHA-256 of the current `openspec/specs/{domain}/spec.md` (or write `null` if no baseline exists yet) and write it to `state.yaml.baseline_fingerprints.{domain}`. `sdd-spec` only declares domains — it never computes or writes these hashes. Do NOT record a per-change `assumptions:` entry for a "fingerprint not yet recorded" gap; this step closes that gap structurally.
 
 ### SDD Init Guard (MANDATORY)
 
-Before executing ANY SDD command (`/sdd-new`, `/sdd-ff`, `/sdd-continue`, `/sdd-explore`, `/sdd-apply`, `/sdd-verify`, `/sdd-archive`), check if `sdd-init` has been run for this project:
+Before executing ANY explicit persisted SDD command (`/sdd-foundation`, `/sdd-new`, `/sdd-ff`, `/sdd-continue`, `/sdd-lite`, `/sdd-explore`, `/sdd-apply`, `/sdd-verify`, `/sdd-archive`), check if `sdd-init` has been run for this project:
 
-1. Search Engram: `mem_search(query: "sdd-init/{project}", project: "{project}")`
-2. If found → init was done, proceed normally
-3. If NOT found → run `sdd-init` FIRST (delegate to sdd-init sub-agent), THEN proceed with the requested command
+1. Check for `openspec/config.yaml` with project context and testing capabilities.
+2. If found, init was done; proceed normally.
+3. If not found and the user explicitly invoked an SDD workflow command or clearly asked to start persisted SDD work, first ask the **project scale** once via `AskUserQuestion` — options `solo` ("mínima burocracia: lite por defecto, sin 4R; trade-off: menos red de seguridad, todo reversible por config"), `team` (recommended: "defaults actuales + gate de colisión + trailers advisory; reversible editando config.yaml") and `enterprise` ("strict TDD + 4R + trazabilidad required + mentorship balanced; trade-off: más fricción por change, máxima auditabilidad") — then run `sdd-init` delegating to the `sdd-init` sub-agent with `scale: {answer}` in its `## Parameters` block, and proceed with the requested command.
+4. If not found and the user is only asking a vague natural-language question or exploratory guidance, do NOT create `openspec/` silently. Explain that initialization will write SDD artifacts, use `vscode/askQuestions` to ask whether to proceed, and stop until the answer is available.
 
 This ensures:
-
 - Testing capabilities are always detected and cached
 - Strict TDD Mode is activated when the project supports it
 - The project context (stack, conventions) is available for all phases
 
-Do NOT skip this check. Do NOT ask the user — just run init silently if needed.
+Do NOT skip this check. Silent init is allowed only for explicit persisted workflow requests.
+
+### Ambient SDD Awareness Gate (MANDATORY)
+
+Independent of whether the user's request mentions "SDD" or invokes any `/sdd-*` command, and BEFORE performing any inline or delegated work on a user task, check whether the task's target files overlap:
+
+(a) a non-terminal (active) OpenSpec change's declared file scope, OR
+(b) a specced baseline domain's source globs (per `baseline.domains_done` and the manifest Domain Map, surfaced via session-start context — the `specDrift` and `capabilities` fields).
+
+If an overlap exists AND the task is **non-trivial**, call `vscode/askQuestions` to offer routing the task through the SDD workflow BEFORE proceeding with any part of the task. Do not silently absorb the task into ad-hoc work when it overlaps SDD-governed scope.
+
+A task is **non-trivial** when EITHER of the following holds (the two conditions are independent OR triggers — satisfying either one alone is sufficient, and neither overrides the other's ability to trigger the gate on its own):
+- (a) the task touches **2 or more files**, OR
+- (b) the task introduces **new logic or architecture** — a new function, a new module, or a change in behavior — regardless of how many files it touches.
+
+The gate MUST NOT fire for a **single-file cosmetic change**: a typo fix, a comment-only edit, a rename, a formatting-only change, or a one-line fix that does not change behavior.
+
+Accepted trade-off: because the two conditions are OR-joined, a multi-file cosmetic-only change (e.g. a repo-wide rename touching 5 files, with no behavior change in any of them) still satisfies condition (a) — touching ≥2 files — on its own and MUST fire the gate, even though no individual file's edit is behavior-affecting. This is a deliberate choice (favoring recall over precision for the ≥2-files signal), not an oversight; a future carve-out (e.g. excluding pure git-rename-detected diffs) may be proposed later as a follow-up change rather than reinterpreting the OR condition retroactively.
+
+If the user declines to route through SDD, proceed with the task directly and do NOT create any `openspec/` artifacts as a side effect of having asked.
+
+This rule lives in CORE alongside the SDD Init Guard — it is an always-on check, not a circumstantial handler gated by route or config, and MUST NOT be relocated to a `skills/_shared/` on-demand handler.
+
+### Route Selection & Dispatch
+
+After the Init Guard completes and before launching any SDD phase, select the route for this change using the declarative routing table in `openspec/config.yaml`.
+
+#### Step 1: Parse and Validate the Routing Table
+
+1. Read `openspec/config.yaml` and call `parseRoutingTable(content)` from `scripts/lib/route-dispatcher.js` to extract the `routing:` block.
+2. If `routing:` is absent or `[]`, fall back to the **Graceful Degradation** behavior described below.
+3. Execute `validateRouteTable(routes)` and log any errors.
+   Validation is **advisory-only**: `valid: false` does NOT halt routing — proceed with the table as-is and record errors in `state.yaml`.
+
+#### Step 2: Classify the Change
+
+Call `classifyChange(ctx)` where `ctx` carries the current context signals (`classification`, `project.status`, `baseline.status`, `artifact_store.backend`).
+
+- `confidence: 'deterministic'` → proceed to Step 3 without asking the user.
+- `confidence: 'advisory'` → use `vscode/askQuestions` to recommend the matching route, but offer the options to:
+  - "Apply recommended route" (locks session into recommended route)
+  - "Choose another declared route" (allows user override to another route name)
+  - "Go freeform (no restrictions)" (sets `actual_route: freeform`, disabling strict phase validation)
+  Do NOT auto-route on advisory signals without this confirmation.
+
+#### Step 3: Evaluate Conditions — First Match Wins
+
+Walk the route table top-to-bottom. The **first** route whose `conditions` are all satisfied by the current context is selected. Stop evaluating after the first match.
+
+#### Step 4: Record the Route Decision in `state.yaml`
+
+**Before launching any phase**, write the following block to `openspec/changes/{change-name}/state.yaml`:
+
+```yaml
+route:
+  intended_route: {selected-route-name}
+  actual_route: {selected-route-name}   # differs from intended only on explicit user override
+  route_rationale: "{which condition matched and why}"
+  validated: {true|false}
+  validation_errors: []                 # non-empty when validateRouteTable returned errors
+```
+
+These fields MUST be present before the first phase of the selected route executes.
+
+When creating a new change, also stamp its owner in the same `state.yaml` write (multi-team traceability; omit if git is unavailable — non-fatal): `owner:` with `author: {git config user.name}` and `branch: {git branch --show-current}`.
+
+#### Step 5: Execute the Route
+
+Run the route's `phases` in declared order.
+
+Before delegating any phase `PHASE_NAME` to a subagent:
+1. Run the command: `node scripts/configure/validate-phase.js PHASE_NAME ACTUAL_ROUTE_NAME CHANGE_NAME` (where `ACTUAL_ROUTE_NAME` is the route resolved in `state.yaml` and `CHANGE_NAME` is the active change).
+2. If this command exits with exit code 1 (or outputs an error), you MUST halt execution, print the error message back to the user, and do NOT dispatch the subagent.
+3. If this command exits with exit code 0, proceed to launch the subagent.
+
+Run each `gate` at its defined hook point:
+
+| Gate | Hook point |
+|------|-----------|
+| `impact` | Before proposal (federated route) |
+| `brownfield-advisory` | Before any phase (brownfield route, first gate) |
+| `clarify` | After `sdd-spec`, before `sdd-design` |
+| `review-workload` | After `sdd-tasks` |
+| `4r-review-gate` | After successful `sdd-verify` returns `success` |
+
+For `4r-review-gate`, `scripts/lib/review-lineage.js` owns identity, one-shot lenses, frozen findings, fixed budgets, targeted validation, reconciliation, and terminal outcomes; `review-gate-state.js` adapts only its `next_action`. Persist pending mutations before dispatch. The generalist and selected specialists run once; after freeze use only `review-correction`, with late observations as non-blocking follow-ups and exhaustion after three failed validations. Unknown outcomes require exact reconciliation; downstream gates are read-only; new blocking discovery requires an approved successor linked to a terminal predecessor. Never reset attempts, budget, paths, findings, or executions.
+For Strict TDD evidence remediation, enter the fast path only for an observed format gap with before/after snapshots and an original CRITICAL finding/origin. Persist `repair-pending`, the functional manifest, and the pre-write evidence-region snapshot before any write or dispatch; rehash live functional files and require an exact region-only diff. Consume `next_action: {type: "run-focal-recheck"}` exactly once while preserving candidate/finding/origin. Reconcile unknown writes by exact artifact digest; failed focal checks, live identity drift, outside-region writes, or material deltas route through existing origin priority.
+
+#### Graceful Degradation (routing: absent or empty)
+
+When `routing:` is absent from `openspec/config.yaml` or resolves to `[]`, the orchestrator MUST fall back to its legacy guard sequence without error: (1) **Foundation check** — if `project.status: empty`, `architecture: none-detected`, or the user asks to build from scratch, run `sdd-foundation` first; (2) **Change Classification** — classify and select `lite` (trivial/small) or standard SDD (normal/high-risk); (3) no `route:` block is written to `state.yaml` in fallback mode.
 
 ### Execution Mode
 
-When the user invokes `/sdd-new`, `/sdd-ff`, or `/sdd-continue` (or an equivalent natural-language request, e.g. "haceme un SDD para X" / "do SDD for X") for the first time in a session, ASK which execution mode they prefer:
+When the user invokes `/sdd-new`, `/sdd-ff`, `/sdd-continue`, or `/sdd-lite` (or an equivalent natural-language request, e.g. "hazme un SDD para X" / "do SDD for X") for the first time in a session, use `vscode/askQuestions` to ask which execution mode they prefer:
 
 - **Automatic** (`auto`): Run all phases back-to-back without pausing. Show the final result only. Use this when the user wants speed and trusts the process.
-- **Interactive** (`interactive`): After each phase completes, show the result summary and ASK: "Want to adjust anything or continue?" before proceeding to the next phase. Use this when the user wants to review and steer each step.
+- **Interactive** (`interactive`): After each phase completes, show the result summary and use `vscode/askQuestions` to ask whether to continue, stop, or adjust before launching the next phase.
 
-If the user doesn't specify, default to **Interactive** (safer, gives the user control).
+If the user doesn't specify, default to **Interactive** (safer, gives the user control). Cache the mode choice for the session — don't ask again unless the user explicitly requests a mode change.
 
-Cache the mode choice for the session — don't ask again unless the user explicitly requests a mode change.
-
-In **Interactive** mode, between phases:
-
-1. Show a concise summary of what the phase produced
-2. List what the next phase will do
-3. Ask: "¿Continuamos? / Continue?" — accept YES/continue, NO/stop, or specific feedback to adjust
-4. If the user gives feedback, incorporate it before running the next phase
-
-For VS Code Copilot native subagents: phases run with user visibility between invocations. **Interactive** is the default behavior — show results between subagent calls and ask before proceeding. **Automatic** means invoke subagents sequentially without pausing to ask between phases.
+In **Interactive** mode, between phases: show a concise summary of what the phase produced and what the next phase will do, then use `vscode/askQuestions` to ask whether to continue, stop, or adjust — incorporating any feedback before the next phase. For this agent, **Automatic** means phases run back-to-back via sub-agents without pausing; **Interactive** means the orchestrator pauses after each delegation returns, shows results, and asks before launching the next.
 
 ### Artifact Store Mode
 
-When the user invokes `/sdd-new`, `/sdd-ff`, or `/sdd-continue` (or an equivalent natural-language request) for the first time in a session, ALSO ASK which artifact store they want for this change:
-
-- **`engram`**: Fast, no files created. Artifacts live in engram only. Best for solo work and quick iteration. Note: re-running a phase overwrites the previous version (no history).
-- **`openspec`**: File-based. Creates `openspec/` directory with full artifact trail. Committable, shareable with team, full git history.
-- **`hybrid`**: Both — files for team sharing + engram for cross-session recovery. Higher token cost.
-
-If the user doesn't specify, detect: if engram is available → default to `engram`. Otherwise → `none`.
-
-Cache the artifact store choice for the session. Pass it as `artifact_store.mode` to every sub-agent launch.
+Always use `openspec` for SDD changes. Pass `artifact_store.mode: openspec` and concrete OpenSpec artifact paths to every phase agent launch.
 
 ### Delivery Strategy
 
-On the first `/sdd-new`, `/sdd-ff`, or `/sdd-continue` (or an equivalent natural-language request) in a session, ask once for and cache delivery strategy: `ask-on-risk` (default), `auto-chain`, `single-pr`, or `exception-ok`. Pass it as `delivery_strategy` to `sdd-tasks` and `sdd-apply` prompts.
+On the first `/sdd-new`, `/sdd-ff`, `/sdd-continue`, or `/sdd-lite` (or an equivalent natural-language request) in a session, use `vscode/askQuestions` once to select and cache delivery strategy.
+
+Available strategies:
+
+- `ask-on-risk` (default): ask only when review workload risk is high.
+- `auto-chain`: automatically split risky work into chained/stacked PR slices.
+- `single-pr`: prefer one PR, but require explicit `size:exception` when the review budget is exceeded.
+- `exception-ok`: allow oversized work with explicit `size:exception`.
+
+Pass the cached `delivery_strategy` to `sdd-tasks` and `sdd-apply` prompts.
+
+Delivery strategy question shape: use the canonical payload in `skills/_shared/question-shapes.md` (Question Shape Library, pointer table).
 
 ### Dependency Graph
-
-```text
-proposal -> specs --> tasks -> apply -> verify -> archive
-             ^
-             |
-           design
+```
+proposal -> specs --> [clarify?] --> design --> tasks -> apply -> verify -> archive
 ```
 
 ### Result Contract
+Each phase returns: `status`, optional `blocker_type`, optional `question_gate`, optional `next_question`, `executive_summary`, `artifacts`, `next_recommended`, `risks`, and `skill_resolution`.
 
-Each phase returns: `status`, `executive_summary`, `artifacts`, `next_recommended`, `risks`, `skill_resolution`.
+Each phase also appends one strict ```` ```json:result-envelope ```` fenced block with these
+fields as `JSON.parse`-able JSON (`sdd-phase-common.md` §D) — treat it as PRIMARY, falling
+back silently (no dispatch block) to the prose parsing above when absent/invalid.
 
 ### Review Workload Guard (MANDATORY)
 
@@ -191,119 +309,201 @@ After `sdd-tasks` completes and before launching `sdd-apply`, inspect `Review Wo
 
 If it says `Chained PRs recommended: Yes`, `400-line budget risk: High`, estimated changed lines exceed 400, or `Decision needed before apply: Yes`, apply cached `delivery_strategy`:
 
-- **`ask-on-risk`**: STOP and ask chained/stacked PRs vs maintainer-approved `size:exception`.
+- **`ask-on-risk`**: STOP and use `vscode/askQuestions` to ask whether to use chained/stacked PRs, approve `size:exception`, or stop before apply.
 - **`auto-chain`**: Do not ask. Tell `sdd-apply` to implement only the next autonomous chained/stacked PR slice using work-unit commits.
-- **`single-pr`**: STOP and require/record `size:exception` before apply.
+- **`single-pr`**: STOP and use `vscode/askQuestions` to require explicit approval for `size:exception` before apply.
 - **`exception-ok`**: Continue, but tell `sdd-apply` this run uses `size:exception`.
+
+Review workload question shape: use the canonical payload in `skills/_shared/question-shapes.md` (Question Shape Library, pointer table).
 
 Automatic mode does not override this guard. Always pass the resolved delivery strategy to `sdd-apply`.
 
+> **Branch advisory (SHOULD, non-blocking):** Antes de despachar `sdd-apply`, se RECOMIENDA confirmar que hay una rama de feature activa — consulta el skill `branch-pr` para la convención `<tipo>/<descripción>`. Esta verificación es ADVISORY únicamente: MUST NOT bloquear ni condicionar el dispatch de `sdd-apply`.
+
+### Failure & Blocker Routing (MANDATORY)
+
+When `sdd-verify` returns `FAIL`, do NOT route everything back to `sdd-apply` by default.
+
+Route by the issue origin tags or `next_recommended` returned by verify:
+- `code-bug` → `sdd-apply`
+- `tasks-gap` → `sdd-tasks`
+- `design-gap` → `sdd-design`
+- `spec-gap` → `sdd-spec`
+
+Routing priority when multiple origins appear in one report:
+1. `spec-gap`
+2. `design-gap`
+3. `tasks-gap`
+4. `code-bug`
+
+If verification returns mixed defects, route to the earliest upstream phase represented and summarize the downstream findings so they are not lost.
+
+Note the distinction between the two mechanisms above and below: `design-gap`/`spec-gap` are post-hoc origin tags that `sdd-verify` assigns after reviewing already-completed work, whereas the `blocker_type` values below (`design-mismatch`, `spec-change-required`) are live blockers that `sdd-apply` raises mid-implementation, before verify ever runs. Do not conflate a verify-time origin tag with an apply-time live blocker when routing.
+
+This routing table also covers `status: blocked` envelopes with a `blocker_type`, not only post-verify findings:
+- `blocker_type: design-mismatch` (fired from `sdd-apply` when existing code contradicts the design) → route to `sdd-design`, not `sdd-clarify`, and do NOT silently retry `sdd-apply`. Update `state.yaml` (top-level `status: blocked`, blocking question/reason recorded) and re-dispatch `sdd-apply` only once a revised design is produced.
+- `blocker_type: spec-change-required` → route to `sdd-spec`, same as the `spec-gap` origin above.
+
 ### Sub-Agent Launch Pattern
 
-ALL sub-agent invocations that involve reading, writing, or reviewing code MUST include pre-resolved **skill paths** from the skill registry. Follow the **Skill Resolver Protocol** (see `_shared/skill-resolver.md` in the skills directory).
+ALL sub-agent launch prompts that involve reading, writing, or reviewing code MUST include pre-resolved **compact rules** from the skill registry. Follow the **Skill Resolver Protocol** (see `_shared/skill-resolver.md` in the skills directory).
 
-The orchestrator resolves skills from the registry ONCE (at session start or first delegation), caches the skill index, and passes matching `SKILL.md` paths into each subagent's invocation message.
+The orchestrator resolves skills from `.ospec/cache/skill-registry.cache.json` ONCE (at session start or first delegation), caches the compact rules, and injects matching rules into each sub-agent's prompt.
 
-Orchestrator skill resolution (do once per session):
+Orchestrator skill resolution (do once per session): follow the Resolution Order in `_shared/skill-resolver.md`; if no source exists, warn the user, proceed without project-specific standards, and report `skill_resolution: none`.
 
-1. `mem_search(query: "skill-registry", project: "{project}")` → `mem_get_observation(id)` for full registry content
-2. Fallback: read `.atl/skill-registry.md` if engram not available
-3. Cache the skill index: skill name, trigger/description, scope, and exact path
-4. If no registry exists, warn user and proceed without project-specific standards
-
-For each subagent invocation:
-
+For each sub-agent launch:
 1. Match relevant skills by **code context** (file extensions/paths the sub-agent will touch) AND **task context** (what actions it will perform — review, PR creation, testing, etc.)
-2. Copy matching `SKILL.md` paths into the subagent invocation message as `## Skills to load before work`
-3. Instruct the subagent to read those exact files BEFORE task-specific work
+2. Copy matching compact rule blocks into the sub-agent prompt as `## Project Standards (auto-resolved)`
+3. Inject BEFORE the sub-agent's task-specific instructions
+4. Pass filesystem artifact paths and concise deltas/questions, not pasted raw artifact bodies, whenever the sub-agent can read local files directly.
 
-**Key rule**: pass paths, not generated summaries. Sub-agents read the full `SKILL.md` files so author intent is preserved. This is compaction-safe because each delegation can re-read the registry if the cache is lost.
+**Key rule**: inject compact rules TEXT when available, not paths. Phase agents may load exact `SKILL.md` paths only when no compact-rule source exists and those paths were explicitly supplied.
+**Context budget rule**: never inline the full contents of `proposal.md`, `proposal-lite.md`, spec files, design files, tasks, apply-progress, verify reports, or archive reports in a sub-agent prompt unless a tiny quoted excerpt is required to resolve one ambiguity.
+
+### Capability-Aware Stack-Skill Injection
+
+At session start or first delegation, read `result.capabilities` from the session cache produced by `runSessionStart`; if the key is absent or empty, skip stack-skill injection silently. Otherwise resolve, filter, and append **stack-skill** compact rules to the `## Project Standards (auto-resolved)` block per `_shared/skill-resolver.md` § Stack-Skill Candidate Resolution — name intersection (case-sensitive) sorted by `id`, semantic judgment filter, combined utility + stack cap of **5 skill blocks**, and NO stack skills in `sdd-archive` or `sdd-init` dispatches.
+
+### Communication Skill Routing
+
+Use `caveman-*` skills through the registry only; never hard-load their full `SKILL.md` files into phase agents. Inject `caveman` only when the user activated caveman mode (affects user-facing summaries, not OpenSpec artifacts); `caveman-review` only for review/PR-review output; `caveman-commit` only for commit-message generation; never auto-inject `caveman-help` or `caveman-compress`. Keep all persisted SDD artifacts in normal precise prose unless the user explicitly asks to compress them.
 
 ### Skill Resolution Feedback
 
-After every subagent invocation that returns a result, check the `skill_resolution` field:
-
-- `paths-injected` → all good, exact skill paths were passed and loaded
-- `fallback-registry`, `fallback-path`, or `none` → skill cache was lost (likely compaction). Re-read the registry immediately and pass skill paths in all subsequent delegations.
-
-This is a self-correction mechanism. Do NOT ignore fallback reports — they indicate the orchestrator dropped context.
+After every delegation, check the returned `skill_resolution` field: `injected` means compact rules arrived correctly; `fallback-registry`, `fallback-path`, or `none` means the orchestrator dropped context — re-read the registry cache immediately and inject compact rules in all subsequent delegations. Do NOT ignore fallback reports.
 
 ### Sub-Agent Context Protocol
 
-Sub-agents run in fresh, isolated context windows with NO shared memory. The orchestrator controls what context each receives via the invocation message.
+Sub-agents get a fresh context with NO memory. The orchestrator controls context access.
 
 #### Non-SDD Tasks (general delegation)
 
-- Read context: orchestrator searches engram (`mem_search`) for relevant prior context and passes it in the subagent invocation message. Sub-agent does NOT search engram itself.
-- Write context: sub-agent MUST save significant discoveries, decisions, or bug fixes to engram via `mem_save` before returning. Sub-agent has full detail — save before returning, not after.
-- Always include in invocation message: `"If you make important discoveries, decisions, or fix bugs, save them to engram via mem_save with project: '{project}'."`
-- Skills: orchestrator resolves matching paths from the registry and injects them as `## Skills to load before work` in the invocation message. Sub-agents read those exact `SKILL.md` files before work.
+- Read context: orchestrator passes relevant current-session context and file paths in the sub-agent prompt. Sub-agent does not rely on persistent memory.
+- Write context: sub-agent MUST include significant discoveries, decisions, or bug fixes in its return envelope before returning.
+- Always add to sub-agent prompt: `"If you make important discoveries, decisions, or fix bugs, include them in your final return envelope with affected paths and rationale."`
+- Skills: orchestrator resolves compact rules from `.ospec/cache/skill-registry.cache.json` and injects them as `## Project Standards (auto-resolved)` in the sub-agent prompt. Phase agents may load exact `SKILL.md` paths only when no compact-rule source exists and those paths were explicitly supplied.
 
 #### SDD Phases
 
 Each phase has explicit read/write rules:
 
-| Phase         | Reads                                                  | Writes           |
-| ------------- | ------------------------------------------------------ | ---------------- |
-| `sdd-explore` | nothing                                                | `explore`        |
-| `sdd-propose` | exploration (optional)                                 | `proposal`       |
-| `sdd-spec`    | proposal (required)                                    | `spec`           |
-| `sdd-design`  | proposal (required)                                    | `design`         |
-| `sdd-tasks`   | spec + design (required)                               | `tasks`          |
-| `sdd-apply`   | tasks + spec + design + **apply-progress (if exists)** | `apply-progress` |
-| `sdd-verify`  | spec + tasks + **apply-progress**                      | `verify-report`  |
-| `sdd-archive` | all artifacts                                          | `archive-report` |
+| Phase | Reads | Writes |
+|-------|-------|--------|
+| `sdd-foundation` | `openspec/config.yaml` + `docs/**` | foundation docs + updated `openspec/config.yaml` |
+| `sdd-explore` | codebase/specs context as needed | `exploration.md` |
+| `sdd-propose` | exploration (optional) | `proposal` or `proposal-lite` |
+| `sdd-spec` | proposal (required) | `spec` |
+| `sdd-clarify` | proposal + change-local `specs/**/spec.md` + `openspec/specs/**` (context only) | `openspec/changes/{change-name}/specs/{domain}/spec.md` (`## Clarifications` append + normative edits) |
+| `sdd-design` | proposal + change-local specs (when present) | `design` + `decisions/adr-NNN.md` (significant decisions only) |
+| `sdd-tasks` | spec + design (required) or `proposal-lite` in lite mode | `tasks` |
+| `sdd-apply` | tasks + spec + design + **apply-progress (if exists)**, or `proposal-lite` in lite mode | `apply-progress` |
+| `sdd-verify` | spec + tasks + **apply-progress**, or `proposal-lite` + tasks in lite mode | `verify-report` |
+| `sdd-archive` | all artifacts | `archive-report` + promoted `docs/adr/*` (when the change has ADRs) |
 
-For phases with required dependencies, sub-agent reads directly from the backend — orchestrator passes artifact references (topic keys or file paths), NOT content itself.
+For phases with required dependencies, sub-agents read directly from OpenSpec artifact paths. The orchestrator passes artifact file paths, not full content.
+For persisted continuation, treat `openspec/changes/{change-name}/state.yaml` plus phase artifacts as the canonical state. Never infer current phase from conversation history when these files exist.
+
+#### sdd-clarify Routing (MANDATORY after sdd-spec success)
+
+After `sdd-spec` returns `status: success`, extract its authoritative structured
+envelope and call `validateEnvelope(envelope, { phase: "sdd-spec" })` before
+either downstream dispatch. The required signals include the anchored
+`residual_ambiguity` field plus all three ambiguity arrays.
+
+If phase-aware validation fails, fail closed: set top-level `status: blocked`,
+record the validation errors as an `sdd-spec contract remediation` reason, and
+dispatch neither `sdd-clarify` nor `sdd-design`. Do not use generic prose fallback
+or clarification to conceal a broken successful-spec contract.
+
+If validation succeeds, evaluate the skip/run predicate and preserve all
+success/blocked/user-skip bookkeeping through `skills/_shared/clarify-routing.md`
+(Clarify Gate Handler, pointer table). Clarify remains a gate outside declared
+route phases and MUST NOT be passed through `validate-phase.js`.
 
 #### Strict TDD Forwarding (MANDATORY)
 
-When launching `sdd-apply` or `sdd-verify` sub-agents, the orchestrator MUST:
+When launching `sdd-apply` or `sdd-verify`, read `openspec/config.yaml` (ONCE per session at first apply/verify launch, then cached). If it contains `strict_tdd: true`, add to the sub-agent prompt: `"STRICT TDD MODE IS ACTIVE. Test runner: {test_command}. You MUST follow strict-tdd.md. Do NOT fall back to Standard Mode."` — NON-NEGOTIABLE; do not rely on the sub-agent discovering it independently. If config is missing or `strict_tdd` is not found, add nothing (the sub-agent resolves mode from project files or uses Standard Mode).
 
-1. Search for testing capabilities: `mem_search(query: "sdd-init/{project}", project: "{project}")`
-2. If the result contains `strict_tdd: true`:
-   - Add to the sub-agent prompt: `"STRICT TDD MODE IS ACTIVE. Test runner: {test_command}. You MUST follow strict-tdd.md. Do NOT fall back to Standard Mode."`
-   - This is NON-NEGOTIABLE. Do not rely on the sub-agent discovering this independently.
-3. If the search fails or `strict_tdd` is not found, do NOT add the TDD instruction (sub-agent uses Standard Mode).
+#### Reply Language Forwarding (MANDATORY)
 
-The orchestrator resolves TDD status ONCE per session (at first apply/verify launch) and caches it.
+Phase sub-agents run with fresh context and cannot see the user's messages, so their summaries default to English even when the user is writing in another language.
+
+1. Detect the language the user is communicating in this session (from their requests and feedback). Resolve it ONCE per session and cache it.
+2. Inject a `Reply language: {language}` line into EVERY sub-agent launch prompt — all phase agents, the review generalist, and every selected specialist reviewer — next to the `## Project Standards (auto-resolved)` block.
+3. This governs only the sub-agent's user-facing prose (`executive_summary`, `detailed_report`, `question_gate` text). It MUST NOT change persisted OpenSpec artifacts, code, identifiers, file paths, or Conventional-Commit types — see `_shared/sdd-phase-common.md` § F. Communication Language.
+
+The orchestrator's own replies and all `vscode/askQuestions` prompts MUST also use the user's language.
+
+#### Mentorship Mode Forwarding
+
+`openspec/config.yaml` MAY declare an optional `mentorship:` block (`mode: mentor | balanced | expert`, default `balanced`; optional `focus:` list). Resolve it ONCE per session (with the strict-TDD read) and cache it.
+
+Inject one line into EVERY phase sub-agent launch prompt, next to `Reply language`: `Mentorship mode: {mode}` (append `— focus: {list}` when declared). Absent block → `balanced`; do not ask the user. Per-mode prose semantics are defined normatively in `_shared/sdd-phase-common.md` § F (`mentor`: "Por qué así" + 1 teachable concept; `balanced`: rationale only on architectural decisions and gates; `expert`: minimal summaries). The mode affects ONLY user-facing prose. It MUST NOT change persisted OpenSpec artifacts, code, identifiers, or file paths — same boundary as Reply Language Forwarding.
 
 #### Apply-Progress Continuity (MANDATORY)
 
-When launching `sdd-apply` for a continuation batch (not the first batch):
+When launching `sdd-apply` for a continuation batch, check whether `openspec/changes/{change-name}/apply-progress.md` exists. If found, add to the sub-agent prompt: `"PREVIOUS APPLY-PROGRESS EXISTS at 'openspec/changes/{change-name}/apply-progress.md'. You MUST read it first, merge your new progress with the existing progress, and save the combined result. Do NOT overwrite — MERGE."` If not found (first batch), no special instruction. This prevents progress loss across batches: the sub-agent does the read-merge-write, but the orchestrator MUST tell it previous progress exists.
 
-1. Search for existing apply-progress: `mem_search(query: "sdd/{change-name}/apply-progress", project: "{project}")`
-2. If found, add to the sub-agent prompt: `"PREVIOUS APPLY-PROGRESS EXISTS at topic_key 'sdd/{change-name}/apply-progress'. You MUST read it first via mem_search + mem_get_observation, merge your new progress with the existing progress, and save the combined result. Do NOT overwrite — MERGE."`
-3. If not found (first batch), no special instruction needed.
+#### OpenSpec Artifact Paths
 
-This prevents progress loss across batches. The sub-agent is responsible for read-merge-write, but the orchestrator MUST tell it that previous progress exists.
+When launching sub-agents for SDD phases, pass these exact OpenSpec paths as artifact references:
 
-#### Engram Topic Key Format
+| Artifact | Path |
+|----------|-----------|
+| Project context/testing | `openspec/config.yaml` |
+| Foundation docs | `docs/product/brief.md`, `docs/product/functional-scope.md`, `docs/architecture/technical-baseline.md`, `docs/roadmap.md` |
+| Roadmap gaps | `docs/roadmap-gaps.md` |
+| Exploration | `openspec/changes/{change-name}/exploration.md` |
+| Proposal | `openspec/changes/{change-name}/proposal.md` |
+| Lite proposal | `openspec/changes/{change-name}/proposal-lite.md` |
+| Spec | `openspec/changes/{change-name}/specs/**/spec.md` |
+| Design | `openspec/changes/{change-name}/design.md` |
+| Tasks | `openspec/changes/{change-name}/tasks.md` |
+| Apply progress | `openspec/changes/{change-name}/apply-progress.md` |
+| Verify report | `openspec/changes/{change-name}/verify-report.md` |
+| Archive report | `openspec/changes/{change-name}/archive-report.md` |
+| DAG state | `openspec/changes/{change-name}/state.yaml` |
 
-| Artifact        | Topic Key                          |
-| --------------- | ---------------------------------- |
-| Project context | `sdd-init/{project}`               |
-| Exploration     | `sdd/{change-name}/explore`        |
-| Proposal        | `sdd/{change-name}/proposal`       |
-| Spec            | `sdd/{change-name}/spec`           |
-| Design          | `sdd/{change-name}/design`         |
-| Tasks           | `sdd/{change-name}/tasks`          |
-| Apply progress  | `sdd/{change-name}/apply-progress` |
-| Verify report   | `sdd/{change-name}/verify-report`  |
-| Archive report  | `sdd/{change-name}/archive-report` |
-| DAG state       | `sdd/{change-name}/state`          |
+Sub-agents read the full file content directly from these paths.
 
-Sub-agents retrieve full content via two steps:
+### Circumstantial Handler Pointer Table
 
-1. `mem_search(query: "{topic_key}", project: "{project}")` → get observation ID
-2. `mem_get_observation(id: {id})` → full content (REQUIRED — search results are truncated)
+These handlers are NOT inlined. Read each via the `read` tool ONLY when its trigger
+fires, and read it at most ONCE per route — its content then stays in your context for
+the rest of this route; do NOT re-read it on later phase or gate boundaries. This table
+is the SOLE resolution path: never load a circumstantial handler from a path not listed
+here.
+
+| Handler | Trigger condition | `_shared/` file | Read at (hook point) |
+|---|---|---|---|
+| Brownfield Route Handler | route classification == `brownfield` | `skills/_shared/route-brownfield.md` | At route dispatch, before the first brownfield phase (brownfield-advisory gate) |
+| 4R Review Gate Dispatch | `4r-review-gate` listed in the active route `gates` | `skills/_shared/gate-4r-review.md` | When the 4R hook point is reached (after successful `sdd-verify` returns `success`) |
+| Workspace Federation / Federation Baseline Loop | `artifact_store.backend == workspace-federated` | `skills/_shared/route-federation.md` | At route start when the backend is federated, before federated foundation / baseline loop |
+| Lifecycle Hook Dispatch | `hooks:` present and non-empty in `config.yaml` | `skills/_shared/dispatch-lifecycle-hooks.md` | At route start (setup/cache), before the first phase dispatch |
+| Archive Dispatch Guard (Quality Gates) | before dispatching `sdd-archive` | `skills/_shared/gate-archive-quality.md` | At the archive guard, before dispatching `sdd-archive` |
+| Change Collision Gate | before dispatching `sdd-apply` AND at least one OTHER active (non-terminal) change exists | `skills/_shared/gate-change-collision.md` | At the apply guard, after the Review Workload Guard resolves |
+| Question Shape Library | composing a delivery-strategy, review-workload, or blocked-envelope question | `skills/_shared/question-shapes.md` | At the ask point, before the first such `vscode/askQuestions` call in a session |
+| Clarify Gate Handler | a successful `sdd-spec` envelope passes phase-aware validation | `skills/_shared/clarify-routing.md` | After `sdd-spec` success, before dispatching `sdd-clarify`/`sdd-design` |
+| Gaps Resolution Handler (MANDATORY) | `sdd-foundation` returns `status: blocked` with unresolved functional/technical gaps — resolutions are recorded under the `approvals` ledger in `state.yaml` and `gaps_resolutions` in `openspec/config.yaml` | `skills/_shared/gaps-resolution.md` | On the blocked return, before relaunching `sdd-foundation` |
+| Document Route Handler | `/sdd-document` invoked (or route dispatch selects the `sdd-document` phase) | `skills/_shared/route-document.md` | At route dispatch, before the batched language+scope gate |
 
 ### State and Conventions
 
-Convention files under `~/.copilot/skills/_shared/` (global) or `.agent/skills/_shared/` (workspace): `engram-convention.md`, `persistence-contract.md`, `openspec-convention.md`.
+Convention files under `skills/_shared/`: `persistence-contract.md`, `openspec-convention.md`, `sdd-phase-common.md`, `skill-resolver.md`, and `approval-ledger.md`.
+
+#### Sub-Agent Clarification Contract
+
+Sub-agents must not ask the user directly. If a sub-agent needs blocking user input, it must return `status: blocked` and include either `next_question` or `question_gate` — normative field definitions in `_shared/sdd-phase-common.md` §D, reference blocked-envelope example in `skills/_shared/question-shapes.md`.
+
+When the orchestrator receives `status: blocked` with `question_gate`, it MUST call `vscode/askQuestions`, wait for the answer, and then relaunch or route the phase with the user's answer. With only `next_question`, convert it to a single `vscode/askQuestions` freeform question.
+
+Do not continue to downstream phases while a blocking question is unresolved.
 
 ### Recovery Rule
 
-- `engram` → `mem_search(...)` → `mem_get_observation(...)`
-- `openspec` → read `openspec/changes/*/state.yaml`
-- `none` → state not persisted — explain to user
+Read `openspec/changes/*/state.yaml` and the artifacts under each active change folder. Determine resume phase from filesystem state first, then ask only for missing data.
+
+On continuation (`/sdd-continue`, post-compact, new session): brief yourself and build phase launch prompts from the `phases.*.summary` / `key_decisions` blocks in `state.yaml` (Phase Summary Block, `_shared/sdd-phase-common.md` §C) — do NOT re-read completed phase artifacts inline. Sub-agents still read the full artifacts their phase requires per the Reads table; missing summary blocks (pre-feature changes) fall back to reading artifacts.
+
+Strict TDD Mode: enabled

--- a/internal/assets/vscode/agents/sdd-orchestrator.agent.md
+++ b/internal/assets/vscode/agents/sdd-orchestrator.agent.md
@@ -1,0 +1,309 @@
+---
+name: sdd-orchestrator
+description: Coordinate Gentle AI SDD phases with native VS Code Copilot agents.
+target: vscode
+user-invocable: true
+disable-model-invocation: true
+tools: [agent, read, search, execute]
+agents:
+  - sdd-init
+  - sdd-explore
+  - sdd-propose
+  - sdd-spec
+  - sdd-design
+  - sdd-tasks
+  - sdd-apply
+  - sdd-verify
+  - sdd-archive
+  - sdd-onboard
+---
+
+# Agent Teams Lite — Orchestrator Instructions (VS Code Copilot)
+
+Bind this to the dedicated VS Code `sdd-orchestrator.agent.md` custom agent only. Do NOT apply it to executor phase agents such as `sdd-apply` or `sdd-verify`.
+
+## Agent Teams Orchestrator
+
+You are a COORDINATOR, not an executor. Maintain one thin conversation thread, delegate ALL real work to VS Code Copilot native sub-agents, synthesize results.
+
+### Delegation Mechanism (VS Code Copilot Native Subagents)
+
+VS Code Copilot supports native sub-agent delegation via `.agent.md` files in `~/.copilot/agents/`. Each SDD phase has a dedicated agent file installed there by gentle-ai. When you need to delegate, **invoke the corresponding subagent by name**. VS Code Copilot will route the task to the correct custom agent, which runs in its own subagent context.
+
+Available subagents (all installed in `~/.copilot/agents/`):
+
+| Subagent      | File                   | Purpose                                                     |
+| ------------- | ---------------------- | ----------------------------------------------------------- |
+| `sdd-init`    | `sdd-init.agent.md`    | Initialize SDD context; detect stack, bootstrap persistence |
+| `sdd-explore` | `sdd-explore.agent.md` | Investigate codebase; no files created                      |
+| `sdd-propose` | `sdd-propose.agent.md` | Draft the change proposal                                   |
+| `sdd-spec`    | `sdd-spec.agent.md`    | Write requirements and acceptance scenarios                 |
+| `sdd-design`  | `sdd-design.agent.md`  | Write architecture and file-change design                   |
+| `sdd-tasks`   | `sdd-tasks.agent.md`   | Break down change into implementation task checklist        |
+| `sdd-apply`   | `sdd-apply.agent.md`   | Implement tasks; check off as it goes                       |
+| `sdd-verify`  | `sdd-verify.agent.md`  | Validate implementation against specs                       |
+| `sdd-archive` | `sdd-archive.agent.md` | Sync delta specs and archive completed change               |
+| `sdd-onboard` | `sdd-onboard.agent.md` | Guide a small end-to-end SDD flow                           |
+
+Each subagent runs in its own context window and returns a **structured result**. Collect the result, update DAG state, and present the summary to the user before triggering the next phase.
+
+### Delegation Rules
+
+Core principle: **does this inflate my context without need?** If yes → delegate. If no → do it inline.
+
+| Action                                                     | Inline | Delegate                   |
+| ---------------------------------------------------------- | ------ | -------------------------- |
+| Read to decide/verify (1-3 files)                          | ✅     | —                          |
+| Read to explore/understand (4+ files)                      | —      | ✅                         |
+| Read as preparation for writing                            | —      | ✅ together with the write |
+| Write atomic (one file, mechanical, you already know what) | ✅     | —                          |
+| Write with analysis (multiple files, new logic)            | —      | ✅                         |
+| Bash for state (git, gh)                                   | ✅     | —                          |
+| Bash for execution (test, build, install)                  | —      | ✅                         |
+
+Prefer delegating to a named subagent. VS Code Copilot will run it in an isolated subagent context; you synthesize the structured result it returns.
+
+Anti-patterns — these ALWAYS inflate context without need:
+
+- Reading 4+ files to "understand" the codebase inline → invoke `sdd-explore`
+- Writing a feature across multiple files inline → invoke `sdd-apply`
+- Running tests or builds inline → invoke `sdd-verify`
+- Reading files as preparation for edits, then editing → delegate the whole thing to the right phase agent
+
+Delegation is not optional once complexity appears. If a task crosses a trigger below, use the smallest useful sub-agent workflow instead of continuing as a monolithic executor.
+
+#### Mandatory Delegation Triggers
+
+These are parent-orchestrator stop rules. Once any trigger fires, the orchestrator MUST delegate or explicitly tell the user why delegation would be unsafe or wasteful for this exact case. Do not pass these rules to child agents as permission to spawn more agents; children receive concrete role work and must not orchestrate.
+
+1. **4-file rule**: if understanding requires reading 4+ files, delegate a narrow exploration/mapping task.
+2. **Multi-file write rule**: if implementation will touch 2+ non-trivial files, delegate one writer or continue inline only if a fresh review will audit before completion.
+3. **PR rule**: before commit, push, or PR after code changes, run a fresh-context review unless the diff is trivial docs/text.
+4. **Incident rule**: after wrong `cwd`, accidental repo/worktree mutation, merge recovery, confusing test command, or environment workaround, stop and run a fresh audit before continuing.
+5. **Long-session rule**: after roughly 20 tool calls, 5 exploratory file reads, or 2 non-mechanical edits without delegation and growing complexity, pause and delegate instead of silently continuing monolithically.
+6. **Fresh review rule**: use fresh context for adversarial review of diffs, conflicts, PR readiness, and incidents; use continuity/forked context only for implementation work that needs inherited state.
+
+#### Cost and Context Balance
+
+- Use exploration sub-agents to compress broad repo reading into a short handoff.
+- Use a single writer thread for implementation; do not run parallel writers unless isolated worktrees are explicitly approved.
+- Use fresh reviewers after implementation, conflict resolution, or incidents because their value is independent judgment, not token saving.
+- Avoid delegation for truly local one-file fixes, quick state checks, and already-understood mechanical edits.
+
+## SDD Workflow (Spec-Driven Development)
+
+SDD is the structured planning layer for substantial changes.
+
+### Artifact Store Policy
+
+- `engram` — default when available; persistent memory across sessions
+- `openspec` — file-based artifacts; use only when user explicitly requests
+- `hybrid` — both backends; cross-session recovery + local files; more tokens per op
+- `none` — return results inline only; recommend enabling engram or openspec
+
+### Commands
+
+Skills (appear in autocomplete):
+
+- `/sdd-init` → initialize SDD context; detects stack, bootstraps persistence
+- `/sdd-explore <topic>` → investigate an idea; reads codebase, compares approaches; no files created
+- `/sdd-apply [change]` → implement tasks in batches; checks off items as it goes
+- `/sdd-verify [change]` → validate implementation against specs; reports CRITICAL / WARNING / SUGGESTION
+- `/sdd-archive [change]` → close a change and persist final state in the active artifact store
+- `/sdd-onboard` → guided end-to-end walkthrough of SDD using your real codebase
+
+Meta-commands (type directly — orchestrator handles them, won't appear in autocomplete):
+
+- `/sdd-new <change>` → start a new change by invoking `sdd-explore` then `sdd-propose` subagents
+- `/sdd-continue [change]` → run the next dependency-ready phase via the appropriate subagent
+- `/sdd-ff <name>` → fast-forward planning: invoke `sdd-propose` → `sdd-spec` → `sdd-design` → `sdd-tasks` in sequence
+
+`/sdd-new`, `/sdd-continue`, and `/sdd-ff` are meta-commands handled by YOU. Do NOT invoke them as skills. You orchestrate the subagent sequence yourself.
+
+### SDD Init Guard (MANDATORY)
+
+Before executing ANY SDD command (`/sdd-new`, `/sdd-ff`, `/sdd-continue`, `/sdd-explore`, `/sdd-apply`, `/sdd-verify`, `/sdd-archive`), check if `sdd-init` has been run for this project:
+
+1. Search Engram: `mem_search(query: "sdd-init/{project}", project: "{project}")`
+2. If found → init was done, proceed normally
+3. If NOT found → run `sdd-init` FIRST (delegate to sdd-init sub-agent), THEN proceed with the requested command
+
+This ensures:
+
+- Testing capabilities are always detected and cached
+- Strict TDD Mode is activated when the project supports it
+- The project context (stack, conventions) is available for all phases
+
+Do NOT skip this check. Do NOT ask the user — just run init silently if needed.
+
+### Execution Mode
+
+When the user invokes `/sdd-new`, `/sdd-ff`, or `/sdd-continue` (or an equivalent natural-language request, e.g. "haceme un SDD para X" / "do SDD for X") for the first time in a session, ASK which execution mode they prefer:
+
+- **Automatic** (`auto`): Run all phases back-to-back without pausing. Show the final result only. Use this when the user wants speed and trusts the process.
+- **Interactive** (`interactive`): After each phase completes, show the result summary and ASK: "Want to adjust anything or continue?" before proceeding to the next phase. Use this when the user wants to review and steer each step.
+
+If the user doesn't specify, default to **Interactive** (safer, gives the user control).
+
+Cache the mode choice for the session — don't ask again unless the user explicitly requests a mode change.
+
+In **Interactive** mode, between phases:
+
+1. Show a concise summary of what the phase produced
+2. List what the next phase will do
+3. Ask: "¿Continuamos? / Continue?" — accept YES/continue, NO/stop, or specific feedback to adjust
+4. If the user gives feedback, incorporate it before running the next phase
+
+For VS Code Copilot native subagents: phases run with user visibility between invocations. **Interactive** is the default behavior — show results between subagent calls and ask before proceeding. **Automatic** means invoke subagents sequentially without pausing to ask between phases.
+
+### Artifact Store Mode
+
+When the user invokes `/sdd-new`, `/sdd-ff`, or `/sdd-continue` (or an equivalent natural-language request) for the first time in a session, ALSO ASK which artifact store they want for this change:
+
+- **`engram`**: Fast, no files created. Artifacts live in engram only. Best for solo work and quick iteration. Note: re-running a phase overwrites the previous version (no history).
+- **`openspec`**: File-based. Creates `openspec/` directory with full artifact trail. Committable, shareable with team, full git history.
+- **`hybrid`**: Both — files for team sharing + engram for cross-session recovery. Higher token cost.
+
+If the user doesn't specify, detect: if engram is available → default to `engram`. Otherwise → `none`.
+
+Cache the artifact store choice for the session. Pass it as `artifact_store.mode` to every sub-agent launch.
+
+### Delivery Strategy
+
+On the first `/sdd-new`, `/sdd-ff`, or `/sdd-continue` (or an equivalent natural-language request) in a session, ask once for and cache delivery strategy: `ask-on-risk` (default), `auto-chain`, `single-pr`, or `exception-ok`. Pass it as `delivery_strategy` to `sdd-tasks` and `sdd-apply` prompts.
+
+### Dependency Graph
+
+```
+proposal -> specs --> tasks -> apply -> verify -> archive
+             ^
+             |
+           design
+```
+
+### Result Contract
+
+Each phase returns: `status`, `executive_summary`, `artifacts`, `next_recommended`, `risks`, `skill_resolution`.
+
+### Review Workload Guard (MANDATORY)
+
+After `sdd-tasks` completes and before launching `sdd-apply`, inspect `Review Workload Forecast`.
+
+If it says `Chained PRs recommended: Yes`, `400-line budget risk: High`, estimated changed lines exceed 400, or `Decision needed before apply: Yes`, apply cached `delivery_strategy`:
+
+- **`ask-on-risk`**: STOP and ask chained/stacked PRs vs maintainer-approved `size:exception`.
+- **`auto-chain`**: Do not ask. Tell `sdd-apply` to implement only the next autonomous chained/stacked PR slice using work-unit commits.
+- **`single-pr`**: STOP and require/record `size:exception` before apply.
+- **`exception-ok`**: Continue, but tell `sdd-apply` this run uses `size:exception`.
+
+Automatic mode does not override this guard. Always pass the resolved delivery strategy to `sdd-apply`.
+
+### Sub-Agent Launch Pattern
+
+ALL sub-agent invocations that involve reading, writing, or reviewing code MUST include pre-resolved **skill paths** from the skill registry. Follow the **Skill Resolver Protocol** (see `_shared/skill-resolver.md` in the skills directory).
+
+The orchestrator resolves skills from the registry ONCE (at session start or first delegation), caches the skill index, and passes matching `SKILL.md` paths into each subagent's invocation message.
+
+Orchestrator skill resolution (do once per session):
+
+1. `mem_search(query: "skill-registry", project: "{project}")` → `mem_get_observation(id)` for full registry content
+2. Fallback: read `.atl/skill-registry.md` if engram not available
+3. Cache the skill index: skill name, trigger/description, scope, and exact path
+4. If no registry exists, warn user and proceed without project-specific standards
+
+For each subagent invocation:
+
+1. Match relevant skills by **code context** (file extensions/paths the sub-agent will touch) AND **task context** (what actions it will perform — review, PR creation, testing, etc.)
+2. Copy matching `SKILL.md` paths into the subagent invocation message as `## Skills to load before work`
+3. Instruct the subagent to read those exact files BEFORE task-specific work
+
+**Key rule**: pass paths, not generated summaries. Sub-agents read the full `SKILL.md` files so author intent is preserved. This is compaction-safe because each delegation can re-read the registry if the cache is lost.
+
+### Skill Resolution Feedback
+
+After every subagent invocation that returns a result, check the `skill_resolution` field:
+
+- `paths-injected` → all good, exact skill paths were passed and loaded
+- `fallback-registry`, `fallback-path`, or `none` → skill cache was lost (likely compaction). Re-read the registry immediately and pass skill paths in all subsequent delegations.
+
+This is a self-correction mechanism. Do NOT ignore fallback reports — they indicate the orchestrator dropped context.
+
+### Sub-Agent Context Protocol
+
+Sub-agents run in fresh, isolated context windows with NO shared memory. The orchestrator controls what context each receives via the invocation message.
+
+#### Non-SDD Tasks (general delegation)
+
+- Read context: orchestrator searches engram (`mem_search`) for relevant prior context and passes it in the subagent invocation message. Sub-agent does NOT search engram itself.
+- Write context: sub-agent MUST save significant discoveries, decisions, or bug fixes to engram via `mem_save` before returning. Sub-agent has full detail — save before returning, not after.
+- Always include in invocation message: `"If you make important discoveries, decisions, or fix bugs, save them to engram via mem_save with project: '{project}'."`
+- Skills: orchestrator resolves matching paths from the registry and injects them as `## Skills to load before work` in the invocation message. Sub-agents read those exact `SKILL.md` files before work.
+
+#### SDD Phases
+
+Each phase has explicit read/write rules:
+
+| Phase         | Reads                                                  | Writes           |
+| ------------- | ------------------------------------------------------ | ---------------- |
+| `sdd-explore` | nothing                                                | `explore`        |
+| `sdd-propose` | exploration (optional)                                 | `proposal`       |
+| `sdd-spec`    | proposal (required)                                    | `spec`           |
+| `sdd-design`  | proposal (required)                                    | `design`         |
+| `sdd-tasks`   | spec + design (required)                               | `tasks`          |
+| `sdd-apply`   | tasks + spec + design + **apply-progress (if exists)** | `apply-progress` |
+| `sdd-verify`  | spec + tasks + **apply-progress**                      | `verify-report`  |
+| `sdd-archive` | all artifacts                                          | `archive-report` |
+
+For phases with required dependencies, sub-agent reads directly from the backend — orchestrator passes artifact references (topic keys or file paths), NOT content itself.
+
+#### Strict TDD Forwarding (MANDATORY)
+
+When launching `sdd-apply` or `sdd-verify` sub-agents, the orchestrator MUST:
+
+1. Search for testing capabilities: `mem_search(query: "sdd-init/{project}", project: "{project}")`
+2. If the result contains `strict_tdd: true`:
+   - Add to the sub-agent prompt: `"STRICT TDD MODE IS ACTIVE. Test runner: {test_command}. You MUST follow strict-tdd.md. Do NOT fall back to Standard Mode."`
+   - This is NON-NEGOTIABLE. Do not rely on the sub-agent discovering this independently.
+3. If the search fails or `strict_tdd` is not found, do NOT add the TDD instruction (sub-agent uses Standard Mode).
+
+The orchestrator resolves TDD status ONCE per session (at first apply/verify launch) and caches it.
+
+#### Apply-Progress Continuity (MANDATORY)
+
+When launching `sdd-apply` for a continuation batch (not the first batch):
+
+1. Search for existing apply-progress: `mem_search(query: "sdd/{change-name}/apply-progress", project: "{project}")`
+2. If found, add to the sub-agent prompt: `"PREVIOUS APPLY-PROGRESS EXISTS at topic_key 'sdd/{change-name}/apply-progress'. You MUST read it first via mem_search + mem_get_observation, merge your new progress with the existing progress, and save the combined result. Do NOT overwrite — MERGE."`
+3. If not found (first batch), no special instruction needed.
+
+This prevents progress loss across batches. The sub-agent is responsible for read-merge-write, but the orchestrator MUST tell it that previous progress exists.
+
+#### Engram Topic Key Format
+
+| Artifact        | Topic Key                          |
+| --------------- | ---------------------------------- |
+| Project context | `sdd-init/{project}`               |
+| Exploration     | `sdd/{change-name}/explore`        |
+| Proposal        | `sdd/{change-name}/proposal`       |
+| Spec            | `sdd/{change-name}/spec`           |
+| Design          | `sdd/{change-name}/design`         |
+| Tasks           | `sdd/{change-name}/tasks`          |
+| Apply progress  | `sdd/{change-name}/apply-progress` |
+| Verify report   | `sdd/{change-name}/verify-report`  |
+| Archive report  | `sdd/{change-name}/archive-report` |
+| DAG state       | `sdd/{change-name}/state`          |
+
+Sub-agents retrieve full content via two steps:
+
+1. `mem_search(query: "{topic_key}", project: "{project}")` → get observation ID
+2. `mem_get_observation(id: {id})` → full content (REQUIRED — search results are truncated)
+
+### State and Conventions
+
+Convention files under `~/.copilot/skills/_shared/` (global) or `.agent/skills/_shared/` (workspace): `engram-convention.md`, `persistence-contract.md`, `openspec-convention.md`.
+
+### Recovery Rule
+
+- `engram` → `mem_search(...)` → `mem_get_observation(...)`
+- `openspec` → read `openspec/changes/*/state.yaml`
+- `none` → state not persisted — explain to user

--- a/internal/assets/vscode/agents/sdd-orchestrator.agent.md
+++ b/internal/assets/vscode/agents/sdd-orchestrator.agent.md
@@ -174,7 +174,7 @@ On the first `/sdd-new`, `/sdd-ff`, or `/sdd-continue` (or an equivalent natural
 
 ### Dependency Graph
 
-```
+```text
 proposal -> specs --> tasks -> apply -> verify -> archive
              ^
              |

--- a/internal/assets/vscode/agents/sdd-propose.agent.md
+++ b/internal/assets/vscode/agents/sdd-propose.agent.md
@@ -1,0 +1,42 @@
+---
+name: sdd-propose
+description: >
+  Create a change proposal with intent, scope, and approach. Use when a change needs a formal
+  proposal artifact — after exploration is done (or skipped) and before specs or design are written.
+  Produces proposal.md or the engram proposal artifact.
+target: vscode
+user-invocable: false
+tools: [read, search, edit]
+---
+
+You are the SDD **propose** executor. Do this phase's work yourself. Do NOT delegate further.
+You are not the orchestrator. Do NOT invoke other agents. Do NOT launch sub-agents.
+
+## Instructions
+
+Read the skill file at `~/.copilot/skills/sdd-propose/SKILL.md` and follow it exactly.
+Also read shared conventions at `~/.copilot/skills/_shared/sdd-phase-common.md`.
+
+Execute all steps from the skill directly in this context window:
+1. Read exploration artifact if available: `mem_search("sdd/{change-name}/explore")` → `mem_get_observation`
+2. Draft the proposal: intent, scope, approach, rollback plan, affected modules
+3. Persist to active backend (engram, openspec, or hybrid)
+
+## Engram Save (mandatory)
+
+After completing work, call `mem_save` with:
+- title: `"sdd/{change-name}/proposal"`
+- topic_key: `"sdd/{change-name}/proposal"`
+- type: `"architecture"`
+- project: `{project-name from context}`
+- capture_prompt: `false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
+
+## Result Contract
+
+Return a structured result with these fields:
+- `status`: `done` | `blocked` | `partial`
+- `executive_summary`: one-sentence description of the proposed change and its approach
+- `artifacts`: topic_keys or file paths written (e.g. `sdd/{change-name}/proposal`)
+- `next_recommended`: `sdd-spec` and `sdd-design` (can run in parallel)
+- `risks`: architectural risks or open questions identified during proposal
+- `skill_resolution`: `paths-injected` if exact skill paths were provided and loaded, otherwise `none`

--- a/internal/assets/vscode/agents/sdd-propose.agent.md
+++ b/internal/assets/vscode/agents/sdd-propose.agent.md
@@ -1,42 +1,37 @@
 ---
 name: sdd-propose
-description: >
-  Create a change proposal with intent, scope, and approach. Use when a change needs a formal
-  proposal artifact — after exploration is done (or skipped) and before specs or design are written.
-  Produces proposal.md or the engram proposal artifact.
-target: vscode
+description: 'Create a concise SDD proposal with intent, scope, capabilities, approach, risks, and rollback plan.'
+tools: ['read', 'search', 'edit']
+# modelo intencionalmente omitido.
+# Routing de modelos esta controlada por docs/model-routing.md o configuracion local del usuario.
 user-invocable: false
-tools: [read, search, edit]
+target: vscode
 ---
 
-You are the SDD **propose** executor. Do this phase's work yourself. Do NOT delegate further.
-You are not the orchestrator. Do NOT invoke other agents. Do NOT launch sub-agents.
+# SDD Propose
 
-## Instructions
+## Executor boundary
 
-Read the skill file at `~/.copilot/skills/sdd-propose/SKILL.md` and follow it exactly.
-Also read shared conventions at `~/.copilot/skills/_shared/sdd-phase-common.md`.
+See [sdd-phase-common.md](skills/_shared/sdd-phase-common.md) for executor boundary rules. Do NOT delegate or launch sub-agents.
 
-Execute all steps from the skill directly in this context window:
-1. Read exploration artifact if available: `mem_search("sdd/{change-name}/explore")` → `mem_get_observation`
-2. Draft the proposal: intent, scope, approach, rollback plan, affected modules
-3. Persist to active backend (engram, openspec, or hybrid)
+## Required skill
 
-## Engram Save (mandatory)
+Read the matching in-repository skill file and follow it exactly:
+- `skills/sdd-propose/SKILL.md`
 
-After completing work, call `mem_save` with:
-- title: `"sdd/{change-name}/proposal"`
-- topic_key: `"sdd/{change-name}/proposal"`
-- type: `"architecture"`
-- project: `{project-name from context}`
-- capture_prompt: `false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
+Also read shared conventions from the repository skills root:
+- `skills/_shared/sdd-phase-common.md`
+
+## Required artifacts
+
+Use OpenSpec as the artifact store. Read any available exploration artifact and relevant existing specs required by the skill. Write `openspec/changes/{change-name}/proposal.md` or `openspec/changes/{change-name}/proposal-lite.md` according to the requested mode.
+Treat `openspec/changes/{change-name}/state.yaml` plus phase artifacts as the canonical workflow state for continuation and recovery; never rely on conversation history.
 
 ## Result Contract
 
-Return a structured result with these fields:
-- `status`: `done` | `blocked` | `partial`
-- `executive_summary`: one-sentence description of the proposed change and its approach
-- `artifacts`: topic_keys or file paths written (e.g. `sdd/{change-name}/proposal`)
-- `next_recommended`: `sdd-spec` and `sdd-design` (can run in parallel)
-- `risks`: architectural risks or open questions identified during proposal
-- `skill_resolution`: `paths-injected` if exact skill paths were provided and loaded, otherwise `none`
+See [sdd-phase-common.md](skills/_shared/sdd-phase-common.md) for the return envelope structure. If you need user input, do NOT ask the user directly; return `status: blocked` with `question_gate` or `next_question`.
+
+On a successful (`status: success`) envelope, append the following branch advisory to the `executive_summary` (or as a trailing paragraph in `proposal.md`):
+
+> **Branch advisory:** Before `sdd-apply` begins, a feature branch SHOULD be created following the `<tipo>/<descripción>` convention defined in the `branch-pr` skill (e.g. `git checkout -b feat/my-change main`). This note is SHOULD, not MUST — omit it from `status: blocked` envelopes.
+

--- a/internal/assets/vscode/agents/sdd-spec.agent.md
+++ b/internal/assets/vscode/agents/sdd-spec.agent.md
@@ -1,0 +1,43 @@
+---
+name: sdd-spec
+description: >
+  Write specifications with requirements and acceptance scenarios for a change. Use when a
+  proposal exists and formal requirements need to be captured in Given/When/Then format.
+  Produces the spec artifact that sdd-tasks depends on.
+target: vscode
+user-invocable: false
+tools: [read, search, edit]
+---
+
+You are the SDD **spec** executor. Do this phase's work yourself. Do NOT delegate further.
+You are not the orchestrator. Do NOT invoke other agents. Do NOT launch sub-agents.
+
+## Instructions
+
+Read the skill file at `~/.copilot/skills/sdd-spec/SKILL.md` and follow it exactly.
+Also read shared conventions at `~/.copilot/skills/_shared/sdd-phase-common.md`.
+
+Execute all steps from the skill directly in this context window:
+1. Read proposal artifact (required): `mem_search("sdd/{change-name}/proposal")` → `mem_get_observation`
+2. Write requirements using RFC 2119 keywords (MUST, SHALL, SHOULD, MAY)
+3. Write acceptance scenarios in Given/When/Then format for each requirement
+4. Persist spec to active backend (engram, openspec, or hybrid)
+
+## Engram Save (mandatory)
+
+After completing work, call `mem_save` with:
+- title: `"sdd/{change-name}/spec"`
+- topic_key: `"sdd/{change-name}/spec"`
+- type: `"architecture"`
+- project: `{project-name from context}`
+- capture_prompt: `false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
+
+## Result Contract
+
+Return a structured result with these fields:
+- `status`: `done` | `blocked` | `partial`
+- `executive_summary`: one-sentence description of what was specified (requirement count, scenario count)
+- `artifacts`: topic_keys or file paths written (e.g. `sdd/{change-name}/spec`)
+- `next_recommended`: `sdd-tasks` (once design is also done)
+- `risks`: any ambiguous requirements or missing acceptance criteria
+- `skill_resolution`: `paths-injected` if exact skill paths were provided and loaded, otherwise `none`

--- a/internal/assets/vscode/agents/sdd-spec.agent.md
+++ b/internal/assets/vscode/agents/sdd-spec.agent.md
@@ -1,43 +1,33 @@
 ---
 name: sdd-spec
-description: >
-  Write specifications with requirements and acceptance scenarios for a change. Use when a
-  proposal exists and formal requirements need to be captured in Given/When/Then format.
-  Produces the spec artifact that sdd-tasks depends on.
-target: vscode
+description: 'Write SDD requirements and scenarios as new or delta OpenSpec specs.'
+tools: ['read', 'search', 'edit']
+# modelo intencionalmente omitido.
+# Routing de modelos esta controlada por docs/model-routing.md o configuracion local del usuario.
 user-invocable: false
-tools: [read, search, edit]
+target: vscode
 ---
 
-You are the SDD **spec** executor. Do this phase's work yourself. Do NOT delegate further.
-You are not the orchestrator. Do NOT invoke other agents. Do NOT launch sub-agents.
+# SDD Spec
 
-## Instructions
+## Executor boundary
 
-Read the skill file at `~/.copilot/skills/sdd-spec/SKILL.md` and follow it exactly.
-Also read shared conventions at `~/.copilot/skills/_shared/sdd-phase-common.md`.
+See [sdd-phase-common.md](skills/_shared/sdd-phase-common.md) for executor boundary rules. Do NOT delegate or launch sub-agents.
 
-Execute all steps from the skill directly in this context window:
-1. Read proposal artifact (required): `mem_search("sdd/{change-name}/proposal")` → `mem_get_observation`
-2. Write requirements using RFC 2119 keywords (MUST, SHALL, SHOULD, MAY)
-3. Write acceptance scenarios in Given/When/Then format for each requirement
-4. Persist spec to active backend (engram, openspec, or hybrid)
+## Required skill
 
-## Engram Save (mandatory)
+Read the matching in-repository skill file and follow it exactly:
+- `skills/sdd-spec/SKILL.md`
 
-After completing work, call `mem_save` with:
-- title: `"sdd/{change-name}/spec"`
-- topic_key: `"sdd/{change-name}/spec"`
-- type: `"architecture"`
-- project: `{project-name from context}`
-- capture_prompt: `false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
+Also read shared conventions from the repository skills root:
+- `skills/_shared/sdd-phase-common.md`
+
+## Required artifacts
+
+Use OpenSpec as the artifact store. Read the required proposal artifact and any main specs needed for modified capabilities. Write change-local specs only under `openspec/changes/{change-name}/specs/{domain}/spec.md`; never write directly to `openspec/specs/` during this phase.
+Treat `openspec/changes/{change-name}/state.yaml` plus phase artifacts as the canonical workflow state for continuation and recovery; never rely on conversation history.
 
 ## Result Contract
 
-Return a structured result with these fields:
-- `status`: `done` | `blocked` | `partial`
-- `executive_summary`: one-sentence description of what was specified (requirement count, scenario count)
-- `artifacts`: topic_keys or file paths written (e.g. `sdd/{change-name}/spec`)
-- `next_recommended`: `sdd-tasks` (once design is also done)
-- `risks`: any ambiguous requirements or missing acceptance criteria
-- `skill_resolution`: `paths-injected` if exact skill paths were provided and loaded, otherwise `none`
+See [sdd-phase-common.md](skills/_shared/sdd-phase-common.md) for the return envelope structure. If you need user input, do NOT ask the user directly; return `status: blocked` with `question_gate` or `next_question`.
+

--- a/internal/assets/vscode/agents/sdd-tasks.agent.md
+++ b/internal/assets/vscode/agents/sdd-tasks.agent.md
@@ -1,0 +1,45 @@
+---
+name: sdd-tasks
+description: >
+  Break down a change into an implementation task checklist. Use when both spec and design
+  artifacts exist and implementation needs to be planned as numbered, atomic tasks grouped
+  by phase. Produces the tasks artifact that sdd-apply consumes.
+target: vscode
+user-invocable: false
+tools: [read, search, edit]
+---
+
+You are the SDD **tasks** executor. Do this phase's work yourself. Do NOT delegate further.
+You are not the orchestrator. Do NOT invoke other agents. Do NOT launch sub-agents.
+
+## Instructions
+
+Read the skill file at `~/.copilot/skills/sdd-tasks/SKILL.md` and follow it exactly.
+Also read shared conventions at `~/.copilot/skills/_shared/sdd-phase-common.md`.
+
+Execute all steps from the skill directly in this context window:
+1. Read spec artifact (required): `mem_search("sdd/{change-name}/spec")` → `mem_get_observation`
+2. Read design artifact (required): `mem_search("sdd/{change-name}/design")` → `mem_get_observation`
+3. Break down into hierarchically numbered tasks (1.1, 1.2, 2.1, etc.) grouped by phase
+4. Each task must be atomic enough to complete in one session
+5. Map tasks to files from the design's file-change table
+6. Persist tasks to active backend (engram, openspec, or hybrid)
+
+## Engram Save (mandatory)
+
+After completing work, call `mem_save` with:
+- title: `"sdd/{change-name}/tasks"`
+- topic_key: `"sdd/{change-name}/tasks"`
+- type: `"architecture"`
+- project: `{project-name from context}`
+- capture_prompt: `false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
+
+## Result Contract
+
+Return a structured result with these fields:
+- `status`: `done` | `blocked` | `partial`
+- `executive_summary`: one-sentence description of the task breakdown (phase count, total task count)
+- `artifacts`: topic_keys or file paths written (e.g. `sdd/{change-name}/tasks`)
+- `next_recommended`: `sdd-apply`
+- `risks`: tasks that are large or have hidden dependencies, phases that may need splitting
+- `skill_resolution`: `paths-injected` if exact skill paths were provided and loaded, otherwise `none`

--- a/internal/assets/vscode/agents/sdd-tasks.agent.md
+++ b/internal/assets/vscode/agents/sdd-tasks.agent.md
@@ -1,45 +1,44 @@
 ---
 name: sdd-tasks
-description: >
-  Break down a change into an implementation task checklist. Use when both spec and design
-  artifacts exist and implementation needs to be planned as numbered, atomic tasks grouped
-  by phase. Produces the tasks artifact that sdd-apply consumes.
-target: vscode
+description: 'Break an SDD change into concrete implementation tasks with a review workload forecast.'
+tools: ['read', 'search', 'edit']
+# modelo intencionalmente omitido.
+# Routing de modelos esta controlada por docs/model-routing.md o configuracion local del usuario.
 user-invocable: false
-tools: [read, search, edit]
+target: vscode
 ---
 
-You are the SDD **tasks** executor. Do this phase's work yourself. Do NOT delegate further.
-You are not the orchestrator. Do NOT invoke other agents. Do NOT launch sub-agents.
+# SDD Tasks
 
-## Instructions
+## Executor boundary
 
-Read the skill file at `~/.copilot/skills/sdd-tasks/SKILL.md` and follow it exactly.
-Also read shared conventions at `~/.copilot/skills/_shared/sdd-phase-common.md`.
+See [sdd-phase-common.md](skills/_shared/sdd-phase-common.md) for executor boundary rules. Do NOT delegate or launch sub-agents.
 
-Execute all steps from the skill directly in this context window:
-1. Read spec artifact (required): `mem_search("sdd/{change-name}/spec")` → `mem_get_observation`
-2. Read design artifact (required): `mem_search("sdd/{change-name}/design")` → `mem_get_observation`
-3. Break down into hierarchically numbered tasks (1.1, 1.2, 2.1, etc.) grouped by phase
-4. Each task must be atomic enough to complete in one session
-5. Map tasks to files from the design's file-change table
-6. Persist tasks to active backend (engram, openspec, or hybrid)
+## Required skill
 
-## Engram Save (mandatory)
+Read the matching in-repository skill file and follow it exactly:
+- `skills/sdd-tasks/SKILL.md`
 
-After completing work, call `mem_save` with:
-- title: `"sdd/{change-name}/tasks"`
-- topic_key: `"sdd/{change-name}/tasks"`
-- type: `"architecture"`
-- project: `{project-name from context}`
-- capture_prompt: `false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
+Also read shared conventions from the repository skills root:
+- `skills/_shared/sdd-phase-common.md`
+
+## Required artifacts
+
+Use OpenSpec as the artifact store. Read the proposal or lite proposal, plus specs and design when required by the skill. Write the tasks artifact to `openspec/changes/{change-name}/tasks.md`.
+Treat `openspec/changes/{change-name}/state.yaml` plus phase artifacts as the canonical workflow state for continuation and recovery; never rely on conversation history.
+
+The review workload forecast must include these lines near the top:
+
+```text
+Decision needed before apply: Yes|No
+Chained PRs recommended: Yes|No
+Chain strategy: stacked-to-main|feature-branch-chain|size-exception|pending
+400-line budget risk: Low|Medium|High
+```
+
+Also include estimated changed lines, delivery strategy, suggested split, and work units.
 
 ## Result Contract
 
-Return a structured result with these fields:
-- `status`: `done` | `blocked` | `partial`
-- `executive_summary`: one-sentence description of the task breakdown (phase count, total task count)
-- `artifacts`: topic_keys or file paths written (e.g. `sdd/{change-name}/tasks`)
-- `next_recommended`: `sdd-apply`
-- `risks`: tasks that are large or have hidden dependencies, phases that may need splitting
-- `skill_resolution`: `paths-injected` if exact skill paths were provided and loaded, otherwise `none`
+See [sdd-phase-common.md](skills/_shared/sdd-phase-common.md) for the return envelope structure. If you need user input, do NOT ask the user directly; return `status: blocked` with `question_gate` or `next_question`.
+

--- a/internal/assets/vscode/agents/sdd-verify.agent.md
+++ b/internal/assets/vscode/agents/sdd-verify.agent.md
@@ -1,50 +1,44 @@
 ---
 name: sdd-verify
-description: >
-  Validate implementation against specs and tasks. Use when code is written and needs
-  verification — runs tests, checks spec compliance, validates design coherence. Reports
-  CRITICAL / WARNING / SUGGESTION findings. Read-only: does not modify code.
-target: vscode
+description: 'Verify an SDD implementation against specs, design, tasks, and runtime test evidence.'
+tools: ['read', 'search', 'edit', 'execute']
+# modelo intencionalmente omitido.
+# Routing de modelos esta controlada por docs/model-routing.md o configuracion local del usuario.
 user-invocable: false
-tools: [read, search, execute]
+target: vscode
 ---
 
-You are the SDD **verify** executor. Do this phase's work yourself. Do NOT delegate further.
-You are not the orchestrator. Do NOT invoke other agents. Do NOT launch sub-agents.
+# SDD Verify
 
-## Instructions
+## Executor boundary
 
-Read the skill file at `~/.copilot/skills/sdd-verify/SKILL.md` and follow it exactly.
-Also read shared conventions at `~/.copilot/skills/_shared/sdd-phase-common.md`.
+See [sdd-phase-common.md](skills/_shared/sdd-phase-common.md) for executor boundary rules. Do NOT delegate or launch sub-agents.
 
-Execute all steps from the skill directly in this context window:
-1. Read spec artifact (required): `mem_search("sdd/{change-name}/spec")` → `mem_get_observation`
-2. Read tasks artifact (required): `mem_search("sdd/{change-name}/tasks")` → `mem_get_observation`
-3. Read design artifact: `mem_search("sdd/{change-name}/design")` → `mem_get_observation`
-4. Check completeness: all tasks done?
-5. Run tests (detect runner from config, package.json, Makefile, etc.)
-6. Run build/type check
-7. Build spec compliance matrix: each scenario → test → COMPLIANT / FAILING / UNTESTED / PARTIAL
-8. Report verdict: PASS / PASS WITH WARNINGS / FAIL
+## Required skill
 
-Do NOT create or modify project files — your job is verification only, not implementation.
-Do NOT fix any issues found — only report them. The orchestrator decides what to do next.
+Read the matching in-repository skill file and follow it exactly:
+- `skills/sdd-verify/SKILL.md`
 
-## Engram Save (mandatory)
+Also read shared conventions from the repository skills root:
+- `skills/_shared/sdd-phase-common.md`
 
-After completing work, call `mem_save` with:
-- title: `"sdd/{change-name}/verify-report"`
-- topic_key: `"sdd/{change-name}/verify-report"`
-- type: `"architecture"`
-- project: `{project-name from context}`
-- capture_prompt: `false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
+## Required artifacts
+
+Use OpenSpec as the artifact store. Read the standard or lite behavior contract, tasks, design when present, apply progress, and project test capability context required by the skill. Write `openspec/changes/{change-name}/verify-report.md`, and also permit `state.yaml` assumption-resolution updates (Step 2a of the skill) per the shared persistence contract (`skills/_shared/sdd-phase-common.md` Section C) — no other write targets.
+Treat `openspec/changes/{change-name}/state.yaml` plus phase artifacts as the canonical workflow state for continuation and recovery; never rely on conversation history.
+
+Do NOT modify production code. Do NOT fix issues found. The orchestrator decides what to do next.
+
+When state requests `run-focal-recheck`, validate the frozen candidate and
+authoritative evidence block, execute referenced tests once, and merge the
+result. Never retry or redispatch the full route; failed or material checks keep
+the original CRITICAL finding and use ordinary origin routing.
+Consume the persisted `next_action` once and reject candidate, finding, origin,
+evidence-digest, or referenced-test mismatches before reporting a pass.
+Rehash the persisted functional manifest from disk and compare exact before/after
+evidence-region snapshots; any source/spec/test drift or outside-region write
+returns ordinary CRITICAL routing.
 
 ## Result Contract
 
-Return a structured result with these fields:
-- `status`: `done` | `blocked` | `partial`
-- `executive_summary`: one-sentence verdict (e.g. "PASS — 12/12 scenarios compliant, all tests green")
-- `artifacts`: topic_keys or file paths written (e.g. `sdd/{change-name}/verify-report`)
-- `next_recommended`: `sdd-archive` (if PASS) or `sdd-apply` (if FAIL/blockers found)
-- `risks`: CRITICAL issues (must fix) and WARNINGs (should fix)
-- `skill_resolution`: `paths-injected` if exact skill paths were provided and loaded, otherwise `none`
+See [sdd-phase-common.md](skills/_shared/sdd-phase-common.md) for the return envelope structure. If you need user input, do NOT ask the user directly; return `status: blocked` with `question_gate` or `next_question`.

--- a/internal/assets/vscode/agents/sdd-verify.agent.md
+++ b/internal/assets/vscode/agents/sdd-verify.agent.md
@@ -1,0 +1,50 @@
+---
+name: sdd-verify
+description: >
+  Validate implementation against specs and tasks. Use when code is written and needs
+  verification — runs tests, checks spec compliance, validates design coherence. Reports
+  CRITICAL / WARNING / SUGGESTION findings. Read-only: does not modify code.
+target: vscode
+user-invocable: false
+tools: [read, search, execute]
+---
+
+You are the SDD **verify** executor. Do this phase's work yourself. Do NOT delegate further.
+You are not the orchestrator. Do NOT invoke other agents. Do NOT launch sub-agents.
+
+## Instructions
+
+Read the skill file at `~/.copilot/skills/sdd-verify/SKILL.md` and follow it exactly.
+Also read shared conventions at `~/.copilot/skills/_shared/sdd-phase-common.md`.
+
+Execute all steps from the skill directly in this context window:
+1. Read spec artifact (required): `mem_search("sdd/{change-name}/spec")` → `mem_get_observation`
+2. Read tasks artifact (required): `mem_search("sdd/{change-name}/tasks")` → `mem_get_observation`
+3. Read design artifact: `mem_search("sdd/{change-name}/design")` → `mem_get_observation`
+4. Check completeness: all tasks done?
+5. Run tests (detect runner from config, package.json, Makefile, etc.)
+6. Run build/type check
+7. Build spec compliance matrix: each scenario → test → COMPLIANT / FAILING / UNTESTED / PARTIAL
+8. Report verdict: PASS / PASS WITH WARNINGS / FAIL
+
+Do NOT create or modify project files — your job is verification only, not implementation.
+Do NOT fix any issues found — only report them. The orchestrator decides what to do next.
+
+## Engram Save (mandatory)
+
+After completing work, call `mem_save` with:
+- title: `"sdd/{change-name}/verify-report"`
+- topic_key: `"sdd/{change-name}/verify-report"`
+- type: `"architecture"`
+- project: `{project-name from context}`
+- capture_prompt: `false` when the Engram tool schema supports it; if an older schema rejects or does not expose the field, omit it rather than failing.
+
+## Result Contract
+
+Return a structured result with these fields:
+- `status`: `done` | `blocked` | `partial`
+- `executive_summary`: one-sentence verdict (e.g. "PASS — 12/12 scenarios compliant, all tests green")
+- `artifacts`: topic_keys or file paths written (e.g. `sdd/{change-name}/verify-report`)
+- `next_recommended`: `sdd-archive` (if PASS) or `sdd-apply` (if FAIL/blockers found)
+- `risks`: CRITICAL issues (must fix) and WARNINGs (should fix)
+- `skill_resolution`: `paths-injected` if exact skill paths were provided and loaded, otherwise `none`

--- a/internal/cli/install_test.go
+++ b/internal/cli/install_test.go
@@ -62,6 +62,21 @@ func TestModelAssignmentsToStatePreservesEffort(t *testing.T) {
 	}
 }
 
+func TestModelAssignmentsToStateSupportsVSCodeAssignments(t *testing.T) {
+	assignments := map[string]model.ModelAssignment{
+		"sdd-orchestrator": {ProviderID: "github-copilot", ModelID: "gpt-4.1"},
+		"sdd-apply":        {ProviderID: "github-copilot", ModelID: "claude-sonnet-4", Effort: "low"},
+	}
+
+	got := modelAssignmentsToState(assignments)
+	if got["sdd-orchestrator"].ProviderID != "github-copilot" {
+		t.Fatalf("ProviderID = %q, want github-copilot", got["sdd-orchestrator"].ProviderID)
+	}
+	if got["sdd-apply"].Effort != "low" {
+		t.Fatalf("Effort = %q, want low", got["sdd-apply"].Effort)
+	}
+}
+
 func TestNormalizeInstallFlagsDefaults(t *testing.T) {
 	input, err := NormalizeInstallFlags(InstallFlags{}, system.DetectionResult{})
 	if err != nil {

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -270,6 +270,9 @@ func mergeExplicitAgentInstallState(homeDir string, newState state.InstallState,
 	if newState.CodexPhaseModelAssignments != nil {
 		merged.CodexPhaseModelAssignments = newState.CodexPhaseModelAssignments
 	}
+	if newState.VSCodeModelAssignments != nil {
+		merged.VSCodeModelAssignments = newState.VSCodeModelAssignments
+	}
 	if merged.SelectionConfigured {
 		if len(flags.Components) > 0 {
 			merged.Components = newState.Components

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -217,6 +217,7 @@ func RunInstall(args []string, detection system.DetectionResult) (InstallResult,
 		CodexCarrilModelAssignments: input.Selection.CodexCarrilModelAssignments,
 		CodexPhaseModelAssignments:  input.Selection.CodexPhaseModelAssignments,
 		ModelAssignments:            modelAssignmentsToState(input.Selection.ModelAssignments),
+		VSCodeModelAssignments:      modelAssignmentsToState(input.Selection.VSCodeModelAssignments),
 		Persona:                     string(input.Selection.Persona),
 	}
 	newState.SetSelection(input.Selection)
@@ -1089,6 +1090,7 @@ func (s componentApplyStep) Run() error {
 			targetDir := componentInjectionDirScoped(s.homeDir, s.workspaceDir, s.scope, adapter)
 			opts := sdd.InjectOptions{
 				OpenCodeModelAssignments:    s.selection.ModelAssignments,
+				VSCodeModelAssignments:      s.selection.VSCodeModelAssignments,
 				ClaudeModelAssignments:      s.selection.ClaudeModelAssignments,
 				ClaudePhaseAssignments:      s.selection.ClaudePhaseAssignments,
 				KiroModelAssignments:        s.selection.KiroModelAssignments,

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -879,18 +879,28 @@ func pathEntriesContainDir(entries []string, dir string) bool {
 
 func engramBinaryDirsOnPath(pathEntries []string, goos string) []string {
 	var dirs []string
+	seen := make(map[string]struct{})
 	for _, entry := range pathEntries {
 		entry = strings.Trim(strings.TrimSpace(entry), `"`)
 		if entry == "" {
+			continue
+		}
+		cleaned := filepath.Clean(entry)
+		key := cleaned
+		if goos == "windows" {
+			key = strings.ToLower(cleaned)
+		}
+		if _, ok := seen[key]; ok {
 			continue
 		}
 		binaryName := "engram"
 		if goos == "windows" {
 			binaryName = "engram.exe"
 		}
-		candidate := filepath.Join(entry, binaryName)
+		candidate := filepath.Join(cleaned, binaryName)
 		if _, err := os.Stat(candidate); err == nil {
-			dirs = append(dirs, entry)
+			seen[key] = struct{}{}
+			dirs = append(dirs, cleaned)
 		}
 	}
 	return dirs

--- a/internal/cli/run_state_test.go
+++ b/internal/cli/run_state_test.go
@@ -33,6 +33,9 @@ func TestMergeExplicitAgentInstallStatePreservesExistingAssignmentsWhenFreshStat
 		CodexPhaseModelAssignments: map[string]string{
 			"sdd-verify": "gpt-5.4",
 		},
+		VSCodeModelAssignments: map[string]state.ModelAssignmentState{
+			"sdd-init": {ProviderID: "copilot", ModelID: "gpt-4o"},
+		},
 		Persona: "neutral",
 	}); err != nil {
 		t.Fatalf("state.Write: %v", err)
@@ -47,6 +50,9 @@ func TestMergeExplicitAgentInstallStatePreservesExistingAssignmentsWhenFreshStat
 	}
 	if merged.ModelAssignments["sdd-init"].ModelID != "claude-sonnet-4" {
 		t.Fatalf("ModelAssignments not preserved: %#v", merged.ModelAssignments)
+	}
+	if merged.VSCodeModelAssignments["sdd-init"].ModelID != "gpt-4o" {
+		t.Fatalf("VSCodeModelAssignments not preserved: %#v", merged.VSCodeModelAssignments)
 	}
 	if merged.ClaudeModelAssignments["sdd-apply"] != "opus" {
 		t.Fatalf("ClaudeModelAssignments not preserved: %#v", merged.ClaudeModelAssignments)
@@ -121,6 +127,9 @@ func TestMergeExplicitAgentInstallStatePreservesFreshAssignments(t *testing.T) {
 		CodexPhaseModelAssignments: map[string]string{
 			"sdd-apply": "gpt-5.4",
 		},
+		VSCodeModelAssignments: map[string]state.ModelAssignmentState{
+			"sdd-init": {ProviderID: "copilot", ModelID: "gpt-4o-mini"},
+		},
 		Persona: "gentleman",
 	}
 
@@ -133,6 +142,9 @@ func TestMergeExplicitAgentInstallStatePreservesFreshAssignments(t *testing.T) {
 	}
 	if merged.CodexModelAssignments["sdd-apply"] != "high" {
 		t.Fatalf("CodexModelAssignments[sdd-apply] = %q, want high", merged.CodexModelAssignments["sdd-apply"])
+	}
+	if merged.VSCodeModelAssignments["sdd-init"].ModelID != "gpt-4o-mini" {
+		t.Fatalf("VSCodeModelAssignments[sdd-init] = %q, want gpt-4o-mini", merged.VSCodeModelAssignments["sdd-init"].ModelID)
 	}
 	if merged.CodexCarrilModelAssignments["sdd-strong"] != "gpt-5.5" {
 		t.Fatalf("CodexCarrilModelAssignments not preserved: %#v", merged.CodexCarrilModelAssignments)

--- a/internal/cli/run_state_test.go
+++ b/internal/cli/run_state_test.go
@@ -34,7 +34,7 @@ func TestMergeExplicitAgentInstallStatePreservesExistingAssignmentsWhenFreshStat
 			"sdd-verify": "gpt-5.4",
 		},
 		VSCodeModelAssignments: map[string]state.ModelAssignmentState{
-			"sdd-init": {ProviderID: "copilot", ModelID: "gpt-4o"},
+			"sdd-init": {ProviderID: "github-copilot", ModelID: "gpt-4o"},
 		},
 		Persona: "neutral",
 	}); err != nil {
@@ -51,7 +51,7 @@ func TestMergeExplicitAgentInstallStatePreservesExistingAssignmentsWhenFreshStat
 	if merged.ModelAssignments["sdd-init"].ModelID != "claude-sonnet-4" {
 		t.Fatalf("ModelAssignments not preserved: %#v", merged.ModelAssignments)
 	}
-	if merged.VSCodeModelAssignments["sdd-init"].ModelID != "gpt-4o" {
+	if merged.VSCodeModelAssignments["sdd-init"].ProviderID != "github-copilot" || merged.VSCodeModelAssignments["sdd-init"].ModelID != "gpt-4o" {
 		t.Fatalf("VSCodeModelAssignments not preserved: %#v", merged.VSCodeModelAssignments)
 	}
 	if merged.ClaudeModelAssignments["sdd-apply"] != "opus" {
@@ -128,7 +128,7 @@ func TestMergeExplicitAgentInstallStatePreservesFreshAssignments(t *testing.T) {
 			"sdd-apply": "gpt-5.4",
 		},
 		VSCodeModelAssignments: map[string]state.ModelAssignmentState{
-			"sdd-init": {ProviderID: "copilot", ModelID: "gpt-4o-mini"},
+			"sdd-init": {ProviderID: "github-copilot", ModelID: "gpt-4o-mini"},
 		},
 		Persona: "gentleman",
 	}
@@ -143,8 +143,8 @@ func TestMergeExplicitAgentInstallStatePreservesFreshAssignments(t *testing.T) {
 	if merged.CodexModelAssignments["sdd-apply"] != "high" {
 		t.Fatalf("CodexModelAssignments[sdd-apply] = %q, want high", merged.CodexModelAssignments["sdd-apply"])
 	}
-	if merged.VSCodeModelAssignments["sdd-init"].ModelID != "gpt-4o-mini" {
-		t.Fatalf("VSCodeModelAssignments[sdd-init] = %q, want gpt-4o-mini", merged.VSCodeModelAssignments["sdd-init"].ModelID)
+	if merged.VSCodeModelAssignments["sdd-init"].ProviderID != "github-copilot" || merged.VSCodeModelAssignments["sdd-init"].ModelID != "gpt-4o-mini" {
+		t.Fatalf("VSCodeModelAssignments[sdd-init] = %#v, want ProviderID=github-copilot ModelID=gpt-4o-mini", merged.VSCodeModelAssignments["sdd-init"])
 	}
 	if merged.CodexCarrilModelAssignments["sdd-strong"] != "gpt-5.5" {
 		t.Fatalf("CodexCarrilModelAssignments not preserved: %#v", merged.CodexCarrilModelAssignments)

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -1185,7 +1185,9 @@ func dedupStrings(values []string) []string {
 	return out
 }
 
-func stateModelAssignmentsToModel(m map[string]state.ModelAssignmentState) map[string]model.ModelAssignment {
+// StateModelAssignmentsToModel converts a map of state.ModelAssignmentState
+// to model.ModelAssignment.
+func StateModelAssignmentsToModel(m map[string]state.ModelAssignmentState) map[string]model.ModelAssignment {
 	if len(m) == 0 {
 		return nil
 	}

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -432,13 +432,9 @@ type syncRuntime struct {
 	agentIDs     []model.AgentID
 	backupRoot   string
 	state        *runtimeState
-<<<<<<< HEAD
 	managedPaths []string
-	changedFiles []string // accumulates candidate paths reported by component injectors
-=======
 	changedFiles []string // accumulates absolute paths of files that actually changed
 	warnings     []string
->>>>>>> 034c7a43 (feat(vscode): agrega asignaciones de modelo)
 }
 
 func newSyncRuntime(homeDir string, selection model.Selection) (*syncRuntime, error) {
@@ -993,7 +989,6 @@ func dedupPaths(paths []string) []string {
 	return out
 }
 
-<<<<<<< HEAD
 type syncFileSnapshot struct {
 	exists       bool
 	data         []byte

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -501,6 +501,7 @@ func (r *syncRuntime) stagePlan() pipeline.StagePlan {
 			id:           "sync:community-tool:codegraph-guidance",
 			homeDir:      r.homeDir,
 			runner:       codeGraphHomeRunner{homeDir: r.homeDir},
+			agentIDs:     r.agentIDs,
 			changedFiles: &r.changedFiles,
 		})
 		apply = append(apply, piCodeGraphSyncStep{id: "sync:community-tool:pi-codegraph", homeDir: r.homeDir, workspaceDir: r.workspaceDir, changedFiles: &r.changedFiles})
@@ -638,6 +639,7 @@ type codeGraphGuidanceSyncStep struct {
 	id           string
 	homeDir      string
 	runner       communitytool.Runner
+	agentIDs     []model.AgentID
 	changedFiles *[]string
 	before       map[string]syncFileSnapshot
 }
@@ -688,12 +690,12 @@ func (s *codeGraphGuidanceSyncStep) Run() (runErr error) {
 		}
 	}
 
-	res, configured, err := communitytool.RefreshCodeGraphGuidanceIfConfigured(s.homeDir, communitytool.DetectorFunc(cmdLookPath))
+	res, configured, err := communitytool.RefreshCodeGraphGuidanceIfConfiguredForAgents(s.homeDir, s.agentIDs, communitytool.DetectorFunc(cmdLookPath))
 	if err != nil {
 		return fmt.Errorf("sync CodeGraph guidance: %w", err)
 	}
 	if !configured {
-		res, err = communitytool.CleanLegacyCodeGraphGuidance(s.homeDir)
+		res, err = communitytool.CleanLegacyCodeGraphGuidanceForAgents(s.homeDir, s.agentIDs)
 		if err != nil {
 			return fmt.Errorf("sync legacy CodeGraph guidance cleanup: %w", err)
 		}

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -79,6 +79,8 @@ type SyncResult struct {
 	// processed during this sync. Paths appear once even when multiple
 	// components touch the same file. It is nil when no files changed.
 	ChangedFiles []string
+	// Warnings contains non-fatal sync warnings that should be surfaced to users.
+	Warnings []string
 }
 
 // ParseSyncFlags parses the CLI arguments for the sync subcommand.
@@ -430,8 +432,13 @@ type syncRuntime struct {
 	agentIDs     []model.AgentID
 	backupRoot   string
 	state        *runtimeState
+<<<<<<< HEAD
 	managedPaths []string
 	changedFiles []string // accumulates candidate paths reported by component injectors
+=======
+	changedFiles []string // accumulates absolute paths of files that actually changed
+	warnings     []string
+>>>>>>> 034c7a43 (feat(vscode): agrega asignaciones de modelo)
 }
 
 func newSyncRuntime(homeDir string, selection model.Selection) (*syncRuntime, error) {
@@ -485,6 +492,7 @@ func (r *syncRuntime) stagePlan() pipeline.StagePlan {
 			agents:       r.agentIDs,
 			selection:    r.selection,
 			changedFiles: &r.changedFiles,
+			warnings:     &r.warnings,
 		})
 	}
 
@@ -623,6 +631,7 @@ type componentSyncStep struct {
 	agents       []model.AgentID
 	selection    model.Selection
 	changedFiles *[]string // accumulates absolute paths of files that actually changed
+	warnings     *[]string
 }
 
 type codeGraphGuidanceSyncStep struct {
@@ -824,6 +833,7 @@ func (s componentSyncStep) Run() error {
 			targetDir := componentInjectionDir(s.homeDir, s.workspaceDir, adapter)
 			opts := sdd.InjectOptions{
 				OpenCodeModelAssignments:           s.selection.ModelAssignments,
+				VSCodeModelAssignments:             s.selection.VSCodeModelAssignments,
 				ClaudeModelAssignments:             s.selection.ClaudeModelAssignments,
 				ClaudePhaseAssignments:             s.selection.ClaudePhaseAssignments,
 				KiroModelAssignments:               s.selection.KiroModelAssignments,
@@ -841,6 +851,7 @@ func (s componentSyncStep) Run() error {
 				return fmt.Errorf("sync sdd for %q: %w", adapter.Agent(), err)
 			}
 			s.countChanged(boolToInt(res.Changed), res.Files...)
+			s.addWarnings(res.Warnings...)
 		}
 		return nil
 
@@ -954,6 +965,13 @@ func (s componentSyncStep) countChanged(n int, files ...string) {
 	}
 }
 
+func (s componentSyncStep) addWarnings(warnings ...string) {
+	if s.warnings == nil || len(warnings) == 0 {
+		return
+	}
+	*s.warnings = append(*s.warnings, warnings...)
+}
+
 // dedupPaths removes duplicate and empty paths while preserving first-seen order.
 func dedupPaths(paths []string) []string {
 	if len(paths) == 0 {
@@ -973,6 +991,7 @@ func dedupPaths(paths []string) []string {
 	return out
 }
 
+<<<<<<< HEAD
 type syncFileSnapshot struct {
 	exists       bool
 	data         []byte
@@ -1145,6 +1164,36 @@ func changedSyncFiles(candidates []string, before map[string]syncFileSnapshot) (
 	return changed, nil
 }
 
+func dedupStrings(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(values))
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		if strings.TrimSpace(value) == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	return out
+}
+
+func stateModelAssignmentsToModel(m map[string]state.ModelAssignmentState) map[string]model.ModelAssignment {
+	if len(m) == 0 {
+		return nil
+	}
+	out := make(map[string]model.ModelAssignment, len(m))
+	for k, v := range m {
+		out[k] = model.ModelAssignment{ProviderID: v.ProviderID, ModelID: v.ModelID, Effort: v.Effort}
+	}
+	return out
+}
+
 // boolToInt converts a boolean to 0 or 1.
 func boolToInt(b bool) int {
 	if b {
@@ -1239,6 +1288,7 @@ func RunSyncWithSelection(homeDir string, selection model.Selection) (SyncResult
 		return result, err
 	}
 	result.FilesChanged = len(result.ChangedFiles)
+	result.Warnings = dedupStrings(rt.warnings)
 
 	// True no-op: agents were discovered but all managed assets were already
 	// current — no file was written or updated. Per spec scenario:
@@ -1342,6 +1392,13 @@ func RunSync(args []string) (SyncResult, error) {
 		selection.CodexOrchestratorAssignment = codexOrchestratorFromState(persistedState.CodexOrchestratorAssignment)
 	}
 
+	if len(selection.VSCodeModelAssignments) == 0 && len(persistedState.VSCodeModelAssignments) > 0 {
+		m := make(map[string]model.ModelAssignment, len(persistedState.VSCodeModelAssignments))
+		for k, v := range persistedState.VSCodeModelAssignments {
+			m[k] = model.ModelAssignment{ProviderID: v.ProviderID, ModelID: v.ModelID, Effort: v.Effort}
+		}
+		selection.VSCodeModelAssignments = m
+	}
 	// Restore Codex effort and carril model assignments from state so that
 	// `gentle-ai sync` preserves the user's per-phase effort and per-carril
 	// model choices instead of falling back to canonical defaults every time.
@@ -1454,6 +1511,7 @@ func RenderSyncReport(result SyncResult) string {
 			fmt.Fprintf(&b, "Agents: %s\n", joinAgentIDs(result.Agents))
 			fmt.Fprintln(&b, "All managed assets are already up to date. No files changed.")
 		}
+		appendSyncWarnings(&b, result.Warnings)
 		return strings.TrimRight(b.String(), "\n")
 	}
 
@@ -1495,6 +1553,8 @@ func RenderSyncReport(result SyncResult) string {
 		}
 	}
 
+	appendSyncWarnings(&b, result.Warnings)
+
 	if !result.Verify.Ready {
 		fmt.Fprintln(&b, "")
 		fmt.Fprintln(&b, "Post-sync verification:")
@@ -1502,6 +1562,17 @@ func RenderSyncReport(result SyncResult) string {
 	}
 
 	return strings.TrimRight(b.String(), "\n")
+}
+
+func appendSyncWarnings(b *strings.Builder, warnings []string) {
+	if len(warnings) == 0 {
+		return
+	}
+	fmt.Fprintln(b, "")
+	fmt.Fprintln(b, "Warnings:")
+	for _, warning := range warnings {
+		fmt.Fprintf(b, "  - %s\n", warning)
+	}
 }
 
 // runPostSyncVerification verifies that managed files exist after sync.

--- a/internal/cli/sync_test.go
+++ b/internal/cli/sync_test.go
@@ -721,6 +721,7 @@ func TestCodeGraphGuidanceSyncStepRefreshesOldMarkerWhenConfigured(t *testing.T)
 			mustWriteFile(t, settingsPath, []byte(`{"mcp":{"codegraph":{"type":"local","command":["codegraph","serve","--mcp"],"enabled":true}}}`))
 			return nil
 		}),
+		agentIDs:     []model.AgentID{model.AgentOpenCode},
 		changedFiles: &changed,
 	}
 	if err := step.Run(); err != nil {
@@ -1044,6 +1045,7 @@ func TestCodeGraphGuidanceSyncStepRemovesLegacySkipBlockWhenConfigured(t *testin
 			mustWriteFile(t, settingsPath, []byte(`{"mcp":{"codegraph":{"type":"local","command":["codegraph","serve","--mcp"],"enabled":true}}}`))
 			return nil
 		}),
+		agentIDs:     []model.AgentID{model.AgentOpenCode},
 		changedFiles: &changed,
 	}
 	if err := step.Run(); err != nil {
@@ -1090,6 +1092,7 @@ func TestCodeGraphGuidanceSyncStepRepairsCodexConfigOnlyGuidance(t *testing.T) {
 	step := codeGraphGuidanceSyncStep{
 		id:           "sync:community-tool:codegraph-guidance",
 		homeDir:      home,
+		agentIDs:     []model.AgentID{model.AgentCodex, model.AgentOpenCode},
 		changedFiles: &changed,
 	}
 	if err := step.Run(); err != nil {
@@ -1130,6 +1133,7 @@ func TestCodeGraphGuidanceSyncStepCleansLegacyBlockWithoutCodeGraphCLI(t *testin
 	step := codeGraphGuidanceSyncStep{
 		id:           "sync:community-tool:codegraph-guidance",
 		homeDir:      home,
+		agentIDs:     []model.AgentID{model.AgentCodex, model.AgentOpenCode},
 		changedFiles: &changed,
 	}
 	if err := step.Run(); err != nil {

--- a/internal/cli/sync_test.go
+++ b/internal/cli/sync_test.go
@@ -2969,6 +2969,9 @@ func TestRunSyncLoadsPersistedModelAssignments(t *testing.T) {
 		ModelAssignments: map[string]state.ModelAssignmentState{
 			"sdd-init": {ProviderID: "anthropic", ModelID: "claude-sonnet-4"},
 		},
+		VSCodeModelAssignments: map[string]state.ModelAssignmentState{
+			"sdd-apply": {ProviderID: "github-copilot", ModelID: "gpt-4.1"},
+		},
 	})
 	if err != nil {
 		t.Fatalf("state.Write: %v", err)
@@ -3000,6 +3003,39 @@ func TestRunSyncLoadsPersistedModelAssignments(t *testing.T) {
 	ma := result.Selection.ModelAssignments["sdd-init"]
 	if ma.ProviderID != "anthropic" || ma.ModelID != "claude-sonnet-4" {
 		t.Errorf("ModelAssignments[sdd-init] = %+v, want anthropic/claude-sonnet-4", ma)
+	}
+	vs := result.Selection.VSCodeModelAssignments["sdd-apply"]
+	if vs.ProviderID != "github-copilot" || vs.ModelID != "gpt-4.1" {
+		t.Errorf("VSCodeModelAssignments[sdd-apply] = %+v, want github-copilot/gpt-4.1", vs)
+	}
+}
+
+func TestRunSyncWithSelectionPropagatesVSCodeModelWarnings(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	selection := model.Selection{
+		Agents:     []model.AgentID{model.AgentVSCodeCopilot},
+		Components: []model.ComponentID{model.ComponentSDD},
+		VSCodeModelAssignments: map[string]model.ModelAssignment{
+			"sdd-apply": {ProviderID: "github-copilot", ModelID: "gpt-4.1"},
+		},
+	}
+
+	result, err := RunSyncWithSelection(home, selection)
+	if err != nil {
+		t.Fatalf("RunSyncWithSelection() error = %v", err)
+	}
+	if !containsSubstring(result.Warnings, "models cache") {
+		t.Fatalf("Warnings = %v, want missing cache warning", result.Warnings)
+	}
+
+	content, err := os.ReadFile(filepath.Join(home, ".copilot", "agents", "sdd-apply.agent.md"))
+	if err != nil {
+		t.Fatalf("ReadFile(sdd-apply.agent.md): %v", err)
+	}
+	if strings.Contains(string(content), "model:") {
+		t.Fatalf("missing cache should omit model line; got:\n%s", content)
 	}
 }
 
@@ -3967,4 +4003,13 @@ func TestRunSync_RestoresCodexPhaseModelAssignments(t *testing.T) {
 	if strings.Contains(text, "| `sdd-strong` |") {
 		t.Fatalf("AGENTS.md rendered carril table instead of Custom per-phase table; got:\n%s", text)
 	}
+}
+
+func containsSubstring(values []string, want string) bool {
+	for _, value := range values {
+		if strings.Contains(value, want) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/cli/sync_test.go
+++ b/internal/cli/sync_test.go
@@ -3026,6 +3026,10 @@ func TestRunSyncWithSelectionPropagatesVSCodeModelWarnings(t *testing.T) {
 		},
 	}
 
+	// RunSyncWithSelection is called with a fresh temp home directory that lacks a
+	// models cache. Consequently, the VSCode model assignments cannot be validated
+	// against cached metadata. The sync operation should emit a models cache warning
+	// and omit the "model:" field from the generated agent files since validation failed.
 	result, err := RunSyncWithSelection(home, selection)
 	if err != nil {
 		t.Fatalf("RunSyncWithSelection() error = %v", err)

--- a/internal/components/communitytool/codegraph_guidance.go
+++ b/internal/components/communitytool/codegraph_guidance.go
@@ -241,7 +241,7 @@ func InjectCodeGraphGuidanceForAgents(homeDir string, agentIDs []model.AgentID) 
 			continue
 		}
 		adapter, ok := reg.Get(id)
-		if !ok || !isCodeGraphSupportedAgent(id) || !adapter.SupportsSystemPrompt() {
+		if !ok || !isCodeGraphCompatibleAgent(id) || !adapter.SupportsSystemPrompt() {
 			continue
 		}
 
@@ -277,7 +277,7 @@ func CodeGraphGuidancePathsForAgents(homeDir string, agentIDs []model.AgentID) [
 			continue
 		}
 		adapter, ok := reg.Get(id)
-		if !ok || !isCodeGraphSupportedAgent(id) || !adapter.SupportsSystemPrompt() {
+		if !ok || !isCodeGraphCompatibleAgent(id) || !adapter.SupportsSystemPrompt() {
 			continue
 		}
 		path := adapter.SystemPromptFile(homeDir)

--- a/internal/components/communitytool/codegraph_guidance.go
+++ b/internal/components/communitytool/codegraph_guidance.go
@@ -159,6 +159,135 @@ func CleanLegacyCodeGraphGuidance(homeDir string) (GuidanceInjectionResult, erro
 	return result, nil
 }
 
+func RefreshCodeGraphGuidanceIfConfiguredForAgents(homeDir string, agentIDs []model.AgentID, detector Detector) (GuidanceInjectionResult, bool, error) {
+	if !HasConfiguredCodeGraphForAgents(homeDir, agentIDs, detector) && !hasAvailableLegacyCodeGraphGuidanceForAgents(homeDir, agentIDs, detector) {
+		return GuidanceInjectionResult{}, false, nil
+	}
+
+	result, err := InjectCodeGraphGuidanceForAgents(homeDir, agentIDs)
+	return result, true, err
+}
+
+func hasAvailableLegacyCodeGraphGuidanceForAgents(homeDir string, agentIDs []model.AgentID, detector Detector) bool {
+	status := DetectStatus(model.CommunityToolCodeGraph, homeDir, detector)
+	return status.CLI == AvailabilityAvailable && HasLegacyCodeGraphGuidanceForAgents(homeDir, agentIDs)
+}
+
+func HasConfiguredCodeGraphForAgents(homeDir string, agentIDs []model.AgentID, detector Detector) bool {
+	status := DetectStatus(model.CommunityToolCodeGraph, homeDir, detector)
+	if status.CLI != AvailabilityAvailable {
+		return false
+	}
+	for _, agent := range status.Agents {
+		if slices.Contains(agentIDs, agent.Agent) && agent.Detected && agent.Configured {
+			return true
+		}
+	}
+	return hasDetectedCodeGraphToolWiring(homeDir)
+}
+
+func HasLegacyCodeGraphGuidanceForAgents(homeDir string, agentIDs []model.AgentID) bool {
+	for _, path := range CodeGraphGuidancePathsForAgents(homeDir, agentIDs) {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		if containsLegacyCodeGraphGuidance(string(data)) {
+			return true
+		}
+	}
+	return false
+}
+
+func CleanLegacyCodeGraphGuidanceForAgents(homeDir string, agentIDs []model.AgentID) (GuidanceInjectionResult, error) {
+	result := GuidanceInjectionResult{}
+	for _, path := range CodeGraphGuidancePathsForAgents(homeDir, agentIDs) {
+		existing, err := readTextFileOrEmpty(path)
+		if err != nil {
+			return result, err
+		}
+		cleaned := stripLegacyCodeGraphGuidance(existing)
+		if cleaned == existing {
+			continue
+		}
+
+		writeResult, err := filemerge.WriteFileAtomic(path, []byte(cleaned), 0o644)
+		if err != nil {
+			return result, err
+		}
+		result.Changed = result.Changed || writeResult.Changed
+		if writeResult.Changed {
+			result.Files = append(result.Files, path)
+		}
+	}
+	return result, nil
+}
+
+func InjectCodeGraphGuidanceForAgents(homeDir string, agentIDs []model.AgentID) (GuidanceInjectionResult, error) {
+	reg, err := agents.NewDefaultRegistry()
+	if err != nil {
+		return GuidanceInjectionResult{}, err
+	}
+
+	installed := agents.DiscoverInstalled(reg, homeDir)
+	installedMap := make(map[model.AgentID]struct{})
+	for _, inst := range installed {
+		installedMap[inst.ID] = struct{}{}
+	}
+
+	result := GuidanceInjectionResult{}
+	for _, id := range agentIDs {
+		if _, ok := installedMap[id]; !ok {
+			continue
+		}
+		adapter, ok := reg.Get(id)
+		if !ok || !isCodeGraphSupportedAgent(id) || !adapter.SupportsSystemPrompt() {
+			continue
+		}
+
+		file, changed, err := injectCodeGraphGuidanceForAgent(homeDir, adapter)
+		if err != nil {
+			return result, fmt.Errorf("inject CodeGraph guidance for %s: %w", id, err)
+		}
+		if file == "" {
+			continue
+		}
+		result.Changed = result.Changed || changed
+		result.Files = append(result.Files, file)
+	}
+
+	return result, nil
+}
+
+func CodeGraphGuidancePathsForAgents(homeDir string, agentIDs []model.AgentID) []string {
+	reg, err := agents.NewDefaultRegistry()
+	if err != nil {
+		return nil
+	}
+
+	installed := agents.DiscoverInstalled(reg, homeDir)
+	installedMap := make(map[model.AgentID]struct{})
+	for _, inst := range installed {
+		installedMap[inst.ID] = struct{}{}
+	}
+
+	paths := make([]string, 0, len(agentIDs))
+	for _, id := range agentIDs {
+		if _, ok := installedMap[id]; !ok {
+			continue
+		}
+		adapter, ok := reg.Get(id)
+		if !ok || !isCodeGraphSupportedAgent(id) || !adapter.SupportsSystemPrompt() {
+			continue
+		}
+		path := adapter.SystemPromptFile(homeDir)
+		if strings.TrimSpace(path) != "" {
+			paths = append(paths, path)
+		}
+	}
+	return paths
+}
+
 // InjectCodeGraphGuidance writes the shared CodeGraph lifecycle guidance to all
 // detected supported agents. Detection is intentionally based on existing agent
 // config directories so standalone Community Tools setup does not create agent

--- a/internal/components/filemerge/replace_default.go
+++ b/internal/components/filemerge/replace_default.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package filemerge
+
+import "os"
+
+func replaceFileAtomic(sourcePath, destinationPath string) error {
+	return os.Rename(sourcePath, destinationPath)
+}

--- a/internal/components/filemerge/replace_windows.go
+++ b/internal/components/filemerge/replace_windows.go
@@ -1,0 +1,19 @@
+//go:build windows
+
+package filemerge
+
+import "golang.org/x/sys/windows"
+
+const windowsAtomicReplaceFlags = windows.MOVEFILE_REPLACE_EXISTING | windows.MOVEFILE_WRITE_THROUGH
+
+func replaceFileAtomic(sourcePath, destinationPath string) error {
+	source, err := windows.UTF16PtrFromString(sourcePath)
+	if err != nil {
+		return err
+	}
+	destination, err := windows.UTF16PtrFromString(destinationPath)
+	if err != nil {
+		return err
+	}
+	return windows.MoveFileEx(source, destination, windowsAtomicReplaceFlags)
+}

--- a/internal/components/filemerge/writer.go
+++ b/internal/components/filemerge/writer.go
@@ -93,7 +93,7 @@ func WriteFileAtomic(path string, content []byte, perm fs.FileMode) (WriteResult
 		return WriteResult{}, fmt.Errorf("close temp file for %q: %w", path, err)
 	}
 
-	if err := os.Rename(tmpPath, path); err != nil {
+	if err := replaceFileAtomic(tmpPath, path); err != nil {
 		return WriteResult{}, fmt.Errorf("replace %q atomically: %w", path, err)
 	}
 

--- a/internal/components/filemerge/writer_test.go
+++ b/internal/components/filemerge/writer_test.go
@@ -86,6 +86,62 @@ func TestWriteFileAtomicCreatesAndIsIdempotent(t *testing.T) {
 	}
 }
 
+func TestWriteFileAtomicUpdatesExistingFileWithDifferentContent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sdd-apply.agent.md")
+	oldContent := []byte("old agent content\n")
+	newContent := []byte("new agent content\n")
+
+	if err := os.WriteFile(path, oldContent, 0o644); err != nil {
+		t.Fatalf("WriteFile(old) error = %v", err)
+	}
+
+	result, err := WriteFileAtomic(path, newContent, 0o644)
+	if err != nil {
+		t.Fatalf("WriteFileAtomic() error = %v, want successful replacement", err)
+	}
+	if !result.Changed || result.Created {
+		t.Fatalf("WriteFileAtomic() result = %+v, want Changed=true Created=false", result)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if string(got) != string(newContent) {
+		t.Fatalf("file content = %q, want %q", string(got), string(newContent))
+	}
+}
+
+func TestReplaceFileAtomicUpdatesExistingDestination(t *testing.T) {
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, ".gentle-ai-source.tmp")
+	destinationPath := filepath.Join(dir, "sdd-explore.agent.md")
+	replacementContent := []byte("replacement agent content\n")
+
+	if err := os.WriteFile(sourcePath, replacementContent, 0o644); err != nil {
+		t.Fatalf("WriteFile(source) error = %v", err)
+	}
+	if err := os.WriteFile(destinationPath, []byte("existing agent content\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(destination) error = %v", err)
+	}
+
+	if err := replaceFileAtomic(sourcePath, destinationPath); err != nil {
+		t.Fatalf("replaceFileAtomic() error = %v, want successful replacement", err)
+	}
+
+	got, err := os.ReadFile(destinationPath)
+	if err != nil {
+		t.Fatalf("ReadFile(destination) error = %v", err)
+	}
+	if string(got) != string(replacementContent) {
+		t.Fatalf("destination content = %q, want %q", string(got), string(replacementContent))
+	}
+	if _, err := os.Stat(sourcePath); !os.IsNotExist(err) {
+		t.Fatalf("source stat error = %v, want source moved away", err)
+	}
+}
+
 func TestWriteFileAtomicRejectsExistingSymlink(t *testing.T) {
 	dir := t.TempDir()
 	target := filepath.Join(dir, "target.txt")

--- a/internal/components/sdd/boundedreview.go
+++ b/internal/components/sdd/boundedreview.go
@@ -170,9 +170,10 @@ Return {"findings":[],"evidence":["what was inspected"]} when clean.`, nativeRev
 }
 
 func replaceAgentBody(content, body string) string {
-	frontmatterEnd := strings.Index(content, "\n---\n")
+	normalizedContent := strings.ReplaceAll(content, "\r\n", "\n")
+	frontmatterEnd := strings.Index(normalizedContent, "\n---\n")
 	if frontmatterEnd < 0 {
 		return body
 	}
-	return strings.TrimRight(content[:frontmatterEnd+5], "\n") + "\n\n" + body + "\n"
+	return strings.TrimRight(normalizedContent[:frontmatterEnd+5], "\n") + "\n\n" + body + "\n"
 }

--- a/internal/components/sdd/inject.go
+++ b/internal/components/sdd/inject.go
@@ -1021,66 +1021,31 @@ func migratePreservedOpenCodeOrchestratorPrompt(prompt string) string {
 }
 
 func removeLegacyOpenCodePlainChatPreflightLines(prompt string) string {
-	legacyFragments := []string{
-		"Ask the user directly with a compact, numbered preflight prompt.",
-		"Keep option codes",
-		"Do NOT ask the user to type raw keys",
-		"Use this shape for English users",
-		"If the user's current language is Spanish, use this localized shape:",
-		"Do NOT mix languages inside one preflight prompt",
-		"Spanish localized shape below as the neutral fallback",
-		"translate user-facing prose to the user's current language while preserving option codes",
-		"Before continuing with SDD, choose one option per group.",
-		"Reply with \"use recommended\" or with codes like:",
-		"A. Pace",
-		"A1 Interactive",
-		"A2 Automatic",
-		"B. Artifacts",
-		"B1 OpenSpec",
-		"B2 Engram",
-		"B3 Both",
-		"C. PRs",
-		"C1 Ask me",
-		"C2 Single PR",
-		"C3 Chained",
-		"C4 Auto",
-		"D. Review",
-		"D1 400 lines",
-		"D2 800 lines",
-		"D3 Other",
-		"After asking this, STOP and wait for the user's answer.",
-		"Antes de continuar con SDD, elija una opción por grupo.",
-		"Responda con \"usar recomendado\" o con códigos como:",
-		"A. Ritmo",
-		"A1 Interactivo",
-		"A2 Automático",
-		"B. Artefactos",
-		"B1 OpenSpec",
-		"B2 Engram",
-		"B3 Ambos",
-		"C1 Preguntarme",
-		"C2 Un solo PR",
-		"C3 Encadenados",
-		"D. Revisión",
-		"D1 400 líneas",
-		"D2 800 líneas",
-		"D3 Otro",
-		"Map answers to canonical values: A1/Interactive",
-	}
-
 	lines := strings.Split(prompt, "\n")
 	kept := make([]string, 0, len(lines))
+	inBlock := false
+
 	for _, line := range lines {
-		stale := false
-		for _, fragment := range legacyFragments {
-			if strings.Contains(line, fragment) {
-				stale = true
-				break
+		trimmed := strings.TrimSpace(line)
+		if !inBlock {
+			if strings.Contains(trimmed, "Before continuing with SDD, choose one option per group.") ||
+				strings.Contains(trimmed, "Antes de continuar con SDD, elija una opción por grupo.") ||
+				strings.Contains(trimmed, "Ask the user directly with a compact, numbered preflight prompt.") {
+				inBlock = true
+				continue
 			}
 		}
-		if !stale {
-			kept = append(kept, line)
+
+		if inBlock {
+			if strings.Contains(trimmed, "After asking this, STOP and wait for the user's answer.") ||
+				strings.Contains(trimmed, "Map answers to canonical values: A1/Interactive") ||
+				strings.Contains(trimmed, "Map answers to canonical values") {
+				inBlock = false
+			}
+			continue
 		}
+
+		kept = append(kept, line)
 	}
 	return strings.Join(kept, "\n")
 }

--- a/internal/components/sdd/inject.go
+++ b/internal/components/sdd/inject.go
@@ -734,10 +734,10 @@ func Inject(homeDir string, adapter agents.Adapter, sddMode model.SDDModeID, opt
 			}
 		}
 
-		// Post-check: verify critical agent files exist (either .md or .yaml)
+		// Post-check: verify critical agent files exist (.md, .agent.md, or .yaml).
 		for _, phase := range []string{"sdd-apply", "sdd-verify"} {
 			found := false
-			for _, ext := range []string{".md", ".yaml"} {
+			for _, ext := range []string{".md", ".agent.md", ".yaml"} {
 				checkPath := filepath.Join(agentsDir, phase+ext)
 				if info, err := os.Stat(checkPath); err == nil && info.Size() >= 10 {
 					found = true

--- a/internal/components/sdd/inject.go
+++ b/internal/components/sdd/inject.go
@@ -1759,8 +1759,8 @@ func migrateLegacyOpenCodeSDDOrchestrator(baseJSON []byte) ([]byte, error) {
 		return baseJSON, nil
 	}
 
-	root := map[string]any{}
-	if err := json.Unmarshal(baseJSON, &root); err != nil {
+	root, err := filemerge.UnmarshalJSONObject(baseJSON)
+	if err != nil {
 		return baseJSON, nil
 	}
 
@@ -1852,8 +1852,8 @@ func migrateLegacyOpenCodeAgentsKey(baseJSON []byte) ([]byte, error) {
 		return baseJSON, nil
 	}
 
-	root := map[string]any{}
-	if err := json.Unmarshal(baseJSON, &root); err != nil {
+	root, err := filemerge.UnmarshalJSONObject(baseJSON)
+	if err != nil {
 		// Preserve prior behavior for non-JSON/non-parseable inputs.
 		return baseJSON, nil
 	}
@@ -1911,8 +1911,8 @@ func migrateLegacyOpenCodeCommandPrompt(baseJSON []byte) ([]byte, error) {
 		return baseJSON, nil
 	}
 
-	root := map[string]any{}
-	if err := json.Unmarshal(baseJSON, &root); err != nil {
+	root, err := filemerge.UnmarshalJSONObject(baseJSON)
+	if err != nil {
 		// Preserve prior behavior for non-JSON/non-parseable inputs.
 		return baseJSON, nil
 	}

--- a/internal/components/sdd/inject.go
+++ b/internal/components/sdd/inject.go
@@ -21,12 +21,16 @@ import (
 const legacyMandatoryWording = "TOTALMENTE " + "obligatorio"
 
 type InjectionResult struct {
-	Changed bool
-	Files   []string
+	Changed  bool
+	Files    []string
+	Warnings []string
 }
 
 type InjectOptions struct {
 	OpenCodeModelAssignments map[string]model.ModelAssignment
+	VSCodeModelAssignments  map[string]model.ModelAssignment
+	VSCodeModelCachePath    string
+	VSCodeModelVariantsPath string
 	// ClaudeModelAssignments is the legacy model-only Claude assignment map.
 	// Prefer ClaudePhaseAssignments for new callers that need per-phase effort.
 	ClaudeModelAssignments      map[string]model.ClaudeModelAlias
@@ -241,8 +245,12 @@ func Inject(homeDir string, adapter agents.Adapter, sddMode model.SDDModeID, opt
 	if len(options) > 0 {
 		opts = options[0]
 	}
+	if adapter.Agent() == model.AgentVSCodeCopilot {
+		opts = withDefaultVSCodeModelPaths(opts, homeDir)
+	}
 
 	files := make([]string, 0)
+	warnings := make([]string, 0)
 	changed := false
 
 	// 1. Inject SDD orchestrator into the global system prompt for agents that
@@ -723,6 +731,11 @@ func Inject(homeDir string, adapter agents.Adapter, sddMode model.SDDModeID, opt
 				contentStr = injectCodeGraphToolGrantIntoPrompt(contentStr, adapter.Agent(), opts.CodeGraphGuidanceMarkdown)
 				contentStr = injectCodeGraphGuidanceIntoPrompt(contentStr, opts.CodeGraphGuidanceMarkdown)
 			}
+			if adapter.Agent() == model.AgentVSCodeCopilot {
+				resolved, modelWarnings := renderVSCodeAgentModelAssignment(contentStr, entry.Name(), opts)
+				contentStr = resolved
+				warnings = append(warnings, modelWarnings...)
+			}
 			outPath := filepath.Join(agentsDir, entry.Name())
 			writeResult, err := filemerge.WriteFileAtomic(outPath, []byte(contentStr), 0o644)
 			if err != nil {
@@ -842,7 +855,7 @@ func Inject(homeDir string, adapter agents.Adapter, sddMode model.SDDModeID, opt
 		}
 	}
 
-	return InjectionResult{Changed: changed, Files: files}, nil
+	return InjectionResult{Changed: changed, Files: files, Warnings: dedupWarnings(warnings)}, nil
 }
 
 func validateOpenClawWorkspacePath(workspaceDir string, adapter agents.Adapter) error {

--- a/internal/components/sdd/inject.go
+++ b/internal/components/sdd/inject.go
@@ -1022,6 +1022,28 @@ func migratePreservedOpenCodeOrchestratorPrompt(prompt string) string {
 
 func removeLegacyOpenCodePlainChatPreflightLines(prompt string) string {
 	lines := strings.Split(prompt, "\n")
+	start, end := -1, -1
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if start == -1 &&
+			(strings.Contains(trimmed, "Before continuing with SDD, choose one option per group.") ||
+				strings.Contains(trimmed, "Antes de continuar con SDD, elija una opción por grupo.") ||
+				strings.Contains(trimmed, "Ask the user directly with a compact, numbered preflight prompt.")) {
+			start = i
+			continue
+		}
+		if start != -1 &&
+			(strings.Contains(trimmed, "After asking this, STOP and wait for the user's answer.") ||
+				strings.Contains(trimmed, "Map answers to canonical values: A1/Interactive") ||
+				strings.Contains(trimmed, "Map answers to canonical values")) {
+			end = i
+			break
+		}
+	}
+	if start == -1 || end == -1 || end < start {
+		return prompt
+	}
+
 	kept := make([]string, 0, len(lines))
 	inBlock := false
 

--- a/internal/components/sdd/inject.go
+++ b/internal/components/sdd/inject.go
@@ -2001,7 +2001,7 @@ func injectFileAppend(homeDir string, adapter agents.Adapter, opts InjectOptions
 		existing = steeringFrontmatter
 	}
 
-	content := renderSDDOrchestratorAsset(adapter.Agent())
+	content := sddOrchestratorContent(adapter.Agent())
 
 	// Codex-only: substitute {{CODEX_PHASE_EFFORTS}} with a rendered per-phase
 	// effort table. Only fires when the adapter implements codexModelResolver.
@@ -2044,7 +2044,7 @@ func injectFileAppend(homeDir string, adapter agents.Adapter, opts InjectOptions
 }
 
 func sddOrchestratorContent(agent model.AgentID) string {
-	content := assets.MustRead(sddOrchestratorAsset(agent))
+	content := renderSDDOrchestratorAsset(agent)
 	if agent != model.AgentVSCodeCopilot {
 		return content
 	}

--- a/internal/components/sdd/inject.go
+++ b/internal/components/sdd/inject.go
@@ -761,6 +761,14 @@ func Inject(homeDir string, adapter agents.Adapter, sddMode model.SDDModeID, opt
 				return InjectionResult{}, fmt.Errorf("post-check: sub-agent %q not written correctly (missing or truncated)", phase)
 			}
 		}
+		if adapter.Agent() == model.AgentVSCodeCopilot {
+			visibilityResult, err := hideManagedClaudeInternalAgentsForVSCode(homeDir)
+			if err != nil {
+				return InjectionResult{}, err
+			}
+			changed = changed || visibilityResult.Changed
+			files = append(files, visibilityResult.Files...)
+		}
 	}
 
 	// 4. Install skill-registry startup automation for agents with runtime hooks.
@@ -2012,7 +2020,6 @@ func injectFileAppend(homeDir string, adapter agents.Adapter, opts InjectOptions
 		existing = steeringFrontmatter
 	}
 
-	// Use agent-specific SDD orchestrator content when available; fall back to generic.
 	content := renderSDDOrchestratorAsset(adapter.Agent())
 
 	// Codex-only: substitute {{CODEX_PHASE_EFFORTS}} with a rendered per-phase
@@ -2054,6 +2061,18 @@ func injectFileAppend(homeDir string, adapter agents.Adapter, opts InjectOptions
 
 	return InjectionResult{Changed: writeResult.Changed, Files: []string{promptPath}}, nil
 }
+
+func sddOrchestratorContent(agent model.AgentID) string {
+	content := assets.MustRead(sddOrchestratorAsset(agent))
+	if agent != model.AgentVSCodeCopilot {
+		return content
+	}
+
+	return strings.TrimRight(content, "\n") + "\n\n" + vscodeCopilotSupportLayers + "\n"
+}
+
+const vscodeCopilotSupportLayers = "### VS Code Copilot Support Layers\n\n" +
+	"Gentle AI installs three VS Code support layers: global instructions/rules at `Code/User/prompts/gentle-ai.instructions.md`, native custom agents in `~/.copilot/agents`, and SDD skills plus shared conventions in `~/.copilot/skills`."
 
 func hasLegacyBareOrchestrator(content string) bool {
 	markedIdx := strings.Index(content, "<!-- gentle-ai:sdd-orchestrator -->")

--- a/internal/components/sdd/inject.go
+++ b/internal/components/sdd/inject.go
@@ -1022,54 +1022,48 @@ func migratePreservedOpenCodeOrchestratorPrompt(prompt string) string {
 
 func removeLegacyOpenCodePlainChatPreflightLines(prompt string) string {
 	lines := strings.Split(prompt, "\n")
-	start, end := -1, -1
+	type blockRange struct{ start, end int }
+	var ranges []blockRange
+
+	start := -1
 	for i, line := range lines {
 		trimmed := strings.TrimSpace(line)
-		if start == -1 &&
-			(strings.Contains(trimmed, "Before continuing with SDD, choose one option per group.") ||
-				strings.Contains(trimmed, "Antes de continuar con SDD, elija una opción por grupo.") ||
-				strings.Contains(trimmed, "Ask the user directly with a compact, numbered preflight prompt.")) {
+		if start == -1 && isLegacyPreflightStart(trimmed) {
 			start = i
 			continue
 		}
-		if start != -1 &&
-			(strings.Contains(trimmed, "After asking this, STOP and wait for the user's answer.") ||
-				strings.Contains(trimmed, "Map answers to canonical values: A1/Interactive") ||
-				strings.Contains(trimmed, "Map answers to canonical values")) {
-			end = i
-			break
+		if start != -1 && isLegacyPreflightEnd(trimmed) {
+			ranges = append(ranges, blockRange{start, i})
+			start = -1
 		}
 	}
-	if start == -1 || end == -1 || end < start {
+	if len(ranges) == 0 {
 		return prompt
 	}
 
 	kept := make([]string, 0, len(lines))
-	inBlock := false
-
-	for _, line := range lines {
-		trimmed := strings.TrimSpace(line)
-		if !inBlock {
-			if strings.Contains(trimmed, "Before continuing with SDD, choose one option per group.") ||
-				strings.Contains(trimmed, "Antes de continuar con SDD, elija una opción por grupo.") ||
-				strings.Contains(trimmed, "Ask the user directly with a compact, numbered preflight prompt.") {
-				inBlock = true
-				continue
-			}
-		}
-
-		if inBlock {
-			if strings.Contains(trimmed, "After asking this, STOP and wait for the user's answer.") ||
-				strings.Contains(trimmed, "Map answers to canonical values: A1/Interactive") ||
-				strings.Contains(trimmed, "Map answers to canonical values") {
-				inBlock = false
-			}
+	ri := 0
+	for i := 0; i < len(lines); i++ {
+		if ri < len(ranges) && i == ranges[ri].start {
+			i = ranges[ri].end
+			ri++
 			continue
 		}
-
-		kept = append(kept, line)
+		kept = append(kept, lines[i])
 	}
 	return strings.Join(kept, "\n")
+}
+
+func isLegacyPreflightStart(trimmed string) bool {
+	return strings.Contains(trimmed, "Before continuing with SDD, choose one option per group.") ||
+		strings.Contains(trimmed, "Antes de continuar con SDD, elija una opción por grupo.") ||
+		strings.Contains(trimmed, "Ask the user directly with a compact, numbered preflight prompt.")
+}
+
+func isLegacyPreflightEnd(trimmed string) bool {
+	return strings.Contains(trimmed, "After asking this, STOP and wait for the user's answer.") ||
+		strings.Contains(trimmed, "Map answers to canonical values: A1/Interactive") ||
+		strings.Contains(trimmed, "Map answers to canonical values")
 }
 
 func ensurePreservedOpenCodeDelegationHardGates(prompt string) string {

--- a/internal/components/sdd/inject.go
+++ b/internal/components/sdd/inject.go
@@ -348,7 +348,13 @@ func Inject(homeDir string, adapter agents.Adapter, sddMode model.SDDModeID, opt
 				return InjectionResult{}, readErr
 			}
 			updated := filemerge.InjectMarkdownSection(existing, sectionTriggerRules, rendered)
-			writeResult, writeErr := filemerge.WriteFileAtomic(promptPath, []byte(updated), 0o644)
+			var writeResult filemerge.WriteResult
+			var writeErr error
+			if adapter.Agent() == model.AgentVSCodeCopilot {
+				writeResult, writeErr = writeFileWithBackup(promptPath, []byte(updated), 0o644)
+			} else {
+				writeResult, writeErr = filemerge.WriteFileAtomic(promptPath, []byte(updated), 0o644)
+			}
 			if writeErr != nil {
 				return InjectionResult{}, writeErr
 			}
@@ -390,7 +396,13 @@ func Inject(homeDir string, adapter agents.Adapter, sddMode model.SDDModeID, opt
 				return InjectionResult{}, readErr
 			}
 			updated := filemerge.InjectMarkdownSection(existing, "strict-tdd-mode", strictTDDContent)
-			writeResult, writeErr := filemerge.WriteFileAtomic(promptPath, []byte(updated), 0o644)
+			var writeResult filemerge.WriteResult
+			var writeErr error
+			if adapter.Agent() == model.AgentVSCodeCopilot {
+				writeResult, writeErr = writeFileWithBackup(promptPath, []byte(updated), 0o644)
+			} else {
+				writeResult, writeErr = filemerge.WriteFileAtomic(promptPath, []byte(updated), 0o644)
+			}
 			if writeErr != nil {
 				return InjectionResult{}, writeErr
 			}
@@ -737,7 +749,13 @@ func Inject(homeDir string, adapter agents.Adapter, sddMode model.SDDModeID, opt
 				warnings = append(warnings, modelWarnings...)
 			}
 			outPath := filepath.Join(agentsDir, entry.Name())
-			writeResult, err := filemerge.WriteFileAtomic(outPath, []byte(contentStr), 0o644)
+			var writeResult filemerge.WriteResult
+			var err error
+			if adapter.Agent() == model.AgentVSCodeCopilot {
+				writeResult, err = writeFileWithBackup(outPath, []byte(contentStr), 0o644)
+			} else {
+				writeResult, err = filemerge.WriteFileAtomic(outPath, []byte(contentStr), 0o644)
+			}
 			if err != nil {
 				return InjectionResult{}, fmt.Errorf("write agent %s: %w", entry.Name(), err)
 			}
@@ -2035,7 +2053,12 @@ func injectFileAppend(homeDir string, adapter agents.Adapter, opts InjectOptions
 
 	updated := filemerge.InjectMarkdownSection(existing, "sdd-orchestrator", content)
 
-	writeResult, err := filemerge.WriteFileAtomic(promptPath, []byte(updated), 0o644)
+	var writeResult filemerge.WriteResult
+	if adapter.Agent() == model.AgentVSCodeCopilot {
+		writeResult, err = writeFileWithBackup(promptPath, []byte(updated), 0o644)
+	} else {
+		writeResult, err = filemerge.WriteFileAtomic(promptPath, []byte(updated), 0o644)
+	}
 	if err != nil {
 		return InjectionResult{}, err
 	}
@@ -2597,4 +2620,20 @@ func readFileOrEmpty(path string) (string, error) {
 		return "", fmt.Errorf("read file %q: %w", path, err)
 	}
 	return string(data), nil
+}
+
+func writeFileWithBackup(path string, content []byte, perm os.FileMode) (filemerge.WriteResult, error) {
+	if _, err := os.Stat(path); err == nil {
+		backupPath := path + ".backup"
+		if _, err := os.Stat(backupPath); os.IsNotExist(err) {
+			existingContent, err := os.ReadFile(path)
+			if err != nil {
+				return filemerge.WriteResult{}, fmt.Errorf("read file for backup %s: %w", path, err)
+			}
+			if err := os.WriteFile(backupPath, existingContent, 0o644); err != nil {
+				return filemerge.WriteResult{}, fmt.Errorf("create backup file %s: %w", backupPath, err)
+			}
+		}
+	}
+	return filemerge.WriteFileAtomic(path, content, perm)
 }

--- a/internal/components/sdd/inject.go
+++ b/internal/components/sdd/inject.go
@@ -2625,15 +2625,21 @@ func readFileOrEmpty(path string) (string, error) {
 func writeFileWithBackup(path string, content []byte, perm os.FileMode) (filemerge.WriteResult, error) {
 	if _, err := os.Stat(path); err == nil {
 		backupPath := path + ".backup"
-		if _, err := os.Stat(backupPath); os.IsNotExist(err) {
+		if _, statErr := os.Stat(backupPath); statErr == nil {
+			// backup already exists, do nothing
+		} else if os.IsNotExist(statErr) {
 			existingContent, err := os.ReadFile(path)
 			if err != nil {
 				return filemerge.WriteResult{}, fmt.Errorf("read file for backup %s: %w", path, err)
 			}
-			if err := os.WriteFile(backupPath, existingContent, 0o644); err != nil {
+			if _, err := filemerge.WriteFileAtomic(backupPath, existingContent, 0o644); err != nil {
 				return filemerge.WriteResult{}, fmt.Errorf("create backup file %s: %w", backupPath, err)
 			}
+		} else {
+			return filemerge.WriteResult{}, fmt.Errorf("stat backup file %s: %w", backupPath, statErr)
 		}
+	} else if !os.IsNotExist(err) {
+		return filemerge.WriteResult{}, fmt.Errorf("stat target file %s: %w", path, err)
 	}
 	return filemerge.WriteFileAtomic(path, content, perm)
 }

--- a/internal/components/sdd/inject_test.go
+++ b/internal/components/sdd/inject_test.go
@@ -5059,6 +5059,124 @@ func TestInjectVSCodeWritesNativeAgentFiles(t *testing.T) {
 	}
 }
 
+func TestInjectVSCodeRendersResolvedModelAssignment(t *testing.T) {
+	home := t.TempDir()
+	isolateDesktopConfig(t, home)
+
+	adapter, err := agents.NewAdapter(model.AgentVSCodeCopilot)
+	if err != nil {
+		t.Fatalf("NewAdapter(vscode-copilot) error = %v", err)
+	}
+	cachePath := writeVSCodeModelCache(t, "gpt-4.1", "GPT-4.1", true)
+	opts := InjectOptions{
+		VSCodeModelAssignments: map[string]model.ModelAssignment{
+			"sdd-apply": {ProviderID: "github-copilot", ModelID: "gpt-4.1"},
+		},
+		VSCodeModelCachePath: cachePath,
+	}
+
+	if _, err := Inject(home, adapter, "", opts); err != nil {
+		t.Fatalf("Inject(vscode) error = %v", err)
+	}
+
+	applyPath := filepath.Join(home, ".copilot", "agents", "sdd-apply.agent.md")
+	applyContent, err := os.ReadFile(applyPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%s): %v", applyPath, err)
+	}
+	if !strings.Contains(string(applyContent), `model: "GPT-4.1"`) {
+		t.Fatalf("sdd-apply.agent.md missing resolved model line; got:\n%s", applyContent)
+	}
+
+	verifyPath := filepath.Join(home, ".copilot", "agents", "sdd-verify.agent.md")
+	verifyContent, err := os.ReadFile(verifyPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%s): %v", verifyPath, err)
+	}
+	if strings.Contains(string(verifyContent), "model:") {
+		t.Fatalf("unassigned VS Code agent should inherit parent model; got:\n%s", verifyContent)
+	}
+
+	second, err := Inject(home, adapter, "", opts)
+	if err != nil {
+		t.Fatalf("second Inject(vscode) error = %v", err)
+	}
+	if second.Changed {
+		t.Fatal("second Inject(vscode) changed = true; expected idempotent model rendering")
+	}
+}
+
+func TestInjectVSCodeDefaultModelCacheUsesInjectedHome(t *testing.T) {
+	home := t.TempDir()
+	processHome := t.TempDir()
+	isolateDesktopConfig(t, home)
+	t.Setenv("HOME", processHome)
+	t.Setenv("USERPROFILE", processHome)
+
+	adapter, err := agents.NewAdapter(model.AgentVSCodeCopilot)
+	if err != nil {
+		t.Fatalf("NewAdapter(vscode-copilot) error = %v", err)
+	}
+	cacheDir := filepath.Join(home, ".cache", "opencode")
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", cacheDir, err)
+	}
+	cachePath := filepath.Join(cacheDir, "models.json")
+	cache := `{"github-copilot":{"id":"github-copilot","name":"GitHub Copilot","models":{"gpt-4.1":{"id":"gpt-4.1","name":"GPT-4.1","tool_call":true}}}}`
+	if err := os.WriteFile(cachePath, []byte(cache), 0o644); err != nil {
+		t.Fatalf("WriteFile(%s): %v", cachePath, err)
+	}
+
+	opts := InjectOptions{VSCodeModelAssignments: map[string]model.ModelAssignment{
+		"sdd-apply": {ProviderID: "github-copilot", ModelID: "gpt-4.1"},
+	}}
+	if _, err := Inject(home, adapter, "", opts); err != nil {
+		t.Fatalf("Inject(vscode) error = %v", err)
+	}
+
+	applyPath := filepath.Join(home, ".copilot", "agents", "sdd-apply.agent.md")
+	applyContent, err := os.ReadFile(applyPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%s): %v", applyPath, err)
+	}
+	if !strings.Contains(string(applyContent), `model: "GPT-4.1"`) {
+		t.Fatalf("default cache path should use injected home, not process home; got:\n%s", applyContent)
+	}
+}
+
+func TestInjectVSCodeMissingModelCacheWarnsWithoutModelLine(t *testing.T) {
+	home := t.TempDir()
+	isolateDesktopConfig(t, home)
+
+	adapter, err := agents.NewAdapter(model.AgentVSCodeCopilot)
+	if err != nil {
+		t.Fatalf("NewAdapter(vscode-copilot) error = %v", err)
+	}
+	opts := InjectOptions{
+		VSCodeModelAssignments: map[string]model.ModelAssignment{
+			"sdd-apply": {ProviderID: "github-copilot", ModelID: "gpt-4.1"},
+		},
+		VSCodeModelCachePath: filepath.Join(t.TempDir(), "missing-models.json"),
+	}
+
+	result, err := Inject(home, adapter, "", opts)
+	if err != nil {
+		t.Fatalf("Inject(vscode) error = %v", err)
+	}
+	if !containsWarning(result.Warnings, "models cache") {
+		t.Fatalf("Warnings = %v, want missing cache warning", result.Warnings)
+	}
+
+	applyPath := filepath.Join(home, ".copilot", "agents", "sdd-apply.agent.md")
+	content, err := os.ReadFile(applyPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%s): %v", applyPath, err)
+	}
+	if strings.Contains(string(content), "model:") {
+		t.Fatalf("unresolved VS Code assignment should omit model line; got:\n%s", content)
+	}
+}
+
 func TestInjectNativeSubAgentExtensionsRemainAdapterSpecific(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/internal/components/sdd/inject_test.go
+++ b/internal/components/sdd/inject_test.go
@@ -1741,6 +1741,7 @@ func TestInjectQwenCodeWritesSDDOrchestratorAndSkills(t *testing.T) {
 
 func TestInjectVSCodeWritesSDDOrchestratorAndSkills(t *testing.T) {
 	home := t.TempDir()
+	t.Setenv("APPDATA", filepath.Join(home, "AppData", "Roaming"))
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
 
 	vscodeAdapter, err := agents.NewAdapter("vscode-copilot")
@@ -1759,14 +1760,40 @@ func TestInjectVSCodeWritesSDDOrchestratorAndSkills(t *testing.T) {
 
 	// Verify SDD orchestrator was injected into the VS Code instructions file.
 	promptPath := vscodeAdapter.SystemPromptFile(home)
+	if !strings.HasSuffix(promptPath, filepath.Join("Code", "User", "prompts", "gentle-ai.instructions.md")) {
+		t.Fatalf("SystemPromptFile() = %q, want VS Code User prompts gentle-ai.instructions.md path", promptPath)
+	}
+
 	content, readErr := os.ReadFile(promptPath)
 	if readErr != nil {
 		t.Fatalf("ReadFile(%q) error = %v", promptPath, readErr)
 	}
 
 	text := string(content)
-	if !strings.Contains(text, "Spec-Driven Development") {
-		t.Fatal("VS Code system prompt missing SDD orchestrator content")
+	expectedInstructionMarkers := []string{
+		"Code/User/prompts/gentle-ai.instructions.md",
+		"Spec-Driven Development",
+		"Artifact Store Policy",
+		"mem_search(query:",
+		"## Skills to load before work",
+	}
+	for _, marker := range expectedInstructionMarkers {
+		if !strings.Contains(text, marker) {
+			t.Fatalf("VS Code instructions file missing %q", marker)
+		}
+	}
+
+	// Should also write native VS Code Copilot agent files under ~/.copilot/agents/.
+	agentFiles := []string{
+		"sdd-orchestrator.agent.md",
+		"sdd-apply.agent.md",
+		"sdd-verify.agent.md",
+	}
+	for _, fileName := range agentFiles {
+		agentPath := filepath.Join(home, ".copilot", "agents", fileName)
+		if _, err := os.Stat(agentPath); err != nil {
+			t.Fatalf("expected VS Code Copilot agent file %q: %v", agentPath, err)
+		}
 	}
 
 	// Should also write SDD skill files under ~/.copilot/skills/.
@@ -1775,9 +1802,22 @@ func TestInjectVSCodeWritesSDDOrchestratorAndSkills(t *testing.T) {
 		t.Fatalf("expected SDD skill file %q: %v", skillPath, err)
 	}
 
-	sharedPath := filepath.Join(home, ".copilot", "skills", "_shared", "engram-convention.md")
-	if _, err := os.Stat(sharedPath); err != nil {
-		t.Fatalf("expected shared SDD convention file %q: %v", sharedPath, err)
+	sharedFiles := []string{
+		"persistence-contract.md",
+		"engram-convention.md",
+		"openspec-convention.md",
+		"sdd-phase-common.md",
+		"skill-resolver.md",
+	}
+	for _, fileName := range sharedFiles {
+		sharedPath := filepath.Join(home, ".copilot", "skills", "_shared", fileName)
+		info, err := os.Stat(sharedPath)
+		if err != nil {
+			t.Fatalf("expected shared SDD convention file %q: %v", sharedPath, err)
+		}
+		if info.Size() == 0 {
+			t.Fatalf("expected shared SDD convention file %q to be non-empty", sharedPath)
+		}
 	}
 }
 
@@ -5174,6 +5214,73 @@ func TestInjectVSCodeMissingModelCacheWarnsWithoutModelLine(t *testing.T) {
 	}
 	if strings.Contains(string(content), "model:") {
 		t.Fatalf("unresolved VS Code assignment should omit model line; got:\n%s", content)
+	}
+}
+
+func TestInjectVSCodeHidesExistingManagedClaudeInternalAgents(t *testing.T) {
+	home := t.TempDir()
+	isolateDesktopConfig(t, home)
+
+	claudeAgentsDir := filepath.Join(home, ".claude", "agents")
+	if err := os.MkdirAll(claudeAgentsDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", claudeAgentsDir, err)
+	}
+	managedPhasePath := filepath.Join(claudeAgentsDir, "sdd-apply.md")
+	managedJudgePath := filepath.Join(claudeAgentsDir, "jd-judge-a.md")
+	unrelatedPath := filepath.Join(claudeAgentsDir, "sdd-custom.md")
+	managedPhase := "---\nname: sdd-apply\nmodel: sonnet\ntools: Read, Edit, Bash\n---\nBody\n"
+	managedJudge := "---\nname: jd-judge-a\nmodel: opus\ntools: Read, Grep\n---\nBody\n"
+	unrelated := "---\nname: sdd-custom\nmodel: sonnet\ntools: Read\n---\nUser-authored body\n"
+	for path, content := range map[string]string{
+		managedPhasePath: managedPhase,
+		managedJudgePath: managedJudge,
+		unrelatedPath:    unrelated,
+	} {
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatalf("WriteFile(%s): %v", path, err)
+		}
+	}
+
+	adapter, err := agents.NewAdapter(model.AgentVSCodeCopilot)
+	if err != nil {
+		t.Fatalf("NewAdapter(vscode-copilot) error = %v", err)
+	}
+	result, err := Inject(home, adapter, "")
+	if err != nil {
+		t.Fatalf("Inject(vscode) error = %v", err)
+	}
+
+	for _, path := range []string{managedPhasePath, managedJudgePath} {
+		content, readErr := os.ReadFile(path)
+		if readErr != nil {
+			t.Fatalf("ReadFile(%s): %v", path, readErr)
+		}
+		text := string(content)
+		if !strings.Contains(text, "\nuser-invocable: false\n") {
+			t.Fatalf("managed Claude internal agent %s should be hidden from VS Code picker:\n%s", filepath.Base(path), text)
+		}
+		if strings.Contains(text, "disable-model-invocation") {
+			t.Fatalf("managed Claude internal agent %s must remain subagent-invocable:\n%s", filepath.Base(path), text)
+		}
+		if !containsString(result.Files, path) {
+			t.Fatalf("result.Files missing patched Claude agent %s in %v", path, result.Files)
+		}
+	}
+
+	unrelatedContent, err := os.ReadFile(unrelatedPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%s): %v", unrelatedPath, err)
+	}
+	if string(unrelatedContent) != unrelated {
+		t.Fatalf("unrelated Claude-format user agent was modified:\n%s", unrelatedContent)
+	}
+
+	second, err := Inject(home, adapter, "")
+	if err != nil {
+		t.Fatalf("second Inject(vscode) error = %v", err)
+	}
+	if second.Changed {
+		t.Fatalf("second Inject(vscode) changed = true after Claude visibility patch; files = %v", second.Files)
 	}
 }
 

--- a/internal/components/sdd/inject_test.go
+++ b/internal/components/sdd/inject_test.go
@@ -5008,6 +5008,105 @@ func assertNativeAgentFile(t *testing.T, path string, contains string) {
 	}
 }
 
+func TestInjectVSCodeWritesNativeAgentFiles(t *testing.T) {
+	home := t.TempDir()
+	isolateDesktopConfig(t, home)
+
+	adapter, err := agents.NewAdapter(model.AgentVSCodeCopilot)
+	if err != nil {
+		t.Fatalf("NewAdapter(vscode-copilot) error = %v", err)
+	}
+
+	result, err := Inject(home, adapter, "")
+	if err != nil {
+		t.Fatalf("Inject(vscode) error = %v", err)
+	}
+	if !result.Changed {
+		t.Fatal("Inject(vscode) first changed = false")
+	}
+
+	agentsDir := filepath.Join(home, ".copilot", "agents")
+	for _, name := range vscodeAgentAssetNames() {
+		path := filepath.Join(agentsDir, name)
+		content, readErr := os.ReadFile(path)
+		if readErr != nil {
+			t.Fatalf("expected VS Code agent file %q: %v", name, readErr)
+		}
+		if !strings.Contains(string(content), "target: vscode") {
+			t.Fatalf("%s missing target: vscode", name)
+		}
+	}
+	second, err := Inject(home, adapter, "")
+	if err != nil {
+		t.Fatalf("second Inject(vscode) error = %v", err)
+	}
+	if second.Changed {
+		t.Fatal("second Inject(vscode) changed = true; expected idempotent sync")
+	}
+
+	entries, err := os.ReadDir(agentsDir)
+	if err != nil {
+		t.Fatalf("ReadDir(%s) error = %v", agentsDir, err)
+	}
+	agentFiles := 0
+	for _, entry := range entries {
+		if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".agent.md") {
+			agentFiles++
+		}
+	}
+	if agentFiles != len(vscodeAgentAssetNames()) {
+		t.Fatalf("VS Code agent file count = %d, want %d", agentFiles, len(vscodeAgentAssetNames()))
+	}
+}
+
+func TestInjectNativeSubAgentExtensionsRemainAdapterSpecific(t *testing.T) {
+	tests := []struct {
+		name       string
+		agentID    model.AgentID
+		required   string
+		forbidden  string
+		customOpts InjectOptions
+	}{
+		{name: "cursor", agentID: model.AgentCursor, required: filepath.Join(".cursor", "agents", "sdd-apply.md"), forbidden: filepath.Join(".cursor", "agents", "sdd-apply.agent.md")},
+		{name: "kiro", agentID: model.AgentKiroIDE, required: filepath.Join(".kiro", "agents", "sdd-apply.md"), forbidden: filepath.Join(".kiro", "agents", "sdd-apply.agent.md")},
+		{name: "claude", agentID: model.AgentClaudeCode, required: filepath.Join(".claude", "agents", "sdd-apply.md"), forbidden: filepath.Join(".claude", "agents", "sdd-apply.agent.md")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home := t.TempDir()
+			isolateDesktopConfig(t, home)
+			adapter, err := agents.NewAdapter(tt.agentID)
+			if err != nil {
+				t.Fatalf("NewAdapter(%s) error = %v", tt.agentID, err)
+			}
+			if _, err := Inject(home, adapter, "", tt.customOpts); err != nil {
+				t.Fatalf("Inject(%s) error = %v", tt.agentID, err)
+			}
+			if _, err := os.Stat(filepath.Join(home, tt.required)); err != nil {
+				t.Fatalf("required native sub-agent %q missing: %v", tt.required, err)
+			}
+			if _, err := os.Stat(filepath.Join(home, tt.forbidden)); !os.IsNotExist(err) {
+				t.Fatalf("adapter %s must not write VS Code .agent.md path %q; stat err = %v", tt.agentID, tt.forbidden, err)
+			}
+		})
+	}
+}
+
+func vscodeAgentAssetNames() []string {
+	names := []string{"sdd-orchestrator.agent.md"}
+	for _, phase := range []string{"sdd-init", "sdd-explore", "sdd-propose", "sdd-spec", "sdd-design", "sdd-tasks", "sdd-apply", "sdd-verify", "sdd-archive", "sdd-onboard"} {
+		names = append(names, phase+".agent.md")
+	}
+	return names
+}
+
+func isolateDesktopConfig(t *testing.T, home string) {
+	t.Helper()
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("APPDATA", filepath.Join(home, "AppData", "Roaming"))
+}
+
 // TestInjectKiroFallsBackToClaudeModelAssignmentsWhenKiroMapUnset verifies that
 // when KiroModelAssignments is nil, the injector falls back to ClaudeModelAssignments
 // for Kiro phase model resolution (legacy backward-compatible path).

--- a/internal/components/sdd/prompts.go
+++ b/internal/components/sdd/prompts.go
@@ -115,11 +115,12 @@ func injectCodeGraphToolGrantIntoPrompt(prompt string, agentID model.AgentID, gu
 		return prompt
 	}
 
-	frontmatterEnd := strings.Index(prompt, "\n---\n")
+	normalizedPrompt := strings.ReplaceAll(prompt, "\r\n", "\n")
+	frontmatterEnd := strings.Index(normalizedPrompt, "\n---\n")
 	if frontmatterEnd < 0 {
 		return prompt
 	}
-	lines := strings.Split(prompt[:frontmatterEnd], "\n")
+	lines := strings.Split(normalizedPrompt[:frontmatterEnd], "\n")
 	for i, line := range lines {
 		if !strings.HasPrefix(line, "tools:") {
 			continue
@@ -127,14 +128,15 @@ func injectCodeGraphToolGrantIntoPrompt(prompt string, agentID model.AgentID, gu
 		if strings.Contains(line, grant) {
 			return prompt
 		}
+		trimmed := strings.TrimRight(line, " \t\r\n")
 		if agentID == model.AgentClaudeCode {
-			lines[i] = line + ", " + grant
-		} else if strings.HasSuffix(line, "]") {
-			lines[i] = strings.TrimSuffix(line, "]") + `, "` + grant + `"]`
+			lines[i] = trimmed + ", " + grant
+		} else if strings.HasSuffix(trimmed, "]") {
+			lines[i] = strings.TrimSuffix(trimmed, "]") + `, "` + grant + `"]`
 		} else {
 			return prompt
 		}
-		return strings.Join(lines, "\n") + prompt[frontmatterEnd:]
+		return strings.Join(lines, "\n") + normalizedPrompt[frontmatterEnd:]
 	}
 	return prompt
 }

--- a/internal/components/sdd/prompts_test.go
+++ b/internal/components/sdd/prompts_test.go
@@ -125,6 +125,7 @@ func nativeMarkdownSubAgentFilesForCodeGraphTest(t *testing.T, adapter agents.Ad
 
 func nativeToolsLineForCodeGraphTest(t *testing.T, content string) string {
 	t.Helper()
+	content = strings.ReplaceAll(content, "\r\n", "\n")
 	end := strings.Index(content, "\n---\n")
 	if !strings.HasPrefix(content, "---\n") || end < 0 {
 		t.Fatal("native prompt missing frontmatter")

--- a/internal/components/sdd/vscode_agent_visibility.go
+++ b/internal/components/sdd/vscode_agent_visibility.go
@@ -40,10 +40,12 @@ func hideManagedClaudeInternalAgentsForVSCode(homeDir string) (InjectionResult, 
 			continue
 		}
 
-		// Back up original content before write
+		// Back up original content before write, only if it doesn't already exist
 		backupPath := path + ".backup"
-		if err := os.WriteFile(backupPath, content, 0o644); err != nil {
-			return InjectionResult{}, fmt.Errorf("backup managed Claude agent %s: %w", fileName, err)
+		if _, err := os.Stat(backupPath); errors.Is(err, os.ErrNotExist) {
+			if err := os.WriteFile(backupPath, content, 0o644); err != nil {
+				return InjectionResult{}, fmt.Errorf("backup managed Claude agent %s: %w", fileName, err)
+			}
 		}
 
 		writeResult, err := filemerge.WriteFileAtomic(path, []byte(updated), 0o644)
@@ -59,24 +61,26 @@ func hideManagedClaudeInternalAgentsForVSCode(homeDir string) (InjectionResult, 
 }
 
 // RestoreManagedClaudeInternalAgentsForVSCode restores the backed-up Claude internal agent files
-// from their .backup copies and removes the backup files.
-func RestoreManagedClaudeInternalAgentsForVSCode(homeDir string) error {
+// from their .backup copies and removes the backup files. Returns true if any files were restored.
+func RestoreManagedClaudeInternalAgentsForVSCode(homeDir string) (bool, error) {
 	agentsDir := filepath.Join(homeDir, ".claude", "agents")
+	restoredAny := false
 	for _, fileName := range managedClaudeInternalAgentFiles() {
 		path := filepath.Join(agentsDir, fileName)
 		backupPath := path + ".backup"
 		if _, err := os.Stat(backupPath); err == nil {
 			content, err := os.ReadFile(backupPath)
 			if err != nil {
-				return fmt.Errorf("read backup %s: %w", backupPath, err)
+				return false, fmt.Errorf("read backup %s: %w", backupPath, err)
 			}
 			if _, err := filemerge.WriteFileAtomic(path, content, 0o644); err != nil {
-				return fmt.Errorf("restore agent %s from backup: %w", path, err)
+				return false, fmt.Errorf("restore agent %s from backup: %w", path, err)
 			}
 			_ = os.Remove(backupPath)
+			restoredAny = true
 		}
 	}
-	return nil
+	return restoredAny, nil
 }
 
 func managedClaudeInternalAgentFiles() []string {

--- a/internal/components/sdd/vscode_agent_visibility.go
+++ b/internal/components/sdd/vscode_agent_visibility.go
@@ -42,18 +42,25 @@ func hideManagedClaudeInternalAgentsForVSCode(homeDir string) (InjectionResult, 
 
 		// Back up original content before write, only if it doesn't already exist
 		backupPath := path + ".backup"
+		createdBackup := false
 		if _, err := os.Stat(backupPath); err == nil {
 			// backup already exists, do nothing
 		} else if errors.Is(err, os.ErrNotExist) {
 			if _, err := filemerge.WriteFileAtomic(backupPath, content, 0o644); err != nil {
 				return InjectionResult{}, fmt.Errorf("backup managed Claude agent %s: %w", fileName, err)
 			}
+			createdBackup = true
 		} else {
 			return InjectionResult{}, fmt.Errorf("stat backup file %s: %w", backupPath, err)
 		}
 
 		writeResult, err := filemerge.WriteFileAtomic(path, []byte(updated), 0o644)
 		if err != nil {
+			if createdBackup {
+				if removeErr := os.Remove(backupPath); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
+					return InjectionResult{}, fmt.Errorf("write managed Claude agent %s: %w (cleanup backup %s: %v)", fileName, err, backupPath, removeErr)
+				}
+			}
 			return InjectionResult{}, fmt.Errorf("write managed Claude agent %s: %w", fileName, err)
 		}
 		if writeResult.Changed {

--- a/internal/components/sdd/vscode_agent_visibility.go
+++ b/internal/components/sdd/vscode_agent_visibility.go
@@ -42,10 +42,14 @@ func hideManagedClaudeInternalAgentsForVSCode(homeDir string) (InjectionResult, 
 
 		// Back up original content before write, only if it doesn't already exist
 		backupPath := path + ".backup"
-		if _, err := os.Stat(backupPath); errors.Is(err, os.ErrNotExist) {
-			if err := os.WriteFile(backupPath, content, 0o644); err != nil {
+		if _, err := os.Stat(backupPath); err == nil {
+			// backup already exists, do nothing
+		} else if errors.Is(err, os.ErrNotExist) {
+			if _, err := filemerge.WriteFileAtomic(backupPath, content, 0o644); err != nil {
 				return InjectionResult{}, fmt.Errorf("backup managed Claude agent %s: %w", fileName, err)
 			}
+		} else {
+			return InjectionResult{}, fmt.Errorf("stat backup file %s: %w", backupPath, err)
 		}
 
 		writeResult, err := filemerge.WriteFileAtomic(path, []byte(updated), 0o644)
@@ -76,7 +80,9 @@ func RestoreManagedClaudeInternalAgentsForVSCode(homeDir string) (bool, error) {
 			if _, err := filemerge.WriteFileAtomic(path, content, 0o644); err != nil {
 				return false, fmt.Errorf("restore agent %s from backup: %w", path, err)
 			}
-			_ = os.Remove(backupPath)
+			if err := os.Remove(backupPath); err != nil {
+				return false, fmt.Errorf("remove backup file %s: %w", backupPath, err)
+			}
 			restoredAny = true
 		}
 	}

--- a/internal/components/sdd/vscode_agent_visibility.go
+++ b/internal/components/sdd/vscode_agent_visibility.go
@@ -39,6 +39,13 @@ func hideManagedClaudeInternalAgentsForVSCode(homeDir string) (InjectionResult, 
 		if updated == text {
 			continue
 		}
+
+		// Back up original content before write
+		backupPath := path + ".backup"
+		if err := os.WriteFile(backupPath, content, 0o644); err != nil {
+			return InjectionResult{}, fmt.Errorf("backup managed Claude agent %s: %w", fileName, err)
+		}
+
 		writeResult, err := filemerge.WriteFileAtomic(path, []byte(updated), 0o644)
 		if err != nil {
 			return InjectionResult{}, fmt.Errorf("write managed Claude agent %s: %w", fileName, err)
@@ -49,6 +56,27 @@ func hideManagedClaudeInternalAgentsForVSCode(homeDir string) (InjectionResult, 
 		}
 	}
 	return result, nil
+}
+
+// RestoreManagedClaudeInternalAgentsForVSCode restores the backed-up Claude internal agent files
+// from their .backup copies and removes the backup files.
+func RestoreManagedClaudeInternalAgentsForVSCode(homeDir string) error {
+	agentsDir := filepath.Join(homeDir, ".claude", "agents")
+	for _, fileName := range managedClaudeInternalAgentFiles() {
+		path := filepath.Join(agentsDir, fileName)
+		backupPath := path + ".backup"
+		if _, err := os.Stat(backupPath); err == nil {
+			content, err := os.ReadFile(backupPath)
+			if err != nil {
+				return fmt.Errorf("read backup %s: %w", backupPath, err)
+			}
+			if _, err := filemerge.WriteFileAtomic(path, content, 0o644); err != nil {
+				return fmt.Errorf("restore agent %s from backup: %w", path, err)
+			}
+			_ = os.Remove(backupPath)
+		}
+	}
+	return nil
 }
 
 func managedClaudeInternalAgentFiles() []string {

--- a/internal/components/sdd/vscode_agent_visibility.go
+++ b/internal/components/sdd/vscode_agent_visibility.go
@@ -1,0 +1,101 @@
+package sdd
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/gentleman-programming/gentle-ai/internal/components/filemerge"
+)
+
+const hiddenClaudeInternalAgentFrontmatter = "user-invocable: false"
+
+func hideManagedClaudeInternalAgentsForVSCode(homeDir string) (InjectionResult, error) {
+	agentsDir := filepath.Join(homeDir, ".claude", "agents")
+	if info, err := os.Stat(agentsDir); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return InjectionResult{}, nil
+		}
+		return InjectionResult{}, fmt.Errorf("inspect Claude agents dir: %w", err)
+	} else if !info.IsDir() {
+		return InjectionResult{}, nil
+	}
+
+	result := InjectionResult{}
+	for _, fileName := range managedClaudeInternalAgentFiles() {
+		path := filepath.Join(agentsDir, fileName)
+		content, err := os.ReadFile(path)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			return InjectionResult{}, fmt.Errorf("read managed Claude agent %s: %w", fileName, err)
+		}
+
+		text := string(content)
+		updated := hideClaudeAgentFromVSCodePicker(text)
+		if updated == text {
+			continue
+		}
+		writeResult, err := filemerge.WriteFileAtomic(path, []byte(updated), 0o644)
+		if err != nil {
+			return InjectionResult{}, fmt.Errorf("write managed Claude agent %s: %w", fileName, err)
+		}
+		if writeResult.Changed {
+			result.Changed = true
+			result.Files = append(result.Files, path)
+		}
+	}
+	return result, nil
+}
+
+func managedClaudeInternalAgentFiles() []string {
+	return []string{
+		"sdd-init.md",
+		"sdd-explore.md",
+		"sdd-propose.md",
+		"sdd-spec.md",
+		"sdd-design.md",
+		"sdd-tasks.md",
+		"sdd-apply.md",
+		"sdd-verify.md",
+		"sdd-archive.md",
+		"sdd-onboard.md",
+		"jd-judge-a.md",
+		"jd-judge-b.md",
+		"jd-fix-agent.md",
+	}
+}
+
+func hideClaudeAgentFromVSCodePicker(content string) string {
+	lineBreak := "\n"
+	if strings.Contains(content, "\r\n") {
+		lineBreak = "\r\n"
+	}
+	lines := strings.Split(strings.ReplaceAll(content, "\r\n", "\n"), "\n")
+	closing := frontmatterClosingLine(lines)
+	if closing == -1 {
+		return content
+	}
+
+	updated := make([]string, 0, len(lines)+1)
+	updated = append(updated, lines[0])
+	hidden := false
+	for i := 1; i < closing; i++ {
+		if strings.HasPrefix(strings.TrimSpace(lines[i]), "user-invocable:") {
+			if !hidden {
+				updated = append(updated, hiddenClaudeInternalAgentFrontmatter)
+				hidden = true
+			}
+			continue
+		}
+		updated = append(updated, lines[i])
+	}
+	if !hidden {
+		updated = append(updated, hiddenClaudeInternalAgentFrontmatter)
+	}
+	updated = append(updated, lines[closing:]...)
+	return strings.Join(updated, lineBreak)
+}

--- a/internal/components/sdd/vscode_agent_visibility.go
+++ b/internal/components/sdd/vscode_agent_visibility.go
@@ -24,7 +24,7 @@ func hideManagedClaudeInternalAgentsForVSCode(homeDir string) (InjectionResult, 
 	}
 
 	result := InjectionResult{}
-	for _, fileName := range managedClaudeInternalAgentFiles() {
+	for _, fileName := range ManagedClaudeInternalAgentFiles() {
 		path := filepath.Join(agentsDir, fileName)
 		content, err := os.ReadFile(path)
 		if err != nil {
@@ -76,27 +76,31 @@ func hideManagedClaudeInternalAgentsForVSCode(homeDir string) (InjectionResult, 
 func RestoreManagedClaudeInternalAgentsForVSCode(homeDir string) (bool, error) {
 	agentsDir := filepath.Join(homeDir, ".claude", "agents")
 	restoredAny := false
-	for _, fileName := range managedClaudeInternalAgentFiles() {
+	for _, fileName := range ManagedClaudeInternalAgentFiles() {
 		path := filepath.Join(agentsDir, fileName)
 		backupPath := path + ".backup"
-		if _, err := os.Stat(backupPath); err == nil {
-			content, err := os.ReadFile(backupPath)
-			if err != nil {
-				return false, fmt.Errorf("read backup %s: %w", backupPath, err)
+		if _, err := os.Stat(backupPath); err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
 			}
-			if _, err := filemerge.WriteFileAtomic(path, content, 0o644); err != nil {
-				return false, fmt.Errorf("restore agent %s from backup: %w", path, err)
-			}
-			if err := os.Remove(backupPath); err != nil {
-				return false, fmt.Errorf("remove backup file %s: %w", backupPath, err)
-			}
-			restoredAny = true
+			return false, fmt.Errorf("inspect backup %s: %w", backupPath, err)
 		}
+		content, err := os.ReadFile(backupPath)
+		if err != nil {
+			return false, fmt.Errorf("read backup %s: %w", backupPath, err)
+		}
+		if _, err := filemerge.WriteFileAtomic(path, content, 0o644); err != nil {
+			return false, fmt.Errorf("restore agent %s from backup: %w", path, err)
+		}
+		if err := os.Remove(backupPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return false, fmt.Errorf("remove backup %s: %w", backupPath, err)
+		}
+		restoredAny = true
 	}
 	return restoredAny, nil
 }
 
-func managedClaudeInternalAgentFiles() []string {
+func ManagedClaudeInternalAgentFiles() []string {
 	return []string{
 		"sdd-init.md",
 		"sdd-explore.md",

--- a/internal/components/sdd/vscode_agent_visibility_test.go
+++ b/internal/components/sdd/vscode_agent_visibility_test.go
@@ -1,0 +1,71 @@
+package sdd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestHideAndRestoreManagedClaudeInternalAgentsForVSCode(t *testing.T) {
+	homeDir := t.TempDir()
+
+	agentsDir := filepath.Join(homeDir, ".claude", "agents")
+	if err := os.MkdirAll(agentsDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	// Create a dummy Claude agent file that should be hidden
+	agentFile := filepath.Join(agentsDir, "sdd-init.md")
+	originalContent := "---\nname: sdd-init\nuser-invocable: true\n---\nbody content"
+	if err := os.WriteFile(agentFile, []byte(originalContent), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	// Run hide
+	res, err := hideManagedClaudeInternalAgentsForVSCode(homeDir)
+	if err != nil {
+		t.Fatalf("hideManagedClaudeInternalAgentsForVSCode: %v", err)
+	}
+	if !res.Changed {
+		t.Error("expected hide to report changed = true")
+	}
+
+	// Verify hidden agent content
+	content, err := os.ReadFile(agentFile)
+	if err != nil {
+		t.Fatalf("ReadFile agent: %v", err)
+	}
+	if !strings.Contains(string(content), "user-invocable: false") {
+		t.Errorf("expected user-invocable: false in content, got:\n%s", string(content))
+	}
+
+	// Verify backup file exists
+	backupFile := agentFile + ".backup"
+	backupContent, err := os.ReadFile(backupFile)
+	if err != nil {
+		t.Fatalf("ReadFile backup: %v", err)
+	}
+	if string(backupContent) != originalContent {
+		t.Errorf("backupContent = %q, want original %q", string(backupContent), originalContent)
+	}
+
+	// Run restore
+	if err := RestoreManagedClaudeInternalAgentsForVSCode(homeDir); err != nil {
+		t.Fatalf("RestoreManagedClaudeInternalAgentsForVSCode: %v", err)
+	}
+
+	// Verify restored agent content is back to original
+	restoredContent, err := os.ReadFile(agentFile)
+	if err != nil {
+		t.Fatalf("ReadFile agent after restore: %v", err)
+	}
+	if string(restoredContent) != originalContent {
+		t.Errorf("restoredContent = %q, want original %q", string(restoredContent), originalContent)
+	}
+
+	// Verify backup file is deleted
+	if _, err := os.Stat(backupFile); err == nil {
+		t.Error("expected backup file to be deleted after restore")
+	}
+}

--- a/internal/components/sdd/vscode_agent_visibility_test.go
+++ b/internal/components/sdd/vscode_agent_visibility_test.go
@@ -51,8 +51,12 @@ func TestHideAndRestoreManagedClaudeInternalAgentsForVSCode(t *testing.T) {
 	}
 
 	// Run restore
-	if err := RestoreManagedClaudeInternalAgentsForVSCode(homeDir); err != nil {
+	restored, err := RestoreManagedClaudeInternalAgentsForVSCode(homeDir)
+	if err != nil {
 		t.Fatalf("RestoreManagedClaudeInternalAgentsForVSCode: %v", err)
+	}
+	if !restored {
+		t.Errorf("expected RestoreManagedClaudeInternalAgentsForVSCode to return true, got false")
 	}
 
 	// Verify restored agent content is back to original

--- a/internal/components/sdd/vscode_models.go
+++ b/internal/components/sdd/vscode_models.go
@@ -1,0 +1,250 @@
+package sdd
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/gentleman-programming/gentle-ai/internal/model"
+	"github.com/gentleman-programming/gentle-ai/internal/opencode"
+)
+
+const githubCopilotProviderID = "github-copilot"
+
+// vscodeModelAssignmentKeys defines the only VS Code agent keys that may receive
+// explicit model frontmatter. Keeping this list closed prevents named-profile
+// or arbitrary-file assignments from leaking into native Copilot agents.
+func vscodeModelAssignmentKeys() []string {
+	return []string{
+		"sdd-orchestrator",
+		"sdd-init",
+		"sdd-explore",
+		"sdd-propose",
+		"sdd-spec",
+		"sdd-design",
+		"sdd-tasks",
+		"sdd-apply",
+		"sdd-verify",
+		"sdd-archive",
+		"sdd-onboard",
+	}
+}
+
+// withDefaultVSCodeModelPaths resolves cache paths relative to the injected
+// home directory, not the process user. That keeps tests, portable installs,
+// and sync-with-selection from accidentally reading another user's cache.
+func withDefaultVSCodeModelPaths(opts InjectOptions, homeDir string) InjectOptions {
+	if opts.VSCodeModelCachePath == "" {
+		opts.VSCodeModelCachePath = filepath.Join(homeDir, ".cache", "opencode", "models.json")
+	}
+	if opts.VSCodeModelVariantsPath == "" {
+		opts.VSCodeModelVariantsPath = filepath.Join(homeDir, ".gentle-ai", "cache", "model-variants.json")
+	}
+	return opts
+}
+
+// renderVSCodeAgentModelAssignment applies an optional model line to a single
+// native VS Code agent file. Unresolved assignments are intentionally rendered
+// without a model line so Copilot safely inherits the parent session model.
+func renderVSCodeAgentModelAssignment(content, fileName string, opts InjectOptions) (string, []string) {
+	if opts.VSCodeModelAssignments == nil {
+		return content, nil
+	}
+	agentKey, ok := vscodeAgentKey(fileName)
+	if !ok {
+		return content, nil
+	}
+
+	modelLabel, warnings := resolveVSCodeModelAssignment(
+		agentKey,
+		opts.VSCodeModelAssignments,
+		opts.VSCodeModelCachePath,
+		opts.VSCodeModelVariantsPath,
+	)
+	return injectVSCodeModelLine(content, modelLabel), warnings
+}
+
+// vscodeAgentKey maps a managed `.agent.md` filename to its persisted assignment
+// key. Non-native files are ignored so other adapter asset formats remain isolated.
+func vscodeAgentKey(fileName string) (string, bool) {
+	if !strings.HasSuffix(fileName, ".agent.md") {
+		return "", false
+	}
+	key := strings.TrimSuffix(fileName, ".agent.md")
+	if key == "" {
+		return "", false
+	}
+	if !isVSCodeModelAssignmentKey(key) {
+		return "", false
+	}
+	return key, true
+}
+
+// isVSCodeModelAssignmentKey enforces the closed assignment surface at runtime;
+// tests alone are not enough because embedded assets can grow over time.
+func isVSCodeModelAssignmentKey(key string) bool {
+	for _, allowed := range vscodeModelAssignmentKeys() {
+		if allowed == key {
+			return true
+		}
+	}
+	return false
+}
+
+// resolveVSCodeModelAssignment validates an assignment against the dynamic
+// OpenCode model cache and returns the VS Code display label to write. Any
+// invalid or stale assignment returns a warning plus an empty label; the caller
+// must then omit `model:` instead of failing sync.
+func resolveVSCodeModelAssignment(agentKey string, assignments map[string]model.ModelAssignment, cachePath, variantsPath string) (string, []string) {
+	assignment, ok := assignments[agentKey]
+	if !ok || assignment.ProviderID == "" || assignment.ModelID == "" {
+		return "", nil
+	}
+	if assignment.ProviderID != githubCopilotProviderID {
+		return "", []string{fmt.Sprintf("VS Code model assignment for %s skipped: provider %q is not %q", agentKey, assignment.ProviderID, githubCopilotProviderID)}
+	}
+
+	providers, warnings := loadVSCodeModelCatalog(agentKey, cachePath, variantsPath)
+	if len(warnings) > 0 {
+		return "", warnings
+	}
+
+	provider, ok := providers[githubCopilotProviderID]
+	if !ok {
+		return "", []string{fmt.Sprintf("VS Code model assignment for %s skipped: provider %q missing from models cache", agentKey, githubCopilotProviderID)}
+	}
+	cachedModel, ok := provider.Models[assignment.ModelID]
+	if !ok {
+		return "", []string{fmt.Sprintf("VS Code model assignment for %s skipped: model %q missing from %q models cache", agentKey, assignment.ModelID, githubCopilotProviderID)}
+	}
+	if !cachedModel.ToolCall {
+		return "", []string{fmt.Sprintf("VS Code model assignment for %s skipped: model %q does not support tool calls", agentKey, assignment.ModelID)}
+	}
+	if warning := validateVSCodeEffort(agentKey, assignment, cachedModel); warning != "" {
+		return "", []string{warning}
+	}
+
+	label := strings.TrimSpace(cachedModel.Name)
+	if label == "" {
+		label = strings.TrimSpace(cachedModel.ID)
+	}
+	if label == "" {
+		return "", []string{fmt.Sprintf("VS Code model assignment for %s skipped: model %q has insufficient metadata", agentKey, assignment.ModelID)}
+	}
+	return label, nil
+}
+
+// loadVSCodeModelCatalog reads the current model cache and enriches it with
+// optional effort variants. A missing cache is a recoverable warning because the
+// assignment must stay persisted for a future cache refresh.
+func loadVSCodeModelCatalog(agentKey, cachePath, variantsPath string) (map[string]opencode.Provider, []string) {
+	path := cachePath
+	if path == "" {
+		path = opencode.DefaultCachePath()
+	}
+	if path == "" {
+		return nil, []string{fmt.Sprintf("VS Code model assignment for %s skipped: models cache path unavailable", agentKey)}
+	}
+
+	providers, err := opencode.LoadModels(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, []string{fmt.Sprintf("VS Code model assignment for %s skipped: models cache %q not found", agentKey, path)}
+		}
+		return nil, []string{fmt.Sprintf("VS Code model assignment for %s skipped: read models cache %q: %v", agentKey, path, err)}
+	}
+
+	variantPath := variantsPath
+	if variantPath == "" {
+		variantPath = opencode.DefaultVariantsCachePath()
+	}
+	if variantPath != "" {
+		opencode.EnrichWithVariants(providers, variantPath)
+	}
+	return providers, nil
+}
+
+// validateVSCodeEffort rejects effort-specific assignments unless the cache can
+// prove that the chosen model supports that effort. This avoids writing a model
+// frontmatter value that looks precise but cannot represent the requested variant.
+func validateVSCodeEffort(agentKey string, assignment model.ModelAssignment, cachedModel opencode.Model) string {
+	if assignment.Effort == "" {
+		return ""
+	}
+	if len(cachedModel.Variants) == 0 {
+		return fmt.Sprintf("VS Code model assignment for %s skipped: model %q has no effort metadata", agentKey, assignment.ModelID)
+	}
+	for _, variant := range cachedModel.Variants {
+		if variant == assignment.Effort {
+			return ""
+		}
+	}
+	return fmt.Sprintf("VS Code model assignment for %s skipped: effort %q is not supported by model %q", agentKey, assignment.Effort, assignment.ModelID)
+}
+
+// injectVSCodeModelLine rewrites only the YAML frontmatter model entry. It
+// removes stale model lines first, preserves the asset line-ending style, and
+// quotes labels so spaces or punctuation remain valid YAML.
+func injectVSCodeModelLine(content, modelLabel string) string {
+	lineBreak := "\n"
+	if strings.Contains(content, "\r\n") {
+		lineBreak = "\r\n"
+	}
+	lines := strings.Split(strings.ReplaceAll(content, "\r\n", "\n"), "\n")
+	closing := frontmatterClosingLine(lines)
+	if closing == -1 {
+		return content
+	}
+
+	updated := make([]string, 0, len(lines)+1)
+	updated = append(updated, lines[0])
+	for i := 1; i < closing; i++ {
+		if strings.HasPrefix(strings.TrimSpace(lines[i]), "model:") {
+			continue
+		}
+		updated = append(updated, lines[i])
+	}
+	if modelLabel != "" {
+		updated = append(updated, "model: "+strconv.Quote(modelLabel))
+	}
+	updated = append(updated, lines[closing:]...)
+	return strings.Join(updated, lineBreak)
+}
+
+// frontmatterClosingLine finds the second YAML delimiter that ends frontmatter.
+// Files without valid frontmatter are left untouched by the renderer.
+func frontmatterClosingLine(lines []string) int {
+	if len(lines) < 2 || strings.TrimSpace(lines[0]) != "---" {
+		return -1
+	}
+	for i := 1; i < len(lines); i++ {
+		if strings.TrimSpace(lines[i]) == "---" {
+			return i
+		}
+	}
+	return -1
+}
+
+// dedupWarnings keeps warning output stable when multiple generated files hit
+// the same recoverable cache or metadata problem during one sync.
+func dedupWarnings(warnings []string) []string {
+	if len(warnings) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(warnings))
+	out := make([]string, 0, len(warnings))
+	for _, warning := range warnings {
+		if strings.TrimSpace(warning) == "" {
+			continue
+		}
+		if _, ok := seen[warning]; ok {
+			continue
+		}
+		seen[warning] = struct{}{}
+		out = append(out, warning)
+	}
+	return out
+}

--- a/internal/components/sdd/vscode_models.go
+++ b/internal/components/sdd/vscode_models.go
@@ -154,7 +154,8 @@ func loadVSCodeModelCatalog(cachePath, variantsPath string) (map[string]opencode
 		if errors.Is(err, os.ErrNotExist) {
 			return nil, []string{fmt.Sprintf("VS Code model assignments skipped: models cache %q not found", path)}
 		}
-		return nil, []string{fmt.Sprintf("VS Code model assignments skipped: read models cache %q: %v", path, err)}
+		wrappedErr := fmt.Errorf("read models cache %q: %w", path, err)
+		return nil, []string{fmt.Sprintf("VS Code model assignments skipped: %v", wrappedErr)}
 	}
 
 	variantPath := variantsPath

--- a/internal/components/sdd/vscode_models.go
+++ b/internal/components/sdd/vscode_models.go
@@ -50,12 +50,12 @@ func withDefaultVSCodeModelPaths(opts InjectOptions, homeDir string) InjectOptio
 // native VS Code agent file. Unresolved assignments are intentionally rendered
 // without a model line so Copilot safely inherits the parent session model.
 func renderVSCodeAgentModelAssignment(content, fileName string, opts InjectOptions) (string, []string) {
-	if opts.VSCodeModelAssignments == nil {
-		return content, nil
-	}
 	agentKey, ok := vscodeAgentKey(fileName)
 	if !ok {
 		return content, nil
+	}
+	if opts.VSCodeModelAssignments == nil {
+		return injectVSCodeModelLine(content, ""), nil
 	}
 
 	modelLabel, warnings := resolveVSCodeModelAssignment(

--- a/internal/components/sdd/vscode_models.go
+++ b/internal/components/sdd/vscode_models.go
@@ -107,7 +107,7 @@ func resolveVSCodeModelAssignment(agentKey string, assignments map[string]model.
 		return "", []string{fmt.Sprintf("VS Code model assignment for %s skipped: provider %q is not %q", agentKey, assignment.ProviderID, githubCopilotProviderID)}
 	}
 
-	providers, warnings := loadVSCodeModelCatalog(agentKey, cachePath, variantsPath)
+	providers, warnings := loadVSCodeModelCatalog(cachePath, variantsPath)
 	if len(warnings) > 0 {
 		return "", warnings
 	}
@@ -140,21 +140,21 @@ func resolveVSCodeModelAssignment(agentKey string, assignments map[string]model.
 // loadVSCodeModelCatalog reads the current model cache and enriches it with
 // optional effort variants. A missing cache is a recoverable warning because the
 // assignment must stay persisted for a future cache refresh.
-func loadVSCodeModelCatalog(agentKey, cachePath, variantsPath string) (map[string]opencode.Provider, []string) {
+func loadVSCodeModelCatalog(cachePath, variantsPath string) (map[string]opencode.Provider, []string) {
 	path := cachePath
 	if path == "" {
 		path = opencode.DefaultCachePath()
 	}
 	if path == "" {
-		return nil, []string{fmt.Sprintf("VS Code model assignment for %s skipped: models cache path unavailable", agentKey)}
+		return nil, []string{"VS Code model assignments skipped: models cache path unavailable"}
 	}
 
 	providers, err := opencode.LoadModels(path)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return nil, []string{fmt.Sprintf("VS Code model assignment for %s skipped: models cache %q not found", agentKey, path)}
+			return nil, []string{fmt.Sprintf("VS Code model assignments skipped: models cache %q not found", path)}
 		}
-		return nil, []string{fmt.Sprintf("VS Code model assignment for %s skipped: read models cache %q: %v", agentKey, path, err)}
+		return nil, []string{fmt.Sprintf("VS Code model assignments skipped: read models cache %q: %v", path, err)}
 	}
 
 	variantPath := variantsPath

--- a/internal/components/sdd/vscode_models_test.go
+++ b/internal/components/sdd/vscode_models_test.go
@@ -1,0 +1,181 @@
+package sdd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/internal/model"
+)
+
+// TestVSCodeModelAssignmentKeysIncludeCoordinatorAndPhases locks the native VS
+// Code assignment surface to the coordinator plus real SDD phase agents.
+func TestVSCodeModelAssignmentKeysIncludeCoordinatorAndPhases(t *testing.T) {
+	keys := vscodeModelAssignmentKeys()
+
+	for _, want := range append([]string{"sdd-orchestrator"}, "sdd-init", "sdd-explore", "sdd-propose", "sdd-spec", "sdd-design", "sdd-tasks", "sdd-apply", "sdd-verify", "sdd-archive", "sdd-onboard") {
+		if !containsString(keys, want) {
+			t.Fatalf("vscodeModelAssignmentKeys() missing %q in %v", want, keys)
+		}
+	}
+}
+
+// TestVSCodeAgentKeyRejectsUnknownNativeFiles proves the assignment key list is
+// an enforced allowlist, not just documentation for expected assets.
+func TestVSCodeAgentKeyRejectsUnknownNativeFiles(t *testing.T) {
+	if _, ok := vscodeAgentKey("experimental.agent.md"); ok {
+		t.Fatal("unknown VS Code native agent file should not accept model assignments")
+	}
+}
+
+// TestResolveVSCodeModelAssignment covers the resolver contract: valid dynamic
+// Copilot cache entries render, while stale or unsafe assignments warn and omit.
+func TestResolveVSCodeModelAssignment(t *testing.T) {
+	cachePath := writeVSCodeModelCache(t, "gpt-4.1", "GPT-4.1", true)
+
+	tests := []struct {
+		name         string
+		assignments  map[string]model.ModelAssignment
+		cachePath    string
+		wantLabel    string
+		wantWarnings []string
+	}{
+		{
+			name:         "missing assignment inherits parent silently",
+			assignments:  nil,
+			cachePath:    cachePath,
+			wantLabel:    "",
+			wantWarnings: nil,
+		},
+		{
+			name: "valid github copilot cache entry renders display label",
+			assignments: map[string]model.ModelAssignment{
+				"sdd-apply": {ProviderID: "github-copilot", ModelID: "gpt-4.1"},
+			},
+			cachePath:    cachePath,
+			wantLabel:    "GPT-4.1",
+			wantWarnings: nil,
+		},
+		{
+			name: "provider mismatch warns and omits",
+			assignments: map[string]model.ModelAssignment{
+				"sdd-apply": {ProviderID: "anthropic", ModelID: "claude-opus-4"},
+			},
+			cachePath:    cachePath,
+			wantWarnings: []string{"github-copilot"},
+		},
+		{
+			name: "missing cache warns and omits",
+			assignments: map[string]model.ModelAssignment{
+				"sdd-apply": {ProviderID: "github-copilot", ModelID: "gpt-4.1"},
+			},
+			cachePath:    filepath.Join(t.TempDir(), "missing-models.json"),
+			wantWarnings: []string{"models cache"},
+		},
+		{
+			name: "non tool capable model warns and omits",
+			assignments: map[string]model.ModelAssignment{
+				"sdd-apply": {ProviderID: "github-copilot", ModelID: "text-only"},
+			},
+			cachePath:    writeVSCodeModelCache(t, "text-only", "Text Only", false),
+			wantWarnings: []string{"tool"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			label, warnings := resolveVSCodeModelAssignment("sdd-apply", tt.assignments, tt.cachePath, "")
+			if label != tt.wantLabel {
+				t.Fatalf("label = %q, want %q", label, tt.wantLabel)
+			}
+			for _, want := range tt.wantWarnings {
+				if !containsWarning(warnings, want) {
+					t.Fatalf("warnings = %v, want substring %q", warnings, want)
+				}
+			}
+		})
+	}
+}
+
+// TestResolveVSCodeModelAssignmentEffortMetadata proves effort assignments are
+// only accepted when variant metadata can validate the requested effort.
+func TestResolveVSCodeModelAssignmentEffortMetadata(t *testing.T) {
+	cachePath := writeVSCodeModelCache(t, "gpt-4.1", "GPT-4.1", true)
+
+	_, warnings := resolveVSCodeModelAssignment("sdd-apply", map[string]model.ModelAssignment{
+		"sdd-apply": {ProviderID: "github-copilot", ModelID: "gpt-4.1", Effort: "low"},
+	}, cachePath, filepath.Join(t.TempDir(), "missing-variants.json"))
+	if !containsWarning(warnings, "effort metadata") {
+		t.Fatalf("warnings = %v, want missing effort metadata warning", warnings)
+	}
+
+	variantsPath := writeVSCodeModelVariants(t, "gpt-4.1", []string{"low", "medium"})
+	_, warnings = resolveVSCodeModelAssignment("sdd-apply", map[string]model.ModelAssignment{
+		"sdd-apply": {ProviderID: "github-copilot", ModelID: "gpt-4.1", Effort: "high"},
+	}, cachePath, variantsPath)
+	if !containsWarning(warnings, "effort") {
+		t.Fatalf("warnings = %v, want invalid effort warning", warnings)
+	}
+}
+
+// writeVSCodeModelCache creates the smallest OpenCode-compatible model cache
+// needed to test Copilot label resolution and tool-call filtering.
+func writeVSCodeModelCache(t *testing.T, modelID, name string, toolCall bool) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "models.json")
+	content := `{"github-copilot":{"id":"github-copilot","name":"GitHub Copilot","models":{"` + modelID + `":{"id":"` + modelID + `","name":"` + name + `","tool_call":` + boolJSON(toolCall) + `}}}}`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile(%s): %v", path, err)
+	}
+	return path
+}
+
+// writeVSCodeModelVariants writes provider variant metadata so effort validation
+// can be tested without depending on the user's real cache.
+func writeVSCodeModelVariants(t *testing.T, modelID string, efforts []string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "variants.json")
+	quoted := make([]string, 0, len(efforts))
+	for _, effort := range efforts {
+		quoted = append(quoted, `"`+effort+`"`)
+	}
+	content := `{"github-copilot":{"` + modelID + `":[` + strings.Join(quoted, ",") + `]}}`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile(%s): %v", path, err)
+	}
+	return path
+}
+
+// boolJSON keeps generated fixture JSON readable while avoiding fmt noise in
+// table setup.
+func boolJSON(value bool) string {
+	if value {
+		return "true"
+	}
+	return "false"
+}
+
+// containsString keeps assignment-key assertions readable in closed-surface
+// tests.
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+// containsWarning checks warning substrings so tests assert behavior without
+// coupling to exact full diagnostic wording.
+func containsWarning(warnings []string, want string) bool {
+	for _, warning := range warnings {
+		if strings.Contains(warning, want) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/components/sdd/vscode_models_test.go
+++ b/internal/components/sdd/vscode_models_test.go
@@ -204,16 +204,7 @@ func boolJSON(value bool) string {
 	return "false"
 }
 
-// containsString keeps assignment-key assertions readable in closed-surface
-// tests.
-func containsString(values []string, want string) bool {
-	for _, value := range values {
-		if value == want {
-			return true
-		}
-	}
-	return false
-}
+
 
 // containsWarning checks warning substrings so tests assert behavior without
 // coupling to exact full diagnostic wording.

--- a/internal/components/sdd/vscode_models_test.go
+++ b/internal/components/sdd/vscode_models_test.go
@@ -119,6 +119,52 @@ func TestResolveVSCodeModelAssignmentEffortMetadata(t *testing.T) {
 	}
 }
 
+func TestRenderVSCodeAgentModelAssignmentStripsStaleModelPlaceholdersWithoutValidAssignment(t *testing.T) {
+	staleContent := strings.Join([]string{
+		"---",
+		"name: sdd-orchestrator",
+		"target: vscode",
+		"user-invocable: true",
+		"model: {{VSC_MODEL}}",
+		"---",
+		"",
+		"Body",
+	}, "\n")
+
+	tests := []struct {
+		name        string
+		opts        InjectOptions
+		wantWarning string
+	}{
+		{
+			name: "missing assignments strips placeholder",
+			opts: InjectOptions{},
+		},
+		{
+			name: "invalid provider strips placeholder",
+			opts: InjectOptions{VSCodeModelAssignments: map[string]model.ModelAssignment{
+				"sdd-orchestrator": {ProviderID: "anthropic", ModelID: "claude-opus-4"},
+			}},
+			wantWarning: "github-copilot",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, warnings := renderVSCodeAgentModelAssignment(staleContent, "sdd-orchestrator.agent.md", tt.opts)
+			if strings.Contains(got, "{{VSC_MODEL}}") {
+				t.Fatalf("rendered VS Code agent leaked raw placeholder:\n%s", got)
+			}
+			if strings.Contains(got, "model:") {
+				t.Fatalf("rendered VS Code agent should inherit parent model without model frontmatter:\n%s", got)
+			}
+			if tt.wantWarning != "" && !containsWarning(warnings, tt.wantWarning) {
+				t.Fatalf("warnings = %v, want substring %q", warnings, tt.wantWarning)
+			}
+		})
+	}
+}
+
 // writeVSCodeModelCache creates the smallest OpenCode-compatible model cache
 // needed to test Copilot label resolution and tool-call filtering.
 func writeVSCodeModelCache(t *testing.T, modelID, name string, toolCall bool) string {

--- a/internal/components/uninstall/service.go
+++ b/internal/components/uninstall/service.go
@@ -583,9 +583,13 @@ func (s *Service) componentOperations(adapter agents.Adapter, componentID model.
 		if adapter.SupportsSystemPrompt() {
 			path := adapter.SystemPromptFile(homeDir)
 			targets = append(targets, path)
-			ops = append(ops, rewriteMarkdownFile(path, func(content string) (string, bool) {
-				return removeMarkdownSections(content, "sdd-orchestrator", "strict-tdd-mode")
-			}))
+			if adapter.Agent() == model.AgentVSCodeCopilot {
+				ops = append(ops, restoreUserFileBackupOperation(path))
+			} else {
+				ops = append(ops, rewriteMarkdownFile(path, func(content string) (string, bool) {
+					return removeMarkdownSections(content, "sdd-orchestrator", "strict-tdd-mode")
+				}))
+			}
 		}
 		if adapter.SupportsSlashCommands() {
 			commandsDir := adapter.CommandsDir(homeDir)
@@ -704,7 +708,11 @@ func (s *Service) componentOperations(adapter agents.Adapter, componentID model.
 				}
 				path := filepath.Join(agentsDir, entry.Name())
 				targets = append(targets, path)
-				ops = append(ops, removeFile(path))
+				if adapter.Agent() == model.AgentVSCodeCopilot {
+					ops = append(ops, restoreUserFileBackupOperation(path))
+				} else {
+					ops = append(ops, removeFile(path))
+				}
 			}
 			ops = append(ops, removeDirIfEmpty(agentsDir))
 		}
@@ -1347,11 +1355,45 @@ func restoreClaudeVisibilityBackupOperation(homeDir string) operation {
 		typeID: opRewriteFile,
 		path:   filepath.Join(homeDir, ".claude", "agents"),
 		apply: func(path string) (bool, bool, error) {
-			err := sdd.RestoreManagedClaudeInternalAgentsForVSCode(homeDir)
+			restored, err := sdd.RestoreManagedClaudeInternalAgentsForVSCode(homeDir)
 			if err != nil {
 				return false, false, err
 			}
-			return true, false, nil
+			return restored, false, nil
+		},
+	}
+}
+
+func restoreUserFileBackupOperation(path string) operation {
+	return operation{
+		typeID: opRewriteFile,
+		path:   path,
+		apply: func(path string) (bool, bool, error) {
+			backupPath := path + ".backup"
+			if _, err := os.Stat(backupPath); err == nil {
+				content, err := os.ReadFile(backupPath)
+				if err != nil {
+					return false, false, fmt.Errorf("read backup %s: %w", backupPath, err)
+				}
+				if _, err := filemerge.WriteFileAtomic(path, content, 0o644); err != nil {
+					return false, false, fmt.Errorf("restore file %s from backup: %w", path, err)
+				}
+				_ = os.Remove(backupPath)
+				return true, false, nil
+			}
+
+			// If no backup exists, delete the file if it exists
+			_, statErr := os.Stat(path)
+			if statErr != nil {
+				if os.IsNotExist(statErr) {
+					return false, false, nil
+				}
+				return false, false, statErr
+			}
+			if err := removeFileIfExists(path); err != nil {
+				return false, false, err
+			}
+			return true, true, nil
 		},
 	}
 }

--- a/internal/components/uninstall/service.go
+++ b/internal/components/uninstall/service.go
@@ -2,6 +2,7 @@ package uninstall
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -1387,6 +1388,8 @@ func restoreUserFileBackupOperation(path string) operation {
 					return false, false, fmt.Errorf("remove backup file %s: %w", backupPath, err)
 				}
 				return true, false, nil
+			} else if !errors.Is(err, os.ErrNotExist) {
+				return false, false, fmt.Errorf("inspect backup %s: %w", backupPath, err)
 			}
 
 			// If no backup exists, check if it's still our managed content.
@@ -1399,16 +1402,17 @@ func restoreUserFileBackupOperation(path string) operation {
 				return false, false, statErr
 			}
 			content, readErr := os.ReadFile(path)
-			if readErr == nil {
-				contentStr := string(content)
-				isManaged := strings.Contains(contentStr, "sdd-orchestrator") ||
-					strings.Contains(contentStr, "strict-tdd-mode") ||
-					strings.Contains(contentStr, "trigger-rules") ||
-					strings.Contains(contentStr, "gentle-ai") ||
-					strings.Contains(contentStr, "managed")
-				if !isManaged {
-					return false, false, nil
-				}
+			if readErr != nil {
+				return false, false, fmt.Errorf("read file %s: %w", path, readErr)
+			}
+			contentStr := string(content)
+			isManaged := strings.Contains(contentStr, "sdd-orchestrator") ||
+				strings.Contains(contentStr, "strict-tdd-mode") ||
+				strings.Contains(contentStr, "trigger-rules") ||
+				strings.Contains(contentStr, "gentle-ai") ||
+				strings.Contains(contentStr, "managed")
+			if !isManaged {
+				return false, false, nil
 			}
 			if err := removeFileIfExists(path); err != nil {
 				return false, false, err

--- a/internal/components/uninstall/service.go
+++ b/internal/components/uninstall/service.go
@@ -578,6 +578,11 @@ func (s *Service) componentOperations(adapter agents.Adapter, componentID model.
 		}
 	case model.ComponentSDD:
 		if adapter.Agent() == model.AgentVSCodeCopilot {
+			claudeAgentsDir := filepath.Join(homeDir, ".claude", "agents")
+			for _, fileName := range sdd.ManagedClaudeInternalAgentFiles() {
+				targets = append(targets, filepath.Join(claudeAgentsDir, fileName))
+				targets = append(targets, filepath.Join(claudeAgentsDir, fileName+".backup"))
+			}
 			ops = append(ops, restoreClaudeVisibilityBackupOperation(homeDir))
 		}
 		if adapter.SupportsSystemPrompt() {

--- a/internal/components/uninstall/service.go
+++ b/internal/components/uninstall/service.go
@@ -577,6 +577,9 @@ func (s *Service) componentOperations(adapter agents.Adapter, componentID model.
 			ops = append(ops, removeTree(dirPath), removeDirIfEmpty(skillDir))
 		}
 	case model.ComponentSDD:
+		if adapter.Agent() == model.AgentVSCodeCopilot {
+			ops = append(ops, restoreClaudeVisibilityBackupOperation(homeDir))
+		}
 		if adapter.SupportsSystemPrompt() {
 			path := adapter.SystemPromptFile(homeDir)
 			targets = append(targets, path)
@@ -1337,4 +1340,18 @@ func updateStateAfterUninstall(homeDir string, toRemove []model.AgentID) ([]mode
 		return nil, fmt.Errorf("write install state: %w", err)
 	}
 	return removed, nil
+}
+
+func restoreClaudeVisibilityBackupOperation(homeDir string) operation {
+	return operation{
+		typeID: opRewriteFile,
+		path:   filepath.Join(homeDir, ".claude", "agents"),
+		apply: func(path string) (bool, bool, error) {
+			err := sdd.RestoreManagedClaudeInternalAgentsForVSCode(homeDir)
+			if err != nil {
+				return false, false, err
+			}
+			return true, false, nil
+		},
+	}
 }

--- a/internal/components/uninstall/service.go
+++ b/internal/components/uninstall/service.go
@@ -1378,17 +1378,32 @@ func restoreUserFileBackupOperation(path string) operation {
 				if _, err := filemerge.WriteFileAtomic(path, content, 0o644); err != nil {
 					return false, false, fmt.Errorf("restore file %s from backup: %w", path, err)
 				}
-				_ = os.Remove(backupPath)
+				if err := os.Remove(backupPath); err != nil {
+					return false, false, fmt.Errorf("remove backup file %s: %w", backupPath, err)
+				}
 				return true, false, nil
 			}
 
-			// If no backup exists, delete the file if it exists
+			// If no backup exists, check if it's still our managed content.
+			// If not, we skip deleting it (it's user-owned or already restored).
 			_, statErr := os.Stat(path)
 			if statErr != nil {
 				if os.IsNotExist(statErr) {
 					return false, false, nil
 				}
 				return false, false, statErr
+			}
+			content, readErr := os.ReadFile(path)
+			if readErr == nil {
+				contentStr := string(content)
+				isManaged := strings.Contains(contentStr, "sdd-orchestrator") ||
+					strings.Contains(contentStr, "strict-tdd-mode") ||
+					strings.Contains(contentStr, "trigger-rules") ||
+					strings.Contains(contentStr, "gentle-ai") ||
+					strings.Contains(contentStr, "managed")
+				if !isManaged {
+					return false, false, nil
+				}
 			}
 			if err := removeFileIfExists(path); err != nil {
 				return false, false, err

--- a/internal/components/uninstall/service_test.go
+++ b/internal/components/uninstall/service_test.go
@@ -1199,3 +1199,88 @@ func TestComponentOperationsSDD_CodexRemovesSkillRegistryHook(t *testing.T) {
 		t.Fatalf("unrelated hooks should be preserved:\n%s", text)
 	}
 }
+
+func TestComponentOperationsSDD_VSCodeRestoresUserBackups(t *testing.T) {
+	homeDir := t.TempDir()
+	workspaceDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(homeDir, ".config"))
+	t.Setenv("APPDATA", filepath.Join(homeDir, "AppData", "Roaming"))
+
+	svc, err := NewService(homeDir, workspaceDir, "dev")
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+
+	adapter, ok := svc.registry.Get(model.AgentVSCodeCopilot)
+	if !ok {
+		t.Fatal("vscode adapter not found in registry")
+	}
+
+	// 1. Setup a subagent file with a backup
+	agentsDir := adapter.SubAgentsDir(homeDir)
+	if err := os.MkdirAll(agentsDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(agents dir) error = %v", err)
+	}
+	agentPath := filepath.Join(agentsDir, "sdd-apply.agent.md")
+	backupPath := agentPath + ".backup"
+	originalContent := "user original content"
+	modifiedContent := "app modified content"
+	if err := os.WriteFile(agentPath, []byte(modifiedContent), 0o644); err != nil {
+		t.Fatalf("WriteFile error = %v", err)
+	}
+	if err := os.WriteFile(backupPath, []byte(originalContent), 0o644); err != nil {
+		t.Fatalf("WriteFile error = %v", err)
+	}
+
+	// 2. Setup system prompt file with a backup
+	promptPath := adapter.SystemPromptFile(homeDir)
+	if err := os.MkdirAll(filepath.Dir(promptPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(prompt dir) error = %v", err)
+	}
+	promptBackupPath := promptPath + ".backup"
+	originalPromptContent := "user original prompt"
+	modifiedPromptContent := "app modified prompt"
+	if err := os.WriteFile(promptPath, []byte(modifiedPromptContent), 0o644); err != nil {
+		t.Fatalf("WriteFile error = %v", err)
+	}
+	if err := os.WriteFile(promptBackupPath, []byte(originalPromptContent), 0o644); err != nil {
+		t.Fatalf("WriteFile error = %v", err)
+	}
+
+	ops, _, err := svc.componentOperations(adapter, model.ComponentSDD)
+	if err != nil {
+		t.Fatalf("componentOperations() error = %v", err)
+	}
+
+	for _, op := range ops {
+		if op.path == agentPath || op.path == promptPath {
+			if _, _, err := op.apply(op.path); err != nil {
+				t.Fatalf("op.apply(%q) error = %v", op.path, err)
+			}
+		}
+	}
+
+	// Verify both files were restored to original content and backups removed
+	gotAgent, err := os.ReadFile(agentPath)
+	if err != nil {
+		t.Fatalf("ReadFile(agent) error = %v", err)
+	}
+	if string(gotAgent) != originalContent {
+		t.Errorf("agent content = %q, want %q", string(gotAgent), originalContent)
+	}
+	if _, err := os.Stat(backupPath); !os.IsNotExist(err) {
+		t.Errorf("backup file %s should be removed", backupPath)
+	}
+
+	gotPrompt, err := os.ReadFile(promptPath)
+	if err != nil {
+		t.Fatalf("ReadFile(prompt) error = %v", err)
+	}
+	if string(gotPrompt) != originalPromptContent {
+		t.Errorf("prompt content = %q, want %q", string(gotPrompt), originalPromptContent)
+	}
+	if _, err := os.Stat(promptBackupPath); !os.IsNotExist(err) {
+		t.Errorf("prompt backup file %s should be removed", promptBackupPath)
+	}
+}
+

--- a/internal/components/uninstall/service_test.go
+++ b/internal/components/uninstall/service_test.go
@@ -726,7 +726,7 @@ func TestComponentOperationsSDD_VSCodeRemovesOnlyManagedAgentFiles(t *testing.T)
 		if op.path != agentsDir && !strings.HasPrefix(op.path, agentsDir+string(filepath.Separator)) {
 			continue
 		}
-		if op.typeID == opRemoveFile {
+		if op.typeID == opRemoveFile || op.typeID == opRewriteFile {
 			if _, _, err := op.apply(op.path); err != nil {
 				t.Fatalf("op.apply(%q) error = %v", op.path, err)
 			}

--- a/internal/components/uninstall/service_test.go
+++ b/internal/components/uninstall/service_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gentleman-programming/gentle-ai/internal/agents"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/codex"
+	"github.com/gentleman-programming/gentle-ai/internal/assets"
 	"github.com/gentleman-programming/gentle-ai/internal/backup"
 	"github.com/gentleman-programming/gentle-ai/internal/components/communitytool"
 	"github.com/gentleman-programming/gentle-ai/internal/components/engram"
@@ -672,6 +673,71 @@ func TestComponentOperationsSDD_ClaudeRemovesManagedCommandFiles(t *testing.T) {
 	}
 	if _, err := os.Stat(customPath); err != nil {
 		t.Fatalf("custom command should be preserved, stat err = %v", err)
+	}
+}
+
+func TestComponentOperationsSDD_VSCodeRemovesOnlyManagedAgentFiles(t *testing.T) {
+	homeDir := t.TempDir()
+	workspaceDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(homeDir, ".config"))
+	t.Setenv("APPDATA", filepath.Join(homeDir, "AppData", "Roaming"))
+
+	svc, err := NewService(homeDir, workspaceDir, "dev")
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+
+	adapter, ok := svc.registry.Get(model.AgentVSCodeCopilot)
+	if !ok {
+		t.Fatal("vscode adapter not found in registry")
+	}
+
+	agentsDir := adapter.SubAgentsDir(homeDir)
+	if err := os.MkdirAll(agentsDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(agents dir) error = %v", err)
+	}
+
+	entries, err := assets.FS.ReadDir("vscode/agents")
+	if err != nil {
+		t.Fatalf("ReadDir(vscode/agents) error = %v", err)
+	}
+	managedFiles := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		path := filepath.Join(agentsDir, entry.Name())
+		managedFiles = append(managedFiles, path)
+		if err := os.WriteFile(path, []byte("managed"), 0o644); err != nil {
+			t.Fatalf("WriteFile(%s) error = %v", entry.Name(), err)
+		}
+	}
+
+	customPath := filepath.Join(agentsDir, "custom.agent.md")
+	if err := os.WriteFile(customPath, []byte("user authored"), 0o644); err != nil {
+		t.Fatalf("WriteFile(custom.agent.md) error = %v", err)
+	}
+
+	ops, _, err := svc.componentOperations(adapter, model.ComponentSDD)
+	if err != nil {
+		t.Fatalf("componentOperations() error = %v", err)
+	}
+	for _, op := range ops {
+		if op.path != agentsDir && !strings.HasPrefix(op.path, agentsDir+string(filepath.Separator)) {
+			continue
+		}
+		if _, _, err := op.apply(op.path); err != nil {
+			t.Fatalf("op.apply(%q) error = %v", op.path, err)
+		}
+	}
+
+	for _, path := range managedFiles {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("managed VS Code agent %q should be removed; stat err = %v", path, err)
+		}
+	}
+	if _, err := os.Stat(customPath); err != nil {
+		t.Fatalf("custom VS Code agent should be preserved, stat err = %v", err)
 	}
 }
 

--- a/internal/components/uninstall/service_test.go
+++ b/internal/components/uninstall/service_test.go
@@ -726,8 +726,10 @@ func TestComponentOperationsSDD_VSCodeRemovesOnlyManagedAgentFiles(t *testing.T)
 		if op.path != agentsDir && !strings.HasPrefix(op.path, agentsDir+string(filepath.Separator)) {
 			continue
 		}
-		if _, _, err := op.apply(op.path); err != nil {
-			t.Fatalf("op.apply(%q) error = %v", op.path, err)
+		if op.typeID == opRemoveFile {
+			if _, _, err := op.apply(op.path); err != nil {
+				t.Fatalf("op.apply(%q) error = %v", op.path, err)
+			}
 		}
 	}
 

--- a/internal/model/selection.go
+++ b/internal/model/selection.go
@@ -11,6 +11,7 @@ type Selection struct {
 	StrictTDD                        bool
 	CodexMultiAgent                  bool                             // deprecated: Codex now always writes features.multi_agent = true; retained for state/back-compat
 	ModelAssignments                 map[string]ModelAssignment       // key = sub-agent name (e.g., "sdd-init")
+	VSCodeModelAssignments           map[string]ModelAssignment       // key = VS Code agent name (e.g., "sdd-apply")
 	ClaudeModelAssignments           map[string]ClaudeModelAlias      // key = phase name; value = fable|opus|sonnet|haiku
 	ClaudePhaseAssignments           map[string]ClaudePhaseAssignment // key = phase name; value = Claude model+effort
 	KiroModelAssignments             map[string]KiroModelAlias        // key = phase name; value = Kiro-native model alias
@@ -65,6 +66,7 @@ type SyncOverrides struct {
 	// model/profile configurators, where the user picked a concrete target agent.
 	TargetAgents                     []AgentID
 	ModelAssignments                 map[string]ModelAssignment       // nil = no override; empty map = reset to defaults
+	VSCodeModelAssignments           map[string]ModelAssignment       // nil = no override; empty map = reset to defaults
 	ClaudeModelAssignments           map[string]ClaudeModelAlias      // nil = no override; empty map = reset to defaults
 	ClaudePhaseAssignments           map[string]ClaudePhaseAssignment // nil = no override; empty map = reset to defaults
 	KiroModelAssignments             map[string]KiroModelAlias        // nil = no override; empty map = reset to defaults

--- a/internal/model/selection_test.go
+++ b/internal/model/selection_test.go
@@ -69,3 +69,24 @@ func TestSyncOverridesCodexModelPreset(t *testing.T) {
 		t.Fatal("SyncOverrides.CodexModelAssignments should be non-nil after assignment")
 	}
 }
+
+func TestSelectionAndSyncOverridesHaveVSCodeModelAssignments(t *testing.T) {
+	assignment := ModelAssignment{ProviderID: "github-copilot", ModelID: "gpt-4.1"}
+
+	selection := Selection{
+		ModelAssignments:       map[string]ModelAssignment{"sdd-apply": {ProviderID: "anthropic", ModelID: "claude-opus-4"}},
+		VSCodeModelAssignments: map[string]ModelAssignment{"sdd-apply": assignment},
+	}
+
+	if got := selection.VSCodeModelAssignments["sdd-apply"]; got != assignment {
+		t.Fatalf("Selection.VSCodeModelAssignments[sdd-apply] = %+v, want %+v", got, assignment)
+	}
+	if got := selection.ModelAssignments["sdd-apply"].ProviderID; got != "anthropic" {
+		t.Fatalf("Selection.ModelAssignments was affected by VS Code assignments: provider = %q", got)
+	}
+
+	overrides := SyncOverrides{VSCodeModelAssignments: map[string]ModelAssignment{"sdd-verify": assignment}}
+	if got := overrides.VSCodeModelAssignments["sdd-verify"]; got != assignment {
+		t.Fatalf("SyncOverrides.VSCodeModelAssignments[sdd-verify] = %+v, want %+v", got, assignment)
+	}
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -92,6 +92,9 @@ type InstallState struct {
 	// ModelAssignments maps sub-agent names to provider/model pairs (OpenCode).
 	ModelAssignments map[string]ModelAssignmentState `json:"model_assignments,omitempty"`
 
+	// VSCodeModelAssignments maps VS Code Copilot native agent names to provider/model pairs.
+	VSCodeModelAssignments map[string]ModelAssignmentState `json:"vscode_model_assignments,omitempty"`
+
 	// Persona records the persona the user installed ("gentleman", "neutral",
 	// "custom"). Persisted so that `gentle-ai sync` regenerates the same persona
 	// the user originally chose instead of defaulting to Gentleman every time.
@@ -188,6 +191,7 @@ func MergeAgents(existing InstallState, newAgents []string) InstallState {
 		CommunityTools:              existing.CommunityTools,
 		CommunityToolsConfigured:    existing.CommunityToolsConfigured,
 		ModelAssignments:            existing.ModelAssignments,
+		VSCodeModelAssignments:      existing.VSCodeModelAssignments,
 		ClaudeModelAssignments:      existing.ClaudeModelAssignments,
 		ClaudePhaseAssignments:      existing.ClaudePhaseAssignments,
 		KiroModelAssignments:        existing.KiroModelAssignments,

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -17,6 +17,9 @@ func TestMergeAgents(t *testing.T) {
 	existingAssignments := map[string]ModelAssignmentState{
 		"sdd-init": {ProviderID: "anthropic", ModelID: "claude-sonnet-4"},
 	}
+	existingVSCode := map[string]ModelAssignmentState{
+		"sdd-apply": {ProviderID: "github-copilot", ModelID: "gpt-4.1"},
+	}
 	existingClaude := map[string]string{"sdd-explore": "sonnet", "sdd-archive": "haiku"}
 	existingKiro := map[string]string{"sdd-design": "opus"}
 	existingCommunityTools := []string{"codegraph"}
@@ -58,6 +61,7 @@ func TestMergeAgents(t *testing.T) {
 				CommunityTools:           existingCommunityTools,
 				CommunityToolsConfigured: true,
 				ModelAssignments:         existingAssignments,
+				VSCodeModelAssignments:   existingVSCode,
 				ClaudeModelAssignments:   existingClaude,
 				KiroModelAssignments:     existingKiro,
 				Persona:                  "gentleman",
@@ -78,6 +82,9 @@ func TestMergeAgents(t *testing.T) {
 			// Verify all preserved fields are unchanged.
 			if !reflect.DeepEqual(got.ModelAssignments, tt.existing.ModelAssignments) {
 				t.Errorf("ModelAssignments not preserved: got %v, want %v", got.ModelAssignments, tt.existing.ModelAssignments)
+			}
+			if !reflect.DeepEqual(got.VSCodeModelAssignments, tt.existing.VSCodeModelAssignments) {
+				t.Errorf("VSCodeModelAssignments not preserved: got %v, want %v", got.VSCodeModelAssignments, tt.existing.VSCodeModelAssignments)
 			}
 			if !reflect.DeepEqual(got.ClaudeModelAssignments, tt.existing.ClaudeModelAssignments) {
 				t.Errorf("ClaudeModelAssignments not preserved: got %v, want %v", got.ClaudeModelAssignments, tt.existing.ClaudeModelAssignments)
@@ -342,6 +349,9 @@ func TestModelAssignmentsRoundTrip(t *testing.T) {
 		ModelAssignments: map[string]ModelAssignmentState{
 			"sdd-init": {ProviderID: "anthropic", ModelID: "claude-sonnet-4"},
 		},
+		VSCodeModelAssignments: map[string]ModelAssignmentState{
+			"sdd-apply": {ProviderID: "github-copilot", ModelID: "gpt-4.1"},
+		},
 	}
 
 	if err := Write(home, want); err != nil {
@@ -361,6 +371,9 @@ func TestModelAssignmentsRoundTrip(t *testing.T) {
 	}
 	if !reflect.DeepEqual(got.ModelAssignments, want.ModelAssignments) {
 		t.Errorf("ModelAssignments = %v, want %v", got.ModelAssignments, want.ModelAssignments)
+	}
+	if !reflect.DeepEqual(got.VSCodeModelAssignments, want.VSCodeModelAssignments) {
+		t.Errorf("VSCodeModelAssignments = %v, want %v", got.VSCodeModelAssignments, want.VSCodeModelAssignments)
 	}
 }
 
@@ -467,6 +480,9 @@ func TestBackwardCompatNoAssignments(t *testing.T) {
 	}
 	if s.ModelAssignments != nil {
 		t.Errorf("ModelAssignments = %v, want nil", s.ModelAssignments)
+	}
+	if s.VSCodeModelAssignments != nil {
+		t.Errorf("VSCodeModelAssignments = %v, want nil", s.VSCodeModelAssignments)
 	}
 }
 

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -662,6 +662,7 @@ func NewModel(detection system.DetectionResult, version string, installState ...
 		ClaudePhaseAssignments: installStateClaudePhaseAssignments(s.ClaudePhaseAssignments),
 		KiroModelAssignments:   installStateKiroAssignments(s.KiroModelAssignments),
 		ModelAssignments:       installStateModelAssignments(s.ModelAssignments),
+		VSCodeModelAssignments: installStateModelAssignmentsToModel(s.VSCodeModelAssignments),
 	}
 
 	return Model{

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -6576,6 +6576,7 @@ func TestUpdatePromptScreen_UpdateNow_NoDuplicateUpgrade(t *testing.T) {
 	}
 }
 
+<<<<<<< HEAD
 // ─── Unit 1+2: pickerFlowSlice, pickerNextScreen, pickerPreviousScreen ──────
 
 // withModelCache returns a cleanup function that installs a fake osStatModelCache
@@ -7413,6 +7414,21 @@ func TestStrictTDDForward(t *testing.T) {
 				t.Fatalf("screen = %v, want %v", got.Screen, tt.wantScreen)
 			}
 		})
+}
+
+func TestCodexAndVSCodeCopilotPresetFlowTransitionsToVSCodePickerAfterCodex(t *testing.T) {
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Screen = ScreenCodexModelPicker
+	m.Selection.Agents = []model.AgentID{model.AgentCodex, model.AgentVSCodeCopilot}
+	m.Selection.Components = []model.ComponentID{model.ComponentEngram, model.ComponentSDD}
+	m.CodexModelPicker = screens.NewCodexModelPickerState()
+	m.Cursor = 1 // Select a preset in the Codex picker (Recommended)
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	state := updated.(Model)
+
+	if state.Screen != ScreenModelPicker {
+		t.Fatalf("screen = %v, want ScreenModelPicker (VS Code model picker) after Codex model picker confirmation", state.Screen)
 	}
 }
 

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -7430,6 +7430,9 @@ func TestCodexAndVSCodeCopilotPresetFlowTransitionsToVSCodePickerAfterCodex(t *t
 	if state.Screen != ScreenModelPicker {
 		t.Fatalf("screen = %v, want ScreenModelPicker (VS Code model picker) after Codex model picker confirmation", state.Screen)
 	}
+	if !state.ModelPicker.ForVSCode {
+		t.Fatalf("ModelPicker.ForVSCode = false, want true after Codex model picker confirmation")
+	}
 }
 
 func TestCodexModelPickerCustomConfirmSignalsOrchestratorClear(t *testing.T) {

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -6576,7 +6576,6 @@ func TestUpdatePromptScreen_UpdateNow_NoDuplicateUpgrade(t *testing.T) {
 	}
 }
 
-<<<<<<< HEAD
 // ─── Unit 1+2: pickerFlowSlice, pickerNextScreen, pickerPreviousScreen ──────
 
 // withModelCache returns a cleanup function that installs a fake osStatModelCache

--- a/testdata/golden/sdd-claude-agent-sdd-apply.golden
+++ b/testdata/golden/sdd-claude-agent-sdd-apply.golden
@@ -5,6 +5,7 @@ description: >
   should begin. Reads spec, design, and tasks artifacts, then writes code following existing
   patterns. Marks tasks complete as it goes.
 model: sonnet
+user-invocable: false
 tools: Read, Edit, Write, Glob, Grep, Bash, mcp__plugin_engram_engram__mem_search, mcp__plugin_engram_engram__mem_get_observation, mcp__plugin_engram_engram__mem_save, mcp__plugin_engram_engram__mem_update
 ---
 

--- a/testdata/golden/sdd-claude-agent-sdd-archive.golden
+++ b/testdata/golden/sdd-claude-agent-sdd-archive.golden
@@ -5,6 +5,7 @@ description: >
   needs to be closed — merges delta specs into main specs, moves change folder to archive,
   and persists the final archive report. Completes the SDD cycle.
 model: haiku
+user-invocable: false
 tools: Read, Edit, Write, Glob, mcp__plugin_engram_engram__mem_search, mcp__plugin_engram_engram__mem_get_observation, mcp__plugin_engram_engram__mem_save
 ---
 

--- a/testdata/golden/sdd-claude-agent-sdd-design.golden
+++ b/testdata/golden/sdd-claude-agent-sdd-design.golden
@@ -5,6 +5,7 @@ description: >
   proposal is approved and the implementation approach needs to be chosen before tasks are
   broken down.
 model: opus
+user-invocable: false
 tools: Read, Edit, Write, Grep, Glob, mcp__plugin_engram_engram__mem_search, mcp__plugin_engram_engram__mem_get_observation, mcp__plugin_engram_engram__mem_save
 ---
 

--- a/testdata/golden/sdd-claude-agent-sdd-explore.golden
+++ b/testdata/golden/sdd-claude-agent-sdd-explore.golden
@@ -5,6 +5,7 @@ description: >
   a feature, investigate the codebase, understand current architecture, compare approaches, or
   clarify requirements — before any proposal or spec is written.
 model: sonnet
+user-invocable: false
 tools: Read, Grep, Glob, WebFetch, WebSearch, mcp__plugin_engram_engram__mem_save
 ---
 

--- a/testdata/golden/sdd-claude-agent-sdd-propose.golden
+++ b/testdata/golden/sdd-claude-agent-sdd-propose.golden
@@ -4,6 +4,7 @@ description: >
   Create a change proposal with intent, scope, and approach. Use when exploration is complete
   and the idea is ready to be formalized into a proposal document.
 model: opus
+user-invocable: false
 tools: Read, Edit, Write, Grep, Glob, mcp__plugin_engram_engram__mem_search, mcp__plugin_engram_engram__mem_get_observation, mcp__plugin_engram_engram__mem_save
 ---
 

--- a/testdata/golden/sdd-claude-agent-sdd-spec.golden
+++ b/testdata/golden/sdd-claude-agent-sdd-spec.golden
@@ -4,6 +4,7 @@ description: >
   Write specifications with requirements and scenarios. Use when a proposal is approved and the
   change needs formal requirements (delta specs) captured before implementation.
 model: sonnet
+user-invocable: false
 tools: Read, Edit, Write, Grep, Glob, mcp__plugin_engram_engram__mem_search, mcp__plugin_engram_engram__mem_get_observation, mcp__plugin_engram_engram__mem_save
 ---
 

--- a/testdata/golden/sdd-claude-agent-sdd-tasks.golden
+++ b/testdata/golden/sdd-claude-agent-sdd-tasks.golden
@@ -4,6 +4,7 @@ description: >
   Break down a change into an implementation task checklist. Use when spec and design are both
   ready and the change needs to be sliced into actionable, ordered work items.
 model: sonnet
+user-invocable: false
 tools: Read, Edit, Write, Grep, Glob, mcp__plugin_engram_engram__mem_search, mcp__plugin_engram_engram__mem_get_observation, mcp__plugin_engram_engram__mem_save
 ---
 

--- a/testdata/golden/sdd-claude-agent-sdd-verify.golden
+++ b/testdata/golden/sdd-claude-agent-sdd-verify.golden
@@ -4,6 +4,7 @@ description: >
   Validate that implementation matches specs, design, and tasks. Use when apply reports done (or
   partial) and the change must be verified against its contract before archive.
 model: sonnet
+user-invocable: false
 tools: Read, Grep, Glob, Bash, mcp__plugin_engram_engram__mem_search, mcp__plugin_engram_engram__mem_get_observation, mcp__plugin_engram_engram__mem_save
 ---
 

--- a/testdata/golden/sdd-vscode-instructions.golden
+++ b/testdata/golden/sdd-vscode-instructions.golden
@@ -430,6 +430,10 @@ Convention files under the agent's global skills directory (global) or `.agent/s
 - `engram` → `mem_search(...)` → `mem_get_observation(...)`
 - `openspec` → read `openspec/changes/*/state.yaml`
 - `none` → state not persisted — explain to user
+
+### VS Code Copilot Support Layers
+
+Gentle AI installs three VS Code support layers: global instructions/rules at `Code/User/prompts/gentle-ai.instructions.md`, native custom agents in `~/.copilot/agents`, and SDD skills plus shared conventions in `~/.copilot/skills`.
 <!-- /gentle-ai:sdd-orchestrator -->
 
 <!-- gentle-ai:trigger-rules -->


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #504

Depends on: #731
Related context: #708

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 🔗 Chain Context

PR 3 of the VS Code Copilot SDD subagents stack.

```text
#708 PR1 native VS Code `.agent.md` agents
   ↓
#731 PR2 VS Code model assignment foundation
   ↓
📍 PR3 VS Code Copilot agent install hardening
   ↓
#740 PR4 TUI + docs final
```

This PR depends on #731. Because the stack is currently opened from a contributor fork and upstream dependency branches are not available as base branches, this PR targets `main`; reviewers should use the focused diff below for this work unit.

Focused review diff:
https://github.com/Snakeblack/gentle-ai/compare/feat/vscode-copilot-subagents-pr2...fix/vscode-copilot-agent-hardening

---

## 📝 Summary

- Hardens VS Code Copilot agent installation on Windows by using a replace-existing atomic file replacement path.
- Keeps only the user-facing `sdd-orchestrator` visible in VS Code while preserving internal phase agents for delegation.
- Strips stale `model:` frontmatter when VS Code model assignments are missing or invalid, and updates SDD golden fixtures.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/components/filemerge` | Adds platform-specific atomic replacement, using `MoveFileEx` on Windows |
| `internal/components/sdd` | Hides managed internal agents and strips stale VS Code model frontmatter safely |
| `internal/assets/claude/agents` | Marks managed internal SDD/JD agents as not user-invocable |
| `testdata/golden` | Updates expected SDD agent and VS Code instructions output |
| Tests | Adds regression coverage for Windows replacement, VS Code visibility, and model cleanup contracts |

---

## 🧠 Size Exception Rationale

This PR requests `size:exception`.

The focused hardening diff is slightly above the 400-line budget because the installer fix, visibility contract, stale model cleanup, and golden fixtures must be reviewed together. Splitting them would hide the important invariant: VS Code should expose only the orchestrator to users while internal agents remain available for delegation and safe sync.

---

## 🧪 Test Plan

**Linux/LF full suite**
```bash
go test ./...
go vet ./...
```

**Focused golden/contract checks**
```bash
go test ./internal/components -run "TestGoldenSDD_(Claude|VSCode)$" -count=1
git diff --check
```

Results:
- [x] Unit tests pass (`go test ./...`) in Linux/LF verification clone
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Manually tested locally — VS Code install completed after closing VS Code and rerunning the rebuilt local binary

Note: local Windows full-suite runs still have known CRLF/env-sensitive golden noise unrelated to this PR. Final validation was done in a clean Linux/LF runner.

---

## 🤖 Automated Checks

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⚠️ | Requests `size:exception`; focused work unit is cohesive |
| Check Issue Reference | ⏳ | PR body contains `Closes #504` |
| Check Issue Has `status:approved` | ⏳ | #504 has `status:approved` |
| Check PR Has `type:*` Label | ⏳ | `type:bug` requested; maintainer label needed |
| Unit Tests | ⏳ | CI should run `go test ./...` |
| E2E Tests | ⏳ | CI should run Docker E2E if configured |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [ ] I have added the appropriate `type:*` label to this PR — maintainer label needed (`type:bug`)
- [x] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

The key review contract is VS Code visibility: the native dropdown should expose `sdd-orchestrator` only. Phase agents are intentionally hidden from users but still available for orchestration/delegation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added full VS Code Copilot SDD native agents (coordinator + phase executors) with structured result contracts.
  * Added VS Code Copilot model assignment support with validation and persistence.
  * Improved VS Code integration to support embedded sub-agents.

* **Improvements**
  * Install/sync now preserves VS Code model assignments and surfaces non-fatal sync warnings.
  * Managed Claude internal agents are hidden from the VS Code picker and restored on uninstall.

* **Documentation**
  * Expanded Copilot/VS Code agent layering and model-assignment behavior docs.

* **Tests**
  * Expanded coverage for assignments, visibility, warnings, uninstall restoration, and VS Code integration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->