### PR TITLE
feat(install): add beta channel for main testing

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -70,6 +70,11 @@ func RunArgs(args []string, stdout io.Writer) error {
 			return cli.RunSDDStatus(args[1:], stdout)
 		case "sdd-continue":
 			return cli.RunSDDContinue(args[1:], stdout)
+		case "install":
+			if hasHelpFlag(args[1:]) {
+				cli.PrintInstallHelp(stdout)
+				return nil
+			}
 		}
 	}
 
@@ -195,6 +200,16 @@ func RunArgs(args []string, stdout io.Writer) error {
 	default:
 		return fmt.Errorf("unknown command %q — run 'gentle-ai help' for available commands", args[0])
 	}
+}
+
+func hasHelpFlag(args []string) bool {
+	for _, arg := range args {
+		if arg == "--help" || arg == "-h" {
+			return true
+		}
+	}
+
+	return false
 }
 
 func gentleAIUpgradeVersionFromTUI(finalModel tea.Model) (string, bool) {

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -221,6 +221,27 @@ func TestRunArgsUninstallBypassesPlatformValidation(t *testing.T) {
 	// If we got here, uninstall bypassed the platform validation.
 }
 
+func TestRunArgsInstallHelpPrintsInstallSpecificHelp(t *testing.T) {
+	origEnsure := ensureCurrentOSSupported
+	t.Cleanup(func() { ensureCurrentOSSupported = origEnsure })
+	ensureCurrentOSSupported = func() error {
+		return fmt.Errorf("platform validation should not run for install help")
+	}
+
+	var buf bytes.Buffer
+	err := RunArgs([]string{"install", "--help"}, &buf)
+	if err != nil {
+		t.Fatalf("RunArgs(install --help) error = %v", err)
+	}
+
+	out := buf.String()
+	for _, want := range []string{"--channel", "beta", "nightly", "GENTLE_AI_CHANNEL"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("install help missing %q; output:\n%s", want, out)
+		}
+	}
+}
+
 func TestRunArgsSDDStatusIsDispatchedBeforePlatformValidation(t *testing.T) {
 	origEnsure := ensureCurrentOSSupported
 	t.Cleanup(func() { ensureCurrentOSSupported = origEnsure })

--- a/internal/cli/channel.go
+++ b/internal/cli/channel.go
@@ -1,0 +1,43 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// InstallChannel controls whether Gentle AI uses the stable release path or an
+// opt-in beta path for product-level dependencies such as core Engram.
+type InstallChannel string
+
+const (
+	ChannelStable InstallChannel = "stable"
+	ChannelBeta   InstallChannel = "beta"
+
+	channelEnvVar = "GENTLE_AI_CHANNEL"
+)
+
+// ResolveInstallChannel resolves the channel from the flag value and env var.
+// The explicit flag wins over the environment. Empty values default to stable.
+func ResolveInstallChannel(flagValue string) (InstallChannel, error) {
+	raw := strings.TrimSpace(flagValue)
+	if raw == "" {
+		raw = strings.TrimSpace(os.Getenv(channelEnvVar))
+	}
+	if raw == "" {
+		return ChannelStable, nil
+	}
+
+	switch InstallChannel(strings.ToLower(raw)) {
+	case ChannelStable:
+		return ChannelStable, nil
+	case ChannelBeta, "nightly":
+		return ChannelBeta, nil
+	default:
+		return "", fmt.Errorf("unsupported Gentle AI channel %q (use stable, beta, or nightly)", raw)
+	}
+}
+
+func (c InstallChannel) IsBeta() bool {
+	return c == ChannelBeta
+}

--- a/internal/cli/channel.go
+++ b/internal/cli/channel.go
@@ -6,8 +6,6 @@ import (
 	"strings"
 )
 
-// InstallChannel controls whether Gentle AI uses the stable release path or an
-// opt-in beta path for product-level dependencies such as core Engram.
 type InstallChannel string
 
 const (
@@ -17,8 +15,6 @@ const (
 	channelEnvVar = "GENTLE_AI_CHANNEL"
 )
 
-// ResolveInstallChannel resolves the channel from the flag value and env var.
-// The explicit flag wins over the environment. Empty values default to stable.
 func ResolveInstallChannel(flagValue string) (InstallChannel, error) {
 	raw := strings.TrimSpace(flagValue)
 	if raw == "" {

--- a/internal/cli/channel_test.go
+++ b/internal/cli/channel_test.go
@@ -1,0 +1,51 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestResolveInstallChannel(t *testing.T) {
+	t.Setenv(channelEnvVar, "")
+
+	tests := []struct {
+		name      string
+		flagValue string
+		envValue  string
+		want      InstallChannel
+		wantErr   bool
+	}{
+		{name: "default stable", want: ChannelStable},
+		{name: "flag beta", flagValue: "beta", want: ChannelBeta},
+		{name: "flag nightly aliases beta", flagValue: "nightly", want: ChannelBeta},
+		{name: "env beta", envValue: "beta", want: ChannelBeta},
+		{name: "flag wins over env", flagValue: "stable", envValue: "beta", want: ChannelStable},
+		{name: "invalid", flagValue: "engram-beta", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(channelEnvVar, tt.envValue)
+
+			got, err := ResolveInstallChannel(tt.flagValue)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ResolveInstallChannel(%q) error = %v, wantErr %v", tt.flagValue, err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Fatalf("ResolveInstallChannel(%q) = %q, want %q", tt.flagValue, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveInstallChannelInvalidErrorMentionsNightly(t *testing.T) {
+	t.Setenv(channelEnvVar, "")
+
+	_, err := ResolveInstallChannel("engram-beta")
+	if err == nil {
+		t.Fatal("ResolveInstallChannel() expected error")
+	}
+	if !strings.Contains(err.Error(), "nightly") {
+		t.Fatalf("error = %q, want nightly mentioned", err.Error())
+	}
+}

--- a/internal/cli/channel_test.go
+++ b/internal/cli/channel_test.go
@@ -24,28 +24,19 @@ func TestResolveInstallChannel(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+			t.Run(tt.name, func(t *testing.T) {
 			t.Setenv(channelEnvVar, tt.envValue)
 
 			got, err := ResolveInstallChannel(tt.flagValue)
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("ResolveInstallChannel(%q) error = %v, wantErr %v", tt.flagValue, err, tt.wantErr)
 			}
+			if tt.wantErr && !strings.Contains(err.Error(), "nightly") {
+				t.Fatalf("error = %q, want nightly mentioned", err.Error())
+			}
 			if got != tt.want {
 				t.Fatalf("ResolveInstallChannel(%q) = %q, want %q", tt.flagValue, got, tt.want)
 			}
 		})
-	}
-}
-
-func TestResolveInstallChannelInvalidErrorMentionsNightly(t *testing.T) {
-	t.Setenv(channelEnvVar, "")
-
-	_, err := ResolveInstallChannel("engram-beta")
-	if err == nil {
-		t.Fatal("ResolveInstallChannel() expected error")
-	}
-	if !strings.Contains(err.Error(), "nightly") {
-		t.Fatalf("error = %q, want nightly mentioned", err.Error())
 	}
 }

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"flag"
 	"fmt"
+	"io"
 	"strings"
 )
 
@@ -14,7 +15,28 @@ type InstallFlags struct {
 	Preset     string
 	SDDMode    string
 	Scope      string
+	Channel    string
 	DryRun     bool
+}
+
+const installChannelHelp = "Gentle AI channel: stable (default), beta, or nightly (alias for beta) — env: GENTLE_AI_CHANNEL"
+
+func PrintInstallHelp(w io.Writer) {
+	fmt.Fprint(w, `USAGE
+  gentle-ai install [flags]
+
+FLAGS
+  --agent, --agents <list>           Agents to install
+  --component, --components <list>   Components to install
+  --skill, --skills <list>           Skills to install
+  --persona <name>                   Persona to apply
+  --preset <name>                    Preset to apply
+  --sdd-mode single|multi            SDD orchestrator mode
+  --scope global|workspace           Install scope (env: GENTLE_AI_INSTALL_SCOPE)
+  --channel stable|beta|nightly      Release channel; nightly is an alias for beta (env: GENTLE_AI_CHANNEL)
+  --dry-run                          Preview plan without executing
+  --help, -h                         Show this help
+`)
 }
 
 func ParseInstallFlags(args []string) (InstallFlags, error) {
@@ -32,6 +54,7 @@ func ParseInstallFlags(args []string) (InstallFlags, error) {
 	fs.StringVar(&opts.Preset, "preset", "", "preset to apply")
 	fs.StringVar(&opts.SDDMode, "sdd-mode", "", "SDD orchestrator mode: single or multi (default: single)")
 	fs.StringVar(&opts.Scope, "scope", "", "install scope: global (default) or workspace — env: GENTLE_AI_INSTALL_SCOPE")
+	fs.StringVar(&opts.Channel, "channel", "", installChannelHelp)
 	fs.BoolVar(&opts.DryRun, "dry-run", false, "preview plan without executing")
 
 	if err := fs.Parse(args); err != nil {

--- a/internal/cli/install_test.go
+++ b/internal/cli/install_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/gentleman-programming/gentle-ai/internal/model"
@@ -17,6 +18,7 @@ func TestParseInstallFlagsSupportsCSVAndRepeated(t *testing.T) {
 		"--skill", "sdd-apply",
 		"--persona", "neutral",
 		"--preset", "minimal",
+		"--channel", "beta",
 		"--dry-run",
 	})
 	if err != nil {
@@ -33,6 +35,15 @@ func TestParseInstallFlagsSupportsCSVAndRepeated(t *testing.T) {
 
 	if !flags.DryRun {
 		t.Fatalf("DryRun = false, want true")
+	}
+	if flags.Channel != "beta" {
+		t.Fatalf("Channel = %q, want beta", flags.Channel)
+	}
+}
+
+func TestInstallChannelHelpMentionsNightly(t *testing.T) {
+	if !strings.Contains(installChannelHelp, "nightly") {
+		t.Fatalf("installChannelHelp = %q, want nightly mentioned", installChannelHelp)
 	}
 }
 
@@ -76,6 +87,19 @@ func TestNormalizeInstallFlagsDefaults(t *testing.T) {
 
 	if !reflect.DeepEqual(input.Selection, want) {
 		t.Fatalf("selection = %#v, want %#v", input.Selection, want)
+	}
+	if input.Channel != ChannelStable {
+		t.Fatalf("Channel = %q, want %q", input.Channel, ChannelStable)
+	}
+}
+
+func TestNormalizeInstallFlagsChannelBeta(t *testing.T) {
+	input, err := NormalizeInstallFlags(InstallFlags{Channel: "beta"}, system.DetectionResult{})
+	if err != nil {
+		t.Fatalf("NormalizeInstallFlags() error = %v", err)
+	}
+	if input.Channel != ChannelBeta {
+		t.Fatalf("Channel = %q, want %q", input.Channel, ChannelBeta)
 	}
 }
 

--- a/internal/cli/openclaw_orchestration_test.go
+++ b/internal/cli/openclaw_orchestration_test.go
@@ -179,7 +179,7 @@ func TestInstallRuntimeOpenClawUsesConfiguredActiveWorkspace(t *testing.T) {
 		Agents:            []model.AgentID{model.AgentOpenClaw},
 		OrderedComponents: selection.Components,
 	}
-	rt, err := newInstallRuntime(home, ScopeGlobal, selection, resolved, system.PlatformProfile{PackageManager: "brew"})
+	rt, err := newInstallRuntime(home, ScopeGlobal, ChannelStable, selection, resolved, system.PlatformProfile{PackageManager: "brew"})
 	if err != nil {
 		t.Fatalf("newInstallRuntime() error = %v", err)
 	}

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -54,6 +54,7 @@ var (
 	runCommand          = executeCommand
 	cmdLookPath         = exec.LookPath
 	streamCommandOutput = true
+	goEnv               = defaultGoEnv
 
 	// ggaAvailableCheck is an optional override for ggaAvailable behavior.
 	// When set, it is called instead of the default filesystem check.
@@ -126,7 +127,7 @@ func RunInstall(args []string, detection system.DetectionResult) (InstallResult,
 				"To install only into the current workspace, rerun with --scope=workspace.\n\n")
 	}
 
-	runtime, err := newInstallRuntime(homeDir, input.Scope, input.Selection, resolved, profile)
+	runtime, err := newInstallRuntime(homeDir, input.Scope, input.Channel, input.Selection, resolved, profile)
 	if err != nil {
 		return result, err
 	}
@@ -274,6 +275,73 @@ func goInstallBinDir() string {
 	return filepath.Join("~", "go", "bin")
 }
 
+func defaultGoEnv(keys ...string) (map[string]string, error) {
+	args := append([]string{"env"}, keys...)
+	out, err := exec.Command("go", args...).Output()
+	if err != nil {
+		return nil, err
+	}
+
+	lines := strings.Split(strings.TrimRight(string(out), "\r\n"), "\n")
+	values := make(map[string]string, len(keys))
+	for i, key := range keys {
+		if i < len(lines) {
+			values[key] = strings.TrimSpace(lines[i])
+		}
+	}
+	return values, nil
+}
+
+func goInstallBinDirFromGoEnv() (string, error) {
+	values, err := goEnv("GOBIN", "GOPATH")
+	if err != nil {
+		return "", err
+	}
+	if gobin := strings.TrimSpace(values["GOBIN"]); gobin != "" {
+		return gobin, nil
+	}
+	if gopath := strings.TrimSpace(values["GOPATH"]); gopath != "" {
+		return filepath.Join(gopath, "bin"), nil
+	}
+	return "", fmt.Errorf("go env returned empty GOBIN and GOPATH")
+}
+
+func installBetaEngramFromMain() (string, error) {
+	const pkg = "github.com/Gentleman-Programming/engram/cmd/engram@main"
+	if err := runCommand("go", "install", pkg); err != nil {
+		return "", err
+	}
+
+	binDir, err := goInstallBinDirFromGoEnv()
+	if err != nil {
+		return "", fmt.Errorf("resolve go install bin dir: %w", err)
+	}
+
+	binaryName := "engram"
+	if runtime.GOOS == "windows" {
+		binaryName += ".exe"
+	}
+	binaryPath := filepath.Join(binDir, binaryName)
+	if err := prependToPath(binDir); err != nil {
+		return "", err
+	}
+	return binaryPath, nil
+}
+
+func prependToPath(dir string) error {
+	if dir == "" {
+		return nil
+	}
+	if isInPATH(dir) {
+		return nil
+	}
+	path := os.Getenv("PATH")
+	if path == "" {
+		return osSetenv("PATH", dir)
+	}
+	return osSetenv("PATH", dir+string(os.PathListSeparator)+path)
+}
+
 // isInPATH reports whether dir is present in the current PATH.
 func isInPATH(dir string) bool {
 	for _, entry := range filepath.SplitList(os.Getenv("PATH")) {
@@ -313,6 +381,7 @@ type installRuntime struct {
 	selection    model.Selection
 	resolved     planner.ResolvedPlan
 	profile      system.PlatformProfile
+	channel      InstallChannel
 	backupRoot   string
 	state        *runtimeState
 }
@@ -321,7 +390,7 @@ type runtimeState struct {
 	manifest backup.Manifest
 }
 
-func newInstallRuntime(homeDir string, scope InstallScope, selection model.Selection, resolved planner.ResolvedPlan, profile system.PlatformProfile) (*installRuntime, error) {
+func newInstallRuntime(homeDir string, scope InstallScope, channel InstallChannel, selection model.Selection, resolved planner.ResolvedPlan, profile system.PlatformProfile) (*installRuntime, error) {
 	backupRoot := filepath.Join(homeDir, ".gentle-ai", "backups")
 	if err := os.MkdirAll(backupRoot, 0o755); err != nil {
 		return nil, fmt.Errorf("create backup root directory %q: %w", backupRoot, err)
@@ -337,6 +406,7 @@ func newInstallRuntime(homeDir string, scope InstallScope, selection model.Selec
 		selection:    selection,
 		resolved:     resolved,
 		profile:      profile,
+		channel:      channel,
 		backupRoot:   backupRoot,
 		state:        &runtimeState{},
 	}, nil
@@ -391,6 +461,7 @@ func (r *installRuntime) stagePlan() pipeline.StagePlan {
 			agents:       r.resolved.Agents,
 			selection:    r.selection,
 			profile:      r.profile,
+			channel:      r.channel,
 		})
 	}
 
@@ -571,6 +642,7 @@ type componentApplyStep struct {
 	agents       []model.AgentID
 	selection    model.Selection
 	profile      system.PlatformProfile
+	channel      InstallChannel
 }
 
 func (s componentApplyStep) ID() string {
@@ -595,7 +667,14 @@ func (s componentApplyStep) Run() error {
 
 	switch s.component {
 	case model.ComponentEngram:
-		if _, err := cmdLookPath("engram"); err != nil {
+		engramCommand := "engram"
+		if s.channel.IsBeta() {
+			binaryPath, err := installBetaEngramFromMain()
+			if err != nil {
+				return fmt.Errorf("install beta engram from main: %w", err)
+			}
+			engramCommand = binaryPath
+		} else if _, err := cmdLookPath("engram"); err != nil {
 			// Engram not on PATH — install it.
 			if s.profile.PackageManager == "brew" {
 				// macOS (or Linux with Homebrew): use brew tap + brew install.
@@ -630,7 +709,7 @@ func (s componentApplyStep) Run() error {
 			if engram.ShouldAttemptSetup(setupMode, adapter.Agent()) {
 				slug, _ := engram.SetupAgentSlug(adapter.Agent())
 				if _, seen := attemptedSlugs[slug]; !seen {
-					if err := runCommand("engram", "setup", slug); err != nil {
+					if err := runCommand(engramCommand, "setup", slug); err != nil {
 						if setupStrict {
 							return fmt.Errorf("engram setup for %q: %w", adapter.Agent(), err)
 						}
@@ -819,7 +898,12 @@ func BuildRealStagePlan(homeDir string, scope InstallScope, selection model.Sele
 		return pipeline.StagePlan{}, fmt.Errorf("create backup root directory %q: %w", backupRoot, err)
 	}
 
-	runtime, err := newInstallRuntime(homeDir, scope, selection, resolved, profile)
+	channel, err := ResolveInstallChannel("")
+	if err != nil {
+		return pipeline.StagePlan{}, err
+	}
+
+	runtime, err := newInstallRuntime(homeDir, scope, channel, selection, resolved, profile)
 	if err != nil {
 		return pipeline.StagePlan{}, err
 	}

--- a/internal/cli/run_engram_download_test.go
+++ b/internal/cli/run_engram_download_test.go
@@ -210,5 +210,73 @@ func TestRunInstallMacOSEngramStillUsesBrew(t *testing.T) {
 	}
 }
 
+func TestRunInstallBetaEngramUsesMainGoInstallAndInstalledBinary(t *testing.T) {
+	home := t.TempDir()
+	gobin := filepath.Join(home, "go-bin")
+	if err := os.MkdirAll(gobin, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	betaEngram := filepath.Join(gobin, "engram")
+	if err := os.WriteFile(betaEngram, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	restoreHome := osUserHomeDir
+	restoreCommand := runCommand
+	restoreLookPath := cmdLookPath
+	restoreGoEnv := goEnv
+	restorePath := os.Getenv("PATH")
+	t.Cleanup(func() {
+		osUserHomeDir = restoreHome
+		runCommand = restoreCommand
+		cmdLookPath = restoreLookPath
+		goEnv = restoreGoEnv
+		os.Setenv("PATH", restorePath)
+	})
+
+	osUserHomeDir = func() (string, error) { return home, nil }
+	cmdLookPath = func(name string) (string, error) {
+		if name == "engram" {
+			return "/usr/local/bin/engram", nil
+		}
+		return missingBinaryLookPath(name)
+	}
+	goEnv = func(keys ...string) (map[string]string, error) {
+		return map[string]string{"GOBIN": gobin, "GOPATH": filepath.Join(home, "go")}, nil
+	}
+	recorder := &commandRecorder{}
+	runCommand = recorder.record
+
+	detection := linuxDetectionResult(system.LinuxDistroUbuntu, "apt")
+	_, err := RunInstall(
+		[]string{"--agent", "opencode", "--component", "engram", "--channel", "beta"},
+		detection,
+	)
+	if err != nil {
+		t.Fatalf("RunInstall() error = %v", err)
+	}
+
+	commands := recorder.get()
+	foundGoInstall := false
+	foundSetupWithBetaBinary := false
+	for _, cmd := range commands {
+		if cmd == "go install github.com/Gentleman-Programming/engram/cmd/engram@main" {
+			foundGoInstall = true
+		}
+		if strings.HasPrefix(cmd, betaEngram+" setup ") {
+			foundSetupWithBetaBinary = true
+		}
+	}
+	if !foundGoInstall {
+		t.Fatalf("expected beta engram go install from main, got commands: %v", commands)
+	}
+	if !foundSetupWithBetaBinary {
+		t.Fatalf("expected setup to use beta engram binary %q, got commands: %v", betaEngram, commands)
+	}
+	if got := filepath.SplitList(os.Getenv("PATH"))[0]; got != gobin {
+		t.Fatalf("PATH first entry = %q, want %q", got, gobin)
+	}
+}
+
 // Make sure the engram package's DownloadLatestBinary is accessible.
 var _ = engram.DownloadLatestBinary

--- a/internal/cli/run_engram_download_test.go
+++ b/internal/cli/run_engram_download_test.go
@@ -213,28 +213,19 @@ func TestRunInstallMacOSEngramStillUsesBrew(t *testing.T) {
 func TestRunInstallBetaEngramUsesMainGoInstallAndInstalledBinary(t *testing.T) {
 	home := t.TempDir()
 	gobin := filepath.Join(home, "go-bin")
-	if err := os.MkdirAll(gobin, 0o755); err != nil {
-		t.Fatalf("MkdirAll() error = %v", err)
-	}
 	betaEngram := filepath.Join(gobin, "engram")
-	if err := os.WriteFile(betaEngram, []byte("#!/bin/sh\n"), 0o755); err != nil {
-		t.Fatalf("WriteFile() error = %v", err)
-	}
 
-	restoreHome := osUserHomeDir
 	restoreCommand := runCommand
 	restoreLookPath := cmdLookPath
 	restoreGoEnv := goEnv
 	restorePath := os.Getenv("PATH")
 	t.Cleanup(func() {
-		osUserHomeDir = restoreHome
 		runCommand = restoreCommand
 		cmdLookPath = restoreLookPath
 		goEnv = restoreGoEnv
 		os.Setenv("PATH", restorePath)
 	})
 
-	osUserHomeDir = func() (string, error) { return home, nil }
 	cmdLookPath = func(name string) (string, error) {
 		if name == "engram" {
 			return "/usr/local/bin/engram", nil
@@ -272,9 +263,6 @@ func TestRunInstallBetaEngramUsesMainGoInstallAndInstalledBinary(t *testing.T) {
 	}
 	if !foundSetupWithBetaBinary {
 		t.Fatalf("expected setup to use beta engram binary %q, got commands: %v", betaEngram, commands)
-	}
-	if got := filepath.SplitList(os.Getenv("PATH"))[0]; got != gobin {
-		t.Fatalf("PATH first entry = %q, want %q", got, gobin)
 	}
 }
 

--- a/internal/cli/validate.go
+++ b/internal/cli/validate.go
@@ -12,6 +12,7 @@ import (
 type InstallInput struct {
 	Selection model.Selection
 	Scope     InstallScope
+	Channel   InstallChannel
 	DryRun    bool
 }
 
@@ -63,7 +64,12 @@ func NormalizeInstallFlags(flags InstallFlags, detection system.DetectionResult)
 		return InstallInput{}, err
 	}
 
-	return InstallInput{Selection: selection, Scope: scope, DryRun: flags.DryRun}, nil
+	channel, err := ResolveInstallChannel(flags.Channel)
+	if err != nil {
+		return InstallInput{}, err
+	}
+
+	return InstallInput{Selection: selection, Scope: scope, Channel: channel, DryRun: flags.DryRun}, nil
 }
 
 func normalizePersona(value string) (model.PersonaID, error) {

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -7,6 +7,7 @@
 .DESCRIPTION
     Downloads and installs the gentle-ai binary for Windows.
     Supports installation via Go or pre-built binary from GitHub Releases.
+    Accepted channels: stable (default), beta, nightly.
 
 .EXAMPLE
     # Run directly:
@@ -19,6 +20,9 @@
     # Force a specific method:
     .\install.ps1 -Method binary
     .\install.ps1 -Method go
+
+    # Install the beta channel from main:
+    .\install.ps1 -Channel beta
 
     # Skip checksum verification (not recommended):
     .\install.ps1 -Method binary -Insecure
@@ -110,7 +114,15 @@ function Test-Prerequisites {
 # ============================================================================
 
 function Get-InstallMethod {
-    param([string]$Forced)
+    param([string]$Forced, [string]$Channel)
+
+    if ($Channel -eq "beta") {
+        if ($Forced -ne "auto" -and $Forced -ne "go") {
+            Stop-WithError "-Channel beta installs Gentle AI from main and only supports -Method go"
+        }
+        Write-Info "Using beta channel — will install $BINARY_NAME from main via go install"
+        return "go"
+    }
 
     if ($Forced -ne "auto") {
         Write-Info "Using forced method: $Forced"
@@ -131,9 +143,12 @@ function Get-InstallMethod {
 # ============================================================================
 
 function Install-ViaGo {
+    param([string]$Channel = "stable")
+
     Write-Step "Installing via go install"
 
-    $goPackage = "github.com/$($GITHUB_OWNER.ToLower())/$GITHUB_REPO/cmd/$BINARY_NAME@latest"
+    $version = if ($Channel -eq "beta") { "main" } else { "latest" }
+    $goPackage = "github.com/$($GITHUB_OWNER.ToLower())/$GITHUB_REPO/cmd/$BINARY_NAME@$version"
     Write-Info "Running: go install $goPackage"
 
     & go install $goPackage
@@ -346,11 +361,17 @@ function Test-Installation {
 # ============================================================================
 
 function Show-NextSteps {
+    param([string]$Channel = "stable")
+
     Write-Host ""
     Write-Host "Installation complete!" -ForegroundColor Green
     Write-Host ""
     Write-Host "Next steps:" -ForegroundColor White
-    Write-Host "  1. Run '$BINARY_NAME' to start the TUI installer" -ForegroundColor Cyan
+    if ($Channel -eq "beta") {
+        Write-Host ('  1. Run ''$env:GENTLE_AI_CHANNEL = "beta"; {0} install'' to keep using the beta channel' -f $BINARY_NAME) -ForegroundColor Cyan
+    } else {
+        Write-Host "  1. Run '$BINARY_NAME' to start the TUI installer" -ForegroundColor Cyan
+    }
     Write-Host "  2. Select your AI agent(s) and tools to configure" -ForegroundColor Cyan
     Write-Host "  3. Follow the interactive prompts" -ForegroundColor Cyan
     Write-Host ""
@@ -369,6 +390,9 @@ function Main {
         [ValidateSet("auto", "go", "binary")]
         [string]$Method = "auto",
 
+        [ValidateSet("stable", "beta", "nightly")]
+        [string]$Channel = $(if ($env:GENTLE_AI_CHANNEL) { $env:GENTLE_AI_CHANNEL } else { "stable" }),
+
         [string]$InstallDir = "",
 
         [switch]$Insecure
@@ -379,15 +403,17 @@ function Main {
     $arch = Get-Platform
     Test-Prerequisites
 
-    $installMethod = Get-InstallMethod -Forced $Method
+    if ($Channel -eq "nightly") { $Channel = "beta" }
+
+    $installMethod = Get-InstallMethod -Forced $Method -Channel $Channel
 
     switch ($installMethod) {
-        "go"     { Install-ViaGo }
+        "go"     { Install-ViaGo -Channel $Channel }
         "binary" { Install-ViaBinary -Arch $arch }
     }
 
     Test-Installation
-    Show-NextSteps
+    Show-NextSteps -Channel $Channel
 }
 
 Main @args

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -94,6 +94,7 @@ Usage: install.sh [OPTIONS]
 
 Options:
   --method METHOD   Force install method: brew, go, binary (default: auto-detect)
+  --channel CHANNEL Gentle AI channel: stable (default), beta, or nightly (env: GENTLE_AI_CHANNEL)
   --dir DIR         Custom install directory for binary method
   --insecure        Skip checksum verification (not recommended)
   -h, --help        Show this help
@@ -106,6 +107,7 @@ Install methods (auto-detected in priority order):
 Examples:
   curl -sL https://raw.githubusercontent.com/${GITHUB_OWNER}/${GITHUB_REPO}/main/scripts/install.sh | bash
   ./install.sh --method binary
+  ./install.sh --channel beta
   ./install.sh --method binary --dir \$HOME/.local/bin
   ./install.sh --method binary --insecure   # skip checksum (not recommended)
 
@@ -184,6 +186,15 @@ check_prerequisites() {
 # ============================================================================
 
 detect_install_method() {
+    if [ "${CHANNEL}" = "beta" ]; then
+        if [ -n "${FORCE_METHOD:-}" ] && [ "${FORCE_METHOD}" != "go" ]; then
+            fatal "--channel beta installs Gentle AI from main and only supports --method go"
+        fi
+        INSTALL_METHOD="go"
+        info "Using beta channel — will install ${BINARY_NAME} from main via go install"
+        return
+    fi
+
     if [ -n "${FORCE_METHOD:-}" ]; then
         case "$FORCE_METHOD" in
             brew|go|binary) INSTALL_METHOD="$FORCE_METHOD" ;;
@@ -258,7 +269,11 @@ install_brew() {
 install_go() {
     step "Installing via go install"
 
-    local go_package="github.com/${GITHUB_OWNER,,}/${GITHUB_REPO}/cmd/${BINARY_NAME}@latest"
+    local version="latest"
+    if [ "${CHANNEL}" = "beta" ]; then
+        version="main"
+    fi
+    local go_package="github.com/${GITHUB_OWNER,,}/${GITHUB_REPO}/cmd/${BINARY_NAME}@${version}"
 
     info "Running: go install ${go_package}"
     if ! go install "$go_package"; then
@@ -493,7 +508,11 @@ print_next_steps() {
     echo -e "${GREEN}${BOLD}Installation complete!${NC}"
     echo ""
     echo -e "${BOLD}Next steps:${NC}"
-    echo -e "  ${CYAN}1.${NC} Run ${BOLD}${BINARY_NAME}${NC} to start the TUI installer"
+    if [ "${CHANNEL}" = "beta" ]; then
+        echo -e "  ${CYAN}1.${NC} Run ${BOLD}GENTLE_AI_CHANNEL=beta ${BINARY_NAME} install${NC} to keep using the beta channel"
+    else
+        echo -e "  ${CYAN}1.${NC} Run ${BOLD}${BINARY_NAME}${NC} to start the TUI installer"
+    fi
     echo -e "  ${CYAN}2.${NC} Select your AI agent(s) and tools to configure"
     echo -e "  ${CYAN}3.${NC} Follow the interactive prompts"
     echo ""
@@ -513,12 +532,17 @@ main() {
     FORCE_METHOD=""
     INSTALL_DIR=""
     INSECURE="false"
+    CHANNEL="${GENTLE_AI_CHANNEL:-stable}"
 
     while [ $# -gt 0 ]; do
         case "$1" in
             --method)
                 [ $# -lt 2 ] && fatal "--method requires an argument"
                 FORCE_METHOD="$2"; shift 2
+                ;;
+            --channel)
+                [ $# -lt 2 ] && fatal "--channel requires an argument"
+                CHANNEL="$2"; shift 2
                 ;;
             --dir)
                 [ $# -lt 2 ] && fatal "--dir requires an argument"
@@ -537,6 +561,14 @@ main() {
                 ;;
         esac
     done
+
+    case "${CHANNEL}" in
+        stable|beta|nightly) ;;
+        *) fatal "Unknown channel: ${CHANNEL}. Use: stable, beta, or nightly" ;;
+    esac
+    if [ "${CHANNEL}" = "nightly" ]; then
+        CHANNEL="beta"
+    fi
 
     print_banner
 


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #854

---

## 🏷️ PR Type

- [ ] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [x] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Adds a top-level Gentle AI beta/nightly channel for testing unreleased main-branch integrations.
- Installer beta/nightly installs Gentle AI from `main` and tells users to continue with `GENTLE_AI_CHANNEL=beta gentle-ai install`.
- CLI beta/nightly installs core Engram from `main` via Go and injects the absolute beta Engram command so stable PATH binaries cannot win.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|--------------|
| `scripts/install.sh`, `scripts/install.ps1` | Add `--channel` / `-Channel` with `stable`, `beta`, and `nightly`; beta installs Gentle AI from main and prints beta next steps. |
| `internal/cli/channel.go` | Adds product-level channel resolution from flag/env. |
| `internal/cli/install.go`, `validate.go`, `run.go` | Threads channel through install and beta Engram install/setup/injection. |
| `internal/app/app.go` | Adds `gentle-ai install --help` handling. |
| Tests | Covers channel parsing, install help, beta Engram main install, path precedence, and stable behavior. |

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test -count=1 ./internal/app ./internal/cli
bash -n scripts/install.sh
```

**E2E Tests** (Docker required)
```bash
cd e2e && ./docker-test.sh
```

- [x] Unit tests pass (`go test -count=1 ./internal/app ./internal/cli`)
- [x] Script syntax passes (`bash -n scripts/install.sh`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — N/A for installer/channel unit slice; CI E2E will still run.
- [x] Manually reviewed with fresh-context review.

---

## 🤖 Automated Checks

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ✅ | 398 changed lines, under budget. |
| Check Issue Reference | ✅ | Body contains `Closes #854`. |
| Check Issue Has `status:approved` | ✅ | Issue #854 has `status:approved`. |
| Check PR Has `type:*` Label | ⏳ | `type:feature` to be applied. |
| Unit Tests | ✅ | Focused tests passed locally. |
| E2E Tests | ⏳ | Run in CI. |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test -count=1 ./internal/app ./internal/cli`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] I have updated documentation if necessary
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

This intentionally ignores Pi, `gentle-pi`, and `gentle-engram`. The beta/nightly channel is product-level for Gentle AI plus core Engram only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--channel` option to install commands, supporting `stable`, `beta`, and `nightly` releases (nightly is an alias for beta), with `stable` as the default
  * Channel can be configured via `--channel` flag or `GENTLE_AI_CHANNEL` environment variable
  * Beta channel provides development builds with specific post-install setup instructions

* **Documentation**
  * Updated install help and examples to document channel selection usage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->