### PR TITLE
fix(installer): stop Engram before Windows upgrade

### DIFF
--- a/internal/components/engram/download.go
+++ b/internal/components/engram/download.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -28,10 +29,11 @@ const (
 
 // Package-level vars for testability.
 var (
-	engramHTTPClient       = &http.Client{Timeout: 5 * time.Minute}
-	engramGitHubBaseURL    = "https://github.com"
-	engramInstallDirFn     = engramInstallDir
-	engramChecksumURLFn    = engramChecksumURL
+	engramHTTPClient      = &http.Client{Timeout: 5 * time.Minute}
+	engramGitHubBaseURL   = "https://github.com"
+	engramInstallDirFn    = engramInstallDir
+	engramChecksumURLFn   = engramChecksumURL
+	engramStopProcessesFn = stopEngramProcesses
 )
 
 // DownloadLatestBinary fetches the latest engram release from GitHub and
@@ -98,7 +100,16 @@ func DownloadLatestBinary(profile system.PlatformProfile) (string, error) {
 			archiveName, expectedDigest, actualDigest)
 	}
 
-	// 6. Extract the verified binary.
+	// 6. On Windows, stop running Engram processes before replacing engram.exe.
+	// Windows locks running executables, unlike POSIX where atomic rename can
+	// replace the directory entry while the old process keeps its inode.
+	if goos == "windows" {
+		if err := engramStopProcessesFn(); err != nil {
+			return "", fmt.Errorf("stop running engram processes before upgrade: %w", err)
+		}
+	}
+
+	// 7. Extract the verified binary.
 	f, err := os.Open(archivePath)
 	if err != nil {
 		return "", fmt.Errorf("open archive: %w", err)
@@ -418,6 +429,23 @@ func extractZipBinary(data []byte, binaryName, outPath string) error {
 	}
 
 	return fmt.Errorf("binary %q not found in zip archive", binaryName)
+}
+
+// stopEngramProcesses stops any running Engram process so Windows can replace
+// engram.exe during upgrade. Missing processes are not an error because
+// Get-Process uses SilentlyContinue.
+func stopEngramProcesses() error {
+	cmd := exec.Command("powershell.exe",
+		"-NoProfile",
+		"-NonInteractive",
+		"-Command",
+		"Get-Process -Name engram -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction Stop",
+	)
+	cmd.Stdin = nil
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("powershell Stop-Process engram: %w (output: %s)", err, strings.TrimSpace(string(out)))
+	}
+	return nil
 }
 
 // engramInstallDir returns the directory where the engram binary should be installed

