### PR TITLE
fix(upgrade): handle missing engram process on Windows

### DIFF
--- a/internal/components/engram/download.go
+++ b/internal/components/engram/download.go
@@ -438,6 +438,9 @@ func stopEngramProcesses() error {
 	return stopEngramProcessesNamed("engram")
 }
 
+// stopEngramProcessesNamed stops running processes with the given name.
+// Missing processes are treated as success so clean Windows installs and
+// upgrades do not fail when Engram is not currently running.
 func stopEngramProcessesNamed(processName string) error {
 	escapedProcessName := strings.ReplaceAll(processName, "'", "''")
 	script := fmt.Sprintf("$p = Get-Process -Name '%s' -ErrorAction SilentlyContinue; if ($p) { $p | Stop-Process -Force -ErrorAction Stop }; exit 0", escapedProcessName)

--- a/internal/components/engram/download.go
+++ b/internal/components/engram/download.go
@@ -431,18 +431,26 @@ func extractZipBinary(data []byte, binaryName, outPath string) error {
 }
 
 // stopEngramProcesses stops any running Engram process so Windows can replace
-// engram.exe during upgrade. Missing processes are not an error because
-// Get-Process uses SilentlyContinue.
+// engram.exe during upgrade. Missing processes are not an error; avoid piping
+// directly from Get-Process because Windows PowerShell 5.1 can still exit 1
+// when the process does not exist.
 func stopEngramProcesses() error {
+	return stopEngramProcessesNamed("engram")
+}
+
+func stopEngramProcessesNamed(processName string) error {
+	escapedProcessName := strings.ReplaceAll(processName, "'", "''")
+	script := fmt.Sprintf("$p = Get-Process -Name '%s' -ErrorAction SilentlyContinue; if ($p) { $p | Stop-Process -Force -ErrorAction Stop }; exit 0", escapedProcessName)
+
 	cmd := exec.Command("powershell.exe",
 		"-NoProfile",
 		"-NonInteractive",
 		"-Command",
-		"Get-Process -Name engram -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction Stop",
+		script,
 	)
 	cmd.Stdin = nil
 	if out, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("powershell Stop-Process engram: %w (output: %s)", err, strings.TrimSpace(string(out)))
+		return fmt.Errorf("powershell Stop-Process %s: %w (output: %s)", processName, err, strings.TrimSpace(string(out)))
 	}
 	return nil
 }

--- a/internal/components/engram/download_test.go
+++ b/internal/components/engram/download_test.go
@@ -521,6 +521,17 @@ func TestDownloadLatestBinaryWindowsStopsEngramBeforeReplace(t *testing.T) {
 	}
 }
 
+func TestStopEngramProcessesWindowsNoProcessSucceeds(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("PowerShell process handling is Windows-specific")
+	}
+
+	err := stopEngramProcessesNamed("gentle-ai-engram-test-definitely-missing")
+	if err != nil {
+		t.Fatalf("stopEngramProcessesNamed() with missing process error = %v, want nil", err)
+	}
+}
+
 func TestDownloadLatestBinaryWindowsStopFailureAbortsBeforeReplace(t *testing.T) {
 	version := versions.EngramCore
 	server := makeServerWithFakeZip(t, version)


### PR DESCRIPTION
Fixes #815

## Summary
- Avoid piping directly from Get-Process into Stop-Process on Windows.
- Make the Engram stop step succeed when the process is not running.
- Add a Windows-specific regression test for the missing-process path.

## Changes
| File | Change |
|------|--------|
| \internal/components/engram/download.go\ | Guard the PowerShell stop command with an explicit process lookup |
| \internal/components/engram/download_test.go\ | Add regression coverage for missing process handling |

## Test plan
- [x] \go test ./internal/components/engram\
- [x] On Windows PowerShell 5.1, verified missing Engram process handling succeeds without blocking upgrade.
- [x] Verified stop-process failure still aborts before replacing \engram.exe\.

## Notes
I also reproduced this through the interactive TUI \upgrade tools\ path while upgrading Engram on Windows/Scoop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows shutdown reliability: shutdown now tolerates missing target processes, forces a successful exit, and provides clearer, trimmed error diagnostics including the target process name.

* **Tests**
  * Added Windows-specific test coverage for scenarios where target processes are not found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->