### PR TITLE
feat(filemerge): add generic managed-block section scanner

### DIFF
--- a/internal/components/filemerge/section_scan.go
+++ b/internal/components/filemerge/section_scan.go
@@ -1,0 +1,110 @@
+package filemerge
+
+import "strings"
+
+// Section is one matched gentle-ai marker pair.
+type Section struct {
+	ID        string // marker id, e.g. "persona" (never a whitelist — whatever the file contains)
+	Content   string // raw text between open and close markers, markers excluded
+	StartLine int    // 1-based line number of the opening marker
+	EndLine   int    // 1-based line number of the closing marker
+	CharCount int    // len(Content) in bytes
+	LineCount int    // number of content lines (0 when Content == "")
+}
+
+// AnomalyKind classifies a structural marker defect.
+type AnomalyKind string
+
+const (
+	AnomalyOrphanOpen  AnomalyKind = "orphan-open"  // opener with no matching closer (unbounded block)
+	AnomalyOrphanClose AnomalyKind = "orphan-close" // closer with no preceding opener
+	AnomalyMismatch    AnomalyKind = "mismatch"     // closer id != currently-open id
+)
+
+// Anomaly is a structural marker defect surfaced by ScanSections.
+type Anomaly struct {
+	Kind AnomalyKind
+	ID   string // id on the offending marker
+	Line int    // 1-based line of the offending marker
+}
+
+// ScanResult is the full outcome of one pass over a markdown file.
+type ScanResult struct {
+	Sections  []Section
+	Anomalies []Anomaly
+}
+
+// ScanSections finds every <!-- gentle-ai:ID --> ... <!-- /gentle-ai:ID --> pair
+// in content, generically (no id whitelist), plus any structural anomalies.
+func ScanSections(content string) ScanResult {
+	var result ScanResult
+
+	var (
+		openActive   bool
+		openID       string
+		openLine     int
+		contentLines []string
+	)
+
+	lines := strings.Split(content, "\n")
+	for i, raw := range lines {
+		lineNum := i + 1
+		line := strings.TrimSuffix(raw, "\r")
+		trimmed := strings.TrimSpace(line)
+
+		switch {
+		case strings.HasPrefix(trimmed, closePrefix) && strings.HasSuffix(trimmed, markerSuffix):
+			id := strings.TrimSuffix(strings.TrimPrefix(trimmed, closePrefix), markerSuffix)
+			switch {
+			case !openActive:
+				// No opener is active: this closer has nothing to pair with.
+				result.Anomalies = append(result.Anomalies, Anomaly{Kind: AnomalyOrphanClose, ID: id, Line: lineNum})
+			case id != openID:
+				// Closer id doesn't match the active opener: report only the
+				// mismatch (not a second AnomalyOrphanOpen for the discarded
+				// opener) and drop the open context so scanning resumes clean
+				// from the next marker — a single anomaly per malformed event.
+				result.Anomalies = append(result.Anomalies, Anomaly{Kind: AnomalyMismatch, ID: id, Line: lineNum})
+				openActive = false
+				contentLines = nil
+			default:
+				sectionContent := strings.Join(contentLines, "\n")
+				lineCount := 0
+				if sectionContent != "" {
+					lineCount = strings.Count(sectionContent, "\n") + 1
+				}
+				result.Sections = append(result.Sections, Section{
+					ID:        openID,
+					Content:   sectionContent,
+					StartLine: openLine,
+					EndLine:   lineNum,
+					CharCount: len(sectionContent),
+					LineCount: lineCount,
+				})
+				openActive = false
+				contentLines = nil
+			}
+
+		case strings.HasPrefix(trimmed, markerPrefix) && strings.HasSuffix(trimmed, markerSuffix):
+			id := strings.TrimSuffix(strings.TrimPrefix(trimmed, markerPrefix), markerSuffix)
+			if openActive {
+				result.Anomalies = append(result.Anomalies, Anomaly{Kind: AnomalyOrphanOpen, ID: openID, Line: openLine})
+			}
+			openActive = true
+			openID = id
+			openLine = lineNum
+			contentLines = nil
+
+		default:
+			if openActive {
+				contentLines = append(contentLines, line)
+			}
+		}
+	}
+
+	if openActive {
+		result.Anomalies = append(result.Anomalies, Anomaly{Kind: AnomalyOrphanOpen, ID: openID, Line: openLine})
+	}
+
+	return result
+}

