### PR TITLE
docs(engram): document optional Engram cloud sync setup (platform-agnostic)

### DIFF
--- a/docs/engram.md
+++ b/docs/engram.md
@@ -72,8 +72,8 @@ Cloud sync runs **in-process** inside the `engram` binary -- any subcommand that
 | Variable | Purpose |
 |----------|---------|
 | `ENGRAM_CLOUD_AUTOSYNC="1"` | Turns on the background sync loop (must be exactly the string `1` -- not `true`, not `yes`, not `1` as integer) |
-| `ENGRAM_CLOUD_TOKEN` | Authenticates the agent against your cloud server (env var only; never persisted to disk by engram) |
-| `ENGRAM_CLOUD_SERVER` | URL of the cloud server you self-host (env var, or persisted to `~/.engram/cloud.json` via `engram cloud config --server <url>`) |
+| `ENGRAM_CLOUD_TOKEN` | Bearer token. Source of truth is `~/.engram/cloud.json` (loaded first); this env var overrides the file when set. Used directly when neither is present only as a fallback. |
+| `ENGRAM_CLOUD_SERVER` | URL of the cloud server you self-host. Persist with `engram cloud config --server <url>` (writes `~/.engram/cloud.json`); this env var overrides the file when set. |
 
 All three must be present **before the engram processes start**. Setting them after engram is already running has no effect on the current processes; restart is required.
 
@@ -107,14 +107,15 @@ launchctl setenv ENGRAM_CLOUD_SERVER https://your-server
 systemctl --user import-environment ENGRAM_CLOUD_AUTOSYNC ENGRAM_CLOUD_TOKEN ENGRAM_CLOUD_SERVER
 ```
 
-### Windows (Task Scheduler)
+### Running as a service (systemd, launchd, Task Scheduler)
 
-Windows Task Scheduler is the native service equivalent on Windows. It restarts `engram serve` on login and after reboots, keeping autosync alive. The full step-by-step is in the upstream engram docs:
+The upstream engram docs publish ready-to-copy templates for the three supported service supervisors. If you want `engram serve` to survive reboots and `brew upgrade`, follow the upstream setup for your platform -- the templates set the cloud env vars in the service definition so autosync stays alive across restarts:
 
-- [Engram docs -- Cloud Autosync](https://github.com/Gentleman-Programming/engram/blob/main/DOCS.md#cloud-autosync)
-- [Engram docs -- Windows Task Scheduler setup](https://github.com/Gentleman-Programming/engram/blob/main/DOCS.md#using-windows-task-scheduler)
+- [systemd (Linux user service)](https://github.com/Gentleman-Programming/engram/blob/main/DOCS.md#using-systemd-linux)
+- [launchd (macOS LaunchAgent plist)](https://github.com/Gentleman-Programming/engram/blob/main/DOCS.md#using-launchd-macos)
+- [Windows Task Scheduler](https://github.com/Gentleman-Programming/engram/blob/main/DOCS.md#using-windows-task-scheduler)
 
-Key constraint: Task Scheduler does **not** inherit session environment variables. `ENGRAM_CLOUD_TOKEN`, `ENGRAM_CLOUD_SERVER`, and `ENGRAM_CLOUD_AUTOSYNC` must be set as persistent user or system environment variables (Control Panel -> System -> Advanced -> Environment Variables), not via `$env:` in a PowerShell session or `export` in a shell profile.
+On Windows, Task Scheduler does **not** inherit session environment variables. `ENGRAM_CLOUD_TOKEN`, `ENGRAM_CLOUD_SERVER`, and `ENGRAM_CLOUD_AUTOSYNC` must be set as persistent user or system environment variables (Control Panel -> System -> Advanced -> Environment Variables), not via `$env:` in a PowerShell session or `export` in a shell profile. The token can also be stored in `~/.engram/cloud.json` so the scheduled task picks it up without needing session env vars at all.
 
 ### Verify it's working
 
@@ -122,14 +123,24 @@ Key constraint: Task Scheduler does **not** inherit session environment variable
 engram cloud status
 ```
 
-`engram cloud status` reports `Cloud status: configured (target=cloud)` when the three variables are set, the server is reachable, and a token is available. If anything is missing or the server is unreachable, it warns without blocking local-only operation.
+`engram cloud status` is a multi-line report. When everything is set you see:
+
+```
+Cloud status: configured (target=cloud)
+Server: https://your-server
+Auth status: ready (token provided via runtime cloud config)
+Sync readiness: ready for explicit --project sync (project must be enrolled)
+Local daemon: running on port 7437
+```
+
+The `Sync readiness: ready` line confirms the three variables are set, the server URL is reachable, and a token is available. If anything is missing or the server is unreachable, the command warns without blocking local-only operation.
 
 ### Security
 
 - **Never commit the token** -- keep it in your shell rc file, a user-level env store, or a secrets manager. Not in `.env` files that get committed, not in version-controlled config, not in plist or unit files checked into git.
