### PR TITLE
fix(engram): ensure saving to memory never replaces the user reply

### DIFF
--- a/internal/assets/engram/protocol.md
+++ b/internal/assets/engram/protocol.md
@@ -22,6 +22,16 @@ Call `mem_save` IMMEDIATELY and WITHOUT BEING ASKED after any of these:
 
 Self-check after EVERY task: "Did I make a decision, fix a bug, learn something non-obvious, or establish a convention? If yes, call mem_save NOW."
 
+### DELIVERY GUARANTEE — saving is not replying
+
+Saving to memory is internal bookkeeping. It NEVER counts as answering the user, and the user never sees your tool calls or the content you store.
+
+- If the answer exists only inside a `mem_save`, the user never received it. Saving is not replying.
+- End every turn with your complete user-facing answer as the final message, with NO tool calls after it.
+- Save memory BEFORE composing that final answer, not after. Never let a `mem_save`/`mem_judge` be the last action in a turn that still owed the user a substantive reply.
+- If a memory chain (`mem_save` → `mem_judge`) ran late, still write the full answer in that final message — do not collapse it into a one-line "saved / done" acknowledgement.
+- Never treat the text you stored in memory as the text you delivered: memory is for your future self, the reply is for the user.
+
 Format for `mem_save`:
 - **title**: Verb + what — short, searchable (e.g. "Fixed N+1 query in UserList")
 - **type**: bugfix | decision | architecture | discovery | pattern | config | preference
@@ -114,6 +124,10 @@ MCP server instructions and the SessionStart hook. Always-on rules:
   automated/SDD artifacts.
 - On any reference to past work: `mem_context` → `mem_search` → `mem_get_observation`.
 - Before saying "done", call `mem_session_summary`.
+- Saving to memory is bookkeeping, never the reply: it NEVER counts as answering.
+  End every turn with the complete user-facing answer as the final message (no
+  tool calls after it), and save memory before composing it — never collapse the
+  answer into a "saved / done" acknowledgement.
 <!-- /section:slim -->
 
 <!-- section:passive-capture -->

--- a/internal/assets/engram/protocol.md
+++ b/internal/assets/engram/protocol.md
@@ -30,6 +30,7 @@ Saving to memory is internal bookkeeping. It NEVER counts as answering the user,
 - End every turn with your complete user-facing answer as the final message, with NO tool calls after it.
 - Save memory BEFORE composing that final answer, not after. Never let a `mem_save`/`mem_judge` be the last action in a turn that still owed the user a substantive reply.
 - If a memory chain (`mem_save` → `mem_judge`) ran late, still write the full answer in that final message — do not collapse it into a one-line "saved / done" acknowledgement.
+- If a memory call (`mem_save`, `mem_judge`, `mem_session_summary`) fails or times out, deliver the complete answer anyway and note the failure briefly — a failed or slow memory operation never blocks, truncates, or replaces the reply.
 - Never treat the text you stored in memory as the text you delivered: memory is for your future self, the reply is for the user.
 
 Format for `mem_save`:
@@ -128,6 +129,8 @@ MCP server instructions and the SessionStart hook. Always-on rules:
   End every turn with the complete user-facing answer as the final message (no
   tool calls after it), and save memory before composing it — never collapse the
   answer into a "saved / done" acknowledgement.
+- If a memory call fails or times out, deliver the answer anyway — memory
+  failures never block or replace the reply.
 <!-- /section:slim -->
 
 <!-- section:passive-capture -->

