### PR TITLE
feat(linux): add Deepin and UOS support

### DIFF
--- a/internal/system/detect.go
+++ b/internal/system/detect.go
@@ -189,12 +189,14 @@ func detectLinuxDistro(linuxOSRelease string) string {
 	id := fields["ID"]
 	idLike := fields["ID_LIKE"]
 
-	if isDebianLike(id, idLike) {
-		return LinuxDistroDebian
-	}
-
+	// Ubuntu-like check first: Ubuntu derivatives (linuxmint, pop, etc.) have
+	// ID_LIKE containing "debian" but must NOT be classified as Debian-like.
 	if isUbuntuLike(id, idLike) {
 		return LinuxDistroUbuntu
+	}
+
+	if isDebianLike(id, idLike) {
+		return LinuxDistroDebian
 	}
 
 	if isArchLike(id, idLike) {
@@ -211,6 +213,12 @@ func detectLinuxDistro(linuxOSRelease string) string {
 func isDebianLike(id, idLike string) bool {
 	if id == LinuxDistroDebian || id == "deepin" || id == "uos" {
 		return true
+	}
+
+	for _, token := range strings.Fields(idLike) {
+		if token == LinuxDistroDebian || token == "deepin" || token == "uos" {
+			return true
+		}
 	}
 
 	return false

--- a/internal/system/detect.go
+++ b/internal/system/detect.go
@@ -189,10 +189,11 @@ func detectLinuxDistro(linuxOSRelease string) string {
 	id := fields["ID"]
 	idLike := fields["ID_LIKE"]
 
+	if isDebianLike(id, idLike) {
+		return LinuxDistroDebian
+	}
+
 	if isUbuntuLike(id, idLike) {
-		if id == LinuxDistroDebian {
-			return LinuxDistroDebian
-		}
 		return LinuxDistroUbuntu
 	}
 
@@ -207,13 +208,21 @@ func detectLinuxDistro(linuxOSRelease string) string {
 	return LinuxDistroUnknown
 }
 
+func isDebianLike(id, idLike string) bool {
+	if id == LinuxDistroDebian || id == "deepin" || id == "uos" {
+		return true
+	}
+
+	return false
+}
+
 func isUbuntuLike(id, idLike string) bool {
-	if id == LinuxDistroUbuntu || id == LinuxDistroDebian {
+	if id == LinuxDistroUbuntu || id == "linuxmint" || id == "pop" {
 		return true
 	}
 
 	for _, token := range strings.Fields(idLike) {
-		if token == LinuxDistroUbuntu || token == LinuxDistroDebian {
+		if token == LinuxDistroUbuntu {
 			return true
 		}
 	}

--- a/internal/system/detect_test.go
+++ b/internal/system/detect_test.go
@@ -73,6 +73,40 @@ func TestDetectFromInputsMarksUbuntuSupported(t *testing.T) {
 	}
 }
 
+func TestDetectFromInputsMarksDeepinSupported(t *testing.T) {
+	osRelease := "ID=deepin\n"
+	result := detectFromInputs("linux", "amd64", "/bin/bash", osRelease, nil, nil)
+
+	if !result.System.Supported {
+		t.Fatalf("expected deepin linux to be supported")
+	}
+
+	if result.System.Profile.LinuxDistro != LinuxDistroDebian {
+		t.Fatalf("expected debian distro for deepin, got %q", result.System.Profile.LinuxDistro)
+	}
+
+	if result.System.Profile.PackageManager != "apt" {
+		t.Fatalf("expected apt package manager for deepin, got %q", result.System.Profile.PackageManager)
+	}
+}
+
+func TestDetectFromInputsMarksUosSupported(t *testing.T) {
+	osRelease := "ID=uos\n"
+	result := detectFromInputs("linux", "amd64", "/bin/bash", osRelease, nil, nil)
+
+	if !result.System.Supported {
+		t.Fatalf("expected uos linux to be supported")
+	}
+
+	if result.System.Profile.LinuxDistro != LinuxDistroDebian {
+		t.Fatalf("expected debian distro for uos, got %q", result.System.Profile.LinuxDistro)
+	}
+
+	if result.System.Profile.PackageManager != "apt" {
+		t.Fatalf("expected apt package manager for uos, got %q", result.System.Profile.PackageManager)
+	}
+}
+
 func TestDetectFromInputsMarksArchSupported(t *testing.T) {
 	osRelease := "ID=arch\nID_LIKE=archlinux\n"
 	result := detectFromInputs("linux", "amd64", "/bin/bash", osRelease, nil, nil)
@@ -117,6 +151,16 @@ func TestDetectLinuxDistroMatrix(t *testing.T) {
 			name:       "pop os derivative of ubuntu",
 			osRelease:  "ID=pop\nID_LIKE=\"ubuntu debian\"\n",
 			wantDistro: LinuxDistroUbuntu,
+		},
+		{
+			name:       "deepin derivative of debian",
+			osRelease:  "ID=deepin\n",
+			wantDistro: LinuxDistroDebian,
+		},
+		{
+			name:       "uos derivative of debian",
+			osRelease:  "ID=uos\n",
+			wantDistro: LinuxDistroDebian,
 		},
 		{
 			name:       "arch linux",
@@ -200,6 +244,59 @@ func TestDetectLinuxDistroMatrix(t *testing.T) {
 			got := detectLinuxDistro(tc.osRelease)
 			if got != tc.wantDistro {
 				t.Fatalf("detectLinuxDistro() = %q, want %q", got, tc.wantDistro)
+			}
+		})
+	}
+}
+
+func TestIsDebianLike(t *testing.T) {
+	tests := []struct {
+		name   string
+		id     string
+		idLike string
+		want   bool
+	}{
+		{name: "debian itself", id: "debian", idLike: "", want: true},
+		{name: "deepin directly", id: "deepin", idLike: "", want: true},
+		{name: "uos directly", id: "uos", idLike: "", want: true},
+		{name: "ubuntu not debian-like", id: "ubuntu", idLike: "", want: false},
+		{name: "linuxmint not debian-like", id: "linuxmint", idLike: "", want: false},
+		{name: "arch not debian-like", id: "arch", idLike: "", want: false},
+		{name: "unknown unknown", id: "unknown", idLike: "", want: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isDebianLike(tc.id, tc.idLike)
+			if got != tc.want {
+				t.Fatalf("isDebianLike(%q, %q) = %v, want %v", tc.id, tc.idLike, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsUbuntuLike(t *testing.T) {
+	tests := []struct {
+		name   string
+		id     string
+		idLike string
+		want   bool
+	}{
+		{name: "ubuntu itself", id: "ubuntu", idLike: "", want: true},
+		{name: "linuxmint directly", id: "linuxmint", idLike: "", want: true},
+		{name: "pop directly", id: "pop", idLike: "", want: true},
+		{name: "debian not ubuntu-like", id: "debian", idLike: "", want: false},
+		{name: "deepin not ubuntu-like", id: "deepin", idLike: "", want: false},
+		{name: "arch not ubuntu-like", id: "arch", idLike: "", want: false},
+		{name: "via id_like ubuntu", id: "custom", idLike: "ubuntu", want: true},
+		{name: "unknown unknown", id: "unknown", idLike: "", want: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isUbuntuLike(tc.id, tc.idLike)
+			if got != tc.want {
+				t.Fatalf("isUbuntuLike(%q, %q) = %v, want %v", tc.id, tc.idLike, got, tc.want)
 			}
 		})
 	}

--- a/internal/system/detect_test.go
+++ b/internal/system/detect_test.go
@@ -262,6 +262,9 @@ func TestIsDebianLike(t *testing.T) {
 		{name: "ubuntu not debian-like", id: "ubuntu", idLike: "", want: false},
 		{name: "linuxmint not debian-like", id: "linuxmint", idLike: "", want: false},
 		{name: "arch not debian-like", id: "arch", idLike: "", want: false},
+		{name: "via id_like deepin", id: "custom", idLike: "deepin", want: true},
+		{name: "via id_like uos", id: "custom", idLike: "uos", want: true},
+		{name: "via id_like debian", id: "custom", idLike: "debian", want: true},
 		{name: "unknown unknown", id: "unknown", idLike: "", want: false},
 	}
 


### PR DESCRIPTION
## Summary

- Add detection for Deepin and UOS Linux distributions as Debian family members
- Both distros are Debian-based and use the `apt` package manager

## Changes

| File | Change |
|------|--------|
| `internal/system/detect.go` | 19 lines changed (+14/-5) |
| `internal/system/detect_test.go` | 97 lines added |

## Scope (as requested)

Following the feedback on #182, this is a small focused PR that only touches:
- System detection (`internal/system/detect.go`)
- Focused unit tests (`internal/system/detect_test.go`)

No changes to unrelated files, no docs changes needed.

## Test Plan

- [x] `go test ./internal/system -v` — all 109 tests pass

## Notes

- Deepin and UOS map to `LinuxDistroDebian`, which automatically resolves to `apt` package manager via the existing `resolvePlatformProfile` logic
- No changes needed to install command resolution — the existing `apt` paths cover these distros
- Version-agnostic: supports Deepin 20/23/25+ and UOS 20/25+


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Deepin Linux distribution
  * Added support for UOS Linux distribution
* **Bug Fixes**
  * Improved Linux distribution detection for Debian-based systems
  * Tightened Ubuntu-like classification to avoid misclassifying Debian-like variants
* **Tests**
  * Expanded unit test coverage for Linux distribution and package manager detection, including Deepin/UOS and Debian-like derivatives
<!-- end of auto-generated comment: release notes by coderabbit.ai -->