### PR TITLE
docs(sdd): add update-experience SDD artifacts

### DIFF
--- a/openspec/changes/update-experience/design.md
+++ b/openspec/changes/update-experience/design.md
@@ -1,0 +1,125 @@
+# Design: Update Experience Overhaul
+
+## Technical Approach
+
+Layer the change onto existing modules without new packages. State store (`internal/state`) gains two additive fields backing cooldown + deferred sync. The update check (`internal/update`) gains a TTL gate and an async advisory fetch. The TUI (`internal/tui/model.go`) gains one pre-Welcome screen state. The CLI self-update (`internal/app/selfupdate.go`) makes the existing TTY-aware prompt the default and converges on close-and-reopen. The upgrade executor (`internal/update/upgrade`, `internal/components/engram/download.go`) starts honoring `GENTLE_AI_CHANNEL`. All artifacts are informational-only — no version gate anywhere.
+
+## Architecture Decisions
+
+### Decision: TUI pre-Welcome prompt as a new Screen state
+
+**Choice**: Add `ScreenUpdatePrompt`. `Init` (model.go:602) keeps firing `update.CheckAll`; when `UpdateCheckResultMsg` arrives with `HasUpdates`, set `Screen = ScreenUpdatePrompt` BEFORE Welcome. Render lists current→latest, three key actions: `u`=update (run `UpgradeFn` for gentle-ai then `tea.Quit`), `c`/Enter=keep (transition to `ScreenWelcome`), `v`=view changes (open `UpdateResults[i].ReleaseURL`, types.go:68, via an `openURLFn` command). If no update, go straight to Welcome (current behavior, model.go:851). The banner at model.go:852 stays as a fallback for the keep path.
+
+**Alternatives considered**: Overlay/modal on Welcome; a bubbletea sub-model.
+**Rationale**: The codebase models every screen as a `Screen` enum with a `View()` switch (model.go:848). A new enum value is the idiomatic, lowest-risk fit. Bubbletea note: the screen renders only after the async check resolves, so a brief Welcome-less spinner frame may show; reuse the existing `UpdateCheckDone` guard to render a "checking…" state until results land.
+
+### Decision: Converge both OSes on close-and-reopen
+
+**Choice**: After a successful gentle-ai self-upgrade, ALWAYS print "Updated to vX — restart gentle-ai to use the new version." and return (no re-exec) on BOTH Unix and Windows. Drop the Unix `reExec` branch in `restartAfterGentleAIUpgrade` (selfupdate.go:153-184). TUI "update" path runs the upgrade then `tea.Quit`.
+
+**Alternatives considered**: Keep Unix re-exec (status quo); OS-conditional behavior.
+**Rationale**: Locked decision. Re-exec is invisible on Unix but impossible on Windows (binary lock) — divergent UX and divergent test surface. One close-and-reopen path is consistent, sidesteps the Windows lock, and the copy makes the exit non-surprising. Tradeoff: Unix users lose seamless restart; mitigated by one clear line of copy.
+
+### Decision: CLI prompt is default, gated by TTY not env
+
+**Choice**: Remove the `envConfirmUpdate` gate (selfupdate.go:29, 110-116). Always call `promptFn` before applying. `defaultPromptForUpdate` already declines when stdin is not a TTY (selfupdate.go:40-41) — that becomes the CI/non-interactive fallback (no update applied, no prompt). Add a `--yes` flag and honor existing `GENTLE_AI_NO_SELF_UPDATE=1` opt-out; keep `GENTLE_AI_SELF_UPDATE_DONE` loop guard.
+
+**Alternatives considered**: Keep env gate but default it on; prompt always regardless of TTY.
+**Rationale**: TTY detection already exists and is the correct non-interactive signal. Prompting a pipe would hang CI. `--yes` covers scripted opt-in; env opt-out preserves existing escape hatch.
+
+### Decision: Update-check cooldown = 6h TTL in state.json
+
+**Choice**: Add `LastUpdateCheck time.Time` (`json:"last_update_check,omitempty"`) to `InstallState` (state.go:31). Before `CheckAll` in TUI `Init` (model.go:609) and CLI `selfUpdate` (selfupdate.go:94), skip the network check if `now - LastUpdateCheck < 6h`. Write `LastUpdateCheck = now` ONLY on a successful check (not on error/rate-limit), so failures don't poison the window. Cache the last successful `[]UpdateResult` is out of scope; on cooldown skip we simply suppress the check and show no banner that launch.
+
+**Alternatives considered**: 1h (too chatty), 24h (misses same-day engram bumps), caching results too.
+**Rationale**: 6h balances freshness against GitHub rate limits for users who launch many times per day. `omitempty` + zero-value `time.Time` means old state files (no field) always check — safe back-compat. Refresh-on-success-only is the explicit anti-poison rule from the proposal.
+
+### Decision: pending_sync flag drives deferred sync after self-upgrade
+
+**Choice**: Add `PendingSync bool` (`json:"pending_sync,omitempty"`). Set it true in the self-upgrade success path (selfupdate.go ~141, before printing restart copy) and in TUI "Upgrade + Sync" when a gentle-ai self-upgrade occurred. On next launch, early in `app.go` Run (after `state.Read`, app.go:127), if `PendingSync`, the NEW binary runs `cli.RunSync` then writes the flag false. Failure: log a warning, leave the flag set so it retries next launch (idempotent sync).
+
+**Alternatives considered**: Re-exec then sync inline (status quo gap); a separate sentinel file.
+**Rationale**: state.json is already read at launch (app.go:127) — one extra bool, no new I/O surface. Leaving the flag on failure makes recovery automatic. Sync is idempotent (sync.go re-sync is a no-op when current), so retry is safe.
+
+### Decision: Advisory manifest = single JSON release asset, async, fail-open
+
+**Choice**: Host `advisory.json` as a release asset on the gentle-ai repo's `latest` release (stable, owner-controlled, CDN-backed, no extra infra): `https://github.com/Gentleman-Programming/gentle-ai/releases/latest/download/advisory.json`. Schema: `{"message": string, "severity": "info"|"warn", "url": string}` — all optional, informational only. Fetch with a 2s timeout in a background goroutine kicked off alongside `CheckAll`; on any error, return empty (fail-open, no blocking). Display the message after the update prompt / on Welcome; never gate.
+
+**Alternatives considered**: GitHub Pages (extra setup, another moving part), raw repo file (tied to a branch ref, no CDN), gist (low discoverability, easy to lose).
+**Rationale**: A release asset is the most stable owner-controlled option for a solo maintainer — same trust boundary as releases, CDN latency, editable by re-uploading the asset without a code change. 2s timeout + fail-open guarantees zero added launch latency on a slow/absent endpoint.
+
+### Decision: Channel-honoring engram upgrade
+
+**Choice**: Thread channel into the engram download. `cli.ResolveInstallChannel` already exists (channel.go:18). Add a `version`/`ref` param to `engram.DownloadLatestBinary` (download.go:49): stable → `versions.EngramCore` pin (current behavior, download.go:54); beta → `@main` ref. The executor (`strategy.go:399`, `engramBinaryUpgrade` 491-503) resolves channel via `ResolveInstallChannel("")` and passes it through. This fills the gap the comment at download.go:52-54 admits but never implements.
+
+**Alternatives considered**: Read env directly inside download.go (bypasses the existing resolver), separate beta downloader.
+**Rationale**: `ResolveInstallChannel` is the single source of truth for channel; reuse it rather than re-parsing the env. The drop point is precisely `engramBinaryUpgrade`, which today ignores channel entirely.
+
+### Decision: 7-slice order confirmed, TUI prompt stands alone
+
+**Choice**: Keep proposal order: (2) cooldown → (3) channel → (4) pending_sync → (5) CLI prompt → (6) TUI prompt → (7) manifest. Slices 2-5,7 each fit under 400 lines. Slice 6 (TUI pre-Welcome screen + render + key handling + tests) is the one likely to exceed 400 lines → its own PR, no other slice bundled.
+
+**Rationale**: Cooldown adds the state field both later slices reuse, so it goes first. Channel and pending_sync are small, independent executor/state changes. TUI carries the most surface (new screen, view, input, tests) and is isolated to keep reviewer load bounded.
+
+## Data Flow
+
+    launch ──→ state.Read ──→ PendingSync? ──→ RunSync ──→ clear flag
+                  │
+                  └─ now - LastUpdateCheck < 6h? ── yes ──→ skip check
+                                 │ no
+                                 ▼
+                     CheckAll ─┬─→ UpdateResult{ReleaseURL} ─→ prompt (TUI screen / CLI [Y/n])
+                               └─→ advisory.json (2s, fail-open) ─→ message
+                     on success: LastUpdateCheck = now
+                     update chosen ─→ upgradeExecute(channel) ─→ set PendingSync ─→ close
+
+## File Changes
+
+| File | Action | Description |
+|------|--------|-------------|
+| `internal/state/state.go` | Modify | Add `LastUpdateCheck time.Time`, `PendingSync bool` (omitempty); carry both in `MergeAgents` |
+| `internal/update/check.go` | Modify | TTL gate helper; refresh-on-success timestamp write |
+| `internal/update/advisory.go` | Create | `FetchAdvisory(ctx)` — 2s timeout, fail-open, `Advisory{Message,Severity,URL}` |
+| `internal/tui/model.go` | Modify | `ScreenUpdatePrompt` enum, View case, key handling, gate `CheckAll` on cooldown |
+| `internal/tui/screens/update_prompt.go` | Create | Render pre-Welcome prompt (update / view-changes / keep) |
+| `internal/app/selfupdate.go` | Modify | Drop env gate; prompt default; `--yes`; converge restart copy (no re-exec); set `PendingSync` |
+| `internal/app/app.go` | Modify | Deferred-sync check after `state.Read`; advisory display |
+| `internal/update/upgrade/strategy.go` | Modify | Resolve + pass channel into `engramBinaryUpgrade` |
+| `internal/components/engram/download.go` | Modify | Accept channel/ref; beta → `@main`, stable → pin |
+
+## Interfaces / Contracts
+
+```go
+// state.InstallState additions (back-compatible, omitempty)
+LastUpdateCheck time.Time `json:"last_update_check,omitempty"`
+PendingSync     bool      `json:"pending_sync,omitempty"`
+
+// advisory.json (release asset) — all fields optional, informational only
+type Advisory struct {
+    Message  string `json:"message"`
+    Severity string `json:"severity"` // "info" | "warn"
+    URL      string `json:"url"`
+}
+func FetchAdvisory(ctx context.Context) (Advisory, bool) // false = fail-open
+
+// engram download gains channel awareness
+func DownloadLatestBinary(profile system.PlatformProfile, channel cli.InstallChannel) (string, error)
+```
+
+## Testing Strategy
+
+| Layer | What to Test | Approach |
+|-------|-------------|----------|
+| Unit | Cooldown TTL gate; refresh-on-success-only | Inject clock + state; assert no check inside window, timestamp untouched on error |
+| Unit | Prompt default + TTY decline + `--yes`; channel routing (beta→@main) | Swap `promptFn`/stdin; table-test `ResolveInstallChannel` → ref |
+| Unit | pending_sync set/clear/retry-on-failure; advisory fail-open on timeout/4xx | Fake state writer; httptest server returning slow/500 |
+| Integration | TUI `ScreenUpdatePrompt` transitions (update/keep/view) | bubbletea model test (model_test.go pattern) |
+
+## Migration / Rollout
+
+All state fields are additive with `omitempty`; old binaries ignore unknown JSON, new binaries treat missing fields as zero (always-check / no-pending-sync). No data migration. Manifest is fail-open: not publishing `advisory.json` yields no behavior change. Each slice ships as an independent, revertible PR per the proposal rollback plan.
+
+## Open Questions
+
+- [ ] Confirm `advisory.json` lives on gentle-ai `latest` release vs. a dedicated `advisory` tag (latency identical; tag avoids re-upload per release).
+- [ ] TUI "view changes": open in browser (`openURLFn`) vs. print URL and stay on prompt — confirm with maintainer UX preference.

