### PR TITLE
fix(tests): avoid Windows User PATH registry writes

### DIFF
--- a/internal/system/path.go
+++ b/internal/system/path.go
@@ -1,6 +1,7 @@
 package system
 
 import (
+	"flag"
 	"fmt"
 	"os"
 	"os/exec"
@@ -19,6 +20,12 @@ import (
 func AddToUserPath(dir string) error {
 	if runtime.GOOS != "windows" {
 		// Still add to the current process PATH on non-Windows (harmless for callers).
+		return addToProcessPath(dir)
+	}
+	if runningInGoTest() {
+		// Go tests must not mutate the real Windows user PATH registry. Keep the
+		// test process behavior identical for callers that need the new directory
+		// available later in the same run.
 		return addToProcessPath(dir)
 	}
 
@@ -65,7 +72,7 @@ func PrioritizeUserPath(dir string) error {
 	if err := prioritizeProcessPath(dir); err != nil {
 		return err
 	}
-	if runtime.GOOS != "windows" {
+	if runtime.GOOS != "windows" || runningInGoTest() {
 		return nil
 	}
 
@@ -103,6 +110,10 @@ func splitWindowsPath(value string) []string {
 		return nil
 	}
 	return strings.Split(value, ";")
+}
+
+func runningInGoTest() bool {
+	return flag.Lookup("test.v") != nil
 }
 
 // escapePowerShellString escapes a string for safe use inside a PowerShell

--- a/internal/system/path_test.go
+++ b/internal/system/path_test.go
@@ -85,6 +85,49 @@ func TestAddToUserPathNoOpOnNonWindows(t *testing.T) {
 	}
 }
 
+func TestAddToUserPathUsesProcessPathInGoTests(t *testing.T) {
+	if !runningInGoTest() {
+		t.Fatal("runningInGoTest() = false in go test binary")
+	}
+
+	targetDir := filepath.Join(t.TempDir(), "test-bin")
+	original := os.Getenv("PATH")
+	t.Cleanup(func() { os.Setenv("PATH", original) })
+
+	os.Setenv("PATH", strings.ReplaceAll(original, targetDir, ""))
+
+	if err := AddToUserPath(targetDir); err != nil {
+		t.Fatalf("AddToUserPath() error = %v", err)
+	}
+
+	entries := filepath.SplitList(os.Getenv("PATH"))
+	if len(entries) == 0 || !strings.EqualFold(filepath.Clean(entries[0]), filepath.Clean(targetDir)) {
+		t.Fatalf("PATH first entry = %q, want %q; full PATH=%q", entries, targetDir, os.Getenv("PATH"))
+	}
+}
+
+func TestPrioritizeUserPathUsesProcessPathInGoTests(t *testing.T) {
+	if !runningInGoTest() {
+		t.Fatal("runningInGoTest() = false in go test binary")
+	}
+
+	firstDir := filepath.Join(t.TempDir(), "first")
+	targetDir := filepath.Join(t.TempDir(), "target")
+	original := os.Getenv("PATH")
+	t.Cleanup(func() { os.Setenv("PATH", original) })
+
+	os.Setenv("PATH", strings.Join([]string{firstDir, targetDir}, string(os.PathListSeparator)))
+
+	if err := PrioritizeUserPath(targetDir); err != nil {
+		t.Fatalf("PrioritizeUserPath() error = %v", err)
+	}
+
+	entries := filepath.SplitList(os.Getenv("PATH"))
+	if len(entries) == 0 || !strings.EqualFold(filepath.Clean(entries[0]), filepath.Clean(targetDir)) {
+		t.Fatalf("PATH first entry = %q, want %q; full PATH=%q", entries, targetDir, os.Getenv("PATH"))
+	}
+}
+
 func TestPrioritizeProcessPathMovesExistingEntryToFront(t *testing.T) {
 	firstDir := filepath.Join(t.TempDir(), "first")
 	targetDir := filepath.Join(t.TempDir(), "target")


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #925

---

## 🏷️ PR Type

- [ ] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [x] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Prevent Go tests from writing temporary directories into the real Windows User PATH registry.
- Keep process-local PATH updates during tests so same-process installer behavior remains covered.
- Add focused tests for test-time PATH persistence isolation.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/system/path.go` | Skips persistent Windows User PATH writes when running under `go test`. |
| `internal/system/path_test.go` | Adds regression coverage for process-only PATH updates in tests. |

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./internal/system
```

- [x] Unit tests pass for affected package
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [ ] Manually tested locally

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass for affected package
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [ ] I have updated documentation if necessary
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

Production behavior is unchanged outside Go test binaries. The goal is to prevent test runs from mutating the real Windows User PATH registry.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PATH handling during test runs so changes stay process-local and do not update the Windows user PATH permanently.
  * Ensured PATH prioritization behaves consistently in tests on Windows as well as other platforms.

* **Tests**
  * Added coverage for PATH updates and prioritization when running under the Go test runner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->