--- a/internal/components/delivery_guarantee_installed_test.go
+++ b/internal/components/delivery_guarantee_installed_test.go
@@ -1,0 +1,94 @@
+package components_test
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/internal/components/engram"
+)
+
+// deliveryGuaranteePhrases are the semantic rules that every installed
+// protocol output must state so memory bookkeeping can never replace the
+// final user-facing reply — including when a memory call fails or times out
+// (issue #1042 acceptance scope). Matching is done on whitespace-normalized,
+// lowercased content so the assertions survive reformatting and line wraps,
+// unlike golden byte-equality.
+var deliveryGuaranteePhrases = []struct {
+	name   string
+	phrase string
+}{
+	{"memory-is-bookkeeping", "bookkeeping"},
+	{"saving-never-counts-as-answering", "never counts as answering"},
+	{"turn-ends-with-answer-as-final-message", "final message"},
+	{"save-before-composing-the-reply", "before composing"},
+	{"covers-memory-call-failure-and-timeout", "fails or times out"},
+	{"failure-still-delivers-the-answer", "answer anyway"},
+}
+
+func assertDeliveryGuarantee(t *testing.T, surface string, content []byte) {
+	t.Helper()
+	normalized := strings.ToLower(strings.Join(strings.Fields(string(content)), " "))
+	for _, inv := range deliveryGuaranteePhrases {
+		if !strings.Contains(normalized, inv.phrase) {
+			t.Errorf("installed output %q violates delivery-guarantee invariant %q: missing phrase %q", surface, inv.name, inv.phrase)
+		}
+	}
+}
+
+// TestDeliveryGuarantee_InstalledOutputs runs the real injection into a temp
+// home and asserts the delivery-guarantee semantics on representative
+// installed outputs, one per protocol variant:
+//   - Claude Code CLAUDE.md — slim section (engram version above the
+//     Decision 1 floor, the surface where the bug was reproduced)
+//   - Antigravity GEMINI.md — full section
+//   - Codex engram-instructions.md — full + passive-capture concatenation
+func TestDeliveryGuarantee_InstalledOutputs(t *testing.T) {
+	t.Run("claude-slim", func(t *testing.T) {
+		home := t.TempDir()
+		engram.SetLookPathForTest(t, "/opt/homebrew/bin/engram", "")
+
+		result, err := engram.InjectWithOptions(home, claudeAdapter(), engram.InjectOptions{Version: "1.18.0"})
+		if err != nil {
+			t.Fatalf("engram.InjectWithOptions(claude) error = %v", err)
+		}
+		if !result.Changed {
+			t.Fatal("engram.InjectWithOptions(claude) changed = false")
+		}
+
+		claudeMD := readTestFile(t, filepath.Join(home, ".claude", "CLAUDE.md"))
+		assertDeliveryGuarantee(t, "claude CLAUDE.md (slim)", claudeMD)
+	})
+
+	t.Run("antigravity-full", func(t *testing.T) {
+		home := t.TempDir()
+		engram.SetLookPathForTest(t, "/opt/homebrew/bin/engram", "")
+
+		result, err := engram.Inject(home, antigravityAdapter())
+		if err != nil {
+			t.Fatalf("engram.Inject(antigravity) error = %v", err)
+		}
+		if !result.Changed {
+			t.Fatal("engram.Inject(antigravity) changed = false")
+		}
+
+		rulesFile := readTestFile(t, filepath.Join(home, ".gemini", "GEMINI.md"))
+		assertDeliveryGuarantee(t, "antigravity GEMINI.md (full)", rulesFile)
+	})
+
+	t.Run("codex-instructions", func(t *testing.T) {
+		home := t.TempDir()
+		engram.SetLookPathForTest(t, "/opt/homebrew/bin/engram", "")
+
+		result, err := engram.Inject(home, codexAdapter())
+		if err != nil {
+			t.Fatalf("engram.Inject(codex) error = %v", err)
+		}
+		if !result.Changed {
+			t.Fatal("engram.Inject(codex) changed = false")
+		}
+
+		instructions := readTestFile(t, filepath.Join(home, ".codex", "engram-instructions.md"))
+		assertDeliveryGuarantee(t, "codex engram-instructions.md (full+passive-capture)", instructions)
+	})
+}

--- a/internal/components/delivery_guarantee_installed_test.go
+++ b/internal/components/delivery_guarantee_installed_test.go
@@ -8,31 +8,75 @@ import (
 	"github.com/gentleman-programming/gentle-ai/internal/components/engram"
 )
 