--- a/openspec/changes/update-experience/proposal.md
+++ b/openspec/changes/update-experience/proposal.md
@@ -1,0 +1,93 @@
+# Proposal: Update Experience Overhaul
+
+## Intent
+
+The gentle-ai update/upgrade/sync flow is unreliable and passive: engram bumps force a gentle-ai release, TUI users get only a silent banner, "Upgrade + Sync" doesn't fully sync, the upgrade executor ignores the active channel, and every launch hits the GitHub API with no cooldown. This change makes updates reach users without a gentle-ai release, prompts users at launch (Codex-style), and fixes the three reliability gaps — while staying informational-only (no forced-update gate).
+
+## Scope
+
+### In Scope
+1. **Engram always-latest** (slice 1, DONE — branch `fix/engram-always-latest`, commit `36aee12`): un-pin engram-core + gentle-engram; runtime fetch filters tags to `^v[0-9]+\.[0-9]+\.[0-9]+$`; unifies download with update-check source of truth; prerelease/rc tags stay invisible until a clean `vX.Y.Z` is cut.
+2. **Codex-style startup prompt**: when an update is available at launch, prompt every launch (no snooze/skip state). "Update" applies then CLOSES the app (user reopens; sidesteps Windows binary lock). Prompt shows "view changes" (release notes link) and "keep current version". Applies to TUI (new pre-Welcome screen) AND CLI (make the existing `[y/N]` the default, drop the `GENTLE_AI_CONFIRM_UPDATE` env gate).
+3. **Remote advisory manifest (informational only)**: small JSON fetched at launch carrying an optional message ("important update, run X"). No version gate, no forced update. Only lever to reach already-deployed clients for FUTURE breaking changes; cannot help clients that predate it.
+4. **Reliability fixes**: (a) `gentle-ai upgrade` honors `GENTLE_AI_CHANNEL` (beta → `@main`, stable → latest release); (b) "Upgrade + Sync" completes after a self-upgrade (flag so the NEW binary auto-runs sync on next launch); (c) update-check cooldown caches the check so launches don't hammer the GitHub API (today it fails silently on rate-limit).
+
+### Out of Scope (Non-goals)
+- Minimum-supported-version / forced-update gate (manifest is info-only).
+- Rewriting the install pipeline or sync engine wholesale.
+- Snooze / skip-this-version state (cadence is ask-every-launch by decision).
+
+## Capabilities
+
+### New Capabilities
+- `update-prompt`: launch-time update prompt (TUI pre-Welcome screen + CLI default prompt) with update / view-changes / keep-current actions, ask-every-launch cadence, apply-then-close behavior.
+- `advisory-manifest`: launch fetch of a remote informational JSON message; no version gating.
+- `update-check-cache`: cooldown cache for the update check persisted in state.
+
+### Modified Capabilities
+- `self-update`: CLI prompt becomes default (env gate removed); upgrade executor honors `GENTLE_AI_CHANNEL`.
+- `upgrade-sync`: sync completes across a self-upgrade via a deferred-sync flag.
+- `version-resolution`: engram download filters to stable `vX.Y.Z` tags (slice 1, done).
+
+## Approach
+
+- **State store**: add fields to `InstallState` (`~/.gentle-ai/state.json`): `last_update_check`, `pending_sync` (deferred-sync flag). No skip/snooze fields by decision.
+- **Cooldown**: gate `update.CheckAll` (TUI `Init`) and CLI check behind a TTL read from `last_update_check`; refresh on success only, so rate-limit failures don't poison the cache.
+- **Prompt**: TUI gains a pre-Welcome model state that renders when an update is available; CLI `selfUpdate` always prompts. "Update" applies + exits (Unix and Windows converge on close-and-reopen).
+- **Channel**: upgrade executor reads `GENTLE_AI_CHANNEL` and routes beta to `@main`, stable to latest release.
+- **Deferred sync**: on self-upgrade, set `pending_sync`; new binary runs sync on next launch then clears the flag.
+- **Manifest**: fetch a small JSON at launch (short timeout, fail-open), display its optional message; never block or gate on it.
+
+## Affected Areas
+
+| Area | Impact | Description |
+|------|--------|-------------|
+| `internal/state/state.go` | Modified | Add `last_update_check`, `pending_sync` fields |
+| `internal/update/check.go`, `github.go` | Modified | Cooldown TTL; manifest fetch |
+| `internal/tui/model.go` | Modified | Pre-Welcome prompt state; gate `CheckAll` on cooldown |
+| `internal/app/selfupdate.go` | Modified | Default prompt; remove env gate; apply-then-close |
+| `internal/cli/upgrade_sync.go` | Modified | Complete sync across self-upgrade via `pending_sync` |
+| upgrade executor (`strategy.go` area) | Modified | Honor `GENTLE_AI_CHANNEL` |
+| `internal/app/version.go`, `versions.go` | Done | Engram un-pin + stable-tag filter (slice 1) |
+
+## Proposed Slicing (reviewable units, ≤400 lines each where possible)
+
+1. **Engram un-pin** — DONE (branch `fix/engram-always-latest`).
+2. **Update-check cooldown** — state fields + TTL gate; smallest, unblocks the rest.
+3. **Channel fix** — upgrade executor honors `GENTLE_AI_CHANNEL`.
+4. **Upgrade + Sync fix** — `pending_sync` flag + deferred sync on next launch.
+5. **CLI prompt default** — drop env gate, make prompt default, apply-then-close.
+6. **TUI startup prompt** — pre-Welcome screen (largest UI slice; may need its own PR).
+7. **Advisory manifest** — fetch + display informational message.
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| Network dependency on upgrade (fetch latest at runtime) | Med | Short timeout, fail-open to current binary; install script is the escape hatch |
+| No buffer for a bad stable release (always-latest) | Med | Staging lever: cut prerelease/rc tags (invisible) until a clean `vX.Y.Z` is ready |
+| Prompt fatigue from ask-every-launch | Med | Predictable cadence; "keep current" is one keystroke; revisit snooze later if needed |
+| Manifest can't reach pre-manifest clients | High (inherent) | Acknowledged; one-time out-of-band advertisement covers the transition |
+| Apply-then-close surprises users mid-session | Low | Clear prompt copy; matches today's Windows behavior |
+
+## Rollback Plan
+
+Each slice is an independent PR. Revert per slice. Slice 1 (engram un-pin) rolls back by restoring the pin in `versions.go`. Cooldown/state-field additions are additive and backward-compatible (older binaries ignore unknown JSON fields). The manifest is fail-open, so disabling its endpoint reverts behavior with no client change.
+
+## Dependencies
+
+- A hosted remote endpoint for the advisory manifest JSON (slice 7).
+- One transition gentle-ai release shipping this work (bootstrap, below).
+
+## Bootstrap / Migration Plan
+
+New behavior only exists in clients that already updated (chicken-and-egg). CLI users mostly auto-migrate — `selfUpdate` of the gentle-ai binary works and is unaffected by the engram pin. TUI-only users see only a passive banner today and must act once manually. The version-independent escape hatch is the install script (`irm/curl … | iex/sh`), which always pulls latest regardless of installed logic. Plan: cut ONE transition gentle-ai release with this work, advertise the one-time manual update out-of-band (Discord / README / release notes); from then on the new prompt + manifest carry the load. Transition cost is exactly one more gentle-ai release; afterward engram releases reach users via runtime fetch with zero gentle-ai release.
+
+## Success Criteria
+
+- [ ] An engram bump reaches users with ZERO gentle-ai release (runtime fetch).
+- [ ] User is prompted at launch (TUI and CLI) when an update is available.
+- [ ] "Upgrade + Sync" completes in one action, including across a self-upgrade.
+- [ ] `gentle-ai upgrade` installs from the channel-correct source (beta → `@main`).
+- [ ] Launches do not hit the GitHub API within the cooldown window; rate-limit no longer silently suppresses the banner.
+- [ ] Advisory manifest message displays at launch without gating or forcing updates.

