### PR TITLE
fix(review): model selected lens executions

### DIFF
--- a/internal/app/help.go
+++ b/internal/app/help.go
@@ -22,11 +22,11 @@ COMMANDS
                Print native SDD phase status for orchestrators
   sdd-continue [change]
                Print native SDD dispatcher routing output
-	  review-start --cwd <repo> --lineage <id> --policy-file <path>
+	  review-start --cwd <repo> --lineage <id> --policy-file <path> [--mode ordinary_bounded] [--lens <name> ...]
 	               Build a target and append to the repository-derived review store
 	  review-resume --cwd <repo> --lineage <id>
 	  review-step --cwd <repo> --lineage <id> --operation <operation> --input <json>
-	               Re-emit authoritative state after output or mirror failure
+	               Append a lifecycle step; record-lens-result derives identity from structured findings and evidence
 	  review-bundle-export --cwd <repo> --lineage <id> --out <path>
 	               Export the validated full chain as a portable content-addressed bundle
 	  review-bundle-import --cwd <repo> --bundle <path> --receipt <path> --request <path>

--- a/internal/app/help_test.go
+++ b/internal/app/help_test.go
@@ -27,6 +27,16 @@ func TestHelpContainsVersion(t *testing.T) {
 	}
 }
 
+func TestHelpDescribesOrdinaryBoundedLensOperations(t *testing.T) {
+	var buf bytes.Buffer
+	printHelp(&buf, "v1.0.0-test")
+	for _, want := range []string{"ordinary_bounded", "--lens <name>", "record-lens-result", "structured findings and evidence"} {
+		if !strings.Contains(buf.String(), want) {
+			t.Fatalf("help output missing %q", want)
+		}
+	}
+}
+
 func TestHelpCommandsHeadingIsAligned(t *testing.T) {
 	var buf bytes.Buffer
 	printHelp(&buf, "v1.2.3")

--- a/internal/cli/review.go
+++ b/internal/cli/review.go
@@ -9,6 +9,9 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/gentleman-programming/gentle-ai/internal/reviewtransaction"
@@ -82,6 +85,7 @@ type ReviewStepInput struct {
 	Release         *reviewtransaction.ReleaseEvidence        `json:"release"`
 	JudgeProofs     []reviewtransaction.JudgeProof            `json:"judge_proofs"`
 	JudgeAgreement  string                                    `json:"judge_agreement_hash"`
+	LensResult      *reviewtransaction.LensResult             `json:"lens_result"`
 }
 
 func RunReviewStep(args []string, stdout io.Writer) error {
@@ -118,6 +122,11 @@ func RunReviewStep(args []string, stdout io.Writer) error {
 	}
 	tx := chain.Records[len(chain.Records)-1].Transaction
 	switch *operation {
+	case "record-lens-result":
+		if input.LensResult == nil {
+			return errors.New("record-lens-result requires lens_result")
+		}
+		err = tx.RecordLensResult(*input.LensResult)
 	case "record-judge-proofs":
 		err = tx.RecordJudgeProofs(input.JudgeProofs, input.JudgeAgreement)
 	case "freeze-findings":
@@ -205,8 +214,10 @@ func RunReviewStart(args []string, stdout io.Writer) error {
 	machineTransactionOut := flags.String("machine-transaction-out", "", "optional non-authoritative transaction JSON output path")
 	var intended repeatedString
 	var ledgerIDs repeatedString
+	var selectedLenses repeatedString
 	flags.Var(&intended, "intended-untracked", "repository-relative intended untracked path; repeatable")
 	flags.Var(&ledgerIDs, "ledger-id", "frozen ledger finding ID for fix-diff; repeatable and comma-safe")
+	flags.Var(&selectedLenses, "lens", "selected ordinary bounded review lens; repeatable in canonical 4R order")
 	if err := flags.Parse(args); err != nil {
 		return err
 	}
@@ -244,9 +255,16 @@ func RunReviewStart(args []string, stdout io.Writer) error {
 	if err != nil {
 		return fmt.Errorf("build review target: %w", err)
 	}
+	riskLevel := reviewtransaction.RiskLevel("")
+	if reviewtransaction.Mode(*mode) == reviewtransaction.ModeOrdinaryBounded {
+		riskLevel, err = classifyReviewSnapshot(context.Background(), *cwd, snapshot)
+		if err != nil {
+			return fmt.Errorf("classify immutable review target: %w", err)
+		}
+	}
 	transaction, err := reviewtransaction.NewTransaction(reviewtransaction.Start{
 		LineageID: *lineage, Mode: reviewtransaction.Mode(*mode), Generation: *generation,
-		Snapshot: snapshot, PolicyHash: policyHash,
+		Snapshot: snapshot, PolicyHash: policyHash, RiskLevel: riskLevel, SelectedLenses: []string(selectedLenses),
 	})
 	if err != nil {
 		return fmt.Errorf("create review transaction: %w", err)
@@ -276,6 +294,78 @@ func RunReviewStart(args []string, stdout io.Writer) error {
 		}
 	}
 	return encodeReviewJSON(stdout, result)
+}
+
+func classifyReviewSnapshot(ctx context.Context, repo string, snapshot reviewtransaction.Snapshot) (reviewtransaction.RiskLevel, error) {
+	command := exec.CommandContext(ctx, "git", "-C", repo, "diff", "--numstat", "--no-renames", snapshot.BaseTree, snapshot.CandidateTree, "--")
+	output, err := command.Output()
+	if err != nil {
+		return "", err
+	}
+	stats := make([]reviewtransaction.DiffStat, 0, len(snapshot.Paths))
+	onlyNonExecutable := true
+	touchesConfiguration := false
+	seenPaths := make(map[string]struct{}, len(snapshot.Paths))
+	for _, line := range strings.Split(strings.TrimSpace(string(output)), "\n") {
+		if line == "" {
+			continue
+		}
+		fields := strings.Split(line, "\t")
+		if len(fields) != 3 {
+			return "", fmt.Errorf("unexpected immutable diff stat %q", line)
+		}
+		stat := reviewtransaction.DiffStat{Path: fields[2]}
+		if fields[0] == "-" && fields[1] == "-" {
+			stat.Binary = true
+		} else {
+			stat.Additions, err = strconv.Atoi(fields[0])
+			if err != nil {
+				return "", fmt.Errorf("parse additions for %q: %w", stat.Path, err)
+			}
+			stat.Deletions, err = strconv.Atoi(fields[1])
+			if err != nil {
+				return "", fmt.Errorf("parse deletions for %q: %w", stat.Path, err)
+			}
+		}
+		stats = append(stats, stat)
+		seenPaths[stat.Path] = struct{}{}
+		onlyNonExecutable = onlyNonExecutable && isNonExecutableReviewPath(stat.Path)
+		touchesConfiguration = touchesConfiguration || isConfigurationReviewPath(stat.Path)
+	}
+	for _, path := range snapshot.Paths {
+		if _, ok := seenPaths[path]; !ok {
+			return "", fmt.Errorf("immutable snapshot path %q is missing from tree diff stats", path)
+		}
+	}
+	if len(seenPaths) != len(snapshot.Paths) {
+		return "", errors.New("immutable tree diff contains paths outside the review snapshot")
+	}
+	return reviewtransaction.ClassifyRisk(reviewtransaction.RiskInput{
+		Stats: stats, OnlyNonExecutableChanges: onlyNonExecutable, TouchesConfiguration: touchesConfiguration,
+	})
+}
+
+func isNonExecutableReviewPath(path string) bool {
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".md", ".mdx", ".rst", ".adoc", ".png", ".jpg", ".jpeg", ".gif", ".svg":
+		return true
+	default:
+		return false
+	}
+}
+
+func isConfigurationReviewPath(path string) bool {
+	base := strings.ToLower(filepath.Base(path))
+	switch base {
+	case "go.mod", "go.sum", "package.json", "package-lock.json", "pnpm-lock.yaml", "yarn.lock", "dockerfile", "makefile":
+		return true
+	}
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".json", ".yaml", ".yml", ".toml", ".ini", ".env":
+		return true
+	default:
+		return false
+	}
 }
 
 func RunReviewResume(args []string, stdout io.Writer) error {

--- a/internal/cli/review_test.go
+++ b/internal/cli/review_test.go
@@ -238,6 +238,116 @@ func TestRunReviewStepAppendsLifecycleStateThroughAuthoritativeStore(t *testing.
 	}
 }
 
+func TestRunReviewStartStepAndResumeOrdinaryBoundedLensResult(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("standard executable change\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	policy := filepath.Join(t.TempDir(), "policy.md")
+	if err := os.WriteFile(policy, []byte("bounded policy\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var started bytes.Buffer
+	if err := RunReviewStart([]string{
+		"--cwd", repo,
+		"--lineage", "bounded-lens",
+		"--policy-file", policy,
+		"--mode", string(reviewtransaction.ModeOrdinaryBounded),
+		"--lens", "review-reliability",
+	}, &started); err != nil {
+		t.Fatalf("RunReviewStart() error = %v", err)
+	}
+	var startResult ReviewStartResult
+	if err := json.Unmarshal(started.Bytes(), &startResult); err != nil {
+		t.Fatal(err)
+	}
+	if startResult.Transaction.Counters != (reviewtransaction.Counters{}) || len(startResult.Transaction.SelectedLenses) != 1 {
+		t.Fatalf("bounded start = %#v", startResult.Transaction)
+	}
+
+	input := filepath.Join(t.TempDir(), "lens-result.json")
+	writeReviewCLIJSON(t, input, ReviewStepInput{LensResult: &reviewtransaction.LensResult{
+		Lens: "review-reliability", Findings: []reviewtransaction.Finding{}, Evidence: []string{"focused reliability sweep completed"},
+	}})
+	if err := RunReviewStep([]string{
+		"--cwd", repo, "--lineage", "bounded-lens", "--operation", "record-lens-result", "--input", input,
+	}, failingReviewWriter{}); err == nil {
+		t.Fatal("RunReviewStep() hid the post-commit output failure")
+	}
+
+	var resumed bytes.Buffer
+	if err := RunReviewResume([]string{"--cwd", repo, "--lineage", "bounded-lens"}, &resumed); err != nil {
+		t.Fatalf("RunReviewResume() error = %v", err)
+	}
+	var resumeResult ReviewResumeResult
+	if err := json.Unmarshal(resumed.Bytes(), &resumeResult); err != nil {
+		t.Fatal(err)
+	}
+	if len(resumeResult.Transaction.LensResults) != 1 || resumeResult.Transaction.Counters.ReliabilityExecutions != 1 || resumeResult.Transaction.State != reviewtransaction.StateReviewing {
+		t.Fatalf("resumed bounded result = %#v", resumeResult.Transaction)
+	}
+}
+
+func TestRunReviewStartBindsSelectedLensesToImmutableSnapshotRisk(t *testing.T) {
+	policy := filepath.Join(t.TempDir(), "policy.md")
+	if err := os.WriteFile(policy, []byte("bounded policy\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	tests := []struct {
+		name       string
+		changePath string
+		content    string
+		lenses     []string
+		wantRisk   reviewtransaction.RiskLevel
+	}{
+		{name: "low", changePath: "guide.md", content: "documentation only\n", wantRisk: reviewtransaction.RiskLow},
+		{name: "medium", changePath: "tracked.txt", content: "standard executable change\n", lenses: []string{reviewtransaction.LensReliability}, wantRisk: reviewtransaction.RiskMedium},
+		{name: "high", changePath: "internal/security/check.go", content: "package security\n", lenses: []string{reviewtransaction.LensRisk, reviewtransaction.LensResilience, reviewtransaction.LensReadability, reviewtransaction.LensReliability}, wantRisk: reviewtransaction.RiskHigh},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := initReviewCLIRepo(t)
+			if err := os.MkdirAll(filepath.Dir(filepath.Join(repo, tt.changePath)), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(repo, tt.changePath), []byte(tt.content), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			args := []string{"--cwd", repo, "--lineage", "risk-" + tt.name, "--policy-file", policy, "--mode", string(reviewtransaction.ModeOrdinaryBounded)}
+			if tt.changePath != "tracked.txt" {
+				args = append(args, "--intended-untracked", tt.changePath)
+			}
+			for _, lens := range tt.lenses {
+				args = append(args, "--lens", lens)
+			}
+			var output bytes.Buffer
+			if err := RunReviewStart(args, &output); err != nil {
+				t.Fatalf("RunReviewStart() error = %v", err)
+			}
+			var result ReviewStartResult
+			if err := json.Unmarshal(output.Bytes(), &result); err != nil {
+				t.Fatal(err)
+			}
+			if result.Transaction.RiskLevel != tt.wantRisk || len(result.Transaction.SelectedLenses) != len(tt.lenses) {
+				t.Fatalf("bounded classification = %q, %v", result.Transaction.RiskLevel, result.Transaction.SelectedLenses)
+			}
+		})
+	}
+
+	repo := initReviewCLIRepo(t)
+	if err := os.WriteFile(filepath.Join(repo, "guide.md"), []byte("documentation only\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	err := RunReviewStart([]string{
+		"--cwd", repo, "--lineage", "risk-mismatch", "--policy-file", policy,
+		"--mode", string(reviewtransaction.ModeOrdinaryBounded), "--intended-untracked", "guide.md",
+		"--lens", reviewtransaction.LensReliability,
+	}, io.Discard)
+	if err == nil || !strings.Contains(err.Error(), "low risk requires exactly 0") {
+		t.Fatalf("RunReviewStart(risk mismatch) error = %v", err)
+	}
+}
+
 func TestRunReviewStepAppendsTargetedValidationAndResumeReemitsIt(t *testing.T) {
 	repo := initReviewCLIRepo(t)
 	lineage := "targeted-validation"

--- a/internal/reviewtransaction/bounded_lenses_test.go
+++ b/internal/reviewtransaction/bounded_lenses_test.go
@@ -1,0 +1,358 @@
+package reviewtransaction
+
+import (
+	"encoding/json"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestOrdinaryBoundedSupportsOnlyZeroOneOrCanonicalFourLenses(t *testing.T) {
+	tests := []struct {
+		name    string
+		lenses  []string
+		wantErr bool
+	}{
+		{name: "zero", lenses: []string{}},
+		{name: "one", lenses: []string{"review-reliability"}},
+		{name: "four", lenses: append([]string(nil), supportedLenses...)},
+		{name: "two", lenses: []string{"review-risk", "review-resilience"}, wantErr: true},
+		{name: "unknown", lenses: []string{"review-performance"}, wantErr: true},
+		{name: "out of order", lenses: []string{"review-resilience", "review-risk", "review-readability", "review-reliability"}, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			start := boundedStart(t, tt.lenses)
+			tx, err := NewTransaction(start)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("NewTransaction() accepted invalid lens selection")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("NewTransaction() error = %v", err)
+			}
+			if tx.Counters != (Counters{}) {
+				t.Fatalf("genesis counters = %#v, want all zero", tx.Counters)
+			}
+			if err := tx.StartReview(); err != nil {
+				t.Fatal(err)
+			}
+			if tx.Counters != (Counters{}) {
+				t.Fatalf("started counters = %#v, want all zero", tx.Counters)
+			}
+		})
+	}
+}
+
+func TestOrdinaryBoundedRecordsEachSelectedLensExactlyOnceBeforeFreeze(t *testing.T) {
+	tx, err := NewTransaction(boundedStart(t, supportedLenses))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = tx.StartReview()
+	if err := tx.FreezeFindings([]Finding{}, hash("0")); err == nil {
+		t.Fatal("FreezeFindings() accepted incomplete selected lenses")
+	}
+	for _, result := range []LensResult{
+		{Lens: "review-performance", Findings: []Finding{}, Evidence: []string{"complete performance sweep"}},
+		{Lens: "review-reliability", Findings: []Finding{}, Evidence: []string{"complete reliability sweep"}},
+		{Lens: "review-risk", Findings: nil, Evidence: []string{"complete risk sweep"}},
+	} {
+		if err := tx.RecordLensResult(result); err == nil {
+			t.Fatalf("RecordLensResult(%#v) accepted invalid result", result)
+		}
+	}
+	for index, lens := range supportedLenses {
+		result := boundedLensResult(lens, string(rune('1'+index)))
+		if err := tx.RecordLensResult(result); err != nil {
+			t.Fatalf("RecordLensResult(%q) error = %v", lens, err)
+		}
+		if err := tx.RecordLensResult(result); err == nil {
+			t.Fatalf("RecordLensResult(%q) accepted duplicate", lens)
+		}
+	}
+	if err := tx.FreezeFindings([]Finding{}, hash("9")); err != nil {
+		t.Fatalf("FreezeFindings() error = %v", err)
+	}
+}
+
+func TestOrdinaryBoundedRejectsSupportedButUnselectedLens(t *testing.T) {
+	tx, err := NewTransaction(boundedStart(t, []string{LensRisk}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = tx.StartReview()
+	if err := tx.RecordLensResult(boundedLensResult(LensResilience, "1")); err == nil || !strings.Contains(err.Error(), "was not selected") {
+		t.Fatalf("RecordLensResult(unselected) error = %v", err)
+	}
+}
+
+func TestZeroLensOrdinaryBoundedRequiresExplicitEmptyLedger(t *testing.T) {
+	tx, err := NewTransaction(boundedStart(t, []string{}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = tx.StartReview()
+	if err := tx.FreezeFindings(nil, hash("1")); err == nil {
+		t.Fatal("FreezeFindings(nil) accepted an implicit zero-lens ledger")
+	}
+	if err := tx.FreezeFindings([]Finding{}, hash("1")); err != nil {
+		t.Fatalf("FreezeFindings(explicit empty) error = %v", err)
+	}
+}
+
+func TestOrdinaryBoundedLensStateRoundTripsAndLegacyJSONRemainsAdditive(t *testing.T) {
+	bounded, err := NewTransaction(boundedStart(t, []string{"review-reliability"}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = bounded.StartReview()
+	_ = bounded.RecordLensResult(boundedLensResult("review-reliability", "1"))
+	payload, err := json.Marshal(bounded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	parsed, err := ParseTransaction(payload)
+	if err != nil {
+		t.Fatalf("ParseTransaction() error = %v", err)
+	}
+	if len(parsed.SelectedLenses) != 1 || len(parsed.LensResults) != 1 || parsed.Counters.ReliabilityExecutions != 1 {
+		t.Fatalf("round-tripped bounded state = %#v", parsed)
+	}
+
+	legacy := newTestTransaction(t, ModeOrdinary4R)
+	_ = legacy.StartReview()
+	legacyPayload, err := json.Marshal(legacy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, additiveField := range []string{"risk_level", "selected_lenses", "lens_results", "risk_executions", "resilience_executions", "readability_executions", "reliability_executions"} {
+		if strings.Contains(string(legacyPayload), additiveField) {
+			t.Fatalf("legacy ordinary_4r JSON unexpectedly contains %q", additiveField)
+		}
+	}
+	if legacy.Counters.FullReviews != 1 {
+		t.Fatalf("legacy FullReviews = %d, want 1", legacy.Counters.FullReviews)
+	}
+	legacyRevision, err := (Store{Dir: t.TempDir()}).Append("", Record{Operation: "review/start", Transaction: *legacy})
+	if err != nil {
+		t.Fatal(err)
+	}
+	const baselineRevision = "sha256:077a4d5e483613817b335c69976e874f37f5112488e70c08dc5ad94ca9bb04a5"
+	if legacyRevision != baselineRevision {
+		t.Fatalf("legacy ordinary_4r genesis revision = %q, want baseline %q", legacyRevision, baselineRevision)
+	}
+}
+
+func TestStoreValidatesContentAddressedLensResultSuccessorsAndReplay(t *testing.T) {
+	store := Store{Dir: filepath.Join(t.TempDir(), "review-store")}
+	tx, err := NewTransaction(boundedStart(t, []string{"review-reliability"}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = tx.StartReview()
+	genesis, err := store.Append("", Record{Operation: "review/start", Transaction: *tx})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.RecordLensResult(boundedLensResult("review-reliability", "1")); err != nil {
+		t.Fatal(err)
+	}
+	record := Record{Operation: "review/record-lens-result", Transaction: *tx}
+	completed, err := store.Append(genesis, record)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if retried, err := store.Append(genesis, record); err != nil || retried != completed {
+		t.Fatalf("Append(exact retry) = %q, %v; want %q, nil", retried, err, completed)
+	}
+	chain, err := store.LoadChain()
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := chain.Records[len(chain.Records)-1].Transaction
+	if chain.HeadRevision != completed || len(got.LensResults) != 1 || got.Counters.ReliabilityExecutions != 1 {
+		t.Fatalf("replayed chain = %#v", chain)
+	}
+	if err := tx.FreezeFindings([]Finding{}, hash("3")); err != nil {
+		t.Fatal(err)
+	}
+	completed, err = store.Append(completed, Record{Operation: "review/freeze-findings", Transaction: *tx})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tx.ClassifyEvidence([]FindingEvidence{}); err != nil {
+		t.Fatal(err)
+	}
+	completed, err = store.Append(completed, Record{Operation: "review/classify-evidence", Transaction: *tx})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.BeginFinalVerification(); err != nil {
+		t.Fatal(err)
+	}
+	completed, err = store.Append(completed, Record{Operation: "review/begin-final-verification", Transaction: *tx})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.CompleteFinalVerification(hash("4"), true); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Append(completed, Record{Operation: "review/complete-final-verification", Transaction: *tx}); err != nil {
+		t.Fatal(err)
+	}
+	bundle, err := store.ExportBundle()
+	if err != nil {
+		t.Fatalf("ExportBundle() error = %v", err)
+	}
+	payload, err := json.Marshal(bundle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	parsedBundle, err := ParseChainBundle(payload)
+	if err != nil {
+		t.Fatalf("ParseChainBundle() error = %v", err)
+	}
+	terminal := parsedBundle.Events[len(parsedBundle.Events)-1]
+	if len(terminal.Payload) == 0 || parsedBundle.TerminalReceipt == nil || len(parsedBundle.TerminalReceipt.LensResults) != 1 {
+		t.Fatalf("bounded bundle did not preserve lens completion: %#v", parsedBundle)
+	}
+
+	forged := *tx
+	forged.LensResults = append([]LensResult(nil), tx.LensResults...)
+	forged.LensResults[0].ResultHash = hash("2")
+	if _, err := store.Append(genesis, Record{Operation: "review/freeze-findings", Transaction: forged}); !errors.Is(err, ErrInvalidSuccessor) {
+		t.Fatalf("Append(forged stale result) error = %v, want ErrInvalidSuccessor", err)
+	}
+	otherStore := Store{Dir: filepath.Join(t.TempDir(), "review-store")}
+	fresh, err := NewTransaction(boundedStart(t, []string{"review-reliability"}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = fresh.StartReview()
+	otherGenesis, err := otherStore.Append("", Record{Operation: "review/start", Transaction: *fresh})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := fresh.RecordLensResult(boundedLensResult("review-reliability", "2")); err != nil {
+		t.Fatal(err)
+	}
+	forgedResult := *fresh
+	forgedResult.PolicyHash = hash("f")
+	if _, err := otherStore.Append(otherGenesis, Record{Operation: "review/record-lens-result", Transaction: forgedResult}); !errors.Is(err, ErrInvalidSuccessor) {
+		t.Fatalf("Append(forged lens successor) error = %v, want ErrInvalidSuccessor", err)
+	}
+	if _, err := otherStore.Append(otherGenesis, Record{Operation: "review/freeze-findings", Transaction: *fresh}); !errors.Is(err, ErrInvalidSuccessor) {
+		t.Fatalf("Append(forged operation) error = %v, want ErrInvalidSuccessor", err)
+	}
+}
+
+func TestOrdinaryBoundedDerivesLensIdentityFromStructuredContent(t *testing.T) {
+	tx, err := NewTransaction(boundedStart(t, []string{LensRisk, LensResilience, LensReadability, LensReliability}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = tx.StartReview()
+	risk := boundedLensResult(LensRisk, "shared evidence")
+	risk.ResultHash = hash("f")
+	if err := tx.RecordLensResult(risk); err == nil || !strings.Contains(err.Error(), "does not match") {
+		t.Fatalf("RecordLensResult(caller hash) error = %v", err)
+	}
+	risk.ResultHash = ""
+	if err := tx.RecordLensResult(risk); err != nil {
+		t.Fatal(err)
+	}
+	resilience := boundedLensResult(LensResilience, "shared evidence")
+	if err := tx.RecordLensResult(resilience); err != nil {
+		t.Fatal(err)
+	}
+	if tx.LensResults[0].ResultHash == tx.LensResults[1].ResultHash {
+		t.Fatal("lens-bound canonical identities allowed cross-lens hash reuse")
+	}
+	payload, err := json.Marshal(tx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var forged Transaction
+	if err := json.Unmarshal(payload, &forged); err != nil {
+		t.Fatal(err)
+	}
+	forged.LensResults[0].Evidence[0] = "tampered evidence"
+	forgedPayload, _ := json.Marshal(forged)
+	if _, err := ParseTransaction(forgedPayload); err == nil {
+		t.Fatal("ParseTransaction() accepted content that no longer matches its canonical lens result hash")
+	}
+}
+
+func TestStoreRejectsForgedIncompleteLensFreezeBeforeAppend(t *testing.T) {
+	store := Store{Dir: filepath.Join(t.TempDir(), "review-store")}
+	tx, err := NewTransaction(boundedStart(t, []string{LensReliability}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = tx.StartReview()
+	genesis, err := store.Append("", Record{Operation: "review/start", Transaction: *tx})
+	if err != nil {
+		t.Fatal(err)
+	}
+	forged := *tx
+	forged.State = StateFindingsFrozen
+	forged.Findings = []Finding{}
+	forged.LedgerHash = hash("1")
+	forged.LedgerFindingsHash = findingsHash(forged.Findings)
+	if _, err := store.Append(genesis, Record{Operation: "review/freeze-findings", Transaction: forged}); !errors.Is(err, ErrInvalidSuccessor) {
+		t.Fatalf("Append(forged incomplete freeze) error = %v, want ErrInvalidSuccessor", err)
+	}
+	if chain, err := store.LoadChain(); err != nil || chain.HeadRevision != genesis {
+		t.Fatalf("forged successor changed authoritative HEAD: %#v, %v", chain, err)
+	}
+}
+
+func TestStoreRequiresExactNativeFreezeOperation(t *testing.T) {
+	store := Store{Dir: filepath.Join(t.TempDir(), "review-store")}
+	tx, err := NewTransaction(boundedStart(t, []string{LensReliability}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = tx.StartReview()
+	genesis, err := store.Append("", Record{Operation: "review/start", Transaction: *tx})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.RecordLensResult(boundedLensResult(LensReliability, "complete")); err != nil {
+		t.Fatal(err)
+	}
+	completed, err := store.Append(genesis, Record{Operation: "review/record-lens-result", Transaction: *tx})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.FreezeFindings([]Finding{}, hash("2")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Append(completed, Record{Operation: "review/complete-final-verification", Transaction: *tx}); !errors.Is(err, ErrInvalidSuccessor) {
+		t.Fatalf("Append(forged freeze operation) error = %v, want ErrInvalidSuccessor", err)
+	}
+}
+
+func boundedStart(t *testing.T, lenses []string) Start {
+	t.Helper()
+	template := newTestTransaction(t, ModeOrdinary4R)
+	riskLevel := RiskHigh
+	if len(lenses) == 0 {
+		riskLevel = RiskLow
+	} else if len(lenses) == 1 {
+		riskLevel = RiskMedium
+	}
+	return Start{
+		LineageID: "bounded-lineage", Mode: ModeOrdinaryBounded, Generation: 1,
+		Snapshot: template.Snapshot, PolicyHash: hash("d"), RiskLevel: riskLevel, SelectedLenses: append([]string(nil), lenses...),
+	}
+}
+
+func boundedLensResult(lens, evidence string) LensResult {
+	return LensResult{Lens: lens, Findings: []Finding{}, Evidence: []string{"completed " + evidence + " sweep"}}
+}

--- a/internal/reviewtransaction/receipt.go
+++ b/internal/reviewtransaction/receipt.go
@@ -42,6 +42,9 @@ type Receipt struct {
 	JudgeProofHash     string           `json:"judge_proof_hash,omitempty"`
 	Release            *ReleaseEvidence `json:"release,omitempty"`
 	Counters           Counters         `json:"counters"`
+	RiskLevel          RiskLevel        `json:"risk_level,omitempty"`
+	SelectedLenses     []string         `json:"selected_lenses,omitempty"`
+	LensResults        []LensResult     `json:"lens_results,omitempty"`
 	TerminalState      TerminalState    `json:"terminal_state"`
 }
 
@@ -89,7 +92,8 @@ func (transaction *Transaction) Receipt() (Receipt, error) {
 		PathsDigest: transaction.PathsDigest, FixDeltaHash: transaction.FixDeltaHash,
 		PolicyHash: transaction.PolicyHash, LedgerHash: ledgerHash, EvidenceHash: evidenceHash,
 		JudgeProofHash: transaction.JudgeProofHash, Release: cloneReleaseEvidence(transaction.Release),
-		Counters: transaction.Counters, TerminalState: terminal,
+		Counters: transaction.Counters, RiskLevel: transaction.RiskLevel, SelectedLenses: append([]string(nil), transaction.SelectedLenses...),
+		LensResults: append([]LensResult(nil), transaction.LensResults...), TerminalState: terminal,
 	}
 	if err := validateReceiptStructure(receipt); err != nil {
 		return Receipt{}, err
@@ -246,7 +250,7 @@ func validateReceiptStructure(receipt Receipt) error {
 	if receipt.Generation < 1 {
 		return errors.New("receipt requires a positive generation")
 	}
-	if receipt.Mode != ModeOrdinary4R && receipt.Mode != ModeJudgmentDay {
+	if receipt.Mode != ModeOrdinary4R && receipt.Mode != ModeOrdinaryBounded && receipt.Mode != ModeJudgmentDay {
 		return fmt.Errorf("invalid receipt mode %q", receipt.Mode)
 	}
 	for _, tree := range []string{receipt.BaseTree, receipt.InitialReviewTree, receipt.FinalCandidateTree} {
@@ -262,6 +266,10 @@ func validateReceiptStructure(receipt Receipt) error {
 	if err := validateCounters(receipt.Mode, receipt.Counters); err != nil {
 		return err
 	}
+	lensState := Transaction{Mode: receipt.Mode, State: StateApproved, RiskLevel: receipt.RiskLevel, SelectedLenses: receipt.SelectedLenses, LensResults: receipt.LensResults, Counters: receipt.Counters, Findings: mergedLensFindings(receipt.LensResults)}
+	if err := lensState.validateLensState(); err != nil {
+		return err
+	}
 	switch receipt.TerminalState {
 	case TerminalApproved:
 		if receipt.Counters.FinalVerifications != 1 {
@@ -271,6 +279,10 @@ func validateReceiptStructure(receipt Receipt) error {
 		case ModeOrdinary4R:
 			if receipt.Counters.FullReviews != 1 || receipt.Counters.FixBatches != receipt.Counters.ScopedFixValidations {
 				return errors.New("approved ordinary receipt has incoherent review/fix counters")
+			}
+		case ModeOrdinaryBounded:
+			if len(receipt.LensResults) != len(receipt.SelectedLenses) || receipt.Counters.FixBatches != receipt.Counters.ScopedFixValidations {
+				return errors.New("approved ordinary bounded receipt has incomplete lenses or incoherent fix counters")
 			}
 		case ModeJudgmentDay:
 			if receipt.Counters.FixRounds != receipt.Counters.ScopedRejudgments {
@@ -284,7 +296,7 @@ func validateReceiptStructure(receipt Receipt) error {
 	default:
 		return fmt.Errorf("invalid terminal_state %q", receipt.TerminalState)
 	}
-	if receipt.Mode == ModeOrdinary4R && receipt.JudgeProofHash != "" {
+	if isOrdinaryMode(receipt.Mode) && receipt.JudgeProofHash != "" {
 		return errors.New("ordinary receipt cannot contain Judgment Day proof")
 	}
 	if receipt.Release != nil {
@@ -296,6 +308,14 @@ func validateReceiptStructure(receipt Receipt) error {
 		}
 	}
 	return nil
+}
+
+func mergedLensFindings(results []LensResult) []Finding {
+	findings := make([]Finding, 0)
+	for _, result := range results {
+		findings = append(findings, result.Findings...)
+	}
+	return findings
 }
 
 func validateReleaseEvidence(release ReleaseEvidence) error {

--- a/internal/reviewtransaction/store.go
+++ b/internal/reviewtransaction/store.go
@@ -303,6 +303,36 @@ func validateSuccessor(previous, next Transaction, operation string) error {
 	if !equalStrings(previous.GenesisPaths, next.GenesisPaths) {
 		return fmt.Errorf("%w: immutable genesis paths changed", ErrInvalidSuccessor)
 	}
+	if !equalStrings(previous.SelectedLenses, next.SelectedLenses) {
+		return fmt.Errorf("%w: selected lenses are immutable", ErrInvalidSuccessor)
+	}
+	if previous.RiskLevel != next.RiskLevel {
+		return fmt.Errorf("%w: native risk classification is immutable", ErrInvalidSuccessor)
+	}
+	lensStateChanged := !reflect.DeepEqual(previous.LensResults, next.LensResults) ||
+		previous.Counters.RiskExecutions != next.Counters.RiskExecutions ||
+		previous.Counters.ResilienceExecutions != next.Counters.ResilienceExecutions ||
+		previous.Counters.ReadabilityExecutions != next.Counters.ReadabilityExecutions ||
+		previous.Counters.ReliabilityExecutions != next.Counters.ReliabilityExecutions
+	lensTransition := operation == "review/record-lens-result" && previous.Mode == ModeOrdinaryBounded && previous.State == StateReviewing && next.State == StateReviewing
+	if lensTransition {
+		if len(next.LensResults) != len(previous.LensResults)+1 {
+			return fmt.Errorf("%w: lens result transition must append exactly one result", ErrInvalidSuccessor)
+		}
+		expected := previous
+		if err := expected.RecordLensResult(next.LensResults[len(next.LensResults)-1]); err != nil || !transactionsEqual(expected, next) {
+			return fmt.Errorf("%w: lens result transition changed unrelated transaction state", ErrInvalidSuccessor)
+		}
+	} else if lensStateChanged || operation == "review/record-lens-result" {
+		return fmt.Errorf("%w: lens state changed outside the native lens result transition", ErrInvalidSuccessor)
+	}
+	freezeTransition := (previous.State == StateReviewing || previous.State == StateJudgesConfirmed) && next.State == StateFindingsFrozen
+	if freezeTransition {
+		expected := previous
+		if operation != "review/freeze-findings" || expected.FreezeFindings(next.Findings, next.LedgerHash) != nil || !transactionsEqual(expected, next) {
+			return fmt.Errorf("%w: findings freeze must replay the exact native transition", ErrInvalidSuccessor)
+		}
+	}
 	fixCompletion := previous.State == StateFixing && next.State == StateFixValidating
 	if !fixCompletion && !snapshotsEqual(previous.Snapshot, next.Snapshot) {
 		return fmt.Errorf("%w: immutable review snapshot changed", ErrInvalidSuccessor)
@@ -330,7 +360,7 @@ func validateSuccessor(previous, next Transaction, operation string) error {
 			return fmt.Errorf("%w: release evidence must be bound as the only change while ready for final verification", ErrInvalidSuccessor)
 		}
 	}
-	if !releaseBinding && !legalStateTransition(previous.State, next.State) {
+	if !releaseBinding && !lensTransition && !legalStateTransition(previous.State, next.State) {
 		return fmt.Errorf("%w: illegal state transition %q -> %q", ErrInvalidSuccessor, previous.State, next.State)
 	}
 	if !countersMonotonic(previous.Counters, next.Counters) {
@@ -370,7 +400,7 @@ func validateSuccessor(previous, next Transaction, operation string) error {
 	if previous.FixDeltaHash != next.FixDeltaHash && !fixCompletion {
 		return fmt.Errorf("%w: fix delta changed outside fix completion", ErrInvalidSuccessor)
 	}
-	validationCompletion := previous.Mode == ModeOrdinary4R && previous.State == StateFixValidating && (next.State == StateReadyFinalVerification || next.State == StateEscalated)
+	validationCompletion := isOrdinaryMode(previous.Mode) && previous.State == StateFixValidating && (next.State == StateReadyFinalVerification || next.State == StateEscalated)
 	if validationCompletion {
 		legacy := next.OriginalCriteria == nil && next.CorrectionRegression == nil
 		if legacy {
@@ -418,6 +448,12 @@ func transactionsEqual(left, right Transaction) bool {
 		if len(transaction.JudgeProofs) == 0 {
 			transaction.JudgeProofs = nil
 		}
+		if len(transaction.SelectedLenses) == 0 {
+			transaction.SelectedLenses = nil
+		}
+		if len(transaction.LensResults) == 0 {
+			transaction.LensResults = nil
+		}
 		for index := range transaction.Findings {
 			if len(transaction.Findings[index].ProofRefs) == 0 {
 				transaction.Findings[index].ProofRefs = nil
@@ -444,18 +480,23 @@ func followUpSliceIsPrefix(previous, next []FollowUp) bool {
 func validateSuccessorCounters(previous, next Transaction) error {
 	expected := previous.Counters
 	switch {
+	case previous.Mode == ModeOrdinaryBounded && previous.State == StateReviewing && next.State == StateReviewing:
+		if len(next.LensResults) != len(previous.LensResults)+1 {
+			return fmt.Errorf("%w: lens result transition must consume exactly one execution", ErrInvalidSuccessor)
+		}
+		setLensCounter(&expected, next.LensResults[len(next.LensResults)-1].Lens, 1)
 	case previous.State == StateReviewing && next.State == StateJudgesConfirmed:
 		expected.JudgeExecutions = 2
 	case previous.State == StateEvidenceClassified && next.State != StateEvidenceClassified:
 		expected.RefuterBatches++
 	case previous.State == StateFixRequired && next.State == StateFixing:
-		if previous.Mode == ModeOrdinary4R {
+		if isOrdinaryMode(previous.Mode) {
 			expected.FixBatches++
 		} else {
 			expected.FixRounds++
 		}
 	case previous.State == StateFixValidating && (next.State == StateReadyFinalVerification || next.State == StateFixRequired || next.State == StateEscalated):
-		if previous.Mode == ModeOrdinary4R {
+		if isOrdinaryMode(previous.Mode) {
 			expected.ScopedFixValidations++
 		} else {
 			expected.ScopedRejudgments++
@@ -504,6 +545,8 @@ func validInitialStoreRecord(record Record) bool {
 	switch transaction.Mode {
 	case ModeOrdinary4R:
 		return transaction.Counters == (Counters{FullReviews: 1})
+	case ModeOrdinaryBounded:
+		return transaction.Counters == (Counters{}) && len(transaction.LensResults) == 0
 	case ModeJudgmentDay:
 		return transaction.Counters == (Counters{})
 	default:
@@ -548,7 +591,11 @@ func countersMonotonic(previous, next Counters) bool {
 		next.FinalVerifications >= previous.FinalVerifications &&
 		next.FixRounds >= previous.FixRounds &&
 		next.ScopedRejudgments >= previous.ScopedRejudgments &&
-		next.JudgeExecutions >= previous.JudgeExecutions
+		next.JudgeExecutions >= previous.JudgeExecutions &&
+		next.RiskExecutions >= previous.RiskExecutions &&
+		next.ResilienceExecutions >= previous.ResilienceExecutions &&
+		next.ReadabilityExecutions >= previous.ReadabilityExecutions &&
+		next.ReliabilityExecutions >= previous.ReliabilityExecutions
 }
 
 func mapIsMonotonic[K comparable, V comparable](previous, next map[K]V) bool {

--- a/internal/reviewtransaction/transaction.go
+++ b/internal/reviewtransaction/transaction.go
@@ -17,9 +17,19 @@ const TransactionSchema = "gentle-ai.review-transaction/v1"
 type Mode string
 
 const (
-	ModeOrdinary4R  Mode = "ordinary_4r"
-	ModeJudgmentDay Mode = "judgment_day"
+	ModeOrdinary4R      Mode = "ordinary_4r"
+	ModeOrdinaryBounded Mode = "ordinary_bounded"
+	ModeJudgmentDay     Mode = "judgment_day"
 )
+
+const (
+	LensRisk        = "review-risk"
+	LensResilience  = "review-resilience"
+	LensReadability = "review-readability"
+	LensReliability = "review-reliability"
+)
+
+var supportedLenses = []string{LensRisk, LensResilience, LensReadability, LensReliability}
 
 type State string
 
@@ -56,22 +66,35 @@ const (
 )
 
 type Counters struct {
-	FullReviews          int `json:"full_reviews"`
-	RefuterBatches       int `json:"refuter_batches"`
-	FixBatches           int `json:"fix_batches"`
-	ScopedFixValidations int `json:"scoped_fix_validations"`
-	FinalVerifications   int `json:"final_verifications"`
-	FixRounds            int `json:"fix_rounds"`
-	ScopedRejudgments    int `json:"scoped_rejudgments"`
-	JudgeExecutions      int `json:"judge_executions"`
+	FullReviews           int `json:"full_reviews"`
+	RefuterBatches        int `json:"refuter_batches"`
+	FixBatches            int `json:"fix_batches"`
+	ScopedFixValidations  int `json:"scoped_fix_validations"`
+	FinalVerifications    int `json:"final_verifications"`
+	FixRounds             int `json:"fix_rounds"`
+	ScopedRejudgments     int `json:"scoped_rejudgments"`
+	JudgeExecutions       int `json:"judge_executions"`
+	RiskExecutions        int `json:"risk_executions,omitempty"`
+	ResilienceExecutions  int `json:"resilience_executions,omitempty"`
+	ReadabilityExecutions int `json:"readability_executions,omitempty"`
+	ReliabilityExecutions int `json:"reliability_executions,omitempty"`
 }
 
 type Start struct {
-	LineageID  string
-	Mode       Mode
-	Generation int
-	Snapshot   Snapshot
-	PolicyHash string
+	LineageID      string
+	Mode           Mode
+	Generation     int
+	Snapshot       Snapshot
+	PolicyHash     string
+	RiskLevel      RiskLevel
+	SelectedLenses []string
+}
+
+type LensResult struct {
+	Lens       string    `json:"lens"`
+	Findings   []Finding `json:"findings"`
+	Evidence   []string  `json:"evidence"`
+	ResultHash string    `json:"result_hash"`
 }
 
 type Finding struct {
@@ -166,14 +189,21 @@ type Transaction struct {
 	FollowUps              []FollowUp                 `json:"follow_ups"`
 	OriginalCriteria       *ValidationCheck           `json:"original_criteria,omitempty"`
 	CorrectionRegression   *ValidationCheck           `json:"correction_regression,omitempty"`
+	RiskLevel              RiskLevel                  `json:"risk_level,omitempty"`
+	SelectedLenses         []string                   `json:"selected_lenses,omitempty"`
+	LensResults            []LensResult               `json:"lens_results,omitempty"`
 }
 
 func NewTransaction(start Start) (*Transaction, error) {
 	if err := validateLineageID(start.LineageID); err != nil {
 		return nil, err
 	}
-	if start.Mode != ModeOrdinary4R && start.Mode != ModeJudgmentDay {
+	if start.Mode != ModeOrdinary4R && start.Mode != ModeOrdinaryBounded && start.Mode != ModeJudgmentDay {
 		return nil, fmt.Errorf("unsupported review mode %q", start.Mode)
+	}
+	selectedLenses, err := validateSelectedLenses(start.Mode, start.RiskLevel, start.SelectedLenses)
+	if err != nil {
+		return nil, err
 	}
 	if start.Generation < 1 {
 		return nil, errors.New("generation must be positive")
@@ -184,7 +214,7 @@ func NewTransaction(start Start) (*Transaction, error) {
 	if !validSHA256(start.PolicyHash) {
 		return nil, errors.New("policy_hash must be a lowercase SHA-256 identity")
 	}
-	return &Transaction{
+	transaction := &Transaction{
 		Schema: TransactionSchema, LineageID: start.LineageID, Mode: start.Mode,
 		Generation: start.Generation, State: StateUnreviewed, Snapshot: start.Snapshot,
 		GenesisPaths: append([]string(nil), start.Snapshot.Paths...),
@@ -194,7 +224,13 @@ func NewTransaction(start Start) (*Transaction, error) {
 		Findings: []Finding{}, Classifications: map[string]FindingEvidence{},
 		Outcomes: map[string]EvidenceOutcome{}, FixFindingIDs: []string{}, PendingRefuterIDs: []string{},
 		FixCausedFindings: []Finding{}, FollowUps: []FollowUp{}, JudgeProofs: []JudgeProof{},
-	}, nil
+	}
+	if start.Mode == ModeOrdinaryBounded {
+		transaction.RiskLevel = start.RiskLevel
+		transaction.SelectedLenses = selectedLenses
+		transaction.LensResults = []LensResult{}
+	}
+	return transaction, nil
 }
 
 func NewLineage(previousLineageID string, start Start) (*Transaction, error) {
@@ -216,6 +252,85 @@ func (transaction *Transaction) StartReview() error {
 	}
 	transaction.State = StateReviewing
 	return nil
+}
+
+func (transaction *Transaction) RecordLensResult(result LensResult) error {
+	if transaction.Mode != ModeOrdinaryBounded || transaction.State != StateReviewing {
+		return transaction.invalidTransition("record lens result")
+	}
+	result.Lens = strings.TrimSpace(result.Lens)
+	if !isSupportedLens(result.Lens) {
+		return fmt.Errorf("unknown review lens %q", result.Lens)
+	}
+	selectedIndex := stringIndex(transaction.SelectedLenses, result.Lens)
+	if selectedIndex < 0 {
+		return fmt.Errorf("review lens %q was not selected", result.Lens)
+	}
+	if transaction.lensExecutions(result.Lens) != 0 || stringIndexLensResult(transaction.LensResults, result.Lens) >= 0 {
+		return fmt.Errorf("review lens %q already has a complete result", result.Lens)
+	}
+	if selectedIndex != len(transaction.LensResults) {
+		return fmt.Errorf("review lens %q is out of canonical execution order", result.Lens)
+	}
+	validated, err := validateLensResult(result)
+	if err != nil {
+		return err
+	}
+	for _, existing := range transaction.LensResults {
+		if existing.ResultHash == validated.ResultHash {
+			return errors.New("lens result evidence cannot be reused across selected lenses")
+		}
+	}
+	transaction.LensResults = append(transaction.LensResults, validated)
+	transaction.setLensExecutions(validated.Lens, 1)
+	return nil
+}
+
+// LensResultHash binds a complete native lens result to its lens and content.
+func LensResultHash(result LensResult) string {
+	payload, _ := json.Marshal(struct {
+		Lens     string    `json:"lens"`
+		Findings []Finding `json:"findings"`
+		Evidence []string  `json:"evidence"`
+	}{Lens: result.Lens, Findings: result.Findings, Evidence: result.Evidence})
+	sum := sha256.Sum256(append([]byte("gentle-ai.lens-result/v1\x00"), payload...))
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+func validateLensResult(result LensResult) (LensResult, error) {
+	result.Lens = strings.TrimSpace(result.Lens)
+	if !isSupportedLens(result.Lens) {
+		return LensResult{}, fmt.Errorf("unknown review lens %q", result.Lens)
+	}
+	if result.Findings == nil || result.Evidence == nil || len(result.Evidence) == 0 {
+		return LensResult{}, errors.New("lens result requires explicit findings and concrete evidence")
+	}
+	wantFindingLens := strings.TrimPrefix(result.Lens, "review-")
+	for index, finding := range result.Findings {
+		if err := validateStructuredFinding(finding); err != nil {
+			return LensResult{}, fmt.Errorf("lens result finding[%d]: %w", index, err)
+		}
+		if finding.Lens != wantFindingLens {
+			return LensResult{}, fmt.Errorf("lens result finding[%d] is not bound to %q", index, result.Lens)
+		}
+	}
+	for index, evidence := range result.Evidence {
+		if !isConcreteEvidence(evidence) {
+			return LensResult{}, fmt.Errorf("lens result evidence[%d] must be concrete", index)
+		}
+	}
+	findings := make([]Finding, len(result.Findings))
+	copy(findings, result.Findings)
+	result.Findings = findings
+	evidence := make([]string, len(result.Evidence))
+	copy(evidence, result.Evidence)
+	result.Evidence = evidence
+	derived := LensResultHash(result)
+	if result.ResultHash != "" && result.ResultHash != derived {
+		return LensResult{}, errors.New("lens result_hash does not match canonical structured result content")
+	}
+	result.ResultHash = derived
+	return result, nil
 }
 
 func (transaction *Transaction) RecordJudgeProofs(proofs []JudgeProof, agreementHash string) error {
@@ -241,6 +356,17 @@ func (transaction *Transaction) FreezeFindings(findings []Finding, ledgerHash st
 	}
 	if transaction.State != expectedState {
 		return transaction.invalidTransition("freeze findings")
+	}
+	if transaction.Mode == ModeOrdinaryBounded {
+		if len(transaction.LensResults) != len(transaction.SelectedLenses) {
+			return errors.New("cannot freeze findings before every selected lens has one complete result")
+		}
+		if len(transaction.SelectedLenses) == 0 && findings == nil {
+			return errors.New("zero-lens review requires an explicit empty findings ledger")
+		}
+		if !reflectLensFindings(transaction.LensResults, findings) {
+			return errors.New("frozen findings must exactly match the completed native lens results")
+		}
 	}
 	if !validSHA256(ledgerHash) {
 		return errors.New("ledger_hash must be a lowercase SHA-256 identity")
@@ -358,7 +484,7 @@ func (transaction *Transaction) ClassifyEvidence(evidence []FindingEvidence) (Ev
 }
 
 func (transaction *Transaction) ApplyRefuterOutcomes(results []EvidenceResult) error {
-	if transaction.Mode != ModeOrdinary4R || transaction.State != StateEvidenceClassified || len(transaction.PendingRefuterIDs) == 0 {
+	if !isOrdinaryMode(transaction.Mode) || transaction.State != StateEvidenceClassified || len(transaction.PendingRefuterIDs) == 0 {
 		return transaction.invalidTransition("apply refuter outcomes")
 	}
 	if transaction.Counters.RefuterBatches >= 1 {
@@ -423,7 +549,7 @@ func (transaction *Transaction) BeginFix(failedEvidenceRevision string) error {
 		return errors.New("failed evidence revision must be a lowercase SHA-256 identity")
 	}
 	switch transaction.Mode {
-	case ModeOrdinary4R:
+	case ModeOrdinary4R, ModeOrdinaryBounded:
 		if transaction.Counters.FixBatches >= 1 {
 			return transaction.escalateBudget("fix batch")
 		}
@@ -506,7 +632,7 @@ func (transaction *Transaction) ValidateFixDeltaResult(result ScopedValidationRe
 	if !equalStrings(ids, transaction.FixFindingIDs) {
 		return errors.New("scoped validation must use the frozen fix ledger IDs")
 	}
-	if transaction.Mode == ModeOrdinary4R {
+	if isOrdinaryMode(transaction.Mode) {
 		legacy := result.OriginalCriteria.EvidenceHash == transaction.FixDeltaHash &&
 			result.CorrectionRegression.EvidenceHash == transaction.FixDeltaHash
 		if !legacy {
@@ -518,10 +644,10 @@ func (transaction *Transaction) ValidateFixDeltaResult(result ScopedValidationRe
 	if result.FixCausedFindings == nil {
 		return errors.New("scoped validation must provide an explicit fix_caused_findings array")
 	}
-	if transaction.Mode == ModeOrdinary4R && result.FollowUps == nil {
+	if isOrdinaryMode(transaction.Mode) && result.FollowUps == nil {
 		return errors.New("scoped validation must provide an explicit follow_ups array")
 	}
-	if transaction.Mode == ModeOrdinary4R && len(result.FixCausedFindings) != 0 {
+	if isOrdinaryMode(transaction.Mode) && len(result.FixCausedFindings) != 0 {
 		return errors.New("ordinary scoped validation records later observations only as non-blocking follow-ups")
 	}
 	if err := validateFollowUps(result.FollowUps); err != nil {
@@ -546,7 +672,7 @@ func (transaction *Transaction) ValidateFixDeltaResult(result ScopedValidationRe
 			severeFixCaused++
 		}
 	}
-	if transaction.Mode == ModeOrdinary4R {
+	if isOrdinaryMode(transaction.Mode) {
 		result.Approved = result.OriginalCriteria.Passed && result.CorrectionRegression.Passed
 		legacy := result.OriginalCriteria.EvidenceHash == transaction.FixDeltaHash &&
 			result.CorrectionRegression.EvidenceHash == transaction.FixDeltaHash
@@ -572,7 +698,7 @@ func (transaction *Transaction) ValidateFixDeltaResult(result ScopedValidationRe
 		}
 	}
 	switch transaction.Mode {
-	case ModeOrdinary4R:
+	case ModeOrdinary4R, ModeOrdinaryBounded:
 		if transaction.Counters.ScopedFixValidations >= 1 {
 			return transaction.escalateBudget("scoped fix validation")
 		}
@@ -706,7 +832,7 @@ func (transaction *Transaction) validate() error {
 	if transaction.Generation < 1 {
 		return errors.New("transaction requires a positive generation")
 	}
-	if transaction.Mode != ModeOrdinary4R && transaction.Mode != ModeJudgmentDay {
+	if transaction.Mode != ModeOrdinary4R && transaction.Mode != ModeOrdinaryBounded && transaction.Mode != ModeJudgmentDay {
 		return errors.New("invalid transaction mode")
 	}
 	if err := validateSnapshot(transaction.Snapshot); err != nil {
@@ -757,7 +883,7 @@ func (transaction *Transaction) validate() error {
 	}
 	if transaction.OriginalCriteria != nil {
 		result := ScopedValidationResult{OriginalCriteria: *transaction.OriginalCriteria, CorrectionRegression: *transaction.CorrectionRegression}
-		if transaction.Mode != ModeOrdinary4R || transaction.Counters.ScopedFixValidations != 1 || transaction.State == StateFixValidating {
+		if !isOrdinaryMode(transaction.Mode) || transaction.Counters.ScopedFixValidations != 1 || transaction.State == StateFixValidating {
 			return errors.New("targeted validation checks require a completed ordinary scoped validation")
 		}
 		if err := validateTargetedValidation(result, transaction.FixDeltaHash); err != nil {
@@ -785,6 +911,9 @@ func (transaction *Transaction) validate() error {
 	if err := validateCounters(transaction.Mode, transaction.Counters); err != nil {
 		return err
 	}
+	if err := transaction.validateLensState(); err != nil {
+		return err
+	}
 	if err := transaction.validateJudgeState(); err != nil {
 		return err
 	}
@@ -792,7 +921,7 @@ func (transaction *Transaction) validate() error {
 		if !validSHA256(transaction.FailedEvidenceRevision) {
 			return errors.New("active fix state requires an exact failed evidence revision")
 		}
-		if transaction.Mode == ModeOrdinary4R && transaction.Counters.FixBatches != 1 {
+		if isOrdinaryMode(transaction.Mode) && transaction.Counters.FixBatches != 1 {
 			return errors.New("ordinary active fix state requires its single fix batch")
 		}
 		if transaction.Mode == ModeJudgmentDay && (transaction.Counters.FixRounds < 1 || transaction.Counters.FixRounds > 2) {
@@ -848,23 +977,175 @@ func validateSnapshot(snapshot Snapshot) error {
 }
 
 func validateCounters(mode Mode, counters Counters) error {
-	values := []int{counters.FullReviews, counters.RefuterBatches, counters.FixBatches, counters.ScopedFixValidations, counters.FinalVerifications, counters.FixRounds, counters.ScopedRejudgments, counters.JudgeExecutions}
+	values := []int{counters.FullReviews, counters.RefuterBatches, counters.FixBatches, counters.ScopedFixValidations, counters.FinalVerifications, counters.FixRounds, counters.ScopedRejudgments, counters.JudgeExecutions, counters.RiskExecutions, counters.ResilienceExecutions, counters.ReadabilityExecutions, counters.ReliabilityExecutions}
 	for _, value := range values {
 		if value < 0 {
 			return errors.New("review counters cannot be negative")
 		}
 	}
 	switch mode {
-	case ModeOrdinary4R:
-		if counters.FullReviews > 1 || counters.RefuterBatches > 1 || counters.FixBatches > 1 || counters.ScopedFixValidations > 1 || counters.FinalVerifications > 1 || counters.FixRounds != 0 || counters.ScopedRejudgments != 0 || counters.JudgeExecutions != 0 {
-			return errors.New("ordinary_4r budget exceeded")
+	case ModeOrdinary4R, ModeOrdinaryBounded:
+		if counters.FullReviews > 1 || counters.RefuterBatches > 1 || counters.FixBatches > 1 || counters.ScopedFixValidations > 1 || counters.FinalVerifications > 1 || counters.FixRounds != 0 || counters.ScopedRejudgments != 0 || counters.JudgeExecutions != 0 || counters.RiskExecutions > 1 || counters.ResilienceExecutions > 1 || counters.ReadabilityExecutions > 1 || counters.ReliabilityExecutions > 1 {
+			return errors.New("ordinary review budget exceeded")
+		}
+		if mode == ModeOrdinary4R && (counters.RiskExecutions != 0 || counters.ResilienceExecutions != 0 || counters.ReadabilityExecutions != 0 || counters.ReliabilityExecutions != 0) {
+			return errors.New("ordinary_4r cannot contain native lens execution counters")
+		}
+		if mode == ModeOrdinaryBounded && counters.FullReviews != 0 {
+			return errors.New("ordinary_bounded cannot consume the legacy full review counter")
 		}
 	case ModeJudgmentDay:
-		if counters.FixRounds > 2 || counters.ScopedRejudgments > 2 || counters.RefuterBatches != 0 || counters.FixBatches != 0 || counters.ScopedFixValidations != 0 || counters.FinalVerifications > 1 || (counters.JudgeExecutions != 0 && counters.JudgeExecutions != 2) {
+		if counters.FixRounds > 2 || counters.ScopedRejudgments > 2 || counters.RefuterBatches != 0 || counters.FixBatches != 0 || counters.ScopedFixValidations != 0 || counters.FinalVerifications > 1 || (counters.JudgeExecutions != 0 && counters.JudgeExecutions != 2) || counters.RiskExecutions != 0 || counters.ResilienceExecutions != 0 || counters.ReadabilityExecutions != 0 || counters.ReliabilityExecutions != 0 {
 			return errors.New("judgment_day budget exceeded")
 		}
 	}
 	return nil
+}
+
+func validateSelectedLenses(mode Mode, riskLevel RiskLevel, lenses []string) ([]string, error) {
+	if mode != ModeOrdinaryBounded {
+		if riskLevel != "" || len(lenses) != 0 {
+			return nil, errors.New("selected lenses require ordinary_bounded mode")
+		}
+		return nil, nil
+	}
+	validated := append([]string(nil), lenses...)
+	want := -1
+	switch riskLevel {
+	case RiskLow:
+		want = 0
+	case RiskMedium:
+		want = 1
+	case RiskHigh:
+		want = len(supportedLenses)
+	default:
+		return nil, errors.New("ordinary_bounded requires a native low, medium, or high risk classification")
+	}
+	if len(validated) != want {
+		return nil, fmt.Errorf("ordinary_bounded %s risk requires exactly %d selected lenses", riskLevel, want)
+	}
+	for index, lens := range validated {
+		if strings.TrimSpace(lens) != lens || !isSupportedLens(lens) {
+			return nil, fmt.Errorf("unknown review lens %q", lens)
+		}
+		if len(validated) == len(supportedLenses) && lens != supportedLenses[index] {
+			return nil, errors.New("the full selected lens set must use canonical 4R order")
+		}
+	}
+	return validated, nil
+}
+
+func (transaction *Transaction) validateLensState() error {
+	if transaction.Mode != ModeOrdinaryBounded {
+		if len(transaction.SelectedLenses) != 0 || len(transaction.LensResults) != 0 {
+			return errors.New("native lens state requires ordinary_bounded mode")
+		}
+		return nil
+	}
+	selected, err := validateSelectedLenses(transaction.Mode, transaction.RiskLevel, transaction.SelectedLenses)
+	if err != nil || !equalStrings(selected, transaction.SelectedLenses) {
+		return errors.New("ordinary_bounded selected lenses are invalid")
+	}
+	if len(transaction.LensResults) > len(selected) {
+		return errors.New("ordinary_bounded has more lens results than selected lenses")
+	}
+	for index, result := range transaction.LensResults {
+		validated, validationErr := validateLensResult(result)
+		if validationErr != nil || result.Lens != selected[index] || result.ResultHash != validated.ResultHash || transaction.lensExecutions(result.Lens) != 1 {
+			return errors.New("ordinary_bounded lens results must be complete, unique, and canonically ordered")
+		}
+		for previous := 0; previous < index; previous++ {
+			if transaction.LensResults[previous].ResultHash == result.ResultHash {
+				return errors.New("ordinary_bounded lens result identities must be distinct")
+			}
+		}
+	}
+	for _, lens := range supportedLenses {
+		want := 0
+		if stringIndexLensResult(transaction.LensResults, lens) >= 0 {
+			want = 1
+		}
+		if transaction.lensExecutions(lens) != want {
+			return errors.New("ordinary_bounded lens execution counters do not match completed results")
+		}
+	}
+	if transaction.State != StateUnreviewed && transaction.State != StateReviewing {
+		if len(transaction.LensResults) != len(selected) {
+			return errors.New("ordinary_bounded cannot leave reviewing before every selected lens is complete")
+		}
+		if !reflectLensFindings(transaction.LensResults, transaction.Findings) {
+			return errors.New("ordinary_bounded frozen ledger does not match completed lens results")
+		}
+	}
+	return nil
+}
+
+func reflectLensFindings(results []LensResult, findings []Finding) bool {
+	merged := make([]Finding, 0)
+	for _, result := range results {
+		merged = append(merged, result.Findings...)
+	}
+	left, _ := json.Marshal(merged)
+	right, _ := json.Marshal(findings)
+	return bytes.Equal(left, right)
+}
+
+func isOrdinaryMode(mode Mode) bool {
+	return mode == ModeOrdinary4R || mode == ModeOrdinaryBounded
+}
+
+func isSupportedLens(lens string) bool {
+	return stringIndex(supportedLenses, lens) >= 0
+}
+
+func stringIndex(values []string, value string) int {
+	for index, candidate := range values {
+		if candidate == value {
+			return index
+		}
+	}
+	return -1
+}
+
+func stringIndexLensResult(results []LensResult, lens string) int {
+	for index, result := range results {
+		if result.Lens == lens {
+			return index
+		}
+	}
+	return -1
+}
+
+func (transaction *Transaction) lensExecutions(lens string) int {
+	switch lens {
+	case LensRisk:
+		return transaction.Counters.RiskExecutions
+	case LensResilience:
+		return transaction.Counters.ResilienceExecutions
+	case LensReadability:
+		return transaction.Counters.ReadabilityExecutions
+	case LensReliability:
+		return transaction.Counters.ReliabilityExecutions
+	default:
+		return 0
+	}
+}
+
+func (transaction *Transaction) setLensExecutions(lens string, value int) {
+	setLensCounter(&transaction.Counters, lens, value)
+}
+
+func setLensCounter(counters *Counters, lens string, value int) {
+	switch lens {
+	case LensRisk:
+		counters.RiskExecutions = value
+	case LensResilience:
+		counters.ResilienceExecutions = value
+	case LensReadability:
+		counters.ReadabilityExecutions = value
+	case LensReliability:
+		counters.ReliabilityExecutions = value
+	}
 }
 
 func validateJudgeProofs(proofs []JudgeProof, agreementHash string) ([]JudgeProof, string, error) {
@@ -904,7 +1185,7 @@ func validateJudgeProofs(proofs []JudgeProof, agreementHash string) ([]JudgeProo
 }
 
 func (transaction *Transaction) validateJudgeState() error {
-	if transaction.Mode == ModeOrdinary4R {
+	if isOrdinaryMode(transaction.Mode) {
 		if len(transaction.JudgeProofs) != 0 || transaction.JudgeProofHash != "" || transaction.JudgeAgreementHash != "" || transaction.Counters.JudgeExecutions != 0 || transaction.State == StateJudgesConfirmed {
 			return errors.New("ordinary review cannot contain Judgment Day judge proof")
 		}
@@ -1104,7 +1385,7 @@ func (transaction *Transaction) validateFindingState(findings, severe map[string
 			}
 		}
 	}
-	if transaction.Mode == ModeOrdinary4R && hasResolvedInferential && !hasInsufficient && transaction.Counters.RefuterBatches != 1 {
+	if isOrdinaryMode(transaction.Mode) && hasResolvedInferential && !hasInsufficient && transaction.Counters.RefuterBatches != 1 {
 		return errors.New("resolved ordinary inferential findings require exactly one consumed refuter batch")
 	}
 	return transaction.validateResolutionCounters(len(corroborated) > 0)
@@ -1113,7 +1394,7 @@ func (transaction *Transaction) validateFindingState(findings, severe map[string
 func (transaction *Transaction) validateResolutionCounters(hasCorrections bool) error {
 	switch transaction.State {
 	case StateFixRequired:
-		if transaction.Mode == ModeOrdinary4R && (transaction.Counters.FixBatches != 0 || transaction.Counters.ScopedFixValidations != 0) {
+		if isOrdinaryMode(transaction.Mode) && (transaction.Counters.FixBatches != 0 || transaction.Counters.ScopedFixValidations != 0) {
 			return errors.New("ordinary fix_required state cannot pre-consume correction or validation")
 		}
 	case StateFixing, StateFixValidating:
@@ -1125,7 +1406,7 @@ func (transaction *Transaction) validateResolutionCounters(hasCorrections bool) 
 			return errors.New("final verification states cannot contain pending refuter IDs")
 		}
 		switch transaction.Mode {
-		case ModeOrdinary4R:
+		case ModeOrdinary4R, ModeOrdinaryBounded:
 			want := 0
 			if hasCorrections {
 				want = 1
@@ -1143,7 +1424,7 @@ func (transaction *Transaction) validateResolutionCounters(hasCorrections bool) 
 			}
 		}
 		if hasCorrections {
-			wrongBase := transaction.Mode == ModeOrdinary4R && transaction.Snapshot.BaseTree != transaction.InitialReviewTree
+			wrongBase := isOrdinaryMode(transaction.Mode) && transaction.Snapshot.BaseTree != transaction.InitialReviewTree
 			if !validSHA256(transaction.FailedEvidenceRevision) || transaction.Snapshot.Kind != TargetFixDiff || wrongBase || transaction.Snapshot.CandidateTree != transaction.FinalCandidateTree || !equalStrings(transaction.Snapshot.LedgerIDs, transaction.FixFindingIDs) || transaction.FixDeltaHash != FixDeltaHashForSnapshot(transaction.Snapshot) {
 				return errors.New("corrected final verification readiness requires a complete ledger-bound fix snapshot")
 			}


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1110

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

Model native ordinary bounded review execution as a content-addressed transaction: immutable risk classification selects zero, one, or four canonical lenses, each selected lens records exactly one structured result, and the store replays the exact result and freeze transitions before issuing a receipt.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/reviewtransaction/transaction.go` | Added risk-bound lens selection, structured result identities, per-lens counters, and bounded lifecycle invariants |
| `internal/reviewtransaction/store.go` | Enforced immutable lens state and exact successor replay for result and freeze transitions |
| `internal/reviewtransaction/receipt.go` | Bound bounded-mode lens state and counters into terminal receipts |
| `internal/reviewtransaction/bounded_lenses_test.go` | Covered selection, identity, replay, retry, freeze, and legacy compatibility behavior |
| `internal/cli/review.go` | Added immutable snapshot risk classification and native `record-lens-result` handling |
| `internal/cli/review_test.go` | Covered CLI start, step, resume, persistence, and risk selection |
| `internal/app/help.go` | Documented ordinary bounded mode, repeatable lens selection, and structured result recording |
| `internal/app/help_test.go` | Verified the native bounded review help contract |

---

## 🧪 Test Plan

**Focused Tests**
```bash
go test ./internal/reviewtransaction -run 'OrdinaryBounded|Lens|StoreRejectsForgedIncompleteLensFreeze|StoreRequiresExactNativeFreezeOperation|Receipt|Bundle|Judgment'
go test ./internal/cli -run 'Review'
go test ./internal/app -run 'Help'
go vet ./...
git diff --check origin/main...HEAD
```

- [x] Focused review transaction, CLI, and help tests pass
- [x] `go vet ./...` passes
- [x] `git diff --check origin/main...HEAD` passes
- [ ] Full unit suite passes (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [ ] Manually tested locally

`go test ./...` still reports the existing installer/updater baseline failures in `internal/cli`, `internal/update`, and `internal/update/upgrade`. Independent final verification reproduced those failures on untouched `main`; this change does not affect them.

---

## 🤖 Automated Checks

The following checks run automatically on this PR:

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | Maintainer-approved `size:exception` applies |
| Check Issue Reference | ⏳ | PR body contains `Closes #1110` |
| Check Issue Has `status:approved` | ⏳ | Issue #1110 is approved |
| Check PR Has `type:*` Label | ⏳ | Exactly `type:bug` will be applied |
| Unit Tests | ⏳ | CI verification pending |
| E2E Tests | ⏳ | CI verification pending |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] Maintainer-approved `size:exception` is documented below
- [x] Exactly one appropriate `type:*` label is applied
- [ ] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] User-facing CLI help is updated
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

**Size exception:** The 1,014-author-line schema/CAS/CLI/test change is one atomic content-bound unit. Splitting it would separate invariants from their persistence and verification coverage and invalidate the approved native receipt for snapshot `sha256:514fcacda64d4e423b6941c8cdad92758d370a0ef402396832f40aba0d21ef85`.

**Scope:** Issue #1109 lifecycle authority-ordering work is explicitly excluded.

**Rollback boundary:** Revert commit `3e91877` to remove the bounded-lens model, CAS validation, CLI integration, help text, and their tests together; no unrelated behavior or files are part of this commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for ordinary bounded reviews with selectable risk, resilience, readability, and reliability lenses.
  * Review steps can now record structured lens findings and evidence.
  * Review receipts preserve risk level, selected lenses, and lens results.
  * Added validation to ensure lens results are complete, ordered, and tamper-resistant.
* **Documentation**
  * Updated help text with ordinary bounded review options and lens-result operations.
* **Bug Fixes**
  * Improved review lifecycle validation, counter tracking, and resume behavior for ordinary reviews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->