### PR TITLE
feat(opencode): load custom providers in model picker

### DIFF
--- a/internal/opencode/models.go
+++ b/internal/opencode/models.go
@@ -425,10 +425,11 @@ func globalConfigPaths(settingsPath string) []string {
 	if !strings.EqualFold(filepath.Base(settingsPath), "opencode.json") {
 		return []string{settingsPath}
 	}
-	if _, err := os.Stat(settingsPath); err == nil || !errors.Is(err, os.ErrNotExist) {
-		return []string{settingsPath}
-	}
-	return []string{settingsPath, filepath.Join(filepath.Dir(settingsPath), "opencode.jsonc")}
+	// Always probe both opencode.json and opencode.jsonc so that a user who
+	// keeps providers in the .jsonc file (e.g. for comments) is not missed.
+	// The .jsonc entry comes last so its values win on merge.
+	jsoncPath := filepath.Join(filepath.Dir(settingsPath), "opencode.jsonc")
+	return []string{settingsPath, jsoncPath}
 }
 
 func projectConfigPaths(cwd string) []string {

--- a/internal/opencode/models.go
+++ b/internal/opencode/models.go
@@ -1,12 +1,14 @@
 package opencode
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 )
 
 // DefaultCachePath returns the default path to the OpenCode models cache file.
@@ -341,17 +343,232 @@ func LoadConfigProviders(path string) (map[string]ConfigProvider, error) {
 		}
 		return map[string]ConfigProvider{}, err
 	}
+	return loadConfigProvidersData(path, data)
+}
 
