### PR TITLE
feat(hermes): refine ephemeral delegation guardrails

### DIFF
--- a/internal/assets/assets_test.go
+++ b/internal/assets/assets_test.go
@@ -260,6 +260,8 @@ func TestAllEmbeddedAssetsAreReadable(t *testing.T) {
 		"skills/skill-creator/SKILL.md",
 		"skills/skill-improver/SKILL.md",
 		"skills/chained-pr/references/chaining-details.md",
+		"skills/hermes-ephemeral-delegation/SKILL.md",
+		"skills/hermes-ephemeral-delegation/references/tuning-knobs.md",
 	}
 
 	for _, path := range expectedFiles {

--- a/internal/assets/skills/hermes-ephemeral-delegation/SKILL.md
+++ b/internal/assets/skills/hermes-ephemeral-delegation/SKILL.md
@@ -24,6 +24,8 @@ Do NOT load this skill if you are already inside a delegated child task — you 
 - Use `delegate_task` for all complex work listed above. Do NOT execute it inline.
 - Workers are EPHEMERAL: each `delegate_task` call creates a fresh context. Do NOT request persistent agent files or profiles.
 - Pass a self-contained mission. Workers have no memory of the parent conversation.
+- Pass exact skill names and exact `SKILL.md` paths. Category, catalog, or section headings are not skills and must not be used as skill names.
+- Grant the smallest toolset that can complete the mission. Do not grant terminal, browser, file-write, or broad filesystem tools for pure reasoning, review, summarization, or planning unless the mission explicitly needs them.
 - Treat worker output as self-report: verify file writes, test pass/fail, URLs, and IDs before reporting success to the user.
 - Batch parallel calls only for INDEPENDENT workstreams. Sequential dependencies must run sequentially.
 
@@ -50,10 +52,21 @@ Do NOT load this skill if you are already inside a delegated child task — you 
    - Expected evidence to return (e.g., file written, test output, URL found)
    - Allowed toolsets/MCP/skills the worker should use
    - Any `SKILL.md` paths to load before work
+   - Tools intentionally withheld because they are not required
 3. Call `delegate_task` with that mission.
 4. Wait for the worker summary.
 5. Verify the claimed output (check file existence, test result, side effect).
 6. Synthesize the verified result into your orchestrator reply.
+
+## Mission Checklist
+
+Before calling `delegate_task`, confirm the mission answers:
+
+- What is the bounded goal, and what evidence must the worker return?
+- Which exact files, URLs, or targets are in scope?
+- Which exact `SKILL.md` paths must be read before task-specific work?
+- Which tools are allowed, and why is each necessary?
+- Which tools are intentionally not allowed for this mission?
 
 ## Output Contract
 


### PR DESCRIPTION
Closes #860

Required issue link for PR validation. This PR is an additive follow-up to merged PR #868; #860 is already closed by #868, and this PR does not replace that work.

## Type

New feature (`type:feature`)

## Summary

- Tightens Hermes ephemeral delegation guardrails added in #868.
- Clarifies that worker missions should receive exact skill names or exact `SKILL.md` paths, not category/catalog headings.
- Documents minimal toolset guidance for pure reasoning, review, or summarization worker missions.
- Adds embedded asset readability coverage for the new Hermes delegation skill and tuning reference.

## Chain Context

This is PR 1 of 3 planned additive follow-ups from the approved #860 work.

```text
main (#868 merged)
└── 📍 PR 1: delegation guardrails
    └── PR 2: durable Kanban boundary (open after PR 1 merges)
        └── PR 3: validated operational defaults (open after PR 2 merges)
```

Why sequential instead of one large PR: each slice is intentionally small and reviewable. This PR keeps the #868 foundation intact and only refines the worker mission contract.

## Why

The #860 validation surfaced two practical Hermes delegation gotchas:

1. Category or catalog headings can be mistaken for skills if prompts are too loose.
2. Child workers should not receive terminal, browser, file, or write tools when a pure reasoning/review/summarization task does not need them.

This PR captures those guardrails in the upstream Hermes delegation guidance.

## Changes

| File | Change |
|------|--------|
| `internal/assets/skills/hermes-ephemeral-delegation/SKILL.md` | Adds exact skill/path and minimal toolset guardrails for worker missions. |
| `internal/assets/assets_test.go` | Adds readability coverage for the Hermes delegation skill and tuning reference. |

## Test Plan

- [x] `go test ./internal/assets`

## Checklist

- [x] Linked an approved issue (`#860`)
- [x] Exactly one `type:*` label will be applied
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
- [x] Additive follow-up to #868; no replacement or revert of Alan's merged work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced skill delegation documentation with stricter constraints and expanded guidelines for worker missions, including a more detailed pre-delegation checklist to ensure proper resource allocation and scope definition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->