### PR TITLE
feat(codex): SDD model-selection profiles + bump Codex to 0.137.0

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -138,6 +138,13 @@ Kiro uses native custom agents in `~/.kiro/agents/`. `gentle-ai` writes phase ag
 - System prompt at `~/.codex/AGENTS.md`
 - Engram instruction files at `~/.codex/engram-instructions.md`
 - MCP servers (Engram and Context7) are upserted as `[mcp_servers.<name>]` blocks in `~/.codex/config.toml`
+- SDD model-selection profiles written as separate files at `~/.codex/<name>.config.toml` (Codex >= 0.134.0 separate-file mechanism). Selected at runtime via `codex --profile <name>`:
+
+  | Profile | `model_reasoning_effort` | SDD phases |
+  |---------|--------------------------|------------|
+  | `sdd-strong` | `xhigh` | propose, design, verify, judge |
+  | `sdd-mid` | `high` | spec, tasks, apply |
+  | `sdd-cheap` | `low` | explore, archive, onboard |
 
 ### Windsurf
 

--- a/internal/agents/codex/profiles.go
+++ b/internal/agents/codex/profiles.go
@@ -43,6 +43,17 @@ func readProfileFileOrEmpty(path string) (string, error) {
 	return string(data), nil
 }
 
+// SddProfilePaths returns the absolute paths of all gentle-ai SDD profile
+// files that WriteCodexProfiles would write into codexHomeDir. Useful for
+// uninstall path tracking without re-running the write.
+func SddProfilePaths(codexHomeDir string) []string {
+	paths := make([]string, 0, len(gentleAIProfiles))
+	for _, p := range gentleAIProfiles {
+		paths = append(paths, filepath.Join(codexHomeDir, p.filename))
+	}
+	return paths
+}
+
 // WriteCodexProfiles writes the three gentle-ai SDD profile files into the
 // given Codex home directory (~/.codex). Each profile file contains a
 // model_reasoning_effort key set to the appropriate SDD tier.

--- a/internal/agents/codex/profiles.go
+++ b/internal/agents/codex/profiles.go
@@ -1,0 +1,77 @@
+package codex
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+
+	"github.com/gentleman-programming/gentle-ai/internal/components/filemerge"
+)
+
+// codexProfile maps a profile filename to its model_reasoning_effort value.
+// These profiles use the separate-file mechanism introduced in Codex >= 0.134.0:
+// each file lives at ~/.codex/<name>.config.toml and is selected at runtime via
+// `codex --profile <name>`. The model_reasoning_effort key is model-agnostic —
+// Codex maps the effort tier to the appropriate model at runtime, so we do NOT
+// hardcode any OpenAI model ID.
+//
+// Tier mapping to SDD Model Assignments:
+//   - sdd-strong  xhigh  propose, design, verify, judge phases
+//   - sdd-mid     high   spec, tasks, apply phases
+//   - sdd-cheap   low    explore, archive, onboard phases
+type codexProfile struct {
+	filename        string
+	reasoningEffort string
+}
+
+var gentleAIProfiles = []codexProfile{
+	{filename: "sdd-strong.config.toml", reasoningEffort: "xhigh"},
+	{filename: "sdd-mid.config.toml", reasoningEffort: "high"},
+	{filename: "sdd-cheap.config.toml", reasoningEffort: "low"},
+}
+
+// readProfileFileOrEmpty returns the file content as a string, or "" if the
+// file does not exist. Any other error is returned as-is.
+func readProfileFileOrEmpty(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", nil
+		}
+		return "", err
+	}
+	return string(data), nil
+}
+
+// WriteCodexProfiles writes the three gentle-ai SDD profile files into the
+// given Codex home directory (~/.codex). Each profile file contains a
+// model_reasoning_effort key set to the appropriate SDD tier.
+//
+// Profile files are written idempotently using UpsertTopLevelTOMLString +
+// WriteFileAtomic — re-running this function when files already contain the
+// canonical values produces changed=false and leaves the files unchanged.
+//
+// Returns (changed, files, err) where changed is true if at least one file
+// was written or modified, and files is the list of profile paths written.
+func WriteCodexProfiles(codexHomeDir string) (changed bool, files []string, err error) {
+	for _, p := range gentleAIProfiles {
+		path := filepath.Join(codexHomeDir, p.filename)
+
+		existing, readErr := readProfileFileOrEmpty(path)
+		if readErr != nil {
+			return false, nil, readErr
+		}
+
+		content := filemerge.UpsertTopLevelTOMLString(existing, "model_reasoning_effort", p.reasoningEffort)
+
+		writeResult, writeErr := filemerge.WriteFileAtomic(path, []byte(content), 0o644)
+		if writeErr != nil {
+			return false, nil, writeErr
+		}
+
+		changed = changed || writeResult.Changed
+		files = append(files, path)
+	}
+
+	return changed, files, nil
+}

