### PR TITLE
fix(tui): bound and scroll long advisories

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -78,6 +79,15 @@ func sanitizeAdvisoryMessage(s string) string {
 		}
 	}
 	return b.String()
+}
+
+func sanitizeAdvisoryURL(raw string) string {
+	cleaned := sanitizeAdvisoryMessage(strings.TrimSpace(raw))
+	parsed, err := url.ParseRequestURI(cleaned)
+	if err != nil || parsed.Scheme != "https" || parsed.Host == "" {
+		return ""
+	}
+	return parsed.String()
 }
 
 // osStatModelCache is a package-level variable so tests can override it to
@@ -460,6 +470,8 @@ type Model struct {
 	// fetch, when a non-empty message was returned. Empty string means no
 	// advisory to display. Set asynchronously via AdvisoryMsg.
 	AdvisoryMessage string
+	AdvisoryURL     string
+	AdvisoryScroll  int
 
 	// pipelineRunning tracks whether the pipeline goroutine is active.
 	pipelineRunning bool
@@ -723,6 +735,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		m.Width = msg.Width
 		m.Height = msg.Height
+		m.clampAdvisoryScroll()
 		return m, nil
 	case TickMsg:
 		if m.Screen == ScreenInstalling && !m.Progress.Done() {
@@ -823,6 +836,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Sanitize before storing: strip ANSI escape sequences and control
 		// characters so remote-controlled content cannot corrupt the TUI layout.
 		m.AdvisoryMessage = sanitizeAdvisoryMessage(msg.Advisory.Message)
+		m.AdvisoryURL = sanitizeAdvisoryURL(msg.Advisory.URL)
+		m.AdvisoryScroll = 0
 		return m, nil
 	case UpgradeDoneMsg:
 		m.OperationRunning = false
@@ -991,16 +1006,12 @@ func (m Model) View() string {
 		if m.UpdateCheckDone && update.HasUpdates(m.UpdateResults) {
 			banner = "Updates available: " + update.UpdateSummaryLine(m.UpdateResults)
 		}
-		// Append advisory message below the update banner when present.
-		// The advisory is purely informational and never replaces or blocks
-		// any other launch behavior.
-		if m.AdvisoryMessage != "" {
-			if banner != "" {
-				banner += "\n"
-			}
-			banner += "Advisory: " + m.AdvisoryMessage
-		}
-		return screens.RenderWelcomeWithWidth(m.Cursor, m.Version, banner, m.UpdateResults, m.UpdateCheckDone, m.hasDetectedOpenCode(), len(m.ProfileList), m.hasAgentBuilderEngines(), m.Width)
+		return screens.RenderWelcomeWithAdvisory(
+			m.Cursor, m.Version, banner, m.UpdateResults, m.UpdateCheckDone,
+			m.hasDetectedOpenCode(), len(m.ProfileList), m.hasAgentBuilderEngines(),
+			m.Width, m.Height,
+			screens.WelcomeAdvisory{Message: m.AdvisoryMessage, URL: m.AdvisoryURL, Scroll: m.AdvisoryScroll},
+		)
 	case ScreenUpgrade:
 		return screens.RenderUpgradeWithWidth(m.UpdateResults, m.UpgradeReport, m.UpgradeErr, m.OperationRunning, m.UpdateCheckDone, m.Cursor, m.SpinnerFrame, m.Width)
 	case ScreenSync:
@@ -1286,6 +1297,17 @@ func (m Model) handleKeyPress(key tea.KeyMsg) (tea.Model, tea.Cmd) {
 	if m.Screen == ScreenUpdatePrompt {
 		return m.handleUpdatePromptKey(keyStr)
 	}
+	if m.Screen == ScreenWelcome {
+		pageSize, maxScroll := screens.WelcomeAdvisoryScrollBounds(m.AdvisoryMessage, m.AdvisoryURL, m.Width, m.Height)
+		switch keyStr {
+		case "pgup":
+			m.AdvisoryScroll = max(0, m.AdvisoryScroll-pageSize)
+			return m, nil
+		case "pgdown":
+			m.AdvisoryScroll = min(maxScroll, m.AdvisoryScroll+pageSize)
+			return m, nil
+		}
+	}
 
 	switch keyStr {
 	case "ctrl+c", "q":
@@ -1478,6 +1500,11 @@ func (m Model) handleKeyPress(key tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 
 	return m, nil
+}
+
+func (m *Model) clampAdvisoryScroll() {
+	_, maxScroll := screens.WelcomeAdvisoryScrollBounds(m.AdvisoryMessage, m.AdvisoryURL, m.Width, m.Height)
+	m.AdvisoryScroll = min(max(0, m.AdvisoryScroll), maxScroll)
 }
 
 func (m Model) shouldSkipModelPickerSeparator() bool {

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -5459,6 +5459,122 @@ func TestWelcomeView_LongAdvisoryStaysWithinWindowWidth(t *testing.T) {
 	}
 }
 
+func TestWelcomeAdvisory_BoundsAndScrollsOverflow(t *testing.T) {
+	const releaseURL = "https://github.com/Gentleman-Programming/gentle-ai/releases/tag/v1.49.0"
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Width = 60
+	m.Height = 50
+	updated, _ := m.Update(AdvisoryMsg{Advisory: update.Advisory{
+		Message: strings.Repeat("release detail ", 80),
+		URL:     releaseURL,
+	}})
+	state := updated.(Model)
+	initial := state.View()
+
+	if got := lipgloss.Height(initial); got > state.Height {
+		t.Fatalf("welcome height = %d, want <= terminal height %d", got, state.Height)
+	}
+	if !strings.Contains(initial, "PgUp/PgDn: scroll") {
+		t.Fatalf("overflowing advisory missing scroll affordance\nview:\n%s", initial)
+	}
+	if !strings.Contains(initial, "Latest release:") || !strings.Contains(initial, "v1.49.0") {
+		t.Fatalf("overflowing advisory did not keep release link visible\nview:\n%s", initial)
+	}
+	if !strings.Contains(initial, "Start installation") {
+		t.Fatalf("overflowing advisory crowded out primary action\nview:\n%s", initial)
+	}
+
+	updated, _ = state.Update(tea.KeyMsg{Type: tea.KeyPgDown})
+	state = updated.(Model)
+	if state.AdvisoryScroll == 0 {
+		t.Fatal("Page Down did not advance advisory scroll")
+	}
+	if state.Cursor != 0 {
+		t.Fatalf("Page Down changed menu cursor to %d", state.Cursor)
+	}
+	if got := state.View(); got == initial {
+		t.Fatal("Page Down did not change visible advisory content")
+	}
+
+	updated, _ = state.Update(tea.KeyMsg{Type: tea.KeyPgUp})
+	if got := updated.(Model).AdvisoryScroll; got != 0 {
+		t.Fatalf("Page Up scroll = %d, want 0", got)
+	}
+}
+
+func TestWelcomeAdvisory_FittingContentShowsLatestReleaseWithoutScrollHint(t *testing.T) {
+	const releaseURL = "https://github.com/Gentleman-Programming/gentle-ai/releases/tag/v1.49.0"
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Width = 100
+	m.Height = 60
+	updated, _ := m.Update(AdvisoryMsg{Advisory: update.Advisory{
+		Message: "Maintenance improvements are available.",
+		URL:     releaseURL,
+	}})
+	state := updated.(Model)
+	view := state.View()
+
+	if state.AdvisoryURL != releaseURL || !strings.Contains(view, "Latest release: "+releaseURL) {
+		t.Fatalf("latest release link not carried through\nview:\n%s", view)
+	}
+	if strings.Contains(view, "PgUp/PgDn: scroll") {
+		t.Fatalf("fitting advisory unexpectedly shows scroll affordance\nview:\n%s", view)
+	}
+}
+
+func TestWelcomeAdvisory_SmallTerminalPreservesMenu(t *testing.T) {
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Width = 60
+	m.Height = 35
+	baselineHeight := lipgloss.Height(m.View())
+	updated, _ := m.Update(AdvisoryMsg{Advisory: update.Advisory{
+		Message: strings.Repeat("long advisory ", 80),
+		URL:     "https://github.com/Gentleman-Programming/gentle-ai/releases/tag/v1.49.0",
+	}})
+	view := updated.(Model).View()
+
+	if got := lipgloss.Height(view); got != baselineHeight {
+		t.Fatalf("small-terminal advisory added %d lines, want none", got-baselineHeight)
+	}
+	if !strings.Contains(view, "Start installation") {
+		t.Fatalf("small-terminal welcome lost primary action\nview:\n%s", view)
+	}
+}
+
+func TestWelcomeAdvisory_ResizeAndContentChangesClampScroll(t *testing.T) {
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Width = 45
+	m.Height = 60
+	updated, _ := m.Update(AdvisoryMsg{Advisory: update.Advisory{
+		Message: strings.Repeat("release detail ", 12),
+		URL:     "https://github.com/Gentleman-Programming/gentle-ai/releases/tag/v1.49.0",
+	}})
+	state := updated.(Model)
+	updated, _ = state.Update(tea.KeyMsg{Type: tea.KeyPgDown})
+	state = updated.(Model)
+	if state.AdvisoryScroll == 0 {
+		t.Fatal("test setup did not produce advisory overflow")
+	}
+
+	updated, _ = state.Update(tea.WindowSizeMsg{Width: 120, Height: 80})
+	state = updated.(Model)
+	if state.AdvisoryScroll != 0 {
+		t.Fatalf("scroll after fitting resize = %d, want 0", state.AdvisoryScroll)
+	}
+	if strings.Contains(state.View(), "PgUp/PgDn: scroll") {
+		t.Fatal("scroll affordance remained after content fit")
+	}
+
+	updated, _ = state.Update(tea.WindowSizeMsg{Width: 45, Height: 60})
+	state = updated.(Model)
+	updated, _ = state.Update(tea.KeyMsg{Type: tea.KeyPgDown})
+	state = updated.(Model)
+	updated, _ = state.Update(AdvisoryMsg{Advisory: update.Advisory{Message: "Short notice."}})
+	if got := updated.(Model).AdvisoryScroll; got != 0 {
+		t.Fatalf("scroll after advisory content change = %d, want 0", got)
+	}
+}
+
 // ─── Advisory message sanitization tests ─────────────────────────────────────
 
 // TestSanitizeAdvisoryMessage_StripControlChars verifies that ASCII control

--- a/internal/tui/screens/welcome.go
+++ b/internal/tui/screens/welcome.go
@@ -10,6 +10,17 @@ import (
 	"github.com/rivo/uniseg"
 )
 
+const (
+	welcomeAdvisoryMaxRegionHeight = 7
+	welcomePrimaryContentHeight    = 44
+)
+
+type WelcomeAdvisory struct {
+	Message string
+	URL     string
+	Scroll  int
+}
+
 // WelcomeOptions returns the welcome menu options.
 // When showProfiles is true, an "OpenCode SDD Profiles" option is inserted
 // between "Configure models" and "Manage backups".
@@ -60,6 +71,10 @@ func RenderWelcome(cursor int, version string, updateBanner string, updateResult
 }
 
 func RenderWelcomeWithWidth(cursor int, version string, updateBanner string, updateResults []update.UpdateResult, updateCheckDone bool, showProfiles bool, profileCount int, hasEngines bool, width int) string {
+	return RenderWelcomeWithAdvisory(cursor, version, updateBanner, updateResults, updateCheckDone, showProfiles, profileCount, hasEngines, width, 0, WelcomeAdvisory{})
+}
+
+func RenderWelcomeWithAdvisory(cursor int, version string, updateBanner string, updateResults []update.UpdateResult, updateCheckDone bool, showProfiles bool, profileCount int, hasEngines bool, width int, height int, advisory WelcomeAdvisory) string {
 	var b strings.Builder
 
 	b.WriteString(styles.RenderLogo())
@@ -69,6 +84,10 @@ func RenderWelcomeWithWidth(cursor int, version string, updateBanner string, upd
 
 	if updateBanner != "" {
 		b.WriteString(styles.WarningStyle.Render(wrapWelcomeBanner(updateBanner, welcomeContentWidth(width))))
+		b.WriteString("\n")
+	}
+	if rendered := renderWelcomeAdvisory(advisory, width, height); rendered != "" {
+		b.WriteString(rendered)
 		b.WriteString("\n")
 	}
 
@@ -83,6 +102,64 @@ func RenderWelcomeWithWidth(cursor int, version string, updateBanner string, upd
 		return styles.FrameStyle.Width(width - 4).Render(b.String())
 	}
 	return styles.FrameStyle.Render(b.String())
+}
+
+func WelcomeAdvisoryScrollBounds(message string, releaseURL string, width int, height int) (int, int) {
+	lines := welcomeAdvisoryLines(message, releaseURL, welcomeContentWidth(width))
+	regionHeight := welcomeAdvisoryRegionHeight(height)
+	if len(lines) == 0 || regionHeight == 0 {
+		return 0, 0
+	}
+	if len(lines) <= regionHeight {
+		return len(lines), 0
+	}
+	if regionHeight < 2 {
+		return 0, 0
+	}
+	pageSize := regionHeight - 1
+	return pageSize, len(lines) - pageSize
+}
+
+func renderWelcomeAdvisory(advisory WelcomeAdvisory, width int, height int) string {
+	lines := welcomeAdvisoryLines(advisory.Message, advisory.URL, welcomeContentWidth(width))
+	pageSize, maxScroll := WelcomeAdvisoryScrollBounds(advisory.Message, advisory.URL, width, height)
+	if pageSize == 0 {
+		return ""
+	}
+	scroll := min(max(0, advisory.Scroll), maxScroll)
+	end := min(scroll+pageSize, len(lines))
+	rendered := styles.WarningStyle.Render(strings.Join(lines[scroll:end], "\n"))
+	if maxScroll > 0 {
+		hint := fmt.Sprintf("PgUp/PgDn: scroll  •  lines %d-%d/%d", scroll+1, end, len(lines))
+		rendered += "\n" + styles.HelpStyle.Render(hint)
+	}
+	return rendered
+}
+
+func welcomeAdvisoryLines(message string, releaseURL string, width int) []string {
+	message = strings.TrimSpace(message)
+	if message == "" {
+		return nil
+	}
+	if !strings.HasPrefix(message, "Advisory:") {
+		message = "Advisory: " + message
+	}
+	messageLines := strings.Split(wrapWelcomeBanner(message, width), "\n")
+	if releaseURL == "" {
+		return messageLines
+	}
+	link := "Latest release: " + releaseURL
+	if width <= 0 {
+		return append([]string{link}, messageLines...)
+	}
+	return append(wrapPlainLine(link, width), messageLines...)
+}
+
+func welcomeAdvisoryRegionHeight(height int) int {
+	if height <= 0 {
+		return welcomeAdvisoryMaxRegionHeight
+	}
+	return min(welcomeAdvisoryMaxRegionHeight, max(0, height-welcomePrimaryContentHeight))
 }
 
 func welcomeContentWidth(width int) int {


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1140

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

Bounds long welcome advisories to the available terminal height and makes overflowing content scrollable without hiding primary menu actions.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/tui/model.go` | Track sanitized release URLs and advisory scroll state; handle Page Up/Page Down and resize clamping |
| `internal/tui/screens/welcome.go` | Render a height-bounded advisory viewport with release link and overflow position hint |
| `internal/tui/model_test.go` | Cover overflow bounds, scrolling, small terminals, release links, and resize/content reset behavior |

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./internal/tui/... -count=1
env -u GENTLE_AI_CHANNEL go test ./... -count=1
```

**E2E Tests** (Docker required)
```bash
cd e2e && ./docker-test.sh
```

- [x] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Manually tested locally

Verified the overflowing welcome layout across terminal-height and menu-option combinations. E2E is not run because this repository has no interactive TUI runtime harness for this behavior.

---

## 🤖 Automated Checks

The following checks run automatically on this PR:

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | PR should stay within 400 changed lines (`additions + deletions`) or use `size:exception` |
| Check Issue Reference | ⏳ | PR body must contain `Closes/Fixes/Resolves #N` |
| Check Issue Has `status:approved` | ⏳ | Linked issue must have been approved before work began |
| Check PR Has `type:*` Label | ⏳ | Exactly one `type:*` label must be applied |
| Unit Tests | ⏳ | `go test ./...` must pass |
| E2E Tests | ⏳ | `cd e2e && ./docker-test.sh` must pass |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

The advisory viewport is intentionally capped so remote advisory content cannot crowd out the welcome menu and controls.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added advisory content to the welcome screen, including a “Latest release” link.
  * Added PgUp/PgDn scrolling for longer advisory messages.
  * Preserved the primary installation action across different terminal sizes.
  * Validated advisory links to accept only secure HTTPS URLs.

* **Bug Fixes**
  * Advisory content now stays within the available terminal area.
  * Scrolling resets and remains within valid bounds when content or window size changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->