### PR TITLE
fix(opencode): use unique tmp path to avoid rename race on plugin double-load

### DIFF
--- a/internal/assets/assets_test.go
+++ b/internal/assets/assets_test.go
@@ -335,6 +335,15 @@ func TestModelVariantsPluginContract(t *testing.T) {
 	if !strings.Contains(src, "console.error") {
 		t.Errorf("model-variants.ts must log errors via console.error so users see failures")
 	}
+
+	// Per-invocation tmp path: OpenCode loads the plugin twice within the
+	// same process when started with `--port`. Both loads share the same
+	// PID, so a fixed `.tmp` name races with itself and the second rename()
+	// fails with ENOENT. The tmp name must include a per-invocation random
+	// suffix (randomBytes) to be unique across both loads.
+	if !strings.Contains(src, "randomBytes") {
+		t.Errorf("model-variants.ts tmp path must use randomBytes to be unique across plugin double-loads within the same process")
+	}
 }
 
 func TestSkillRegistryPluginContract(t *testing.T) {

--- a/internal/assets/assets_test.go
+++ b/internal/assets/assets_test.go
@@ -2,6 +2,7 @@ package assets
 
 import (
 	"encoding/json"
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -340,9 +341,40 @@ func TestModelVariantsPluginContract(t *testing.T) {
 	// same process when started with `--port`. Both loads share the same
 	// PID, so a fixed `.tmp` name races with itself and the second rename()
 	// fails with ENOENT. The tmp name must include a per-invocation random
-	// suffix (randomBytes) to be unique across both loads.
-	if !strings.Contains(src, "randomBytes") {
-		t.Errorf("model-variants.ts tmp path must use randomBytes to be unique across plugin double-loads within the same process")
+	// suffix (randomBytes) to be unique across both loads, and it must be
+	// constructed from cacheDir plus the cache basename so this invocation can
+	// track and clean only its own temp file if the write path fails.
+	tmpPathPattern := regexp.MustCompile("tmpPath\\s*=\\s*path\\.join\\(\\s*cacheDir\\s*,\\s*`model-variants\\.json\\.\\$\\{\\s*randomBytes\\([^)]*\\)\\s*\\.\\s*toString\\(\\s*[\"']hex[\"']\\s*\\)\\s*\\}\\.tmp`\\s*\\)")
+	if !tmpPathPattern.MatchString(src) {
+		t.Errorf("model-variants.ts tmp path must use path.join(cacheDir, randomized basename) to be unique across plugin double-loads within the same process")
+	}
+
+	// Own-temp cleanup: this randomized temp path has not shipped yet, so there
+	// are no previous randomized orphan files to scan at startup. The plugin
+	// should only best-effort remove the temp file created by this invocation
+	// when it still exists after failure; after rename, the temp file is consumed.
+	for _, want := range []string{
+		"finally",
+		"removeOwnTempFile(tmpPath)",
+		"await rm(tmpPath, { force: true })",
+		"tmpPath = undefined",
+	} {
+		if !strings.Contains(src, want) {
+			t.Errorf("model-variants.ts missing own-temp cleanup contract %q", want)
+		}
+	}
+	for _, forbidden := range []string{
+		"removeStaleModelVariantsTempFiles",
+		"STALE_TEMP_FILE_AGE_MS",
+		"mtimeMs",
+		"Date.now()",
+	} {
+		if strings.Contains(src, forbidden) {
+			t.Errorf("model-variants.ts must not use stale temp cleanup by age; found %q", forbidden)
+		}
+	}
+	if strings.Contains(src, "setTimeout") {
+		t.Errorf("model-variants.ts must not use setTimeout for temp cleanup")
 	}
 }
 

--- a/internal/assets/assets_test.go
+++ b/internal/assets/assets_test.go
@@ -344,7 +344,15 @@ func TestModelVariantsPluginContract(t *testing.T) {
 	// suffix (randomBytes) to be unique across both loads, and it must be
 	// constructed from cacheDir plus the cache basename so this invocation can
 	// track and clean only its own temp file if the write path fails.
-	tmpPathPattern := regexp.MustCompile("tmpPath\\s*=\\s*path\\.join\\(\\s*cacheDir\\s*,\\s*`model-variants\\.json\\.\\$\\{\\s*randomBytes\\([^)]*\\)\\s*\\.\\s*toString\\(\\s*[\"']hex[\"']\\s*\\)\\s*\\}\\.tmp`\\s*\\)")
+	for _, want := range []string{
+		`const MODEL_VARIANTS_CACHE_FILE = "model-variants.json"`,
+		"const finalPath = path.join(cacheDir, MODEL_VARIANTS_CACHE_FILE)",
+	} {
+		if !strings.Contains(src, want) {
+			t.Errorf("model-variants.ts missing constant-based cache path contract %q", want)
+		}
+	}
+	tmpPathPattern := regexp.MustCompile("tmpPath\\s*=\\s*path\\.join\\(\\s*cacheDir\\s*,\\s*`\\$\\{\\s*MODEL_VARIANTS_CACHE_FILE\\s*\\}\\.\\$\\{\\s*randomBytes\\([^)]*\\)\\s*\\.\\s*toString\\(\\s*[\"']hex[\"']\\s*\\)\\s*\\}\\.tmp`\\s*\\)")
 	if !tmpPathPattern.MatchString(src) {
 		t.Errorf("model-variants.ts tmp path must use path.join(cacheDir, randomized basename) to be unique across plugin double-loads within the same process")
 	}

--- a/internal/assets/opencode/plugins/model-variants.ts
+++ b/internal/assets/opencode/plugins/model-variants.ts
@@ -10,6 +10,7 @@
 
 import type { Plugin } from "@opencode-ai/plugin"
 import { writeFile, mkdir, rename } from "fs/promises"
+import { randomBytes } from "crypto"
 import { homedir } from "os"
 import path from "path"
 
@@ -38,8 +39,14 @@ export const ModelVariantsPlugin: Plugin = async (input) => {
       // so concurrent readers (e.g. `gentle-ai sync`) never see a partial JSON.
       // Always write — even when empty — to avoid leaving a stale cache from
       // a previous run alive after providers stop reporting variants.
+      //
+      // The tmp path includes a per-invocation random suffix because OpenCode
+      // loads the plugin twice within the same process when started with
+      // `--port` (or `opencode web`). Both loads share the same PID and the
+      // same homedir, so a fixed `.tmp` name races with itself and the second
+      // rename() fails with ENOENT. See issue #766.
       const finalPath = path.join(cacheDir, "model-variants.json")
-      const tmpPath = finalPath + ".tmp"
+      const tmpPath = `${finalPath}.${randomBytes(3).toString("hex")}.tmp`
       await writeFile(tmpPath, JSON.stringify(variants, null, 2))
       await rename(tmpPath, finalPath)
     } catch (err) {

--- a/internal/assets/opencode/plugins/model-variants.ts
+++ b/internal/assets/opencode/plugins/model-variants.ts
@@ -52,18 +52,9 @@ export const ModelVariantsPlugin: Plugin = async (input) => {
       const cacheDir = path.join(homedir(), ".gentle-ai", "cache")
       await mkdir(cacheDir, { recursive: true })
 
-      // Atomic write: write to .tmp then rename. rename() is atomic on POSIX,
-      // so concurrent readers (e.g. `gentle-ai sync`) never see a partial JSON.
-      // Always write — even when empty — to avoid leaving a stale cache from
-      // a previous run alive after providers stop reporting variants.
-      //
-      // The tmp path includes a per-invocation random suffix because OpenCode
-      // can load this plugin more than once in the same process when started
-      // with `--port` (or `opencode web`). Those invocations share the same
-      // PID and homedir, so a fixed `.tmp` path lets concurrent writes race
-      // over the same file. A unique tmp path keeps each invocation isolated;
-      // the finally block below removes this invocation's tmp file if the
-      // write path fails before rename consumes it. See issue #766.
+      // Always write through a per-invocation tmp file before renaming, so
+      // readers never see partial JSON and concurrent plugin loads do not
+      // race over the same tmp path. See issue #766.
       const finalPath = path.join(cacheDir, MODEL_VARIANTS_CACHE_FILE)
       tmpPath = path.join(cacheDir, `${MODEL_VARIANTS_CACHE_FILE}.${randomBytes(3).toString("hex")}.tmp`)
       await writeFile(tmpPath, JSON.stringify(variants, null, 2))

--- a/internal/assets/opencode/plugins/model-variants.ts
+++ b/internal/assets/opencode/plugins/model-variants.ts
@@ -54,7 +54,7 @@ export const ModelVariantsPlugin: Plugin = async (input) => {
 
       // Always write through a per-invocation tmp file before renaming, so
       // readers never see partial JSON and concurrent plugin loads do not
-      // race over the same tmp path. See issue #766.
+      // race over the same tmp path. See issues #766 and #786.
       const finalPath = path.join(cacheDir, MODEL_VARIANTS_CACHE_FILE)
       tmpPath = path.join(cacheDir, `${MODEL_VARIANTS_CACHE_FILE}.${randomBytes(3).toString("hex")}.tmp`)
       await writeFile(tmpPath, JSON.stringify(variants, null, 2))

--- a/internal/assets/opencode/plugins/model-variants.ts
+++ b/internal/assets/opencode/plugins/model-variants.ts
@@ -9,13 +9,28 @@
  */
 
 import type { Plugin } from "@opencode-ai/plugin"
-import { writeFile, mkdir, rename } from "fs/promises"
+import { writeFile, mkdir, rename, rm } from "fs/promises"
 import { randomBytes } from "crypto"
 import { homedir } from "os"
 import path from "path"
 
+function isIgnorableFileRace(err: unknown) {
+  return typeof err === "object" && err !== null && "code" in err && (err as { code?: string }).code === "ENOENT"
+}
+
+async function removeOwnTempFile(tmpPath: string) {
+  try {
+    await rm(tmpPath, { force: true })
+  } catch (err) {
+    if (!isIgnorableFileRace(err)) {
+      console.error("[model-variants] temp cleanup failed:", err)
+    }
+  }
+}
+
 export const ModelVariantsPlugin: Plugin = async (input) => {
   async function refreshVariantsCache() {
+    let tmpPath: string | undefined
     try {
       const result = await input.client.provider.list()
       const data = (result as any).data ?? result
@@ -41,16 +56,23 @@ export const ModelVariantsPlugin: Plugin = async (input) => {
       // a previous run alive after providers stop reporting variants.
       //
       // The tmp path includes a per-invocation random suffix because OpenCode
-      // loads the plugin twice within the same process when started with
-      // `--port` (or `opencode web`). Both loads share the same PID and the
-      // same homedir, so a fixed `.tmp` name races with itself and the second
-      // rename() fails with ENOENT. See issue #766.
+      // can load this plugin more than once in the same process when started
+      // with `--port` (or `opencode web`). Those invocations share the same
+      // PID and homedir, so a fixed `.tmp` path lets concurrent writes race
+      // over the same file. A unique tmp path keeps each invocation isolated;
+      // the finally block below removes this invocation's tmp file if the
+      // write path fails before rename consumes it. See issue #766.
       const finalPath = path.join(cacheDir, "model-variants.json")
-      const tmpPath = `${finalPath}.${randomBytes(3).toString("hex")}.tmp`
+      tmpPath = path.join(cacheDir, `model-variants.json.${randomBytes(3).toString("hex")}.tmp`)
       await writeFile(tmpPath, JSON.stringify(variants, null, 2))
       await rename(tmpPath, finalPath)
+      tmpPath = undefined
     } catch (err) {
       console.error("[model-variants] cache refresh failed:", err)
+    } finally {
+      if (tmpPath) {
+        await removeOwnTempFile(tmpPath)
+      }
     }
   }
 

--- a/internal/assets/opencode/plugins/model-variants.ts
+++ b/internal/assets/opencode/plugins/model-variants.ts
@@ -14,6 +14,8 @@ import { randomBytes } from "crypto"
 import { homedir } from "os"
 import path from "path"
 
+const MODEL_VARIANTS_CACHE_FILE = "model-variants.json"
+
 function isIgnorableFileRace(err: unknown) {
   return typeof err === "object" && err !== null && "code" in err && (err as { code?: string }).code === "ENOENT"
 }
@@ -62,8 +64,8 @@ export const ModelVariantsPlugin: Plugin = async (input) => {
       // over the same file. A unique tmp path keeps each invocation isolated;
       // the finally block below removes this invocation's tmp file if the
       // write path fails before rename consumes it. See issue #766.
-      const finalPath = path.join(cacheDir, "model-variants.json")
-      tmpPath = path.join(cacheDir, `model-variants.json.${randomBytes(3).toString("hex")}.tmp`)
+      const finalPath = path.join(cacheDir, MODEL_VARIANTS_CACHE_FILE)
+      tmpPath = path.join(cacheDir, `${MODEL_VARIANTS_CACHE_FILE}.${randomBytes(3).toString("hex")}.tmp`)
       await writeFile(tmpPath, JSON.stringify(variants, null, 2))
       await rename(tmpPath, finalPath)
       tmpPath = undefined

--- a/internal/components/uninstall/service.go
+++ b/internal/components/uninstall/service.go
@@ -607,10 +607,7 @@ func (s *Service) componentOperations(adapter agents.Adapter, componentID model.
 			ops = append(ops, removeDirIfEmpty(pluginDir))
 
 			modelVariantsCacheDir := filepath.Join(homeDir, ".gentle-ai", "cache")
-			for _, cachePath := range []string{
-				filepath.Join(modelVariantsCacheDir, "model-variants.json"),
-				filepath.Join(modelVariantsCacheDir, "model-variants.json.tmp"),
-			} {
+			for _, cachePath := range modelVariantsCachePaths(modelVariantsCacheDir) {
 				targets = append(targets, cachePath)
 				ops = append(ops, removeFile(cachePath))
 			}
@@ -953,6 +950,46 @@ func rewriteTOMLFile(path string, mutate func(content string) (string, bool)) op
 			return true, false, nil
 		},
 	}
+}
+
+func modelVariantsCachePaths(cacheDir string) []string {
+	paths := []string{
+		filepath.Join(cacheDir, "model-variants.json"),
+		filepath.Join(cacheDir, "model-variants.json.tmp"),
+	}
+	matches, err := filepath.Glob(filepath.Join(cacheDir, "model-variants.json.*.tmp"))
+	if err != nil {
+		return paths
+	}
+	for _, path := range matches {
+		if !isModelVariantsRandomTempName(filepath.Base(path)) {
+			continue
+		}
+		info, err := os.Stat(path)
+		if err != nil || info.IsDir() {
+			continue
+		}
+		paths = append(paths, path)
+	}
+	return paths
+}
+
+func isModelVariantsRandomTempName(name string) bool {
+	const prefix = "model-variants.json."
+	const suffix = ".tmp"
+	if !strings.HasPrefix(name, prefix) || !strings.HasSuffix(name, suffix) {
+		return false
+	}
+	token := strings.TrimSuffix(strings.TrimPrefix(name, prefix), suffix)
+	if len(token) != 6 {
+		return false
+	}
+	for _, char := range token {
+		if !((char >= '0' && char <= '9') || (char >= 'a' && char <= 'f')) {
+			return false
+		}
+	}
+	return true
 }
 
 func removeFile(path string) operation {

--- a/internal/components/uninstall/service_test.go
+++ b/internal/components/uninstall/service_test.go
@@ -329,8 +329,15 @@ func TestComponentOperationsSDD_OpenCodeRemovesManagedPluginSourcesAndModelVaria
 	}
 	modelVariantsCachePath := filepath.Join(cacheDir, "model-variants.json")
 	modelVariantsTempPath := filepath.Join(cacheDir, "model-variants.json.tmp")
+	modelVariantsRandomTempPath := filepath.Join(cacheDir, "model-variants.json.a1b2c3.tmp")
 	unrelatedCachePath := filepath.Join(cacheDir, "keep.txt")
-	for _, path := range []string{modelVariantsCachePath, modelVariantsTempPath, unrelatedCachePath} {
+	unrelatedTempPaths := []string{
+		filepath.Join(cacheDir, "model-variants.json.abc12.tmp"),
+		filepath.Join(cacheDir, "model-variants.json.abc1234.tmp"),
+		filepath.Join(cacheDir, "model-variants.json.ABC123.tmp"),
+		filepath.Join(cacheDir, "model-variants.json.notes.tmp"),
+	}
+	for _, path := range append([]string{modelVariantsCachePath, modelVariantsTempPath, modelVariantsRandomTempPath, unrelatedCachePath}, unrelatedTempPaths...) {
 		if err := os.WriteFile(path, []byte("cache"), 0o644); err != nil {
 			t.Fatalf("WriteFile(%q) error = %v", path, err)
 		}
@@ -338,7 +345,7 @@ func TestComponentOperationsSDD_OpenCodeRemovesManagedPluginSourcesAndModelVaria
 
 	applySDDOpenCodeOperations(t, svc, adapter)
 
-	for _, path := range []string{backgroundAgentsPath, modelVariantsPluginPath, skillRegistryPluginPath, modelVariantsCachePath, modelVariantsTempPath} {
+	for _, path := range []string{backgroundAgentsPath, modelVariantsPluginPath, skillRegistryPluginPath, modelVariantsCachePath, modelVariantsTempPath, modelVariantsRandomTempPath} {
 		if _, err := os.Stat(path); !os.IsNotExist(err) {
 			t.Fatalf("managed file %q should be removed; stat err = %v", path, err)
 		}
@@ -348,6 +355,11 @@ func TestComponentOperationsSDD_OpenCodeRemovesManagedPluginSourcesAndModelVaria
 	}
 	if _, err := os.Stat(unrelatedCachePath); err != nil {
 		t.Fatalf("unrelated cache file should be preserved, stat err = %v", err)
+	}
+	for _, path := range unrelatedTempPaths {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("unrelated model variants temp-like file should be preserved, stat err = %v", err)
+		}
 	}
 	if _, err := os.Stat(thirdPartyPluginPath); err != nil {
 		t.Fatalf("third-party plugin should be preserved, stat err = %v", err)
@@ -372,7 +384,7 @@ func TestComponentOperationsSDD_OpenCodePreservesEmptyModelVariantsCacheDirector
 	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
 		t.Fatalf("MkdirAll(cacheDir) error = %v", err)
 	}
-	for _, name := range []string{"model-variants.json", "model-variants.json.tmp"} {
+	for _, name := range []string{"model-variants.json", "model-variants.json.tmp", "model-variants.json.d4e5f6.tmp"} {
 		path := filepath.Join(cacheDir, name)
 		if err := os.WriteFile(path, []byte("cache"), 0o644); err != nil {
 			t.Fatalf("WriteFile(%q) error = %v", path, err)


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #786
Related: #599, #766

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)

---

## 📝 Summary

- Fixes the spurious `ENOENT` from the `model-variants` OpenCode plugin when OpenCode loads the plugin more than once in the same process, such as `opencode --port`, `opencode web`, or `opencode server`.
- Uses a per-invocation randomized tmp file name so concurrent plugin loads do not race over the same `model-variants.json.tmp` path.
- Keeps the atomic write behavior, adds best-effort cleanup for this invocation's own tmp file on failure, and tightens the asset contract test so the tmp path construction cannot regress silently.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|--------------|
| `internal/assets/opencode/plugins/model-variants.ts` | Reuses `MODEL_VARIANTS_CACHE_FILE`, writes via `model-variants.json.<hex>.tmp`, renames to the final cache file, and removes this invocation's tmp file in `finally` if the write path fails before `rename` consumes it. |
| `internal/assets/assets_test.go` | Strengthens `TestModelVariantsPluginContract` to verify the constant-based final path, randomized tmp path construction, `.toString("hex")`, `.tmp` suffix, and own-temp cleanup behavior. |

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test -count=1 ./internal/assets/... ./internal/components/uninstall/...
```

**E2E Tests** (Docker required)
```bash
cd e2e && ./docker-test.sh
```

- [x] Unit tests pass (`go test -count=1 ./internal/assets/... ./internal/components/uninstall/...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — N/A: no e2e coverage exists for OpenCode plugin internals; verified manually instead (see below)
- [x] Manually tested locally

**Manual verification** (linux, OpenCode 1.16.2):
1. `rm -f ~/.gentle-ai/cache/model-variants.json{,.tmp}`
2. `opencode --port 4096` in an interactive TTY
3. Status panel no longer shows the ENOENT; `~/.gentle-ai/cache/model-variants.json` is written correctly on first try.

---

## 🤖 Automated Checks

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ✅ | Small, focused change across 2 files; no `size:exception` needed |
| Check Issue Reference | ✅ | Body contains `Closes #786` |
| Check Issue Has `status:approved` | ✅ | #786 received `status:approved` on 2026-06-12 04:20 UTC |
| Check PR Has `type:*` Label | ⏳ | `type:bug` to be applied to this PR |
| Unit Tests | ✅ | `go test -count=1 ./internal/assets/... ./internal/components/uninstall/...` passes |
| E2E Tests | ⏬ | N/A for this change |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved` (#786)
- [x] PR stays within 400 changed lines (no `size:exception` needed)
- [x] `type:bug` label to be applied to this PR
- [x] Unit tests pass (`go test -count=1 ./internal/assets/... ./internal/components/uninstall/...`)
- [x] E2E tests: N/A (no e2e coverage for OpenCode plugin internals; verified manually)
- [x] No documentation changes needed (fix is internal to the plugin)
- [x] Commits follow Conventional Commits
- [x] No `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

- **Root cause.** OpenCode can load this plugin more than once in the same process. Those invocations share the same PID and homedir, so a fixed `.tmp` path lets concurrent writes race over the same temp file.
- **Fix strategy.** Each invocation now writes to its own randomized tmp file and then renames it to `model-variants.json`. If the write path fails before `rename` consumes that tmp file, the plugin removes only its own tracked tmp path in `finally`.
- **Why not uninstall cleanup.** The randomized tmp filename format has not shipped yet, so there are no historical randomized tmp files to clean up. Keeping cleanup in the plugin also keeps ownership close to the code that creates the tmp file.
- **Why not remove-then-rename.** Removing `model-variants.json` before retrying a rename would create a window where readers cannot see the cache file. This PR keeps the no-partial-JSON write path intact.
- **Closing strategy.** Once merged, this PR closes #786. #599 can be closed as a duplicate at maintainer discretion; #766 is related to the same underlying race.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable temporary-file cleanup to prevent leftover cache artifacts and reduce failed cleanup races.

* **Tests**
  * Expanded test coverage for cache and temp-file handling, including randomized-temp scenarios and uninstall cleanup validation.

* **Chores**
  * Refactored cache cleanup to use per-invocation randomized temps for safer concurrent runs and more robust failure recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->