### PR TITLE
feat(codex): prepare GPT-5.6 model defaults

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -144,12 +144,14 @@ Kiro uses native custom agents in `~/.kiro/agents/`. `gentle-ai` writes phase ag
 - MCP servers (Engram and Context7) are upserted as `[mcp_servers.<name>]` blocks in `~/.codex/config.toml`
 - SDD model-selection profiles written as separate files at `~/.codex/<name>.config.toml` (Codex >= 0.134.0 separate-file mechanism). Selected at runtime via `codex --profile <name>`:
 
-  | Profile | `model_reasoning_effort` | SDD phases |
-  |---------|--------------------------|------------|
-  | `sdd-strong` | `xhigh` | propose, design, verify, judge |
-  | `sdd-mid` | `high` | spec, tasks, apply |
-  | `sdd-cheap` | `low` | explore, archive, onboard |
+  | Profile | Default model | `model_reasoning_effort` | SDD phases |
+  |---------|---------------|--------------------------|------------|
+  | `sdd-strong` | `gpt-5.6-sol` | `high` (`xhigh` in Powerful preset) | propose, design, verify, judge |
+  | `sdd-mid` | `gpt-5.6-terra` | `medium` (`high` in Powerful preset) | apply, fix-agent |
+  | `sdd-cheap` | `gpt-5.6-luna` | `low` | explore, spec, tasks, archive, onboard |
 
+- Explicit saved Codex model assignments are preserved on sync, including older pinned IDs such as `gpt-5.5` or `gpt-5.4-mini`; GPT-5.6 IDs are used only for missing/default assignments.
+- GPT-5.6 `max` reasoning effort and `ultra` mode are intentionally not enabled by this default update. `max` requires confirmed Codex support; `ultra` changes orchestration semantics and needs separate design.
 - Multi-agent SDD delegation is available as an **experimental opt-in** (default off). gentle-ai writes `features.multi_agent = false` and `agents.max_threads = 4` / `agents.max_depth = 2` into `~/.codex/config.toml`. To enable, set `multi_agent = true` in the `[features]` section. When enabled, the `sdd-orchestrator` asset uses Codex's native `spawn_agent` / `wait_agent` / `close_agent` tools to delegate SDD phases; otherwise it falls back to solo-agent inline execution.
 - **Delegation**: Solo-agent (multi-agent opt-in, experimental)
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -142,13 +142,15 @@ Kiro uses native custom agents in `~/.kiro/agents/`. `gentle-ai` writes phase ag
 - System prompt at `~/.codex/AGENTS.md`
 - Engram instruction files at `~/.codex/engram-instructions.md`
 - MCP servers (Engram and Context7) are upserted as `[mcp_servers.<name>]` blocks in `~/.codex/config.toml`
-- SDD model-selection profiles written as separate files at `~/.codex/<name>.config.toml` (Codex >= 0.134.0 separate-file mechanism). Selected at runtime via `codex --profile <name>`:
+- SDD model-selection profiles written as separate files at `~/.codex/<name>.config.toml`. GPT-5.6 defaults require Codex >= 0.144.0 (the separate-file mechanism itself is available since 0.134.0). Select a profile at runtime via `codex --profile <name>`:
 
-  | Profile | Default model | `model_reasoning_effort` | SDD phases |
-  |---------|---------------|--------------------------|------------|
-  | `sdd-strong` | `gpt-5.6-sol` | `high` (`xhigh` in Powerful preset) | propose, design, verify, judge |
-  | `sdd-mid` | `gpt-5.6-terra` | `medium` (`high` in Powerful preset) | apply, fix-agent |
-  | `sdd-cheap` | `gpt-5.6-luna` | `low` | explore, spec, tasks, archive, onboard |
+  Model and effort defaults vary together by preset:
+
+  | Profile | Low-cost | Recommended | Powerful | SDD phases |
+  |---------|----------|-------------|----------|------------|
+  | `sdd-strong` | `gpt-5.6-terra` / `medium` | `gpt-5.6-sol` / `high` | `gpt-5.6-sol` / `xhigh` | propose, design, verify, judge |
+  | `sdd-mid` | `gpt-5.6-terra` / `medium` | `gpt-5.6-terra` / `medium` | `gpt-5.6-sol` / `high` | apply, fix-agent |
+  | `sdd-cheap` | `gpt-5.6-luna` / `low` | `gpt-5.6-luna` / `low` | `gpt-5.6-luna` / `low` | explore, spec, tasks, archive, onboard |
 
 - Explicit saved Codex model assignments are preserved on sync, including older pinned IDs such as `gpt-5.5` or `gpt-5.4-mini`; GPT-5.6 IDs are used only for missing/default assignments.
 - GPT-5.6 `max` reasoning effort and `ultra` mode are intentionally not enabled by this default update. `max` requires confirmed Codex support; `ultra` changes orchestration semantics and needs separate design.

