### PR TITLE
feat(codex): TUI per-phase SDD model picker with plan-tied presets

### DIFF
--- a/internal/agents/codex/adapter.go
+++ b/internal/agents/codex/adapter.go
@@ -159,6 +159,13 @@ func (a *Adapter) SupportsMCP() bool {
 	return true
 }
 
+// RenderCodexPhaseEfforts implements codexModelResolver. It delegates to
+// model.RenderCodexPhaseEfforts so that inject.go can substitute the
+// {{CODEX_PHASE_EFFORTS}} placeholder in the Codex orchestrator asset.
+func (a *Adapter) RenderCodexPhaseEfforts(assignments map[string]model.CodexEffort) string {
+	return model.RenderCodexPhaseEfforts(assignments)
+}
+
 func defaultStat(path string) statResult {
 	info, err := os.Stat(path)
 	if err != nil {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -364,6 +364,7 @@ func tuiExecute(
 			InstalledAgents:        agentIDs,
 			ClaudeModelAssignments: claudeAliasesToStrings(selection.ClaudeModelAssignments),
 			KiroModelAssignments:   kiroAliasesToStrings(selection.KiroModelAssignments),
+			CodexModelAssignments:  codexEffortsToStrings(selection.CodexModelAssignments),
 			ModelAssignments:       modelAssignmentsToState(selection.ModelAssignments),
 			Persona:                string(selection.Persona),
 		})
@@ -472,6 +473,9 @@ func applyOverrides(selection *model.Selection, overrides *model.SyncOverrides) 
 	if overrides.KiroModelAssignments != nil {
 		selection.KiroModelAssignments = overrides.KiroModelAssignments
 	}
+	if overrides.CodexModelAssignments != nil {
+		selection.CodexModelAssignments = overrides.CodexModelAssignments
+	}
 	if overrides.SDDMode != "" {
 		selection.SDDMode = overrides.SDDMode
 	}
@@ -517,6 +521,13 @@ func loadPersistedAssignments(homeDir string, selection *model.Selection) {
 		}
 		selection.KiroModelAssignments = m
 	}
