### PR TITLE
feat: add support for Freebuff agent

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -294,7 +294,7 @@ The full delegation decision table lives in `~/.hermes/skills/hermes-ephemeral-d
 
 ### Freebuff
 
-- **Detection**: gentle-ai detects Freebuff from the `freebuff` binary on `PATH` and its config root at `~/.agents`.
+- **Detection**: gentle-ai checks for the `freebuff` binary on `PATH` and the config root at `~/.agents` independently.
 - **Install**: `npm install -g freebuff` — auto-install is supported (`--auto-install` flag). On Linux with system-owned npm prefix, `sudo` is prepended automatically.
 - **Config path**: `~/.agents/` (shared with Codebuff; Freebuff reads from this directory)
 - **System prompt**: SDD orchestrator and persona are written to `~/knowledge.md` (read first by Freebuff, before `AGENTS.md` and `CLAUDE.md`) via markdown section markers (`<!-- gentle-ai:sdd-orchestrator -->`, `<!-- gentle-ai:persona -->`).

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -24,6 +24,7 @@
 | Trae            | `trae-ide`       | Yes          | Yes | Solo-agent                       | No            | No             | `~/.trae`                           |
 | Pi              | `pi`             | Yes          | Yes | Full (package-managed subagents) | No            | Yes            | `~/.pi`                             |
 | Hermes          | `hermes`         | Yes          | Yes | Full (delegate_task ephemeral)   | No            | No             | `~/.hermes`                         |
+| Freebuff        | `freebuff`       | Yes          | Yes | Solo-agent                       | No            | No             | `~/.agents`                         |
 
 Most agents receive the **full SDD orchestrator** policy, plus skill files written to their skills directory. Most receive it through their system prompt; OpenCode and Kilo Code receive it through the OpenCode-compatible `opencode.json` agent overlay. Pi is the exception: Gentle AI installs Pi packages, and `gentle-pi` owns Pi skills, prompts, SDD agents, and chains at runtime. The agent handles SDD automatically when the task is large enough, or when the user explicitly asks for it — no manual setup required.
 
@@ -39,7 +40,7 @@ Most agents receive the **full SDD orchestrator** policy, plus skill files writt
 | --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
 | **Full (sub-agents)** | Each SDD phase runs in an isolated context window via native sub-agent delegation, package-managed subagents, or an OpenCode-compatible overlay. The orchestrator coordinates; sub-agents execute. | Claude Code, OpenCode, Kilo Code, Gemini CLI, Cursor, VS Code Copilot, Kimi Code, Kiro IDE, Qwen Code, Pi |
 | **Full (delegate_task)** | The orchestrator uses Hermes's native `delegate_task` primitive to spawn ephemeral workers in fresh context windows. Workers receive only a self-contained mission; the parent receives only their final summary. Toolsets, MCP, and skills must be passed explicitly (not inherited by default). | Hermes |
-| **Solo-agent**        | All SDD phases run inline in the same conversation. The orchestrator IS the executor. Engram provides cross-phase persistence.                                                                     | Codex, Windsurf, Antigravity, OpenClaw, Trae                                                              |
+| **Solo-agent**        | All SDD phases run inline in the same conversation. The orchestrator IS the executor. Engram provides cross-phase persistence.                                                                     | Codex, Windsurf, Antigravity, OpenClaw, Trae, Freebuff                                                    |
 
 ### Cursor Native Subagents
 
@@ -74,11 +75,11 @@ Kiro uses native custom agents in `~/.kiro/agents/`. `gentle-ai` writes phase ag
 
 ## SDD Mode Support
 
-| Feature          | Claude Code | OpenCode | Kilo Code | Gemini CLI | Cursor | VS Code Copilot | Codex | Windsurf | Antigravity | Kiro IDE | Qwen Code | OpenClaw | Trae |   Pi    | Hermes |
-| ---------------- | :---------: | :------: | :-------: | :--------: | :----: | :-------------: | :---: | :------: | :---------: | :------: | :-------: | :------: | :--: | :-----: | :----: |
-| SDD orchestrator |     Yes     |   Yes    |    Yes    |    Yes     |  Yes   |       Yes       |  Yes  |   Yes    |     Yes     |   Yes    |    Yes    |   Yes    | Yes  |   Yes   |  Yes   |
-| Single-mode SDD  |     Yes     |   Yes    |    Yes    |    Yes     |  Yes   |       Yes       |  Yes  |   Yes    |     Yes     |   Yes    |    Yes    |   Yes    | Yes  |   Yes   |  Yes   |
-| Multi-mode SDD   |      —      |   Yes    |    Yes    |     —      |   —    |        —        |   —   |    —     |      —      |  Yes\*   |     —     |    —     |  —   | Yes\*\* |   —    |
+| Feature          | Claude Code | OpenCode | Kilo Code | Gemini CLI | Cursor | VS Code Copilot | Codex | Windsurf | Antigravity | Kiro IDE | Qwen Code | OpenClaw | Trae |   Pi    | Hermes | Freebuff |
+| ---------------- | :---------: | :------: | :-------: | :--------: | :----: | :-------------: | :---: | :------: | :---------: | :------: | :-------: | :------: | :--: | :-----: | :----: | :------: |
+| SDD orchestrator |     Yes     |   Yes    |    Yes    |    Yes     |  Yes   |       Yes       |  Yes  |   Yes    |     Yes     |   Yes    |    Yes    |   Yes    | Yes  |   Yes   |  Yes   |   Yes    |
+| Single-mode SDD  |     Yes     |   Yes    |    Yes    |    Yes     |  Yes   |       Yes       |  Yes  |   Yes    |     Yes     |   Yes    |    Yes    |   Yes    | Yes  |   Yes   |  Yes   |   Yes    |
+| Multi-mode SDD   |      —      |   Yes    |    Yes    |     —      |   —    |        —        |   —   |    —     |      —      |  Yes\*   |     —     |    —     |  —   | Yes\*\* |   —    |    —     |
 
 **Multi-mode** (assigning different AI models to each SDD phase) is supported by **OpenCode** and **Kilo Code** through the OpenCode-compatible multi-mode overlay, and by **Kiro IDE** through native subagent `model:` frontmatter. All other agents run in **single-mode** — the orchestrator manages everything using whatever model the agent is already running.
 
@@ -290,3 +291,14 @@ The full delegation decision table lives in `~/.hermes/skills/hermes-ephemeral-d
 - **Profiles**: Hermes does not support multi-mode SDD (no per-phase model routing). Single-mode only.
 - **Memory**: Hermes has a native memory and skill-learning loop. Engram complements it — Engram provides cross-agent, cross-session memory protocol so knowledge is portable across all agents, not just Hermes.
 - **Persona markers and identity behavior**: The `<!-- gentle-ai:persona -->` / `<!-- /gentle-ai:persona -->` markers in `SOUL.md` tell gentle-ai which section it manages — they delimit where the persona content is written and updated on sync. The markers alone do NOT guarantee that Hermes answers identity questions ("who are you?", "quién eres?") as Gentle AI. That guarantee comes from the explicit `## Identity` section inside the managed persona content, which instructs Hermes to identify itself as **Gentle AI running on Hermes Agent** in any language. If the user has written a manual `## Identity` section OUTSIDE the managed markers, it is preserved by gentle-ai but may conflict with the managed identity instruction — the managed block is what gentle-ai guarantees, and any manual identity section outside the markers may need cleanup to avoid contradiction.
