### PR TITLE
feat(model,filemerge): Hermes foundation + YAML MCP helpers (1/4)

### DIFF
--- a/internal/components/filemerge/yaml.go
+++ b/internal/components/filemerge/yaml.go
@@ -1,0 +1,325 @@
+package filemerge
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/gentleman-programming/gentle-ai/internal/versions"
+)
+
+// UpsertYAMLMCPServerBlock removes any existing <serverID>: block nested under
+// the top-level mcp_servers: key and re-appends a fresh block with command/args
+// (and optional env). If mcp_servers: is absent, it is created. Everything
+// outside the managed server block — other servers, top-level keys, and user
+// comments — is preserved.
+//
+// command/args/env are emitted with 2-space indentation:
+//
+//	mcp_servers:
+//	  <serverID>:
+//	    command: <command>
+//	    args:
+//	      - <arg0>
+//	      - <arg1>
+//	    env:
+//	      KEY: value
+//
+// Idempotent: calling twice with the same arguments yields identical output.
+func UpsertYAMLMCPServerBlock(content, serverID, command string, args []string, env map[string]string) string {
+	content = strings.ReplaceAll(content, "\r\n", "\n")
+	lines := strings.Split(content, "\n")
+
+	// Build the server sub-block (4-space indent for keys, 6-space for list items).
+	block := buildServerBlock(serverID, command, args, env)
+
+	// Locate the top-level mcp_servers: line (zero leading indent, exact match).
+	mcpLineIdx := -1
+	for i, line := range lines {
+		if strings.TrimSpace(line) == "mcp_servers:" && !hasLeadingSpaces(line) {
+			mcpLineIdx = i
+			break
+		}
+	}
+
+	if mcpLineIdx == -1 {
+		// mcp_servers: is absent — append it at EOF.
+		base := strings.TrimRight(strings.Join(lines, "\n"), "\n")
+		if base == "" {
+			return "mcp_servers:\n" + block
+		}
+		return base + "\n\nmcp_servers:\n" + block
+	}
+
+	// mcp_servers: is present — find the region of its child lines.
+	// The child region spans from mcpLineIdx+1 to the next zero-indent non-blank
+	// non-comment line (exclusive), or EOF.
+	regionEnd := len(lines)
+	for i := mcpLineIdx + 1; i < len(lines); i++ {
+		line := lines[i]
+		if line == "" || strings.TrimSpace(line) == "" {
+			continue
+		}
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		// A full-line comment at zero indent is treated as part of the region if
+		// it immediately precedes the next non-comment section. However to keep the
+		// logic simple and consistent with the design requirement, any zero-indent
+		// non-blank, non-comment line ends the region.
+		if !hasLeadingSpaces(line) && !strings.HasPrefix(trimmed, "#") {
+			regionEnd = i
+			break
+		}
+	}
+
+	// Within the region [mcpLineIdx+1, regionEnd), strip any existing <serverID>: block.
+	// The server key is at exactly 2-space indent: "  <serverID>:".
+	serverKey := "  " + serverID + ":"
+	var kept []string
+	kept = append(kept, lines[:mcpLineIdx+1]...)
+
+	region := lines[mcpLineIdx+1 : regionEnd]
+	i := 0
+	for i < len(region) {
+		line := region[i]
+		trimmed := strings.TrimSpace(line)
+
+		// Match the server key at exactly 2-space indent.
+		if strings.TrimRight(line, " \t") == serverKey || line == serverKey {
+			// Skip this server's sub-block: all lines indented more than 2 spaces
+			// (i.e., indent > 2), until the next sibling server key (2-space indent
+			// non-blank, non-comment) or end of region.
+			i++
+			for i < len(region) {
+				nextLine := region[i]
+				nextTrimmed := strings.TrimSpace(nextLine)
+				if nextTrimmed == "" {
+					// Blank lines at the boundary — include until we hit a sibling.
+					i++
+					continue
+				}
+				// A sibling server key has exactly 2 leading spaces and is not a comment.
+				if len(nextLine) >= 2 && nextLine[:2] == "  " && !strings.HasPrefix(strings.TrimSpace(nextLine), "#") {
+					// Check it's exactly at 2-space indent (not deeper).
+					restAfterTwo := nextLine[2:]
+					if len(restAfterTwo) > 0 && restAfterTwo[0] != ' ' {
+						break // sibling found
+					}
+				}
+				// Also break on zero-indent non-blank lines (end of mcp_servers region).
+				if !hasLeadingSpaces(nextLine) && nextTrimmed != "" && !strings.HasPrefix(nextTrimmed, "#") {
+					break
+				}
+				i++
+			}
+			continue
+		}
+
+		// Trim trailing blank lines that belong to the old block boundary.
+		if trimmed == "" {
+			// We'll handle trailing blanks after the loop.
+			kept = append(kept, line)
+			i++
+			continue
+		}
+
+		kept = append(kept, line)
+		i++
+	}
+
+	// Trim trailing blank lines at the end of the kept mcp_servers region before
+	// appending the fresh block.
+	for len(kept) > mcpLineIdx+1 && strings.TrimSpace(kept[len(kept)-1]) == "" {
+		kept = kept[:len(kept)-1]
+	}
+
+	// Append the fresh server block lines.
+	blockLines := strings.Split(strings.TrimRight(block, "\n"), "\n")
+	kept = append(kept, blockLines...)
+
+	// Append the rest (after the mcp_servers region).
+	if regionEnd < len(lines) {
+		// Add a blank separator if the next section doesn't start with a blank line.
+		if strings.TrimSpace(lines[regionEnd]) != "" {
+			kept = append(kept, "")
+		}
+		kept = append(kept, lines[regionEnd:]...)
+	}
+
+	result := strings.Join(kept, "\n")
+	result = strings.TrimRight(result, "\n")
+	return result + "\n"
+}
+
+// buildServerBlock builds the 2-space-indented YAML block for a single MCP server.
+// The block does NOT include mcp_servers: — it starts at "  <serverID>:".
+func buildServerBlock(serverID, command string, args []string, env map[string]string) string {
+	var sb strings.Builder
+	sb.WriteString("  " + serverID + ":\n")
+	sb.WriteString("    command: " + command + "\n")
+	if len(args) > 0 {
+		sb.WriteString("    args:\n")
+		for _, arg := range args {
+			sb.WriteString("      - " + arg + "\n")
+		}
+	}
+	if len(env) > 0 {
+		sb.WriteString("    env:\n")
+		// Sort keys for deterministic output (idempotency).
+		keys := make([]string, 0, len(env))
+		for k := range env {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			sb.WriteString("      " + k + ": " + env[k] + "\n")
+		}
+	}
+	return sb.String()
+}
+
+// hasLeadingSpaces reports whether line starts with a space or tab character.
+func hasLeadingSpaces(line string) bool {
+	return len(line) > 0 && (line[0] == ' ' || line[0] == '\t')
+}
+
+// UpsertHermesEngramBlock is a thin convenience wrapper that upserts the canonical
+// engram MCP server block (command=engramCmd, args=["mcp","--tools=agent"], no env).
+// Falls back to "engram" when engramCmd is empty. Mirrors UpsertCodexEngramBlock.
+func UpsertHermesEngramBlock(content, engramCmd string) string {
+	if engramCmd == "" {
+		engramCmd = "engram"
+	}
+	return UpsertYAMLMCPServerBlock(content, "engram", engramCmd, []string{"mcp", "--tools=agent"}, nil)
+}
+
+// UpsertHermesContext7Block is a thin convenience wrapper that upserts the canonical
+// context7 MCP server block. Context7 is a stdio server; the first slice uses
+// the same stdio shape as Codex (command + pinned args from versions.Context7MCP).
+func UpsertHermesContext7Block(content string) string {
+	args := []string{
+		"-y",
+		fmt.Sprintf("--package=@upstash/context7-mcp@%s", versions.Context7MCP),
+		"--",
+		"context7-mcp",
+	}
+	return UpsertYAMLMCPServerBlock(content, "context7", "npx", args, nil)
+}
+
+// ReadYAMLMCPServerCommand recovers the executable of a named MCP server's
+// command from a YAML config (read-only — never mutates). It is the YAML
+// counterpart of the JSON path inside engram's existingMergedEngramCommand,
+// enabling gentle-ai to preserve a command already written for a server
+// (e.g. an absolute path) instead of clobbering it on re-run.
+//
+// Algorithm (hand-rolled, NO gopkg.in/yaml.v3 — read-only block scanning):
+//  1. Normalize line endings; split into lines; ignore full-line comments (# ...).
+//  2. Locate the top-level mcp_servers: line (trimmed == "mcp_servers:" AND
+//     zero leading indent).
+//  3. Within its child region (indent > 0, until the next zero-indent non-blank
+//     line or EOF), find the <serverID>: block at exactly 2-space indent.
+//  4. Within that server's sub-block (indent deeper than the server key, up to
+//     the next 2-space sibling or end of region), read command::
+//     - scalar string  -> command: engram     => "engram"
+//     - YAML list       -> command: then - engram items => first element
+//  5. Return ("", false) when mcp_servers / serverID / command is absent or the
+//     file does not match the expected shape.
+//
+// Generalizes to any future YAML-backed agent; engram dispatches to it for Hermes.
+func ReadYAMLMCPServerCommand(content string, serverID string) (string, bool) {
+	content = strings.ReplaceAll(content, "\r\n", "\n")
+	lines := strings.Split(content, "\n")
+
+	// Step 1: Find the top-level mcp_servers: key.
+	mcpLineIdx := -1
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "#" || strings.HasPrefix(trimmed, "# ") || trimmed == "" {
+			continue // skip blank and comment lines
+		}
+		if trimmed == "mcp_servers:" && !hasLeadingSpaces(line) {
+			mcpLineIdx = i
+			break
+		}
+	}
+	if mcpLineIdx == -1 {
+		return "", false
+	}
+
+	// Step 2: Find the child region of mcp_servers:.
+	regionEnd := len(lines)
+	for i := mcpLineIdx + 1; i < len(lines); i++ {
+		line := lines[i]
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		if !hasLeadingSpaces(line) {
+			regionEnd = i
+			break
+		}
+	}
+
+	// Step 3: Within the region, find the server key at exactly 2-space indent.
+	serverKey := "  " + serverID + ":"
+	serverLineIdx := -1
+	for i := mcpLineIdx + 1; i < regionEnd; i++ {
+		line := lines[i]
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "#") || trimmed == "" {
+			continue
+		}
+		if line == serverKey {
+			serverLineIdx = i
+			break
+		}
+	}
+	if serverLineIdx == -1 {
+		return "", false
+	}
+
+	// Step 4: Within the server's sub-block, find the command: line.
+	// The sub-block ends at the next sibling (2-space indent) or end of region.
+	for i := serverLineIdx + 1; i < regionEnd; i++ {
+		line := lines[i]
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+
+		// A 2-space-indent line that is not a comment signals a sibling server.
+		if len(line) >= 2 && line[:2] == "  " && len(line) > 2 && line[2] != ' ' {
+			break // sibling server key — end of sub-block
+		}
+
+		// Look for command: key (at 4-space indent inside the server block).
+		if strings.HasPrefix(trimmed, "command:") {
+			rest := strings.TrimPrefix(trimmed, "command:")
+			rest = strings.TrimSpace(rest)
+			if rest != "" {
+				// Scalar form: command: engram
+				return rest, true
+			}
+			// List form: command: followed by list items on the next lines.
+			for j := i + 1; j < regionEnd; j++ {
+				nextLine := lines[j]
+				nextTrimmed := strings.TrimSpace(nextLine)
+				if nextTrimmed == "" || strings.HasPrefix(nextTrimmed, "#") {
+					continue
+				}
+				// A list item starts with "- ".
+				if strings.HasPrefix(nextTrimmed, "- ") {
+					return strings.TrimPrefix(nextTrimmed, "- "), true
+				}
+				// Anything else (non-list, non-comment, non-blank) means command: was empty
+				// and no list items follow — treat as absent.
+				break
+			}
+			return "", false
+		}
+	}
+
+	return "", false
+}

