### PR TITLE
fix(codegraph): preserve Pi onboarding pending state

### DIFF
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -520,7 +520,7 @@ func (r *installRuntime) stagePlan() pipeline.StagePlan {
 	}
 
 	for _, tool := range r.selection.CommunityTools {
-		apply = append(apply, communityToolInstallStep{id: "community-tool:" + string(tool), tool: tool, workspaceDir: r.workspaceDir, homeDir: r.homeDir})
+		apply = append(apply, communityToolInstallStep{id: "community-tool:" + string(tool), tool: tool, workspaceDir: r.workspaceDir, homeDir: r.homeDir, state: r.state})
 	}
 
 	for _, component := range r.resolved.OrderedComponents {
@@ -555,9 +555,12 @@ type piCodeGraphReconcileStep struct {
 	state                     *runtimeState
 }
 
+var reconcilePiCodeGraph = communitytool.ReconcilePiCodeGraph
+
 func (s piCodeGraphReconcileStep) ID() string { return s.id }
 func (s piCodeGraphReconcileStep) Run() error {
-	result, err := communitytool.ReconcilePiCodeGraph(communitytool.PiCodeGraphOptions{HomeDir: s.homeDir, WorkspaceDir: s.workspaceDir, Selected: s.selected})
+	result, err := reconcilePiCodeGraph(communitytool.PiCodeGraphOptions{HomeDir: s.homeDir, WorkspaceDir: s.workspaceDir, Selected: s.selected})
+	result, err = communitytool.PreservePiCodeGraphPending(result, err)
 	if err == nil && s.state != nil {
 		s.state.piCodeGraph = &result
 	}
@@ -755,14 +758,18 @@ type communityToolInstallStep struct {
 	tool         model.CommunityToolID
 	workspaceDir string
 	homeDir      string
+	state        *runtimeState
 }
 
 func (s communityToolInstallStep) ID() string { return s.id }
 
 func (s communityToolInstallStep) Run() error {
-	_, err := installCommunityToolWithHome(s.tool, s.workspaceDir, s.homeDir, communitytool.RunnerFunc(runCommand), communitytool.DetectorFunc(cmdLookPath))
+	result, err := installCommunityToolWithHome(s.tool, s.workspaceDir, s.homeDir, communitytool.RunnerFunc(runCommand), communitytool.DetectorFunc(cmdLookPath))
 	if err != nil {
 		return fmt.Errorf("install community tool %q: %w", s.tool, err)
+	}
+	if result.PiCodeGraph != nil && s.state != nil {
+		s.state.piCodeGraph = result.PiCodeGraph
 	}
 	return nil
 }

--- a/internal/cli/run_community_tool_test.go
+++ b/internal/cli/run_community_tool_test.go
@@ -2,15 +2,18 @@ package cli
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"slices"
 	"strings"
 	"testing"
 
 	"github.com/gentleman-programming/gentle-ai/internal/components/communitytool"
 	"github.com/gentleman-programming/gentle-ai/internal/model"
+	"github.com/gentleman-programming/gentle-ai/internal/pipeline"
 	"github.com/gentleman-programming/gentle-ai/internal/planner"
 	"github.com/gentleman-programming/gentle-ai/internal/system"
 )
@@ -35,6 +38,26 @@ func TestInstallRuntimeStagePlanAddsCommunityToolStepsInSelectionOrder(t *testin
 	want := []string{"apply:rollback-restore", "community-tool:codegraph"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("apply step IDs = %#v, want %#v", got, want)
+	}
+}
+
+func TestInstallRuntimeStagePlanKeepsPiReconcileIndependentFromOpenCode(t *testing.T) {
+	runtime := &installRuntime{
+		homeDir:      t.TempDir(),
+		workspaceDir: "/work/project",
+		selection: model.Selection{
+			CommunityTools: []model.CommunityToolID{model.CommunityToolCodeGraph},
+		},
+		resolved: planner.ResolvedPlan{Agents: []model.AgentID{model.AgentOpenCode, model.AgentPi}},
+		profile:  system.PlatformProfile{},
+		state:    &runtimeState{},
+	}
+
+	plan := runtime.stagePlan()
+	if !slices.ContainsFunc(plan.Apply, func(step pipeline.Step) bool {
+		return step.ID() == "community-tool:pi-codegraph-reconcile"
+	}) {
+		t.Fatal("install plan with OpenCode and Pi must keep independent Pi CodeGraph reconciliation")
 	}
 }
 
@@ -146,6 +169,35 @@ func TestPiCodeGraphReconcileStepRollbackRemovesDynamicPackageOverlay(t *testing
 	}
 	if _, err := os.Stat(overlay); !os.IsNotExist(err) {
 		t.Fatalf("dynamic package overlay remains after later pipeline rollback: %v", err)
+	}
+}
+
+func TestPiCodeGraphPendingClassification(t *testing.T) {
+	realErr := errors.New("restore Pi CodeGraph journal")
+	tests := []struct {
+		name    string
+		err     error
+		pending bool
+	}{
+		{name: "bare", err: communitytool.ErrPiCodeGraphAdapterHealthUnavailable, pending: true},
+		{name: "wrapped", err: fmt.Errorf("verify adapter: %w", communitytool.ErrPiCodeGraphAdapterHealthUnavailable), pending: true},
+		{name: "all pending join", err: errors.Join(communitytool.ErrPiCodeGraphAdapterHealthUnavailable, fmt.Errorf("wrapped: %w", communitytool.ErrPiCodeGraphAdapterHealthUnavailable)), pending: true},
+		{name: "pending plus rollback failure", err: errors.Join(communitytool.ErrPiCodeGraphAdapterHealthUnavailable, realErr)},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := communitytool.PreservePiCodeGraphPending(communitytool.PiCodeGraphResult{}, tc.err)
+			if tc.pending {
+				if err != nil || len(result.ManualActions) != 1 || !strings.Contains(result.ManualActions[0], "pending") {
+					t.Fatalf("result=%#v error=%v, want exactly one pending action", result, err)
+				}
+				return
+			}
+			if !errors.Is(err, realErr) || len(result.ManualActions) != 0 {
+				t.Fatalf("result=%#v error=%v, want fatal rollback error without pending action", result, err)
+			}
+		})
 	}
 }
 
