### PR TITLE
fix(sdd): gate CodeGraph guidance for subagents

### DIFF
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -899,6 +899,7 @@ func (s componentApplyStep) Run() error {
 				CodexPhaseModelAssignments:  s.selection.CodexPhaseModelAssignments,
 				WorkspaceDir:                s.workspaceDir,
 				StrictTDD:                   s.selection.StrictTDD,
+				CodeGraphGuidanceMarkdown:   codeGraphGuidanceMarkdownForSDD(s.homeDir, s.selection.CommunityTools),
 			}
 			if _, err := sdd.Inject(targetDir, adapter, s.selection.SDDMode, opts); err != nil {
 				return fmt.Errorf("inject sdd for %q: %w", adapter.Agent(), err)
@@ -1363,6 +1364,30 @@ func componentInjectionDirScoped(homeDir, workspaceDir string, scope InstallScop
 		return workspaceDir
 	}
 	return ResolveAgentConfigDir(scope, homeDir, workspaceDir)
+}
+
+func codeGraphGuidanceMarkdownForSDD(homeDir string, selected []model.CommunityToolID) string {
+	if !shouldInjectCodeGraphGuidanceForSDD(homeDir, selected) {
+		return ""
+	}
+	return communitytool.CodeGraphGuidanceMarkdown()
+}
+
+func shouldInjectCodeGraphGuidanceForSDD(homeDir string, selected []model.CommunityToolID) bool {
+	for _, tool := range selected {
+		if tool == model.CommunityToolCodeGraph {
+			return true
+		}
+	}
+	detector := communitytool.DetectorFunc(cmdLookPath)
+	if communitytool.HasConfiguredCodeGraph(homeDir, detector) {
+		return true
+	}
+	if !communitytool.HasLegacyCodeGraphGuidance(homeDir) {
+		return false
+	}
+	_, err := cmdLookPath("codegraph")
+	return err == nil
 }
 
 type openClawWorkspaceConfig struct {

--- a/internal/cli/run_community_tool_test.go
+++ b/internal/cli/run_community_tool_test.go
@@ -1,7 +1,11 @@
 package cli
 
 import (
+	"errors"
+	"os"
+	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/gentleman-programming/gentle-ai/internal/components/communitytool"
@@ -33,6 +37,194 @@ func TestInstallRuntimeStagePlanAddsCommunityToolStepsInSelectionOrder(t *testin
 	}
 }
 
+func TestCodeGraphGuidanceMarkdownForSDDOnlyWhenSelectedOrConfigured(t *testing.T) {
+	tests := []struct {
+		name      string
+		setupHome func(t *testing.T, home string)
+		lookPath  func(string) (string, error)
+		selected  []model.CommunityToolID
+		want      bool
+	}{
+		{
+			name:     "CLI missing and no selection",
+			lookPath: func(string) (string, error) { return "", errors.New("not found") },
+		},
+		{
+			name:     "CLI available but not configured",
+			lookPath: func(string) (string, error) { return "/bin/codegraph", nil },
+		},
+		{
+			name:     "selected CodeGraph",
+			lookPath: func(string) (string, error) { return "", errors.New("not found") },
+			selected: []model.CommunityToolID{model.CommunityToolCodeGraph},
+			want:     true,
+		},
+		{
+			name: "configured guidance marker",
+			setupHome: func(t *testing.T, home string) {
+				mustWriteFile(t, filepath.Join(home, ".claude", "CLAUDE.md"), []byte(strings.Join([]string{
+					"existing Claude guidance",
+					"<!-- gentle-ai:codegraph-guidance -->",
+					"CodeGraph guidance with `codegraph init <project-root>`",
+					"<!-- /gentle-ai:codegraph-guidance -->",
+				}, "\n")))
+			},
+			lookPath: func(string) (string, error) { return "/bin/codegraph", nil },
+			want:     true,
+		},
+		{
+			name: "configured MCP marker",
+			setupHome: func(t *testing.T, home string) {
+				mustWriteFile(t, filepath.Join(home, ".codex", "config.toml"), []byte(strings.Join([]string{
+					`[mcp_servers.codegraph]`,
+					`command = "codegraph"`,
+				}, "\n")))
+			},
+			lookPath: func(string) (string, error) { return "/bin/codegraph", nil },
+			want:     true,
+		},
+		{
+			name: "legacy marker with CLI available",
+			setupHome: func(t *testing.T, home string) {
+				mustWriteFile(t, filepath.Join(home, ".config", "opencode", "opencode.json"), []byte(`{}`))
+				mustWriteFile(t, filepath.Join(home, ".config", "opencode", "AGENTS.md"), []byte(strings.Join([]string{
+					"custom notes",
+					"<!-- CODEGRAPH_START -->",
+					"old CodeGraph instructions",
+					"<!-- CODEGRAPH_END -->",
+				}, "\n")))
+			},
+			lookPath: func(string) (string, error) { return "/bin/codegraph", nil },
+			want:     true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			previousLookPath := cmdLookPath
+			t.Cleanup(func() { cmdLookPath = previousLookPath })
+			cmdLookPath = tc.lookPath
+
+			home := t.TempDir()
+			if tc.setupHome != nil {
+				tc.setupHome(t, home)
+			}
+
+			got := codeGraphGuidanceMarkdownForSDD(home, tc.selected)
+			if !tc.want {
+				if got != "" {
+					t.Fatalf("guidance = %q, want empty", got)
+				}
+				return
+			}
+			if !strings.Contains(got, "codegraph init <project-root>") {
+				t.Fatalf("CodeGraph guidance missing search-order rule:\n%s", got)
+			}
+		})
+	}
+}
+
+func TestComponentApplyStepInjectsCodeGraphGuidanceWhenCodeGraphSelected(t *testing.T) {
+	home := t.TempDir()
+	withCodeGraphLookPath(t, func(string) (string, error) { return "", errors.New("not found") })
+
+	step := componentApplyStep{
+		id:           "apply:sdd",
+		component:    model.ComponentSDD,
+		homeDir:      home,
+		workspaceDir: "/work/project",
+		scope:        ScopeGlobal,
+		agents:       []model.AgentID{model.AgentOpenCode},
+		selection: model.Selection{
+			CommunityTools: []model.CommunityToolID{model.CommunityToolCodeGraph},
+			SDDMode:        model.SDDModeMulti,
+		},
+	}
+	if err := step.Run(); err != nil {
+		t.Fatalf("componentApplyStep.Run() error = %v", err)
+	}
+
+	assertOpenCodeSharedPromptCodeGraphGuidance(t, home, true)
+}
+
+func TestComponentApplyStepInjectsCodeGraphGuidanceWhenCodeGraphConfigured(t *testing.T) {
+	home := t.TempDir()
+	withCodeGraphLookPath(t, func(string) (string, error) { return "/bin/codegraph", nil })
+	mustWriteFile(t, filepath.Join(home, ".codex", "config.toml"), []byte(strings.Join([]string{
+		`[mcp_servers.codegraph]`,
+		`command = "codegraph"`,
+	}, "\n")))
+	mustWriteFile(t, filepath.Join(home, ".codex", "AGENTS.md"), []byte(strings.Join([]string{
+		"existing Codex guidance",
+		"<!-- gentle-ai:codegraph-guidance -->",
+		"CodeGraph guidance with `codegraph init <project-root>`",
+		"<!-- /gentle-ai:codegraph-guidance -->",
+	}, "\n")))
+
+	step := componentApplyStep{
+		id:           "apply:sdd",
+		component:    model.ComponentSDD,
+		homeDir:      home,
+		workspaceDir: "/work/project",
+		scope:        ScopeGlobal,
+		agents:       []model.AgentID{model.AgentOpenCode},
+		selection:    model.Selection{SDDMode: model.SDDModeMulti},
+	}
+	if err := step.Run(); err != nil {
+		t.Fatalf("componentApplyStep.Run() error = %v", err)
+	}
+
+	assertOpenCodeSharedPromptCodeGraphGuidance(t, home, true)
+}
+
+func TestComponentApplyStepOmitsCodeGraphGuidanceWhenOnlyCLIAvailable(t *testing.T) {
+	home := t.TempDir()
+	withCodeGraphLookPath(t, func(string) (string, error) { return "/bin/codegraph", nil })
+
+	step := componentApplyStep{
+		id:           "apply:sdd",
+		component:    model.ComponentSDD,
+		homeDir:      home,
+		workspaceDir: "/work/project",
+		scope:        ScopeGlobal,
+		agents:       []model.AgentID{model.AgentOpenCode},
+		selection:    model.Selection{SDDMode: model.SDDModeMulti},
+	}
+	if err := step.Run(); err != nil {
+		t.Fatalf("componentApplyStep.Run() error = %v", err)
+	}
+
+	assertOpenCodeSharedPromptCodeGraphGuidance(t, home, false)
+}
+
+func TestComponentSyncStepInjectsCodeGraphGuidanceFromLegacyMarker(t *testing.T) {
+	home := t.TempDir()
+	withCodeGraphLookPath(t, func(string) (string, error) { return "/bin/codegraph", nil })
+	mustWriteFile(t, filepath.Join(home, ".config", "opencode", "opencode.json"), []byte(`{}`))
+	mustWriteFile(t, filepath.Join(home, ".config", "opencode", "AGENTS.md"), []byte(strings.Join([]string{
+		"custom notes",
+		"<!-- CODEGRAPH_START -->",
+		"old CodeGraph instructions",
+		"<!-- CODEGRAPH_END -->",
+	}, "\n")))
+
+	var changed []string
+	step := componentSyncStep{
+		id:           "sync:sdd",
+		component:    model.ComponentSDD,
+		homeDir:      home,
+		workspaceDir: "/work/project",
+		agents:       []model.AgentID{model.AgentOpenCode},
+		selection:    model.Selection{SDDMode: model.SDDModeMulti},
+		changedFiles: &changed,
+	}
+	if err := step.Run(); err != nil {
+		t.Fatalf("componentSyncStep.Run() error = %v", err)
+	}
+
+	assertOpenCodeSharedPromptCodeGraphGuidance(t, home, true)
+}
+
 func TestCommunityToolInstallStepUsesInjectableInstaller(t *testing.T) {
 	previousInstall := installCommunityTool
 	previousRunCommand := runCommand
@@ -62,5 +254,31 @@ func TestCommunityToolInstallStepUsesInjectableInstaller(t *testing.T) {
 	}
 	if gotTool != model.CommunityToolCodeGraph || gotWorkspace != "/work/project" || runner == nil {
 		t.Fatalf("installer args = (%q, %q, %#v), want CodeGraph, workspace, runner", gotTool, gotWorkspace, runner)
+	}
+}
+
+func withCodeGraphLookPath(t *testing.T, lookPath func(string) (string, error)) {
+	t.Helper()
+	previousLookPath := cmdLookPath
+	t.Cleanup(func() { cmdLookPath = previousLookPath })
+	cmdLookPath = func(name string) (string, error) {
+		if name != "codegraph" {
+			return "", errors.New("not found")
+		}
+		return lookPath(name)
+	}
+}
+
+func assertOpenCodeSharedPromptCodeGraphGuidance(t *testing.T, home string, want bool) {
+	t.Helper()
+	promptPath := filepath.Join(home, ".config", "opencode", "prompts", "sdd", "sdd-apply.md")
+	content, err := os.ReadFile(promptPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", promptPath, err)
+	}
+	text := string(content)
+	hasGuidance := strings.Contains(text, "<!-- gentle-ai:codegraph-guidance -->") && strings.Contains(text, "codegraph init <project-root>")
+	if hasGuidance != want {
+		t.Fatalf("CodeGraph guidance present = %v, want %v in %s", hasGuidance, want, promptPath)
 	}
 }

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -438,7 +438,7 @@ func (r *syncRuntime) stagePlan() pipeline.StagePlan {
 		})
 	}
 
