### PR TITLE
fix(install): repair Windows engram path shadowing

### DIFF
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -55,6 +55,12 @@ var (
 	cmdLookPath         = exec.LookPath
 	streamCommandOutput = true
 	goEnv               = defaultGoEnv
+	pathEnvEntries      = func(profile system.PlatformProfile) []string {
+		return splitPathForOS(os.Getenv("PATH"), profile.OS)
+	}
+	addUserPath         = system.AddToUserPath
+	ensureUserPathFirst = system.PrioritizeUserPath
+	userPathEntries     = system.UserPathEntries
 
 	// ggaAvailableCheck is an optional override for ggaAvailable behavior.
 	// When set, it is called instead of the default filesystem check.
@@ -682,6 +688,74 @@ func resolveAdapters(agentIDs []model.AgentID) []agents.Adapter {
 	return adapters
 }
 
+func shouldRefreshWindowsEngram(profile system.PlatformProfile, resolvedPath string, pathEntries []string) bool {
+	if profile.OS != "windows" || profile.PackageManager == "brew" || strings.TrimSpace(resolvedPath) == "" {
+		return false
+	}
+	return len(engramBinaryDirsOnPath(pathEntries, profile.OS)) > 1
+}
+
+func ensureRepairableWindowsEngramShadowing(profile system.PlatformProfile, installedPath, managedDir string) error {
+	userEntries, err := userPathEntries(profile.OS)
+	if err != nil {
+		return fmt.Errorf("read user PATH: %w", err)
+	}
+
+	staleDir := filepath.Dir(installedPath)
+	if !pathEntriesContainDir(userEntries, staleDir) {
+		return fmt.Errorf("%s is not in the user PATH, so user-scoped PATH repair cannot guarantee future shells will resolve %s before %s", staleDir, managedDir, staleDir)
+	}
+
+	return nil
+}
+
+func pathEntriesContainDir(entries []string, dir string) bool {
+	dir = strings.Trim(strings.TrimSpace(dir), `"`)
+	if dir == "" {
+		return false
+	}
+	for _, entry := range entries {
+		entry = strings.Trim(strings.TrimSpace(entry), `"`)
+		if entry == "" {
+			continue
+		}
+		if strings.EqualFold(filepath.Clean(entry), filepath.Clean(dir)) {
+			return true
+		}
+	}
+	return false
+}
+
+func engramBinaryDirsOnPath(pathEntries []string, goos string) []string {
+	var dirs []string
+	for _, entry := range pathEntries {
+		entry = strings.Trim(strings.TrimSpace(entry), `"`)
+		if entry == "" {
+			continue
+		}
+		binaryName := "engram"
+		if goos == "windows" {
+			binaryName = "engram.exe"
+		}
+		candidate := filepath.Join(entry, binaryName)
+		if _, err := os.Stat(candidate); err == nil {
+			dirs = append(dirs, entry)
+		}
+	}
+	return dirs
+}
+
+func splitPathForOS(value, goos string) []string {
+	separator := string(os.PathListSeparator)
+	if goos == "windows" {
+		separator = ";"
+	}
+	if value == "" {
+		return nil
+	}
+	return strings.Split(value, separator)
+}
+
 func (s componentApplyStep) Run() error {
 	adapters := resolveAdapters(s.agents)
 
@@ -694,7 +768,7 @@ func (s componentApplyStep) Run() error {
 				return fmt.Errorf("install beta engram from main: %w", err)
 			}
 			engramCommand = binaryPath
-		} else if _, err := cmdLookPath("engram"); err != nil {
+		} else if installedPath, err := cmdLookPath("engram"); err != nil {
 			// Engram not on PATH — install it.
 			if s.profile.PackageManager == "brew" {
 				// macOS (or Linux with Homebrew): use brew tap + brew install.
@@ -716,11 +790,25 @@ func (s componentApplyStep) Run() error {
 				// (engram setup, engram.Inject → resolveEngramCommand) can find it.
 				// On Windows this also persists the change to the user registry via PowerShell.
 				binDir := filepath.Dir(binaryPath)
-				if err := system.AddToUserPath(binDir); err != nil {
+				if err := addUserPath(binDir); err != nil {
 					// Non-fatal: warn but continue — the binary was downloaded successfully.
 					fmt.Fprintf(os.Stderr, "WARNING: could not add %s to PATH: %v\n", binDir, err)
 				}
 			}
+		} else if shouldRefreshWindowsEngram(s.profile, installedPath, pathEnvEntries(s.profile)) {
+			binaryPath, err := engramDownloadFn(s.profile)
+			if err != nil {
+				return fmt.Errorf("refresh shadowed engram binary: %w", err)
+			}
+			engramCommand = binaryPath
+			binDir := filepath.Dir(binaryPath)
+			if err := ensureRepairableWindowsEngramShadowing(s.profile, installedPath, binDir); err != nil {
+				return fmt.Errorf("repair Windows Engram PATH shadowing: refreshed managed Engram at %s, but cannot safely repair PATH order: %w. Move %s before %s in your user PATH or remove the stale Machine/System PATH entry, then rerun install", binaryPath, err, binDir, filepath.Dir(installedPath))
+			}
+			if err := ensureUserPathFirst(binDir); err != nil {
+				return fmt.Errorf("repair Windows Engram PATH shadowing: refreshed managed Engram at %s, but could not move %s ahead of stale PATH entry %s: %w. Move %s before %s in your user PATH, then rerun install", binaryPath, binDir, installedPath, err, binDir, filepath.Dir(installedPath))
+			}
+			fmt.Fprintf(os.Stderr, "WARNING: multiple engram.exe entries were found on PATH and %s resolved first. Refreshed managed Engram at %s and moved %s ahead of the stale entry in the user PATH.\n", installedPath, binaryPath, binDir)
 		}
 		setupMode := engram.ParseSetupMode(os.Getenv(engram.SetupModeEnvVar))
 		setupStrict := engram.ParseSetupStrict(os.Getenv(engram.SetupStrictEnvVar))
@@ -839,7 +927,7 @@ func (s componentApplyStep) Run() error {
 			// Add GGA bin dir to the user PATH persistently on Windows.
 			// GGA's install.sh drops the binary into ~/bin which is not on PATH by default.
 			ggaBinDir := filepath.Join(s.homeDir, "bin")
-			if err := system.AddToUserPath(ggaBinDir); err != nil {
+			if err := addUserPath(ggaBinDir); err != nil {
 				// Non-fatal: warn but continue — GGA was installed successfully.
 				fmt.Fprintf(os.Stderr, "WARNING: could not add %s to PATH: %v\n", ggaBinDir, err)
 			}

--- a/internal/cli/run_engram_download_test.go
+++ b/internal/cli/run_engram_download_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/gentleman-programming/gentle-ai/internal/components/engram"
+	"github.com/gentleman-programming/gentle-ai/internal/model"
 	"github.com/gentleman-programming/gentle-ai/internal/system"
 )
 
@@ -110,20 +111,29 @@ func TestRunInstallWindowsEngramUsesDownloadNotGoInstall(t *testing.T) {
 	restoreHome := osUserHomeDir
 	restoreCommand := runCommand
 	restoreLookPath := cmdLookPath
+	restoreAddUserPath := addUserPath
 	t.Cleanup(func() {
 		osUserHomeDir = restoreHome
 		runCommand = restoreCommand
 		cmdLookPath = restoreLookPath
+		addUserPath = restoreAddUserPath
 	})
 
 	osUserHomeDir = func() (string, error) { return home, nil }
 	cmdLookPath = missingBinaryLookPath
 	recorder := &commandRecorder{}
 	runCommand = recorder.record
+	fakeBinDir := filepath.Join(home, "engram-bin")
+	fakeBinaryPath := filepath.Join(fakeBinDir, "engram.exe")
+	var addedPath string
+	addUserPath = func(dir string) error {
+		addedPath = dir
+		return nil
+	}
 
 	origDownloadFn := engramDownloadFn
 	engramDownloadFn = func(profile system.PlatformProfile) (string, error) {
-		return `C:\fake\engram.exe`, nil
+		return fakeBinaryPath, nil
 	}
 	t.Cleanup(func() { engramDownloadFn = origDownloadFn })
 
@@ -151,12 +161,290 @@ func TestRunInstallWindowsEngramUsesDownloadNotGoInstall(t *testing.T) {
 	if !result.Verify.Ready {
 		t.Fatalf("verification ready = false, report = %#v", result.Verify)
 	}
+	if addedPath != fakeBinDir {
+		t.Fatalf("Windows engram install should request adding downloaded binary dir to PATH, got %q", addedPath)
+	}
 
 	// Must NOT have called "go install" for engram.
 	for _, cmd := range recorder.get() {
 		if strings.Contains(cmd, "go install") && strings.Contains(cmd, "engram") {
 			t.Fatalf("Windows engram install should NOT use go install, got command: %s", cmd)
 		}
+	}
+}
+
+func TestRunInstallWindowsRefreshesEngramWhenDuplicatePathEntriesShadowManagedBinary(t *testing.T) {
+	home := t.TempDir()
+	staleDir := filepath.Join(home, "stale")
+	managedDir := filepath.Join(home, "managed")
+	if err := os.MkdirAll(staleDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(staleDir) error = %v", err)
+	}
+	if err := os.MkdirAll(managedDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(managedDir) error = %v", err)
+	}
+	staleBinary := filepath.Join(staleDir, "engram.exe")
+	managedBinary := filepath.Join(managedDir, "engram.exe")
+	if err := os.WriteFile(staleBinary, []byte("stale"), 0o755); err != nil {
+		t.Fatalf("WriteFile(staleBinary) error = %v", err)
+	}
+	if err := os.WriteFile(managedBinary, []byte("managed"), 0o755); err != nil {
+		t.Fatalf("WriteFile(managedBinary) error = %v", err)
+	}
+
+	restoreHome := osUserHomeDir
+	restoreCommand := runCommand
+	restoreLookPath := cmdLookPath
+	restorePathEntries := pathEnvEntries
+	restoreEnsureUserPathFirst := ensureUserPathFirst
+	restoreUserPathEntries := userPathEntries
+	restorePath := os.Getenv("PATH")
+	t.Cleanup(func() {
+		osUserHomeDir = restoreHome
+		runCommand = restoreCommand
+		cmdLookPath = restoreLookPath
+		pathEnvEntries = restorePathEntries
+		ensureUserPathFirst = restoreEnsureUserPathFirst
+		userPathEntries = restoreUserPathEntries
+		os.Setenv("PATH", restorePath)
+	})
+
+	osUserHomeDir = func() (string, error) { return home, nil }
+	cmdLookPath = func(name string) (string, error) {
+		if name == "engram" {
+			return staleBinary, nil
+		}
+		return missingBinaryLookPath(name)
+	}
+	pathEnvEntries = func(profile system.PlatformProfile) []string {
+		return []string{staleDir, managedDir}
+	}
+	userPathEntries = func(goos string) ([]string, error) {
+		return []string{staleDir, managedDir}, nil
+	}
+	recorder := &commandRecorder{}
+	runCommand = recorder.record
+	var repairedPath string
+	ensureUserPathFirst = func(dir string) error {
+		repairedPath = dir
+		return os.Setenv("PATH", dir+";"+staleDir)
+	}
+
+	downloadCalled := false
+	origDownloadFn := engramDownloadFn
+	engramDownloadFn = func(profile system.PlatformProfile) (string, error) {
+		downloadCalled = true
+		return managedBinary, nil
+	}
+	t.Cleanup(func() { engramDownloadFn = origDownloadFn })
+
+	step := componentApplyStep{
+		component: model.ComponentEngram,
+		homeDir:   home,
+		agents:    []model.AgentID{model.AgentOpenCode},
+		profile: system.PlatformProfile{
+			OS:             "windows",
+			PackageManager: "winget",
+			Supported:      true,
+		},
+	}
+
+	err := step.Run()
+	if err != nil {
+		t.Fatalf("RunInstall() error = %v", err)
+	}
+	if !downloadCalled {
+		t.Fatal("engramDownloadFn was not called for shadowed duplicate Windows PATH entries")
+	}
+	if repairedPath != managedDir {
+		t.Fatalf("persistent user PATH repair should prioritize managed dir %q, got %q", managedDir, repairedPath)
+	}
+	if gotPath := os.Getenv("PATH"); !strings.HasPrefix(gotPath, managedDir+";") {
+		t.Fatalf("PATH should prioritize managed engram for current install, got %q", gotPath)
+	}
+	commands := recorder.get()
+	foundSetupWithManagedBinary := false
+	for _, cmd := range commands {
+		if strings.HasPrefix(cmd, managedBinary+" setup ") {
+			foundSetupWithManagedBinary = true
+		}
+		if strings.HasPrefix(cmd, "engram setup ") || strings.HasPrefix(cmd, staleBinary+" setup ") {
+			t.Fatalf("engram setup should use refreshed managed binary %q, got commands: %v", managedBinary, commands)
+		}
+	}
+	if !foundSetupWithManagedBinary {
+		t.Fatalf("expected engram setup to use refreshed managed binary %q, got commands: %v", managedBinary, commands)
+	}
+}
+
+func TestRunInstallWindowsFailsWhenShadowedEngramPathCannotBePersistentlyRepaired(t *testing.T) {
+	home := t.TempDir()
+	staleDir := filepath.Join(home, "stale")
+	managedDir := filepath.Join(home, "managed")
+	if err := os.MkdirAll(staleDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(staleDir) error = %v", err)
+	}
+	if err := os.MkdirAll(managedDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(managedDir) error = %v", err)
+	}
+	staleBinary := filepath.Join(staleDir, "engram.exe")
+	managedBinary := filepath.Join(managedDir, "engram.exe")
+	if err := os.WriteFile(staleBinary, []byte("stale"), 0o755); err != nil {
+		t.Fatalf("WriteFile(staleBinary) error = %v", err)
+	}
+	if err := os.WriteFile(managedBinary, []byte("managed"), 0o755); err != nil {
+		t.Fatalf("WriteFile(managedBinary) error = %v", err)
+	}
+
+	restoreHome := osUserHomeDir
+	restoreCommand := runCommand
+	restoreLookPath := cmdLookPath
+	restorePathEntries := pathEnvEntries
+	restoreEnsureUserPathFirst := ensureUserPathFirst
+	restoreUserPathEntries := userPathEntries
+	t.Cleanup(func() {
+		osUserHomeDir = restoreHome
+		runCommand = restoreCommand
+		cmdLookPath = restoreLookPath
+		pathEnvEntries = restorePathEntries
+		ensureUserPathFirst = restoreEnsureUserPathFirst
+		userPathEntries = restoreUserPathEntries
+	})
+
+	osUserHomeDir = func() (string, error) { return home, nil }
+	cmdLookPath = func(name string) (string, error) {
+		if name == "engram" {
+			return staleBinary, nil
+		}
+		return missingBinaryLookPath(name)
+	}
+	pathEnvEntries = func(profile system.PlatformProfile) []string {
+		return []string{staleDir, managedDir}
+	}
+	userPathEntries = func(goos string) ([]string, error) {
+		return []string{staleDir, managedDir}, nil
+	}
+	recorder := &commandRecorder{}
+	runCommand = recorder.record
+	ensureUserPathFirst = func(dir string) error {
+		return os.ErrPermission
+	}
+
+	origDownloadFn := engramDownloadFn
+	engramDownloadFn = func(profile system.PlatformProfile) (string, error) {
+		return managedBinary, nil
+	}
+	t.Cleanup(func() { engramDownloadFn = origDownloadFn })
+
+	step := componentApplyStep{
+		component: model.ComponentEngram,
+		homeDir:   home,
+		agents:    []model.AgentID{model.AgentOpenCode},
+		profile: system.PlatformProfile{
+			OS:             "windows",
+			PackageManager: "winget",
+			Supported:      true,
+		},
+	}
+
+	err := step.Run()
+	if err == nil {
+		t.Fatal("componentApplyStep.Run() should fail when shadowed Engram PATH cannot be persistently repaired")
+	}
+	errText := err.Error()
+	for _, want := range []string{"repair Windows Engram PATH shadowing", "Move", managedDir, staleDir, "rerun install"} {
+		if !strings.Contains(errText, want) {
+			t.Fatalf("error %q missing actionable text %q", errText, want)
+		}
+	}
+	if commands := recorder.get(); len(commands) != 0 {
+		t.Fatalf("engram setup should not run after persistent PATH repair fails, got commands: %v", commands)
+	}
+}
+
+func TestRunInstallWindowsFailsWhenShadowedEngramPathIsNotInUserPath(t *testing.T) {
+	home := t.TempDir()
+	staleMachineDir := filepath.Join(home, "machine-stale")
+	managedDir := filepath.Join(home, "managed")
+	if err := os.MkdirAll(staleMachineDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(staleMachineDir) error = %v", err)
+	}
+	if err := os.MkdirAll(managedDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(managedDir) error = %v", err)
+	}
+	staleBinary := filepath.Join(staleMachineDir, "engram.exe")
+	managedBinary := filepath.Join(managedDir, "engram.exe")
+	if err := os.WriteFile(staleBinary, []byte("stale"), 0o755); err != nil {
+		t.Fatalf("WriteFile(staleBinary) error = %v", err)
+	}
+	if err := os.WriteFile(managedBinary, []byte("managed"), 0o755); err != nil {
+		t.Fatalf("WriteFile(managedBinary) error = %v", err)
+	}
+
+	restoreHome := osUserHomeDir
+	restoreCommand := runCommand
+	restoreLookPath := cmdLookPath
+	restorePathEntries := pathEnvEntries
+	restoreEnsureUserPathFirst := ensureUserPathFirst
+	restoreUserPathEntries := userPathEntries
+	t.Cleanup(func() {
+		osUserHomeDir = restoreHome
+		runCommand = restoreCommand
+		cmdLookPath = restoreLookPath
+		pathEnvEntries = restorePathEntries
+		ensureUserPathFirst = restoreEnsureUserPathFirst
+		userPathEntries = restoreUserPathEntries
+	})
+
+	osUserHomeDir = func() (string, error) { return home, nil }
+	cmdLookPath = func(name string) (string, error) {
+		if name == "engram" {
+			return staleBinary, nil
+		}
+		return missingBinaryLookPath(name)
+	}
+	pathEnvEntries = func(profile system.PlatformProfile) []string {
+		return []string{staleMachineDir, managedDir}
+	}
+	userPathEntries = func(goos string) ([]string, error) {
+		return []string{managedDir}, nil
+	}
+	recorder := &commandRecorder{}
+	runCommand = recorder.record
+	ensureUserPathFirst = func(dir string) error {
+		t.Fatal("ensureUserPathFirst should not run when stale entry is outside user PATH")
+		return nil
+	}
+
+	origDownloadFn := engramDownloadFn
+	engramDownloadFn = func(profile system.PlatformProfile) (string, error) {
+		return managedBinary, nil
+	}
+	t.Cleanup(func() { engramDownloadFn = origDownloadFn })
+
+	step := componentApplyStep{
+		component: model.ComponentEngram,
+		homeDir:   home,
+		agents:    []model.AgentID{model.AgentOpenCode},
+		profile: system.PlatformProfile{
+			OS:             "windows",
+			PackageManager: "winget",
+			Supported:      true,
+		},
+	}
+
+	err := step.Run()
+	if err == nil {
+		t.Fatal("componentApplyStep.Run() should fail when the stale Engram path is not in user PATH")
+	}
+	errText := err.Error()
+	for _, want := range []string{"cannot safely repair PATH order", "not in the user PATH", "Machine/System PATH", managedDir, staleMachineDir, "rerun install"} {
+		if !strings.Contains(errText, want) {
+			t.Fatalf("error %q missing actionable text %q", errText, want)
+		}
+	}
+	if commands := recorder.get(); len(commands) != 0 {
+		t.Fatalf("engram setup should not run after unsafe PATH repair detection, got commands: %v", commands)
 	}
 }
 

--- a/internal/components/permissions/inject.go
+++ b/internal/components/permissions/inject.go
@@ -3,11 +3,14 @@ package permissions
 import (
 	"fmt"
 	"os"
+	"runtime"
 
 	"github.com/gentleman-programming/gentle-ai/internal/agents"
 	"github.com/gentleman-programming/gentle-ai/internal/components/filemerge"
 	"github.com/gentleman-programming/gentle-ai/internal/model"
 )
+
+var codexPermissionsGOOS = runtime.GOOS
 
 type InjectionResult struct {
 	Changed bool
@@ -186,14 +189,17 @@ func injectCodexPermissions(homeDir string, adapter agents.Adapter) (InjectionRe
 	merged = filemerge.UpsertTOMLTableKey(merged, "permissions.gentle-dev.network.domains", `"*"`, `"allow"`)
 
 	merged = filemerge.RemoveTOMLTableKeys(merged, `permissions.gentle-dev.filesystem.":root"`, []string{`"."`})
-	for _, path := range []string{
+	readPaths := []string{
 		`":minimal"`,
 		`"~/.config/git"`,
 		`"~/.gitconfig"`,
 		`"~/.local/state/nix/profiles/home-manager/home-path"`,
 		`"~/.nix-profile"`,
-		`"/nix/store"`,
-	} {
+	}
+	if codexPermissionsGOOS != "windows" {
+		readPaths = append(readPaths, `"/nix/store"`)
+	}
+	for _, path := range readPaths {
 		merged = filemerge.UpsertTOMLTableKey(merged, "permissions.gentle-dev.filesystem", path, `"read"`)
 	}
 	for _, path := range []string{

--- a/internal/components/permissions/inject_test.go
+++ b/internal/components/permissions/inject_test.go
@@ -381,6 +381,36 @@ func TestInjectCodexWritesGentleDevPermissionsProfile(t *testing.T) {
 	}
 }
 
+func TestInjectCodexPermissionsSkipsNixStoreOnWindows(t *testing.T) {
+	home := t.TempDir()
+	origGOOS := codexPermissionsGOOS
+	codexPermissionsGOOS = "windows"
+	t.Cleanup(func() { codexPermissionsGOOS = origGOOS })
+
+	if _, err := Inject(home, codexAdapter()); err != nil {
+		t.Fatalf("Inject() error = %v", err)
+	}
+
+	configPath := filepath.Join(home, ".codex", "config.toml")
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config.toml: %v", err)
+	}
+	text := string(content)
+
+	if strings.Contains(text, `"/nix/store"`) {
+		t.Fatalf("Windows Codex config should not include /nix/store; got:\n%s", text)
+	}
+	for _, want := range []string{
+		`"~/.local/state/nix/profiles/home-manager/home-path" = "read"`,
+		`"~/.nix-profile" = "read"`,
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("Windows Codex config missing non-fatal Nix home path %q; got:\n%s", want, text)
+		}
+	}
+}
+
 func TestInjectCodexPermissionsAllowsEnvExamples(t *testing.T) {
 	home := t.TempDir()
 

--- a/internal/system/path.go
+++ b/internal/system/path.go
@@ -53,8 +53,60 @@ func AddToUserPath(dir string) error {
 	return cmd.Run()
 }
 
+// PrioritizeUserPath moves dir to the front of PATH for the current process and,
+// on Windows, the user-scoped persistent PATH. Existing entries are preserved;
+// only exact matches for dir are removed before the refreshed dir is prepended.
+func PrioritizeUserPath(dir string) error {
+	dir = strings.Trim(strings.TrimSpace(dir), `"`)
+	if dir == "" {
+		return nil
+	}
+
+	if err := prioritizeProcessPath(dir); err != nil {
+		return err
+	}
+	if runtime.GOOS != "windows" {
+		return nil
+	}
+
+	safeDir := escapePowerShellString(dir)
+	script := fmt.Sprintf(
+		`$dir = '%s'; `+
+			`$current = [Environment]::GetEnvironmentVariable('PATH', 'User'); `+
+			`$entries = @(); `+
+			`if ($current) { $entries = $current.Split(';') | Where-Object { $_ -and ([string]::Compare($_.Trim('"'), $dir, $true) -ne 0) } }; `+
+			`[Environment]::SetEnvironmentVariable('PATH', ($dir + ';' + ($entries -join ';')).TrimEnd(';'), 'User')`,
+		safeDir,
+	)
+	cmd := exec.Command("powershell", "-NoProfile", "-NonInteractive", "-Command", script)
+	return cmd.Run()
+}
+
+// UserPathEntries returns the persistent user-scoped PATH entries for the given
+// platform. On Windows it reads the User PATH registry-backed environment value;
+// on other platforms it returns the current process PATH entries.
+func UserPathEntries(goos string) ([]string, error) {
+	if goos != "windows" {
+		return filepath.SplitList(os.Getenv("PATH")), nil
+	}
+
+	cmd := exec.Command("powershell", "-NoProfile", "-NonInteractive", "-Command", `[Environment]::GetEnvironmentVariable('PATH', 'User')`)
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+	return splitWindowsPath(strings.TrimSpace(string(output))), nil
+}
+
+func splitWindowsPath(value string) []string {
+	if value == "" {
+		return nil
+	}
+	return strings.Split(value, ";")
+}
+
 // escapePowerShellString escapes a string for safe use inside a PowerShell
-// single-quoted string literal by replacing each ' with '' (PowerShell's escape
+// single-quoted string literal by replacing each ' with ” (PowerShell's escape
 // sequence for a literal single quote within single-quoted strings).
 func escapePowerShellString(s string) string {
 	return strings.ReplaceAll(s, "'", "''")
@@ -76,4 +128,21 @@ func addToProcessPath(dir string) error {
 		return os.Setenv("PATH", dir)
 	}
 	return os.Setenv("PATH", dir+string(os.PathListSeparator)+currentPath)
+}
+
+func prioritizeProcessPath(dir string) error {
+	currentPath := os.Getenv("PATH")
+	if currentPath == "" {
+		return os.Setenv("PATH", dir)
+	}
+
+	entries := []string{dir}
+	for _, entry := range filepath.SplitList(currentPath) {
+		entry = strings.TrimSpace(entry)
+		if entry == "" || strings.EqualFold(filepath.Clean(entry), filepath.Clean(dir)) {
+			continue
+		}
+		entries = append(entries, entry)
+	}
+	return os.Setenv("PATH", strings.Join(entries, string(os.PathListSeparator)))
 }

--- a/internal/system/path_test.go
+++ b/internal/system/path_test.go
@@ -36,9 +36,9 @@ func TestAddToUserPathAlreadyPresent(t *testing.T) {
 	}
 }
 
-// TestAddToUserPathAddsToProcessEnv verifies that on any platform the target
-// directory is added to the current process PATH (os.Setenv part).
-func TestAddToUserPathAddsToProcessEnv(t *testing.T) {
+// TestAddToProcessPathAddsToProcessEnv verifies the process-local PATH update
+// without mutating the persistent user PATH on Windows.
+func TestAddToProcessPathAddsToProcessEnv(t *testing.T) {
 	targetDir := filepath.Join(t.TempDir(), "new-bin-dir")
 	original := os.Getenv("PATH")
 	t.Cleanup(func() { os.Setenv("PATH", original) })
@@ -46,9 +46,9 @@ func TestAddToUserPathAddsToProcessEnv(t *testing.T) {
 	// Ensure target is NOT currently in PATH.
 	os.Setenv("PATH", strings.ReplaceAll(original, targetDir, ""))
 
-	err := AddToUserPath(targetDir)
+	err := addToProcessPath(targetDir)
 	if err != nil {
-		t.Fatalf("AddToUserPath returned unexpected error: %v", err)
+		t.Fatalf("addToProcessPath returned unexpected error: %v", err)
 	}
 
 	// The directory must now be in the process PATH.
@@ -82,5 +82,30 @@ func TestAddToUserPathNoOpOnNonWindows(t *testing.T) {
 	err := AddToUserPath(targetDir)
 	if err != nil {
 		t.Fatalf("AddToUserPath should be a no-op on non-Windows but returned error: %v", err)
+	}
+}
+
+func TestPrioritizeProcessPathMovesExistingEntryToFront(t *testing.T) {
+	firstDir := filepath.Join(t.TempDir(), "first")
+	targetDir := filepath.Join(t.TempDir(), "target")
+	lastDir := filepath.Join(t.TempDir(), "last")
+	original := os.Getenv("PATH")
+	t.Cleanup(func() { os.Setenv("PATH", original) })
+
+	os.Setenv("PATH", strings.Join([]string{firstDir, targetDir, lastDir}, string(os.PathListSeparator)))
+
+	if err := prioritizeProcessPath(targetDir); err != nil {
+		t.Fatalf("prioritizeProcessPath() error = %v", err)
+	}
+
+	entries := filepath.SplitList(os.Getenv("PATH"))
+	if len(entries) != 3 {
+		t.Fatalf("PATH entries = %v, want three preserved entries", entries)
+	}
+	if entries[0] != targetDir {
+		t.Fatalf("PATH first entry = %q, want %q", entries[0], targetDir)
+	}
+	if entries[1] != firstDir || entries[2] != lastDir {
+		t.Fatalf("PATH should preserve non-target order after target move, got %v", entries)
 	}
 }


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #943
Closes #941

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Repairs Windows Engram install behavior when duplicate `engram.exe` entries cause PATH shadowing.
- Skips the fatal Codex `/nix/store` permission rule on Windows.
- Keeps Engram setup pinned to the refreshed managed binary during the install flow.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/cli/run.go` | Detects duplicate Windows Engram PATH entries, refreshes managed Engram, and repairs/fails safely. |
| `internal/cli/run_engram_download_test.go` | Adds regression coverage for shadowed Engram PATH, setup command selection, and no-go-install behavior. |
| `internal/system/path.go` | Adds user PATH prioritization and user PATH entry helpers. |
| `internal/system/path_test.go` | Adds process PATH prioritization coverage without persistent Windows PATH mutation. |
| `internal/components/permissions/inject.go` | Skips `/nix/store` Codex filesystem permission on Windows. |
| `internal/components/permissions/inject_test.go` | Adds Windows regression coverage for Codex config generation. |

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./internal/cli ./internal/components/permissions ./internal/system
go test ./...
```

**E2E Tests** (Docker required)
```bash
cd e2e && ./docker-test.sh
```

- [x] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Manually tested locally via targeted unit coverage and fresh-context review

---

## 🤖 Automated Checks

The following checks run automatically on this PR:

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | PR uses maintainer-approved `size:exception` because this combines two Windows bug fixes with regression tests. |
| Check Issue Reference | ⏳ | PR body contains `Closes #943` and `Closes #941` |
| Check Issue Has `status:approved` | ⏳ | Linked issues are approved |
| Check PR Has `type:*` Label | ⏳ | `type:bug` label applied after creation |
| Unit Tests | ⏳ | `go test ./...` passed locally |
| E2E Tests | ⏳ | Not run locally |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

`size:exception` rationale: this PR is above the 400-line budget because it includes two Windows bug fixes plus behavior-focused regression tests. The changes are still scoped to install PATH handling and Codex permission generation.

For #940, no code change was needed: Gentle AI already uses the correctly cased Engram module path and stable install uses binary downloads rather than `go install`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Windows PATH repair: Automatically detects and repairs shadowed Engram binary entries in system PATH, ensuring the managed installation is prioritized.
  * OS-aware Codex permissions: Removed unnecessary Nix-specific permissions on Windows while maintaining required functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->