### PR TITLE
feat(upgrade): honor GENTLE_AI_CHANNEL when upgrading engram

### DIFF
--- a/internal/cli/channel_test.go
+++ b/internal/cli/channel_test.go
@@ -21,10 +21,12 @@ func TestResolveInstallChannel(t *testing.T) {
 		{name: "env beta", envValue: "beta", want: ChannelBeta},
 		{name: "flag wins over env", flagValue: "stable", envValue: "beta", want: ChannelStable},
 		{name: "invalid", flagValue: "engram-beta", wantErr: true},
+		// Spec: empty-string env var treated as unset → stable (slice 3 channel-honoring).
+		{name: "empty env string defaults stable", flagValue: "", envValue: "", want: ChannelStable},
 	}
 
 	for _, tt := range tests {
-			t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(t *testing.T) {
 			t.Setenv(channelEnvVar, tt.envValue)
 
 			got, err := ResolveInstallChannel(tt.flagValue)

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -62,7 +62,11 @@ var (
 
 	// engramDownloadFn is the function used to download the engram binary on non-brew platforms.
 	// Package-level var for testability — tests can replace this to avoid real HTTP calls.
-	engramDownloadFn = engram.DownloadLatestBinary
+	// Always uses the stable (release) path; beta channel at install time is handled
+	// separately via installBetaEngramFromMain.
+	engramDownloadFn = func(profile system.PlatformProfile) (string, error) {
+		return engram.DownloadLatestBinary(profile, false)
+	}
 
 	// AppVersion is the gentle-ai version that will be written into backup manifests.
 	// It is set by app.go before any CLI operation so that every backup created during

--- a/internal/components/engram/download.go
+++ b/internal/components/engram/download.go
@@ -39,6 +39,37 @@ var (
 	// engramGoInstallFn runs `go install <pkg>` and returns the path to the installed binary.
 	// Package-level var for testability — swapped in tests to avoid real go install calls.
 	engramGoInstallFn = engramGoInstallFromMain
+
+	// engramGoInstallCmdFn executes `go install <pkg>`. Package-level var for testability.
+	engramGoInstallCmdFn = func(pkg string) error {
+		cmd := exec.Command("go", "install", pkg)
+		cmd.Stdin = nil
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("go install %s: %w (output: %s)", pkg, err, strings.TrimSpace(string(out)))
+		}
+		return nil
+	}
+
+	// engramGoEnvFn queries the Go toolchain's effective environment for the
+	// given keys (e.g. "GOBIN", "GOPATH"). Package-level var for testability —
+	// swapped in tests to simulate values set via `go env -w` without mutating
+	// the real Go env file.
+	engramGoEnvFn = func(keys ...string) (map[string]string, error) {
+		args := append([]string{"env"}, keys...)
+		out, err := exec.Command("go", args...).Output()
+		if err != nil {
+			return nil, err
+		}
+		lines := strings.Split(strings.TrimRight(string(out), "\r\n"), "\n")
+		values := make(map[string]string, len(keys))
+		for i, key := range keys {
+			if i < len(lines) {
+				values[key] = strings.TrimSpace(lines[i])
+			}
+		}
+		return values, nil
+	}
 )
 
 // engramCoreTagPattern matches only plain semver tags (vX.Y.Z) that identify
@@ -715,16 +746,25 @@ func (b *byteReaderAt) ReadAt(p []byte, off int64) (int, error) {
 // engramGoInstallFromMain installs engram from the given Go package path (expected
 // to be "github.com/Gentleman-Programming/engram/cmd/engram@main") using `go install`.
 // It returns the path to the installed binary. This is the beta-channel upgrade path.
+//
+// The install directory is resolved via `go env GOBIN GOPATH` (the effective Go
+// environment) so that values set via `go env -w GOBIN=...` (stored in Go's env
+// file, NOT in shell env) are honored correctly. This mirrors the resolution done
+// by goInstallBinDirFromGoEnv in internal/cli/run.go.
 func engramGoInstallFromMain(pkg string) (string, error) {
-	cmd := exec.Command("go", "install", pkg)
-	cmd.Stdin = nil
-	if out, err := cmd.CombinedOutput(); err != nil {
-		return "", fmt.Errorf("go install %s: %w (output: %s)", pkg, err, strings.TrimSpace(string(out)))
+	if err := engramGoInstallCmdFn(pkg); err != nil {
+		return "", err
 	}
 
-	// Resolve the directory where `go install` placed the binary.
-	gopath := os.Getenv("GOPATH")
-	gobin := os.Getenv("GOBIN")
+	// Resolve the directory where `go install` placed the binary using the
+	// effective Go environment (honors `go env -w GOBIN=...`, not just shell env).
+	values, err := engramGoEnvFn("GOBIN", "GOPATH")
+	if err != nil {
+		return "", fmt.Errorf("resolve go install bin dir: %w", err)
+	}
+	gobin := strings.TrimSpace(values["GOBIN"])
+	gopath := strings.TrimSpace(values["GOPATH"])
+
 	if gobin == "" && gopath != "" {
 		gobin = filepath.Join(gopath, "bin")
 	}

--- a/internal/components/engram/download.go
+++ b/internal/components/engram/download.go
@@ -35,6 +35,10 @@ var (
 	engramInstallDirFn    = engramInstallDir
 	engramChecksumURLFn   = engramChecksumURL
 	engramStopProcessesFn = stopEngramProcesses
+
+	// engramGoInstallFn runs `go install <pkg>` and returns the path to the installed binary.
+	// Package-level var for testability — swapped in tests to avoid real go install calls.
+	engramGoInstallFn = engramGoInstallFromMain
 )
 
 // engramCoreTagPattern matches only plain semver tags (vX.Y.Z) that identify
@@ -50,12 +54,24 @@ const engramCoreTagPattern = `^v[0-9]+\.[0-9]+\.[0-9]+$`
 // installs it to the appropriate directory for the given platform.
 // It returns the full path to the installed binary.
 //
-// Checksum verification is mandatory: the install fails if checksums.txt is
-// unavailable, if the archive is not listed, or if the digest does not match.
+// When isBeta is true, engram is installed from source via `go install @main`
+// instead of downloading a release archive. This mirrors the install-time beta
+// path used by the CLI and ensures the upgrade executor honors GENTLE_AI_CHANNEL.
+//
+// Checksum verification is mandatory for the stable (release) path: the install
+// fails if checksums.txt is unavailable, if the archive is not listed, or if
+// the digest does not match.
 //
 // This is the non-brew installation method for Linux and Windows.
 // On macOS, brew handles engram transitively and this should not be called.
-func DownloadLatestBinary(profile system.PlatformProfile) (string, error) {
+func DownloadLatestBinary(profile system.PlatformProfile, isBeta bool) (string, error) {
+	// Beta channel: install from HEAD via go install rather than a release archive.
+	// This mirrors the installBetaEngramFromMain path used at install time.
+	if isBeta {
+		const pkg = "github.com/Gentleman-Programming/engram/cmd/engram@main"
+		return engramGoInstallFn(pkg)
+	}
+
 	ctx := context.Background()
 
 	// 1. Fetch the latest version tag from GitHub API. Only tags matching the
@@ -694,6 +710,34 @@ func (b *byteReaderAt) ReadAt(p []byte, off int64) (int, error) {
 		return n, io.EOF
 	}
 	return n, nil
+}
+
+// engramGoInstallFromMain installs engram from the given Go package path (expected
+// to be "github.com/Gentleman-Programming/engram/cmd/engram@main") using `go install`.
+// It returns the path to the installed binary. This is the beta-channel upgrade path.
+func engramGoInstallFromMain(pkg string) (string, error) {
+	cmd := exec.Command("go", "install", pkg)
+	cmd.Stdin = nil
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("go install %s: %w (output: %s)", pkg, err, strings.TrimSpace(string(out)))
+	}
+
+	// Resolve the directory where `go install` placed the binary.
+	gopath := os.Getenv("GOPATH")
+	gobin := os.Getenv("GOBIN")
+	if gobin == "" && gopath != "" {
+		gobin = filepath.Join(gopath, "bin")
+	}
+	if gobin == "" {
+		home, _ := os.UserHomeDir()
+		gobin = filepath.Join(home, "go", "bin")
+	}
+
+	binaryName := engramName
+	if runtime.GOOS == "windows" {
+		binaryName += ".exe"
+	}
+	return filepath.Join(gobin, binaryName), nil
 }
 
 // writeExecutable writes the content from r to outPath with executable permissions.

--- a/internal/components/engram/download_test.go
+++ b/internal/components/engram/download_test.go
@@ -277,7 +277,7 @@ func TestDownloadLatestBinaryLinux(t *testing.T) {
 	t.Cleanup(func() { engramInstallDirFn = origInstallDirFn })
 
 	profile := system.PlatformProfile{OS: "linux", PackageManager: "apt"}
-	installedPath, err := DownloadLatestBinary(profile)
+	installedPath, err := DownloadLatestBinary(profile, false)
 	if err != nil {
 		t.Fatalf("DownloadLatestBinary() error = %v", err)
 	}
@@ -324,7 +324,7 @@ func TestDownloadLatestBinaryWindows(t *testing.T) {
 	t.Cleanup(func() { engramInstallDirFn = origInstallDirFn })
 
 	profile := system.PlatformProfile{OS: "windows", PackageManager: "winget"}
-	installedPath, err := DownloadLatestBinary(profile)
+	installedPath, err := DownloadLatestBinary(profile, false)
 	if err != nil {
 		t.Fatalf("DownloadLatestBinary() error = %v", err)
 	}
@@ -364,7 +364,7 @@ func TestDownloadLatestBinaryDownloadError(t *testing.T) {
 	})
 
 	profile := system.PlatformProfile{OS: "linux", PackageManager: "apt"}
-	_, err := DownloadLatestBinary(profile)
+	_, err := DownloadLatestBinary(profile, false)
 	if err == nil {
 		t.Fatal("expected error when GitHub API returns 500, got nil")
 	}
@@ -442,7 +442,7 @@ func TestDownloadLatestBinarySkipsLatestReleaseWithoutBinaryAssets(t *testing.T)
 	t.Cleanup(func() { engramInstallDirFn = origInstallDirFn })
 
 	profile := system.PlatformProfile{OS: "linux", PackageManager: "apt"}
-	installedPath, err := DownloadLatestBinary(profile)
+	installedPath, err := DownloadLatestBinary(profile, false)
 	if err != nil {
 		t.Fatalf("DownloadLatestBinary() error = %v", err)
 	}
@@ -527,7 +527,7 @@ func TestDownloadLatestBinaryReleaseListFallsBackToAnonymousWhenTokenGets403(t *
 	t.Cleanup(func() { engramInstallDirFn = origInstallDirFn })
 
 	profile := system.PlatformProfile{OS: "linux", PackageManager: "apt"}
-	installedPath, err := DownloadLatestBinary(profile)
+	installedPath, err := DownloadLatestBinary(profile, false)
 	if err != nil {
 		t.Fatalf("DownloadLatestBinary() error = %v", err)
 	}
@@ -564,7 +564,7 @@ func TestDownloadLatestBinaryWindowsStopsEngramBeforeReplace(t *testing.T) {
 		return nil
 	}
 
-	installedPath, err := DownloadLatestBinary(system.PlatformProfile{OS: "windows", PackageManager: "winget"})
+	installedPath, err := DownloadLatestBinary(system.PlatformProfile{OS: "windows", PackageManager: "winget"}, false)
 	if err != nil {
 		t.Fatalf("DownloadLatestBinary(windows) error = %v", err)
 	}
@@ -602,7 +602,7 @@ func TestDownloadLatestBinaryWindowsStopFailureAbortsBeforeReplace(t *testing.T)
 	engramInstallDirFn = func(goos string) string { return installDir }
 	engramStopProcessesFn = func() error { return errors.New("stop denied") }
 
-	_, err := DownloadLatestBinary(system.PlatformProfile{OS: "windows", PackageManager: "winget"})
+	_, err := DownloadLatestBinary(system.PlatformProfile{OS: "windows", PackageManager: "winget"}, false)
 	if err == nil {
 		t.Fatal("expected stop failure, got nil")
 	}
@@ -645,7 +645,7 @@ func TestDownloadLatestBinaryWindowsStopSucceedsWhenProcessNotRunning(t *testing
 	// Simulate stopEngramProcesses returning nil (no engram process found — clean).
 	engramStopProcessesFn = func() error { return nil }
 
-	installedPath, err := DownloadLatestBinary(system.PlatformProfile{OS: "windows", PackageManager: "winget"})
+	installedPath, err := DownloadLatestBinary(system.PlatformProfile{OS: "windows", PackageManager: "winget"}, false)
 	if err != nil {
 		t.Fatalf("DownloadLatestBinary(windows) should succeed when stop returns nil, got: %v", err)
 	}
@@ -688,7 +688,7 @@ func TestDownloadLatestBinaryWindowsStopNilProceedsToInstall(t *testing.T) {
 		return nil
 	}
 
-	installedPath, err := DownloadLatestBinary(system.PlatformProfile{OS: "windows", PackageManager: "winget"})
+	installedPath, err := DownloadLatestBinary(system.PlatformProfile{OS: "windows", PackageManager: "winget"}, false)
 	if err != nil {
 		t.Fatalf("DownloadLatestBinary(windows) should not abort when stop returns nil (warning path), got: %v", err)
 	}
@@ -783,7 +783,7 @@ func TestDownloadLatestBinaryIgnoresGentleEngramAndPiTags(t *testing.T) {
 	t.Cleanup(func() { engramInstallDirFn = origInstallDirFn })
 
 	profile := system.PlatformProfile{OS: "linux", PackageManager: "apt"}
-	installedPath, err := DownloadLatestBinary(profile)
+	installedPath, err := DownloadLatestBinary(profile, false)
 	if err != nil {
 		t.Fatalf("DownloadLatestBinary() error = %v, want core engram v%s to be selected", err, binaryVersion)
 	}
@@ -880,7 +880,7 @@ func TestEngramChecksumVerification(t *testing.T) {
 			t.Cleanup(func() { engramInstallDirFn = origInstallDirFn })
 
 			profile := system.PlatformProfile{OS: "linux", PackageManager: "apt"}
-			_, err := DownloadLatestBinary(profile)
+			_, err := DownloadLatestBinary(profile, false)
 
 			if tt.wantErrSubstr == "" {
 				if err != nil {
@@ -1094,5 +1094,74 @@ func TestEngramExpectedChecksumFor(t *testing.T) {
 				t.Errorf("got digest %q, want %q", got, tt.wantDigest)
 			}
 		})
+	}
+}
+
+// --- TestDownloadLatestBinary_ChannelRouting (Slice 3) ---
+
+// TestDownloadLatestBinary_StableChannelUsesRelease verifies that calling
+// DownloadLatestBinary with isBeta=false fetches from the release download
+// path (the existing GitHub Releases flow).
+func TestDownloadLatestBinary_StableChannelUsesRelease(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on Windows: uses tar.gz server fixture")
+	}
+
+	server := makeServerWithFakeTarGz(t, "1.3.0")
+	defer server.Close()
+
+	origClient := engramHTTPClient
+	origBaseURL := engramGitHubBaseURL
+	engramHTTPClient = server.Client()
+	engramGitHubBaseURL = server.URL
+	t.Cleanup(func() {
+		engramHTTPClient = origClient
+		engramGitHubBaseURL = origBaseURL
+	})
+
+	tmpDir := t.TempDir()
+	origInstallDirFn := engramInstallDirFn
+	engramInstallDirFn = func(goos string) string { return tmpDir }
+	t.Cleanup(func() { engramInstallDirFn = origInstallDirFn })
+
+	profile := system.PlatformProfile{OS: "linux", PackageManager: "apt"}
+	// isBeta=false → should use the release download path.
+	installedPath, err := DownloadLatestBinary(profile, false)
+	if err != nil {
+		t.Fatalf("DownloadLatestBinary(stable): unexpected error: %v", err)
+	}
+	if !strings.HasPrefix(installedPath, tmpDir) {
+		t.Errorf("installedPath = %q, want prefix %q", installedPath, tmpDir)
+	}
+}
+
+// TestDownloadLatestBinary_BetaChannelUsesGoInstallMain verifies that calling
+// DownloadLatestBinary with isBeta=true performs go install @main instead of
+// fetching a release archive.
+func TestDownloadLatestBinary_BetaChannelUsesGoInstallMain(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping: requires go install command")
+	}
+
+	origGoInstallFn := engramGoInstallFn
+	t.Cleanup(func() { engramGoInstallFn = origGoInstallFn })
+
+	var gotPkg string
+	engramGoInstallFn = func(pkg string) (string, error) {
+		gotPkg = pkg
+		return "/tmp/engram-beta", nil
+	}
+
+	profile := system.PlatformProfile{OS: "linux", PackageManager: "apt"}
+	// isBeta=true → should use go install @main, not release download.
+	installedPath, err := DownloadLatestBinary(profile, true)
+	if err != nil {
+		t.Fatalf("DownloadLatestBinary(beta): unexpected error: %v", err)
+	}
+	if !strings.Contains(gotPkg, "@main") {
+		t.Errorf("go install pkg = %q, want @main suffix", gotPkg)
+	}
+	if installedPath == "" {
+		t.Error("expected non-empty installedPath for beta channel")
 	}
 }

--- a/internal/components/engram/download_test.go
+++ b/internal/components/engram/download_test.go
@@ -1165,3 +1165,49 @@ func TestDownloadLatestBinary_BetaChannelUsesGoInstallMain(t *testing.T) {
 		t.Error("expected non-empty installedPath for beta channel")
 	}
 }
+
+// TestEngramGoInstallFromMain_UsesGoEnvForBinDir verifies that
+// engramGoInstallFromMain resolves the install directory via `go env GOBIN GOPATH`
+// (the effective Go environment) rather than reading raw shell env vars.
+// This matters when GOBIN is set via `go env -w GOBIN=...` (stored in Go's
+// env file) but NOT exported into the shell environment.
+func TestEngramGoInstallFromMain_UsesGoEnvForBinDir(t *testing.T) {
+	const fakeInstallDir = "/custom/gobin/via/go-env"
+
+	origGoEnvFn := engramGoEnvFn
+	t.Cleanup(func() { engramGoEnvFn = origGoEnvFn })
+
+	// Simulate GOBIN set only via `go env -w` (not in shell env).
+	// The raw os.Getenv("GOBIN") would return "", but go env GOBIN returns
+	// the persisted value from the Go env file.
+	t.Setenv("GOBIN", "")
+	t.Setenv("GOPATH", "")
+
+	engramGoEnvFn = func(keys ...string) (map[string]string, error) {
+		result := make(map[string]string, len(keys))
+		for _, k := range keys {
+			if k == "GOBIN" {
+				result[k] = fakeInstallDir
+			} else {
+				result[k] = ""
+			}
+		}
+		return result, nil
+	}
+
+	// Inject a fake go install that does nothing (no real network/build).
+	origGoInstallCmdFn := engramGoInstallCmdFn
+	t.Cleanup(func() { engramGoInstallCmdFn = origGoInstallCmdFn })
+	engramGoInstallCmdFn = func(pkg string) error { return nil }
+
+	binaryPath, err := engramGoInstallFromMain("github.com/Gentleman-Programming/engram/cmd/engram@main")
+	if err != nil {
+		t.Fatalf("engramGoInstallFromMain: unexpected error: %v", err)
+	}
+
+	wantDir := fakeInstallDir
+	gotDir := filepath.Dir(binaryPath)
+	if gotDir != wantDir {
+		t.Errorf("binary dir = %q, want %q (from go env GOBIN)", gotDir, wantDir)
+	}
+}

--- a/internal/components/engram/download_test.go
+++ b/internal/components/engram/download_test.go
@@ -1012,7 +1012,7 @@ func TestFetchLatestEngramVersionWithAssetsPaginates(t *testing.T) {
 	t.Cleanup(func() { engramInstallDirFn = origInstallDirFn })
 
 	profile := system.PlatformProfile{OS: "linux", PackageManager: "apt"}
-	installedPath, err := DownloadLatestBinary(profile)
+	installedPath, err := DownloadLatestBinary(profile, false)
 	if err != nil {
 		t.Fatalf("DownloadLatestBinary() error = %v, want core engram v%s selected from page 2", err, binaryVersion)
 	}

--- a/internal/update/upgrade/strategy.go
+++ b/internal/update/upgrade/strategy.go
@@ -14,14 +14,17 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gentleman-programming/gentle-ai/internal/cli"
 	"github.com/gentleman-programming/gentle-ai/internal/components/engram"
 	"github.com/gentleman-programming/gentle-ai/internal/system"
 	"github.com/gentleman-programming/gentle-ai/internal/update"
 )
 
-// engramDownloadFn is the function used to download the engram binary.
+// engramDownloadFn is the function used to download the engram binary on the stable channel.
 // Package-level var for testability — swapped in tests to avoid real network calls.
-var engramDownloadFn = engram.DownloadLatestBinary
+var engramDownloadFn = func(profile system.PlatformProfile) (string, error) {
+	return engram.DownloadLatestBinary(profile, false)
+}
 
 // execCommand is a package-level var declared in executor.go (same package).
 
@@ -485,18 +488,60 @@ func installerUpgrade(ctx context.Context, tool update.ToolInfo, releaseURL stri
 	return true, nil
 }
 
-// engramBinaryUpgrade downloads the latest engram binary using its dedicated
-// cross-platform downloader and adds the install directory to PATH.
-// On Windows the PATH change is also persisted to the user registry via PowerShell.
+// engramBinaryUpgrade downloads or installs the latest engram binary.
+// It honors GENTLE_AI_CHANNEL: when the channel is beta, engram is installed
+// from source via `go install @main`. For stable (the default when the env var
+// is unset or unknown), the pre-built release binary is downloaded via
+// engramDownloadFn. On Windows, PATH changes are persisted to the user registry
+// via PowerShell.
 func engramBinaryUpgrade(profile system.PlatformProfile) error {
-	binaryPath, err := engramDownloadFn(profile)
+	// Resolve the install channel from the environment. Unknown values fall back
+	// to stable (ResolveInstallChannel returns an error for truly unrecognized
+	// values; we treat those as stable and emit a warning so users are not silently
+	// misrouted).
+	channel, err := cli.ResolveInstallChannel("")
 	if err != nil {
-		return fmt.Errorf("download engram binary: %w", err)
+		fmt.Fprintf(os.Stderr, "WARNING: unrecognized GENTLE_AI_CHANNEL value (%v); defaulting to stable\n", err)
+		channel = cli.ChannelStable
 	}
+
+	var binaryPath string
+	if channel.IsBeta() {
+		// Beta channel: install engram from HEAD using go install @main. This mirrors
+		// the installBetaEngramFromMain path used at install time in internal/cli/run.go.
+		const pkg = "github.com/Gentleman-Programming/engram/cmd/engram@main"
+		cmd := execCommand("go", "install", pkg)
+		cmd.Stdin = nil
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return fmt.Errorf("go install %s: %w (output: %s)", pkg, err, strings.TrimSpace(string(out)))
+		}
+		// Resolve the bin directory where go install placed the binary.
+		gopath := os.Getenv("GOPATH")
+		gobin := os.Getenv("GOBIN")
+		if gobin == "" && gopath != "" {
+			gobin = filepath.Join(gopath, "bin")
+		}
+		if gobin == "" {
+			home, _ := os.UserHomeDir()
+			gobin = filepath.Join(home, "go", "bin")
+		}
+		binaryName := "engram"
+		if runtime.GOOS == "windows" {
+			binaryName += ".exe"
+		}
+		binaryPath = filepath.Join(gobin, binaryName)
+	} else {
+		// Stable channel (default): download the latest release binary.
+		binaryPath, err = engramDownloadFn(profile)
+		if err != nil {
+			return fmt.Errorf("download engram binary: %w", err)
+		}
+	}
+
 	// Add install dir to PATH. On Windows this also persists via PowerShell (user registry).
 	binDir := filepath.Dir(binaryPath)
 	if err := system.AddToUserPath(binDir); err != nil {
-		// Non-fatal: the binary was downloaded successfully. Warn and continue.
+		// Non-fatal: the binary was downloaded or installed successfully. Warn and continue.
 		fmt.Fprintf(os.Stderr, "WARNING: could not add %s to PATH: %v\n", binDir, err)
 	}
 	return nil

--- a/internal/update/upgrade/strategy.go
+++ b/internal/update/upgrade/strategy.go
@@ -26,6 +26,14 @@ var engramDownloadFn = func(profile system.PlatformProfile) (string, error) {
 	return engram.DownloadLatestBinary(profile, false)
 }
 
+// engramBetaInstallFn installs engram from HEAD via `go install @main` (beta channel).
+// It delegates to engram.DownloadLatestBinary(profile, true), which is the single
+// canonical beta path shared with the install-time flow. Package-level var for
+// testability — swapped in tests to avoid real go install/network calls.
+var engramBetaInstallFn = func(profile system.PlatformProfile) (string, error) {
+	return engram.DownloadLatestBinary(profile, true)
+}
+
 // execCommand is a package-level var declared in executor.go (same package).
 
 // scriptHTTPClient is the HTTP client used for downloading install.sh.
@@ -507,29 +515,15 @@ func engramBinaryUpgrade(profile system.PlatformProfile) error {
 
 	var binaryPath string
 	if channel.IsBeta() {
-		// Beta channel: install engram from HEAD using go install @main. This mirrors
-		// the installBetaEngramFromMain path used at install time in internal/cli/run.go.
-		const pkg = "github.com/Gentleman-Programming/engram/cmd/engram@main"
-		cmd := execCommand("go", "install", pkg)
-		cmd.Stdin = nil
-		if out, err := cmd.CombinedOutput(); err != nil {
-			return fmt.Errorf("go install %s: %w (output: %s)", pkg, err, strings.TrimSpace(string(out)))
+		// Beta channel: install engram from HEAD via engramBetaInstallFn, which
+		// delegates to engram.DownloadLatestBinary(profile, true). This is the
+		// single canonical beta path shared with the install-time flow in
+		// internal/cli/run.go (installBetaEngramFromMain). The previous inline
+		// `go install` block is removed — all beta logic lives in download.go.
+		binaryPath, err = engramBetaInstallFn(profile)
+		if err != nil {
+			return fmt.Errorf("install engram from main (beta): %w", err)
 		}
-		// Resolve the bin directory where go install placed the binary.
-		gopath := os.Getenv("GOPATH")
-		gobin := os.Getenv("GOBIN")
-		if gobin == "" && gopath != "" {
-			gobin = filepath.Join(gopath, "bin")
-		}
-		if gobin == "" {
-			home, _ := os.UserHomeDir()
-			gobin = filepath.Join(home, "go", "bin")
-		}
-		binaryName := "engram"
-		if runtime.GOOS == "windows" {
-			binaryName += ".exe"
-		}
-		binaryPath = filepath.Join(gobin, binaryName)
 	} else {
 		// Stable channel (default): download the latest release binary.
 		binaryPath, err = engramDownloadFn(profile)

--- a/internal/update/upgrade/strategy_test.go
+++ b/internal/update/upgrade/strategy_test.go
@@ -1533,6 +1533,94 @@ func TestInstallerUpgrade_NonWindows(t *testing.T) {
 	}
 }
 
+// --- TestEngramBinaryUpgrade_ChannelRouting (Slice 3) ---
+
+// TestEngramBinaryUpgrade_StableChannelCallsDownloadFn verifies that when
+// GENTLE_AI_CHANNEL is unset or "stable", engramBinaryUpgrade delegates to
+// engramDownloadFn (the release-download path) and NOT go install @main.
+func TestEngramBinaryUpgrade_StableChannelCallsDownloadFn(t *testing.T) {
+	tests := []struct {
+		name   string
+		envVal string
+	}{
+		{name: "channel unset", envVal: ""},
+		{name: "channel explicit stable", envVal: "stable"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("GENTLE_AI_CHANNEL", tt.envVal)
+
+			origDownloadFn := engramDownloadFn
+			origExecCommand := execCommand
+			t.Cleanup(func() {
+				engramDownloadFn = origDownloadFn
+				execCommand = origExecCommand
+			})
+
+			downloadCalled := false
+			engramDownloadFn = func(profile system.PlatformProfile) (string, error) {
+				downloadCalled = true
+				return "/tmp/engram", nil
+			}
+
+			// go install must NOT be called for stable channel.
+			execCommand = func(name string, args ...string) *exec.Cmd {
+				t.Errorf("execCommand called unexpectedly for stable channel: %s %v", name, args)
+				return mockCmd("echo", "unexpected")
+			}
+
+			profile := system.PlatformProfile{OS: "linux", PackageManager: "apt"}
+			err := engramBinaryUpgrade(profile)
+			if err != nil {
+				t.Fatalf("engramBinaryUpgrade stable: unexpected error: %v", err)
+			}
+			if !downloadCalled {
+				t.Error("expected engramDownloadFn to be called for stable channel, but it was not")
+			}
+		})
+	}
+}
+
+// TestEngramBinaryUpgrade_BetaChannelUsesGoInstallMain verifies that when
+// GENTLE_AI_CHANNEL=beta, engramBinaryUpgrade uses go install @main and does
+// NOT call engramDownloadFn.
+func TestEngramBinaryUpgrade_BetaChannelUsesGoInstallMain(t *testing.T) {
+	t.Setenv("GENTLE_AI_CHANNEL", "beta")
+
+	origDownloadFn := engramDownloadFn
+	origExecCommand := execCommand
+	t.Cleanup(func() {
+		engramDownloadFn = origDownloadFn
+		execCommand = origExecCommand
+	})
+
+	engramDownloadFn = func(profile system.PlatformProfile) (string, error) {
+		t.Error("engramDownloadFn must NOT be called for beta channel")
+		return "", nil
+	}
+
+	var gotGoInstallTarget string
+	execCommand = func(name string, args ...string) *exec.Cmd {
+		if name == "go" && len(args) >= 2 && args[0] == "install" {
+			gotGoInstallTarget = args[1]
+		}
+		return mockCmd("true")
+	}
+
+	profile := system.PlatformProfile{OS: "linux", PackageManager: "apt"}
+	err := engramBinaryUpgrade(profile)
+	if err != nil {
+		t.Fatalf("engramBinaryUpgrade beta: unexpected error: %v", err)
+	}
+	if gotGoInstallTarget == "" {
+		t.Fatal("expected go install to be called for beta channel, but execCommand received no go install call")
+	}
+	if !strings.Contains(gotGoInstallTarget, "@main") {
+		t.Errorf("go install target = %q, want it to contain @main", gotGoInstallTarget)
+	}
+}
+
 type roundTripFunc func(req *http.Request) (*http.Response, error)
 
 func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {

--- a/internal/update/upgrade/strategy_test.go
+++ b/internal/update/upgrade/strategy_test.go
@@ -1583,29 +1583,29 @@ func TestEngramBinaryUpgrade_StableChannelCallsDownloadFn(t *testing.T) {
 }
 
 // TestEngramBinaryUpgrade_BetaChannelUsesGoInstallMain verifies that when
-// GENTLE_AI_CHANNEL=beta, engramBinaryUpgrade uses go install @main and does
-// NOT call engramDownloadFn.
+// GENTLE_AI_CHANNEL=beta, engramBinaryUpgrade delegates to
+// engramBetaInstallFn (the consolidated beta path, backed by
+// engram.DownloadLatestBinary(profile, true) in production). The stable
+// engramDownloadFn must NOT be called.
 func TestEngramBinaryUpgrade_BetaChannelUsesGoInstallMain(t *testing.T) {
 	t.Setenv("GENTLE_AI_CHANNEL", "beta")
 
 	origDownloadFn := engramDownloadFn
-	origExecCommand := execCommand
+	origBetaFn := engramBetaInstallFn
 	t.Cleanup(func() {
 		engramDownloadFn = origDownloadFn
-		execCommand = origExecCommand
+		engramBetaInstallFn = origBetaFn
 	})
 
 	engramDownloadFn = func(profile system.PlatformProfile) (string, error) {
-		t.Error("engramDownloadFn must NOT be called for beta channel")
+		t.Error("engramDownloadFn (stable path) must NOT be called for beta channel")
 		return "", nil
 	}
 
-	var gotGoInstallTarget string
-	execCommand = func(name string, args ...string) *exec.Cmd {
-		if name == "go" && len(args) >= 2 && args[0] == "install" {
-			gotGoInstallTarget = args[1]
-		}
-		return mockCmd("true")
+	var betaCalled bool
+	engramBetaInstallFn = func(profile system.PlatformProfile) (string, error) {
+		betaCalled = true
+		return "/tmp/engram-beta", nil
 	}
 
 	profile := system.PlatformProfile{OS: "linux", PackageManager: "apt"}
@@ -1613,11 +1613,8 @@ func TestEngramBinaryUpgrade_BetaChannelUsesGoInstallMain(t *testing.T) {
 	if err != nil {
 		t.Fatalf("engramBinaryUpgrade beta: unexpected error: %v", err)
 	}
-	if gotGoInstallTarget == "" {
-		t.Fatal("expected go install to be called for beta channel, but execCommand received no go install call")
-	}
-	if !strings.Contains(gotGoInstallTarget, "@main") {
-		t.Errorf("go install target = %q, want it to contain @main", gotGoInstallTarget)
+	if !betaCalled {
+		t.Fatal("expected engramBetaInstallFn (beta path) to be called, but it was not")
 	}
 }
 


### PR DESCRIPTION
Slice 3/7 — gentle-ai upgrade honors the channel (beta to @main, stable to latest release); single canonical beta path; GOBIN via go env. Stacked on slice 1.

Part of the `update-experience` stacked chain. Refs #872.

- [x] Bug fix / feature slice
- [x] Strict TDD, fresh-context reviewed, `go test ./...` green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for beta channel installation via environment variable, allowing users to opt into development builds alongside stable releases.

* **Tests**
  * Added test coverage for stable and beta installation paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->