### PR TITLE
feat(community-tool): add RTK as community tool

### DIFF
--- a/internal/components/communitytool/tool.go
+++ b/internal/components/communitytool/tool.go
@@ -92,6 +92,14 @@ var definitions = []Definition{
 		RepoURL:     "https://github.com/colbymchenry/codegraph",
 		Description: "Code graph indexing and MCP wiring for supported coding agents",
 	},
+	{
+		ID:          model.CommunityToolRTK,
+		Name:        "RTK",
+		PackageName: "",
+		CommandName: "rtk",
+		RepoURL:     "https://github.com/rtk-ai/rtk",
+		Description: "CLI proxy that reduces LLM token consumption by 60-90% on common dev commands",
+	},
 }
 
 func Definitions() []Definition {
@@ -121,19 +129,26 @@ func InstallWithHome(id model.CommunityToolID, workspaceDir string, homeDir stri
 	if !ok {
 		return Result{}, fmt.Errorf("unknown community tool %q", id)
 	}
-	if def.ID != model.CommunityToolCodeGraph {
+	switch def.ID {
+	case model.CommunityToolCodeGraph:
+		return installCodeGraph(workspaceDir, homeDir, runner, detector)
+	case model.CommunityToolRTK:
+		return installRTK(workspaceDir, homeDir, runner, detector)
+	default:
 		return Result{}, fmt.Errorf("community tool %q is not supported", id)
 	}
+}
 
-	result := Result{Tool: id}
-	before := DetectStatus(id, homeDir, detector)
+func installCodeGraph(workspaceDir string, homeDir string, runner Runner, detector Detector) (Result, error) {
+	result := Result{Tool: model.CommunityToolCodeGraph}
+	before := DetectStatus(model.CommunityToolCodeGraph, homeDir, detector)
 	result.StatusBefore = &before
 	if before.CodeGraphReconcileSatisfied() || (before.CLI == AvailabilityAvailable && hasDetectedCodeGraphToolWiring(homeDir)) {
-		guidanceResult, err := InjectCodeGraphGuidanceIfSelected(homeDir, []model.CommunityToolID{id})
+		guidanceResult, err := InjectCodeGraphGuidanceIfSelected(homeDir, []model.CommunityToolID{model.CommunityToolCodeGraph})
 		if err != nil {
 			return result, err
 		}
-		after := DetectStatus(id, homeDir, detector)
+		after := DetectStatus(model.CommunityToolCodeGraph, homeDir, detector)
 		result.StatusAfter = &after
 		if err := validateCodeGraphInstallStatus(after); err != nil {
 			return result, err
@@ -159,16 +174,67 @@ func InstallWithHome(id model.CommunityToolID, workspaceDir string, homeDir stri
 			return result, fmt.Errorf("run %q: %w", strings.Join(command, " "), err)
 		}
 	}
-	if _, err := InjectCodeGraphGuidanceIfSelected(homeDir, []model.CommunityToolID{id}); err != nil {
+	if _, err := InjectCodeGraphGuidanceIfSelected(homeDir, []model.CommunityToolID{model.CommunityToolCodeGraph}); err != nil {
 		return result, err
 	}
-	after := DetectStatus(id, homeDir, detector)
+	after := DetectStatus(model.CommunityToolCodeGraph, homeDir, detector)
 	result.StatusAfter = &after
 	if err := validateCodeGraphInstallStatus(after); err != nil {
 		return result, err
 	}
 	result.ManualActions = append(result.ManualActions, "CodeGraph CLI was installed and supported agents were connected. Project indexes will be created automatically when an enabled agent opens inside a project.")
 	return result, nil
+}
+
+func installRTK(workspaceDir string, homeDir string, runner Runner, detector Detector) (Result, error) {
+	result := Result{Tool: model.CommunityToolRTK}
+	if detector == nil {
+		detector = DetectorFunc(exec.LookPath)
+	}
+
+	// Check if RTK is already installed.
+	if _, err := detector.LookPath("rtk"); err == nil {
+		result.ManualActions = append(result.ManualActions, "RTK is already available. Run 'rtk init -g' in your project to configure agent hooks.")
+		after := DetectStatus(model.CommunityToolRTK, homeDir, detector)
+		result.StatusAfter = &after
+		return result, nil
+	}
+
+	// Install RTK via cargo (preferred) or binary download.
+	commands := rtkInstallCommands(detector)
+	for _, command := range commands {
+		if len(command) == 0 {
+			continue
+		}
+		result.CommandsRun = append(result.CommandsRun, strings.Join(command, " "))
+		if err := runner.Run(command[0], command[1:]...); err != nil {
+			return result, fmt.Errorf("run %q: %w", strings.Join(command, " "), err)
+		}
+	}
+
+	after := DetectStatus(model.CommunityToolRTK, homeDir, detector)
+	result.StatusAfter = &after
+	if after.CLI != AvailabilityAvailable {
+		return result, fmt.Errorf("RTK install did not leave the rtk CLI available")
+	}
+	result.ManualActions = append(result.ManualActions, "RTK CLI was installed. Run 'rtk init -g' in your project to configure agent hooks for token-optimized command output.")
+	return result, nil
+}
+
+func rtkInstallCommands(detector Detector) [][]string {
+	if detector == nil {
+		detector = DetectorFunc(exec.LookPath)
+	}
+	// Prefer cargo if available (Rust ecosystem).
+	if _, err := detector.LookPath("cargo"); err == nil {
+		return [][]string{
+			{"cargo", "install", "--git", "https://github.com/rtk-ai/rtk"},
+		}
+	}
+	// Fallback: binary download from GitHub releases (platform-specific).
+	return [][]string{
+		{"sh", "-c", "curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/main/install.sh | sh"},
+	}
 }
 
 func validateCodeGraphInstallStatus(status Status) error {
@@ -193,7 +259,7 @@ func validateCodeGraphInstallStatus(status Status) error {
 func DetectStatus(id model.CommunityToolID, homeDir string, detector Detector) Status {
 	status := Status{Tool: id, CLI: AvailabilityMissing}
 	def, ok := DefinitionFor(id)
-	if !ok || id != model.CommunityToolCodeGraph {
+	if !ok {
 		status.FollowUps = append(status.FollowUps, fmt.Sprintf("status detection for %q is not implemented", id))
 		return status
 	}
@@ -204,8 +270,17 @@ func DetectStatus(id model.CommunityToolID, homeDir string, detector Detector) S
 		status.CLI = AvailabilityAvailable
 		status.CLIPath = path
 	}
-	status.Agents = detectCodeGraphAgents(homeDir)
-	status.FollowUps = append(status.FollowUps, "CodeGraph markers can vary by upstream version; detection currently checks conservative MCP entries and instruction markers containing codegraph.")
+
+	switch id {
+	case model.CommunityToolCodeGraph:
+		status.Agents = detectCodeGraphAgents(homeDir)
+		status.FollowUps = append(status.FollowUps, "CodeGraph markers can vary by upstream version; detection currently checks conservative MCP entries and instruction markers containing codegraph.")
+	case model.CommunityToolRTK:
+		status.Agents = detectRTKAgents(homeDir)
+		status.FollowUps = append(status.FollowUps, "RTK hook detection checks for rtk rewrite rules in agent configuration files.")
+	default:
+		status.FollowUps = append(status.FollowUps, fmt.Sprintf("status detection for %q is not implemented", id))
+	}
 	return status
 }
 
@@ -444,4 +519,100 @@ func codeGraphCommands(packageManager string) [][]string {
 		installCommand,
 		{"codegraph", "install", "--yes"},
 	}
+}
+
+// RTK agent detection.
+
+func detectRTKAgents(homeDir string) []AgentStatus {
+	reg, err := agents.NewDefaultRegistry()
+	if err != nil {
+		return nil
+	}
+	supported := rtkSupportedAgents()
+	installed := agents.DiscoverInstalled(reg, homeDir)
+	installedByID := make(map[model.AgentID]string, len(installed))
+	for _, agent := range installed {
+		installedByID[agent.ID] = agent.ConfigDir
+	}
+
+	result := make([]AgentStatus, 0, len(supported))
+	for _, id := range supported {
+		adapter, ok := reg.Get(id)
+		if !ok {
+			continue
+		}
+		name := agentDisplayName(id)
+		configDir, detected := installedByID[id]
+		state := AgentStatus{
+			Agent:    id,
+			Name:     name,
+			Detected: detected,
+			Path:     configDir,
+			Status:   AgentStatusUnavailable,
+			Reason:   "agent config directory was not detected",
+		}
+		if detected {
+			configured, markerPath, reason := hasRTKWiring(homeDir, adapter)
+			state.Configured = configured
+			state.Path = markerPath
+			state.Reason = reason
+			if configured {
+				state.Status = AgentStatusConfigured
+			} else {
+				state.Status = AgentStatusMissing
+			}
+		}
+		result = append(result, state)
+	}
+	return result
+}
+
+func rtkSupportedAgents() []model.AgentID {
+	reg, err := agents.NewDefaultRegistry()
+	if err != nil {
+		return nil
+	}
+	ids := reg.SupportedAgents()
+	ids = slices.DeleteFunc(ids, func(id model.AgentID) bool { return !isRTKSupportedAgent(id) })
+	return ids
+}
+
+func isRTKSupportedAgent(id model.AgentID) bool {
+	return slices.Contains([]model.AgentID{
+		model.AgentClaudeCode,
+		model.AgentOpenCode,
+		model.AgentCursor,
+		model.AgentGeminiCLI,
+		model.AgentCodex,
+		model.AgentWindsurf,
+		model.AgentVSCodeCopilot,
+		model.AgentHermes,
+	}, id)
+}
+
+func hasRTKWiring(homeDir string, adapter agents.Adapter) (bool, string, string) {
+	// Check if RTK hooks are configured in the agent's settings or config files.
+	paths := []string{
+		adapter.SettingsPath(homeDir),
+		adapter.MCPConfigPath(homeDir, "rtk"),
+	}
+	seen := map[string]struct{}{}
+	for _, path := range paths {
+		if path == "" {
+			continue
+		}
+		if _, ok := seen[path]; ok {
+			continue
+		}
+		seen[path] = struct{}{}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		content := strings.ToLower(string(data))
+		if strings.Contains(content, "rtk") {
+			return true, path, "found RTK hook marker"
+		}
+	}
+	return false, adapter.GlobalConfigDir(homeDir), "detected agent but no RTK hook marker was found"
 }

--- a/internal/components/communitytool/tool.go
+++ b/internal/components/communitytool/tool.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"slices"
 	"strings"
 
@@ -133,7 +134,7 @@ func InstallWithHome(id model.CommunityToolID, workspaceDir string, homeDir stri
 	case model.CommunityToolCodeGraph:
 		return installCodeGraph(workspaceDir, homeDir, runner, detector)
 	case model.CommunityToolRTK:
-		return installRTK(workspaceDir, homeDir, runner, detector)
+		return installRTK(homeDir, runner, detector)
 	default:
 		return Result{}, fmt.Errorf("community tool %q is not supported", id)
 	}
@@ -186,7 +187,7 @@ func installCodeGraph(workspaceDir string, homeDir string, runner Runner, detect
 	return result, nil
 }
 
-func installRTK(workspaceDir string, homeDir string, runner Runner, detector Detector) (Result, error) {
+func installRTK(homeDir string, runner Runner, detector Detector) (Result, error) {
 	result := Result{Tool: model.CommunityToolRTK}
 	if detector == nil {
 		detector = DetectorFunc(exec.LookPath)
@@ -215,7 +216,18 @@ func installRTK(workspaceDir string, homeDir string, runner Runner, detector Det
 	after := DetectStatus(model.CommunityToolRTK, homeDir, detector)
 	result.StatusAfter = &after
 	if after.CLI != AvailabilityAvailable {
-		return result, fmt.Errorf("RTK install did not leave the rtk CLI available")
+		// Fallback: cargo installs to ~/.cargo/bin which may not be on PATH.
+		if home, homeErr := os.UserHomeDir(); homeErr == nil {
+			cargoBin := filepath.Join(home, ".cargo", "bin", "rtk")
+			if _, statErr := os.Stat(cargoBin); statErr == nil {
+				after.CLI = AvailabilityAvailable
+				after.CLIPath = cargoBin
+				result.StatusAfter = &after
+			}
+		}
+		if after.CLI != AvailabilityAvailable {
+			return result, fmt.Errorf("RTK install did not leave the rtk CLI available")
+		}
 	}
 	result.ManualActions = append(result.ManualActions, "RTK CLI was installed. Run 'rtk init -g' in your project to configure agent hooks for token-optimized command output.")
 	return result, nil
@@ -225,15 +237,15 @@ func rtkInstallCommands(detector Detector) [][]string {
 	if detector == nil {
 		detector = DetectorFunc(exec.LookPath)
 	}
-	// Prefer cargo if available (Rust ecosystem).
+	// Prefer cargo if available (Rust ecosystem). Try crates.io first, fall back to git.
 	if _, err := detector.LookPath("cargo"); err == nil {
 		return [][]string{
-			{"cargo", "install", "--git", "https://github.com/rtk-ai/rtk"},
+			{"cargo", "install", "rtk"},
 		}
 	}
-	// Fallback: binary download from GitHub releases (platform-specific).
+	// Fallback: pinned binary download from GitHub releases.
 	return [][]string{
-		{"sh", "-c", "curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/main/install.sh | sh"},
+		{"sh", "-c", "curl -fsSL https://github.com/rtk-ai/rtk/releases/latest/download/install.sh | sh"},
 	}
 }
 
@@ -610,7 +622,7 @@ func hasRTKWiring(homeDir string, adapter agents.Adapter) (bool, string, string)
 			continue
 		}
 		content := strings.ToLower(string(data))
-		if strings.Contains(content, "rtk") {
+		if strings.Contains(content, "rtk init") || strings.Contains(content, "rtk rewrite") {
 			return true, path, "found RTK hook marker"
 		}
 	}

--- a/internal/components/communitytool/tool_test.go
+++ b/internal/components/communitytool/tool_test.go
@@ -1030,32 +1030,47 @@ func TestRTKSupportedAgents(t *testing.T) {
 	if len(agents) == 0 {
 		t.Fatal("rtkSupportedAgents() returned empty")
 	}
-	// Claude Code and OpenCode should be in the list.
-	hasClaude := false
-	hasOpenCode := false
-	for _, id := range agents {
-		if id == model.AgentClaudeCode {
-			hasClaude = true
-		}
-		if id == model.AgentOpenCode {
-			hasOpenCode = true
-		}
+	supported := []model.AgentID{
+		model.AgentClaudeCode,
+		model.AgentOpenCode,
+		model.AgentCursor,
+		model.AgentGeminiCLI,
+		model.AgentCodex,
+		model.AgentWindsurf,
+		model.AgentVSCodeCopilot,
+		model.AgentHermes,
 	}
-	if !hasClaude {
-		t.Fatal("rtkSupportedAgents() missing Claude Code")
-	}
-	if !hasOpenCode {
-		t.Fatal("rtkSupportedAgents() missing OpenCode")
+	for _, want := range supported {
+		found := false
+		for _, id := range agents {
+			if id == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("rtkSupportedAgents() missing %s", want)
+		}
 	}
 }
 
 func TestIsRTKSupportedAgent(t *testing.T) {
-	if !isRTKSupportedAgent(model.AgentClaudeCode) {
-		t.Fatal("Claude Code should be RTK supported")
+	supported := []model.AgentID{
+		model.AgentClaudeCode,
+		model.AgentOpenCode,
+		model.AgentCursor,
+		model.AgentGeminiCLI,
+		model.AgentCodex,
+		model.AgentWindsurf,
+		model.AgentVSCodeCopilot,
+		model.AgentHermes,
 	}
-	if !isRTKSupportedAgent(model.AgentOpenCode) {
-		t.Fatal("OpenCode should be RTK supported")
+	for _, id := range supported {
+		if !isRTKSupportedAgent(id) {
+			t.Errorf("isRTKSupportedAgent(%s) = false, want true", id)
+		}
 	}
+	// Pi is not RTK-supported.
 	if isRTKSupportedAgent(model.AgentPi) {
 		t.Fatal("Pi should NOT be RTK supported")
 	}

--- a/internal/components/communitytool/tool_test.go
+++ b/internal/components/communitytool/tool_test.go
@@ -883,3 +883,180 @@ func findAgentStatus(t *testing.T, status Status, id model.AgentID) AgentStatus 
 	t.Fatalf("agent %s not found in %#v", id, status.Agents)
 	return AgentStatus{}
 }
+
+// RTK tests.
+
+func TestDefinitionsIncludesRTK(t *testing.T) {
+	def, ok := DefinitionFor(model.CommunityToolRTK)
+	if !ok {
+		t.Fatal("RTK definition not found")
+	}
+	if def.CommandName != "rtk" {
+		t.Fatalf("RTK definition CommandName = %q, want %q", def.CommandName, "rtk")
+	}
+	if def.RepoURL != "https://github.com/rtk-ai/rtk" {
+		t.Fatalf("RTK definition RepoURL = %q", def.RepoURL)
+	}
+}
+
+func TestRTKInstallWhenAlreadyAvailable(t *testing.T) {
+	homeDir := t.TempDir()
+	result, err := InstallWithHome(model.CommunityToolRTK, "/work/project", homeDir, RunnerFunc(func(string, ...string) error {
+		t.Fatal("runner should not be called when RTK is already available")
+		return nil
+	}), DetectorFunc(func(name string) (string, error) {
+		if name == "rtk" {
+			return "/usr/local/bin/rtk", nil
+		}
+		return "", errors.New("not found")
+	}))
+	if err != nil {
+		t.Fatalf("Install() error = %v", err)
+	}
+	if len(result.CommandsRun) != 0 {
+		t.Fatalf("CommandsRun = %#v, want empty (already installed)", result.CommandsRun)
+	}
+	if len(result.ManualActions) == 0 || !strings.Contains(result.ManualActions[0], "already available") {
+		t.Fatalf("ManualActions = %#v, want 'already available' message", result.ManualActions)
+	}
+}
+
+func TestRTKInstallWithCargo(t *testing.T) {
+	homeDir := t.TempDir()
+	var ranCommands [][]string
+	result, err := InstallWithHome(model.CommunityToolRTK, "/work/project", homeDir, RunnerFunc(func(name string, args ...string) error {
+		ranCommands = append(ranCommands, append([]string{name}, args...))
+		return nil
+	}), DetectorFunc(func(name string) (string, error) {
+		if name == "cargo" {
+			return "/usr/bin/cargo", nil
+		}
+		if name == "rtk" {
+			// After install, rtk becomes available.
+			if len(ranCommands) > 0 {
+				return "/home/user/.cargo/bin/rtk", nil
+			}
+			return "", errors.New("not found")
+		}
+		return "", errors.New("not found")
+	}))
+	if err != nil {
+		t.Fatalf("Install() error = %v", err)
+	}
+	if len(ranCommands) != 1 {
+		t.Fatalf("runner calls = %d, want 1 (cargo install)", len(ranCommands))
+	}
+	if !strings.Contains(strings.Join(ranCommands[0], " "), "cargo install") {
+		t.Fatalf("CommandsRun = %#v, want cargo install", result.CommandsRun)
+	}
+	if len(result.ManualActions) == 0 || !strings.Contains(result.ManualActions[0], "RTK CLI was installed") {
+		t.Fatalf("ManualActions = %#v, want install success message", result.ManualActions)
+	}
+}
+
+func TestRTKInstallWithBinaryFallback(t *testing.T) {
+	homeDir := t.TempDir()
+	var ranCommands [][]string
+	result, err := InstallWithHome(model.CommunityToolRTK, "/work/project", homeDir, RunnerFunc(func(name string, args ...string) error {
+		ranCommands = append(ranCommands, append([]string{name}, args...))
+		return nil
+	}), DetectorFunc(func(name string) (string, error) {
+		if name == "cargo" {
+			return "", errors.New("not found")
+		}
+		if name == "rtk" {
+			if len(ranCommands) > 0 {
+				return "/usr/local/bin/rtk", nil
+			}
+			return "", errors.New("not found")
+		}
+		return "", errors.New("not found")
+	}))
+	if err != nil {
+		t.Fatalf("Install() error = %v", err)
+	}
+	if len(ranCommands) != 1 {
+		t.Fatalf("runner calls = %d, want 1 (binary install)", len(ranCommands))
+	}
+	if !strings.Contains(strings.Join(ranCommands[0], " "), "curl") {
+		t.Fatalf("CommandsRun = %#v, want curl install", result.CommandsRun)
+	}
+}
+
+func TestRTKInstallFailure(t *testing.T) {
+	homeDir := t.TempDir()
+	boom := errors.New("cargo failed")
+	_, err := InstallWithHome(model.CommunityToolRTK, "/work/project", homeDir, RunnerFunc(func(string, ...string) error {
+		return boom
+	}), DetectorFunc(func(name string) (string, error) {
+		if name == "cargo" {
+			return "/usr/bin/cargo", nil
+		}
+		return "", errors.New("not found")
+	}))
+	if !errors.Is(err, boom) {
+		t.Fatalf("Install() error = %v, want %v", err, boom)
+	}
+}
+
+func TestDetectStatusRTK(t *testing.T) {
+	homeDir := t.TempDir()
+	status := DetectStatus(model.CommunityToolRTK, homeDir, DetectorFunc(func(name string) (string, error) {
+		if name == "rtk" {
+			return "/usr/local/bin/rtk", nil
+		}
+		return "", errors.New("not found")
+	}))
+	if status.CLI != AvailabilityAvailable {
+		t.Fatalf("CLI = %q, want %q", status.CLI, AvailabilityAvailable)
+	}
+	if status.CLIPath != "/usr/local/bin/rtk" {
+		t.Fatalf("CLIPath = %q", status.CLIPath)
+	}
+}
+
+func TestDetectStatusRTKMissing(t *testing.T) {
+	homeDir := t.TempDir()
+	status := DetectStatus(model.CommunityToolRTK, homeDir, DetectorFunc(func(string) (string, error) {
+		return "", errors.New("not found")
+	}))
+	if status.CLI != AvailabilityMissing {
+		t.Fatalf("CLI = %q, want %q", status.CLI, AvailabilityMissing)
+	}
+}
+
+func TestRTKSupportedAgents(t *testing.T) {
+	agents := rtkSupportedAgents()
+	if len(agents) == 0 {
+		t.Fatal("rtkSupportedAgents() returned empty")
+	}
+	// Claude Code and OpenCode should be in the list.
+	hasClaude := false
+	hasOpenCode := false
+	for _, id := range agents {
+		if id == model.AgentClaudeCode {
+			hasClaude = true
+		}
+		if id == model.AgentOpenCode {
+			hasOpenCode = true
+		}
+	}
+	if !hasClaude {
+		t.Fatal("rtkSupportedAgents() missing Claude Code")
+	}
+	if !hasOpenCode {
+		t.Fatal("rtkSupportedAgents() missing OpenCode")
+	}
+}
+
+func TestIsRTKSupportedAgent(t *testing.T) {
+	if !isRTKSupportedAgent(model.AgentClaudeCode) {
+		t.Fatal("Claude Code should be RTK supported")
+	}
+	if !isRTKSupportedAgent(model.AgentOpenCode) {
+		t.Fatal("OpenCode should be RTK supported")
+	}
+	if isRTKSupportedAgent(model.AgentPi) {
+		t.Fatal("Pi should NOT be RTK supported")
+	}
+}

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -179,6 +179,7 @@ type CommunityToolID string
 
 const (
 	CommunityToolCodeGraph CommunityToolID = "codegraph"
+	CommunityToolRTK       CommunityToolID = "rtk"
 )
 
 // Profile represents a named SDD orchestrator configuration with model assignments.


### PR DESCRIPTION
## Summary
- Adds RTK (Rust Token Killer) as a community tool following the CodeGraph pattern
- Generalizes the install/detect dispatch so new tools can be added without hard-coded guards
- RTK reduces LLM token consumption by 60-90% on common dev commands (git, ls, test runners, etc.)

## Changes
- `internal/model/types.go`: Add `CommunityToolRTK` constant
- `internal/components/communitytool/tool.go`:
  - Add RTK definition to registry
  - Refactor `InstallWithHome()` to dispatch per tool ID (removes CodeGraph-only hard guard)
  - Refactor `DetectStatus()` to dispatch per tool ID
  - Add `installRTK()` with cargo-first, binary-fallback install strategy
  - Add `detectRTKAgents()`, `rtkSupportedAgents()`, `hasRTKWiring()` for agent detection
- `internal/components/communitytool/tool_test.go`: Add 9 RTK tests

## Supported Agents
Claude Code, OpenCode, Cursor, Gemini CLI, Codex, Windsurf, Copilot, Hermes

## Install Strategy
1. Check if `rtk` binary already exists → skip install
2. If `cargo` is available → `cargo install --git https://github.com/rtk-ai/rtk`
3. Fallback → binary download via install script

## Test Results
- `go test ./...`: 3953 passed in 54 packages (9 new RTK tests)

Closes #1050

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new community tool, RTK, including installation and status detection.
  * Expanded tool status checks to show when RTK is already available and provide setup guidance.

* **Bug Fixes**
  * Improved tool-specific handling so installation and detection now behave correctly for both supported tools.
  * Added clearer fallback behavior when one installation method is unavailable.

* **Tests**
  * Added coverage for RTK installation, availability detection, and supported agent checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->