### PR TITLE
feat(tui): Codex-style update prompt before the welcome screen

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -35,6 +35,23 @@ import (
 // Package-level var so tests can inject a deterministic clock.
 var tuiNowFn = time.Now
 
+// tuiOpenBrowserFn opens a URL in the default system browser.
+// Package-level var so tests can inject a stub without spawning a process.
+// Returns a non-nil error when the browser cannot be opened; callers fall back
+// to printing the URL to stdout.
+var tuiOpenBrowserFn = func(url string) error {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = execCommandFn("open", url)
+	case "windows":
+		cmd = execCommandFn("rundll32", "url.dll,FileProtocolHandler", url)
+	default:
+		cmd = execCommandFn("xdg-open", url)
+	}
+	return cmd.Start()
+}
+
 // advisoryFetchFn is the function used to fetch the advisory manifest.
 // Package-level var so tests can override without network calls.
 var advisoryFetchFn = update.FetchAdvisory
@@ -342,6 +359,10 @@ const (
 	ScreenAgentBuilderPreview
 	ScreenAgentBuilderInstalling
 	ScreenAgentBuilderComplete
+	// ScreenUpdatePrompt is shown BEFORE ScreenWelcome when an update is available
+	// at launch. No snooze or skip state is persisted — shown on every launch with
+	// a pending update. Keys: u=update+quit, c/Enter=keep→Welcome, v=view changes.
+	ScreenUpdatePrompt
 )
 
 type Model struct {
@@ -690,6 +711,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.SpinnerFrame = (m.SpinnerFrame + 1) % 10
 			return m, tickCmd()
 		}
+		// Keep spinner running on ScreenUpdatePrompt while the update check is
+		// still in-flight. Once UpdateCheckDone is true, the ticker is no longer
+		// needed for this screen and is intentionally not re-scheduled.
+		if m.Screen == ScreenUpdatePrompt && !m.UpdateCheckDone {
+			m.SpinnerFrame = (m.SpinnerFrame + 1) % 10
+			return m, tickCmd()
+		}
 		// Keep spinner running for agent builder generating/installing screens.
 		if m.AgentBuilder.Generating || m.AgentBuilder.Installing {
 			m.SpinnerFrame = (m.SpinnerFrame + 1) % 10
@@ -746,6 +774,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case UpdateCheckResultMsg:
 		m.UpdateResults = msg.Results
 		m.UpdateCheckDone = true
+		// Show the pre-Welcome update prompt only when the user is still on the
+		// initial Welcome screen. The update check is async (~10 s) so if the user
+		// has already navigated into a flow we must not interrupt them mid-action.
+		if update.HasUpdates(m.UpdateResults) && m.Screen == ScreenWelcome {
+			m.setScreen(ScreenUpdatePrompt)
+		}
 		return m, nil
 	case AdvisoryMsg:
 		// Store the advisory message for display on the Welcome screen.
@@ -1040,6 +1074,8 @@ func (m Model) View() string {
 		return screens.RenderABInstalling(engineName, m.SpinnerFrame, m.AgentBuilder.InstallErr)
 	case ScreenAgentBuilderComplete:
 		return screens.RenderABComplete(m.AgentBuilder.Generated, m.AgentBuilder.InstallResults)
+	case ScreenUpdatePrompt:
+		return screens.RenderUpdatePrompt(m.UpdateResults, m.Cursor, m.SpinnerFrame, m.UpdateCheckDone)
 	default:
 		return ""
 	}
@@ -1240,6 +1276,13 @@ func (m Model) handleKeyPress(key tea.KeyMsg) (tea.Model, tea.Cmd) {
 			}
 			return m, nil
 		}
+	}
+
+	// ScreenUpdatePrompt has its own dedicated key handlers that take priority
+	// over the generic navigation below. All three actions (u/v/c) are handled
+	// here so the generic enter/esc/up/down logic is bypassed for this screen.
+	if m.Screen == ScreenUpdatePrompt {
+		return m.handleUpdatePromptKey(keyStr)
 	}
 
 	switch keyStr {
@@ -2364,6 +2407,18 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 		}
 	case ScreenAgentBuilderComplete:
 		m.setScreen(ScreenWelcome)
+	case ScreenUpdatePrompt:
+		// Cursor maps to: 0=Update now, 1=View changes, 2=Keep current version.
+		// Enter always confirms the currently highlighted option.
+		// Direct key presses (u/v/c) are handled separately in handleUpdatePromptKey.
+		switch m.Cursor {
+		case 0: // Update now — route through startUpgrade so the result is surfaced.
+			return m, m.startUpgrade()
+		case 1: // View changes
+			return m.openUpdateReleaseURL()
+		default: // Keep current version (cursor=2) or any other position
+			m.setScreen(ScreenWelcome)
+		}
 	}
 
 	return m, nil
@@ -2463,6 +2518,71 @@ func (m Model) withResetUninstallState() Model {
 	m.OperationMode = ""
 	m.Cursor = 0
 	return m
+}
+
+// handleUpdatePromptKey processes key events on ScreenUpdatePrompt.
+//
+// Key bindings:
+//
+//	up / down → move cursor through the three options (wraps around)
+//	enter     → confirm the currently highlighted option (cursor-driven)
+//	u         → shortcut: run upgrade regardless of cursor position
+//	v         → shortcut: open release notes URL in browser; fallback: print URL; stay on screen
+//	c         → shortcut: keep current version (go to Welcome) regardless of cursor
+//	q, ctrl+c → quit
+func (m Model) handleUpdatePromptKey(keyStr string) (tea.Model, tea.Cmd) {
+	const optCount = 3
+	switch keyStr {
+	case "ctrl+c", "q":
+		return m, tea.Quit
+	case "up":
+		if m.Cursor > 0 {
+			m.Cursor--
+		} else {
+			m.Cursor = optCount - 1
+		}
+		return m, nil
+	case "down":
+		if m.Cursor+1 < optCount {
+			m.Cursor++
+		} else {
+			m.Cursor = 0
+		}
+		return m, nil
+	case "enter":
+		// Confirm the highlighted option — same as confirmSelection() for this screen.
+		return m.confirmSelection()
+	case "u":
+		return m, m.startUpgrade()
+	case "v":
+		return m.openUpdateReleaseURL()
+	case "c":
+		m.setScreen(ScreenWelcome)
+		return m, nil
+	}
+	return m, nil
+}
+
+// openUpdateReleaseURL attempts to open the release notes URL for the first
+// available update result in the default system browser. When the browser cannot
+// be opened the URL is printed to stdout as a fallback. The screen stays on
+// ScreenUpdatePrompt in both cases (the user may still choose to update or keep).
+func (m Model) openUpdateReleaseURL() (tea.Model, tea.Cmd) {
+	var releaseURL string
+	for _, r := range m.UpdateResults {
+		if r.Status == update.UpdateAvailable && r.ReleaseURL != "" {
+			releaseURL = r.ReleaseURL
+			break
+		}
+	}
+	if releaseURL != "" {
+		if err := tuiOpenBrowserFn(releaseURL); err != nil {
+			// Fallback: print the URL so the user can open it manually.
+			fmt.Println("Release notes:", releaseURL)
+		}
+	}
+	// Stay on ScreenUpdatePrompt so the user can still choose to update or keep.
+	return m, nil
 }
 
 // startUpgrade launches the upgrade goroutine and returns a tea.Cmd.
