### PR TITLE
feat(components): Hermes MCP/engram/sdd/persona injectors (3/4)

### DIFF
--- a/internal/components/engram/inject.go
+++ b/internal/components/engram/inject.go
@@ -358,6 +358,23 @@ func injectWithOptions(configHomeDir, promptDir string, adapter agents.Adapter, 
 			files = append(files, pluginFiles...)
 		}
 
+	case model.StrategyMergeIntoYAML:
+		// Hermes: upsert the engram MCP server block under mcp_servers: in
+		// ~/.hermes/config.yaml via the comment-preserving YAML string helpers.
+		configPath := adapter.MCPConfigPath(configHomeDir, "engram")
+		existing, readErr := readFileOrEmpty(configPath)
+		if readErr != nil {
+			return InjectionResult{}, readErr
+		}
+		engramCmd := stableEngramCommandForMergedConfig(configPath, adapter.Agent())
+		updated := filemerge.UpsertHermesEngramBlock(existing, engramCmd)
+		yamlWrite, writeErr := filemerge.WriteFileAtomic(configPath, []byte(updated), 0o644)
+		if writeErr != nil {
+			return InjectionResult{}, fmt.Errorf("write Hermes engram YAML %q: %w", configPath, writeErr)
+		}
+		changed = changed || yamlWrite.Changed
+		files = append(files, configPath)
+
 	case model.StrategyTOMLFile:
 		// Codex: upsert [mcp_servers.engram] block and instruction-file keys
 		// in ~/.codex/config.toml, then write instruction files.
@@ -644,6 +661,14 @@ func existingMergedEngramCommand(raw []byte, agentID model.AgentID) (string, boo
 		return "", false
 	}
 
