### PR TITLE
docs(sdd): compress SDD skills and add filesystem path convention notes

### DIFF
--- a/internal/assets/opencode/sdd-orchestrator.md
+++ b/internal/assets/opencode/sdd-orchestrator.md
@@ -69,32 +69,6 @@ These are parent-orchestrator stop rules. When a trigger fires, perform the spec
 
 If multiple rows match, run the narrow set that covers the risk. Example: shell integration that mutates live state should use `review-reliability` plus `review-resilience`, not `review-readability` by default.
 
-#### Review Execution Contract
-
-**Exhaustive first pass.** Loop until dry: sweep the diff repeatedly until N consecutive sweeps yield zero new findings, then stop; the loop MUST be finite. Default N = 2 consecutive dry sweeps. R2 Readability MAY use N = 1. Hard ceiling: 4 sweeps regardless of N.
-
-**Findings ledger.** Emit a findings ledger with this schema for every entry:
-
-| Field | Values |
-|-------|--------|
-| `id` | `{LENS}-{NNN}` (e.g. `R1-001`) |
-| `lens` | risk \| readability \| reliability \| resilience \| judgment-day |
-| `location` | `path/to/file.ext:line` or `:start-end` |
-| `severity` | BLOCKER \| CRITICAL \| WARNING \| SUGGESTION |
-| `status` | open \| fixed \| verified \| wont-fix \| info |
-| `evidence` | why it matters |
-
-If the first pass finds nothing, persist an empty ledger record rather than skip persistence.
-
-**Ledger persistence honors the artifact store.**
-- `openspec`: write `openspec/changes/{change-name}/review-ledger.md`.
-- `engram`: upsert topic `sdd/{change-name}/review-ledger` (ad-hoc judgment-day without a change: `review/{target-slug}/ledger`, where `target-slug` = `pr-{number}` when reviewing a PR, else the current branch name kebab-cased, else a kebab-case slug of the user-stated review target).
-- `none`: keep the ledger inline in the response; do not write files or Engram artifacts — the ledger lives only in this conversation; complete the review → fix → re-review loop within the session because it is not persisted across compaction.
-
-**Scoped re-review.** A re-review pass takes the persisted ledger and the fix diff as input. It MUST verify each ledger finding's resolution and MUST review only fix-touched lines; it MUST NOT re-read the full original diff. A finding on an untouched line MUST be logged with status `info` as a first-pass quality signal and MUST NOT by itself trigger another full round.
-
-**Execution mode.** Inline mode (this adapter has no dedicated review-*/jd-* subagents): run each lens sequentially inside your own orchestrator context and maintain the merged ledger directly.
-
 #### Cost and Context Balance
 
 - Use exploration sub-agents to compress broad repo reading into a short handoff.
@@ -112,6 +86,11 @@ SDD is the structured planning layer for substantial changes.
 - `openspec` -> file-based artifacts; use only when the user explicitly requests it
 - `hybrid` -> both backends; cross-session recovery + local files; more tokens per operation
 - `none` -> return results inline only; recommend enabling engram or openspec
+
+> **Filesystem path convention**: Engram topic keys use the `sdd/` prefix for
+> memory organization — this is NOT a filesystem path. The canonical filesystem
+> directory for SDD artifacts is `openspec/`. Never reference `.sdd/`, `sdds/`,
+> or bare `sdd/` as filesystem paths. These do not exist.
 
 ### Commands
 
@@ -263,24 +242,30 @@ The gatekeeper runs in addition to the Review Workload Guard and the Mandatory D
 
 ### Artifact Store Mode
 
-This is collected by `SDD Session Preflight`. If missing, enforce the hard gate before any phase work. Ask which artifact store they want for this change:
+This is collected by `SDD Session Preflight`. If missing, enforce the hard gate before any phase work. Ask using this EXACT question text:
 
