### PR TITLE
feat(update): show informational remote advisory at launch

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -34,6 +34,10 @@ import (
 // Package-level var so tests can inject a deterministic clock.
 var tuiNowFn = time.Now
 
+// advisoryFetchFn is the function used to fetch the advisory manifest.
+// Package-level var so tests can override without network calls.
+var advisoryFetchFn = update.FetchAdvisory
+
 // osStatModelCache is a package-level variable so tests can override it to
 // simulate a missing or present OpenCode model cache file.
 var osStatModelCache = os.Stat
@@ -157,6 +161,12 @@ type BackupRestoreMsg struct {
 // UpdateCheckResultMsg is sent when the background update check completes.
 type UpdateCheckResultMsg struct {
 	Results []update.UpdateResult
+}
+
+// AdvisoryMsg is sent when the background advisory manifest fetch completes.
+// Advisory is the zero value (Advisory{}) when there is no message to display.
+type AdvisoryMsg struct {
+	Advisory update.Advisory
 }
 
 // UpgradeDoneMsg is sent when the upgrade operation completes.
@@ -385,6 +395,11 @@ type Model struct {
 	// UpdateCheckDone is true once the background update check has completed.
 	UpdateCheckDone bool
 
+	// AdvisoryMessage holds the informational text from the advisory manifest
+	// fetch, when a non-empty message was returned. Empty string means no
+	// advisory to display. Set asynchronously via AdvisoryMsg.
+	AdvisoryMessage string
+
 	// pipelineRunning tracks whether the pipeline goroutine is active.
 	pipelineRunning bool
 
@@ -609,7 +624,7 @@ func (m Model) Init() tea.Cmd {
 	profile := m.Detection.System.Profile
 	home := homeDir()
 
-	return func() tea.Msg {
+	updateCmd := func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
 		results := update.CheckAllWithCooldown(ctx, version, profile, home, update.UpdateCheckTTL,
@@ -618,6 +633,20 @@ func (m Model) Init() tea.Cmd {
 		)
 		return UpdateCheckResultMsg{Results: results}
 	}
+
+	// Fetch the advisory manifest concurrently with the update check.
+	// advisoryFetchFn is a package-level var so tests can override it.
+	// The fetch is fully non-blocking: it runs in its own goroutine and
+	// delivers an AdvisoryMsg when done. Zero latency is added to TUI launch.
+	advisoryCmd := func() tea.Msg {
+		a, ok := advisoryFetchFn(context.Background())
+		if !ok {
+			return AdvisoryMsg{}
+		}
+		return AdvisoryMsg{Advisory: a}
+	}
+
+	return tea.Batch(updateCmd, advisoryCmd)
 }
 
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -693,6 +722,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case UpdateCheckResultMsg:
 		m.UpdateResults = msg.Results
 		m.UpdateCheckDone = true
+		return m, nil
+	case AdvisoryMsg:
+		// Store the advisory message for display on the Welcome screen.
+		// Empty Advisory.Message (no advisory or fetch failed) is a no-op.
+		m.AdvisoryMessage = msg.Advisory.Message
 		return m, nil
 	case UpgradeDoneMsg:
 		m.OperationRunning = false
@@ -860,6 +894,15 @@ func (m Model) View() string {
 		var banner string
 		if m.UpdateCheckDone && update.HasUpdates(m.UpdateResults) {
 			banner = "Updates available: " + update.UpdateSummaryLine(m.UpdateResults)
+		}
+		// Append advisory message below the update banner when present.
+		// The advisory is purely informational and never replaces or blocks
+		// any other launch behavior.
+		if m.AdvisoryMessage != "" {
+			if banner != "" {
+				banner += "\n"
+			}
+			banner += "Advisory: " + m.AdvisoryMessage
 		}
 		return screens.RenderWelcome(m.Cursor, m.Version, banner, m.UpdateResults, m.UpdateCheckDone, m.hasDetectedOpenCode(), len(m.ProfileList), m.hasAgentBuilderEngines())
 	case ScreenUpgrade:

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 	"time"
@@ -37,6 +38,29 @@ var tuiNowFn = time.Now
 // advisoryFetchFn is the function used to fetch the advisory manifest.
 // Package-level var so tests can override without network calls.
 var advisoryFetchFn = update.FetchAdvisory
+
+// ansiEscapeRe matches ANSI/VT100 escape sequences (CSI sequences and bare ESC).
+// These must be stripped from remote-controlled content before it is rendered
+// in the TUI to prevent layout corruption or terminal injection attacks.
+var ansiEscapeRe = regexp.MustCompile(`\x1b(?:\[[0-9;]*[A-Za-z]|[^[]|)`)
+
+// sanitizeAdvisoryMessage removes ANSI escape sequences and ASCII control
+// characters from a remote-sourced advisory message, keeping only printable
+// characters (≥ 0x20, excluding DEL 0x7f) and the ASCII space (0x20).
+// The function is pure and allocation-minimal for typical short strings.
+func sanitizeAdvisoryMessage(s string) string {
+	// First pass: strip ANSI escape sequences.
+	s = ansiEscapeRe.ReplaceAllString(s, "")
+	// Second pass: remove remaining control characters (0x00–0x1f, 0x7f).
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		if r >= 0x20 && r != 0x7f {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
 
 // osStatModelCache is a package-level variable so tests can override it to
 // simulate a missing or present OpenCode model cache file.
@@ -726,7 +750,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case AdvisoryMsg:
 		// Store the advisory message for display on the Welcome screen.
 		// Empty Advisory.Message (no advisory or fetch failed) is a no-op.
-		m.AdvisoryMessage = msg.Advisory.Message
+		// Sanitize before storing: strip ANSI escape sequences and control
+		// characters so remote-controlled content cannot corrupt the TUI layout.
+		m.AdvisoryMessage = sanitizeAdvisoryMessage(msg.Advisory.Message)
 		return m, nil
 	case UpgradeDoneMsg:
 		m.OperationRunning = false

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -4833,3 +4833,133 @@ func TestWelcomeView_NewlineSeparatorBetweenUpdateAndAdvisory(t *testing.T) {
 		t.Fatalf("update banner and advisory appear on the same line (%d); expected separate lines\nView output:\n%s", updateLineIdx, view)
 	}
 }
+
+// ─── Advisory message sanitization tests ─────────────────────────────────────
+
+// TestSanitizeAdvisoryMessage_StripControlChars verifies that ASCII control
+// characters (including carriage return, bell, backspace, etc.) are removed
+// from the advisory message, keeping only printable characters and normal spaces.
+func TestSanitizeAdvisoryMessage_StripControlChars(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "carriage return stripped",
+			input: "hello\rworld",
+			want:  "helloworld",
+		},
+		{
+			name:  "bell stripped",
+			input: "ring\x07bell",
+			want:  "ringbell",
+		},
+		{
+			name:  "backspace stripped",
+			input: "a\x08b",
+			want:  "ab",
+		},
+		{
+			name:  "null byte stripped",
+			input: "null\x00byte",
+			want:  "nullbyte",
+		},
+		{
+			name:  "tab stripped",
+			input: "ta\tb",
+			want:  "tab",
+		},
+		{
+			name:  "newline stripped",
+			input: "line\nbreak",
+			want:  "linebreak",
+		},
+		{
+			name:  "clean message unchanged",
+			input: "security notice: update now",
+			want:  "security notice: update now",
+		},
+		{
+			name:  "empty string unchanged",
+			input: "",
+			want:  "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := sanitizeAdvisoryMessage(tc.input)
+			if got != tc.want {
+				t.Errorf("sanitizeAdvisoryMessage(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSanitizeAdvisoryMessage_StripANSIEscapes verifies that ANSI escape
+// sequences (e.g. color codes, cursor movement) are stripped from the message
+// so they cannot corrupt the TUI layout.
+func TestSanitizeAdvisoryMessage_StripANSIEscapes(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "color reset stripped",
+			input: "\x1b[0mhello",
+			want:  "hello",
+		},
+		{
+			name:  "bold red color stripped",
+			input: "\x1b[1;31mwarn\x1b[0m",
+			want:  "warn",
+		},
+		{
+			name:  "cursor movement stripped",
+			input: "a\x1b[2Jb",
+			want:  "ab",
+		},
+		{
+			name:  "mixed text and escapes",
+			input: "normal \x1b[32mgreen\x1b[0m text",
+			want:  "normal green text",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := sanitizeAdvisoryMessage(tc.input)
+			if got != tc.want {
+				t.Errorf("sanitizeAdvisoryMessage(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestAdvisoryMsg_SanitizesOnStore verifies that control characters in an
+// advisory message dispatched via AdvisoryMsg are sanitized before being stored
+// in m.AdvisoryMessage, so they can never reach the rendered View.
+func TestAdvisoryMsg_SanitizesOnStore(t *testing.T) {
+	m := NewModel(system.DetectionResult{}, "dev")
+
+	dirty := "notice\x1b[1;31m URGENT\x1b[0m\r\nupdate now"
+	updated, _ := m.Update(AdvisoryMsg{Advisory: update.Advisory{Message: dirty}})
+	state := updated.(Model)
+
+	// Must not contain any ESC character or control character.
+	for i, ch := range state.AdvisoryMessage {
+		if ch < 0x20 || ch == 0x7f {
+			t.Errorf("AdvisoryMessage[%d] = %U (%q) — control character not stripped; full value: %q",
+				i, ch, ch, state.AdvisoryMessage)
+		}
+	}
+	// Printable parts of the original message must be preserved.
+	if !strings.Contains(state.AdvisoryMessage, "notice") {
+		t.Errorf("AdvisoryMessage = %q — expected printable word %q to survive sanitization", state.AdvisoryMessage, "notice")
+	}
+	if !strings.Contains(state.AdvisoryMessage, "update now") {
+		t.Errorf("AdvisoryMessage = %q — expected printable phrase %q to survive sanitization", state.AdvisoryMessage, "update now")
+	}
+}

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -4726,3 +4726,110 @@ func TestStartUpgradeSync_NoClobberOnCorruptStateFile(t *testing.T) {
 		t.Errorf("state file was overwritten on corrupt-read error\ngot:  %q\nwant: %q", got, corruptPayload)
 	}
 }
+
+// ─── AdvisoryMsg TUI layer tests ─────────────────────────────────────────────
+
+// TestAdvisoryMsg_SetsAdvisoryMessage verifies that dispatching AdvisoryMsg
+// into model.Update stores the advisory text in m.AdvisoryMessage.
+func TestAdvisoryMsg_SetsAdvisoryMessage(t *testing.T) {
+	m := NewModel(system.DetectionResult{}, "dev")
+
+	updated, _ := m.Update(AdvisoryMsg{Advisory: update.Advisory{Message: "test advisory"}})
+	state := updated.(Model)
+
+	if state.AdvisoryMessage != "test advisory" {
+		t.Fatalf("AdvisoryMessage = %q, want %q", state.AdvisoryMessage, "test advisory")
+	}
+}
+
+// TestAdvisoryMsg_EmptyAdvisoryNoChange verifies that dispatching an AdvisoryMsg
+// with an empty message leaves AdvisoryMessage as the empty string.
+func TestAdvisoryMsg_EmptyAdvisoryNoChange(t *testing.T) {
+	m := NewModel(system.DetectionResult{}, "dev")
+
+	updated, _ := m.Update(AdvisoryMsg{})
+	state := updated.(Model)
+
+	if state.AdvisoryMessage != "" {
+		t.Fatalf("AdvisoryMessage = %q, want empty for zero-value AdvisoryMsg", state.AdvisoryMessage)
+	}
+}
+
+// TestWelcomeView_ContainsAdvisoryMessage verifies that View() on ScreenWelcome
+// renders the advisory message when AdvisoryMessage is set.
+func TestWelcomeView_ContainsAdvisoryMessage(t *testing.T) {
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Screen = ScreenWelcome
+	m.AdvisoryMessage = "security notice"
+
+	view := m.View()
+
+	if !strings.Contains(view, "security notice") {
+		t.Fatalf("View() does not contain advisory message %q\nView output:\n%s", "security notice", view)
+	}
+}
+
+// TestWelcomeView_AdvisoryPrefixed verifies that the advisory message is
+// rendered with the "Advisory: " prefix on the Welcome screen.
+func TestWelcomeView_AdvisoryPrefixed(t *testing.T) {
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Screen = ScreenWelcome
+	m.AdvisoryMessage = "critical update"
+
+	view := m.View()
+
+	if !strings.Contains(view, "Advisory: critical update") {
+		t.Fatalf("View() does not contain %q\nView output:\n%s", "Advisory: critical update", view)
+	}
+}
+
+// TestWelcomeView_NewlineSeparatorBetweenUpdateAndAdvisory verifies that when
+// both an update banner and an advisory message are present, they are rendered
+// on separate lines (the banner string uses "\n" as separator so RenderWelcome
+// outputs them as distinct visual lines).
+func TestWelcomeView_NewlineSeparatorBetweenUpdateAndAdvisory(t *testing.T) {
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Screen = ScreenWelcome
+	m.UpdateCheckDone = true
+	m.UpdateResults = []update.UpdateResult{
+		{
+			Tool:             update.ToolInfo{Name: "engram"},
+			InstalledVersion: "1.0.0",
+			LatestVersion:    "1.1.0",
+			Status:           update.UpdateAvailable,
+		},
+	}
+	m.AdvisoryMessage = "advisory here"
+
+	view := m.View()
+
+	// Both pieces must appear in the view.
+	if !strings.Contains(view, "Updates available") {
+		t.Fatalf("View() does not contain update banner\nView output:\n%s", view)
+	}
+	if !strings.Contains(view, "Advisory: advisory here") {
+		t.Fatalf("View() does not contain advisory message\nView output:\n%s", view)
+	}
+	// The box renderer wraps the banner string into per-line box rows, so the
+	// update line and the advisory line must appear on distinct lines. Verify
+	// that no single rendered line contains both substrings at once.
+	lines := strings.Split(view, "\n")
+	updateLineIdx, advisoryLineIdx := -1, -1
+	for i, line := range lines {
+		if strings.Contains(line, "Updates available") {
+			updateLineIdx = i
+		}
+		if strings.Contains(line, "Advisory: advisory here") {
+			advisoryLineIdx = i
+		}
+	}
+	if updateLineIdx < 0 {
+		t.Fatalf("no line contains 'Updates available'\nView output:\n%s", view)
+	}
+	if advisoryLineIdx < 0 {
+		t.Fatalf("no line contains 'Advisory: advisory here'\nView output:\n%s", view)
+	}
+	if updateLineIdx == advisoryLineIdx {
+		t.Fatalf("update banner and advisory appear on the same line (%d); expected separate lines\nView output:\n%s", updateLineIdx, view)
+	}
+}

--- a/internal/update/advisory.go
+++ b/internal/update/advisory.go
@@ -3,9 +3,16 @@ package update
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"time"
 )
+
+// advisoryMaxBytes is the maximum number of bytes read from an advisory
+// response body. A well-formed advisory.json is always tiny (< 1 KB); the
+// 64 KB cap prevents a malicious or misconfigured endpoint from exhausting
+// memory while still leaving an enormous margin for any realistic payload.
+const advisoryMaxBytes = 64 * 1024
 
 // advisoryURL is the endpoint for the advisory manifest JSON.
 // It points to a dedicated "advisory" git tag/release whose single asset
@@ -68,8 +75,9 @@ func FetchAdvisory(ctx context.Context) (Advisory, bool) {
 	}
 
 	var a Advisory
-	if err := json.NewDecoder(resp.Body).Decode(&a); err != nil {
-		// Malformed JSON — fail-open.
+	limited := io.LimitReader(resp.Body, advisoryMaxBytes)
+	if err := json.NewDecoder(limited).Decode(&a); err != nil {
+		// Malformed JSON or body exceeded the size cap — fail-open.
 		return Advisory{}, false
 	}
 

--- a/internal/update/advisory.go
+++ b/internal/update/advisory.go
@@ -1,0 +1,82 @@
+package update
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"time"
+)
+
+// advisoryURL is the endpoint for the advisory manifest JSON.
+// It points to a dedicated "advisory" git tag/release whose single asset
+// (advisory.json) is edited in-place without bumping the binary version.
+//
+// PREREQUISITE: the repo owner must create a GitHub release tagged "advisory"
+// and upload advisory.json as a release asset before any advisory message will
+// appear. Until then, every fetch returns 404 and is silently discarded
+// (fail-open). No launch latency is added regardless.
+//
+// Package-level var so tests can substitute an httptest server URL.
+var advisoryURL = "https://github.com/Gentleman-Programming/gentle-ai/releases/download/advisory/advisory.json"
+
+// advisoryHTTPClient is the HTTP client used exclusively for advisory fetches.
+// Timeout is 2s — intentionally shorter than the general GitHub client (5s)
+// so a stale advisory endpoint never adds perceptible launch latency.
+// This client is NOT shared with any other client in the package.
+var advisoryHTTPClient = &http.Client{Timeout: 2 * time.Second}
+
+// Advisory holds the decoded advisory manifest payload.
+// All fields are optional; unknown fields are ignored.
+type Advisory struct {
+	// Message is the human-readable advisory text shown at launch.
+	// An empty or absent message means "nothing to display."
+	Message string `json:"message"`
+
+	// Severity is an optional hint for how to style the message
+	// (e.g. "info", "warn"). Purely cosmetic; not enforced.
+	Severity string `json:"severity"`
+
+	// URL is an optional link shown alongside the message.
+	URL string `json:"url"`
+}
+
+// FetchAdvisory attempts to retrieve the advisory manifest from the dedicated
+// advisory release asset. It returns the decoded Advisory and true when a
+// non-empty message is present; otherwise it returns Advisory{} and false.
+//
+// The function is FAIL-OPEN: any network error, timeout, non-200 HTTP status,
+// malformed JSON, or missing/empty message field silently returns (Advisory{}, false).
+// It never blocks launch — callers must run it in a background goroutine when
+// zero-added-latency is required.
+func FetchAdvisory(ctx context.Context) (Advisory, bool) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, advisoryURL, nil)
+	if err != nil {
+		return Advisory{}, false
+	}
+	req.Header.Set("User-Agent", "gentle-ai-advisory-check")
+
+	resp, err := advisoryHTTPClient.Do(req)
+	if err != nil {
+		// Network error, timeout, or context cancellation — fail-open.
+		return Advisory{}, false
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		// Non-200 (e.g. 404 before advisory tag is created) — fail-open.
+		return Advisory{}, false
+	}
+
+	var a Advisory
+	if err := json.NewDecoder(resp.Body).Decode(&a); err != nil {
+		// Malformed JSON — fail-open.
+		return Advisory{}, false
+	}
+
+	if a.Message == "" {
+		// Empty or absent message field — nothing to display.
+		return Advisory{}, false
+	}
+
+	return a, true
+}

--- a/internal/update/advisory_test.go
+++ b/internal/update/advisory_test.go
@@ -1,0 +1,166 @@
+package update
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestFetchAdvisory_ValidJSON verifies that a well-formed advisory manifest
+// with a non-empty message is returned successfully.
+func TestFetchAdvisory_ValidJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"message":"hi","severity":"info","url":"https://example.com"}`))
+	}))
+	defer srv.Close()
+
+	// Override advisory URL for this test.
+	orig := advisoryURL
+	advisoryURL = srv.URL
+	t.Cleanup(func() { advisoryURL = orig })
+
+	a, ok := FetchAdvisory(context.Background())
+	if !ok {
+		t.Fatal("FetchAdvisory() returned ok=false, want true")
+	}
+	if a.Message != "hi" {
+		t.Errorf("FetchAdvisory().Message = %q, want %q", a.Message, "hi")
+	}
+	if a.Severity != "info" {
+		t.Errorf("FetchAdvisory().Severity = %q, want %q", a.Severity, "info")
+	}
+	if a.URL != "https://example.com" {
+		t.Errorf("FetchAdvisory().URL = %q, want %q", a.URL, "https://example.com")
+	}
+}
+
+// TestFetchAdvisory_Timeout verifies that a server that responds after 3s
+// (beyond the 2s advisory timeout) causes FetchAdvisory to fail-open and
+// return (Advisory{}, false) without blocking.
+func TestFetchAdvisory_Timeout(t *testing.T) {
+	var wg sync.WaitGroup
+	wg.Add(1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Signal that the handler was reached, then stall.
+		wg.Done()
+		// Sleep long enough to exceed the 2s advisory client timeout.
+		// The test has its own deadline so this will be cleaned up.
+		time.Sleep(10 * time.Second)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	orig := advisoryURL
+	advisoryURL = srv.URL
+	t.Cleanup(func() { advisoryURL = orig })
+
+	start := time.Now()
+	a, ok := FetchAdvisory(context.Background())
+	elapsed := time.Since(start)
+
+	// Must have received the "request reached server" signal or timed out.
+	if ok {
+		t.Error("FetchAdvisory() returned ok=true on timeout, want false (fail-open)")
+	}
+	if a.Message != "" {
+		t.Errorf("FetchAdvisory().Message = %q on timeout, want empty", a.Message)
+	}
+	// Must return in well under the server's sleep (10s); allow up to 4s for CI variance.
+	if elapsed > 4*time.Second {
+		t.Errorf("FetchAdvisory() took %v, expected to time out in ~2s", elapsed)
+	}
+}
+
+// TestFetchAdvisory_HTTP500 verifies that a 500 response is treated as
+// fail-open: (Advisory{}, false).
+func TestFetchAdvisory_HTTP500(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	orig := advisoryURL
+	advisoryURL = srv.URL
+	t.Cleanup(func() { advisoryURL = orig })
+
+	a, ok := FetchAdvisory(context.Background())
+	if ok {
+		t.Error("FetchAdvisory() returned ok=true on HTTP 500, want false")
+	}
+	if a.Message != "" {
+		t.Errorf("FetchAdvisory().Message = %q on HTTP 500, want empty", a.Message)
+	}
+}
+
+// TestFetchAdvisory_MalformedJSON verifies that invalid JSON is silently
+// discarded and (Advisory{}, false) is returned.
+func TestFetchAdvisory_MalformedJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`not valid json`))
+	}))
+	defer srv.Close()
+
+	orig := advisoryURL
+	advisoryURL = srv.URL
+	t.Cleanup(func() { advisoryURL = orig })
+
+	a, ok := FetchAdvisory(context.Background())
+	if ok {
+		t.Error("FetchAdvisory() returned ok=true on malformed JSON, want false")
+	}
+	if a.Message != "" {
+		t.Errorf("FetchAdvisory().Message = %q on malformed JSON, want empty", a.Message)
+	}
+}
+
+// TestFetchAdvisory_EmptyMessage verifies that a valid JSON payload with an
+// empty or absent message field returns (Advisory{}, false) — nothing to display.
+func TestFetchAdvisory_EmptyMessage(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"severity":"info","url":"https://example.com"}`))
+	}))
+	defer srv.Close()
+
+	orig := advisoryURL
+	advisoryURL = srv.URL
+	t.Cleanup(func() { advisoryURL = orig })
+
+	a, ok := FetchAdvisory(context.Background())
+	if ok {
+		t.Error("FetchAdvisory() returned ok=true for empty message, want false")
+	}
+	if a.Message != "" {
+		t.Errorf("FetchAdvisory().Message = %q for empty message, want empty", a.Message)
+	}
+}
+
+// TestFetchAdvisory_HTTP404 verifies that a 404 (advisory tag not yet created)
+// returns (Advisory{}, false) silently — expected production state before the
+// advisory release tag is created.
+func TestFetchAdvisory_HTTP404(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	orig := advisoryURL
+	advisoryURL = srv.URL
+	t.Cleanup(func() { advisoryURL = orig })
+
+	a, ok := FetchAdvisory(context.Background())
+	if ok {
+		t.Error("FetchAdvisory() returned ok=true on HTTP 404, want false")
+	}
+	if a.Message != "" {
+		t.Errorf("FetchAdvisory().Message = %q on HTTP 404, want empty", a.Message)
+	}
+}

--- a/internal/update/advisory_test.go
+++ b/internal/update/advisory_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
-	"sync"
 	"testing"
 	"time"
 )
