### PR TITLE
fix(codex): set glob_scan_max_depth for workspace deny globs

### DIFF
--- a/internal/components/permissions/inject.go
+++ b/internal/components/permissions/inject.go
@@ -229,6 +229,11 @@ func injectCodexPermissions(homeDir string, adapter agents.Adapter) (InjectionRe
 		merged = filemerge.UpsertTOMLTableKey(merged, "permissions.gentle-dev.filesystem", path, `"write"`)
 	}
 	merged = filemerge.UpsertTOMLTableKey(merged, "permissions.gentle-dev.filesystem", "glob_scan_max_depth", "6")
+	// Also set glob_scan_max_depth in the :workspace_roots sub-table.
+	// Codex's sandbox does not inherit this setting from the parent
+	// filesystem table, so unbounded ** globs in deny rules would emit
+	// warnings on Linux and Windows without this.
+	merged = filemerge.UpsertTOMLTableKey(merged, `permissions.gentle-dev.filesystem.":workspace_roots"`, "glob_scan_max_depth", "6")
 	for _, path := range []string{`"."`, `".git/**"`} {
 		merged = filemerge.UpsertTOMLTableKey(merged, `permissions.gentle-dev.filesystem.":workspace_roots"`, path, `"write"`)
 	}

--- a/internal/components/permissions/inject_test.go
+++ b/internal/components/permissions/inject_test.go
@@ -420,6 +420,9 @@ func TestInjectCodexWritesGentleDevPermissionsProfile(t *testing.T) {
 			t.Fatalf("workspace-scoped filesystem table missing %q; got:\n%s", want, scopedFilesystem)
 		}
 	}
+	if !strings.Contains(scopedFilesystem, `glob_scan_max_depth = 6`) {
+		t.Fatalf("workspace-scoped filesystem table missing glob_scan_max_depth; got:\n%s", scopedFilesystem)
+	}
 	for _, invalid := range []string{
 		`"**/.git" = "write"`,
 		`"**/.git/**" = "write"`,


### PR DESCRIPTION
## Summary

Sets `glob_scan_max_depth = 6` in the `:workspace_roots` sub-table so Codex caps `**` glob expansion and silences sandbox warnings on Linux and Windows.

## Problem

The Codex permissions injector generates `:workspace_roots` deny rules with unbounded `**` globs (e.g. `**/*.key`, `**/.ssh/**`). While `glob_scan_max_depth = 6` is set at the parent `permissions.gentle-dev.filesystem` table, Codex's sandbox does not inherit this setting for sub-tables, so every `**` pattern in `:workspace_roots` emits a warning.

## Solution

Set `glob_scan_max_depth = 6` directly in the `permissions.gentle-dev.filesystem.":workspace_roots"` sub-table in addition to the parent filesystem table.

**Files changed:** 2 files, 8 insertions

- `internal/components/permissions/inject.go` — add `glob_scan_max_depth` to `:workspace_roots`
- `internal/components/permissions/inject_test.go` — add assertion that `:workspace_roots` has the setting

## Testing

- `go test ./internal/components/permissions/...` — 43 tests pass

Closes #861

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved permissions setup so workspace-scoped filesystem access now includes the same scan depth limit as the main filesystem settings.
  * Updated validation to ensure this workspace-specific limit is applied correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->