--- a/openspec/changes/update-experience/specs/advisory-manifest/spec.md
+++ b/openspec/changes/update-experience/specs/advisory-manifest/spec.md
@@ -1,0 +1,72 @@
+# Advisory Manifest Specification
+
+> **Slice**: 7 (Advisory manifest)
+> **Type**: New Capability
+
+## Purpose
+
+At launch the system MAY fetch a small remote JSON payload carrying an optional operator message. If a message is present, it is displayed to the user as informational text. The manifest MUST NOT gate on versions, block launch, or force any action.
+
+## Requirements
+
+### Requirement: Manifest Fetch at Launch
+
+The system SHOULD attempt to fetch the advisory manifest JSON from the configured remote endpoint at launch.
+
+The fetch MUST use a short timeout. If the fetch fails, times out, or returns an error status, the system MUST proceed normally without displaying any error to the user (fail-open).
+
+#### Scenario: Manifest present with message
+
+- GIVEN the advisory manifest endpoint is reachable
+- AND the manifest JSON contains a non-empty `message` field
+- WHEN the binary launches
+- THEN the system fetches the manifest
+- AND the message is displayed to the user (TUI or CLI) as informational text
+- AND the binary continues to its normal entry point without any gate or block
+
+#### Scenario: Manifest present but message is empty or absent
+
+- GIVEN the advisory manifest endpoint is reachable
+- AND the manifest JSON has no `message` field, or the field is an empty string
+- WHEN the binary launches
+- THEN the system fetches the manifest
+- AND no message is displayed
+- AND launch proceeds normally
+
+#### Scenario: Manifest endpoint unreachable or returns non-200
+
+- GIVEN the advisory manifest endpoint is down, returns a non-200 status, or the request times out
+- WHEN the binary launches
+- THEN the system silently ignores the failure
+- AND no error is shown to the user
+- AND launch proceeds normally
+
+### Requirement: Manifest JSON — Malformed Payload
+
+The system MUST gracefully handle any malformed or unexpected JSON from the manifest endpoint.
+
+#### Scenario: Malformed JSON response
+
+- GIVEN the manifest endpoint returns a response that is not valid JSON
+- WHEN the binary launches and attempts to parse the manifest
+- THEN the parse error is silently discarded
+- AND no message is displayed
+- AND launch proceeds normally
+
+#### Scenario: Unexpected JSON schema
+
+- GIVEN the manifest endpoint returns valid JSON but with an unrecognized schema (no expected fields)
+- WHEN the binary launches
+- THEN no message is displayed
+- AND launch proceeds normally
+
+### Requirement: No Version Gating
+
+The advisory manifest MUST NOT enforce a minimum or maximum version requirement. The manifest is informational only and MUST NOT prevent or delay launch for any reason.
+
+#### Scenario: Manifest contains version fields
+
+- GIVEN the manifest JSON contains version-related fields (e.g., `min_version`, `required_version`)
+- WHEN the binary processes the manifest
+- THEN those fields are ignored
+- AND the binary does not block or alter its launch based on version data in the manifest

