### PR TITLE
fix(tui): split long ManualHint across two lines to avoid terminal clipping

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -966,7 +966,7 @@ func (m Model) View() string {
 		}
 		return screens.RenderWelcomeWithWidth(m.Cursor, m.Version, banner, m.UpdateResults, m.UpdateCheckDone, m.hasDetectedOpenCode(), len(m.ProfileList), m.hasAgentBuilderEngines(), m.Width)
 	case ScreenUpgrade:
-		return screens.RenderUpgrade(m.UpdateResults, m.UpgradeReport, m.UpgradeErr, m.OperationRunning, m.UpdateCheckDone, m.Cursor, m.SpinnerFrame)
+		return screens.RenderUpgradeWithWidth(m.UpdateResults, m.UpgradeReport, m.UpgradeErr, m.OperationRunning, m.UpdateCheckDone, m.Cursor, m.SpinnerFrame, m.Width)
 	case ScreenSync:
 		return screens.RenderSync(m.SyncFiles, m.SyncErr, m.OperationRunning, m.HasSyncRun, m.SpinnerFrame)
 	case ScreenModelConfig:
@@ -988,7 +988,7 @@ func (m Model) View() string {
 	case ScreenProfileDelete:
 		return screens.RenderProfileDelete(m.ProfileDeleteTarget, m.Cursor)
 	case ScreenUpgradeSync:
-		return screens.RenderUpgradeSync(m.UpdateResults, m.UpgradeReport, m.SyncFiles, m.UpgradeErr, m.SyncErr, m.OperationRunning, m.UpdateCheckDone, m.Cursor, m.SpinnerFrame)
+		return screens.RenderUpgradeSyncWithWidth(m.UpdateResults, m.UpgradeReport, m.SyncFiles, m.UpgradeErr, m.SyncErr, m.OperationRunning, m.UpdateCheckDone, m.Cursor, m.SpinnerFrame, m.Width)
 	case ScreenUninstallMode:
 		return screens.RenderUninstallMode(m.Cursor)
 	case ScreenUninstall:

--- a/internal/tui/screens/upgrade.go
+++ b/internal/tui/screens/upgrade.go
@@ -195,14 +195,15 @@ func renderUpgradeResult(b *strings.Builder, report *upgrade.UpgradeReport, widt
 }
 
 // writeManualHint renders a ManualHint to the builder.
-// Hints longer than 80 runes that contain ": " are split so the command
-// appears on its own line and remains visible on narrow terminals.
+// Hints that exceed the available terminal width and contain ": " are split so
+// the command appears on its own wrapped block and remains visible on narrow terminals.
 func writeManualHint(b *strings.Builder, hint string, width int) {
 	const indent = "     "
 	const commandIndent = indent + "  "
 
-	if idx := strings.Index(hint, ": "); idx >= 0 && utf8.RuneCountInString(hint) > 80 {
-		b.WriteString("\n" + indent + styles.SubtextStyle.Render(hint[:idx+1]))
+	availableWidth := width - utf8.RuneCountInString(indent)
+	if idx := strings.Index(hint, ": "); idx >= 0 && availableWidth > 0 && utf8.RuneCountInString(hint) > availableWidth {
+		writeWrappedManualHintLine(b, indent, hint[:idx+1], width)
 		writeWrappedManualHintLine(b, commandIndent, hint[idx+2:], width)
 		return
 	}

--- a/internal/tui/screens/upgrade.go
+++ b/internal/tui/screens/upgrade.go
@@ -3,6 +3,7 @@ package screens
 import (
 	"fmt"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/gentleman-programming/gentle-ai/internal/tui/styles"
 	"github.com/gentleman-programming/gentle-ai/internal/update"
@@ -27,6 +28,12 @@ func SpinnerChar(frame int) string {
 //  4. upgradeErr != nil (and report == nil) → show error with return prompt
 //  5. Otherwise → show list of tools with status, option to upgrade
 func RenderUpgrade(results []update.UpdateResult, report *upgrade.UpgradeReport, upgradeErr error, operationRunning bool, updateCheckDone bool, cursor int, spinnerFrame int) string {
+	return RenderUpgradeWithWidth(results, report, upgradeErr, operationRunning, updateCheckDone, cursor, spinnerFrame, 0)
+}
+
+// RenderUpgradeWithWidth handles all states of the upgrade screen, constraining
+// long manual hints to the terminal width when width is known.
+func RenderUpgradeWithWidth(results []update.UpdateResult, report *upgrade.UpgradeReport, upgradeErr error, operationRunning bool, updateCheckDone bool, cursor int, spinnerFrame int, width int) string {
 	var b strings.Builder
 
 	b.WriteString(styles.TitleStyle.Render("Upgrade Tools"))
@@ -50,7 +57,7 @@ func RenderUpgrade(results []update.UpdateResult, report *upgrade.UpgradeReport,
 
 	// State 3: upgrade report is available — show results
 	if report != nil {
-		return renderUpgradeResult(&b, report)
+		return renderUpgradeResult(&b, report, width)
 	}
 
 	// State 4: upgrade error — show error and allow returning
@@ -115,7 +122,7 @@ func renderUpgradeReady(b *strings.Builder, results []update.UpdateResult) strin
 	return b.String()
 }
 
-func renderUpgradeResult(b *strings.Builder, report *upgrade.UpgradeReport) string {
+func renderUpgradeResult(b *strings.Builder, report *upgrade.UpgradeReport, width int) string {
 	if len(report.Results) == 0 {
 		b.WriteString("  " + styles.SuccessStyle.Render("✓ All tools are up to date"))
 		b.WriteString("\n\n")
@@ -147,7 +154,7 @@ func renderUpgradeResult(b *strings.Builder, report *upgrade.UpgradeReport) stri
 			line := r.ToolName + "  " + styles.SubtextStyle.Render("(skipped)")
 			b.WriteString("  " + styles.SubtextStyle.Render("-") + "  " + styles.SubtextStyle.Render(line))
 			if r.ManualHint != "" {
-				writeManualHint(b, r.ManualHint)
+				writeManualHint(b, r.ManualHint, width)
 			}
 		}
 		b.WriteString("\n")
@@ -188,15 +195,30 @@ func renderUpgradeResult(b *strings.Builder, report *upgrade.UpgradeReport) stri
 }
 
 // writeManualHint renders a ManualHint to the builder.
-// Hints longer than 80 chars that contain ": " are split so the command
+// Hints longer than 80 runes that contain ": " are split so the command
 // appears on its own line and remains visible on narrow terminals.
-func writeManualHint(b *strings.Builder, hint string) {
+func writeManualHint(b *strings.Builder, hint string, width int) {
 	const indent = "     "
-	if idx := strings.LastIndex(hint, ": "); idx >= 0 && len(hint) > 80 {
+	const commandIndent = indent + "  "
+
+	if idx := strings.Index(hint, ": "); idx >= 0 && utf8.RuneCountInString(hint) > 80 {
 		b.WriteString("\n" + indent + styles.SubtextStyle.Render(hint[:idx+1]))
-		b.WriteString("\n" + indent + "  " + styles.SubtextStyle.Render(hint[idx+2:]))
-	} else {
-		b.WriteString("\n" + indent + styles.SubtextStyle.Render(hint))
+		writeWrappedManualHintLine(b, commandIndent, hint[idx+2:], width)
+		return
+	}
+
+	writeWrappedManualHintLine(b, indent, hint, width)
+}
+
+func writeWrappedManualHintLine(b *strings.Builder, indent string, text string, width int) {
+	availableWidth := width - len(indent)
+	if width <= 0 || availableWidth <= 0 {
+		b.WriteString("\n" + indent + styles.SubtextStyle.Render(text))
+		return
+	}
+
+	for _, line := range wrapPlainLine(text, availableWidth) {
+		b.WriteString("\n" + indent + styles.SubtextStyle.Render(line))
 	}
 }
 

--- a/internal/tui/screens/upgrade.go
+++ b/internal/tui/screens/upgrade.go
@@ -147,7 +147,7 @@ func renderUpgradeResult(b *strings.Builder, report *upgrade.UpgradeReport) stri
 			line := r.ToolName + "  " + styles.SubtextStyle.Render("(skipped)")
 			b.WriteString("  " + styles.SubtextStyle.Render("-") + "  " + styles.SubtextStyle.Render(line))
 			if r.ManualHint != "" {
-				b.WriteString("\n     " + styles.SubtextStyle.Render(r.ManualHint))
+				writeManualHint(b, r.ManualHint)
 			}
 		}
 		b.WriteString("\n")
@@ -185,6 +185,19 @@ func renderUpgradeResult(b *strings.Builder, report *upgrade.UpgradeReport) stri
 	b.WriteString(styles.HelpStyle.Render("enter: return • esc: back • q: quit"))
 
 	return b.String()
+}
+
+// writeManualHint renders a ManualHint to the builder.
+// Hints longer than 80 chars that contain ": " are split so the command
+// appears on its own line and remains visible on narrow terminals.
+func writeManualHint(b *strings.Builder, hint string) {
+	const indent = "     "
+	if idx := strings.LastIndex(hint, ": "); idx >= 0 && len(hint) > 80 {
+		b.WriteString("\n" + indent + styles.SubtextStyle.Render(hint[:idx+1]))
+		b.WriteString("\n" + indent + "  " + styles.SubtextStyle.Render(hint[idx+2:]))
+	} else {
+		b.WriteString("\n" + indent + styles.SubtextStyle.Render(hint))
+	}
 }
 
 func reportUpgradedGentleAI(report *upgrade.UpgradeReport) bool {

--- a/internal/tui/screens/upgrade_sync.go
+++ b/internal/tui/screens/upgrade_sync.go
@@ -17,6 +17,12 @@ import (
 //  3. !operationRunning && (upgradeReport != nil || upgradeErr != nil) → show combined results
 //  4. Otherwise → show confirmation screen
 func RenderUpgradeSync(results []update.UpdateResult, upgradeReport *upgrade.UpgradeReport, syncFiles []string, upgradeErr error, syncErr error, operationRunning bool, updateCheckDone bool, cursor int, spinnerFrame int) string {
+	return RenderUpgradeSyncWithWidth(results, upgradeReport, syncFiles, upgradeErr, syncErr, operationRunning, updateCheckDone, cursor, spinnerFrame, 0)
+}
+
+// RenderUpgradeSyncWithWidth handles all states of the combined upgrade+sync
+// screen, constraining long manual hints to the terminal width when width is known.
+func RenderUpgradeSyncWithWidth(results []update.UpdateResult, upgradeReport *upgrade.UpgradeReport, syncFiles []string, upgradeErr error, syncErr error, operationRunning bool, updateCheckDone bool, cursor int, spinnerFrame int, width int) string {
 	var b strings.Builder
 
 	b.WriteString(styles.TitleStyle.Render("Upgrade + Sync"))
@@ -51,7 +57,7 @@ func RenderUpgradeSync(results []update.UpdateResult, upgradeReport *upgrade.Upg
 	// State 3: both operations done — show combined results
 	// Triggered when not running and either upgrade report or upgrade error is present.
 	if !operationRunning && (upgradeReport != nil || upgradeErr != nil) {
-		b.WriteString(renderUpgradeSyncResult(upgradeReport, syncFiles, upgradeErr, syncErr))
+		b.WriteString(renderUpgradeSyncResult(upgradeReport, syncFiles, upgradeErr, syncErr, width))
 		return b.String()
 	}
 
@@ -107,7 +113,7 @@ func renderUpgradeSyncConfirm(results []update.UpdateResult, updateCheckDone boo
 	return b.String()
 }
 
-func renderUpgradeSyncResult(report *upgrade.UpgradeReport, syncFiles []string, upgradeErr error, syncErr error) string {
+func renderUpgradeSyncResult(report *upgrade.UpgradeReport, syncFiles []string, upgradeErr error, syncErr error, width int) string {
 	var b strings.Builder
 
 	// --- Upgrade section ---
@@ -145,7 +151,7 @@ func renderUpgradeSyncResult(report *upgrade.UpgradeReport, syncFiles []string, 
 				upgradeSkipped++
 				b.WriteString("  " + styles.SubtextStyle.Render("-") + "  " + styles.SubtextStyle.Render(r.ToolName+" (skipped)"))
 				if r.ManualHint != "" {
-					writeManualHint(&b, r.ManualHint)
+					writeManualHint(&b, r.ManualHint, width)
 				}
 			}
 			b.WriteString("\n")

--- a/internal/tui/screens/upgrade_sync.go
+++ b/internal/tui/screens/upgrade_sync.go
@@ -143,11 +143,10 @@ func renderUpgradeSyncResult(report *upgrade.UpgradeReport, syncFiles []string, 
 				}
 			case upgrade.UpgradeSkipped:
 				upgradeSkipped++
-				hint := ""
+				b.WriteString("  " + styles.SubtextStyle.Render("-") + "  " + styles.SubtextStyle.Render(r.ToolName+" (skipped)"))
 				if r.ManualHint != "" {
-					hint = "  " + styles.SubtextStyle.Render(r.ManualHint)
+					writeManualHint(&b, r.ManualHint)
 				}
-				b.WriteString("  " + styles.SubtextStyle.Render("-") + "  " + styles.SubtextStyle.Render(r.ToolName+" (skipped)") + hint)
 			}
 			b.WriteString("\n")
 		}

--- a/internal/tui/screens/upgrade_sync_test.go
+++ b/internal/tui/screens/upgrade_sync_test.go
@@ -97,6 +97,37 @@ func TestRenderUpgradeSync_CombinedResult(t *testing.T) {
 	}
 }
 
+func TestRenderUpgradeSync_LongManualHintUsesWidth(t *testing.T) {
+	longHint := `upgrade "gentle-ai" on Windows requires manual update: irm https://raw.githubusercontent.com/Gentleman-Programming/gentle-ai/main/scripts/install.ps1 | iex`
+	report := &upgrade.UpgradeReport{Results: []upgrade.ToolUpgradeResult{
+		{ToolName: "gentle-ai", Status: upgrade.UpgradeSkipped, ManualHint: longHint},
+	}}
+
+	out := stripANSI(RenderUpgradeSyncWithWidth(nil, report, nil, nil, nil, false, true, 0, 0, 80))
+	lines := strings.Split(out, "\n")
+	for i, line := range lines {
+		if !strings.Contains(line, "requires manual update:") {
+			continue
+		}
+		if i+1 >= len(lines) || !strings.Contains(lines[i+1], "irm") {
+			t.Fatalf("hint command should start on the line after the preamble; got:\n%s", out)
+		}
+		if !strings.Contains(out, "install.ps1") || !strings.Contains(out, "| iex") {
+			t.Fatalf("full manual command should remain visible; got:\n%s", out)
+		}
+		for _, wrapped := range lines[i+1:] {
+			if strings.TrimSpace(wrapped) == "" {
+				return
+			}
+			if len(wrapped) > 80 {
+				t.Fatalf("manual hint line exceeds terminal width: len=%d line=%q\noutput:\n%s", len(wrapped), wrapped, out)
+			}
+		}
+		return
+	}
+	t.Fatalf("hint preamble should appear in output; got:\n%s", out)
+}
+
 func TestRenderUpgradeSync_SkipsSyncWhenGentleAIUpgraded(t *testing.T) {
 	report := &upgrade.UpgradeReport{Results: []upgrade.ToolUpgradeResult{
 		{ToolName: "gentle-ai", OldVersion: "v1.36.1", NewVersion: "v1.36.2", Status: upgrade.UpgradeSucceeded},

--- a/internal/tui/screens/upgrade_test.go
+++ b/internal/tui/screens/upgrade_test.go
@@ -2,6 +2,7 @@ package screens
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -144,19 +145,38 @@ func TestRenderUpgrade_LongManualHintSplitsAcrossLines(t *testing.T) {
 		},
 	}
 
-	out := RenderUpgrade(nil, report, nil, false, true, 0, 0)
+	out := stripANSI(RenderUpgradeWithWidth(nil, report, nil, false, true, 0, 0, 80))
+	lines := strings.Split(out, "\n")
 
-	if !strings.Contains(out, "requires manual update:") {
-		t.Errorf("hint preamble should appear in output; got:\n%s", out)
+	preambleIndex := -1
+	for i, line := range lines {
+		if strings.Contains(line, "requires manual update:") {
+			preambleIndex = i
+			break
+		}
 	}
-	if !strings.Contains(out, "irm https://") {
-		t.Errorf("hint command should appear in output; got:\n%s", out)
+	if preambleIndex == -1 {
+		t.Fatalf("hint preamble should appear in output; got:\n%s", out)
 	}
-	// Both parts must be present on separate lines — verify the preamble ends with ":"
-	// and the command starts on its own indented line.
-	if !strings.Contains(out, "manual update:\n") {
-		t.Errorf("preamble should end with colon followed by newline (split layout); got:\n%s", out)
+	if preambleIndex+1 >= len(lines) || !strings.Contains(lines[preambleIndex+1], "irm") {
+		t.Fatalf("hint command should start on the line after the preamble; got:\n%s", out)
 	}
+	if !strings.Contains(out, "install.ps1") || !strings.Contains(out, "| iex") {
+		t.Fatalf("full manual command should remain visible; got:\n%s", out)
+	}
+	for _, line := range lines[preambleIndex+1:] {
+		if strings.TrimSpace(line) == "" {
+			break
+		}
+		if len(line) > 80 {
+			t.Fatalf("manual hint line exceeds terminal width: len=%d line=%q\noutput:\n%s", len(line), line, out)
+		}
+	}
+}
+
+func stripANSI(s string) string {
+	ansiPattern := regexp.MustCompile(`\x1b\[[0-9;]*[A-Za-z]`)
+	return ansiPattern.ReplaceAllString(s, "")
 }
 
 // TestRenderUpgrade_TitleAlwaysPresent verifies that the "Upgrade Tools" title

--- a/internal/tui/screens/upgrade_test.go
+++ b/internal/tui/screens/upgrade_test.go
@@ -127,6 +127,38 @@ func TestRenderUpgrade_ErrorState(t *testing.T) {
 	}
 }
 
+// TestRenderUpgrade_LongManualHintSplitsAcrossLines verifies that a long ManualHint
+// containing ": " is split so the command appears on its own line and is not clipped
+// by BubbleTea at the terminal width.
+func TestRenderUpgrade_LongManualHintSplitsAcrossLines(t *testing.T) {
+	longHint := `upgrade "gentle-ai" on Windows requires manual update: irm https://raw.githubusercontent.com/Gentleman-Programming/gentle-ai/main/scripts/install.ps1 | iex`
+	report := &upgrade.UpgradeReport{
+		Results: []upgrade.ToolUpgradeResult{
+			{
+				ToolName:   "gentle-ai",
+				OldVersion: "v1.0.0",
+				NewVersion: "v1.1.0",
+				Status:     upgrade.UpgradeSkipped,
+				ManualHint: longHint,
+			},
+		},
+	}
+
+	out := RenderUpgrade(nil, report, nil, false, true, 0, 0)
+
+	if !strings.Contains(out, "requires manual update:") {
+		t.Errorf("hint preamble should appear in output; got:\n%s", out)
+	}
+	if !strings.Contains(out, "irm https://") {
+		t.Errorf("hint command should appear in output; got:\n%s", out)
+	}
+	// Both parts must be present on separate lines — verify the preamble ends with ":"
+	// and the command starts on its own indented line.
+	if !strings.Contains(out, "manual update:\n") {
+		t.Errorf("preamble should end with colon followed by newline (split layout); got:\n%s", out)
+	}
+}
+
 // TestRenderUpgrade_TitleAlwaysPresent verifies that the "Upgrade Tools" title
 // is always present regardless of state.
 func TestRenderUpgrade_TitleAlwaysPresent(t *testing.T) {


### PR DESCRIPTION
Closes #953

## Type of change
- [x] Bug fix

## Summary
- BubbleTea clips lines at terminal width — it does NOT wrap. The Windows manual update hint (~163 chars) was invisible past ~120 chars, hiding the PowerShell command the user needs to run.
- Added `writeManualHint` helper: hints >80 chars with `": "` separator are split so the command appears on its own indented line.
- Applied to both `ScreenUpgrade` and `ScreenUpgradeSync` result views.

## Changes

| File | Change |
|------|--------|
| `internal/tui/screens/upgrade.go` | Added `writeManualHint` helper, used in `renderUpgradeResult` |
| `internal/tui/screens/upgrade_sync.go` | Used `writeManualHint` in `renderUpgradeSyncResult` |
| `internal/tui/screens/upgrade_test.go` | Added regression test for long hint split layout |

## Test plan
- [x] `go test ./internal/tui/screens/...` passes
- [x] New test `TestRenderUpgrade_LongManualHintSplitsAcrossLines` validates the split behavior
- [x] Manually traced the hint rendering for the Windows install command

## Contributor Checklist
- [x] Linked issue #953
- [x] Conventional commit format
- [x] No shell scripts modified (shellcheck N/A)
- [x] No `Co-Authored-By` trailers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved upgrade screen rendering for narrow terminals by making manual update hints width-aware, with consistent indentation and cleaner line wrapping.
  * Skipped-tool upgrade results now display manual update instructions in a clearer, more readable multi-line format.
* **Tests**
  * Added unit tests to verify long manual hints split correctly across lines and respect the specified terminal width (including ANSI-stripped output checks).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->