### PR TITLE
fix(codegraph): preserve pending Pi configuration

### DIFF
--- a/internal/components/communitytool/pi_codegraph.go
+++ b/internal/components/communitytool/pi_codegraph.go
@@ -265,11 +265,15 @@ func ReconcilePiCodeGraph(options PiCodeGraphOptions) (result PiCodeGraphResult,
 		}
 	}
 	if err = verifyPiCodeGraphWithProbe(effectiveMCPPath, result.Children, probe); err != nil {
-		return result, err
-	}
-	result.MCP, err = verifyPiMCPWithProbe(effectiveMCPPath, probe)
-	if err != nil {
-		return result, err
+		result, err = PreservePiCodeGraphPending(result, err)
+		if err != nil {
+			return result, err
+		}
+	} else {
+		result.MCP, err = verifyPiMCPWithProbe(effectiveMCPPath, probe)
+		if err != nil {
+			return result, err
+		}
 	}
 	encoded, marshalErr := json.MarshalIndent(manifest, "", "  ")
 	if marshalErr != nil {

--- a/internal/components/communitytool/pi_codegraph_test.go
+++ b/internal/components/communitytool/pi_codegraph_test.go
@@ -471,6 +471,34 @@ func TestPiCodeGraphFailureRemovesNewPackageOverlayWithoutVerificationSuccess(t 
 	}
 }
 
+func TestPiCodeGraphPendingProbePreservesConfiguredFiles(t *testing.T) {
+	home := t.TempDir()
+	mcpPath := filepath.Join(home, ".pi", "agent", "mcp.json")
+	childPath := filepath.Join(home, ".pi", "agent", "subagents", "worker.md")
+	manifestPath := filepath.Join(home, ".gentle-ai", "pi-codegraph.json")
+	writePiFile(t, childPath, "---\ntools: bash\n---\nwork\n")
+	pendingProbe := func(string) (PiCodeGraphMCPProbeResult, error) {
+		return PiCodeGraphMCPProbeResult{}, ErrPiCodeGraphAdapterHealthUnavailable
+	}
+
+	result, err := ReconcilePiCodeGraph(PiCodeGraphOptions{HomeDir: home, Selected: true, EffectiveMCPProbe: pendingProbe})
+	if err != nil {
+		t.Fatalf("ReconcilePiCodeGraph() error = %v, want pending success", err)
+	}
+	if len(result.ManualActions) != 1 || !strings.Contains(result.ManualActions[0], "pending") {
+		t.Fatalf("ManualActions = %#v, want one pending action", result.ManualActions)
+	}
+	if got := string(mustReadPiFile(t, mcpPath)); !strings.Contains(got, `"codegraph"`) {
+		t.Fatalf("pending MCP config = %s, want preserved CodeGraph server", got)
+	}
+	if got := string(mustReadPiFile(t, childPath)); !strings.Contains(got, piCodeGraphGuidanceMarker) {
+		t.Fatalf("pending child = %q, want preserved CodeGraph guidance", got)
+	}
+	if _, err := os.Stat(manifestPath); err != nil {
+		t.Fatalf("pending manifest was not persisted: %v", err)
+	}
+}
+
 func TestPiCodeGraphUninstallRollsBackWhenManifestRemovalFails(t *testing.T) {
 	home := t.TempDir()
 	mcpPath := filepath.Join(home, ".pi", "agent", "mcp.json")


### PR DESCRIPTION
## Linked Issue

Closes #1107

## PR Type

- [x] type:bug - Bug fix

## Summary

- Preserve the Pi CodeGraph MCP configuration when adapter health cannot be machine-verified.
- Keep concrete reconciliation and rollback failures fatal.
- Add filesystem coverage for MCP config, child guidance, and manifest persistence.

## Changes

| File / Area | What Changed |
|-------------|-------------|
| internal/components/communitytool/pi_codegraph.go | Commits pending reconciliation instead of rolling it back |
| internal/components/communitytool/pi_codegraph_test.go | Proves pending configuration files persist |

## Test Plan

- [x] go test ./internal/components/communitytool
- [x] Focused pending and rollback tests
- [x] go vet ./internal/components/communitytool ./internal/cli
- [ ] go test ./internal/cli (unrelated existing environment/install failures)

## Contributor Checklist

- [x] PR is linked to an issue with status:approved
- [x] PR stays within 400 changed lines
- [x] Appropriate type label added
- [x] Focused tests pass
- [x] Documentation is not required
- [x] Commits follow Conventional Commits
- [x] Commits contain no Co-Authored-By trailers

## Notes for Reviewers

Follow-up to #1125: the initial fix made unavailable adapter health non-fatal after reconciliation had already rolled back. This moves pending classification inside the transaction so the expected MCP configuration persists.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when CodeGraph health cannot be verified.
  * Preserved configured CodeGraph integration files and settings while the integration remains pending.
  * Added a manual action indicating that verification is still pending instead of reporting an immediate failure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->