### PR TITLE
feat(hermes): add ephemeral delegation skill and orchestrator guidance

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -263,8 +263,8 @@ Hermes uses `delegate_task` to spawn ephemeral sub-agents. Each worker starts in
 
 | Parameter | Default | Effect |
 |-----------|---------|--------|
-| `delegation.max_spawn_depth` | 2 | Maximum recursive delegation depth |
-| `delegation.max_concurrent_children` | 4 | Maximum parallel workers |
+| `max_spawn_depth` | 2 | Maximum recursive delegation depth |
+| `max_concurrent_children` | 4 | Maximum parallel workers |
 | `max_iterations` | agent default | Iteration budget per worker |
 | `child_timeout_seconds` | agent default | Hard timeout per worker |
 | `inherit_mcp_toolsets` | false | When true, workers inherit parent MCP toolsets automatically |

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -23,7 +23,7 @@
 | OpenClaw        | `openclaw`       | Yes          | Yes | Solo-agent                       | No            | No             | `~/.openclaw`                       |
 | Trae            | `trae-ide`       | Yes          | Yes | Solo-agent                       | No            | No             | `~/.trae`                           |
 | Pi              | `pi`             | Yes          | Yes | Full (package-managed subagents) | No            | Yes            | `~/.pi`                             |
-| Hermes          | `hermes`         | Yes          | Yes | Detect-only (no auto-install)    | No            | No             | `~/.hermes`                         |
+| Hermes          | `hermes`         | Yes          | Yes | Full (delegate_task ephemeral)   | No            | No             | `~/.hermes`                         |
 
 Most agents receive the **full SDD orchestrator** policy, plus skill files written to their skills directory. Most receive it through their system prompt; OpenCode and Kilo Code receive it through the OpenCode-compatible `opencode.json` agent overlay. Pi is the exception: Gentle AI installs Pi packages, and `gentle-pi` owns Pi skills, prompts, SDD agents, and chains at runtime. The agent handles SDD automatically when the task is large enough, or when the user explicitly asks for it — no manual setup required.
 
@@ -36,8 +36,8 @@ Most agents receive the **full SDD orchestrator** policy, plus skill files writt
 | Model                 | How It Works                                                                                                                                                                                       | Agents                                                                                                    |
 | --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
 | **Full (sub-agents)** | Each SDD phase runs in an isolated context window via native sub-agent delegation, package-managed subagents, or an OpenCode-compatible overlay. The orchestrator coordinates; sub-agents execute. | Claude Code, OpenCode, Kilo Code, Gemini CLI, Cursor, VS Code Copilot, Kimi Code, Kiro IDE, Qwen Code, Pi |
+| **Full (delegate_task)** | The orchestrator uses Hermes's native `delegate_task` primitive to spawn ephemeral workers in fresh context windows. Workers receive only a self-contained mission; the parent receives only their final summary. Toolsets, MCP, and skills must be passed explicitly (not inherited by default). | Hermes |
 | **Solo-agent**        | All SDD phases run inline in the same conversation. The orchestrator IS the executor. Engram provides cross-phase persistence.                                                                     | Codex, Windsurf, Antigravity, OpenClaw, Trae                                                              |
-| **Detect-only**       | gentle-ai detects the agent and injects skills, MCP, and persona when the binary is present. Auto-install is not supported — the user installs the agent manually.                                | Hermes                                                                                                    |
 
 ### Cursor Native Subagents
 
@@ -246,6 +246,31 @@ For the full Pi command and package reference, see [Pi Agent](pi.md).
 - **`@juicesharp/rpiv-ask-user-question` package**: lets Pi child agents ask the active user session for clarification when they need human input.
 - **Pi companion packages**: `pi-web-access`, `@juicesharp/rpiv-todo`, and `pi-btw` add web access, todo tracking, and companion workflow support.
 - **Pi-only flow**: when Pi is the only selected agent, gentle-ai skips persona, ecosystem component selection, and Strict TDD prompts because those behaviors are provided by `gentle-pi`.
