### PR TITLE
fix(install): use portable lowercase for go owner on bash 3.2

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -273,7 +273,11 @@ install_go() {
     if [ "${CHANNEL}" = "beta" ]; then
         version="main"
     fi
-    local go_package="github.com/${GITHUB_OWNER,,}/${GITHUB_REPO}/cmd/${BINARY_NAME}@${version}"
+    # Lowercase the owner portably: ${var,,} needs bash 4+, but macOS ships
+    # bash 3.2, so piping `| bash` would fail with "bad substitution".
+    local owner_lc
+    owner_lc="$(printf '%s' "$GITHUB_OWNER" | tr '[:upper:]' '[:lower:]')"
+    local go_package="github.com/${owner_lc}/${GITHUB_REPO}/cmd/${BINARY_NAME}@${version}"
 
     info "Running: go install ${go_package}"
     if [ "${CHANNEL}" = "beta" ]; then


### PR DESCRIPTION
Closes #890

## Type

- [x] Bug fix

## Summary

- The beta channel built the `go install` package path with `${GITHUB_OWNER,,}` (bash 4+ lowercase expansion). macOS ships bash 3.2, so `curl ... | bash -s -- --channel beta` failed with `bad substitution`.
- Lowercase the owner with `tr '[:upper:]' '[:lower:]'`, which is portable to bash 3.2. It was the only bash-4-only construct in the script.

## Changes

| File | Change |
|------|--------|
| `scripts/install.sh` | Replace `${GITHUB_OWNER,,}` with a `tr`-based lowercase computed into `owner_lc`; add a comment explaining the bash 3.2 constraint |

## Test Plan

- [x] `shellcheck scripts/install.sh` — clean, no findings
- [x] `bash -n scripts/install.sh` — syntax OK
- [x] Functional check: `Gentleman-Programming` → `gentleman-programming` via the new `tr` pipeline
- [x] No remaining `${var,,}`/`${var^^}` or other bash-4-only constructs (no assoc arrays / mapfile)

## Checklist

- [x] Linked an approved issue (#890, `status:approved`)
- [x] Added exactly one `type:*` label (`type:bug`)
- [x] Ran shellcheck on the modified script
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility of the installation script to work reliably on systems with older shell versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->