### PR TITLE
fix(sdd): grant CodeGraph tools to native subagents

### DIFF
--- a/internal/components/sdd/inject.go
+++ b/internal/components/sdd/inject.go
@@ -703,6 +703,7 @@ func Inject(homeDir string, adapter agents.Adapter, sddMode model.SDDModeID, opt
 			}
 
 			if isMarkdownSubAgentPromptFile(entry.Name()) {
+				contentStr = injectCodeGraphToolGrantIntoPrompt(contentStr, adapter.Agent(), opts.CodeGraphGuidanceMarkdown)
 				contentStr = injectCodeGraphGuidanceIntoPrompt(contentStr, opts.CodeGraphGuidanceMarkdown)
 			}
 			outPath := filepath.Join(agentsDir, entry.Name())

--- a/internal/components/sdd/prompts.go
+++ b/internal/components/sdd/prompts.go
@@ -6,6 +6,12 @@ import (
 
 	"github.com/gentleman-programming/gentle-ai/internal/assets"
 	"github.com/gentleman-programming/gentle-ai/internal/components/filemerge"
+	"github.com/gentleman-programming/gentle-ai/internal/model"
+)
+
+const (
+	claudeCodeGraphToolGrant = "mcp__codegraph__codegraph_explore"
+	kiroCodeGraphToolGrant   = "@codegraph"
 )
 
 // readSkillContent reads the embedded skill content for the given phase.
@@ -92,6 +98,45 @@ func injectCodeGraphGuidanceIntoPrompt(prompt, guidance string) string {
 		return prompt
 	}
 	return filemerge.InjectMarkdownSection(prompt, "codegraph-guidance", guidance)
+}
+
+func injectCodeGraphToolGrantIntoPrompt(prompt string, agentID model.AgentID, guidance string) string {
+	if strings.TrimSpace(guidance) == "" {
+		return prompt
+	}
+
+	grant := ""
+	switch agentID {
+	case model.AgentClaudeCode:
+		grant = claudeCodeGraphToolGrant
+	case model.AgentKiroIDE:
+		grant = kiroCodeGraphToolGrant
+	default:
+		return prompt
+	}
+
+	frontmatterEnd := strings.Index(prompt, "\n---\n")
+	if frontmatterEnd < 0 {
+		return prompt
+	}
+	lines := strings.Split(prompt[:frontmatterEnd], "\n")
+	for i, line := range lines {
+		if !strings.HasPrefix(line, "tools:") {
+			continue
+		}
+		if strings.Contains(line, grant) {
+			return prompt
+		}
+		if agentID == model.AgentClaudeCode {
+			lines[i] = line + ", " + grant
+		} else if strings.HasSuffix(line, "]") {
+			lines[i] = strings.TrimSuffix(line, "]") + `, "` + grant + `"]`
+		} else {
+			return prompt
+		}
+		return strings.Join(lines, "\n") + prompt[frontmatterEnd:]
+	}
+	return prompt
 }
 
 func isMarkdownSubAgentPromptFile(fileName string) bool {

--- a/internal/components/sdd/prompts_test.go
+++ b/internal/components/sdd/prompts_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gentleman-programming/gentle-ai/internal/agents"
+	"github.com/gentleman-programming/gentle-ai/internal/assets"
 	"github.com/gentleman-programming/gentle-ai/internal/components/communitytool"
 	"github.com/gentleman-programming/gentle-ai/internal/model"
 )
@@ -76,12 +78,34 @@ func sddReviewSubAgentsForCodeGraphTest() []string {
 	}
 }
 
