### PR TITLE
fix(sdd-apply): move Executor Override before Orchestrator Gate

### DIFF
--- a/internal/assets/skills/sdd-apply/SKILL.md
+++ b/internal/assets/skills/sdd-apply/SKILL.md
@@ -11,15 +11,15 @@ metadata:
   delegate_only: true
 ---
 
+## Executor Override
+
+If you ARE the `sdd-apply` sub-agent (NOT the orchestrator), the gate below does NOT apply to you. Continue with the phase work below. Do NOT delegate. Do NOT call the Skill tool. You are the executor — execute.
+
 > **ORCHESTRATOR GATE**: If you loaded this skill via the `skill()` tool, you are
 > the ORCHESTRATOR — STOP. Do NOT execute these instructions inline. Delegate to
 > the dedicated `sdd-apply` sub-agent using your platform's delegation primitive
 > (e.g., `task(...)`, sub-agent invocation, etc.). This skill is for EXECUTORS
 > only.
-
-## Executor Override
-
-If you ARE the `sdd-apply` sub-agent (NOT the orchestrator), the gate above does NOT apply to you. Continue with the phase work below. Do NOT delegate. Do NOT call the Skill tool. You are the executor — execute.
 
 
 ## Language Domain Contract


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #721

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

The `Executor Override` block in `skills/sdd-apply/SKILL.md` was placed **after** the `ORCHESTRATOR GATE`. LLMs are autoregressive — they process instructions sequentially. When the `sdd-apply` sub-agent reads the skill, the first imperative instruction it encounters is "STOP. Delegate to the dedicated sdd-apply sub-agent". By the time it reaches the Executor Override (which says the gate does NOT apply), it has already locked onto the delegate action.

This causes the sub-agent to attempt self-delegation, resulting in loops or no action taken.

The fix moves the `Executor Override` **above** the `ORCHESTRATOR GATE` so the sub-agent reads "you are the executor — execute" before encountering the gate instruction. The internal reference is also updated ("the gate above" → "the gate below").

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/assets/skills/sdd-apply/SKILL.md` | Moved `## Executor Override` block above `ORCHESTRATOR GATE`; updated "the gate above" → "the gate below" |

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./...
```

**E2E Tests** (Docker required)
```bash
cd e2e && ./docker-test.sh
```

- [x] Unit tests pass (`go test ./...`)
- [x] E2E tests pass (`cd e2e && ./docker-test.sh`) — Ubuntu: 79 passed, 0 failed, 2 skipped
- [ ] Manually tested locally

---

## 🤖 Automated Checks

The following checks run automatically on this PR:

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | PR should stay within 400 changed lines (`additions + deletions`) or use `size:exception` |
| Check Issue Reference | ⏳ | PR body must contain `Closes/Fixes/Resolves #N` |
| Check Issue Has `status:approved` | ⏳ | Linked issue must have been approved before work began |
| Check PR Has `type:*` Label | ⏳ | Exactly one `type:*` label must be applied |
| Unit Tests | ⏳ | `go test ./...` must pass |
| E2E Tests | ⏳ | `cd e2e && ./docker-test.sh` must pass |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [x] I have added the appropriate `type:*` label to this PR (needs maintainer to add via UI)
- [x] Unit tests pass (`go test ./...`)
- [x] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

E2E tests ran successfully in Docker (Ubuntu: 79 passed, 0 failed, 2 skipped). The change is purely a Markdown block reordering inside an embedded skill asset — no Go code or behavioral logic was modified.