### PR TITLE
test(engram): lock in Windows stop-script guard against issue #815 regression

### DIFF
--- a/internal/components/engram/download.go
+++ b/internal/components/engram/download.go
@@ -578,24 +578,25 @@ func extractZipBinary(data []byte, binaryName, outPath string) error {
 	return fmt.Errorf("binary %q not found in zip archive", binaryName)
 }
 
-// stopEngramProcesses stops any running Engram process so Windows can replace
-// engram.exe during upgrade.
+// engramStopScript returns the PowerShell script that stops running Engram
+// processes so Windows can replace engram.exe during an upgrade.
 //
-// The PowerShell script is written defensively:
-//  1. Get-Process with -ErrorAction SilentlyContinue returns nothing (not an
-//     error) when no engram process exists, so the no-op case is clean.
-//  2. Stop-Process uses -ErrorAction SilentlyContinue so that an access-denied
-//     condition (e.g. the MCP server is held by the running editor session) does
-//     not produce a terminating error and a non-zero exit code.
-//  3. If processes were found but could not all be stopped (count mismatch) we
-//     return an informative warning so the caller can surface it, but we do NOT
-//     abort the install — Windows may still succeed in replacing the binary if
-//     at least the file lock was released.
-func stopEngramProcesses() error {
-	// Two-step: find running engram processes, then attempt to stop them.
-	// Using -ErrorAction SilentlyContinue on both Get-Process and Stop-Process
-	// prevents access-denied and "no such process" from producing exit status 1.
-	const script = `
+// The script is written defensively so a clean install (no engram process
+// running) is a clean no-op instead of a failure:
+//  1. Get-Process uses -ErrorAction SilentlyContinue, so a missing process is
+//     not a terminating error.
+//  2. The Stop-Process call is guarded by `if ($procs)`, so the pipeline never
+//     runs on an empty result. This matters on Windows PowerShell 5.1, where
+//     piping an empty Get-Process result still flips `$?` and makes
+//     powershell.exe exit 1 with empty output — the clean-install regression in
+//     issue #815.
+//  3. Stop-Process uses -ErrorAction SilentlyContinue (never -ErrorAction Stop),
+//     so an access-denied condition (e.g. the binary is held by the running
+//     editor session) does not abort the install.
+//  4. If processes were found but could not all be stopped, the script emits a
+//     WARNING line so the caller can surface it without failing the install.
+func engramStopScript() string {
+	return `
 $procs = Get-Process -Name engram -ErrorAction SilentlyContinue
 if ($procs) {
     $procs | Stop-Process -Force -ErrorAction SilentlyContinue
@@ -605,11 +606,18 @@ if ($procs) {
     }
 }
 `
+}
+
+// stopEngramProcesses runs the defensive stop script (see engramStopScript) and
+// returns a non-nil error only when powershell.exe itself fails to launch or
+// exits non-zero. A WARNING line (processes found but not all stopped) is
+// surfaced to stderr but is treated as non-fatal.
+func stopEngramProcesses() error {
 	cmd := exec.Command("powershell.exe",
 		"-NoProfile",
 		"-NonInteractive",
 		"-Command",
-		script,
+		engramStopScript(),
 	)
 	cmd.Stdin = nil
 	out, err := cmd.CombinedOutput()

--- a/internal/components/engram/download_test.go
+++ b/internal/components/engram/download_test.go
@@ -1249,3 +1249,35 @@ func TestEngramGoInstallFromMain_BypassesPublicGoProxy(t *testing.T) {
 		}
 	}
 }
+
+// TestEngramStopScriptIsDefensive locks in the shape of the PowerShell stop
+// script so the clean-install regression from issue #815 cannot reappear.
+//
+// On Windows PowerShell 5.1, piping an empty `Get-Process` result straight into
+// Stop-Process flips `$?` and makes powershell.exe exit 1 with no output, which
+// the Go installer surfaces as a bare "exit status 1 (output: )" and marks the
+// whole engram component FAILED on a fresh machine. The fix is structural: guard
+// the pipeline with `if ($procs)` and never use `-ErrorAction Stop`. Because the
+// script only runs on real Windows (integration-covered on Windows CI), this
+// unit test asserts the invariants on the generated string so a future "cleanup"
+// that reintroduces the direct pipe or a terminating error action fails here.
+func TestEngramStopScriptIsDefensive(t *testing.T) {
+	script := engramStopScript()
+
+	// The lookup must not treat a missing process as a terminating error.
+	if !strings.Contains(script, "Get-Process -Name engram -ErrorAction SilentlyContinue") {
+		t.Errorf("stop script must look up engram with -ErrorAction SilentlyContinue\nscript:\n%s", script)
+	}
+
+	// The Stop-Process pipeline must be guarded so it never runs on an empty
+	// result — this is the core of the issue #815 fix.
+	if !strings.Contains(script, "if ($procs)") {
+		t.Errorf("stop script must guard Stop-Process behind `if ($procs)` (issue #815)\nscript:\n%s", script)
+	}
+
+	// -ErrorAction Stop on Stop-Process is exactly what produced exit 1 when the
+	// pipeline was empty. It must never come back.
+	if strings.Contains(script, "Stop-Process -Force -ErrorAction Stop") {
+		t.Errorf("stop script must not use -ErrorAction Stop on Stop-Process (reintroduces issue #815/#850)\nscript:\n%s", script)
+	}
+}


### PR DESCRIPTION
## What

Extracts the Windows PowerShell stop script into `engramStopScript()` and adds `TestEngramStopScriptIsDefensive`, a regression test that asserts the script keeps its defensive shape:

- `Get-Process ... -ErrorAction SilentlyContinue` (missing process is not a terminating error)
- `if ($procs)` guard so the pipeline never runs on an empty result
- never `-ErrorAction Stop` on `Stop-Process`

No behavior change — the production fix already shipped in #866. This locks the contract so it cannot silently regress.

## Why

The script previously lived inline and was only integration-covered on Windows CI. The clean-install regression in #815 (an empty `Get-Process` pipeline flips `$?` and makes powershell.exe exit 1 on PowerShell 5.1) had no unit-level protection. A future "cleanup" back to a direct pipe or `-ErrorAction Stop` would reintroduce it with nothing to catch it. Now there is.

## Credit

The root-cause diagnosis (the `$?` flip on PowerShell 5.1) and the structural fix came from the community on #815 — thank you @skiveldev (#859) and @serberato (#864). This commit carries both as co-authors.

Closes #815

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal Windows process termination logic organization for better maintainability.

* **Tests**
  * Added test coverage for Windows process stop script defensive behavior to ensure reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->