--- a/openspec/changes/update-experience/specs/self-update/spec.md
+++ b/openspec/changes/update-experience/specs/self-update/spec.md
@@ -1,0 +1,83 @@
+# Delta for Self-Update
+
+> **Slice**: 3 (Channel fix) and 5 (CLI prompt default)
+> **Type**: Modified Capability
+
+## MODIFIED Requirements
+
+### Requirement: CLI Update Prompt Is Default
+
+The CLI self-update flow MUST present the `[Y/n]` update prompt unconditionally whenever an update is available.
+
+The system MUST NOT require the `GENTLE_AI_CONFIRM_UPDATE` environment variable to be set in order to show the prompt. That variable is removed.
+
+The default answer MUST be Y (update); pressing Enter without input MUST be treated as Y.
+
+(Previously: the `[y/N]` prompt was only shown when `GENTLE_AI_CONFIRM_UPDATE` was set; without it the upgrade proceeded non-interactively.)
+
+#### Scenario: Default prompt shown
+
+- GIVEN an update is available
+- AND the user invokes `gentle-ai upgrade` or a CLI path that triggers `selfUpdate`
+- WHEN `selfUpdate` runs
+- THEN a `[Y/n]` prompt is displayed with the available version and release notes link
+- AND `GENTLE_AI_CONFIRM_UPDATE` is not checked
+
+#### Scenario: User presses Enter (accepts default)
+
+- GIVEN the CLI update prompt is shown
+- WHEN the user presses Enter without entering a character
+- THEN the update is applied (default Y)
+- AND the process exits after the update completes
+
+#### Scenario: User explicitly accepts (Y)
+
+- GIVEN the CLI update prompt is shown
+- WHEN the user enters Y or y
+- THEN the update is applied
+- AND the process exits after the update completes
+
+#### Scenario: User declines (N)
+
+- GIVEN the CLI update prompt is shown
+- WHEN the user enters N or n
+- THEN the update is skipped
+- AND the CLI continues normally without applying any update
+
+### Requirement: Upgrade Executor Honors GENTLE_AI_CHANNEL
+
+The upgrade executor MUST read the `GENTLE_AI_CHANNEL` environment variable to determine the install source.
+
+When `GENTLE_AI_CHANNEL=beta`, the executor MUST install from `@main` (the main branch HEAD).
+
+When `GENTLE_AI_CHANNEL` is unset or set to any value other than `beta`, the executor MUST install from the latest stable release.
+
+(Previously: the upgrade executor ignored `GENTLE_AI_CHANNEL` and always installed from the latest stable release.)
+
+#### Scenario: Stable upgrade (default)
+
+- GIVEN `GENTLE_AI_CHANNEL` is unset
+- WHEN `gentle-ai upgrade` runs
+- THEN the executor installs the latest stable release
+- AND no beta or main-branch artifacts are used
+
+#### Scenario: Beta upgrade
+
+- GIVEN `GENTLE_AI_CHANNEL=beta`
+- WHEN `gentle-ai upgrade` runs
+- THEN the executor installs from `@main`
+- AND the installed binary reflects the main branch HEAD
+
+#### Scenario: Channel unset defaults to stable
+
+- GIVEN `GENTLE_AI_CHANNEL` is not set in the environment
+- WHEN `gentle-ai upgrade` runs
+- THEN the behavior is identical to stable upgrade
+- AND the latest stable release tag is the install source
+
+## REMOVED Requirements
+
+### Requirement: GENTLE_AI_CONFIRM_UPDATE Gate
+
+(Reason: The env-var gate prevented the interactive prompt from appearing by default. The new behavior shows the prompt unconditionally, making the gate redundant.)
+(Migration: Remove any shell profile exports of `GENTLE_AI_CONFIRM_UPDATE`. The prompt now appears without it. Existing scripts that set this variable will see no change in behavior — the variable is simply ignored.)

--- a/openspec/changes/update-experience/specs/update-check-cache/spec.md
+++ b/openspec/changes/update-experience/specs/update-check-cache/spec.md
@@ -1,0 +1,74 @@
+# Update Check Cache Specification
+
+> **Slice**: 2 (Update-check cooldown)
+> **Type**: New Capability
+
+## Purpose
+
+The system MUST cache the result of the GitHub update check so that repeated launches within a cooldown window do not hit the GitHub API. The cache is persisted in the state file. On a failed check the cache MUST NOT be updated, so a transient rate-limit or network error does not lock out future fresh checks.
+
+## Requirements
+
+### Requirement: Cooldown Gate on Update Check
+
+The system MUST skip the remote update check when the time elapsed since `last_update_check` is less than the configured cooldown TTL.
+
+The system MUST perform the remote update check when `last_update_check` is absent (first run) or when the cooldown TTL has elapsed.
+
+The system MUST update `last_update_check` in the state file only upon a successful check.
+
+#### Scenario: Cache fresh — no network call
+
+- GIVEN `last_update_check` is present in state
+- AND the elapsed time since `last_update_check` is less than the cooldown TTL
+- WHEN the binary launches and the update check runs
+- THEN no request is made to the GitHub API
+- AND the previously known update status is used
+
+#### Scenario: Cache stale — refresh from GitHub
+
+- GIVEN `last_update_check` is present in state
+- AND the elapsed time since `last_update_check` meets or exceeds the cooldown TTL
+- WHEN the binary launches and the update check runs
+- THEN a request is made to the GitHub API
+- AND on success `last_update_check` is updated to the current timestamp
+- AND the fresh update status is used
+
+#### Scenario: Cache missing — first run
+
+- GIVEN `last_update_check` is absent from state (new install or cleared state)
+- WHEN the binary launches and the update check runs
+- THEN a request is made to the GitHub API
+- AND on success `last_update_check` is set to the current timestamp
+
+### Requirement: Rate-Limit and Failure Resilience
+
+When the update check fails (rate-limit, network error, timeout), the system MUST NOT update `last_update_check`, MUST NOT display an error banner or crash, and MUST continue launch normally.
+
+#### Scenario: Rate-limited response
+
+- GIVEN the GitHub API returns a rate-limit error (HTTP 429 or equivalent)
+- WHEN the binary runs the update check
+- THEN `last_update_check` is NOT updated
+- AND no error is shown to the user
+- AND launch continues normally
+- AND the next launch will retry the check (cache is not poisoned)
+
+#### Scenario: Network error during check
+
+- GIVEN the update check request fails due to a network error or timeout
+- WHEN the binary runs the update check
+- THEN `last_update_check` is NOT updated
+- AND no error is shown to the user
+- AND launch continues normally
+
+### Requirement: State Persistence
+
+`last_update_check` MUST be persisted as a field in `~/.gentle-ai/state.json`. It MUST be a timestamp (RFC 3339 or Unix epoch). Older binaries that do not know this field MUST be able to load the state file without error (additive field, backward-compatible).
+
+#### Scenario: Older binary reads state with new field
+
+- GIVEN the state file contains a `last_update_check` field
+- WHEN an older binary (predating this change) loads the state file
+- THEN the older binary ignores the unknown field
+- AND it does not error or corrupt the state file

