### PR TITLE
fix(codex): require waited sub-agent batches

### DIFF
--- a/internal/assets/assets_test.go
+++ b/internal/assets/assets_test.go
@@ -78,11 +78,23 @@ func TestOrchestratorsRejectDelegationBypassLanguage(t *testing.T) {
 	}
 	for _, want := range []string{
 		"## Delegated Path (default",
+		"### Blocking Delegation Contract",
+		"Codex sub-agents MUST be treated as waited handoffs, not fire-and-forget background jobs.",
+		"You MAY launch more than one independent sub-agent when useful",
+		"`wait_agent` for every spawned agent in that batch",
+		"Parallel does not mean background",
 		"## Graceful Degradation Path (tooling unavailable only)",
 		"do not run the full phase pipeline inline as a normal fallback",
 	} {
 		if !strings.Contains(codex, want) {
 			t.Fatalf("codex/sdd-orchestrator.md missing guarded degradation wording %q", want)
+		}
+	}
+	for _, forbidden := range []string{
+		"both `spawn_agent` calls before either `wait_agent`",
+	} {
+		if strings.Contains(codex, forbidden) {
+			t.Fatalf("codex/sdd-orchestrator.md contains fire-and-forget delegation wording %q", forbidden)
 		}
 	}
 }

--- a/internal/assets/codex/sdd-orchestrator.md
+++ b/internal/assets/codex/sdd-orchestrator.md
@@ -78,6 +78,15 @@ When multi-agent tools are available, delegate each SDD phase to a sub-agent usi
 
 **Thread budget**: `agents.max_threads = 4`, `agents.max_depth = 2` (set in `~/.codex/config.toml`).
 
+### Blocking Delegation Contract
+
+Codex sub-agents MUST be treated as waited handoffs, not fire-and-forget background jobs.
+You MAY launch more than one independent sub-agent when useful, but before reporting
+progress, asking the user a follow-up question, or launching a dependent phase, you MUST
+`wait_agent` for every spawned agent in that batch and then `close_agent` each completed
+agent. Do not tell the user a sub-agent is "running in the background" unless the user
+explicitly requested background execution.
+
 ### Phase delegation pattern
 
 For each phase:
@@ -99,7 +108,10 @@ Note: the `~/.codex/<tier>.config.toml` profile files apply to whole CLI session
 
 ### Parallelism
 
-`sdd-spec` and `sdd-design` have the same input (proposal) and independent outputs. Spawn them in parallel (both `spawn_agent` calls before either `wait_agent`) when your thread budget allows.
+Independent phases such as `sdd-spec` and `sdd-design` MAY be spawned in parallel when the
+thread budget allows. Parallel does not mean background: after launching the batch, call
+`wait_agent` for all spawned agents, then `close_agent` for each completed agent, and only
+then summarize results or continue to the next dependent phase.
 
 ### Graceful degradation
 

--- a/testdata/golden/sdd-codex-agentsmd-lowcost.golden
+++ b/testdata/golden/sdd-codex-agentsmd-lowcost.golden
@@ -79,6 +79,15 @@ When multi-agent tools are available, delegate each SDD phase to a sub-agent usi
 
 **Thread budget**: `agents.max_threads = 4`, `agents.max_depth = 2` (set in `~/.codex/config.toml`).
 
+### Blocking Delegation Contract
+
+Codex sub-agents MUST be treated as waited handoffs, not fire-and-forget background jobs.
+You MAY launch more than one independent sub-agent when useful, but before reporting
+progress, asking the user a follow-up question, or launching a dependent phase, you MUST
+`wait_agent` for every spawned agent in that batch and then `close_agent` each completed
+agent. Do not tell the user a sub-agent is "running in the background" unless the user
+explicitly requested background execution.
+
 ### Phase delegation pattern
 
 For each phase:
@@ -100,7 +109,10 @@ Note: the `~/.codex/<tier>.config.toml` profile files apply to whole CLI session
 
 ### Parallelism
 
-`sdd-spec` and `sdd-design` have the same input (proposal) and independent outputs. Spawn them in parallel (both `spawn_agent` calls before either `wait_agent`) when your thread budget allows.
+Independent phases such as `sdd-spec` and `sdd-design` MAY be spawned in parallel when the
+thread budget allows. Parallel does not mean background: after launching the batch, call
+`wait_agent` for all spawned agents, then `close_agent` for each completed agent, and only
+then summarize results or continue to the next dependent phase.
 
 ### Graceful degradation
 

--- a/testdata/golden/sdd-codex-agentsmd-powerful.golden
+++ b/testdata/golden/sdd-codex-agentsmd-powerful.golden
@@ -79,6 +79,15 @@ When multi-agent tools are available, delegate each SDD phase to a sub-agent usi
 
 **Thread budget**: `agents.max_threads = 4`, `agents.max_depth = 2` (set in `~/.codex/config.toml`).
 
