### PR TITLE
fix: openspec config template mixes sequence and mapping (invalid YAML)

### DIFF
--- a/internal/assets/skills/_shared/openspec-convention.md
+++ b/internal/assets/skills/_shared/openspec-convention.md
@@ -98,7 +98,8 @@ rules:
     - Group by phase, use hierarchical numbering
     - Keep tasks completable in one session
   apply:
-    - Follow existing code patterns
+    guidelines:
+      - Follow existing code patterns
     tdd: false           # Set to true to enable RED-GREEN-REFACTOR
     test_command: ""
   verify:


### PR DESCRIPTION
<!-- ⚠️ READ BEFORE SUBMITTING
  Every PR must be linked to an issue that has the "status:approved" label.
  PRs without a linked approved issue will be automatically rejected by CI.
  See CONTRIBUTING.md for the full contribution workflow.
-->

## 🔗 Linked Issue

Closes #1007

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [ ] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [x] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

`internal/assets/skills/_shared/openspec-convention.md` documents the `openspec/config.yaml` shape SDD phases read. The `rules.apply` example mixed a block sequence with sibling mapping keys under the same YAML node, which is invalid YAML — a node can't be both a sequence and a mapping. Any strict parser rejects it:

```bash
python3 -c "import yaml; yaml.safe_load(open('f.yaml'))"
```

Since `sdd-init` and this shared convention doc instruct agents to create real `openspec/config.yaml` files from this exact template, any project bootstrapped from it inherits a config file that fails to parse.

The fix nests the guideline bullet under a `guidelines:` key so `tdd` and `test_command` remain valid mapping siblings — the same shape the doc already uses for `rules.verify`:

```yaml
apply:
  guidelines:
    - Follow existing code patterns
  tdd: false           # Set to true to enable RED-GREEN-REFACTOR
  test_command: ""
```

I checked `internal/` Go source (`rg -n "test_command|strict_tdd|rules" --type go`) and confirmed no Go code parses `openspec/config.yaml`'s `rules` section — it's prompt/documentation-consumed only, so this is a pure documentation-shape fix with no parser coupling. I also surveyed the rest of the repo (`rg -n "apply:" --type md --type go`) for the same mixing pattern; the analogous blocks in `docs/openspec-config.md` and the repo's own `openspec/config.yaml` already keep `apply:` as a pure sequence, so they don't hit this bug and were left untouched.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/assets/skills/_shared/openspec-convention.md` | Nested the `rules.apply` guideline bullet under a new `guidelines:` key so the block is valid YAML |

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./...
```

**E2E Tests** (Docker required)
```bash
cd e2e && ./docker-test.sh
```

- [x] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — not run; change is a docs/template-only markdown edit with no runtime code path
- [x] Manually tested locally — validated the corrected YAML block with `yaml.safe_load`

---

## 🤖 Automated Checks

The following checks run automatically on this PR:

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | PR should stay within 400 changed lines (`additions + deletions`) or use `size:exception` |
| Check Issue Reference | ⏳ | PR body must contain `Closes/Fixes/Resolves #N` |
| Check Issue Has `status:approved` | ⏳ | Linked issue must have been approved before work began |
| Check PR Has `type:*` Label | ⏳ | Exactly one `type:*` label must be applied |
| Unit Tests | ⏳ | `go test ./...` must pass |
| E2E Tests | ⏳ | `cd e2e && ./docker-test.sh` must pass |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [ ] I have added the appropriate `type:*` label to this PR — I don't have write access to apply labels; `type:docs` requested above
- [x] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — not applicable, no runtime code touched
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

This is a 2-line, 1-file diff. Issue #1007 is freshly filed alongside this PR (I don't have write access to the repo, so I can't self-apply `status:approved` — flagging that the linked-issue CI check will stay pending until a maintainer approves it).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the sample configuration rules to include a new `guidelines` section under `apply`.
  * Reorganized the existing “Follow existing code patterns” guidance into the new nested structure for clearer formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->