### PR TITLE
feat(memory): add lifecycle protocol guardrails

### DIFF
--- a/internal/assets/assets_test.go
+++ b/internal/assets/assets_test.go
@@ -772,6 +772,37 @@ func TestGentlemanLanguageInstructionsDoNotBiasEnglishSessions(t *testing.T) {
 			}
 		})
 	}
+
+	for _, path := range []string{
+		"claude/engram-protocol.md",
+		"codex/engram-instructions.md",
+		"skills/_shared/engram-convention.md",
+	} {
+		t.Run(path+"/lifecycle", func(t *testing.T) {
+			content := MustRead(path)
+
+			required := []string{
+				"when Engram exposes lifecycle metadata/tooling",
+				"active memories may be used normally",
+				"needs_review",
+				"stale context",
+				"verify it against current evidence before relying on it",
+				"Do NOT mark memories reviewed automatically",
+				"explicit user confirmation or through a dedicated memory maintenance command",
+			}
+			for _, want := range required {
+				if !strings.Contains(content, want) {
+					t.Fatalf("%s missing memory lifecycle rule %q", path, want)
+				}
+			}
+
+			for _, forbidden := range []string{"mem_review", "mark_reviewed"} {
+				if strings.Contains(content, forbidden) {
+					t.Fatalf("%s must not mention blocked runtime lifecycle tooling %q", path, forbidden)
+				}
+			}
+		})
+	}
 }
 
 // TestPersonasContainContextualSkillLoadingDirective verifies that every

--- a/internal/assets/claude/engram-protocol.md
+++ b/internal/assets/claude/engram-protocol.md
@@ -47,6 +47,12 @@ Topic update rules:
 - Unsure about key → call `mem_suggest_topic_key` first
 - Know exact ID to fix → use `mem_update`
 
+Memory lifecycle rule (when Engram exposes lifecycle metadata/tooling):
+- active memories may be used normally.
+- needs_review memories are stale context, not trusted facts.
+- When a retrieved memory is marked `needs_review`, surface that stale context to the user and verify it against current evidence before relying on it.
+- Do NOT mark memories reviewed automatically. Only mark reviewed after explicit user confirmation or through a dedicated memory maintenance command.
+
 ### WHEN TO SEARCH MEMORY
 
 On any variation of "remember", "recall", "what did we do", "how did we solve", or references to past work (in any language the user writes in):

--- a/internal/assets/codex/engram-instructions.md
+++ b/internal/assets/codex/engram-instructions.md
@@ -38,6 +38,12 @@ Topic update rules:
 - Unsure about key → call mem_suggest_topic_key first
 - Know exact ID → use mem_update
 
+Memory lifecycle rule (when Engram exposes lifecycle metadata/tooling):
+- active memories may be used normally.
+- needs_review memories are stale context, not trusted facts.
+- When a retrieved memory is marked needs_review, surface that stale context to the user and verify it against current evidence before relying on it.
+- Do NOT mark memories reviewed automatically. Only mark reviewed after explicit user confirmation or through a dedicated memory maintenance command.
+
 ### WHEN TO SEARCH MEMORY
 
 On any variation of "remember", "recall", "what did we do", "how did we solve", or references to past work (in any language the user writes in):

--- a/internal/assets/skills/_shared/engram-convention.md
+++ b/internal/assets/skills/_shared/engram-convention.md
@@ -50,6 +50,12 @@ Recovery: `mem_search("sdd/{change-name}/state")` → `mem_get_observation(id)` 
 
 ## Recovery Protocol (2 steps)
 
