### PR TITLE
feat(skills): add archive isolation policy to openspec-convention

### DIFF
--- a/internal/assets/skills/_shared/openspec-convention.md
+++ b/internal/assets/skills/_shared/openspec-convention.md
@@ -118,3 +118,10 @@ openspec/changes/archive/YYYY-MM-DD-{change-name}/
 ```
 
 Use today's date in ISO format. The archive is an AUDIT TRAIL — never delete or modify archived changes.
+
+## Archive Isolation
+
+- Do not proactively read, search, or index `openspec/changes/archive/` during normal SDD work, except when delegating or executing the `sdd-archive` phase.
+- Treat `openspec/changes/archive/` as historical-only content that may contradict current requirements.
+- Ignore accidental search hits from that path unless the task is explicitly a historical audit, legacy comparison, archived logic retrieval, or the user explicitly directs otherwise.
+- Only the `sdd-archive` phase writes to the archive path.


### PR DESCRIPTION
Closes #261

## 🏷️ PR Type

- [ ] `type:bug`
- [x] `type:feature`
- [ ] `type:docs`
- [ ] `type:refactor`
- [ ] `type:chore`
- [ ] `type:breaking-change`

## 📝 Summary

- Adds `## Archive Isolation` section to `openspec-convention.md` (shared SDD skill)
- Prevents agents from proactively reading/searching/indexing `openspec/changes/archive/` during normal SDD work
- Allows exceptions for `sdd-archive` phase delegation/execution and explicit user direction
- Only `sdd-archive` writes to the archive path

## 📂 Changes

| File | Change |
|------|--------|
| `internal/assets/skills/_shared/openspec-convention.md` | Added `## Archive Isolation` policy section |

## 🧪 Test Plan

- [x] Unit tests pass (`go test ./...`)

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [x] I have added the appropriate `type:*` label
- [x] Unit tests pass (`go test ./...`)
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new guidance for archive isolation in the OpenSpec file conventions.
  * Archived content is now clearly marked as historical-only and should not affect normal workflow searches or indexing.
  * Clarified that archived entries may conflict with current requirements and should only be referenced for historical audits, legacy comparisons, or archive-specific retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->