### PR TITLE
fix(update): handle Homebrew trust and restart flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Run `gentle-ai doctor` at any time for a read-only health check of your ecosyste
 ```bash
 # macOS / Linux
 brew tap Gentleman-Programming/homebrew-tap
+brew trust --formula gentleman-programming/tap/gentle-ai  # one-time, for Homebrew tap trust
 brew install gentle-ai
 
 # Windows

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -6,12 +6,14 @@
 
 - Homebrew installed and available in PATH.
 - `git` available.
+- If Homebrew requires tap trust, run `brew trust --formula gentleman-programming/tap/gentle-ai` once.
 
 ### Ubuntu/Debian (and derivatives like Linux Mint, Pop!\_OS)
 
 - `apt-get` available (standard on these distros).
 - `sudo` access for package installs.
 - `git` available.
+- If using Homebrew on Linux, Bubblewrap may require unprivileged user namespaces; see `docs/usage.md#homebrew-upgrade-troubleshooting`.
 
 ### Arch Linux (and derivatives like Manjaro, EndeavourOS)
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -275,6 +275,35 @@ gentle-ai uninstall --agent claude-code --component sdd,persona
 gentle-ai install --agent windsurf --preset full-gentleman
 ```
 
+### Homebrew upgrade troubleshooting
+
+Homebrew 6 can require explicit trust for non-official taps and, on Linux, can
+sandbox builds with Bubblewrap. `gentle-ai upgrade` and `scripts/install.sh`
+auto-trust only the Gentle AI formula, but manual upgrades may still need this
+one-time command:
+
+```bash
+brew trust --formula gentleman-programming/tap/gentle-ai
+brew upgrade gentle-ai
+```
+
+On Linux, if Homebrew reports that Bubblewrap cannot create a rootless sandbox,
+there is nothing for Gentle AI to install: Bubblewrap is already present, but the
+host blocks the rootless namespace primitives it needs. This is a security
+tradeoff and should be an explicit admin decision. If your policy allows it,
+fix the host namespace policy first:
+
+```bash
+sudo sysctl -w kernel.unprivileged_userns_clone=1
+sudo sysctl -w user.max_user_namespaces=28633
+sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 || true
+```
+
+Use `HOMEBREW_NO_SANDBOX_LINUX=1 brew upgrade gentle-ai` only as a final
+workaround when your distro policy forbids the namespace settings; it disables
+Homebrew's Linux sandbox for that command.
+
+
 ---
 
 ## Dependency Management

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -138,8 +138,14 @@ func RunArgs(args []string, stdout io.Writer) error {
 		m.SyncFn = tuiSync(homeDir)
 		m.UninstallFn = tuiUninstall(homeDir)
 		m.UninstallWithProfilesFn = tuiUninstallWithProfiles(homeDir)
-		_, err = runTUI(m, tea.WithAltScreen())
-		return err
+		finalModel, err := runTUI(m, tea.WithAltScreen())
+		if err != nil {
+			return err
+		}
+		if latestVersion, ok := gentleAIUpgradeVersionFromTUI(finalModel); ok {
+			return restartAfterGentleAIUpgrade(latestVersion, stdout)
+		}
+		return nil
 	}
 
 	switch args[0] {
@@ -188,6 +194,20 @@ func RunArgs(args []string, stdout io.Writer) error {
 		return cli.RunDoctor(context.Background(), stdout)
 	default:
 		return fmt.Errorf("unknown command %q — run 'gentle-ai help' for available commands", args[0])
+	}
+}
+
+func gentleAIUpgradeVersionFromTUI(finalModel tea.Model) (string, bool) {
+	switch m := finalModel.(type) {
+	case tui.Model:
+		return m.GentleAIUpgradeVersion()
+	case *tui.Model:
+		if m == nil {
+			return "", false
+		}
+		return m.GentleAIUpgradeVersion()
+	default:
+		return "", false
 	}
 }
 

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gentleman-programming/gentle-ai/internal/model"
 	"github.com/gentleman-programming/gentle-ai/internal/state"
 	"github.com/gentleman-programming/gentle-ai/internal/system"
+	"github.com/gentleman-programming/gentle-ai/internal/tui"
 	"github.com/gentleman-programming/gentle-ai/internal/update"
 	"github.com/gentleman-programming/gentle-ai/internal/update/upgrade"
 )
@@ -1156,5 +1157,63 @@ func writeAppSDDStatusFile(t *testing.T, path string, content string) {
 	}
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		t.Fatalf("WriteFile(%s): %v", path, err)
+	}
+}
+
+func TestRunArgs_TUIRestartsAfterGentleAIUpgradeResult(t *testing.T) {
+	origDetect := detectSystem
+	origEnsure := ensureCurrentOSSupported
+	origRunTUI := runTUI
+	origReExec := reExec
+	origLookPath := lookPathFn
+	origGoOS := goOS
+	t.Cleanup(func() {
+		detectSystem = origDetect
+		ensureCurrentOSSupported = origEnsure
+		runTUI = origRunTUI
+		reExec = origReExec
+		lookPathFn = origLookPath
+		goOS = origGoOS
+		unsetEnv(t, envSelfUpdateDone)
+	})
+	unsetEnv(t, envSelfUpdateDone)
+
+	ensureCurrentOSSupported = func() error { return nil }
+	detectSystem = func(context.Context) (system.DetectionResult, error) {
+		return system.DetectionResult{System: system.SystemInfo{Supported: true, Profile: system.PlatformProfile{OS: "darwin", PackageManager: "brew", Supported: true}}}, nil
+	}
+	goOS = func() string { return "darwin" }
+	lookPathFn = func(string) (string, error) { return "/usr/local/bin/gentle-ai", nil }
+
+	report := upgrade.UpgradeReport{Results: []upgrade.ToolUpgradeResult{
+		{ToolName: "gentle-ai", Status: upgrade.UpgradeSucceeded, NewVersion: "v1.40.0"},
+	}}
+	runTUI = func(m tea.Model, _ ...tea.ProgramOption) (tea.Model, error) {
+		model := m.(tui.Model)
+		model.UpgradeReport = &report
+		return model, nil
+	}
+
+	var reExecCalled int
+	reExec = func(argv0 string, _ []string, envv []string) error {
+		reExecCalled++
+		if argv0 != "/usr/local/bin/gentle-ai" {
+			t.Fatalf("reExec argv0 = %q, want PATH gentle-ai", argv0)
+		}
+		if !envContains(envv, envSelfUpdateDone+"=1") {
+			t.Fatalf("reExec env missing %s=1", envSelfUpdateDone)
+		}
+		return nil
+	}
+
+	var buf bytes.Buffer
+	if err := RunArgs(nil, &buf); err != nil {
+		t.Fatalf("RunArgs(TUI) error = %v", err)
+	}
+	if reExecCalled != 1 {
+		t.Fatalf("reExecCalled = %d, want 1", reExecCalled)
+	}
+	if !strings.Contains(buf.String(), "Updated to v1.40.0, restarting") {
+		t.Fatalf("output missing restart notice:\n%s", buf.String())
 	}
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1229,6 +1229,9 @@ func (m Model) handleKeyPress(key tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if m.Screen == ScreenInstalling && m.pipelineRunning {
 			return m, nil
 		}
+		if _, ok := m.GentleAIUpgradeVersion(); ok {
+			return m, tea.Quit
+		}
 		return m.goBack(), nil
 	case " ":
 		switch m.Screen {
@@ -1507,6 +1510,11 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 		if m.OperationRunning {
 			return m, nil
 		}
+		// If gentle-ai itself was upgraded, leave the TUI so the app layer can restart
+		// or ask for restart using the platform-specific restart helper.
+		if _, ok := m.GentleAIUpgradeVersion(); ok {
+			return m, tea.Quit
+		}
 		// If showing results (UpgradeReport != nil or UpgradeErr != nil), return to welcome.
 		if m.UpgradeReport != nil || m.UpgradeErr != nil {
 			m = m.withResetOperationState()
@@ -1545,6 +1553,11 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 		// Guard: don't re-launch while running.
 		if m.OperationRunning {
 			return m, nil
+		}
+		// If gentle-ai itself was upgraded, leave the TUI so the app layer can restart
+		// or ask for restart using the platform-specific restart helper.
+		if _, ok := m.GentleAIUpgradeVersion(); ok {
+			return m, tea.Quit
 		}
 		// If operations are done, return to welcome.
 		if m.HasSyncRun || m.UpgradeReport != nil || m.UpgradeErr != nil {
@@ -2520,6 +2533,20 @@ func reportUpgradedGentleAI(report upgrade.UpgradeReport) bool {
 		}
 	}
 	return false
+}
+
+// GentleAIUpgradeVersion returns the upgraded gentle-ai version when the current
+// TUI result requires restarting the app before continuing with config sync.
+func (m Model) GentleAIUpgradeVersion() (string, bool) {
+	if m.UpgradeReport == nil {
+		return "", false
+	}
+	for _, result := range m.UpgradeReport.Results {
+		if result.ToolName == "gentle-ai" && result.Status == upgrade.UpgradeSucceeded {
+			return strings.TrimPrefix(result.NewVersion, "v"), true
+		}
+	}
+	return "", false
 }
 
 // restoreBackup triggers a backup restore in a goroutine.

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -4473,3 +4473,46 @@ func TestCodexModelPickerCustomModeEscResetsCursor(t *testing.T) {
 		t.Fatalf("Cursor = %d, want 0 after Esc from Codex custom sub-mode (cursor not reset)", state.Cursor)
 	}
 }
+
+func TestGentleAIUpgradeVersionDetectsSucceededGentleAI(t *testing.T) {
+	report := upgrade.UpgradeReport{Results: []upgrade.ToolUpgradeResult{
+		{ToolName: "engram", Status: upgrade.UpgradeSucceeded, NewVersion: "1.0.0"},
+		{ToolName: "gentle-ai", Status: upgrade.UpgradeSucceeded, NewVersion: "v1.40.0"},
+	}}
+	m := Model{UpgradeReport: &report}
+	got, ok := m.GentleAIUpgradeVersion()
+	if !ok {
+		t.Fatal("GentleAIUpgradeVersion() ok = false, want true")
+	}
+	if got != "1.40.0" {
+		t.Fatalf("GentleAIUpgradeVersion() = %q, want %q", got, "1.40.0")
+	}
+}
+
+func TestUpgradeResultEnterQuitsWhenGentleAIWasUpgraded(t *testing.T) {
+	report := upgrade.UpgradeReport{Results: []upgrade.ToolUpgradeResult{
+		{ToolName: "gentle-ai", Status: upgrade.UpgradeSucceeded, NewVersion: "v1.40.0"},
+	}}
+	m := Model{Screen: ScreenUpgrade, UpgradeReport: &report}
+	_, cmd := m.confirmSelection()
+	if cmd == nil {
+		t.Fatal("confirmSelection() cmd = nil, want tea.Quit")
+	}
+	if _, ok := cmd().(tea.QuitMsg); !ok {
+		t.Fatalf("confirmSelection() command returned %T, want tea.QuitMsg", cmd())
+	}
+}
+
+func TestUpgradeSyncResultEscQuitsWhenGentleAIWasUpgraded(t *testing.T) {
+	report := upgrade.UpgradeReport{Results: []upgrade.ToolUpgradeResult{
+		{ToolName: "gentle-ai", Status: upgrade.UpgradeSucceeded, NewVersion: "v1.40.0"},
+	}}
+	m := Model{Screen: ScreenUpgradeSync, UpgradeReport: &report, HasSyncRun: true}
+	_, cmd := m.handleKeyPress(tea.KeyMsg{Type: tea.KeyEsc})
+	if cmd == nil {
+		t.Fatal("handleKeyPress(esc) cmd = nil, want tea.Quit")
+	}
+	if _, ok := cmd().(tea.QuitMsg); !ok {
+		t.Fatalf("handleKeyPress(esc) command returned %T, want tea.QuitMsg", cmd())
+	}
+}

--- a/internal/update/upgrade/strategy.go
+++ b/internal/update/upgrade/strategy.go
@@ -3,6 +3,7 @@ package upgrade
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -302,6 +303,15 @@ func brewUpgrade(ctx context.Context, toolName string) error {
 	tapCmd.Stdin = nil
 	_ = tapCmd.Run()
 
+	// Trust only the Gentleman Programming formula being upgraded. Homebrew 6 can
+	// require explicit trust for non-official taps; this is intentionally scoped to
+	// our formula, not the whole tap or third-party taps. Older Homebrew versions
+	// may not support `brew trust`, so this is non-fatal and the upgrade output
+	// below remains the source of truth.
+	trustCmd := execCommand("brew", "trust", "--formula", gentlemanProgrammingFormulaRef(toolName))
+	trustCmd.Stdin = nil
+	_ = trustCmd.Run()
+
 	// Update Homebrew formula cache before upgrading.
 	// Non-fatal: if update fails (e.g. no network), attempt upgrade with existing cache.
 	updateCmd := execCommand("brew", "update")
@@ -311,9 +321,38 @@ func brewUpgrade(ctx context.Context, toolName string) error {
 	upgradeCmd := execCommand("brew", "upgrade", toolName)
 	upgradeCmd.Stdin = nil
 	if out, err := upgradeCmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("brew upgrade %s: %w (output: %s)", toolName, err, string(out))
+		return formatBrewUpgradeError(toolName, err, string(out))
 	}
 	return nil
+}
+
+func gentlemanProgrammingFormulaRef(toolName string) string {
+	return "gentleman-programming/tap/" + strings.TrimSpace(toolName)
+}
+
+func formatBrewUpgradeError(toolName string, err error, output string) error {
+	message := fmt.Sprintf("brew upgrade %s: %v (output: %s)", toolName, err, output)
+	if advice := homebrewFailureAdvice(toolName, output); advice != "" {
+		message += "\n\n" + advice
+	}
+	return errors.New(message)
+}
+
+func homebrewFailureAdvice(toolName string, output string) string {
+	lower := strings.ToLower(output)
+	formula := gentlemanProgrammingFormulaRef(toolName)
+
+	if strings.Contains(lower, "untrusted tap") || strings.Contains(lower, "tap trust is required") || strings.Contains(lower, "homebrew_require_tap_trust") {
+		return fmt.Sprintf("Homebrew requires explicit trust for external taps. Trust only this Gentle AI formula, then retry:\n  brew trust --formula %s\n  brew upgrade %s", formula, toolName)
+	}
+
+	if strings.Contains(lower, "bubblewrap is installed but cannot create a rootless sandbox") ||
+		strings.Contains(lower, "rootless sandbox") ||
+		strings.Contains(lower, "homebrew_no_sandbox_linux") {
+		return "Homebrew on Linux could not create its Bubblewrap rootless sandbox. This requires an explicit admin/security decision: enabling unprivileged user namespaces lets Homebrew use its sandbox but changes host kernel/AppArmor policy. If acceptable, run:\n  sudo sysctl -w kernel.unprivileged_userns_clone=1\n  sudo sysctl -w user.max_user_namespaces=28633\n  sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 || true\n\nFinal workaround if your distro policy forbids this sandbox:\n  HOMEBREW_NO_SANDBOX_LINUX=1 brew upgrade " + toolName
+	}
+
+	return ""
 }
 
 // goInstallUpgrade runs `go install <importPath>@v<version>`.

--- a/internal/update/upgrade/strategy_test.go
+++ b/internal/update/upgrade/strategy_test.go
@@ -674,15 +674,18 @@ func TestBrewUpgrade_RunsUpdateBeforeUpgrade(t *testing.T) {
 		t.Fatalf("brewUpgrade: unexpected error: %v", err)
 	}
 
-	// Must have called brew tap, brew update AND brew upgrade — in that order.
-	if len(callOrder) < 3 {
-		t.Fatalf("expected 3 brew calls (tap, update, upgrade), got %d: %v", len(callOrder), callOrder)
+	// Must have called brew tap, scoped trust, brew update AND brew upgrade — in that order.
+	if len(callOrder) < 4 {
+		t.Fatalf("expected 4 brew calls (tap, trust, update, upgrade), got %d: %v", len(callOrder), callOrder)
 	}
-	if callOrder[1] != "update" {
-		t.Errorf("second brew call = %q, want %q", callOrder[1], "update")
+	if callOrder[1] != "trust" {
+		t.Errorf("second brew call = %q, want %q", callOrder[1], "trust")
 	}
-	if callOrder[2] != "upgrade" {
-		t.Errorf("third brew call = %q, want %q", callOrder[2], "upgrade")
+	if callOrder[2] != "update" {
+		t.Errorf("third brew call = %q, want %q", callOrder[2], "update")
+	}
+	if callOrder[3] != "upgrade" {
+		t.Errorf("fourth brew call = %q, want %q", callOrder[3], "upgrade")
 	}
 }
 
@@ -713,39 +716,39 @@ func TestBrewUpgrade_UpdateFailureIsNonFatal(t *testing.T) {
 		t.Errorf("expected success when brew update fails but brew upgrade succeeds, got: %v", err)
 	}
 
-	// Both brew update and brew upgrade must have been called (after the tap).
-	if len(callArgs) < 3 {
-		t.Fatalf("expected 3 brew calls, got %d: %v", len(callArgs), callArgs)
+	// Brew trust, update, and upgrade must have been called (after the tap).
+	if len(callArgs) < 4 {
+		t.Fatalf("expected 4 brew calls, got %d: %v", len(callArgs), callArgs)
 	}
-	if callArgs[1] != "update" {
-		t.Errorf("second brew call = %q, want %q", callArgs[1], "update")
+	if callArgs[1] != "trust" {
+		t.Errorf("second brew call = %q, want %q", callArgs[1], "trust")
 	}
-	if callArgs[2] != "upgrade" {
-		t.Errorf("third brew call = %q, want %q", callArgs[2], "upgrade")
+	if callArgs[2] != "update" {
+		t.Errorf("third brew call = %q, want %q", callArgs[2], "update")
+	}
+	if callArgs[3] != "upgrade" {
+		t.Errorf("fourth brew call = %q, want %q", callArgs[3], "upgrade")
 	}
 }
 
 // --- TestBrewUpgrade_TapsBeforeUpdateAndUpgrade ---
 
-// TestBrewUpgrade_TapsBeforeUpdateAndUpgrade verifies that brewUpgrade calls
-// `brew tap Gentleman-Programming/homebrew-tap` BEFORE `brew update` and
-// `brew upgrade <toolName>`. This makes the upgrade idempotent when a user
-// has lost the tap (untap, machine swap, brew cleanup). See issue #455.
-func TestBrewUpgrade_TapsBeforeUpdateAndUpgrade(t *testing.T) {
+// TestBrewUpgrade_TapsAndTrustsBeforeUpdateAndUpgrade verifies that brewUpgrade calls
+// `brew tap Gentleman-Programming/homebrew-tap` and scoped formula trust BEFORE
+// `brew update` and `brew upgrade <toolName>`. This makes the upgrade idempotent
+// when a user has lost the tap and works with Homebrew tap trust enforcement.
+func TestBrewUpgrade_TapsAndTrustsBeforeUpdateAndUpgrade(t *testing.T) {
 	origExecCommand := execCommand
 	t.Cleanup(func() { execCommand = origExecCommand })
 
 	type call struct {
 		subcommand string
-		arg        string
+		args       []string
 	}
 	var calls []call
 	execCommand = func(name string, args ...string) *exec.Cmd {
 		if name == "brew" && len(args) > 0 {
-			c := call{subcommand: args[0]}
-			if len(args) > 1 {
-				c.arg = args[1]
-			}
+			c := call{subcommand: args[0], args: append([]string(nil), args[1:]...)}
 			calls = append(calls, c)
 		}
 		return mockCmd("echo", "ok")
@@ -755,20 +758,60 @@ func TestBrewUpgrade_TapsBeforeUpdateAndUpgrade(t *testing.T) {
 		t.Fatalf("brewUpgrade: unexpected error: %v", err)
 	}
 
-	if len(calls) < 3 {
-		t.Fatalf("expected 3 brew calls (tap, update, upgrade), got %d: %+v", len(calls), calls)
+	if len(calls) < 4 {
+		t.Fatalf("expected 4 brew calls (tap, trust, update, upgrade), got %d: %+v", len(calls), calls)
 	}
 	if calls[0].subcommand != "tap" {
 		t.Errorf("first brew call subcommand = %q, want %q", calls[0].subcommand, "tap")
 	}
-	if calls[0].arg != "Gentleman-Programming/homebrew-tap" {
-		t.Errorf("first brew call arg = %q, want %q", calls[0].arg, "Gentleman-Programming/homebrew-tap")
+	if len(calls[0].args) != 1 || calls[0].args[0] != "Gentleman-Programming/homebrew-tap" {
+		t.Errorf("first brew call args = %v, want [Gentleman-Programming/homebrew-tap]", calls[0].args)
 	}
-	if calls[1].subcommand != "update" {
-		t.Errorf("second brew call = %q, want %q", calls[1].subcommand, "update")
+	if calls[1].subcommand != "trust" {
+		t.Errorf("second brew call = %q, want %q", calls[1].subcommand, "trust")
 	}
-	if calls[2].subcommand != "upgrade" {
-		t.Errorf("third brew call = %q, want %q", calls[2].subcommand, "upgrade")
+	if len(calls[1].args) != 2 || calls[1].args[0] != "--formula" || calls[1].args[1] != "gentleman-programming/tap/engram" {
+		t.Errorf("second brew call args = %v, want [--formula gentleman-programming/tap/engram]", calls[1].args)
+	}
+	if calls[2].subcommand != "update" {
+		t.Errorf("third brew call = %q, want %q", calls[2].subcommand, "update")
+	}
+	if calls[3].subcommand != "upgrade" {
+		t.Errorf("fourth brew call = %q, want %q", calls[3].subcommand, "upgrade")
+	}
+}
+
+func TestHomebrewFailureAdviceTapTrust(t *testing.T) {
+	output := `Error: Refusing to load formula gentleman-programming/tap/gentle-ai from untrusted tap.
+Run brew trust --formula gentleman-programming/tap/gentle-ai to trust it.`
+	advice := homebrewFailureAdvice("gentle-ai", output)
+	for _, want := range []string{
+		"brew trust --formula gentleman-programming/tap/gentle-ai",
+		"brew upgrade gentle-ai",
+	} {
+		if !strings.Contains(advice, want) {
+			t.Fatalf("tap trust advice missing %q:\n%s", want, advice)
+		}
+	}
+}
+
+func TestHomebrewFailureAdviceBubblewrap(t *testing.T) {
+	output := `Error: Bubblewrap is installed but cannot create a rootless sandbox.
+Homebrew's Linux sandbox requires rootless Bubblewrap and unprivileged user namespaces.`
+	advice := homebrewFailureAdvice("gentle-ai", output)
+	if strings.Contains(strings.ToLower(advice), "preferred fix") {
+		t.Fatalf("bubblewrap advice must not frame host policy changes as preferred defaults:\n%s", advice)
+	}
+	for _, want := range []string{
+		"explicit admin/security decision",
+		"sudo sysctl -w kernel.unprivileged_userns_clone=1",
+		"sudo sysctl -w user.max_user_namespaces=28633",
+		"sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 || true",
+		"HOMEBREW_NO_SANDBOX_LINUX=1 brew upgrade gentle-ai",
+	} {
+		if !strings.Contains(advice, want) {
+			t.Fatalf("bubblewrap advice missing %q:\n%s", want, advice)
+		}
 	}
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -18,6 +18,7 @@ GITHUB_OWNER="Gentleman-Programming"
 GITHUB_REPO="gentle-ai"
 BINARY_NAME="gentle-ai"
 BREW_TAP="Gentleman-Programming/homebrew-tap"
