### PR TITLE
feat(update): cache update check with a 6h cooldown

### DIFF
--- a/internal/app/selfupdate.go
+++ b/internal/app/selfupdate.go
@@ -22,6 +22,12 @@ import (
 // lookPathFn is a package-level var for testability.
 var lookPathFn = exec.LookPath
 
+// selfUpdateNowFn returns the current time; injected for test determinism.
+var selfUpdateNowFn = func() time.Time { return time.Now() }
+
+// selfUpdateHomeDirFn resolves the user home directory; injected for tests.
+var selfUpdateHomeDirFn = os.UserHomeDir
+
 // Environment variable names for self-update control.
 const (
 	envNoSelfUpdate   = "GENTLE_AI_NO_SELF_UPDATE"
@@ -90,8 +96,22 @@ func selfUpdate(ctx context.Context, version string, profile system.PlatformProf
 	ctx, cancel := context.WithTimeout(ctx, selfUpdateTimeout)
 	defer cancel()
 
-	// Check for updates (only gentle-ai).
-	results := updateCheckFiltered(ctx, version, profile, []string{"gentle-ai"})
+	// Resolve home directory for cooldown state read/write.
+	homeDir, err := selfUpdateHomeDirFn()
+	if err != nil {
+		homeDir = "" // fall back to always-check on home dir failure
+	}
+
+	// Check for updates (only gentle-ai), gated by the 6h cooldown.
+	// When the cache is fresh (elapsed < UpdateCheckTTL), this returns nil
+	// and no network request is made. The underlying check is always
+	// updateCheckFiltered, kept as a package-level var for other tests.
+	results := update.CheckAllWithCooldown(ctx, version, profile, homeDir, update.UpdateCheckTTL,
+		selfUpdateNowFn,
+		func(c context.Context, ver string, prof system.PlatformProfile) []update.UpdateResult {
+			return updateCheckFiltered(c, ver, prof, []string{"gentle-ai"})
+		},
+	)
 
 	// Find the gentle-ai result.
 	var target *update.UpdateResult
@@ -116,9 +136,9 @@ func selfUpdate(ctx context.Context, version string, profile system.PlatformProf
 	}
 
 	// Run upgrade (backup + strategy execution).
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		_, _ = fmt.Fprintf(stdout, "self-update: cannot resolve home directory: %v\n", err)
+	// homeDir was resolved above for the cooldown gate; re-check in case it failed.
+	if homeDir == "" {
+		_, _ = fmt.Fprintf(stdout, "self-update: cannot resolve home directory\n")
 		return nil // non-fatal
 	}
 

--- a/internal/app/selfupdate_test.go
+++ b/internal/app/selfupdate_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gentleman-programming/gentle-ai/internal/system"
 	"github.com/gentleman-programming/gentle-ai/internal/update"
@@ -65,13 +66,25 @@ func swapSelfUpdateDeps(t *testing.T, checkResult []update.UpdateResult, upgrade
 	origUpgrade := upgradeExecute
 	origReExec := reExec
 	origGoOS := goOS
+	origHomeDir := selfUpdateHomeDirFn
+	origNow := selfUpdateNowFn
+
+	// Use a temp dir for cooldown state so the gate always reads "never checked"
+	// (no state.json present) and calls the injected updateCheckFiltered stub.
+	tmpHome := t.TempDir()
 
 	t.Cleanup(func() {
 		updateCheckFiltered = origCheck
 		upgradeExecute = origUpgrade
 		reExec = origReExec
 		goOS = origGoOS
+		selfUpdateHomeDirFn = origHomeDir
+		selfUpdateNowFn = origNow
 	})
+
+	selfUpdateHomeDirFn = func() (string, error) { return tmpHome, nil }
+	// Use a fixed "now" far in the future so any stale state would still trigger.
+	selfUpdateNowFn = func() time.Time { return time.Date(2099, 1, 1, 0, 0, 0, 0, time.UTC) }
 
 	updateCheckFiltered = func(_ context.Context, _ string, _ system.PlatformProfile, _ []string) []update.UpdateResult {
 		stubs.checkCalled++
@@ -354,11 +367,20 @@ func TestSelfUpdate_BrewInstallMethod_PassedToUpgradeExecutor(t *testing.T) {
 	origCheck := updateCheckFiltered
 	origUpgrade := upgradeExecute
 	origReExec := reExec
+	origHomeDir := selfUpdateHomeDirFn
+	origNow := selfUpdateNowFn
+	tmpHome := t.TempDir()
 	t.Cleanup(func() {
 		updateCheckFiltered = origCheck
 		upgradeExecute = origUpgrade
 		reExec = origReExec
+		selfUpdateHomeDirFn = origHomeDir
+		selfUpdateNowFn = origNow
 	})
+
+	// Use a temp home with no state.json so the cooldown gate never fires.
+	selfUpdateHomeDirFn = func() (string, error) { return tmpHome, nil }
+	selfUpdateNowFn = func() time.Time { return time.Date(2099, 1, 1, 0, 0, 0, 0, time.UTC) }
 
 	updateCheckFiltered = func(_ context.Context, _ string, _ system.PlatformProfile, _ []string) []update.UpdateResult {
 		return checkResults

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"time"
 )
 
 const stateDir = ".gentle-ai"
@@ -74,6 +75,13 @@ type InstallState struct {
 	// Empty for state files written before persona persistence was added —
 	// callers fall back to PersonaGentleman in that case.
 	Persona string `json:"persona,omitempty"`
+
+	// LastUpdateCheck records the last time a successful remote update check was
+	// performed. Used by the cooldown gate (UpdateCheckTTL = 6h) to avoid
+	// hitting the GitHub API on every launch. Nil = never checked, so the
+	// check will always run on first launch (safe back-compat for existing
+	// state files that lack the field entirely).
+	LastUpdateCheck *time.Time `json:"last_update_check,omitempty"`
 }
 
 // Path returns the absolute path to the state file for the given home directory.
@@ -132,6 +140,7 @@ func MergeAgents(existing InstallState, newAgents []string) InstallState {
 		CodexCarrilModelAssignments: existing.CodexCarrilModelAssignments,
 		CodexPhaseModelAssignments:  existing.CodexPhaseModelAssignments,
 		Persona:                     existing.Persona,
+		LastUpdateCheck:             existing.LastUpdateCheck,
 	}
 }
 

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"testing"
+	"time"
 )
 
 // TestMergeAgents verifies that MergeAgents appends new agents to existing
@@ -658,6 +659,97 @@ func TestMergeAgents_PreservesCodexPhaseModelAssignments(t *testing.T) {
 	if !reflect.DeepEqual(merged.CodexPhaseModelAssignments, existing.CodexPhaseModelAssignments) {
 		t.Errorf("MergeAgents did not preserve CodexPhaseModelAssignments: got %v, want %v",
 			merged.CodexPhaseModelAssignments, existing.CodexPhaseModelAssignments)
+	}
+}
+
+// ─── Slice 2 RED: LastUpdateCheck round-trip and backward-compat ─────────────
+
+// TestLastUpdateCheck_RoundTrip verifies that LastUpdateCheck survives a
+// Write/Read cycle with the expected JSON key "last_update_check".
+func TestLastUpdateCheck_RoundTrip(t *testing.T) {
+	home := t.TempDir()
+
+	ts := time.Date(2026, 6, 14, 12, 0, 0, 0, time.UTC)
+	s := InstallState{
+		InstalledAgents: []string{"claude-code"},
+		LastUpdateCheck: &ts,
+	}
+
+	if err := Write(home, s); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+
+	got, err := Read(home)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+
+	if got.LastUpdateCheck == nil || !got.LastUpdateCheck.Equal(ts) {
+		t.Errorf("LastUpdateCheck = %v, want %v", got.LastUpdateCheck, ts)
+	}
+
+	// JSON must contain the expected key.
+	data, err := os.ReadFile(Path(home))
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if !contains(string(data), "last_update_check") {
+		t.Errorf("JSON must contain key last_update_check; got:\n%s", data)
+	}
+}
+
+// TestLastUpdateCheck_OmitWhenZero verifies that a zero-value LastUpdateCheck
+// is omitted from JSON (omitempty), so old binaries that wrote state without
+// the field still produce clean JSON.
+func TestLastUpdateCheck_OmitWhenZero(t *testing.T) {
+	home := t.TempDir()
+	s := InstallState{InstalledAgents: []string{"claude-code"}}
+	if err := Write(home, s); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	data, err := os.ReadFile(Path(home))
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if contains(string(data), "last_update_check") {
+		t.Error("JSON must not contain last_update_check when zero")
+	}
+}
+
+// TestLastUpdateCheck_BackwardCompat verifies that state.json files written
+// before the LastUpdateCheck field was added still read without error, with a
+// nil LastUpdateCheck (never checked = always-check behavior).
+func TestLastUpdateCheck_BackwardCompat(t *testing.T) {
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, stateDir), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	legacy := `{"installed_agents":["claude-code"]}` + "\n"
+	if err := os.WriteFile(Path(home), []byte(legacy), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	s, err := Read(home)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if s.LastUpdateCheck != nil {
+		t.Errorf("LastUpdateCheck = %v, want nil for legacy state", s.LastUpdateCheck)
+	}
+}
+
+// TestMergeAgents_PreservesLastUpdateCheck verifies MergeAgents carries
+// LastUpdateCheck from the existing state into the merged result.
+func TestMergeAgents_PreservesLastUpdateCheck(t *testing.T) {
+	ts := time.Date(2026, 6, 14, 10, 0, 0, 0, time.UTC)
+	existing := InstallState{
+		InstalledAgents: []string{"claude-code"},
+		LastUpdateCheck: &ts,
+	}
+	merged := MergeAgents(existing, []string{"opencode"})
+	if merged.LastUpdateCheck == nil || !merged.LastUpdateCheck.Equal(ts) {
+		t.Errorf("MergeAgents did not preserve LastUpdateCheck: got %v, want %v",
+			merged.LastUpdateCheck, ts)
 	}
 }
 

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -29,6 +29,10 @@ import (
 	"github.com/gentleman-programming/gentle-ai/internal/update/upgrade"
 )
 
+// tuiNowFn returns the current time for the update-check cooldown gate.
+// Package-level var so tests can inject a deterministic clock.
+var tuiNowFn = time.Now
+
 // osStatModelCache is a package-level variable so tests can override it to
 // simulate a missing or present OpenCode model cache file.
 var osStatModelCache = os.Stat
@@ -602,11 +606,15 @@ func installStateModelAssignments(assignments map[string]state.ModelAssignmentSt
 func (m Model) Init() tea.Cmd {
 	version := m.Version
 	profile := m.Detection.System.Profile
+	home := homeDir()
 
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
-		results := update.CheckAll(ctx, version, profile)
+		results := update.CheckAllWithCooldown(ctx, version, profile, home, update.UpdateCheckTTL,
+			tuiNowFn,
+			update.CheckAll,
+		)
 		return UpdateCheckResultMsg{Results: results}
 	}
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -3914,7 +3914,10 @@ func (m Model) buildAgentBuilderAdapters() []agentbuilder.AdapterInfo {
 	return adapters
 }
 
-// homeDir returns the current user's home directory path.
+// homeDir returns the current user's home directory path, or "" if it cannot
+// be resolved. Callers that use the result for cooldown state must treat "" as
+// "no persistence" (always-check, never write) to avoid routing state under
+// /tmp or any other fallback path that could pollute unrelated sessions.
 func homeDir() string {
 	if h, err := os.UserHomeDir(); err == nil && h != "" {
 		return h
@@ -3922,7 +3925,7 @@ func homeDir() string {
 	if h := os.Getenv("HOME"); h != "" {
 		return h
 	}
-	return "/tmp"
+	return ""
 }
 
 // buildInstalledAgentIDs returns the list of AgentIDs from the adapter list.

--- a/internal/update/cooldown.go
+++ b/internal/update/cooldown.go
@@ -2,6 +2,8 @@ package update
 
 import (
 	"context"
+	"errors"
+	"os"
 	"time"
 
 	"github.com/gentleman-programming/gentle-ai/internal/state"
@@ -23,6 +25,10 @@ type checkAllFn func(ctx context.Context, currentVersion string, profile system.
 // current time back to LastUpdateCheck. On any read/write error the function
 // falls back to running the check (fail-open).
 //
+// When homeDir is "" (home directory resolution failed), both the state read
+// and write are skipped entirely: the check always runs and no state file is
+// touched, preventing writes to arbitrary CWD-relative paths.
+//
 // nowFn is injected for test determinism; pass func() time.Time { return time.Now() }
 // in production code. checkFn is injected for testing; pass CheckAll in production.
 func CheckAllWithCooldown(
@@ -36,27 +42,40 @@ func CheckAllWithCooldown(
 ) []UpdateResult {
 	now := nowFn()
 
-	// Read existing state to inspect LastUpdateCheck.
-	s, err := state.Read(homeDir)
-	if err == nil && s.LastUpdateCheck != nil {
-		elapsed := now.Sub(*s.LastUpdateCheck)
-		if elapsed < ttl {
-			// Cache is fresh — skip network call.
-			return nil
+	// When homeDir is empty (home resolution failed), skip both state read and
+	// write: always run the check and never touch any state.json.
+	if homeDir != "" {
+		// Read existing state to inspect LastUpdateCheck.
+		s, err := state.Read(homeDir)
+		if err == nil && s.LastUpdateCheck != nil {
+			elapsed := now.Sub(*s.LastUpdateCheck)
+			// Only skip when elapsed is non-negative AND within the TTL window.
+			// A future LastUpdateCheck (negative elapsed from clock skew) must
+			// not suppress the check.
+			if elapsed >= 0 && elapsed < ttl {
+				// Cache is fresh — skip network call.
+				return nil
+			}
 		}
+		// err != nil means no state file (first run) → always check.
 	}
-	// err != nil means no state file (first run) → always check.
 
 	// Perform the remote check.
 	results := checkFn(ctx, currentVersion, profile)
 
 	// Update LastUpdateCheck only when the check succeeded (at least one
 	// non-failed result, or empty-but-no-error; never if all are CheckFailed).
-	if checkSucceeded(results) {
+	// Also skip write when homeDir is empty.
+	if homeDir != "" && checkSucceeded(results) {
 		// Re-read state to avoid clobbering unrelated fields written concurrently.
 		current, readErr := state.Read(homeDir)
 		if readErr != nil {
-			// No existing state — start fresh.
+			if !errors.Is(readErr, os.ErrNotExist) {
+				// File exists but is unreadable/corrupt — do not overwrite; skip
+				// persisting the timestamp this round to avoid data loss.
+				return results
+			}
+			// File genuinely missing (first run) — start fresh.
 			current = state.InstallState{}
 		}
 		current.LastUpdateCheck = &now

--- a/internal/update/cooldown.go
+++ b/internal/update/cooldown.go
@@ -1,0 +1,80 @@
+package update
+
+import (
+	"context"
+	"time"
+
+	"github.com/gentleman-programming/gentle-ai/internal/state"
+	"github.com/gentleman-programming/gentle-ai/internal/system"
+)
+
+// UpdateCheckTTL is the minimum time between remote update checks. Launches
+// within this window reuse the cached state and skip the GitHub API call.
+const UpdateCheckTTL = 6 * time.Hour
+
+// checkAllFn is the function type that matches CheckAll's signature, used to
+// allow injection of a stub in tests.
+type checkAllFn func(ctx context.Context, currentVersion string, profile system.PlatformProfile) []UpdateResult
+
+// CheckAllWithCooldown gates CheckAll behind a TTL-based cooldown. It reads
+// LastUpdateCheck from state.json in homeDir; if the elapsed time since the
+// last successful check is less than ttl, it returns nil (no network call).
+// When a check is performed and ALL results are non-failed, it writes the
+// current time back to LastUpdateCheck. On any read/write error the function
+// falls back to running the check (fail-open).
+//
+// nowFn is injected for test determinism; pass func() time.Time { return time.Now() }
+// in production code. checkFn is injected for testing; pass CheckAll in production.
+func CheckAllWithCooldown(
+	ctx context.Context,
+	currentVersion string,
+	profile system.PlatformProfile,
+	homeDir string,
+	ttl time.Duration,
+	nowFn func() time.Time,
+	checkFn checkAllFn,
+) []UpdateResult {
+	now := nowFn()
+
+	// Read existing state to inspect LastUpdateCheck.
+	s, err := state.Read(homeDir)
+	if err == nil && s.LastUpdateCheck != nil {
+		elapsed := now.Sub(*s.LastUpdateCheck)
+		if elapsed < ttl {
+			// Cache is fresh — skip network call.
+			return nil
+		}
+	}
+	// err != nil means no state file (first run) → always check.
+
+	// Perform the remote check.
+	results := checkFn(ctx, currentVersion, profile)
+
+	// Update LastUpdateCheck only when the check succeeded (at least one
+	// non-failed result, or empty-but-no-error; never if all are CheckFailed).
+	if checkSucceeded(results) {
+		// Re-read state to avoid clobbering unrelated fields written concurrently.
+		current, readErr := state.Read(homeDir)
+		if readErr != nil {
+			// No existing state — start fresh.
+			current = state.InstallState{}
+		}
+		current.LastUpdateCheck = &now
+		// Ignore write errors — non-fatal; next launch will retry.
+		_ = state.Write(homeDir, current)
+	}
+
+	return results
+}
+
+// checkSucceeded returns true when the result set should be considered a
+// successful check. A check is successful when every result is non-failed, or
+// there are no results at all (empty slice = no tools to check = trivially ok).
+func checkSucceeded(results []UpdateResult) bool {
+	for _, r := range results {
+		if r.Status == CheckFailed {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/update/cooldown_test.go
+++ b/internal/update/cooldown_test.go
@@ -2,6 +2,8 @@ package update
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -159,5 +161,146 @@ func TestCheckAllWithCooldown_FailedCheckDoesNotAdvanceTimestamp(t *testing.T) {
 	// It should remain the original stale value.
 	if updated.LastUpdateCheck == nil || !updated.LastUpdateCheck.Equal(stale) {
 		t.Errorf("LastUpdateCheck = %v, want original stale %v", updated.LastUpdateCheck, stale)
+	}
+}
+
+// TestCheckAllWithCooldown_EmptyHomeDirAlwaysChecks verifies that when homeDir
+// is "" (home resolution failed), the check always runs and no state file is
+// written anywhere.
+func TestCheckAllWithCooldown_EmptyHomeDirAlwaysChecks(t *testing.T) {
+	profile := system.PlatformProfile{OS: "darwin", PackageManager: "brew"}
+	now := time.Date(2026, 6, 14, 12, 0, 0, 0, time.UTC)
+
+	// Ensure the CWD-relative state directory does not pre-exist from a
+	// previous (buggy) run, so we can detect a fresh write unambiguously.
+	cwd, _ := os.Getwd()
+	stateInCWD := filepath.Join(cwd, ".gentle-ai", "state.json")
+	_ = os.Remove(stateInCWD)
+	_ = os.Remove(filepath.Join(cwd, ".gentle-ai"))
+
+	checkCalled := 0
+	stubCheckAll := func(_ context.Context, _ string, _ system.PlatformProfile) []UpdateResult {
+		checkCalled++
+		return []UpdateResult{{Tool: ToolInfo{Name: "gentle-ai"}, Status: UpToDate}}
+	}
+
+	results := CheckAllWithCooldown(context.Background(), "1.0.0", profile, "", 6*time.Hour,
+		func() time.Time { return now },
+		stubCheckAll,
+	)
+
+	if checkCalled != 1 {
+		t.Errorf("network check called %d times with empty homeDir, want 1 (always-check)", checkCalled)
+	}
+	if len(results) == 0 {
+		t.Error("expected non-empty results from the check, got empty")
+	}
+
+	// Verify no state file was written to CWD or any relative path.
+	if _, err := os.Stat(stateInCWD); err == nil {
+		t.Errorf("state file was written to CWD (%s) — must not write when homeDir is empty", stateInCWD)
+	}
+}
+
+// TestCheckAllWithCooldown_EmptyHomeDirNoStateRead verifies that when homeDir
+// is "", the cooldown skip does not engage (no state.Read), so the check runs
+// even when a real state file might exist somewhere.
+func TestCheckAllWithCooldown_EmptyHomeDirNoStateRead(t *testing.T) {
+	profile := system.PlatformProfile{OS: "darwin", PackageManager: "brew"}
+	now := time.Date(2026, 6, 14, 12, 0, 0, 0, time.UTC)
+	recent := now.Add(-1 * time.Minute)
+
+	checkCalled := 0
+	stubCheckAll := func(_ context.Context, _ string, _ system.PlatformProfile) []UpdateResult {
+		checkCalled++
+		return nil
+	}
+
+	// Even if we pretend there's a "recent" timestamp, with empty homeDir we
+	// never read state so the cooldown cannot engage — check must run.
+	_ = recent // intentionally unused: we cannot write to homeDir="" safely
+
+	CheckAllWithCooldown(context.Background(), "1.0.0", profile, "", 6*time.Hour,
+		func() time.Time { return now },
+		stubCheckAll,
+	)
+
+	if checkCalled != 1 {
+		t.Errorf("network check called %d times, want 1 — empty homeDir disables cooldown read", checkCalled)
+	}
+}
+
+// TestCheckAllWithCooldown_FutureTimestampAlwaysChecks verifies that a future
+// LastUpdateCheck (clock skew) does not cause the cooldown to skip the check.
+// Negative elapsed must be treated as needing a check.
+func TestCheckAllWithCooldown_FutureTimestampAlwaysChecks(t *testing.T) {
+	home := t.TempDir()
+	profile := system.PlatformProfile{OS: "darwin", PackageManager: "brew"}
+
+	now := time.Date(2026, 6, 14, 12, 0, 0, 0, time.UTC)
+	// LastUpdateCheck is 1 hour IN THE FUTURE relative to now.
+	future := now.Add(1 * time.Hour)
+	s := state.InstallState{
+		InstalledAgents: []string{"claude-code"},
+		LastUpdateCheck: &future,
+	}
+	if err := state.Write(home, s); err != nil {
+		t.Fatalf("state.Write() error = %v", err)
+	}
+
+	checkCalled := 0
+	stubCheckAll := func(_ context.Context, _ string, _ system.PlatformProfile) []UpdateResult {
+		checkCalled++
+		return nil
+	}
+
+	CheckAllWithCooldown(context.Background(), "1.0.0", profile, home, 6*time.Hour,
+		func() time.Time { return now },
+		stubCheckAll,
+	)
+
+	if checkCalled != 1 {
+		t.Errorf("network check called %d times with future timestamp, want 1 (must not skip on negative elapsed)", checkCalled)
+	}
+}
+
+// TestCheckAllWithCooldown_NonMissingReadErrorSkipsWrite verifies that when the
+// state file exists but produces a non-missing read error (e.g. corrupt JSON),
+// the timestamp write is skipped — existing state must never be clobbered.
+func TestCheckAllWithCooldown_NonMissingReadErrorSkipsWrite(t *testing.T) {
+	home := t.TempDir()
+	profile := system.PlatformProfile{OS: "darwin", PackageManager: "brew"}
+	now := time.Date(2026, 6, 14, 12, 0, 0, 0, time.UTC)
+
+	// Write a corrupt (non-parseable) state file so state.Read returns a
+	// non-missing error (file exists but JSON is invalid).
+	stateDir := filepath.Join(home, ".gentle-ai")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	corruptPath := filepath.Join(stateDir, "state.json")
+	if err := os.WriteFile(corruptPath, []byte("NOT VALID JSON"), 0o644); err != nil {
+		t.Fatalf("WriteFile corrupt: %v", err)
+	}
+
+	stubCheckAll := func(_ context.Context, _ string, _ system.PlatformProfile) []UpdateResult {
+		// Return a successful result — checkSucceeded will be true.
+		return []UpdateResult{{Tool: ToolInfo{Name: "gentle-ai"}, Status: UpToDate}}
+	}
+
+	// stale first read: corrupt file → read error → always-check (skip cooldown).
+	// After check, re-read for write: corrupt → non-missing error → must skip write.
+	CheckAllWithCooldown(context.Background(), "1.0.0", profile, home, 6*time.Hour,
+		func() time.Time { return now },
+		stubCheckAll,
+	)
+
+	// The corrupt file must still be corrupt — not overwritten with valid JSON.
+	data, err := os.ReadFile(corruptPath)
+	if err != nil {
+		t.Fatalf("ReadFile after cooldown: %v", err)
+	}
+	if string(data) != "NOT VALID JSON" {
+		t.Errorf("state file was overwritten; got %q, want original corrupt content", string(data))
 	}
 }

--- a/internal/update/cooldown_test.go
+++ b/internal/update/cooldown_test.go
@@ -1,0 +1,163 @@
+package update
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/gentleman-programming/gentle-ai/internal/state"
+	"github.com/gentleman-programming/gentle-ai/internal/system"
+)
+
+// TestCheckAllWithCooldown_FreshCacheSkipsNetwork verifies that when
+// LastUpdateCheck is recent (elapsed < TTL) no GitHub call is made and the
+// cached/empty result is returned immediately.
+func TestCheckAllWithCooldown_FreshCacheSkipsNetwork(t *testing.T) {
+	home := t.TempDir()
+	profile := system.PlatformProfile{OS: "darwin", PackageManager: "brew"}
+
+	// Write state with a LastUpdateCheck 1 minute ago (well within 6h TTL).
+	now := time.Date(2026, 6, 14, 12, 0, 0, 0, time.UTC)
+	recent := now.Add(-1 * time.Minute)
+	s := state.InstallState{
+		InstalledAgents: []string{"claude-code"},
+		LastUpdateCheck: &recent,
+	}
+	if err := state.Write(home, s); err != nil {
+		t.Fatalf("state.Write() error = %v", err)
+	}
+
+	checkCalled := 0
+	stubCheckAll := func(_ context.Context, _ string, _ system.PlatformProfile) []UpdateResult {
+		checkCalled++
+		return []UpdateResult{{Status: UpdateAvailable}}
+	}
+
+	results := CheckAllWithCooldown(context.Background(), "1.0.0", profile, home, 6*time.Hour,
+		func() time.Time { return now },
+		stubCheckAll,
+	)
+
+	if checkCalled != 0 {
+		t.Errorf("network check called %d times, want 0 (cache is fresh)", checkCalled)
+	}
+	if len(results) != 0 {
+		t.Errorf("results = %v, want empty (fresh cache returns nil/empty)", results)
+	}
+}
+
+// TestCheckAllWithCooldown_StaleCacheRefreshes verifies that when
+// LastUpdateCheck is older than the TTL the network check fires and on success
+// LastUpdateCheck is updated in state.
+func TestCheckAllWithCooldown_StaleCacheRefreshes(t *testing.T) {
+	home := t.TempDir()
+	profile := system.PlatformProfile{OS: "darwin", PackageManager: "brew"}
+
+	// Write state with LastUpdateCheck 7 hours ago (> 6h TTL).
+	now := time.Date(2026, 6, 14, 12, 0, 0, 0, time.UTC)
+	stale := now.Add(-7 * time.Hour)
+	s := state.InstallState{
+		InstalledAgents: []string{"claude-code"},
+		LastUpdateCheck: &stale,
+	}
+	if err := state.Write(home, s); err != nil {
+		t.Fatalf("state.Write() error = %v", err)
+	}
+
+	stubResults := []UpdateResult{{Tool: ToolInfo{Name: "gentle-ai"}, Status: UpToDate}}
+	checkCalled := 0
+	stubCheckAll := func(_ context.Context, _ string, _ system.PlatformProfile) []UpdateResult {
+		checkCalled++
+		return stubResults
+	}
+
+	results := CheckAllWithCooldown(context.Background(), "1.0.0", profile, home, 6*time.Hour,
+		func() time.Time { return now },
+		stubCheckAll,
+	)
+
+	if checkCalled != 1 {
+		t.Errorf("network check called %d times, want 1 (cache is stale)", checkCalled)
+	}
+	if len(results) != len(stubResults) {
+		t.Errorf("results len = %d, want %d", len(results), len(stubResults))
+	}
+
+	// Verify LastUpdateCheck was updated to now on success.
+	updated, err := state.Read(home)
+	if err != nil {
+		t.Fatalf("state.Read() error = %v", err)
+	}
+	if updated.LastUpdateCheck == nil || !updated.LastUpdateCheck.Equal(now) {
+		t.Errorf("LastUpdateCheck after stale refresh = %v, want %v", updated.LastUpdateCheck, now)
+	}
+}
+
+// TestCheckAllWithCooldown_MissingCache first-run always checks.
+func TestCheckAllWithCooldown_MissingCache(t *testing.T) {
+	home := t.TempDir()
+	profile := system.PlatformProfile{OS: "darwin", PackageManager: "brew"}
+
+	// No state file — first-run scenario.
+	now := time.Date(2026, 6, 14, 12, 0, 0, 0, time.UTC)
+
+	checkCalled := 0
+	stubCheckAll := func(_ context.Context, _ string, _ system.PlatformProfile) []UpdateResult {
+		checkCalled++
+		return nil
+	}
+
+	CheckAllWithCooldown(context.Background(), "1.0.0", profile, home, 6*time.Hour,
+		func() time.Time { return now },
+		stubCheckAll,
+	)
+
+	if checkCalled != 1 {
+		t.Errorf("network check called %d times on first run, want 1", checkCalled)
+	}
+}
+
+// TestCheckAllWithCooldown_FailedCheckDoesNotAdvanceTimestamp verifies that
+// when the underlying check returns an error-flagged result (CheckFailed), the
+// LastUpdateCheck timestamp is NOT updated, so the next launch retries.
+func TestCheckAllWithCooldown_FailedCheckDoesNotAdvanceTimestamp(t *testing.T) {
+	home := t.TempDir()
+	profile := system.PlatformProfile{OS: "darwin", PackageManager: "brew"}
+
+	// Stale cache — will attempt a refresh.
+	now := time.Date(2026, 6, 14, 12, 0, 0, 0, time.UTC)
+	stale := now.Add(-7 * time.Hour)
+	s := state.InstallState{
+		InstalledAgents: []string{"claude-code"},
+		LastUpdateCheck: &stale,
+	}
+	if err := state.Write(home, s); err != nil {
+		t.Fatalf("state.Write() error = %v", err)
+	}
+
+	// Return a failed-check result (all tools failed).
+	failedResults := []UpdateResult{
+		{Tool: ToolInfo{Name: "gentle-ai"}, Status: CheckFailed},
+	}
+	stubCheckAll := func(_ context.Context, _ string, _ system.PlatformProfile) []UpdateResult {
+		return failedResults
+	}
+
+	CheckAllWithCooldown(context.Background(), "1.0.0", profile, home, 6*time.Hour,
+		func() time.Time { return now },
+		stubCheckAll,
+	)
+
+	// LastUpdateCheck must NOT have advanced.
+	updated, err := state.Read(home)
+	if err != nil {
+		t.Fatalf("state.Read() error = %v", err)
+	}
+	if updated.LastUpdateCheck != nil && updated.LastUpdateCheck.Equal(now) {
+		t.Error("LastUpdateCheck was advanced after a failed check — must only advance on success")
+	}
+	// It should remain the original stale value.
+	if updated.LastUpdateCheck == nil || !updated.LastUpdateCheck.Equal(stale) {
+		t.Errorf("LastUpdateCheck = %v, want original stale %v", updated.LastUpdateCheck, stale)
+	}
+}


### PR DESCRIPTION
Slice 2/7 — gate the GitHub update check behind a 6h TTL cached in state.json; only advance the timestamp on a successful check.

Part of the `update-experience` stacked chain. Refs #872.

- [x] Bug fix / feature slice
- [x] Strict TDD, fresh-context reviewed, `go test ./...` green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Update checks now use a 6-hour, timestamp-based cooldown to avoid redundant network calls.
  * The app persists the last successful update-check time and preserves it when updating installed state.

* **Bug Fixes**
  * Update-check behavior is more reliable when the home directory can’t be resolved; cooldown state won’t be used in that case.
  * Failed checks no longer advance the stored cooldown timestamp.

* **Tests**
  * Added unit tests for cooldown caching, persistence, backward-compatible state loading, and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->