-// deliveryGuaranteePhrases are the semantic rules that every installed
-// protocol output must state so memory bookkeeping can never replace the
-// final user-facing reply — including when a memory call fails or times out
-// (issue #1042 acceptance scope). Matching is done on whitespace-normalized,
-// lowercased content so the assertions survive reformatting and line wraps,
-// unlike golden byte-equality.
-var deliveryGuaranteePhrases = []struct {
+type installedDeliveryGuaranteeInvariant struct {
 	name   string
 	phrase string
-}{
+}
+
+// deliveryGuaranteePhrases are the common semantic rules that every installed
+// protocol output must state so memory bookkeeping can never replace the final
+// user-facing reply (issue #1042 acceptance scope). Matching is done on
+// whitespace-normalized, lowercased content so assertions survive reformatting
+// and line wraps, unlike golden byte-equality.
+var deliveryGuaranteePhrases = []installedDeliveryGuaranteeInvariant{
 	{"memory-is-bookkeeping", "bookkeeping"},
 	{"saving-never-counts-as-answering", "never counts as answering"},
 	{"turn-ends-with-answer-as-final-message", "final message"},
 	{"save-before-composing-the-reply", "before composing"},
-	{"covers-memory-call-failure-and-timeout", "fails or times out"},
-	{"failure-still-delivers-the-answer", "answer anyway"},
 }
 
-func assertDeliveryGuarantee(t *testing.T, surface string, content []byte) {
-	t.Helper()
-	normalized := strings.ToLower(strings.Join(strings.Fields(string(content)), " "))
-	for _, inv := range deliveryGuaranteePhrases {
+var installedFullFailureContract = []installedDeliveryGuaranteeInvariant{
+	{"failure-delivers-complete-answer", "fails or times out, deliver the complete answer anyway and note the failure briefly"},
+	{"failure-never-blocks-truncates-or-replaces", "failed or slow memory operation never blocks, truncates, or replaces the reply"},
+}
+
+var installedSlimFailureContract = []installedDeliveryGuaranteeInvariant{
+	{"failure-delivers-answer", "fails or times out, deliver the answer anyway"},
+	{"failure-never-blocks-or-replaces", "memory failures never block or replace the reply"},
+}
+
+const fullPositiveFailureContract = "If a memory call (`mem_save`, `mem_judge`, `mem_session_summary`) fails or times out, deliver the complete answer anyway and note the failure briefly — a failed or slow memory operation never blocks, truncates, or replaces the reply."
+const fullOppositeFailureContract = "If a memory call (`mem_save`, `mem_judge`, `mem_session_summary`) fails or times out, do not deliver the complete answer anyway; a failed or slow memory operation may block, truncate, or replace the reply."
+const slimPositiveFailureContract = "If a memory call fails or times out, deliver the answer anyway — memory failures never block or replace the reply."
+const slimOppositeFailureContract = "If a memory call fails or times out, do not deliver the answer anyway — memory failures may block or replace the reply."
+
+func normalizeInstalledDeliveryGuarantee(content string) string {
+	return strings.ToLower(strings.Join(strings.Fields(content), " "))
+}
+
+func missingInstalledDeliveryGuarantees(content []byte, failureContract []installedDeliveryGuaranteeInvariant) []string {
+	normalized := normalizeInstalledDeliveryGuarantee(string(content))
+	invariants := append(append([]installedDeliveryGuaranteeInvariant{}, deliveryGuaranteePhrases...), failureContract...)
+	missing := make([]string, 0)
+	for _, inv := range invariants {
 		if !strings.Contains(normalized, inv.phrase) {
-			t.Errorf("installed output %q violates delivery-guarantee invariant %q: missing phrase %q", surface, inv.name, inv.phrase)
+			missing = append(missing, inv.name)
 		}
+	}
+	return missing
+}
+
+func assertDeliveryGuarantee(t *testing.T, surface string, content []byte, failureContract []installedDeliveryGuaranteeInvariant) {
+	t.Helper()
+	for _, missing := range missingInstalledDeliveryGuarantees(content, failureContract) {
+		t.Errorf("installed output %q violates delivery-guarantee invariant %q", surface, missing)
+	}
+}
+
+func assertRejectsOppositeFailureContract(t *testing.T, surface string, content []byte, failureContract []installedDeliveryGuaranteeInvariant, positive, opposite string) {
+	t.Helper()
+	normalizedContent := normalizeInstalledDeliveryGuarantee(string(content))
+	mutated := []byte(strings.Replace(
+		normalizedContent,
+		normalizeInstalledDeliveryGuarantee(positive),
+		normalizeInstalledDeliveryGuarantee(opposite),
+		1,
+	))
+	if string(mutated) == normalizedContent {
+		t.Fatalf("positive failure contract was not found in installed output %q", surface)
+	}
+	if missing := missingInstalledDeliveryGuarantees(mutated, failureContract); len(missing) == 0 {
+		t.Fatalf("installed output %q accepted opposite failure wording that retained weak fragments", surface)
 	}
 }
 
@@ -57,7 +101,8 @@ func TestDeliveryGuarantee_InstalledOutputs(t *testing.T) {
 		}
 
 		claudeMD := readTestFile(t, filepath.Join(home, ".claude", "CLAUDE.md"))
-		assertDeliveryGuarantee(t, "claude CLAUDE.md (slim)", claudeMD)
+		assertDeliveryGuarantee(t, "claude CLAUDE.md (slim)", claudeMD, installedSlimFailureContract)
+		assertRejectsOppositeFailureContract(t, "claude CLAUDE.md (slim)", claudeMD, installedSlimFailureContract, slimPositiveFailureContract, slimOppositeFailureContract)
 	})
 
 	t.Run("antigravity-full", func(t *testing.T) {
@@ -73,7 +118,8 @@ func TestDeliveryGuarantee_InstalledOutputs(t *testing.T) {
 		}
 
 		rulesFile := readTestFile(t, filepath.Join(home, ".gemini", "GEMINI.md"))
-		assertDeliveryGuarantee(t, "antigravity GEMINI.md (full)", rulesFile)
+		assertDeliveryGuarantee(t, "antigravity GEMINI.md (full)", rulesFile, installedFullFailureContract)
+		assertRejectsOppositeFailureContract(t, "antigravity GEMINI.md (full)", rulesFile, installedFullFailureContract, fullPositiveFailureContract, fullOppositeFailureContract)
 	})
 
 	t.Run("codex-instructions", func(t *testing.T) {
@@ -89,6 +135,7 @@ func TestDeliveryGuarantee_InstalledOutputs(t *testing.T) {
 		}
 
 		instructions := readTestFile(t, filepath.Join(home, ".codex", "engram-instructions.md"))
-		assertDeliveryGuarantee(t, "codex engram-instructions.md (full+passive-capture)", instructions)
+		assertDeliveryGuarantee(t, "codex engram-instructions.md (full+passive-capture)", instructions, installedFullFailureContract)
+		assertRejectsOppositeFailureContract(t, "codex engram-instructions.md (full+passive-capture)", instructions, installedFullFailureContract, fullPositiveFailureContract, fullOppositeFailureContract)
 	})
 }

