### PR TITLE
fix(install): replace em dashes with ASCII hyphens for PowerShell 5.1

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,7 +1,7 @@
 #Requires -Version 5.1
 <#
 .SYNOPSIS
-    Gentle-AI — Install Script for Windows
+    Gentle-AI - Install Script for Windows
     Ecosystem, Frameworks, Workflows for AI coding agents.
 
 .DESCRIPTION
@@ -66,7 +66,7 @@ function Show-Banner {
     Write-Host " | |_| |  __/ | | | |_| |  __/_____/ ___ \ | | " -ForegroundColor Cyan
     Write-Host "  \____|\___|_| |_|\__|_|\___|    /_/   \_\___|" -ForegroundColor Cyan
     Write-Host ""
-    Write-Host "  Gentle-AI — Ecosystem, Frameworks, Workflows" -ForegroundColor DarkGray
+    Write-Host "  Gentle-AI - Ecosystem, Frameworks, Workflows" -ForegroundColor DarkGray
     Write-Host ""
 }
 
@@ -271,7 +271,7 @@ function Install-ViaBinary {
         # a fully lossless round-trip would require the Win32 Registry class with
         # GetValue(..., DoNotExpandEnvironmentNames). We accept the trade-off here
         # because user PATH entries that rely on unexpanded refs are uncommon and
-        # we only ever append — we never rewrite the whole value.
+        # we only ever append - we never rewrite the whole value.
         $userPath = [Environment]::GetEnvironmentVariable("PATH", "User")
 
         # Split on ';' and compare entries case-insensitively so wildcard chars


### PR DESCRIPTION
## Problem

Self-update on Windows PowerShell 5.1 is broken. When `gentle-ai upgrade` downloads `install.ps1` to `%TEMP%` and executes it with `powershell -File`, the script fails with parse errors:

```
At C:\Users\...\Temp\gentle-ai-install-3698139138.ps1:205 char:78
+ ... Error "Downloaded file is suspiciously small ($fileSize bytes). Archi ...
                                                             ~~~~~
Unexpected token 'bytes' in expression or statement.
```

## Root Cause

The file `install.ps1` contains UTF-8 em dashes (`—`) in three places:
- Line 4: `.SYNOPSIS` comment
- Line 69: Banner string
- Line 274: Code comment

When PowerShell 5.1 reads the file **without BOM** (which is required for `irm | iex` to work - see #783), it interprets the file as ANSI (cp1252). The em dash bytes `E2 80 94` decode as:
- `E2` → `â`
- `80` → `€`
- `94` → `"` (RIGHT DOUBLE QUOTATION MARK)

The `"` character is a valid string delimiter in PowerShell, causing the banner string on line 69 to close prematurely. This unbalances all quotes downstream, and the parser reports errors on innocent lines like 205 (the `bytes` error) as a cascade effect.

## The Seesaw Problem

There are two execution paths for the install script:

1. **`irm <url> | iex`**: Requires NO BOM (BOM breaks `Invoke-RestMethod` pipeline - #783)
2. **`powershell -File`**: Requires either BOM or pure ASCII (without BOM, WinPS 5.1 reads as ANSI)

Previous attempts:
- #783: Removed BOM → fixed `irm | iex`, broke `powershell -File`
- This PR: Makes file pure ASCII → fixes both paths

## Solution

Replace all em dashes (`—`) with ASCII hyphens (`-`) in `install.ps1`. This makes the file pure ASCII, which works correctly with both execution paths:

- `irm <url> | iex` ✅ (no BOM to choke on)
- `powershell -File` on WinPS 5.1 ✅ (no multibyte chars to misdecode)

## Changes

- Line 4: `Gentle-AI — Install Script` → `Gentle-AI - Install Script`
- Line 69: `Gentle-AI — Ecosystem` → `Gentle-AI - Ecosystem`
- Line 274: `we only ever append — we never` → `we only ever append - we never`

## Testing

- ✅ PowerShell parser validates without errors
- ✅ Script executes successfully with `powershell -File`
- ✅ Script executes successfully with `irm | iex` (no BOM present)
- ✅ File is pure ASCII (no bytes > 0x7F)

## Impact

Fixes self-update for all Windows users on PowerShell 5.1 (the OS default).

Closes #830


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated punctuation formatting in installer banner text for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->