--- a/internal/components/filemerge/section_scan_test.go
+++ b/internal/components/filemerge/section_scan_test.go
@@ -1,0 +1,113 @@
+package filemerge
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestScanSections(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         string
+		wantSections  []Section
+		wantAnomalies []Anomaly
+	}{
+		{
+			name:  "single well-formed block",
+			input: "before\n<!-- gentle-ai:persona -->\nHello\nWorld\n<!-- /gentle-ai:persona -->\nafter\n",
+			wantSections: []Section{
+				{ID: "persona", Content: "Hello\nWorld", StartLine: 2, EndLine: 5, CharCount: 11, LineCount: 2},
+			},
+		},
+		{
+			name: "multiple distinct blocks in one file",
+			input: "<!-- gentle-ai:persona -->\nP body\n<!-- /gentle-ai:persona -->\n\n" +
+				"<!-- gentle-ai:engram-protocol -->\nE body\n<!-- /gentle-ai:engram-protocol -->\n\n" +
+				"<!-- gentle-ai:strict-tdd-mode -->\nT body\n<!-- /gentle-ai:strict-tdd-mode -->\n",
+			wantSections: []Section{
+				{ID: "persona", Content: "P body", StartLine: 1, EndLine: 3, CharCount: 6, LineCount: 1},
+				{ID: "engram-protocol", Content: "E body", StartLine: 5, EndLine: 7, CharCount: 6, LineCount: 1},
+				{ID: "strict-tdd-mode", Content: "T body", StartLine: 9, EndLine: 11, CharCount: 6, LineCount: 1},
+			},
+		},
+		{
+			name:  "empty-content block",
+			input: "<!-- gentle-ai:empty -->\n<!-- /gentle-ai:empty -->\n",
+			wantSections: []Section{
+				{ID: "empty", Content: "", StartLine: 1, EndLine: 2, CharCount: 0, LineCount: 0},
+			},
+		},
+		{
+			name:  "unclosed opener at EOF",
+			input: "<!-- gentle-ai:orphan -->\nsome content\n",
+			wantAnomalies: []Anomaly{
+				{Kind: AnomalyOrphanOpen, ID: "orphan", Line: 1},
+			},
+		},
+		{
+			name:  "stray closer with no opener",
+			input: "before\n<!-- /gentle-ai:stray -->\nafter\n",
+			wantAnomalies: []Anomaly{
+				{Kind: AnomalyOrphanClose, ID: "stray", Line: 2},
+			},
+		},
+		{
+			name:  "closer id mismatch with opener id",
+			input: "<!-- gentle-ai:a -->\ncontent\n<!-- /gentle-ai:b -->\nafter\n",
+			wantAnomalies: []Anomaly{
+				{Kind: AnomalyMismatch, ID: "b", Line: 3},
+			},
+		},
+		{
+			name: "mismatch discards stale opener then resumes cleanly on next block",
+			input: "<!-- gentle-ai:a -->\nstale\n<!-- /gentle-ai:b -->\n" +
+				"<!-- gentle-ai:c -->\nclean\n<!-- /gentle-ai:c -->\n",
+			wantSections: []Section{
+				{ID: "c", Content: "clean", StartLine: 4, EndLine: 6, CharCount: 5, LineCount: 1},
+			},
+			wantAnomalies: []Anomaly{
+				{Kind: AnomalyMismatch, ID: "b", Line: 3},
+			},
+		},
+		{
+			name:  "unknown novel id measured like any other",
+			input: "<!-- gentle-ai:brand-new-block -->\nnovel content\n<!-- /gentle-ai:brand-new-block -->\n",
+			wantSections: []Section{
+				{ID: "brand-new-block", Content: "novel content", StartLine: 1, EndLine: 3, CharCount: 13, LineCount: 1},
+			},
+		},
+		{
+			name:  "markers with leading indentation and trailing CR",
+			input: "  <!-- gentle-ai:indented -->\r\ncontent line\r\n  <!-- /gentle-ai:indented -->\r\n",
+			wantSections: []Section{
+				{ID: "indented", Content: "content line", StartLine: 1, EndLine: 3, CharCount: 12, LineCount: 1},
+			},
+		},
+		{
+			name:  "file with zero markers",
+			input: "just some text\nno markers at all\n",
+		},
+		{
+			name:  "consecutive opener while a block is already active",
+			input: "<!-- gentle-ai:a -->\n<!-- gentle-ai:b -->\ninner content\n<!-- /gentle-ai:b -->\n",
+			wantSections: []Section{
+				{ID: "b", Content: "inner content", StartLine: 2, EndLine: 4, CharCount: 13, LineCount: 1},
+			},
+			wantAnomalies: []Anomaly{
+				{Kind: AnomalyOrphanOpen, ID: "a", Line: 1},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ScanSections(tt.input)
+			if !reflect.DeepEqual(got.Sections, tt.wantSections) {
+				t.Fatalf("Sections mismatch:\ngot:  %+v\nwant: %+v", got.Sections, tt.wantSections)
+			}
+			if !reflect.DeepEqual(got.Anomalies, tt.wantAnomalies) {
+				t.Fatalf("Anomalies mismatch:\ngot:  %+v\nwant: %+v", got.Anomalies, tt.wantAnomalies)
+			}
+		})
+	}
+}

