### PR TITLE
feat(memory): use lifecycle review when available

### DIFF
--- a/internal/assets/assets_test.go
+++ b/internal/assets/assets_test.go
@@ -783,22 +783,23 @@ func TestGentlemanLanguageInstructionsDoNotBiasEnglishSessions(t *testing.T) {
 
 			required := []string{
 				"when Engram exposes lifecycle metadata/tooling",
+				"At session start or before architecture-sensitive work",
+				"mem_review",
+				"action `list`",
+				"current project",
+				"If `mem_review` is unavailable, do not fail the task",
+				"Continue with normal `mem_context`/`mem_search`",
+				"still apply lifecycle metadata from any returned observations when present",
 				"active memories may be used normally",
 				"needs_review",
 				"stale context",
 				"verify it against current evidence before relying on it",
-				"Do NOT mark memories reviewed automatically",
-				"explicit user confirmation or through a dedicated memory maintenance command",
+				"Do NOT call `mem_review` with action `mark_reviewed` automatically",
+				"Only call `mark_reviewed` after explicit user confirmation or through a dedicated memory maintenance command",
 			}
 			for _, want := range required {
-				if !strings.Contains(content, want) {
+				if !strings.Contains(content, want) && !strings.Contains(normalizedWords(content), normalizedWords(want)) {
 					t.Fatalf("%s missing memory lifecycle rule %q", path, want)
-				}
-			}
-
-			for _, forbidden := range []string{"mem_review", "mark_reviewed"} {
-				if strings.Contains(content, forbidden) {
-					t.Fatalf("%s must not mention blocked runtime lifecycle tooling %q", path, forbidden)
 				}
 			}
 		})

--- a/internal/assets/claude/engram-protocol.md
+++ b/internal/assets/claude/engram-protocol.md
@@ -48,10 +48,12 @@ Topic update rules:
 - Know exact ID to fix → use `mem_update`
 
 Memory lifecycle rule (when Engram exposes lifecycle metadata/tooling):
-- active memories may be used normally.
-- needs_review memories are stale context, not trusted facts.
+- At session start or before architecture-sensitive work, call `mem_review` with action `list` for the current project when the tool is available.
+- If `mem_review` is unavailable, do not fail the task. Continue with normal `mem_context`/`mem_search`, and still apply lifecycle metadata from any returned observations when present.
+- `active` memories may be used normally.
+- `needs_review` memories are stale context, not trusted facts.
 - When a retrieved memory is marked `needs_review`, surface that stale context to the user and verify it against current evidence before relying on it.
-- Do NOT mark memories reviewed automatically. Only mark reviewed after explicit user confirmation or through a dedicated memory maintenance command.
+- Do NOT call `mem_review` with action `mark_reviewed` automatically. Only call `mark_reviewed` after explicit user confirmation or through a dedicated memory maintenance command.
 
 ### WHEN TO SEARCH MEMORY
 

--- a/internal/assets/codex/engram-instructions.md
+++ b/internal/assets/codex/engram-instructions.md
@@ -39,10 +39,12 @@ Topic update rules:
 - Know exact ID → use mem_update
 
 Memory lifecycle rule (when Engram exposes lifecycle metadata/tooling):
+- At session start or before architecture-sensitive work, call mem_review with action list for the current project when the tool is available.
+- If mem_review is unavailable, do not fail the task. Continue with normal mem_context/mem_search, and still apply lifecycle metadata from any returned observations when present.
 - active memories may be used normally.
 - needs_review memories are stale context, not trusted facts.
 - When a retrieved memory is marked needs_review, surface that stale context to the user and verify it against current evidence before relying on it.
-- Do NOT mark memories reviewed automatically. Only mark reviewed after explicit user confirmation or through a dedicated memory maintenance command.
+- Do NOT call mem_review with action mark_reviewed automatically. Only call mark_reviewed after explicit user confirmation or through a dedicated memory maintenance command.
 
 ### WHEN TO SEARCH MEMORY
 

--- a/internal/assets/skills/_shared/engram-convention.md
+++ b/internal/assets/skills/_shared/engram-convention.md
@@ -51,10 +51,12 @@ Recovery: `mem_search("sdd/{change-name}/state")` → `mem_get_observation(id)` 
 ## Recovery Protocol (2 steps)
 
 Memory lifecycle rule (when Engram exposes lifecycle metadata/tooling):
