### PR TITLE
feat(skillregistry,docs): Hermes skill registry + tests + docs (4/4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Gentle-AI is NOT an AI agent installer. Most agents are easy to install. It is a
 | **OpenClaw**        |            Solo-agent            | Workspace-first `AGENTS.md` / `SOUL.md` with global MCP config  |
 | **Trae**            |            Solo-agent            | Desktop app by ByteDance; `~/.trae/skills/` + OS-specific rules |
 | **Pi**              | Full (package-managed subagents) | `gentle-pi` harness with persona/model commands + Engram memory |
+| **Hermes**          |         Detect-only              | YAML MCP config, SOUL.md persona; install manually first        |
 
 > **Note**: This project supersedes [Agent Teams Lite](https://github.com/Gentleman-Programming/agent-teams-lite) (now archived). Everything ATL provided is included here with better installation, automatic updates, and persistent memory.
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -250,7 +250,7 @@ For the full Pi command and package reference, see [Pi Agent](pi.md).
 
 ### Hermes
 
-- **Detection**: gentle-ai detects Hermes from the `hermes` binary on `PATH` and its config root at `~/.hermes`. Both must be present for detection to succeed.
+- **Detection**: gentle-ai reports the `hermes` binary on `PATH` and the config root at `~/.hermes` independently; the config directory drives install detection (the binary can be absent and Hermes is still detected as configured).
 - **Install**: detect-only — gentle-ai cannot install Hermes. Install Hermes manually first, then run `gentle-ai install --agent hermes`.
 - **Config path**: `~/.hermes/` (config.yaml, SOUL.md, skills/)
 - **MCP config**: Engram and Context7 are injected as YAML blocks under `mcp_servers:` in `~/.hermes/config.yaml` (`StrategyMergeIntoYAML`). Pre-existing top-level keys (e.g. `model:`) are preserved verbatim.

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -23,6 +23,7 @@
 | OpenClaw        | `openclaw`       | Yes          | Yes | Solo-agent                       | No            | No             | `~/.openclaw`                       |
 | Trae            | `trae-ide`       | Yes          | Yes | Solo-agent                       | No            | No             | `~/.trae`                           |
 | Pi              | `pi`             | Yes          | Yes | Full (package-managed subagents) | No            | Yes            | `~/.pi`                             |
+| Hermes          | `hermes`         | Yes          | Yes | Detect-only (no auto-install)    | No            | No             | `~/.hermes`                         |
 
 Most agents receive the **full SDD orchestrator** policy, plus skill files written to their skills directory. Most receive it through their system prompt; OpenCode and Kilo Code receive it through the OpenCode-compatible `opencode.json` agent overlay. Pi is the exception: Gentle AI installs Pi packages, and `gentle-pi` owns Pi skills, prompts, SDD agents, and chains at runtime. The agent handles SDD automatically when the task is large enough, or when the user explicitly asks for it — no manual setup required.
 
@@ -36,6 +37,7 @@ Most agents receive the **full SDD orchestrator** policy, plus skill files writt
 | --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
 | **Full (sub-agents)** | Each SDD phase runs in an isolated context window via native sub-agent delegation, package-managed subagents, or an OpenCode-compatible overlay. The orchestrator coordinates; sub-agents execute. | Claude Code, OpenCode, Kilo Code, Gemini CLI, Cursor, VS Code Copilot, Kimi Code, Kiro IDE, Qwen Code, Pi |
 | **Solo-agent**        | All SDD phases run inline in the same conversation. The orchestrator IS the executor. Engram provides cross-phase persistence.                                                                     | Codex, Windsurf, Antigravity, OpenClaw, Trae                                                              |
+| **Detect-only**       | gentle-ai detects the agent and injects skills, MCP, and persona when the binary is present. Auto-install is not supported — the user installs the agent manually.                                | Hermes                                                                                                    |
 
 ### Cursor Native Subagents
 
@@ -70,11 +72,11 @@ Kiro uses native custom agents in `~/.kiro/agents/`. `gentle-ai` writes phase ag
 
 ## SDD Mode Support
 
-| Feature          | Claude Code | OpenCode | Kilo Code | Gemini CLI | Cursor | VS Code Copilot | Codex | Windsurf | Antigravity | Kiro IDE | Qwen Code | OpenClaw | Trae |   Pi    |
-| ---------------- | :---------: | :------: | :-------: | :--------: | :----: | :-------------: | :---: | :------: | :---------: | :------: | :-------: | :------: | :--: | :-----: |
-| SDD orchestrator |     Yes     |   Yes    |    Yes    |    Yes     |  Yes   |       Yes       |  Yes  |   Yes    |     Yes     |   Yes    |    Yes    |   Yes    | Yes  |   Yes   |
-| Single-mode SDD  |     Yes     |   Yes    |    Yes    |    Yes     |  Yes   |       Yes       |  Yes  |   Yes    |     Yes     |   Yes    |    Yes    |   Yes    | Yes  |   Yes   |
-| Multi-mode SDD   |      —      |   Yes    |    Yes    |     —      |   —    |        —        |   —   |    —     |      —      |  Yes\*   |     —     |    —     |  —   | Yes\*\* |
+| Feature          | Claude Code | OpenCode | Kilo Code | Gemini CLI | Cursor | VS Code Copilot | Codex | Windsurf | Antigravity | Kiro IDE | Qwen Code | OpenClaw | Trae |   Pi    | Hermes |
+| ---------------- | :---------: | :------: | :-------: | :--------: | :----: | :-------------: | :---: | :------: | :---------: | :------: | :-------: | :------: | :--: | :-----: | :----: |
+| SDD orchestrator |     Yes     |   Yes    |    Yes    |    Yes     |  Yes   |       Yes       |  Yes  |   Yes    |     Yes     |   Yes    |    Yes    |   Yes    | Yes  |   Yes   |  Yes   |
+| Single-mode SDD  |     Yes     |   Yes    |    Yes    |    Yes     |  Yes   |       Yes       |  Yes  |   Yes    |     Yes     |   Yes    |    Yes    |   Yes    | Yes  |   Yes   |  Yes   |
+| Multi-mode SDD   |      —      |   Yes    |    Yes    |     —      |   —    |        —        |   —   |    —     |      —      |  Yes\*   |     —     |    —     |  —   | Yes\*\* |   —    |
 
 **Multi-mode** (assigning different AI models to each SDD phase) is supported by **OpenCode** and **Kilo Code** through the OpenCode-compatible multi-mode overlay, and by **Kiro IDE** through native subagent `model:` frontmatter. All other agents run in **single-mode** — the orchestrator manages everything using whatever model the agent is already running.
 
@@ -245,3 +247,15 @@ For the full Pi command and package reference, see [Pi Agent](pi.md).
 - **`@juicesharp/rpiv-ask-user-question` package**: lets Pi child agents ask the active user session for clarification when they need human input.
 - **Pi companion packages**: `pi-web-access`, `pi-lens`, `@juicesharp/rpiv-todo`, and `pi-btw` add web access, context inspection, todo tracking, and companion workflow support.
 - **Pi-only flow**: when Pi is the only selected agent, gentle-ai skips persona, ecosystem component selection, and Strict TDD prompts because those behaviors are provided by `gentle-pi`.
+
+### Hermes
+
+- **Detection**: gentle-ai detects Hermes from the `hermes` binary on `PATH` and its config root at `~/.hermes`. Both must be present for detection to succeed.
+- **Install**: detect-only — gentle-ai cannot install Hermes. Install Hermes manually first, then run `gentle-ai install --agent hermes`.
+- **Config path**: `~/.hermes/` (config.yaml, SOUL.md, skills/)
+- **MCP config**: Engram and Context7 are injected as YAML blocks under `mcp_servers:` in `~/.hermes/config.yaml` (`StrategyMergeIntoYAML`). Pre-existing top-level keys (e.g. `model:`) are preserved verbatim.
+- **System prompt**: SDD orchestrator and persona are written to `~/.hermes/SOUL.md` via markdown section markers (`<!-- gentle-ai:sdd-orchestrator -->`, `<!-- gentle-ai:persona -->`).
+- **Skills**: `~/.hermes/skills/` — gentle-ai writes SDD phase skills; the skill registry also scans this path.
+- **Permissions**: Hermes uses an undocumented permission format. gentle-ai skips permission injection for Hermes.
+- **Profiles**: Hermes does not support multi-mode SDD (no per-phase model routing). Single-mode only.
+- **Memory**: Hermes has a native memory and skill-learning loop. Engram complements it — Engram provides cross-agent, cross-session memory protocol so knowledge is portable across all agents, not just Hermes.

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -47,3 +47,4 @@ Release artifacts are produced by CI, but Windows users should install through S
 | OpenClaw | `%USERPROFILE%\.openclaw\openclaw.json` (global MCP/settings) + active workspace from `agents.defaults.workspace` for `AGENTS.md` / `SOUL.md` / workspace-scoped SDD skills |
 | Trae | `%USERPROFILE%\.trae\` (skills) + `%APPDATA%\Trae\User\user_rules.md` (rules) + `%APPDATA%\Trae\User\mcp.json` (MCP) |
 | Pi | `%USERPROFILE%\.pi\` (Pi config, project agents/chains, Gentle AI support assets) |
+| Hermes | `%USERPROFILE%\.hermes\` (config.yaml, SOUL.md, skills/) |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -117,6 +117,8 @@ Sync is safe and idempotent — running it twice produces no changes the second 
 
 For OpenClaw, sync reads the active workspace from `~/.openclaw/openclaw.json` (`agents.defaults.workspace`). It writes `AGENTS.md` / `SOUL.md` into that workspace, while MCP servers stay in the global OpenClaw config under `mcp.servers`.
 
+For Hermes, gentle-ai is detect-only: it cannot install Hermes. Install Hermes manually first. When Hermes is detected (`hermes` binary on `PATH` and `~/.hermes` present), `gentle-ai install --agent hermes` injects context7 and Engram MCP blocks into `~/.hermes/config.yaml`, writes the SDD orchestrator and persona into `~/.hermes/SOUL.md`, and copies skills to `~/.hermes/skills/`.
+
 ### uninstall
 
 Remove only the `gentle-ai` managed configuration from one or more agents. This does not uninstall external packages or binaries — it removes managed prompt sections, MCP entries, skills/config fragments, and other managed files, then updates `state.json` accordingly.

--- a/internal/agents/registry_test.go
+++ b/internal/agents/registry_test.go
@@ -101,6 +101,7 @@ func TestDefaultRegistryIncludesAllAgents(t *testing.T) {
 		model.AgentAntigravity,
 		model.AgentWindsurf,
 		model.AgentQwenCode,
+		model.AgentHermes,
 	} {
 		if _, ok := registry.Get(agent); !ok {
 			t.Fatalf("registry missing %s adapter", agent)

--- a/internal/assets/assets_test.go
+++ b/internal/assets/assets_test.go
@@ -213,6 +213,11 @@ func TestAllEmbeddedAssetsAreReadable(t *testing.T) {
 		"skills/_shared/sdd-phase-common.md",
 		"skills/_shared/sdd-status-contract.md",
 
+		// Hermes agent files
+		"hermes/sdd-orchestrator.md",
+		"hermes/persona-gentleman.md",
+		"hermes/persona-neutral.md",
+
 		// Foundation skills
 		"skills/go-testing/SKILL.md",
 		"skills/go-testing/references/examples.md",

--- a/internal/assets/language_contract_test.go
+++ b/internal/assets/language_contract_test.go
@@ -67,6 +67,7 @@ func TestSupportedAgentSDDLanguageMatrix(t *testing.T) {
 		{agent: "openclaw", path: "generic/sdd-orchestrator.md"},
 		{agent: "pi", path: "generic/sdd-orchestrator.md"},
 		{agent: "trae-ide", path: "generic/sdd-orchestrator.md"},
+		{agent: "hermes", path: "hermes/sdd-orchestrator.md"},
 	}
 
 	for _, tc := range tests {

--- a/internal/components/engram/inject_test.go
+++ b/internal/components/engram/inject_test.go
@@ -1890,6 +1890,10 @@ func TestEngramYAMLCommandRecoveryVersionedCellar(t *testing.T) {
 	if strings.Contains(text, "/Cellar/engram/") {
 		t.Fatalf("config.yaml retained versioned Cellar path after stabilization; got:\n%s", text)
 	}
+	// And it must be stabilized to the bare "engram" command.
+	if !strings.Contains(text, "command: engram") {
+		t.Fatalf("config.yaml did not stabilize to bare \"engram\" command; got:\n%s", text)
+	}
 }
 
 // TestEngramYAMLCommandRecoveryAbsent verifies that when no prior engram entry

--- a/internal/components/mcp/inject_test.go
+++ b/internal/components/mcp/inject_test.go
@@ -899,3 +899,67 @@ func TestInjectHermesStrategyMergeIntoYAMLDispatches(t *testing.T) {
 		t.Fatal("Inject(hermes) Changed = false, want true on first run")
 	}
 }
+
+// TestInjectHermesPreservesExistingTopLevelKeys verifies that a full Inject
+// round-trip on a config.yaml that already contains an unrelated top-level key
+// (e.g. "model: claude") preserves that key after context7 injection.
+// This covers the review-flagged coverage gap: existing non-managed content
+// must survive the MCP upsert.
+func TestInjectHermesPreservesExistingTopLevelKeys(t *testing.T) {
+	home := t.TempDir()
+	hermesDir := filepath.Join(home, ".hermes")
+	if err := os.MkdirAll(hermesDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	// Pre-existing config.yaml with an unrelated top-level key.
+	initial := "model: claude\n"
+	configPath := filepath.Join(hermesDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte(initial), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	result, err := Inject(home, hermesAdapter())
+	if err != nil {
+		t.Fatalf("Inject(hermes) error = %v", err)
+	}
+	if !result.Changed {
+		t.Fatal("Inject(hermes) changed = false, want true on first run")
+	}
+
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("ReadFile(config.yaml) error = %v", err)
+	}
+	text := string(content)
+
+	// The pre-existing key must be preserved verbatim.
+	if !strings.Contains(text, "model: claude") {
+		t.Fatalf("config.yaml lost pre-existing top-level key 'model: claude':\n%s", text)
+	}
+	// The injected context7 entry must also be present.
+	if !strings.Contains(text, "mcp_servers:") {
+		t.Fatal("config.yaml missing mcp_servers: after injection")
+	}
+	if !strings.Contains(text, "context7:") {
+		t.Fatal("config.yaml missing context7: after injection")
+	}
+
+	// Second Inject must be idempotent and still preserve the original key.
+	second, err := Inject(home, hermesAdapter())
+	if err != nil {
+		t.Fatalf("Inject(hermes) second error = %v", err)
+	}
+	if second.Changed {
+		t.Fatal("Inject(hermes) second changed = true (not idempotent)")
+	}
+
+	content2, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("ReadFile(config.yaml) second error = %v", err)
+	}
+	text2 := string(content2)
+	if !strings.Contains(text2, "model: claude") {
+		t.Fatalf("config.yaml lost pre-existing key on second Inject:\n%s", text2)
+	}
+}

--- a/internal/skillregistry/registry.go
+++ b/internal/skillregistry/registry.go
@@ -70,6 +70,7 @@ func UserSkillDirs(home string) []string {
 		filepath.Join(home, ".qwen", "skills"),
 		filepath.Join(home, ".kiro", "skills"),
 		filepath.Join(home, ".openclaw", "skills"),
+		filepath.Join(home, ".hermes", "skills"),
 	}
 }
 
@@ -94,6 +95,7 @@ func ProjectSkillDirs(cwd string) []string {
 		filepath.Join(cwd, ".agent", "skills"),
 		filepath.Join(cwd, ".agents", "skills"),
 		filepath.Join(cwd, ".atl", "skills"),
+		filepath.Join(cwd, ".hermes", "skills"),
 	}
 }
 

--- a/internal/skillregistry/registry_test.go
+++ b/internal/skillregistry/registry_test.go
@@ -198,10 +198,29 @@ func TestUserSkillDirsIncludesSupportedAgentSkillLocations(t *testing.T) {
 		filepath.Join(home, ".openclaw", "skills"),
 		filepath.Join(home, ".pi", "agent", "skills"),
 		filepath.Join(home, ".agents", "skills"),
+		filepath.Join(home, ".hermes", "skills"),
 	} {
 		if !containsPath(dirs, want) {
 			t.Fatalf("UserSkillDirs() missing %q in %#v", want, dirs)
 		}
+	}
+}
+
+func TestUserSkillDirsIncludesHermesSkillLocation(t *testing.T) {
+	home := t.TempDir()
+	dirs := UserSkillDirs(home)
+	want := filepath.Join(home, ".hermes", "skills")
+	if !containsPath(dirs, want) {
+		t.Fatalf("UserSkillDirs() missing Hermes skill location %q", want)
+	}
+}
+
+func TestProjectSkillDirsIncludesHermesSkillLocation(t *testing.T) {
+	cwd := t.TempDir()
+	dirs := ProjectSkillDirs(cwd)
+	want := filepath.Join(cwd, ".hermes", "skills")
+	if !containsPath(dirs, want) {
+		t.Fatalf("ProjectSkillDirs() missing Hermes skill location %q", want)
 	}
 }
 


### PR DESCRIPTION
## Summary

PR 4 of 4 — **Skill registry + cross-cutting tests + docs**. Final slice; closes the change.

Closes #569

## Changes

- `internal/skillregistry/registry.go`: scan `~/.hermes/skills` (user) + `.hermes/skills` (project) + tests.
- Cross-cutting tests: default registry, assets embed readability, language contract matrix, MCP full-round-trip preserving pre-existing top-level keys.
- Docs: `docs/agents.md` (matrix + delegation + SDD tables + `### Hermes` section), `docs/platforms.md`, `docs/usage.md`, `README.md`.
- Verify follow-ups: corrected detection wording in `docs/agents.md`; added positive engram stabilization assertion.

`sdd-verify` over the full change: pass (0 critical). `go test ./...` green across 50 packages.

## Chain Context

| Field | Value |
|-------|-------|
| Chain | hermes-agent-support (feature-branch-chain) |
| Tracker PR | #774 |
| Position | 4 of 4 |
| Base | `feat/hermes-agent-support-03-injectors` |
| Depends on | PR 1–3 |
| Follow-up | None — last slice; tracker #774 stays open for community testing |
| Review budget | 124 / 400 |
| Starts at | PR 3 |
| Ends with | skill registry + full test coverage + user-facing docs |

### Chain Overview

```text
main
 └── #774 tracker (draft)
      └── PR 1 ...01-yaml-helpers
           └── PR 2 ...02-adapter-registration
                └── PR 3 ...03-injectors
                     └── 📍 PR 4 ...04-tests-docs
```

### Scope
- Includes: skill registry wiring, cross-cutting tests, docs.
- Excludes: nothing — this completes the feature.

### Autonomy
- [x] CI is expected to pass for this PR branch
- [x] This PR has one deliverable scope
- [x] This PR can be rolled back without unrelated changes
- [x] Tests + docs cover this unit