--- a/openspec/changes/update-experience/specs/update-prompt/spec.md
+++ b/openspec/changes/update-experience/specs/update-prompt/spec.md
@@ -1,0 +1,112 @@
+# Update Prompt Specification
+
+> **Slice**: 5 (CLI prompt default) and 6 (TUI startup prompt)
+> **Type**: New Capability
+
+## Purpose
+
+When an update is available at launch, the system MUST prompt the user before proceeding. The prompt appears on every launch where an update is detected (no snooze or skip state). The user can apply the update, view release notes, or continue with the current version.
+
+## Requirements
+
+### Requirement: Launch-Time Update Prompt — Presence
+
+The system MUST display an update prompt at launch whenever an update is available, regardless of how many times the user has previously seen or dismissed the prompt.
+
+The system MUST NOT show the prompt when no update is available.
+
+The system MUST NOT show the prompt when the update check failed or the system is offline (fail-open: launch proceeds normally).
+
+#### Scenario: Update available — TUI path
+
+- GIVEN the TUI is launched
+- AND an update is available (update check succeeded within cooldown)
+- WHEN the TUI initializes
+- THEN a pre-Welcome prompt screen is shown BEFORE the Welcome screen
+- AND the prompt displays the available version and three options: "Update", "View changes", and "Keep current version"
+
+#### Scenario: Update available — CLI path
+
+- GIVEN a CLI command is invoked that triggers `selfUpdate`
+- AND an update is available
+- WHEN `selfUpdate` runs
+- THEN the user is prompted with a `[Y/n]` prompt (default: Y) listing the available version
+- AND a "view changes" link to the release notes is shown alongside the prompt
+
+#### Scenario: No update available
+
+- GIVEN the binary is at the latest version
+- WHEN the TUI or CLI launches
+- THEN no update prompt is shown
+- AND launch proceeds directly to the normal entry point
+
+#### Scenario: Update check failed or offline
+
+- GIVEN the update check could not complete (network error, timeout, rate-limit)
+- WHEN the TUI or CLI launches
+- THEN no update prompt is shown
+- AND launch proceeds normally without error output
+
+### Requirement: Update Action — Apply Then Close
+
+When the user selects "Update", the system MUST apply the update and then close the current process. The user MUST reopen the binary to use the new version.
+
+This behavior MUST be consistent across Unix and Windows.
+
+#### Scenario: User selects "Update" (TUI)
+
+- GIVEN the TUI pre-Welcome update prompt is displayed
+- WHEN the user selects "Update"
+- THEN the update is downloaded and applied
+- AND the TUI process exits after the update completes
+- AND no further TUI screens are shown
+
+#### Scenario: User selects "Update" (CLI)
+
+- GIVEN the CLI update prompt is shown
+- WHEN the user enters Y or presses Enter
+- THEN the update is downloaded and applied
+- AND the CLI process exits after the update completes
+
+#### Scenario: User selects "Keep current version" (TUI)
+
+- GIVEN the TUI pre-Welcome update prompt is displayed
+- WHEN the user selects "Keep current version"
+- THEN the prompt is dismissed
+- AND the TUI proceeds to the normal Welcome screen
+
+#### Scenario: User declines update (CLI)
+
+- GIVEN the CLI update prompt is shown
+- WHEN the user enters N
+- THEN the update is skipped
+- AND the CLI command proceeds normally
+
+### Requirement: View Changes Link
+
+The prompt MUST expose a link to the release notes for the available version.
+
+#### Scenario: View changes — TUI
+
+- GIVEN the TUI pre-Welcome update prompt is displayed
+- WHEN the user selects "View changes"
+- THEN the release notes URL for the available version is opened in the default browser (or displayed as a URL if opening is not possible)
+- AND the prompt remains visible for the user to then choose "Update" or "Keep current version"
+
+#### Scenario: View changes — CLI
+
+- GIVEN the CLI update prompt is shown
+- WHEN the user views the prompt
+- THEN a release notes URL is visible as part of the prompt text
+- AND the user can still choose to update or decline
+
+### Requirement: Ask-Every-Launch Cadence
+
+The system MUST NOT persist any "skip this version" or "remind me later" state. Every launch where an update is detected MUST show the prompt.
+
+#### Scenario: Repeated launches with pending update
+
+- GIVEN an update is available
+- AND the user has previously selected "Keep current version"
+- WHEN the user launches the binary again
+- THEN the update prompt is shown again

--- a/openspec/changes/update-experience/specs/upgrade-channel/spec.md
+++ b/openspec/changes/update-experience/specs/upgrade-channel/spec.md
@@ -1,0 +1,50 @@
+# Delta for Upgrade Channel
+
+> **Slice**: 3 (Channel fix)
+> **Type**: Modified Capability — upgrade executor channel routing
+
+## Purpose
+
+`gentle-ai upgrade` MUST honor the `GENTLE_AI_CHANNEL` environment variable when choosing the install source. This spec covers the routing logic in isolation from the broader self-update prompt change (covered in the self-update spec).
+
+## MODIFIED Requirements
+
+### Requirement: Channel-Aware Upgrade Routing
+
+The upgrade executor MUST inspect `GENTLE_AI_CHANNEL` at execution time and route the install to the channel-correct source.
+
+| Channel value | Install source |
+|---------------|----------------|
+| `beta`        | `@main` (HEAD of main branch) |
+| unset / other | Latest stable release tag |
+
+The executor MUST NOT default to stable silently when `GENTLE_AI_CHANNEL` is set to an unrecognized value — unrecognized values SHOULD be treated as stable and MAY surface a warning.
+
+(Previously: the upgrade executor always installed from the latest stable release regardless of `GENTLE_AI_CHANNEL`.)
+
+#### Scenario: Stable upgrade (channel unset)
+
+- GIVEN `GENTLE_AI_CHANNEL` is not set in the process environment
+- WHEN `gentle-ai upgrade` is invoked
+- THEN the executor selects the latest stable release as the install source
+- AND installs the stable binary
+
+#### Scenario: Beta upgrade (channel = beta)
+
+- GIVEN `GENTLE_AI_CHANNEL=beta` is set in the process environment
+- WHEN `gentle-ai upgrade` is invoked
+- THEN the executor selects `@main` as the install source
+- AND installs the HEAD of the main branch
+
+#### Scenario: Unknown channel value
+
+- GIVEN `GENTLE_AI_CHANNEL` is set to an unrecognized value (e.g., `nightly`)
+- WHEN `gentle-ai upgrade` is invoked
+- THEN the executor falls back to stable behavior
+- AND MAY emit a warning that the channel value is unrecognized
+
+#### Scenario: Channel value is empty string
+
+- GIVEN `GENTLE_AI_CHANNEL` is set to an empty string (`""`)
+- WHEN `gentle-ai upgrade` is invoked
+- THEN the executor treats this as unset and selects the stable channel

