### PR TITLE
feat(cli): add runtime channel switching (stable/beta) via `gentle-ai channel`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Binaries
 /gentle-ai
+/.bin/
 *.exe
 *.dll
 *.so

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Binaries
 /gentle-ai
 /.bin/
+/bin/
 *.exe
 *.dll
 *.so

--- a/README.md
+++ b/README.md
@@ -84,19 +84,38 @@ scoop install gentle-ai
 
 The beta channel builds Gentle AI straight from `main`, so you need **Go 1.24+** installed first. Use it to try unreleased changes and report issues early.
 
-**macOS / Linux**
+Install Gentle AI normally first, then switch channels through the launcher:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/Gentleman-Programming/gentle-ai/main/scripts/install.sh | bash -s -- --channel beta
+gentle-ai channel beta
 ```
 
-**Windows (PowerShell)**
+Return to the stable launcher at any time:
 
-```powershell
+```bash
+gentle-ai channel stable
+```
+
+Do not add `~/.gentle-ai/channels/beta` or `~/.gentle-ai/channels/stable` to your `PATH`. Keep your Homebrew/Scoop/binary/Go-installed launcher first; it delegates to the selected channel internally.
+
+If you used an older beta install and `gentle-ai` still resolves to an old Go binary, check:
+
+```bash
+which -a gentle-ai      # macOS/Linux
+where.exe gentle-ai     # Windows
+```
+
+The first entry should be your launcher (`brew`, `scoop`, the binary installer, or your stable `go install`). If an older `~/go/bin/gentle-ai` wins, rerun the installer: it moves the launcher ahead of the legacy binary in your user `PATH` and keeps channel payloads out of `PATH`.
+
+Fresh installs can also activate beta in one step:
+
+```bash
+# macOS / Linux
+curl -fsSL https://raw.githubusercontent.com/Gentleman-Programming/gentle-ai/main/scripts/install.sh | bash -s -- --channel beta
+
+# Windows (PowerShell)
 $env:GENTLE_AI_CHANNEL="beta"; irm https://raw.githubusercontent.com/Gentleman-Programming/gentle-ai/main/scripts/install.ps1 | iex
 ```
