### PR TITLE
fix(sdd-status): don't flag PENDING/TODO in compliant prose as blocker

### DIFF
--- a/internal/sddstatus/status.go
+++ b/internal/sddstatus/status.go
@@ -871,12 +871,19 @@ var reportCriticalGlyphStatusPattern = regexp.MustCompile(`(?i)❌\s*(?:FAIL|FAI
 var reportPassNegationPattern = regexp.MustCompile(`(?i)\bnot\s+(?:pass|passed|passing|successful|complete|completed)\b|\b(?:pass|passed|success|successful|complete|completed)\s*:\s*no\b`)
 var reportPendingPattern = regexp.MustCompile(`(?i)\b(?:TODO|PENDING)\b`)
 var reportBenignValuePattern = regexp.MustCompile(`(?i)^(?:none|no|n/a|not\s+applicable|0\s+(?:failed|blockers?|critical|issues?))\.?$`)
+var reportCompliantGlyphPattern = regexp.MustCompile(`✅`)
 
 func reportLineHasBlocker(line string) bool {
 	if line == "" {
 		return false
 	}
-	if reportPassNegationPattern.MatchString(line) || reportPendingPattern.MatchString(line) {
+	// Don't flag PENDING/TODO as blockers when the line has a compliant
+	// glyph (✅) — the word may appear in prose or test names without
+	// indicating an actual pending status.
+	if reportPassNegationPattern.MatchString(line) {
+		return true
+	}
+	if reportPendingPattern.MatchString(line) && !reportCompliantGlyphPattern.MatchString(line) {
 		return true
 	}
 	if reportCriticalGlyphStatusPattern.MatchString(line) {

--- a/internal/sddstatus/status_test.go
+++ b/internal/sddstatus/status_test.go
@@ -491,6 +491,18 @@ func TestResolveApplyVerifyArchiveGates(t *testing.T) {
 			wantArchive: DependencyReady,
 			wantNext:    "archive",
 		},
+		{
+			name: "archive ready when verify report has pending word in compliant prose with checkmark",
+			seed: func(t *testing.T, root string) {
+				changeRoot := seedReadyChange(t, root, "thin", "- [x] 1.1 Work\n")
+				write(t, filepath.Join(changeRoot, "verify-report.md"), "# Verify\nVerdict: PASS\n\n| Scenario | Description | Test | Status |\n|---|---|---|---|\n| Per-interface polling | Pending apply/update messages drain before final poll | test_pending_final_poll | ✅ COMPLIANT |\n")
+			},
+			wantApply:   ApplyAllDone,
+			wantApplyD:  DependencyAllDone,
+			wantVerify:  DependencyAllDone,
+			wantArchive: DependencyReady,
+			wantNext:    "archive",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

Fixes #848 — the verify-report parser blocked archive when compliant prose contained the word "Pending" (e.g. test names like `test_pending_final_poll` alongside ✅ COMPLIANT status).

## Root Cause

`reportPendingPattern = regexp.MustCompile("(?i)\\b(?:TODO|PENDING)\\b")` matched PENDING anywhere in a line, including test names that appeared alongside a ✅ compliant glyph. The parser treated these as blockers, preventing archive even though all checks were compliant.

## Fix

Added `reportCompliantGlyphPattern` to detect ✅ in a line. Modified `reportLineHasBlocker()` to skip the PENDING/TODO check when the line contains a ✅ — the compliant glyph takes precedence.

**Files changed:**
- `internal/sddstatus/status.go` — added compliant glyph pattern, updated `reportLineHasBlocker()`
- `internal/sddstatus/status_test.go` — added test case for compliant prose with "pending" in test name

## Verification

- `go test ./internal/sddstatus/` — all tests pass
- `go test ./...` — 3945 passed, 54 packages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved status detection so lines marked with a checkmark are no longer treated as blockers, even if they also include “pending” or “TODO”.
  * Updated archive gating behavior to recognize compliant report language and allow the archive phase to proceed when appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->