### PR TITLE
fix(codex): remove home workspace root on Windows

### DIFF
--- a/internal/components/permissions/inject.go
+++ b/internal/components/permissions/inject.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"strconv"
+	"strings"
 
 	"github.com/gentleman-programming/gentle-ai/internal/agents"
 	"github.com/gentleman-programming/gentle-ai/internal/components/filemerge"
@@ -236,7 +238,11 @@ func injectCodexPermissions(homeDir string, adapter agents.Adapter) (InjectionRe
 		merged = filemerge.UpsertTOMLTableKey(merged, `permissions.gentle-dev.filesystem.":workspace_roots"`, path, `"deny"`)
 	}
 
-	merged = filemerge.UpsertTOMLTableKey(merged, "permissions.gentle-dev.workspace_roots", `"~"`, "true")
+	if codexPermissionsGOOS == "windows" {
+		merged = removeCodexHomeWorkspaceRoot(merged)
+	} else {
+		merged = filemerge.UpsertTOMLTableKey(merged, "permissions.gentle-dev.workspace_roots", `"~"`, "true")
+	}
 
 	writeResult, err := filemerge.WriteFileAtomic(configPath, []byte(merged), 0o644)
 	if err != nil {
@@ -244,6 +250,166 @@ func injectCodexPermissions(homeDir string, adapter agents.Adapter) (InjectionRe
 	}
 
 	return InjectionResult{Changed: writeResult.Changed, Files: []string{configPath}}, nil
+}
+
+func removeCodexHomeWorkspaceRoot(content string) string {
+	targetPath := []string{"permissions", "gentle-dev", "workspace_roots", "~"}
+	var tablePath []string
+	lines := strings.SplitAfter(content, "\n")
+	kept := make([]string, 0, len(lines))
+	for _, line := range lines {
+		if path, ok := parseTOMLTableHeader(line); ok {
+			tablePath = path
+			kept = append(kept, line)
+			continue
+		}
+		keyPath, ok := parseTOMLAssignmentKey(line)
+		if ok && equalTOMLKeyPath(append(tablePath, keyPath...), targetPath) {
+			continue
+		}
+		kept = append(kept, line)
+	}
+
+	return strings.Join(kept, "")
+}
+
+func parseTOMLTableHeader(line string) ([]string, bool) {
+	code := strings.TrimSpace(tomlCodeBeforeComment(line))
+	if len(code) < 3 || code[0] != '[' {
+		return nil, false
+	}
+
+	if strings.HasPrefix(code, "[[") {
+		if len(code) < 5 || !strings.HasSuffix(code, "]]") {
+			return nil, false
+		}
+		return parseTOMLKeyPath(code[2 : len(code)-2])
+	}
+	if !strings.HasSuffix(code, "]") {
+		return nil, false
+	}
+	return parseTOMLKeyPath(code[1 : len(code)-1])
+}
+
+func parseTOMLAssignmentKey(line string) ([]string, bool) {
+	code := tomlCodeBeforeComment(line)
+	equals := tomlIndexOutsideQuotes(code, '=')
+	if equals == -1 {
+		return nil, false
+	}
+	return parseTOMLKeyPath(code[:equals])
+}
+
+func tomlCodeBeforeComment(line string) string {
+	if comment := tomlIndexOutsideQuotes(line, '#'); comment != -1 {
+		return line[:comment]
+	}
+	return line
+}
+
+func tomlIndexOutsideQuotes(text string, target byte) int {
+	var quote byte
+	escaped := false
+	for i := 0; i < len(text); i++ {
+		char := text[i]
+		if quote == '"' && escaped {
+			escaped = false
+			continue
+		}
+		if quote == '"' && char == '\\' {
+			escaped = true
+			continue
+		}
+		if char == '"' || char == '\'' {
+			if quote == 0 {
+				quote = char
+			} else if quote == char {
+				quote = 0
+			}
+			continue
+		}
+		if quote == 0 && char == target {
+			return i
+		}
+	}
+	return -1
+}
+
+func parseTOMLKeyPath(text string) ([]string, bool) {
+	var path []string
+	for pos := 0; ; {
+		pos = skipTOMLKeyWhitespace(text, pos)
+		part, next, ok := parseTOMLKeyPart(text, pos)
+		if !ok {
+			return nil, false
+		}
+		path = append(path, part)
+		pos = skipTOMLKeyWhitespace(text, next)
+		if pos == len(text) {
+			return path, true
+		}
+		if text[pos] != '.' {
+			return nil, false
+		}
+		pos++
+	}
+}
+
+func skipTOMLKeyWhitespace(text string, pos int) int {
+	for pos < len(text) && (text[pos] == ' ' || text[pos] == '\t') {
+		pos++
+	}
+	return pos
+}
+
+func parseTOMLKeyPart(text string, pos int) (string, int, bool) {
+	if pos >= len(text) {
+		return "", pos, false
+	}
+	if text[pos] == '\'' {
+		if end := strings.IndexByte(text[pos+1:], '\''); end != -1 {
+			return text[pos+1 : pos+1+end], pos + end + 2, true
+		}
+		return "", pos, false
+	}
+	if text[pos] == '"' {
+		for end := pos + 1; end < len(text); end++ {
+			if text[end] == '\\' {
+				end++
+				continue
+			}
+			if text[end] == '"' {
+				value, err := strconv.Unquote(text[pos : end+1])
+				return value, end + 1, err == nil
+			}
+		}
+		return "", pos, false
+	}
+
+	end := pos
+	for end < len(text) && isBareTOMLKeyByte(text[end]) {
+		end++
+	}
+	if end == pos {
+		return "", pos, false
+	}
+	return text[pos:end], end, true
+}
+
+func isBareTOMLKeyByte(char byte) bool {
+	return char >= 'A' && char <= 'Z' || char >= 'a' && char <= 'z' || char >= '0' && char <= '9' || char == '_' || char == '-'
+}
+
+func equalTOMLKeyPath(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if left[i] != right[i] {
+			return false
+		}
+	}
+	return true
 }
 
 func mergeJSONFile(path string, overlay []byte) (filemerge.WriteResult, error) {

--- a/internal/components/permissions/inject_test.go
+++ b/internal/components/permissions/inject_test.go
@@ -61,6 +61,10 @@ func assertCodexWorkspaceWriteRulesScoped(t *testing.T, text string) {
 	}
 }
 
