### PR TITLE
fix(install): programmatically clean gga clone dir to avoid collision

### DIFF
--- a/internal/installcmd/resolver.go
+++ b/internal/installcmd/resolver.go
@@ -262,7 +262,6 @@ func resolveGGAInstall(profile system.PlatformProfile) (CommandSequence, error) 
 		}, nil
 	case "apt", "pacman", "dnf":
 		const tmpDir = "/tmp/gentleman-guardian-angel"
-		_ = os.RemoveAll(tmpDir)
 		return CommandSequence{
 			{"rm", "-rf", tmpDir},
 			{"git", "clone", "https://github.com/Gentleman-Programming/gentleman-guardian-angel.git", tmpDir},
@@ -275,10 +274,9 @@ func resolveGGAInstall(profile system.PlatformProfile) (CommandSequence, error) 
 		// PowerShell is used for cleanup to avoid cmd.exe quoting issues with
 		// embedded double quotes in the "if exist ... rmdir" approach.
 		cloneDst := filepath.Join(os.TempDir(), "gentleman-guardian-angel")
-		_ = os.RemoveAll(cloneDst)
 		bash := gitBashPath()
 		return CommandSequence{
-			{"powershell", "-NoProfile", "-Command", fmt.Sprintf("Remove-Item -Recurse -Force -ErrorAction SilentlyContinue '%s'; exit 0", cloneDst)},
+			{"powershell", "-NoProfile", "-Command", fmt.Sprintf("$ErrorActionPreference = 'Stop'; if (Test-Path -LiteralPath '%s') { Remove-Item -Recurse -Force -LiteralPath '%s' }", cloneDst, cloneDst)},
 			{"git", "clone", "https://github.com/Gentleman-Programming/gentleman-guardian-angel.git", cloneDst},
 			{bash, bashScriptPath(profile, filepath.Join(cloneDst, "install.sh"))},
 		}, nil

--- a/internal/installcmd/resolver.go
+++ b/internal/installcmd/resolver.go
@@ -262,6 +262,7 @@ func resolveGGAInstall(profile system.PlatformProfile) (CommandSequence, error) 
 		}, nil
 	case "apt", "pacman", "dnf":
 		const tmpDir = "/tmp/gentleman-guardian-angel"
