### PR TITLE
fix(model): parse model specs with multiple slashes and colons correctly

### DIFF
--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -250,22 +250,9 @@ func parseProfilePhaseFlag(raw string) (name, phase string, assignment model.Mod
 // parseModelSpec parses a "provider/model" or "provider:model" string into a
 // ModelAssignment. Returns an error if the spec is empty or has no separator.
 func parseModelSpec(spec string) (model.ModelAssignment, error) {
-	// Try slash separator first (common CLI format: anthropic/claude-haiku-3-5),
-	// then colon (opencode internal format: anthropic:claude-haiku-3-5).
-	sep := -1
-	for i, c := range spec {
-		if c == '/' || c == ':' {
-			sep = i
-			break
-		}
-	}
-	if sep <= 0 {
+	providerID, modelID, ok := model.SplitModelSpec(spec)
+	if !ok {
 		return model.ModelAssignment{}, fmt.Errorf("invalid model spec %q: expected provider/model or provider:model", spec)
-	}
-	providerID := spec[:sep]
-	modelID := spec[sep+1:]
-	if providerID == "" || modelID == "" {
-		return model.ModelAssignment{}, fmt.Errorf("invalid model spec %q: provider and model must both be non-empty", spec)
 	}
 	return model.ModelAssignment{ProviderID: providerID, ModelID: modelID}, nil
 }

--- a/internal/components/sdd/profiles.go
+++ b/internal/components/sdd/profiles.go
@@ -238,21 +238,8 @@ func extractModelFromAgent(agentMap map[string]any) model.ModelAssignment {
 		return model.ModelAssignment{}
 	}
 
-	// Find the first separator (either "/" or ":") to split provider from model.
-	// This handles specs like "openrouter/qwen/qwen3.6-plus:free" correctly.
-	idx := -1
-	for i := 0; i < len(modelStr); i++ {
-		if modelStr[i] == '/' || modelStr[i] == ':' {
-			idx = i
-			break
-		}
-	}
-	if idx <= 0 {
-		return model.ModelAssignment{}
-	}
-	providerID := modelStr[:idx]
-	modelID := modelStr[idx+1:]
-	if modelID == "" {
+	providerID, modelID, ok := model.SplitModelSpec(modelStr)
+	if !ok {
 		return model.ModelAssignment{}
 	}
 	effort, _ := agentMap["variant"].(string)

--- a/internal/components/sdd/profiles.go
+++ b/internal/components/sdd/profiles.go
@@ -238,10 +238,14 @@ func extractModelFromAgent(agentMap map[string]any) model.ModelAssignment {
 		return model.ModelAssignment{}
 	}
 
-	// Try colon separator first (standard: "anthropic:claude-sonnet-4"), then slash.
-	idx := strings.Index(modelStr, ":")
-	if idx <= 0 {
-		idx = strings.Index(modelStr, "/")
+	// Find the first separator (either "/" or ":") to split provider from model.
+	// This handles specs like "openrouter/qwen/qwen3.6-plus:free" correctly.
+	idx := -1
+	for i := 0; i < len(modelStr); i++ {
+		if modelStr[i] == '/' || modelStr[i] == ':' {
+			idx = i
+			break
+		}
 	}
 	if idx <= 0 {
 		return model.ModelAssignment{}

--- a/internal/components/sdd/profiles_test.go
+++ b/internal/components/sdd/profiles_test.go
@@ -1027,6 +1027,23 @@ func TestExtractModelFromAgent_NoVariantDefaultsEmpty(t *testing.T) {
 	}
 }
 
+// TestExtractModelFromAgent_OpenRouterFreeModel verifies that extractModelFromAgent
+// correctly parses OpenRouter free-model specs like "openrouter/qwen/qwen3.6-plus:free".
+// The first separator is "/" (not ":"), so the provider should be "openrouter" and
+// the model should be "qwen/qwen3.6-plus:free".
+func TestExtractModelFromAgent_OpenRouterFreeModel(t *testing.T) {
+	agentMap := map[string]any{
+		"model": "openrouter/qwen/qwen3.6-plus:free",
+	}
+	got := extractModelFromAgent(agentMap)
+	if got.ProviderID != "openrouter" {
+		t.Errorf("extractModelFromAgent ProviderID = %q, want %q", got.ProviderID, "openrouter")
+	}
+	if got.ModelID != "qwen/qwen3.6-plus:free" {
+		t.Errorf("extractModelFromAgent ModelID = %q, want %q", got.ModelID, "qwen/qwen3.6-plus:free")
+	}
+}
+
 // TestGenerateProfileOverlay_VariantInjected verifies that a profile
 // phase assignment with Effort="medium" results in "variant":"medium"
 // in the generated overlay JSON.

--- a/internal/components/sdd/profiles_test.go
+++ b/internal/components/sdd/profiles_test.go
@@ -1044,6 +1044,53 @@ func TestExtractModelFromAgent_OpenRouterFreeModel(t *testing.T) {
 	}
 }
 
+// TestDetectProfiles_OpenRouterFreeModel verifies that DetectProfiles
+// correctly parses OpenRouter free-model specs when detecting profiles.
+func TestDetectProfiles_OpenRouterFreeModel(t *testing.T) {
+	dir := t.TempDir()
+	settingsPath := filepath.Join(dir, "opencode.json")
+
+	content := `{
+  "agent": {
+    "sdd-orchestrator-openr": { "mode": "primary", "model": "openrouter/qwen/qwen3.6-plus:free" },
+    "sdd-apply-openr": { "mode": "subagent", "model": "openrouter/qwen/qwen3.6-plus:free" }
+  }
+}`
+	if err := os.WriteFile(settingsPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write settings: %v", err)
+	}
+
+	profiles, err := DetectProfiles(settingsPath)
+	if err != nil {
+		t.Fatalf("DetectProfiles() error = %v", err)
+	}
+	if len(profiles) != 1 {
+		t.Fatalf("DetectProfiles() returned %d profiles, want 1", len(profiles))
+	}
+
+	p := profiles[0]
+	if p.Name != "openr" {
+		t.Errorf("Profile.Name = %q, want %q", p.Name, "openr")
+	}
+	if p.OrchestratorModel.ProviderID != "openrouter" {
+		t.Errorf("OrchestratorModel.ProviderID = %q, want %q", p.OrchestratorModel.ProviderID, "openrouter")
+	}
+	if p.OrchestratorModel.ModelID != "qwen/qwen3.6-plus:free" {
+		t.Errorf("OrchestratorModel.ModelID = %q, want %q", p.OrchestratorModel.ModelID, "qwen/qwen3.6-plus:free")
+	}
+
+	m, ok := p.PhaseAssignments["sdd-apply"]
+	if !ok {
+		t.Fatal("sdd-apply missing from PhaseAssignments")
+	}
+	if m.ProviderID != "openrouter" {
+		t.Errorf("PhaseAssignments[sdd-apply] ProviderID = %q, want %q", m.ProviderID, "openrouter")
+	}
+	if m.ModelID != "qwen/qwen3.6-plus:free" {
+		t.Errorf("PhaseAssignments[sdd-apply] ModelID = %q, want %q", m.ModelID, "qwen/qwen3.6-plus:free")
+	}
+}
+
 // TestGenerateProfileOverlay_VariantInjected verifies that a profile
 // phase assignment with Effort="medium" results in "variant":"medium"
 // in the generated overlay JSON.

--- a/internal/components/sdd/read_assignments.go
+++ b/internal/components/sdd/read_assignments.go
@@ -78,24 +78,8 @@ func ReadCurrentModelAssignments(settingsPath string) (map[string]model.ModelAss
 		if !ok || modelStr == "" {
 			continue
 		}
-		// Find the first separator (either '/' or ':') to correctly parse
-		// model specs like "openrouter/qwen/qwen3.6-plus:free" where the
-		// provider is before the first slash, not before the colon.
-		// Issue #802: colon-first parsing broke OpenRouter free-model specs.
-		sep := -1
-		for i, c := range modelStr {
-			if c == '/' || c == ':' {
-				sep = i
-				break
-			}
-		}
-		if sep <= 0 {
-			// No separator or separator is the first character — skip malformed value.
-			continue
-		}
-		providerID := modelStr[:sep]
-		modelID := modelStr[sep+1:]
-		if modelID == "" {
+		providerID, modelID, ok := model.SplitModelSpec(modelStr)
+		if !ok {
 			continue
 		}
 		assignmentKey := name

--- a/internal/components/sdd/read_assignments.go
+++ b/internal/components/sdd/read_assignments.go
@@ -3,7 +3,6 @@ package sdd
 import (
 	"encoding/json"
 	"os"
-	"strings"
 
 	"github.com/gentleman-programming/gentle-ai/internal/model"
 	"github.com/gentleman-programming/gentle-ai/internal/opencode"
@@ -79,18 +78,23 @@ func ReadCurrentModelAssignments(settingsPath string) (map[string]model.ModelAss
 		if !ok || modelStr == "" {
 			continue
 		}
-		// Try colon first (standard: "anthropic:claude-sonnet-4"), then slash
-		// ("zai-coding-plan/glm-5-turbo") for custom providers (issue #152).
-		idx := strings.Index(modelStr, ":")
-		if idx <= 0 {
-			idx = strings.Index(modelStr, "/")
+		// Find the first separator (either '/' or ':') to correctly parse
+		// model specs like "openrouter/qwen/qwen3.6-plus:free" where the
+		// provider is before the first slash, not before the colon.
+		// Issue #802: colon-first parsing broke OpenRouter free-model specs.
+		sep := -1
+		for i, c := range modelStr {
+			if c == '/' || c == ':' {
+				sep = i
+				break
+			}
 		}
-		if idx <= 0 {
+		if sep <= 0 {
 			// No separator or separator is the first character — skip malformed value.
 			continue
 		}
-		providerID := modelStr[:idx]
-		modelID := modelStr[idx+1:]
+		providerID := modelStr[:sep]
+		modelID := modelStr[sep+1:]
 		if modelID == "" {
 			continue
 		}

--- a/internal/components/sdd/read_assignments_test.go
+++ b/internal/components/sdd/read_assignments_test.go
@@ -215,6 +215,40 @@ func TestReadCurrentModelAssignmentsSlashSeparator(t *testing.T) {
 	}
 }
 
+// TestReadCurrentModelAssignmentsOpenRouterFreeModel verifies that model specs
+// with multiple slashes and a colon (like "openrouter/qwen/qwen3.6-plus:free")
+// are parsed correctly. The provider is everything before the FIRST separator
+// (slash or colon), not before the colon. Issue #802.
+func TestReadCurrentModelAssignmentsOpenRouterFreeModel(t *testing.T) {
+	dir := t.TempDir()
+	settingsPath := filepath.Join(dir, "opencode.json")
+
+	content := `{
+  "agent": {
+    "sdd-apply": { "model": "openrouter/qwen/qwen3.6-plus:free" }
+  }
+}`
+	if err := os.WriteFile(settingsPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write settings: %v", err)
+	}
+
+	got, err := ReadCurrentModelAssignments(settingsPath)
+	if err != nil {
+		t.Fatalf("ReadCurrentModelAssignments() error = %v", err)
+	}
+
+	a, ok := got["sdd-apply"]
+	if !ok {
+		t.Fatal("sdd-apply missing from result — OpenRouter free-model format not parsed")
+	}
+	if a.ProviderID != "openrouter" {
+		t.Errorf("ProviderID = %q, want %q", a.ProviderID, "openrouter")
+	}
+	if a.ModelID != "qwen/qwen3.6-plus:free" {
+		t.Errorf("ModelID = %q, want %q", a.ModelID, "qwen/qwen3.6-plus:free")
+	}
+}
+
 // TestReadCurrentModelAssignmentsReadsVariant verifies that the
 // variant field in an agent definition is populated on the returned
 // ModelAssignment.Effort.

--- a/internal/model/model_assignment.go
+++ b/internal/model/model_assignment.go
@@ -10,6 +10,20 @@ type ModelAssignment struct {
 	Effort     string // "" = provider default; "low" | "medium" | "high"
 }
 
+// SplitModelSpec splits a provider-qualified model spec at its first separator.
+func SplitModelSpec(spec string) (providerID, modelID string, ok bool) {
+	for i := 0; i < len(spec); i++ {
+		if spec[i] != '/' && spec[i] != ':' {
+			continue
+		}
+		if i == 0 || i == len(spec)-1 {
+			return "", "", false
+		}
+		return spec[:i], spec[i+1:], true
+	}
+	return "", "", false
+}
+
 // FullID returns the provider-qualified model identifier (e.g., "anthropic/claude-sonnet-4-20250514").
 func (m ModelAssignment) FullID() string {
 	return m.ProviderID + "/" + m.ModelID

--- a/internal/model/model_assignment_test.go
+++ b/internal/model/model_assignment_test.go
@@ -20,3 +20,29 @@ func TestModelAssignment_FullIDUnaffectedByEffort(t *testing.T) {
 		t.Errorf("FullID() = %q, want %q", a.FullID(), want)
 	}
 }
+
+func TestSplitModelSpec(t *testing.T) {
+	tests := []struct {
+		name         string
+		spec         string
+		wantProvider string
+		wantModel    string
+		wantOK       bool
+	}{
+		{name: "slash separator", spec: "anthropic/claude-sonnet-4", wantProvider: "anthropic", wantModel: "claude-sonnet-4", wantOK: true},
+		{name: "colon separator", spec: "anthropic:claude-sonnet-4", wantProvider: "anthropic", wantModel: "claude-sonnet-4", wantOK: true},
+		{name: "first separator wins", spec: "openrouter/qwen/qwen3.6-plus:free", wantProvider: "openrouter", wantModel: "qwen/qwen3.6-plus:free", wantOK: true},
+		{name: "missing separator", spec: "claude-sonnet-4"},
+		{name: "empty provider", spec: "/claude-sonnet-4"},
+		{name: "empty model", spec: "anthropic/"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider, modelID, ok := SplitModelSpec(tt.spec)
+			if provider != tt.wantProvider || modelID != tt.wantModel || ok != tt.wantOK {
+				t.Fatalf("SplitModelSpec(%q) = (%q, %q, %v), want (%q, %q, %v)", tt.spec, provider, modelID, ok, tt.wantProvider, tt.wantModel, tt.wantOK)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes model spec parsing in \ReadCurrentModelAssignments\ to correctly handle specs with multiple slashes and colons like \openrouter/qwen/qwen3.6-plus:free\.

## Problem

The read-path parser was splitting on the first colon before checking for slashes. This broke model specs where the provider is before the first slash, not before the colon.

For example, \openrouter/qwen/qwen3.6-plus:free\ was incorrectly parsed as:
- ProviderID: \openrouter/qwen/qwen3.6-plus\
- ModelID: \ree\

When it should be:
- ProviderID: \openrouter\
- ModelID: \qwen/qwen3.6-plus:free\

## Solution

Changed the parsing logic to find the **first separator** (either \/\ or \:\) instead of preferring colon-first. This aligns with the write-path parser in \parseModelSpec\ (sync.go) which already handles this correctly.

## Changes

- Modified \internal/components/sdd/read_assignments.go\ to iterate through the string and find the first \/\ or \:\ character
- Removed unused \strings\ import
- Added test \TestReadCurrentModelAssignmentsOpenRouterFreeModel\ to verify OpenRouter free-model specs are parsed correctly

## Testing

All existing tests pass, including:
- Colon-separated specs: \nthropic:claude-sonnet-4-20250514\
- Slash-separated specs: \zai-coding-plan/glm-5-turbo\
- Mixed separators in the same file
- New test for OpenRouter free-model specs: \openrouter/qwen/qwen3.6-plus:free\

Fixes #802

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing to split at the first separator (`/` or `:`) for model strings with multiple separators.
  * Now skips malformed assignment/model entries with missing or leading separators instead of attempting to process them.
  * Enhanced support for OpenRouter-style “free” model names in profile and assignment detection.
* **Tests**
  * Added unit tests covering OpenRouter free-model parsing for both model extraction and current assignment reading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->