### PR TITLE
docs(openspec): fix invalid YAML in config template rules.apply section

### DIFF
--- a/internal/assets/skills/_shared/openspec-convention.md
+++ b/internal/assets/skills/_shared/openspec-convention.md
@@ -98,7 +98,8 @@ rules:
     - Group by phase, use hierarchical numbering
     - Keep tasks completable in one session
   apply:
-    - Follow existing code patterns
+    guidelines:
+      - Follow existing code patterns
     tdd: false           # Set to true to enable RED-GREEN-REFACTOR
     test_command: ""
   verify:


### PR DESCRIPTION
## Summary

Fixes invalid YAML in the openspec config template where `rules.apply` mixed a YAML sequence with sibling mapping keys under the same node.

## Problem

The `rules.apply` block in `internal/assets/skills/_shared/openspec-convention.md` (lines 100-103) had:

```yaml
apply:
  - Follow existing code patterns
  tdd: false
  test_command: ""
```

This is invalid YAML — a node cannot be both a sequence and a mapping. Any strict YAML parser rejects it.

## Solution

Wrapped the sequence items under a `guidelines:` key:

```yaml
apply:
  guidelines:
    - Follow existing code patterns
  tdd: false
  test_command: ""
```

## Verification

- ✅ YAML validates cleanly with `yaml.safe_load()`
- ✅ No Go code changes — documentation-only fix
- ✅ Single file changed, well under 400 lines

Closes #1007

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the configuration example to reflect the current rule structure, placing the existing code-pattern guidance under a dedicated guidelines section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->