### PR TITLE
fix(update): require active Homebrew ownership

### DIFF
--- a/internal/update/check_test.go
+++ b/internal/update/check_test.go
@@ -977,17 +977,28 @@ func TestCheckFiltered_FetchErrorPreservesCheckFailedForMissingTool(t *testing.T
 // --- TestUpdateHint ---
 
 func TestUpdateHint(t *testing.T) {
+	origHomebrewPackageInstalled := homebrewPackageInstalled
+	t.Cleanup(func() { homebrewPackageInstalled = origHomebrewPackageInstalled })
+
 	tests := []struct {
-		name    string
-		tool    ToolInfo
-		profile system.PlatformProfile
-		want    string
+		name          string
+		tool          ToolInfo
+		profile       system.PlatformProfile
+		brewInstalled bool
+		want          string
 	}{
 		{
-			name:    "gentle-ai macOS",
+			name:          "gentle-ai macOS brew-owned",
+			tool:          ToolInfo{Name: "gentle-ai"},
+			profile:       system.PlatformProfile{OS: "darwin", PackageManager: "brew"},
+			brewInstalled: true,
+			want:          "brew upgrade gentle-ai",
+		},
+		{
+			name:    "gentle-ai macOS non-brew",
 			tool:    ToolInfo{Name: "gentle-ai"},
 			profile: system.PlatformProfile{OS: "darwin", PackageManager: "brew"},
-			want:    "brew upgrade gentle-ai",
+			want:    "gentle-ai upgrade (downloads pre-built binary)",
 		},
 		{
 			name:    "gentle-ai linux",
@@ -1002,10 +1013,17 @@ func TestUpdateHint(t *testing.T) {
 			want:    "irm https://raw.githubusercontent.com/Gentleman-Programming/gentle-ai/main/scripts/install.ps1 | iex",
 		},
 		{
-			name:    "engram macOS brew",
+			name:          "engram macOS brew-owned",
+			tool:          ToolInfo{Name: "engram"},
+			profile:       system.PlatformProfile{OS: "darwin", PackageManager: "brew"},
+			brewInstalled: true,
+			want:          "brew upgrade engram",
+		},
+		{
+			name:    "engram macOS non-brew",
 			tool:    ToolInfo{Name: "engram"},
 			profile: system.PlatformProfile{OS: "darwin", PackageManager: "brew"},
-			want:    "brew upgrade engram",
+			want:    "gentle-ai upgrade (downloads pre-built binary)",
 		},
 		{
 			name:    "engram linux",
@@ -1020,10 +1038,17 @@ func TestUpdateHint(t *testing.T) {
 			want:    "gentle-ai upgrade (downloads pre-built binary)",
 		},
 		{
-			name:    "gga macOS brew",
+			name:          "gga macOS brew-owned",
+			tool:          ToolInfo{Name: "gga"},
+			profile:       system.PlatformProfile{OS: "darwin", PackageManager: "brew"},
+			brewInstalled: true,
+			want:          "brew upgrade gga",
+		},
+		{
+			name:    "gga macOS non-brew",
 			tool:    ToolInfo{Name: "gga"},
 			profile: system.PlatformProfile{OS: "darwin", PackageManager: "brew"},
-			want:    "brew upgrade gga",
+			want:    "See https://github.com/Gentleman-Programming/gentleman-guardian-angel",
 		},
 		{
 			name:    "gga linux",
@@ -1041,11 +1066,47 @@ func TestUpdateHint(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			homebrewPackageInstalled = func(toolName string) bool {
+				return toolName == tc.tool.Name && tc.brewInstalled
+			}
+
 			got := updateHint(tc.tool, tc.profile)
 			if got != tc.want {
 				t.Fatalf("updateHint(%q, %q) = %q, want %q", tc.tool.Name, tc.profile.OS, got, tc.want)
 			}
 		})
+	}
+}
+
+func TestHomebrewPackageInstalledWithRequiresActiveBrewPath(t *testing.T) {
+	brewPrefix := filepath.Join(t.TempDir(), "opt", "gentle-ai")
+	brewBin := filepath.Join(brewPrefix, "bin", "gentle-ai")
+	nonBrewBin := filepath.Join(t.TempDir(), "gentle-ai")
+
+	run := func(name string, args ...string) *exec.Cmd {
+		if name != "brew" {
+			return mockCmd("false")
+		}
+		if len(args) >= 3 && args[0] == "list" && args[1] == "--formula" && args[2] == "gentle-ai" {
+			return mockCmd("true")
+		}
+		if len(args) == 2 && args[0] == "--prefix" && args[1] == "gentle-ai" {
+			return mockCmd("echo", brewPrefix)
+		}
+		return mockCmd("false")
+	}
+
+	if !homebrewPackageInstalledWith(run, func(string) (string, error) { return brewBin, nil }, "gentle-ai") {
+		t.Fatal("expected brew-owned active path to be treated as Homebrew installed")
+	}
+	if homebrewPackageInstalledWith(run, func(string) (string, error) { return nonBrewBin, nil }, "gentle-ai") {
+		t.Fatal("expected shadowing non-brew active path to avoid Homebrew")
+	}
+	if homebrewPackageInstalledWith(func(string, ...string) *exec.Cmd { return mockCmd("false") }, func(string) (string, error) { return brewBin, nil }, "gentle-ai") {
+		t.Fatal("expected brew list failure to avoid Homebrew")
+	}
+	if homebrewPackageInstalledWith(func(string, ...string) *exec.Cmd { return mockCmd("true") }, func(string) (string, error) { return "", fmt.Errorf("not found") }, "gentle-ai") {
+		t.Fatal("expected active path lookup failure to avoid Homebrew")
 	}
 }
 

--- a/internal/update/homebrew.go
+++ b/internal/update/homebrew.go
@@ -1,0 +1,59 @@
+package update
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+var homebrewPackageInstalled = defaultHomebrewPackageInstalled
+
+type commandRunner func(string, ...string) *exec.Cmd
+type pathResolver func(string) (string, error)
+
+func defaultHomebrewPackageInstalled(toolName string) bool {
+	return homebrewPackageInstalledWith(execCommand, lookPath, toolName)
+}
+
+func homebrewPackageInstalledWith(run commandRunner, resolvePath pathResolver, toolName string) bool {
+	if toolName == "" {
+		return false
+	}
+	if run("brew", "list", "--formula", toolName).Run() != nil {
+		return false
+	}
+
+	brewPrefixOutput, err := run("brew", "--prefix", toolName).Output()
+	if err != nil {
+		return false
+	}
+	brewPrefix := strings.TrimSpace(string(brewPrefixOutput))
+	if brewPrefix == "" {
+		return false
+	}
+
+	activePath, err := resolvePath(toolName)
+	if err != nil || activePath == "" {
+		return false
+	}
+
+	return pathWithinPrefix(activePath, brewPrefix)
+}
+
+func pathWithinPrefix(path, prefix string) bool {
+	resolvedPath, err := filepath.EvalSymlinks(path)
+	if err == nil {
+		path = resolvedPath
+	}
+	resolvedPrefix, err := filepath.EvalSymlinks(prefix)
+	if err == nil {
+		prefix = resolvedPrefix
+	}
+
+	path = filepath.Clean(path)
+	prefix = filepath.Clean(prefix)
+	if path == prefix {
+		return true
+	}
+	return strings.HasPrefix(path, prefix+string(filepath.Separator))
+}

--- a/internal/update/instructions.go
+++ b/internal/update/instructions.go
@@ -32,11 +32,15 @@ func openCodeRegisteredNotMaterializedHint(tool ToolInfo) string {
 }
 
 func gentleAIHint(profile system.PlatformProfile) string {
-	switch profile.OS {
-	case "darwin":
+	if profile.PackageManager == "brew" && homebrewPackageInstalled("gentle-ai") {
 		return "brew upgrade gentle-ai"
+	}
+
+	switch profile.OS {
 	case "linux":
 		return "curl -fsSL https://raw.githubusercontent.com/Gentleman-Programming/gentle-ai/main/scripts/install.sh | bash"
+	case "darwin":
+		return "gentle-ai upgrade (downloads pre-built binary)"
 	case "windows":
 		return "irm https://raw.githubusercontent.com/Gentleman-Programming/gentle-ai/main/scripts/install.ps1 | iex"
 	default:
@@ -45,19 +49,15 @@ func gentleAIHint(profile system.PlatformProfile) string {
 }
 
 func engramHint(profile system.PlatformProfile) string {
-	switch profile.PackageManager {
-	case "brew":
+	if profile.PackageManager == "brew" && homebrewPackageInstalled("engram") {
 		return "brew upgrade engram"
-	default:
-		return "gentle-ai upgrade (downloads pre-built binary)"
 	}
+	return "gentle-ai upgrade (downloads pre-built binary)"
 }
 
 func ggaHint(profile system.PlatformProfile) string {
-	switch profile.PackageManager {
-	case "brew":
+	if profile.PackageManager == "brew" && homebrewPackageInstalled("gga") {
 		return "brew upgrade gga"
-	default:
-		return "See https://github.com/Gentleman-Programming/gentleman-guardian-angel"
 	}
+	return "See https://github.com/Gentleman-Programming/gentleman-guardian-angel"
 }

--- a/internal/update/registry.go
+++ b/internal/update/registry.go
@@ -6,13 +6,14 @@ import (
 
 // Tools is the static registry of managed tools that can be checked for updates.
 //
-// InstallMethod controls which upgrade strategy the executor uses:
-//   - InstallBrew: managed via homebrew (macOS/Linux with brew)
+// InstallMethod controls which non-Homebrew upgrade strategy the executor uses:
+//   - InstallBrew: explicitly managed via Homebrew
 //   - InstallGoInstall: installed via `go install <GoImportPath>@version`
 //   - InstallBinary: downloaded binary from GitHub Releases (atomic replace)
 //
-// For brew-managed platforms the executor picks brew regardless of the
-// field here; InstallMethod represents the non-brew fallback strategy.
+// On platforms where Homebrew is available, the executor selects brew only
+// when Homebrew confirms it owns the specific tool. Otherwise this field is
+// the fallback strategy.
 var Tools = []ToolInfo{
 	{
 		Name:          "gentle-ai",
@@ -20,7 +21,7 @@ var Tools = []ToolInfo{
 		Repo:          "gentle-ai",
 		DetectCmd:     nil, // version comes from build-time ldflags (app.Version)
 		VersionPrefix: "v",
-		// gentle-ai: brew on macOS, binary release download on Linux.
+		// gentle-ai: Homebrew when the package is brew-owned, binary release download otherwise.
 		// Windows self-upgrade uses the PowerShell installer so the running binary can exit before replacement.
 		InstallMethod: InstallBinary,
 	},
@@ -31,7 +32,7 @@ var Tools = []ToolInfo{
 		DetectCmd:         []string{"engram", "version"},
 		VersionPrefix:     "v",
 		ReleaseTagPattern: `^v[0-9]+\.[0-9]+\.[0-9]+$`,
-		// engram: brew on macOS/Linux-brew, binary download elsewhere.
+		// engram: Homebrew when the package is brew-owned, binary download elsewhere.
 		InstallMethod: InstallBinary,
 		// FallbackPaths covers the Windows stale-PATH scenario (and Linux ~/.local/bin
 		// when not yet in PATH): AddToUserPath updates the registry/profile but the
@@ -60,7 +61,7 @@ var Tools = []ToolInfo{
 		Repo:          "gentleman-guardian-angel",
 		DetectCmd:     []string{"gga", "--version"},
 		VersionPrefix: "v",
-		// gga: brew on macOS, install.sh script on Linux/Windows.
+		// gga: Homebrew when the package is brew-owned, install.sh script elsewhere.
 		// GGA does not publish pre-built release binary assets — only source archives.
 		// Using InstallScript runs curl | bash via the project's install.sh.
 		InstallMethod: InstallScript,

--- a/internal/update/upgrade/executor.go
+++ b/internal/update/upgrade/executor.go
@@ -600,10 +600,10 @@ func executeOne(ctx context.Context, r update.UpdateResult, profile system.Platf
 }
 
 // effectiveMethod resolves the actual upgrade strategy for a tool on a given platform.
-// Priority order matches the documented install hierarchy: plugin → brew → Windows installer → go-install → declared method.
+// Priority order matches the documented install hierarchy: plugin → brew-owned package → Windows installer → go-install → declared method.
 //
 //  1. OpenCode plugins are always handled by their own method — never overridden.
-//  2. Brew-managed platforms always use brew regardless of the tool's declared method.
+//  2. Homebrew is used only when Homebrew confirms it owns this specific tool.
 //  3. gentle-ai on Windows uses the installer so the running binary can exit before replacement.
 //  4. When Go is available on PATH and the tool has a GoImportPath, go-install is
 //     preferred over a direct binary download.
@@ -612,7 +612,7 @@ func effectiveMethod(tool update.ToolInfo, profile system.PlatformProfile) updat
 	if tool.InstallMethod == update.InstallOpenCodePlugin {
 		return update.InstallOpenCodePlugin
 	}
-	if profile.PackageManager == "brew" {
+	if profile.PackageManager == "brew" && homebrewPackageInstalled(tool.Name) {
 		return update.InstallBrew
 	}
 	// Use installer method for gentle-ai on Windows (launches PowerShell installer).

--- a/internal/update/upgrade/homebrew.go
+++ b/internal/update/upgrade/homebrew.go
@@ -1,0 +1,59 @@
+package upgrade
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+var homebrewPackageInstalled = defaultHomebrewPackageInstalled
+
+type commandRunner func(string, ...string) *exec.Cmd
+type pathResolver func(string) (string, error)
+
+func defaultHomebrewPackageInstalled(toolName string) bool {
+	return homebrewPackageInstalledWith(execCommand, lookPathCommand, toolName)
+}
+
+func homebrewPackageInstalledWith(run commandRunner, resolvePath pathResolver, toolName string) bool {
+	if toolName == "" {
+		return false
+	}
+	if run("brew", "list", "--formula", toolName).Run() != nil {
+		return false
+	}
+
+	brewPrefixOutput, err := run("brew", "--prefix", toolName).Output()
+	if err != nil {
+		return false
+	}
+	brewPrefix := strings.TrimSpace(string(brewPrefixOutput))
+	if brewPrefix == "" {
+		return false
+	}
+
+	activePath, err := resolvePath(toolName)
+	if err != nil || activePath == "" {
+		return false
+	}
+
+	return pathWithinPrefix(activePath, brewPrefix)
+}
+
+func pathWithinPrefix(path, prefix string) bool {
+	resolvedPath, err := filepath.EvalSymlinks(path)
+	if err == nil {
+		path = resolvedPath
+	}
+	resolvedPrefix, err := filepath.EvalSymlinks(prefix)
+	if err == nil {
+		prefix = resolvedPrefix
+	}
+
+	path = filepath.Clean(path)
+	prefix = filepath.Clean(prefix)
+	if path == prefix {
+		return true
+	}
+	return strings.HasPrefix(path, prefix+string(filepath.Separator))
+}

--- a/internal/update/upgrade/strategy_test.go
+++ b/internal/update/upgrade/strategy_test.go
@@ -348,29 +348,48 @@ func TestEffectiveMethod_NonGentleAIToolsOnWindowsUseBinary(t *testing.T) {
 // --- TestEffectiveMethod ---
 
 func TestEffectiveMethod(t *testing.T) {
+	origHomebrewPackageInstalled := homebrewPackageInstalled
+	t.Cleanup(func() { homebrewPackageInstalled = origHomebrewPackageInstalled })
+
 	tests := []struct {
-		name    string
-		tool    update.ToolInfo
-		profile system.PlatformProfile
-		want    update.InstallMethod
+		name          string
+		tool          update.ToolInfo
+		profile       system.PlatformProfile
+		brewInstalled bool
+		want          update.InstallMethod
 	}{
 		{
-			name:    "brew profile overrides go-install",
-			tool:    update.ToolInfo{Name: "engram", InstallMethod: update.InstallGoInstall},
-			profile: system.PlatformProfile{PackageManager: "brew"},
-			want:    update.InstallBrew,
+			name:          "brew-owned package overrides go-install",
+			tool:          update.ToolInfo{Name: "engram", InstallMethod: update.InstallGoInstall},
+			profile:       system.PlatformProfile{PackageManager: "brew"},
+			brewInstalled: true,
+			want:          update.InstallBrew,
 		},
 		{
-			name:    "brew profile overrides binary",
-			tool:    update.ToolInfo{Name: "gga", InstallMethod: update.InstallBinary},
-			profile: system.PlatformProfile{PackageManager: "brew"},
-			want:    update.InstallBrew,
+			name:          "brew-owned package overrides binary",
+			tool:          update.ToolInfo{Name: "gga", InstallMethod: update.InstallBinary},
+			profile:       system.PlatformProfile{PackageManager: "brew"},
+			brewInstalled: true,
+			want:          update.InstallBrew,
 		},
 		{
-			name:    "brew profile overrides script",
-			tool:    update.ToolInfo{Name: "gga", InstallMethod: update.InstallScript},
-			profile: system.PlatformProfile{PackageManager: "brew"},
-			want:    update.InstallBrew,
+			name:          "brew-owned package overrides script",
+			tool:          update.ToolInfo{Name: "gga", InstallMethod: update.InstallScript},
+			profile:       system.PlatformProfile{PackageManager: "brew"},
+			brewInstalled: true,
+			want:          update.InstallBrew,
+		},
+		{
+			name:    "brew profile without package ownership respects declared method",
+			tool:    update.ToolInfo{Name: "gentle-ai", InstallMethod: update.InstallBinary},
+			profile: system.PlatformProfile{OS: "darwin", PackageManager: "brew"},
+			want:    update.InstallBinary,
+		},
+		{
+			name:    "brew profile without package ownership can use go-install fallback",
+			tool:    update.ToolInfo{Name: "mytool", InstallMethod: update.InstallBinary, GoImportPath: "github.com/example/mytool/cmd/mytool"},
+			profile: system.PlatformProfile{PackageManager: "brew", GoAvailable: true},
+			want:    update.InstallGoInstall,
 		},
 		{
 			name:    "apt profile respects declared method (go-install)",
@@ -391,17 +410,19 @@ func TestEffectiveMethod(t *testing.T) {
 			want:    update.InstallScript,
 		},
 		{
-			name:    "brew profile does not override OpenCode plugin method",
-			tool:    update.ToolInfo{Name: "opencode-subagent-statusline", InstallMethod: update.InstallOpenCodePlugin, NpmPackage: "opencode-subagent-statusline"},
-			profile: system.PlatformProfile{PackageManager: "brew"},
-			want:    update.InstallOpenCodePlugin,
+			name:          "brew profile does not override OpenCode plugin method",
+			tool:          update.ToolInfo{Name: "opencode-subagent-statusline", InstallMethod: update.InstallOpenCodePlugin, NpmPackage: "opencode-subagent-statusline"},
+			profile:       system.PlatformProfile{PackageManager: "brew"},
+			brewInstalled: true,
+			want:          update.InstallOpenCodePlugin,
 		},
-		// Auto-detect order: brew → go-install → binary (issue #246).
+		// Auto-detect order: brew-owned package → go-install → binary (issue #246).
 		{
-			name:    "auto-detect: brew available → brew wins regardless of GoImportPath",
-			tool:    update.ToolInfo{Name: "mytool", InstallMethod: update.InstallBinary, GoImportPath: "github.com/example/mytool/cmd/mytool"},
-			profile: system.PlatformProfile{PackageManager: "brew", GoAvailable: true},
-			want:    update.InstallBrew,
+			name:          "auto-detect: brew-owned package wins regardless of GoImportPath",
+			tool:          update.ToolInfo{Name: "mytool", InstallMethod: update.InstallBinary, GoImportPath: "github.com/example/mytool/cmd/mytool"},
+			profile:       system.PlatformProfile{PackageManager: "brew", GoAvailable: true},
+			brewInstalled: true,
+			want:          update.InstallBrew,
 		},
 		{
 			name:    "auto-detect: brew missing + go available + GoImportPath set → go-install",
@@ -425,11 +446,47 @@ func TestEffectiveMethod(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			homebrewPackageInstalled = func(toolName string) bool {
+				return toolName == tc.tool.Name && tc.brewInstalled
+			}
+
 			got := effectiveMethod(tc.tool, tc.profile)
 			if got != tc.want {
 				t.Errorf("effectiveMethod = %q, want %q", got, tc.want)
 			}
 		})
+	}
+}
+
+func TestHomebrewPackageInstalledWithRequiresActiveBrewPath(t *testing.T) {
+	brewPrefix := filepath.Join(t.TempDir(), "opt", "gentle-ai")
+	brewBin := filepath.Join(brewPrefix, "bin", "gentle-ai")
+	nonBrewBin := filepath.Join(t.TempDir(), "gentle-ai")
+
+	run := func(name string, args ...string) *exec.Cmd {
+		if name != "brew" {
+			return mockCmd("false")
+		}
+		if len(args) >= 3 && args[0] == "list" && args[1] == "--formula" && args[2] == "gentle-ai" {
+			return mockCmd("true")
+		}
+		if len(args) == 2 && args[0] == "--prefix" && args[1] == "gentle-ai" {
+			return mockCmd("echo", brewPrefix)
+		}
+		return mockCmd("false")
+	}
+
+	if !homebrewPackageInstalledWith(run, func(string) (string, error) { return brewBin, nil }, "gentle-ai") {
+		t.Fatal("expected brew-owned active path to be treated as Homebrew installed")
+	}
+	if homebrewPackageInstalledWith(run, func(string) (string, error) { return nonBrewBin, nil }, "gentle-ai") {
+		t.Fatal("expected shadowing non-brew active path to avoid Homebrew")
+	}
+	if homebrewPackageInstalledWith(func(string, ...string) *exec.Cmd { return mockCmd("false") }, func(string) (string, error) { return brewBin, nil }, "gentle-ai") {
+		t.Fatal("expected brew list failure to avoid Homebrew")
+	}
+	if homebrewPackageInstalledWith(func(string, ...string) *exec.Cmd { return mockCmd("true") }, func(string) (string, error) { return "", errors.New("not found") }, "gentle-ai") {
+		t.Fatal("expected active path lookup failure to avoid Homebrew")
 	}
 }
 
@@ -1489,10 +1546,10 @@ func TestInstallerUpgradeArgs(t *testing.T) {
 	const tmpPath = `C:\Users\user\AppData\Local\Temp\gentle-ai-install-12345.ps1`
 
 	tests := []struct {
-		name          string
-		beta          bool
-		wantContains  []string
-		wantAbsent    []string
+		name         string
+		beta         bool
+		wantContains []string
+		wantAbsent   []string
 	}{
 		{
 			name: "stable upgrade does not include -Channel beta",


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1056

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Require active Homebrew ownership before suggesting or selecting `brew upgrade` for managed tools.
- Prevent macOS/Homebrew availability from overriding non-brew installs such as `~/.local/bin` or shadowed binaries.
- Add regression coverage for brew-owned, shadowed, and degraded lookup paths.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/update/homebrew.go` | Add formula ownership plus active binary prefix validation for update hints. |
| `internal/update/upgrade/homebrew.go` | Add the same ownership validation for upgrade method selection. |
| `internal/update/instructions.go` | Gate brew hints on verified active Homebrew ownership. |
| `internal/update/upgrade/executor.go` | Gate brew upgrade strategy on verified active Homebrew ownership. |
| `internal/update/*_test.go` | Add regression tests for brew-owned, shadowed, and failure fallback behavior. |

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./internal/update ./internal/update/upgrade ./internal/app
go test -count=1 ./internal/update ./internal/update/upgrade ./internal/app
```

**E2E Tests** (Docker required)
```bash
cd e2e && ./docker-test.sh
```

- [x] Targeted unit tests pass (`go test ./internal/update ./internal/update/upgrade ./internal/app`)
- [ ] Full unit tests pass (`go test ./...`) — covered by CI
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — covered by CI
- [x] Manually tested locally

Manual testing:
```bash
go run -ldflags='-X main.version=1.44.0' ./cmd/gentle-ai upgrade gentle-ai --dry-run
# verified: Upgrading gentle-ai via binary, not brew
```

---

## 🤖 Automated Checks

The following checks run automatically on this PR:

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | PR should stay within 400 changed lines (`additions + deletions`) or use `size:exception` |
| Check Issue Reference | ⏳ | PR body must contain `Closes/Fixes/Resolves #N` |
| Check Issue Has `status:approved` | ⏳ | Linked issue must have been approved before work began |
| Check PR Has `type:*` Label | ⏳ | Exactly one `type:*` label must be applied |
| Unit Tests | ⏳ | `go test ./...` must pass |
| E2E Tests | ⏳ | `cd e2e && ./docker-test.sh` must pass |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [x] I have added the appropriate `type:*` label to this PR
- [x] Targeted unit tests pass (`go test ./internal/update ./internal/update/upgrade ./internal/app`)
- [ ] Full unit tests pass (`go test ./...`) — covered by CI
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — covered by CI
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

This intentionally treats Homebrew ownership as verified only when the package is installed as a formula and the active executable resolves under that formula prefix. If Homebrew is installed but the active tool is shadowed by `~/.local/bin` or `~/go/bin`, the updater falls back to the non-brew method instead of mutating the wrong install.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Update checks now better detect when tools were installed through Homebrew, so upgrade suggestions can match the installation method more accurately.
  * Homebrew-managed tools may now receive `brew upgrade` guidance when that is the appropriate path.

* **Bug Fixes**
  * Improved upgrade behavior for Homebrew environments where a tool may be shadowed by another binary on the system.
  * Refined fallback update hints for non-Homebrew installations to avoid misleading instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->