+func loadConfigProvidersData(source string, data []byte) (map[string]ConfigProvider, error) {
 	var raw struct {
 		Provider map[string]ConfigProvider `json:"provider"`
 	}
+	if source == "OPENCODE_CONFIG_CONTENT" || strings.EqualFold(filepath.Ext(source), ".jsonc") {
+		data = stripJSONC(data)
+	}
 	if err := json.Unmarshal(data, &raw); err != nil {
-		return map[string]ConfigProvider{}, fmt.Errorf("parse opencode settings %q: %w", path, err)
+		return map[string]ConfigProvider{}, fmt.Errorf("parse opencode settings %q: %w", source, err)
 	}
 	if raw.Provider == nil {
 		return map[string]ConfigProvider{}, nil
 	}
 	return raw.Provider, nil
+}
+
+// LoadEffectiveConfigProviders loads custom providers from OpenCode's effective
+// config sources: the global settings path plus project config discovered from
+// the current working directory. Project config overrides global config.
+func LoadEffectiveConfigProviders(settingsPath string) (map[string]ConfigProvider, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		providers, loadErr := LoadConfigProviders(settingsPath)
+		if loadErr != nil {
+			return providers, loadErr
+		}
+		return providers, err
+	}
+	return LoadEffectiveConfigProvidersForDir(settingsPath, cwd)
+}
+
+// LoadEffectiveConfigProvidersForDir is the testable form of
+// LoadEffectiveConfigProviders.
+func LoadEffectiveConfigProvidersForDir(settingsPath, cwd string) (map[string]ConfigProvider, error) {
+	merged := map[string]ConfigProvider{}
+	var firstErr error
+
+	for _, path := range globalConfigPaths(settingsPath) {
+		providers, err := LoadConfigProviders(path)
+		if err != nil && firstErr == nil {
+			firstErr = err
+		}
+		merged = mergeConfigProviders(merged, providers)
+	}
+
+	if path := os.Getenv("OPENCODE_CONFIG"); path != "" {
+		providers, err := LoadConfigProviders(path)
+		if err != nil && firstErr == nil {
+			firstErr = err
+		}
+		merged = mergeConfigProviders(merged, providers)
+	}
+
+	for _, path := range projectConfigPaths(cwd) {
+		providers, err := LoadConfigProviders(path)
+		if err != nil && firstErr == nil {
+			firstErr = err
+		}
+		merged = mergeConfigProviders(merged, providers)
+	}
+
+	if content := os.Getenv("OPENCODE_CONFIG_CONTENT"); content != "" {
+		providers, err := loadConfigProvidersData("OPENCODE_CONFIG_CONTENT", []byte(content))
+		if err != nil && firstErr == nil {
+			firstErr = err
+		}
+		merged = mergeConfigProviders(merged, providers)
+	}
+
+	return merged, firstErr
+}
+
+func globalConfigPaths(settingsPath string) []string {
+	if settingsPath == "" {
+		return nil
+	}
+	if !strings.EqualFold(filepath.Base(settingsPath), "opencode.json") {
+		return []string{settingsPath}
+	}
+	if _, err := os.Stat(settingsPath); err == nil || !errors.Is(err, os.ErrNotExist) {
+		return []string{settingsPath}
+	}
+	return []string{settingsPath, filepath.Join(filepath.Dir(settingsPath), "opencode.jsonc")}
+}
+
+func projectConfigPaths(cwd string) []string {
+	var dirs []string
+	for dir := filepath.Clean(cwd); ; dir = filepath.Dir(dir) {
+		dirs = append(dirs, dir)
+		if _, err := os.Stat(filepath.Join(dir, ".git")); err == nil {
+			break
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+	}
+
+	paths := make([]string, 0, len(dirs)*3)
+	for i := len(dirs) - 1; i >= 0; i-- {
+		dir := dirs[i]
+		paths = append(paths,
+			filepath.Join(dir, "opencode.json"),
+			filepath.Join(dir, "opencode.jsonc"),
+			filepath.Join(dir, ".opencode", "opencode.json"),
+		)
+	}
+	return paths
+}
+
+func mergeConfigProviders(base, override map[string]ConfigProvider) map[string]ConfigProvider {
+	if len(override) == 0 {
+		return base
+	}
+	if base == nil {
+		base = map[string]ConfigProvider{}
+	}
+	for id, incoming := range override {
+		existing := base[id]
+		if incoming.Name != "" {
+			existing.Name = incoming.Name
+		}
+		if len(incoming.Models) > 0 {
+			if existing.Models == nil {
+				existing.Models = map[string]ConfigModel{}
+			}
+			for modelID, model := range incoming.Models {
+				existing.Models[modelID] = model
+			}
+		}
+		base[id] = existing
+	}
+	return base
+}
+
+func stripJSONC(data []byte) []byte {
+	var out bytes.Buffer
+	inString := false
+	escaped := false
+	for i := 0; i < len(data); i++ {
+		c := data[i]
+		if inString {
+			out.WriteByte(c)
+			if escaped {
+				escaped = false
+				continue
+			}
+			if c == '\\' {
+				escaped = true
+				continue
+			}
+			if c == '"' {
+				inString = false
+			}
+			continue
+		}
+
+		if c == '"' {
+			inString = true
+			out.WriteByte(c)
+			continue
+		}
+		if c == '/' && i+1 < len(data) && data[i+1] == '/' {
+			for i < len(data) && data[i] != '\n' {
+				i++
+			}
+			if i < len(data) {
+				out.WriteByte(data[i])
+			}
+			continue
+		}
+		if c == '/' && i+1 < len(data) && data[i+1] == '*' {
+			i += 2
+			for i+1 < len(data) && !(data[i] == '*' && data[i+1] == '/') {
+				i++
+			}
+			i++
+			continue
+		}
+		out.WriteByte(c)
+	}
+
+	return removeTrailingJSONCommas(out.Bytes())
+}
+
+func removeTrailingJSONCommas(data []byte) []byte {
+	var out bytes.Buffer
+	inString := false
+	escaped := false
+	for i := 0; i < len(data); i++ {
+		c := data[i]
+		if inString {
+			out.WriteByte(c)
+			if escaped {
+				escaped = false
+				continue
+			}
+			if c == '\\' {
+				escaped = true
+				continue
+			}
+			if c == '"' {
+				inString = false
+			}
+			continue
+		}
+		if c == '"' {
+			inString = true
+			out.WriteByte(c)
+			continue
+		}
+		if c == ',' {
+			j := i + 1
+			for j < len(data) && (data[j] == ' ' || data[j] == '\t' || data[j] == '\r' || data[j] == '\n') {
+				j++
+			}
+			if j < len(data) && (data[j] == '}' || data[j] == ']') {
+				continue
+			}
+		}
+		out.WriteByte(c)
+	}
+	return out.Bytes()
 }
 
 // MergeCustomProviders merges custom providers from opencode.json into the cache-loaded

--- a/internal/opencode/models_test.go
+++ b/internal/opencode/models_test.go
@@ -771,6 +771,43 @@ func TestLoadEffectiveConfigProvidersSourcesAndPrecedence(t *testing.T) {
 	}
 }
 
