### PR TITLE
fix(install): escape parentheses in PowerShell install script

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 5.1
+﻿#Requires -Version 5.1
 <#
 .SYNOPSIS
     Gentle-AI — Install Script for Windows
@@ -202,9 +202,9 @@ function Install-ViaBinary {
 
         $fileSize = (Get-Item $archivePath).Length
         if ($fileSize -lt 1000) {
-            Stop-WithError "Downloaded file is suspiciously small ($fileSize bytes). Archive may not exist for this platform."
+            Stop-WithError "Downloaded file is suspiciously small `($fileSize bytes`). Archive may not exist for this platform."
         }
-        Write-Success "Downloaded $archiveName ($fileSize bytes)"
+        Write-Success "Downloaded $archiveName `($fileSize bytes`)"
 
         # Verify checksum
         Write-Info "Verifying checksum..."
@@ -282,7 +282,7 @@ function Install-ViaBinary {
         if (-not $alreadyPresent) {
             $newUserPath = if ($userPath) { "$userPath;$installDir" } else { $installDir }
             [Environment]::SetEnvironmentVariable("PATH", $newUserPath, "User")
-            Write-Success "Added $installDir to your PATH (takes effect in new shells)"
+            Write-Success "Added $installDir to your PATH `(takes effect in new shells`)"
         }
 
         # Also update the current session's PATH so Test-Installation can find the binary.


### PR DESCRIPTION
## Problem

On Windows PowerShell 5.1, running the install script fails with parse errors:

```
At C:\Users\...\gentle-ai-install-XXXX.ps1:205 char:78
+ ... Error "Downloaded file is suspiciously small ($fileSize bytes). Archi ...
+                                                             ~~~~~
Unexpected token 'bytes' in expression or statement.
```

## Root Cause

PowerShell interprets parentheses `()` inside double-quoted strings as subexpression syntax. When the content inside parentheses is not a valid expression (e.g., `$fileSize bytes` where `bytes` is not a variable), it causes a parse error.

Affected lines:
- Line 205: `"...suspiciously small ($fileSize bytes)..."`
- Line 207: `"Downloaded $archiveName ($fileSize bytes)"`
- Line 285: `"Added $installDir to your PATH (takes effect in new shells)"`

## Solution

1. Escape parentheses with backticks: `` `(`` and `` `)``
2. Convert file to UTF-8 with BOM (PowerShell preference)

## Testing

- PowerShell parser validates the script without errors
- Tested with minimal reproduction script
- Backticks correctly render literal parentheses in output

## Impact

Fixes installation/update failures on Windows PowerShell 5.1 (the default Windows PowerShell version).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the installation script's message formatting for improved text display in error and success notifications.

* **Chores**
  * Added UTF-8 encoding declaration to the installation script.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->