### PR TITLE
docs(readme): clarify beta updates on PowerShell

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,9 +99,7 @@ $env:GENTLE_AI_CHANNEL="beta"; irm https://raw.githubusercontent.com/Gentleman-P
 
 #### Refreshing on the beta channel
 
-The beta channel has no auto-update — `main` only advances when you re-roll the binary yourself.
-
-**Refresh managed tools (engram, GGA, configs)**
+The beta channel does not update in the background. Run `gentle-ai upgrade` when you want to refresh Gentle AI and its managed tools:
 
 ```bash
 # macOS / Linux
@@ -113,32 +111,42 @@ GENTLE_AI_CHANNEL=beta gentle-ai upgrade
 $env:GENTLE_AI_CHANNEL="beta"; gentle-ai upgrade
 ```
 
-> On Windows the running binary cannot replace itself in place, so `gentle-ai upgrade` updates the managed tool binaries (engram, GGA, etc.) and the report typically shows `gentle-ai` as needing a manual update. That signal is expected on beta — to actually roll the binary, follow the next path.
-
-**Re-roll the Gentle AI beta binary**
-
-With Go 1.24+ on PATH:
+If you only need to rebuild the beta binary from the current `main`, use Go directly:
 
 ```bash
 go install github.com/gentleman-programming/gentle-ai/cmd/gentle-ai@main
 ```
 
