### PR TITLE
feat(community-tool): version-aware upgrade/reconcile for CodeGraph

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ dist/
 # Engram local runtime state (project sync chunks are intentionally versioned)
 .engram/engram.db
 .engram/cloud.json
+.engram/chunks/
+
+# Node package lock (used for local npm experiments)
+package-lock.json

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -57,7 +57,6 @@ var (
 	cmdLookPath                  = exec.LookPath
 	streamCommandOutput          = true
 	goEnv                        = defaultGoEnv
-	installCommunityTool         = communitytool.Install
 	installCommunityToolWithHome = communitytool.InstallWithHome
 	pathEnvEntries               = func(profile system.PlatformProfile) []string {
 		return splitPathForOS(os.Getenv("PATH"), profile.OS)
@@ -523,7 +522,7 @@ func (r *installRuntime) stagePlan() pipeline.StagePlan {
 	}
 
 	for _, tool := range r.selection.CommunityTools {
-		apply = append(apply, communityToolInstallStep{id: "community-tool:" + string(tool), tool: tool, workspaceDir: r.workspaceDir, homeDir: r.homeDir, state: r.state})
+		apply = append(apply, communityToolInstallStep{id: "community-tool:" + string(tool), tool: tool, workspaceDir: r.workspaceDir, homeDir: r.homeDir, state: r.state, force: false})
 	}
 
 	for _, component := range r.resolved.OrderedComponents {
@@ -762,12 +761,13 @@ type communityToolInstallStep struct {
 	workspaceDir string
 	homeDir      string
 	state        *runtimeState
+	force        bool
 }
 
 func (s communityToolInstallStep) ID() string { return s.id }
 
 func (s communityToolInstallStep) Run() error {
-	result, err := installCommunityToolWithHome(s.tool, s.workspaceDir, s.homeDir, communitytool.RunnerFunc(runCommand), communitytool.DetectorFunc(cmdLookPath))
+	result, err := installCommunityToolWithHome(s.tool, s.workspaceDir, s.homeDir, communitytool.RunnerFunc(runCommand), communitytool.DetectorFunc(cmdLookPath), s.force)
 	if err != nil {
 		return fmt.Errorf("install community tool %q: %w", s.tool, err)
 	}

--- a/internal/cli/run_community_tool_test.go
+++ b/internal/cli/run_community_tool_test.go
@@ -409,19 +409,21 @@ func TestCommunityToolInstallStepUsesInjectableInstaller(t *testing.T) {
 	var gotTool model.CommunityToolID
 	var gotWorkspace string
 	var runner communitytool.Runner
-	installCommunityToolWithHome = func(tool model.CommunityToolID, workspaceDir string, _ string, r communitytool.Runner, _ communitytool.Detector) (communitytool.Result, error) {
+	var gotForce bool
+	installCommunityToolWithHome = func(tool model.CommunityToolID, workspaceDir string, _ string, r communitytool.Runner, _ communitytool.Detector, force bool) (communitytool.Result, error) {
 		gotTool = tool
 		gotWorkspace = workspaceDir
 		runner = r
+		gotForce = force
 		return communitytool.Result{Tool: tool}, nil
 	}
 
-	step := communityToolInstallStep{id: "community-tool:codegraph", tool: model.CommunityToolCodeGraph, workspaceDir: "/work/project"}
+	step := communityToolInstallStep{id: "community-tool:codegraph", tool: model.CommunityToolCodeGraph, workspaceDir: "/work/project", force: false}
 	if err := step.Run(); err != nil {
 		t.Fatalf("Run() error = %v", err)
 	}
-	if gotTool != model.CommunityToolCodeGraph || gotWorkspace != "/work/project" || runner == nil {
-		t.Fatalf("installer args = (%q, %q, %#v), want CodeGraph, workspace, runner", gotTool, gotWorkspace, runner)
+	if gotTool != model.CommunityToolCodeGraph || gotWorkspace != "/work/project" || runner == nil || gotForce {
+		t.Fatalf("installer args = (%q, %q, %#v, %v), want CodeGraph, workspace, runner, false", gotTool, gotWorkspace, runner, gotForce)
 	}
 }
 
@@ -429,7 +431,7 @@ func TestCommunityToolInstallStepPassesRuntimeHomeToPiReconciler(t *testing.T) {
 	previous := installCommunityToolWithHome
 	t.Cleanup(func() { installCommunityToolWithHome = previous })
 	var gotHome string
-	installCommunityToolWithHome = func(_ model.CommunityToolID, _ string, home string, _ communitytool.Runner, _ communitytool.Detector) (communitytool.Result, error) {
+	installCommunityToolWithHome = func(_ model.CommunityToolID, _ string, home string, _ communitytool.Runner, _ communitytool.Detector, _ bool) (communitytool.Result, error) {
 		gotHome = home
 		return communitytool.Result{Tool: model.CommunityToolCodeGraph}, nil
 	}
@@ -446,7 +448,7 @@ func TestInstallPipelinePropagatesInitialPiPendingWhenPiUnselected(t *testing.T)
 	previous := installCommunityToolWithHome
 	t.Cleanup(func() { installCommunityToolWithHome = previous })
 	pending := communitytool.PiCodeGraphResult{ManualActions: []string{"Pi CodeGraph runtime verification is pending."}}
-	installCommunityToolWithHome = func(_ model.CommunityToolID, _ string, _ string, _ communitytool.Runner, _ communitytool.Detector) (communitytool.Result, error) {
+	installCommunityToolWithHome = func(_ model.CommunityToolID, _ string, _ string, _ communitytool.Runner, _ communitytool.Detector, _ bool) (communitytool.Result, error) {
 		return communitytool.Result{Tool: model.CommunityToolCodeGraph, PiCodeGraph: &pending}, nil
 	}
 	runtime := &installRuntime{
@@ -473,7 +475,7 @@ func TestInstallPipelineDoesNotDuplicatePiPendingWhenSelected(t *testing.T) {
 		reconcilePiCodeGraph = previousReconcile
 	})
 	pending := communitytool.PiCodeGraphResult{ManualActions: []string{"Pi CodeGraph integration is pending: Pi 0.80.6 has no supported machine-verifiable adapter health signal. CodeGraph capability was not reported as configured."}}
-	installCommunityToolWithHome = func(_ model.CommunityToolID, _ string, _ string, _ communitytool.Runner, _ communitytool.Detector) (communitytool.Result, error) {
+	installCommunityToolWithHome = func(_ model.CommunityToolID, _ string, _ string, _ communitytool.Runner, _ communitytool.Detector, _ bool) (communitytool.Result, error) {
 		return communitytool.Result{Tool: model.CommunityToolCodeGraph, PiCodeGraph: &pending}, nil
 	}
 	reconcilePiCodeGraph = func(communitytool.PiCodeGraphOptions) (communitytool.PiCodeGraphResult, error) {

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -42,6 +42,7 @@ type SyncFlags struct {
 	StrictTDD          bool
 	IncludePermissions bool
 	IncludeTheme       bool
+	ForceCommunityTools bool
 	DryRun             bool
 	// Profiles holds named SDD profiles parsed from --profile flags.
 	// Each entry is populated by parseProfileFlag and augmented by
@@ -90,6 +91,7 @@ func ParseSyncFlags(args []string) (SyncFlags, error) {
 	fs.BoolVar(&opts.StrictTDD, "strict-tdd", false, "enable strict TDD mode for SDD agents (RED → GREEN → REFACTOR)")
 	fs.BoolVar(&opts.IncludePermissions, "include-permissions", false, "include permissions component in sync")
 	fs.BoolVar(&opts.IncludeTheme, "include-theme", false, "include theme component in sync")
+	fs.BoolVar(&opts.ForceCommunityTools, "force-community-tools", false, "force reinstall/upgrade of community tools during sync")
 	fs.BoolVar(&opts.DryRun, "dry-run", false, "preview plan without executing")
 	registerListFlag(fs, "profile", &opts.rawProfiles)
 	registerListFlag(fs, "profile-phase", &opts.rawProfilePhases)
@@ -324,6 +326,7 @@ func BuildSyncSelection(flags SyncFlags, agentIDs []model.AgentID) model.Selecti
 		SDDMode:            sddMode,
 		SDDProfileStrategy: model.SDDProfileStrategyID(flags.SDDProfileStrategy),
 		StrictTDD:          flags.StrictTDD,
+		ForceCommunityTools: flags.ForceCommunityTools,
 		Skills:             skillIDs,
 		Profiles:           flags.Profiles,
 		// Preset is set to full-gentleman so selectedSkillIDs() returns the
@@ -455,6 +458,25 @@ func (r *syncRuntime) stagePlan() pipeline.StagePlan {
 		apply = append(apply, piCodeGraphSyncStep{id: "sync:community-tool:pi-codegraph", homeDir: r.homeDir, workspaceDir: r.workspaceDir, changedFiles: &r.changedFiles})
 	}
 
+	configured := communitytool.HasConfiguredCodeGraph(r.homeDir, communitytool.DetectorFunc(cmdLookPath))
+	hasLegacy := communitytool.HasLegacyCodeGraphGuidance(r.homeDir)
+	if configured || hasLegacy {
+		if configured {
+			apply = append(apply, communityToolSyncStep{
+				id:           "sync:community-tool:codegraph-upgrade",
+				homeDir:      r.homeDir,
+				workspaceDir: r.workspaceDir,
+				force:        r.selection.ForceCommunityTools,
+			})
+		} else {
+			apply = append(apply, &codeGraphGuidanceSyncStep{
+				id:           "sync:community-tool:codegraph-guidance",
+				homeDir:      r.homeDir,
+				changedFiles: &r.changedFiles,
+			})
+		}
+	}
+
 	return pipeline.StagePlan{Prepare: prepare, Apply: apply}
 }
 
@@ -469,7 +491,9 @@ func syncBackupTargets(homeDir, workspaceDir string, selection model.Selection, 
 			paths[path] = struct{}{}
 		}
 	}
-	if selection.HasCommunityTool(model.CommunityToolCodeGraph) {
+	configured := communitytool.HasConfiguredCodeGraph(homeDir, communitytool.DetectorFunc(cmdLookPath))
+	hasLegacy := communitytool.HasLegacyCodeGraphGuidance(homeDir)
+	if configured || hasLegacy {
 		for _, path := range communitytool.CodeGraphManagedPaths(homeDir) {
 			paths[path] = struct{}{}
 		}
@@ -588,6 +612,25 @@ type codeGraphGuidanceSyncStep struct {
 	runner       communitytool.Runner
 	changedFiles *[]string
 	before       map[string]syncFileSnapshot
+}
+
+type communityToolSyncStep struct {
+	id           string
+	homeDir      string
+	workspaceDir string
+	force        bool
+}
+
+func (s communityToolSyncStep) ID() string {
+	return s.id
+}
+
+func (s communityToolSyncStep) Run() error {
+	_, err := communitytool.InstallWithHome(model.CommunityToolCodeGraph, s.workspaceDir, s.homeDir, communitytool.RunnerFunc(runCommand), communitytool.DetectorFunc(cmdLookPath), s.force)
+	if err != nil {
+		return fmt.Errorf("sync community tool %q: %w", model.CommunityToolCodeGraph, err)
+	}
+	return nil
 }
 
 type piCodeGraphSyncStep struct {

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -448,20 +448,11 @@ func (r *syncRuntime) stagePlan() pipeline.StagePlan {
 		})
 	}
 
-	if r.selection.HasCommunityTool(model.CommunityToolCodeGraph) {
-		apply = append(apply, &codeGraphGuidanceSyncStep{
-			id:           "sync:community-tool:codegraph-guidance",
-			homeDir:      r.homeDir,
-			runner:       codeGraphHomeRunner{homeDir: r.homeDir},
-			changedFiles: &r.changedFiles,
-		})
-		apply = append(apply, piCodeGraphSyncStep{id: "sync:community-tool:pi-codegraph", homeDir: r.homeDir, workspaceDir: r.workspaceDir, changedFiles: &r.changedFiles})
-	}
-
 	configured := communitytool.HasConfiguredCodeGraph(r.homeDir, communitytool.DetectorFunc(cmdLookPath))
 	hasLegacy := communitytool.HasLegacyCodeGraphGuidance(r.homeDir)
-	if configured || hasLegacy {
-		if configured {
+	selectedCodeGraph := r.selection.HasCommunityTool(model.CommunityToolCodeGraph)
+	if configured || selectedCodeGraph || hasLegacy {
+		if configured || selectedCodeGraph {
 			apply = append(apply, communityToolSyncStep{
 				id:           "sync:community-tool:codegraph-upgrade",
 				homeDir:      r.homeDir,
@@ -475,6 +466,16 @@ func (r *syncRuntime) stagePlan() pipeline.StagePlan {
 				changedFiles: &r.changedFiles,
 			})
 		}
+	}
+
+	if r.selection.HasCommunityTool(model.CommunityToolCodeGraph) {
+		apply = append(apply, &codeGraphGuidanceSyncStep{
+			id:           "sync:community-tool:codegraph-guidance",
+			homeDir:      r.homeDir,
+			runner:       codeGraphHomeRunner{homeDir: r.homeDir},
+			changedFiles: &r.changedFiles,
+		})
+		apply = append(apply, piCodeGraphSyncStep{id: "sync:community-tool:pi-codegraph", homeDir: r.homeDir, workspaceDir: r.workspaceDir, changedFiles: &r.changedFiles})
 	}
 
 	return pipeline.StagePlan{Prepare: prepare, Apply: apply}
@@ -493,7 +494,8 @@ func syncBackupTargets(homeDir, workspaceDir string, selection model.Selection, 
 	}
 	configured := communitytool.HasConfiguredCodeGraph(homeDir, communitytool.DetectorFunc(cmdLookPath))
 	hasLegacy := communitytool.HasLegacyCodeGraphGuidance(homeDir)
-	if configured || hasLegacy {
+	selectedCodeGraph := selection.HasCommunityTool(model.CommunityToolCodeGraph)
+	if configured || selectedCodeGraph || hasLegacy {
 		for _, path := range communitytool.CodeGraphManagedPaths(homeDir) {
 			paths[path] = struct{}{}
 		}

--- a/internal/cli/sync_test.go
+++ b/internal/cli/sync_test.go
@@ -1154,6 +1154,9 @@ func TestSyncRuntimeAddsCodeGraphStepsOnlyWhenSelected(t *testing.T) {
 	if !hasStepID(plan.Apply, "sync:community-tool:pi-codegraph") {
 		t.Fatal("sync plan missing selected Pi CodeGraph step")
 	}
+	if !hasStepID(plan.Apply, "sync:community-tool:codegraph-upgrade") {
+		t.Fatalf("sync plan missing selected CodeGraph community tool upgrade step")
+	}
 
 	rt, err = newSyncRuntime(home, model.Selection{Agents: []model.AgentID{model.AgentOpenCode}})
 	if err != nil {
@@ -1165,6 +1168,9 @@ func TestSyncRuntimeAddsCodeGraphStepsOnlyWhenSelected(t *testing.T) {
 	}
 	if hasStepID(plan.Apply, "sync:community-tool:pi-codegraph") {
 		t.Fatal("sync plan included Pi CodeGraph without explicit selection")
+	}
+	if hasStepID(plan.Apply, "sync:community-tool:codegraph-upgrade") {
+		t.Fatalf("sync plan included CodeGraph community tool upgrade without explicit selection")
 	}
 
 	paths := syncBackupTargets(home, "", selected, resolveAdapters([]model.AgentID{model.AgentOpenCode}))
@@ -3859,5 +3865,91 @@ func TestRunSync_RestoresCodexPhaseModelAssignments(t *testing.T) {
 	}
 	if strings.Contains(text, "| `sdd-strong` |") {
 		t.Fatalf("AGENTS.md rendered carril table instead of Custom per-phase table; got:\n%s", text)
+	}
+}
+
+func TestParseSyncFlagsForceCommunityTools(t *testing.T) {
+	flags, err := ParseSyncFlags([]string{"--force-community-tools"})
+	if err != nil {
+		t.Fatalf("ParseSyncFlags() error = %v", err)
+	}
+	if !flags.ForceCommunityTools {
+		t.Fatal("ForceCommunityTools = false, want true")
+	}
+
+	flags, err = ParseSyncFlags([]string{})
+	if err != nil {
+		t.Fatalf("ParseSyncFlags() error = %v", err)
+	}
+	if flags.ForceCommunityTools {
+		t.Fatal("ForceCommunityTools = true, want false")
+	}
+}
+
+func TestSyncStagePlanIncludesCommunityToolUpgradeWhenConfigured(t *testing.T) {
+	home := t.TempDir()
+	mustWriteFile(t, filepath.Join(home, ".claude", "mcp", "codegraph.json"), []byte(`{"command":"codegraph"}`))
+
+	rt, err := newSyncRuntime(home, model.Selection{
+		Agents:              []model.AgentID{model.AgentClaudeCode},
+		Components:          []model.ComponentID{},
+		ForceCommunityTools: false,
+	})
+	if err != nil {
+		t.Fatalf("newSyncRuntime() error = %v", err)
+	}
+	plan := rt.stagePlan()
+
+	found := false
+	for _, step := range plan.Apply {
+		if step.ID() == "sync:community-tool:codegraph-upgrade" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("sync stage plan missing community tool upgrade step; apply steps = %#v", plan.Apply)
+	}
+}
+
+func TestSyncStagePlanIncludesCommunityToolUpgradeWithForce(t *testing.T) {
+	home := t.TempDir()
+	mustWriteFile(t, filepath.Join(home, ".claude", "mcp", "codegraph.json"), []byte(`{"command":"codegraph"}`))
+
+	rt, err := newSyncRuntime(home, model.Selection{
+		Agents:              []model.AgentID{model.AgentClaudeCode},
+		Components:          []model.ComponentID{},
+		ForceCommunityTools: true,
+	})
+	if err != nil {
+		t.Fatalf("newSyncRuntime() error = %v", err)
+	}
+	plan := rt.stagePlan()
+
+	for _, step := range plan.Apply {
+		if s, ok := step.(communityToolSyncStep); ok && s.force {
+			return
+		}
+	}
+	t.Fatal("sync stage plan missing community tool sync step with force=true")
+}
+
+
+func TestSyncStagePlanExcludesCommunityToolWhenNotConfigured(t *testing.T) {
+	home := t.TempDir()
+
+	rt, err := newSyncRuntime(home, model.Selection{
+		Agents:     []model.AgentID{model.AgentClaudeCode},
+		Components: []model.ComponentID{},
+	})
+	if err != nil {
+		t.Fatalf("newSyncRuntime() error = %v", err)
+	}
+	plan := rt.stagePlan()
+
+	for _, step := range plan.Apply {
+		if strings.HasPrefix(step.ID(), "sync:community-tool") {
+			t.Fatalf("unexpected community tool step in sync plan when CodeGraph not configured: %q", step.ID())
+		}
 	}
 }

--- a/internal/cli/sync_test.go
+++ b/internal/cli/sync_test.go
@@ -3968,8 +3968,8 @@ func TestSyncStagePlanExcludesCommunityToolWhenNotConfigured(t *testing.T) {
 	plan := rt.stagePlan()
 
 	for _, step := range plan.Apply {
-		if strings.HasPrefix(step.ID(), "sync:community-tool") {
-			t.Fatalf("unexpected community tool step in sync plan when CodeGraph not configured: %q", step.ID())
+		if _, ok := step.(communityToolSyncStep); ok {
+			t.Fatalf("unexpected community tool upgrade step in sync plan when CodeGraph not configured: %q", step.ID())
 		}
 	}
 }

--- a/internal/cli/sync_test.go
+++ b/internal/cli/sync_test.go
@@ -3890,6 +3890,16 @@ func TestSyncStagePlanIncludesCommunityToolUpgradeWhenConfigured(t *testing.T) {
 	home := t.TempDir()
 	mustWriteFile(t, filepath.Join(home, ".claude", "mcp", "codegraph.json"), []byte(`{"command":"codegraph"}`))
 
+	// Simulate codegraph on PATH so HasConfiguredCodeGraph returns true.
+	restoreLookPath := cmdLookPath
+	t.Cleanup(func() { cmdLookPath = restoreLookPath })
+	cmdLookPath = func(name string) (string, error) {
+		if name == "codegraph" {
+			return "/usr/local/bin/codegraph", nil
+		}
+		return restoreLookPath(name)
+	}
+
 	rt, err := newSyncRuntime(home, model.Selection{
 		Agents:              []model.AgentID{model.AgentClaudeCode},
 		Components:          []model.ComponentID{},
@@ -3915,6 +3925,16 @@ func TestSyncStagePlanIncludesCommunityToolUpgradeWhenConfigured(t *testing.T) {
 func TestSyncStagePlanIncludesCommunityToolUpgradeWithForce(t *testing.T) {
 	home := t.TempDir()
 	mustWriteFile(t, filepath.Join(home, ".claude", "mcp", "codegraph.json"), []byte(`{"command":"codegraph"}`))
+
+	// Simulate codegraph on PATH so HasConfiguredCodeGraph returns true.
+	restoreLookPath := cmdLookPath
+	t.Cleanup(func() { cmdLookPath = restoreLookPath })
+	cmdLookPath = func(name string) (string, error) {
+		if name == "codegraph" {
+			return "/usr/local/bin/codegraph", nil
+		}
+		return restoreLookPath(name)
+	}
 
 	rt, err := newSyncRuntime(home, model.Selection{
 		Agents:              []model.AgentID{model.AgentClaudeCode},

--- a/internal/components/communitytool/tool.go
+++ b/internal/components/communitytool/tool.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gentleman-programming/gentle-ai/internal/model"
 )
 
+// Availability describes whether a community tool CLI was found on the system.
 type Availability string
 
 const (
@@ -21,6 +22,7 @@ const (
 	AvailabilityMissing   Availability = "missing"
 )
 
+// AgentStatusKind describes the configuration state of a supported agent relative to a community tool.
 type AgentStatusKind string
 
 const (
@@ -29,6 +31,7 @@ const (
 	AgentStatusMissing     AgentStatusKind = "missing"
 )
 
+// Definition describes a community tool that can be installed and wired to agents.
 type Definition struct {
 	ID          model.CommunityToolID
 	Name        string
@@ -38,6 +41,7 @@ type Definition struct {
 	Description string
 }
 
+// Result reports what happened during a community tool installation or upgrade.
 type Result struct {
 	Tool          model.CommunityToolID
 	CommandsRun   []string
@@ -48,6 +52,7 @@ type Result struct {
 	PiCodeGraph   *PiCodeGraphResult
 }
 
+// Status describes the detected installation and agent wiring state of a community tool.
 type Status struct {
 	Tool       model.CommunityToolID
 	CLI        Availability
@@ -57,6 +62,7 @@ type Status struct {
 	FollowUps  []string
 }
 
+// AgentStatus describes the configuration state of a single agent for a community tool.
 type AgentStatus struct {
 	Agent      model.AgentID
 	Name       string
@@ -68,18 +74,22 @@ type AgentStatus struct {
 	Children   []PiCodeGraphChild
 }
 
+// Detector abstracts how a community tool looks up a command on PATH.
 type Detector interface {
 	LookPath(name string) (string, error)
 }
 
+// DetectorFunc adapts a plain function to the Detector interface.
 type DetectorFunc func(name string) (string, error)
 
 func (fn DetectorFunc) LookPath(name string) (string, error) { return fn(name) }
 
+// Runner abstracts how a community tool install command is executed.
 type Runner interface {
 	Run(name string, args ...string) error
 }
 
+// RunnerFunc adapts a plain function to the Runner interface.
 type RunnerFunc func(name string, args ...string) error
 
 func (fn RunnerFunc) Run(name string, args ...string) error { return fn(name, args...) }
@@ -100,6 +110,7 @@ var definitions = []Definition{
 	},
 }
 
+// Definitions returns the configured community tool definitions.
 func Definitions() []Definition {
 	out := make([]Definition, len(definitions))
 	copy(out, definitions)
@@ -286,6 +297,7 @@ func validateCodeGraphInstallStatus(status Status) error {
 	return nil
 }
 
+// DetectStatus returns the current installation and agent wiring status for a community tool.
 func DetectStatus(id model.CommunityToolID, homeDir string, detector Detector) Status {
 	status := Status{Tool: id, CLI: AvailabilityMissing}
 	def, ok := DefinitionFor(id)
@@ -513,10 +525,12 @@ func defaultHomeDir() string {
 	return os.Getenv("HOME")
 }
 
+// CodeGraphCommands returns the install/upgrade commands for CodeGraph using npm.
 func CodeGraphCommands() [][]string {
 	return codeGraphCommands("npm")
 }
 
+// CodeGraphCommandsForDetector returns the install/upgrade commands for CodeGraph using the provided detector.
 func CodeGraphCommandsForDetector(detector Detector) ([][]string, error) {
 	packageManager, err := detectCodeGraphPackageManager(detector)
 	if err != nil {

--- a/internal/components/communitytool/tool.go
+++ b/internal/components/communitytool/tool.go
@@ -1,6 +1,7 @@
 package communitytool
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -41,17 +42,19 @@ type Result struct {
 	Tool          model.CommunityToolID
 	CommandsRun   []string
 	ManualActions []string
+	FollowUps     []string
 	StatusBefore  *Status
 	StatusAfter   *Status
 	PiCodeGraph   *PiCodeGraphResult
 }
 
 type Status struct {
-	Tool      model.CommunityToolID
-	CLI       Availability
-	CLIPath   string
-	Agents    []AgentStatus
-	FollowUps []string
+	Tool       model.CommunityToolID
+	CLI        Availability
+	CLIPath    string
+	CLIVersion string
+	Agents     []AgentStatus
+	FollowUps  []string
 }
 
 type AgentStatus struct {
@@ -103,6 +106,7 @@ func Definitions() []Definition {
 	return out
 }
 
+// DefinitionFor returns the definition for a community tool, or false if it is unknown.
 func DefinitionFor(id model.CommunityToolID) (Definition, bool) {
 	for _, def := range definitions {
 		if def.ID == id {
@@ -112,11 +116,16 @@ func DefinitionFor(id model.CommunityToolID) (Definition, bool) {
 	return Definition{}, false
 }
 
-func Install(id model.CommunityToolID, workspaceDir string, runner Runner) (Result, error) {
-	return InstallWithHome(id, workspaceDir, defaultHomeDir(), runner, DetectorFunc(exec.LookPath))
+// Install installs the requested community tool in the default home directory.
+// When force is true, the installation commands run even if the tool appears already configured.
+func Install(id model.CommunityToolID, workspaceDir string, runner Runner, force bool) (Result, error) {
+	return InstallWithHome(id, workspaceDir, defaultHomeDir(), runner, DetectorFunc(exec.LookPath), force)
 }
 
-func InstallWithHome(id model.CommunityToolID, workspaceDir string, homeDir string, runner Runner, detector Detector) (Result, error) {
+// InstallWithHome installs the requested community tool using the provided home directory.
+// It detects the current state, upgrades when the installed version is older than the npm latest,
+// and skips installation when the tool is already reconciled unless force is true.
+func InstallWithHome(id model.CommunityToolID, workspaceDir string, homeDir string, runner Runner, detector Detector, force bool) (Result, error) {
 	if runner == nil {
 		return Result{}, fmt.Errorf("community tool runner is not configured")
 	}
@@ -129,9 +138,19 @@ func InstallWithHome(id model.CommunityToolID, workspaceDir string, homeDir stri
 	}
 
 	result := Result{Tool: id}
+
+	targetVersion, err := resolveCodeGraphTargetVersionFn()
+	if err != nil {
+		result.FollowUps = append(result.FollowUps, fmt.Sprintf("Could not determine latest CodeGraph version: %v", err))
+	}
+
 	before := DetectStatus(id, homeDir, detector)
 	result.StatusBefore = &before
-	if before.CodeGraphReconcileSatisfied() || codeGraphCanRepairWithoutFullInstall(homeDir, before) {
+
+	reconciled := before.CodeGraphReconcileSatisfied() || codeGraphCanRepairWithoutFullInstall(homeDir, before)
+	needsUpgrade := targetVersion != "" && versionNeedsUpgrade(before.CLIVersion, targetVersion)
+
+	if reconciled && !needsUpgrade && !force {
 		if NeedsOpenCodeCodeGraphReconcile(homeDir) {
 			result.CommandsRun = append(result.CommandsRun, "codegraph install --target opencode --location global --yes")
 		}
@@ -165,7 +184,7 @@ func InstallWithHome(id model.CommunityToolID, workspaceDir string, homeDir stri
 	}
 
 	commands := [][]string{{"codegraph", "install", "--yes"}}
-	if before.CLI != AvailabilityAvailable {
+	if before.CLI != AvailabilityAvailable || needsUpgrade {
 		var err error
 		commands, err = CodeGraphCommandsForDetector(DetectorFunc(codeGraphPackageLookPath))
 		if err != nil {
@@ -197,7 +216,11 @@ func InstallWithHome(id model.CommunityToolID, workspaceDir string, homeDir stri
 	if err := validateCodeGraphInstallStatus(after); err != nil {
 		return result, err
 	}
-	result.ManualActions = append(result.ManualActions, "CodeGraph CLI was installed and supported agents were connected. Project indexes will be created automatically when an enabled agent opens inside a project.")
+	if needsUpgrade {
+		result.ManualActions = append(result.ManualActions, fmt.Sprintf("CodeGraph CLI was upgraded from %s to %s and supported agents were reconnected. Project indexes will be created automatically when an enabled agent opens inside a project.", before.CLIVersion, targetVersion))
+	} else {
+		result.ManualActions = append(result.ManualActions, "CodeGraph CLI was installed and supported agents were connected. Project indexes will be created automatically when an enabled agent opens inside a project.")
+	}
 	return result, nil
 }
 
@@ -276,6 +299,9 @@ func DetectStatus(id model.CommunityToolID, homeDir string, detector Detector) S
 	if path, err := detector.LookPath(def.CommandName); err == nil && strings.TrimSpace(path) != "" {
 		status.CLI = AvailabilityAvailable
 		status.CLIPath = path
+		if v, err := installedVersion(path); err == nil && v != "" {
+			status.CLIVersion = v
+		}
 	}
 	status.Agents = detectCodeGraphAgents(homeDir)
 	status.FollowUps = append(status.FollowUps, "CodeGraph markers can vary by upstream version; detection currently checks conservative MCP entries and instruction markers containing codegraph.")
@@ -540,4 +566,56 @@ func codeGraphCommands(packageManager string) [][]string {
 		installCommand,
 		{"codegraph", "install", "--yes"},
 	}
+}
+
+// installedVersion runs the given CLI binary with --version and returns the
+// first non-empty line. It is exported as a package helper for testing.
+func installedVersion(commandPath string) (string, error) {
+	if commandPath == "" {
+		return "", fmt.Errorf("command path is empty")
+	}
+	out, err := exec.Command(commandPath, "--version").Output()
+	if err != nil {
+		return "", fmt.Errorf("run %q --version: %w", commandPath, err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			return line, nil
+		}
+	}
+	return "", fmt.Errorf("no version output from %q", commandPath)
+}
+
+// resolveCodeGraphTargetVersionFn is the package-level resolver used by
+// InstallWithHome so tests can stub the npm lookup.
+var resolveCodeGraphTargetVersionFn = resolveCodeGraphTargetVersion
+
+// resolveCodeGraphTargetVersion returns the latest published version of the
+// CodeGraph npm package by querying npm dist-tags.
+func resolveCodeGraphTargetVersion() (string, error) {
+	out, err := exec.Command("npm", "view", "@colbymchenry/codegraph", "dist-tags", "--json").Output()
+	if err != nil {
+		return "", fmt.Errorf("npm view dist-tags: %w", err)
+	}
+	var tags map[string]string
+	if err := json.Unmarshal(out, &tags); err != nil {
+		return "", fmt.Errorf("parse npm dist-tags: %w", err)
+	}
+	latest, ok := tags["latest"]
+	if !ok || latest == "" {
+		return "", fmt.Errorf("npm dist-tags missing latest")
+	}
+	return latest, nil
+}
+
+// versionNeedsUpgrade reports whether the installed version is different from
+// the target version. Exact equality is used because npm dist-tags resolve to
+// concrete semver versions.
+func versionNeedsUpgrade(installed, target string) bool {
+	if installed == "" || target == "" {
+		return false
+	}
+	return installed != target
 }

--- a/internal/components/communitytool/tool_test.go
+++ b/internal/components/communitytool/tool_test.go
@@ -884,7 +884,7 @@ func TestInstallRecordsTargetedOpenCodeReconciliation(t *testing.T) {
 		mustWrite(t, settingsPath, `{"mcp":{"codegraph":{"type":"local","command":["codegraph","serve","--mcp"],"enabled":true}}}`)
 		mustWrite(t, filepath.Join(home, ".claude", "mcp", "codegraph.json"), `{"command":"codegraph","args":["serve","--mcp"]}`)
 		return nil
-	}), DetectorFunc(func(string) (string, error) { return "/bin/codegraph", nil }))
+	}), DetectorFunc(func(string) (string, error) { return "/bin/codegraph", nil }), false)
 	if err != nil {
 		t.Fatalf("InstallWithHome() error = %v", err)
 	}
@@ -904,7 +904,7 @@ func TestInstallRunsFullReconcileWhenAnotherAgentIsMissing(t *testing.T) {
 		mustWrite(t, settingsPath, `{"mcp":{"codegraph":{"type":"local","command":["codegraph","serve","--mcp"],"enabled":true}}}`)
 		mustWrite(t, filepath.Join(home, ".claude", "mcp", "codegraph.json"), `{"command":"codegraph","args":["serve","--mcp"]}`)
 		return nil
-	}), DetectorFunc(func(string) (string, error) { return "/bin/codegraph", nil }))
+	}), DetectorFunc(func(string) (string, error) { return "/bin/codegraph", nil }), false)
 	if err != nil {
 		t.Fatalf("InstallWithHome() error = %v", err)
 	}

--- a/internal/components/communitytool/tool_test.go
+++ b/internal/components/communitytool/tool_test.go
@@ -158,9 +158,9 @@ func TestInstallUsesPnpmWhenNpmIsUnavailable(t *testing.T) {
 			return "/bin/codegraph", nil
 		}
 		return "", errors.New("not found")
-	}))
+	}), false)
 	if err != nil {
-		t.Fatalf("InstallWithHome() error = %v", err)
+		t.Fatalf("InstallWithHome(, false) error = %v", err)
 	}
 	want := []string{
 		"pnpm add -g @colbymchenry/codegraph@latest",
@@ -311,9 +311,9 @@ func TestCodeGraphGuidanceInjectsForRepresentativeAgents(t *testing.T) {
 			return "/bin/codegraph", nil
 		}
 		return "", errors.New("not found")
-	}))
+	}), false)
 	if err != nil {
-		t.Fatalf("InstallWithHome() error = %v", err)
+		t.Fatalf("InstallWithHome(, false) error = %v", err)
 	}
 	if result.StatusAfter == nil {
 		t.Fatal("StatusAfter = nil")
@@ -647,7 +647,7 @@ func TestInstallRunsCommandsAndReturnsLazyProjectIndexManualAction(t *testing.T)
 			return "/bin/codegraph", nil
 		}
 		return "", errors.New("not found")
-	}))
+	}), false)
 	if err != nil {
 		t.Fatalf("Install() error = %v", err)
 	}
@@ -1030,9 +1030,9 @@ func TestInstallFailsWhenPostInstallContractStillMissing(t *testing.T) {
 		return nil
 	}), DetectorFunc(func(string) (string, error) {
 		return "", errors.New("not found")
-	}))
+	}), false)
 	if err == nil || !strings.Contains(err.Error(), "CLI available") {
-		t.Fatalf("InstallWithHome() error = %v, want missing CLI validation", err)
+		t.Fatalf("InstallWithHome(, false) error = %v, want missing CLI validation", err)
 	}
 	if result.StatusAfter == nil {
 		t.Fatal("StatusAfter = nil, want partial result context")
@@ -1063,9 +1063,9 @@ func TestInstallSkipsWhenCodeGraphAlreadyReconciled(t *testing.T) {
 		return nil
 	}), DetectorFunc(func(string) (string, error) {
 		return "/bin/codegraph", nil
-	}))
+	}), false)
 	if err != nil {
-		t.Fatalf("InstallWithHome() error = %v", err)
+		t.Fatalf("InstallWithHome(, false) error = %v", err)
 	}
 	if calls != 0 {
 		t.Fatalf("runner calls = %d, want 0 for already reconciled install", calls)
@@ -1091,9 +1091,9 @@ func TestInstallRefreshesOldCodeGraphGuidanceMarker(t *testing.T) {
 		return nil
 	}), DetectorFunc(func(string) (string, error) {
 		return "/bin/codegraph", nil
-	}))
+	}), false)
 	if err != nil {
-		t.Fatalf("InstallWithHome() error = %v", err)
+		t.Fatalf("InstallWithHome(, false) error = %v", err)
 	}
 	if !reflect.DeepEqual(result.CommandsRun, []string{"codegraph install --target opencode --location global --yes"}) {
 		t.Fatalf("CommandsRun = %#v, want MCP reconciliation only", result.CommandsRun)
@@ -1127,9 +1127,9 @@ func TestInstallRepairsMissingCLIWhenAgentMarkerExists(t *testing.T) {
 			return "/bin/codegraph", nil
 		}
 		return "", errors.New("not found")
-	}))
+	}), false)
 	if err != nil {
-		t.Fatalf("InstallWithHome() error = %v", err)
+		t.Fatalf("InstallWithHome(, false) error = %v", err)
 	}
 	want := []string{
 		"npm install -g @colbymchenry/codegraph@latest",
@@ -1145,7 +1145,7 @@ func TestInstallRepairsMissingCLIWhenAgentMarkerExists(t *testing.T) {
 
 func TestInstallFailurePaths(t *testing.T) {
 	t.Run("nil runner", func(t *testing.T) {
-		result, err := Install(model.CommunityToolCodeGraph, "/work/project", nil)
+		result, err := Install(model.CommunityToolCodeGraph, "/work/project", nil, false)
 		if err == nil {
 			t.Fatal("Install() error = nil, want configured runner error")
 		}
@@ -1155,7 +1155,7 @@ func TestInstallFailurePaths(t *testing.T) {
 	})
 
 	t.Run("unknown tool", func(t *testing.T) {
-		result, err := Install(model.CommunityToolID("missing-tool"), "/work/project", RunnerFunc(func(string, ...string) error { return nil }))
+		result, err := Install(model.CommunityToolID("missing-tool"), "/work/project", RunnerFunc(func(string, ...string) error { return nil }), false)
 		if err == nil || !strings.Contains(err.Error(), "unknown community tool") {
 			t.Fatalf("Install() error = %v, want unknown tool error", err)
 		}
@@ -1168,7 +1168,7 @@ func TestInstallFailurePaths(t *testing.T) {
 		boom := errors.New("npm failed")
 		result, err := InstallWithHome(model.CommunityToolCodeGraph, "/work/project", t.TempDir(), RunnerFunc(func(string, ...string) error { return boom }), DetectorFunc(func(string) (string, error) {
 			return "", errors.New("not found")
-		}))
+		}), false)
 		if !errors.Is(err, boom) {
 			t.Fatalf("Install() error = %v, want wrapped runner error", err)
 		}
@@ -1191,7 +1191,7 @@ func TestInstallFailurePaths(t *testing.T) {
 			return nil
 		}), DetectorFunc(func(string) (string, error) {
 			return "", errors.New("not found")
-		}))
+		}), false)
 		if !errors.Is(err, boom) {
 			t.Fatalf("Install() error = %v, want wrapped install error", err)
 		}