--- a/internal/agents/codex/profiles.go
+++ b/internal/agents/codex/profiles.go
@@ -15,7 +15,7 @@ import (
 // about the user's selection) and WriteCodexProfiles (which knows about TOML).
 type ProfileAssignment struct {
 	Profile         string // e.g. "sdd-strong"
-	Model           string // e.g. "gpt-5.5"
+	Model           string // e.g. "gpt-5.6-sol"
 	ReasoningEffort string // e.g. "high"
 }
 
@@ -70,9 +70,9 @@ func SddProfilePaths(codexHomeDir string) []string {
 //
 // When assignments is nil or empty, canonical Recommended defaults are used
 // (derived from model.CodexTierGroups()):
-//   - sdd-strong: model=gpt-5.5, model_reasoning_effort=high
-//   - sdd-mid:    model=gpt-5.5, model_reasoning_effort=medium
-//   - sdd-cheap:  model=gpt-5.4-mini, model_reasoning_effort=low
+//   - sdd-strong: model=gpt-5.6-sol, model_reasoning_effort=high
+//   - sdd-mid:    model=gpt-5.6-terra, model_reasoning_effort=medium
+//   - sdd-cheap:  model=gpt-5.6-luna, model_reasoning_effort=low
 //
 // Profile files are written idempotently using UpsertTopLevelTOMLString +
 // WriteFileAtomic — re-running this function when files already contain the

--- a/internal/agents/codex/profiles_test.go
+++ b/internal/agents/codex/profiles_test.go
@@ -76,26 +76,26 @@ func TestWriteCodexProfiles_DefaultFallback(t *testing.T) {
 		t.Fatal("WriteCodexProfiles(nil) changed = false, want true on first write")
 	}
 
-	// sdd-strong must have gpt-5.5 and effort=high (Recommended default)
+	// sdd-strong must have gpt-5.6-sol and effort=high (Recommended default)
 	strong, _ := os.ReadFile(filepath.Join(dir, "sdd-strong.config.toml"))
-	if !strings.Contains(string(strong), `"gpt-5.5"`) {
-		t.Errorf("sdd-strong default model: want gpt-5.5; got:\n%s", strong)
+	if !strings.Contains(string(strong), `"gpt-5.6-sol"`) {
+		t.Errorf("sdd-strong default model: want gpt-5.6-sol; got:\n%s", strong)
 	}
 	if !strings.Contains(string(strong), `"high"`) {
 		t.Errorf("sdd-strong default effort: want high; got:\n%s", strong)
 	}
-	// sdd-mid must have gpt-5.5 and effort=medium (Recommended default)
+	// sdd-mid must have gpt-5.6-terra and effort=medium (Recommended default)
 	mid, _ := os.ReadFile(filepath.Join(dir, "sdd-mid.config.toml"))
-	if !strings.Contains(string(mid), `"gpt-5.5"`) {
-		t.Errorf("sdd-mid default model: want gpt-5.5; got:\n%s", mid)
+	if !strings.Contains(string(mid), `"gpt-5.6-terra"`) {
+		t.Errorf("sdd-mid default model: want gpt-5.6-terra; got:\n%s", mid)
 	}
 	if !strings.Contains(string(mid), `"medium"`) {
 		t.Errorf("sdd-mid default effort: want medium; got:\n%s", mid)
 	}
-	// sdd-cheap must have gpt-5.4-mini and effort=low (Recommended default)
+	// sdd-cheap must have gpt-5.6-luna and effort=low (Recommended default)
 	cheap, _ := os.ReadFile(filepath.Join(dir, "sdd-cheap.config.toml"))
-	if !strings.Contains(string(cheap), `"gpt-5.4-mini"`) {
-		t.Errorf("sdd-cheap default model: want gpt-5.4-mini; got:\n%s", cheap)
+	if !strings.Contains(string(cheap), `"gpt-5.6-luna"`) {
+		t.Errorf("sdd-cheap default model: want gpt-5.6-luna; got:\n%s", cheap)
 	}
 	if !strings.Contains(string(cheap), `"low"`) {
 		t.Errorf("sdd-cheap default effort: want low; got:\n%s", cheap)

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -1459,11 +1459,11 @@ func TestApplyOverrides_CodexCarrilModelAssignments(t *testing.T) {
 	if len(sel.CodexCarrilModelAssignments) != len(carrilModels) {
 		t.Fatalf("CodexCarrilModelAssignments len = %d, want %d", len(sel.CodexCarrilModelAssignments), len(carrilModels))
 	}
-	if sel.CodexCarrilModelAssignments["sdd-cheap"] != "gpt-5.4-mini" {
-		t.Errorf("CodexCarrilModelAssignments[sdd-cheap] = %q, want gpt-5.4-mini", sel.CodexCarrilModelAssignments["sdd-cheap"])
+	if sel.CodexCarrilModelAssignments["sdd-cheap"] != "gpt-5.6-luna" {
+		t.Errorf("CodexCarrilModelAssignments[sdd-cheap] = %q, want gpt-5.6-luna", sel.CodexCarrilModelAssignments["sdd-cheap"])
 	}
-	if sel.CodexCarrilModelAssignments["sdd-strong"] != "gpt-5.5" {
-		t.Errorf("CodexCarrilModelAssignments[sdd-strong] = %q, want gpt-5.5", sel.CodexCarrilModelAssignments["sdd-strong"])
+	if sel.CodexCarrilModelAssignments["sdd-strong"] != "gpt-5.6-sol" {
+		t.Errorf("CodexCarrilModelAssignments[sdd-strong] = %q, want gpt-5.6-sol", sel.CodexCarrilModelAssignments["sdd-strong"])
 	}
 }
 

--- a/internal/assets/codex/sdd-orchestrator.md
+++ b/internal/assets/codex/sdd-orchestrator.md
@@ -139,7 +139,7 @@ For each phase:
 
 Example — launching `sdd-design` with its assigned model and effort:
 ```
-spawn_agent(task_name="sdd-design", message=<design prompt>, model="gpt-5.5", reasoning_effort="xhigh", fork_turns="none")
+spawn_agent(task_name="sdd-design", message=<design prompt>, model="gpt-5.6-sol", reasoning_effort="xhigh", fork_turns="none")
 wait_agent(task_name="sdd-design")
 close_agent(task_name="sdd-design")
 ```

--- a/internal/assets/codex/sdd-orchestrator.md
+++ b/internal/assets/codex/sdd-orchestrator.md
@@ -137,9 +137,9 @@ For each phase:
 5. `close_agent` to release the thread.
 6. Verify the artifact was persisted before launching the next phase.
 
-Example — launching `sdd-design` with its assigned model and effort:
+Example — launching `sdd-design` with the values from its generated table row:
 ```
-spawn_agent(task_name="sdd-design", message=<design prompt>, model="gpt-5.6-sol", reasoning_effort="xhigh", fork_turns="none")
+spawn_agent(task_name="sdd-design", message=<design prompt>, model="<assigned-model>", reasoning_effort="<assigned-effort>", fork_turns="none")
 wait_agent(task_name="sdd-design")
 close_agent(task_name="sdd-design")
 ```

--- a/internal/components/engram/inject.go
+++ b/internal/components/engram/inject.go
@@ -176,7 +176,7 @@ type InjectOptions struct {
 
 	// CodexCarrilModelAssignments holds the resolved carril→model-id map used
 	// when writing SDD profile .config.toml files. nil/empty = use canonical
-	// defaults (sdd-strong/sdd-mid=gpt-5.5, sdd-cheap=gpt-5.4-mini).
+	// defaults (sdd-strong=gpt-5.6-sol, sdd-mid=gpt-5.6-terra, sdd-cheap=gpt-5.6-luna).
 	CodexCarrilModelAssignments map[string]string
 
 	// CodexModelAssignments holds the resolved phase→effort map used to derive

--- a/internal/components/golden_test.go
+++ b/internal/components/golden_test.go
@@ -304,7 +304,8 @@ func TestGoldenSDD_Codex(t *testing.T) {
 	home := t.TempDir()
 
 	result, err := sdd.Inject(home, codexAdapter(), "", sdd.InjectOptions{
-		CodexModelAssignments: model.CodexModelPresetRecommended(),
+		CodexModelAssignments:       model.CodexModelPresetRecommended(),
+		CodexCarrilModelAssignments: model.CodexCarrilModelsForPreset("recommended"),
 	})
 	if err != nil {
 		t.Fatalf("sdd.Inject(codex) error = %v", err)
@@ -340,7 +341,8 @@ func TestGoldenSDD_Codex_LowCost(t *testing.T) {
 	home := t.TempDir()
 
 	result, err := sdd.Inject(home, codexAdapter(), "", sdd.InjectOptions{
-		CodexModelAssignments: model.CodexModelPresetLowCost(),
+		CodexModelAssignments:       model.CodexModelPresetLowCost(),
+		CodexCarrilModelAssignments: model.CodexCarrilModelsForPreset("low-cost"),
 	})
 	if err != nil {
 		t.Fatalf("sdd.Inject(codex, LowCost) error = %v", err)
@@ -357,7 +359,8 @@ func TestGoldenSDD_Codex_Powerful(t *testing.T) {
 	home := t.TempDir()
 
 	result, err := sdd.Inject(home, codexAdapter(), "", sdd.InjectOptions{
-		CodexModelAssignments: model.CodexModelPresetPowerful(),
+		CodexModelAssignments:       model.CodexModelPresetPowerful(),
+		CodexCarrilModelAssignments: model.CodexCarrilModelsForPreset("powerful"),
 	})
 	if err != nil {
 		t.Fatalf("sdd.Inject(codex, Powerful) error = %v", err)

--- a/internal/components/sdd/inject.go
+++ b/internal/components/sdd/inject.go
@@ -1842,8 +1842,13 @@ func injectFileAppend(homeDir string, adapter agents.Adapter, opts InjectOptions
 	if cmr, ok := adapter.(codexModelResolver); ok {
 		var rendered string
 		if len(opts.CodexPhaseModelAssignments) > 0 {
-			// Custom per-phase mode: render a per-phase table (phase | model | effort).
-			rendered = model.RenderCodexPhaseEffortsByPhase(opts.CodexPhaseModelAssignments, opts.CodexModelAssignments)
+			// Custom per-phase mode: render a per-phase table (phase | model | effort),
+			// preserving the selected or explicitly saved carril models as fallbacks.
+			rendered = model.RenderCodexPhaseEffortsByPhase(
+				opts.CodexPhaseModelAssignments,
+				opts.CodexModelAssignments,
+				opts.CodexCarrilModelAssignments,
+			)
 		} else {
 			// Preset / carril mode: render the standard per-carril table.
 			rendered = cmr.RenderCodexPhaseEfforts(opts.CodexModelAssignments, opts.CodexCarrilModelAssignments)

--- a/internal/components/sdd/inject_test.go
+++ b/internal/components/sdd/inject_test.go
@@ -6248,7 +6248,7 @@ func TestInjectCodexWithCarrilModels(t *testing.T) {
 }
 
 // TestInjectCodexNilCarrilModels verifies that nil CodexCarrilModelAssignments
-// causes the render to use canonical defaults (gpt-5.5 / gpt-5.4-mini).
+// causes the render to use canonical GPT-5.6 defaults.
 func TestInjectCodexNilCarrilModels(t *testing.T) {
 	home := t.TempDir()
 	adapter := codexInjectAdapter()
@@ -6270,8 +6270,10 @@ func TestInjectCodexNilCarrilModels(t *testing.T) {
 	if !strings.Contains(text, "Model") {
 		t.Error("AGENTS.md missing Model column — nil carrilModels should fall back to defaults")
 	}
-	if !strings.Contains(text, "gpt-5.4-mini") {
-		t.Error("AGENTS.md missing gpt-5.4-mini — nil carrilModels should show sdd-cheap default")
+	for _, want := range []string{"gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"} {
+		if !strings.Contains(text, want) {
+			t.Errorf("AGENTS.md missing %s — nil carrilModels should show GPT-5.6 defaults", want)
+		}
 	}
 }
 

--- a/internal/components/sdd/inject_test.go
+++ b/internal/components/sdd/inject_test.go
@@ -6069,11 +6069,18 @@ func TestInject_CodexPerPhaseModelAssignments_InjectsPerPhaseTable(t *testing.T)
 	home := t.TempDir()
 	adapter := codexInjectAdapter()
 
-	// Custom per-phase: sdd-propose gets gpt-5.4.
+	// Custom per-phase: sdd-propose gets gpt-5.4, while unassigned phases
+	// preserve the selected/saved carril models instead of reverting to the
+	// Recommended preset.
 	opts := InjectOptions{
 		CodexModelAssignments: model.CodexModelPresetRecommended(),
 		CodexPhaseModelAssignments: map[string]string{
 			"sdd-propose": "gpt-5.4",
+		},
+		CodexCarrilModelAssignments: map[string]string{
+			"sdd-strong": "gpt-5.4-mini",
+			"sdd-mid":    "gpt-5.5",
+			"sdd-cheap":  "gpt-5.3-codex",
 		},
 	}
 
@@ -6104,7 +6111,20 @@ func TestInject_CodexPerPhaseModelAssignments_InjectsPerPhaseTable(t *testing.T)
 	if !strings.Contains(text, wantRow) {
 		t.Errorf("AGENTS.md missing expected sdd-propose row %q:\n%s", wantRow, text)
 	}
-	// No unresolved placeholders.
+	// An unassigned strong phase must preserve the supplied carril model.
+	wantFallbackRow := "| `sdd-design` | `gpt-5.4-mini` | `high` |"
+	if !strings.Contains(text, wantFallbackRow) {
+		t.Errorf("AGENTS.md missing preserved carril fallback row %q:\n%s", wantFallbackRow, text)
+	}
+	// The delegation example must refer readers back to the generated table,
+	// not hardcode values that are wrong for some presets.
+	if strings.Contains(text, `model="gpt-5.6-sol", reasoning_effort="xhigh"`) {
+		t.Errorf("AGENTS.md contains a hardcoded delegation example that can contradict the generated table:\n%s", text)
+	}
+	if !strings.Contains(text, `model="<assigned-model>"`) || !strings.Contains(text, `reasoning_effort="<assigned-effort>"`) {
+		t.Errorf("AGENTS.md delegation example must use assigned-value placeholders:\n%s", text)
+	}
+	// No unresolved template placeholders.
 	if strings.Contains(text, "{{") {
 		t.Errorf("AGENTS.md contains unresolved placeholder '{{' after Inject:\n%s", text)
 	}

--- a/internal/model/codex_model.go
+++ b/internal/model/codex_model.go
@@ -8,6 +8,9 @@ import (
 // codexAvailableModels is the curated list of Codex model IDs available for
 // per-phase custom assignments. Order is intentional: newest/most-capable first.
 var codexAvailableModels = []string{
+	"gpt-5.6-sol",
+	"gpt-5.6-terra",
+	"gpt-5.6-luna",
 	"gpt-5.5",
 	"gpt-5.4",
 	"gpt-5.4-mini",
@@ -62,79 +65,75 @@ func (e CodexEffort) Valid() bool {
 	}
 }
 
-// CodexModelPresetRecommended returns the Recommended (ChatGPT Pro $100/mo) preset.
-// Carril-aligned effort: Razonamiento=high, Código=medium, Liviano=low.
-// Every phase within a carril carries the same effort so that maxEffort over the
-// carril's phases yields exactly the carril's intended tier.
+type CodexCarrilDefault struct {
+	Model  string
+	Effort CodexEffort
+}
+
+var codexPresetMatrix = map[string]map[string]CodexCarrilDefault{
+	"low-cost": {
+		"sdd-strong": {Model: "gpt-5.6-terra", Effort: CodexEffortMedium},
+		"sdd-mid":    {Model: "gpt-5.6-terra", Effort: CodexEffortMedium},
+		"sdd-cheap":  {Model: "gpt-5.6-luna", Effort: CodexEffortLow},
+	},
+	"recommended": {
+		"sdd-strong": {Model: "gpt-5.6-sol", Effort: CodexEffortHigh},
+		"sdd-mid":    {Model: "gpt-5.6-terra", Effort: CodexEffortMedium},
+		"sdd-cheap":  {Model: "gpt-5.6-luna", Effort: CodexEffortLow},
+	},
+	"powerful": {
+		"sdd-strong": {Model: "gpt-5.6-sol", Effort: CodexEffortXHigh},
+		"sdd-mid":    {Model: "gpt-5.6-sol", Effort: CodexEffortHigh},
+		"sdd-cheap":  {Model: "gpt-5.6-luna", Effort: CodexEffortLow},
+	},
+}
+
+func CodexPresetCarrilDefaults(preset string) map[string]CodexCarrilDefault {
+	defaults, ok := codexPresetMatrix[preset]
+	if !ok {
+		defaults = codexPresetMatrix["recommended"]
+	}
+	out := make(map[string]CodexCarrilDefault, len(defaults))
+	for carril, value := range defaults {
+		out[carril] = value
+	}
+	return out
+}
+
+func CodexCarrilModelsForPreset(preset string) map[string]string {
+	defaults := CodexPresetCarrilDefaults(preset)
+	out := make(map[string]string, len(defaults))
+	for carril, value := range defaults {
+		out[carril] = value.Model
+	}
+	return out
+}
+
+func codexPresetEfforts(preset string) map[string]CodexEffort {
+	defaults := CodexPresetCarrilDefaults(preset)
+	out := make(map[string]CodexEffort, 13)
+	for _, tier := range codexTierGroups {
+		effort := defaults[tier.Profile].Effort
+		for _, phase := range tier.Phases {
+			out[phase] = effort
+		}
+	}
+	return out
+}
+
+// CodexModelPresetRecommended returns the Recommended preset.
 func CodexModelPresetRecommended() map[string]CodexEffort {
-	return map[string]CodexEffort{
-		// Razonamiento (sdd-strong): high
-		"sdd-propose": CodexEffortHigh,
-		"sdd-design":  CodexEffortHigh,
-		"sdd-verify":  CodexEffortHigh,
-		"jd-judge-a":  CodexEffortHigh,
-		"jd-judge-b":  CodexEffortHigh,
-		"default":     CodexEffortHigh,
-		// Código (sdd-mid): medium
-		"sdd-apply":    CodexEffortMedium,
-		"jd-fix-agent": CodexEffortMedium,
-		// Liviano (sdd-cheap): low
-		"sdd-explore": CodexEffortLow,
-		"sdd-spec":    CodexEffortLow,
-		"sdd-tasks":   CodexEffortLow,
-		"sdd-archive": CodexEffortLow,
-		"sdd-onboard": CodexEffortLow,
-	}
+	return codexPresetEfforts("recommended")
 }
 
-// CodexModelPresetPowerful returns the Powerful (ChatGPT Pro $200/mo) preset.
-// Carril-aligned effort: Razonamiento=xhigh, Código=high, Liviano=low.
-// Every phase within a carril carries the same effort so that maxEffort over the
-// carril's phases yields exactly the carril's intended tier.
+// CodexModelPresetPowerful returns the Powerful preset.
 func CodexModelPresetPowerful() map[string]CodexEffort {
-	return map[string]CodexEffort{
-		// Razonamiento (sdd-strong): xhigh
-		"sdd-propose": CodexEffortXHigh,
-		"sdd-design":  CodexEffortXHigh,
-		"sdd-verify":  CodexEffortXHigh,
-		"jd-judge-a":  CodexEffortXHigh,
-		"jd-judge-b":  CodexEffortXHigh,
-		"default":     CodexEffortXHigh,
-		// Código (sdd-mid): high
-		"sdd-apply":    CodexEffortHigh,
-		"jd-fix-agent": CodexEffortHigh,
-		// Liviano (sdd-cheap): low
-		"sdd-explore": CodexEffortLow,
-		"sdd-spec":    CodexEffortLow,
-		"sdd-tasks":   CodexEffortLow,
-		"sdd-archive": CodexEffortLow,
-		"sdd-onboard": CodexEffortLow,
-	}
+	return codexPresetEfforts("powerful")
 }
 
-// CodexModelPresetLowCost returns the Low-cost (ChatGPT Plus $20/mo) preset.
-// Carril-aligned effort: Razonamiento=medium, Código=medium, Liviano=low.
-// Every phase within a carril carries the same effort so that maxEffort over the
-// carril's phases yields exactly the carril's intended tier.
+// CodexModelPresetLowCost returns the Low-cost preset.
 func CodexModelPresetLowCost() map[string]CodexEffort {
-	return map[string]CodexEffort{
-		// Razonamiento (sdd-strong): medium
-		"sdd-propose": CodexEffortMedium,
-		"sdd-design":  CodexEffortMedium,
-		"sdd-verify":  CodexEffortMedium,
-		"jd-judge-a":  CodexEffortMedium,
-		"jd-judge-b":  CodexEffortMedium,
-		"default":     CodexEffortMedium,
-		// Código (sdd-mid): medium
-		"sdd-apply":    CodexEffortMedium,
-		"jd-fix-agent": CodexEffortMedium,
-		// Liviano (sdd-cheap): low
-		"sdd-explore": CodexEffortLow,
-		"sdd-spec":    CodexEffortLow,
-		"sdd-tasks":   CodexEffortLow,
-		"sdd-archive": CodexEffortLow,
-		"sdd-onboard": CodexEffortLow,
-	}
+	return codexPresetEfforts("low-cost")
 }
 
 // CodexTierGroup defines one CLI profile tier: the profile filename (without
@@ -171,20 +170,20 @@ type CodexTierGroup struct {
 var codexTierGroups = []CodexTierGroup{
 	{
 		Profile:       "sdd-strong",
-		Model:         "gpt-5.5",
-		DefaultEffort: CodexEffortHigh,
+		Model:         codexPresetMatrix["recommended"]["sdd-strong"].Model,
+		DefaultEffort: codexPresetMatrix["recommended"]["sdd-strong"].Effort,
 		Phases:        []string{"sdd-propose", "sdd-design", "sdd-verify", "jd-judge-a", "jd-judge-b", "default"},
 	},
 	{
 		Profile:       "sdd-mid",
-		Model:         "gpt-5.5",
-		DefaultEffort: CodexEffortMedium,
+		Model:         codexPresetMatrix["recommended"]["sdd-mid"].Model,
+		DefaultEffort: codexPresetMatrix["recommended"]["sdd-mid"].Effort,
 		Phases:        []string{"sdd-apply", "jd-fix-agent"},
 	},
 	{
 		Profile:       "sdd-cheap",
-		Model:         "gpt-5.4-mini",
-		DefaultEffort: CodexEffortLow,
+		Model:         codexPresetMatrix["recommended"]["sdd-cheap"].Model,
+		DefaultEffort: codexPresetMatrix["recommended"]["sdd-cheap"].Effort,
 		Phases:        []string{"sdd-explore", "sdd-spec", "sdd-tasks", "sdd-archive", "sdd-onboard"},
 	},
 }
@@ -292,7 +291,7 @@ func phaseToCarrilModel(phase string, carrilModels map[string]string) string {
 			}
 		}
 	}
-	return "gpt-5.5" // ultimate fallback
+	return "gpt-5.6-sol" // ultimate fallback
 }
 
 // RenderCodexPhaseEffortsByPhase renders a per-phase Markdown table for the

--- a/internal/model/codex_model.go
+++ b/internal/model/codex_model.go
@@ -5,9 +5,11 @@ import (
 	"strings"
 )
 
-// codexAvailableModels is the curated list of Codex model IDs available for
-// per-phase custom assignments. Order is intentional: newest/most-capable first.
-var codexAvailableModels = []string{
+// codexModelCatalog is Gentle AI's curated selectable Codex model catalog for
+// per-phase custom assignments. It is a UI/configuration catalog, not a runtime
+// availability probe; the Codex CLI remains the source of truth at execution
+// time. Order is intentional: newest/most-capable first.
+var codexModelCatalog = []string{
 	"gpt-5.6-sol",
 	"gpt-5.6-terra",
 	"gpt-5.6-luna",
@@ -18,12 +20,12 @@ var codexAvailableModels = []string{
 	"gpt-5.3-codex",
 }
 
-// CodexAvailableModels returns the curated list of Codex model IDs that can be
-// assigned per-phase in the Custom picker. The slice is a copy — mutations do
-// not affect the canonical list.
+// CodexAvailableModels returns Gentle AI's curated selectable Codex model
+// catalog for per-phase Custom picker assignments. The slice is a copy —
+// mutations do not affect the canonical catalog.
 func CodexAvailableModels() []string {
-	out := make([]string, len(codexAvailableModels))
-	copy(out, codexAvailableModels)
+	out := make([]string, len(codexModelCatalog))
+	copy(out, codexModelCatalog)
 	return out
 }
 
@@ -70,18 +72,26 @@ type CodexCarrilDefault struct {
 	Effort CodexEffort
 }
 
-var codexPresetMatrix = map[string]map[string]CodexCarrilDefault{
-	"low-cost": {
+type CodexPresetKey string
+
+const (
+	CodexPresetLowCost     CodexPresetKey = "low-cost"
+	CodexPresetRecommended CodexPresetKey = "recommended"
+	CodexPresetPowerful    CodexPresetKey = "powerful"
+)
+
+var codexPresetMatrix = map[CodexPresetKey]map[string]CodexCarrilDefault{
+	CodexPresetLowCost: {
 		"sdd-strong": {Model: "gpt-5.6-terra", Effort: CodexEffortMedium},
 		"sdd-mid":    {Model: "gpt-5.6-terra", Effort: CodexEffortMedium},
 		"sdd-cheap":  {Model: "gpt-5.6-luna", Effort: CodexEffortLow},
 	},
-	"recommended": {
+	CodexPresetRecommended: {
 		"sdd-strong": {Model: "gpt-5.6-sol", Effort: CodexEffortHigh},
 		"sdd-mid":    {Model: "gpt-5.6-terra", Effort: CodexEffortMedium},
 		"sdd-cheap":  {Model: "gpt-5.6-luna", Effort: CodexEffortLow},
 	},
-	"powerful": {
+	CodexPresetPowerful: {
 		"sdd-strong": {Model: "gpt-5.6-sol", Effort: CodexEffortXHigh},
 		"sdd-mid":    {Model: "gpt-5.6-sol", Effort: CodexEffortHigh},
 		"sdd-cheap":  {Model: "gpt-5.6-luna", Effort: CodexEffortLow},
@@ -89,9 +99,9 @@ var codexPresetMatrix = map[string]map[string]CodexCarrilDefault{
 }
 
 func CodexPresetCarrilDefaults(preset string) map[string]CodexCarrilDefault {
-	defaults, ok := codexPresetMatrix[preset]
+	defaults, ok := codexPresetMatrix[CodexPresetKey(preset)]
 	if !ok {
-		defaults = codexPresetMatrix["recommended"]
+		defaults = codexPresetMatrix[CodexPresetRecommended]
 	}
 	out := make(map[string]CodexCarrilDefault, len(defaults))
 	for carril, value := range defaults {
@@ -123,17 +133,17 @@ func codexPresetEfforts(preset string) map[string]CodexEffort {
 
 // CodexModelPresetRecommended returns the Recommended preset.
 func CodexModelPresetRecommended() map[string]CodexEffort {
-	return codexPresetEfforts("recommended")
+	return codexPresetEfforts(string(CodexPresetRecommended))
 }
 
 // CodexModelPresetPowerful returns the Powerful preset.
 func CodexModelPresetPowerful() map[string]CodexEffort {
-	return codexPresetEfforts("powerful")
+	return codexPresetEfforts(string(CodexPresetPowerful))
 }
 
 // CodexModelPresetLowCost returns the Low-cost preset.
 func CodexModelPresetLowCost() map[string]CodexEffort {
-	return codexPresetEfforts("low-cost")
+	return codexPresetEfforts(string(CodexPresetLowCost))
 }
 
 // CodexTierGroup defines one CLI profile tier: the profile filename (without
@@ -170,20 +180,20 @@ type CodexTierGroup struct {
 var codexTierGroups = []CodexTierGroup{
 	{
 		Profile:       "sdd-strong",
-		Model:         codexPresetMatrix["recommended"]["sdd-strong"].Model,
-		DefaultEffort: codexPresetMatrix["recommended"]["sdd-strong"].Effort,
+		Model:         codexPresetMatrix[CodexPresetRecommended]["sdd-strong"].Model,
+		DefaultEffort: codexPresetMatrix[CodexPresetRecommended]["sdd-strong"].Effort,
 		Phases:        []string{"sdd-propose", "sdd-design", "sdd-verify", "jd-judge-a", "jd-judge-b", "default"},
 	},
 	{
 		Profile:       "sdd-mid",
-		Model:         codexPresetMatrix["recommended"]["sdd-mid"].Model,
-		DefaultEffort: codexPresetMatrix["recommended"]["sdd-mid"].Effort,
+		Model:         codexPresetMatrix[CodexPresetRecommended]["sdd-mid"].Model,
+		DefaultEffort: codexPresetMatrix[CodexPresetRecommended]["sdd-mid"].Effort,
 		Phases:        []string{"sdd-apply", "jd-fix-agent"},
 	},
 	{
 		Profile:       "sdd-cheap",
-		Model:         codexPresetMatrix["recommended"]["sdd-cheap"].Model,
-		DefaultEffort: codexPresetMatrix["recommended"]["sdd-cheap"].Effort,
+		Model:         codexPresetMatrix[CodexPresetRecommended]["sdd-cheap"].Model,
+		DefaultEffort: codexPresetMatrix[CodexPresetRecommended]["sdd-cheap"].Effort,
 		Phases:        []string{"sdd-explore", "sdd-spec", "sdd-tasks", "sdd-archive", "sdd-onboard"},
 	},
 }
@@ -291,7 +301,7 @@ func phaseToCarrilModel(phase string, carrilModels map[string]string) string {
 			}
 		}
 	}
-	return "gpt-5.6-sol" // ultimate fallback
+	return codexPresetMatrix[CodexPresetRecommended]["sdd-strong"].Model // ultimate fallback
 }
 
 // RenderCodexPhaseEffortsByPhase renders a per-phase Markdown table for the

--- a/internal/model/codex_model.go
+++ b/internal/model/codex_model.go
@@ -16,8 +16,8 @@ var codexModelCatalog = []string{
 	"gpt-5.5",
 	"gpt-5.4",
 	"gpt-5.4-mini",
-	"gpt-5.2-codex",
 	"gpt-5.3-codex",
+	"gpt-5.2-codex",
 }
 
 // CodexAvailableModels returns Gentle AI's curated selectable Codex model
@@ -98,6 +98,9 @@ var codexPresetMatrix = map[CodexPresetKey]map[string]CodexCarrilDefault{
 	},
 }
 
+// CodexPresetCarrilDefaults returns a defensive copy of the selected preset's
+// carril defaults. The string boundary preserves compatibility with persisted
+// state; unknown keys intentionally fall back to Recommended.
 func CodexPresetCarrilDefaults(preset string) map[string]CodexCarrilDefault {
 	defaults, ok := codexPresetMatrix[CodexPresetKey(preset)]
 	if !ok {
@@ -110,6 +113,8 @@ func CodexPresetCarrilDefaults(preset string) map[string]CodexCarrilDefault {
 	return out
 }
 
+// CodexCarrilModelsForPreset returns the model portion of a preset's carril
+// defaults. Unknown persisted keys inherit the Recommended fallback policy.
 func CodexCarrilModelsForPreset(preset string) map[string]string {
 	defaults := CodexPresetCarrilDefaults(preset)
 	out := make(map[string]string, len(defaults))
@@ -309,16 +314,20 @@ func phaseToCarrilModel(phase string, carrilModels map[string]string) string {
 // active. Each row shows: phase | model | reasoning_effort.
 //
 // phaseModels maps phase names to custom model IDs. Phases not present in
-// phaseModels fall back to the carril default model. efforts maps phase names to
-// CodexEffort values (typically from a preset + user overrides). When efforts is
-// nil, CodexModelPresetRecommended is used.
+// phaseModels fall back to carrilModels, preserving the selected or explicitly
+// saved carril assignments. efforts maps phase names to CodexEffort values
+// (typically from a preset + user overrides). When efforts is nil,
+// CodexModelPresetRecommended is used. When carrilModels is nil, the canonical
+// Recommended carril models are used.
 //
 // The output is deterministic: phases are always rendered in codexPhaseOrder.
-func RenderCodexPhaseEffortsByPhase(phaseModels map[string]string, efforts map[string]CodexEffort) string {
+func RenderCodexPhaseEffortsByPhase(phaseModels map[string]string, efforts map[string]CodexEffort, carrilModels map[string]string) string {
 	if len(efforts) == 0 {
 		efforts = CodexModelPresetRecommended()
 	}
-	carrilModels := DefaultCarrilModels()
+	if len(carrilModels) == 0 {
+		carrilModels = DefaultCarrilModels()
+	}
 
 	var sb strings.Builder
 	sb.WriteString("| Phase | Model | `reasoning_effort` |\n")

--- a/internal/model/codex_model_internal_test.go
+++ b/internal/model/codex_model_internal_test.go
@@ -1,0 +1,17 @@
+package model
+
+import "testing"
+
+func TestPhaseToCarrilModel_UnknownPhaseUsesRecommendedStrongDefault(t *testing.T) {
+	want := codexPresetMatrix[CodexPresetRecommended]["sdd-strong"].Model
+	if got := phaseToCarrilModel("unknown-phase", nil); got != want {
+		t.Errorf("phaseToCarrilModel(unknown) = %q, want %q", got, want)
+	}
+}
+
+func TestPhaseToCarrilModel_KnownPhaseUsesCarrilOverride(t *testing.T) {
+	carrilModels := map[string]string{"sdd-mid": "gpt-5.5"}
+	if got := phaseToCarrilModel("sdd-apply", carrilModels); got != "gpt-5.5" {
+		t.Errorf("phaseToCarrilModel(sdd-apply) = %q, want gpt-5.5", got)
+	}
+}

--- a/internal/model/codex_model_test.go
+++ b/internal/model/codex_model_test.go
@@ -20,6 +20,7 @@ func TestCodexEffortValid(t *testing.T) {
 		{"empty", model.CodexEffort(""), false},
 		{"junk", model.CodexEffort("junk"), false},
 		{"uppercase", model.CodexEffort("HIGH"), false},
+		{"max deferred", model.CodexEffort("max"), false},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -214,85 +215,91 @@ func TestCodexTierGroups_AllPhasesAssigned(t *testing.T) {
 
 func TestDefaultCarrilModels(t *testing.T) {
 	m := model.DefaultCarrilModels()
-	if m["sdd-strong"] != "gpt-5.5" {
-		t.Errorf("sdd-strong = %q, want gpt-5.5", m["sdd-strong"])
+	if m["sdd-strong"] != "gpt-5.6-sol" {
+		t.Errorf("sdd-strong = %q, want gpt-5.6-sol", m["sdd-strong"])
 	}
-	if m["sdd-mid"] != "gpt-5.5" {
-		t.Errorf("sdd-mid = %q, want gpt-5.5", m["sdd-mid"])
+	if m["sdd-mid"] != "gpt-5.6-terra" {
+		t.Errorf("sdd-mid = %q, want gpt-5.6-terra", m["sdd-mid"])
 	}
-	if m["sdd-cheap"] != "gpt-5.4-mini" {
-		t.Errorf("sdd-cheap = %q, want gpt-5.4-mini", m["sdd-cheap"])
+	if m["sdd-cheap"] != "gpt-5.6-luna" {
+		t.Errorf("sdd-cheap = %q, want gpt-5.6-luna", m["sdd-cheap"])
 	}
 	if len(m) != 3 {
 		t.Errorf("DefaultCarrilModels() has %d entries, want 3", len(m))
 	}
 }
 
-func TestPresetPlus_ModelEffortPerCarril(t *testing.T) {
+func TestPresetLowCost_ModelEffortPerCarril(t *testing.T) {
 	m := model.CodexModelPresetLowCost()
-	// Plus $20: Razonamiento=gpt-5.5/medium, Código=gpt-5.5/medium, Liviano=gpt-5.4-mini/low
+	// Low-cost: Razonamiento=gpt-5.6-terra/medium, Código=gpt-5.6-terra/medium, Liviano=gpt-5.6-luna/low
 	// Check that propose/design (Razonamiento/sdd-strong) is medium
 	if m["sdd-propose"] != model.CodexEffortMedium {
-		t.Errorf("Plus preset sdd-propose = %q, want medium", m["sdd-propose"])
+		t.Errorf("Low-cost preset sdd-propose = %q, want medium", m["sdd-propose"])
 	}
 	// apply (Código/sdd-mid) is medium
 	if m["sdd-apply"] != model.CodexEffortMedium {
-		t.Errorf("Plus preset sdd-apply = %q, want medium", m["sdd-apply"])
+		t.Errorf("Low-cost preset sdd-apply = %q, want medium", m["sdd-apply"])
 	}
 	// explore (Liviano/sdd-cheap) is low
 	if m["sdd-explore"] != model.CodexEffortLow {
-		t.Errorf("Plus preset sdd-explore = %q, want low", m["sdd-explore"])
+		t.Errorf("Low-cost preset sdd-explore = %q, want low", m["sdd-explore"])
 	}
 
-	// Verify Plus preset carril models
-	carrilModels := model.DefaultCarrilModels()
-	if carrilModels["sdd-strong"] != "gpt-5.5" {
-		t.Errorf("Plus preset sdd-strong model = %q, want gpt-5.5", carrilModels["sdd-strong"])
+	// Verify Low-cost preset carril models
+	carrilModels := model.CodexCarrilModelsForPreset("low-cost")
+	if carrilModels["sdd-strong"] != "gpt-5.6-terra" {
+		t.Errorf("Low-cost preset sdd-strong model = %q, want gpt-5.6-terra", carrilModels["sdd-strong"])
 	}
-	if carrilModels["sdd-mid"] != "gpt-5.5" {
-		t.Errorf("Plus preset sdd-mid model = %q, want gpt-5.5", carrilModels["sdd-mid"])
+	if carrilModels["sdd-mid"] != "gpt-5.6-terra" {
+		t.Errorf("Low-cost preset sdd-mid model = %q, want gpt-5.6-terra", carrilModels["sdd-mid"])
 	}
-	if carrilModels["sdd-cheap"] != "gpt-5.4-mini" {
-		t.Errorf("Plus preset sdd-cheap model = %q, want gpt-5.4-mini", carrilModels["sdd-cheap"])
+	if carrilModels["sdd-cheap"] != "gpt-5.6-luna" {
+		t.Errorf("Low-cost preset sdd-cheap model = %q, want gpt-5.6-luna", carrilModels["sdd-cheap"])
 	}
 }
 
-func TestPresetPro100_ModelEffortPerCarril(t *testing.T) {
-	// Pro $100: Razonamiento=gpt-5.5/high, Código=gpt-5.5/medium, Liviano=gpt-5.4-mini/low
+func TestPresetRecommended_ModelEffortPerCarril(t *testing.T) {
+	// Recommended: Razonamiento=gpt-5.6-sol/high, Código=gpt-5.6-terra/medium, Liviano=gpt-5.6-luna/low
 	m := model.CodexModelPresetRecommended()
 	if m["sdd-propose"] != model.CodexEffortHigh {
-		t.Errorf("Pro100 preset sdd-propose = %q, want high", m["sdd-propose"])
+		t.Errorf("Recommended preset sdd-propose = %q, want high", m["sdd-propose"])
 	}
 	// sdd-apply belongs to Código (sdd-mid): must be medium in Pro $100, not high.
 	if m["sdd-apply"] != model.CodexEffortMedium {
-		t.Errorf("Pro100 preset sdd-apply = %q, want medium (Código carril)", m["sdd-apply"])
+		t.Errorf("Recommended preset sdd-apply = %q, want medium (Código carril)", m["sdd-apply"])
 	}
 
-	carrilModels := model.DefaultCarrilModels()
-	if carrilModels["sdd-strong"] != "gpt-5.5" {
-		t.Errorf("Pro100 preset sdd-strong model = %q, want gpt-5.5", carrilModels["sdd-strong"])
+	carrilModels := model.CodexCarrilModelsForPreset("recommended")
+	if carrilModels["sdd-strong"] != "gpt-5.6-sol" {
+		t.Errorf("Recommended preset sdd-strong model = %q, want gpt-5.6-sol", carrilModels["sdd-strong"])
 	}
-	if carrilModels["sdd-cheap"] != "gpt-5.4-mini" {
-		t.Errorf("Pro100 preset sdd-cheap model = %q, want gpt-5.4-mini", carrilModels["sdd-cheap"])
+	if carrilModels["sdd-mid"] != "gpt-5.6-terra" {
+		t.Errorf("Recommended preset sdd-mid model = %q, want gpt-5.6-terra", carrilModels["sdd-mid"])
+	}
+	if carrilModels["sdd-cheap"] != "gpt-5.6-luna" {
+		t.Errorf("Recommended preset sdd-cheap model = %q, want gpt-5.6-luna", carrilModels["sdd-cheap"])
 	}
 }
 
-func TestPresetPro200_ModelEffortPerCarril(t *testing.T) {
-	// Pro $200: Razonamiento=gpt-5.5/xhigh, Código=gpt-5.5/high, Liviano=gpt-5.4-mini/low
+func TestPresetPowerful_ModelEffortPerCarril(t *testing.T) {
+	// Powerful: Razonamiento=gpt-5.6-sol/xhigh, Código=gpt-5.6-sol/high, Liviano=gpt-5.6-luna/low
 	m := model.CodexModelPresetPowerful()
 	if m["sdd-propose"] != model.CodexEffortXHigh {
-		t.Errorf("Pro200 preset sdd-propose = %q, want xhigh", m["sdd-propose"])
+		t.Errorf("Powerful preset sdd-propose = %q, want xhigh", m["sdd-propose"])
 	}
 	if m["sdd-apply"] != model.CodexEffortHigh {
-		t.Errorf("Pro200 preset sdd-apply = %q, want high", m["sdd-apply"])
+		t.Errorf("Powerful preset sdd-apply = %q, want high", m["sdd-apply"])
 	}
 
-	carrilModels := model.DefaultCarrilModels()
-	if carrilModels["sdd-strong"] != "gpt-5.5" {
-		t.Errorf("Pro200 preset sdd-strong model = %q, want gpt-5.5", carrilModels["sdd-strong"])
+	carrilModels := model.CodexCarrilModelsForPreset("powerful")
+	if carrilModels["sdd-strong"] != "gpt-5.6-sol" {
+		t.Errorf("Powerful preset sdd-strong model = %q, want gpt-5.6-sol", carrilModels["sdd-strong"])
 	}
-	if carrilModels["sdd-cheap"] != "gpt-5.4-mini" {
-		t.Errorf("Pro200 preset sdd-cheap model = %q, want gpt-5.4-mini", carrilModels["sdd-cheap"])
+	if carrilModels["sdd-mid"] != "gpt-5.6-sol" {
+		t.Errorf("Powerful preset sdd-mid model = %q, want gpt-5.6-sol", carrilModels["sdd-mid"])
+	}
+	if carrilModels["sdd-cheap"] != "gpt-5.6-luna" {
+		t.Errorf("Powerful preset sdd-cheap model = %q, want gpt-5.6-luna", carrilModels["sdd-cheap"])
 	}
 }
 
@@ -304,21 +311,19 @@ func TestRenderCodexPhaseEfforts_ModelColumn(t *testing.T) {
 	if !strings.Contains(out, "Model") {
 		t.Errorf("RenderCodexPhaseEfforts: table header missing 'Model' column; got:\n%s", out)
 	}
-	// All rows should contain gpt-5.5 or gpt-5.4-mini.
-	if !strings.Contains(out, "gpt-5.5") {
-		t.Errorf("RenderCodexPhaseEfforts: expected gpt-5.5 in output; got:\n%s", out)
-	}
-	if !strings.Contains(out, "gpt-5.4-mini") {
-		t.Errorf("RenderCodexPhaseEfforts: expected gpt-5.4-mini in output; got:\n%s", out)
+	for _, want := range []string{"gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("RenderCodexPhaseEfforts: expected %s in output; got:\n%s", want, out)
+		}
 	}
 }
 
 func TestRenderCodexPhaseEfforts_NilCarrilModels(t *testing.T) {
 	assignments := model.CodexModelPresetRecommended()
 	out := model.RenderCodexPhaseEfforts(assignments, nil)
-	// nil carrilModels: defaults apply; sdd-cheap row must show gpt-5.4-mini
-	if !strings.Contains(out, "gpt-5.4-mini") {
-		t.Errorf("RenderCodexPhaseEfforts(nil): sdd-cheap should show gpt-5.4-mini; got:\n%s", out)
+	// nil carrilModels: defaults apply; sdd-cheap row must show gpt-5.6-luna
+	if !strings.Contains(out, "gpt-5.6-luna") {
+		t.Errorf("RenderCodexPhaseEfforts(nil): sdd-cheap should show gpt-5.6-luna; got:\n%s", out)
 	}
 }
 
@@ -332,7 +337,7 @@ func TestRenderCodexPhaseEfforts_NonDefaultModel(t *testing.T) {
 		"sdd-cheap":  "gpt-5.4-mini",
 	}
 	out := model.RenderCodexPhaseEfforts(assignments, carrilModels)
-	// The sdd-strong row must show the overridden model, not the default gpt-5.5.
+	// The sdd-strong row must show the overridden model, not the default GPT-5.6 model.
 	checkCarrilRowModel(t, out, "sdd-strong", "gpt-5.4")
 	// Other rows must still show their canonical models.
 	checkCarrilRowModel(t, out, "sdd-mid", "gpt-5.5")
@@ -343,7 +348,7 @@ func TestRenderCodexPhaseEfforts_NonDefaultModel(t *testing.T) {
 
 func TestCodexAvailableModels_Contents(t *testing.T) {
 	models := model.CodexAvailableModels()
-	want := []string{"gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.2-codex", "gpt-5.3-codex"}
+	want := []string{"gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.2-codex", "gpt-5.3-codex"}
 	if len(models) != len(want) {
 		t.Fatalf("CodexAvailableModels() len = %d, want %d", len(models), len(want))
 	}
@@ -374,6 +379,21 @@ func TestFilterCodexModels_Match(t *testing.T) {
 		wantAny  []string
 		wantNone []string
 	}{
+		{
+			query:    "sol",
+			wantAny:  []string{"gpt-5.6-sol"},
+			wantNone: []string{"gpt-5.6-terra", "gpt-5.6-luna"},
+		},
+		{
+			query:    "terra",
+			wantAny:  []string{"gpt-5.6-terra"},
+			wantNone: []string{"gpt-5.6-sol", "gpt-5.6-luna"},
+		},
+		{
+			query:    "luna",
+			wantAny:  []string{"gpt-5.6-luna"},
+			wantNone: []string{"gpt-5.6-sol", "gpt-5.6-terra"},
+		},
 		{
 			query:    "gpt-5.5",
 			wantAny:  []string{"gpt-5.5"},
@@ -472,9 +492,9 @@ func TestRenderCodexPhaseEffortsByPhase_UnassignedUsesDefaultModel(t *testing.T)
 	efforts := model.CodexModelPresetRecommended()
 	out := model.RenderCodexPhaseEffortsByPhase(nil, efforts)
 
-	// sdd-explore is in sdd-cheap carril → gpt-5.4-mini.
-	if !strings.Contains(out, "gpt-5.4-mini") {
-		t.Errorf("RenderCodexPhaseEffortsByPhase(nil models): sdd-cheap phases should show gpt-5.4-mini; output:\n%s", out)
+	// sdd-explore is in sdd-cheap carril → gpt-5.6-luna.
+	if !strings.Contains(out, "gpt-5.6-luna") {
+		t.Errorf("RenderCodexPhaseEffortsByPhase(nil models): sdd-cheap phases should show gpt-5.6-luna; output:\n%s", out)
 	}
 }
 

--- a/internal/model/codex_model_test.go
+++ b/internal/model/codex_model_test.go
@@ -246,7 +246,7 @@ func TestPresetLowCost_ModelEffortPerCarril(t *testing.T) {
 	}
 
 	// Verify Low-cost preset carril models
-	carrilModels := model.CodexCarrilModelsForPreset("low-cost")
+	carrilModels := model.CodexCarrilModelsForPreset(string(model.CodexPresetLowCost))
 	if carrilModels["sdd-strong"] != "gpt-5.6-terra" {
 		t.Errorf("Low-cost preset sdd-strong model = %q, want gpt-5.6-terra", carrilModels["sdd-strong"])
 	}
@@ -269,7 +269,7 @@ func TestPresetRecommended_ModelEffortPerCarril(t *testing.T) {
 		t.Errorf("Recommended preset sdd-apply = %q, want medium (Código carril)", m["sdd-apply"])
 	}
 
-	carrilModels := model.CodexCarrilModelsForPreset("recommended")
+	carrilModels := model.CodexCarrilModelsForPreset(string(model.CodexPresetRecommended))
 	if carrilModels["sdd-strong"] != "gpt-5.6-sol" {
 		t.Errorf("Recommended preset sdd-strong model = %q, want gpt-5.6-sol", carrilModels["sdd-strong"])
 	}
@@ -291,7 +291,7 @@ func TestPresetPowerful_ModelEffortPerCarril(t *testing.T) {
 		t.Errorf("Powerful preset sdd-apply = %q, want high", m["sdd-apply"])
 	}
 
-	carrilModels := model.CodexCarrilModelsForPreset("powerful")
+	carrilModels := model.CodexCarrilModelsForPreset(string(model.CodexPresetPowerful))
 	if carrilModels["sdd-strong"] != "gpt-5.6-sol" {
 		t.Errorf("Powerful preset sdd-strong model = %q, want gpt-5.6-sol", carrilModels["sdd-strong"])
 	}
@@ -300,6 +300,40 @@ func TestPresetPowerful_ModelEffortPerCarril(t *testing.T) {
 	}
 	if carrilModels["sdd-cheap"] != "gpt-5.6-luna" {
 		t.Errorf("Powerful preset sdd-cheap model = %q, want gpt-5.6-luna", carrilModels["sdd-cheap"])
+	}
+}
+
+func TestCodexPresetCarrilDefaults_UnknownPresetFallsBackToRecommended(t *testing.T) {
+	got := model.CodexPresetCarrilDefaults("unknown-preset")
+	want := model.CodexPresetCarrilDefaults(string(model.CodexPresetRecommended))
+
+	for carril, wantDefault := range want {
+		if got[carril] != wantDefault {
+			t.Errorf("CodexPresetCarrilDefaults(unknown)[%q] = %+v, want recommended %+v", carril, got[carril], wantDefault)
+		}
+	}
+	if len(got) != len(want) {
+		t.Errorf("CodexPresetCarrilDefaults(unknown) len = %d, want %d", len(got), len(want))
+	}
+}
+
+func TestCodexPresetConstantsRemainStringCompatible(t *testing.T) {
+	tests := []struct {
+		name string
+		key  model.CodexPresetKey
+		want string
+	}{
+		{"low cost", model.CodexPresetLowCost, "low-cost"},
+		{"recommended", model.CodexPresetRecommended, "recommended"},
+		{"powerful", model.CodexPresetPowerful, "powerful"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if string(tc.key) != tc.want {
+				t.Errorf("string(%s) = %q, want %q", tc.name, tc.key, tc.want)
+			}
+		})
 	}
 }
 

--- a/internal/model/codex_model_test.go
+++ b/internal/model/codex_model_test.go
@@ -382,7 +382,7 @@ func TestRenderCodexPhaseEfforts_NonDefaultModel(t *testing.T) {
 
 func TestCodexAvailableModels_Contents(t *testing.T) {
 	models := model.CodexAvailableModels()
-	want := []string{"gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.2-codex", "gpt-5.3-codex"}
+	want := []string{"gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex", "gpt-5.2-codex"}
 	if len(models) != len(want) {
 		t.Fatalf("CodexAvailableModels() len = %d, want %d", len(models), len(want))
 	}
@@ -487,7 +487,7 @@ func TestRenderCodexPhaseEffortsByPhase_AllPhasesPresent(t *testing.T) {
 		"sdd-apply":   "gpt-5.4",
 	}
 	efforts := model.CodexModelPresetRecommended()
-	out := model.RenderCodexPhaseEffortsByPhase(phaseModels, efforts)
+	out := model.RenderCodexPhaseEffortsByPhase(phaseModels, efforts, nil)
 
 	phases := []string{
 		"sdd-explore", "sdd-propose", "sdd-spec", "sdd-design", "sdd-tasks",
@@ -509,7 +509,7 @@ func TestRenderCodexPhaseEffortsByPhase_CustomModelShown(t *testing.T) {
 		"sdd-propose": "gpt-5.4",
 	}
 	efforts := model.CodexModelPresetRecommended()
-	out := model.RenderCodexPhaseEffortsByPhase(phaseModels, efforts)
+	out := model.RenderCodexPhaseEffortsByPhase(phaseModels, efforts, nil)
 
 	// The sdd-propose row must contain exactly | `sdd-propose` | `gpt-5.4` |
 	// (not gpt-5.4-mini or any other model that happens to contain "gpt-5.4").
@@ -524,7 +524,7 @@ func TestRenderCodexPhaseEffortsByPhase_CustomModelShown(t *testing.T) {
 func TestRenderCodexPhaseEffortsByPhase_UnassignedUsesDefaultModel(t *testing.T) {
 	// No custom models — all phases should use carril defaults.
 	efforts := model.CodexModelPresetRecommended()
-	out := model.RenderCodexPhaseEffortsByPhase(nil, efforts)
+	out := model.RenderCodexPhaseEffortsByPhase(nil, efforts, nil)
 
 	// sdd-explore is in sdd-cheap carril → gpt-5.6-luna.
 	if !strings.Contains(out, "gpt-5.6-luna") {
@@ -532,10 +532,34 @@ func TestRenderCodexPhaseEffortsByPhase_UnassignedUsesDefaultModel(t *testing.T)
 	}
 }
 
+func TestRenderCodexPhaseEffortsByPhase_UnassignedUsesProvidedCarrilModel(t *testing.T) {
+	out := model.RenderCodexPhaseEffortsByPhase(
+		map[string]string{"sdd-propose": "gpt-5.4"},
+		model.CodexModelPresetRecommended(),
+		map[string]string{
+			"sdd-strong": "gpt-5.4-mini",
+			"sdd-mid":    "gpt-5.5",
+			"sdd-cheap":  "gpt-5.3-codex",
+		},
+	)
+
+	wantRows := []string{
+		"| `sdd-propose` | `gpt-5.4` | `high` |",
+		"| `sdd-design` | `gpt-5.4-mini` | `high` |",
+		"| `sdd-apply` | `gpt-5.5` | `medium` |",
+		"| `sdd-explore` | `gpt-5.3-codex` | `low` |",
+	}
+	for _, wantRow := range wantRows {
+		if !strings.Contains(out, wantRow) {
+			t.Errorf("RenderCodexPhaseEffortsByPhase missing row %q; output:\n%s", wantRow, out)
+		}
+	}
+}
+
 // TestRenderCodexPhaseEffortsByPhase_HeaderPresent verifies the table has a
 // Phase column header.
 func TestRenderCodexPhaseEffortsByPhase_HeaderPresent(t *testing.T) {
-	out := model.RenderCodexPhaseEffortsByPhase(nil, model.CodexModelPresetRecommended())
+	out := model.RenderCodexPhaseEffortsByPhase(nil, model.CodexModelPresetRecommended(), nil)
 	if !strings.Contains(out, "Phase") {
 		t.Errorf("RenderCodexPhaseEffortsByPhase: missing 'Phase' header; output:\n%s", out)
 	}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -54,13 +54,13 @@ type InstallState struct {
 
 	// CodexCarrilModelAssignments maps the three carril profile names
 	// (sdd-strong|sdd-mid|sdd-cheap) to OpenAI subscription model IDs
-	// (e.g. "gpt-5.5", "gpt-5.4-mini"). Persisted so that `gentle-ai sync`
+	// (e.g. "gpt-5.6-sol", "gpt-5.6-luna"). Persisted so that `gentle-ai sync`
 	// regenerates profile files with the user's chosen model per tier.
 	// Absent/empty = resolve to DefaultCarrilModels at runtime (backward-compat).
 	CodexCarrilModelAssignments map[string]string `json:"codexCarrilModelAssignments,omitempty"`
 
 	// CodexPhaseModelAssignments maps each of the 13 SDD phase names to the
-	// model id the user assigned in the Custom per-phase picker (e.g. "gpt-5.5").
+	// model id the user assigned in the Custom per-phase picker (e.g. "gpt-5.6-sol").
 	// When non-nil, overrides the carril-level model selection for that phase.
 	// Absent/nil = not using custom per-phase assignments (preset/carril behavior
 	// unchanged for backward-compatibility).

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1222,9 +1222,9 @@ func (m Model) handleKeyPress(key tea.KeyMsg) (tea.Model, tea.Cmd) {
 			}
 			if assignments != nil {
 				m.Selection.CodexModelAssignments = assignments
-				// Derive carril model assignments from the selected preset (all
-				// current presets use canonical subscription models).
-				presetCarrilModels := model.DefaultCarrilModels()
+				// Derive carril model assignments from the selected preset so each
+				// preset writes the same model matrix the UI displayed.
+				presetCarrilModels := model.CodexCarrilModelsForPreset(string(m.CodexModelPicker.Preset))
 				m.Selection.CodexCarrilModelAssignments = presetCarrilModels
 
 				// When the user confirmed Custom per-phase assignments, also

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -4931,50 +4931,77 @@ func TestCodexPicker_EscBackNavToPresetWhenNeitherClaudeNorKiro(t *testing.T) {
 	}
 }
 
-// TestCodexPresetSelection_PopulatesPendingSyncOverrides verifies that selecting a
-// Codex preset in ModelConfigMode populates PendingSyncOverrides with both
-// CodexModelAssignments and CodexCarrilModelAssignments (and the expected Selection fields).
+// TestCodexPresetSelection_PopulatesPendingSyncOverrides verifies that every
+// preset persists its model matrix through the user-visible Model.Update path.
 func TestCodexPresetSelection_PopulatesPendingSyncOverrides(t *testing.T) {
-	m := NewModel(system.DetectionResult{}, "dev")
-	m.Screen = ScreenCodexModelPicker
-	m.ModelConfigMode = true
-	m.Selection.Agents = []model.AgentID{model.AgentCodex}
-	m.Selection.Components = []model.ComponentID{model.ComponentEngram, model.ComponentSDD}
-	m.CodexModelPicker = screens.NewCodexModelPickerState()
-	m.Cursor = 1 // Recommended preset (index 1: LowCost=0, Recommended=1, Powerful=2)
-
-	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
-	state := updated.(Model)
-
-	// ModelConfigMode must be cleared after selection.
-	if state.ModelConfigMode {
-		t.Fatal("ModelConfigMode should be false after Codex preset selection")
+	tests := []struct {
+		name   string
+		cursor int
+		want   map[string]string
+	}{
+		{
+			name:   "low cost",
+			cursor: 0,
+			want: map[string]string{
+				"sdd-strong": "gpt-5.6-terra",
+				"sdd-mid":    "gpt-5.6-terra",
+				"sdd-cheap":  "gpt-5.6-luna",
+			},
+		},
+		{
+			name:   "recommended",
+			cursor: 1,
+			want: map[string]string{
+				"sdd-strong": "gpt-5.6-sol",
+				"sdd-mid":    "gpt-5.6-terra",
+				"sdd-cheap":  "gpt-5.6-luna",
+			},
+		},
+		{
+			name:   "powerful",
+			cursor: 2,
+			want: map[string]string{
+				"sdd-strong": "gpt-5.6-sol",
+				"sdd-mid":    "gpt-5.6-sol",
+				"sdd-cheap":  "gpt-5.6-luna",
+			},
+		},
 	}
 
-	// PendingSyncOverrides must be populated.
-	if state.PendingSyncOverrides == nil {
-		t.Fatal("PendingSyncOverrides = nil, want non-nil after Codex preset selection")
-	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := NewModel(system.DetectionResult{}, "dev")
+			m.Screen = ScreenCodexModelPicker
+			m.ModelConfigMode = true
+			m.Selection.Agents = []model.AgentID{model.AgentCodex}
+			m.Selection.Components = []model.ComponentID{model.ComponentEngram, model.ComponentSDD}
+			m.CodexModelPicker = screens.NewCodexModelPickerState()
+			m.Cursor = tt.cursor
 
-	// CodexCarrilModelAssignments must contain all three carrils.
-	carrilMap := state.PendingSyncOverrides.CodexCarrilModelAssignments
-	if carrilMap == nil {
-		t.Fatal("PendingSyncOverrides.CodexCarrilModelAssignments = nil, want non-nil")
-	}
-	for _, carril := range []string{"sdd-strong", "sdd-mid", "sdd-cheap"} {
-		if _, ok := carrilMap[carril]; !ok {
-			t.Errorf("PendingSyncOverrides.CodexCarrilModelAssignments missing carril %q", carril)
-		}
-	}
+			updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+			state := updated.(Model)
 
-	// CodexModelAssignments must be non-nil (phase→effort map).
-	if state.PendingSyncOverrides.CodexModelAssignments == nil {
-		t.Fatal("PendingSyncOverrides.CodexModelAssignments = nil, want non-nil")
-	}
+			if state.ModelConfigMode {
+				t.Fatal("ModelConfigMode should be false after Codex preset selection")
+			}
+			if state.PendingSyncOverrides == nil {
+				t.Fatal("PendingSyncOverrides = nil, want non-nil after Codex preset selection")
+			}
+			if state.PendingSyncOverrides.CodexModelAssignments == nil {
+				t.Fatal("PendingSyncOverrides.CodexModelAssignments = nil, want non-nil")
+			}
 
-	// Selection must also be updated.
-	if state.Selection.CodexCarrilModelAssignments == nil {
-		t.Fatal("Selection.CodexCarrilModelAssignments = nil, want non-nil after preset selection")
+			pendingCarrils := state.PendingSyncOverrides.CodexCarrilModelAssignments
+			selectedCarrils := state.Selection.CodexCarrilModelAssignments
+			for carril, wantModel := range tt.want {
+				if got := pendingCarrils[carril]; got != wantModel {
+					t.Errorf("PendingSyncOverrides.CodexCarrilModelAssignments[%q] = %q, want %q", carril, got, wantModel)
+				}
+				if got := selectedCarrils[carril]; got != wantModel {
+					t.Errorf("Selection.CodexCarrilModelAssignments[%q] = %q, want %q", carril, got, wantModel)
+				}
+			}
+		})
 	}
 }
 

--- a/internal/tui/screens/codex_model_picker.go
+++ b/internal/tui/screens/codex_model_picker.go
@@ -35,9 +35,9 @@ var codexPresetOrder = []CodexModelPreset{
 }
 
 var codexPresetDescriptions = map[CodexModelPreset]string{
-	CodexPresetLowCost:     "Minimal effort — preserves tight ChatGPT Plus ($20/mo) usage limits",
-	CodexPresetRecommended: "Balanced effort — high on key phases, low on lightweight work (Pro $100/mo)",
-	CodexPresetPowerful:    "Maximum effort — xhigh on architecture, design, and verification (Pro $200/mo)",
+	CodexPresetLowCost:     "Lowest-cost GPT-5.6 mix — Terra for work, Luna for lightweight phases",
+	CodexPresetRecommended: "Balanced GPT-5.6 mix — Sol for reasoning, Terra for code, Luna for light work",
+	CodexPresetPowerful:    "Maximum GPT-5.6 mix — Sol for strong and code phases, Luna for light work",
 }
 
 var codexPresetConstructors = map[CodexModelPreset]func() map[string]model.CodexEffort{
@@ -546,18 +546,32 @@ func codexModelSearchDisplay(query string) string {
 // Labels are self-describing: they include the model id and effort tier per
 // carril so the user can see what will be written to profile files.
 //
-// Format: "<Plan> — Razonamiento gpt-5.5/<effort> · Código gpt-5.5/<effort> · Liviano gpt-5.4-mini/low"
+// Format: "<Plan> — Razonamiento <model>/<effort> · Código <model>/<effort> · Liviano <model>/<effort>"
 func CodexPresetLabel(preset CodexModelPreset) string {
+	defaults := model.CodexPresetCarrilDefaults(string(preset))
+	strong := defaults["sdd-strong"]
+	mid := defaults["sdd-mid"]
+	cheap := defaults["sdd-cheap"]
+
+	plan := string(preset)
 	switch preset {
 	case CodexPresetLowCost:
-		return "Plus $20 — Razonamiento gpt-5.5/medium · Código gpt-5.5/medium · Liviano gpt-5.4-mini/low"
+		plan = "Low-cost"
 	case CodexPresetRecommended:
-		return "Pro $100 — Razonamiento gpt-5.5/high · Código gpt-5.5/medium · Liviano gpt-5.4-mini/low"
+		plan = "Recommended"
 	case CodexPresetPowerful:
-		return "Pro $200 — Razonamiento gpt-5.5/xhigh · Código gpt-5.5/high · Liviano gpt-5.4-mini/low"
-	default:
-		return string(preset)
+		plan = "Powerful"
 	}
+
+	return fmt.Sprintf("%s — Razonamiento %s/%s · Código %s/%s · Liviano %s/%s",
+		plan,
+		strong.Model,
+		strong.Effort,
+		mid.Model,
+		mid.Effort,
+		cheap.Model,
+		cheap.Effort,
+	)
 }
 
 // CodexPresetDescription returns a one-line description for a preset.

--- a/internal/tui/screens/codex_model_picker.go
+++ b/internal/tui/screens/codex_model_picker.go
@@ -17,15 +17,15 @@ type CodexModelPreset string
 const (
 	// CodexPresetLowCost targets ChatGPT Plus ($20/mo) — minimal effort to
 	// stay within the plan's tight usage limits.
-	CodexPresetLowCost CodexModelPreset = "low-cost"
+	CodexPresetLowCost CodexModelPreset = CodexModelPreset(model.CodexPresetLowCost)
 
 	// CodexPresetRecommended targets ChatGPT Pro ($100/mo) — balanced effort
 	// for most SDD work. This is the default preset.
-	CodexPresetRecommended CodexModelPreset = "recommended"
+	CodexPresetRecommended CodexModelPreset = CodexModelPreset(model.CodexPresetRecommended)
 
 	// CodexPresetPowerful targets ChatGPT Pro ($200/mo) — xhigh effort for
 	// architecture-heavy and review-heavy phases.
-	CodexPresetPowerful CodexModelPreset = "powerful"
+	CodexPresetPowerful CodexModelPreset = CodexModelPreset(model.CodexPresetPowerful)
 )
 
 var codexPresetOrder = []CodexModelPreset{

--- a/internal/tui/screens/codex_model_picker_test.go
+++ b/internal/tui/screens/codex_model_picker_test.go
@@ -217,26 +217,25 @@ func TestCodexPickerLabels_SelfDescribing(t *testing.T) {
 		t.Run(string(tc.preset), func(t *testing.T) {
 			label := screens.CodexPresetLabel(tc.preset)
 
-			// Model must appear at least once.
-			if !strings.Contains(label, "gpt-5.5") {
-				t.Errorf("CodexPresetLabel(%q) = %q: missing gpt-5.5", tc.preset, label)
-			}
+			defaults := model.CodexPresetCarrilDefaults(string(tc.preset))
 
 			// Verify each carril by anchoring the model/effort token to its OWN
 			// carril segment. This catches a regression in one carril even when
-			// another carril shares the same model+effort (e.g. LowCost strong
-			// and mid are both gpt-5.5/medium).
-			strongToken := "Razonamiento gpt-5.5/" + tc.wantStrongEffort
+			// another carril shares the same model+effort.
+			strong := defaults["sdd-strong"]
+			strongToken := "Razonamiento " + strong.Model + "/" + tc.wantStrongEffort
 			if !strings.Contains(label, strongToken) {
 				t.Errorf("CodexPresetLabel(%q) = %q: Razonamiento carril missing %q", tc.preset, label, strongToken)
 			}
 
-			midToken := "Código gpt-5.5/" + tc.wantMidEffort
+			mid := defaults["sdd-mid"]
+			midToken := "Código " + mid.Model + "/" + tc.wantMidEffort
 			if !strings.Contains(label, midToken) {
 				t.Errorf("CodexPresetLabel(%q) = %q: Código carril missing %q", tc.preset, label, midToken)
 			}
 
-			cheapToken := "Liviano gpt-5.4-mini/" + tc.wantCheapEffort
+			cheap := defaults["sdd-cheap"]
+			cheapToken := "Liviano " + cheap.Model + "/" + tc.wantCheapEffort
 			if !strings.Contains(label, cheapToken) {
 				t.Errorf("CodexPresetLabel(%q) = %q: Liviano carril missing %q", tc.preset, label, cheapToken)
 			}
@@ -309,7 +308,7 @@ func TestCodexCustomModelSearch_EmptyQueryShowsAll(t *testing.T) {
 	state.CustomMode = screens.CodexCustomModeModelSelect
 	state.CustomModelSearch = ""
 	out := screens.RenderCodexModelPicker(state, 0)
-	for _, m := range []string{"gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.2-codex", "gpt-5.3-codex"} {
+	for _, m := range model.CodexAvailableModels() {
 		if !strings.Contains(out, m) {
 			t.Errorf("model search empty query must show all models; missing %q; output:\n%s", m, out)
 		}
@@ -411,8 +410,8 @@ func TestCodexCustom_SelectModelAndEffortUpdatesAssignment(t *testing.T) {
 	if !ok {
 		t.Fatalf("CustomAssignments missing sdd-explore; got: %v", state.CustomAssignments)
 	}
-	if a.ModelID != "gpt-5.5" {
-		t.Errorf("CustomAssignments[sdd-explore].ModelID = %q, want gpt-5.5", a.ModelID)
+	if a.ModelID != "gpt-5.6-sol" {
+		t.Errorf("CustomAssignments[sdd-explore].ModelID = %q, want gpt-5.6-sol", a.ModelID)
 	}
 	if a.Effort != model.CodexEffortHigh {
 		t.Errorf("CustomAssignments[sdd-explore].Effort = %q, want high", a.Effort)

--- a/internal/versions/versions.go
+++ b/internal/versions/versions.go
@@ -17,7 +17,7 @@ const OpenCode = "1.14.48"
 const QwenCode = "0.15.10"
 
 // renovate: datasource=npm depName=@openai/codex
-const Codex = "0.137.0"
+const Codex = "0.144.0"
 
 // renovate: datasource=npm depName=@google/gemini-cli
 const GeminiCLI = "0.41.2"

--- a/testdata/golden/sdd-codex-agentsmd-lowcost.golden
+++ b/testdata/golden/sdd-codex-agentsmd-lowcost.golden
@@ -140,7 +140,7 @@ For each phase:
 
 Example — launching `sdd-design` with its assigned model and effort:
 ```
-spawn_agent(task_name="sdd-design", message=<design prompt>, model="gpt-5.5", reasoning_effort="xhigh", fork_turns="none")
+spawn_agent(task_name="sdd-design", message=<design prompt>, model="gpt-5.6-sol", reasoning_effort="xhigh", fork_turns="none")
 wait_agent(task_name="sdd-design")
 close_agent(task_name="sdd-design")
 ```
@@ -355,9 +355,9 @@ These profile files apply to whole CLI sessions: `codex --profile <name> "<promp
 
 | Profile (CLI) | Model | `reasoning_effort` (spawn_agent) | SDD phases |
 |---------------|-------|----------------------------------|------------|
-| `sdd-strong` | `gpt-5.5` | `medium` | propose, design, verify, judge |
-| `sdd-mid` | `gpt-5.5` | `medium` | apply, fix-agent |
-| `sdd-cheap` | `gpt-5.4-mini` | `low` | explore, spec, tasks, archive, onboard |
+| `sdd-strong` | `gpt-5.6-terra` | `medium` | propose, design, verify, judge |
+| `sdd-mid` | `gpt-5.6-terra` | `medium` | apply, fix-agent |
+| `sdd-cheap` | `gpt-5.6-luna` | `low` | explore, spec, tasks, archive, onboard |
 
 <!-- /gentle-ai:sdd-orchestrator -->
 

--- a/testdata/golden/sdd-codex-agentsmd-lowcost.golden
+++ b/testdata/golden/sdd-codex-agentsmd-lowcost.golden
@@ -138,9 +138,9 @@ For each phase:
 5. `close_agent` to release the thread.
 6. Verify the artifact was persisted before launching the next phase.
 
-Example — launching `sdd-design` with its assigned model and effort:
+Example — launching `sdd-design` with the values from its generated table row:
 ```
-spawn_agent(task_name="sdd-design", message=<design prompt>, model="gpt-5.6-sol", reasoning_effort="xhigh", fork_turns="none")
+spawn_agent(task_name="sdd-design", message=<design prompt>, model="<assigned-model>", reasoning_effort="<assigned-effort>", fork_turns="none")
 wait_agent(task_name="sdd-design")
 close_agent(task_name="sdd-design")
 ```

--- a/testdata/golden/sdd-codex-agentsmd-powerful.golden
+++ b/testdata/golden/sdd-codex-agentsmd-powerful.golden
@@ -140,7 +140,7 @@ For each phase:
 
 Example — launching `sdd-design` with its assigned model and effort:
 ```
-spawn_agent(task_name="sdd-design", message=<design prompt>, model="gpt-5.5", reasoning_effort="xhigh", fork_turns="none")
+spawn_agent(task_name="sdd-design", message=<design prompt>, model="gpt-5.6-sol", reasoning_effort="xhigh", fork_turns="none")
 wait_agent(task_name="sdd-design")
 close_agent(task_name="sdd-design")
 ```
@@ -355,9 +355,9 @@ These profile files apply to whole CLI sessions: `codex --profile <name> "<promp
 
 | Profile (CLI) | Model | `reasoning_effort` (spawn_agent) | SDD phases |
 |---------------|-------|----------------------------------|------------|
-| `sdd-strong` | `gpt-5.5` | `xhigh` | propose, design, verify, judge |
-| `sdd-mid` | `gpt-5.5` | `high` | apply, fix-agent |
-| `sdd-cheap` | `gpt-5.4-mini` | `low` | explore, spec, tasks, archive, onboard |
+| `sdd-strong` | `gpt-5.6-sol` | `xhigh` | propose, design, verify, judge |
+| `sdd-mid` | `gpt-5.6-sol` | `high` | apply, fix-agent |
+| `sdd-cheap` | `gpt-5.6-luna` | `low` | explore, spec, tasks, archive, onboard |
 
 <!-- /gentle-ai:sdd-orchestrator -->
 

--- a/testdata/golden/sdd-codex-agentsmd-powerful.golden
+++ b/testdata/golden/sdd-codex-agentsmd-powerful.golden
@@ -138,9 +138,9 @@ For each phase:
 5. `close_agent` to release the thread.
 6. Verify the artifact was persisted before launching the next phase.
 
-Example — launching `sdd-design` with its assigned model and effort:
+Example — launching `sdd-design` with the values from its generated table row:
 ```
-spawn_agent(task_name="sdd-design", message=<design prompt>, model="gpt-5.6-sol", reasoning_effort="xhigh", fork_turns="none")
+spawn_agent(task_name="sdd-design", message=<design prompt>, model="<assigned-model>", reasoning_effort="<assigned-effort>", fork_turns="none")
 wait_agent(task_name="sdd-design")
 close_agent(task_name="sdd-design")
 ```

--- a/testdata/golden/sdd-codex-agentsmd.golden
+++ b/testdata/golden/sdd-codex-agentsmd.golden
@@ -140,7 +140,7 @@ For each phase:
 
 Example — launching `sdd-design` with its assigned model and effort:
 ```
-spawn_agent(task_name="sdd-design", message=<design prompt>, model="gpt-5.5", reasoning_effort="xhigh", fork_turns="none")
+spawn_agent(task_name="sdd-design", message=<design prompt>, model="gpt-5.6-sol", reasoning_effort="xhigh", fork_turns="none")
 wait_agent(task_name="sdd-design")
 close_agent(task_name="sdd-design")
 ```
@@ -355,9 +355,9 @@ These profile files apply to whole CLI sessions: `codex --profile <name> "<promp
 
 | Profile (CLI) | Model | `reasoning_effort` (spawn_agent) | SDD phases |
 |---------------|-------|----------------------------------|------------|
-| `sdd-strong` | `gpt-5.5` | `high` | propose, design, verify, judge |
-| `sdd-mid` | `gpt-5.5` | `medium` | apply, fix-agent |
-| `sdd-cheap` | `gpt-5.4-mini` | `low` | explore, spec, tasks, archive, onboard |
+| `sdd-strong` | `gpt-5.6-sol` | `high` | propose, design, verify, judge |
+| `sdd-mid` | `gpt-5.6-terra` | `medium` | apply, fix-agent |
+| `sdd-cheap` | `gpt-5.6-luna` | `low` | explore, spec, tasks, archive, onboard |
 
 <!-- /gentle-ai:sdd-orchestrator -->
 

--- a/testdata/golden/sdd-codex-agentsmd.golden
+++ b/testdata/golden/sdd-codex-agentsmd.golden
@@ -138,9 +138,9 @@ For each phase:
 5. `close_agent` to release the thread.
 6. Verify the artifact was persisted before launching the next phase.
 
-Example — launching `sdd-design` with its assigned model and effort:
+Example — launching `sdd-design` with the values from its generated table row:
 ```
-spawn_agent(task_name="sdd-design", message=<design prompt>, model="gpt-5.6-sol", reasoning_effort="xhigh", fork_turns="none")
+spawn_agent(task_name="sdd-design", message=<design prompt>, model="<assigned-model>", reasoning_effort="<assigned-effort>", fork_turns="none")
 wait_agent(task_name="sdd-design")
 close_agent(task_name="sdd-design")
 ```


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1066

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [ ] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [x] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Prepares Codex SDD model defaults for GPT-5.6 Sol/Terra/Luna.
- Preserves explicit saved old/custom model assignments instead of migrating user choices.
- Keeps `max` effort and `ultra` mode out of the active surface until Codex support is confirmed.

✅ **Runtime gate satisfied:** after updating to `codex-cli 0.144.0`, `codex debug models` lists `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna`. This PR is now ready for review.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/model/codex_model.go` | Adds GPT-5.6 model IDs and centralizes preset/carril defaults. |
| `internal/tui/screens/codex_model_picker.go` | Renders Codex preset labels from the shared matrix. |
| `internal/tui/model.go` | Persists preset-specific carril model assignments. |
| `internal/agents/codex/*` | Updates Codex profile defaults/comments/tests. |
| `internal/components/*` | Updates SDD/Codex injection tests and goldens. |
| `docs/agents.md` | Documents GPT-5.6 defaults, preserved custom state, and deferred `max`/`ultra`. |

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./...
go vet ./...
```

**Codex catalog smoke**
```bash
codex debug models
# Verified with codex-cli 0.144.0: GPT-5.6 Sol/Terra/Luna are listed.
```

Runtime recognition validated locally with `codex debug models`:
- [x] `gpt-5.6-sol`
- [x] `gpt-5.6-terra`
- [x] `gpt-5.6-luna`

- [x] Unit tests pass (`go test ./...`)
- [x] E2E tests pass in CI (ubuntu, fedora, arch)
- [x] Manually tested locally

---

## 🤖 Automated Checks

The following checks run automatically on this PR:

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ✅ | PR is slightly over 400 changed lines; `size:exception` rationale documented because this is mostly synchronized tests/goldens/docs. |
| Check Issue Reference | ✅ | PR body contains `Closes #1066` |
| Check Issue Has `status:approved` | ✅ | Linked issue has `status:approved` |
| Check PR Has `type:*` Label | ✅ | `type:feature` label applied |
| Unit Tests | ✅ | `go test ./...` passed in CI |
| E2E Tests | ✅ | CI E2E passed on ubuntu, fedora, and arch |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [x] E2E tests pass in CI (ubuntu, fedora, arch)
- [x] I have updated documentation if necessary
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

Review the behavior as ready: code/tests are prepared and the Codex model catalog/runtime gate has been validated locally with `codex-cli 0.144.0`.

SDD planning artifacts were created locally under `openspec/changes/prepare-gpt-5-6-codex-models/`, but are intentionally not included in this PR to keep reviewer load focused on the implementation diff.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated Codex SDD preset defaults to newer GPT model options (strong, mid, low-cost) and revised phase-to-model mappings.
  * Model picker now shows dynamically generated preset labels with per-carril model and effort details.
* **Bug Fixes**
  * Sync now preserves explicitly saved Codex model assignments and only fills missing defaults.
  * Custom per-phase effort/model rendering now correctly incorporates carril-derived model fallbacks.
  * Improved fallback behavior for unassigned phases to use the latest defaults.
* **Documentation**
  * Refreshed Codex/SDD docs and examples to match the new defaults.
* **Chores**
  * Updated the bundled Codex integration version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## 🔧 Review fixes

- Bumped the managed Codex CLI pin to `0.144.0`, the verified runtime that exposes GPT-5.6 Sol/Terra/Luna.
- Preserved selected or explicitly saved carril models as fallbacks in sparse Custom per-phase configurations.
- Replaced the hardcoded delegation example with generated-table placeholders.
- Added preset-specific TUI persistence coverage and refreshed Codex goldens/docs.
- Reordered the curated legacy Codex entries to match the documented newest-first contract.

Fresh 4R scoped re-review approved the fix diff. `go test -count=1 ./...`, `go vet ./...`, `go build ./...`, and `git diff --check` pass locally.
