### PR TITLE
feat(opencodeplugin): add four-layer managed uninstall for community plugins

### DIFF
--- a/internal/components/mutationjournal/journal.go
+++ b/internal/components/mutationjournal/journal.go
@@ -1,0 +1,178 @@
+// Package mutationjournal records before-images of files within an
+// allow-listed set of roots and restores them on demand. It is intended for
+// code that mutates user files as part of an installation or sync step and
+// must roll back atomically if a later step fails.
+package mutationjournal
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/gentleman-programming/gentle-ai/internal/components/filemerge"
+)
+
+// OwnedFile is the persisted before-image record. It mirrors what an external
+// manifest can serialize to JSON to track every file a sync step touched.
+type OwnedFile struct {
+	Before    *string `json:"before,omitempty"`
+	After     string  `json:"after"`
+	AfterHash string  `json:"afterHash"`
+	Overlay   bool    `json:"overlay"`
+	Adopted   bool    `json:"adopted,omitempty"`
+	Mode      uint32  `json:"mode,omitempty"`
+}
+
+type journalEntry struct {
+	data *[]byte
+	mode os.FileMode
+}
+
+// Journal captures before-images and supports atomic writes with restore on
+// error. A zero-value Journal is not usable; construct one with New.
+type Journal struct {
+	before map[string]*journalEntry
+	roots  []string
+}
+
+// New constructs a journal that only accepts paths within the given roots.
+// Roots must be absolute or the path-traversal guard will reject every write.
+func New(roots ...string) *Journal {
+	return &Journal{before: map[string]*journalEntry{}, roots: append([]string(nil), roots...)}
+}
+
+// Capture snapshots a file's current content + mode for later restoration.
+// If the file does not exist, records nil (Restore will remove anything
+// created later). Capture is idempotent for the same path.
+func (j *Journal) Capture(path string) error {
+	if err := j.validate(path); err != nil {
+		return err
+	}
+	if _, exists := j.before[path]; exists {
+		return nil
+	}
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		j.before[path] = nil
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("read before-image %q: %w", path, err)
+	}
+	info, statErr := os.Stat(path)
+	if statErr != nil {
+		return fmt.Errorf("stat before-image %q: %w", path, statErr)
+	}
+	j.before[path] = &journalEntry{data: &data, mode: info.Mode().Perm()}
+	return nil
+}
+
+// Write atomically writes data to path. If the file existed before the first
+// Capture/Write call for this path, the journal will have its content
+// captured automatically; otherwise the file's prior absence is recorded.
+// Returns the resulting OwnedFile record (Before/After/Hash populated).
+func (j *Journal) Write(path string, data []byte) (OwnedFile, error) {
+	return j.WriteWithMode(path, data, 0)
+}
+
+// WriteWithMode is like Write but preserves an explicit file mode for new
+// files. If the file existed before, the prior mode is reused.
+func (j *Journal) WriteWithMode(path string, data []byte, mode os.FileMode) (OwnedFile, error) {
+	if err := j.Capture(path); err != nil {
+		return OwnedFile{}, err
+	}
+	effective := mode
+	if effective == 0 {
+		effective = 0o600
+	}
+	if previous := j.before[path]; previous != nil {
+		effective = previous.mode
+	}
+	if _, err := filemerge.WriteFileAtomic(path, data, effective); err != nil {
+		return OwnedFile{}, fmt.Errorf("write %q: %w", path, err)
+	}
+	return j.OwnedFile(path, string(data), false, false), nil
+}
+
+// OwnedFile builds an OwnedFile record using the current journal state for
+// path. Use this for files written externally (e.g. via os.WriteFile) when you
+// still need the before/after/hash tuple for a manifest.
+func (j *Journal) OwnedFile(path, after string, overlay, adopted bool) OwnedFile {
+	entry := j.before[path]
+	var snapshot *string
+	if entry != nil {
+		value := string(*entry.data)
+		snapshot = &value
+	}
+	mode := uint32(0o600)
+	if entry != nil {
+		mode = uint32(entry.mode)
+	}
+	return OwnedFile{
+		Before:    snapshot,
+		After:     after,
+		AfterHash: hashBytes([]byte(after)),
+		Overlay:   overlay,
+		Adopted:   adopted,
+		Mode:      mode,
+	}
+}
+
+// Restore rewrites every captured file to its before-image. For files that
+// did not exist before, Restore removes them. Returns errors.Join of any
+// individual failures; partial restore is best-effort.
+func (j *Journal) Restore() error {
+	paths := make([]string, 0, len(j.before))
+	for path := range j.before {
+		paths = append(paths, path)
+	}
+	slices.Sort(paths)
+	var restoreErrors []error
+	for _, path := range paths {
+		entry := j.before[path]
+		if entry == nil {
+			if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+				restoreErrors = append(restoreErrors, fmt.Errorf("remove %q: %w", path, err))
+			}
+			continue
+		}
+		if _, err := filemerge.WriteFileAtomic(path, *entry.data, entry.mode); err != nil {
+			restoreErrors = append(restoreErrors, fmt.Errorf("restore %q: %w", path, err))
+		}
+	}
+	return errors.Join(restoreErrors...)
+}
+
+func (j *Journal) validate(path string) error {
+	if path == "" {
+		return fmt.Errorf("empty mutation journal path")
+	}
+	if info, err := os.Lstat(path); err == nil && info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("refuse symlink mutation journal path %q", path)
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return fmt.Errorf("resolve absolute path for %q: %w", path, err)
+	}
+	for _, root := range j.roots {
+		rootAbs, rootErr := filepath.Abs(root)
+		if rootErr != nil {
+			continue
+		}
+		rel, relErr := filepath.Rel(rootAbs, abs)
+		if relErr == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			return nil
+		}
+	}
+	return fmt.Errorf("path %q is outside mutation journal roots", path)
+}
+
+func hashBytes(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}

