### PR TITLE
feat(cli): wire managed block footprint into doctor with --footprint flag

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -91,6 +91,11 @@ func RunArgs(args []string, stdout io.Writer) error {
 				cli.PrintInstallHelp(stdout)
 				return nil
 			}
+		case "doctor":
+			if hasHelpFlag(args[1:]) {
+				cli.PrintDoctorHelp(stdout)
+				return nil
+			}
 		}
 	}
 
@@ -232,7 +237,7 @@ func RunArgs(args []string, stdout io.Writer) error {
 	case "restore":
 		return cli.RunRestore(args[1:], stdout)
 	case "doctor":
-		return cli.RunDoctor(context.Background(), stdout)
+		return cli.RunDoctor(context.Background(), args[1:], stdout)
 	default:
 		return fmt.Errorf("unknown command %q — run 'gentle-ai help' for available commands", args[0])
 	}

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -275,6 +275,27 @@ func TestRunArgsInstallHelpPrintsInstallSpecificHelp(t *testing.T) {
 	}
 }
 
+func TestRunArgsDoctorHelpPrintsDoctorSpecificHelp(t *testing.T) {
+	origEnsure := ensureCurrentOSSupported
+	t.Cleanup(func() { ensureCurrentOSSupported = origEnsure })
+	ensureCurrentOSSupported = func() error {
+		return fmt.Errorf("platform validation should not run for doctor help")
+	}
+
+	var buf bytes.Buffer
+	err := RunArgs([]string{"doctor", "--help"}, &buf)
+	if err != nil {
+		t.Fatalf("RunArgs(doctor --help) error = %v", err)
+	}
+
+	out := buf.String()
+	for _, want := range []string{"USAGE", "gentle-ai doctor", "--footprint"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("doctor help missing %q; output:\n%s", want, out)
+		}
+	}
+}
+
 func TestRunArgsSDDStatusIsDispatchedBeforePlatformValidation(t *testing.T) {
 	origEnsure := ensureCurrentOSSupported
 	t.Cleanup(func() { ensureCurrentOSSupported = origEnsure })

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -2,6 +2,8 @@ package cli
 
 import (
 	"context"
+	"errors"
+	"flag"
 	"fmt"
 	"io"
 	"net/http"
@@ -70,8 +72,52 @@ var (
 	newDoctorRegistry = agents.NewDefaultRegistry
 )
 
+// DoctorFlags holds parsed CLI flags for the doctor command.
+type DoctorFlags struct {
+	Footprint bool
+}
+
+// ParseDoctorFlags parses the CLI arguments for the doctor subcommand.
+func ParseDoctorFlags(args []string) (*DoctorFlags, error) {
+	opts := &DoctorFlags{}
+
+	fs := flag.NewFlagSet("doctor", flag.ContinueOnError)
+	fs.SetOutput(ioDiscard{})
+	fs.BoolVar(&opts.Footprint, "footprint", false, "show per-agent/per-block managed block footprint breakdown")
+
+	if err := fs.Parse(args); err != nil {
+		return nil, err
+	}
+
+	if fs.NArg() > 0 {
+		return nil, fmt.Errorf("unexpected doctor argument %q", fs.Arg(0))
+	}
+
+	return opts, nil
+}
+
+// PrintDoctorHelp writes doctor's usage text to w.
+func PrintDoctorHelp(w io.Writer) {
+	fmt.Fprint(w, `USAGE
+  gentle-ai doctor [flags]
+
+FLAGS
+  --footprint   Show per-agent/per-block managed block footprint breakdown
+  --help, -h    Show this help
+`)
+}
+
 // RunDoctor runs all ecosystem health checks and renders a report to w.
-func RunDoctor(ctx context.Context, w io.Writer) error {
+func RunDoctor(ctx context.Context, args []string, w io.Writer) error {
+	flags, err := ParseDoctorFlags(args)
+	if err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			PrintDoctorHelp(w)
+			return nil
+		}
+		return err
+	}
+
 	homeDir, err := osUserHomeDirDoctor()
 	if err != nil {
 		return fmt.Errorf("resolve home directory: %w", err)
@@ -83,7 +129,22 @@ func RunDoctor(ctx context.Context, w io.Writer) error {
 	report.Checks = append(report.Checks, checkEngramReachable())
 	report.Checks = append(report.Checks, checkDiskSpace(homeDir))
 
+	summary, panicked := safeCollectFootprint(homeDir)
+	if panicked {
+		report.Checks = append(report.Checks, CheckResult{
+			Name:   "managed:footprint",
+			Status: CheckStatusWarn,
+			Detail: "footprint check failed unexpectedly and was recovered — managed block footprint unavailable this run",
+			Remedy: "Re-run 'gentle-ai doctor'; if this persists, report a bug",
+		})
+	} else {
+		report.Checks = append(report.Checks, footprintCheckResult(summary))
+	}
+
 	renderDoctorReport(w, report)
+	if flags.Footprint && !panicked {
+		renderFootprintDetail(w, summary)
+	}
 	return nil
 }
 
@@ -464,6 +525,23 @@ func collectFootprint(homeDir string) FootprintSummary {
 	return sum
 }
 
+// safeCollectFootprint runs collectFootprint with panic recovery. The
+// footprint scan reads arbitrary, user-edited files from disk (agent
+// instruction files) — a diagnostic tool must never let that turn into a
+// crash that loses every other check RunDoctor already computed. panicked is
+// true when a panic was recovered; callers should treat sum as unavailable
+// (zero value) in that case and surface a dedicated CheckResult instead of
+// footprintCheckResult(sum).
+func safeCollectFootprint(homeDir string) (sum FootprintSummary, panicked bool) {
+	defer func() {
+		if r := recover(); r != nil {
+			panicked = true
+		}
+	}()
+	sum = collectFootprint(homeDir)
+	return sum, false
+}
+
 // collectAgentFootprint resolves and scans a single agent's instruction file.
 func collectAgentFootprint(reg *agents.Registry, homeDir, agentID string) AgentFootprint {
 	af := AgentFootprint{AgentID: agentID}
@@ -599,6 +677,44 @@ func renderDoctorReport(w io.Writer, report DoctorReport) {
 		status = "degraded"
 	}
 	fmt.Fprintf(w, "Status:  %s\n", status)
+}
+
+// renderFootprintDetail writes the per-agent, per-block managed footprint
+// table to w. Only called when --footprint is set; the compact summary is
+// already rendered by renderDoctorReport via the managed:footprint CheckResult.
+func renderFootprintDetail(w io.Writer, sum FootprintSummary) {
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Managed block footprint (rough estimate)")
+	fmt.Fprintln(w, "----------------------------------------")
+
+	for _, af := range sum.Agents {
+		renderAgentFootprint(w, af)
+	}
+
+	fmt.Fprintln(w, "----------------------------------------")
+	fmt.Fprintf(w, "TOTAL  %d block(s) · %d agent(s) · ~%d tokens (rough estimate)\n", sum.TotalBlocks, sum.AgentsCovered, sum.TotalTokenEst)
+}
+
+func renderAgentFootprint(w io.Writer, af AgentFootprint) {
+	if af.Unresolved {
+		fmt.Fprintf(w, "  %s  (unresolved — no registered adapter for this agent id)\n", af.AgentID)
+		return
+	}
+
+	fmt.Fprintf(w, "  %s  %s\n", af.AgentID, af.Path)
+	if !af.Present {
+		fmt.Fprintln(w, "    (instruction file absent)")
+		return
+	}
+	if len(af.Sections) == 0 {
+		fmt.Fprintln(w, "    (no managed blocks)")
+		return
+	}
+
+	for _, sec := range af.Sections {
+		fmt.Fprintf(w, "    %-18s %6d lines %8d chars %6d tokens\n", sec.ID, sec.LineCount, sec.CharCount, estimateTokens(sec.CharCount))
+	}
+	fmt.Fprintf(w, "    %-18s %6d lines %8d chars %6d tokens\n", "subtotal", af.LineCount, af.CharCount, af.TokenEst)
 }
 
 func statusIcon(s CheckStatus) string {

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -12,6 +12,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gentleman-programming/gentle-ai/internal/agents"
+	"github.com/gentleman-programming/gentle-ai/internal/components/filemerge"
+	"github.com/gentleman-programming/gentle-ai/internal/model"
 	"github.com/gentleman-programming/gentle-ai/internal/state"
 	"github.com/gentleman-programming/gentle-ai/internal/storage"
 )
@@ -64,6 +67,7 @@ var (
 		_ = resp.Body.Close()
 		return resp.StatusCode, nil
 	}
+	newDoctorRegistry = agents.NewDefaultRegistry
 )
 
 // RunDoctor runs all ecosystem health checks and renders a report to w.
@@ -363,6 +367,201 @@ func checkDiskSpace(homeDir string) CheckResult {
 			Detail: fmt.Sprintf("%d MB free on %s filesystem", freeMB, dir),
 		}
 	}
+}
+
+// estimateTokens returns a rough token count using the ~4-chars/token
+// heuristic. Intentionally coarse: doctor labels every token figure a "rough
+// estimate" and no model-specific tokenizer is a dependency (out of scope).
+func estimateTokens(chars int) int {
+	return chars / 4
+}
+
+// AgentFootprint is one agent's measured managed-block footprint.
+type AgentFootprint struct {
+	AgentID    string
+	Path       string // "" when the agent id had no adapter
+	Unresolved bool   // state listed an id with no registered adapter
+	Present    bool   // instruction file existed and was read
+	Sections   []filemerge.Section
+	Anomalies  []filemerge.Anomaly
+	CharCount  int // sum of section CharCounts
+	LineCount  int // sum of section LineCounts
+	TokenEst   int // estimateTokens(CharCount)
+}
+
+// FootprintSummary aggregates managed-block footprint measurements across all
+// agents listed in the persisted install state.
+type FootprintSummary struct {
+	Agents        []AgentFootprint
+	TotalBlocks   int
+	AgentsCovered int // agents with >=1 measured block
+	TotalChars    int
+	TotalTokenEst int
+	HasFail       bool // any AnomalyOrphanOpen or AnomalyMismatch anywhere
+	HasWarn       bool // any AnomalyOrphanClose anywhere
+	StateMissing  bool // state.json absent (first-time install)
+	NoAgents      bool // state present and readable, but InstalledAgents is genuinely empty
+	// StateUnreadable is true when state.Read failed for a reason OTHER than
+	// "file does not exist" — i.e. a malformed/corrupt state.json. This is
+	// deliberately distinct from NoAgents: telling a user with a corrupt
+	// state file to "run install" (the NoAgents remedy) contradicts the
+	// state:json check, which correctly diagnoses the same file as needing
+	// repair.
+	StateUnreadable bool
+	// RegistryUnavailable is true when newDoctorRegistry() itself failed.
+	// This is a defensive, not user-actionable, path — it does not mean
+	// "no agents installed" and must not carry that remedy.
+	RegistryUnavailable bool
+}
+
+// collectFootprint reads the install state and every installed agent's
+// instruction file, scanning each for managed marker blocks.
+func collectFootprint(homeDir string) FootprintSummary {
+	var sum FootprintSummary
+
+	reg, err := newDoctorRegistry()
+	if err != nil {
+		sum.RegistryUnavailable = true
+		return sum
+	}
+
+	s, err := state.Read(homeDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			sum.StateMissing = true
+		} else {
+			sum.StateUnreadable = true
+		}
+		return sum
+	}
+
+	if len(s.InstalledAgents) == 0 {
+		sum.NoAgents = true
+		return sum
+	}
+
+	for _, id := range s.InstalledAgents {
+		sum.Agents = append(sum.Agents, collectAgentFootprint(reg, homeDir, id))
+	}
+
+	for _, af := range sum.Agents {
+		sum.TotalBlocks += len(af.Sections)
+		sum.TotalChars += af.CharCount
+		sum.TotalTokenEst += af.TokenEst
+		if len(af.Sections) > 0 {
+			sum.AgentsCovered++
+		}
+		for _, an := range af.Anomalies {
+			switch an.Kind {
+			case filemerge.AnomalyOrphanOpen, filemerge.AnomalyMismatch:
+				sum.HasFail = true
+			case filemerge.AnomalyOrphanClose:
+				sum.HasWarn = true
+			}
+		}
+	}
+
+	return sum
+}
+
+// collectAgentFootprint resolves and scans a single agent's instruction file.
+func collectAgentFootprint(reg *agents.Registry, homeDir, agentID string) AgentFootprint {
+	af := AgentFootprint{AgentID: agentID}
+
+	adapter, ok := reg.Get(model.AgentID(agentID))
+	if !ok {
+		af.Unresolved = true
+		return af
+	}
+
+	af.Path = adapter.SystemPromptFile(homeDir)
+	data, err := os.ReadFile(af.Path)
+	if err != nil {
+		return af
+	}
+	af.Present = true
+
+	res := filemerge.ScanSections(string(data))
+	af.Sections = res.Sections
+	af.Anomalies = res.Anomalies
+	for _, sec := range res.Sections {
+		af.CharCount += sec.CharCount
+		af.LineCount += sec.LineCount
+	}
+	af.TokenEst = estimateTokens(af.CharCount)
+
+	return af
+}
+
+// footprintCheckResult classifies a FootprintSummary into the always-on
+// "managed:footprint" CheckResult.
+func footprintCheckResult(sum FootprintSummary) CheckResult {
+	const name = "managed:footprint"
+
+	switch {
+	case sum.StateMissing:
+		return CheckResult{
+			Name:   name,
+			Status: CheckStatusWarn,
+			Detail: "state file not found — managed block footprint unavailable (expected for first-time install)",
+			Remedy: "Run 'gentle-ai install' to create initial state",
+		}
+	case sum.StateUnreadable:
+		return CheckResult{
+			Name:   name,
+			Status: CheckStatusFail,
+			Detail: "state file could not be read — managed block footprint unavailable (see the state:json check above for details)",
+			Remedy: "Delete or repair the state file, then re-run 'gentle-ai install'",
+		}
+	case sum.NoAgents:
+		return CheckResult{
+			Name:   name,
+			Status: CheckStatusWarn,
+			Detail: "no installed agents — managed block footprint unavailable",
+			Remedy: "Run 'gentle-ai install' to configure agents",
+		}
+	case sum.RegistryUnavailable:
+		return CheckResult{
+			Name:   name,
+			Status: CheckStatusWarn,
+			Detail: "agent registry unavailable — managed block footprint could not be computed",
+			Remedy: "Re-run 'gentle-ai doctor'; if this persists, reinstall gentle-ai",
+		}
+	case sum.HasFail:
+		return CheckResult{
+			Name:   name,
+			Status: CheckStatusFail,
+			Detail: "broken managed block marker(s): " + strings.Join(footprintFailLocations(sum), ", "),
+			Remedy: "Run 'gentle-ai sync' to repair marker boundaries",
+		}
+	case sum.HasWarn:
+		return CheckResult{
+			Name:   name,
+			Status: CheckStatusWarn,
+			Detail: "stray closing marker found in managed block(s)",
+			Remedy: "Run 'gentle-ai sync' to repair marker boundaries",
+		}
+	default:
+		return CheckResult{
+			Name:   name,
+			Status: CheckStatusPass,
+			Detail: fmt.Sprintf("%d block(s) across %d agent(s), ~%d tokens (rough estimate)", sum.TotalBlocks, sum.AgentsCovered, sum.TotalTokenEst),
+		}
+	}
+}
+
+// footprintFailLocations returns "agentID:sectionID" for every orphan-open or
+// mismatch anomaly, for the Fail detail message.
+func footprintFailLocations(sum FootprintSummary) []string {
+	var locations []string
+	for _, af := range sum.Agents {
+		for _, an := range af.Anomalies {
+			if an.Kind == filemerge.AnomalyOrphanOpen || an.Kind == filemerge.AnomalyMismatch {
+				locations = append(locations, af.AgentID+":"+an.ID)
+			}
+		}
+	}
+	return locations
 }
 
 // renderDoctorReport writes a human-readable report to w.

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gentleman-programming/gentle-ai/internal/agents"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/claude"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/opencode"
+	"github.com/gentleman-programming/gentle-ai/internal/components/filemerge"
 	"github.com/gentleman-programming/gentle-ai/internal/model"
 )
 
