### PR TITLE
chore(repo): stop tracking the compiled gentle-ai binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ Thumbs.db
 # Docker
 *.tar
 cmd/gentle-ai/main
+cmd/gentle-ai/gentle-ai
 dist/
 
 # Agent tooling metadata (generated per-user, not product code)


### PR DESCRIPTION
Closes #821

## PR Type
- [x] `type:chore` — Maintenance/tooling

## Summary
- The 15MB compiled binary `cmd/gentle-ai/gentle-ai` was tracked in the repo as build output.
- Untracked it (`git rm --cached`, kept on disk) and added it to `.gitignore` next to the existing `cmd/gentle-ai/main` entry.

## Test Plan
- [x] `go build ./...` clean
- [x] `git check-ignore cmd/gentle-ai/gentle-ai` confirms it is now ignored

## Contributor Checklist
- [x] Linked an approved issue (#821, `status:approved`)
- [x] One `type:*` label
- [x] Conventional commit
- [x] No `Co-Authored-By` trailers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository configuration to improve build artifact management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->