@@ -2726,6 +2846,13 @@ func (m Model) goBack() Model {
 
 	// Block going back while agent installation is in progress.
 	if m.AgentBuilder.Installing {
+		return m
+	}
+
+	// Esc on the update prompt dismisses it and proceeds to Welcome
+	// (equivalent to "Keep current version").
+	if m.Screen == ScreenUpdatePrompt {
+		m.setScreen(ScreenWelcome)
 		return m
 	}
 
@@ -3014,6 +3141,11 @@ func (m *Model) setScreen(next Screen) {
 	m.PreviousScreen = m.Screen
 	m.Screen = next
 	m.Cursor = 0
+	// Safe default: start on "Keep current version" (index 2) so an accidental
+	// Enter press does not trigger an upgrade.
+	if next == ScreenUpdatePrompt {
+		m.Cursor = 2
+	}
 	if next == ScreenBackups {
 		m.BackupScroll = 0
 		m.PinErr = nil
@@ -3201,6 +3333,8 @@ func (m Model) optionCount() int {
 		return 0 // no cursor navigation while installing
 	case ScreenAgentBuilderComplete:
 		return 1 // Done
+	case ScreenUpdatePrompt:
+		return len(screens.UpdatePromptOptions()) // Update now / View changes / Keep current
 	default:
 		return 0
 	}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -2412,8 +2412,13 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 		// Enter always confirms the currently highlighted option.
 		// Direct key presses (u/v/c) are handled separately in handleUpdatePromptKey.
 		switch m.Cursor {
-		case 0: // Update now — route through startUpgrade so the result is surfaced.
-			return m, m.startUpgrade()
+		case 0: // Update now — guard against duplicate/concurrent upgrades.
+			if m.OperationRunning {
+				return m, nil
+			}
+			m.OperationRunning = true
+			m.OperationMode = "upgrade"
+			return m, tea.Batch(tickCmd(), m.startUpgrade())
 		case 1: // View changes
 			return m.openUpdateReleaseURL()
 		default: // Keep current version (cursor=2) or any other position
@@ -2553,7 +2558,13 @@ func (m Model) handleUpdatePromptKey(keyStr string) (tea.Model, tea.Cmd) {
 		// Confirm the highlighted option — same as confirmSelection() for this screen.
 		return m.confirmSelection()
 	case "u":
-		return m, m.startUpgrade()
+		// Guard against duplicate/concurrent upgrades — mirrors ScreenUpgrade behavior.
+		if m.OperationRunning {
+			return m, nil
+		}
+		m.OperationRunning = true
+		m.OperationMode = "upgrade"
+		return m, tea.Batch(tickCmd(), m.startUpgrade())
 	case "v":
 		return m.openUpdateReleaseURL()
 	case "c":

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -5606,10 +5606,20 @@ func TestUpdatePromptScreen_UpdateNow_NoDuplicateUpgrade(t *testing.T) {
 		return upgrade.UpgradeReport{}
 	}
 
-	m3aRaw, _ := m3.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m3aRaw, cmd3a := m3.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	m3a := m3aRaw.(Model)
 	if !m3a.OperationRunning {
 		t.Error("OperationRunning must be true after Enter on cursor=0 (Update now) on ScreenUpdatePrompt")
+	}
+	if cmd3a == nil {
+		t.Fatal("first Enter on Update now should return a command")
+	}
+	if batch, ok := cmd3a().(tea.BatchMsg); ok {
+		for _, fn := range batch {
+			if fn != nil {
+				fn()
+			}
+		}
 	}
 
 	// Second Enter while in progress — must be no-op.
@@ -5623,7 +5633,7 @@ func TestUpdatePromptScreen_UpdateNow_NoDuplicateUpgrade(t *testing.T) {
 		}
 	}
 
-	if enterCallCount > 1 {
-		t.Errorf("UpgradeFn call count via Enter = %d, want at most 1 (duplicate Enter guard failed)", enterCallCount)
+	if enterCallCount != 1 {
+		t.Errorf("UpgradeFn call count via Enter = %d, want exactly 1 (Enter must start exactly one upgrade)", enterCallCount)
 	}
 }

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -4963,3 +4963,538 @@ func TestAdvisoryMsg_SanitizesOnStore(t *testing.T) {
 		t.Errorf("AdvisoryMessage = %q — expected printable phrase %q to survive sanitization", state.AdvisoryMessage, "update now")
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Slice 6 — TUI Pre-Welcome Update Prompt Screen
+// ---------------------------------------------------------------------------
+
+// makeUpdateResult returns a minimal UpdateResult with the given status and release URL.
+func makeUpdateResult(status update.UpdateStatus, releaseURL string) update.UpdateResult {
+	return update.UpdateResult{
+		Tool:             update.ToolInfo{Name: "gentle-ai"},
+		Status:           status,
+		InstalledVersion: "1.0.0",
+		LatestVersion:    "2.0.0",
+		ReleaseURL:       releaseURL,
+	}
+}
+
+// TestUpdatePromptScreen_ShownWhenUpdateAvailable verifies that receiving
+// UpdateCheckResultMsg with HasUpdates=true transitions to ScreenUpdatePrompt.
+func TestUpdatePromptScreen_ShownWhenUpdateAvailable(t *testing.T) {
+	m := NewModel(system.DetectionResult{}, "dev")
+
+	result := makeUpdateResult(update.UpdateAvailable, "https://github.com/releases/v2.0.0")
+	updated, _ := m.Update(UpdateCheckResultMsg{Results: []update.UpdateResult{result}})
+	got := updated.(Model)
+
+	if got.Screen != ScreenUpdatePrompt {
+		t.Fatalf("Screen = %v, want ScreenUpdatePrompt when update is available", got.Screen)
+	}
+	if !got.UpdateCheckDone {
+		t.Fatal("UpdateCheckDone should be true after UpdateCheckResultMsg")
+	}
+}
+
+// TestUpdatePromptScreen_SkippedWhenNoUpdate verifies that when no update is
+// available, UpdateCheckResultMsg does NOT transition to ScreenUpdatePrompt.
+func TestUpdatePromptScreen_SkippedWhenNoUpdate(t *testing.T) {
+	m := NewModel(system.DetectionResult{}, "dev")
+
+	result := makeUpdateResult(update.UpToDate, "")
+	updated, _ := m.Update(UpdateCheckResultMsg{Results: []update.UpdateResult{result}})
+	got := updated.(Model)
+
+	if got.Screen == ScreenUpdatePrompt {
+		t.Fatal("Screen should NOT be ScreenUpdatePrompt when no update is available")
+	}
+	// Should stay on Welcome (the initial screen).
+	if got.Screen != ScreenWelcome {
+		t.Fatalf("Screen = %v, want ScreenWelcome when no update", got.Screen)
+	}
+}
+
+// TestUpdatePromptScreen_SkippedWhenCheckFailed verifies that an empty results
+// slice (check failed / offline) does NOT trigger ScreenUpdatePrompt.
+func TestUpdatePromptScreen_SkippedWhenCheckFailed(t *testing.T) {
+	m := NewModel(system.DetectionResult{}, "dev")
+
+	updated, _ := m.Update(UpdateCheckResultMsg{Results: nil})
+	got := updated.(Model)
+
+	if got.Screen == ScreenUpdatePrompt {
+		t.Fatal("Screen should NOT be ScreenUpdatePrompt when update check returned nil results")
+	}
+	if got.Screen != ScreenWelcome {
+		t.Fatalf("Screen = %v, want ScreenWelcome when check failed", got.Screen)
+	}
+}
+
+// TestUpdatePromptScreen_KeyU_RunsUpgradeThenQuits verifies that pressing "u"
+// on ScreenUpdatePrompt invokes UpgradeFn and on success (ExitRequested=true)
+// eventually produces a tea.QuitMsg via the UpgradeDoneMsg two-step flow.
+func TestUpdatePromptScreen_KeyU_RunsUpgradeThenQuits(t *testing.T) {
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Screen = ScreenUpdatePrompt
+	m.UpdateResults = []update.UpdateResult{makeUpdateResult(update.UpdateAvailable, "https://example.com/releases")}
+	m.UpdateCheckDone = true
+
+	upgraded := false
+	m.UpgradeFn = func(_ context.Context, results []update.UpdateResult) upgrade.UpgradeReport {
+		upgraded = true
+		return upgrade.UpgradeReport{ExitRequested: true}
+	}
+
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("u")})
+	if cmd == nil {
+		t.Fatal("cmd should not be nil after pressing 'u' on ScreenUpdatePrompt")
+	}
+
+	// Step 1: execute the goroutine cmd → should produce UpgradeDoneMsg.
+	msg := cmd()
+	if batch, ok := msg.(tea.BatchMsg); ok {
+		for _, fn := range batch {
+			if inner := fn(); inner != nil {
+				msg = inner
+				break
+			}
+		}
+	}
+
+	if !upgraded {
+		t.Error("UpgradeFn should have been called when pressing 'u'")
+	}
+
+	// Step 2: feed UpgradeDoneMsg into the model → should produce tea.Quit cmd.
+	doneMsg, ok := msg.(UpgradeDoneMsg)
+	if !ok {
+		t.Fatalf("expected UpgradeDoneMsg from upgrade goroutine, got %T", msg)
+	}
+	_, quitCmd := m.Update(doneMsg)
+	if quitCmd == nil {
+		t.Fatal("cmd must not be nil after UpgradeDoneMsg with ExitRequested=true")
+	}
+	gotQuit := false
+	if _, ok := quitCmd().(tea.QuitMsg); ok {
+		gotQuit = true
+	}
+	if !gotQuit {
+		t.Error("expected QuitMsg after UpgradeDoneMsg with ExitRequested=true")
+	}
+}
+
+// TestUpdatePromptScreen_KeyC_TransitionsToWelcome verifies that pressing "c"
+// on ScreenUpdatePrompt transitions to ScreenWelcome.
+func TestUpdatePromptScreen_KeyC_TransitionsToWelcome(t *testing.T) {
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Screen = ScreenUpdatePrompt
+	m.UpdateResults = []update.UpdateResult{makeUpdateResult(update.UpdateAvailable, "")}
+	m.UpdateCheckDone = true
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("c")})
+	got := updated.(Model)
+
+	if got.Screen != ScreenWelcome {
+		t.Fatalf("Screen = %v, want ScreenWelcome after pressing 'c'", got.Screen)
+	}
+}
+
+// TestUpdatePromptScreen_KeyEnter_TransitionsToWelcome verifies that pressing
+// Enter on ScreenUpdatePrompt with cursor on "Keep current version" (cursor=2,
+// the default when entering via setScreen) transitions to ScreenWelcome.
+func TestUpdatePromptScreen_KeyEnter_TransitionsToWelcome(t *testing.T) {
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.setScreen(ScreenUpdatePrompt) // cursor is set to 2 (Keep current) by setScreen
+	m.UpdateResults = []update.UpdateResult{makeUpdateResult(update.UpdateAvailable, "")}
+	m.UpdateCheckDone = true
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	got := updated.(Model)
+
+	if got.Screen != ScreenWelcome {
+		t.Fatalf("Screen = %v, want ScreenWelcome after Enter with default cursor (Keep current) on ScreenUpdatePrompt", got.Screen)
+	}
+}
+
+// TestUpdatePromptScreen_KeyV_CallsOpenBrowser verifies that pressing "v" on
+// ScreenUpdatePrompt calls the open-browser function with the release URL and
+// the screen remains on ScreenUpdatePrompt.
+func TestUpdatePromptScreen_KeyV_CallsOpenBrowser(t *testing.T) {
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Screen = ScreenUpdatePrompt
+	releaseURL := "https://github.com/releases/v2.0.0"
+	m.UpdateResults = []update.UpdateResult{makeUpdateResult(update.UpdateAvailable, releaseURL)}
+	m.UpdateCheckDone = true
+
+	var openedURL string
+	origFn := tuiOpenBrowserFn
+	tuiOpenBrowserFn = func(url string) error {
+		openedURL = url
+		return nil
+	}
+	defer func() { tuiOpenBrowserFn = origFn }()
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("v")})
+	got := updated.(Model)
+
+	if got.Screen != ScreenUpdatePrompt {
+		t.Fatalf("Screen = %v, want ScreenUpdatePrompt to remain after 'v'", got.Screen)
+	}
+	if openedURL != releaseURL {
+		t.Fatalf("openedURL = %q, want %q", openedURL, releaseURL)
+	}
+}
+
+// TestUpdatePromptScreen_KeyV_FallsBackWhenBrowserFails verifies that when the
+// open-browser function returns an error, the screen stays on ScreenUpdatePrompt
+// (the URL is printed as fallback — tested by ensuring no panic and correct screen).
+func TestUpdatePromptScreen_KeyV_FallsBackWhenBrowserFails(t *testing.T) {
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Screen = ScreenUpdatePrompt
+	m.UpdateResults = []update.UpdateResult{makeUpdateResult(update.UpdateAvailable, "https://example.com")}
+	m.UpdateCheckDone = true
+
+	origFn := tuiOpenBrowserFn
+	tuiOpenBrowserFn = func(_ string) error {
+		return fmt.Errorf("browser not found")
+	}
+	defer func() { tuiOpenBrowserFn = origFn }()
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("v")})
+	got := updated.(Model)
+
+	// Screen must remain on ScreenUpdatePrompt even when browser fails.
+	if got.Screen != ScreenUpdatePrompt {
+		t.Fatalf("Screen = %v, want ScreenUpdatePrompt after browser failure", got.Screen)
+	}
+}
+
+// TestUpdatePromptScreen_OptionCount verifies that optionCount() returns 3
+// for ScreenUpdatePrompt (Update / View changes / Keep current).
+func TestUpdatePromptScreen_OptionCount(t *testing.T) {
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Screen = ScreenUpdatePrompt
+
+	if got := m.optionCount(); got != 3 {
+		t.Fatalf("optionCount() = %d, want 3 for ScreenUpdatePrompt", got)
+	}
+}
+
+// TestUpdatePromptScreen_View_NonEmpty verifies that View() returns a non-empty
+// string when the screen is ScreenUpdatePrompt (smoke test for the render function).
+func TestUpdatePromptScreen_View_NonEmpty(t *testing.T) {
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Screen = ScreenUpdatePrompt
+	m.UpdateResults = []update.UpdateResult{makeUpdateResult(update.UpdateAvailable, "https://example.com")}
+	m.UpdateCheckDone = true
+
+	rendered := m.View()
+	if strings.TrimSpace(rendered) == "" {
+		t.Fatal("View() should return non-empty string for ScreenUpdatePrompt")
+	}
+}
+
+// TestUpdatePromptScreen_ConfirmSelection_EnterEquivalent verifies that
+// confirmSelection() on ScreenUpdatePrompt (cursor 2 = Keep current) navigates
+// to Welcome, mirroring the "Enter" behavior exercised via handleKeyPress.
+func TestUpdatePromptScreen_ConfirmSelection_EnterEquivalent(t *testing.T) {
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Screen = ScreenUpdatePrompt
+	m.UpdateResults = []update.UpdateResult{makeUpdateResult(update.UpdateAvailable, "")}
+	m.UpdateCheckDone = true
+	m.Cursor = 2 // "Keep current version"
+
+	updated, _ := m.confirmSelection()
+	got := updated.(Model)
+
+	if got.Screen != ScreenWelcome {
+		t.Fatalf("Screen = %v, want ScreenWelcome after confirmSelection cursor=2 on ScreenUpdatePrompt", got.Screen)
+	}
+}
+
+// ─── Enter confirms highlighted cursor option ─────────────────────────────────
+
+// TestUpdatePromptScreen_EnterWithCursorOnUpdate_RunsUpgrade verifies that when
+// the cursor is on "Update now" (0) and Enter is pressed, the upgrade is started
+// (not silently ignored or treated as keep-current).
+func TestUpdatePromptScreen_EnterWithCursorOnUpdate_RunsUpgrade(t *testing.T) {
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Screen = ScreenUpdatePrompt
+	m.UpdateResults = []update.UpdateResult{makeUpdateResult(update.UpdateAvailable, "https://example.com/releases")}
+	m.UpdateCheckDone = true
+	m.Cursor = 0 // Update now
+
+	upgraded := false
+	m.UpgradeFn = func(_ context.Context, results []update.UpdateResult) upgrade.UpgradeReport {
+		upgraded = true
+		return upgrade.UpgradeReport{ExitRequested: true}
+	}
+
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("cmd should not be nil when Enter is pressed with cursor on Update now")
+	}
+
+	// Execute the command to trigger the upgrade goroutine.
+	msg := cmd()
+	// Accept BatchMsg: unwrap one level.
+	if batch, ok := msg.(tea.BatchMsg); ok {
+		for _, fn := range batch {
+			fn()
+		}
+	}
+
+	if !upgraded {
+		t.Error("UpgradeFn should have been called when Enter is pressed with cursor on Update now (cursor=0)")
+	}
+}
+
+// TestUpdatePromptScreen_EnterWithDefaultCursor_GoesToWelcome verifies that the
+// default cursor position on ScreenUpdatePrompt is "Keep current" (2), so an
+// accidental Enter press does NOT trigger an upgrade.
+func TestUpdatePromptScreen_EnterWithDefaultCursor_GoesToWelcome(t *testing.T) {
+	m := NewModel(system.DetectionResult{}, "dev")
+	// Simulate entering ScreenUpdatePrompt via setScreen (which sets cursor=2).
+	m.setScreen(ScreenUpdatePrompt)
+	m.UpdateResults = []update.UpdateResult{makeUpdateResult(update.UpdateAvailable, "")}
+	m.UpdateCheckDone = true
+
+	// Cursor should be at 2 (Keep current) after setScreen.
+	if m.Cursor != 2 {
+		t.Fatalf("Cursor = %d after setScreen(ScreenUpdatePrompt), want 2 (Keep current)", m.Cursor)
+	}
+
+	upgraded := false
+	m.UpgradeFn = func(_ context.Context, _ []update.UpdateResult) upgrade.UpgradeReport {
+		upgraded = true
+		return upgrade.UpgradeReport{}
+	}
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	got := updated.(Model)
+
+	if upgraded {
+		t.Error("UpgradeFn must NOT be called when Enter is pressed on the default cursor (Keep current)")
+	}
+	if got.Screen != ScreenWelcome {
+		t.Fatalf("Screen = %v, want ScreenWelcome after Enter with default cursor (Keep current)", got.Screen)
+	}
+}
+
+// TestUpdatePromptScreen_ShortcutU_WorksRegardlessOfCursor verifies that the
+// "u" shortcut triggers an upgrade even when the cursor is on a different option.
+func TestUpdatePromptScreen_ShortcutU_WorksRegardlessOfCursor(t *testing.T) {
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Screen = ScreenUpdatePrompt
+	m.UpdateResults = []update.UpdateResult{makeUpdateResult(update.UpdateAvailable, "https://example.com/releases")}
+	m.UpdateCheckDone = true
+	m.Cursor = 2 // Keep current
+
+	upgraded := false
+	m.UpgradeFn = func(_ context.Context, _ []update.UpdateResult) upgrade.UpgradeReport {
+		upgraded = true
+		return upgrade.UpgradeReport{ExitRequested: true}
+	}
+
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("u")})
+	if cmd == nil {
+		t.Fatal("cmd should not be nil after pressing 'u'")
+	}
+	msg := cmd()
+	if batch, ok := msg.(tea.BatchMsg); ok {
+		for _, fn := range batch {
+			fn()
+		}
+	}
+
+	if !upgraded {
+		t.Error("UpgradeFn should have been called via 'u' shortcut regardless of cursor position")
+	}
+}
+
+// TestUpdatePromptScreen_ShortcutC_WorksRegardlessOfCursor verifies that the
+// "c" shortcut transitions to Welcome even when the cursor is on Update now.
+func TestUpdatePromptScreen_ShortcutC_WorksRegardlessOfCursor(t *testing.T) {
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Screen = ScreenUpdatePrompt
+	m.UpdateResults = []update.UpdateResult{makeUpdateResult(update.UpdateAvailable, "")}
+	m.UpdateCheckDone = true
+	m.Cursor = 0 // Update now
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("c")})
+	got := updated.(Model)
+
+	if got.Screen != ScreenWelcome {
+		t.Fatalf("Screen = %v, want ScreenWelcome after pressing 'c' regardless of cursor", got.Screen)
+	}
+}
+
+// ─── Upgrade error surfacing ──────────────────────────────────────────────────
+
+// TestUpdatePromptScreen_UpgradeError_IsSurfaced verifies that when UpgradeFn
+// is nil (infrastructure failure), the "u" key produces UpgradeDoneMsg with a
+// non-nil Err rather than a silent QuitMsg — the error is routed through the
+// existing UpgradeDoneMsg handler so it can be surfaced to the user.
+func TestUpdatePromptScreen_UpgradeError_IsSurfaced(t *testing.T) {
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Screen = ScreenUpdatePrompt
+	m.UpdateResults = []update.UpdateResult{makeUpdateResult(update.UpdateAvailable, "https://example.com/releases")}
+	m.UpdateCheckDone = true
+	m.Cursor = 0
+	m.UpgradeFn = nil // nil fn → startUpgrade returns UpgradeDoneMsg{Err: ...}
+
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("u")})
+	if cmd == nil {
+		t.Fatal("cmd must not be nil after pressing 'u'")
+	}
+
+	// Execute the command: expect UpgradeDoneMsg (not a silent QuitMsg).
+	msg := cmd()
+	if batch, ok := msg.(tea.BatchMsg); ok {
+		for _, fn := range batch {
+			if inner := fn(); inner != nil {
+				msg = inner
+				break
+			}
+		}
+	}
+
+	doneMsg, ok := msg.(UpgradeDoneMsg)
+	if !ok {
+		t.Fatalf("pressing 'u' must produce UpgradeDoneMsg (not %T) so errors are surfaced", msg)
+	}
+	if doneMsg.Err == nil {
+		t.Fatal("UpgradeDoneMsg.Err must be non-nil when UpgradeFn is nil")
+	}
+
+	// Feed the UpgradeDoneMsg into the model — the error must be stored.
+	updated, _ := m.Update(doneMsg)
+	got := updated.(Model)
+
+	if got.UpgradeErr == nil {
+		t.Fatal("UpgradeErr must be set after UpgradeDoneMsg with non-nil Err")
+	}
+}
+
+// TestUpdatePromptScreen_UpgradeSuccess_EmitsQuit verifies that when UpgradeFn
+// succeeds with ExitRequested=true, a QuitMsg is eventually produced.
+func TestUpdatePromptScreen_UpgradeSuccess_EmitsQuit(t *testing.T) {
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Screen = ScreenUpdatePrompt
+	m.UpdateResults = []update.UpdateResult{makeUpdateResult(update.UpdateAvailable, "https://example.com/releases")}
+	m.UpdateCheckDone = true
+	m.Cursor = 0
+
+	m.UpgradeFn = func(_ context.Context, _ []update.UpdateResult) upgrade.UpgradeReport {
+		return upgrade.UpgradeReport{ExitRequested: true}
+	}
+
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("u")})
+	if cmd == nil {
+		t.Fatal("cmd must not be nil after pressing 'u'")
+	}
+
+	// Execute the command to get UpgradeDoneMsg.
+	msg := cmd()
+	if batch, ok := msg.(tea.BatchMsg); ok {
+		for _, fn := range batch {
+			if inner := fn(); inner != nil {
+				msg = inner
+				break
+			}
+		}
+	}
+
+	doneMsg, ok := msg.(UpgradeDoneMsg)
+	if !ok {
+		t.Fatalf("expected UpgradeDoneMsg from upgrade goroutine, got %T", msg)
+	}
+
+	// Feed the UpgradeDoneMsg into the model — should trigger tea.Quit.
+	_, quitCmd := m.Update(doneMsg)
+	if quitCmd == nil {
+		t.Fatal("cmd must not be nil after UpgradeDoneMsg with ExitRequested=true")
+	}
+	gotQuit := false
+	quitMsg := quitCmd()
+	if _, ok := quitMsg.(tea.QuitMsg); ok {
+		gotQuit = true
+	}
+	if !gotQuit {
+		t.Error("expected QuitMsg after UpgradeDoneMsg with ExitRequested=true")
+	}
+}
+
+// ─── UpdateCheckResultMsg guard: only switch from Welcome ────────────────────
+
+// TestUpdateCheckResult_DoesNotInterruptNonWelcomeScreen verifies that when an
+// update result arrives while the user is already on a screen other than Welcome,
+// the TUI does NOT jump back to ScreenUpdatePrompt.
+func TestUpdateCheckResult_DoesNotInterruptNonWelcomeScreen(t *testing.T) {
+	m := NewModel(system.DetectionResult{}, "dev")
+	// User has already navigated away from Welcome.
+	m.Screen = ScreenDetection
+	m.UpdateCheckDone = false
+
+	result := makeUpdateResult(update.UpdateAvailable, "https://example.com/releases")
+	updated, _ := m.Update(UpdateCheckResultMsg{Results: []update.UpdateResult{result}})
+	got := updated.(Model)
+
+	if got.Screen == ScreenUpdatePrompt {
+		t.Fatal("Screen must NOT jump to ScreenUpdatePrompt when update arrives while user is not on ScreenWelcome")
+	}
+	if got.Screen != ScreenDetection {
+		t.Fatalf("Screen = %v, want ScreenDetection (should not change when not on Welcome)", got.Screen)
+	}
+	if !got.UpdateCheckDone {
+		t.Fatal("UpdateCheckDone should still be set to true")
+	}
+}
+
+// ─── UpgradeFn nil guard ─────────────────────────────────────────────────────
+
+// TestUpdatePromptScreen_KeyU_NilUpgradeFn_NosPanic verifies that pressing "u"
+// when UpgradeFn is nil does not panic and still produces an UpgradeDoneMsg
+// (with a non-nil error) rather than silently quitting.
+func TestUpdatePromptScreen_KeyU_NilUpgradeFn_NoPanic(t *testing.T) {
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Screen = ScreenUpdatePrompt
+	m.UpdateResults = []update.UpdateResult{makeUpdateResult(update.UpdateAvailable, "")}
+	m.UpdateCheckDone = true
+	m.UpgradeFn = nil
+
+	// Must not panic.
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("panic when UpgradeFn is nil: %v", r)
+		}
+	}()
+
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("u")})
+	if cmd == nil {
+		// nil cmd is acceptable when UpgradeFn is nil (no-op or immediate msg).
+		return
+	}
+
+	msg := cmd()
+	if batch, ok := msg.(tea.BatchMsg); ok {
+		for _, fn := range batch {
+			if inner := fn(); inner != nil {
+				msg = inner
+				break
+			}
+		}
+	}
+	// Accept either UpgradeDoneMsg (with error) or QuitMsg (both are acceptable
+	// non-panic outcomes; UpgradeDoneMsg preferred so error is surfaced).
+	switch m2 := msg.(type) {
+	case UpgradeDoneMsg:
+		if m2.Err == nil {
+			t.Error("UpgradeDoneMsg.Err must be non-nil when UpgradeFn is nil")
+		}
+	case tea.QuitMsg:
+		// Acceptable fallback.
+	default:
+		t.Logf("got %T — acceptable non-panic outcome when UpgradeFn is nil", msg)
+	}
+}

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -5045,32 +5045,45 @@ func TestUpdatePromptScreen_KeyU_RunsUpgradeThenQuits(t *testing.T) {
 		return upgrade.UpgradeReport{ExitRequested: true}
 	}
 
