### PR TITLE
fix(install.ps1): make script compatible with irm | iex

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -24,16 +24,6 @@
     .\install.ps1 -Method binary -Insecure
 #>
 
-[CmdletBinding()]
-param(
-    [ValidateSet("auto", "go", "binary")]
-    [string]$Method = "auto",
-
-    [string]$InstallDir = "",
-
-    [switch]$Insecure
-)
-
 $ErrorActionPreference = "Stop"
 
 $GITHUB_OWNER = "Gentleman-Programming"
@@ -342,6 +332,16 @@ function Show-NextSteps {
 # ============================================================================
 
 function Main {
+    [CmdletBinding()]
+    param(
+        [ValidateSet("auto", "go", "binary")]
+        [string]$Method = "auto",
+
+        [string]$InstallDir = "",
+
+        [switch]$Insecure
+    )
+
     Show-Banner
 
     $arch = Get-Platform
@@ -358,4 +358,4 @@ function Main {
     Show-NextSteps
 }
 
-Main
+Main @args


### PR DESCRIPTION
Top-level [CmdletBinding()] / param() blocks are only valid when
PowerShell parses the file as a script. When users run the documented
`irm <url> | iex` one-liner, Windows PowerShell 5.1 evaluates the
downloaded string as an expression and errors with:

  Atributo 'CmdletBinding' inesperado
  Token 'param' inesperado en la expresión o la instrucción
  La expresión de asignación no es válida.

Move the param block onto the Main function and splat $args into it
so both `irm | iex` and `.\install.ps1 -Method binary` keep working.