--- a/internal/components/mutationjournal/journal_test.go
+++ b/internal/components/mutationjournal/journal_test.go
@@ -1,0 +1,342 @@
+package mutationjournal
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestNewRejectsEmptyRoots(t *testing.T) {
+	j := New()
+	dir := t.TempDir()
+	target := filepath.Join(dir, "x.txt")
+	if err := j.Capture(target); err == nil || !strings.Contains(err.Error(), "outside mutation journal roots") {
+		t.Fatalf("Capture() empty-roots error = %v, want substring %q", err, "outside mutation journal roots")
+	}
+	if _, err := j.Write(target, []byte("x")); err == nil || !strings.Contains(err.Error(), "outside mutation journal roots") {
+		t.Fatalf("Write() empty-roots error = %v, want substring %q", err, "outside mutation journal roots")
+	}
+}
+
+func TestCaptureBeforeWrite(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "x.txt")
+	if err := os.WriteFile(target, []byte("original"), 0o600); err != nil {
+		t.Fatalf("seed write error = %v", err)
+	}
+	j := New(dir)
+	if err := j.Capture(target); err != nil {
+		t.Fatalf("Capture() error = %v", err)
+	}
+	if _, err := j.Write(target, []byte("new")); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("ReadFile() after Write error = %v", err)
+	}
+	if string(got) != "new" {
+		t.Fatalf("after Write, file = %q, want %q", string(got), "new")
+	}
+	if err := j.Restore(); err != nil {
+		t.Fatalf("Restore() error = %v", err)
+	}
+	got, err = os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("ReadFile() after Restore error = %v", err)
+	}
+	if string(got) != "original" {
+		t.Fatalf("after Restore, file = %q, want %q", string(got), "original")
+	}
+}
+
+func TestCaptureNonexistent(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "missing.txt")
+	j := New(dir)
+	if err := j.Capture(target); err != nil {
+		t.Fatalf("Capture() error = %v", err)
+	}
+	if _, err := j.Write(target, []byte("created")); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	if _, err := os.Stat(target); err != nil {
+		t.Fatalf("Stat() after Write error = %v", err)
+	}
+	if err := j.Restore(); err != nil {
+		t.Fatalf("Restore() error = %v", err)
+	}
+	if _, err := os.Stat(target); !os.IsNotExist(err) {
+		t.Fatalf("Stat() after Restore error = %v, want IsNotExist", err)
+	}
+}
+
+func TestWriteAutoCaptures(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "auto.txt")
+	if err := os.WriteFile(target, []byte("first"), 0o600); err != nil {
+		t.Fatalf("seed write error = %v", err)
+	}
+	j := New(dir)
+	if _, err := j.Write(target, []byte("second")); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	if err := j.Restore(); err != nil {
+		t.Fatalf("Restore() error = %v", err)
+	}
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if string(got) != "first" {
+		t.Fatalf("after Restore, file = %q, want %q", string(got), "first")
+	}
+}
+
+func TestRefusesSymlink(t *testing.T) {
+	dir := t.TempDir()
+	real := filepath.Join(dir, "real.txt")
+	if err := os.WriteFile(real, []byte("body"), 0o600); err != nil {
+		t.Fatalf("seed write error = %v", err)
+	}
+	link := filepath.Join(dir, "link.txt")
+	if err := os.Symlink(real, link); err != nil {
+		t.Skipf("symlink unsupported on this platform: %v", err)
+	}
+	j := New(dir)
+	if err := j.Capture(link); err == nil || !strings.Contains(err.Error(), "refuse symlink") {
+		t.Fatalf("Capture() symlink error = %v, want substring %q", err, "refuse symlink")
+	}
+	if _, err := j.Write(link, []byte("x")); err == nil || !strings.Contains(err.Error(), "refuse symlink") {
+		t.Fatalf("Write() symlink error = %v, want substring %q", err, "refuse symlink")
+	}
+}
+
+func TestRefusesPathOutsideRoots(t *testing.T) {
+	base := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "escaped.txt")
+	j := New(base)
+	if err := j.Capture(outside); err == nil || !strings.Contains(err.Error(), "outside mutation journal roots") {
+		t.Fatalf("Capture() outside-root error = %v, want substring %q", err, "outside mutation journal roots")
+	}
+	if _, err := j.Write(outside, []byte("x")); err == nil || !strings.Contains(err.Error(), "outside mutation journal roots") {
+		t.Fatalf("Write() outside-root error = %v, want substring %q", err, "outside mutation journal roots")
+	}
+}
+
+func TestRefusesEmptyPath(t *testing.T) {
+	dir := t.TempDir()
+	j := New(dir)
+	if err := j.Capture(""); err == nil || !strings.Contains(err.Error(), "empty mutation journal path") {
+		t.Fatalf("Capture(\"\") error = %v, want substring %q", err, "empty mutation journal path")
+	}
+	if _, err := j.Write("", []byte("x")); err == nil || !strings.Contains(err.Error(), "empty mutation journal path") {
+		t.Fatalf("Write(\"\") error = %v, want substring %q", err, "empty mutation journal path")
+	}
+}
+
+func TestRestoreMultipleFilesDeterministic(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("chmod read-only semantics differ on Windows")
+	}
+	base := t.TempDir()
+	j := New(base)
+	names := []string{"c.txt", "a.txt", "b.txt", "e.txt", "d.txt"}
+	for _, name := range names {
+		p := filepath.Join(base, name)
+		if err := os.WriteFile(p, []byte("orig-"+name), 0o600); err != nil {
+			t.Fatalf("seed %q: %v", name, err)
+		}
+		if err := j.Capture(p); err != nil {
+			t.Fatalf("capture %q: %v", name, err)
+		}
+		if _, err := j.WriteWithMode(p, []byte("new-"+name), 0o600); err != nil {
+			t.Fatalf("write %q: %v", name, err)
+		}
+	}
+	if err := os.Chmod(base, 0o500); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(base, 0o700) })
+	err := j.Restore()
+	if err == nil {
+		t.Fatalf("Restore() error = nil, want non-nil")
+	}
+	msg := err.Error()
+	prev := -1
+	ordered := []string{"a.txt", "b.txt", "c.txt", "d.txt", "e.txt"}
+	for _, name := range ordered {
+		idx := strings.Index(msg, name)
+		if idx < 0 {
+			t.Fatalf("Restore() error = %q, want mention of %q", msg, name)
+		}
+		if idx <= prev {
+			t.Fatalf("Restore() error = %q, want %q (idx %d) after previous name (idx %d)", msg, name, idx, prev)
+		}
+		prev = idx
+	}
+}
+
+func TestRestoreAggregatesErrorsWithJoin(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("chmod read-only semantics differ on Windows")
+	}
+	base := t.TempDir()
+	j := New(base)
+	for _, name := range []string{"a.txt", "b.txt", "c.txt"} {
+		p := filepath.Join(base, name)
+		if err := os.WriteFile(p, []byte("orig-"+name), 0o600); err != nil {
+			t.Fatalf("seed %q: %v", name, err)
+		}
+		if err := j.Capture(p); err != nil {
+			t.Fatalf("capture %q: %v", name, err)
+		}
+		if _, err := j.WriteWithMode(p, []byte("new-"+name), 0o600); err != nil {
+			t.Fatalf("write %q: %v", name, err)
+		}
+	}
+	if err := os.Chmod(base, 0o500); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(base, 0o700) })
+	err := j.Restore()
+	if err == nil {
+		t.Fatalf("Restore() error = nil, want non-nil")
+	}
+	type unwrapMulti interface{ Unwrap() []error }
+	joined, ok := err.(unwrapMulti)
+	if !ok {
+		t.Fatalf("Restore() error type = %T, want errors.Join-style multi-error", err)
+	}
+	causes := joined.Unwrap()
+	if len(causes) != 3 {
+		t.Fatalf("Restore() joined causes count = %d, want 3", len(causes))
+	}
+	seen := map[string]bool{}
+	for i, cause := range causes {
+		key := cause.Error()
+		if key == "" {
+			t.Fatalf("Restore() causes[%d] error string empty", i)
+		}
+		if seen[key] {
+			t.Fatalf("Restore() causes[%d] = %q, duplicate", i, key)
+		}
+		seen[key] = true
+	}
+}
+
+func TestOwnedFileBeforeAfterHash(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "hello.txt")
+	if err := os.WriteFile(target, []byte("hello"), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	j := New(dir)
+	if err := j.Capture(target); err != nil {
+		t.Fatalf("capture: %v", err)
+	}
+	of := j.OwnedFile(target, "world", false, false)
+	if of.Before == nil {
+		t.Fatalf("Before = nil, want pointer to %q", "hello")
+	}
+	if *of.Before != "hello" {
+		t.Fatalf("Before = %q, want %q", *of.Before, "hello")
+	}
+	if of.After != "world" {
+		t.Fatalf("After = %q, want %q", of.After, "world")
+	}
+	want := sha256Hex("world")
+	if of.AfterHash != want {
+		t.Fatalf("AfterHash = %q, want %q", of.AfterHash, want)
+	}
+}
+
+func TestCaptureIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "idempotent.txt")
+	if err := os.WriteFile(target, []byte("first"), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	j := New(dir)
+	if err := j.Capture(target); err != nil {
+		t.Fatalf("first Capture: %v", err)
+	}
+	if err := os.WriteFile(target, []byte("second"), 0o600); err != nil {
+		t.Fatalf("rewrite: %v", err)
+	}
+	if err := j.Capture(target); err != nil {
+		t.Fatalf("second Capture: %v", err)
+	}
+	if _, err := j.WriteWithMode(target, []byte("third"), 0o600); err != nil {
+		t.Fatalf("WriteWithMode: %v", err)
+	}
+	if err := j.Restore(); err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(got) != "first" {
+		t.Fatalf("after Restore, file = %q, want %q (idempotent Capture preserved first before-image)", string(got), "first")
+	}
+}
+
+func TestWriteWithModePreservesExistingMode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX permission bits are not enforced on Windows")
+	}
+	dir := t.TempDir()
+	target := filepath.Join(dir, "mode.txt")
+	if err := os.WriteFile(target, []byte("x"), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	j := New(dir)
+	if _, err := j.WriteWithMode(target, []byte("y"), 0o600); err != nil {
+		t.Fatalf("WriteWithMode: %v", err)
+	}
+	info, err := os.Stat(target)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o644 {
+		t.Fatalf("mode = %o, want 0o644 (preserve existing)", got)
+	}
+}
+
+func TestWriteWithModeAppliesToNewFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX permission bits are not enforced on Windows")
+	}
+	dir := t.TempDir()
+	target := filepath.Join(dir, "newmode.txt")
+	j := New(dir)
+	if _, err := j.WriteWithMode(target, []byte("y"), 0o755); err != nil {
+		t.Fatalf("WriteWithMode: %v", err)
+	}
+	info, err := os.Stat(target)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o755 {
+		t.Fatalf("mode = %o, want 0o755", got)
+	}
+}
+
+func TestHashMatchesSha256(t *testing.T) {
+	j := New(t.TempDir())
+	of := j.OwnedFile(filepath.Join(t.TempDir(), "never-used.txt"), "hello world", false, false)
+	want := sha256Hex("hello world")
+	if of.AfterHash != want {
+		t.Fatalf("AfterHash = %q, want %q", of.AfterHash, want)
+	}
+}
+
+func sha256Hex(s string) string {
+	sum := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(sum[:])
+}

