### PR TITLE
fix(model): split provider/model specs at first separator, not first colon

### DIFF
--- a/internal/components/sdd/profiles.go
+++ b/internal/components/sdd/profiles.go
@@ -237,10 +237,16 @@ func extractModelFromAgent(agentMap map[string]any) model.ModelAssignment {
 		return model.ModelAssignment{}
 	}
 
-	// Try colon separator first (standard: "anthropic:claude-sonnet-4"), then slash.
-	idx := strings.Index(modelStr, ":")
-	if idx <= 0 {
-		idx = strings.Index(modelStr, "/")
+	// Find the first separator — slash or colon, whichever appears first.
+	// Standard format: "anthropic:claude-sonnet-4" (colon).
+	// Custom providers: "zai-coding-plan/glm-5-turbo" (slash).
+	// Mixed: "openrouter/qwen/qwen3.6-plus:free" — slash is the provider boundary.
+	idx := -1
+	for i, c := range modelStr {
+		if c == '/' || c == ':' {
+			idx = i
+			break
+		}
 	}
 	if idx <= 0 {
 		return model.ModelAssignment{}

--- a/internal/components/sdd/profiles_test.go
+++ b/internal/components/sdd/profiles_test.go
@@ -1014,6 +1014,55 @@ func TestExtractModelFromAgent_ReadsVariant(t *testing.T) {
 	}
 }
 
+// TestExtractModelFromAgent_SlashBeforeColon verifies that a model spec with
+// a slash before a colon (e.g. OpenRouter free models) is split at the first
+// separator, not at the colon. Issue #802.
+func TestExtractModelFromAgent_SlashBeforeColon(t *testing.T) {
+	tests := []struct {
+		name       string
+		model      string
+		providerID string
+		modelID    string
+	}{
+		{
+			name:       "openrouter free model (slash before colon)",
+			model:      "openrouter/qwen/qwen3.6-plus:free",
+			providerID: "openrouter",
+			modelID:    "qwen/qwen3.6-plus:free",
+		},
+		{
+			name:       "standard colon format",
+			model:      "anthropic:claude-sonnet-4",
+			providerID: "anthropic",
+			modelID:    "claude-sonnet-4",
+		},
+		{
+			name:       "slash-only custom provider",
+			model:      "zai-coding-plan/glm-5-turbo",
+			providerID: "zai-coding-plan",
+			modelID:    "glm-5-turbo",
+		},
+		{
+			name:       "colon with slash in model ID",
+			model:      "openrouter:anthropic/claude-sonnet-4",
+			providerID: "openrouter",
+			modelID:    "anthropic/claude-sonnet-4",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			agentMap := map[string]any{"model": tt.model}
+			got := extractModelFromAgent(agentMap)
+			if got.ProviderID != tt.providerID {
+				t.Errorf("ProviderID = %q, want %q", got.ProviderID, tt.providerID)
+			}
+			if got.ModelID != tt.modelID {
+				t.Errorf("ModelID = %q, want %q", got.ModelID, tt.modelID)
+			}
+		})
+	}
+}
+
 // TestExtractModelFromAgent_NoVariantDefaultsEmpty verifies that a missing
 // "variant" key results in Effort="".
 func TestExtractModelFromAgent_NoVariantDefaultsEmpty(t *testing.T) {

--- a/internal/components/sdd/read_assignments.go
+++ b/internal/components/sdd/read_assignments.go
@@ -3,7 +3,6 @@ package sdd
 import (
 	"encoding/json"
 	"os"
-	"strings"
 
 	"github.com/gentleman-programming/gentle-ai/internal/model"
 	"github.com/gentleman-programming/gentle-ai/internal/opencode"
@@ -79,11 +78,16 @@ func ReadCurrentModelAssignments(settingsPath string) (map[string]model.ModelAss
 		if !ok || modelStr == "" {
 			continue
 		}
-		// Try colon first (standard: "anthropic:claude-sonnet-4"), then slash
-		// ("zai-coding-plan/glm-5-turbo") for custom providers (issue #152).
-		idx := strings.Index(modelStr, ":")
-		if idx <= 0 {
-			idx = strings.Index(modelStr, "/")
+		// Find the first separator — slash or colon, whichever appears first.
+		// Standard format: "anthropic:claude-sonnet-4" (colon).
+		// Custom providers: "zai-coding-plan/glm-5-turbo" (slash).
+		// Mixed: "openrouter/qwen/qwen3.6-plus:free" — slash is the provider boundary.
+		idx := -1
+		for i, c := range modelStr {
+			if c == '/' || c == ':' {
+				idx = i
+				break
+			}
 		}
 		if idx <= 0 {
 			// No separator or separator is the first character — skip malformed value.

--- a/internal/components/sdd/read_assignments_test.go
+++ b/internal/components/sdd/read_assignments_test.go
@@ -182,6 +182,53 @@ func TestReadCurrentModelAssignmentsMalformedModelField(t *testing.T) {
 	}
 }
 
+// TestReadCurrentModelAssignmentsSlashBeforeColon verifies that model specs with
+// a slash before a colon (e.g. OpenRouter free models like
+// "openrouter/qwen/qwen3.6-plus:free") are split at the first separator, not at
+// the colon. Issue #802.
+func TestReadCurrentModelAssignmentsSlashBeforeColon(t *testing.T) {
+	dir := t.TempDir()
+	settingsPath := filepath.Join(dir, "opencode.json")
+
+	content := `{
+  "agent": {
+    "gentle-orchestrator": { "model": "openrouter/qwen/qwen3.6-plus:free" },
+    "sdd-apply":           { "model": "openrouter:anthropic/claude-sonnet-4" }
+  }
+}`
+	if err := os.WriteFile(settingsPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write settings: %v", err)
+	}
+
+	got, err := ReadCurrentModelAssignments(settingsPath)
+	if err != nil {
+		t.Fatalf("ReadCurrentModelAssignments() error = %v", err)
+	}
+
+	tests := []struct {
+		phase      string
+		providerID string
+		modelID    string
+	}{
+		{"gentle-orchestrator", "openrouter", "qwen/qwen3.6-plus:free"},
+		{"sdd-apply", "openrouter", "anthropic/claude-sonnet-4"},
+	}
+
+	for _, tt := range tests {
+		a, ok := got[tt.phase]
+		if !ok {
+			t.Errorf("phase %q missing from result", tt.phase)
+			continue
+		}
+		if a.ProviderID != tt.providerID {
+			t.Errorf("phase %q: ProviderID = %q, want %q", tt.phase, a.ProviderID, tt.providerID)
+		}
+		if a.ModelID != tt.modelID {
+			t.Errorf("phase %q: ModelID = %q, want %q", tt.phase, a.ModelID, tt.modelID)
+		}
+	}
+}
+
 // TestReadCurrentModelAssignmentsSlashSeparator verifies that custom provider
 // models using slash format ("provider/model-id") are parsed correctly.
 // Issue #152: OpenCode uses "zai-coding-plan/glm-5-turbo" for custom providers.


### PR DESCRIPTION
## Summary

Fixes #802 — model spec strings like `openrouter/qwen/qwen3.6-plus:free` were split at the first `:` (position 31) instead of the first `/` (position 9), producing `ProviderID=openrouter/qwen/qwen3.6-plus`, `ModelID=free`.

## Root Cause

Both `extractModelFromAgent` (profiles.go) and the inline parser in `read_assignments.go` tried colon first with `strings.Index(modelStr, ":")`, falling back to slash only when no colon was found. For OpenRouter free-model specs that contain both `/` (provider boundary) and `:` (variant suffix), the colon appeared later in the string but was matched first.

## Fix

Changed both parsers to scan left-to-right and split at whichever separator (`/` or `:`) appears first — matching the existing correct behavior of `parseModelSpec` in `sync.go`.

**Files changed:**
- `internal/components/sdd/profiles.go` — `extractModelFromAgent()`: replaced `strings.Index` colon-first logic with left-to-right scan
- `internal/components/sdd/read_assignments.go` — inline parser: same fix, removed unused `strings` import

**Tests added:**
- `TestExtractModelFromAgent_SlashBeforeColon` — 4 sub-tests: openrouter free model, standard colon, slash-only, colon with slash in model ID
- `TestReadCurrentModelAssignmentsSlashBeforeColon` — integration test with both slash-before-colon and colon-with-slash specs

## Verification

- `go test ./internal/components/sdd/ -run "TestExtractModelFromAgent|TestReadCurrentModelAssignments"` — 17 passed
- `go test ./...` — 3945 passed, 54 packages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model string parsing so values containing both `:` and `/` are split at the first separator, handling mixed provider/model formats correctly.
  * Fixed model assignment reading for cases where a slash appears before a colon, ensuring provider and model names are extracted accurately.

* **Tests**
  * Added coverage for mixed-separator model strings and slash-before-colon parsing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->