### PR TITLE
fix(model): split provider/model at first separator (slash or colon)

### DIFF
--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -250,22 +250,9 @@ func parseProfilePhaseFlag(raw string) (name, phase string, assignment model.Mod
 // parseModelSpec parses a "provider/model" or "provider:model" string into a
 // ModelAssignment. Returns an error if the spec is empty or has no separator.
 func parseModelSpec(spec string) (model.ModelAssignment, error) {
-	// Try slash separator first (common CLI format: anthropic/claude-haiku-3-5),
-	// then colon (opencode internal format: anthropic:claude-haiku-3-5).
-	sep := -1
-	for i, c := range spec {
-		if c == '/' || c == ':' {
-			sep = i
-			break
-		}
-	}
-	if sep <= 0 {
+	providerID, modelID, ok := model.SplitProviderModel(spec)
+	if !ok {
 		return model.ModelAssignment{}, fmt.Errorf("invalid model spec %q: expected provider/model or provider:model", spec)
-	}
-	providerID := spec[:sep]
-	modelID := spec[sep+1:]
-	if providerID == "" || modelID == "" {
-		return model.ModelAssignment{}, fmt.Errorf("invalid model spec %q: provider and model must both be non-empty", spec)
 	}
 	return model.ModelAssignment{ProviderID: providerID, ModelID: modelID}, nil
 }

--- a/internal/components/sdd/profiles.go
+++ b/internal/components/sdd/profiles.go
@@ -236,18 +236,8 @@ func extractModelFromAgent(agentMap map[string]any) model.ModelAssignment {
 	if modelStr == "" {
 		return model.ModelAssignment{}
 	}
-
-	// Try colon separator first (standard: "anthropic:claude-sonnet-4"), then slash.
-	idx := strings.Index(modelStr, ":")
-	if idx <= 0 {
-		idx = strings.Index(modelStr, "/")
-	}
-	if idx <= 0 {
-		return model.ModelAssignment{}
-	}
-	providerID := modelStr[:idx]
-	modelID := modelStr[idx+1:]
-	if modelID == "" {
+	providerID, modelID, ok := model.SplitProviderModel(modelStr)
+	if !ok {
 		return model.ModelAssignment{}
 	}
 	effort, _ := agentMap["variant"].(string)

--- a/internal/components/sdd/profiles_test.go
+++ b/internal/components/sdd/profiles_test.go
@@ -1126,3 +1126,72 @@ func assertExactTaskPermissions(t *testing.T, got, want map[string]any) {
 		}
 	}
 }
+
+// TestExtractModelFromAgent covers the model-spec parsing path used by
+// DetectProfiles. Includes regression coverage for issue #260: OpenRouter
+// free models such as "openrouter/qwen/qwen3.6-plus:free" must split at the
+// first separator (the leading '/'), not at ':'.
+func TestExtractModelFromAgent(t *testing.T) {
+	tests := []struct {
+		name     string
+		agentMap map[string]any
+		want     model.ModelAssignment
+	}{
+		{
+			name:     "nil map",
+			agentMap: nil,
+			want:     model.ModelAssignment{},
+		},
+		{
+			name:     "missing model field",
+			agentMap: map[string]any{"prompt": "hello"},
+			want:     model.ModelAssignment{},
+		},
+		{
+			name:     "model field not a string",
+			agentMap: map[string]any{"model": 42},
+			want:     model.ModelAssignment{},
+		},
+		{
+			name:     "empty model string",
+			agentMap: map[string]any{"model": ""},
+			want:     model.ModelAssignment{},
+		},
+		{
+			name:     "model with no separator",
+			agentMap: map[string]any{"model": "no-separator-here"},
+			want:     model.ModelAssignment{},
+		},
+		{
+			name:     "colon separator",
+			agentMap: map[string]any{"model": "anthropic:claude-sonnet-4-20250514"},
+			want:     model.ModelAssignment{ProviderID: "anthropic", ModelID: "claude-sonnet-4-20250514"},
+		},
+		{
+			name:     "slash separator",
+			agentMap: map[string]any{"model": "zai-coding-plan/glm-5-turbo"},
+			want:     model.ModelAssignment{ProviderID: "zai-coding-plan", ModelID: "glm-5-turbo"},
+		},
+		// Regression #260: OpenRouter free models contain both '/' and ':'.
+		// Must split at the first '/' so the colon stays inside the modelID.
+		{
+			name:     "openrouter free suffix",
+			agentMap: map[string]any{"model": "openrouter/qwen/qwen3.6-plus:free"},
+			want:     model.ModelAssignment{ProviderID: "openrouter", ModelID: "qwen/qwen3.6-plus:free"},
+		},
+		{
+			name:     "openrouter paid with multiple slashes",
+			agentMap: map[string]any{"model": "openrouter/anthropic/claude-sonnet-4"},
+			want:     model.ModelAssignment{ProviderID: "openrouter", ModelID: "anthropic/claude-sonnet-4"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractModelFromAgent(tt.agentMap)
+			if got != tt.want {
+				t.Errorf("extractModelFromAgent() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/components/sdd/read_assignments.go
+++ b/internal/components/sdd/read_assignments.go
@@ -3,7 +3,6 @@ package sdd
 import (
 	"encoding/json"
 	"os"
-	"strings"
 
 	"github.com/gentleman-programming/gentle-ai/internal/model"
 	"github.com/gentleman-programming/gentle-ai/internal/opencode"
@@ -79,19 +78,9 @@ func ReadCurrentModelAssignments(settingsPath string) (map[string]model.ModelAss
 		if !ok || modelStr == "" {
 			continue
 		}
-		// Try colon first (standard: "anthropic:claude-sonnet-4"), then slash
-		// ("zai-coding-plan/glm-5-turbo") for custom providers (issue #152).
-		idx := strings.Index(modelStr, ":")
-		if idx <= 0 {
-			idx = strings.Index(modelStr, "/")
-		}
-		if idx <= 0 {
+		providerID, modelID, ok := model.SplitProviderModel(modelStr)
+		if !ok {
 			// No separator or separator is the first character — skip malformed value.
-			continue
-		}
-		providerID := modelStr[:idx]
-		modelID := modelStr[idx+1:]
-		if modelID == "" {
 			continue
 		}
 		assignmentKey := name

--- a/internal/components/sdd/read_assignments_test.go
+++ b/internal/components/sdd/read_assignments_test.go
@@ -297,3 +297,59 @@ func TestReadCurrentModelAssignmentsMixedSeparators(t *testing.T) {
 		}
 	}
 }
+
+// TestReadCurrentModelAssignmentsOpenRouterFreeSuffix is a regression test
+// for issue #260: OpenRouter free models have the form
+// "openrouter/qwen/qwen3.6-plus:free" — they contain BOTH '/' and ':'.
+// The parser must split on the FIRST separator (the leading '/'), producing
+// providerID="openrouter" and modelID="qwen/qwen3.6-plus:free". Splitting
+// on ':' first would mis-attribute "openrouter/qwen/qwen3.6-plus" to the
+// provider, which breaks OpenCode model resolution.
+//
+// The fixture intentionally uses the legacy "sdd-orchestrator" key (the
+// real-world config shape from issue #260, before the user re-syncs) and
+// asserts the result lands under "gentle-orchestrator" — exercising both
+// the first-separator split and the legacy alias normalization together.
+func TestReadCurrentModelAssignmentsOpenRouterFreeSuffix(t *testing.T) {
+	dir := t.TempDir()
+	settingsPath := filepath.Join(dir, "opencode.json")
+
+	content := `{
+  "agent": {
+    "sdd-orchestrator": { "model": "openrouter/qwen/qwen3.6-plus:free" },
+    "sdd-apply":        { "model": "openrouter/anthropic/claude-sonnet-4" }
+  }
+}`
+	if err := os.WriteFile(settingsPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write settings: %v", err)
+	}
+
+	got, err := ReadCurrentModelAssignments(settingsPath)
+	if err != nil {
+		t.Fatalf("ReadCurrentModelAssignments() error = %v", err)
+	}
+
+	tests := []struct {
+		phase      string
+		providerID string
+		modelID    string
+	}{
+		// Legacy "sdd-orchestrator" fixture key normalizes to "gentle-orchestrator".
+		{"gentle-orchestrator", "openrouter", "qwen/qwen3.6-plus:free"},
+		{"sdd-apply", "openrouter", "anthropic/claude-sonnet-4"},
+	}
+
+	for _, tt := range tests {
+		a, ok := got[tt.phase]
+		if !ok {
+			t.Errorf("phase %q missing from result", tt.phase)
+			continue
+		}
+		if a.ProviderID != tt.providerID {
+			t.Errorf("phase %q: ProviderID = %q, want %q", tt.phase, a.ProviderID, tt.providerID)
+		}
+		if a.ModelID != tt.modelID {
+			t.Errorf("phase %q: ModelID = %q, want %q", tt.phase, a.ModelID, tt.modelID)
+		}
+	}
+}

--- a/internal/model/split.go
+++ b/internal/model/split.go
@@ -1,0 +1,29 @@
+package model
+
+// SplitProviderModel splits a model spec string into its provider and model
+// components at the FIRST occurrence of '/' or ':'. Splitting on the first
+// separator correctly handles compound model identifiers such as OpenRouter
+// free models — e.g. "openrouter/qwen/qwen3.6-plus:free" is split into
+// providerID="openrouter" and modelID="qwen/qwen3.6-plus:free".
+//
+// Returns (providerID, modelID, true) when both parts are non-empty.
+// Returns ("", "", false) when the input is empty, has no separator, starts
+// with a separator, or has an empty model part.
+func SplitProviderModel(spec string) (providerID, modelID string, ok bool) {
+	sep := -1
+	for i, c := range spec {
+		if c == '/' || c == ':' {
+			sep = i
+			break
+		}
+	}
+	if sep <= 0 {
+		return "", "", false
+	}
+	providerID = spec[:sep]
+	modelID = spec[sep+1:]
+	if providerID == "" || modelID == "" {
+		return "", "", false
+	}
+	return providerID, modelID, true
+}

--- a/internal/model/split_test.go
+++ b/internal/model/split_test.go
@@ -1,0 +1,101 @@
+package model
+
+import "testing"
+
+func TestSplitProviderModel(t *testing.T) {
+	tests := []struct {
+		name      string
+		spec      string
+		wantProv  string
+		wantModel string
+		wantOK    bool
+	}{
+		{
+			name:      "colon separator",
+			spec:      "anthropic:claude-sonnet-4-20250514",
+			wantProv:  "anthropic",
+			wantModel: "claude-sonnet-4-20250514",
+			wantOK:    true,
+		},
+		{
+			name:      "slash separator",
+			spec:      "zai-coding-plan/glm-5-turbo",
+			wantProv:  "zai-coding-plan",
+			wantModel: "glm-5-turbo",
+			wantOK:    true,
+		},
+		// Regression #260: OpenRouter free models contain BOTH '/' and ':'.
+		// The provider is the first segment; the rest (slashes and colons
+		// included) is the model. Splitting on ':' first would mis-attribute
+		// "openrouter/qwen/qwen3.6-plus" to the provider.
+		{
+			name:      "openrouter free suffix — slash before colon",
+			spec:      "openrouter/qwen/qwen3.6-plus:free",
+			wantProv:  "openrouter",
+			wantModel: "qwen/qwen3.6-plus:free",
+			wantOK:    true,
+		},
+		{
+			name:      "openrouter paid — multiple slashes, no colon",
+			spec:      "openrouter/anthropic/claude-sonnet-4",
+			wantProv:  "openrouter",
+			wantModel: "anthropic/claude-sonnet-4",
+			wantOK:    true,
+		},
+		{
+			name:      "colon appears before slash in model id",
+			spec:      "provider:model/variant",
+			wantProv:  "provider",
+			wantModel: "model/variant",
+			wantOK:    true,
+		},
+		{
+			name:   "empty spec",
+			spec:   "",
+			wantOK: false,
+		},
+		{
+			name:   "no separator",
+			spec:   "just-a-string",
+			wantOK: false,
+		},
+		{
+			name:   "leading slash",
+			spec:   "/model-id",
+			wantOK: false,
+		},
+		{
+			name:   "leading colon",
+			spec:   ":model-id",
+			wantOK: false,
+		},
+		{
+			name:   "trailing slash with empty model",
+			spec:   "provider/",
+			wantOK: false,
+		},
+		{
+			name:   "trailing colon with empty model",
+			spec:   "provider:",
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotProv, gotModel, gotOK := SplitProviderModel(tt.spec)
+			if gotOK != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", gotOK, tt.wantOK)
+			}
+			if !tt.wantOK {
+				return
+			}
+			if gotProv != tt.wantProv {
+				t.Errorf("providerID = %q, want %q", gotProv, tt.wantProv)
+			}
+			if gotModel != tt.wantModel {
+				t.Errorf("modelID = %q, want %q", gotModel, tt.wantModel)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #802

## Summary

Introduces `model.SplitProviderModel` helper that splits at the FIRST occurrence of '/' or ':', fixing OpenRouter free model specs like `openrouter/qwen/qwen3.6-plus:free` which contain both separators.

Applied to the 3 parse sites:
- `internal/cli/sync.go`: `parseModelSpec`
- `internal/components/sdd/profiles.go`: `extractModelFromAgent`
- `internal/components/sdd/read_assignments.go`: `ReadCurrentModelAssignments`

## Changes

| File | Change |
|------|--------|
| `internal/model/split.go` | New `SplitProviderModel` helper (first-separator split) |
| `internal/model/split_test.go` | 11 test cases covering colon, slash, OpenRouter free/paid, edge cases |
| `internal/cli/sync.go` | Use new helper in `parseModelSpec` |
| `internal/components/sdd/profiles.go` | Use new helper in `extractModelFromAgent` |
| `internal/components/sdd/read_assignments.go` | Use new helper in `ReadCurrentModelAssignments` |
| `internal/components/sdd/profiles_test.go` | `TestExtractModelFromAgent` regression tests |
| `internal/components/sdd/read_assignments_test.go` | `TestReadCurrentModelAssignmentsOpenRouterFreeSuffix` regression test |

## Test Plan

- [x] `go test ./internal/model/...` — 11 SplitProviderModel tests pass
- [x] `go test ./internal/cli/...` — all sync tests pass
- [x] `go test ./internal/components/sdd/...` — all profiles/read_assignments tests pass
- [x] New regression tests: `openrouter/qwen/qwen3.6-plus:free` correctly splits to provider=openrouter, model=qwen/qwen3.6-plus:free

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model specification parsing across the app, including support for both `provider/model` and `provider:model` formats.
  * Fixed handling of model names that contain multiple separators, preventing incorrect parsing of certain provider strings.
  * Invalid or incomplete model entries are now safely ignored or reported instead of being misread.
* **Tests**
  * Added regression coverage for standard and edge-case model parsing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->