+
+### Freebuff
+
+- **Detection**: gentle-ai detects Freebuff from the `freebuff` binary on `PATH` and its config root at `~/.agents`.
+- **Install**: `npm install -g freebuff` — auto-install is supported (`--auto-install` flag). On Linux with system-owned npm prefix, `sudo` is prepended automatically.
+- **Config path**: `~/.agents/` (shared with Codebuff; Freebuff reads from this directory)
+- **System prompt**: SDD orchestrator and persona are written to `~/knowledge.md` (read first by Freebuff, before `AGENTS.md` and `CLAUDE.md`) via markdown section markers (`<!-- gentle-ai:sdd-orchestrator -->`, `<!-- gentle-ai:persona -->`).
+- **MCP config**: `~/.agents/mcp.json` — written as a standalone JSON file with a top-level `mcpServers` object (`StrategyMCPConfigFile`).
+- **Skills**: `~/.agents/skills/` — gentle-ai writes SDD phase skills here.
+- **Delegation**: Solo-agent — all SDD phases run inline in the same conversation. Engram provides cross-phase persistence.
+- **Multi-mode SDD**: Not supported — single-mode only.

--- a/internal/agents/factory.go
+++ b/internal/agents/factory.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gentleman-programming/gentle-ai/internal/agents/claude"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/codex"
 	cursoradapter "github.com/gentleman-programming/gentle-ai/internal/agents/cursor"
