### PR TITLE
fix(tui): honor persona visual opt-out

### DIFF
--- a/e2e/e2e_test.sh
+++ b/e2e/e2e_test.sh
@@ -305,9 +305,9 @@ test_dry_run_full_preset_persona_before_sdd() {
 }
 
 test_preset_no_legacy_theme_in_any_preset() {
-    log_test "Legacy theme component is NOT in any preset"
+    log_test "Only Dev Stack + Polish includes the OpenCode theme component"
 
-    for preset in minimal ecosystem-only full-gentleman; do
+    for preset in minimal ecosystem-only; do
         output=$($BINARY install --preset "$preset" --agent claude-code --dry-run 2>&1) || true
         local components_line
         components_line=$(echo "$output" | grep "Components order:")
@@ -315,11 +315,23 @@ test_preset_no_legacy_theme_in_any_preset() {
         order_str=${components_line#*Components order:}
         order_str=${order_str# }
         if echo "$order_str" | tr ',' '\n' | grep -qx "theme"; then
-            log_fail "Preset '$preset' unexpectedly includes legacy theme component"
+            log_fail "Preset '$preset' unexpectedly includes OpenCode theme component"
         else
-            log_pass "Preset '$preset' does NOT include legacy theme component"
+            log_pass "Preset '$preset' does NOT include OpenCode theme component"
         fi
     done
+
+    output=$($BINARY install --preset full-gentleman --agent claude-code --dry-run 2>&1) || true
+    local components_line
+    components_line=$(echo "$output" | grep "Components order:")
+    local order_str
+    order_str=${components_line#*Components order:}
+    order_str=${order_str# }
+    if echo "$order_str" | tr ',' '\n' | grep -qx "theme"; then
+        log_pass "Preset 'full-gentleman' includes OpenCode theme component"
+    else
+        log_fail "Preset 'full-gentleman' must include OpenCode theme component"
+    fi
 }
 
 test_preset_custom_no_components() {

--- a/internal/catalog/components.go
+++ b/internal/catalog/components.go
@@ -13,12 +13,12 @@ var mvpComponents = []Component{
 	{ID: model.ComponentSDD, Name: "SDD", Description: "Spec-driven development workflow"},
 	{ID: model.ComponentSkills, Name: "Skills", Description: "Curated coding skill library"},
 	{ID: model.ComponentContext7, Name: "Context7", Description: "Latest framework and library docs"},
-	{ID: model.ComponentPersona, Name: "Persona", Description: "Gentleman, neutral or custom behavior"},
+	{ID: model.ComponentPersona, Name: "Persona", Description: "Managed agent behavior and conversation tone"},
 	{ID: model.ComponentPermission, Name: "Permissions", Description: "Security-first defaults and guardrails"},
 	{ID: model.ComponentGGA, Name: "GGA", Description: "Gentleman Guardian Angel — AI provider switcher"},
-	{ID: model.ComponentTheme, Name: "Theme", Description: "Gentleman Kanagawa theme overlay"},
-	{ID: model.ComponentClaudeTheme, Name: "Claude Gentleman Theme", Description: "Claude Code Gentleman custom theme"},
-	{ID: model.ComponentOpenCodeGentleLogo, Name: "OpenCode Gentle Logo", Description: "OpenCode home logo TUI plugin with Braille rose"},
+	{ID: model.ComponentTheme, Name: "OpenCode Theme", Description: "Visual polish: Gentleman Kanagawa theme overlay"},
+	{ID: model.ComponentClaudeTheme, Name: "Claude Code Theme", Description: "Visual polish: Claude Code Gentleman custom theme"},
+	{ID: model.ComponentOpenCodeGentleLogo, Name: "OpenCode Logo", Description: "Visual polish: OpenCode home logo TUI plugin with Braille rose"},
 }
 
 func MVPComponents() []Component {

--- a/internal/catalog/components.go
+++ b/internal/catalog/components.go
@@ -16,9 +16,9 @@ var mvpComponents = []Component{
 	{ID: model.ComponentPersona, Name: "Persona", Description: "Managed agent behavior and conversation tone"},
 	{ID: model.ComponentPermission, Name: "Permissions", Description: "Security-first defaults and guardrails"},
 	{ID: model.ComponentGGA, Name: "GGA", Description: "Gentleman Guardian Angel — AI provider switcher"},
-	{ID: model.ComponentTheme, Name: "OpenCode Theme", Description: "Visual polish: Gentleman Kanagawa theme overlay"},
-	{ID: model.ComponentClaudeTheme, Name: "Claude Code Theme", Description: "Visual polish: Claude Code Gentleman custom theme"},
-	{ID: model.ComponentOpenCodeGentleLogo, Name: "OpenCode Logo", Description: "Visual polish: OpenCode home logo TUI plugin with Braille rose"},
+	{ID: model.ComponentTheme, Name: "OpenCode Theme", Description: "Visual polish: OpenCode color theme"},
+	{ID: model.ComponentClaudeTheme, Name: "Claude Code Theme", Description: "Visual polish: Claude Code color theme"},
+	{ID: model.ComponentOpenCodeGentleLogo, Name: "OpenCode Logo", Description: "Visual polish: OpenCode home logo plugin"},
 }
 
 func MVPComponents() []Component {

--- a/internal/cli/install_test.go
+++ b/internal/cli/install_test.go
@@ -79,6 +79,7 @@ func TestNormalizeInstallFlagsDefaults(t *testing.T) {
 			model.ComponentContext7,
 			model.ComponentPermission,
 			model.ComponentGGA,
+			model.ComponentTheme,
 			model.ComponentClaudeTheme,
 			model.ComponentOpenCodeGentleLogo,
 			model.ComponentPersona,
@@ -118,7 +119,7 @@ func TestNormalizeInstallFlagsFullPresetCustomPersonaKeepsPresetPolish(t *testin
 		}
 	}
 
-	for _, want := range []model.ComponentID{model.ComponentClaudeTheme, model.ComponentOpenCodeGentleLogo} {
+	for _, want := range model.VisualPolishComponents() {
 		found := false
 		for _, got := range input.Selection.Components {
 			if got == want {

--- a/internal/cli/install_test.go
+++ b/internal/cli/install_test.go
@@ -103,7 +103,7 @@ func TestNormalizeInstallFlagsChannelBeta(t *testing.T) {
 	}
 }
 
-func TestNormalizeInstallFlagsFullPresetCustomPersonaExcludesManagedPolish(t *testing.T) {
+func TestNormalizeInstallFlagsFullPresetCustomPersonaKeepsPresetPolish(t *testing.T) {
 	input, err := NormalizeInstallFlags(InstallFlags{
 		Preset:  string(model.PresetFullGentleman),
 		Persona: string(model.PersonaCustom),
@@ -112,11 +112,22 @@ func TestNormalizeInstallFlagsFullPresetCustomPersonaExcludesManagedPolish(t *te
 		t.Fatalf("NormalizeInstallFlags() error = %v", err)
 	}
 
-	for _, forbidden := range []model.ComponentID{model.ComponentPersona, model.ComponentClaudeTheme, model.ComponentOpenCodeGentleLogo} {
+	for _, got := range input.Selection.Components {
+		if got == model.ComponentPersona {
+			t.Fatalf("components should not include persona for custom persona; got %#v", input.Selection.Components)
+		}
+	}
+
+	for _, want := range []model.ComponentID{model.ComponentClaudeTheme, model.ComponentOpenCodeGentleLogo} {
+		found := false
 		for _, got := range input.Selection.Components {
-			if got == forbidden {
-				t.Fatalf("components should not include %q for custom persona; got %#v", forbidden, input.Selection.Components)
+			if got == want {
+				found = true
+				break
 			}
+		}
+		if !found {
+			t.Fatalf("components should include preset polish %q; got %#v", want, input.Selection.Components)
 		}
 	}
 }

--- a/internal/cli/install_test.go
+++ b/internal/cli/install_test.go
@@ -103,6 +103,24 @@ func TestNormalizeInstallFlagsChannelBeta(t *testing.T) {
 	}
 }
 
+func TestNormalizeInstallFlagsFullPresetCustomPersonaExcludesManagedPolish(t *testing.T) {
+	input, err := NormalizeInstallFlags(InstallFlags{
+		Preset:  string(model.PresetFullGentleman),
+		Persona: string(model.PersonaCustom),
+	}, system.DetectionResult{})
+	if err != nil {
+		t.Fatalf("NormalizeInstallFlags() error = %v", err)
+	}
+
+	for _, forbidden := range []model.ComponentID{model.ComponentPersona, model.ComponentClaudeTheme, model.ComponentOpenCodeGentleLogo} {
+		for _, got := range input.Selection.Components {
+			if got == forbidden {
+				t.Fatalf("components should not include %q for custom persona; got %#v", forbidden, input.Selection.Components)
+			}
+		}
+	}
+}
+
 func TestNormalizeInstallFlagsCustomAcceptsOptionalGentlemanInstallables(t *testing.T) {
 	input, err := NormalizeInstallFlags(InstallFlags{
 		Preset:     string(model.PresetCustom),

--- a/internal/cli/validate.go
+++ b/internal/cli/validate.go
@@ -156,30 +156,7 @@ func normalizeSDDMode(value string) (model.SDDModeID, error) {
 }
 
 func componentsForPreset(preset model.PresetID, persona model.PersonaID) []model.ComponentID {
-	var components []model.ComponentID
-	switch preset {
-	case model.PresetMinimal:
-		components = []model.ComponentID{model.ComponentEngram}
-	case model.PresetEcosystemOnly:
-		components = []model.ComponentID{model.ComponentEngram, model.ComponentSDD, model.ComponentSkills, model.ComponentContext7, model.ComponentGGA}
-	case model.PresetCustom:
-		return nil
-	default: // full-gentleman
-		components = []model.ComponentID{
-			model.ComponentEngram,
-			model.ComponentSDD,
-			model.ComponentSkills,
-			model.ComponentContext7,
-			model.ComponentPermission,
-			model.ComponentGGA,
-			model.ComponentClaudeTheme,
-			model.ComponentOpenCodeGentleLogo,
-		}
-	}
-	if persona != model.PersonaCustom {
-		components = append(components, model.ComponentPersona)
-	}
-	return components
+	return model.ComponentsForPreset(preset, persona)
 }
 
 func defaultAgentsFromDetection(detection system.DetectionResult) []model.AgentID {

--- a/internal/components/uninstall/service.go
+++ b/internal/components/uninstall/service.go
@@ -259,9 +259,9 @@ func (s *Service) PartialUninstallWithProfiles(agentIDs []model.AgentID, compone
 
 func expandVisualPolishUninstallComponents(components []model.ComponentID) []model.ComponentID {
 	shouldExpand := false
+	visualPolish := model.VisualPolishComponents()
 	for _, component := range components {
-		switch component {
-		case model.ComponentTheme, model.ComponentClaudeTheme, model.ComponentOpenCodeGentleLogo:
+		if slices.Contains(visualPolish, component) {
 			shouldExpand = true
 		}
 	}
@@ -270,7 +270,7 @@ func expandVisualPolishUninstallComponents(components []model.ComponentID) []mod
 	}
 
 	expanded := slices.Clone(components)
-	for _, component := range []model.ComponentID{model.ComponentTheme, model.ComponentClaudeTheme, model.ComponentOpenCodeGentleLogo} {
+	for _, component := range model.VisualPolishComponents() {
 		if !slices.Contains(expanded, component) {
 			expanded = append(expanded, component)
 		}

--- a/internal/components/uninstall/service.go
+++ b/internal/components/uninstall/service.go
@@ -218,6 +218,7 @@ func (s *Service) PartialUninstall(agentIDs []model.AgentID, componentIDs []mode
 	if len(components) == 0 {
 		components = slices.Clone(allManagedComponents)
 	}
+	components = expandVisualPolishUninstallComponents(components)
 
 	plan, err := s.buildPlan(agentIDs, components)
 	if err != nil {
@@ -245,6 +246,7 @@ func (s *Service) PartialUninstallWithProfiles(agentIDs []model.AgentID, compone
 	if len(components) == 0 {
 		components = slices.Clone(allManagedComponents)
 	}
+	components = expandVisualPolishUninstallComponents(components)
 
 	plan, err := s.buildPlan(agentIDs, components)
 	if err != nil {
@@ -253,6 +255,27 @@ func (s *Service) PartialUninstallWithProfiles(agentIDs []model.AgentID, compone
 
 	stateRemovals := stateAgentsToRemove(agentIDs, components)
 	return s.executePlan(plan, stateRemovals)
+}
+
+func expandVisualPolishUninstallComponents(components []model.ComponentID) []model.ComponentID {
+	shouldExpand := false
+	for _, component := range components {
+		switch component {
+		case model.ComponentTheme, model.ComponentClaudeTheme, model.ComponentOpenCodeGentleLogo:
+			shouldExpand = true
+		}
+	}
+	if !shouldExpand {
+		return components
+	}
+
+	expanded := slices.Clone(components)
+	for _, component := range []model.ComponentID{model.ComponentTheme, model.ComponentClaudeTheme, model.ComponentOpenCodeGentleLogo} {
+		if !slices.Contains(expanded, component) {
+			expanded = append(expanded, component)
+		}
+	}
+	return expanded
 }
 
 func (s *Service) SetProfileNamesToRemove(profileNames []string) {

--- a/internal/components/uninstall/service_test.go
+++ b/internal/components/uninstall/service_test.go
@@ -17,6 +17,20 @@ import (
 
 type stubSnapshotter struct{}
 
+func TestExpandVisualPolishUninstallComponents(t *testing.T) {
+	got := expandVisualPolishUninstallComponents([]model.ComponentID{model.ComponentTheme})
+	for _, want := range []model.ComponentID{model.ComponentTheme, model.ComponentClaudeTheme, model.ComponentOpenCodeGentleLogo} {
+		if !slices.Contains(got, want) {
+			t.Fatalf("expanded visual polish components missing %q: %v", want, got)
+		}
+	}
+
+	unchanged := expandVisualPolishUninstallComponents([]model.ComponentID{model.ComponentPersona})
+	if !slices.Equal(unchanged, []model.ComponentID{model.ComponentPersona}) {
+		t.Fatalf("non-polish components should not expand: %v", unchanged)
+	}
+}
+
 func readJSONFileForTest(t *testing.T, path string) map[string]any {
 	t.Helper()
 	data, err := os.ReadFile(path)

--- a/internal/components/uninstall/service_test.go
+++ b/internal/components/uninstall/service_test.go
@@ -18,16 +18,80 @@ import (
 type stubSnapshotter struct{}
 
 func TestExpandVisualPolishUninstallComponents(t *testing.T) {
-	got := expandVisualPolishUninstallComponents([]model.ComponentID{model.ComponentTheme})
-	for _, want := range []model.ComponentID{model.ComponentTheme, model.ComponentClaudeTheme, model.ComponentOpenCodeGentleLogo} {
-		if !slices.Contains(got, want) {
-			t.Fatalf("expanded visual polish components missing %q: %v", want, got)
-		}
+	for _, trigger := range model.VisualPolishComponents() {
+		t.Run(string(trigger), func(t *testing.T) {
+			got := expandVisualPolishUninstallComponents([]model.ComponentID{trigger})
+			for _, want := range model.VisualPolishComponents() {
+				if !slices.Contains(got, want) {
+					t.Fatalf("expanded visual polish components missing %q: %v", want, got)
+				}
+			}
+		})
 	}
 
 	unchanged := expandVisualPolishUninstallComponents([]model.ComponentID{model.ComponentPersona})
 	if !slices.Equal(unchanged, []model.ComponentID{model.ComponentPersona}) {
 		t.Fatalf("non-polish components should not expand: %v", unchanged)
+	}
+}
+
+func TestPartialUninstallVisualPolishSelectionRemovesThemeLogoGroup(t *testing.T) {
+	homeDir := t.TempDir()
+	workspaceDir := t.TempDir()
+
+	svc, err := NewService(homeDir, workspaceDir, "dev")
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	svc.snapshotter = stubSnapshotter{}
+
+	opencodeAdapter, ok := svc.registry.Get(model.AgentOpenCode)
+	if !ok {
+		t.Fatal("opencode adapter not found in registry")
+	}
+	settingsPath := opencodeAdapter.SettingsPath(homeDir)
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(opencode settings dir) error = %v", err)
+	}
+	if err := os.WriteFile(settingsPath, []byte(`{"theme":"gentleman-kanagawa","keep":true}`), 0o644); err != nil {
+		t.Fatalf("WriteFile(opencode settings) error = %v", err)
+	}
+
+	logoPath := filepath.Join(homeDir, ".config", "opencode", "tui-plugins", "gentle-logo.tsx")
+	if err := os.MkdirAll(filepath.Dir(logoPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(logo dir) error = %v", err)
+	}
+	if err := os.WriteFile(logoPath, []byte("// managed logo"), 0o644); err != nil {
+		t.Fatalf("WriteFile(logo) error = %v", err)
+	}
+
+	claudeThemePath := filepath.Join(homeDir, ".claude", "themes", "gentleman.json")
+	if err := os.MkdirAll(filepath.Dir(claudeThemePath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(claude theme dir) error = %v", err)
+	}
+	if err := os.WriteFile(claudeThemePath, []byte(`{"name":"Gentleman"}`), 0o644); err != nil {
+		t.Fatalf("WriteFile(claude theme) error = %v", err)
+	}
+
+	if _, err := svc.PartialUninstall(
+		[]model.AgentID{model.AgentOpenCode, model.AgentClaudeCode},
+		[]model.ComponentID{model.ComponentTheme},
+	); err != nil {
+		t.Fatalf("PartialUninstall() error = %v", err)
+	}
+
+	settings := readJSONFileForTest(t, settingsPath)
+	if _, exists := settings["theme"]; exists {
+		t.Fatalf("theme should be removed from OpenCode settings: %#v", settings)
+	}
+	if got := settings["keep"]; got != true {
+		t.Fatalf("user setting should be preserved, got %#v", got)
+	}
+	if _, err := os.Stat(logoPath); !os.IsNotExist(err) {
+		t.Fatalf("OpenCode logo should be removed by visual polish group uninstall, err = %v", err)
+	}
+	if _, err := os.Stat(claudeThemePath); !os.IsNotExist(err) {
+		t.Fatalf("Claude theme should be removed by visual polish group uninstall, err = %v", err)
 	}
 }
 

--- a/internal/model/presets.go
+++ b/internal/model/presets.go
@@ -1,8 +1,8 @@
 package model
 
 // ComponentsForPreset returns the managed components implied by a preset/persona
-// pair. PersonaCustom is a full opt-out from managed persona and managed visual
-// polish, even when the user selects the full Gentleman preset.
+// pair. PersonaCustom opts out of managed persona only; preset choice still
+// controls visual polish.
 func ComponentsForPreset(preset PresetID, persona PersonaID) []ComponentID {
 	var components []ComponentID
 	switch preset {
@@ -20,9 +20,8 @@ func ComponentsForPreset(preset PresetID, persona PersonaID) []ComponentID {
 			ComponentContext7,
 			ComponentPermission,
 			ComponentGGA,
-		}
-		if persona != PersonaCustom {
-			components = append(components, ComponentClaudeTheme, ComponentOpenCodeGentleLogo)
+			ComponentClaudeTheme,
+			ComponentOpenCodeGentleLogo,
 		}
 	}
 	if persona != PersonaCustom {

--- a/internal/model/presets.go
+++ b/internal/model/presets.go
@@ -1,5 +1,11 @@
 package model
 
+// VisualPolishComponents returns the managed theme/logo components that make up
+// the visual polish option across install and uninstall flows.
+func VisualPolishComponents() []ComponentID {
+	return []ComponentID{ComponentTheme, ComponentClaudeTheme, ComponentOpenCodeGentleLogo}
+}
+
 // ComponentsForPreset returns the managed components implied by a preset/persona
 // pair. PersonaCustom opts out of managed persona only; preset choice still
 // controls visual polish.
@@ -20,9 +26,8 @@ func ComponentsForPreset(preset PresetID, persona PersonaID) []ComponentID {
 			ComponentContext7,
 			ComponentPermission,
 			ComponentGGA,
-			ComponentClaudeTheme,
-			ComponentOpenCodeGentleLogo,
 		}
+		components = append(components, VisualPolishComponents()...)
 	}
 	if persona != PersonaCustom {
 		components = append(components, ComponentPersona)

--- a/internal/model/presets.go
+++ b/internal/model/presets.go
@@ -1,0 +1,32 @@
+package model
+
+// ComponentsForPreset returns the managed components implied by a preset/persona
+// pair. PersonaCustom is a full opt-out from managed persona and managed visual
+// polish, even when the user selects the full Gentleman preset.
+func ComponentsForPreset(preset PresetID, persona PersonaID) []ComponentID {
+	var components []ComponentID
+	switch preset {
+	case PresetMinimal:
+		components = []ComponentID{ComponentEngram}
+	case PresetEcosystemOnly:
+		components = []ComponentID{ComponentEngram, ComponentSDD, ComponentSkills, ComponentContext7, ComponentGGA}
+	case PresetCustom:
+		return nil
+	default: // full-gentleman
+		components = []ComponentID{
+			ComponentEngram,
+			ComponentSDD,
+			ComponentSkills,
+			ComponentContext7,
+			ComponentPermission,
+			ComponentGGA,
+		}
+		if persona != PersonaCustom {
+			components = append(components, ComponentClaudeTheme, ComponentOpenCodeGentleLogo)
+		}
+	}
+	if persona != PersonaCustom {
+		components = append(components, ComponentPersona)
+	}
+	return components
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -4038,30 +4038,7 @@ func (m *Model) applyPickerEntry(next Screen) {
 }
 
 func componentsForPreset(preset model.PresetID, persona model.PersonaID) []model.ComponentID {
-	var components []model.ComponentID
-	switch preset {
-	case model.PresetMinimal:
-		components = []model.ComponentID{model.ComponentEngram}
-	case model.PresetEcosystemOnly:
-		components = []model.ComponentID{model.ComponentEngram, model.ComponentSDD, model.ComponentSkills, model.ComponentContext7, model.ComponentGGA}
-	case model.PresetCustom:
-		return nil
-	default: // full-gentleman
-		components = []model.ComponentID{
-			model.ComponentEngram,
-			model.ComponentSDD,
-			model.ComponentSkills,
-			model.ComponentContext7,
-			model.ComponentPermission,
-			model.ComponentGGA,
-			model.ComponentClaudeTheme,
-			model.ComponentOpenCodeGentleLogo,
-		}
-	}
-	if persona != model.PersonaCustom {
-		components = append(components, model.ComponentPersona)
-	}
-	return components
+	return model.ComponentsForPreset(preset, persona)
 }
 
 func hasSelectedComponent(components []model.ComponentID, target model.ComponentID) bool {

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -4523,12 +4523,12 @@ func TestComponentsForPreset_PersonaMatrix(t *testing.T) {
 			wantOpenCodeLogo: true,
 		},
 		{
-			name:             "full-gentleman + custom excludes persona and visual polish",
+			name:             "full-gentleman + custom excludes persona but keeps visual polish",
 			preset:           model.PresetFullGentleman,
 			persona:          model.PersonaCustom,
 			wantPersona:      false,
-			wantClaudeTheme:  false,
-			wantOpenCodeLogo: false,
+			wantClaudeTheme:  true,
+			wantOpenCodeLogo: true,
 		},
 		{
 			name:        "minimal + gentleman includes persona",
@@ -4649,14 +4649,22 @@ func TestPersonaScreenRecomputesComponentsWhenPresetAlreadySet(t *testing.T) {
 		t.Fatalf("Persona = %v, want %v", state.Selection.Persona, model.PersonaCustom)
 	}
 
-	// ComponentPersona and managed visual polish must be removed after recompute.
+	// ComponentPersona must be removed after recompute, but preset-owned visual polish remains.
+	hasClaudeThemeAfter := false
+	hasOpenCodeLogoAfter := false
 	for _, c := range state.Selection.Components {
 		if c == model.ComponentPersona {
 			t.Fatalf("ComponentPersona must not be in components after switching to PersonaCustom; got: %v", state.Selection.Components)
 		}
-		if c == model.ComponentClaudeTheme || c == model.ComponentOpenCodeGentleLogo {
-			t.Fatalf("managed visual polish must not be in components after switching to PersonaCustom; got: %v", state.Selection.Components)
+		if c == model.ComponentClaudeTheme {
+			hasClaudeThemeAfter = true
 		}
+		if c == model.ComponentOpenCodeGentleLogo {
+			hasOpenCodeLogoAfter = true
+		}
+	}
+	if !hasClaudeThemeAfter || !hasOpenCodeLogoAfter {
+		t.Fatalf("visual polish should remain preset-owned after switching to PersonaCustom; got: %v", state.Selection.Components)
 	}
 }
 

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -4506,23 +4506,29 @@ func TestPinErrClearedOnScreenReentry(t *testing.T) {
 // ComponentPersona when persona != PersonaCustom and excludes it for PersonaCustom.
 func TestComponentsForPreset_PersonaMatrix(t *testing.T) {
 	tests := []struct {
-		name        string
-		preset      model.PresetID
-		persona     model.PersonaID
-		wantPersona bool
-		wantNil     bool
+		name             string
+		preset           model.PresetID
+		persona          model.PersonaID
+		wantPersona      bool
+		wantClaudeTheme  bool
+		wantOpenCodeLogo bool
+		wantNil          bool
 	}{
 		{
-			name:        "full-gentleman + gentleman includes persona",
-			preset:      model.PresetFullGentleman,
-			persona:     model.PersonaGentleman,
-			wantPersona: true,
+			name:             "full-gentleman + gentleman includes persona and visual polish",
+			preset:           model.PresetFullGentleman,
+			persona:          model.PersonaGentleman,
+			wantPersona:      true,
+			wantClaudeTheme:  true,
+			wantOpenCodeLogo: true,
 		},
 		{
-			name:        "full-gentleman + custom does not include persona",
-			preset:      model.PresetFullGentleman,
-			persona:     model.PersonaCustom,
-			wantPersona: false,
+			name:             "full-gentleman + custom excludes persona and visual polish",
+			preset:           model.PresetFullGentleman,
+			persona:          model.PersonaCustom,
+			wantPersona:      false,
+			wantClaudeTheme:  false,
+			wantOpenCodeLogo: false,
 		},
 		{
 			name:        "minimal + gentleman includes persona",
@@ -4574,10 +4580,17 @@ func TestComponentsForPreset_PersonaMatrix(t *testing.T) {
 			}
 
 			hasPersona := false
+			hasClaudeTheme := false
+			hasOpenCodeLogo := false
 			for _, c := range got {
 				if c == model.ComponentPersona {
 					hasPersona = true
-					break
+				}
+				if c == model.ComponentClaudeTheme {
+					hasClaudeTheme = true
+				}
+				if c == model.ComponentOpenCodeGentleLogo {
+					hasOpenCodeLogo = true
 				}
 			}
 
@@ -4586,6 +4599,12 @@ func TestComponentsForPreset_PersonaMatrix(t *testing.T) {
 			}
 			if !tt.wantPersona && hasPersona {
 				t.Fatalf("componentsForPreset(%v, %v) should not include ComponentPersona; got: %v", tt.preset, tt.persona, got)
+			}
+			if tt.wantClaudeTheme != hasClaudeTheme {
+				t.Fatalf("componentsForPreset(%v, %v) ComponentClaudeTheme present = %v, want %v; got: %v", tt.preset, tt.persona, hasClaudeTheme, tt.wantClaudeTheme, got)
+			}
+			if tt.wantOpenCodeLogo != hasOpenCodeLogo {
+				t.Fatalf("componentsForPreset(%v, %v) ComponentOpenCodeGentleLogo present = %v, want %v; got: %v", tt.preset, tt.persona, hasOpenCodeLogo, tt.wantOpenCodeLogo, got)
 			}
 		})
 	}
@@ -4603,16 +4622,22 @@ func TestPersonaScreenRecomputesComponentsWhenPresetAlreadySet(t *testing.T) {
 	m.Selection.Persona = model.PersonaGentleman
 	m.Selection.Components = componentsForPreset(model.PresetFullGentleman, model.PersonaGentleman)
 
-	// Confirm that persona currently includes ComponentPersona.
+	// Confirm that managed persona and visual polish are initially included.
 	hasPersonaBefore := false
+	hasPolishBefore := false
 	for _, c := range m.Selection.Components {
 		if c == model.ComponentPersona {
 			hasPersonaBefore = true
-			break
+		}
+		if c == model.ComponentClaudeTheme || c == model.ComponentOpenCodeGentleLogo {
+			hasPolishBefore = true
 		}
 	}
 	if !hasPersonaBefore {
 		t.Fatal("setup: expected ComponentPersona in initial components")
+	}
+	if !hasPolishBefore {
+		t.Fatal("setup: expected managed visual polish in initial components")
 	}
 
 	// Move cursor to PersonaCustom and confirm.
@@ -4624,10 +4649,13 @@ func TestPersonaScreenRecomputesComponentsWhenPresetAlreadySet(t *testing.T) {
 		t.Fatalf("Persona = %v, want %v", state.Selection.Persona, model.PersonaCustom)
 	}
 
-	// ComponentPersona must be removed after recompute.
+	// ComponentPersona and managed visual polish must be removed after recompute.
 	for _, c := range state.Selection.Components {
 		if c == model.ComponentPersona {
 			t.Fatalf("ComponentPersona must not be in components after switching to PersonaCustom; got: %v", state.Selection.Components)
+		}
+		if c == model.ComponentClaudeTheme || c == model.ComponentOpenCodeGentleLogo {
+			t.Fatalf("managed visual polish must not be in components after switching to PersonaCustom; got: %v", state.Selection.Components)
 		}
 	}
 }

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -4510,6 +4510,7 @@ func TestComponentsForPreset_PersonaMatrix(t *testing.T) {
 		preset           model.PresetID
 		persona          model.PersonaID
 		wantPersona      bool
+		wantTheme        bool
 		wantClaudeTheme  bool
 		wantOpenCodeLogo bool
 		wantNil          bool
@@ -4519,6 +4520,7 @@ func TestComponentsForPreset_PersonaMatrix(t *testing.T) {
 			preset:           model.PresetFullGentleman,
 			persona:          model.PersonaGentleman,
 			wantPersona:      true,
+			wantTheme:        true,
 			wantClaudeTheme:  true,
 			wantOpenCodeLogo: true,
 		},
@@ -4527,6 +4529,7 @@ func TestComponentsForPreset_PersonaMatrix(t *testing.T) {
 			preset:           model.PresetFullGentleman,
 			persona:          model.PersonaCustom,
 			wantPersona:      false,
+			wantTheme:        true,
 			wantClaudeTheme:  true,
 			wantOpenCodeLogo: true,
 		},
@@ -4580,11 +4583,15 @@ func TestComponentsForPreset_PersonaMatrix(t *testing.T) {
 			}
 
 			hasPersona := false
+			hasTheme := false
 			hasClaudeTheme := false
 			hasOpenCodeLogo := false
 			for _, c := range got {
 				if c == model.ComponentPersona {
 					hasPersona = true
+				}
+				if c == model.ComponentTheme {
+					hasTheme = true
 				}
 				if c == model.ComponentClaudeTheme {
 					hasClaudeTheme = true
@@ -4599,6 +4606,9 @@ func TestComponentsForPreset_PersonaMatrix(t *testing.T) {
 			}
 			if !tt.wantPersona && hasPersona {
 				t.Fatalf("componentsForPreset(%v, %v) should not include ComponentPersona; got: %v", tt.preset, tt.persona, got)
+			}
+			if tt.wantTheme != hasTheme {
+				t.Fatalf("componentsForPreset(%v, %v) ComponentTheme present = %v, want %v; got: %v", tt.preset, tt.persona, hasTheme, tt.wantTheme, got)
 			}
 			if tt.wantClaudeTheme != hasClaudeTheme {
 				t.Fatalf("componentsForPreset(%v, %v) ComponentClaudeTheme present = %v, want %v; got: %v", tt.preset, tt.persona, hasClaudeTheme, tt.wantClaudeTheme, got)
@@ -4629,7 +4639,7 @@ func TestPersonaScreenRecomputesComponentsWhenPresetAlreadySet(t *testing.T) {
 		if c == model.ComponentPersona {
 			hasPersonaBefore = true
 		}
-		if c == model.ComponentClaudeTheme || c == model.ComponentOpenCodeGentleLogo {
+		if slices.Contains(model.VisualPolishComponents(), c) {
 			hasPolishBefore = true
 		}
 	}
@@ -4650,21 +4660,15 @@ func TestPersonaScreenRecomputesComponentsWhenPresetAlreadySet(t *testing.T) {
 	}
 
 	// ComponentPersona must be removed after recompute, but preset-owned visual polish remains.
-	hasClaudeThemeAfter := false
-	hasOpenCodeLogoAfter := false
 	for _, c := range state.Selection.Components {
 		if c == model.ComponentPersona {
 			t.Fatalf("ComponentPersona must not be in components after switching to PersonaCustom; got: %v", state.Selection.Components)
 		}
-		if c == model.ComponentClaudeTheme {
-			hasClaudeThemeAfter = true
-		}
-		if c == model.ComponentOpenCodeGentleLogo {
-			hasOpenCodeLogoAfter = true
-		}
 	}
-	if !hasClaudeThemeAfter || !hasOpenCodeLogoAfter {
-		t.Fatalf("visual polish should remain preset-owned after switching to PersonaCustom; got: %v", state.Selection.Components)
+	for _, want := range model.VisualPolishComponents() {
+		if !slices.Contains(state.Selection.Components, want) {
+			t.Fatalf("visual polish should remain preset-owned after switching to PersonaCustom; missing %v in %v", want, state.Selection.Components)
+		}
 	}
 }
 
@@ -4684,6 +4688,49 @@ func TestPersonaScreenDoesNotRecomputeForCustomPreset(t *testing.T) {
 	// Components must remain nil for custom preset.
 	if state.Selection.Components != nil {
 		t.Fatalf("components should stay nil for custom preset; got: %v", state.Selection.Components)
+	}
+}
+
+func TestCustomPersonaCustomPresetCanSelectEngramWithoutPersonaOrPolish(t *testing.T) {
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Screen = ScreenPreset
+	m.Selection.Persona = model.PersonaCustom
+	m.Cursor = len(screens.PresetOptions()) - 1 // Custom preset
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	state := updated.(Model)
+
+	if state.Selection.Preset != model.PresetCustom {
+		t.Fatalf("Preset = %v, want %v", state.Selection.Preset, model.PresetCustom)
+	}
+	if state.Screen != ScreenDependencyTree {
+		t.Fatalf("Screen = %v, want ScreenDependencyTree for custom component selection", state.Screen)
+	}
+	if len(state.Selection.Components) != 0 {
+		t.Fatalf("custom preset should start with no components selected; got %v", state.Selection.Components)
+	}
+
+	engramCursor := -1
+	for idx, component := range screens.AllComponents() {
+		if component.ID == model.ComponentEngram {
+			engramCursor = idx
+			break
+		}
+	}
+	if engramCursor < 0 {
+		t.Fatal("Engram component not found in custom component picker")
+	}
+	state.Cursor = engramCursor
+	updated, _ = state.Update(tea.KeyMsg{Type: tea.KeySpace})
+	state = updated.(Model)
+
+	if !slices.Equal(state.Selection.Components, []model.ComponentID{model.ComponentEngram}) {
+		t.Fatalf("components = %v, want only Engram selected", state.Selection.Components)
+	}
+	for _, unwanted := range append([]model.ComponentID{model.ComponentPersona}, model.VisualPolishComponents()...) {
+		if slices.Contains(state.Selection.Components, unwanted) {
+			t.Fatalf("custom preset should not auto-select %v; components: %v", unwanted, state.Selection.Components)
+		}
 	}
 }
 

--- a/internal/tui/screens/persona.go
+++ b/internal/tui/screens/persona.go
@@ -15,7 +15,7 @@ var personaDescriptions = map[model.PersonaID]string{
 	model.PersonaGentleman:                 "Managed Gentleman persona with teaching-first guidance",
 	model.PersonaGentlemanNeutralArtifacts: "Gentleman conversation with English technical artifacts and comments in context language",
 	model.PersonaNeutral:                   "Managed neutral persona with the same guidance and less regional tone",
-	model.PersonaCustom:                    "Keep your existing persona unmanaged; gentle-ai does not inject a persona",
+	model.PersonaCustom:                    "Keep your existing persona and visual polish unmanaged",
 }
 
 func RenderPersona(selected model.PersonaID, cursor int) string {

--- a/internal/tui/screens/persona.go
+++ b/internal/tui/screens/persona.go
@@ -15,7 +15,7 @@ var personaDescriptions = map[model.PersonaID]string{
 	model.PersonaGentleman:                 "Managed Gentleman persona with teaching-first guidance",
 	model.PersonaGentlemanNeutralArtifacts: "Gentleman conversation with English technical artifacts and comments in context language",
 	model.PersonaNeutral:                   "Managed neutral persona with the same guidance and less regional tone",
-	model.PersonaCustom:                    "Keep your existing persona unmanaged; preset still controls visual polish",
+	model.PersonaCustom:                    "Do not install a managed persona; choose themes/logo on the next screens",
 }
 
 func RenderPersona(selected model.PersonaID, cursor int) string {

--- a/internal/tui/screens/persona.go
+++ b/internal/tui/screens/persona.go
@@ -15,7 +15,7 @@ var personaDescriptions = map[model.PersonaID]string{
 	model.PersonaGentleman:                 "Managed Gentleman persona with teaching-first guidance",
 	model.PersonaGentlemanNeutralArtifacts: "Gentleman conversation with English technical artifacts and comments in context language",
 	model.PersonaNeutral:                   "Managed neutral persona with the same guidance and less regional tone",
-	model.PersonaCustom:                    "Keep your existing persona and visual polish unmanaged",
+	model.PersonaCustom:                    "Keep your existing persona unmanaged; preset still controls visual polish",
 }
 
 func RenderPersona(selected model.PersonaID, cursor int) string {

--- a/internal/tui/screens/persona_preset_test.go
+++ b/internal/tui/screens/persona_preset_test.go
@@ -13,7 +13,7 @@ func TestRenderPersonaClarifiesCustomKeepsExistingPersona(t *testing.T) {
 	if !strings.Contains(out, "custom") {
 		t.Fatalf("RenderPersona missing custom option; output:\n%s", out)
 	}
-	if !strings.Contains(out, "Keep your existing persona unmanaged; preset still controls visual polish") {
+	if !strings.Contains(out, "Do not install a managed persona; choose themes/logo on the next screens") {
 		t.Fatalf("RenderPersona missing custom persona clarification; output:\n%s", out)
 	}
 	if strings.Contains(out, "Bring your own persona instructions") {
@@ -24,7 +24,7 @@ func TestRenderPersonaClarifiesCustomKeepsExistingPersona(t *testing.T) {
 func TestRenderPresetClarifiesCustomManualSelection(t *testing.T) {
 	out := RenderPreset(model.PresetCustom, 3)
 
-	if !strings.Contains(out, "Choose components and skills manually") {
+	if !strings.Contains(out, "Choose each component manually") {
 		t.Fatalf("RenderPreset missing custom preset clarification; output:\n%s", out)
 	}
 	if strings.Contains(out, "Pick individual components yourself") {

--- a/internal/tui/screens/persona_preset_test.go
+++ b/internal/tui/screens/persona_preset_test.go
@@ -13,7 +13,7 @@ func TestRenderPersonaClarifiesCustomKeepsExistingPersona(t *testing.T) {
 	if !strings.Contains(out, "custom") {
 		t.Fatalf("RenderPersona missing custom option; output:\n%s", out)
 	}
-	if !strings.Contains(out, "Keep your existing persona unmanaged") {
+	if !strings.Contains(out, "Keep your existing persona and visual polish unmanaged") {
 		t.Fatalf("RenderPersona missing custom persona clarification; output:\n%s", out)
 	}
 	if strings.Contains(out, "Bring your own persona instructions") {

--- a/internal/tui/screens/persona_preset_test.go
+++ b/internal/tui/screens/persona_preset_test.go
@@ -13,7 +13,7 @@ func TestRenderPersonaClarifiesCustomKeepsExistingPersona(t *testing.T) {
 	if !strings.Contains(out, "custom") {
 		t.Fatalf("RenderPersona missing custom option; output:\n%s", out)
 	}
-	if !strings.Contains(out, "Keep your existing persona and visual polish unmanaged") {
+	if !strings.Contains(out, "Keep your existing persona unmanaged; preset still controls visual polish") {
 		t.Fatalf("RenderPersona missing custom persona clarification; output:\n%s", out)
 	}
 	if strings.Contains(out, "Bring your own persona instructions") {

--- a/internal/tui/screens/preset.go
+++ b/internal/tui/screens/preset.go
@@ -19,14 +19,14 @@ func PresetOptions() []model.PresetID {
 var presetDescriptions = map[model.PresetID]string{
 	model.PresetMinimal:       "Just Engram persistent memory across sessions",
 	model.PresetEcosystemOnly: "Memory + SDD + skills + docs + GGA",
-	model.PresetFullGentleman: "Dev Stack + security gates; adds theme/logo only with managed persona",
-	model.PresetCustom:        "Choose components and skills manually; keep existing persona/visual settings unmanaged",
+	model.PresetFullGentleman: "Dev Stack + security gates, theme, and logo",
+	model.PresetCustom:        "Choose components and skills manually; keep existing persona/settings unmanaged",
 }
 
 var presetLabels = map[model.PresetID]string{
 	model.PresetMinimal:       "Memory Only",
 	model.PresetEcosystemOnly: "Dev Stack",
-	model.PresetFullGentleman: "Dev Stack + Managed Polish",
+	model.PresetFullGentleman: "Dev Stack + Polish",
 	model.PresetCustom:        "Custom",
 }
 

--- a/internal/tui/screens/preset.go
+++ b/internal/tui/screens/preset.go
@@ -19,14 +19,14 @@ func PresetOptions() []model.PresetID {
 var presetDescriptions = map[model.PresetID]string{
 	model.PresetMinimal:       "Just Engram persistent memory across sessions",
 	model.PresetEcosystemOnly: "Memory + SDD + skills + docs + GGA",
-	model.PresetFullGentleman: "Dev Stack + security gates, theme, and logo",
-	model.PresetCustom:        "Choose components and skills manually; keep existing persona/settings unmanaged",
+	model.PresetFullGentleman: "Dev Stack + security gates; adds theme/logo only with managed persona",
+	model.PresetCustom:        "Choose components and skills manually; keep existing persona/visual settings unmanaged",
 }
 
 var presetLabels = map[model.PresetID]string{
 	model.PresetMinimal:       "Memory Only",
 	model.PresetEcosystemOnly: "Dev Stack",
-	model.PresetFullGentleman: "Dev Stack + Polish",
+	model.PresetFullGentleman: "Dev Stack + Managed Polish",
 	model.PresetCustom:        "Custom",
 }
 

--- a/internal/tui/screens/preset.go
+++ b/internal/tui/screens/preset.go
@@ -19,8 +19,8 @@ func PresetOptions() []model.PresetID {
 var presetDescriptions = map[model.PresetID]string{
 	model.PresetMinimal:       "Just Engram persistent memory across sessions",
 	model.PresetEcosystemOnly: "Memory + SDD + skills + docs + GGA",
-	model.PresetFullGentleman: "Dev Stack + security gates, theme, and logo",
-	model.PresetCustom:        "Choose components and skills manually; keep existing persona/settings unmanaged",
+	model.PresetFullGentleman: "Dev Stack plus managed themes and logo polish",
+	model.PresetCustom:        "Choose each component manually: memory, persona, themes, logo, and more",
 }
 
 var presetLabels = map[model.PresetID]string{

--- a/internal/tui/testdata/preset-custom-no-opencode-next.golden
+++ b/internal/tui/testdata/preset-custom-no-opencode-next.golden
@@ -11,17 +11,17 @@ Toggle components with enter or space.
   [ ] context7
     Latest framework and library docs
   [ ] persona
-    Gentleman, neutral or custom behavior
+    Managed agent behavior and conversation tone
   [ ] permissions
     Security-first defaults and guardrails
   [ ] gga
     Gentleman Guardian Angel — AI provider switcher
   [ ] theme
-    Gentleman Kanagawa theme overlay
+    Visual polish: Gentleman Kanagawa theme overlay
   [ ] claude-theme
-    Claude Code Gentleman custom theme
+    Visual polish: Claude Code Gentleman custom theme
   [ ] opencode-gentle-logo
-    OpenCode home logo TUI plugin with Braille rose
+    Visual polish: OpenCode home logo TUI plugin with Braille rose
 
   Continue
   Back

--- a/internal/tui/testdata/preset-custom-no-opencode-next.golden
+++ b/internal/tui/testdata/preset-custom-no-opencode-next.golden
@@ -17,11 +17,11 @@ Toggle components with enter or space.
   [ ] gga
     Gentleman Guardian Angel — AI provider switcher
   [ ] theme
-    Visual polish: Gentleman Kanagawa theme overlay
+    Visual polish: OpenCode color theme
   [ ] claude-theme
-    Visual polish: Claude Code Gentleman custom theme
+    Visual polish: Claude Code color theme
   [ ] opencode-gentle-logo
-    Visual polish: OpenCode home logo TUI plugin with Braille rose
+    Visual polish: OpenCode home logo plugin
 
   Continue
   Back

--- a/internal/tui/testdata/preset-custom-opencode-next.golden
+++ b/internal/tui/testdata/preset-custom-opencode-next.golden
@@ -11,17 +11,17 @@ Toggle components with enter or space.
   [ ] context7
     Latest framework and library docs
   [ ] persona
-    Gentleman, neutral or custom behavior
+    Managed agent behavior and conversation tone
   [ ] permissions
     Security-first defaults and guardrails
   [ ] gga
     Gentleman Guardian Angel — AI provider switcher
   [ ] theme
-    Gentleman Kanagawa theme overlay
+    Visual polish: Gentleman Kanagawa theme overlay
   [ ] claude-theme
-    Claude Code Gentleman custom theme
+    Visual polish: Claude Code Gentleman custom theme
   [ ] opencode-gentle-logo
-    OpenCode home logo TUI plugin with Braille rose
+    Visual polish: OpenCode home logo TUI plugin with Braille rose
 
   Continue
   Back

--- a/internal/tui/testdata/preset-custom-opencode-next.golden
+++ b/internal/tui/testdata/preset-custom-opencode-next.golden
@@ -17,11 +17,11 @@ Toggle components with enter or space.
   [ ] gga
     Gentleman Guardian Angel — AI provider switcher
   [ ] theme
-    Visual polish: Gentleman Kanagawa theme overlay
+    Visual polish: OpenCode color theme
   [ ] claude-theme
-    Visual polish: Claude Code Gentleman custom theme
+    Visual polish: Claude Code color theme
   [ ] opencode-gentle-logo
-    Visual polish: OpenCode home logo TUI plugin with Braille rose
+    Visual polish: OpenCode home logo plugin
 
   Continue
   Back

--- a/internal/tui/testdata/preset-minimal-no-opencode-next.golden
+++ b/internal/tui/testdata/preset-minimal-no-opencode-next.golden
@@ -2,7 +2,7 @@ Install Plan
 
 Components to install
   1. persona included
-     Gentleman, neutral or custom behavior
+     Managed agent behavior and conversation tone
   2. engram included
      Persistent cross-session memory
 


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1058

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Treat `PersonaCustom` as an opt-out from managed persona while keeping `Dev Stack + Polish` visual polish independent.
- Centralize preset/component resolution so CLI and TUI cannot drift.
- Make uninstall remove managed visual polish as a group when any visual polish component is selected.
- Clarify TUI copy for persona/preset/component selection: custom persona only affects persona; custom preset is where users manually include/exclude Engram, persona, themes, and logo.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/model/presets.go` | Centralized preset/persona to component mapping. |
| `internal/tui/model.go` / `internal/cli/validate.go` | Delegate component resolution to the shared model helper. |
| `internal/tui/screens/*` / `internal/catalog/components.go` | Clarify managed persona and visual polish copy. |
| `internal/components/uninstall/service.go` | Expand any visual polish uninstall selection to remove OpenCode theme, Claude theme, and OpenCode logo together. |
| `internal/tui/*_test.go` / `internal/cli/install_test.go` / `internal/components/uninstall/*_test.go` | Add regression coverage for custom persona and grouped visual polish uninstall. |

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test -count=1 ./internal/model ./internal/tui ./internal/tui/screens ./internal/cli ./internal/catalog ./internal/components/uninstall
```

**E2E Tests** (Docker required)
```bash
cd e2e && ./docker-test.sh
```

- [x] Targeted unit tests pass
- [ ] Full unit tests pass (`go test ./...`) — covered by CI
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — covered by CI
- [x] Manually reviewed TUI flow behavior in code/tests

---

## 🤖 Automated Checks

The following checks run automatically on this PR:

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | PR should stay within 400 changed lines (`additions + deletions`) or use `size:exception` |
| Check Issue Reference | ⏳ | PR body must contain `Closes/Fixes/Resolves #N` |
| Check Issue Has `status:approved` | ⏳ | Linked issue must have been approved before work began |
| Check PR Has `type:*` Label | ⏳ | Exactly one `type:*` label must be applied |
| Unit Tests | ⏳ | `go test ./...` must pass |
| E2E Tests | ⏳ | `cd e2e && ./docker-test.sh` must pass |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [x] I have added the appropriate `type:*` label to this PR
- [x] Targeted unit tests pass
- [ ] Full unit tests pass (`go test ./...`) — covered by CI
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — covered by CI
- [x] I have updated documentation if necessary
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

This intentionally keeps preset selection authoritative for visual polish: `PersonaCustom` disables managed persona only. Users who do not want theming/logo should choose the custom preset and leave visual polish components unselected. During uninstall, selecting any visual polish component removes the managed OpenCode theme, Claude theme, and OpenCode logo together so users do not have to know the internal split.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Uninstall now automatically includes all related “visual polish” theme/logo components when any of them are selected.
* **Bug Fixes**
  * Preset/persona selection is now consistent across CLI and TUI: preset visual-polish components remain enabled when switching to a custom persona; only the persona component becomes unmanaged.
* **Documentation**
  * Updated UI wording and preset/component descriptions to clarify managed versus user-chosen items, including the “Visual polish:” phrasing and updated persona clarification text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
