### PR TITLE
feat(codex): add per-carril model + effort selection

### DIFF
--- a/internal/agents/codex/adapter.go
+++ b/internal/agents/codex/adapter.go
@@ -162,8 +162,8 @@ func (a *Adapter) SupportsMCP() bool {
 // RenderCodexPhaseEfforts implements codexModelResolver. It delegates to
 // model.RenderCodexPhaseEfforts so that inject.go can substitute the
 // {{CODEX_PHASE_EFFORTS}} placeholder in the Codex orchestrator asset.
-func (a *Adapter) RenderCodexPhaseEfforts(assignments map[string]model.CodexEffort) string {
-	return model.RenderCodexPhaseEfforts(assignments)
+func (a *Adapter) RenderCodexPhaseEfforts(assignments map[string]model.CodexEffort, carrilModels map[string]string) string {
+	return model.RenderCodexPhaseEfforts(assignments, carrilModels)
 }
 
 func defaultStat(path string) statResult {

--- a/internal/agents/codex/profiles.go
+++ b/internal/agents/codex/profiles.go
@@ -6,28 +6,37 @@ import (
 	"path/filepath"
 
 	"github.com/gentleman-programming/gentle-ai/internal/components/filemerge"
+	"github.com/gentleman-programming/gentle-ai/internal/model"
 )
 
-// codexProfile maps a profile filename to its model_reasoning_effort value.
-// These profiles use the separate-file mechanism introduced in Codex >= 0.134.0:
-// each file lives at ~/.codex/<name>.config.toml and is selected at runtime via
-// `codex --profile <name>`. The model_reasoning_effort key is model-agnostic —
-// Codex maps the effort tier to the appropriate model at runtime, so we do NOT
-// hardcode any OpenAI model ID.
-//
-// Tier mapping to SDD Model Assignments:
-//   - sdd-strong  xhigh  propose, design, verify, judge phases
-//   - sdd-mid     high   spec, tasks, apply phases
-//   - sdd-cheap   low    explore, archive, onboard phases
-type codexProfile struct {
-	filename        string
-	reasoningEffort string
+// ProfileAssignment holds the resolved model and reasoning_effort for a
+// single Codex SDD profile (one of the three carriles: sdd-strong, sdd-mid,
+// sdd-cheap). This is the contract between the inject call site (which knows
+// about the user's selection) and WriteCodexProfiles (which knows about TOML).
+type ProfileAssignment struct {
+	Profile         string // e.g. "sdd-strong"
+	Model           string // e.g. "gpt-5.5"
+	ReasoningEffort string // e.g. "high"
 }
 
-var gentleAIProfiles = []codexProfile{
-	{filename: "sdd-strong.config.toml", reasoningEffort: "xhigh"},
-	{filename: "sdd-mid.config.toml", reasoningEffort: "high"},
-	{filename: "sdd-cheap.config.toml", reasoningEffort: "low"},
+// defaultProfileAssignments derives the canonical default assignments from
+// model.CodexTierGroups() so that WriteCodexProfiles(dir, nil) and
+// resolveProfileAssignments(nil, nil) agree on the Recommended preset values:
+//
+//	sdd-strong: high
+//	sdd-mid:    medium
+//	sdd-cheap:  low
+func defaultProfileAssignments() []ProfileAssignment {
+	tiers := model.CodexTierGroups()
+	out := make([]ProfileAssignment, 0, len(tiers))
+	for _, t := range tiers {
+		out = append(out, ProfileAssignment{
+			Profile:         t.Profile,
+			Model:           t.Model,
+			ReasoningEffort: string(t.DefaultEffort),
+		})
+	}
+	return out
 }
 
 // readProfileFileOrEmpty returns the file content as a string, or "" if the
@@ -47,16 +56,23 @@ func readProfileFileOrEmpty(path string) (string, error) {
 // files that WriteCodexProfiles would write into codexHomeDir. Useful for
 // uninstall path tracking without re-running the write.
 func SddProfilePaths(codexHomeDir string) []string {
-	paths := make([]string, 0, len(gentleAIProfiles))
-	for _, p := range gentleAIProfiles {
-		paths = append(paths, filepath.Join(codexHomeDir, p.filename))
+	defaults := defaultProfileAssignments()
+	paths := make([]string, 0, len(defaults))
+	for _, p := range defaults {
+		paths = append(paths, filepath.Join(codexHomeDir, p.Profile+".config.toml"))
 	}
 	return paths
 }
 
 // WriteCodexProfiles writes the three gentle-ai SDD profile files into the
-// given Codex home directory (~/.codex). Each profile file contains a
-// model_reasoning_effort key set to the appropriate SDD tier.
+// given Codex home directory (~/.codex). Each profile file contains both a
+// model key and a model_reasoning_effort key set to the resolved tier values.
+//
+// When assignments is nil or empty, canonical Recommended defaults are used
+// (derived from model.CodexTierGroups()):
+//   - sdd-strong: model=gpt-5.5, model_reasoning_effort=high
+//   - sdd-mid:    model=gpt-5.5, model_reasoning_effort=medium
+//   - sdd-cheap:  model=gpt-5.4-mini, model_reasoning_effort=low
 //
 // Profile files are written idempotently using UpsertTopLevelTOMLString +
 // WriteFileAtomic — re-running this function when files already contain the
@@ -64,16 +80,23 @@ func SddProfilePaths(codexHomeDir string) []string {
 //
 // Returns (changed, files, err) where changed is true if at least one file
 // was written or modified, and files is the list of profile paths written.
-func WriteCodexProfiles(codexHomeDir string) (changed bool, files []string, err error) {
-	for _, p := range gentleAIProfiles {
-		path := filepath.Join(codexHomeDir, p.filename)
+func WriteCodexProfiles(codexHomeDir string, assignments []ProfileAssignment) (changed bool, files []string, err error) {
+	if len(assignments) == 0 {
+		assignments = defaultProfileAssignments()
+	}
+
+	for _, a := range assignments {
+		path := filepath.Join(codexHomeDir, a.Profile+".config.toml")
 
 		existing, readErr := readProfileFileOrEmpty(path)
 		if readErr != nil {
 			return false, nil, readErr
 		}
 
-		content := filemerge.UpsertTopLevelTOMLString(existing, "model_reasoning_effort", p.reasoningEffort)
+		// Write model first, then model_reasoning_effort. Each UpsertTopLevelTOMLString
+		// call is idempotent: existing value unchanged = no re-write.
+		content := filemerge.UpsertTopLevelTOMLString(existing, "model", a.Model)
+		content = filemerge.UpsertTopLevelTOMLString(content, "model_reasoning_effort", a.ReasoningEffort)
 
 		writeResult, writeErr := filemerge.WriteFileAtomic(path, []byte(content), 0o644)
 		if writeErr != nil {

--- a/internal/agents/codex/profiles_test.go
+++ b/internal/agents/codex/profiles_test.go
@@ -7,31 +7,37 @@ import (
 	"testing"
 )
 
-// TestWriteCodexProfiles_Written asserts that WriteCodexProfiles creates the
-// three gentle-ai SDD profile files in the given Codex home directory, each
-// containing a non-empty model_reasoning_effort key.
-func TestWriteCodexProfiles_Written(t *testing.T) {
+// TestWriteCodexProfiles_WritesModelAndEffort asserts that WriteCodexProfiles
+// creates the three gentle-ai SDD profile files, each containing BOTH model
+// and model_reasoning_effort TOML keys.
+func TestWriteCodexProfiles_WritesModelAndEffort(t *testing.T) {
 	dir := t.TempDir()
 
-	changed, files, err := WriteCodexProfiles(dir)
+	assignments := []ProfileAssignment{
+		{Profile: "sdd-strong", Model: "gpt-5.5", ReasoningEffort: "xhigh"},
+		{Profile: "sdd-mid", Model: "gpt-5.5", ReasoningEffort: "high"},
+		{Profile: "sdd-cheap", Model: "gpt-5.4-mini", ReasoningEffort: "low"},
+	}
+
+	changed, files, err := WriteCodexProfiles(dir, assignments)
 	if err != nil {
 		t.Fatalf("WriteCodexProfiles() error = %v", err)
 	}
 	if !changed {
 		t.Fatal("WriteCodexProfiles() changed = false, want true on first write")
 	}
+	if len(files) != 3 {
+		t.Fatalf("WriteCodexProfiles() returned %d files, want 3", len(files))
+	}
 
 	expected := []struct {
 		name            string
+		model           string
 		reasoningEffort string
 	}{
-		{"sdd-strong.config.toml", "xhigh"},
-		{"sdd-mid.config.toml", "high"},
-		{"sdd-cheap.config.toml", "low"},
-	}
-
-	if len(files) != len(expected) {
-		t.Fatalf("WriteCodexProfiles() returned %d files, want %d", len(files), len(expected))
+		{"sdd-strong.config.toml", "gpt-5.5", "xhigh"},
+		{"sdd-mid.config.toml", "gpt-5.5", "high"},
+		{"sdd-cheap.config.toml", "gpt-5.4-mini", "low"},
 	}
 
 	for _, tc := range expected {
@@ -43,24 +49,77 @@ func TestWriteCodexProfiles_Written(t *testing.T) {
 		if !strings.Contains(string(content), `model_reasoning_effort`) {
 			t.Fatalf("profile %q missing model_reasoning_effort key; got:\n%s", tc.name, content)
 		}
-		want := `"` + tc.reasoningEffort + `"`
-		if !strings.Contains(string(content), want) {
-			t.Fatalf("profile %q: want model_reasoning_effort = %s; got:\n%s", tc.name, want, content)
+		wantEffort := `"` + tc.reasoningEffort + `"`
+		if !strings.Contains(string(content), wantEffort) {
+			t.Fatalf("profile %q: want model_reasoning_effort = %s; got:\n%s", tc.name, wantEffort, content)
+		}
+		if !strings.Contains(string(content), `model = `) {
+			t.Fatalf("profile %q missing model key; got:\n%s", tc.name, content)
+		}
+		wantModel := `"` + tc.model + `"`
+		if !strings.Contains(string(content), wantModel) {
+			t.Fatalf("profile %q: want model = %s; got:\n%s", tc.name, wantModel, content)
 		}
 	}
 }
 
+// TestWriteCodexProfiles_DefaultFallback asserts that nil assignments use
+// canonical Recommended defaults: sdd-strong=high, sdd-mid=medium, sdd-cheap=low.
+func TestWriteCodexProfiles_DefaultFallback(t *testing.T) {
+	dir := t.TempDir()
+
+	changed, _, err := WriteCodexProfiles(dir, nil)
+	if err != nil {
+		t.Fatalf("WriteCodexProfiles(nil) error = %v", err)
+	}
+	if !changed {
+		t.Fatal("WriteCodexProfiles(nil) changed = false, want true on first write")
+	}
+
+	// sdd-strong must have gpt-5.5 and effort=high (Recommended default)
+	strong, _ := os.ReadFile(filepath.Join(dir, "sdd-strong.config.toml"))
+	if !strings.Contains(string(strong), `"gpt-5.5"`) {
+		t.Errorf("sdd-strong default model: want gpt-5.5; got:\n%s", strong)
+	}
+	if !strings.Contains(string(strong), `"high"`) {
+		t.Errorf("sdd-strong default effort: want high; got:\n%s", strong)
+	}
+	// sdd-mid must have gpt-5.5 and effort=medium (Recommended default)
+	mid, _ := os.ReadFile(filepath.Join(dir, "sdd-mid.config.toml"))
+	if !strings.Contains(string(mid), `"gpt-5.5"`) {
+		t.Errorf("sdd-mid default model: want gpt-5.5; got:\n%s", mid)
+	}
+	if !strings.Contains(string(mid), `"medium"`) {
+		t.Errorf("sdd-mid default effort: want medium; got:\n%s", mid)
+	}
+	// sdd-cheap must have gpt-5.4-mini and effort=low (Recommended default)
+	cheap, _ := os.ReadFile(filepath.Join(dir, "sdd-cheap.config.toml"))
+	if !strings.Contains(string(cheap), `"gpt-5.4-mini"`) {
+		t.Errorf("sdd-cheap default model: want gpt-5.4-mini; got:\n%s", cheap)
+	}
+	if !strings.Contains(string(cheap), `"low"`) {
+		t.Errorf("sdd-cheap default effort: want low; got:\n%s", cheap)
+	}
+}
+
 // TestWriteCodexProfiles_Idempotent asserts that running WriteCodexProfiles
-// twice produces no change on the second run and does not duplicate keys.
+// twice with the same assignments produces no change on the second run and
+// does not duplicate keys.
 func TestWriteCodexProfiles_Idempotent(t *testing.T) {
 	dir := t.TempDir()
 
-	_, _, err := WriteCodexProfiles(dir)
+	assignments := []ProfileAssignment{
+		{Profile: "sdd-strong", Model: "gpt-5.5", ReasoningEffort: "high"},
+		{Profile: "sdd-mid", Model: "gpt-5.5", ReasoningEffort: "medium"},
+		{Profile: "sdd-cheap", Model: "gpt-5.4-mini", ReasoningEffort: "low"},
+	}
+
+	_, _, err := WriteCodexProfiles(dir, assignments)
 	if err != nil {
 		t.Fatalf("first WriteCodexProfiles() error = %v", err)
 	}
 
-	changed, _, err := WriteCodexProfiles(dir)
+	changed, _, err := WriteCodexProfiles(dir, assignments)
 	if err != nil {
 		t.Fatalf("second WriteCodexProfiles() error = %v", err)
 	}
@@ -68,27 +127,34 @@ func TestWriteCodexProfiles_Idempotent(t *testing.T) {
 		t.Fatal("WriteCodexProfiles() changed = true on second run, want false (idempotent)")
 	}
 
-	// Verify no duplicate keys by checking the count.
+	// Verify no duplicate keys.
 	for _, name := range []string{"sdd-strong.config.toml", "sdd-mid.config.toml", "sdd-cheap.config.toml"} {
 		content, readErr := os.ReadFile(filepath.Join(dir, name))
 		if readErr != nil {
 			t.Fatalf("profile %q missing after second run: %v", name, readErr)
 		}
-		count := strings.Count(string(content), "model_reasoning_effort")
-		if count != 1 {
-			t.Fatalf("profile %q: expected 1 model_reasoning_effort key, got %d; content:\n%s", name, count, content)
+		countEffort := strings.Count(string(content), "model_reasoning_effort")
+		if countEffort != 1 {
+			t.Fatalf("profile %q: expected 1 model_reasoning_effort key, got %d; content:\n%s", name, countEffort, content)
+		}
+		countModel := strings.Count(string(content), `model = `)
+		if countModel != 1 {
+			t.Fatalf("profile %q: expected 1 model key, got %d; content:\n%s", name, countModel, content)
 		}
 	}
 }
 
-// TestWriteCodexProfiles_ReturnsAllThreePaths asserts that the returned files
-// slice contains paths for all three profile files.
-func TestWriteCodexProfiles_ReturnsAllThreePaths(t *testing.T) {
+// TestWriteCodexProfiles_ReturnsChangedPathsOnFirstWrite asserts that the
+// returned changed flag is true and files slice has all 3 paths on first write.
+func TestWriteCodexProfiles_ReturnsChangedPathsOnFirstWrite(t *testing.T) {
 	dir := t.TempDir()
 
-	_, files, err := WriteCodexProfiles(dir)
+	changed, files, err := WriteCodexProfiles(dir, nil)
 	if err != nil {
 		t.Fatalf("WriteCodexProfiles() error = %v", err)
+	}
+	if !changed {
+		t.Fatal("WriteCodexProfiles() changed = false on first write")
 	}
 
 	wantNames := []string{"sdd-strong.config.toml", "sdd-mid.config.toml", "sdd-cheap.config.toml"}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -373,12 +373,13 @@ func tuiExecute(
 		}
 		// Non-fatal: a state write failure must not break an otherwise successful install.
 		_ = state.Write(homeDir, state.InstallState{
-			InstalledAgents:        agentIDs,
-			ClaudeModelAssignments: claudeAliasesToStrings(selection.ClaudeModelAssignments),
-			KiroModelAssignments:   kiroAliasesToStrings(selection.KiroModelAssignments),
-			CodexModelAssignments:  codexEffortsToStrings(selection.CodexModelAssignments),
-			ModelAssignments:       modelAssignmentsToState(selection.ModelAssignments),
-			Persona:                string(selection.Persona),
+			InstalledAgents:             agentIDs,
+			ClaudeModelAssignments:      claudeAliasesToStrings(selection.ClaudeModelAssignments),
+			KiroModelAssignments:        kiroAliasesToStrings(selection.KiroModelAssignments),
+			CodexModelAssignments:       codexEffortsToStrings(selection.CodexModelAssignments),
+			CodexCarrilModelAssignments: selection.CodexCarrilModelAssignments,
+			ModelAssignments:            modelAssignmentsToState(selection.ModelAssignments),
+			Persona:                     string(selection.Persona),
 		})
 	}
 
@@ -488,6 +489,9 @@ func applyOverrides(selection *model.Selection, overrides *model.SyncOverrides) 
 	if overrides.CodexModelAssignments != nil {
 		selection.CodexModelAssignments = overrides.CodexModelAssignments
 	}
+	if overrides.CodexCarrilModelAssignments != nil {
+		selection.CodexCarrilModelAssignments = overrides.CodexCarrilModelAssignments
+	}
 	if overrides.SDDMode != "" {
 		selection.SDDMode = overrides.SDDMode
 	}
@@ -540,6 +544,13 @@ func loadPersistedAssignments(homeDir string, selection *model.Selection) {
 		}
 		selection.CodexModelAssignments = m
 	}
+	if len(selection.CodexCarrilModelAssignments) == 0 && len(s.CodexCarrilModelAssignments) > 0 {
+		m := make(map[string]string, len(s.CodexCarrilModelAssignments))
+		for k, v := range s.CodexCarrilModelAssignments {
+			m[k] = v
+		}
+		selection.CodexCarrilModelAssignments = m
+	}
 	if len(selection.ModelAssignments) == 0 && len(s.ModelAssignments) > 0 {
 		m := make(map[string]model.ModelAssignment, len(s.ModelAssignments))
 		for k, v := range s.ModelAssignments {
@@ -553,7 +564,7 @@ func loadPersistedAssignments(homeDir string, selection *model.Selection) {
 // state.json using a read-merge-write pattern so that other fields
 // (InstalledAgents) are not lost.
 func persistAssignments(homeDir string, selection model.Selection) {
-	if len(selection.ClaudeModelAssignments) == 0 && len(selection.KiroModelAssignments) == 0 && len(selection.ModelAssignments) == 0 && len(selection.CodexModelAssignments) == 0 {
+	if len(selection.ClaudeModelAssignments) == 0 && len(selection.KiroModelAssignments) == 0 && len(selection.ModelAssignments) == 0 && len(selection.CodexModelAssignments) == 0 && len(selection.CodexCarrilModelAssignments) == 0 {
 		return
 	}
 	current, err := state.Read(homeDir)
@@ -569,6 +580,9 @@ func persistAssignments(homeDir string, selection model.Selection) {
 	}
 	if len(selection.CodexModelAssignments) > 0 {
 		current.CodexModelAssignments = codexEffortsToStrings(selection.CodexModelAssignments)
+	}
+	if len(selection.CodexCarrilModelAssignments) > 0 {
+		current.CodexCarrilModelAssignments = selection.CodexCarrilModelAssignments
 	}
 	if len(selection.ModelAssignments) > 0 {
 		current.ModelAssignments = modelAssignmentsToState(selection.ModelAssignments)

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -972,6 +972,83 @@ func TestPersistAssignments_Codex(t *testing.T) {
 	}
 }
 
+// ─── Carril model assignment tests (W-3 fix) ─────────────────────────────────
+
+// TestApplyOverrides_CodexCarrilModelAssignments verifies that a non-nil
+// CodexCarrilModelAssignments override sets the selection.
+func TestApplyOverrides_CodexCarrilModelAssignments(t *testing.T) {
+	sel := model.Selection{}
+	carrilModels := model.DefaultCarrilModels()
+	overrides := &model.SyncOverrides{
+		CodexCarrilModelAssignments: carrilModels,
+	}
+	applyOverrides(&sel, overrides)
+	if len(sel.CodexCarrilModelAssignments) != len(carrilModels) {
+		t.Fatalf("CodexCarrilModelAssignments len = %d, want %d", len(sel.CodexCarrilModelAssignments), len(carrilModels))
+	}
+	if sel.CodexCarrilModelAssignments["sdd-cheap"] != "gpt-5.4-mini" {
+		t.Errorf("CodexCarrilModelAssignments[sdd-cheap] = %q, want gpt-5.4-mini", sel.CodexCarrilModelAssignments["sdd-cheap"])
+	}
+	if sel.CodexCarrilModelAssignments["sdd-strong"] != "gpt-5.5" {
+		t.Errorf("CodexCarrilModelAssignments[sdd-strong] = %q, want gpt-5.5", sel.CodexCarrilModelAssignments["sdd-strong"])
+	}
+}
+
+// TestLoadPersistedAssignments_CodexCarrilModels verifies that state with
+// codexCarrilModelAssignments populates selection.CodexCarrilModelAssignments.
+func TestLoadPersistedAssignments_CodexCarrilModels(t *testing.T) {
+	home := t.TempDir()
+	if err := state.Write(home, state.InstallState{
+		InstalledAgents: []string{"codex"},
+		CodexCarrilModelAssignments: map[string]string{
+			"sdd-strong": "gpt-5.5",
+			"sdd-mid":    "gpt-5.5",
+			"sdd-cheap":  "gpt-5.4-mini",
+		},
+	}); err != nil {
+		t.Fatalf("state.Write: %v", err)
+	}
+
+	sel := model.Selection{}
+	loadPersistedAssignments(home, &sel)
+
+	if sel.CodexCarrilModelAssignments["sdd-cheap"] != "gpt-5.4-mini" {
+		t.Errorf("CodexCarrilModelAssignments[sdd-cheap] = %q, want gpt-5.4-mini", sel.CodexCarrilModelAssignments["sdd-cheap"])
+	}
+	if sel.CodexCarrilModelAssignments["sdd-strong"] != "gpt-5.5" {
+		t.Errorf("CodexCarrilModelAssignments[sdd-strong] = %q, want gpt-5.5", sel.CodexCarrilModelAssignments["sdd-strong"])
+	}
+}
+
+// TestPersistAssignments_CodexCarrilModels verifies that non-empty
+// CodexCarrilModelAssignments are persisted to state.json.
+func TestPersistAssignments_CodexCarrilModels(t *testing.T) {
+	home := t.TempDir()
+	if err := state.Write(home, state.InstallState{InstalledAgents: []string{"codex"}}); err != nil {
+		t.Fatalf("state.Write: %v", err)
+	}
+
+	sel := model.Selection{
+		CodexCarrilModelAssignments: map[string]string{
+			"sdd-strong": "gpt-5.5",
+			"sdd-mid":    "gpt-5.5",
+			"sdd-cheap":  "gpt-5.4-mini",
+		},
+	}
+	persistAssignments(home, sel)
+
+	s, err := state.Read(home)
+	if err != nil {
+		t.Fatalf("state.Read: %v", err)
+	}
+	if s.CodexCarrilModelAssignments["sdd-cheap"] != "gpt-5.4-mini" {
+		t.Errorf("state.CodexCarrilModelAssignments[sdd-cheap] = %q, want gpt-5.4-mini", s.CodexCarrilModelAssignments["sdd-cheap"])
+	}
+	if s.CodexCarrilModelAssignments["sdd-strong"] != "gpt-5.5" {
+		t.Errorf("state.CodexCarrilModelAssignments[sdd-strong] = %q, want gpt-5.5", s.CodexCarrilModelAssignments["sdd-strong"])
+	}
+}
+
 func writeAppSDDStatusFile(t *testing.T, path string, content string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {

--- a/internal/assets/codex/sdd-orchestrator.md
+++ b/internal/assets/codex/sdd-orchestrator.md
@@ -286,7 +286,7 @@ Each phase returns: `status`, `executive_summary`, `artifacts`, `next_recommende
 
 ## Model Profiles
 
-gentle-ai writes three SDD model-selection profile files into `~/.codex/` during installation. Each profile sets `model_reasoning_effort` so Codex picks the right tier — no hardcoded model IDs.
+gentle-ai writes three SDD model-selection profile files into `~/.codex/` during installation. Each profile pins both a `model` and a `model_reasoning_effort` so Codex picks the right tier for each carril.
 
 These profile files apply to whole CLI sessions: `codex --profile <name> "<prompt>"`. They do NOT apply to spawned sub-agents. When delegating a phase via `spawn_agent`, pass the tier's effort directly as `reasoning_effort` (with `fork_turns: "none"`), using the same tier values below.
 

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -593,12 +593,16 @@ func (s componentApplyStep) Run() error {
 					attemptedSlugs[slug] = struct{}{}
 				}
 			}
+			engramOpts := engram.InjectOptions{
+				CodexCarrilModelAssignments: s.selection.CodexCarrilModelAssignments,
+				CodexModelAssignments:       s.selection.CodexModelAssignments,
+			}
 			var err error
 			if adapter.Agent() == model.AgentOpenClaw {
 				_, err = engram.InjectWithPromptDir(s.homeDir, s.workspaceDir, adapter)
 			} else {
 				targetDir := componentInjectionDirScoped(s.homeDir, s.workspaceDir, s.scope, adapter)
-				_, err = engram.Inject(targetDir, adapter)
+				_, err = engram.InjectWithOptions(targetDir, adapter, engramOpts)
 			}
 			if err != nil {
 				return fmt.Errorf("inject engram for %q: %w", adapter.Agent(), err)
@@ -631,12 +635,13 @@ func (s componentApplyStep) Run() error {
 		for _, adapter := range adapters {
 			targetDir := componentInjectionDirScoped(s.homeDir, s.workspaceDir, s.scope, adapter)
 			opts := sdd.InjectOptions{
-				OpenCodeModelAssignments: s.selection.ModelAssignments,
-				ClaudeModelAssignments:   s.selection.ClaudeModelAssignments,
-				KiroModelAssignments:     s.selection.KiroModelAssignments,
-				CodexModelAssignments:    s.selection.CodexModelAssignments,
-				WorkspaceDir:             s.workspaceDir,
-				StrictTDD:                s.selection.StrictTDD,
+				OpenCodeModelAssignments:    s.selection.ModelAssignments,
+				ClaudeModelAssignments:      s.selection.ClaudeModelAssignments,
+				KiroModelAssignments:        s.selection.KiroModelAssignments,
+				CodexModelAssignments:       s.selection.CodexModelAssignments,
+				CodexCarrilModelAssignments: s.selection.CodexCarrilModelAssignments,
+				WorkspaceDir:                s.workspaceDir,
+				StrictTDD:                   s.selection.StrictTDD,
 			}
 			if _, err := sdd.Inject(targetDir, adapter, s.selection.SDDMode, opts); err != nil {
 				return fmt.Errorf("inject sdd for %q: %w", adapter.Agent(), err)

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -567,6 +567,10 @@ func (s componentSyncStep) Run() error {
 	case model.ComponentEngram:
 		// Sync: inject MCP config + system prompt protocol only.
 		// NO binary install. NO engram setup.
+		engramOpts := engram.InjectOptions{
+			CodexCarrilModelAssignments: s.selection.CodexCarrilModelAssignments,
+			CodexModelAssignments:       s.selection.CodexModelAssignments,
+		}
 		for _, adapter := range adapters {
 			var res engram.InjectionResult
 			var err error
@@ -574,7 +578,7 @@ func (s componentSyncStep) Run() error {
 				res, err = engram.InjectWithPromptDir(s.homeDir, s.workspaceDir, adapter)
 			} else {
 				targetDir := componentInjectionDir(s.homeDir, s.workspaceDir, adapter)
-				res, err = engram.Inject(targetDir, adapter)
+				res, err = engram.InjectWithOptions(targetDir, adapter, engramOpts)
 			}
 			if err != nil {
 				return fmt.Errorf("sync engram for %q: %w", adapter.Agent(), err)
@@ -635,6 +639,7 @@ func (s componentSyncStep) Run() error {
 				ClaudeModelAssignments:             s.selection.ClaudeModelAssignments,
 				KiroModelAssignments:               s.selection.KiroModelAssignments,
 				CodexModelAssignments:              s.selection.CodexModelAssignments,
+				CodexCarrilModelAssignments:        s.selection.CodexCarrilModelAssignments,
 				WorkspaceDir:                       s.workspaceDir,
 				StrictTDD:                          s.selection.StrictTDD,
 				PreserveOpenCodeOrchestratorPrompt: profileStrategy == model.SDDProfileStrategyExternalSingleActive,
@@ -923,6 +928,24 @@ func RunSync(args []string) (SyncResult, error) {
 			m[k] = model.ModelAssignment{ProviderID: v.ProviderID, ModelID: v.ModelID, Effort: v.Effort}
 		}
 		selection.ModelAssignments = m
+	}
+	// Restore Codex effort and carril model assignments from state so that
+	// `gentle-ai sync` preserves the user's per-phase effort and per-carril
+	// model choices instead of falling back to canonical defaults every time.
+	// This mirrors the TUI path (loadPersistedAssignments in app.go).
+	if len(selection.CodexModelAssignments) == 0 && len(persistedState.CodexModelAssignments) > 0 {
+		m := make(map[string]model.CodexEffort, len(persistedState.CodexModelAssignments))
+		for k, v := range persistedState.CodexModelAssignments {
+			m[k] = model.CodexEffort(v)
+		}
+		selection.CodexModelAssignments = m
+	}
+	if len(selection.CodexCarrilModelAssignments) == 0 && len(persistedState.CodexCarrilModelAssignments) > 0 {
+		m := make(map[string]string, len(persistedState.CodexCarrilModelAssignments))
+		for k, v := range persistedState.CodexCarrilModelAssignments {
+			m[k] = v
+		}
+		selection.CodexCarrilModelAssignments = m
 	}
 
 	// Resolve persona from the already-read state. This covers both the dry-run

--- a/internal/cli/sync_test.go
+++ b/internal/cli/sync_test.go
@@ -2756,3 +2756,104 @@ func TestDedupPathsFiltersEmptyStrings(t *testing.T) {
 		}
 	}
 }
+
+// ─── WU-3 RED: RunSync restores CodexCarrilModelAssignments ──────────────────
+
+// setupCodexSyncHome creates a temp home with a state.json containing the codex
+// agent and the provided carril model map, returning the home directory.
+func setupCodexSyncHome(t *testing.T, carrilModels map[string]string, effortAssignments map[string]string) string {
+	t.Helper()
+	home := t.TempDir()
+	s := state.InstallState{
+		InstalledAgents:             []string{"codex"},
+		CodexModelAssignments:       effortAssignments,
+		CodexCarrilModelAssignments: carrilModels,
+	}
+	if err := state.Write(home, s); err != nil {
+		t.Fatalf("state.Write() error = %v", err)
+	}
+	return home
+}
+
+// TestRunSync_RestoresCodexCarrilAssignments verifies that RunSync reads
+// CodexCarrilModelAssignments from state.json and uses them when writing
+// Codex profile files (model key present).
+func TestRunSync_RestoresCodexCarrilAssignments(t *testing.T) {
+	home := setupCodexSyncHome(t,
+		map[string]string{"sdd-strong": "gpt-5.5", "sdd-mid": "gpt-5.5", "sdd-cheap": "gpt-5.4-mini"},
+		nil,
+	)
+
+	restoreHome := osUserHomeDir
+	restoreCommand := runCommand
+	restoreLookPath := cmdLookPath
+	t.Cleanup(func() {
+		osUserHomeDir = restoreHome
+		runCommand = restoreCommand
+		cmdLookPath = restoreLookPath
+	})
+
+	osUserHomeDir = func() (string, error) { return home, nil }
+	runCommand = func(string, ...string) error { return nil }
+	cmdLookPath = func(name string) (string, error) { return "/usr/local/bin/" + name, nil }
+
+	_, err := RunSync([]string{"--agents", "codex"})
+	if err != nil {
+		t.Fatalf("RunSync() error = %v", err)
+	}
+
+	// The sdd-strong.config.toml profile must have both model and model_reasoning_effort.
+	strongProfile := filepath.Join(home, ".codex", "sdd-strong.config.toml")
+	content, readErr := os.ReadFile(strongProfile)
+	if readErr != nil {
+		t.Fatalf("ReadFile(%q) error = %v", strongProfile, readErr)
+	}
+	if !strings.Contains(string(content), `model`) {
+		t.Errorf("sdd-strong.config.toml missing model key; got:\n%s", content)
+	}
+	if !strings.Contains(string(content), "gpt-5.5") {
+		t.Errorf("sdd-strong.config.toml: expected gpt-5.5; got:\n%s", content)
+	}
+}
+
+// TestRunSync_RestoresCodexEffortAssignments verifies that RunSync reads
+// CodexModelAssignments (phase→effort) from state.json and writes them to
+// profile files.
+func TestRunSync_RestoresCodexEffortAssignments(t *testing.T) {
+	efforts := map[string]string{
+		"sdd-propose": "xhigh", "sdd-design": "xhigh", "sdd-verify": "xhigh",
+		"jd-judge-a": "xhigh", "jd-judge-b": "xhigh", "default": "xhigh",
+		"sdd-apply": "high", "jd-fix-agent": "high",
+		"sdd-explore": "low", "sdd-spec": "low", "sdd-tasks": "low",
+		"sdd-archive": "low", "sdd-onboard": "low",
+	}
+	home := setupCodexSyncHome(t, nil, efforts)
+
+	restoreHome := osUserHomeDir
+	restoreCommand := runCommand
+	restoreLookPath := cmdLookPath
+	t.Cleanup(func() {
+		osUserHomeDir = restoreHome
+		runCommand = restoreCommand
+		cmdLookPath = restoreLookPath
+	})
+
+	osUserHomeDir = func() (string, error) { return home, nil }
+	runCommand = func(string, ...string) error { return nil }
+	cmdLookPath = func(name string) (string, error) { return "/usr/local/bin/" + name, nil }
+
+	_, err := RunSync([]string{"--agents", "codex"})
+	if err != nil {
+		t.Fatalf("RunSync() error = %v", err)
+	}
+
+	// sdd-strong profile should have xhigh.
+	strongProfile := filepath.Join(home, ".codex", "sdd-strong.config.toml")
+	content, readErr := os.ReadFile(strongProfile)
+	if readErr != nil {
+		t.Fatalf("ReadFile(%q) error = %v", strongProfile, readErr)
+	}
+	if !strings.Contains(string(content), "xhigh") {
+		t.Errorf("sdd-strong.config.toml: expected xhigh effort; got:\n%s", content)
+	}
+}

--- a/internal/components/engram/inject.go
+++ b/internal/components/engram/inject.go
@@ -174,6 +174,16 @@ type InjectOptions struct {
 	// is the safe no-op value for the experimental Codex multi-agent tool set.
 	// Set to true only when the user explicitly opts in via a CLI flag or TUI choice.
 	CodexMultiAgent bool
+
+	// CodexCarrilModelAssignments holds the resolved carril→model-id map used
+	// when writing SDD profile .config.toml files. nil/empty = use canonical
+	// defaults (sdd-strong/sdd-mid=gpt-5.5, sdd-cheap=gpt-5.4-mini).
+	CodexCarrilModelAssignments map[string]string
+
+	// CodexModelAssignments holds the resolved phase→effort map used to derive
+	// the per-carril reasoning_effort written to SDD profile files.
+	// nil/empty = use canonical defaults.
+	CodexModelAssignments map[string]model.CodexEffort
 }
 
 func Inject(homeDir string, adapter agents.Adapter) (InjectionResult, error) {
@@ -447,7 +457,8 @@ func injectWithOptions(configHomeDir, promptDir string, adapter agents.Adapter, 
 		// selected at runtime via `codex --profile <name>`.
 		// codexHomeDir is the ~/.codex directory (the parent of config.toml).
 		codexHomeDir := filepath.Dir(configPath)
-		profilesChanged, profileFiles, profileErr := codex.WriteCodexProfiles(codexHomeDir)
+		profileAssignments := resolveProfileAssignments(opts.CodexCarrilModelAssignments, opts.CodexModelAssignments)
+		profilesChanged, profileFiles, profileErr := codex.WriteCodexProfiles(codexHomeDir, profileAssignments)
 		if profileErr != nil {
 			return InjectionResult{}, profileErr
 		}
@@ -825,4 +836,60 @@ func isVersionedHomebrewCellarPath(path string) bool {
 func isStableHomebrewEngramPath(path string) bool {
 	clean := filepath.ToSlash(filepath.Clean(path))
 	return (clean == "/opt/homebrew/bin/engram" || clean == "/usr/local/bin/engram") && isEngramCommand(clean)
+}
+
+// resolveProfileAssignments builds the []codex.ProfileAssignment slice used
+// to write the three SDD profile .config.toml files. The carril→model map and
+// the phase→effort map are resolved independently (they live on different axes)
+// so either can be nil and the other still takes effect.
+//
+//   - nil carrilModels → model for each carril falls back to model.DefaultCarrilModels.
+//   - nil phaseEfforts → effort for each carril falls back to the carril's canonical
+//     DefaultEffort from model.CodexTierGroups (Recommended preset values).
+//
+// Single source of truth: tier definitions (phases, default effort, default model)
+// are read from model.CodexTierGroups instead of a duplicate local table.
+func resolveProfileAssignments(carrilModels map[string]string, phaseEfforts map[string]model.CodexEffort) []codex.ProfileAssignment {
+	tiers := model.CodexTierGroups()
+
+	effortRank := map[model.CodexEffort]int{
+		model.CodexEffortLow:    0,
+		model.CodexEffortMedium: 1,
+		model.CodexEffortHigh:   2,
+		model.CodexEffortXHigh:  3,
+	}
+
+	out := make([]codex.ProfileAssignment, 0, len(tiers))
+	for _, t := range tiers {
+		// Resolve model: carrilModels override, fall back to canonical default.
+		mdl := t.Model
+		if v, ok := carrilModels[t.Profile]; ok && v != "" {
+			mdl = v
+		}
+
+		// Resolve effort: max over assigned phases, fall back to carril's DefaultEffort.
+		eff := t.DefaultEffort
+		if len(phaseEfforts) > 0 {
+			best := model.CodexEffort("")
+			bestRank := -1
+			for _, phase := range t.Phases {
+				if e, ok := phaseEfforts[phase]; ok {
+					if r, ok2 := effortRank[e]; ok2 && r > bestRank {
+						bestRank = r
+						best = e
+					}
+				}
+			}
+			if best != "" {
+				eff = best
+			}
+		}
+
+		out = append(out, codex.ProfileAssignment{
+			Profile:         t.Profile,
+			Model:           mdl,
+			ReasoningEffort: string(eff),
+		})
+	}
+	return out
 }

--- a/internal/components/engram/inject_test.go
+++ b/internal/components/engram/inject_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/gentleman-programming/gentle-ai/internal/agents/pi"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/qwen"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/vscode"
+	"github.com/gentleman-programming/gentle-ai/internal/model"
 )
 
 func claudeAdapter() agents.Adapter   { return claude.NewAdapter() }
@@ -975,8 +976,8 @@ func TestInjectCodexWritesProfiles(t *testing.T) {
 		name            string
 		reasoningEffort string
 	}{
-		{"sdd-strong.config.toml", "xhigh"},
-		{"sdd-mid.config.toml", "high"},
+		{"sdd-strong.config.toml", "high"},
+		{"sdd-mid.config.toml", "medium"},
 		{"sdd-cheap.config.toml", "low"},
 	}
 
@@ -1017,6 +1018,60 @@ func TestInjectCodexProfilesIdempotent(t *testing.T) {
 		count := strings.Count(string(content), "model_reasoning_effort")
 		if count != 1 {
 			t.Fatalf("profile %q: expected 1 model_reasoning_effort key after second Inject, got %d; content:\n%s", name, count, string(content))
+		}
+	}
+}
+
+// TestProfileFallbackAgreesWithRenderFallback asserts that resolveProfileAssignments
+// with nil inputs produces the same per-carril effort as RenderCodexPhaseEfforts with
+// nil inputs (both must use the Recommended preset as the canonical nil fallback).
+func TestProfileFallbackAgreesWithRenderFallback(t *testing.T) {
+	// Profile fallback: nil carrilModels + nil phaseEfforts
+	assignments := resolveProfileAssignments(nil, nil)
+
+	// Build a quick carril→effort map from the profile assignments.
+	profileEffort := make(map[string]string, len(assignments))
+	for _, a := range assignments {
+		profileEffort[a.Profile] = a.ReasoningEffort
+	}
+
+	// Render fallback: nil inputs → CodexModelPresetRecommended
+	renderOut := model.RenderCodexPhaseEfforts(nil, nil)
+
+	// For each carril, the render table and the profile files must agree.
+	// The render check is per-row: we find the carril's row and assert the effort
+	// cell appears within that specific row (not just anywhere in the table).
+	cases := []struct {
+		carril     string
+		wantEffort string
+	}{
+		{"sdd-strong", "high"},
+		{"sdd-mid", "medium"},
+		{"sdd-cheap", "low"},
+	}
+	for _, tc := range cases {
+		got := profileEffort[tc.carril]
+		if got != tc.wantEffort {
+			t.Errorf("profile fallback for %q = %q, want %q", tc.carril, got, tc.wantEffort)
+		}
+		// Render-side: find the carril's row and check the effort cell is in THAT row.
+		needle := "| `" + tc.carril + "`"
+		rowStart := strings.Index(renderOut, needle)
+		if rowStart == -1 {
+			t.Errorf("render fallback table missing row for carril %q; table:\n%s", tc.carril, renderOut)
+			continue
+		}
+		rowEnd := len(renderOut)
+		for i := rowStart + 1; i < len(renderOut); i++ {
+			if renderOut[i] == '\n' {
+				rowEnd = i
+				break
+			}
+		}
+		row := renderOut[rowStart:rowEnd]
+		effortCell := "| `" + tc.wantEffort + "` |"
+		if !strings.Contains(row, effortCell) {
+			t.Errorf("render fallback carril %q row = %q: want effort cell %q", tc.carril, row, effortCell)
 		}
 	}
 }

--- a/internal/components/sdd/inject.go
+++ b/internal/components/sdd/inject.go
@@ -22,10 +22,11 @@ type InjectionResult struct {
 }
 
 type InjectOptions struct {
-	OpenCodeModelAssignments map[string]model.ModelAssignment
-	ClaudeModelAssignments   map[string]model.ClaudeModelAlias
-	KiroModelAssignments     map[string]model.KiroModelAlias
-	CodexModelAssignments    map[string]model.CodexEffort
+	OpenCodeModelAssignments    map[string]model.ModelAssignment
+	ClaudeModelAssignments      map[string]model.ClaudeModelAlias
+	KiroModelAssignments        map[string]model.KiroModelAlias
+	CodexModelAssignments       map[string]model.CodexEffort
+	CodexCarrilModelAssignments map[string]string // carril→model-id; nil = use defaults
 
 	// WorkspaceDir is the root of the current workspace (e.g. os.Getwd()).
 	// When non-empty and the adapter implements workflowInjector, native
@@ -92,13 +93,13 @@ type claudeModelResolver interface {
 
 // codexModelResolver is an optional adapter capability. When implemented,
 // injectFileAppend will replace the {{CODEX_PHASE_EFFORTS}} placeholder in the
-// Codex SDD orchestrator asset with a rendered per-phase effort table derived
-// from the CodexModelAssignments in InjectOptions.
+// Codex SDD orchestrator asset with a rendered per-phase effort+model table
+// derived from CodexModelAssignments and CodexCarrilModelAssignments in InjectOptions.
 //
 // Adapters that do NOT implement this interface are completely unaffected —
 // the substitution only fires when the adapter satisfies this interface.
 type codexModelResolver interface {
-	RenderCodexPhaseEfforts(assignments map[string]model.CodexEffort) string
+	RenderCodexPhaseEfforts(assignments map[string]model.CodexEffort, carrilModels map[string]string) string
 }
 
 // monorepoRootMarkers identify files/dirs that ONLY exist at the true root
@@ -1579,7 +1580,7 @@ func injectFileAppend(homeDir string, adapter agents.Adapter, opts InjectOptions
 	// effort table. Only fires when the adapter implements codexModelResolver.
 	// All other FileReplace adapters (Gemini, Cursor, etc.) are unaffected.
 	if cmr, ok := adapter.(codexModelResolver); ok {
-		rendered := cmr.RenderCodexPhaseEfforts(opts.CodexModelAssignments)
+		rendered := cmr.RenderCodexPhaseEfforts(opts.CodexModelAssignments, opts.CodexCarrilModelAssignments)
 		content = strings.ReplaceAll(content, "{{CODEX_PHASE_EFFORTS}}", rendered)
 		// Post-check: fail loudly if any placeholder token remains unresolved.
 		if strings.Contains(content, "{{") {

--- a/internal/components/sdd/inject_test.go
+++ b/internal/components/sdd/inject_test.go
@@ -5514,3 +5514,87 @@ func TestInject_NonCodexAdapterUnaffected(t *testing.T) {
 		})
 	}
 }
+
+// ─── WU-3 RED: InjectOptions.CodexCarrilModelAssignments threading ───────────
+
+// TestInjectCodexWithCarrilModels verifies that InjectOptions.CodexCarrilModelAssignments
+// is threaded into the rendered AGENTS.md Model column.
+func TestInjectCodexWithCarrilModels(t *testing.T) {
+	home := t.TempDir()
+	adapter := codexInjectAdapter()
+
+	carrilModels := map[string]string{
+		"sdd-strong": "gpt-5.5",
+		"sdd-mid":    "gpt-5.5",
+		"sdd-cheap":  "gpt-5.4-mini",
+	}
+
+	_, err := Inject(home, adapter, "", InjectOptions{
+		CodexModelAssignments:       model.CodexModelPresetRecommended(),
+		CodexCarrilModelAssignments: carrilModels,
+	})
+	if err != nil {
+		t.Fatalf("Inject(codex, carrilModels) error = %v", err)
+	}
+
+	agentsMD, readErr := os.ReadFile(filepath.Join(home, ".codex", "AGENTS.md"))
+	if readErr != nil {
+		t.Fatalf("ReadFile(AGENTS.md) error = %v", readErr)
+	}
+	text := string(agentsMD)
+
+	// Table must have a Model column.
+	if !strings.Contains(text, "Model") {
+		t.Error("AGENTS.md missing Model column in phase-efforts table")
+	}
+	// gpt-5.5 and gpt-5.4-mini must appear in the table.
+	if !strings.Contains(text, "gpt-5.5") {
+		t.Error("AGENTS.md missing gpt-5.5 in phase-efforts table")
+	}
+	if !strings.Contains(text, "gpt-5.4-mini") {
+		t.Error("AGENTS.md missing gpt-5.4-mini in phase-efforts table")
+	}
+}
+
+// TestInjectCodexNilCarrilModels verifies that nil CodexCarrilModelAssignments
+// causes the render to use canonical defaults (gpt-5.5 / gpt-5.4-mini).
+func TestInjectCodexNilCarrilModels(t *testing.T) {
+	home := t.TempDir()
+	adapter := codexInjectAdapter()
+
+	_, err := Inject(home, adapter, "", InjectOptions{
+		CodexModelAssignments: model.CodexModelPresetRecommended(),
+		// CodexCarrilModelAssignments intentionally nil
+	})
+	if err != nil {
+		t.Fatalf("Inject(codex, nil carrilModels) error = %v", err)
+	}
+
+	agentsMD, readErr := os.ReadFile(filepath.Join(home, ".codex", "AGENTS.md"))
+	if readErr != nil {
+		t.Fatalf("ReadFile(AGENTS.md) error = %v", readErr)
+	}
+	text := string(agentsMD)
+
+	if !strings.Contains(text, "Model") {
+		t.Error("AGENTS.md missing Model column — nil carrilModels should fall back to defaults")
+	}
+	if !strings.Contains(text, "gpt-5.4-mini") {
+		t.Error("AGENTS.md missing gpt-5.4-mini — nil carrilModels should show sdd-cheap default")
+	}
+}
+
+// TestInjectNonCodexAdapterCarrilUnaffected verifies that non-Codex adapters
+// are completely unaffected by the new CodexCarrilModelAssignments field.
+func TestInjectNonCodexAdapterCarrilUnaffected(t *testing.T) {
+	home := t.TempDir()
+	// Use Claude adapter — it must not attempt to resolve carril models.
+	_, err := Inject(home, claudeAdapter(), "", InjectOptions{
+		CodexCarrilModelAssignments: map[string]string{
+			"sdd-strong": "gpt-5.5",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Inject(claude, carrilModels) should not error; got: %v", err)
+	}
+}

--- a/internal/model/codex_model.go
+++ b/internal/model/codex_model.go
@@ -26,102 +26,148 @@ func (e CodexEffort) Valid() bool {
 	}
 }
 
-// codexPhaseOrder defines the canonical order of phases used in render output.
-// These 13 keys match the claudePhases list (plus "default") from the TUI screens package.
-var codexPhaseOrder = []string{
-	"sdd-explore",
-	"sdd-propose",
-	"sdd-spec",
-	"sdd-design",
-	"sdd-tasks",
-	"sdd-apply",
-	"sdd-verify",
-	"sdd-archive",
-	"sdd-onboard",
-	"jd-judge-a",
-	"jd-judge-b",
-	"jd-fix-agent",
-	"default",
-}
-
 // CodexModelPresetRecommended returns the Recommended (ChatGPT Pro $100/mo) preset.
-// Balanced effort — high for key SDD phases, low for lightweight ones.
+// Carril-aligned effort: Razonamiento=high, Código=medium, Liviano=low.
+// Every phase within a carril carries the same effort so that maxEffort over the
+// carril's phases yields exactly the carril's intended tier.
 func CodexModelPresetRecommended() map[string]CodexEffort {
 	return map[string]CodexEffort{
-		"sdd-explore":  CodexEffortLow,
-		"sdd-propose":  CodexEffortHigh,
-		"sdd-spec":     CodexEffortMedium,
-		"sdd-design":   CodexEffortHigh,
-		"sdd-tasks":    CodexEffortHigh,
-		"sdd-apply":    CodexEffortHigh,
-		"sdd-verify":   CodexEffortHigh,
-		"sdd-archive":  CodexEffortLow,
-		"sdd-onboard":  CodexEffortLow,
-		"jd-judge-a":   CodexEffortHigh,
-		"jd-judge-b":   CodexEffortHigh,
+		// Razonamiento (sdd-strong): high
+		"sdd-propose": CodexEffortHigh,
+		"sdd-design":  CodexEffortHigh,
+		"sdd-verify":  CodexEffortHigh,
+		"jd-judge-a":  CodexEffortHigh,
+		"jd-judge-b":  CodexEffortHigh,
+		"default":     CodexEffortHigh,
+		// Código (sdd-mid): medium
+		"sdd-apply":    CodexEffortMedium,
 		"jd-fix-agent": CodexEffortMedium,
-		"default":      CodexEffortHigh,
+		// Liviano (sdd-cheap): low
+		"sdd-explore": CodexEffortLow,
+		"sdd-spec":    CodexEffortLow,
+		"sdd-tasks":   CodexEffortLow,
+		"sdd-archive": CodexEffortLow,
+		"sdd-onboard": CodexEffortLow,
 	}
 }
 
 // CodexModelPresetPowerful returns the Powerful (ChatGPT Pro $200/mo) preset.
-// xhigh effort for architecture-heavy and review-heavy phases.
+// Carril-aligned effort: Razonamiento=xhigh, Código=high, Liviano=low.
+// Every phase within a carril carries the same effort so that maxEffort over the
+// carril's phases yields exactly the carril's intended tier.
 func CodexModelPresetPowerful() map[string]CodexEffort {
 	return map[string]CodexEffort{
-		"sdd-explore":  CodexEffortMedium,
-		"sdd-propose":  CodexEffortXHigh,
-		"sdd-spec":     CodexEffortHigh,
-		"sdd-design":   CodexEffortXHigh,
-		"sdd-tasks":    CodexEffortHigh,
+		// Razonamiento (sdd-strong): xhigh
+		"sdd-propose": CodexEffortXHigh,
+		"sdd-design":  CodexEffortXHigh,
+		"sdd-verify":  CodexEffortXHigh,
+		"jd-judge-a":  CodexEffortXHigh,
+		"jd-judge-b":  CodexEffortXHigh,
+		"default":     CodexEffortXHigh,
+		// Código (sdd-mid): high
 		"sdd-apply":    CodexEffortHigh,
-		"sdd-verify":   CodexEffortXHigh,
-		"sdd-archive":  CodexEffortLow,
-		"sdd-onboard":  CodexEffortLow,
-		"jd-judge-a":   CodexEffortXHigh,
-		"jd-judge-b":   CodexEffortXHigh,
 		"jd-fix-agent": CodexEffortHigh,
-		"default":      CodexEffortHigh,
+		// Liviano (sdd-cheap): low
+		"sdd-explore": CodexEffortLow,
+		"sdd-spec":    CodexEffortLow,
+		"sdd-tasks":   CodexEffortLow,
+		"sdd-archive": CodexEffortLow,
+		"sdd-onboard": CodexEffortLow,
 	}
 }
 
 // CodexModelPresetLowCost returns the Low-cost (ChatGPT Plus $20/mo) preset.
-// Minimal effort to stay within tight Plus plan limits.
+// Carril-aligned effort: Razonamiento=medium, Código=medium, Liviano=low.
+// Every phase within a carril carries the same effort so that maxEffort over the
+// carril's phases yields exactly the carril's intended tier.
 func CodexModelPresetLowCost() map[string]CodexEffort {
 	return map[string]CodexEffort{
-		"sdd-explore":  CodexEffortLow,
-		"sdd-propose":  CodexEffortMedium,
-		"sdd-spec":     CodexEffortLow,
-		"sdd-design":   CodexEffortMedium,
-		"sdd-tasks":    CodexEffortLow,
+		// Razonamiento (sdd-strong): medium
+		"sdd-propose": CodexEffortMedium,
+		"sdd-design":  CodexEffortMedium,
+		"sdd-verify":  CodexEffortMedium,
+		"jd-judge-a":  CodexEffortMedium,
+		"jd-judge-b":  CodexEffortMedium,
+		"default":     CodexEffortMedium,
+		// Código (sdd-mid): medium
 		"sdd-apply":    CodexEffortMedium,
-		"sdd-verify":   CodexEffortMedium,
-		"sdd-archive":  CodexEffortLow,
-		"sdd-onboard":  CodexEffortLow,
-		"jd-judge-a":   CodexEffortLow,
-		"jd-judge-b":   CodexEffortLow,
-		"jd-fix-agent": CodexEffortLow,
-		"default":      CodexEffortMedium,
+		"jd-fix-agent": CodexEffortMedium,
+		// Liviano (sdd-cheap): low
+		"sdd-explore": CodexEffortLow,
+		"sdd-spec":    CodexEffortLow,
+		"sdd-tasks":   CodexEffortLow,
+		"sdd-archive": CodexEffortLow,
+		"sdd-onboard": CodexEffortLow,
 	}
 }
 
+// CodexTierGroup defines one CLI profile tier: the profile filename (without
+// extension), the canonical default model id for that carril, the default
+// reasoning_effort tier, and the SDD phases covered.
+//
+// Phase groupings (Approach C — orthogonal carril axis):
+//   - sdd-strong (Razonamiento): propose, design, verify, judge-a, judge-b, default
+//   - sdd-mid    (Código):       apply, fix-agent
+//   - sdd-cheap  (Liviano):      explore, spec, tasks, archive, onboard
+type CodexTierGroup struct {
+	Profile       string
+	Model         string
+	DefaultEffort CodexEffort
+	Phases        []string
+}
+
 // codexTierGroups defines the three CLI profile tiers and which phases they cover.
-// The tier effort is derived by taking the maximum effort across phases in the group.
-var codexTierGroups = []struct {
-	profile string
-	phases  []string
-}{
+//
+// Invariant: within each carril, ALL phases carry the same effort value in every
+// preset constructor (CodexModelPresetLowCost, CodexModelPresetRecommended,
+// CodexModelPresetPowerful). This guarantees that maxEffort over a carril's phases
+// always yields the carril's intended effort tier — never an accidental max from a
+// stale per-phase value.
+//
+// DefaultEffort values match CodexModelPresetRecommended so that the nil-input
+// fallback in RenderCodexPhaseEfforts and the nil-input fallback in
+// resolveProfileAssignments agree on the same canonical tier values:
+//
+//	Carril      LowCost(+$20)  Recommended($100)  Powerful($200)
+//	sdd-strong  medium         high               xhigh
+//	sdd-mid     medium         medium             high
+//	sdd-cheap   low            low                low
+var codexTierGroups = []CodexTierGroup{
 	{
-		profile: "sdd-strong",
-		phases:  []string{"sdd-propose", "sdd-design", "sdd-verify", "jd-judge-a", "jd-judge-b"},
+		Profile:       "sdd-strong",
+		Model:         "gpt-5.5",
+		DefaultEffort: CodexEffortHigh,
+		Phases:        []string{"sdd-propose", "sdd-design", "sdd-verify", "jd-judge-a", "jd-judge-b", "default"},
 	},
 	{
-		profile: "sdd-mid",
-		phases:  []string{"sdd-spec", "sdd-tasks", "sdd-apply"},
+		Profile:       "sdd-mid",
+		Model:         "gpt-5.5",
+		DefaultEffort: CodexEffortMedium,
+		Phases:        []string{"sdd-apply", "jd-fix-agent"},
 	},
 	{
-		profile: "sdd-cheap",
-		phases:  []string{"sdd-explore", "sdd-archive", "sdd-onboard"},
+		Profile:       "sdd-cheap",
+		Model:         "gpt-5.4-mini",
+		DefaultEffort: CodexEffortLow,
+		Phases:        []string{"sdd-explore", "sdd-spec", "sdd-tasks", "sdd-archive", "sdd-onboard"},
 	},
+}
+
+// CodexTierGroups returns the canonical tier group definitions used by the
+// three SDD profile carriles. Callers (e.g. the inject layer) should derive
+// profile assignments from this slice rather than maintaining a separate table.
+func CodexTierGroups() []CodexTierGroup {
+	return codexTierGroups
+}
+
+// DefaultCarrilModels returns the canonical default model id for each carril.
+// Used when state.CodexCarrilModelAssignments is absent (old state files).
+func DefaultCarrilModels() map[string]string {
+	m := make(map[string]string, len(codexTierGroups))
+	for _, g := range codexTierGroups {
+		m[g.Profile] = g.Model
+	}
+	return m
 }
 
 // codexEffortRank maps effort levels to a numeric rank for max-derivation.
@@ -147,31 +193,40 @@ func maxEffort(assignments map[string]CodexEffort, phases []string) CodexEffort 
 }
 
 // RenderCodexPhaseEfforts renders the Model Profiles table for the Codex
-// sdd-orchestrator.md asset. The table maps CLI profile names to their
-// reasoning_effort tier and covered SDD phases. The output is deterministic:
+// sdd-orchestrator.md asset. The table maps CLI profile names to their model,
+// reasoning_effort tier, and covered SDD phases. The output is deterministic:
 // tier groups are always rendered in codexTierGroups order.
 //
 // When assignments is nil or empty, falls back to CodexModelPresetRecommended.
-func RenderCodexPhaseEfforts(assignments map[string]CodexEffort) string {
+// When carrilModels is nil or empty, falls back to DefaultCarrilModels.
+func RenderCodexPhaseEfforts(assignments map[string]CodexEffort, carrilModels map[string]string) string {
 	if len(assignments) == 0 {
 		assignments = CodexModelPresetRecommended()
+	}
+	if len(carrilModels) == 0 {
+		carrilModels = DefaultCarrilModels()
 	}
 
 	tierPhaseLabels := map[string]string{
 		"sdd-strong": "propose, design, verify, judge",
-		"sdd-mid":    "spec, tasks, apply",
-		"sdd-cheap":  "explore, archive, onboard",
+		"sdd-mid":    "apply, fix-agent",
+		"sdd-cheap":  "explore, spec, tasks, archive, onboard",
 	}
 
 	var sb strings.Builder
-	sb.WriteString("| Profile (CLI) | `reasoning_effort` (spawn_agent) | SDD phases |\n")
-	sb.WriteString("|---------------|----------------------------------|------------|\n")
+	sb.WriteString("| Profile (CLI) | Model | `reasoning_effort` (spawn_agent) | SDD phases |\n")
+	sb.WriteString("|---------------|-------|----------------------------------|------------|\n")
 
 	for _, tier := range codexTierGroups {
-		effort := maxEffort(assignments, tier.phases)
-		phases := tierPhaseLabels[tier.profile]
-		sb.WriteString(fmt.Sprintf("| `%s` | `%s` | %s |\n",
-			tier.profile,
+		effort := maxEffort(assignments, tier.Phases)
+		phases := tierPhaseLabels[tier.Profile]
+		modelID := carrilModels[tier.Profile]
+		if modelID == "" {
+			modelID = tier.Model
+		}
+		sb.WriteString(fmt.Sprintf("| `%s` | `%s` | `%s` | %s |\n",
+			tier.Profile,
+			modelID,
 			effort,
 			phases,
 		))

--- a/internal/model/codex_model_test.go
+++ b/internal/model/codex_model_test.go
@@ -1,6 +1,7 @@
 package model_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/gentleman-programming/gentle-ai/internal/model"
@@ -66,17 +67,17 @@ func TestCodexPresetsCoverAllPhases(t *testing.T) {
 
 func TestRenderCodexPhaseEfforts_Deterministic(t *testing.T) {
 	assignments := model.CodexModelPresetRecommended()
-	out1 := model.RenderCodexPhaseEfforts(assignments)
-	out2 := model.RenderCodexPhaseEfforts(assignments)
+	out1 := model.RenderCodexPhaseEfforts(assignments, nil)
+	out2 := model.RenderCodexPhaseEfforts(assignments, nil)
 	if out1 != out2 {
 		t.Error("RenderCodexPhaseEfforts() is not deterministic: two calls returned different results")
 	}
 }
 
 func TestRenderCodexPhaseEfforts_NilFallsBackToRecommended(t *testing.T) {
-	nilOut := model.RenderCodexPhaseEfforts(nil)
-	emptyOut := model.RenderCodexPhaseEfforts(map[string]model.CodexEffort{})
-	recommended := model.RenderCodexPhaseEfforts(model.CodexModelPresetRecommended())
+	nilOut := model.RenderCodexPhaseEfforts(nil, nil)
+	emptyOut := model.RenderCodexPhaseEfforts(map[string]model.CodexEffort{}, nil)
+	recommended := model.RenderCodexPhaseEfforts(model.CodexModelPresetRecommended(), nil)
 	if nilOut != recommended {
 		t.Error("RenderCodexPhaseEfforts(nil) should equal Recommended output")
 	}
@@ -86,40 +87,278 @@ func TestRenderCodexPhaseEfforts_NilFallsBackToRecommended(t *testing.T) {
 }
 
 func TestRenderCodexPhaseEfforts_LowCostTierValues(t *testing.T) {
-	out := model.RenderCodexPhaseEfforts(model.CodexModelPresetLowCost())
-	// Low-cost: sdd-strong row = medium, sdd-mid row = medium, sdd-cheap row = low
-	assertContainsSubstring(t, out, "sdd-strong")
-	assertContainsSubstring(t, out, "sdd-mid")
-	assertContainsSubstring(t, out, "sdd-cheap")
-	// The table should have "medium" for strong and mid tiers and "low" for cheap.
-	// We check values per row; the render function groups by tier.
+	out := model.RenderCodexPhaseEfforts(model.CodexModelPresetLowCost(), nil)
+	// Low-cost: sdd-strong=medium, sdd-mid=medium, sdd-cheap=low
+	checkCarrilRow(t, out, "sdd-strong", model.CodexEffortMedium)
+	checkCarrilRow(t, out, "sdd-mid", model.CodexEffortMedium)
+	checkCarrilRow(t, out, "sdd-cheap", model.CodexEffortLow)
 }
 
 func TestRenderCodexPhaseEfforts_PowerfulTierValues(t *testing.T) {
-	out := model.RenderCodexPhaseEfforts(model.CodexModelPresetPowerful())
-	// Powerful: sdd-strong row = xhigh, sdd-mid row = high, sdd-cheap row = low
-	assertContainsSubstring(t, out, "sdd-strong")
-	assertContainsSubstring(t, out, "sdd-mid")
-	assertContainsSubstring(t, out, "sdd-cheap")
+	out := model.RenderCodexPhaseEfforts(model.CodexModelPresetPowerful(), nil)
+	// Powerful: sdd-strong=xhigh, sdd-mid=high, sdd-cheap=low
+	checkCarrilRow(t, out, "sdd-strong", model.CodexEffortXHigh)
+	checkCarrilRow(t, out, "sdd-mid", model.CodexEffortHigh)
+	checkCarrilRow(t, out, "sdd-cheap", model.CodexEffortLow)
 }
 
-func assertContainsSubstring(t *testing.T, s, substr string) {
-	t.Helper()
-	if !containsStr(s, substr) {
-		t.Errorf("expected output to contain %q, got:\n%s", substr, s)
+// ─── Targeted fix: carril effort correctness per preset ──────────────────────
+
+// TestRenderCodexPhaseEfforts_CorrectCarrilEfforts asserts that each preset
+// renders the correct per-carril effort as determined by the carril intent
+// (not by the historical per-phase max). Each row is checked by extracting the
+// line that starts with "| `<profile>`" and verifying the effort cell.
+func TestRenderCodexPhaseEfforts_CorrectCarrilEfforts(t *testing.T) {
+	cases := []struct {
+		name       string
+		preset     map[string]model.CodexEffort
+		wantStrong model.CodexEffort
+		wantMid    model.CodexEffort
+		wantCheap  model.CodexEffort
+	}{
+		{
+			name:       "LowCost/Plus$20",
+			preset:     model.CodexModelPresetLowCost(),
+			wantStrong: model.CodexEffortMedium,
+			wantMid:    model.CodexEffortMedium,
+			wantCheap:  model.CodexEffortLow,
+		},
+		{
+			name:       "Recommended/Pro$100",
+			preset:     model.CodexModelPresetRecommended(),
+			wantStrong: model.CodexEffortHigh,
+			wantMid:    model.CodexEffortMedium,
+			wantCheap:  model.CodexEffortLow,
+		},
+		{
+			name:       "Powerful/Pro$200",
+			preset:     model.CodexModelPresetPowerful(),
+			wantStrong: model.CodexEffortXHigh,
+			wantMid:    model.CodexEffortHigh,
+			wantCheap:  model.CodexEffortLow,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := model.RenderCodexPhaseEfforts(tc.preset, nil)
+			checkCarrilRow(t, out, "sdd-strong", tc.wantStrong)
+			checkCarrilRow(t, out, "sdd-mid", tc.wantMid)
+			checkCarrilRow(t, out, "sdd-cheap", tc.wantCheap)
+		})
 	}
 }
 
-func containsStr(s, substr string) bool {
-	return len(s) >= len(substr) && (s == substr || len(substr) == 0 ||
-		findSubstring(s, substr))
-}
-
-func findSubstring(s, sub string) bool {
-	for i := 0; i <= len(s)-len(sub); i++ {
-		if s[i:i+len(sub)] == sub {
-			return true
+// checkCarrilRow verifies that the table row for profile contains wantEffort in
+// the reasoning_effort cell. Format: "| `profile` | `model` | `effort` | phases |"
+func checkCarrilRow(t *testing.T, table string, profile string, wantEffort model.CodexEffort) {
+	t.Helper()
+	needle := "| `" + profile + "`"
+	if !strings.Contains(table, needle) {
+		t.Errorf("table missing row for profile %q", profile)
+		return
+	}
+	// Find the row text.
+	rowStart := strings.Index(table, needle)
+	rowEnd := len(table)
+	for i := rowStart + 1; i < len(table); i++ {
+		if table[i] == '\n' {
+			rowEnd = i
+			break
 		}
 	}
-	return false
+	row := table[rowStart:rowEnd]
+	effortCell := "| `" + string(wantEffort) + "` |"
+	if !strings.Contains(row, effortCell) {
+		t.Errorf("profile %q row = %q: want effort cell %q", profile, row, effortCell)
+	}
+}
+
+// ─── WU-1 RED: carril helpers and defaults ───────────────────────────────────
+
+func TestCodexTierGroups_AllPhasesAssigned(t *testing.T) {
+	// Validates that CodexTierGroups covers all 13 known phases exactly once
+	// and maps each to one of the three valid carrils.
+	tiers := model.CodexTierGroups()
+	validCarrils := map[string]bool{
+		"sdd-strong": true,
+		"sdd-mid":    true,
+		"sdd-cheap":  true,
+	}
+	seen := make(map[string]string) // phase → carril
+	for _, g := range tiers {
+		if !validCarrils[g.Profile] {
+			t.Errorf("CodexTierGroups: unknown carril %q", g.Profile)
+		}
+		for _, phase := range g.Phases {
+			if prev, dup := seen[phase]; dup {
+				t.Errorf("phase %q appears in both %q and %q", phase, prev, g.Profile)
+			}
+			seen[phase] = g.Profile
+		}
+	}
+	wantPhases := []string{
+		"sdd-explore", "sdd-propose", "sdd-spec", "sdd-design", "sdd-tasks",
+		"sdd-apply", "sdd-verify", "sdd-archive", "sdd-onboard",
+		"jd-judge-a", "jd-judge-b", "jd-fix-agent", "default",
+	}
+	for _, phase := range wantPhases {
+		if _, ok := seen[phase]; !ok {
+			t.Errorf("CodexTierGroups: phase %q not covered by any carril", phase)
+		}
+	}
+	if len(seen) != 13 {
+		t.Errorf("expected 13 phases total, got %d", len(seen))
+	}
+}
+
+func TestDefaultCarrilModels(t *testing.T) {
+	m := model.DefaultCarrilModels()
+	if m["sdd-strong"] != "gpt-5.5" {
+		t.Errorf("sdd-strong = %q, want gpt-5.5", m["sdd-strong"])
+	}
+	if m["sdd-mid"] != "gpt-5.5" {
+		t.Errorf("sdd-mid = %q, want gpt-5.5", m["sdd-mid"])
+	}
+	if m["sdd-cheap"] != "gpt-5.4-mini" {
+		t.Errorf("sdd-cheap = %q, want gpt-5.4-mini", m["sdd-cheap"])
+	}
+	if len(m) != 3 {
+		t.Errorf("DefaultCarrilModels() has %d entries, want 3", len(m))
+	}
+}
+
+func TestPresetPlus_ModelEffortPerCarril(t *testing.T) {
+	m := model.CodexModelPresetLowCost()
+	// Plus $20: Razonamiento=gpt-5.5/medium, Código=gpt-5.5/medium, Liviano=gpt-5.4-mini/low
+	// Check that propose/design (Razonamiento/sdd-strong) is medium
+	if m["sdd-propose"] != model.CodexEffortMedium {
+		t.Errorf("Plus preset sdd-propose = %q, want medium", m["sdd-propose"])
+	}
+	// apply (Código/sdd-mid) is medium
+	if m["sdd-apply"] != model.CodexEffortMedium {
+		t.Errorf("Plus preset sdd-apply = %q, want medium", m["sdd-apply"])
+	}
+	// explore (Liviano/sdd-cheap) is low
+	if m["sdd-explore"] != model.CodexEffortLow {
+		t.Errorf("Plus preset sdd-explore = %q, want low", m["sdd-explore"])
+	}
+
+	// Verify Plus preset carril models
+	carrilModels := model.DefaultCarrilModels()
+	if carrilModels["sdd-strong"] != "gpt-5.5" {
+		t.Errorf("Plus preset sdd-strong model = %q, want gpt-5.5", carrilModels["sdd-strong"])
+	}
+	if carrilModels["sdd-mid"] != "gpt-5.5" {
+		t.Errorf("Plus preset sdd-mid model = %q, want gpt-5.5", carrilModels["sdd-mid"])
+	}
+	if carrilModels["sdd-cheap"] != "gpt-5.4-mini" {
+		t.Errorf("Plus preset sdd-cheap model = %q, want gpt-5.4-mini", carrilModels["sdd-cheap"])
+	}
+}
+
+func TestPresetPro100_ModelEffortPerCarril(t *testing.T) {
+	// Pro $100: Razonamiento=gpt-5.5/high, Código=gpt-5.5/medium, Liviano=gpt-5.4-mini/low
+	m := model.CodexModelPresetRecommended()
+	if m["sdd-propose"] != model.CodexEffortHigh {
+		t.Errorf("Pro100 preset sdd-propose = %q, want high", m["sdd-propose"])
+	}
+	// sdd-apply belongs to Código (sdd-mid): must be medium in Pro $100, not high.
+	if m["sdd-apply"] != model.CodexEffortMedium {
+		t.Errorf("Pro100 preset sdd-apply = %q, want medium (Código carril)", m["sdd-apply"])
+	}
+
+	carrilModels := model.DefaultCarrilModels()
+	if carrilModels["sdd-strong"] != "gpt-5.5" {
+		t.Errorf("Pro100 preset sdd-strong model = %q, want gpt-5.5", carrilModels["sdd-strong"])
+	}
+	if carrilModels["sdd-cheap"] != "gpt-5.4-mini" {
+		t.Errorf("Pro100 preset sdd-cheap model = %q, want gpt-5.4-mini", carrilModels["sdd-cheap"])
+	}
+}
+
+func TestPresetPro200_ModelEffortPerCarril(t *testing.T) {
+	// Pro $200: Razonamiento=gpt-5.5/xhigh, Código=gpt-5.5/high, Liviano=gpt-5.4-mini/low
+	m := model.CodexModelPresetPowerful()
+	if m["sdd-propose"] != model.CodexEffortXHigh {
+		t.Errorf("Pro200 preset sdd-propose = %q, want xhigh", m["sdd-propose"])
+	}
+	if m["sdd-apply"] != model.CodexEffortHigh {
+		t.Errorf("Pro200 preset sdd-apply = %q, want high", m["sdd-apply"])
+	}
+
+	carrilModels := model.DefaultCarrilModels()
+	if carrilModels["sdd-strong"] != "gpt-5.5" {
+		t.Errorf("Pro200 preset sdd-strong model = %q, want gpt-5.5", carrilModels["sdd-strong"])
+	}
+	if carrilModels["sdd-cheap"] != "gpt-5.4-mini" {
+		t.Errorf("Pro200 preset sdd-cheap model = %q, want gpt-5.4-mini", carrilModels["sdd-cheap"])
+	}
+}
+
+// ─── WU-2 RED: RenderCodexPhaseEfforts Model column ───────────────────────────
+
+func TestRenderCodexPhaseEfforts_ModelColumn(t *testing.T) {
+	assignments := model.CodexModelPresetRecommended()
+	out := model.RenderCodexPhaseEfforts(assignments, nil)
+	if !strings.Contains(out, "Model") {
+		t.Errorf("RenderCodexPhaseEfforts: table header missing 'Model' column; got:\n%s", out)
+	}
+	// All rows should contain gpt-5.5 or gpt-5.4-mini.
+	if !strings.Contains(out, "gpt-5.5") {
+		t.Errorf("RenderCodexPhaseEfforts: expected gpt-5.5 in output; got:\n%s", out)
+	}
+	if !strings.Contains(out, "gpt-5.4-mini") {
+		t.Errorf("RenderCodexPhaseEfforts: expected gpt-5.4-mini in output; got:\n%s", out)
+	}
+}
+
+func TestRenderCodexPhaseEfforts_NilCarrilModels(t *testing.T) {
+	assignments := model.CodexModelPresetRecommended()
+	out := model.RenderCodexPhaseEfforts(assignments, nil)
+	// nil carrilModels: defaults apply; sdd-cheap row must show gpt-5.4-mini
+	if !strings.Contains(out, "gpt-5.4-mini") {
+		t.Errorf("RenderCodexPhaseEfforts(nil): sdd-cheap should show gpt-5.4-mini; got:\n%s", out)
+	}
+}
+
+func TestRenderCodexPhaseEfforts_NonDefaultModel(t *testing.T) {
+	// Pass a carril override that differs from the defaults so the test will
+	// FAIL if the carrilModels override path is removed from RenderCodexPhaseEfforts.
+	assignments := model.CodexModelPresetRecommended()
+	carrilModels := map[string]string{
+		"sdd-strong": "gpt-5.4", // non-default model for sdd-strong
+		"sdd-mid":    "gpt-5.5",
+		"sdd-cheap":  "gpt-5.4-mini",
+	}
+	out := model.RenderCodexPhaseEfforts(assignments, carrilModels)
+	// The sdd-strong row must show the overridden model, not the default gpt-5.5.
+	checkCarrilRowModel(t, out, "sdd-strong", "gpt-5.4")
+	// Other rows must still show their canonical models.
+	checkCarrilRowModel(t, out, "sdd-mid", "gpt-5.5")
+	checkCarrilRowModel(t, out, "sdd-cheap", "gpt-5.4-mini")
+}
+
+// checkCarrilRowModel verifies that the table row for profile contains wantModel
+// in the model cell. Format: "| `profile` | `model` | `effort` | phases |"
+func checkCarrilRowModel(t *testing.T, table string, profile string, wantModel string) {
+	t.Helper()
+	needle := "| `" + profile + "`"
+	rowStart := strings.Index(table, needle)
+	if rowStart == -1 {
+		t.Errorf("table missing row for profile %q", profile)
+		return
+	}
+	rowEnd := len(table)
+	for i := rowStart + 1; i < len(table); i++ {
+		if table[i] == '\n' {
+			rowEnd = i
+			break
+		}
+	}
+	row := table[rowStart:rowEnd]
+	modelCell := "| `" + wantModel + "` |"
+	if !strings.Contains(row, modelCell) {
+		t.Errorf("profile %q row = %q: want model cell %q", profile, row, modelCell)
+	}
 }

--- a/internal/model/selection.go
+++ b/internal/model/selection.go
@@ -1,21 +1,22 @@
 package model
 
 type Selection struct {
-	Agents                 []AgentID
-	Components             []ComponentID
-	Skills                 []SkillID
-	Persona                PersonaID
-	Preset                 PresetID
-	SDDMode                SDDModeID
-	SDDProfileStrategy     SDDProfileStrategyID
-	StrictTDD              bool
-	CodexMultiAgent        bool                        // deprecated: Codex now always writes features.multi_agent = true; retained for state/back-compat
-	ModelAssignments       map[string]ModelAssignment  // key = sub-agent name (e.g., "sdd-init")
-	ClaudeModelAssignments map[string]ClaudeModelAlias // key = phase name; value = fable|opus|sonnet|haiku
-	KiroModelAssignments   map[string]KiroModelAlias   // key = phase name; value = Kiro-native model alias
-	CodexModelAssignments  map[string]CodexEffort      // key = phase name; value = low|medium|high|xhigh
-	Profiles               []Profile                   // named SDD profiles to generate/update during sync
-	OpenCodePlugins        []OpenCodeCommunityPluginID // optional community OpenCode TUI plugins
+	Agents                      []AgentID
+	Components                  []ComponentID
+	Skills                      []SkillID
+	Persona                     PersonaID
+	Preset                      PresetID
+	SDDMode                     SDDModeID
+	SDDProfileStrategy          SDDProfileStrategyID
+	StrictTDD                   bool
+	CodexMultiAgent             bool                        // deprecated: Codex now always writes features.multi_agent = true; retained for state/back-compat
+	ModelAssignments            map[string]ModelAssignment  // key = sub-agent name (e.g., "sdd-init")
+	ClaudeModelAssignments      map[string]ClaudeModelAlias // key = phase name; value = fable|opus|sonnet|haiku
+	KiroModelAssignments        map[string]KiroModelAlias   // key = phase name; value = Kiro-native model alias
+	CodexModelAssignments       map[string]CodexEffort      // key = phase name; value = low|medium|high|xhigh
+	CodexCarrilModelAssignments map[string]string           // key = carril profile (sdd-strong|sdd-mid|sdd-cheap); value = model id
+	Profiles                    []Profile                   // named SDD profiles to generate/update during sync
+	OpenCodePlugins             []OpenCodeCommunityPluginID // optional community OpenCode TUI plugins
 }
 
 func (s Selection) HasAgent(agent AgentID) bool {
@@ -48,13 +49,14 @@ type SyncOverrides struct {
 	// TargetAgents forces TUI sync to run the adapter(s) affected by the
 	// override, even when persisted install state omits them. This is used by
 	// model/profile configurators, where the user picked a concrete target agent.
-	TargetAgents           []AgentID
-	ModelAssignments       map[string]ModelAssignment  // nil = no override; empty map = reset to defaults
-	ClaudeModelAssignments map[string]ClaudeModelAlias // nil = no override; empty map = reset to defaults
-	KiroModelAssignments   map[string]KiroModelAlias   // nil = no override; empty map = reset to defaults
-	CodexModelAssignments  map[string]CodexEffort      // nil = no override; empty map = reset to defaults
-	SDDMode                SDDModeID                   // "" = no override; when non-empty, overrides the sync's default SDD mode
-	SDDProfileStrategy     SDDProfileStrategyID        // "" = auto; otherwise explicit sync profile strategy
-	StrictTDD              *bool                       // nil = no override; non-nil = override strict TDD mode
-	Profiles               []Profile                   // NEW: profile creation/updates during sync
+	TargetAgents                []AgentID
+	ModelAssignments            map[string]ModelAssignment  // nil = no override; empty map = reset to defaults
+	ClaudeModelAssignments      map[string]ClaudeModelAlias // nil = no override; empty map = reset to defaults
+	KiroModelAssignments        map[string]KiroModelAlias   // nil = no override; empty map = reset to defaults
+	CodexModelAssignments       map[string]CodexEffort      // nil = no override; empty map = reset to defaults
+	CodexCarrilModelAssignments map[string]string           // nil = no override; empty map = reset to defaults
+	SDDMode                     SDDModeID                   // "" = no override; when non-empty, overrides the sync's default SDD mode
+	SDDProfileStrategy          SDDProfileStrategyID        // "" = auto; otherwise explicit sync profile strategy
+	StrictTDD                   *bool                       // nil = no override; non-nil = override strict TDD mode
+	Profiles                    []Profile                   // NEW: profile creation/updates during sync
 }

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -40,6 +40,13 @@ type InstallState struct {
 	// user's per-phase effort preset instead of falling back to Recommended.
 	CodexModelAssignments map[string]string `json:"codexModelAssignments,omitempty"`
 
+	// CodexCarrilModelAssignments maps the three carril profile names
+	// (sdd-strong|sdd-mid|sdd-cheap) to OpenAI subscription model IDs
+	// (e.g. "gpt-5.5", "gpt-5.4-mini"). Persisted so that `gentle-ai sync`
+	// regenerates profile files with the user's chosen model per tier.
+	// Absent/empty = resolve to DefaultCarrilModels at runtime (backward-compat).
+	CodexCarrilModelAssignments map[string]string `json:"codexCarrilModelAssignments,omitempty"`
+
 	// ModelAssignments maps sub-agent names to provider/model pairs (OpenCode).
 	ModelAssignments map[string]ModelAssignmentState `json:"model_assignments,omitempty"`
 
@@ -98,12 +105,13 @@ func MergeAgents(existing InstallState, newAgents []string) InstallState {
 	}
 
 	return InstallState{
-		InstalledAgents:        merged,
-		ModelAssignments:       existing.ModelAssignments,
-		ClaudeModelAssignments: existing.ClaudeModelAssignments,
-		KiroModelAssignments:   existing.KiroModelAssignments,
-		CodexModelAssignments:  existing.CodexModelAssignments,
-		Persona:                existing.Persona,
+		InstalledAgents:             merged,
+		ModelAssignments:            existing.ModelAssignments,
+		ClaudeModelAssignments:      existing.ClaudeModelAssignments,
+		KiroModelAssignments:        existing.KiroModelAssignments,
+		CodexModelAssignments:       existing.CodexModelAssignments,
+		CodexCarrilModelAssignments: existing.CodexCarrilModelAssignments,
+		Persona:                     existing.Persona,
 	}
 }
 

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -381,7 +381,7 @@ func TestInstallStateCodexRoundTrip(t *testing.T) {
 	}
 
 	s := InstallState{
-		InstalledAgents:      []string{"codex"},
+		InstalledAgents:       []string{"codex"},
 		CodexModelAssignments: assignments,
 	}
 
@@ -439,6 +439,106 @@ func TestInstallStateCodexMissingKeyReadback(t *testing.T) {
 
 	if s.CodexModelAssignments != nil {
 		t.Errorf("CodexModelAssignments = %v, want nil (forward-compat)", s.CodexModelAssignments)
+	}
+}
+
+// ─── WU-1 RED: CodexCarrilModelAssignments round-trip and backward-compat ────
+
+// TestCodexCarrilModelAssignments_RoundTrip verifies the new carril→model key
+// serialises with the JSON key "codexCarrilModelAssignments" and reads back.
+func TestCodexCarrilModelAssignments_RoundTrip(t *testing.T) {
+	home := t.TempDir()
+
+	carrilMap := map[string]string{
+		"sdd-strong": "gpt-5.5",
+		"sdd-mid":    "gpt-5.5",
+		"sdd-cheap":  "gpt-5.4-mini",
+	}
+	s := InstallState{
+		InstalledAgents:             []string{"codex"},
+		CodexCarrilModelAssignments: carrilMap,
+	}
+
+	if err := Write(home, s); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+
+	got, err := Read(home)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+
+	if !reflect.DeepEqual(got.CodexCarrilModelAssignments, carrilMap) {
+		t.Errorf("CodexCarrilModelAssignments = %v, want %v", got.CodexCarrilModelAssignments, carrilMap)
+	}
+
+	// JSON key must be "codexCarrilModelAssignments"
+	data, err := os.ReadFile(Path(home))
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if !contains(string(data), "codexCarrilModelAssignments") {
+		t.Errorf("JSON must contain key codexCarrilModelAssignments; got:\n%s", data)
+	}
+}
+
+// TestCodexCarrilModelAssignments_BackwardCompat verifies that a state blob
+// without the new key still reads cleanly (field is nil or empty).
+func TestCodexCarrilModelAssignments_BackwardCompat(t *testing.T) {
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, stateDir), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	// Legacy blob has codexModelAssignments but no codexCarrilModelAssignments.
+	legacy := `{"installed_agents":["codex"],"codexModelAssignments":{"sdd-apply":"high"}}` + "\n"
+	if err := os.WriteFile(Path(home), []byte(legacy), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	s, err := Read(home)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if s.CodexCarrilModelAssignments != nil {
+		t.Errorf("CodexCarrilModelAssignments = %v, want nil for legacy state", s.CodexCarrilModelAssignments)
+	}
+	// Original key must still be there.
+	if s.CodexModelAssignments["sdd-apply"] != "high" {
+		t.Errorf("CodexModelAssignments[sdd-apply] = %q, want high", s.CodexModelAssignments["sdd-apply"])
+	}
+}
+
+// TestCodexCarrilModelAssignments_OmitWhenEmpty verifies that the new key is
+// absent from the JSON when the map is nil/empty (omitempty).
+func TestCodexCarrilModelAssignments_OmitWhenEmpty(t *testing.T) {
+	home := t.TempDir()
+	s := InstallState{InstalledAgents: []string{"codex"}}
+	if err := Write(home, s); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	data, err := os.ReadFile(Path(home))
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if contains(string(data), "codexCarrilModelAssignments") {
+		t.Error("JSON must not contain codexCarrilModelAssignments when empty")
+	}
+}
+
+// TestMergeAgents_PreservesCodexCarrilAssignments verifies that MergeAgents
+// preserves CodexCarrilModelAssignments from the existing state.
+func TestMergeAgents_PreservesCodexCarrilAssignments(t *testing.T) {
+	existing := InstallState{
+		InstalledAgents: []string{"codex"},
+		CodexCarrilModelAssignments: map[string]string{
+			"sdd-strong": "gpt-5.5",
+			"sdd-cheap":  "gpt-5.4-mini",
+		},
+	}
+	merged := MergeAgents(existing, []string{"opencode"})
+	if !reflect.DeepEqual(merged.CodexCarrilModelAssignments, existing.CodexCarrilModelAssignments) {
+		t.Errorf("MergeAgents did not preserve CodexCarrilModelAssignments: got %v, want %v",
+			merged.CodexCarrilModelAssignments, existing.CodexCarrilModelAssignments)
 	}
 }
 

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1037,11 +1037,16 @@ func (m Model) handleKeyPress(key tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if handled {
 			if assignments != nil {
 				m.Selection.CodexModelAssignments = assignments
+				// Derive carril model assignments from the selected preset (all
+				// current presets use canonical subscription models).
+				presetCarrilModels := model.DefaultCarrilModels()
+				m.Selection.CodexCarrilModelAssignments = presetCarrilModels
 				if m.ModelConfigMode {
 					m.ModelConfigMode = false
 					m.PendingSyncOverrides = &model.SyncOverrides{
-						TargetAgents:          []model.AgentID{model.AgentCodex},
-						CodexModelAssignments: assignments,
+						TargetAgents:                []model.AgentID{model.AgentCodex},
+						CodexModelAssignments:       assignments,
+						CodexCarrilModelAssignments: presetCarrilModels,
 					}
 					m = m.withResetSyncState()
 					m.setScreen(ScreenSync)

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -4366,3 +4366,50 @@ func TestCodexPicker_EscBackNavToPresetWhenNeitherClaudeNorKiro(t *testing.T) {
 		t.Fatalf("CodexPicker esc (no Claude, no Kiro): screen = %v, want ScreenPreset", state.Screen)
 	}
 }
+
+// TestCodexPresetSelection_PopulatesPendingSyncOverrides verifies that selecting a
+// Codex preset in ModelConfigMode populates PendingSyncOverrides with both
+// CodexModelAssignments and CodexCarrilModelAssignments (and the expected Selection fields).
+func TestCodexPresetSelection_PopulatesPendingSyncOverrides(t *testing.T) {
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Screen = ScreenCodexModelPicker
+	m.ModelConfigMode = true
+	m.Selection.Agents = []model.AgentID{model.AgentCodex}
+	m.Selection.Components = []model.ComponentID{model.ComponentEngram, model.ComponentSDD}
+	m.CodexModelPicker = screens.NewCodexModelPickerState()
+	m.Cursor = 1 // Recommended preset (index 1: LowCost=0, Recommended=1, Powerful=2)
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	state := updated.(Model)
+
+	// ModelConfigMode must be cleared after selection.
+	if state.ModelConfigMode {
+		t.Fatal("ModelConfigMode should be false after Codex preset selection")
+	}
+
+	// PendingSyncOverrides must be populated.
+	if state.PendingSyncOverrides == nil {
+		t.Fatal("PendingSyncOverrides = nil, want non-nil after Codex preset selection")
+	}
+
+	// CodexCarrilModelAssignments must contain all three carrils.
+	carrilMap := state.PendingSyncOverrides.CodexCarrilModelAssignments
+	if carrilMap == nil {
+		t.Fatal("PendingSyncOverrides.CodexCarrilModelAssignments = nil, want non-nil")
+	}
+	for _, carril := range []string{"sdd-strong", "sdd-mid", "sdd-cheap"} {
+		if _, ok := carrilMap[carril]; !ok {
+			t.Errorf("PendingSyncOverrides.CodexCarrilModelAssignments missing carril %q", carril)
+		}
+	}
+
+	// CodexModelAssignments must be non-nil (phase→effort map).
+	if state.PendingSyncOverrides.CodexModelAssignments == nil {
+		t.Fatal("PendingSyncOverrides.CodexModelAssignments = nil, want non-nil")
+	}
+
+	// Selection must also be updated.
+	if state.Selection.CodexCarrilModelAssignments == nil {
+		t.Fatal("Selection.CodexCarrilModelAssignments = nil, want non-nil after preset selection")
+	}
+}

--- a/internal/tui/screens/codex_model_picker.go
+++ b/internal/tui/screens/codex_model_picker.go
@@ -141,14 +141,18 @@ func RenderCodexModelPicker(state CodexModelPickerState, cursor int) string {
 }
 
 // CodexPresetLabel returns the human-readable plan label for a preset.
+// Labels are self-describing: they include the model id and effort tier per
+// carril so the user can see what will be written to profile files.
+//
+// Format: "<Plan> — Razonamiento gpt-5.5/<effort> · Código gpt-5.5/<effort> · Liviano gpt-5.4-mini/low"
 func CodexPresetLabel(preset CodexModelPreset) string {
 	switch preset {
 	case CodexPresetLowCost:
-		return "Low-cost (ChatGPT Plus $20/mo)"
+		return "Plus $20 — Razonamiento gpt-5.5/medium · Código gpt-5.5/medium · Liviano gpt-5.4-mini/low"
 	case CodexPresetRecommended:
-		return "Recommended (ChatGPT Pro $100/mo)"
+		return "Pro $100 — Razonamiento gpt-5.5/high · Código gpt-5.5/medium · Liviano gpt-5.4-mini/low"
 	case CodexPresetPowerful:
-		return "Powerful (ChatGPT Pro $200/mo)"
+		return "Pro $200 — Razonamiento gpt-5.5/xhigh · Código gpt-5.5/high · Liviano gpt-5.4-mini/low"
 	default:
 		return string(preset)
 	}

--- a/internal/tui/screens/codex_model_picker_test.go
+++ b/internal/tui/screens/codex_model_picker_test.go
@@ -154,3 +154,66 @@ func TestRenderCodexModelPicker_ContainsAllLabels(t *testing.T) {
 		}
 	}
 }
+
+// ─── WU-4 RED: self-describing labels ────────────────────────────────────────
+
+// TestCodexPickerLabels_SelfDescribing verifies that each preset label contains
+// the correct model and effort for each carril independently.
+// Each carril is verified separately so a wrong effort in ONE carril is caught
+// even if another carril's effort happens to match.
+func TestCodexPickerLabels_SelfDescribing(t *testing.T) {
+	tests := []struct {
+		preset           screens.CodexModelPreset
+		wantStrongEffort string // Razonamiento/sdd-strong effort
+		wantMidEffort    string // Código/sdd-mid effort
+		wantCheapEffort  string // Liviano/sdd-cheap effort
+	}{
+		{
+			preset:           screens.CodexPresetLowCost,
+			wantStrongEffort: "medium",
+			wantMidEffort:    "medium",
+			wantCheapEffort:  "low",
+		},
+		{
+			preset:           screens.CodexPresetRecommended,
+			wantStrongEffort: "high",
+			wantMidEffort:    "medium",
+			wantCheapEffort:  "low",
+		},
+		{
+			preset:           screens.CodexPresetPowerful,
+			wantStrongEffort: "xhigh",
+			wantMidEffort:    "high",
+			wantCheapEffort:  "low",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(string(tc.preset), func(t *testing.T) {
+			label := screens.CodexPresetLabel(tc.preset)
+
+			// Model must appear at least once.
+			if !strings.Contains(label, "gpt-5.5") {
+				t.Errorf("CodexPresetLabel(%q) = %q: missing gpt-5.5", tc.preset, label)
+			}
+
+			// Verify each carril by anchoring the model/effort token to its OWN
+			// carril segment. This catches a regression in one carril even when
+			// another carril shares the same model+effort (e.g. LowCost strong
+			// and mid are both gpt-5.5/medium).
+			strongToken := "Razonamiento gpt-5.5/" + tc.wantStrongEffort
+			if !strings.Contains(label, strongToken) {
+				t.Errorf("CodexPresetLabel(%q) = %q: Razonamiento carril missing %q", tc.preset, label, strongToken)
+			}
+
+			midToken := "Código gpt-5.5/" + tc.wantMidEffort
+			if !strings.Contains(label, midToken) {
+				t.Errorf("CodexPresetLabel(%q) = %q: Código carril missing %q", tc.preset, label, midToken)
+			}
+
+			cheapToken := "Liviano gpt-5.4-mini/" + tc.wantCheapEffort
+			if !strings.Contains(label, cheapToken) {
+				t.Errorf("CodexPresetLabel(%q) = %q: Liviano carril missing %q", tc.preset, label, cheapToken)
+			}
+		})
+	}
+}

--- a/testdata/golden/sdd-codex-agentsmd-lowcost.golden
+++ b/testdata/golden/sdd-codex-agentsmd-lowcost.golden
@@ -287,14 +287,14 @@ Each phase returns: `status`, `executive_summary`, `artifacts`, `next_recommende
 
 ## Model Profiles
 
-gentle-ai writes three SDD model-selection profile files into `~/.codex/` during installation. Each profile sets `model_reasoning_effort` so Codex picks the right tier — no hardcoded model IDs.
+gentle-ai writes three SDD model-selection profile files into `~/.codex/` during installation. Each profile pins both a `model` and a `model_reasoning_effort` so Codex picks the right tier for each carril.
 
 These profile files apply to whole CLI sessions: `codex --profile <name> "<prompt>"`. They do NOT apply to spawned sub-agents. When delegating a phase via `spawn_agent`, pass the tier's effort directly as `reasoning_effort` (with `fork_turns: "none"`), using the same tier values below.
 
-| Profile (CLI) | `reasoning_effort` (spawn_agent) | SDD phases |
-|---------------|----------------------------------|------------|
-| `sdd-strong` | `medium` | propose, design, verify, judge |
-| `sdd-mid` | `medium` | spec, tasks, apply |
-| `sdd-cheap` | `low` | explore, archive, onboard |
+| Profile (CLI) | Model | `reasoning_effort` (spawn_agent) | SDD phases |
+|---------------|-------|----------------------------------|------------|
+| `sdd-strong` | `gpt-5.5` | `medium` | propose, design, verify, judge |
+| `sdd-mid` | `gpt-5.5` | `medium` | apply, fix-agent |
+| `sdd-cheap` | `gpt-5.4-mini` | `low` | explore, spec, tasks, archive, onboard |
 
 <!-- /gentle-ai:sdd-orchestrator -->

--- a/testdata/golden/sdd-codex-agentsmd-powerful.golden
+++ b/testdata/golden/sdd-codex-agentsmd-powerful.golden
@@ -287,14 +287,14 @@ Each phase returns: `status`, `executive_summary`, `artifacts`, `next_recommende
 
 ## Model Profiles
 
-gentle-ai writes three SDD model-selection profile files into `~/.codex/` during installation. Each profile sets `model_reasoning_effort` so Codex picks the right tier — no hardcoded model IDs.
+gentle-ai writes three SDD model-selection profile files into `~/.codex/` during installation. Each profile pins both a `model` and a `model_reasoning_effort` so Codex picks the right tier for each carril.
 
 These profile files apply to whole CLI sessions: `codex --profile <name> "<prompt>"`. They do NOT apply to spawned sub-agents. When delegating a phase via `spawn_agent`, pass the tier's effort directly as `reasoning_effort` (with `fork_turns: "none"`), using the same tier values below.
 
-| Profile (CLI) | `reasoning_effort` (spawn_agent) | SDD phases |
-|---------------|----------------------------------|------------|
-| `sdd-strong` | `xhigh` | propose, design, verify, judge |
-| `sdd-mid` | `high` | spec, tasks, apply |
-| `sdd-cheap` | `medium` | explore, archive, onboard |
+| Profile (CLI) | Model | `reasoning_effort` (spawn_agent) | SDD phases |
+|---------------|-------|----------------------------------|------------|
+| `sdd-strong` | `gpt-5.5` | `xhigh` | propose, design, verify, judge |
+| `sdd-mid` | `gpt-5.5` | `high` | apply, fix-agent |
+| `sdd-cheap` | `gpt-5.4-mini` | `low` | explore, spec, tasks, archive, onboard |
 
 <!-- /gentle-ai:sdd-orchestrator -->

--- a/testdata/golden/sdd-codex-agentsmd.golden
+++ b/testdata/golden/sdd-codex-agentsmd.golden
@@ -287,14 +287,14 @@ Each phase returns: `status`, `executive_summary`, `artifacts`, `next_recommende
 
 ## Model Profiles
 
-gentle-ai writes three SDD model-selection profile files into `~/.codex/` during installation. Each profile sets `model_reasoning_effort` so Codex picks the right tier — no hardcoded model IDs.
+gentle-ai writes three SDD model-selection profile files into `~/.codex/` during installation. Each profile pins both a `model` and a `model_reasoning_effort` so Codex picks the right tier for each carril.
 
 These profile files apply to whole CLI sessions: `codex --profile <name> "<prompt>"`. They do NOT apply to spawned sub-agents. When delegating a phase via `spawn_agent`, pass the tier's effort directly as `reasoning_effort` (with `fork_turns: "none"`), using the same tier values below.
 
-| Profile (CLI) | `reasoning_effort` (spawn_agent) | SDD phases |
-|---------------|----------------------------------|------------|
-| `sdd-strong` | `high` | propose, design, verify, judge |
-| `sdd-mid` | `high` | spec, tasks, apply |
-| `sdd-cheap` | `low` | explore, archive, onboard |
+| Profile (CLI) | Model | `reasoning_effort` (spawn_agent) | SDD phases |
+|---------------|-------|----------------------------------|------------|
+| `sdd-strong` | `gpt-5.5` | `high` | propose, design, verify, judge |
+| `sdd-mid` | `gpt-5.5` | `medium` | apply, fix-agent |
+| `sdd-cheap` | `gpt-5.4-mini` | `low` | explore, spec, tasks, archive, onboard |
 
 <!-- /gentle-ai:sdd-orchestrator -->


### PR DESCRIPTION
Closes #814

## PR Type
- [x] New feature

## Summary
- Add per-carril **model + effort** selection for Codex: pick the model (`gpt-5.5` vs `gpt-5.4-mini`) per carril alongside reasoning effort.
- Three carriles over the existing CLI profiles — Razonamiento (gpt-5.5), Código (gpt-5.5), Liviano (gpt-5.4-mini) — with plan-aware presets (Plus $20 / Pro $100 / Pro $200).
- Fix a latent decoupling: the runtime `.config.toml` profiles were hardcoded; the chosen model+effort now actually reach `codex --profile`.

## Changes
| File | Change |
|------|--------|
| `internal/model/codex_model.go` | `codexTierGroups` is the single source of truth (model + default effort per carril); exported `CodexTierGroups()`; `RenderCodexPhaseEfforts` gains a Model column |
| `internal/agents/codex/profiles.go` | `WriteCodexProfiles` writes both `model` and `model_reasoning_effort`; nil fallback derives from `CodexTierGroups()` |
| `internal/components/engram/inject.go` | `resolveProfileAssignments` derives from the model package; threads carril assignments |
| `internal/components/sdd/inject.go` | `InjectOptions.CodexCarrilModelAssignments` + render call |
| `internal/state/state.go` | new optional `codexCarrilModelAssignments` (omitempty, zero migration) |
| `internal/cli/sync.go` | restore Codex assignments in `RunSync` (was dropped) |
| `internal/cli/run.go`, `internal/app/app.go` | thread + persist the new assignments |
| `internal/tui/screens/codex_model_picker.go`, `internal/tui/model.go` | self-describing carril labels; wiring |
| `testdata/golden/sdd-codex-agentsmd*.golden`, `internal/assets/codex/sdd-orchestrator.md` | Model column + prose update |

## Test Plan
- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test ./...` — all green
- [x] Backward-compat: old effort-only state loads unchanged
- [x] Nil fallbacks (render / profile / default) all agree (high/medium/low)
- [x] Judgment Day: 3 rounds, dual blind review → APPROVED

## Contributor Checklist
- [x] Linked an approved issue (#814, `status:approved`)
- [x] Added exactly one `type:*` label
- [x] No shell scripts modified (Go-only change)
- [x] Conventional commit format
- [x] Docs/golden updated for the behavior change
- [x] No `Co-Authored-By` trailers

> Note: `size:exception` — single-PR delivery as requested; the diff is large but cohesive (one feature, single source of truth refactor + tests + goldens).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Codex now supports assigning different models to performance tiers (strong/mid/cheap), enabling flexible model-per-tier configuration.
  * Model and reasoning effort assignments persist across sessions and syncs.
  * Enhanced model configuration workflow preserves tier-based assignments.

* **Documentation**
  * Updated Codex configuration documentation to reflect model assignment capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->