+	"github.com/gentleman-programming/gentle-ai/internal/agents/freebuff"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/gemini"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/hermes"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/kilocode"
@@ -39,6 +40,7 @@ var defaultAgentIDs = []model.AgentID{
 	model.AgentPi,
 	model.AgentTrae,
 	model.AgentHermes,
+	model.AgentFreebuff,
 }
 
 func NewAdapter(agent model.AgentID) (Adapter, error) {
@@ -75,6 +77,8 @@ func NewAdapter(agent model.AgentID) (Adapter, error) {
 		return trae.NewAdapter(), nil
 	case model.AgentHermes:
 		return hermes.NewAdapter(), nil
+	case model.AgentFreebuff:
+		return freebuff.NewAdapter(), nil
 	default:
 		return nil, AgentNotSupportedError{Agent: agent}
 	}

--- a/internal/agents/factory_test.go
+++ b/internal/agents/factory_test.go
@@ -73,6 +73,7 @@ func TestDefaultRegistrySupportedAgentsMatchesFactoryAgents(t *testing.T) {
 		model.AgentClaudeCode,
 		model.AgentCodex,
 		model.AgentCursor,
+		model.AgentFreebuff,
 		model.AgentGeminiCLI,
 		model.AgentHermes,
 		model.AgentKilocode,
@@ -127,5 +128,32 @@ func TestFactoryRejectsUnsupportedOpenClawLookalike(t *testing.T) {
 
 	if !errors.Is(err, ErrAgentNotSupported) {
 		t.Fatalf("NewAdapter() error = %v, want ErrAgentNotSupported", err)
+	}
+}
+
+func TestFactoryResolvesFreebuffAdapter(t *testing.T) {
+	adapter, err := NewAdapter(model.AgentFreebuff)
+	if err != nil {
+		t.Fatalf("NewAdapter(%q) returned error: %v", model.AgentFreebuff, err)
+	}
+
+	if got := adapter.Agent(); got != model.AgentFreebuff {
+		t.Fatalf("adapter.Agent() = %q, want %q", got, model.AgentFreebuff)
+	}
+}
+
+func TestDefaultRegistryIncludesFreebuff(t *testing.T) {
+	registry, err := NewDefaultRegistry()
+	if err != nil {
+		t.Fatalf("NewDefaultRegistry() returned error: %v", err)
+	}
+
+	adapter, ok := registry.Get(model.AgentFreebuff)
+	if !ok {
+		t.Fatalf("registry missing %s adapter", model.AgentFreebuff)
+	}
+
+	if got := adapter.Agent(); got != model.AgentFreebuff {
+		t.Fatalf("registry adapter.Agent() = %q, want %q", got, model.AgentFreebuff)
 	}
 }

--- a/internal/agents/freebuff/adapter.go
+++ b/internal/agents/freebuff/adapter.go
@@ -1,0 +1,175 @@
+package freebuff
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/gentleman-programming/gentle-ai/internal/model"
+	"github.com/gentleman-programming/gentle-ai/internal/system"
+)
+
+var LookPathOverride = exec.LookPath
+
+type statResult struct {
+	isDir bool
+	err   error
+}
+
+type Adapter struct {
+	lookPath func(string) (string, error)
+	statPath func(string) statResult
+}
+
+func NewAdapter() *Adapter {
+	return &Adapter{
+		lookPath: LookPathOverride,
+		statPath: defaultStat,
+	}
+}
+
+// --- Identity ---
+
+func (a *Adapter) Agent() model.AgentID {
+	return model.AgentFreebuff
+}
+
+func (a *Adapter) Tier() model.SupportTier {
+	return model.TierFull
+}
+
+// --- Detection ---
+
+func (a *Adapter) Detect(_ context.Context, homeDir string) (bool, string, string, bool, error) {
+	configPath := ConfigPath(homeDir)
+
+	binaryPath, err := a.lookPath("freebuff")
+	installed := err == nil
+
+	stat := a.statPath(configPath)
+	if stat.err != nil {
+		if os.IsNotExist(stat.err) {
+			return installed, binaryPath, configPath, false, nil
+		}
+		return false, "", "", false, stat.err
+	}
+
+	return installed, binaryPath, configPath, stat.isDir, nil
+}
+
+// --- Installation ---
+
+func (a *Adapter) SupportsAutoInstall() bool {
+	return true
+}
+
+func (a *Adapter) InstallCommand(_ system.PlatformProfile) ([][]string, error) {
+	return [][]string{{"npm", "install", "-g", "freebuff"}}, nil
+}
+
+// --- Config paths ---
+
+func (a *Adapter) GlobalConfigDir(homeDir string) string {
+	return ConfigPath(homeDir)
+}
+
+func (a *Adapter) SystemPromptDir(homeDir string) string {
+	return homeDir
+}
+
+// SystemPromptFile returns the path to knowledge.md, which Freebuff reads
+// first (highest priority) before AGENTS.md and CLAUDE.md.
+func (a *Adapter) SystemPromptFile(homeDir string) string {
+	return filepath.Join(homeDir, "knowledge.md")
+}
+
+func (a *Adapter) SkillsDir(homeDir string) string {
+	return filepath.Join(ConfigPath(homeDir), "skills")
+}
+
+// SettingsPath returns empty string — Freebuff has no separate settings file.
+func (a *Adapter) SettingsPath(_ string) string {
+	return ""
+}
+
+// --- Config strategies ---
+
+func (a *Adapter) SystemPromptStrategy() model.SystemPromptStrategy {
+	return model.StrategyMarkdownSections
+}
+
+func (a *Adapter) MCPStrategy() model.MCPStrategy {
+	return model.StrategyMCPConfigFile
+}
+
+// --- MCP ---
+
+func (a *Adapter) MCPConfigPath(homeDir string, _ string) string {
+	return filepath.Join(ConfigPath(homeDir), "mcp.json")
+}
+
+// --- Optional capabilities ---
+
+func (a *Adapter) SupportsOutputStyles() bool {
+	return false
+}
+
+func (a *Adapter) OutputStyleDir(_ string) string {
+	return ""
+}
+
+func (a *Adapter) SupportsSlashCommands() bool {
+	return false
+}
+
+func (a *Adapter) CommandsDir(_ string) string {
+	return ""
+}
+
+func (a *Adapter) SupportsSubAgents() bool {
+	return false
+}
+
+func (a *Adapter) SubAgentsDir(_ string) string {
+	return ""
+}
+
+func (a *Adapter) EmbeddedSubAgentsDir() string {
+	return ""
+}
+
+func (a *Adapter) SupportsSkills() bool {
+	return true
+}
+
+func (a *Adapter) SupportsSystemPrompt() bool {
+	return true
+}
+
+func (a *Adapter) SupportsMCP() bool {
+	return true
+}
+
+func defaultStat(path string) statResult {
+	info, err := os.Stat(path)
+	if err != nil {
+		return statResult{err: err}
+	}
+
+	return statResult{isDir: info.IsDir()}
+}
+
+// ConfigPath returns the global Freebuff config directory (~/.agents).
+func ConfigPath(homeDir string) string {
+	return filepath.Join(homeDir, ".agents")
+}
+
+type AgentNotInstallableError struct {
+	Agent model.AgentID
+}
+
+func (e AgentNotInstallableError) Error() string {
+	return fmt.Sprintf("agent %q must be installed manually before Gentle AI can configure it", e.Agent)
+}

--- a/internal/agents/freebuff/adapter_test.go
+++ b/internal/agents/freebuff/adapter_test.go
@@ -1,0 +1,169 @@
+package freebuff
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/internal/model"
+	"github.com/gentleman-programming/gentle-ai/internal/system"
+)
+
+func TestAdapterIdentityAndStrategies(t *testing.T) {
+	a := NewAdapter()
+	homeDir := filepath.Join(string(filepath.Separator), "tmp", "home")
+
+	if got := a.Agent(); got != model.AgentFreebuff {
+		t.Fatalf("Agent() = %q, want %q", got, model.AgentFreebuff)
+	}
+
+	if got := a.Tier(); got != model.TierFull {
+		t.Fatalf("Tier() = %q, want %q", got, model.TierFull)
+	}
+
+	if got := a.SystemPromptStrategy(); got != model.StrategyMarkdownSections {
+		t.Fatalf("SystemPromptStrategy() = %v, want %v", got, model.StrategyMarkdownSections)
+	}
+
+	if got := a.MCPStrategy(); got != model.StrategyMCPConfigFile {
+		t.Fatalf("MCPStrategy() = %v, want %v", got, model.StrategyMCPConfigFile)
+	}
+
+	if !a.SupportsSystemPrompt() {
+		t.Fatalf("SupportsSystemPrompt() = false, want true")
+	}
+
+	if !a.SupportsMCP() {
+		t.Fatalf("SupportsMCP() = false, want true")
+	}
+
+	if a.SupportsOutputStyles() {
+		t.Fatalf("SupportsOutputStyles() = true, want false")
+	}
+
+	if got := a.SystemPromptFile(homeDir); got != filepath.Join(homeDir, "knowledge.md") {
+		t.Fatalf("SystemPromptFile() = %q, want workspace knowledge.md", got)
+	}
+
+	if got := a.OutputStyleDir(homeDir); got != "" {
+		t.Fatalf("OutputStyleDir() = %q, want empty", got)
+	}
+}
+
+func TestInstallCommand(t *testing.T) {
+	a := NewAdapter()
+
+	commands, err := a.InstallCommand(system.PlatformProfile{})
+	if err != nil {
+		t.Fatalf("InstallCommand() unexpected error: %v", err)
+	}
+	if len(commands) != 1 || commands[0][0] != "npm" || commands[0][3] != "freebuff" {
+		t.Fatalf("InstallCommand() commands = %v, want npm install -g freebuff", commands)
+	}
+}
+
+func TestAdapterConfigPaths(t *testing.T) {
+	a := NewAdapter()
+	homeDir := filepath.Join(string(filepath.Separator), "tmp", "home")
+	configDir := filepath.Join(homeDir, ".agents")
+
+	paths := map[string]string{
+		"GlobalConfigDir": a.GlobalConfigDir(homeDir),
+		"SettingsPath":    a.SettingsPath(homeDir),
+		"MCPConfigPath":   a.MCPConfigPath(homeDir, "engram"),
+		"SkillsDir":       a.SkillsDir(homeDir),
+	}
+
+	if got := paths["GlobalConfigDir"]; got != configDir {
+		t.Fatalf("GlobalConfigDir() = %q, want %q", got, configDir)
+	}
+
+	if got := paths["SettingsPath"]; got != "" {
+		t.Fatalf("SettingsPath() = %q, want empty", got)
+	}
+
+	if got := paths["MCPConfigPath"]; got != filepath.Join(configDir, "mcp.json") {
+		t.Fatalf("MCPConfigPath() = %q, want %q", got, filepath.Join(configDir, "mcp.json"))
+	}
+
+	if got := paths["SkillsDir"]; got != filepath.Join(configDir, "skills") {
+		t.Fatalf("SkillsDir() = %q, want Freebuff skills dir", got)
+	}
+}
+
+func TestDetect(t *testing.T) {
+	tests := []struct {
+		name            string
+		lookPathPath    string
+		lookPathErr     error
+		stat            statResult
+		wantInstalled   bool
+		wantBinaryPath  string
+		wantConfigFound bool
+		wantErr         bool
+	}{
+		{
+			name:            "binary and config directory found",
+			lookPathPath:    "/usr/local/bin/freebuff",
+			stat:            statResult{isDir: true},
+			wantInstalled:   true,
+			wantBinaryPath:  "/usr/local/bin/freebuff",
+			wantConfigFound: true,
+		},
+		{
+			name:            "binary missing and config missing",
+			lookPathErr:     errors.New("missing"),
+			stat:            statResult{err: os.ErrNotExist},
+			wantInstalled:   false,
+			wantBinaryPath:  "",
+			wantConfigFound: false,
+		},
+		{
+			name:    "stat error bubbles up",
+			stat:    statResult{err: errors.New("permission denied")},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := &Adapter{
+				lookPath: func(string) (string, error) {
+					return tt.lookPathPath, tt.lookPathErr
+				},
+				statPath: func(string) statResult {
+					return tt.stat
+				},
+			}
+			homeDir := filepath.Join(string(filepath.Separator), "tmp", "home")
+
+			installed, binaryPath, configPath, configFound, err := a.Detect(context.Background(), homeDir)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Detect() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if tt.wantErr {
+				return
+			}
+
+			if installed != tt.wantInstalled {
+				t.Fatalf("Detect() installed = %v, want %v", installed, tt.wantInstalled)
+			}
+
+			if binaryPath != tt.wantBinaryPath {
+				t.Fatalf("Detect() binaryPath = %q, want %q", binaryPath, tt.wantBinaryPath)
+			}
+
+			wantConfigPath := filepath.Join(homeDir, ".agents")
+			if configPath != wantConfigPath {
+				t.Fatalf("Detect() configPath = %q, want %q", configPath, wantConfigPath)
+			}
+
+			if configFound != tt.wantConfigFound {
+				t.Fatalf("Detect() configFound = %v, want %v", configFound, tt.wantConfigFound)
+			}
+		})
+	}
+}