@@ -1227,4 +1227,175 @@ func findAgentStatus(t *testing.T, status Status, id model.AgentID) AgentStatus 
 	}
 	t.Fatalf("agent %s not found in %#v", id, status.Agents)
 	return AgentStatus{}
+}
+
+func TestInstalledVersionParsesFirstLine(t *testing.T) {
+	script := fakeCLI(t, "#!/bin/sh\necho '1.1.1'\n")
+	got, err := installedVersion(script)
+	if err != nil {
+		t.Fatalf("installedVersion() error = %v", err)
+	}
+	if got != "1.1.1" {
+		t.Fatalf("installedVersion() = %q, want 1.1.1", got)
+	}
+}
+
+func TestDetectStatusReportsInstalledVersion(t *testing.T) {
+	script := fakeCLI(t, "#!/bin/sh\necho '1.1.1'\n")
+	status := DetectStatus(model.CommunityToolCodeGraph, t.TempDir(), DetectorFunc(func(name string) (string, error) {
+		if name != "codegraph" {
+			t.Fatalf("LookPath(%q), want codegraph", name)
+		}
+		return script, nil
+	}))
+	if status.CLI != AvailabilityAvailable {
+		t.Fatalf("CLI = %s, want available", status.CLI)
+	}
+	if status.CLIVersion != "1.1.1" {
+		t.Fatalf("CLIVersion = %q, want 1.1.1", status.CLIVersion)
+	}
+}
+
+func TestInstallUpgradesWhenVersionMismatches(t *testing.T) {
+	previous := codeGraphPackageLookPath
+	codeGraphPackageLookPath = func(name string) (string, error) {
+		if name == "npm" {
+			return "/bin/npm", nil
+		}
+		return "", errors.New("not found")
+	}
+	t.Cleanup(func() { codeGraphPackageLookPath = previous })
+
+	previousResolver := resolveCodeGraphTargetVersionFn
+	resolveCodeGraphTargetVersionFn = func() (string, error) { return "1.1.2", nil }
+	t.Cleanup(func() { resolveCodeGraphTargetVersionFn = previousResolver })
+
+	home := t.TempDir()
+	mustWrite(t, filepath.Join(home, ".claude", "mcp", "codegraph.json"), `{"command":"codegraph"}`)
+
+	codegraph := fakeCLI(t, "#!/bin/sh\necho '1.1.1'\n")
+	var commands []string
+	result, err := InstallWithHome(model.CommunityToolCodeGraph, "/work/project", home, RunnerFunc(func(name string, args ...string) error {
+		commands = append(commands, strings.Join(append([]string{name}, args...), " "))
+		return nil
+	}), DetectorFunc(func(name string) (string, error) {
+		if name != "codegraph" {
+			t.Fatalf("LookPath(%q), want codegraph", name)
+		}
+		return codegraph, nil
+	}), false)
+	if err != nil {
+		t.Fatalf("InstallWithHome() error = %v", err)
+	}
+	if len(commands) == 0 {
+		t.Fatal("expected install commands to run for version upgrade")
+	}
+	if result.StatusBefore == nil || result.StatusBefore.CLIVersion != "1.1.1" {
+		t.Fatalf("StatusBefore.CLIVersion = %q, want 1.1.1", result.StatusBefore.CLIVersion)
+	}
+	if len(result.ManualActions) != 1 || !strings.Contains(result.ManualActions[0], "upgraded") {
+		t.Fatalf("ManualActions = %#v, want upgrade message", result.ManualActions)
+	}
+}
+
+func TestInstallSkipsWhenVersionMatches(t *testing.T) {
+	previous := codeGraphPackageLookPath
+	codeGraphPackageLookPath = func(name string) (string, error) {
+		if name == "npm" {
+			return "/bin/npm", nil
+		}
+		return "", errors.New("not found")
+	}
+	t.Cleanup(func() { codeGraphPackageLookPath = previous })
+
+	previousResolver := resolveCodeGraphTargetVersionFn
+	resolveCodeGraphTargetVersionFn = func() (string, error) { return "1.1.2", nil }
+	t.Cleanup(func() { resolveCodeGraphTargetVersionFn = previousResolver })
+
+	home := t.TempDir()
+	mustWrite(t, filepath.Join(home, ".claude", "mcp", "codegraph.json"), `{"command":"codegraph"}`)
+	if _, err := InjectCodeGraphGuidanceIfSelected(home, []model.CommunityToolID{model.CommunityToolCodeGraph}); err != nil {
+		t.Fatalf("pre-inject guidance: %v", err)
+	}
+
+	codegraph := fakeCLI(t, "#!/bin/sh\necho '1.1.2'\n")
+	var commands []string
+	result, err := InstallWithHome(model.CommunityToolCodeGraph, "/work/project", home, RunnerFunc(func(name string, args ...string) error {
+		commands = append(commands, strings.Join(append([]string{name}, args...), " "))
+		return nil
+	}), DetectorFunc(func(name string) (string, error) {
+		if name != "codegraph" {
+			t.Fatalf("LookPath(%q), want codegraph", name)
+		}
+		return codegraph, nil
+	}), false)
+	if err != nil {
+		t.Fatalf("InstallWithHome() error = %v", err)
+	}
+	if len(commands) != 0 {
+		t.Fatalf("commands = %#v, want no install commands when version matches", commands)
+	}
+	wantMsg := "No changes were needed"
+	if len(result.ManualActions) != 1 || !strings.Contains(result.ManualActions[0], wantMsg) {
+		t.Fatalf("ManualActions = %#v, want message containing %q", result.ManualActions, wantMsg)
+	}
+}
+
+func TestInstallWithForceRunsCommandsEvenWhenReconciled(t *testing.T) {
+	previous := codeGraphPackageLookPath
+	codeGraphPackageLookPath = func(name string) (string, error) {
+		if name == "npm" {
+			return "/bin/npm", nil
+		}
+		return "", errors.New("not found")
+	}
+	t.Cleanup(func() { codeGraphPackageLookPath = previous })
+
+	previousResolver := resolveCodeGraphTargetVersionFn
+	resolveCodeGraphTargetVersionFn = func() (string, error) { return "1.1.2", nil }
+	t.Cleanup(func() { resolveCodeGraphTargetVersionFn = previousResolver })
+
+	home := t.TempDir()
+	mustWrite(t, filepath.Join(home, ".claude", "mcp", "codegraph.json"), `{"command":"codegraph"}`)
+
+	codegraph := fakeCLI(t, "#!/bin/sh\necho '1.1.2'\n")
+	var commands []string
+	_, err := InstallWithHome(model.CommunityToolCodeGraph, "/work/project", home, RunnerFunc(func(name string, args ...string) error {
+		commands = append(commands, strings.Join(append([]string{name}, args...), " "))
+		return nil
+	}), DetectorFunc(func(name string) (string, error) {
+		if name != "codegraph" {
+			t.Fatalf("LookPath(%q), want codegraph", name)
+		}
+		return codegraph, nil
+	}), true)
+	if err != nil {
+		t.Fatalf("InstallWithHome() error = %v", err)
+	}
+	if len(commands) == 0 {
+		t.Fatal("expected install commands to run when force is true")
+	}
+}
+
+func TestResolveCodeGraphTargetVersionParsesNpmLatest(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skips npm network integration test in short mode")
+	}
+	got, err := resolveCodeGraphTargetVersion()
+	if err != nil {
+		t.Fatalf("resolveCodeGraphTargetVersion() error = %v", err)
+	}
+	if got == "" {
+		t.Fatal("resolveCodeGraphTargetVersion() returned empty version")
+	}
+}
+
+func fakeCLI(t *testing.T, script string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "codegraph")
+	if err := os.WriteFile(path, []byte(script), 0755); err != nil {
+		t.Fatalf("WriteFile(%q): %v", path, err)
+	}
+	return path
 }

