### PR TITLE
fix(skill-registry): scan skill dirs one level deep, following symlinks

### DIFF
--- a/docs/skill-registry.md
+++ b/docs/skill-registry.md
@@ -118,6 +118,25 @@ Compact rules were cheaper per delegation but could distort skills. The index-fi
 | Compact summaries | Small prompt injection | Can lose nuance and break custom skills |
 | Index + paths | Preserves full skill intent | Subagents read selected full skills |
 
+## Excluded Skills
+
+The registry never indexes `_shared`, `skill-registry`, or any `sdd-*` skill.
+The first two are internal plumbing; `sdd-*` skills are orchestrator-managed by
+the SDD workflow, not delegator-selected. This exclusion is intentional and
+silent, so a user skill whose name collides with these prefixes is dropped
+without a warning.
+
+## Inspecting Without Writing
+
+`skill-registry list` resolves the same deduplicated skill set as `refresh`, but
+prints it instead of writing `.atl/skill-registry.md`, the cache, or
+`.gitignore`. Handy for debugging what a delegator would see.
+
+```bash
+gentle-ai skill-registry list          # name<TAB>scope<TAB>path
+gentle-ai skill-registry list --json   # machine-readable, includes descriptions
+```
+
 ## Quick Check
 
 ```bash

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -258,15 +259,42 @@ func gentleAIUpgradeVersionFromTUI(finalModel tea.Model) (string, bool) {
 }
 
 func runSkillRegistry(args []string, stdout io.Writer) error {
-	if len(args) == 0 || args[0] != "refresh" {
-		return fmt.Errorf("usage: gentle-ai skill-registry refresh [--cwd <dir>] [--force] [--quiet] [--no-gitignore]")
+	if len(args) == 0 {
+		return fmt.Errorf("usage: gentle-ai skill-registry <refresh|list> [flags]")
 	}
+	switch args[0] {
+	case "refresh":
+		return runSkillRegistryRefresh(args[1:], stdout)
+	case "list":
+		return runSkillRegistryList(args[1:], stdout)
+	default:
+		return fmt.Errorf("unknown skill-registry command %q (want refresh or list)", args[0])
+	}
+}
 
+// resolveSkillRegistryDirs resolves the working directory (defaulting to the
+// process cwd) and the user home directory used to locate skills.
+func resolveSkillRegistryDirs(cwd string) (string, string, error) {
+	if cwd == "" {
+		var err error
+		cwd, err = os.Getwd()
+		if err != nil {
+			return "", "", fmt.Errorf("resolve cwd: %w", err)
+		}
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", "", fmt.Errorf("resolve home directory: %w", err)
+	}
+	return cwd, home, nil
+}
+
+func runSkillRegistryRefresh(args []string, stdout io.Writer) error {
 	cwd := ""
 	force := false
 	quiet := false
 	ensureGitignore := true
-	for i := 1; i < len(args); i++ {
+	for i := 0; i < len(args); i++ {
 		switch args[i] {
 		case "--force", "-f":
 			force = true
@@ -281,19 +309,12 @@ func runSkillRegistry(args []string, stdout io.Writer) error {
 			cwd = args[i+1]
 			i++
 		default:
-			return fmt.Errorf("unknown skill-registry argument %q", args[i])
+			return fmt.Errorf("unknown skill-registry refresh argument %q", args[i])
 		}
 	}
-	if cwd == "" {
-		var err error
-		cwd, err = os.Getwd()
-		if err != nil {
-			return fmt.Errorf("resolve cwd: %w", err)
-		}
-	}
-	home, err := os.UserHomeDir()
+	cwd, home, err := resolveSkillRegistryDirs(cwd)
 	if err != nil {
-		return fmt.Errorf("resolve home directory: %w", err)
+		return err
 	}
 	if ensureGitignore {
 		if err := skillregistry.EnsureATLIgnored(cwd); err != nil {
@@ -310,6 +331,63 @@ func runSkillRegistry(args []string, stdout io.Writer) error {
 		} else {
 			_, _ = fmt.Fprintf(stdout, "Skill registry up to date (%s): %s\n", result.Reason, result.Registry)
 		}
+	}
+	return nil
+}
+
+func runSkillRegistryList(args []string, stdout io.Writer) error {
+	cwd := ""
+	asJSON := false
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--json":
+			asJSON = true
+		case "--cwd":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--cwd requires a value")
+			}
+			cwd = args[i+1]
+			i++
+		default:
+			return fmt.Errorf("unknown skill-registry list argument %q", args[i])
+		}
+	}
+	cwd, home, err := resolveSkillRegistryDirs(cwd)
+	if err != nil {
+		return err
+	}
+	entries := skillregistry.List(cwd, home)
+
+	if asJSON {
+		type row struct {
+			Name        string `json:"name"`
+			Scope       string `json:"scope"`
+			Description string `json:"description"`
+			Path        string `json:"path"`
+		}
+		rows := make([]row, 0, len(entries))
+		for _, e := range entries {
+			rows = append(rows, row{
+				Name:        e.Name,
+				Scope:       skillregistry.ScopeForPath(cwd, e.Path),
+				Description: e.Description,
+				Path:        e.Path,
+			})
+		}
+		data, err := json.MarshalIndent(rows, "", "  ")
+		if err != nil {
+			return err
+		}
+		_, _ = fmt.Fprintln(stdout, string(data))
+		return nil
+	}
+
+	if len(entries) == 0 {
+		_, _ = fmt.Fprintln(stdout, "No skills found.")
+		return nil
+	}
+	for _, e := range entries {
+		_, _ = fmt.Fprintf(stdout, "%s\t%s\t%s\n", e.Name, skillregistry.ScopeForPath(cwd, e.Path), e.Path)
 	}
 	return nil
 }

--- a/internal/skillregistry/registry.go
+++ b/internal/skillregistry/registry.go
@@ -23,6 +23,12 @@ const (
 	atlIgnoreEntry  = ".atl/"
 )
 
+// Excluded skills never appear in the registry. This policy is intentionally
+// hardcoded and applied silently: `_shared` and `skill-registry` are internal
+// plumbing, and `sdd-*` skills are orchestrator-managed via the SDD workflow,
+// not delegator-selected. NOTE: a user skill whose name collides with these
+// (e.g. any name starting with `sdd-`) is dropped without warning. Revisit as
+// configuration if that collision ever becomes a real constraint.
 var (
 	excludeNames    = map[string]bool{"_shared": true, "skill-registry": true}
 	excludePrefixes = []string{"sdd-"}
@@ -33,7 +39,6 @@ type SkillEntry struct {
 	Name        string
 	Path        string
 	Description string
-	Scope       string
 }
 
 type Result struct {
@@ -161,6 +166,26 @@ func Regenerate(cwd, home string, force bool) (Result, error) {
 	return Result{Regenerated: true, SkillCount: len(entries), Reason: reason, Registry: registryPath, Cache: cachePath}, nil
 }
 
+// List resolves the deduplicated, sorted set of skills that Regenerate would
+// index, without writing the registry, cache, or .gitignore. It is the
+// read-only inspection path behind `gentle-ai skill-registry list`.
+func List(cwd, home string) []SkillEntry {
+	cwd = filepath.Clean(cwd)
+	home = filepath.Clean(home)
+	existingDirs := uniqueExistingDirs(append(ProjectSkillDirs(cwd), UserSkillDirs(home)...))
+	files, err := findAllSkillFiles(existingDirs)
+	if err != nil {
+		return nil
+	}
+	entries := make([]SkillEntry, 0, len(files))
+	for _, file := range files {
+		if entry, ok := LoadSkill(file); ok {
+			entries = append(entries, entry)
+		}
+	}
+	return dedupeBySkillName(entries, cwd)
+}
+
 func EnsureATLIgnored(cwd string) error {
 	gitignorePath := filepath.Join(cwd, ".gitignore")
 	existingBytes, err := os.ReadFile(gitignorePath)
@@ -182,7 +207,12 @@ func EnsureATLIgnored(cwd string) error {
 	if !strings.Contains(existing, "# Local AI runtime state") && !strings.Contains(existing, "# Local Pi runtime state") {
 		header = "# Local AI runtime state\n"
 	}
-	return os.WriteFile(gitignorePath, []byte(existing+prefix+header+atlIgnoreEntry+"\n"), 0o644)
+	// Atomic write guards against concurrent startup hooks (Codex + OpenCode +
+	// Claude) racing on .gitignore, matching how the registry file is written.
+	if _, err := filemerge.WriteFileAtomic(gitignorePath, []byte(existing+prefix+header+atlIgnoreEntry+"\n"), 0o644); err != nil {
+		return fmt.Errorf("write .gitignore: %w", err)
+	}
+	return nil
 }
 
 func Fingerprint(files []string) string {
@@ -206,14 +236,13 @@ func LoadSkill(file string) (SkillEntry, bool) {
 	if err != nil {
 		return SkillEntry{}, false
 	}
-	name, desc, body := parseFrontmatter(string(data))
+	name, desc := parseFrontmatter(string(data))
 	if strings.TrimSpace(name) == "" {
 		name = filepath.Base(filepath.Dir(file))
 	}
 	if isExcluded(name) {
 		return SkillEntry{}, false
 	}
-	_ = body
 	return SkillEntry{Name: name, Path: file, Description: desc}, true
 }
 
@@ -234,10 +263,7 @@ func RenderRegistry(cwd string, sources []string, entries []SkillEntry) string {
 	lines = append(lines, "| Skill | Trigger / description | Scope | Path |")
 	lines = append(lines, "| --- | --- | --- | --- |")
 	for _, entry := range entries {
-		scope := entry.Scope
-		if scope == "" {
-			scope = scopeForPath(cwd, entry.Path)
-		}
+		scope := ScopeForPath(cwd, entry.Path)
 		lines = append(lines, fmt.Sprintf("| `%s` | %s | %s | `%s` |", markdownCell(entry.Name), markdownCell(entry.Description), markdownCell(scope), markdownCell(entry.Path)))
 	}
 	lines = append(lines, "", "## Loading protocol", "")
@@ -248,20 +274,30 @@ func RenderRegistry(cwd string, sources []string, entries []SkillEntry) string {
 	return strings.TrimRight(strings.Join(lines, "\n"), "\n") + "\n"
 }
 
+// findAllSkillFiles scans each root exactly one level deep for
+// <root>/<skill>/SKILL.md, the Agent Skills layout. A single-level scan is
+// deliberate: it follows symlinked skill directories (dotfiles/nix setups,
+// which filepath.WalkDir silently skips) and never indexes nested fixture or
+// example SKILL.md files that would otherwise pollute the registry with
+// phantom entries named after their parent directory.
 func findAllSkillFiles(dirs []string) ([]string, error) {
 	var out []string
 	for _, root := range dirs {
-		err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
-			if err != nil {
-				return nil
-			}
-			if !d.IsDir() && d.Name() == "SKILL.md" {
-				out = append(out, path)
-			}
-			return nil
-		})
+		entries, err := os.ReadDir(root)
 		if err != nil {
-			return nil, err
+			continue
+		}
+		for _, entry := range entries {
+			// dirExists/fileExists use os.Stat, so symlinked skill dirs and
+			// symlinked SKILL.md files are resolved instead of skipped.
+			skillDir := filepath.Join(root, entry.Name())
+			if !dirExists(skillDir) {
+				continue
+			}
+			candidate := filepath.Join(skillDir, "SKILL.md")
+			if fileExists(candidate) {
+				out = append(out, candidate)
+			}
 		}
 	}
 	return out, nil
@@ -281,19 +317,18 @@ func uniqueExistingDirs(dirs []string) []string {
 	return out
 }
 
-func parseFrontmatter(source string) (name, description, body string) {
+func parseFrontmatter(source string) (name, description string) {
 	source = strings.ReplaceAll(source, "\r\n", "\n")
 	source = strings.ReplaceAll(source, "\r", "\n")
 	if !strings.HasPrefix(source, "---\n") {
-		return "", "", source
+		return "", ""
 	}
 	end := strings.Index(source[4:], "\n---")
 	if end == -1 {
-		return "", "", source
+		return "", ""
 	}
 	end += 4
 	fm := source[4:end]
-	body = strings.TrimPrefix(source[end+4:], "\n")
 	lines := strings.Split(fm, "\n")
 	for i := 0; i < len(lines); i++ {
 		line := lines[i]
@@ -328,7 +363,7 @@ func parseFrontmatter(source string) (name, description, body string) {
 			description = value
 		}
 	}
-	return name, description, body
+	return name, description
 }
 
 func dedupeBySkillName(entries []SkillEntry, cwd string) []SkillEntry {
@@ -352,7 +387,9 @@ func dedupeBySkillName(entries []SkillEntry, cwd string) []SkillEntry {
 	return out
 }
 
-func scopeForPath(cwd, path string) string {
+// ScopeForPath reports whether a skill path is project-local or user-global,
+// relative to cwd.
+func ScopeForPath(cwd, path string) string {
 	projectPrefix := filepath.Clean(cwd) + string(os.PathSeparator)
 	if strings.HasPrefix(filepath.Clean(path), projectPrefix) {
 		return "project"

--- a/internal/skillregistry/registry_test.go
+++ b/internal/skillregistry/registry_test.go
@@ -395,7 +395,7 @@ func TestParseFrontmatterHandlesCRLF(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			gotName, gotDesc, _ := parseFrontmatter(tc.source)
+			gotName, gotDesc := parseFrontmatter(tc.source)
 			if gotName != tc.wantName {
 				t.Errorf("name = %q, want %q", gotName, tc.wantName)
 			}
@@ -403,6 +403,102 @@ func TestParseFrontmatterHandlesCRLF(t *testing.T) {
 				t.Errorf("description = %q, want %q", gotDesc, tc.wantDesc)
 			}
 		})
+	}
+}
+
+func TestFindAllSkillFilesFollowsSymlinkedSkillDir(t *testing.T) {
+	cwd := t.TempDir()
+	home := t.TempDir()
+	// A real skill living outside the project, linked in as a project skill.
+	// filepath.WalkDir would silently skip this; the one-level scan must not.
+	realDir := filepath.Join(t.TempDir(), "linked-skill")
+	writeSkill(t, filepath.Join(realDir, "SKILL.md"), `---
+name: linked
+description: linked via symlink
+---
+
+## Hard Rules
+
+- ok
+`)
+	linkParent := filepath.Join(cwd, "skills")
+	if err := os.MkdirAll(linkParent, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(realDir, filepath.Join(linkParent, "linked")); err != nil {
+		t.Skipf("symlink unsupported on this platform: %v", err)
+	}
+
+	result, err := Regenerate(cwd, home, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.SkillCount != 1 {
+		t.Fatalf("SkillCount = %d, want 1 (symlinked skill dir must be indexed)", result.SkillCount)
+	}
+	registry := readFile(t, filepath.Join(cwd, RegistryRelPath))
+	if !strings.Contains(registry, "`linked`") || !strings.Contains(registry, "linked via symlink") {
+		t.Fatalf("registry missing symlinked skill:\n%s", registry)
+	}
+}
+
+func TestRegenerateIgnoresNestedSkillMd(t *testing.T) {
+	cwd := t.TempDir()
+	home := t.TempDir()
+	writeSkill(t, filepath.Join(cwd, "skills", "parent", "SKILL.md"), `---
+name: parent
+description: top-level skill
+---
+
+## Hard Rules
+
+- ok
+`)
+	// A SKILL.md bundled as an example inside the skill must not be indexed.
+	writeSkill(t, filepath.Join(cwd, "skills", "parent", "examples", "SKILL.md"), `---
+name: nested-example
+description: should not be indexed
+---
+
+## Hard Rules
+
+- no
+`)
+
+	result, err := Regenerate(cwd, home, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.SkillCount != 1 {
+		t.Fatalf("SkillCount = %d, want 1 (nested SKILL.md must be ignored)", result.SkillCount)
+	}
+	registry := readFile(t, filepath.Join(cwd, RegistryRelPath))
+	if strings.Contains(registry, "nested-example") || strings.Contains(registry, "should not be indexed") {
+		t.Fatalf("nested SKILL.md leaked into registry:\n%s", registry)
+	}
+}
+
+func TestListReturnsDedupedEntriesWithoutWriting(t *testing.T) {
+	cwd := t.TempDir()
+	home := t.TempDir()
+	writeSkill(t, filepath.Join(home, ".claude", "skills", "dup", "SKILL.md"), "---\nname: dup\ndescription: user copy\n---\n")
+	writeSkill(t, filepath.Join(cwd, "skills", "dup", "SKILL.md"), "---\nname: dup\ndescription: project copy\n---\n")
+	writeSkill(t, filepath.Join(cwd, "skills", "solo", "SKILL.md"), "---\nname: solo\ndescription: solo\n---\n")
+
+	entries := List(cwd, home)
+	if len(entries) != 2 {
+		t.Fatalf("len(entries) = %d, want 2", len(entries))
+	}
+	// Sorted by name: dup, solo. The project copy of dup must win.
+	if entries[0].Name != "dup" || entries[0].Description != "project copy" {
+		t.Fatalf("entries[0] = %#v, want project dup", entries[0])
+	}
+	if got := ScopeForPath(cwd, entries[0].Path); got != "project" {
+		t.Fatalf("dup scope = %q, want project", got)
+	}
+	// List is read-only: it must not write the registry or cache.
+	if _, err := os.Stat(filepath.Join(cwd, RegistryRelPath)); !os.IsNotExist(err) {
+		t.Fatalf("List wrote registry (stat err = %v), want it absent", err)
 	}
 }
 


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #256

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)

Primary change is the symlink scan fix (#256). It also bundles small, in-area hardening (a read-only `list` command, dead-code cleanup, atomic `.gitignore` write).

---

## 📝 Summary

- Skills installed as **symlinks** (the standard `install.sh`/dotfiles path) were invisible to the registry scan because `filepath.WalkDir` does not follow symlinked directories — every rebuild silently dropped them.
- Replaces the recursive walk with an explicit **one-level scan** (`<root>/<skill>/SKILL.md`) that resolves symlinks via `os.Stat` and no longer indexes nested fixture `SKILL.md` files as phantom entries.
- Adds a read-only `skill-registry list [--json]` command, removes dead code, and makes the `.gitignore` write atomic.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/skillregistry/registry.go` | One-level symlink-safe scan; drop dead `SkillEntry.Scope` field and unused parsed body; atomic `.gitignore` write; new `List` + exported `ScopeForPath`; documented exclude policy |
| `internal/app/app.go` | Split `skill-registry` handler into `refresh`/`list` subcommands; add `list [--cwd] [--json]` |
| `internal/skillregistry/registry_test.go` | Tests: symlinked skill dir indexed, nested `SKILL.md` ignored, `List` deduped and non-writing; updated `parseFrontmatter` signature |
| `docs/skill-registry.md` | Document excluded skills and the `list` command |

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./...
```

- [x] Unit tests pass (`go test ./internal/skillregistry/... ./internal/app/... ./internal/cli/... ./internal/catalog/...`)
- [x] `go build ./...` and `go vet` clean
- [x] Manually tested locally: `skill-registry list` / `--json` indexes 48 skills in a real symlink-free and symlinked layout

---

## ✅ Checklist

- [x] Linked an approved issue (#256 has `status:approved`)
- [x] Added exactly one `type:*` label
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
- [x] Docs updated (behavior changed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a read-only `skill-registry list` command to view the current skill registry without writing files.
  * Added `--json` output for easier scripting and automation.

* **Bug Fixes**
  * Skill listing now uses consistent deduplication and clearer scope handling.
  * Registry scanning now ignores nested skill files and unsupported skill folders.

* **Documentation**
  * Expanded guidance on excluded skills and how to inspect skills safely without updating cache or ignore files.

* **Tests**
  * Added coverage for listing behavior, symlinked skills, and nested skill file handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->