### PR TITLE
fix(codex): restore git workspace permissions

### DIFF
--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -35,6 +35,27 @@ func tomlSection(text, header string) string {
 	return section
 }
 
+func assertCodexWorkspaceWriteRulesScoped(t *testing.T, text string) {
+	t.Helper()
+
+	rootFilesystem := tomlSection(text, `[permissions.gentle-dev.filesystem]`)
+	for _, rule := range []string{`"." = "write"`, `".git/**" = "write"`} {
+		if strings.Contains(rootFilesystem, rule) {
+			t.Fatalf("root filesystem table contains workspace write rule %q; got:\n%s", rule, rootFilesystem)
+		}
+	}
+
+	scopedFilesystem := tomlSection(text, `[permissions.gentle-dev.filesystem.":workspace_roots"]`)
+	if scopedFilesystem == "" {
+		t.Fatalf("config.toml missing workspace-scoped filesystem table; got:\n%s", text)
+	}
+	for _, rule := range []string{`"." = "write"`, `".git/**" = "write"`} {
+		if !strings.Contains(scopedFilesystem, rule) {
+			t.Fatalf("workspace-scoped filesystem table missing workspace write rule %q; got:\n%s", rule, scopedFilesystem)
+		}
+	}
+}
+
 // TestListBackupsNewestFirst verifies that ListBackups returns manifests sorted
 // newest-first by CreatedAt timestamp, matching the spec "newest first" ordering.
 func TestListBackupsNewestFirst(t *testing.T) {
@@ -470,14 +491,15 @@ func TestTuiSyncIncludesCodexPermissions(t *testing.T) {
 		t.Fatalf("ReadFile(%s): %v", configPath, err)
 	}
 	text := string(body)
-	if !strings.Contains(text, `[permissions.gentle-dev.filesystem]`) || !strings.Contains(text, `":minimal" = "read"`) || !strings.Contains(text, `[permissions.gentle-dev.filesystem.":workspace_roots"]`) || !strings.Contains(text, `"**/*.key" = "deny"`) {
+	if !strings.Contains(text, `[permissions.gentle-dev.filesystem]`) || !strings.Contains(text, `":minimal" = "read"`) || !strings.Contains(text, `":tmpdir" = "write"`) || !strings.Contains(text, `":slash_tmp" = "write"`) || !strings.Contains(text, `[permissions.gentle-dev.filesystem.":workspace_roots"]`) || !strings.Contains(text, `"**/*.key" = "deny"`) {
 		t.Fatalf("Codex permissions sync should add valid filesystem reads; got:\n%s", text)
 	}
+	assertCodexWorkspaceWriteRulesScoped(t, text)
 	rootFilesystem := tomlSection(text, `[permissions.gentle-dev.filesystem]`)
 	if strings.Contains(rootFilesystem, `"**/*.key" = "deny"`) || strings.Contains(rootFilesystem, `"**/*.pem" = "deny"`) {
 		t.Fatalf("Codex root filesystem table should not contain secret glob denies; got:\n%s", rootFilesystem)
 	}
-	for _, invalid := range []string{`":slash_tmp" = "write"`, `":tmpdir" = "write"`} {
+	for _, invalid := range []string{`"**/.git" = "write"`, `"**/.git/**" = "write"`} {
 		if strings.Contains(text, invalid) {
 			t.Fatalf("Codex permissions sync should remove invalid entry %q; got:\n%s", invalid, text)
 		}
@@ -492,7 +514,7 @@ func TestTuiSyncIncludesCodexPermissions(t *testing.T) {
 		t.Fatalf("ReadFile(%s) after second sync: %v", configPath, err)
 	}
 	text = string(body)
-	for _, invalid := range []string{`":slash_tmp" = "write"`, `":tmpdir" = "write"`} {
+	for _, invalid := range []string{`"**/.git" = "write"`, `"**/.git/**" = "write"`} {
 		if strings.Contains(text, invalid) {
 			t.Fatalf("second sync should keep invalid entry %q removed; got:\n%s", invalid, text)
 		}
@@ -529,14 +551,15 @@ func TestTuiSyncIncludesCodexPermissionsForTargetedOverrides(t *testing.T) {
 		t.Fatalf("ReadFile(%s): %v", configPath, err)
 	}
 	text := string(body)
-	if !strings.Contains(text, `":minimal" = "read"`) || !strings.Contains(text, `[permissions.gentle-dev.workspace_roots]`) || !strings.Contains(text, `[permissions.gentle-dev.filesystem.":workspace_roots"]`) || !strings.Contains(text, `"**/*.key" = "deny"`) {
+	if !strings.Contains(text, `":minimal" = "read"`) || !strings.Contains(text, `":tmpdir" = "write"`) || !strings.Contains(text, `":slash_tmp" = "write"`) || !strings.Contains(text, `[permissions.gentle-dev.workspace_roots]`) || !strings.Contains(text, `[permissions.gentle-dev.filesystem.":workspace_roots"]`) || !strings.Contains(text, `"**/*.key" = "deny"`) {
 		t.Fatalf("targeted sync should add valid Codex permissions profile; got:\n%s", text)
 	}
+	assertCodexWorkspaceWriteRulesScoped(t, text)
 	rootFilesystem := tomlSection(text, `[permissions.gentle-dev.filesystem]`)
 	if strings.Contains(rootFilesystem, `"**/*.key" = "deny"`) {
 		t.Fatalf("targeted sync root filesystem table should not contain secret glob denies; got:\n%s", rootFilesystem)
 	}
-	for _, invalid := range []string{`":slash_tmp" = "write"`, `":tmpdir" = "write"`} {
+	for _, invalid := range []string{`"**/.git" = "write"`, `"**/.git/**" = "write"`} {
 		if strings.Contains(text, invalid) {
 			t.Fatalf("targeted sync should remove invalid entry %q; got:\n%s", invalid, text)
 		}
@@ -1772,14 +1795,15 @@ func TestRunArgsPendingSyncRepairsCodexPermissions(t *testing.T) {
 		t.Fatalf("ReadFile(%s): %v", configPath, err)
 	}
 	text := string(body)
-	if !strings.Contains(text, `":minimal" = "read"`) || !strings.Contains(text, `[permissions.gentle-dev.workspace_roots]`) || !strings.Contains(text, `[permissions.gentle-dev.filesystem.":workspace_roots"]`) || !strings.Contains(text, `"**/*.key" = "deny"`) {
+	if !strings.Contains(text, `":minimal" = "read"`) || !strings.Contains(text, `":tmpdir" = "write"`) || !strings.Contains(text, `":slash_tmp" = "write"`) || !strings.Contains(text, `[permissions.gentle-dev.workspace_roots]`) || !strings.Contains(text, `[permissions.gentle-dev.filesystem.":workspace_roots"]`) || !strings.Contains(text, `"**/*.key" = "deny"`) {
 		t.Fatalf("deferred sync should add valid Codex permissions profile; got:\n%s", text)
 	}
+	assertCodexWorkspaceWriteRulesScoped(t, text)
 	rootFilesystem := tomlSection(text, `[permissions.gentle-dev.filesystem]`)
 	if strings.Contains(rootFilesystem, `"**/*.key" = "deny"`) || strings.Contains(rootFilesystem, `"**/*.pem" = "deny"`) {
 		t.Fatalf("deferred sync root filesystem table should not contain secret glob denies; got:\n%s", rootFilesystem)
 	}
-	for _, invalid := range []string{`":slash_tmp" = "write"`, `":tmpdir" = "write"`} {
+	for _, invalid := range []string{`"**/.git" = "write"`, `"**/.git/**" = "write"`} {
 		if strings.Contains(text, invalid) {
 			t.Fatalf("deferred sync should remove invalid entry %q; got:\n%s", invalid, text)
 		}

--- a/internal/components/permissions/inject.go
+++ b/internal/components/permissions/inject.go
@@ -190,10 +190,6 @@ func injectCodexPermissions(homeDir string, adapter agents.Adapter) (InjectionRe
 	merged = filemerge.UpsertTOMLTableKey(merged, "permissions.gentle-dev.network.domains", `"*"`, `"allow"`)
 
 	merged = filemerge.RemoveTOMLTableKeys(merged, `permissions.gentle-dev.filesystem.":root"`, []string{`"."`})
-	merged = filemerge.RemoveTOMLTableKeys(merged, "permissions.gentle-dev.filesystem", []string{
-		`":tmpdir"`,
-		`":slash_tmp"`,
-	})
 	secretDenyPaths := []string{
 		`"**/.env"`,
 		`"**/.env.local"`,
@@ -211,7 +207,6 @@ func injectCodexPermissions(homeDir string, adapter agents.Adapter) (InjectionRe
 	merged = filemerge.RemoveTOMLTableKeys(merged, `permissions.gentle-dev.filesystem.":workspace_roots"`, []string{
 		`"**/.git"`,
 		`"**/.git/**"`,
-		`".git/**"`,
 		`"**/.env.*"`,
 		`"*.env.*"`,
 		`"**/secrets/*"`,
@@ -230,7 +225,13 @@ func injectCodexPermissions(homeDir string, adapter agents.Adapter) (InjectionRe
 	for _, path := range readPaths {
 		merged = filemerge.UpsertTOMLTableKey(merged, "permissions.gentle-dev.filesystem", path, `"read"`)
 	}
+	for _, path := range []string{`":tmpdir"`, `":slash_tmp"`} {
+		merged = filemerge.UpsertTOMLTableKey(merged, "permissions.gentle-dev.filesystem", path, `"write"`)
+	}
 	merged = filemerge.UpsertTOMLTableKey(merged, "permissions.gentle-dev.filesystem", "glob_scan_max_depth", "6")
+	for _, path := range []string{`"."`, `".git/**"`} {
+		merged = filemerge.UpsertTOMLTableKey(merged, `permissions.gentle-dev.filesystem.":workspace_roots"`, path, `"write"`)
+	}
 	for _, path := range secretDenyPaths {
 		merged = filemerge.UpsertTOMLTableKey(merged, `permissions.gentle-dev.filesystem.":workspace_roots"`, path, `"deny"`)
 	}

--- a/internal/components/permissions/inject_test.go
+++ b/internal/components/permissions/inject_test.go
@@ -40,6 +40,27 @@ func tomlSection(text, header string) string {
 	return section
 }
 
+func assertCodexWorkspaceWriteRulesScoped(t *testing.T, text string) {
+	t.Helper()
+
+	rootFilesystem := tomlSection(text, `[permissions.gentle-dev.filesystem]`)
+	for _, rule := range []string{`"." = "write"`, `".git/**" = "write"`} {
+		if strings.Contains(rootFilesystem, rule) {
+			t.Fatalf("root filesystem table contains workspace write rule %q; got:\n%s", rule, rootFilesystem)
+		}
+	}
+
+	scopedFilesystem := tomlSection(text, `[permissions.gentle-dev.filesystem.":workspace_roots"]`)
+	if scopedFilesystem == "" {
+		t.Fatalf("config.toml missing workspace-scoped filesystem table; got:\n%s", text)
+	}
+	for _, rule := range []string{`"." = "write"`, `".git/**" = "write"`} {
+		if !strings.Contains(scopedFilesystem, rule) {
+			t.Fatalf("workspace-scoped filesystem table missing workspace write rule %q; got:\n%s", rule, scopedFilesystem)
+		}
+	}
+}
+
 // TestInjectHermesSkipsPermissions verifies that Hermes returns nil (no file written)
 // because Hermes permission format is undocumented — §14 of spec.
 func TestInjectHermesSkipsPermissions(t *testing.T) {
@@ -357,6 +378,8 @@ func TestInjectCodexWritesGentleDevPermissionsProfile(t *testing.T) {
 		`"~/.local/state/nix/profiles/home-manager/home-path" = "read"`,
 		`"~/.nix-profile" = "read"`,
 		`"/nix/store" = "read"`,
+		`":tmpdir" = "write"`,
+		`":slash_tmp" = "write"`,
 		`glob_scan_max_depth = 6`,
 		`[permissions.gentle-dev.filesystem.":workspace_roots"]`,
 		`"**/.env" = "deny"`,
@@ -387,6 +410,7 @@ func TestInjectCodexWritesGentleDevPermissionsProfile(t *testing.T) {
 			t.Fatalf("root filesystem table contains scoped secret deny %q; got:\n%s", invalidRootGlob, rootFilesystem)
 		}
 	}
+	assertCodexWorkspaceWriteRulesScoped(t, text)
 	scopedFilesystem := tomlSection(text, `[permissions.gentle-dev.filesystem.":workspace_roots"]`)
 	if scopedFilesystem == "" {
 		t.Fatalf("config.toml missing workspace-scoped filesystem table; got:\n%s", text)
@@ -397,10 +421,6 @@ func TestInjectCodexWritesGentleDevPermissionsProfile(t *testing.T) {
 		}
 	}
 	for _, invalid := range []string{
-		`":tmpdir" = "write"`,
-		`":slash_tmp" = "write"`,
-		`"." = "write"`,
-		`".git/**" = "write"`,
 		`"**/.git" = "write"`,
 		`"**/.git/**" = "write"`,
 	} {
@@ -538,16 +558,17 @@ args = ["mcp", "--tools=agent"]
 		}
 	}
 	rootFilesystem := tomlSection(text, `[permissions.gentle-dev.filesystem]`)
-	for _, invalid := range []string{`":tmpdir" = "write"`, `":slash_tmp" = "write"`, `"**/*.key" = "deny"`, `"**/*.pem" = "deny"`} {
+	for _, invalid := range []string{`"**/*.key" = "deny"`, `"**/*.pem" = "deny"`} {
 		if strings.Contains(rootFilesystem, invalid) {
 			t.Fatalf("root filesystem table should not contain invalid/stale entry %q; got:\n%s", invalid, rootFilesystem)
 		}
 	}
-	for _, invalid := range []string{`":tmpdir" = "write"`, `":slash_tmp" = "write"`} {
-		if strings.Contains(text, invalid) {
-			t.Fatalf("config.toml should remove stale invalid entry %q; got:\n%s", invalid, text)
+	for _, want := range []string{`":tmpdir" = "write"`, `":slash_tmp" = "write"`} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("config.toml missing compatible Codex permission entry %q; got:\n%s", want, text)
 		}
 	}
+	assertCodexWorkspaceWriteRulesScoped(t, text)
 }
 
 func TestInjectCodexPermissionsRelocatesSecretDeniesToWorkspaceRootsTable(t *testing.T) {


### PR DESCRIPTION
Closes #1040

## PR Type
- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Restores Codex gentle-dev workspace and temp write rules required for git.
- Keeps secret deny rules scoped to workspace roots.
- Tightens tests so workspace write rules must stay in the scoped table, not root filesystem.

## Changes
| File | Change |
|------|--------|
| `internal/components/permissions/inject.go` | Restores `:tmpdir`, `:slash_tmp`, `.`, and `.git/**` compatible write rules. |
| `internal/components/permissions/inject_test.go` | Verifies workspace write placement and secret deny preservation. |
| `internal/app/app_test.go` | Updates sync expectations for the restored compatible profile. |

## Test Plan
- [x] `go test ./internal/components/permissions ./internal/app`
- [x] `git diff --check`
- [x] `go run ./cmd/gentle-ai sync --agent codex --include-permissions`
- [x] `codex sandbox -P gentle-dev -C /Users/alanbuscaglia/work/gentle-ai --include-managed-config` with `git status`, write test, and `git rev-parse --git-dir`
- [x] Fresh R1/R3 review passed after scoped test fix

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one type:* label
- [x] Ran shellcheck on modified scripts or no scripts changed
- [x] Skills tested in at least one agent or not applicable
- [x] Docs updated if behavior changed
- [x] Conventional commit format
- [x] No Co-Authored-By trailers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Codex permission handling so workspace write access is scoped correctly and temporary directories retain the expected write rules.
  * Tightened permission validation to prevent secret-related deny patterns from appearing in the wrong place, reducing the chance of incorrect configuration output.

* **Tests**
  * Expanded Codex permission coverage to verify workspace-scoped rules, expected filesystem entries, and removal of invalid Git-related write rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->