### PR TITLE
fix(engram): canonicalize go install module casing

### DIFF
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -332,9 +332,10 @@ func goInstallBinDirFromGoEnv() (string, error) {
 	return "", fmt.Errorf("go env returned empty GOBIN and GOPATH")
 }
 
+const engramBetaGoInstallPackage = "github.com/Gentleman-Programming/engram/cmd/engram@main"
+
 func installBetaEngramFromMain() (string, error) {
-	const pkg = "github.com/Gentleman-Programming/engram/cmd/engram@main"
-	if err := runCommand("go", "install", pkg); err != nil {
+	if err := runCommand("go", "install", engramBetaGoInstallPackage); err != nil {
 		return "", err
 	}
 

--- a/internal/components/engram/download.go
+++ b/internal/components/engram/download.go
@@ -23,9 +23,11 @@ import (
 )
 
 const (
-	engramOwner = "Gentleman-Programming"
-	engramRepo  = "engram"
-	engramName  = "engram"
+	engramOwner            = "Gentleman-Programming"
+	engramRepo             = "engram"
+	engramName             = "engram"
+	engramCanonicalModule  = "github.com/Gentleman-Programming/engram"
+	engramCanonicalPackage = engramCanonicalModule + "/cmd/engram"
 )
 
 // Package-level vars for testability.
@@ -43,7 +45,7 @@ var (
 	// engramGoInstallCmdFn executes `go install <pkg>`. Package-level var for testability.
 	engramGoInstallCmdFn = func(pkg string) error {
 		cmd := exec.Command("go", "install", pkg)
-		cmd.Env = goPrivateModuleEnv(os.Environ(), "github.com/Gentleman-Programming/engram")
+		cmd.Env = goPrivateModuleEnv(os.Environ(), engramCanonicalModule)
 		cmd.Stdin = nil
 		out, err := cmd.CombinedOutput()
 		if err != nil {
@@ -110,6 +112,14 @@ func appendGoEnvPattern(required, existing string) string {
 	return existing + "," + required
 }
 
+func canonicalEngramGoInstallPackage(pkg string) string {
+	const lowerPackage = "github.com/gentleman-programming/engram/cmd/engram"
+	if strings.HasPrefix(strings.ToLower(pkg), lowerPackage) {
+		return engramCanonicalPackage + pkg[len(lowerPackage):]
+	}
+	return pkg
+}
+
 // engramCoreTagPattern matches only plain semver tags (vX.Y.Z) that identify
 // core engram binary releases. The Gentleman-Programming/engram repository also
 // publishes gentle-engram npm and pi releases under tags like
@@ -137,8 +147,7 @@ func DownloadLatestBinary(profile system.PlatformProfile, isBeta bool) (string, 
 	// Beta channel: install from HEAD via go install rather than a release archive.
 	// This mirrors the installBetaEngramFromMain path used at install time.
 	if isBeta {
-		const pkg = "github.com/Gentleman-Programming/engram/cmd/engram@main"
-		return engramGoInstallFn(pkg)
+		return engramGoInstallFn(engramCanonicalPackage + "@main")
 	}
 
 	ctx := context.Background()
@@ -791,7 +800,7 @@ func (b *byteReaderAt) ReadAt(p []byte, off int64) (int, error) {
 }
 
 // engramGoInstallFromMain installs engram from the given Go package path (expected
-// to be "github.com/Gentleman-Programming/engram/cmd/engram@main") using `go install`.
+// to be engramCanonicalPackage + "@main") using `go install`.
 // It returns the path to the installed binary. This is the beta-channel upgrade path.
 //
 // The install directory is resolved via `go env GOBIN GOPATH` (the effective Go
@@ -799,6 +808,7 @@ func (b *byteReaderAt) ReadAt(p []byte, off int64) (int, error) {
 // file, NOT in shell env) are honored correctly. This mirrors the resolution done
 // by goInstallBinDirFromGoEnv in internal/cli/run.go.
 func engramGoInstallFromMain(pkg string) (string, error) {
+	pkg = canonicalEngramGoInstallPackage(pkg)
 	if err := engramGoInstallCmdFn(pkg); err != nil {
 		return "", err
 	}

--- a/internal/components/engram/download_test.go
+++ b/internal/components/engram/download_test.go
@@ -1166,6 +1166,68 @@ func TestDownloadLatestBinary_BetaChannelUsesGoInstallMain(t *testing.T) {
 	}
 }
 
+func TestCanonicalEngramGoInstallPackagePreservesDeclaredModuleCasing(t *testing.T) {
+	tests := []struct {
+		name string
+		pkg  string
+		want string
+	}{
+		{
+			name: "lowercase owner is canonicalized",
+			pkg:  "github.com/gentleman-programming/engram/cmd/engram@main",
+			want: "github.com/Gentleman-Programming/engram/cmd/engram@main",
+		},
+		{
+			name: "canonical owner remains unchanged",
+			pkg:  "github.com/Gentleman-Programming/engram/cmd/engram@v1.2.3",
+			want: "github.com/Gentleman-Programming/engram/cmd/engram@v1.2.3",
+		},
+		{
+			name: "unrelated package remains unchanged",
+			pkg:  "github.com/gentleman-programming/gentle-ai/cmd/gentle-ai@latest",
+			want: "github.com/gentleman-programming/gentle-ai/cmd/gentle-ai@latest",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := canonicalEngramGoInstallPackage(tt.pkg); got != tt.want {
+				t.Fatalf("canonicalEngramGoInstallPackage(%q) = %q, want %q", tt.pkg, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEngramGoInstallFromMainCanonicalizesModuleCasing(t *testing.T) {
+	const fakeInstallDir = "/custom/gobin"
+
+	origGoInstallCmdFn := engramGoInstallCmdFn
+	origGoEnvFn := engramGoEnvFn
+	t.Cleanup(func() {
+		engramGoInstallCmdFn = origGoInstallCmdFn
+		engramGoEnvFn = origGoEnvFn
+	})
+
+	var gotPkg string
+	engramGoInstallCmdFn = func(pkg string) error {
+		gotPkg = pkg
+		return nil
+	}
+	engramGoEnvFn = func(keys ...string) (map[string]string, error) {
+		return map[string]string{"GOBIN": fakeInstallDir, "GOPATH": ""}, nil
+	}
+
+	_, err := engramGoInstallFromMain("github.com/gentleman-programming/engram/cmd/engram@main")
+	if err != nil {
+		t.Fatalf("engramGoInstallFromMain: unexpected error: %v", err)
+	}
+
+	wantPkg := "github.com/Gentleman-Programming/engram/cmd/engram@main"
+	if gotPkg != wantPkg {
+		t.Fatalf("go install package = %q, want %q", gotPkg, wantPkg)
+	}
+}
+
 // TestEngramGoInstallFromMain_UsesGoEnvForBinDir verifies that
 // engramGoInstallFromMain resolves the install directory via `go env GOBIN GOPATH`
 // (the effective Go environment) rather than reading raw shell env vars.


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #940

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Canonicalize Engram `go install` package paths to match the module-declared casing.
- Reuse canonical Engram module/package constants for beta/source install paths.
- Add regression coverage for lowercase Engram module inputs.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/components/engram/download.go` | Added canonical Engram module/package constants and normalization. |
| `internal/components/engram/download_test.go` | Added casing regression tests. |
| `internal/cli/run.go` | Uses canonical Engram Go package path for source install. |

---

## 🧪 Test Plan

**Unit Tests**
```bash
env -u GENTLE_AI_CHANNEL go test ./internal/components/engram
env -u GENTLE_AI_CHANNEL go test ./internal/installcmd
env -u GENTLE_AI_CHANNEL go test ./internal/update/upgrade ./internal/update
```

- [x] Unit tests pass for affected packages
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [ ] Manually tested locally

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass for affected packages
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [ ] I have updated documentation if necessary
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

Targeted Engram CLI install tests passed in the worker run. Broader `internal/cli` had unrelated local npm/tooling assumptions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved beta installation reliability by normalizing package path casing during install.
  * Updated installation settings to use a consistent module path, reducing failures caused by case-sensitive path differences.
  * Beta upgrades now resolve the latest binary more predictably when installing from the main branch.
* **Tests**
  * Added coverage for package path casing behavior in the beta install flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->