### PR TITLE
feat(codex): experimental multi-agent SDD enablement (opt-in)

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -14,7 +14,7 @@
 | Gemini CLI      | `gemini-cli`     | Yes          | Yes | Full (experimental)              | No            | No             | `~/.gemini`                         |
 | Cursor          | `cursor`         | Yes          | Yes | Full (native subagents)          | No            | No             | `~/.cursor`                         |
 | VS Code Copilot | `vscode-copilot` | Yes          | Yes | Full (runSubagent)               | No            | No             | `~/.copilot` + VS Code User profile |
-| Codex           | `codex`          | Yes          | Yes | Solo-agent                       | No            | No             | `~/.codex`                          |
+| Codex           | `codex`          | Yes          | Yes | Solo-agent (multi-agent opt-in, experimental) | No            | No             | `~/.codex`                          |
 | Windsurf        | `windsurf`       | Yes (native) | Yes | Solo-agent                       | No            | No             | `~/.codeium/windsurf`               |
 | Antigravity     | `antigravity`    | Yes (native) | Yes | Solo-agent + Mission Control     | No            | No             | `~/.gemini/antigravity`             |
 | Kimi Code       | `kimi`           | Yes          | Yes | Full (native custom agents)      | No            | No             | `~/.kimi`                           |
@@ -145,6 +145,9 @@ Kiro uses native custom agents in `~/.kiro/agents/`. `gentle-ai` writes phase ag
   | `sdd-strong` | `xhigh` | propose, design, verify, judge |
   | `sdd-mid` | `high` | spec, tasks, apply |
   | `sdd-cheap` | `low` | explore, archive, onboard |
+
+- Multi-agent SDD delegation is available as an **experimental opt-in** (default off). gentle-ai writes `features.multi_agent = false` and `agents.max_threads = 4` / `agents.max_depth = 2` into `~/.codex/config.toml`. To enable, set `multi_agent = true` in the `[features]` section. When enabled, the `sdd-orchestrator` asset uses Codex's native `spawn_agent` / `wait_agent` / `close_agent` tools to delegate SDD phases; otherwise it falls back to solo-agent inline execution.
+- **Delegation**: Solo-agent (multi-agent opt-in, experimental)
 
 ### Windsurf
 

--- a/internal/agents/codex/adapter_test.go
+++ b/internal/agents/codex/adapter_test.go
@@ -178,6 +178,32 @@ func TestAdapterSystemPromptFile_UsesUppercaseAGENTSmd(t *testing.T) {
 	}
 }
 