--- a/internal/components/communitytool/tool_test.go
+++ b/internal/components/communitytool/tool_test.go
@@ -184,7 +184,7 @@ func TestInstallWithHomeReportsPiChildClassifications(t *testing.T) {
 			return "/bin/codegraph", nil
 		}
 		return "", errors.New("not found")
-	}))
+	}), false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -209,7 +209,7 @@ func TestInstallWithHomeReportsWorkspaceChildAndOwnershipTarget(t *testing.T) {
 			return "/bin/codegraph", nil
 		}
 		return "", errors.New("not found")
-	}))
+	}), false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -235,7 +235,7 @@ func TestInstallWithHomeReportsEffectiveMCPAdapterSchema(t *testing.T) {
 			return "/bin/codegraph", nil
 		}
 		return "", errors.New("not found")
-	}))
+	}), false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -261,7 +261,7 @@ func TestInstallWithHomeFailsClosedForEmptyPiSettingsWithoutMCPProcess(t *testin
 			return "/bin/codegraph", nil
 		}
 		return "", errors.New("not found")
-	}))
+	}), false)
 	if err == nil || !strings.Contains(err.Error(), "capability probe") {
 		t.Fatalf("InstallWithHome() error = %v, want failed effective MCP capability probe", err)
 	}
@@ -693,7 +693,7 @@ func TestInstallLeavesPiPendingWhenAdapterHealthIsNotMachineVerifiable(t *testin
 			return "/bin/codegraph", nil
 		}
 		return "", errors.New("not found")