-- **Token is per-agent** -- generate a separate token per machine or per service. Rotate by exporting a new value and restarting the engram processes.
+- **Token is per-agent** -- generate a separate token per machine or per service. Rotate by exporting a new value and restarting the engram processes, or by replacing the token inside `~/.engram/cloud.json`.
 - **Server URL is yours** -- `ENGRAM_CLOUD_SERVER` points at a server you control. The official binary does not phone home to any default endpoint; without the three variables set, no network traffic leaves your machine.
-- **`cloud.json` stores only the server URL, never the token** -- the token is intentionally env-var-only (see [Engram docs -- Cloud Troubleshooting](https://github.com/Gentleman-Programming/engram/blob/main/docs/engram-cloud/troubleshooting.md)).
+- **`cloud.json` stores the server URL and can store the token** -- the token field in `~/.engram/cloud.json` is read first by `resolveCloudRuntimeConfig`, with `ENGRAM_CLOUD_TOKEN` overriding it when set. This is what makes Windows Task Scheduler work (the env var is often absent there -- see issues #343 and #421 upstream).
 
 ### What this does and does not replace
 
@@ -138,7 +149,6 @@ engram cloud status
 - **Does not replace** local storage. If the cloud server is unreachable, engram keeps working locally and syncs when connectivity returns.
 - **Does not include** scripts, install-time hooks, or `brew tap` automation. Those belong in engram's own `scripts/` directory if maintainers ever want them -- for now, the env vars and `engram cloud config` are the entire activation surface.
 
----
 ---
 
 ## MCP Tools Reference

--- a/docs/engram.md
+++ b/docs/engram.md
@@ -61,6 +61,84 @@ engram sync --import
 
 Add `.engram/` to your repo and commit it. When a teammate clones and runs `engram sync --import`, they get the full project context. This is especially useful for onboarding -- new contributors start with the accumulated knowledge of the team.
 
+## Cloud Sync (Optional)
+
+Sync your engram memories across machines through a self-hosted cloud server, so the same observations are available wherever your agent runs.
+
+Cloud sync runs **in-process** inside the `engram` binary -- any subcommand that holds the store open (e.g. `serve`, `mcp`, `protocol-mode`). It activates when three environment variables are set before engram starts. Without them, engram behaves exactly as it does today: local-only, with git-based team sharing via `engram sync`.
+
+### Required environment variables
+
+| Variable | Purpose |
+|----------|---------|
+| `ENGRAM_CLOUD_AUTOSYNC="1"` | Turns on the background sync loop (must be exactly the string `1` -- not `true`, not `yes`, not `1` as integer) |
+| `ENGRAM_CLOUD_TOKEN` | Authenticates the agent against your cloud server (env var only; never persisted to disk by engram) |
+| `ENGRAM_CLOUD_SERVER` | URL of the cloud server you self-host (env var, or persisted to `~/.engram/cloud.json` via `engram cloud config --server <url>`) |
+
+All three must be present **before the engram processes start**. Setting them after engram is already running has no effect on the current processes; restart is required.
+
+### Setup (any platform)
+
+```bash
+# 1. Persist the server URL to cloud.json (skippable if you prefer env-only)
+engram cloud config --server https://your-server
+
+# 2. Export the two runtime variables
+export ENGRAM_CLOUD_AUTOSYNC="1"
+export ENGRAM_CLOUD_TOKEN=***
+
+# 3. Restart engram so the new environment is picked up
+pkill -f "engram mcp"
+pkill -f "engram serve"
+
+# 4. Verify
+engram cloud status
+```
+
+For shell rc files (~/.zshrc, ~/.bashrc), the variables load on every new shell but not in already-running services. For long-running services that don't inherit your shell environment:
+
+```bash
+# macOS (launchd user services)
+launchctl setenv ENGRAM_CLOUD_AUTOSYNC "1"
+launchctl setenv ENGRAM_CLOUD_TOKEN YOUR_TOKEN_HERE
+launchctl setenv ENGRAM_CLOUD_SERVER https://your-server
+
+# Linux (systemd user services)
+systemctl --user import-environment ENGRAM_CLOUD_AUTOSYNC ENGRAM_CLOUD_TOKEN ENGRAM_CLOUD_SERVER
+```
+
+### Windows (Task Scheduler)
+
+Windows Task Scheduler is the native service equivalent on Windows. It restarts `engram serve` on login and after reboots, keeping autosync alive. The full step-by-step is in the upstream engram docs:
+
+- [Engram docs -- Cloud Autosync](https://github.com/Gentleman-Programming/engram/blob/main/DOCS.md#cloud-autosync)
+- [Engram docs -- Windows Task Scheduler setup](https://github.com/Gentleman-Programming/engram/blob/main/DOCS.md#using-windows-task-scheduler)
+
+Key constraint: Task Scheduler does **not** inherit session environment variables. `ENGRAM_CLOUD_TOKEN`, `ENGRAM_CLOUD_SERVER`, and `ENGRAM_CLOUD_AUTOSYNC` must be set as persistent user or system environment variables (Control Panel -> System -> Advanced -> Environment Variables), not via `$env:` in a PowerShell session or `export` in a shell profile.
+
+### Verify it's working
+
+```bash
+engram cloud status
+```
+
+`engram cloud status` reports `Cloud status: configured (target=cloud)` when the three variables are set, the server is reachable, and a token is available. If anything is missing or the server is unreachable, it warns without blocking local-only operation.
+
+### Security
+
+- **Never commit the token** -- keep it in your shell rc file, a user-level env store, or a secrets manager. Not in `.env` files that get committed, not in version-controlled config, not in plist or unit files checked into git.
+- **Token is per-agent** -- generate a separate token per machine or per service. Rotate by exporting a new value and restarting the engram processes.
+- **Server URL is yours** -- `ENGRAM_CLOUD_SERVER` points at a server you control. The official binary does not phone home to any default endpoint; without the three variables set, no network traffic leaves your machine.
+- **`cloud.json` stores only the server URL, never the token** -- the token is intentionally env-var-only (see [Engram docs -- Cloud Troubleshooting](https://github.com/Gentleman-Programming/engram/blob/main/docs/engram-cloud/troubleshooting.md)).
+
+### What this does and does not replace
+
+- **Adds** background sync of observations across machines pointing at the same cloud server.
+- **Composes with** git-based team sharing (`engram sync` to `.engram/` then commit) -- they solve different problems. Cloud sync keeps your personal machine states aligned; git sharing keeps team knowledge versioned and reviewable.
+- **Does not replace** local storage. If the cloud server is unreachable, engram keeps working locally and syncs when connectivity returns.
+- **Does not include** scripts, install-time hooks, or `brew tap` automation. Those belong in engram's own `scripts/` directory if maintainers ever want them -- for now, the env vars and `engram cloud config` are the entire activation surface.
+
+---
 ---
 
 ## MCP Tools Reference


### PR DESCRIPTION
Adds a **Cloud Sync (Optional)** section to `docs/engram.md` covering the in-process autosync loop shipped in engram v1.18.0+.

| What | How |
|------|-----|
| Activates via 3 env vars | `ENGRAM_CLOUD_AUTOSYNC="1"`, `ENGRAM_CLOUD_TOKEN`, `ENGRAM_CLOUD_SERVER` |
| Server URL persistence | `engram cloud config --server <url>` writes to `~/.engram/cloud.json` |
| Token resolution | cloud.json loaded first; env var overrides (issues #343, #421) |
| Lifecycle templates | systemd, launchd, Windows Task Scheduler -- links to upstream DOCS.md |

## Why this PR

`gentle-ai doctor` advertises **Engram reachability** as a check, but `docs/engram.md` only documented local storage + git-based team sharing (`engram sync`). Cloud sync is an opt-in capability of the engram binary that ships with gentle-ai, but the docs never pointed users at it. This closes the discovery gap.

## What this PR does NOT cover (deferred to upstream engram)

- `scripts/setup-cloud-sync.sh` style automation
- `brew tap` / installer hooks
- GUI toggles

Those belong in engram's own repo (`scripts/`, installer plumbing), not in gentle-ai's user docs. The doc explicitly points users at the upstream engram docs for those paths.

## v1.20.0 re-check

A second commit on this branch (`232bd5a`) realigned three claims that diverged from engram v1.20.0 source:

1. Token persistence -- cloud.json IS the source of truth, env var overrides (verified at `cmd/engram/main.go::resolveCloudRuntimeConfig`).
2. `engram cloud status` output -- real output is multi-line (verified at `cmd/engram/cloud.go:679-700`).
3. Service supervisor templates -- upstream publishes ready-to-copy systemd, launchd, and Windows Task Scheduler templates in `DOCS.md:1227-1343`; the previous "lifecycle deferred" framing was stale.

## Verification

- [x] Diff is append-only on the original PR (`+78/-0`)
- [x] Re-check commit (`232bd5a`) is a focused rewrite of in-scope claims, no scope creep (`+21/-11`)
- [x] All env var names match `cmd/engram/main.go::tryStartAutosync`
- [x] `ENGRAM_CLOUD_AUTOSYNC="1"` exact-string requirement matches REQ-210 in upstream
- [x] Token resolution claim matches `cmd/engram/main.go::resolveCloudRuntimeConfig` (issues #343, #421)
- [x] `engram cloud status` output matches `cmd/engram/cloud.go:679-700`
- [x] Service template links point at the actual upstream sections in `DOCS.md#using-systemd-linux`, `DOCS.md#using-launchd-macos`, `DOCS.md#using-windows-task-scheduler`
- [x] No secrets, tokens, or real URLs introduced

## Closes

Closes #1021

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an optional cloud sync guide for syncing memories across machines with a self-hosted server.
  * Documented environment-based activation, cloud configuration, platform-specific setup, and token/server setting precedence.
  * Added instructions for verifying sync readiness and applying configuration changes after restart, including Windows requirements.
  * Clarified security requirements, offline fallback behavior, and how cloud sync works alongside local and Git-based storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->