--- a/openspec/changes/doctor-footprint/apply-progress.md
+++ b/openspec/changes/doctor-footprint/apply-progress.md
@@ -1,0 +1,35 @@
+# Apply Progress: doctor-footprint
+
+## Status
+
+- **WU1 (Phase 1 — Generic Section Scanner)**: DONE. This is PR 1 of the stacked chain.
+- **WU2+WU3 (Phase 2 — Token helper + collector/classifier)**: NOT STARTED. Next batch, on a new branch off `feat/doctor-footprint-scanner`.
+- **WU4 (Phase 3 — flag + `RunDoctor` signature migration)**: NOT STARTED.
+- **WU5 (Phase 4 — `renderFootprintDetail`)**: NOT STARTED.
+- **WU6 (Phase 5 — integration test + full verification)**: NOT STARTED.
+
+## What was implemented (WU1, this batch)
+
+- `internal/components/filemerge/section_scan.go` — `Section`, `AnomalyKind`, `Anomaly`, `ScanResult` types and `ScanSections(content string) ScanResult`, per design.md §2's exact 4-step line-based single-pass algorithm. Reuses existing `markerPrefix`/`markerSuffix`/`closePrefix` constants from `section.go` (no redefinition).
+- `internal/components/filemerge/section_scan_test.go` — `TestScanSections`, table-driven, 9 cases matching design.md §8.1 and tasks.md 1.1 exactly: single well-formed block, multi-block, empty-content block, unclosed opener at EOF (`AnomalyOrphanOpen`), stray closer with no opener (`AnomalyOrphanClose`), id mismatch (`AnomalyMismatch`), novel/unknown id (genericity proof, no whitelist), leading indentation + trailing `\r`, zero markers.
+
+## Scope discipline
+
+Touched ONLY `internal/components/filemerge/`. Did NOT touch `internal/cli/doctor.go`, `internal/app/app.go`, or anything else — those are WU2/WU3 (PR2) and WU4/WU5/WU6 (PR3), reserved for future branches per the stacked-PRs delivery strategy.
+
+## Verification run
+
+- `go test ./internal/components/filemerge/... -v` — all tests pass, including pre-existing suite (safety net, no regressions).
+- `go vet ./internal/components/filemerge/...` — clean.
+- `gofmt -l internal/components/filemerge/section_scan.go internal/components/filemerge/section_scan_test.go` — clean (not in the repo-wide `gofmt -l .` unformatted list).
+- `go test ./...` (full repo) — `internal/components/filemerge` passes (cached ok). Failures present in `internal/components/engram`, `internal/components/gga`, `internal/components/permissions`, `internal/components/sdd`, `internal/components/uninstall`, `internal/tui`, `internal/update/upgrade` are PRE-EXISTING and environment-specific (Windows symlink privilege errors, `TempDir` cleanup lock contention, network/install-script mocking) — none touch any file this PR modified, and this PR adds only new, unreferenced exported symbols (nothing outside `filemerge` imports them yet). Not introduced by WU1.
+
+## Next steps (WU2 — new branch off this one)
+
+Per design.md §3-4 and tasks.md Phase 2:
+1. `estimateTokens(chars int) int` in `internal/cli/doctor.go`.
+2. New seam `var newDoctorRegistry = agents.NewDefaultRegistry`.
+3. `AgentFootprint` / `FootprintSummary` structs.
+4. `collectFootprint(homeDir string) FootprintSummary` — consumes `filemerge.ScanSections` from this PR.
+5. `footprintCheckResult(sum FootprintSummary) CheckResult`.
+6. RED tests first: `TestCollectFootprint` / `TestFootprintCheckResult`, 7 cases per design.md §8.2.


