### PR TITLE
feat(system): add NixOS support and nix package manager integration

### DIFF
--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -10,6 +10,7 @@
 | Linux (Ubuntu/Debian) | apt | Supported |
 | Linux (Arch) | pacman | Supported |
 | Linux (Fedora/RHEL family) | dnf | Supported |
+| Linux (NixOS) | nix | Supported |
 | Windows 10/11 | PowerShell installer | Supported |
 
 Derivatives are detected via `ID_LIKE` in `/etc/os-release` (Linux Mint, Pop!_OS, Manjaro, EndeavourOS, CentOS Stream, Rocky Linux, AlmaLinux, etc.).

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -376,8 +376,10 @@ func goInstallBinDirFromGoEnv() (string, error) {
 	if gobin := strings.TrimSpace(values["GOBIN"]); gobin != "" {
 		return gobin, nil
 	}
-	if gopath := strings.TrimSpace(values["GOPATH"]); gopath != "" {
-		return filepath.Join(gopath, "bin"), nil
+	for _, gopath := range filepath.SplitList(values["GOPATH"]) {
+		if gopath = strings.TrimSpace(gopath); gopath != "" {
+			return filepath.Join(gopath, "bin"), nil
+		}
 	}
 	return "", fmt.Errorf("go env returned empty GOBIN and GOPATH")
 }
@@ -931,14 +933,33 @@ func (s componentApplyStep) Run() error {
 			engramCommand = binaryPath
 		} else if installedPath, err := cmdLookPath("engram"); err != nil {
 			// Engram not on PATH — install it.
-			if s.profile.PackageManager == "brew" {
-				// macOS (or Linux with Homebrew): use brew tap + brew install.
+			if s.profile.PackageManager == "brew" || s.profile.PackageManager == "nix" {
+				// macOS/Brew or NixOS: use component resolver. NixOS installs from source via go install.
+				var nixBinDir string
+				var nixBinDirOnPath bool
+				if s.profile.PackageManager == "nix" {
+					nixBinDir, err = goInstallBinDirFromGoEnv()
+					if err != nil {
+						return fmt.Errorf("resolve go install bin dir: %w", err)
+					}
+					nixBinDirOnPath = pathEntriesContainDir(pathEnvEntries(s.profile), nixBinDir)
+				}
 				commands, err := engram.InstallCommand(s.profile)
 				if err != nil {
 					return fmt.Errorf("resolve install command for component %q: %w", s.component, err)
 				}
 				if err := runCommandSequence(commands); err != nil {
 					return err
+				}
+				if s.profile.PackageManager == "nix" {
+					if !nixBinDirOnPath {
+						return fmt.Errorf("Engram was installed in %s, but that directory is not on PATH for this shell or fresh shells; add %s to your persistent user PATH, start a new shell, and rerun gentle-ai install", nixBinDir, nixBinDir)
+					}
+					binaryName := "engram"
+					if runtime.GOOS == "windows" {
+						binaryName += ".exe"
+					}
+					engramCommand = filepath.Join(nixBinDir, binaryName)
 				}
 			} else {
 				// Linux / Windows: download the pre-built binary from GitHub Releases.

--- a/internal/cli/run_engram_download_test.go
+++ b/internal/cli/run_engram_download_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gentleman-programming/gentle-ai/internal/backup"
 	"github.com/gentleman-programming/gentle-ai/internal/components/engram"
 	"github.com/gentleman-programming/gentle-ai/internal/model"
 	"github.com/gentleman-programming/gentle-ai/internal/system"
@@ -674,6 +675,169 @@ func TestRunInstallBetaEngramUsesMainGoInstallAndInstalledBinary(t *testing.T) {
 	}
 	if probeCommand != betaEngram {
 		t.Fatalf("expected protocol probe to use beta engram binary %q, got %q", betaEngram, probeCommand)
+	}
+}
+
+// TestRunInstallNixOSEngramUsesGoInstall verifies NixOS uses go install.
+func TestRunInstallNixOSEngramUsesGoInstall(t *testing.T) {
+	home := t.TempDir()
+	restoreHome := osUserHomeDir
+	restoreBackupHome := backup.UserHomeDirFn
+	restoreCommand := runCommand
+	restoreLookPath := cmdLookPath
+	restoreGoEnv := goEnv
+	restorePathEntries := pathEnvEntries
+	t.Cleanup(func() {
+		osUserHomeDir = restoreHome
+		backup.UserHomeDirFn = restoreBackupHome
+		runCommand = restoreCommand
+		cmdLookPath = restoreLookPath
+		goEnv = restoreGoEnv
+		pathEnvEntries = restorePathEntries
+	})
+
+	osUserHomeDir = func() (string, error) { return home, nil }
+	backup.UserHomeDirFn = func() (string, error) { return home, nil }
+	cmdLookPath = missingBinaryLookPath
+	gobin := filepath.Join(home, "go-bin")
+	goEnv = func(keys ...string) (map[string]string, error) {
+		return map[string]string{"GOBIN": gobin, "GOPATH": filepath.Join(home, "go")}, nil
+	}
+	pathEnvEntries = func(system.PlatformProfile) []string { return []string{gobin} }
+	recorder := &commandRecorder{}
+	runCommand = recorder.record
+
+	// DownloadFn should NOT be called for NixOS (go install handles it).
+	origDownloadFn := engramDownloadFn
+	engramDownloadFn = func(profile system.PlatformProfile) (string, error) {
+		t.Error("DownloadLatestBinary should NOT be called on NixOS (go install handles it)")
+		return "", nil
+	}
+	t.Cleanup(func() { engramDownloadFn = origDownloadFn })
+
+	detection := linuxDetectionResult(system.LinuxDistroNixOS, "nix")
+	result, err := RunInstall(
+		[]string{"--agent", "opencode", "--component", "engram"},
+		detection,
+	)
+	if err != nil {
+		t.Fatalf("RunInstall() error = %v", err)
+	}
+	if !result.Verify.Ready {
+		t.Fatalf("verification ready = false")
+	}
+
+	// Must use go install.
+	commands := recorder.get()
+	foundGoInstall := false
+	for _, cmd := range commands {
+		if strings.Contains(cmd, "go install github.com/Gentleman-Programming/engram/cmd/engram@latest") {
+			foundGoInstall = true
+		}
+	}
+	if !foundGoInstall {
+		t.Fatalf("expected go install on NixOS, got commands: %v", commands)
+	}
+}
+
+func TestRunInstallNixOSEngramRequiresPersistentPathGuidance(t *testing.T) {
+	home := t.TempDir()
+	gobin := filepath.Join(home, "go-bin")
+	restoreHome, restoreBackupHome := osUserHomeDir, backup.UserHomeDirFn
+	restoreCommand, restoreLookPath := runCommand, cmdLookPath
+	restoreGoEnv, restorePathEntries := goEnv, pathEnvEntries
+	t.Cleanup(func() {
+		osUserHomeDir, backup.UserHomeDirFn = restoreHome, restoreBackupHome
+		runCommand, cmdLookPath = restoreCommand, restoreLookPath
+		goEnv, pathEnvEntries = restoreGoEnv, restorePathEntries
+	})
+	osUserHomeDir = func() (string, error) { return home, nil }
+	backup.UserHomeDirFn = func() (string, error) { return home, nil }
+	cmdLookPath = missingBinaryLookPath
+	goEnv = func(...string) (map[string]string, error) {
+		return map[string]string{"GOBIN": gobin}, nil
+	}
+	pathEnvEntries = func(system.PlatformProfile) []string { return []string{filepath.Join(home, "other-bin")} }
+	recorder := &commandRecorder{}
+	runCommand = recorder.record
+
+	result, err := RunInstall([]string{"--agent", "opencode", "--component", "engram"}, linuxDetectionResult(system.LinuxDistroNixOS, "nix"))
+	if err == nil || !strings.Contains(err.Error(), gobin) || !strings.Contains(err.Error(), "persistent user PATH") {
+		t.Fatalf("RunInstall() error = %v, want actionable PATH guidance for %q", err, gobin)
+	}
+	if result.Verify.Ready {
+		t.Fatal("installation requiring manual PATH action must not report ready")
+	}
+	if !strings.Contains(strings.Join(recorder.get(), "\n"), "go install github.com/Gentleman-Programming/engram/cmd/engram@latest") {
+		t.Fatalf("expected installation before PATH guidance, got %v", recorder.get())
+	}
+}
+
+func TestRunInstallNixOSEngramReportsGoEnvFailure(t *testing.T) {
+	restoreGoEnv := goEnv
+	t.Cleanup(func() {
+		goEnv = restoreGoEnv
+	})
+
+	goEnv = func(keys ...string) (map[string]string, error) {
+		return nil, os.ErrInvalid
+	}
+
+	_, err := goInstallBinDirFromGoEnv()
+	if err == nil || !strings.Contains(err.Error(), os.ErrInvalid.Error()) {
+		t.Fatalf("goInstallBinDirFromGoEnv() error = %v, want go env failure", err)
+	}
+}
+
+func TestGoInstallBinDirFromGoEnvGOPATH(t *testing.T) {
+	restoreGoEnv := goEnv
+	t.Cleanup(func() { goEnv = restoreGoEnv })
+
+	first := filepath.Join(t.TempDir(), "first")
+	second := filepath.Join(t.TempDir(), "second")
+	tests := []struct {
+		name    string
+		gopath  string
+		want    string
+		wantErr string
+	}{
+		{
+			name:   "uses first entry from platform-separated list",
+			gopath: first + string(os.PathListSeparator) + second,
+			want:   filepath.Join(first, "bin"),
+		},
+		{
+			name:   "skips empty entries",
+			gopath: string(os.PathListSeparator) + second,
+			want:   filepath.Join(second, "bin"),
+		},
+		{
+			name:    "rejects only empty entries",
+			gopath:  string(os.PathListSeparator),
+			wantErr: "go env returned empty GOBIN and GOPATH",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			goEnv = func(keys ...string) (map[string]string, error) {
+				return map[string]string{"GOBIN": "", "GOPATH": tt.gopath}, nil
+			}
+
+			got, err := goInstallBinDirFromGoEnv()
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("goInstallBinDirFromGoEnv() error = %v, want containing %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("goInstallBinDirFromGoEnv() error = %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("goInstallBinDirFromGoEnv() = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/cli/run_engram_download_test.go
+++ b/internal/cli/run_engram_download_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	opencodeagent "github.com/gentleman-programming/gentle-ai/internal/agents/opencode"
 	"github.com/gentleman-programming/gentle-ai/internal/backup"
 	"github.com/gentleman-programming/gentle-ai/internal/components/engram"
 	"github.com/gentleman-programming/gentle-ai/internal/model"
@@ -43,7 +44,7 @@ func TestRunInstallLinuxEngramUsesDownloadNotGoInstall(t *testing.T) {
 
 	detection := linuxDetectionResult(system.LinuxDistroUbuntu, "apt")
 	result, err := RunInstall(
-		[]string{"--agent", "opencode", "--component", "engram"},
+		[]string{"--agent", "cursor", "--component", "engram"},
 		detection,
 	)
 	if err != nil {
@@ -678,7 +679,6 @@ func TestRunInstallBetaEngramUsesMainGoInstallAndInstalledBinary(t *testing.T) {
 	}
 }
 
-// TestRunInstallNixOSEngramUsesGoInstall verifies NixOS uses go install.
 func TestRunInstallNixOSEngramUsesGoInstall(t *testing.T) {
 	home := t.TempDir()
 	restoreHome := osUserHomeDir
@@ -687,6 +687,8 @@ func TestRunInstallNixOSEngramUsesGoInstall(t *testing.T) {
 	restoreLookPath := cmdLookPath
 	restoreGoEnv := goEnv
 	restorePathEntries := pathEnvEntries
+	restoreOpenCodeLookPath := opencodeagent.LookPathOverride
+	restoreGGAAvailable := ggaAvailableCheck
 	t.Cleanup(func() {
 		osUserHomeDir = restoreHome
 		backup.UserHomeDirFn = restoreBackupHome
@@ -694,6 +696,8 @@ func TestRunInstallNixOSEngramUsesGoInstall(t *testing.T) {
 		cmdLookPath = restoreLookPath
 		goEnv = restoreGoEnv
 		pathEnvEntries = restorePathEntries
+		opencodeagent.LookPathOverride = restoreOpenCodeLookPath
+		ggaAvailableCheck = restoreGGAAvailable
 	})
 
 	osUserHomeDir = func() (string, error) { return home, nil }
@@ -704,10 +708,11 @@ func TestRunInstallNixOSEngramUsesGoInstall(t *testing.T) {
 		return map[string]string{"GOBIN": gobin, "GOPATH": filepath.Join(home, "go")}, nil
 	}
 	pathEnvEntries = func(system.PlatformProfile) []string { return []string{gobin} }
+	opencodeagent.LookPathOverride = missingBinaryLookPath
+	ggaAvailableCheck = func(system.PlatformProfile) bool { return false }
 	recorder := &commandRecorder{}
 	runCommand = recorder.record
 
-	// DownloadFn should NOT be called for NixOS (go install handles it).
 	origDownloadFn := engramDownloadFn
 	engramDownloadFn = func(profile system.PlatformProfile) (string, error) {
 		t.Error("DownloadLatestBinary should NOT be called on NixOS (go install handles it)")
@@ -717,7 +722,7 @@ func TestRunInstallNixOSEngramUsesGoInstall(t *testing.T) {
 
 	detection := linuxDetectionResult(system.LinuxDistroNixOS, "nix")
 	result, err := RunInstall(
-		[]string{"--agent", "opencode", "--component", "engram"},
+		[]string{"--agent", "opencode", "--component", "engram,gga"},
 		detection,
 	)
 	if err != nil {
@@ -727,16 +732,40 @@ func TestRunInstallNixOSEngramUsesGoInstall(t *testing.T) {
 		t.Fatalf("verification ready = false")
 	}
 
-	// Must use go install.
 	commands := recorder.get()
-	foundGoInstall := false
-	for _, cmd := range commands {
-		if strings.Contains(cmd, "go install github.com/Gentleman-Programming/engram/cmd/engram@latest") {
-			foundGoInstall = true
+	allCommands := strings.Join(commands, "\n")
+	for _, want := range []string{"nix profile install nixpkgs#opencode", "go install github.com/Gentleman-Programming/engram/cmd/engram@latest", "git clone https://github.com/Gentleman-Programming/gentleman-guardian-angel.git"} {
+		if !strings.Contains(allCommands, want) {
+			t.Fatalf("expected %q, got commands: %v", want, commands)
 		}
 	}
-	if !foundGoInstall {
-		t.Fatalf("expected go install on NixOS, got commands: %v", commands)
+}
+
+func TestRunInstallNixOSOpenCodeSkipsInstallWhenPresent(t *testing.T) {
+	restore := opencodeagent.LookPathOverride
+	t.Cleanup(func() { opencodeagent.LookPathOverride = restore })
+	opencodeagent.LookPathOverride = func(string) (string, error) { return "/nix/profile/bin/opencode", nil }
+	step := agentInstallStep{agent: model.AgentOpenCode, homeDir: t.TempDir(), profile: system.PlatformProfile{OS: "linux", LinuxDistro: system.LinuxDistroNixOS, PackageManager: "nix"}}
+	if err := step.Run(); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+}
+
+func TestRunInstallNixOSOpenCodeFailureStopsPipeline(t *testing.T) {
+	restoreLookPath, restoreCommand := opencodeagent.LookPathOverride, runCommand
+	t.Cleanup(func() { opencodeagent.LookPathOverride, runCommand = restoreLookPath, restoreCommand })
+	opencodeagent.LookPathOverride = missingBinaryLookPath
+	commands := 0
+	runCommand = func(name string, args ...string) error { commands++; return os.ErrPermission }
+	result, err := RunInstall([]string{"--agent", "opencode", "--component", "engram,gga"}, linuxDetectionResult(system.LinuxDistroNixOS, "nix"))
+	if err == nil || !strings.Contains(err.Error(), os.ErrPermission.Error()) {
+		t.Fatalf("RunInstall() error = %v, want command failure", err)
+	}
+	if result.Verify.Ready {
+		t.Fatal("failed OpenCode installation must not report ready")
+	}
+	if commands != 1 {
+		t.Fatalf("command count = %d, want only failed OpenCode install", commands)
 	}
 }
 
@@ -761,7 +790,7 @@ func TestRunInstallNixOSEngramRequiresPersistentPathGuidance(t *testing.T) {
 	recorder := &commandRecorder{}
 	runCommand = recorder.record
 
-	result, err := RunInstall([]string{"--agent", "opencode", "--component", "engram"}, linuxDetectionResult(system.LinuxDistroNixOS, "nix"))
+	result, err := RunInstall([]string{"--agent", "cursor", "--component", "engram"}, linuxDetectionResult(system.LinuxDistroNixOS, "nix"))
 	if err == nil || !strings.Contains(err.Error(), gobin) || !strings.Contains(err.Error(), "persistent user PATH") {
 		t.Fatalf("RunInstall() error = %v, want actionable PATH guidance for %q", err, gobin)
 	}

--- a/internal/components/gga/config_test.go
+++ b/internal/components/gga/config_test.go
@@ -3,6 +3,7 @@ package gga
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -120,6 +121,10 @@ func TestInjectWritesConfigAndAgents(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("APPDATA", filepath.Join(home, "AppData", "Roaming"))
 
+	if runtime.GOOS == "windows" {
+		t.Setenv("APPDATA", filepath.Join(home, "AppData", "Roaming"))
+	}
+
 	result, err := Inject(home, []model.AgentID{model.AgentClaudeCode})
 	if err != nil {
 		t.Fatalf("Inject() error = %v", err)
@@ -164,6 +169,10 @@ func TestInjectWritesConfigAndAgents(t *testing.T) {
 func TestInjectIsIdempotent(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("APPDATA", filepath.Join(home, "AppData", "Roaming"))
+
+	if runtime.GOOS == "windows" {
+		t.Setenv("APPDATA", filepath.Join(home, "AppData", "Roaming"))
+	}
 
 	first, err := Inject(home, []model.AgentID{model.AgentOpenCode})
 	if err != nil {

--- a/internal/components/gga/install_test.go
+++ b/internal/components/gga/install_test.go
@@ -101,6 +101,15 @@ func TestInstallCommandByProfile(t *testing.T) {
 			},
 		},
 		{
+			name:    "nixos uses git clone and install.sh",
+			profile: system.PlatformProfile{OS: "linux", LinuxDistro: system.LinuxDistroNixOS, PackageManager: "nix"},
+			want: [][]string{
+				{"rm", "-rf", "/tmp/gentleman-guardian-angel"},
+				{"git", "clone", "https://github.com/Gentleman-Programming/gentleman-guardian-angel.git", "/tmp/gentleman-guardian-angel"},
+				{"bash", "/tmp/gentleman-guardian-angel/install.sh"},
+			},
+		},
+		{
 			name: "unsupported package manager returns error",
 			profile: system.PlatformProfile{
 				OS:             "linux",

--- a/internal/installcmd/resolver.go
+++ b/internal/installcmd/resolver.go
@@ -260,7 +260,7 @@ func resolveGGAInstall(profile system.PlatformProfile) (CommandSequence, error) 
 			{"brew", "tap", "Gentleman-Programming/homebrew-tap"},
 			{"brew", "reinstall", "gga"},
 		}, nil
-	case "apt", "pacman", "dnf":
+	case "apt", "pacman", "dnf", "nix":
 		const tmpDir = "/tmp/gentleman-guardian-angel"
 		return CommandSequence{
 			{"rm", "-rf", tmpDir},
@@ -406,6 +406,15 @@ func resolveEngramInstall(profile system.PlatformProfile) (CommandSequence, erro
 		return CommandSequence{
 			{"brew", "tap", "Gentleman-Programming/homebrew-tap"},
 			{"brew", "install", "engram"},
+		}, nil
+	case "nix":
+		// NixOS requires installing from source via go install because pre-built release
+		// binaries fail to run natively due to hardcoded dynamic linker paths.
+		if err := validateGoForModuleInstall(profile); err != nil {
+			return nil, err
+		}
+		return CommandSequence{
+			{"go", "install", "github.com/Gentleman-Programming/engram/cmd/engram@latest"},
 		}, nil
 	default:
 		return nil, fmt.Errorf(

--- a/internal/installcmd/resolver.go
+++ b/internal/installcmd/resolver.go
@@ -242,6 +242,8 @@ func resolveOpenCodeInstall(profile system.PlatformProfile) (CommandSequence, er
 	case "winget":
 		// On Windows, npm global installs do not require sudo.
 		return CommandSequence{{"npm", "install", "-g", "--ignore-scripts", "opencode-ai@" + versions.OpenCode}}, nil
+	case "nix":
+		return CommandSequence{{"nix", "profile", "install", "nixpkgs#opencode"}}, nil
 	default:
 		return nil, fmt.Errorf(
 			"unsupported platform for opencode: os=%q distro=%q pm=%q",
@@ -408,8 +410,6 @@ func resolveEngramInstall(profile system.PlatformProfile) (CommandSequence, erro
 			{"brew", "install", "engram"},
 		}, nil
 	case "nix":
-		// NixOS requires installing from source via go install because pre-built release
-		// binaries fail to run natively due to hardcoded dynamic linker paths.
 		if err := validateGoForModuleInstall(profile); err != nil {
 			return nil, err
 		}

--- a/internal/installcmd/resolver_test.go
+++ b/internal/installcmd/resolver_test.go
@@ -375,6 +375,12 @@ func TestResolveAgentInstall(t *testing.T) {
 			want:    CommandSequence{{"npm", "install", "-g", "--ignore-scripts", "opencode-ai@" + versions.OpenCode}},
 		},
 		{
+			name:    "opencode on nix uses persistent profile install",
+			profile: system.PlatformProfile{OS: "linux", LinuxDistro: system.LinuxDistroNixOS, PackageManager: "nix"},
+			agent:   model.AgentOpenCode,
+			want:    CommandSequence{{"nix", "profile", "install", "nixpkgs#opencode"}},
+		},
+		{
 			name:    "claude-code on windows uses npm without sudo",
 			profile: system.PlatformProfile{OS: "windows", PackageManager: "winget", NpmWritable: true},
 			agent:   model.AgentClaudeCode,

--- a/internal/installcmd/resolver_test.go
+++ b/internal/installcmd/resolver_test.go
@@ -145,6 +145,20 @@ func TestResolveEngramBrewBypassesGoValidation(t *testing.T) {
 	}
 }
 
+func TestResolveEngramNixValidatesGo(t *testing.T) {
+	origLookPath := cmdLookPath
+	cmdLookPath = func(file string) (string, error) {
+		return "", fmt.Errorf("go not found")
+	}
+	t.Cleanup(func() { cmdLookPath = origLookPath })
+
+	profile := system.PlatformProfile{OS: "linux", LinuxDistro: system.LinuxDistroNixOS, PackageManager: "nix"}
+	_, err := resolveEngramInstall(profile)
+	if err == nil || !strings.Contains(err.Error(), "Go 1.24+ is required") {
+		t.Fatalf("resolveEngramInstall() error = %v, want actionable Go requirement", err)
+	}
+}
+
 func TestResolveDependencyInstall(t *testing.T) {
 	r := NewResolver()
 
@@ -614,6 +628,12 @@ func TestResolveComponentInstall(t *testing.T) {
 			wantErr:   true,
 		},
 		{
+			name:      "engram on nixos uses go install",
+			profile:   system.PlatformProfile{OS: "linux", LinuxDistro: system.LinuxDistroNixOS, PackageManager: "nix"},
+			component: model.ComponentEngram,
+			want:      CommandSequence{{"go", "install", "github.com/Gentleman-Programming/engram/cmd/engram@latest"}},
+		},
+		{
 			name:      "gga on darwin uses brew tap and reinstall",
 			profile:   system.PlatformProfile{OS: "darwin", PackageManager: "brew"},
 			component: model.ComponentGGA,
@@ -646,6 +666,16 @@ func TestResolveComponentInstall(t *testing.T) {
 			want: CommandSequence{
 				{"rm", "-rf", "/tmp/gentleman-guardian-angel"},
 				{"git", "clone", "--depth=1", "--branch", "v" + versions.GGAVersion, "https://github.com/Gentleman-Programming/gentleman-guardian-angel.git", "/tmp/gentleman-guardian-angel"},
+				{"bash", "/tmp/gentleman-guardian-angel/install.sh"},
+			},
+		},
+		{
+			name:      "gga on nixos uses git clone and install.sh",
+			profile:   system.PlatformProfile{OS: "linux", LinuxDistro: system.LinuxDistroNixOS, PackageManager: "nix"},
+			component: model.ComponentGGA,
+			want: CommandSequence{
+				{"rm", "-rf", "/tmp/gentleman-guardian-angel"},
+				{"git", "clone", "https://github.com/Gentleman-Programming/gentleman-guardian-angel.git", "/tmp/gentleman-guardian-angel"},
 				{"bash", "/tmp/gentleman-guardian-angel/install.sh"},
 			},
 		},

--- a/internal/installcmd/resolver_test.go
+++ b/internal/installcmd/resolver_test.go
@@ -681,7 +681,7 @@ func TestResolveComponentInstall(t *testing.T) {
 			component: model.ComponentGGA,
 			want: CommandSequence{
 				{"rm", "-rf", "/tmp/gentleman-guardian-angel"},
-				{"git", "clone", "https://github.com/Gentleman-Programming/gentleman-guardian-angel.git", "/tmp/gentleman-guardian-angel"},
+				{"git", "clone", "--depth=1", "--branch", "v" + versions.GGAVersion, "https://github.com/Gentleman-Programming/gentleman-guardian-angel.git", "/tmp/gentleman-guardian-angel"},
 				{"bash", "/tmp/gentleman-guardian-angel/install.sh"},
 			},
 		},

--- a/internal/system/detect.go
+++ b/internal/system/detect.go
@@ -31,6 +31,7 @@ const (
 	LinuxDistroDebian  = "debian"
 	LinuxDistroArch    = "arch"
 	LinuxDistroFedora  = "fedora"
+	LinuxDistroNixOS   = "nixos"
 )
 
 type DetectionResult struct {
@@ -39,6 +40,8 @@ type DetectionResult struct {
 	Configs      []ConfigState
 	Dependencies DependencyReport
 }
+
+var detectTools = DetectTools
 
 func IsSupportedOS(goos string) bool {
 	return goos == "darwin" || goos == "linux" || goos == "windows"
@@ -50,7 +53,7 @@ func Detect(ctx context.Context) (DetectionResult, error) {
 		return DetectionResult{}, err
 	}
 
-	tools := DetectTools(ctx, []string{"git", "curl", "brew", "node", "go"})
+	tools := detectTools(ctx, []string{"git", "curl", "brew", "nix", "node", "go"})
 	configs := ScanConfigs(homeDir)
 	osReleaseContent, _ := osReleaseContent(runtime.GOOS)
 
@@ -131,6 +134,13 @@ func resolvePlatformProfile(goos, linuxOSRelease string, tools map[string]ToolSt
 		distro := detectLinuxDistro(linuxOSRelease)
 		profile.LinuxDistro = distro
 
+		// NixOS should always resolve to nix, even if Homebrew is also installed.
+		if distro == LinuxDistroNixOS {
+			profile.PackageManager = "nix"
+			profile.Supported = true
+			return profile
+		}
+
 		// Check if brew is available on Linux
 		if brew, ok := tools["brew"]; ok && brew.Installed {
 			profile.PackageManager = "brew"
@@ -149,8 +159,13 @@ func resolvePlatformProfile(goos, linuxOSRelease string, tools map[string]ToolSt
 			profile.PackageManager = "dnf"
 			profile.Supported = true
 		default:
-			profile.PackageManager = ""
-			profile.Supported = false
+			if nix, ok := tools["nix"]; ok && nix.Installed {
+				profile.PackageManager = "nix"
+				profile.Supported = true
+			} else {
+				profile.PackageManager = ""
+				profile.Supported = false
+			}
 		}
 
 		return profile
@@ -188,6 +203,10 @@ func detectLinuxDistro(linuxOSRelease string) string {
 
 	id := fields["ID"]
 	idLike := fields["ID_LIKE"]
+
+	if isNixOSLike(id, idLike) {
+		return LinuxDistroNixOS
+	}
 
 	if isUbuntuLike(id, idLike) {
 		if id == LinuxDistroDebian {
@@ -242,6 +261,20 @@ func isFedoraLike(id, idLike string) bool {
 
 	for _, token := range strings.Fields(idLike) {
 		if token == LinuxDistroFedora || token == "rhel" || token == "centos" || token == "rocky" || token == "almalinux" || token == "nobara" {
+			return true
+		}
+	}
+
+	return false
+}
+
+func isNixOSLike(id, idLike string) bool {
+	if id == LinuxDistroNixOS {
+		return true
+	}
+
+	for _, token := range strings.Fields(idLike) {
+		if token == LinuxDistroNixOS {
 			return true
 		}
 	}

--- a/internal/system/detect_test.go
+++ b/internal/system/detect_test.go
@@ -1,6 +1,28 @@
 package system
 
-import "testing"
+import (
+	"context"
+	"slices"
+	"testing"
+)
+
+func TestDetectProbesNix(t *testing.T) {
+	restoreDetectTools := detectTools
+	t.Cleanup(func() { detectTools = restoreDetectTools })
+
+	var probed []string
+	detectTools = func(_ context.Context, names []string) map[string]ToolStatus {
+		probed = append([]string(nil), names...)
+		return map[string]ToolStatus{}
+	}
+
+	if _, err := Detect(context.Background()); err != nil {
+		t.Fatalf("Detect() error = %v", err)
+	}
+	if !slices.Contains(probed, "nix") {
+		t.Fatalf("Detect() probed tools = %v, want nix", probed)
+	}
+}
 
 func TestIsSupportedOS(t *testing.T) {
 	tests := []struct {
@@ -90,6 +112,81 @@ func TestDetectFromInputsMarksArchSupported(t *testing.T) {
 	}
 }
 
+func TestDetectFromInputsMarksNixOSSupported(t *testing.T) {
+	osRelease := "ID=nixos\n"
+	result := detectFromInputs("linux", "amd64", "/bin/bash", osRelease, nil, nil)
+
+	if !result.System.Supported {
+		t.Fatalf("expected nixos linux to be supported")
+	}
+
+	if result.System.Profile.LinuxDistro != LinuxDistroNixOS {
+		t.Fatalf("expected nixos distro, got %q", result.System.Profile.LinuxDistro)
+	}
+
+	if result.System.Profile.PackageManager != "nix" {
+		t.Fatalf("expected nix package manager, got %q", result.System.Profile.PackageManager)
+	}
+}
+
+func TestDetectFromInputsMarksNixOSLikeSupported(t *testing.T) {
+	osRelease := "ID=custom-distro\nID_LIKE=nixos\n"
+	result := detectFromInputs("linux", "amd64", "/bin/bash", osRelease, nil, nil)
+
+	if !result.System.Supported {
+		t.Fatalf("expected nixos-like linux to be supported")
+	}
+
+	if result.System.Profile.LinuxDistro != LinuxDistroNixOS {
+		t.Fatalf("expected nixos distro for ID_LIKE=nixos, got %q", result.System.Profile.LinuxDistro)
+	}
+}
+
+func TestDetectFromInputsPrefersBrewOverNixOnUbuntu(t *testing.T) {
+	tools := map[string]ToolStatus{
+		"nix":  {Name: "nix", Installed: true, Path: "/nix/var/nix/profiles/default/bin/nix"},
+		"brew": {Name: "brew", Installed: true, Path: "/home/linuxbrew/.linuxbrew/bin/brew"},
+	}
+	result := detectFromInputs("linux", "amd64", "/bin/bash", "ID=ubuntu\n", tools, nil)
+
+	if result.System.Profile.PackageManager != "brew" {
+		t.Fatalf("expected brew package manager when both nix and brew installed on Ubuntu, got %q", result.System.Profile.PackageManager)
+	}
+}
+
+func TestDetectFromInputsPrefersAptOverNixOnUbuntu(t *testing.T) {
+	tools := map[string]ToolStatus{
+		"nix": {Name: "nix", Installed: true, Path: "/nix/var/nix/profiles/default/bin/nix"},
+	}
+	result := detectFromInputs("linux", "amd64", "/bin/bash", "ID=ubuntu\n", tools, nil)
+
+	if result.System.Profile.PackageManager != "apt" {
+		t.Fatalf("expected apt package manager when only nix is installed on Ubuntu, got %q", result.System.Profile.PackageManager)
+	}
+}
+
+func TestDetectFromInputsFallsBackToNixOnUnsupportedLinux(t *testing.T) {
+	tools := map[string]ToolStatus{
+		"nix": {Name: "nix", Installed: true, Path: "/nix/var/nix/profiles/default/bin/nix"},
+	}
+	result := detectFromInputs("linux", "amd64", "/bin/bash", "ID=alpine\n", tools, nil)
+
+	if result.System.Profile.PackageManager != "nix" {
+		t.Fatalf("expected nix package manager fallback on unsupported Linux with nix installed, got %q", result.System.Profile.PackageManager)
+	}
+}
+
+func TestDetectFromInputsNixOSPrefersNixOverBrew(t *testing.T) {
+	tools := map[string]ToolStatus{
+		"brew": {Name: "brew", Installed: true, Path: "/home/linuxbrew/.linuxbrew/bin/brew"},
+	}
+	result := detectFromInputs("linux", "amd64", "/bin/bash", "ID=nixos\n", tools, nil)
+
+	if result.System.Profile.PackageManager != "nix" {
+		t.Fatalf("expected nix package manager for NixOS even when brew is installed, got %q", result.System.Profile.PackageManager)
+	}
+}
+
 // --- Batch E: Comprehensive platform detection matrix ---
 
 func TestDetectLinuxDistroMatrix(t *testing.T) {
@@ -167,6 +264,11 @@ func TestDetectLinuxDistroMatrix(t *testing.T) {
 			name:       "nobara via id_like token",
 			osRelease:  "ID=custom-linux\nID_LIKE=\"nobara\"\n",
 			wantDistro: LinuxDistroFedora,
+		},
+		{
+			name:       "nixos wins mixed id_like precedence",
+			osRelease:  "ID=custom-linux\nID_LIKE=\"ubuntu arch fedora nixos\"\n",
+			wantDistro: LinuxDistroNixOS,
 		},
 		{
 			name:       "empty os-release",

--- a/internal/system/detect_test.go
+++ b/internal/system/detect_test.go
@@ -112,78 +112,27 @@ func TestDetectFromInputsMarksArchSupported(t *testing.T) {
 	}
 }
 
-func TestDetectFromInputsMarksNixOSSupported(t *testing.T) {
-	osRelease := "ID=nixos\n"
-	result := detectFromInputs("linux", "amd64", "/bin/bash", osRelease, nil, nil)
-
-	if !result.System.Supported {
-		t.Fatalf("expected nixos linux to be supported")
+func TestDetectFromInputsNixProfiles(t *testing.T) {
+	nix := ToolStatus{Name: "nix", Installed: true}
+	brew := ToolStatus{Name: "brew", Installed: true}
+	tests := []struct {
+		name, release, wantDistro, wantPM string
+		tools                             map[string]ToolStatus
+	}{
+		{"nixos", "ID=nixos\n", LinuxDistroNixOS, "nix", nil},
+		{"nixos-like", "ID=custom\nID_LIKE=nixos\n", LinuxDistroNixOS, "nix", nil},
+		{"ubuntu prefers brew", "ID=ubuntu\n", LinuxDistroUbuntu, "brew", map[string]ToolStatus{"nix": nix, "brew": brew}},
+		{"ubuntu prefers apt", "ID=ubuntu\n", LinuxDistroUbuntu, "apt", map[string]ToolStatus{"nix": nix}},
+		{"unsupported falls back to nix", "ID=alpine\n", LinuxDistroUnknown, "nix", map[string]ToolStatus{"nix": nix}},
+		{"nixos prefers nix over brew", "ID=nixos\n", LinuxDistroNixOS, "nix", map[string]ToolStatus{"brew": brew}},
 	}
-
-	if result.System.Profile.LinuxDistro != LinuxDistroNixOS {
-		t.Fatalf("expected nixos distro, got %q", result.System.Profile.LinuxDistro)
-	}
-
-	if result.System.Profile.PackageManager != "nix" {
-		t.Fatalf("expected nix package manager, got %q", result.System.Profile.PackageManager)
-	}
-}
-
-func TestDetectFromInputsMarksNixOSLikeSupported(t *testing.T) {
-	osRelease := "ID=custom-distro\nID_LIKE=nixos\n"
-	result := detectFromInputs("linux", "amd64", "/bin/bash", osRelease, nil, nil)
-
-	if !result.System.Supported {
-		t.Fatalf("expected nixos-like linux to be supported")
-	}
-
-	if result.System.Profile.LinuxDistro != LinuxDistroNixOS {
-		t.Fatalf("expected nixos distro for ID_LIKE=nixos, got %q", result.System.Profile.LinuxDistro)
-	}
-}
-
-func TestDetectFromInputsPrefersBrewOverNixOnUbuntu(t *testing.T) {
-	tools := map[string]ToolStatus{
-		"nix":  {Name: "nix", Installed: true, Path: "/nix/var/nix/profiles/default/bin/nix"},
-		"brew": {Name: "brew", Installed: true, Path: "/home/linuxbrew/.linuxbrew/bin/brew"},
-	}
-	result := detectFromInputs("linux", "amd64", "/bin/bash", "ID=ubuntu\n", tools, nil)
-
-	if result.System.Profile.PackageManager != "brew" {
-		t.Fatalf("expected brew package manager when both nix and brew installed on Ubuntu, got %q", result.System.Profile.PackageManager)
-	}
-}
-
-func TestDetectFromInputsPrefersAptOverNixOnUbuntu(t *testing.T) {
-	tools := map[string]ToolStatus{
-		"nix": {Name: "nix", Installed: true, Path: "/nix/var/nix/profiles/default/bin/nix"},
-	}
-	result := detectFromInputs("linux", "amd64", "/bin/bash", "ID=ubuntu\n", tools, nil)
-
-	if result.System.Profile.PackageManager != "apt" {
-		t.Fatalf("expected apt package manager when only nix is installed on Ubuntu, got %q", result.System.Profile.PackageManager)
-	}
-}
-
-func TestDetectFromInputsFallsBackToNixOnUnsupportedLinux(t *testing.T) {
-	tools := map[string]ToolStatus{
-		"nix": {Name: "nix", Installed: true, Path: "/nix/var/nix/profiles/default/bin/nix"},
-	}
-	result := detectFromInputs("linux", "amd64", "/bin/bash", "ID=alpine\n", tools, nil)
-
-	if result.System.Profile.PackageManager != "nix" {
-		t.Fatalf("expected nix package manager fallback on unsupported Linux with nix installed, got %q", result.System.Profile.PackageManager)
-	}
-}
-
-func TestDetectFromInputsNixOSPrefersNixOverBrew(t *testing.T) {
-	tools := map[string]ToolStatus{
-		"brew": {Name: "brew", Installed: true, Path: "/home/linuxbrew/.linuxbrew/bin/brew"},
-	}
-	result := detectFromInputs("linux", "amd64", "/bin/bash", "ID=nixos\n", tools, nil)
-
-	if result.System.Profile.PackageManager != "nix" {
-		t.Fatalf("expected nix package manager for NixOS even when brew is installed, got %q", result.System.Profile.PackageManager)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			profile := detectFromInputs("linux", "amd64", "/bin/bash", tt.release, tt.tools, nil).System.Profile
+			if !profile.Supported || profile.LinuxDistro != tt.wantDistro || profile.PackageManager != tt.wantPM {
+				t.Fatalf("profile = %#v, want supported distro=%q pm=%q", profile, tt.wantDistro, tt.wantPM)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #110

Adds native support for NixOS Linux distribution and the `nix` package manager across Linux environments.

## Problem

Gentle AI installer currently did not detect NixOS systems or recognize `nix` as a package manager, preventing users on NixOS or using `nix` on Linux from installing prerequisites smoothly.

## Solution

1. **Distro Detection**: Detected NixOS via `/etc/os-release` (`ID=nixos` or `ID_LIKE=nixos`). Added `LinuxDistroNixOS = "nixos"` constant.
2. **Package Manager**: Mapped `nix` as the platform package manager when running on NixOS or when `nix` tool is detected on Linux.
3. **Dependency Hints & Commands**: Added `nix-env -iA nixpkgs.<package>` hints and execution commands for prerequisites (`git`, `curl`, `node`, `go`).
4. **Unit Tests**: Updated system detection matrix and dependency installation matrix unit tests to cover NixOS and `nix`.

## Test Plan

- [x] Ran `go test ./internal/system/...` — all tests pass including full package manager matrix.
- [x] Ran `go build ./...` — builds cleanly across workspace.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for NixOS and the `nix` package manager.
  * Engram can now be installed on NixOS using Go tooling.
  * GGA installation is supported on NixOS.

* **Documentation**
  * Added NixOS to the supported Linux platforms list.

* **Bug Fixes**
  * Improved handling of multiple Go workspace paths during installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->