### PR TITLE
fix(sync): resolve persona from state on TUI sync path

### DIFF
--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -748,12 +748,51 @@ func boolToInt(b bool) int {
 	return 0
 }
 
+// applyResolvedPersona fills selection.Persona when it was not explicitly set.
+// It accepts the already-loaded persisted persona string (from state.json)
+// so no disk I/O happens inside this function.
+//
+// Resolution order:
+//  1. Explicit: if selection.Persona is non-empty, it is left untouched.
+//  2. Persisted: the persisted string is normalized via normalizePersona;
+//     on error (unknown/misspelled value) the fallback is used instead.
+//  3. Fallback: PersonaGentleman for backward-compat (old installs that
+//     have no Persona field in state.json).
+func applyResolvedPersona(selection *model.Selection, persisted string) {
+	if selection.Persona != "" {
+		return
+	}
+	if persisted != "" {
+		if id, err := normalizePersona(persisted); err == nil {
+			selection.Persona = id
+			return
+		}
+		// Unknown/misspelled persisted value — fall through to Gentleman.
+	}
+	// Backward-compat fallback: state files written before persona persistence
+	// have no Persona field. Default to Gentleman so sync still has a target.
+	selection.Persona = model.PersonaGentleman
+}
+
 // RunSyncWithSelection is the programmatic entry point for sync.
 // It skips flag parsing and agent discovery — the caller provides the homeDir
 // and a fully-built Selection (agents + components + options).
 // This is the function the TUI calls directly to avoid CLI flag parsing.
 func RunSyncWithSelection(homeDir string, selection model.Selection) (SyncResult, error) {
 	agentIDs := selection.Agents
+
+	// Resolve persona from persisted state when the caller has not provided one.
+	// RunSync already resolves persona before delegating here, so on the CLI path
+	// selection.Persona is already set and applyResolvedPersona early-returns with
+	// no disk read. On the TUI path the Selection has an empty Persona field, so
+	// we read state once here and apply the persisted value (or Gentleman fallback).
+	if selection.Persona == "" {
+		var persistedPersona string
+		if s, err := state.Read(homeDir); err == nil {
+			persistedPersona = s.Persona
+		}
+		applyResolvedPersona(&selection, persistedPersona)
+	}
 
 	result := SyncResult{
 		Agents:    agentIDs,
@@ -830,48 +869,46 @@ func RunSync(args []string) (SyncResult, error) {
 
 	selection := BuildSyncSelection(flags, agentIDs)
 
-	// Load persisted model assignments and persona from state when not provided
-	// via flags. Without this, every CLI sync falls back to defaults and would
-	// silently overwrite the user's model choices and persona selection.
-	if len(selection.ClaudeModelAssignments) == 0 || len(selection.KiroModelAssignments) == 0 || len(selection.ModelAssignments) == 0 || selection.Persona == "" {
-		s, readErr := state.Read(homeDir)
-		if readErr == nil {
-			if len(selection.ClaudeModelAssignments) == 0 && len(s.ClaudeModelAssignments) > 0 {
-				m := make(map[string]model.ClaudeModelAlias, len(s.ClaudeModelAssignments))
-				for k, v := range s.ClaudeModelAssignments {
-					// Claude Code controls the main session/orchestrator model itself.
-					// Keep persisted assignments scoped to Agent tool calls only.
-					if k == "orchestrator" {
-						continue
-					}
-					m[k] = model.ClaudeModelAlias(v)
-				}
-				selection.ClaudeModelAssignments = m
+	// Read state once for both model-assignment restoration and persona resolution.
+	// On error (e.g. state.json absent), treat persisted values as empty — model
+	// maps stay as-is and persona falls back to Gentleman.
+	persistedState, _ := state.Read(homeDir)
+
+	// Load persisted model assignments from state when not provided via flags.
+	// Without this, every CLI sync falls back to defaults and would silently
+	// overwrite the user's model choices.
+	if len(selection.ClaudeModelAssignments) == 0 && len(persistedState.ClaudeModelAssignments) > 0 {
+		m := make(map[string]model.ClaudeModelAlias, len(persistedState.ClaudeModelAssignments))
+		for k, v := range persistedState.ClaudeModelAssignments {
+			// Claude Code controls the main session/orchestrator model itself.
+			// Keep persisted assignments scoped to Agent tool calls only.
+			if k == "orchestrator" {
+				continue
 			}
-			if len(selection.KiroModelAssignments) == 0 && len(s.KiroModelAssignments) > 0 {
-				m := make(map[string]model.KiroModelAlias, len(s.KiroModelAssignments))
-				for k, v := range s.KiroModelAssignments {
-					m[k] = model.KiroModelAlias(v)
-				}
-				selection.KiroModelAssignments = m
-			}
-			if len(selection.ModelAssignments) == 0 && len(s.ModelAssignments) > 0 {
-				m := make(map[string]model.ModelAssignment, len(s.ModelAssignments))
-				for k, v := range s.ModelAssignments {
-					m[k] = model.ModelAssignment{ProviderID: v.ProviderID, ModelID: v.ModelID, Effort: v.Effort}
-				}
-				selection.ModelAssignments = m
-			}
-			if selection.Persona == "" && s.Persona != "" {
-				selection.Persona = model.PersonaID(s.Persona)
-			}
+			m[k] = model.ClaudeModelAlias(v)
 		}
+		selection.ClaudeModelAssignments = m
 	}
-	// Backward-compat fallback: state files written before persona persistence
-	// have no Persona field. Default to Gentleman so sync still has a target.
-	if selection.Persona == "" {
-		selection.Persona = model.PersonaGentleman
+	if len(selection.KiroModelAssignments) == 0 && len(persistedState.KiroModelAssignments) > 0 {
+		m := make(map[string]model.KiroModelAlias, len(persistedState.KiroModelAssignments))
+		for k, v := range persistedState.KiroModelAssignments {
+			m[k] = model.KiroModelAlias(v)
+		}
+		selection.KiroModelAssignments = m
 	}
+	if len(selection.ModelAssignments) == 0 && len(persistedState.ModelAssignments) > 0 {
+		m := make(map[string]model.ModelAssignment, len(persistedState.ModelAssignments))
+		for k, v := range persistedState.ModelAssignments {
+			m[k] = model.ModelAssignment{ProviderID: v.ProviderID, ModelID: v.ModelID, Effort: v.Effort}
+		}
+		selection.ModelAssignments = m
+	}
+
+	// Resolve persona from the already-read state. This covers both the dry-run
+	// branch (which returns early) and the normal path (which delegates to
+	// RunSyncWithSelection — that function's early-return guard prevents a second
+	// disk read on the CLI path).
+	applyResolvedPersona(&selection, persistedState.Persona)
 
 	if flags.DryRun {
 		// Build the plan for inspection, skip execution.

--- a/internal/cli/sync_test.go
+++ b/internal/cli/sync_test.go
@@ -2346,6 +2346,181 @@ func TestRunSyncFallsBackToGentlemanWhenStateLacksPersona(t *testing.T) {
 	}
 }
 
+// ─── TUI path: RunSyncWithSelection persona resolution from state ───────────
+
+// TestRunSyncWithSelection_PersonaResolvesFromStateNeutral verifies that when
+// the TUI calls RunSyncWithSelection with an empty persona, the persisted
+// persona from state.json is used — not the Gentleman default.
+func TestRunSyncWithSelection_PersonaResolvesFromStateNeutral(t *testing.T) {
+	home := t.TempDir()
+	setSyncTestHome(t, home)
+
+	if err := os.MkdirAll(filepath.Join(home, ".claude"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := state.Write(home, state.InstallState{
+		InstalledAgents: []string{"claude-code"},
+		Persona:         "neutral",
+	}); err != nil {
+		t.Fatalf("state.Write: %v", err)
+	}
+
+	// TUI path: empty persona — must be resolved from state.
+	sel := model.Selection{
+		Agents:     []model.AgentID{model.AgentClaudeCode},
+		Components: []model.ComponentID{model.ComponentPersona},
+		Persona:    "", // empty — the bug scenario
+	}
+
+	result, err := RunSyncWithSelection(home, sel)
+	if err != nil {
+		t.Fatalf("RunSyncWithSelection() error = %v", err)
+	}
+
+	if got, want := result.Selection.Persona, model.PersonaNeutral; got != want {
+		t.Errorf("result.Selection.Persona = %q, want %q (should be resolved from state.json)", got, want)
+	}
+}
+
+// TestRunSyncWithSelection_PersonaResolvesFromStateCustom verifies that a
+// "custom" persona persisted in state is restored on the TUI sync path.
+func TestRunSyncWithSelection_PersonaResolvesFromStateCustom(t *testing.T) {
+	home := t.TempDir()
+	setSyncTestHome(t, home)
+
+	if err := os.MkdirAll(filepath.Join(home, ".claude"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := state.Write(home, state.InstallState{
+		InstalledAgents: []string{"claude-code"},
+		Persona:         "custom",
+	}); err != nil {
+		t.Fatalf("state.Write: %v", err)
+	}
+
+	sel := model.Selection{
+		Agents:     []model.AgentID{model.AgentClaudeCode},
+		Components: []model.ComponentID{model.ComponentPersona},
+		Persona:    "",
+	}
+
+	result, err := RunSyncWithSelection(home, sel)
+	if err != nil {
+		t.Fatalf("RunSyncWithSelection() error = %v", err)
+	}
+
+	if got, want := result.Selection.Persona, model.PersonaCustom; got != want {
+		t.Errorf("result.Selection.Persona = %q, want %q (should be resolved from state.json)", got, want)
+	}
+}
+
+// TestRunSyncWithSelection_PersonaFallsBackToGentlemanWhenStateHasNone verifies
+// the backward-compat fallback: old state files without a Persona field still
+// result in the Gentleman persona (not empty / not panic).
+func TestRunSyncWithSelection_PersonaFallsBackToGentlemanWhenStateHasNone(t *testing.T) {
+	home := t.TempDir()
+	setSyncTestHome(t, home)
+
+	if err := os.MkdirAll(filepath.Join(home, ".claude"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	// State with no Persona field — old install before persona persistence.
+	if err := state.Write(home, state.InstallState{
+		InstalledAgents: []string{"claude-code"},
+	}); err != nil {
+		t.Fatalf("state.Write: %v", err)
+	}
+
+	sel := model.Selection{
+		Agents:     []model.AgentID{model.AgentClaudeCode},
+		Components: []model.ComponentID{model.ComponentPersona},
+		Persona:    "",
+	}
+
+	result, err := RunSyncWithSelection(home, sel)
+	if err != nil {
+		t.Fatalf("RunSyncWithSelection() error = %v", err)
+	}
+
+	if got, want := result.Selection.Persona, model.PersonaGentleman; got != want {
+		t.Errorf("result.Selection.Persona = %q, want %q (fallback for pre-feature state)", got, want)
+	}
+}
+
+// TestRunSyncWithSelection_ExplicitPersonaWinsOverState verifies that when the
+// caller provides a non-empty persona (e.g. the user just picked one in the
+// ModelConfig TUI step), that explicit choice is preserved even if state says
+// something different.
+func TestRunSyncWithSelection_ExplicitPersonaWinsOverState(t *testing.T) {
+	home := t.TempDir()
+	setSyncTestHome(t, home)
+
+	if err := os.MkdirAll(filepath.Join(home, ".claude"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	// State says "gentleman" but the caller explicitly chose "neutral".
+	if err := state.Write(home, state.InstallState{
+		InstalledAgents: []string{"claude-code"},
+		Persona:         "gentleman",
+	}); err != nil {
+		t.Fatalf("state.Write: %v", err)
+	}
+
+	sel := model.Selection{
+		Agents:     []model.AgentID{model.AgentClaudeCode},
+		Components: []model.ComponentID{model.ComponentPersona},
+		Persona:    model.PersonaNeutral, // explicit — must not be overridden by state
+	}
+
+	result, err := RunSyncWithSelection(home, sel)
+	if err != nil {
+		t.Fatalf("RunSyncWithSelection() error = %v", err)
+	}
+
+	if got, want := result.Selection.Persona, model.PersonaNeutral; got != want {
+		t.Errorf("result.Selection.Persona = %q, want %q (explicit selection must win over state)", got, want)
+	}
+}
+
+// TestRunSyncWithSelection_UnknownPersistedPersonaFallsBackToGentleman documents
+// the normalizePersona contract for unrecognized persisted values: an unknown or
+// misspelled persona string (e.g. "Gentleman" capitalized, or "bogus") must NOT
+// silently propagate as a PersonaID — it must fall back to PersonaGentleman.
+func TestRunSyncWithSelection_UnknownPersistedPersonaFallsBackToGentleman(t *testing.T) {
+	home := t.TempDir()
+	setSyncTestHome(t, home)
+
+	if err := os.MkdirAll(filepath.Join(home, ".claude"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	// Write a state with an unrecognized persona value (wrong capitalization).
+	// normalizePersona does a case-sensitive switch, so "Gentleman" != "gentleman"
+	// and must return an error, triggering the Gentleman fallback.
+	if err := state.Write(home, state.InstallState{
+		InstalledAgents: []string{"claude-code"},
+		Persona:         "Gentleman", // capitalized — not a valid PersonaID
+	}); err != nil {
+		t.Fatalf("state.Write: %v", err)
+	}
+
+	sel := model.Selection{
+		Agents:     []model.AgentID{model.AgentClaudeCode},
+		Components: []model.ComponentID{model.ComponentPersona},
+		Persona:    "", // empty — resolution from state must happen
+	}
+
+	result, err := RunSyncWithSelection(home, sel)
+	if err != nil {
+		t.Fatalf("RunSyncWithSelection() error = %v", err)
+	}
+
+	// normalizePersona returns an error for "Gentleman" (unknown); applyResolvedPersona
+	// must fall through to the Gentleman fallback, not propagate the raw bad string.
+	if got, want := result.Selection.Persona, model.PersonaGentleman; got != want {
+		t.Errorf("result.Selection.Persona = %q, want %q (unknown persisted value must fall back to Gentleman)", got, want)
+	}
+}
+
 // ─── Changed file path reporting ────────────────────────────────────────────
 
 // TestRenderSyncReportIncludesChangedFilePaths verifies that RenderSyncReport
@@ -2435,6 +2610,92 @@ func TestDedupPathsNilOnEmpty(t *testing.T) {
 	got = dedupPaths([]string{})
 	if got != nil {
 		t.Errorf("dedupPaths([]) = %v, want nil", got)
+	}
+}
+
+// ─── Dry-run persona resolution ───────────────────────────────────────────────
+
+// TestRunSyncDryRunResolvesPersonaFromState verifies that --dry-run mode
+// resolves the persona from state.json instead of leaving it empty.
+// This is a regression test: the dry-run branch returns early and never calls
+// RunSyncWithSelection, so without an explicit resolvePersonaFromState call the
+// persona is never populated.
+func TestRunSyncDryRunResolvesPersonaFromState(t *testing.T) {
+	home := t.TempDir()
+	setSyncTestHome(t, home)
+
+	if err := os.MkdirAll(filepath.Join(home, ".claude"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	// Write state with persona "neutral" and the model-assignment maps populated
+	// to exercise a realistic dry-run scenario. RunSync reads state once
+	// unconditionally and resolves persona before the dry-run early return, so
+	// result.Selection.Persona must reflect the persisted value regardless of
+	// whether the model-assignment maps are empty or full.
+	if err := state.Write(home, state.InstallState{
+		InstalledAgents: []string{"claude-code"},
+		Persona:         "neutral",
+		ClaudeModelAssignments: map[string]string{
+			"sdd-apply": "sonnet",
+		},
+		KiroModelAssignments: map[string]string{
+			"default": "auto",
+		},
+		ModelAssignments: map[string]state.ModelAssignmentState{
+			"sdd-init": {ProviderID: "anthropic", ModelID: "claude-sonnet-4"},
+		},
+	}); err != nil {
+		t.Fatalf("state.Write: %v", err)
+	}
+
+	result, err := RunSync([]string{"--agents", "claude-code", "--dry-run"})
+	if err != nil {
+		t.Fatalf("RunSync() --dry-run error = %v", err)
+	}
+	if !result.DryRun {
+		t.Fatalf("DryRun = false, want true")
+	}
+	if got, want := result.Selection.Persona, model.PersonaNeutral; got != want {
+		t.Errorf("dry-run: Selection.Persona = %q, want %q (should be resolved from state.json)", got, want)
+	}
+}
+
+// TestRunSyncDryRunFallsBackToGentlemanWhenStateLacksPersona verifies that
+// --dry-run mode falls back to Gentleman when state has no recorded persona
+// (backward-compat: old installs without persona persistence).
+func TestRunSyncDryRunFallsBackToGentlemanWhenStateLacksPersona(t *testing.T) {
+	home := t.TempDir()
+	setSyncTestHome(t, home)
+
+	if err := os.MkdirAll(filepath.Join(home, ".claude"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	// State with all model maps populated but no Persona field (old install).
+	if err := state.Write(home, state.InstallState{
+		InstalledAgents: []string{"claude-code"},
+		// No Persona field — pre-persona-persistence install.
+		ClaudeModelAssignments: map[string]string{
+			"sdd-apply": "sonnet",
+		},
+		KiroModelAssignments: map[string]string{
+			"default": "auto",
+		},
+		ModelAssignments: map[string]state.ModelAssignmentState{
+			"sdd-init": {ProviderID: "anthropic", ModelID: "claude-sonnet-4"},
+		},
+	}); err != nil {
+		t.Fatalf("state.Write: %v", err)
+	}
+
+	result, err := RunSync([]string{"--agents", "claude-code", "--dry-run"})
+	if err != nil {
+		t.Fatalf("RunSync() --dry-run error = %v", err)
+	}
+	if !result.DryRun {
+		t.Fatalf("DryRun = false, want true")
+	}
+	if got, want := result.Selection.Persona, model.PersonaGentleman; got != want {
+		t.Errorf("dry-run fallback: Selection.Persona = %q, want %q (Gentleman fallback for pre-feature state)", got, want)
 	}
 }
 


### PR DESCRIPTION
Closes #772

## Problem
Running upgrade + sync from the TUI reinstalls the Gentleman persona even when `neutral` or `custom` was selected. The choice is persisted in `state.json`, but the TUI path never read it back.

## Root cause
Persona-from-state resolution lived only in `RunSync` (CLI path). The TUI calls `RunSyncWithSelection` directly with an empty `selection.Persona`, so `personaContent("")` fell through to the default case and returned the Gentleman persona. CLI `gentle-ai sync` was unaffected.

## Fix
- Extract the persona decision into a pure helper `applyResolvedPersona` (explicit wins → persisted value → Gentleman fallback) with no disk I/O.
- Call it from both entry points so persona is resolved regardless of how sync is triggered; each path reads state at most once.
- Run the persisted value through `normalizePersona` so an unknown/corrupt value falls back to Gentleman instead of producing an invalid persona id.

## Tests
- TUI path resolves `neutral`/`custom` from state; explicit choice wins over state; old installs without a persona field fall back to Gentleman.
- Dry-run path resolves persona before the early return.
- Unknown persisted value falls back to Gentleman.

`go test ./...` green, `go build ./...` clean. Reviewed via dual adversarial review (two rounds) before opening.