### PR TITLE
feat(cli): add managed block footprint collector and check

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -12,6 +12,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gentleman-programming/gentle-ai/internal/agents"
+	"github.com/gentleman-programming/gentle-ai/internal/components/filemerge"
+	"github.com/gentleman-programming/gentle-ai/internal/model"
 	"github.com/gentleman-programming/gentle-ai/internal/state"
 	"github.com/gentleman-programming/gentle-ai/internal/storage"
 )
@@ -64,6 +67,7 @@ var (
 		_ = resp.Body.Close()
 		return resp.StatusCode, nil
 	}
+	newDoctorRegistry = agents.NewDefaultRegistry
 )
 
 // RunDoctor runs all ecosystem health checks and renders a report to w.
@@ -363,6 +367,201 @@ func checkDiskSpace(homeDir string) CheckResult {
 			Detail: fmt.Sprintf("%d MB free on %s filesystem", freeMB, dir),
 		}
 	}
+}
+
+// estimateTokens returns a rough token count using the ~4-chars/token
+// heuristic. Intentionally coarse: doctor labels every token figure a "rough
+// estimate" and no model-specific tokenizer is a dependency (out of scope).
+func estimateTokens(chars int) int {
+	return chars / 4
+}
+
+// AgentFootprint is one agent's measured managed-block footprint.
+type AgentFootprint struct {
+	AgentID    string
+	Path       string // "" when the agent id had no adapter
+	Unresolved bool   // state listed an id with no registered adapter
+	Present    bool   // instruction file existed and was read
+	Sections   []filemerge.Section
+	Anomalies  []filemerge.Anomaly
+	CharCount  int // sum of section CharCounts
+	LineCount  int // sum of section LineCounts
+	TokenEst   int // estimateTokens(CharCount)
+}
+
+// FootprintSummary aggregates managed-block footprint measurements across all
+// agents listed in the persisted install state.
+type FootprintSummary struct {
+	Agents        []AgentFootprint
+	TotalBlocks   int
+	AgentsCovered int // agents with >=1 measured block
+	TotalChars    int
+	TotalTokenEst int
+	HasFail       bool // any AnomalyOrphanOpen or AnomalyMismatch anywhere
+	HasWarn       bool // any AnomalyOrphanClose anywhere
+	StateMissing  bool // state.json absent (first-time install)
+	NoAgents      bool // state present and readable, but InstalledAgents is genuinely empty
+	// StateUnreadable is true when state.Read failed for a reason OTHER than
+	// "file does not exist" — i.e. a malformed/corrupt state.json. This is
+	// deliberately distinct from NoAgents: telling a user with a corrupt
+	// state file to "run install" (the NoAgents remedy) contradicts the
+	// state:json check, which correctly diagnoses the same file as needing
+	// repair.
+	StateUnreadable bool
+	// RegistryUnavailable is true when newDoctorRegistry() itself failed.
+	// This is a defensive, not user-actionable, path — it does not mean
+	// "no agents installed" and must not carry that remedy.
+	RegistryUnavailable bool
+}
+
+// collectFootprint reads the install state and every installed agent's
+// instruction file, scanning each for managed marker blocks.
+func collectFootprint(homeDir string) FootprintSummary {
+	var sum FootprintSummary
+
+	reg, err := newDoctorRegistry()
+	if err != nil {
+		sum.RegistryUnavailable = true
+		return sum
+	}
+
+	s, err := state.Read(homeDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			sum.StateMissing = true
+		} else {
+			sum.StateUnreadable = true
+		}
+		return sum
+	}
+
+	if len(s.InstalledAgents) == 0 {
+		sum.NoAgents = true
+		return sum
+	}
+
+	for _, id := range s.InstalledAgents {
+		sum.Agents = append(sum.Agents, collectAgentFootprint(reg, homeDir, id))
+	}
+
+	for _, af := range sum.Agents {
+		sum.TotalBlocks += len(af.Sections)
+		sum.TotalChars += af.CharCount
+		sum.TotalTokenEst += af.TokenEst
+		if len(af.Sections) > 0 {
+			sum.AgentsCovered++
+		}
+		for _, an := range af.Anomalies {
+			switch an.Kind {
+			case filemerge.AnomalyOrphanOpen, filemerge.AnomalyMismatch:
+				sum.HasFail = true
+			case filemerge.AnomalyOrphanClose:
+				sum.HasWarn = true
+			}
+		}
+	}
+
+	return sum
+}
+
+// collectAgentFootprint resolves and scans a single agent's instruction file.
+func collectAgentFootprint(reg *agents.Registry, homeDir, agentID string) AgentFootprint {
+	af := AgentFootprint{AgentID: agentID}
+
+	adapter, ok := reg.Get(model.AgentID(agentID))
+	if !ok {
+		af.Unresolved = true
+		return af
+	}
+
+	af.Path = adapter.SystemPromptFile(homeDir)
+	data, err := os.ReadFile(af.Path)
+	if err != nil {
+		return af
+	}
+	af.Present = true
+
+	res := filemerge.ScanSections(string(data))
+	af.Sections = res.Sections
+	af.Anomalies = res.Anomalies
+	for _, sec := range res.Sections {
+		af.CharCount += sec.CharCount
+		af.LineCount += sec.LineCount
+	}
+	af.TokenEst = estimateTokens(af.CharCount)
+
+	return af
+}
+
+// footprintCheckResult classifies a FootprintSummary into the always-on
+// "managed:footprint" CheckResult.
+func footprintCheckResult(sum FootprintSummary) CheckResult {
+	const name = "managed:footprint"
+
+	switch {
+	case sum.StateMissing:
+		return CheckResult{
+			Name:   name,
+			Status: CheckStatusWarn,
+			Detail: "state file not found — managed block footprint unavailable (expected for first-time install)",
+			Remedy: "Run 'gentle-ai install' to create initial state",
+		}
+	case sum.StateUnreadable:
+		return CheckResult{
+			Name:   name,
+			Status: CheckStatusFail,
+			Detail: "state file could not be read — managed block footprint unavailable (see the state:json check above for details)",
+			Remedy: "Delete or repair the state file, then re-run 'gentle-ai install'",
+		}
+	case sum.NoAgents:
+		return CheckResult{
+			Name:   name,
+			Status: CheckStatusWarn,
+			Detail: "no installed agents — managed block footprint unavailable",
+			Remedy: "Run 'gentle-ai install' to configure agents",
+		}
+	case sum.RegistryUnavailable:
+		return CheckResult{
+			Name:   name,
+			Status: CheckStatusWarn,
+			Detail: "agent registry unavailable — managed block footprint could not be computed",
+			Remedy: "Re-run 'gentle-ai doctor'; if this persists, reinstall gentle-ai",
+		}
+	case sum.HasFail:
+		return CheckResult{
+			Name:   name,
+			Status: CheckStatusFail,
+			Detail: "broken managed block marker(s): " + strings.Join(footprintFailLocations(sum), ", "),
+			Remedy: "Run 'gentle-ai sync' to repair marker boundaries",
+		}
+	case sum.HasWarn:
+		return CheckResult{
+			Name:   name,
+			Status: CheckStatusWarn,
+			Detail: "stray closing marker found in managed block(s)",
+			Remedy: "Run 'gentle-ai sync' to repair marker boundaries",
+		}
+	default:
+		return CheckResult{
+			Name:   name,
+			Status: CheckStatusPass,
+			Detail: fmt.Sprintf("%d block(s) across %d agent(s), ~%d tokens (rough estimate)", sum.TotalBlocks, sum.AgentsCovered, sum.TotalTokenEst),
+		}
+	}
+}
+
+// footprintFailLocations returns "agentID:sectionID" for every orphan-open or
+// mismatch anomaly, for the Fail detail message.
+func footprintFailLocations(sum FootprintSummary) []string {
+	var locations []string
+	for _, af := range sum.Agents {
+		for _, an := range af.Anomalies {
+			if an.Kind == filemerge.AnomalyOrphanOpen || an.Kind == filemerge.AnomalyMismatch {
+				locations = append(locations, af.AgentID+":"+an.ID)
+			}
+		}
+	}
+	return locations
 }
 
 // renderDoctorReport writes a human-readable report to w.

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -10,6 +10,11 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/gentleman-programming/gentle-ai/internal/agents"
+	"github.com/gentleman-programming/gentle-ai/internal/agents/claude"
+	"github.com/gentleman-programming/gentle-ai/internal/agents/opencode"
+	"github.com/gentleman-programming/gentle-ai/internal/model"
 )
 
 // --- checkOneTool ---