+	// YAML recovery early branch: placed before MergeJSONObjects (which would
+	// fail on YAML input). ReadYAMLMCPServerCommand scans the YAML content for
+	// the named server's command — no external dependency, read-only. The
+	// branch generalizes to any future YAML-backed agent. (Decision 9)
+	if agentID == model.AgentHermes {
+		return filemerge.ReadYAMLMCPServerCommand(string(raw), "engram")
+	}
+
 	normalized, err := filemerge.MergeJSONObjects(raw, []byte("{}"))
 	if err != nil {
 		return "", false
@@ -717,7 +742,7 @@ func executableFromCommandValue(command any) (string, bool) {
 
 func isStandardAgent(id model.AgentID) bool {
 	switch id {
-	case model.AgentOpenCode, model.AgentQwenCode, model.AgentCodex, model.AgentGeminiCLI, model.AgentAntigravity, model.AgentClaudeCode, model.AgentOpenClaw:
+	case model.AgentOpenCode, model.AgentQwenCode, model.AgentCodex, model.AgentGeminiCLI, model.AgentAntigravity, model.AgentClaudeCode, model.AgentOpenClaw, model.AgentHermes:
 		return true
 	default:
 		return false

--- a/internal/components/engram/inject_test.go
+++ b/internal/components/engram/inject_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gentleman-programming/gentle-ai/internal/agents/claude"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/codex"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/gemini"
+	"github.com/gentleman-programming/gentle-ai/internal/agents/hermes"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/openclaw"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/opencode"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/pi"
@@ -24,6 +25,7 @@ func claudeAdapter() agents.Adapter   { return claude.NewAdapter() }
 func opencodeAdapter() agents.Adapter { return opencode.NewAdapter() }
 func codexAdapter() agents.Adapter    { return codex.NewAdapter() }
 func geminiAdapter() agents.Adapter   { return gemini.NewAdapter() }
+func hermesAdapter() agents.Adapter   { return hermes.NewAdapter() }
 func qwenAdapter() agents.Adapter     { return qwen.NewAdapter() }
 func openclawAdapter() agents.Adapter { return openclaw.NewAdapter() }
 func antigravityAdapter() agents.Adapter {
@@ -1781,4 +1783,169 @@ func objectAtForTest(t *testing.T, root map[string]any, key string) map[string]a
 		t.Fatalf("key %q has type %T, want object", key, value)
 	}
 	return object
+}
+
+// TestInjectEngramHermesYAMLOverlay verifies that Inject writes the engram MCP
+// server block under mcp_servers: in ~/.hermes/config.yaml (StrategyMergeIntoYAML),
+// and that a second call is idempotent (Changed=false).
+func TestInjectEngramHermesYAMLOverlay(t *testing.T) {
+	home := t.TempDir()
+	SetLookPathForTest(t, "engram", "")
+
+	result, err := Inject(home, hermesAdapter())
+	if err != nil {
+		t.Fatalf("Inject(hermes) error = %v", err)
+	}
+	if !result.Changed {
+		t.Fatal("Inject(hermes) first run: changed = false, want true")
+	}
+
+	configPath := filepath.Join(home, ".hermes", "config.yaml")
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("ReadFile(config.yaml) error = %v", err)
+	}
+	text := string(content)
+
+	if !strings.Contains(text, "mcp_servers:") {
+		t.Fatal("config.yaml missing mcp_servers: key")
+	}
+	if !strings.Contains(text, "  engram:") {
+		t.Fatal("config.yaml missing engram: entry under mcp_servers:")
+	}
+	if !strings.Contains(text, "--tools=agent") {
+		t.Fatal("config.yaml missing --tools=agent in engram args")
+	}
+
+	// Second call must be idempotent.
+	second, err := Inject(home, hermesAdapter())
+	if err != nil {
+		t.Fatalf("Inject(hermes) second error = %v", err)
+	}
+	if second.Changed {
+		t.Fatal("Inject(hermes) second run changed = true (not idempotent)")
+	}
+}
+
+// TestEngramYAMLCommandRecoveryCustomPath verifies that a custom absolute
+// engram command already in config.yaml is preserved (not clobbered) on re-run.
+func TestEngramYAMLCommandRecoveryCustomPath(t *testing.T) {
+	home := t.TempDir()
+	SetLookPathForTest(t, "engram", "")
+
+	configPath := filepath.Join(home, ".hermes", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	// Write a config.yaml with a custom absolute engram command.
+	prior := "mcp_servers:\n  engram:\n    command: /custom/path/engram\n    args:\n      - mcp\n      - --tools=agent\n"
+	if err := os.WriteFile(configPath, []byte(prior), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	_, err := Inject(home, hermesAdapter())
+	if err != nil {
+		t.Fatalf("Inject(hermes) error = %v", err)
+	}
+
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	text := string(content)
+	if !strings.Contains(text, "/custom/path/engram") {
+		t.Fatalf("config.yaml clobbered custom engram command; got:\n%s", text)
+	}
+}
+
+// TestEngramYAMLCommandRecoveryVersionedCellar verifies that a versioned Homebrew
+// cellar path is stabilized to the bare "engram" command on re-run.
+func TestEngramYAMLCommandRecoveryVersionedCellar(t *testing.T) {
+	home := t.TempDir()
+	SetLookPathForTest(t, "engram", "")
+
+	configPath := filepath.Join(home, ".hermes", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	// Write a config.yaml with a versioned Cellar engram path.
+	prior := "mcp_servers:\n  engram:\n    command: /opt/homebrew/Cellar/engram/1.2.3/bin/engram\n    args:\n      - mcp\n      - --tools=agent\n"
+	if err := os.WriteFile(configPath, []byte(prior), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	_, err := Inject(home, hermesAdapter())
+	if err != nil {
+		t.Fatalf("Inject(hermes) error = %v", err)
+	}
+
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	text := string(content)
+	// Versioned cellar path must be stabilized — the versioned path should not remain.
+	if strings.Contains(text, "/Cellar/engram/") {
+		t.Fatalf("config.yaml retained versioned Cellar path after stabilization; got:\n%s", text)
+	}
+}
+
+// TestEngramYAMLCommandRecoveryAbsent verifies that when no prior engram entry
+// exists in config.yaml, the stable "engram" fallback is written.
+func TestEngramYAMLCommandRecoveryAbsent(t *testing.T) {
+	home := t.TempDir()
+	SetLookPathForTest(t, "engram", "")
+
+	result, err := Inject(home, hermesAdapter())
+	if err != nil {
+		t.Fatalf("Inject(hermes) error = %v", err)
+	}
+	if !result.Changed {
+		t.Fatal("Inject(hermes) changed = false")
+	}
+
+	configPath := filepath.Join(home, ".hermes", "config.yaml")
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	text := string(content)
+	if !strings.Contains(text, "command: engram") {
+		t.Fatalf("expected 'command: engram' fallback when no prior entry; got:\n%s", text)
+	}
+}
+
+// TestEngramYAMLCommandRecoveryListShape verifies that a YAML list-shaped command
+// (command: - /path/engram) has its first element recovered correctly.
+func TestEngramYAMLCommandRecoveryListShape(t *testing.T) {
+	home := t.TempDir()
+	SetLookPathForTest(t, "engram", "")
+
+	configPath := filepath.Join(home, ".hermes", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	// Write a config.yaml with command as a YAML list.
+	prior := "mcp_servers:\n  engram:\n    command:\n      - /absolute/path/engram\n    args:\n      - mcp\n      - --tools=agent\n"
+	if err := os.WriteFile(configPath, []byte(prior), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	_, err := Inject(home, hermesAdapter())
+	if err != nil {
+		t.Fatalf("Inject(hermes) error = %v", err)
+	}
+
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	text := string(content)
+	// The list first element (/absolute/path/engram) should be recovered and preserved.
+	if !strings.Contains(text, "/absolute/path/engram") {
+		t.Fatalf("list-shaped command first element not recovered; got:\n%s", text)
+	}
 }

--- a/internal/components/mcp/inject.go
+++ b/internal/components/mcp/inject.go
@@ -30,6 +30,8 @@ func Inject(homeDir string, adapter agents.Adapter) (InjectionResult, error) {
 		return injectMCPConfigFile(homeDir, adapter)
 	case model.StrategyTOMLFile:
 		return injectTOMLFile(homeDir, adapter)
+	case model.StrategyMergeIntoYAML:
+		return injectYAMLFile(homeDir, adapter)
 	default:
 		return InjectionResult{}, fmt.Errorf("mcp injector does not support MCP strategy %d for agent %q", adapter.MCPStrategy(), adapter.Agent())
 	}
@@ -57,6 +59,29 @@ func injectTOMLFile(homeDir string, adapter agents.Adapter) (InjectionResult, er
 	writeResult, err := filemerge.WriteFileAtomic(configPath, []byte(updated), 0o644)
 	if err != nil {
 		return InjectionResult{}, fmt.Errorf("write TOML config %q: %w", configPath, err)
+	}
+
+	return InjectionResult{Changed: writeResult.Changed, Files: []string{configPath}}, nil
+}
+
+// injectYAMLFile upserts the context7 MCP server block into a YAML-based agent
+// config file (e.g. ~/.hermes/config.yaml) via the filemerge YAML helpers.
+// The file is created if it does not yet exist. The upsert is idempotent and
+// comment-preserving — user content outside the managed block is untouched.
+func injectYAMLFile(homeDir string, adapter agents.Adapter) (InjectionResult, error) {
+	configPath := adapter.MCPConfigPath(homeDir, "context7")
+
+	existingBytes, err := osReadFile(configPath)
+	if err != nil {
+		return InjectionResult{}, fmt.Errorf("read YAML config %q: %w", configPath, err)
+	}
+
+	existing := string(existingBytes)
+	updated := filemerge.UpsertHermesContext7Block(existing)
+
+	writeResult, err := filemerge.WriteFileAtomic(configPath, []byte(updated), 0o644)
+	if err != nil {
+		return InjectionResult{}, fmt.Errorf("write YAML config %q: %w", configPath, err)
 	}
 
 	return InjectionResult{Changed: writeResult.Changed, Files: []string{configPath}}, nil

--- a/internal/components/mcp/inject_test.go
+++ b/internal/components/mcp/inject_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gentleman-programming/gentle-ai/internal/agents/antigravity"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/claude"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/codex"
+	"github.com/gentleman-programming/gentle-ai/internal/agents/hermes"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/kilocode"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/kimi"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/openclaw"
@@ -29,6 +30,7 @@ func cursorAdapter(t *testing.T) agents.Adapter {
 
 func antigravityAdapter() agents.Adapter { return antigravity.NewAdapter() }
 func claudeAdapter() agents.Adapter      { return claude.NewAdapter() }
+func hermesAdapter() agents.Adapter      { return hermes.NewAdapter() }
 func kilocodeAdapter() agents.Adapter    { return kilocode.NewAdapter() }
 func kimiAdapter() agents.Adapter        { return kimi.NewAdapter() }
 func openclawAdapter() agents.Adapter    { return openclaw.NewAdapter() }
@@ -812,4 +814,88 @@ func TestInjectKimiReplacesLegacyContext7LocalConfig(t *testing.T) {
 	}
 
 	assertKimiContext7Schema(t, configPath)
+}
+
+// TestInjectHermesContext7IntoYAML verifies that Inject(hermes) writes context7
+// under mcp_servers: in ~/.hermes/config.yaml (StrategyMergeIntoYAML).
+func TestInjectHermesContext7IntoYAML(t *testing.T) {
+	home := t.TempDir()
+
+	result, err := Inject(home, hermesAdapter())
+	if err != nil {
+		t.Fatalf("Inject(hermes) error = %v", err)
+	}
+	if !result.Changed {
+		t.Fatal("Inject(hermes) changed = false")
+	}
+
+	configPath := filepath.Join(home, ".hermes", "config.yaml")
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("ReadFile(config.yaml) error = %v", err)
+	}
+	text := string(content)
+
+	if !strings.Contains(text, "mcp_servers:") {
+		t.Fatal("config.yaml missing mcp_servers: key")
+	}
+	if !strings.Contains(text, "context7:") {
+		t.Fatal("config.yaml missing context7: entry under mcp_servers:")
+	}
+	if !strings.Contains(text, "context7-mcp") {
+		t.Fatal("config.yaml missing context7-mcp in args")
+	}
+	if result.Files[0] != configPath {
+		t.Fatalf("result.Files[0] = %q, want %q", result.Files[0], configPath)
+	}
+}
+
+// TestInjectHermesContext7Idempotent verifies calling Inject twice yields exactly
+// one context7: entry (idempotent upsert), and Changed=false on the second call.
+func TestInjectHermesContext7Idempotent(t *testing.T) {
+	home := t.TempDir()
+
+	first, err := Inject(home, hermesAdapter())
+	if err != nil {
+		t.Fatalf("Inject(hermes) first error = %v", err)
+	}
+	if !first.Changed {
+		t.Fatal("Inject(hermes) first changed = false")
+	}
+
+	second, err := Inject(home, hermesAdapter())
+	if err != nil {
+		t.Fatalf("Inject(hermes) second error = %v", err)
+	}
+	if second.Changed {
+		t.Fatal("Inject(hermes) second changed = true (not idempotent)")
+	}
+
+	configPath := filepath.Join(home, ".hermes", "config.yaml")
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("ReadFile(config.yaml) error = %v", err)
+	}
+	text := string(content)
+
+	// Exactly one context7: entry should be present.
+	count := strings.Count(text, "  context7:")
+	if count != 1 {
+		t.Fatalf("config.yaml has %d context7: entries, want 1:\n%s", count, text)
+	}
+}
+
+// TestInjectHermesStrategyMergeIntoYAMLDispatches verifies that StrategyMergeIntoYAML
+// no longer hits the hard-error default case in the strategy switch.
+func TestInjectHermesStrategyMergeIntoYAMLDispatches(t *testing.T) {
+	home := t.TempDir()
+
+	// Confirm no error is returned (the old code returned an error for strategy 4).
+	result, err := Inject(home, hermesAdapter())
+	if err != nil {
+		t.Fatalf("Inject(hermes) with StrategyMergeIntoYAML returned error = %v (expected nil)", err)
+	}
+	if !result.Changed {
+		t.Fatal("Inject(hermes) Changed = false, want true on first run")
+	}
 }

--- a/internal/components/permissions/inject.go
+++ b/internal/components/permissions/inject.go
@@ -127,6 +127,9 @@ func agentOverlay(id model.AgentID) []byte {
 	case model.AgentCodex:
 		// Codex has no known settings.json path; permissions are skipped.
 		return nil
+	case model.AgentHermes:
+		// Hermes permission format is undocumented — no overlay is injected (§14).
+		return nil
 	default:
 		return nil
 	}

--- a/internal/components/permissions/inject_test.go
+++ b/internal/components/permissions/inject_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gentleman-programming/gentle-ai/internal/agents/codex"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/cursor"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/gemini"
+	"github.com/gentleman-programming/gentle-ai/internal/agents/hermes"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/opencode"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/vscode"
 	"github.com/gentleman-programming/gentle-ai/internal/model"
@@ -26,6 +27,30 @@ func cursorAdapter() agents.Adapter      { return cursor.NewAdapter() }
 func vscodeAdapter() agents.Adapter      { return vscode.NewAdapter() }
 func codexAdapter() agents.Adapter       { return codex.NewAdapter() }
 func antigravityAdapter() agents.Adapter { return antigravity.NewAdapter() }
+func hermesAdapter() agents.Adapter      { return hermes.NewAdapter() }
+
+// TestInjectHermesSkipsPermissions verifies that Hermes returns nil (no file written)
+// because Hermes permission format is undocumented — §14 of spec.
+func TestInjectHermesSkipsPermissions(t *testing.T) {
+	home := t.TempDir()
+
+	result, err := Inject(home, hermesAdapter())
+	if err != nil {
+		t.Fatalf("Inject(hermes) error = %v", err)
+	}
+	if result.Changed {
+		t.Fatal("Inject(hermes) changed = true, want false (no file should be written)")
+	}
+	if len(result.Files) != 0 {
+		t.Fatalf("Inject(hermes) files = %v, want [] (no file should be written)", result.Files)
+	}
+
+	// Confirm no config.yaml or settings file was created.
+	hermesDir := filepath.Join(home, ".hermes")
+	if _, err := os.Stat(hermesDir); err == nil {
+		t.Fatal("Inject(hermes) created ~/.hermes directory, want no files written")
+	}
+}
 
 func TestInjectOpenCodeIsIdempotent(t *testing.T) {
 	home := t.TempDir()

--- a/internal/components/persona/inject.go
+++ b/internal/components/persona/inject.go
@@ -459,7 +459,15 @@ func isGentlemanConversationPersona(persona model.PersonaID) bool {
 func personaContent(agent model.AgentID, persona model.PersonaID) string {
 	switch persona {
 	case model.PersonaNeutral:
-		return assets.MustRead("generic/persona-neutral.md")
+		// Per-agent neutral selection: Hermes uses its own neutral asset with
+		// the skill-loading block rewritten for ~/.hermes/skills/ (Decision 5).
+		// All other agents receive the byte-identical generic/persona-neutral.md.
+		switch agent {
+		case model.AgentHermes:
+			return assets.MustRead("hermes/persona-neutral.md")
+		default:
+			return assets.MustRead("generic/persona-neutral.md")
+		}
 	case model.PersonaCustom:
 		return ""
 	default:
@@ -475,6 +483,8 @@ func personaContent(agent model.AgentID, persona model.PersonaID) string {
 			// Kiro uses a steering-file based persona. The asset is identical to
 			// generic today but kept separate so it can diverge independently.
 			return assets.MustRead("kiro/persona-gentleman.md")
+		case model.AgentHermes:
+			return assets.MustRead("hermes/persona-gentleman.md")
 		default:
 			// Generic persona includes Gentleman personality + skills table + SDD orchestrator.
 			// Used by Gemini CLI, Cursor, VS Code Copilot, and any future agents.

--- a/internal/components/persona/inject_test.go
+++ b/internal/components/persona/inject_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gentleman-programming/gentle-ai/internal/agents"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/antigravity"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/claude"
+	"github.com/gentleman-programming/gentle-ai/internal/agents/hermes"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/kilocode"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/kimi"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/openclaw"
@@ -20,6 +21,7 @@ import (
 
 func antigravityAdapter() agents.Adapter { return antigravity.NewAdapter() }
 func claudeAdapter() agents.Adapter      { return claude.NewAdapter() }
+func hermesAdapter() agents.Adapter      { return hermes.NewAdapter() }
 func kimiAdapter() agents.Adapter        { return kimi.NewAdapter() }
 func kilocodeAdapter() agents.Adapter    { return kilocode.NewAdapter() }
 func openclawAdapter() agents.Adapter    { return openclaw.NewAdapter() }
@@ -1799,5 +1801,168 @@ func TestInjectForSync_ClaudeGentlemanToNeutral_CleansOutputStyle(t *testing.T) 
 	}
 	if strings.Contains(string(afterRaw), `"outputStyle"`) {
 		t.Fatal("settings.json still has outputStyle key after InjectForSync(neutral) — residue not cleaned")
+	}
+}
+
+// --- Hermes persona tests (T-29, T-30) ---
+
+// availableSkillsIsAuthoritative is the pattern from the generic persona assets
+// that must NOT appear in Hermes personas (Hermes uses ~/.hermes/skills/ natively,
+// not the Claude-style <available_skills> injection mechanism).
+const availableSkillsIsAuthoritative = "block in your system prompt is authoritative"
+
+// TestPersonaContentHermesGentleman verifies that personaContent returns the
+// Hermes-specific gentleman asset with the skill-loading block rewritten for
+// Hermes's native skill model (no <available_skills> injection mechanism).
+func TestPersonaContentHermesGentleman(t *testing.T) {
+	tests := []struct {
+		name    string
+		persona model.PersonaID
+	}{
+		{"gentleman", model.PersonaGentleman},
+		{"gentleman-neutral-artifacts", model.PersonaGentlemanNeutralArtifacts},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			content := personaContent(model.AgentHermes, tt.persona)
+			if content == "" {
+				t.Fatal("personaContent(hermes, gentleman) returned empty string")
+			}
+			// The generic <available_skills> "is authoritative" block must be absent.
+			if strings.Contains(content, availableSkillsIsAuthoritative) {
+				t.Fatal("hermes gentleman persona still has the generic <available_skills> instruction — skill-loading block not rewritten")
+			}
+			// Should reference ~/.hermes/skills/ (Hermes-native skill loading).
+			if !strings.Contains(content, "~/.hermes/skills/") {
+				t.Fatal("hermes gentleman persona missing ~/.hermes/skills/ reference")
+			}
+			// Must be distinct from generic asset.
+			generic := assets.MustRead("generic/persona-gentleman.md")
+			if content == generic {
+				t.Fatal("hermes gentleman persona is byte-identical to generic — Hermes-specific asset not used")
+			}
+		})
+	}
+}
+
+// TestPersonaContentHermesNeutral verifies that personaContent returns the
+// Hermes-specific neutral asset with the skill-loading block rewritten for
+// Hermes's native skill model.
+func TestPersonaContentHermesNeutral(t *testing.T) {
+	content := personaContent(model.AgentHermes, model.PersonaNeutral)
+	if content == "" {
+		t.Fatal("personaContent(hermes, neutral) returned empty string")
+	}
+	// The generic <available_skills> "is authoritative" block must be absent.
+	if strings.Contains(content, availableSkillsIsAuthoritative) {
+		t.Fatal("hermes neutral persona still has the generic <available_skills> instruction — skill-loading block not rewritten")
+	}
+	if !strings.Contains(content, "~/.hermes/skills/") {
+		t.Fatal("hermes neutral persona missing ~/.hermes/skills/ reference")
+	}
+	// Must be distinct from generic neutral.
+	generic := assets.MustRead("generic/persona-neutral.md")
+	if content == generic {
+		t.Fatal("hermes neutral persona is byte-identical to generic — Hermes-specific asset not used")
+	}
+}
+
+// TestPersonaContentHermesCustom verifies that PersonaCustom returns empty string
+// for Hermes (no persona injected — user keeps their own config).
+func TestPersonaContentHermesCustom(t *testing.T) {
+	content := personaContent(model.AgentHermes, model.PersonaCustom)
+	if content != "" {
+		t.Fatalf("personaContent(hermes, custom) = %q, want empty string", content)
+	}
+}
+
+// TestPersonaContentNonHermesNeutralUnchanged is a regression test verifying that
+// non-Hermes agents still receive the byte-identical generic/persona-neutral.md
+// when PersonaNeutral is selected. This ensures the refactor is additive-only.
+func TestPersonaContentNonHermesNeutralUnchanged(t *testing.T) {
+	genericNeutral := assets.MustRead("generic/persona-neutral.md")
+	if genericNeutral == "" {
+		t.Fatal("generic/persona-neutral.md asset is empty")
+	}
+
+	agents := []model.AgentID{
+		model.AgentClaudeCode,
+		model.AgentOpenCode,
+		model.AgentGeminiCLI,
+		model.AgentCursor,
+		model.AgentCodex,
+	}
+	for _, agent := range agents {
+		t.Run(string(agent), func(t *testing.T) {
+			got := personaContent(agent, model.PersonaNeutral)
+			if got != genericNeutral {
+				t.Fatalf("personaContent(%q, neutral) is no longer byte-identical to generic/persona-neutral.md — regression", agent)
+			}
+		})
+	}
+}
+
+// TestInjectHermesGentlemanWritesSOULMD verifies that Inject writes the Hermes
+// gentleman persona into ~/.hermes/SOUL.md with <!-- gentle-ai:persona --> markers.
+func TestInjectHermesGentlemanWritesSOULMD(t *testing.T) {
+	home := t.TempDir()
+	adapter := hermesAdapter()
+
+	result, err := Inject(home, adapter, model.PersonaGentleman)
+	if err != nil {
+		t.Fatalf("Inject(hermes, gentleman) error = %v", err)
+	}
+	if !result.Changed {
+		t.Fatal("Inject(hermes, gentleman) changed = false")
+	}
+
+	soulPath := filepath.Join(home, ".hermes", "SOUL.md")
+	content, err := os.ReadFile(soulPath)
+	if err != nil {
+		t.Fatalf("ReadFile(SOUL.md) error = %v", err)
+	}
+	text := string(content)
+
+	if !strings.Contains(text, "<!-- gentle-ai:persona -->") {
+		t.Fatal("SOUL.md missing <!-- gentle-ai:persona --> open marker")
+	}
+	if !strings.Contains(text, "<!-- /gentle-ai:persona -->") {
+		t.Fatal("SOUL.md missing <!-- /gentle-ai:persona --> close marker")
+	}
+	if strings.Contains(text, availableSkillsIsAuthoritative) {
+		t.Fatal("SOUL.md contains the generic <available_skills> instruction — Hermes-specific asset not used")
+	}
+	if !strings.Contains(text, "~/.hermes/skills/") {
+		t.Fatal("SOUL.md missing ~/.hermes/skills/ reference")
+	}
+}
+
+// TestInjectHermesNeutralWritesSOULMD verifies that neutral persona injection into
+// SOUL.md uses the Hermes-specific neutral asset, not the generic one.
+func TestInjectHermesNeutralWritesSOULMD(t *testing.T) {
+	home := t.TempDir()
+	adapter := hermesAdapter()
+
+	result, err := Inject(home, adapter, model.PersonaNeutral)
+	if err != nil {
+		t.Fatalf("Inject(hermes, neutral) error = %v", err)
+	}
+	if !result.Changed {
+		t.Fatal("Inject(hermes, neutral) changed = false")
+	}
+
+	soulPath := filepath.Join(home, ".hermes", "SOUL.md")
+	content, err := os.ReadFile(soulPath)
+	if err != nil {
+		t.Fatalf("ReadFile(SOUL.md) error = %v", err)
+	}
+	text := string(content)
+
+	if !strings.Contains(text, "<!-- gentle-ai:persona -->") {
+		t.Fatal("SOUL.md missing <!-- gentle-ai:persona --> open marker")
+	}
+	if strings.Contains(text, availableSkillsIsAuthoritative) {
+		t.Fatal("SOUL.md contains the generic <available_skills> instruction — generic neutral used instead of Hermes-specific")
 	}
 }

--- a/internal/components/sdd/inject.go
+++ b/internal/components/sdd/inject.go
@@ -1626,6 +1626,8 @@ func sddOrchestratorAsset(agent model.AgentID) string {
 		return "qwen/sdd-orchestrator.md"
 	case model.AgentKiroIDE:
 		return "kiro/sdd-orchestrator.md"
+	case model.AgentHermes:
+		return "hermes/sdd-orchestrator.md"
 	case model.AgentOpenCode, model.AgentKilocode:
 		return "opencode/sdd-orchestrator.md"
 	default:

--- a/internal/components/sdd/inject_test.go
+++ b/internal/components/sdd/inject_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/gentleman-programming/gentle-ai/internal/agents"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/claude"
+	"github.com/gentleman-programming/gentle-ai/internal/agents/hermes"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/kilocode"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/kimi"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/openclaw"
@@ -23,6 +24,7 @@ import (
 )
 
 func claudeAdapter() agents.Adapter   { return claude.NewAdapter() }
+func hermesAdapter() agents.Adapter   { return hermes.NewAdapter() }
 func kilocodeAdapter() agents.Adapter { return kilocode.NewAdapter() }
 func kimiAdapter() agents.Adapter     { return kimi.NewAdapter() }
 func openclawAdapter() agents.Adapter { return openclaw.NewAdapter() }
@@ -58,6 +60,7 @@ func TestSDDOrchestratorAssetSelectionCoversSupportedAgents(t *testing.T) {
 		{model.AgentOpenClaw, "generic/sdd-orchestrator.md"},
 		{model.AgentPi, "generic/sdd-orchestrator.md"},
 		{model.AgentTrae, "generic/sdd-orchestrator.md"},
+		{model.AgentHermes, "hermes/sdd-orchestrator.md"},
 	}
 
 	for _, tc := range tests {
@@ -66,6 +69,85 @@ func TestSDDOrchestratorAssetSelectionCoversSupportedAgents(t *testing.T) {
 				t.Fatalf("sddOrchestratorAsset(%q) = %q, want %q", tc.agent, got, tc.want)
 			}
 		})
+	}
+}
+
+// TestInjectHermesWritesSDDOrchestratorToSOULMD verifies that sdd.Inject writes
+// the Hermes-specific SDD orchestrator content into ~/.hermes/SOUL.md via
+// StrategyMarkdownSections markers. Content is preserved across re-runs.
+func TestInjectHermesWritesSDDOrchestratorToSOULMD(t *testing.T) {
+	home := t.TempDir()
+	mockNoPackageManager(t)
+
+	adapter := hermesAdapter()
+
+	result, err := Inject(home, adapter, "")
+	if err != nil {
+		t.Fatalf("Inject(hermes) first error = %v", err)
+	}
+	if !result.Changed {
+		t.Fatal("Inject(hermes) first run: changed = false, want true")
+	}
+
+	soulPath := filepath.Join(home, ".hermes", "SOUL.md")
+	content, err := os.ReadFile(soulPath)
+	if err != nil {
+		t.Fatalf("ReadFile(SOUL.md) error = %v", err)
+	}
+	text := string(content)
+
+	if !strings.Contains(text, "<!-- gentle-ai:sdd-orchestrator -->") {
+		t.Fatal("SOUL.md missing <!-- gentle-ai:sdd-orchestrator --> open marker")
+	}
+	if !strings.Contains(text, "<!-- /gentle-ai:sdd-orchestrator -->") {
+		t.Fatal("SOUL.md missing <!-- /gentle-ai:sdd-orchestrator --> close marker")
+	}
+	// Verify the Hermes-specific content is present (references ~/.hermes/skills/).
+	if !strings.Contains(text, "~/.hermes/skills/") {
+		t.Fatal("SOUL.md missing ~/.hermes/skills/ reference — wrong orchestrator asset loaded")
+	}
+
+	// Add user content outside markers and verify it is preserved on re-run.
+	userContent := "\n\n# My custom Hermes rules\nAlways be concise.\n"
+	if err := os.WriteFile(soulPath, []byte(text+userContent), 0o644); err != nil {
+		t.Fatalf("WriteFile(SOUL.md user content) error = %v", err)
+	}
+
+	_, err = Inject(home, adapter, "")
+	if err != nil {
+		t.Fatalf("Inject(hermes) second error = %v", err)
+	}
+	afterContent, err := os.ReadFile(soulPath)
+	if err != nil {
+		t.Fatalf("ReadFile(SOUL.md) after second inject error = %v", err)
+	}
+	if !strings.Contains(string(afterContent), "My custom Hermes rules") {
+		t.Fatal("Inject(hermes) second run clobbered user content outside markers")
+	}
+}
+
+// TestInjectHermesSDDIdempotent verifies StrategyMergeIntoYAML (from MCPStrategy)
+// does not cause a panic or error, and repeated Inject calls converge to Changed=false.
+func TestInjectHermesSDDIdempotent(t *testing.T) {
+	home := t.TempDir()
+	mockNoPackageManager(t)
+
+	adapter := hermesAdapter()
+
+	first, err := Inject(home, adapter, "")
+	if err != nil {
+		t.Fatalf("Inject(hermes) first error = %v", err)
+	}
+	if !first.Changed {
+		t.Fatal("Inject(hermes) first changed = false")
+	}
+
+	second, err := Inject(home, adapter, "")
+	if err != nil {
+		t.Fatalf("Inject(hermes) second error = %v", err)
+	}
+	if second.Changed {
+		t.Fatal("Inject(hermes) second changed = true (not idempotent)")
 	}
 }
 


### PR DESCRIPTION
## Summary

PR 3 of 4 — **Component injectors**. Implements the `StrategyMergeIntoYAML` dispatch and the per-component Hermes behavior. After this slice, Hermes is **end-to-end functional**.

Closes #569

## Changes

- `mcp/inject.go`: `StrategyMergeIntoYAML` case → writes context7 into `~/.hermes/config.yaml` (idempotent, comment-preserving).
- `engram/inject.go`: YAML engram injection; `AgentHermes` in `isStandardAgent`; early YAML branch in `existingMergedEngramCommand` (Decision 9 — recovers a custom engram command from YAML instead of clobbering it).
- `sdd/inject.go`: `sddOrchestratorAsset(AgentHermes)` → `hermes/sdd-orchestrator.md`.
- `persona/inject.go`: Hermes gentleman asset + per-agent neutral refactor (byte-identical `generic/persona-neutral.md` for all non-Hermes agents — regression-tested).
- `permissions/inject.go`: Hermes → `nil` (no file).
- Tests beside each injector.

Fresh review: APPROVE — regression check and idempotency check both PASS; `isStandardAgent` addition has a single call site with no cross-agent effect.

## Chain Context

| Field | Value |
|-------|-------|
| Chain | hermes-agent-support (feature-branch-chain) |
| Tracker PR | #774 |
| Position | 3 of 4 |
| Base | `feat/hermes-agent-support-02-adapter-registration` |
| Depends on | PR 1 (YAML helpers), PR 2 (adapter) |
| Follow-up | PR 4 — `...04-tests-docs` |
| Review budget | 594 / 400 — `size:exception` (tests dominate) |
| Starts at | PR 2 |
| Ends with | Hermes fully wired end-to-end (MCP YAML + SOUL.md injection + persona + permissions) |

### Chain Overview

```text
main
 └── #774 tracker (draft)
      └── PR 1 ...01-yaml-helpers
           └── PR 2 ...02-adapter-registration
                └── 📍 PR 3 ...03-injectors
                     └── PR 4 ...04-tests-docs
```

### Scope
- Includes: mcp/engram/sdd/persona/permissions injector behavior for Hermes + tests.
- Excludes: skill registry, cross-cutting tests, docs (PR 4).

### Autonomy
- [x] CI is expected to pass for this PR branch
- [x] This PR has one deliverable scope
- [x] This PR can be rolled back without unrelated changes
- [x] Tests cover this unit