+
+### Hermes Ephemeral Delegation
+
+Hermes uses `delegate_task` to spawn ephemeral sub-agents. Each worker starts in a fresh context window and returns only its final summary to the parent orchestrator.
+
+**Delegation rules:**
+
+- Delegate when work needs broad exploration (4+ files), multi-file implementation, test/build execution, or fresh adversarial review.
+- Each worker mission must be self-contained: include the exact goal, file paths or targets, relevant prior context, constraints, expected evidence, and the toolsets/MCP/skills the worker is allowed to use.
+- Toolsets, MCP servers, and skills are NOT automatically inherited from the parent; pass them explicitly in the mission when `inherit_mcp_toolsets` is false (the default).
+- Prefer parallel workers only for truly independent workstreams. Dependencies must run sequentially.
+- Treat worker output as self-report: verify file writes, test pass/fail, URLs, and external side effects before reporting success.
+
+**Tuning knobs** (configure in `~/.hermes/config.yaml` under the `delegation` key):
+
+| Parameter | Default | Effect |
+|-----------|---------|--------|
+| `delegation.max_spawn_depth` | 2 | Maximum recursive delegation depth |
+| `delegation.max_concurrent_children` | 4 | Maximum parallel workers |
+| `max_iterations` | agent default | Iteration budget per worker |
+| `child_timeout_seconds` | agent default | Hard timeout per worker |
+| `inherit_mcp_toolsets` | false | When true, workers inherit parent MCP toolsets automatically |
+| `subagent_auto_approve` | false | When true, workers auto-approve tool calls |
+
+The full delegation decision table lives in `~/.hermes/skills/hermes-ephemeral-delegation/SKILL.md` (installed by gentle-ai). The SDD orchestrator in `~/.hermes/SOUL.md` references this skill.
 
 ### Hermes
 

--- a/internal/assets/assets_test.go
+++ b/internal/assets/assets_test.go
@@ -999,9 +999,9 @@ func TestEmbeddedAssetCount(t *testing.T) {
 		}
 	}
 