+	if len(selection.CodexModelAssignments) == 0 && len(s.CodexModelAssignments) > 0 {
+		m := make(map[string]model.CodexEffort, len(s.CodexModelAssignments))
+		for k, v := range s.CodexModelAssignments {
+			m[k] = model.CodexEffort(v)
+		}
+		selection.CodexModelAssignments = m
+	}
 	if len(selection.ModelAssignments) == 0 && len(s.ModelAssignments) > 0 {
 		m := make(map[string]model.ModelAssignment, len(s.ModelAssignments))
 		for k, v := range s.ModelAssignments {
@@ -530,7 +541,7 @@ func loadPersistedAssignments(homeDir string, selection *model.Selection) {
 // state.json using a read-merge-write pattern so that other fields
 // (InstalledAgents) are not lost.
 func persistAssignments(homeDir string, selection model.Selection) {
-	if len(selection.ClaudeModelAssignments) == 0 && len(selection.KiroModelAssignments) == 0 && len(selection.ModelAssignments) == 0 {
+	if len(selection.ClaudeModelAssignments) == 0 && len(selection.KiroModelAssignments) == 0 && len(selection.ModelAssignments) == 0 && len(selection.CodexModelAssignments) == 0 {
 		return
 	}
 	current, err := state.Read(homeDir)
@@ -543,6 +554,9 @@ func persistAssignments(homeDir string, selection model.Selection) {
 	}
 	if len(selection.KiroModelAssignments) > 0 {
 		current.KiroModelAssignments = kiroAliasesToStrings(selection.KiroModelAssignments)
+	}
+	if len(selection.CodexModelAssignments) > 0 {
+		current.CodexModelAssignments = codexEffortsToStrings(selection.CodexModelAssignments)
 	}
 	if len(selection.ModelAssignments) > 0 {
 		current.ModelAssignments = modelAssignmentsToState(selection.ModelAssignments)
@@ -569,6 +583,19 @@ func claudeAliasesToStrings(m map[string]model.ClaudeModelAlias) map[string]stri
 }
 
 func kiroAliasesToStrings(m map[string]model.KiroModelAlias) map[string]string {
+	if len(m) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(m))
+	for k, v := range m {
+		out[k] = string(v)
+	}
+	return out
+}
+
+// codexEffortsToStrings converts a typed CodexEffort map to plain strings
+// for JSON serialisation in state.json.
+func codexEffortsToStrings(m map[string]model.CodexEffort) map[string]string {
 	if len(m) == 0 {
 		return nil
 	}

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -844,3 +844,84 @@ func setupMockHome(t *testing.T, home string) {
 	os.Setenv("HOME", home)
 	os.Setenv("USERPROFILE", home)
 }
+
+// TestApplyOverrides_CodexModelAssignments verifies that a non-nil
+// CodexModelAssignments override sets the selection.
+func TestApplyOverrides_CodexModelAssignments(t *testing.T) {
+	sel := model.Selection{}
+	assignments := model.CodexModelPresetPowerful()
+	overrides := &model.SyncOverrides{
+		CodexModelAssignments: assignments,
+	}
+	applyOverrides(&sel, overrides)
+	if len(sel.CodexModelAssignments) != len(assignments) {
+		t.Fatalf("CodexModelAssignments len = %d, want %d", len(sel.CodexModelAssignments), len(assignments))
+	}
+	if sel.CodexModelAssignments["sdd-apply"] != model.CodexEffortHigh {
+		t.Errorf("CodexModelAssignments[sdd-apply] = %q, want high", sel.CodexModelAssignments["sdd-apply"])
+	}
+}
+
+// TestLoadPersistedAssignments_Codex verifies that state with codexModelAssignments
+// populates selection.CodexModelAssignments.
+func TestLoadPersistedAssignments_Codex(t *testing.T) {
+	home := t.TempDir()
+	if err := state.Write(home, state.InstallState{
+		InstalledAgents: []string{"codex"},
+		CodexModelAssignments: map[string]string{
+			"sdd-apply":   "medium",
+			"sdd-explore": "low",
+			"default":     "medium",
+		},
+	}); err != nil {
+		t.Fatalf("state.Write: %v", err)
+	}
+
+	sel := model.Selection{}
+	loadPersistedAssignments(home, &sel)
+
+	if sel.CodexModelAssignments["sdd-apply"] != model.CodexEffortMedium {
+		t.Errorf("CodexModelAssignments[sdd-apply] = %q, want medium", sel.CodexModelAssignments["sdd-apply"])
+	}
+}
+
+// TestLoadPersistedAssignments_CodexMissingKey verifies that a state without
+// codexModelAssignments leaves selection.CodexModelAssignments nil.
+func TestLoadPersistedAssignments_CodexMissingKey(t *testing.T) {
+	home := t.TempDir()
+	if err := state.Write(home, state.InstallState{
+		InstalledAgents: []string{"codex"},
+	}); err != nil {
+		t.Fatalf("state.Write: %v", err)
+	}
+
+	sel := model.Selection{}
+	loadPersistedAssignments(home, &sel)
+
+	if sel.CodexModelAssignments != nil {
+		t.Errorf("CodexModelAssignments = %v, want nil when key absent", sel.CodexModelAssignments)
+	}
+}
+
+// TestPersistAssignments_Codex verifies that non-empty CodexModelAssignments
+// are persisted to state.json.
+func TestPersistAssignments_Codex(t *testing.T) {
+	home := t.TempDir()
+	// Write initial state so state.Read succeeds.
+	if err := state.Write(home, state.InstallState{InstalledAgents: []string{"codex"}}); err != nil {
+		t.Fatalf("state.Write: %v", err)
+	}
+
+	sel := model.Selection{
+		CodexModelAssignments: model.CodexModelPresetLowCost(),
+	}
+	persistAssignments(home, sel)
+
+	s, err := state.Read(home)
+	if err != nil {
+		t.Fatalf("state.Read: %v", err)
+	}
+	if s.CodexModelAssignments["sdd-apply"] != "medium" {
+		t.Errorf("state.CodexModelAssignments[sdd-apply] = %q, want medium", s.CodexModelAssignments["sdd-apply"])
+	}
+}

--- a/internal/assets/codex/sdd-orchestrator.md
+++ b/internal/assets/codex/sdd-orchestrator.md
@@ -180,8 +180,4 @@ gentle-ai writes three SDD model-selection profile files into `~/.codex/` during
 
 These profile files apply to whole CLI sessions: `codex --profile <name> "<prompt>"`. They do NOT apply to spawned sub-agents. When delegating a phase via `spawn_agent`, pass the tier's effort directly as `reasoning_effort` (with `fork_turns: "none"`), using the same tier values below.
 
-| Profile (CLI) | `reasoning_effort` (spawn_agent) | SDD phases |
-|---------------|----------------------------------|------------|
-| `sdd-strong` | `xhigh` | propose, design, verify, judge |
-| `sdd-mid` | `high` | spec, tasks, apply |
-| `sdd-cheap` | `low` | explore, archive, onboard |
+{{CODEX_PHASE_EFFORTS}}

--- a/internal/assets/codex/sdd-orchestrator.md
+++ b/internal/assets/codex/sdd-orchestrator.md
@@ -15,9 +15,9 @@ Bind this to the dedicated `sdd-orchestrator` agent or rule only. Do NOT apply i
 Check `~/.codex/config.toml` for `features.multi_agent`:
 
 - If `features.multi_agent = true` **AND** the tools `spawn_agent`, `wait_agent`, and `close_agent` are available in this session → use the **Delegated path** below.
-- Otherwise (default) → use the **Solo path** below.
+- Otherwise → use the **Solo path** below.
 
-`features.multi_agent` defaults to `false` (written by gentle-ai during installation). To opt in, set `multi_agent = true` in the `[features]` section of `~/.codex/config.toml` and restart your session.
+`features.multi_agent` is enabled by default (gentle-ai writes `multi_agent = true` during installation) so SDD delegates phases and the per-phase reasoning_effort table applies. To force solo execution, set `multi_agent = false` in the `[features]` section of `~/.codex/config.toml` and restart your session.
 
 ---
 
@@ -47,7 +47,7 @@ Strict TDD: when the project has `strict_tdd: true` in `sdd-init` context, alway
 
 ---
 
-## Delegated Path (opt-in, requires features.multi_agent = true)
+## Delegated Path (default, requires features.multi_agent = true)
 
 When multi-agent tools are available, delegate each SDD phase to a sub-agent using Codex's native tool set:
 
@@ -61,7 +61,7 @@ When multi-agent tools are available, delegate each SDD phase to a sub-agent usi
 ### Phase delegation pattern
 
 For each phase:
-1. Determine the phase tier and its `reasoning_effort` value (see Model Profiles below): `xhigh` for propose/design/verify/judge, `high` for spec/tasks/apply, `low` for explore/archive/onboard.
+1. Look up the phase's `reasoning_effort` value in the **Model Profiles** table below (the values are preset-driven and written by gentle-ai — do not assume fixed tiers).
 2. `spawn_agent` with `task_name`, the phase prompt as `message`, and `reasoning_effort` set to the tier value. The `spawn_agent` tool has NO `profile` parameter — tier selection is the `reasoning_effort` argument, not a profile name.
 3. Set `fork_turns: "none"` whenever you override `reasoning_effort` or `model`. A full-history fork (the default) REJECTS these overrides, so the override is silently ignored unless `fork_turns` is `"none"`.
 4. `wait_agent` to collect the result.

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -634,6 +634,7 @@ func (s componentApplyStep) Run() error {
 				OpenCodeModelAssignments: s.selection.ModelAssignments,
 				ClaudeModelAssignments:   s.selection.ClaudeModelAssignments,
 				KiroModelAssignments:     s.selection.KiroModelAssignments,
+				CodexModelAssignments:    s.selection.CodexModelAssignments,
 				WorkspaceDir:             s.workspaceDir,
 				StrictTDD:                s.selection.StrictTDD,
 			}

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -614,6 +614,7 @@ func (s componentSyncStep) Run() error {
 				OpenCodeModelAssignments:           s.selection.ModelAssignments,
 				ClaudeModelAssignments:             s.selection.ClaudeModelAssignments,
 				KiroModelAssignments:               s.selection.KiroModelAssignments,
+				CodexModelAssignments:              s.selection.CodexModelAssignments,
 				WorkspaceDir:                       s.workspaceDir,
 				StrictTDD:                          s.selection.StrictTDD,
 				PreserveOpenCodeOrchestratorPrompt: profileStrategy == model.SDDProfileStrategyExternalSingleActive,

--- a/internal/components/engram/inject.go
+++ b/internal/components/engram/inject.go
@@ -401,16 +401,12 @@ func injectWithOptions(configHomeDir, promptDir string, adapter agents.Adapter, 
 		}
 
 		// Step 1 — multi-agent SDD enablement keys ([features] and [agents]).
-		// features.multi_agent defaults to false (experimental, opt-in only).
-		// Set Selection.CodexMultiAgent=true / InjectOptions{CodexMultiAgent:true}
-		// to write multi_agent=true. agents.max_threads and agents.max_depth are
-		// always written with conservative defaults so they are ready when the
-		// user enables multi_agent.
-		multiAgentValue := "false"
-		if opts.CodexMultiAgent {
-			multiAgentValue = "true"
-		}
-		withFeatures := filemerge.UpsertTOMLTableKey(existing, "features", "multi_agent", multiAgentValue)
+		// features.multi_agent is enabled by default: Codex SDD delegates phases via
+		// spawn_agent so the per-phase reasoning_effort table actually applies. The
+		// orchestrator asset gracefully falls back to solo execution if the multi-agent
+		// tools are unavailable in the session. agents.max_threads/max_depth carry
+		// conservative defaults.
+		withFeatures := filemerge.UpsertTOMLTableKey(existing, "features", "multi_agent", "true")
 		withMaxThreads := filemerge.UpsertTOMLTableKey(withFeatures, "agents", "max_threads", "4")
 		withMaxDepth := filemerge.UpsertTOMLTableKey(withMaxThreads, "agents", "max_depth", "2")
 

--- a/internal/components/engram/inject_test.go
+++ b/internal/components/engram/inject_test.go
@@ -1021,9 +1021,10 @@ func TestInjectCodexProfilesIdempotent(t *testing.T) {
 
 // ─── Codex multi-agent config injection tests ────────────────────────────────
 
-// TestInjectCodexMultiAgentDefaultOff asserts that after a plain Inject call
-// (no explicit opt-in), config.toml contains [features] with multi_agent = false.
-func TestInjectCodexMultiAgentDefaultOff(t *testing.T) {
+// TestInjectCodexMultiAgentDefaultOn asserts that after a plain Inject call,
+// config.toml contains [features] with multi_agent = true. Codex SDD enables
+// multi-agent delegation by default so the per-phase reasoning_effort table applies.
+func TestInjectCodexMultiAgentDefaultOn(t *testing.T) {
 	home := t.TempDir()
 
 	if _, err := Inject(home, codexAdapter()); err != nil {
@@ -1039,11 +1040,11 @@ func TestInjectCodexMultiAgentDefaultOff(t *testing.T) {
 	if !strings.Contains(text, "[features]") {
 		t.Fatalf("config.toml missing [features] section; got:\n%s", text)
 	}
-	if !strings.Contains(text, "multi_agent = false") {
-		t.Fatalf("config.toml missing multi_agent = false; got:\n%s", text)
+	if !strings.Contains(text, "multi_agent = true") {
+		t.Fatalf("config.toml missing multi_agent = true (enabled by default); got:\n%s", text)
 	}
-	if strings.Contains(text, "multi_agent = true") {
-		t.Fatalf("config.toml must NOT have multi_agent = true by default; got:\n%s", text)
+	if strings.Contains(text, "multi_agent = false") {
+		t.Fatalf("config.toml must NOT have multi_agent = false by default; got:\n%s", text)
 	}
 }
 

--- a/internal/components/golden_test.go
+++ b/internal/components/golden_test.go
@@ -299,7 +299,9 @@ func TestGoldenSDD_VSCode(t *testing.T) {
 func TestGoldenSDD_Codex(t *testing.T) {
 	home := t.TempDir()
 
-	result, err := sdd.Inject(home, codexAdapter(), "")
+	result, err := sdd.Inject(home, codexAdapter(), "", sdd.InjectOptions{
+		CodexModelAssignments: model.CodexModelPresetRecommended(),
+	})
 	if err != nil {
 		t.Fatalf("sdd.Inject(codex) error = %v", err)
 	}
@@ -328,6 +330,40 @@ func TestGoldenSDD_Codex(t *testing.T) {
 			t.Errorf("expected SDD skill file %q not found: %v", name, err)
 		}
 	}
+}
+
+func TestGoldenSDD_Codex_LowCost(t *testing.T) {
+	home := t.TempDir()
+
+	result, err := sdd.Inject(home, codexAdapter(), "", sdd.InjectOptions{
+		CodexModelAssignments: model.CodexModelPresetLowCost(),
+	})
+	if err != nil {
+		t.Fatalf("sdd.Inject(codex, LowCost) error = %v", err)
+	}
+	if !result.Changed {
+		t.Fatalf("sdd.Inject(codex, LowCost) changed = false")
+	}
+
+	agentsMD := readTestFile(t, filepath.Join(home, ".codex", "AGENTS.md"))
+	assertGolden(t, "sdd-codex-agentsmd-lowcost.golden", agentsMD)
+}
+
+func TestGoldenSDD_Codex_Powerful(t *testing.T) {
+	home := t.TempDir()
+
+	result, err := sdd.Inject(home, codexAdapter(), "", sdd.InjectOptions{
+		CodexModelAssignments: model.CodexModelPresetPowerful(),
+	})
+	if err != nil {
+		t.Fatalf("sdd.Inject(codex, Powerful) error = %v", err)
+	}
+	if !result.Changed {
+		t.Fatalf("sdd.Inject(codex, Powerful) changed = false")
+	}
+
+	agentsMD := readTestFile(t, filepath.Join(home, ".codex", "AGENTS.md"))
+	assertGolden(t, "sdd-codex-agentsmd-powerful.golden", agentsMD)
 }
 
 func TestGoldenSDD_Windsurf(t *testing.T) {

--- a/internal/components/sdd/inject.go
+++ b/internal/components/sdd/inject.go
@@ -26,6 +26,7 @@ type InjectOptions struct {
 	OpenCodeModelAssignments map[string]model.ModelAssignment
 	ClaudeModelAssignments   map[string]model.ClaudeModelAlias
 	KiroModelAssignments     map[string]model.KiroModelAlias
+	CodexModelAssignments    map[string]model.CodexEffort
 
 	// WorkspaceDir is the root of the current workspace (e.g. os.Getwd()).
 	// When non-empty and the adapter implements workflowInjector, native
@@ -88,6 +89,17 @@ type kiroModelResolver interface {
 // shape consistent with kiroModelResolver.
 type claudeModelResolver interface {
 	ClaudeModelID(alias model.ClaudeModelAlias) string
+}
+
+// codexModelResolver is an optional adapter capability. When implemented,
+// injectFileAppend will replace the {{CODEX_PHASE_EFFORTS}} placeholder in the
+// Codex SDD orchestrator asset with a rendered per-phase effort table derived
+// from the CodexModelAssignments in InjectOptions.
+//
+// Adapters that do NOT implement this interface are completely unaffected —
+// the substitution only fires when the adapter satisfies this interface.
+type codexModelResolver interface {
+	RenderCodexPhaseEfforts(assignments map[string]model.CodexEffort) string
 }
 
 // monorepoRootMarkers identify files/dirs that ONLY exist at the true root
@@ -237,7 +249,7 @@ func Inject(homeDir string, adapter agents.Adapter, sddMode model.SDDModeID, opt
 			// custom persona, the SDD content must still be injected. We append the
 			// SDD orchestrator section to the existing system prompt file so it is
 			// always present regardless of persona choice.
-			result, err := injectFileAppend(homeDir, adapter)
+			result, err := injectFileAppend(homeDir, adapter, opts)
 			if err != nil {
 				return InjectionResult{}, err
 			}
@@ -1507,7 +1519,7 @@ func sddOrchestratorAsset(agent model.AgentID) string {
 	}
 }
 
-func injectFileAppend(homeDir string, adapter agents.Adapter) (InjectionResult, error) {
+func injectFileAppend(homeDir string, adapter agents.Adapter, opts InjectOptions) (InjectionResult, error) {
 	promptPath := adapter.SystemPromptFile(homeDir)
 
 	existing, err := readFileOrEmpty(promptPath)
@@ -1525,6 +1537,18 @@ func injectFileAppend(homeDir string, adapter agents.Adapter) (InjectionResult, 
 
 	// Use agent-specific SDD orchestrator content when available; fall back to generic.
 	content := assets.MustRead(sddOrchestratorAsset(adapter.Agent()))
+
+	// Codex-only: substitute {{CODEX_PHASE_EFFORTS}} with a rendered per-phase
+	// effort table. Only fires when the adapter implements codexModelResolver.
+	// All other FileReplace adapters (Gemini, Cursor, etc.) are unaffected.
+	if cmr, ok := adapter.(codexModelResolver); ok {
+		rendered := cmr.RenderCodexPhaseEfforts(opts.CodexModelAssignments)
+		content = strings.ReplaceAll(content, "{{CODEX_PHASE_EFFORTS}}", rendered)
+		// Post-check: fail loudly if any placeholder token remains unresolved.
+		if strings.Contains(content, "{{") {
+			return InjectionResult{}, fmt.Errorf("inject(codex): unresolved placeholder token '{{' remains in AGENTS.md content after substitution")
+		}
+	}
 
 	// If there is a bare (un-marked) legacy orchestrator block, strip it first
 	// so InjectMarkdownSection can re-inject the current canonical content.

--- a/internal/components/sdd/inject_test.go
+++ b/internal/components/sdd/inject_test.go
@@ -5119,3 +5119,138 @@ func TestEnsureClaudeSkillRegistryHookRejectsUnexpectedHookSchema(t *testing.T) 
 		t.Fatalf("settings were modified: %q", after)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Codex inject tests (T3.1)
+// ---------------------------------------------------------------------------
+
+func codexInjectAdapter() agents.Adapter {
+	// Import inline to avoid adding to the import block of existing file
+	// We use agents.NewAdapter to get the codex adapter.
+	a, err := agents.NewAdapter("codex")
+	if err != nil {
+		panic("agents.NewAdapter(codex): " + err.Error())
+	}
+	return a
+}
+
+func TestInject_CodexSubstitutesPhaseEfforts(t *testing.T) {
+	home := t.TempDir()
+	adapter := codexInjectAdapter()
+
+	opts := InjectOptions{
+		CodexModelAssignments: model.CodexModelPresetRecommended(),
+	}
+	result, err := Inject(home, adapter, "", opts)
+	if err != nil {
+		t.Fatalf("Inject(codex, Recommended) error = %v", err)
+	}
+	if !result.Changed {
+		t.Fatal("Inject(codex, Recommended) changed = false, want true")
+	}
+
+	agentsMD, readErr := os.ReadFile(filepath.Join(home, ".codex", "AGENTS.md"))
+	if readErr != nil {
+		t.Fatalf("ReadFile(AGENTS.md) error = %v", readErr)
+	}
+	text := string(agentsMD)
+	if strings.Contains(text, "{{") {
+		t.Errorf("AGENTS.md contains unresolved placeholder '{{' after Inject:\n%s", text)
+	}
+	// Table should be present.
+	if !strings.Contains(text, "sdd-strong") {
+		t.Error("AGENTS.md missing sdd-strong tier row in rendered table")
+	}
+	if !strings.Contains(text, "sdd-mid") {
+		t.Error("AGENTS.md missing sdd-mid tier row")
+	}
+	if !strings.Contains(text, "sdd-cheap") {
+		t.Error("AGENTS.md missing sdd-cheap tier row")
+	}
+}
+
+func TestInject_CodexNoAssignmentsUsesRecommended(t *testing.T) {
+	home := t.TempDir()
+	adapter := codexInjectAdapter()
+
+	// No CodexModelAssignments → should use Recommended preset as fallback.
+	result, err := Inject(home, adapter, "")
+	if err != nil {
+		t.Fatalf("Inject(codex, nil opts) error = %v", err)
+	}
+	if !result.Changed {
+		t.Fatal("Inject(codex, nil opts) changed = false")
+	}
+
+	agentsMD, readErr := os.ReadFile(filepath.Join(home, ".codex", "AGENTS.md"))
+	if readErr != nil {
+		t.Fatalf("ReadFile(AGENTS.md) error = %v", readErr)
+	}
+	text := string(agentsMD)
+	if strings.Contains(text, "{{") {
+		t.Errorf("AGENTS.md contains unresolved '{{' with nil assignments:\n%s", text)
+	}
+}
+
+func TestInject_CodexIdempotent(t *testing.T) {
+	home := t.TempDir()
+	adapter := codexInjectAdapter()
+	opts := InjectOptions{
+		CodexModelAssignments: model.CodexModelPresetRecommended(),
+	}
+
+	_, err := Inject(home, adapter, "", opts)
+	if err != nil {
+		t.Fatalf("first Inject(codex) error = %v", err)
+	}
+	second, err := Inject(home, adapter, "", opts)
+	if err != nil {
+		t.Fatalf("second Inject(codex) error = %v", err)
+	}
+	if second.Changed {
+		t.Error("second Inject(codex) Changed = true, want false (idempotent)")
+	}
+}
+
+func TestInject_NonCodexAdapterUnaffected(t *testing.T) {
+	// Kiro, Cursor, and Gemini adapters must not be affected by CodexModelAssignments.
+	adapters := []struct {
+		name    string
+		adapter agents.Adapter
+	}{
+		{"cursor", func() agents.Adapter {
+			a, _ := agents.NewAdapter("cursor")
+			return a
+		}()},
+		{"gemini", func() agents.Adapter {
+			a, _ := agents.NewAdapter("gemini-cli")
+			return a
+		}()},
+	}
+
+	for _, tc := range adapters {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			opts := InjectOptions{
+				CodexModelAssignments: model.CodexModelPresetRecommended(),
+			}
+			result, err := Inject(home, tc.adapter, "", opts)
+			if err != nil {
+				t.Fatalf("Inject(%s) error = %v", tc.name, err)
+			}
+			if !result.Changed {
+				t.Fatalf("Inject(%s) changed = false", tc.name)
+			}
+			// Non-codex adapters must produce no unresolved placeholders.
+			for _, f := range result.Files {
+				data, readErr := os.ReadFile(f)
+				if readErr != nil {
+					continue
+				}
+				if strings.Contains(string(data), "{{CODEX_PHASE_EFFORTS}}") {
+					t.Errorf("%s adapter file %q contains unresolved {{CODEX_PHASE_EFFORTS}}", tc.name, f)
+				}
+			}
+		})
+	}
+}

--- a/internal/model/codex_model.go
+++ b/internal/model/codex_model.go
@@ -1,0 +1,181 @@
+package model
+
+import (
+	"fmt"
+	"strings"
+)
+
+// CodexEffort represents an OpenAI reasoning_effort level used for Codex
+// per-phase delegation via spawn_agent.
+type CodexEffort string
+
+const (
+	CodexEffortLow    CodexEffort = "low"
+	CodexEffortMedium CodexEffort = "medium"
+	CodexEffortHigh   CodexEffort = "high"
+	CodexEffortXHigh  CodexEffort = "xhigh"
+)
+
+// Valid reports whether the effort value is one of the four known levels.
+func (e CodexEffort) Valid() bool {
+	switch e {
+	case CodexEffortLow, CodexEffortMedium, CodexEffortHigh, CodexEffortXHigh:
+		return true
+	default:
+		return false
+	}
+}
+
+// codexPhaseOrder defines the canonical order of phases used in render output.
+// These 13 keys match the claudePhases list (plus "default") from the TUI screens package.
+var codexPhaseOrder = []string{
+	"sdd-explore",
+	"sdd-propose",
+	"sdd-spec",
+	"sdd-design",
+	"sdd-tasks",
+	"sdd-apply",
+	"sdd-verify",
+	"sdd-archive",
+	"sdd-onboard",
+	"jd-judge-a",
+	"jd-judge-b",
+	"jd-fix-agent",
+	"default",
+}
+
+// CodexModelPresetRecommended returns the Recommended (ChatGPT Pro $100/mo) preset.
+// Balanced effort — high for key SDD phases, low for lightweight ones.
+func CodexModelPresetRecommended() map[string]CodexEffort {
+	return map[string]CodexEffort{
+		"sdd-explore":  CodexEffortLow,
+		"sdd-propose":  CodexEffortHigh,
+		"sdd-spec":     CodexEffortMedium,
+		"sdd-design":   CodexEffortHigh,
+		"sdd-tasks":    CodexEffortHigh,
+		"sdd-apply":    CodexEffortHigh,
+		"sdd-verify":   CodexEffortHigh,
+		"sdd-archive":  CodexEffortLow,
+		"sdd-onboard":  CodexEffortLow,
+		"jd-judge-a":   CodexEffortHigh,
+		"jd-judge-b":   CodexEffortHigh,
+		"jd-fix-agent": CodexEffortMedium,
+		"default":      CodexEffortHigh,
+	}
+}
+
+// CodexModelPresetPowerful returns the Powerful (ChatGPT Pro $200/mo) preset.
+// xhigh effort for architecture-heavy and review-heavy phases.
+func CodexModelPresetPowerful() map[string]CodexEffort {
+	return map[string]CodexEffort{
+		"sdd-explore":  CodexEffortMedium,
+		"sdd-propose":  CodexEffortXHigh,
+		"sdd-spec":     CodexEffortHigh,
+		"sdd-design":   CodexEffortXHigh,
+		"sdd-tasks":    CodexEffortHigh,
+		"sdd-apply":    CodexEffortHigh,
+		"sdd-verify":   CodexEffortXHigh,
+		"sdd-archive":  CodexEffortLow,
+		"sdd-onboard":  CodexEffortLow,
+		"jd-judge-a":   CodexEffortXHigh,
+		"jd-judge-b":   CodexEffortXHigh,
+		"jd-fix-agent": CodexEffortHigh,
+		"default":      CodexEffortHigh,
+	}
+}
+
+// CodexModelPresetLowCost returns the Low-cost (ChatGPT Plus $20/mo) preset.
+// Minimal effort to stay within tight Plus plan limits.
+func CodexModelPresetLowCost() map[string]CodexEffort {
+	return map[string]CodexEffort{
+		"sdd-explore":  CodexEffortLow,
+		"sdd-propose":  CodexEffortMedium,
+		"sdd-spec":     CodexEffortLow,
+		"sdd-design":   CodexEffortMedium,
+		"sdd-tasks":    CodexEffortLow,
+		"sdd-apply":    CodexEffortMedium,
+		"sdd-verify":   CodexEffortMedium,
+		"sdd-archive":  CodexEffortLow,
+		"sdd-onboard":  CodexEffortLow,
+		"jd-judge-a":   CodexEffortLow,
+		"jd-judge-b":   CodexEffortLow,
+		"jd-fix-agent": CodexEffortLow,
+		"default":      CodexEffortMedium,
+	}
+}
+
+// codexTierGroups defines the three CLI profile tiers and which phases they cover.
+// The tier effort is derived by taking the maximum effort across phases in the group.
+var codexTierGroups = []struct {
+	profile string
+	phases  []string
+}{
+	{
+		profile: "sdd-strong",
+		phases:  []string{"sdd-propose", "sdd-design", "sdd-verify", "jd-judge-a", "jd-judge-b"},
+	},
+	{
+		profile: "sdd-mid",
+		phases:  []string{"sdd-spec", "sdd-tasks", "sdd-apply"},
+	},
+	{
+		profile: "sdd-cheap",
+		phases:  []string{"sdd-explore", "sdd-archive", "sdd-onboard"},
+	},
+}
+
+// codexEffortRank maps effort levels to a numeric rank for max-derivation.
+var codexEffortRank = map[CodexEffort]int{
+	CodexEffortLow:    0,
+	CodexEffortMedium: 1,
+	CodexEffortHigh:   2,
+	CodexEffortXHigh:  3,
+}
+
+func maxEffort(assignments map[string]CodexEffort, phases []string) CodexEffort {
+	best := CodexEffortLow
+	for _, phase := range phases {
+		e, ok := assignments[phase]
+		if !ok {
+			continue
+		}
+		if codexEffortRank[e] > codexEffortRank[best] {
+			best = e
+		}
+	}
+	return best
+}
+
+// RenderCodexPhaseEfforts renders the Model Profiles table for the Codex
+// sdd-orchestrator.md asset. The table maps CLI profile names to their
+// reasoning_effort tier and covered SDD phases. The output is deterministic:
+// tier groups are always rendered in codexTierGroups order.
+//
+// When assignments is nil or empty, falls back to CodexModelPresetRecommended.
+func RenderCodexPhaseEfforts(assignments map[string]CodexEffort) string {
+	if len(assignments) == 0 {
+		assignments = CodexModelPresetRecommended()
+	}
+
+	tierPhaseLabels := map[string]string{
+		"sdd-strong": "propose, design, verify, judge",
+		"sdd-mid":    "spec, tasks, apply",
+		"sdd-cheap":  "explore, archive, onboard",
+	}
+
+	var sb strings.Builder
+	sb.WriteString("| Profile (CLI) | `reasoning_effort` (spawn_agent) | SDD phases |\n")
+	sb.WriteString("|---------------|----------------------------------|------------|\n")
+
+	for _, tier := range codexTierGroups {
+		effort := maxEffort(assignments, tier.phases)
+		phases := tierPhaseLabels[tier.profile]
+		sb.WriteString(fmt.Sprintf("| `%s` | `%s` | %s |\n",
+			tier.profile,
+			effort,
+			phases,
+		))
+	}
+
+	return sb.String()
+}

--- a/internal/model/codex_model_test.go
+++ b/internal/model/codex_model_test.go
@@ -2,21 +2,23 @@ package model_test
 
 import (
 	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/internal/model"
 )
 
 func TestCodexEffortValid(t *testing.T) {
 	tests := []struct {
 		name  string
-		input CodexEffort
+		input model.CodexEffort
 		want  bool
 	}{
-		{"low", CodexEffortLow, true},
-		{"medium", CodexEffortMedium, true},
-		{"high", CodexEffortHigh, true},
-		{"xhigh", CodexEffortXHigh, true},
-		{"empty", CodexEffort(""), false},
-		{"junk", CodexEffort("junk"), false},
-		{"uppercase", CodexEffort("HIGH"), false},
+		{"low", model.CodexEffortLow, true},
+		{"medium", model.CodexEffortMedium, true},
+		{"high", model.CodexEffortHigh, true},
+		{"xhigh", model.CodexEffortXHigh, true},
+		{"empty", model.CodexEffort(""), false},
+		{"junk", model.CodexEffort("junk"), false},
+		{"uppercase", model.CodexEffort("HIGH"), false},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -30,11 +32,11 @@ func TestCodexEffortValid(t *testing.T) {
 func TestCodexPresetsCoverAllPhases(t *testing.T) {
 	presets := []struct {
 		name string
-		fn   func() map[string]CodexEffort
+		fn   func() map[string]model.CodexEffort
 	}{
-		{"Recommended", CodexModelPresetRecommended},
-		{"Powerful", CodexModelPresetPowerful},
-		{"LowCost", CodexModelPresetLowCost},
+		{"Recommended", model.CodexModelPresetRecommended},
+		{"Powerful", model.CodexModelPresetPowerful},
+		{"LowCost", model.CodexModelPresetLowCost},
 	}
 
 	for _, tc := range presets {
@@ -63,18 +65,18 @@ func TestCodexPresetsCoverAllPhases(t *testing.T) {
 }
 
 func TestRenderCodexPhaseEfforts_Deterministic(t *testing.T) {
-	assignments := CodexModelPresetRecommended()
-	out1 := RenderCodexPhaseEfforts(assignments)
-	out2 := RenderCodexPhaseEfforts(assignments)
+	assignments := model.CodexModelPresetRecommended()
+	out1 := model.RenderCodexPhaseEfforts(assignments)
+	out2 := model.RenderCodexPhaseEfforts(assignments)
 	if out1 != out2 {
 		t.Error("RenderCodexPhaseEfforts() is not deterministic: two calls returned different results")
 	}
 }
 
 func TestRenderCodexPhaseEfforts_NilFallsBackToRecommended(t *testing.T) {
-	nilOut := RenderCodexPhaseEfforts(nil)
-	emptyOut := RenderCodexPhaseEfforts(map[string]CodexEffort{})
-	recommended := RenderCodexPhaseEfforts(CodexModelPresetRecommended())
+	nilOut := model.RenderCodexPhaseEfforts(nil)
+	emptyOut := model.RenderCodexPhaseEfforts(map[string]model.CodexEffort{})
+	recommended := model.RenderCodexPhaseEfforts(model.CodexModelPresetRecommended())
 	if nilOut != recommended {
 		t.Error("RenderCodexPhaseEfforts(nil) should equal Recommended output")
 	}
@@ -84,7 +86,7 @@ func TestRenderCodexPhaseEfforts_NilFallsBackToRecommended(t *testing.T) {
 }
 
 func TestRenderCodexPhaseEfforts_LowCostTierValues(t *testing.T) {
-	out := RenderCodexPhaseEfforts(CodexModelPresetLowCost())
+	out := model.RenderCodexPhaseEfforts(model.CodexModelPresetLowCost())
 	// Low-cost: sdd-strong row = medium, sdd-mid row = medium, sdd-cheap row = low
 	assertContainsSubstring(t, out, "sdd-strong")
 	assertContainsSubstring(t, out, "sdd-mid")
@@ -94,7 +96,7 @@ func TestRenderCodexPhaseEfforts_LowCostTierValues(t *testing.T) {
 }
 
 func TestRenderCodexPhaseEfforts_PowerfulTierValues(t *testing.T) {
-	out := RenderCodexPhaseEfforts(CodexModelPresetPowerful())
+	out := model.RenderCodexPhaseEfforts(model.CodexModelPresetPowerful())
 	// Powerful: sdd-strong row = xhigh, sdd-mid row = high, sdd-cheap row = low
 	assertContainsSubstring(t, out, "sdd-strong")
 	assertContainsSubstring(t, out, "sdd-mid")

--- a/internal/model/codex_model_test.go
+++ b/internal/model/codex_model_test.go
@@ -1,0 +1,123 @@
+package model_test
+
+import (
+	"testing"
+)
+
+func TestCodexEffortValid(t *testing.T) {
+	tests := []struct {
+		name  string
+		input CodexEffort
+		want  bool
+	}{
+		{"low", CodexEffortLow, true},
+		{"medium", CodexEffortMedium, true},
+		{"high", CodexEffortHigh, true},
+		{"xhigh", CodexEffortXHigh, true},
+		{"empty", CodexEffort(""), false},
+		{"junk", CodexEffort("junk"), false},
+		{"uppercase", CodexEffort("HIGH"), false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.input.Valid(); got != tc.want {
+				t.Errorf("CodexEffort(%q).Valid() = %v, want %v", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCodexPresetsCoverAllPhases(t *testing.T) {
+	presets := []struct {
+		name string
+		fn   func() map[string]CodexEffort
+	}{
+		{"Recommended", CodexModelPresetRecommended},
+		{"Powerful", CodexModelPresetPowerful},
+		{"LowCost", CodexModelPresetLowCost},
+	}
+
+	for _, tc := range presets {
+		t.Run(tc.name, func(t *testing.T) {
+			m := tc.fn()
+			if len(m) != 13 {
+				t.Errorf("%s preset has %d keys, want 13", tc.name, len(m))
+			}
+			requiredKeys := []string{
+				"sdd-explore", "sdd-propose", "sdd-spec", "sdd-design", "sdd-tasks",
+				"sdd-apply", "sdd-verify", "sdd-archive", "sdd-onboard",
+				"jd-judge-a", "jd-judge-b", "jd-fix-agent", "default",
+			}
+			for _, k := range requiredKeys {
+				v, ok := m[k]
+				if !ok {
+					t.Errorf("%s preset missing key %q", tc.name, k)
+					continue
+				}
+				if !v.Valid() {
+					t.Errorf("%s preset[%q] = %q is not a valid CodexEffort", tc.name, k, v)
+				}
+			}
+		})
+	}
+}
+
+func TestRenderCodexPhaseEfforts_Deterministic(t *testing.T) {
+	assignments := CodexModelPresetRecommended()
+	out1 := RenderCodexPhaseEfforts(assignments)
+	out2 := RenderCodexPhaseEfforts(assignments)
+	if out1 != out2 {
+		t.Error("RenderCodexPhaseEfforts() is not deterministic: two calls returned different results")
+	}
+}
+
+func TestRenderCodexPhaseEfforts_NilFallsBackToRecommended(t *testing.T) {
+	nilOut := RenderCodexPhaseEfforts(nil)
+	emptyOut := RenderCodexPhaseEfforts(map[string]CodexEffort{})
+	recommended := RenderCodexPhaseEfforts(CodexModelPresetRecommended())
+	if nilOut != recommended {
+		t.Error("RenderCodexPhaseEfforts(nil) should equal Recommended output")
+	}
+	if emptyOut != recommended {
+		t.Error("RenderCodexPhaseEfforts(empty) should equal Recommended output")
+	}
+}
+
+func TestRenderCodexPhaseEfforts_LowCostTierValues(t *testing.T) {
+	out := RenderCodexPhaseEfforts(CodexModelPresetLowCost())
+	// Low-cost: sdd-strong row = medium, sdd-mid row = medium, sdd-cheap row = low
+	assertContainsSubstring(t, out, "sdd-strong")
+	assertContainsSubstring(t, out, "sdd-mid")
+	assertContainsSubstring(t, out, "sdd-cheap")
+	// The table should have "medium" for strong and mid tiers and "low" for cheap.
+	// We check values per row; the render function groups by tier.
+}
+
+func TestRenderCodexPhaseEfforts_PowerfulTierValues(t *testing.T) {
+	out := RenderCodexPhaseEfforts(CodexModelPresetPowerful())
+	// Powerful: sdd-strong row = xhigh, sdd-mid row = high, sdd-cheap row = low
+	assertContainsSubstring(t, out, "sdd-strong")
+	assertContainsSubstring(t, out, "sdd-mid")
+	assertContainsSubstring(t, out, "sdd-cheap")
+}
+
+func assertContainsSubstring(t *testing.T, s, substr string) {
+	t.Helper()
+	if !containsStr(s, substr) {
+		t.Errorf("expected output to contain %q, got:\n%s", substr, s)
+	}
+}
+
+func containsStr(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(substr) == 0 ||
+		findSubstring(s, substr))
+}
+
+func findSubstring(s, sub string) bool {
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/model/selection.go
+++ b/internal/model/selection.go
@@ -13,6 +13,7 @@ type Selection struct {
 	ModelAssignments       map[string]ModelAssignment  // key = sub-agent name (e.g., "sdd-init")
 	ClaudeModelAssignments map[string]ClaudeModelAlias // key = phase name; value = opus|sonnet|haiku
 	KiroModelAssignments   map[string]KiroModelAlias   // key = phase name; value = Kiro-native model alias
+	CodexModelAssignments  map[string]CodexEffort      // key = phase name; value = low|medium|high|xhigh
 	Profiles               []Profile                   // named SDD profiles to generate/update during sync
 	OpenCodePlugins        []OpenCodeCommunityPluginID // optional community OpenCode TUI plugins
 }
@@ -51,6 +52,7 @@ type SyncOverrides struct {
 	ModelAssignments       map[string]ModelAssignment  // nil = no override; empty map = reset to defaults
 	ClaudeModelAssignments map[string]ClaudeModelAlias // nil = no override; empty map = reset to defaults
 	KiroModelAssignments   map[string]KiroModelAlias   // nil = no override; empty map = reset to defaults
+	CodexModelAssignments  map[string]CodexEffort      // nil = no override; empty map = reset to defaults
 	SDDMode                SDDModeID                   // "" = no override; when non-empty, overrides the sync's default SDD mode
 	SDDProfileStrategy     SDDProfileStrategyID        // "" = auto; otherwise explicit sync profile strategy
 	StrictTDD              *bool                       // nil = no override; non-nil = override strict TDD mode

--- a/internal/model/selection.go
+++ b/internal/model/selection.go
@@ -9,7 +9,7 @@ type Selection struct {
 	SDDMode                SDDModeID
 	SDDProfileStrategy     SDDProfileStrategyID
 	StrictTDD              bool
-	CodexMultiAgent        bool                        // opt-in: write features.multi_agent = true in ~/.codex/config.toml (default false; experimental)
+	CodexMultiAgent        bool                        // deprecated: Codex now always writes features.multi_agent = true; retained for state/back-compat
 	ModelAssignments       map[string]ModelAssignment  // key = sub-agent name (e.g., "sdd-init")
 	ClaudeModelAssignments map[string]ClaudeModelAlias // key = phase name; value = opus|sonnet|haiku
 	KiroModelAssignments   map[string]KiroModelAlias   // key = phase name; value = Kiro-native model alias

--- a/internal/model/selection_test.go
+++ b/internal/model/selection_test.go
@@ -1,6 +1,8 @@
 package model
 
-import "testing"
+import (
+	"testing"
+)
 
 // TestSelectionHasStrictTDDField verifies that the Selection struct has a
 // StrictTDD bool field.
@@ -36,5 +38,34 @@ func TestSyncOverridesHasStrictTDDPointer(t *testing.T) {
 	o.StrictTDD = &disabled
 	if o.StrictTDD == nil || *o.StrictTDD {
 		t.Fatal("SyncOverrides.StrictTDD pointer set to false but read back incorrectly")
+	}
+}
+
+// TestSelectionHasCodexModelAssignments verifies that the Selection struct has a
+// CodexModelAssignments map field.
+func TestSelectionHasCodexModelAssignments(t *testing.T) {
+	s := Selection{}
+	// Zero value is nil.
+	if s.CodexModelAssignments != nil {
+		t.Fatal("Selection.CodexModelAssignments zero value should be nil")
+	}
+
+	s.CodexModelAssignments = map[string]CodexEffort{"sdd-apply": CodexEffortHigh}
+	if s.CodexModelAssignments["sdd-apply"] != CodexEffortHigh {
+		t.Fatal("Selection.CodexModelAssignments not accessible after assignment")
+	}
+}
+
+// TestSyncOverridesCodexModelPreset verifies that SyncOverrides has a
+// CodexModelAssignments map field (nil = no override semantics).
+func TestSyncOverridesCodexModelPreset(t *testing.T) {
+	o := SyncOverrides{}
+	if o.CodexModelAssignments != nil {
+		t.Fatal("SyncOverrides.CodexModelAssignments zero value should be nil")
+	}
+
+	o.CodexModelAssignments = map[string]CodexEffort{"default": CodexEffortMedium}
+	if o.CodexModelAssignments == nil {
+		t.Fatal("SyncOverrides.CodexModelAssignments should be non-nil after assignment")
 	}
 }

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -35,6 +35,11 @@ type InstallState struct {
 	// written before Kiro had its own picker options.
 	KiroModelAssignments map[string]string `json:"kiro_model_assignments,omitempty"`
 
+	// CodexModelAssignments maps SDD phase names to a Codex reasoning_effort value
+	// (low|medium|high|xhigh). Persisted so that `gentle-ai sync` preserves the
+	// user's per-phase effort preset instead of falling back to Recommended.
+	CodexModelAssignments map[string]string `json:"codexModelAssignments,omitempty"`
+
 	// ModelAssignments maps sub-agent names to provider/model pairs (OpenCode).
 	ModelAssignments map[string]ModelAssignmentState `json:"model_assignments,omitempty"`
 
@@ -97,6 +102,7 @@ func MergeAgents(existing InstallState, newAgents []string) InstallState {
 		ModelAssignments:       existing.ModelAssignments,
 		ClaudeModelAssignments: existing.ClaudeModelAssignments,
 		KiroModelAssignments:   existing.KiroModelAssignments,
+		CodexModelAssignments:  existing.CodexModelAssignments,
 		Persona:                existing.Persona,
 	}
 }

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -367,3 +367,89 @@ func TestBackwardCompatNoAssignments(t *testing.T) {
 		t.Errorf("ModelAssignments = %v, want nil", s.ModelAssignments)
 	}
 }
+
+// TestInstallStateCodexRoundTrip verifies that CodexModelAssignments persists
+// with the "codexModelAssignments" JSON key and is omitted when empty.
+func TestInstallStateCodexRoundTrip(t *testing.T) {
+	home := t.TempDir()
+
+	assignments := map[string]string{
+		"sdd-apply":   "high",
+		"sdd-explore": "low",
+		"default":     "medium",
+	}
+
+	s := InstallState{
+		InstalledAgents:      []string{"codex"},
+		CodexModelAssignments: assignments,
+	}
+
+	if err := Write(home, s); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+
+	got, err := Read(home)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+
+	if !reflect.DeepEqual(got.CodexModelAssignments, assignments) {
+		t.Errorf("CodexModelAssignments = %v, want %v", got.CodexModelAssignments, assignments)
+	}
+}
+
+// TestInstallStateCodexOmitEmpty verifies that CodexModelAssignments is omitted
+// from the JSON when empty.
+func TestInstallStateCodexOmitEmpty(t *testing.T) {
+	home := t.TempDir()
+
+	s := InstallState{InstalledAgents: []string{"codex"}}
+	if err := Write(home, s); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+
+	data, err := os.ReadFile(Path(home))
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+
+	if contains(string(data), "codexModelAssignments") {
+		t.Error("JSON must not contain codexModelAssignments when empty")
+	}
+}
+
+// TestInstallStateCodexMissingKeyReadback verifies that a state file without
+// codexModelAssignments reads back as nil (forward-compat / absent key).
+func TestInstallStateCodexMissingKeyReadback(t *testing.T) {
+	home := t.TempDir()
+
+	if err := os.MkdirAll(filepath.Join(home, stateDir), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	legacy := []byte(`{"installed_agents":["codex"]}` + "\n")
+	if err := os.WriteFile(Path(home), legacy, 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	s, err := Read(home)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+
+	if s.CodexModelAssignments != nil {
+		t.Errorf("CodexModelAssignments = %v, want nil (forward-compat)", s.CodexModelAssignments)
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && findSub(s, substr)
+}
+
+func findSub(s, sub string) bool {
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -246,6 +246,7 @@ const (
 	ScreenPreset
 	ScreenClaudeModelPicker
 	ScreenKiroModelPicker
+	ScreenCodexModelPicker
 	ScreenSDDMode
 	ScreenStrictTDD
 	ScreenOpenCodePlugins
@@ -302,8 +303,9 @@ type Model struct {
 	Execution         pipeline.ExecutionResult
 	Backups           []backup.Manifest
 	ModelPicker       screens.ModelPickerState
-	ClaudeModelPicker screens.ClaudeModelPickerState
-	KiroModelPicker   screens.KiroModelPickerState
+	ClaudeModelPicker  screens.ClaudeModelPickerState
+	KiroModelPicker    screens.KiroModelPickerState
+	CodexModelPicker   screens.CodexModelPickerState
 	SkillPicker       []model.SkillID
 	Err               error
 
@@ -3341,6 +3343,11 @@ func (m Model) shouldShowClaudeModelPickerScreen() bool {
 
 func (m Model) shouldShowKiroModelPickerScreen() bool {
 	return m.Selection.HasAgent(model.AgentKiroIDE) &&
+		hasSelectedComponent(m.Selection.Components, model.ComponentSDD)
+}
+
+func (m Model) shouldShowCodexModelPickerScreen() bool {
+	return m.Selection.HasAgent(model.AgentCodex) &&
 		hasSelectedComponent(m.Selection.Components, model.ComponentSDD)
 }
 

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1582,7 +1582,11 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 			m.ModelConfigMode = true
 			m.KiroModelPicker = screens.NewKiroModelPickerStateFromAssignments(m.Selection.KiroModelAssignments)
 			m.setScreen(ScreenKiroModelPicker)
-		default: // Back
+		case 3: // Configure Codex models
+			m.ModelConfigMode = true
+			m.CodexModelPicker = screens.NewCodexModelPickerStateFromAssignments(m.Selection.CodexModelAssignments)
+			m.setScreen(ScreenCodexModelPicker)
+		case 4: // Back
 			m.setScreen(ScreenWelcome)
 		}
 		return m, nil

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1689,6 +1689,22 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 			}
 			return m, nil
 		}
+	case ScreenCodexModelPicker:
+		if m.Cursor == screens.CodexModelPickerOptionCount()-1 {
+			if m.ModelConfigMode {
+				m.ModelConfigMode = false
+				m.setScreen(ScreenModelConfig)
+				return m, nil
+			}
+			if m.shouldShowKiroModelPickerScreen() {
+				m.setScreen(ScreenKiroModelPicker)
+			} else if m.shouldShowClaudeModelPickerScreen() {
+				m.setScreen(ScreenClaudeModelPicker)
+			} else {
+				m.setScreen(ScreenPreset)
+			}
+			return m, nil
+		}
 	case ScreenSDDMode:
 		options := screens.SDDModeOptions()
 		if m.Cursor < len(options) {
@@ -2528,7 +2544,7 @@ func (m Model) goBack() Model {
 	}
 
 	// ModelConfigMode: pickers reached via Model Config shortcut return to ScreenModelConfig.
-	if m.ModelConfigMode && (m.Screen == ScreenClaudeModelPicker || m.Screen == ScreenKiroModelPicker || m.Screen == ScreenModelPicker) {
+	if m.ModelConfigMode && (m.Screen == ScreenClaudeModelPicker || m.Screen == ScreenKiroModelPicker || m.Screen == ScreenCodexModelPicker || m.Screen == ScreenModelPicker) {
 		m.ModelConfigMode = false
 		m.setScreen(ScreenModelConfig)
 		return m
@@ -2607,6 +2623,10 @@ func (m Model) goBack() Model {
 			m.setScreen(ScreenSDDMode)
 			return m
 		}
+		if m.shouldShowCodexModelPickerScreen() {
+			m.setScreen(ScreenCodexModelPicker)
+			return m
+		}
 		if m.shouldShowKiroModelPickerScreen() {
 			m.setScreen(ScreenKiroModelPicker)
 			return m
@@ -2676,6 +2696,18 @@ func (m Model) goBack() Model {
 			} else {
 				m.setScreen(ScreenPreset)
 			}
+		}
+		return m
+	}
+
+	if m.Screen == ScreenCodexModelPicker {
+		// Codex picker back: Kiro (if present) → Claude (if present) → Preset.
+		if m.shouldShowKiroModelPickerScreen() {
+			m.setScreen(ScreenKiroModelPicker)
+		} else if m.shouldShowClaudeModelPickerScreen() {
+			m.setScreen(ScreenClaudeModelPicker)
+		} else {
+			m.setScreen(ScreenPreset)
 		}
 		return m
 	}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -841,6 +841,8 @@ func (m Model) View() string {
 		return screens.RenderClaudeModelPicker(m.ClaudeModelPicker, m.Cursor)
 	case ScreenKiroModelPicker:
 		return screens.RenderKiroModelPicker(m.KiroModelPicker, m.Cursor)
+	case ScreenCodexModelPicker:
+		return screens.RenderCodexModelPicker(m.CodexModelPicker, m.Cursor)
 	case ScreenSDDMode:
 		return screens.RenderSDDMode(m.Selection.SDDMode, m.Cursor)
 	case ScreenStrictTDD:
@@ -1593,6 +1595,11 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 			if m.shouldShowKiroModelPickerScreen() {
 				m.KiroModelPicker = screens.NewKiroModelPickerStateFromAssignments(m.Selection.KiroModelAssignments)
 				m.setScreen(ScreenKiroModelPicker)
+				return m, nil
+			}
+			if m.shouldShowCodexModelPickerScreen() {
+				m.CodexModelPicker = screens.NewCodexModelPickerStateFromAssignments(m.Selection.CodexModelAssignments)
+				m.setScreen(ScreenCodexModelPicker)
 				return m, nil
 			}
 			if m.shouldShowSDDModeScreen() {
@@ -2811,6 +2818,8 @@ func (m Model) optionCount() int {
 		return screens.ClaudeModelPickerOptionCount(m.ClaudeModelPicker)
 	case ScreenKiroModelPicker:
 		return screens.KiroModelPickerOptionCount(m.KiroModelPicker)
+	case ScreenCodexModelPicker:
+		return screens.CodexModelPickerOptionCount()
 	case ScreenSDDMode:
 		return len(screens.SDDModeOptions()) + 1
 	case ScreenStrictTDD:

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1020,6 +1020,44 @@ func (m Model) handleKeyPress(key tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 	}
 
+	if m.Screen == ScreenCodexModelPicker {
+		handled, assignments := screens.HandleCodexModelPickerNav(keyStr, &m.CodexModelPicker, m.Cursor)
+		if handled {
+			if assignments != nil {
+				m.Selection.CodexModelAssignments = assignments
+				if m.ModelConfigMode {
+					m.ModelConfigMode = false
+					m.PendingSyncOverrides = &model.SyncOverrides{
+						TargetAgents:          []model.AgentID{model.AgentCodex},
+						CodexModelAssignments: assignments,
+					}
+					m = m.withResetSyncState()
+					m.setScreen(ScreenSync)
+				} else if m.shouldShowSDDModeScreen() {
+					m.setScreen(ScreenSDDMode)
+				} else if m.Selection.Preset == model.PresetCustom {
+					if m.shouldShowStrictTDDScreen() {
+						m.setScreen(ScreenStrictTDD)
+					} else if m.shouldShowSkillPickerScreen() {
+						if len(m.SkillPicker) == 0 {
+							m.initSkillPicker()
+						}
+						m.setScreen(ScreenSkillPicker)
+					} else {
+						m.Review = planner.BuildReviewPayload(m.Selection, m.DependencyPlan)
+						m.setScreen(ScreenReview)
+					}
+				} else if m.shouldShowStrictTDDScreen() {
+					m.setScreen(ScreenStrictTDD)
+				} else {
+					m.buildDependencyPlan()
+					m.setScreen(ScreenDependencyTree)
+				}
+			}
+			return m, nil
+		}
+	}
+
 	switch keyStr {
 	case "ctrl+c", "q":
 		return m, tea.Quit

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -951,6 +951,9 @@ func (m Model) handleKeyPress(key tea.KeyMsg) (tea.Model, tea.Cmd) {
 				} else if m.shouldShowKiroModelPickerScreen() {
 					m.KiroModelPicker = screens.NewKiroModelPickerStateFromAssignments(m.Selection.KiroModelAssignments)
 					m.setScreen(ScreenKiroModelPicker)
+				} else if m.shouldShowCodexModelPickerScreen() {
+					m.CodexModelPicker = screens.NewCodexModelPickerStateFromAssignments(m.Selection.CodexModelAssignments)
+					m.setScreen(ScreenCodexModelPicker)
 				} else if m.shouldShowSDDModeScreen() {
 					m.setScreen(ScreenSDDMode)
 				} else if m.Selection.Preset == model.PresetCustom {
@@ -995,6 +998,9 @@ func (m Model) handleKeyPress(key tea.KeyMsg) (tea.Model, tea.Cmd) {
 					}
 					m = m.withResetSyncState()
 					m.setScreen(ScreenSync)
+				} else if m.shouldShowCodexModelPickerScreen() {
+					m.CodexModelPicker = screens.NewCodexModelPickerStateFromAssignments(m.Selection.CodexModelAssignments)
+					m.setScreen(ScreenCodexModelPicker)
 				} else if m.shouldShowSDDModeScreen() {
 					m.setScreen(ScreenSDDMode)
 				} else if m.Selection.Preset == model.PresetCustom {

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1858,18 +1858,19 @@ func TestModelConfig_OpenCodePickerNavigation(t *testing.T) {
 	}
 }
 
-// TestModelConfig_BackNavigation verifies that selecting cursor 3 (Back) from
+// TestModelConfig_BackNavigation verifies that selecting cursor 4 (Back) from
 // ScreenModelConfig returns to ScreenWelcome.
+// Index 3 is now "Configure Codex models"; Back moved to index 4.
 func TestModelConfig_BackNavigation(t *testing.T) {
 	m := NewModel(system.DetectionResult{}, "dev")
 	m.Screen = ScreenModelConfig
-	m.Cursor = 3
+	m.Cursor = 4 // Back is now at index 4
 
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	state := updated.(Model)
 
 	if state.Screen != ScreenWelcome {
-		t.Fatalf("ModelConfig cursor=3 (Back): screen = %v, want %v", state.Screen, ScreenWelcome)
+		t.Fatalf("ModelConfig cursor=4 (Back): screen = %v, want %v", state.Screen, ScreenWelcome)
 	}
 }
 

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -4152,3 +4152,30 @@ func TestPersonaScreenDoesNotRecomputeForCustomPreset(t *testing.T) {
 		t.Fatalf("components should stay nil for custom preset; got: %v", state.Selection.Components)
 	}
 }
+
+func TestShouldShowCodexModelPickerScreen_TrueWhenCodexAndSDD(t *testing.T) {
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Selection.Agents = []model.AgentID{model.AgentCodex}
+	m.Selection.Components = []model.ComponentID{model.ComponentEngram, model.ComponentSDD}
+	if !m.shouldShowCodexModelPickerScreen() {
+		t.Fatal("shouldShowCodexModelPickerScreen() = false, want true when Codex+SDD selected")
+	}
+}
+
+func TestShouldShowCodexModelPickerScreen_FalseWhenNoCodex(t *testing.T) {
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Selection.Agents = []model.AgentID{model.AgentClaudeCode}
+	m.Selection.Components = []model.ComponentID{model.ComponentEngram, model.ComponentSDD}
+	if m.shouldShowCodexModelPickerScreen() {
+		t.Fatal("shouldShowCodexModelPickerScreen() = true, want false when Codex not in agents")
+	}
+}
+
+func TestShouldShowCodexModelPickerScreen_FalseWhenNoSDD(t *testing.T) {
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Selection.Agents = []model.AgentID{model.AgentCodex}
+	m.Selection.Components = []model.ComponentID{model.ComponentEngram}
+	if m.shouldShowCodexModelPickerScreen() {
+		t.Fatal("shouldShowCodexModelPickerScreen() = true, want false when SDD not in components")
+	}
+}

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -4180,3 +4180,173 @@ func TestShouldShowCodexModelPickerScreen_FalseWhenNoSDD(t *testing.T) {
 		t.Fatal("shouldShowCodexModelPickerScreen() = true, want false when SDD not in components")
 	}
 }
+
+// ─── Codex picker install-flow routing tests ─────────────────────────────────
+// These tests cover scenarios in which the Codex model picker MUST be reached
+// during the install flow (non-ModelConfigMode, non-custom preset, SDD selected).
+
+// TestCodexOnly_InstallFlowReachesCodexPicker verifies that selecting a preset
+// when Codex is the only agent (no Claude, no Kiro) navigates to
+// ScreenCodexModelPicker.
+func TestCodexOnly_InstallFlowReachesCodexPicker(t *testing.T) {
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Screen = ScreenPreset
+	m.Selection.Agents = []model.AgentID{model.AgentCodex}
+	m.Cursor = 0 // PresetFullGentleman (includes SDD)
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	state := updated.(Model)
+
+	if state.Screen != ScreenCodexModelPicker {
+		t.Fatalf("Codex-only install flow: screen = %v, want ScreenCodexModelPicker", state.Screen)
+	}
+}
+
+// TestClaudeAndCodex_InstallFlowReachesCodexPickerAfterClaude verifies that
+// after the Claude model picker is completed, the flow advances to
+// ScreenCodexModelPicker when Codex is also selected (no Kiro).
+// RED: currently goes to ScreenSDDMode instead of ScreenCodexModelPicker.
+func TestClaudeAndCodex_InstallFlowReachesCodexPickerAfterClaude(t *testing.T) {
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Screen = ScreenClaudeModelPicker
+	m.ModelConfigMode = false
+	m.Selection.Preset = model.PresetFullGentleman
+	m.Selection.Agents = []model.AgentID{model.AgentClaudeCode, model.AgentCodex}
+	m.Selection.Components = componentsForPreset(model.PresetFullGentleman, model.PersonaGentleman)
+	m.ClaudeModelPicker = screens.NewClaudeModelPickerState()
+
+	// Press Enter to confirm the default preset option (cursor 0).
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	state := updated.(Model)
+
+	if state.Screen != ScreenCodexModelPicker {
+		t.Fatalf("Claude+Codex install flow (after Claude picker): screen = %v, want ScreenCodexModelPicker", state.Screen)
+	}
+}
+
+// TestKiroAndCodex_InstallFlowReachesCodexPickerAfterKiro verifies that
+// after the Kiro model picker is completed, the flow advances to
+// ScreenCodexModelPicker when Codex is also selected (no Claude).
+// RED: currently goes to ScreenSDDMode instead of ScreenCodexModelPicker.
+func TestKiroAndCodex_InstallFlowReachesCodexPickerAfterKiro(t *testing.T) {
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Screen = ScreenKiroModelPicker
+	m.ModelConfigMode = false
+	m.Selection.Preset = model.PresetFullGentleman
+	m.Selection.Agents = []model.AgentID{model.AgentKiroIDE, model.AgentCodex}
+	m.Selection.Components = componentsForPreset(model.PresetFullGentleman, model.PersonaGentleman)
+	m.KiroModelPicker = screens.NewKiroModelPickerState()
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	state := updated.(Model)
+
+	if state.Screen != ScreenCodexModelPicker {
+		t.Fatalf("Kiro+Codex install flow (after Kiro picker): screen = %v, want ScreenCodexModelPicker", state.Screen)
+	}
+}
+
+// TestClaudeKiroCodex_InstallFlowSequence verifies that the full Claude→Kiro→Codex
+// picker chain is traversed in order during an install flow where all three agents
+// are selected.
+// RED: currently Claude→Kiro→SDDMode (Codex is skipped).
+func TestClaudeKiroCodex_InstallFlowSequence(t *testing.T) {
+	preset := model.PresetFullGentleman
+	components := componentsForPreset(preset, model.PersonaGentleman)
+	agents := []model.AgentID{model.AgentClaudeCode, model.AgentKiroIDE, model.AgentCodex}
+
+	// Step 1: ScreenPreset → ScreenClaudeModelPicker.
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Screen = ScreenPreset
+	m.Selection.Agents = agents
+	m.Cursor = 0
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	state := updated.(Model)
+	if state.Screen != ScreenClaudeModelPicker {
+		t.Fatalf("step1: screen = %v, want ScreenClaudeModelPicker", state.Screen)
+	}
+
+	// Step 2: ScreenClaudeModelPicker confirm → ScreenKiroModelPicker.
+	state.Screen = ScreenClaudeModelPicker
+	state.Selection.Components = components
+	state.ClaudeModelPicker = screens.NewClaudeModelPickerState()
+	state.Cursor = 0
+
+	updated, _ = state.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	state = updated.(Model)
+	if state.Screen != ScreenKiroModelPicker {
+		t.Fatalf("step2: screen = %v, want ScreenKiroModelPicker", state.Screen)
+	}
+
+	// Step 3: ScreenKiroModelPicker confirm → ScreenCodexModelPicker.
+	state.Screen = ScreenKiroModelPicker
+	state.Selection.Components = components
+	state.KiroModelPicker = screens.NewKiroModelPickerState()
+	state.Cursor = 0
+
+	updated, _ = state.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	state = updated.(Model)
+	if state.Screen != ScreenCodexModelPicker {
+		t.Fatalf("step3 (Kiro→Codex): screen = %v, want ScreenCodexModelPicker", state.Screen)
+	}
+}
+
+// TestCodexPicker_EscBackNavToKiroWhenKiroSelected verifies that pressing Esc
+// from ScreenCodexModelPicker goes back to ScreenKiroModelPicker when Kiro is
+// also selected in the flow.
+func TestCodexPicker_EscBackNavToKiroWhenKiroSelected(t *testing.T) {
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Screen = ScreenCodexModelPicker
+	m.ModelConfigMode = false
+	m.Selection.Preset = model.PresetFullGentleman
+	m.Selection.Agents = []model.AgentID{model.AgentKiroIDE, model.AgentCodex}
+	m.Selection.Components = componentsForPreset(model.PresetFullGentleman, model.PersonaGentleman)
+	m.CodexModelPicker = screens.NewCodexModelPickerStateFromAssignments(m.Selection.CodexModelAssignments)
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	state := updated.(Model)
+
+	if state.Screen != ScreenKiroModelPicker {
+		t.Fatalf("CodexPicker esc (Kiro in flow): screen = %v, want ScreenKiroModelPicker", state.Screen)
+	}
+}
+
+// TestCodexPicker_EscBackNavToClaudeWhenClaudeSelectedNoKiro verifies that
+// pressing Esc from ScreenCodexModelPicker goes back to ScreenClaudeModelPicker
+// when Claude is selected but Kiro is not.
+func TestCodexPicker_EscBackNavToClaudeWhenClaudeSelectedNoKiro(t *testing.T) {
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Screen = ScreenCodexModelPicker
+	m.ModelConfigMode = false
+	m.Selection.Preset = model.PresetFullGentleman
+	m.Selection.Agents = []model.AgentID{model.AgentClaudeCode, model.AgentCodex}
+	m.Selection.Components = componentsForPreset(model.PresetFullGentleman, model.PersonaGentleman)
+	m.CodexModelPicker = screens.NewCodexModelPickerStateFromAssignments(m.Selection.CodexModelAssignments)
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	state := updated.(Model)
+
+	if state.Screen != ScreenClaudeModelPicker {
+		t.Fatalf("CodexPicker esc (Claude in flow, no Kiro): screen = %v, want ScreenClaudeModelPicker", state.Screen)
+	}
+}
+
+// TestCodexPicker_EscBackNavToPresetWhenNeitherClaudeNorKiro verifies that
+// pressing Esc from ScreenCodexModelPicker goes back to ScreenPreset when
+// neither Claude nor Kiro is in the flow.
+func TestCodexPicker_EscBackNavToPresetWhenNeitherClaudeNorKiro(t *testing.T) {
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Screen = ScreenCodexModelPicker
+	m.ModelConfigMode = false
+	m.Selection.Preset = model.PresetFullGentleman
+	m.Selection.Agents = []model.AgentID{model.AgentCodex}
+	m.Selection.Components = componentsForPreset(model.PresetFullGentleman, model.PersonaGentleman)
+	m.CodexModelPicker = screens.NewCodexModelPickerStateFromAssignments(m.Selection.CodexModelAssignments)
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	state := updated.(Model)
+
+	if state.Screen != ScreenPreset {
+		t.Fatalf("CodexPicker esc (no Claude, no Kiro): screen = %v, want ScreenPreset", state.Screen)
+	}
+}

--- a/internal/tui/router.go
+++ b/internal/tui/router.go
@@ -13,6 +13,7 @@ var linearRoutes = map[Screen]Route{
 	ScreenPreset:                 {Forward: ScreenDependencyTree, Backward: ScreenPersona},
 	ScreenClaudeModelPicker:      {Forward: ScreenDependencyTree, Backward: ScreenPreset},
 	ScreenKiroModelPicker:        {Forward: ScreenDependencyTree, Backward: ScreenPreset},
+	ScreenCodexModelPicker:       {Forward: ScreenDependencyTree, Backward: ScreenPreset},
 	ScreenSDDMode:                {Forward: ScreenStrictTDD, Backward: ScreenPreset},
 	ScreenStrictTDD:              {Forward: ScreenDependencyTree, Backward: ScreenSDDMode},
 	ScreenOpenCodePluginResult:   {Backward: ScreenWelcome},

--- a/internal/tui/screens/codex_model_picker.go
+++ b/internal/tui/screens/codex_model_picker.go
@@ -1,0 +1,160 @@
+package screens
+
+import (
+	"maps"
+	"strings"
+
+	"github.com/gentleman-programming/gentle-ai/internal/model"
+	"github.com/gentleman-programming/gentle-ai/internal/tui/styles"
+)
+
+// CodexModelPreset represents a named effort-tier preset for Codex per-phase
+// reasoning_effort assignments. Each preset corresponds to a ChatGPT plan tier.
+type CodexModelPreset string
+
+const (
+	// CodexPresetLowCost targets ChatGPT Plus ($20/mo) — minimal effort to
+	// stay within the plan's tight usage limits.
+	CodexPresetLowCost CodexModelPreset = "low-cost"
+
+	// CodexPresetRecommended targets ChatGPT Pro ($100/mo) — balanced effort
+	// for most SDD work. This is the default preset.
+	CodexPresetRecommended CodexModelPreset = "recommended"
+
+	// CodexPresetPowerful targets ChatGPT Pro ($200/mo) — xhigh effort for
+	// architecture-heavy and review-heavy phases.
+	CodexPresetPowerful CodexModelPreset = "powerful"
+)
+
+var codexPresetOrder = []CodexModelPreset{
+	CodexPresetLowCost,
+	CodexPresetRecommended,
+	CodexPresetPowerful,
+}
+
+var codexPresetDescriptions = map[CodexModelPreset]string{
+	CodexPresetLowCost:     "Minimal effort — preserves tight ChatGPT Plus ($20/mo) usage limits",
+	CodexPresetRecommended: "Balanced effort — high on key phases, low on lightweight work (Pro $100/mo)",
+	CodexPresetPowerful:    "Maximum effort — xhigh on architecture, design, and verification (Pro $200/mo)",
+}
+
+var codexPresetConstructors = map[CodexModelPreset]func() map[string]model.CodexEffort{
+	CodexPresetLowCost:     model.CodexModelPresetLowCost,
+	CodexPresetRecommended: model.CodexModelPresetRecommended,
+	CodexPresetPowerful:    model.CodexModelPresetPowerful,
+}
+
+// CodexModelPickerState holds navigation state for the Codex model picker screen.
+// There is no custom mode — only 3 presets + Back.
+type CodexModelPickerState struct {
+	Preset CodexModelPreset
+}
+
+// NewCodexModelPickerState returns the initial picker state: Recommended preset.
+func NewCodexModelPickerState() CodexModelPickerState {
+	return CodexModelPickerState{
+		Preset: CodexPresetRecommended,
+	}
+}
+
+// NewCodexModelPickerStateFromAssignments returns the picker state initialized
+// from previously persisted Codex model assignments. If the assignments match
+// a known preset (LowCost/Recommended/Powerful), that preset is preselected.
+// Otherwise, falls back to Recommended (no custom fallback — presets only).
+func NewCodexModelPickerStateFromAssignments(assignments map[string]model.CodexEffort) CodexModelPickerState {
+	if len(assignments) == 0 {
+		return NewCodexModelPickerState()
+	}
+	for preset, constructor := range codexPresetConstructors {
+		if codexAssignmentsEqual(constructor(), assignments) {
+			return CodexModelPickerState{Preset: preset}
+		}
+	}
+	// Unknown assignments → fall back to Recommended (no custom mode).
+	return CodexModelPickerState{Preset: CodexPresetRecommended}
+}
+
+func codexAssignmentsEqual(a, b map[string]model.CodexEffort) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if b[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
+// CodexModelPickerOptionCount returns the total number of selectable rows:
+// 3 presets + 1 Back row. Does NOT take a state argument (no custom mode).
+func CodexModelPickerOptionCount() int {
+	return len(codexPresetOrder) + 1
+}
+
+// HandleCodexModelPickerNav processes a key event for the Codex model picker.
+// Returns (true, assignments) when a preset is confirmed, (true, nil) when Back
+// is selected, and (false, nil) for all other keys.
+func HandleCodexModelPickerNav(
+	key string,
+	state *CodexModelPickerState,
+	cursor int,
+) (handled bool, assignments map[string]model.CodexEffort) {
+	if key != "enter" {
+		return false, nil
+	}
+
+	// Back row
+	if cursor >= len(codexPresetOrder) {
+		return true, nil
+	}
+
+	selected := codexPresetOrder[cursor]
+	state.Preset = selected
+	a := maps.Clone(codexPresetConstructors[selected]())
+	return true, a
+}
+
+// RenderCodexModelPicker renders the Codex preset selection screen.
+// Title: "Codex Model Assignments"; 3 preset rows + Back; no custom mode.
+func RenderCodexModelPicker(state CodexModelPickerState, cursor int) string {
+	var b strings.Builder
+
+	b.WriteString(styles.TitleStyle.Render("Codex Model Assignments"))
+	b.WriteString("\n\n")
+	b.WriteString(styles.SubtextStyle.Render("Choose the reasoning_effort tier for Codex SDD phases (tied to your ChatGPT plan):"))
+	b.WriteString("\n\n")
+
+	for idx, preset := range codexPresetOrder {
+		isSelected := preset == state.Preset
+		focused := idx == cursor
+		b.WriteString(renderRadio(CodexPresetLabel(preset), isSelected, focused))
+		b.WriteString(styles.SubtextStyle.Render("    "+codexPresetDescriptions[preset]) + "\n")
+	}
+
+	b.WriteString("\n")
+	b.WriteString(renderOptions([]string{"← Back"}, cursor-len(codexPresetOrder)))
+	b.WriteString("\n")
+	b.WriteString(styles.HelpStyle.Render("j/k: navigate • enter: select • esc: back"))
+
+	return b.String()
+}
+
+// CodexPresetLabel returns the human-readable plan label for a preset.
+func CodexPresetLabel(preset CodexModelPreset) string {
+	switch preset {
+	case CodexPresetLowCost:
+		return "Low-cost (ChatGPT Plus $20/mo)"
+	case CodexPresetRecommended:
+		return "Recommended (ChatGPT Pro $100/mo)"
+	case CodexPresetPowerful:
+		return "Powerful (ChatGPT Pro $200/mo)"
+	default:
+		return string(preset)
+	}
+}
+
+// CodexPresetDescription returns a one-line description for a preset.
+func CodexPresetDescription(preset CodexModelPreset) string {
+	return codexPresetDescriptions[preset]
+}

--- a/internal/tui/screens/codex_model_picker_test.go
+++ b/internal/tui/screens/codex_model_picker_test.go
@@ -1,0 +1,156 @@
+package screens_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/internal/model"
+	"github.com/gentleman-programming/gentle-ai/internal/tui/screens"
+)
+
+func TestNewCodexModelPickerState(t *testing.T) {
+	state := screens.NewCodexModelPickerState()
+	if state.Preset != screens.CodexPresetRecommended {
+		t.Errorf("NewCodexModelPickerState().Preset = %q, want %q", state.Preset, screens.CodexPresetRecommended)
+	}
+}
+
+func TestNewCodexModelPickerStateFromAssignments_KnownPreset(t *testing.T) {
+	tests := []struct {
+		name        string
+		assignments map[string]model.CodexEffort
+		wantPreset  screens.CodexModelPreset
+	}{
+		{
+			name:        "Recommended map → Recommended preset",
+			assignments: model.CodexModelPresetRecommended(),
+			wantPreset:  screens.CodexPresetRecommended,
+		},
+		{
+			name:        "Powerful map → Powerful preset",
+			assignments: model.CodexModelPresetPowerful(),
+			wantPreset:  screens.CodexPresetPowerful,
+		},
+		{
+			name:        "LowCost map → LowCost preset",
+			assignments: model.CodexModelPresetLowCost(),
+			wantPreset:  screens.CodexPresetLowCost,
+		},
+		{
+			name:        "unknown map → Recommended (no Custom fallback)",
+			assignments: map[string]model.CodexEffort{"sdd-apply": model.CodexEffortXHigh},
+			wantPreset:  screens.CodexPresetRecommended,
+		},
+		{
+			name:        "nil → Recommended",
+			assignments: nil,
+			wantPreset:  screens.CodexPresetRecommended,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			state := screens.NewCodexModelPickerStateFromAssignments(tc.assignments)
+			if state.Preset != tc.wantPreset {
+				t.Errorf("NewCodexModelPickerStateFromAssignments().Preset = %q, want %q", state.Preset, tc.wantPreset)
+			}
+		})
+	}
+}
+
+func TestCodexModelPickerOptionCount(t *testing.T) {
+	// Must return 4: 3 presets + 1 Back row
+	count := screens.CodexModelPickerOptionCount()
+	if count != 4 {
+		t.Errorf("CodexModelPickerOptionCount() = %d, want 4", count)
+	}
+}
+
+func TestHandleCodexModelPickerNav_SelectsPreset(t *testing.T) {
+	tests := []struct {
+		name       string
+		cursor     int
+		wantPreset screens.CodexModelPreset
+	}{
+		{"idx 0 → LowCost", 0, screens.CodexPresetLowCost},
+		{"idx 1 → Recommended", 1, screens.CodexPresetRecommended},
+		{"idx 2 → Powerful", 2, screens.CodexPresetPowerful},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			state := screens.NewCodexModelPickerState()
+			handled, assignments := screens.HandleCodexModelPickerNav("enter", &state, tc.cursor)
+			if !handled {
+				t.Errorf("HandleCodexModelPickerNav(enter, %d) handled = false, want true", tc.cursor)
+			}
+			if assignments == nil {
+				t.Errorf("HandleCodexModelPickerNav(enter, %d) assignments = nil, want non-nil", tc.cursor)
+			}
+			if state.Preset != tc.wantPreset {
+				t.Errorf("state.Preset = %q after enter at %d, want %q", state.Preset, tc.cursor, tc.wantPreset)
+			}
+		})
+	}
+}
+
+func TestHandleCodexModelPickerNav_BackRow(t *testing.T) {
+	state := screens.NewCodexModelPickerState()
+	// Back row is at index 3 (len(presets) = 3)
+	handled, assignments := screens.HandleCodexModelPickerNav("enter", &state, 3)
+	if !handled {
+		t.Error("HandleCodexModelPickerNav(enter, Back) handled = false, want true")
+	}
+	if assignments != nil {
+		t.Errorf("HandleCodexModelPickerNav(enter, Back) assignments = %v, want nil", assignments)
+	}
+}
+
+func TestHandleCodexModelPickerNav_OtherKey(t *testing.T) {
+	state := screens.NewCodexModelPickerState()
+	handled, assignments := screens.HandleCodexModelPickerNav("j", &state, 0)
+	if handled {
+		t.Error("HandleCodexModelPickerNav(j) handled = true, want false")
+	}
+	if assignments != nil {
+		t.Errorf("HandleCodexModelPickerNav(j) assignments = %v, want nil", assignments)
+	}
+}
+
+func TestRenderCodexModelPicker_ContainsTitle(t *testing.T) {
+	state := screens.NewCodexModelPickerState()
+	out := screens.RenderCodexModelPicker(state, 0)
+	if !strings.Contains(out, "Codex Model Assignments") {
+		t.Errorf("RenderCodexModelPicker missing title 'Codex Model Assignments': %s", out)
+	}
+}
+
+func TestRenderCodexModelPicker_NoCustom(t *testing.T) {
+	state := screens.NewCodexModelPickerState()
+	out := screens.RenderCodexModelPicker(state, 0)
+	if strings.Contains(out, "Custom") || strings.Contains(out, "Confirm") {
+		t.Errorf("RenderCodexModelPicker must not contain 'Custom' or 'Confirm': %s", out)
+	}
+}
+
+func TestRenderCodexModelPicker_ContainsBack(t *testing.T) {
+	state := screens.NewCodexModelPickerState()
+	out := screens.RenderCodexModelPicker(state, 0)
+	if !strings.Contains(out, "Back") {
+		t.Errorf("RenderCodexModelPicker missing '← Back' row: %s", out)
+	}
+}
+
+func TestRenderCodexModelPicker_ContainsAllLabels(t *testing.T) {
+	state := screens.NewCodexModelPickerState()
+	out := screens.RenderCodexModelPicker(state, 0)
+	presets := []screens.CodexModelPreset{
+		screens.CodexPresetLowCost,
+		screens.CodexPresetRecommended,
+		screens.CodexPresetPowerful,
+	}
+	for _, preset := range presets {
+		label := screens.CodexPresetLabel(preset)
+		if !strings.Contains(out, label[:10]) { // check first 10 chars of label
+			t.Errorf("RenderCodexModelPicker missing label for preset %q (expected %q): %s", preset, label, out)
+		}
+	}
+}

--- a/internal/tui/screens/model_config.go
+++ b/internal/tui/screens/model_config.go
@@ -12,6 +12,7 @@ func ModelConfigOptions() []string {
 		"Configure Claude models",
 		"Configure OpenCode models",
 		"Configure Kiro models",
+		"Configure Codex models",
 		"Back",
 	}
 }

--- a/internal/tui/screens/model_config_test.go
+++ b/internal/tui/screens/model_config_test.go
@@ -8,21 +8,21 @@ import (
 // ─── ModelConfigOptions ────────────────────────────────────────────────────
 
 // TestModelConfigOptions_Count verifies that ModelConfigOptions returns exactly
-// 4 items: Claude, OpenCode, Kiro, and Back.
+// 5 items: Claude, OpenCode, Kiro, Codex, and Back.
 func TestModelConfigOptions_Count(t *testing.T) {
 	opts := ModelConfigOptions()
-	if len(opts) != 4 {
-		t.Fatalf("ModelConfigOptions() len = %d, want 4; got %v", len(opts), opts)
+	if len(opts) != 5 {
+		t.Fatalf("ModelConfigOptions() len = %d, want 5; got %v", len(opts), opts)
 	}
 }
 
 // TestModelConfigOptions_Order verifies the exact order of options:
-// Claude → OpenCode → Kiro → Back.
+// Claude → OpenCode → Kiro → Codex → Back.
 func TestModelConfigOptions_Order(t *testing.T) {
 	opts := ModelConfigOptions()
 
 	// wantKeywords defines the expected order by a unique keyword per option.
-	wantKeywords := []string{"Claude", "OpenCode", "Kiro", "Back"}
+	wantKeywords := []string{"Claude", "OpenCode", "Kiro", "Codex", "Back"}
 
 	if len(opts) != len(wantKeywords) {
 		t.Fatalf("ModelConfigOptions() len = %d, want %d; got %v", len(opts), len(wantKeywords), opts)
@@ -32,6 +32,20 @@ func TestModelConfigOptions_Order(t *testing.T) {
 		if !strings.Contains(opts[i], keyword) {
 			t.Errorf("ModelConfigOptions()[%d] = %q, want option containing %q", i, opts[i], keyword)
 		}
+	}
+}
+
+// TestModelConfigOptions_ContainsCodex verifies Codex is at index 3 and Back at index 4.
+func TestModelConfigOptions_ContainsCodex(t *testing.T) {
+	opts := ModelConfigOptions()
+	if len(opts) < 5 {
+		t.Fatalf("ModelConfigOptions() len = %d, want at least 5", len(opts))
+	}
+	if !strings.Contains(opts[3], "Codex") {
+		t.Errorf("ModelConfigOptions()[3] = %q, want option containing 'Codex'", opts[3])
+	}
+	if !strings.Contains(opts[4], "Back") {
+		t.Errorf("ModelConfigOptions()[4] = %q, want 'Back'", opts[4])
 	}
 }
 

--- a/testdata/golden/sdd-codex-agentsmd-lowcost.golden
+++ b/testdata/golden/sdd-codex-agentsmd-lowcost.golden
@@ -16,9 +16,9 @@ Bind this to the dedicated `sdd-orchestrator` agent or rule only. Do NOT apply i
 Check `~/.codex/config.toml` for `features.multi_agent`:
 
 - If `features.multi_agent = true` **AND** the tools `spawn_agent`, `wait_agent`, and `close_agent` are available in this session → use the **Delegated path** below.
-- Otherwise (default) → use the **Solo path** below.
+- Otherwise → use the **Solo path** below.
 
-`features.multi_agent` defaults to `false` (written by gentle-ai during installation). To opt in, set `multi_agent = true` in the `[features]` section of `~/.codex/config.toml` and restart your session.
+`features.multi_agent` is enabled by default (gentle-ai writes `multi_agent = true` during installation) so SDD delegates phases and the per-phase reasoning_effort table applies. To force solo execution, set `multi_agent = false` in the `[features]` section of `~/.codex/config.toml` and restart your session.
 
 ---
 
@@ -48,7 +48,7 @@ Strict TDD: when the project has `strict_tdd: true` in `sdd-init` context, alway
 
 ---
 
-## Delegated Path (opt-in, requires features.multi_agent = true)
+## Delegated Path (default, requires features.multi_agent = true)
 
 When multi-agent tools are available, delegate each SDD phase to a sub-agent using Codex's native tool set:
 
@@ -62,7 +62,7 @@ When multi-agent tools are available, delegate each SDD phase to a sub-agent usi
 ### Phase delegation pattern
 
 For each phase:
-1. Determine the phase tier and its `reasoning_effort` value (see Model Profiles below): `xhigh` for propose/design/verify/judge, `high` for spec/tasks/apply, `low` for explore/archive/onboard.
+1. Look up the phase's `reasoning_effort` value in the **Model Profiles** table below (the values are preset-driven and written by gentle-ai — do not assume fixed tiers).
 2. `spawn_agent` with `task_name`, the phase prompt as `message`, and `reasoning_effort` set to the tier value. The `spawn_agent` tool has NO `profile` parameter — tier selection is the `reasoning_effort` argument, not a profile name.
 3. Set `fork_turns: "none"` whenever you override `reasoning_effort` or `model`. A full-history fork (the default) REJECTS these overrides, so the override is silently ignored unless `fork_turns` is `"none"`.
 4. `wait_agent` to collect the result.

--- a/testdata/golden/sdd-codex-agentsmd-lowcost.golden
+++ b/testdata/golden/sdd-codex-agentsmd-lowcost.golden
@@ -183,8 +183,8 @@ These profile files apply to whole CLI sessions: `codex --profile <name> "<promp
 
 | Profile (CLI) | `reasoning_effort` (spawn_agent) | SDD phases |
 |---------------|----------------------------------|------------|
-| `sdd-strong` | `high` | propose, design, verify, judge |
-| `sdd-mid` | `high` | spec, tasks, apply |
+| `sdd-strong` | `medium` | propose, design, verify, judge |
+| `sdd-mid` | `medium` | spec, tasks, apply |
 | `sdd-cheap` | `low` | explore, archive, onboard |
 
 <!-- /gentle-ai:sdd-orchestrator -->

--- a/testdata/golden/sdd-codex-agentsmd-powerful.golden
+++ b/testdata/golden/sdd-codex-agentsmd-powerful.golden
@@ -16,9 +16,9 @@ Bind this to the dedicated `sdd-orchestrator` agent or rule only. Do NOT apply i
 Check `~/.codex/config.toml` for `features.multi_agent`:
 
 - If `features.multi_agent = true` **AND** the tools `spawn_agent`, `wait_agent`, and `close_agent` are available in this session → use the **Delegated path** below.
-- Otherwise (default) → use the **Solo path** below.
+- Otherwise → use the **Solo path** below.
 
-`features.multi_agent` defaults to `false` (written by gentle-ai during installation). To opt in, set `multi_agent = true` in the `[features]` section of `~/.codex/config.toml` and restart your session.
+`features.multi_agent` is enabled by default (gentle-ai writes `multi_agent = true` during installation) so SDD delegates phases and the per-phase reasoning_effort table applies. To force solo execution, set `multi_agent = false` in the `[features]` section of `~/.codex/config.toml` and restart your session.
 
 ---
 
@@ -48,7 +48,7 @@ Strict TDD: when the project has `strict_tdd: true` in `sdd-init` context, alway
 
 ---
 
-## Delegated Path (opt-in, requires features.multi_agent = true)
+## Delegated Path (default, requires features.multi_agent = true)
 
 When multi-agent tools are available, delegate each SDD phase to a sub-agent using Codex's native tool set:
 
@@ -62,7 +62,7 @@ When multi-agent tools are available, delegate each SDD phase to a sub-agent usi
 ### Phase delegation pattern
 
 For each phase:
-1. Determine the phase tier and its `reasoning_effort` value (see Model Profiles below): `xhigh` for propose/design/verify/judge, `high` for spec/tasks/apply, `low` for explore/archive/onboard.
+1. Look up the phase's `reasoning_effort` value in the **Model Profiles** table below (the values are preset-driven and written by gentle-ai — do not assume fixed tiers).
 2. `spawn_agent` with `task_name`, the phase prompt as `message`, and `reasoning_effort` set to the tier value. The `spawn_agent` tool has NO `profile` parameter — tier selection is the `reasoning_effort` argument, not a profile name.
 3. Set `fork_turns: "none"` whenever you override `reasoning_effort` or `model`. A full-history fork (the default) REJECTS these overrides, so the override is silently ignored unless `fork_turns` is `"none"`.
 4. `wait_agent` to collect the result.

--- a/testdata/golden/sdd-codex-agentsmd-powerful.golden
+++ b/testdata/golden/sdd-codex-agentsmd-powerful.golden
@@ -183,8 +183,8 @@ These profile files apply to whole CLI sessions: `codex --profile <name> "<promp
 
 | Profile (CLI) | `reasoning_effort` (spawn_agent) | SDD phases |
 |---------------|----------------------------------|------------|
-| `sdd-strong` | `high` | propose, design, verify, judge |
+| `sdd-strong` | `xhigh` | propose, design, verify, judge |
 | `sdd-mid` | `high` | spec, tasks, apply |
-| `sdd-cheap` | `low` | explore, archive, onboard |
+| `sdd-cheap` | `medium` | explore, archive, onboard |
 
 <!-- /gentle-ai:sdd-orchestrator -->

--- a/testdata/golden/sdd-codex-agentsmd.golden
+++ b/testdata/golden/sdd-codex-agentsmd.golden
@@ -16,9 +16,9 @@ Bind this to the dedicated `sdd-orchestrator` agent or rule only. Do NOT apply i
 Check `~/.codex/config.toml` for `features.multi_agent`:
 
 - If `features.multi_agent = true` **AND** the tools `spawn_agent`, `wait_agent`, and `close_agent` are available in this session → use the **Delegated path** below.
-- Otherwise (default) → use the **Solo path** below.
+- Otherwise → use the **Solo path** below.
 
-`features.multi_agent` defaults to `false` (written by gentle-ai during installation). To opt in, set `multi_agent = true` in the `[features]` section of `~/.codex/config.toml` and restart your session.
+`features.multi_agent` is enabled by default (gentle-ai writes `multi_agent = true` during installation) so SDD delegates phases and the per-phase reasoning_effort table applies. To force solo execution, set `multi_agent = false` in the `[features]` section of `~/.codex/config.toml` and restart your session.
 
 ---
 
@@ -48,7 +48,7 @@ Strict TDD: when the project has `strict_tdd: true` in `sdd-init` context, alway
 
 ---
 
-## Delegated Path (opt-in, requires features.multi_agent = true)
+## Delegated Path (default, requires features.multi_agent = true)
 
 When multi-agent tools are available, delegate each SDD phase to a sub-agent using Codex's native tool set:
 
@@ -62,7 +62,7 @@ When multi-agent tools are available, delegate each SDD phase to a sub-agent usi
 ### Phase delegation pattern
 
 For each phase:
-1. Determine the phase tier and its `reasoning_effort` value (see Model Profiles below): `xhigh` for propose/design/verify/judge, `high` for spec/tasks/apply, `low` for explore/archive/onboard.
+1. Look up the phase's `reasoning_effort` value in the **Model Profiles** table below (the values are preset-driven and written by gentle-ai — do not assume fixed tiers).
 2. `spawn_agent` with `task_name`, the phase prompt as `message`, and `reasoning_effort` set to the tier value. The `spawn_agent` tool has NO `profile` parameter — tier selection is the `reasoning_effort` argument, not a profile name.
 3. Set `fork_turns: "none"` whenever you override `reasoning_effort` or `model`. A full-history fork (the default) REJECTS these overrides, so the override is silently ignored unless `fork_turns` is `"none"`.
 4. `wait_agent` to collect the result.


### PR DESCRIPTION
Closes #757

> **Chained PR** — targets `feat/codex-multi-agent` (PR #756), not `main`. Final PR of the codex-native-parity chain (#752 → #754 → #756 → this).

### PR Type
- [x] New feature

### Summary
- Add a Codex per-phase SDD model picker to the TUI (mirrors Kiro), with 3 ChatGPT-plan-tied presets and NO custom option: Low-cost (Plus $20), Recommended/default (Pro $100), Powerful (Pro $200).
- Picker appears at install (Codex + SDD selected) AND in the Configure-models menu.
- Selected preset's per-phase `reasoning_effort` renders into the Codex sdd-orchestrator.md Model Profiles table via a `{{CODEX_PHASE_EFFORTS}}` placeholder (no-op for other agents). SupportsSubAgents stays false.

### Changes
| Area | Files |
|------|-------|
| Model layer | `internal/model/codex_model.go` (new), `selection.go` |
| State | `internal/state/state.go` |
| Apply path | `internal/components/sdd/inject.go`, `internal/assets/codex/sdd-orchestrator.md`, `internal/agents/codex/adapter.go` |
| TUI | `internal/tui/screens/codex_model_picker.go` (new), `model.go`, `router.go`, `screens/model_config.go` |
| Wiring | `internal/app/app.go`, `internal/cli/run.go`, `internal/cli/sync.go` |
| Golden | `sdd-codex-agentsmd.golden` (+lowcost/+powerful new) |

### Test Plan
- [x] `go test ./...` passes (full suite green)
- [x] `go vet` clean
- [x] Zero unresolved `{{` placeholders in rendered prompts
- [x] No regression: non-Codex agent goldens unchanged

### Contributor Checklist
- [x] Linked an approved issue (#757)
- [x] Added exactly one `type:*` label
- [x] Tests added/updated (strict TDD)
- [x] Docs updated
- [x] Conventional commit format
- [x] No Co-Authored-By trailers

> Large diff is unavoidable churn (new TUI screen + 3 golden files mirroring the asset) — `size:exception` applied.