@@ -39,19 +38,23 @@ func TestFetchAdvisory_ValidJSON(t *testing.T) {
 	}
 }
 
-// TestFetchAdvisory_Timeout verifies that a server that responds after 3s
-// (beyond the 2s advisory timeout) causes FetchAdvisory to fail-open and
-// return (Advisory{}, false) without blocking.
+// TestFetchAdvisory_Timeout verifies that a server that never responds causes
+// FetchAdvisory to fail-open after the 2s client timeout, without blocking
+// teardown for the duration of the stall.
 func TestFetchAdvisory_Timeout(t *testing.T) {
-	var wg sync.WaitGroup
-	wg.Add(1)
+	// unblock is closed in t.Cleanup so the handler exits immediately when the
+	// test ends, allowing srv.Close() to return without waiting for the stall.
+	unblock := make(chan struct{})
+	t.Cleanup(func() { close(unblock) })
+
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Signal that the handler was reached, then stall.
-		wg.Done()
-		// Sleep long enough to exceed the 2s advisory client timeout.
-		// The test has its own deadline so this will be cleaned up.
-		time.Sleep(10 * time.Second)
-		w.WriteHeader(http.StatusOK)
+		// Stall until either the client disconnects (2s timeout) or the test
+		// cleanup fires — whichever comes first.
+		select {
+		case <-r.Context().Done():
+		case <-unblock:
+		}
+		// Handler exits immediately; no response is sent.
 	}))
 	defer srv.Close()
 
