### PR TITLE
fix(install): use -f operator in install.ps1 to support PowerShell 5.1

### DIFF
--- a/internal/update/install_script_test.go
+++ b/internal/update/install_script_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"regexp"
 	"testing"
 )
 
@@ -15,5 +16,32 @@ func TestWindowsInstallScriptHasNoUTF8BOM(t *testing.T) {
 	}
 	if bytes.HasPrefix(content, []byte{0xEF, 0xBB, 0xBF}) {
 		t.Fatal("scripts/install.ps1 starts with UTF-8 BOM; PowerShell irm | iex treats BOM+#Requires as an invalid command")
+	}
+}
+
+// TestWindowsInstallScriptHasNoUnsafeStringSubexpression guards against the
+// PowerShell 5.1 parser failure reported in issue #849. Patterns like
+// "($fileSize bytes)" inside a double-quoted string are read by Windows
+// PowerShell 5.1 as an invalid subexpression and abort parsing before any code
+// runs. Use the -f format operator instead, e.g. ("... {0} bytes" -f $fileSize).
+func TestWindowsInstallScriptHasNoUnsafeStringSubexpression(t *testing.T) {
+	path := filepath.Join("..", "..", "scripts", "install.ps1")
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", path, err)
+	}
+
+	// Match double-quoted strings, then flag any "($identifier <word>" inside
+	// them. Scoping to quoted strings avoids false positives on real code such
+	// as `foreach ($loc in $locations)`.
+	stringLiteral := regexp.MustCompile(`"[^"]*"`)
+	unsafeSubexpr := regexp.MustCompile(`\(\$[A-Za-z_][A-Za-z0-9_]*\s+[A-Za-z]`)
+
+	for _, line := range bytes.Split(content, []byte("\n")) {
+		for _, str := range stringLiteral.FindAll(line, -1) {
+			if unsafeSubexpr.Match(str) {
+				t.Errorf("scripts/install.ps1 contains an unsafe ($var word) string subexpression that breaks PowerShell 5.1 parsing: %s\nUse the -f format operator instead.", str)
+			}
+		}
 	}
 }

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -217,9 +217,9 @@ function Install-ViaBinary {
 
         $fileSize = (Get-Item $archivePath).Length
         if ($fileSize -lt 1000) {
-            Stop-WithError "Downloaded file is suspiciously small ($fileSize bytes). Archive may not exist for this platform."
+            Stop-WithError ("Downloaded file is suspiciously small ({0} bytes). Archive may not exist for this platform." -f $fileSize)
         }
-        Write-Success "Downloaded $archiveName ($fileSize bytes)"
+        Write-Success ("Downloaded {0} ({1} bytes)" -f $archiveName, $fileSize)
 
         # Verify checksum
         Write-Info "Verifying checksum..."


### PR DESCRIPTION
## Linked Issue

Closes #849

## PR Type

- [x] Bug fix

## Summary

- Windows PowerShell 5.1 aborts `scripts/install.ps1` before any code runs because `"($fileSize bytes)"` inside a double-quoted string is parsed as an invalid subexpression.
- Replaces the two affected interpolations with the `-f` format operator so the script parses on both PS 5.1 and PowerShell 7+.
- Adds a regression test that scans `install.ps1` for the unsafe pattern.

This is the same failure community members hit from "Upgrade tools": that flow downloads `scripts/install.ps1` to a temp file (`gentle-ai-install-*.ps1`) and runs it, so the parser error surfaces there too. Note that PS 5.1 reports the error at a later closing brace (e.g. `line 139: unexpected '}'`) because the broken string interpolation desyncs block parsing — the reported line is not where the real bug is.

## Changes

| File | Change |
|------|--------|
| `scripts/install.ps1` | Lines 220, 222: use `-f` format operator instead of `"($var word)"` interpolation |
| `internal/update/install_script_test.go` | Add `TestWindowsInstallScriptHasNoUnsafeStringSubexpression` guarding the pattern (scoped to quoted strings to avoid false positives like `foreach ($loc in $locations)`) |

## Test Plan

- [x] `go test ./internal/update/` passes (both install-script guards green)
- [x] Verified the regex matches the original buggy lines and not real code

## Contributor Checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] No shell scripts modified (PowerShell + Go only)
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added validation test for installation script compatibility with PowerShell 5.1.

* **Bug Fixes**
  * Updated string formatting in the installation script to improve compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->