### PR TITLE
fix(codex): migrate legacy carril defaults

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -152,7 +152,7 @@ Kiro uses native custom agents in `~/.kiro/agents/`. `gentle-ai` writes phase ag
   | `sdd-mid` | `gpt-5.6-terra` / `medium` | `gpt-5.6-terra` / `medium` | `gpt-5.6-terra` / `high` | apply, fix-agent |
   | `sdd-cheap` | `gpt-5.6-luna` / `low` | `gpt-5.6-luna` / `low` | `gpt-5.6-luna` / `low` | explore, spec, tasks, archive, onboard |
 
-- Explicit saved Codex model assignments are preserved on sync, including older pinned IDs such as `gpt-5.5` or `gpt-5.4-mini`; GPT-5.6 IDs are used only for missing/default assignments.
+- Explicit saved Codex model assignments are preserved on sync, including older pinned IDs such as `gpt-5.5` or `gpt-5.4-mini`. The narrow exception is the exact former implicit-default tuple (`sdd-strong=gpt-5.5`, `sdd-mid=gpt-5.5`, `sdd-cheap=gpt-5.4-mini`), which sync treats as Recommended and upgrades to the current GPT-5.6 tuple; partial, extended, or otherwise different maps remain custom and unchanged.
 - GPT-5.6 `max` reasoning effort and `ultra` mode are intentionally not enabled by this default update. `max` requires confirmed Codex support; `ultra` changes orchestration semantics and needs separate design.
 - Multi-agent SDD delegation is available as an **experimental opt-in** (default off). gentle-ai writes `features.multi_agent = false` and `agents.max_threads = 4` / `agents.max_depth = 2` into `~/.codex/config.toml`. To enable, set `multi_agent = true` in the `[features]` section. When enabled, the `sdd-orchestrator` asset uses Codex's native `spawn_agent` / `wait_agent` / `close_agent` tools to delegate SDD phases; otherwise it falls back to solo-agent inline execution.
 - **Delegation**: Solo-agent (multi-agent opt-in, experimental)

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -748,11 +748,7 @@ func loadPersistedAssignments(homeDir string, selection *model.Selection) {
 		selection.CodexModelAssignments = m
 	}
 	if len(selection.CodexCarrilModelAssignments) == 0 && len(s.CodexCarrilModelAssignments) > 0 {
-		m := make(map[string]string, len(s.CodexCarrilModelAssignments))
-		for k, v := range s.CodexCarrilModelAssignments {
-			m[k] = v
-		}
-		selection.CodexCarrilModelAssignments = m
+		selection.CodexCarrilModelAssignments = model.MigrateLegacyCodexCarrilDefaults(s.CodexCarrilModelAssignments)
 	}
 	if len(selection.CodexPhaseModelAssignments) == 0 && len(s.CodexPhaseModelAssignments) > 0 {
 		m := make(map[string]string, len(s.CodexPhaseModelAssignments))

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -1495,29 +1495,82 @@ func TestApplyOverrides_CodexCarrilModelAssignments(t *testing.T) {
 	}
 }
 
