### PR TITLE
fix(upgrade): verify tool is brew-managed before selecting brew strategy

### DIFF
--- a/internal/update/upgrade/executor.go
+++ b/internal/update/upgrade/executor.go
@@ -37,6 +37,15 @@ import (
 // Swapping this var in tests controls which commands are actually run.
 var execCommand = exec.Command
 
+// brewListFn checks whether a tool is installed via Homebrew by running
+// `brew list --formula <name>`. Swappable in tests for isolation.
+var brewListFn = defaultBrewList
+
+func defaultBrewList(toolName string) bool {
+	cmd := execCommand("brew", "list", "--formula", toolName)
+	return cmd.Run() == nil
+}
+
 // snapshotCreator is the function used to create a backup snapshot before
 // upgrade execution. Swapping this var in tests allows forcing snapshot
 // failures to verify end-to-end warning surfacing in UpgradeReport.
@@ -612,7 +621,11 @@ func effectiveMethod(tool update.ToolInfo, profile system.PlatformProfile) updat
 	if tool.InstallMethod == update.InstallOpenCodePlugin {
 		return update.InstallOpenCodePlugin
 	}
-	if profile.PackageManager == "brew" {
+	// On macOS, the brew profile means all tools are brew-managed. On Linux
+	// with Linuxbrew, brew may be present for unrelated packages while the
+	// tool itself was installed via binary or go-install. Verify the tool is
+	// actually in the brew Cellar before selecting the brew strategy.
+	if profile.PackageManager == "brew" && brewListFn(tool.Name) {
 		return update.InstallBrew
 	}
 	// Use installer method for gentle-ai on Windows (launches PowerShell installer).

--- a/internal/update/upgrade/strategy_test.go
+++ b/internal/update/upgrade/strategy_test.go
@@ -348,6 +348,12 @@ func TestEffectiveMethod_NonGentleAIToolsOnWindowsUseBinary(t *testing.T) {
 // --- TestEffectiveMethod ---
 
 func TestEffectiveMethod(t *testing.T) {
+	origBrewList := brewListFn
+	t.Cleanup(func() { brewListFn = origBrewList })
+
+	// Default mock: tool IS brew-managed (simulates macOS where all tools are in brew).
+	brewListFn = func(toolName string) bool { return true }
+
 	tests := []struct {
 		name    string
 		tool    update.ToolInfo
@@ -430,6 +436,67 @@ func TestEffectiveMethod(t *testing.T) {
 				t.Errorf("effectiveMethod = %q, want %q", got, tc.want)
 			}
 		})
+	}
+}
+
+// TestEffectiveMethod_LinuxbrewFallsThrough verifies that on Linux with
+// Linuxbrew installed, tools that are NOT in the brew Cellar fall through
+// to their declared InstallMethod instead of failing with "No available
+// formula". Issue #186.
+func TestEffectiveMethod_LinuxbrewFallsThrough(t *testing.T) {
+	origBrewList := brewListFn
+	t.Cleanup(func() { brewListFn = origBrewList })
+
+	// Simulate Linux with Linuxbrew: brew is available but the tool is NOT
+	// in the brew Cellar (brewListFn returns false).
+	brewListFn = func(toolName string) bool { return false }
+
+	tests := []struct {
+		name string
+		tool update.ToolInfo
+		want update.InstallMethod
+	}{
+		{
+			name: "binary tool falls through to declared method",
+			tool: update.ToolInfo{Name: "gentle-ai", InstallMethod: update.InstallBinary},
+			want: update.InstallBinary,
+		},
+		{
+			name: "script tool falls through to declared method",
+			tool: update.ToolInfo{Name: "gga", InstallMethod: update.InstallScript},
+			want: update.InstallScript,
+		},
+		{
+			name: "go-install tool falls through to go-install when go available",
+			tool: update.ToolInfo{Name: "engram", InstallMethod: update.InstallGoInstall, GoImportPath: "github.com/Gentleman-Programming/engram/cmd/engram"},
+			want: update.InstallGoInstall,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			profile := system.PlatformProfile{OS: "linux", PackageManager: "brew", GoAvailable: true}
+			got := effectiveMethod(tc.tool, profile)
+			if got != tc.want {
+				t.Errorf("effectiveMethod(%q) = %q, want %q", tc.tool.Name, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestEffectiveMethod_BrewInstalledToolUsesBrew verifies that when a tool IS
+// in the brew Cellar, the brew strategy is selected even on Linux.
+func TestEffectiveMethod_BrewInstalledToolUsesBrew(t *testing.T) {
+	origBrewList := brewListFn
+	t.Cleanup(func() { brewListFn = origBrewList })
+
+	brewListFn = func(toolName string) bool { return true }
+
+	profile := system.PlatformProfile{OS: "linux", PackageManager: "brew"}
+	tool := update.ToolInfo{Name: "engram", InstallMethod: update.InstallBinary}
+	got := effectiveMethod(tool, profile)
+	if got != update.InstallBrew {
+		t.Errorf("effectiveMethod = %q, want %q", got, update.InstallBrew)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #186 — on Linux with Linuxbrew installed, `gentle-ai upgrade` fails for tools installed via binary or go-install because `effectiveMethod()` unconditionally returns `InstallBrew` when `profile.PackageManager == "brew"`.

## Root Cause

`effectiveMethod()` in `executor.go` checked only `profile.PackageManager == "brew"` and blindly returned `InstallBrew` for **all** tools. On Linux, platform detection (`detect.go`) sets `PackageManager = "brew"` whenever the `brew` binary is found — even if the tools themselves were installed via binary download or `go install`. This caused `brew upgrade <tool>` to fail with "No available formula" for non-brew-managed tools.

## Fix

Added a `brewListFn` gate that runs `brew list --formula <name>` to verify the tool is actually in the brew Cellar before selecting the brew strategy. If the tool is not brew-managed, the function falls through to the tool's declared `InstallMethod` (binary, script, go-install).

**Files changed:**
- `internal/update/upgrade/executor.go` — added `brewListFn` var + `defaultBrewList` helper, gated brew override in `effectiveMethod()`
- `internal/update/upgrade/strategy_test.go` — updated `TestEffectiveMethod` to mock `brewListFn`, added `TestEffectiveMethod_LinuxbrewFallsThrough` and `TestEffectiveMethod_BrewInstalledToolUsesBrew`

## Verification

- `go test ./internal/update/upgrade/ -run TestEffectiveMethod -v` — 27 passed
- `go test ./...` — 3944 passed, 54 packages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved upgrade method selection so tools installed through Homebrew are only upgraded with the brew path when they are actually present in the Homebrew cellar.
  * If a tool is not managed by Homebrew, upgrades now fall back to the previously selected install method more reliably.
  * Added coverage for Linuxbrew scenarios to ensure the correct upgrade path is chosen in both installed and non-installed cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->