--- a/internal/components/engram/delivery_guarantee_test.go
+++ b/internal/components/engram/delivery_guarantee_test.go
@@ -1,0 +1,51 @@
+package engram
+
+import (
+	"strings"
+	"testing"
+)
+
+// normalizeForSemanticMatch collapses all whitespace runs (including line
+// wraps) into single spaces and lowercases, so semantic invariants are
+// asserted on meaning-bearing phrases rather than on exact formatting or
+// byte layout (issue #1042 acceptance scope).
+func normalizeForSemanticMatch(s string) string {
+	return strings.ToLower(strings.Join(strings.Fields(s), " "))
+}
+
+// deliveryGuaranteeInvariants are the semantic rules every rendered protocol
+// surface must state so that memory bookkeeping can never replace the final
+// user-facing reply — including when a memory call fails or times out.
+var deliveryGuaranteeInvariants = []struct {
+	name   string
+	phrase string
+}{
+	{"memory-is-bookkeeping", "bookkeeping"},
+	{"saving-never-counts-as-answering", "never counts as answering"},
+	{"turn-ends-with-answer-as-final-message", "final message"},
+	{"save-before-composing-the-reply", "before composing"},
+	{"covers-memory-call-failure-and-timeout", "fails or times out"},
+	{"failure-still-delivers-the-answer", "deliver the"},
+	{"failure-never-replaces-the-reply", "answer anyway"},
+}
+
+// TestDeliveryGuaranteeSemantics_RenderedSurfaces asserts the delivery
+// guarantee on every rendered protocol variant, independent of golden
+// byte-equality: full (non-slim adapters), slim (Claude Code), and the
+// Codex model_instructions content.
+func TestDeliveryGuaranteeSemantics_RenderedSurfaces(t *testing.T) {
+	surfaces := map[string]string{
+		"full":               protocolFull(),
+		"slim":               protocolSlim(),
+		"codex-instructions": codexInstructions(),
+	}
+
+	for surfaceName, content := range surfaces {
+		normalized := normalizeForSemanticMatch(content)
+		for _, inv := range deliveryGuaranteeInvariants {
+			if !strings.Contains(normalized, inv.phrase) {
+				t.Errorf("surface %q violates delivery-guarantee invariant %q: missing phrase %q", surfaceName, inv.name, inv.phrase)
+			}
+		}
+	}
+}

--- a/internal/components/engram/delivery_guarantee_test.go
+++ b/internal/components/engram/delivery_guarantee_test.go
@@ -13,20 +13,44 @@ func normalizeForSemanticMatch(s string) string {
 	return strings.ToLower(strings.Join(strings.Fields(s), " "))
 }
 