@@ -393,6 +445,98 @@ func TestCommunityToolInstallStepPassesRuntimeHomeToPiReconciler(t *testing.T) {
 	}
 }
 
+func TestInstallPipelinePropagatesInitialPiPendingWhenPiUnselected(t *testing.T) {
+	previous := installCommunityToolWithHome
+	t.Cleanup(func() { installCommunityToolWithHome = previous })
+	pending := communitytool.PiCodeGraphResult{ManualActions: []string{"Pi CodeGraph runtime verification is pending."}}
+	installCommunityToolWithHome = func(_ model.CommunityToolID, _ string, _ string, _ communitytool.Runner, _ communitytool.Detector) (communitytool.Result, error) {
+		return communitytool.Result{Tool: model.CommunityToolCodeGraph, PiCodeGraph: &pending}, nil
+	}
+	runtime := &installRuntime{
+		selection: model.Selection{CommunityTools: []model.CommunityToolID{model.CommunityToolCodeGraph}},
+		state:     &runtimeState{},
+	}
+
+	if err := runtime.stagePlan().Apply[1].Run(); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if runtime.state.piCodeGraph == nil || !reflect.DeepEqual(runtime.state.piCodeGraph.ManualActions, pending.ManualActions) {
+		t.Fatalf("pipeline Pi result = %#v, want initial pending action", runtime.state.piCodeGraph)
+	}
+	if out := RenderInstallManualActions(InstallResult{PiCodeGraph: runtime.state.piCodeGraph}); !strings.Contains(out, pending.ManualActions[0]) {
+		t.Fatalf("rendered install actions = %q, want pending action", out)
+	}
+}
+
+func TestInstallPipelineDoesNotDuplicatePiPendingWhenSelected(t *testing.T) {
+	previousInstall := installCommunityToolWithHome
+	previousReconcile := reconcilePiCodeGraph
+	t.Cleanup(func() {
+		installCommunityToolWithHome = previousInstall
+		reconcilePiCodeGraph = previousReconcile
+	})
+	pending := communitytool.PiCodeGraphResult{ManualActions: []string{"Pi CodeGraph integration is pending: Pi 0.80.6 has no supported machine-verifiable adapter health signal. CodeGraph capability was not reported as configured."}}
+	installCommunityToolWithHome = func(_ model.CommunityToolID, _ string, _ string, _ communitytool.Runner, _ communitytool.Detector) (communitytool.Result, error) {
+		return communitytool.Result{Tool: model.CommunityToolCodeGraph, PiCodeGraph: &pending}, nil
+	}
+	reconcilePiCodeGraph = func(communitytool.PiCodeGraphOptions) (communitytool.PiCodeGraphResult, error) {
+		return pending, communitytool.ErrPiCodeGraphAdapterHealthUnavailable
+	}
+	runtime := &installRuntime{
+		selection: model.Selection{CommunityTools: []model.CommunityToolID{model.CommunityToolCodeGraph}},
+		resolved:  planner.ResolvedPlan{Agents: []model.AgentID{model.AgentPi}},
+		state:     &runtimeState{},
+	}
+
+	for _, step := range runtime.stagePlan().Apply[1:] {
+		if err := step.Run(); err != nil {
+			t.Fatalf("step %q error = %v", step.ID(), err)
+		}
+	}
+	if runtime.state.piCodeGraph == nil || len(runtime.state.piCodeGraph.ManualActions) != 1 {
+		t.Fatalf("pipeline Pi result = %#v, want exactly one pending action", runtime.state.piCodeGraph)
+	}
+}
+
+func TestPiCodeGraphRuntimeOutputClassification(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake Pi runtime uses a POSIX script")
+	}
+	tests := []struct {
+		name    string
+		output  string
+		pending bool
+	}{
+		{name: "session only", output: `{"type":"session","version":3}` + "\n", pending: true},
+		{name: "not ready", output: "codegraph: not ready\n"},
+		{name: "not running", output: "codegraph: not running\n"},
+		{name: "unloaded", output: "codegraph: unloaded\n"},
+		{name: "inactive", output: "codegraph: inactive\n"},
+		{name: "broken", output: "codegraph: broken\n"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			writePiInstallFixture(t, home)
+			mustWriteFile(t, filepath.Join(home, ".pi", "agent", "npm", "node_modules", "pi-mcp-adapter", "index.ts"), []byte("export default {}\n"))
+			installFakePiRuntime(t, tc.output)
+
+			result, err := communitytool.ReconcilePiCodeGraph(communitytool.PiCodeGraphOptions{HomeDir: home, Selected: true})
+			result, err = communitytool.PreservePiCodeGraphPending(result, err)
+			if tc.pending {
+				if err != nil || len(result.ManualActions) != 1 {
+					t.Fatalf("result=%#v error=%v, want exactly one pending action", result, err)
+				}
+				return
+			}
+			if err == nil || errors.Is(err, communitytool.ErrPiCodeGraphAdapterHealthUnavailable) {
+				t.Fatalf("result=%#v error=%v, want concrete fatal runtime error", result, err)
+			}
+		})
+	}
+}
+
 func TestSyncPlanAlwaysIncludesPiCodeGraphReconciliationAfterComponents(t *testing.T) {
 	home := t.TempDir()
 	runtime, err := newSyncRuntime(home, model.Selection{Agents: []model.AgentID{model.AgentPi}})
@@ -435,4 +579,15 @@ func writePiInstallFixture(t *testing.T, home string) {
 	t.Helper()
 	mustWriteFile(t, filepath.Join(home, ".pi", "agent", "settings.json"), []byte(`{}`))
 	mustWriteFile(t, filepath.Join(home, ".pi", "agent", "subagents", "worker.md"), []byte("---\ntools: bash\n---\nwork\n"))
+}
+
+func installFakePiRuntime(t *testing.T, output string) {
+	t.Helper()
+	binDir := t.TempDir()
+	piPath := filepath.Join(binDir, "pi")
+	quoted := strings.ReplaceAll(output, "'", "'\"'\"'")
+	if err := os.WriteFile(piPath, []byte("#!/bin/sh\nprintf '%s' '"+quoted+"'\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 }

--- a/internal/components/communitytool/pi_codegraph.go
+++ b/internal/components/communitytool/pi_codegraph.go
@@ -38,6 +38,8 @@ var piCodeGraphEffectiveMCPProbe PiCodeGraphEffectiveMCPProbe = probePiCodeGraph
 // verification remains separate capability evidence.
 var ErrPiCodeGraphAdapterHealthUnavailable = errors.New("Pi MCP adapter health is not machine-verifiable")
 
+const piCodeGraphPendingAction = "Pi CodeGraph integration is pending: Pi 0.80.6 has no supported machine-verifiable adapter health signal. CodeGraph capability was not reported as configured."
+
 // piCodeGraphAdapterRuntimeRunner is the Pi subprocess boundary. It captures
 // combined stdout/stderr so exit status alone cannot be mistaken for adapter
 // health.
@@ -98,6 +100,40 @@ type PiCodeGraphMCPProbeResult struct {
 	AdapterAvailable bool
 	Initialized      bool
 	Tools            []PiCodeGraphMCPTool
+}
+
+// PreservePiCodeGraphPending converts only unavailable adapter-health evidence
+// into the manual action used while Pi has no verifiable health signal.
+func PreservePiCodeGraphPending(result PiCodeGraphResult, err error) (PiCodeGraphResult, error) {
+	if !isExclusivePiCodeGraphPending(err) {
+		return result, err
+	}
+	if !slices.Contains(result.ManualActions, piCodeGraphPendingAction) {
+		result.ManualActions = append(result.ManualActions, piCodeGraphPendingAction)
+	}
+	return result, nil
+}
+
+func isExclusivePiCodeGraphPending(err error) bool {
+	if err == ErrPiCodeGraphAdapterHealthUnavailable {
+		return true
+	}
+	if joined, ok := err.(interface{ Unwrap() []error }); ok {
+		children := joined.Unwrap()
+		if len(children) == 0 {
+			return false
+		}
+		for _, child := range children {
+			if !isExclusivePiCodeGraphPending(child) {
+				return false
+			}
+		}
+		return true
+	}
+	if wrapped, ok := err.(interface{ Unwrap() error }); ok {
+		return isExclusivePiCodeGraphPending(wrapped.Unwrap())
+	}
+	return false
 }
 
 // PiCodeGraphEffectiveMCPProbe initializes the configured MCP server through
@@ -545,6 +581,11 @@ func validatePiCodeGraphAdapterRuntimeOutput(output []byte) error {
 		"adapter load error",
 		"error loading mcp",
 		"mcp adapter error",
+		"not ready",
+		"not running",
+		"unloaded",
+		"inactive",
+		"broken",
 		"not connected",
 		"disconnected",
 	}

--- a/internal/components/communitytool/tool.go
+++ b/internal/components/communitytool/tool.go
@@ -1,7 +1,6 @@
 package communitytool
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -199,9 +198,7 @@ func reconcileDetectedPiCodeGraph(homeDir, workspaceDir string) (*PiCodeGraphRes
 		return nil, err
 	}
 	result, err := ReconcilePiCodeGraph(PiCodeGraphOptions{HomeDir: homeDir, WorkspaceDir: workspaceDir, Selected: true})
-	if errors.Is(err, ErrPiCodeGraphAdapterHealthUnavailable) {
-		return &PiCodeGraphResult{ManualActions: []string{"Pi CodeGraph integration is pending: Pi 0.80.6 has no supported machine-verifiable adapter health signal. CodeGraph capability was not reported as configured."}}, nil
-	}
+	result, err = PreservePiCodeGraphPending(result, err)
 	return &result, err
 }
 


### PR DESCRIPTION
## Linked Issue

Closes #1107

## PR Type

- [x] type:bug - Bug fix

## Summary

- Preserve Pi CodeGraph onboarding as pending when the MCP adapter runtime is unavailable during capability probing.
- Reconcile pending onboarding after community-tool installation.
- Add focused coverage for the deferred initialization flow.

## Changes

| File / Area | What Changed |
|-------------|-------------|
| internal/cli/run.go | Reconciles pending Pi CodeGraph onboarding after installation |
| internal/cli/run_community_tool_test.go | Covers deferred reconciliation behavior |
| internal/components/communitytool/pi_codegraph.go | Adds Pi CodeGraph pending-state handling |
| internal/components/communitytool/tool.go | Integrates pending onboarding state |

## Test Plan

- [x] Focused communitytool package tests pass
- [ ] Full go test ./... (fails in unrelated existing install/update tests due local environment and current main drift)
- [ ] E2E tests not run

## Contributor Checklist

- [x] PR is linked to an issue with status:approved
- [x] PR stays within 400 changed lines
- [x] Appropriate type label added
- [x] Focused tests pass
- [x] Documentation is not required for this fix
- [x] Commits follow Conventional Commits
- [x] Commits contain no Co-Authored-By trailers

## Notes for Reviewers

Merged on maintainer request without waiting for CodeRabbit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Pi CodeGraph installation and synchronization handling.
  * Preserved pending manual actions when adapter health cannot be verified.
  * Prevented duplicate pending actions during installation and reconciliation.
  * Improved detection of inactive, unavailable, or failed adapter runtimes.
  * Kept Pi CodeGraph reconciliation independent from other selected integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->