-- **`engram`**: Fast, no files created. Artifacts live in engram only.
-- **`openspec`**: File-based. Creates `openspec/` with a shareable artifact trail.
-- **`both` / `hybrid`**: Both - files for team sharing + engram for cross-session recovery.
+```
+2. Artifact Store: Where should SDD artifacts (proposals, specs, designs, tasks) be persisted?
+- openspec/ -- filesystem only (openspec/<change-name>/) (Recommended)
+- engram -- Engram persistent memory only
+- hybrid -- both filesystem AND Engram
+```
 
-If the user doesn't specify, detect: if engram is available -> default to `engram`. Otherwise -> `none`.
+**CRITICAL**: `openspec/` is the canonical filesystem path for SDD artifacts. Do NOT use `sdds/`, `sdd/`, or `.sdd/` in the option text. Engram topic keys use the `sdd/` prefix for memory organization only.
+
+Cache the artifact store choice for the session. Pass it as `artifact_store.mode` to every sub-agent launch. If the user doesn't specify, detect: if engram is available -> default to `engram`. Otherwise -> `none`.
 
 Cache the artifact store choice for the session. Pass it as `artifact_store.mode` to every sub-agent launch.
 
 ### Delivery Strategy
 
-This is collected by `SDD Session Preflight` as the chained PR strategy. If missing, enforce the hard gate before any phase work. Ask which delivery/review strategy they want:
+This is collected by `SDD Session Preflight` as the chained PR strategy. If missing, enforce the hard gate before any phase work. Ask using this EXACT question text:
 
-- **`ask-on-risk`** (default): Ask later if `sdd-tasks` forecasts high risk or >400 changed lines.
-- **`auto-chain`**: If forecast is high, continue with chained/stacked PR slices without asking again.
-- **`single-pr`**: Prefer one PR; if forecast exceeds 400 lines, require `size:exception` before apply.
-- **`exception-ok`**: Allow a large PR because the maintainer explicitly accepts `size:exception`.
+```
+3. Chained PR Strategy: How should delivery be packaged?
+- single-pr -- one PR with all changes (Recommended)
+- chained -- multiple stacked PRs (for changes over 400 lines)
+```
 
 Cache the delivery strategy for the session. Pass it as `delivery_strategy` to `sdd-tasks` and `sdd-apply` prompts.
 

--- a/internal/assets/skills/sdd-init/SKILL.md
+++ b/internal/assets/skills/sdd-init/SKILL.md
@@ -42,6 +42,7 @@ Run this phase when the orchestrator/user asks to initialize SDD in a project. Y
 - Always build `.atl/skill-registry.md`; also save `skill-registry` to Engram when available.
 - Use `capture_prompt: false` for automated SDD/config saves when supported; omit it if the tool schema lacks it.
 - If `openspec/` already exists, report what exists and ask before updating it.
+- When presenting filesystem persistence options to the user, use `openspec/` as the canonical path label. NEVER use `sdds/`, `sdd/`, or `.sdd/` as filesystem paths. Engram topic keys use the `sdd/` prefix for memory organization only — that is NOT a filesystem path.
 
 ## Decision Gates
 
@@ -60,6 +61,9 @@ Run this phase when the orchestrator/user asks to initialize SDD in a project. Y
 1. Inspect project files (`package.json`, `go.mod`, `pyproject.toml`, CI, lint/test config) and summarize stack/conventions.
 2. Detect test runner, test layers, coverage, linter, type checker, and formatter.
 3. Resolve Strict TDD from agent marker, `openspec/config.yaml`, detected runner fallback, or no-runner fallback.
+3.5. Resolve artifact store mode if not passed by orchestrator:
+    - If `artifact_store.mode` was provided (engram/openspec/hybrid/none), skip this step.
+    - If NOT provided, ask the user using the EXACT question template in `references/init-details.md` section "Mode Selection Question Template". Use `openspec/` as the filesystem label — NEVER `sdds/`, `sdd/`, or `.sdd/`.
 4. Initialize persistence for the resolved mode.
 5. Build `.atl/skill-registry.md` using the skill-registry scan rules.
 6. Persist testing capabilities and project context.