-
-To keep upgrading on beta later, run `GENTLE_AI_CHANNEL=beta gentle-ai upgrade`. To return to stable, reinstall via Homebrew or Scoop.
 
 ### After install: project-level setup
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -63,6 +63,10 @@ func RunArgs(args []string, stdout io.Writer) error {
 	// --yes as a global CLI flag for self-update is handled via GENTLE_AI_YES=1.
 	// Per-subcommand --yes flags (e.g. restore --yes) are parsed by each subcommand.
 
+	if dispatched, err := cli.MaybeExecChannelTarget(args); dispatched || err != nil {
+		return err
+	}
+
 	// Info commands: no system detection, no self-update, no platform validation.
 	if len(args) > 0 {
 		switch args[0] {
@@ -72,6 +76,8 @@ func RunArgs(args []string, stdout io.Writer) error {
 		case "help", "--help", "-h":
 			printHelp(stdout, Version)
 			return nil
+		case "channel":
+			return cli.RunChannel(args[1:], stdout)
 		case "uninstall":
 			_, err := cli.RunUninstall(args[1:], stdout)
 			return err

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -72,6 +72,20 @@ func RunArgs(args []string, stdout io.Writer) error {
 		switch args[0] {
 		case "version", "--version", "-v":
 			_, _ = fmt.Fprintf(stdout, "gentle-ai %s\n", Version)
+			// The version/--version command is launcher-owned so the launcher's own
+			// version stays reachable. When a non-stable channel is active, annotate it
+			// so a beta user is not misled into reading this as the beta build's version.
+			if channel, err := cli.ResolveInstallChannel(""); err == nil && channel != cli.ChannelStable {
+				_, _ = fmt.Fprintf(stdout, "channel: %s\n", channel)
+				// ActiveChannelBinaryPath only joins paths; it does not check existence.
+				// Only print the binary line when the file is actually on disk, so a
+				// not-yet-built channel binary is not advertised as present.
+				if path, err := cli.ActiveChannelBinaryPath(channel); err == nil && path != "" {
+					if _, statErr := os.Stat(path); statErr == nil {
+						_, _ = fmt.Fprintf(stdout, "channel binary: %s\n", path)
+					}
+				}
+			}
 			return nil
 		case "help", "--help", "-h":
 			printHelp(stdout, Version)

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -1767,12 +1767,17 @@ func TestRunArgs_PendingSync_ClearWriteFailureIsLogged(t *testing.T) {
 		t.Fatalf("state.Write() error = %v", err)
 	}
 
-	// Make the state file read-only so state.Write (the clear-PendingSync write) fails.
-	stateFilePath := state.Path(home)
-	if err := os.Chmod(stateFilePath, 0o444); err != nil {
+	// Make the state DIRECTORY read-only so the clear-PendingSync state.Write
+	// fails. state.Write is atomic (it writes a temp file in this directory and
+	// renames it over the target), so a read-only target file would NOT fail the
+	// write — only a read-only directory blocks the temp-file creation. The state
+	// file itself stays readable, so the earlier state.Read still succeeds and the
+	// PendingSync=true branch is reached.
+	stateDirPath := filepath.Dir(state.Path(home))
+	if err := os.Chmod(stateDirPath, 0o555); err != nil {
 		t.Fatalf("Chmod: %v", err)
 	}
-	t.Cleanup(func() { _ = os.Chmod(stateFilePath, 0o644) })
+	t.Cleanup(func() { _ = os.Chmod(stateDirPath, 0o755) })
 
 	origSelf := selfUpdateFn
 	origEnsure := ensureCurrentOSSupported

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -200,6 +200,7 @@ func TestRunArgsRestoreUnknownIDReturnsError(t *testing.T) {
 }
 
 func TestRunArgsUninstallIsDispatched(t *testing.T) {
+	isolateChannelResolution(t)
 	var buf bytes.Buffer
 	// uninstall without required flags prints usage help — that's enough to
 	// confirm the dispatch path works without needing real agents or state.
@@ -208,6 +209,7 @@ func TestRunArgsUninstallIsDispatched(t *testing.T) {
 }
 
 func TestRunArgsUninstallBypassesPlatformValidation(t *testing.T) {
+	isolateChannelResolution(t)
 	origEnsure := ensureCurrentOSSupported
 	t.Cleanup(func() { ensureCurrentOSSupported = origEnsure })
 	ensureCurrentOSSupported = func() error {
@@ -222,6 +224,7 @@ func TestRunArgsUninstallBypassesPlatformValidation(t *testing.T) {
 }
 
 func TestRunArgsInstallHelpPrintsInstallSpecificHelp(t *testing.T) {
+	isolateChannelResolution(t)
 	origEnsure := ensureCurrentOSSupported
 	t.Cleanup(func() { ensureCurrentOSSupported = origEnsure })
 	ensureCurrentOSSupported = func() error {
@@ -243,6 +246,7 @@ func TestRunArgsInstallHelpPrintsInstallSpecificHelp(t *testing.T) {
 }
 
 func TestRunArgsSDDStatusIsDispatchedBeforePlatformValidation(t *testing.T) {
+	isolateChannelResolution(t)
 	origEnsure := ensureCurrentOSSupported
 	t.Cleanup(func() { ensureCurrentOSSupported = origEnsure })
 	ensureCurrentOSSupported = func() error {
@@ -266,6 +270,7 @@ func TestRunArgsSDDStatusIsDispatchedBeforePlatformValidation(t *testing.T) {
 }
 
 func TestRunArgsSDDContinueIsDispatchedBeforePlatformValidation(t *testing.T) {
+	isolateChannelResolution(t)
 	origEnsure := ensureCurrentOSSupported
 	t.Cleanup(func() { ensureCurrentOSSupported = origEnsure })
 	ensureCurrentOSSupported = func() error {
@@ -1025,6 +1030,7 @@ func TestHelpCommand(t *testing.T) {
 // TestUnknownCommandSuggestsHelp verifies that an unrecognised command returns
 // an error whose message suggests running 'gentle-ai help'.
 func TestUnknownCommandSuggestsHelp(t *testing.T) {
+	isolateChannelResolution(t)
 	var buf bytes.Buffer
 	err := RunArgs([]string{"notacommand"}, &buf)
 	if err == nil {
@@ -1131,6 +1137,7 @@ func TestRunArgs_UpgradeSkipsSelfUpdate(t *testing.T) {
 
 func TestRunArgs_TUISkipsSelfUpdate(t *testing.T) {
 	// NOTE: modifies package-level vars; must not run in parallel.
+	isolateChannelResolution(t)
 	origSelfUpdate := selfUpdateFn
 	origDetect := detectSystem
 	origEnsure := ensureCurrentOSSupported
@@ -1208,6 +1215,28 @@ func setupMockHome(t *testing.T, home string) {
 	})
 	os.Setenv("HOME", home)
 	os.Setenv("USERPROFILE", home)
+}
+
+// isolateChannelResolution makes RunArgs / MaybeExecChannelTarget deterministic
+// regardless of the host's ~/.gentle-ai/channel file and GENTLE_AI_CHANNEL value.
+// It points HOME/USERPROFILE at a fresh empty temp dir (so the saved-channel lookup
+// degrades to stable and no dispatch to a managed target binary happens) and unsets
+// the channel env var. Launcher-routing tests must call this so they pass on machines
+// with a persisted non-stable channel and an installed channel target binary.
+func isolateChannelResolution(t *testing.T) {
+	t.Helper()
+	setupMockHome(t, t.TempDir())
+	previous, hadPrevious := os.LookupEnv("GENTLE_AI_CHANNEL")
+	if err := os.Unsetenv("GENTLE_AI_CHANNEL"); err != nil {
+		t.Fatalf("Unsetenv GENTLE_AI_CHANNEL: %v", err)
+	}
+	t.Cleanup(func() {
+		if hadPrevious {
+			_ = os.Setenv("GENTLE_AI_CHANNEL", previous)
+			return
+		}
+		_ = os.Unsetenv("GENTLE_AI_CHANNEL")
+	})
 }
 
 // TestApplyOverrides_CodexModelAssignments verifies that a non-nil
@@ -1482,6 +1511,7 @@ func writeAppSDDStatusFile(t *testing.T, path string, content string) {
 // reports a successful gentle-ai upgrade, RunArgs calls restartAfterGentleAIUpgrade
 // which (after task 4.6) prints the restart guidance message instead of re-execing.
 func TestRunArgs_TUIRestartsAfterGentleAIUpgradeResult(t *testing.T) {
+	isolateChannelResolution(t)
 	origDetect := detectSystem
 	origEnsure := ensureCurrentOSSupported
 	origRunTUI := runTUI

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -15,6 +15,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/gentleman-programming/gentle-ai/internal/backup"
+	"github.com/gentleman-programming/gentle-ai/internal/cli"
 	"github.com/gentleman-programming/gentle-ai/internal/model"
 	"github.com/gentleman-programming/gentle-ai/internal/state"
 	"github.com/gentleman-programming/gentle-ai/internal/system"
@@ -997,6 +998,7 @@ func TestLoadPersistedAssignmentsWiresEffort(t *testing.T) {
 // TestVersionBeforeSystemGuards verifies that `gentle-ai version` returns the
 // version string without going through system detection or platform guards.
 func TestVersionBeforeSystemGuards(t *testing.T) {
+	isolateChannelResolution(t)
 	var buf bytes.Buffer
 	err := RunArgs([]string{"version"}, &buf)
 	if err != nil {
@@ -1004,6 +1006,76 @@ func TestVersionBeforeSystemGuards(t *testing.T) {
 	}
 	if !strings.Contains(buf.String(), "gentle-ai") {
 		t.Error("version output should contain 'gentle-ai'")
+	}
+}
+
+// TestVersionAnnotatesNonStableChannel verifies that the launcher-owned version
+// output annotates the active channel when it is non-stable, so a beta user is not
+// misled into reading the launcher version as the beta build. Stable output stays
+// unannotated.
+func TestVersionAnnotatesNonStableChannel(t *testing.T) {
+	for _, arg := range []string{"version", "--version", "-v"} {
+		// Beta with the channel binary present: both the channel and the binary path
+		// lines are printed.
+		t.Run("beta-with-binary/"+arg, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			t.Setenv("USERPROFILE", home)
+			t.Setenv("GENTLE_AI_CHANNEL", "beta")
+
+			path, err := cli.ChannelBinaryPath(cli.ChannelBeta)
+			if err != nil {
+				t.Fatalf("ChannelBinaryPath: %v", err)
+			}
+			if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+				t.Fatalf("MkdirAll: %v", err)
+			}
+			if err := os.WriteFile(path, []byte("fake beta binary"), 0o755); err != nil {
+				t.Fatalf("WriteFile beta binary: %v", err)
+			}
+
+			var buf bytes.Buffer
+			if err := RunArgs([]string{arg}, &buf); err != nil {
+				t.Fatalf("version (%s) should not fail: %v", arg, err)
+			}
+			if !strings.Contains(buf.String(), "channel: beta") {
+				t.Errorf("beta version output should annotate the channel, got %q", buf.String())
+			}
+			if !strings.Contains(buf.String(), "channel binary: "+path) {
+				t.Errorf("beta version output should print the existing binary path, got %q", buf.String())
+			}
+		})
+
+		// Beta with NO channel binary on disk: the channel line is printed but the
+		// binary line is suppressed (the path is not advertised as present).
+		t.Run("beta-without-binary/"+arg, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			t.Setenv("USERPROFILE", home)
+			t.Setenv("GENTLE_AI_CHANNEL", "beta")
+
+			var buf bytes.Buffer
+			if err := RunArgs([]string{arg}, &buf); err != nil {
+				t.Fatalf("version (%s) should not fail: %v", arg, err)
+			}
+			if !strings.Contains(buf.String(), "channel: beta") {
+				t.Errorf("beta version output should annotate the channel, got %q", buf.String())
+			}
+			if strings.Contains(buf.String(), "channel binary:") {
+				t.Errorf("missing beta binary must not be advertised, got %q", buf.String())
+			}
+		})
+
+		t.Run("stable/"+arg, func(t *testing.T) {
+			isolateChannelResolution(t)
+			var buf bytes.Buffer
+			if err := RunArgs([]string{arg}, &buf); err != nil {
+				t.Fatalf("version (%s) should not fail: %v", arg, err)
+			}
+			if strings.Contains(buf.String(), "channel:") {
+				t.Errorf("stable version output must not annotate the channel, got %q", buf.String())
+			}
+		})
 	}
 }
 

--- a/internal/app/help.go
+++ b/internal/app/help.go
@@ -14,6 +14,7 @@ USAGE
 
 COMMANDS
   install      Configure AI coding agents on this machine
+  channel      Show or set runtime channel: stable or beta (nightly = beta)
   uninstall    Remove Gentle AI managed files from this machine
   sync         Sync agent configs and skills to current version
   skill-registry refresh

--- a/internal/app/parity_test.go
+++ b/internal/app/parity_test.go
@@ -162,6 +162,7 @@ func TestGuardFlowLinuxDryRunPropagatesDecision(t *testing.T) {
 }
 
 func TestRunArgsNoCommandLaunchesTUI(t *testing.T) {
+	isolateChannelResolution(t)
 	origRunTUI := runTUI
 	t.Cleanup(func() { runTUI = origRunTUI })
 	runTUI = func(m tea.Model, opts ...tea.ProgramOption) (tea.Model, error) {
@@ -183,6 +184,7 @@ func TestRunArgsNoCommandLaunchesTUI(t *testing.T) {
 }
 
 func TestRunArgsUnknownCommandReturnsError(t *testing.T) {
+	isolateChannelResolution(t)
 	var buf bytes.Buffer
 	err := RunArgs([]string{"bogus"}, &buf)
 	if err == nil {
@@ -199,6 +201,7 @@ func TestRunArgsUnknownCommandReturnsError(t *testing.T) {
 // `RunArgs(["sync", "--dry-run", ...])` is correctly wired through app.go
 // and produces output about the sync plan — not a "unknown command" error.
 func TestRunArgsSyncDryRunIsDispatchedAndPrintsReport(t *testing.T) {
+	isolateChannelResolution(t)
 	var buf bytes.Buffer
 	err := RunArgs([]string{"sync", "--agents", "opencode", "--dry-run"}, &buf)
 	if err != nil {
@@ -220,6 +223,7 @@ func TestRunArgsSyncDryRunIsDispatchedAndPrintsReport(t *testing.T) {
 // TestRunArgsSyncUnknownFlagReturnsError verifies that an unknown flag
 // returns a proper parse error via the sync command path.
 func TestRunArgsSyncUnknownFlagReturnsError(t *testing.T) {
+	isolateChannelResolution(t)
 	var buf bytes.Buffer
 	err := RunArgs([]string{"sync", "--this-flag-does-not-exist"}, &buf)
 	if err == nil {
@@ -239,6 +243,7 @@ func TestRunArgsSyncNoAgentsIsNoOp(t *testing.T) {
 	// but we can verify that the command exits without error and prints
 	// something meaningful (the no-op message).
 	// Use --dry-run to avoid any file creation and allow running in CI.
+	isolateChannelResolution(t)
 	var buf bytes.Buffer
 	err := RunArgs([]string{"sync", "--agents", "opencode", "--dry-run"}, &buf)
 	if err != nil {

--- a/internal/app/selfupdate.go
+++ b/internal/app/selfupdate.go
@@ -171,15 +171,34 @@ func selfUpdate(ctx context.Context, version string, profile system.PlatformProf
 	// previous "restart and sync manually" skip path. Failure to write state is
 	// non-fatal — the user can re-run sync explicitly.
 	//
-	// No-clobber guard: only fall back to a fresh InstallState{} when the file
-	// is genuinely missing (ErrNotExist). Any other read error (e.g. corrupt
-	// JSON, permission denied) means an existing file is present — do not
-	// overwrite it and risk dropping unrelated persisted fields.
+	// Note: CheckAllWithCooldown ran earlier in this flow and normally heals a
+	// corrupt state file first (it resets-and-persists LastUpdateCheck on
+	// ErrCorruptState). So reaching this branch with a corrupt file is rare — it
+	// only happens if that cooldown write failed, or the file was corrupted after
+	// the cooldown check. The corrupt handling below is therefore defense-in-depth,
+	// not the primary heal path; do not remove it.
+	//
+	// Resettable-state guard — this contract is shared by the deferred-sync write
+	// sites (this block and internal/tui/model.go) and the cooldown writer in
+	// internal/update/cooldown.go (LastUpdateCheck). It is NOT a codebase-wide
+	// policy: the install/assignment/uninstall sites
+	// (internal/app/app.go persistAssignments, internal/cli/run.go
+	// mergeExplicitAgentInstallState, internal/components/uninstall/service.go)
+	// deliberately PRESERVE on corrupt to avoid silently dropping installed_agents.
+	//   - Missing (os.ErrNotExist) or corrupt (state.ErrCorruptState): start fresh
+	//     and persist PendingSync. state.Read already returned a zero InstallState
+	//     on error, and a corrupt file's fields are already undecodable and lost,
+	//     so resetting loses nothing recoverable.
+	//   - Any OTHER read error (genuine IO/permission failure): the bytes may still
+	//     be a valid state.json that is merely unreadable this once — do not
+	//     overwrite it and risk dropping installed_agents, model assignments, etc.
+	//   - Valid state (readErr == nil): other fields are preserved; only PendingSync
+	//     flips to true.
 	if homeDir != "" {
 		s, readErr := state.Read(homeDir)
-		if readErr != nil && !errors.Is(readErr, os.ErrNotExist) {
-			// File exists but is unreadable/corrupt — skip this round to avoid
-			// clobbering installed_agents, model assignments, etc.
+		if readErr != nil && !errors.Is(readErr, os.ErrNotExist) && !errors.Is(readErr, state.ErrCorruptState) {
+			// Genuine IO/permission error — skip this round to avoid clobbering a
+			// possibly-valid-but-unreadable file.
 		} else {
 			s.PendingSync = true
 			_ = state.Write(homeDir, s)

--- a/internal/app/selfupdate_test.go
+++ b/internal/app/selfupdate_test.go
@@ -3,6 +3,7 @@ package app
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -697,10 +698,110 @@ func TestSelfUpdate_DoesNotSetPendingSyncOnFailure(t *testing.T) {
 	}
 }
 
-// TestSelfUpdate_NoClobberOnCorruptStateFile verifies that when state.Read fails
-// with a non-ErrNotExist error (e.g. corrupt JSON), PendingSync is NOT written
-// and the existing state file bytes are preserved unchanged.
-func TestSelfUpdate_NoClobberOnCorruptStateFile(t *testing.T) {
+// TestSelfUpdate_ResetsCorruptStateAndPersistsPendingSync verifies the unified
+// resettable-state contract: when the deferred-sync read fails with
+// state.ErrCorruptState (a decode failure — the persisted data is already
+// unrecoverable), selfUpdate resets to a fresh InstallState and persists
+// PendingSync=true instead of skipping. Resetting loses nothing recoverable
+// because the corrupt fields were already undecodable. This mirrors the policy
+// in internal/update/cooldown.go and internal/cli/channel_command.go.
+//
+// Both corrupt shapes route through state.Read's ErrCorruptState wrapping:
+//   - structurally-broken JSON ("this is not valid JSON {{{")
+//   - a malformed RFC3339 timestamp in the *time.Time field
+func TestSelfUpdate_ResetsCorruptStateAndPersistsPendingSync(t *testing.T) {
+	checkResults := []update.UpdateResult{
+		{
+			Tool:             update.ToolInfo{Name: "gentle-ai"},
+			InstalledVersion: "1.7.0",
+			LatestVersion:    "1.8.0",
+			Status:           update.UpdateAvailable,
+		},
+	}
+	upgradeReport := upgrade.UpgradeReport{
+		Results: []upgrade.ToolUpgradeResult{
+			{ToolName: "gentle-ai", Status: upgrade.UpgradeSucceeded, NewVersion: "1.8.0"},
+		},
+	}
+
+	tests := []struct {
+		name string
+		blob string
+	}{
+		{name: "structurally broken json", blob: "this is not valid JSON {{{"},
+		{name: "malformed timestamp field", blob: `{"last_update_check":"not-a-timestamp"}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			unsetEnv(t, envNoSelfUpdate)
+			unsetEnv(t, envSelfUpdateDone)
+
+			swapSelfUpdateDeps(t, checkResults, upgradeReport)
+			tmpHome := t.TempDir()
+			selfUpdateHomeDirFn = func() (string, error) { return tmpHome, nil }
+
+			stateDir := filepath.Join(tmpHome, ".gentle-ai")
+			if err := os.MkdirAll(stateDir, 0o755); err != nil {
+				t.Fatalf("MkdirAll: %v", err)
+			}
+			stateFilePath := filepath.Join(stateDir, "state.json")
+
+			// Seed the corrupt state INSIDE the prompt hook. The cooldown gate
+			// (internal/update/cooldown.go) runs before promptFn and would itself
+			// reset a corrupt file on a successful check, masking the deferred-sync
+			// guard under test. promptFn fires after the cooldown returns and before
+			// the upgrade + deferred-sync block, so writing the corrupt bytes here
+			// guarantees state.Read inside the deferred-sync block faces
+			// ErrCorruptState — isolating the guard this test targets.
+			origPrompt := promptFn
+			t.Cleanup(func() { promptFn = origPrompt })
+			promptFn = func(_ io.Writer, _ io.Reader, _, _ string) (bool, error) {
+				if err := os.WriteFile(stateFilePath, []byte(tt.blob), 0o644); err != nil {
+					t.Fatalf("WriteFile corrupt at prompt time: %v", err)
+				}
+				// Guard against false positives: state.Read must now classify the
+				// seeded bytes as ErrCorruptState.
+				if _, err := state.Read(tmpHome); !errors.Is(err, state.ErrCorruptState) {
+					t.Fatalf("precondition: state.Read(%q) = %v, want errors.Is(..., ErrCorruptState)", tt.blob, err)
+				}
+				return true, nil
+			}
+
+			err := selfUpdate(context.Background(), "1.7.0", stubProfile(), io.Discard)
+			if err != nil {
+				t.Fatalf("selfUpdate returned error: %v", err)
+			}
+
+			// The corrupt file must have been reset to a valid, decodable
+			// state.json with PendingSync=true persisted. (LastUpdateCheck may
+			// also be set because the cooldown gate runs earlier in the flow;
+			// do not over-constrain — PendingSync is the contract under test.)
+			updated, readErr := state.Read(tmpHome)
+			if readErr != nil {
+				t.Fatalf("state.Read() after selfUpdate = %v, want nil (corrupt file should be reset)", readErr)
+			}
+			if !updated.PendingSync {
+				t.Errorf("PendingSync = false after corrupt-state reset, want true")
+			}
+		})
+	}
+}
+
+// TestSelfUpdate_UnreadableStateSkipsWrite verifies the conservative branch:
+// when the deferred-sync read fails with a genuine IO/permission error (NEITHER
+// os.ErrNotExist NOR state.ErrCorruptState), the file's bytes may still be a
+// valid state.json that is merely unreadable this once, so the PendingSync write
+// is skipped to avoid clobbering recoverable data.
+//
+// The unreadable file is simulated with mode 0o000. This is not portable as
+// root (root bypasses permission bits), so the test skips when running as root
+// rather than asserting flakily. Mirrors cooldown_test.go's
+// TestCheckAllWithCooldown_UnreadableStateSkipsWrite.
+func TestSelfUpdate_UnreadableStateSkipsWrite(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root bypasses file permission bits; cannot simulate an unreadable state.json")
+	}
+
 	unsetEnv(t, envNoSelfUpdate)
 	unsetEnv(t, envSelfUpdateDone)
 
@@ -722,15 +823,26 @@ func TestSelfUpdate_NoClobberOnCorruptStateFile(t *testing.T) {
 	tmpHome := t.TempDir()
 	selfUpdateHomeDirFn = func() (string, error) { return tmpHome, nil }
 
-	// Write a corrupt (non-missing) state file so state.Read returns a non-ErrNotExist error.
+	// Seed a VALID state.json, then strip read permission so state.Read returns
+	// an unwrapped os.ErrPermission (the bytes are possibly-valid-but-unreadable).
 	stateDir := filepath.Join(tmpHome, ".gentle-ai")
 	if err := os.MkdirAll(stateDir, 0o755); err != nil {
 		t.Fatalf("MkdirAll: %v", err)
 	}
-	corruptPayload := []byte("this is not valid JSON {{{")
+	original := []byte(`{"installed_agents":["claude-code"]}` + "\n")
 	stateFilePath := filepath.Join(stateDir, "state.json")
-	if err := os.WriteFile(stateFilePath, corruptPayload, 0o644); err != nil {
-		t.Fatalf("WriteFile: %v", err)
+	if err := os.WriteFile(stateFilePath, original, 0o644); err != nil {
+		t.Fatalf("WriteFile valid: %v", err)
+	}
+	if err := os.Chmod(stateFilePath, 0o000); err != nil {
+		t.Fatalf("Chmod 0o000: %v", err)
+	}
+	// Restore perms so t.TempDir cleanup can remove the file.
+	t.Cleanup(func() { _ = os.Chmod(stateFilePath, 0o644) })
+
+	// Guard the precondition: the read error must be neither NotExist nor Corrupt.
+	if _, err := state.Read(tmpHome); errors.Is(err, os.ErrNotExist) || errors.Is(err, state.ErrCorruptState) {
+		t.Skipf("could not simulate an unreadable-only state.json (read err = %v)", err)
 	}
 
 	// Slice 5: prompt is always called — inject auto-accept stub.
@@ -743,13 +855,17 @@ func TestSelfUpdate_NoClobberOnCorruptStateFile(t *testing.T) {
 		t.Fatalf("selfUpdate returned error: %v", err)
 	}
 
-	// The state file must not have been overwritten — original bytes must be intact.
+	// The unreadable file must NOT have been overwritten: restore read access
+	// and confirm the original bytes survive untouched.
+	if err := os.Chmod(stateFilePath, 0o644); err != nil {
+		t.Fatalf("Chmod restore: %v", err)
+	}
 	got, readErr := os.ReadFile(stateFilePath)
 	if readErr != nil {
 		t.Fatalf("os.ReadFile after selfUpdate: %v", readErr)
 	}
-	if string(got) != string(corruptPayload) {
-		t.Errorf("state file was overwritten on corrupt-read error\ngot:  %q\nwant: %q", got, corruptPayload)
+	if string(got) != string(original) {
+		t.Errorf("unreadable state file was overwritten\ngot:  %q\nwant: %q", got, original)
 	}
 }
 

--- a/internal/cli/channel.go
+++ b/internal/cli/channel.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 )
 
@@ -16,24 +17,91 @@ const (
 )
 
 func ResolveInstallChannel(flagValue string) (InstallChannel, error) {
+	// Flag and env are explicit user input: a present non-empty value must be
+	// validated and an invalid value must error. The saved file is only a
+	// preference cache, so it never errors (see loadSavedInstallChannel).
 	raw := strings.TrimSpace(flagValue)
+
+	// An empty/whitespace env value is treated as "unset" and falls through to
+	// the saved-file lookup, exactly as if the variable were absent.
 	if raw == "" {
-		raw = strings.TrimSpace(os.Getenv(channelEnvVar))
+		if envValue := strings.TrimSpace(os.Getenv(channelEnvVar)); envValue != "" {
+			raw = envValue
+		}
 	}
 	if raw == "" {
-		return ChannelStable, nil
+		// No explicit input: fall back to the saved preference cache. A missing
+		// or corrupt saved value degrades silently to stable.
+		return loadSavedInstallChannel(), nil
 	}
 
-	switch InstallChannel(strings.ToLower(raw)) {
-	case ChannelStable:
-		return ChannelStable, nil
-	case ChannelBeta, "nightly":
-		return ChannelBeta, nil
-	default:
+	channel, ok := parseInstallChannel(raw)
+	if !ok {
 		return "", fmt.Errorf("unsupported Gentle AI channel %q (use stable, beta, or nightly)", raw)
+	}
+	return channel, nil
+}
+
+// parseInstallChannel maps an input string to a canonical channel. "nightly" is
+// an accepted INPUT alias that resolves to beta; it is never persisted as-is.
+func parseInstallChannel(raw string) (InstallChannel, bool) {
+	switch InstallChannel(strings.ToLower(strings.TrimSpace(raw))) {
+	case ChannelStable:
+		return ChannelStable, true
+	case ChannelBeta, "nightly":
+		return ChannelBeta, true
+	default:
+		return "", false
 	}
 }
 
 func (c InstallChannel) IsBeta() bool {
 	return c == ChannelBeta
+}
+
+// SaveInstallChannel persists a channel preference. It shares parseInstallChannel
+// as the single source of truth for validity, so the accepted set and error wording
+// match ResolveInstallChannel exactly. The value is normalized to its canonical form
+// before writing ("nightly" persists as beta), so the saved file always round-trips.
+func SaveInstallChannel(channel InstallChannel) error {
+	canonical, ok := parseInstallChannel(string(channel))
+	if !ok {
+		return fmt.Errorf("unsupported Gentle AI channel %q (use stable, beta, or nightly)", channel)
+	}
+	path, err := channelFilePath()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create channel config dir: %w", err)
+	}
+	return os.WriteFile(path, []byte(string(canonical)+"\n"), 0o644)
+}
+
+// loadSavedInstallChannel reads the persisted channel preference. The saved file
+// is a best-effort cache: a missing file, an unreadable file, or a corrupt/invalid
+// value all degrade silently to ChannelStable. It NEVER returns an error so that a
+// garbage ~/.gentle-ai/channel can never brick the launcher.
+func loadSavedInstallChannel() InstallChannel {
+	path, err := channelFilePath()
+	if err != nil {
+		return ChannelStable
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ChannelStable
+	}
+	channel, ok := parseInstallChannel(string(data))
+	if !ok {
+		return ChannelStable
+	}
+	return channel
+}
+
+func channelFilePath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve user home directory: %w", err)
+	}
+	return filepath.Join(home, ".gentle-ai", "channel"), nil
 }

--- a/internal/cli/channel_command.go
+++ b/internal/cli/channel_command.go
@@ -27,6 +27,11 @@ var (
 	goToolchainAvailable           = defaultGoToolchainAvailable
 	channelStderr        io.Writer = os.Stderr
 	channelStaleNow                = time.Now
+	channelExit                    = os.Exit
+	// channelStateRead reads the persisted state. It is a seam so tests can inject a
+	// non-decode read error (e.g. a transient IO/permission failure) deterministically,
+	// which is not portably reproducible against the real filesystem.
+	channelStateRead = state.Read
 )
 
 // defaultGoToolchainAvailable reports whether a `go` toolchain is on PATH. Non-stable
@@ -107,7 +112,27 @@ func MaybeExecChannelTarget(args []string) (bool, error) {
 		}
 	}
 	env := append(os.Environ(), channelExecEnv+"=1", "GENTLE_AI_NO_SELF_UPDATE=1")
-	return true, channelRun(target, args, env)
+	if err := channelRun(target, args, env); err != nil {
+		// The delegated binary exited non-zero: propagate its exit code transparently
+		// so the launcher mirrors the child instead of collapsing every failure to 1
+		// (and printing a spurious "Error: exit status N" wrapper at the top level).
+		var exitErr interface{ ExitCode() int }
+		if errors.As(err, &exitErr) {
+			// A signal-terminated child reports ExitCode() == -1, which os.Exit coerces
+			// to 255 (a misleading code). Clamp any negative code to 1 so the launcher
+			// reports a conventional non-zero failure instead.
+			code := exitErr.ExitCode()
+			if code < 0 {
+				code = 1
+			}
+			channelExit(code)
+			return true, nil
+		}
+		// Non-exit failures (e.g. the binary could not be started) are real errors —
+		// surface them so the top-level handler reports them.
+		return true, err
+	}
+	return true, nil
 }
 
 // shouldWarnChannelStale gates the stale-binary warning behind a once-per-day TTL
@@ -129,19 +154,44 @@ func shouldWarnChannelStale() bool {
 	return true
 }
 
-// recordChannelStaleWarning persists the warning timestamp, re-reading state first so
-// it never clobbers unrelated fields. A corrupt/unreadable (but present) state file is
-// left untouched; write errors are non-fatal (the next due launch retries).
+// recordChannelStaleWarning persists the warning timestamp, re-reading state first.
+// The success path preserves all existing fields (only the timestamp is updated).
+// When the existing state is genuinely absent (os.ErrNotExist) or genuinely corrupt
+// (state.ErrCorruptState — the bytes decoded into nothing usable, so the data is
+// already unrecoverable) it resets to a fresh state carrying the new timestamp, so the
+// once-per-day cooldown still records (otherwise the warning would fire on every
+// command). Any other read failure (filesystem/permission/IO) is conservative: it does
+// NOT write, to avoid clobbering a valid state.json whose bytes were merely unreadable
+// this once — the warning may repeat but no data is lost. Write errors are non-fatal
+// (the next due launch retries).
 func recordChannelStaleWarning(home string, now time.Time) {
-	current, err := state.Read(home)
+	current, err := channelStateRead(home)
 	if err != nil {
-		if !errors.Is(err, os.ErrNotExist) {
+		if !isResettableStateError(err) {
+			// Transient/permission/IO read error against a possibly-valid file: do not
+			// write, so persisted fields are never clobbered by an unreadable-this-once read.
 			return
 		}
+		// Absent or corrupt: the contents cannot be preserved, but the cooldown timestamp
+		// must still be written so the warning does not nag every command.
 		current = state.InstallState{}
 	}
 	current.LastChannelStaleWarning = &now
 	_ = state.Write(home, current)
+}
+
+// isResettableStateError reports whether a state.Read error means the existing state
+// can be safely replaced by a fresh one. Only two cases qualify: the file is genuinely
+// absent (os.ErrNotExist), or its contents are genuinely undecodable
+// (state.ErrCorruptState — the data is already lost). state.Read is the single source
+// of truth for the corrupt classification: it wraps ErrCorruptState around ANY decode
+// failure (malformed JSON, a type mismatch, or a nested failure such as a corrupt
+// timestamp in a *time.Time field), so this no longer enumerates concrete json error
+// types. Every other error (e.g. EACCES, EISDIR, an I/O failure) is treated as
+// "preserve": the file may hold a valid state whose bytes were just unreadable this
+// once, so overwriting it would clobber persisted user data.
+func isResettableStateError(err error) bool {
+	return errors.Is(err, os.ErrNotExist) || errors.Is(err, state.ErrCorruptState)
 }
 
 // channelBinaryStale reports whether the channel binary is older than the launcher

--- a/internal/cli/channel_command.go
+++ b/internal/cli/channel_command.go
@@ -1,0 +1,282 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/gentleman-programming/gentle-ai/internal/state"
+)
+
+// channelStaleWarnTTL is the minimum time between stale-channel-binary warnings.
+// The warning nudges once per day instead of on every delegated command.
+const channelStaleWarnTTL = 24 * time.Hour
+
+const channelExecEnv = "GENTLE_AI_CHANNEL_TARGET"
+
+var (
+	channelExecutable              = os.Executable
+	channelRun                     = runChannelTarget
+	channelGoInstall               = goInstallChannelBinary
+	goToolchainAvailable           = defaultGoToolchainAvailable
+	channelStderr        io.Writer = os.Stderr
+	channelStaleNow                = time.Now
+)
+
+// defaultGoToolchainAvailable reports whether a `go` toolchain is on PATH. Non-stable
+// channels are built from source via `go install ...@main`, so this is checked before
+// attempting the build to surface an actionable message instead of a raw exec error.
+func defaultGoToolchainAvailable() bool {
+	_, err := exec.LookPath("go")
+	return err == nil
+}
+
+// RunChannel shows or changes the active Gentle AI runtime channel.
+func RunChannel(args []string, stdout io.Writer) error {
+	if len(args) == 0 {
+		channel, err := ResolveInstallChannel("")
+		if err != nil {
+			return err
+		}
+		path, _ := ActiveChannelBinaryPath(channel)
+		_, _ = fmt.Fprintf(stdout, "Gentle AI channel: %s\n", channel)
+		if path != "" {
+			_, _ = fmt.Fprintf(stdout, "Binary: %s\n", path)
+		}
+		return nil
+	}
+	if len(args) != 1 {
+		return fmt.Errorf("usage: gentle-ai channel [stable|beta] (nightly = beta)")
+	}
+
+	channel, err := ResolveInstallChannel(args[0])
+	if err != nil {
+		return err
+	}
+	path, err := ActivateChannel(channel)
+	if err != nil {
+		return err
+	}
+	_, _ = fmt.Fprintf(stdout, "Gentle AI channel set to %s\n", channel)
+	_, _ = fmt.Fprintf(stdout, "Binary: %s\n", path)
+	return nil
+}
+
+// MaybeExecChannelTarget delegates to the configured channel binary. The launcher
+// keeps `gentle-ai channel ...` available even when the selected target binary does
+// not yet include the channel command.
+func MaybeExecChannelTarget(args []string) (bool, error) {
+	if os.Getenv(channelExecEnv) == "1" {
+		return false, nil
+	}
+	if len(args) > 0 && isLauncherOwnedCommand(args[0]) {
+		return false, nil
+	}
+	channel, err := ResolveInstallChannel("")
+	if err != nil {
+		return false, err
+	}
+	if channel == ChannelStable {
+		return false, nil
+	}
+	target, err := ChannelBinaryPath(channel)
+	if err != nil {
+		return false, err
+	}
+	if _, err := os.Stat(target); err != nil {
+		return false, nil
+	}
+	current, err := channelExecutable()
+	if err == nil {
+		if sameExecutable(current, target) {
+			return false, nil
+		}
+		// A launcher that is newer than the channel binary signals an out-of-band
+		// launcher update (e.g. `brew upgrade gentle-ai`) that left the channel
+		// binary stale. Warn — the launcher still delegates so the user keeps
+		// working, but their channel build is no longer fresh. Gated to once per
+		// day so it nudges without nagging on every delegated command.
+		if channelBinaryStale(current, target) && shouldWarnChannelStale() {
+			fmt.Fprintf(channelStderr, "warning: the %s channel binary is older than the launcher (e.g. after `brew upgrade`); run `gentle-ai channel %s` to rebuild it.\n", channel, channel)
+		}
+	}
+	env := append(os.Environ(), channelExecEnv+"=1", "GENTLE_AI_NO_SELF_UPDATE=1")
+	return true, channelRun(target, args, env)
+}
+
+// shouldWarnChannelStale gates the stale-binary warning behind a once-per-day TTL
+// using LastChannelStaleWarning in state.json. It returns true (and records the new
+// timestamp) when a warning is due. Best-effort: if home resolution fails it warns
+// without recording (fail-open); a future timestamp from clock skew never suppresses.
+func shouldWarnChannelStale() bool {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return true
+	}
+	now := channelStaleNow()
+	if s, err := state.Read(home); err == nil && s.LastChannelStaleWarning != nil {
+		if elapsed := now.Sub(*s.LastChannelStaleWarning); elapsed >= 0 && elapsed < channelStaleWarnTTL {
+			return false
+		}
+	}
+	recordChannelStaleWarning(home, now)
+	return true
+}
+
+// recordChannelStaleWarning persists the warning timestamp, re-reading state first so
+// it never clobbers unrelated fields. A corrupt/unreadable (but present) state file is
+// left untouched; write errors are non-fatal (the next due launch retries).
+func recordChannelStaleWarning(home string, now time.Time) {
+	current, err := state.Read(home)
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return
+		}
+		current = state.InstallState{}
+	}
+	current.LastChannelStaleWarning = &now
+	_ = state.Write(home, current)
+}
+
+// channelBinaryStale reports whether the channel binary is older than the launcher
+// executable — the signature of an out-of-band launcher upgrade (e.g. brew) that
+// did not rebuild the channel binary. Best-effort: any stat failure returns false so
+// a missing/unreadable mtime never produces a spurious warning.
+func channelBinaryStale(launcherPath, channelBinaryPath string) bool {
+	launcherInfo, err := os.Stat(launcherPath)
+	if err != nil {
+		return false
+	}
+	channelInfo, err := os.Stat(channelBinaryPath)
+	if err != nil {
+		return false
+	}
+	return launcherInfo.ModTime().After(channelInfo.ModTime())
+}
+
+func isLauncherOwnedCommand(command string) bool {
+	switch command {
+	// Channel management and self-update must always run on the launcher.
+	case "channel", "update", "upgrade":
+		return true
+	// Identity and help are launcher-owned so the launcher's own version/help
+	// handlers stay reachable even when a non-stable channel target is active.
+	case "version", "--version", "-v", "help", "--help", "-h":
+		return true
+	default:
+		return false
+	}
+}
+
+func ActivateChannel(channel InstallChannel) (string, error) {
+	if channel == ChannelStable {
+		if err := SaveInstallChannel(channel); err != nil {
+			return "", err
+		}
+		return ActiveChannelBinaryPath(channel)
+	}
+	path, err := InstallChannelBinary(channel)
+	if err != nil {
+		return "", err
+	}
+	if err := SaveInstallChannel(channel); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+func InstallChannelBinary(channel InstallChannel) (string, error) {
+	// The beta channel builds from main with `go install`, which needs the Go
+	// toolchain. Validate it up front so a missing Go yields an actionable message
+	// (mirroring the install script) instead of a low-level "exec: go: not found".
+	if !goToolchainAvailable() {
+		return "", fmt.Errorf("the %s channel builds from main and requires Go 1.24+. Install Go, then run: gentle-ai channel %s", channel, channel)
+	}
+	path, err := ChannelBinaryPath(channel)
+	if err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return "", fmt.Errorf("create channel binary dir: %w", err)
+	}
+	target := "github.com/gentleman-programming/gentle-ai/cmd/gentle-ai@latest"
+	if channel.IsBeta() {
+		target = "github.com/gentleman-programming/gentle-ai/cmd/gentle-ai@main"
+	}
+	if err := channelGoInstall(target, filepath.Dir(path)); err != nil {
+		return "", fmt.Errorf("install Gentle AI %s binary: %w", channel, err)
+	}
+	return path, nil
+}
+
+func ActiveChannelBinaryPath(channel InstallChannel) (string, error) {
+	path, err := ChannelBinaryPath(channel)
+	if err != nil {
+		return "", err
+	}
+	if channel == ChannelStable {
+		current, err := channelExecutable()
+		if err != nil {
+			return "", err
+		}
+		return current, nil
+	}
+	return path, nil
+}
+
+func ChannelBinaryPath(channel InstallChannel) (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve user home directory: %w", err)
+	}
+	name := "gentle-ai"
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
+	return filepath.Join(home, ".gentle-ai", "channels", string(channel), name), nil
+}
+
+func runChannelTarget(target string, args []string, env []string) error {
+	cmd := exec.Command(target, args...)
+	cmd.Env = env
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func goInstallChannelBinary(target, binDir string) error {
+	// Derive the module from the install target (".../cmd/gentle-ai@main") so the
+	// proxy/sumdb bypass forces `@main` to resolve to the true HEAD, matching the
+	// self-upgrade path. GOBIN is appended last so it overrides any inherited value.
+	module := target
+	if i := strings.Index(target, "/cmd/"); i > 0 {
+		module = target[:i]
+	}
+	cmd := exec.Command("go", "install", target)
+	cmd.Env = append(GoProxyBypassEnv(nil, module), "GOBIN="+binDir)
+	cmd.Stdin = nil
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("go install %s: %w (output: %s)", target, err, string(out))
+	}
+	return nil
+}
+
+func sameExecutable(a, b string) bool {
+	aEval, aErr := filepath.EvalSymlinks(a)
+	bEval, bErr := filepath.EvalSymlinks(b)
+	if aErr == nil {
+		a = aEval
+	}
+	if bErr == nil {
+		b = bEval
+	}
+	return filepath.Clean(a) == filepath.Clean(b)
+}

--- a/internal/cli/channel_command_test.go
+++ b/internal/cli/channel_command_test.go
@@ -1,0 +1,631 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func unsetChannelEnv(t *testing.T) {
+	t.Helper()
+	previous, hadPrevious := os.LookupEnv(channelEnvVar)
+	if err := os.Unsetenv(channelEnvVar); err != nil {
+		t.Fatalf("Unsetenv: %v", err)
+	}
+	t.Cleanup(func() {
+		if hadPrevious {
+			_ = os.Setenv(channelEnvVar, previous)
+			return
+		}
+		_ = os.Unsetenv(channelEnvVar)
+	})
+}
+
+// isolateChannelResolution makes ResolveInstallChannel deterministic regardless of
+// the host's ~/.gentle-ai/channel file and GENTLE_AI_CHANNEL value. It points HOME
+// at a fresh empty temp dir (so the saved-channel lookup finds nothing and degrades
+// to stable) and unsets the channel env var. Tests that exercise the default install
+// channel must call this so they pass on machines with a persisted channel.
+func isolateChannelResolution(t *testing.T) {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+	unsetChannelEnv(t)
+}
+
+func TestRunChannelStablePersistsWithoutInstallingTarget(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	unsetChannelEnv(t)
+
+	origGoInstall := channelGoInstall
+	origExecutable := channelExecutable
+	t.Cleanup(func() {
+		channelGoInstall = origGoInstall
+		channelExecutable = origExecutable
+	})
+
+	channelGoInstall = func(target, binDir string) error {
+		t.Fatalf("stable channel must not require go install; got target=%q binDir=%q", target, binDir)
+		return nil
+	}
+	launcherPath := filepath.Join(home, "launcher", "gentle-ai")
+	channelExecutable = func() (string, error) { return launcherPath, nil }
+
+	var out bytes.Buffer
+	if err := RunChannel([]string{"stable"}, &out); err != nil {
+		t.Fatalf("RunChannel(stable): %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(home, ".gentle-ai", "channel"))
+	if err != nil {
+		t.Fatalf("read channel file: %v", err)
+	}
+	if string(data) != "stable\n" {
+		t.Fatalf("channel file = %q, want stable", string(data))
+	}
+	if !bytes.Contains(out.Bytes(), []byte("Binary: "+launcherPath)) {
+		t.Fatalf("output = %q, want launcher binary path %q", out.String(), launcherPath)
+	}
+}
+
+func TestRunChannelInstallsTargetAndPersistsChannel(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	unsetChannelEnv(t)
+
+	origGoInstall := channelGoInstall
+	origGoAvailable := goToolchainAvailable
+	t.Cleanup(func() {
+		channelGoInstall = origGoInstall
+		goToolchainAvailable = origGoAvailable
+	})
+	// Pin the toolchain probe so the test never depends on the host having Go.
+	goToolchainAvailable = func() bool { return true }
+
+	var gotTarget string
+	var gotBinDir string
+	channelGoInstall = func(target, binDir string) error {
+		gotTarget = target
+		gotBinDir = binDir
+		if err := os.MkdirAll(binDir, 0o755); err != nil {
+			return err
+		}
+		return os.WriteFile(filepath.Join(binDir, "gentle-ai"), []byte("fake"), 0o755)
+	}
+
+	var out bytes.Buffer
+	if err := RunChannel([]string{"beta"}, &out); err != nil {
+		t.Fatalf("RunChannel(beta): %v", err)
+	}
+	if gotTarget != "github.com/gentleman-programming/gentle-ai/cmd/gentle-ai@main" {
+		t.Fatalf("target = %q, want beta @main", gotTarget)
+	}
+	wantBinDir := filepath.Join(home, ".gentle-ai", "channels", "beta")
+	if gotBinDir != wantBinDir {
+		t.Fatalf("binDir = %q, want %q", gotBinDir, wantBinDir)
+	}
+	data, err := os.ReadFile(filepath.Join(home, ".gentle-ai", "channel"))
+	if err != nil {
+		t.Fatalf("read channel file: %v", err)
+	}
+	if string(data) != "beta\n" {
+		t.Fatalf("channel file = %q, want beta", string(data))
+	}
+}
+
+func TestMaybeExecChannelTargetDoesNotDelegateStable(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	unsetChannelEnv(t)
+	if err := SaveInstallChannel(ChannelStable); err != nil {
+		t.Fatalf("SaveInstallChannel: %v", err)
+	}
+	target, err := ChannelBinaryPath(ChannelStable)
+	if err != nil {
+		t.Fatalf("ChannelBinaryPath: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(target, []byte("old stable target"), 0o755); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	dispatched, err := MaybeExecChannelTarget([]string{"version"})
+	if err != nil {
+		t.Fatalf("MaybeExecChannelTarget: %v", err)
+	}
+	if dispatched {
+		t.Fatal("stable channel should stay on the launcher instead of dispatching to a managed target")
+	}
+}
+
+func TestMaybeExecChannelTargetSkipsLauncherOwnedCommands(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	unsetChannelEnv(t)
+	if err := SaveInstallChannel(ChannelBeta); err != nil {
+		t.Fatalf("SaveInstallChannel: %v", err)
+	}
+	target, err := ChannelBinaryPath(ChannelBeta)
+	if err != nil {
+		t.Fatalf("ChannelBinaryPath: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(target, []byte("fake"), 0o755); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	launcherOwned := [][]string{
+		{"channel", "stable"},
+		{"update"},
+		{"upgrade"},
+		// Identity and help commands are launcher-owned so the launcher's own
+		// handlers stay reachable on a non-stable channel.
+		{"version"},
+		{"--version"},
+		{"-v"},
+		{"help"},
+		{"--help"},
+		{"-h"},
+	}
+	for _, args := range launcherOwned {
+		dispatched, err := MaybeExecChannelTarget(args)
+		if err != nil {
+			t.Fatalf("MaybeExecChannelTarget(%v): %v", args, err)
+		}
+		if dispatched {
+			t.Fatalf("%v must stay in launcher and not dispatch to target", args)
+		}
+	}
+}
+
+func TestMaybeExecChannelTargetDelegatesWhenTargetExists(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	unsetChannelEnv(t)
+	if err := SaveInstallChannel(ChannelBeta); err != nil {
+		t.Fatalf("SaveInstallChannel: %v", err)
+	}
+	target, err := ChannelBinaryPath(ChannelBeta)
+	if err != nil {
+		t.Fatalf("ChannelBinaryPath: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(target, []byte("fake"), 0o755); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	origExecutable := channelExecutable
+	origRun := channelRun
+	t.Cleanup(func() {
+		channelExecutable = origExecutable
+		channelRun = origRun
+	})
+	channelExecutable = func() (string, error) { return filepath.Join(home, "launcher", "gentle-ai"), nil }
+
+	var gotTarget string
+	var gotArgs []string
+	var gotEnv []string
+	channelRun = func(target string, args []string, env []string) error {
+		gotTarget = target
+		gotArgs = append([]string(nil), args...)
+		gotEnv = append([]string(nil), env...)
+		return nil
+	}
+
+	// Use a delegated command (not launcher-owned): version/help/channel/update/
+	// upgrade stay on the launcher, so they would not exercise the dispatch path.
+	dispatched, err := MaybeExecChannelTarget([]string{"sync"})
+	if err != nil {
+		t.Fatalf("MaybeExecChannelTarget: %v", err)
+	}
+	if !dispatched {
+		t.Fatal("expected dispatch to beta target")
+	}
+	if gotTarget != target {
+		t.Fatalf("target = %q, want %q", gotTarget, target)
+	}
+	if len(gotArgs) != 1 || gotArgs[0] != "sync" {
+		t.Fatalf("args = %v, want [sync]", gotArgs)
+	}
+	if !containsEnv(gotEnv, channelExecEnv+"=1") {
+		t.Fatalf("env missing %s=1", channelExecEnv)
+	}
+	if !containsEnv(gotEnv, "GENTLE_AI_NO_SELF_UPDATE=1") {
+		t.Fatal("delegated channel targets must not run self-update; env missing GENTLE_AI_NO_SELF_UPDATE=1")
+	}
+}
+
+func containsEnv(env []string, want string) bool {
+	for _, entry := range env {
+		if entry == want {
+			return true
+		}
+	}
+	return false
+}
+
+// writeSavedChannelFile writes raw bytes to ~/.gentle-ai/channel under the test's
+// HOME so tests can simulate persisted (or corrupt) channel preferences.
+func TestChannelBinaryStale(t *testing.T) {
+	dir := t.TempDir()
+	launcher := filepath.Join(dir, "launcher")
+	channelBin := filepath.Join(dir, "channel")
+	for _, p := range []string{launcher, channelBin} {
+		if err := os.WriteFile(p, []byte("x"), 0o755); err != nil {
+			t.Fatalf("WriteFile %s: %v", p, err)
+		}
+	}
+	base := time.Unix(1_700_000_000, 0)
+	older := base
+	newer := base.Add(time.Hour)
+
+	tests := []struct {
+		name          string
+		launcherMtime time.Time
+		channelMtime  time.Time
+		want          bool
+	}{
+		{name: "launcher newer than channel binary is stale", launcherMtime: newer, channelMtime: older, want: true},
+		{name: "channel binary newer is fresh", launcherMtime: older, channelMtime: newer, want: false},
+		{name: "equal mtimes are not stale", launcherMtime: base, channelMtime: base, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := os.Chtimes(launcher, tt.launcherMtime, tt.launcherMtime); err != nil {
+				t.Fatalf("Chtimes launcher: %v", err)
+			}
+			if err := os.Chtimes(channelBin, tt.channelMtime, tt.channelMtime); err != nil {
+				t.Fatalf("Chtimes channel: %v", err)
+			}
+			if got := channelBinaryStale(launcher, channelBin); got != tt.want {
+				t.Fatalf("channelBinaryStale = %v, want %v", got, tt.want)
+			}
+		})
+	}
+
+	// A missing path degrades to "not stale" so it never produces a spurious warning.
+	if channelBinaryStale(filepath.Join(dir, "missing"), channelBin) {
+		t.Fatal("missing launcher must not be reported stale")
+	}
+	if channelBinaryStale(launcher, filepath.Join(dir, "missing")) {
+		t.Fatal("missing channel binary must not be reported stale")
+	}
+}
+
+func TestMaybeExecChannelTargetWarnsWhenChannelBinaryStale(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	unsetChannelEnv(t)
+	if err := SaveInstallChannel(ChannelBeta); err != nil {
+		t.Fatalf("SaveInstallChannel: %v", err)
+	}
+	target, err := ChannelBinaryPath(ChannelBeta)
+	if err != nil {
+		t.Fatalf("ChannelBinaryPath: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(target, []byte("stale beta"), 0o755); err != nil {
+		t.Fatalf("WriteFile target: %v", err)
+	}
+	launcher := filepath.Join(home, "launcher", "gentle-ai")
+	if err := os.MkdirAll(filepath.Dir(launcher), 0o755); err != nil {
+		t.Fatalf("MkdirAll launcher: %v", err)
+	}
+	if err := os.WriteFile(launcher, []byte("new launcher"), 0o755); err != nil {
+		t.Fatalf("WriteFile launcher: %v", err)
+	}
+	// Launcher rebuilt after the channel binary (the brew-upgrade signature).
+	base := time.Unix(1_700_000_000, 0)
+	if err := os.Chtimes(target, base, base); err != nil {
+		t.Fatalf("Chtimes target: %v", err)
+	}
+	if err := os.Chtimes(launcher, base.Add(time.Hour), base.Add(time.Hour)); err != nil {
+		t.Fatalf("Chtimes launcher: %v", err)
+	}
+
+	origExecutable := channelExecutable
+	origRun := channelRun
+	origStderr := channelStderr
+	var warn bytes.Buffer
+	t.Cleanup(func() {
+		channelExecutable = origExecutable
+		channelRun = origRun
+		channelStderr = origStderr
+	})
+	channelExecutable = func() (string, error) { return launcher, nil }
+	channelRun = func(string, []string, []string) error { return nil }
+	channelStderr = &warn
+
+	dispatched, err := MaybeExecChannelTarget([]string{"sync"})
+	if err != nil {
+		t.Fatalf("MaybeExecChannelTarget: %v", err)
+	}
+	if !dispatched {
+		t.Fatal("expected delegation to the beta target")
+	}
+	if !strings.Contains(warn.String(), "older than the launcher") {
+		t.Fatalf("expected staleness warning, got %q", warn.String())
+	}
+
+	// When the channel binary is newer than the launcher, no warning is emitted.
+	warn.Reset()
+	if err := os.Chtimes(target, base.Add(2*time.Hour), base.Add(2*time.Hour)); err != nil {
+		t.Fatalf("Chtimes target fresh: %v", err)
+	}
+	if _, err := MaybeExecChannelTarget([]string{"sync"}); err != nil {
+		t.Fatalf("MaybeExecChannelTarget fresh: %v", err)
+	}
+	if warn.Len() != 0 {
+		t.Fatalf("fresh channel binary must not warn, got %q", warn.String())
+	}
+}
+
+func TestMaybeExecChannelTargetStaleWarningCooldown(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	unsetChannelEnv(t)
+	if err := SaveInstallChannel(ChannelBeta); err != nil {
+		t.Fatalf("SaveInstallChannel: %v", err)
+	}
+	target, err := ChannelBinaryPath(ChannelBeta)
+	if err != nil {
+		t.Fatalf("ChannelBinaryPath: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(target, []byte("stale beta"), 0o755); err != nil {
+		t.Fatalf("WriteFile target: %v", err)
+	}
+	launcher := filepath.Join(home, "launcher", "gentle-ai")
+	if err := os.MkdirAll(filepath.Dir(launcher), 0o755); err != nil {
+		t.Fatalf("MkdirAll launcher: %v", err)
+	}
+	if err := os.WriteFile(launcher, []byte("new launcher"), 0o755); err != nil {
+		t.Fatalf("WriteFile launcher: %v", err)
+	}
+	base := time.Unix(1_700_000_000, 0)
+	if err := os.Chtimes(target, base, base); err != nil {
+		t.Fatalf("Chtimes target: %v", err)
+	}
+	if err := os.Chtimes(launcher, base.Add(time.Hour), base.Add(time.Hour)); err != nil {
+		t.Fatalf("Chtimes launcher: %v", err)
+	}
+
+	origExecutable := channelExecutable
+	origRun := channelRun
+	origStderr := channelStderr
+	origNow := channelStaleNow
+	var warn bytes.Buffer
+	now := base.Add(48 * time.Hour) // well past any prior warning
+	t.Cleanup(func() {
+		channelExecutable = origExecutable
+		channelRun = origRun
+		channelStderr = origStderr
+		channelStaleNow = origNow
+	})
+	channelExecutable = func() (string, error) { return launcher, nil }
+	channelRun = func(string, []string, []string) error { return nil }
+	channelStderr = &warn
+	channelStaleNow = func() time.Time { return now }
+
+	warned := func() bool {
+		warn.Reset()
+		if _, err := MaybeExecChannelTarget([]string{"sync"}); err != nil {
+			t.Fatalf("MaybeExecChannelTarget: %v", err)
+		}
+		return strings.Contains(warn.String(), "older than the launcher")
+	}
+
+	// First stale launch: warns and records the timestamp.
+	if !warned() {
+		t.Fatal("first stale launch must warn")
+	}
+	// Second launch within the 24h window: suppressed by cooldown.
+	if warned() {
+		t.Fatal("second launch within cooldown must not warn")
+	}
+	// Advance past the TTL: warns again.
+	now = now.Add(channelStaleWarnTTL + time.Minute)
+	if !warned() {
+		t.Fatal("launch after the cooldown window must warn again")
+	}
+}
+
+func writeSavedChannelFile(t *testing.T, contents string) {
+	t.Helper()
+	path, err := channelFilePath()
+	if err != nil {
+		t.Fatalf("channelFilePath: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+}
+
+// TestResolveInstallChannelSavedFileDegradesGracefully verifies that the saved
+// channel file is a best-effort preference cache: a corrupt/garbage value must
+// degrade to stable without ever surfacing an error (FIX 1), while a valid saved
+// value is honored.
+func TestResolveInstallChannelSavedFileDegradesGracefully(t *testing.T) {
+	tests := []struct {
+		name  string
+		saved string
+		want  InstallChannel
+	}{
+		{name: "garbage value degrades to stable", saved: "garbage", want: ChannelStable},
+		{name: "empty file degrades to stable", saved: "", want: ChannelStable},
+		{name: "whitespace file degrades to stable", saved: "   \n", want: ChannelStable},
+		{name: "valid beta is honored", saved: "beta\n", want: ChannelBeta},
+		{name: "valid stable is honored", saved: "stable\n", want: ChannelStable},
+		{name: "nightly alias resolves to beta", saved: "nightly\n", want: ChannelBeta},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("HOME", t.TempDir())
+			unsetChannelEnv(t)
+			writeSavedChannelFile(t, tt.saved)
+
+			got, err := ResolveInstallChannel("")
+			if err != nil {
+				t.Fatalf("ResolveInstallChannel(\"\") error = %v, want nil (saved file must never error)", err)
+			}
+			if got != tt.want {
+				t.Fatalf("ResolveInstallChannel(\"\") = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestMaybeExecChannelTargetCorruptSavedFileStaysOnLauncher verifies that a garbage
+// saved channel file does not brick the binary: dispatch resolves to stable and the
+// launcher keeps control with no error (FIX 1).
+func TestMaybeExecChannelTargetCorruptSavedFileStaysOnLauncher(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	unsetChannelEnv(t)
+	writeSavedChannelFile(t, "garbage")
+
+	dispatched, err := MaybeExecChannelTarget(nil)
+	if err != nil {
+		t.Fatalf("MaybeExecChannelTarget(nil) error = %v, want nil", err)
+	}
+	if dispatched {
+		t.Fatal("corrupt saved channel must degrade to stable and stay on the launcher")
+	}
+}
+
+// TestResolveInstallChannelEmptyEnvFallsThroughToSavedFile verifies that an
+// empty/whitespace GENTLE_AI_CHANNEL is treated as unset and falls through to the
+// saved-file preference instead of short-circuiting to stable (FIX 3).
+func TestResolveInstallChannelEmptyEnvFallsThroughToSavedFile(t *testing.T) {
+	tests := []struct {
+		name     string
+		envValue string
+	}{
+		{name: "empty env falls through", envValue: ""},
+		{name: "whitespace env falls through", envValue: "   "},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("HOME", t.TempDir())
+			t.Setenv(channelEnvVar, tt.envValue)
+			writeSavedChannelFile(t, "beta\n")
+
+			got, err := ResolveInstallChannel("")
+			if err != nil {
+				t.Fatalf("ResolveInstallChannel(\"\") error = %v", err)
+			}
+			if got != ChannelBeta {
+				t.Fatalf("ResolveInstallChannel(\"\") = %q, want beta (env must fall through to saved file)", got)
+			}
+		})
+	}
+}
+
+// TestRunChannelBetaRequiresGoToolchain verifies that activating beta without a Go
+// toolchain fails with an actionable message (mirroring the install script) instead
+// of a raw exec error, never runs go install, and never persists the channel.
+func TestRunChannelBetaRequiresGoToolchain(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	unsetChannelEnv(t)
+
+	origGoInstall := channelGoInstall
+	origGoAvailable := goToolchainAvailable
+	t.Cleanup(func() {
+		channelGoInstall = origGoInstall
+		goToolchainAvailable = origGoAvailable
+	})
+	goToolchainAvailable = func() bool { return false }
+	channelGoInstall = func(target, binDir string) error {
+		t.Fatalf("must not attempt go install when Go is unavailable; got target=%q", target)
+		return nil
+	}
+
+	var out bytes.Buffer
+	err := RunChannel([]string{"beta"}, &out)
+	if err == nil {
+		t.Fatal("RunChannel(beta) without Go must return an error")
+	}
+	if !strings.Contains(err.Error(), "requires Go 1.24+") || !strings.Contains(err.Error(), "gentle-ai channel beta") {
+		t.Fatalf("error = %q, want actionable Go-toolchain guidance", err.Error())
+	}
+	// A failed activation must not persist the channel preference.
+	if _, statErr := os.Stat(filepath.Join(home, ".gentle-ai", "channel")); !os.IsNotExist(statErr) {
+		t.Fatalf("channel must not be persisted on failed activation, stat err = %v", statErr)
+	}
+}
+
+// TestRunChannelNoArgShowsCurrentChannel verifies the no-arg show path reports the
+// resolved channel without mutating the saved preference.
+func TestRunChannelNoArgShowsCurrentChannel(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	unsetChannelEnv(t)
+	writeSavedChannelFile(t, "stable\n")
+
+	origGoInstall := channelGoInstall
+	origExecutable := channelExecutable
+	t.Cleanup(func() {
+		channelGoInstall = origGoInstall
+		channelExecutable = origExecutable
+	})
+	channelGoInstall = func(target, binDir string) error {
+		t.Fatalf("show path must not install anything; got target=%q binDir=%q", target, binDir)
+		return nil
+	}
+	launcherPath := filepath.Join(home, "launcher", "gentle-ai")
+	channelExecutable = func() (string, error) { return launcherPath, nil }
+
+	var out bytes.Buffer
+	if err := RunChannel(nil, &out); err != nil {
+		t.Fatalf("RunChannel(nil): %v", err)
+	}
+	if !bytes.Contains(out.Bytes(), []byte("Gentle AI channel: stable")) {
+		t.Fatalf("output = %q, want current channel stable", out.String())
+	}
+	// The show path must not have written or changed the saved file.
+	data, err := os.ReadFile(filepath.Join(home, ".gentle-ai", "channel"))
+	if err != nil {
+		t.Fatalf("read channel file: %v", err)
+	}
+	if string(data) != "stable\n" {
+		t.Fatalf("channel file = %q, want unchanged stable", string(data))
+	}
+}
+
+// TestRunChannelRejectsInvalidInput verifies that an explicit invalid channel
+// argument is rejected with an error (FIX 4 messaging) and never persisted.
+func TestRunChannelRejectsInvalidInput(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	unsetChannelEnv(t)
+
+	var out bytes.Buffer
+	err := RunChannel([]string{"engram-beta"}, &out)
+	if err == nil {
+		t.Fatal("RunChannel(engram-beta) error = nil, want rejection of invalid channel")
+	}
+	if !strings.Contains(err.Error(), "unsupported Gentle AI channel") {
+		t.Fatalf("error = %q, want unsupported-channel message", err.Error())
+	}
+	// Invalid input must not create the saved channel file.
+	if _, statErr := os.Stat(filepath.Join(home, ".gentle-ai", "channel")); !os.IsNotExist(statErr) {
+		t.Fatalf("channel file should not exist after invalid input; stat err = %v", statErr)
+	}
+}

--- a/internal/cli/channel_command_test.go
+++ b/internal/cli/channel_command_test.go
@@ -2,11 +2,17 @@ package cli
 
 import (
 	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
+
+	"github.com/gentleman-programming/gentle-ai/internal/state"
 )
 
 func unsetChannelEnv(t *testing.T) {
@@ -259,6 +265,96 @@ func containsEnv(env []string, want string) bool {
 	return false
 }
 
+// fakeExitError implements the ExitCode() int interface that *exec.ExitError
+// satisfies, so exit-code propagation can be tested hermetically without
+// spawning a real process.
+type fakeExitError struct {
+	code int
+}
+
+func (e fakeExitError) Error() string { return fmt.Sprintf("exit status %d", e.code) }
+func (e fakeExitError) ExitCode() int { return e.code }
+
+// TestMaybeExecChannelTargetPropagatesChildExitCode verifies that when the
+// delegated channel binary exits non-zero, the launcher exits transparently with
+// the child's exit code instead of collapsing every failure to 1 with a spurious
+// "Error:" wrapper line. Non-exit errors (e.g. binary not found) must still bubble
+// up as real errors so the top-level error handler reports them.
+func TestMaybeExecChannelTargetPropagatesChildExitCode(t *testing.T) {
+	tests := []struct {
+		name         string
+		runErr       error
+		wantExit     bool
+		wantExitCode int
+		wantErr      bool
+	}{
+		{name: "child exits non-zero propagates code", runErr: fakeExitError{code: 42}, wantExit: true, wantExitCode: 42},
+		{name: "child exits with 2 propagates 2", runErr: fakeExitError{code: 2}, wantExit: true, wantExitCode: 2},
+		// A signal-terminated child reports ExitCode() == -1; os.Exit would coerce that
+		// to 255, so the launcher clamps any negative code to a conventional 1.
+		{name: "signal-terminated child clamps -1 to 1", runErr: fakeExitError{code: -1}, wantExit: true, wantExitCode: 1},
+		{name: "non-exit error bubbles up", runErr: errors.New("exec: \"gentle-ai\": executable file not found"), wantErr: true},
+		{name: "success neither exits nor errors", runErr: nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			t.Setenv("USERPROFILE", home)
+			unsetChannelEnv(t)
+			if err := SaveInstallChannel(ChannelBeta); err != nil {
+				t.Fatalf("SaveInstallChannel: %v", err)
+			}
+			target, err := ChannelBinaryPath(ChannelBeta)
+			if err != nil {
+				t.Fatalf("ChannelBinaryPath: %v", err)
+			}
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+				t.Fatalf("MkdirAll: %v", err)
+			}
+			if err := os.WriteFile(target, []byte("fake"), 0o755); err != nil {
+				t.Fatalf("WriteFile: %v", err)
+			}
+
+			origExecutable := channelExecutable
+			origRun := channelRun
+			origExit := channelExit
+			t.Cleanup(func() {
+				channelExecutable = origExecutable
+				channelRun = origRun
+				channelExit = origExit
+			})
+			channelExecutable = func() (string, error) { return filepath.Join(home, "launcher", "gentle-ai"), nil }
+			channelRun = func(string, []string, []string) error { return tt.runErr }
+
+			var gotExit bool
+			var gotCode int
+			channelExit = func(code int) {
+				gotExit = true
+				gotCode = code
+			}
+
+			dispatched, err := MaybeExecChannelTarget([]string{"sync"})
+			if !dispatched {
+				t.Fatalf("expected dispatch to beta target")
+			}
+			if gotExit != tt.wantExit {
+				t.Fatalf("channelExit called = %v, want %v", gotExit, tt.wantExit)
+			}
+			if tt.wantExit && gotCode != tt.wantExitCode {
+				t.Fatalf("exit code = %d, want %d", gotCode, tt.wantExitCode)
+			}
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected a non-exit error to bubble up, got nil")
+				}
+			} else if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
 func TestChannelBinaryStale(t *testing.T) {
 	dir := t.TempDir()
 	launcher := filepath.Join(dir, "launcher")
@@ -446,6 +542,189 @@ func TestMaybeExecChannelTargetStaleWarningCooldown(t *testing.T) {
 	now = now.Add(channelStaleWarnTTL + time.Minute)
 	if !warned() {
 		t.Fatal("launch after the cooldown window must warn again")
+	}
+}
+
+// TestRecordChannelStaleWarningRecoversFromCorruptState verifies that a corrupt
+// (non-NotExist) state.json does not defeat the once-per-day cooldown: recording must
+// overwrite the unreadable file with a fresh state carrying the new timestamp so a
+// subsequent shouldWarnChannelStale is cooled down within the TTL. This exercises the
+// REAL state.Read path (no seam) across every corruption shape state.Read classifies
+// as ErrCorruptState — structurally-broken JSON AND a corrupt timestamp in the
+// *time.Time field. A corrupt timestamp surfaces as *time.ParseError (not a json
+// type error), so classifying via the ErrCorruptState sentinel — rather than
+// enumerating concrete json error types — is what keeps the cooldown working.
+func TestRecordChannelStaleWarningRecoversFromCorruptState(t *testing.T) {
+	corruptBlobs := map[string]string{
+		"structurally broken json":    "{ this is not valid json",
+		"malformed RFC3339 timestamp": `{"last_channel_stale_warning":"not-a-timestamp"}`,
+		"wrong-typed timestamp":       `{"last_channel_stale_warning":12345}`,
+	}
+	for name, blob := range corruptBlobs {
+		t.Run(name, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			t.Setenv("USERPROFILE", home)
+			unsetChannelEnv(t)
+
+			// Seed a corrupt state.json so the REAL state.Read returns a non-NotExist
+			// decode error (wrapped with ErrCorruptState), exercising the recovery branch.
+			stateDir := filepath.Join(home, ".gentle-ai")
+			if err := os.MkdirAll(stateDir, 0o755); err != nil {
+				t.Fatalf("MkdirAll: %v", err)
+			}
+			if err := os.WriteFile(filepath.Join(stateDir, "state.json"), []byte(blob), 0o644); err != nil {
+				t.Fatalf("WriteFile corrupt state: %v", err)
+			}
+
+			origNow := channelStaleNow
+			t.Cleanup(func() { channelStaleNow = origNow })
+			now := time.Unix(1_700_000_000, 0)
+			channelStaleNow = func() time.Time { return now }
+
+			recordChannelStaleWarning(home, now)
+
+			// The timestamp must have been persisted despite the prior corrupt file.
+			persisted, err := state.Read(home)
+			if err != nil {
+				t.Fatalf("state.Read after record: %v (corrupt state must be overwritten)", err)
+			}
+			if persisted.LastChannelStaleWarning == nil {
+				t.Fatal("LastChannelStaleWarning was not persisted; cooldown will never record on corrupt state")
+			}
+			if !persisted.LastChannelStaleWarning.Equal(now) {
+				t.Fatalf("persisted timestamp = %v, want %v", persisted.LastChannelStaleWarning, now)
+			}
+
+			// Within the TTL the warning must now be suppressed (cooldown took effect).
+			if shouldWarnChannelStale() {
+				t.Fatal("warning should be cooled down within TTL after recording over corrupt state")
+			}
+		})
+	}
+}
+
+// TestIsResettableStateError verifies the precise classification used by
+// recordChannelStaleWarning: only a genuinely absent file (os.ErrNotExist) or a
+// genuinely undecodable file (state.ErrCorruptState) may be reset to a fresh state.
+// The classifier keys off the state.ErrCorruptState sentinel — state.Read is the
+// single source of truth that wraps it around EVERY decode failure, including ones
+// that surface as *time.ParseError or a plain errors.errorString (not just the
+// concrete json error types). Every other read error (permission/IO) must be
+// preserved so a valid-but-unreadable state.json is never clobbered.
+func TestIsResettableStateError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil error is not resettable", err: nil, want: false},
+		{name: "absent file is resettable", err: os.ErrNotExist, want: true},
+		{name: "wrapped absent file is resettable", err: fmt.Errorf("open state: %w", os.ErrNotExist), want: true},
+		{name: "ErrCorruptState sentinel is resettable", err: state.ErrCorruptState, want: true},
+		{name: "wrapped ErrCorruptState is resettable", err: fmt.Errorf("read state: %w", state.ErrCorruptState), want: true},
+		{name: "corrupt read from malformed JSON is resettable", err: corruptReadError(t, "{ not valid"), want: true},
+		{name: "corrupt read from type mismatch is resettable", err: corruptReadError(t, `{"installed_agents": 5}`), want: true},
+		{name: "corrupt read from malformed timestamp (time.ParseError) is resettable", err: corruptReadError(t, `{"last_channel_stale_warning":"not-a-timestamp"}`), want: true},
+		{name: "corrupt read from wrong-typed timestamp is resettable", err: corruptReadError(t, `{"last_channel_stale_warning":12345}`), want: true},
+		{name: "permission error is preserved", err: fmt.Errorf("open state: %w", os.ErrPermission), want: false},
+		{name: "EISDIR-style IO error is preserved", err: &os.PathError{Op: "read", Path: "state.json", Err: syscall.EISDIR}, want: false},
+		{name: "generic IO error is preserved", err: errors.New("input/output error"), want: false},
+		{name: "bare json syntax error (not via state.Read) is preserved", err: jsonSyntaxError(t), want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isResettableStateError(tt.err); got != tt.want {
+				t.Fatalf("isResettableStateError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+// corruptReadError writes the given blob to a real state.json under a temp home and
+// returns the error state.Read produces for it. This exercises the actual sentinel
+// wrapping (including nested *time.Time decode failures) rather than a hand-built
+// error, so the classifier is tested against what production code really returns.
+func corruptReadError(t *testing.T, blob string) error {
+	t.Helper()
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, ".gentle-ai"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(state.Path(home), []byte(blob), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	_, err := state.Read(home)
+	if err == nil {
+		t.Fatalf("state.Read(%q) expected a corrupt-decode error, got nil", blob)
+	}
+	return err
+}
+
+// jsonSyntaxError returns a bare *json.SyntaxError NOT routed through state.Read.
+// Under the sentinel contract this is NOT resettable on its own: only errors that
+// state.Read wraps with ErrCorruptState qualify, so a raw json error from some other
+// source must be treated conservatively (preserve).
+func jsonSyntaxError(t *testing.T) error {
+	t.Helper()
+	var v map[string]any
+	err := json.Unmarshal([]byte("{ not valid"), &v)
+	if err == nil {
+		t.Fatal("expected a JSON syntax error")
+	}
+	return err
+}
+
+// TestRecordChannelStaleWarningPreservesStateOnNonDecodeReadError verifies the
+// regression fix: when state.Read fails with a NON-decode error (a transient
+// IO/permission failure) against a state.json that actually holds valid persisted
+// data, recordChannelStaleWarning must NOT write — so InstalledAgents, Persona,
+// PendingSync, etc. are never clobbered by an unreadable-this-once read. The read
+// failure is injected via the channelStateRead seam because such errors are not
+// portably reproducible against the real filesystem.
+func TestRecordChannelStaleWarningPreservesStateOnNonDecodeReadError(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	unsetChannelEnv(t)
+
+	// Seed a genuinely valid state.json with populated fields that must survive.
+	valid := state.InstallState{
+		InstalledAgents: []string{"claude-code", "opencode"},
+		Persona:         "gentleman",
+		PendingSync:     true,
+	}
+	if err := state.Write(home, valid); err != nil {
+		t.Fatalf("seed valid state: %v", err)
+	}
+
+	origRead := channelStateRead
+	t.Cleanup(func() { channelStateRead = origRead })
+	// Simulate a transient IO/permission read failure (not a decode error, not NotExist).
+	channelStateRead = func(string) (state.InstallState, error) {
+		return state.InstallState{}, &os.PathError{Op: "open", Path: state.Path(home), Err: os.ErrPermission}
+	}
+
+	now := time.Unix(1_700_000_000, 0)
+	recordChannelStaleWarning(home, now)
+
+	// The conservative branch must NOT have written: the on-disk state is untouched.
+	// Read with the real reader (restore happens at cleanup, so read directly).
+	persisted, err := origRead(home)
+	if err != nil {
+		t.Fatalf("state.Read after record: %v", err)
+	}
+	if len(persisted.InstalledAgents) != 2 || persisted.InstalledAgents[0] != "claude-code" || persisted.InstalledAgents[1] != "opencode" {
+		t.Fatalf("InstalledAgents clobbered: got %v, want [claude-code opencode]", persisted.InstalledAgents)
+	}
+	if persisted.Persona != "gentleman" {
+		t.Fatalf("Persona clobbered: got %q, want gentleman", persisted.Persona)
+	}
+	if !persisted.PendingSync {
+		t.Fatal("PendingSync clobbered: got false, want true")
+	}
+	if persisted.LastChannelStaleWarning != nil {
+		t.Fatal("timestamp was written on a non-decode read error; the conservative branch must not write")
 	}
 }
 

--- a/internal/cli/channel_command_test.go
+++ b/internal/cli/channel_command_test.go
@@ -31,13 +31,16 @@ func unsetChannelEnv(t *testing.T) {
 // channel must call this so they pass on machines with a persisted channel.
 func isolateChannelResolution(t *testing.T) {
 	t.Helper()
-	t.Setenv("HOME", t.TempDir())
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
 	unsetChannelEnv(t)
 }
 
 func TestRunChannelStablePersistsWithoutInstallingTarget(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
 	unsetChannelEnv(t)
 
 	origGoInstall := channelGoInstall
@@ -73,6 +76,7 @@ func TestRunChannelStablePersistsWithoutInstallingTarget(t *testing.T) {
 func TestRunChannelInstallsTargetAndPersistsChannel(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
 	unsetChannelEnv(t)
 
 	origGoInstall := channelGoInstall
@@ -118,6 +122,7 @@ func TestRunChannelInstallsTargetAndPersistsChannel(t *testing.T) {
 func TestMaybeExecChannelTargetDoesNotDelegateStable(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
 	unsetChannelEnv(t)
 	if err := SaveInstallChannel(ChannelStable); err != nil {
 		t.Fatalf("SaveInstallChannel: %v", err)
@@ -145,6 +150,7 @@ func TestMaybeExecChannelTargetDoesNotDelegateStable(t *testing.T) {
 func TestMaybeExecChannelTargetSkipsLauncherOwnedCommands(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
 	unsetChannelEnv(t)
 	if err := SaveInstallChannel(ChannelBeta); err != nil {
 		t.Fatalf("SaveInstallChannel: %v", err)
@@ -187,6 +193,7 @@ func TestMaybeExecChannelTargetSkipsLauncherOwnedCommands(t *testing.T) {
 func TestMaybeExecChannelTargetDelegatesWhenTargetExists(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
 	unsetChannelEnv(t)
 	if err := SaveInstallChannel(ChannelBeta); err != nil {
 		t.Fatalf("SaveInstallChannel: %v", err)
@@ -252,8 +259,6 @@ func containsEnv(env []string, want string) bool {
 	return false
 }
 
-// writeSavedChannelFile writes raw bytes to ~/.gentle-ai/channel under the test's
-// HOME so tests can simulate persisted (or corrupt) channel preferences.
 func TestChannelBinaryStale(t *testing.T) {
 	dir := t.TempDir()
 	launcher := filepath.Join(dir, "launcher")
@@ -303,6 +308,7 @@ func TestChannelBinaryStale(t *testing.T) {
 func TestMaybeExecChannelTargetWarnsWhenChannelBinaryStale(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
 	unsetChannelEnv(t)
 	if err := SaveInstallChannel(ChannelBeta); err != nil {
 		t.Fatalf("SaveInstallChannel: %v", err)
@@ -373,6 +379,7 @@ func TestMaybeExecChannelTargetWarnsWhenChannelBinaryStale(t *testing.T) {
 func TestMaybeExecChannelTargetStaleWarningCooldown(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
 	unsetChannelEnv(t)
 	if err := SaveInstallChannel(ChannelBeta); err != nil {
 		t.Fatalf("SaveInstallChannel: %v", err)
@@ -442,6 +449,8 @@ func TestMaybeExecChannelTargetStaleWarningCooldown(t *testing.T) {
 	}
 }
 
+// writeSavedChannelFile writes raw bytes to ~/.gentle-ai/channel under the test's
+// HOME so tests can simulate persisted (or corrupt) channel preferences.
 func writeSavedChannelFile(t *testing.T, contents string) {
 	t.Helper()
 	path, err := channelFilePath()
@@ -476,7 +485,9 @@ func TestResolveInstallChannelSavedFileDegradesGracefully(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Setenv("HOME", t.TempDir())
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			t.Setenv("USERPROFILE", home)
 			unsetChannelEnv(t)
 			writeSavedChannelFile(t, tt.saved)
 
@@ -495,7 +506,9 @@ func TestResolveInstallChannelSavedFileDegradesGracefully(t *testing.T) {
 // saved channel file does not brick the binary: dispatch resolves to stable and the
 // launcher keeps control with no error (FIX 1).
 func TestMaybeExecChannelTargetCorruptSavedFileStaysOnLauncher(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
 	unsetChannelEnv(t)
 	writeSavedChannelFile(t, "garbage")
 
@@ -522,7 +535,9 @@ func TestResolveInstallChannelEmptyEnvFallsThroughToSavedFile(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Setenv("HOME", t.TempDir())
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			t.Setenv("USERPROFILE", home)
 			t.Setenv(channelEnvVar, tt.envValue)
 			writeSavedChannelFile(t, "beta\n")
 
@@ -543,6 +558,7 @@ func TestResolveInstallChannelEmptyEnvFallsThroughToSavedFile(t *testing.T) {
 func TestRunChannelBetaRequiresGoToolchain(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
 	unsetChannelEnv(t)
 
 	origGoInstall := channelGoInstall
@@ -576,6 +592,7 @@ func TestRunChannelBetaRequiresGoToolchain(t *testing.T) {
 func TestRunChannelNoArgShowsCurrentChannel(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
 	unsetChannelEnv(t)
 	writeSavedChannelFile(t, "stable\n")
 
@@ -614,6 +631,7 @@ func TestRunChannelNoArgShowsCurrentChannel(t *testing.T) {
 func TestRunChannelRejectsInvalidInput(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
 	unsetChannelEnv(t)
 
 	var out bytes.Buffer

--- a/internal/cli/channel_test.go
+++ b/internal/cli/channel_test.go
@@ -1,11 +1,17 @@
 package cli
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
 
 func TestResolveInstallChannel(t *testing.T) {
+	// Point HOME at an empty temp dir so the saved-channel preference cache is
+	// absent and the default/unset paths deterministically resolve to stable,
+	// regardless of the host's ~/.gentle-ai/channel.
+	t.Setenv("HOME", t.TempDir())
 	t.Setenv(channelEnvVar, "")
 
 	tests := []struct {
@@ -21,8 +27,10 @@ func TestResolveInstallChannel(t *testing.T) {
 		{name: "env beta", envValue: "beta", want: ChannelBeta},
 		{name: "flag wins over env", flagValue: "stable", envValue: "beta", want: ChannelStable},
 		{name: "invalid", flagValue: "engram-beta", wantErr: true},
-		// Spec: empty-string env var treated as unset → stable (slice 3 channel-honoring).
-		{name: "empty env string defaults stable", flagValue: "", envValue: "", want: ChannelStable},
+		// Empty/whitespace env is treated as unset and falls through to the saved
+		// file; with no saved file present (temp HOME) that resolves to stable.
+		{name: "empty env string falls through to stable", flagValue: "", envValue: "", want: ChannelStable},
+		{name: "whitespace env string falls through to stable", flagValue: "", envValue: "   ", want: ChannelStable},
 	}
 
 	for _, tt := range tests {
@@ -33,11 +41,63 @@ func TestResolveInstallChannel(t *testing.T) {
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("ResolveInstallChannel(%q) error = %v, wantErr %v", tt.flagValue, err, tt.wantErr)
 			}
-			if tt.wantErr && !strings.Contains(err.Error(), "nightly") {
-				t.Fatalf("error = %q, want nightly mentioned", err.Error())
+			if tt.wantErr && !strings.Contains(err.Error(), "unsupported Gentle AI channel") {
+				t.Fatalf("error = %q, want unsupported-channel wording", err.Error())
 			}
 			if got != tt.want {
 				t.Fatalf("ResolveInstallChannel(%q) = %q, want %q", tt.flagValue, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestSaveInstallChannelPersistsCanonicalForm locks the single-source-of-truth
+// contract of SaveInstallChannel: it shares parseInstallChannel for validity and
+// always persists the canonical channel, so "nightly" round-trips as beta and an
+// invalid value is rejected without writing the file.
+func TestSaveInstallChannelPersistsCanonicalForm(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv(channelEnvVar, "")
+
+	tests := []struct {
+		name    string
+		input   InstallChannel
+		want    string // persisted file contents; empty means no file should exist
+		wantErr bool
+	}{
+		{name: "stable persists stable", input: ChannelStable, want: "stable\n"},
+		{name: "beta persists beta", input: ChannelBeta, want: "beta\n"},
+		{name: "nightly canonicalizes to beta", input: InstallChannel("nightly"), want: "beta\n"},
+		{name: "invalid value is rejected and not written", input: InstallChannel("engram-beta"), wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Fresh HOME per case so a rejected write cannot read a prior file.
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			path := filepath.Join(home, ".gentle-ai", "channel")
+
+			err := SaveInstallChannel(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("SaveInstallChannel(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+			}
+			if tt.wantErr {
+				if !strings.Contains(err.Error(), "unsupported Gentle AI channel") {
+					t.Fatalf("error = %q, want unsupported-channel wording consistent with ResolveInstallChannel", err.Error())
+				}
+				if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
+					t.Fatalf("rejected channel must not write the file, stat err = %v", statErr)
+				}
+				return
+			}
+
+			data, readErr := os.ReadFile(path)
+			if readErr != nil {
+				t.Fatalf("read channel file: %v", readErr)
+			}
+			if string(data) != tt.want {
+				t.Fatalf("channel file = %q, want %q", string(data), tt.want)
 			}
 		})
 	}

--- a/internal/cli/channel_test.go
+++ b/internal/cli/channel_test.go
@@ -11,7 +11,9 @@ func TestResolveInstallChannel(t *testing.T) {
 	// Point HOME at an empty temp dir so the saved-channel preference cache is
 	// absent and the default/unset paths deterministically resolve to stable,
 	// regardless of the host's ~/.gentle-ai/channel.
-	t.Setenv("HOME", t.TempDir())
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
 	t.Setenv(channelEnvVar, "")
 
 	tests := []struct {
@@ -56,7 +58,9 @@ func TestResolveInstallChannel(t *testing.T) {
 // always persists the canonical channel, so "nightly" round-trips as beta and an
 // invalid value is rejected without writing the file.
 func TestSaveInstallChannelPersistsCanonicalForm(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
 	t.Setenv(channelEnvVar, "")
 
 	tests := []struct {
@@ -76,6 +80,7 @@ func TestSaveInstallChannelPersistsCanonicalForm(t *testing.T) {
 			// Fresh HOME per case so a rejected write cannot read a prior file.
 			home := t.TempDir()
 			t.Setenv("HOME", home)
+			t.Setenv("USERPROFILE", home)
 			path := filepath.Join(home, ".gentle-ai", "channel")
 
 			err := SaveInstallChannel(tt.input)

--- a/internal/cli/goproxy.go
+++ b/internal/cli/goproxy.go
@@ -1,0 +1,60 @@
+package cli
+
+import (
+	"os"
+	"strings"
+)
+
+// GoProxyBypassEnv returns a copy of base (or the current environment when base is
+// nil) with the given module prepended to GONOSUMDB, GOPRIVATE and GONOPROXY. This
+// makes `go install <module>...@main` fetch the true HEAD directly from the source
+// instead of a proxy/sumdb-cached pseudo-version. It is shared by the channel install
+// flow and the self-upgrade flow so both build beta identically.
+func GoProxyBypassEnv(base []string, module string) []string {
+	if base == nil {
+		base = os.Environ()
+	}
+	env := append([]string{}, base...)
+	for _, key := range []string{"GONOSUMDB", "GOPRIVATE", "GONOPROXY"} {
+		env = setGoEnvValue(env, key, prependGoPattern(getGoEnvValue(env, key), module))
+	}
+	return env
+}
+
+func getGoEnvValue(env []string, key string) string {
+	prefix := key + "="
+	for i := len(env) - 1; i >= 0; i-- {
+		if strings.HasPrefix(env[i], prefix) {
+			return strings.TrimPrefix(env[i], prefix)
+		}
+	}
+	return ""
+}
+
+func setGoEnvValue(env []string, key, value string) []string {
+	prefix := key + "="
+	for i := len(env) - 1; i >= 0; i-- {
+		if strings.HasPrefix(env[i], prefix) {
+			env[i] = prefix + value
+			return env
+		}
+	}
+	return append(env, prefix+value)
+}
+
+func prependGoPattern(existing, pattern string) string {
+	pattern = strings.TrimSpace(pattern)
+	if pattern == "" {
+		return existing
+	}
+	parts := strings.Split(existing, ",")
+	for _, part := range parts {
+		if strings.TrimSpace(part) == pattern {
+			return existing
+		}
+	}
+	if strings.TrimSpace(existing) == "" {
+		return pattern
+	}
+	return pattern + "," + existing
+}

--- a/internal/cli/goproxy_test.go
+++ b/internal/cli/goproxy_test.go
@@ -1,0 +1,34 @@
+package cli
+
+import "testing"
+
+func TestGoProxyBypassEnvPreservesExistingPatterns(t *testing.T) {
+	module := "github.com/gentleman-programming/gentle-ai"
+	env := GoProxyBypassEnv([]string{
+		"PATH=/usr/bin",
+		"GONOSUMDB=example.com/private",
+		"GOPRIVATE=github.com/acme/*",
+		"GONOPROXY=github.com/gentleman-programming/gentle-ai",
+	}, module)
+
+	for _, want := range []string{
+		"PATH=/usr/bin",
+		"GONOSUMDB=github.com/gentleman-programming/gentle-ai,example.com/private",
+		"GOPRIVATE=github.com/gentleman-programming/gentle-ai,github.com/acme/*",
+		// Already present: must not be duplicated.
+		"GONOPROXY=github.com/gentleman-programming/gentle-ai",
+	} {
+		if !goEnvContains(env, want) {
+			t.Fatalf("env missing %q in %v", want, env)
+		}
+	}
+}
+
+func goEnvContains(env []string, want string) bool {
+	for _, entry := range env {
+		if entry == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/cli/install_test.go
+++ b/internal/cli/install_test.go
@@ -63,6 +63,7 @@ func TestModelAssignmentsToStatePreservesEffort(t *testing.T) {
 }
 
 func TestNormalizeInstallFlagsDefaults(t *testing.T) {
+	isolateChannelResolution(t)
 	input, err := NormalizeInstallFlags(InstallFlags{}, system.DetectionResult{})
 	if err != nil {
 		t.Fatalf("NormalizeInstallFlags() error = %v", err)

--- a/internal/cli/run_engram_download_test.go
+++ b/internal/cli/run_engram_download_test.go
@@ -14,6 +14,7 @@ import (
 // Linux engram installation does NOT use "go install" but instead calls
 // DownloadLatestBinary (i.e. no "go install" in recorder.get()).
 func TestRunInstallLinuxEngramUsesDownloadNotGoInstall(t *testing.T) {
+	isolateChannelResolution(t)
 	home := t.TempDir()
 	restoreHome := osUserHomeDir
 	restoreCommand := runCommand
@@ -62,6 +63,7 @@ func TestRunInstallLinuxEngramUsesDownloadNotGoInstall(t *testing.T) {
 // the engram binary, its directory is prepended to PATH so that subsequent
 // commands (engram setup, resolveEngramCommand) can find it.
 func TestRunInstallEngramDownloadAddsBinDirToPath(t *testing.T) {
+	isolateChannelResolution(t)
 	home := t.TempDir()
 	restoreHome := osUserHomeDir
 	restoreCommand := runCommand
@@ -106,6 +108,7 @@ func TestRunInstallEngramDownloadAddsBinDirToPath(t *testing.T) {
 
 // TestRunInstallWindowsEngramUsesDownloadNotGoInstall verifies Windows path.
 func TestRunInstallWindowsEngramUsesDownloadNotGoInstall(t *testing.T) {
+	isolateChannelResolution(t)
 	home := t.TempDir()
 	restoreHome := osUserHomeDir
 	restoreCommand := runCommand
@@ -162,6 +165,7 @@ func TestRunInstallWindowsEngramUsesDownloadNotGoInstall(t *testing.T) {
 
 // TestRunInstallMacOSEngramStillUsesBrew verifies macOS unchanged.
 func TestRunInstallMacOSEngramStillUsesBrew(t *testing.T) {
+	isolateChannelResolution(t)
 	home := t.TempDir()
 	restoreHome := osUserHomeDir
 	restoreCommand := runCommand

--- a/internal/cli/run_integration_test.go
+++ b/internal/cli/run_integration_test.go
@@ -211,6 +211,7 @@ func TestPiAgentInstallRunsPackageCommandsWhenPiAlreadyInstalled(t *testing.T) {
 }
 
 func TestRunInstallRollsBackOnComponentFailure(t *testing.T) {
+	isolateChannelResolution(t)
 	home := t.TempDir()
 	settingsPath := filepath.Join(home, ".config", "opencode", "opencode.json")
 	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
@@ -380,6 +381,7 @@ func TestRunInstallLinuxArchResolvesPacmanCommands(t *testing.T) {
 }
 
 func TestRunInstallLinuxUbuntuWithEngramUsesDirectDownload(t *testing.T) {
+	isolateChannelResolution(t)
 	home := t.TempDir()
 	restoreHome := osUserHomeDir
 	restoreCommand := runCommand
@@ -424,6 +426,7 @@ func TestRunInstallLinuxUbuntuWithEngramUsesDirectDownload(t *testing.T) {
 }
 
 func TestRunInstallLinuxArchWithEngramUsesDirectDownload(t *testing.T) {
+	isolateChannelResolution(t)
 	home := t.TempDir()
 	restoreHome := osUserHomeDir
 	restoreCommand := runCommand
@@ -467,6 +470,7 @@ func TestRunInstallLinuxArchWithEngramUsesDirectDownload(t *testing.T) {
 }
 
 func TestRunInstallLinuxRollsBackOnComponentFailure(t *testing.T) {
+	isolateChannelResolution(t)
 	home := t.TempDir()
 	settingsPath := filepath.Join(home, ".config", "opencode", "opencode.json")
 	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
@@ -727,6 +731,7 @@ func macOSDetectionResult() system.DetectionResult {
 }
 
 func TestRunInstallMacOSStillResolvesBrewCommands(t *testing.T) {
+	isolateChannelResolution(t)
 	home := t.TempDir()
 	restoreHome := osUserHomeDir
 	restoreCommand := runCommand
@@ -820,6 +825,7 @@ func TestRunInstallMacOSVerificationMatchesPreLinuxBehavior(t *testing.T) {
 }
 
 func TestRunInstallMacOSRollbackStillWorks(t *testing.T) {
+	isolateChannelResolution(t)
 	home := t.TempDir()
 	settingsPath := filepath.Join(home, ".config", "opencode", "opencode.json")
 	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
@@ -876,6 +882,7 @@ func TestRunInstallMacOSRollbackStillWorks(t *testing.T) {
 // --- Skip-when-installed and Go auto-install tests ---
 
 func TestRunInstallEngramSkipsInstallWhenAlreadyOnPath(t *testing.T) {
+	isolateChannelResolution(t)
 	home := t.TempDir()
 	restoreHome := osUserHomeDir
 	restoreCommand := runCommand
@@ -997,6 +1004,7 @@ func TestRunInstallEngramFallsBackToInjectWhenSetupFails(t *testing.T) {
 }
 
 func TestRunInstallEngramSetupStrictFailsWhenSetupFails(t *testing.T) {
+	isolateChannelResolution(t)
 	t.Setenv("GENTLE_AI_ENGRAM_SETUP_STRICT", "1")
 
 	home := t.TempDir()
@@ -1290,6 +1298,7 @@ func TestRunInstallGGALinuxIncludesTempCleanupBeforeClone(t *testing.T) {
 // TestRunInstallEngramLinuxUsesDirectDownloadNoGoRequired verifies that on Linux,
 // engram is now installed via pre-built binary download — Go is NOT required.
 func TestRunInstallEngramLinuxUsesDirectDownloadNoGoRequired(t *testing.T) {
+	isolateChannelResolution(t)
 	home := t.TempDir()
 	restoreHome := osUserHomeDir
 	restoreCommand := runCommand
@@ -1385,6 +1394,7 @@ func TestRunInstallEngramLinuxNeverInstallsGo(t *testing.T) {
 }
 
 func TestRunInstallEngramBrewSkipsGoCheck(t *testing.T) {
+	isolateChannelResolution(t)
 	home := t.TempDir()
 	restoreHome := osUserHomeDir
 	restoreCommand := runCommand

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -91,6 +91,13 @@ type InstallState struct {
 	// False (zero value) = no deferred sync pending. Omitted from JSON when
 	// false for backward-compatibility with existing state files.
 	PendingSync bool `json:"pending_sync,omitempty"`
+
+	// LastChannelStaleWarning records the last time the stale-channel-binary
+	// warning was shown. Gated by a once-per-day TTL so an out-of-date channel
+	// binary (e.g. after an out-of-band `brew upgrade`) nudges the user without
+	// nagging on every command. Nil = never warned, so the next stale launch warns
+	// immediately (safe back-compat for older state files).
+	LastChannelStaleWarning *time.Time `json:"last_channel_stale_warning,omitempty"`
 }
 
 // Path returns the absolute path to the state file for the given home directory.
@@ -151,6 +158,7 @@ func MergeAgents(existing InstallState, newAgents []string) InstallState {
 		Persona:                     existing.Persona,
 		LastUpdateCheck:             existing.LastUpdateCheck,
 		PendingSync:                 existing.PendingSync,
+		LastChannelStaleWarning:     existing.LastChannelStaleWarning,
 	}
 }
 

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -2,6 +2,8 @@ package state
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"time"
@@ -9,6 +11,17 @@ import (
 
 const stateDir = ".gentle-ai"
 const stateFile = "state.json"
+
+// ErrCorruptState is the sentinel returned (wrapped) by Read when the state file
+// is readable (its bytes were obtained) but cannot be decoded — malformed JSON, a
+// type mismatch, or a nested decode failure such as a corrupt RFC3339 timestamp in
+// a *time.Time field. The underlying data is already unrecoverable. Callers can
+// detect this with errors.Is(err, ErrCorruptState) to safely reset to a fresh
+// state. It is deliberately distinct from os.ErrNotExist (file absent) and from raw
+// file-read/IO/permission errors (the bytes may be a valid state.json that is just
+// unreadable this once), both of which Read returns unwrapped so callers can still
+// distinguish them with errors.Is.
+var ErrCorruptState = errors.New("corrupt install state")
 
 // ModelAssignmentState is the JSON-serialisable form of a provider+model pair
 // used by OpenCode-style model assignments. It mirrors model.ModelAssignment
@@ -106,15 +119,32 @@ func Path(homeDir string) string {
 }
 
 // Read reads and unmarshals the state file from the given home directory.
-// Returns an error if the file does not exist or cannot be decoded.
+//
+// Error contract:
+//   - File absent: returns the raw os error unwrapped, so callers can detect it
+//     with errors.Is(err, os.ErrNotExist).
+//   - File read/IO/permission failure (bytes NOT obtained): returns the raw os
+//     error unwrapped, so the caller can tell a possibly-valid-but-unreadable file
+//     apart from genuinely corrupt data and avoid clobbering it.
+//   - Decode failure (bytes obtained but json.Unmarshal fails, including a nested
+//     decode such as a malformed timestamp in a *time.Time field): returns an error
+//     wrapping ErrCorruptState, so callers can detect it with
+//     errors.Is(err, ErrCorruptState). The data is already unrecoverable.
+//
+// A usable zero InstallState is returned alongside any error.
 func Read(homeDir string) (InstallState, error) {
 	data, err := os.ReadFile(Path(homeDir))
 	if err != nil {
+		// Absent / IO / permission: keep the raw error unwrapped so callers can
+		// distinguish it (e.g. errors.Is(err, os.ErrNotExist)) and avoid resetting
+		// a file whose bytes were merely unreadable this once.
 		return InstallState{}, err
 	}
 	var s InstallState
 	if err := json.Unmarshal(data, &s); err != nil {
-		return InstallState{}, err
+		// The bytes are present but undecodable — the persisted data is already
+		// lost. Wrap the sentinel so callers can safely reset to a fresh state.
+		return InstallState{}, fmt.Errorf("%w: %v", ErrCorruptState, err)
 	}
 	return s, nil
 }

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -194,6 +194,22 @@ func MergeAgents(existing InstallState, newAgents []string) InstallState {
 
 // Write persists the full install state to disk under the given home directory.
 // It creates the .gentle-ai directory if it does not already exist.
+//
+// The write is atomic: the bytes are written to a temporary file in the SAME
+// directory as the target and then os.Rename'd onto the final path. Renaming
+// within one directory is atomic on POSIX (and an atomic replace on Windows),
+// so a concurrent reader can never observe a torn/partial file and misclassify
+// it as ErrCorruptState. On any error before the rename the temp file is removed.
+//
+// This guarantees atomic visibility, not crash durability: the bytes are not
+// fsync'd, so a power loss right after Rename may lose the write (acceptable for
+// non-critical install state). If the process is hard-killed (SIGKILL, crash)
+// between CreateTemp and Rename, a "state-*.json.tmp" orphan may be left behind;
+// these are tiny and harmless, and we deliberately do not sweep them here to
+// avoid racing a concurrent writer's in-flight temp. On Windows, the rename
+// replace can intermittently fail (ERROR_SHARING_VIOLATION) if an antivirus or
+// indexer transiently opens the target; Write callers treat that error as
+// non-fatal and retry on the next launch.
 func Write(homeDir string, s InstallState) error {
 	dir := filepath.Join(homeDir, stateDir)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
@@ -203,5 +219,45 @@ func Write(homeDir string, s InstallState) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(Path(homeDir), append(data, '\n'), 0o644)
+	data = append(data, '\n')
+
+	target := Path(homeDir)
+
+	// Create the temp file in the SAME directory as the target so that the
+	// subsequent os.Rename is a same-filesystem (atomic) operation rather than a
+	// cross-device move.
+	tmp, err := os.CreateTemp(dir, "state-*.json.tmp")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+
+	// On any failure before a successful rename, remove the temp file so we do
+	// not leak partial artifacts into the state directory.
+	cleanup := func() {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+	}
+
+	if _, err := tmp.Write(data); err != nil {
+		cleanup()
+		return err
+	}
+	// CreateTemp defaults to 0o600; force 0o644 before the rename to match the
+	// previous nominal os.WriteFile mode. Note this sets 0o644 regardless of
+	// umask, whereas the old os.WriteFile was umask-subject (e.g. 0o600 under
+	// umask 077); state.json holds no secrets, so 0o644 is intended here.
+	if err := tmp.Chmod(0o644); err != nil {
+		cleanup()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpName)
+		return err
+	}
+	if err := os.Rename(tmpName, target); err != nil {
+		_ = os.Remove(tmpName)
+		return err
+	}
+	return nil
 }

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -106,6 +106,54 @@ func TestWriteAndRead(t *testing.T) {
 	}
 }
 
+// TestWriteIsAtomic verifies that Write persists atomically: the value round-trips
+// through Read, the final state file has mode 0o644, and no leftover temp file is
+// left behind in the state directory after a successful write. Atomicity (write to
+// a temp file in the same directory, then os.Rename onto the target) prevents a
+// concurrent reader from observing a torn/partial file and misclassifying it as
+// ErrCorruptState. The rename itself is hard to race deterministically, so this
+// test asserts the observable structural guarantees rather than a timing race.
+func TestWriteIsAtomic(t *testing.T) {
+	home := t.TempDir()
+	want := InstallState{InstalledAgents: []string{"claude-code", "opencode"}}
+
+	if err := Write(home, want); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+
+	// 1) Round-trip: the written state reads back intact.
+	got, err := Read(home)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if !reflect.DeepEqual(got.InstalledAgents, want.InstalledAgents) {
+		t.Errorf("InstalledAgents = %v, want %v", got.InstalledAgents, want.InstalledAgents)
+	}
+
+	// 2) Final file mode must be 0o644 (CreateTemp defaults to 0o600, so the
+	//    implementation must chmod the temp/final file to 0o644).
+	info, err := os.Stat(Path(home))
+	if err != nil {
+		t.Fatalf("Stat(state file) error = %v", err)
+	}
+	if got, want := info.Mode().Perm(), os.FileMode(0o644); got != want {
+		t.Errorf("state file mode = %o, want %o", got, want)
+	}
+
+	// 3) No leftover temp file may remain in the state directory after success.
+	dir := filepath.Join(home, stateDir)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir(%q) error = %v", dir, err)
+	}
+	for _, e := range entries {
+		if e.Name() == stateFile {
+			continue
+		}
+		t.Errorf("unexpected leftover file in state dir after Write: %q", e.Name())
+	}
+}
+
 // TestPersonaRoundTrip verifies the Persona field round-trips through
 // Write/Read. Both `gentle-ai install` (CLI in run.go) and the TUI app
 // (internal/app/app.go) write this field after a successful install so that

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -1,6 +1,7 @@
 package state
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -187,7 +188,8 @@ func TestReadMissing(t *testing.T) {
 	}
 }
 
-// TestReadCorrupt verifies that writing garbage produces an error on read.
+// TestReadCorrupt verifies that writing garbage produces an error on read that is
+// classified as ErrCorruptState (the bytes were obtained but could not be decoded).
 func TestReadCorrupt(t *testing.T) {
 	home := t.TempDir()
 
@@ -203,6 +205,58 @@ func TestReadCorrupt(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Read() expected error for corrupt JSON, got nil")
 	}
+	if !errors.Is(err, ErrCorruptState) {
+		t.Fatalf("Read() corrupt JSON error = %v, want errors.Is(..., ErrCorruptState)", err)
+	}
+}
+
+// TestReadErrCorruptStateClassification verifies the sentinel contract: a decode
+// failure (whatever its underlying shape) is reported as ErrCorruptState, while a
+// genuinely absent file is NOT — it stays distinguishable as os.ErrNotExist so callers
+// can avoid clobbering a valid-but-unreadable file. Decode shapes include malformed
+// JSON, a top-level type mismatch, and a nested decode failure inside a *time.Time
+// field (a corrupt RFC3339 string → *time.ParseError, a wrong-typed value → plain
+// errors.errorString) — none of which expose a concrete json error type.
+func TestReadErrCorruptStateClassification(t *testing.T) {
+	corruptBlobs := map[string]string{
+		"malformed json":              "{ this is not valid json",
+		"top-level type mismatch":     `{"installed_agents": 5}`,
+		"malformed RFC3339 timestamp": `{"last_channel_stale_warning":"not-a-timestamp"}`,
+		"wrong-typed timestamp":       `{"last_channel_stale_warning":12345}`,
+	}
+	for name, blob := range corruptBlobs {
+		t.Run(name, func(t *testing.T) {
+			home := t.TempDir()
+			if err := os.MkdirAll(filepath.Join(home, stateDir), 0o755); err != nil {
+				t.Fatalf("MkdirAll() error = %v", err)
+			}
+			if err := os.WriteFile(Path(home), []byte(blob), 0o644); err != nil {
+				t.Fatalf("WriteFile() error = %v", err)
+			}
+			_, err := Read(home)
+			if !errors.Is(err, ErrCorruptState) {
+				t.Fatalf("Read(%q) error = %v, want errors.Is(..., ErrCorruptState)", blob, err)
+			}
+			// A corrupt decode must NOT masquerade as an absent file.
+			if errors.Is(err, os.ErrNotExist) {
+				t.Fatalf("Read(%q) error = %v, must not satisfy errors.Is(..., os.ErrNotExist)", blob, err)
+			}
+		})
+	}
+
+	t.Run("absent file is not ErrCorruptState", func(t *testing.T) {
+		home := t.TempDir() // no Write — state.json absent
+		_, err := Read(home)
+		if err == nil {
+			t.Fatal("Read() expected error for absent file, got nil")
+		}
+		if errors.Is(err, ErrCorruptState) {
+			t.Fatalf("Read() absent-file error = %v, must NOT satisfy errors.Is(..., ErrCorruptState)", err)
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("Read() absent-file error = %v, want errors.Is(..., os.ErrNotExist)", err)
+		}
+	})
 }
 
 // TestWriteOverwrite verifies that a second Write call replaces the previous state.

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -2774,15 +2774,24 @@ func (m Model) startUpgradeSync() tea.Cmd {
 			// Set PendingSync=true so the new binary runs sync on next launch
 			// instead of silently skipping it. Non-fatal if state write fails.
 			//
-			// No-clobber guard: only fall back to a fresh InstallState{} when
-			// the file is genuinely missing (ErrNotExist). Any other read error
-			// (e.g. corrupt JSON, permission denied) means an existing file is
-			// present — skip writing to avoid dropping installed_agents, model
-			// assignments, and other persisted fields.
+			// Resettable-state guard (same contract as internal/app/selfupdate.go's
+			// deferred-sync block, internal/update/cooldown.go, and
+			// internal/cli/channel_command.go):
+			//   - Missing (os.ErrNotExist) or corrupt (state.ErrCorruptState): start
+			//     fresh and persist PendingSync. state.Read already returned a zero
+			//     InstallState on error, and a corrupt file's fields are already
+			//     undecodable and lost, so resetting loses nothing recoverable.
+			//   - Any OTHER read error (genuine IO/permission failure): the bytes may
+			//     still be a valid state.json that is merely unreadable this once — do
+			//     not overwrite it and risk dropping installed_agents, model
+			//     assignments, etc.
+			//   - Valid state (readErr == nil): other fields are preserved; only
+			//     PendingSync flips to true.
 			if h := homeDir(); h != "" {
 				s, readErr := state.Read(h)
-				if readErr != nil && !errors.Is(readErr, os.ErrNotExist) {
-					// File exists but unreadable/corrupt — skip to avoid clobber.
+				if readErr != nil && !errors.Is(readErr, os.ErrNotExist) && !errors.Is(readErr, state.ErrCorruptState) {
+					// Genuine IO/permission error — skip this round to avoid
+					// clobbering a possibly-valid-but-unreadable file.
 				} else {
 					s.PendingSync = true
 					_ = state.Write(h, s)

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -17,6 +17,7 @@ import (
 	"github.com/gentleman-programming/gentle-ai/internal/agentbuilder"
 	"github.com/gentleman-programming/gentle-ai/internal/backup"
 	"github.com/gentleman-programming/gentle-ai/internal/catalog"
+	"github.com/gentleman-programming/gentle-ai/internal/cli"
 	"github.com/gentleman-programming/gentle-ai/internal/components/opencodeplugin"
 	"github.com/gentleman-programming/gentle-ai/internal/components/sdd"
 	componentuninstall "github.com/gentleman-programming/gentle-ai/internal/components/uninstall"
@@ -375,6 +376,7 @@ type Model struct {
 	SpinnerFrame   int
 
 	Selection         model.Selection
+	InstallChannel    cli.InstallChannel
 	Detection         system.DetectionResult
 	DependencyPlan    planner.ResolvedPlan
 	Review            planner.ReviewPayload
@@ -566,6 +568,11 @@ func NewModel(detection system.DetectionResult, version string, installState ...
 		components = piOnlyComponents()
 	}
 
+	installChannel, err := cli.ResolveInstallChannel("")
+	if err != nil {
+		installChannel = cli.ChannelStable
+	}
+
 	selection := model.Selection{
 		Agents:                 agents,
 		Persona:                model.PersonaGentleman,
@@ -581,6 +588,7 @@ func NewModel(detection system.DetectionResult, version string, installState ...
 		Screen:               ScreenWelcome,
 		Version:              version,
 		Selection:            selection,
+		InstallChannel:       installChannel,
 		Detection:            detection,
 		UninstallAgents:      agents,
 		UninstallComponents:  defaultUninstallComponents(),
@@ -964,7 +972,8 @@ func (m Model) View() string {
 			}
 			banner += "Advisory: " + m.AdvisoryMessage
 		}
-		return screens.RenderWelcomeWithWidth(m.Cursor, m.Version, banner, m.UpdateResults, m.UpdateCheckDone, m.hasDetectedOpenCode(), len(m.ProfileList), m.hasAgentBuilderEngines(), m.Width)
+		version := fmt.Sprintf("%s • channel: %s", m.Version, m.InstallChannel)
+		return screens.RenderWelcomeWithWidth(m.Cursor, version, banner, m.UpdateResults, m.UpdateCheckDone, m.hasDetectedOpenCode(), len(m.ProfileList), m.hasAgentBuilderEngines(), m.Width)
 	case ScreenUpgrade:
 		return screens.RenderUpgrade(m.UpdateResults, m.UpgradeReport, m.UpgradeErr, m.OperationRunning, m.UpdateCheckDone, m.Cursor, m.SpinnerFrame)
 	case ScreenSync:

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -4683,16 +4683,22 @@ func TestStartUpgradeSync_DoesNotSetPendingSyncWhenGentleAINotUpgraded(t *testin
 	}
 }
 
-// TestStartUpgradeSync_NoClobberOnCorruptStateFile verifies that when the HOME
-// directory has a corrupt (non-missing) state.json, the TUI syncCmd branch does
-// NOT overwrite it when setting PendingSync=true — matching the no-clobber
-// pattern in internal/update/cooldown.go.
-func TestStartUpgradeSync_NoClobberOnCorruptStateFile(t *testing.T) {
+// TestStartUpgradeSync_ResetsAndPersistsOnCorruptStateFile verifies the unified
+// resettable-on-corrupt contract for the TUI deferred-sync path: when the HOME
+// directory has a corrupt (non-missing) state.json, the syncCmd branch treats it
+// like a missing file — it resets to a fresh InstallState and persists
+// PendingSync=true. A corrupt file's fields are already undecodable and lost, so
+// resetting loses nothing recoverable, and persisting PendingSync ensures the new
+// binary still completes its deferred sync. This mirrors the deferred-sync block
+// in internal/app/selfupdate.go and the cooldown writer in
+// internal/update/cooldown.go.
+func TestStartUpgradeSync_ResetsAndPersistsOnCorruptStateFile(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("USERPROFILE", home)
 
-	// Write a corrupt state file so state.Read returns a non-ErrNotExist error.
+	// Write a corrupt state file so state.Read returns ErrCorruptState
+	// (a non-ErrNotExist error whose bytes were obtained but cannot be decoded).
 	stateDir := filepath.Join(home, ".gentle-ai")
 	if err := os.MkdirAll(stateDir, 0o755); err != nil {
 		t.Fatalf("MkdirAll: %v", err)
@@ -4718,13 +4724,14 @@ func TestStartUpgradeSync_NoClobberOnCorruptStateFile(t *testing.T) {
 
 	executeUpgradeSyncSequence(t, m)
 
-	// The corrupt state file must NOT have been overwritten.
-	got, readErr := os.ReadFile(stateFilePath)
-	if readErr != nil {
-		t.Fatalf("os.ReadFile after startUpgradeSync: %v", readErr)
+	// The corrupt state file must have been reset to a fresh, decodable state
+	// with PendingSync=true persisted — not left in its corrupt form.
+	s, err := state.Read(home)
+	if err != nil {
+		t.Fatalf("state.Read(%q) after corrupt reset error = %v (file was not repaired)", home, err)
 	}
-	if string(got) != string(corruptPayload) {
-		t.Errorf("state file was overwritten on corrupt-read error\ngot:  %q\nwant: %q", got, corruptPayload)
+	if !s.PendingSync {
+		t.Errorf("PendingSync = false after corrupt-state reset, want true (deferred sync must still be recorded)")
 	}
 }
 

--- a/internal/update/cooldown.go
+++ b/internal/update/cooldown.go
@@ -70,12 +70,18 @@ func CheckAllWithCooldown(
 		// Re-read state to avoid clobbering unrelated fields written concurrently.
 		current, readErr := state.Read(homeDir)
 		if readErr != nil {
-			if !errors.Is(readErr, os.ErrNotExist) {
-				// File exists but is unreadable/corrupt — do not overwrite; skip
-				// persisting the timestamp this round to avoid data loss.
+			if !errors.Is(readErr, os.ErrNotExist) && !errors.Is(readErr, state.ErrCorruptState) {
+				// File exists but is unreadable (IO/permission) — its bytes may
+				// still be a valid state.json that is merely unreadable this once,
+				// so do not overwrite; skip persisting the timestamp this round to
+				// avoid clobbering recoverable data.
 				return results
 			}
-			// File genuinely missing (first run) — start fresh.
+			// File genuinely missing (first run) OR corrupt (state.ErrCorruptState —
+			// the persisted fields are already undecodable and lost). Start fresh
+			// so the cooldown can still record: resetting loses nothing recoverable
+			// and stops the remote update check from firing on EVERY launch until
+			// the file is repaired.
 			current = state.InstallState{}
 		}
 		current.LastUpdateCheck = &now

--- a/internal/update/cooldown_test.go
+++ b/internal/update/cooldown_test.go
@@ -2,6 +2,7 @@ package update
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -264,43 +265,125 @@ func TestCheckAllWithCooldown_FutureTimestampAlwaysChecks(t *testing.T) {
 	}
 }
 
-// TestCheckAllWithCooldown_NonMissingReadErrorSkipsWrite verifies that when the
-// state file exists but produces a non-missing read error (e.g. corrupt JSON),
-// the timestamp write is skipped — existing state must never be clobbered.
-func TestCheckAllWithCooldown_NonMissingReadErrorSkipsWrite(t *testing.T) {
+// TestCheckAllWithCooldown_CorruptStateResetsAndPersists verifies that when the
+// write-side re-read fails with state.ErrCorruptState (a decode failure — the
+// persisted data is already unrecoverable), the cooldown still records by
+// resetting to a fresh InstallState and writing the timestamp. Without this the
+// remote update check would fire on EVERY launch until the file is repaired.
+//
+// Both corrupt shapes route through state.Read's ErrCorruptState wrapping:
+//   - structurally-broken JSON ("{ not valid")
+//   - a malformed RFC3339 timestamp in the *time.Time field
+func TestCheckAllWithCooldown_CorruptStateResetsAndPersists(t *testing.T) {
+	profile := system.PlatformProfile{OS: "darwin", PackageManager: "brew"}
+	now := time.Date(2026, 6, 14, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name string
+		blob string
+	}{
+		{name: "structurally broken json", blob: "{ not valid"},
+		{name: "malformed timestamp field", blob: `{"last_update_check":"not-a-timestamp"}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home := t.TempDir()
+
+			// Seed a corrupt state.json that state.Read classifies as
+			// ErrCorruptState (verified below to guard against false positives).
+			stateDir := filepath.Join(home, ".gentle-ai")
+			if err := os.MkdirAll(stateDir, 0o755); err != nil {
+				t.Fatalf("MkdirAll: %v", err)
+			}
+			if err := os.WriteFile(state.Path(home), []byte(tt.blob), 0o644); err != nil {
+				t.Fatalf("WriteFile corrupt: %v", err)
+			}
+			if _, err := state.Read(home); !errors.Is(err, state.ErrCorruptState) {
+				t.Fatalf("precondition: state.Read(%q) = %v, want errors.Is(..., ErrCorruptState)", tt.blob, err)
+			}
+
+			stubCheckAll := func(_ context.Context, _ string, _ system.PlatformProfile) []UpdateResult {
+				// Successful result → checkSucceeded is true → write attempted.
+				return []UpdateResult{{Tool: ToolInfo{Name: "gentle-ai"}, Status: UpToDate}}
+			}
+
+			CheckAllWithCooldown(context.Background(), "1.0.0", profile, home, 6*time.Hour,
+				func() time.Time { return now },
+				stubCheckAll,
+			)
+
+			// After the run the corrupt file must have been reset to a valid,
+			// decodable state.json whose LastUpdateCheck equals the injected now.
+			updated, err := state.Read(home)
+			if err != nil {
+				t.Fatalf("state.Read() after cooldown error = %v, want nil (corrupt file should be reset)", err)
+			}
+			if updated.LastUpdateCheck == nil || !updated.LastUpdateCheck.Equal(now) {
+				t.Errorf("LastUpdateCheck after corrupt reset = %v, want %v (timestamp must persist)", updated.LastUpdateCheck, now)
+			}
+		})
+	}
+}
+
+// TestCheckAllWithCooldown_UnreadableStateSkipsWrite verifies the conservative
+// branch: when the write-side re-read fails with a genuine IO/permission error
+// (NEITHER os.ErrNotExist NOR state.ErrCorruptState), the file's bytes may still
+// be a valid state.json that is merely unreadable this once, so the timestamp
+// write is skipped to avoid clobbering recoverable data.
+//
+// The unreadable file is simulated with mode 0o000. This is not portable as
+// root (root bypasses permission bits), so the test skips when running as root
+// rather than asserting flakily.
+func TestCheckAllWithCooldown_UnreadableStateSkipsWrite(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root bypasses file permission bits; cannot simulate an unreadable state.json")
+	}
+
 	home := t.TempDir()
 	profile := system.PlatformProfile{OS: "darwin", PackageManager: "brew"}
 	now := time.Date(2026, 6, 14, 12, 0, 0, 0, time.UTC)
 
-	// Write a corrupt (non-parseable) state file so state.Read returns a
-	// non-missing error (file exists but JSON is invalid).
+	// Seed a VALID state.json, then strip read permission so state.Read returns
+	// an unwrapped os.ErrPermission (the bytes are possibly-valid-but-unreadable).
 	stateDir := filepath.Join(home, ".gentle-ai")
 	if err := os.MkdirAll(stateDir, 0o755); err != nil {
 		t.Fatalf("MkdirAll: %v", err)
 	}
-	corruptPath := filepath.Join(stateDir, "state.json")
-	if err := os.WriteFile(corruptPath, []byte("NOT VALID JSON"), 0o644); err != nil {
-		t.Fatalf("WriteFile corrupt: %v", err)
+	original := []byte(`{"installed_agents":["claude-code"]}` + "\n")
+	statePath := state.Path(home)
+	if err := os.WriteFile(statePath, original, 0o644); err != nil {
+		t.Fatalf("WriteFile valid: %v", err)
+	}
+	if err := os.Chmod(statePath, 0o000); err != nil {
+		t.Fatalf("Chmod 0o000: %v", err)
+	}
+	// Restore perms so t.TempDir cleanup can remove the file.
+	t.Cleanup(func() { _ = os.Chmod(statePath, 0o644) })
+
+	// Guard the precondition: the read error must be neither NotExist nor Corrupt.
+	if _, err := state.Read(home); errors.Is(err, os.ErrNotExist) || errors.Is(err, state.ErrCorruptState) {
+		t.Skipf("could not simulate an unreadable-only state.json (read err = %v)", err)
 	}
 
 	stubCheckAll := func(_ context.Context, _ string, _ system.PlatformProfile) []UpdateResult {
-		// Return a successful result — checkSucceeded will be true.
 		return []UpdateResult{{Tool: ToolInfo{Name: "gentle-ai"}, Status: UpToDate}}
 	}
 
-	// stale first read: corrupt file → read error → always-check (skip cooldown).
-	// After check, re-read for write: corrupt → non-missing error → must skip write.
 	CheckAllWithCooldown(context.Background(), "1.0.0", profile, home, 6*time.Hour,
 		func() time.Time { return now },
 		stubCheckAll,
 	)
 
-	// The corrupt file must still be corrupt — not overwritten with valid JSON.
-	data, err := os.ReadFile(corruptPath)
+	// The unreadable file must NOT have been overwritten: restore read access
+	// and confirm the original bytes survive untouched.
+	if err := os.Chmod(statePath, 0o644); err != nil {
+		t.Fatalf("Chmod restore: %v", err)
+	}
+	data, err := os.ReadFile(statePath)
 	if err != nil {
 		t.Fatalf("ReadFile after cooldown: %v", err)
 	}
-	if string(data) != "NOT VALID JSON" {
-		t.Errorf("state file was overwritten; got %q, want original corrupt content", string(data))
+	if string(data) != string(original) {
+		t.Errorf("unreadable state file was overwritten; got %q, want original %q", string(data), string(original))
 	}
 }

--- a/internal/update/install_script_test.go
+++ b/internal/update/install_script_test.go
@@ -116,7 +116,6 @@ func TestInstallScriptsActivateBetaThroughLauncher(t *testing.T) {
 			if err != nil {
 				t.Fatalf("ReadFile(%q) error = %v", tc.path, err)
 			}
-			text := string(content)
 			for _, forbidden := range tc.forbidden {
 				if bytes.Contains(content, []byte(forbidden)) {
 					t.Fatalf("%s still contains obsolete beta install behavior %q", tc.path, forbidden)
@@ -130,7 +129,6 @@ func TestInstallScriptsActivateBetaThroughLauncher(t *testing.T) {
 			if bytes.Contains(content, []byte("@main")) && !bytes.Contains(content, []byte("channel beta")) {
 				t.Fatalf("%s references @main without launcher channel activation", tc.path)
 			}
-			_ = text
 		})
 	}
 }

--- a/internal/update/install_script_test.go
+++ b/internal/update/install_script_test.go
@@ -26,6 +26,115 @@ func TestWindowsInstallScriptHasNoUTF8BOM(t *testing.T) {
 // "($fileSize bytes)" inside a double-quoted string are read by Windows
 // PowerShell 5.1 as an invalid subexpression and abort parsing before any code
 // runs. Use the -f format operator instead, e.g. ("... {0} bytes" -f $fileSize).
+func TestInstallScriptsRepairLegacyPathShadowing(t *testing.T) {
+	checks := []struct {
+		name     string
+		path     string
+		required []string
+	}{
+		{
+			name: "unix",
+			path: filepath.Join("..", "..", "scripts", "install.sh"),
+			required: []string{
+				"ensure_launcher_first_in_path",
+				"persist_launcher_path_first",
+				"Legacy installs can shadow the launcher",
+				"This session now uses the Gentle AI launcher first",
+			},
+		},
+		{
+			name: "windows",
+			path: filepath.Join("..", "..", "scripts", "install.ps1"),
+			required: []string{
+				"Ensure-LauncherFirstInPath",
+				"SetEnvironmentVariable(\"PATH\", $newUserPath, \"User\")",
+				"Legacy installs can shadow the launcher",
+				"Moved the Gentle AI launcher to the front of your User PATH",
+			},
+		},
+	}
+
+	for _, tc := range checks {
+		t.Run(tc.name, func(t *testing.T) {
+			content, err := os.ReadFile(tc.path)
+			if err != nil {
+				t.Fatalf("ReadFile(%q) error = %v", tc.path, err)
+			}
+			for _, required := range tc.required {
+				if !bytes.Contains(content, []byte(required)) {
+					t.Fatalf("%s missing legacy PATH repair marker %q", tc.path, required)
+				}
+			}
+		})
+	}
+}
+
+func TestInstallScriptsActivateBetaThroughLauncher(t *testing.T) {
+	checks := []struct {
+		name      string
+		path      string
+		forbidden []string
+		required  []string
+	}{
+		{
+			name: "unix",
+			path: filepath.Join("..", "..", "scripts", "install.sh"),
+			forbidden: []string{
+				"--channel beta installs Gentle AI from main and only supports --method go",
+				"GENTLE_AI_CHANNEL=beta ${BINARY_NAME} install",
+			},
+			required: []string{
+				"activate_requested_channel",
+				"$launcher\" channel beta",
+				"cmd/${BINARY_NAME}@latest",
+				"install_channel_capable_launcher_from_main",
+				"cmd/${BINARY_NAME}@main",
+				"bootstrapping from main",
+			},
+		},
+		{
+			name: "windows",
+			path: filepath.Join("..", "..", "scripts", "install.ps1"),
+			forbidden: []string{
+				"-Channel beta installs Gentle AI from main and only supports -Method go",
+				"Install-ViaGo -Channel $Channel",
+			},
+			required: []string{
+				"Activate-RequestedChannel",
+				"& $launcher channel beta",
+				"cmd/$BINARY_NAME@latest",
+				"Install-ChannelCapableLauncherFromMain",
+				"cmd/$BINARY_NAME@main",
+				"bootstrapping from main",
+			},
+		},
+	}
+
+	for _, tc := range checks {
+		t.Run(tc.name, func(t *testing.T) {
+			content, err := os.ReadFile(tc.path)
+			if err != nil {
+				t.Fatalf("ReadFile(%q) error = %v", tc.path, err)
+			}
+			text := string(content)
+			for _, forbidden := range tc.forbidden {
+				if bytes.Contains(content, []byte(forbidden)) {
+					t.Fatalf("%s still contains obsolete beta install behavior %q", tc.path, forbidden)
+				}
+			}
+			for _, required := range tc.required {
+				if !bytes.Contains(content, []byte(required)) {
+					t.Fatalf("%s missing required launcher beta activation marker %q", tc.path, required)
+				}
+			}
+			if bytes.Contains(content, []byte("@main")) && !bytes.Contains(content, []byte("channel beta")) {
+				t.Fatalf("%s references @main without launcher channel activation", tc.path)
+			}
+			_ = text
+		})
+	}
+}
+
 func TestWindowsInstallScriptHasNoUnsafeStringSubexpression(t *testing.T) {
 	path := filepath.Join("..", "..", "scripts", "install.ps1")
 	content, err := os.ReadFile(path)

--- a/internal/update/upgrade/strategy.go
+++ b/internal/update/upgrade/strategy.go
@@ -415,63 +415,34 @@ func goInstallMainUpgrade(tool update.ToolInfo) error {
 		module = "github.com/gentleman-programming/gentle-ai"
 	}
 	target := module + "/cmd/gentle-ai@main"
+
+	// The launcher delegates beta commands to ~/.gentle-ai/channels/beta/gentle-ai,
+	// so the upgraded binary MUST land there — mirroring install-time
+	// goInstallChannelBinary, which sets GOBIN to the channel directory. Without an
+	// explicit GOBIN, `go install` writes to $GOPATH/bin and the running beta binary
+	// the launcher execs would never actually be refreshed.
+	betaBinary, err := cli.ChannelBinaryPath(cli.ChannelBeta)
+	if err != nil {
+		return fmt.Errorf("resolve beta channel directory: %w", err)
+	}
+	binDir := filepath.Dir(betaBinary)
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		return fmt.Errorf("create beta channel dir: %w", err)
+	}
+
 	cmd := execCommand("go", "install", target)
 	cmd.Stdin = nil
-	cmd.Env = goProxyBypassEnv(cmd.Env, module)
+	// GOBIN is appended last so it overrides any inherited GOBIN (exec uses the last
+	// value for duplicate keys), pinning the build to the channel directory.
+	cmd.Env = append(cli.GoProxyBypassEnv(cmd.Env, module), "GOBIN="+binDir)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("go install %s: %w (output: %s)", target, err, strings.TrimSpace(string(out)))
 	}
 	return nil
 }
 
-func goProxyBypassEnv(base []string, module string) []string {
-	if base == nil {
-		base = os.Environ()
-	}
-	env := append([]string{}, base...)
-	for _, key := range []string{"GONOSUMDB", "GOPRIVATE", "GONOPROXY"} {
-		env = setEnvValue(env, key, prependGoPattern(getEnvValue(env, key), module))
-	}
-	return env
-}
-
-func getEnvValue(env []string, key string) string {
-	prefix := key + "="
-	for i := len(env) - 1; i >= 0; i-- {
-		if strings.HasPrefix(env[i], prefix) {
-			return strings.TrimPrefix(env[i], prefix)
-		}
-	}
-	return ""
-}
-
-func setEnvValue(env []string, key, value string) []string {
-	prefix := key + "="
-	for i := len(env) - 1; i >= 0; i-- {
-		if strings.HasPrefix(env[i], prefix) {
-			env[i] = prefix + value
-			return env
-		}
-	}
-	return append(env, prefix+value)
-}
-
-func prependGoPattern(existing, pattern string) string {
-	pattern = strings.TrimSpace(pattern)
-	if pattern == "" {
-		return existing
-	}
-	parts := strings.Split(existing, ",")
-	for _, part := range parts {
-		if strings.TrimSpace(part) == pattern {
-			return existing
-		}
-	}
-	if strings.TrimSpace(existing) == "" {
-		return pattern
-	}
-	return pattern + "," + existing
-}
+// goProxyBypassEnv and its helpers moved to internal/cli (GoProxyBypassEnv), shared
+// by the channel install and self-upgrade flows so both build beta identically.
 
 // binaryUpgrade handles binary-release upgrades via GitHub Releases asset download.
 //

--- a/internal/update/upgrade/strategy_test.go
+++ b/internal/update/upgrade/strategy_test.go
@@ -119,10 +119,10 @@ func TestRunStrategy_GoInstallUpgrade(t *testing.T) {
 }
 
 func TestRunStrategy_BetaGentleAISelfUpgradeUsesGoInstallMain(t *testing.T) {
-	// Isolate HOME: the upgrade now resolves and creates the beta channel directory,
-	// so it must not touch the real ~/.gentle-ai.
-	home := t.TempDir()
-	t.Setenv("HOME", home)
+	// Isolate HOME/USERPROFILE so ChannelBinaryPath(os.UserHomeDir()) is hermetic
+	// across platforms — the upgrade now resolves and creates the beta channel dir.
+	isolateChannelHome(t)
+	home := os.Getenv("HOME")
 
 	origExecCommand := execCommand
 	t.Cleanup(func() { execCommand = origExecCommand })

--- a/internal/update/upgrade/strategy_test.go
+++ b/internal/update/upgrade/strategy_test.go
@@ -15,6 +15,34 @@ import (
 	"testing"
 )
 
+// isolateChannelHome points HOME (and USERPROFILE on Windows) at a fresh empty
+// temp dir so cli.ResolveInstallChannel("") cannot fall through to the host's
+// saved ~/.gentle-ai/channel file. With no saved channel present, resolution
+// degrades to stable. Callers that drive the channel via an explicit
+// GENTLE_AI_CHANNEL value use this so the empty/unset path stays deterministic
+// regardless of the developer's persisted channel.
+func isolateChannelHome(t *testing.T) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+}
+
+// isolateChannelResolution makes engramBinaryUpgrade's call to
+// cli.ResolveInstallChannel("") deterministic regardless of the host's
+// ~/.gentle-ai/channel file and GENTLE_AI_CHANNEL value. It isolates HOME (so
+// the saved-channel lookup finds nothing and degrades to stable) and unsets the
+// channel env var. Upgrade tests that assert the stable download path must call
+// this so they pass on machines with a persisted non-stable channel.
+func isolateChannelResolution(t *testing.T) {
+	t.Helper()
+	isolateChannelHome(t)
+	t.Setenv("GENTLE_AI_CHANNEL", "")
+	if err := os.Unsetenv("GENTLE_AI_CHANNEL"); err != nil {
+		t.Fatalf("Unsetenv GENTLE_AI_CHANNEL: %v", err)
+	}
+}
+
 // --- TestRunStrategy_BrewUpgrade ---
 
 func TestRunStrategy_BrewUpgrade(t *testing.T) {
@@ -91,6 +119,11 @@ func TestRunStrategy_GoInstallUpgrade(t *testing.T) {
 }
 
 func TestRunStrategy_BetaGentleAISelfUpgradeUsesGoInstallMain(t *testing.T) {
+	// Isolate HOME: the upgrade now resolves and creates the beta channel directory,
+	// so it must not touch the real ~/.gentle-ai.
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
 	origExecCommand := execCommand
 	t.Cleanup(func() { execCommand = origExecCommand })
 
@@ -137,6 +170,17 @@ func TestRunStrategy_BetaGentleAISelfUpgradeUsesGoInstallMain(t *testing.T) {
 			t.Fatalf("go install env missing %q in %v", want, gotCmd.Env)
 		}
 	}
+
+	// The build must be pinned to the beta channel directory the launcher delegates
+	// to; otherwise the upgrade lands in $GOPATH/bin and silently no-ops the running
+	// beta binary.
+	wantGOBIN := "GOBIN=" + filepath.Join(home, ".gentle-ai", "channels", "beta")
+	if !envContains(gotCmd.Env, wantGOBIN) {
+		t.Fatalf("go install env missing %q in %v", wantGOBIN, gotCmd.Env)
+	}
+	if _, statErr := os.Stat(filepath.Join(home, ".gentle-ai", "channels", "beta")); statErr != nil {
+		t.Fatalf("beta channel dir must be created before go install: %v", statErr)
+	}
 }
 
 func envContains(env []string, want string) bool {
@@ -146,27 +190,6 @@ func envContains(env []string, want string) bool {
 		}
 	}
 	return false
-}
-
-func TestGoProxyBypassEnvPreservesExistingPatterns(t *testing.T) {
-	module := "github.com/gentleman-programming/gentle-ai"
-	env := goProxyBypassEnv([]string{
-		"PATH=/usr/bin",
-		"GONOSUMDB=example.com/private",
-		"GOPRIVATE=github.com/acme/*",
-		"GONOPROXY=github.com/gentleman-programming/gentle-ai",
-	}, module)
-
-	for _, want := range []string{
-		"PATH=/usr/bin",
-		"GONOSUMDB=github.com/gentleman-programming/gentle-ai,example.com/private",
-		"GOPRIVATE=github.com/gentleman-programming/gentle-ai,github.com/acme/*",
-		"GONOPROXY=github.com/gentleman-programming/gentle-ai",
-	} {
-		if !envContains(env, want) {
-			t.Fatalf("env missing %q in %v", want, env)
-		}
-	}
 }
 
 // --- TestRunStrategy_GoInstallMissingImportPath ---
@@ -1345,6 +1368,7 @@ func TestInstallScriptURL(t *testing.T) {
 // engram upgrade calls the binary download function, NOT go install.
 // This is the regression test for issue #160.
 func TestEngramUpgradeUsesDownloadNotGoInstall(t *testing.T) {
+	isolateChannelResolution(t)
 	origExecCommand := execCommand
 	origEngramDownloadFn := engramDownloadFn
 	t.Cleanup(func() {
@@ -1394,6 +1418,7 @@ func TestEngramUpgradeUsesDownloadNotGoInstall(t *testing.T) {
 // TestEngramUpgradeLinuxUsesDownload verifies that on Linux (non-brew),
 // engram upgrade uses the binary download function, not go install.
 func TestEngramUpgradeLinuxUsesDownload(t *testing.T) {
+	isolateChannelResolution(t)
 	origExecCommand := execCommand
 	origEngramDownloadFn := engramDownloadFn
 	t.Cleanup(func() {
@@ -1628,6 +1653,11 @@ func TestEngramBinaryUpgrade_StableChannelCallsDownloadFn(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			// Isolate HOME so the empty/unset-channel subcase cannot fall through
+			// to the host's saved ~/.gentle-ai/channel file (which would resolve to
+			// a non-stable channel on developer machines). The subcase still drives
+			// the channel via the explicit GENTLE_AI_CHANNEL value below.
+			isolateChannelHome(t)
 			t.Setenv("GENTLE_AI_CHANNEL", tt.envVal)
 
 			origDownloadFn := engramDownloadFn

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -5,9 +5,10 @@
     Ecosystem, Frameworks, Workflows for AI coding agents.
 
 .DESCRIPTION
-    Downloads and installs the gentle-ai binary for Windows.
+    Downloads and installs the gentle-ai launcher for Windows.
     Supports installation via Go or pre-built binary from GitHub Releases.
-    Accepted channels: stable (default), beta, nightly.
+    Accepted channels: stable (default), beta, nightly. Beta installs the launcher first,
+    then activates the beta runtime through `gentle-ai channel beta`.
 
 .EXAMPLE
     # Run directly:
@@ -21,7 +22,7 @@
     .\install.ps1 -Method binary
     .\install.ps1 -Method go
 
-    # Install the beta channel from main:
+    # Install the launcher and activate the beta channel from main:
     .\install.ps1 -Channel beta
 
     # Skip checksum verification (not recommended):
@@ -116,14 +117,6 @@ function Test-Prerequisites {
 function Get-InstallMethod {
     param([string]$Forced, [string]$Channel)
 
-    if ($Channel -eq "beta") {
-        if ($Forced -ne "auto" -and $Forced -ne "go") {
-            Stop-WithError "-Channel beta installs Gentle AI from main and only supports -Method go"
-        }
-        Write-Info "Using beta channel — will install $BINARY_NAME from main via go install"
-        return "go"
-    }
-
     if ($Forced -ne "auto") {
         Write-Info "Using forced method: $Forced"
         return $Forced
@@ -143,12 +136,9 @@ function Get-InstallMethod {
 # ============================================================================
 
 function Install-ViaGo {
-    param([string]$Channel = "stable")
+    Write-Step "Installing launcher via go install"
 
-    Write-Step "Installing via go install"
-
-    $version = if ($Channel -eq "beta") { "main" } else { "latest" }
-    $goPackage = "github.com/$($GITHUB_OWNER.ToLower())/$GITHUB_REPO/cmd/$BINARY_NAME@$version"
+    $goPackage = "github.com/$($GITHUB_OWNER.ToLower())/$GITHUB_REPO/cmd/$BINARY_NAME@latest"
     Write-Info "Running: go install $goPackage"
 
     if ($Channel -eq "beta") {
@@ -173,7 +163,8 @@ function Install-ViaGo {
         Write-Warn "Add it to your PATH environment variable."
     }
 
-    Write-Success "Installed $BINARY_NAME via go install"
+    $script:InstalledBinaryPath = Join-Path $gobin "$BINARY_NAME.exe"
+    Write-Success "Installed $BINARY_NAME launcher via go install"
 }
 
 function Add-GoEnvPattern {
@@ -300,6 +291,7 @@ function Install-ViaBinary {
         Write-Info "Installing to $destPath..."
         Copy-Item -Path $binaryPath -Destination $destPath -Force
 
+        $script:InstalledBinaryPath = $destPath
         Write-Success "Installed $BINARY_NAME to $destPath"
 
         # Persist install dir to the User PATH if not already present.
@@ -338,6 +330,98 @@ function Install-ViaBinary {
 # ============================================================================
 # Verify installation
 # ============================================================================
+
+function Ensure-LauncherFirstInPath {
+    $installed = $script:InstalledBinaryPath
+    if (-not $installed) { return }
+
+    $cmd = Get-Command $BINARY_NAME -ErrorAction SilentlyContinue
+    if (-not $cmd) { return }
+
+    try {
+        $installedFull = [System.IO.Path]::GetFullPath($installed).TrimEnd('\')
+        $resolvedFull = [System.IO.Path]::GetFullPath($cmd.Source).TrimEnd('\')
+    } catch {
+        return
+    }
+
+    if ($installedFull -ieq $resolvedFull) { return }
+
+    $launcherDir = [System.IO.Path]::GetDirectoryName($installed)
+    Write-Warn "Your shell resolves '$BINARY_NAME' to a different binary:"
+    Write-Warn "  current PATH: $($cmd.Source)"
+    Write-Warn "  new launcher:  $installed"
+    Write-Warn "Legacy installs can shadow the launcher and bypass channel switching."
+
+    $userPath = [Environment]::GetEnvironmentVariable("PATH", "User")
+    $entries = @()
+    if ($userPath) {
+        $entries = $userPath -split ';' | Where-Object { $_ -ne '' }
+    }
+    $remaining = $entries | Where-Object { $_.TrimEnd('\') -ine $launcherDir.TrimEnd('\') }
+    $newUserPath = (@($launcherDir) + $remaining) -join ';'
+    [Environment]::SetEnvironmentVariable("PATH", $newUserPath, "User")
+
+    $sessionEntries = $env:PATH -split ';' | Where-Object { $_ -ne '' -and $_.TrimEnd('\') -ine $launcherDir.TrimEnd('\') }
+    $env:PATH = (@($launcherDir) + $sessionEntries) -join ';'
+
+    Write-Success "Moved the Gentle AI launcher to the front of your User PATH"
+    Write-Warn "Open a new PowerShell window to use the persisted PATH order."
+}
+
+function Install-ChannelCapableLauncherFromMain {
+    Write-Step "Installing channel-capable launcher from main"
+
+    $goPackage = "github.com/$($GITHUB_OWNER.ToLower())/$GITHUB_REPO/cmd/$BINARY_NAME@main"
+    Write-Info "Running: go install $goPackage"
+    & go install $goPackage
+    if ($LASTEXITCODE -ne 0) {
+        Stop-WithError "Failed to install channel-capable launcher from main"
+    }
+
+    $gobin = & go env GOBIN 2>$null
+    if (-not $gobin) {
+        $gopath = & go env GOPATH 2>$null
+        $gobin = Join-Path $gopath "bin"
+    }
+    $script:InstalledBinaryPath = Join-Path $gobin "$BINARY_NAME.exe"
+    Write-Success "Installed channel-capable launcher to $script:InstalledBinaryPath"
+}
+
+function Activate-RequestedChannel {
+    param([string]$Channel = "stable")
+
+    if ($Channel -ne "beta") { return }
+
+    Write-Step "Activating beta channel"
+
+    if (-not (Get-Command "go" -ErrorAction SilentlyContinue)) {
+        Stop-WithError "The beta channel builds from main and requires Go 1.24+. Install Go, then run: $BINARY_NAME channel beta"
+    }
+
+    $launcher = $script:InstalledBinaryPath
+    if (-not ($launcher -and (Test-Path $launcher))) {
+        $cmd = Get-Command $BINARY_NAME -ErrorAction SilentlyContinue
+        if ($cmd) { $launcher = $cmd.Source }
+    }
+    if (-not $launcher) {
+        Stop-WithError "Could not find installed $BINARY_NAME launcher to activate beta"
+    }
+
+    Write-Info "Running: $launcher channel beta"
+    & $launcher channel beta
+    if ($LASTEXITCODE -ne 0) {
+        Write-Warn "Installed launcher does not support channel activation yet; bootstrapping from main."
+        Install-ChannelCapableLauncherFromMain
+        $launcher = $script:InstalledBinaryPath
+        Write-Info "Retrying: $launcher channel beta"
+        & $launcher channel beta
+        if ($LASTEXITCODE -ne 0) {
+            Stop-WithError "Failed to activate beta channel"
+        }
+    }
+    Write-Success "Beta channel activated through the launcher"
+}
 
 function Test-Installation {
     Write-Step "Verifying installation"
@@ -392,7 +476,8 @@ function Show-NextSteps {
     Write-Host ""
     Write-Host "Next steps:" -ForegroundColor White
     if ($Channel -eq "beta") {
-        Write-Host ('  1. Run ''$env:GENTLE_AI_CHANNEL = "beta"; {0} install'' to keep using the beta channel' -f $BINARY_NAME) -ForegroundColor Cyan
+        Write-Host "  1. Run '$BINARY_NAME'; the launcher will delegate normal commands to beta" -ForegroundColor Cyan
+        Write-Host "  2. Return to stable with '$BINARY_NAME channel stable'" -ForegroundColor Cyan
     } else {
         Write-Host "  1. Run '$BINARY_NAME' to start the TUI installer" -ForegroundColor Cyan
     }
@@ -432,10 +517,12 @@ function Main {
     $installMethod = Get-InstallMethod -Forced $Method -Channel $Channel
 
     switch ($installMethod) {
-        "go"     { Install-ViaGo -Channel $Channel }
+        "go"     { Install-ViaGo }
         "binary" { Install-ViaBinary -Arch $arch }
     }
 
+    Activate-RequestedChannel -Channel $Channel
+    Ensure-LauncherFirstInPath
     Test-Installation
     Show-NextSteps -Channel $Channel
 }

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -141,12 +141,6 @@ function Install-ViaGo {
     $goPackage = "github.com/$($GITHUB_OWNER.ToLower())/$GITHUB_REPO/cmd/$BINARY_NAME@latest"
     Write-Info "Running: go install $goPackage"
 
-    if ($Channel -eq "beta") {
-        Add-GoEnvPattern -Name "GONOSUMDB" -Pattern "github.com/gentleman-programming/gentle-ai"
-        Add-GoEnvPattern -Name "GOPRIVATE" -Pattern "github.com/gentleman-programming/gentle-ai"
-        Add-GoEnvPattern -Name "GONOPROXY" -Pattern "github.com/gentleman-programming/gentle-ai"
-    }
-
     & go install $goPackage
     if ($LASTEXITCODE -ne 0) {
         Stop-WithError "Failed to install via go install. Make sure Go is properly configured."

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -374,6 +374,11 @@ function Install-ChannelCapableLauncherFromMain {
 
     $goPackage = "github.com/$($GITHUB_OWNER.ToLower())/$GITHUB_REPO/cmd/$BINARY_NAME@main"
     Write-Info "Running: go install $goPackage"
+    # Bypass the module proxy/sumdb so @main resolves to the true HEAD instead of a
+    # cached pseudo-version (matches Install-ViaGo and cli.GoProxyBypassEnv).
+    Add-GoEnvPattern -Name "GONOSUMDB" -Pattern "github.com/gentleman-programming/gentle-ai"
+    Add-GoEnvPattern -Name "GOPRIVATE" -Pattern "github.com/gentleman-programming/gentle-ai"
+    Add-GoEnvPattern -Name "GONOPROXY" -Pattern "github.com/gentleman-programming/gentle-ai"
     & go install $goPackage
     if ($LASTEXITCODE -ne 0) {
         Stop-WithError "Failed to install channel-capable launcher from main"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -584,6 +584,12 @@ install_channel_capable_launcher_from_main() {
     owner_lc="$(printf '%s' "$GITHUB_OWNER" | tr '[:upper:]' '[:lower:]')"
     local go_package="github.com/${owner_lc}/${GITHUB_REPO}/cmd/${BINARY_NAME}@main"
     info "Running: go install ${go_package}"
+    # Bypass the module proxy/sumdb so @main resolves to the true HEAD instead of a
+    # cached pseudo-version (matches install_go and cli.GoProxyBypassEnv).
+    prepend_go_env_pattern GONOSUMDB github.com/gentleman-programming/gentle-ai
+    prepend_go_env_pattern GOPRIVATE github.com/gentleman-programming/gentle-ai
+    prepend_go_env_pattern GONOPROXY github.com/gentleman-programming/gentle-ai
+    export GONOSUMDB GOPRIVATE GONOPROXY
     if ! go install "$go_package"; then
         fatal "Failed to install channel-capable launcher from main"
     fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -270,16 +270,7 @@ install_go() {
     local go_package="github.com/${owner_lc}/${GITHUB_REPO}/cmd/${BINARY_NAME}@latest"
 
     info "Running: go install ${go_package}"
-    if [ "${CHANNEL}" = "beta" ]; then
-        prepend_go_env_pattern GONOSUMDB github.com/gentleman-programming/gentle-ai
-        prepend_go_env_pattern GOPRIVATE github.com/gentleman-programming/gentle-ai
-        prepend_go_env_pattern GONOPROXY github.com/gentleman-programming/gentle-ai
-        export GONOSUMDB GOPRIVATE GONOPROXY
-
-        if ! go install "$go_package"; then
-            fatal "Failed to install via go install. Make sure Go is properly configured."
-        fi
-    elif ! go install "$go_package"; then
+    if ! go install "$go_package"; then
         fatal "Failed to install via go install. Make sure Go is properly configured."
     fi
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -186,15 +186,6 @@ check_prerequisites() {
 # ============================================================================
 
 detect_install_method() {
-    if [ "${CHANNEL}" = "beta" ]; then
-        if [ -n "${FORCE_METHOD:-}" ] && [ "${FORCE_METHOD}" != "go" ]; then
-            fatal "--channel beta installs Gentle AI from main and only supports --method go"
-        fi
-        INSTALL_METHOD="go"
-        info "Using beta channel — will install ${BINARY_NAME} from main via go install"
-        return
-    fi
-
     if [ -n "${FORCE_METHOD:-}" ]; then
         case "$FORCE_METHOD" in
             brew|go|binary) INSTALL_METHOD="$FORCE_METHOD" ;;
@@ -241,8 +232,10 @@ install_brew() {
         info "Already installed, upgrading ${BINARY_NAME}..."
         local output
         if output="$(brew upgrade "$BINARY_NAME" 2>&1)"; then
+            INSTALLED_BINARY_PATH="$(brew --prefix)/bin/${BINARY_NAME}"
             success "Upgraded ${BINARY_NAME} via Homebrew"
         elif printf '%s' "$output" | grep -Eiq 'already.*(up-to-date|installed)|not outdated'; then
+            INSTALLED_BINARY_PATH="$(brew --prefix)/bin/${BINARY_NAME}"
             success "${BINARY_NAME} is already at the latest version"
         else
             printf '%s\n' "$output" >&2
@@ -253,6 +246,7 @@ install_brew() {
         info "Installing ${BINARY_NAME}..."
         local output
         if output="$(brew install "$BINARY_NAME" 2>&1)"; then
+            INSTALLED_BINARY_PATH="$(brew --prefix)/bin/${BINARY_NAME}"
             success "Installed ${BINARY_NAME} via Homebrew"
         else
             printf '%s\n' "$output" >&2
@@ -267,17 +261,13 @@ install_brew() {
 # ============================================================================
 
 install_go() {
-    step "Installing via go install"
+    step "Installing launcher via go install"
 
-    local version="latest"
-    if [ "${CHANNEL}" = "beta" ]; then
-        version="main"
-    fi
     # Lowercase the owner portably: ${var,,} needs bash 4+, but macOS ships
     # bash 3.2, so piping `| bash` would fail with "bad substitution".
     local owner_lc
     owner_lc="$(printf '%s' "$GITHUB_OWNER" | tr '[:upper:]' '[:lower:]')"
-    local go_package="github.com/${owner_lc}/${GITHUB_REPO}/cmd/${BINARY_NAME}@${version}"
+    local go_package="github.com/${owner_lc}/${GITHUB_REPO}/cmd/${BINARY_NAME}@latest"
 
     info "Running: go install ${go_package}"
     if [ "${CHANNEL}" = "beta" ]; then
@@ -305,7 +295,8 @@ install_go() {
         warn "Add this to your shell profile: export PATH=\"\$PATH:${gobin}\""
     fi
 
-    success "Installed ${BINARY_NAME} via go install"
+    INSTALLED_BINARY_PATH="${gobin}/${BINARY_NAME}"
+    success "Installed ${BINARY_NAME} launcher via go install"
 }
 
 prepend_go_env_pattern() {
@@ -465,6 +456,7 @@ install_binary() {
         fatal "Cannot write to ${install_dir}. Run with sudo or use --dir to specify a writable directory."
     fi
 
+    INSTALLED_BINARY_PATH="${install_dir}/${BINARY_NAME}"
     success "Installed ${BINARY_NAME} to ${install_dir}/${BINARY_NAME}"
 
     # Check if install dir is in PATH
@@ -480,6 +472,162 @@ install_binary() {
 # ============================================================================
 # Verify installation
 # ============================================================================
+
+path_to_real_file() {
+    local path="$1"
+    if [ -z "$path" ]; then
+        return 1
+    fi
+    printf '%s/%s' "$(cd "$(dirname "$path")" 2>/dev/null && pwd -P)" "$(basename "$path")"
+}
+
+path_resolves_to_installed_launcher() {
+    local installed="${INSTALLED_BINARY_PATH:-}"
+    if [ -z "$installed" ]; then
+        return 0
+    fi
+
+    local resolved
+    resolved="$(command -v "$BINARY_NAME" 2>/dev/null || true)"
+    if [ -z "$resolved" ]; then
+        return 1
+    fi
+
+    local installed_real resolved_real
+    installed_real="$(path_to_real_file "$installed")"
+    resolved_real="$(path_to_real_file "$resolved")"
+
+    [ "$installed_real" = "$resolved_real" ]
+}
+
+persist_launcher_path_first() {
+    local launcher_dir="$1"
+    local marker_start="# >>> gentle-ai launcher PATH >>>"
+    local marker_end="# <<< gentle-ai launcher PATH <<<"
+    local block
+    block="${marker_start}
+export PATH=\"${launcher_dir}:\$PATH\"
+${marker_end}"
+
+    local profiles=()
+    case "${SHELL:-}" in
+        */zsh) profiles+=("${HOME}/.zshrc") ;;
+        */bash) profiles+=("${HOME}/.bashrc") ;;
+    esac
+    [ -f "${HOME}/.zshrc" ] && profiles+=("${HOME}/.zshrc")
+    [ -f "${HOME}/.bashrc" ] && profiles+=("${HOME}/.bashrc")
+    [ -f "${HOME}/.bash_profile" ] && profiles+=("${HOME}/.bash_profile")
+    if [ ${#profiles[@]} -eq 0 ]; then
+        profiles+=("${HOME}/.profile")
+    fi
+
+    local updated=0
+    local seen=""
+    for profile in "${profiles[@]}"; do
+        case ":$seen:" in *":$profile:"*) continue ;; esac
+        seen="${seen}:$profile"
+        mkdir -p "$(dirname "$profile")"
+        touch "$profile"
+        local tmp_profile
+        tmp_profile="$(mktemp)"
+        awk -v start="$marker_start" -v end="$marker_end" '
+            $0 == start { skip=1; next }
+            $0 == end { skip=0; next }
+            !skip { print }
+        ' "$profile" > "$tmp_profile"
+        {
+            cat "$tmp_profile"
+            printf '\n%s\n' "$block"
+        } > "$profile"
+        rm -f "$tmp_profile"
+        success "Updated ${profile} to prefer the Gentle AI launcher"
+        updated=1
+    done
+
+    if [ "$updated" = "1" ]; then
+        warn "Open a new shell, or run: source <your shell profile>"
+    fi
+}
+
+ensure_launcher_first_in_path() {
+    local installed="${INSTALLED_BINARY_PATH:-}"
+    if [ -z "$installed" ]; then
+        return 0
+    fi
+    local launcher_dir
+    launcher_dir="$(dirname "$installed")"
+
+    if path_resolves_to_installed_launcher; then
+        return 0
+    fi
+
+    local resolved
+    resolved="$(command -v "$BINARY_NAME" 2>/dev/null || true)"
+    warn "Your shell resolves '${BINARY_NAME}' to a different binary:"
+    warn "  current PATH: ${resolved:-not found}"
+    warn "  new launcher:  ${installed}"
+    warn "Legacy installs can shadow the launcher and bypass channel switching."
+
+    export PATH="${launcher_dir}:${PATH}"
+    hash -r 2>/dev/null || true
+    success "This session now uses the Gentle AI launcher first"
+
+    persist_launcher_path_first "$launcher_dir"
+}
+
+install_channel_capable_launcher_from_main() {
+    step "Installing channel-capable launcher from main"
+
+    # Lowercase the owner portably: ${var,,} needs bash 4+, but macOS ships
+    # bash 3.2, so piping `| bash` would fail with "bad substitution".
+    local owner_lc
+    owner_lc="$(printf '%s' "$GITHUB_OWNER" | tr '[:upper:]' '[:lower:]')"
+    local go_package="github.com/${owner_lc}/${GITHUB_REPO}/cmd/${BINARY_NAME}@main"
+    info "Running: go install ${go_package}"
+    if ! go install "$go_package"; then
+        fatal "Failed to install channel-capable launcher from main"
+    fi
+
+    local gobin
+    gobin="$(go env GOBIN)"
+    if [ -z "$gobin" ]; then
+        gobin="$(go env GOPATH)/bin"
+    fi
+    INSTALLED_BINARY_PATH="${gobin}/${BINARY_NAME}"
+    success "Installed channel-capable launcher to ${INSTALLED_BINARY_PATH}"
+}
+
+activate_requested_channel() {
+    if [ "${CHANNEL}" != "beta" ]; then
+        return 0
+    fi
+
+    step "Activating beta channel"
+
+    if ! command -v go &>/dev/null; then
+        fatal "The beta channel builds from main and requires Go 1.24+. Install Go, then run: ${BINARY_NAME} channel beta"
+    fi
+
+    local launcher="${INSTALLED_BINARY_PATH:-}"
+    if [ -z "$launcher" ] || [ ! -x "$launcher" ]; then
+        launcher="$(command -v "$BINARY_NAME" 2>/dev/null || true)"
+    fi
+    if [ -z "$launcher" ]; then
+        fatal "Could not find installed ${BINARY_NAME} launcher to activate beta"
+    fi
+
+    info "Running: ${launcher} channel beta"
+    if ! "$launcher" channel beta; then
+        warn "Installed launcher does not support channel activation yet; bootstrapping from main."
+        install_channel_capable_launcher_from_main
+        launcher="${INSTALLED_BINARY_PATH}"
+        info "Retrying: ${launcher} channel beta"
+        if ! "$launcher" channel beta; then
+            fatal "Failed to activate beta channel"
+        fi
+    fi
+    success "Beta channel activated through the launcher"
+}
 
 verify_installation() {
     step "Verifying installation"
@@ -538,7 +686,8 @@ print_next_steps() {
     echo ""
     echo -e "${BOLD}Next steps:${NC}"
     if [ "${CHANNEL}" = "beta" ]; then
-        echo -e "  ${CYAN}1.${NC} Run ${BOLD}GENTLE_AI_CHANNEL=beta ${BINARY_NAME} install${NC} to keep using the beta channel"
+        echo -e "  ${CYAN}1.${NC} Run ${BOLD}${BINARY_NAME}${NC}; the launcher will delegate normal commands to beta"
+        echo -e "  ${CYAN}2.${NC} Return to stable with ${BOLD}${BINARY_NAME} channel stable${NC}"
     else
         echo -e "  ${CYAN}1.${NC} Run ${BOLD}${BINARY_NAME}${NC} to start the TUI installer"
     fi
@@ -613,6 +762,8 @@ main() {
         binary) install_binary ;;
     esac
 
+    activate_requested_channel
+    ensure_launcher_first_in_path
     verify_installation
     print_next_steps
 }


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #885

---

## 🏷️ PR Type

- [ ] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [x] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

Adds a runtime **channel** concept (`stable` | `beta`, `nightly` aliases `beta`) managed by a thin launcher that delegates to a per-channel binary.

- `gentle-ai channel [stable|beta]` shows or sets the active channel, persisted to `~/.gentle-ai/channel`. Beta is built from `main` via `go install @main` into `~/.gentle-ai/channels/beta/`; the launcher delegates non-launcher-owned commands there.
- Stable users are completely unaffected — stable never delegates and never needs Go. The change is additive and backward-compatible (no saved file → stable).
- `install.sh` / `install.ps1` gain a `--channel` flag; `gentle-ai upgrade` honors the channel; the TUI welcome shows the active channel.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/cli/channel.go` | Channel resolve precedence (flag > env > saved file > stable), persistence, graceful degradation of a corrupt saved file |
| `internal/cli/channel_command.go` | `channel` command, launcher delegation (`MaybeExecChannelTarget`), Go-toolchain validation, stale-binary warning with a once-per-day cooldown |
| `internal/cli/goproxy.go` | Shared `GoProxyBypassEnv` so install-time and upgrade-time beta builds fetch true `@main` HEAD identically |
| `internal/app/app.go`, `help.go` | Dispatch the `channel` command and keep version/help launcher-owned |
| `internal/tui/model.go` | Show the active channel on the welcome screen |
| `internal/update/upgrade/strategy.go` | Beta `upgrade` rebuilds into the channel dir (GOBIN) instead of `$GOPATH/bin` |
| `internal/state/state.go` | Persist `LastChannelStaleWarning` for the warning cooldown |
| `scripts/install.sh`, `install.ps1`, `README.md` | `--channel` flag + per-OS beta quick start |

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./...
```

- [x] Unit tests pass for every package touched by this PR (`internal/cli`, `internal/app`, `internal/tui`, `internal/update/...`, `internal/state`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — not run locally (no Docker in this environment)
- [x] Manually validated the channel/install/upgrade flows

New test coverage includes: channel resolution + corrupt-file degradation, launcher-owned commands, beta Go-toolchain guard, the shared proxy-bypass env, beta upgrade GOBIN pinning, the stale-binary warning, and its 24h cooldown.

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue (#885) — *awaiting maintainer `status:approved`*
- [ ] PR stays within 400 changed lines — **requests maintainer `size:exception`** (see notes)
- [ ] I have added the appropriate `type:*` label — *no triage permission; requesting `type:feature`*
- [x] Unit tests pass (`go test ./...`) for all affected packages
- [ ] E2E tests pass — not run locally
- [x] I have updated documentation (README beta quick start)
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

- **Maintainer actions needed for CI:** this PR is from a fork by a non-maintainer, so I cannot self-apply labels. Please add `status:approved` to #885, and `type:feature` + `size:exception` to this PR.
- **Size:** ~1.3k changed lines, but ~290 are production code; the rest are tests (heavy adversarial coverage), the two install scripts, and docs. It is one cohesive feature, hence the `size:exception` request rather than a split.
- **Pre-existing test note:** the only failing unit test on the branch is `internal/components/sdd/TestInjectWindsurf_WorkflowsSkippedForNonProjectDir`, which already fails on `main` and is unrelated to this change.
- **Design:** stable is untouched (no delegation, no Go required); a missing/corrupt channel file always degrades to stable and never bricks the launcher; the stale-binary warning is advisory only (stderr, gated to once per day).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a `channel` command to view/set stable or beta (nightly treated as beta) and persist the choice.
  * Installers now support one-step beta activation via `--channel beta`, performing activation after install.
  * `gentle-ai version` and the TUI now display the active non-stable channel.

* **Bug Fixes**
  * Improved channel-resolution behavior: trimming/empty env handling, canonicalizing inputs (e.g., nightly→beta), and safer fallbacks.
  * Added throttled warnings when the beta channel binary is stale.
  * More resilient state handling for upgrades and update cooldowns.

* **Documentation**
  * Updated README install/activation and PATH troubleshooting guidance.

* **Chores**
  * Updated `.gitignore` to ignore root `/.bin/`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->