-// deliveryGuaranteeInvariants are the semantic rules every rendered protocol
-// surface must state so that memory bookkeeping can never replace the final
-// user-facing reply — including when a memory call fails or times out.
-var deliveryGuaranteeInvariants = []struct {
+type deliveryGuaranteeInvariant struct {
 	name   string
 	phrase string
-}{
+}
+
+// deliveryGuaranteeInvariants are the semantic rules every rendered protocol
+// surface must state so that memory bookkeeping can never replace the final
+// user-facing reply.
+var deliveryGuaranteeInvariants = []deliveryGuaranteeInvariant{
 	{"memory-is-bookkeeping", "bookkeeping"},
 	{"saving-never-counts-as-answering", "never counts as answering"},
 	{"turn-ends-with-answer-as-final-message", "final message"},
 	{"save-before-composing-the-reply", "before composing"},
-	{"covers-memory-call-failure-and-timeout", "fails or times out"},
-	{"failure-still-delivers-the-answer", "deliver the"},
-	{"failure-never-replaces-the-reply", "answer anyway"},
+}
+
+// The failure contracts deliberately include both the positive delivery
+// obligation and the negative blocking/replacement prohibition. Independent
+// fragments such as "answer anyway" cannot prove the direction of the rule.
+var fullFailureContract = []deliveryGuaranteeInvariant{
+	{"failure-delivers-complete-answer", "fails or times out, deliver the complete answer anyway and note the failure briefly"},
+	{"failure-never-blocks-truncates-or-replaces", "failed or slow memory operation never blocks, truncates, or replaces the reply"},
+}
+
+var slimFailureContract = []deliveryGuaranteeInvariant{
+	{"failure-delivers-answer", "fails or times out, deliver the answer anyway"},
+	{"failure-never-blocks-or-replaces", "memory failures never block or replace the reply"},
+}
+
+func missingDeliveryGuaranteeInvariants(content string, failureContract []deliveryGuaranteeInvariant) []string {
+	normalized := normalizeForSemanticMatch(content)
+	invariants := append(append([]deliveryGuaranteeInvariant{}, deliveryGuaranteeInvariants...), failureContract...)
+	missing := make([]string, 0)
+	for _, inv := range invariants {
+		if !strings.Contains(normalized, inv.phrase) {
+			missing = append(missing, inv.name)
+		}
+	}
+	return missing
 }
 
 // TestDeliveryGuaranteeSemantics_RenderedSurfaces asserts the delivery
@@ -34,18 +58,55 @@ var deliveryGuaranteeInvariants = []struct {
 // byte-equality: full (non-slim adapters), slim (Claude Code), and the
 // Codex model_instructions content.
 func TestDeliveryGuaranteeSemantics_RenderedSurfaces(t *testing.T) {
-	surfaces := map[string]string{
-		"full":               protocolFull(),
-		"slim":               protocolSlim(),
-		"codex-instructions": codexInstructions(),
+	surfaces := map[string]struct {
+		content         string
+		failureContract []deliveryGuaranteeInvariant
+	}{
+		"full":               {content: protocolFull(), failureContract: fullFailureContract},
+		"slim":               {content: protocolSlim(), failureContract: slimFailureContract},
+		"codex-instructions": {content: codexInstructions(), failureContract: fullFailureContract},
 	}
 
-	for surfaceName, content := range surfaces {
-		normalized := normalizeForSemanticMatch(content)
-		for _, inv := range deliveryGuaranteeInvariants {
-			if !strings.Contains(normalized, inv.phrase) {
-				t.Errorf("surface %q violates delivery-guarantee invariant %q: missing phrase %q", surfaceName, inv.name, inv.phrase)
-			}
+	for surfaceName, surface := range surfaces {
+		for _, missing := range missingDeliveryGuaranteeInvariants(surface.content, surface.failureContract) {
+			t.Errorf("surface %q violates delivery-guarantee invariant %q", surfaceName, missing)
 		}
+	}
+}
+
+func TestDeliveryGuaranteeSemantics_RejectsOppositeFailureContract(t *testing.T) {
+	const fullPositive = "If a memory call (`mem_save`, `mem_judge`, `mem_session_summary`) fails or times out, deliver the complete answer anyway and note the failure briefly — a failed or slow memory operation never blocks, truncates, or replaces the reply."
+	const fullOpposite = "If a memory call (`mem_save`, `mem_judge`, `mem_session_summary`) fails or times out, do not deliver the complete answer anyway; a failed or slow memory operation may block, truncate, or replace the reply."
+	const slimPositive = "If a memory call fails or times out, deliver the answer anyway — memory failures never block or replace the reply."
+	const slimOpposite = "If a memory call fails or times out, do not deliver the answer anyway — memory failures may block or replace the reply."
+
+	tests := []struct {
+		name            string
+		content         string
+		positive        string
+		opposite        string
+		failureContract []deliveryGuaranteeInvariant
+	}{
+		{name: "full", content: protocolFull(), positive: fullPositive, opposite: fullOpposite, failureContract: fullFailureContract},
+		{name: "slim", content: protocolSlim(), positive: slimPositive, opposite: slimOpposite, failureContract: slimFailureContract},
+		{name: "codex-instructions", content: codexInstructions(), positive: fullPositive, opposite: fullOpposite, failureContract: fullFailureContract},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			normalizedContent := normalizeForSemanticMatch(tt.content)
+			mutated := strings.Replace(
+				normalizedContent,
+				normalizeForSemanticMatch(tt.positive),
+				normalizeForSemanticMatch(tt.opposite),
+				1,
+			)
+			if mutated == normalizedContent {
+				t.Fatalf("positive failure contract was not found in %s surface", tt.name)
+			}
+			if missing := missingDeliveryGuaranteeInvariants(mutated, tt.failureContract); len(missing) == 0 {
+				t.Fatalf("opposite failure contract retained weak fragments and was incorrectly accepted")
+			}
+		})
 	}
 }

--- a/internal/components/engram/testdata/protocol-full.md
+++ b/internal/components/engram/testdata/protocol-full.md
@@ -29,6 +29,7 @@ Saving to memory is internal bookkeeping. It NEVER counts as answering the user,
 - End every turn with your complete user-facing answer as the final message, with NO tool calls after it.
 - Save memory BEFORE composing that final answer, not after. Never let a `mem_save`/`mem_judge` be the last action in a turn that still owed the user a substantive reply.
 - If a memory chain (`mem_save` → `mem_judge`) ran late, still write the full answer in that final message — do not collapse it into a one-line "saved / done" acknowledgement.
+- If a memory call (`mem_save`, `mem_judge`, `mem_session_summary`) fails or times out, deliver the complete answer anyway and note the failure briefly — a failed or slow memory operation never blocks, truncates, or replaces the reply.
 - Never treat the text you stored in memory as the text you delivered: memory is for your future self, the reply is for the user.
 
 Format for `mem_save`:

--- a/internal/components/engram/testdata/protocol-full.md
+++ b/internal/components/engram/testdata/protocol-full.md
@@ -21,6 +21,16 @@ Call `mem_save` IMMEDIATELY and WITHOUT BEING ASKED after any of these:
 
 Self-check after EVERY task: "Did I make a decision, fix a bug, learn something non-obvious, or establish a convention? If yes, call mem_save NOW."
 
+### DELIVERY GUARANTEE — saving is not replying
+
+Saving to memory is internal bookkeeping. It NEVER counts as answering the user, and the user never sees your tool calls or the content you store.
+
+- If the answer exists only inside a `mem_save`, the user never received it. Saving is not replying.
+- End every turn with your complete user-facing answer as the final message, with NO tool calls after it.
+- Save memory BEFORE composing that final answer, not after. Never let a `mem_save`/`mem_judge` be the last action in a turn that still owed the user a substantive reply.
+- If a memory chain (`mem_save` → `mem_judge`) ran late, still write the full answer in that final message — do not collapse it into a one-line "saved / done" acknowledgement.
+- Never treat the text you stored in memory as the text you delivered: memory is for your future self, the reply is for the user.
+
 Format for `mem_save`:
 - **title**: Verb + what — short, searchable (e.g. "Fixed N+1 query in UserList")
 - **type**: bugfix | decision | architecture | discovery | pattern | config | preference

--- a/internal/components/engram/testdata/protocol-slim.md
+++ b/internal/components/engram/testdata/protocol-slim.md
@@ -9,3 +9,7 @@ MCP server instructions and the SessionStart hook. Always-on rules:
   automated/SDD artifacts.
 - On any reference to past work: `mem_context` → `mem_search` → `mem_get_observation`.
 - Before saying "done", call `mem_session_summary`.
+- Saving to memory is bookkeeping, never the reply: it NEVER counts as answering.
+  End every turn with the complete user-facing answer as the final message (no
+  tool calls after it), and save memory before composing it — never collapse the
+  answer into a "saved / done" acknowledgement.

--- a/internal/components/engram/testdata/protocol-slim.md
+++ b/internal/components/engram/testdata/protocol-slim.md
@@ -13,3 +13,5 @@ MCP server instructions and the SessionStart hook. Always-on rules:
   End every turn with the complete user-facing answer as the final message (no
   tool calls after it), and save memory before composing it — never collapse the
   answer into a "saved / done" acknowledgement.
+- If a memory call fails or times out, deliver the answer anyway — memory
+  failures never block or replace the reply.

--- a/testdata/golden/combined-claude-claudemd.golden
+++ b/testdata/golden/combined-claude-claudemd.golden
@@ -173,4 +173,6 @@ MCP server instructions and the SessionStart hook. Always-on rules:
   End every turn with the complete user-facing answer as the final message (no
   tool calls after it), and save memory before composing it — never collapse the
   answer into a "saved / done" acknowledgement.
+- If a memory call fails or times out, deliver the answer anyway — memory
+  failures never block or replace the reply.
 <!-- /gentle-ai:engram-protocol -->

--- a/testdata/golden/combined-claude-claudemd.golden
+++ b/testdata/golden/combined-claude-claudemd.golden
@@ -169,4 +169,8 @@ MCP server instructions and the SessionStart hook. Always-on rules:
   automated/SDD artifacts.
 - On any reference to past work: `mem_context` → `mem_search` → `mem_get_observation`.
 - Before saying "done", call `mem_session_summary`.
+- Saving to memory is bookkeeping, never the reply: it NEVER counts as answering.
+  End every turn with the complete user-facing answer as the final message (no
+  tool calls after it), and save memory before composing it — never collapse the
+  answer into a "saved / done" acknowledgement.
 <!-- /gentle-ai:engram-protocol -->

--- a/testdata/golden/combined-windsurf-global-rules.golden
+++ b/testdata/golden/combined-windsurf-global-rules.golden
@@ -575,6 +575,7 @@ Saving to memory is internal bookkeeping. It NEVER counts as answering the user,
 - End every turn with your complete user-facing answer as the final message, with NO tool calls after it.
 - Save memory BEFORE composing that final answer, not after. Never let a `mem_save`/`mem_judge` be the last action in a turn that still owed the user a substantive reply.
 - If a memory chain (`mem_save` → `mem_judge`) ran late, still write the full answer in that final message — do not collapse it into a one-line "saved / done" acknowledgement.
+- If a memory call (`mem_save`, `mem_judge`, `mem_session_summary`) fails or times out, deliver the complete answer anyway and note the failure briefly — a failed or slow memory operation never blocks, truncates, or replaces the reply.
 - Never treat the text you stored in memory as the text you delivered: memory is for your future self, the reply is for the user.
 
 Format for `mem_save`:

--- a/testdata/golden/combined-windsurf-global-rules.golden
+++ b/testdata/golden/combined-windsurf-global-rules.golden
@@ -567,6 +567,16 @@ Call `mem_save` IMMEDIATELY and WITHOUT BEING ASKED after any of these:
 
 Self-check after EVERY task: "Did I make a decision, fix a bug, learn something non-obvious, or establish a convention? If yes, call mem_save NOW."
 
+### DELIVERY GUARANTEE — saving is not replying
+
+Saving to memory is internal bookkeeping. It NEVER counts as answering the user, and the user never sees your tool calls or the content you store.
+
+- If the answer exists only inside a `mem_save`, the user never received it. Saving is not replying.
+- End every turn with your complete user-facing answer as the final message, with NO tool calls after it.
+- Save memory BEFORE composing that final answer, not after. Never let a `mem_save`/`mem_judge` be the last action in a turn that still owed the user a substantive reply.
+- If a memory chain (`mem_save` → `mem_judge`) ran late, still write the full answer in that final message — do not collapse it into a one-line "saved / done" acknowledgement.
+- Never treat the text you stored in memory as the text you delivered: memory is for your future self, the reply is for the user.
+
 Format for `mem_save`:
 - **title**: Verb + what — short, searchable (e.g. "Fixed N+1 query in UserList")
 - **type**: bugfix | decision | architecture | discovery | pattern | config | preference

--- a/testdata/golden/engram-antigravity-rulesmd.golden
+++ b/testdata/golden/engram-antigravity-rulesmd.golden
@@ -22,6 +22,16 @@ Call `mem_save` IMMEDIATELY and WITHOUT BEING ASKED after any of these:
 
 Self-check after EVERY task: "Did I make a decision, fix a bug, learn something non-obvious, or establish a convention? If yes, call mem_save NOW."
 
+### DELIVERY GUARANTEE — saving is not replying
+
+Saving to memory is internal bookkeeping. It NEVER counts as answering the user, and the user never sees your tool calls or the content you store.
+
+- If the answer exists only inside a `mem_save`, the user never received it. Saving is not replying.
+- End every turn with your complete user-facing answer as the final message, with NO tool calls after it.
+- Save memory BEFORE composing that final answer, not after. Never let a `mem_save`/`mem_judge` be the last action in a turn that still owed the user a substantive reply.
+- If a memory chain (`mem_save` → `mem_judge`) ran late, still write the full answer in that final message — do not collapse it into a one-line "saved / done" acknowledgement.
+- Never treat the text you stored in memory as the text you delivered: memory is for your future self, the reply is for the user.
+
 Format for `mem_save`:
 - **title**: Verb + what — short, searchable (e.g. "Fixed N+1 query in UserList")
 - **type**: bugfix | decision | architecture | discovery | pattern | config | preference

--- a/testdata/golden/engram-antigravity-rulesmd.golden
+++ b/testdata/golden/engram-antigravity-rulesmd.golden
@@ -30,6 +30,7 @@ Saving to memory is internal bookkeeping. It NEVER counts as answering the user,
 - End every turn with your complete user-facing answer as the final message, with NO tool calls after it.
 - Save memory BEFORE composing that final answer, not after. Never let a `mem_save`/`mem_judge` be the last action in a turn that still owed the user a substantive reply.
 - If a memory chain (`mem_save` → `mem_judge`) ran late, still write the full answer in that final message — do not collapse it into a one-line "saved / done" acknowledgement.
+- If a memory call (`mem_save`, `mem_judge`, `mem_session_summary`) fails or times out, deliver the complete answer anyway and note the failure briefly — a failed or slow memory operation never blocks, truncates, or replaces the reply.
 - Never treat the text you stored in memory as the text you delivered: memory is for your future self, the reply is for the user.
 
 Format for `mem_save`:

--- a/testdata/golden/engram-claude-claudemd.golden
+++ b/testdata/golden/engram-claude-claudemd.golden
@@ -14,4 +14,6 @@ MCP server instructions and the SessionStart hook. Always-on rules:
   End every turn with the complete user-facing answer as the final message (no
   tool calls after it), and save memory before composing it — never collapse the
   answer into a "saved / done" acknowledgement.
+- If a memory call fails or times out, deliver the answer anyway — memory
+  failures never block or replace the reply.
 <!-- /gentle-ai:engram-protocol -->

--- a/testdata/golden/engram-claude-claudemd.golden
+++ b/testdata/golden/engram-claude-claudemd.golden
@@ -10,4 +10,8 @@ MCP server instructions and the SessionStart hook. Always-on rules:
   automated/SDD artifacts.
 - On any reference to past work: `mem_context` → `mem_search` → `mem_get_observation`.
 - Before saying "done", call `mem_session_summary`.
+- Saving to memory is bookkeeping, never the reply: it NEVER counts as answering.
+  End every turn with the complete user-facing answer as the final message (no
+  tool calls after it), and save memory before composing it — never collapse the
+  answer into a "saved / done" acknowledgement.
 <!-- /gentle-ai:engram-protocol -->

--- a/testdata/golden/engram-codex-instructions.golden
+++ b/testdata/golden/engram-codex-instructions.golden
@@ -29,6 +29,7 @@ Saving to memory is internal bookkeeping. It NEVER counts as answering the user,
 - End every turn with your complete user-facing answer as the final message, with NO tool calls after it.
 - Save memory BEFORE composing that final answer, not after. Never let a `mem_save`/`mem_judge` be the last action in a turn that still owed the user a substantive reply.
 - If a memory chain (`mem_save` → `mem_judge`) ran late, still write the full answer in that final message — do not collapse it into a one-line "saved / done" acknowledgement.
+- If a memory call (`mem_save`, `mem_judge`, `mem_session_summary`) fails or times out, deliver the complete answer anyway and note the failure briefly — a failed or slow memory operation never blocks, truncates, or replaces the reply.
 - Never treat the text you stored in memory as the text you delivered: memory is for your future self, the reply is for the user.
 
 Format for `mem_save`:

--- a/testdata/golden/engram-codex-instructions.golden
+++ b/testdata/golden/engram-codex-instructions.golden
@@ -21,6 +21,16 @@ Call `mem_save` IMMEDIATELY and WITHOUT BEING ASKED after any of these:
 
 Self-check after EVERY task: "Did I make a decision, fix a bug, learn something non-obvious, or establish a convention? If yes, call mem_save NOW."
 
+### DELIVERY GUARANTEE — saving is not replying
+
+Saving to memory is internal bookkeeping. It NEVER counts as answering the user, and the user never sees your tool calls or the content you store.
+
+- If the answer exists only inside a `mem_save`, the user never received it. Saving is not replying.
+- End every turn with your complete user-facing answer as the final message, with NO tool calls after it.
+- Save memory BEFORE composing that final answer, not after. Never let a `mem_save`/`mem_judge` be the last action in a turn that still owed the user a substantive reply.
+- If a memory chain (`mem_save` → `mem_judge`) ran late, still write the full answer in that final message — do not collapse it into a one-line "saved / done" acknowledgement.
+- Never treat the text you stored in memory as the text you delivered: memory is for your future self, the reply is for the user.
+
 Format for `mem_save`:
 - **title**: Verb + what — short, searchable (e.g. "Fixed N+1 query in UserList")
 - **type**: bugfix | decision | architecture | discovery | pattern | config | preference


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1042

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)

> ℹ️ I don't have write access to add the `type:bug` label myself — could a maintainer apply it so the "Check PR Has type:* Label" gate passes?

---

## 📝 Summary

The injected Engram protocol tells the agent to save proactively and *before saying "done"* but never states that **saving to memory is not the same as replying**. An agent can write the full answer into a `mem_save` and then close the turn with a one-line "saved / done", so the real reply never reaches the user — especially when a `mem_save` fires the `mem_save` → `mem_judge` conflict chain after the substantive work. This adds a **DELIVERY GUARANTEE** clause making the output-ordering rule explicit, covers memory-call failure/timeout, and proves the contract with semantic tests per the acceptance scope in #1042.

> Note: rebased onto current `main`, which meanwhile consolidated the protocol assets (#1030). The fix targets `internal/assets/engram/protocol.md` — **both** the `full` and `slim` sections, since Claude Code receives the `slim` CLAUDE.md section (the exact surface where this was reproduced).

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/assets/engram/protocol.md` | DELIVERY GUARANTEE clause in `section:full` (also flows to Codex `model_instructions` via `codexInstructions()`) and always-on bullets in `section:slim`. Includes failure/timeout coverage: a failed or slow `mem_save`/`mem_judge`/`mem_session_summary` never blocks, truncates, or replaces the reply. |
| `internal/components/engram/delivery_guarantee_test.go` *(new)* | Semantic invariants asserted on every rendered surface (`protocolFull()`, `protocolSlim()`, `codexInstructions()`) over whitespace-normalized content — independent of byte layout. |
| `internal/components/delivery_guarantee_installed_test.go` *(new)* | Runs the real injection into a temp home and asserts the invariants on representative **installed outputs**: Claude `CLAUDE.md` (slim), Antigravity `GEMINI.md` (full), Codex `engram-instructions.md` (full+passive-capture). |
| `internal/components/engram/testdata/protocol-full.md`, `protocol-slim.md` | Regenerated section fixtures. |
| `testdata/golden/*.golden` (×5) | Regenerated combined snapshots (`-update`). |

---

## 🧪 Test Plan

- [x] Unit tests pass (`go test ./...`) — full suite green, including the two new semantic test files.
- [x] **Negative check**: tampering the failure phrase out of the canonical asset makes both new tests fail across all surfaces — the invariants genuinely bite.
- [ ] E2E tests (`cd e2e && ./docker-test.sh`) — not run locally (no Docker in this environment); deferring to CI.
- [x] Verified the protocol diff is additive-only and the clause lands on the correct surfaces (slim bullets in the Claude combined golden; full clause in the Codex instructions golden).

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved` (#1042)
- [x] PR stays within 400 changed lines
- [ ] I have added the appropriate `type:*` label — **cannot self-apply (no write access); requesting maintainer to add `type:bug`**
- [x] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass — deferring to CI (no local Docker)
- [x] Documentation updated (this change is the injected protocol asset itself; fixtures + goldens updated)
- [x] Commits follow Conventional Commits
- [x] No `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

- Semantic-vs-behavioral scope: these tests prove every installed surface *states* the delivery/failure contract; whether an agent *obeys* it at runtime is LLM behavior outside gentle-ai's Go suite. Behavioral coverage would belong in engram (Gentleman-Programming/engram#584).
- The CodeRabbit markdownlint finding on `protocol-full.md` is addressed in a PR comment: the fixture is byte-exact testdata, the findings predate this PR, and CI doesn't run markdownlint.
- Reproduction with screenshots is in #1042.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added/expanded a “delivery guarantee” section explaining that memory-saving is internal bookkeeping and never counts as the user-facing reply.
  * Strengthened end-of-turn ordering rules (final user-facing answer last; memory saved before composing it; no tool actions after the final answer).
  * Clarified what happens if memory saving fails or times out (still deliver the full reply, with only a brief failure note).

* **Tests**
  * Added semantic, formatting-agnostic tests for delivery-guarantee wording across protocol variants and installed outputs (including positive vs opposite failure-contract rejection).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->