--- a/openspec/changes/update-experience/specs/upgrade-sync/spec.md
+++ b/openspec/changes/update-experience/specs/upgrade-sync/spec.md
@@ -1,0 +1,53 @@
+# Delta for Upgrade Sync
+
+> **Slice**: 4 (Upgrade + Sync fix)
+> **Type**: Modified Capability
+
+## MODIFIED Requirements
+
+### Requirement: Sync Completes Across a Self-Upgrade
+
+When "Upgrade + Sync" is invoked and the upgrade step replaces the current binary (self-upgrade), the sync step MUST still complete. If the current process cannot run sync after replacing itself, the system MUST set a `pending_sync` flag in the state file so that the newly installed binary runs sync automatically on its next launch.
+
+The `pending_sync` flag MUST be cleared after the deferred sync completes successfully.
+
+(Previously: "Upgrade + Sync" silently skipped the sync step after a self-upgrade, leaving the installation in a partially-updated state.)
+
+#### Scenario: Upgrade without self-upgrade (inline sync)
+
+- GIVEN the user invokes "Upgrade + Sync"
+- AND the upgrade step does NOT replace the currently-running binary (e.g., only engram or other components are updated)
+- WHEN the upgrade step completes
+- THEN sync runs in the same process immediately after the upgrade
+- AND no `pending_sync` flag is set
+
+#### Scenario: Upgrade WITH self-upgrade — sync deferred
+
+- GIVEN the user invokes "Upgrade + Sync"
+- AND the upgrade step replaces the currently-running binary (self-upgrade)
+- WHEN the upgrade step applies the new binary
+- THEN `pending_sync = true` is written to `~/.gentle-ai/state.json` before the process exits
+- AND the current process exits (or closes) after recording the flag
+
+#### Scenario: Deferred sync runs on next launch
+
+- GIVEN `pending_sync = true` is present in state
+- WHEN the user next launches the binary (any entry point)
+- THEN sync runs automatically at startup before the normal entry point proceeds
+- AND after sync completes successfully `pending_sync` is cleared (set to false or removed)
+- AND the user sees confirmation that sync completed
+
+#### Scenario: Pending flag cleared after sync
+
+- GIVEN sync was deferred and ran on the next launch
+- WHEN the sync step finishes without error
+- THEN `pending_sync` is removed or set to false in state
+- AND subsequent launches do NOT re-run sync
+
+#### Scenario: Deferred sync fails
+
+- GIVEN `pending_sync = true` is present in state
+- AND sync fails during the next launch
+- WHEN the failure occurs
+- THEN an error is surfaced to the user (not silently swallowed)
+- AND `pending_sync` remains true so that the next launch retries

--- a/openspec/changes/update-experience/specs/version-resolution/spec.md
+++ b/openspec/changes/update-experience/specs/version-resolution/spec.md
@@ -1,0 +1,54 @@
+# Delta for Version Resolution
+
+> **Slice**: 1 (Engram un-pin — DONE, branch `fix/engram-always-latest`, commit `36aee12`)
+> **Type**: Modified Capability
+
+## MODIFIED Requirements
+
+### Requirement: Engram Always-Latest Resolution
+
+The system MUST resolve engram-core and gentle-engram at runtime by fetching the list of available tags from the upstream repository and selecting the highest version that matches the stable tag pattern `^v\d+\.\d+\.\d+$`.
+
+The system MUST NOT hard-pin engram-core or gentle-engram to a specific version at compile time.
+
+The system MUST use the same tag-filtered result as both the download source and the update-check source of truth so the two are always consistent.
+
+Prerelease, release-candidate, and shared-stream tags (e.g., `gentle-engram/v*`, `pi/*`) MUST be invisible to the resolver — they MUST NOT be selected even if they sort higher than the latest stable tag.
+
+(Previously: engram-core and gentle-engram were pinned to a fixed version in `versions.go`; updating either required a new gentle-ai release.)
+
+#### Scenario: Stable tags present
+
+- GIVEN the upstream tag list contains one or more tags matching `^v\d+\.\d+\.\d+$`
+- WHEN the resolver runs the tag filter
+- THEN the highest semantically-ordered stable tag is selected as the version to install
+- AND that same version is used for the update-check comparison
+
+#### Scenario: Mixed tags — stable and prerelease present
+
+- GIVEN the upstream tag list contains both stable tags (e.g., `v1.2.0`) and prerelease tags (e.g., `v1.3.0-rc1`, `v2.0.0-beta`)
+- WHEN the resolver runs the tag filter
+- THEN only tags matching `^v\d+\.\d+\.\d+$` are considered
+- AND the highest stable tag is selected
+- AND prerelease tags are ignored even if they sort higher
+
+#### Scenario: Shared-stream tags must not be selected
+
+- GIVEN the upstream tag list contains tags from shared streams (e.g., `gentle-engram/v1.0.0`, `pi/v1.0.0`)
+- WHEN the resolver runs the tag filter
+- THEN those tags do not match `^v\d+\.\d+\.\d+$` and are excluded
+- AND only clean `vX.Y.Z` tags are eligible
+
+#### Scenario: No stable tags available
+
+- GIVEN the upstream tag list contains no tags matching `^v\d+\.\d+\.\d+$`
+- WHEN the resolver runs
+- THEN the resolver returns an appropriate error or falls back to the current installed version
+- AND no download or update is attempted
+
+#### Scenario: gentle-engram `@latest` behavior
+
+- GIVEN gentle-engram is configured to resolve at `@latest`
+- WHEN the resolver fetches tags and applies the stable filter
+- THEN `@latest` resolves to the highest tag matching `^v\d+\.\d+\.\d+$`
+- AND the resolved version is used for both install and update-check