-// TestLoadPersistedAssignments_CodexCarrilModels verifies that state with
-// codexCarrilModelAssignments populates selection.CodexCarrilModelAssignments.
 func TestLoadPersistedAssignments_CodexCarrilModels(t *testing.T) {
+	tests := []struct {
+		name      string
+		persisted map[string]string
+		want      map[string]string
+	}{
+		{name: "migrates exact legacy defaults", persisted: map[string]string{"sdd-strong": "gpt-5.5", "sdd-mid": "gpt-5.5", "sdd-cheap": "gpt-5.4-mini"}, want: model.DefaultCarrilModels()},
+		{name: "preserves custom tuple", persisted: map[string]string{"sdd-strong": "gpt-5.5", "sdd-mid": "gpt-5.4", "sdd-cheap": "gpt-5.4-mini"}, want: map[string]string{"sdd-strong": "gpt-5.5", "sdd-mid": "gpt-5.4", "sdd-cheap": "gpt-5.4-mini"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home := t.TempDir()
+			if err := state.Write(home, state.InstallState{InstalledAgents: []string{"codex"}, CodexCarrilModelAssignments: tt.persisted}); err != nil {
+				t.Fatalf("state.Write: %v", err)
+			}
+
+			sel := model.Selection{}
+			loadPersistedAssignments(home, &sel)
+			if !reflect.DeepEqual(sel.CodexCarrilModelAssignments, tt.want) {
+				t.Fatalf("CodexCarrilModelAssignments = %#v, want %#v", sel.CodexCarrilModelAssignments, tt.want)
+			}
+		})
+	}
+}
+
+func TestTuiSyncMigratesLegacyCodexCarrilDefaults(t *testing.T) {
+	t.Cleanup(codex.SetRuntimeVersionCommandForTest("codex-cli 0.144.0", nil))
 	home := t.TempDir()
 	if err := state.Write(home, state.InstallState{
-		InstalledAgents: []string{"codex"},
-		CodexCarrilModelAssignments: map[string]string{
-			"sdd-strong": "gpt-5.5",
-			"sdd-mid":    "gpt-5.5",
-			"sdd-cheap":  "gpt-5.4-mini",
-		},
+		InstalledAgents:             []string{"codex"},
+		CodexCarrilModelAssignments: map[string]string{"sdd-strong": "gpt-5.5", "sdd-mid": "gpt-5.5", "sdd-cheap": "gpt-5.4-mini"},
+		CodexModelAssignments:       map[string]string{"sdd-apply": "medium"},
 	}); err != nil {
 		t.Fatalf("state.Write: %v", err)
 	}
 
-	sel := model.Selection{}
-	loadPersistedAssignments(home, &sel)
-
-	if sel.CodexCarrilModelAssignments["sdd-cheap"] != "gpt-5.4-mini" {
-		t.Errorf("CodexCarrilModelAssignments[sdd-cheap] = %q, want gpt-5.4-mini", sel.CodexCarrilModelAssignments["sdd-cheap"])
+	changed, err := tuiSync(home)(nil)
+	if err != nil {
+		t.Fatalf("tuiSync() error = %v", err)
 	}
-	if sel.CodexCarrilModelAssignments["sdd-strong"] != "gpt-5.5" {
-		t.Errorf("CodexCarrilModelAssignments[sdd-strong] = %q, want gpt-5.5", sel.CodexCarrilModelAssignments["sdd-strong"])
+	changedSet := make(map[string]bool, len(changed))
+	for _, path := range changed {
+		changedSet[path] = true
+	}
+
+	wantProfiles := map[string][]string{
+		"sdd-strong.config.toml": {`model = "gpt-5.6-sol"`, `model_reasoning_effort = "medium"`},
+		"sdd-mid.config.toml":    {`model = "gpt-5.6-terra"`, `model_reasoning_effort = "medium"`},
+		"sdd-cheap.config.toml":  {`model = "gpt-5.6-luna"`, `model_reasoning_effort = "low"`},
+	}
+	for name, wantContent := range wantProfiles {
+		path := filepath.Join(home, ".codex", name)
+		body, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("ReadFile(%s): %v", path, err)
+		}
+		for _, want := range wantContent {
+			if !strings.Contains(string(body), want) {
+				t.Fatalf("%s missing %q; got:\n%s", name, want, body)
+			}
+		}
+		if !changedSet[path] {
+			t.Errorf("tuiSync changed files missing %s: %#v", path, changed)
+		}
+	}
+
+	persisted, err := state.Read(home)
+	if err != nil {
+		t.Fatalf("state.Read after tuiSync: %v", err)
+	}
+	if !reflect.DeepEqual(persisted.CodexCarrilModelAssignments, model.DefaultCarrilModels()) {
+		t.Fatalf("persisted carril assignments = %#v, want %#v", persisted.CodexCarrilModelAssignments, model.DefaultCarrilModels())
+	}
+	if persisted.CodexModelAssignments["sdd-apply"] != "medium" {
+		t.Fatalf("persisted effort assignment = %#v, want sdd-apply medium", persisted.CodexModelAssignments)
 	}
 }
 

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"context"
 	"flag"
 	"fmt"
@@ -60,8 +61,7 @@ type SyncResult struct {
 	// were already current (idempotent re-sync).
 	NoOp bool
 	// FilesChanged is the number of deduplicated managed file paths
-	// processed during this sync. A file is counted when at least one
-	// component reports it as part of its injection result.
+	// whose persisted content or existence changed during this sync.
 	// Zero means all assets were already current.
 	FilesChanged int
 	// ChangedFiles lists deduplicated absolute paths of managed files
@@ -382,7 +382,8 @@ type syncRuntime struct {
 	agentIDs     []model.AgentID
 	backupRoot   string
 	state        *runtimeState
-	changedFiles []string // accumulates absolute paths of files that actually changed
+	managedPaths []string
+	changedFiles []string // accumulates candidate paths reported by component injectors
 }
 
 func newSyncRuntime(homeDir string, selection model.Selection) (*syncRuntime, error) {
@@ -407,6 +408,7 @@ func newSyncRuntime(homeDir string, selection model.Selection) (*syncRuntime, er
 func (r *syncRuntime) stagePlan() pipeline.StagePlan {
 	adapters := resolveAdapters(r.agentIDs)
 	targets := syncBackupTargets(r.homeDir, r.workspaceDir, r.selection, adapters)
+	r.managedPaths = targets
 
 	prepare := []pipeline.Step{
 		prepareBackupStep{
@@ -568,10 +570,9 @@ func managedOutputStyleFile(persona model.PersonaID) string {
 // Unlike componentApplyStep, it ONLY calls inject functions —
 // no binary install, no engram setup, no persona injection.
 //
-// changedFiles is a shared slice pointer. Each step appends the file
-// paths from its InjectionResult.Files when InjectionResult.Changed
-// is true. Paths may contain duplicates across components; the caller
-// (RunSync) deduplicates before exposing them via SyncResult.
+// changedFiles is a shared slice pointer. Each step appends candidate paths
+// from its aggregate InjectionResult when any file changed. RunSync compares
+// candidates with pre-sync snapshots before exposing persisted changes.
 type componentSyncStep struct {
 	id           string
 	component    model.ComponentID
@@ -813,7 +814,7 @@ func (s componentSyncStep) Run() error {
 	}
 }
 
-// countChanged records the file paths that were actually changed (nil-safe).
+// countChanged records candidate changed paths from an aggregate injector result.
 func (s componentSyncStep) countChanged(n int, files ...string) {
 	if s.changedFiles != nil && n > 0 {
 		*s.changedFiles = append(*s.changedFiles, files...)
@@ -837,6 +838,48 @@ func dedupPaths(paths []string) []string {
 		}
 	}
 	return out
+}
+
+type syncFileSnapshot struct {
+	exists bool
+	data   []byte
+}
+
+func snapshotSyncFiles(paths []string) (map[string]syncFileSnapshot, error) {
+	snapshots := make(map[string]syncFileSnapshot, len(paths))
+	for _, path := range dedupPaths(paths) {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				snapshots[path] = syncFileSnapshot{}
+				continue
+			}
+			return nil, fmt.Errorf("snapshot managed sync file %q: %w", path, err)
+		}
+		snapshots[path] = syncFileSnapshot{exists: true, data: data}
+	}
+	return snapshots, nil
+}
+
+func changedSyncFiles(candidates []string, before map[string]syncFileSnapshot) ([]string, error) {
+	var changed []string
+	for _, path := range dedupPaths(candidates) {
+		after, err := os.ReadFile(path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				if before[path].exists {
+					changed = append(changed, path)
+				}
+				continue
+			}
+			return nil, fmt.Errorf("compare managed sync file %q: %w", path, err)
+		}
+		previous := before[path]
+		if !previous.exists || !bytes.Equal(after, previous.data) {
+			changed = append(changed, path)
+		}
+	}
+	return changed, nil
 }
 
 // boolToInt converts a boolean to 0 or 1.
@@ -914,6 +957,10 @@ func RunSyncWithSelection(homeDir string, selection model.Selection) (SyncResult
 
 	stagePlan := rt.stagePlan()
 	result.Plan = stagePlan
+	before, err := snapshotSyncFiles(rt.managedPaths)
+	if err != nil {
+		return result, err
+	}
 
 	orchestrator := pipeline.NewOrchestrator(pipeline.DefaultRollbackPolicy())
 	result.Execution = orchestrator.Execute(stagePlan)
@@ -924,7 +971,10 @@ func RunSyncWithSelection(homeDir string, selection model.Selection) (SyncResult
 	// Capture how many managed assets were actually changed.
 	// Deduplicate paths — multiple components may touch the same file
 	// (e.g. Engram and Context7 both merge into settings.json).
-	result.ChangedFiles = dedupPaths(rt.changedFiles)
+	result.ChangedFiles, err = changedSyncFiles(rt.changedFiles, before)
+	if err != nil {
+		return result, err
+	}
 	result.FilesChanged = len(result.ChangedFiles)
 
 	// True no-op: agents were discovered but all managed assets were already
@@ -1032,11 +1082,7 @@ func RunSync(args []string) (SyncResult, error) {
 		selection.CodexModelAssignments = m
 	}
 	if len(selection.CodexCarrilModelAssignments) == 0 && len(persistedState.CodexCarrilModelAssignments) > 0 {
-		m := make(map[string]string, len(persistedState.CodexCarrilModelAssignments))
-		for k, v := range persistedState.CodexCarrilModelAssignments {
-			m[k] = v
-		}
-		selection.CodexCarrilModelAssignments = m
+		selection.CodexCarrilModelAssignments = model.MigrateLegacyCodexCarrilDefaults(persistedState.CodexCarrilModelAssignments)
 	}
 	if len(selection.CodexPhaseModelAssignments) == 0 && len(persistedState.CodexPhaseModelAssignments) > 0 {
 		m := make(map[string]string, len(persistedState.CodexPhaseModelAssignments))

--- a/internal/cli/sync_test.go
+++ b/internal/cli/sync_test.go
@@ -1,12 +1,14 @@
 package cli
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"reflect"
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gentleman-programming/gentle-ai/internal/agents"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/codex"
@@ -3191,15 +3193,7 @@ func setupCodexSyncHomeWithPhaseModels(t *testing.T, carrilModels map[string]str
 	return home
 }
 
-// TestRunSync_RestoresCodexCarrilAssignments verifies that RunSync reads
-// CodexCarrilModelAssignments from state.json and uses them when writing
-// Codex profile files (model key present).
 func TestRunSync_RestoresCodexCarrilAssignments(t *testing.T) {
-	home := setupCodexSyncHome(t,
-		map[string]string{"sdd-strong": "gpt-5.5", "sdd-mid": "gpt-5.5", "sdd-cheap": "gpt-5.4-mini"},
-		nil,
-	)
-
 	restoreHome := osUserHomeDir
 	restoreCommand := runCommand
 	restoreLookPath := cmdLookPath
@@ -3209,26 +3203,124 @@ func TestRunSync_RestoresCodexCarrilAssignments(t *testing.T) {
 		cmdLookPath = restoreLookPath
 	})
 
+	runCommand = func(string, ...string) error { return nil }
+	cmdLookPath = func(name string) (string, error) { return "/usr/local/bin/" + name, nil }
+
+	tests := []struct {
+		name      string
+		persisted map[string]string
+		want      map[string]string
+		runs      int
+	}{
+		{name: "migrates exact legacy defaults repeatedly", persisted: map[string]string{"sdd-strong": "gpt-5.5", "sdd-mid": "gpt-5.5", "sdd-cheap": "gpt-5.4-mini"}, want: model.DefaultCarrilModels(), runs: 2},
+		{name: "preserves custom tuple", persisted: map[string]string{"sdd-strong": "gpt-5.5", "sdd-mid": "gpt-5.4", "sdd-cheap": "gpt-5.4-mini"}, want: map[string]string{"sdd-strong": "gpt-5.5", "sdd-mid": "gpt-5.4", "sdd-cheap": "gpt-5.4-mini"}, runs: 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Cleanup(codex.SetRuntimeVersionCommandForTest("codex-cli 0.144.0", nil))
+			home := t.TempDir()
+			if err := state.Write(home, state.InstallState{InstalledAgents: []string{"codex"}, CodexCarrilModelAssignments: tt.persisted}); err != nil {
+				t.Fatalf("state.Write: %v", err)
+			}
+			osUserHomeDir = func() (string, error) { return home, nil }
+
+			var firstProfiles map[string][]byte
+			for run := 0; run < tt.runs; run++ {
+				result, err := RunSync([]string{"--agents", "codex"})
+				if err != nil {
+					t.Fatalf("RunSync() run %d error = %v", run+1, err)
+				}
+				if !reflect.DeepEqual(result.Selection.CodexCarrilModelAssignments, tt.want) {
+					t.Fatalf("run %d carril assignments = %#v, want %#v", run+1, result.Selection.CodexCarrilModelAssignments, tt.want)
+				}
+				profiles := make(map[string][]byte, 3)
+				for _, name := range []string{"sdd-strong.config.toml", "sdd-mid.config.toml", "sdd-cheap.config.toml"} {
+					body, err := os.ReadFile(filepath.Join(home, ".codex", name))
+					if err != nil {
+						t.Fatalf("run %d ReadFile(%s): %v", run+1, name, err)
+					}
+					profiles[name] = body
+				}
+				if run == 0 {
+					if result.NoOp || result.FilesChanged == 0 {
+						t.Fatalf("first sync metadata = NoOp %v, FilesChanged %d; want managed changes", result.NoOp, result.FilesChanged)
+					}
+					firstProfiles = profiles
+				} else {
+					for name, first := range firstProfiles {
+						if !bytes.Equal(profiles[name], first) {
+							t.Fatalf("%s changed between repeated syncs", name)
+						}
+					}
+					if !result.NoOp || result.FilesChanged != 0 || len(result.ChangedFiles) != 0 {
+						t.Fatalf("second sync metadata = NoOp %v, FilesChanged %d, ChangedFiles %#v; want no changes", result.NoOp, result.FilesChanged, result.ChangedFiles)
+					}
+				}
+			}
+
+			content, err := os.ReadFile(filepath.Join(home, ".codex", "sdd-strong.config.toml"))
+			if err != nil {
+				t.Fatalf("ReadFile(sdd-strong.config.toml): %v", err)
+			}
+			if !strings.Contains(string(content), tt.want["sdd-strong"]) {
+				t.Fatalf("sdd-strong.config.toml missing %q; got:\n%s", tt.want["sdd-strong"], content)
+			}
+		})
+	}
+}
+
+func TestRunSyncPreservesCompletePersistedState(t *testing.T) {
+	t.Cleanup(codex.SetRuntimeVersionCommandForTest("codex-cli 0.144.0", nil))
+	home := t.TempDir()
+	lastUpdate := time.Date(2026, time.July, 11, 12, 0, 0, 0, time.UTC)
+	before := state.InstallState{
+		InstalledAgents: []string{"codex", "opencode"},
+		ClaudeModelAssignments: map[string]string{
+			"sdd-archive": "haiku",
+		},
+		ClaudePhaseAssignments: map[string]state.ClaudePhaseAssignmentState{
+			"sdd-verify": {Model: "opus", Effort: "high"},
+		},
+		KiroModelAssignments: map[string]string{"sdd-design": "sonnet"},
+		CodexModelAssignments: map[string]string{
+			"sdd-apply": "medium",
+		},
+		CodexOrchestratorAssignment: &state.CodexOrchestratorAssignmentState{Model: "gpt-5.6-sol", Effort: "low"},
+		CodexCarrilModelAssignments: map[string]string{"sdd-strong": "gpt-5.5", "sdd-mid": "gpt-5.5", "sdd-cheap": "gpt-5.4-mini"},
+		CodexPhaseModelAssignments:  map[string]string{"sdd-apply": "gpt-5.6-terra"},
+		ModelAssignments: map[string]state.ModelAssignmentState{
+			"sdd-init": {ProviderID: "anthropic", ModelID: "claude-sonnet-4", Effort: "medium"},
+		},
+		Persona:         "neutral",
+		LastUpdateCheck: &lastUpdate,
+		PendingSync:     true,
+	}
+	if err := state.Write(home, before); err != nil {
+		t.Fatalf("state.Write: %v", err)
+	}
+
+	restoreHome := osUserHomeDir
+	restoreCommand := runCommand
+	restoreLookPath := cmdLookPath
+	t.Cleanup(func() {
+		osUserHomeDir = restoreHome
+		runCommand = restoreCommand
+		cmdLookPath = restoreLookPath
+	})
 	osUserHomeDir = func() (string, error) { return home, nil }
 	runCommand = func(string, ...string) error { return nil }
 	cmdLookPath = func(name string) (string, error) { return "/usr/local/bin/" + name, nil }
 
-	_, err := RunSync([]string{"--agents", "codex"})
-	if err != nil {
+	if _, err := RunSync([]string{"--agents", "codex"}); err != nil {
 		t.Fatalf("RunSync() error = %v", err)
 	}
-
-	// The sdd-strong.config.toml profile must have both model and model_reasoning_effort.
-	strongProfile := filepath.Join(home, ".codex", "sdd-strong.config.toml")
-	content, readErr := os.ReadFile(strongProfile)
-	if readErr != nil {
-		t.Fatalf("ReadFile(%q) error = %v", strongProfile, readErr)
+	after, err := state.Read(home)
+	if err != nil {
+		t.Fatalf("state.Read after sync: %v", err)
 	}
-	if !strings.Contains(string(content), `model`) {
-		t.Errorf("sdd-strong.config.toml missing model key; got:\n%s", content)
-	}
-	if !strings.Contains(string(content), "gpt-5.5") {
-		t.Errorf("sdd-strong.config.toml: expected gpt-5.5; got:\n%s", content)
+	if !reflect.DeepEqual(after, before) {
+		t.Fatalf("CLI sync changed persisted state:\nafter:  %#v\nbefore: %#v", after, before)
 	}
 }
 

--- a/internal/model/codex_model.go
+++ b/internal/model/codex_model.go
@@ -142,6 +142,24 @@ func CodexCarrilModelsForPreset(preset string) map[string]string {
 	return out
 }
 
+// MigrateLegacyCodexCarrilDefaults replaces the exact historical implicit
+// default tuple with the current Recommended models. Every other persisted map
+// is custom and is returned unchanged as a defensive copy.
+func MigrateLegacyCodexCarrilDefaults(assignments map[string]string) map[string]string {
+	if len(assignments) == 3 &&
+		assignments["sdd-strong"] == "gpt-5.5" &&
+		assignments["sdd-mid"] == "gpt-5.5" &&
+		assignments["sdd-cheap"] == "gpt-5.4-mini" {
+		return CodexCarrilModelsForPreset(string(CodexPresetRecommended))
+	}
+
+	out := make(map[string]string, len(assignments))
+	for carril, modelID := range assignments {
+		out[carril] = modelID
+	}
+	return out
+}
+
 func codexPresetEfforts(preset string) map[string]CodexEffort {
 	defaults := CodexPresetCarrilDefaults(preset)
 	out := make(map[string]CodexEffort, 13)

--- a/internal/model/codex_model_test.go
+++ b/internal/model/codex_model_test.go
@@ -1,6 +1,7 @@
 package model_test
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 
@@ -226,6 +227,33 @@ func TestDefaultCarrilModels(t *testing.T) {
 	}
 	if len(m) != 3 {
 		t.Errorf("DefaultCarrilModels() has %d entries, want 3", len(m))
+	}
+}
+
+func TestMigrateLegacyCodexCarrilDefaults(t *testing.T) {
+	legacy := map[string]string{
+		"sdd-strong": "gpt-5.5",
+		"sdd-mid":    "gpt-5.5",
+		"sdd-cheap":  "gpt-5.4-mini",
+	}
+	tests := []struct {
+		name  string
+		input map[string]string
+		want  map[string]string
+	}{
+		{name: "exact legacy tuple", input: legacy, want: model.DefaultCarrilModels()},
+		{name: "different value", input: map[string]string{"sdd-cheap": "gpt-5.4", "sdd-mid": "gpt-5.5", "sdd-strong": "gpt-5.5"}, want: map[string]string{"sdd-cheap": "gpt-5.4", "sdd-mid": "gpt-5.5", "sdd-strong": "gpt-5.5"}},
+		{name: "partial map", input: map[string]string{"sdd-strong": "gpt-5.5", "sdd-mid": "gpt-5.5"}, want: map[string]string{"sdd-strong": "gpt-5.5", "sdd-mid": "gpt-5.5"}},
+		{name: "extra key", input: map[string]string{"sdd-strong": "gpt-5.5", "sdd-mid": "gpt-5.5", "sdd-cheap": "gpt-5.4-mini", "custom": "gpt-5.6-sol"}, want: map[string]string{"sdd-strong": "gpt-5.5", "sdd-mid": "gpt-5.5", "sdd-cheap": "gpt-5.4-mini", "custom": "gpt-5.6-sol"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := model.MigrateLegacyCodexCarrilDefaults(tt.input)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("MigrateLegacyCodexCarrilDefaults() = %#v, want %#v", got, tt.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Closes #1089

## PR Type

- [x] Bug fix

## Summary

- Migrates the exact historical Codex SDD carril default set (`sdd-strong=gpt-5.5`, `sdd-mid=gpt-5.5`, `sdd-cheap=gpt-5.4-mini`) to the current GPT-5.6 defaults (`gpt-5.6-sol` / `gpt-5.6-terra` / `gpt-5.6-luna`) during sync.
- Uses exact-match semantics: any deviation from the three-entry legacy set (partial map, extra key, different value) is preserved as genuine user custom state.
- Derives sync `FilesChanged`/`ChangedFiles` from a pre/post byte comparison of managed paths so restored carril assignments are reported correctly.

## Changes

| File | Change |
|------|--------|
| `internal/model/codex_model.go` | Add `MigrateLegacyCodexCarrilDefaults` with exact-match legacy set detection |
| `internal/model/codex_model_test.go` | Table tests: exact legacy set, deviating value, partial map, extra key |
| `internal/app/app.go` | Apply migration when loading persisted assignments in the TUI path |
| `internal/app/app_test.go` | Cover migration through app assignment loading |
| `internal/cli/sync.go` | Apply migration in CLI `RunSync`; snapshot-based changed-file reporting |
| `internal/cli/sync_test.go` | End-to-end sync tests incl. repeated-run idempotence with legacy state |
| `docs/agents.md` | Document the exact-match migration contract |

## Test Plan

- [x] `env -u GENTLE_AI_CHANNEL go test ./... -count=1` — all 53 packages pass
- [x] `go vet ./...` and `go build ./...` clean
- [x] Native bounded review lineage `issue-1089-legacy-codex-default-migration-g4` approved (reliability lens, zero severe findings); pre-commit/pre-push/pre-PR gates returned `allow` on the content-bound receipt

## Contributor Checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] N/A — no shell scripts modified
- [x] Tested via full Go suite
- [x] Docs updated (`docs/agents.md`)
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated legacy Codex model assignments to the current recommended defaults while preserving customized mappings.
  * Improved sync change detection so only files with actual content or existence changes are reported.
  * Preserved existing configuration state during Codex synchronization.
  * Made repeated syncs idempotent, avoiding unnecessary file changes on subsequent runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->