### PR TITLE
feat(mcp): inject Context7 into Codex config.toml

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -137,6 +137,7 @@ Kiro uses native custom agents in `~/.kiro/agents/`. `gentle-ai` writes phase ag
 - Skills at `~/.codex/skills/`
 - System prompt at `~/.codex/AGENTS.md`
 - Engram instruction files at `~/.codex/engram-instructions.md`
+- MCP servers (Engram and Context7) are upserted as `[mcp_servers.<name>]` blocks in `~/.codex/config.toml`
 
 ### Windsurf
 

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1015,8 +1015,9 @@ func componentPathsWithWorkspaceScoped(homeDir, workspaceDir string, scope Insta
 					paths = append(paths, p)
 				}
 			case model.StrategyTOMLFile:
-				// Codex uses TOML for Engram but Context7 is not injected via TOML.
-				// No path to report — Context7 injection is skipped for TOML agents.
+				if p := adapter.MCPConfigPath(homeDir, "context7"); p != "" {
+					paths = append(paths, p)
+				}
 			}
 		case model.ComponentPersona:
 			if selection.Persona == model.PersonaCustom {

--- a/internal/components/filemerge/toml.go
+++ b/internal/components/filemerge/toml.go
@@ -54,6 +54,60 @@ func UpsertCodexEngramBlock(content, engramCmd string) string {
 	return base + "\n\n" + codexEngramBlock + "\n"
 }
 
+// UpsertCodexMCPServerBlock removes any existing [mcp_servers.<serverID>] block
+// from the given TOML content and appends a fresh block with the provided
+// command and args. This is a generalized helper for any stdio MCP server that
+// Codex hosts via its config.toml. Backslashes in command and args are escaped
+// for TOML double-quoted strings (Windows paths).
+//
+// This is a string-based helper (no TOML parser dependency) following the same
+// pattern as UpsertCodexEngramBlock.
+func UpsertCodexMCPServerBlock(content, serverID, command string, args []string) string {
+	header := "[mcp_servers." + serverID + "]"
+
+	escapedCmd := strings.ReplaceAll(command, `\`, `\\`)
+
+	// Build TOML args array: args = ["-y", "--package=...", "--", "context7-mcp"]
+	var quotedArgs []string
+	for _, arg := range args {
+		escaped := strings.ReplaceAll(arg, `\`, `\\`)
+		quotedArgs = append(quotedArgs, `"`+escaped+`"`)
+	}
+	argsLine := "args = [" + strings.Join(quotedArgs, ", ") + "]"
+
+	block := header + "\ncommand = \"" + escapedCmd + "\"\n" + argsLine
+
+	content = strings.ReplaceAll(content, "\r\n", "\n")
+	lines := strings.Split(content, "\n")
+
+	var kept []string
+	for i := 0; i < len(lines); {
+		trimmed := strings.TrimSpace(lines[i])
+		if trimmed == header {
+			// Skip the old block header and all its key-value lines.
+			i++
+			for i < len(lines) {
+				next := strings.TrimSpace(lines[i])
+				if strings.HasPrefix(next, "[") && strings.HasSuffix(next, "]") {
+					break
+				}
+				i++
+			}
+			continue
+		}
+
+		kept = append(kept, lines[i])
+		i++
+	}
+
+	base := strings.TrimSpace(strings.Join(kept, "\n"))
+	if base == "" {
+		return block + "\n"
+	}
+
+	return base + "\n\n" + block + "\n"
+}
+
 // UpsertTopLevelTOMLString inserts or replaces a top-level key = "value" pair
 // in TOML content. The key is placed before the first [section] header so it
 // remains a top-level (non-table) setting. Existing occurrences of the key are

--- a/internal/components/filemerge/toml_test.go
+++ b/internal/components/filemerge/toml_test.go
@@ -182,7 +182,7 @@ func TestUpsertCodexMCPServerBlock_Empty(t *testing.T) {
 	if !strings.Contains(result, `command = "npx"`) {
 		t.Fatalf("result missing command = \"npx\"; got:\n%s", result)
 	}
-	if !strings.Contains(result, `"@upstash/context7-mcp@2.2.5"`) {
+	if !strings.Contains(result, `"--package=@upstash/context7-mcp@2.2.5"`) {
 		t.Fatalf("result missing pinned version arg; got:\n%s", result)
 	}
 	if !strings.HasSuffix(result, "\n") {

--- a/internal/components/filemerge/toml_test.go
+++ b/internal/components/filemerge/toml_test.go
@@ -170,3 +170,108 @@ command = "engram"
 		t.Fatalf("UpsertTopLevelTOMLString is not idempotent:\nfirst:\n%s\nsecond:\n%s", first, second)
 	}
 }
+
+// ─── UpsertCodexMCPServerBlock ────────────────────────────────────────────────
+
+func TestUpsertCodexMCPServerBlock_Empty(t *testing.T) {
+	result := UpsertCodexMCPServerBlock("", "context7", "npx", []string{"-y", "--package=@upstash/context7-mcp@2.2.5", "--", "context7-mcp"})
+
+	if !strings.Contains(result, "[mcp_servers.context7]") {
+		t.Fatalf("result missing [mcp_servers.context7]; got:\n%s", result)
+	}
+	if !strings.Contains(result, `command = "npx"`) {
+		t.Fatalf("result missing command = \"npx\"; got:\n%s", result)
+	}
+	if !strings.Contains(result, `"@upstash/context7-mcp@2.2.5"`) {
+		t.Fatalf("result missing pinned version arg; got:\n%s", result)
+	}
+	if !strings.HasSuffix(result, "\n") {
+		t.Fatalf("result does not end with newline; got:\n%q", result)
+	}
+}
+
+func TestUpsertCodexMCPServerBlock_ReplacesExisting(t *testing.T) {
+	input := `[other_section]
+key = "value"
+
+[mcp_servers.context7]
+command = "npx"
+args = ["-y", "@upstash/context7-mcp@1.0.0"]
+
+[another_section]
+foo = "bar"
+`
+	result := UpsertCodexMCPServerBlock(input, "context7", "npx", []string{"-y", "--package=@upstash/context7-mcp@2.2.5", "--", "context7-mcp"})
+
+	count := strings.Count(result, "[mcp_servers.context7]")
+	if count != 1 {
+		t.Fatalf("expected 1 [mcp_servers.context7] block, got %d; result:\n%s", count, result)
+	}
+
+	if strings.Contains(result, "@upstash/context7-mcp@1.0.0") {
+		t.Fatalf("result still contains stale args; got:\n%s", result)
+	}
+	if !strings.Contains(result, "[other_section]") {
+		t.Fatalf("result missing [other_section]; got:\n%s", result)
+	}
+	if !strings.Contains(result, "[another_section]") {
+		t.Fatalf("result missing [another_section]; got:\n%s", result)
+	}
+}
+
+func TestUpsertCodexMCPServerBlock_Idempotent(t *testing.T) {
+	input := `[other]
+key = "val"
+`
+	args := []string{"-y", "--package=@upstash/context7-mcp@2.2.5", "--", "context7-mcp"}
+	first := UpsertCodexMCPServerBlock(input, "context7", "npx", args)
+	second := UpsertCodexMCPServerBlock(first, "context7", "npx", args)
+
+	if first != second {
+		t.Fatalf("UpsertCodexMCPServerBlock is not idempotent:\nfirst:\n%s\nsecond:\n%s", first, second)
+	}
+
+	count := strings.Count(second, "[mcp_servers.context7]")
+	if count != 1 {
+		t.Fatalf("after two runs: expected 1 [mcp_servers.context7] block, got %d; result:\n%s", count, second)
+	}
+}
+
+func TestUpsertCodexMCPServerBlock_PreservesEngramBlock(t *testing.T) {
+	input := `[mcp_servers.engram]
+command = "engram"
+args = ["mcp", "--tools=agent"]
+`
+	result := UpsertCodexMCPServerBlock(input, "context7", "npx", []string{"-y", "--package=@upstash/context7-mcp@2.2.5", "--", "context7-mcp"})
+
+	if !strings.Contains(result, "[mcp_servers.engram]") {
+		t.Fatalf("result missing [mcp_servers.engram] after context7 upsert; got:\n%s", result)
+	}
+	if !strings.Contains(result, `command = "engram"`) {
+		t.Fatalf("result missing engram command after context7 upsert; got:\n%s", result)
+	}
+	if !strings.Contains(result, "[mcp_servers.context7]") {
+		t.Fatalf("result missing [mcp_servers.context7]; got:\n%s", result)
+	}
+
+	engramCount := strings.Count(result, "[mcp_servers.engram]")
+	if engramCount != 1 {
+		t.Fatalf("expected 1 [mcp_servers.engram] block, got %d; result:\n%s", engramCount, result)
+	}
+}
+
+func TestUpsertCodexMCPServerBlock_EscapesBackslashes(t *testing.T) {
+	// Windows-style path in command must have backslashes doubled in TOML double-quoted strings.
+	winCmd := `C:\Users\PERC\AppData\Roaming\npm\npx.cmd`
+	result := UpsertCodexMCPServerBlock("", "context7", winCmd, []string{`C:\some\arg\path`})
+
+	wantCmd := `command = "C:\\Users\\PERC\\AppData\\Roaming\\npm\\npx.cmd"`
+	if !strings.Contains(result, wantCmd) {
+		t.Fatalf("result missing properly escaped Windows command;\nwant substring: %s\ngot:\n%s", wantCmd, result)
+	}
+
+	wantArg := `"C:\\some\\arg\\path"`
+	if !strings.Contains(result, wantArg) {
+		t.Fatalf("result missing properly escaped Windows arg;\nwant substring: %s\ngot:\n%s", wantArg, result)
+	}
+}

--- a/internal/components/mcp/inject.go
+++ b/internal/components/mcp/inject.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gentleman-programming/gentle-ai/internal/agents"
 	"github.com/gentleman-programming/gentle-ai/internal/components/filemerge"
 	"github.com/gentleman-programming/gentle-ai/internal/model"
+	"github.com/gentleman-programming/gentle-ai/internal/versions"
 )
 
 type InjectionResult struct {
@@ -28,12 +29,37 @@ func Inject(homeDir string, adapter agents.Adapter) (InjectionResult, error) {
 	case model.StrategyMCPConfigFile:
 		return injectMCPConfigFile(homeDir, adapter)
 	case model.StrategyTOMLFile:
-		// Context7 injection is not supported for TOML-based agents (Codex).
-		// Codex receives Context7 through its agents.md system prompt, not via MCP config.
-		return InjectionResult{}, nil
+		return injectTOMLFile(homeDir, adapter)
 	default:
 		return InjectionResult{}, fmt.Errorf("mcp injector does not support MCP strategy %d for agent %q", adapter.MCPStrategy(), adapter.Agent())
 	}
+}
+
+// context7Args returns the pinned args slice for the Context7 MCP server.
+func context7Args() []string {
+	return []string{"-y", "--package=@upstash/context7-mcp@" + versions.Context7MCP, "--", "context7-mcp"}
+}
+
+// injectTOMLFile upserts the [mcp_servers.context7] block into a TOML-based
+// agent config file (e.g. ~/.codex/config.toml) using a string-based, idempotent
+// helper. The file is created if it does not yet exist.
+func injectTOMLFile(homeDir string, adapter agents.Adapter) (InjectionResult, error) {
+	configPath := adapter.MCPConfigPath(homeDir, "context7")
+
+	existingBytes, err := osReadFile(configPath)
+	if err != nil {
+		return InjectionResult{}, fmt.Errorf("read TOML config %q: %w", configPath, err)
+	}
+
+	existing := string(existingBytes)
+	updated := filemerge.UpsertCodexMCPServerBlock(existing, "context7", "npx", context7Args())
+
+	writeResult, err := filemerge.WriteFileAtomic(configPath, []byte(updated), 0o644)
+	if err != nil {
+		return InjectionResult{}, fmt.Errorf("write TOML config %q: %w", configPath, err)
+	}
+
+	return InjectionResult{Changed: writeResult.Changed, Files: []string{configPath}}, nil
 }
 
 // injectSeparateFile writes a standalone JSON file per MCP server (Claude Code pattern).

--- a/internal/components/mcp/inject_test.go
+++ b/internal/components/mcp/inject_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gentleman-programming/gentle-ai/internal/agents/openclaw"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/opencode"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/vscode"
+	"github.com/gentleman-programming/gentle-ai/internal/versions"
 )
 
 func cursorAdapter(t *testing.T) agents.Adapter {
@@ -493,28 +494,114 @@ func TestInjectCursorWithMalformedMCPJsonRecovery(t *testing.T) {
 	}
 }
 
-// TestInjectCodexTOMLStrategyIsSkipped verifies that Context7 injection for
-// Codex (StrategyTOMLFile) is a no-op — Codex does not get Context7 via MCP
-// config since there is no JSON-based config path; it receives Context7 via
-// its system prompt (agents.md) instead.
-func TestInjectCodexTOMLStrategyIsSkipped(t *testing.T) {
+// TestInjectCodexContext7TOML verifies that Context7 injection for Codex
+// (StrategyTOMLFile) creates config.toml with [mcp_servers.context7] block.
+func TestInjectCodexContext7TOML(t *testing.T) {
 	home := t.TempDir()
 
 	result, err := Inject(home, codex.NewAdapter())
 	if err != nil {
-		t.Fatalf("Inject(codex) error = %v; want nil (TOML strategy must not error)", err)
+		t.Fatalf("Inject(codex) error = %v", err)
 	}
-	if result.Changed {
-		t.Fatal("Inject(codex) changed = true; want false (TOML strategy should be a no-op for context7)")
+	if !result.Changed {
+		t.Fatal("Inject(codex) first call changed = false; want true")
 	}
-	if len(result.Files) != 0 {
-		t.Fatalf("Inject(codex) files = %v; want empty", result.Files)
+	if len(result.Files) == 0 {
+		t.Fatal("Inject(codex) files is empty; want config.toml path")
 	}
 
-	// config.toml must NOT be created by the context7 injector.
 	configTOML := filepath.Join(home, ".codex", "config.toml")
-	if _, err := os.Stat(configTOML); err == nil {
-		t.Fatal("config.toml should NOT be written by the context7 injector")
+	if result.Files[0] != configTOML {
+		t.Fatalf("Inject(codex) files[0] = %q; want %q", result.Files[0], configTOML)
+	}
+
+	content, err := os.ReadFile(configTOML)
+	if err != nil {
+		t.Fatalf("ReadFile(config.toml) error = %v", err)
+	}
+	text := string(content)
+
+	if !strings.Contains(text, "[mcp_servers.context7]") {
+		t.Fatalf("config.toml missing [mcp_servers.context7]; got:\n%s", text)
+	}
+	if !strings.Contains(text, `command = "npx"`) {
+		t.Fatalf("config.toml missing command = npx; got:\n%s", text)
+	}
+	if !strings.Contains(text, versions.Context7MCP) {
+		t.Fatalf("config.toml missing pinned Context7 version %q; got:\n%s", versions.Context7MCP, text)
+	}
+}
+
+// TestInjectCodexContext7Idempotent verifies that a second Inject call with
+// the same pinned version is a no-op (Changed == false, single block).
+func TestInjectCodexContext7Idempotent(t *testing.T) {
+	home := t.TempDir()
+
+	first, err := Inject(home, codex.NewAdapter())
+	if err != nil {
+		t.Fatalf("Inject(codex) first error = %v", err)
+	}
+	if !first.Changed {
+		t.Fatal("Inject(codex) first changed = false; want true")
+	}
+
+	second, err := Inject(home, codex.NewAdapter())
+	if err != nil {
+		t.Fatalf("Inject(codex) second error = %v", err)
+	}
+	if second.Changed {
+		t.Fatal("Inject(codex) second changed = true; want false (idempotent)")
+	}
+
+	configTOML := filepath.Join(home, ".codex", "config.toml")
+	content, err := os.ReadFile(configTOML)
+	if err != nil {
+		t.Fatalf("ReadFile(config.toml) error = %v", err)
+	}
+	count := strings.Count(string(content), "[mcp_servers.context7]")
+	if count != 1 {
+		t.Fatalf("config.toml has %d [mcp_servers.context7] blocks; want exactly 1", count)
+	}
+}
+
+// TestInjectCodexContext7CoexistsWithEngram verifies that injecting context7
+// into a config.toml that already has [mcp_servers.engram] preserves both
+// blocks and does not duplicate either.
+func TestInjectCodexContext7CoexistsWithEngram(t *testing.T) {
+	home := t.TempDir()
+
+	// Pre-seed config.toml with an engram block.
+	configTOML := filepath.Join(home, ".codex", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(configTOML), 0o755); err != nil {
+		t.Fatalf("MkdirAll error = %v", err)
+	}
+	existing := `[mcp_servers.engram]
+command = "engram"
+args = ["mcp", "--tools=agent"]
+`
+	if err := os.WriteFile(configTOML, []byte(existing), 0o644); err != nil {
+		t.Fatalf("WriteFile(config.toml) error = %v", err)
+	}
+
+	_, err := Inject(home, codex.NewAdapter())
+	if err != nil {
+		t.Fatalf("Inject(codex) error = %v", err)
+	}
+
+	content, err := os.ReadFile(configTOML)
+	if err != nil {
+		t.Fatalf("ReadFile(config.toml) error = %v", err)
+	}
+	text := string(content)
+
+	engramCount := strings.Count(text, "[mcp_servers.engram]")
+	if engramCount != 1 {
+		t.Fatalf("expected 1 [mcp_servers.engram], got %d; result:\n%s", engramCount, text)
+	}
+
+	context7Count := strings.Count(text, "[mcp_servers.context7]")
+	if context7Count != 1 {
+		t.Fatalf("expected 1 [mcp_servers.context7], got %d; result:\n%s", context7Count, text)
 	}
 }
 


### PR DESCRIPTION
Closes #751

### PR Type
- [x] New feature

### Summary
- Wire the `StrategyTOMLFile` MCP strategy to inject Context7 into `~/.codex/config.toml` instead of skipping it.
- Add a generalized, string-based, idempotent `UpsertCodexMCPServerBlock` TOML helper (no TOML parser dependency), mirroring the existing Engram block helper.
- First slice (PR1) of the 3-PR codex-native-parity chain (profiles and multi-agent SDD follow as separate PRs).

### Changes
| File | Change |
|------|--------|
| `internal/components/filemerge/toml.go` | New `UpsertCodexMCPServerBlock(content, name, command, args)` string-based idempotent helper |
| `internal/components/mcp/inject.go` | `StrategyTOMLFile` now upserts `[mcp_servers.context7]`; removed the false "not supported" comment |
| `internal/cli/run.go` | `componentPaths` reports the Context7 TOML config path for uninstall tracking |
| `docs/agents.md` | Codex section notes Engram and Context7 are upserted as `[mcp_servers.<name>]` blocks |
| `internal/components/filemerge/toml_test.go` | Tests for the new helper (idempotency, coexistence) |
| `internal/components/mcp/inject_test.go` | Replaced the no-op skip assertion with Context7 injection assertions |

### Test Plan
- [x] `go test ./...` passes (full suite green)
- [x] `go vet ./...` clean on touched packages
- [x] Idempotency: re-running injection does not duplicate or clobber the Engram block

### Contributor Checklist
- [x] Linked an approved issue (#751)
- [x] Added exactly one `type:*` label
- [x] Tests added/updated (strict TDD: test-first commits)
- [x] Docs updated (behavior changed)
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers