### PR TITLE
test(tui): harden headless TUI test to prevent CI hang

### DIFF
--- a/internal/app/parity_test.go
+++ b/internal/app/parity_test.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"reflect"
 	"strings"
@@ -163,22 +164,31 @@ func TestGuardFlowLinuxDryRunPropagatesDecision(t *testing.T) {
 
 func TestRunArgsNoCommandLaunchesTUI(t *testing.T) {
 	origRunTUI := runTUI
-	t.Cleanup(func() { runTUI = origRunTUI })
+	origDetect := detectSystem
+	origEnsure := ensureCurrentOSSupported
+	t.Cleanup(func() {
+		runTUI = origRunTUI
+		detectSystem = origDetect
+		ensureCurrentOSSupported = origEnsure
+	})
+
+	ensureCurrentOSSupported = func() error { return nil }
+	detectSystem = func(context.Context) (system.DetectionResult, error) {
+		return system.DetectionResult{System: system.SystemInfo{Supported: true}}, nil
+	}
+
+	tuiCalled := false
 	runTUI = func(m tea.Model, opts ...tea.ProgramOption) (tea.Model, error) {
-		return nil, errors.New("mock TUI error: no TTY")
+		tuiCalled = true
+		return m, nil
 	}
 
 	var buf bytes.Buffer
-	err := RunArgs(nil, &buf)
-	// With no args, RunArgs now launches the TUI via Bubbletea.
-	// In a headless/test environment without a TTY, this returns an error
-	// about opening /dev/tty. That's expected — the TUI requires a terminal.
-	if err == nil {
-		// If no error, we're somehow in a TTY — that's fine too.
-		return
+	if err := RunArgs(nil, &buf); err != nil {
+		t.Fatalf("RunArgs(nil) unexpected error = %v", err)
 	}
-	if !strings.Contains(err.Error(), "TTY") && !strings.Contains(err.Error(), "tty") && !strings.Contains(err.Error(), "mock TUI") {
-		t.Fatalf("RunArgs(nil) unexpected error = %v; want TTY-related error or nil", err)
+	if !tuiCalled {
+		t.Fatal("RunArgs(nil) did not launch the TUI")
 	}
 }
 


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #254

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

> ⚠️ Labels are applied by maintainers. Requesting `type:bug` for this PR.

---

## 📝 Summary

The previous `TestRunArgsNoCommandLaunchesTUI` had a silent pass path: if `err == nil` it returned early with the comment *"we're somehow in a TTY — that's fine too"*. This masked the headless hang described in #254 — Bubbletea blocks indefinitely trying to open `/dev/tty` in CI environments, and the test would never catch it.

The `runTUI` injectable seam already existed in `main` (introduced in `a743e5f`). This PR hardens the test to use it correctly: all TTY-dependent seams are mocked (`ensureCurrentOSSupported`, `detectSystem`, `runTUI`) and the test asserts positively that `runTUI` was invoked, making it environment-independent.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/app/parity_test.go` | Replace TTY-accepting test with deterministic mock; add `"context"` import |

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./internal/app/... -run TestRunArgs -v -count=1
```

**E2E Tests** (Docker required)
```bash
cd e2e && ./docker-test.sh
```

- [x] Unit tests pass — all 24 `TestRunArgs*` green, `TestRunArgsNoCommandLaunchesTUI` runs in 0.01s without touching TTY
- [x] E2E tests pass (`cd e2e && ./docker-test.sh`) — Ubuntu, Arch, Fedora all green
- [x] Manually tested locally — confirmed the test no longer depends on terminal availability

---

## 🤖 Automated Checks

The following checks run automatically on this PR:

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | PR should stay within 400 changed lines (`additions + deletions`) or use `size:exception` |
| Check Issue Reference | ⏳ | PR body must contain `Closes/Fixes/Resolves #N` |
| Check Issue Has `status:approved` | ⏳ | Linked issue must have been approved before work began |
| Check PR Has `type:*` Label | ⏳ | Exactly one `type:*` label must be applied |
| Unit Tests | ⏳ | `go test ./...` must pass |
| E2E Tests | ⏳ | `cd e2e && ./docker-test.sh` must pass |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines (32 lines changed)
- [ ] I have added the appropriate `type:*` label to this PR _(applied by maintainers)_
- [x] Unit tests pass (`go test ./...`)
- [x] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

The production code (`app.go`) is untouched — the `runTUI` seam was already in place. This PR only fixes the test that was supposed to guard against the headless hang but silently passed in any environment.

Known gap: `selfUpdateFn` is not mocked in this test. A dedicated test (`TestRunArgs_TUISkipsSelfUpdate`) already covers that path, so there's no regression risk, but it's worth noting as future hardening opportunity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved coverage for the no-command startup flow, confirming the app launches the TUI successfully in this scenario.
  * Strengthened mocks around environment checks to make the behavior more reliable in automated testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->