### PR TITLE
fix(tui): show PI install progress per package

### DIFF
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -432,10 +432,7 @@ func buildStagePlan(selection model.Selection, resolved planner.ResolvedPlan) pi
 	return pipeline.StagePlan{Prepare: prepare, Apply: apply}
 }
 
-// StagePlanLabels generates step labels that match the IDs produced by
-// installRuntime.stagePlan(), including multi-command agent expansion.
-// It is the authoritative source for label → step-ID alignment used by both
-// CLI and TUI. communityTools are appended verbatim as "community-tool:<id>".
+// StagePlanLabels generates step labels matching stagePlan() output for CLI/TUI progress.
 func StagePlanLabels(resolved planner.ResolvedPlan, communityTools []model.CommunityToolID) []string {
 	labels := make([]string, 0, 3+len(resolved.Agents)+len(communityTools)+len(resolved.OrderedComponents))
 
@@ -458,9 +455,7 @@ func StagePlanLabels(resolved planner.ResolvedPlan, communityTools []model.Commu
 	return labels
 }
 
-// agentStepLabels returns the step labels for a single agent.
-// For multi-command agents (PI), it returns one label per command.
-// For single-command agents, it returns one standard label.
+// agentStepLabels returns per-command labels for multi-command agents, or "agent:<name>".
 func agentStepLabels(agent model.AgentID) []string {
 	adapter, err := agents.NewAdapter(agent)
 	if err != nil || !adapter.SupportsAutoInstall() {
@@ -619,10 +614,8 @@ func (s piCodeGraphReconcileStep) Rollback() error {
 	return err
 }
 
-// agentStepsForAgent returns the pipeline steps for installing a single agent.
-// For multi-command agents (those whose InstallCommand returns >1 command),
-// it creates one agentCommandStep per command. For single-command agents,
-// it returns the existing agentInstallStep.
+// agentStepsForAgent returns one agentCommandStep per command for multi-command agents,
+// falling back to agentInstallStep for single-command agents.
 func (r *installRuntime) agentStepsForAgent(agent model.AgentID) []pipeline.Step {
 	adapter, err := agents.NewAdapter(agent)
 	if err != nil || !adapter.SupportsAutoInstall() {
@@ -637,7 +630,6 @@ func (r *installRuntime) agentStepsForAgent(agent model.AgentID) []pipeline.Step
 		return []pipeline.Step{agentInstallStep{id: "agent:" + string(agent), agent: agent, homeDir: r.homeDir, profile: r.profile}}
 	}
 
-	// Multi-command agent: create one sub-step per command.
 	steps := make([]pipeline.Step, len(commands))
 	for i, cmd := range commands {
 		steps[i] = agentCommandStep{
@@ -652,19 +644,20 @@ func (r *installRuntime) agentStepsForAgent(agent model.AgentID) []pipeline.Step
 	return steps
 }
 
-// commandStepID generates a deterministic step ID from a command.
-// For npm install commands, the format is "agent:<name>/npm:<package>".
+// commandStepID returns "agent:<name>/npm:<package>" for npm installs, or "agent:<name>/<arg>".
 func commandStepID(agent model.AgentID, cmd []string) string {
+	if len(cmd) == 0 {
+		return fmt.Sprintf("agent:%s/command", string(agent))
+	}
 	if len(cmd) >= 3 && cmd[1] == "install" && strings.HasPrefix(cmd[2], "npm:") {
 		pkg := strings.TrimPrefix(cmd[2], "npm:")
 		return fmt.Sprintf("agent:%s/npm:%s", string(agent), pkg)
 	}
-	// Fallback for non-npm commands (e.g., engram init).
 	return fmt.Sprintf("agent:%s/%s", string(agent), cmd[0])
 }
 
-// agentCommandStep runs a single install command for an agent.
-// When first is true, it also runs detection and preflight checks.
+// agentCommandStep runs a single agent install command as a pipeline step.
+// On first=true, it also runs detection and preflight checks.
 type agentCommandStep struct {
 	id      string
 	agent   model.AgentID
@@ -676,13 +669,14 @@ type agentCommandStep struct {
 
 func (s agentCommandStep) ID() string { return s.id }
 
+// Run executes the install command, running detection/preflight on first sub-step
+// and mapping Pi "module not found" errors to a user-friendly message.
 func (s agentCommandStep) Run() error {
 	adapter, err := agents.NewAdapter(s.agent)
 	if err != nil {
 		return fmt.Errorf("create adapter for %q: %w", s.agent, err)
 	}
 
-	// First sub-step handles detection and preflight.
 	if s.first {
 		if !adapter.SupportsAutoInstall() {
 			return nil
@@ -692,7 +686,6 @@ func (s agentCommandStep) Run() error {
 		if err != nil {
 			return fmt.Errorf("detect agent %q: %w", s.agent, err)
 		}
-		// PI always proceeds to install even if detected.
 		if installed && s.agent != model.AgentPi {
 			return nil
 		}

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -432,6 +432,53 @@ func buildStagePlan(selection model.Selection, resolved planner.ResolvedPlan) pi
 	return pipeline.StagePlan{Prepare: prepare, Apply: apply}
 }
 
+// StagePlanLabels generates step labels that match the IDs produced by
+// installRuntime.stagePlan(), including multi-command agent expansion.
+// It is the authoritative source for label → step-ID alignment used by both
+// CLI and TUI. communityTools are appended verbatim as "community-tool:<id>".
+func StagePlanLabels(resolved planner.ResolvedPlan, communityTools []model.CommunityToolID) []string {
+	labels := make([]string, 0, 3+len(resolved.Agents)+len(communityTools)+len(resolved.OrderedComponents))
+
+	labels = append(labels, "prepare:check-dependencies")
+	labels = append(labels, "prepare:backup-snapshot")
+	labels = append(labels, "apply:rollback-restore")
+
+	for _, agent := range resolved.Agents {
+		labels = append(labels, agentStepLabels(agent)...)
+	}
+
+	for _, tool := range communityTools {
+		labels = append(labels, "community-tool:"+string(tool))
+	}
+
+	for _, component := range resolved.OrderedComponents {
+		labels = append(labels, "component:"+string(component))
+	}
+
+	return labels
+}
+
+// agentStepLabels returns the step labels for a single agent.
+// For multi-command agents (PI), it returns one label per command.
+// For single-command agents, it returns one standard label.
+func agentStepLabels(agent model.AgentID) []string {
+	adapter, err := agents.NewAdapter(agent)
+	if err != nil || !adapter.SupportsAutoInstall() {
+		return []string{"agent:" + string(agent)}
+	}
+
+	commands, err := adapter.InstallCommand(system.PlatformProfile{})
+	if err != nil || len(commands) <= 1 {
+		return []string{"agent:" + string(agent)}
+	}
+
+	labels := make([]string, len(commands))
+	for i, cmd := range commands {
+		labels[i] = commandStepID(agent, cmd)
+	}
+	return labels
+}
+
 type installRuntime struct {
 	homeDir      string
 	workspaceDir string
@@ -509,8 +556,8 @@ func (r *installRuntime) stagePlan() pipeline.StagePlan {
 	}
 
 	for _, agent := range r.resolved.Agents {
-
-		apply = append(apply, agentInstallStep{id: "agent:" + string(agent), agent: agent, homeDir: r.homeDir, profile: r.profile})
+		agentSteps := r.agentStepsForAgent(agent)
+		apply = append(apply, agentSteps...)
 	}
 
 	if containsAgent(r.resolved.Agents, model.AgentOpenCode) {
@@ -570,6 +617,103 @@ func (s piCodeGraphReconcileStep) Run() error {
 func (s piCodeGraphReconcileStep) Rollback() error {
 	_, err := communitytool.UninstallPiCodeGraph(s.homeDir)
 	return err
+}
+
+// agentStepsForAgent returns the pipeline steps for installing a single agent.
+// For multi-command agents (those whose InstallCommand returns >1 command),
+// it creates one agentCommandStep per command. For single-command agents,
+// it returns the existing agentInstallStep.
+func (r *installRuntime) agentStepsForAgent(agent model.AgentID) []pipeline.Step {
+	adapter, err := agents.NewAdapter(agent)
+	if err != nil || !adapter.SupportsAutoInstall() {
+		return []pipeline.Step{agentInstallStep{id: "agent:" + string(agent), agent: agent, homeDir: r.homeDir, profile: r.profile}}
+	}
+
+	commands, err := adapter.InstallCommand(r.profile)
+	if err != nil || len(commands) <= 1 {
+		if err != nil {
+			log.Printf("stagePlan: InstallCommand for %q failed: %v; falling back to single step", agent, err)
+		}
+		return []pipeline.Step{agentInstallStep{id: "agent:" + string(agent), agent: agent, homeDir: r.homeDir, profile: r.profile}}
+	}
+
+	// Multi-command agent: create one sub-step per command.
+	steps := make([]pipeline.Step, len(commands))
+	for i, cmd := range commands {
+		steps[i] = agentCommandStep{
+			id:      commandStepID(agent, cmd),
+			agent:   agent,
+			homeDir: r.homeDir,
+			profile: r.profile,
+			command: cmd,
+			first:   i == 0,
+		}
+	}
+	return steps
+}
+
+// commandStepID generates a deterministic step ID from a command.
+// For npm install commands, the format is "agent:<name>/npm:<package>".
+func commandStepID(agent model.AgentID, cmd []string) string {
+	if len(cmd) >= 3 && cmd[1] == "install" && strings.HasPrefix(cmd[2], "npm:") {
+		pkg := strings.TrimPrefix(cmd[2], "npm:")
+		return fmt.Sprintf("agent:%s/npm:%s", string(agent), pkg)
+	}
+	// Fallback for non-npm commands (e.g., engram init).
+	return fmt.Sprintf("agent:%s/%s", string(agent), cmd[0])
+}
+
+// agentCommandStep runs a single install command for an agent.
+// When first is true, it also runs detection and preflight checks.
+type agentCommandStep struct {
+	id      string
+	agent   model.AgentID
+	homeDir string
+	profile system.PlatformProfile
+	command []string
+	first   bool
+}
+
+func (s agentCommandStep) ID() string { return s.id }
+
+func (s agentCommandStep) Run() error {
+	adapter, err := agents.NewAdapter(s.agent)
+	if err != nil {
+		return fmt.Errorf("create adapter for %q: %w", s.agent, err)
+	}
+
+	// First sub-step handles detection and preflight.
+	if s.first {
+		if !adapter.SupportsAutoInstall() {
+			return nil
+		}
+
+		installed, _, _, _, err := adapter.Detect(context.Background(), s.homeDir)
+		if err != nil {
+			return fmt.Errorf("detect agent %q: %w", s.agent, err)
+		}
+		// PI always proceeds to install even if detected.
+		if installed && s.agent != model.AgentPi {
+			return nil
+		}
+
+		if err := installcmd.ValidateAgentInstallPreflight(s.profile, s.agent); err != nil {
+			return fmt.Errorf("preflight for agent %q: %w", s.agent, err)
+		}
+	}
+
+	if len(s.command) > 0 {
+		err := runCommand(s.command[0], s.command[1:]...)
+		if err != nil && s.command[0] == "pi" {
+			errStr := err.Error()
+			if strings.Contains(errStr, "Cannot find module") ||
+				strings.Contains(errStr, "MODULE_NOT_FOUND") {
+				return fmt.Errorf("Pi CLI module not found")
+			}
+		}
+		return err
+	}
+	return nil
 }
 
 type prepareBackupStep struct {

--- a/internal/cli/stageplan_labels_test.go
+++ b/internal/cli/stageplan_labels_test.go
@@ -1,0 +1,68 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/internal/model"
+	"github.com/gentleman-programming/gentle-ai/internal/planner"
+)
+
+func TestStagePlanLabelsPiAgentExpands(t *testing.T) {
+	resolved := planner.ResolvedPlan{
+		Agents: []model.AgentID{model.AgentPi},
+	}
+
+	labels := StagePlanLabels(resolved, nil)
+
+	if len(labels) < 4 {
+		t.Fatalf("PI agent: expected at least 4 labels, got %d", len(labels))
+	}
+	// First 3 are fixed
+	if labels[0] != "prepare:check-dependencies" {
+		t.Fatalf("label[0] = %q, want %q", labels[0], "prepare:check-dependencies")
+	}
+	// PI sub-steps start at index 3
+	piLabels := labels[3:]
+	if len(piLabels) < 2 {
+		t.Fatalf("PI agent: expected multiple sub-step labels, got %d: %v", len(piLabels), piLabels)
+	}
+	for _, l := range piLabels {
+		if len(l) < 10 || l[:9] != "agent:pi/" {
+			t.Fatalf("PI sub-step label = %q, want prefix \"agent:pi/\"", l)
+		}
+	}
+}
+
+func TestStagePlanLabelsSingleCommandAgent(t *testing.T) {
+	resolved := planner.ResolvedPlan{
+		Agents: []model.AgentID{model.AgentClaudeCode},
+	}
+
+	labels := StagePlanLabels(resolved, nil)
+
+	if len(labels) != 4 {
+		t.Fatalf("single-command agent: expected 4 labels, got %d: %v", len(labels), labels)
+	}
+	if labels[3] != "agent:claude-code" {
+		t.Fatalf("label[3] = %q, want %q", labels[3], "agent:claude-code")
+	}
+}
+
+func TestStagePlanLabelsWithCommunityTools(t *testing.T) {
+	resolved := planner.ResolvedPlan{
+		Agents: []model.AgentID{model.AgentPi},
+	}
+
+	labels := StagePlanLabels(resolved, []model.CommunityToolID{model.CommunityToolCodeGraph})
+
+	hasCodeGraph := false
+	for _, l := range labels {
+		if l == "community-tool:codegraph" {
+			hasCodeGraph = true
+			break
+		}
+	}
+	if !hasCodeGraph {
+		t.Fatalf("expected community-tool:codegraph in labels, got %v", labels)
+	}
+}

--- a/internal/cli/stageplan_labels_test.go
+++ b/internal/cli/stageplan_labels_test.go
@@ -8,20 +8,14 @@ import (
 )
 
 func TestStagePlanLabelsPiAgentExpands(t *testing.T) {
-	resolved := planner.ResolvedPlan{
-		Agents: []model.AgentID{model.AgentPi},
-	}
-
-	labels := StagePlanLabels(resolved, nil)
+	labels := StagePlanLabels(planner.ResolvedPlan{Agents: []model.AgentID{model.AgentPi}}, nil)
 
 	if len(labels) < 4 {
 		t.Fatalf("PI agent: expected at least 4 labels, got %d", len(labels))
 	}
-	// First 3 are fixed
 	if labels[0] != "prepare:check-dependencies" {
 		t.Fatalf("label[0] = %q, want %q", labels[0], "prepare:check-dependencies")
 	}
-	// PI sub-steps start at index 3
 	piLabels := labels[3:]
 	if len(piLabels) < 2 {
 		t.Fatalf("PI agent: expected multiple sub-step labels, got %d: %v", len(piLabels), piLabels)
@@ -34,11 +28,7 @@ func TestStagePlanLabelsPiAgentExpands(t *testing.T) {
 }
 
 func TestStagePlanLabelsSingleCommandAgent(t *testing.T) {
-	resolved := planner.ResolvedPlan{
-		Agents: []model.AgentID{model.AgentClaudeCode},
-	}
-
-	labels := StagePlanLabels(resolved, nil)
+	labels := StagePlanLabels(planner.ResolvedPlan{Agents: []model.AgentID{model.AgentClaudeCode}}, nil)
 
 	if len(labels) != 4 {
 		t.Fatalf("single-command agent: expected 4 labels, got %d: %v", len(labels), labels)
@@ -49,11 +39,7 @@ func TestStagePlanLabelsSingleCommandAgent(t *testing.T) {
 }
 
 func TestStagePlanLabelsWithCommunityTools(t *testing.T) {
-	resolved := planner.ResolvedPlan{
-		Agents: []model.AgentID{model.AgentPi},
-	}
-
-	labels := StagePlanLabels(resolved, []model.CommunityToolID{model.CommunityToolCodeGraph})
+	labels := StagePlanLabels(planner.ResolvedPlan{Agents: []model.AgentID{model.AgentPi}}, []model.CommunityToolID{model.CommunityToolCodeGraph})
 
 	hasCodeGraph := false
 	for _, l := range labels {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -16,6 +16,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/gentleman-programming/gentle-ai/internal/agentbuilder"
 	"github.com/gentleman-programming/gentle-ai/internal/backup"
+	"github.com/gentleman-programming/gentle-ai/internal/cli"
 	"github.com/gentleman-programming/gentle-ai/internal/catalog"
 	"github.com/gentleman-programming/gentle-ai/internal/components/communitytool"
 	"github.com/gentleman-programming/gentle-ai/internal/components/opencodeplugin"
@@ -183,6 +184,26 @@ func tickCmd() tea.Cmd {
 	return tea.Tick(100*time.Millisecond, func(t time.Time) tea.Msg {
 		return TickMsg(t)
 	})
+}
+
+// progressListenerCmd reads one event from the progress channel and returns it
+// as a StepProgressMsg. When the channel is closed (pipeline done), it returns
+// nil, causing the listener to exit cleanly.
+func (m Model) progressListenerCmd() tea.Cmd {
+	return func() tea.Msg {
+		if m.progressCh == nil {
+			return nil
+		}
+		event, ok := <-m.progressCh
+		if !ok {
+			return nil // channel closed, listener exits
+		}
+		return StepProgressMsg{
+			StepID: event.StepID,
+			Status: event.Status,
+			Err:    event.Err,
+		}
+	}
 }
 
 // StepProgressMsg is sent from the pipeline goroutine when a step changes status.
@@ -460,6 +481,10 @@ type Model struct {
 	// fetch, when a non-empty message was returned. Empty string means no
 	// advisory to display. Set asynchronously via AdvisoryMsg.
 	AdvisoryMessage string
+
+	// progressCh is a buffered channel for real-time pipeline progress events.
+	// Created in startInstalling, closed when the pipeline goroutine finishes.
+	progressCh chan pipeline.ProgressEvent
 
 	// pipelineRunning tracks whether the pipeline goroutine is active.
 	pipelineRunning bool
@@ -802,7 +827,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.CommunityToolStatusErr = msg.Err
 		return m, nil
 	case StepProgressMsg:
-		return m.handleStepProgress(msg)
+		updated, cmd := m.handleStepProgress(msg)
+		// Re-subscribe progress listener after each event so the goroutine
+		// continues delivering progress until the channel is closed.
+		if mod, ok := updated.(Model); ok && mod.pipelineRunning {
+			return mod, tea.Batch(cmd, mod.progressListenerCmd())
+		}
+		return updated, cmd
 	case PipelineDoneMsg:
 		return m.handlePipelineDone(msg)
 	case BackupRestoreMsg:
@@ -2423,23 +2454,27 @@ func (m Model) startInstalling() (tea.Model, tea.Cmd) {
 	}
 
 	m.pipelineRunning = true
+	m.progressCh = make(chan pipeline.ProgressEvent, 32)
 
 	// Capture values for the goroutine closure.
 	executeFn := m.ExecuteFn
 	selection := m.Selection
 	resolved := m.DependencyPlan
 	detection := m.Detection
+	progressCh := m.progressCh
 
-	return m, tea.Batch(tickCmd(), func() tea.Msg {
+	return m, tea.Batch(tickCmd(), m.progressListenerCmd(), func() tea.Msg {
 		onProgress := func(event pipeline.ProgressEvent) {
-			// NOTE: ProgressFunc is called synchronously from the pipeline goroutine.
-			// We cannot use p.Send() here because we don't have a reference to the
-			// tea.Program. Instead, these events are collected in the ExecutionResult
-			// and the PipelineDoneMsg handles the final state. For real-time updates,
-			// we rely on the pipeline calling this synchronously from each step.
+			// Non-blocking write: if the channel buffer is full, drop the event
+			// so the pipeline goroutine is never blocked.
+			select {
+			case progressCh <- event:
+			default:
+			}
 		}
 
 		result := executeFn(selection, resolved, detection, onProgress)
+		close(progressCh)
 		return PipelineDoneMsg{Result: result}
 	})
 }
@@ -2874,27 +2909,11 @@ func (m Model) restoreBackup(manifest backup.Manifest) (tea.Model, tea.Cmd) {
 }
 
 // buildProgressLabels creates step labels from the resolved plan that match
-// the step IDs the pipeline will produce.
+// the step IDs the pipeline will produce. It delegates to cli.StagePlanLabels
+// for authoritative label generation that accounts for multi-command agent
+// (e.g., PI) expansion into per-command sub-steps.
 func buildProgressLabels(resolved planner.ResolvedPlan, communityTools []model.CommunityToolID) []string {
-	labels := make([]string, 0, 3+len(resolved.Agents)+len(communityTools)+len(resolved.OrderedComponents))
-
-	labels = append(labels, "prepare:check-dependencies")
-	labels = append(labels, "prepare:backup-snapshot")
-	labels = append(labels, "apply:rollback-restore")
-
-	for _, agent := range resolved.Agents {
-		labels = append(labels, "agent:"+string(agent))
-	}
-
-	for _, tool := range communityTools {
-		labels = append(labels, "community-tool:"+string(tool))
-	}
-
-	for _, component := range resolved.OrderedComponents {
-		labels = append(labels, "component:"+string(component))
-	}
-
-	return labels
+	return cli.StagePlanLabels(resolved, communityTools)
 }
 
 func (m Model) goBack() Model {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -962,7 +962,13 @@ func (m Model) handleStepProgress(msg StepProgressMsg) (tea.Model, tea.Cmd) {
 		m.Progress.Mark(idx, string(pipeline.StepStatusFailed))
 		errMsg := "unknown error"
 		if msg.Err != nil {
+			// Truncate at \noutput: to keep the log readable.
+			// The full error (including command output) is still available
+			// via PipelineDoneMsg/ProgressFromExecution if needed for debugging.
 			errMsg = msg.Err.Error()
+			if idx := strings.Index(errMsg, "\noutput:\n"); idx >= 0 {
+				errMsg = errMsg[:idx]
+			}
 		}
 		m.Progress.AppendLog("FAILED: %s — %s", msg.StepID, errMsg)
 	}
@@ -979,15 +985,27 @@ func (m Model) handlePipelineDone(msg PipelineDoneMsg) (tea.Model, tea.Cmd) {
 	m.Progress = ProgressFromExecution(msg.Result)
 
 	// Surface individual error messages so the user knows WHAT failed.
+	piModuleErrors := 0
 	appendStepErrors := func(steps []pipeline.StepResult) {
 		for _, step := range steps {
 			if step.Status == pipeline.StepStatusFailed && step.Err != nil {
-				m.Progress.AppendLog("FAILED: %s — %s", step.StepID, step.Err.Error())
+				errMsg := step.Err.Error()
+				if idx := strings.Index(errMsg, "\noutput:\n"); idx >= 0 {
+					errMsg = errMsg[:idx]
+				}
+				if strings.Contains(errMsg, "Pi CLI module not found") {
+					piModuleErrors++
+				}
+				m.Progress.AppendLog("FAILED: %s — %s", step.StepID, errMsg)
 			}
 		}
 	}
 	appendStepErrors(msg.Result.Prepare.Steps)
 	appendStepErrors(msg.Result.Apply.Steps)
+
+	if piModuleErrors > 0 {
+		m.Progress.AppendLog("Note: Pi CLI module not found in %d package(s) — reinstall with: pnpm add -g @earendil-works/pi-coding-agent", piModuleErrors)
+	}
 
 	if msg.Result.Err != nil {
 		m.Progress.AppendLog("pipeline completed with errors")

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -16,8 +16,8 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/gentleman-programming/gentle-ai/internal/agentbuilder"
 	"github.com/gentleman-programming/gentle-ai/internal/backup"
-	"github.com/gentleman-programming/gentle-ai/internal/cli"
 	"github.com/gentleman-programming/gentle-ai/internal/catalog"
+	"github.com/gentleman-programming/gentle-ai/internal/cli"
 	"github.com/gentleman-programming/gentle-ai/internal/components/communitytool"
 	"github.com/gentleman-programming/gentle-ai/internal/components/opencodeplugin"
 	"github.com/gentleman-programming/gentle-ai/internal/components/sdd"
@@ -186,9 +186,8 @@ func tickCmd() tea.Cmd {
 	})
 }
 
-// progressListenerCmd reads one event from the progress channel and returns it
-// as a StepProgressMsg. When the channel is closed (pipeline done), it returns
-// nil, causing the listener to exit cleanly.
+// progressListenerCmd reads one channel event and returns StepProgressMsg,
+// or nil when the channel is closed (pipeline done).
 func (m Model) progressListenerCmd() tea.Cmd {
 	return func() tea.Msg {
 		if m.progressCh == nil {
@@ -828,8 +827,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case StepProgressMsg:
 		updated, cmd := m.handleStepProgress(msg)
-		// Re-subscribe progress listener after each event so the goroutine
-		// continues delivering progress until the channel is closed.
+		// Re-subscribe listener until channel closes.
 		if mod, ok := updated.(Model); ok && mod.pipelineRunning {
 			return mod, tea.Batch(cmd, mod.progressListenerCmd())
 		}
@@ -942,6 +940,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m Model) handleStepProgress(msg StepProgressMsg) (tea.Model, tea.Cmd) {
+	if !m.pipelineRunning {
+		return m, nil
+	}
+
 	if m.Screen != ScreenInstalling {
 		return m, nil
 	}
@@ -962,9 +964,7 @@ func (m Model) handleStepProgress(msg StepProgressMsg) (tea.Model, tea.Cmd) {
 		m.Progress.Mark(idx, string(pipeline.StepStatusFailed))
 		errMsg := "unknown error"
 		if msg.Err != nil {
-			// Truncate at \noutput: to keep the log readable.
-			// The full error (including command output) is still available
-			// via PipelineDoneMsg/ProgressFromExecution if needed for debugging.
+			// Truncate at \noutput: to keep logs readable.
 			errMsg = msg.Err.Error()
 			if idx := strings.Index(errMsg, "\noutput:\n"); idx >= 0 {
 				errMsg = errMsg[:idx]
@@ -2483,8 +2483,7 @@ func (m Model) startInstalling() (tea.Model, tea.Cmd) {
 
 	return m, tea.Batch(tickCmd(), m.progressListenerCmd(), func() tea.Msg {
 		onProgress := func(event pipeline.ProgressEvent) {
-			// Non-blocking write: if the channel buffer is full, drop the event
-			// so the pipeline goroutine is never blocked.
+			// Non-blocking write: drop if buffer full.
 			select {
 			case progressCh <- event:
 			default:
@@ -2926,10 +2925,7 @@ func (m Model) restoreBackup(manifest backup.Manifest) (tea.Model, tea.Cmd) {
 	}
 }
 
-// buildProgressLabels creates step labels from the resolved plan that match
-// the step IDs the pipeline will produce. It delegates to cli.StagePlanLabels
-// for authoritative label generation that accounts for multi-command agent
-// (e.g., PI) expansion into per-command sub-steps.
+// buildProgressLabels delegates to cli.StagePlanLabels for TUI/CLI label alignment.
 func buildProgressLabels(resolved planner.ResolvedPlan, communityTools []model.CommunityToolID) []string {
 	return cli.StagePlanLabels(resolved, communityTools)
 }

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -513,9 +513,6 @@ func TestPiCombinedWithOtherAgentsTUIInstallKeepsAllAgentsInPlan(t *testing.T) {
 		t.Fatalf("expected BatchMsg, got %T", msg)
 	}
 
-	// Run batch commands concurrently, like Bubbletea does. The
-	// progressListenerCmd blocks on channel read until the execute
-	// command writes events or closes the channel.
 	results := make(chan tea.Msg, len(batch))
 	var launched int
 	for _, innerCmd := range batch {
@@ -571,23 +568,21 @@ func TestReviewToInstallingInitializesProgress(t *testing.T) {
 func TestStepProgressMsgUpdatesProgressState(t *testing.T) {
 	m := NewModel(system.DetectionResult{}, "dev")
 	m.Screen = ScreenInstalling
+	m.pipelineRunning = true
 	m.Progress = NewProgressState([]string{"step-a", "step-b"})
 
-	// Send running event for step-a.
 	updated, _ := m.Update(StepProgressMsg{StepID: "step-a", Status: pipeline.StepStatusRunning})
 	state := updated.(Model)
 	if state.Progress.Items[0].Status != ProgressStatusRunning {
 		t.Fatalf("step-a status = %q, want running", state.Progress.Items[0].Status)
 	}
 
-	// Send succeeded event for step-a.
 	updated, _ = state.Update(StepProgressMsg{StepID: "step-a", Status: pipeline.StepStatusSucceeded})
 	state = updated.(Model)
 	if state.Progress.Items[0].Status != string(pipeline.StepStatusSucceeded) {
 		t.Fatalf("step-a status = %q, want succeeded", state.Progress.Items[0].Status)
 	}
 
-	// Send failed event for step-b.
 	updated, _ = state.Update(StepProgressMsg{StepID: "step-b", Status: pipeline.StepStatusFailed, Err: fmt.Errorf("oops")})
 	state = updated.(Model)
 	if state.Progress.Items[1].Status != string(pipeline.StepStatusFailed) {
@@ -596,6 +591,21 @@ func TestStepProgressMsgUpdatesProgressState(t *testing.T) {
 
 	if !state.Progress.HasFailures() {
 		t.Fatalf("expected HasFailures() = true")
+	}
+}
+
+func TestStepProgressMsgIgnoredAfterPipelineCompletes(t *testing.T) {
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Screen = ScreenInstalling
+	m.pipelineRunning = false
+	m.Progress = NewProgressState([]string{"step-a"})
+	m.Progress.Mark(0, string(pipeline.StepStatusSucceeded))
+
+	updated, _ := m.Update(StepProgressMsg{StepID: "step-a", Status: pipeline.StepStatusRunning})
+	state := updated.(Model)
+
+	if state.Progress.Items[0].Status != string(pipeline.StepStatusSucceeded) {
+		t.Fatalf("step-a status = %q, want succeeded", state.Progress.Items[0].Status)
 	}
 }
 
@@ -721,7 +731,7 @@ func TestInstallingDoneToComplete(t *testing.T) {
 	}
 }
 
-func TestBuildProgressLabelsFromResolvedPlan(t *testing.T) {
+func TestBuildProgressLabelsDelegatesStagePlanLabels(t *testing.T) {
 	resolved := planner.ResolvedPlan{
 		Agents:            []model.AgentID{model.AgentClaudeCode},
 		OrderedComponents: []model.ComponentID{model.ComponentEngram, model.ComponentSDD},
@@ -744,55 +754,6 @@ func TestBuildProgressLabelsFromResolvedPlan(t *testing.T) {
 	}
 }
 
-func TestBuildProgressLabelsPiAgentProducesSubStepLabels(t *testing.T) {
-	resolved := planner.ResolvedPlan{
-		Agents: []model.AgentID{model.AgentPi},
-	}
-
-	labels := buildProgressLabels(resolved, nil)
-
-	if len(labels) < 4 {
-		t.Fatalf("PI agent: expected at least 4 labels (3 fixed + sub-steps), got %d", len(labels))
-	}
-	// First three are fixed
-	if labels[0] != "prepare:check-dependencies" {
-		t.Fatalf("label[0] = %q, want %q", labels[0], "prepare:check-dependencies")
-	}
-	if labels[1] != "prepare:backup-snapshot" {
-		t.Fatalf("label[1] = %q, want %q", labels[1], "prepare:backup-snapshot")
-	}
-	if labels[2] != "apply:rollback-restore" {
-		t.Fatalf("label[2] = %q, want %q", labels[2], "apply:rollback-restore")
-	}
-	// PI sub-step labels should follow the pattern "agent:pi/npm:<package>"
-	piLabels := labels[3:]
-	if len(piLabels) < 2 {
-		t.Fatalf("PI agent: expected multiple sub-step labels, got %d: %v", len(piLabels), piLabels)
-	}
-	for _, l := range piLabels {
-		if len(l) < 10 || l[:9] != "agent:pi/" {
-			t.Fatalf("PI sub-step label = %q, want prefix \"agent:pi/\"", l)
-		}
-	}
-}
-
-func TestBuildProgressLabelsNonPiAgentSingleStep(t *testing.T) {
-	for _, agent := range []model.AgentID{model.AgentClaudeCode, model.AgentKimi, model.AgentCursor} {
-		resolved := planner.ResolvedPlan{
-			Agents: []model.AgentID{agent},
-		}
-
-		labels := buildProgressLabels(resolved, nil)
-
-		if len(labels) != 4 {
-			t.Fatalf("agent %q: expected 4 labels (3 fixed + 1 agent), got %d: %v", agent, len(labels), labels)
-		}
-		if labels[3] != "agent:"+string(agent) {
-			t.Fatalf("agent %q: label[3] = %q, want %q", agent, labels[3], "agent:"+string(agent))
-		}
-	}
-}
-
 func TestProgressListenerChannelCloseExitsCleanly(t *testing.T) {
 	m := NewModel(system.DetectionResult{}, "dev")
 	ch := make(chan pipeline.ProgressEvent)
@@ -804,7 +765,6 @@ func TestProgressListenerChannelCloseExitsCleanly(t *testing.T) {
 		t.Fatal("progressListenerCmd returned nil")
 	}
 
-	// Close channel — listener should return nil (no message).
 	close(ch)
 	msg := cmd()
 	if msg != nil {
@@ -812,24 +772,21 @@ func TestProgressListenerChannelCloseExitsCleanly(t *testing.T) {
 	}
 }
 
-func TestProgressListenerNonBlockingWrite(t *testing.T) {
+func TestProgressListenerResubscribesAfterStepProgress(t *testing.T) {
 	m := NewModel(system.DetectionResult{}, "dev")
 	m.Screen = ScreenInstalling
 	m.Progress = NewProgressState([]string{"test-step"})
 
-	// Create a full channel (buffer 1, fill it).
 	ch := make(chan pipeline.ProgressEvent, 1)
 	ch <- pipeline.ProgressEvent{StepID: "test-step", Status: pipeline.StepStatusRunning}
 	m.progressCh = ch
 	m.pipelineRunning = true
 
-	// This should produce a StepProgressMsg (reads from channel).
 	updated, cmd := m.Update(StepProgressMsg{StepID: "test-step", Status: pipeline.StepStatusSucceeded})
 	state := updated.(Model)
 	if state.Progress.Items[0].Status != "succeeded" {
 		t.Fatalf("status = %q, want succeeded", state.Progress.Items[0].Status)
 	}
-	// cmd should be non-nil (re-subscribed listener)
 	if cmd == nil {
 		t.Fatal("expected re-subscribed listener cmd, got nil")
 	}

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -10,6 +10,7 @@ import (
 	"slices"
 	"strings"
 	"testing"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -507,14 +508,30 @@ func TestPiCombinedWithOtherAgentsTUIInstallKeepsAllAgentsInPlan(t *testing.T) {
 		t.Fatal("start installing command = nil")
 	}
 	msg := cmd()
-	if batch, ok := msg.(tea.BatchMsg); ok {
-		for _, innerCmd := range batch {
-			if innerCmd == nil {
-				continue
-			}
-			if _, ok := innerCmd().(PipelineDoneMsg); ok {
-				break
-			}
+	batch, ok := msg.(tea.BatchMsg)
+	if !ok {
+		t.Fatalf("expected BatchMsg, got %T", msg)
+	}
+
+	// Run batch commands concurrently, like Bubbletea does. The
+	// progressListenerCmd blocks on channel read until the execute
+	// command writes events or closes the channel.
+	results := make(chan tea.Msg, len(batch))
+	var launched int
+	for _, innerCmd := range batch {
+		if innerCmd == nil {
+			continue
+		}
+		launched++
+		go func(cmd tea.Cmd) {
+			results <- cmd()
+		}(innerCmd)
+	}
+	for i := 0; i < launched; i++ {
+		select {
+		case <-results:
+		case <-time.After(10 * time.Second):
+			t.Fatal("timed out waiting for installing commands to complete")
 		}
 	}
 
@@ -724,6 +741,97 @@ func TestBuildProgressLabelsFromResolvedPlan(t *testing.T) {
 
 	if !reflect.DeepEqual(labels, want) {
 		t.Fatalf("labels = %v, want %v", labels, want)
+	}
+}
+
+func TestBuildProgressLabelsPiAgentProducesSubStepLabels(t *testing.T) {
+	resolved := planner.ResolvedPlan{
+		Agents: []model.AgentID{model.AgentPi},
+	}
+
+	labels := buildProgressLabels(resolved, nil)
+
+	if len(labels) < 4 {
+		t.Fatalf("PI agent: expected at least 4 labels (3 fixed + sub-steps), got %d", len(labels))
+	}
+	// First three are fixed
+	if labels[0] != "prepare:check-dependencies" {
+		t.Fatalf("label[0] = %q, want %q", labels[0], "prepare:check-dependencies")
+	}
+	if labels[1] != "prepare:backup-snapshot" {
+		t.Fatalf("label[1] = %q, want %q", labels[1], "prepare:backup-snapshot")
+	}
+	if labels[2] != "apply:rollback-restore" {
+		t.Fatalf("label[2] = %q, want %q", labels[2], "apply:rollback-restore")
+	}
+	// PI sub-step labels should follow the pattern "agent:pi/npm:<package>"
+	piLabels := labels[3:]
+	if len(piLabels) < 2 {
+		t.Fatalf("PI agent: expected multiple sub-step labels, got %d: %v", len(piLabels), piLabels)
+	}
+	for _, l := range piLabels {
+		if len(l) < 10 || l[:9] != "agent:pi/" {
+			t.Fatalf("PI sub-step label = %q, want prefix \"agent:pi/\"", l)
+		}
+	}
+}
+
+func TestBuildProgressLabelsNonPiAgentSingleStep(t *testing.T) {
+	for _, agent := range []model.AgentID{model.AgentClaudeCode, model.AgentKimi, model.AgentCursor} {
+		resolved := planner.ResolvedPlan{
+			Agents: []model.AgentID{agent},
+		}
+
+		labels := buildProgressLabels(resolved, nil)
+
+		if len(labels) != 4 {
+			t.Fatalf("agent %q: expected 4 labels (3 fixed + 1 agent), got %d: %v", agent, len(labels), labels)
+		}
+		if labels[3] != "agent:"+string(agent) {
+			t.Fatalf("agent %q: label[3] = %q, want %q", agent, labels[3], "agent:"+string(agent))
+		}
+	}
+}
+
+func TestProgressListenerChannelCloseExitsCleanly(t *testing.T) {
+	m := NewModel(system.DetectionResult{}, "dev")
+	ch := make(chan pipeline.ProgressEvent)
+	m.progressCh = ch
+	m.pipelineRunning = false // not running; we manually control the channel
+
+	cmd := m.progressListenerCmd()
+	if cmd == nil {
+		t.Fatal("progressListenerCmd returned nil")
+	}
+
+	// Close channel — listener should return nil (no message).
+	close(ch)
+	msg := cmd()
+	if msg != nil {
+		t.Fatalf("expected nil after channel close, got %T: %v", msg, msg)
+	}
+}
+
+func TestProgressListenerNonBlockingWrite(t *testing.T) {
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Screen = ScreenInstalling
+	m.Progress = NewProgressState([]string{"test-step"})
+
+	// Create a full channel (buffer 1, fill it).
+	ch := make(chan pipeline.ProgressEvent, 1)
+	ch <- pipeline.ProgressEvent{StepID: "test-step", Status: pipeline.StepStatusRunning}
+	m.progressCh = ch
+	m.pipelineRunning = true
+
+	// This should produce a StepProgressMsg (reads from channel).
+	updated, cmd := m.Update(StepProgressMsg{StepID: "test-step", Status: pipeline.StepStatusSucceeded})
+	state := updated.(Model)
+	if state.Progress.Items[0].Status != "succeeded" {
+		t.Fatalf("status = %q, want succeeded", state.Progress.Items[0].Status)
+	}
+	// cmd should be non-nil (re-subscribed listener)
+	if cmd == nil {
+		t.Fatal("expected re-subscribed listener cmd, got nil")
 	}
 }
 

--- a/internal/tui/progress.go
+++ b/internal/tui/progress.go
@@ -91,9 +91,7 @@ func ProgressFromExecution(result pipeline.ExecutionResult) ProgressState {
 
 	appendSteps(result.Prepare)
 	appendSteps(result.Apply)
-	// Rollback stage is intentionally excluded: its steps mirror the Apply stage
-	// (same StepIDs), so including them would duplicate entries and inflate the
-	// progress total without adding new information for the user.
+	// Rollback steps mirror Apply StageIDs; exclude to avoid duplicates.
 
 	progress := NewProgressState(labels)
 	for idx, status := range statuses {

--- a/internal/tui/progress.go
+++ b/internal/tui/progress.go
@@ -79,7 +79,7 @@ func (p ProgressState) Percent() int {
 }
 
 func ProgressFromExecution(result pipeline.ExecutionResult) ProgressState {
-	labels := make([]string, 0, len(result.Prepare.Steps)+len(result.Apply.Steps)+len(result.Rollback.Steps))
+	labels := make([]string, 0, len(result.Prepare.Steps)+len(result.Apply.Steps))
 	statuses := make([]pipeline.StepStatus, 0, cap(labels))
 
 	appendSteps := func(stage pipeline.StageResult) {
@@ -91,7 +91,9 @@ func ProgressFromExecution(result pipeline.ExecutionResult) ProgressState {
 
 	appendSteps(result.Prepare)
 	appendSteps(result.Apply)
-	appendSteps(result.Rollback)
+	// Rollback stage is intentionally excluded: its steps mirror the Apply stage
+	// (same StepIDs), so including them would duplicate entries and inflate the
+	// progress total without adding new information for the user.
 
 	progress := NewProgressState(labels)
 	for idx, status := range statuses {

--- a/internal/tui/screens/installing.go
+++ b/internal/tui/screens/installing.go
@@ -68,8 +68,9 @@ func RenderInstalling(progress InstallProgress, spinner string) string {
 			logLines = append(logLines, strings.Split(entry, "\n")...)
 		}
 		if len(logLines) > maxLogLines {
+			omitted := len(logLines) - maxLogLines
 			logLines = logLines[len(logLines)-maxLogLines:]
-			b.WriteString(styles.SubtextStyle.Render(fmt.Sprintf("  ... (truncated %d lines)", len(logLines))))
+			b.WriteString(styles.SubtextStyle.Render(fmt.Sprintf("  ... (truncated %d lines)", omitted)))
 			b.WriteString("\n")
 		}
 		for _, line := range logLines {

--- a/internal/tui/screens/installing.go
+++ b/internal/tui/screens/installing.go
@@ -56,15 +56,25 @@ func RenderInstalling(progress InstallProgress, spinner string) string {
 		b.WriteString("\n")
 		b.WriteString(styles.HeadingStyle.Render("Logs"))
 		b.WriteString("\n")
+
+		// Collect all log lines from the last 5 entries, then cap at 20 total lines.
+		const maxLogLines = 20
 		start := 0
 		if len(progress.Logs) > 5 {
 			start = len(progress.Logs) - 5
 		}
+		var logLines []string
 		for _, entry := range progress.Logs[start:] {
-			for _, line := range strings.Split(entry, "\n") {
-				b.WriteString(styles.SubtextStyle.Render("  " + line))
-				b.WriteString("\n")
-			}
+			logLines = append(logLines, strings.Split(entry, "\n")...)
+		}
+		if len(logLines) > maxLogLines {
+			logLines = logLines[len(logLines)-maxLogLines:]
+			b.WriteString(styles.SubtextStyle.Render(fmt.Sprintf("  ... (truncated %d lines)", len(logLines))))
+			b.WriteString("\n")
+		}
+		for _, line := range logLines {
+			b.WriteString(styles.SubtextStyle.Render("  " + line))
+			b.WriteString("\n")
 		}
 	}
 


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #533

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [x] 	Type:bug — Bug fix (non-breaking change that fixes an issue)
- [ ] 	Type:feature — New feature (non-breaking change that adds functionality)
- [ ] 	Type:docs — Documentation only
- [ ] 	Type:refactor — Code refactoring (no functional changes)
- [ ] 	Type:chore — Build, CI, or tooling changes
- [ ] 	Type:breaking-change — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Expands multi-command PI agent installs into per-package pipeline steps.
- Wires pipeline progress events into the TUI through a buffered progress channel.
- Keeps install log rendering bounded and covers PI progress behavior with targeted tests.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| internal/cli/run.go | Expands multi-command agent installs into command-level steps and exposes matching stage labels. |
| internal/cli/stageplan_labels_test.go | Adds coverage for PI expansion, single-command fallback, and community tool labels. |
| internal/tui/model.go | Delivers pipeline progress to Bubble Tea via a buffered listener command and ignores delayed updates after completion. |
| internal/tui/model_test.go | Adds regression coverage for progress listener behavior and PI label delegation. |
| internal/tui/progress.go | Preserves final progress state for completed installs. |
| internal/tui/screens/installing.go | Caps verbose install logs and reports omitted log count correctly. |

---

### PI not installed

<img width="1023" height="619" alt="image" src="https://github.com/user-attachments/assets/634116cc-f90a-4fea-8bb0-e1d96822d808" />



### PI installed

<img width="531" height="504" alt="image" src="https://github.com/user-attachments/assets/ae0d4a32-ce43-4a63-b614-aba030c0d29f" />


---

## 🧪 Test Plan

**Targeted tests**
`ash
go test -run TestStagePlanLabels -v ./internal/cli
go test -run 'Test(BuildProgressLabels|ProgressListener|PiCombined|StepProgressMsg)' -v ./internal/tui
` 

- [x] Targeted CLI tests pass (go test -run TestStagePlanLabels -v ./internal/cli)
- [x] Targeted TUI tests pass (go test -run 'Test(BuildProgressLabels|ProgressListener|PiCombined|StepProgressMsg)' -v ./internal/tui)
- [ ] Unit tests pass (go test ./...)
- [ ] E2E tests pass (cd e2e && ./docker-test.sh)
- [x] Manually tested PI not installed flow
- [x] Manually tested PI installed flow with progress advancing per package

Notes:
- Local broader TUI package tests have unrelated pre-existing SDD model-picker failures.
- Local broader CLI package test run timed out after 120s; targeted coverage for this change passes.

---

## 🤖 Automated Checks

The following checks run automatically on this PR:

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | PR stays under 400 changed lines (349 insertions + 49 deletions = 398) |
| Check Issue Reference | ⏳ | PR body contains Closes #533 |
| Check Issue Has status:approved | ⏳ | Issue #533 has status:approved |
| Check PR Has 	ype:* Label | ⏳ | Exactly one 	ype:* label must be applied |
| Unit Tests | ⏳ | CI will run full unit tests |
| E2E Tests | ⏳ | CI will run E2E tests |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with status:approved`n- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied size:exception with rationale documented
- [x] I have added the appropriate 	ype:* label to this PR
- [x] Targeted tests for this change pass
- [ ] Unit tests pass (go test ./...)
- [ ] E2E tests pass (cd e2e && ./docker-test.sh)
- [x] I have updated documentation if necessary — not needed for this bugfix
- [x] My commits follow Conventional Commits format
- [x] My commits do not include Co-Authored-By trailers

---

## 💬 Notes for Reviewers

This PR intentionally keeps the runtime expansion, TUI progress delivery, and regression tests together so the reviewer can validate the end-to-end PI progress behavior in one focused diff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Installation progress now streams in real time per pipeline step/command.
  - Deterministic progress labels support multi-command agent installs and include community tool/component labels.

- **Bug Fixes**
  - Progress updates are ignored once the pipeline completes.
  - Progress totals no longer duplicate rollback steps.
  - Failed-step output is truncated for cleaner logs, with clearer messaging when the Pi CLI module is missing.

- **UI Improvements**
  - Installation logs are now capped and show a truncation notice when exceeding the limit.

- **Tests**
  - Added/updated unit tests for stage-plan label generation and progress-listener/resubscribe behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->