### PR TITLE
fix(release): address user-blocking setup issues

### DIFF
--- a/internal/agents/pi/adapter.go
+++ b/internal/agents/pi/adapter.go
@@ -29,6 +29,12 @@ const (
 	piSubagentsJ0k3rPackageSpec = "npm:pi-subagents-j0k3r"
 )
 
+var legacyPiSubagentPackageIdentities = map[string]struct{}{
+	"npm:pi-subagents":          {},
+	"vendor/pi-subagents":       {},
+	"vendor/pi-subagents-fixed": {},
+}
+
 func piSubagentsInstallCommand(system.PlatformProfile) []string {
 	return []string{"pi", "install", piSubagentsJ0k3rPackageSpec}
 }
@@ -223,7 +229,8 @@ func appendPiPackage(existing any, desired string) []any {
 	packages := piPackagesAsSlice(existing)
 	filtered := make([]any, 0, len(packages)+1)
 	for _, pkg := range packages {
-		if piPackageIdentity(pkg) == piMCPAdapterPackage {
+		identity := piPackageIdentity(pkg)
+		if identity == piMCPAdapterPackage || isLegacyPiSubagentPackage(identity) {
 			continue
 		}
 		filtered = append(filtered, pkg)
@@ -269,7 +276,17 @@ func piPackageIdentity(pkg any) string {
 	if strings.HasPrefix(source, piMCPAdapterPackage+"@") || source == piMCPAdapterPackage {
 		return piMCPAdapterPackage
 	}
+	for legacy := range legacyPiSubagentPackageIdentities {
+		if source == legacy || strings.HasPrefix(source, legacy+"@") {
+			return legacy
+		}
+	}
 	return source
+}
+
+func isLegacyPiSubagentPackage(identity string) bool {
+	_, ok := legacyPiSubagentPackageIdentities[identity]
+	return ok
 }
 
 func mergePiJSONFile(path string, overlay []byte) (filemerge.WriteResult, error) {

--- a/internal/agents/pi/adapter_test.go
+++ b/internal/agents/pi/adapter_test.go
@@ -2,6 +2,7 @@ package pi
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -209,5 +210,53 @@ func TestAdapterInstallCommandSequenceUsesPnpmForEngramInitWhenAvailable(t *test
 	want := []string{"pnpm", "dlx", "gentle-engram@latest", "pi-engram", "init"}
 	if !reflect.DeepEqual(commands[3], want) {
 		t.Fatalf("InstallCommand()[3] = %#v, want %#v", commands[3], want)
+	}
+}
+
+func TestMergePiSettingsFileRemovesLegacySubagentPackages(t *testing.T) {
+	home := t.TempDir()
+	settingsPath := filepath.Join(home, ".pi", "agent", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(settings dir) error = %v", err)
+	}
+	initial := `{
+  "theme": "kanagawa",
+  "packages": [
+    "npm:pi-subagents",
+    "npm:pi-subagents@1.0.0",
+    "vendor/pi-subagents",
+    "vendor/pi-subagents-fixed@0.0.1",
+    "npm:pi-subagents-j0k3r",
+    "npm:other@1.0.0"
+  ]
+}`
+	if err := os.WriteFile(settingsPath, []byte(initial), 0o644); err != nil {
+		t.Fatalf("WriteFile(settings) error = %v", err)
+	}
+
+	if _, err := mergePiSettingsFile(settingsPath); err != nil {
+		t.Fatalf("mergePiSettingsFile() error = %v", err)
+	}
+
+	var settings struct {
+		Packages []string `json:"packages"`
+	}
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("ReadFile(settings) error = %v", err)
+	}
+	if err := json.Unmarshal(data, &settings); err != nil {
+		t.Fatalf("Unmarshal(settings) error = %v", err)
+	}
+
+	for _, forbidden := range []string{"npm:pi-subagents", "npm:pi-subagents@1.0.0", "vendor/pi-subagents", "vendor/pi-subagents-fixed@0.0.1"} {
+		for _, pkg := range settings.Packages {
+			if pkg == forbidden {
+				t.Fatalf("packages still contains legacy subagent package %q: %#v", forbidden, settings.Packages)
+			}
+		}
+	}
+	if !reflect.DeepEqual(settings.Packages, []string{"npm:pi-subagents-j0k3r", "npm:other@1.0.0", "npm:pi-mcp-adapter"}) {
+		t.Fatalf("packages = %#v", settings.Packages)
 	}
 }

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1282,6 +1282,12 @@ func componentPathsWithWorkspaceScoped(homeDir, workspaceDir string, scope Insta
 		case model.ComponentContext7:
 			switch adapter.MCPStrategy() {
 			case model.StrategySeparateMCPFiles:
+				if adapter.Agent() == model.AgentClaudeCode {
+					if p := adapter.SettingsPath(homeDir); p != "" {
+						paths = append(paths, p)
+					}
+					break
+				}
 				paths = append(paths, adapter.MCPConfigPath(homeDir, "context7"))
 			case model.StrategyMergeIntoSettings:
 				if p := adapter.SettingsPath(homeDir); p != "" {

--- a/internal/cli/run_component_paths_test.go
+++ b/internal/cli/run_component_paths_test.go
@@ -346,6 +346,22 @@ func TestComponentPathsContext7KimiIncludesMCPConfig(t *testing.T) {
 	}
 }
 
+func TestComponentPathsContext7ClaudeUsesSettingsFile(t *testing.T) {
+	home := t.TempDir()
+	adapters := resolveAdapters([]model.AgentID{model.AgentClaudeCode})
+
+	paths := componentPaths(home, model.Selection{}, adapters, model.ComponentContext7)
+
+	want := filepath.Join(home, ".claude", "settings.json")
+	if !containsPath(paths, want) {
+		t.Fatalf("componentPaths(context7,claude) missing %q\npaths=%v", want, paths)
+	}
+	legacy := filepath.Join(home, ".claude", "mcp", "context7.json")
+	if containsPath(paths, legacy) {
+		t.Fatalf("componentPaths(context7,claude) should not verify legacy path %q\npaths=%v", legacy, paths)
+	}
+}
+
 // TestComponentPathsEngramCodexIncludesConfigTOML verifies that componentPaths
 // for ComponentEngram + Codex reports ~/.codex/config.toml as a backup target.
 func TestComponentPathsEngramCodexIncludesConfigTOML(t *testing.T) {

--- a/internal/components/mcp/inject.go
+++ b/internal/components/mcp/inject.go
@@ -23,6 +23,9 @@ func Inject(homeDir string, adapter agents.Adapter) (InjectionResult, error) {
 
 	switch adapter.MCPStrategy() {
 	case model.StrategySeparateMCPFiles:
+		if adapter.Agent() == model.AgentClaudeCode {
+			return injectMergeIntoSettings(homeDir, adapter)
+		}
 		return injectSeparateFile(homeDir, adapter)
 	case model.StrategyMergeIntoSettings:
 		return injectMergeIntoSettings(homeDir, adapter)
@@ -93,7 +96,7 @@ func injectYAMLFile(homeDir string, adapter agents.Adapter) (InjectionResult, er
 	return InjectionResult{Changed: writeResult.Changed, Files: []string{configPath}}, nil
 }
 
-// injectSeparateFile writes a standalone JSON file per MCP server (Claude Code pattern).
+// injectSeparateFile writes a standalone JSON file per MCP server.
 func injectSeparateFile(homeDir string, adapter agents.Adapter) (InjectionResult, error) {
 	path := adapter.MCPConfigPath(homeDir, "context7")
 	writeResult, err := filemerge.WriteFileAtomic(path, DefaultContext7ServerJSON(), 0o644)

--- a/internal/components/mcp/inject_test.go
+++ b/internal/components/mcp/inject_test.go
@@ -432,8 +432,15 @@ func TestInjectOpenCodePreservesOtherMCPEntriesWhenReplacingContext7(t *testing.
 	}
 }
 
-func TestInjectClaudeWritesContext7FileAndIsIdempotent(t *testing.T) {
+func TestInjectClaudeMergesContext7IntoSettingsAndIsIdempotent(t *testing.T) {
 	home := t.TempDir()
+	settingsPath := filepath.Join(home, ".claude", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(settings dir) error = %v", err)
+	}
+	if err := os.WriteFile(settingsPath, []byte(`{"theme":"dark"}`), 0o644); err != nil {
+		t.Fatalf("WriteFile(settings) error = %v", err)
+	}
 
 	first, err := Inject(home, claudeAdapter())
 	if err != nil {
@@ -451,10 +458,32 @@ func TestInjectClaudeWritesContext7FileAndIsIdempotent(t *testing.T) {
 		t.Fatalf("Inject() second changed = true")
 	}
 
-	path := filepath.Join(home, ".claude", "mcp", "context7.json")
-	if _, err := os.Stat(path); err != nil {
-		t.Fatalf("expected context7 file %q: %v", path, err)
+	context7 := readMCPServersContext7Entry(t, settingsPath)
+	if got := context7["command"]; got != "npx" {
+		t.Fatalf("mcpServers.context7.command = %#v; want npx", got)
 	}
+	if _, err := os.Stat(filepath.Join(home, ".claude", "mcp", "context7.json")); !os.IsNotExist(err) {
+		t.Fatalf("Claude Context7 must not be written to ~/.claude/mcp/context7.json; stat err = %v", err)
+	}
+}
+
+func TestInjectClaudeLeavesLegacyContext7FileForExplicitUninstallCleanup(t *testing.T) {
+	home := t.TempDir()
+	legacyPath := filepath.Join(home, ".claude", "mcp", "context7.json")
+	if err := os.MkdirAll(filepath.Dir(legacyPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(legacy dir) error = %v", err)
+	}
+	if err := os.WriteFile(legacyPath, DefaultContext7ServerJSON(), 0o644); err != nil {
+		t.Fatalf("WriteFile(legacy context7) error = %v", err)
+	}
+
+	if _, err := Inject(home, claudeAdapter()); err != nil {
+		t.Fatalf("Inject() error = %v", err)
+	}
+	if _, err := os.Stat(legacyPath); err != nil {
+		t.Fatalf("legacy context7 file should be left for explicit uninstall cleanup: %v", err)
+	}
+	readMCPServersContext7Entry(t, filepath.Join(home, ".claude", "settings.json"))
 }
 
 func TestInjectCursorWithMalformedMCPJsonRecovery(t *testing.T) {

--- a/internal/components/opencodeplugin/plugin.go
+++ b/internal/components/opencodeplugin/plugin.go
@@ -52,7 +52,7 @@ const gentleLogoPluginFile = "gentle-logo.tsx"
 
 const gentleLogoPluginSource = `// @ts-nocheck
 /** @jsxImportSource @opentui/solid */
-import type { TuiPlugin, TuiThemeCurrent } from "@opencode-ai/plugin/tui"
+import type { TuiPlugin } from "@opencode-ai/plugin/tui"
 import { useTerminalDimensions } from "@opentui/solid"
 import { createMemo } from "solid-js"
 
@@ -81,7 +81,7 @@ const roseArt = [
 
 const compactArt = ["✦ Gentle AI ✦"]
 
-const Logo = (props: { theme: TuiThemeCurrent }) => {
+const Logo = () => {
   const dim = useTerminalDimensions()
   const lines = createMemo(() => {
     const term = dim()
@@ -91,7 +91,7 @@ const Logo = (props: { theme: TuiThemeCurrent }) => {
   return (
     <box flexDirection="column" alignItems="center">
       {lines().map((line) => (
-        <text fg={props.theme.accent}>{line}</text>
+        <text fg="magenta">{line}</text>
       ))}
     </box>
   )
@@ -102,8 +102,8 @@ const tui: TuiPlugin = async (api) => {
     id,
     order: 100,
     slots: {
-      home_logo(ctx) {
-        return <Logo theme={ctx.theme.current} />
+      home_logo() {
+        return <Logo />
       },
     },
   })

--- a/internal/components/opencodeplugin/plugin_test.go
+++ b/internal/components/opencodeplugin/plugin_test.go
@@ -135,6 +135,11 @@ func TestInstallGentleLogoWritesLocalTUIPluginAndRegistersAbsolutePath(t *testin
 	if strings.Contains(pluginContent, "server") {
 		t.Fatalf("plugin must not export or define server shape")
 	}
+	for _, forbidden := range []string{"TuiThemeCurrent", "ctx.theme", "props.theme"} {
+		if strings.Contains(pluginContent, forbidden) {
+			t.Fatalf("plugin must not subscribe to theme state (%q) because OpenCode can destroy TextBuffer during theme swaps", forbidden)
+		}
+	}
 
 	data, err := os.ReadFile(configPath)
 	if err != nil {

--- a/internal/components/uninstall/service.go
+++ b/internal/components/uninstall/service.go
@@ -676,6 +676,9 @@ func (s *Service) componentOperations(adapter agents.Adapter, componentID model.
 func context7Targets(adapter agents.Adapter, homeDir string) []string {
 	switch adapter.MCPStrategy() {
 	case model.StrategySeparateMCPFiles:
+		if adapter.Agent() == model.AgentClaudeCode {
+			return []string{adapter.SettingsPath(homeDir), adapter.MCPConfigPath(homeDir, "context7")}
+		}
 		return []string{adapter.MCPConfigPath(homeDir, "context7")}
 	case model.StrategyMergeIntoSettings, model.StrategyMCPConfigFile:
 		return []string{adapter.MCPConfigPath(homeDir, "context7")}
@@ -687,6 +690,10 @@ func context7Targets(adapter agents.Adapter, homeDir string) []string {
 func context7Operations(adapter agents.Adapter, homeDir string) []operation {
 	switch adapter.MCPStrategy() {
 	case model.StrategySeparateMCPFiles:
+		if adapter.Agent() == model.AgentClaudeCode {
+			legacyPath := adapter.MCPConfigPath(homeDir, "context7")
+			return []operation{rewriteJSONFile(adapter.SettingsPath(homeDir), jsonPath{"mcpServers", "context7"}), removeManagedContext7File(legacyPath), removeDirIfEmpty(filepath.Dir(legacyPath))}
+		}
 		path := adapter.MCPConfigPath(homeDir, "context7")
 		return []operation{removeFile(path), removeDirIfEmpty(filepath.Dir(path))}
 	case model.StrategyMergeIntoSettings:
@@ -990,6 +997,55 @@ func isModelVariantsRandomTempName(name string) bool {
 		}
 	}
 	return true
+}
+
+func removeManagedContext7File(path string) operation {
+	return operation{
+		typeID: opRemoveFile,
+		path:   path,
+		apply: func(path string) (bool, bool, error) {
+			content, err := os.ReadFile(path)
+			if err != nil {
+				if os.IsNotExist(err) {
+					return false, false, nil
+				}
+				return false, false, err
+			}
+			if !isManagedContext7ServerJSON(content) {
+				return false, false, nil
+			}
+			if err := removeFileIfExists(path); err != nil {
+				return false, false, err
+			}
+			return true, true, nil
+		},
+	}
+}
+
+func isManagedContext7ServerJSON(content []byte) bool {
+	var root map[string]any
+	if err := json.Unmarshal(content, &root); err != nil {
+		return false
+	}
+	if command, _ := root["command"].(string); command != "npx" {
+		return false
+	}
+	rawArgs, ok := root["args"].([]any)
+	if !ok || len(rawArgs) != 4 {
+		return false
+	}
+	args := make([]string, 0, len(rawArgs))
+	for _, raw := range rawArgs {
+		arg, ok := raw.(string)
+		if !ok {
+			return false
+		}
+		args = append(args, arg)
+	}
+	return args[0] == "-y" &&
+		strings.HasPrefix(args[1], "--package=@upstash/context7-mcp@") &&
+		args[2] == "--" &&
+		args[3] == "context7-mcp"
 }
 
 func removeFile(path string) operation {

--- a/internal/components/uninstall/service_test.go
+++ b/internal/components/uninstall/service_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -14,6 +15,19 @@ import (
 )
 
 type stubSnapshotter struct{}
+
+func readJSONFileForTest(t *testing.T, path string) map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", path, err)
+	}
+	var root map[string]any
+	if err := json.Unmarshal(data, &root); err != nil {
+		t.Fatalf("Unmarshal(%q) error = %v", path, err)
+	}
+	return root
+}
 
 func (stubSnapshotter) Create(snapshotDir string, paths []string) (backup.Manifest, error) {
 	if err := os.MkdirAll(snapshotDir, 0o755); err != nil {
@@ -67,6 +81,118 @@ func TestExecutePlanReportsManualCleanupForNonEmptyDirectory(t *testing.T) {
 	}
 	if !strings.Contains(result.ManualActions[0], nonEmptyDir) {
 		t.Fatalf("manual action should mention %q, got %q", nonEmptyDir, result.ManualActions[0])
+	}
+}
+
+func TestComponentOperationsContext7ClaudeRemovesSettingsAndManagedLegacyFile(t *testing.T) {
+	homeDir := t.TempDir()
+	workspaceDir := t.TempDir()
+
+	svc, err := NewService(homeDir, workspaceDir, "dev")
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	adapter, ok := svc.registry.Get(model.AgentClaudeCode)
+	if !ok {
+		t.Fatal("Claude adapter not found in registry")
+	}
+
+	settingsPath := adapter.SettingsPath(homeDir)
+	legacyPath := adapter.MCPConfigPath(homeDir, "context7")
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(settings dir) error = %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(legacyPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(legacy dir) error = %v", err)
+	}
+	if err := os.WriteFile(settingsPath, []byte(`{"mcpServers":{"context7":{"command":"npx"},"engram":{"command":"engram"}},"theme":"dark"}`), 0o644); err != nil {
+		t.Fatalf("WriteFile(settings) error = %v", err)
+	}
+	legacyManaged := []byte(`{
+  "command": "npx",
+  "args": [
+    "-y",
+    "--package=@upstash/context7-mcp@1.0.0",
+    "--",
+    "context7-mcp"
+  ]
+}
+`)
+	if err := os.WriteFile(legacyPath, legacyManaged, 0o644); err != nil {
+		t.Fatalf("WriteFile(legacy) error = %v", err)
+	}
+
+	ops, targets, err := svc.componentOperations(adapter, model.ComponentContext7)
+	if err != nil {
+		t.Fatalf("componentOperations() error = %v", err)
+	}
+	if !slices.Contains(targets, settingsPath) || !slices.Contains(targets, legacyPath) {
+		t.Fatalf("targets = %#v, want settings and legacy paths", targets)
+	}
+	for _, op := range ops {
+		if _, _, err := op.apply(op.path); err != nil {
+			t.Fatalf("operation %v on %q error = %v", op.typeID, op.path, err)
+		}
+	}
+
+	if _, err := os.Stat(legacyPath); !os.IsNotExist(err) {
+		t.Fatalf("legacy managed context7 file should be removed; stat err = %v", err)
+	}
+	settings := readJSONFileForTest(t, settingsPath)
+	mcpServers := settings["mcpServers"].(map[string]any)
+	if _, ok := mcpServers["context7"]; ok {
+		t.Fatalf("settings still contains mcpServers.context7: %#v", settings)
+	}
+	if _, ok := mcpServers["engram"]; !ok {
+		t.Fatalf("settings lost unrelated mcpServers.engram: %#v", settings)
+	}
+}
+
+func TestComponentOperationsContext7ClaudePreservesCustomLegacyFile(t *testing.T) {
+	homeDir := t.TempDir()
+	workspaceDir := t.TempDir()
+
+	svc, err := NewService(homeDir, workspaceDir, "dev")
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	adapter, ok := svc.registry.Get(model.AgentClaudeCode)
+	if !ok {
+		t.Fatal("Claude adapter not found in registry")
+	}
+
+	settingsPath := adapter.SettingsPath(homeDir)
+	legacyPath := adapter.MCPConfigPath(homeDir, "context7")
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(settings dir) error = %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(legacyPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(legacy dir) error = %v", err)
+	}
+	custom := []byte(`{"command":"custom-context7"}`)
+	if err := os.WriteFile(settingsPath, []byte(`{"mcpServers":{"context7":{"command":"npx"}}}`), 0o644); err != nil {
+		t.Fatalf("WriteFile(settings) error = %v", err)
+	}
+	if err := os.WriteFile(legacyPath, custom, 0o644); err != nil {
+		t.Fatalf("WriteFile(legacy) error = %v", err)
+	}
+
+	ops, _, err := svc.componentOperations(adapter, model.ComponentContext7)
+	if err != nil {
+		t.Fatalf("componentOperations() error = %v", err)
+	}
+	for _, op := range ops {
+		if _, _, err := op.apply(op.path); err != nil {
+			t.Fatalf("operation %v on %q error = %v", op.typeID, op.path, err)
+		}
+	}
+
+	got, err := os.ReadFile(legacyPath)
+	if err != nil {
+		t.Fatalf("ReadFile(legacy) error = %v", err)
+	}
+	if string(got) != string(custom) {
+		t.Fatalf("custom legacy file changed: %s", string(got))
 	}
 }
 


### PR DESCRIPTION
Closes #971
Closes #899
Closes #1011

## PR Type

- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary

- Cleans legacy Pi subagent package entries, including versioned legacy specs, during Pi settings merge.
- Moves Claude Code Context7 injection to `~/.claude/settings.json` and makes uninstall clean managed legacy files without deleting custom files.
- Avoids OpenCode TUI theme-state subscription in the Gentle Logo plugin to mitigate theme-swap TextBuffer crashes.

## Changes

| File | Change |
|------|--------|
| `internal/agents/pi/adapter.go` | Filters legacy Pi subagent package specs before appending current Pi MCP adapter package. |
| `internal/components/mcp/inject.go` | Routes Claude Code Context7 through settings-based MCP server injection. |
| `internal/cli/run.go` | Reports Claude Context7 verification/backup path as `settings.json`. |
| `internal/components/uninstall/service.go` | Removes Claude settings Context7 entry and only removes managed legacy Context7 files. |
| `internal/components/opencodeplugin/plugin.go` | Removes theme-state dependency from the Gentle Logo TUI plugin. |
| `*_test.go` | Adds regression coverage for Pi cleanup, Claude Context7 paths/uninstall, and OpenCode theme-state avoidance. |

## Test Plan

- [x] `go test ./internal/components/uninstall ./internal/cli ./internal/components/mcp ./internal/agents/pi ./internal/components/opencodeplugin`
- [x] Fresh reliability review via subagent: no findings
- [x] No generated test artifact included in commit

## Contributor Checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Shell scripts not modified
- [x] Skills tested in at least one agent / not applicable
- [x] Docs updated if behavior changed / covered by tests for config paths
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Claude-related setup so Context7 is stored in the main settings file instead of creating a separate legacy file.
  * Updated uninstall behavior to remove managed legacy Context7 entries safely while preserving custom user-created files and unrelated settings.
  * Prevented duplicate Pi package entries when older identity formats are present.

* **Style**
  * Simplified the gentle logo plugin to use a fixed color instead of theme-based styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->