### PR TITLE
fix(codex): only inject Nix read paths when Nix is installed

### DIFF
--- a/internal/components/permissions/inject.go
+++ b/internal/components/permissions/inject.go
@@ -188,11 +188,6 @@ func injectCodexPermissions(homeDir string, adapter agents.Adapter) (InjectionRe
 	merged = filemerge.UpsertTOMLTableKey(merged, "permissions.gentle-dev.network.domains", `"*"`, `"allow"`)
 
 	merged = filemerge.RemoveTOMLTableKeys(merged, `permissions.gentle-dev.filesystem.":root"`, []string{`"."`})
-	readPaths := []string{
-		`":minimal"`,
-		`"~/.config/git"`,
-		`"~/.gitconfig"`,
-	}
 	// Only inject Nix read paths that actually resolve on disk. Codex enforces the
 	// profile through a bubblewrap sandbox, and binding a non-existent path makes
 	// bubblewrap create a synthetic ".../deleted" read-only tmpfs entry whose access
@@ -208,6 +203,17 @@ func injectCodexPermissions(homeDir string, adapter agents.Adapter) (InjectionRe
 		{`"~/.local/state/nix/profiles/home-manager/home-path"`, filepath.Join(homeDir, ".local", "state", "nix", "profiles", "home-manager", "home-path")},
 		{`"~/.nix-profile"`, filepath.Join(homeDir, ".nix-profile")},
 		{`"/nix/store"`, "/nix/store"},
+	}
+	nixReadPathKeys := make([]string, 0, len(nixReadPaths))
+	for _, nix := range nixReadPaths {
+		nixReadPathKeys = append(nixReadPathKeys, nix.key)
+	}
+	merged = filemerge.RemoveTOMLTableKeys(merged, "permissions.gentle-dev.filesystem", nixReadPathKeys)
+
+	readPaths := []string{
+		`":minimal"`,
+		`"~/.config/git"`,
+		`"~/.gitconfig"`,
 	}
 	for _, nix := range nixReadPaths {
 		if _, err := osStat(nix.resolved); err == nil {

--- a/internal/components/permissions/inject.go
+++ b/internal/components/permissions/inject.go
@@ -3,14 +3,12 @@ package permissions
 import (
 	"fmt"
 	"os"
-	"runtime"
+	"path/filepath"
 
 	"github.com/gentleman-programming/gentle-ai/internal/agents"
 	"github.com/gentleman-programming/gentle-ai/internal/components/filemerge"
 	"github.com/gentleman-programming/gentle-ai/internal/model"
 )
-
-var codexPermissionsGOOS = runtime.GOOS
 
 type InjectionResult struct {
 	Changed bool
@@ -194,11 +192,27 @@ func injectCodexPermissions(homeDir string, adapter agents.Adapter) (InjectionRe
 		`":minimal"`,
 		`"~/.config/git"`,
 		`"~/.gitconfig"`,
-		`"~/.local/state/nix/profiles/home-manager/home-path"`,
-		`"~/.nix-profile"`,
 	}
-	if codexPermissionsGOOS != "windows" {
-		readPaths = append(readPaths, `"/nix/store"`)
+	// Only inject Nix read paths that actually resolve on disk. Codex enforces the
+	// profile through a bubblewrap sandbox, and binding a non-existent path makes
+	// bubblewrap create a synthetic ".../deleted" read-only tmpfs entry whose access
+	// then fails with "Device or resource busy" (EBUSY), breaking Codex on non-Nix
+	// Linux/WSL. The prior OS-based guard (#941) only skipped "/nix/store" on Windows,
+	// which left the "~/.nix-profile" and home-manager paths breaking config load on
+	// non-Nix hosts. This existence check subsumes that guard and covers every host.
+	// Keep a deterministic slice order (no map) so the generated TOML stays stable.
+	nixReadPaths := []struct {
+		key      string
+		resolved string
+	}{
+		{`"~/.local/state/nix/profiles/home-manager/home-path"`, filepath.Join(homeDir, ".local", "state", "nix", "profiles", "home-manager", "home-path")},
+		{`"~/.nix-profile"`, filepath.Join(homeDir, ".nix-profile")},
+		{`"/nix/store"`, "/nix/store"},
+	}
+	for _, nix := range nixReadPaths {
+		if _, err := osStat(nix.resolved); err == nil {
+			readPaths = append(readPaths, nix.key)
+		}
 	}
 	merged = filemerge.UpsertTOMLTableKey(merged, "permissions.gentle-dev.filesystem", "glob_scan_max_depth", "6")
 	for _, path := range readPaths {
@@ -261,6 +275,10 @@ func mergeJSONFile(path string, overlay []byte) (filemerge.WriteResult, error) {
 
 	return filemerge.WriteFileAtomic(path, merged, 0o644)
 }
+
+// osStat is a mockable indirection over os.Stat so tests can simulate the
+// presence or absence of the Nix read paths without touching the real filesystem.
+var osStat = os.Stat
 
 var osReadFile = func(path string) ([]byte, error) {
 	content, err := os.ReadFile(path)

--- a/internal/components/permissions/inject_test.go
+++ b/internal/components/permissions/inject_test.go
@@ -420,19 +420,35 @@ func TestInjectCodexWritesGentleDevPermissionsProfile(t *testing.T) {
 }
 
 // TestInjectCodexPermissionsSkipsNixPathsWhenAbsent verifies that on a host
-// without Nix installed (none of the Nix paths resolve on disk), the generated
-// Codex profile contains NONE of the three Nix read paths. Binding a
-// non-existent path makes bubblewrap create a synthetic ".../deleted" tmpfs
-// entry that fails with EBUSY, which broke Codex on non-Nix Linux/WSL.
+// without Nix installed (none of the Nix paths resolve on disk), stale managed
+// Nix read paths are removed while non-Nix filesystem permissions remain.
+// Binding a non-existent path makes bubblewrap create a synthetic ".../deleted"
+// tmpfs entry that fails with EBUSY, which broke Codex on non-Nix Linux/WSL.
 func TestInjectCodexPermissionsSkipsNixPathsWhenAbsent(t *testing.T) {
 	home := t.TempDir()
 	nixPathsAbsent(t)
+	configPath := filepath.Join(home, ".codex", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+
+	initial := `[permissions.gentle-dev.filesystem]
+":minimal" = "read"
+"~/.config/git" = "read"
+"~/.gitconfig" = "read"
+"~/.local/state/nix/profiles/home-manager/home-path" = "read"
+"~/.nix-profile" = "read"
+"/nix/store" = "read"
+"/opt/tooling" = "read"
+`
+	if err := os.WriteFile(configPath, []byte(initial), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
 
 	if _, err := Inject(home, codexAdapter()); err != nil {
 		t.Fatalf("Inject() error = %v", err)
 	}
 
-	configPath := filepath.Join(home, ".codex", "config.toml")
 	content, err := os.ReadFile(configPath)
 	if err != nil {
 		t.Fatalf("read config.toml: %v", err)
@@ -455,9 +471,12 @@ func TestInjectCodexPermissionsSkipsNixPathsWhenAbsent(t *testing.T) {
 		`"~/.config/git" = "read"`,
 		`"~/.gitconfig" = "read"`,
 	} {
-		if !strings.Contains(text, want) {
-			t.Fatalf("Codex config missing base read path %q; got:\n%s", want, text)
+		if strings.Count(text, want) != 1 {
+			t.Fatalf("Codex config should keep base read path %q exactly once; got:\n%s", want, text)
 		}
+	}
+	if strings.Count(text, `"/opt/tooling" = "read"`) != 1 {
+		t.Fatalf("Codex config should preserve unrelated filesystem permissions; got:\n%s", text)
 	}
 }
 

--- a/internal/components/permissions/inject_test.go
+++ b/internal/components/permissions/inject_test.go
@@ -320,8 +320,27 @@ func TestInjectAntigravitySkipsPermissions(t *testing.T) {
 	}
 }
 
+// nixPathsPresent forces osStat to report every path as present so tests that
+// assert the Nix read paths are injected do not depend on the host filesystem.
+func nixPathsPresent(t *testing.T) {
+	t.Helper()
+	orig := osStat
+	osStat = func(string) (os.FileInfo, error) { return nil, nil }
+	t.Cleanup(func() { osStat = orig })
+}
+
+// nixPathsAbsent forces osStat to report every path as missing so tests can
+// verify that the Nix read paths are skipped on non-Nix hosts.
+func nixPathsAbsent(t *testing.T) {
+	t.Helper()
+	orig := osStat
+	osStat = func(string) (os.FileInfo, error) { return nil, os.ErrNotExist }
+	t.Cleanup(func() { osStat = orig })
+}
+
 func TestInjectCodexWritesGentleDevPermissionsProfile(t *testing.T) {
 	home := t.TempDir()
+	nixPathsPresent(t)
 
 	result, err := Inject(home, codexAdapter())
 	if err != nil {
@@ -400,11 +419,14 @@ func TestInjectCodexWritesGentleDevPermissionsProfile(t *testing.T) {
 	}
 }
 
-func TestInjectCodexPermissionsSkipsNixStoreOnWindows(t *testing.T) {
+// TestInjectCodexPermissionsSkipsNixPathsWhenAbsent verifies that on a host
+// without Nix installed (none of the Nix paths resolve on disk), the generated
+// Codex profile contains NONE of the three Nix read paths. Binding a
+// non-existent path makes bubblewrap create a synthetic ".../deleted" tmpfs
+// entry that fails with EBUSY, which broke Codex on non-Nix Linux/WSL.
+func TestInjectCodexPermissionsSkipsNixPathsWhenAbsent(t *testing.T) {
 	home := t.TempDir()
-	origGOOS := codexPermissionsGOOS
-	codexPermissionsGOOS = "windows"
-	t.Cleanup(func() { codexPermissionsGOOS = origGOOS })
+	nixPathsAbsent(t)
 
 	if _, err := Inject(home, codexAdapter()); err != nil {
 		t.Fatalf("Inject() error = %v", err)
@@ -417,15 +439,53 @@ func TestInjectCodexPermissionsSkipsNixStoreOnWindows(t *testing.T) {
 	}
 	text := string(content)
 
-	if strings.Contains(text, `"/nix/store"`) {
-		t.Fatalf("Windows Codex config should not include /nix/store; got:\n%s", text)
-	}
-	for _, want := range []string{
-		`"~/.local/state/nix/profiles/home-manager/home-path" = "read"`,
+	for _, forbidden := range []string{
+		`"/nix/store" = "read"`,
 		`"~/.nix-profile" = "read"`,
+		`"~/.local/state/nix/profiles/home-manager/home-path" = "read"`,
+	} {
+		if strings.Contains(text, forbidden) {
+			t.Fatalf("non-Nix Codex config should not include Nix read path %q; got:\n%s", forbidden, text)
+		}
+	}
+
+	// The always-present read paths must still be there.
+	for _, want := range []string{
+		`":minimal" = "read"`,
+		`"~/.config/git" = "read"`,
+		`"~/.gitconfig" = "read"`,
 	} {
 		if !strings.Contains(text, want) {
-			t.Fatalf("Windows Codex config missing non-fatal Nix home path %q; got:\n%s", want, text)
+			t.Fatalf("Codex config missing base read path %q; got:\n%s", want, text)
+		}
+	}
+}
+
+// TestInjectCodexPermissionsIncludesNixPathsWhenPresent verifies that when the
+// Nix paths resolve on disk, all three Nix read paths are injected into the
+// generated Codex profile.
+func TestInjectCodexPermissionsIncludesNixPathsWhenPresent(t *testing.T) {
+	home := t.TempDir()
+	nixPathsPresent(t)
+
+	if _, err := Inject(home, codexAdapter()); err != nil {
+		t.Fatalf("Inject() error = %v", err)
+	}
+
+	configPath := filepath.Join(home, ".codex", "config.toml")
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config.toml: %v", err)
+	}
+	text := string(content)
+
+	for _, want := range []string{
+		`"/nix/store" = "read"`,
+		`"~/.nix-profile" = "read"`,
+		`"~/.local/state/nix/profiles/home-manager/home-path" = "read"`,
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("Codex config with Nix present missing read path %q; got:\n%s", want, text)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

The Codex permission injector now writes the three Nix read paths into the generated `[permissions.gentle-dev.filesystem]` profile **only when they actually resolve on disk**. On hosts without Nix, none of these paths are injected.

## Root cause

`injectCodexPermissions` wrote `/nix/store`, `~/.nix-profile`, and `~/.local/state/nix/profiles/home-manager/home-path` into the profile unconditionally. Codex enforces the profile through a bubblewrap sandbox, and binding a **non-existent** path makes bubblewrap create a synthetic `.../deleted` read-only tmpfs entry whose access then fails with `Device or resource busy` (EBUSY). This breaks Codex on non-Nix Linux/WSL.

The prior fix (#941) only guarded `/nix/store` behind a `GOOS != "windows"` check, leaving `~/.nix-profile` and the home-manager path unconditionally injected — so the sandbox still broke on non-Nix Linux/WSL, and `~/.nix-profile`/home-manager paths still loaded on Windows.

## Fix

- Replaced the OS-based guard with a filesystem **existence check** (`os.Stat`, via a mockable `osStat` indirection). Each Nix read path is appended only when `osStat(resolved)` returns no error.
- `~` is resolved to `homeDir` via `filepath.Join`; `/nix/store` is checked directly.
- Deterministic slice order is preserved (home-manager path, then `~/.nix-profile`, then `/nix/store`) — no map is used, so generated TOML stays stable and idempotent.
- Removed the now-unused `codexPermissionsGOOS`/`runtime` OS guard entirely; the existence check subsumes the Windows special-case and covers every non-Nix host.

This supersedes the partial #941 Windows guard.

## Testing

Run from the repo root:

- `gofmt -l internal/components/permissions/inject.go internal/components/permissions/inject_test.go` — no diff
- `go vet ./internal/components/permissions/...` — passes
- `go build ./...` — passes
- `go test ./internal/components/permissions/...` — `ok` (passes)

Test changes:
- Updated `TestInjectCodexWritesGentleDevPermissionsProfile` to mock `osStat` as present (via a `nixPathsPresent` helper) so the Nix-path assertions no longer depend on the host filesystem.
- Replaced the Windows-guard test with `TestInjectCodexPermissionsSkipsNixPathsWhenAbsent`, which proves that when `osStat` reports the Nix paths as absent, the generated TOML contains **none** of the three Nix read paths (while base read paths remain).
- Added `TestInjectCodexPermissionsIncludesNixPathsWhenPresent`, which proves all three Nix read paths **are** included when present.

## Notes

Fixes #1022. Supersedes the partial `/nix/store` Windows guard from #941.

Opened as a **draft** pending `status:approved` per the repository's contribution workflow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved permission generation so Nix-related filesystem read entries are included only when the corresponding paths exist locally.
  * Removed OS-specific Nix path handling for more consistent permissions across environments.

* **Tests**
  * Updated permission tests to be deterministic and not depend on the machine’s filesystem state.
  * Added scenarios verifying Nix read paths are omitted when missing and included when present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->