### PR TITLE
feat(model): add fable as a valid Claude model alias

### DIFF
--- a/internal/agents/claude/adapter.go
+++ b/internal/agents/claude/adapter.go
@@ -167,7 +167,7 @@ func (a *Adapter) EmbeddedSubAgentsDir() string {
 
 // ClaudeModelID resolves a ClaudeModelAlias to the string Claude Code accepts
 // in the `model:` frontmatter field of a sub-agent file. Claude Code uses the
-// aliases ("opus", "sonnet", "haiku") verbatim, so this is an identity over
+// aliases ("fable", "opus", "sonnet", "haiku") verbatim, so this is an identity over
 // alias.String(). Implemented as a method so the SDD injector's
 // claudeModelResolver type assertion fires for this adapter.
 func (a *Adapter) ClaudeModelID(alias model.ClaudeModelAlias) string {

--- a/internal/components/sdd/inject.go
+++ b/internal/components/sdd/inject.go
@@ -83,8 +83,8 @@ type kiroModelResolver interface {
 
 // claudeModelResolver is an optional adapter capability. When implemented,
 // the subagent copy loop stamps the resolved ClaudeModelAlias into the agent
-// frontmatter sentinel {{CLAUDE_MODEL}}. Claude Code accepts "opus", "sonnet",
-// and "haiku" directly as model values, so the resolver is effectively an
+// frontmatter sentinel {{CLAUDE_MODEL}}. Claude Code accepts "fable", "opus",
+// "sonnet", and "haiku" directly as model values, so the resolver is effectively an
 // identity function on the alias string — but the interface keeps the opt-in
 // shape consistent with kiroModelResolver.
 type claudeModelResolver interface {

--- a/internal/components/sdd/inject_test.go
+++ b/internal/components/sdd/inject_test.go
@@ -325,8 +325,9 @@ func TestInjectClaudeCustomModelAssignments(t *testing.T) {
 	home := t.TempDir()
 
 	opts := InjectOptions{ClaudeModelAssignments: map[string]model.ClaudeModelAlias{
-		"sdd-design": model.ClaudeModelSonnet,
-		"default":    model.ClaudeModelHaiku,
+		"sdd-design":  model.ClaudeModelSonnet,
+		"sdd-propose": model.ClaudeModelFable,
+		"default":     model.ClaudeModelHaiku,
 	}}
 
 	result, err := Inject(home, claudeAdapter(), "", opts)
@@ -348,6 +349,7 @@ func TestInjectClaudeCustomModelAssignments(t *testing.T) {
 	}
 	for _, want := range []string{
 		"| sdd-design | sonnet | Architecture decisions |",
+		"| sdd-propose | fable | Architectural decisions |",
 		"| default | haiku | Non-SDD general delegation |",
 		"Gentle AI does not configure the main orchestrator model",
 	} {
@@ -4912,6 +4914,7 @@ func TestInjectClaudeSubAgentsResolveModels(t *testing.T) {
 
 	assignments := map[string]model.ClaudeModelAlias{
 		"sdd-design":  model.ClaudeModelOpus,
+		"sdd-propose": model.ClaudeModelFable,
 		"sdd-archive": model.ClaudeModelHaiku,
 		"default":     model.ClaudeModelSonnet,
 	}
@@ -4929,6 +4932,7 @@ func TestInjectClaudeSubAgentsResolveModels(t *testing.T) {
 		want  string
 	}{
 		{phase: "sdd-design", want: "model: opus"},
+		{phase: "sdd-propose", want: "model: fable"},
 		{phase: "sdd-archive", want: "model: haiku"},
 		{phase: "sdd-spec", want: "model: sonnet"},
 	}

--- a/internal/model/claude_model.go
+++ b/internal/model/claude_model.go
@@ -2,13 +2,19 @@ package model
 
 import "maps"
 
-// ClaudeModelAlias represents one of the three Claude model tiers used for
+// ClaudeModelAlias represents one of the Claude model tiers used for
 // per-phase model assignments in the SDD orchestrator.
 //
-// Only three values are valid: ClaudeModelOpus, ClaudeModelSonnet, ClaudeModelHaiku.
+// Only four values are valid: ClaudeModelFable, ClaudeModelOpus,
+// ClaudeModelSonnet, ClaudeModelHaiku.
 type ClaudeModelAlias string
 
 const (
+	// ClaudeModelFable is the highest-reasoning tier, above opus, for the most
+	// demanding architectural and review work. Maps to the current
+	// claude-fable-* family.
+	ClaudeModelFable ClaudeModelAlias = "fable"
+
 	// ClaudeModelOpus is the high-capability tier, best for architectural decisions
 	// and orchestration. Maps to the current claude-opus-* family.
 	ClaudeModelOpus ClaudeModelAlias = "opus"
@@ -27,10 +33,10 @@ func (a ClaudeModelAlias) String() string {
 	return string(a)
 }
 
-// Valid reports whether the alias is one of the three known Claude model tiers.
+// Valid reports whether the alias is one of the known Claude model tiers.
 func (a ClaudeModelAlias) Valid() bool {
 	switch a {
-	case ClaudeModelOpus, ClaudeModelSonnet, ClaudeModelHaiku:
+	case ClaudeModelFable, ClaudeModelOpus, ClaudeModelSonnet, ClaudeModelHaiku:
 		return true
 	default:
 		return false

--- a/internal/model/claude_model_test.go
+++ b/internal/model/claude_model_test.go
@@ -1,0 +1,69 @@
+package model_test
+
+import (
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/internal/model"
+)
+
+// TestClaudeModelAliasValid verifies that Valid accepts exactly the four
+// known aliases and rejects empty, unknown, uppercase, and full-model-ID inputs.
+func TestClaudeModelAliasValid(t *testing.T) {
+	tests := []struct {
+		name  string
+		input model.ClaudeModelAlias
+		want  bool
+	}{
+		{"fable", model.ClaudeModelFable, true},
+		{"opus", model.ClaudeModelOpus, true},
+		{"sonnet", model.ClaudeModelSonnet, true},
+		{"haiku", model.ClaudeModelHaiku, true},
+		{"empty", model.ClaudeModelAlias(""), false},
+		{"junk", model.ClaudeModelAlias("junk"), false},
+		{"uppercase", model.ClaudeModelAlias("FABLE"), false},
+		{"full model id", model.ClaudeModelAlias("claude-fable-5"), false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.input.Valid(); got != tc.want {
+				t.Errorf("ClaudeModelAlias(%q).Valid() = %v, want %v", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestClaudeModelAliasString verifies that the fable alias renders as its
+// literal string value.
+func TestClaudeModelAliasString(t *testing.T) {
+	if got := model.ClaudeModelFable.String(); got != "fable" {
+		t.Errorf("ClaudeModelFable.String() = %q, want %q", got, "fable")
+	}
+}
+
+// TestClaudeModelPresetsContainOnlyValidAliases verifies that every preset
+// assigns a valid alias to all 14 phase keys, guarding against preset drift
+// when new aliases are introduced.
+func TestClaudeModelPresetsContainOnlyValidAliases(t *testing.T) {
+	presets := []struct {
+		name string
+		fn   func() map[string]model.ClaudeModelAlias
+	}{
+		{"Balanced", model.ClaudeModelPresetBalanced},
+		{"Performance", model.ClaudeModelPresetPerformance},
+		{"Economy", model.ClaudeModelPresetEconomy},
+		{"Diversity", model.ClaudeModelPresetDiversity},
+	}
+	for _, tc := range presets {
+		t.Run(tc.name, func(t *testing.T) {
+			m := tc.fn()
+			if len(m) != 14 {
+				t.Errorf("%s preset has %d keys, want 14", tc.name, len(m))
+			}
+			for k, v := range m {
+				if !v.Valid() {
+					t.Errorf("%s preset[%q] = %q is not a valid ClaudeModelAlias", tc.name, k, v)
+				}
+			}
+		})
+	}
+}

--- a/internal/model/selection.go
+++ b/internal/model/selection.go
@@ -11,7 +11,7 @@ type Selection struct {
 	StrictTDD              bool
 	CodexMultiAgent        bool                        // deprecated: Codex now always writes features.multi_agent = true; retained for state/back-compat
 	ModelAssignments       map[string]ModelAssignment  // key = sub-agent name (e.g., "sdd-init")
-	ClaudeModelAssignments map[string]ClaudeModelAlias // key = phase name; value = opus|sonnet|haiku
+	ClaudeModelAssignments map[string]ClaudeModelAlias // key = phase name; value = fable|opus|sonnet|haiku
 	KiroModelAssignments   map[string]KiroModelAlias   // key = phase name; value = Kiro-native model alias
 	CodexModelAssignments  map[string]CodexEffort      // key = phase name; value = low|medium|high|xhigh
 	Profiles               []Profile                   // named SDD profiles to generate/update during sync

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -25,7 +25,7 @@ type InstallState struct {
 	InstalledAgents []string `json:"installed_agents"`
 
 	// ClaudeModelAssignments maps SDD phase names (e.g. "sdd-explore") to a
-	// Claude model alias ("opus", "sonnet", "haiku"). Persisted so that
+	// Claude model alias ("fable", "opus", "sonnet", "haiku"). Persisted so that
 	// `gentle-ai sync` preserves the user's model choices instead of falling
 	// back to the "balanced" preset every time.
 	ClaudeModelAssignments map[string]string `json:"claude_model_assignments,omitempty"`

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -255,6 +255,7 @@ func TestModelAssignmentsRoundTrip(t *testing.T) {
 		ClaudeModelAssignments: map[string]string{
 			"orchestrator": "opus",
 			"sdd-explore":  "sonnet",
+			"sdd-propose":  "fable",
 			"sdd-archive":  "haiku",
 		},
 		KiroModelAssignments: map[string]string{

--- a/internal/tui/screens/claude_model_picker.go
+++ b/internal/tui/screens/claude_model_picker.go
@@ -74,6 +74,7 @@ var claudePhaseLabels = map[string]string{
 
 // claudeAliasOrder defines the cycling order when pressing Enter on a phase row.
 var claudeAliasOrder = []model.ClaudeModelAlias{
+	model.ClaudeModelFable,
 	model.ClaudeModelOpus,
 	model.ClaudeModelSonnet,
 	model.ClaudeModelHaiku,
@@ -245,7 +246,7 @@ func handleCustomPhaseNav(
 	return false, nil
 }
 
-// nextAlias cycles through opus → sonnet → haiku → opus.
+// nextAlias cycles through fable → opus → sonnet → haiku → fable.
 func nextAlias(current model.ClaudeModelAlias) model.ClaudeModelAlias {
 	for i, a := range claudeAliasOrder {
 		if a == current {
@@ -293,7 +294,7 @@ func renderCustomPhaseList(state ClaudeModelPickerState, cursor int) string {
 
 	b.WriteString(styles.TitleStyle.Render("Custom Model Assignments"))
 	b.WriteString("\n\n")
-	b.WriteString(styles.SubtextStyle.Render("Press enter on a phase to cycle: opus → sonnet → haiku"))
+	b.WriteString(styles.SubtextStyle.Render("Press enter on a phase to cycle: fable → opus → sonnet → haiku"))
 	b.WriteString("\n\n")
 
 	for idx, phase := range claudePhases {
@@ -325,6 +326,8 @@ func renderCustomPhaseList(state ClaudeModelPickerState, cursor int) string {
 // aliasTag returns a styled badge for the alias value.
 func aliasTag(alias model.ClaudeModelAlias) string {
 	switch alias {
+	case model.ClaudeModelFable:
+		return styles.TitleStyle.Render("[fable]")
 	case model.ClaudeModelOpus:
 		return styles.WarningStyle.Render("[opus]")
 	case model.ClaudeModelHaiku:

--- a/internal/tui/screens/claude_model_picker_test.go
+++ b/internal/tui/screens/claude_model_picker_test.go
@@ -73,6 +73,79 @@ func TestNewClaudeModelPickerStateFromAssignments_CopiesMap(t *testing.T) {
 	}
 }
 
+// TestNextAliasCyclesThroughAllAliases verifies the fable → opus → sonnet →
+// haiku cycle order and the sonnet fallback for unknown aliases.
+func TestNextAliasCyclesThroughAllAliases(t *testing.T) {
+	cases := []struct {
+		name    string
+		current model.ClaudeModelAlias
+		want    model.ClaudeModelAlias
+	}{
+		{"fable → opus", model.ClaudeModelFable, model.ClaudeModelOpus},
+		{"opus → sonnet", model.ClaudeModelOpus, model.ClaudeModelSonnet},
+		{"sonnet → haiku", model.ClaudeModelSonnet, model.ClaudeModelHaiku},
+		{"haiku → fable", model.ClaudeModelHaiku, model.ClaudeModelFable},
+		{"unknown falls back to sonnet", model.ClaudeModelAlias("bogus"), model.ClaudeModelSonnet},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := nextAlias(tc.current); got != tc.want {
+				t.Errorf("nextAlias(%q) = %q, want %q", tc.current, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestHandleCustomPhaseNav_CycleReachesEveryAlias drives the picker's nav
+// handler through a full cycle on one phase and verifies every alias is
+// reachable and the cycle returns to its starting alias.
+func TestHandleCustomPhaseNav_CycleReachesEveryAlias(t *testing.T) {
+	state := NewClaudeModelPickerState()
+	state.InCustomMode = true
+	phase := claudePhases[0]
+	start := state.CustomAssignments[phase]
+
+	seen := map[model.ClaudeModelAlias]bool{start: true}
+	for i := 0; i < len(claudeAliasOrder); i++ {
+		handled, assignments := HandleClaudeModelPickerNav("enter", &state, 0)
+		if !handled {
+			t.Fatal("enter on a phase row should be handled")
+		}
+		if assignments != nil {
+			t.Fatal("cycling a phase should not confirm the screen")
+		}
+		seen[state.CustomAssignments[phase]] = true
+	}
+
+	for _, alias := range claudeAliasOrder {
+		if !seen[alias] {
+			t.Errorf("cycling never reached alias %q", alias)
+		}
+	}
+	if state.CustomAssignments[phase] != start {
+		t.Errorf("after a full cycle, alias = %q, want starting alias %q", state.CustomAssignments[phase], start)
+	}
+}
+
+// TestRenderClaudeModelPicker_CustomModeRendersFable verifies that custom
+// mode renders the [fable] badge for a fable-assigned phase and that the help
+// text advertises the four-alias cycle.
+func TestRenderClaudeModelPicker_CustomModeRendersFable(t *testing.T) {
+	state := NewClaudeModelPickerStateFromAssignments(map[string]model.ClaudeModelAlias{
+		"sdd-propose": model.ClaudeModelFable,
+	})
+	state.InCustomMode = true
+
+	out := RenderClaudeModelPicker(state, 0)
+	if !strings.Contains(out, "[fable]") {
+		t.Errorf("expected [fable] tag in custom mode render, got:\n%s", out)
+	}
+	if !strings.Contains(out, "fable → opus → sonnet → haiku") {
+		t.Errorf("expected cycle help text to include fable, got:\n%s", out)
+	}
+}
+
 func TestRenderClaudeModelPicker_ShowsCurrentPreset(t *testing.T) {
 	cases := []struct {
 		name        string


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #798

---

## 🏷️ PR Type

- [ ] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [x] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Adds `fable` (Anthropic Fable 5) as a fourth valid `ClaudeModelAlias`, so user-selected fable assignments survive `gentle-ai sync` instead of being silently dropped by `Valid()` and reverted to the Balanced preset.
- Exposes `fable` in the TUI Claude model picker (cycle order, help text, `[fable]` badge).
- Fully backward compatible: all four presets (Balanced/Performance/Economy/Diversity) are untouched; legacy `state.json` files round-trip identically; no defaults change. `claudeAliasOrder[0]` is only consumed by `nextAlias`, so picker ordering introduces no implicit default change.

**Evidence the alias is real (re: doc-comment claims):** Claude Code's `Agent` tool accepts `model: "fable"` alongside opus/sonnet/haiku (its model enum is `sonnet | opus | haiku | fable`), resolving to model ID `claude-fable-5`. Verified live on Claude Code by launching a sub-agent with `model: fable`, which self-reported `claude-fable-5[1m]`. Frontmatter `model: fable` in agent definition files is honored the same way as the existing three aliases.

**Behavior note for reviewers:** cycling past `haiku` in the picker now lands on `fable` (the new highest-capability tier) instead of wrapping to `opus`.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/model/claude_model.go` | `ClaudeModelFable = "fable"` const, accepted by `Valid()`, type doc updated |
| `internal/model/claude_model_test.go` | New table-driven tests: `Valid()` (incl. negatives: `FABLE`, `claude-fable-5`), `String()`, presets contain only valid aliases |
| `internal/tui/screens/claude_model_picker.go` | Picker cycle fable → opus → sonnet → haiku, help text, `[fable]` badge style |
| `internal/tui/screens/claude_model_picker_test.go` | Cycle reachability via nav handler, render test for badge + help text |
| `internal/components/sdd/inject.go` | Doc comment lists fable among accepted aliases (validity gating already flows through `Valid()`) |
| `internal/components/sdd/inject_test.go` | Asserts `model: fable` frontmatter stamping and `| sdd-propose | fable |` table row |
| `internal/model/selection.go` / `internal/state/state.go` / `internal/agents/claude/adapter.go` | Alias enumeration doc comments updated |
| `internal/state/state_test.go` | Round-trip fixture persists a fable assignment |

---

## 🧪 Test Plan

**Unit Tests**
```bash
go build ./...   # PASS
go vet ./...     # PASS
go test ./...    # PASS — 50 packages ok
```

**E2E (manual sandbox)**
Built the patched binary, created `$HOME/.gentle-ai/state.json` in a sandbox HOME with all 13 phases assigned to `fable`, ran `sync`: the generated `CLAUDE.md` Model Assignments table renders all 13 rows as `fable` and all 13 generated `.claude/agents/*.md` files carry `model: fable` frontmatter. Legacy state files without fable produce output identical to `main`.

---

## ✅ Contributor Checklist

- [x] Linked an issue (#798 — pending `status:approved` from maintainers)
- [x] Conventional commit format (`feat(model): ...`)
- [x] No `Co-Authored-By` trailers
- [x] Tests added/updated and passing (`go test ./...`)
- [x] Docs/comments updated where behavior is described
- [ ] `type:feature` label (cannot self-apply as external contributor — maintainer assist appreciated)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the "fable" Claude model alias; selectable and cycled in the model picker alongside opus, sonnet, and haiku.

* **Documentation**
  * Updated help text, UI labels, and persisted model-value docs to include "fable" where model options are shown (including the sdd-propose phase).

* **Tests**
  * Added and extended unit tests for model validation, picker cycling/rendering, and state round-trip persistence covering the new alias.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->