-	if shouldRefreshCodeGraphGuidance(r.homeDir) {
+	if shouldHandleCodeGraphGuidance(r.homeDir) {
 		apply = append(apply, codeGraphGuidanceSyncStep{
 			id:           "sync:community-tool:codegraph-guidance",
 			homeDir:      r.homeDir,
@@ -449,7 +449,9 @@ func (r *syncRuntime) stagePlan() pipeline.StagePlan {
 	return pipeline.StagePlan{Prepare: prepare, Apply: apply}
 }
 
-func shouldRefreshCodeGraphGuidance(homeDir string) bool {
+// shouldHandleCodeGraphGuidance gates both managed CodeGraph guidance refresh
+// and cleanup of legacy guidance blocks left by older installers.
+func shouldHandleCodeGraphGuidance(homeDir string) bool {
 	return communitytool.HasConfiguredCodeGraph(homeDir, communitytool.DetectorFunc(cmdLookPath)) ||
 		communitytool.HasLegacyCodeGraphGuidance(homeDir)
 }
@@ -465,7 +467,7 @@ func syncBackupTargets(homeDir, workspaceDir string, selection model.Selection, 
 			paths[path] = struct{}{}
 		}
 	}
-	if shouldRefreshCodeGraphGuidance(homeDir) {
+	if shouldHandleCodeGraphGuidance(homeDir) {
 		for _, path := range communitytool.CodeGraphGuidancePaths(homeDir) {
 			paths[path] = struct{}{}
 		}
@@ -693,6 +695,7 @@ func (s componentSyncStep) Run() error {
 				StrictTDD:                          s.selection.StrictTDD,
 				PreserveOpenCodeOrchestratorPrompt: profileStrategy == model.SDDProfileStrategyExternalSingleActive,
 				Profiles:                           profiles,
+				CodeGraphGuidanceMarkdown:          codeGraphGuidanceMarkdownForSDD(s.homeDir, nil),
 			}
 			res, err := sdd.Inject(targetDir, adapter, sddMode, opts)
 			if err != nil {

--- a/internal/cli/sync_test.go
+++ b/internal/cli/sync_test.go
@@ -699,7 +699,7 @@ func TestCodeGraphGuidanceSyncStepRepairsCodexConfigOnlyGuidance(t *testing.T) {
 		return "/bin/codegraph", nil
 	}
 
-	if !shouldRefreshCodeGraphGuidance(home) {
+	if !shouldHandleCodeGraphGuidance(home) {
 		t.Fatal("sync should plan CodeGraph guidance repair when Codex has CodeGraph MCP config but no managed guidance")
 	}
 
@@ -743,7 +743,7 @@ func TestCodeGraphGuidanceSyncStepCleansLegacyBlockWithoutCodeGraphCLI(t *testin
 	t.Cleanup(func() { cmdLookPath = restoreLookPath })
 	cmdLookPath = func(string) (string, error) { return "", os.ErrNotExist }
 
-	if !shouldRefreshCodeGraphGuidance(home) {
+	if !shouldHandleCodeGraphGuidance(home) {
 		t.Fatal("sync should plan legacy CodeGraph cleanup even when the CodeGraph CLI is unavailable")
 	}
 

--- a/internal/components/sdd/inject.go
+++ b/internal/components/sdd/inject.go
@@ -60,6 +60,11 @@ type InjectOptions struct {
 	// (no section extraction, full content written).
 	Capability string
 
+	// CodeGraphGuidanceMarkdown is the shared CodeGraph search-order guidance to
+	// inject into SDD phase sub-agent prompts. Empty means disabled; normal SDD
+	// installs must leave it empty unless the Community Tool path enabled CodeGraph.
+	CodeGraphGuidanceMarkdown string
+
 	// triggerRulesContent is an internal field set by step 1c in Inject()
 	// for OpenCode/Kilocode adapters. It holds the rendered trigger-rules
 	// block so inlineOpenCodeSDDPrompts can append it to the gentle-orchestrator
@@ -453,14 +458,14 @@ func Inject(homeDir string, adapter agents.Adapter, sddMode model.SDDModeID, opt
 						}
 					}
 				}
-				promptsChanged, promptsErr := WriteSharedPromptFiles(homeDir, phaseCapabilities)
+				promptsChanged, promptsErr := WriteSharedPromptFiles(homeDir, phaseCapabilities, opts.CodeGraphGuidanceMarkdown)
 				if promptsErr != nil {
 					return InjectionResult{}, fmt.Errorf("write shared SDD prompt files: %w", promptsErr)
 				}
 				changed = changed || promptsChanged
 			}
 
-			overlayBytes, err = inlineOpenCodeSDDPrompts(overlayBytes, homeDir, settingsPath, opts.PreserveOpenCodeOrchestratorPrompt, opts.triggerRulesContent)
+			overlayBytes, err = inlineOpenCodeSDDPrompts(overlayBytes, homeDir, settingsPath, opts.PreserveOpenCodeOrchestratorPrompt, opts.triggerRulesContent, opts.CodeGraphGuidanceMarkdown)
 			if err != nil {
 				return InjectionResult{}, fmt.Errorf("inline OpenCode SDD prompts: %w", err)
 			}
@@ -523,7 +528,7 @@ func Inject(homeDir string, adapter agents.Adapter, sddMode model.SDDModeID, opt
 					return InjectionResult{}, fmt.Errorf("clean stale profile JD agents %q: %w", profile.Name, cleanupErr)
 				}
 				changed = changed || cleanupResult.Changed
-				profileOverlay, profileErr := GenerateProfileOverlay(profile, homeDir)
+				profileOverlay, profileErr := GenerateProfileOverlay(profile, homeDir, opts.CodeGraphGuidanceMarkdown)
 				if profileErr != nil {
 					return InjectionResult{}, fmt.Errorf("generate profile overlay %q: %w", profile.Name, profileErr)
 				}
@@ -694,6 +699,10 @@ func Inject(homeDir string, adapter agents.Adapter, sddMode model.SDDModeID, opt
 				contentStr = strings.ReplaceAll(contentStr, "{{CLAUDE_MODEL}}", cmr.ClaudeModelID(assignment.Model))
 				contentStr = injectClaudeEffortFrontmatter(contentStr, assignment)
 			}
+
+			if isMarkdownSubAgentPromptFile(entry.Name()) {
+				contentStr = injectCodeGraphGuidanceIntoPrompt(contentStr, opts.CodeGraphGuidanceMarkdown)
+			}
 			outPath := filepath.Join(agentsDir, entry.Name())
 			writeResult, err := filemerge.WriteFileAtomic(outPath, []byte(contentStr), 0o644)
 			if err != nil {
@@ -823,7 +832,7 @@ func validateOpenClawWorkspacePath(workspaceDir string, adapter agents.Adapter) 
 	return nil
 }
 
-func inlineOpenCodeSDDPrompts(overlayBytes []byte, homeDir, settingsPath string, preserveExistingOrchestratorPrompt bool, triggerRulesContent string) ([]byte, error) {
+func inlineOpenCodeSDDPrompts(overlayBytes []byte, homeDir, settingsPath string, preserveExistingOrchestratorPrompt bool, triggerRulesContent string, codeGraphGuidance string) ([]byte, error) {
 	var overlay map[string]any
 	if err := json.Unmarshal(overlayBytes, &overlay); err != nil {
 		return nil, fmt.Errorf("unmarshal OpenCode SDD overlay: %w", err)
@@ -902,6 +911,13 @@ func inlineOpenCodeSDDPrompts(overlayBytes []byte, homeDir, settingsPath string,
 			}
 		}
 	}
+
+	// Single-mode SDD embeds sub-agent prompts directly in opencode.json instead
+	// of using shared prompt files. Multi-mode still keeps JD/review prompts inline.
+	// When CodeGraph is enabled through the Community Tool path, every sub-agent
+	// needs the same search-order rule the orchestrator gets; task artifact
+	// references alone are not enough.
+	injectCodeGraphGuidanceIntoOpenCodeSubagentPrompts(agentsMap, codeGraphGuidance)
 
 	result, err := json.MarshalIndent(overlay, "", "  ")
 	if err != nil {

--- a/internal/components/sdd/profiles.go
+++ b/internal/components/sdd/profiles.go
@@ -260,9 +260,13 @@ func extractModelFromAgent(agentMap map[string]any) model.ModelAssignment {
 //     sub-agent references and model assignments table), permissions scoped to *-{name}
 //   - sdd-{phase}-{name} (10 agents): subagent mode, hidden, file reference to
 //     the shared prompt at SharedPromptDir(homeDir)/sdd-{phase}.md
-func GenerateProfileOverlay(profile model.Profile, homeDir string) ([]byte, error) {
+func GenerateProfileOverlay(profile model.Profile, homeDir string, codeGraphGuidance ...string) ([]byte, error) {
 	if profile.Name == "" || profile.Name == "default" {
 		return nil, fmt.Errorf("GenerateProfileOverlay: profile name must be non-empty and not 'default'")
+	}
+	guidance := ""
+	if len(codeGraphGuidance) > 0 {
+		guidance = codeGraphGuidance[0]
 	}
 
 	suffix := "-" + profile.Name
@@ -393,6 +397,8 @@ func GenerateProfileOverlay(profile model.Profile, homeDir string) ([]byte, erro
 		}
 		agentMap[key] = entry
 	}
+
+	injectCodeGraphGuidanceIntoOpenCodeSubagentPrompts(agentMap, guidance)
 
 	overlay := map[string]any{
 		"agent": agentMap,

--- a/internal/components/sdd/prompts.go
+++ b/internal/components/sdd/prompts.go
@@ -2,6 +2,7 @@ package sdd
 
 import (
 	"path/filepath"
+	"strings"
 
 	"github.com/gentleman-programming/gentle-ai/internal/assets"
 	"github.com/gentleman-programming/gentle-ai/internal/components/filemerge"
@@ -43,9 +44,13 @@ func SharedPromptPhases() []string {
 // Returns (true, nil) if any file was created or changed, (false, nil) if all
 // files already match (idempotent). Uses WriteFileAtomic so the operation is
 // safe to repeat.
-func WriteSharedPromptFiles(homeDir string, phaseCapabilities map[string]string) (bool, error) {
+func WriteSharedPromptFiles(homeDir string, phaseCapabilities map[string]string, codeGraphGuidance ...string) (bool, error) {
 	promptDir := SharedPromptDir(homeDir)
 	anyChanged := false
+	guidance := ""
+	if len(codeGraphGuidance) > 0 {
+		guidance = codeGraphGuidance[0]
+	}
 
 	for _, phase := range subAgentPhaseOrder {
 		// Read the embedded skill content for this phase.
@@ -66,6 +71,7 @@ func WriteSharedPromptFiles(homeDir string, phaseCapabilities map[string]string)
 		// if no matching section marker is found — correct behavior for phases
 		// that don't yet have conditional sections).
 		content := extractModelSection(skillContent, capability)
+		content = injectCodeGraphGuidanceIntoPrompt(content, guidance)
 
 		path := filepath.Join(promptDir, phase+".md")
 		result, err := filemerge.WriteFileAtomic(path, []byte(content), 0o644)
@@ -79,4 +85,38 @@ func WriteSharedPromptFiles(homeDir string, phaseCapabilities map[string]string)
 	}
 
 	return anyChanged, nil
+}
+
+func injectCodeGraphGuidanceIntoPrompt(prompt, guidance string) string {
+	if strings.TrimSpace(guidance) == "" {
+		return prompt
+	}
+	return filemerge.InjectMarkdownSection(prompt, "codegraph-guidance", guidance)
+}
+
+func isMarkdownSubAgentPromptFile(fileName string) bool {
+	if filepath.Ext(fileName) != ".md" {
+		return false
+	}
+	return !strings.HasPrefix(filepath.Base(fileName), ".")
+}
+
+func injectCodeGraphGuidanceIntoOpenCodeSubagentPrompts(agentMap map[string]any, guidance string) {
+	if strings.TrimSpace(guidance) == "" {
+		return
+	}
+	for _, agentRaw := range agentMap {
+		agent, ok := agentRaw.(map[string]any)
+		if !ok {
+			continue
+		}
+		if mode, _ := agent["mode"].(string); mode == "primary" {
+			continue
+		}
+		prompt, ok := agent["prompt"].(string)
+		if !ok || strings.HasPrefix(prompt, "{file:") {
+			continue
+		}
+		agent["prompt"] = injectCodeGraphGuidanceIntoPrompt(prompt, guidance)
+	}
 }

--- a/internal/components/sdd/prompts_test.go
+++ b/internal/components/sdd/prompts_test.go
@@ -1,10 +1,14 @@
 package sdd
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/internal/components/communitytool"
+	"github.com/gentleman-programming/gentle-ai/internal/model"
 )
 
 // TestSharedPromptDir verifies the expected directory path is returned.
@@ -14,6 +18,94 @@ func TestSharedPromptDir(t *testing.T) {
 	if got != want {
 		t.Fatalf("SharedPromptDir(%q) = %q, want %q", "/home/testuser", got, want)
 	}
+}
+
+func readOpenCodeAgents(t *testing.T, settingsPath string) map[string]any {
+	t.Helper()
+	content, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", settingsPath, err)
+	}
+	var settings struct {
+		Agent map[string]any `json:"agent"`
+	}
+	if err := json.Unmarshal(content, &settings); err != nil {
+		t.Fatalf("Unmarshal(%q) error = %v", settingsPath, err)
+	}
+	return settings.Agent
+}
+
+func agentPrompt(t *testing.T, agentsMap map[string]any, agentName string) string {
+	t.Helper()
+	agentRaw, ok := agentsMap[agentName]
+	if !ok {
+		t.Fatalf("agent %q missing", agentName)
+	}
+	agentMap, ok := agentRaw.(map[string]any)
+	if !ok {
+		t.Fatalf("agent %q has type %T, want object", agentName, agentRaw)
+	}
+	prompt, ok := agentMap["prompt"].(string)
+	if !ok {
+		t.Fatalf("agent %q prompt has type %T, want string", agentName, agentMap["prompt"])
+	}
+	return prompt
+}
+
+func sddInstalledSubAgentsForCodeGraphTest() []string {
+	agents := append([]string{}, SharedPromptPhases()...)
+	agents = append(agents, sddJudgmentDaySubAgentsForCodeGraphTest()...)
+	agents = append(agents, sddReviewSubAgentsForCodeGraphTest()...)
+	return agents
+}
+
+func sddJudgmentDaySubAgentsForCodeGraphTest() []string {
+	return []string{
+		"jd-judge-a",
+		"jd-judge-b",
+		"jd-fix-agent",
+	}
+}
+
+func sddReviewSubAgentsForCodeGraphTest() []string {
+	return []string{
+		"review-risk",
+		"review-readability",
+		"review-reliability",
+		"review-resilience",
+	}
+}
+
+func nativeMarkdownSubAgentsForCodeGraphTest(agentID model.AgentID) []string {
+	agents := sddInstalledSubAgentsForCodeGraphTest()
+	if agentID == model.AgentCursor || agentID == model.AgentKimi {
+		return withoutStrings(agents, sddJudgmentDaySubAgentsForCodeGraphTest()...)
+	}
+	return agents
+}
+
+func kimiYAMLSubagentFilesForCodeGraphTest() []string {
+	return []string{"sdd-apply.yaml", "review-risk.yaml"}
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+func withoutStrings(values []string, excluded ...string) []string {
+	kept := make([]string, 0, len(values))
+	for _, value := range values {
+		if containsString(excluded, value) {
+			continue
+		}
+		kept = append(kept, value)
+	}
+	return kept
 }
 
 // TestWriteSharedPromptFilesCreates10Files verifies that WriteSharedPromptFiles
@@ -245,6 +337,235 @@ func TestInjectOpenCodeMultiModeSubagentPromptsUseFilePaths(t *testing.T) {
 		expectedRef = strings.ReplaceAll(expectedRef, `\`, `/`)
 		if !strings.Contains(text, expectedRef) {
 			t.Errorf("opencode.json sub-agent %q missing {file:...} reference %q", phase, expectedRef)
+		}
+	}
+}
+
+func TestWriteSharedPromptFilesOmitCodeGraphGuidanceByDefault(t *testing.T) {
+	home := t.TempDir()
+
+	if _, err := WriteSharedPromptFiles(home, nil); err != nil {
+		t.Fatalf("WriteSharedPromptFiles() error = %v", err)
+	}
+
+	for _, phase := range SharedPromptPhases() {
+		path := filepath.Join(SharedPromptDir(home), phase+".md")
+		content, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("ReadFile(%q) error = %v", path, err)
+		}
+		text := string(content)
+		if strings.Contains(text, "<!-- gentle-ai:codegraph-guidance -->") || strings.Contains(text, "codegraph init <project-root>") {
+			t.Fatalf("%s unexpectedly contains CodeGraph guidance by default", phase)
+		}
+	}
+}
+
+func TestWriteSharedPromptFilesIncludeCodeGraphGuidanceWhenEnabled(t *testing.T) {
+	home := t.TempDir()
+	guidance := communitytool.CodeGraphGuidanceMarkdown()
+
+	if _, err := WriteSharedPromptFiles(home, nil, guidance); err != nil {
+		t.Fatalf("WriteSharedPromptFiles() error = %v", err)
+	}
+
+	for _, phase := range SharedPromptPhases() {
+		path := filepath.Join(SharedPromptDir(home), phase+".md")
+		content, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("ReadFile(%q) error = %v", path, err)
+		}
+		text := string(content)
+		if !strings.Contains(text, "<!-- gentle-ai:codegraph-guidance -->") || !strings.Contains(text, "codegraph init <project-root>") {
+			t.Fatalf("%s missing CodeGraph guidance when enabled", phase)
+		}
+		if count := strings.Count(text, "<!-- gentle-ai:codegraph-guidance -->"); count != 1 {
+			t.Fatalf("%s has %d CodeGraph guidance sections, want 1", phase, count)
+		}
+	}
+}
+
+func TestInjectOpenCodeSingleModeSubagentPromptsOmitCodeGraphGuidanceByDefault(t *testing.T) {
+	home := t.TempDir()
+	mockNoPackageManager(t)
+
+	if _, err := Inject(home, opencodeAdapter(), model.SDDModeSingle); err != nil {
+		t.Fatalf("Inject(single) error = %v", err)
+	}
+
+	agentsMap := readOpenCodeAgents(t, filepath.Join(home, ".config", "opencode", "opencode.json"))
+	for _, agentName := range sddInstalledSubAgentsForCodeGraphTest() {
+		prompt := agentPrompt(t, agentsMap, agentName)
+		if strings.Contains(prompt, "<!-- gentle-ai:codegraph-guidance -->") || strings.Contains(prompt, "codegraph init <project-root>") {
+			t.Fatalf("%s unexpectedly contains CodeGraph guidance by default", agentName)
+		}
+	}
+}
+
+func TestInjectOpenCodeSingleModeSubagentPromptsIncludeCodeGraphGuidanceWhenEnabled(t *testing.T) {
+	home := t.TempDir()
+	mockNoPackageManager(t)
+
+	if _, err := Inject(home, opencodeAdapter(), model.SDDModeSingle, InjectOptions{CodeGraphGuidanceMarkdown: communitytool.CodeGraphGuidanceMarkdown()}); err != nil {
+		t.Fatalf("Inject(single) error = %v", err)
+	}
+
+	agentsMap := readOpenCodeAgents(t, filepath.Join(home, ".config", "opencode", "opencode.json"))
+	for _, agentName := range sddInstalledSubAgentsForCodeGraphTest() {
+		prompt := agentPrompt(t, agentsMap, agentName)
+		if !strings.Contains(prompt, "<!-- gentle-ai:codegraph-guidance -->") || !strings.Contains(prompt, "codegraph init <project-root>") {
+			t.Fatalf("%s missing CodeGraph guidance when enabled", agentName)
+		}
+		if count := strings.Count(prompt, "<!-- gentle-ai:codegraph-guidance -->"); count != 1 {
+			t.Fatalf("%s has %d CodeGraph guidance sections, want 1", agentName, count)
+		}
+	}
+}
+
+func TestInjectOpenCodeMultiModeSubagentPromptFilesIncludeCodeGraphGuidanceWhenEnabled(t *testing.T) {
+	home := t.TempDir()
+	mockNoPackageManager(t)
+
+	if _, err := Inject(home, opencodeAdapter(), model.SDDModeMulti, InjectOptions{CodeGraphGuidanceMarkdown: communitytool.CodeGraphGuidanceMarkdown()}); err != nil {
+		t.Fatalf("Inject(multi) error = %v", err)
+	}
+
+	for _, phase := range SharedPromptPhases() {
+		path := filepath.Join(SharedPromptDir(home), phase+".md")
+		content, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("ReadFile(%q) error = %v", path, err)
+		}
+		text := string(content)
+		if !strings.Contains(text, "<!-- gentle-ai:codegraph-guidance -->") || !strings.Contains(text, "codegraph init <project-root>") {
+			t.Fatalf("%s missing CodeGraph guidance when enabled", phase)
+		}
+	}
+
+	agentsMap := readOpenCodeAgents(t, filepath.Join(home, ".config", "opencode", "opencode.json"))
+	inlineSubagents := append(sddJudgmentDaySubAgentsForCodeGraphTest(), sddReviewSubAgentsForCodeGraphTest()...)
+	for _, agentName := range inlineSubagents {
+		prompt := agentPrompt(t, agentsMap, agentName)
+		if !strings.Contains(prompt, "<!-- gentle-ai:codegraph-guidance -->") || !strings.Contains(prompt, "codegraph init <project-root>") {
+			t.Fatalf("%s missing CodeGraph guidance in multi-mode inline prompt when enabled", agentName)
+		}
+	}
+}
+
+func TestInjectNativeSDDSubagentsIncludeCodeGraphGuidanceWhenEnabled(t *testing.T) {
+	tests := []struct {
+		name    string
+		agentID model.AgentID
+	}{
+		{name: "claude", agentID: model.AgentClaudeCode},
+		{name: "cursor", agentID: model.AgentCursor},
+		{name: "kiro", agentID: model.AgentKiroIDE},
+		{name: "kimi", agentID: model.AgentKimi},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			adapter := mustAdapter(t, tc.agentID)
+
+			if _, err := Inject(home, adapter, model.SDDModeSingle, InjectOptions{CodeGraphGuidanceMarkdown: communitytool.CodeGraphGuidanceMarkdown()}); err != nil {
+				t.Fatalf("Inject(%s) error = %v", tc.name, err)
+			}
+
+			for _, agentName := range nativeMarkdownSubAgentsForCodeGraphTest(tc.agentID) {
+				path := filepath.Join(adapter.SubAgentsDir(home), agentName+".md")
+				content, err := os.ReadFile(path)
+				if err != nil {
+					t.Fatalf("ReadFile(%q) error = %v", path, err)
+				}
+				text := string(content)
+				if !strings.Contains(text, "<!-- gentle-ai:codegraph-guidance -->") || !strings.Contains(text, "codegraph init <project-root>") {
+					t.Fatalf("%s native subagent missing CodeGraph guidance when enabled", agentName)
+				}
+			}
+		})
+	}
+
+	for _, agentName := range []string{"jd-judge-a", "review-risk"} {
+		if !containsString(nativeMarkdownSubAgentsForCodeGraphTest(model.AgentClaudeCode), agentName) {
+			t.Fatalf("native coverage helper missing %s", agentName)
+		}
+	}
+}
+
+func TestInjectNativeSDDSubagentsOmitCodeGraphGuidanceByDefault(t *testing.T) {
+	home := t.TempDir()
+
+	if _, err := Inject(home, claudeAdapter(), model.SDDModeSingle); err != nil {
+		t.Fatalf("Inject(claude) error = %v", err)
+	}
+
+	for _, agentName := range nativeMarkdownSubAgentsForCodeGraphTest(model.AgentClaudeCode) {
+		path := filepath.Join(home, ".claude", "agents", agentName+".md")
+		content, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("ReadFile(%q) error = %v", path, err)
+		}
+		text := string(content)
+		if strings.Contains(text, "<!-- gentle-ai:codegraph-guidance -->") || strings.Contains(text, "codegraph init <project-root>") {
+			t.Fatalf("%s native subagent unexpectedly contains CodeGraph guidance by default", agentName)
+		}
+	}
+}
+
+func TestInjectKimiYAMLSubagentsOmitCodeGraphGuidanceByDefault(t *testing.T) {
+	home := t.TempDir()
+
+	if _, err := Inject(home, kimiAdapter(), model.SDDModeSingle); err != nil {
+		t.Fatalf("Inject(kimi) error = %v", err)
+	}
+
+	for _, fileName := range kimiYAMLSubagentFilesForCodeGraphTest() {
+		path := filepath.Join(home, ".kimi", "agents", fileName)
+		content, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("ReadFile(%q) error = %v", path, err)
+		}
+		text := string(content)
+		if strings.Contains(text, "  instructions: |-") || strings.Contains(text, "codegraph init <project-root>") {
+			t.Fatalf("%s YAML unexpectedly contains CodeGraph guidance by default", fileName)
+		}
+	}
+}
+
+func TestInjectKimiYAMLSubagentsRemainControlFilesWhenCodeGraphEnabled(t *testing.T) {
+	home := t.TempDir()
+
+	if _, err := Inject(home, kimiAdapter(), model.SDDModeSingle, InjectOptions{CodeGraphGuidanceMarkdown: communitytool.CodeGraphGuidanceMarkdown()}); err != nil {
+		t.Fatalf("Inject(kimi) error = %v", err)
+	}
+
+	for _, fileName := range kimiYAMLSubagentFilesForCodeGraphTest() {
+		path := filepath.Join(home, ".kimi", "agents", fileName)
+		content, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("ReadFile(%q) error = %v", path, err)
+		}
+		text := string(content)
+		for _, want := range []string{"  system_prompt_path: ./", "  exclude_tools:"} {
+			if !strings.Contains(text, want) {
+				t.Fatalf("%s YAML missing %q:\n%s", fileName, want, text)
+			}
+		}
+		for _, forbidden := range []string{"  instructions: |-", "<!-- gentle-ai:codegraph-guidance -->", "codegraph init <project-root>"} {
+			if strings.Contains(text, forbidden) {
+				t.Fatalf("%s YAML unexpectedly contains %q:\n%s", fileName, forbidden, text)
+			}
+		}
+
+		markdownPath := strings.TrimSuffix(path, ".yaml") + ".md"
+		markdownContent, err := os.ReadFile(markdownPath)
+		if err != nil {
+			t.Fatalf("ReadFile(%q) error = %v", markdownPath, err)
+		}
+		markdownText := string(markdownContent)
+		if !strings.Contains(markdownText, "<!-- gentle-ai:codegraph-guidance -->") || !strings.Contains(markdownText, "codegraph init <project-root>") {
+			t.Fatalf("%s referenced Markdown prompt missing CodeGraph guidance when enabled", markdownPath)
 		}
 	}
 }


### PR DESCRIPTION
Closes #997

## PR Type
- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Propagates CodeGraph guidance into generated SDD/JD/review sub-agent prompts only when CodeGraph is selected or configured.
- Keeps normal SDD installs default-off when only the CodeGraph CLI is present.
- Preserves Kimi YAML control files and injects guidance into referenced Markdown prompts instead.

## Changes
| File | Change |
|------|--------|
| `internal/cli/run.go` | Adds gated CodeGraph guidance selection for SDD install paths. |
| `internal/cli/sync.go` | Adds same-run sync wiring and clarifies CodeGraph guidance handling. |
| `internal/components/sdd/inject.go` | Passes gated guidance into OpenCode/native/profile generated sub-agents. |
| `internal/components/sdd/profiles.go` | Propagates guidance through generated OpenCode profile overlays. |
| `internal/components/sdd/prompts.go` | Adds shared prompt injection helpers while avoiding YAML mutation. |
| `internal/cli/*_test.go`, `internal/components/sdd/prompts_test.go` | Adds gating, behavior-level, and Kimi YAML regression coverage. |

## Test Plan
- [x] `go test ./internal/cli -run 'CodeGraphGuidance|Component.*CodeGraph|Sync.*CodeGraph|Apply.*CodeGraph|InstallRuntimeStagePlanAddsCommunityToolStepsInSelectionOrder|CommunityToolInstallStepUsesInjectableInstaller'`
- [x] `go test ./internal/components/sdd -run 'CodeGraph|Subagent|Kimi'`
- [x] `go test ./internal/components/sdd ./internal/components/communitytool`

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran shellcheck on modified scripts (not applicable: no shell scripts changed)
- [x] Skills tested in at least one agent
- [x] Docs updated if behavior changed (not applicable: generated prompt behavior covered by tests)
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SDD-generated prompts can now include CodeGraph guidance when the tool is selected or already configured.
  * Guidance is carried through shared prompts, profile overlays, and sub-agent prompts across supported modes.

* **Bug Fixes**
  * Prevents CodeGraph guidance from appearing when only the CLI is installed and no guidance is configured.
  * Sync now preserves and restores guidance content more consistently, including legacy setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->