### PR TITLE
test(upgrade): fix GGA backup test for Windows paths

### DIFF
--- a/internal/components/gga/config_test.go
+++ b/internal/components/gga/config_test.go
@@ -118,6 +118,7 @@ func TestBuildConfigDifferentProviders(t *testing.T) {
 
 func TestInjectWritesConfigAndAgents(t *testing.T) {
 	home := t.TempDir()
+	t.Setenv("APPDATA", filepath.Join(home, "AppData", "Roaming"))
 
 	result, err := Inject(home, []model.AgentID{model.AgentClaudeCode})
 	if err != nil {
@@ -162,6 +163,7 @@ func TestInjectWritesConfigAndAgents(t *testing.T) {
 
 func TestInjectIsIdempotent(t *testing.T) {
 	home := t.TempDir()
+	t.Setenv("APPDATA", filepath.Join(home, "AppData", "Roaming"))
 
 	first, err := Inject(home, []model.AgentID{model.AgentOpenCode})
 	if err != nil {

--- a/internal/update/upgrade/executor_test.go
+++ b/internal/update/upgrade/executor_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/gentleman-programming/gentle-ai/internal/backup"
+	"github.com/gentleman-programming/gentle-ai/internal/components/gga"
 	"github.com/gentleman-programming/gentle-ai/internal/model"
 	"github.com/gentleman-programming/gentle-ai/internal/state"
 	"github.com/gentleman-programming/gentle-ai/internal/system"
@@ -856,8 +857,9 @@ func TestConfigPathsForBackup_CoversRegistryAgentsNotInOldList(t *testing.T) {
 func TestConfigPathsForBackup_GGAExtrasAreIncluded(t *testing.T) {
 	homeDir := t.TempDir()
 
-	// Create GGA config file at ~/.config/gga/config
-	ggaConfigFile := filepath.Join(homeDir, ".config", "gga", "config")
+	// Use gga package functions to get platform-correct paths
+	// (Windows uses %APPDATA%\gga, Unix uses ~/.config/gga)
+	ggaConfigFile := gga.ConfigPath(homeDir)
 	if err := os.MkdirAll(filepath.Dir(ggaConfigFile), 0o755); err != nil {
 		t.Fatalf("MkdirAll gga config: %v", err)
 	}
@@ -865,8 +867,9 @@ func TestConfigPathsForBackup_GGAExtrasAreIncluded(t *testing.T) {
 		t.Fatalf("WriteFile gga config: %v", err)
 	}
 
-	// Create GGA runtime lib file at ~/.local/share/gga/lib/pr_mode.sh
-	ggaLibFile := filepath.Join(homeDir, ".local", "share", "gga", "lib", "pr_mode.sh")
+	// GGA runtime lib file at ~/.local/share/gga/lib/pr_mode.sh
+	// (same path on all platforms)
+	ggaLibFile := gga.RuntimePRModePath(homeDir)
 	if err := os.MkdirAll(filepath.Dir(ggaLibFile), 0o755); err != nil {
 		t.Fatalf("MkdirAll gga lib: %v", err)
 	}

--- a/internal/update/upgrade/executor_test.go
+++ b/internal/update/upgrade/executor_test.go
@@ -856,6 +856,7 @@ func TestConfigPathsForBackup_CoversRegistryAgentsNotInOldList(t *testing.T) {
 // non-agent extras that must be preserved outside the canonical managed set.
 func TestConfigPathsForBackup_GGAExtrasAreIncluded(t *testing.T) {
 	homeDir := t.TempDir()
+	t.Setenv("APPDATA", filepath.Join(homeDir, "AppData", "Roaming"))
 
 	// Use gga package functions to get platform-correct paths
 	// (Windows uses %APPDATA%\gga, Unix uses ~/.config/gga)


### PR DESCRIPTION
## Summary

Fixes TestConfigPathsForBackup_GGAExtrasAreIncluded which was failing on Windows because it hardcoded Unix-style paths.

## Problem

The test created GGA config files at ~/.config/gga/config (Unix-style path), but gga.ConfigPath(homeDir) uses platform-specific paths:
- Windows: %APPDATA%\gga\config\ (e.g., C:\Users\...\AppData\Roaming\gga\config)
- Unix: ~/.config/gga/config

This caused the test to fail on Windows because configPathsForBackup() correctly returned the Windows path, but the test expected the Unix path it had created.

## Solution

Use gga.ConfigPath(homeDir) and gga.RuntimePRModePath(homeDir) instead of hardcoding paths. This ensures the test creates files at the correct platform-specific locations.

## Changes

- Import github.com/gentleman-programming/gentle-ai/internal/components/gga
- Replace hardcoded paths with gga.ConfigPath(homeDir) and gga.RuntimePRModePath(homeDir)

## Testing

- Test passes on Windows
- All other tests in internal/update/upgrade continue to pass

Closes #960
