### PR TITLE
docs: Add comprehensive docstring to GenerationEngine in engine.go

### DIFF
--- a/internal/agentbuilder/engine.go
+++ b/internal/agentbuilder/engine.go
@@ -10,6 +10,11 @@ import (
 )
 
 // GenerationEngine abstracts the AI CLI tool used to generate a skill.
+// It provides an interface for interacting with different AI code generation
+// tools through their command line interfaces. Implementations handle
+// execution, availability checks, and agent-specific invocation patterns.
+// The engine is responsible for managing the lifecycle of CLI commands
+// and interpreting their outputs.
 type GenerationEngine interface {
 	// Agent returns the AgentID this engine wraps.
 	Agent() model.AgentID


### PR DESCRIPTION
# Context
The `engine.go` file in the `agentbuilder` package lacks a proper docstring explaining its purpose and functionality.

# Solution
Add a clear and comprehensive docstring to the `GenerationEngine` interface, outlining its role within the `agentbuilder` package, detailing its responsibilities regarding the management of CLI commands and interactions with AI generation tools.

# Scope
This change directly modifies the `engine.go` file to include the new documentation with no functional changes to the code.

# Tests Run
No tests were affected by this change as it pertains solely to documentation.

# Results
All checks passed, ensuring that the addition of the documentation complies with project standards.

# Risks
Low risk. This is a documentation-only change that does not affect the code's execution.

# Related Issue
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a clearer description of the generation engine interface, including how it runs CLI commands, checks availability, and handles command output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->