--- a/internal/components/engram/download_test.go
+++ b/internal/components/engram/download_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -307,11 +308,14 @@ func TestDownloadLatestBinaryWindows(t *testing.T) {
 
 	origClient := engramHTTPClient
 	origBaseURL := engramGitHubBaseURL
+	origStopProcessesFn := engramStopProcessesFn
 	engramHTTPClient = server.Client()
 	engramGitHubBaseURL = server.URL
+	engramStopProcessesFn = func() error { return nil }
 	t.Cleanup(func() {
 		engramHTTPClient = origClient
 		engramGitHubBaseURL = origBaseURL
+		engramStopProcessesFn = origStopProcessesFn
 	})
 
 	tmpDir := t.TempDir()
@@ -514,6 +518,83 @@ func TestDownloadLatestBinaryReleaseListFallsBackToAnonymousWhenTokenGets403(t *
 
 	if _, err := os.Stat(installedPath); err != nil {
 		t.Fatalf("stat installed binary: %v", err)
+	}
+}
+
+func TestDownloadLatestBinaryWindowsStopsEngramBeforeReplace(t *testing.T) {
+	const version = "1.4.0"
+	server := makeServerWithFakeZip(t, version)
+	defer server.Close()
+
+	origClient := engramHTTPClient
+	origBaseURL := engramGitHubBaseURL
+	origInstallDirFn := engramInstallDirFn
+	origStopProcessesFn := engramStopProcessesFn
+	t.Cleanup(func() {
+		engramHTTPClient = origClient
+		engramGitHubBaseURL = origBaseURL
+		engramInstallDirFn = origInstallDirFn
+		engramStopProcessesFn = origStopProcessesFn
+	})
+
+	engramHTTPClient = server.Client()
+	engramGitHubBaseURL = server.URL
+	installDir := t.TempDir()
+	engramInstallDirFn = func(goos string) string { return installDir }
+
+	stopCalls := 0
+	engramStopProcessesFn = func() error {
+		stopCalls++
+		return nil
+	}
+
+	installedPath, err := DownloadLatestBinary(system.PlatformProfile{OS: "windows", PackageManager: "winget"})
+	if err != nil {
+		t.Fatalf("DownloadLatestBinary(windows) error = %v", err)
+	}
+
+	if stopCalls != 1 {
+		t.Fatalf("stop calls = %d, want 1", stopCalls)
+	}
+	if filepath.Base(installedPath) != "engram.exe" {
+		t.Fatalf("installed path = %q, want engram.exe", installedPath)
+	}
+	if _, err := os.Stat(installedPath); err != nil {
+		t.Fatalf("stat installed binary: %v", err)
+	}
+}
+
+func TestDownloadLatestBinaryWindowsStopFailureAbortsBeforeReplace(t *testing.T) {
+	const version = "1.4.1"
+	server := makeServerWithFakeZip(t, version)
+	defer server.Close()
+
+	origClient := engramHTTPClient
+	origBaseURL := engramGitHubBaseURL
+	origInstallDirFn := engramInstallDirFn
+	origStopProcessesFn := engramStopProcessesFn
+	t.Cleanup(func() {
+		engramHTTPClient = origClient
+		engramGitHubBaseURL = origBaseURL
+		engramInstallDirFn = origInstallDirFn
+		engramStopProcessesFn = origStopProcessesFn
+	})
+
+	engramHTTPClient = server.Client()
+	engramGitHubBaseURL = server.URL
+	installDir := t.TempDir()
+	engramInstallDirFn = func(goos string) string { return installDir }
+	engramStopProcessesFn = func() error { return errors.New("stop denied") }
+
+	_, err := DownloadLatestBinary(system.PlatformProfile{OS: "windows", PackageManager: "winget"})
+	if err == nil {
+		t.Fatal("expected stop failure, got nil")
+	}
+	if !strings.Contains(err.Error(), "stop running engram processes before upgrade") {
+		t.Fatalf("error = %q, want stop context", err.Error())
+	}
+	if _, err := os.Stat(filepath.Join(installDir, "engram.exe")); !os.IsNotExist(err) {
+		t.Fatalf("engram.exe should not be written after stop failure, stat err: %v", err)
 	}
 }
 


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #806

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)

## 📝 Summary

Stops running Engram processes on Windows before replacing `engram.exe` during the binary upgrade path. Windows locks running executables, so the POSIX atomic rename behavior is not enough for `gentle-ai upgrade` or TUI Upgrade + Sync when Engram is active as an MCP server.

`gentle-ai sync` remains configuration-only and does not install binaries.

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/components/engram/download.go` | Adds a Windows-only process stop step before extracting/replacing the Engram binary |
| `internal/components/engram/download_test.go` | Adds mocked tests for successful stop-before-replace and abort-on-stop-failure behavior |

## 🧪 Test Plan

**Unit Tests**
```bash
go test -count=1 ./internal/components/engram ./internal/update/upgrade ./internal/cli ./internal/tui
go test -count=1 ./...
go vet ./...
git diff --check
```

**E2E Tests** (Docker required)
```bash
cd e2e && ./docker-test.sh
```

- [x] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Manually tested locally

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] I have updated documentation if necessary
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved Windows file-lock errors that could prevent successful updates, especially when the application was running during an upgrade. The update process now automatically stops any active instances before replacing the binary.
  * Improved reliability and safety: if stopping the running instance fails, the update safely aborts to prevent incomplete or corrupted installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->