### PR TITLE
fix(theme): align Claude theme key with installed theme identifier

### DIFF
--- a/e2e/e2e_test.sh
+++ b/e2e/e2e_test.sh
@@ -808,7 +808,7 @@ test_cc_theme_injection() {
         local settings="$HOME/.claude/settings.json"
         assert_file_exists "$settings" "Claude settings.json"
         assert_file_contains "$settings" '"theme"' "Has theme key"
-        assert_file_contains "$settings" 'gentleman-kanagawa' "Has gentleman-kanagawa theme"
+        assert_file_contains "$settings" 'gentleman' "Has gentleman theme"
         assert_valid_json "$settings" "settings.json is valid JSON"
     else
         log_fail "theme install command failed"
@@ -1019,7 +1019,7 @@ test_oc_theme_injection() {
         local settings="$HOME/.config/opencode/opencode.json"
         assert_file_exists "$settings" "OpenCode opencode.json"
         assert_file_contains "$settings" '"theme"' "Has theme key"
-        assert_file_contains "$settings" 'gentleman-kanagawa' "Has gentleman-kanagawa theme"
+        assert_file_contains "$settings" 'gentleman' "Has gentleman theme"
         assert_valid_json "$settings" "opencode.json is valid JSON"
     else
         log_fail "OpenCode theme install command failed"

--- a/internal/components/theme/inject.go
+++ b/internal/components/theme/inject.go
@@ -16,7 +16,7 @@ type InjectionResult struct {
 	Files   []string
 }
 
-var themeOverlayJSON = []byte("{\n  \"theme\": \"gentleman-kanagawa\"\n}\n")
+var themeOverlayJSON = []byte("{\n  \"theme\": \"gentleman\"\n}\n")
 
 type claudeTheme struct {
 	Name      string            `json:"name"`

--- a/internal/components/theme/inject_test.go
+++ b/internal/components/theme/inject_test.go
@@ -55,8 +55,8 @@ func TestInjectMergesThemeOverlayIntoAdapterSettings(t *testing.T) {
 	if err := json.Unmarshal(data, &root); err != nil {
 		t.Fatalf("Unmarshal(settings) error = %v", err)
 	}
-	if root.Theme != "gentleman-kanagawa" {
-		t.Fatalf("theme = %q, want gentleman-kanagawa", root.Theme)
+	if root.Theme != "gentleman" {
+		t.Fatalf("theme = %q, want gentleman", root.Theme)
 	}
 	if got := root.Permissions["allow"]; len(got) != 1 || got[0] != "Bash(go test ./...)" {
 		t.Fatalf("permissions.allow = %#v, want preserved existing permission", got)
@@ -92,8 +92,8 @@ func TestInjectCreatesAdapterSettingsWhenMissing(t *testing.T) {
 	if err := json.Unmarshal(data, &root); err != nil {
 		t.Fatalf("Unmarshal(settings) error = %v", err)
 	}
-	if root.Theme != "gentleman-kanagawa" {
-		t.Fatalf("theme = %q, want gentleman-kanagawa", root.Theme)
+	if root.Theme != "gentleman" {
+		t.Fatalf("theme = %q, want gentleman", root.Theme)
 	}
 }
 

--- a/internal/components/uninstall/cleaners_test.go
+++ b/internal/components/uninstall/cleaners_test.go
@@ -141,7 +141,7 @@ func TestRemoveMarkdownSections_RemovesSlimResidualPersonaViaMarkerNotFingerprin
 
 func TestRemoveJSONPaths_RemovesOnlyManagedKeys(t *testing.T) {
 	input := []byte(`{
-  "theme": "gentleman-kanagawa",
+  "theme": "gentleman",
   "permission": {
     "bash": {
       "*": "allow"


### PR DESCRIPTION
## Summary

Aligns the `theme` value written to `settings.json` with the installed theme identifier so Claude Code can resolve and apply the Gentleman theme.

## Problem

`theme.Inject()` wrote `"theme": "gentleman-kanagawa"` to `~/.claude/settings.json`, but the installed theme file is `gentleman.json` with `Name: "Gentleman"`. Three identifiers disagreed:

| Where | Identifier |
|-------|-----------|
| `settings.json` `theme` value | `gentleman-kanagawa` |
| theme file name | `gentleman` |
| theme `Name` field | `Gentleman` |

Claude Code looks up custom themes by identifier; `gentleman-kanagawa` matched neither, so the Gentleman theme was silently never applied.

## Fix

Changed `themeOverlayJSON` from `"gentleman-kanagawa"` to `"gentleman"` to match the installed theme filename.

**Files changed:** 4 files, 8 insertions, 8 deletions

- `internal/components/theme/inject.go` — source fix
- `internal/components/theme/inject_test.go` — updated assertions
- `internal/components/uninstall/cleaners_test.go` — updated test fixture
- `e2e/e2e_test.sh` — updated e2e assertions

## Testing

- `go test ./internal/components/theme/...` — 5 tests pass
- Zero remaining references to `gentleman-kanagawa` in codebase

Closes #896

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized theme settings to use the `gentleman` theme value across setup and configuration handling.
  * Updated theme-related checks so saved settings reflect the current expected theme name.
  * Adjusted cleanup validation to match the revised theme value in existing settings data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->