### PR TITLE
fix(codex): scope secret denies to workspace roots

### DIFF
--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -23,6 +23,18 @@ import (
 	"github.com/gentleman-programming/gentle-ai/internal/update/upgrade"
 )
 
+func tomlSection(text, header string) string {
+	start := strings.Index(text, header)
+	if start == -1 {
+		return ""
+	}
+	section := text[start+len(header):]
+	if next := strings.Index(section, "\n["); next != -1 {
+		section = section[:next]
+	}
+	return section
+}
+
 // TestListBackupsNewestFirst verifies that ListBackups returns manifests sorted
 // newest-first by CreatedAt timestamp, matching the spec "newest first" ordering.
 func TestListBackupsNewestFirst(t *testing.T) {
@@ -458,10 +470,14 @@ func TestTuiSyncIncludesCodexPermissions(t *testing.T) {
 		t.Fatalf("ReadFile(%s): %v", configPath, err)
 	}
 	text := string(body)
-	if !strings.Contains(text, `[permissions.gentle-dev.filesystem]`) || !strings.Contains(text, `":minimal" = "read"`) || !strings.Contains(text, `"**/*.key" = "deny"`) {
+	if !strings.Contains(text, `[permissions.gentle-dev.filesystem]`) || !strings.Contains(text, `":minimal" = "read"`) || !strings.Contains(text, `[permissions.gentle-dev.filesystem.":workspace_roots"]`) || !strings.Contains(text, `"**/*.key" = "deny"`) {
 		t.Fatalf("Codex permissions sync should add valid filesystem reads; got:\n%s", text)
 	}
-	for _, invalid := range []string{`":slash_tmp" = "write"`, `":tmpdir" = "write"`, `[permissions.gentle-dev.filesystem.":workspace_roots"]`} {
+	rootFilesystem := tomlSection(text, `[permissions.gentle-dev.filesystem]`)
+	if strings.Contains(rootFilesystem, `"**/*.key" = "deny"`) || strings.Contains(rootFilesystem, `"**/*.pem" = "deny"`) {
+		t.Fatalf("Codex root filesystem table should not contain secret glob denies; got:\n%s", rootFilesystem)
+	}
+	for _, invalid := range []string{`":slash_tmp" = "write"`, `":tmpdir" = "write"`} {
 		if strings.Contains(text, invalid) {
 			t.Fatalf("Codex permissions sync should remove invalid entry %q; got:\n%s", invalid, text)
 		}
@@ -476,7 +492,7 @@ func TestTuiSyncIncludesCodexPermissions(t *testing.T) {
 		t.Fatalf("ReadFile(%s) after second sync: %v", configPath, err)
 	}
 	text = string(body)
-	for _, invalid := range []string{`":slash_tmp" = "write"`, `":tmpdir" = "write"`, `[permissions.gentle-dev.filesystem.":workspace_roots"]`} {
+	for _, invalid := range []string{`":slash_tmp" = "write"`, `":tmpdir" = "write"`} {
 		if strings.Contains(text, invalid) {
 			t.Fatalf("second sync should keep invalid entry %q removed; got:\n%s", invalid, text)
 		}
@@ -513,10 +529,14 @@ func TestTuiSyncIncludesCodexPermissionsForTargetedOverrides(t *testing.T) {
 		t.Fatalf("ReadFile(%s): %v", configPath, err)
 	}
 	text := string(body)
-	if !strings.Contains(text, `":minimal" = "read"`) || !strings.Contains(text, `[permissions.gentle-dev.workspace_roots]`) || !strings.Contains(text, `"**/*.key" = "deny"`) {
+	if !strings.Contains(text, `":minimal" = "read"`) || !strings.Contains(text, `[permissions.gentle-dev.workspace_roots]`) || !strings.Contains(text, `[permissions.gentle-dev.filesystem.":workspace_roots"]`) || !strings.Contains(text, `"**/*.key" = "deny"`) {
 		t.Fatalf("targeted sync should add valid Codex permissions profile; got:\n%s", text)
 	}
-	for _, invalid := range []string{`":slash_tmp" = "write"`, `":tmpdir" = "write"`, `[permissions.gentle-dev.filesystem.":workspace_roots"]`} {
+	rootFilesystem := tomlSection(text, `[permissions.gentle-dev.filesystem]`)
+	if strings.Contains(rootFilesystem, `"**/*.key" = "deny"`) {
+		t.Fatalf("targeted sync root filesystem table should not contain secret glob denies; got:\n%s", rootFilesystem)
+	}
+	for _, invalid := range []string{`":slash_tmp" = "write"`, `":tmpdir" = "write"`} {
 		if strings.Contains(text, invalid) {
 			t.Fatalf("targeted sync should remove invalid entry %q; got:\n%s", invalid, text)
 		}
@@ -1752,10 +1772,14 @@ func TestRunArgsPendingSyncRepairsCodexPermissions(t *testing.T) {
 		t.Fatalf("ReadFile(%s): %v", configPath, err)
 	}
 	text := string(body)
-	if !strings.Contains(text, `":minimal" = "read"`) || !strings.Contains(text, `[permissions.gentle-dev.workspace_roots]`) || !strings.Contains(text, `"**/*.key" = "deny"`) {
+	if !strings.Contains(text, `":minimal" = "read"`) || !strings.Contains(text, `[permissions.gentle-dev.workspace_roots]`) || !strings.Contains(text, `[permissions.gentle-dev.filesystem.":workspace_roots"]`) || !strings.Contains(text, `"**/*.key" = "deny"`) {
 		t.Fatalf("deferred sync should add valid Codex permissions profile; got:\n%s", text)
 	}
-	for _, invalid := range []string{`":slash_tmp" = "write"`, `":tmpdir" = "write"`, `[permissions.gentle-dev.filesystem.":workspace_roots"]`} {
+	rootFilesystem := tomlSection(text, `[permissions.gentle-dev.filesystem]`)
+	if strings.Contains(rootFilesystem, `"**/*.key" = "deny"`) || strings.Contains(rootFilesystem, `"**/*.pem" = "deny"`) {
+		t.Fatalf("deferred sync root filesystem table should not contain secret glob denies; got:\n%s", rootFilesystem)
+	}
+	for _, invalid := range []string{`":slash_tmp" = "write"`, `":tmpdir" = "write"`} {
 		if strings.Contains(text, invalid) {
 			t.Fatalf("deferred sync should remove invalid entry %q; got:\n%s", invalid, text)
 		}

--- a/internal/components/permissions/inject.go
+++ b/internal/components/permissions/inject.go
@@ -194,7 +194,28 @@ func injectCodexPermissions(homeDir string, adapter agents.Adapter) (InjectionRe
 		`":tmpdir"`,
 		`":slash_tmp"`,
 	})
-	merged = filemerge.RemoveTOMLTable(merged, `permissions.gentle-dev.filesystem.":workspace_roots"`)
+	secretDenyPaths := []string{
+		`"**/.env"`,
+		`"**/.env.local"`,
+		`"**/.env.*.local"`,
+		`"**/*.pem"`,
+		`"**/*.key"`,
+		`"**/secrets/**"`,
+		`"**/.ssh/**"`,
+		`"**/.credentials/**"`,
+		`"**/credentials.json"`,
+		`"**/.aws/credentials"`,
+		`"**/.config/gh/hosts.yml"`,
+	}
+	merged = filemerge.RemoveTOMLTableKeys(merged, "permissions.gentle-dev.filesystem", secretDenyPaths)
+	merged = filemerge.RemoveTOMLTableKeys(merged, `permissions.gentle-dev.filesystem.":workspace_roots"`, []string{
+		`"**/.git"`,
+		`"**/.git/**"`,
+		`".git/**"`,
+		`"**/.env.*"`,
+		`"*.env.*"`,
+		`"**/secrets/*"`,
+	})
 
 	readPaths := []string{
 		`":minimal"`,
@@ -210,21 +231,8 @@ func injectCodexPermissions(homeDir string, adapter agents.Adapter) (InjectionRe
 		merged = filemerge.UpsertTOMLTableKey(merged, "permissions.gentle-dev.filesystem", path, `"read"`)
 	}
 	merged = filemerge.UpsertTOMLTableKey(merged, "permissions.gentle-dev.filesystem", "glob_scan_max_depth", "6")
-	secretDenyPaths := []string{
-		`"**/.env"`,
-		`"**/.env.local"`,
-		`"**/.env.*.local"`,
-		`"**/*.pem"`,
-		`"**/*.key"`,
-		`"**/secrets/**"`,
-		`"**/.ssh/**"`,
-		`"**/.credentials/**"`,
-		`"**/credentials.json"`,
-		`"**/.aws/credentials"`,
-		`"**/.config/gh/hosts.yml"`,
-	}
 	for _, path := range secretDenyPaths {
-		merged = filemerge.UpsertTOMLTableKey(merged, "permissions.gentle-dev.filesystem", path, `"deny"`)
+		merged = filemerge.UpsertTOMLTableKey(merged, `permissions.gentle-dev.filesystem.":workspace_roots"`, path, `"deny"`)
 	}
 
 	merged = filemerge.UpsertTOMLTableKey(merged, "permissions.gentle-dev.workspace_roots", `"~"`, "true")

--- a/internal/components/permissions/inject_test.go
+++ b/internal/components/permissions/inject_test.go
@@ -358,6 +358,7 @@ func TestInjectCodexWritesGentleDevPermissionsProfile(t *testing.T) {
 		`"~/.nix-profile" = "read"`,
 		`"/nix/store" = "read"`,
 		`glob_scan_max_depth = 6`,
+		`[permissions.gentle-dev.filesystem.":workspace_roots"]`,
 		`"**/.env" = "deny"`,
 		`"**/.env.local" = "deny"`,
 		`"**/.env.*.local" = "deny"`,
@@ -377,10 +378,27 @@ func TestInjectCodexWritesGentleDevPermissionsProfile(t *testing.T) {
 			t.Fatalf("config.toml missing %q; got:\n%s", want, text)
 		}
 	}
+	rootFilesystem := tomlSection(text, `[permissions.gentle-dev.filesystem]`)
+	if !strings.Contains(rootFilesystem, `glob_scan_max_depth = 6`) {
+		t.Fatalf("root filesystem table missing glob_scan_max_depth; got:\n%s", rootFilesystem)
+	}
+	for _, invalidRootGlob := range []string{`"**/.env" = "deny"`, `"**/*.pem" = "deny"`, `"**/*.key" = "deny"`} {
+		if strings.Contains(rootFilesystem, invalidRootGlob) {
+			t.Fatalf("root filesystem table contains scoped secret deny %q; got:\n%s", invalidRootGlob, rootFilesystem)
+		}
+	}
+	scopedFilesystem := tomlSection(text, `[permissions.gentle-dev.filesystem.":workspace_roots"]`)
+	if scopedFilesystem == "" {
+		t.Fatalf("config.toml missing workspace-scoped filesystem table; got:\n%s", text)
+	}
+	for _, want := range []string{`"**/.env" = "deny"`, `"**/*.pem" = "deny"`, `"**/*.key" = "deny"`} {
+		if !strings.Contains(scopedFilesystem, want) {
+			t.Fatalf("workspace-scoped filesystem table missing %q; got:\n%s", want, scopedFilesystem)
+		}
+	}
 	for _, invalid := range []string{
 		`":tmpdir" = "write"`,
 		`":slash_tmp" = "write"`,
-		`[permissions.gentle-dev.filesystem.":workspace_roots"]`,
 		`"." = "write"`,
 		`".git/**" = "write"`,
 		`"**/.git" = "write"`,
@@ -510,6 +528,7 @@ args = ["mcp", "--tools=agent"]
 	for _, section := range []string{
 		"[permissions.gentle-dev]",
 		"[permissions.gentle-dev.filesystem]",
+		`[permissions.gentle-dev.filesystem.":workspace_roots"]`,
 		"[permissions.gentle-dev.network]",
 		"[permissions.gentle-dev.network.domains]",
 		"[permissions.gentle-dev.workspace_roots]",
@@ -518,21 +537,31 @@ args = ["mcp", "--tools=agent"]
 			t.Fatalf("section %q count = %d, want 1; got:\n%s", section, count, text)
 		}
 	}
-	for _, invalid := range []string{`":tmpdir" = "write"`, `":slash_tmp" = "write"`, `[permissions.gentle-dev.filesystem.":workspace_roots"]`} {
+	rootFilesystem := tomlSection(text, `[permissions.gentle-dev.filesystem]`)
+	for _, invalid := range []string{`":tmpdir" = "write"`, `":slash_tmp" = "write"`, `"**/*.key" = "deny"`, `"**/*.pem" = "deny"`} {
+		if strings.Contains(rootFilesystem, invalid) {
+			t.Fatalf("root filesystem table should not contain invalid/stale entry %q; got:\n%s", invalid, rootFilesystem)
+		}
+	}
+	for _, invalid := range []string{`":tmpdir" = "write"`, `":slash_tmp" = "write"`} {
 		if strings.Contains(text, invalid) {
 			t.Fatalf("config.toml should remove stale invalid entry %q; got:\n%s", invalid, text)
 		}
 	}
 }
 
-func TestInjectCodexPermissionsRemovesInvalidWorkspaceRootsTable(t *testing.T) {
+func TestInjectCodexPermissionsRelocatesSecretDeniesToWorkspaceRootsTable(t *testing.T) {
 	home := t.TempDir()
 	configPath := filepath.Join(home, ".codex", "config.toml")
 	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
 		t.Fatalf("MkdirAll() error = %v", err)
 	}
 
-	initial := `[permissions.gentle-dev.filesystem.":workspace_roots"]
+	initial := `[permissions.gentle-dev.filesystem]
+"**/*.key" = "deny"
+"**/*.pem" = "deny"
+
+[permissions.gentle-dev.filesystem.":workspace_roots"]
 "**/.git" = "write"
 "**/.git/**" = "write"
 "**/.env" = "deny"
@@ -556,13 +585,25 @@ func TestInjectCodexPermissionsRemovesInvalidWorkspaceRootsTable(t *testing.T) {
 	}
 	text := string(content)
 
-	for _, invalid := range []string{
-		`[permissions.gentle-dev.filesystem.":workspace_roots"]`,
-		`"**/.git" = "write"`,
-		`"**/.git/**" = "write"`,
-	} {
+	rootFilesystem := tomlSection(text, `[permissions.gentle-dev.filesystem]`)
+	for _, invalid := range []string{`"**/*.key" = "deny"`, `"**/*.pem" = "deny"`} {
+		if strings.Contains(rootFilesystem, invalid) {
+			t.Fatalf("root filesystem table still contains stale secret deny %q; got:\n%s", invalid, rootFilesystem)
+		}
+	}
+
+	scopedFilesystem := tomlSection(text, `[permissions.gentle-dev.filesystem.":workspace_roots"]`)
+	if scopedFilesystem == "" {
+		t.Fatalf("config.toml should keep workspace-scoped table for secret denies; got:\n%s", text)
+	}
+	for _, want := range []string{`"**/.env" = "deny"`, `"**/*.key" = "deny"`, `"**/*.pem" = "deny"`} {
+		if !strings.Contains(scopedFilesystem, want) {
+			t.Fatalf("workspace-scoped table missing relocated secret deny %q; got:\n%s", want, scopedFilesystem)
+		}
+	}
+	for _, invalid := range []string{`"**/.git" = "write"`, `"**/.git/**" = "write"`} {
 		if strings.Contains(text, invalid) {
-			t.Fatalf("config.toml still contains invalid workspace_roots entry %q; got:\n%s", invalid, text)
+			t.Fatalf("config.toml still contains invalid git write rule %q; got:\n%s", invalid, text)
 		}
 	}
 }
@@ -596,7 +637,6 @@ func TestInjectCodexPermissionsRemovesObsoleteWorkspaceRootDenyRules(t *testing.
 	text := string(content)
 
 	for _, obsolete := range []string{
-		`[permissions.gentle-dev.filesystem.":workspace_roots"]`,
 		`"**/.env.*" = "deny"`,
 		`"*.env.*" = "deny"`,
 	} {


### PR DESCRIPTION
Closes #1038

## PR Type
- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Moves Codex secret glob deny rules out of the root filesystem table into the workspace-roots scoped table.
- Keeps `glob_scan_max_depth = 6` and valid read roots in `[permissions.gentle-dev.filesystem]`.
- Adds tests for the generated TOML shape and app-level sync expectations.

## Changes
| File | Change |
|------|--------|
| `internal/components/permissions/inject.go` | Emit Codex secret denies under `[permissions.gentle-dev.filesystem.":workspace_roots"]`. |
| `internal/components/permissions/inject_test.go` | Assert root filesystem table excludes glob denies and scoped table contains them. |
| `internal/app/app_test.go` | Update sync expectations for the compatible Codex TOML shape. |

## Test Plan
- [x] `go test ./internal/components/permissions ./internal/app`
- [x] `git diff --check`
- [x] `go run ./cmd/gentle-ai sync --agent codex --include-permissions`
- [x] `codex` no longer fails config parsing; non-TTY run reaches `stdin is not a terminal`
- [x] Fresh R1/R3 review returned no findings

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one type:* label
- [x] Ran shellcheck on modified scripts or no scripts changed
- [x] Skills tested in at least one agent or not applicable
- [x] Docs updated if behavior changed
- [x] Conventional commit format
- [x] No Co-Authored-By trailers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how permission rules are organized so secret-related access restrictions now appear in the correct workspace-scoped section and no longer leak into the broader filesystem settings.
  * Tightened handling of outdated or invalid permission entries, reducing stale rules after syncing or repairing settings.

* **Tests**
  * Strengthened permission-related test coverage to verify TOML sections more precisely and ensure secret-deny rules are placed and removed correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->