### PR TITLE
feat(hermes): honor HERMES_HOME in adapter ConfigPath

### DIFF
--- a/internal/agents/hermes/adapter.go
+++ b/internal/agents/hermes/adapter.go
@@ -161,8 +161,16 @@ func defaultStat(path string) statResult {
 	return statResult{isDir: info.IsDir()}
 }
 
-// ConfigPath returns the path to ~/.hermes, the Hermes global config directory.
+// ConfigPath returns the Hermes global config directory. It honors the
+// HERMES_HOME environment variable when set (the same override Hermes Desktop
+// itself uses), so that gentle-ai and Hermes agree on where persona/skills/MCP
+// config live. When HERMES_HOME is unset, the historical default of
+// filepath.Join(homeDir, ".hermes") is preserved to avoid changing existing
+// behavior on any platform.
 func ConfigPath(homeDir string) string {
+	if envHome := os.Getenv("HERMES_HOME"); envHome != "" {
+		return envHome
+	}
 	return filepath.Join(homeDir, ".hermes")
 }
 

--- a/internal/agents/hermes/adapter_test.go
+++ b/internal/agents/hermes/adapter_test.go
@@ -64,6 +64,7 @@ func TestDetect(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("HERMES_HOME", "")
 			a := &Adapter{
 				lookPath: func(string) (string, error) {
 					return tt.lookPathPath, tt.lookPathErr
@@ -103,6 +104,44 @@ func TestDetect(t *testing.T) {
 	}
 }
 
+func TestConfigPathHERMES_HOME(t *testing.T) {
+	homeDir := filepath.Join(string(filepath.Separator), "home", "test")
+
+	tests := []struct {
+		name string
+		envs map[string]string
+		want string
+	}{
+		{
+			name: "HERMES_HOME overrides default",
+			envs: map[string]string{"HERMES_HOME": filepath.Join(homeDir, "custom")},
+			want: filepath.Join(homeDir, "custom"),
+		},
+		{
+			name: "HERMES_HOME empty falls back to ~/.hermes",
+			envs: map[string]string{"HERMES_HOME": ""},
+			want: filepath.Join(homeDir, ".hermes"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cleared := map[string]string{"HERMES_HOME": ""}
+			for k := range cleared {
+				t.Setenv(k, "")
+			}
+			for k, v := range tt.envs {
+				t.Setenv(k, v)
+			}
+
+			got := ConfigPath(homeDir)
+			if got != tt.want {
+				t.Fatalf("ConfigPath() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestInstallCommand(t *testing.T) {
 	a := NewAdapter()
 
@@ -131,6 +170,7 @@ func TestSupportsAutoInstall(t *testing.T) {
 }
 
 func TestConfigPaths(t *testing.T) {
+	t.Setenv("HERMES_HOME", "")
 	a := NewAdapter()
 	homeDir := filepath.Join(string(filepath.Separator), "home", "test")
 	configDir := filepath.Join(homeDir, ".hermes")


### PR DESCRIPTION
Make gentle-ai use the same Hermes home directory Hermes Desktop uses by honoring the HERMES_HOME environment variable in the Hermes adapter.

On Windows, Hermes Desktop stores its config under the Hermes-generated path from get_hermes_home(), which typically resolves to %LOCALAPPDATA%\hermes. Until now, gentle-ai hardcoded ~/.hermes and ignored that, so users had to keep the paths in sync manually.

With this change, ConfigPath() checks HERMES_HOME first. When it is set, all gentle-ai paths for Hermes (SOUL.md, skills, MCP config) resolve to the same directory Hermes already uses. When HERMES_HOME is unset, the historical default (~/.hermes) is preserved, so behavior is unchanged for CLI-only workflows.

Files changed
- internal/agents/hermes/adapter.go: add HERMES_HOME override to ConfigPath()
- internal/agents/hermes/adapter_test.go: cover the new behavior while isolating existing tests from the environment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration now respects the `HERMES_HOME` environment variable when it is set, while keeping the default location unchanged when it is not.
  * Test setup was tightened to avoid environment-related interference between runs.
* **Tests**
  * Added coverage for configuration path behavior with `HERMES_HOME` set and unset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->