--- a/internal/assets/skills/sdd-apply/SKILL.md
+++ b/internal/assets/skills/sdd-apply/SKILL.md
@@ -3,7 +3,7 @@
 name: sdd-apply
 description: "Implement SDD tasks from specs and design. Trigger: orchestrator launches apply for one or more change tasks."
 disable-model-invocation: true
-user-invocable: false
+user-invocable: true
 license: MIT
 metadata:
   author: gentleman-programming
@@ -278,7 +278,7 @@ If none, say "None."}
 name: sdd-apply
 description: "Implement SDD tasks from specs and design. Trigger: orchestrator launches apply for one or more change tasks."
 disable-model-invocation: true
-user-invocable: false
+user-invocable: true
 license: MIT
 metadata:
   author: gentleman-programming

--- a/internal/assets/skills/sdd-archive/SKILL.md
+++ b/internal/assets/skills/sdd-archive/SKILL.md
@@ -2,7 +2,7 @@
 name: sdd-archive
 description: "Archive a completed SDD change by syncing delta specs. Trigger: orchestrator launches archive after implementation and verification."
 disable-model-invocation: true
-user-invocable: false
+user-invocable: true
 license: MIT
 metadata:
   author: gentleman-programming

--- a/internal/assets/skills/sdd-design/SKILL.md
+++ b/internal/assets/skills/sdd-design/SKILL.md
@@ -2,7 +2,7 @@
 name: sdd-design
 description: "Create the SDD technical design and architecture approach. Trigger: orchestrator launches design for a change."
 disable-model-invocation: true
