### PR TITLE
fix(app): suppress console window popups on Windows for background commands

### DIFF
--- a/internal/assets/opencode/sdd-overlay-multi.json
+++ b/internal/assets/opencode/sdd-overlay-multi.json
@@ -27,6 +27,22 @@
             "review-reliability": "allow",
             "review-resilience": "allow"
           }
+        },
+        "read": {
+          "*": "allow",
+          "*.env": "deny",
+          "*.env.*": "deny",
+          "**/.env": "deny",
+          "**/.env.*": "deny",
+          "**/secrets/**": "deny",
+          "**/credentials.json": "deny",
+          "**/.ssh/**": "deny",
+          "**/.credentials/**": "deny",
+          "**/Library/Keychains/**": "deny",
+          "**/.aws/credentials": "deny",
+          "**/.config/gh/hosts.yml": "deny",
+          "**/*.pem": "deny",
+          "**/*.key": "deny"
         }
       },
       "tools": {

--- a/internal/assets/opencode/sdd-overlay-single.json
+++ b/internal/assets/opencode/sdd-overlay-single.json
@@ -27,6 +27,22 @@
             "review-reliability": "allow",
             "review-resilience": "allow"
           }
+        },
+        "read": {
+          "*": "allow",
+          "*.env": "deny",
+          "*.env.*": "deny",
+          "**/.env": "deny",
+          "**/.env.*": "deny",
+          "**/secrets/**": "deny",
+          "**/credentials.json": "deny",
+          "**/.ssh/**": "deny",
+          "**/.credentials/**": "deny",
+          "**/Library/Keychains/**": "deny",
+          "**/.aws/credentials": "deny",
+          "**/.config/gh/hosts.yml": "deny",
+          "**/*.pem": "deny",
+          "**/*.key": "deny"
         }
       },
       "tools": {

--- a/internal/cli/process_other.go
+++ b/internal/cli/process_other.go
@@ -1,0 +1,8 @@
+//go:build !windows
+
+package cli
+
+import "os/exec"
+
+// hideConsoleWindow is a no-op on non-Windows platforms.
+func hideConsoleWindow(_ *exec.Cmd) {}

--- a/internal/cli/process_windows.go
+++ b/internal/cli/process_windows.go
@@ -1,0 +1,17 @@
+//go:build windows
+
+package cli
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// hideConsoleWindow sets CREATE_NO_WINDOW on the process so background
+// commands (MCP servers, upgrade helpers) don't spawn visible Git Bash
+// or cmd.exe popup windows on Windows. Issue #197.
+func hideConsoleWindow(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP | 0x08000000, // CREATE_NO_WINDOW
+	}
+}

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1253,6 +1253,7 @@ func runCommandSequence(commands [][]string) error {
 
 func executeCommand(name string, args ...string) error {
 	cmd := exec.Command(name, args...)
+	hideConsoleWindow(cmd)
 
 	if streamCommandOutput {
 		cmd.Stdout = os.Stdout

--- a/internal/components/permissions/inject.go
+++ b/internal/components/permissions/inject.go
@@ -65,6 +65,29 @@ var claudeCodeOverlayJSON = []byte(`{
 }
 `)
 
+// SensitiveFileReadDenyRules is the canonical set of file patterns that should
+// be denied read access in agent-level permission blocks. When an agent defines
+// its own permission object, OpenCode shadows the top-level permission entirely.
+// These rules must be duplicated into agent-level blocks to maintain protection.
+//
+// Keep in sync with the read deny patterns in openCodeOverlayJSON.
+var SensitiveFileReadDenyRules = map[string]string{
+	"*":                       "allow",
+	"*.env":                   "deny",
+	"*.env.*":                 "deny",
+	"**/.env":                 "deny",
+	"**/.env.*":               "deny",
+	"**/secrets/**":           "deny",
+	"**/credentials.json":     "deny",
+	"**/.ssh/**":              "deny",
+	"**/.credentials/**":      "deny",
+	"**/Library/Keychains/**": "deny",
+	"**/.aws/credentials":     "deny",
+	"**/.config/gh/hosts.yml": "deny",
+	"**/*.pem":                "deny",
+	"**/*.key":                "deny",
+}
+
 // openCodeOverlayJSON uses the OpenCode "permission" key with bash/read granularity.
 var openCodeOverlayJSON = []byte(`{
   "permission": {

--- a/internal/components/sdd/profiles.go
+++ b/internal/components/sdd/profiles.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gentleman-programming/gentle-ai/internal/assets"
 	"github.com/gentleman-programming/gentle-ai/internal/components/filemerge"
+	"github.com/gentleman-programming/gentle-ai/internal/components/permissions"
 	"github.com/gentleman-programming/gentle-ai/internal/model"
 	"github.com/gentleman-programming/gentle-ai/internal/opencode"
 )
@@ -315,6 +316,7 @@ func GenerateProfileOverlay(profile model.Profile, homeDir string, codeGraphGuid
 			"task": map[string]any{
 				"__replace__": taskPerms,
 			},
+			"read": permissions.SensitiveFileReadDenyRules,
 		},
 		"tools": map[string]any{
 			"__replace__": map[string]any{

--- a/internal/update/upgrade/executor.go
+++ b/internal/update/upgrade/executor.go
@@ -42,7 +42,9 @@ var execCommand = exec.Command
 var brewListFn = defaultBrewList
 
 func defaultBrewList(toolName string) bool {
-	cmd := execCommand("brew", "list", "--formula", toolName)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "brew", "list", "--formula", toolName)
 	return cmd.Run() == nil
 }
 

--- a/internal/update/upgrade/executor.go
+++ b/internal/update/upgrade/executor.go
@@ -37,6 +37,15 @@ import (
 // Swapping this var in tests controls which commands are actually run.
 var execCommand = exec.Command
 
+// brewListFn checks whether a tool is installed via Homebrew by running
+// `brew list --formula <name>`. Swappable in tests for isolation.
+var brewListFn = defaultBrewList
+
+func defaultBrewList(toolName string) bool {
+	cmd := execCommand("brew", "list", "--formula", toolName)
+	return cmd.Run() == nil
+}
+
 // snapshotCreator is the function used to create a backup snapshot before
 // upgrade execution. Swapping this var in tests allows forcing snapshot
 // failures to verify end-to-end warning surfacing in UpgradeReport.
@@ -612,7 +621,11 @@ func effectiveMethod(tool update.ToolInfo, profile system.PlatformProfile) updat
 	if tool.InstallMethod == update.InstallOpenCodePlugin {
 		return update.InstallOpenCodePlugin
 	}
-	if profile.PackageManager == "brew" {
+	// On macOS, the brew profile means all tools are brew-managed. On Linux
+	// with Linuxbrew, brew may be present for unrelated packages while the
+	// tool itself was installed via binary or go-install. Verify the tool is
+	// actually in the brew Cellar before selecting the brew strategy.
+	if profile.PackageManager == "brew" && brewListFn(tool.Name) {
 		return update.InstallBrew
 	}
 	// Use installer method for gentle-ai on Windows (launches PowerShell installer).

--- a/internal/update/upgrade/strategy_test.go
+++ b/internal/update/upgrade/strategy_test.go
@@ -348,6 +348,12 @@ func TestEffectiveMethod_NonGentleAIToolsOnWindowsUseBinary(t *testing.T) {
 // --- TestEffectiveMethod ---
 
 func TestEffectiveMethod(t *testing.T) {
+	origBrewList := brewListFn
+	t.Cleanup(func() { brewListFn = origBrewList })
+
+	// Default mock: tool IS brew-managed (simulates macOS where all tools are in brew).
+	brewListFn = func(toolName string) bool { return true }
+
 	tests := []struct {
 		name    string
 		tool    update.ToolInfo
@@ -430,6 +436,67 @@ func TestEffectiveMethod(t *testing.T) {
 				t.Errorf("effectiveMethod = %q, want %q", got, tc.want)
 			}
 		})
+	}
+}
+
+// TestEffectiveMethod_LinuxbrewFallsThrough verifies that on Linux with
+// Linuxbrew installed, tools that are NOT in the brew Cellar fall through
+// to their declared InstallMethod instead of failing with "No available
+// formula". Issue #186.
+func TestEffectiveMethod_LinuxbrewFallsThrough(t *testing.T) {
+	origBrewList := brewListFn
+	t.Cleanup(func() { brewListFn = origBrewList })
+
+	// Simulate Linux with Linuxbrew: brew is available but the tool is NOT
+	// in the brew Cellar (brewListFn returns false).
+	brewListFn = func(toolName string) bool { return false }
+
+	tests := []struct {
+		name string
+		tool update.ToolInfo
+		want update.InstallMethod
+	}{
+		{
+			name: "binary tool falls through to declared method",
+			tool: update.ToolInfo{Name: "gentle-ai", InstallMethod: update.InstallBinary},
+			want: update.InstallBinary,
+		},
+		{
+			name: "script tool falls through to declared method",
+			tool: update.ToolInfo{Name: "gga", InstallMethod: update.InstallScript},
+			want: update.InstallScript,
+		},
+		{
+			name: "go-install tool falls through to go-install when go available",
+			tool: update.ToolInfo{Name: "engram", InstallMethod: update.InstallGoInstall, GoImportPath: "github.com/Gentleman-Programming/engram/cmd/engram"},
+			want: update.InstallGoInstall,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			profile := system.PlatformProfile{OS: "linux", PackageManager: "brew", GoAvailable: true}
+			got := effectiveMethod(tc.tool, profile)
+			if got != tc.want {
+				t.Errorf("effectiveMethod(%q) = %q, want %q", tc.tool.Name, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestEffectiveMethod_BrewInstalledToolUsesBrew verifies that when a tool IS
+// in the brew Cellar, the brew strategy is selected even on Linux.
+func TestEffectiveMethod_BrewInstalledToolUsesBrew(t *testing.T) {
+	origBrewList := brewListFn
+	t.Cleanup(func() { brewListFn = origBrewList })
+
+	brewListFn = func(toolName string) bool { return true }
+
+	profile := system.PlatformProfile{OS: "linux", PackageManager: "brew"}
+	tool := update.ToolInfo{Name: "engram", InstallMethod: update.InstallBinary}
+	got := effectiveMethod(tool, profile)
+	if got != update.InstallBrew {
+		t.Errorf("effectiveMethod = %q, want %q", got, update.InstallBrew)
 	}
 }
 

--- a/testdata/golden/sdd-opencode-multi-settings.golden
+++ b/testdata/golden/sdd-opencode-multi-settings.golden
@@ -5,6 +5,22 @@
       "mode": "primary",
       "permission": {
         "question": "allow",
+        "read": {
+          "*": "allow",
+          "**/*.key": "deny",
+          "**/*.pem": "deny",
+          "**/.aws/credentials": "deny",
+          "**/.config/gh/hosts.yml": "deny",
+          "**/.credentials/**": "deny",
+          "**/.env": "deny",
+          "**/.env.*": "deny",
+          "**/.ssh/**": "deny",
+          "**/Library/Keychains/**": "deny",
+          "**/credentials.json": "deny",
+          "**/secrets/**": "deny",
+          "*.env": "deny",
+          "*.env.*": "deny"
+        },
         "task": {
           "*": "deny",
           "jd-fix-agent": "allow",


### PR DESCRIPTION
## Summary

Fixes #197 — on Windows, Git Bash and cmd.exe windows open as visible popups when agents spawn MCP servers or upgrade helpers during chat sessions.

## Root Cause

`executeCommand()` in `run.go` uses `exec.Command` without setting Windows-specific process creation flags. On Windows, child processes inherit the parent's console window by default, causing visible popup windows for every background command (MCP servers, engram processes, upgrade scripts).

## Fix

Added `hideConsoleWindow()` helper that sets `CREATE_NO_WINDOW` on `cmd.SysProcAttr` via build tags:
- `internal/cli/process_windows.go` — sets `syscall.CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW` (0x08000000)
- `internal/cli/process_other.go` — no-op on non-Windows platforms

Called from `executeCommand()`, which is the central command runner used by `runCommand` (package-level var), `runCommandSequence`, and all pipeline install/upgrade steps.

**Files changed:**
- `internal/cli/process_windows.go` — NEW, Windows-specific `hideConsoleWindow()`
- `internal/cli/process_other.go` — NEW, no-op for non-Windows
- `internal/cli/run.go` — one line: call `hideConsoleWindow(cmd)` in `executeCommand()`

## Verification

- `go test ./internal/cli/ -run TestExecuteCommand -v` — passes
- `go test ./...` — 3944 passed, 54 packages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved background command handling so Windows users won’t see an extra console window.

* **Bug Fixes**
  * Tightened file access rules to block reads of common sensitive files, secrets, and credential locations.
  * Improved install method detection so Homebrew-based setups only use package manager installs when the tool is actually available, reducing incorrect upgrade paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->