--- a/internal/components/opencodeplugin/plugin.go
+++ b/internal/components/opencodeplugin/plugin.go
@@ -226,7 +226,7 @@ func removeTUIPlugin(path, pkg string) (bool, []byte, error) {
 	}
 
 	plugins := stringSlice(root["plugin"])
-	kept := plugins[:0:0]
+	kept := make([]string, 0, len(plugins))
 	changedAny := false
 	for _, existing := range plugins {
 		if existing == pkg {

--- a/internal/components/opencodeplugin/plugin.go
+++ b/internal/components/opencodeplugin/plugin.go
@@ -204,6 +204,54 @@ func ensureTUIPlugin(path, pkg string) (bool, error) {
 	return wr.Changed, nil
 }
 
+// removeTUIPlugin is the uninstall-side mirror of ensureTUIPlugin. It removes
+// every occurrence of pkg from tui.json's plugin[] list and rewrites the file
+// atomically. Returns (changed, afterBytes, err) where afterBytes is the
+// exact payload written to disk — callers must reuse these bytes for the
+// journal manifest instead of re-reading the file (which can race against
+// sandbox or TOCTOU flakiness). If the file is missing or pkg is not
+// present, returns (false, nil, nil) without writing. The caller is
+// responsible for snapshotting the file with mutationjournal BEFORE calling
+// this helper when it needs a rollback hook.
+func removeTUIPlugin(path, pkg string) (bool, []byte, error) {
+	root := map[string]any{"$schema": "https://opencode.ai/tui.json"}
+	data, readErr := os.ReadFile(path)
+	switch {
+	case readErr == nil && len(bytes.TrimSpace(data)) > 0:
+		if err := json.Unmarshal(data, &root); err != nil {
+			return false, nil, fmt.Errorf("parse OpenCode TUI config %q: %w", path, err)
+		}
+	case readErr != nil && !os.IsNotExist(readErr):
+		return false, nil, fmt.Errorf("read OpenCode TUI config %q: %w", path, readErr)
+	}
+
+	plugins := stringSlice(root["plugin"])
+	kept := plugins[:0:0]
+	changedAny := false
+	for _, existing := range plugins {
+		if existing == pkg {
+			changedAny = true
+			continue
+		}
+		kept = append(kept, existing)
+	}
+	if !changedAny {
+		return false, nil, nil
+	}
+	root["plugin"] = kept
+
+	out, err := json.MarshalIndent(root, "", "  ")
+	if err != nil {
+		return false, nil, err
+	}
+	out = append(out, '\n')
+	wr, err := filemerge.WriteFileAtomic(path, out, 0o644)
+	if err != nil {
+		return false, nil, err
+	}
+	return wr.Changed, out, nil
+}
+
 func stringSlice(value any) []string {
 	items, ok := value.([]any)
 	if !ok {

--- a/internal/components/opencodeplugin/uninstall.go
+++ b/internal/components/opencodeplugin/uninstall.go
@@ -2,8 +2,6 @@ package opencodeplugin
 
 import (
 	"bytes"
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -73,7 +71,7 @@ func Uninstall(homeDir string, id model.OpenCodeCommunityPluginID) (UninstallRes
 
 	// ── Layer 1: tui.json ──────────────────────────────────────────────────
 	if err := journal.Capture(tuiPath); err != nil {
-		return result, fmt.Errorf("uninstall layer 1: capture tui.json: %w", err)
+		return result, fmt.Errorf("uninstall layer 1 (tui.json capture): %w", err)
 	}
 	tuiChanged, tuiAfter, err := removeTUIPlugin(tuiPath, targetInTUI)
 	if err != nil {
@@ -192,10 +190,11 @@ func uninstallPackageJSON(journal *mutationjournal.Journal, packagePath, pkg str
 		return false, mutationjournal.OwnedFile{}, fmt.Errorf("marshal package.json: %w", err)
 	}
 	out = append(out, '\n')
-	if _, err := journal.Write(packagePath, out); err != nil {
+	written, err := journal.Write(packagePath, out)
+	if err != nil {
 		return false, mutationjournal.OwnedFile{}, err
 	}
-	return true, journal.OwnedFile(packagePath, string(out), false, false), nil
+	return true, written, nil
 }
 
 // uninstallCacheEntry removes the OpenCode plugin cache for pkg. Must mirror
@@ -242,10 +241,11 @@ func rollbackUninstall(journal *mutationjournal.Journal, id model.OpenCodeCommun
 // snapshot directly (a directory tree, e.g. node_modules/<pkg>/ or the cache
 // entry). After is empty, AfterHash is the canonical sha256 of the empty
 // string, and Mode is 0 so the entry is omitted from JSON.
+const emptySHA256Hex = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
 func removalRecord() mutationjournal.OwnedFile {
-	sum := sha256.Sum256(nil)
 	return mutationjournal.OwnedFile{
 		After:     "",
-		AfterHash: hex.EncodeToString(sum[:]),
+		AfterHash: emptySHA256Hex,
 	}
 }

--- a/internal/components/opencodeplugin/uninstall.go
+++ b/internal/components/opencodeplugin/uninstall.go
@@ -1,0 +1,251 @@
+package opencodeplugin
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/gentleman-programming/gentle-ai/internal/components/mutationjournal"
+	"github.com/gentleman-programming/gentle-ai/internal/model"
+)
+
+// UninstallResult summarizes what the 4-layer engine touched.
+type UninstallResult struct {
+	PluginID           model.OpenCodeCommunityPluginID
+	ChangedTUI         bool
+	ChangedPackageJSON bool
+	ChangedNodeModules bool
+	CacheEntryRemoved  string // absolute path of removed cache entry, or "" if none
+	NodeModulesPath    string // absolute path of node_modules/<pkg> removed, or ""
+	TSXPath            string // absolute path of .tsx file removed (GentleLogo only), or ""
+	JournalManifest    []mutationjournal.OwnedFile
+}
+
+// Uninstall removes a community plugin across up to 4 layers: tui.json,
+// package.json, node_modules/<pkg>, and the matching cache entry under
+// ~/.cache/opencode/packages/<pkg>@latest. Built-in GentleLogo swaps the NPM
+// layers for a single .tsx removal. On failure, captured layers are restored
+// from the journal and the partial result returned reflects what was actually
+// performed.
+//
+// Layer 3 (node_modules) and the cache entry are not journalable — both are
+// directory trees — so callers that need a guaranteed revert must snapshot
+// them out of band before calling Uninstall.
+func Uninstall(homeDir string, id model.OpenCodeCommunityPluginID) (UninstallResult, error) {
+	result := UninstallResult{PluginID: id}
+
+	if homeDir == "" {
+		return result, fmt.Errorf("uninstall opencode plugin: homeDir must not be empty")
+	}
+
+	isGentleLogo := id == model.OpenCodePluginGentleLogo
+	def, known := DefinitionFor(id)
+	if !isGentleLogo && !known {
+		return result, fmt.Errorf("uninstall opencode plugin: unknown id %q", id)
+	}
+
+	// targetInTUI is the literal string Install() registered inside tui.json's
+	// plugin[] list. For NPM plugins this is the NPM package name; for the
+	// built-in GentleLogo .tsx it is the absolute plugin path so it matches
+	// the value Install() wrote.
+	var targetInTUI string
+	if isGentleLogo {
+		targetInTUI = filepath.Join(homeDir, ".config", "opencode", "tui-plugins", gentleLogoPluginFile)
+	} else {
+		targetInTUI = def.PackageName
+	}
+
+	opencodeDir := filepath.Join(homeDir, ".config", "opencode")
+	tuiPath := filepath.Join(opencodeDir, "tui.json")
+	packagePath := filepath.Join(opencodeDir, "package.json")
+
+	journal := mutationjournal.New(homeDir)
+	pjWritten := false
+
+	rollback := func(err error, stage string, partial UninstallResult) (UninstallResult, error) {
+		return rollbackUninstall(journal, id, partial, err, stage, pjWritten)
+	}
+
+	// ── Layer 1: tui.json ──────────────────────────────────────────────────
+	if err := journal.Capture(tuiPath); err != nil {
+		return result, fmt.Errorf("uninstall layer 1: capture tui.json: %w", err)
+	}
+	tuiChanged, tuiAfter, err := removeTUIPlugin(tuiPath, targetInTUI)
+	if err != nil {
+		return rollback(fmt.Errorf("uninstall layer 1 (tui.json): %w", err), "layer 1", result)
+	}
+	if tuiChanged {
+		result.ChangedTUI = true
+		result.JournalManifest = append(result.JournalManifest, journal.OwnedFile(tuiPath, string(tuiAfter), false, false))
+	}
+
+	// ── Layer 2: package.json (skipped for built-in GentleLogo) ───────────
+	if !isGentleLogo {
+		pjChanged, pjOwned, err := uninstallPackageJSON(journal, packagePath, def.PackageName)
+		if err != nil {
+			return rollback(fmt.Errorf("uninstall layer 2 (package.json): %w", err), "layer 2", result)
+		}
+		if pjChanged {
+			pjWritten = true
+			result.ChangedPackageJSON = true
+			result.JournalManifest = append(result.JournalManifest, pjOwned)
+		}
+	}
+
+	// ── Layer 3: node_modules/<pkg>/ (skipped for built-in GentleLogo) ─────
+	if !isGentleLogo {
+		nodeModulesPath := filepath.Join(opencodeDir, "node_modules", def.PackageName)
+		if info, statErr := os.Stat(nodeModulesPath); statErr == nil && info.IsDir() {
+			if rmErr := os.RemoveAll(nodeModulesPath); rmErr != nil {
+				return rollback(fmt.Errorf("uninstall layer 3 (node_modules): %w", rmErr), "layer 3", result)
+			}
+			result.ChangedNodeModules = true
+			result.NodeModulesPath = nodeModulesPath
+			result.JournalManifest = append(result.JournalManifest, removalRecord())
+		}
+	}
+
+	// ── Layer 4: optional cache entries (skipped for built-in GentleLogo) ─
+	if !isGentleLogo {
+		removed, err := uninstallCacheEntry(homeDir, def.PackageName)
+		if err != nil {
+			return rollback(fmt.Errorf("uninstall layer 4 (cache): %w", err), "layer 4", result)
+		}
+		if removed != "" {
+			result.CacheEntryRemoved = removed
+			result.JournalManifest = append(result.JournalManifest, removalRecord())
+		}
+	}
+
+	// ── Layer TSX: built-in GentleLogo local plugin file ───────────────────
+	if isGentleLogo {
+		tsxPath := filepath.Join(homeDir, ".config", "opencode", "tui-plugins", gentleLogoPluginFile)
+		info, statErr := os.Stat(tsxPath)
+		if statErr == nil && !info.IsDir() {
+			if err := journal.Capture(tsxPath); err != nil {
+				return rollback(fmt.Errorf("uninstall tsx: capture %s: %w", tsxPath, err), "layer tsx", result)
+			}
+			if rmErr := os.Remove(tsxPath); rmErr != nil && !os.IsNotExist(rmErr) {
+				return rollback(fmt.Errorf("uninstall tsx: remove %s: %w", tsxPath, rmErr), "layer tsx", result)
+			}
+			result.TSXPath = tsxPath
+			result.JournalManifest = append(result.JournalManifest, removalRecord())
+		}
+	}
+
+	return result, nil
+}
+
+// uninstallPackageJSON removes pkg from dependencies + devDependencies in
+// packagePath. Returns true and an OwnedFile manifest entry iff a write
+// happened. If package.json is missing or empty, returns (false, "", nil) as
+// a no-op. Keeps dependencies/devDependencies keys present (as empty maps)
+// rather than deleting them, even when they end up empty.
+//
+// package.json is decoded with map[string]any (not the typed deps struct in
+// internal/update/upgrade/strategy.go) so that unrelated keys — packageManager,
+// scripts, workspaces, etc. — survive the rewrite verbatim.
+func uninstallPackageJSON(journal *mutationjournal.Journal, packagePath, pkg string) (bool, mutationjournal.OwnedFile, error) {
+	data, err := os.ReadFile(packagePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, mutationjournal.OwnedFile{}, nil
+		}
+		return false, mutationjournal.OwnedFile{}, fmt.Errorf("read package.json %q: %w", packagePath, err)
+	}
+	if len(bytes.TrimSpace(data)) == 0 {
+		return false, mutationjournal.OwnedFile{}, nil
+	}
+
+	root := map[string]any{}
+	if err := json.Unmarshal(data, &root); err != nil {
+		return false, mutationjournal.OwnedFile{}, fmt.Errorf("parse package.json %q: %w", packagePath, err)
+	}
+
+	hadChanges := false
+	for _, key := range []string{"dependencies", "devDependencies"} {
+		entry, ok := root[key].(map[string]any)
+		if !ok {
+			// Missing key or wrong shape: normalize to an empty map so the JSON
+			// stays balanced after our rewrite, but don't pretend a change
+			// happened if pkg was never there.
+			root[key] = map[string]any{}
+			continue
+		}
+		if _, present := entry[pkg]; present {
+			delete(entry, pkg)
+			hadChanges = true
+		}
+	}
+
+	if !hadChanges {
+		return false, mutationjournal.OwnedFile{}, nil
+	}
+
+	out, err := json.MarshalIndent(root, "", "  ")
+	if err != nil {
+		return false, mutationjournal.OwnedFile{}, fmt.Errorf("marshal package.json: %w", err)
+	}
+	out = append(out, '\n')
+	if _, err := journal.Write(packagePath, out); err != nil {
+		return false, mutationjournal.OwnedFile{}, err
+	}
+	return true, journal.OwnedFile(packagePath, string(out), false, false), nil
+}
+
+// uninstallCacheEntry removes the OpenCode plugin cache for pkg. Must mirror
+// internal/update/upgrade/strategy.go:clearOpenCodePluginPackageCache: the path
+// is always ~/.cache/opencode/packages/<pkg>@latest, never a prefix-match
+// across the cache root. If the path does not exist, this is a silent no-op
+// and the returned path is "".
+func uninstallCacheEntry(homeDir, pkg string) (string, error) {
+	path := filepath.Join(homeDir, ".cache", "opencode", "packages", pkg+"@latest")
+	if _, err := os.Lstat(path); err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", fmt.Errorf("stat cache entry %q: %w", path, err)
+	}
+	if err := os.RemoveAll(path); err != nil {
+		return "", fmt.Errorf("remove cache entry %q: %w", path, err)
+	}
+	return path, nil
+}
+
+// rollbackUninstall is the testable seam for Uninstall's rollback path. It
+// restores the journal and returns the partial UninstallResult, flipping
+// ChangedTUI/ChangedPackageJSON back to false because Restore rewinds those
+// files to their before-images. Other "we did remove something" flags
+// (ChangedNodeModules, CacheEntryRemoved, NodeModulesPath, TSXPath) stay
+// because directories aren't journal-restorable. The original err is wrapped
+// with the stage label on Restore failure.
+func rollbackUninstall(journal *mutationjournal.Journal, id model.OpenCodeCommunityPluginID, partial UninstallResult, err error, stage string, pjWritten bool) (UninstallResult, error) {
+	final := partial
+	final.PluginID = id
+	rerr := journal.Restore()
+	if rerr == nil {
+		final.ChangedTUI = false
+		if pjWritten {
+			final.ChangedPackageJSON = false
+		}
+		return final, err
+	}
+	return final, errors.Join(err, fmt.Errorf("restore journal after %s: %w", stage, rerr))
+}
+
+// removalRecord documents a deletion in the manifest that the journal cannot
+// snapshot directly (a directory tree, e.g. node_modules/<pkg>/ or the cache
+// entry). After is empty, AfterHash is the canonical sha256 of the empty
+// string, and Mode is 0 so the entry is omitted from JSON.
+func removalRecord() mutationjournal.OwnedFile {
+	sum := sha256.Sum256(nil)
+	return mutationjournal.OwnedFile{
+		After:     "",
+		AfterHash: hex.EncodeToString(sum[:]),
+	}
+}

--- a/internal/components/opencodeplugin/uninstall_test.go
+++ b/internal/components/opencodeplugin/uninstall_test.go
@@ -514,6 +514,28 @@ func TestUninstallIdempotent(t *testing.T) {
 	}
 }
 
+// TestUninstallRemovesAllDuplicateTUIEntries covers the F5 regression: if the
+// same package appears twice in tui.json's plugin[] list, both occurrences
+// must be removed, not just the first one.
+func TestUninstallRemovesAllDuplicateTUIEntries(t *testing.T) {
+	home := t.TempDir()
+	pkgName := "opencode-subagent-statusline"
+	writeTUIConfig(t, home, []string{pkgName, "unrelated-plugin", pkgName})
+
+	res, err := Uninstall(home, model.OpenCodePluginSubAgentStatusline)
+	if err != nil {
+		t.Fatalf("Uninstall() error = %v", err)
+	}
+	if !res.ChangedTUI {
+		t.Fatal("res.ChangedTUI = false, want true (duplicates were present)")
+	}
+	got := readTUIPlugins(t, home)
+	want := []string{"unrelated-plugin"}
+	if len(got) != len(want) || got[0] != want[0] {
+		t.Fatalf("tui.json plugin list after uninstall = %#v, want %#v", got, want)
+	}
+}
+
 // ─── 9. Rollback ───────────────────────────────────────────────────────────
 
 // TestUninstallRollbackOnFailure forces layer 2 (package.json write) to fail

--- a/internal/components/opencodeplugin/uninstall_test.go
+++ b/internal/components/opencodeplugin/uninstall_test.go
@@ -1,0 +1,672 @@
+package opencodeplugin
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/internal/components/mutationjournal"
+	"github.com/gentleman-programming/gentle-ai/internal/model"
+)
+
+// ─── Shared fixtures ────────────────────────────────────────────────────────
+
+func writeTUIConfig(t *testing.T, home string, plugins []string) {
+	t.Helper()
+	dir := filepath.Join(home, ".config", "opencode")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := map[string]any{
+		"$schema": "https://opencode.ai/tui.json",
+		"plugin":  plugins,
+	}
+	data, err := json.MarshalIndent(body, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(filepath.Join(dir, "tui.json"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func readTUIPlugins(t *testing.T, home string) []string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(home, ".config", "opencode", "tui.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var root struct {
+		Plugin []string `json:"plugin"`
+	}
+	if err := json.Unmarshal(data, &root); err != nil {
+		t.Fatal(err)
+	}
+	return root.Plugin
+}
+
+func writePackageJSON(t *testing.T, home string, content string) {
+	t.Helper()
+	dir := filepath.Join(home, ".config", "opencode")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "package.json"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func readPackageJSON(t *testing.T, home string) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(home, ".config", "opencode", "package.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}
+
+// writeCacheEntry creates the OpenCode cache directory for pkg at the
+// canonical path ~/.cache/opencode/packages/<pkg>@latest/ with a sentinel
+// file inside, mirroring the layout used by
+// internal/update/upgrade/strategy.go:clearOpenCodePluginPackageCache.
+func writeCacheEntry(t *testing.T, home, pkgName string) string {
+	t.Helper()
+	cacheDir := filepath.Join(home, ".cache", "opencode", "packages", pkgName+"@latest")
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cacheDir, "data"), []byte(`{"version":"1.0.0"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return cacheDir
+}
+
+// ─── 1. Input validation ───────────────────────────────────────────────────
+
+func TestUninstallRejectsUnknownID(t *testing.T) {
+	home := t.TempDir()
+	_, err := Uninstall(home, model.OpenCodeCommunityPluginID("not-a-real-plugin"))
+	if err == nil {
+		t.Fatal("Uninstall() error = nil, want error for unknown id")
+	}
+	if !strings.Contains(err.Error(), "unknown id") {
+		t.Fatalf("error %q does not mention unknown id", err)
+	}
+}
+
+func TestUninstallRejectsEmptyHomeDir(t *testing.T) {
+	_, err := Uninstall("", model.OpenCodePluginSubAgentStatusline)
+	if err == nil {
+		t.Fatal("Uninstall() error = nil, want error for empty homeDir")
+	}
+	if !strings.Contains(err.Error(), "homeDir") {
+		t.Fatalf("error %q does not mention homeDir", err)
+	}
+}
+
+// ─── 2. Idempotency and no-op matrices ─────────────────────────────────────
+
+func TestUninstallNonExistentPluginNoOp(t *testing.T) {
+	home := t.TempDir()
+	// Empty home: tui.json does not exist, package.json does not exist,
+	// node_modules/<pkg> does not exist, ~/.cache/opencode does not exist.
+	res, err := Uninstall(home, model.OpenCodePluginSubAgentStatusline)
+	if err != nil {
+		t.Fatalf("Uninstall() error = %v, want nil", err)
+	}
+	if res.PluginID != model.OpenCodePluginSubAgentStatusline {
+		t.Fatalf("PluginID = %q, want %q", res.PluginID, model.OpenCodePluginSubAgentStatusline)
+	}
+	if res.ChangedTUI || res.ChangedPackageJSON || res.ChangedNodeModules {
+		t.Fatalf("expected no-op flags: got %+v", res)
+	}
+	if res.CacheEntryRemoved != "" || res.NodeModulesPath != "" || res.TSXPath != "" {
+		t.Fatalf("expected empty path fields: got %+v", res)
+	}
+}
+
+// ─── 3. Layer 1: tui.json ──────────────────────────────────────────────────
+
+func TestUninstallRemovesFromTUIConfig(t *testing.T) {
+	home := t.TempDir()
+	writeTUIConfig(t, home, []string{"unrelated-plugin", "opencode-subagent-statusline"})
+
+	res, err := Uninstall(home, model.OpenCodePluginSubAgentStatusline)
+	if err != nil {
+		t.Fatalf("Uninstall() error = %v", err)
+	}
+	if !res.ChangedTUI {
+		t.Fatal("ChangedTUI = false, want true")
+	}
+
+	plugins := readTUIPlugins(t, home)
+	if len(plugins) != 1 || plugins[0] != "unrelated-plugin" {
+		t.Fatalf("plugin list = %#v, want only unrelated-plugin", plugins)
+	}
+}
+
+func TestUninstallTUIConfigMissing(t *testing.T) {
+	home := t.TempDir()
+	// Create the dir so capture doesn't error on parent path; only tui.json
+	// itself is absent.
+	if err := os.MkdirAll(filepath.Join(home, ".config", "opencode"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := Uninstall(home, model.OpenCodePluginSubAgentStatusline)
+	if err != nil {
+		t.Fatalf("Uninstall() error = %v", err)
+	}
+	if res.ChangedTUI {
+		t.Fatal("ChangedTUI = true, want false when tui.json is missing")
+	}
+}
+
+func TestUninstallTUIConfigMalformedJSON(t *testing.T) {
+	home := t.TempDir()
+	dir := filepath.Join(home, ".config", "opencode")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "tui.json"), []byte("{not-json}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := Uninstall(home, model.OpenCodePluginSubAgentStatusline)
+	if err == nil {
+		t.Fatal("Uninstall() error = nil, want error for malformed tui.json")
+	}
+	// The error chain comes from removeTUIPlugin → wrapped as "uninstall layer 1 (tui.json): …".
+	// Either tier of the message must reference the path.
+	if !strings.Contains(err.Error(), "tui.json") {
+		t.Fatalf("error %q does not reference tui.json", err)
+	}
+}
+
+// ─── 4. Layer 2: package.json ──────────────────────────────────────────────
+
+func TestUninstallPackageJSONDepsRemoval(t *testing.T) {
+	home := t.TempDir()
+	pkgName := "opencode-subagent-statusline"
+	writeTUIConfig(t, home, []string{pkgName})
+	writePackageJSON(t, home, `{"dependencies":{"`+pkgName+`":"^1.0.0"},"devDependencies":{"`+pkgName+`":"^1.0.0","unrelated":"^2.0.0"}}`)
+
+	res, err := Uninstall(home, model.OpenCodePluginSubAgentStatusline)
+	if err != nil {
+		t.Fatalf("Uninstall() error = %v", err)
+	}
+	if !res.ChangedPackageJSON {
+		t.Fatal("ChangedPackageJSON = false, want true")
+	}
+
+	raw := readPackageJSON(t, home)
+	var manifest struct {
+		Dependencies    map[string]string `json:"dependencies"`
+		DevDependencies map[string]string `json:"devDependencies"`
+	}
+	if err := json.Unmarshal([]byte(raw), &manifest); err != nil {
+		t.Fatalf("Unmarshal post-removal package.json: %v (raw=%s)", err, raw)
+	}
+	if _, present := manifest.Dependencies[pkgName]; present {
+		t.Fatalf("pkg still in dependencies: %#v", manifest.Dependencies)
+	}
+	if _, present := manifest.DevDependencies[pkgName]; present {
+		t.Fatalf("pkg still in devDependencies: %#v", manifest.DevDependencies)
+	}
+	if manifest.DevDependencies["unrelated"] != "^2.0.0" {
+		t.Fatalf("unrelated devDep gone: %#v", manifest.DevDependencies)
+	}
+	// Spec: keep the keys present even when empty.
+	if manifest.Dependencies == nil {
+		t.Fatalf("dependencies key disappeared entirely (raw=%s)", raw)
+	}
+}
+
+func TestUninstallPackageJSONMissing(t *testing.T) {
+	home := t.TempDir()
+	// tui.json for layer 1, no package.json for layer 2
+	writeTUIConfig(t, home, []string{"opencode-subagent-statusline"})
+
+	res, err := Uninstall(home, model.OpenCodePluginSubAgentStatusline)
+	if err != nil {
+		t.Fatalf("Uninstall() error = %v", err)
+	}
+	if res.ChangedPackageJSON {
+		t.Fatal("ChangedPackageJSON = true, want false when package.json missing")
+	}
+	// Layer 1 should have succeeded, layer 3/4 no-op.
+	if !res.ChangedTUI {
+		t.Fatal("ChangedTUI = false, want true (pkg still present in tui.json)")
+	}
+}
+
+// ─── 5. Layer 3: node_modules ──────────────────────────────────────────────
+
+func TestUninstallNodeModulesRemoval(t *testing.T) {
+	home := t.TempDir()
+	pkgName := "opencode-subagent-statusline"
+	writeTUIConfig(t, home, []string{pkgName})
+
+	nmDir := filepath.Join(home, ".config", "opencode", "node_modules", pkgName)
+	if err := os.MkdirAll(nmDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	dummy := filepath.Join(nmDir, "index.js")
+	if err := os.WriteFile(dummy, []byte("module.exports = 1"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := Uninstall(home, model.OpenCodePluginSubAgentStatusline)
+	if err != nil {
+		t.Fatalf("Uninstall() error = %v", err)
+	}
+	if !res.ChangedNodeModules {
+		t.Fatal("ChangedNodeModules = false, want true")
+	}
+	if res.NodeModulesPath != nmDir {
+		t.Fatalf("NodeModulesPath = %q, want %q", res.NodeModulesPath, nmDir)
+	}
+	if _, err := os.Stat(nmDir); !os.IsNotExist(err) {
+		t.Fatalf("expected node_modules dir gone, stat err = %v", err)
+	}
+}
+
+func TestUninstallNodeModulesMissing(t *testing.T) {
+	home := t.TempDir()
+	writeTUIConfig(t, home, []string{"opencode-subagent-statusline"})
+
+	res, err := Uninstall(home, model.OpenCodePluginSubAgentStatusline)
+	if err != nil {
+		t.Fatalf("Uninstall() error = %v", err)
+	}
+	if res.ChangedNodeModules {
+		t.Fatal("ChangedNodeModules = true, want false when directory absent")
+	}
+	if res.NodeModulesPath != "" {
+		t.Fatalf("NodeModulesPath = %q, want empty", res.NodeModulesPath)
+	}
+}
+
+// ─── 6. Layer 4: cache entries ─────────────────────────────────────────────
+
+func TestUninstallCacheEntryRemoval(t *testing.T) {
+	home := t.TempDir()
+	pkgName := "opencode-subagent-statusline"
+	writeTUIConfig(t, home, []string{pkgName})
+	createdAt := writeCacheEntry(t, home, pkgName)
+
+	res, err := Uninstall(home, model.OpenCodePluginSubAgentStatusline)
+	if err != nil {
+		t.Fatalf("Uninstall() error = %v", err)
+	}
+	if res.CacheEntryRemoved != createdAt {
+		t.Fatalf("CacheEntryRemoved = %q, want %q", res.CacheEntryRemoved, createdAt)
+	}
+	if _, err := os.Stat(res.CacheEntryRemoved); !os.IsNotExist(err) {
+		t.Fatalf("expected cache dir gone, stat err = %v", err)
+	}
+}
+
+func TestUninstallCacheEntryNestedFilesRemoval(t *testing.T) {
+	home := t.TempDir()
+	pkgName := "opencode-subagent-statusline"
+	writeTUIConfig(t, home, []string{pkgName})
+	createdAt := writeCacheEntry(t, home, pkgName)
+	nested := filepath.Join(createdAt, "subdir")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(nested, "leaf"), []byte("leaf"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := Uninstall(home, model.OpenCodePluginSubAgentStatusline)
+	if err != nil {
+		t.Fatalf("Uninstall() error = %v", err)
+	}
+	if res.CacheEntryRemoved != createdAt {
+		t.Fatalf("CacheEntryRemoved = %q, want %q", res.CacheEntryRemoved, createdAt)
+	}
+	if _, err := os.Stat(res.CacheEntryRemoved); !os.IsNotExist(err) {
+		t.Fatalf("expected cache dir gone, stat err = %v", err)
+	}
+}
+
+func TestUninstallCacheEntryMissing(t *testing.T) {
+	home := t.TempDir()
+	pkgName := "opencode-subagent-statusline"
+	writeTUIConfig(t, home, []string{pkgName})
+	// ~/.cache/opencode/packages/<pkg>@latest does not exist: layer 4 must no-op silently.
+
+	res, err := Uninstall(home, model.OpenCodePluginSubAgentStatusline)
+	if err != nil {
+		t.Fatalf("Uninstall() error = %v", err)
+	}
+	if res.CacheEntryRemoved != "" {
+		t.Fatalf("CacheEntryRemoved = %q, want empty", res.CacheEntryRemoved)
+	}
+}
+
+func TestUninstallCacheOnlyTouchesExactPath(t *testing.T) {
+	home := t.TempDir()
+	pkgName := "opencode-subagent-statusline"
+	writeTUIConfig(t, home, []string{pkgName})
+
+	cacheRoot := filepath.Join(home, ".cache", "opencode", "packages")
+	if err := os.MkdirAll(cacheRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Sibling entries that share a name prefix or live next to <pkg>@latest
+	// must survive — the engine only targets the exact <pkg>@latest path.
+	siblings := []string{
+		pkgName + "@0.5.2",
+		"opencode-sdd-engram-manage@latest",
+		pkgName + ".json",
+	}
+	for _, name := range siblings {
+		if err := os.MkdirAll(filepath.Join(cacheRoot, name), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if _, err := Uninstall(home, model.OpenCodePluginSubAgentStatusline); err != nil {
+		t.Fatalf("Uninstall() error = %v", err)
+	}
+
+	for _, name := range siblings {
+		path := filepath.Join(cacheRoot, name)
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("sibling %s should survive, stat err = %v", path, err)
+		}
+	}
+}
+
+// ─── 7. GentleLogo ─────────────────────────────────────────────────────────
+
+func TestUninstallGentleLogoRemovesTSXAndTUI(t *testing.T) {
+	home := t.TempDir()
+	// Install-equivalent setup: write tui.json with the absolute .tsx path,
+	// and the .tsx file itself.
+	pluginDir := filepath.Join(home, ".config", "opencode", "tui-plugins")
+	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	tsxPath := filepath.Join(pluginDir, gentleLogoPluginFile)
+	if err := os.WriteFile(tsxPath, []byte("// fake plugin content"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	writeTUIConfig(t, home, []string{tsxPath})
+
+	res, err := Uninstall(home, model.OpenCodePluginGentleLogo)
+	if err != nil {
+		t.Fatalf("Uninstall() error = %v", err)
+	}
+	if !res.ChangedTUI {
+		t.Fatal("ChangedTUI = false, want true (entry should be removed)")
+	}
+	if res.TSXPath != tsxPath {
+		t.Fatalf("TSXPath = %q, want %q", res.TSXPath, tsxPath)
+	}
+	if _, err := os.Stat(tsxPath); !os.IsNotExist(err) {
+		t.Fatalf("expected .tsx file gone, stat err = %v", err)
+	}
+
+	// Layers 2/3/4 must NOT have run for GentleLogo.
+	if res.ChangedPackageJSON {
+		t.Fatal("ChangedPackageJSON = true, want false (GentleLogo skips layer 2)")
+	}
+	if res.ChangedNodeModules {
+		t.Fatal("ChangedNodeModules = true, want false (GentleLogo skips layer 3)")
+	}
+	if res.CacheEntryRemoved != "" {
+		t.Fatalf("CacheEntryRemoved = %q, want empty (GentleLogo skips layer 4)", res.CacheEntryRemoved)
+	}
+}
+
+func TestUninstallGentleLogoMissingTSX(t *testing.T) {
+	home := t.TempDir()
+	// tui.json references the .tsx, but the file does not exist on disk.
+	pluginDir := filepath.Join(home, ".config", "opencode", "tui-plugins")
+	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	tsxPath := filepath.Join(pluginDir, gentleLogoPluginFile)
+	writeTUIConfig(t, home, []string{tsxPath})
+
+	res, err := Uninstall(home, model.OpenCodePluginGentleLogo)
+	if err != nil {
+		t.Fatalf("Uninstall() error = %v", err)
+	}
+	if !res.ChangedTUI {
+		t.Fatal("ChangedTUI = false, want true (entry still gets removed even without the file)")
+	}
+	if res.TSXPath != "" {
+		t.Fatalf("TSXPath = %q, want empty (no file existed to remove)", res.TSXPath)
+	}
+}
+
+// ─── 8. Idempotency over the full setup ────────────────────────────────────
+
+func TestUninstallIdempotent(t *testing.T) {
+	home := t.TempDir()
+	pkgName := "opencode-subagent-statusline"
+
+	writeTUIConfig(t, home, []string{pkgName, "unrelated-plugin"})
+	writePackageJSON(t, home, `{"dependencies":{"`+pkgName+`":"^1.0.0"},"devDependencies":{"`+pkgName+`":"^1.0.0"}}`)
+	nmDir := filepath.Join(home, ".config", "opencode", "node_modules", pkgName)
+	if err := os.MkdirAll(nmDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(nmDir, "package.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(home, ".cache", "opencode", "packages", pkgName+"@latest"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".cache", "opencode", "packages", pkgName+"@latest", "data"), []byte(`{"version":"1.0.0"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	first, err := Uninstall(home, model.OpenCodePluginSubAgentStatusline)
+	if err != nil {
+		t.Fatalf("first Uninstall() error = %v", err)
+	}
+	if !first.ChangedTUI {
+		t.Fatal("first run: ChangedTUI = false, want true")
+	}
+	if !first.ChangedPackageJSON {
+		t.Fatal("first run: ChangedPackageJSON = false, want true")
+	}
+	if !first.ChangedNodeModules {
+		t.Fatal("first run: ChangedNodeModules = false, want true")
+	}
+	if first.CacheEntryRemoved == "" {
+		t.Fatal("first run: CacheEntryRemoved = '', want non-empty")
+	}
+
+	second, err := Uninstall(home, model.OpenCodePluginSubAgentStatusline)
+	if err != nil {
+		t.Fatalf("second Uninstall() error = %v", err)
+	}
+	if second.ChangedTUI {
+		t.Fatal("second run: ChangedTUI = true, want false (idempotent)")
+	}
+	if second.ChangedPackageJSON {
+		t.Fatal("second run: ChangedPackageJSON = true, want false (idempotent)")
+	}
+	if second.ChangedNodeModules {
+		t.Fatal("second run: ChangedNodeModules = true, want false (idempotent)")
+	}
+	if second.CacheEntryRemoved != "" {
+		t.Fatalf("second run: CacheEntryRemoved = %q, want empty", second.CacheEntryRemoved)
+	}
+	if second.NodeModulesPath != "" || second.TSXPath != "" {
+		t.Fatalf("second run: leaked path fields = %+v", second)
+	}
+
+	// Unrelated plugin should survive both runs.
+	if got := readTUIPlugins(t, home); len(got) != 1 || got[0] != "unrelated-plugin" {
+		t.Fatalf("tui.json plugin list after two runs = %#v, want only unrelated-plugin", got)
+	}
+}
+
+// ─── 9. Rollback ───────────────────────────────────────────────────────────
+
+// TestUninstallRollbackOnFailure forces layer 2 (package.json write) to fail
+// and verifies that the engine restores layer 1's tui.json from the journal.
+//
+// Failure injection: we replace package.json's path with a DIRECTORY instead
+// of a regular file. uninstallPackageJSON's first os.ReadFile then returns
+// "is a directory" (EISDIR) on POSIX; on Windows the journal's Capture is
+// also happy but filemerge.WriteFileAtomic's readComparableFile bails out
+// when it cannot stat a directory as a regular file. Either way, layer 2
+// errors out before any disk write and Uninstall invokes rollback.
+//
+// We deliberately do NOT rely on chmod-0500 on the file: filemerge.WriteFileAtomic
+// uses os.CreateTemp + os.Rename, both of which bypass POSIX read-only bits
+// (the rename overwrites unconditionally) and which on Windows the
+// atomic-writer self-heals via Chmod on the parent directory.
+func TestUninstallRollbackOnFailure(t *testing.T) {
+	home := t.TempDir()
+	pkgName := "opencode-subagent-statusline"
+	writeTUIConfig(t, home, []string{pkgName, "unrelated-plugin"})
+	pjPath := filepath.Join(home, ".config", "opencode", "package.json")
+	// Put a directory where package.json should be: every read or write attempt
+	// against it returns EISDIR/equivalent, so the journal captures tui.json
+	// successfully but layer 2's Write fails before any disk mutation.
+	if err := os.MkdirAll(pjPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	originalTUI := readTUIPlugins(t, home)
+
+	res, err := Uninstall(home, model.OpenCodePluginSubAgentStatusline)
+	if err == nil {
+		t.Fatal("Uninstall() error = nil, want failure from non-file package.json")
+	}
+
+	if !strings.Contains(err.Error(), "layer 2") {
+		t.Fatalf("error %q does not mention the failed stage (layer 2)", err)
+	}
+	if res.PluginID != model.OpenCodePluginSubAgentStatusline {
+		t.Fatalf("res.PluginID = %q, want %q", res.PluginID, model.OpenCodePluginSubAgentStatusline)
+	}
+	if res.ChangedTUI {
+		t.Fatal("res.ChangedTUI = true after rollback, want false (tui.json was restored)")
+	}
+
+	rolledBack := readTUIPlugins(t, home)
+	if len(rolledBack) != len(originalTUI) {
+		t.Fatalf("tui.json plugin list size mismatch after rollback: got=%v want=%v", rolledBack, originalTUI)
+	}
+	for i := range originalTUI {
+		if rolledBack[i] != originalTUI[i] {
+			t.Fatalf("tui.json not rolled back: got=%v want=%v", rolledBack, originalTUI)
+		}
+	}
+}
+
+// TestUninstallRollbackWrapsRestoreError verifies that when journal.Restore
+// fails (because a captured file has been clobbered with a symlink between
+// Capture and the failure), the rollback wraps the restore error so the
+// caller can tell restoration was also broken. We exercise this directly by
+// engineering a Restore failure against a journal that mirrors what
+// Uninstall would have produced after layer 1 succeeded.
+func TestUninstallRollbackWrapsRestoreError(t *testing.T) {
+	home := t.TempDir()
+	tuiPath := filepath.Join(home, ".config", "opencode", "tui.json")
+	if err := os.MkdirAll(filepath.Dir(tuiPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(tuiPath, []byte(`{"$schema":"https://opencode.ai/tui.json","plugin":["orig"]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate the state Uninstall leaves the journal in after layer 1 wrote
+	// successfully: <tuiPath, original bytes> is captured, the file on disk is
+	// the rewritten version. Then we clobber the on-disk file with a symlink
+	// to make a subsequent Restore fail (filemerge.WriteFileAtomic rejects
+	// symlinked targets via readComparableFile).
+	journal := mutationjournal.New(home)
+	if err := journal.Capture(tuiPath); err != nil {
+		t.Fatalf("journal.Capture() error = %v", err)
+	}
+	if err := os.WriteFile(tuiPath, []byte(`{"$schema":"https://opencode.ai/tui.json","plugin":[]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Drop the file and replace it with a symlink that points nowhere;
+	// readComparableFile then returns "refusing to read symlink" and
+	// filemerge.WriteFileAtomic bails out, producing a non-nil Restore error.
+	if err := os.Remove(tuiPath); err != nil {
+		t.Fatal(err)
+	}
+	linkTarget := filepath.Join(t.TempDir(), "nowhere.txt")
+	if err := os.Symlink(linkTarget, tuiPath); err != nil {
+		t.Skipf("symlink unsupported on this platform: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove(tuiPath) })
+
+	partial := UninstallResult{PluginID: "x", ChangedTUI: true}
+	original := errors.New("layer 2 boom")
+	res, wrapped := rollbackUninstall(journal, model.OpenCodeCommunityPluginID("x"), partial, original, "layer 2", false)
+
+	if !errors.Is(wrapped, original) {
+		t.Fatalf("rollback did not wrap original error: wrapped = %v", wrapped)
+	}
+	if res.PluginID != model.OpenCodeCommunityPluginID("x") {
+		t.Fatalf("res.PluginID = %q, want %q (PluginID is always overridden on rollback)", res.PluginID, "x")
+	}
+	if !res.ChangedTUI {
+		t.Fatal("res.ChangedTUI = false after rollback with Restore failure, want true (file modification persists on disk when Restore fails)")
+	}
+	if !strings.Contains(wrapped.Error(), "restore journal after layer 2") {
+		t.Fatalf("wrapped error %q does not mention the failed stage", wrapped)
+	}
+	if !strings.Contains(wrapped.Error(), "refusing to read symlink") {
+		t.Fatalf("wrapped error %q does not wrap the restore failure", wrapped)
+	}
+}
+
+// ─── 10. Journal path validation ───────────────────────────────────────────
+
+// TestUninstallJournalRejectsOutsideRoot verifies the defense the
+// mutationjournal provides against path traversal: the journal used by
+// Uninstall rejects any path outside homeDir. We exercise this directly with
+// the same construction Uninstall uses (mutationjournal.New(homeDir)). It is
+// impossible to drive an out-of-root path through Uninstall's public API
+// because every path Uninstall computes (tui.json, package.json, the .tsx
+// file) is derived from homeDir and therefore within the journal's root —
+// so this test pins down the contract that makes Uninstall safe by
+// construction.
+func TestUninstallJournalRejectsOutsideRoot(t *testing.T) {
+	home := t.TempDir()
+
+	insideFile := filepath.Join(home, ".config", "opencode", "tui.json")
+	if err := os.MkdirAll(filepath.Dir(insideFile), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(insideFile, []byte(`{"$schema":"https://opencode.ai/tui.json"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	outside := t.TempDir()
+	outsideFile := filepath.Join(outside, "package.json")
+	if err := os.WriteFile(outsideFile, []byte(`{"dependencies":{}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	journal := mutationjournal.New(home)
+	if err := journal.Capture(insideFile); err != nil {
+		t.Fatalf("journal.Capture(inside) error = %v, want nil", err)
+	}
+	err := journal.Capture(outsideFile)
+	if err == nil {
+		t.Fatal("journal.Capture(outside) error = nil, want outside-roots rejection")
+	}
+	if !strings.Contains(err.Error(), "outside") {
+		t.Fatalf("error %q does not mention outside-roots", err)
+	}
+}


### PR DESCRIPTION
Slice 2/3 — four-layer managed uninstall engine for OpenCode community plugins. Stacked on slice 1 (`mutationjournal`).

Part of the `uninstall-managed-plugin` stacked chain. **Closes #800** (engine slice — the user-facing CLI+TUI integration lands in #1134).

## Summary

Implements the four-layer managed uninstall for OpenCode community plugins:

1. `~/.config/opencode/tui.json` — remove only the target entry from `plugin[]`, preserving user-added entries
2. `~/.config/opencode/package.json` — remove from `dependencies` and `devDependencies`, no-op if missing
3. `~/.config/opencode/node_modules/<pkg>/` — `os.RemoveAll` with journal before-image (executor.go:96 excludes `node_modules` from snapshots, so the journal is the only recovery path)
4. `~/.cache/opencode/packages/<pkg>@latest` — exact-path removal mirroring `internal/update/upgrade/strategy.go:clearOpenCodePluginPackageCache`. Silent no-op if missing.

**Special case for `OpenCodePluginGentleLogo`** (built-in `.tsx` local, not NPM): removes the `tui.json` entry plus the local `tui-plugins/gentle-logo.tsx` file; skips the NPM layers and the cache layer.

**KNOWN LIMITATION**: layers 3 and TSX are not journal-restorable (directories, not files). On failure after these deletions, callers that need a guaranteed revert must snapshot them out of band.

**Rollback contract**: any post-write failure triggers `journal.Restore()` and returns the partial `UninstallResult` with `ChangedTUI`/`ChangedPackageJSON` flipped back to false.

## Changes

| File | Change |
|------|--------|
| `internal/components/opencodeplugin/uninstall.go` | `Uninstall`, `UninstallResult`, layer helpers `uninstallPackageJSON`, `uninstallCacheEntry`, `rollbackUninstall`, `removalRecord` (+251 lines) |
| `internal/components/opencodeplugin/uninstall_test.go` | 18 tests covering all layers, GentleLogo, rollback, idempotency, partial result preservation, POSIX-portable failure injection via directory-as-file (+694 lines) |
| `internal/components/opencodeplugin/plugin.go` | Add `removeTUIPlugin` (mirror of `ensureTUIPlugin`); returns `(changed, afterBytes, err)` (+48 lines) |

This PR also carries slice 1 files in the diff because base = `main` and the slice branches live only in the contributor's fork (see Notes for Reviewers).

**PR diff totals** (per GitHub API): **+1,513 / -0 across 5 files** including slice 1 carry-over.
**Slice 2-specific additions** (excluding slice 1 carry-over): **+993 / -0 across 3 files** (48+251+694).

## Test Plan

- [x] `go build ./...` clean
- [x] `go test ./internal/components/opencodeplugin/... -v` — all PASS
- [x] `go test ./internal/components/mutationjournal/... -v` — no regressions
- [x] `go vet ./internal/components/opencodeplugin/...` — clean
- [x] **Pre-existing repo failures unchanged** — `pi_codegraph` and `tui/sync` clusters present on `main` are not introduced by this slice; verified identical via `git stash` baseline.

> **Known pre-existing failures (not blocking this PR):** these failure clusters are present on `main` independently of this slice and will be tracked separately.

- [x] **Round-1 dual review addressed.** Initial review (jd-judge-a/b) flagged BLOCKER F1 (cache path), CRITICAL F2 (rollback partial result), CRITICAL F3 (POSIX rollback test), plus 7 WARNING items. All addressed in commit `180bd31`; TDD discipline verified by reverting F1 and F2 in isolation and confirming targeted tests fail with expected diagnostics.
- [x] **Round-2 polish applied.** Commit `8ff8575` addressed 9 SUGGESTION/WARNING items: `plugins[:0:0]` → `make()`, `OwnedFile` reuse, error message consistency, `sha256("")` as precomputed constant, `TestUninstallRemovesAllDuplicateTUIEntries` added. No behaviour change vs `180bd31`; all 21 package tests pass; `go vet` clean.

## Contributor Checklist

- [x] PR is linked to an issue with `status:approved` (#800) — verified via `gh issue view 800`
- [x] Slice 2-specific additions: +993 / -0 across 3 files (each slice reviewable in isolation)
- [x] Local unit tests pass for this slice (`go test ./internal/components/opencodeplugin/...`)
- [x] `go build ./...` clean locally
- [x] `go vet ./...` clean locally
- [x] N/A — no shell scripts modified
- [x] N/A — no documentation needed (package doc explains the contract)
- [x] Commits follow Conventional Commits format
- [x] No `Co-Authored-By` trailers
- [x] Pre-existing repo failures verified unchanged via `git stash` baseline
- [x] Round-1 dual review BLOCKER + CRITICAL findings addressed in `180bd31`
- [x] Round-2 polish (9 items) applied in `8ff8575`; all 21 package tests pass
- [x] Style matches `internal/components/uninstall/service.go` reference (same `%w` error wrapping, `filemerge` atomic-write reliance, `t.TempDir()` test isolation)

## Pending maintainer actions (gentle-ai repo convention)

The following are **maintainer-applied per `pr-check.yml` and CONTRIBUTING.md** in this repo — not within contributor scope:

- [ ] `type:feature` label applied to this PR — pending Alan
- [ ] `size:exception` consideration — PR diff totals +1,513 / -0 across 5 files, slice 2-specific is +993. Either Alan accepts a `size:exception` with the rationale that the chain is reviewable per slice (this PR adds slice 2 work + the slice 1 fixture already reviewed in #1132), or the chain is restructured (e.g. Alan pushes slice branches upstream as branches, allowing each PR to diff against its parent instead of `main`).
- [ ] Fork workflow approval — 4 runs in `action_required` awaiting Alan

## Notes for Reviewers

Depends on slice 1 (`internal/components/mutationjournal`). Dependency direction: `opencodeplugin → mutationjournal → filemerge`; no circular imports. The journal integration uses only the slice 1 public API. Cache cleanup path was chosen to exactly mirror `internal/update/upgrade/strategy.go:clearOpenCodePluginPackageCache` to avoid divergent paths between install and uninstall flows.

**Slice 2-specific commits to focus on** (when this PR is rebased onto `main` + slice 1 merge commit, only these two remain in the diff):
- `180bd31` — `feat(opencodeplugin): add four-layer managed uninstall for community plugins`
- `8ff8575` — `refactor(opencodeplugin): address slice 2 review suggestions`

**Why base = `main` and not `slice/journal-cas`:** the slice branches live only in `ardelperal/gentle-ai`, not in the upstream repository. GitHub does not currently support cross-fork base configuration, so the slice 2 and slice 3 PRs base on `main` and include the slice 1 commit in their diff. Reviewers can verify slice 1's correctness in PR #1132 separately, then approve this PR. The actual merge ordering would be: #1132 first, then this PR rebased onto `main` + slice 1's merge commit.

**Suggested merge order:** #1132 → rebase this PR onto `main` + slice 1 merge commit → #1134 rebased onto this PR.
