### PR TITLE
feat(model): add fable as a valid Claude model alias

### DIFF
--- a/internal/components/sdd/inject.go
+++ b/internal/components/sdd/inject.go
@@ -84,8 +84,8 @@ type kiroModelResolver interface {
 // claudeModelResolver is an optional adapter capability. When implemented,
 // the subagent copy loop stamps the resolved ClaudeModelAlias into the agent
 // frontmatter sentinel {{CLAUDE_MODEL}}. Claude Code accepts "opus", "sonnet",
-// and "haiku" directly as model values, so the resolver is effectively an
-// identity function on the alias string — but the interface keeps the opt-in
+// "haiku", and "fable" directly as model values, so the resolver is effectively
+// an identity function on the alias string — but the interface keeps the opt-in
 // shape consistent with kiroModelResolver.
 type claudeModelResolver interface {
 	ClaudeModelID(alias model.ClaudeModelAlias) string

--- a/internal/model/claude_model.go
+++ b/internal/model/claude_model.go
@@ -2,10 +2,10 @@ package model
 
 import "maps"
 
-// ClaudeModelAlias represents one of the three Claude model tiers used for
+// ClaudeModelAlias represents one of the known Claude model tiers used for
 // per-phase model assignments in the SDD orchestrator.
 //
-// Only three values are valid: ClaudeModelOpus, ClaudeModelSonnet, ClaudeModelHaiku.
+// Valid values: ClaudeModelOpus, ClaudeModelSonnet, ClaudeModelHaiku, ClaudeModelFable.
 type ClaudeModelAlias string
 
 const (
@@ -20,6 +20,11 @@ const (
 	// ClaudeModelHaiku is the lightweight tier, ideal for mechanical tasks like
 	// archiving or simple copy work. Maps to the current claude-haiku-* family.
 	ClaudeModelHaiku ClaudeModelAlias = "haiku"
+
+	// ClaudeModelFable is Anthropic's top-tier reasoning model (claude-fable-* family),
+	// released 2026-06-09. Use it for phases that benefit from deep multi-step reasoning
+	// at the cost of higher latency and token spend.
+	ClaudeModelFable ClaudeModelAlias = "fable"
 )
 
 // String returns the string representation of the alias.
@@ -27,10 +32,10 @@ func (a ClaudeModelAlias) String() string {
 	return string(a)
 }
 
-// Valid reports whether the alias is one of the three known Claude model tiers.
+// Valid reports whether the alias is one of the known Claude model tiers.
 func (a ClaudeModelAlias) Valid() bool {
 	switch a {
-	case ClaudeModelOpus, ClaudeModelSonnet, ClaudeModelHaiku:
+	case ClaudeModelOpus, ClaudeModelSonnet, ClaudeModelHaiku, ClaudeModelFable:
 		return true
 	default:
 		return false

--- a/internal/model/claude_model_test.go
+++ b/internal/model/claude_model_test.go
@@ -1,0 +1,105 @@
+package model_test
+
+import (
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/internal/model"
+)
+
+func TestClaudeModelAliasValid(t *testing.T) {
+	tests := []struct {
+		name  string
+		input model.ClaudeModelAlias
+		want  bool
+	}{
+		{"opus", model.ClaudeModelOpus, true},
+		{"sonnet", model.ClaudeModelSonnet, true},
+		{"haiku", model.ClaudeModelHaiku, true},
+		{"fable", model.ClaudeModelFable, true},
+		{"empty", model.ClaudeModelAlias(""), false},
+		{"garbage", model.ClaudeModelAlias("garbage"), false},
+		{"uppercase", model.ClaudeModelAlias("FABLE"), false},
+		{"partial", model.ClaudeModelAlias("fab"), false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.input.Valid(); got != tc.want {
+				t.Errorf("ClaudeModelAlias(%q).Valid() = %v, want %v", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestClaudeModelAliasString(t *testing.T) {
+	tests := []struct {
+		alias model.ClaudeModelAlias
+		want  string
+	}{
+		{model.ClaudeModelOpus, "opus"},
+		{model.ClaudeModelSonnet, "sonnet"},
+		{model.ClaudeModelHaiku, "haiku"},
+		{model.ClaudeModelFable, "fable"},
+	}
+	for _, tc := range tests {
+		if got := tc.alias.String(); got != tc.want {
+			t.Errorf("ClaudeModelAlias(%q).String() = %q, want %q", tc.alias, got, tc.want)
+		}
+	}
+}
+
+func TestClaudeModelPresetsCoverAllPhasesAndAllValuesAreValid(t *testing.T) {
+	presets := []struct {
+		name string
+		fn   func() map[string]model.ClaudeModelAlias
+	}{
+		{"Balanced", model.ClaudeModelPresetBalanced},
+		{"Performance", model.ClaudeModelPresetPerformance},
+		{"Economy", model.ClaudeModelPresetEconomy},
+		{"Diversity", model.ClaudeModelPresetDiversity},
+	}
+
+	requiredKeys := []string{
+		"orchestrator",
+		"sdd-explore", "sdd-propose", "sdd-spec", "sdd-design", "sdd-tasks",
+		"sdd-apply", "sdd-verify", "sdd-archive", "sdd-onboard",
+		"jd-judge-a", "jd-judge-b", "jd-fix-agent", "default",
+	}
+
+	for _, tc := range presets {
+		t.Run(tc.name, func(t *testing.T) {
+			m := tc.fn()
+			for _, k := range requiredKeys {
+				v, ok := m[k]
+				if !ok {
+					t.Errorf("%s preset missing key %q", tc.name, k)
+					continue
+				}
+				if !v.Valid() {
+					t.Errorf("%s preset[%q] = %q is not a valid ClaudeModelAlias", tc.name, k, v)
+				}
+			}
+		})
+	}
+}
+
+func TestClaudeModelPresetsDoNotUseFable(t *testing.T) {
+	// Presets should remain unchanged: fable is selectable but not a new default.
+	presets := []struct {
+		name string
+		fn   func() map[string]model.ClaudeModelAlias
+	}{
+		{"Balanced", model.ClaudeModelPresetBalanced},
+		{"Performance", model.ClaudeModelPresetPerformance},
+		{"Economy", model.ClaudeModelPresetEconomy},
+		{"Diversity", model.ClaudeModelPresetDiversity},
+	}
+	for _, tc := range presets {
+		t.Run(tc.name, func(t *testing.T) {
+			for phase, alias := range tc.fn() {
+				if alias == model.ClaudeModelFable {
+					t.Errorf("%s preset[%q] = %q: presets should not default to fable", tc.name, phase, alias)
+				}
+			}
+		})
+	}
+}

--- a/internal/model/selection.go
+++ b/internal/model/selection.go
@@ -11,7 +11,7 @@ type Selection struct {
 	StrictTDD              bool
 	CodexMultiAgent        bool                        // deprecated: Codex now always writes features.multi_agent = true; retained for state/back-compat
 	ModelAssignments       map[string]ModelAssignment  // key = sub-agent name (e.g., "sdd-init")
-	ClaudeModelAssignments map[string]ClaudeModelAlias // key = phase name; value = opus|sonnet|haiku
+	ClaudeModelAssignments map[string]ClaudeModelAlias // key = phase name; value = opus|sonnet|haiku|fable
 	KiroModelAssignments   map[string]KiroModelAlias   // key = phase name; value = Kiro-native model alias
 	CodexModelAssignments  map[string]CodexEffort      // key = phase name; value = low|medium|high|xhigh
 	Profiles               []Profile                   // named SDD profiles to generate/update during sync
@@ -50,7 +50,7 @@ type SyncOverrides struct {
 	// model/profile configurators, where the user picked a concrete target agent.
 	TargetAgents           []AgentID
 	ModelAssignments       map[string]ModelAssignment  // nil = no override; empty map = reset to defaults
-	ClaudeModelAssignments map[string]ClaudeModelAlias // nil = no override; empty map = reset to defaults
+	ClaudeModelAssignments map[string]ClaudeModelAlias // nil = no override; empty map = reset to defaults; values = opus|sonnet|haiku|fable
 	KiroModelAssignments   map[string]KiroModelAlias   // nil = no override; empty map = reset to defaults
 	CodexModelAssignments  map[string]CodexEffort      // nil = no override; empty map = reset to defaults
 	SDDMode                SDDModeID                   // "" = no override; when non-empty, overrides the sync's default SDD mode

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -25,7 +25,7 @@ type InstallState struct {
 	InstalledAgents []string `json:"installed_agents"`
 
 	// ClaudeModelAssignments maps SDD phase names (e.g. "sdd-explore") to a
-	// Claude model alias ("opus", "sonnet", "haiku"). Persisted so that
+	// Claude model alias ("opus", "sonnet", "haiku", "fable"). Persisted so that
 	// `gentle-ai sync` preserves the user's model choices instead of falling
 	// back to the "balanced" preset every time.
 	ClaudeModelAssignments map[string]string `json:"claude_model_assignments,omitempty"`

--- a/internal/tui/screens/claude_model_picker.go
+++ b/internal/tui/screens/claude_model_picker.go
@@ -77,6 +77,7 @@ var claudeAliasOrder = []model.ClaudeModelAlias{
 	model.ClaudeModelOpus,
 	model.ClaudeModelSonnet,
 	model.ClaudeModelHaiku,
+	model.ClaudeModelFable,
 }
 
 // ClaudeModelPickerState holds navigation state for the Claude model picker screen.
@@ -293,7 +294,7 @@ func renderCustomPhaseList(state ClaudeModelPickerState, cursor int) string {
 
 	b.WriteString(styles.TitleStyle.Render("Custom Model Assignments"))
 	b.WriteString("\n\n")
-	b.WriteString(styles.SubtextStyle.Render("Press enter on a phase to cycle: opus → sonnet → haiku"))
+	b.WriteString(styles.SubtextStyle.Render("Press enter on a phase to cycle: opus → sonnet → haiku → fable"))
 	b.WriteString("\n\n")
 
 	for idx, phase := range claudePhases {
@@ -329,6 +330,8 @@ func aliasTag(alias model.ClaudeModelAlias) string {
 		return styles.WarningStyle.Render("[opus]")
 	case model.ClaudeModelHaiku:
 		return styles.SubtextStyle.Render("[haiku]")
+	case model.ClaudeModelFable:
+		return styles.WarningStyle.Render("[fable]")
 	default:
 		return styles.SuccessStyle.Render("[sonnet]")
 	}

--- a/internal/tui/screens/claude_model_picker_test.go
+++ b/internal/tui/screens/claude_model_picker_test.go
@@ -111,3 +111,37 @@ func TestRenderClaudeModelPicker_ShowsCurrentPreset(t *testing.T) {
 		})
 	}
 }
+
+func TestNextAliasIncludesFable(t *testing.T) {
+	// Verify fable is reachable and cycles correctly.
+	cases := []struct {
+		current model.ClaudeModelAlias
+		want    model.ClaudeModelAlias
+	}{
+		{model.ClaudeModelOpus, model.ClaudeModelSonnet},
+		{model.ClaudeModelSonnet, model.ClaudeModelHaiku},
+		{model.ClaudeModelHaiku, model.ClaudeModelFable},
+		{model.ClaudeModelFable, model.ClaudeModelOpus},
+		// Unknown aliases fall back to sonnet (nextAlias default).
+		{model.ClaudeModelAlias("unknown"), model.ClaudeModelSonnet},
+	}
+	for _, tc := range cases {
+		t.Run(string(tc.current), func(t *testing.T) {
+			got := nextAlias(tc.current)
+			if got != tc.want {
+				t.Errorf("nextAlias(%q) = %q, want %q", tc.current, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAliasTagFable(t *testing.T) {
+	// fable should produce a non-empty tag string, not fall through to sonnet default.
+	tag := aliasTag(model.ClaudeModelFable)
+	if tag == "" {
+		t.Error("aliasTag(ClaudeModelFable) returned empty string")
+	}
+	if strings.Contains(tag, "sonnet") {
+		t.Errorf("aliasTag(ClaudeModelFable) = %q, should not fall back to sonnet tag", tag)
+	}
+}


### PR DESCRIPTION
Closes #799

## Type

- [x] New feature

## Summary

- Adds `ClaudeModelFable` (`"fable"`) as the fourth valid `ClaudeModelAlias` in `internal/model/claude_model.go`.
- Extends the TUI custom model picker (`internal/tui/screens/claude_model_picker.go`) so `fable` appears in the cycling order (`opus → sonnet → haiku → fable`) and renders its own badge.
- Updates `Valid()` to accept `"fable"`, which prevents the silent fallback to the Balanced preset when a user hand-edits `~/.gentle-ai/state.json` to assign `"fable"` to a phase.
- Existing presets (Balanced, Performance, Economy, Diversity) are unchanged — `fable` is opt-in via the Custom picker only.

## Changes

| File | Change |
|------|--------|
| `internal/model/claude_model.go` | Add `ClaudeModelFable` const and extend `Valid()` |
| `internal/model/claude_model_test.go` | New file — table-driven tests for `Valid()`, `String()`, preset coverage, and preset-no-fable invariant |
| `internal/tui/screens/claude_model_picker.go` | Add `fable` to cycle order, `aliasTag`, and cycle hint text |
| `internal/tui/screens/claude_model_picker_test.go` | Tests for `nextAlias` cycle through fable and `aliasTag` fable branch |
| `internal/components/sdd/inject.go` | Update comment enumerating accepted Claude Code model values |
| `internal/model/selection.go` | Update inline comments |
| `internal/state/state.go` | Update inline comment |

## Motivation

Fable (`claude-fable-5` family) is Anthropic's top-tier reasoning model, released 2026-06-09. Claude Code's `Agent` tool and sub-agent frontmatter already accept `"fable"` as a model value. Without this change, `Valid()` rejects it and the injector silently falls back to the Balanced preset, discarding the user's explicit override with no warning or error.

## Kiro fallback path

When `KiroModelAssignments` is nil and `ClaudeModelAssignments` contains `"fable"`, the Kiro injection path casts it to `KiroModelAlias("fable")`. `KiroModelAlias.Valid()` returns false for `"fable"`, so `KiroModelID` falls through to its default (`"claude-sonnet-4.6"`). This is the correct safe behavior — no change needed in the Kiro path.

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./...` — all packages pass (47 packages, 0 failures)
- [x] `TestClaudeModelAliasValid` — `fable` accepted, garbage/FABLE/empty rejected
- [x] `TestClaudeModelPresetsDoNotUseFable` — presets remain unchanged
- [x] `TestNextAliasIncludesFable` — full cycle confirmed
- [x] `TestAliasTagFable` — fable renders its own badge, not the sonnet default

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Claude Fable model tier support, now available alongside existing Opus, Sonnet, and Haiku options
  * Fable is now included in model selection with dedicated UI badge and styling
  * Users can cycle through the new model tier in custom selection mode

* **Tests**
  * Added comprehensive test coverage for the new Fable model functionality and validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->