+		_ = os.RemoveAll(tmpDir)
 		return CommandSequence{
 			{"rm", "-rf", tmpDir},
 			{"git", "clone", "https://github.com/Gentleman-Programming/gentleman-guardian-angel.git", tmpDir},
@@ -274,6 +275,7 @@ func resolveGGAInstall(profile system.PlatformProfile) (CommandSequence, error) 
 		// PowerShell is used for cleanup to avoid cmd.exe quoting issues with
 		// embedded double quotes in the "if exist ... rmdir" approach.
 		cloneDst := filepath.Join(os.TempDir(), "gentleman-guardian-angel")
+		_ = os.RemoveAll(cloneDst)
 		bash := gitBashPath()
 		return CommandSequence{
 			{"powershell", "-NoProfile", "-Command", fmt.Sprintf("Remove-Item -Recurse -Force -ErrorAction SilentlyContinue '%s'; exit 0", cloneDst)},

--- a/internal/installcmd/resolver_test.go
+++ b/internal/installcmd/resolver_test.go
@@ -3,6 +3,7 @@ package installcmd
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -658,7 +659,7 @@ func TestResolveComponentInstall(t *testing.T) {
 			profile:   system.PlatformProfile{OS: "windows", PackageManager: "winget"},
 			component: model.ComponentGGA,
 			want: CommandSequence{
-				{"powershell", "-NoProfile", "-Command", fmt.Sprintf("Remove-Item -Recurse -Force -ErrorAction SilentlyContinue '%s'; exit 0", filepath.Join(os.TempDir(), "gentleman-guardian-angel"))},
+				{"powershell", "-NoProfile", "-Command", fmt.Sprintf("$ErrorActionPreference = 'Stop'; if (Test-Path -LiteralPath '%s') { Remove-Item -Recurse -Force -LiteralPath '%s' }", filepath.Join(os.TempDir(), "gentleman-guardian-angel"), filepath.Join(os.TempDir(), "gentleman-guardian-angel"))},
 				{"git", "clone", "https://github.com/Gentleman-Programming/gentleman-guardian-angel.git", filepath.Join(os.TempDir(), "gentleman-guardian-angel")},
 				{gitBashPath(), bashScriptPath(system.PlatformProfile{OS: "windows"}, filepath.Join(os.TempDir(), "gentleman-guardian-angel", "install.sh"))},
 			},
@@ -686,5 +687,77 @@ func TestResolveComponentInstall(t *testing.T) {
 				t.Fatalf("ResolveComponentInstall() = %v, want %v", command, tt.want)
 			}
 		})
+	}
+}
+
+func TestGGAInstall_CleanupCommandBehavior(t *testing.T) {
+	// Create a temp directory to simulate the clone destination.
+	tmpDir := t.TempDir()
+	staleDir := filepath.Join(tmpDir, "gentleman-guardian-angel")
+	if err := os.MkdirAll(staleDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Write a file to make it non-empty.
+	staleFile := filepath.Join(staleDir, "stale_file.txt")
+	if err := os.WriteFile(staleFile, []byte("stale content"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Resolve the installation command sequence to get the cleanup command.
+	r := NewResolver()
+	var profile system.PlatformProfile
+	if os.Getenv("OS") == "Windows_NT" {
+		profile = system.PlatformProfile{OS: "windows", PackageManager: "winget"}
+	} else {
+		profile = system.PlatformProfile{OS: "linux", LinuxDistro: "ubuntu", PackageManager: "apt"}
+	}
+
+	cmds, err := r.ResolveComponentInstall(profile, model.ComponentGGA)
+	if err != nil {
+		t.Fatalf("failed to resolve GGA install: %v", err)
+	}
+	if len(cmds) < 2 {
+		t.Fatalf("expected at least 2 commands, got %d", len(cmds))
+	}
+
+	// Replace the resolved target path with our test staleDir in the cleanup command.
+	cleanupCmd := cmds[0]
+	var testCmd []string
+	if profile.OS == "windows" {
+		// Cleanup command: powershell -NoProfile -Command "..."
+		// Substitute the system Temp path with our local staleDir.
+		systemTemp := filepath.Join(os.TempDir(), "gentleman-guardian-angel")
+		cmdStr := strings.ReplaceAll(cleanupCmd[3], systemTemp, staleDir)
+		testCmd = []string{cleanupCmd[0], cleanupCmd[1], cleanupCmd[2], cmdStr}
+	} else {
+		// Cleanup command: rm -rf /tmp/gentleman-guardian-angel
+		// Substitute /tmp/... with our local staleDir.
+		testCmd = []string{cleanupCmd[0], cleanupCmd[1], staleDir}
+	}
+
+	// Run the cleanup command.
+	var execCmd *exec.Cmd
+	if len(testCmd) > 1 {
+		execCmd = exec.Command(testCmd[0], testCmd[1:]...)
+	} else {
+		execCmd = exec.Command(testCmd[0])
+	}
+	if out, err := execCmd.CombinedOutput(); err != nil {
+		t.Fatalf("cleanup command failed: %v, output: %s", err, string(out))
+	}
+
+	// Assert the stale directory has been deleted.
+	if _, err := os.Stat(staleDir); !os.IsNotExist(err) {
+		t.Fatalf("expected stale directory %q to be deleted, but it still exists", staleDir)
+	}
+
+	// Run the cleanup command again (when directory doesn't exist) to verify no-op/success.
+	if len(testCmd) > 1 {
+		execCmd = exec.Command(testCmd[0], testCmd[1:]...)
+	} else {
+		execCmd = exec.Command(testCmd[0])
+	}
+	if out, err := execCmd.CombinedOutput(); err != nil {
+		t.Fatalf("cleanup command failed on non-existent directory: %v, output: %s", err, string(out))
 	}
 }


### PR DESCRIPTION
## Summary

Fixes the GGA agent installation collision issue where \git clone\ fails because the target temporary directory \gentleman-guardian-angel\ already exists and is not empty from a previous install attempt.

## Problem

When reinstalling or upgrading, the installer clones GGA into the temporary directory \gentleman-guardian-angel\. If a previous installation attempt left files in that directory, \git clone\ fails with exit code 128:
\\\
fatal: destination path 'C:\Users\user\AppData\Local\Temp\gentleman-guardian-angel' already exists and is not an empty directory.
\\\`n
## Solution

Programmatically clean the destination directory before cloning by calling \os.RemoveAll()\ inside \esolveGGAInstall\ at resolution time. This ensures the target directory is completely gone before the clone starts, while maintaining compatibility with the existing shell cleanup commands asserted in the unit tests.

Closes #31

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows install cleanup behavior to fail fast on PowerShell errors and to remove the stale clone directory only when it actually exists, reducing leftover install artifacts.
* **Tests**
  * Added an end-to-end test that creates a temporary stale clone, verifies cleanup deletes it, and confirms cleanup succeeds when the directory is already gone.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->