-	}))
+	}), false)
 	if err != nil {
 		t.Fatalf("InstallWithHome() error = %v", err)
 	}

--- a/internal/model/selection.go
+++ b/internal/model/selection.go
@@ -9,8 +9,9 @@ type Selection struct {
 	SDDMode                     SDDModeID
 	SDDProfileStrategy          SDDProfileStrategyID
 	StrictTDD                   bool
+	ForceCommunityTools         bool                             // force reinstall/upgrade of community tools during sync
 	CodexMultiAgent             bool                             // deprecated: Codex now always writes features.multi_agent = true; retained for state/back-compat
-	ModelAssignments            map[string]ModelAssignment       // key = sub-agent name (e.g., "sdd-init")
+	ModelAssignments            map[string]ModelAssignment       // key = sub-agent name (e.g. "sdd-init")
 	ClaudeModelAssignments      map[string]ClaudeModelAlias      // key = phase name; value = fable|opus|sonnet|haiku
 	ClaudePhaseAssignments      map[string]ClaudePhaseAssignment // key = phase name; value = Claude model+effort
 	KiroModelAssignments        map[string]KiroModelAlias        // key = phase name; value = Kiro-native model alias

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -98,7 +98,9 @@ var osGetwdFn = os.Getwd
 var osExecutableFn = os.Executable
 var osRemoveFn = os.Remove
 var execCommandFn = exec.Command
-var communityToolInstallFn = communitytool.Install
+var communityToolInstallFn = func(id model.CommunityToolID, workspaceDir string, runner communitytool.Runner, force bool) (communitytool.Result, error) {
+	return communitytool.Install(id, workspaceDir, runner, force)
+}
 var communityToolStatusFn = communitytool.DetectStatus
 
 // readCurrentAssignmentsFn is a package-level variable so tests can override
@@ -2649,7 +2651,7 @@ func (m Model) startCommunityToolInstallation() tea.Cmd {
 	return func() tea.Msg {
 		results := make([]communitytool.Result, 0, len(tools))
 		for _, tool := range tools {
-			result, err := communityToolInstallFn(tool, workspaceDir, runner)
+			result, err := communityToolInstallFn(tool, workspaceDir, runner, false)
 			if err != nil {
 				if hasCommunityToolResultContext(result) {
 					results = append(results, result)

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1627,9 +1627,9 @@ func TestCommunityToolInstallationPreservesPartialResultOnError(t *testing.T) {
 	})
 
 	osGetwdFn = func() (string, error) { return "/work/project", nil }
-	communityToolInstallFn = func(id model.CommunityToolID, workspaceDir string, runner communitytool.Runner) (communitytool.Result, error) {
-		if id != model.CommunityToolCodeGraph || workspaceDir != "/work/project" || runner == nil {
-			t.Fatalf("install args = (%q, %q, %#v), want CodeGraph, workspace, runner", id, workspaceDir, runner)
+	communityToolInstallFn = func(id model.CommunityToolID, workspaceDir string, runner communitytool.Runner, force bool) (communitytool.Result, error) {
+		if id != model.CommunityToolCodeGraph || workspaceDir != "/work/project" || runner == nil || force {
+			t.Fatalf("install args = (%q, %q, %#v, %v), want CodeGraph, workspace, runner, false", id, workspaceDir, runner, force)
 		}
 		return communitytool.Result{
 			Tool:        id,


### PR DESCRIPTION
Closes #984



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--force-community-tools` to force community tool reinstall/upgrade during sync.
* **Bug Fixes**
  * Community tools now detect the installed CodeGraph CLI version and upgrade when it differs from the resolved target (unless reconciliation is allowed to skip).
  * Sync now cleanly separates configured/selected vs legacy-only CodeGraph handling, applying guidance refresh or install/upgrade accordingly.
  * Community tool installation and upgrade behavior improvements, including more consistent error handling and partial-result preservation.
* **Tests**
  * Expanded sync and community tool coverage for force behavior and version-aware decisions.
* **Chores**
  * Updated local development ignore rules to avoid tracking generated chunks and the lockfile.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