--- a/internal/agents/codex/profiles_test.go
+++ b/internal/agents/codex/profiles_test.go
@@ -1,0 +1,108 @@
+package codex
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestWriteCodexProfiles_Written asserts that WriteCodexProfiles creates the
+// three gentle-ai SDD profile files in the given Codex home directory, each
+// containing a non-empty model_reasoning_effort key.
+func TestWriteCodexProfiles_Written(t *testing.T) {
+	dir := t.TempDir()
+
+	changed, files, err := WriteCodexProfiles(dir)
+	if err != nil {
+		t.Fatalf("WriteCodexProfiles() error = %v", err)
+	}
+	if !changed {
+		t.Fatal("WriteCodexProfiles() changed = false, want true on first write")
+	}
+
+	expected := []struct {
+		name            string
+		reasoningEffort string
+	}{
+		{"sdd-strong.config.toml", "xhigh"},
+		{"sdd-mid.config.toml", "high"},
+		{"sdd-cheap.config.toml", "low"},
+	}
+
+	if len(files) != len(expected) {
+		t.Fatalf("WriteCodexProfiles() returned %d files, want %d", len(files), len(expected))
+	}
+
+	for _, tc := range expected {
+		path := filepath.Join(dir, tc.name)
+		content, readErr := os.ReadFile(path)
+		if readErr != nil {
+			t.Fatalf("profile file %q not created: %v", tc.name, readErr)
+		}
+		if !strings.Contains(string(content), `model_reasoning_effort`) {
+			t.Fatalf("profile %q missing model_reasoning_effort key; got:\n%s", tc.name, content)
+		}
+		want := `"` + tc.reasoningEffort + `"`
+		if !strings.Contains(string(content), want) {
+			t.Fatalf("profile %q: want model_reasoning_effort = %s; got:\n%s", tc.name, want, content)
+		}
+	}
+}
+
+// TestWriteCodexProfiles_Idempotent asserts that running WriteCodexProfiles
+// twice produces no change on the second run and does not duplicate keys.
+func TestWriteCodexProfiles_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+
+	_, _, err := WriteCodexProfiles(dir)
+	if err != nil {
+		t.Fatalf("first WriteCodexProfiles() error = %v", err)
+	}
+
+	changed, _, err := WriteCodexProfiles(dir)
+	if err != nil {
+		t.Fatalf("second WriteCodexProfiles() error = %v", err)
+	}
+	if changed {
+		t.Fatal("WriteCodexProfiles() changed = true on second run, want false (idempotent)")
+	}
+
+	// Verify no duplicate keys by checking the count.
+	for _, name := range []string{"sdd-strong.config.toml", "sdd-mid.config.toml", "sdd-cheap.config.toml"} {
+		content, readErr := os.ReadFile(filepath.Join(dir, name))
+		if readErr != nil {
+			t.Fatalf("profile %q missing after second run: %v", name, readErr)
+		}
+		count := strings.Count(string(content), "model_reasoning_effort")
+		if count != 1 {
+			t.Fatalf("profile %q: expected 1 model_reasoning_effort key, got %d; content:\n%s", name, count, content)
+		}
+	}
+}
+
+// TestWriteCodexProfiles_ReturnsAllThreePaths asserts that the returned files
+// slice contains paths for all three profile files.
+func TestWriteCodexProfiles_ReturnsAllThreePaths(t *testing.T) {
+	dir := t.TempDir()
+
+	_, files, err := WriteCodexProfiles(dir)
+	if err != nil {
+		t.Fatalf("WriteCodexProfiles() error = %v", err)
+	}
+
+	wantNames := []string{"sdd-strong.config.toml", "sdd-mid.config.toml", "sdd-cheap.config.toml"}
+	for _, name := range wantNames {
+		want := filepath.Join(dir, name)
+		found := false
+		for _, f := range files {
+			if f == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("WriteCodexProfiles() files does not contain %q; got %v", want, files)
+		}
+	}
+}