-	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("u")})
+	m2Raw, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("u")})
 	if cmd == nil {
 		t.Fatal("cmd should not be nil after pressing 'u' on ScreenUpdatePrompt")
 	}
+	m2 := m2Raw.(Model)
 
 	// Step 1: execute the goroutine cmd → should produce UpgradeDoneMsg.
-	msg := cmd()
-	if batch, ok := msg.(tea.BatchMsg); ok {
+	// The cmd may be a BatchMsg (tickCmd + upgrade goroutine); search all items
+	// in the batch to find the UpgradeDoneMsg rather than stopping at the first
+	// non-nil result (which could be a TickMsg from the spinner).
+	var msg tea.Msg
+	raw := cmd()
+	if batch, ok := raw.(tea.BatchMsg); ok {
 		for _, fn := range batch {
 			if inner := fn(); inner != nil {
-				msg = inner
-				break
+				if _, isDone := inner.(UpgradeDoneMsg); isDone {
+					msg = inner
+					break
+				}
 			}
 		}
+		if msg == nil {
+			msg = raw // fallback: use the batch result itself
+		}
+	} else {
+		msg = raw
 	}
 
 	if !upgraded {
 		t.Error("UpgradeFn should have been called when pressing 'u'")
 	}
 
-	// Step 2: feed UpgradeDoneMsg into the model → should produce tea.Quit cmd.
+	// Step 2: feed UpgradeDoneMsg into the model returned by the keypress
+	// Update (m2), not the pre-keypress model, to avoid masking false positives.
 	doneMsg, ok := msg.(UpgradeDoneMsg)
 	if !ok {
 		t.Fatalf("expected UpgradeDoneMsg from upgrade goroutine, got %T", msg)
 	}
-	_, quitCmd := m.Update(doneMsg)
+	_, quitCmd := m2.Update(doneMsg)
 	if quitCmd == nil {
 		t.Fatal("cmd must not be nil after UpgradeDoneMsg with ExitRequested=true")
 	}
@@ -5349,14 +5362,24 @@ func TestUpdatePromptScreen_UpgradeError_IsSurfaced(t *testing.T) {
 	}
 
 	// Execute the command: expect UpgradeDoneMsg (not a silent QuitMsg).
-	msg := cmd()
-	if batch, ok := msg.(tea.BatchMsg); ok {
+	// The cmd may be a BatchMsg (tickCmd + upgrade goroutine); search all items
+	// to find the UpgradeDoneMsg rather than stopping at the first non-nil result.
+	var msg tea.Msg
+	raw := cmd()
+	if batch, ok := raw.(tea.BatchMsg); ok {
 		for _, fn := range batch {
 			if inner := fn(); inner != nil {
-				msg = inner
-				break
+				if _, isDone := inner.(UpgradeDoneMsg); isDone {
+					msg = inner
+					break
+				}
 			}
 		}
+		if msg == nil {
+			msg = raw
+		}
+	} else {
+		msg = raw
 	}
 
 	doneMsg, ok := msg.(UpgradeDoneMsg)
@@ -5395,14 +5418,24 @@ func TestUpdatePromptScreen_UpgradeSuccess_EmitsQuit(t *testing.T) {
 	}
 
 	// Execute the command to get UpgradeDoneMsg.
-	msg := cmd()
-	if batch, ok := msg.(tea.BatchMsg); ok {
+	// The cmd may be a BatchMsg (tickCmd + upgrade goroutine); search all items
+	// to find the UpgradeDoneMsg rather than stopping at the first non-nil result.
+	var msg tea.Msg
+	raw := cmd()
+	if batch, ok := raw.(tea.BatchMsg); ok {
 		for _, fn := range batch {
 			if inner := fn(); inner != nil {
-				msg = inner
-				break
+				if _, isDone := inner.(UpgradeDoneMsg); isDone {
+					msg = inner
+					break
+				}
 			}
 		}
+		if msg == nil {
+			msg = raw
+		}
+	} else {
+		msg = raw
 	}
 
 	doneMsg, ok := msg.(UpgradeDoneMsg)
@@ -5453,9 +5486,10 @@ func TestUpdateCheckResult_DoesNotInterruptNonWelcomeScreen(t *testing.T) {
 
 // ─── UpgradeFn nil guard ─────────────────────────────────────────────────────
 
-// TestUpdatePromptScreen_KeyU_NilUpgradeFn_NosPanic verifies that pressing "u"
-// when UpgradeFn is nil does not panic and still produces an UpgradeDoneMsg
-// (with a non-nil error) rather than silently quitting.
+// TestUpdatePromptScreen_KeyU_NilUpgradeFn_NoPanic verifies the contract when
+// UpgradeFn is nil: pressing "u" must NOT panic, must NOT silently quit, and
+// must produce an UpgradeDoneMsg carrying a non-nil error (so the error is
+// surfaced via the normal upgrade-done path rather than lost).
 func TestUpdatePromptScreen_KeyU_NilUpgradeFn_NoPanic(t *testing.T) {
 	m := NewModel(system.DetectionResult{}, "dev")
 	m.Screen = ScreenUpdatePrompt
@@ -5472,29 +5506,124 @@ func TestUpdatePromptScreen_KeyU_NilUpgradeFn_NoPanic(t *testing.T) {
 
 	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("u")})
 	if cmd == nil {
-		// nil cmd is acceptable when UpgradeFn is nil (no-op or immediate msg).
-		return
+		t.Fatal("cmd must not be nil when UpgradeFn is nil: the contract requires an UpgradeDoneMsg to surface the error")
 	}
 
-	msg := cmd()
-	if batch, ok := msg.(tea.BatchMsg); ok {
+	// The cmd may be a BatchMsg (tickCmd + upgrade goroutine); search all items
+	// in the batch to find the UpgradeDoneMsg rather than stopping at the first
+	// non-nil result (which could be a TickMsg from the spinner).
+	var msg tea.Msg
+	raw := cmd()
+	if batch, ok := raw.(tea.BatchMsg); ok {
 		for _, fn := range batch {
 			if inner := fn(); inner != nil {
-				msg = inner
-				break
+				if _, isDone := inner.(UpgradeDoneMsg); isDone {
+					msg = inner
+					break
+				}
+			}
+		}
+		if msg == nil {
+			msg = raw // fallback: use the batch result itself
+		}
+	} else {
+		msg = raw
+	}
+
+	// The ONLY acceptable outcome is UpgradeDoneMsg with a non-nil error.
+	// A silent quit or an untyped result means the error was swallowed.
+	doneMsgResult, ok := msg.(UpgradeDoneMsg)
+	if !ok {
+		t.Fatalf("expected UpgradeDoneMsg when UpgradeFn is nil, got %T — error must not be swallowed", msg)
+	}
+	if doneMsgResult.Err == nil {
+		t.Error("UpgradeDoneMsg.Err must be non-nil when UpgradeFn is nil")
+	}
+}
+
+// TestUpdatePromptScreen_UpdateNow_NoDuplicateUpgrade verifies that triggering
+// the "Update now" action twice (or while an upgrade is already in progress)
+// starts the upgrade only ONCE. The operation-in-progress guard on
+// ScreenUpdatePrompt must mirror the guard on ScreenUpgrade.
+func TestUpdatePromptScreen_UpdateNow_NoDuplicateUpgrade(t *testing.T) {
+	callCount := 0
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Screen = ScreenUpdatePrompt
+	m.UpdateResults = []update.UpdateResult{makeUpdateResult(update.UpdateAvailable, "")}
+	m.UpdateCheckDone = true
+	m.UpgradeFn = func(_ context.Context, _ []update.UpdateResult) upgrade.UpgradeReport {
+		callCount++
+		return upgrade.UpgradeReport{}
+	}
+
+	// First trigger via "u" key — should start the upgrade and set OperationRunning.
+	m1Raw, cmd1 := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("u")})
+	if cmd1 == nil {
+		t.Fatal("cmd should not be nil after first 'u' press")
+	}
+	m1 := m1Raw.(Model)
+
+	if !m1.OperationRunning {
+		t.Error("OperationRunning must be true after triggering update-now on ScreenUpdatePrompt")
+	}
+
+	// Second trigger while OperationRunning=true — must be a no-op (no new cmd, no second goroutine).
+	m2Raw, cmd2 := m1.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("u")})
+	m2 := m2Raw.(Model)
+
+	if cmd2 != nil {
+		// Execute to check whether it would invoke UpgradeFn a second time.
+		msg := cmd2()
+		if batch, ok := msg.(tea.BatchMsg); ok {
+			for _, fn := range batch {
+				fn()
 			}
 		}
 	}
-	// Accept either UpgradeDoneMsg (with error) or QuitMsg (both are acceptable
-	// non-panic outcomes; UpgradeDoneMsg preferred so error is surfaced).
-	switch m2 := msg.(type) {
-	case UpgradeDoneMsg:
-		if m2.Err == nil {
-			t.Error("UpgradeDoneMsg.Err must be non-nil when UpgradeFn is nil")
+	_ = m2
+
+	// Execute the first cmd so UpgradeFn runs (exactly once across all batch items).
+	raw1 := cmd1()
+	if batch, ok := raw1.(tea.BatchMsg); ok {
+		for _, fn := range batch {
+			fn()
 		}
-	case tea.QuitMsg:
-		// Acceptable fallback.
-	default:
-		t.Logf("got %T — acceptable non-panic outcome when UpgradeFn is nil", msg)
+	}
+
+	if callCount != 1 {
+		t.Errorf("UpgradeFn call count = %d, want exactly 1 (duplicate upgrade guard failed)", callCount)
+	}
+
+	// Also verify via Enter key (cursor=0) on the original model — same guard must apply.
+	m3 := NewModel(system.DetectionResult{}, "dev")
+	m3.setScreen(ScreenUpdatePrompt)
+	m3.Cursor = 0 // "Update now"
+	m3.UpdateResults = []update.UpdateResult{makeUpdateResult(update.UpdateAvailable, "")}
+	m3.UpdateCheckDone = true
+	enterCallCount := 0
+	m3.UpgradeFn = func(_ context.Context, _ []update.UpdateResult) upgrade.UpgradeReport {
+		enterCallCount++
+		return upgrade.UpgradeReport{}
+	}
+
+	m3aRaw, _ := m3.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m3a := m3aRaw.(Model)
+	if !m3a.OperationRunning {
+		t.Error("OperationRunning must be true after Enter on cursor=0 (Update now) on ScreenUpdatePrompt")
+	}
+
+	// Second Enter while in progress — must be no-op.
+	_, cmd3b := m3a.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd3b != nil {
+		msg := cmd3b()
+		if batch, ok := msg.(tea.BatchMsg); ok {
+			for _, fn := range batch {
+				fn()
+			}
+		}
+	}
+
+	if enterCallCount > 1 {
+		t.Errorf("UpgradeFn call count via Enter = %d, want at most 1 (duplicate Enter guard failed)", enterCallCount)
 	}
 }

--- a/internal/tui/router.go
+++ b/internal/tui/router.go
@@ -49,6 +49,8 @@ var linearRoutes = map[Screen]Route{
 	ScreenUninstallComponents:    {Backward: ScreenUninstall},
 	ScreenUninstallProfiles:      {Backward: ScreenUninstallComponents},
 	ScreenUninstallResult:        {Backward: ScreenWelcome},
+	// ScreenUpdatePrompt appears before Welcome; Esc/back goes to Welcome.
+	ScreenUpdatePrompt: {Backward: ScreenWelcome},
 }
 
 func NextScreen(screen Screen) (Screen, bool) {

--- a/internal/tui/screens/update_prompt.go
+++ b/internal/tui/screens/update_prompt.go
@@ -1,0 +1,96 @@
+package screens
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/gentleman-programming/gentle-ai/internal/tui/styles"
+	"github.com/gentleman-programming/gentle-ai/internal/update"
+)
+
+// UpdatePromptOptions returns the display labels for the three update-prompt options.
+// The order matches the cursor index used in model.go:
+//
+//	0 = Update now
+//	1 = View changes
+//	2 = Keep current version
+func UpdatePromptOptions() []string {
+	return []string{
+		"Update now",
+		"View changes",
+		"Keep current version",
+	}
+}
+
+// RenderUpdatePrompt renders the pre-Welcome update prompt screen.
+//
+// While the update check is still in-flight (updateCheckDone=false) a spinner
+// is shown. Once done and updates are present the full prompt is rendered.
+//
+// Cursor starts on "Keep current version" (safe default).
+// Enter confirms the highlighted option; shortcuts bypass the cursor.
+//
+// Keys (displayed as hints):
+//
+//	↑/↓    = move cursor between options
+//	enter  = confirm highlighted option (default: Keep current version)
+//	u      = shortcut: Update now → run upgrade then close
+//	v      = shortcut: View changes → open release notes in browser (or print URL)
+//	c      = shortcut: Keep current version → proceed to Welcome
+func RenderUpdatePrompt(results []update.UpdateResult, cursor int, spinnerFrame int, updateCheckDone bool) string {
+	var b strings.Builder
+
+	b.WriteString(styles.TitleStyle.Render("Update Available"))
+	b.WriteString("\n\n")
+
+	if !updateCheckDone {
+		b.WriteString(styles.WarningStyle.Render(SpinnerChar(spinnerFrame) + "  Checking for updates..."))
+		b.WriteString("\n\n")
+		b.WriteString(styles.HelpStyle.Render("Please wait..."))
+		return b.String()
+	}
+
+	// Collect update entries for display.
+	var updateLines []string
+	var releaseURL string
+	for _, r := range results {
+		if r.Status == update.UpdateAvailable {
+			line := fmt.Sprintf("%s  %s → %s",
+				r.Tool.Name,
+				styles.SubtextStyle.Render(r.InstalledVersion),
+				styles.SuccessStyle.Render(r.LatestVersion),
+			)
+			updateLines = append(updateLines, line)
+			if releaseURL == "" && r.ReleaseURL != "" {
+				releaseURL = r.ReleaseURL
+			}
+		}
+	}
+
+	if len(updateLines) == 0 {
+		// No updates to display — this screen should not normally appear in this state.
+		b.WriteString(styles.SuccessStyle.Render("✓ All tools are up to date"))
+		b.WriteString("\n\n")
+		b.WriteString(styles.HelpStyle.Render("c / enter: continue • q: quit"))
+		return b.String()
+	}
+
+	b.WriteString(styles.HeadingStyle.Render("New versions available:"))
+	b.WriteString("\n\n")
+	for _, line := range updateLines {
+		b.WriteString("  " + styles.WarningStyle.Render("↑") + "  " + line + "\n")
+	}
+	b.WriteString("\n")
+
+	if releaseURL != "" {
+		b.WriteString(styles.SubtextStyle.Render("Release notes: " + releaseURL))
+		b.WriteString("\n\n")
+	}
+
+	opts := UpdatePromptOptions()
+	b.WriteString(renderOptions(opts, cursor))
+	b.WriteString("\n")
+	b.WriteString(styles.HelpStyle.Render("↑/↓: move • enter: confirm (default: keep) • u: update • v: view changes • c: keep • q: quit"))
+
+	return styles.FrameStyle.Render(b.String())
+}


### PR DESCRIPTION
Slice 6/7 of the `update-experience` chain (the final slice). Refs #872.

When an update is available at launch, the TUI shows a pre-Welcome prompt: **Update now / View changes / Keep current**. Cursor defaults to *Keep current* (a stray Enter is safe); Enter confirms the highlighted option; `u`/`v`/`c` are shortcuts. *Update now* routes through the existing upgrade flow so failures surface (no silent quit) and closes on success (apply-then-close). The prompt is skipped on no-update / failed-check, and the async check never hijacks a non-Welcome screen.

- [x] New feature slice
- [x] Strict TDD (19 tests), fresh-context reviewed (2 CRITICAL + warnings fixed), green CI
- [x] Exhaustive Screen-switch coverage verified

Standalone PR — ~767 lines, exceeds the 400-line review budget (size:exception).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a pre-welcome update prompt when updates are detected (with a “checking for updates” spinner).
  * Users can select **Update now**, **View changes**, or **Keep current version**.
  * Added keyboard shortcuts: **u**/**v**/**c**, plus **Enter** to confirm the highlighted option.

* **Bug Fixes**
  * Prevents duplicate upgrades when “Update now” is triggered repeatedly.
  * If release notes can’t be opened in a browser, a fallback message shows the link.
  * Back/Esc now returns from the prompt to the welcome screen.

* **Tests**
  * Expanded UI, navigation, input, browser-fallback, and two-step upgrade flow coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->