### PR TITLE
fix(community-tool): resolve installed CodeGraph binary path

### DIFF
--- a/internal/components/communitytool/tool.go
+++ b/internal/components/communitytool/tool.go
@@ -170,15 +170,17 @@ func InstallWithHome(id model.CommunityToolID, workspaceDir string, homeDir stri
 		return result, err
 	}
 	after := DetectStatus(id, homeDir, detector)
+	pathFollowUp := ""
 	if after.CLI != AvailabilityAvailable && setupCommand[0] != "codegraph" {
-		after.FollowUps = append(after.FollowUps, fmt.Sprintf("CodeGraph setup ran via %s, but `codegraph` is still not available in PATH. Add the package manager global binary directory to PATH, restart your shell, then rerun Gentle AI.", setupCommand[0]))
+		pathFollowUp = fmt.Sprintf("CodeGraph setup ran via %s, but `codegraph` is still not available in PATH. Add the package manager global binary directory to PATH, restart your shell, then rerun Gentle AI.", setupCommand[0])
+		after.FollowUps = append(after.FollowUps, pathFollowUp)
 	}
 	result.StatusAfter = &after
-	if after.CLI != AvailabilityAvailable && setupCommand[0] != "codegraph" && len(after.FollowUps) > 0 {
+	if pathFollowUp != "" {
 		if err := validateCodeGraphDetectedAgentsConfigured(after); err != nil {
 			return result, err
 		}
-		result.ManualActions = append(result.ManualActions, after.FollowUps[len(after.FollowUps)-1])
+		result.ManualActions = append(result.ManualActions, pathFollowUp)
 		result.ManualActions = append(result.ManualActions, "CodeGraph setup completed through the resolved package-manager executable. Add the package manager global binary directory to PATH before running `codegraph` directly.")
 		return result, nil
 	}

--- a/internal/components/communitytool/tool.go
+++ b/internal/components/communitytool/tool.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"runtime"
 	"slices"
 	"strings"
 
@@ -81,6 +83,7 @@ func (fn RunnerFunc) Run(name string, args ...string) error { return fn(name, ar
 var (
 	codeGraphPackageLookPath = exec.LookPath
 	codeGraphPnpmGlobalBin   = defaultPnpmGlobalBin
+	codeGraphNpmGlobalBin    = defaultNpmGlobalBin
 )
 
 var definitions = []Definition{
@@ -146,24 +149,39 @@ func InstallWithHome(id model.CommunityToolID, workspaceDir string, homeDir stri
 		return result, nil
 	}
 
-	commands, err := CodeGraphCommandsForDetector(DetectorFunc(codeGraphPackageLookPath))
+	packageManager, err := detectCodeGraphPackageManager(DetectorFunc(codeGraphPackageLookPath))
 	if err != nil {
 		return result, err
 	}
-	for _, command := range commands {
-		if len(command) == 0 {
-			continue
-		}
-		result.CommandsRun = append(result.CommandsRun, strings.Join(command, " "))
-		if err := runner.Run(command[0], command[1:]...); err != nil {
-			return result, fmt.Errorf("run %q: %w", strings.Join(command, " "), err)
-		}
+	installCommand := codeGraphPackageInstallCommand(packageManager)
+	result.CommandsRun = append(result.CommandsRun, strings.Join(installCommand, " "))
+	if err := runner.Run(installCommand[0], installCommand[1:]...); err != nil {
+		return result, fmt.Errorf("run %q: %w", strings.Join(installCommand, " "), err)
+	}
+	setupCommand, err := resolveCodeGraphSetupCommand(packageManager, DetectorFunc(codeGraphPackageLookPath))
+	if err != nil {
+		return result, err
+	}
+	result.CommandsRun = append(result.CommandsRun, strings.Join(setupCommand, " "))
+	if err := runner.Run(setupCommand[0], setupCommand[1:]...); err != nil {
+		return result, fmt.Errorf("run %q: %w", strings.Join(setupCommand, " "), err)
 	}
 	if _, err := InjectCodeGraphGuidanceIfSelected(homeDir, []model.CommunityToolID{id}); err != nil {
 		return result, err
 	}
 	after := DetectStatus(id, homeDir, detector)
+	if after.CLI != AvailabilityAvailable && setupCommand[0] != "codegraph" {
+		after.FollowUps = append(after.FollowUps, fmt.Sprintf("CodeGraph setup ran via %s, but `codegraph` is still not available in PATH. Add the package manager global binary directory to PATH, restart your shell, then rerun Gentle AI.", setupCommand[0]))
+	}
 	result.StatusAfter = &after
+	if after.CLI != AvailabilityAvailable && setupCommand[0] != "codegraph" && len(after.FollowUps) > 0 {
+		if err := validateCodeGraphDetectedAgentsConfigured(after); err != nil {
+			return result, err
+		}
+		result.ManualActions = append(result.ManualActions, after.FollowUps[len(after.FollowUps)-1])
+		result.ManualActions = append(result.ManualActions, "CodeGraph setup completed through the resolved package-manager executable. Add the package manager global binary directory to PATH before running `codegraph` directly.")
+		return result, nil
+	}
 	if err := validateCodeGraphInstallStatus(after); err != nil {
 		return result, err
 	}
@@ -178,6 +196,10 @@ func validateCodeGraphInstallStatus(status Status) error {
 	if status.CLI != AvailabilityAvailable {
 		return fmt.Errorf("CodeGraph install did not leave the codegraph CLI available")
 	}
+	return validateCodeGraphDetectedAgentsConfigured(status)
+}
+
+func validateCodeGraphDetectedAgentsConfigured(status Status) error {
 	missing := make([]string, 0)
 	for _, agent := range status.Agents {
 		if agent.Detected && !agent.Configured {
@@ -415,6 +437,29 @@ func defaultPnpmGlobalBin() (string, error) {
 	return strings.TrimSpace(string(output)), nil
 }
 
+func defaultNpmGlobalBin() (string, error) {
+	output, err := exec.Command("npm", "prefix", "-g").CombinedOutput()
+	if err != nil {
+		message := strings.TrimSpace(string(output))
+		if message == "" {
+			message = err.Error()
+		}
+		return "", fmt.Errorf("npm global prefix is not usable: %s", message)
+	}
+	prefix := strings.TrimSpace(string(output))
+	if prefix == "" {
+		return "", fmt.Errorf("npm global prefix is empty")
+	}
+	return codeGraphNpmGlobalBinForOS(prefix, runtime.GOOS), nil
+}
+
+func codeGraphNpmGlobalBinForOS(prefix string, goos string) string {
+	if goos == "windows" {
+		return prefix
+	}
+	return filepath.Join(prefix, "bin")
+}
+
 func detectCodeGraphPackageManager(detector Detector) (string, error) {
 	if detector == nil {
 		detector = DetectorFunc(exec.LookPath)
@@ -436,12 +481,66 @@ func detectCodeGraphPackageManager(detector Detector) (string, error) {
 }
 
 func codeGraphCommands(packageManager string) [][]string {
-	installCommand := []string{"npm", "install", "-g", "@colbymchenry/codegraph@latest"}
-	if packageManager == "pnpm" {
-		installCommand = []string{"pnpm", "add", "-g", "@colbymchenry/codegraph@latest"}
-	}
 	return [][]string{
-		installCommand,
+		codeGraphPackageInstallCommand(packageManager),
 		{"codegraph", "install", "--yes"},
 	}
+}
+
+func codeGraphPackageInstallCommand(packageManager string) []string {
+	if packageManager == "pnpm" {
+		return []string{"pnpm", "add", "-g", "@colbymchenry/codegraph@latest"}
+	}
+	return []string{"npm", "install", "-g", "@colbymchenry/codegraph@latest"}
+}
+
+func resolveCodeGraphSetupCommand(packageManager string, detector Detector) ([]string, error) {
+	if detector == nil {
+		detector = DetectorFunc(exec.LookPath)
+	}
+	if _, err := detector.LookPath("codegraph"); err == nil {
+		return []string{"codegraph", "install", "--yes"}, nil
+	}
+
+	globalBin, err := codeGraphGlobalBin(packageManager)
+	if err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(globalBin) == "" {
+		return nil, fmt.Errorf("CodeGraph CLI was installed with %s, but the global binary directory could not be determined. Add the package manager global bin directory to PATH, restart your shell, then rerun Gentle AI", packageManager)
+	}
+
+	for _, candidate := range codeGraphExecutableCandidates(globalBin) {
+		if _, err := detector.LookPath(candidate); err == nil {
+			return []string{candidate, "install", "--yes"}, nil
+		}
+	}
+	return nil, fmt.Errorf("CodeGraph CLI was installed with %s, but `codegraph` is not in PATH and no executable was found in %q. Add that directory to PATH or restart your shell, then rerun Gentle AI", packageManager, globalBin)
+}
+
+func codeGraphGlobalBin(packageManager string) (string, error) {
+	if packageManager == "pnpm" {
+		globalBin, err := codeGraphPnpmGlobalBin()
+		if err != nil {
+			return "", fmt.Errorf("CodeGraph CLI was installed with pnpm, but pnpm global binary directory could not be resolved. Run `pnpm setup`, restart your shell, then rerun Gentle AI: %w", err)
+		}
+		return globalBin, nil
+	}
+	globalBin, err := codeGraphNpmGlobalBin()
+	if err != nil {
+		return "", fmt.Errorf("CodeGraph CLI was installed with npm, but npm global binary directory could not be resolved. Add npm's global bin directory to PATH, restart your shell, then rerun Gentle AI: %w", err)
+	}
+	return globalBin, nil
+}
+
+func codeGraphExecutableCandidates(globalBin string) []string {
+	return codeGraphExecutableCandidatesForOS(globalBin, runtime.GOOS)
+}
+
+func codeGraphExecutableCandidatesForOS(globalBin string, goos string) []string {
+	candidates := []string{filepath.Join(globalBin, "codegraph")}
+	if goos == "windows" {
+		candidates = append(candidates, filepath.Join(globalBin, "codegraph.cmd"), filepath.Join(globalBin, "codegraph.exe"))
+	}
+	return candidates
 }

--- a/internal/components/communitytool/tool_test.go
+++ b/internal/components/communitytool/tool_test.go
@@ -17,9 +17,15 @@ func TestMain(m *testing.M) {
 		if name == "npm" {
 			return "/bin/npm", nil
 		}
+		if name == "codegraph" {
+			return "/bin/codegraph", nil
+		}
 		return "", fmt.Errorf("not found")
 	}
 	codeGraphPnpmGlobalBin = func() (string, error) {
+		return "/bin", nil
+	}
+	codeGraphNpmGlobalBin = func() (string, error) {
 		return "/bin", nil
 	}
 	os.Exit(m.Run())
@@ -122,6 +128,9 @@ func TestInstallUsesPnpmWhenNpmIsUnavailable(t *testing.T) {
 		if name == "pnpm" {
 			return "/bin/pnpm", nil
 		}
+		if name == "codegraph" {
+			return "/bin/codegraph", nil
+		}
 		return "", errors.New("not found")
 	}
 	t.Cleanup(func() { codeGraphPackageLookPath = previous })
@@ -147,6 +156,217 @@ func TestInstallUsesPnpmWhenNpmIsUnavailable(t *testing.T) {
 	}
 	if !reflect.DeepEqual(commands, want) {
 		t.Fatalf("commands = %#v, want %#v", commands, want)
+	}
+}
+
+func TestResolveCodeGraphSetupCommand(t *testing.T) {
+	tests := []struct {
+		name        string
+		manager     string
+		globalBin   string
+		lookPath    func(string) (string, error)
+		wantCommand []string
+		wantErr     []string
+	}{
+		{
+			name:      "preserves codegraph from PATH",
+			manager:   "npm",
+			globalBin: "/unused",
+			lookPath: func(name string) (string, error) {
+				if name == "codegraph" {
+					return "/usr/local/bin/codegraph", nil
+				}
+				return "", errors.New("not found")
+			},
+			wantCommand: []string{"codegraph", "install", "--yes"},
+		},
+		{
+			name:      "uses npm global bin when PATH misses codegraph",
+			manager:   "npm",
+			globalBin: "/home/example/.npm/bin",
+			lookPath: func(name string) (string, error) {
+				candidate := filepath.Join("/home/example/.npm/bin", "codegraph")
+				if name == candidate {
+					return candidate, nil
+				}
+				return "", errors.New("not found")
+			},
+			wantCommand: []string{filepath.Join("/home/example/.npm/bin", "codegraph"), "install", "--yes"},
+		},
+		{
+			name:      "uses pnpm global bin when PATH misses codegraph",
+			manager:   "pnpm",
+			globalBin: "/home/example/.local/share/pnpm",
+			lookPath: func(name string) (string, error) {
+				candidate := filepath.Join("/home/example/.local/share/pnpm", "codegraph")
+				if name == candidate {
+					return candidate, nil
+				}
+				return "", errors.New("not found")
+			},
+			wantCommand: []string{filepath.Join("/home/example/.local/share/pnpm", "codegraph"), "install", "--yes"},
+		},
+		{
+			name:      "reports actionable error when installed binary cannot be resolved",
+			manager:   "npm",
+			globalBin: "/home/example/.npm/bin",
+			lookPath: func(string) (string, error) {
+				return "", errors.New("not found")
+			},
+			wantErr: []string{"CodeGraph CLI was installed with npm", "not in PATH", "/home/example/.npm/bin", "restart your shell"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			previousNpmGlobalBin := codeGraphNpmGlobalBin
+			previousPnpmGlobalBin := codeGraphPnpmGlobalBin
+			codeGraphNpmGlobalBin = func() (string, error) { return tt.globalBin, nil }
+			codeGraphPnpmGlobalBin = func() (string, error) { return tt.globalBin, nil }
+			t.Cleanup(func() {
+				codeGraphNpmGlobalBin = previousNpmGlobalBin
+				codeGraphPnpmGlobalBin = previousPnpmGlobalBin
+			})
+
+			command, err := resolveCodeGraphSetupCommand(tt.manager, DetectorFunc(tt.lookPath))
+			if len(tt.wantErr) > 0 {
+				if err == nil {
+					t.Fatal("resolveCodeGraphSetupCommand() error = nil, want error")
+				}
+				for _, want := range tt.wantErr {
+					if !strings.Contains(err.Error(), want) {
+						t.Fatalf("error = %v, want %q", err, want)
+					}
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("resolveCodeGraphSetupCommand() error = %v", err)
+			}
+			if !reflect.DeepEqual(command, tt.wantCommand) {
+				t.Fatalf("resolveCodeGraphSetupCommand() = %#v, want %#v", command, tt.wantCommand)
+			}
+		})
+	}
+}
+
+func TestCodeGraphExecutableCandidatesForOS(t *testing.T) {
+	globalBin := filepath.Join("C:", "Users", "example", "AppData", "Roaming", "npm")
+
+	tests := []struct {
+		name string
+		goos string
+		want []string
+	}{
+		{
+			name: "windows includes cmd and exe shims",
+			goos: "windows",
+			want: []string{
+				filepath.Join(globalBin, "codegraph"),
+				filepath.Join(globalBin, "codegraph.cmd"),
+				filepath.Join(globalBin, "codegraph.exe"),
+			},
+		},
+		{
+			name: "non windows uses extensionless executable",
+			goos: "linux",
+			want: []string{filepath.Join(globalBin, "codegraph")},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := codeGraphExecutableCandidatesForOS(globalBin, tt.goos)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("codeGraphExecutableCandidatesForOS() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCodeGraphNpmGlobalBinForOS(t *testing.T) {
+	tests := []struct {
+		name   string
+		prefix string
+		goos   string
+		want   string
+	}{
+		{
+			name:   "windows npm prefix is already the global bin directory",
+			prefix: filepath.Join("C:", "Users", "example", "AppData", "Roaming", "npm"),
+			goos:   "windows",
+			want:   filepath.Join("C:", "Users", "example", "AppData", "Roaming", "npm"),
+		},
+		{
+			name:   "non windows npm prefix uses bin child",
+			prefix: filepath.Join("home", "example", ".npm-global"),
+			goos:   "linux",
+			want:   filepath.Join("home", "example", ".npm-global", "bin"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := codeGraphNpmGlobalBinForOS(tt.prefix, tt.goos)
+			if got != tt.want {
+				t.Fatalf("codeGraphNpmGlobalBinForOS() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestInstallUsesResolvedNpmCodeGraphButKeepsMissingStatusWhenNotInPath(t *testing.T) {
+	globalBin := filepath.Join("home", "example", ".npm", "bin")
+	codeGraphPath := filepath.Join(globalBin, "codegraph")
+
+	previousLookPath := codeGraphPackageLookPath
+	previousNpmGlobalBin := codeGraphNpmGlobalBin
+	codeGraphPackageLookPath = func(name string) (string, error) {
+		if name == "npm" {
+			return "/usr/bin/npm", nil
+		}
+		if name == codeGraphPath {
+			return codeGraphPath, nil
+		}
+		return "", errors.New("not found")
+	}
+	codeGraphNpmGlobalBin = func() (string, error) { return globalBin, nil }
+	t.Cleanup(func() {
+		codeGraphPackageLookPath = previousLookPath
+		codeGraphNpmGlobalBin = previousNpmGlobalBin
+	})
+
+	var commands []string
+	result, err := InstallWithHome(model.CommunityToolCodeGraph, "/work/project", t.TempDir(), RunnerFunc(func(name string, args ...string) error {
+		commands = append(commands, strings.Join(append([]string{name}, args...), " "))
+		return nil
+	}), DetectorFunc(func(string) (string, error) {
+		return "", errors.New("not found")
+	}))
+	if err != nil {
+		t.Fatalf("InstallWithHome() error = %v", err)
+	}
+	wantCommands := []string{
+		"npm install -g @colbymchenry/codegraph@latest",
+		strings.Join([]string{codeGraphPath, "install", "--yes"}, " "),
+	}
+	if !reflect.DeepEqual(commands, wantCommands) {
+		t.Fatalf("commands = %#v, want %#v", commands, wantCommands)
+	}
+	if result.StatusAfter == nil || result.StatusAfter.CLI != AvailabilityMissing || result.StatusAfter.CLIPath != "" {
+		t.Fatalf("StatusAfter = %#v, want missing CodeGraph CLI from DetectStatus", result.StatusAfter)
+	}
+	followUps := strings.Join(result.StatusAfter.FollowUps, "\n")
+	for _, want := range []string{codeGraphPath, "not available in PATH", "restart your shell"} {
+		if !strings.Contains(followUps, want) {
+			t.Fatalf("StatusAfter.FollowUps = %#v, want %q", result.StatusAfter.FollowUps, want)
+		}
+	}
+	manualActions := strings.Join(result.ManualActions, "\n")
+	for _, want := range []string{codeGraphPath, "not available in PATH", "global binary directory to PATH"} {
+		if !strings.Contains(manualActions, want) {
+			t.Fatalf("ManualActions = %#v, want %q", result.ManualActions, want)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- resolves the installed CodeGraph executable from npm/pnpm global bin when `codegraph` is not yet in PATH
- runs `codegraph install --yes` through the resolved executable path while keeping PATH status honest
- surfaces follow-up/manual guidance when setup succeeds but direct `codegraph` usage still requires PATH refresh

## Context
Closes #1003.

This is intentionally narrower than #1059, which focuses on version-aware upgrade/reconcile behavior. This PR only fixes the post-install executable resolution path for environments where npm/pnpm global bin is not available to the non-interactive Gentle AI process.

## Tests
- `go test ./internal/components/communitytool`
- `go test ./internal/cli -run CommunityTool`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced CodeGraph installer to auto-detect whether `npm` or `pnpm` is available, install globally accordingly, and then resolve the `codegraph` CLI by checking `PATH` and common global-bin locations (OS-aware).

* **Bug Fixes**
  * Improved handling when CodeGraph is present but the CLI isn’t yet on `PATH`, including clearer follow-up/manual guidance.
  * Improved install status validation for detected agents configuration.
  * Better error reporting now surfaces the exact command that failed.

* **Tests**
  * Expanded coverage for setup-command resolution, global-bin detection, OS-specific candidate paths, and end-to-end install behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->