+func codexWorkspaceRootsSection(text string) string {
+	return tomlSection(text, `[permissions.gentle-dev.workspace_roots]`)
+}
+
 // TestInjectHermesSkipsPermissions verifies that Hermes returns nil (no file written)
 // because Hermes permission format is undocumented — §14 of spec.
 func TestInjectHermesSkipsPermissions(t *testing.T) {
@@ -343,6 +347,9 @@ func TestInjectAntigravitySkipsPermissions(t *testing.T) {
 
 func TestInjectCodexWritesGentleDevPermissionsProfile(t *testing.T) {
 	home := t.TempDir()
+	origGOOS := codexPermissionsGOOS
+	codexPermissionsGOOS = "linux"
+	t.Cleanup(func() { codexPermissionsGOOS = origGOOS })
 
 	result, err := Inject(home, codexAdapter())
 	if err != nil {
@@ -460,6 +467,257 @@ func TestInjectCodexPermissionsSkipsNixStoreOnWindows(t *testing.T) {
 		if !strings.Contains(text, want) {
 			t.Fatalf("Windows Codex config missing non-fatal Nix home path %q; got:\n%s", want, text)
 		}
+	}
+}
+
+func TestInjectCodexPermissionsExcludesHomeWorkspaceRootOnWindows(t *testing.T) {
+	home := t.TempDir()
+	origGOOS := codexPermissionsGOOS
+	codexPermissionsGOOS = "windows"
+	t.Cleanup(func() { codexPermissionsGOOS = origGOOS })
+
+	if _, err := Inject(home, codexAdapter()); err != nil {
+		t.Fatalf("Inject() error = %v", err)
+	}
+
+	configPath := filepath.Join(home, ".codex", "config.toml")
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	workspaceRoots := codexWorkspaceRootsSection(string(content))
+	if strings.Contains(workspaceRoots, `"~" = true`) {
+		t.Fatalf("Windows Codex config should not include the home workspace root; got:\n%s", workspaceRoots)
+	}
+}
+
+func TestInjectCodexPermissionsRemovesHomeWorkspaceRootOnWindows(t *testing.T) {
+	origGOOS := codexPermissionsGOOS
+	codexPermissionsGOOS = "windows"
+	t.Cleanup(func() { codexPermissionsGOOS = origGOOS })
+
+	tests := []struct {
+		name         string
+		homeRoot     string
+		prefixedRoot string
+	}{
+		{name: "canonical double-quoted key", homeRoot: `"~" = true`, prefixedRoot: `"~/Documents/project" = true`},
+		{name: "single-quoted key", homeRoot: `'~' = true`, prefixedRoot: `'~/Documents/project' = true`},
+		{name: "tab before equals", homeRoot: "\"~\"\t=\ttrue", prefixedRoot: "\"~/Documents/project\"\t=\ttrue"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home := t.TempDir()
+			configPath := filepath.Join(home, ".codex", "config.toml")
+			if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+				t.Fatalf("MkdirAll() error = %v", err)
+			}
+			initial := "[permissions.gentle-dev.workspace_roots]\n" + tt.homeRoot + "\n" + tt.prefixedRoot + "\n\n[unrelated]\n'~'\t= true\n"
+			if err := os.WriteFile(configPath, []byte(initial), 0o644); err != nil {
+				t.Fatalf("WriteFile() error = %v", err)
+			}
+
+			if _, err := Inject(home, codexAdapter()); err != nil {
+				t.Fatalf("Inject() error = %v", err)
+			}
+
+			content, err := os.ReadFile(configPath)
+			if err != nil {
+				t.Fatalf("ReadFile() error = %v", err)
+			}
+			workspaceRoots := codexWorkspaceRootsSection(string(content))
+			if strings.Contains(workspaceRoots, tt.homeRoot) {
+				t.Fatalf("Windows Codex config still contains home workspace root %q; got:\n%s", tt.homeRoot, workspaceRoots)
+			}
+			if !strings.Contains(workspaceRoots, tt.prefixedRoot) {
+				t.Fatalf("Windows Codex config did not preserve prefixed workspace root %q; got:\n%s", tt.prefixedRoot, workspaceRoots)
+			}
+			if !strings.Contains(tomlSection(string(content), "[unrelated]"), "'~'\t= true") {
+				t.Fatalf("Windows Codex migration removed the home key from an unrelated table; got:\n%s", content)
+			}
+		})
+	}
+}
+
+func TestInjectCodexPermissionsRemovesDottedHomeWorkspaceRootOnWindows(t *testing.T) {
+	home := t.TempDir()
+	configPath := filepath.Join(home, ".codex", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	initial := "permissions.\"gentle-dev\".workspace_roots.\"~\" = true\npermissions.gentle-dev.workspace_roots.\"~/project\" = true\n"
+	if err := os.WriteFile(configPath, []byte(initial), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	origGOOS := codexPermissionsGOOS
+	codexPermissionsGOOS = "windows"
+	t.Cleanup(func() { codexPermissionsGOOS = origGOOS })
+
+	if _, err := Inject(home, codexAdapter()); err != nil {
+		t.Fatalf("Inject() error = %v", err)
+	}
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if strings.Contains(string(content), `workspace_roots."~" = true`) {
+		t.Fatalf("Windows Codex config still contains dotted home workspace root; got:\n%s", content)
+	}
+	if !strings.Contains(string(content), `workspace_roots."~/project" = true`) {
+		t.Fatalf("Windows Codex config did not preserve dotted prefixed workspace root; got:\n%s", content)
+	}
+}
+
+func TestInjectCodexPermissionsRecognizesQuotedWorkspaceRootsHeader(t *testing.T) {
+	home := t.TempDir()
+	configPath := filepath.Join(home, ".codex", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	initial := "[permissions.\"gentle-dev\".workspace_roots]\n\"~\" = true\n\"~/project\" = true\n"
+	if err := os.WriteFile(configPath, []byte(initial), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	origGOOS := codexPermissionsGOOS
+	codexPermissionsGOOS = "windows"
+	t.Cleanup(func() { codexPermissionsGOOS = origGOOS })
+
+	if _, err := Inject(home, codexAdapter()); err != nil {
+		t.Fatalf("Inject() error = %v", err)
+	}
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if strings.Contains(string(content), `"~" = true`) {
+		t.Fatalf("Windows Codex config still contains home root under quoted table header; got:\n%s", content)
+	}
+	if !strings.Contains(string(content), `"~/project" = true`) {
+		t.Fatalf("Windows Codex config did not preserve prefixed root under quoted table header; got:\n%s", content)
+	}
+}
+
+func TestInjectCodexPermissionsRecognizesWorkspaceRootsHeaderWithComment(t *testing.T) {
+	home := t.TempDir()
+	configPath := filepath.Join(home, ".codex", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	initial := "[permissions.gentle-dev.workspace_roots] # managed roots\n'~' = true\n'~/project' = true\n"
+	if err := os.WriteFile(configPath, []byte(initial), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	origGOOS := codexPermissionsGOOS
+	codexPermissionsGOOS = "windows"
+	t.Cleanup(func() { codexPermissionsGOOS = origGOOS })
+
+	if _, err := Inject(home, codexAdapter()); err != nil {
+		t.Fatalf("Inject() error = %v", err)
+	}
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if strings.Contains(string(content), `'~' = true`) {
+		t.Fatalf("Windows Codex config still contains home root under commented table header; got:\n%s", content)
+	}
+	if !strings.Contains(string(content), `'~/project' = true`) {
+		t.Fatalf("Windows Codex config did not preserve prefixed root under commented table header; got:\n%s", content)
+	}
+}
+
+func TestInjectCodexPermissionsStopsAtCommentedFollowingHeader(t *testing.T) {
+	home := t.TempDir()
+	configPath := filepath.Join(home, ".codex", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	initial := "[permissions.gentle-dev.workspace_roots]\n\"~\" = true\n\n[unrelated] # preserve this table\n\"~\" = true\n"
+	if err := os.WriteFile(configPath, []byte(initial), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	origGOOS := codexPermissionsGOOS
+	codexPermissionsGOOS = "windows"
+	t.Cleanup(func() { codexPermissionsGOOS = origGOOS })
+
+	if _, err := Inject(home, codexAdapter()); err != nil {
+		t.Fatalf("Inject() error = %v", err)
+	}
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	unrelated := tomlSection(string(content), "[unrelated] # preserve this table")
+	if !strings.Contains(unrelated, `"~" = true`) {
+		t.Fatalf("Windows Codex migration removed home key from following commented table; got:\n%s", content)
+	}
+}
+
+func TestInjectCodexPermissionsRetainsHomeWorkspaceRootOutsideWindows(t *testing.T) {
+	home := t.TempDir()
+	origGOOS := codexPermissionsGOOS
+	codexPermissionsGOOS = "linux"
+	t.Cleanup(func() { codexPermissionsGOOS = origGOOS })
+
+	if _, err := Inject(home, codexAdapter()); err != nil {
+		t.Fatalf("Inject() error = %v", err)
+	}
+
+	configPath := filepath.Join(home, ".codex", "config.toml")
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	workspaceRoots := codexWorkspaceRootsSection(string(content))
+	if !strings.Contains(workspaceRoots, `"~" = true`) {
+		t.Fatalf("non-Windows Codex config missing the home workspace root; got:\n%s", workspaceRoots)
+	}
+}
+
+func TestInjectCodexPermissionsWindowsWorkspaceRootMigrationIsIdempotent(t *testing.T) {
+	home := t.TempDir()
+	configPath := filepath.Join(home, ".codex", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	initial := "[permissions.gentle-dev.workspace_roots]\n'~'\t=\ttrue\n"
+	if err := os.WriteFile(configPath, []byte(initial), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	origGOOS := codexPermissionsGOOS
+	codexPermissionsGOOS = "windows"
+	t.Cleanup(func() { codexPermissionsGOOS = origGOOS })
+
+	first, err := Inject(home, codexAdapter())
+	if err != nil {
+		t.Fatalf("Inject() first error = %v", err)
+	}
+	if !first.Changed {
+		t.Fatal("Inject() first changed = false")
+	}
+	firstContent, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("ReadFile() first error = %v", err)
+	}
+
+	second, err := Inject(home, codexAdapter())
+	if err != nil {
+		t.Fatalf("Inject() second error = %v", err)
+	}
+	if second.Changed {
+		t.Fatal("Inject() second changed = true")
+	}
+	secondContent, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("ReadFile() second error = %v", err)
+	}
+	if string(firstContent) != string(secondContent) {
+		t.Fatalf("Windows Codex workspace root migration is not idempotent:\nfirst:\n%s\nsecond:\n%s", firstContent, secondContent)
 	}
 }
 


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1081

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

Remove the Codex home workspace root from existing and generated Windows configurations while preserving custom roots and non-Windows behavior.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/components/permissions/inject.go` | Removes the exact TOML home-root key on Windows across supported table and dotted-key forms. |
| `internal/components/permissions/inject_test.go` | Covers Windows migration, TOML-equivalent syntax, preservation, non-Windows behavior, and idempotency. |

---

## 🧪 Test Plan

**Verified on Linux**

- [x] Focused original regression scenarios pass
- [x] Permissions package tests pass
- [x] All internal component tests pass
- [x] `go vet` passes
- [x] `gofmt` and diff/scope checks pass
- [x] Windows test binary cross-compilation passes
- [ ] Native Windows runtime test (unavailable; verification host was Linux)
- [ ] Full unit suite (`go test ./...`)
- [ ] E2E suite (`cd e2e && ./docker-test.sh`)

---

## 🤖 Automated Checks

The repository's required CI checks control merge eligibility.

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] Maintainer-approved `size:exception`: semantic TOML regression coverage pushed the diff over 400 lines, but the change remains one atomic Windows migration unit with one rollback boundary
- [x] I have added the appropriate `type:*` label to this PR
- [ ] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Documentation is not required for this internal migration fix
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

The rollback boundary is the Windows workspace-root migration and its regression coverage in the two changed files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows permission configuration handling by removing the home-directory workspace entry when appropriate.
  * Preserved other workspace entries and unrelated configuration settings.
  * Ensured repeated configuration updates produce consistent results across supported formatting variations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->