--- a/internal/assets/skills/sdd-init/references/init-details.md
+++ b/internal/assets/skills/sdd-init/references/init-details.md
@@ -93,6 +93,19 @@ openspec/
 | Formatter    | ✅ / ❌   | {command or —} |
 ```
 
+## Mode Selection Question Template
+
+Use this EXACT question when `artifact_store.mode` was NOT passed by the orchestrator:
+
+```
+Where should SDD artifacts (proposals, specs, designs, tasks) be persisted?
+1. Hybrid - Engram + openspec/ (Recommended)
+2. Engram only
+3. openspec/ only
+```
+
+**CRITICAL**: `openspec/` is the canonical filesystem path. Do NOT substitute `sdds/`, `sdd/`, or `.sdd/`. Engram topic keys use the `sdd/` prefix for memory organization only.
+
 ## Output Templates
 
 For each mode, include project, stack, persistence, Strict TDD Mode, Testing Capabilities table, artifacts created/saved, limitations where relevant, and next steps. Engram mode must mention local/non-shareable limitations; none mode must recommend enabling persistence.


### PR DESCRIPTION
### Problem

SDD orchestrator and sub-agents (sdd-explore, sdd-init, sdd-apply, etc.) sometimes confuse Engram topic keys (prefix `sdd/`) with filesystem paths, generating globs like `**/.sdd/**` and `**/sdd/**` during exploration. These directories don't exist — the canonical filesystem path is `openspec/`.

Root cause: the orchestrator's Engram topic key table (`sdd/{change-name}/proposal`, etc.) pattern-matches to a mental filesystem path because the `sdd/` prefix collides with the old `.sdd/` Windsurf IDE convention.

### Changes

1. **SDD skill compression** (~70% reduction): Condenses verbose step-by-step instructions into compact numbered lists across all 8 SDD phase skills (apply, archive, design, explore, init, propose, spec, tasks).

2. **Filesystem path convention notes**: Adds explicit `Filesystem path convention` notes to 5 files:

| File | Location |
|------|----------|
| `internal/assets/opencode/sdd-orchestrator.md` | After Artifact Store Policy section |
| `internal/assets/skills/sdd-explore/SKILL.md` | After Retrieving Context section |
| `internal/assets/skills/sdd-init/SKILL.md` | After Hard Rules section |
| `internal/assets/skills/_shared/sdd-phase-common.md` | End of document |
| `internal/assets/windsurf/workflows/sdd-new.md` | End of document (contextual note) |

Each note clarifies:
- Engram topic keys use `sdd/` prefix for **memory organization only** — NOT filesystem paths
- The canonical filesystem directory for SDD artifacts is `openspec/`
- `.sdd/` is the Windsurf IDE artifact directory (allowed in Windsurf-only contexts)

### Code Review Fixes Applied

- **CodeRabbit**: Added `skill_resolution` to Output Contracts (sdd-explore, sdd-init)
- **CodeRabbit**: Made `spec` required in sdd-design (was optional)
- **CodeRabbit + Copilot**: Scoped `.sdd/` ban to non-Windsurf contexts (sdd-phase-common, sdd-explore, sdd-init)
- **Copilot**: Removed duplicate Output Contract + heading in sdd-explore
- **CodeRabbit**: Added standalone "Filesystem path convention" note to sdd-apply
- **CodeRabbit**: Fixed archive path to canonical `openspec/changes/archive/` form
- **MD022**: Fixed blank-lines-around-headings warnings

### Background

This change is Track 2 of a two-track fix. Track 1 (local Nix overrides) has been cleaned up in the [nixos-hosts](https://github.com/glats/nixos-hosts) repo — all SDD skills now come from upstream. This PR provides the same guardrails upstream so downstream consumers don't need per-repo workarounds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Clarified the standard location for SDD planning artifacts across supported workflows.
  * Added guidance for choosing a storage mode when one is not provided.

* **Bug Fixes**
  * Prevented confusion between memory topic prefixes and filesystem paths.
  * Explicitly disallowed invalid path variants to keep artifact locations consistent.

* **Documentation**
  * Updated setup and workflow instructions with a standard question template and path rules for end-user guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->