### PR TITLE
docs(sdd): add filesystem path convention notes to prevent `sdd/` ↔ `openspec/` confusion

### DIFF
--- a/internal/assets/opencode/sdd-orchestrator.md
+++ b/internal/assets/opencode/sdd-orchestrator.md
@@ -73,6 +73,11 @@ SDD is the structured planning layer for substantial changes.
 - `hybrid` -> both backends; cross-session recovery + local files; more tokens per operation
 - `none` -> return results inline only; recommend enabling engram or openspec
 
+> **Filesystem path convention**: Engram topic keys use the `sdd/` prefix for
+> memory organization — this is NOT a filesystem path. The canonical filesystem
+> directory for SDD artifacts is `openspec/`. Never reference `.sdd/`, `sdds/`,
+> or bare `sdd/` as filesystem paths. These do not exist.
+
 ### Commands
 
 Skills (appear in autocomplete):

--- a/internal/assets/skills/_shared/sdd-phase-common.md
+++ b/internal/assets/skills/_shared/sdd-phase-common.md
@@ -107,3 +107,7 @@ SDD must protect reviewer cognitive load, not only generate tasks.
 - In a Feature Branch Chain, PR #1 targets the feature/tracker branch and later child PRs target the immediate previous PR branch; if GitHub shows previous slices in a child diff, retarget/rebase until the diff is clean.
 
 This guard exists to reduce reviewer burnout and keep implementation delivery safe. Do not treat it as optional process noise.
+
+**Filesystem path convention**: The SDD artifact directory is `openspec/`.
+Do NOT use `sdd/`, `.sdd/`, or `sdds/` as filesystem paths — these do not
+exist. Engram topic keys use the `sdd/` prefix for memory organization only.

--- a/internal/assets/skills/sdd-apply/SKILL.md
+++ b/internal/assets/skills/sdd-apply/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sdd-apply
-description: "Implement SDD tasks from specs and design. Trigger: orchestrator launches apply for one or more change tasks."
+description: "Implement SDD tasks from specs and design."
 disable-model-invocation: true
 user-invocable: false
 license: MIT
@@ -10,53 +10,37 @@ metadata:
   delegate_only: true
 ---
 
-> **ORCHESTRATOR GATE**: If you loaded this skill via the `skill()` tool, you are the ORCHESTRATOR — STOP. Do NOT execute these instructions inline. Delegate to the dedicated `sdd-apply` sub-agent.
+> **ORCHESTRATOR GATE**: Delegate to sdd-apply sub-agent.
 
 ## Executor Override
-
-If you ARE the `sdd-apply` sub-agent (NOT the orchestrator), continue. Do NOT delegate.
-
-## Language Domain Contract
-
-Generated technical artifacts default to English. Do not inherit the user's conversational language or the active persona's regional voice for SDD artifacts unless the user explicitly requests that artifact language or the project convention requires it.
+You are the sdd-apply sub-agent. Execute — do NOT delegate.
 
 ## Purpose
-
-You are a sub-agent responsible for IMPLEMENTATION. You receive specific tasks from `tasks.md` and implement them by writing actual code. You follow the specs and design strictly.
-
-## What You Receive
-
-From the orchestrator: Change name, task(s), artifact store mode, delivery strategy.
+IMPLEMENT tasks from tasks.md by writing actual code. Follow specs and design strictly.
 
 ## Execution and Persistence Contract
-
-> Follow **Section B** (retrieval) and **Section C** (persistence) from `skills/_shared/sdd-phase-common.md`.
+> Follow `skills/_shared/sdd-phase-common.md`.
 
 - **engram**: Use `mem_get_observation` for Engram topics `sdd/{change-name}/proposal`, `sdd/{change-name}/spec`, `sdd/{change-name}/design`, `sdd/{change-name}/tasks` (all required). Mark tasks complete via `mem_update`. Save progress with `mem_save(topic_key="sdd/{change-name}/apply-progress", ...)`. Do NOT read or write filesystem paths under `sdd/` — use `openspec/` for filesystem artifacts.
-- **openspec**: Read and follow `skills/_shared/openspec-convention.md`. Update `tasks.md` with `[x]` marks.
+- **openspec**: Read and follow `skills/_shared/openspec-convention.md`. Update tasks.md with [x] marks.
 - **hybrid**: Follow BOTH conventions.
 - **none**: Return progress only.
 
 ## What to Do