-	// We expect 22 skill directories (10 SDD + judgment-day + 6 foundation + 4 sustainable-review + _shared).
-	if skillDirs != 22 {
-		t.Fatalf("expected 22 skill directories, got %d", skillDirs)
+	// We expect 23 skill directories (10 SDD + judgment-day + 6 foundation + 4 sustainable-review + hermes-ephemeral-delegation + _shared).
+	if skillDirs != 23 {
+		t.Fatalf("expected 23 skill directories, got %d", skillDirs)
 	}
 
 	// Verify each skill directory has a SKILL.md.

--- a/internal/assets/hermes/sdd-orchestrator.md
+++ b/internal/assets/hermes/sdd-orchestrator.md
@@ -13,8 +13,8 @@ The native delegation primitive in Hermes is `delegate_task`. Use it to spawn ep
 - Workers are ephemeral by default. Do NOT request persistent agent files or profiles unless the user explicitly asks for persistent agents.
 
 **Tuning knobs** (configure in `~/.hermes/config.yaml` under the `delegation` key, or pass per-call):
-- `delegation.max_spawn_depth` — maximum recursive depth (default: 2; set 1 to prevent workers from spawning workers)
-- `delegation.max_concurrent_children` — maximum parallel workers (default: 4)
+- `max_spawn_depth` — maximum recursive depth (default: 2; set 1 to prevent workers from spawning workers)
+- `max_concurrent_children` — maximum parallel workers (default: 4)
 - `max_iterations` — iteration budget per worker
 - `child_timeout_seconds` — hard timeout per worker
 - `inherit_mcp_toolsets` — when false (default), toolsets must be passed explicitly in the mission

--- a/internal/assets/hermes/sdd-orchestrator.md
+++ b/internal/assets/hermes/sdd-orchestrator.md
@@ -2,9 +2,29 @@
 
 Bind this to the dedicated `sdd-orchestrator` agent or rule only. Do NOT apply it to executor phase agents such as `sdd-apply` or `sdd-verify`.
 
+## Hermes Native Delegation
+
+The native delegation primitive in Hermes is `delegate_task`. Use it to spawn ephemeral workers that run in a fresh context window and return only their final summary to you.
+
+**Key behaviors of `delegate_task`:**
+- Each worker starts with a fresh context — no parent conversation history is inherited.
+- The parent (this orchestrator) receives only the worker's final output, not its intermediate steps.
+- Toolsets, MCP servers, and skills are NOT automatically inherited; pass them explicitly in the worker mission when `inherit_mcp_toolsets` is false (the default).
+- Workers are ephemeral by default. Do NOT request persistent agent files or profiles unless the user explicitly asks for persistent agents.
+
+**Tuning knobs** (configure in `~/.hermes/config.yaml` under the `delegation` key, or pass per-call):
+- `delegation.max_spawn_depth` — maximum recursive depth (default: 2; set 1 to prevent workers from spawning workers)
+- `delegation.max_concurrent_children` — maximum parallel workers (default: 4)
+- `max_iterations` — iteration budget per worker
+- `child_timeout_seconds` — hard timeout per worker
+- `inherit_mcp_toolsets` — when false (default), toolsets must be passed explicitly in the mission
+- `subagent_auto_approve` — when false (default), workers prompt for tool-call approval
+
+Load `~/.hermes/skills/hermes-ephemeral-delegation/SKILL.md` for the full delegation decision table and mission-drafting protocol before delegating non-SDD work.
+
 ## Agent Teams Orchestrator
 
-You are a COORDINATOR, not an executor. Maintain one thin conversation thread, delegate ALL real work to sub-agents, synthesize results.
+You are a COORDINATOR, not an executor. Maintain one thin conversation thread, delegate ALL real work to sub-agents via `delegate_task`, synthesize results.
 
 
 ### Language Domain Contract
@@ -43,7 +63,7 @@ Delegation is not optional once complexity appears. If a task crosses a trigger 
 
 These gates are **non-skippable hard gates**, not recommendations. They are TOTALMENTE obligatorio: do not skip them, do not weaken them, and do not replace delegation-required gates with inline execution. Tool unavailability is not a waiver; document it, stop the blocked delegated work, and perform the closest fresh-context audit only where the fired rule calls for review/audit.
 
-Semantic guard: **delegate** means using the platform's native sub-agent mechanism. Running local scripts, Python, or Bash inline is execution, not delegation.
+Semantic guard: **delegate** means calling Hermes's native `delegate_task`. Running local scripts, Python, or Bash inline is execution, not delegation.
 
 These are parent-orchestrator stop rules. When a trigger fires, perform the specific required action stated in that rule. Rules that say **delegate** require native sub-agent delegation. Rules that say **fresh review/audit** require fresh context before continuing. Do not pass these rules to child agents as permission to spawn more agents; children receive concrete role work and must not orchestrate.
 

--- a/internal/assets/skills/hermes-ephemeral-delegation/SKILL.md
+++ b/internal/assets/skills/hermes-ephemeral-delegation/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: hermes-ephemeral-delegation
+description: "Trigger: broad exploration, multi-file reads, tests/builds, fresh review, or multi-step debug. Orchestrate complex work via delegate_task to protect context."
+license: Apache-2.0
+metadata:
+  author: gentleman-programming
+  version: "1.0"
+---
+
+## Activation Contract
+
+Load this skill when you are acting as the parent orchestrator and the work ahead falls into any of these categories:
+
+- Broad exploration (4+ files to understand, codebase mapping, approach comparison)
+- Multi-file implementation (touching 2+ non-trivial files)
+- Test or build execution
+- Fresh adversarial review (diffs, PR readiness, incident audit)
+- Multi-step debugging that would flood the parent context
+
+Do NOT load this skill if you are already inside a delegated child task — you are the executor, not the orchestrator.
+
+## Hard Rules
+
+- Use `delegate_task` for all complex work listed above. Do NOT execute it inline.
+- Workers are EPHEMERAL: each `delegate_task` call creates a fresh context. Do NOT request persistent agent files or profiles.
+- Pass a self-contained mission. Workers have no memory of the parent conversation.
+- Treat worker output as self-report: verify file writes, test pass/fail, URLs, and IDs before reporting success to the user.
+- Batch parallel calls only for INDEPENDENT workstreams. Sequential dependencies must run sequentially.
+
+## Decision Gates
+
+| Situation | Action |
+|-----------|--------|
+| Need to read 4+ files to understand | Delegate a narrow exploration worker |
+| Need to write 2+ non-trivial files | Delegate a single writer with the full mission |
+| Need to run tests or builds | Delegate an executor; do not run inline |
+| Need an adversarial review of a diff | Delegate a fresh-context reviewer |
+| Multi-step debug that grows the context | Delegate a debug worker; feed results back inline |
+| Simple 1-file edit you already understand | Do it inline; no delegation needed |
+| Quick git/state check | Do it inline; no delegation needed |
+
+## Execution Steps
+
+1. Identify which gate applies. If none applies, skip delegation.
+2. Draft a self-contained mission for the worker — include:
+   - Exact goal (one sentence)
+   - File paths or targets to act on
+   - Relevant prior context the worker needs (decisions, conventions, prior findings)
+   - Constraints (style, test runner, budget)
+   - Expected evidence to return (e.g., file written, test output, URL found)
+   - Allowed toolsets/MCP/skills the worker should use
+   - Any `SKILL.md` paths to load before work
+3. Call `delegate_task` with that mission.
+4. Wait for the worker summary.
+5. Verify the claimed output (check file existence, test result, side effect).
+6. Synthesize the verified result into your orchestrator reply.
+
+## Output Contract
+
+After synthesizing worker results, return:
+
+- What was delegated and to how many workers
+- What each worker returned (verified, not just claimed)
+- Any discrepancy between worker self-report and verified evidence
+- Final answer or next step for the user
+
+## References
+
+- [references/tuning-knobs.md](references/tuning-knobs.md) — Full table of `delegate_task` configuration parameters and the explicit toolset/MCP/skill checklist for worker missions.
+- [../../hermes/sdd-orchestrator.md](../../hermes/sdd-orchestrator.md) — SDD orchestrator protocol that uses this delegation standard for SDD phase work.

--- a/internal/assets/skills/hermes-ephemeral-delegation/references/tuning-knobs.md
+++ b/internal/assets/skills/hermes-ephemeral-delegation/references/tuning-knobs.md
@@ -1,0 +1,22 @@
+# Hermes Delegation Tuning Knobs
+
+Configure these in `~/.hermes/config.yaml` under the `delegation` key, or pass per `delegate_task` call.
+
+| Parameter | Default | Effect |
+|-----------|---------|--------|
+| `delegation.max_spawn_depth` | 2 | Maximum recursive delegation depth. Set to 1 to prevent workers from spawning their own workers. |
+| `delegation.max_concurrent_children` | 4 | Maximum number of parallel workers active at once. |
+| `max_iterations` | agent default | Iteration budget for each worker before it is forced to return. |
+| `child_timeout_seconds` | agent default | Hard wall-clock timeout per worker. |
+| `inherit_mcp_toolsets` | false | When true, workers inherit the parent's MCP toolsets automatically. When false (default), pass toolsets explicitly in the mission. |
+| `subagent_auto_approve` | false | When true, workers auto-approve all tool calls. When false (default), workers prompt for approval on dangerous calls. |
+
+## Mission Checklist
+
+When `inherit_mcp_toolsets` is false (the default), every mission passed to `delegate_task` MUST explicitly list:
+
+- Which toolsets the worker is allowed to use (file read, shell, browser, etc.)
+- Which MCP servers the worker can call (engram, context7, etc.)
+- Which `SKILL.md` paths the worker must load before starting work
+
+Without this, workers start with no tools beyond their built-in defaults.

--- a/internal/assets/skills/hermes-ephemeral-delegation/references/tuning-knobs.md
+++ b/internal/assets/skills/hermes-ephemeral-delegation/references/tuning-knobs.md
@@ -4,8 +4,8 @@ Configure these in `~/.hermes/config.yaml` under the `delegation` key, or pass p
 
 | Parameter | Default | Effect |
 |-----------|---------|--------|
-| `delegation.max_spawn_depth` | 2 | Maximum recursive delegation depth. Set to 1 to prevent workers from spawning their own workers. |
-| `delegation.max_concurrent_children` | 4 | Maximum number of parallel workers active at once. |
+| `max_spawn_depth` | 2 | Maximum recursive delegation depth. Set to 1 to prevent workers from spawning their own workers. |
+| `max_concurrent_children` | 4 | Maximum number of parallel workers active at once. |
 | `max_iterations` | agent default | Iteration budget for each worker before it is forced to return. |
 | `child_timeout_seconds` | agent default | Hard wall-clock timeout per worker. |
 | `inherit_mcp_toolsets` | false | When true, workers inherit the parent's MCP toolsets automatically. When false (default), pass toolsets explicitly in the mission. |


### PR DESCRIPTION
Closes #860

## Type

New feature (`type:feature`)

## Summary

- Adds a `hermes-ephemeral-delegation` skill that teaches Hermes to act as an orchestrator and use its native `delegate_task` ephemeral subagents for complex work (broad exploration, multi-file work, test/build runs, fresh reviews, multi-step debugging).
- Wires the standard into the Hermes SDD orchestrator and corrects the Hermes delegation entry in `docs/agents.md`.
- Scoped to the delegation standard only. The cross-runtime inventory/wrapper layer mentioned in the issue is intentionally **out of scope** (no Go code added).

## Why

Hermes handled complex work inline, exhausting iteration/context budgets in long sessions. OpenCode already delegates aggressively; this brings the same orchestrator discipline to Hermes via its existing `delegate_task` primitive.

## Changes

| File | Change |
|------|--------|
| `internal/assets/skills/hermes-ephemeral-delegation/SKILL.md` | New skill: activation contract, hard rules, decision gates, execution steps, output contract |
| `internal/assets/skills/hermes-ephemeral-delegation/references/tuning-knobs.md` | `delegate_task` tuning knobs + worker-mission checklist |
| `internal/assets/hermes/sdd-orchestrator.md` | Hermes native delegation section; load the skill before delegating non-SDD work |
| `docs/agents.md` | Fix Hermes delegation entry; add delegation notes |
| `internal/assets/assets_test.go` | Bump expected embedded skill count 22 → 23 |

## Test Plan

- [x] `go build ./...`
- [x] `go test ./...` — all packages pass
- [x] `TestEmbeddedAssetCount` updated for the new skill
- [x] `TestSkillFrontmatterIsLintClean` passes (description within 160-char budget)

## Checklist

- [x] Linked an approved issue
- [x] Exactly one `type:*` label
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
- [x] Skill frontmatter lint-clean and embedded
- [x] Stayed within scope (no cross-runtime wrapper)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support documentation for Hermes **full ephemeral delegation**, including fresh-context worker behavior and explicit tool/skill inheritance rules.

* **Documentation**
  * Updated Hermes agent guidance and delegation terminology.
  * Added a new “Hermes Native Delegation” orchestration specification.
  * Introduced a dedicated delegation skill contract and detailed configuration “tuning knobs” for `~/.hermes/config.yaml`.

* **Tests**
  * Updated embedded asset inventory validation to match the new skill layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->