-user-invocable: false
+user-invocable: true
 license: MIT
 metadata:
   author: gentleman-programming

--- a/internal/assets/skills/sdd-explore/SKILL.md
+++ b/internal/assets/skills/sdd-explore/SKILL.md
@@ -2,7 +2,7 @@
 name: sdd-explore
 description: "Explore SDD ideas before committing to a change. Trigger: orchestrator launches exploration or requirement clarification."
 disable-model-invocation: true
-user-invocable: false
+user-invocable: true
 license: MIT
 metadata:
   author: gentleman-programming

--- a/internal/assets/skills/sdd-init/SKILL.md
+++ b/internal/assets/skills/sdd-init/SKILL.md
@@ -2,7 +2,7 @@
 name: sdd-init
 description: "Trigger: sdd init, iniciar sdd, openspec init. Initialize SDD context, testing capabilities, registry, and persistence."
 disable-model-invocation: true
-user-invocable: false
+user-invocable: true
 license: MIT
 metadata:
   author: gentleman-programming

--- a/internal/assets/skills/sdd-onboard/SKILL.md
+++ b/internal/assets/skills/sdd-onboard/SKILL.md
@@ -2,7 +2,7 @@
 name: sdd-onboard
 description: "Walk users through the SDD workflow on the real codebase. Trigger: orchestrator launches onboarding for the full SDD cycle."
 disable-model-invocation: true
-user-invocable: false
+user-invocable: true
 license: MIT
 metadata:
   author: gentleman-programming

--- a/internal/assets/skills/sdd-propose/SKILL.md
+++ b/internal/assets/skills/sdd-propose/SKILL.md
@@ -2,7 +2,7 @@
 name: sdd-propose
 description: "Create an SDD change proposal with intent, scope, and approach. Trigger: orchestrator launches proposal work for a change."
 disable-model-invocation: true
-user-invocable: false
+user-invocable: true
 license: MIT
 metadata:
   author: gentleman-programming

--- a/internal/assets/skills/sdd-spec/SKILL.md
+++ b/internal/assets/skills/sdd-spec/SKILL.md
@@ -2,7 +2,7 @@
 name: sdd-spec
 description: "Write SDD delta specs with requirements and scenarios. Trigger: orchestrator launches spec work for a change."
 disable-model-invocation: true
-user-invocable: false
+user-invocable: true
 license: MIT
 metadata:
   author: gentleman-programming

--- a/internal/assets/skills/sdd-tasks/SKILL.md
+++ b/internal/assets/skills/sdd-tasks/SKILL.md
@@ -2,7 +2,7 @@
 name: sdd-tasks
 description: "Break an SDD change into implementation tasks. Trigger: orchestrator launches task planning for a change."
 disable-model-invocation: true
-user-invocable: false
+user-invocable: true
 license: MIT
 metadata:
   author: gentleman-programming

--- a/internal/assets/skills/sdd-verify/SKILL.md
+++ b/internal/assets/skills/sdd-verify/SKILL.md
@@ -3,7 +3,7 @@
 name: sdd-verify
 description: "Trigger: SDD verification phase, verify change. Execute tests and prove implementation matches specs, design, and tasks."
 disable-model-invocation: true
-user-invocable: false
+user-invocable: true
 license: MIT
 metadata:
   author: gentleman-programming
@@ -104,7 +104,7 @@ Return `## Verification Report` with change, mode, completeness table, build/tes
 name: sdd-verify
 description: "Trigger: SDD verification phase, verify change. Execute tests and prove implementation matches specs, design, and tasks."
 disable-model-invocation: true
-user-invocable: false
+user-invocable: true
 license: MIT
 metadata:
   author: gentleman-programming

--- a/internal/catalog/agents.go
+++ b/internal/catalog/agents.go
@@ -26,6 +26,7 @@ var allAgents = []Agent{
 	{ID: model.AgentPi, Name: "Pi", Tier: model.TierFull, ConfigPath: "~/.pi"},
 	{ID: model.AgentTrae, Name: "Trae IDE", Tier: model.TierFull, ConfigPath: "~/.trae"},
 	{ID: model.AgentHermes, Name: "Hermes", Tier: model.TierFull, ConfigPath: "~/.hermes"},
+	{ID: model.AgentFreebuff, Name: "Freebuff", Tier: model.TierFull, ConfigPath: "~/.agents"},
 }
 
 // mvpAgents are the original MVP agents (Claude Code, OpenCode).

--- a/internal/catalog/agents_test.go
+++ b/internal/catalog/agents_test.go
@@ -95,3 +95,35 @@ func TestIsSupportedAgentAcceptsHermes(t *testing.T) {
 		t.Fatalf("IsSupportedAgent(%q) = false, want true", model.AgentHermes)
 	}
 }
+
+func TestAllAgentsIncludesFreebuff(t *testing.T) {
+	agents := AllAgents()
+
+	for _, agent := range agents {
+		if agent.ID != model.AgentFreebuff {
+			continue
+		}
+
+		if agent.Name != "Freebuff" {
+			t.Fatalf("Freebuff Name = %q, want Freebuff", agent.Name)
+		}
+
+		if agent.Tier != model.TierFull {
+			t.Fatalf("Freebuff Tier = %q, want %q", agent.Tier, model.TierFull)
+		}
+
+		if agent.ConfigPath != "~/.agents" {
+			t.Fatalf("Freebuff ConfigPath = %q, want ~/.agents", agent.ConfigPath)
+		}
+
+		return
+	}
+
+	t.Fatalf("AllAgents() missing %s", model.AgentFreebuff)
+}
+
+func TestIsSupportedAgentAcceptsFreebuff(t *testing.T) {
+	if !IsSupportedAgent(model.AgentFreebuff) {
+		t.Fatalf("IsSupportedAgent(%q) = false, want true", model.AgentFreebuff)
+	}
+}

