### PR TITLE
fix(doctor): detect PATH-shadowed binaries on Windows via PATHEXT

### DIFF
--- a/internal/assets/gga/gga.cmd
+++ b/internal/assets/gga/gga.cmd
@@ -1,0 +1,5 @@
+@echo off
+setlocal
+set "GGA_PS1=%~dp0gga.ps1"
+powershell -NoProfile -ExecutionPolicy Bypass -File "%GGA_PS1%" %*
+exit /b %ERRORLEVEL%

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -40,9 +41,9 @@ type DoctorReport struct {
 var knownTools = []string{"gentle-ai", "engram", "gga", "claude", "opencode"}
 
 const (
-	engramHealthEnvVar    = "ENGRAM_BASE_URL"
-	diskWarnThreshold     = int64(100 * 1024 * 1024) // 100 MB
-	diskFailThreshold     = int64(10 * 1024 * 1024)  // 10 MB
+	engramHealthEnvVar = "ENGRAM_BASE_URL"
+	diskWarnThreshold  = int64(100 * 1024 * 1024) // 100 MB
+	diskFailThreshold  = int64(10 * 1024 * 1024)  // 10 MB
 )
 
 // Overridable for testing.
@@ -50,6 +51,7 @@ var (
 	lookPathFn          = exec.LookPath
 	availableBytesFn    = storage.AvailableBytes
 	osUserHomeDirDoctor = os.UserHomeDir
+	executableExtsFn    = executableExtensions
 	pathDirsFn          = func() []string {
 		return filepath.SplitList(os.Getenv("PATH"))
 	}
@@ -102,8 +104,8 @@ func checkOneTool(tool string, pathDirs []string) CheckResult {
 
 	var copies []string
 	for _, dir := range pathDirs {
-		if _, statErr := os.Stat(filepath.Join(dir, tool)); statErr == nil {
-			copies = append(copies, filepath.Join(dir, tool))
+		if p := toolInDir(dir, tool); p != "" {
+			copies = append(copies, p)
 		}
 	}
 
@@ -121,6 +123,44 @@ func checkOneTool(tool string, pathDirs []string) CheckResult {
 		Status: CheckStatusPass,
 		Detail: tool + " found at " + resolved,
 	}
+}
+
+// executableExtensions returns the filename suffixes to probe when scanning a
+// PATH directory for a tool binary. On Windows it mirrors exec.LookPath, which
+// resolves a bare name like "gentle-ai" to "gentle-ai.exe"/".cmd" via PATHEXT;
+// on other platforms the bare name is used as-is. Without this, the duplicate
+// scan never matches real Windows binaries and PATH shadowing goes unreported.
+func executableExtensions() []string {
+	if runtime.GOOS != "windows" {
+		return []string{""}
+	}
+	pathext := os.Getenv("PATHEXT")
+	if pathext == "" {
+		pathext = ".COM;.EXE;.BAT;.CMD"
+	}
+	var exts []string
+	for _, e := range strings.Split(pathext, ";") {
+		if e = strings.TrimSpace(e); e != "" {
+			exts = append(exts, strings.ToLower(e))
+		}
+	}
+	if len(exts) == 0 {
+		return []string{".exe"}
+	}
+	return exts
+}
+
+// toolInDir returns the path to tool's executable inside dir, or "" if absent.
+// It honors Windows executable extensions so the duplicate scan agrees with
+// exec.LookPath (used for the resolved path).
+func toolInDir(dir, tool string) string {
+	for _, ext := range executableExtsFn() {
+		candidate := filepath.Join(dir, tool+ext)
+		if info, err := os.Stat(candidate); err == nil && !info.IsDir() {
+			return candidate
+		}
+	}
+	return ""
 }
 
 // checkStateJSON validates ~/.gentle-ai/state.json and agent config dirs.

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -131,21 +131,26 @@ func checkOneTool(tool string, pathDirs []string) CheckResult {
 // on other platforms the bare name is used as-is. Without this, the duplicate
 // scan never matches real Windows binaries and PATH shadowing goes unreported.
 func executableExtensions() []string {
-	if runtime.GOOS != "windows" {
+	return executableExtensionsFor(runtime.GOOS, os.Getenv("PATHEXT"))
+}
+
+func executableExtensionsFor(goos, pathext string) []string {
+	if goos != "windows" {
 		return []string{""}
 	}
-	pathext := os.Getenv("PATHEXT")
 	if pathext == "" {
-		pathext = ".COM;.EXE;.BAT;.CMD"
+		return []string{".com", ".exe", ".bat", ".cmd"}
 	}
 	var exts []string
 	for _, e := range strings.Split(pathext, ";") {
-		if e = strings.TrimSpace(e); e != "" {
-			exts = append(exts, strings.ToLower(e))
+		e = strings.ToLower(strings.TrimSpace(e))
+		if e == "" {
+			continue
 		}
-	}
-	if len(exts) == 0 {
-		return []string{".exe"}
+		if !strings.HasPrefix(e, ".") {
+			e = "." + e
+		}
+		exts = append(exts, e)
 	}
 	return exts
 }

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -51,6 +51,7 @@ var (
 	lookPathFn          = exec.LookPath
 	availableBytesFn    = storage.AvailableBytes
 	osUserHomeDirDoctor = os.UserHomeDir
+	doctorGOOS          = runtime.GOOS
 	executableExtsFn    = executableExtensions
 	pathDirsFn          = func() []string {
 		return filepath.SplitList(os.Getenv("PATH"))
@@ -92,7 +93,7 @@ func checkToolBinaries(pathDirs []string) []CheckResult {
 }
 
 func checkOneTool(tool string, pathDirs []string) CheckResult {
-	resolved, err := lookPathFn(tool)
+	resolved, shim, err := resolveDoctorTool(tool)
 	if err != nil {
 		return CheckResult{
 			Name:   "tool:" + tool,
@@ -102,13 +103,7 @@ func checkOneTool(tool string, pathDirs []string) CheckResult {
 		}
 	}
 
-	var copies []string
-	for _, dir := range pathDirs {
-		if p := toolInDir(dir, tool); p != "" {
-			copies = append(copies, p)
-		}
-	}
-
+	copies := doctorToolCopies(tool, pathDirs)
 	if len(copies) > 1 {
 		return CheckResult{
 			Name:   "tool:" + tool,
@@ -118,11 +113,46 @@ func checkOneTool(tool string, pathDirs []string) CheckResult {
 		}
 	}
 
+	detail := tool + " found at " + resolved
+	if shim != "" {
+		detail += " (" + shim + ")"
+	}
 	return CheckResult{
 		Name:   "tool:" + tool,
 		Status: CheckStatusPass,
-		Detail: tool + " found at " + resolved,
+		Detail: detail,
 	}
+}
+
+func resolveDoctorTool(tool string) (string, string, error) {
+	resolved, err := lookPathFn(tool)
+	if err == nil {
+		return resolved, "", nil
+	}
+	if doctorGOOS != "windows" {
+		return "", "", err
+	}
+	resolved, ps1Err := lookPathFn(tool + ".ps1")
+	if ps1Err != nil {
+		return "", "", err
+	}
+	return resolved, "PowerShell shim", nil
+}
+
+func doctorToolCopies(tool string, pathDirs []string) []string {
+	seenDirs := make(map[string]struct{}, len(pathDirs))
+	copies := make([]string, 0, len(pathDirs))
+	for _, dir := range pathDirs {
+		cleanDir := filepath.Clean(dir)
+		if _, seen := seenDirs[cleanDir]; seen {
+			continue
+		}
+		if p := toolInDir(dir, tool); p != "" {
+			seenDirs[cleanDir] = struct{}{}
+			copies = append(copies, p)
+		}
+	}
+	return copies
 }
 
 // executableExtensions returns the filename suffixes to probe when scanning a
@@ -131,7 +161,7 @@ func checkOneTool(tool string, pathDirs []string) CheckResult {
 // on other platforms the bare name is used as-is. Without this, the duplicate
 // scan never matches real Windows binaries and PATH shadowing goes unreported.
 func executableExtensions() []string {
-	return executableExtensionsFor(runtime.GOOS, os.Getenv("PATHEXT"))
+	return executableExtensionsFor(doctorGOOS, os.Getenv("PATHEXT"))
 }
 
 func executableExtensionsFor(goos, pathext string) []string {
@@ -159,13 +189,31 @@ func executableExtensionsFor(goos, pathext string) []string {
 // It honors Windows executable extensions so the duplicate scan agrees with
 // exec.LookPath (used for the resolved path).
 func toolInDir(dir, tool string) string {
-	for _, ext := range executableExtsFn() {
+	for _, ext := range doctorToolExecutableExts() {
 		candidate := filepath.Join(dir, tool+ext)
 		if info, err := os.Stat(candidate); err == nil && !info.IsDir() {
 			return candidate
 		}
 	}
 	return ""
+}
+
+func doctorToolExecutableExts() []string {
+	exts := append([]string(nil), executableExtsFn()...)
+	if doctorGOOS == "windows" {
+		exts = appendUniqueExt(exts, "")
+		exts = appendUniqueExt(exts, ".ps1")
+	}
+	return exts
+}
+
+func appendUniqueExt(exts []string, ext string) []string {
+	for _, existing := range exts {
+		if strings.EqualFold(existing, ext) {
+			return exts
+		}
+	}
+	return append(exts, ext)
 }
 
 // checkStateJSON validates ~/.gentle-ai/state.json and agent config dirs.

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -95,9 +95,14 @@ func TestCheckOneTool_OK(t *testing.T) {
 // extensions the duplicate copies are detected and a warning is produced.
 func TestCheckOneTool_ShadowedWindowsExt(t *testing.T) {
 	origLook := lookPathFn
-	defer func() { lookPathFn = origLook }()
+	origGOOS := doctorGOOS
 	origExts := executableExtsFn
-	defer func() { executableExtsFn = origExts }()
+	defer func() {
+		lookPathFn = origLook
+		doctorGOOS = origGOOS
+		executableExtsFn = origExts
+	}()
+	doctorGOOS = "windows"
 	executableExtsFn = func() []string { return []string{".exe", ".cmd"} }
 
 	dir1 := t.TempDir()
@@ -119,6 +124,75 @@ func TestCheckOneTool_ShadowedWindowsExt(t *testing.T) {
 	}
 	if !strings.Contains(got.Detail, "2 copies found") {
 		t.Errorf("unexpected detail: %s", got.Detail)
+	}
+}
+
+func TestCheckOneTool_WindowsPowerShellShimFallback(t *testing.T) {
+	origLook := lookPathFn
+	origGOOS := doctorGOOS
+	origExts := executableExtsFn
+	defer func() {
+		lookPathFn = origLook
+		doctorGOOS = origGOOS
+		executableExtsFn = origExts
+	}()
+	doctorGOOS = "windows"
+	executableExtsFn = func() []string { return []string{".exe", ".cmd"} }
+
+	dir := t.TempDir()
+	ps1Path := filepath.Join(dir, "gga.ps1")
+	if err := os.WriteFile(ps1Path, []byte("fake"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	lookPathFn = func(file string) (string, error) {
+		if file == "gga.ps1" {
+			return ps1Path, nil
+		}
+		return "", errors.New("not found")
+	}
+
+	got := checkOneTool("gga", []string{dir})
+
+	if got.Status != CheckStatusPass {
+		t.Fatalf("expected pass, got %s: %s", got.Status, got.Detail)
+	}
+	if !strings.Contains(got.Detail, "PowerShell shim") {
+		t.Fatalf("expected PowerShell shim detail, got %q", got.Detail)
+	}
+}
+
+func TestCheckOneTool_WindowsShimVariantsInSameDirAreNotDuplicates(t *testing.T) {
+	origLook := lookPathFn
+	origGOOS := doctorGOOS
+	origExts := executableExtsFn
+	defer func() {
+		lookPathFn = origLook
+		doctorGOOS = origGOOS
+		executableExtsFn = origExts
+	}()
+	doctorGOOS = "windows"
+	executableExtsFn = func() []string { return []string{".cmd"} }
+
+	dir := t.TempDir()
+	cmdPath := filepath.Join(dir, "gga.cmd")
+	for _, path := range []string{cmdPath, filepath.Join(dir, "gga.ps1")} {
+		if err := os.WriteFile(path, []byte("fake"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	lookPathFn = func(file string) (string, error) {
+		if file == "gga" {
+			return cmdPath, nil
+		}
+		return "", errors.New("not found")
+	}
+
+	got := checkOneTool("gga", []string{dir})
+
+	if got.Status != CheckStatusPass {
+		t.Fatalf("expected pass for same-directory shim variants, got %s: %s", got.Status, got.Detail)
 	}
 }
 

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -34,6 +35,9 @@ func TestCheckOneTool_MissingBinary(t *testing.T) {
 func TestCheckOneTool_ShadowedBinary(t *testing.T) {
 	orig := lookPathFn
 	defer func() { lookPathFn = orig }()
+	origExts := executableExtsFn
+	defer func() { executableExtsFn = origExts }()
+	executableExtsFn = func() []string { return []string{""} }
 
 	dir1 := t.TempDir()
 	dir2 := t.TempDir()
@@ -65,6 +69,9 @@ func TestCheckOneTool_ShadowedBinary(t *testing.T) {
 func TestCheckOneTool_OK(t *testing.T) {
 	orig := lookPathFn
 	defer func() { lookPathFn = orig }()
+	origExts := executableExtsFn
+	defer func() { executableExtsFn = origExts }()
+	executableExtsFn = func() []string { return []string{""} }
 
 	dir := t.TempDir()
 	f, err := os.Create(filepath.Join(dir, "engram"))
@@ -79,6 +86,60 @@ func TestCheckOneTool_OK(t *testing.T) {
 
 	if got.Status != CheckStatusPass {
 		t.Errorf("expected pass, got %s: %s", got.Status, got.Detail)
+	}
+}
+
+// TestCheckOneTool_ShadowedWindowsExt reproduces the Windows bug: binaries on
+// disk carry an executable extension (e.g. gentle-ai.exe / gentle-ai.cmd), so a
+// bare-name scan misses them and shadowing is reported as [ok]. With PATHEXT
+// extensions the duplicate copies are detected and a warning is produced.
+func TestCheckOneTool_ShadowedWindowsExt(t *testing.T) {
+	origLook := lookPathFn
+	defer func() { lookPathFn = origLook }()
+	origExts := executableExtsFn
+	defer func() { executableExtsFn = origExts }()
+	executableExtsFn = func() []string { return []string{".exe", ".cmd"} }
+
+	dir1 := t.TempDir()
+	dir2 := t.TempDir()
+	for _, p := range []string{filepath.Join(dir1, "gentle-ai.exe"), filepath.Join(dir2, "gentle-ai.cmd")} {
+		f, err := os.Create(p)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_ = f.Close()
+	}
+
+	lookPathFn = func(string) (string, error) { return filepath.Join(dir1, "gentle-ai.exe"), nil }
+
+	got := checkOneTool("gentle-ai", []string{dir1, dir2})
+
+	if got.Status != CheckStatusWarn {
+		t.Fatalf("expected warn for extensioned shadow, got %s: %s", got.Status, got.Detail)
+	}
+	if !strings.Contains(got.Detail, "2 copies found") {
+		t.Errorf("unexpected detail: %s", got.Detail)
+	}
+}
+
+// TestExecutableExtensions verifies the per-platform extension set.
+func TestExecutableExtensions(t *testing.T) {
+	exts := executableExtensions()
+	if len(exts) == 0 {
+		t.Fatal("expected at least one extension")
+	}
+	if runtime.GOOS == "windows" {
+		var hasExe bool
+		for _, e := range exts {
+			if e == ".exe" {
+				hasExe = true
+			}
+		}
+		if !hasExe {
+			t.Errorf("expected .exe among Windows extensions, got %v", exts)
+		}
+	} else if len(exts) != 1 || exts[0] != "" {
+		t.Errorf(`expected [""] on non-Windows, got %v`, exts)
 	}
 }
 

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -143,6 +143,41 @@ func TestExecutableExtensions(t *testing.T) {
 	}
 }
 
+func TestExecutableExtensionsFor(t *testing.T) {
+	tests := []struct {
+		name    string
+		goos    string
+		pathext string
+		want    []string
+	}{
+		{
+			name: "non-windows uses bare name",
+			goos: "darwin",
+			want: []string{""},
+		},
+		{
+			name: "windows default PATHEXT",
+			goos: "windows",
+			want: []string{".com", ".exe", ".bat", ".cmd"},
+		},
+		{
+			name:    "windows normalizes PATHEXT case and missing dots",
+			goos:    "windows",
+			pathext: "EXE;.Cmd; ;BAT",
+			want:    []string{".exe", ".cmd", ".bat"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := executableExtensionsFor(tt.goos, tt.pathext)
+			if strings.Join(got, ",") != strings.Join(tt.want, ",") {
+				t.Fatalf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 // --- checkStateJSON ---
 
 func TestCheckStateJSON_Missing(t *testing.T) {

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -924,6 +924,9 @@ func (s componentApplyStep) Run() error {
 			if err := gga.EnsurePowerShellShim(s.homeDir); err != nil {
 				return fmt.Errorf("ensure gga powershell shim: %w", err)
 			}
+			if err := gga.EnsureCommandShim(s.homeDir); err != nil {
+				return fmt.Errorf("ensure gga command shim: %w", err)
+			}
 			// Add GGA bin dir to the user PATH persistently on Windows.
 			// GGA's install.sh drops the binary into ~/bin which is not on PATH by default.
 			ggaBinDir := filepath.Join(s.homeDir, "bin")

--- a/internal/components/gga/runtime.go
+++ b/internal/components/gga/runtime.go
@@ -24,10 +24,15 @@ func RuntimePRModePath(homeDir string) string {
 }
 
 // RuntimePS1Path returns the expected gga.ps1 path.
-// On Windows, the shim goes to ~/bin/ (same dir as the bash gga script,
-// already in PATH) so PowerShell finds it as a native command.
+// On Windows, the shim goes to ~/bin/ so PowerShell finds it as a native command.
 func RuntimePS1Path(homeDir string) string {
 	return filepath.Join(homeDir, "bin", "gga.ps1")
+}
+
+// RuntimeCMDPath returns the expected gga.cmd path.
+// On Windows, cmd.exe and exec.LookPath resolve .cmd files through PATHEXT.
+func RuntimeCMDPath(homeDir string) string {
+	return filepath.Join(homeDir, "bin", "gga.cmd")
 }
 
 // EnsureRuntimeAssets ensures critical gga runtime files are current.
@@ -65,6 +70,23 @@ func EnsurePowerShellShim(homeDir string) error {
 
 	if _, err := filemerge.WriteFileAtomic(ps1Path, []byte(content), 0o755); err != nil {
 		return fmt.Errorf("write gga runtime file %q: %w", ps1Path, err)
+	}
+
+	return nil
+}
+
+// EnsureCommandShim writes gga.cmd to the GGA bin directory.
+// Must only be called on Windows (caller is responsible for the OS guard).
+func EnsureCommandShim(homeDir string) error {
+	cmdPath := RuntimeCMDPath(homeDir)
+
+	content, err := assets.Read("gga/gga.cmd")
+	if err != nil {
+		return fmt.Errorf("read embedded gga runtime asset gga.cmd: %w", err)
+	}
+
+	if _, err := filemerge.WriteFileAtomic(cmdPath, []byte(content), 0o755); err != nil {
+		return fmt.Errorf("write gga runtime file %q: %w", cmdPath, err)
 	}
 
 	return nil

--- a/internal/components/gga/runtime_test.go
+++ b/internal/components/gga/runtime_test.go
@@ -147,6 +147,22 @@ func TestRuntimePS1Path(t *testing.T) {
 	}
 }
 
+func TestRuntimeCMDPath(t *testing.T) {
+	tests := []struct {
+		homeDir    string
+		wantSuffix string
+	}{
+		{"/home/user", filepath.Join("bin", "gga.cmd")},
+		{"/root", filepath.Join("bin", "gga.cmd")},
+	}
+	for _, tc := range tests {
+		got := RuntimeCMDPath(tc.homeDir)
+		if !strings.HasSuffix(got, tc.wantSuffix) {
+			t.Errorf("RuntimeCMDPath(%q) = %q, want suffix %q", tc.homeDir, got, tc.wantSuffix)
+		}
+	}
+}
+
 // ---------------------------------------------------------------------------
 // EnsurePowerShellShim
 // ---------------------------------------------------------------------------
@@ -204,6 +220,54 @@ func TestEnsurePowerShellShimOverwritesStaleShim(t *testing.T) {
 // TestEnsurePowerShellShimIsNoOpWhenContentMatches verifies idempotency:
 // when gga.ps1 already contains the correct embedded content,
 // EnsurePowerShellShim must not modify it (WriteFileAtomic no-op).
+func TestEnsureCommandShimCreatesFileWhenMissing(t *testing.T) {
+	home := t.TempDir()
+	path := RuntimeCMDPath(home)
+
+	if err := EnsureCommandShim(home); err != nil {
+		t.Fatalf("EnsureCommandShim() error = %v", err)
+	}
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", path, err)
+	}
+
+	text := string(content)
+	if !strings.Contains(text, "gga.ps1") {
+		t.Fatalf("gga.cmd missing expected PowerShell shim delegation, got: %s", text)
+	}
+}
+
+func TestEnsureCommandShimOverwritesStaleShim(t *testing.T) {
+	home := t.TempDir()
+	path := RuntimeCMDPath(home)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+
+	const stale = "@echo stale\r\n"
+	if err := os.WriteFile(path, []byte(stale), 0o755); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	if err := EnsureCommandShim(home); err != nil {
+		t.Fatalf("EnsureCommandShim() error = %v", err)
+	}
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", path, err)
+	}
+
+	if string(content) == stale {
+		t.Fatalf("EnsureCommandShim did not overwrite stale gga.cmd")
+	}
+	if !strings.Contains(string(content), "gga.ps1") {
+		t.Fatalf("overwritten gga.cmd missing expected embedded content")
+	}
+}
+
 func TestEnsurePowerShellShimIsNoOpWhenContentMatches(t *testing.T) {
 	home := t.TempDir()
 


### PR DESCRIPTION
## What

`gentle-ai doctor`'s PATH-shadow detection (`checkOneTool`) never fires on Windows because it probes the bare tool name with no executable extension:

```go
os.Stat(filepath.Join(dir, tool)) // "…\gentle-ai" — never exists on Windows
```

Windows binaries are `gentle-ai.exe` (shims `.cmd`), so every `os.Stat` misses, `copies` stays empty, and `doctor` reports `[ok]` even when a stale duplicate shadows the managed copy on `PATH`. Note the inconsistency: `resolved` comes from `exec.LookPath`, which *does* honor `PATHEXT`, so the resolver and the duplicate scan disagree.

Closes #951.

## Real-world repro

- `irm` installer placed gentle-ai at `%LOCALAPPDATA%\gentle-ai\bin\gentle-ai.exe` (1.42.0)
- a stale scoop copy `scoop\shims\gentle-ai.exe` (1.40.2) sat earlier on `PATH`
- `gentle-ai update` / the installer reported success ("Updated to v1.42.0"), but `gentle-ai version` stayed **1.40.2**
- `gentle-ai doctor` showed `[ok] tool:gentle-ai  found at …\scoop\shims\gentle-ai.exe` — no warning

So updates appear to apply but never take effect, and the one diagnostic meant to catch it gives a false all-clear. This is especially easy to hit on Windows where security software (e.g. Kaspersky System Watcher) quarantines/deletes unsigned binaries mid-install or disables shims, leaving exactly these partial/duplicate states.

## Fix

Probe executable extensions on Windows (`PATHEXT`) in the duplicate scan so it matches `exec.LookPath` semantics. Non-Windows behavior is unchanged (`[""]`). The extension provider is an overridable var (`executableExtsFn`) following the file's existing "Overridable for testing" pattern.

## Tests

- `TestCheckOneTool_ShadowedWindowsExt` — two copies (`.exe` + `.cmd`) → warns; deterministic on any OS via the override.
- `TestExecutableExtensions` — per-platform extension set.
- Existing bare-name tests pinned to `[""]` so they stay green on all platforms.
- `gofmt`, `go vet`, and `go test ./internal/cli/` all pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the doctor check’s PATH shadowing/duplicate detection on Windows so it correctly accounts for executable extensions (for example, `.exe`/`.cmd`) and reports duplicate copies more reliably.
  * Made extension and PowerShell/CMD shim handling consistent in the doctor output, reducing false positives/incorrect counts.

* **New Features**
  * On Windows, the installer now also ensures a `gga.cmd` command shim in addition to the existing PowerShell shim.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #924