+### Blocking Delegation Contract
+
+Codex sub-agents MUST be treated as waited handoffs, not fire-and-forget background jobs.
+You MAY launch more than one independent sub-agent when useful, but before reporting
+progress, asking the user a follow-up question, or launching a dependent phase, you MUST
+`wait_agent` for every spawned agent in that batch and then `close_agent` each completed
+agent. Do not tell the user a sub-agent is "running in the background" unless the user
+explicitly requested background execution.
+
 ### Phase delegation pattern
 
 For each phase:
@@ -100,7 +109,10 @@ Note: the `~/.codex/<tier>.config.toml` profile files apply to whole CLI session
 
 ### Parallelism
 
-`sdd-spec` and `sdd-design` have the same input (proposal) and independent outputs. Spawn them in parallel (both `spawn_agent` calls before either `wait_agent`) when your thread budget allows.
+Independent phases such as `sdd-spec` and `sdd-design` MAY be spawned in parallel when the
+thread budget allows. Parallel does not mean background: after launching the batch, call
+`wait_agent` for all spawned agents, then `close_agent` for each completed agent, and only
+then summarize results or continue to the next dependent phase.
 
 ### Graceful degradation
 

--- a/testdata/golden/sdd-codex-agentsmd.golden
+++ b/testdata/golden/sdd-codex-agentsmd.golden
@@ -79,6 +79,15 @@ When multi-agent tools are available, delegate each SDD phase to a sub-agent usi
 
 **Thread budget**: `agents.max_threads = 4`, `agents.max_depth = 2` (set in `~/.codex/config.toml`).
 
+### Blocking Delegation Contract
+
+Codex sub-agents MUST be treated as waited handoffs, not fire-and-forget background jobs.
+You MAY launch more than one independent sub-agent when useful, but before reporting
+progress, asking the user a follow-up question, or launching a dependent phase, you MUST
+`wait_agent` for every spawned agent in that batch and then `close_agent` each completed
+agent. Do not tell the user a sub-agent is "running in the background" unless the user
+explicitly requested background execution.
+
 ### Phase delegation pattern
 
 For each phase:
@@ -100,7 +109,10 @@ Note: the `~/.codex/<tier>.config.toml` profile files apply to whole CLI session
 
 ### Parallelism
 
-`sdd-spec` and `sdd-design` have the same input (proposal) and independent outputs. Spawn them in parallel (both `spawn_agent` calls before either `wait_agent`) when your thread budget allows.
+Independent phases such as `sdd-spec` and `sdd-design` MAY be spawned in parallel when the
+thread budget allows. Parallel does not mean background: after launching the batch, call
+`wait_agent` for all spawned agents, then `close_agent` for each completed agent, and only
+then summarize results or continue to the next dependent phase.
 
 ### Graceful degradation
 


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #804

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Updates the Codex SDD orchestrator so sub-agent delegation is not treated as fire-and-forget background work.
- Preserves parallel independent sub-agent batches, but requires waiting and closing every spawned agent before reporting progress or continuing dependent work.
- Adds regression coverage and updates Codex SDD goldens.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/assets/codex/sdd-orchestrator.md` | Adds waited batch delegation contract for Codex sub-agents. |
| `internal/assets/assets_test.go` | Asserts Codex keeps guarded delegated path and waited batch wording. |
| `testdata/golden/sdd-codex-agentsmd*.golden` | Updates generated Codex SDD instructions. |

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test -count=1 ./internal/assets
go test ./internal/components -run 'TestGoldenSDD_Codex' -update
go test -count=1 ./internal/components -run 'TestGoldenSDD_Codex'
go test -count=1 ./internal/assets ./internal/components
go test -count=1 ./...
go vet ./...
git diff --check
```

**E2E Tests** (Docker required)
```bash
cd e2e && ./docker-test.sh
```

- [x] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Manually tested locally

---

## 🤖 Automated Checks

The following checks run automatically on this PR:

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | PR should stay within 400 changed lines (`additions + deletions`) or use `size:exception` |
| Check Issue Reference | ⏳ | PR body must contain `Closes/Fixes/Resolves #N` |
| Check Issue Has `status:approved` | ⏳ | Linked issue must have been approved before work began |
| Check PR Has `type:*` Label | ⏳ | Exactly one `type:*` label must be applied |
| Unit Tests | ⏳ | `go test ./...` must pass |
| E2E Tests | ⏳ | `cd e2e && ./docker-test.sh` must pass |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

The key behavior is: parallel independent Codex sub-agents are allowed, but every spawned agent in the batch must be waited and closed before user-visible progress or dependent work continues.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified delegation contract requirements to prevent fire-and-forget behavior in agent launches
  * Updated parallelism guidance to require proper result collection before proceeding to dependent phases

* **Tests**
  * Enhanced validation for delegation contract enforcement

<!-- end of auto-generated comment: release notes by coderabbit.ai -->