--- a/internal/cli/install_test.go
+++ b/internal/cli/install_test.go
@@ -321,7 +321,7 @@ func TestRunInstallDryRunSkipsExecution(t *testing.T) {
 func makeDetectionWithAgents(present ...string) system.DetectionResult {
 	var configs []system.ConfigState
 	// Full canonical agent set — mirrors knownAgentConfigDirs in config_scan.go.
-	known := []string{"claude-code", "opencode", "kilocode", "gemini-cli", "cursor", "vscode-copilot", "codex", "antigravity", "windsurf", "kimi", "qwen-code", "kiro-ide", "openclaw", "pi", "trae-ide", "hermes"}
+	known := []string{"claude-code", "opencode", "kilocode", "gemini-cli", "cursor", "vscode-copilot", "codex", "antigravity", "windsurf", "kimi", "qwen-code", "kiro-ide", "openclaw", "pi", "trae-ide", "hermes", "freebuff"}
 	presentSet := make(map[string]bool, len(present))
 	for _, p := range present {
 		presentSet[p] = true

--- a/internal/cli/install_test.go
+++ b/internal/cli/install_test.go
@@ -69,7 +69,7 @@ func TestNormalizeInstallFlagsDefaults(t *testing.T) {
 	}
 
 	want := model.Selection{
-		Agents:  []model.AgentID{model.AgentClaudeCode, model.AgentOpenCode, model.AgentKilocode, model.AgentGeminiCLI, model.AgentCodex, model.AgentCursor, model.AgentVSCodeCopilot, model.AgentAntigravity, model.AgentWindsurf, model.AgentKimi, model.AgentQwenCode, model.AgentKiroIDE, model.AgentOpenClaw, model.AgentPi, model.AgentTrae, model.AgentHermes},
+		Agents:  []model.AgentID{model.AgentClaudeCode, model.AgentOpenCode, model.AgentKilocode, model.AgentGeminiCLI, model.AgentCodex, model.AgentCursor, model.AgentVSCodeCopilot, model.AgentAntigravity, model.AgentWindsurf, model.AgentKimi, model.AgentQwenCode, model.AgentKiroIDE, model.AgentOpenClaw, model.AgentPi, model.AgentTrae, model.AgentHermes, model.AgentFreebuff},
 		Persona: model.PersonaGentleman,
 		Preset:  model.PresetFullGentleman,
 		Components: []model.ComponentID{
@@ -382,6 +382,7 @@ func TestDefaultAgentsFromDetection_AllAgentsMappedCorrectly(t *testing.T) {
 		{"pi", model.AgentPi},
 		{"trae-ide", model.AgentTrae},
 		{"hermes", model.AgentHermes},
+		{"freebuff", model.AgentFreebuff},
 	}
 
 	for _, tt := range tests {

--- a/internal/cli/run_community_tool_test.go
+++ b/internal/cli/run_community_tool_test.go
@@ -475,6 +475,12 @@ func TestInstallPipelineDoesNotDuplicatePiPendingWhenSelected(t *testing.T) {
 		installCommunityToolWithHome = previousInstall
 		reconcilePiCodeGraph = previousReconcile
 	})
+	tmpBin := t.TempDir()
+	piPath := filepath.Join(tmpBin, "pi")
+	if err := os.WriteFile(piPath, []byte("#!/bin/sh\n"), 0755); err != nil {
+		t.Fatalf("failed to write mock pi binary: %v", err)
+	}
+	t.Setenv("PATH", tmpBin+string(os.PathListSeparator)+os.Getenv("PATH"))
 	pending := communitytool.PiCodeGraphResult{ManualActions: []string{"Pi CodeGraph integration is pending: Pi 0.80.6 has no supported machine-verifiable adapter health signal. CodeGraph capability was not reported as configured."}}
 	installCommunityToolWithHome = func(_ model.CommunityToolID, _ string, _ string, _ communitytool.Runner, _ communitytool.Detector) (communitytool.Result, error) {
 		return communitytool.Result{Tool: model.CommunityToolCodeGraph, PiCodeGraph: &pending}, nil

--- a/internal/cli/validate.go
+++ b/internal/cli/validate.go
@@ -199,6 +199,8 @@ func defaultAgentsFromDetection(detection system.DetectionResult) []model.AgentI
 			agents = append(agents, model.AgentTrae)
 		case string(model.AgentHermes):
 			agents = append(agents, model.AgentHermes)
+		case string(model.AgentFreebuff):
+			agents = append(agents, model.AgentFreebuff)
 		}
 	}
 

--- a/internal/components/communitytool/tool.go
+++ b/internal/components/communitytool/tool.go
@@ -333,6 +333,7 @@ func isCodeGraphSupportedAgent(id model.AgentID) bool {
 		model.AgentClaudeCode,
 		model.AgentCodex,
 		model.AgentCursor,
+		model.AgentFreebuff,
 		model.AgentGeminiCLI,
 		model.AgentHermes,
 		model.AgentKilocode,

--- a/internal/components/sdd/bounded_review_contract_test.go
+++ b/internal/components/sdd/bounded_review_contract_test.go
@@ -46,8 +46,8 @@ var boundedReviewRequiredClauses = []string{
 
 func TestBoundedReviewContractRendersForEverySupportedAgent(t *testing.T) {
 	agents := catalog.AllAgents()
-	if len(agents) != 16 {
-		t.Fatalf("catalog.AllAgents() = %d, want 16", len(agents))
+	if len(agents) != 17 {
+		t.Fatalf("catalog.AllAgents() = %d, want 17", len(agents))
 	}
 	for _, agent := range agents {
 		t.Run(string(agent.ID), func(t *testing.T) {

--- a/internal/components/sdd/inject_test.go
+++ b/internal/components/sdd/inject_test.go
@@ -6836,6 +6836,13 @@ func TestInjectTriggerRules_AllAdapters(t *testing.T) {
 				return readFileOrEmpty(a.SystemPromptFile(home))
 			},
 		},
+		{
+			name:    "freebuff",
+			agentID: model.AgentFreebuff,
+			getContent: func(home string, a agents.Adapter) (string, error) {
+				return readFileOrEmpty(a.SystemPromptFile(home))
+			},
+		},
 	}
 
 	// Count guard: the test table must enumerate exactly as many adapters as the

--- a/internal/installcmd/resolver.go
+++ b/internal/installcmd/resolver.go
@@ -83,10 +83,11 @@ func resolveKilocodeInstall(profile system.PlatformProfile) CommandSequence {
 // resolveFreebuffInstall returns the npm install command for Freebuff.
 // On Linux with system npm (non-writable prefix), sudo is required.
 func resolveFreebuffInstall(profile system.PlatformProfile) CommandSequence {
+	pkg := "freebuff@" + versions.Freebuff
 	if profile.OS == "linux" && !profile.NpmWritable {
-		return CommandSequence{{"sudo", "npm", "install", "-g", "freebuff"}}
+		return CommandSequence{{"sudo", "npm", "install", "-g", "--ignore-scripts", pkg}}
 	}
-	return CommandSequence{{"npm", "install", "-g", "freebuff"}}
+	return CommandSequence{{"npm", "install", "-g", "--ignore-scripts", pkg}}
 }
 
 // resolveKimiInstall returns the official Kimi install command sequence.

--- a/internal/installcmd/resolver.go
+++ b/internal/installcmd/resolver.go
@@ -48,6 +48,8 @@ func (profileResolver) ResolveAgentInstall(profile system.PlatformProfile, agent
 		return resolveKilocodeInstall(profile), nil
 	case model.AgentKimi:
 		return resolveKimiInstall(profile)
+	case model.AgentFreebuff:
+		return resolveFreebuffInstall(profile), nil
 	default:
 		return nil, fmt.Errorf("install command is not supported for agent %q", agent)
 	}
@@ -76,6 +78,15 @@ func resolveKilocodeInstall(profile system.PlatformProfile) CommandSequence {
 		return CommandSequence{{"sudo", "npm", "install", "-g", "--ignore-scripts", pkg}}
 	}
 	return CommandSequence{{"npm", "install", "-g", "--ignore-scripts", pkg}}
+}
+
+// resolveFreebuffInstall returns the npm install command for Freebuff.
+// On Linux with system npm (non-writable prefix), sudo is required.
+func resolveFreebuffInstall(profile system.PlatformProfile) CommandSequence {
+	if profile.OS == "linux" && !profile.NpmWritable {
+		return CommandSequence{{"sudo", "npm", "install", "-g", "freebuff"}}
+	}
+	return CommandSequence{{"npm", "install", "-g", "freebuff"}}
 }
 
 // resolveKimiInstall returns the official Kimi install command sequence.
@@ -107,6 +118,7 @@ var npmBasedAgents = map[model.AgentID]struct{}{
 	model.AgentCodex:      {},
 	model.AgentQwenCode:   {},
 	model.AgentPi:         {},
+	model.AgentFreebuff:   {},
 }
 
 // ValidateAgentInstallPreflight validates agent-specific prerequisites that must

--- a/internal/installcmd/resolver_test.go
+++ b/internal/installcmd/resolver_test.go
@@ -390,6 +390,25 @@ func TestResolveAgentInstall(t *testing.T) {
 		},
 
 		{
+			name:    "freebuff on darwin uses npm without sudo",
+			profile: system.PlatformProfile{OS: "darwin", PackageManager: "brew"},
+			agent:   model.AgentFreebuff,
+			want:    CommandSequence{{"npm", "install", "-g", "--ignore-scripts", "freebuff@" + versions.Freebuff}},
+		},
+		{
+			name:    "freebuff on linux system npm uses sudo",
+			profile: system.PlatformProfile{OS: "linux", LinuxDistro: system.LinuxDistroUbuntu, PackageManager: "apt"},
+			agent:   model.AgentFreebuff,
+			want:    CommandSequence{{"sudo", "npm", "install", "-g", "--ignore-scripts", "freebuff@" + versions.Freebuff}},
+		},
+		{
+			name:    "freebuff on linux nvm skips sudo",
+			profile: system.PlatformProfile{OS: "linux", LinuxDistro: system.LinuxDistroUbuntu, PackageManager: "apt", NpmWritable: true},
+			agent:   model.AgentFreebuff,
+			want:    CommandSequence{{"npm", "install", "-g", "--ignore-scripts", "freebuff@" + versions.Freebuff}},
+		},
+
+		{
 			name:    "unsupported agent returns error",
 			profile: system.PlatformProfile{OS: "darwin", PackageManager: "brew"},
 			agent:   "unsupported",

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -19,6 +19,7 @@ const (
 	AgentPi            AgentID = "pi"
 	AgentTrae          AgentID = "trae-ide"
 	AgentHermes        AgentID = "hermes"
+	AgentFreebuff      AgentID = "freebuff"
 )
 
 // SupportTier indicates how fully an agent supports the Gentleman AI ecosystem.

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -3830,6 +3830,8 @@ func detectedAgentIDs(detection system.DetectionResult) []model.AgentID {
 			selected = append(selected, model.AgentPi)
 		case string(model.AgentHermes):
 			selected = append(selected, model.AgentHermes)
+		case string(model.AgentFreebuff):
+			selected = append(selected, model.AgentFreebuff)
 		}
 	}
 	return selected

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -3271,6 +3271,7 @@ func TestPreselectedAgents_AllKnownAgentsMappedCorrectly(t *testing.T) {
 		{"vscode-copilot", model.AgentVSCodeCopilot},
 		{"codex", model.AgentCodex},
 		{"hermes", model.AgentHermes},
+		{"freebuff", model.AgentFreebuff},
 	}
 
 	for _, tt := range tests {

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -2486,7 +2486,7 @@ func TestModelConfig_OpenCodePickerBackReturnsToModelConfig(t *testing.T) {
 // makeDetectionWithAgents builds a DetectionResult with the specified agents
 // marked as Exists=true. All other agents are absent.
 func makeDetectionWithAgents(present ...string) system.DetectionResult {
-	known := []string{"claude-code", "opencode", "gemini-cli", "cursor", "vscode-copilot", "codex", "antigravity", "windsurf", "qwen-code", "hermes"}
+	known := []string{"claude-code", "opencode", "gemini-cli", "cursor", "vscode-copilot", "codex", "antigravity", "windsurf", "qwen-code", "hermes", "freebuff"}
 	presentSet := make(map[string]bool, len(present))
 	for _, p := range present {
 		presentSet[p] = true

--- a/internal/versions/versions.go
+++ b/internal/versions/versions.go
@@ -24,3 +24,6 @@ const GeminiCLI = "0.41.2"
 
 // renovate: datasource=npm depName=@upstash/context7-mcp
 const Context7MCP = "2.2.5"
+
+// renovate: datasource=npm depName=freebuff
+const Freebuff = "0.0.122"

--- a/testdata/golden/engram-freebuff-mcp.golden
+++ b/testdata/golden/engram-freebuff-mcp.golden
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "engram": {
+      "args": [
+        "mcp",
+        "--tools=agent"
+      ],
+      "command": "/opt/homebrew/bin/engram"
+    }
+  }
+}

--- a/testdata/golden/sdd-antigravity-skill-sdd-init.golden
+++ b/testdata/golden/sdd-antigravity-skill-sdd-init.golden
@@ -2,7 +2,7 @@
 name: sdd-init
 description: "Trigger: sdd init, iniciar sdd, openspec init. Initialize SDD context, testing capabilities, registry, and persistence."
 disable-model-invocation: true
-user-invocable: false
+user-invocable: true
 license: MIT
 metadata:
   author: gentleman-programming

--- a/testdata/golden/sdd-codex-skill-sdd-init.golden
+++ b/testdata/golden/sdd-codex-skill-sdd-init.golden
@@ -2,7 +2,7 @@
 name: sdd-init
 description: "Trigger: sdd init, iniciar sdd, openspec init. Initialize SDD context, testing capabilities, registry, and persistence."
 disable-model-invocation: true
-user-invocable: false
+user-invocable: true
 license: MIT
 metadata:
   author: gentleman-programming

--- a/testdata/golden/sdd-cursor-skill-sdd-init.golden
+++ b/testdata/golden/sdd-cursor-skill-sdd-init.golden
@@ -2,7 +2,7 @@
 name: sdd-init
 description: "Trigger: sdd init, iniciar sdd, openspec init. Initialize SDD context, testing capabilities, registry, and persistence."
 disable-model-invocation: true
-user-invocable: false
+user-invocable: true
 license: MIT
 metadata:
   author: gentleman-programming

--- a/testdata/golden/sdd-gemini-skill-sdd-init.golden
+++ b/testdata/golden/sdd-gemini-skill-sdd-init.golden
@@ -2,7 +2,7 @@
 name: sdd-init
 description: "Trigger: sdd init, iniciar sdd, openspec init. Initialize SDD context, testing capabilities, registry, and persistence."
 disable-model-invocation: true
-user-invocable: false
+user-invocable: true
 license: MIT
 metadata:
   author: gentleman-programming

--- a/testdata/golden/sdd-kiro-skill-sdd-init.golden
+++ b/testdata/golden/sdd-kiro-skill-sdd-init.golden
@@ -2,7 +2,7 @@
 name: sdd-init
 description: "Trigger: sdd init, iniciar sdd, openspec init. Initialize SDD context, testing capabilities, registry, and persistence."
 disable-model-invocation: true
-user-invocable: false
+user-invocable: true
 license: MIT
 metadata:
   author: gentleman-programming

--- a/testdata/golden/sdd-opencode-skill-sdd-init.golden
+++ b/testdata/golden/sdd-opencode-skill-sdd-init.golden
@@ -2,7 +2,7 @@
 name: sdd-init
 description: "Trigger: sdd init, iniciar sdd, openspec init. Initialize SDD context, testing capabilities, registry, and persistence."
 disable-model-invocation: true
-user-invocable: false
+user-invocable: true
 license: MIT
 metadata:
   author: gentleman-programming

--- a/testdata/golden/sdd-vscode-skill-sdd-init.golden
+++ b/testdata/golden/sdd-vscode-skill-sdd-init.golden
@@ -2,7 +2,7 @@
 name: sdd-init
 description: "Trigger: sdd init, iniciar sdd, openspec init. Initialize SDD context, testing capabilities, registry, and persistence."
 disable-model-invocation: true
-user-invocable: false
+user-invocable: true
 license: MIT
 metadata:
   author: gentleman-programming

--- a/testdata/golden/sdd-windsurf-skill-sdd-init.golden
+++ b/testdata/golden/sdd-windsurf-skill-sdd-init.golden
@@ -2,7 +2,7 @@
 name: sdd-init
 description: "Trigger: sdd init, iniciar sdd, openspec init. Initialize SDD context, testing capabilities, registry, and persistence."
 disable-model-invocation: true
-user-invocable: false
+user-invocable: true
 license: MIT
 metadata:
   author: gentleman-programming


### PR DESCRIPTION
This PR adds full support for the Freebuff agent in gentle-ai. Freebuff is a terminal-native, ad-supported AI coding agent based on the Codebuff platform.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Freebuff as a supported agent, including detection of its assets (config, skills, and system prompt) and enabling MCP support.
  * Added automatic Freebuff installation via the CLI and ensured it’s included in default agent selection.
* **Documentation**
  * Updated agent documentation with Freebuff installation/config locations and noted that SDD multi-mode isn’t supported.
* **Skills**
  * Made multiple SDD skills directly user-invocable.
* **Bug Fixes**
  * Improved handling so Freebuff detections are correctly mapped into managed/preselected agents.
* **Tests**
  * Expanded coverage for Freebuff wiring, installation resolution, and adapter behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->