### PR TITLE
fix(install): replace em dashes with ASCII hyphens for PS5.1 compat

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,7 +1,7 @@
 #Requires -Version 5.1
 <#
 .SYNOPSIS
-    Gentle-AI — Install Script for Windows
+    Gentle-AI - Install Script for Windows
     Ecosystem, Frameworks, Workflows for AI coding agents.
 
 .DESCRIPTION
@@ -70,7 +70,7 @@ function Show-Banner {
     Write-Host " | |_| |  __/ | | | |_| |  __/_____/ ___ \ | | " -ForegroundColor Cyan
     Write-Host "  \____|\___|_| |_|\__|_|\___|    /_/   \_\___|" -ForegroundColor Cyan
     Write-Host ""
-    Write-Host "  Gentle-AI — Ecosystem, Frameworks, Workflows" -ForegroundColor DarkGray
+    Write-Host "  Gentle-AI - Ecosystem, Frameworks, Workflows" -ForegroundColor DarkGray
     Write-Host ""
 }
 
@@ -120,7 +120,7 @@ function Get-InstallMethod {
         if ($Forced -ne "auto" -and $Forced -ne "go") {
             Stop-WithError "-Channel beta installs Gentle AI from main and only supports -Method go"
         }
-        Write-Info "Using beta channel — will install $BINARY_NAME from main via go install"
+        Write-Info "Using beta channel - will install $BINARY_NAME from main via go install"
         return "go"
     }
 
@@ -310,7 +310,7 @@ function Install-ViaBinary {
         # a fully lossless round-trip would require the Win32 Registry class with
         # GetValue(..., DoNotExpandEnvironmentNames). We accept the trade-off here
         # because user PATH entries that rely on unexpanded refs are uncommon and
-        # we only ever append — we never rewrite the whole value.
+        # we only ever append - we never rewrite the whole value.
         $userPath = [Environment]::GetEnvironmentVariable("PATH", "User")
 
         # Split on ';' and compare entries case-insensitively so wildcard chars


### PR DESCRIPTION
Closes #849

## PR Type

- [x] Bug fix

## Summary

- PowerShell 5.1 reads \install.ps1\ (UTF-8 without BOM) as Windows-1252, where the em dash bytes (\---\, U+2014, encoded as \E2 80 94\) cause byte \

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated punctuation formatting in installer banner and status messages for consistent styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->