### PR TITLE
feat(engram): always fetch latest engram-core and gentle-engram

### DIFF
--- a/internal/agents/pi/adapter.go
+++ b/internal/agents/pi/adapter.go
@@ -13,7 +13,6 @@ import (
 	"github.com/gentleman-programming/gentle-ai/internal/components/filemerge"
 	"github.com/gentleman-programming/gentle-ai/internal/model"
 	"github.com/gentleman-programming/gentle-ai/internal/system"
-	"github.com/gentleman-programming/gentle-ai/internal/versions"
 )
 
 const (
@@ -86,9 +85,9 @@ func (a *Adapter) InstallCommand(system.PlatformProfile) ([][]string, error) {
 
 func (a *Adapter) engramInitCommand() []string {
 	if _, err := a.lookPath("pnpm"); err == nil {
-		return []string{"pnpm", "dlx", "gentle-engram@" + versions.GentleEngram, "pi-engram", "init"}
+		return []string{"pnpm", "dlx", "gentle-engram@latest", "pi-engram", "init"}
 	}
-	return []string{"npm", "exec", "--yes", "--package", "gentle-engram@" + versions.GentleEngram, "--", "pi-engram", "init"}
+	return []string{"npm", "exec", "--yes", "--package", "gentle-engram@latest", "--", "pi-engram", "init"}
 }
 
 func (a *Adapter) GlobalConfigDir(homeDir string) string { return ConfigPath(homeDir) }

--- a/internal/agents/pi/adapter_test.go
+++ b/internal/agents/pi/adapter_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/gentleman-programming/gentle-ai/internal/model"
 	"github.com/gentleman-programming/gentle-ai/internal/system"
-	"github.com/gentleman-programming/gentle-ai/internal/versions"
 )
 
 func TestAdapterIdentityAndCapabilities(t *testing.T) {
@@ -158,7 +157,7 @@ func TestAdapterInstallCommandSequenceUsesNpmWhenPnpmIsUnavailable(t *testing.T)
 		{"pi", "install", "npm:gentle-pi"},
 		{"pi", "install", "npm:gentle-engram"},
 		{"pi", "install", "npm:pi-mcp-adapter"},
-		{"npm", "exec", "--yes", "--package", "gentle-engram@" + versions.GentleEngram, "--", "pi-engram", "init"},
+		{"npm", "exec", "--yes", "--package", "gentle-engram@latest", "--", "pi-engram", "init"},
 		{"pi", "install", "npm:pi-subagents"},
 		{"pi", "install", "npm:pi-intercom"},
 		{"pi", "install", "npm:@juicesharp/rpiv-ask-user-question"},
@@ -186,7 +185,7 @@ func TestAdapterInstallCommandSequenceUsesPnpmForEngramInitWhenAvailable(t *test
 		t.Fatalf("InstallCommand() error = %v", err)
 	}
 
-	want := []string{"pnpm", "dlx", "gentle-engram@" + versions.GentleEngram, "pi-engram", "init"}
+	want := []string{"pnpm", "dlx", "gentle-engram@latest", "pi-engram", "init"}
 	if !reflect.DeepEqual(commands[3], want) {
 		t.Fatalf("InstallCommand()[3] = %#v, want %#v", commands[3], want)
 	}

--- a/internal/cli/run_integration_test.go
+++ b/internal/cli/run_integration_test.go
@@ -49,9 +49,9 @@ func stringSliceContains(items []string, want string) bool {
 
 func engramInitCommandForTest() string {
 	if _, err := exec.LookPath("pnpm"); err == nil {
-		return fmt.Sprintf("pnpm dlx gentle-engram@%s pi-engram init", versions.GentleEngram)
+		return "pnpm dlx gentle-engram@latest pi-engram init"
 	}
-	return fmt.Sprintf("npm exec --yes --package gentle-engram@%s -- pi-engram init", versions.GentleEngram)
+	return "npm exec --yes --package gentle-engram@latest -- pi-engram init"
 }
 
 func TestRunInstallAppliesFilesystemChanges(t *testing.T) {
@@ -141,8 +141,8 @@ func TestRunInstallEngramForPiAndOpenCodeProvisionsBothMCPTargets(t *testing.T) 
 	if !stringSliceContains(commands, "pi install npm:pi-mcp-adapter") {
 		t.Fatalf("commands missing %q; got %v", "pi install npm:pi-mcp-adapter", commands)
 	}
-	if !stringSliceContains(commands, fmt.Sprintf("npm exec --yes --package gentle-engram@%s -- pi-engram init", versions.GentleEngram)) &&
-		!stringSliceContains(commands, fmt.Sprintf("pnpm dlx gentle-engram@%s pi-engram init", versions.GentleEngram)) {
+	if !stringSliceContains(commands, "npm exec --yes --package gentle-engram@latest -- pi-engram init") &&
+		!stringSliceContains(commands, "pnpm dlx gentle-engram@latest pi-engram init") {
 		t.Fatalf("commands missing Engram init command; got %v", commands)
 	}
 }

--- a/internal/components/engram/download.go
+++ b/internal/components/engram/download.go
@@ -260,60 +260,84 @@ func hasEngramBinaryAsset(assets []json.RawMessage) bool {
 	return false
 }
 
+// engramReleasePageSize is the number of releases requested per page when
+// paginating the GitHub Releases list. GitHub's maximum is 100; 20 is
+// sufficient for typical cadence while keeping response payloads small.
+const engramReleasePageSize = 20
+
+// engramReleaseMaxPages caps the pagination loop so it can never run forever.
+// At 20 releases/page this covers 100 releases — enough runway even when the
+// Gentleman-Programming/engram repo publishes many pi-v*/gentle-engram entries
+// between core vX.Y.Z releases.
+const engramReleaseMaxPages = 5
+
 func fetchLatestEngramVersionWithAssets(token string) (string, int, error) {
-	apiURL := fmt.Sprintf("%s/repos/%s/%s/releases?per_page=20",
-		engramAPIBaseURL(), engramOwner, engramRepo)
+	lastStatus := 0
 
-	req, err := http.NewRequest(http.MethodGet, apiURL, nil)
-	if err != nil {
-		return "", 0, fmt.Errorf("build releases request: %w", err)
-	}
-	req.Header.Set("Accept", "application/vnd.github+json")
-	if token != "" {
-		req.Header.Set("Authorization", "Bearer "+token)
-	}
+	for page := 1; page <= engramReleaseMaxPages; page++ {
+		apiURL := fmt.Sprintf("%s/repos/%s/%s/releases?per_page=%d&page=%d",
+			engramAPIBaseURL(), engramOwner, engramRepo, engramReleasePageSize, page)
 
-	resp, err := engramHTTPClient.Do(req)
-	if err != nil {
-		return "", 0, fmt.Errorf("call GitHub releases API: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return "", resp.StatusCode, fmt.Errorf("GitHub releases API returned HTTP %d", resp.StatusCode)
-	}
-
-	var releases []struct {
-		TagName    string `json:"tag_name"`
-		Draft      bool   `json:"draft"`
-		Prerelease bool   `json:"prerelease"`
-		Assets     []struct {
-			Name string `json:"name"`
-		} `json:"assets"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&releases); err != nil {
-		return "", resp.StatusCode, fmt.Errorf("decode releases JSON: %w", err)
-	}
-
-	for _, release := range releases {
-		if release.Draft || release.Prerelease || len(release.Assets) == 0 {
-			continue
+		req, err := http.NewRequest(http.MethodGet, apiURL, nil)
+		if err != nil {
+			return "", 0, fmt.Errorf("build releases request: %w", err)
 		}
-		// Skip tags that don't match the core engram pattern (e.g. gentle-engram/pi-v* tags).
-		if !engramCoreTagRE.MatchString(release.TagName) {
-			continue
+		req.Header.Set("Accept", "application/vnd.github+json")
+		if token != "" {
+			req.Header.Set("Authorization", "Bearer "+token)
 		}
-		for _, asset := range release.Assets {
-			if strings.HasPrefix(asset.Name, engramRepo+"_") {
-				version := strings.TrimPrefix(release.TagName, "v")
-				if version != "" {
-					return version, resp.StatusCode, nil
+
+		resp, err := engramHTTPClient.Do(req)
+		if err != nil {
+			return "", lastStatus, fmt.Errorf("call GitHub releases API: %w", err)
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			status := resp.StatusCode
+			resp.Body.Close()
+			return "", status, fmt.Errorf("GitHub releases API returned HTTP %d", status)
+		}
+		lastStatus = resp.StatusCode
+
+		var releases []struct {
+			TagName    string `json:"tag_name"`
+			Draft      bool   `json:"draft"`
+			Prerelease bool   `json:"prerelease"`
+			Assets     []struct {
+				Name string `json:"name"`
+			} `json:"assets"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&releases); err != nil {
+			resp.Body.Close()
+			return "", lastStatus, fmt.Errorf("decode releases JSON: %w", err)
+		}
+		resp.Body.Close()
+
+		// An empty page means GitHub has no more releases — stop early.
+		if len(releases) == 0 {
+			break
+		}
+
+		for _, release := range releases {
+			if release.Draft || release.Prerelease || len(release.Assets) == 0 {
+				continue
+			}
+			// Skip tags that don't match the core engram pattern (e.g. gentle-engram/pi-v* tags).
+			if !engramCoreTagRE.MatchString(release.TagName) {
+				continue
+			}
+			for _, asset := range release.Assets {
+				if strings.HasPrefix(asset.Name, engramRepo+"_") {
+					version := strings.TrimPrefix(release.TagName, "v")
+					if version != "" {
+						return version, lastStatus, nil
+					}
 				}
 			}
 		}
 	}
 
-	return "", resp.StatusCode, fmt.Errorf("no engram release with downloadable binary assets found")
+	return "", lastStatus, fmt.Errorf("no engram release with downloadable binary assets found")
 }
 
 // githubToken returns a GitHub API token from the environment, if available.

--- a/internal/components/engram/download.go
+++ b/internal/components/engram/download.go
@@ -14,12 +14,12 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 	"time"
 
 	"github.com/gentleman-programming/gentle-ai/internal/system"
-	"github.com/gentleman-programming/gentle-ai/internal/versions"
 )
 
 const (
@@ -37,7 +37,16 @@ var (
 	engramStopProcessesFn = stopEngramProcesses
 )
 
-// DownloadLatestBinary fetches the pinned engram release from GitHub and
+// engramCoreTagPattern matches only plain semver tags (vX.Y.Z) that identify
+// core engram binary releases. The Gentleman-Programming/engram repository also
+// publishes gentle-engram npm and pi releases under tags like
+// "gentle-engram vX.Y.Z" or "pi-vX.Y.Z" in the same release stream. This
+// pattern intentionally excludes those so a gentle-engram/pi tag can never be
+// selected as the core engram binary version. It mirrors the ReleaseTagPattern
+// used by the update-check path in internal/update/registry.go.
+const engramCoreTagPattern = `^v[0-9]+\.[0-9]+\.[0-9]+$`
+
+// DownloadLatestBinary fetches the latest engram release from GitHub and
 // installs it to the appropriate directory for the given platform.
 // It returns the full path to the installed binary.
 //
@@ -49,9 +58,13 @@ var (
 func DownloadLatestBinary(profile system.PlatformProfile) (string, error) {
 	ctx := context.Background()
 
-	// 1. Use the pinned core Engram version. Beta/nightly installs are handled
-	// separately and still install Engram from @main.
-	version := versions.EngramCore
+	// 1. Fetch the latest version tag from GitHub API. Only tags matching the
+	// core engram pattern (vX.Y.Z) are considered; gentle-engram/pi tags are
+	// excluded so the download and update-check paths share the same source of truth.
+	version, err := fetchLatestEngramVersion()
+	if err != nil {
+		return "", fmt.Errorf("fetch latest engram version: %w", err)
+	}
 
 	// 2. Determine binary name and archive URL.
 	goos := profile.OS
@@ -132,8 +145,14 @@ func DownloadLatestBinary(profile system.PlatformProfile) (string, error) {
 	return outPath, nil
 }
 
-// fetchLatestEngramVersion queries the GitHub Releases API for the latest engram
-// release and returns the version string (without leading "v").
+// engramCoreTagRE is the compiled form of engramCoreTagPattern, used to filter
+// GitHub release tags so only core engram binary releases are selected.
+var engramCoreTagRE = regexp.MustCompile(engramCoreTagPattern)
+
+// fetchLatestEngramVersion queries the GitHub Releases API for the latest
+// core engram binary release and returns the version string (without leading "v").
+// Only releases whose tag matches engramCoreTagPattern (vX.Y.Z) are considered,
+// so gentle-engram/pi tags published in the same release stream are ignored.
 func fetchLatestEngramVersion() (string, error) {
 	token := githubToken()
 	version, status, err := fetchLatestEngramVersionRequest(token)
@@ -184,6 +203,22 @@ func fetchLatestEngramVersionRequest(token string) (string, int, error) {
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
 		return "", resp.StatusCode, fmt.Errorf("decode release JSON: %w", err)
+	}
+
+	// Reject tags that don't match the core engram pattern (e.g. gentle-engram/pi-v* tags).
+	// Fall through to the release-list scan when /latest points at a non-core release.
+	if !engramCoreTagRE.MatchString(release.TagName) {
+		fallbackVersion, fallbackStatus, err := fetchLatestEngramVersionWithAssets(token)
+		if err == nil {
+			return fallbackVersion, resp.StatusCode, nil
+		}
+		if token != "" && (fallbackStatus == http.StatusUnauthorized || fallbackStatus == http.StatusForbidden) {
+			fallbackVersion, _, retryErr := fetchLatestEngramVersionWithAssets("")
+			if retryErr == nil {
+				return fallbackVersion, resp.StatusCode, nil
+			}
+		}
+		return "", resp.StatusCode, err
 	}
 
 	version := strings.TrimPrefix(release.TagName, "v")
@@ -262,6 +297,10 @@ func fetchLatestEngramVersionWithAssets(token string) (string, int, error) {
 
 	for _, release := range releases {
 		if release.Draft || release.Prerelease || len(release.Assets) == 0 {
+			continue
+		}
+		// Skip tags that don't match the core engram pattern (e.g. gentle-engram/pi-v* tags).
+		if !engramCoreTagRE.MatchString(release.TagName) {
 			continue
 		}
 		for _, asset := range release.Assets {

--- a/internal/components/engram/download_test.go
+++ b/internal/components/engram/download_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 
 	"github.com/gentleman-programming/gentle-ai/internal/system"
-	"github.com/gentleman-programming/gentle-ai/internal/versions"
 )
 
 // --- test helpers ---
@@ -258,7 +257,7 @@ func TestDownloadLatestBinaryLinux(t *testing.T) {
 		t.Skip("this test verifies Linux path behaviour, not applicable on Windows")
 	}
 
-	server := makeServerWithFakeTarGz(t, versions.EngramCore)
+	server := makeServerWithFakeTarGz(t, "1.3.0")
 	defer server.Close()
 
 	// Override the HTTP client and the base URL for GitHub API.
@@ -304,7 +303,7 @@ func TestDownloadLatestBinaryLinux(t *testing.T) {
 // --- TestDownloadLatestBinaryWindows ---
 
 func TestDownloadLatestBinaryWindows(t *testing.T) {
-	server := makeServerWithFakeZip(t, versions.EngramCore)
+	server := makeServerWithFakeZip(t, "1.3.0")
 	defer server.Close()
 
 	origClient := engramHTTPClient
@@ -367,12 +366,12 @@ func TestDownloadLatestBinaryDownloadError(t *testing.T) {
 	profile := system.PlatformProfile{OS: "linux", PackageManager: "apt"}
 	_, err := DownloadLatestBinary(profile)
 	if err == nil {
-		t.Fatal("expected error when pinned release download returns 500, got nil")
+		t.Fatal("expected error when GitHub API returns 500, got nil")
 	}
 }
 
-func TestDownloadLatestBinaryUsesPinnedEngramCoreRelease(t *testing.T) {
-	binaryVersion := versions.EngramCore
+func TestDownloadLatestBinarySkipsLatestReleaseWithoutBinaryAssets(t *testing.T) {
+	const binaryVersion = "1.15.13"
 
 	tarContent := buildFakeTarGz(t, "engram")
 	// Build checksums.txt covering all linux arches so the test is arch-agnostic.
@@ -383,9 +382,32 @@ func TestDownloadLatestBinaryUsesPinnedEngramCoreRelease(t *testing.T) {
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
-		case strings.Contains(r.URL.Path, "/releases/latest") || strings.Contains(r.URL.RawQuery, "per_page=20"):
-			t.Fatalf("DownloadLatestBinary() should not query latest releases when using pinned core Engram version: %s?%s", r.URL.Path, r.URL.RawQuery)
-		case strings.HasSuffix(r.URL.Path, "/releases/download/v"+binaryVersion+"/checksums.txt"):
+		case strings.Contains(r.URL.Path, "releases/latest"):
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]any{
+				"tag_name": "pi-v0.1.7",
+				"assets":   []any{},
+			})
+		case strings.Contains(r.URL.Path, "releases") && r.URL.RawQuery == "per_page=20":
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode([]map[string]any{
+				{
+					"tag_name":   "pi-v0.1.7",
+					"draft":      false,
+					"prerelease": false,
+					"assets":     []any{},
+				},
+				{
+					"tag_name":   "v" + binaryVersion,
+					"draft":      false,
+					"prerelease": false,
+					"assets": []map[string]string{
+						{"name": "checksums.txt"},
+						{"name": "engram_" + binaryVersion + "_linux_amd64.tar.gz"},
+					},
+				},
+			})
+		case strings.HasSuffix(r.URL.Path, "checksums.txt"):
 			w.Header().Set("Content-Type", "text/plain")
 			fmt.Fprint(w, checksums)
 		case strings.Contains(r.URL.Path, "/releases/download/v"+binaryVersion+"/engram_"+binaryVersion+"_linux_"):
@@ -423,9 +445,9 @@ func TestDownloadLatestBinaryUsesPinnedEngramCoreRelease(t *testing.T) {
 	}
 }
 
-func TestDownloadLatestBinaryUsesPinnedReleaseWhenTokenIsSet(t *testing.T) {
+func TestDownloadLatestBinaryReleaseListFallsBackToAnonymousWhenTokenGets403(t *testing.T) {
 	const fakeToken = "ci-token"
-	binaryVersion := versions.EngramCore
+	const binaryVersion = "1.15.13"
 
 	tarContent := buildFakeTarGz(t, "engram")
 	checksums := ""
@@ -434,9 +456,32 @@ func TestDownloadLatestBinaryUsesPinnedReleaseWhenTokenIsSet(t *testing.T) {
 	}
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := r.Header.Get("Authorization")
 		switch {
-		case strings.Contains(r.URL.Path, "/releases/latest") || strings.Contains(r.URL.RawQuery, "per_page=20"):
-			t.Fatalf("DownloadLatestBinary() should not query latest releases when using pinned core Engram version: %s?%s", r.URL.Path, r.URL.RawQuery)
+		case strings.Contains(r.URL.Path, "releases/latest"):
+			if auth != "" {
+				// Simulate 403 when authenticated to trigger anonymous retry.
+				w.WriteHeader(http.StatusForbidden)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]string{"tag_name": "v" + binaryVersion})
+		case strings.Contains(r.URL.Path, "releases") && r.URL.RawQuery == "per_page=20":
+			if auth != "" {
+				w.WriteHeader(http.StatusForbidden)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode([]map[string]any{
+				{
+					"tag_name":   "v" + binaryVersion,
+					"draft":      false,
+					"prerelease": false,
+					"assets": []map[string]string{
+						{"name": "engram_" + binaryVersion + "_linux_amd64.tar.gz"},
+					},
+				},
+			})
 		case strings.HasSuffix(r.URL.Path, "checksums.txt"):
 			w.Header().Set("Content-Type", "text/plain")
 			fmt.Fprint(w, checksums)
@@ -479,7 +524,7 @@ func TestDownloadLatestBinaryUsesPinnedReleaseWhenTokenIsSet(t *testing.T) {
 }
 
 func TestDownloadLatestBinaryWindowsStopsEngramBeforeReplace(t *testing.T) {
-	version := versions.EngramCore
+	version := "1.3.0"
 	server := makeServerWithFakeZip(t, version)
 	defer server.Close()
 
@@ -522,7 +567,7 @@ func TestDownloadLatestBinaryWindowsStopsEngramBeforeReplace(t *testing.T) {
 }
 
 func TestDownloadLatestBinaryWindowsStopFailureAbortsBeforeReplace(t *testing.T) {
-	version := versions.EngramCore
+	version := "1.3.0"
 	server := makeServerWithFakeZip(t, version)
 	defer server.Close()
 
@@ -563,7 +608,7 @@ func TestDownloadLatestBinaryWindowsStopFailureAbortsBeforeReplace(t *testing.T)
 // The seam returning nil (no error) is the contract that must hold for the
 // "engram not running" case; the implementation no longer uses -ErrorAction Stop.
 func TestDownloadLatestBinaryWindowsStopSucceedsWhenProcessNotRunning(t *testing.T) {
-	version := versions.EngramCore
+	version := "1.3.0"
 	server := makeServerWithFakeZip(t, version)
 	defer server.Close()
 
@@ -601,7 +646,7 @@ func TestDownloadLatestBinaryWindowsStopSucceedsWhenProcessNotRunning(t *testing
 // exercise the WARNING-to-stderr emission inside stopEngramProcesses (that branch
 // requires a real PowerShell call and is only integration-covered on Windows CI).
 func TestDownloadLatestBinaryWindowsStopNilProceedsToInstall(t *testing.T) {
-	version := versions.EngramCore
+	version := "1.3.0"
 	server := makeServerWithFakeZip(t, version)
 	defer server.Close()
 
@@ -638,29 +683,66 @@ func TestDownloadLatestBinaryWindowsStopNilProceedsToInstall(t *testing.T) {
 	}
 }
 
-func TestDownloadLatestBinaryUsesPinnedReleaseWithoutLatestAPIFallback(t *testing.T) {
-	const fakeToken = "ci-token"
-	version := versions.EngramCore
+// TestDownloadLatestBinaryIgnoresGentleEngramAndPiTags asserts the CORRECTNESS
+// CRUX: when the release list contains a mix of a core engram tag (vX.Y.Z), a
+// gentle-engram tag, and a pi-v* tag, DownloadLatestBinary MUST pick the core
+// engram version and MUST NOT pick the gentle-engram or pi-* tag.
+func TestDownloadLatestBinaryIgnoresGentleEngramAndPiTags(t *testing.T) {
+	const binaryVersion = "1.16.3"
 
 	tarContent := buildFakeTarGz(t, "engram")
 	checksums := ""
-	for _, goos := range []string{"linux", "darwin"} {
-		for _, goarch := range []string{"amd64", "arm64"} {
-			checksums += makeChecksumsTxt(engramArchiveName(version, goos, goarch), tarContent)
-		}
+	for _, goarch := range []string{"amd64", "arm64"} {
+		checksums += makeChecksumsTxt(engramArchiveName(binaryVersion, "linux", goarch), tarContent)
 	}
 
+	// The release list intentionally lists gentle-engram first (highest position)
+	// and pi-v* second — both without binary assets — followed by the real core
+	// engram release. The download MUST skip the first two and pick the third.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
-		case strings.Contains(r.URL.Path, "/releases/latest") || strings.Contains(r.URL.RawQuery, "per_page=20"):
-			t.Fatalf("DownloadLatestBinary() should not query latest releases when using pinned core Engram version: %s?%s", r.URL.Path, r.URL.RawQuery)
+		case strings.Contains(r.URL.Path, "releases/latest"):
+			// /latest points at a gentle-engram tag — the non-core tag that must be skipped.
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]any{
+				"tag_name": "gentle-engram v0.1.8",
+				"assets":   []any{},
+			})
+		case strings.Contains(r.URL.Path, "releases") && r.URL.RawQuery == "per_page=20":
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode([]map[string]any{
+				{
+					"tag_name":   "gentle-engram v0.1.8",
+					"draft":      false,
+					"prerelease": false,
+					"assets":     []any{},
+				},
+				{
+					"tag_name":   "pi-v0.1.7",
+					"draft":      false,
+					"prerelease": false,
+					"assets":     []any{},
+				},
+				{
+					"tag_name":   "v" + binaryVersion,
+					"draft":      false,
+					"prerelease": false,
+					"assets": []map[string]string{
+						{"name": "checksums.txt"},
+						{"name": "engram_" + binaryVersion + "_linux_amd64.tar.gz"},
+					},
+				},
+			})
 		case strings.HasSuffix(r.URL.Path, "checksums.txt"):
 			w.Header().Set("Content-Type", "text/plain")
 			fmt.Fprint(w, checksums)
-		default:
+		case strings.Contains(r.URL.Path, "/releases/download/v"+binaryVersion+"/engram_"+binaryVersion+"_linux_"):
 			w.Header().Set("Content-Type", "application/octet-stream")
 			w.WriteHeader(http.StatusOK)
 			w.Write(tarContent)
+		default:
+			t.Fatalf("unexpected request path (should be core engram v%s, not gentle-engram/pi): %s?%s",
+				binaryVersion, r.URL.Path, r.URL.RawQuery)
 		}
 	}))
 	defer server.Close()
@@ -674,9 +756,6 @@ func TestDownloadLatestBinaryUsesPinnedReleaseWithoutLatestAPIFallback(t *testin
 		engramGitHubBaseURL = origBaseURL
 	})
 
-	t.Setenv("GITHUB_TOKEN", fakeToken)
-	t.Setenv("GH_TOKEN", "")
-
 	tmpDir := t.TempDir()
 	origInstallDirFn := engramInstallDirFn
 	engramInstallDirFn = func(goos string) string { return tmpDir }
@@ -685,13 +764,12 @@ func TestDownloadLatestBinaryUsesPinnedReleaseWithoutLatestAPIFallback(t *testin
 	profile := system.PlatformProfile{OS: "linux", PackageManager: "apt"}
 	installedPath, err := DownloadLatestBinary(profile)
 	if err != nil {
-		t.Fatalf("DownloadLatestBinary() error = %v", err)
+		t.Fatalf("DownloadLatestBinary() error = %v, want core engram v%s to be selected", err, binaryVersion)
 	}
 
 	if !strings.HasPrefix(installedPath, tmpDir) {
 		t.Errorf("installedPath = %q, want prefix %q", installedPath, tmpDir)
 	}
-
 	if _, err := os.Stat(installedPath); err != nil {
 		t.Fatalf("stat installed binary: %v", err)
 	}
@@ -706,7 +784,7 @@ func TestDownloadLatestBinaryUsesPinnedReleaseWithoutLatestAPIFallback(t *testin
 //   - digest mismatch: checksums.txt lists wrong digest → fail closed
 //   - malformed checksums.txt: content has no parseable entries → fail closed
 func TestEngramChecksumVerification(t *testing.T) {
-	version := versions.EngramCore
+	version := "1.3.0"
 
 	// tarContent is a real .tar.gz archive used across sub-tests.
 	tarContent := buildFakeTarGz(t, "engram")

--- a/internal/components/engram/download_test.go
+++ b/internal/components/engram/download_test.go
@@ -388,8 +388,15 @@ func TestDownloadLatestBinarySkipsLatestReleaseWithoutBinaryAssets(t *testing.T)
 				"tag_name": "pi-v0.1.7",
 				"assets":   []any{},
 			})
-		case strings.Contains(r.URL.Path, "releases") && r.URL.RawQuery == "per_page=20":
+		case strings.Contains(r.URL.Path, "releases") && !strings.Contains(r.URL.Path, "releases/latest") &&
+			!strings.Contains(r.URL.Path, "/releases/download") &&
+			r.URL.Query().Get("per_page") == "20":
 			w.Header().Set("Content-Type", "application/json")
+			// Pages beyond 1 return empty to signal end-of-list.
+			if r.URL.Query().Get("page") != "1" {
+				json.NewEncoder(w).Encode([]map[string]any{})
+				return
+			}
 			json.NewEncoder(w).Encode([]map[string]any{
 				{
 					"tag_name":   "pi-v0.1.7",
@@ -466,12 +473,19 @@ func TestDownloadLatestBinaryReleaseListFallsBackToAnonymousWhenTokenGets403(t *
 			}
 			w.Header().Set("Content-Type", "application/json")
 			json.NewEncoder(w).Encode(map[string]string{"tag_name": "v" + binaryVersion})
-		case strings.Contains(r.URL.Path, "releases") && r.URL.RawQuery == "per_page=20":
+		case strings.Contains(r.URL.Path, "releases") && !strings.Contains(r.URL.Path, "releases/latest") &&
+			!strings.Contains(r.URL.Path, "/releases/download") &&
+			r.URL.Query().Get("per_page") == "20":
 			if auth != "" {
 				w.WriteHeader(http.StatusForbidden)
 				return
 			}
 			w.Header().Set("Content-Type", "application/json")
+			// Pages beyond 1 return empty to signal end-of-list.
+			if r.URL.Query().Get("page") != "1" {
+				json.NewEncoder(w).Encode([]map[string]any{})
+				return
+			}
 			json.NewEncoder(w).Encode([]map[string]any{
 				{
 					"tag_name":   "v" + binaryVersion,
@@ -708,8 +722,15 @@ func TestDownloadLatestBinaryIgnoresGentleEngramAndPiTags(t *testing.T) {
 				"tag_name": "gentle-engram v0.1.8",
 				"assets":   []any{},
 			})
-		case strings.Contains(r.URL.Path, "releases") && r.URL.RawQuery == "per_page=20":
+		case strings.Contains(r.URL.Path, "releases") && !strings.Contains(r.URL.Path, "releases/latest") &&
+			!strings.Contains(r.URL.Path, "/releases/download") &&
+			r.URL.Query().Get("per_page") == "20":
 			w.Header().Set("Content-Type", "application/json")
+			// Pages beyond 1 return empty to signal end-of-list.
+			if r.URL.Query().Get("page") != "1" {
+				json.NewEncoder(w).Encode([]map[string]any{})
+				return
+			}
 			json.NewEncoder(w).Encode([]map[string]any{
 				{
 					"tag_name":   "gentle-engram v0.1.8",
@@ -875,6 +896,135 @@ func TestEngramChecksumVerification(t *testing.T) {
 				t.Errorf("error = %q, want it to contain %q", err.Error(), tt.wantErrSubstr)
 			}
 		})
+	}
+}
+
+// TestFetchLatestEngramVersionWithAssetsPaginates asserts that
+// fetchLatestEngramVersionWithAssets paginates beyond the first page when
+// page 1 contains only non-core tags (pi-v* / gentle-engram) and the valid
+// core vX.Y.Z release with a binary asset is on page 2.
+//
+// Regression test for the issue where per_page=20 capped discovery and returned
+// "no engram release with downloadable binary assets found" even though a valid
+// core release existed just beyond the window.
+func TestFetchLatestEngramVersionWithAssetsPaginates(t *testing.T) {
+	const binaryVersion = "1.17.0"
+
+	tarContent := buildFakeTarGz(t, "engram")
+	checksums := ""
+	for _, goarch := range []string{"amd64", "arm64"} {
+		checksums += makeChecksumsTxt(engramArchiveName(binaryVersion, "linux", goarch), tarContent)
+	}
+
+	// Track which pages were requested so we can assert pagination occurred.
+	var pagesRequested []string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "releases/latest"):
+			// /latest points at a pi-v* tag so the single-release path falls
+			// through to fetchLatestEngramVersionWithAssets.
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]any{
+				"tag_name": "pi-v0.2.0",
+				"assets":   []any{},
+			})
+
+		case strings.Contains(r.URL.Path, "/repos/") && strings.Contains(r.URL.Path, "/releases") &&
+			!strings.Contains(r.URL.Path, "/releases/download") &&
+			!strings.Contains(r.URL.Path, "releases/latest"):
+			// Release list endpoint — track the page parameter.
+			page := r.URL.Query().Get("page")
+			if page == "" {
+				page = "1"
+			}
+			pagesRequested = append(pagesRequested, page)
+
+			w.Header().Set("Content-Type", "application/json")
+			switch page {
+			case "1":
+				// Page 1: only non-core tags — must NOT pick any of these.
+				json.NewEncoder(w).Encode([]map[string]any{
+					{
+						"tag_name":   "pi-v0.2.0",
+						"draft":      false,
+						"prerelease": false,
+						"assets":     []any{},
+					},
+					{
+						"tag_name":   "gentle-engram v0.2.0",
+						"draft":      false,
+						"prerelease": false,
+						"assets":     []any{},
+					},
+					{
+						"tag_name":   "pi-v0.1.9",
+						"draft":      false,
+						"prerelease": false,
+						"assets":     []any{},
+					},
+				})
+			case "2":
+				// Page 2: the real core engram release.
+				json.NewEncoder(w).Encode([]map[string]any{
+					{
+						"tag_name":   "v" + binaryVersion,
+						"draft":      false,
+						"prerelease": false,
+						"assets": []map[string]string{
+							{"name": "checksums.txt"},
+							{"name": "engram_" + binaryVersion + "_linux_amd64.tar.gz"},
+						},
+					},
+				})
+			default:
+				// Any further page is empty — signals end of releases.
+				json.NewEncoder(w).Encode([]map[string]any{})
+			}
+
+		case strings.HasSuffix(r.URL.Path, "checksums.txt"):
+			w.Header().Set("Content-Type", "text/plain")
+			fmt.Fprint(w, checksums)
+
+		case strings.Contains(r.URL.Path, "/releases/download/v"+binaryVersion+"/engram_"+binaryVersion+"_linux_"):
+			w.Header().Set("Content-Type", "application/octet-stream")
+			w.WriteHeader(http.StatusOK)
+			w.Write(tarContent)
+
+		default:
+			t.Fatalf("unexpected request: %s?%s", r.URL.Path, r.URL.RawQuery)
+		}
+	}))
+	defer server.Close()
+
+	origClient := engramHTTPClient
+	origBaseURL := engramGitHubBaseURL
+	engramHTTPClient = server.Client()
+	engramGitHubBaseURL = server.URL
+	t.Cleanup(func() {
+		engramHTTPClient = origClient
+		engramGitHubBaseURL = origBaseURL
+	})
+
+	tmpDir := t.TempDir()
+	origInstallDirFn := engramInstallDirFn
+	engramInstallDirFn = func(goos string) string { return tmpDir }
+	t.Cleanup(func() { engramInstallDirFn = origInstallDirFn })
+
+	profile := system.PlatformProfile{OS: "linux", PackageManager: "apt"}
+	installedPath, err := DownloadLatestBinary(profile)
+	if err != nil {
+		t.Fatalf("DownloadLatestBinary() error = %v, want core engram v%s selected from page 2", err, binaryVersion)
+	}
+
+	if _, err := os.Stat(installedPath); err != nil {
+		t.Fatalf("stat installed binary: %v", err)
+	}
+
+	// Verify that pagination actually happened — both page 1 and page 2 must have been requested.
+	gotPages := strings.Join(pagesRequested, ",")
+	if !strings.Contains(gotPages, "1") || !strings.Contains(gotPages, "2") {
+		t.Errorf("expected pagination across pages 1 and 2, got pages requested: [%s]", gotPages)
 	}
 }
 

--- a/internal/tui/screens/dependency_tree.go
+++ b/internal/tui/screens/dependency_tree.go
@@ -8,7 +8,6 @@ import (
 	"github.com/gentleman-programming/gentle-ai/internal/model"
 	"github.com/gentleman-programming/gentle-ai/internal/planner"
 	"github.com/gentleman-programming/gentle-ai/internal/tui/styles"
-	"github.com/gentleman-programming/gentle-ai/internal/versions"
 )
 
 func DependencyTreeOptions() []string {
@@ -99,7 +98,7 @@ func piInstallCommands() []string {
 		"pi install npm:gentle-pi",
 		"pi install npm:gentle-engram",
 		"pi install npm:pi-mcp-adapter",
-		fmt.Sprintf("npm exec --yes --package gentle-engram@%s -- pi-engram init", versions.GentleEngram),
+		"npm exec --yes --package gentle-engram@latest -- pi-engram init",
 		"pi install npm:pi-subagents",
 		"pi install npm:pi-intercom",
 		"pi install npm:@juicesharp/rpiv-ask-user-question",

--- a/internal/tui/screens/dependency_tree_test.go
+++ b/internal/tui/screens/dependency_tree_test.go
@@ -1,13 +1,11 @@
 package screens
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/gentleman-programming/gentle-ai/internal/model"
 	"github.com/gentleman-programming/gentle-ai/internal/planner"
-	"github.com/gentleman-programming/gentle-ai/internal/versions"
 )
 
 func TestRenderDependencyTreePiOnlyEngramPlanShowsComponentAndPiInstallCopy(t *testing.T) {
@@ -33,7 +31,7 @@ func TestRenderDependencyTreePiOnlyEngramPlanShowsComponentAndPiInstallCopy(t *t
 		"pi install npm:gentle-pi",
 		"pi install npm:gentle-engram",
 		"pi install npm:pi-mcp-adapter",
-		fmt.Sprintf("npm exec --yes --package gentle-engram@%s -- pi-engram init", versions.GentleEngram),
+		"npm exec --yes --package gentle-engram@latest -- pi-engram init",
 		"pi install npm:pi-subagents",
 		"pi install npm:pi-intercom",
 		"pi install npm:@juicesharp/rpiv-ask-user-question",
@@ -77,7 +75,7 @@ func TestRenderDependencyTreeMixedPiEmptyPlanShowsPiInstallCopy(t *testing.T) {
 		"pi install npm:gentle-pi",
 		"pi install npm:gentle-engram",
 		"pi install npm:pi-mcp-adapter",
-		fmt.Sprintf("npm exec --yes --package gentle-engram@%s -- pi-engram init", versions.GentleEngram),
+		"npm exec --yes --package gentle-engram@latest -- pi-engram init",
 		"pi install npm:pi-subagents",
 		"pi install npm:pi-intercom",
 		"pi install npm:@juicesharp/rpiv-ask-user-question",

--- a/internal/versions/versions.go
+++ b/internal/versions/versions.go
@@ -24,9 +24,3 @@ const GeminiCLI = "0.41.2"
 
 // renovate: datasource=npm depName=@upstash/context7-mcp
 const Context7MCP = "2.2.5"
-
-// renovate: datasource=npm depName=gentle-engram
-const GentleEngram = "0.1.8"
-
-// renovate: datasource=github-releases depName=Gentleman-Programming/engram
-const EngramCore = "1.16.3"

--- a/internal/versions/versions_test.go
+++ b/internal/versions/versions_test.go
@@ -2,14 +2,18 @@ package versions
 
 import "testing"
 
-func TestEngramPinsStaySeparate(t *testing.T) {
-	if EngramCore != "1.16.3" {
-		t.Fatalf("EngramCore = %q, want %q", EngramCore, "1.16.3")
-	}
-	if GentleEngram != "0.1.8" {
-		t.Fatalf("GentleEngram = %q, want %q", GentleEngram, "0.1.8")
-	}
-	if EngramCore == GentleEngram {
-		t.Fatalf("EngramCore and GentleEngram must remain separate pins; both are %q", EngramCore)
+func TestPinnedVersionsAreDefined(t *testing.T) {
+	for name, val := range map[string]string{
+		"ClaudeCode":  ClaudeCode,
+		"Kilocode":    Kilocode,
+		"OpenCode":    OpenCode,
+		"QwenCode":    QwenCode,
+		"Codex":       Codex,
+		"GeminiCLI":   GeminiCLI,
+		"Context7MCP": Context7MCP,
+	} {
+		if val == "" {
+			t.Errorf("%s must not be empty", name)
+		}
 	}
 }

--- a/renovate.json
+++ b/renovate.json
@@ -17,13 +17,6 @@
       "matchDatasources": ["npm"],
       "groupName": "pinned npm packages",
       "labels": ["dependencies", "security"]
-    },
-    {
-      "matchManagers": ["custom.regex"],
-      "matchFileNames": ["internal/versions/versions.go"],
-      "matchDatasources": ["github-releases"],
-      "groupName": "pinned GitHub releases",
-      "labels": ["dependencies", "security"]
     }
   ]
 }


### PR DESCRIPTION
Slice 1/7 — un-pin engram; fetch latest release filtered by ^v[0-9]+.[0-9]+.[0-9]+$; gentle-engram@latest.

Part of the `update-experience` stacked chain. Refs #872.

- [x] Bug fix / feature slice
- [x] Strict TDD, fresh-context reviewed, `go test ./...` green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Engram initialization to automatically use `gentle-engram@latest` instead of a pinned version.
  * Updated core Engram binary downloads to dynamically discover the newest core release from GitHub, with stricter filtering and pagination to ignore non-core releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->