--- a/internal/components/filemerge/yaml.go
+++ b/internal/components/filemerge/yaml.go
@@ -33,10 +33,13 @@ func UpsertYAMLMCPServerBlock(content, serverID, command string, args []string, 
 	// Build the server sub-block (4-space indent for keys, 6-space for list items).
 	block := buildServerBlock(serverID, command, args, env)
 
-	// Locate the top-level mcp_servers: line (zero leading indent, exact match).
+	// Locate the top-level mcp_servers: line (zero leading indent, key prefix match).
+	// We match any zero-indent line whose trimmed form starts with "mcp_servers:" to
+	// handle both the block form ("mcp_servers:") and inline forms ("mcp_servers: {}").
 	mcpLineIdx := -1
 	for i, line := range lines {
-		if strings.TrimSpace(line) == "mcp_servers:" && !hasLeadingSpaces(line) {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "mcp_servers:") && !hasLeadingSpaces(line) {
 			mcpLineIdx = i
 			break
 		}
@@ -51,15 +54,20 @@ func UpsertYAMLMCPServerBlock(content, serverID, command string, args []string, 
 		return base + "\n\nmcp_servers:\n" + block
 	}
 
+	// Normalize an inline mcp_servers: value (e.g. "mcp_servers: {}" or
+	// "mcp_servers: somevalue") to a bare block-form "mcp_servers:" so the
+	// rest of the algorithm can treat it uniformly. This prevents duplicate
+	// top-level keys when the user (or a tool) wrote an inline mapping.
+	if strings.TrimSpace(lines[mcpLineIdx]) != "mcp_servers:" {
+		lines[mcpLineIdx] = "mcp_servers:"
+	}
+
 	// mcp_servers: is present — find the region of its child lines.
 	// The child region spans from mcpLineIdx+1 to the next zero-indent non-blank
 	// non-comment line (exclusive), or EOF.
 	regionEnd := len(lines)
 	for i := mcpLineIdx + 1; i < len(lines); i++ {
 		line := lines[i]
-		if line == "" || strings.TrimSpace(line) == "" {
-			continue
-		}
 		trimmed := strings.TrimSpace(line)
 		if trimmed == "" {
 			continue
@@ -236,7 +244,7 @@ func ReadYAMLMCPServerCommand(content string, serverID string) (string, bool) {
 	mcpLineIdx := -1
 	for i, line := range lines {
 		trimmed := strings.TrimSpace(line)
-		if trimmed == "#" || strings.HasPrefix(trimmed, "# ") || trimmed == "" {
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
 			continue // skip blank and comment lines
 		}
 		if trimmed == "mcp_servers:" && !hasLeadingSpaces(line) {
@@ -299,7 +307,24 @@ func ReadYAMLMCPServerCommand(content string, serverID string) (string, bool) {
 			rest := strings.TrimPrefix(trimmed, "command:")
 			rest = strings.TrimSpace(rest)
 			if rest != "" {
-				// Scalar form: command: engram
+				// Scalar form: command: <value>
+				// Normalize order: strip inline comment (only for unquoted values),
+				// then TrimSpace, then strip surrounding matching quotes.
+				isDoubleQuoted := len(rest) >= 2 && rest[0] == '"' && rest[len(rest)-1] == '"'
+				isSingleQuoted := len(rest) >= 2 && rest[0] == '\'' && rest[len(rest)-1] == '\''
+				if !isDoubleQuoted && !isSingleQuoted {
+					// Strip trailing inline comment: split on first " #" (space-hash).
+					if idx := strings.Index(rest, " #"); idx != -1 {
+						rest = rest[:idx]
+					}
+					rest = strings.TrimSpace(rest)
+				}
+				// Strip surrounding matching quotes.
+				if isDoubleQuoted {
+					rest = rest[1 : len(rest)-1]
+				} else if isSingleQuoted {
+					rest = rest[1 : len(rest)-1]
+				}
 				return rest, true
 			}
 			// List form: command: followed by list items on the next lines.

--- a/internal/components/filemerge/yaml_test.go
+++ b/internal/components/filemerge/yaml_test.go
@@ -1,0 +1,420 @@
+package filemerge
+
+import (
+	"strings"
+	"testing"
+)
+
+// ─── UpsertYAMLMCPServerBlock ─────────────────────────────────────────────────
+
+// TestUpsertYAMLMCPServerBlock covers the full golden matrix required by the spec
+// and design (scenarios #1–#9). Scenario #10 (context7 wrapper) is in
+// TestUpsertHermesContext7Block below.
+func TestUpsertYAMLMCPServerBlock(t *testing.T) {
+	t.Parallel()
+
+	engram := func(content string) string {
+		return UpsertYAMLMCPServerBlock(content, "engram", "engram", []string{"mcp", "--tools=agent"}, nil)
+	}
+
+	tests := []struct {
+		name   string
+		input  string
+		fn     func(string) string
+		checks []string // substrings that must be present
+		absent []string // substrings that must be absent
+		suffix string   // if non-empty, result must end with this
+		exact  string   // if non-empty, result must equal this exactly
+	}{
+		{
+			// #1: empty/absent content → engram block created from scratch
+			name:  "empty_content_creates_mcp_servers",
+			input: "",
+			fn:    engram,
+			checks: []string{
+				"mcp_servers:\n",
+				"  engram:\n",
+				"    command: engram\n",
+				"    args:\n",
+				"      - mcp\n",
+				"      - --tools=agent\n",
+			},
+			suffix: "\n",
+		},
+		{
+			// #2: mcp_servers: absent, other top-level keys present → keys/comments preserved; section appended
+			name: "other_top_level_keys_preserved",
+			input: `# user config
+model: gpt-4o
+temperature: 0.7
+`,
+			fn: engram,
+			checks: []string{
+				"# user config\n",
+				"model: gpt-4o\n",
+				"temperature: 0.7\n",
+				"mcp_servers:\n",
+				"  engram:\n",
+				"    command: engram\n",
+			},
+			suffix: "\n",
+		},
+		{
+			// #3: mcp_servers: present, no engram entry → user server preserved, engram appended as sibling
+			name: "user_server_preserved_engram_appended",
+			input: `mcp_servers:
+  myserver:
+    command: myserver
+    args:
+      - --flag
+`,
+			fn: engram,
+			checks: []string{
+				"  myserver:\n",
+				"    command: myserver\n",
+				"    args:\n",
+				"      - --flag\n",
+				"  engram:\n",
+				"    command: engram\n",
+			},
+		},
+		{
+			// #4: idempotency — output of #3 fed back in → byte-identical result
+			name: "idempotent_rerun",
+			input: `mcp_servers:
+  myserver:
+    command: myserver
+    args:
+      - --flag
+`,
+			fn: func(content string) string {
+				first := engram(content)
+				second := engram(first)
+				if first != second {
+					t.Errorf("idempotency violated:\nfirst:\n%s\nsecond:\n%s", first, second)
+				}
+				return second
+			},
+			checks: []string{
+				"  myserver:\n",
+				"  engram:\n",
+			},
+			absent: []string{
+				// Must not duplicate engram
+				"  engram:\n  engram:\n",
+			},
+		},
+		{
+			// #5: upsert replaces stale engram block (old args) → old block removed, fresh block appended, siblings intact
+			name: "stale_block_replaced",
+			input: `mcp_servers:
+  myserver:
+    command: myserver
+  engram:
+    command: engram
+    args:
+      - mcp
+`,
+			fn: engram,
+			checks: []string{
+				"  myserver:\n",
+				"  engram:\n",
+				"      - --tools=agent\n",
+			},
+			absent: []string{
+				// Old engram args-only entry must be gone; replaced with full block
+			},
+		},
+		{
+			// #6: user comments outside managed block → all comments preserved verbatim
+			name: "comments_outside_block_preserved",
+			input: `# top-level comment
+model: gpt-4o
+
+# comment before mcp
+mcp_servers:
+  # comment inside mcp
+  myserver:
+    command: myserver
+
+# trailing comment
+`,
+			fn: engram,
+			checks: []string{
+				"# top-level comment\n",
+				"# comment before mcp\n",
+				"# trailing comment\n",
+				"  # comment inside mcp\n",
+				"  myserver:\n",
+				"  engram:\n",
+			},
+		},
+		{
+			// #7: two managed servers coexist (engram then context7) → both present, both at 2-space indent, idempotent
+			name:  "two_managed_servers_coexist",
+			input: "",
+			fn: func(content string) string {
+				withEngram := engram(content)
+				withBoth := UpsertYAMLMCPServerBlock(withEngram, "context7", "npx",
+					[]string{"-y", "--package=@upstash/context7-mcp@2.2.5", "--", "context7-mcp"}, nil)
+				// idempotency check
+				withBothAgain := UpsertYAMLMCPServerBlock(withBoth, "context7", "npx",
+					[]string{"-y", "--package=@upstash/context7-mcp@2.2.5", "--", "context7-mcp"}, nil)
+				if withBoth != withBothAgain {
+					t.Errorf("two-server idempotency violated:\nfirst:\n%s\nsecond:\n%s", withBoth, withBothAgain)
+				}
+				return withBoth
+			},
+			checks: []string{
+				"  engram:\n",
+				"    command: engram\n",
+				"  context7:\n",
+				"    command: npx\n",
+			},
+		},
+		{
+			// #8: CRLF input → normalized to \n, single trailing \n
+			name:  "crlf_normalized",
+			input: "model: gpt-4o\r\n",
+			fn:    engram,
+			checks: []string{
+				"model: gpt-4o\n",
+				"mcp_servers:\n",
+			},
+			absent: []string{"\r\n"},
+			suffix: "\n",
+		},
+		{
+			// #9: env map rendered → env: sub-block with 2-space-deeper KV pairs
+			name:  "env_block_rendered",
+			input: "",
+			fn: func(content string) string {
+				return UpsertYAMLMCPServerBlock(content, "engram", "engram",
+					[]string{"mcp", "--tools=agent"},
+					map[string]string{"ENGRAM_HOME": "/data/engram"})
+			},
+			checks: []string{
+				"    env:\n",
+				"      ENGRAM_HOME: /data/engram\n",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := tt.fn(tt.input)
+			for _, want := range tt.checks {
+				if !strings.Contains(got, want) {
+					t.Errorf("missing expected content %q in:\n%s", want, got)
+				}
+			}
+			for _, absent := range tt.absent {
+				if strings.Contains(got, absent) {
+					t.Errorf("unexpected content %q found in:\n%s", absent, got)
+				}
+			}
+			if tt.suffix != "" && !strings.HasSuffix(got, tt.suffix) {
+				t.Errorf("result does not end with %q; got:\n%q", tt.suffix, got)
+			}
+			if tt.exact != "" && got != tt.exact {
+				t.Errorf("result mismatch:\nwant:\n%s\ngot:\n%s", tt.exact, got)
+			}
+		})
+	}
+}
+
+// #10: UpsertHermesContext7Block on empty → pinned versions.Context7MCP args emitted
+func TestUpsertHermesContext7Block(t *testing.T) {
+	t.Parallel()
+
+	got := UpsertHermesContext7Block("")
+
+	if !strings.Contains(got, "  context7:\n") {
+		t.Fatalf("missing context7 server key; got:\n%s", got)
+	}
+	if !strings.Contains(got, "    command: npx\n") {
+		t.Fatalf("missing command: npx; got:\n%s", got)
+	}
+	// Must contain the pinned context7 package arg.
+	if !strings.Contains(got, "--package=@upstash/context7-mcp@") {
+		t.Fatalf("missing pinned context7-mcp package arg; got:\n%s", got)
+	}
+	if !strings.Contains(got, "      - context7-mcp\n") {
+		t.Fatalf("missing context7-mcp arg; got:\n%s", got)
+	}
+	if !strings.HasSuffix(got, "\n") {
+		t.Fatalf("result does not end with newline; got:\n%q", got)
+	}
+
+	// Idempotency.
+	second := UpsertHermesContext7Block(got)
+	if got != second {
+		t.Fatalf("UpsertHermesContext7Block not idempotent:\nfirst:\n%s\nsecond:\n%s", got, second)
+	}
+}
+
+// TestUpsertHermesEngramBlock verifies the engram-specific convenience wrapper.
+func TestUpsertHermesEngramBlock(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty_content_default_command", func(t *testing.T) {
+		t.Parallel()
+		got := UpsertHermesEngramBlock("", "")
+		if !strings.Contains(got, "  engram:\n") {
+			t.Fatalf("missing engram server key; got:\n%s", got)
+		}
+		if !strings.Contains(got, "    command: engram\n") {
+			t.Fatalf("missing default command 'engram'; got:\n%s", got)
+		}
+		if !strings.Contains(got, "      - --tools=agent\n") {
+			t.Fatalf("missing --tools=agent arg; got:\n%s", got)
+		}
+	})
+
+	t.Run("custom_command_used", func(t *testing.T) {
+		t.Parallel()
+		got := UpsertHermesEngramBlock("", "/usr/local/bin/engram")
+		if !strings.Contains(got, "    command: /usr/local/bin/engram\n") {
+			t.Fatalf("missing custom command; got:\n%s", got)
+		}
+	})
+
+	t.Run("idempotent", func(t *testing.T) {
+		t.Parallel()
+		first := UpsertHermesEngramBlock("", "engram")
+		second := UpsertHermesEngramBlock(first, "engram")
+		if first != second {
+			t.Fatalf("not idempotent:\nfirst:\n%s\nsecond:\n%s", first, second)
+		}
+		if strings.Count(second, "  engram:\n") != 1 {
+			t.Fatalf("expected exactly 1 engram block; got:\n%s", second)
+		}
+	})
+}
+
+// ─── ReadYAMLMCPServerCommand ─────────────────────────────────────────────────
+
+// TestReadYAMLMCPServerCommand covers T-04: all recovery shapes.
+func TestReadYAMLMCPServerCommand(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		content  string
+		serverID string
+		wantCmd  string
+		wantOK   bool
+	}{
+		{
+			// scalar command: command: engram → ("engram", true)
+			name: "scalar_command",
+			content: `mcp_servers:
+  engram:
+    command: engram
+    args:
+      - mcp
+      - --tools=agent
+`,
+			serverID: "engram",
+			wantCmd:  "engram",
+			wantOK:   true,
+		},
+		{
+			// list command: command:\n  - /path/engram items → first element ("/path/engram", true)
+			name: "list_command_first_element",
+			content: `mcp_servers:
+  engram:
+    command:
+      - /path/to/engram
+      - mcp
+      - --tools=agent
+`,
+			serverID: "engram",
+			wantCmd:  "/path/to/engram",
+			wantOK:   true,
+		},
+		{
+			// server absent under mcp_servers: → ("", false)
+			name: "server_absent_under_mcp_servers",
+			content: `mcp_servers:
+  context7:
+    command: npx
+`,
+			serverID: "engram",
+			wantCmd:  "",
+			wantOK:   false,
+		},
+		{
+			// mcp_servers: key absent entirely → ("", false)
+			name: "mcp_servers_key_absent",
+			content: `model: gpt-4o
+temperature: 0.7
+`,
+			serverID: "engram",
+			wantCmd:  "",
+			wantOK:   false,
+		},
+		{
+			// comment lines inside/around block ignored without breaking recovery
+			name: "comment_lines_ignored",
+			content: `# top comment
+mcp_servers:
+  # comment about servers
+  engram:
+    # comment inside server
+    command: engram
+    args:
+      - mcp
+`,
+			serverID: "engram",
+			wantCmd:  "engram",
+			wantOK:   true,
+		},
+		{
+			// absolute path command preserved
+			name: "absolute_path_command",
+			content: `mcp_servers:
+  engram:
+    command: /custom/path/engram
+`,
+			serverID: "engram",
+			wantCmd:  "/custom/path/engram",
+			wantOK:   true,
+		},
+		{
+			// empty content → ("", false)
+			name:     "empty_content",
+			content:  "",
+			serverID: "engram",
+			wantCmd:  "",
+			wantOK:   false,
+		},
+		{
+			// versioned cellar path (ensure it is recoverable)
+			name: "versioned_cellar_path",
+			content: `mcp_servers:
+  engram:
+    command: /opt/homebrew/Cellar/engram/1.2.3/bin/engram
+`,
+			serverID: "engram",
+			wantCmd:  "/opt/homebrew/Cellar/engram/1.2.3/bin/engram",
+			wantOK:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			gotCmd, gotOK := ReadYAMLMCPServerCommand(tt.content, tt.serverID)
+			if gotCmd != tt.wantCmd {
+				t.Errorf("command: got %q, want %q", gotCmd, tt.wantCmd)
+			}
+			if gotOK != tt.wantOK {
+				t.Errorf("ok: got %v, want %v", gotOK, tt.wantOK)
+			}
+		})
+	}
+}

--- a/internal/components/filemerge/yaml_test.go
+++ b/internal/components/filemerge/yaml_test.go
@@ -402,6 +402,50 @@ mcp_servers:
 			wantCmd:  "/opt/homebrew/Cellar/engram/1.2.3/bin/engram",
 			wantOK:   true,
 		},
+		// FIX 1: double-quoted command value must be stripped of quotes
+		{
+			name: "double_quoted_command_stripped",
+			content: `mcp_servers:
+  engram:
+    command: "engram"
+`,
+			serverID: "engram",
+			wantCmd:  "engram",
+			wantOK:   true,
+		},
+		// FIX 1: single-quoted command value must be stripped of quotes
+		{
+			name: "single_quoted_command_stripped",
+			content: `mcp_servers:
+  engram:
+    command: 'engram'
+`,
+			serverID: "engram",
+			wantCmd:  "engram",
+			wantOK:   true,
+		},
+		// FIX 2: inline trailing comment must be stripped
+		{
+			name: "inline_trailing_comment_stripped",
+			content: `mcp_servers:
+  engram:
+    command: engram  # installed via brew
+`,
+			serverID: "engram",
+			wantCmd:  "engram",
+			wantOK:   true,
+		},
+		// FIX 1+2 combined: quoted value with hash inside must NOT be truncated
+		{
+			name: "quoted_value_with_hash_not_truncated",
+			content: `mcp_servers:
+  engram:
+    command: "engram#x"
+`,
+			serverID: "engram",
+			wantCmd:  "engram#x",
+			wantOK:   true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -416,5 +460,79 @@ mcp_servers:
 				t.Errorf("ok: got %v, want %v", gotOK, tt.wantOK)
 			}
 		})
+	}
+}
+
+// TestReadYAMLMCPServerCommandNitA covers NIT FIX A: a comment with no space after # must
+// be skipped when scanning for mcp_servers: (asymmetry fix at the top-level scanner).
+func TestReadYAMLMCPServerCommandNitA(t *testing.T) {
+	t.Parallel()
+
+	content := "#nospacecomment\nmcp_servers:\n  engram:\n    command: engram\n"
+	got, ok := ReadYAMLMCPServerCommand(content, "engram")
+	if !ok {
+		t.Fatalf("expected ok=true, got false; result %q", got)
+	}
+	if got != "engram" {
+		t.Errorf("command: got %q, want %q", got, "engram")
+	}
+}
+
+// TestUpsertYAMLMCPServerBlockInlineMCPServers covers FIX 3: when mcp_servers: has an
+// inline value (e.g. "mcp_servers: {}"), the function must NOT produce a duplicate
+// top-level mcp_servers: key. Output must contain exactly one mcp_servers: key,
+// valid nested engram block, and preserve other top-level keys.
+func TestUpsertYAMLMCPServerBlockInlineMCPServers(t *testing.T) {
+	t.Parallel()
+
+	input := "mcp_servers: {}\nmodel: gpt-4o\n"
+	got := UpsertYAMLMCPServerBlock(input, "engram", "engram", []string{"mcp", "--tools=agent"}, nil)
+
+	// Must contain exactly one top-level mcp_servers: key.
+	count := strings.Count(got, "\nmcp_servers:")
+	// Account for the case where mcp_servers: is at the very beginning of the string.
+	if strings.HasPrefix(got, "mcp_servers:") {
+		count++
+	}
+	if count != 1 {
+		t.Errorf("expected exactly 1 top-level mcp_servers: key, got %d in:\n%s", count, got)
+	}
+
+	// Must contain valid nested engram block.
+	if !strings.Contains(got, "  engram:\n") {
+		t.Errorf("missing nested engram block in:\n%s", got)
+	}
+	if !strings.Contains(got, "    command: engram\n") {
+		t.Errorf("missing command: engram in:\n%s", got)
+	}
+
+	// model: gpt-4o must be preserved.
+	if !strings.Contains(got, "model: gpt-4o") {
+		t.Errorf("model: gpt-4o not preserved in:\n%s", got)
+	}
+}
+
+// TestBuildServerBlockEnvOrdering covers COVERAGE: two+ env keys appear in
+// lexicographic order, pinning the existing sort.Strings guarantee.
+func TestBuildServerBlockEnvOrdering(t *testing.T) {
+	t.Parallel()
+
+	env := map[string]string{
+		"ZEBRA_KEY": "z",
+		"ALPHA_KEY": "a",
+		"MIDDLE":    "m",
+	}
+	got := UpsertYAMLMCPServerBlock("", "engram", "engram", nil, env)
+
+	alphaIdx := strings.Index(got, "ALPHA_KEY")
+	middleIdx := strings.Index(got, "MIDDLE")
+	zebraIdx := strings.Index(got, "ZEBRA_KEY")
+
+	if alphaIdx == -1 || middleIdx == -1 || zebraIdx == -1 {
+		t.Fatalf("one or more env keys missing in:\n%s", got)
+	}
+	if !(alphaIdx < middleIdx && middleIdx < zebraIdx) {
+		t.Errorf("env keys not in lexicographic order: ALPHA_KEY@%d MIDDLE@%d ZEBRA_KEY@%d\n%s",
+			alphaIdx, middleIdx, zebraIdx, got)
 	}
 }

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -18,6 +18,7 @@ const (
 	AgentOpenClaw      AgentID = "openclaw"
 	AgentPi            AgentID = "pi"
 	AgentTrae          AgentID = "trae-ide"
+	AgentHermes        AgentID = "hermes"
 )
 
 // SupportTier indicates how fully an agent supports the Gentleman AI ecosystem.
