### PR TITLE
fix(app): detect missing TTY before launching Bubbletea TUI

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -134,7 +134,10 @@ func RunArgs(args []string, stdout io.Writer) error {
 		// Detect missing TTY early: Bubbletea requires /dev/tty to render.
 		// Print a helpful error with available non-TUI subcommands instead of
 		// letting Bubbletea panic with a cryptic "could not open a new TTY".
-		if f, ok := os.Stdin.(*os.File); !ok || !isattyFn(f.Fd()) {
+		if !isattyFn(os.Stdin.Fd()) {
+			return fmt.Errorf("no terminal attached (TTY required for the interactive TUI)\n\nAvailable non-interactive commands:\n  gentle-ai --version    Show version\n  gentle-ai --help       List all commands\n  gentle-ai install      Install agents/tools from CLI\n  gentle-ai upgrade      Upgrade managed tools from CLI\n  gentle-ai update check Check for updates\n  gentle-ai sync         Sync agent configs")
+		}
+		if !isattyFn(os.Stdout.Fd()) {
 			return fmt.Errorf("no terminal attached (TTY required for the interactive TUI)\n\nAvailable non-interactive commands:\n  gentle-ai --version    Show version\n  gentle-ai --help       List all commands\n  gentle-ai install      Install agents/tools from CLI\n  gentle-ai upgrade      Upgrade managed tools from CLI\n  gentle-ai update check Check for updates\n  gentle-ai sync         Sync agent configs")
 		}
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -131,6 +131,13 @@ func RunArgs(args []string, stdout io.Writer) error {
 	}
 
 	if len(args) == 0 {
+		// Detect missing TTY early: Bubbletea requires /dev/tty to render.
+		// Print a helpful error with available non-TUI subcommands instead of
+		// letting Bubbletea panic with a cryptic "could not open a new TTY".
+		if f, ok := os.Stdin.(*os.File); !ok || !isattyFn(f.Fd()) {
+			return fmt.Errorf("no terminal attached (TTY required for the interactive TUI)\n\nAvailable non-interactive commands:\n  gentle-ai --version    Show version\n  gentle-ai --help       List all commands\n  gentle-ai install      Install agents/tools from CLI\n  gentle-ai upgrade      Upgrade managed tools from CLI\n  gentle-ai update check Check for updates\n  gentle-ai sync         Sync agent configs")
+		}
+
 		homeDir, err := os.UserHomeDir()
 		if err != nil {
 			return fmt.Errorf("resolve user home directory: %w", err)

--- a/internal/app/parity_test.go
+++ b/internal/app/parity_test.go
@@ -170,14 +170,14 @@ func TestRunArgsNoCommandLaunchesTUI(t *testing.T) {
 
 	var buf bytes.Buffer
 	err := RunArgs(nil, &buf)
-	// With no args, RunArgs now launches the TUI via Bubbletea.
-	// In a headless/test environment without a TTY, this returns an error
-	// about opening /dev/tty. That's expected — the TUI requires a terminal.
 	if err == nil {
 		// If no error, we're somehow in a TTY — that's fine too.
 		return
 	}
-	if !strings.Contains(err.Error(), "TTY") && !strings.Contains(err.Error(), "tty") && !strings.Contains(err.Error(), "mock TUI") {
+	// With no args, RunArgs first checks for a TTY. In headless/test
+	// environments without a TTY, the TTY check fires before Bubbletea
+	// can attempt to open /dev/tty.
+	if !strings.Contains(err.Error(), "TTY") && !strings.Contains(err.Error(), "tty") && !strings.Contains(err.Error(), "mock TUI") && !strings.Contains(err.Error(), "no terminal attached") {
 		t.Fatalf("RunArgs(nil) unexpected error = %v; want TTY-related error or nil", err)
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #95 — launching Bubbletea without a TTY (e.g. in CI, piped stdout, or SSH without allocation) caused a cryptic crash. Now detects missing TTY before launching the TUI and returns a clear error listing non-interactive alternatives.

## Root Cause

`Run()` in `app.go` launched the Bubbletea TUI unconditionally when no subcommand was given. Bubbletea requires a terminal; without one it panics or renders garbage.

## Fix

Added TTY detection before TUI launch using the existing `isattyFn` (package-level var from `selfupdate.go`, injectable for tests). When `isattyFn(os.Stdout.Fd())` returns false, the function returns an error message listing available non-interactive commands: `--version`, `--help`, `install`, `upgrade`, `update check`, `sync`.

**Files changed:**
- `internal/app/app.go` — added TTY check before TUI initialization
- `internal/app/parity_test.go` — updated `TestRunArgsNoCommandLaunchesTUI` to accept "no terminal attached" error

## Verification

- `go test ./internal/app/ -run TestRunArgsNoCommandLaunchesTUI` — passes
- `go test ./...` — 3945 passed, 54 packages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the error shown when launching the interactive terminal experience without a TTY.
  * The app now fails early with a clear message that a terminal is required and lists supported non-interactive commands.
  * This avoids a later, more cryptic terminal-related crash.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->