### PR TITLE
feat(opencode): set gentle-orchestrator as default_agent in managed config

### DIFF
--- a/internal/assets/opencode/sdd-overlay-multi.json
+++ b/internal/assets/opencode/sdd-overlay-multi.json
@@ -1,4 +1,5 @@
 {
+  "default_agent": "gentle-orchestrator",
   "agent": {
     "gentle-orchestrator": {
       "mode": "primary",

--- a/internal/assets/opencode/sdd-overlay-single.json
+++ b/internal/assets/opencode/sdd-overlay-single.json
@@ -1,4 +1,5 @@
 {
+  "default_agent": "gentle-orchestrator",
   "agent": {
     "gentle-orchestrator": {
       "mode": "primary",

--- a/testdata/golden/sdd-opencode-multi-settings.golden
+++ b/testdata/golden/sdd-opencode-multi-settings.golden
@@ -1,4 +1,5 @@
 {
+  "default_agent": "gentle-orchestrator",
   "agent": {
     "gentle-orchestrator": {
       "description": "Gentle AI SDD Orchestrator - coordinates sub-agents, never does work inline",


### PR DESCRIPTION
Closes #1054

### PR Type
- [x] New feature
- [ ] Bug fix
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

### Summary
Sets `gentle-orchestrator` as the default agent in OpenCode managed config. This eliminates the need for users to manually switch agents at startup.

### Changes Table
| File | Change |
|------|--------|
| `internal/assets/opencode/sdd-overlay-single.json` | Added `default_agent: gentle-orchestrator` to overlay |
| `internal/assets/opencode/sdd-overlay-multi.json` | Added `default_agent: gentle-orchestrator` to overlay |
| `testdata/golden/sdd-opencode-multi-settings.golden` | Updated golden settings file |

### Test Plan
- [x] Verified overlay schema allows `default_agent`.
- [x] Golden file updated and aligned with tests.

### Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran shellcheck on modified scripts (N/A)
- [x] Skills tested in at least one agent (N/A)
- [x] Docs updated if behavior changed (N/A)
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Set a default agent for SDD overlays, making the experience more consistent when opening or using these configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->