-Or just re-run the installer — it does the same `go install @main` for you. Use the same commands from [Try the beta channel](#try-the-beta-channel-test-main-before-a-release) above.
+You can also re-run the beta installer shown above; it runs the same `go install ...@main` flow.
 
-> ⚠️ **Go proxy lag.** `proxy.golang.org` can lag behind new commits on `main` for up to ~30 minutes. When the proxy is stale, `go install ...@main` exits silently without updating the binary — the symptom looks like "nothing happened". If you hit that, prefer an explicit released tag (always available on the proxy):
+> ⚠️ **Go proxy lag.** `proxy.golang.org` can temporarily serve an older `main`. If `go install ...@main` finishes but the version does not change, prefer an explicit released tag:
 >
 > ```bash
-> # Pin to a known-good tag from https://github.com/Gentleman-Programming/gentle-ai/releases
+> # Choose a tag from https://github.com/Gentleman-Programming/gentle-ai/releases
 > go install github.com/gentleman-programming/gentle-ai/cmd/gentle-ai@vX.Y.Z
 > ```
 >
-> Only use `GOPROXY=direct` as a scoped workaround when you really need fresh `main` right now. It bypasses the proxy cache and queries the module server directly, which is slower on first use and not a stable default:
+> When you specifically need the latest `main`, bypass the module proxy for that command and fetch from the VCS repository directly:
+>
+> ```bash
+> GOPROXY=direct go install github.com/gentleman-programming/gentle-ai/cmd/gentle-ai@main
+> ```
 >
 > ```powershell
 > $env:GOPROXY="direct"; go install github.com/gentleman-programming/gentle-ai/cmd/gentle-ai@main
 > ```
 
-To return to stable on either platform, reinstall with the default installer.
+To return to stable, clear the beta channel first, then reinstall with Homebrew or Scoop:
+
+```bash
+unset GENTLE_AI_CHANNEL
+brew upgrade gentle-ai
+```
+
+```powershell
+Remove-Item Env:GENTLE_AI_CHANNEL -ErrorAction SilentlyContinue
+scoop install gentle-ai
+```
 
 ### After install: project-level setup
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ $env:GENTLE_AI_CHANNEL="beta"; irm https://raw.githubusercontent.com/Gentleman-P
 
 #### Refreshing on the beta channel
 
-The beta channel does not update in the background. Run `gentle-ai upgrade` when you want to refresh Gentle AI and its managed tools:
+The beta channel does not update in the background. Run `gentle-ai upgrade` to refresh managed tools such as Engram and GGA:
 
 ```bash
 # macOS / Linux
@@ -136,17 +136,21 @@ You can also re-run the beta installer shown above; it runs the same `go install
 > $env:GOPROXY="direct"; go install github.com/gentleman-programming/gentle-ai/cmd/gentle-ai@main
 > ```
 
-To return to stable, clear the beta channel first, then reinstall with Homebrew or Scoop:
+To update the Gentle AI beta binary itself, run the `go install ...@main` command above or re-run the beta installer.
+
+To return to stable, clear the beta channel first. Then use the installer you prefer:
 
 ```bash
 unset GENTLE_AI_CHANNEL
-brew upgrade gentle-ai
+curl -fsSL https://raw.githubusercontent.com/Gentleman-Programming/gentle-ai/main/scripts/install.sh | bash
 ```
 
 ```powershell
 Remove-Item Env:GENTLE_AI_CHANNEL -ErrorAction SilentlyContinue
-scoop install gentle-ai
+irm https://raw.githubusercontent.com/Gentleman-Programming/gentle-ai/main/scripts/install.ps1 | iex
 ```
+
+If Homebrew or Scoop already manages your stable installation, you can use `brew upgrade gentle-ai` or `scoop update gentle-ai` instead.
 
 ### After install: project-level setup
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,48 @@ curl -fsSL https://raw.githubusercontent.com/Gentleman-Programming/gentle-ai/mai
 $env:GENTLE_AI_CHANNEL="beta"; irm https://raw.githubusercontent.com/Gentleman-Programming/gentle-ai/main/scripts/install.ps1 | iex
 ```
 
-To keep upgrading on beta later, run `$env:GENTLE_AI_CHANNEL="beta"; gentle-ai upgrade` on Windows or `GENTLE_AI_CHANNEL=beta gentle-ai upgrade` on macOS/Linux. To return to stable, reinstall with the default installer.
+#### Refreshing on the beta channel
+
+The beta channel has no auto-update — `main` only advances when you re-roll the binary yourself.
+
+**Refresh managed tools (engram, GGA, configs)**
+
+```bash
+# macOS / Linux
+GENTLE_AI_CHANNEL=beta gentle-ai upgrade
+```
+
+```powershell
+# Windows (PowerShell)
+$env:GENTLE_AI_CHANNEL="beta"; gentle-ai upgrade
+```
+
+> On Windows the running binary cannot replace itself in place, so `gentle-ai upgrade` updates the managed tool binaries (engram, GGA, etc.) and the report typically shows `gentle-ai` as needing a manual update. That signal is expected on beta — to actually roll the binary, follow the next path.
+
+**Re-roll the Gentle AI beta binary**
+
+With Go 1.24+ on PATH:
+
+```bash
+go install github.com/gentleman-programming/gentle-ai/cmd/gentle-ai@main
+```
+
+Or just re-run the installer — it does the same `go install @main` for you. Use the same commands from [Try the beta channel](#try-the-beta-channel-test-main-before-a-release) above.
+
+> ⚠️ **Go proxy lag.** `proxy.golang.org` can lag behind new commits on `main` for up to ~30 minutes. When the proxy is stale, `go install ...@main` exits silently without updating the binary — the symptom looks like "nothing happened". If you hit that, prefer an explicit released tag (always available on the proxy):
+>
+> ```bash
+> # Pin to a known-good tag from https://github.com/Gentleman-Programming/gentle-ai/releases
+> go install github.com/gentleman-programming/gentle-ai/cmd/gentle-ai@vX.Y.Z
+> ```
+>
+> Only use `GOPROXY=direct` as a scoped workaround when you really need fresh `main` right now. It bypasses the proxy cache and queries the module server directly, which is slower on first use and not a stable default:
+>
+> ```powershell
+> $env:GOPROXY="direct"; go install github.com/gentleman-programming/gentle-ai/cmd/gentle-ai@main
+> ```
+
+To return to stable on either platform, reinstall with the default installer.
 
 ### After install: project-level setup
 


### PR DESCRIPTION
<!-- Following .github/PULL_REQUEST_TEMPLATE.md -->

## Linked Issue

Closes #968

---

## PR Type

What kind of change does this PR introduce?

- [x] `type:docs` — Documentation only
- [ ] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## Summary

- Splits the single inline upgrade sentence into per-platform code blocks for the beta refresh commands.
- Adds a "Re-roll the beta binary" path that points users at `go install ...@main` or re-running the installer, since the beta channel has no auto-update.
- Surfaces the `proxy.golang.org` ~30-minute lag, the silent-failure symptom, and the safe fallback (explicit released tag); frames `GOPROXY=direct` as a scoped workaround rather than a default.
- Documents that on Windows `gentle-ai upgrade` updates managed tool binaries (engram, GGA, etc.) and typically reports `gentle-ai` itself as needing a manual update.

No code, scripts, or tests changed.

---

## Changes

| File / Area | What Changed |
|-------------|-------------|
| `README.md` | Replaced the one-line beta refresh sentence with a per-platform section covering `gentle-ai upgrade`, re-rolling the binary against `main`, the Go proxy lag, and the safe-tag fallback. |

Diff size: `1 file changed, 42 insertions(+), 1 deletion(-)`.

---

## Test Plan

This PR is documentation-only (no Go code, scripts, or tests touched).

```bash
# Manually render the README and sanity-check the beta section
# (any markdown renderer is fine; spot-check headings, code blocks, and the
# callout typography in the GO proxy lag section).
```

- [ ] Unit tests pass (`go test ./...`) — N/A, no code touched
- [x] E2E tests pass (`cd e2e && ./docker-test.sh`) — N/A, no scripts touched
- [x] Manually tested locally — verified the diff against `install.ps1` (proxy-lag warning at lines 134-138) and `internal/update/upgrade/executor.go` (Windows self-replace on `gentle-ai`)

---

## Automated Checks

The following checks run automatically on this PR:

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | PR should stay within 400 changed lines (`additions + deletions`) or use `size:exception` |
| Check Issue Reference | ⏳ | PR body must contain `Closes/Fixes/Resolves #N` |
| Check Issue Has `status:approved` | ⏳ | Linked issue must have been approved before work began |
| Check PR Has `type:*` Label | ⏳ | Exactly one `type:*` label must be applied |
| Unit Tests | ⏳ | `go test ./...` must pass |
| E2E Tests | ⏳ | `cd e2e && ./docker-test.sh` must pass |

---

## Contributor Checklist

- [x] PR is linked to an issue with `status:approved` (issue #968)
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented (42 lines added)
- [x] I have added the appropriate `type:*` label to this PR (`type:docs` will be applied via `gh pr edit --add-label`)
- [x] Unit tests pass (`go test ./...`) — N/A, no Go code changed
- [x] E2E tests pass (`cd e2e && ./docker-test.sh`) — N/A, no scripts changed
- [x] I have updated documentation if necessary (this PR is the documentation)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] My commits do not include `Co-Authored-By` trailers

---

## Notes for Reviewers

Scope is intentionally narrow: only the beta-channel section in `README.md`. I verified two claims against the current source tree before writing:

- The ~30-minute proxy lag language matches `scripts/install.ps1` lines 134-138, which already warns about this internally.
- The "Windows `gentle-ai upgrade` does not roll the binary in place" behavior matches `internal/update/upgrade/executor.go` (`effectiveMethod` returns `InstallInstaller` for `gentle-ai` on Windows, with a manual-update fallback in the upgrade report when the safe path is not applicable).

No other README sections were modified. If reviewers want this content moved to a dedicated `docs/beta-channel.md` instead of inline, happy to follow up in a chained PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded beta-channel guidance with a new “Refreshing on the beta channel” section, including explicit refresh/reinstall commands for macOS/Linux and Windows.
  * Added instructions to rebuild/reroll the beta binary from the latest source and guidance for Go proxy lag (use a specific release tag or bypass the module proxy).
  * Clarified how to switch back to the stable channel by clearing the beta channel setting and reinstalling (including platform-specific upgrade options).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->