### PR TITLE
fix(codex): generate compatible permissions profile

### DIFF
--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -458,14 +458,13 @@ func TestTuiSyncIncludesCodexPermissions(t *testing.T) {
 		t.Fatalf("ReadFile(%s): %v", configPath, err)
 	}
 	text := string(body)
-	if !strings.Contains(text, `[permissions.gentle-dev.filesystem]`) || !strings.Contains(text, `glob_scan_max_depth = 6`) {
-		t.Fatalf("Codex permissions sync should add glob_scan_max_depth to filesystem profile; got:\n%s", text)
+	if !strings.Contains(text, `[permissions.gentle-dev.filesystem]`) || !strings.Contains(text, `":minimal" = "read"`) {
+		t.Fatalf("Codex permissions sync should add valid filesystem reads; got:\n%s", text)
 	}
-	if count := strings.Count(text, `glob_scan_max_depth = 6`); count != 1 {
-		t.Fatalf("glob_scan_max_depth count = %d, want 1; got:\n%s", count, text)
-	}
-	if !strings.Contains(text, `"**/*.key" = "deny"`) || !strings.Contains(text, `"**/*.pem" = "deny"`) {
-		t.Fatalf("Codex permissions sync should preserve deny rules; got:\n%s", text)
+	for _, invalid := range []string{`glob_scan_max_depth = 6`, `":slash_tmp" = "write"`, `":tmpdir" = "write"`, `[permissions.gentle-dev.filesystem.":workspace_roots"]`, `"**/*.key" = "deny"`, `"**/*.pem" = "deny"`} {
+		if strings.Contains(text, invalid) {
+			t.Fatalf("Codex permissions sync should remove invalid entry %q; got:\n%s", invalid, text)
+		}
 	}
 
 	changed, err = tuiSync(home)(nil)
@@ -477,8 +476,10 @@ func TestTuiSyncIncludesCodexPermissions(t *testing.T) {
 		t.Fatalf("ReadFile(%s) after second sync: %v", configPath, err)
 	}
 	text = string(body)
-	if count := strings.Count(text, `glob_scan_max_depth = 6`); count != 1 {
-		t.Fatalf("second sync glob_scan_max_depth count = %d, want 1; got:\n%s", count, text)
+	for _, invalid := range []string{`glob_scan_max_depth = 6`, `":slash_tmp" = "write"`, `":tmpdir" = "write"`, `[permissions.gentle-dev.filesystem.":workspace_roots"]`} {
+		if strings.Contains(text, invalid) {
+			t.Fatalf("second sync should keep invalid entry %q removed; got:\n%s", invalid, text)
+		}
 	}
 }
 
@@ -512,11 +513,13 @@ func TestTuiSyncIncludesCodexPermissionsForTargetedOverrides(t *testing.T) {
 		t.Fatalf("ReadFile(%s): %v", configPath, err)
 	}
 	text := string(body)
-	if count := strings.Count(text, `glob_scan_max_depth = 6`); count != 1 {
-		t.Fatalf("targeted sync glob_scan_max_depth count = %d, want 1; got:\n%s", count, text)
+	if !strings.Contains(text, `":minimal" = "read"`) || !strings.Contains(text, `[permissions.gentle-dev.workspace_roots]`) {
+		t.Fatalf("targeted sync should add valid Codex permissions profile; got:\n%s", text)
 	}
-	if !strings.Contains(text, `"**/*.key" = "deny"`) {
-		t.Fatalf("targeted sync should preserve Codex deny rules; got:\n%s", text)
+	for _, invalid := range []string{`glob_scan_max_depth = 6`, `":slash_tmp" = "write"`, `":tmpdir" = "write"`, `[permissions.gentle-dev.filesystem.":workspace_roots"]`, `"**/*.key" = "deny"`} {
+		if strings.Contains(text, invalid) {
+			t.Fatalf("targeted sync should remove invalid entry %q; got:\n%s", invalid, text)
+		}
 	}
 }
 
@@ -1749,11 +1752,13 @@ func TestRunArgsPendingSyncRepairsCodexPermissions(t *testing.T) {
 		t.Fatalf("ReadFile(%s): %v", configPath, err)
 	}
 	text := string(body)
-	if count := strings.Count(text, `glob_scan_max_depth = 6`); count != 1 {
-		t.Fatalf("deferred sync glob_scan_max_depth count = %d, want 1; got:\n%s", count, text)
+	if !strings.Contains(text, `":minimal" = "read"`) || !strings.Contains(text, `[permissions.gentle-dev.workspace_roots]`) {
+		t.Fatalf("deferred sync should add valid Codex permissions profile; got:\n%s", text)
 	}
-	if !strings.Contains(text, `"**/*.key" = "deny"`) || !strings.Contains(text, `"**/*.pem" = "deny"`) {
-		t.Fatalf("deferred sync should preserve Codex deny rules; got:\n%s", text)
+	for _, invalid := range []string{`glob_scan_max_depth = 6`, `":slash_tmp" = "write"`, `":tmpdir" = "write"`, `[permissions.gentle-dev.filesystem.":workspace_roots"]`, `"**/*.key" = "deny"`, `"**/*.pem" = "deny"`} {
+		if strings.Contains(text, invalid) {
+			t.Fatalf("deferred sync should remove invalid entry %q; got:\n%s", invalid, text)
+		}
 	}
 
 	s, err := state.Read(home)

--- a/internal/components/permissions/inject.go
+++ b/internal/components/permissions/inject.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"strings"
 
 	"github.com/gentleman-programming/gentle-ai/internal/agents"
 	"github.com/gentleman-programming/gentle-ai/internal/components/filemerge"
@@ -184,12 +185,19 @@ func injectCodexPermissions(homeDir string, adapter agents.Adapter) (InjectionRe
 	merged := filemerge.UpsertTopLevelTOMLString(string(baseTOML), "approval_policy", "on-request")
 	merged = filemerge.UpsertTopLevelTOMLString(merged, "default_permissions", "gentle-dev")
 	merged = filemerge.RemoveTOMLTableKeys(merged, "permissions.gentle-dev", []string{"extends"})
-	merged = filemerge.UpsertTOMLTableKey(merged, "permissions.gentle-dev", "description", `"Comfortable local development profile with workspace writes, network access, Git metadata writes, Nix/Home Manager support, and secret-file protections."`)
+	merged = filemerge.UpsertTOMLTableKey(merged, "permissions.gentle-dev", "description", `"Comfortable local development profile with workspace writes, network access, and read-only access to Git and Nix/Home Manager metadata."`)
 	merged = filemerge.RemoveTOMLTableKeys(merged, "permissions.gentle-dev", []string{"glob_scan_max_depth"})
 	merged = filemerge.UpsertTOMLTableKey(merged, "permissions.gentle-dev.network", "enabled", "true")
 	merged = filemerge.UpsertTOMLTableKey(merged, "permissions.gentle-dev.network.domains", `"*"`, `"allow"`)
 
 	merged = filemerge.RemoveTOMLTableKeys(merged, `permissions.gentle-dev.filesystem.":root"`, []string{`"."`})
+	merged = filemerge.RemoveTOMLTableKeys(merged, "permissions.gentle-dev.filesystem", []string{
+		"glob_scan_max_depth",
+		`":tmpdir"`,
+		`":slash_tmp"`,
+	})
+	merged = removeTOMLTable(merged, `permissions.gentle-dev.filesystem.":workspace_roots"`)
+
 	readPaths := []string{
 		`":minimal"`,
 		`"~/.config/git"`,
@@ -200,45 +208,11 @@ func injectCodexPermissions(homeDir string, adapter agents.Adapter) (InjectionRe
 	if codexPermissionsGOOS != "windows" {
 		readPaths = append(readPaths, `"/nix/store"`)
 	}
-	merged = filemerge.UpsertTOMLTableKey(merged, "permissions.gentle-dev.filesystem", "glob_scan_max_depth", "6")
 	for _, path := range readPaths {
 		merged = filemerge.UpsertTOMLTableKey(merged, "permissions.gentle-dev.filesystem", path, `"read"`)
 	}
-	for _, path := range []string{
-		`":tmpdir"`,
-		`":slash_tmp"`,
-	} {
-		merged = filemerge.UpsertTOMLTableKey(merged, "permissions.gentle-dev.filesystem", path, `"write"`)
-	}
 
 	merged = filemerge.UpsertTOMLTableKey(merged, "permissions.gentle-dev.workspace_roots", `"~"`, "true")
-
-	workspaceRootsSection := `permissions.gentle-dev.filesystem.":workspace_roots"`
-	merged = filemerge.RemoveTOMLTableKeys(merged, workspaceRootsSection, []string{
-		`"**/.git"`,
-		`"**/.git/**"`,
-		`"**/.env.*"`,
-		`"*.env.*"`,
-	})
-	merged = filemerge.UpsertTOMLTableKey(merged, workspaceRootsSection, `"."`, `"write"`)
-	merged = filemerge.UpsertTOMLTableKey(merged, workspaceRootsSection, `".git/**"`, `"write"`)
-
-	for _, pattern := range []string{
-		`"**/.env"`,
-		`"**/.env.local"`,
-		`"**/.env.*.local"`,
-		`"**/.aws/credentials"`,
-		`"**/.config/gh/hosts.yml"`,
-		`"**/.credentials/**"`,
-		`"**/.ssh/**"`,
-		`"**/Library/Keychains/**"`,
-		`"**/credentials.json"`,
-		`"**/*.pem"`,
-		`"**/*.key"`,
-		`"**/secrets/**"`,
-	} {
-		merged = filemerge.UpsertTOMLTableKey(merged, workspaceRootsSection, pattern, `"deny"`)
-	}
 
 	writeResult, err := filemerge.WriteFileAtomic(configPath, []byte(merged), 0o644)
 	if err != nil {
@@ -246,6 +220,32 @@ func injectCodexPermissions(homeDir string, adapter agents.Adapter) (InjectionRe
 	}
 
 	return InjectionResult{Changed: writeResult.Changed, Files: []string{configPath}}, nil
+}
+
+func removeTOMLTable(content, section string) string {
+	content = strings.ReplaceAll(content, "\r\n", "\n")
+	header := "[" + section + "]"
+	lines := strings.Split(content, "\n")
+	out := make([]string, 0, len(lines))
+	inSection := false
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == header {
+			inSection = true
+			continue
+		}
+		if inSection {
+			if strings.HasPrefix(trimmed, "[") && strings.HasSuffix(trimmed, "]") {
+				inSection = false
+			} else {
+				continue
+			}
+		}
+		out = append(out, line)
+	}
+
+	return strings.TrimSpace(strings.Join(out, "\n")) + "\n"
 }
 
 func mergeJSONFile(path string, overlay []byte) (filemerge.WriteResult, error) {

--- a/internal/components/permissions/inject_test.go
+++ b/internal/components/permissions/inject_test.go
@@ -346,7 +346,6 @@ func TestInjectCodexWritesGentleDevPermissionsProfile(t *testing.T) {
 		`approval_policy = "on-request"`,
 		`default_permissions = "gentle-dev"`,
 		`[permissions.gentle-dev]`,
-		`glob_scan_max_depth = 6`,
 		`[permissions.gentle-dev.network]`,
 		`enabled = true`,
 		`[permissions.gentle-dev.network.domains]`,
@@ -358,41 +357,28 @@ func TestInjectCodexWritesGentleDevPermissionsProfile(t *testing.T) {
 		`"~/.local/state/nix/profiles/home-manager/home-path" = "read"`,
 		`"~/.nix-profile" = "read"`,
 		`"/nix/store" = "read"`,
-		`":tmpdir" = "write"`,
-		`":slash_tmp" = "write"`,
 		`[permissions.gentle-dev.workspace_roots]`,
 		`"~" = true`,
-		`[permissions.gentle-dev.filesystem.":workspace_roots"]`,
-		`"." = "write"`,
-		`".git/**" = "write"`,
-		`"**/.env" = "deny"`,
-		`"**/.env.local" = "deny"`,
-		`"**/.env.*.local" = "deny"`,
-		`"**/.aws/credentials" = "deny"`,
-		`"**/.config/gh/hosts.yml" = "deny"`,
-		`"**/.credentials/**" = "deny"`,
-		`"**/.ssh/**" = "deny"`,
-		`"**/Library/Keychains/**" = "deny"`,
-		`"**/credentials.json" = "deny"`,
-		`"**/*.pem" = "deny"`,
-		`"**/*.key" = "deny"`,
-		`"**/secrets/**" = "deny"`,
 	}
 	for _, want := range wantSubstrings {
 		if !strings.Contains(text, want) {
 			t.Fatalf("config.toml missing %q; got:\n%s", want, text)
 		}
 	}
-	if !strings.Contains(tomlSection(text, "[permissions.gentle-dev.filesystem]"), `glob_scan_max_depth = 6`) {
-		t.Fatalf("config.toml should set glob_scan_max_depth in the filesystem profile; got:\n%s", text)
-	}
-	if strings.Contains(tomlSection(text, "[permissions.gentle-dev]"), `glob_scan_max_depth = 6`) {
-		t.Fatalf("config.toml should not set glob_scan_max_depth in the permissions profile; got:\n%s", text)
-	}
-
-	for _, invalidGitRule := range []string{`"**/.git" = "write"`, `"**/.git/**" = "write"`, `".git" = "write"`} {
-		if strings.Contains(text, invalidGitRule) {
-			t.Fatalf("config.toml contains invalid or redundant Codex permissions git rule %q; got:\n%s", invalidGitRule, text)
+	for _, invalid := range []string{
+		`glob_scan_max_depth = 6`,
+		`":tmpdir" = "write"`,
+		`":slash_tmp" = "write"`,
+		`[permissions.gentle-dev.filesystem.":workspace_roots"]`,
+		`"." = "write"`,
+		`".git/**" = "write"`,
+		`"**/.git" = "write"`,
+		`"**/.git/**" = "write"`,
+		`"**/.env" = "deny"`,
+		`"**/*.pem" = "deny"`,
+	} {
+		if strings.Contains(text, invalid) {
+			t.Fatalf("config.toml contains invalid Codex permission entry %q; got:\n%s", invalid, text)
 		}
 	}
 	if strings.Contains(text, `extends = ":workspace"`) {
@@ -518,24 +504,19 @@ args = ["mcp", "--tools=agent"]
 		"[permissions.gentle-dev.network]",
 		"[permissions.gentle-dev.network.domains]",
 		"[permissions.gentle-dev.workspace_roots]",
-		`[permissions.gentle-dev.filesystem.":workspace_roots"]`,
 	} {
 		if count := strings.Count(text, section); count != 1 {
 			t.Fatalf("section %q count = %d, want 1; got:\n%s", section, count, text)
 		}
 	}
-	if count := strings.Count(text, `glob_scan_max_depth = 6`); count != 1 {
-		t.Fatalf("glob_scan_max_depth count = %d, want 1; got:\n%s", count, text)
-	}
-	if !strings.Contains(tomlSection(text, "[permissions.gentle-dev.filesystem]"), `glob_scan_max_depth = 6`) {
-		t.Fatalf("config.toml should keep glob_scan_max_depth in the filesystem profile; got:\n%s", text)
-	}
-	if strings.Contains(tomlSection(text, "[permissions.gentle-dev]"), `glob_scan_max_depth = 6`) {
-		t.Fatalf("config.toml should not keep glob_scan_max_depth in the permissions profile; got:\n%s", text)
+	for _, invalid := range []string{`glob_scan_max_depth = 6`, `":tmpdir" = "write"`, `":slash_tmp" = "write"`, `[permissions.gentle-dev.filesystem.":workspace_roots"]`} {
+		if strings.Contains(text, invalid) {
+			t.Fatalf("config.toml should remove stale invalid entry %q; got:\n%s", invalid, text)
+		}
 	}
 }
 
-func TestInjectCodexPermissionsRemovesInvalidGitWriteRules(t *testing.T) {
+func TestInjectCodexPermissionsRemovesInvalidWorkspaceRootsTable(t *testing.T) {
 	home := t.TempDir()
 	configPath := filepath.Join(home, ".codex", "config.toml")
 	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
@@ -566,36 +547,21 @@ func TestInjectCodexPermissionsRemovesInvalidGitWriteRules(t *testing.T) {
 	}
 	text := string(content)
 
-	if !strings.Contains(text, `".git/**" = "write"`) {
-		t.Fatalf("config.toml missing valid git write rule; got:\n%s", text)
-	}
-	for _, invalidGitRule := range []string{`"**/.git" = "write"`, `"**/.git/**" = "write"`} {
-		if strings.Contains(text, invalidGitRule) {
-			t.Fatalf("config.toml still contains invalid git write rule %q; got:\n%s", invalidGitRule, text)
-		}
-	}
-
-	for _, denyRule := range []string{
+	for _, invalid := range []string{
+		`[permissions.gentle-dev.filesystem.":workspace_roots"]`,
+		`"**/.git" = "write"`,
+		`"**/.git/**" = "write"`,
 		`"**/.env" = "deny"`,
-		`"**/.env.local" = "deny"`,
-		`"**/.env.*.local" = "deny"`,
-		`"**/.aws/credentials" = "deny"`,
-		`"**/.config/gh/hosts.yml" = "deny"`,
-		`"**/.credentials/**" = "deny"`,
-		`"**/.ssh/**" = "deny"`,
-		`"**/Library/Keychains/**" = "deny"`,
-		`"**/credentials.json" = "deny"`,
 		`"**/*.pem" = "deny"`,
 		`"**/*.key" = "deny"`,
-		`"**/secrets/**" = "deny"`,
 	} {
-		if strings.Count(text, denyRule) != 1 {
-			t.Fatalf("config.toml should preserve deny rule %q exactly once; got:\n%s", denyRule, text)
+		if strings.Contains(text, invalid) {
+			t.Fatalf("config.toml still contains invalid workspace_roots entry %q; got:\n%s", invalid, text)
 		}
 	}
 }
 
-func TestInjectCodexPermissionsRemovesObsoleteBroadEnvDenyRules(t *testing.T) {
+func TestInjectCodexPermissionsRemovesObsoleteWorkspaceRootDenyRules(t *testing.T) {
 	home := t.TempDir()
 	configPath := filepath.Join(home, ".codex", "config.toml")
 	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
@@ -623,14 +589,16 @@ func TestInjectCodexPermissionsRemovesObsoleteBroadEnvDenyRules(t *testing.T) {
 	}
 	text := string(content)
 
-	for _, obsolete := range []string{`"**/.env.*" = "deny"`, `"*.env.*" = "deny"`} {
+	for _, obsolete := range []string{
+		`[permissions.gentle-dev.filesystem.":workspace_roots"]`,
+		`"**/.env.*" = "deny"`,
+		`"*.env.*" = "deny"`,
+		`"**/.env" = "deny"`,
+		`"**/.env.local" = "deny"`,
+		`"**/.env.*.local" = "deny"`,
+	} {
 		if strings.Contains(text, obsolete) {
-			t.Fatalf("config.toml still contains obsolete broad env deny rule %q; got:\n%s", obsolete, text)
-		}
-	}
-	for _, current := range []string{`"**/.env" = "deny"`, `"**/.env.local" = "deny"`, `"**/.env.*.local" = "deny"`} {
-		if strings.Count(text, current) != 1 {
-			t.Fatalf("config.toml should preserve current env deny rule %q exactly once; got:\n%s", current, text)
+			t.Fatalf("config.toml still contains obsolete workspace root deny entry %q; got:\n%s", obsolete, text)
 		}
 	}
 }


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1025

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Stop generating Codex permission entries that Codex CLI 0.118 rejects while loading `config.toml`.
- Remove stale invalid Codex permission entries when re-running permission injection.
- Update focused permission and app sync tests to assert the compatible profile shape.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/components/permissions/inject.go` | Removed unsupported Codex filesystem permissions and added stale table cleanup. |
| `internal/components/permissions/inject_test.go` | Updated direct injector tests to assert valid output and stale cleanup. |
| `internal/app/app_test.go` | Updated app-level sync/deferred sync expectations for the new Codex profile shape. |

---

## 🧪 Test Plan

**Focused Tests**
```bash
git diff --check
go test -count=1 ./internal/components/permissions ./internal/app
```

- [ ] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Manually tested locally

Additional verification:
- [x] `git diff --check`
- [x] `go test -count=1 ./internal/components/permissions ./internal/app`
- [x] Fresh `review-reliability` review: no findings
- [x] Fresh `review-resilience` review: no findings

---

## 🤖 Automated Checks

The following checks run automatically on this PR:

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | PR should stay within 400 changed lines (`additions + deletions`) or use `size:exception` |
| Check Issue Reference | ⏳ | PR body must contain `Closes/Fixes/Resolves #N` |
| Check Issue Has `status:approved` | ⏳ | Linked issue must have been approved before work began |
| Check PR Has `type:*` Label | ⏳ | Exactly one `type:*` label must be applied |
| Unit Tests | ⏳ | `go test ./...` must pass |
| E2E Tests | ⏳ | `cd e2e && ./docker-test.sh` must pass |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [x] I have added the appropriate `type:*` label to this PR
- [ ] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

This intentionally removes the prior workspace-root deny glob table instead of moving `glob_scan_max_depth`: Codex 0.118 rejects that nested filesystem table as a schema error.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved permissions sync so outdated or invalid entries are cleaned up more reliably.
  * Updated filesystem permissions handling to keep only the intended read access entries and workspace roots setting.
  * Reduced the chance of stale or duplicate permission rules persisting after initial, targeted, or deferred syncs.
  * Tightened validation to ensure unwanted legacy permission entries are removed consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->