@@ -478,7 +479,7 @@ func TestRunDoctor_IntegrationAllMocked(t *testing.T) {
 	osUserHomeDirDoctor = func() (string, error) { return homeDir, nil }
 
 	var buf bytes.Buffer
-	if err := RunDoctor(context.Background(), &buf); err != nil {
+	if err := RunDoctor(context.Background(), nil, &buf); err != nil {
 		t.Fatalf("RunDoctor returned error: %v", err)
 	}
 
@@ -500,7 +501,7 @@ func TestRunDoctor_HomeDirError(t *testing.T) {
 	osUserHomeDirDoctor = func() (string, error) { return "", errors.New("no home dir") }
 
 	var buf bytes.Buffer
-	err := RunDoctor(context.Background(), &buf)
+	err := RunDoctor(context.Background(), nil, &buf)
 	if err == nil {
 		t.Error("expected error when home dir fails")
 	}
@@ -772,5 +773,319 @@ func TestCollectFootprint_RegistryConstructionFailureIsWarnNotNoAgents(t *testin
 	}
 	if result.Status != CheckStatusWarn {
 		t.Errorf("expected Warn status for registry construction failure, got %s", result.Status)
+	}
+}
+
+// setupRunDoctorMocks stubs the four seams RunDoctor's non-footprint checks
+// depend on (tool lookup, disk space, Engram HTTP, PATH dirs) so integration
+// tests can focus on footprint behavior without those checks failing/warning.
+func setupRunDoctorMocks(t *testing.T) {
+	t.Helper()
+	origLookPath := lookPathFn
+	origAvail := availableBytesFn
+	origHTTP := httpGetFn
+	origPathDirs := pathDirsFn
+	t.Cleanup(func() {
+		lookPathFn = origLookPath
+		availableBytesFn = origAvail
+		httpGetFn = origHTTP
+		pathDirsFn = origPathDirs
+	})
+	lookPathFn = func(name string) (string, error) { return "/usr/local/bin/" + name, nil }
+	availableBytesFn = func(string) (int64, error) { return 1024 * 1024 * 1024, nil }
+	httpGetFn = func(string, time.Duration) (int, error) { return 200, nil }
+	pathDirsFn = func() []string { return []string{"/usr/local/bin"} }
+}
+
+// --- ParseDoctorFlags ---
+
+func TestParseDoctorFlags(t *testing.T) {
+	tests := []struct {
+		name          string
+		args          []string
+		wantFootprint bool
+		wantErr       bool
+	}{
+		{name: "nil args defaults to false", args: nil, wantFootprint: false},
+		{name: "empty args defaults to false", args: []string{}, wantFootprint: false},
+		{name: "footprint flag enables detail", args: []string{"--footprint"}, wantFootprint: true},
+		{name: "footprint=false stays disabled", args: []string{"--footprint=false"}, wantFootprint: false},
+		{name: "unknown flag errors", args: []string{"--bogus"}, wantErr: true},
+		{name: "unexpected positional argument errors", args: []string{"extra"}, wantErr: true},
+		{name: "--help returns flag.ErrHelp", args: []string{"--help"}, wantErr: true},
+		{name: "-h returns flag.ErrHelp", args: []string{"-h"}, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseDoctorFlags(tt.args)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got.Footprint != tt.wantFootprint {
+				t.Errorf("Footprint = %v, want %v", got.Footprint, tt.wantFootprint)
+			}
+		})
+	}
+}
+
+func TestRunDoctor_HelpFlagPrintsUsageWithoutError(t *testing.T) {
+	var buf bytes.Buffer
+	if err := RunDoctor(context.Background(), []string{"--help"}, &buf); err != nil {
+		t.Fatalf("RunDoctor with --help should not return an error, got: %v", err)
+	}
+	output := buf.String()
+	if !strings.Contains(output, "gentle-ai doctor") {
+		t.Errorf("expected usage text mentioning the command, got:\n%s", output)
+	}
+	if !strings.Contains(output, "--footprint") {
+		t.Errorf("expected usage text to document --footprint, got:\n%s", output)
+	}
+}
+
+// --- renderFootprintDetail ---
+
+func TestRenderFootprintDetail(t *testing.T) {
+	tests := []struct {
+		name    string
+		summary FootprintSummary
+		wantAll []string
+	}{
+		{
+			name: "healthy agent with blocks",
+			summary: FootprintSummary{
+				Agents: []AgentFootprint{
+					{
+						AgentID: "claude-code",
+						Path:    "/home/user/.claude/CLAUDE.md",
+						Present: true,
+						Sections: []filemerge.Section{
+							{ID: "persona", CharCount: 400, LineCount: 10},
+						},
+						CharCount: 400,
+						LineCount: 10,
+						TokenEst:  100,
+					},
+				},
+				TotalBlocks:   1,
+				AgentsCovered: 1,
+				TotalTokenEst: 100,
+			},
+			wantAll: []string{
+				"Managed block footprint",
+				"claude-code",
+				"/home/user/.claude/CLAUDE.md",
+				"persona",
+				"10",
+				"400",
+				"100",
+				"TOTAL",
+			},
+		},
+		{
+			name: "absent instruction file gets a note",
+			summary: FootprintSummary{
+				Agents: []AgentFootprint{
+					{AgentID: "opencode", Path: "/home/user/.config/opencode/AGENTS.md", Present: false},
+				},
+			},
+			wantAll: []string{"opencode", "absent"},
+		},
+		{
+			name: "unresolved agent gets a note",
+			summary: FootprintSummary{
+				Agents: []AgentFootprint{
+					{AgentID: "unknown-agent", Unresolved: true},
+				},
+			},
+			wantAll: []string{"unknown-agent", "unresolved"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			renderFootprintDetail(&buf, tt.summary)
+			output := buf.String()
+			for _, want := range tt.wantAll {
+				if !strings.Contains(output, want) {
+					t.Errorf("expected output to contain %q, got:\n%s", want, output)
+				}
+			}
+		})
+	}
+}
+
+// --- RunDoctor --footprint integration ---
+
+func TestRunDoctor_FootprintFlag(t *testing.T) {
+	homeDir := t.TempDir()
+	setupFootprintSeams(t, homeDir)
+	writeDoctorState(t, homeDir, []string{"claude-code"})
+	reg, _ := footprintSubsetRegistry()
+	adapter, ok := reg.Get(model.AgentID("claude-code"))
+	if !ok {
+		t.Fatal("no adapter for claude-code in subset registry")
+	}
+	writeDoctorFixture(t, adapter.SystemPromptFile(homeDir), "<!-- gentle-ai:persona -->\nsome persona text\n<!-- /gentle-ai:persona -->\n")
+	setupRunDoctorMocks(t)
+
+	var withFlag bytes.Buffer
+	if err := RunDoctor(context.Background(), []string{"--footprint"}, &withFlag); err != nil {
+		t.Fatalf("RunDoctor returned error: %v", err)
+	}
+	withFlagOutput := withFlag.String()
+	if !strings.Contains(withFlagOutput, "managed:footprint") {
+		t.Error("expected compact managed:footprint line in output")
+	}
+	if !strings.Contains(withFlagOutput, "Managed block footprint") {
+		t.Error("expected detail table header when --footprint is set")
+	}
+	if !strings.Contains(withFlagOutput, "persona") {
+		t.Error("expected persona section id in detail table")
+	}
+
+	var withoutFlag bytes.Buffer
+	if err := RunDoctor(context.Background(), nil, &withoutFlag); err != nil {
+		t.Fatalf("RunDoctor returned error: %v", err)
+	}
+	withoutFlagOutput := withoutFlag.String()
+	if !strings.Contains(withoutFlagOutput, "managed:footprint") {
+		t.Error("expected compact managed:footprint line in output")
+	}
+	if strings.Contains(withoutFlagOutput, "Managed block footprint") {
+		t.Error("expected no detail table header without --footprint")
+	}
+}
+
+// --- safeCollectFootprint / panic isolation ---
+
+func TestRunDoctor_FootprintPanicIsRecoveredWithoutLosingOtherChecks(t *testing.T) {
+	setupRunDoctorMocks(t)
+	homeDir := t.TempDir()
+	origHomeDir := osUserHomeDirDoctor
+	origRegistry := newDoctorRegistry
+	t.Cleanup(func() {
+		osUserHomeDirDoctor = origHomeDir
+		newDoctorRegistry = origRegistry
+	})
+	osUserHomeDirDoctor = func() (string, error) { return homeDir, nil }
+	newDoctorRegistry = func() (*agents.Registry, error) {
+		panic("simulated footprint scan crash")
+	}
+
+	var buf bytes.Buffer
+	if err := RunDoctor(context.Background(), nil, &buf); err != nil {
+		t.Fatalf("RunDoctor returned error: %v", err)
+	}
+
+	output := buf.String()
+	for _, name := range []string{"tool:gentle-ai", "state:json", "engram:reachable", "disk:space"} {
+		if !strings.Contains(output, name) {
+			t.Errorf("expected other check %q to still appear after footprint panic, got:\n%s", name, output)
+		}
+	}
+	if !strings.Contains(output, "managed:footprint") {
+		t.Error("expected a managed:footprint entry explaining the recovery")
+	}
+	if !strings.Contains(output, "recovered") {
+		t.Error("expected footprint entry to explain the panic was recovered")
+	}
+}
+
+func TestRunDoctor_FootprintFlagSkipsDetailTableOnPanic(t *testing.T) {
+	setupRunDoctorMocks(t)
+	homeDir := t.TempDir()
+	origHomeDir := osUserHomeDirDoctor
+	origRegistry := newDoctorRegistry
+	t.Cleanup(func() {
+		osUserHomeDirDoctor = origHomeDir
+		newDoctorRegistry = origRegistry
+	})
+	osUserHomeDirDoctor = func() (string, error) { return homeDir, nil }
+	newDoctorRegistry = func() (*agents.Registry, error) {
+		panic("simulated footprint scan crash")
+	}
+
+	var buf bytes.Buffer
+	if err := RunDoctor(context.Background(), []string{"--footprint"}, &buf); err != nil {
+		t.Fatalf("RunDoctor returned error: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "recovered") {
+		t.Error("expected footprint entry to explain the panic was recovered")
+	}
+	if strings.Contains(output, "Managed block footprint") {
+		t.Error("expected the --footprint detail table to be skipped after a recovered panic, but it was rendered")
+	}
+}
+
+// --- RunDoctor overall status reflects a broken marker end-to-end ---
+
+func TestRunDoctor_FootprintFailureDegradesOverallStatus(t *testing.T) {
+	homeDir := t.TempDir()
+	setupFootprintSeams(t, homeDir)
+	writeDoctorState(t, homeDir, []string{"claude-code"})
+	reg, _ := footprintSubsetRegistry()
+	adapter, ok := reg.Get(model.AgentID("claude-code"))
+	if !ok {
+		t.Fatal("no adapter for claude-code in subset registry")
+	}
+	writeDoctorFixture(t, adapter.SystemPromptFile(homeDir), "<!-- gentle-ai:persona -->\nunclosed content\n")
+	setupRunDoctorMocks(t)
+
+	var buf bytes.Buffer
+	if err := RunDoctor(context.Background(), nil, &buf); err != nil {
+		t.Fatalf("RunDoctor returned error: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "managed:footprint") {
+		t.Error("expected managed:footprint check in output")
+	}
+	if !strings.Contains(output, "broken managed block marker") {
+		t.Errorf("expected the broken marker detail in output, got:\n%s", output)
+	}
+	if !strings.Contains(output, "Status:  unhealthy") {
+		t.Errorf("expected overall Status to flip to unhealthy from the broken marker, got:\n%s", output)
+	}
+}
+
+// --- RunDoctor --footprint on a genuinely fresh install (no state.json at all) ---
+
+func TestRunDoctor_FootprintFlagFreshInstallNoStateFile(t *testing.T) {
+	setupRunDoctorMocks(t)
+	homeDir := t.TempDir()
+	origHomeDir := osUserHomeDirDoctor
+	t.Cleanup(func() { osUserHomeDirDoctor = origHomeDir })
+	osUserHomeDirDoctor = func() (string, error) { return homeDir, nil }
+
+	var buf bytes.Buffer
+	if err := RunDoctor(context.Background(), []string{"--footprint"}, &buf); err != nil {
+		t.Fatalf("RunDoctor returned error: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "managed:footprint") {
+		t.Error("expected compact managed:footprint line in output")
+	}
+	if !strings.Contains(output, "state file not found") {
+		t.Error("expected footprint detail to explain the missing state file")
+	}
+	if !strings.Contains(output, "Managed block footprint") {
+		t.Error("expected detail table header when --footprint is set")
+	}
+	if strings.Contains(output, "<nil>") || strings.Contains(output, "panic") {
+		t.Errorf("expected no garbage/panic output in the detail table, got:\n%s", output)
+	}
+	if !strings.Contains(output, "TOTAL") {
+		t.Error("expected a well-formed TOTAL line even with zero agents scanned")
 	}
 }

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -10,6 +10,11 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/gentleman-programming/gentle-ai/internal/agents"
+	"github.com/gentleman-programming/gentle-ai/internal/agents/claude"
+	"github.com/gentleman-programming/gentle-ai/internal/agents/opencode"
+	"github.com/gentleman-programming/gentle-ai/internal/model"
 )
 
 // --- checkOneTool ---
@@ -498,5 +503,274 @@ func TestRunDoctor_HomeDirError(t *testing.T) {
 	err := RunDoctor(context.Background(), &buf)
 	if err == nil {
 		t.Error("expected error when home dir fails")
+	}
+}
+
+// --- estimateTokens ---
+
+func TestEstimateTokens(t *testing.T) {
+	tests := []struct {
+		name  string
+		chars int
+		want  int
+	}{
+		{name: "zero chars", chars: 0, want: 0},
+		{name: "exact multiple of four", chars: 400, want: 100},
+		{name: "non-multiple rounds down", chars: 10, want: 2},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := estimateTokens(tt.chars)
+			if got != tt.want {
+				t.Errorf("estimateTokens(%d) = %d, want %d", tt.chars, got, tt.want)
+			}
+		})
+	}
+}
+
+// --- collectFootprint / footprintCheckResult ---
+
+func footprintSubsetRegistry() (*agents.Registry, error) {
+	return agents.NewRegistry(claude.NewAdapter(), opencode.NewAdapter())
+}
+
+func writeDoctorState(t *testing.T, homeDir string, agentIDs []string) {
+	t.Helper()
+	stateDir := filepath.Join(homeDir, ".gentle-ai")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	quoted := make([]string, len(agentIDs))
+	for i, id := range agentIDs {
+		quoted[i] = `"` + id + `"`
+	}
+	payload := `{"installed_agents":[` + strings.Join(quoted, ",") + `]}`
+	if err := os.WriteFile(filepath.Join(stateDir, "state.json"), []byte(payload), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeDoctorFixture(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func setupFootprintSeams(t *testing.T, homeDir string) {
+	t.Helper()
+	origHome := osUserHomeDirDoctor
+	origRegistry := newDoctorRegistry
+	t.Cleanup(func() {
+		osUserHomeDirDoctor = origHome
+		newDoctorRegistry = origRegistry
+	})
+	osUserHomeDirDoctor = func() (string, error) { return homeDir, nil }
+	newDoctorRegistry = footprintSubsetRegistry
+}
+
+func TestCollectFootprint(t *testing.T) {
+	tests := []struct {
+		name       string
+		agentIDs   []string // nil skips writing state.json entirely
+		fixtures   map[string]string
+		wantStatus CheckStatus
+		check      func(t *testing.T, sum FootprintSummary, result CheckResult)
+	}{
+		{
+			name:     "healthy two agents",
+			agentIDs: []string{"claude-code", "opencode"},
+			fixtures: map[string]string{
+				"claude-code": "<!-- gentle-ai:persona -->\nsome persona text\n<!-- /gentle-ai:persona -->\n",
+				"opencode":    "<!-- gentle-ai:engram-protocol -->\nprotocol text here\n<!-- /gentle-ai:engram-protocol -->\n",
+			},
+			wantStatus: CheckStatusPass,
+			check: func(t *testing.T, sum FootprintSummary, result CheckResult) {
+				if sum.TotalBlocks != 2 || sum.AgentsCovered != 2 {
+					t.Fatalf("expected 2 blocks across 2 agents, got %d/%d", sum.TotalBlocks, sum.AgentsCovered)
+				}
+				if sum.HasFail || sum.HasWarn {
+					t.Fatalf("expected no anomalies, got HasFail=%v HasWarn=%v", sum.HasFail, sum.HasWarn)
+				}
+				if !strings.Contains(result.Detail, "2 block") {
+					t.Errorf("expected detail to mention block count, got %q", result.Detail)
+				}
+			},
+		},
+		{
+			name:       "orphan open fails",
+			agentIDs:   []string{"claude-code"},
+			fixtures:   map[string]string{"claude-code": "<!-- gentle-ai:persona -->\nunclosed content\n"},
+			wantStatus: CheckStatusFail,
+			check: func(t *testing.T, sum FootprintSummary, result CheckResult) {
+				if !sum.HasFail {
+					t.Fatal("expected HasFail true for unclosed marker")
+				}
+				if !strings.Contains(result.Detail, "claude-code") || !strings.Contains(result.Detail, "persona") {
+					t.Errorf("expected detail to name agent and section id, got %q", result.Detail)
+				}
+				if result.Remedy == "" {
+					t.Error("expected non-empty remedy")
+				}
+			},
+		},
+		{
+			name:       "mismatch anomaly fails",
+			agentIDs:   []string{"claude-code"},
+			fixtures:   map[string]string{"claude-code": "<!-- gentle-ai:persona -->\ncontent\n<!-- /gentle-ai:other -->\n"},
+			wantStatus: CheckStatusFail,
+			check: func(t *testing.T, sum FootprintSummary, result CheckResult) {
+				if !sum.HasFail {
+					t.Fatal("expected HasFail true for id mismatch")
+				}
+				if !strings.Contains(result.Detail, "claude-code") || !strings.Contains(result.Detail, "other") {
+					t.Errorf("expected detail to name agent and the offending closer id, got %q", result.Detail)
+				}
+				if result.Remedy == "" {
+					t.Error("expected non-empty remedy")
+				}
+			},
+		},
+		{
+			name:       "stray closer warns",
+			agentIDs:   []string{"claude-code"},
+			fixtures:   map[string]string{"claude-code": "<!-- /gentle-ai:persona -->\nsome text\n"},
+			wantStatus: CheckStatusWarn,
+			check: func(t *testing.T, sum FootprintSummary, result CheckResult) {
+				if sum.HasFail {
+					t.Fatal("expected HasFail false for stray closer")
+				}
+				if !sum.HasWarn {
+					t.Fatal("expected HasWarn true for stray closer")
+				}
+			},
+		},
+		{
+			name:       "state missing",
+			wantStatus: CheckStatusWarn,
+			check: func(t *testing.T, sum FootprintSummary, result CheckResult) {
+				if !sum.StateMissing {
+					t.Fatal("expected StateMissing true")
+				}
+				if !strings.Contains(result.Remedy, "install") {
+					t.Errorf("expected install remedy, got %q", result.Remedy)
+				}
+			},
+		},
+		{
+			name:       "no agents",
+			agentIDs:   []string{},
+			wantStatus: CheckStatusWarn,
+			check: func(t *testing.T, sum FootprintSummary, result CheckResult) {
+				if !sum.NoAgents {
+					t.Fatal("expected NoAgents true")
+				}
+			},
+		},
+		{
+			name:       "unresolved agent is tracked but not scanned",
+			agentIDs:   []string{"unknown-agent"},
+			wantStatus: CheckStatusPass,
+			check: func(t *testing.T, sum FootprintSummary, result CheckResult) {
+				if len(sum.Agents) != 1 || !sum.Agents[0].Unresolved {
+					t.Fatalf("expected 1 unresolved agent entry, got %+v", sum.Agents)
+				}
+				if sum.AgentsCovered != 0 {
+					t.Errorf("expected unresolved agent not counted in AgentsCovered, got %d", sum.AgentsCovered)
+				}
+			},
+		},
+		{
+			name:       "absent instruction file is informational",
+			agentIDs:   []string{"claude-code"},
+			wantStatus: CheckStatusPass,
+			check: func(t *testing.T, sum FootprintSummary, result CheckResult) {
+				if len(sum.Agents) != 1 || sum.Agents[0].Present {
+					t.Fatalf("expected Present false when instruction file is absent, got %+v", sum.Agents)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			homeDir := t.TempDir()
+			setupFootprintSeams(t, homeDir)
+			if tt.agentIDs != nil {
+				writeDoctorState(t, homeDir, tt.agentIDs)
+			}
+			reg, _ := footprintSubsetRegistry()
+			for id, content := range tt.fixtures {
+				adapter, ok := reg.Get(model.AgentID(id))
+				if !ok {
+					t.Fatalf("no adapter for %q in subset registry", id)
+				}
+				writeDoctorFixture(t, adapter.SystemPromptFile(homeDir), content)
+			}
+
+			sum := collectFootprint(homeDir)
+			result := footprintCheckResult(sum)
+			if result.Status != tt.wantStatus {
+				t.Fatalf("expected status %s, got %s: %s", tt.wantStatus, result.Status, result.Detail)
+			}
+			tt.check(t, sum, result)
+		})
+	}
+}
+
+func TestCollectFootprint_MalformedStateJSONIsNotConflatedWithEmptyAgents(t *testing.T) {
+	homeDir := t.TempDir()
+	setupFootprintSeams(t, homeDir)
+	stateDir := filepath.Join(homeDir, ".gentle-ai")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "state.json"), []byte("not-json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	sum := collectFootprint(homeDir)
+	result := footprintCheckResult(sum)
+
+	if !sum.StateUnreadable {
+		t.Fatal("expected StateUnreadable true for malformed state.json")
+	}
+	if sum.NoAgents {
+		t.Fatal("expected NoAgents false for malformed state.json — must not conflate a corrupt state file with a genuinely empty agent list")
+	}
+	if result.Status != CheckStatusFail {
+		t.Errorf("expected Fail status for malformed state.json (mirroring checkStateJSON's severity), got %s", result.Status)
+	}
+	if strings.Contains(result.Detail, "no installed agents") {
+		t.Errorf("malformed state.json must not reuse the NoAgents wording, got detail=%q", result.Detail)
+	}
+	if result.Remedy == "Run 'gentle-ai install' to configure agents" {
+		t.Errorf("malformed state.json must not reuse the NoAgents remedy verbatim, got remedy=%q", result.Remedy)
+	}
+}
+
+func TestCollectFootprint_RegistryConstructionFailureIsWarnNotNoAgents(t *testing.T) {
+	homeDir := t.TempDir()
+	origRegistry := newDoctorRegistry
+	t.Cleanup(func() { newDoctorRegistry = origRegistry })
+	newDoctorRegistry = func() (*agents.Registry, error) {
+		return nil, errors.New("registry construction failed")
+	}
+
+	sum := collectFootprint(homeDir)
+	result := footprintCheckResult(sum)
+
+	if !sum.RegistryUnavailable {
+		t.Fatal("expected RegistryUnavailable true when newDoctorRegistry fails")
+	}
+	if sum.NoAgents {
+		t.Fatal("expected NoAgents false when registry construction fails")
+	}
+	if result.Status != CheckStatusWarn {
+		t.Errorf("expected Warn status for registry construction failure, got %s", result.Status)
 	}
 }

--- a/internal/components/filemerge/section_scan.go
+++ b/internal/components/filemerge/section_scan.go
@@ -1,0 +1,110 @@
+package filemerge
+
+import "strings"
+
+// Section is one matched gentle-ai marker pair.
+type Section struct {
+	ID        string // marker id, e.g. "persona" (never a whitelist — whatever the file contains)
+	Content   string // raw text between open and close markers, markers excluded
+	StartLine int    // 1-based line number of the opening marker
+	EndLine   int    // 1-based line number of the closing marker
+	CharCount int    // len(Content) in bytes
+	LineCount int    // number of content lines (0 when Content == "")
+}
+
+// AnomalyKind classifies a structural marker defect.
+type AnomalyKind string
+
+const (
+	AnomalyOrphanOpen  AnomalyKind = "orphan-open"  // opener with no matching closer (unbounded block)
+	AnomalyOrphanClose AnomalyKind = "orphan-close" // closer with no preceding opener
+	AnomalyMismatch    AnomalyKind = "mismatch"     // closer id != currently-open id
+)
+
+// Anomaly is a structural marker defect surfaced by ScanSections.
+type Anomaly struct {
+	Kind AnomalyKind
+	ID   string // id on the offending marker
+	Line int    // 1-based line of the offending marker
+}
+
+// ScanResult is the full outcome of one pass over a markdown file.
+type ScanResult struct {
+	Sections  []Section
+	Anomalies []Anomaly
+}
+
+// ScanSections finds every <!-- gentle-ai:ID --> ... <!-- /gentle-ai:ID --> pair
+// in content, generically (no id whitelist), plus any structural anomalies.
+func ScanSections(content string) ScanResult {
+	var result ScanResult
+
+	var (
+		openActive   bool
+		openID       string
+		openLine     int
+		contentLines []string
+	)
+
+	lines := strings.Split(content, "\n")
+	for i, raw := range lines {
+		lineNum := i + 1
+		line := strings.TrimSuffix(raw, "\r")
+		trimmed := strings.TrimSpace(line)
+
+		switch {
+		case strings.HasPrefix(trimmed, closePrefix) && strings.HasSuffix(trimmed, markerSuffix):
+			id := strings.TrimSuffix(strings.TrimPrefix(trimmed, closePrefix), markerSuffix)
+			switch {
+			case !openActive:
+				// No opener is active: this closer has nothing to pair with.
+				result.Anomalies = append(result.Anomalies, Anomaly{Kind: AnomalyOrphanClose, ID: id, Line: lineNum})
+			case id != openID:
+				// Closer id doesn't match the active opener: report only the
+				// mismatch (not a second AnomalyOrphanOpen for the discarded
+				// opener) and drop the open context so scanning resumes clean
+				// from the next marker — a single anomaly per malformed event.
+				result.Anomalies = append(result.Anomalies, Anomaly{Kind: AnomalyMismatch, ID: id, Line: lineNum})
+				openActive = false
+				contentLines = nil
+			default:
+				sectionContent := strings.Join(contentLines, "\n")
+				lineCount := 0
+				if sectionContent != "" {
+					lineCount = strings.Count(sectionContent, "\n") + 1
+				}
+				result.Sections = append(result.Sections, Section{
+					ID:        openID,
+					Content:   sectionContent,
+					StartLine: openLine,
+					EndLine:   lineNum,
+					CharCount: len(sectionContent),
+					LineCount: lineCount,
+				})
+				openActive = false
+				contentLines = nil
+			}
+
+		case strings.HasPrefix(trimmed, markerPrefix) && strings.HasSuffix(trimmed, markerSuffix):
+			id := strings.TrimSuffix(strings.TrimPrefix(trimmed, markerPrefix), markerSuffix)
+			if openActive {
+				result.Anomalies = append(result.Anomalies, Anomaly{Kind: AnomalyOrphanOpen, ID: openID, Line: openLine})
+			}
+			openActive = true
+			openID = id
+			openLine = lineNum
+			contentLines = nil
+
+		default:
+			if openActive {
+				contentLines = append(contentLines, line)
+			}
+		}
+	}
+
+	if openActive {
+		result.Anomalies = append(result.Anomalies, Anomaly{Kind: AnomalyOrphanOpen, ID: openID, Line: openLine})
+	}
+
+	return result
+}

--- a/internal/components/filemerge/section_scan_test.go
+++ b/internal/components/filemerge/section_scan_test.go
@@ -1,0 +1,103 @@
+package filemerge
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestScanSections(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         string
+		wantSections  []Section
+		wantAnomalies []Anomaly
+	}{
+		{
+			name:  "single well-formed block",
+			input: "before\n<!-- gentle-ai:persona -->\nHello\nWorld\n<!-- /gentle-ai:persona -->\nafter\n",
+			wantSections: []Section{
+				{ID: "persona", Content: "Hello\nWorld", StartLine: 2, EndLine: 5, CharCount: 11, LineCount: 2},
+			},
+		},
+		{
+			name: "multiple distinct blocks in one file",
+			input: "<!-- gentle-ai:persona -->\nP body\n<!-- /gentle-ai:persona -->\n\n" +
+				"<!-- gentle-ai:engram-protocol -->\nE body\n<!-- /gentle-ai:engram-protocol -->\n\n" +
+				"<!-- gentle-ai:strict-tdd-mode -->\nT body\n<!-- /gentle-ai:strict-tdd-mode -->\n",
+			wantSections: []Section{
+				{ID: "persona", Content: "P body", StartLine: 1, EndLine: 3, CharCount: 6, LineCount: 1},
+				{ID: "engram-protocol", Content: "E body", StartLine: 5, EndLine: 7, CharCount: 6, LineCount: 1},
+				{ID: "strict-tdd-mode", Content: "T body", StartLine: 9, EndLine: 11, CharCount: 6, LineCount: 1},
+			},
+		},
+		{
+			name:  "empty-content block",
+			input: "<!-- gentle-ai:empty -->\n<!-- /gentle-ai:empty -->\n",
+			wantSections: []Section{
+				{ID: "empty", Content: "", StartLine: 1, EndLine: 2, CharCount: 0, LineCount: 0},
+			},
+		},
+		{
+			name:  "unclosed opener at EOF",
+			input: "<!-- gentle-ai:orphan -->\nsome content\n",
+			wantAnomalies: []Anomaly{
+				{Kind: AnomalyOrphanOpen, ID: "orphan", Line: 1},
+			},
+		},
+		{
+			name:  "stray closer with no opener",
+			input: "before\n<!-- /gentle-ai:stray -->\nafter\n",
+			wantAnomalies: []Anomaly{
+				{Kind: AnomalyOrphanClose, ID: "stray", Line: 2},
+			},
+		},
+		{
+			name:  "closer id mismatch with opener id",
+			input: "<!-- gentle-ai:a -->\ncontent\n<!-- /gentle-ai:b -->\nafter\n",
+			wantAnomalies: []Anomaly{
+				{Kind: AnomalyMismatch, ID: "b", Line: 3},
+			},
+		},
+		{
+			name: "mismatch discards stale opener then resumes cleanly on next block",
+			input: "<!-- gentle-ai:a -->\nstale\n<!-- /gentle-ai:b -->\n" +
+				"<!-- gentle-ai:c -->\nclean\n<!-- /gentle-ai:c -->\n",
+			wantSections: []Section{
+				{ID: "c", Content: "clean", StartLine: 4, EndLine: 6, CharCount: 5, LineCount: 1},
+			},
+			wantAnomalies: []Anomaly{
+				{Kind: AnomalyMismatch, ID: "b", Line: 3},
+			},
+		},
+		{
+			name:  "unknown novel id measured like any other",
+			input: "<!-- gentle-ai:brand-new-block -->\nnovel content\n<!-- /gentle-ai:brand-new-block -->\n",
+			wantSections: []Section{
+				{ID: "brand-new-block", Content: "novel content", StartLine: 1, EndLine: 3, CharCount: 13, LineCount: 1},
+			},
+		},
+		{
+			name:  "markers with leading indentation and trailing CR",
+			input: "  <!-- gentle-ai:indented -->\r\ncontent line\r\n  <!-- /gentle-ai:indented -->\r\n",
+			wantSections: []Section{
+				{ID: "indented", Content: "content line", StartLine: 1, EndLine: 3, CharCount: 12, LineCount: 1},
+			},
+		},
+		{
+			name:  "file with zero markers",
+			input: "just some text\nno markers at all\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ScanSections(tt.input)
+			if !reflect.DeepEqual(got.Sections, tt.wantSections) {
+				t.Fatalf("Sections mismatch:\ngot:  %+v\nwant: %+v", got.Sections, tt.wantSections)
+			}
+			if !reflect.DeepEqual(got.Anomalies, tt.wantAnomalies) {
+				t.Fatalf("Anomalies mismatch:\ngot:  %+v\nwant: %+v", got.Anomalies, tt.wantAnomalies)
+			}
+		})
+	}
+}

--- a/openspec/changes/doctor-footprint/apply-progress.md
+++ b/openspec/changes/doctor-footprint/apply-progress.md
@@ -1,0 +1,35 @@
+# Apply Progress: doctor-footprint
+
+## Status
+
+- **WU1 (Phase 1 — Generic Section Scanner)**: DONE. This is PR 1 of the stacked chain.
+- **WU2+WU3 (Phase 2 — Token helper + collector/classifier)**: NOT STARTED. Next batch, on a new branch off `feat/doctor-footprint-scanner`.
+- **WU4 (Phase 3 — flag + `RunDoctor` signature migration)**: NOT STARTED.
+- **WU5 (Phase 4 — `renderFootprintDetail`)**: NOT STARTED.
+- **WU6 (Phase 5 — integration test + full verification)**: NOT STARTED.
+
+## What was implemented (WU1, this batch)
+
+- `internal/components/filemerge/section_scan.go` — `Section`, `AnomalyKind`, `Anomaly`, `ScanResult` types and `ScanSections(content string) ScanResult`, per design.md §2's exact 4-step line-based single-pass algorithm. Reuses existing `markerPrefix`/`markerSuffix`/`closePrefix` constants from `section.go` (no redefinition).
+- `internal/components/filemerge/section_scan_test.go` — `TestScanSections`, table-driven, 9 cases matching design.md §8.1 and tasks.md 1.1 exactly: single well-formed block, multi-block, empty-content block, unclosed opener at EOF (`AnomalyOrphanOpen`), stray closer with no opener (`AnomalyOrphanClose`), id mismatch (`AnomalyMismatch`), novel/unknown id (genericity proof, no whitelist), leading indentation + trailing `\r`, zero markers.
+
+## Scope discipline
+
+Touched ONLY `internal/components/filemerge/`. Did NOT touch `internal/cli/doctor.go`, `internal/app/app.go`, or anything else — those are WU2/WU3 (PR2) and WU4/WU5/WU6 (PR3), reserved for future branches per the stacked-PRs delivery strategy.
+
+## Verification run
+
+- `go test ./internal/components/filemerge/... -v` — all tests pass, including pre-existing suite (safety net, no regressions).
+- `go vet ./internal/components/filemerge/...` — clean.
+- `gofmt -l internal/components/filemerge/section_scan.go internal/components/filemerge/section_scan_test.go` — clean (not in the repo-wide `gofmt -l .` unformatted list).
+- `go test ./...` (full repo) — `internal/components/filemerge` passes (cached ok). Failures present in `internal/components/engram`, `internal/components/gga`, `internal/components/permissions`, `internal/components/sdd`, `internal/components/uninstall`, `internal/tui`, `internal/update/upgrade` are PRE-EXISTING and environment-specific (Windows symlink privilege errors, `TempDir` cleanup lock contention, network/install-script mocking) — none touch any file this PR modified, and this PR adds only new, unreferenced exported symbols (nothing outside `filemerge` imports them yet). Not introduced by WU1.
+
+## Next steps (WU2 — new branch off this one)
+
+Per design.md §3-4 and tasks.md Phase 2:
+1. `estimateTokens(chars int) int` in `internal/cli/doctor.go`.
+2. New seam `var newDoctorRegistry = agents.NewDefaultRegistry`.
+3. `AgentFootprint` / `FootprintSummary` structs.
+4. `collectFootprint(homeDir string) FootprintSummary` — consumes `filemerge.ScanSections` from this PR.
+5. `footprintCheckResult(sum FootprintSummary) CheckResult`.
+6. RED tests first: `TestCollectFootprint` / `TestFootprintCheckResult`, 7 cases per design.md §8.2.


### PR DESCRIPTION
<!-- ⚠️ READ BEFORE SUBMITTING
  Every PR must be linked to an issue that has the "status:approved" label.
  PRs without a linked approved issue will be automatically rejected by CI.
  See CONTRIBUTING.md for the full contribution workflow.
-->

## 🔗 Linked Issue

Closes #1018

<!-- Replace the # above with the issue number, e.g.: Closes #42 -->

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [ ] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [x] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking chanes existing behavior)

---

## 📝 Summary

Adds doctor's first CLI flag (`--footprint`)ept `args`, and wires`collectFootprint`/`footprintCheckResult` (from PR 2) into the live check list for the first time. Adds `renderFootprintDetail` for the opt-in per-agent/per-block table. Also adds `safeCollectFootprint`, a panic-recovery wrapper, since this is the first PR where ths as part of a live `RunDoctor` call — a
## 🔗 Linked Issue

Closes #1018

<!-- Replace the # above with the issue number, e.g.: Closes #42 -->

---

## 🏷️ PR Type

What kind of change does this PR introduce?
## 🏷️ PR Type

What kind of change does this PR introduce?

- [ ] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [x] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling c
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

Adds doctor's first CLI flag (`--footprint`), migrates `RunDoctor` to accept `args`, and wires `collectFootprint`/`footprintCheckResult` (from PR 2) into the live check list for the first time. Adds `renderFootprintDetail` for the opt-in per-agent/per-block table. Also adds `safeCollectFootprint`, a panic-recovery
wrapper, since this is the first PR where ths as part of a live `RunDoctor` call — a
nal PR of the stacked chain (scanner → check → this).

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/cli/doctor.go` | `DoctorFlags`/`ParseDoctorFlags`, `PrintDoctorHelp`, `RunDoctor` signature migration + live wiring + `--help` handling, `safeCollectFootprint`, `renderFootprintDetail`/`renderAgentFootprint` |
| `internal/cli/doctor_test.go` | `TestParseDoctorFlags` (incl. `--help`/`-h` cases), `TestRunDoctor_HelpFlagPrintsUsageWithoutError`, `TestRenderFootprintDetail`, `TestRunDoctor_FootprintFlag`, `TestRunDoctor_FootprintPanicIsRecoveredWithoutLosingOtherChecks`,
`TestRunDoctor_FootprintFailureDegradesOveratprintFlagFreshInstallNoStateFile`; migrated2 existing `RunDoctor` call sites to the new signature |
| `internal/app/app.go` | `case "doctor"` caRunDoctor(ctx, args, w)` signature |

---

## 🧪 Test Plan

**Unit Tests**re merge
- [x] go build ./..., go vet ./..., gofmt -l clean

---
🤖 Automated Checks

┌─────────────────────────────┬────────┬──────────────────────────────────────────────────────────────────────────┐
│            Check            │ Status │                               Description                                │
├─────────────────────────────┼────────┼──────────────────────────────────────────────────────────────────────────┤
│ Check PR Cognitive Load     │ ⏳     │ PR should stay within 400 changed lines (additions + deletions) or use   │
│                             │        │ size:exception                                                           │
├─────────────────────────────┼────────┼──────────────────────────────────────────────────────────────────────────┤
│ Check Issue Reference       │ ⏳     │ PR body must contain Closes/Fixes/Resolves #N                            │
├─────────────────────────────┼────────┼─────────────────────────────────────────────┤
roved             │        │                                                                          │
├─────────────────────────────┼────────┼──────────────────────────────────────────────────────────────────────────┤
│ Check PR Has type:* Label   │ ⏳     │ Exactly one type:* label must be applied                                 │
├─────────────────────────────┼────────┼──────────────────────────────────────────────────────────────────────────┤
│ Unit Tests                  │ ⏳     │ go test ./... must pass                                                  │
├─────────────────────────────┼────────┼──────────────────────────────────────────────────────────────────────────┤
│ E2E Tests                   │ ⏳     │ cd e2e && ./docker-test.sh must pass                                     │
└─────────────────────────────┴────────┴──────────────────────────────────────────────────────────────────────────┘

---
✅ Contributor Checklist

- [x] PR is linked to an issue with status:approved
- [ ] PR stays within 400 changed lines, or ntainer-applied size:exception with rationale documented (411 lines — see note below)
- [ ] I have added the appropriate type:* label to this PR
- [x] Unit tests pass (go test ./...)                                                                           - [ ] E2E tests pass (cd e2e && ./docker-tes
- [x] I have updated documentation if necessary
- [x] My commits follow Conventional Commits format
- [x] My commits do not include Co-Authored-By trailers

---
💬 Notes for Reviewers

This is 3 of 3 (final) stacked PRs toward issue #1018. Base this PR against PR 2 (feat/doctor-footprint-check) until it merges, then retarget to main.
                                                                                                                This PR previously carried a duplicate copy hat actually belongs to PR 2 (wherecollectFootprint is defined) — moved it there after review, which brought this PR from 463 down to 379 lines. A follow-up CodeRabbit finding (--help handling) added 32 lines back, landing at 411 — 11 over budget. Requesting size:exception: this is marginal (2.75% overviewer-requested fix plus its test, not scope creep; trimming further would mean cutting real test coverage for a one-off 11 lines.

⚠️ GitHub UI note: this PR's diff currently shows as +1096 -4 because PR 1 and PR 2 haven't merged into main yet — the diff against main necessarily includes their commits too, since this branch is stacked on top of them. This PR's actual own diff is the 411 lines above (git diff against PR 2's branch tip). Once PR 1 and PR 2 merge, the diff on this PR will automatically shrink to just its own changes.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `doctor --footprint` to show a detailed managed-footprint breakdown per installed agent and block.
  * The `doctor` report now always includes a managed-footprint check, with richer detail available via `--footprint`.

* **Bug Fixes**
  * Improved `doctor` command argument handling so `doctor --help` reliably prints doctor-specific help and rejects unexpected input.
  * Footprint scanning is more resilient: panics are recovered and other diagnostics still appear; overall health degrades appropriately when footprint markers are broken.

* **Improvements**
  * Enhanced marker-based section detection for extracting and validating marked content blocks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->