+BREW_FORMULA_REF="gentleman-programming/tap/${BINARY_NAME}"
 
 # ============================================================================
 # Color support
@@ -48,6 +49,38 @@ warn()    { echo -e "${YELLOW}[warn]${NC}    $*"; }
 error()   { echo -e "${RED}[error]${NC}   $*" >&2; }
 fatal()   { error "$@"; exit 1; }
 step()    { echo -e "\n${CYAN}${BOLD}==>${NC} ${BOLD}$*${NC}"; }
+
+homebrew_trust_gentle_ai_formula() {
+    if brew help trust &>/dev/null; then
+        info "Trusting ${BREW_FORMULA_REF} for Homebrew tap-trust enforcement"
+        brew trust --formula "$BREW_FORMULA_REF" &>/dev/null || true
+    fi
+}
+
+print_homebrew_failure_help() {
+    local output="$1"
+    local lower
+    lower="$(printf '%s' "$output" | tr '[:upper:]' '[:lower:]')"
+
+    if [[ "$lower" == *"untrusted tap"* || "$lower" == *"tap trust is required"* || "$lower" == *"homebrew_require_tap_trust"* ]]; then
+        warn "Homebrew requires explicit trust for external taps."
+        echo "Trust only the Gentle AI formula, then retry:" >&2
+        echo "  brew trust --formula ${BREW_FORMULA_REF}" >&2
+        echo "  brew upgrade ${BINARY_NAME}" >&2
+    fi
+
+    if [[ "$lower" == *"bubblewrap is installed but cannot create a rootless sandbox"* || "$lower" == *"rootless sandbox"* || "$lower" == *"homebrew_no_sandbox_linux"* ]]; then
+        warn "Homebrew on Linux could not create its Bubblewrap rootless sandbox."
+        echo "This requires an explicit admin/security decision: enabling unprivileged user namespaces lets Homebrew use its sandbox but changes host kernel/AppArmor policy." >&2
+        echo "If acceptable, run:" >&2
+        echo "  sudo sysctl -w kernel.unprivileged_userns_clone=1" >&2
+        echo "  sudo sysctl -w user.max_user_namespaces=28633" >&2
+        echo "  sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 || true" >&2
+        echo >&2
+        echo "Final workaround if your distro policy forbids this sandbox:" >&2
+        echo "  HOMEBREW_NO_SANDBOX_LINUX=1 brew upgrade ${BINARY_NAME}" >&2
+    fi
+}
 
 # ============================================================================
 # Help
