### PR TITLE
fix(engram): stop engram processes gracefully on Windows upgrade

### DIFF
--- a/internal/components/engram/download.go
+++ b/internal/components/engram/download.go
@@ -431,15 +431,15 @@ func extractZipBinary(data []byte, binaryName, outPath string) error {
 	return fmt.Errorf("binary %q not found in zip archive", binaryName)
 }
 
-// stopEngramProcesses stops any running Engram process so Windows can replace
-// engram.exe during upgrade. Missing processes are not an error because
-// Get-Process uses SilentlyContinue.
+// stopEngramProcesses stops any running Engram processes so Windows can replace
+// engram.exe during an upgrade. If Engram is not running, the pipeline produces
+// no output and Stop-Process is not invoked.
 func stopEngramProcesses() error {
 	cmd := exec.Command("powershell.exe",
 		"-NoProfile",
 		"-NonInteractive",
 		"-Command",
-		"Get-Process -Name engram -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction Stop",
+		"Get-Process | Where-Object Name -eq engram | Stop-Process -Force -ErrorAction Stop",
 	)
 	cmd.Stdin = nil
 	if out, err := cmd.CombinedOutput(); err != nil {


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #815

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

This PR fixes a regression on Windows clean installs / upgrades where the installer fails if `engram.exe` is not already running.

### Cause
Using `Get-Process -Name engram -ErrorAction SilentlyContinue` generates a non-terminating error (`ProcessNameNotFound`) when Engram is not running. Even though the output is suppressed, this non-terminating error marks the execution status `$?` as `$false`, causing the parent `powershell.exe -Command` to return exit code `1`.

### Solution
Rewrote the pipeline to list processes and filter them using `Where-Object`:
`Get-Process | Where-Object Name -eq engram | Stop-Process -Force -ErrorAction Stop`

If the process is not running, the pipeline yields no output, `Stop-Process` is not called, and the exit code is `0`. If it is running and fails to stop (due to permissions or other system errors), it triggers a terminating error via `-ErrorAction Stop` and correctly exits with code `1`.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/components/engram/download.go` | Replaced direct Get-Process with a Where-Object pipeline to avoid non-terminating errors when engram is not running. Updated function documentation to clarify this behavior. |

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./internal/components/engram/...
```

- [x] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Manually tested locally

---

## 🤖 Automated Checks

The following checks run automatically on this PR:

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | PR should stay within 400 changed lines (`additions + deletions`) or use `size:exception` |
| Check Issue Reference | ⏳ | PR body must contain `Closes/Fixes/Resolves #N` |
| Check Issue Has `status:approved` | ⏳ | Linked issue must have been approved before work began |
| Check PR Has `type:*` Label | ⏳ | Exactly one `type:*` label must be applied |
| Unit Tests | ⏳ | `go test ./...` must pass |
| E2E Tests | ⏳ | `cd e2e && ./docker-test.sh` must pass |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

- PowerShell 5.1 behavior verified locally. The change uses a pipeline with `Where-Object` which gracefully returns nothing if no process exists, maintaining `$? = $true` and resulting in exit code `0`.
- E2E tests could not be run locally as Docker is not installed in the Windows environment, but they will run on the remote GitHub Actions runner once approved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of the upgrade process on Windows when stopping background services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->