### PR TITLE
feat(system): add android support and improve temp dir handling

### DIFF
--- a/internal/installcmd/resolver.go
+++ b/internal/installcmd/resolver.go
@@ -174,6 +174,8 @@ func (profileResolver) ResolveDependencyInstall(profile system.PlatformProfile, 
 		return CommandSequence{{"sudo", "dnf", "install", "-y", dependency}}, nil
 	case "winget":
 		return CommandSequence{{"winget", "install", "--id", dependency, "-e", "--accept-source-agreements", "--accept-package-agreements"}}, nil
+	case "pkg":
+		return CommandSequence{{"pkg", "install", "-y", dependency}}, nil
 	default:
 		return nil, fmt.Errorf(
 			"unsupported package manager %q for os=%q distro=%q",
@@ -194,7 +196,7 @@ func resolveOpenCodeInstall(profile system.PlatformProfile) (CommandSequence, er
 		return CommandSequence{
 			{"brew", "install", "anomalyco/tap/opencode"},
 		}, nil
-	case "apt", "pacman", "dnf":
+	case "apt", "pacman", "dnf", "pkg":
 		pkg := "opencode-ai@" + versions.OpenCode
 		if profile.NpmWritable {
 			return CommandSequence{{"npm", "install", "-g", "--ignore-scripts", pkg}}, nil
@@ -221,8 +223,8 @@ func resolveGGAInstall(profile system.PlatformProfile) (CommandSequence, error) 
 			{"brew", "tap", "Gentleman-Programming/homebrew-tap"},
 			{"brew", "reinstall", "gga"},
 		}, nil
-	case "apt", "pacman", "dnf":
-		const tmpDir = "/tmp/gentleman-guardian-angel"
+	case "apt", "pacman", "dnf", "pkg":
+		tmpDir := filepath.Join(os.TempDir(), "gentleman-guardian-angel")
 		return CommandSequence{
 			{"rm", "-rf", tmpDir},
 			{"git", "clone", "https://github.com/Gentleman-Programming/gentleman-guardian-angel.git", tmpDir},

--- a/internal/system/detect.go
+++ b/internal/system/detect.go
@@ -41,7 +41,7 @@ type DetectionResult struct {
 }
 
 func IsSupportedOS(goos string) bool {
-	return goos == "darwin" || goos == "linux" || goos == "windows"
+	return goos == "darwin" || goos == "linux" || goos == "windows" || goos == "android"
 }
 
 func Detect(ctx context.Context) (DetectionResult, error) {
@@ -156,6 +156,10 @@ func resolvePlatformProfile(goos, linuxOSRelease string, tools map[string]ToolSt
 		return profile
 	case "windows":
 		profile.PackageManager = "winget"
+		profile.Supported = true
+		return profile
+	case "android":
+		profile.PackageManager = "pkg"
 		profile.Supported = true
 		return profile
 	default:


### PR DESCRIPTION
## Context
Currently, Gentle AI assumes standard Unix paths (like `/tmp`) and doesn't recognize `android` as a supported OS, making it impossible to run on environments like Termux.

## Changes
- **OS Support**: Added `android` to the supported OS list in `internal/system/detect.go`.
- **Package Manager**: Mapped `android` to use `pkg` (Termux default) in the platform resolver.
- **Portability**: Refactored fixed `/tmp` paths to use `os.TempDir()` in `internal/installcmd/resolver.go`.

## Impact & Compatibility
- **Zero breaking changes**: All additions are scoped to the new `android` detection.
- **Improved Robustness**: Switching to `os.TempDir()` benefits all systems by respecting environment-specific temporary directories instead of hardcoding `/tmp`.

## Verification
- Verified on Android via Termux.
- Code remains idiomatic and follows existing patterns.