@@ -498,5 +503,274 @@ func TestRunDoctor_HomeDirError(t *testing.T) {
 	err := RunDoctor(context.Background(), &buf)
 	if err == nil {
 		t.Error("expected error when home dir fails")
+	}
+}
+
+// --- estimateTokens ---
+
+func TestEstimateTokens(t *testing.T) {
+	tests := []struct {
+		name  string
+		chars int
+		want  int
+	}{
+		{name: "zero chars", chars: 0, want: 0},
+		{name: "exact multiple of four", chars: 400, want: 100},
+		{name: "non-multiple rounds down", chars: 10, want: 2},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := estimateTokens(tt.chars)
+			if got != tt.want {
+				t.Errorf("estimateTokens(%d) = %d, want %d", tt.chars, got, tt.want)
+			}
+		})
+	}
+}
+
+// --- collectFootprint / footprintCheckResult ---
+
+func footprintSubsetRegistry() (*agents.Registry, error) {
+	return agents.NewRegistry(claude.NewAdapter(), opencode.NewAdapter())
+}
+
+func writeDoctorState(t *testing.T, homeDir string, agentIDs []string) {
+	t.Helper()
+	stateDir := filepath.Join(homeDir, ".gentle-ai")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	quoted := make([]string, len(agentIDs))
+	for i, id := range agentIDs {
+		quoted[i] = `"` + id + `"`
+	}
+	payload := `{"installed_agents":[` + strings.Join(quoted, ",") + `]}`
+	if err := os.WriteFile(filepath.Join(stateDir, "state.json"), []byte(payload), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeDoctorFixture(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func setupFootprintSeams(t *testing.T, homeDir string) {
+	t.Helper()
+	origHome := osUserHomeDirDoctor
+	origRegistry := newDoctorRegistry
+	t.Cleanup(func() {
+		osUserHomeDirDoctor = origHome
+		newDoctorRegistry = origRegistry
+	})
+	osUserHomeDirDoctor = func() (string, error) { return homeDir, nil }
+	newDoctorRegistry = footprintSubsetRegistry
+}
+
+func TestCollectFootprint(t *testing.T) {
+	tests := []struct {
+		name       string
+		agentIDs   []string // nil skips writing state.json entirely
+		fixtures   map[string]string
+		wantStatus CheckStatus
+		check      func(t *testing.T, sum FootprintSummary, result CheckResult)
+	}{
+		{
+			name:     "healthy two agents",
+			agentIDs: []string{"claude-code", "opencode"},
+			fixtures: map[string]string{
+				"claude-code": "<!-- gentle-ai:persona -->\nsome persona text\n<!-- /gentle-ai:persona -->\n",
+				"opencode":    "<!-- gentle-ai:engram-protocol -->\nprotocol text here\n<!-- /gentle-ai:engram-protocol -->\n",
+			},
+			wantStatus: CheckStatusPass,
+			check: func(t *testing.T, sum FootprintSummary, result CheckResult) {
+				if sum.TotalBlocks != 2 || sum.AgentsCovered != 2 {
+					t.Fatalf("expected 2 blocks across 2 agents, got %d/%d", sum.TotalBlocks, sum.AgentsCovered)
+				}
+				if sum.HasFail || sum.HasWarn {
+					t.Fatalf("expected no anomalies, got HasFail=%v HasWarn=%v", sum.HasFail, sum.HasWarn)
+				}
+				if !strings.Contains(result.Detail, "2 block") {
+					t.Errorf("expected detail to mention block count, got %q", result.Detail)
+				}
+			},
+		},
+		{
+			name:       "orphan open fails",
+			agentIDs:   []string{"claude-code"},
+			fixtures:   map[string]string{"claude-code": "<!-- gentle-ai:persona -->\nunclosed content\n"},
+			wantStatus: CheckStatusFail,
+			check: func(t *testing.T, sum FootprintSummary, result CheckResult) {
+				if !sum.HasFail {
+					t.Fatal("expected HasFail true for unclosed marker")
+				}
+				if !strings.Contains(result.Detail, "claude-code") || !strings.Contains(result.Detail, "persona") {
+					t.Errorf("expected detail to name agent and section id, got %q", result.Detail)
+				}
+				if result.Remedy == "" {
+					t.Error("expected non-empty remedy")
+				}
+			},
+		},
+		{
+			name:       "mismatch anomaly fails",
+			agentIDs:   []string{"claude-code"},
+			fixtures:   map[string]string{"claude-code": "<!-- gentle-ai:persona -->\ncontent\n<!-- /gentle-ai:other -->\n"},
+			wantStatus: CheckStatusFail,
+			check: func(t *testing.T, sum FootprintSummary, result CheckResult) {
+				if !sum.HasFail {
+					t.Fatal("expected HasFail true for id mismatch")
+				}
+				if !strings.Contains(result.Detail, "claude-code") || !strings.Contains(result.Detail, "other") {
+					t.Errorf("expected detail to name agent and the offending closer id, got %q", result.Detail)
+				}
+				if result.Remedy == "" {
+					t.Error("expected non-empty remedy")
+				}
+			},
+		},
+		{
+			name:       "stray closer warns",
+			agentIDs:   []string{"claude-code"},
+			fixtures:   map[string]string{"claude-code": "<!-- /gentle-ai:persona -->\nsome text\n"},
+			wantStatus: CheckStatusWarn,
+			check: func(t *testing.T, sum FootprintSummary, result CheckResult) {
+				if sum.HasFail {
+					t.Fatal("expected HasFail false for stray closer")
+				}
+				if !sum.HasWarn {
+					t.Fatal("expected HasWarn true for stray closer")
+				}
+			},
+		},
+		{
+			name:       "state missing",
+			wantStatus: CheckStatusWarn,
+			check: func(t *testing.T, sum FootprintSummary, result CheckResult) {
+				if !sum.StateMissing {
+					t.Fatal("expected StateMissing true")
+				}
+				if !strings.Contains(result.Remedy, "install") {
+					t.Errorf("expected install remedy, got %q", result.Remedy)
+				}
+			},
+		},
+		{
+			name:       "no agents",
+			agentIDs:   []string{},
+			wantStatus: CheckStatusWarn,
+			check: func(t *testing.T, sum FootprintSummary, result CheckResult) {
+				if !sum.NoAgents {
+					t.Fatal("expected NoAgents true")
+				}
+			},
+		},
+		{
+			name:       "unresolved agent is tracked but not scanned",
+			agentIDs:   []string{"unknown-agent"},
+			wantStatus: CheckStatusPass,
+			check: func(t *testing.T, sum FootprintSummary, result CheckResult) {
+				if len(sum.Agents) != 1 || !sum.Agents[0].Unresolved {
+					t.Fatalf("expected 1 unresolved agent entry, got %+v", sum.Agents)
+				}
+				if sum.AgentsCovered != 0 {
+					t.Errorf("expected unresolved agent not counted in AgentsCovered, got %d", sum.AgentsCovered)
+				}
+			},
+		},
+		{
+			name:       "absent instruction file is informational",
+			agentIDs:   []string{"claude-code"},
+			wantStatus: CheckStatusPass,
+			check: func(t *testing.T, sum FootprintSummary, result CheckResult) {
+				if len(sum.Agents) != 1 || sum.Agents[0].Present {
+					t.Fatalf("expected Present false when instruction file is absent, got %+v", sum.Agents)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			homeDir := t.TempDir()
+			setupFootprintSeams(t, homeDir)
+			if tt.agentIDs != nil {
+				writeDoctorState(t, homeDir, tt.agentIDs)
+			}
+			reg, _ := footprintSubsetRegistry()
+			for id, content := range tt.fixtures {
+				adapter, ok := reg.Get(model.AgentID(id))
+				if !ok {
+					t.Fatalf("no adapter for %q in subset registry", id)
+				}
+				writeDoctorFixture(t, adapter.SystemPromptFile(homeDir), content)
+			}
+
+			sum := collectFootprint(homeDir)
+			result := footprintCheckResult(sum)
+			if result.Status != tt.wantStatus {
+				t.Fatalf("expected status %s, got %s: %s", tt.wantStatus, result.Status, result.Detail)
+			}
+			tt.check(t, sum, result)
+		})
+	}
+}
+
+func TestCollectFootprint_MalformedStateJSONIsNotConflatedWithEmptyAgents(t *testing.T) {
+	homeDir := t.TempDir()
+	setupFootprintSeams(t, homeDir)
+	stateDir := filepath.Join(homeDir, ".gentle-ai")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "state.json"), []byte("not-json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	sum := collectFootprint(homeDir)
+	result := footprintCheckResult(sum)
+
+	if !sum.StateUnreadable {
+		t.Fatal("expected StateUnreadable true for malformed state.json")
+	}
+	if sum.NoAgents {
+		t.Fatal("expected NoAgents false for malformed state.json — must not conflate a corrupt state file with a genuinely empty agent list")
+	}
+	if result.Status != CheckStatusFail {
+		t.Errorf("expected Fail status for malformed state.json (mirroring checkStateJSON's severity), got %s", result.Status)
+	}
+	if strings.Contains(result.Detail, "no installed agents") {
+		t.Errorf("malformed state.json must not reuse the NoAgents wording, got detail=%q", result.Detail)
+	}
+	if result.Remedy == "Run 'gentle-ai install' to configure agents" {
+		t.Errorf("malformed state.json must not reuse the NoAgents remedy verbatim, got remedy=%q", result.Remedy)
+	}
+}
+
+func TestCollectFootprint_RegistryConstructionFailureIsWarnNotNoAgents(t *testing.T) {
+	homeDir := t.TempDir()
+	origRegistry := newDoctorRegistry
+	t.Cleanup(func() { newDoctorRegistry = origRegistry })
+	newDoctorRegistry = func() (*agents.Registry, error) {
+		return nil, errors.New("registry construction failed")
+	}
+
+	sum := collectFootprint(homeDir)
+	result := footprintCheckResult(sum)
+
+	if !sum.RegistryUnavailable {
+		t.Fatal("expected RegistryUnavailable true when newDoctorRegistry fails")
+	}
+	if sum.NoAgents {
+		t.Fatal("expected NoAgents false when registry construction fails")
+	}
+	if result.Status != CheckStatusWarn {
+		t.Errorf("expected Warn status for registry construction failure, got %s", result.Status)
 	}
 }

--- a/internal/components/filemerge/section_scan.go
+++ b/internal/components/filemerge/section_scan.go
@@ -1,0 +1,110 @@
+package filemerge
+
+import "strings"
+
+// Section is one matched gentle-ai marker pair.
+type Section struct {
+	ID        string // marker id, e.g. "persona" (never a whitelist — whatever the file contains)
+	Content   string // raw text between open and close markers, markers excluded
+	StartLine int    // 1-based line number of the opening marker
+	EndLine   int    // 1-based line number of the closing marker
+	CharCount int    // len(Content) in bytes
+	LineCount int    // number of content lines (0 when Content == "")
+}
+
+// AnomalyKind classifies a structural marker defect.
+type AnomalyKind string
+
+const (
+	AnomalyOrphanOpen  AnomalyKind = "orphan-open"  // opener with no matching closer (unbounded block)
+	AnomalyOrphanClose AnomalyKind = "orphan-close" // closer with no preceding opener
+	AnomalyMismatch    AnomalyKind = "mismatch"     // closer id != currently-open id
+)
+
+// Anomaly is a structural marker defect surfaced by ScanSections.
+type Anomaly struct {
+	Kind AnomalyKind
+	ID   string // id on the offending marker
+	Line int    // 1-based line of the offending marker
+}
+
+// ScanResult is the full outcome of one pass over a markdown file.
+type ScanResult struct {
+	Sections  []Section
+	Anomalies []Anomaly
+}
+
+// ScanSections finds every <!-- gentle-ai:ID --> ... <!-- /gentle-ai:ID --> pair
+// in content, generically (no id whitelist), plus any structural anomalies.
+func ScanSections(content string) ScanResult {
+	var result ScanResult
+
+	var (
+		openActive   bool
+		openID       string
+		openLine     int
+		contentLines []string
+	)
+
+	lines := strings.Split(content, "\n")
+	for i, raw := range lines {
+		lineNum := i + 1
+		line := strings.TrimSuffix(raw, "\r")
+		trimmed := strings.TrimSpace(line)
+
+		switch {
+		case strings.HasPrefix(trimmed, closePrefix) && strings.HasSuffix(trimmed, markerSuffix):
+			id := strings.TrimSuffix(strings.TrimPrefix(trimmed, closePrefix), markerSuffix)
+			switch {
+			case !openActive:
+				// No opener is active: this closer has nothing to pair with.
+				result.Anomalies = append(result.Anomalies, Anomaly{Kind: AnomalyOrphanClose, ID: id, Line: lineNum})
+			case id != openID:
+				// Closer id doesn't match the active opener: report only the
+				// mismatch (not a second AnomalyOrphanOpen for the discarded
+				// opener) and drop the open context so scanning resumes clean
+				// from the next marker — a single anomaly per malformed event.
+				result.Anomalies = append(result.Anomalies, Anomaly{Kind: AnomalyMismatch, ID: id, Line: lineNum})
+				openActive = false
+				contentLines = nil
+			default:
+				sectionContent := strings.Join(contentLines, "\n")
+				lineCount := 0
+				if sectionContent != "" {
+					lineCount = strings.Count(sectionContent, "\n") + 1
+				}
+				result.Sections = append(result.Sections, Section{
+					ID:        openID,
+					Content:   sectionContent,
+					StartLine: openLine,
+					EndLine:   lineNum,
+					CharCount: len(sectionContent),
+					LineCount: lineCount,
+				})
+				openActive = false
+				contentLines = nil
+			}
+
+		case strings.HasPrefix(trimmed, markerPrefix) && strings.HasSuffix(trimmed, markerSuffix):
+			id := strings.TrimSuffix(strings.TrimPrefix(trimmed, markerPrefix), markerSuffix)
+			if openActive {
+				result.Anomalies = append(result.Anomalies, Anomaly{Kind: AnomalyOrphanOpen, ID: openID, Line: openLine})
+			}
+			openActive = true
+			openID = id
+			openLine = lineNum
+			contentLines = nil
+
+		default:
+			if openActive {
+				contentLines = append(contentLines, line)
+			}
+		}
+	}
+
+	if openActive {
+		result.Anomalies = append(result.Anomalies, Anomaly{Kind: AnomalyOrphanOpen, ID: openID, Line: openLine})
+	}
+
+	return result
+}

--- a/internal/components/filemerge/section_scan_test.go
+++ b/internal/components/filemerge/section_scan_test.go
@@ -1,0 +1,103 @@
+package filemerge
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestScanSections(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         string
+		wantSections  []Section
+		wantAnomalies []Anomaly
+	}{
+		{
+			name:  "single well-formed block",
+			input: "before\n<!-- gentle-ai:persona -->\nHello\nWorld\n<!-- /gentle-ai:persona -->\nafter\n",
+			wantSections: []Section{
+				{ID: "persona", Content: "Hello\nWorld", StartLine: 2, EndLine: 5, CharCount: 11, LineCount: 2},
+			},
+		},
+		{
+			name: "multiple distinct blocks in one file",
+			input: "<!-- gentle-ai:persona -->\nP body\n<!-- /gentle-ai:persona -->\n\n" +
+				"<!-- gentle-ai:engram-protocol -->\nE body\n<!-- /gentle-ai:engram-protocol -->\n\n" +
+				"<!-- gentle-ai:strict-tdd-mode -->\nT body\n<!-- /gentle-ai:strict-tdd-mode -->\n",
+			wantSections: []Section{
+				{ID: "persona", Content: "P body", StartLine: 1, EndLine: 3, CharCount: 6, LineCount: 1},
+				{ID: "engram-protocol", Content: "E body", StartLine: 5, EndLine: 7, CharCount: 6, LineCount: 1},
+				{ID: "strict-tdd-mode", Content: "T body", StartLine: 9, EndLine: 11, CharCount: 6, LineCount: 1},
+			},
+		},
+		{
+			name:  "empty-content block",
+			input: "<!-- gentle-ai:empty -->\n<!-- /gentle-ai:empty -->\n",
+			wantSections: []Section{
+				{ID: "empty", Content: "", StartLine: 1, EndLine: 2, CharCount: 0, LineCount: 0},
+			},
+		},
+		{
+			name:  "unclosed opener at EOF",
+			input: "<!-- gentle-ai:orphan -->\nsome content\n",
+			wantAnomalies: []Anomaly{
+				{Kind: AnomalyOrphanOpen, ID: "orphan", Line: 1},
+			},
+		},
+		{
+			name:  "stray closer with no opener",
+			input: "before\n<!-- /gentle-ai:stray -->\nafter\n",
+			wantAnomalies: []Anomaly{
+				{Kind: AnomalyOrphanClose, ID: "stray", Line: 2},
+			},
+		},
+		{
+			name:  "closer id mismatch with opener id",
+			input: "<!-- gentle-ai:a -->\ncontent\n<!-- /gentle-ai:b -->\nafter\n",
+			wantAnomalies: []Anomaly{
+				{Kind: AnomalyMismatch, ID: "b", Line: 3},
+			},
+		},
+		{
+			name: "mismatch discards stale opener then resumes cleanly on next block",
+			input: "<!-- gentle-ai:a -->\nstale\n<!-- /gentle-ai:b -->\n" +
+				"<!-- gentle-ai:c -->\nclean\n<!-- /gentle-ai:c -->\n",
+			wantSections: []Section{
+				{ID: "c", Content: "clean", StartLine: 4, EndLine: 6, CharCount: 5, LineCount: 1},
+			},
+			wantAnomalies: []Anomaly{
+				{Kind: AnomalyMismatch, ID: "b", Line: 3},
+			},
+		},
+		{
+			name:  "unknown novel id measured like any other",
+			input: "<!-- gentle-ai:brand-new-block -->\nnovel content\n<!-- /gentle-ai:brand-new-block -->\n",
+			wantSections: []Section{
+				{ID: "brand-new-block", Content: "novel content", StartLine: 1, EndLine: 3, CharCount: 13, LineCount: 1},
+			},
+		},
+		{
+			name:  "markers with leading indentation and trailing CR",
+			input: "  <!-- gentle-ai:indented -->\r\ncontent line\r\n  <!-- /gentle-ai:indented -->\r\n",
+			wantSections: []Section{
+				{ID: "indented", Content: "content line", StartLine: 1, EndLine: 3, CharCount: 12, LineCount: 1},
+			},
+		},
+		{
+			name:  "file with zero markers",
+			input: "just some text\nno markers at all\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ScanSections(tt.input)
+			if !reflect.DeepEqual(got.Sections, tt.wantSections) {
+				t.Fatalf("Sections mismatch:\ngot:  %+v\nwant: %+v", got.Sections, tt.wantSections)
+			}
+			if !reflect.DeepEqual(got.Anomalies, tt.wantAnomalies) {
+				t.Fatalf("Anomalies mismatch:\ngot:  %+v\nwant: %+v", got.Anomalies, tt.wantAnomalies)
+			}
+		})
+	}
+}

--- a/openspec/changes/doctor-footprint/apply-progress.md
+++ b/openspec/changes/doctor-footprint/apply-progress.md
@@ -1,0 +1,35 @@
+# Apply Progress: doctor-footprint
+
+## Status
+
+- **WU1 (Phase 1 — Generic Section Scanner)**: DONE. This is PR 1 of the stacked chain.
+- **WU2+WU3 (Phase 2 — Token helper + collector/classifier)**: NOT STARTED. Next batch, on a new branch off `feat/doctor-footprint-scanner`.
+- **WU4 (Phase 3 — flag + `RunDoctor` signature migration)**: NOT STARTED.
+- **WU5 (Phase 4 — `renderFootprintDetail`)**: NOT STARTED.
+- **WU6 (Phase 5 — integration test + full verification)**: NOT STARTED.
+
+## What was implemented (WU1, this batch)
+
+- `internal/components/filemerge/section_scan.go` — `Section`, `AnomalyKind`, `Anomaly`, `ScanResult` types and `ScanSections(content string) ScanResult`, per design.md §2's exact 4-step line-based single-pass algorithm. Reuses existing `markerPrefix`/`markerSuffix`/`closePrefix` constants from `section.go` (no redefinition).
+- `internal/components/filemerge/section_scan_test.go` — `TestScanSections`, table-driven, 9 cases matching design.md §8.1 and tasks.md 1.1 exactly: single well-formed block, multi-block, empty-content block, unclosed opener at EOF (`AnomalyOrphanOpen`), stray closer with no opener (`AnomalyOrphanClose`), id mismatch (`AnomalyMismatch`), novel/unknown id (genericity proof, no whitelist), leading indentation + trailing `\r`, zero markers.
+
+## Scope discipline
+
+Touched ONLY `internal/components/filemerge/`. Did NOT touch `internal/cli/doctor.go`, `internal/app/app.go`, or anything else — those are WU2/WU3 (PR2) and WU4/WU5/WU6 (PR3), reserved for future branches per the stacked-PRs delivery strategy.
+
+## Verification run
+
+- `go test ./internal/components/filemerge/... -v` — all tests pass, including pre-existing suite (safety net, no regressions).
+- `go vet ./internal/components/filemerge/...` — clean.
+- `gofmt -l internal/components/filemerge/section_scan.go internal/components/filemerge/section_scan_test.go` — clean (not in the repo-wide `gofmt -l .` unformatted list).
+- `go test ./...` (full repo) — `internal/components/filemerge` passes (cached ok). Failures present in `internal/components/engram`, `internal/components/gga`, `internal/components/permissions`, `internal/components/sdd`, `internal/components/uninstall`, `internal/tui`, `internal/update/upgrade` are PRE-EXISTING and environment-specific (Windows symlink privilege errors, `TempDir` cleanup lock contention, network/install-script mocking) — none touch any file this PR modified, and this PR adds only new, unreferenced exported symbols (nothing outside `filemerge` imports them yet). Not introduced by WU1.
+
+## Next steps (WU2 — new branch off this one)
+
+Per design.md §3-4 and tasks.md Phase 2:
+1. `estimateTokens(chars int) int` in `internal/cli/doctor.go`.
+2. New seam `var newDoctorRegistry = agents.NewDefaultRegistry`.
+3. `AgentFootprint` / `FootprintSummary` structs.
+4. `collectFootprint(homeDir string) FootprintSummary` — consumes `filemerge.ScanSections` from this PR.
+5. `footprintCheckResult(sum FootprintSummary) CheckResult`.
+6. RED tests first: `TestCollectFootprint` / `TestFootprintCheckResult`, 7 cases per design.md §8.2.


### PR DESCRIPTION
<!-- ⚠️ READ BEFORE SUBMITTING
  Every PR must be linked to an issue that has the "status:approved" label.
  PRs without a linked approved issue will be automatically rejected by CI.
  See CONTRIBUTING.md for the full contribution workflow.
-->

## 🔗 Linked Issue

Closes #1018

<!-- Replace the # above with the issue number, e.g.: Closes #42 -->

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [ ] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [x] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

Adds `estimateTokens` (chars/4 heuristic), the `collectFootprint`/`footprintCheckResult` pair, and a `newDoctorRegistry` seam that resolves per-agent instruction file paths via `agents.Registry` instead of a hardcoded path switch. Not yet wired into `RunDoctor`'s live check list — second of 3 stacked PRs toward the managed block footprint diagnostic for `gentle-ai doctor` (issue #1018).

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/cli/doctor.go` | `estimateTokens`, `collectFootprint`, `collectAgentFootprint`, `footprintCheckResult`, `footprintFailLocations`, `AgentFootprint`/`FootprintSummary` structs, `newDoctorRegistry` seam |
| `internal/cli/doctor_test.go` | `TestEstimateTokens`, table-driven `TestCollectFootprint` (9 cases), 2 standalone tests for the failure-mode classification fix below |

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./internal/cli/...

E2E Tests (Docker required)
cd e2e && ./docker-test.sh

- [x] Unit tests pass (go test ./internal/cli/... — 12 TestCollectFootprint cases + TestEstimateTokens + 2 classification tests, all green)
- [ ] E2E tests pass — not run (no RunDoctor wiring yet in this PR; will run ahead of PR 3)
- [x] go vet ./... and gofmt -l clean

---
🤖 Automated Checks

┌─────────────────────────────┬────────┬──────────────────────────────────────────────────────────────────────────┐
│            Check            │ Status │                               Description                                │
├─────────────────────────────┼────────┼──────────────────────────────────────────────────────────────────────────┤
│ Check PR Cognitive Load     │ ⏳     │ PR should stay within 400 changed lines (additions + deletions) or use   │
│                             │        │ size:exception                                                           │
├─────────────────────────────┼────────┼──────────────────────────────────────────────────────────────────────────┤
│ Check Issue Reference       │ ⏳     │ PR body must contain Closes/Fixes/Resolves #N                            │
├─────────────────────────────┼────────┼──────────────────────────────────────────────────────────────────────────┤
│ Check Issue Has             │ ⏳     │ Linked issue must have been approved before work began                   │
│ status:approved             │        │                                                                          │
├─────────────────────────────┼────────┼──────────────────────────────────────────────────────────────────────────┤
│ Check PR Has type:* Label   │ ⏳     │ Exactly one type:* label must be applied                                 │
├─────────────────────────────┼────────┼──────────────────────────────────────────────────────────────────────────┤
│ Unit Tests                  │ ⏳     │ go test ./... must pass                                                  │
├─────────────────────────────┼────────┼──────────────────────────────────────────────────────────────────────────┤
│ E2E Tests                   │ ⏳     │ cd e2e && ./docker-test.sh must pass                                     │
└─────────────────────────────┴────────┴──────────────────────────────────────────────────────────────────────────┘

---
✅ Contributor Checklist

- [x] PR is linked to an issue with status:approved
- [ ] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied size:exception with rationale documented (473 lines — see note below)
- [ ] I have added the appropriate type:* label to this PR
- [x] Unit tests pass (go test ./...)
- [ ] E2E tests pass (cd e2e && ./docker-test.sh)
- [x] I have updated documentation if necessary
- [x] My commits follow Conventional Commits format
- [x] My commits do not include Co-Authored-By trailers

---
💬 Notes for Reviewers

This is 2 of 3 stacked PRs toward issue #1018. Closes #1018 is set because check-issue-reference CI requires it on every PR in the chain — merging this alone will auto-close #1018 early even though PR 3 is still coming.

This PR is 473 changed lines, over the 400-line budget. That's driven by a real correctness fix caught during review (see below), not scope creep: collectFootprint originally collapsed three distinct failure modes into one NoAgents flag — a corrupt state.json got the same "run install" remedy as a genuinely empty agent list, contradicting the checkStateJSON check running in the same report. Split into NoAgents / StateUnreadable / RegistryUnavailable with 3 distinct messages, plus 2 new tests (TestCollectFootprint_MalformedStateJSONIsNotConflatedWithEmptyAgents, TestCollectFootprint_RegistryConstructionFailureIsWarnNotNoAgents). Also added the mismatch anomaly test case CodeRabbit flagged. Requesting size:exception.