### PR TITLE
fix(installer): make engram stop script exit 0 on clean Windows install

### DIFF
--- a/internal/components/engram/download.go
+++ b/internal/components/engram/download.go
@@ -605,6 +605,7 @@ if ($procs) {
         Write-Output "WARNING: $($remaining.Count) engram process(es) could not be stopped (access denied or still running). The upgrade may fail if the file is still locked."
     }
 }
+exit 0
 `
 }
 

--- a/internal/components/engram/download_test.go
+++ b/internal/components/engram/download_test.go
@@ -1280,4 +1280,10 @@ func TestEngramStopScriptIsDefensive(t *testing.T) {
 	if strings.Contains(script, "Stop-Process -Force -ErrorAction Stop") {
 		t.Errorf("stop script must not use -ErrorAction Stop on Stop-Process (reintroduces issue #815/#850)\nscript:\n%s", script)
 	}
+
+	// The clean/no-process path must report success explicitly, regardless of any
+	// PowerShell status left behind by defensive no-op commands.
+	if !strings.HasSuffix(strings.TrimSpace(script), "exit 0") {
+		t.Errorf("stop script must explicitly exit 0 on the clean/no-process path\nscript:\n%s", script)
+	}
 }


### PR DESCRIPTION
## Summary

Fixes #815.

On a **clean Windows install** (no `engram` process running), `gentle-ai install`
aborts before configuring any agent:

```
Error: execute install pipeline: download engram binary:
stop running engram processes before upgrade:
powershell Stop-Process engram: exit status 1 (output: )
```

Because `engram` is auto-added as a dependency of every agent install, this
blocks the installer entirely on Windows — even `--components skills` pulls it in.

## Root cause

`engramStopScript()` (in `internal/components/engram/download.go`) begins with:

```powershell
$procs = Get-Process -Name engram -ErrorAction SilentlyContinue
if ($procs) { ... }
```

On **Windows PowerShell 5.1**, when no process matches, the *suppressed* error
still sets `$?` to `$false`. The `if ($procs)` guard is skipped and does **not**
reset `$?`, so the script's final automatic status is failure and
`powershell.exe -NoProfile -NonInteractive -Command <script>` exits `1` with empty
output. `stopEngramProcesses()` treats any non-zero exit as fatal and aborts the
whole pipeline.

This is the same clean-install regression class as #815 / #919. Those fixes added
the `if ($procs)` pipeline guard, but the **trailing exit code** still leaks on a
clean no-op.

### Minimal reproduction (Windows PowerShell 5.1)

```powershell
powershell.exe -NoProfile -NonInteractive -Command '$procs = Get-Process -Name engram -ErrorAction SilentlyContinue; if ($procs) { $procs | Stop-Process -Force -ErrorAction SilentlyContinue }'
echo $LASTEXITCODE   # => 1  (no engram running)
```

## Fix

Append `exit 0` to the script. The stop step is best-effort — every call already
uses `-ErrorAction SilentlyContinue`, and the `WARNING:` surfacing path (parsed
from stdout by `stopEngramProcesses`) is unchanged — so forcing a success exit on
a clean no-op is correct.

```powershell
powershell.exe -NoProfile -NonInteractive -Command '$procs = Get-Process -Name engram -ErrorAction SilentlyContinue; if ($procs) { $procs | Stop-Process -Force -ErrorAction SilentlyContinue }; exit 0'
echo $LASTEXITCODE   # => 0
```

## Verification

Built from this branch on **Windows 11 / PowerShell 5.1** and ran
`gentle-ai install --agents claude-code --scope global` — install now completes
with **65/65** verification checks passing (engram, gga, SDD, skills, theme).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stop script reliability on Windows by ensuring it explicitly exits successfully (`exit 0`) along the no-process path, preventing false failure outcomes.
* **Tests**
  * Strengthened coverage to assert the generated PowerShell stop script ends with `exit 0` when no running processes are found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->