### PR TITLE
fix(pi): clean legacy subagent package entries

### DIFF
--- a/internal/agents/pi/adapter.go
+++ b/internal/agents/pi/adapter.go
@@ -26,6 +26,9 @@ const (
 	piSettingsFile              = "settings.json"
 	piNPMDirectory              = "npm"
 	piNPMPackageFile            = "package.json"
+	piSubagentsLegacyPackage    = "npm:pi-subagents"
+	piSubagentsLegacyVendor     = "vendor/pi-subagents"
+	piSubagentsLegacyFixed      = "vendor/pi-subagents-fixed"
 	piSubagentsJ0k3rPackageSpec = "npm:pi-subagents-j0k3r"
 )
 
@@ -223,12 +226,22 @@ func appendPiPackage(existing any, desired string) []any {
 	packages := piPackagesAsSlice(existing)
 	filtered := make([]any, 0, len(packages)+1)
 	for _, pkg := range packages {
-		if piPackageIdentity(pkg) == piMCPAdapterPackage {
+		identity := piPackageIdentity(pkg)
+		if identity == piMCPAdapterPackage || isLegacyPiSubagentsPackage(identity) {
 			continue
 		}
 		filtered = append(filtered, pkg)
 	}
 	return append(filtered, desired)
+}
+
+func isLegacyPiSubagentsPackage(source string) bool {
+	switch source {
+	case piSubagentsLegacyPackage, piSubagentsLegacyVendor, piSubagentsLegacyFixed:
+		return true
+	default:
+		return false
+	}
 }
 
 func piPackagesAsSlice(existing any) []any {

--- a/internal/agents/pi/adapter_test.go
+++ b/internal/agents/pi/adapter_test.go
@@ -211,3 +211,41 @@ func TestAdapterInstallCommandSequenceUsesPnpmForEngramInitWhenAvailable(t *test
 		t.Fatalf("InstallCommand()[3] = %#v, want %#v", commands[3], want)
 	}
 }
+
+func TestAppendPiPackageRemovesLegacyPiSubagentsEntries(t *testing.T) {
+	existing := []any{
+		"npm:pi-subagents",
+		"vendor/pi-subagents",
+		"vendor/pi-subagents-fixed",
+		"npm:pi-subagents-j0k3r",
+		"npm:pi-mcp-adapter",
+		"npm:gentle-pi",
+	}
+
+	got := appendPiPackage(existing, piMCPAdapterPackageSpec)
+	want := []any{
+		"npm:pi-subagents-j0k3r",
+		"npm:gentle-pi",
+		"npm:pi-mcp-adapter",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("appendPiPackage() = %#v, want %#v", got, want)
+	}
+}
+
+func TestAppendPiPackagePreservesUnrelatedPackages(t *testing.T) {
+	existing := []any{
+		"npm:gentle-pi",
+		"npm:pi-web-access",
+	}
+
+	got := appendPiPackage(existing, piMCPAdapterPackageSpec)
+	want := []any{
+		"npm:gentle-pi",
+		"npm:pi-web-access",
+		"npm:pi-mcp-adapter",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("appendPiPackage() = %#v, want %#v", got, want)
+	}
+}


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #971

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Removes legacy Pi subagent package entries during Pi settings normalization.
- Keeps the supported `npm:pi-subagents-j0k3r` package while preserving unrelated user packages.
- Adds regression tests and was validated locally via Gentle AI TUI `sync` followed by a successful `pi` startup.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/agents/pi/adapter.go` | Filter out legacy Pi subagent package entries (`npm:pi-subagents`, `vendor/pi-subagents`, `vendor/pi-subagents-fixed`) during package normalization. |
| `internal/agents/pi/adapter_test.go` | Added regression coverage for legacy cleanup and unrelated package preservation. |

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./...
```

**E2E Tests** (Docker required)
```bash
cd e2e && ./docker-test.sh
```

- [x] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Manually tested locally

Manual validation:
- Built the patched local `gentle-ai` binary.
- Ran the TUI and executed `sync`.
- Started `pi` successfully in an environment that previously failed with duplicate `subagent` tool registration.

---

## 🤖 Automated Checks

The following checks run automatically on this PR:

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | PR should stay within 400 changed lines (`additions + deletions`) or use `size:exception` |
| Check Issue Reference | ⏳ | PR body must contain `Closes/Fixes/Resolves #N` |
| Check Issue Has `status:approved` | ⏳ | Linked issue must have been approved before work began |
| Check PR Has `type:*` Label | ⏳ | Exactly one `type:*` label must be applied |
| Unit Tests | ⏳ | `go test ./...` must pass |
| E2E Tests | ⏳ | `cd e2e && ./docker-test.sh` must pass |

---

## ✅ Contributor Checklist

- [ ] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [ ] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [ ] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

This PR intentionally limits the fix to Pi package normalization so existing install/sync behavior stays unchanged except for removing legacy subagent entries that cause duplicate `subagent` tool conflicts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Legacy `pi-subagents` package entries are now removed when generating package lists, preventing outdated entries from being carried forward.
  * Package updates preserve unrelated existing packages while still appending the required Pi adapter package.
* **Tests**
  * Added coverage for removing legacy Pi package entries and for keeping unrelated packages intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->