@@ -63,14 +66,14 @@ func TestFetchAdvisory_Timeout(t *testing.T) {
 	a, ok := FetchAdvisory(context.Background())
 	elapsed := time.Since(start)
 
-	// Must have received the "request reached server" signal or timed out.
 	if ok {
 		t.Error("FetchAdvisory() returned ok=true on timeout, want false (fail-open)")
 	}
 	if a.Message != "" {
 		t.Errorf("FetchAdvisory().Message = %q on timeout, want empty", a.Message)
 	}
-	// Must return in well under the server's sleep (10s); allow up to 4s for CI variance.
+	// Must return near the 2s client timeout, not after the server's stall duration.
+	// Allow up to 4s for CI variance.
 	if elapsed > 4*time.Second {
 		t.Errorf("FetchAdvisory() took %v, expected to time out in ~2s", elapsed)
 	}

--- a/internal/update/advisory_test.go
+++ b/internal/update/advisory_test.go
@@ -146,6 +146,51 @@ func TestFetchAdvisory_EmptyMessage(t *testing.T) {
 	}
 }
 
+// TestFetchAdvisory_OversizedBody verifies that a response body that exceeds
+// the advisory size cap is handled gracefully: FetchAdvisory returns
+// (Advisory{}, false) without panicking or propagating an error to the caller.
+// A legitimate advisory.json is tiny; an oversized body is either malicious or
+// a misconfiguration and must never exhaust memory.
+func TestFetchAdvisory_OversizedBody(t *testing.T) {
+	// Stream a body that is larger than the 64 KB cap without buffering the
+	// whole thing in the test process.
+	const bodySize = 128 * 1024 // 128 KB — well over the 64 KB cap
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		// Write a leading '{' so JSON decoding starts, then flood with garbage.
+		// The decoder must stop reading at the cap, not consume the full body.
+		_, _ = w.Write([]byte{'{'})
+		chunk := make([]byte, 4096)
+		for i := range chunk {
+			chunk[i] = 'x'
+		}
+		written := 1
+		for written < bodySize {
+			n, err := w.Write(chunk)
+			written += n
+			if err != nil {
+				return
+			}
+		}
+	}))
+	defer srv.Close()
+
+	orig := advisoryURL
+	advisoryURL = srv.URL
+	t.Cleanup(func() { advisoryURL = orig })
+
+	a, ok := FetchAdvisory(context.Background())
+	// Oversized / unparseable body must be treated as fail-open.
+	if ok {
+		t.Error("FetchAdvisory() returned ok=true on oversized body, want false")
+	}
+	if a.Message != "" {
+		t.Errorf("FetchAdvisory().Message = %q on oversized body, want empty", a.Message)
+	}
+}
+
 // TestFetchAdvisory_HTTP404 verifies that a 404 (advisory tag not yet created)
 // returns (Advisory{}, false) silently — expected production state before the
 // advisory release tag is created.


### PR DESCRIPTION
Slice 7/7 — fail-open advisory.json fetch from the dedicated advisory tag, shown on Welcome; 2s timeout, non-blocking. Stacked on slice 4.

Part of the `update-experience` stacked chain. Refs #872.

- [x] Bug fix / feature slice
- [x] Strict TDD, fresh-context reviewed, `go test ./...` green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional advisory messages to the Welcome screen, fetched in parallel with update checks.
  * Advisory text is sanitized (removes terminal styling/control characters) and shown as an “Advisory:” line beneath the update banner when available.
* **Tests**
  * Extended coverage for advisory fetching “fail-open” behavior, message sanitization, correct model updates, and Welcome-screen rendering/layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->