### PR TITLE
fix(sddstatus): make verify-report blocker detection context-aware

### DIFF
--- a/internal/sddstatus/status.go
+++ b/internal/sddstatus/status.go
@@ -914,9 +914,12 @@ func reportLineHasComplianceSignal(line string) bool {
 	trimmed := strings.ToUpper(stripMarkdownSignal(line))
 	return strings.Contains(trimmed, "COMPLIANT") ||
 		strings.Contains(trimmed, "NO BLOCKERS") ||
-		strings.Contains(trimmed, "0 BLOCKING") ||
-		strings.HasPrefix(trimmed, "PASS")
+		reportZeroBlockingPattern.MatchString(trimmed) ||
+		reportPassWordPattern.MatchString(trimmed)
 }
+
+var reportZeroBlockingPattern = regexp.MustCompile(`\b0\s+BLOCKING\b`)
+var reportPassWordPattern = regexp.MustCompile(`\bPASS(?:ED|ING)?\b`)
 
 func reportLineHasPassSignal(line string) bool {
 	if line == "" {

--- a/internal/sddstatus/status.go
+++ b/internal/sddstatus/status.go
@@ -909,7 +909,11 @@ func reportLineHasBlocker(line string) bool {
 	return reportFailValuePattern.MatchString(trimmed)
 }
 
-// reportLineHasComplianceSignal checks if a line contains explicit pass/compliance indicators.
+// reportLineHasComplianceSignal checks if a line contains explicit compliance indicators.
+// PASS/PASSED/PASSING alone is NOT sufficient — it matches too broadly in prose
+// (e.g. "pending work continues but tests pass") and would incorrectly exempt
+// lines with real TODO/PENDING blockers. Only COMPLIANT (non-negated), NO BLOCKERS,
+// and 0 BLOCKING qualify as compliance signals.
 func reportLineHasComplianceSignal(line string) bool {
 	trimmed := strings.ToUpper(stripMarkdownSignal(line))
 	if reportNonCompliantPattern.MatchString(trimmed) {
@@ -917,11 +921,10 @@ func reportLineHasComplianceSignal(line string) bool {
 	}
 	return strings.Contains(trimmed, "COMPLIANT") ||
 		strings.Contains(trimmed, "NO BLOCKERS") ||
-		reportZeroBlockingPattern.MatchString(trimmed) ||
-		reportPassWordPattern.MatchString(trimmed)
+		reportZeroBlockingPattern.MatchString(trimmed)
 }
 
-var reportNonCompliantPattern = regexp.MustCompile(`\bNON[-\s]*COMPLIANT\b`)
+var reportNonCompliantPattern = regexp.MustCompile(`\b(?:NON[-\s]*|NOT\s+)COMPLIANT\b`)
 var reportZeroBlockingPattern = regexp.MustCompile(`\b0\s+BLOCKING\b`)
 var reportPassWordPattern = regexp.MustCompile(`\bPASS(?:ED|ING)?\b`)
 

--- a/internal/sddstatus/status.go
+++ b/internal/sddstatus/status.go
@@ -876,7 +876,7 @@ func reportLineHasBlocker(line string) bool {
 	if line == "" {
 		return false
 	}
-	if reportPassNegationPattern.MatchString(line) || reportPendingPattern.MatchString(line) {
+	if reportPassNegationPattern.MatchString(line) {
 		return true
 	}
 	if reportCriticalGlyphStatusPattern.MatchString(line) {
@@ -893,7 +893,7 @@ func reportLineHasBlocker(line string) bool {
 		normalizedLabel := normalizeReportToken(label)
 		trimmedValue := strings.TrimSpace(value)
 		switch normalizedLabel {
-		case "critical", "blocker", "blockers", "verificationblocker", "verificationblockers", "failure", "fail", "failed":
+		case "critical", "blocker", "blockers", "verificationblocker", "verificationblockers", "failure", "fail", "failed", "pending", "todo":
 			return !reportValueIsBenign(trimmedValue)
 		case "verdict", "status", "result", "verification", "finalverdict", "build", "tests":
 			if reportFailValuePattern.MatchString(stripMarkdownSignal(trimmedValue)) {

--- a/internal/sddstatus/status.go
+++ b/internal/sddstatus/status.go
@@ -912,12 +912,16 @@ func reportLineHasBlocker(line string) bool {
 // reportLineHasComplianceSignal checks if a line contains explicit pass/compliance indicators.
 func reportLineHasComplianceSignal(line string) bool {
 	trimmed := strings.ToUpper(stripMarkdownSignal(line))
+	if reportNonCompliantPattern.MatchString(trimmed) {
+		return false
+	}
 	return strings.Contains(trimmed, "COMPLIANT") ||
 		strings.Contains(trimmed, "NO BLOCKERS") ||
 		reportZeroBlockingPattern.MatchString(trimmed) ||
 		reportPassWordPattern.MatchString(trimmed)
 }
 
+var reportNonCompliantPattern = regexp.MustCompile(`\bNON[-\s]*COMPLIANT\b`)
 var reportZeroBlockingPattern = regexp.MustCompile(`\b0\s+BLOCKING\b`)
 var reportPassWordPattern = regexp.MustCompile(`\bPASS(?:ED|ING)?\b`)
 

--- a/internal/sddstatus/status.go
+++ b/internal/sddstatus/status.go
@@ -911,12 +911,11 @@ func reportLineHasBlocker(line string) bool {
 
 // reportLineHasComplianceSignal checks if a line contains explicit pass/compliance indicators.
 func reportLineHasComplianceSignal(line string) bool {
-	trimmed := stripMarkdownSignal(line)
+	trimmed := strings.ToUpper(stripMarkdownSignal(line))
 	return strings.Contains(trimmed, "COMPLIANT") ||
-		strings.Contains(trimmed, "no blockers") ||
-		strings.Contains(trimmed, "0 blocking") ||
-		strings.HasPrefix(trimmed, "PASS") ||
-		strings.HasPrefix(trimmed, "PASSED")
+		strings.Contains(trimmed, "NO BLOCKERS") ||
+		strings.Contains(trimmed, "0 BLOCKING") ||
+		strings.HasPrefix(trimmed, "PASS")
 }
 
 func reportLineHasPassSignal(line string) bool {

--- a/internal/sddstatus/status.go
+++ b/internal/sddstatus/status.go
@@ -901,8 +901,22 @@ func reportLineHasBlocker(line string) bool {
 			}
 		}
 	}
+	// PENDING/TODO sin field parseable solo bloquean si no hay señal de compliance
+	if !hasField && reportPendingPattern.MatchString(line) && !reportLineHasComplianceSignal(line) {
+		return true
+	}
 	trimmed := stripMarkdownSignal(line)
 	return reportFailValuePattern.MatchString(trimmed)
+}
+
+// reportLineHasComplianceSignal checks if a line contains explicit pass/compliance indicators.
+func reportLineHasComplianceSignal(line string) bool {
+	trimmed := stripMarkdownSignal(line)
+	return strings.Contains(trimmed, "COMPLIANT") ||
+		strings.Contains(trimmed, "no blockers") ||
+		strings.Contains(trimmed, "0 blocking") ||
+		strings.HasPrefix(trimmed, "PASS") ||
+		strings.HasPrefix(trimmed, "PASSED")
 }
 
 func reportLineHasPassSignal(line string) bool {

--- a/internal/sddstatus/status.go
+++ b/internal/sddstatus/status.go
@@ -912,20 +912,23 @@ func reportLineHasBlocker(line string) bool {
 // reportLineHasComplianceSignal checks if a line contains explicit compliance indicators.
 // PASS/PASSED/PASSING alone is NOT sufficient — it matches too broadly in prose
 // (e.g. "pending work continues but tests pass") and would incorrectly exempt
-// lines with real TODO/PENDING blockers. Only COMPLIANT (non-negated), NO BLOCKERS,
-// and 0 BLOCKING qualify as compliance signals.
+// lines with real TODO/PENDING blockers. Only the standalone word COMPLIANT (non-negated),
+// the phrase NO BLOCKERS (with whitespace tolerance), and 0 BLOCKING qualify as compliance signals.
+// Matching uses word boundaries to avoid false positives (e.g. "INCOMPLIANT" or "NO BLOCKERSHIP").
 func reportLineHasComplianceSignal(line string) bool {
 	trimmed := strings.ToUpper(stripMarkdownSignal(line))
 	if reportNonCompliantPattern.MatchString(trimmed) {
 		return false
 	}
-	return strings.Contains(trimmed, "COMPLIANT") ||
-		strings.Contains(trimmed, "NO BLOCKERS") ||
+	return reportCompliantWordPattern.MatchString(trimmed) ||
+		reportNoBlockersPattern.MatchString(trimmed) ||
 		reportZeroBlockingPattern.MatchString(trimmed)
 }
 
 var reportNonCompliantPattern = regexp.MustCompile(`\b(?:NON[-\s]*|NOT\s+)COMPLIANT\b`)
 var reportZeroBlockingPattern = regexp.MustCompile(`\b0\s+BLOCKING\b`)
+var reportCompliantWordPattern = regexp.MustCompile(`\bCOMPLIANT\b`)
+var reportNoBlockersPattern = regexp.MustCompile(`\bNO\s+BLOCKERS\b`)
 var reportPassWordPattern = regexp.MustCompile(`\bPASS(?:ED|ING)?\b`)
 
 func reportLineHasPassSignal(line string) bool {

--- a/internal/sddstatus/status_test.go
+++ b/internal/sddstatus/status_test.go
@@ -879,8 +879,6 @@ func TestReportLineHasBlocker_AllowsCompliantProseWithRiskTerms(t *testing.T) {
 		{"fail term in description", "fail-fast propagation"},
 		{"pending in table row with pass signal", "| REQ-01 | Covers auth | ✅ COMPLIANT | — no pending issues"},
 		{"pending in table with COMPLIANT", "| REQ-02 | Validates input | test_validate | ✅ COMPLIANT — pending review done"},
-		{"todo in table with PASS", "| REQ-03 | rate limit | | ⚠️ TODO (known limitation, documented)"},
-		// Casos que sí deben fallar
 	}
 	for _, tt := range tests {
 		t.Run("allow_"+tt.name, func(t *testing.T) {
@@ -901,6 +899,7 @@ func TestReportLineHasBlocker_BlocksGenuineBlockers(t *testing.T) {
 		{"critical with blocker value", "critical: archive blocker"},
 		{"failed count nonzero", "failed: 3"},
 		{"pending field with real blocker", "Pending: evidence missing"},
+		{"todo in result cell without compliance signal", "| REQ-03 | rate limit | | ⚠️ TODO (known limitation, documented)"},
 	}
 	for _, tt := range tests {
 		t.Run("block_"+tt.name, func(t *testing.T) {
@@ -913,11 +912,13 @@ func TestReportLineHasBlocker_BlocksGenuineBlockers(t *testing.T) {
 
 func TestReportTextIsClearlyPassing_FalsePositivesFromIssue848(t *testing.T) {
 	tests := []struct {
-		name string
-		text string
+		name        string
+		text        string
+		wantPassing bool
 	}{
 		{
 			name: "canonical pass with warnings and risk terms in prose",
+			wantPassing: true,
 			text: strings.Join([]string{
 				"## Verification Report",
 				"### Build & Tests Execution",
@@ -937,7 +938,22 @@ func TestReportTextIsClearlyPassing_FalsePositivesFromIssue848(t *testing.T) {
 			}, "\n"),
 		},
 		{
-			name: "spec compliance matrix with pending in compliant rows",
+			name: "spec compliance matrix with pending in COMPLIANT rows",
+			wantPassing: true,
+			text: strings.Join([]string{
+				"## Verification Report",
+				"### Spec Compliance Matrix",
+				"| Requirement | Scenario | Test | Result |",
+				"|-------------|----------|------|--------|",
+				"| REQ-01 | Covers auth | test_auth | ✅ COMPLIANT — pending review done |",
+				"| REQ-02 | rate limit | test_rate | ✅ COMPLIANT — no pending issues |",
+				"### Verdict",
+				"Verdict: PASS",
+				"",
+			}, "\n"),
+		},
+		{
+			name: "spec compliance matrix with TODO in non-compliant cell blocks",
 			text: strings.Join([]string{
 				"## Verification Report",
 				"### Spec Compliance Matrix",
@@ -946,15 +962,17 @@ func TestReportTextIsClearlyPassing_FalsePositivesFromIssue848(t *testing.T) {
 				"| REQ-01 | Covers auth | test_auth | ✅ COMPLIANT — pending review done |",
 				"| REQ-02 | rate limit | | ⚠️ TODO (known limitation, documented) |",
 				"### Verdict",
-				"Verdict: PASS",
+				"Verdict: FAIL",
 				"",
 			}, "\n"),
+			wantPassing: false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if !reportTextIsClearlyPassing(tt.text) {
-				t.Errorf("reportTextIsClearlyPassing() = false, want true")
+			got := reportTextIsClearlyPassing(tt.text)
+			if got != tt.wantPassing {
+				t.Errorf("reportTextIsClearlyPassing() = %v, want %v", got, tt.wantPassing)
 			}
 		})
 	}

--- a/internal/sddstatus/status_test.go
+++ b/internal/sddstatus/status_test.go
@@ -900,6 +900,10 @@ func TestReportLineHasBlocker_BlocksGenuineBlockers(t *testing.T) {
 		{"failed count nonzero", "failed: 3"},
 		{"pending field with real blocker", "Pending: evidence missing"},
 		{"todo in result cell without compliance signal", "| REQ-03 | rate limit | | ⚠️ TODO (known limitation, documented)"},
+		// Alan-TheGentleman: NOT COMPLIANT must not be treated as a compliance signal.
+		{"not compliant with pending todo", "NOT COMPLIANT — TODO: needs full audit"},
+		// Alan-TheGentleman: standalone pass must not exempt lines with real TODO/PENDING.
+		{"pending with pass in prose", "- pending work continues but tests pass"},
 	}
 	for _, tt := range tests {
 		t.Run("block_"+tt.name, func(t *testing.T) {

--- a/internal/sddstatus/status_test.go
+++ b/internal/sddstatus/status_test.go
@@ -904,6 +904,9 @@ func TestReportLineHasBlocker_BlocksGenuineBlockers(t *testing.T) {
 		{"not compliant with pending todo", "NOT COMPLIANT — TODO: needs full audit"},
 		// Alan-TheGentleman: standalone pass must not exempt lines with real TODO/PENDING.
 		{"pending with pass in prose", "- pending work continues but tests pass"},
+		// Additional test cases for substring matches
+		{"TODO with internal COMPLIANT substring", "TODO: fix this COMPLIANTLY issue"},
+		{"TODO with internal NO BLOCKERS substring", "TODO: beware of NO BLOCKERSHIP"},
 	}
 	for _, tt := range tests {
 		t.Run("block_"+tt.name, func(t *testing.T) {

--- a/internal/sddstatus/status_test.go
+++ b/internal/sddstatus/status_test.go
@@ -863,6 +863,103 @@ func equalStringPtr(left *string, right *string) bool {
 	return *left == *right
 }
 
+func TestReportLineHasBlocker_AllowsCompliantProseWithRiskTerms(t *testing.T) {
+	tests := []struct {
+		name string
+		line string
+	}{
+		// False positives reportados en #848
+		{"CRITICAL with None value", "**CRITICAL**: None"},
+		{"WARNING with None value", "**WARNING**: None"},
+		{"blocking count zero", "Issues found: 0 (0 blocking, 0 advisory)"},
+		{"failed count zero", "failed: 0"},
+		{"error term in description", "an errored step skips its dependents"},
+		{"missing term in description", "tolerates a missing/empty field"},
+		{"not-ok term in description", "run is not-ok when a step is skipped"},
+		{"fail term in description", "fail-fast propagation"},
+		{"pending in table row with pass signal", "| REQ-01 | Covers auth | ✅ COMPLIANT | — no pending issues"},
+		{"pending in table with COMPLIANT", "| REQ-02 | Validates input | test_validate | ✅ COMPLIANT — pending review done"},
+		{"todo in table with PASS", "| REQ-03 | rate limit | | ⚠️ TODO (known limitation, documented)"},
+		// Casos que sí deben fallar
+	}
+	for _, tt := range tests {
+		t.Run("allow_"+tt.name, func(t *testing.T) {
+			if reportLineHasBlocker(tt.line) {
+				t.Errorf("reportLineHasBlocker(%q) = true, want false (false positive)", tt.line)
+			}
+		})
+	}
+}
+
+func TestReportLineHasBlocker_BlocksGenuineBlockers(t *testing.T) {
+	tests := []struct {
+		name string
+		line string
+	}{
+		{"TODO with non-benign value", "TODO: finish audit"},
+		{"PENDING with non-benign value", "PENDING: test run"},
+		{"critical with blocker value", "critical: archive blocker"},
+		{"failed count nonzero", "failed: 3"},
+		{"pending field with real blocker", "Pending: evidence missing"},
+	}
+	for _, tt := range tests {
+		t.Run("block_"+tt.name, func(t *testing.T) {
+			if !reportLineHasBlocker(tt.line) {
+				t.Errorf("reportLineHasBlocker(%q) = false, want true", tt.line)
+			}
+		})
+	}
+}
+
+func TestReportTextIsClearlyPassing_FalsePositivesFromIssue848(t *testing.T) {
+	tests := []struct {
+		name string
+		text string
+	}{
+		{
+			name: "canonical pass with warnings and risk terms in prose",
+			text: strings.Join([]string{
+				"## Verification Report",
+				"### Build & Tests Execution",
+				"**Tests**: ✅ 12 passed / ❌ 0 failed / ⚠️ 0 skipped",
+				"failed: 0",
+				"Issues found: 0 (0 blocking, 0 advisory)",
+				"an errored step skips its dependents",
+				"tolerates a missing/empty field",
+				"fail-fast propagation",
+				"### Issues Found",
+				"**CRITICAL**: None",
+				"**WARNING**: None",
+				"No blockers",
+				"### Verdict",
+				"Verdict: PASS",
+				"",
+			}, "\n"),
+		},
+		{
+			name: "spec compliance matrix with pending in compliant rows",
+			text: strings.Join([]string{
+				"## Verification Report",
+				"### Spec Compliance Matrix",
+				"| Requirement | Scenario | Test | Result |",
+				"|-------------|----------|------|--------|",
+				"| REQ-01 | Covers auth | test_auth | ✅ COMPLIANT — pending review done |",
+				"| REQ-02 | rate limit | | ⚠️ TODO (known limitation, documented) |",
+				"### Verdict",
+				"Verdict: PASS",
+				"",
+			}, "\n"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if !reportTextIsClearlyPassing(tt.text) {
+				t.Errorf("reportTextIsClearlyPassing() = false, want true")
+			}
+		})
+	}
+}
+
 func ptrValue(value *string) string {
 	if value == nil {
 		return "<nil>"


### PR DESCRIPTION
Closes #848

## Summary

- **PENDING** and **TODO** no longer block archive when they appear in compliant prose (table cells with ✅ COMPLIANT, severity labels with `: None`, zero-count findings, etc.)
- They only block when used as `field: value` labels with non-benign values, consistent with how `critical` / `blocker` / `failure` tokens are already handled

## Changes

| File | Change |
|------|--------|
| `internal/sddstatus/status.go` | Moved `PENDING`/`TODO` from raw substring check (L879) to the field-aware switch in `reportLineHasBlocker` |
| `internal/sddstatus/status_test.go` | Added 3 test functions: false-positive cases from #848, genuine blocker cases, and full report integration tests |

## Test Plan

- [x] `go test ./internal/sddstatus/...` — all 54 tests pass
- [x] 11 false-positive cases now correctly pass (CRITICAL: None, `0 blocking`, table rows with COMPLIANT, etc.)
- [x] 5 genuine blocker cases still correctly block (TODO: finish audit, PENDING: test run, etc.)
- [x] Existing integration tests unchanged and green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened “blocker” detection so TODO/PENDING no longer triggers immediate blocking for plain-language report lines.
  * Improved structured report parsing so pending/to-do labels only block when they indicate genuine issues, avoiding risk-language false positives.
  * Refined “clearly passing” classification by requiring explicit compliance/pass signals (e.g., COMPLIANT, PASS) and handling NON-COMPLIANT as non-passing.
* **Tests**
  * Added unit tests covering blocker and passing classification edge cases, including ✅ COMPLIANT rows with pending-like text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->