--- a/internal/assets/codex/sdd-orchestrator.md
+++ b/internal/assets/codex/sdd-orchestrator.md
@@ -294,3 +294,17 @@ Convention files under `~/.codex/skills/_shared/` (global) or `.agent/skills/_sh
 - `engram` → `mem_search(...)` → `mem_get_observation(...)`
 - `openspec` → read `openspec/changes/*/state.yaml`
 - `none` → state not persisted — explain to user
+
+## Model Profiles
+
+gentle-ai writes three SDD model-selection profile files into `~/.codex/` during installation. Each profile sets `model_reasoning_effort` so Codex picks the right model tier at runtime — no hardcoded model IDs.
+
+Select a profile when running a phase: `codex --profile <name>`
+
+| Profile | `model_reasoning_effort` | SDD phases |
+|---------|--------------------------|------------|
+| `sdd-strong` | `xhigh` | propose, design, verify, judge |
+| `sdd-mid` | `high` | spec, tasks, apply |
+| `sdd-cheap` | `low` | explore, archive, onboard |
+
+When spawning a phase agent (once multi-agent delegation is enabled via `features.multi_agent = true`), pass the matching profile name so the sub-agent runs at the appropriate cost/quality tier. Example: for a `sdd-design` phase, use `--profile sdd-strong`.

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/gentleman-programming/gentle-ai/internal/agents"
+	codexagent "github.com/gentleman-programming/gentle-ai/internal/agents/codex"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/kimi"
 	"github.com/gentleman-programming/gentle-ai/internal/assets"
 	"github.com/gentleman-programming/gentle-ai/internal/backup"
@@ -933,6 +934,10 @@ func componentPathsWithWorkspaceScoped(homeDir, workspaceDir string, scope Insta
 			case model.StrategyTOMLFile:
 				if p := adapter.MCPConfigPath(targetDir, "engram"); p != "" {
 					paths = append(paths, p)
+					// Track the gentle-ai SDD profile files written alongside
+					// the Codex config.toml so they are removed on uninstall.
+					codexHomeDir := filepath.Dir(p)
+					paths = append(paths, codexagent.SddProfilePaths(codexHomeDir)...)
 				}
 			}
 			if adapter.SystemPromptStrategy() == model.StrategyMarkdownSections {

--- a/internal/components/engram/inject.go
+++ b/internal/components/engram/inject.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/gentleman-programming/gentle-ai/internal/agents"
+	"github.com/gentleman-programming/gentle-ai/internal/agents/codex"
 	"github.com/gentleman-programming/gentle-ai/internal/assets"
 	"github.com/gentleman-programming/gentle-ai/internal/components/filemerge"
 	"github.com/gentleman-programming/gentle-ai/internal/model"
@@ -372,6 +373,18 @@ func inject(configHomeDir, promptDir string, adapter agents.Adapter) (InjectionR
 		}
 		changed = changed || tomlWrite.Changed
 		files = append(files, configPath)
+
+		// Write gentle-ai SDD model-selection profile files into ~/.codex/.
+		// These use the separate-file mechanism from Codex >= 0.134.0 and are
+		// selected at runtime via `codex --profile <name>`.
+		// codexHomeDir is the ~/.codex directory (the parent of config.toml).
+		codexHomeDir := filepath.Dir(configPath)
+		profilesChanged, profileFiles, profileErr := codex.WriteCodexProfiles(codexHomeDir)
+		if profileErr != nil {
+			return InjectionResult{}, profileErr
+		}
+		changed = changed || profilesChanged
+		files = append(files, profileFiles...)
 	}
 
 	// 2. Inject Engram memory protocol into system prompt (if supported).

--- a/internal/components/engram/inject_test.go
+++ b/internal/components/engram/inject_test.go
@@ -957,6 +957,68 @@ func TestInjectCodexIsIdempotent(t *testing.T) {
 	}
 }
 
+// ─── Codex profile injection tests ───────────────────────────────────────────
+
+// TestInjectCodexWritesProfiles asserts that Inject for the Codex adapter
+// writes the three gentle-ai SDD profile files into ~/.codex/.
+func TestInjectCodexWritesProfiles(t *testing.T) {
+	home := t.TempDir()
+
+	_, err := Inject(home, codexAdapter())
+	if err != nil {
+		t.Fatalf("Inject(codex) error = %v", err)
+	}
+
+	profiles := []struct {
+		name            string
+		reasoningEffort string
+	}{
+		{"sdd-strong.config.toml", "xhigh"},
+		{"sdd-mid.config.toml", "high"},
+		{"sdd-cheap.config.toml", "low"},
+	}
+
+	for _, p := range profiles {
+		path := filepath.Join(home, ".codex", p.name)
+		content, readErr := os.ReadFile(path)
+		if readErr != nil {
+			t.Fatalf("profile %q not written by Inject: %v", p.name, readErr)
+		}
+		want := `"` + p.reasoningEffort + `"`
+		if !strings.Contains(string(content), want) {
+			t.Fatalf("profile %q: want model_reasoning_effort = %s; got:\n%s", p.name, want, string(content))
+		}
+	}
+}
+
+// TestInjectCodexProfilesIdempotent asserts that running Inject twice leaves
+// the profile files unchanged on the second run and does not duplicate keys.
+func TestInjectCodexProfilesIdempotent(t *testing.T) {
+	home := t.TempDir()
+
+	if _, err := Inject(home, codexAdapter()); err != nil {
+		t.Fatalf("first Inject(codex) error = %v", err)
+	}
+	second, err := Inject(home, codexAdapter())
+	if err != nil {
+		t.Fatalf("second Inject(codex) error = %v", err)
+	}
+	if second.Changed {
+		t.Fatal("second Inject(codex) changed = true, want false (profiles are idempotent)")
+	}
+
+	for _, name := range []string{"sdd-strong.config.toml", "sdd-mid.config.toml", "sdd-cheap.config.toml"} {
+		content, readErr := os.ReadFile(filepath.Join(home, ".codex", name))
+		if readErr != nil {
+			t.Fatalf("profile %q missing after second Inject: %v", name, readErr)
+		}
+		count := strings.Count(string(content), "model_reasoning_effort")
+		if count != 1 {
+			t.Fatalf("profile %q: expected 1 model_reasoning_effort key after second Inject, got %d; content:\n%s", name, count, string(content))
+		}
+	}
+}
+
 // ─── Absolute path resolution tests ──────────────────────────────────────────
 
 // mockEngramLookPath sets EngramLookPath to a mock and restores it after the test.

--- a/internal/versions/versions.go
+++ b/internal/versions/versions.go
@@ -17,7 +17,7 @@ const OpenCode = "1.14.48"
 const QwenCode = "0.15.10"
 
 // renovate: datasource=npm depName=@openai/codex
-const Codex = "0.130.0"
+const Codex = "0.137.0"
 
 // renovate: datasource=npm depName=@google/gemini-cli
 const GeminiCLI = "0.41.2"

--- a/testdata/golden/sdd-codex-agentsmd.golden
+++ b/testdata/golden/sdd-codex-agentsmd.golden
@@ -295,4 +295,18 @@ Convention files under `~/.codex/skills/_shared/` (global) or `.agent/skills/_sh
 - `engram` → `mem_search(...)` → `mem_get_observation(...)`
 - `openspec` → read `openspec/changes/*/state.yaml`
 - `none` → state not persisted — explain to user
+
+## Model Profiles
+
+gentle-ai writes three SDD model-selection profile files into `~/.codex/` during installation. Each profile sets `model_reasoning_effort` so Codex picks the right model tier at runtime — no hardcoded model IDs.
+
+Select a profile when running a phase: `codex --profile <name>`
+
+| Profile | `model_reasoning_effort` | SDD phases |
+|---------|--------------------------|------------|
+| `sdd-strong` | `xhigh` | propose, design, verify, judge |
+| `sdd-mid` | `high` | spec, tasks, apply |
+| `sdd-cheap` | `low` | explore, archive, onboard |
+
+When spawning a phase agent (once multi-agent delegation is enabled via `features.multi_agent = true`), pass the matching profile name so the sub-agent runs at the appropriate cost/quality tier. Example: for a `sdd-design` phase, use `--profile sdd-strong`.
 <!-- /gentle-ai:sdd-orchestrator -->


### PR DESCRIPTION
Closes #753

Supersedes #754 (auto-closed by GitHub when its base branch merged during the chained-PR sequence). Same branch, same commits, retargeted to main.

PR2 of the codex-native-parity chain. Bumps Codex 0.130→0.137 and adds the sdd-strong/mid/cheap CLI profiles. Full `go test ./...` green.