@@ -191,19 +224,28 @@ install_brew() {
         fatal "Failed to tap $BREW_TAP"
     fi
 
+    homebrew_trust_gentle_ai_formula
+
     if brew list "$BINARY_NAME" &>/dev/null; then
         info "Already installed, upgrading ${BINARY_NAME}..."
-        if brew upgrade "$BINARY_NAME" 2>/dev/null; then
+        local output
+        if output="$(brew upgrade "$BINARY_NAME" 2>&1)"; then
             success "Upgraded ${BINARY_NAME} via Homebrew"
-        else
-            # "already up-to-date" also exits non-zero on some brew versions
+        elif printf '%s' "$output" | grep -Eiq 'already.*(up-to-date|installed)|not outdated'; then
             success "${BINARY_NAME} is already at the latest version"
+        else
+            printf '%s\n' "$output" >&2
+            print_homebrew_failure_help "$output"
+            fatal "Failed to upgrade ${BINARY_NAME} via Homebrew"
         fi
     else
         info "Installing ${BINARY_NAME}..."
-        if brew install "$BINARY_NAME"; then
+        local output
+        if output="$(brew install "$BINARY_NAME" 2>&1)"; then
             success "Installed ${BINARY_NAME} via Homebrew"
         else
+            printf '%s\n' "$output" >&2
+            print_homebrew_failure_help "$output"
             fatal "Failed to install ${BINARY_NAME} via Homebrew"
         fi
     fi


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #825

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Trusts only Gentle AI-owned Homebrew formulae before brew upgrades, matching Homebrew tap-trust enforcement.
- Adds security-aware Bubblewrap/rootless namespace guidance without changing host policy automatically.
- Lets TUI upgrade/upgrade+sync hand off to the existing restart helper after `gentle-ai` itself is upgraded.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/update/upgrade/strategy.go` | Adds formula-level `brew trust --formula` and Homebrew failure advice |
| `scripts/install.sh` | Adds scoped formula trust and actionable Homebrew trust/Bubblewrap failure messages |
| `internal/tui/model.go` | Quits result screens after `gentle-ai` upgrade so app layer can restart |
| `internal/app/app.go` | Detects final TUI model upgrade result and calls existing restart helper |
| `docs/usage.md`, `docs/quickstart.md`, `README.md` | Documents tap trust and Bubblewrap security tradeoffs |
| Tests | Covers trust target, Bubblewrap advice, TUI quit command, and app restart handoff |

---

## 🧪 Test Plan

**Unit Tests**
```bash
shellcheck scripts/install.sh
go test -count=1 ./internal/update/upgrade ./internal/tui ./internal/app
go test ./...
```

- [x] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Manually tested locally

E2E was not run locally; CI will run the Docker E2E matrix. The changed paths are covered by focused unit tests plus shellcheck.

---

## 🤖 Automated Checks

The following checks run automatically on this PR:

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | PR should stay within 400 changed lines (`additions + deletions`) or use `size:exception` |
| Check Issue Reference | ⏳ | PR body must contain `Closes/Fixes/Resolves #N` |
| Check Issue Has `status:approved` | ⏳ | Linked issue must have been approved before work began |
| Check PR Has `type:*` Label | ⏳ | Exactly one `type:*` label must be applied |
| Unit Tests | ⏳ | `go test ./...` must pass |
| E2E Tests | ⏳ | `cd e2e && ./docker-test.sh` must pass |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

The Bubblewrap fix is intentionally guidance-only. Gentle AI must not auto-run `sudo sysctl` or relax AppArmor/kernel namespace policy without explicit admin consent.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Application now automatically restarts after a successful self-upgrade.

* **Bug Fixes**
  * Improved Homebrew installation and upgrade reliability with explicit tap-trust support.
  * Enhanced error messages for Homebrew trust and Linux sandbox-related issues.

* **Documentation**
  * Updated installation instructions with Homebrew tap-trust setup guidance.
  * Added troubleshooting sections for upgrade issues and Linux Bubblewrap sandbox failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->