### PR TITLE
feat(tui): add BTW OpenCode community plugin

### DIFF
--- a/internal/components/opencodeplugin/plugin.go
+++ b/internal/components/opencodeplugin/plugin.go
@@ -46,6 +46,15 @@ var definitions = []Definition{
 		Repo:        "sdd-engram-plugin",
 		Description: "OpenCode TUI for SDD profiles and Engram memories",
 	},
+	{
+		ID:          model.OpenCodePluginBtwOpenCode,
+		Name:        "BTW Plugin",
+		PackageName: "pabloXDXDXD/btw-opencode",
+		RepoURL:     "https://github.com/pabloXDXDXD/btw-opencode",
+		Owner:       "pabloXDXDXD",
+		Repo:        "btw-opencode",
+		Description: "Parallel /btw questions without interrupting your main session",
+	},
 }
 
 const gentleLogoPluginFile = "gentle-logo.tsx"

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -172,6 +172,7 @@ type OpenCodeCommunityPluginID string
 const (
 	OpenCodePluginSubAgentStatusline OpenCodeCommunityPluginID = "sub-agent-statusline"
 	OpenCodePluginSDDEngramManage    OpenCodeCommunityPluginID = "sdd-engram-plugin"
+	OpenCodePluginBtwOpenCode        OpenCodeCommunityPluginID = "btw-opencode"
 	OpenCodePluginGentleLogo         OpenCodeCommunityPluginID = "gentle-logo"
 )
 

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -3688,7 +3688,7 @@ func (m Model) goBackFromOpenCodePlugins() Model {
 }
 
 func opencodepluginDefinitions() []model.OpenCodeCommunityPluginID {
-	return []model.OpenCodeCommunityPluginID{model.OpenCodePluginSubAgentStatusline, model.OpenCodePluginSDDEngramManage}
+	return []model.OpenCodeCommunityPluginID{model.OpenCodePluginSubAgentStatusline, model.OpenCodePluginSDDEngramManage, model.OpenCodePluginBtwOpenCode}
 }
 
 func communityToolDefinitions() []communitytool.Definition {
@@ -3696,7 +3696,7 @@ func communityToolDefinitions() []communitytool.Definition {
 }
 
 func opencodepluginRepoURLs() []string {
-	return []string{"https://github.com/Joaquinvesapa/sub-agent-statusline", "https://github.com/j0k3r-dev-rgl/sdd-engram-plugin"}
+	return []string{"https://github.com/Joaquinvesapa/sub-agent-statusline", "https://github.com/j0k3r-dev-rgl/sdd-engram-plugin", "https://github.com/pabloXDXDXD/btw-opencode"}
 }
 
 func openBrowserCmd(url string) tea.Cmd {


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #995

---

## 🏷️ PR Type

- [ ] `type:bug`
- [x] `type:feature`
- [ ] `type:docs`
- [ ] `type:refactor`
- [ ] `type:chore`
- [ ] `type:breaking-change`

---

## 📝 Summary

Adds `btw-opencode` (pabloXDXDXD/btw-opencode) as a community plugin in gentle-ai's OpenCode Plugins TUI. Users can select and register it from the plugin list — gentle-ai installs it via GitHub shorthand and adds it to `tui.json`. No npm auth needed.

---

## 📂 Changes

| File | Change |
|------|--------|
| `internal/model/types.go` | Added `OpenCodePluginBtwOpenCode` constant |
| `internal/components/opencodeplugin/plugin.go` | Added BTW Plugin definition with PackageName, RepoURL, owner |
| `internal/tui/model.go` | Added to opencode plugin list and repo URLs |

---

## 🧪 Test Plan

- [ ] Unit tests pass (`go test ./...`)
- [x] Manually tested: plugin appears in TUI list, registers successfully, OpenCode activates both server (`/btw`) and TUI (`/btw-list`) plugins

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue
- [x] PR stays within 400 changed lines (~30 lines total)
- [ ] I have added the appropriate `type:*` label to this PR
- [ ] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] I have updated documentation if necessary
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new community plugin option to the app’s plugin catalog.
  * Expanded the available plugin list and repository sources shown in the UI to include one more supported entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->