-func nativeMarkdownSubAgentsForCodeGraphTest(agentID model.AgentID) []string {
-	agents := sddInstalledSubAgentsForCodeGraphTest()
-	if agentID == model.AgentCursor || agentID == model.AgentKimi {
-		return withoutStrings(agents, sddJudgmentDaySubAgentsForCodeGraphTest()...)
+func nativeMarkdownSubAgentFilesForCodeGraphTest(t *testing.T, adapter agents.Adapter) []string {
+	t.Helper()
+	entries, err := assets.FS.ReadDir(adapter.EmbeddedSubAgentsDir())
+	if err != nil {
+		t.Fatalf("ReadDir(%q) error = %v", adapter.EmbeddedSubAgentsDir(), err)
 	}
-	return agents
+	files := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if !entry.IsDir() && isMarkdownSubAgentPromptFile(entry.Name()) {
+			files = append(files, entry.Name())
+		}
+	}
+	return files
+}
+
+func nativeToolsLineForCodeGraphTest(t *testing.T, content string) string {
+	t.Helper()
+	end := strings.Index(content, "\n---\n")
+	if !strings.HasPrefix(content, "---\n") || end < 0 {
+		t.Fatal("native prompt missing frontmatter")
+	}
+	for _, line := range strings.Split(content[:end], "\n") {
+		if strings.HasPrefix(line, "tools:") {
+			return line
+		}
+	}
+	t.Fatal("native prompt missing tools line")
+	return ""
 }
 
 func kimiYAMLSubagentFilesForCodeGraphTest() []string {
@@ -462,12 +486,13 @@ func TestInjectOpenCodeMultiModeSubagentPromptFilesIncludeCodeGraphGuidanceWhenE
 
 func TestInjectNativeSDDSubagentsIncludeCodeGraphGuidanceWhenEnabled(t *testing.T) {
 	tests := []struct {
-		name    string
-		agentID model.AgentID
+		name      string
+		agentID   model.AgentID
+		toolGrant string
 	}{
-		{name: "claude", agentID: model.AgentClaudeCode},
+		{name: "claude", agentID: model.AgentClaudeCode, toolGrant: claudeCodeGraphToolGrant},
 		{name: "cursor", agentID: model.AgentCursor},
-		{name: "kiro", agentID: model.AgentKiroIDE},
+		{name: "kiro", agentID: model.AgentKiroIDE, toolGrant: kiroCodeGraphToolGrant},
 		{name: "kimi", agentID: model.AgentKimi},
 	}
 
@@ -475,48 +500,101 @@ func TestInjectNativeSDDSubagentsIncludeCodeGraphGuidanceWhenEnabled(t *testing.
 		t.Run(tc.name, func(t *testing.T) {
 			home := t.TempDir()
 			adapter := mustAdapter(t, tc.agentID)
+			guidance := communitytool.CodeGraphGuidanceMarkdown()
 
-			if _, err := Inject(home, adapter, model.SDDModeSingle, InjectOptions{CodeGraphGuidanceMarkdown: communitytool.CodeGraphGuidanceMarkdown()}); err != nil {
+			if _, err := Inject(home, adapter, model.SDDModeSingle, InjectOptions{CodeGraphGuidanceMarkdown: guidance}); err != nil {
 				t.Fatalf("Inject(%s) error = %v", tc.name, err)
 			}
 
-			for _, agentName := range nativeMarkdownSubAgentsForCodeGraphTest(tc.agentID) {
-				path := filepath.Join(adapter.SubAgentsDir(home), agentName+".md")
+			foundRefuter := false
+			for _, fileName := range nativeMarkdownSubAgentFilesForCodeGraphTest(t, adapter) {
+				foundRefuter = foundRefuter || fileName == "review-refuter.md"
+				path := filepath.Join(adapter.SubAgentsDir(home), fileName)
 				content, err := os.ReadFile(path)
 				if err != nil {
 					t.Fatalf("ReadFile(%q) error = %v", path, err)
 				}
 				text := string(content)
-				if !strings.Contains(text, "<!-- gentle-ai:codegraph-guidance -->") || !strings.Contains(text, "gentle-ai codegraph init --cwd <project-root>") {
-					t.Fatalf("%s native subagent missing CodeGraph guidance when enabled", agentName)
+				if count := strings.Count(text, "<!-- gentle-ai:codegraph-guidance -->"); count != 1 {
+					t.Fatalf("%s guidance count = %d, want 1", fileName, count)
+				}
+
+				source := renderBoundedReviewAsset(adapter.EmbeddedSubAgentsDir() + "/" + fileName)
+				if tc.toolGrant != "" {
+					sourceTools := nativeToolsLineForCodeGraphTest(t, source)
+					wantTools := sourceTools + ", " + tc.toolGrant
+					if tc.agentID == model.AgentKiroIDE {
+						wantTools = strings.TrimSuffix(sourceTools, "]") + `, "` + tc.toolGrant + `"]`
+					}
+					if got := nativeToolsLineForCodeGraphTest(t, text); got != wantTools {
+						t.Fatalf("%s tools = %q, want %q", fileName, got, wantTools)
+					}
+				}
+				for _, grant := range []string{claudeCodeGraphToolGrant, kiroCodeGraphToolGrant} {
+					wantCount := 0
+					if grant == tc.toolGrant {
+						wantCount = 1
+					}
+					if count := strings.Count(text, grant); count != wantCount {
+						t.Fatalf("%s grant %q count = %d, want %d", fileName, grant, count, wantCount)
+					}
+				}
+				if strings.Count(text, "Bash") != strings.Count(source, "Bash") {
+					t.Fatalf("%s CodeGraph grant changed Bash count", fileName)
+				}
+			}
+			if !foundRefuter {
+				t.Fatal("dynamic native asset coverage missing review-refuter.md")
+			}
+
+			second, err := Inject(home, adapter, model.SDDModeSingle, InjectOptions{CodeGraphGuidanceMarkdown: guidance})
+			if err != nil {
+				t.Fatalf("Inject(%s) second error = %v", tc.name, err)
+			}
+			if second.Changed {
+				t.Fatalf("Inject(%s) second changed = true, want idempotent output", tc.name)
+			}
+		})
+	}
+}
+
+func TestInjectNativeSDDSubagentsOmitCodeGraphGuidanceByDefault(t *testing.T) {
+	for _, agentID := range []model.AgentID{model.AgentClaudeCode, model.AgentKiroIDE} {
+		t.Run(string(agentID), func(t *testing.T) {
+			home := t.TempDir()
+			adapter := mustAdapter(t, agentID)
+			if _, err := Inject(home, adapter, model.SDDModeSingle); err != nil {
+				t.Fatalf("Inject(%s) error = %v", agentID, err)
+			}
+
+			for _, fileName := range nativeMarkdownSubAgentFilesForCodeGraphTest(t, adapter) {
+				path := filepath.Join(adapter.SubAgentsDir(home), fileName)
+				content, err := os.ReadFile(path)
+				if err != nil {
+					t.Fatalf("ReadFile(%q) error = %v", path, err)
+				}
+				text := string(content)
+				if strings.Contains(text, "<!-- gentle-ai:codegraph-guidance -->") || strings.Contains(text, "gentle-ai codegraph init --cwd <project-root>") {
+					t.Fatalf("%s native subagent unexpectedly contains CodeGraph guidance by default", fileName)
+				}
+				for _, grant := range []string{claudeCodeGraphToolGrant, kiroCodeGraphToolGrant} {
+					if strings.Contains(text, grant) {
+						t.Fatalf("%s native subagent unexpectedly grants %q by default", fileName, grant)
+					}
 				}
 			}
 		})
 	}
 
-	for _, agentName := range []string{"jd-judge-a", "review-risk"} {
-		if !containsString(nativeMarkdownSubAgentsForCodeGraphTest(model.AgentClaudeCode), agentName) {
-			t.Fatalf("native coverage helper missing %s", agentName)
-		}
-	}
-}
-
-func TestInjectNativeSDDSubagentsOmitCodeGraphGuidanceByDefault(t *testing.T) {
-	home := t.TempDir()
-
-	if _, err := Inject(home, claudeAdapter(), model.SDDModeSingle); err != nil {
-		t.Fatalf("Inject(claude) error = %v", err)
-	}
-
-	for _, agentName := range nativeMarkdownSubAgentsForCodeGraphTest(model.AgentClaudeCode) {
-		path := filepath.Join(home, ".claude", "agents", agentName+".md")
-		content, err := os.ReadFile(path)
-		if err != nil {
-			t.Fatalf("ReadFile(%q) error = %v", path, err)
-		}
-		text := string(content)
-		if strings.Contains(text, "<!-- gentle-ai:codegraph-guidance -->") || strings.Contains(text, "gentle-ai codegraph init --cwd <project-root>") {
-			t.Fatalf("%s native subagent unexpectedly contains CodeGraph guidance by default", agentName)
+	for _, tc := range []struct {
+		agentID model.AgentID
+		prompt  string
+	}{
+		{agentID: model.AgentClaudeCode, prompt: "---\ntools: Read, Grep\n---\nBody\n"},
+		{agentID: model.AgentKiroIDE, prompt: "---\ntools: [\"read\"]\n---\nBody\n"},
+	} {
+		if got := injectCodeGraphToolGrantIntoPrompt(tc.prompt, tc.agentID, ""); got != tc.prompt {
+			t.Fatalf("disabled %s grant changed prompt bytes: got %q, want %q", tc.agentID, got, tc.prompt)
 		}
 	}
 }


### PR DESCRIPTION
## Linked Issue

Closes #1096

## PR Type

- [x] `type:bug` - Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` - New feature (non-breaking change that adds functionality)
- [ ] `type:docs` - Documentation only
- [ ] `type:refactor` - Code refactoring (no functional changes)
- [ ] `type:chore` - Build, CI, or tooling changes
- [ ] `type:breaking-change` - Breaking change (fix or feature that changes existing behavior)

## Summary

- Grant Claude Code and Kiro native Markdown subagents the CodeGraph tool whenever CodeGraph guidance is enabled.
- Preserve each adapter's frontmatter format, existing tool grants, and default-disabled output.
- Cover every embedded native Markdown subagent dynamically, including idempotence and Kimi control-file boundaries.

## Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/components/sdd/inject.go` | Inject the adapter-specific CodeGraph grant before the guidance block. |
| `internal/components/sdd/prompts.go` | Add narrow Claude CSV and Kiro array frontmatter grant handling. |
| `internal/components/sdd/prompts_test.go` | Add dynamic all-native-subagent regression coverage and disabled/idempotence checks. |

## Test Plan

**Unit Tests**

```bash
env -u GENTLE_AI_CHANNEL PATH=/tmp/opencode/issue-1096-hermetic-bin:/home/linuxbrew/.linuxbrew/bin:/usr/bin:/bin GOPROXY=off GOSUMDB=off go test ./... -count=1
```

**E2E Tests**

```bash
cd e2e && ./docker-test.sh
```

- [x] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Manually tested locally

E2E was attempted but could not run because Docker is not installed on this host (`docker: No such file or directory`). CI remains the authoritative E2E run.

## Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Documentation is not required for this internal capability fix
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers

## Notes for Reviewers

The E2E checkbox is intentionally left open because Docker is unavailable locally. The focused SDD suite and the full hermetic offline Go suite both pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Enhanced native sub-agent prompts with the appropriate CodeGraph tool access and guidance.
  - Preserved existing tool permissions while ensuring prompt formatting remains compatible across supported agents.
  - Prevented duplicate CodeGraph guidance or permissions when prompts are processed more than once.

- **Quality**
  - Added broader validation to ensure generated prompts consistently include the expected guidance and tool configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->