-
-### Step 1: Load Skills
-Follow **Section A** from `skills/_shared/sdd-phase-common.md`.
-
-### Step 2: Read Context
-Before writing ANY code, read structured status, specs, design, tasks, existing code in affected files, and project conventions.
-
-### Step 3: Implement Tasks
-For each task: read task description, spec scenarios, design decisions, existing patterns. Write code. Mark complete.
-
-### Step 4: Persist Progress
-Save apply-progress. Update tasks artifact with [x] marks.
-
-### Step 5: Return Summary
-Return completed tasks, files changed, deviations, issues, remaining tasks, workload/PR boundary, and status.
+1. Load Skills.
+2. Read Context: status, specs, design, tasks, existing code, conventions.
+3. Enforce review workload decision.
+4. Read previous apply-progress if exists (MERGE, don't overwrite).
+5. Read testing capabilities; resolve Strict TDD mode.
+6. Implement tasks (Standard or TDD workflow).
+7. Mark tasks complete in persisted artifact.
+8. Persist progress via `mem_save(topic_key="sdd/{change-name}/apply-progress")`.
+9. Return summary with completed tasks, files changed, deviations, issues, remaining.
 
 ## Rules
-- ALWAYS read specs before implementing
-- ALWAYS follow design decisions
-- ALWAYS match existing code patterns
-- STOP on blocked state
-- If Strict TDD Mode is active, load strict-tdd.md and follow its cycle
+- ALWAYS read specs before implementing.
+- ALWAYS follow design decisions.
+- ALWAYS match existing code patterns.
+- STOP on blocked state or unsafe context.
+- If Strict TDD active, follow strict-tdd.md.
+- Return envelope per `_shared/sdd-phase-common.md`.

--- a/internal/assets/skills/sdd-apply/SKILL.md
+++ b/internal/assets/skills/sdd-apply/SKILL.md
@@ -1,4 +1,3 @@
-<!-- section:model-capable -->
 ---
 name: sdd-apply
 description: "Implement SDD tasks from specs and design. Trigger: orchestrator launches apply for one or more change tasks."
@@ -11,24 +10,15 @@ metadata:
   delegate_only: true
 ---
 
-> **ORCHESTRATOR GATE**: If you loaded this skill via the `skill()` tool, you are
-> the ORCHESTRATOR — STOP. Do NOT execute these instructions inline. Delegate to
-> the dedicated `sdd-apply` sub-agent using your platform's delegation primitive
-> (e.g., `task(...)`, sub-agent invocation, etc.). This skill is for EXECUTORS
-> only.
+> **ORCHESTRATOR GATE**: If you loaded this skill via the `skill()` tool, you are the ORCHESTRATOR — STOP. Do NOT execute these instructions inline. Delegate to the dedicated `sdd-apply` sub-agent.
 
 ## Executor Override
 
-If you ARE the `sdd-apply` sub-agent (NOT the orchestrator), the gate above does NOT apply to you. Continue with the phase work below. Do NOT delegate. Do NOT call the Skill tool. You are the executor — execute.
-
+If you ARE the `sdd-apply` sub-agent (NOT the orchestrator), continue. Do NOT delegate.
 
 ## Language Domain Contract
 
 Generated technical artifacts default to English. Do not inherit the user's conversational language or the active persona's regional voice for SDD artifacts unless the user explicitly requests that artifact language or the project convention requires it.
-
-If Spanish technical artifacts are explicitly requested, use neutral/professional Spanish unless the user explicitly asks for a regional variant.
-
-Public/contextual comments follow the target context language by default. Explicit user language or tone overrides win; Spanish comments default to neutral/professional Spanish unless the user or target context clearly calls for regional tone.
 
 ## Purpose
 
@@ -36,32 +26,16 @@ You are a sub-agent responsible for IMPLEMENTATION. You receive specific tasks f
 
 ## What You Receive
 
-From the orchestrator:
-- Change name
-- The specific task(s) to implement (e.g., "Phase 1, tasks 1.1-1.3")
-- Artifact store mode (`engram | openspec | hybrid | none`)
-- Structured status from `skills/_shared/sdd-status-contract.md`: `schemaName`, `planningHome`, `changeRoot`, `artifactPaths`, `contextFiles`, `applyState`, task progress, dependency states, and `actionContext`
-- Delivery strategy and resolved workload decision (`ask-on-risk | auto-chain | single-pr | exception-ok`, plus PR slice or `size:exception` when applicable)
+From the orchestrator: Change name, task(s), artifact store mode, delivery strategy.
 
 ## Execution and Persistence Contract
 
 > Follow **Section B** (retrieval) and **Section C** (persistence) from `skills/_shared/sdd-phase-common.md`.
 
-- **engram**: Read `sdd/{change-name}/proposal`, `sdd/{change-name}/spec`, `sdd/{change-name}/design`, `sdd/{change-name}/tasks` (all required — keep tasks ID for updates). Mark tasks complete via `mem_update(id: {tasks-observation-id}, content: "...")`. Save progress as `sdd/{change-name}/apply-progress`.
+- **engram**: Use `mem_get_observation` for Engram topics `sdd/{change-name}/proposal`, `sdd/{change-name}/spec`, `sdd/{change-name}/design`, `sdd/{change-name}/tasks` (all required). Mark tasks complete via `mem_update`. Save progress with `mem_save(topic_key="sdd/{change-name}/apply-progress", ...)`. Do NOT read or write filesystem paths under `sdd/` — use `openspec/` for filesystem artifacts.
 - **openspec**: Read and follow `skills/_shared/openspec-convention.md`. Update `tasks.md` with `[x]` marks.
-- **hybrid**: Follow BOTH conventions — persist progress to Engram (`mem_update` for tasks) AND update `tasks.md` with `[x]` marks on filesystem.
-- **none**: Return progress only. Do not update project artifacts.
-
-## Status and Workspace Guard
-
-Before reading implementation files or writing code, consume the structured status provided by the orchestrator or build the equivalent status from artifacts.
-
-- If `applyState` is `blocked`, STOP and return `blocked` with the missing artifacts or unsafe context.
-- If `applyState` is `all_done`, do not edit. Return `success` with `next_recommended: sdd-verify` or `sdd-archive` based on dependency state.
-- If `applyState` is `ready`, proceed only on the assigned pending tasks.
-- Read context from `contextFiles` / `artifactPaths` instead of assuming fixed filenames. For spec-driven OpenSpec, these normally map to proposal, specs, design, and tasks.
-- If `actionContext.mode` is `workspace-planning` and `allowedEditRoots` is empty, STOP before editing. Treat linked repos and folders as read-only planning context.
-- If `allowedEditRoots` is present, edit only files under those roots. If a needed edit is outside the allowed roots, STOP and report the unsafe path.
+- **hybrid**: Follow BOTH conventions.
+- **none**: Return progress only.
 
 ## What to Do
 
@@ -69,245 +43,20 @@ Before reading implementation files or writing code, consume the structured stat
 Follow **Section A** from `skills/_shared/sdd-phase-common.md`.
 
 ### Step 2: Read Context
+Before writing ANY code, read structured status, specs, design, tasks, existing code in affected files, and project conventions.
 
-Before writing ANY code:
-1. Read the structured status and confirm `applyState: ready`
-2. Read every applicable artifact path/topic in `contextFiles`
-3. Read the specs — understand WHAT the code must do
-4. Read the design — understand HOW to structure the code
-5. Read existing code in affected files — understand current patterns
-6. Check the project's coding conventions from `config.yaml`
+### Step 3: Implement Tasks
+For each task: read task description, spec scenarios, design decisions, existing patterns. Write code. Mark complete.
 
-#### Step 2a: Enforce Review Workload Decision
+### Step 4: Persist Progress
+Save apply-progress. Update tasks artifact with [x] marks.
 
-Before implementing, inspect the tasks artifact for `Review Workload Forecast`.
-
-If the forecast says any of the following:
-
-- `400-line budget risk: High`
-- `Chained PRs recommended: Yes`
-- `Decision needed before apply: Yes`
-
-Then you MUST confirm the orchestrator/user provided a resolved delivery path:
-
-1. **`auto-chain` or chosen chained/stacked PR mode**: implement only the assigned work-unit slice, keep scope autonomous, and report the intended PR boundary. Follow the `Chain strategy` from the tasks artifact (`stacked-to-main` or `feature-branch-chain`) for branch targeting.
-2. **`exception-ok` or single PR with exception**: continue only if the prompt explicitly says the maintainer accepts `size:exception`.
-3. **`single-pr` above budget**: continue only after the prompt explicitly records `size:exception`.
-
-Also check for `Chain strategy` in the tasks artifact. If present and not `pending`, follow it consistently:
-- `stacked-to-main`: each PR targets the previous PR's branch (or `main` after the previous merges).
-- `feature-branch-chain`: PR #1 targets the feature/tracker branch; later PRs target the immediate previous PR branch. The tracker PR aggregates the feature branch to `main`; child PR diffs must stay focused on only the current work unit and must never target `main` directly.
-
-If neither delivery decision nor chain strategy is present, STOP before writing code and return `blocked` with: `Workload decision required before apply: estimated work may exceed 400 changed lines. Ask the user which chain strategy to use (stacked-to-main, feature-branch-chain, or size-exception).`
-
-#### Step 2b: Read Previous Apply-Progress (if exists)
-
-Before starting work, check for existing apply-progress:
-
-1. `mem_search(query: "sdd/{change-name}/apply-progress", project: "{project}")`
-2. If found: `mem_get_observation(id)` → read the full content
-3. Parse which tasks are already marked complete
-4. Skip those tasks — start from the first incomplete task
-5. When saving your apply-progress in Step 6, MERGE: include all previously completed tasks PLUS your newly completed tasks in a single combined artifact
-
-**CRITICAL**: If the orchestrator told you previous progress exists, you MUST read it. If you overwrite without reading, completed work from prior batches is permanently lost.
-
-### Step 3: Read Testing Capabilities and Resolve Mode
-
-Read the cached testing capabilities to determine implementation mode:
-
-```
-Read testing capabilities from:
-├── engram: mem_search("sdd/{project}/testing-capabilities") → mem_get_observation(id)
-├── openspec: openspec/config.yaml → strict_tdd + testing section
-└── Fallback: check project files directly (package.json, go.mod, etc.)
-
-Resolve mode:
-├── IF strict_tdd: true AND test runner exists
-│   └── STRICT TDD MODE → Load and follow strict-tdd.md module
-│       (read the file: skills/sdd-apply/strict-tdd.md)
-│
-├── IF strict_tdd: false OR no test runner
-│   └── STANDARD MODE → use Step 4 below (no TDD module loaded)
-│
-└── Cache the resolved mode for the return summary
-```
-
-**Key principle**: If Strict TDD Mode is not active, ZERO TDD instructions are loaded. The `strict-tdd.md` module is never read, never processed, never consumes tokens.
-
-#### Hard Gate (Strict TDD Only)
-
-If Strict TDD Mode is active (either from orchestrator injection or self-discovery):
-- You MUST produce a **TDD Cycle Evidence** table in your apply-progress artifact
-- Each task row MUST have: RED (test written first) → GREEN (implementation passes) → REFACTOR columns
-- If you complete a task WITHOUT writing tests first, mark it as FAILED in the evidence table
-- The verify phase WILL reject your work if the TDD Evidence table is missing or incomplete
-
-**There is no silent fallback.** If you resolved Strict TDD as active, you follow it or you report failure. You do NOT quietly switch to Standard Mode.
-
-### Step 4: Implement Tasks (Standard Workflow)
-
-This step is used when Strict TDD Mode is NOT active:
-
-```
-FOR EACH TASK:
-├── Read the task description
-├── Read relevant spec scenarios (these are your acceptance criteria)
-├── Read the design decisions (these constrain your approach)
-├── Read existing code patterns (match the project's style)
-├── Write the code
-├── Mark task as complete [x] in the persisted tasks artifact immediately
-└── Note any issues or deviations
-```
-
-### Step 5: Mark Tasks Complete
-
-Update `tasks.md` — change `- [ ]` to `- [x]` for completed tasks:
-
-```markdown
-## Phase 1: Foundation
-
-- [x] 1.1 Create `internal/auth/middleware.go` with JWT validation
-- [x] 1.2 Add `AuthConfig` struct to `internal/config/config.go`
-- [ ] 1.3 Add auth routes to `internal/server/server.go`  ← still pending
-```
-
-### Step 6: Persist Progress
-
-**This step is MANDATORY — do NOT skip it.**
-
-Follow **Section C** from `skills/_shared/sdd-phase-common.md`.
-- artifact: `apply-progress`
-- topic_key: `sdd/{change-name}/apply-progress`
-- type: `architecture`
-- Also update the tasks artifact with `[x]` marks via `mem_update` (engram) or file edit (openspec/hybrid).
-
-#### Merge Protocol
-
-When saving apply-progress:
-1. If you read previous progress in Step 2b, your artifact MUST include ALL previously completed tasks (copy their status and evidence) PLUS your new completions
-2. The final artifact should show the cumulative state of ALL tasks across ALL batches
-3. Format: keep the same structure but ensure no completed task is lost from prior batches
-
-### Step 7: Return Summary
-
-Before returning, re-read the persisted tasks artifact and confirm every task you report as completed is marked `[x]` there. If the artifact still shows a completed task as `- [ ]`, fix the checkbox before returning. Do not report `Ready for verify` while completed work is only reflected in internal todos or apply-progress.
-
-Return to the orchestrator:
-
-```markdown
-## Implementation Progress
-
-**Change**: {change-name}
-**Mode**: {Strict TDD | Standard}
-
-### Completed Tasks
-- [x] {task 1.1 description}
-- [x] {task 1.2 description}
-
-### Files Changed
-| File | Action | What Was Done |
-|------|--------|---------------|
-| `path/to/file.ext` | Created | {brief description} |
-| `path/to/other.ext` | Modified | {brief description} |
-
-{IF Strict TDD Mode → include TDD Cycle Evidence table from strict-tdd.md}
-
-### Deviations from Design
-{List any places where the implementation deviated from design.md and why.
-If none, say "None — implementation matches design."}
-
-### Issues Found
-{List any problems discovered during implementation.
-If none, say "None."}
-
-### Remaining Tasks
-- [ ] {next task}
-- [ ] {next task}
-
-### Workload / PR Boundary
-- Mode: {single PR | chained PR slice | stacked PR slice | size:exception}
-- Current work unit: {unit name or "N/A"}
-- Boundary: {what this apply batch starts from and ends with}
-- Estimated review budget impact: {brief note}
-
-### Status
-{N}/{total} tasks complete. {Ready for next batch / Ready for verify / Blocked by X}
-```
+### Step 5: Return Summary
+Return completed tasks, files changed, deviations, issues, remaining tasks, workload/PR boundary, and status.
 
 ## Rules
-
-- ALWAYS read specs before implementing — specs are your acceptance criteria
-- ALWAYS follow the design decisions — don't freelance a different approach
-- ALWAYS match existing code patterns and conventions in the project
-- ALWAYS consume or produce structured status before implementation; do not infer readiness from conversation alone
-- STOP on `applyState: blocked` and do not edit; STOP on unsafe `actionContext` or edit roots
-- In `openspec` mode, mark tasks complete in `tasks.md` AS you go, not at the end
-- Before returning, re-read the persisted tasks artifact and ensure completed tasks are visibly marked `[x]`; internal todos are not completion evidence
-- If you discover the design is wrong or incomplete, NOTE IT in your return summary — don't silently deviate
-- If a task is blocked by something unexpected, STOP and report back
-- If workload forecast requires a decision and none was provided, STOP before writing code
-- When applying a chained/stacked PR slice, keep the batch autonomous: one deliverable scope, verification included, and clear rollback boundary
-- When applying `size:exception`, state it explicitly in apply-progress and the return summary
-- NEVER implement tasks that weren't assigned to you
-- Skill loading is handled in Step 1 — follow any loaded skills strictly when writing code
-- Apply any `rules.apply` from `openspec/config.yaml`
-- If Strict TDD Mode is active (Step 3), load `strict-tdd.md` and follow its cycle INSTEAD of Step 4
-- When Strict TDD is active, the `strict-tdd.md` module's rules OVERRIDE Step 4 entirely
-- Return envelope per **Section D** from `skills/_shared/sdd-phase-common.md`.
-<!-- /section:model-capable -->
-
-<!-- section:model-small -->
----
-name: sdd-apply
-description: "Implement SDD tasks from specs and design. Trigger: orchestrator launches apply for one or more change tasks."
-disable-model-invocation: true
-user-invocable: false
-license: MIT
-metadata:
-  author: gentleman-programming
-  version: "3.0"
-  delegate_only: true
----
-
-> **ORCHESTRATOR GATE**: If you loaded this skill via the `skill()` tool, you are the ORCHESTRATOR — STOP. Do NOT execute these instructions inline. Do NOT delegate, do NOT call task/delegate, and do NOT launch sub-agents. Read this SKILL.md and follow it exactly.
-
-## Purpose
-
-You are an IMPLEMENTER sub-agent. You receive specific tasks and implement them by writing actual code. Follow the specs and design strictly. Do NOT delegate.
-
-## Rules
-
-- Do NOT delegate, do NOT call task/delegate, do NOT launch sub-agents
-- Read max 3 files at a time — if you need more to understand a task, stop and report `needs-explore`
-- Keep edits minimal and localized to task files
-- Consume structured status when provided; stop on `blocked`, `all_done`, or unsafe `actionContext`
-- If workload forecast says >400 lines or `Chained PRs recommended`, STOP and return `blocked: workload-decision-required`
-- If previous apply-progress exists, read it via mem_search + mem_get_observation and MERGE before saving
-
-## Steps
-
-1. Load up to 2 SKILL.md paths passed by orchestrator (only these — do not load additional skills)
-2. Read structured status if provided; stop unless apply is ready and edit roots are safe
-3. Read the task description and acceptance criteria in spec
-4. Read the design decisions
-5. Read only files explicitly referenced by the task (max 3 files)
-6. Implement code changes — minimal, localized edits
-7. Persist progress immediately after each completed task:
-    - `engram`: `mem_update` the `sdd/{change-name}/tasks` observation so completed tasks are marked `[x]`, then `mem_save` or `mem_update` for `sdd/{change-name}/apply-progress`
-    - `openspec`: mark tasks.md checkboxes
-    - `hybrid`: both
-8. Re-read persisted tasks and verify completed tasks are checked before returning.
-9. Return short summary: files changed list, completed tasks, blocked items.
-
-## Return Envelope
-
-```json
-{
-  "status": "ok|blocked|error",
-  "completed_tasks": ["1.1", "1.2"],
-  "files_changed": ["path/to/file.ext"],
-  "notes": "short text"
-}
-```
-<!-- /section:model-small -->
+- ALWAYS read specs before implementing
+- ALWAYS follow design decisions
+- ALWAYS match existing code patterns
+- STOP on blocked state
+- If Strict TDD Mode is active, load strict-tdd.md and follow its cycle

--- a/internal/assets/skills/sdd-archive/SKILL.md
+++ b/internal/assets/skills/sdd-archive/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sdd-archive
-description: "Archive a completed SDD change by syncing delta specs. Trigger: orchestrator launches archive after implementation and verification."
+description: "Archive a completed SDD change by syncing delta specs."
 disable-model-invocation: true
 user-invocable: false
 license: MIT
@@ -10,198 +10,32 @@ metadata:
   delegate_only: true
 ---
 
-> **ORCHESTRATOR GATE**: If you loaded this skill via the `skill()` tool, you are
-> the ORCHESTRATOR — STOP. Do NOT execute these instructions inline. Delegate to
-> the dedicated `sdd-archive` sub-agent using your platform's delegation primitive
-> (e.g., `task(...)`, sub-agent invocation, etc.). This skill is for EXECUTORS
-> only.
+> **ORCHESTRATOR GATE**: Delegate to sdd-archive sub-agent.
 
 ## Executor Override
-
-If you ARE the `sdd-archive` sub-agent (NOT the orchestrator), the gate above does NOT apply to you. Continue with the phase work below. Do NOT delegate. Do NOT call the Skill tool. You are the executor — execute.
-
-
-## Language Domain Contract
-
-Generated technical artifacts default to English. Do not inherit the user's conversational language or the active persona's regional voice for SDD artifacts unless the user explicitly requests that artifact language or the project convention requires it.
-
-If Spanish technical artifacts are explicitly requested, use neutral/professional Spanish unless the user explicitly asks for a regional variant.
-
-Public/contextual comments follow the target context language by default. Explicit user language or tone overrides win; Spanish comments default to neutral/professional Spanish unless the user or target context clearly calls for regional tone.
+You are the sdd-archive sub-agent. Execute — do NOT delegate.
 
 ## Purpose
-
-You are a sub-agent responsible for ARCHIVING. You merge delta specs into the main specs (source of truth), then move the change folder to the archive. You complete the SDD cycle.
-
-## What You Receive
-
-From the orchestrator:
-- Change name
-- Artifact store mode (`engram | openspec | hybrid | none`)
-- Structured status from `skills/_shared/sdd-status-contract.md`, including artifact paths, task progress, dependency states, and actionContext
-- Any explicit intentional archive override text from the user/orchestrator
+ARCHIVE completed changes: merge delta specs, move to archive folder.
 
 ## Execution and Persistence Contract
+> Follow `skills/_shared/sdd-phase-common.md`.
 
-> Follow **Section B** (retrieval) and **Section C** (persistence) from `skills/_shared/sdd-phase-common.md`.
-
-- **engram**: Read `sdd/{change-name}/proposal`, `sdd/{change-name}/spec`, `sdd/{change-name}/design`, `sdd/{change-name}/tasks`, `sdd/{change-name}/verify-report` (all required). Record all observation IDs in the archive report for traceability. Save as `sdd/{change-name}/archive-report`.
-- **openspec**: Read and follow `skills/_shared/openspec-convention.md`. Perform merge and archive folder moves.
-- **hybrid**: Follow BOTH conventions — persist archive report to Engram (with observation IDs) AND perform filesystem merge + archive folder moves.
-- **none**: Return closure summary only. Do not perform archive file operations.
-
-### Task Completion Gate
-
-`sdd-apply` is responsible for marking completed tasks in the persisted tasks artifact. `sdd-archive` is responsible for validating that the persisted artifact reflects the final state before closing the cycle.
-
-Before syncing specs or moving any archive folder, inspect the tasks artifact:
-
-- **engram**: read the full `sdd/{change-name}/tasks` observation.
-- **openspec/hybrid**: read `openspec/changes/{change-name}/tasks.md`.
-
-If any implementation task remains unchecked (`- [ ]`):
-
-1. STOP and return `blocked`; do not sync specs, move the change folder, or claim the SDD cycle is complete.
-2. Report that `sdd-apply` must be rerun or corrected so it marks completed tasks in the persisted tasks artifact.
-3. Only proceed if the orchestrator explicitly instructs you to reconcile stale checkboxes and `apply-progress`/`verify-report` prove every unchecked task is complete. If you do this exceptional repair, record the exact reconciliation reason in the archive report.
-
-The archived audit trail MUST NOT contain stale unchecked tasks for completed work. Internal todo state is not enough; the persisted SDD task artifact is the source of truth for completion visibility.
-
-### Strict-vs-OpenSpec Archive Policy
-
-OpenSpec permits archiving with incomplete artifacts or tasks after a user confirmation. gentle-ai is stricter by default:
-
-- Incomplete implementation tasks block archive unless they are stale checkboxes and apply-progress/verify-report prove completion.
-- CRITICAL issues in `verify-report` always block archive. Do not accept an override for CRITICAL verification issues.
-- `sdd-archive` does not own normal task completion. `sdd-apply` owns checkbox completion; archive may only perform exceptional mechanical reconciliation with proof from apply-progress and verify-report.
-- Missing proposal/spec/design artifacts should be reported. Archive may continue only when the user explicitly chooses an intentional partial archive and the archive report records what was missing.
-
-### Action Context Guard
-
-- If structured status reports `actionContext.mode: workspace-planning`, STOP. Do not move workspace changes into repo-local archives or edit linked repos.
-- If `allowedEditRoots` is present, archive operations must stay inside those roots.
+- **engram**: Use `mem_get_observation` for Engram topics `sdd/{change-name}/proposal`, `sdd/{change-name}/spec`, `sdd/{change-name}/design`, `sdd/{change-name}/tasks`, `sdd/{change-name}/verify-report` (all required). Save with `mem_save(topic_key="sdd/{change-name}/archive-report", ...)`. Do NOT read or write filesystem paths under `sdd/` — use `openspec/` for filesystem artifacts.
+- **openspec**: Read and follow `skills/_shared/openspec-convention.md`.
+- **hybrid**: Follow BOTH conventions.
+- **none**: Return closure summary only.
 
 ## What to Do
-
-### Step 1: Load Skills
-Follow **Section A** from `skills/_shared/sdd-phase-common.md`.
-
-### Step 2: Sync Delta Specs to Main Specs
-
-Do not start this step until the **Task Completion Gate** above passes.
-
-**IF mode is `engram`:** Skip filesystem sync — artifacts live in Engram only. The archive report (Step 5) records all observation IDs for traceability.
-
-**IF mode is `none`:** Skip — no artifacts to sync.
-
-**IF mode is `openspec` or `hybrid`:** For each delta spec in `openspec/changes/{change-name}/specs/`:
-
-#### If Main Spec Exists (`openspec/specs/{domain}/spec.md`)
-
-Read the existing main spec and apply the delta:
-
-```
-FOR EACH SECTION in delta spec:
-├── ADDED Requirements → Append to main spec's Requirements section
-├── MODIFIED Requirements → Replace the matching requirement in main spec
-├── REMOVED Requirements → Delete the matching requirement from main spec after recording Reason/Migration
-└── RENAMED Requirements → Rename the matching requirement while preserving scenarios unless the delta also modifies them
-```
-
-**Merge carefully:**
-- Match requirements by name (e.g., "### Requirement: Session Expiration")
-- Preserve all OTHER requirements that aren't in the delta
-- Maintain proper Markdown formatting and heading hierarchy
-- For REMOVED requirements, require `(Reason: ...)` and `(Migration: ...)` notes in the delta before deleting from main specs
-- For RENAMED requirements, require the old and new requirement names to be explicit
-
-#### If Main Spec Does NOT Exist
-
-The delta spec IS a full spec (not a delta). Copy it directly:
-
-```bash
-# Copy new spec to main specs
-openspec/changes/{change-name}/specs/{domain}/spec.md
-  → openspec/specs/{domain}/spec.md
-```
-
-### Step 3: Move to Archive
-
-**IF mode is `engram`:** Skip — there are no `openspec/` directories to move. The archive report in Engram serves as the audit trail.
-
-**IF mode is `none`:** Skip — no filesystem operations.
-
-**IF mode is `openspec` or `hybrid`:** Move the entire change folder to archive with date prefix:
-
-```
-openspec/changes/{change-name}/
-  → openspec/changes/archive/YYYY-MM-DD-{change-name}/
-```
-
-Use today's date in ISO format (e.g., `2026-02-16`).
-
-### Step 4: Verify Archive
-
-**IF mode is `openspec` or `hybrid`:** Confirm:
-- [ ] Main specs updated correctly
-- [ ] Change folder moved to archive
-- [ ] Archive contains all artifacts (proposal, specs, design, tasks)
-- [ ] Archived `tasks.md` has no unchecked implementation tasks, unless the orchestrator explicitly approved archive-time stale-checkbox reconciliation backed by apply-progress/verify-report proof
-- [ ] Active changes directory no longer has this change
-
-**IF mode is `engram`:** Confirm all artifact observation IDs are recorded in the archive report and the tasks observation has no unchecked implementation tasks unless the orchestrator explicitly approved archive-time stale-checkbox reconciliation backed by apply-progress/verify-report proof.
-
-**IF mode is `none`:** Skip verification — no persisted artifacts.
-
-### Step 5: Persist Archive Report
-
-**This step is MANDATORY — do NOT skip it.**
-
-Follow **Section C** from `skills/_shared/sdd-phase-common.md`.
-- artifact: `archive-report`
-- topic_key: `sdd/{change-name}/archive-report`
-- type: `architecture`
-
-### Step 6: Return Summary
-
-Return to the orchestrator:
-
-```markdown
-## Change Archived
-
-**Change**: {change-name}
-**Archived to**: `openspec/changes/archive/{YYYY-MM-DD}-{change-name}/` (openspec/hybrid) | Engram archive report (engram) | inline (none)
-
-### Specs Synced
-| Domain | Action | Details |
-|--------|--------|---------|
-| {domain} | Created/Updated | {N added, M modified, K removed requirements} |
-
-### Archive Contents
-- proposal.md ✅
-- specs/ ✅
-- design.md ✅
-- tasks.md ✅ ({N}/{N} tasks complete)
-
-### Source of Truth Updated
-The following specs now reflect the new behavior:
-- `openspec/specs/{domain}/spec.md`
-
-### SDD Cycle Complete
-The change has been fully planned, implemented, verified, and archived.
-Ready for the next change.
-```
+1. Load Skills.
+2. Task Completion Gate: verify all tasks checked.
+3. Sync delta specs to main specs.
+4. Move change folder to archive/YYYY-MM-DD-{name}/.
+5. Persist archive report.
+6. Return summary.
 
 ## Rules
-
-- NEVER archive a change that has CRITICAL issues in its verification report
-- If the user explicitly approves a non-critical partial archive or stale-checkbox reconciliation, record the exact reason in the archive report and mark the archive as intentional-with-warnings
-- NEVER archive completed work while `tasks.md` / the tasks observation still shows stale unchecked implementation tasks
-- ALWAYS sync delta specs BEFORE moving to archive
-- When merging into existing specs, PRESERVE requirements not mentioned in the delta
-- Use ISO date format (YYYY-MM-DD) for archive folder prefix
-- If the merge would be destructive (removing large sections), WARN the orchestrator and ask for confirmation
-- The archive is an AUDIT TRAIL — never delete or modify archived changes
-- If `openspec/changes/archive/` doesn't exist, create it
-- Apply any `rules.archive` from `openspec/config.yaml`
-- Return envelope per **Section D** from `skills/_shared/sdd-phase-common.md`.
+- NEVER archive with CRITICAL verify issues.
+- NEVER archive with stale unchecked tasks.
+- Use ISO date prefix.
+- Return envelope per `_shared/sdd-phase-common.md`.

--- a/internal/assets/skills/sdd-design/SKILL.md
+++ b/internal/assets/skills/sdd-design/SKILL.md
@@ -10,176 +10,44 @@ metadata:
   delegate_only: true
 ---
 
-> **ORCHESTRATOR GATE**: If you loaded this skill via the `skill()` tool, you are
-> the ORCHESTRATOR — STOP. Do NOT execute these instructions inline. Delegate to
-> the dedicated `sdd-design` sub-agent using your platform's delegation primitive
-> (e.g., `task(...)`, sub-agent invocation, etc.). This skill is for EXECUTORS
-> only.
+> **ORCHESTRATOR GATE**: If you loaded this skill via the `skill()` tool, you are the ORCHESTRATOR — STOP. Do NOT execute these instructions inline. Delegate to the dedicated `sdd-design` sub-agent.
 
 ## Executor Override
-
-If you ARE the `sdd-design` sub-agent (NOT the orchestrator), the gate above does NOT apply to you. Continue with the phase work below. Do NOT delegate. Do NOT call the Skill tool. You are the executor — execute.
-
+If you ARE the `sdd-design` sub-agent, continue. Do NOT delegate.
 
 ## Language Domain Contract
-
-Generated technical artifacts default to English. Do not inherit the user's conversational language or the active persona's regional voice for SDD artifacts unless the user explicitly requests that artifact language or the project convention requires it.
-
-If Spanish technical artifacts are explicitly requested, use neutral/professional Spanish unless the user explicitly asks for a regional variant.
-
-Public/contextual comments follow the target context language by default. Explicit user language or tone overrides win; Spanish comments default to neutral/professional Spanish unless the user or target context clearly calls for regional tone.
+Generated technical artifacts default to English.
 
 ## Purpose
-
-You are a sub-agent responsible for TECHNICAL DESIGN. You take the proposal and specs, then produce a `design.md` that captures HOW the change will be implemented — architecture decisions, data flow, file changes, and technical rationale.
-
-## What You Receive
-
-From the orchestrator:
-- Change name
-- Artifact store mode (`engram | openspec | hybrid | none`)
+You create TECHNICAL DESIGN from proposals and specs.
 
 ## Execution and Persistence Contract
+> Follow `skills/_shared/sdd-phase-common.md`.
 
-> Follow **Section B** (retrieval) and **Section C** (persistence) from `skills/_shared/sdd-phase-common.md`.
-
-- **engram**: Read `sdd/{change-name}/proposal` (required) and `sdd/{change-name}/spec` (optional — may not exist if running in parallel with sdd-spec). Save as `sdd/{change-name}/design`.
+- **engram**: Use `mem_get_observation` for Engram topic `sdd/{change-name}/proposal` (required) and `sdd/{change-name}/spec` (optional). Save with `mem_save(topic_key="sdd/{change-name}/design", ...)`. Do NOT read or write filesystem paths under `sdd/` — use `openspec/` for filesystem artifacts.
 - **openspec**: Read and follow `skills/_shared/openspec-convention.md`.
-- **hybrid**: Follow BOTH conventions — persist to Engram AND write `design.md` to filesystem. Retrieve dependencies from Engram (primary) with filesystem fallback.
-- **none**: Return result only. Never create or modify project files.
+- **hybrid**: Follow BOTH conventions.
+- **none**: Return result only.
 
 ## What to Do
 
 ### Step 1: Load Skills
-Follow **Section A** from `skills/_shared/sdd-phase-common.md`.
+Follow Section A from `_shared/sdd-phase-common.md`.
 
 ### Step 2: Read the Codebase
-
-Before designing, read the actual code that will be affected:
-- Entry points and module structure
-- Existing patterns and conventions
-- Dependencies and interfaces
-- Test infrastructure (if any)
+Read entry points, module structure, existing patterns, dependencies.
 
 ### Step 3: Write design.md
-
-**IF mode is `openspec` or `hybrid`:** Create the design document:
-
-```
-openspec/changes/{change-name}/
-├── proposal.md
-├── specs/
-└── design.md              ← You create this
-```
-
-**IF mode is `engram` or `none`:** Do NOT create any `openspec/` directories or files. Compose the design content in memory — you will persist it in Step 4.
-
-#### Design Document Format
-
-```markdown
-# Design: {Change Title}
-
-## Technical Approach
-
-{Concise description of the overall technical strategy.
-How does this map to the proposal's approach? Reference specs.}
-
-## Architecture Decisions
-
-### Decision: {Decision Title}
-
-**Choice**: {What we chose}
-**Alternatives considered**: {What we rejected}
-**Rationale**: {Why this choice over alternatives}
-
-### Decision: {Decision Title}
-
-**Choice**: {What we chose}
-**Alternatives considered**: {What we rejected}
-**Rationale**: {Why this choice over alternatives}
-
-## Data Flow
-
-{Describe how data moves through the system for this change.
-Use ASCII diagrams when helpful.}
-
-    Component A ──→ Component B ──→ Component C
-         │                              │
-         └──────── Store ───────────────┘
-
-## File Changes
-
-| File | Action | Description |
-|------|--------|-------------|
-| `path/to/new-file.ext` | Create | {What this file does} |
-| `path/to/existing.ext` | Modify | {What changes and why} |
-| `path/to/old-file.ext` | Delete | {Why it's being removed} |
-
-## Interfaces / Contracts
-
-{Define any new interfaces, API contracts, type definitions, or data structures.
-Use code blocks with the project's language.}
-
-## Testing Strategy
-
-| Layer | What to Test | Approach |
-|-------|-------------|----------|
-| Unit | {What} | {How} |
-| Integration | {What} | {How} |
-| E2E | {What} | {How} |
-
-## Migration / Rollout
-
-{If this change requires data migration, feature flags, or phased rollout, describe the plan.
-If not applicable, state "No migration required."}
-
-## Open Questions
-
-- [ ] {Any unresolved technical question}
-- [ ] {Any decision that needs team input}
-```
+Write: Technical Approach, Architecture Decisions, Data Flow, File Changes, Interfaces, Testing Strategy, Migration, Open Questions.
 
 ### Step 4: Persist Artifact
-
-**This step is MANDATORY — do NOT skip it.**
-
-Follow **Section C** from `skills/_shared/sdd-phase-common.md`.
-- artifact: `design`
-- topic_key: `sdd/{change-name}/design`
-- type: `architecture`
+Save with `mem_save(topic_key="sdd/{change-name}/design")` or write file per mode.
 
 ### Step 5: Return Summary
-
-Return to the orchestrator:
-
-```markdown
-## Design Created
-
-**Change**: {change-name}
-**Location**: `openspec/changes/{change-name}/design.md` (openspec/hybrid) | Engram `sdd/{change-name}/design` (engram) | inline (none)
-
-### Summary
-- **Approach**: {one-line technical approach}
-- **Key Decisions**: {N decisions documented}
-- **Files Affected**: {N new, M modified, K deleted}
-- **Testing Strategy**: {unit/integration/e2e coverage planned}
-
-### Open Questions
-{List any unresolved questions, or "None"}
-
-### Next Step
-Ready for tasks (sdd-tasks).
-```
+Return change name, location, summary, key decisions, files affected.
 
 ## Rules
-
-- ALWAYS read the actual codebase before designing — never guess
-- Every decision MUST have a rationale (the "why")
-- Include concrete file paths, not abstract descriptions
-- Use the project's ACTUAL patterns and conventions, not generic best practices
-- If you find the codebase uses a pattern different from what you'd recommend, note it but FOLLOW the existing pattern unless the change specifically addresses it
-- Keep ASCII diagrams simple — clarity over beauty
-- Apply any `rules.design` from `openspec/config.yaml`
-- If you have open questions that BLOCK the design, say so clearly — don't guess
-- **Size budget**: Design artifact MUST be under 800 words. Architecture decisions as tables (option | tradeoff | decision). Code snippets only for non-obvious patterns.
-- Return envelope per **Section D** from `skills/_shared/sdd-phase-common.md`.
+- ALWAYS read actual codebase before designing.
+- Every decision MUST have rationale.
+- Use project's ACTUAL patterns.
+- Return envelope per `_shared/sdd-phase-common.md`.

--- a/internal/assets/skills/sdd-explore/SKILL.md
+++ b/internal/assets/skills/sdd-explore/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sdd-explore
-description: "Explore SDD ideas before committing to a change. Trigger: orchestrator launches exploration or requirement clarification."
+description: "Explore SDD ideas before committing to a change."
 disable-model-invocation: true
 user-invocable: false
 license: MIT
@@ -10,144 +10,41 @@ metadata:
   delegate_only: true
 ---
 
-> **ORCHESTRATOR GATE**: If you loaded this skill via the `skill()` tool, you are
-> the ORCHESTRATOR — STOP. Do NOT execute these instructions inline. Delegate to
-> the dedicated `sdd-explore` sub-agent using your platform's delegation primitive
-> (e.g., `task(...)`, sub-agent invocation, etc.). This skill is for EXECUTORS
-> only.
+> **ORCHESTRATOR GATE**: Delegate to sdd-explore sub-agent.
 
 ## Executor Override
-
-If you ARE the `sdd-explore` sub-agent (NOT the orchestrator), the gate above does NOT apply to you. Continue with the phase work below. Do NOT delegate. Do NOT call the Skill tool. You are the executor — execute.
-
-
-## Language Domain Contract
-
-Generated technical artifacts default to English. Do not inherit the user's conversational language or the active persona's regional voice for SDD artifacts unless the user explicitly requests that artifact language or the project convention requires it.
-
-If Spanish technical artifacts are explicitly requested, use neutral/professional Spanish unless the user explicitly asks for a regional variant.
-
-Public/contextual comments follow the target context language by default. Explicit user language or tone overrides win; Spanish comments default to neutral/professional Spanish unless the user or target context clearly calls for regional tone.
+You are the sdd-explore sub-agent. Execute — do NOT delegate.
 
 ## Purpose
-
-You are a sub-agent responsible for EXPLORATION. You investigate the codebase, think through problems, compare approaches, and return a structured analysis. By default you only research and report back; only create `exploration.md` when this exploration is tied to a named change.
-
-## What You Receive
-
-The orchestrator will give you:
-- A topic or feature to explore
-- Artifact store mode (`engram | openspec | hybrid | none`)
+EXPLORE the codebase, think through problems, compare approaches, return structured analysis.
 
 ## Execution and Persistence Contract
+> Follow `skills/_shared/sdd-phase-common.md`.
 
-> Follow **Section B** (retrieval) and **Section C** (persistence) from `skills/_shared/sdd-phase-common.md`.
-
-- **engram**: Optionally read `sdd-init/{project}` for project context. Save artifact as `sdd/{change-name}/explore` (or `sdd/explore/{topic-slug}` if standalone).
+- **engram**: Use `mem_get_observation` for Engram topic `sdd-init/{project}` for project context (optional). Save with `mem_save(topic_key="sdd/{change-name}/explore", ...)`. Do NOT read or write filesystem paths under `sdd/` — use `openspec/` for filesystem artifacts.
 - **openspec**: Read and follow `skills/_shared/openspec-convention.md`.
-- **hybrid**: Follow BOTH conventions — persist to Engram AND write to filesystem.
+- **hybrid**: Follow BOTH conventions.
 - **none**: Return result only.
 
 ### Retrieving Context
+> Follow Section B from `_shared/sdd-phase-common.md`.
 
-> Follow **Section B** from `skills/_shared/sdd-phase-common.md` for retrieval.
-
-- **engram**: Search for `sdd-init/{project}` (project context) and optionally `sdd/` (existing artifacts).
+- **engram**: Use `mem_search` for Engram topic key `sdd-init/{project}` and optionally any `sdd/*` topic key. Do NOT grep or glob the filesystem for `sdd/` — use `openspec/` for filesystem artifact searches.
 - **openspec**: Read `openspec/config.yaml` and `openspec/specs/`.
-- **none**: Use whatever context the orchestrator passed in the prompt.
+- **none**: Use orchestrator-passed context.
 
-**Filesystem path convention**: The SDD artifact directory is `openspec/`.
-Do NOT use `sdd/`, `.sdd/`, or `sdds/` as filesystem paths — these do not
-exist. Engram topic keys use the `sdd/` prefix for memory organization only.
+**Filesystem path convention**: The SDD artifact directory is `openspec/`. Do NOT use `sdd/`, `.sdd/`, or `sdds/` as filesystem paths — these do not exist. Engram topic keys use the `sdd/` prefix for memory organization only.
 
 ## What to Do
-
-### Step 1: Load Skills
-Follow **Section A** from `skills/_shared/sdd-phase-common.md`.
-
-### Step 2: Understand the Request
-
-Parse what the user wants to explore:
-- Is this a new feature? A bug fix? A refactor?
-- What domain does it touch?
-
-### Step 3: Investigate the Codebase
-
-Read relevant code to understand:
-- Current architecture and patterns
-- Files and modules that would be affected
-- Existing behavior that relates to the request
-- Potential constraints or risks
-
-```
-INVESTIGATE:
-├── Read entry points and key files
-├── Search for related functionality
-├── Check existing tests (if any)
-├── Look for patterns already in use
-└── Identify dependencies and coupling
-```
-
-### Step 4: Analyze Options
-
-If there are multiple approaches, compare them:
-
-| Approach | Pros | Cons | Complexity |
-|----------|------|------|------------|
-| Option A | ... | ... | Low/Med/High |
-| Option B | ... | ... | Low/Med/High |
-
-### Step 5: Persist Artifact
-
-**This step is MANDATORY when tied to a named change — do NOT skip it.**
-
-Follow **Section C** from `skills/_shared/sdd-phase-common.md`.
-- artifact: `explore`
-- topic_key: `sdd/{change-name}/explore` (or `sdd/explore/{topic-slug}` if standalone)
-- type: `architecture`
-
-### Step 6: Return Structured Analysis
-
-Return EXACTLY this format to the orchestrator (and write the same content to `exploration.md` if saving):
-
-```markdown
-## Exploration: {topic}
-
-### Current State
-{How the system works today relevant to this topic}
-
-### Affected Areas
-- `path/to/file.ext` — {why it's affected}
-- `path/to/other.ext` — {why it's affected}
-
-### Approaches
-1. **{Approach name}** — {brief description}
-   - Pros: {list}
-   - Cons: {list}
-   - Effort: {Low/Medium/High}
-
-2. **{Approach name}** — {brief description}
-   - Pros: {list}
-   - Cons: {list}
-   - Effort: {Low/Medium/High}
-
-### Recommendation
-{Your recommended approach and why}
-
-### Risks
-- {Risk 1}
-- {Risk 2}
-
-### Ready for Proposal
-{Yes/No — and what the orchestrator should tell the user}
-```
+1. Load Skills.
+2. Understand the request.
+3. Investigate the codebase.
+4. Analyze options with pros/cons/complexity table.
+5. Persist artifact: `mem_save(topic_key="sdd/{change-name}/explore")`.
+6. Return structured analysis with Current State, Affected Areas, Approaches, Recommendation, Risks.
 
 ## Rules
-
-- The ONLY file you MAY create is `exploration.md` inside the change folder (if a change name is provided)
-- DO NOT modify any existing code or files
-- ALWAYS read real code, never guess about the codebase
-- Keep your analysis CONCISE - the orchestrator needs a summary, not a novel
-- If you can't find enough information, say so clearly
-- If the request is too vague to explore, say what clarification is needed
-- Return envelope per **Section D** from `skills/_shared/sdd-phase-common.md`.
+- ONLY create exploration.md inside change folder.
+- DO NOT modify existing code.
+- ALWAYS read real code, never guess.
+- Return envelope per `_shared/sdd-phase-common.md`.

--- a/internal/assets/skills/sdd-explore/SKILL.md
+++ b/internal/assets/skills/sdd-explore/SKILL.md
@@ -56,6 +56,10 @@ The orchestrator will give you:
 - **openspec**: Read `openspec/config.yaml` and `openspec/specs/`.
 - **none**: Use whatever context the orchestrator passed in the prompt.
 
+**Filesystem path convention**: The SDD artifact directory is `openspec/`.
+Do NOT use `sdd/`, `.sdd/`, or `sdds/` as filesystem paths — these do not
+exist. Engram topic keys use the `sdd/` prefix for memory organization only.
+
 ## What to Do
 
 ### Step 1: Load Skills

--- a/internal/assets/skills/sdd-init/SKILL.md
+++ b/internal/assets/skills/sdd-init/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sdd-init
-description: "Trigger: sdd init, iniciar sdd, openspec init. Initialize SDD context, testing capabilities, registry, and persistence."
+description: "Trigger: sdd init, iniciar sdd, openspec init."
 disable-model-invocation: true
 user-invocable: false
 license: MIT
@@ -10,71 +10,38 @@ metadata:
   delegate_only: true
 ---
 
-> **ORCHESTRATOR GATE**: If you loaded this skill via the `skill()` tool, you are
-> the ORCHESTRATOR — STOP. Do NOT execute these instructions inline. Delegate to
-> the dedicated `sdd-init` sub-agent using your platform's delegation primitive
-> (e.g., `task(...)`, sub-agent invocation, etc.). This skill is for EXECUTORS
-> only.
+> **ORCHESTRATOR GATE**: Delegate to sdd-init sub-agent.
 
 ## Executor Override
-
-If you ARE the `sdd-init` sub-agent (NOT the orchestrator), the gate above does NOT apply to you. Continue with the phase work below. Do NOT delegate. Do NOT call the Skill tool. You are the executor — execute.
-
-## Language Domain Contract
-
-Generated technical artifacts default to English. Do not inherit the user's conversational language or the active persona's regional voice for SDD artifacts unless the user explicitly requests that artifact language or the project convention requires it.
-
-If Spanish technical artifacts are explicitly requested, use neutral/professional Spanish unless the user explicitly asks for a regional variant.
-
-Public/contextual comments follow the target context language by default. Explicit user language or tone overrides win; Spanish comments default to neutral/professional Spanish unless the user or target context clearly calls for regional tone.
-
-## Activation Contract
-
-Run this phase when the orchestrator/user asks to initialize SDD in a project. You are the phase executor: do the work yourself, do not delegate, and do not behave like the orchestrator.
+You are the sdd-init sub-agent. Execute — do NOT delegate.
 
 ## Hard Rules
+- Detect real stack, conventions, architecture, testing tools, and persistence mode; never guess.
+- In engram mode, do NOT create openspec/.
+- In openspec mode, follow `_shared/openspec-convention.md`.
+- In hybrid mode, write both openspec files and Engram observations.
+- Always persist testing capabilities separately — use `mem_save` with Engram topic key `sdd/{project}/testing-capabilities`, or write to `openspec/config.yaml` under `testing:` for filesystem. Do NOT write to a filesystem directory called `sdd/`.
+- Always build `.atl/skill-registry.md`; also save to Engram.
+- If openspec/ already exists, report and ask before updating.
 
-- Detect the real stack, conventions, architecture, testing tools, and persistence mode; never guess.
-- In `engram` mode, do **not** create `openspec/`.
-- In `openspec` mode, follow `../_shared/openspec-convention.md` and write file artifacts.
-- In `hybrid` mode, write both openspec files and Engram observations.
-- Always persist testing capabilities separately as `sdd/{project}/testing-capabilities` or `openspec/config.yaml` `testing:`.
-- Always build `.atl/skill-registry.md`; also save `skill-registry` to Engram when available.
-- Use `capture_prompt: false` for automated SDD/config saves when supported; omit it if the tool schema lacks it.
-- If `openspec/` already exists, report what exists and ask before updating it.
-
-**Filesystem path convention**: The SDD artifact directory is `openspec/`.
-Do NOT use `sdd/`, `.sdd/`, or `sdds/` as filesystem paths — these do not
-exist. Engram topic keys use the `sdd/` prefix for memory organization only.
+**Filesystem path convention**: The SDD artifact directory is `openspec/`. Do NOT use `sdd/`, `.sdd/`, or `sdds/` as filesystem paths — these do not exist. Engram topic keys use the `sdd/` prefix for memory organization only.
 
 ## Decision Gates
-
 | Input | Action |
 |---|---|
-| `mode=engram` | Save context and capabilities to Engram only. |
-| `mode=openspec` | Create/update openspec bootstrap files only. |
-| `mode=hybrid` | Do both Engram and openspec persistence. |
-| `mode=none` | Return detected context only; write no SDD artifacts except registry if required. |
-| strict TDD marker/config found | Use that value. |
-| no marker/config but test runner exists | Default `strict_tdd: true`. |
-| no test runner | Set `strict_tdd: false` and explain unavailable. |
+| mode=engram | Save context to Engram only. |
+| mode=openspec | Create/update openspec bootstrap files. |
+| mode=hybrid | Both Engram and openspec. |
+| mode=none | Return detected context only. |
 
 ## Execution Steps
-
-1. Inspect project files (`package.json`, `go.mod`, `pyproject.toml`, CI, lint/test config) and summarize stack/conventions.
-2. Detect test runner, test layers, coverage, linter, type checker, and formatter.
-3. Resolve Strict TDD from agent marker, `openspec/config.yaml`, detected runner fallback, or no-runner fallback.
-4. Initialize persistence for the resolved mode.
-5. Build `.atl/skill-registry.md` using the skill-registry scan rules.
+1. Inspect project files, summarize stack/conventions.
+2. Detect test runner, layers, coverage, linter, formatter.
+3. Resolve Strict TDD.
+4. Initialize persistence for resolved mode.
+5. Build skill-registry.
 6. Persist testing capabilities and project context.
-7. Return the structured initialization envelope.
+7. Return structured initialization envelope.
 
 ## Output Contract
-
-Return `status`, `executive_summary`, `artifacts`, `next_recommended`, and `risks`. Include project, stack, persistence mode, Strict TDD status, testing capability table, saved observation IDs/paths, registry path, and next `/sdd-explore` or `/sdd-new` step.
-
-## References
-
-- [references/init-details.md](references/init-details.md) — detection checklist, Engram payloads, config skeleton, and output templates.
-- `../_shared/engram-convention.md` — Engram artifact naming.
-- `../_shared/openspec-convention.md` — openspec layout and rules.
+Return status, executive_summary, artifacts, next_recommended, risks. Include project, stack, persistence mode, Strict TDD status, testing capabilities, observation IDs/paths.

--- a/internal/assets/skills/sdd-init/SKILL.md
+++ b/internal/assets/skills/sdd-init/SKILL.md
@@ -43,6 +43,10 @@ Run this phase when the orchestrator/user asks to initialize SDD in a project. Y
 - Use `capture_prompt: false` for automated SDD/config saves when supported; omit it if the tool schema lacks it.
 - If `openspec/` already exists, report what exists and ask before updating it.
 
+**Filesystem path convention**: The SDD artifact directory is `openspec/`.
+Do NOT use `sdd/`, `.sdd/`, or `sdds/` as filesystem paths — these do not
+exist. Engram topic keys use the `sdd/` prefix for memory organization only.
+
 ## Decision Gates
 
 | Input | Action |

--- a/internal/assets/skills/sdd-propose/SKILL.md
+++ b/internal/assets/skills/sdd-propose/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sdd-propose
-description: "Create an SDD change proposal with intent, scope, and approach. Trigger: orchestrator launches proposal work for a change."
+description: "Create an SDD change proposal with intent, scope, and approach."
 disable-model-invocation: true
 user-invocable: false
 license: MIT
@@ -10,197 +10,22 @@ metadata:
   delegate_only: true
 ---
 
-> **ORCHESTRATOR GATE**: If you loaded this skill via the `skill()` tool, you are
-> the ORCHESTRATOR — STOP. Do NOT execute these instructions inline. Delegate to
-> the dedicated `sdd-propose` sub-agent using your platform's delegation primitive
-> (e.g., `task(...)`, sub-agent invocation, etc.). This skill is for EXECUTORS
-> only.
+> **ORCHESTRATOR GATE**: If you loaded this skill via the `skill()` tool, you are the ORCHESTRATOR — STOP.
 
 ## Executor Override
-
-If you ARE the `sdd-propose` sub-agent (NOT the orchestrator), the gate above does NOT apply to you. Continue with the phase work below. Do NOT delegate. Do NOT call the Skill tool. You are the executor — execute.
-
-
-## Language Domain Contract
-
-Generated technical artifacts default to English. Do not inherit the user's conversational language or the active persona's regional voice for SDD artifacts unless the user explicitly requests that artifact language or the project convention requires it.
-
-If Spanish technical artifacts are explicitly requested, use neutral/professional Spanish unless the user explicitly asks for a regional variant.
-
-Public/contextual comments follow the target context language by default. Explicit user language or tone overrides win; Spanish comments default to neutral/professional Spanish unless the user or target context clearly calls for regional tone.
-
-## Purpose
-
-You are a sub-agent responsible for creating PROPOSALS. You take the exploration analysis (or direct user input) and produce a structured `proposal.md` document inside the change folder.
-
-## What You Receive
-
-From the orchestrator:
-- Change name (e.g., "add-dark-mode")
-- Exploration analysis (from sdd-explore) OR direct user description
-- Artifact store mode (`engram | openspec | hybrid | none`)
+If you ARE the `sdd-propose` sub-agent, continue. Do NOT delegate.
 
 ## Execution and Persistence Contract
+> Follow `skills/_shared/sdd-phase-common.md`.
 
-> Follow **Section B** (retrieval) and **Section C** (persistence) from `skills/_shared/sdd-phase-common.md`.
-
-- **engram**: Read `sdd/{change-name}/explore` (optional) and `sdd-init/{project}` (optional). Save artifact as `sdd/{change-name}/proposal`.
+- **engram**: Use `mem_get_observation` for Engram topic `sdd/{change-name}/explore` (optional) and `sdd-init/{project}` (optional). Save with `mem_save(topic_key="sdd/{change-name}/proposal", ...)`. Do NOT read or write filesystem paths under `sdd/` — use `openspec/` for filesystem artifacts.
 - **openspec**: Read and follow `skills/_shared/openspec-convention.md`.
-- **hybrid**: Follow BOTH conventions — persist to Engram AND write to filesystem. Retrieve dependencies from Engram (primary) with filesystem fallback.
-- **none**: Return result only. Never create or modify project files.
-- Never force `openspec/` creation unless user requested file-based persistence or mode is `hybrid`.
+- **hybrid**: Follow BOTH conventions.
+- **none**: Return result only.
 
-## What to Do
-
-### Step 0: Shape the Proposal in Interactive Mode
-
-- In interactive SDD mode, do not make the executor decide silently whether the proposal is "clear enough". Offer the user a proposal question round before finalizing the proposal: explain that the questions are meant to improve the PRD/proposal by uncovering business rules, implications, impact, edge cases, and product tradeoffs. Let the user answer, skip, correct the framing, or ask for a second question round.
-- Proposal-shaping questions should uncover business/product/PRD understanding, not harness mechanics. Cover the smallest useful subset of:
-  1. business problem: what pain, opportunity, user confusion, or operational cost makes this change worth doing now;
-  2. target users and situations: who is affected, in which workflow, at what moment, and with what level of urgency;
-  3. business rules: policies, permissions, thresholds, lifecycle rules, compliance/security expectations, or domain invariants the proposal must respect;
-  4. product outcome: what should feel, work, or become possible after the change;
-  5. current-state gap: what is wrong, inconsistent, missing, ad hoc, or hard to explain today;
-  6. implications and impact: which teams, workflows, data, UX expectations, support burden, or operational processes may be affected;
-  7. edge cases: empty states, partial data, failures, permissions, slow paths, unusual customers, migration states, or conflicting user needs;
-  8. decision gaps: which product unknowns would make the proposal ambiguous, risky, or easy to overbuild;
-  9. scope boundaries and non-goals: what belongs in the first product slice, what is later refinement, and what must stay unchanged even if related;
-  10. business risk or tradeoff: what downside matters most if the proposal chooses the wrong direction.
-- Prefer 3–5 concrete product questions per round. After the first answers, summarize the resulting proposal assumptions and ask whether the user wants to correct anything or run a second question round. Do not ask about test commands, PR shape, changed-line budget, or other harness decisions unless the user explicitly asks to discuss delivery. If blocked from asking directly, write a `## Proposal question round` section in the proposal result with the proposed questions and assumptions needing user review.
-
-### Step 1: Load Skills
-Follow **Section A** from `skills/_shared/sdd-phase-common.md`.
-
-### Step 2: Create Change Directory
-
-**IF mode is `openspec` or `hybrid`:** create the change folder structure:
-
-```
-openspec/changes/{change-name}/
-└── proposal.md
-```
-
-**IF mode is `engram` or `none`:** Do NOT create any `openspec/` directories. Skip this step.
-
-### Step 3: Read Existing Specs
-
-**IF mode is `openspec` or `hybrid`:** If `openspec/specs/` has relevant specs, read them to understand current behavior that this change might affect.
-
-**IF mode is `engram`:** Existing context was already retrieved from Engram in the Persistence Contract. Skip filesystem reads.
-
-**IF mode is `none`:** Skip — no existing specs to read.
-
-### Step 4: Write proposal.md
-
-```markdown
-# Proposal: {Change Title}
-
-## Intent
-
-{What problem are we solving? Why does this change need to happen?
-Be specific about the user need or technical debt being addressed.}
-
-## Scope
-
-### In Scope
-- {Concrete deliverable 1}
-- {Concrete deliverable 2}
-- {Concrete deliverable 3}
-
-### Out of Scope
-- {What we're explicitly NOT doing}
-- {Future work that's related but deferred}
-
-## Capabilities
-
-> This section is the CONTRACT between proposal and specs phases.
-> The sdd-spec agent reads this to know exactly which spec files to create or update.
-> Research `openspec/specs/` before filling this in.
-
-### New Capabilities
-<!-- Capabilities being introduced. Each becomes a new `openspec/specs/<name>/spec.md`.
-     Use kebab-case names (e.g., user-auth, data-export, api-rate-limiting).
-     Leave empty if no new capabilities. -->
-- `<capability-name>`: <brief description of what this capability covers>
-
-### Modified Capabilities
-<!-- Existing capabilities whose REQUIREMENTS are changing (not just implementation).
-     Only list here if spec-level behavior changes. Each needs a delta spec.
-     Use existing spec names from openspec/specs/. Leave empty if none. -->
-- `<existing-capability-name>`: <what requirement is changing>
-
-## Approach
-
-{High-level technical approach. How will we solve this?
-Reference the recommended approach from exploration if available.}
-
-## Affected Areas
-
-| Area | Impact | Description |
-|------|--------|-------------|
-| `path/to/area` | New/Modified/Removed | {What changes} |
-
-## Risks
-
-| Risk | Likelihood | Mitigation |
-|------|------------|------------|
-| {Risk description} | Low/Med/High | {How we mitigate} |
-
-## Rollback Plan
-
-{How to revert if something goes wrong. Be specific.}
-
-## Dependencies
-
-- {External dependency or prerequisite, if any}
-
-## Success Criteria
-
-- [ ] {How do we know this change succeeded?}
-- [ ] {Measurable outcome}
-```
-
-### Step 5: Persist Artifact
-
-**This step is MANDATORY — do NOT skip it.**
-
-Follow **Section C** from `skills/_shared/sdd-phase-common.md`.
-- artifact: `proposal`
-- topic_key: `sdd/{change-name}/proposal`
-- type: `architecture`
-
-### Step 6: Return Summary
-
-Return to the orchestrator:
-
-```markdown
-## Proposal Created
-
-**Change**: {change-name}
-**Location**: `openspec/changes/{change-name}/proposal.md` (openspec/hybrid) | Engram `sdd/{change-name}/proposal` (engram) | inline (none)
-
-### Summary
-- **Intent**: {one-line summary}
-- **Scope**: {N deliverables in, M items deferred}
-- **Approach**: {one-line approach}
-- **Risk Level**: {Low/Medium/High}
-
-### Next Step
-Ready for specs (sdd-spec) or design (sdd-design).
-```
+## Purpose
+You create PROPOSALS from exploration analysis.
 
 ## Rules
-
-- In `openspec` mode, ALWAYS create the `proposal.md` file
-- If the change directory already exists with a proposal, READ it first and UPDATE it
-- Keep the proposal CONCISE - it's a thinking tool, not a novel
-- Every proposal MUST have a rollback plan
-- Every proposal MUST have success criteria
-- Use concrete file paths in "Affected Areas" when possible
-- Apply any `rules.proposal` from `openspec/config.yaml`
-- **ALWAYS fill in the Capabilities section** — this is the contract with sdd-spec. Research `openspec/specs/` first to use correct existing capability names.
-- New Capabilities → each will become `openspec/specs/<name>/spec.md` (new full spec)
-- Modified Capabilities → each will become a delta spec in the change folder
-- If nothing changes at the spec level (pure refactor, config change), explicitly write "None" under both sub-sections — don't leave them as template placeholders
-- **Size budget**: Proposal artifact MUST be under 450 words. Use bullet points and tables over prose. Headers organize, not explain.
-- Return envelope per **Section D** from `skills/_shared/sdd-phase-common.md`.
+- Every proposal MUST have rollback plan and success criteria.
+- Return envelope per `_shared/sdd-phase-common.md`.

--- a/internal/assets/skills/sdd-propose/SKILL.md
+++ b/internal/assets/skills/sdd-propose/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sdd-propose
-description: "Create an SDD change proposal with intent, scope, and approach."
+description: "Create an SDD change proposal with intent, scope, and approach. Trigger: orchestrator launches proposal work for a change."
 disable-model-invocation: true
 user-invocable: false
 license: MIT
@@ -10,10 +10,21 @@ metadata:
   delegate_only: true
 ---
 
-> **ORCHESTRATOR GATE**: If you loaded this skill via the `skill()` tool, you are the ORCHESTRATOR — STOP.
+> **ORCHESTRATOR GATE**: If you loaded this skill via the `skill()` tool, you are
+> the ORCHESTRATOR — STOP. Do NOT execute these instructions inline. Delegate to
+> the dedicated `sdd-propose` sub-agent.
 
 ## Executor Override
-If you ARE the `sdd-propose` sub-agent, continue. Do NOT delegate.
+If you ARE the `sdd-propose` sub-agent (NOT the orchestrator), continue. Do NOT delegate.
+
+## Language Domain Contract
+Generated technical artifacts default to English.
+
+## Purpose
+You are a sub-agent responsible for creating PROPOSALS from exploration analysis or direct user input.
+
+## What You Receive
+From the orchestrator: Change name, exploration analysis, artifact store mode.
 
 ## Execution and Persistence Contract
 > Follow `skills/_shared/sdd-phase-common.md`.
@@ -23,9 +34,28 @@ If you ARE the `sdd-propose` sub-agent, continue. Do NOT delegate.
 - **hybrid**: Follow BOTH conventions.
 - **none**: Return result only.
 
-## Purpose
-You create PROPOSALS from exploration analysis.
+## What to Do
+
+### Step 1: Load Skills
+Follow Section A from `_shared/sdd-phase-common.md`.
+
+### Step 2: Create Change Directory
+In openspec/hybrid mode, create `openspec/changes/{change-name}/proposal.md`.
+
+### Step 3: Read Existing Specs
+If openspec/specs/ has relevant specs, read them.
+
+### Step 4: Write proposal.md
+Write a structured proposal with: Intent, Scope, Capabilities, Approach, Affected Areas, Risks, Rollback Plan, Dependencies, Success Criteria.
+
+### Step 5: Persist Artifact
+Save with `mem_save(topic_key="sdd/{change-name}/proposal")` or write file per mode.
+
+### Step 6: Return Summary
+Return change name, location, summary, next step.
 
 ## Rules
 - Every proposal MUST have rollback plan and success criteria.
+- Fill Capabilities section as contract with sdd-spec.
+- Size budget: under 450 words.
 - Return envelope per `_shared/sdd-phase-common.md`.

--- a/internal/assets/skills/sdd-spec/SKILL.md
+++ b/internal/assets/skills/sdd-spec/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sdd-spec
-description: "Write SDD delta specs with requirements and scenarios. Trigger: orchestrator launches spec work for a change."
+description: "Write SDD delta specs with requirements and scenarios."
 disable-model-invocation: true
 user-invocable: false
 license: MIT
@@ -10,246 +10,32 @@ metadata:
   delegate_only: true
 ---
 
-> **ORCHESTRATOR GATE**: If you loaded this skill via the `skill()` tool, you are
-> the ORCHESTRATOR — STOP. Do NOT execute these instructions inline. Delegate to
-> the dedicated `sdd-spec` sub-agent using your platform's delegation primitive
-> (e.g., `task(...)`, sub-agent invocation, etc.). This skill is for EXECUTORS
-> only.
+> **ORCHESTRATOR GATE**: Delegate to sdd-spec sub-agent.
 
 ## Executor Override
-
-If you ARE the `sdd-spec` sub-agent (NOT the orchestrator), the gate above does NOT apply to you. Continue with the phase work below. Do NOT delegate. Do NOT call the Skill tool. You are the executor — execute.
-
-
-## Language Domain Contract
-
-Generated technical artifacts default to English. Do not inherit the user's conversational language or the active persona's regional voice for SDD artifacts unless the user explicitly requests that artifact language or the project convention requires it.
-
-If Spanish technical artifacts are explicitly requested, use neutral/professional Spanish unless the user explicitly asks for a regional variant.
-
-Public/contextual comments follow the target context language by default. Explicit user language or tone overrides win; Spanish comments default to neutral/professional Spanish unless the user or target context clearly calls for regional tone.
+You are the sdd-spec sub-agent. Execute — do NOT delegate.
 
 ## Purpose
-
-You are a sub-agent responsible for writing SPECIFICATIONS. You take the proposal and produce delta specs — structured requirements and scenarios that describe what's being ADDED, MODIFIED, REMOVED, or RENAMED from the system's behavior.
-
-## What You Receive
-
-From the orchestrator:
-- Change name
-- Artifact store mode (`engram | openspec | hybrid | none`)
+Write SPECIFICATIONS from proposals: delta specs with ADDED/MODIFIED/REMOVED/RENAMED requirements.
 
 ## Execution and Persistence Contract
+> Follow `skills/_shared/sdd-phase-common.md`.
 
-> Follow **Section B** (retrieval) and **Section C** (persistence) from `skills/_shared/sdd-phase-common.md`.
-
-- **engram**: Read `sdd/{change-name}/proposal` (required). If specs span multiple domains, concatenate into a single artifact with domain headers. Save as `sdd/{change-name}/spec`.
+- **engram**: Use `mem_get_observation` for Engram topic `sdd/{change-name}/proposal` (required). Save with `mem_save(topic_key="sdd/{change-name}/spec", ...)`. Do NOT read or write filesystem paths under `sdd/` — use `openspec/` for filesystem artifacts.
 - **openspec**: Read and follow `skills/_shared/openspec-convention.md`.
-- **hybrid**: Follow BOTH conventions — persist to Engram (single concatenated artifact) AND write domain files to filesystem.
-- **none**: Return result only. Never create or modify project files.
+- **hybrid**: Follow BOTH conventions.
+- **none**: Return result only.
 
 ## What to Do
-
-### Step 1: Load Skills
-Follow **Section A** from `skills/_shared/sdd-phase-common.md`.
-
-### Step 2: Identify Affected Domains
-
-Read the proposal's **Capabilities section** — this is your primary contract:
-
-```
-FOR EACH entry under "New Capabilities":
-├── This becomes a NEW full spec: openspec/specs/<capability-name>/spec.md
-└── Write a complete spec (not a delta) — no existing behavior to reference
-
-FOR EACH entry under "Modified Capabilities":
-├── This becomes a DELTA spec: openspec/changes/{change-name}/specs/<capability-name>/spec.md
-└── Read existing openspec/specs/<capability-name>/spec.md first — your delta modifies it
-```
-
-If the proposal has no Capabilities section (older format), fall back to inferring from "Affected Areas". But always prefer the explicit Capabilities mapping when present.
-
-### Step 3: Read Existing Specs
-
-**IF mode is `openspec` or `hybrid`:** If `openspec/specs/{domain}/spec.md` exists, read it to understand CURRENT behavior. Your delta specs describe CHANGES to this behavior.
-
-**IF mode is `engram`:** Existing specs were already retrieved from Engram in the Persistence Contract. Skip filesystem reads.
-
-**IF mode is `none`:** Skip — no existing specs to read.
-
-### Step 4: Write Delta Specs
-
-**IF mode is `openspec` or `hybrid`:** Create specs inside the change folder:
-
-```
-openspec/changes/{change-name}/
-├── proposal.md              ← (already exists)
-└── specs/
-    └── {domain}/
-        └── spec.md          ← Delta spec
-```
-
-**IF mode is `engram` or `none`:** Do NOT create any `openspec/` directories or files. Compose the spec content in memory — you will persist it in Step 5.
-
-#### MODIFIED Requirements Workflow (CRITICAL — read before writing deltas)
-
-When writing a `## MODIFIED Requirements` section, follow this exact workflow:
-
-```
-1. Locate the requirement in openspec/specs/{domain}/spec.md
-2. COPY the ENTIRE requirement block — from `### Requirement:` through ALL its scenarios
-3. PASTE it under `## MODIFIED Requirements`
-4. EDIT the copy to reflect the new behavior
-5. Add "(Previously: {one-line summary of what changed})" under the requirement text
-
-Why copy-full-then-edit?
-→ The archive step REPLACES the requirement in main specs with your MODIFIED block
-→ If your block is partial, the archive will lose scenarios you didn't copy
-→ Common pitfall: only writing the changed scenario and losing the rest
-→ If adding NEW behavior WITHOUT changing existing behavior, use ADDED instead
-```
-
-#### Delta Spec Format
-
-```markdown
-# Delta for {Domain}
-
-## ADDED Requirements
-
-### Requirement: {Requirement Name}
-
-{Description using RFC 2119 keywords: MUST, SHALL, SHOULD, MAY}
-
-The system {MUST/SHALL/SHOULD} {do something specific}.
-
-#### Scenario: {Happy path scenario}
-
-- GIVEN {precondition}
-- WHEN {action}
-- THEN {expected outcome}
-- AND {additional outcome, if any}
-
-#### Scenario: {Edge case scenario}
-
-- GIVEN {precondition}
-- WHEN {action}
-- THEN {expected outcome}
-
-## MODIFIED Requirements
-
-### Requirement: {Existing Requirement Name}
-
-{Full updated requirement text — replaces the existing one entirely}
-(Previously: {what it was before, in one line})
-
-#### Scenario: {Unchanged scenario — keep if still valid}
-
-- GIVEN {precondition}
-- WHEN {action}
-- THEN {outcome}
-
-#### Scenario: {Updated or new scenario}
-
-- GIVEN {updated precondition}
-- WHEN {updated action}
-- THEN {updated outcome}
-
-## REMOVED Requirements
-
-### Requirement: {Requirement Being Removed}
-
-(Reason: {why this requirement is being deprecated/removed})
-(Migration: {what replaces it, or "None" if no migration is needed})
-
-## RENAMED Requirements
-
-### Requirement: {Old Requirement Name} → {New Requirement Name}
-
-(Reason: {why the requirement is being renamed})
-(Migration: {how references/tests/docs should update, or "None" if no migration is needed})
-```
-
-#### For NEW Specs (No Existing Spec)
-
-If this is a completely new domain, create a FULL spec (not a delta):
-
-```markdown
-# {Domain} Specification
-
-## Purpose
-
-{High-level description of this spec's domain.}
-
-## Requirements
-
-### Requirement: {Name}
-
-The system {MUST/SHALL/SHOULD} {behavior}.
-
-#### Scenario: {Name}
-
-- GIVEN {precondition}
-- WHEN {action}
-- THEN {outcome}
-```
-
-### Step 5: Persist Artifact
-
-**This step is MANDATORY — do NOT skip it.**
-
-Follow **Section C** from `skills/_shared/sdd-phase-common.md`.
-- artifact: `spec`
-- topic_key: `sdd/{change-name}/spec`
-- type: `architecture`
-
-### Step 6: Return Summary
-
-Return to the orchestrator:
-
-```markdown
-## Specs Created
-
-**Change**: {change-name}
-
-### Specs Written
-| Domain | Type | Requirements | Scenarios |
-|--------|------|-------------|-----------|
-| {domain} | Delta/New | {N added, M modified, K removed} | {total scenarios} |
-
-### Coverage
-- Happy paths: {covered/missing}
-- Edge cases: {covered/missing}
-- Error states: {covered/missing}
-
-### Next Step
-Ready for design (sdd-design). If design already exists, ready for tasks (sdd-tasks).
-```
+1. Load Skills from `_shared/sdd-phase-common.md`.
+2. Identify affected domains from proposal's Capabilities section.
+3. Read existing specs if in openspec/hybrid mode.
+4. Write delta specs using ADDED/MODIFIED/REMOVED/RENAMED sections with Given/When/Then scenarios.
+5. Persist artifact: `mem_save(topic_key="sdd/{change-name}/spec")` or write file.
+6. Return summary with domains, requirements count, coverage.
 
 ## Rules
-
-- ALWAYS use Given/When/Then format for scenarios
-- ALWAYS use RFC 2119 keywords (MUST, SHALL, SHOULD, MAY) for requirement strength
-- Read the proposal's **Capabilities section** first — it tells you exactly which spec files to create
-- If existing specs exist, write DELTA specs (ADDED/MODIFIED/REMOVED sections)
-- If NO existing specs exist for the domain, write a FULL spec
-- Every requirement MUST have at least ONE scenario
-- Include both happy path AND edge case scenarios
-- Keep scenarios TESTABLE — someone should be able to write an automated test from each one
-- DO NOT include implementation details in specs — specs describe WHAT, not HOW
-- **MODIFIED requirements MUST be the FULL block** — copy entire requirement + all scenarios from main spec, then edit. Partial MODIFIED blocks lose content at archive time.
-- If adding new behavior without changing existing behavior → use ADDED, not MODIFIED
-- REMOVED requirements MUST include Reason and SHOULD include Migration when consumers, persisted behavior, docs, or tests are affected
-- RENAMED requirements MUST state both old and new names explicitly and SHOULD include Migration guidance for references/tests/docs
-- Apply any `rules.specs` from `openspec/config.yaml`
-- **Size budget**: Spec artifact MUST be under 650 words. Prefer requirement tables over narrative descriptions. Each scenario: 3-5 lines max.
-- Return envelope per **Section D** from `skills/_shared/sdd-phase-common.md`.
-
-## RFC 2119 Keywords Quick Reference
-
-| Keyword | Meaning |
-|---------|---------|
-| **MUST / SHALL** | Absolute requirement |
-| **MUST NOT / SHALL NOT** | Absolute prohibition |
-| **SHOULD** | Recommended, but exceptions may exist with justification |
-| **SHOULD NOT** | Not recommended, but may be acceptable with justification |
-| **MAY** | Optional |
+- Use RFC 2119 keywords (MUST, SHALL, SHOULD, MAY).
+- Every requirement MUST have at least one scenario.
+- MODIFIED requirements MUST copy the full block from main spec.
+- Return envelope per `_shared/sdd-phase-common.md`.

--- a/internal/assets/skills/sdd-tasks/SKILL.md
+++ b/internal/assets/skills/sdd-tasks/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sdd-tasks
-description: "Break an SDD change into implementation tasks. Trigger: orchestrator launches task planning for a change."
+description: "Break an SDD change into implementation tasks."
 disable-model-invocation: true
 user-invocable: false
 license: MIT
@@ -10,246 +10,32 @@ metadata:
   delegate_only: true
 ---
 
-> **ORCHESTRATOR GATE**: If you loaded this skill via the `skill()` tool, you are
-> the ORCHESTRATOR — STOP. Do NOT execute these instructions inline. Delegate to
-> the dedicated `sdd-tasks` sub-agent using your platform's delegation primitive
-> (e.g., `task(...)`, sub-agent invocation, etc.). This skill is for EXECUTORS
-> only.
+> **ORCHESTRATOR GATE**: Delegate to sdd-tasks sub-agent.
 
 ## Executor Override
-
-If you ARE the `sdd-tasks` sub-agent (NOT the orchestrator), the gate above does NOT apply to you. Continue with the phase work below. Do NOT delegate. Do NOT call the Skill tool. You are the executor — execute.
-
-
-## Language Domain Contract
-
-Generated technical artifacts default to English. Do not inherit the user's conversational language or the active persona's regional voice for SDD artifacts unless the user explicitly requests that artifact language or the project convention requires it.
-
-If Spanish technical artifacts are explicitly requested, use neutral/professional Spanish unless the user explicitly asks for a regional variant.
-
-Public/contextual comments follow the target context language by default. Explicit user language or tone overrides win; Spanish comments default to neutral/professional Spanish unless the user or target context clearly calls for regional tone.
+You are the sdd-tasks sub-agent. Execute — do NOT delegate.
 
 ## Purpose
-
-You are a sub-agent responsible for creating the TASK BREAKDOWN. You take the proposal, specs, and design, then produce a `tasks.md` with concrete, actionable implementation steps organized by phase.
-
-## What You Receive
-
-From the orchestrator:
-- Change name
-- Artifact store mode (`engram | openspec | hybrid | none`)
-- Delivery strategy (`ask-on-risk | auto-chain | single-pr | exception-ok`)
+Create TASK BREAKDOWN from proposal, specs, and design.
 
 ## Execution and Persistence Contract
+> Follow `skills/_shared/sdd-phase-common.md`.
 
-> Follow **Section B** (retrieval) and **Section C** (persistence) from `skills/_shared/sdd-phase-common.md`.
-
-- **engram**: Read `sdd/{change-name}/proposal` (required), `sdd/{change-name}/spec` (required), `sdd/{change-name}/design` (required). Save as `sdd/{change-name}/tasks`.
+- **engram**: Use `mem_get_observation` for Engram topics `sdd/{change-name}/proposal` (required), `sdd/{change-name}/spec` (required), `sdd/{change-name}/design` (required). Save with `mem_save(topic_key="sdd/{change-name}/tasks", ...)`. Do NOT read or write filesystem paths under `sdd/` — use `openspec/` for filesystem artifacts.
 - **openspec**: Read and follow `skills/_shared/openspec-convention.md`.
-- **hybrid**: Follow BOTH conventions — persist to Engram AND write `tasks.md` to filesystem. Retrieve dependencies from Engram (primary) with filesystem fallback.
-- **none**: Return result only. Never create or modify project files.
+- **hybrid**: Follow BOTH conventions.
+- **none**: Return result only.
 
 ## What to Do
-
-### Step 1: Load Skills
-Follow **Section A** from `skills/_shared/sdd-phase-common.md`.
-
-### Step 2: Analyze the Design
-
-From the design document, identify:
-- All files that need to be created/modified/deleted
-- The dependency order (what must come first)
-- Testing requirements per component
-
-### Step 3: Write tasks.md
-
-**IF mode is `openspec` or `hybrid`:** Create the task file:
-
-```
-openspec/changes/{change-name}/
-├── proposal.md
-├── specs/
-├── design.md
-└── tasks.md               ← You create this
-```
-
-**IF mode is `engram` or `none`:** Do NOT create any `openspec/` directories or files. Compose the tasks content in memory — you will persist it in Step 4.
-
-#### Task File Format
-
-```markdown
-# Tasks: {Change Title}
-
-## Review Workload Forecast
-
-| Field | Value |
-|-------|-------|
-| Estimated changed lines | <rough estimate or range> |
-| 400-line budget risk | Low / Medium / High |
-| Chained PRs recommended | Yes / No |
-| Suggested split | <single PR or PR 1 → PR 2 → PR 3> |
-| Delivery strategy | <ask-on-risk / auto-chain / single-pr / exception-ok> |
-| Chain strategy | <stacked-to-main / feature-branch-chain / size-exception / pending> |
-
-Decision needed before apply: <Yes|No>
-Chained PRs recommended: <Yes|No>
-Chain strategy: <stacked-to-main|feature-branch-chain|size-exception|pending>
-400-line budget risk: <Low|Medium|High>
-
-### Suggested Work Units
-
-| Unit | Goal | Likely PR | Notes |
-|------|------|-----------|-------|
-| 1 | <standalone deliverable> | PR 1 | <base branch; tests/docs included> |
-| 2 | <standalone deliverable> | PR 2 | <immediate parent/base branch boundary; depends on PR 1 or independent> |
-
-## Phase 1: {Phase Name} (e.g., Infrastructure / Foundation)
-
-- [ ] 1.1 {Concrete action — what file, what change}
-- [ ] 1.2 {Concrete action}
-- [ ] 1.3 {Concrete action}
-
-## Phase 2: {Phase Name} (e.g., Core Implementation)
-
-- [ ] 2.1 {Concrete action}
-- [ ] 2.2 {Concrete action}
-- [ ] 2.3 {Concrete action}
-- [ ] 2.4 {Concrete action}
-
-## Phase 3: {Phase Name} (e.g., Testing / Verification)
-
-- [ ] 3.1 {Write tests for ...}
-- [ ] 3.2 {Write tests for ...}
-- [ ] 3.3 {Verify integration between ...}
-
-## Phase 4: {Phase Name} (e.g., Cleanup / Documentation)
-
-- [ ] 4.1 {Update docs/comments}
-- [ ] 4.2 {Remove temporary code}
-```
-
-### Task Writing Rules
-
-Each task MUST be:
-
-| Criteria | Example ✅ | Anti-example ❌ |
-|----------|-----------|----------------|
-| **Specific** | "Create `internal/auth/middleware.go` with JWT validation" | "Add auth" |
-| **Actionable** | "Add `ValidateToken()` method to `AuthService`" | "Handle tokens" |
-| **Verifiable** | "Test: `POST /login` returns 401 without token" | "Make sure it works" |
-| **Small** | One file or one logical unit of work | "Implement the feature" |
-
-### Review Workload Forecast Rules
-
-Before finalizing tasks, estimate whether implementation is likely to exceed the **400 changed-line review budget** (`additions + deletions`). This is a planning guard, not an exact diff count.
-
-Use available signals: number of files, phases, integration points, tests, docs, generated artifacts, migrations, and how many concerns the change crosses.
-
-If the estimate is **High** or likely above 400 lines:
-
-1. Mark `Chained PRs recommended` as `Yes`.
-2. Split tasks into **work units** that can become chained or stacked PRs.
-3. Each suggested PR must have a clear start, clear finish, verification, and autonomous scope.
-4. **Ask the user which chain strategy to use** (this is a team decision):
-   - **Stacked PRs to main** — each PR merges to main in order. Fast iteration, fix on the go. Best for speed-first teams and independent slices.
-   - **Feature Branch Chain** — the feature/tracker branch accumulates the final integration; PR #1 targets the tracker branch, later PRs target the immediate previous PR branch so each child diff stays focused. Only the tracker merges to main. Best for rollback control and coordinated releases.
-   - **size:exception** — keep it as a single PR with maintainer approval. Best for generated code, migrations, or vendor diffs.
-5. Cache the user's choice and set `Decision needed before apply` from delivery strategy:
-   - `ask-on-risk`: `Yes` — orchestrator asks before apply.
-   - `auto-chain`: `No` — orchestrator proceeds with the first slice using the chosen chain strategy.
-   - `single-pr`: `Yes` — orchestrator must require `size:exception` before apply.
-   - `exception-ok`: `No` — maintainer has accepted `size:exception`.
-
-Do not bury this in prose. Put the forecast near the top of the tasks artifact so the user sees it before implementation starts.
-
-The forecast MUST include these exact plain-text lines so downstream guards can match them literally:
-
-```text
-Decision needed before apply: Yes|No
-Chained PRs recommended: Yes|No
-Chain strategy: stacked-to-main|feature-branch-chain|size-exception|pending
-400-line budget risk: Low|Medium|High
-```
-
-You may keep the table for readability, but the plain-text lines are the guard contract.
-
-For `feature-branch-chain`, suggested work units SHOULD name the intended base boundary: PR #1 base = feature/tracker branch; PR #2 base = PR #1 branch; PR #3 base = PR #2 branch. If a child PR would show previous PR changes, the base is wrong and must be retargeted/rebased before review.
-
-### Phase Organization Guidelines
-
-```
-Phase 1: Foundation / Infrastructure
-  └─ New types, interfaces, database changes, config
-  └─ Things other tasks depend on
-
-Phase 2: Core Implementation
-  └─ Main logic, business rules, core behavior
-  └─ The meat of the change
-
-Phase 3: Integration / Wiring
-  └─ Connect components, routes, UI wiring
-  └─ Make everything work together
-
-Phase 4: Testing
-  └─ Unit tests, integration tests, e2e tests
-  └─ Verify against spec scenarios
-
-Phase 5: Cleanup (if needed)
-  └─ Documentation, remove dead code, polish
-```
-
-### Step 4: Persist Artifact
-
-**This step is MANDATORY — do NOT skip it.**
-
-Follow **Section C** from `skills/_shared/sdd-phase-common.md`.
-- artifact: `tasks`
-- topic_key: `sdd/{change-name}/tasks`
-- type: `architecture`
-
-### Step 5: Return Summary
-
-Return to the orchestrator:
-
-```markdown
-## Tasks Created
-
-**Change**: {change-name}
-**Location**: `openspec/changes/{change-name}/tasks.md` (openspec/hybrid) | Engram `sdd/{change-name}/tasks` (engram) | inline (none)
-
-### Breakdown
-| Phase | Tasks | Focus |
-|-------|-------|-------|
-| Phase 1 | {N} | {Phase name} |
-| Phase 2 | {N} | {Phase name} |
-| Phase 3 | {N} | {Phase name} |
-| Total | {N} | |
-
-### Implementation Order
-{Brief description of the recommended order and why}
-
-### Review Workload Forecast
-- Estimated changed lines: {estimate or range}
-- 400-line budget risk: {Low | Medium | High}
-- Chained PRs recommended: {Yes | No}
-- Delivery strategy: {ask-on-risk | auto-chain | single-pr | exception-ok}
-- Decision needed before apply: {Yes | No}
-- Suggested work-unit PR split: {brief list or "Not needed"}
-
-### Next Step
-{Ready for implementation (sdd-apply) OR ask the user whether to use chained PRs before sdd-apply.}
-```
+1. Load Skills.
+2. Analyze design for files, dependencies, testing requirements.
+3. Write tasks.md with Review Workload Forecast, phases, checklist items.
+4. Persist: `mem_save(topic_key="sdd/{change-name}/tasks")` or write file.
+5. Return summary with phase breakdown, forecast, next step.
 
 ## Rules
-
-- ALWAYS reference concrete file paths in tasks
-- Tasks MUST be ordered by dependency — Phase 1 tasks shouldn't depend on Phase 2
-- Testing tasks should reference specific scenarios from the specs
-- Each task should be completable in ONE session (if a task feels too big, split it)
-- Use hierarchical numbering: 1.1, 1.2, 2.1, 2.2, etc.
-- NEVER include vague tasks like "implement feature" or "add tests"
-- Apply any `rules.tasks` from `openspec/config.yaml`
-- If the project uses TDD, integrate test-first tasks: RED task (write failing test) → GREEN task (make it pass) → REFACTOR task (clean up)
-- **Size budget**: Tasks artifact MUST be under 530 words. Each task: 1-2 lines max. Use checklist format, not paragraphs.
-- **Review workload guard**: ALWAYS include the Review Workload Forecast. If likely above 400 changed lines, recommend chained PRs and honor the received delivery strategy for whether a decision/exception is needed before apply.
-- Return envelope per **Section D** from `skills/_shared/sdd-phase-common.md`.
+- Tasks MUST reference concrete file paths.
+- Order by dependency.
+- Each task completable in one session.
+- Include Review Workload Forecast with guard lines.
+- Return envelope per `_shared/sdd-phase-common.md`.

--- a/internal/assets/windsurf/workflows/sdd-new.md
+++ b/internal/assets/windsurf/workflows/sdd-new.md
@@ -215,4 +215,8 @@ Este workflow se considera correctamente ejecutado solo si:
 
 Si cualquiera de esos puntos no ocurre, el workflow está mal ejecutado.
 
-
+> **Filesystem path convention (Windsurf IDE)**: `.sdd/` is the Windsurf IDE
+> artifact directory for SDD planning contracts. In non-Windsurf environments
+> (OpenCode, generic CLI), the canonical filesystem directory is `openspec/`.
+> Do NOT use `.sdd/` outside Windsurf workflows, and do NOT confuse Engram
+> topic keys (prefix `sdd/`, no dot) with filesystem paths.


### PR DESCRIPTION
### Problem

SDD orchestrator and sub-agents (sdd-explore, sdd-init, sdd-apply, etc.) sometimes confuse Engram topic keys (prefix `sdd/`) with filesystem paths, generating globs like `**/.sdd/**` and `**/sdd/**` during exploration. These directories don't exist — the canonical filesystem path is `openspec/`.

Root cause: the orchestrator's Engram topic key table (`sdd/{change-name}/proposal`, etc.) pattern-matches to a mental filesystem path because the `sdd/` prefix collides with the old `.sdd/` Windsurf IDE convention.

### Fix

Adds explicit `Filesystem path convention` notes to 5 files:

| File | Location |
|------|----------|
| `internal/assets/opencode/sdd-orchestrator.md` | After Artifact Store Policy section |
| `internal/assets/skills/sdd-explore/SKILL.md` | After Retrieving Context section |
| `internal/assets/skills/sdd-init/SKILL.md` | After Hard Rules section |
| `internal/assets/skills/_shared/sdd-phase-common.md` | End of document |
| `internal/assets/windsurf/workflows/sdd-new.md` | End of document (contextual note) |

Each note clarifies:
- Engram topic keys use `sdd/` prefix for **memory organization only** — NOT filesystem paths
- The canonical filesystem directory for SDD artifacts is `openspec/`
- `.sdd/` is the Windsurf IDE artifact directory (contextual in Windsurf workflows only)

### Background

This change is Track 2 of a two-track fix. Track 1 (local Nix overrides) is already deployed in the [nixos-hosts](https://github.com/glats/nixos-hosts) repo. This PR provides the same guardrails upstream so downstream consumers don't need per-repo workarounds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified the canonical storage location for SDD artifacts (`openspec/`) and explicitly prohibited using `sdd/`, `.sdd/`, or `sdds/` as filesystem paths.
  * Explained the distinction between Engram topic keys (using the `sdd/` prefix for memory organization only) versus filesystem paths.
  * Documented environment-specific guidance for `.sdd/` usage (allowed only in Windsurf workflows).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->