+Memory lifecycle rule (when Engram exposes lifecycle metadata/tooling):
+- active memories may be used normally.
+- needs_review memories are stale context, not trusted facts.
+- Surface needs_review context and verify it against current evidence before relying on it.
+- Do NOT mark memories reviewed automatically. Only mark reviewed after explicit user confirmation or through a dedicated memory maintenance command.
+
 ```
 Step 1: mem_search(query: "sdd/{change-name}/{artifact-type}", project: "{project}") → truncated preview + ID
 Step 2: mem_get_observation(id: {observation-id}) → complete content

--- a/internal/components/engram/inject_test.go
+++ b/internal/components/engram/inject_test.go
@@ -115,6 +115,9 @@ func TestInjectClaudeWritesProtocolSection(t *testing.T) {
 	if !strings.Contains(text, "mem_save") {
 		t.Fatal("CLAUDE.md missing real engram protocol content (expected 'mem_save')")
 	}
+	if !strings.Contains(text, "needs_review") {
+		t.Fatal("CLAUDE.md missing memory lifecycle stale-context rule (expected 'needs_review')")
+	}
 }
 
 func TestInjectClaudeIsIdempotent(t *testing.T) {
@@ -714,6 +717,9 @@ func TestInjectCodexWritesInstructionFiles(t *testing.T) {
 	}
 	if !strings.Contains(string(content), "mem_save") {
 		t.Fatal("engram-instructions.md missing expected content (mem_save)")
+	}
+	if !strings.Contains(string(content), "needs_review") {
+		t.Fatal("engram-instructions.md missing memory lifecycle stale-context rule (needs_review)")
 	}
 
 	compactPath := filepath.Join(home, ".codex", "engram-compact-prompt.md")

--- a/testdata/golden/combined-claude-claudemd.golden
+++ b/testdata/golden/combined-claude-claudemd.golden
@@ -471,6 +471,12 @@ Topic update rules:
 - Unsure about key → call `mem_suggest_topic_key` first
 - Know exact ID to fix → use `mem_update`
 
+Memory lifecycle rule (when Engram exposes lifecycle metadata/tooling):
+- active memories may be used normally.
+- needs_review memories are stale context, not trusted facts.
+- When a retrieved memory is marked `needs_review`, surface that stale context to the user and verify it against current evidence before relying on it.
+- Do NOT mark memories reviewed automatically. Only mark reviewed after explicit user confirmation or through a dedicated memory maintenance command.
+
 ### WHEN TO SEARCH MEMORY
 
 On any variation of "remember", "recall", "what did we do", "how did we solve", or references to past work (in any language the user writes in):

--- a/testdata/golden/combined-windsurf-global-rules.golden
+++ b/testdata/golden/combined-windsurf-global-rules.golden
@@ -519,6 +519,12 @@ Topic update rules:
 - Unsure about key → call `mem_suggest_topic_key` first
 - Know exact ID to fix → use `mem_update`
 
+Memory lifecycle rule (when Engram exposes lifecycle metadata/tooling):
+- active memories may be used normally.
+- needs_review memories are stale context, not trusted facts.
+- When a retrieved memory is marked `needs_review`, surface that stale context to the user and verify it against current evidence before relying on it.
+- Do NOT mark memories reviewed automatically. Only mark reviewed after explicit user confirmation or through a dedicated memory maintenance command.
+
 ### WHEN TO SEARCH MEMORY
 
 On any variation of "remember", "recall", "what did we do", "how did we solve", or references to past work (in any language the user writes in):

--- a/testdata/golden/engram-antigravity-rulesmd.golden
+++ b/testdata/golden/engram-antigravity-rulesmd.golden
@@ -48,6 +48,12 @@ Topic update rules:
 - Unsure about key → call `mem_suggest_topic_key` first
 - Know exact ID to fix → use `mem_update`
 
+Memory lifecycle rule (when Engram exposes lifecycle metadata/tooling):
+- active memories may be used normally.
+- needs_review memories are stale context, not trusted facts.
+- When a retrieved memory is marked `needs_review`, surface that stale context to the user and verify it against current evidence before relying on it.
+- Do NOT mark memories reviewed automatically. Only mark reviewed after explicit user confirmation or through a dedicated memory maintenance command.
+
 ### WHEN TO SEARCH MEMORY
 
 On any variation of "remember", "recall", "what did we do", "how did we solve", or references to past work (in any language the user writes in):

--- a/testdata/golden/engram-claude-claudemd.golden
+++ b/testdata/golden/engram-claude-claudemd.golden
@@ -48,6 +48,12 @@ Topic update rules:
 - Unsure about key → call `mem_suggest_topic_key` first
 - Know exact ID to fix → use `mem_update`
 
+Memory lifecycle rule (when Engram exposes lifecycle metadata/tooling):
+- active memories may be used normally.
+- needs_review memories are stale context, not trusted facts.
+- When a retrieved memory is marked `needs_review`, surface that stale context to the user and verify it against current evidence before relying on it.
+- Do NOT mark memories reviewed automatically. Only mark reviewed after explicit user confirmation or through a dedicated memory maintenance command.
+
 ### WHEN TO SEARCH MEMORY
 
 On any variation of "remember", "recall", "what did we do", "how did we solve", or references to past work (in any language the user writes in):


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #839

---

## 🏷️ PR Type

- [ ] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [x] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Adds forward-compatible Engram memory lifecycle guardrails to injected agent protocols.
- Defines how agents must treat `active` and `needs_review` memories once Engram exposes lifecycle metadata.
- Explicitly blocks automatic reviewed marking unless the user confirms it or a dedicated maintenance command is running.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|--------------|
| `internal/assets/claude/engram-protocol.md` | Adds conditional lifecycle rule for stale memory context. |
| `internal/assets/codex/engram-instructions.md` | Mirrors the lifecycle rule for Codex. |
| `internal/assets/skills/_shared/engram-convention.md` | Adds the same rule for shared SDD memory recovery guidance. |
| `internal/assets/assets_test.go` | Adds guardrails for lifecycle wording and prevents unavailable runtime tool references. |
| `internal/components/engram/inject_test.go` | Verifies injected protocol output includes stale-context guidance. |
| `testdata/golden/*` | Updates affected injected-output goldens. |

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test -count=1 ./internal/assets/... ./internal/components/engram/...
go test -count=1 ./internal/components/...
```

**E2E Tests** (Docker required)
```bash
cd e2e && ./docker-test.sh
```

- [x] Unit tests pass (`go test -count=1 ./internal/assets/... ./internal/components/engram/...`)
- [x] Unit tests pass (`go test -count=1 ./internal/components/...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — N/A: protocol/golden-only change.
- [x] Manually tested locally via focused injection and golden tests.

---

## 🤖 Automated Checks

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ✅ | Small protocol/test change under 400 changed lines. |
| Check Issue Reference | ✅ | Body contains `Closes #839`. |
| Check Issue Has `status:approved` | ✅ | Issue #839 has `status:approved`. |
| Check PR Has `type:*` Label | ⏳ | `type:feature` to be applied to this PR. |
| Unit Tests | ✅ | Focused Go tests passed locally. |
| E2E Tests | ⏬ | N/A for this change. |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test -count=1 ./internal/assets/... ./internal/components/engram/...` and `go test -count=1 ./internal/components/...`)
- [x] E2E tests: N/A for protocol/golden-only change
- [x] I have updated documentation if necessary
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

Runtime lifecycle enforcement remains blocked on Gentleman-Programming/engram#437 and a compatible `gentle-engram` release pin. This PR only prepares the agent protocol so stale memory is handled safely once Engram exposes the signal.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added memory lifecycle rules defining how active and stale memories are handled
  * Documented requirement that memory verification must occur against current evidence
  * Specified that memories require explicit user confirmation before being marked as reviewed, preventing automatic status updates

* **Tests**
  * Enhanced test coverage to verify memory lifecycle metadata is properly included in system protocols and instructions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->