+// TestAdapterSubAgentsStayFalse is a REGRESSION GUARD.
+//
+// Codex multi-agent delegation is config+asset driven (features.multi_agent in
+// ~/.codex/config.toml + sdd-orchestrator.md capability gate). It does NOT use
+// the file-based sub-agents directory mechanism that SupportsSubAgents() gates.
+//
+// Flipping SupportsSubAgents() to true with an empty EmbeddedSubAgentsDir()
+// would cause sdd/inject.go and uninstall/service.go to call
+// assets.FS.ReadDir("") — which returns the embedded root and would copy the
+// entire asset tree into ~/.codex/agents/. This is catastrophic. Therefore
+// SupportsSubAgents() MUST remain false indefinitely for the Codex adapter.
+// Do NOT remove or relax this test without a full audit of those call sites.
+func TestAdapterSubAgentsStayFalse(t *testing.T) {
+	a := NewAdapter()
+
+	if got := a.SupportsSubAgents(); got {
+		t.Fatal("SupportsSubAgents() = true — MUST stay false for Codex: Codex multi-agent is config+asset driven, not file-directory driven. Flipping this flag would copy the embedded asset root into ~/.codex/agents/.")
+	}
+	if got := a.SubAgentsDir("/home/user"); got != "" {
+		t.Fatalf("SubAgentsDir() = %q, want \"\" — must stay empty for Codex", got)
+	}
+	if got := a.EmbeddedSubAgentsDir(); got != "" {
+		t.Fatalf("EmbeddedSubAgentsDir() = %q, want \"\" — must stay empty for Codex", got)
+	}
+}
+
 func TestCapabilities(t *testing.T) {
 	a := NewAdapter()
 

--- a/internal/assets/codex/sdd-orchestrator.md
+++ b/internal/assets/codex/sdd-orchestrator.md
@@ -1,117 +1,107 @@
-# Agent Teams Lite — Orchestrator Rule for Codex
+# SDD Orchestrator for Codex
 
 Bind this to the dedicated `sdd-orchestrator` agent or rule only. Do NOT apply it to executor phase agents such as `sdd-apply` or `sdd-verify`.
 
-## Agent Teams Orchestrator
-
-You are a COORDINATOR, not an executor. Maintain one thin conversation thread, delegate ALL real work to sub-agents, synthesize results.
-
-
-### Language Domain Contract
+## Language Domain Contract
 
 - The active persona controls direct user/orchestrator conversation only. Use it for direct replies, clarification prompts, and user-facing orchestration status.
 - Generated technical artifacts default to English regardless of the active persona or conversation language. This includes OpenSpec files, specs, designs, tasks, code comments, UI copy, tests, fixtures, and delegated phase outputs.
 - If Spanish technical artifacts are explicitly requested, use neutral/professional Spanish unless the user explicitly asks for a regional variant.
 - Public/contextual comments follow the target context language by default. Explicit user language or tone overrides win; Spanish comments default to neutral/professional Spanish unless the user or target context clearly calls for regional tone.
-- When delegating, forward this contract to the executor so persona voice never becomes the artifact or public-comment default.
+- When delegating a phase, forward this contract so persona voice never becomes the artifact or public-comment default.
 
-### Delegation Rules
+## Capability Check (run once, at session start)
 
-Core principle: **does this inflate my context without need?** If yes → delegate. If no → do it inline.
+Check `~/.codex/config.toml` for `features.multi_agent`:
 
-| Action | Inline | Delegate |
-|--------|--------|----------|
-| Read to decide/verify (1-3 files) | ✅ | — |
-| Read to explore/understand (4+ files) | — | ✅ |
-| Read as preparation for writing | — | ✅ together with the write |
-| Write atomic (one file, mechanical, you already know what) | ✅ | — |
-| Write with analysis (multiple files, new logic) | — | ✅ |
-| Bash for state (git, gh) | ✅ | — |
-| Bash for execution (test, build, install) | — | ✅ |
+- If `features.multi_agent = true` **AND** the tools `spawn_agent`, `wait_agent`, and `close_agent` are available in this session → use the **Delegated path** below.
+- Otherwise (default) → use the **Solo path** below.
 
-delegate (async) is the default for delegated work. Use task (sync) only when you need the result before your next action.
+`features.multi_agent` defaults to `false` (written by gentle-ai during installation). To opt in, set `multi_agent = true` in the `[features]` section of `~/.codex/config.toml` and restart your session.
 
-Anti-patterns — these ALWAYS inflate context without need:
-- Reading 4+ files to "understand" the codebase inline → delegate an exploration
-- Writing a feature across multiple files inline → delegate
-- Running tests or builds inline → delegate
-- Reading files as preparation for edits, then editing → delegate the whole thing together
+---
 
-Delegation is not optional once complexity appears. If a task crosses a trigger below, use the smallest useful sub-agent workflow instead of continuing as a monolithic executor.
+## Solo Path (default)
 
-#### Mandatory Delegation Triggers
+Run each SDD phase inline, in dependency order, without spawning sub-agents. You are the executor for all phases.
 
-These are parent-orchestrator stop rules. Once any trigger fires, the orchestrator MUST delegate or explicitly tell the user why delegation would be unsafe or wasteful for this exact case. Do not pass these rules to child agents as permission to spawn more agents; children receive concrete role work and must not orchestrate.
+```
+proposal → spec → design → tasks → apply → verify → archive
+```
 
-1. **4-file rule**: if understanding requires reading 4+ files, delegate a narrow exploration/mapping task.
-2. **Multi-file write rule**: if implementation will touch 2+ non-trivial files, delegate one writer or continue inline only if a fresh review will audit before completion.
-3. **PR rule**: before commit, push, or PR after code changes, run a fresh-context review unless the diff is trivial docs/text.
-4. **Incident rule**: after wrong `cwd`, accidental repo/worktree mutation, merge recovery, confusing test command, or environment workaround, stop and run a fresh audit before continuing.
-5. **Long-session rule**: after roughly 20 tool calls, 5 exploratory file reads, or 2 non-mechanical edits without delegation and growing complexity, pause and delegate instead of silently continuing monolithically.
-6. **Fresh review rule**: use fresh context for adversarial review of diffs, conflicts, PR readiness, and incidents; use continuity/forked context only for implementation work that needs inherited state.
+For each phase:
+1. Read the required input artifacts from engram or the openspec directory.
+2. Produce the phase output inline in your current context.
+3. Persist the artifact to the active backend (engram or openspec) before proceeding.
 
-#### Cost and Context Balance
+**Dependency graph** (run phases in this order; spec and design can run in parallel):
+- `sdd-propose` → read nothing, write proposal
+- `sdd-spec` → read proposal, write spec
+- `sdd-design` → read proposal, write design
+- `sdd-tasks` → read spec + design, write tasks
+- `sdd-apply` → read tasks + spec + design, write apply-progress
+- `sdd-verify` → read spec + tasks + apply-progress, write verify-report
+- `sdd-archive` → read all artifacts, write archive-report
 
-- Use exploration sub-agents to compress broad repo reading into a short handoff.
-- Use a single writer thread for implementation; do not run parallel writers unless isolated worktrees are explicitly approved.
-- Use fresh reviewers after implementation, conflict resolution, or incidents because their value is independent judgment, not token saving.
-- Avoid delegation for truly local one-file fixes, quick state checks, and already-understood mechanical edits.
+Strict TDD: when the project has `strict_tdd: true` in `sdd-init` context, always follow the RED → GREEN → REFACTOR cycle in `sdd-apply`. Failing test first, then implementation.
 
+---
+
+## Delegated Path (opt-in, requires features.multi_agent = true)
+
+When multi-agent tools are available, delegate each SDD phase to a sub-agent using Codex's native tool set:
+
+- `spawn_agent` — launch a phase sub-agent
+- `send_input` — send a message to a running agent
+- `wait_agent` — block until the agent completes and collect its result
+- `close_agent` — terminate a completed or idle agent
+
+**Thread budget**: `agents.max_threads = 4`, `agents.max_depth = 2` (set in `~/.codex/config.toml`).
+
+### Phase delegation pattern
+
+For each phase:
+1. Determine the correct profile for the phase tier (see Model Profiles below).
+2. `spawn_agent` with the phase prompt and `--profile <profile-name>` so the sub-agent runs at the correct cost/quality tier.
+3. `wait_agent` to collect the result.
+4. `close_agent` to release the thread.
+5. Verify the artifact was persisted before launching the next phase.
+
+Example — launching `sdd-design`:
+```
+spawn_agent("sdd-design", prompt=<design prompt>, profile="sdd-strong")
+wait_agent("sdd-design")
+close_agent("sdd-design")
+```
+
+### Parallelism
+
+`sdd-spec` and `sdd-design` have the same input (proposal) and independent outputs. Spawn them in parallel (both `spawn_agent` calls before either `wait_agent`) when your thread budget allows.
+
+### Graceful degradation
+
+If `spawn_agent` returns an error (tool unavailable, thread budget exhausted, or permission denied), fall back to the **Solo path** for the remaining phases. Do not abort the SDD pipeline — complete it inline.
+
+---
 
 ## SDD Workflow (Spec-Driven Development)
 
-SDD is the structured planning layer for substantial changes.
-
-### Artifact Store Policy
-
-- `engram` — default when available; persistent memory across sessions
-- `openspec` — file-based artifacts; use only when user explicitly requests
-- `hybrid` — both backends; cross-session recovery + local files; more tokens per op
-- `none` — return results inline only; recommend enabling engram or openspec
-
 ### Commands
 
-Skills (appear in autocomplete):
 - `/sdd-init` → initialize SDD context; detects stack, bootstraps persistence
-- `/sdd-explore <topic>` → investigate an idea; reads codebase, compares approaches; no files created
-- `/sdd-status [change]` → read-only structured status for active change, artifacts, tasks, and next action
+- `/sdd-explore <topic>` → investigate an idea; no artifacts created
 - `/sdd-apply [change]` → implement tasks in batches; checks off items as it goes
-- `/sdd-verify [change]` → validate implementation against specs; reports CRITICAL / WARNING / SUGGESTION
-- `/sdd-archive [change]` → close a change and persist final state in the active artifact store 
-- `/sdd-onboard` → guided end-to-end walkthrough of SDD using your real codebase
-
-Meta-commands (type directly — orchestrator handles them, won't appear in autocomplete):
-- `/sdd-new <change>` → start a new change by delegating exploration + proposal to sub-agents
-- `/sdd-continue [change]` → run the next dependency-ready phase via sub-agent(s)
-- `/sdd-ff <name>` → fast-forward planning: proposal → specs → design → tasks
-
-`/sdd-new`, `/sdd-continue`, and `/sdd-ff` are meta-commands handled by YOU. Do NOT invoke them as skills.
-
-### SDD Init Guard (MANDATORY)
-
-Before executing ANY SDD command (`/sdd-new`, `/sdd-ff`, `/sdd-continue`, `/sdd-explore`, `/sdd-status`, `/sdd-apply`, `/sdd-verify`, `/sdd-archive`), check if `sdd-init` has been run for this project:
-
-1. Search Engram: `mem_search(query: "sdd-init/{project}", project: "{project}")`
-2. If found → init was done, proceed normally
-3. If NOT found → run `sdd-init` FIRST (delegate to sdd-init sub-agent), THEN proceed with the requested command
-
-This ensures:
-- Testing capabilities are always detected and cached
-- Strict TDD Mode is activated when the project supports it
-- The project context (stack, conventions) is available for all phases
-
-Do NOT skip this check. Do NOT ask the user — just run init silently if needed.
+- `/sdd-verify [change]` → validate implementation against specs
+- `/sdd-archive [change]` → close a change and persist final state
 
 ### Execution Mode
 
-When the user invokes `/sdd-new`, `/sdd-ff`, or `/sdd-continue` (or an equivalent natural-language request, e.g. "haceme un SDD para X" / "do SDD for X") for the first time in a session, ASK which execution mode they prefer:
+When the user invokes `/sdd-new`, `/sdd-ff`, or `/sdd-continue` for the first time in a session, ask which execution mode they prefer:
 
-- **Automatic** (`auto`): Run all phases back-to-back without pausing. Show the final result only. Use this when the user wants speed and trusts the process.
-- **Interactive** (`interactive`): After each phase completes, show the result summary and ASK: "Want to adjust anything or continue?" before proceeding to the next phase. Use this when the user wants to review and steer each step.
+- **Automatic** (`auto`): Run all phases back-to-back. Show the final result only.
+- **Interactive** (`interactive`): After each phase, show the result summary and ask before proceeding.
 
 If the user doesn't specify, default to **Interactive** (safer, gives the user control).
-
-Cache the mode choice for the session — don't ask again unless the user explicitly requests a mode change.
 
 In **Interactive** mode, between phases:
 1. Show a concise summary of what the phase produced
@@ -127,19 +117,17 @@ Before the `sdd-propose` phase in interactive mode, offer the user a proposal qu
 
 ### Artifact Store Mode
 
-When the user invokes `/sdd-new`, `/sdd-ff`, or `/sdd-continue` (or an equivalent natural-language request) for the first time in a session, ALSO ASK which artifact store they want for this change:
+When the user invokes `/sdd-new`, `/sdd-ff`, or `/sdd-continue` for the first time in a session, also ask which artifact store they want:
 
-- **`engram`**: Fast, no files created. Artifacts live in engram only. Best for solo work and quick iteration. Note: re-running a phase overwrites the previous version (no history).
-- **`openspec`**: File-based. Creates `openspec/` directory with full artifact trail. Committable, shareable with team, full git history.
-- **`hybrid`**: Both — files for team sharing + engram for cross-session recovery. Higher token cost.
+- **`engram`**: Fast, no files created. Best for solo work.
+- **`openspec`**: File-based. Creates `openspec/` directory. Committable, shareable.
+- **`hybrid`**: Both — files for team sharing + engram for cross-session recovery.
 
-If the user doesn't specify, detect: if engram is available → default to `engram`. Otherwise → `none`.
-
-Cache the artifact store choice for the session. Pass it as `artifact_store.mode` to every sub-agent launch.
+Default: `engram` when available. Cache the choice for the session.
 
 ### Delivery Strategy
 
-On the first `/sdd-new`, `/sdd-ff`, or `/sdd-continue` (or an equivalent natural-language request) in a session, ask once for and cache delivery strategy: `ask-on-risk` (default), `auto-chain`, `single-pr`, or `exception-ok`. Pass it as `delivery_strategy` to `sdd-tasks` and `sdd-apply` prompts.
+On the first `/sdd-new`, `/sdd-ff`, or `/sdd-continue` in a session, ask once for and cache delivery strategy: `ask-on-risk` (default), `auto-chain`, `single-pr`, or `exception-ok`. Pass it as `delivery_strategy` to `sdd-tasks` and `sdd-apply` prompts.
 
 ### Chain Strategy
 
@@ -150,161 +138,47 @@ When `delivery_strategy` results in chained PRs (either by user choice via `ask-
 
 Cache the chain strategy for the session. Pass it as `chain_strategy` to `sdd-tasks` and `sdd-apply` prompts alongside `delivery_strategy`. Do not ask again unless the user changes scope.
 
-### Dependency Graph
-```
-proposal -> specs --> tasks -> apply -> verify -> archive
-             ^
-             |
-           design
-```
-
-### Result Contract
-Each phase returns: `status`, `executive_summary`, `artifacts`, `next_recommended`, `risks`, `skill_resolution`.
-
 ### Review Workload Guard (MANDATORY)
 
-After `sdd-tasks` completes and before launching `sdd-apply`, inspect `Review Workload Forecast`.
+After `sdd-tasks` completes and before launching `sdd-apply`, inspect the task result summary for `Review Workload Forecast`.
 
-If it says `Chained PRs recommended: Yes`, `400-line budget risk: High`, estimated changed lines exceed 400, or `Decision needed before apply: Yes`, apply cached `delivery_strategy`:
+If it says `Chained PRs recommended: Yes`, `400-line budget risk: High`, estimated changed lines exceed 400, or `Decision needed before apply: Yes`, apply the cached `delivery_strategy`: `ask-on-risk` asks, `auto-chain` asks for a missing `chain_strategy` and applies only the next PR slice, `single-pr` requires `size:exception`, and `exception-ok` records the exception.
 
-- **`ask-on-risk`**: STOP and ask chained/stacked PRs vs maintainer-approved `size:exception`. If the user chooses chained PRs and `chain_strategy` is not yet cached, also ask which chain strategy to use (`stacked-to-main` or `feature-branch-chain`).
-- **`auto-chain`**: Do not ask about splitting. If `chain_strategy` is not yet cached, ask which chain strategy to use. Then tell `sdd-apply` to implement only the next autonomous chained/stacked PR slice using work-unit commits, clear start/finish boundaries, verification, and rollback.
-- **`single-pr`**: STOP and require/record `size:exception` before apply.
-- **`exception-ok`**: Continue, but tell `sdd-apply` this run uses `size:exception`.
+When launching `sdd-apply`, include the resolved `delivery_strategy`, `chain_strategy`, and any chosen PR boundary/exception in the prompt.
 
-Automatic mode does not override this guard. Always pass the resolved `delivery_strategy` and `chain_strategy` to `sdd-apply`.
+### Artifact store (engram default)
 
-When launching `sdd-apply`, always include the resolved `delivery_strategy`, `chain_strategy`, and any chosen PR boundary/exception in the prompt.
-
-### Sub-Agent Launch Deduplication (MANDATORY)
-
-Before emitting any delegation call, check your in-session launch log:
-
-- Maintain a session-scoped list of `(phase, task-fingerprint)` pairs already launched this turn.
-- The task fingerprint is a short hash or normalized summary of the instruction text (phase name + key artifact references).
-- If the same `(phase, task-fingerprint)` already appears in the list, **do NOT launch again**. Emit exactly one launch per distinct task.
-- After launching, append the pair to the list.
-
-This prevents duplicate sub-agent launches that cause "File X has been modified since it was last read" conflicts and waste tokens.
-
-### Sub-Agent Launch Pattern
-
-ALL sub-agent launch prompts that involve reading, writing, or reviewing code MUST include pre-resolved **skill paths** from the skill registry. Follow the **Skill Resolver Protocol** (see `_shared/skill-resolver.md` in the skills directory).
-
-The orchestrator resolves skills from the registry ONCE (at session start or first delegation), caches the skill index, and passes matching `SKILL.md` paths into each sub-agent's prompt.
-
-Orchestrator skill resolution (do once per session):
-1. `mem_search(query: "skill-registry", project: "{project}")` → `mem_get_observation(id)` for full registry content
-2. Fallback: read `.atl/skill-registry.md` if engram not available
-3. Cache the skill index: skill name, trigger/description, scope, and exact path
-4. If no registry exists, warn user and proceed without project-specific standards
-
-For each sub-agent launch:
-1. Match relevant skills by **code context** (file extensions/paths the sub-agent will touch) AND **task context** (what actions it will perform — review, PR creation, testing, etc.)
-2. Copy matching `SKILL.md` paths into the sub-agent prompt as `## Skills to load before work`
-3. Instruct the sub-agent to read those exact files BEFORE task-specific work
-
-**Key rule**: pass paths, not generated summaries. Sub-agents read the full `SKILL.md` files so author intent is preserved. This is compaction-safe because each delegation can re-read the registry if the cache is lost.
-
-### Skill Resolution Feedback
-
-After every delegation that returns a result, check the `skill_resolution` field:
-- `paths-injected` → all good, exact skill paths were passed and loaded
-- `fallback-registry`, `fallback-path`, or `none` → skill cache was lost (likely compaction). Re-read the registry immediately and pass skill paths in all subsequent delegations.
-
-This is a self-correction mechanism. Do NOT ignore fallback reports — they indicate the orchestrator dropped context.
-
-### Sub-Agent Context Protocol
-
-Sub-agents get a fresh context with NO memory. The orchestrator controls context access.
-
-#### Non-SDD Tasks (general delegation)
-
-- Read context: orchestrator searches engram (`mem_search`) for relevant prior context and passes it in the sub-agent prompt. Sub-agent does NOT search engram itself.
-- Write context: sub-agent MUST save significant discoveries, decisions, or bug fixes to engram via `mem_save` before returning. Sub-agent has full detail — save before returning, not after.
-- Always add to sub-agent prompt: `"If you make important discoveries, decisions, or fix bugs, save them to engram via mem_save with project: '{project}'."`
-- Skills: orchestrator resolves matching paths from the registry and injects them as `## Skills to load before work` in the sub-agent prompt. Sub-agents read those exact `SKILL.md` files before work.
-
-#### SDD Phases
-
-Each phase has explicit read/write rules:
-
-| Phase | Reads | Writes |
-|-------|-------|--------|
-| `sdd-explore` | nothing | `explore` |
-| `sdd-propose` | exploration (optional) | `proposal` |
-| `sdd-spec` | proposal (required) | `spec` |
-| `sdd-design` | proposal (required) | `design` |
-| `sdd-tasks` | spec + design (required) | `tasks` |
-| `sdd-apply` | tasks + spec + design + **apply-progress (if exists)** | `apply-progress` |
-| `sdd-verify` | spec + tasks + **apply-progress** | `verify-report` |
-| `sdd-archive` | all artifacts | `archive-report` |
-
-For phases with required dependencies, sub-agent reads directly from the backend — orchestrator passes artifact references (topic keys or file paths), NOT content itself.
-
-#### Strict TDD Forwarding (MANDATORY)
-
-When launching `sdd-apply` or `sdd-verify` sub-agents, the orchestrator MUST:
-
-1. Search for testing capabilities: `mem_search(query: "sdd-init/{project}", project: "{project}")`
-2. If the result contains `strict_tdd: true`:
-   - Add to the sub-agent prompt: `"STRICT TDD MODE IS ACTIVE. Test runner: {test_command}. You MUST follow strict-tdd.md. Do NOT fall back to Standard Mode."`
-   - This is NON-NEGOTIABLE. Do not rely on the sub-agent discovering this independently.
-3. If the search fails or `strict_tdd` is not found, do NOT add the TDD instruction (sub-agent uses Standard Mode).
-
-The orchestrator resolves TDD status ONCE per session (at first apply/verify launch) and caches it.
-
-#### Apply-Progress Continuity (MANDATORY)
-
-When launching `sdd-apply` for a continuation batch (not the first batch):
-
-1. Search for existing apply-progress: `mem_search(query: "sdd/{change-name}/apply-progress", project: "{project}")`
-2. If found, add to the sub-agent prompt: `"PREVIOUS APPLY-PROGRESS EXISTS at topic_key 'sdd/{change-name}/apply-progress'. You MUST read it first via mem_search + mem_get_observation, merge your new progress with the existing progress, and save the combined result. Do NOT overwrite — MERGE."`
-3. If not found (first batch), no special instruction needed.
-
-This prevents progress loss across batches. The sub-agent is responsible for read-merge-write, but the orchestrator MUST tell it that previous progress exists.
-
-#### Engram Topic Key Format
-
-When launching sub-agents for SDD phases with engram mode, pass these exact topic_keys as artifact references:
-
-| Artifact | Topic Key |
+| Artifact | Topic key |
 |----------|-----------|
 | Project context | `sdd-init/{project}` |
-| Exploration | `sdd/{change-name}/explore` |
-| Proposal | `sdd/{change-name}/proposal` |
-| Spec | `sdd/{change-name}/spec` |
-| Design | `sdd/{change-name}/design` |
-| Tasks | `sdd/{change-name}/tasks` |
-| Apply progress | `sdd/{change-name}/apply-progress` |
-| Verify report | `sdd/{change-name}/verify-report` |
-| Archive report | `sdd/{change-name}/archive-report` |
-| DAG state | `sdd/{change-name}/state` |
+| Proposal | `sdd/{change}/proposal` |
+| Spec | `sdd/{change}/spec` |
+| Design | `sdd/{change}/design` |
+| Tasks | `sdd/{change}/tasks` |
+| Apply progress | `sdd/{change}/apply-progress` |
+| Verify report | `sdd/{change}/verify-report` |
+| Archive report | `sdd/{change}/archive-report` |
 
-Sub-agents retrieve full content via two steps:
-1. `mem_search(query: "{topic_key}", project: "{project}")` → get observation ID
-2. `mem_get_observation(id: {id})` → full content (REQUIRED — search results are truncated)
+Retrieve full content: `mem_search(query: "{topic_key}")` → `mem_get_observation(id)`.
 
 ### State and Conventions
 
 Convention files under `~/.codex/skills/_shared/` (global) or `.agent/skills/_shared/` (workspace): `engram-convention.md`, `persistence-contract.md`, `openspec-convention.md`.
 
-### Recovery Rule
+### Result contract
 
-- `engram` → `mem_search(...)` → `mem_get_observation(...)`
-- `openspec` → read `openspec/changes/*/state.yaml`
-- `none` → state not persisted — explain to user
+Each phase returns: `status`, `executive_summary`, `artifacts`, `next_recommended`, `risks`.
+
+---
 
 ## Model Profiles
 
 gentle-ai writes three SDD model-selection profile files into `~/.codex/` during installation. Each profile sets `model_reasoning_effort` so Codex picks the right model tier at runtime — no hardcoded model IDs.
 
-Select a profile when running a phase: `codex --profile <name>`
+Select a profile when spawning a phase agent: `--profile <name>`
 
 | Profile | `model_reasoning_effort` | SDD phases |
 |---------|--------------------------|------------|
 | `sdd-strong` | `xhigh` | propose, design, verify, judge |
 | `sdd-mid` | `high` | spec, tasks, apply |
 | `sdd-cheap` | `low` | explore, archive, onboard |
-
-When spawning a phase agent (once multi-agent delegation is enabled via `features.multi_agent = true`), pass the matching profile name so the sub-agent runs at the appropriate cost/quality tier. Example: for a `sdd-design` phase, use `--profile sdd-strong`.

--- a/internal/assets/codex/sdd-orchestrator.md
+++ b/internal/assets/codex/sdd-orchestrator.md
@@ -61,18 +61,21 @@ When multi-agent tools are available, delegate each SDD phase to a sub-agent usi
 ### Phase delegation pattern
 
 For each phase:
-1. Determine the correct profile for the phase tier (see Model Profiles below).
-2. `spawn_agent` with the phase prompt and `--profile <profile-name>` so the sub-agent runs at the correct cost/quality tier.
-3. `wait_agent` to collect the result.
-4. `close_agent` to release the thread.
-5. Verify the artifact was persisted before launching the next phase.
+1. Determine the phase tier and its `reasoning_effort` value (see Model Profiles below): `xhigh` for propose/design/verify/judge, `high` for spec/tasks/apply, `low` for explore/archive/onboard.
+2. `spawn_agent` with `task_name`, the phase prompt as `message`, and `reasoning_effort` set to the tier value. The `spawn_agent` tool has NO `profile` parameter — tier selection is the `reasoning_effort` argument, not a profile name.
+3. Set `fork_turns: "none"` whenever you override `reasoning_effort` or `model`. A full-history fork (the default) REJECTS these overrides, so the override is silently ignored unless `fork_turns` is `"none"`.
+4. `wait_agent` to collect the result.
+5. `close_agent` to release the thread.
+6. Verify the artifact was persisted before launching the next phase.
 
-Example — launching `sdd-design`:
+Example — launching `sdd-design` at the strong tier:
 ```
-spawn_agent("sdd-design", prompt=<design prompt>, profile="sdd-strong")
-wait_agent("sdd-design")
-close_agent("sdd-design")
+spawn_agent(task_name="sdd-design", message=<design prompt>, reasoning_effort="xhigh", fork_turns="none")
+wait_agent(task_name="sdd-design")
+close_agent(task_name="sdd-design")
 ```
+
+Note: the `~/.codex/<tier>.config.toml` profile files apply to whole CLI sessions launched with `codex --profile <name>`. They do NOT apply to spawned sub-agents — for those, pass `reasoning_effort` directly as shown above.
 
 ### Parallelism
 
@@ -173,12 +176,12 @@ Each phase returns: `status`, `executive_summary`, `artifacts`, `next_recommende
 
 ## Model Profiles
 
-gentle-ai writes three SDD model-selection profile files into `~/.codex/` during installation. Each profile sets `model_reasoning_effort` so Codex picks the right model tier at runtime — no hardcoded model IDs.
+gentle-ai writes three SDD model-selection profile files into `~/.codex/` during installation. Each profile sets `model_reasoning_effort` so Codex picks the right tier — no hardcoded model IDs.
 
-Select a profile when spawning a phase agent: `--profile <name>`
+These profile files apply to whole CLI sessions: `codex --profile <name> "<prompt>"`. They do NOT apply to spawned sub-agents. When delegating a phase via `spawn_agent`, pass the tier's effort directly as `reasoning_effort` (with `fork_turns: "none"`), using the same tier values below.
 
-| Profile | `model_reasoning_effort` | SDD phases |
-|---------|--------------------------|------------|
+| Profile (CLI) | `reasoning_effort` (spawn_agent) | SDD phases |
+|---------------|----------------------------------|------------|
 | `sdd-strong` | `xhigh` | propose, design, verify, judge |
 | `sdd-mid` | `high` | spec, tasks, apply |
 | `sdd-cheap` | `low` | explore, archive, onboard |

--- a/internal/components/engram/inject.go
+++ b/internal/components/engram/inject.go
@@ -166,8 +166,25 @@ func vsCodeEngramOverlayJSON(cmd string) []byte {
 	return append(b, '\n')
 }
 
+// InjectOptions carries optional configuration for an Inject call.
+// Zero value is always safe — all fields have documented defaults.
+type InjectOptions struct {
+	// CodexMultiAgent controls whether features.multi_agent is written as true
+	// in ~/.codex/config.toml. Default (false) writes multi_agent = false, which
+	// is the safe no-op value for the experimental Codex multi-agent tool set.
+	// Set to true only when the user explicitly opts in via a CLI flag or TUI choice.
+	CodexMultiAgent bool
+}
+
 func Inject(homeDir string, adapter agents.Adapter) (InjectionResult, error) {
-	return inject(homeDir, homeDir, adapter)
+	return injectWithOptions(homeDir, homeDir, adapter, InjectOptions{})
+}
+
+// InjectWithOptions is like Inject but accepts additional options such as the
+// Codex multi-agent opt-in flag. Use this when the caller has a model.Selection
+// and needs to forward user-chosen configuration into the injection pass.
+func InjectWithOptions(homeDir string, adapter agents.Adapter, opts InjectOptions) (InjectionResult, error) {
+	return injectWithOptions(homeDir, homeDir, adapter, opts)
 }
 
 // InjectWithPromptDir writes Engram's MCP configuration using configHomeDir and
@@ -175,7 +192,7 @@ func Inject(homeDir string, adapter agents.Adapter) (InjectionResult, error) {
 // as OpenClaw where MCP is loaded from the global config but instructions are
 // read from an active workspace.
 func InjectWithPromptDir(configHomeDir, promptDir string, adapter agents.Adapter) (InjectionResult, error) {
-	return inject(configHomeDir, promptDir, adapter)
+	return injectWithOptions(configHomeDir, promptDir, adapter, InjectOptions{})
 }
 
 const antigravityEngramPluginJSON = `{
@@ -255,7 +272,7 @@ func installAntigravityEngramPlugin(homeDir, engramCommand string) (bool, []stri
 	return changed, files, nil
 }
 
-func inject(configHomeDir, promptDir string, adapter agents.Adapter) (InjectionResult, error) {
+func injectWithOptions(configHomeDir, promptDir string, adapter agents.Adapter, opts InjectOptions) (InjectionResult, error) {
 	if provisioner, ok := adapter.(piEngramProvisioner); ok {
 		changed, files, err := provisioner.ProvisionEngramMCP(configHomeDir)
 		if err != nil {
@@ -357,17 +374,55 @@ func inject(configHomeDir, promptDir string, adapter agents.Adapter) (InjectionR
 			return InjectionResult{}, instrErr
 		}
 
-		// Read existing config and apply all mutations in one pass.
+		// Read existing config and apply all mutations in a single pass.
+		//
+		// Mutation order (matters for idempotency):
+		//   1. UpsertTOMLTableKey for [features] and [agents] — these are
+		//      applied FIRST so that the section headers are present before
+		//      UpsertTopLevelTOMLString and UpsertCodexEngramBlock run. When
+		//      the sections already exist, their keys are replaced in place.
+		//   2. UpsertTopLevelTOMLString for instruction-file keys — places
+		//      top-level keys before the first [section] header (i.e., before
+		//      [features]). Running model→experimental in this order is
+		//      self-correcting on re-runs (the pair of calls always produces
+		//      the same final ordering).
+		//   3. UpsertCodexEngramBlock — strips the [mcp_servers.engram] block
+		//      and re-appends it at EOF on every call. Running last ensures
+		//      engram always ends up at the bottom of the file. On re-runs,
+		//      UpsertCodexEngramBlock stops at [features] (the next section
+		//      header after engram on disk), so [features] and [agents] are
+		//      preserved above engram — the stable layout is:
+		//        model_instructions_file / experimental_compact_prompt_file
+		//        [features] / [agents]
+		//        [mcp_servers.engram]
 		existing, err := readFileOrEmpty(configPath)
 		if err != nil {
 			return InjectionResult{}, err
 		}
-		engramCmd := stableEngramCommandForMergedConfig(configPath, adapter.Agent())
-		withMCP := filemerge.UpsertCodexEngramBlock(existing, engramCmd)
-		withInstr := filemerge.UpsertTopLevelTOMLString(withMCP, "model_instructions_file", instructionsPath)
+
+		// Step 1 — multi-agent SDD enablement keys ([features] and [agents]).
+		// features.multi_agent defaults to false (experimental, opt-in only).
+		// Set Selection.CodexMultiAgent=true / InjectOptions{CodexMultiAgent:true}
+		// to write multi_agent=true. agents.max_threads and agents.max_depth are
+		// always written with conservative defaults so they are ready when the
+		// user enables multi_agent.
+		multiAgentValue := "false"
+		if opts.CodexMultiAgent {
+			multiAgentValue = "true"
+		}
+		withFeatures := filemerge.UpsertTOMLTableKey(existing, "features", "multi_agent", multiAgentValue)
+		withMaxThreads := filemerge.UpsertTOMLTableKey(withFeatures, "agents", "max_threads", "4")
+		withMaxDepth := filemerge.UpsertTOMLTableKey(withMaxThreads, "agents", "max_depth", "2")
+
+		// Step 2 — top-level instruction-file keys (before the first section header).
+		withInstr := filemerge.UpsertTopLevelTOMLString(withMaxDepth, "model_instructions_file", instructionsPath)
 		withCompact := filemerge.UpsertTopLevelTOMLString(withInstr, "experimental_compact_prompt_file", compactPath)
 
-		tomlWrite, err := filemerge.WriteFileAtomic(configPath, []byte(withCompact), 0o644)
+		// Step 3 — [mcp_servers.engram] block (always last; strip+re-append at EOF).
+		engramCmd := stableEngramCommandForMergedConfig(configPath, adapter.Agent())
+		withMCP := filemerge.UpsertCodexEngramBlock(withCompact, engramCmd)
+
+		tomlWrite, err := filemerge.WriteFileAtomic(configPath, []byte(withMCP), 0o644)
 		if err != nil {
 			return InjectionResult{}, err
 		}

--- a/internal/components/engram/inject_test.go
+++ b/internal/components/engram/inject_test.go
@@ -1019,6 +1019,128 @@ func TestInjectCodexProfilesIdempotent(t *testing.T) {
 	}
 }
 
+// ─── Codex multi-agent config injection tests ────────────────────────────────
+
+// TestInjectCodexMultiAgentDefaultOff asserts that after a plain Inject call
+// (no explicit opt-in), config.toml contains [features] with multi_agent = false.
+func TestInjectCodexMultiAgentDefaultOff(t *testing.T) {
+	home := t.TempDir()
+
+	if _, err := Inject(home, codexAdapter()); err != nil {
+		t.Fatalf("Inject(codex) error = %v", err)
+	}
+
+	configPath := filepath.Join(home, ".codex", "config.toml")
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("ReadFile(config.toml) error = %v", err)
+	}
+	text := string(content)
+	if !strings.Contains(text, "[features]") {
+		t.Fatalf("config.toml missing [features] section; got:\n%s", text)
+	}
+	if !strings.Contains(text, "multi_agent = false") {
+		t.Fatalf("config.toml missing multi_agent = false; got:\n%s", text)
+	}
+	if strings.Contains(text, "multi_agent = true") {
+		t.Fatalf("config.toml must NOT have multi_agent = true by default; got:\n%s", text)
+	}
+}
+
+// TestInjectCodexMultiAgentOptIn asserts that InjectWithOptions with
+// CodexMultiAgent=true writes multi_agent = true in [features].
+func TestInjectCodexMultiAgentOptIn(t *testing.T) {
+	home := t.TempDir()
+
+	opts := InjectOptions{CodexMultiAgent: true}
+	if _, err := InjectWithOptions(home, codexAdapter(), opts); err != nil {
+		t.Fatalf("InjectWithOptions(codex, multiAgent=true) error = %v", err)
+	}
+
+	configPath := filepath.Join(home, ".codex", "config.toml")
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("ReadFile(config.toml) error = %v", err)
+	}
+	text := string(content)
+	if !strings.Contains(text, "multi_agent = true") {
+		t.Fatalf("config.toml missing multi_agent = true after opt-in; got:\n%s", text)
+	}
+}
+
+// TestInjectCodexMultiAgentDefaults asserts that the [agents] section is always
+// written with max_threads = 4 and max_depth = 2 regardless of the opt-in flag.
+func TestInjectCodexMultiAgentDefaults(t *testing.T) {
+	home := t.TempDir()
+
+	if _, err := Inject(home, codexAdapter()); err != nil {
+		t.Fatalf("Inject(codex) error = %v", err)
+	}
+
+	configPath := filepath.Join(home, ".codex", "config.toml")
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("ReadFile(config.toml) error = %v", err)
+	}
+	text := string(content)
+	if !strings.Contains(text, "[agents]") {
+		t.Fatalf("config.toml missing [agents] section; got:\n%s", text)
+	}
+	if !strings.Contains(text, "max_threads = 4") {
+		t.Fatalf("config.toml missing max_threads = 4; got:\n%s", text)
+	}
+	if !strings.Contains(text, "max_depth = 2") {
+		t.Fatalf("config.toml missing max_depth = 2; got:\n%s", text)
+	}
+}
+
+// TestInjectCodexMultiAgentIdempotent asserts that running Inject twice
+// produces exactly one [features] section and one [agents] section with no
+// duplicate keys, and that the engram and context7 blocks are not disturbed.
+func TestInjectCodexMultiAgentIdempotent(t *testing.T) {
+	home := t.TempDir()
+
+	if _, err := Inject(home, codexAdapter()); err != nil {
+		t.Fatalf("first Inject(codex) error = %v", err)
+	}
+	second, err := Inject(home, codexAdapter())
+	if err != nil {
+		t.Fatalf("second Inject(codex) error = %v", err)
+	}
+	if second.Changed {
+		// Read content for diagnostics.
+		content, _ := os.ReadFile(filepath.Join(home, ".codex", "config.toml"))
+		t.Fatalf("second Inject(codex) changed = true, want false (multi-agent keys are idempotent); config.toml:\n%s", string(content))
+	}
+
+	configPath := filepath.Join(home, ".codex", "config.toml")
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("ReadFile(config.toml) error = %v", err)
+	}
+	text := string(content)
+
+	if count := strings.Count(text, "[features]"); count != 1 {
+		t.Fatalf("expected 1 [features] section, got %d; config.toml:\n%s", count, text)
+	}
+	if count := strings.Count(text, "[agents]"); count != 1 {
+		t.Fatalf("expected 1 [agents] section, got %d; config.toml:\n%s", count, text)
+	}
+	if count := strings.Count(text, "multi_agent"); count != 1 {
+		t.Fatalf("expected 1 multi_agent key, got %d; config.toml:\n%s", count, text)
+	}
+	if count := strings.Count(text, "max_threads"); count != 1 {
+		t.Fatalf("expected 1 max_threads key, got %d; config.toml:\n%s", count, text)
+	}
+	if count := strings.Count(text, "max_depth"); count != 1 {
+		t.Fatalf("expected 1 max_depth key, got %d; config.toml:\n%s", count, text)
+	}
+	// Engram MCP block must still be present.
+	if !strings.Contains(text, "[mcp_servers.engram]") {
+		t.Fatalf("config.toml missing [mcp_servers.engram] after idempotency run; got:\n%s", text)
+	}
+}
+
 // ─── Absolute path resolution tests ──────────────────────────────────────────
 
 // mockEngramLookPath sets EngramLookPath to a mock and restores it after the test.

--- a/internal/components/filemerge/toml.go
+++ b/internal/components/filemerge/toml.go
@@ -131,8 +131,8 @@ func UpsertTOMLTableKey(content, section, key, rawValue string) string {
 	newLine := key + " = " + rawValue
 
 	// Find the section header and collect the indices of the key lines within it.
-	sectionLine := -1       // line index of the [section] header
-	var keyLines []int      // indices of lines matching key= or key = inside the section
+	sectionLine := -1  // line index of the [section] header
+	var keyLines []int // indices of lines matching key= or key = inside the section
 
 	inSection := false
 	for i, line := range lines {
@@ -164,24 +164,37 @@ func UpsertTOMLTableKey(content, section, key, rawValue string) string {
 		return base + "\n\n" + header + "\n" + newLine + "\n"
 	}
 
-	// Section present — remove stale key occurrences, then insert after header.
-	keySet := make(map[int]bool, len(keyLines))
-	for _, idx := range keyLines {
-		keySet[idx] = true
+	if len(keyLines) > 0 {
+		// Key already exists in the section.
+		// Replace the first occurrence in place; drop any duplicates.
+		firstKey := keyLines[0]
+		dupSet := make(map[int]bool, len(keyLines)-1)
+		for _, idx := range keyLines[1:] {
+			dupSet[idx] = true
+		}
+
+		var out []string
+		for i, line := range lines {
+			if dupSet[i] {
+				continue // drop duplicates
+			}
+			if i == firstKey {
+				out = append(out, newLine) // replace in place
+				continue
+			}
+			out = append(out, line)
+		}
+		return strings.TrimSpace(strings.Join(out, "\n")) + "\n"
 	}
 
+	// Section present but key absent — insert as the first line after the header.
 	var out []string
 	for i, line := range lines {
-		if keySet[i] {
-			continue // drop old key line
-		}
 		out = append(out, line)
 		if i == sectionLine {
-			// Insert the new key immediately after the section header.
 			out = append(out, newLine)
 		}
 	}
-
 	return strings.TrimSpace(strings.Join(out, "\n")) + "\n"
 }
 

--- a/internal/components/filemerge/toml.go
+++ b/internal/components/filemerge/toml.go
@@ -108,6 +108,83 @@ func UpsertCodexMCPServerBlock(content, serverID, command string, args []string)
 	return base + "\n\n" + block + "\n"
 }
 
+// UpsertTOMLTableKey upserts `key = rawValue` inside the named [section] table.
+// rawValue is the already-formatted TOML right-hand side: the caller supplies a
+// bare boolean/integer (false, 4) or a pre-quoted string ("value") — the helper
+// writes it verbatim, staying type-agnostic and parser-free.
+//
+// Behaviour:
+//   - If [section] exists: any existing line whose trimmed prefix is `key ` or
+//     `key=` is removed, then `key = rawValue` is inserted as the first line
+//     after the [section] header.
+//   - If [section] does not exist: `\n[section]\nkey = rawValue` is appended at
+//     EOF.
+//
+// All other sections and top-level keys are preserved verbatim. The result is
+// idempotent: calling with the same arguments twice yields the same output.
+// Only the simple single-line-per-key subset is handled (no inline tables or
+// arrays-of-tables — the Codex config does not require those).
+func UpsertTOMLTableKey(content, section, key, rawValue string) string {
+	content = strings.ReplaceAll(content, "\r\n", "\n")
+	lines := strings.Split(content, "\n")
+	header := "[" + section + "]"
+	newLine := key + " = " + rawValue
+
+	// Find the section header and collect the indices of the key lines within it.
+	sectionLine := -1       // line index of the [section] header
+	var keyLines []int      // indices of lines matching key= or key = inside the section
+
+	inSection := false
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == header {
+			sectionLine = i
+			inSection = true
+			continue
+		}
+		if inSection {
+			// A new [header] ends the current section.
+			if strings.HasPrefix(trimmed, "[") && strings.HasSuffix(trimmed, "]") {
+				inSection = false
+				continue
+			}
+			// Detect an existing occurrence of the key within this section.
+			if strings.HasPrefix(trimmed, key+" ") || strings.HasPrefix(trimmed, key+"=") {
+				keyLines = append(keyLines, i)
+			}
+		}
+	}
+
+	if sectionLine == -1 {
+		// Section absent — append it at EOF.
+		base := strings.TrimSpace(strings.Join(lines, "\n"))
+		if base == "" {
+			return header + "\n" + newLine + "\n"
+		}
+		return base + "\n\n" + header + "\n" + newLine + "\n"
+	}
+
+	// Section present — remove stale key occurrences, then insert after header.
+	keySet := make(map[int]bool, len(keyLines))
+	for _, idx := range keyLines {
+		keySet[idx] = true
+	}
+
+	var out []string
+	for i, line := range lines {
+		if keySet[i] {
+			continue // drop old key line
+		}
+		out = append(out, line)
+		if i == sectionLine {
+			// Insert the new key immediately after the section header.
+			out = append(out, newLine)
+		}
+	}
+
+	return strings.TrimSpace(strings.Join(out, "\n")) + "\n"
+}
+
 // UpsertTopLevelTOMLString inserts or replaces a top-level key = "value" pair
 // in TOML content. The key is placed before the first [section] header so it
 // remains a top-level (non-table) setting. Existing occurrences of the key are

--- a/internal/components/filemerge/toml_test.go
+++ b/internal/components/filemerge/toml_test.go
@@ -275,3 +275,140 @@ func TestUpsertCodexMCPServerBlock_EscapesBackslashes(t *testing.T) {
 		t.Fatalf("result missing properly escaped Windows arg;\nwant substring: %s\ngot:\n%s", wantArg, result)
 	}
 }
+
+// ─── UpsertTOMLTableKey ───────────────────────────────────────────────────────
+
+func TestUpsertTOMLTableKey_CreatesSection(t *testing.T) {
+	// When the [features] section does not exist, it must be appended with the key.
+	result := UpsertTOMLTableKey("", "features", "multi_agent", "false")
+
+	count := strings.Count(result, "[features]")
+	if count != 1 {
+		t.Fatalf("expected 1 [features] header, got %d; result:\n%s", count, result)
+	}
+	if !strings.Contains(result, "multi_agent = false") {
+		t.Fatalf("result missing multi_agent = false; got:\n%s", result)
+	}
+	if !strings.HasSuffix(result, "\n") {
+		t.Fatalf("result does not end with newline; got:\n%q", result)
+	}
+}
+
+func TestUpsertTOMLTableKey_ReplacesKeyInSection(t *testing.T) {
+	input := "[features]\nmulti_agent = true\n"
+	result := UpsertTOMLTableKey(input, "features", "multi_agent", "false")
+
+	count := strings.Count(result, "[features]")
+	if count != 1 {
+		t.Fatalf("expected 1 [features] header, got %d; result:\n%s", count, result)
+	}
+	if !strings.Contains(result, "multi_agent = false") {
+		t.Fatalf("result missing multi_agent = false; got:\n%s", result)
+	}
+	if strings.Contains(result, "multi_agent = true") {
+		t.Fatalf("result still has old value multi_agent = true; got:\n%s", result)
+	}
+	count2 := strings.Count(result, "multi_agent")
+	if count2 != 1 {
+		t.Fatalf("expected 1 multi_agent key, got %d; result:\n%s", count2, result)
+	}
+}
+
+func TestUpsertTOMLTableKey_PreservesOtherTables(t *testing.T) {
+	// Upserting [features].multi_agent must not disturb [agents] or top-level keys.
+	input := `model = "gpt-4o"
+
+[agents]
+max_threads = 4
+max_depth = 2
+`
+	result := UpsertTOMLTableKey(input, "features", "multi_agent", "false")
+
+	if !strings.Contains(result, `model = "gpt-4o"`) {
+		t.Fatalf("result missing top-level model key; got:\n%s", result)
+	}
+	if !strings.Contains(result, "[agents]") {
+		t.Fatalf("result missing [agents] section; got:\n%s", result)
+	}
+	if !strings.Contains(result, "max_threads = 4") {
+		t.Fatalf("result missing max_threads; got:\n%s", result)
+	}
+	if !strings.Contains(result, "[features]") {
+		t.Fatalf("result missing new [features] section; got:\n%s", result)
+	}
+	if !strings.Contains(result, "multi_agent = false") {
+		t.Fatalf("result missing multi_agent; got:\n%s", result)
+	}
+}
+
+func TestUpsertTOMLTableKey_Idempotent(t *testing.T) {
+	input := "[agents]\nmax_threads = 2\n"
+	first := UpsertTOMLTableKey(input, "agents", "max_threads", "4")
+	second := UpsertTOMLTableKey(first, "agents", "max_threads", "4")
+
+	if first != second {
+		t.Fatalf("UpsertTOMLTableKey is not idempotent:\nfirst:\n%s\nsecond:\n%s", first, second)
+	}
+	count := strings.Count(second, "max_threads")
+	if count != 1 {
+		t.Fatalf("after two runs: expected 1 max_threads key, got %d; result:\n%s", count, second)
+	}
+}
+
+func TestUpsertTOMLTableKey_BareValues(t *testing.T) {
+	// Boolean and integer rawValues must be written unquoted.
+	r1 := UpsertTOMLTableKey("", "features", "multi_agent", "false")
+	if !strings.Contains(r1, "multi_agent = false") {
+		t.Fatalf("bool false must be bare (no quotes); got:\n%s", r1)
+	}
+	if strings.Contains(r1, `"false"`) {
+		t.Fatalf("bool false must NOT be quoted; got:\n%s", r1)
+	}
+
+	r2 := UpsertTOMLTableKey("", "agents", "max_threads", "4")
+	if !strings.Contains(r2, "max_threads = 4") {
+		t.Fatalf("integer 4 must be bare (no quotes); got:\n%s", r2)
+	}
+	if strings.Contains(r2, `"4"`) {
+		t.Fatalf("integer 4 must NOT be quoted; got:\n%s", r2)
+	}
+}
+
+func TestUpsertTOMLTableKey_MultipleKeysInSection(t *testing.T) {
+	// Upserting a second key to an existing section keeps the first key intact.
+	input := "[agents]\nmax_threads = 4\n"
+	result := UpsertTOMLTableKey(input, "agents", "max_depth", "2")
+
+	if !strings.Contains(result, "max_threads = 4") {
+		t.Fatalf("result missing original max_threads key; got:\n%s", result)
+	}
+	if !strings.Contains(result, "max_depth = 2") {
+		t.Fatalf("result missing new max_depth key; got:\n%s", result)
+	}
+	count := strings.Count(result, "[agents]")
+	if count != 1 {
+		t.Fatalf("expected 1 [agents] header, got %d; result:\n%s", count, result)
+	}
+}
+
+func TestUpsertTOMLTableKey_ScopedToTargetSection(t *testing.T) {
+	// A same-named key in [other] must NOT be touched when upserting into [agents].
+	input := `[other]
+max_threads = 99
+
+[agents]
+max_threads = 2
+`
+	result := UpsertTOMLTableKey(input, "agents", "max_threads", "4")
+
+	// [agents].max_threads updated; [other].max_threads untouched.
+	if strings.Count(result, "max_threads = 99") != 1 {
+		t.Fatalf("[other].max_threads=99 must be preserved exactly once; got:\n%s", result)
+	}
+	if strings.Count(result, "max_threads = 4") != 1 {
+		t.Fatalf("[agents].max_threads=4 must appear exactly once; got:\n%s", result)
+	}
+	if strings.Contains(result, "max_threads = 2") {
+		t.Fatalf("old [agents].max_threads=2 must be removed; got:\n%s", result)
+	}
+}

--- a/internal/model/selection.go
+++ b/internal/model/selection.go
@@ -9,6 +9,7 @@ type Selection struct {
 	SDDMode                SDDModeID
 	SDDProfileStrategy     SDDProfileStrategyID
 	StrictTDD              bool
+	CodexMultiAgent        bool                        // opt-in: write features.multi_agent = true in ~/.codex/config.toml (default false; experimental)
 	ModelAssignments       map[string]ModelAssignment  // key = sub-agent name (e.g., "sdd-init")
 	ClaudeModelAssignments map[string]ClaudeModelAlias // key = phase name; value = opus|sonnet|haiku
 	KiroModelAssignments   map[string]KiroModelAlias   // key = phase name; value = Kiro-native model alias

--- a/testdata/golden/sdd-codex-agentsmd.golden
+++ b/testdata/golden/sdd-codex-agentsmd.golden
@@ -1,118 +1,108 @@
 <!-- gentle-ai:sdd-orchestrator -->
-# Agent Teams Lite — Orchestrator Rule for Codex
+# SDD Orchestrator for Codex
 
 Bind this to the dedicated `sdd-orchestrator` agent or rule only. Do NOT apply it to executor phase agents such as `sdd-apply` or `sdd-verify`.
 
-## Agent Teams Orchestrator
-
-You are a COORDINATOR, not an executor. Maintain one thin conversation thread, delegate ALL real work to sub-agents, synthesize results.
-
-
-### Language Domain Contract
+## Language Domain Contract
 
 - The active persona controls direct user/orchestrator conversation only. Use it for direct replies, clarification prompts, and user-facing orchestration status.
 - Generated technical artifacts default to English regardless of the active persona or conversation language. This includes OpenSpec files, specs, designs, tasks, code comments, UI copy, tests, fixtures, and delegated phase outputs.
 - If Spanish technical artifacts are explicitly requested, use neutral/professional Spanish unless the user explicitly asks for a regional variant.
 - Public/contextual comments follow the target context language by default. Explicit user language or tone overrides win; Spanish comments default to neutral/professional Spanish unless the user or target context clearly calls for regional tone.
-- When delegating, forward this contract to the executor so persona voice never becomes the artifact or public-comment default.
+- When delegating a phase, forward this contract so persona voice never becomes the artifact or public-comment default.
 
-### Delegation Rules
+## Capability Check (run once, at session start)
 
-Core principle: **does this inflate my context without need?** If yes → delegate. If no → do it inline.
+Check `~/.codex/config.toml` for `features.multi_agent`:
 
-| Action | Inline | Delegate |
-|--------|--------|----------|
-| Read to decide/verify (1-3 files) | ✅ | — |
-| Read to explore/understand (4+ files) | — | ✅ |
-| Read as preparation for writing | — | ✅ together with the write |
-| Write atomic (one file, mechanical, you already know what) | ✅ | — |
-| Write with analysis (multiple files, new logic) | — | ✅ |
-| Bash for state (git, gh) | ✅ | — |
-| Bash for execution (test, build, install) | — | ✅ |
+- If `features.multi_agent = true` **AND** the tools `spawn_agent`, `wait_agent`, and `close_agent` are available in this session → use the **Delegated path** below.
+- Otherwise (default) → use the **Solo path** below.
 
-delegate (async) is the default for delegated work. Use task (sync) only when you need the result before your next action.
+`features.multi_agent` defaults to `false` (written by gentle-ai during installation). To opt in, set `multi_agent = true` in the `[features]` section of `~/.codex/config.toml` and restart your session.
 
-Anti-patterns — these ALWAYS inflate context without need:
-- Reading 4+ files to "understand" the codebase inline → delegate an exploration
-- Writing a feature across multiple files inline → delegate
-- Running tests or builds inline → delegate
-- Reading files as preparation for edits, then editing → delegate the whole thing together
+---
 
-Delegation is not optional once complexity appears. If a task crosses a trigger below, use the smallest useful sub-agent workflow instead of continuing as a monolithic executor.
+## Solo Path (default)
 
-#### Mandatory Delegation Triggers
+Run each SDD phase inline, in dependency order, without spawning sub-agents. You are the executor for all phases.
 
-These are parent-orchestrator stop rules. Once any trigger fires, the orchestrator MUST delegate or explicitly tell the user why delegation would be unsafe or wasteful for this exact case. Do not pass these rules to child agents as permission to spawn more agents; children receive concrete role work and must not orchestrate.
+```
+proposal → spec → design → tasks → apply → verify → archive
+```
 
-1. **4-file rule**: if understanding requires reading 4+ files, delegate a narrow exploration/mapping task.
-2. **Multi-file write rule**: if implementation will touch 2+ non-trivial files, delegate one writer or continue inline only if a fresh review will audit before completion.
-3. **PR rule**: before commit, push, or PR after code changes, run a fresh-context review unless the diff is trivial docs/text.
-4. **Incident rule**: after wrong `cwd`, accidental repo/worktree mutation, merge recovery, confusing test command, or environment workaround, stop and run a fresh audit before continuing.
-5. **Long-session rule**: after roughly 20 tool calls, 5 exploratory file reads, or 2 non-mechanical edits without delegation and growing complexity, pause and delegate instead of silently continuing monolithically.
-6. **Fresh review rule**: use fresh context for adversarial review of diffs, conflicts, PR readiness, and incidents; use continuity/forked context only for implementation work that needs inherited state.
+For each phase:
+1. Read the required input artifacts from engram or the openspec directory.
+2. Produce the phase output inline in your current context.
+3. Persist the artifact to the active backend (engram or openspec) before proceeding.
 
-#### Cost and Context Balance
+**Dependency graph** (run phases in this order; spec and design can run in parallel):
+- `sdd-propose` → read nothing, write proposal
+- `sdd-spec` → read proposal, write spec
+- `sdd-design` → read proposal, write design
+- `sdd-tasks` → read spec + design, write tasks
+- `sdd-apply` → read tasks + spec + design, write apply-progress
+- `sdd-verify` → read spec + tasks + apply-progress, write verify-report
+- `sdd-archive` → read all artifacts, write archive-report
 
-- Use exploration sub-agents to compress broad repo reading into a short handoff.
-- Use a single writer thread for implementation; do not run parallel writers unless isolated worktrees are explicitly approved.
-- Use fresh reviewers after implementation, conflict resolution, or incidents because their value is independent judgment, not token saving.
-- Avoid delegation for truly local one-file fixes, quick state checks, and already-understood mechanical edits.
+Strict TDD: when the project has `strict_tdd: true` in `sdd-init` context, always follow the RED → GREEN → REFACTOR cycle in `sdd-apply`. Failing test first, then implementation.
 
+---
+
+## Delegated Path (opt-in, requires features.multi_agent = true)
+
+When multi-agent tools are available, delegate each SDD phase to a sub-agent using Codex's native tool set:
+
+- `spawn_agent` — launch a phase sub-agent
+- `send_input` — send a message to a running agent
+- `wait_agent` — block until the agent completes and collect its result
+- `close_agent` — terminate a completed or idle agent
+
+**Thread budget**: `agents.max_threads = 4`, `agents.max_depth = 2` (set in `~/.codex/config.toml`).
+
+### Phase delegation pattern
+
+For each phase:
+1. Determine the correct profile for the phase tier (see Model Profiles below).
+2. `spawn_agent` with the phase prompt and `--profile <profile-name>` so the sub-agent runs at the correct cost/quality tier.
+3. `wait_agent` to collect the result.
+4. `close_agent` to release the thread.
+5. Verify the artifact was persisted before launching the next phase.
+
+Example — launching `sdd-design`:
+```
+spawn_agent("sdd-design", prompt=<design prompt>, profile="sdd-strong")
+wait_agent("sdd-design")
+close_agent("sdd-design")
+```
+
+### Parallelism
+
+`sdd-spec` and `sdd-design` have the same input (proposal) and independent outputs. Spawn them in parallel (both `spawn_agent` calls before either `wait_agent`) when your thread budget allows.
+
+### Graceful degradation
+
+If `spawn_agent` returns an error (tool unavailable, thread budget exhausted, or permission denied), fall back to the **Solo path** for the remaining phases. Do not abort the SDD pipeline — complete it inline.
+
+---
 
 ## SDD Workflow (Spec-Driven Development)
 
-SDD is the structured planning layer for substantial changes.
-
-### Artifact Store Policy
-
-- `engram` — default when available; persistent memory across sessions
-- `openspec` — file-based artifacts; use only when user explicitly requests
-- `hybrid` — both backends; cross-session recovery + local files; more tokens per op
-- `none` — return results inline only; recommend enabling engram or openspec
-
 ### Commands
 
-Skills (appear in autocomplete):
 - `/sdd-init` → initialize SDD context; detects stack, bootstraps persistence
-- `/sdd-explore <topic>` → investigate an idea; reads codebase, compares approaches; no files created
-- `/sdd-status [change]` → read-only structured status for active change, artifacts, tasks, and next action
+- `/sdd-explore <topic>` → investigate an idea; no artifacts created
 - `/sdd-apply [change]` → implement tasks in batches; checks off items as it goes
-- `/sdd-verify [change]` → validate implementation against specs; reports CRITICAL / WARNING / SUGGESTION
-- `/sdd-archive [change]` → close a change and persist final state in the active artifact store 
-- `/sdd-onboard` → guided end-to-end walkthrough of SDD using your real codebase
-
-Meta-commands (type directly — orchestrator handles them, won't appear in autocomplete):
-- `/sdd-new <change>` → start a new change by delegating exploration + proposal to sub-agents
-- `/sdd-continue [change]` → run the next dependency-ready phase via sub-agent(s)
-- `/sdd-ff <name>` → fast-forward planning: proposal → specs → design → tasks
-
-`/sdd-new`, `/sdd-continue`, and `/sdd-ff` are meta-commands handled by YOU. Do NOT invoke them as skills.
-
-### SDD Init Guard (MANDATORY)
-
-Before executing ANY SDD command (`/sdd-new`, `/sdd-ff`, `/sdd-continue`, `/sdd-explore`, `/sdd-status`, `/sdd-apply`, `/sdd-verify`, `/sdd-archive`), check if `sdd-init` has been run for this project:
-
-1. Search Engram: `mem_search(query: "sdd-init/{project}", project: "{project}")`
-2. If found → init was done, proceed normally
-3. If NOT found → run `sdd-init` FIRST (delegate to sdd-init sub-agent), THEN proceed with the requested command
-
-This ensures:
-- Testing capabilities are always detected and cached
-- Strict TDD Mode is activated when the project supports it
-- The project context (stack, conventions) is available for all phases
-
-Do NOT skip this check. Do NOT ask the user — just run init silently if needed.
+- `/sdd-verify [change]` → validate implementation against specs
+- `/sdd-archive [change]` → close a change and persist final state
 
 ### Execution Mode
 
-When the user invokes `/sdd-new`, `/sdd-ff`, or `/sdd-continue` (or an equivalent natural-language request, e.g. "haceme un SDD para X" / "do SDD for X") for the first time in a session, ASK which execution mode they prefer:
+When the user invokes `/sdd-new`, `/sdd-ff`, or `/sdd-continue` for the first time in a session, ask which execution mode they prefer:
 
-- **Automatic** (`auto`): Run all phases back-to-back without pausing. Show the final result only. Use this when the user wants speed and trusts the process.
-- **Interactive** (`interactive`): After each phase completes, show the result summary and ASK: "Want to adjust anything or continue?" before proceeding to the next phase. Use this when the user wants to review and steer each step.
+- **Automatic** (`auto`): Run all phases back-to-back. Show the final result only.
+- **Interactive** (`interactive`): After each phase, show the result summary and ask before proceeding.
 
 If the user doesn't specify, default to **Interactive** (safer, gives the user control).
-
-Cache the mode choice for the session — don't ask again unless the user explicitly requests a mode change.
 
 In **Interactive** mode, between phases:
 1. Show a concise summary of what the phase produced
@@ -128,19 +118,17 @@ Before the `sdd-propose` phase in interactive mode, offer the user a proposal qu
 
 ### Artifact Store Mode
 
-When the user invokes `/sdd-new`, `/sdd-ff`, or `/sdd-continue` (or an equivalent natural-language request) for the first time in a session, ALSO ASK which artifact store they want for this change:
+When the user invokes `/sdd-new`, `/sdd-ff`, or `/sdd-continue` for the first time in a session, also ask which artifact store they want:
 
-- **`engram`**: Fast, no files created. Artifacts live in engram only. Best for solo work and quick iteration. Note: re-running a phase overwrites the previous version (no history).
-- **`openspec`**: File-based. Creates `openspec/` directory with full artifact trail. Committable, shareable with team, full git history.
-- **`hybrid`**: Both — files for team sharing + engram for cross-session recovery. Higher token cost.
+- **`engram`**: Fast, no files created. Best for solo work.
+- **`openspec`**: File-based. Creates `openspec/` directory. Committable, shareable.
+- **`hybrid`**: Both — files for team sharing + engram for cross-session recovery.
 
-If the user doesn't specify, detect: if engram is available → default to `engram`. Otherwise → `none`.
-
-Cache the artifact store choice for the session. Pass it as `artifact_store.mode` to every sub-agent launch.
+Default: `engram` when available. Cache the choice for the session.
 
 ### Delivery Strategy
 
-On the first `/sdd-new`, `/sdd-ff`, or `/sdd-continue` (or an equivalent natural-language request) in a session, ask once for and cache delivery strategy: `ask-on-risk` (default), `auto-chain`, `single-pr`, or `exception-ok`. Pass it as `delivery_strategy` to `sdd-tasks` and `sdd-apply` prompts.
+On the first `/sdd-new`, `/sdd-ff`, or `/sdd-continue` in a session, ask once for and cache delivery strategy: `ask-on-risk` (default), `auto-chain`, `single-pr`, or `exception-ok`. Pass it as `delivery_strategy` to `sdd-tasks` and `sdd-apply` prompts.
 
 ### Chain Strategy
 
@@ -151,162 +139,48 @@ When `delivery_strategy` results in chained PRs (either by user choice via `ask-
 
 Cache the chain strategy for the session. Pass it as `chain_strategy` to `sdd-tasks` and `sdd-apply` prompts alongside `delivery_strategy`. Do not ask again unless the user changes scope.
 
-### Dependency Graph
-```
-proposal -> specs --> tasks -> apply -> verify -> archive
-             ^
-             |
-           design
-```
-
-### Result Contract
-Each phase returns: `status`, `executive_summary`, `artifacts`, `next_recommended`, `risks`, `skill_resolution`.
-
 ### Review Workload Guard (MANDATORY)
 
-After `sdd-tasks` completes and before launching `sdd-apply`, inspect `Review Workload Forecast`.
+After `sdd-tasks` completes and before launching `sdd-apply`, inspect the task result summary for `Review Workload Forecast`.
 
-If it says `Chained PRs recommended: Yes`, `400-line budget risk: High`, estimated changed lines exceed 400, or `Decision needed before apply: Yes`, apply cached `delivery_strategy`:
+If it says `Chained PRs recommended: Yes`, `400-line budget risk: High`, estimated changed lines exceed 400, or `Decision needed before apply: Yes`, apply the cached `delivery_strategy`: `ask-on-risk` asks, `auto-chain` asks for a missing `chain_strategy` and applies only the next PR slice, `single-pr` requires `size:exception`, and `exception-ok` records the exception.
 
-- **`ask-on-risk`**: STOP and ask chained/stacked PRs vs maintainer-approved `size:exception`. If the user chooses chained PRs and `chain_strategy` is not yet cached, also ask which chain strategy to use (`stacked-to-main` or `feature-branch-chain`).
-- **`auto-chain`**: Do not ask about splitting. If `chain_strategy` is not yet cached, ask which chain strategy to use. Then tell `sdd-apply` to implement only the next autonomous chained/stacked PR slice using work-unit commits, clear start/finish boundaries, verification, and rollback.
-- **`single-pr`**: STOP and require/record `size:exception` before apply.
-- **`exception-ok`**: Continue, but tell `sdd-apply` this run uses `size:exception`.
+When launching `sdd-apply`, include the resolved `delivery_strategy`, `chain_strategy`, and any chosen PR boundary/exception in the prompt.
 
-Automatic mode does not override this guard. Always pass the resolved `delivery_strategy` and `chain_strategy` to `sdd-apply`.
+### Artifact store (engram default)
 
-When launching `sdd-apply`, always include the resolved `delivery_strategy`, `chain_strategy`, and any chosen PR boundary/exception in the prompt.
-
-### Sub-Agent Launch Deduplication (MANDATORY)
-
-Before emitting any delegation call, check your in-session launch log:
-
-- Maintain a session-scoped list of `(phase, task-fingerprint)` pairs already launched this turn.
-- The task fingerprint is a short hash or normalized summary of the instruction text (phase name + key artifact references).
-- If the same `(phase, task-fingerprint)` already appears in the list, **do NOT launch again**. Emit exactly one launch per distinct task.
-- After launching, append the pair to the list.
-
-This prevents duplicate sub-agent launches that cause "File X has been modified since it was last read" conflicts and waste tokens.
-
-### Sub-Agent Launch Pattern
-
-ALL sub-agent launch prompts that involve reading, writing, or reviewing code MUST include pre-resolved **skill paths** from the skill registry. Follow the **Skill Resolver Protocol** (see `_shared/skill-resolver.md` in the skills directory).
-
-The orchestrator resolves skills from the registry ONCE (at session start or first delegation), caches the skill index, and passes matching `SKILL.md` paths into each sub-agent's prompt.
-
-Orchestrator skill resolution (do once per session):
-1. `mem_search(query: "skill-registry", project: "{project}")` → `mem_get_observation(id)` for full registry content
-2. Fallback: read `.atl/skill-registry.md` if engram not available
-3. Cache the skill index: skill name, trigger/description, scope, and exact path
-4. If no registry exists, warn user and proceed without project-specific standards
-
-For each sub-agent launch:
-1. Match relevant skills by **code context** (file extensions/paths the sub-agent will touch) AND **task context** (what actions it will perform — review, PR creation, testing, etc.)
-2. Copy matching `SKILL.md` paths into the sub-agent prompt as `## Skills to load before work`
-3. Instruct the sub-agent to read those exact files BEFORE task-specific work
-
-**Key rule**: pass paths, not generated summaries. Sub-agents read the full `SKILL.md` files so author intent is preserved. This is compaction-safe because each delegation can re-read the registry if the cache is lost.
-
-### Skill Resolution Feedback
-
-After every delegation that returns a result, check the `skill_resolution` field:
-- `paths-injected` → all good, exact skill paths were passed and loaded
-- `fallback-registry`, `fallback-path`, or `none` → skill cache was lost (likely compaction). Re-read the registry immediately and pass skill paths in all subsequent delegations.
-
-This is a self-correction mechanism. Do NOT ignore fallback reports — they indicate the orchestrator dropped context.
-
-### Sub-Agent Context Protocol
-
-Sub-agents get a fresh context with NO memory. The orchestrator controls context access.
-
-#### Non-SDD Tasks (general delegation)
-
-- Read context: orchestrator searches engram (`mem_search`) for relevant prior context and passes it in the sub-agent prompt. Sub-agent does NOT search engram itself.
-- Write context: sub-agent MUST save significant discoveries, decisions, or bug fixes to engram via `mem_save` before returning. Sub-agent has full detail — save before returning, not after.
-- Always add to sub-agent prompt: `"If you make important discoveries, decisions, or fix bugs, save them to engram via mem_save with project: '{project}'."`
-- Skills: orchestrator resolves matching paths from the registry and injects them as `## Skills to load before work` in the sub-agent prompt. Sub-agents read those exact `SKILL.md` files before work.
-
-#### SDD Phases
-
-Each phase has explicit read/write rules:
-
-| Phase | Reads | Writes |
-|-------|-------|--------|
-| `sdd-explore` | nothing | `explore` |
-| `sdd-propose` | exploration (optional) | `proposal` |
-| `sdd-spec` | proposal (required) | `spec` |
-| `sdd-design` | proposal (required) | `design` |
-| `sdd-tasks` | spec + design (required) | `tasks` |
-| `sdd-apply` | tasks + spec + design + **apply-progress (if exists)** | `apply-progress` |
-| `sdd-verify` | spec + tasks + **apply-progress** | `verify-report` |
-| `sdd-archive` | all artifacts | `archive-report` |
-
-For phases with required dependencies, sub-agent reads directly from the backend — orchestrator passes artifact references (topic keys or file paths), NOT content itself.
-
-#### Strict TDD Forwarding (MANDATORY)
-
-When launching `sdd-apply` or `sdd-verify` sub-agents, the orchestrator MUST:
-
-1. Search for testing capabilities: `mem_search(query: "sdd-init/{project}", project: "{project}")`
-2. If the result contains `strict_tdd: true`:
-   - Add to the sub-agent prompt: `"STRICT TDD MODE IS ACTIVE. Test runner: {test_command}. You MUST follow strict-tdd.md. Do NOT fall back to Standard Mode."`
-   - This is NON-NEGOTIABLE. Do not rely on the sub-agent discovering this independently.
-3. If the search fails or `strict_tdd` is not found, do NOT add the TDD instruction (sub-agent uses Standard Mode).
-
-The orchestrator resolves TDD status ONCE per session (at first apply/verify launch) and caches it.
-
-#### Apply-Progress Continuity (MANDATORY)
-
-When launching `sdd-apply` for a continuation batch (not the first batch):
-
-1. Search for existing apply-progress: `mem_search(query: "sdd/{change-name}/apply-progress", project: "{project}")`
-2. If found, add to the sub-agent prompt: `"PREVIOUS APPLY-PROGRESS EXISTS at topic_key 'sdd/{change-name}/apply-progress'. You MUST read it first via mem_search + mem_get_observation, merge your new progress with the existing progress, and save the combined result. Do NOT overwrite — MERGE."`
-3. If not found (first batch), no special instruction needed.
-
-This prevents progress loss across batches. The sub-agent is responsible for read-merge-write, but the orchestrator MUST tell it that previous progress exists.
-
-#### Engram Topic Key Format
-
-When launching sub-agents for SDD phases with engram mode, pass these exact topic_keys as artifact references:
-
-| Artifact | Topic Key |
+| Artifact | Topic key |
 |----------|-----------|
 | Project context | `sdd-init/{project}` |
-| Exploration | `sdd/{change-name}/explore` |
-| Proposal | `sdd/{change-name}/proposal` |
-| Spec | `sdd/{change-name}/spec` |
-| Design | `sdd/{change-name}/design` |
-| Tasks | `sdd/{change-name}/tasks` |
-| Apply progress | `sdd/{change-name}/apply-progress` |
-| Verify report | `sdd/{change-name}/verify-report` |
-| Archive report | `sdd/{change-name}/archive-report` |
-| DAG state | `sdd/{change-name}/state` |
+| Proposal | `sdd/{change}/proposal` |
+| Spec | `sdd/{change}/spec` |
+| Design | `sdd/{change}/design` |
+| Tasks | `sdd/{change}/tasks` |
+| Apply progress | `sdd/{change}/apply-progress` |
+| Verify report | `sdd/{change}/verify-report` |
+| Archive report | `sdd/{change}/archive-report` |
 
-Sub-agents retrieve full content via two steps:
-1. `mem_search(query: "{topic_key}", project: "{project}")` → get observation ID
-2. `mem_get_observation(id: {id})` → full content (REQUIRED — search results are truncated)
+Retrieve full content: `mem_search(query: "{topic_key}")` → `mem_get_observation(id)`.
 
 ### State and Conventions
 
 Convention files under `~/.codex/skills/_shared/` (global) or `.agent/skills/_shared/` (workspace): `engram-convention.md`, `persistence-contract.md`, `openspec-convention.md`.
 
-### Recovery Rule
+### Result contract
 
-- `engram` → `mem_search(...)` → `mem_get_observation(...)`
-- `openspec` → read `openspec/changes/*/state.yaml`
-- `none` → state not persisted — explain to user
+Each phase returns: `status`, `executive_summary`, `artifacts`, `next_recommended`, `risks`.
+
+---
 
 ## Model Profiles
 
 gentle-ai writes three SDD model-selection profile files into `~/.codex/` during installation. Each profile sets `model_reasoning_effort` so Codex picks the right model tier at runtime — no hardcoded model IDs.
 
-Select a profile when running a phase: `codex --profile <name>`
+Select a profile when spawning a phase agent: `--profile <name>`
 
 | Profile | `model_reasoning_effort` | SDD phases |
 |---------|--------------------------|------------|
 | `sdd-strong` | `xhigh` | propose, design, verify, judge |
 | `sdd-mid` | `high` | spec, tasks, apply |
 | `sdd-cheap` | `low` | explore, archive, onboard |
-
-When spawning a phase agent (once multi-agent delegation is enabled via `features.multi_agent = true`), pass the matching profile name so the sub-agent runs at the appropriate cost/quality tier. Example: for a `sdd-design` phase, use `--profile sdd-strong`.
 <!-- /gentle-ai:sdd-orchestrator -->

--- a/testdata/golden/sdd-codex-agentsmd.golden
+++ b/testdata/golden/sdd-codex-agentsmd.golden
@@ -62,18 +62,21 @@ When multi-agent tools are available, delegate each SDD phase to a sub-agent usi
 ### Phase delegation pattern
 
 For each phase:
-1. Determine the correct profile for the phase tier (see Model Profiles below).
-2. `spawn_agent` with the phase prompt and `--profile <profile-name>` so the sub-agent runs at the correct cost/quality tier.
-3. `wait_agent` to collect the result.
-4. `close_agent` to release the thread.
-5. Verify the artifact was persisted before launching the next phase.
+1. Determine the phase tier and its `reasoning_effort` value (see Model Profiles below): `xhigh` for propose/design/verify/judge, `high` for spec/tasks/apply, `low` for explore/archive/onboard.
+2. `spawn_agent` with `task_name`, the phase prompt as `message`, and `reasoning_effort` set to the tier value. The `spawn_agent` tool has NO `profile` parameter — tier selection is the `reasoning_effort` argument, not a profile name.
+3. Set `fork_turns: "none"` whenever you override `reasoning_effort` or `model`. A full-history fork (the default) REJECTS these overrides, so the override is silently ignored unless `fork_turns` is `"none"`.
+4. `wait_agent` to collect the result.
+5. `close_agent` to release the thread.
+6. Verify the artifact was persisted before launching the next phase.
 
-Example — launching `sdd-design`:
+Example — launching `sdd-design` at the strong tier:
 ```
-spawn_agent("sdd-design", prompt=<design prompt>, profile="sdd-strong")
-wait_agent("sdd-design")
-close_agent("sdd-design")
+spawn_agent(task_name="sdd-design", message=<design prompt>, reasoning_effort="xhigh", fork_turns="none")
+wait_agent(task_name="sdd-design")
+close_agent(task_name="sdd-design")
 ```
+
+Note: the `~/.codex/<tier>.config.toml` profile files apply to whole CLI sessions launched with `codex --profile <name>`. They do NOT apply to spawned sub-agents — for those, pass `reasoning_effort` directly as shown above.
 
 ### Parallelism
 
@@ -174,12 +177,12 @@ Each phase returns: `status`, `executive_summary`, `artifacts`, `next_recommende
 
 ## Model Profiles
 
-gentle-ai writes three SDD model-selection profile files into `~/.codex/` during installation. Each profile sets `model_reasoning_effort` so Codex picks the right model tier at runtime — no hardcoded model IDs.
+gentle-ai writes three SDD model-selection profile files into `~/.codex/` during installation. Each profile sets `model_reasoning_effort` so Codex picks the right tier — no hardcoded model IDs.
 
-Select a profile when spawning a phase agent: `--profile <name>`
+These profile files apply to whole CLI sessions: `codex --profile <name> "<prompt>"`. They do NOT apply to spawned sub-agents. When delegating a phase via `spawn_agent`, pass the tier's effort directly as `reasoning_effort` (with `fork_turns: "none"`), using the same tier values below.
 
-| Profile | `model_reasoning_effort` | SDD phases |
-|---------|--------------------------|------------|
+| Profile (CLI) | `reasoning_effort` (spawn_agent) | SDD phases |
+|---------------|----------------------------------|------------|
 | `sdd-strong` | `xhigh` | propose, design, verify, judge |
 | `sdd-mid` | `high` | spec, tasks, apply |
 | `sdd-cheap` | `low` | explore, archive, onboard |


### PR DESCRIPTION
Closes #755

> **Chained PR** — targets `feat/codex-profiles` (PR #754), not `main`. Review/merge after PR1 and PR2.

### PR Type
- [x] New feature

### Summary
- Write a default-OFF, experimental multi-agent block to `~/.codex/config.toml` (`[features] multi_agent=false`, `[agents] max_threads=4 / max_depth=2`), idempotently composed with the engram + context7 blocks.
- Rewrite the Codex sdd-orchestrator asset to a capability-gated solo/delegated structure with graceful solo-agent fallback; delegated path uses the PR2 profiles per phase.
- Add a nested-table TOML upsert helper (`UpsertTOMLTableKey`). Keep `SupportsSubAgents()=false` (regression-guarded).

### Changes
| File | Change |
|------|--------|
| `internal/components/filemerge/toml.go` | New `UpsertTOMLTableKey` (nested-table upsert, in-place key replace) |
| `internal/components/filemerge/toml_test.go` | Helper tests |
| `internal/model/selection.go` | `CodexMultiAgent bool` option (default false) |
| `internal/components/engram/inject.go` | `InjectOptions`/`InjectWithOptions`; writes multi-agent block in the Codex mutation chain |
| `internal/components/engram/inject_test.go` | Multi-agent + idempotency tests |
| `internal/agents/codex/adapter_test.go` | Regression guard: SupportsSubAgents stays false |
| `internal/assets/codex/sdd-orchestrator.md` | Capability-gated rewrite (solo/delegated + fallback) |
| `testdata/golden/sdd-codex-agentsmd.golden` | Updated golden |
| `docs/agents.md` | Multi-agent opt-in note |

### Test Plan
- [x] `go test ./...` passes (full suite green)
- [x] `go vet` clean on touched packages
- [x] Idempotency: re-running injection does not duplicate `[features]`/`[agents]` and keeps engram + context7 blocks intact

### Contributor Checklist
- [x] Linked an approved issue (#755)
- [x] Added exactly one `type:*` label
- [x] Tests added/updated (strict TDD)
- [x] Docs updated
- [x] Conventional commit format
- [x] No Co-Authored-By trailers