+// TestLoadEffectiveConfigProvidersJSONCWithExistingJSON verifies that when both
+// opencode.json and opencode.jsonc exist in the global config dir, providers
+// from the .jsonc file are loaded even when .json is present and has no providers.
+func TestLoadEffectiveConfigProvidersJSONCWithExistingJSON(t *testing.T) {
+	t.Setenv("OPENCODE_CONFIG", "")
+	t.Setenv("OPENCODE_CONFIG_CONTENT", "")
+
+	dir := t.TempDir()
+	// .json exists but contains no providers (common setup).
+	jsonPath := filepath.Join(dir, "opencode.json")
+	if err := os.WriteFile(jsonPath, []byte(`{}`), 0o644); err != nil {
+		t.Fatalf("write json config: %v", err)
+	}
+	// .jsonc holds the actual providers (e.g. users prefer comments).
+	jsoncPath := filepath.Join(dir, "opencode.jsonc")
+	if err := os.WriteFile(jsoncPath, []byte(`{
+		// Custom provider defined in .jsonc
+		"provider": {
+			"lite-llm": {"name": "Lite LLM", "models": {"my-model": {"name": "My Model", "tool_call": false}}},
+		},
+	}`), 0o644); err != nil {
+		t.Fatalf("write jsonc config: %v", err)
+	}
+
+	config, err := LoadEffectiveConfigProvidersForDir(jsonPath, dir)
+	if err != nil {
+		t.Fatalf("LoadEffectiveConfigProvidersForDir() error = %v", err)
+	}
+	if _, ok := config["lite-llm"]; !ok {
+		keys := make([]string, 0, len(config))
+		for k := range config {
+			keys = append(keys, k)
+		}
+		t.Fatalf("expected provider %q to be loaded from .jsonc when .json exists but has no providers; got keys: %v", "lite-llm", keys)
+	}
+}
+
 func TestLoadEffectiveConfigProvidersAcceptsInlineJSONC(t *testing.T) {
 	t.Setenv("OPENCODE_CONFIG", "")
 	t.Setenv("OPENCODE_CONFIG_CONTENT", `{

--- a/internal/opencode/models_test.go
+++ b/internal/opencode/models_test.go
@@ -566,6 +566,237 @@ func TestLoadConfigProvidersInvalidJSON(t *testing.T) {
 	}
 }
 
+func TestLoadConfigProvidersJSONC(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "opencode.jsonc")
+	if err := os.WriteFile(path, []byte(`{
+		// Project-local provider
+		"provider": {
+			"lite-llm": {
+				"name": "LITE-LLM",
+				"models": {
+					"claude-proxy": {"name": "Claude Proxy", "tool_call": true},
+				},
+			},
+		},
+	}`), 0o644); err != nil {
+		t.Fatalf("write JSONC config: %v", err)
+	}
+
+	config, err := LoadConfigProviders(path)
+	if err != nil {
+		t.Fatalf("LoadConfigProviders() error = %v", err)
+	}
+	if _, ok := config["lite-llm"]; !ok {
+		t.Fatalf("missing JSONC provider; got %v", config)
+	}
+}
+
+func TestLoadConfigProvidersJSONCSyntax(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		wantErr bool
+	}{
+		{
+			name: "line and block markers inside strings",
+			content: `{
+				"provider": {
+					"strings": {"name": "https://example.test/*not-a-comment*/", "models": {"m": {"name": "// not a comment", "tool_call": true}}}
+				}
+			}`,
+		},
+		{
+			name: "block comments and trailing array commas",
+			content: `{
+				/* provider block */
+				"provider": {
+					"block": {"name": "Block", "models": {"m": {"name": "Model", "tool_call": true}}},
+				},
+				"disabled_providers": ["openai",],
+			}`,
+		},
+		{
+			name:    "malformed unterminated block comment",
+			content: `{"provider": { /* unterminated`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "opencode.jsonc")
+			if err := os.WriteFile(path, []byte(tt.content), 0o644); err != nil {
+				t.Fatalf("write JSONC config: %v", err)
+			}
+
+			_, err := LoadConfigProviders(path)
+			if tt.wantErr && err == nil {
+				t.Fatal("expected parse error")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("LoadConfigProviders() error = %v", err)
+			}
+		})
+	}
+}
+
+func TestLoadEffectiveConfigProvidersIncludesProjectConfig(t *testing.T) {
+	t.Setenv("OPENCODE_CONFIG", "")
+	t.Setenv("OPENCODE_CONFIG_CONTENT", "")
+
+	dir := t.TempDir()
+	globalPath := filepath.Join(dir, "global", "opencode.json")
+	if err := os.MkdirAll(filepath.Dir(globalPath), 0o755); err != nil {
+		t.Fatalf("create global dir: %v", err)
+	}
+	if err := os.WriteFile(globalPath, []byte(`{
+		"provider": {
+			"global-only": {"name": "Global Only", "models": {"global-model": {"tool_call": true}}},
+			"shared": {"name": "Global Shared", "models": {"base-model": {"name": "Base", "tool_call": true}}}
+		}
+	}`), 0o644); err != nil {
+		t.Fatalf("write global config: %v", err)
+	}
+
+	projectDir := filepath.Join(dir, "repo")
+	workDir := filepath.Join(projectDir, "subdir")
+	if err := os.MkdirAll(workDir, 0o755); err != nil {
+		t.Fatalf("create project dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(projectDir, "opencode.json"), []byte(`{
+		"provider": {
+			"lite-llm": {"name": "LITE-LLM", "models": {"proxy-model": {"name": "Proxy", "tool_call": true}}},
+			"shared": {"name": "Project Shared", "models": {"project-model": {"name": "Project", "tool_call": true}}}
+		}
+	}`), 0o644); err != nil {
+		t.Fatalf("write project config: %v", err)
+	}
+
+	config, err := LoadEffectiveConfigProvidersForDir(globalPath, workDir)
+	if err != nil {
+		t.Fatalf("LoadEffectiveConfigProvidersForDir() error = %v", err)
+	}
+
+	if _, ok := config["global-only"]; !ok {
+		t.Fatalf("missing provider from global config; got %v", config)
+	}
+	if _, ok := config["lite-llm"]; !ok {
+		t.Fatalf("missing provider from project config; got %v", config)
+	}
+	shared := config["shared"]
+	if shared.Name != "Project Shared" {
+		t.Fatalf("shared provider name = %q, want project override", shared.Name)
+	}
+	if _, ok := shared.Models["base-model"]; !ok {
+		t.Fatalf("shared provider lost global model: %v", shared.Models)
+	}
+	if _, ok := shared.Models["project-model"]; !ok {
+		t.Fatalf("shared provider missing project model: %v", shared.Models)
+	}
+}
+
+func TestLoadEffectiveConfigProvidersSourcesAndPrecedence(t *testing.T) {
+	dir := t.TempDir()
+	globalDir := filepath.Join(dir, "global")
+	if err := os.MkdirAll(globalDir, 0o755); err != nil {
+		t.Fatalf("create global dir: %v", err)
+	}
+	globalPath := filepath.Join(globalDir, "opencode.json")
+	globalJSONCPath := filepath.Join(globalDir, "opencode.jsonc")
+	if err := os.WriteFile(globalJSONCPath, []byte(`{
+		// Global fallback provider.
+		"provider": {
+			"shared": {"name": "Global", "models": {"global-model": {"name": "Global Model", "tool_call": true}}},
+		},
+	}`), 0o644); err != nil {
+		t.Fatalf("write global jsonc config: %v", err)
+	}
+
+	explicitPath := filepath.Join(dir, "explicit.json")
+	if err := os.WriteFile(explicitPath, []byte(`{
+		"provider": {
+			"shared": {"name": "Explicit", "models": {"explicit-model": {"name": "Explicit Model", "tool_call": true}}}
+		}
+	}`), 0o644); err != nil {
+		t.Fatalf("write explicit config: %v", err)
+	}
+	t.Setenv("OPENCODE_CONFIG", explicitPath)
+	t.Setenv("OPENCODE_CONFIG_CONTENT", `{
+		"provider": {
+			"shared": {"name": "Inline", "models": {"inline-model": {"name": "Inline Model", "tool_call": true}}}
+		}
+	}`)
+
+	projectDir := filepath.Join(dir, "repo")
+	workDir := filepath.Join(projectDir, "subdir")
+	if err := os.MkdirAll(filepath.Join(projectDir, ".git"), 0o755); err != nil {
+		t.Fatalf("create git marker: %v", err)
+	}
+	if err := os.MkdirAll(workDir, 0o755); err != nil {
+		t.Fatalf("create work dir: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(projectDir, ".opencode"), 0o755); err != nil {
+		t.Fatalf("create .opencode dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(projectDir, "opencode.json"), []byte(`{
+		"provider": {
+			"shared": {"name": "Project", "models": {"project-model": {"name": "Project Model", "tool_call": true}}}
+		}
+	}`), 0o644); err != nil {
+		t.Fatalf("write project config: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(projectDir, ".opencode", "opencode.json"), []byte(`{
+		"provider": {
+			"shared": {"name": "Dot OpenCode", "models": {"dot-model": {"name": "Dot Model", "tool_call": true}}}
+		}
+	}`), 0o644); err != nil {
+		t.Fatalf("write .opencode config: %v", err)
+	}
+
+	config, err := LoadEffectiveConfigProvidersForDir(globalPath, workDir)
+	if err != nil {
+		t.Fatalf("LoadEffectiveConfigProvidersForDir() error = %v", err)
+	}
+
+	shared := config["shared"]
+	if shared.Name != "Inline" {
+		t.Fatalf("shared provider name = %q, want inline content to win", shared.Name)
+	}
+	for _, modelID := range []string{"global-model", "explicit-model", "project-model", "dot-model", "inline-model"} {
+		if _, ok := shared.Models[modelID]; !ok {
+			t.Fatalf("shared provider missing %s: %v", modelID, shared.Models)
+		}
+	}
+}
+
+func TestLoadEffectiveConfigProvidersAcceptsInlineJSONC(t *testing.T) {
+	t.Setenv("OPENCODE_CONFIG", "")
+	t.Setenv("OPENCODE_CONFIG_CONTENT", `{
+		// Inline content can use JSONC syntax.
+		"provider": {
+			"inline": {"name": "Inline", "models": {"inline-model": {"name": "Inline Model", "tool_call": true}}},
+		},
+	}`)
+
+	dir := t.TempDir()
+	globalPath := filepath.Join(dir, "opencode.json")
+
+	config, err := LoadEffectiveConfigProvidersForDir(globalPath, dir)
+	if err != nil {
+		t.Fatalf("LoadEffectiveConfigProvidersForDir() error = %v", err)
+	}
+
+	provider, ok := config["inline"]
+	if !ok {
+		t.Fatalf("missing inline provider: %v", config)
+	}
+	if _, ok := provider.Models["inline-model"]; !ok {
+		t.Fatalf("missing inline model: %v", provider.Models)
+	}
+}
+
 // MergeCustomProviders
 
 func TestMergeCustomProvidersNewProvider(t *testing.T) {

--- a/internal/tui/screens/model_picker.go
+++ b/internal/tui/screens/model_picker.go
@@ -78,14 +78,14 @@ type ModelPickerState struct {
 }
 
 // NewModelPickerState initializes the picker state from the models cache,
-// merging any custom providers defined in the OpenCode settings file.
+// merging any custom providers defined in OpenCode's effective config.
 func NewModelPickerState(cachePath string, settingsPath string) ModelPickerState {
 	providers, err := opencode.LoadModelsOrEmpty(cachePath)
 	if err != nil {
 		return ModelPickerState{}
 	}
 
-	configProviders, configErr := opencode.LoadConfigProviders(settingsPath)
+	configProviders, configErr := opencode.LoadEffectiveConfigProviders(settingsPath)
 	if len(configProviders) > 0 {
 		providers = opencode.MergeCustomProviders(providers, configProviders)
 	}

--- a/internal/tui/screens/model_picker_test.go
+++ b/internal/tui/screens/model_picker_test.go
@@ -1115,6 +1115,59 @@ func TestNewModelPickerStateCollisionCustomWins(t *testing.T) {
 	}
 }
 
+func TestNewModelPickerStateDiscoversProjectOpenCodeConfig(t *testing.T) {
+	cachePath := writeTempFile(t, "models.json", catalogJSON)
+	globalPath := writeTempFile(t, "opencode.json", `{
+		"provider": {
+			"global-provider": {
+				"name": "Global Provider",
+				"models": {"global-model": {"name": "Global Model", "tool_call": true}}
+			}
+		}
+	}`)
+
+	projectDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(projectDir, ".git"), 0o755); err != nil {
+		t.Fatalf("create git marker: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(projectDir, "opencode.jsonc"), []byte(`{
+		// Project provider should be visible to the picker.
+		"provider": {
+			"lite-llm": {
+				"name": "LITE-LLM",
+				"models": {"proxy-model": {"name": "Proxy Model", "tool_call": true}},
+			},
+		},
+	}`), 0o644); err != nil {
+		t.Fatalf("write project opencode.jsonc: %v", err)
+	}
+
+	oldWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get cwd: %v", err)
+	}
+	if err := os.Chdir(projectDir); err != nil {
+		t.Fatalf("chdir project dir: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(oldWD); err != nil {
+			t.Fatalf("restore cwd: %v", err)
+		}
+	})
+
+	state := NewModelPickerState(cachePath, globalPath)
+
+	if _, ok := state.Providers["global-provider"]; !ok {
+		t.Fatalf("missing provider from global config; got keys: %v", providerKeys(state.Providers))
+	}
+	if _, ok := state.Providers["lite-llm"]; !ok {
+		t.Fatalf("missing provider from project config; got keys: %v", providerKeys(state.Providers))
+	}
+	if !containsString(state.AvailableIDs, "lite-llm") {
+		t.Fatalf("project custom provider not selectable; AvailableIDs = %v", state.AvailableIDs)
+	}
+}
+
 // providerKeys returns the keys of a Provider map for test error messages.
 func providerKeys(providers map[string]opencode.Provider) []string {
 	keys := make([]string, 0, len(providers))
@@ -1122,6 +1175,15 @@ func providerKeys(providers map[string]opencode.Provider) []string {
 		keys = append(keys, k)
 	}
 	return keys
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
 }
 
 // ─── Separator row (non-selectable) ────────────────────────────────────────


### PR DESCRIPTION
## Linked Issue

Closes #TODO

---

## PR Type

What kind of change does this PR introduce?

- [ ] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [x] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## Summary

- Adds OpenCode custom provider discovery so project and global OpenCode config providers can appear in the Gentle AI model picker.
- Loads providers from `opencode.json`, `opencode.jsonc`, `.opencode.json`, `.opencode.jsonc`, and inline OpenCode config content with explicit precedence.
- Fixes the global config edge case where providers in `opencode.jsonc` were skipped when `opencode.json` already existed.

---

## Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/opencode/models.go` | Adds OpenCode custom provider loading from global, project, and inline config sources, including JSONC support and merge precedence. |
| `internal/opencode/models_test.go` | Adds coverage for provider parsing, source precedence, project config loading, inline config loading, and the `.jsonc` global config regression. |
| `internal/tui/screens/model_picker.go` | Wires OpenCode custom providers into the model picker data shown to users. |
| `internal/tui/screens/model_picker_test.go` | Adds model picker coverage for displaying custom OpenCode providers. |

---

## Test Plan

**Unit Tests**
```bash
go test ./internal/opencode
```

**Local Verification**
```bash
git diff --check
```

- [ ] Unit tests pass (`go test ./internal/opencode`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [ ] Manually tested locally

Notes:
- `git diff --check` passed locally before the latest commit.
- `go test ./internal/opencode` could not be run in this terminal because `go` is not available in PATH.
- E2E tests were not run in this terminal.

---

## Automated Checks

The following checks run automatically on this PR:

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | Pending | PR should stay within 400 changed lines (`additions + deletions`) or use `size:exception` |
| Check Issue Reference | Pending | PR body must contain `Closes/Fixes/Resolves #N` |
| Check Issue Has `status:approved` | Pending | Linked issue must have been approved before work began |
| Check PR Has `type:*` Label | Pending | Exactly one `type:*` label must be applied |
| Unit Tests | Pending | `go test ./...` must pass |
| E2E Tests | Pending | `cd e2e && ./docker-test.sh` must pass |

---

## Contributor Checklist

- [ ] PR is linked to an issue with `status:approved`
- [ ] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [ ] I have added the appropriate `type:*` label to this PR
- [ ] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] My commits do not include `Co-Authored-By` trailers

---

## Notes for Reviewers

Replace `#TODO` with the approved issue number before creating the PR, and add the `type:feature` label after opening it.

This PR is 551 changed lines against `Gentleman-Programming/gentle-ai:main`, so it needs either a maintainer-applied `size:exception` label or a split into smaller PRs before the policy check can pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configuration files now support JSONC format (JSON with comments) for improved readability
  * Automatic discovery and merging of project-level configurations with global settings, with project configurations taking precedence

<!-- end of auto-generated comment: release notes by coderabbit.ai -->