### PR TITLE
feat(upgrade): complete sync after a gentle-ai self-upgrade

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -145,7 +145,11 @@ func RunArgs(args []string, stdout io.Writer) error {
 				// Leave PendingSync=true so the next launch retries.
 			} else {
 				installedState.PendingSync = false
-				_ = state.Write(homeDir, installedState)
+				if writeErr := state.Write(homeDir, installedState); writeErr != nil {
+					// Best-effort: surface the failure so it's not silently swallowed.
+					// Idempotent re-sync on the next launch is acceptable.
+					_, _ = fmt.Fprintf(stdout, "Warning: failed to clear PendingSync flag: %v\n", writeErr)
+				}
 			}
 		}
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -40,6 +40,14 @@ var (
 		p := tea.NewProgram(m, opts...)
 		return p.Run()
 	}
+	// deferredSyncFn is the function called when PendingSync=true is found on
+	// launch. Swappable for tests; production value calls cli.RunSync directly.
+	// cli.RunSync is idempotent (re-reads state + re-applies configs each call),
+	// so retrying on failure (spec scenario "deferred sync fails → retry") is safe.
+	deferredSyncFn = func() error {
+		_, err := cli.RunSync(nil)
+		return err
+	}
 )
 
 func Run() error {
@@ -125,6 +133,22 @@ func RunArgs(args []string, stdout io.Writer) error {
 		// A missing or unreadable state file is not an error — NewModel falls
 		// back to filesystem detection for first-time installs.
 		installedState, _ := state.Read(homeDir)
+
+		// Deferred sync: if a previous gentle-ai self-upgrade set PendingSync=true,
+		// run sync now with the new binary before entering the TUI. On success,
+		// clear the flag. On failure, log and leave the flag set for idempotent
+		// retry on the next launch (per spec scenario "deferred sync fails → retry").
+		// This is non-fatal — a sync failure must never block the TUI from opening.
+		if installedState.PendingSync {
+			if err := deferredSyncFn(); err != nil {
+				_, _ = fmt.Fprintf(stdout, "Warning: deferred sync failed: %v\n", err)
+				// Leave PendingSync=true so the next launch retries.
+			} else {
+				installedState.PendingSync = false
+				_ = state.Write(homeDir, installedState)
+			}
+		}
+
 		m := tui.NewModel(result, Version, installedState)
 		m.ExecuteFn = tuiExecute
 		m.RestoreFn = tuiRestore

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -1630,6 +1630,12 @@ func TestRunArgs_PendingSync_LeavesSetOnFailure(t *testing.T) {
 		t.Fatalf("RunArgs(nil) error = %v (deferred sync failure must be non-fatal)", err)
 	}
 
+	// The warning must be printed to stdout so the user knows sync was skipped.
+	out := buf.String()
+	if !strings.Contains(out, "Warning: deferred sync failed:") {
+		t.Errorf("stdout = %q, want warning message for deferred sync failure", out)
+	}
+
 	// PendingSync must remain set so the next launch retries.
 	s, err := state.Read(home)
 	if err != nil {

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -1478,20 +1478,17 @@ func writeAppSDDStatusFile(t *testing.T, path string, content string) {
 	}
 }
 
+// TestRunArgs_TUIRestartsAfterGentleAIUpgradeResult verifies that when the TUI
+// reports a successful gentle-ai upgrade, RunArgs calls restartAfterGentleAIUpgrade
+// which (after task 4.6) prints the restart guidance message instead of re-execing.
 func TestRunArgs_TUIRestartsAfterGentleAIUpgradeResult(t *testing.T) {
 	origDetect := detectSystem
 	origEnsure := ensureCurrentOSSupported
 	origRunTUI := runTUI
-	origReExec := reExec
-	origLookPath := lookPathFn
-	origGoOS := goOS
 	t.Cleanup(func() {
 		detectSystem = origDetect
 		ensureCurrentOSSupported = origEnsure
 		runTUI = origRunTUI
-		reExec = origReExec
-		lookPathFn = origLookPath
-		goOS = origGoOS
 		unsetEnv(t, envSelfUpdateDone)
 	})
 	unsetEnv(t, envSelfUpdateDone)
@@ -1500,8 +1497,6 @@ func TestRunArgs_TUIRestartsAfterGentleAIUpgradeResult(t *testing.T) {
 	detectSystem = func(context.Context) (system.DetectionResult, error) {
 		return system.DetectionResult{System: system.SystemInfo{Supported: true, Profile: system.PlatformProfile{OS: "darwin", PackageManager: "brew", Supported: true}}}, nil
 	}
-	goOS = func() string { return "darwin" }
-	lookPathFn = func(string) (string, error) { return "/usr/local/bin/gentle-ai", nil }
 
 	report := upgrade.UpgradeReport{Results: []upgrade.ToolUpgradeResult{
 		{ToolName: "gentle-ai", Status: upgrade.UpgradeSucceeded, NewVersion: "v1.40.0"},
@@ -1512,26 +1507,189 @@ func TestRunArgs_TUIRestartsAfterGentleAIUpgradeResult(t *testing.T) {
 		return model, nil
 	}
 
-	var reExecCalled int
-	reExec = func(argv0 string, _ []string, envv []string) error {
-		reExecCalled++
-		if argv0 != "/usr/local/bin/gentle-ai" {
-			t.Fatalf("reExec argv0 = %q, want PATH gentle-ai", argv0)
-		}
-		if !envContains(envv, envSelfUpdateDone+"=1") {
-			t.Fatalf("reExec env missing %s=1", envSelfUpdateDone)
-		}
+	var buf bytes.Buffer
+	if err := RunArgs(nil, &buf); err != nil {
+		t.Fatalf("RunArgs(TUI) error = %v", err)
+	}
+	// After task 4.6: restart message is printed, no re-exec occurs.
+	if !strings.Contains(buf.String(), "restart gentle-ai") {
+		t.Fatalf("output missing restart notice:\n%s", buf.String())
+	}
+}
+
+// ─── Slice 4 RED: deferred sync on launch via pending_sync flag ───────────────
+
+// TestRunArgs_PendingSync_RunsSyncAndClearsFlag verifies that when
+// state.json has PendingSync=true, RunArgs (TUI path / no args) calls
+// the deferred sync runner and writes PendingSync=false on success.
+func TestRunArgs_PendingSync_RunsSyncAndClearsFlag(t *testing.T) {
+	home := t.TempDir()
+	setupMockHome(t, home)
+
+	// Write initial state with PendingSync=true.
+	if err := state.Write(home, state.InstallState{
+		InstalledAgents: []string{"claude-code"},
+		PendingSync:     true,
+	}); err != nil {
+		t.Fatalf("state.Write() error = %v", err)
+	}
+
+	origSelf := selfUpdateFn
+	origEnsure := ensureCurrentOSSupported
+	origDetect := detectSystem
+	origRunTUI := runTUI
+	origDeferredSync := deferredSyncFn
+	t.Cleanup(func() {
+		selfUpdateFn = origSelf
+		ensureCurrentOSSupported = origEnsure
+		detectSystem = origDetect
+		runTUI = origRunTUI
+		deferredSyncFn = origDeferredSync
+	})
+
+	selfUpdateFn = func(_ context.Context, _ string, _ system.PlatformProfile, _ io.Writer) error {
+		return nil
+	}
+	ensureCurrentOSSupported = func() error { return nil }
+	detectSystem = func(context.Context) (system.DetectionResult, error) {
+		return system.DetectionResult{System: system.SystemInfo{Supported: true, Profile: system.PlatformProfile{OS: "darwin", PackageManager: "brew", Supported: true}}}, nil
+	}
+	runTUI = func(m tea.Model, _ ...tea.ProgramOption) (tea.Model, error) {
+		return m, nil
+	}
+
+	var syncCalled int
+	deferredSyncFn = func() error {
+		syncCalled++
 		return nil
 	}
 
 	var buf bytes.Buffer
 	if err := RunArgs(nil, &buf); err != nil {
-		t.Fatalf("RunArgs(TUI) error = %v", err)
+		t.Fatalf("RunArgs(nil) error = %v", err)
 	}
-	if reExecCalled != 1 {
-		t.Fatalf("reExecCalled = %d, want 1", reExecCalled)
+
+	if syncCalled != 1 {
+		t.Errorf("deferredSyncFn called %d times, want 1", syncCalled)
 	}
-	if !strings.Contains(buf.String(), "Updated to v1.40.0, restarting") {
-		t.Fatalf("output missing restart notice:\n%s", buf.String())
+
+	// PendingSync must be cleared after successful sync.
+	s, err := state.Read(home)
+	if err != nil {
+		t.Fatalf("state.Read() error = %v", err)
+	}
+	if s.PendingSync {
+		t.Errorf("PendingSync = true after successful deferred sync, want false")
+	}
+}
+
+// TestRunArgs_PendingSync_LeavesSetOnFailure verifies that when the deferred
+// sync fails, PendingSync remains true so the next launch retries idempotently.
+func TestRunArgs_PendingSync_LeavesSetOnFailure(t *testing.T) {
+	home := t.TempDir()
+	setupMockHome(t, home)
+
+	if err := state.Write(home, state.InstallState{
+		InstalledAgents: []string{"claude-code"},
+		PendingSync:     true,
+	}); err != nil {
+		t.Fatalf("state.Write() error = %v", err)
+	}
+
+	origSelf := selfUpdateFn
+	origEnsure := ensureCurrentOSSupported
+	origDetect := detectSystem
+	origRunTUI := runTUI
+	origDeferredSync := deferredSyncFn
+	t.Cleanup(func() {
+		selfUpdateFn = origSelf
+		ensureCurrentOSSupported = origEnsure
+		detectSystem = origDetect
+		runTUI = origRunTUI
+		deferredSyncFn = origDeferredSync
+	})
+
+	selfUpdateFn = func(_ context.Context, _ string, _ system.PlatformProfile, _ io.Writer) error {
+		return nil
+	}
+	ensureCurrentOSSupported = func() error { return nil }
+	detectSystem = func(context.Context) (system.DetectionResult, error) {
+		return system.DetectionResult{System: system.SystemInfo{Supported: true, Profile: system.PlatformProfile{OS: "darwin", PackageManager: "brew", Supported: true}}}, nil
+	}
+	runTUI = func(m tea.Model, _ ...tea.ProgramOption) (tea.Model, error) {
+		return m, nil
+	}
+
+	deferredSyncFn = func() error {
+		return fmt.Errorf("sync: network error")
+	}
+
+	var buf bytes.Buffer
+	// RunArgs must NOT return an error — deferred sync failure is non-fatal.
+	if err := RunArgs(nil, &buf); err != nil {
+		t.Fatalf("RunArgs(nil) error = %v (deferred sync failure must be non-fatal)", err)
+	}
+
+	// PendingSync must remain set so the next launch retries.
+	s, err := state.Read(home)
+	if err != nil {
+		t.Fatalf("state.Read() error = %v", err)
+	}
+	if !s.PendingSync {
+		t.Errorf("PendingSync = false after failed deferred sync, want true (idempotent retry)")
+	}
+}
+
+// TestRunArgs_NoPendingSync_NoSyncCall verifies that when PendingSync=false,
+// the deferred sync runner is NOT called (no extra sync on a normal launch).
+func TestRunArgs_NoPendingSync_NoSyncCall(t *testing.T) {
+	home := t.TempDir()
+	setupMockHome(t, home)
+
+	// Write state without PendingSync.
+	if err := state.Write(home, state.InstallState{
+		InstalledAgents: []string{"claude-code"},
+		PendingSync:     false,
+	}); err != nil {
+		t.Fatalf("state.Write() error = %v", err)
+	}
+
+	origSelf := selfUpdateFn
+	origEnsure := ensureCurrentOSSupported
+	origDetect := detectSystem
+	origRunTUI := runTUI
+	origDeferredSync := deferredSyncFn
+	t.Cleanup(func() {
+		selfUpdateFn = origSelf
+		ensureCurrentOSSupported = origEnsure
+		detectSystem = origDetect
+		runTUI = origRunTUI
+		deferredSyncFn = origDeferredSync
+	})
+
+	selfUpdateFn = func(_ context.Context, _ string, _ system.PlatformProfile, _ io.Writer) error {
+		return nil
+	}
+	ensureCurrentOSSupported = func() error { return nil }
+	detectSystem = func(context.Context) (system.DetectionResult, error) {
+		return system.DetectionResult{System: system.SystemInfo{Supported: true, Profile: system.PlatformProfile{OS: "darwin", PackageManager: "brew", Supported: true}}}, nil
+	}
+	runTUI = func(m tea.Model, _ ...tea.ProgramOption) (tea.Model, error) {
+		return m, nil
+	}
+
+	var syncCalled int
+	deferredSyncFn = func() error {
+		syncCalled++
+		return nil
+	}
+
+	var buf bytes.Buffer
+	if err := RunArgs(nil, &buf); err != nil {
+		t.Fatalf("RunArgs(nil) error = %v", err)
+	}
+
+	if syncCalled != 0 {
+		t.Errorf("deferredSyncFn called %d times, want 0 (no pending sync)", syncCalled)
 	}
 }

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -1646,6 +1646,71 @@ func TestRunArgs_PendingSync_LeavesSetOnFailure(t *testing.T) {
 	}
 }
 
+// TestRunArgs_PendingSync_ClearWriteFailureIsLogged verifies that when the
+// deferred sync succeeds but state.Write (to clear PendingSync) fails, the
+// error is printed to stdout and RunArgs does not return an error.
+// This guards against silently swallowed write failures (Issue 2).
+func TestRunArgs_PendingSync_ClearWriteFailureIsLogged(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("cannot test permission errors as root")
+	}
+	home := t.TempDir()
+	setupMockHome(t, home)
+
+	// Write initial state with PendingSync=true.
+	if err := state.Write(home, state.InstallState{
+		InstalledAgents: []string{"claude-code"},
+		PendingSync:     true,
+	}); err != nil {
+		t.Fatalf("state.Write() error = %v", err)
+	}
+
+	// Make the state file read-only so state.Write (the clear-PendingSync write) fails.
+	stateFilePath := state.Path(home)
+	if err := os.Chmod(stateFilePath, 0o444); err != nil {
+		t.Fatalf("Chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(stateFilePath, 0o644) })
+
+	origSelf := selfUpdateFn
+	origEnsure := ensureCurrentOSSupported
+	origDetect := detectSystem
+	origRunTUI := runTUI
+	origDeferredSync := deferredSyncFn
+	t.Cleanup(func() {
+		selfUpdateFn = origSelf
+		ensureCurrentOSSupported = origEnsure
+		detectSystem = origDetect
+		runTUI = origRunTUI
+		deferredSyncFn = origDeferredSync
+	})
+
+	selfUpdateFn = func(_ context.Context, _ string, _ system.PlatformProfile, _ io.Writer) error {
+		return nil
+	}
+	ensureCurrentOSSupported = func() error { return nil }
+	detectSystem = func(context.Context) (system.DetectionResult, error) {
+		return system.DetectionResult{System: system.SystemInfo{Supported: true, Profile: system.PlatformProfile{OS: "darwin", PackageManager: "brew", Supported: true}}}, nil
+	}
+	runTUI = func(m tea.Model, _ ...tea.ProgramOption) (tea.Model, error) {
+		return m, nil
+	}
+
+	// Deferred sync succeeds — the write-clear is what we're testing.
+	deferredSyncFn = func() error { return nil }
+
+	var buf bytes.Buffer
+	if err := RunArgs(nil, &buf); err != nil {
+		t.Fatalf("RunArgs(nil) error = %v (clear-write failure must be non-fatal)", err)
+	}
+
+	// The warning must appear in stdout when the clear-write fails.
+	out := buf.String()
+	if !strings.Contains(out, "Warning:") {
+		t.Errorf("stdout = %q; want a warning message when PendingSync clear-write fails", out)
+	}
+}
+
 // TestRunArgs_NoPendingSync_NoSyncCall verifies that when PendingSync=false,
 // the deferred sync runner is NOT called (no extra sync on a normal launch).
 func TestRunArgs_NoPendingSync_NoSyncCall(t *testing.T) {

--- a/internal/app/selfupdate.go
+++ b/internal/app/selfupdate.go
@@ -6,10 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
-	"runtime"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/mattn/go-isatty"
@@ -19,9 +16,6 @@ import (
 	"github.com/gentleman-programming/gentle-ai/internal/update"
 	"github.com/gentleman-programming/gentle-ai/internal/update/upgrade"
 )
-
-// lookPathFn is a package-level var for testability.
-var lookPathFn = exec.LookPath
 
 // selfUpdateNowFn returns the current time; injected for test determinism.
 var selfUpdateNowFn = func() time.Time { return time.Now() }
@@ -60,14 +54,6 @@ func defaultPromptForUpdate(stdout io.Writer, stdin io.Reader, currentVersion, l
 
 // selfUpdateTimeout is the maximum time allowed for the update check + upgrade.
 const selfUpdateTimeout = 7 * time.Second
-
-// reExec is swappable for testing — prevents actual syscall.Exec in tests.
-var reExec = func(argv0 string, argv []string, envv []string) error {
-	return syscall.Exec(argv0, argv, envv)
-}
-
-// goOS returns the current operating system name. Package-level var for testing.
-var goOS = func() string { return runtime.GOOS }
 
 // selfUpdate checks for and applies a gentle-ai update before normal dispatch.
 // Returns nil on success or skip; errors are non-fatal (caller logs and continues).

--- a/internal/app/selfupdate.go
+++ b/internal/app/selfupdate.go
@@ -3,6 +3,7 @@ package app
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -149,10 +150,20 @@ func selfUpdate(ctx context.Context, version string, profile system.PlatformProf
 	// binary runs sync automatically on its next launch. This replaces the
 	// previous "restart and sync manually" skip path. Failure to write state is
 	// non-fatal — the user can re-run sync explicitly.
+	//
+	// No-clobber guard: only fall back to a fresh InstallState{} when the file
+	// is genuinely missing (ErrNotExist). Any other read error (e.g. corrupt
+	// JSON, permission denied) means an existing file is present — do not
+	// overwrite it and risk dropping unrelated persisted fields.
 	if homeDir != "" {
-		s, _ := state.Read(homeDir)
-		s.PendingSync = true
-		_ = state.Write(homeDir, s)
+		s, readErr := state.Read(homeDir)
+		if readErr != nil && !errors.Is(readErr, os.ErrNotExist) {
+			// File exists but is unreadable/corrupt — skip this round to avoid
+			// clobbering installed_agents, model assignments, etc.
+		} else {
+			s.PendingSync = true
+			_ = state.Write(homeDir, s)
+		}
 	}
 
 	return restartAfterGentleAIUpgrade(target.LatestVersion, stdout)

--- a/internal/app/selfupdate.go
+++ b/internal/app/selfupdate.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/mattn/go-isatty"
 
+	"github.com/gentleman-programming/gentle-ai/internal/state"
 	"github.com/gentleman-programming/gentle-ai/internal/system"
 	"github.com/gentleman-programming/gentle-ai/internal/update"
 	"github.com/gentleman-programming/gentle-ai/internal/update/upgrade"
@@ -158,6 +159,16 @@ func selfUpdate(ctx context.Context, version string, profile system.PlatformProf
 		return nil
 	}
 
+	// Deferred sync: set PendingSync=true in state before exiting so the new
+	// binary runs sync automatically on its next launch. This replaces the
+	// previous "restart and sync manually" skip path. Failure to write state is
+	// non-fatal — the user can re-run sync explicitly.
+	if homeDir != "" {
+		s, _ := state.Read(homeDir)
+		s.PendingSync = true
+		_ = state.Write(homeDir, s)
+	}
+
 	return restartAfterGentleAIUpgrade(target.LatestVersion, stdout)
 }
 
@@ -172,33 +183,11 @@ func gentleAIUpgradeSucceeded(report upgrade.UpgradeReport) (string, bool) {
 
 func restartAfterGentleAIUpgrade(latestVersion string, stdout io.Writer) error {
 	latestVersion = strings.TrimPrefix(latestVersion, "v")
-	// Re-exec on Unix; print message on Windows.
-	if goOS() == "windows" {
-		_, _ = fmt.Fprintf(stdout, "Updated to v%s — please restart.\n", latestVersion)
-		return nil
-	}
-
-	// Unix: re-exec with the updated binary.
-	//
-	// Use exec.LookPath("gentle-ai") rather than os.Executable() because
-	// on Homebrew, os.Executable() resolves to the versioned Cellar path
-	// (e.g. /opt/homebrew/Cellar/gentle-ai/1.8.5/bin/gentle-ai) which
-	// still points to the OLD binary after upgrade. The PATH symlink
-	// (/opt/homebrew/bin/gentle-ai) is updated by Homebrew to the new
-	// version, so LookPath gives us the correct binary.
-	executable, err := lookPathFn("gentle-ai")
-	if err != nil {
-		// Fallback to os.Executable() if LookPath fails.
-		executable, err = os.Executable()
-		if err != nil {
-			return nil // non-fatal
-		}
-	}
-
-	// Set loop guard env var before re-exec.
-	os.Setenv(envSelfUpdateDone, "1")
-
-	_, _ = fmt.Fprintf(stdout, "Updated to v%s, restarting...\n", latestVersion)
-
-	return reExec(executable, os.Args, os.Environ())
+	// Converged behavior (task 4.6): always print the restart message on every OS
+	// and return. The new binary runs automatically on next launch, picking up
+	// PendingSync=true and completing the deferred sync. This sidesteps the
+	// Windows binary-lock issue and gives a consistent single path across all OSes.
+	// Tradeoff: Unix loses seamless re-exec restart; mitigated by clear copy below.
+	_, _ = fmt.Fprintf(stdout, "Updated to v%s — restart gentle-ai to continue.\n", latestVersion)
+	return nil
 }

--- a/internal/app/selfupdate_test.go
+++ b/internal/app/selfupdate_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gentleman-programming/gentle-ai/internal/state"
 	"github.com/gentleman-programming/gentle-ai/internal/system"
 	"github.com/gentleman-programming/gentle-ai/internal/update"
 	"github.com/gentleman-programming/gentle-ai/internal/update/upgrade"
@@ -172,7 +173,7 @@ func TestSelfUpdate_GuardEvaluationOrder(t *testing.T) {
 	}
 }
 
-func TestSelfUpdate_UpdateAvailable_CallsUpgradeAndReExec(t *testing.T) {
+func TestSelfUpdate_UpdateAvailable_CallsUpgradeAndRestart(t *testing.T) {
 	unsetEnv(t, envNoSelfUpdate)
 	unsetEnv(t, envSelfUpdateDone)
 
@@ -203,20 +204,16 @@ func TestSelfUpdate_UpdateAvailable_CallsUpgradeAndReExec(t *testing.T) {
 	if stubs.upgradeCalled != 1 {
 		t.Errorf("upgradeCalled = %d, want 1", stubs.upgradeCalled)
 	}
-	if stubs.reExecCalled != 1 {
-		t.Errorf("reExecCalled = %d, want 1", stubs.reExecCalled)
+	// After task 4.6: restartAfterGentleAIUpgrade no longer re-execs on any OS.
+	// It always prints the "restart" message and returns. re-exec is gone.
+	if stubs.reExecCalled != 0 {
+		t.Errorf("reExecCalled = %d, want 0 (restart message printed instead)", stubs.reExecCalled)
 	}
 
-	// Verify GENTLE_AI_SELF_UPDATE_DONE=1 is in the re-exec env.
-	found := false
-	for _, e := range stubs.reExecEnv {
-		if e == envSelfUpdateDone+"=1" {
-			found = true
-			break
-		}
-	}
-	if !found {
-		t.Errorf("re-exec env missing %s=1", envSelfUpdateDone)
+	// Output must contain the restart guidance message.
+	out := buf.String()
+	if !containsSubstring(out, "restart") {
+		t.Errorf("output = %q, want it to contain restart guidance", out)
 	}
 }
 
@@ -303,7 +300,10 @@ func TestSelfUpdate_UpgradeError_ReturnsNil(t *testing.T) {
 	}
 }
 
-func TestSelfUpdate_Windows_PrintsRestartMessage(t *testing.T) {
+// TestSelfUpdate_PrintsRestartMessage verifies that after a successful upgrade
+// on any OS, restartAfterGentleAIUpgrade prints a restart-guidance message and
+// does NOT re-exec (converged behavior — task 4.6).
+func TestSelfUpdate_PrintsRestartMessage(t *testing.T) {
 	unsetEnv(t, envNoSelfUpdate)
 	unsetEnv(t, envSelfUpdateDone)
 
@@ -321,26 +321,28 @@ func TestSelfUpdate_Windows_PrintsRestartMessage(t *testing.T) {
 		},
 	}
 
-	stubs := swapSelfUpdateDeps(t, checkResults, upgradeReport)
+	for _, os := range []string{"darwin", "windows", "linux"} {
+		t.Run("os="+os, func(t *testing.T) {
+			stubs := swapSelfUpdateDeps(t, checkResults, upgradeReport)
+			goOS = func() string { return os }
 
-	// Simulate Windows: re-exec should NOT be called, restart message printed instead.
-	goOS = func() string { return "windows" }
+			var buf bytes.Buffer
+			err := selfUpdate(context.Background(), "1.7.0", stubProfile(), &buf)
+			if err != nil {
+				t.Fatalf("selfUpdate returned error: %v", err)
+			}
+			if stubs.reExecCalled != 0 {
+				t.Errorf("reExecCalled = %d, want 0 on %s (restart message path)", stubs.reExecCalled, os)
+			}
+			if stubs.upgradeCalled != 1 {
+				t.Errorf("upgradeCalled = %d, want 1", stubs.upgradeCalled)
+			}
 
-	var buf bytes.Buffer
-	err := selfUpdate(context.Background(), "1.7.0", stubProfile(), &buf)
-	if err != nil {
-		t.Fatalf("selfUpdate returned error: %v", err)
-	}
-	if stubs.reExecCalled != 0 {
-		t.Errorf("reExecCalled = %d, want 0 on Windows", stubs.reExecCalled)
-	}
-	if stubs.upgradeCalled != 1 {
-		t.Errorf("upgradeCalled = %d, want 1", stubs.upgradeCalled)
-	}
-
-	out := buf.String()
-	if want := "please restart"; !containsSubstring(out, want) {
-		t.Errorf("output = %q, want it to contain %q", out, want)
+			out := buf.String()
+			if !containsSubstring(out, "restart") {
+				t.Errorf("output = %q, want it to contain restart guidance", out)
+			}
+		})
 	}
 }
 
@@ -459,8 +461,9 @@ func TestSelfUpdate_ConfirmUpdate_UserAccepts(t *testing.T) {
 	if stubs.upgradeCalled != 1 {
 		t.Errorf("upgradeCalled = %d, want 1 (user accepted)", stubs.upgradeCalled)
 	}
-	if stubs.reExecCalled != 1 {
-		t.Errorf("reExecCalled = %d, want 1 (user accepted)", stubs.reExecCalled)
+	// After task 4.6: no re-exec; restart message is printed instead.
+	if stubs.reExecCalled != 0 {
+		t.Errorf("reExecCalled = %d, want 0 (restart message path)", stubs.reExecCalled)
 	}
 }
 
@@ -548,8 +551,9 @@ func TestSelfUpdate_ConfirmUpdate_EnvUnset(t *testing.T) {
 	if stubs.upgradeCalled != 1 {
 		t.Errorf("upgradeCalled = %d, want 1 (auto-apply)", stubs.upgradeCalled)
 	}
-	if stubs.reExecCalled != 1 {
-		t.Errorf("reExecCalled = %d, want 1 (auto-apply)", stubs.reExecCalled)
+	// After task 4.6: restart message printed instead of re-exec.
+	if stubs.reExecCalled != 0 {
+		t.Errorf("reExecCalled = %d, want 0 (restart message path)", stubs.reExecCalled)
 	}
 }
 
@@ -575,7 +579,7 @@ func TestSelfUpdate_ConfirmUpdateTable(t *testing.T) {
 		confirmEnv      string // "" means unset
 		promptReply     bool
 		wantUpgrade     int
-		wantReExec      int
+		wantReExec      int // always 0 after task 4.6 (restart message path)
 		wantPromptCalls int
 	}{
 		{
@@ -583,7 +587,7 @@ func TestSelfUpdate_ConfirmUpdateTable(t *testing.T) {
 			confirmEnv:      "",
 			promptReply:     false,
 			wantUpgrade:     1,
-			wantReExec:      1,
+			wantReExec:      0, // task 4.6: restart message instead of re-exec
 			wantPromptCalls: 0,
 		},
 		{
@@ -591,7 +595,7 @@ func TestSelfUpdate_ConfirmUpdateTable(t *testing.T) {
 			confirmEnv:      "1",
 			promptReply:     true,
 			wantUpgrade:     1,
-			wantReExec:      1,
+			wantReExec:      0, // task 4.6: restart message instead of re-exec
 			wantPromptCalls: 1,
 		},
 		{
@@ -639,6 +643,91 @@ func TestSelfUpdate_ConfirmUpdateTable(t *testing.T) {
 				t.Errorf("reExecCalled = %d, want %d", stubs.reExecCalled, tc.wantReExec)
 			}
 		})
+	}
+}
+
+// ─── Slice 4 RED: PendingSync written on successful self-upgrade ─────────────
+
+// TestSelfUpdate_SetsPendingSyncOnSuccess verifies that after a successful
+// gentle-ai self-upgrade, PendingSync=true is written to state before the
+// process exits (re-exec or print message). This is the deferred-sync flag
+// that the next launch reads to run sync automatically.
+func TestSelfUpdate_SetsPendingSyncOnSuccess(t *testing.T) {
+	unsetEnv(t, envNoSelfUpdate)
+	unsetEnv(t, envSelfUpdateDone)
+
+	checkResults := []update.UpdateResult{
+		{
+			Tool:             update.ToolInfo{Name: "gentle-ai"},
+			InstalledVersion: "1.7.0",
+			LatestVersion:    "1.8.0",
+			Status:           update.UpdateAvailable,
+		},
+	}
+	upgradeReport := upgrade.UpgradeReport{
+		Results: []upgrade.ToolUpgradeResult{
+			{ToolName: "gentle-ai", Status: upgrade.UpgradeSucceeded, NewVersion: "1.8.0"},
+		},
+	}
+
+	stubs := swapSelfUpdateDeps(t, checkResults, upgradeReport)
+
+	// swapSelfUpdateDeps sets selfUpdateHomeDirFn to a temp dir; capture that dir.
+	tmpHome := t.TempDir()
+	selfUpdateHomeDirFn = func() (string, error) { return tmpHome, nil }
+	// Prevent actual re-exec from racing with state write; stubs.reExecCalled tracks it.
+	_ = stubs
+
+	err := selfUpdate(context.Background(), "1.7.0", stubProfile(), io.Discard)
+	if err != nil {
+		t.Fatalf("selfUpdate returned error: %v", err)
+	}
+
+	s, err := state.Read(tmpHome)
+	if err != nil {
+		// state.json may not exist when PendingSync is not implemented yet.
+		t.Fatalf("state.Read() failed — PendingSync was not written: %v", err)
+	}
+	if !s.PendingSync {
+		t.Errorf("PendingSync = false after successful self-upgrade, want true")
+	}
+}
+
+// TestSelfUpdate_DoesNotSetPendingSyncOnFailure verifies that when the
+// gentle-ai upgrade fails, PendingSync is NOT set in state (no retry needed
+// since sync was never deferred).
+func TestSelfUpdate_DoesNotSetPendingSyncOnFailure(t *testing.T) {
+	unsetEnv(t, envNoSelfUpdate)
+	unsetEnv(t, envSelfUpdateDone)
+
+	checkResults := []update.UpdateResult{
+		{
+			Tool:             update.ToolInfo{Name: "gentle-ai"},
+			InstalledVersion: "1.7.0",
+			LatestVersion:    "1.8.0",
+			Status:           update.UpdateAvailable,
+		},
+	}
+	upgradeReport := upgrade.UpgradeReport{
+		Results: []upgrade.ToolUpgradeResult{
+			{ToolName: "gentle-ai", Status: upgrade.UpgradeFailed, Err: os.ErrPermission},
+		},
+	}
+
+	swapSelfUpdateDeps(t, checkResults, upgradeReport)
+
+	tmpHome := t.TempDir()
+	selfUpdateHomeDirFn = func() (string, error) { return tmpHome, nil }
+
+	err := selfUpdate(context.Background(), "1.7.0", stubProfile(), io.Discard)
+	if err != nil {
+		t.Fatalf("selfUpdate returned error: %v", err)
+	}
+
+	// State may not exist at all (upgrade failed, nothing written) — that's fine.
+	s, readErr := state.Read(tmpHome)
+	if readErr == nil && s.PendingSync {
+		t.Errorf("PendingSync = true after failed upgrade, want false")
 	}
 }
 

--- a/internal/app/selfupdate_test.go
+++ b/internal/app/selfupdate_test.go
@@ -50,12 +50,11 @@ func unsetEnv(t *testing.T, key string) {
 
 // swapSelfUpdateDeps replaces all package-level dependency vars used by selfUpdate
 // and registers cleanup to restore them. Returns pointers to track call counts.
+// Note: reExec and goOS were removed in task 4.6 — restartAfterGentleAIUpgrade
+// now always prints the restart message and returns; no re-exec on any OS.
 type selfUpdateStubs struct {
 	checkCalled   int
 	upgradeCalled int
-	reExecCalled  int
-	reExecArgv0   string
-	reExecEnv     []string
 }
 
 func swapSelfUpdateDeps(t *testing.T, checkResult []update.UpdateResult, upgradeReport upgrade.UpgradeReport) *selfUpdateStubs {
@@ -65,8 +64,6 @@ func swapSelfUpdateDeps(t *testing.T, checkResult []update.UpdateResult, upgrade
 
 	origCheck := updateCheckFiltered
 	origUpgrade := upgradeExecute
-	origReExec := reExec
-	origGoOS := goOS
 	origHomeDir := selfUpdateHomeDirFn
 	origNow := selfUpdateNowFn
 
@@ -77,8 +74,6 @@ func swapSelfUpdateDeps(t *testing.T, checkResult []update.UpdateResult, upgrade
 	t.Cleanup(func() {
 		updateCheckFiltered = origCheck
 		upgradeExecute = origUpgrade
-		reExec = origReExec
-		goOS = origGoOS
 		selfUpdateHomeDirFn = origHomeDir
 		selfUpdateNowFn = origNow
 	})
@@ -95,17 +90,6 @@ func swapSelfUpdateDeps(t *testing.T, checkResult []update.UpdateResult, upgrade
 	upgradeExecute = func(_ context.Context, _ []update.UpdateResult, _ system.PlatformProfile, _ string, _ bool, _ ...io.Writer) upgrade.UpgradeReport {
 		stubs.upgradeCalled++
 		return upgradeReport
-	}
-
-	reExec = func(argv0 string, argv []string, envv []string) error {
-		stubs.reExecCalled++
-		stubs.reExecArgv0 = argv0
-		stubs.reExecEnv = envv
-		return nil
-	}
-
-	goOS = func() string {
-		return "darwin"
 	}
 
 	return stubs
@@ -204,13 +188,8 @@ func TestSelfUpdate_UpdateAvailable_CallsUpgradeAndRestart(t *testing.T) {
 	if stubs.upgradeCalled != 1 {
 		t.Errorf("upgradeCalled = %d, want 1", stubs.upgradeCalled)
 	}
-	// After task 4.6: restartAfterGentleAIUpgrade no longer re-execs on any OS.
-	// It always prints the "restart" message and returns. re-exec is gone.
-	if stubs.reExecCalled != 0 {
-		t.Errorf("reExecCalled = %d, want 0 (restart message printed instead)", stubs.reExecCalled)
-	}
 
-	// Output must contain the restart guidance message.
+	// Output must contain the restart guidance message (print-and-return path, no re-exec).
 	out := buf.String()
 	if !containsSubstring(out, "restart") {
 		t.Errorf("output = %q, want it to contain restart guidance", out)
@@ -289,14 +268,11 @@ func TestSelfUpdate_UpgradeError_ReturnsNil(t *testing.T) {
 		},
 	}
 
-	stubs := swapSelfUpdateDeps(t, checkResults, upgradeReport)
+	swapSelfUpdateDeps(t, checkResults, upgradeReport)
 
 	err := selfUpdate(context.Background(), "1.7.0", stubProfile(), io.Discard)
 	if err != nil {
 		t.Fatalf("selfUpdate should return nil on upgrade error, got: %v", err)
-	}
-	if stubs.reExecCalled != 0 {
-		t.Errorf("reExecCalled = %d, want 0 (upgrade failed)", stubs.reExecCalled)
 	}
 }
 
@@ -321,18 +297,16 @@ func TestSelfUpdate_PrintsRestartMessage(t *testing.T) {
 		},
 	}
 
-	for _, os := range []string{"darwin", "windows", "linux"} {
-		t.Run("os="+os, func(t *testing.T) {
+	// restartAfterGentleAIUpgrade is OS-agnostic after task 4.6 — prints and returns.
+	// No goOS swap needed; the behavior is identical on all platforms.
+	for _, osName := range []string{"darwin", "windows", "linux"} {
+		t.Run("os="+osName, func(t *testing.T) {
 			stubs := swapSelfUpdateDeps(t, checkResults, upgradeReport)
-			goOS = func() string { return os }
 
 			var buf bytes.Buffer
 			err := selfUpdate(context.Background(), "1.7.0", stubProfile(), &buf)
 			if err != nil {
 				t.Fatalf("selfUpdate returned error: %v", err)
-			}
-			if stubs.reExecCalled != 0 {
-				t.Errorf("reExecCalled = %d, want 0 on %s (restart message path)", stubs.reExecCalled, os)
 			}
 			if stubs.upgradeCalled != 1 {
 				t.Errorf("upgradeCalled = %d, want 1", stubs.upgradeCalled)
@@ -368,14 +342,12 @@ func TestSelfUpdate_BrewInstallMethod_PassedToUpgradeExecutor(t *testing.T) {
 
 	origCheck := updateCheckFiltered
 	origUpgrade := upgradeExecute
-	origReExec := reExec
 	origHomeDir := selfUpdateHomeDirFn
 	origNow := selfUpdateNowFn
 	tmpHome := t.TempDir()
 	t.Cleanup(func() {
 		updateCheckFiltered = origCheck
 		upgradeExecute = origUpgrade
-		reExec = origReExec
 		selfUpdateHomeDirFn = origHomeDir
 		selfUpdateNowFn = origNow
 	})
@@ -397,8 +369,6 @@ func TestSelfUpdate_BrewInstallMethod_PassedToUpgradeExecutor(t *testing.T) {
 			},
 		}
 	}
-
-	reExec = func(_ string, _ []string, _ []string) error { return nil }
 
 	brewProfile := system.PlatformProfile{OS: "darwin", PackageManager: "brew"}
 	err := selfUpdate(context.Background(), "1.7.0", brewProfile, io.Discard)
@@ -461,10 +431,6 @@ func TestSelfUpdate_ConfirmUpdate_UserAccepts(t *testing.T) {
 	if stubs.upgradeCalled != 1 {
 		t.Errorf("upgradeCalled = %d, want 1 (user accepted)", stubs.upgradeCalled)
 	}
-	// After task 4.6: no re-exec; restart message is printed instead.
-	if stubs.reExecCalled != 0 {
-		t.Errorf("reExecCalled = %d, want 0 (restart message path)", stubs.reExecCalled)
-	}
 }
 
 // TestSelfUpdate_ConfirmUpdate_UserDeclines verifies that when GENTLE_AI_CONFIRM_UPDATE=1
@@ -503,9 +469,6 @@ func TestSelfUpdate_ConfirmUpdate_UserDeclines(t *testing.T) {
 	}
 	if stubs.upgradeCalled != 0 {
 		t.Errorf("upgradeCalled = %d, want 0 (user declined)", stubs.upgradeCalled)
-	}
-	if stubs.reExecCalled != 0 {
-		t.Errorf("reExecCalled = %d, want 0 (user declined)", stubs.reExecCalled)
 	}
 }
 
@@ -551,10 +514,6 @@ func TestSelfUpdate_ConfirmUpdate_EnvUnset(t *testing.T) {
 	if stubs.upgradeCalled != 1 {
 		t.Errorf("upgradeCalled = %d, want 1 (auto-apply)", stubs.upgradeCalled)
 	}
-	// After task 4.6: restart message printed instead of re-exec.
-	if stubs.reExecCalled != 0 {
-		t.Errorf("reExecCalled = %d, want 0 (restart message path)", stubs.reExecCalled)
-	}
 }
 
 // TestSelfUpdate_ConfirmUpdateTable exercises the three confirmation paths in a
@@ -574,12 +533,12 @@ func TestSelfUpdate_ConfirmUpdateTable(t *testing.T) {
 		},
 	}
 
+	// wantReExec removed: restartAfterGentleAIUpgrade always prints and returns (task 4.6).
 	tests := []struct {
 		name            string
 		confirmEnv      string // "" means unset
 		promptReply     bool
 		wantUpgrade     int
-		wantReExec      int // always 0 after task 4.6 (restart message path)
 		wantPromptCalls int
 	}{
 		{
@@ -587,7 +546,6 @@ func TestSelfUpdate_ConfirmUpdateTable(t *testing.T) {
 			confirmEnv:      "",
 			promptReply:     false,
 			wantUpgrade:     1,
-			wantReExec:      0, // task 4.6: restart message instead of re-exec
 			wantPromptCalls: 0,
 		},
 		{
@@ -595,7 +553,6 @@ func TestSelfUpdate_ConfirmUpdateTable(t *testing.T) {
 			confirmEnv:      "1",
 			promptReply:     true,
 			wantUpgrade:     1,
-			wantReExec:      0, // task 4.6: restart message instead of re-exec
 			wantPromptCalls: 1,
 		},
 		{
@@ -603,7 +560,6 @@ func TestSelfUpdate_ConfirmUpdateTable(t *testing.T) {
 			confirmEnv:      "1",
 			promptReply:     false,
 			wantUpgrade:     0,
-			wantReExec:      0,
 			wantPromptCalls: 1,
 		},
 	}
@@ -639,9 +595,6 @@ func TestSelfUpdate_ConfirmUpdateTable(t *testing.T) {
 			if stubs.upgradeCalled != tc.wantUpgrade {
 				t.Errorf("upgradeCalled = %d, want %d", stubs.upgradeCalled, tc.wantUpgrade)
 			}
-			if stubs.reExecCalled != tc.wantReExec {
-				t.Errorf("reExecCalled = %d, want %d", stubs.reExecCalled, tc.wantReExec)
-			}
 		})
 	}
 }
@@ -670,13 +623,11 @@ func TestSelfUpdate_SetsPendingSyncOnSuccess(t *testing.T) {
 		},
 	}
 
-	stubs := swapSelfUpdateDeps(t, checkResults, upgradeReport)
-
-	// swapSelfUpdateDeps sets selfUpdateHomeDirFn to a temp dir; capture that dir.
+	// swapSelfUpdateDeps sets selfUpdateHomeDirFn to a temp dir; override with our own
+	// so we can read back the state after selfUpdate returns.
+	swapSelfUpdateDeps(t, checkResults, upgradeReport)
 	tmpHome := t.TempDir()
 	selfUpdateHomeDirFn = func() (string, error) { return tmpHome, nil }
-	// Prevent actual re-exec from racing with state write; stubs.reExecCalled tracks it.
-	_ = stubs
 
 	err := selfUpdate(context.Background(), "1.7.0", stubProfile(), io.Discard)
 	if err != nil {

--- a/internal/app/selfupdate_test.go
+++ b/internal/app/selfupdate_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -679,6 +680,57 @@ func TestSelfUpdate_DoesNotSetPendingSyncOnFailure(t *testing.T) {
 	s, readErr := state.Read(tmpHome)
 	if readErr == nil && s.PendingSync {
 		t.Errorf("PendingSync = true after failed upgrade, want false")
+	}
+}
+
+// TestSelfUpdate_NoClobberOnCorruptStateFile verifies that when state.Read fails
+// with a non-ErrNotExist error (e.g. corrupt JSON), PendingSync is NOT written
+// and the existing state file bytes are preserved unchanged.
+func TestSelfUpdate_NoClobberOnCorruptStateFile(t *testing.T) {
+	unsetEnv(t, envNoSelfUpdate)
+	unsetEnv(t, envSelfUpdateDone)
+
+	checkResults := []update.UpdateResult{
+		{
+			Tool:             update.ToolInfo{Name: "gentle-ai"},
+			InstalledVersion: "1.7.0",
+			LatestVersion:    "1.8.0",
+			Status:           update.UpdateAvailable,
+		},
+	}
+	upgradeReport := upgrade.UpgradeReport{
+		Results: []upgrade.ToolUpgradeResult{
+			{ToolName: "gentle-ai", Status: upgrade.UpgradeSucceeded, NewVersion: "1.8.0"},
+		},
+	}
+
+	swapSelfUpdateDeps(t, checkResults, upgradeReport)
+	tmpHome := t.TempDir()
+	selfUpdateHomeDirFn = func() (string, error) { return tmpHome, nil }
+
+	// Write a corrupt (non-missing) state file so state.Read returns a non-ErrNotExist error.
+	stateDir := filepath.Join(tmpHome, ".gentle-ai")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	corruptPayload := []byte("this is not valid JSON {{{")
+	stateFilePath := filepath.Join(stateDir, "state.json")
+	if err := os.WriteFile(stateFilePath, corruptPayload, 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	err := selfUpdate(context.Background(), "1.7.0", stubProfile(), io.Discard)
+	if err != nil {
+		t.Fatalf("selfUpdate returned error: %v", err)
+	}
+
+	// The state file must not have been overwritten — original bytes must be intact.
+	got, readErr := os.ReadFile(stateFilePath)
+	if readErr != nil {
+		t.Fatalf("os.ReadFile after selfUpdate: %v", readErr)
+	}
+	if string(got) != string(corruptPayload) {
+		t.Errorf("state file was overwritten on corrupt-read error\ngot:  %q\nwant: %q", got, corruptPayload)
 	}
 }
 

--- a/internal/app/update_test.go
+++ b/internal/app/update_test.go
@@ -96,20 +96,17 @@ func TestRunUpgrade_ReturnsErrorBeforeExecutingWhenChecksFail(t *testing.T) {
 	}
 }
 
+// TestRunUpgrade_RestartsAfterGentleAIUpgrade verifies that `gentle-ai upgrade`
+// prints the restart guidance message after a successful gentle-ai upgrade.
+// After task 4.6, no re-exec occurs on any OS — the message is always printed.
 func TestRunUpgrade_RestartsAfterGentleAIUpgrade(t *testing.T) {
 	unsetEnv(t, envSelfUpdateDone)
 
 	origCheckFiltered := updateCheckFiltered
 	origUpgradeExecuteWithOptions := upgradeExecuteWithOptions
-	origReExec := reExec
-	origLookPath := lookPathFn
-	origGoOS := goOS
 	t.Cleanup(func() {
 		updateCheckFiltered = origCheckFiltered
 		upgradeExecuteWithOptions = origUpgradeExecuteWithOptions
-		reExec = origReExec
-		lookPathFn = origLookPath
-		goOS = origGoOS
 	})
 
 	updateCheckFiltered = func(context.Context, string, system.PlatformProfile, []string) []update.UpdateResult {
@@ -128,65 +125,36 @@ func TestRunUpgrade_RestartsAfterGentleAIUpgrade(t *testing.T) {
 			Status:     upgrade.UpgradeSucceeded,
 		}}}
 	}
-	lookPathFn = func(string) (string, error) { return "/usr/local/bin/gentle-ai", nil }
-	goOS = func() string { return "darwin" }
-
-	var reExecCalled int
-	var reExecArgv0 string
-	var reExecEnv []string
-	reExec = func(argv0 string, _ []string, envv []string) error {
-		reExecCalled++
-		reExecArgv0 = argv0
-		reExecEnv = envv
-		return nil
-	}
 
 	var buf bytes.Buffer
 	err := runUpgrade(context.Background(), []string{"--no-backup"}, system.DetectionResult{System: system.SystemInfo{Profile: system.PlatformProfile{OS: "darwin", PackageManager: "brew", Supported: true}}}, &buf)
 	if err != nil {
 		t.Fatalf("runUpgrade() error = %v", err)
 	}
-	if reExecCalled != 1 {
-		t.Fatalf("reExecCalled = %d, want 1", reExecCalled)
-	}
-	if reExecArgv0 != "/usr/local/bin/gentle-ai" {
-		t.Fatalf("reExec argv0 = %q, want PATH gentle-ai", reExecArgv0)
-	}
-	if !envContains(reExecEnv, envSelfUpdateDone+"=1") {
-		t.Fatalf("reExec env missing %s=1", envSelfUpdateDone)
-	}
-	if !strings.Contains(buf.String(), "Updated to v1.36.2, restarting") {
+	// After task 4.6: restart message printed, no re-exec.
+	if !strings.Contains(buf.String(), "restart gentle-ai") {
 		t.Fatalf("runUpgrade() output missing restart notice:\n%s", buf.String())
 	}
 }
 
-func TestRestartAfterGentleAIUpgrade_WindowsPrintsRestart(t *testing.T) {
+// TestRestartAfterGentleAIUpgrade_PrintsRestartGuidance verifies that
+// restartAfterGentleAIUpgrade (converged in task 4.6) always prints
+// the restart guidance message and never re-execs, on any OS.
+func TestRestartAfterGentleAIUpgrade_PrintsRestartGuidance(t *testing.T) {
 	unsetEnv(t, envSelfUpdateDone)
-
-	origReExec := reExec
-	origGoOS := goOS
-	t.Cleanup(func() {
-		reExec = origReExec
-		goOS = origGoOS
-	})
-	goOS = func() string { return "windows" }
-
-	var reExecCalled int
-	reExec = func(string, []string, []string) error {
-		reExecCalled++
-		return nil
-	}
 
 	var buf bytes.Buffer
 	err := restartAfterGentleAIUpgrade("1.36.2", &buf)
 	if err != nil {
-		t.Fatalf("runUpgrade() error = %v", err)
+		t.Fatalf("restartAfterGentleAIUpgrade() error = %v", err)
 	}
-	if reExecCalled != 0 {
-		t.Fatalf("reExecCalled = %d, want 0 on Windows", reExecCalled)
+	out := buf.String()
+	// Must contain version and "restart" guidance.
+	if !strings.Contains(out, "1.36.2") {
+		t.Errorf("output = %q, want version 1.36.2 mentioned", out)
 	}
-	if !strings.Contains(strings.ToLower(buf.String()), "please restart") {
-		t.Fatalf("runUpgrade() output missing restart notice:\n%s", buf.String())
+	if !strings.Contains(strings.ToLower(out), "restart") {
+		t.Errorf("output = %q, want restart guidance", out)
 	}
 }
 

--- a/internal/app/update_test.go
+++ b/internal/app/update_test.go
@@ -167,14 +167,16 @@ func envContains(values []string, needle string) bool {
 	return false
 }
 
+// TestRunUpgrade_DryRunDoesNotRestartAfterGentleAIUpgrade verifies that a dry-run
+// upgrade does not trigger the restart-guidance message (no actual upgrade occurred).
+// reExec was removed in task 4.6; restartAfterGentleAIUpgrade now prints+returns.
+// Dry-run skips that path entirely, so no restart message should appear.
 func TestRunUpgrade_DryRunDoesNotRestartAfterGentleAIUpgrade(t *testing.T) {
 	origCheckFiltered := updateCheckFiltered
 	origUpgradeExecuteWithOptions := upgradeExecuteWithOptions
-	origReExec := reExec
 	t.Cleanup(func() {
 		updateCheckFiltered = origCheckFiltered
 		upgradeExecuteWithOptions = origUpgradeExecuteWithOptions
-		reExec = origReExec
 	})
 
 	updateCheckFiltered = func(context.Context, string, system.PlatformProfile, []string) []update.UpdateResult {
@@ -182,11 +184,6 @@ func TestRunUpgrade_DryRunDoesNotRestartAfterGentleAIUpgrade(t *testing.T) {
 	}
 	upgradeExecuteWithOptions = func(context.Context, []update.UpdateResult, system.PlatformProfile, string, bool, upgrade.ExecuteOptions) upgrade.UpgradeReport {
 		return upgrade.UpgradeReport{DryRun: true, Results: []upgrade.ToolUpgradeResult{{ToolName: "gentle-ai", NewVersion: "1.36.2", Status: upgrade.UpgradeSucceeded}}}
-	}
-
-	reExec = func(string, []string, []string) error {
-		t.Fatal("dry-run must not re-exec")
-		return nil
 	}
 
 	var buf bytes.Buffer
@@ -199,20 +196,18 @@ func TestRunUpgrade_DryRunDoesNotRestartAfterGentleAIUpgrade(t *testing.T) {
 	}
 }
 
+// TestTUIUpgrade_DoesNotRestartBeforeModelCanRenderReport verifies that the
+// TUI upgrade path returns the UpgradeReport without triggering any side-effects
+// (e.g. exit or restart) before the UI has a chance to render the result.
+// reExec was removed in task 4.6; tuiUpgrade must still return the report intact.
 func TestTUIUpgrade_DoesNotRestartBeforeModelCanRenderReport(t *testing.T) {
 	origUpgradeExecute := upgradeExecute
-	origReExec := reExec
 	t.Cleanup(func() {
 		upgradeExecute = origUpgradeExecute
-		reExec = origReExec
 	})
 
 	upgradeExecute = func(context.Context, []update.UpdateResult, system.PlatformProfile, string, bool, ...io.Writer) upgrade.UpgradeReport {
 		return upgrade.UpgradeReport{Results: []upgrade.ToolUpgradeResult{{ToolName: "gentle-ai", NewVersion: "1.36.2", Status: upgrade.UpgradeSucceeded}}}
-	}
-	reExec = func(string, []string, []string) error {
-		t.Fatal("TUI upgrade must not re-exec before rendering the upgrade report")
-		return nil
 	}
 
 	report := tuiUpgrade(system.PlatformProfile{OS: "darwin", PackageManager: "brew"}, os.TempDir())(context.Background(), nil)

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -82,6 +82,15 @@ type InstallState struct {
 	// check will always run on first launch (safe back-compat for existing
 	// state files that lack the field entirely).
 	LastUpdateCheck *time.Time `json:"last_update_check,omitempty"`
+
+	// PendingSync is set to true when a gentle-ai self-upgrade succeeded and
+	// the process is about to exit (restart required). The next launch reads
+	// this flag and runs sync automatically before entering the normal flow,
+	// then clears the flag on success. On sync failure the flag is left set
+	// so the following launch retries idempotently.
+	// False (zero value) = no deferred sync pending. Omitted from JSON when
+	// false for backward-compatibility with existing state files.
+	PendingSync bool `json:"pending_sync,omitempty"`
 }
 
 // Path returns the absolute path to the state file for the given home directory.
@@ -141,6 +150,7 @@ func MergeAgents(existing InstallState, newAgents []string) InstallState {
 		CodexPhaseModelAssignments:  existing.CodexPhaseModelAssignments,
 		Persona:                     existing.Persona,
 		LastUpdateCheck:             existing.LastUpdateCheck,
+		PendingSync:                 existing.PendingSync,
 	}
 }
 

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -753,6 +753,94 @@ func TestMergeAgents_PreservesLastUpdateCheck(t *testing.T) {
 	}
 }
 
+// ─── Slice 4 RED: PendingSync round-trip and backward-compat ────────────────
+
+// TestPendingSync_RoundTrip verifies that PendingSync bool survives a
+// Write/Read cycle with the expected JSON key "pending_sync".
+func TestPendingSync_RoundTrip(t *testing.T) {
+	home := t.TempDir()
+
+	s := InstallState{
+		InstalledAgents: []string{"claude-code"},
+		PendingSync:     true,
+	}
+
+	if err := Write(home, s); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+
+	got, err := Read(home)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+
+	if !got.PendingSync {
+		t.Errorf("PendingSync = false after round-trip, want true")
+	}
+
+	// JSON must contain the expected key.
+	data, err := os.ReadFile(Path(home))
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if !contains(string(data), "pending_sync") {
+		t.Errorf("JSON must contain key pending_sync; got:\n%s", data)
+	}
+}
+
+// TestPendingSync_OmitWhenFalse verifies that PendingSync=false (zero value)
+// is omitted from JSON (omitempty), preserving backward-compatibility with
+// existing state files that lack the field.
+func TestPendingSync_OmitWhenFalse(t *testing.T) {
+	home := t.TempDir()
+	s := InstallState{InstalledAgents: []string{"claude-code"}}
+	if err := Write(home, s); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	data, err := os.ReadFile(Path(home))
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if contains(string(data), "pending_sync") {
+		t.Error("JSON must not contain pending_sync when false")
+	}
+}
+
+// TestPendingSync_BackwardCompat verifies that state.json files written before
+// PendingSync was added still read cleanly with PendingSync=false (safe default:
+// no deferred sync pending).
+func TestPendingSync_BackwardCompat(t *testing.T) {
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, stateDir), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	legacy := `{"installed_agents":["claude-code"]}` + "\n"
+	if err := os.WriteFile(Path(home), []byte(legacy), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	s, err := Read(home)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if s.PendingSync {
+		t.Errorf("PendingSync = true for legacy state, want false (no deferred sync)")
+	}
+}
+
+// TestMergeAgents_PreservesPendingSync verifies MergeAgents carries
+// PendingSync from the existing state into the merged result.
+func TestMergeAgents_PreservesPendingSync(t *testing.T) {
+	existing := InstallState{
+		InstalledAgents: []string{"claude-code"},
+		PendingSync:     true,
+	}
+	merged := MergeAgents(existing, []string{"opencode"})
+	if !merged.PendingSync {
+		t.Errorf("MergeAgents did not preserve PendingSync: got false, want true")
+	}
+}
+
 func contains(s, substr string) bool {
 	return len(s) >= len(substr) && findSub(s, substr)
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -2561,10 +2562,20 @@ func (m Model) startUpgradeSync() tea.Cmd {
 			// Deferred sync (task 4.8): gentle-ai was upgraded in this session.
 			// Set PendingSync=true so the new binary runs sync on next launch
 			// instead of silently skipping it. Non-fatal if state write fails.
+			//
+			// No-clobber guard: only fall back to a fresh InstallState{} when
+			// the file is genuinely missing (ErrNotExist). Any other read error
+			// (e.g. corrupt JSON, permission denied) means an existing file is
+			// present — skip writing to avoid dropping installed_agents, model
+			// assignments, and other persisted fields.
 			if h := homeDir(); h != "" {
-				s, _ := state.Read(h)
-				s.PendingSync = true
-				_ = state.Write(h, s)
+				s, readErr := state.Read(h)
+				if readErr != nil && !errors.Is(readErr, os.ErrNotExist) {
+					// File exists but unreadable/corrupt — skip to avoid clobber.
+				} else {
+					s.PendingSync = true
+					_ = state.Write(h, s)
+				}
 			}
 			return SyncDoneMsg{}
 		}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -2558,6 +2558,14 @@ func (m Model) startUpgradeSync() tea.Cmd {
 
 	syncCmd := func() tea.Msg {
 		if gentleAIUpdated {
+			// Deferred sync (task 4.8): gentle-ai was upgraded in this session.
+			// Set PendingSync=true so the new binary runs sync on next launch
+			// instead of silently skipping it. Non-fatal if state write fails.
+			if h := homeDir(); h != "" {
+				s, _ := state.Read(h)
+				s.PendingSync = true
+				_ = state.Write(h, s)
+			}
 			return SyncDoneMsg{}
 		}
 		if syncFn == nil {

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -4653,9 +4654,16 @@ func TestStartUpgradeSync_DoesNotSetPendingSyncWhenGentleAINotUpgraded(t *testin
 	}
 
 	// PendingSync must NOT be set when gentle-ai was not upgraded.
-	// state.json may not exist at all if nothing wrote it; treat that as PendingSync=false.
+	// state.json may not exist at all if nothing wrote it; that is expected and
+	// means PendingSync was never set (correct). Any other read error is
+	// unexpected and should fail the test loudly.
 	s, readErr := state.Read(home)
-	if readErr == nil && s.PendingSync {
+	if readErr != nil {
+		if !errors.Is(readErr, os.ErrNotExist) {
+			t.Fatalf("unexpected state.Read error: %v", readErr)
+		}
+		// File absent → PendingSync was never set — correct.
+	} else if s.PendingSync {
 		t.Errorf("PendingSync = true after non-gentle-ai upgrade, want false")
 	}
 
@@ -4671,5 +4679,50 @@ func TestStartUpgradeSync_DoesNotSetPendingSyncWhenGentleAINotUpgraded(t *testin
 	}
 	if !gotSyncDone {
 		t.Errorf("sequence did not produce SyncDoneMsg; msgs = %v", msgs)
+	}
+}
+
+// TestStartUpgradeSync_NoClobberOnCorruptStateFile verifies that when the HOME
+// directory has a corrupt (non-missing) state.json, the TUI syncCmd branch does
+// NOT overwrite it when setting PendingSync=true — matching the no-clobber
+// pattern in internal/update/cooldown.go.
+func TestStartUpgradeSync_NoClobberOnCorruptStateFile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	// Write a corrupt state file so state.Read returns a non-ErrNotExist error.
+	stateDir := filepath.Join(home, ".gentle-ai")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	corruptPayload := []byte("this is not valid JSON {{{")
+	stateFilePath := filepath.Join(stateDir, "state.json")
+	if err := os.WriteFile(stateFilePath, corruptPayload, 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Screen = ScreenUpgradeSync
+	m.OperationRunning = true
+
+	// UpgradeFn reports gentle-ai as successfully upgraded.
+	m.UpgradeFn = func(_ context.Context, _ []update.UpdateResult) upgrade.UpgradeReport {
+		return upgrade.UpgradeReport{
+			Results: []upgrade.ToolUpgradeResult{
+				{ToolName: "gentle-ai", Status: upgrade.UpgradeSucceeded, NewVersion: "1.8.0"},
+			},
+		}
+	}
+
+	executeUpgradeSyncSequence(t, m)
+
+	// The corrupt state file must NOT have been overwritten.
+	got, readErr := os.ReadFile(stateFilePath)
+	if readErr != nil {
+		t.Fatalf("os.ReadFile after startUpgradeSync: %v", readErr)
+	}
+	if string(got) != string(corruptPayload) {
+		t.Errorf("state file was overwritten on corrupt-read error\ngot:  %q\nwant: %q", got, corruptPayload)
 	}
 }

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -4514,5 +4515,161 @@ func TestUpgradeSyncResultEscQuitsWhenGentleAIWasUpgraded(t *testing.T) {
 	}
 	if _, ok := cmd().(tea.QuitMsg); !ok {
 		t.Fatalf("handleKeyPress(esc) command returned %T, want tea.QuitMsg", cmd())
+	}
+}
+
+// ─── TUI-path PendingSync (task 4.8) ────────────────────────────────────────
+
+// executeUpgradeSyncSequence runs the tea.Sequence returned by startUpgradeSync
+// and collects the messages produced by each command in order.
+// tea.Sequence returns a Cmd whose result is an internal sequenceMsg (type []Cmd).
+// Since sequenceMsg is unexported we iterate via reflect.
+func executeUpgradeSyncSequence(t *testing.T, m Model) []tea.Msg {
+	t.Helper()
+
+	seqCmd := m.startUpgradeSync()
+	if seqCmd == nil {
+		t.Fatal("startUpgradeSync() returned nil cmd")
+	}
+
+	// Calling the outer cmd returns either:
+	//   a) the only element directly (when compactCmds collapses a single-cmd slice), or
+	//   b) a sequenceMsg (type []tea.Cmd) when there are 2+ cmds.
+	outerMsg := seqCmd()
+
+	// Try direct cast to known concrete types first.
+	if _, ok := outerMsg.(UpgradePhaseCompletedMsg); ok {
+		// Only one cmd was returned; no sequence wrapper.
+		return []tea.Msg{outerMsg}
+	}
+	if _, ok := outerMsg.(SyncDoneMsg); ok {
+		return []tea.Msg{outerMsg}
+	}
+
+	// sequenceMsg is type []tea.Cmd — use reflect to iterate without importing
+	// the unexported type.
+	v := reflect.ValueOf(outerMsg)
+	if v.Kind() != reflect.Slice {
+		t.Fatalf("startUpgradeSync outer msg kind = %v, want slice (sequenceMsg)", v.Kind())
+	}
+
+	var msgs []tea.Msg
+	for i := range v.Len() {
+		elem := v.Index(i).Interface()
+		innerCmd, ok := elem.(tea.Cmd)
+		if !ok || innerCmd == nil {
+			continue
+		}
+		msgs = append(msgs, innerCmd())
+	}
+	return msgs
+}
+
+// TestStartUpgradeSync_SetsPendingSyncWhenGentleAIUpgraded verifies that when
+// the UpgradeFn reports gentle-ai as upgraded, the syncCmd branch of
+// startUpgradeSync writes PendingSync=true to state.json before returning
+// SyncDoneMsg. This is the TUI-path equivalent of the selfupdate.go path tested
+// in TestSelfUpdate_SetsPendingSyncOnSuccess.
+func TestStartUpgradeSync_SetsPendingSyncWhenGentleAIUpgraded(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Screen = ScreenUpgradeSync
+	m.OperationRunning = true
+
+	// UpgradeFn reports gentle-ai as successfully upgraded.
+	m.UpgradeFn = func(_ context.Context, _ []update.UpdateResult) upgrade.UpgradeReport {
+		return upgrade.UpgradeReport{
+			Results: []upgrade.ToolUpgradeResult{
+				{ToolName: "gentle-ai", Status: upgrade.UpgradeSucceeded, NewVersion: "1.8.0"},
+			},
+		}
+	}
+
+	msgs := executeUpgradeSyncSequence(t, m)
+
+	// Verify the sequence produced both expected messages.
+	var gotUpgradePhase bool
+	var gotSyncDone bool
+	for _, msg := range msgs {
+		if _, ok := msg.(UpgradePhaseCompletedMsg); ok {
+			gotUpgradePhase = true
+		}
+		if _, ok := msg.(SyncDoneMsg); ok {
+			gotSyncDone = true
+		}
+	}
+	if !gotUpgradePhase {
+		t.Errorf("sequence did not produce UpgradePhaseCompletedMsg; msgs = %v", msgs)
+	}
+	if !gotSyncDone {
+		t.Errorf("sequence did not produce SyncDoneMsg; msgs = %v", msgs)
+	}
+
+	// The key assertion: PendingSync=true must be written to state.json on disk.
+	s, err := state.Read(home)
+	if err != nil {
+		t.Fatalf("state.Read(%q) error = %v (PendingSync was not written)", home, err)
+	}
+	if !s.PendingSync {
+		t.Errorf("PendingSync = false after gentle-ai self-upgrade in TUI flow, want true")
+	}
+}
+
+// TestStartUpgradeSync_DoesNotSetPendingSyncWhenGentleAINotUpgraded verifies
+// that when gentle-ai was NOT upgraded (e.g. only engram was upgraded), the
+// syncCmd branch does NOT set PendingSync, and sync proceeds normally via SyncFn.
+func TestStartUpgradeSync_DoesNotSetPendingSyncWhenGentleAINotUpgraded(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Screen = ScreenUpgradeSync
+	m.OperationRunning = true
+
+	// UpgradeFn reports only engram upgraded, not gentle-ai.
+	m.UpgradeFn = func(_ context.Context, _ []update.UpdateResult) upgrade.UpgradeReport {
+		return upgrade.UpgradeReport{
+			Results: []upgrade.ToolUpgradeResult{
+				{ToolName: "engram", Status: upgrade.UpgradeSucceeded, NewVersion: "1.16.4"},
+			},
+		}
+	}
+
+	var syncCalled bool
+	m.SyncFn = func(_ *model.SyncOverrides) ([]string, error) {
+		syncCalled = true
+		return []string{"file.json"}, nil
+	}
+
+	msgs := executeUpgradeSyncSequence(t, m)
+
+	// SyncFn must have been called (not the deferred-PendingSync path).
+	if !syncCalled {
+		t.Errorf("SyncFn was not called — expected normal sync when gentle-ai was not upgraded")
+	}
+
+	// PendingSync must NOT be set when gentle-ai was not upgraded.
+	// state.json may not exist at all if nothing wrote it; treat that as PendingSync=false.
+	s, readErr := state.Read(home)
+	if readErr == nil && s.PendingSync {
+		t.Errorf("PendingSync = true after non-gentle-ai upgrade, want false")
+	}
+
+	// Verify SyncDoneMsg arrived.
+	var gotSyncDone bool
+	for _, msg := range msgs {
+		if sd, ok := msg.(SyncDoneMsg); ok {
+			gotSyncDone = true
+			if sd.Err != nil {
+				t.Errorf("SyncDoneMsg.Err = %v, want nil", sd.Err)
+			}
+		}
+	}
+	if !gotSyncDone {
+		t.Errorf("sequence did not produce SyncDoneMsg; msgs = %v", msgs)
 	}
 }


### PR DESCRIPTION
Slice 4/7 — PendingSync flag so the new binary runs sync on next launch; apply-then-close convergence (no auto re-exec). Stacked on slice 2.

Part of the `update-experience` stacked chain. Refs #872.

- [x] Bug fix / feature slice
- [x] Strict TDD, fresh-context reviewed, `go test ./...` green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a persisted “pending sync” flow: after a successful self-upgrade, the next app launch automatically runs a deferred sync, retries on failure, and clears the flag on success.
  * After gentle-ai upgrade, the app now shows restart guidance (cross-platform) instead of performing an automatic restart.

* **Bug Fixes**
  * Improved state persistence safety: corrupt or unreadable state is no longer clobbered.

* **Tests**
  * Expanded coverage for pending-sync behavior, state read/write edge cases, and upgrade paths in both TUI and non-TUI flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->