-- active memories may be used normally.
-- needs_review memories are stale context, not trusted facts.
-- Surface needs_review context and verify it against current evidence before relying on it.
-- Do NOT mark memories reviewed automatically. Only mark reviewed after explicit user confirmation or through a dedicated memory maintenance command.
+- At session start or before architecture-sensitive work, call `mem_review` with action `list` for the current project when the tool is available.
+- If `mem_review` is unavailable, do not fail the task. Continue with normal `mem_context`/`mem_search`, and still apply lifecycle metadata from any returned observations when present.
+- `active` memories may be used normally.
+- `needs_review` memories are stale context, not trusted facts.
+- Surface `needs_review` context and verify it against current evidence before relying on it.
+- Do NOT call `mem_review` with action `mark_reviewed` automatically. Only call `mark_reviewed` after explicit user confirmation or through a dedicated memory maintenance command.
 
 ```
 Step 1: mem_search(query: "sdd/{change-name}/{artifact-type}", project: "{project}") → truncated preview + ID

--- a/internal/components/engram/inject.go
+++ b/internal/components/engram/inject.go
@@ -212,7 +212,7 @@ const antigravityEngramPluginJSON = `{
 }
 `
 
-const antigravityEngramToolsMessage = "CRITICAL FIRST ACTION — Ensure these Engram MCP tools are available before responding: mem_save, mem_search, mem_context, mem_session_summary, mem_session_start, mem_session_end, mem_get_observation, mem_suggest_topic_key, mem_capture_passive, mem_save_prompt, mem_update, mem_current_project, mem_judge. If Antigravity defers MCP tools, load/select these tools from the engram MCP server first. Then call mem_context when the user asks about prior work or the session needs project memory."
+const antigravityEngramToolsMessage = "CRITICAL FIRST ACTION — Ensure these Engram MCP tools are available before responding: mem_save, mem_search, mem_context, mem_session_summary, mem_session_start, mem_session_end, mem_get_observation, mem_suggest_topic_key, mem_capture_passive, mem_save_prompt, mem_update, mem_current_project, mem_judge. When available, also load/select optional mem_review for memory lifecycle review; if mem_review is unavailable, continue with the required tools above. If Antigravity defers MCP tools, load/select these tools from the engram MCP server first. Then call mem_context when the user asks about prior work or the session needs project memory."
 
 func antigravityEngramHooksJSON() []byte {
 	cfg := map[string]any{

--- a/internal/components/engram/inject_test.go
+++ b/internal/components/engram/inject_test.go
@@ -612,6 +612,8 @@ func TestInjectAntigravityWritesMCPToCLIConfig(t *testing.T) {
 		"mem_get_observation",
 		"mem_current_project",
 		"mem_judge",
+		"optional mem_review",
+		"if mem_review is unavailable",
 	} {
 		if !strings.Contains(hooksText, want) {
 			t.Fatalf("Antigravity Engram hook missing %q; got:\n%s", want, hooksText)

--- a/testdata/golden/combined-claude-claudemd.golden
+++ b/testdata/golden/combined-claude-claudemd.golden
@@ -472,10 +472,12 @@ Topic update rules:
 - Know exact ID to fix → use `mem_update`
 
 Memory lifecycle rule (when Engram exposes lifecycle metadata/tooling):
-- active memories may be used normally.
-- needs_review memories are stale context, not trusted facts.
+- At session start or before architecture-sensitive work, call `mem_review` with action `list` for the current project when the tool is available.
+- If `mem_review` is unavailable, do not fail the task. Continue with normal `mem_context`/`mem_search`, and still apply lifecycle metadata from any returned observations when present.
+- `active` memories may be used normally.
+- `needs_review` memories are stale context, not trusted facts.
 - When a retrieved memory is marked `needs_review`, surface that stale context to the user and verify it against current evidence before relying on it.
-- Do NOT mark memories reviewed automatically. Only mark reviewed after explicit user confirmation or through a dedicated memory maintenance command.
+- Do NOT call `mem_review` with action `mark_reviewed` automatically. Only call `mark_reviewed` after explicit user confirmation or through a dedicated memory maintenance command.
 
 ### WHEN TO SEARCH MEMORY
 

--- a/testdata/golden/combined-windsurf-global-rules.golden
+++ b/testdata/golden/combined-windsurf-global-rules.golden
@@ -520,10 +520,12 @@ Topic update rules:
 - Know exact ID to fix → use `mem_update`
 
 Memory lifecycle rule (when Engram exposes lifecycle metadata/tooling):
-- active memories may be used normally.
-- needs_review memories are stale context, not trusted facts.
+- At session start or before architecture-sensitive work, call `mem_review` with action `list` for the current project when the tool is available.
+- If `mem_review` is unavailable, do not fail the task. Continue with normal `mem_context`/`mem_search`, and still apply lifecycle metadata from any returned observations when present.
+- `active` memories may be used normally.
+- `needs_review` memories are stale context, not trusted facts.
 - When a retrieved memory is marked `needs_review`, surface that stale context to the user and verify it against current evidence before relying on it.
-- Do NOT mark memories reviewed automatically. Only mark reviewed after explicit user confirmation or through a dedicated memory maintenance command.
+- Do NOT call `mem_review` with action `mark_reviewed` automatically. Only call `mark_reviewed` after explicit user confirmation or through a dedicated memory maintenance command.
 
 ### WHEN TO SEARCH MEMORY
 

--- a/testdata/golden/engram-antigravity-rulesmd.golden
+++ b/testdata/golden/engram-antigravity-rulesmd.golden
@@ -49,10 +49,12 @@ Topic update rules:
 - Know exact ID to fix → use `mem_update`
 
 Memory lifecycle rule (when Engram exposes lifecycle metadata/tooling):
-- active memories may be used normally.
-- needs_review memories are stale context, not trusted facts.
+- At session start or before architecture-sensitive work, call `mem_review` with action `list` for the current project when the tool is available.
+- If `mem_review` is unavailable, do not fail the task. Continue with normal `mem_context`/`mem_search`, and still apply lifecycle metadata from any returned observations when present.
+- `active` memories may be used normally.
+- `needs_review` memories are stale context, not trusted facts.
 - When a retrieved memory is marked `needs_review`, surface that stale context to the user and verify it against current evidence before relying on it.
-- Do NOT mark memories reviewed automatically. Only mark reviewed after explicit user confirmation or through a dedicated memory maintenance command.
+- Do NOT call `mem_review` with action `mark_reviewed` automatically. Only call `mark_reviewed` after explicit user confirmation or through a dedicated memory maintenance command.
 
 ### WHEN TO SEARCH MEMORY
 

--- a/testdata/golden/engram-claude-claudemd.golden
+++ b/testdata/golden/engram-claude-claudemd.golden
@@ -49,10 +49,12 @@ Topic update rules:
 - Know exact ID to fix → use `mem_update`
 
 Memory lifecycle rule (when Engram exposes lifecycle metadata/tooling):
-- active memories may be used normally.
-- needs_review memories are stale context, not trusted facts.
+- At session start or before architecture-sensitive work, call `mem_review` with action `list` for the current project when the tool is available.
+- If `mem_review` is unavailable, do not fail the task. Continue with normal `mem_context`/`mem_search`, and still apply lifecycle metadata from any returned observations when present.
+- `active` memories may be used normally.
+- `needs_review` memories are stale context, not trusted facts.
 - When a retrieved memory is marked `needs_review`, surface that stale context to the user and verify it against current evidence before relying on it.
-- Do NOT mark memories reviewed automatically. Only mark reviewed after explicit user confirmation or through a dedicated memory maintenance command.
+- Do NOT call `mem_review` with action `mark_reviewed` automatically. Only call `mark_reviewed` after explicit user confirmation or through a dedicated memory maintenance command.
 
 ### WHEN TO SEARCH MEMORY
 


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #839

---

## 🏷️ PR Type

- [ ] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [x] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Teaches injected Engram protocols to use `mem_review` lifecycle review when the tool is available.
- Keeps older Engram installs safe by falling back to `mem_context` / `mem_search` when `mem_review` is unavailable.
- Updates Antigravity's Engram tool preflight so optional `mem_review` can be selected without becoming required.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|--------------|
| `internal/assets/claude/engram-protocol.md` | Adds concrete `mem_review` lifecycle guidance with fallback behavior. |
| `internal/assets/codex/engram-instructions.md` | Mirrors lifecycle guidance for Codex. |
| `internal/assets/skills/_shared/engram-convention.md` | Adds lifecycle review behavior for shared SDD recovery guidance. |
| `internal/components/engram/inject.go` | Adds optional `mem_review` to Antigravity's Engram tool-selection prompt. |
| `internal/assets/assets_test.go`, `internal/components/engram/inject_test.go` | Covers lifecycle guidance and optional Antigravity tool selection. |
| `testdata/golden/*` | Updates affected injected-output goldens. |

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test -count=1 ./internal/assets/... ./internal/components/engram/...
go test -count=1 ./internal/components/...
```

**E2E Tests** (Docker required)
```bash
cd e2e && ./docker-test.sh
```

- [x] Unit tests pass (`go test -count=1 ./internal/assets/... ./internal/components/engram/...`)
- [x] Unit tests pass (`go test -count=1 ./internal/components/...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — N/A: protocol/golden-only behavior change.
- [x] Manually reviewed via fresh-context review.

---

## 🤖 Automated Checks

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ✅ | Small protocol/test follow-up under 400 changed lines. |
| Check Issue Reference | ✅ | Body contains `Closes #839`. |
| Check Issue Has `status:approved` | ✅ | Issue #839 has `status:approved`. |
| Check PR Has `type:*` Label | ⏳ | `type:feature` to be applied to this PR. |
| Unit Tests | ✅ | Focused Go tests passed locally. |
| E2E Tests | ⏬ | N/A for this change. |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test -count=1 ./internal/assets/... ./internal/components/engram/...` and `go test -count=1 ./internal/components/...`)
- [x] E2E tests: N/A for protocol/golden-only behavior change
- [x] I have updated documentation if necessary
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

This intentionally does not bump `gentle-engram` yet. The protocol is availability-gated so it is safe before the lifecycle-capable Engram release is pinned.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified memory lifecycle management protocol with explicit session initialization requirements.
  * Enhanced guidance for handling reviewed vs. stale memories.
  * Added conditional behavior specifications for unavailable memory tools.

* **Tests**
  * Updated test assertions to reflect revised memory lifecycle specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->