### PR TITLE
fix(review): preserve receipt validity after commit

### DIFF
--- a/internal/reviewtransaction/gate.go
+++ b/internal/reviewtransaction/gate.go
@@ -125,6 +125,9 @@ func EvaluateNativeGate(ctx context.Context, repo string, receipt Receipt, reque
 	if err != nil {
 		return invalid("current repository target cannot be derived: " + err.Error())
 	}
+	if request.Gate == GatePrePush && record.Transaction.Snapshot.Kind == TargetCurrentChanges && snapshot.BaseTree == snapshot.CandidateTree {
+		return invalid("pre-push current-changes receipt requires a delivered tree change")
+	}
 	policyHash, err := hashArtifactSource(request.PolicyArtifact, request.PolicyContent)
 	if err != nil {
 		return invalid("policy artifact cannot be hashed: " + err.Error())
@@ -173,12 +176,18 @@ func EvaluateNativeGate(ctx context.Context, repo string, receipt Receipt, reque
 // describe review evidence, but it must never authorize a newer HEAD.
 func lifecycleTargetForGate(ctx context.Context, repo string, request GateRequest) (Target, error) {
 	switch request.Gate {
-	case GatePostApply, GatePreCommit, GatePrePush:
+	case GatePostApply, GatePreCommit:
 		intended := request.Target.IntendedUntracked
 		if intended == nil {
 			intended = []string{}
 		}
 		return Target{Kind: TargetCurrentChanges, IntendedUntracked: intended}, nil
+	case GatePrePush:
+		head, err := runGit(ctx, repo, nil, nil, "rev-parse", "HEAD")
+		if err != nil {
+			return Target{}, err
+		}
+		return Target{Kind: TargetExactRevision, Revision: strings.TrimSpace(string(head))}, nil
 	case GatePrePR:
 		if request.Target.Kind != TargetBaseDiff || strings.TrimSpace(request.Target.BaseRef) == "" {
 			return Target{}, errors.New("pre-PR validation requires an explicit base-diff target")

--- a/internal/reviewtransaction/gate_test.go
+++ b/internal/reviewtransaction/gate_test.go
@@ -149,6 +149,75 @@ func TestNativeGateRejectsHistoricalTargetAfterHeadAdvances(t *testing.T) {
 	}
 }
 
+func TestNativePrePushGateAcceptsCommittedCurrentChangesReceipt(t *testing.T) {
+	repo, receipt, request := approvedCurrentChangesGateFixture(t, "pre-push-current-changes")
+	if got := EvaluateNativeGate(context.Background(), repo, receipt, request); got.Result != GateAllow {
+		t.Fatalf("EvaluateNativeGate(pre-commit current changes) = %#v", got)
+	}
+
+	gitSnapshot(t, repo, "add", "tracked.txt")
+	gitSnapshot(t, repo, "commit", "-m", "deliver reviewed current changes")
+	request.Gate = GatePrePush
+	if got := EvaluateNativeGate(context.Background(), repo, receipt, request); got.Result != GateAllow {
+		t.Fatalf("EvaluateNativeGate(pre-push committed current changes) = %#v", got)
+	}
+}
+
+func TestNativePrePushGateRejectsAdvancedEmptyCurrentChangesReceipt(t *testing.T) {
+	repo, receipt, request := approvedEmptyCurrentChangesGateFixture(t, "pre-push-empty-current-changes")
+	gitSnapshot(t, repo, "commit", "--allow-empty", "-m", "first empty delivery")
+	gitSnapshot(t, repo, "commit", "--allow-empty", "-m", "advance empty delivery")
+	request.Gate = GatePrePush
+
+	if got := EvaluateNativeGate(context.Background(), repo, receipt, request); got.Result == GateAllow {
+		t.Fatalf("EvaluateNativeGate(advanced empty current changes) = %#v, want rejection", got)
+	}
+}
+
+func TestNativePrePushGateRejectsChangedOrAdvancedHead(t *testing.T) {
+	tests := []struct {
+		name    string
+		lineage string
+		advance func(t *testing.T, repo string)
+		want    GateResult
+	}{
+		{
+			name:    "changed head",
+			lineage: "pre-push-changed",
+			advance: func(t *testing.T, repo string) {
+				t.Helper()
+				writeSnapshotFile(t, repo, "tracked.txt", "altered delivery\n")
+				gitSnapshot(t, repo, "add", "tracked.txt")
+				gitSnapshot(t, repo, "commit", "-m", "alter reviewed delivery")
+			},
+			want: GateScopeChanged,
+		},
+		{
+			name:    "advanced head",
+			lineage: "pre-push-advanced",
+			advance: func(t *testing.T, repo string) {
+				t.Helper()
+				gitSnapshot(t, repo, "commit", "--allow-empty", "-m", "advance reviewed delivery")
+			},
+			want: GateInvalidated,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo, receipt, request := approvedCurrentChangesGateFixture(t, tt.lineage)
+			gitSnapshot(t, repo, "add", "tracked.txt")
+			gitSnapshot(t, repo, "commit", "-m", "deliver reviewed current changes")
+			tt.advance(t, repo)
+			request.Gate = GatePrePush
+
+			if got := EvaluateNativeGate(context.Background(), repo, receipt, request); got.Result != tt.want {
+				t.Fatalf("EvaluateNativeGate(%s) = %#v, want %q", tt.name, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestNativeGateUsesRetainedArtifactContentAndRejectsMismatch(t *testing.T) {
 	repo := initSnapshotRepo(t)
 	tx, receipt, request := nativeGateFixture(t, repo, "content-gate")
@@ -273,6 +342,35 @@ func nativeGateFixture(t *testing.T, repo, lineage string) (Transaction, Receipt
 		LedgerArtifact:   ledgerPath,
 		EvidenceArtifact: evidencePath,
 	}
+}
+
+func approvedCurrentChangesGateFixture(t *testing.T, lineage string) (string, Receipt, GateRequest) {
+	t.Helper()
+	repo := initSnapshotRepo(t)
+	writeSnapshotFile(t, repo, "tracked.txt", "reviewed delivery\n")
+	transaction, receipt, request := nativeGateFixture(t, repo, lineage)
+	store, err := AuthoritativeStore(context.Background(), repo, transaction.LineageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	appendApprovedStoreChain(t, store, transaction)
+	bindGateRequestToStore(t, &request, store)
+	request.Gate = GatePreCommit
+	return repo, receipt, request
+}
+
+func approvedEmptyCurrentChangesGateFixture(t *testing.T, lineage string) (string, Receipt, GateRequest) {
+	t.Helper()
+	repo := initSnapshotRepo(t)
+	transaction, receipt, request := nativeGateFixture(t, repo, lineage)
+	store, err := AuthoritativeStore(context.Background(), repo, transaction.LineageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	appendApprovedStoreChain(t, store, transaction)
+	bindGateRequestToStore(t, &request, store)
+	request.Gate = GatePreCommit
+	return repo, receipt, request
 }
 
 func appendApprovedStoreChain(t *testing.T, store Store, approved Transaction) string {


### PR DESCRIPTION
Closes #1097

## Type
- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- validate pre-push against the immutable delivered HEAD after committing a reviewed candidate
- reject altered, advanced, and empty-commit replay boundaries fail-closed
- add behavior-first regression coverage for the complete review-to-push lifecycle

## Changes
| File | Change |
|------|--------|
| `internal/reviewtransaction/gate.go` | Derive the pre-push candidate from immutable HEAD and reject tree-identical empty-commit replay. |
| `internal/reviewtransaction/gate_test.go` | Cover exact reviewed commits, altered/advanced HEAD, and empty-commit advancement. |

## Test Plan
- [x] `go test -count=1 ./internal/reviewtransaction`
- [x] `go test -count=1 ./...`
- [x] `go vet ./...`
- [x] Formatting and diff checks pass
- [x] Native pre-commit, pre-push, and pre-PR receipt validation returns `allow`

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] No shell scripts modified
- [x] Review lifecycle behavior tested end-to-end
- [x] Docs updated if behavior changed
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pre-push validation to ensure reviewed current changes include an actual delivered tree change.
  * Pre-push checks now evaluate the exact commit currently at HEAD, preventing approval when the branch head has changed or advanced unexpectedly.
  * Added validation coverage for accepting valid committed changes and rejecting empty or mismatched updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->