### PR TITLE
fix(codex): wrap AGENTS.md persona in managed marker sections

### DIFF
--- a/internal/components/persona/inject.go
+++ b/internal/components/persona/inject.go
@@ -117,7 +117,7 @@ func injectInternal(homeDir string, adapter agents.Adapter, persona model.Person
 	case model.StrategyFileReplace:
 		promptPath := adapter.SystemPromptFile(homeDir)
 
-		if adapter.Agent() == model.AgentOpenCode {
+		if adapter.Agent() == model.AgentOpenCode || adapter.Agent() == model.AgentCodex {
 			existing, err := readFileOrEmpty(promptPath)
 			if err != nil {
 				return InjectionResult{}, err

--- a/internal/components/persona/inject_test.go
+++ b/internal/components/persona/inject_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gentleman-programming/gentle-ai/internal/agents"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/antigravity"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/claude"
+	"github.com/gentleman-programming/gentle-ai/internal/agents/codex"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/hermes"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/kilocode"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/kimi"
@@ -22,6 +23,7 @@ import (
 
 func antigravityAdapter() agents.Adapter { return antigravity.NewAdapter() }
 func claudeAdapter() agents.Adapter      { return claude.NewAdapter() }
+func codexAdapter() agents.Adapter       { return codex.NewAdapter() }
 func hermesAdapter() agents.Adapter      { return hermes.NewAdapter() }
 func kimiAdapter() agents.Adapter        { return kimi.NewAdapter() }
 func kilocodeAdapter() agents.Adapter    { return kilocode.NewAdapter() }
@@ -101,6 +103,55 @@ func TestInjectClaudeGentlemanWritesSectionWithRealContent(t *testing.T) {
 	}
 	if !strings.Contains(text, "Persona Voice") {
 		t.Fatal("CLAUDE.md residual persona section missing the 'Persona Voice' pointer to the output style")
+	}
+}
+
+func TestInjectCodexGentlemanWritesPersonaWithManagedMarkers(t *testing.T) {
+	home := t.TempDir()
+
+	result, err := Inject(home, codexAdapter(), model.PersonaGentleman)
+	if err != nil {
+		t.Fatalf("Inject(codex) error = %v", err)
+	}
+	if !result.Changed {
+		t.Fatal("Inject(codex) changed = false")
+	}
+
+	path := filepath.Join(home, ".codex", "AGENTS.md")
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+
+	text := string(content)
+	if !strings.Contains(text, "<!-- gentle-ai:persona -->") {
+		t.Fatal("AGENTS.md missing open marker for persona")
+	}
+	if !strings.Contains(text, "<!-- /gentle-ai:persona -->") {
+		t.Fatal("AGENTS.md missing close marker for persona")
+	}
+	if !strings.Contains(text, "Senior Architect") {
+		t.Fatal("AGENTS.md persona section missing 'Senior Architect' content")
+	}
+}
+
+func TestInjectCodexGentlemanIsIdempotent(t *testing.T) {
+	home := t.TempDir()
+
+	first, err := Inject(home, codexAdapter(), model.PersonaGentleman)
+	if err != nil {
+		t.Fatalf("Inject(codex) first error = %v", err)
+	}
+	if !first.Changed {
+		t.Fatal("Inject(codex) first changed = false")
+	}
+
+	second, err := Inject(home, codexAdapter(), model.PersonaGentleman)
+	if err != nil {
+		t.Fatalf("Inject(codex) second error = %v", err)
+	}
+	if second.Changed {
+		t.Fatal("Inject(codex) second changed = true — not idempotent")
 	}
 }
 


### PR DESCRIPTION
## Summary

Wraps Codex persona content in `<!-- gentle-ai:persona -->` managed marker sections, matching the pattern already used by Claude Code and OpenCode.

## Problem

Codex uses `StrategyFileReplace` for its system prompt (`~/.codex/AGENTS.md`), but the persona injector wrote raw prose without markers. This made Codex persona content impossible to update, uninstall, or distinguish from user-authored content.

## Solution

Extend the marker-based injection path (already used by OpenCode) to also cover Codex by changing the agent check from `AgentOpenCode` to `AgentOpenCode || AgentCodex`.

**Files changed:** 2 files, 52 insertions, 1 deletion

- `internal/components/persona/inject.go` — extend marker-based path to include Codex
- `internal/components/persona/inject_test.go` — add 2 Codex-specific tests (marker presence + idempotency)

## Testing

- `go test ./internal/components/persona/...` — 143 tests pass (141 existing + 2 new)
- New tests verify: markers are present in AGENTS.md, injection is idempotent

Closes #981

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Persona injection now works correctly for the Codex adapter, ensuring the same managed settings and cleanup behavior applied elsewhere.
  * Added coverage for Codex persona injection to confirm the persona content is written with managed markers.
  * Improved reliability by verifying repeated persona injection does not make unnecessary changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->