### PR TITLE
fix(opencode): refresh skill registry at startup

### DIFF
--- a/internal/assets/assets_test.go
+++ b/internal/assets/assets_test.go
@@ -287,10 +287,10 @@ func TestOpenCodeEmbeddedAssetLayout(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadDir(opencode/plugins) error = %v", err)
 	}
-	if len(pluginEntries) != 1 {
-		t.Fatalf("opencode plugins count = %d, want 1", len(pluginEntries))
+	if len(pluginEntries) != 2 {
+		t.Fatalf("opencode plugins count = %d, want 2", len(pluginEntries))
 	}
-	wantPlugins := map[string]bool{"model-variants.ts": true}
+	wantPlugins := map[string]bool{"model-variants.ts": true, "skill-registry.ts": true}
 	for _, entry := range pluginEntries {
 		if !wantPlugins[entry.Name()] {
 			t.Fatalf("unexpected plugin entry = %q", entry.Name())
@@ -334,6 +334,34 @@ func TestModelVariantsPluginContract(t *testing.T) {
 	}
 	if !strings.Contains(src, "console.error") {
 		t.Errorf("model-variants.ts must log errors via console.error so users see failures")
+	}
+}
+
+func TestSkillRegistryPluginContract(t *testing.T) {
+	source, err := Read("opencode/plugins/skill-registry.ts")
+	if err != nil {
+		t.Fatalf("Read(skill-registry.ts) error = %v", err)
+	}
+	src := string(source)
+
+	for _, want := range []string{
+		"execFile",
+		"skill-registry",
+		"refresh",
+		"--quiet",
+		"--no-gitignore",
+		"--cwd",
+		"input.directory",
+		"input.worktree",
+		"timeout: 30_000",
+		"console.error",
+	} {
+		if !strings.Contains(src, want) {
+			t.Fatalf("skill-registry.ts missing %q", want)
+		}
+	}
+	if strings.Contains(src, "exec(") {
+		t.Fatal("skill-registry.ts must use execFile, not shell exec")
 	}
 }
 

--- a/internal/assets/opencode/plugins/skill-registry.ts
+++ b/internal/assets/opencode/plugins/skill-registry.ts
@@ -1,0 +1,40 @@
+/**
+ * skill-registry
+ * Refreshes Gentle AI's project skill registry when OpenCode starts.
+ *
+ * Codex and Claude Code use native startup hooks for the same command. OpenCode
+ * loads plugins at startup, so this plugin provides the equivalent behavior
+ * without depending on shell interpolation or command-file parse-time cwd.
+ */
+
+import type { Plugin } from "@opencode-ai/plugin"
+import { execFile } from "child_process"
+import { promisify } from "util"
+
+const execFileAsync = promisify(execFile)
+
+export const SkillRegistryPlugin: Plugin = async (input) => {
+  async function refreshSkillRegistry() {
+    const cwd = input.directory || input.worktree || process.cwd()
+
+    try {
+      await execFileAsync(
+        "gentle-ai",
+        ["skill-registry", "refresh", "--quiet", "--no-gitignore", "--cwd", cwd],
+        { timeout: 30_000 },
+      )
+    } catch (err) {
+      console.error("[skill-registry] refresh failed:", err)
+    }
+  }
+
+  // Don't await — keep OpenCode startup responsive. The command is
+  // fingerprint-cached, so normal startup stays cheap.
+  refreshSkillRegistry().catch((err) => {
+    console.error("[skill-registry] unexpected refresh error:", err)
+  })
+
+  return {}
+}
+
+export default SkillRegistryPlugin

--- a/internal/components/sdd/inject.go
+++ b/internal/components/sdd/inject.go
@@ -1243,7 +1243,7 @@ func claudeHookListContains(hookEntries []any, command string) bool {
 
 // installOpenCodePlugins copies the OpenCode plugins that gentle-ai still
 // manages by default. Native OpenCode subagents replace the legacy
-// background-agents plugin, so only model-variants is installed here.
+// background-agents plugin, so only startup support plugins are installed here.
 func installOpenCodePlugins(homeDir string, adapter agents.Adapter) (InjectionResult, error) {
 	opencodeDir := adapter.GlobalConfigDir(homeDir)
 	pluginsDir := filepath.Join(opencodeDir, "plugins")
@@ -1255,7 +1255,7 @@ func installOpenCodePlugins(homeDir string, adapter agents.Adapter) (InjectionRe
 	var files []string
 	var changed bool
 
-	for _, name := range []string{"model-variants.ts"} {
+	for _, name := range []string{"model-variants.ts", "skill-registry.ts"} {
 		content := assets.MustRead("opencode/plugins/" + name)
 		pluginPath := filepath.Join(pluginsDir, name)
 

--- a/internal/components/sdd/inject_test.go
+++ b/internal/components/sdd/inject_test.go
@@ -1709,13 +1709,15 @@ func TestInjectOpenCodeMultiModeIdempotent(t *testing.T) {
 	if _, err := os.Stat(legacyPluginPath); !os.IsNotExist(err) {
 		t.Fatalf("legacy background-agents plugin should not be installed by default; stat err = %v", err)
 	}
-	modelVariantsPath := filepath.Join(home, ".config", "opencode", "plugins", "model-variants.ts")
-	content, err := os.ReadFile(modelVariantsPath)
-	if err != nil {
-		t.Fatalf("ReadFile(model-variants.ts) error = %v", err)
-	}
-	if string(content) != assets.MustRead("opencode/plugins/model-variants.ts") {
-		t.Fatal("model-variants.ts changed after second multi inject")
+	for _, plugin := range []string{"model-variants.ts", "skill-registry.ts"} {
+		pluginPath := filepath.Join(home, ".config", "opencode", "plugins", plugin)
+		content, err := os.ReadFile(pluginPath)
+		if err != nil {
+			t.Fatalf("ReadFile(%s) error = %v", plugin, err)
+		}
+		if string(content) != assets.MustRead("opencode/plugins/"+plugin) {
+			t.Fatalf("%s changed after second multi inject", plugin)
+		}
 	}
 }
 
@@ -3359,7 +3361,7 @@ func TestInjectClaudeDoesNotStripMarkedSection(t *testing.T) {
 // OpenCode plugin tests
 // ---------------------------------------------------------------------------
 
-func TestInjectOpenCodeMultiWritesModelVariantsPluginOnly(t *testing.T) {
+func TestInjectOpenCodeMultiWritesStartupPlugins(t *testing.T) {
 	home := t.TempDir()
 	mockNoPackageManager(t)
 
@@ -3371,26 +3373,28 @@ func TestInjectOpenCodeMultiWritesModelVariantsPluginOnly(t *testing.T) {
 		t.Fatal("Inject(multi) changed = false")
 	}
 
-	modelVariantsPath := filepath.Join(home, ".config", "opencode", "plugins", "model-variants.ts")
-	content, err := os.ReadFile(modelVariantsPath)
-	if err != nil {
-		t.Fatalf("ReadFile(model-variants.ts) error = %v", err)
-	}
-
-	expected := assets.MustRead("opencode/plugins/model-variants.ts")
-	if string(content) != expected {
-		t.Fatalf("plugin content mismatch: got %d bytes, want %d bytes", len(content), len(expected))
-	}
-
-	found := false
-	for _, f := range result.Files {
-		if f == modelVariantsPath {
-			found = true
-			break
+	for _, plugin := range []string{"model-variants.ts", "skill-registry.ts"} {
+		pluginPath := filepath.Join(home, ".config", "opencode", "plugins", plugin)
+		content, err := os.ReadFile(pluginPath)
+		if err != nil {
+			t.Fatalf("ReadFile(%s) error = %v", plugin, err)
 		}
-	}
-	if !found {
-		t.Fatalf("plugin path %q not reported in result.Files: %v", modelVariantsPath, result.Files)
+
+		expected := assets.MustRead("opencode/plugins/" + plugin)
+		if string(content) != expected {
+			t.Fatalf("%s content mismatch: got %d bytes, want %d", plugin, len(content), len(expected))
+		}
+
+		found := false
+		for _, f := range result.Files {
+			if f == pluginPath {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("plugin path %q not reported in result.Files: %v", pluginPath, result.Files)
+		}
 	}
 
 	legacyPluginPath := filepath.Join(home, ".config", "opencode", "plugins", "background-agents.ts")
@@ -3399,7 +3403,7 @@ func TestInjectOpenCodeMultiWritesModelVariantsPluginOnly(t *testing.T) {
 	}
 }
 
-func TestInjectOpenCodeSingleWritesModelVariantsPluginOnly(t *testing.T) {
+func TestInjectOpenCodeSingleWritesStartupPlugins(t *testing.T) {
 	home := t.TempDir()
 	mockNoPackageManager(t)
 
@@ -3408,9 +3412,11 @@ func TestInjectOpenCodeSingleWritesModelVariantsPluginOnly(t *testing.T) {
 		t.Fatalf("Inject(single) error = %v", err)
 	}
 
-	modelVariantsPath := filepath.Join(home, ".config", "opencode", "plugins", "model-variants.ts")
-	if _, err := os.Stat(modelVariantsPath); err != nil {
-		t.Fatalf("model-variants plugin should exist in single mode: %v", err)
+	for _, plugin := range []string{"model-variants.ts", "skill-registry.ts"} {
+		pluginPath := filepath.Join(home, ".config", "opencode", "plugins", plugin)
+		if _, err := os.Stat(pluginPath); err != nil {
+			t.Fatalf("%s plugin should exist in single mode: %v", plugin, err)
+		}
 	}
 	legacyPluginPath := filepath.Join(home, ".config", "opencode", "plugins", "background-agents.ts")
 	if _, err := os.Stat(legacyPluginPath); !os.IsNotExist(err) {
@@ -3426,9 +3432,11 @@ func TestInjectOpenCodePluginNoPkgManagerAvailable(t *testing.T) {
 		t.Fatalf("Inject(multi) with no package manager error = %v", err)
 	}
 
-	modelVariantsPath := filepath.Join(home, ".config", "opencode", "plugins", "model-variants.ts")
-	if _, err := os.Stat(modelVariantsPath); err != nil {
-		t.Fatalf("model-variants plugin should exist without package manager: %v", err)
+	for _, plugin := range []string{"model-variants.ts", "skill-registry.ts"} {
+		pluginPath := filepath.Join(home, ".config", "opencode", "plugins", plugin)
+		if _, err := os.Stat(pluginPath); err != nil {
+			t.Fatalf("%s plugin should exist without package manager: %v", plugin, err)
+		}
 	}
 
 	_ = result

--- a/internal/components/uninstall/service.go
+++ b/internal/components/uninstall/service.go
@@ -599,6 +599,7 @@ func (s *Service) componentOperations(adapter agents.Adapter, componentID model.
 			for _, pluginPath := range []string{
 				filepath.Join(pluginDir, "background-agents.ts"),
 				filepath.Join(pluginDir, "model-variants.ts"),
+				filepath.Join(pluginDir, "skill-registry.ts"),
 			} {
 				targets = append(targets, pluginPath)
 				ops = append(ops, removeFile(pluginPath))

--- a/internal/components/uninstall/service_test.go
+++ b/internal/components/uninstall/service_test.go
@@ -312,8 +312,9 @@ func TestComponentOperationsSDD_OpenCodeRemovesManagedPluginSourcesAndModelVaria
 	}
 	backgroundAgentsPath := filepath.Join(pluginDir, "background-agents.ts")
 	modelVariantsPluginPath := filepath.Join(pluginDir, "model-variants.ts")
+	skillRegistryPluginPath := filepath.Join(pluginDir, "skill-registry.ts")
 	thirdPartyPluginPath := filepath.Join(pluginDir, "third-party.ts")
-	for _, path := range []string{backgroundAgentsPath, modelVariantsPluginPath} {
+	for _, path := range []string{backgroundAgentsPath, modelVariantsPluginPath, skillRegistryPluginPath} {
 		if err := os.WriteFile(path, []byte("managed"), 0o644); err != nil {
 			t.Fatalf("WriteFile(%q) error = %v", path, err)
 		}
@@ -337,7 +338,7 @@ func TestComponentOperationsSDD_OpenCodeRemovesManagedPluginSourcesAndModelVaria
 
 	applySDDOpenCodeOperations(t, svc, adapter)
 
-	for _, path := range []string{backgroundAgentsPath, modelVariantsPluginPath, modelVariantsCachePath, modelVariantsTempPath} {
+	for _, path := range []string{backgroundAgentsPath, modelVariantsPluginPath, skillRegistryPluginPath, modelVariantsCachePath, modelVariantsTempPath} {
 		if _, err := os.Stat(path); !os.IsNotExist(err) {
 			t.Fatalf("managed file %q should be removed; stat err = %v", path, err)
 		}


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #823

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Adds an OpenCode startup plugin that refreshes `.atl/skill-registry.md` automatically.
- Brings OpenCode skill-registry startup behavior in line with Codex and Claude Code.
- Ensures uninstall removes the managed plugin cleanly.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/assets/opencode/plugins/skill-registry.ts` | New OpenCode startup plugin that runs `gentle-ai skill-registry refresh` with fixed argv via `execFile` |
| `internal/components/sdd/inject.go` | Installs the managed OpenCode skill-registry plugin alongside `model-variants.ts` |
| `internal/components/uninstall/service.go` | Removes the managed OpenCode skill-registry plugin during SDD uninstall |
| `internal/assets/assets_test.go` | Covers the new embedded plugin asset and command contract |
| `internal/components/sdd/inject_test.go` | Covers installing both OpenCode startup support plugins |
| `internal/components/uninstall/service_test.go` | Covers uninstall cleanup for the new managed plugin |

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./internal/assets ./internal/components/sdd ./internal/components/uninstall
go test ./...
```

**Manual OpenCode check**
```bash
GENTLE_AI_NO_SELF_UPDATE=1 go run ./cmd/gentle-ai sync --agent opencode
rm -f .atl/skill-registry.md
opencode
ls -l .atl/skill-registry.md
```

- [x] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Manually tested locally

E2E was not run for this small OpenCode plugin patch; the affected behavior was covered by unit tests plus a local OpenCode startup smoke test.

---

## 🤖 Automated Checks

The following checks run automatically on this PR:

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | PR should stay within 400 changed lines (`additions + deletions`) or use `size:exception` |
| Check Issue Reference | ⏳ | PR body must contain `Closes/Fixes/Resolves #N` |
| Check Issue Has `status:approved` | ⏳ | Linked issue must have been approved before work began |
| Check PR Has `type:*` Label | ⏳ | Exactly one `type:*` label must be applied |
| Unit Tests | ⏳ | `go test ./...` must pass |
| E2E Tests | ⏳ | `cd e2e && ./docker-test.sh` must pass |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

The plugin intentionally stays quiet on success and only logs `console.error` on failure, so OpenCode startup remains clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added skill-registry plugin that automatically activates when OpenCode initializes, enabling background skill registry management with error handling and configurable settings.

* **Improvements**
  * Enhanced OpenCode plugin installation workflow to include the new skill-registry startup plugin alongside existing plugins.
  * Updated the uninstall process to properly clean up the skill-registry plugin file along with other managed OpenCode components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->