--- a/openspec/changes/update-experience/tasks.md
+++ b/openspec/changes/update-experience/tasks.md
@@ -1,0 +1,169 @@
+# Tasks: Update Experience Overhaul (Slices 2–7)
+
+> Slice 1 (un-pin engram) is DONE. This file covers slices 2–7.
+> STRICT TDD IS ACTIVE: each slice follows RED → GREEN → REFACTOR order.
+> Test runner: `go test ./...`
+
+---
+
+## Review Workload Forecast
+
+| Field | Value |
+|-------|-------|
+| Estimated changed lines | ~1 000–1 400 total (slices 2–7) |
+| 400-line budget risk | High (total); per-slice varies — see per-slice notes |
+| Chained PRs recommended | Yes |
+| Suggested split | PR 2 → PR 3 → PR 4 → PR 5 → PR 6 → PR 7 (each slice = one PR) |
+| Delivery strategy | ask-on-risk |
+| Chain strategy | pending (ask before apply) |
+
+Decision needed before apply: Yes
+Chained PRs recommended: Yes
+Chain strategy: pending
+400-line budget risk: High
+
+### Suggested Work Units
+
+| Unit | Slice | Goal | Likely PR | Est. lines | Budget risk |
+|------|-------|------|-----------|-----------|-------------|
+| 2 | 2 | Update-check cooldown (6h TTL, state.json) | PR 2 | ~120 | Low |
+| 3 | 3 | Channel-honoring upgrade + split engram downloader | PR 3 | ~150 | Low |
+| 4 | 4 | Upgrade+sync deferred via pending_sync flag | PR 4 | ~130 | Low |
+| 5 | 5 | CLI prompt default + apply-then-close convergence | PR 5 | ~160 | Low |
+| 6 | 6 | TUI pre-Welcome update prompt screen | PR 6 | ~350–450 | **High** — stands alone, own PR mandatory |
+| 7 | 7 | Advisory manifest (informational, advisory tag) | PR 7 | ~130 | Low |
+
+---
+
+## Slice 2 — Update-Check Cooldown
+
+**Spec**: update-check-cache | **Files**: `internal/state/state.go`, `internal/update/check.go`, `internal/app/selfupdate.go`, `internal/tui/model.go`
+
+### Phase 1 — Red (failing tests)
+- [ ] 2.1 `internal/state/state_test.go` — add test: `InstallState` round-trips `LastUpdateCheck` via `Write`/`Read`; field absent in old JSON is deserialized as zero value (back-compat scenario from spec)
+- [ ] 2.2 `internal/update/check_test.go` — add test: `CheckAllWithCooldown` skips GitHub call when `now − LastUpdateCheck < 6h`; makes call and updates timestamp when elapsed ≥ 6h; does NOT update timestamp on fetch error
+
+### Phase 2 — Green (implementation)
+- [ ] 2.3 `internal/state/state.go` — add `LastUpdateCheck time.Time \`json:"last_update_check,omitempty"\`` to `InstallState`; carry field through `MergeAgents` return struct
+- [ ] 2.4 `internal/update/check.go` — add `CheckAllWithCooldown(ctx, version, profile, homeDir, ttl)` that reads state, compares elapsed time, calls `CheckAll` if stale, writes `LastUpdateCheck` on success only
+- [ ] 2.5 `internal/app/selfupdate.go` — replace `updateCheckFiltered` call at line ~94 with cooldown-aware variant; pass `homeDir` and `6*time.Hour` TTL
+- [ ] 2.6 `internal/tui/model.go` `Init()` — wrap `update.CheckAll` with cooldown gate using home dir from `os.UserHomeDir()`; accept zero-value (missing field) as always-check (back-compat)
+
+### Phase 3 — Refactor
+- [ ] 2.7 Extract clock injection (`nowFn func() time.Time`) into `CheckAllWithCooldown` for test determinism; update tests (2.2) to use injected clock
+
+---
+
+## Slice 3 — Channel-Honoring Upgrade
+
+**Spec**: upgrade-channel, self-update | **Files**: `internal/update/upgrade/strategy.go`, `internal/components/engram/download.go`, `internal/cli/channel.go`
+
+### Phase 1 — Red (failing tests)
+- [ ] 3.1 `internal/update/upgrade/strategy_test.go` — add test: `engramBinaryUpgrade` called with `ChannelBeta` passes `@main` ref to `engramDownloadFn`; called with `ChannelStable` passes pinned version ref
+- [ ] 3.2 `internal/components/engram/download_test.go` (new or existing) — add test: `DownloadLatestBinary(profile, ChannelBeta)` uses `@main`; `DownloadLatestBinary(profile, ChannelStable)` uses `versions.EngramCore`
+
+### Phase 2 — Green (implementation)
+- [ ] 3.3 `internal/components/engram/download.go` — add `channel cli.InstallChannel` param to `DownloadLatestBinary`; when `channel.IsBeta()` use `@main`, else `versions.EngramCore` (fills admitted gap at line ~52–54)
+- [ ] 3.4 `internal/update/upgrade/strategy.go` — update `engramDownloadFn` signature to accept channel; `engramBinaryUpgrade` reads `GENTLE_AI_CHANNEL` via `cli.ResolveInstallChannel` and passes channel to `engramDownloadFn`
+- [ ] 3.5 `internal/update/upgrade/strategy.go` — update `engramDownloadFn` package-level var declaration to match new signature; update all callers in test stubs
+
+### Phase 3 — Refactor
+- [ ] 3.6 Verify `cli.ResolveInstallChannel` handles empty-string and unknown values per spec (fall back to stable, optionally warn); add channel_test.go case for unknown value if not already covered
+
+---
+
+## Slice 4 — Upgrade+Sync Deferred via `pending_sync`
+
+**Spec**: upgrade-sync | **Files**: `internal/state/state.go`, `internal/app/selfupdate.go`, `internal/app/app.go`, `internal/tui/screens/upgrade_sync.go`
+
+### Phase 1 — Red (failing tests)
+- [ ] 4.1 `internal/state/state_test.go` — add test: `PendingSync` bool round-trips via `Write`/`Read`; absent field reads as `false` (back-compat)
+- [ ] 4.2 `internal/app/selfupdate_test.go` (new or existing) — add test: after successful `gentle-ai` self-upgrade, `PendingSync = true` is written to state before process exit
+- [ ] 4.3 `internal/app/app_test.go` (new or existing) — add test: on startup with `state.PendingSync = true`, `RunSync` is called and `PendingSync` is cleared on success; on failure, `PendingSync` remains true
+
+### Phase 2 — Green (implementation)
+- [ ] 4.4 `internal/state/state.go` — add `PendingSync bool \`json:"pending_sync,omitempty"\`` to `InstallState`; carry field through `MergeAgents`
+- [ ] 4.5 `internal/app/selfupdate.go` — after `upgradeExecute` confirms `gentle-ai` succeeded, call `state.Read` + set `PendingSync = true` + `state.Write` before calling `restartAfterGentleAIUpgrade`
+- [ ] 4.6 `internal/app/selfupdate.go` `restartAfterGentleAIUpgrade` — converge Unix + Windows: drop `goOS() == "windows"` branch; always print "Updated to vX — restart gentle-ai…" and return (no re-exec); remove `reExec` var and `syscall` import if unused
+- [ ] 4.7 `internal/app/app.go` — after `state.Read` at line ~127, check `installedState.PendingSync`; if true, call `cli.RunSync`; on success write state with `PendingSync = false`; on failure log error and leave flag set
+- [ ] 4.8 `internal/tui/screens/upgrade_sync.go` — set `PendingSync = true` in state when Upgrade+Sync detects a self-upgrade event (parallel to CLI path)
+
+### Phase 3 — Refactor
+- [ ] 4.9 Ensure `RunSync` is idempotent (no state left) before merge; add a guard comment citing spec scenario "deferred sync fails → retry"
+
+---
+
+## Slice 5 — CLI Prompt Default + Apply-Then-Close
+
+**Spec**: self-update | **Files**: `internal/app/selfupdate.go`, `internal/app/selfupdate_test.go`
+
+### Phase 1 — Red (failing tests)
+- [ ] 5.1 `internal/app/selfupdate_test.go` — add test: `selfUpdate` calls `promptFn` unconditionally when update is available (without `GENTLE_AI_CONFIRM_UPDATE`); test `GENTLE_AI_CONFIRM_UPDATE` env set to "1" does NOT gate the prompt (env is ignored)
+- [ ] 5.2 `internal/app/selfupdate_test.go` — add test: non-TTY stdin causes `defaultPromptForUpdate` to return `(false, nil)` (auto-decline in CI)
+- [ ] 5.3 `internal/app/selfupdate_test.go` — add test: `--yes` flag (via injected promptFn) bypasses interactive prompt and returns `(true, nil)`
+
+### Phase 2 — Green (implementation)
+- [ ] 5.4 `internal/app/selfupdate.go` — remove `envConfirmUpdate` constant and the guard block at lines ~111–116; always call `promptFn` when update is available
+- [ ] 5.5 `internal/app/selfupdate.go` — add `--yes` flag handling: accept `yesFlag bool` param or read `GENTLE_AI_YES=1`; when set, substitute `promptFn` with a stub that returns `(true, nil)`
+- [ ] 5.6 `internal/app/selfupdate.go` `defaultPromptForUpdate` — change prompt text to "[Y/n]" (default Y); update answer parse: empty string or "y"/"yes" → true; "n"/"no" → false
+
+### Phase 3 — Refactor
+- [ ] 5.7 Remove `envConfirmUpdate` from constant block entirely; update any test that set it; add a comment "GENTLE_AI_CONFIRM_UPDATE removed — prompt is now unconditional"
+
+---
+
+## Slice 6 — TUI Pre-Welcome Update Prompt Screen
+
+**Spec**: update-prompt | **Files**: `internal/tui/model.go`, `internal/tui/screens/update_prompt.go` (new), `internal/tui/model_test.go`
+
+> **Flagged: this slice stands alone. Estimated ~350–450 lines. Must be its own PR. Do not bundle with any other slice.**
+
+### Phase 1 — Red (failing tests)
+- [ ] 6.1 `internal/tui/model_test.go` — add test: when `UpdateCheckResultMsg` arrives with `HasUpdates = true`, model transitions to `ScreenUpdatePrompt` (not `ScreenWelcome`)
+- [ ] 6.2 `internal/tui/model_test.go` — add test: `ScreenUpdatePrompt` key "u" triggers upgrade and then `tea.Quit`
+- [ ] 6.3 `internal/tui/model_test.go` — add test: `ScreenUpdatePrompt` key "c" or Enter transitions to `ScreenWelcome` (keep current)
+- [ ] 6.4 `internal/tui/model_test.go` — add test: `ScreenUpdatePrompt` key "v" calls open-browser / prints URL; prompt remains visible
+- [ ] 6.5 `internal/tui/model_test.go` — add test: when no update available, `UpdateCheckResultMsg` transitions to `ScreenWelcome` (no prompt screen)
+- [ ] 6.6 `internal/tui/model_test.go` — add test: cooldown gate in `Init()` (from slice 2) causes `UpdateCheckDone = true` immediately with cached results when elapsed < 6h; `ScreenUpdatePrompt` NOT shown when no update in cache
+
+### Phase 2 — Green (implementation)
+- [ ] 6.7 `internal/tui/model.go` — add `ScreenUpdatePrompt Screen` constant after `ScreenUnknown` block (preserve iota order; append after last screen)
+- [ ] 6.8 `internal/tui/model.go` `Update()` — in `UpdateCheckResultMsg` handler: if `HasUpdates`, set `m.Screen = ScreenUpdatePrompt`; else remain at `ScreenWelcome`; show spinner until `UpdateCheckDone`
+- [ ] 6.9 `internal/tui/model.go` `Update()` — add `ScreenUpdatePrompt` key handler: "u" → run `UpgradeFn` then `tea.Quit`; "c"/Enter → `setScreen(ScreenWelcome)`; "v" → `openBrowser(UpdateResults[0].ReleaseURL)` or print URL if browser unavailable, stay on screen
+- [ ] 6.10 `internal/tui/screens/update_prompt.go` (create) — implement `RenderUpdatePrompt(results []update.UpdateResult, spinnerFrame int) string`; shows available version, three options (Update / View changes / Keep current version), spinner while checking
+- [ ] 6.11 `internal/tui/model.go` `View()` — add `case ScreenUpdatePrompt: return screens.RenderUpdatePrompt(m.UpdateResults, m.SpinnerFrame)`
+- [ ] 6.12 `internal/tui/model.go` `optionCount()` — add `case ScreenUpdatePrompt: return 3`
+- [ ] 6.13 `internal/app/app.go` — wire `openBrowser` helper (open URL or fallback to `fmt.Fprintln`) into model for "View changes" action
+
+### Phase 3 — Refactor
+- [ ] 6.14 Verify `ScreenUpdatePrompt` is listed in `confirmSelection()` switch and `withResetOperationState()` if it holds state; confirm `TickMsg` keeps spinner running while `!UpdateCheckDone` on this screen
+- [ ] 6.15 Add `case ScreenUpdatePrompt` to any exhaustive switch that lints missing cases (`optionCount`, `confirmSelection`, `withEscKey`)
+
+---
+
+## Slice 7 — Advisory Manifest
+
+**Spec**: advisory-manifest | **Files**: `internal/update/advisory.go` (new), `internal/update/advisory_test.go` (new), `internal/app/app.go`
+
+### Phase 1 — Red (failing tests)
+- [ ] 7.1 `internal/update/advisory_test.go` (create) — add test: `FetchAdvisory` with `httptest` server returning valid JSON `{message: "hi", severity: "info"}` returns `Advisory{Message:"hi"}, true`
+- [ ] 7.2 `internal/update/advisory_test.go` — add test: `FetchAdvisory` with slow server (> 2s) returns `Advisory{}, false` (timeout, fail-open)
+- [ ] 7.3 `internal/update/advisory_test.go` — add test: `FetchAdvisory` with HTTP 500 returns `Advisory{}, false`
+- [ ] 7.4 `internal/update/advisory_test.go` — add test: `FetchAdvisory` with malformed JSON returns `Advisory{}, false`
+- [ ] 7.5 `internal/update/advisory_test.go` — add test: `FetchAdvisory` with empty `message` field returns `Advisory{}, false` (nothing to display)
+
+### Phase 2 — Green (implementation)
+- [ ] 7.6 `internal/update/advisory.go` (create) — define `Advisory{Message, Severity, URL string}`; implement `FetchAdvisory(ctx context.Context) (Advisory, bool)` with 2s timeout, GET to advisory tag asset URL (`https://github.com/Gentleman-Programming/gentle-ai/releases/download/advisory/advisory.json`), JSON decode, fail-open on any error
+- [ ] 7.7 `internal/app/app.go` — launch `update.FetchAdvisory` in background goroutine alongside `update.CheckAll` at TUI init; collect result; display non-empty `Advisory.Message` as informational text on Welcome screen or after prompt (never gate launch)
+
+### Phase 3 — Refactor
+- [ ] 7.8 Inject advisory fetch URL as package-level var in `advisory.go` for test override; confirm `advisoryHTTPClient` timeout is exactly 2s and not shared with other clients
+
+---
+
+## Cross-Slice Notes
+
+- `state.MergeAgents` must be updated in slices 2 and 4 (both add fields); ensure no merge-conflict between those PRs by keeping slice 2 merged before slice 4 opens.
+- `internal/app/selfupdate.go` is touched by slices 4 and 5; ensure slice 4 is merged first (pending_sync write) before slice 5 (prompt default removal) to avoid rebase conflicts.
+- Slice 6 depends on slice 2 (cooldown gate in `Init()`); merge slice 2 before opening slice 6.
+- Slices 3 and 7 are independent of all others and can be opened in any order after slice 2.


### PR DESCRIPTION
The hybrid-store SDD artifacts (proposal, specs, design, tasks) for the update-experience change, now shipped across #874-#880. Committed trail to complement the engram record. Refs #872.

- [x] Documentation only
- [x] No code changes