### PR DESCRIPTION
<!-- ⚠️ READ BEFORE SUBMITTING
  Every PR must be linked to an issue that has the "status:approved" label.
  PRs without a linked approved issue will be automatically rejected by CI.
  See CONTRIBUTING.md for the full contribution workflow.
-->

## 🔗 Linked Issue

Closes #1018


---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [ ] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [x] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

Parses every `<!-- gentle-ai:X --> ... <!-- /gentle-ai:X -->` marker pair in a file generically (no hardcoded ID whitelist), plus structural anomalies (orphan-open, orphan-close, id mismatch). First of 3 stacked work units toward the managed block footprint diagnostic for `gentle-ai doctor` (issue #1018) — this PR adds the scanner only, no doctor-facing behavior yet.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/components/filemerge/section_scan.go` | New `ScanSections` — generic single-pass marker scanner, no ID whitelist, detects orphan-open/orphan-close/mismatch anomalies |
| `internal/components/filemerge/section_scan_test.go` | New `TestScanSections`, table-driven, 9 cases |

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./internal/components/filemerge/...
```

**E2E Tests** (Docker required)
```bash
cd e2e && ./docker-test.sh
```

- [x] Unit tests pass (`go test ./internal/components/filemerge/...` — 9/9 new cases green, full pre-existing package suite unaffected)
- [ ] E2E tests pass — not run (no doctor-facing behavior changed in this PR; will run ahead of PR 3, which is where live `doctor` behavior actually changes)
- [x] `go vet ./internal/components/filemerge/...` and `gofmt -l` clean

---

## 🤖 Automated Checks

The following checks run automatically on this PR:

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | PR should stay within 400 changed lines (`additions + deletions`) or use `size:exception` |
| Check Issue Reference | ⏳ | PR body must contain `Closes/Fixes/Resolves #N` |
| Check Issue Has `status:approved` | ⏳ | Linked issue must have been approved before work began |
| Check PR Has `type:*` Label | ⏳ | Exactly one `type:*` label must be applied |
| Unit Tests | ⏳ | `go test ./...` must pass |
| E2E Tests | ⏳ | `cd e2e && ./docker-test.sh` must pass |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented (248 lines)
- [ ] I have added the appropriate `type:*` label to this PR <!-- maintainer applies labels per CONTRIBUTING.md -->
- [x] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) <!-- not run, see Test Plan note -->
- [x] I have updated documentation if necessary (planning artifacts in `openspec/changes/doctor-footprint/`)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

This is **1 of 3 stacked PRs** toward issue #1018 (scanner → collector/check → flag/wiring). `Closes #1018` is set here because the repo's `check-issue-reference` CI requires it on every PR in the chain — merging this PR alone will auto-close #1018 even though 2 more PRs are still coming. Flagging this now so it isn't confusing later; happy to handle it differently if you have a preferred convention for chained-PR issue linking.

No doctor-facing behavior changes in this PR — `ScanSections` is implemented and fully unit-tested but not yet called from anywhere in `internal/cli`. That wiring lands in PR 3.