@@ -131,6 +132,9 @@ const (
 	StrategyMCPConfigFile
 	// StrategyTOMLFile writes MCP config to a TOML file (e.g., Codex ~/.codex/config.toml).
 	StrategyTOMLFile
+	// StrategyMergeIntoYAML merges MCP server blocks into a YAML config file using
+	// comment-preserving hand-rolled helpers (e.g., Hermes ~/.hermes/config.yaml).
+	StrategyMergeIntoYAML
 )
 
 type PresetID string


### PR DESCRIPTION
## Summary

PR 1 of 4 — **Foundation + YAML helpers**. Adds the model constants and the hand-rolled, comment-preserving YAML merge helpers that the rest of the chain builds on.

Closes #569

## Changes

- `internal/model/types.go`: `AgentHermes = "hermes"` + `StrategyMergeIntoYAML MCPStrategy = 4` (additive; no existing enum values changed).
- `internal/components/filemerge/yaml.go` (new): `UpsertYAMLMCPServerBlock`, `UpsertHermesEngramBlock`, `UpsertHermesContext7Block`, `ReadYAMLMCPServerCommand` — hand-rolled string scanning, **no `gopkg.in/yaml.v3`** (it destroys user comments on round-trip). Mirrors the existing `filemerge/toml.go` precedent.
- `internal/components/filemerge/yaml_test.go` (new): golden/table tests (insert, idempotency, comment preservation, 2-space indent, command recovery for scalar/list/quoted/commented/absent).

A fresh adversarial review of this slice found and fixed 3 real bugs (quoted-value stripping, inline-comment stripping, duplicate `mcp_servers:` key on inline value).

## Chain Context

| Field | Value |
|-------|-------|
| Chain | hermes-agent-support (feature-branch-chain) |
| Tracker PR | #774 |
| Position | 1 of 4 |
| Base | `feat/hermes-agent-support` (tracker) |
| Depends on | None |
| Follow-up | PR 2 — `...02-adapter-registration` |
| Review budget | 892 / 400 — `size:exception` (538 lines are tests) |
| Starts at | tracker branch |
| Ends with | YAML helpers + constants, fully unit-tested |

### Chain Overview

```text
main
 └── #774 tracker (draft)
      └── 📍 PR 1 ...01-yaml-helpers
           └── PR 2 ...02-adapter-registration
                └── PR 3 ...03-injectors
                     └── PR 4 ...04-tests-docs
```

### Scope
- Includes: model constants, YAML filemerge helpers + tests.
- Excludes: the adapter, registration, injectors, docs (later slices).

### Autonomy
- [x] CI is expected to pass for this PR branch
- [x] This PR has one deliverable scope
- [x] This PR can be rolled back without unrelated changes
- [x] Tests cover this unit
