### PR TITLE
feat(system): add openSUSE platform support

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -75,6 +75,7 @@ This is NOT an "AI agent installer." Most agents are already easy to install (`n
 | Linux - Ubuntu/Debian | apt + Homebrew | P0 |
 | Linux - Arch | pacman | P0 |
 | Linux - Fedora/RHEL | dnf | P1 |
+| Linux - openSUSE | zypper | P1 |
 | WSL 2 (Windows) | apt + Homebrew | P1 |
 | Windows (native) | winget / scoop / choco | P2 |
 | Termux (Android) | pkg | P2 |
@@ -130,7 +131,7 @@ These are the base tools the installer itself and the ecosystem need.
 | Dependency | Min Version | Why | Install Method |
 |-----------|-------------|-----|----------------|
 | `bash` | 3.2+ | GGA, install scripts, Engram plugin hooks | Pre-installed on all targets |
-| `git` | 2.x | GGA (diff/staging), Engram (git sync), skills clone, agent integrations | `brew`/`apt`/`pacman`/`dnf`/`pkg` |
+| `git` | 2.x | GGA (diff/staging), Engram (git sync), skills clone, agent integrations | `brew`/`apt`/`pacman`/`dnf`/`zypper`/`pkg` |
 | `curl` | Any | Binary downloads, GGA providers (lmstudio, github), installer script | Pre-installed on most systems |
 
 #### Conditionally Required (based on user's selections)
@@ -152,6 +153,7 @@ These are the base tools the installer itself and the ecosystem need.
 | **Ubuntu/Debian** | bash, curl, git, sha256sum | Homebrew (optional), Node.js (apt version is often outdated → use NodeSource or fnm) | Node.js from apt is often v12/v16 — MUST use NodeSource repo or version manager for v20+ |
 | **Arch** | bash, curl, git, python3, sha256sum | Node.js (`pacman -S nodejs npm`) | Arch packages are usually current — `pacman` versions are fine |
 | **Fedora/RHEL** | bash, curl, git, sha256sum | Node.js (`dnf install nodejs`) | May need `dnf module enable nodejs:20` for correct version |
+| **openSUSE** | bash, curl, git, sha256sum | Node.js (`zypper install nodejs-default npm-default`) | Leap and Tumbleweed expose default Node/npm packages via `nodejs-default` and `npm-default` |
 | **WSL 2** | Same as host Linux distro | Same as Linux + note about Windows-side agents (Cursor, VSCode) | Windows-side agents use Windows paths; WSL agents use Linux paths |
 | **Windows native** | None guaranteed | Everything: git (Git for Windows), Node.js (winget/scoop), bash (Git Bash) | GGA needs bash — Git for Windows includes Git Bash |
 | **Termux** | bash, curl, git | Node.js (`pkg install nodejs`), python (`pkg install python`) | No sudo, no Homebrew. Commands run directly, not via `sh -c`. Go cross-compile has limitations on Android. |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -15,7 +15,7 @@ internal/
   system/                  OS/distro detection, dependency checks, platform guards
   cli/                     Install flags, validation, orchestration, dry-run
   planner/                 Dependency graph, resolution, ordering, review payloads
-  installcmd/              Profile-aware command resolver (brew/apt/pacman/dnf/winget/go install)
+  installcmd/              Profile-aware command resolver (brew/apt/pacman/dnf/zypper/winget/go install)
   pipeline/                Staged execution + rollback orchestration
   backup/                  Config snapshot + restore
   assets/                  Embedded skill files + persona templates

--- a/docs/docker-e2e-testing.md
+++ b/docs/docker-e2e-testing.md
@@ -10,6 +10,8 @@ e2e/
   e2e_test.sh         # All test cases, tiered by env vars
   Dockerfile.ubuntu   # Ubuntu 22.04 test image
   Dockerfile.arch     # Arch Linux test image
+  Dockerfile.fedora   # Fedora test image
+  Dockerfile.opensuse # openSUSE Leap test image
   docker-test.sh      # Orchestrator: build + run all platforms
 ```
 
@@ -37,6 +39,8 @@ RUN_FULL_E2E=1 RUN_BACKUP_TESTS=1 ./e2e/docker-test.sh
 |----------|-----------|-----------------|
 | Ubuntu 22.04 | `Dockerfile.ubuntu` | apt |
 | Arch Linux | `Dockerfile.arch` | pacman |
+| Fedora 43 | `Dockerfile.fedora` | dnf |
+| openSUSE Leap 15.6 | `Dockerfile.opensuse` | zypper |
 
 ## How it works
 
@@ -59,6 +63,10 @@ docker run --rm gentle-ai-e2e-ubuntu
 # Run with full E2E on Arch
 docker build -f e2e/Dockerfile.arch -t gentle-ai-e2e-arch .
 docker run --rm -e RUN_FULL_E2E=1 gentle-ai-e2e-arch
+
+# Run openSUSE only
+docker build -f e2e/Dockerfile.opensuse -t gentle-ai-e2e-opensuse .
+docker run --rm gentle-ai-e2e-opensuse
 
 # Interactive debugging
 docker run --rm -it gentle-ai-e2e-ubuntu /bin/bash

--- a/docs/non-interactive.md
+++ b/docs/non-interactive.md
@@ -37,6 +37,7 @@ The installer detects the platform automatically at runtime — there is no flag
 | Ubuntu/Debian | `apt` | `sudo npm install -g opencode-ai` |
 | Arch | `pacman` | `sudo npm install -g opencode-ai` |
 | Fedora/RHEL family | `dnf` | `sudo npm install -g opencode-ai` |
+| openSUSE family | `zypper` | `sudo npm install -g opencode-ai` |
 
 The `--dry-run` output includes a `Platform decision` line showing `os`, `distro`, `package-manager`, and `status`.
 

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -10,9 +10,10 @@
 | Linux (Ubuntu/Debian) | apt | Supported |
 | Linux (Arch) | pacman | Supported |
 | Linux (Fedora/RHEL family) | dnf | Supported |
+| Linux (openSUSE family) | zypper | Supported |
 | Windows 10/11 | PowerShell installer | Supported |
 
-Derivatives are detected via `ID_LIKE` in `/etc/os-release` (Linux Mint, Pop!_OS, Manjaro, EndeavourOS, CentOS Stream, Rocky Linux, AlmaLinux, etc.).
+Derivatives are detected via `ID_LIKE` in `/etc/os-release` (Linux Mint, Pop!_OS, Manjaro, EndeavourOS, CentOS Stream, Rocky Linux, AlmaLinux, openSUSE Leap, openSUSE Tumbleweed, etc.).
 
 Release artifacts are produced by CI. Windows users should install through the PowerShell installer so Gentle AI's built-in updater owns the same binary it installed.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -28,6 +28,13 @@
 - `git` available.
 - Node.js installs use NodeSource LTS setup + `dnf install -y nodejs` during dependency remediation.
 
+### openSUSE family (Leap, Tumbleweed)
+
+- `zypper` available (standard on these distros).
+- `sudo` access for package installs.
+- `git` available.
+- Node.js installs use verified openSUSE default packages: `nodejs-default` and `npm-default`.
+
 ### All platforms
 
 - Go 1.24+ (for building from source).
@@ -52,7 +59,7 @@ Use `--dry-run` first to validate selections and execution plan without applying
 go run ./cmd/gentle-ai install
 ```
 
-The installer detects your platform automatically — no flags needed to select macOS vs Linux. Install commands are resolved through the appropriate package manager (brew, apt, pacman, or dnf) based on detection.
+The installer detects your platform automatically — no flags needed to select macOS vs Linux. Install commands are resolved through the appropriate package manager (brew, apt, pacman, dnf, or zypper) based on detection.
 
 After completion, verify that agent configs and selected components were installed to their expected paths.
 
@@ -98,4 +105,4 @@ Optional wrapper tools for extra defense:
 If you run the installer on an unsupported OS or Linux distro, it exits immediately with an error:
 
 - `unsupported operating system: only macOS, Linux, and Windows are supported (detected <os>)`
-- `unsupported linux distro: Linux support is limited to Ubuntu/Debian, Arch, and Fedora/RHEL family (detected <distro>)`
+- `unsupported linux distro: Linux support is limited to Ubuntu/Debian, Arch, Fedora/RHEL family, and openSUSE family (detected <distro>)`

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -333,6 +333,6 @@ Homebrew's Linux sandbox for that command.
 
 - **Detected tools**: git, curl, node, npm, brew, go
 - **Version checks**: validates minimum versions where applicable
-- **Platform-aware hints**: suggests `brew install`, `apt install`, `pacman -S`, `dnf install`, or `winget install` depending on your OS
+- **Platform-aware hints**: suggests `brew install`, `apt install`, `pacman -S`, `dnf install`, `zypper install`, or `winget install` depending on your OS
 - **Node LTS alignment**: on apt/dnf systems, Node.js hints use NodeSource LTS bootstrap before package install
 - **Dependency-first approach**: detects what's installed, calculates what's needed, shows the full dependency tree before installing anything, then verifies each dependency after installation

--- a/e2e/Dockerfile.opensuse
+++ b/e2e/Dockerfile.opensuse
@@ -22,7 +22,7 @@ RUN zypper --non-interactive refresh && \
 # Install Go (match go.mod version)
 # ---------------------------------------------------------------------------
 ARG GO_VERSION=1.25.10
-RUN curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" \
+RUN set -o pipefail && curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" \
     | tar -C /usr/local -xz
 ENV PATH="/usr/local/go/bin:${PATH}"
 

--- a/e2e/Dockerfile.opensuse
+++ b/e2e/Dockerfile.opensuse
@@ -1,0 +1,68 @@
+# syntax=docker/dockerfile:1
+# Dockerfile.opensuse — E2E test image for gentle-ai on openSUSE Leap 15.6
+# Builds the binary from source and runs the E2E test suite as a non-root user.
+FROM opensuse/leap:15.6
+
+# ---------------------------------------------------------------------------
+# System dependencies (includes npm/node for claude-code tests)
+# ---------------------------------------------------------------------------
+RUN zypper --non-interactive refresh && \
+    zypper --non-interactive install --no-recommends \
+        git \
+        curl \
+        sudo \
+        ca-certificates \
+        tar \
+        gzip \
+        nodejs-default \
+        npm-default \
+    && zypper clean --all
+
+# ---------------------------------------------------------------------------
+# Install Go (match go.mod version)
+# ---------------------------------------------------------------------------
+ARG GO_VERSION=1.25.10
+RUN curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" \
+    | tar -C /usr/local -xz
+ENV PATH="/usr/local/go/bin:${PATH}"
+
+# ---------------------------------------------------------------------------
+# Create non-root test user with passwordless sudo
+# ---------------------------------------------------------------------------
+RUN useradd -m -s /bin/bash testuser && \
+    echo "testuser ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+
+# ---------------------------------------------------------------------------
+# Copy project source and build
+# ---------------------------------------------------------------------------
+WORKDIR /build
+COPY go.mod go.sum ./
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/root/go/pkg/mod \
+    go mod download
+COPY . .
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/root/go/pkg/mod \
+    CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
+    go build -o /usr/local/bin/gentle-ai ./cmd/gentle-ai
+
+# ---------------------------------------------------------------------------
+# Prepare test environment
+# ---------------------------------------------------------------------------
+COPY e2e/lib.sh      /home/testuser/e2e/lib.sh
+COPY e2e/e2e_test.sh /home/testuser/e2e/e2e_test.sh
+RUN chmod +x /home/testuser/e2e/e2e_test.sh /home/testuser/e2e/lib.sh && \
+    chown -R testuser:testuser /home/testuser
+
+USER testuser
+
+# Ensure go install binaries are on PATH for testuser
+ENV GOPATH="/home/testuser/go"
+ENV PATH="${GOPATH}/bin:/usr/local/go/bin:${PATH}"
+
+WORKDIR /home/testuser
+
+# ---------------------------------------------------------------------------
+# Default: run Tier 1 tests only
+# ---------------------------------------------------------------------------
+CMD ["./e2e/e2e_test.sh"]

--- a/e2e/docker-test.sh
+++ b/e2e/docker-test.sh
@@ -32,6 +32,7 @@ PLATFORMS=(
     "ubuntu:Dockerfile.ubuntu"
     "arch:Dockerfile.arch"
     "fedora:Dockerfile.fedora"
+    "opensuse:Dockerfile.opensuse"
 )
 
 # Environment variables to forward into containers

--- a/internal/agents/kilocode/adapter_test.go
+++ b/internal/agents/kilocode/adapter_test.go
@@ -221,6 +221,11 @@ func TestInstallCommand(t *testing.T) {
 			want:    [][]string{{"sudo", "npm", "install", "-g", "--ignore-scripts", "@kilocode/cli@" + versions.Kilocode}},
 		},
 		{
+			name:    "opensuse resolves npm install with sudo",
+			profile: system.PlatformProfile{OS: "linux", LinuxDistro: system.LinuxDistroOpenSUSE, PackageManager: "zypper"},
+			want:    [][]string{{"sudo", "npm", "install", "-g", "--ignore-scripts", "@kilocode/cli@" + versions.Kilocode}},
+		},
+		{
 			name:    "linux with writable npm skips sudo",
 			profile: system.PlatformProfile{OS: "linux", LinuxDistro: system.LinuxDistroFedora, PackageManager: "dnf", NpmWritable: true},
 			want:    [][]string{{"npm", "install", "-g", "--ignore-scripts", "@kilocode/cli@" + versions.Kilocode}},

--- a/internal/agents/opencode/adapter_test.go
+++ b/internal/agents/opencode/adapter_test.go
@@ -123,8 +123,18 @@ func TestInstallCommand(t *testing.T) {
 			want:    [][]string{{"npm", "install", "-g", "--ignore-scripts", "opencode-ai@" + versions.OpenCode}},
 		},
 		{
+			name:    "opensuse resolves npm install",
+			profile: system.PlatformProfile{OS: "linux", LinuxDistro: system.LinuxDistroOpenSUSE, PackageManager: "zypper"},
+			want:    [][]string{{"sudo", "npm", "install", "-g", "--ignore-scripts", "opencode-ai@" + versions.OpenCode}},
+		},
+		{
+			name:    "opensuse with writable npm skips sudo",
+			profile: system.PlatformProfile{OS: "linux", LinuxDistro: system.LinuxDistroOpenSUSE, PackageManager: "zypper", NpmWritable: true},
+			want:    [][]string{{"npm", "install", "-g", "--ignore-scripts", "opencode-ai@" + versions.OpenCode}},
+		},
+		{
 			name:    "unsupported package manager returns error",
-			profile: system.PlatformProfile{OS: "linux", LinuxDistro: system.LinuxDistroUbuntu, PackageManager: "zypper"},
+			profile: system.PlatformProfile{OS: "linux", LinuxDistro: system.LinuxDistroUbuntu, PackageManager: "unknownpm"},
 			wantErr: true,
 		},
 	}

--- a/internal/app/parity_test.go
+++ b/internal/app/parity_test.go
@@ -129,6 +129,13 @@ func TestGuardAcceptsFedoraProfile(t *testing.T) {
 	}
 }
 
+func TestGuardAcceptsOpenSUSEProfile(t *testing.T) {
+	profile := system.PlatformProfile{OS: "linux", LinuxDistro: system.LinuxDistroOpenSUSE, PackageManager: "zypper", Supported: true}
+	if err := system.EnsureSupportedPlatform(profile); err != nil {
+		t.Fatalf("expected opensuse profile to be accepted, got %v", err)
+	}
+}
+
 func TestGuardFlowLinuxDryRunPropagatesDecision(t *testing.T) {
 	detection := system.DetectionResult{
 		System: system.SystemInfo{
@@ -336,6 +343,13 @@ func TestGuardFlowLinuxArchProfileExplicitlyPasses(t *testing.T) {
 	profile := system.PlatformProfile{OS: "linux", LinuxDistro: system.LinuxDistroArch, PackageManager: "pacman", Supported: true}
 	if err := system.EnsureSupportedPlatform(profile); err != nil {
 		t.Fatalf("Arch profile should pass guard, got %v", err)
+	}
+}
+
+func TestGuardFlowLinuxOpenSUSEProfileExplicitlyPasses(t *testing.T) {
+	profile := system.PlatformProfile{OS: "linux", LinuxDistro: system.LinuxDistroOpenSUSE, PackageManager: "zypper", Supported: true}
+	if err := system.EnsureSupportedPlatform(profile); err != nil {
+		t.Fatalf("openSUSE profile should pass guard, got %v", err)
 	}
 }
 

--- a/internal/cli/run_integration_test.go
+++ b/internal/cli/run_integration_test.go
@@ -569,6 +569,52 @@ func TestRunInstallFedoraQwenEngramSkipsUnsupportedSetupAndWritesSettings(t *tes
 	}
 }
 
+func TestRunInstallOpenSUSEQwenEngramSkipsUnsupportedSetupAndWritesSettings(t *testing.T) {
+	home := t.TempDir()
+	restoreHome := osUserHomeDir
+	restoreCommand := runCommand
+	restoreLookPath := cmdLookPath
+	t.Cleanup(func() {
+		osUserHomeDir = restoreHome
+		runCommand = restoreCommand
+		cmdLookPath = restoreLookPath
+	})
+
+	osUserHomeDir = func() (string, error) { return home, nil }
+	cmdLookPath = missingBinaryLookPath
+	recorder := &commandRecorder{}
+	runCommand = recorder.record
+
+	origDownloadFn := engramDownloadFn
+	engramDownloadFn = func(profile system.PlatformProfile) (string, error) {
+		return filepath.Join(home, "bin", "engram"), nil
+	}
+	t.Cleanup(func() { engramDownloadFn = origDownloadFn })
+
+	detection := linuxDetectionResult(system.LinuxDistroOpenSUSE, "zypper")
+	result, err := RunInstall(
+		[]string{"--agent", "qwen-code", "--component", "engram"},
+		detection,
+	)
+	if err != nil {
+		t.Fatalf("RunInstall() error = %v", err)
+	}
+	if !result.Verify.Ready {
+		t.Fatalf("verification ready = false, report = %#v", result.Verify)
+	}
+
+	settingsPath := filepath.Join(home, ".qwen", "settings.json")
+	if _, err := os.Stat(settingsPath); err != nil {
+		t.Fatalf("expected qwen settings at %q: %v", settingsPath, err)
+	}
+
+	for _, cmd := range recorder.get() {
+		if strings.Contains(cmd, "engram setup qwen-code") {
+			t.Fatalf("unexpected unsupported setup command: %s", cmd)
+		}
+	}
+}
+
 func TestRunInstallLinuxAgentInstallResolvesGoInstallCommand(t *testing.T) {
 	home := t.TempDir()
 	restoreHome := osUserHomeDir

--- a/internal/cli/run_path_guidance_test.go
+++ b/internal/cli/run_path_guidance_test.go
@@ -26,6 +26,9 @@ func TestEngramPathGuidanceZsh(t *testing.T) {
 }
 
 func TestEngramPathGuidanceDefault(t *testing.T) {
+	t.Setenv("GOBIN", "")
+	t.Setenv("GOPATH", "")
+
 	msg := engramPathGuidance("")
 	want := filepath.Join("go", "bin")
 	if !strings.Contains(msg, want) {

--- a/internal/components/engram/download_resolver_test.go
+++ b/internal/components/engram/download_resolver_test.go
@@ -29,6 +29,10 @@ func TestInstallCommandNonBrewReturnsError(t *testing.T) {
 			profile: system.PlatformProfile{OS: "linux", LinuxDistro: system.LinuxDistroFedora, PackageManager: "dnf"},
 		},
 		{
+			name:    "opensuse returns error (no longer go install)",
+			profile: system.PlatformProfile{OS: "linux", LinuxDistro: system.LinuxDistroOpenSUSE, PackageManager: "zypper"},
+		},
+		{
 			name:    "windows returns error (no longer go install)",
 			profile: system.PlatformProfile{OS: "windows", PackageManager: "winget"},
 		},

--- a/internal/components/engram/install_test.go
+++ b/internal/components/engram/install_test.go
@@ -37,8 +37,13 @@ func TestInstallCommandByProfile(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name:    "opensuse returns error (uses DownloadLatestBinary instead of go install)",
+			profile: system.PlatformProfile{OS: "linux", LinuxDistro: system.LinuxDistroOpenSUSE, PackageManager: "zypper"},
+			wantErr: true,
+		},
+		{
 			name:    "unsupported package manager returns error",
-			profile: system.PlatformProfile{OS: "linux", PackageManager: "zypper"},
+			profile: system.PlatformProfile{OS: "linux", PackageManager: "unknownpm"},
 			wantErr: true,
 		},
 	}

--- a/internal/components/gga/install_test.go
+++ b/internal/components/gga/install_test.go
@@ -100,10 +100,19 @@ func TestInstallCommandByProfile(t *testing.T) {
 			},
 		},
 		{
+			name:    "opensuse uses git clone and install.sh",
+			profile: system.PlatformProfile{OS: "linux", LinuxDistro: system.LinuxDistroOpenSUSE, PackageManager: "zypper"},
+			want: [][]string{
+				{"rm", "-rf", "/tmp/gentleman-guardian-angel"},
+				{"git", "clone", "https://github.com/Gentleman-Programming/gentleman-guardian-angel.git", "/tmp/gentleman-guardian-angel"},
+				{"bash", "/tmp/gentleman-guardian-angel/install.sh"},
+			},
+		},
+		{
 			name: "unsupported package manager returns error",
 			profile: system.PlatformProfile{
 				OS:             "linux",
-				PackageManager: "zypper",
+				PackageManager: "unknownpm",
 			},
 			wantErr: true,
 		},

--- a/internal/installcmd/resolver.go
+++ b/internal/installcmd/resolver.go
@@ -179,6 +179,8 @@ func uvInstallHint(profile system.PlatformProfile) string {
 		return "sudo pacman -S --noconfirm uv"
 	case "dnf":
 		return "sudo dnf install -y uv"
+	case "zypper":
+		return "curl -LsSf https://astral.sh/uv/install.sh | sh"
 	case "winget":
 		return "winget install --id astral-sh.uv -e --accept-source-agreements --accept-package-agreements"
 	default:
@@ -211,6 +213,8 @@ func (profileResolver) ResolveDependencyInstall(profile system.PlatformProfile, 
 		return CommandSequence{{"sudo", "pacman", "-S", "--noconfirm", dependency}}, nil
 	case "dnf":
 		return CommandSequence{{"sudo", "dnf", "install", "-y", dependency}}, nil
+	case "zypper":
+		return CommandSequence{{"sudo", "zypper", "--non-interactive", "install", dependency}}, nil
 	case "winget":
 		return CommandSequence{{"winget", "install", "--id", dependency, "-e", "--accept-source-agreements", "--accept-package-agreements"}}, nil
 	default:
@@ -233,7 +237,7 @@ func resolveOpenCodeInstall(profile system.PlatformProfile) (CommandSequence, er
 		return CommandSequence{
 			{"brew", "install", "anomalyco/tap/opencode"},
 		}, nil
-	case "apt", "pacman", "dnf":
+	case "apt", "pacman", "dnf", "zypper":
 		pkg := "opencode-ai@" + versions.OpenCode
 		if profile.NpmWritable {
 			return CommandSequence{{"npm", "install", "-g", "--ignore-scripts", pkg}}, nil
@@ -260,7 +264,7 @@ func resolveGGAInstall(profile system.PlatformProfile) (CommandSequence, error) 
 			{"brew", "tap", "Gentleman-Programming/homebrew-tap"},
 			{"brew", "reinstall", "gga"},
 		}, nil
-	case "apt", "pacman", "dnf":
+	case "apt", "pacman", "dnf", "zypper":
 		const tmpDir = "/tmp/gentleman-guardian-angel"
 		return CommandSequence{
 			{"rm", "-rf", tmpDir},

--- a/internal/installcmd/resolver_test.go
+++ b/internal/installcmd/resolver_test.go
@@ -178,6 +178,12 @@ func TestResolveDependencyInstall(t *testing.T) {
 			want:    CommandSequence{{"sudo", "dnf", "install", "-y", "somepkg"}},
 		},
 		{
+			name:    "opensuse resolves zypper command",
+			profile: system.PlatformProfile{OS: "linux", LinuxDistro: system.LinuxDistroOpenSUSE, PackageManager: "zypper"},
+			dep:     "somepkg",
+			want:    CommandSequence{{"sudo", "zypper", "--non-interactive", "install", "somepkg"}},
+		},
+		{
 			name:    "windows resolves winget command",
 			profile: system.PlatformProfile{OS: "windows", PackageManager: "winget"},
 			dep:     "somepkg",
@@ -185,7 +191,7 @@ func TestResolveDependencyInstall(t *testing.T) {
 		},
 		{
 			name:    "unsupported package manager returns error",
-			profile: system.PlatformProfile{OS: "linux", LinuxDistro: system.LinuxDistroUbuntu, PackageManager: "zypper"},
+			profile: system.PlatformProfile{OS: "linux", LinuxDistro: system.LinuxDistroUbuntu, PackageManager: "unknownpm"},
 			dep:     "somepkg",
 			wantErr: true,
 		},
@@ -323,6 +329,12 @@ func TestResolveAgentInstall(t *testing.T) {
 			want:    CommandSequence{{"npm", "install", "-g", "--ignore-scripts", "@anthropic-ai/claude-code@" + versions.ClaudeCode}},
 		},
 		{
+			name:    "claude-code on opensuse system npm uses sudo",
+			profile: system.PlatformProfile{OS: "linux", LinuxDistro: system.LinuxDistroOpenSUSE, PackageManager: "zypper"},
+			agent:   model.AgentClaudeCode,
+			want:    CommandSequence{{"sudo", "npm", "install", "-g", "--ignore-scripts", "@anthropic-ai/claude-code@" + versions.ClaudeCode}},
+		},
+		{
 			name:    "opencode on darwin uses official anomalyco brew tap",
 			profile: system.PlatformProfile{OS: "darwin", PackageManager: "brew"},
 			agent:   model.AgentOpenCode,
@@ -359,6 +371,18 @@ func TestResolveAgentInstall(t *testing.T) {
 			want:    CommandSequence{{"npm", "install", "-g", "--ignore-scripts", "opencode-ai@" + versions.OpenCode}},
 		},
 		{
+			name:    "opencode on opensuse system npm uses sudo",
+			profile: system.PlatformProfile{OS: "linux", LinuxDistro: system.LinuxDistroOpenSUSE, PackageManager: "zypper"},
+			agent:   model.AgentOpenCode,
+			want:    CommandSequence{{"sudo", "npm", "install", "-g", "--ignore-scripts", "opencode-ai@" + versions.OpenCode}},
+		},
+		{
+			name:    "opencode on opensuse nvm skips sudo",
+			profile: system.PlatformProfile{OS: "linux", LinuxDistro: system.LinuxDistroOpenSUSE, PackageManager: "zypper", NpmWritable: true},
+			agent:   model.AgentOpenCode,
+			want:    CommandSequence{{"npm", "install", "-g", "--ignore-scripts", "opencode-ai@" + versions.OpenCode}},
+		},
+		{
 			name:    "claude-code on windows uses npm without sudo",
 			profile: system.PlatformProfile{OS: "windows", PackageManager: "winget", NpmWritable: true},
 			agent:   model.AgentClaudeCode,
@@ -379,6 +403,12 @@ func TestResolveAgentInstall(t *testing.T) {
 		{
 			name:    "kimi on unix uses uv to strictly enforce secure package installation",
 			profile: system.PlatformProfile{OS: "linux", LinuxDistro: system.LinuxDistroUbuntu, PackageManager: "apt", Supported: true},
+			agent:   model.AgentKimi,
+			want:    CommandSequence{{"uv", "tool", "install", "--python", "3.13", "kimi-cli"}},
+		},
+		{
+			name:    "kimi on opensuse uses uv to strictly enforce secure package installation",
+			profile: system.PlatformProfile{OS: "linux", LinuxDistro: system.LinuxDistroOpenSUSE, PackageManager: "zypper", Supported: true},
 			agent:   model.AgentKimi,
 			want:    CommandSequence{{"uv", "tool", "install", "--python", "3.13", "kimi-cli"}},
 		},
@@ -446,6 +476,19 @@ func TestValidateAgentInstallPreflight(t *testing.T) {
 			},
 			wantErr:     true,
 			errContains: "brew install uv",
+		},
+		{
+			name:    "kimi missing uv on opensuse returns official installer remediation",
+			profile: system.PlatformProfile{OS: "linux", LinuxDistro: system.LinuxDistroOpenSUSE, PackageManager: "zypper", Supported: true},
+			agent:   model.AgentKimi,
+			lookPath: func(file string) (string, error) {
+				if file == "uv" {
+					return "", fmt.Errorf("not found")
+				}
+				return "/usr/bin/" + file, nil
+			},
+			wantErr:     true,
+			errContains: "https://astral.sh/uv/install.sh",
 		},
 		{
 			name:    "kimi with uv present passes preflight",
@@ -612,6 +655,12 @@ func TestResolveComponentInstall(t *testing.T) {
 			wantErr:   true,
 		},
 		{
+			name:      "engram on opensuse returns error (uses DownloadLatestBinary instead)",
+			profile:   system.PlatformProfile{OS: "linux", LinuxDistro: system.LinuxDistroOpenSUSE, PackageManager: "zypper"},
+			component: model.ComponentEngram,
+			wantErr:   true,
+		},
+		{
 			name:      "gga on darwin uses brew tap and reinstall",
 			profile:   system.PlatformProfile{OS: "darwin", PackageManager: "brew"},
 			component: model.ComponentGGA,
@@ -640,6 +689,16 @@ func TestResolveComponentInstall(t *testing.T) {
 		{
 			name:      "gga on fedora uses git clone and install.sh",
 			profile:   system.PlatformProfile{OS: "linux", LinuxDistro: system.LinuxDistroFedora, PackageManager: "dnf"},
+			component: model.ComponentGGA,
+			want: CommandSequence{
+				{"rm", "-rf", "/tmp/gentleman-guardian-angel"},
+				{"git", "clone", "https://github.com/Gentleman-Programming/gentleman-guardian-angel.git", "/tmp/gentleman-guardian-angel"},
+				{"bash", "/tmp/gentleman-guardian-angel/install.sh"},
+			},
+		},
+		{
+			name:      "gga on opensuse uses git clone and install.sh",
+			profile:   system.PlatformProfile{OS: "linux", LinuxDistro: system.LinuxDistroOpenSUSE, PackageManager: "zypper"},
 			component: model.ComponentGGA,
 			want: CommandSequence{
 				{"rm", "-rf", "/tmp/gentleman-guardian-angel"},

--- a/internal/planner/review_test.go
+++ b/internal/planner/review_test.go
@@ -76,6 +76,15 @@ func TestPlatformDecisionFromProfileMatrix(t *testing.T) {
 				OS: "linux", LinuxDistro: system.LinuxDistroFedora, PackageManager: "dnf", Supported: true,
 			},
 		},
+		{
+			name: "opensuse profile maps to zypper decision",
+			profile: system.PlatformProfile{
+				OS: "linux", LinuxDistro: system.LinuxDistroOpenSUSE, PackageManager: "zypper", Supported: true,
+			},
+			want: PlatformDecision{
+				OS: "linux", LinuxDistro: system.LinuxDistroOpenSUSE, PackageManager: "zypper", Supported: true,
+			},
+		},
 	}
 
 	for _, tc := range tests {
@@ -94,6 +103,7 @@ func TestBuildReviewPayloadPlatformDecisionPropagatesPerProfile(t *testing.T) {
 		{OS: "linux", LinuxDistro: "ubuntu", PackageManager: "apt", Supported: true},
 		{OS: "linux", LinuxDistro: "arch", PackageManager: "pacman", Supported: true},
 		{OS: "linux", LinuxDistro: system.LinuxDistroFedora, PackageManager: "dnf", Supported: true},
+		{OS: "linux", LinuxDistro: system.LinuxDistroOpenSUSE, PackageManager: "zypper", Supported: true},
 	}
 
 	for _, decision := range profiles {

--- a/internal/system/detect.go
+++ b/internal/system/detect.go
@@ -26,11 +26,12 @@ type PlatformProfile struct {
 }
 
 const (
-	LinuxDistroUnknown = "unknown"
-	LinuxDistroUbuntu  = "ubuntu"
-	LinuxDistroDebian  = "debian"
-	LinuxDistroArch    = "arch"
-	LinuxDistroFedora  = "fedora"
+	LinuxDistroUnknown  = "unknown"
+	LinuxDistroUbuntu   = "ubuntu"
+	LinuxDistroDebian   = "debian"
+	LinuxDistroArch     = "arch"
+	LinuxDistroFedora   = "fedora"
+	LinuxDistroOpenSUSE = "opensuse"
 )
 
 type DetectionResult struct {
@@ -148,6 +149,9 @@ func resolvePlatformProfile(goos, linuxOSRelease string, tools map[string]ToolSt
 		case LinuxDistroFedora:
 			profile.PackageManager = "dnf"
 			profile.Supported = true
+		case LinuxDistroOpenSUSE:
+			profile.PackageManager = "zypper"
+			profile.Supported = true
 		default:
 			profile.PackageManager = ""
 			profile.Supported = false
@@ -204,6 +208,10 @@ func detectLinuxDistro(linuxOSRelease string) string {
 		return LinuxDistroFedora
 	}
 
+	if isOpenSUSELike(id, idLike) {
+		return LinuxDistroOpenSUSE
+	}
+
 	return LinuxDistroUnknown
 }
 
@@ -242,6 +250,20 @@ func isFedoraLike(id, idLike string) bool {
 
 	for _, token := range strings.Fields(idLike) {
 		if token == LinuxDistroFedora || token == "rhel" || token == "centos" || token == "rocky" || token == "almalinux" || token == "nobara" {
+			return true
+		}
+	}
+
+	return false
+}
+
+func isOpenSUSELike(id, idLike string) bool {
+	if id == LinuxDistroOpenSUSE || id == "suse" || strings.HasPrefix(id, "opensuse-") {
+		return true
+	}
+
+	for _, token := range strings.Fields(idLike) {
+		if token == LinuxDistroOpenSUSE || token == "suse" || strings.HasPrefix(token, "opensuse-") {
 			return true
 		}
 	}

--- a/internal/system/detect_test.go
+++ b/internal/system/detect_test.go
@@ -56,6 +56,23 @@ func TestDetectFromInputsMarksFedoraSupported(t *testing.T) {
 	}
 }
 
+func TestDetectFromInputsMarksOpenSUSESupported(t *testing.T) {
+	osRelease := "ID=opensuse-leap\nID_LIKE=\"suse opensuse\"\n"
+	result := detectFromInputs("linux", "amd64", "/bin/bash", osRelease, nil, nil)
+
+	if !result.System.Supported {
+		t.Fatalf("expected supported system for openSUSE linux distro")
+	}
+
+	if result.System.Profile.LinuxDistro != LinuxDistroOpenSUSE {
+		t.Fatalf("expected opensuse distro, got %q", result.System.Profile.LinuxDistro)
+	}
+
+	if result.System.Profile.PackageManager != "zypper" {
+		t.Fatalf("expected zypper package manager, got %q", result.System.Profile.PackageManager)
+	}
+}
+
 func TestDetectFromInputsMarksUbuntuSupported(t *testing.T) {
 	osRelease := "ID=ubuntu\nID_LIKE=debian\n"
 	result := detectFromInputs("linux", "amd64", "/bin/bash", osRelease, nil, nil)
@@ -169,6 +186,21 @@ func TestDetectLinuxDistroMatrix(t *testing.T) {
 			wantDistro: LinuxDistroFedora,
 		},
 		{
+			name:       "opensuse tumbleweed",
+			osRelease:  "ID=opensuse-tumbleweed\nID_LIKE=\"opensuse suse\"\n",
+			wantDistro: LinuxDistroOpenSUSE,
+		},
+		{
+			name:       "opensuse leap",
+			osRelease:  "ID=opensuse-leap\nID_LIKE=\"suse opensuse\"\n",
+			wantDistro: LinuxDistroOpenSUSE,
+		},
+		{
+			name:       "opensuse via id_like token",
+			osRelease:  "ID=custom-linux\nID_LIKE=\"opensuse\"\n",
+			wantDistro: LinuxDistroOpenSUSE,
+		},
+		{
 			name:       "empty os-release",
 			osRelease:  "",
 			wantDistro: LinuxDistroUnknown,
@@ -270,6 +302,15 @@ func TestResolvePlatformProfileMatrix(t *testing.T) {
 			wantSupported: true,
 		},
 		{
+			name:          "opensuse profile",
+			goos:          "linux",
+			osRelease:     "ID=opensuse-tumbleweed\nID_LIKE=\"opensuse suse\"\n",
+			wantOS:        "linux",
+			wantPM:        "zypper",
+			wantDistro:    LinuxDistroOpenSUSE,
+			wantSupported: true,
+		},
+		{
 			name:          "windows profile",
 			goos:          "windows",
 			wantOS:        "windows",
@@ -311,9 +352,9 @@ func TestResolvePlatformProfileMatrix(t *testing.T) {
 // used by effectiveMethod to implement the brew → go-install → binary auto-detect order.
 func TestGoAvailableInPlatformProfile(t *testing.T) {
 	tests := []struct {
-		name         string
-		tools        map[string]ToolStatus
-		wantGoAvail  bool
+		name        string
+		tools       map[string]ToolStatus
+		wantGoAvail bool
 	}{
 		{
 			name:        "go in tools and installed → GoAvailable true",

--- a/internal/system/guard.go
+++ b/internal/system/guard.go
@@ -27,7 +27,7 @@ func EnsureSupportedPlatform(profile PlatformProfile) error {
 	}
 
 	if profile.OS == "linux" && !profile.Supported {
-		return fmt.Errorf("%w: Linux support is limited to Ubuntu/Debian, Arch, and Fedora/RHEL family (detected %s)", ErrUnsupportedLinuxDistro, profile.LinuxDistro)
+		return fmt.Errorf("%w: Linux support is limited to Ubuntu/Debian, Arch, Fedora/RHEL family, and openSUSE family (detected %s)", ErrUnsupportedLinuxDistro, profile.LinuxDistro)
 	}
 
 	return nil

--- a/internal/system/guard_test.go
+++ b/internal/system/guard_test.go
@@ -47,6 +47,13 @@ func TestEnsureSupportedPlatformAllowsSupportedFedoraLinux(t *testing.T) {
 	}
 }
 
+func TestEnsureSupportedPlatformAllowsSupportedOpenSUSELinux(t *testing.T) {
+	err := EnsureSupportedPlatform(PlatformProfile{OS: "linux", LinuxDistro: LinuxDistroOpenSUSE, PackageManager: "zypper", Supported: true})
+	if err != nil {
+		t.Fatalf("expected opensuse profile to be supported, got %v", err)
+	}
+}
+
 func TestEnsureSupportedPlatformRejectsUnsupportedLinuxDistro(t *testing.T) {
 	err := EnsureSupportedPlatform(PlatformProfile{OS: "linux", LinuxDistro: LinuxDistroUnknown, Supported: false})
 	if err == nil {
@@ -57,7 +64,7 @@ func TestEnsureSupportedPlatformRejectsUnsupportedLinuxDistro(t *testing.T) {
 		t.Fatalf("expected ErrUnsupportedLinuxDistro, got %v", err)
 	}
 
-	if !strings.Contains(err.Error(), "Linux support is limited to Ubuntu/Debian, Arch, and Fedora/RHEL family") {
+	if !strings.Contains(err.Error(), "Linux support is limited to Ubuntu/Debian, Arch, Fedora/RHEL family, and openSUSE family") {
 		t.Fatalf("expected distro guard message, got %q", err.Error())
 	}
 }

--- a/internal/system/install_deps.go
+++ b/internal/system/install_deps.go
@@ -15,6 +15,8 @@ func installHintGit(profile PlatformProfile) string {
 		return "sudo pacman -S --noconfirm git"
 	case profile.PackageManager == "dnf":
 		return "sudo dnf install -y git"
+	case profile.PackageManager == "zypper":
+		return "sudo zypper --non-interactive install git"
 	default:
 		return "install git from https://git-scm.com/"
 	}
@@ -33,6 +35,8 @@ func installHintCurl(profile PlatformProfile) string {
 		return "sudo pacman -S --noconfirm curl"
 	case profile.PackageManager == "dnf":
 		return "sudo dnf install -y curl"
+	case profile.PackageManager == "zypper":
+		return "sudo zypper --non-interactive install curl"
 	default:
 		return "install curl from https://curl.se/"
 	}
@@ -51,6 +55,8 @@ func installHintNode(profile PlatformProfile) string {
 		return "sudo pacman -S --noconfirm nodejs npm"
 	case profile.PackageManager == "dnf":
 		return "curl -fsSL https://rpm.nodesource.com/setup_lts.x | sudo bash - && sudo dnf install -y nodejs"
+	case profile.PackageManager == "zypper":
+		return "sudo zypper --non-interactive install nodejs-default npm-default"
 	default:
 		return "install node from https://nodejs.org/"
 	}
@@ -80,6 +86,8 @@ func installHintGo(profile PlatformProfile) string {
 		return "sudo pacman -S --noconfirm go"
 	case profile.PackageManager == "dnf":
 		return "sudo dnf install -y golang"
+	case profile.PackageManager == "zypper":
+		return "sudo zypper --non-interactive install go"
 	default:
 		return "install go from https://go.dev/dl/"
 	}
@@ -140,6 +148,8 @@ func installCommandsGit(profile PlatformProfile) [][]string {
 		return [][]string{{"sudo", "pacman", "-S", "--noconfirm", "git"}}
 	case profile.PackageManager == "dnf":
 		return [][]string{{"sudo", "dnf", "install", "-y", "git"}}
+	case profile.PackageManager == "zypper":
+		return [][]string{{"sudo", "zypper", "--non-interactive", "install", "git"}}
 	default:
 		return nil
 	}
@@ -158,6 +168,8 @@ func installCommandsCurl(profile PlatformProfile) [][]string {
 		return [][]string{{"sudo", "pacman", "-S", "--noconfirm", "curl"}}
 	case profile.PackageManager == "dnf":
 		return [][]string{{"sudo", "dnf", "install", "-y", "curl"}}
+	case profile.PackageManager == "zypper":
+		return [][]string{{"sudo", "zypper", "--non-interactive", "install", "curl"}}
 	default:
 		return nil
 	}
@@ -183,6 +195,8 @@ func installCommandsNode(profile PlatformProfile) [][]string {
 			{"bash", "-c", "curl -fsSL https://rpm.nodesource.com/setup_lts.x | sudo bash -"},
 			{"sudo", "dnf", "install", "-y", "nodejs"},
 		}
+	case profile.PackageManager == "zypper":
+		return [][]string{{"sudo", "zypper", "--non-interactive", "install", "nodejs-default", "npm-default"}}
 	default:
 		return nil
 	}
@@ -209,6 +223,8 @@ func installCommandsGo(profile PlatformProfile) [][]string {
 		return [][]string{{"sudo", "pacman", "-S", "--noconfirm", "go"}}
 	case profile.PackageManager == "dnf":
 		return [][]string{{"sudo", "dnf", "install", "-y", "golang"}}
+	case profile.PackageManager == "zypper":
+		return [][]string{{"sudo", "zypper", "--non-interactive", "install", "go"}}
 	default:
 		return nil
 	}

--- a/internal/system/install_deps_test.go
+++ b/internal/system/install_deps_test.go
@@ -61,6 +61,14 @@ func TestInstallHintNodeFedora(t *testing.T) {
 	}
 }
 
+func TestInstallHintNodeOpenSUSE(t *testing.T) {
+	profile := PlatformProfile{OS: "linux", PackageManager: "zypper", LinuxDistro: LinuxDistroOpenSUSE}
+	hint := installHintNode(profile)
+	if !strings.Contains(hint, "zypper") || !strings.Contains(hint, "nodejs-default npm-default") {
+		t.Fatalf("installHintNode(opensuse) = %q, want zypper nodejs-default npm-default install", hint)
+	}
+}
+
 func TestInstallHintBrew(t *testing.T) {
 	hint := installHintBrew()
 	if !strings.Contains(hint, "Homebrew") {
@@ -81,6 +89,14 @@ func TestInstallHintGoUbuntu(t *testing.T) {
 	hint := installHintGo(profile)
 	if !strings.Contains(hint, "apt-get install") {
 		t.Fatalf("installHintGo(ubuntu) = %q", hint)
+	}
+}
+
+func TestInstallHintGoOpenSUSE(t *testing.T) {
+	profile := PlatformProfile{OS: "linux", PackageManager: "zypper", LinuxDistro: LinuxDistroOpenSUSE}
+	hint := installHintGo(profile)
+	if !strings.Contains(hint, "zypper") || !strings.Contains(hint, "install go") {
+		t.Fatalf("installHintGo(opensuse) = %q", hint)
 	}
 }
 
@@ -179,6 +195,28 @@ func TestInstallCommandsForDepGitFedoraUsesDnf(t *testing.T) {
 	}
 	if cmds[0][0] != "sudo" || cmds[0][1] != "dnf" {
 		t.Fatalf("git fedora command = %v, want sudo dnf", cmds[0])
+	}
+}
+
+func TestInstallCommandsForDepGitOpenSUSEUsesZypper(t *testing.T) {
+	profile := PlatformProfile{OS: "linux", PackageManager: "zypper", LinuxDistro: LinuxDistroOpenSUSE}
+	cmds := InstallCommandsForDep("git", profile)
+	if len(cmds) != 1 {
+		t.Fatalf("git opensuse commands = %d, want 1", len(cmds))
+	}
+	if len(cmds[0]) != 5 || cmds[0][0] != "sudo" || cmds[0][1] != "zypper" || cmds[0][2] != "--non-interactive" || cmds[0][3] != "install" || cmds[0][4] != "git" {
+		t.Fatalf("git opensuse command = %v, want sudo zypper --non-interactive install git", cmds[0])
+	}
+}
+
+func TestInstallCommandsForDepNodeOpenSUSEUsesDefaultPackages(t *testing.T) {
+	profile := PlatformProfile{OS: "linux", PackageManager: "zypper", LinuxDistro: LinuxDistroOpenSUSE}
+	cmds := InstallCommandsForDep("node", profile)
+	if len(cmds) != 1 {
+		t.Fatalf("node opensuse commands = %d, want 1", len(cmds))
+	}
+	if len(cmds[0]) != 6 || cmds[0][0] != "sudo" || cmds[0][1] != "zypper" || cmds[0][2] != "--non-interactive" || cmds[0][3] != "install" || cmds[0][4] != "nodejs-default" || cmds[0][5] != "npm-default" {
+		t.Fatalf("node opensuse command = %v, want sudo zypper --non-interactive install nodejs-default npm-default", cmds[0])
 	}
 }
 
@@ -281,6 +319,7 @@ func TestInstallCommandsFullMatrix(t *testing.T) {
 		{OS: "linux", PackageManager: "apt", LinuxDistro: "ubuntu"},
 		{OS: "linux", PackageManager: "pacman", LinuxDistro: "arch"},
 		{OS: "linux", PackageManager: "dnf", LinuxDistro: LinuxDistroFedora},
+		{OS: "linux", PackageManager: "zypper", LinuxDistro: LinuxDistroOpenSUSE},
 	}
 
 	deps := []string{"git", "curl", "node", "go"}


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #140

---

## 🏷️ PR Type

- [ ] `type:bug` — Bug fix
- [x] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring
- [ ] `type:chore` — Build, CI, or tooling
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Detect openSUSE family distros and map them to `zypper`.
- Add zypper dependency commands for git, curl, Go, and Node/npm.
- Add openSUSE tests, Docker Tier 1 E2E coverage, and docs updates.

---

## 📂 Changes

| Area | Change |
|------|--------|
| `internal/system` | openSUSE detection, support flag, and guard text |
| `internal/installcmd`, agents/components | zypper dependency/install paths |
| `internal/**/*_test.go` | openSUSE parity coverage |
| `e2e` | openSUSE Leap 15.6 Docker test image |
| `docs`, `PRD.md` | platform and install docs |

---

## 🧪 Test Plan

```bash
go test ./...
```

```bash
docker run --rm -v "$PWD:/mnt:ro" koalaman/shellcheck:stable e2e/docker-test.sh
```

```bash
docker build -f e2e/Dockerfile.opensuse -t gentle-ai-e2e-opensuse .
docker run --rm gentle-ai-e2e-opensuse
```

openSUSE Tier 1 result: 79 passed, 0 failed, 2 skipped. Full Docker matrix was not run locally.

- [x] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] openSUSE Docker Tier 1 passes
- [x] Manually tested locally

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR exceeds 400 changed lines; requesting `size:exception` because platform support includes implementation, tests, Docker image, and docs
- [ ] Maintainer needs to add exactly one `type:*` label: `type:feature`
- [x] Unit tests pass (`go test ./...`)
- [ ] Full Docker matrix E2E passes (`cd e2e && ./docker-test.sh`)
- [x] Documentation updated
- [x] Conventional commits
- [x] No `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

- Verified openSUSE package names: `git`, `curl`, `go`, `nodejs-default`, `npm-default`.
- `uv` uses Astral's official installer because no verified zypper path is documented upstream.
- `TestEngramPathGuidanceDefault` clears `GOBIN`/`GOPATH` for deterministic default path assertions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added official openSUSE Linux (Leap/Tumbleweed) support with `zypper` package-manager handling.
  * Enabled openSUSE-specific install commands and dependency installation behavior across supported tools and agents.
  * Extended E2E Docker testing to include an openSUSE container target.

* **Documentation**
  * Updated platform support, quickstart, usage, and non-interactive guidance with openSUSE (`zypper`) install examples and messaging.

* **Tests**
  * Expanded unit, guard-flow, integration, and resolver test coverage to validate openSUSE behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->