### PR TITLE
feat(opencode): configure review agent models

### DIFF
--- a/internal/components/sdd/inject.go
+++ b/internal/components/sdd/inject.go
@@ -932,7 +932,7 @@ func inlineOpenCodeSDDPrompts(overlayBytes []byte, homeDir, settingsPath string,
 }
 
 func expandOpenCodeBoundedReviewAgents(agentsMap map[string]any) {
-	for _, name := range []string{"review-risk", "review-readability", "review-reliability", "review-resilience"} {
+	for _, name := range opencode.ReviewLensPhases() {
 		agent, ok := agentsMap[name].(map[string]any)
 		if !ok {
 			continue
@@ -951,7 +951,7 @@ func expandOpenCodeBoundedReviewAgents(agentsMap map[string]any) {
 		agent["tools"] = map[string]any{"read": true, "write": false, "edit": false, "bash": false, "task": false}
 	}
 
-	if refuter, ok := agentsMap[reviewRefuterAgentName].(map[string]any); ok {
+	if refuter, ok := agentsMap[opencode.ReviewRefuterAgent].(map[string]any); ok {
 		refuter["prompt"] = "You are the detached read-only refuter for exactly ONE transaction-wide inferential batch. Receive every inferential severe neutral claim and proof reference, return one corroborated | refuted | inconclusive result per finding, add no findings, modify nothing, return one complete result, and terminate. Missing or malformed entries are inconclusive."
 		refuter["tools"] = map[string]any{"read": true, "write": false, "edit": false, "bash": false, "task": false}
 	}

--- a/internal/components/sdd/inject_test.go
+++ b/internal/components/sdd/inject_test.go
@@ -21,6 +21,7 @@ import (
 	windsurfagent "github.com/gentleman-programming/gentle-ai/internal/agents/windsurf"
 	"github.com/gentleman-programming/gentle-ai/internal/assets"
 	"github.com/gentleman-programming/gentle-ai/internal/model"
+	opencodemodel "github.com/gentleman-programming/gentle-ai/internal/opencode"
 	// agents/cursor, agents/gemini, agents/vscode used via agents.NewAdapter()
 )
 
@@ -2787,10 +2788,23 @@ func TestInjectOpenClawRejectsAmbiguousWorkspacePath(t *testing.T) {
 func TestInjectOpenCodeMultiModeWithModelAssignments(t *testing.T) {
 	mockNoPackageManager(t)
 	home := t.TempDir()
+	settingsPath := filepath.Join(home, ".config", "opencode", "opencode.json")
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	seed := `{"$schema":"https://opencode.ai/config.json","username":"review-user","agent":{"custom":{"model":"custom/provider-model","description":"preserve me"}}}`
+	if err := os.WriteFile(settingsPath, []byte(seed), 0o644); err != nil {
+		t.Fatalf("WriteFile(opencode.json) error = %v", err)
+	}
 
 	assignments := map[string]model.ModelAssignment{
-		"sdd-init":  {ProviderID: "anthropic", ModelID: "claude-sonnet-4-20250514"},
-		"sdd-apply": {ProviderID: "openai", ModelID: "gpt-4o"},
+		"sdd-init":           {ProviderID: "anthropic", ModelID: "claude-sonnet-4-20250514"},
+		"sdd-apply":          {ProviderID: "openai", ModelID: "gpt-4o"},
+		"review-risk":        {ProviderID: "anthropic", ModelID: "claude-sonnet-4"},
+		"review-readability": {ProviderID: "openai", ModelID: "gpt-5-mini"},
+		"review-reliability": {ProviderID: "openai", ModelID: "gpt-5"},
+		"review-resilience":  {ProviderID: "anthropic", ModelID: "claude-sonnet-4"},
+		"review-refuter":     {ProviderID: "openai", ModelID: "gpt-5", Effort: "high"},
 	}
 
 	result, err := Inject(home, opencodeAdapter(), "multi", InjectOptions{OpenCodeModelAssignments: assignments})
@@ -2801,7 +2815,6 @@ func TestInjectOpenCodeMultiModeWithModelAssignments(t *testing.T) {
 		t.Fatal("Inject(multi, assignments) changed = false")
 	}
 
-	settingsPath := filepath.Join(home, ".config", "opencode", "opencode.json")
 	content, err := os.ReadFile(settingsPath)
 	if err != nil {
 		t.Fatalf("ReadFile(opencode.json) error = %v", err)
@@ -2815,6 +2828,13 @@ func TestInjectOpenCodeMultiModeWithModelAssignments(t *testing.T) {
 	agentMap, ok := root["agent"].(map[string]any)
 	if !ok {
 		t.Fatal("opencode.json missing agent map")
+	}
+	if root["$schema"] != "https://opencode.ai/config.json" || root["username"] != "review-user" {
+		t.Fatalf("unrelated config was not preserved: %v", root)
+	}
+	custom := agentMap["custom"].(map[string]any)
+	if custom["model"] != "custom/provider-model" || custom["description"] != "preserve me" {
+		t.Fatalf("unrelated custom agent changed: %v", custom)
 	}
 
 	// Verify sdd-init has the assigned model.
@@ -2833,6 +2853,21 @@ func TestInjectOpenCodeMultiModeWithModelAssignments(t *testing.T) {
 	}
 	if m, _ := applyAgent["model"].(string); m != "openai/gpt-4o" {
 		t.Fatalf("sdd-apply model = %q, want %q", m, "openai/gpt-4o")
+	}
+	for agent, want := range map[string]string{
+		"review-risk":        "anthropic/claude-sonnet-4",
+		"review-readability": "openai/gpt-5-mini",
+		"review-reliability": "openai/gpt-5",
+		"review-resilience":  "anthropic/claude-sonnet-4",
+		"review-refuter":     "openai/gpt-5",
+	} {
+		definition := agentMap[agent].(map[string]any)
+		if got := definition["model"]; got != want {
+			t.Fatalf("%s model = %q, want %q", agent, got, want)
+		}
+	}
+	if got := agentMap["review-refuter"].(map[string]any)["variant"]; got != "high" {
+		t.Fatalf("review-refuter variant = %q, want high", got)
 	}
 
 	// Unassigned phases should NOT have a model field — the overlay no longer
@@ -4919,7 +4954,7 @@ func TestInjectWritesNativeReviewAgentFiles(t *testing.T) {
 				t.Fatalf("Inject(%s) changed = false", tt.name)
 			}
 
-			for _, agent := range reviewAgentNames {
+			for _, agent := range opencodemodel.ReviewLensPhases() {
 				assertNativeAgentFile(t, filepath.Join(tt.agentsDir(home), agent+".md"), `"findings":[]`)
 				for _, ext := range tt.extraExts {
 					want := tt.extraContains[ext]
@@ -4929,13 +4964,13 @@ func TestInjectWritesNativeReviewAgentFiles(t *testing.T) {
 					assertNativeAgentFile(t, filepath.Join(tt.agentsDir(home), agent+ext), want)
 				}
 			}
-			assertNativeAgentFile(t, filepath.Join(tt.agentsDir(home), reviewRefuterAgentName+".md"), "complete merged list of BLOCKER/CRITICAL candidates")
+			assertNativeAgentFile(t, filepath.Join(tt.agentsDir(home), opencodemodel.ReviewRefuterAgent+".md"), "complete merged list of BLOCKER/CRITICAL candidates")
 			for _, ext := range tt.extraExts {
 				want := tt.extraContains[ext]
 				if ext == ".yaml" {
-					want += reviewRefuterAgentName + ".md"
+					want += opencodemodel.ReviewRefuterAgent + ".md"
 				}
-				assertNativeAgentFile(t, filepath.Join(tt.agentsDir(home), reviewRefuterAgentName+ext), want)
+				assertNativeAgentFile(t, filepath.Join(tt.agentsDir(home), opencodemodel.ReviewRefuterAgent+ext), want)
 			}
 		})
 	}

--- a/internal/components/sdd/profiles.go
+++ b/internal/components/sdd/profiles.go
@@ -65,15 +65,6 @@ var profilePhaseOrder = []string{
 	"sdd-onboard",
 }
 
-var reviewAgentNames = []string{
-	"review-risk",
-	"review-readability",
-	"review-reliability",
-	"review-resilience",
-}
-
-const reviewRefuterAgentName = "review-refuter"
-
 // ProfilePhaseOrder returns the ordered list of SDD sub-agent phase names.
 // Use this instead of duplicating the slice in other packages.
 func ProfilePhaseOrder() []string {
@@ -302,13 +293,12 @@ func GenerateProfileOverlay(profile model.Profile, homeDir string, codeGraphGuid
 			taskPerms[jd] = "allow"
 		}
 	}
-	// Add 4R review agent permissions (global, not profile-scoped).
+	// Add native review agent permissions (global, not profile-scoped).
 	// The base overlays define these shared review agents; named profiles only
 	// need permission to delegate to the unsuffixed global agent keys.
-	for _, reviewAgent := range reviewAgentNames {
+	for _, reviewAgent := range opencode.ReviewPhases() {
 		taskPerms[reviewAgent] = "allow"
 	}
-	taskPerms[reviewRefuterAgentName] = "allow"
 
 	orchEntry := map[string]any{
 		"mode":        "primary",

--- a/internal/components/sdd/profiles_test.go
+++ b/internal/components/sdd/profiles_test.go
@@ -985,10 +985,9 @@ func expectedTaskPermissions(suffix string) map[string]any {
 	}
 	// Review agents are global (not profile-scoped), so named profile
 	// orchestrators also need unsuffixed permissions to delegate to them.
-	for _, reviewAgent := range reviewAgentNames {
+	for _, reviewAgent := range opencode.ReviewPhases() {
 		permissions[reviewAgent] = "allow"
 	}
-	permissions[reviewRefuterAgentName] = "allow"
 	// JD agents are global (not profile-scoped) — always unsuffixed.
 	for _, jd := range opencode.JDPhases() {
 		permissions[jd] = "allow"

--- a/internal/components/sdd/read_assignments.go
+++ b/internal/components/sdd/read_assignments.go
@@ -1,20 +1,20 @@
 package sdd
 
 import (
-	"encoding/json"
 	"os"
 	"strings"
 
+	"github.com/gentleman-programming/gentle-ai/internal/components/filemerge"
 	"github.com/gentleman-programming/gentle-ai/internal/model"
 	"github.com/gentleman-programming/gentle-ai/internal/opencode"
 )
 
 // configurableAgentSet is the set of valid agent names that may appear in
-// opencode.json. It includes SDD phases, JD agents, and the gentle-orchestrator coordinator.
+// opencode.json. It includes SDD, Judgment Day, review, and coordinator agents.
 var configurableAgentSet = buildConfigurableAgentSet()
 
 func buildConfigurableAgentSet() map[string]bool {
-	phases := opencode.ConfigurableAgentPhases() // SDD + JD phases
+	phases := opencode.ConfigurableAgentPhases()
 	set := make(map[string]bool, len(phases)+1)
 	for _, p := range phases {
 		set[p] = true
@@ -51,8 +51,8 @@ func ReadCurrentModelAssignments(settingsPath string) (map[string]model.ModelAss
 		return nil, err
 	}
 
-	var root map[string]any
-	if err := json.Unmarshal(data, &root); err != nil {
+	root, err := filemerge.UnmarshalJSONObject(data)
+	if err != nil {
 		// Unparseable JSON — return empty map, no error.
 		return map[string]model.ModelAssignment{}, nil
 	}

--- a/internal/components/sdd/read_assignments_test.go
+++ b/internal/components/sdd/read_assignments_test.go
@@ -59,6 +59,37 @@ func TestReadCurrentModelAssignments(t *testing.T) {
 	}
 }
 
+func TestReadCurrentModelAssignmentsIncludesReviewAgentsFromJSONC(t *testing.T) {
+	dir := t.TempDir()
+	settingsPath := filepath.Join(dir, "opencode.json")
+	content := `{
+  // Reviewer models remain global across named profiles.
+  "agent": {
+    "review-risk": { "model": "anthropic/claude-sonnet-4" },
+    "review-readability": { "model": "openai/gpt-5" },
+    "review-reliability": { "model": "openai/gpt-5" },
+    "review-resilience": { "model": "anthropic/claude-sonnet-4" },
+    "review-refuter": { "model": "openai/gpt-5", "variant": "high" },
+  },
+}`
+	if err := os.WriteFile(settingsPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write settings: %v", err)
+	}
+
+	got, err := ReadCurrentModelAssignments(settingsPath)
+	if err != nil {
+		t.Fatalf("ReadCurrentModelAssignments() error = %v", err)
+	}
+	for _, agent := range []string{"review-risk", "review-readability", "review-reliability", "review-resilience", "review-refuter"} {
+		if got[agent].ProviderID == "" || got[agent].ModelID == "" {
+			t.Errorf("review assignment %q missing: %v", agent, got)
+		}
+	}
+	if got["review-refuter"].Effort != "high" {
+		t.Fatalf("review-refuter effort = %q, want high", got["review-refuter"].Effort)
+	}
+}
+
 func TestReadCurrentModelAssignmentsNoFile(t *testing.T) {
 	got, err := ReadCurrentModelAssignments("/nonexistent/path/opencode.json")
 	if err != nil {

--- a/internal/components/sdd/review_ledger_contract_test.go
+++ b/internal/components/sdd/review_ledger_contract_test.go
@@ -10,6 +10,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/gentleman-programming/gentle-ai/internal/assets"
+	"github.com/gentleman-programming/gentle-ai/internal/opencode"
 )
 
 var requiredLedgerClauses = boundedReviewRequiredClauses
@@ -142,7 +143,7 @@ func TestOpenCodeOverlaysRenderBoundedReadOnlyReviewRoles(t *testing.T) {
 				assertNoReviewerLifecycleInstructions(t, path+" "+name, prompt)
 				assertOpenCodeReadOnlyTools(t, path+" "+name, agent["tools"].(map[string]any))
 			}
-			refuter := agentsMap[reviewRefuterAgentName].(map[string]any)
+			refuter := agentsMap[opencode.ReviewRefuterAgent].(map[string]any)
 			refuterPrompt := refuter["prompt"].(string)
 			if !strings.Contains(refuterPrompt, "exactly ONE transaction-wide inferential batch") || !strings.Contains(refuterPrompt, "terminate") {
 				t.Errorf("%s refuter prompt is not bounded: %s", path, refuterPrompt)

--- a/internal/opencode/models.go
+++ b/internal/opencode/models.go
@@ -426,13 +426,32 @@ func JDPhases() []string {
 	}
 }
 
+const ReviewRefuterAgent = "review-refuter"
+
+// ReviewLensPhases returns the ordered native bounded-review lens agents.
+func ReviewLensPhases() []string {
+	return []string{
+		"review-risk",
+		"review-readability",
+		"review-reliability",
+		"review-resilience",
+	}
+}
+
+// ReviewPhases returns every agent invoked by the native review lifecycle.
+func ReviewPhases() []string {
+	phases := ReviewLensPhases()
+	return append(phases, ReviewRefuterAgent)
+}
+
 // ConfigurableAgentPhases returns all agent names that support per-agent
-// model configuration. This includes SDD phases + JD agents.
+// model configuration. This includes SDD, Judgment Day, and review agents.
 // Used by the inject model assignment table builder and the configurable agent set
-// in ReadCurrentModelAssignments. The TUI model picker uses SDDPhases() and
-// JDPhases() separately for row layout control.
+// in ReadCurrentModelAssignments. The TUI uses each role family separately
+// for row layout control.
 func ConfigurableAgentPhases() []string {
 	phases := SDDPhases()
 	phases = append(phases, JDPhases()...)
+	phases = append(phases, ReviewPhases()...)
 	return phases
 }

--- a/internal/opencode/models_test.go
+++ b/internal/opencode/models_test.go
@@ -372,6 +372,24 @@ func TestModel_EffortLevels(t *testing.T) {
 	}
 }
 
+func TestReviewPhasesCompleteRuntimeSet(t *testing.T) {
+	want := []string{
+		"review-risk",
+		"review-readability",
+		"review-reliability",
+		"review-resilience",
+		"review-refuter",
+	}
+	if got := ReviewPhases(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("ReviewPhases() = %v, want %v", got, want)
+	}
+
+	configurable := ConfigurableAgentPhases()
+	if got := configurable[len(configurable)-len(want):]; !reflect.DeepEqual(got, want) {
+		t.Fatalf("ConfigurableAgentPhases() review suffix = %v, want %v", got, want)
+	}
+}
+
 func TestDefaultVariantsCachePath(t *testing.T) {
 	got := DefaultVariantsCachePath()
 	if got == "" {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1162,7 +1162,7 @@ func (m Model) handleKeyPress(key tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.ModelPicker.Mode == screens.ModePhaseList && keyStr == "backspace" &&
 		len(m.ModelPicker.AvailableIDs) > 0 {
 		rows := screens.ModelPickerRowsForProfile()
-		if m.Cursor < len(rows) && m.Cursor != screens.SeparatorRowIdx() {
+		if m.Cursor < len(rows) && !screens.IsModelPickerSeparatorRow(rows[m.Cursor]) {
 			m.ModelPicker.SelectedPhaseIdx = m.Cursor
 			m.Selection.ModelAssignments = screens.ClearModelPickerAssignment(&m.ModelPicker, m.Selection.ModelAssignments)
 			return m, nil
@@ -1336,7 +1336,7 @@ func (m Model) handleKeyPress(key tea.KeyMsg) (tea.Model, tea.Cmd) {
 			}
 		}
 		// Skip separator row in model picker — it is not selectable.
-		if m.shouldSkipModelPickerSeparator() && m.Cursor == screens.SeparatorRowIdx() && m.Cursor > 0 {
+		if m.shouldSkipModelPickerSeparator() && m.isModelPickerSeparatorCursor() && m.Cursor > 0 {
 			m.Cursor--
 		}
 		return m, nil
@@ -1360,7 +1360,7 @@ func (m Model) handleKeyPress(key tea.KeyMsg) (tea.Model, tea.Cmd) {
 			}
 		}
 		// Skip separator row in model picker — it is not selectable.
-		if m.shouldSkipModelPickerSeparator() && m.Cursor == screens.SeparatorRowIdx() {
+		if m.shouldSkipModelPickerSeparator() && m.isModelPickerSeparatorCursor() {
 			if m.Cursor+1 < count {
 				m.Cursor++
 			}
@@ -1383,7 +1383,7 @@ func (m Model) handleKeyPress(key tea.KeyMsg) (tea.Model, tea.Cmd) {
 			}
 		}
 		// Skip separator row in model picker — it is not selectable.
-		if m.shouldSkipModelPickerSeparator() && m.Cursor == screens.SeparatorRowIdx() && m.Cursor > 0 {
+		if m.shouldSkipModelPickerSeparator() && m.isModelPickerSeparatorCursor() && m.Cursor > 0 {
 			m.Cursor--
 		}
 		return m, nil
@@ -1402,7 +1402,7 @@ func (m Model) handleKeyPress(key tea.KeyMsg) (tea.Model, tea.Cmd) {
 			}
 		}
 		// Skip separator row in model picker — it is not selectable.
-		if m.shouldSkipModelPickerSeparator() && m.Cursor == screens.SeparatorRowIdx() {
+		if m.shouldSkipModelPickerSeparator() && m.isModelPickerSeparatorCursor() {
 			if m.Cursor+1 < count {
 				m.Cursor++
 			}
@@ -1513,6 +1513,14 @@ func (m Model) shouldSkipModelPickerSeparator() bool {
 	}
 	return (m.Screen == ScreenModelPicker && !m.ModelPicker.ForProfile) ||
 		(m.Screen == ScreenProfileCreate && m.ProfileCreateStep == 1 && m.ModelPicker.Mode == screens.ModePhaseList)
+}
+
+func (m Model) isModelPickerSeparatorCursor() bool {
+	rows := screens.ModelPickerRows()
+	if m.ModelPicker.ForProfile {
+		rows = screens.ModelPickerRowsForProfile()
+	}
+	return m.Cursor >= 0 && m.Cursor < len(rows) && screens.IsModelPickerSeparatorRow(rows[m.Cursor])
 }
 
 func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
@@ -2054,7 +2062,7 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 		rows := screens.ModelPickerRows()
 		if m.Cursor < len(rows) {
 			// Skip separator row — it is not actionable.
-			if !m.ModelPicker.ForProfile && m.Cursor == screens.SeparatorRowIdx() {
+			if screens.IsModelPickerSeparatorRow(rows[m.Cursor]) {
 				return m, nil
 			}
 			// Enter sub-selection: pick provider then model.
@@ -4263,7 +4271,7 @@ func (m Model) confirmProfileCreate() (tea.Model, tea.Cmd) {
 		}
 		rows := screens.ModelPickerRowsForProfile()
 		if m.Cursor < len(rows) {
-			if m.Cursor == screens.SeparatorRowIdx() {
+			if screens.IsModelPickerSeparatorRow(rows[m.Cursor]) {
 				return m, nil
 			}
 			// Enter sub-selection: pick provider then model.

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -277,6 +277,30 @@ func TestProfileCreateSeparatorIsIgnoredAndSkipped(t *testing.T) {
 	}
 }
 
+func TestModelPickerNavigationSkipsReviewSeparator(t *testing.T) {
+	rows := screens.ModelPickerRows()
+	separator := -1
+	for i, row := range rows {
+		if row == "--- Review agents ---" {
+			separator = i
+			break
+		}
+	}
+	if separator < 1 {
+		t.Fatalf("review separator missing from rows: %v", rows)
+	}
+
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Screen = ScreenModelPicker
+	m.ModelPicker = screens.ModelPickerState{Mode: screens.ModePhaseList, AvailableIDs: []string{"openai"}}
+	m.Cursor = separator - 1
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
+	if got := updated.(Model).Cursor; got != separator+1 {
+		t.Fatalf("cursor after review separator = %d, want %d", got, separator+1)
+	}
+}
+
 func TestProfileCreateBackspaceClearsSelectedJDAssignment(t *testing.T) {
 	jdPhases := opencode.JDPhases()
 	if len(jdPhases) == 0 {
@@ -4213,6 +4237,7 @@ func TestModelConfigOpenCodePrePopulatesAssignments(t *testing.T) {
 	preExisting := map[string]model.ModelAssignment{
 		"gentle-orchestrator": {ProviderID: "anthropic", ModelID: "claude-sonnet-4-20250514"},
 		"sdd-apply":           {ProviderID: "openai", ModelID: "gpt-4o"},
+		"review-refuter":      {ProviderID: "openai", ModelID: "gpt-5"},
 	}
 
 	// Override the read function to return pre-existing assignments
@@ -4254,6 +4279,9 @@ func TestModelConfigOpenCodePrePopulatesAssignments(t *testing.T) {
 	want2 := preExisting["sdd-apply"]
 	if got2 != want2 {
 		t.Errorf("sdd-apply assignment = %+v, want %+v", got2, want2)
+	}
+	if got := state.Selection.ModelAssignments["review-refuter"]; got != preExisting["review-refuter"] {
+		t.Errorf("review-refuter assignment = %+v, want %+v", got, preExisting["review-refuter"])
 	}
 }
 

--- a/internal/tui/screens/model_picker.go
+++ b/internal/tui/screens/model_picker.go
@@ -25,6 +25,7 @@ const (
 
 // maxVisibleItems is the maximum number of items shown in scrollable sub-lists.
 const maxVisibleItems = 10
+const maxVisiblePhaseRows = 16
 
 // ProviderEntry holds a provider ID, display name, and model count for the provider list.
 type ProviderEntry struct {
@@ -123,9 +124,13 @@ const SDDOrchestratorPhase = "gentle-orchestrator"
 
 // ModelPickerRows returns the row labels for the model picker screen.
 // Row 0 is "gentle-orchestrator" (coordinator), row 1 is "Set all phases",
-// rows 2-11 are the 10 SDD sub-agent phases, then a separator and JD agents.
+// rows 2-11 are the 10 SDD sub-agent phases, followed by workflow agent sections.
 func ModelPickerRows() []string {
-	rows := make([]string, 0, 2+len(opencode.SDDPhases())+1+len(opencode.JDPhases()))
+	return modelPickerRows(true)
+}
+
+func modelPickerRows(includeReview bool) []string {
+	rows := make([]string, 0, 2+len(opencode.SDDPhases())+1+len(opencode.JDPhases())+1+len(opencode.ReviewPhases()))
 	rows = append(rows, SDDOrchestratorPhase)
 	rows = append(rows, "Set all SDD phases")
 	rows = append(rows, opencode.SDDPhases()...)
@@ -133,14 +138,22 @@ func ModelPickerRows() []string {
 		rows = append(rows, "--- Judgment Day ---")
 		rows = append(rows, opencode.JDPhases()...)
 	}
+	if includeReview && len(opencode.ReviewPhases()) > 0 {
+		rows = append(rows, "--- Review agents ---")
+		rows = append(rows, opencode.ReviewPhases()...)
+	}
 	return rows
 }
 
 // ModelPickerRowsForProfile returns model picker rows for profile creation.
 // Profiles support both SDD phase assignments and optional Judgment Day agent
-// assignments, so this mirrors the main OpenCode row list.
+// assignments. Native review agents remain unsuffixed global runtime agents.
 func ModelPickerRowsForProfile() []string {
-	return ModelPickerRows()
+	return modelPickerRows(false)
+}
+
+func IsModelPickerSeparatorRow(row string) bool {
+	return strings.HasPrefix(row, "--- ")
 }
 
 // SeparatorRowIdx returns the index of the "--- Judgment Day ---" separator
@@ -420,28 +433,14 @@ func compareVersionKeys(left, right []int) int {
 
 func applyAssignmentPreservingMatchingEffort(state ModelPickerState, assignments map[string]model.ModelAssignment, assignment model.ModelAssignment, preserveEffort bool) map[string]model.ModelAssignment {
 	phases := opencode.SDDPhases()
-	jdPhases := opencode.JDPhases()
-	separatorIdx := SeparatorRowIdx()
 	switch {
-	case state.SelectedPhaseIdx == 0:
-		assignments[SDDOrchestratorPhase] = preserveMatchingEffort(assignments[SDDOrchestratorPhase], assignment, preserveEffort)
 	case state.SelectedPhaseIdx == 1:
 		for _, phase := range phases {
 			assignments[phase] = preserveMatchingEffort(assignments[phase], assignment, preserveEffort)
 		}
-	case state.SelectedPhaseIdx == separatorIdx:
-		// Separator row ("--- Judgment Day ---") — no action, skip.
-	case state.SelectedPhaseIdx > separatorIdx:
-		// JD agent rows: map to JDPhases() after separator.
-		jdIdx := state.SelectedPhaseIdx - separatorIdx - 1
-		if jdIdx < len(jdPhases) {
-			assignments[jdPhases[jdIdx]] = preserveMatchingEffort(assignments[jdPhases[jdIdx]], assignment, preserveEffort)
-		}
 	default:
-		phaseIdx := state.SelectedPhaseIdx - 2
-		if phaseIdx < len(phases) {
-			phase := phases[phaseIdx]
-			assignments[phase] = preserveMatchingEffort(assignments[phase], assignment, preserveEffort)
+		if key := selectedModelPickerAgent(state); key != "" {
+			assignments[key] = preserveMatchingEffort(assignments[key], assignment, preserveEffort)
 		}
 	}
 	return assignments
@@ -456,28 +455,15 @@ func ClearModelPickerAssignment(state *ModelPickerState, assignments map[string]
 	}
 
 	phases := opencode.SDDPhases()
-	jdPhases := opencode.JDPhases()
-	separatorIdx := SeparatorRowIdx()
-
 	switch {
-	case state.SelectedPhaseIdx == 0:
-		delete(assignments, SDDOrchestratorPhase)
 	case state.SelectedPhaseIdx == 1:
 		for _, phase := range phases {
 			delete(assignments, phase)
 		}
 		state.AllPhasesModel = model.ModelAssignment{}
-	case state.SelectedPhaseIdx == separatorIdx:
-		// Separator row — no assignment to clear.
-	case state.SelectedPhaseIdx > separatorIdx:
-		jdIdx := state.SelectedPhaseIdx - separatorIdx - 1
-		if jdIdx < len(jdPhases) {
-			delete(assignments, jdPhases[jdIdx])
-		}
 	default:
-		phaseIdx := state.SelectedPhaseIdx - 2
-		if phaseIdx < len(phases) {
-			delete(assignments, phases[phaseIdx])
+		if key := selectedModelPickerAgent(*state); key != "" {
+			delete(assignments, key)
 		}
 	}
 	return assignments
@@ -505,30 +491,32 @@ func formatAssignmentLabel(row, provName, modelName, effort string) string {
 // the single sub-agent phase matching the index is set.
 func applyAssignment(state ModelPickerState, assignments map[string]model.ModelAssignment, assignment model.ModelAssignment) map[string]model.ModelAssignment {
 	phases := opencode.SDDPhases()
-	jdPhases := opencode.JDPhases()
-	separatorIdx := SeparatorRowIdx()
 	switch {
-	case state.SelectedPhaseIdx == 0:
-		assignments[SDDOrchestratorPhase] = assignment
 	case state.SelectedPhaseIdx == 1:
 		for _, phase := range phases {
 			assignments[phase] = assignment
 		}
-	case state.SelectedPhaseIdx == separatorIdx:
-		// Separator row ("--- Judgment Day ---") — no action, skip.
-	case state.SelectedPhaseIdx > separatorIdx:
-		// JD agent rows: map to JDPhases() after separator.
-		jdIdx := state.SelectedPhaseIdx - separatorIdx - 1
-		if jdIdx < len(jdPhases) {
-			assignments[jdPhases[jdIdx]] = assignment
-		}
 	default:
-		phaseIdx := state.SelectedPhaseIdx - 2
-		if phaseIdx < len(phases) {
-			assignments[phases[phaseIdx]] = assignment
+		if key := selectedModelPickerAgent(state); key != "" {
+			assignments[key] = assignment
 		}
 	}
 	return assignments
+}
+
+func selectedModelPickerAgent(state ModelPickerState) string {
+	rows := ModelPickerRows()
+	if state.ForProfile {
+		rows = ModelPickerRowsForProfile()
+	}
+	if state.SelectedPhaseIdx < 0 || state.SelectedPhaseIdx >= len(rows) {
+		return ""
+	}
+	row := rows[state.SelectedPhaseIdx]
+	if state.SelectedPhaseIdx == 1 || IsModelPickerSeparatorRow(row) {
+		return ""
+	}
+	return row
 }
 
 // effortOptionsFromLevels returns the effort picker options in display order.
@@ -666,7 +654,7 @@ func renderPhaseList(
 ) string {
 	var b strings.Builder
 
-	title := "Assign Models to SDD Phases & JD Agents"
+	title := "Assign Models to SDD, JD & Review Agents"
 	if state.ForProfile {
 		title = "Assign Models to SDD Phases & JD Agents"
 	}
@@ -703,11 +691,16 @@ func renderPhaseList(
 	} else {
 		rows = ModelPickerRows()
 	}
-	phases := opencode.SDDPhases()
-	jdPhases := opencode.JDPhases()
-	separatorIdx := SeparatorRowIdx()
-
-	for idx, row := range rows {
+	start, end := 0, len(rows)
+	if len(rows) > maxVisiblePhaseRows {
+		start = max(0, min(cursor-maxVisiblePhaseRows+1, len(rows)-maxVisiblePhaseRows))
+		end = start + maxVisiblePhaseRows
+	}
+	if start > 0 {
+		b.WriteString(styles.SubtextStyle.Render("  ↑ more assignments") + "\n")
+	}
+	for offset, row := range rows[start:end] {
+		idx := start + offset
 		focused := idx == cursor
 
 		var label string
@@ -731,7 +724,7 @@ func renderPhaseList(
 			} else {
 				label = fmt.Sprintf("%-20s (not set)", row)
 			}
-		case idx == separatorIdx:
+		case IsModelPickerSeparatorRow(row):
 			// Separator row — render as a visual divider with subtle indicator when focused.
 			if focused {
 				b.WriteString(styles.SubtextStyle.Render("▸ "+row) + "\n")
@@ -739,23 +732,8 @@ func renderPhaseList(
 				b.WriteString(styles.SubtextStyle.Render("  "+row) + "\n")
 			}
 			continue
-		case idx > separatorIdx:
-			// JD agent rows
-			jdIdx := idx - separatorIdx - 1
-			if jdIdx < len(jdPhases) {
-				phase := jdPhases[jdIdx]
-				assignment, ok := assignments[phase]
-				if ok && assignment.ProviderID != "" {
-					provName, modelName := resolveNames(assignment, state)
-					label = formatAssignmentLabel(row, provName, modelName, assignment.Effort)
-				} else {
-					label = fmt.Sprintf("%-20s (default)", row)
-				}
-			}
 		default:
-			// SDD sub-agent rows start at idx 2; phases[idx-2] maps to the correct phase
-			phase := phases[idx-2]
-			assignment, ok := assignments[phase]
+			assignment, ok := assignments[row]
 			if ok && assignment.ProviderID != "" {
 				provName, modelName := resolveNames(assignment, state)
 				label = formatAssignmentLabel(row, provName, modelName, assignment.Effort)
@@ -769,6 +747,9 @@ func renderPhaseList(
 		} else {
 			b.WriteString(styles.UnselectedStyle.Render("  "+label) + "\n")
 		}
+	}
+	if end < len(rows) {
+		b.WriteString(styles.SubtextStyle.Render("  ↓ more assignments") + "\n")
 	}
 
 	b.WriteString("\n")

--- a/internal/tui/screens/model_picker_test.go
+++ b/internal/tui/screens/model_picker_test.go
@@ -31,10 +31,34 @@ func makeTestState(phaseIdx int) *ModelPickerState {
 
 func TestModelPickerRows_Count(t *testing.T) {
 	rows := ModelPickerRows()
-	// 1 orchestrator + 1 "Set all" + 10 sub-agents + 1 separator + 3 JD agents = 16
-	want := 16
+	want := 2 + len(opencode.SDDPhases()) + 1 + len(opencode.JDPhases()) + 1 + len(opencode.ReviewPhases())
 	if len(rows) != want {
 		t.Fatalf("ModelPickerRows() len = %d, want %d; rows = %v", len(rows), want, rows)
+	}
+}
+
+func TestModelPickerRows_ReviewAgentsFollowJudgmentDay(t *testing.T) {
+	rows := ModelPickerRows()
+	wantSuffix := append([]string{"--- Review agents ---"}, opencode.ReviewPhases()...)
+	got := rows[len(rows)-len(wantSuffix):]
+	for i := range wantSuffix {
+		if got[i] != wantSuffix[i] {
+			t.Fatalf("review row %d = %q, want %q; rows = %v", i, got[i], wantSuffix[i], rows)
+		}
+	}
+}
+
+func TestRenderModelPickerScrollsToReviewAgents(t *testing.T) {
+	rows := ModelPickerRows()
+	cursor := len(rows) - 1
+	state := ModelPickerState{AvailableIDs: []string{"openai"}}
+
+	output := RenderModelPicker(nil, state, cursor)
+	if !strings.Contains(output, "review-refuter") || !strings.Contains(output, "↑ more assignments") {
+		t.Fatalf("review rows are not visible at cursor %d:\n%s", cursor, output)
+	}
+	if strings.Contains(output, "gentle-orchestrator") {
+		t.Fatalf("picker did not window rows around review cursor:\n%s", output)
 	}
 }
 
@@ -1243,6 +1267,26 @@ func TestHandleModelNav_JDLastRow(t *testing.T) {
 	}
 }
 
+func TestHandleModelNav_ReviewAgentRowsAssignCorrectly(t *testing.T) {
+	rows := ModelPickerRows()
+	for _, agent := range opencode.ReviewPhases() {
+		t.Run(agent, func(t *testing.T) {
+			rowIdx := -1
+			for i, row := range rows {
+				if row == agent {
+					rowIdx = i
+					break
+				}
+			}
+			state := makeTestState(rowIdx)
+			_, updated := handleModelNav("enter", state, map[string]model.ModelAssignment{})
+			if got := updated[agent]; got.ProviderID != "test-provider" || got.ModelID != "model-alpha" {
+				t.Fatalf("%s assignment = %+v, want test-provider/model-alpha", agent, got)
+			}
+		})
+	}
+}
+
 // ─── ModelPickerRowsForProfile ──────────────────────────────────────────
 
 func TestModelPickerRowsForProfile(t *testing.T) {
@@ -1270,6 +1314,13 @@ func TestModelPickerRowsForProfile(t *testing.T) {
 		}
 		if !found {
 			t.Fatalf("ModelPickerRowsForProfile() missing JD agent %q; got: %v", jd, rows)
+		}
+	}
+	for _, reviewAgent := range opencode.ReviewPhases() {
+		for _, row := range rows {
+			if row == reviewAgent {
+				t.Fatalf("profile rows must use global reviewer %q, got: %v", reviewAgent, rows)
+			}
 		}
 	}
 }


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1142

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [ ] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [x] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

Extends OpenCode model configuration to the complete native review family: `review-risk`, `review-readability`, `review-reliability`, `review-resilience`, and `review-refuter`. These agents remain global, unsuffixed runtime agents while the user-facing Configure Models flow can now read, display, update, and preserve their provider-qualified assignments.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/opencode` | Defines the ordered five-agent review family and includes it in configurable model phases. |
| `internal/tui/screens/model_picker.go` | Adds review-agent rows, generic separator handling, and a 16-row window so the expanded picker remains usable. |
| `internal/tui/model.go` | Makes navigation, selection, clearing, and pre-population work across multiple picker sections. |
| `internal/components/sdd` | Reads reviewer assignments from JSON/JSONC, injects all five global unsuffixed assignments, and preserves unrelated OpenCode configuration during round trips. |
| Tests | Covers the complete runtime family, picker windowing/navigation, assignment mapping, JSONC reads, config preservation, and generated models/variants. |

---

## 🧪 Test Plan

**Unit Tests**
```bash
env -u GENTLE_AI_CHANNEL go test ./internal/opencode ./internal/tui/screens ./internal/tui ./internal/components/sdd -count=1
env -u GENTLE_AI_CHANNEL go test ./... -count=1
```

**Runtime Harness**
```bash
GOWORK=off go run -mod=mod .
opencode debug config
```

- [x] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Manually tested locally

The isolated OpenCode 1.17.18 harness exercised the production multi-mode injection path, loaded the generated config without schema errors, and asserted exact provider-qualified models for all five review agents, `review-refuter` variant preservation, and unrelated JSON fields.

---

## 🤖 Automated Checks

The following checks run automatically on this PR:

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | PR should stay within 400 changed lines (`additions + deletions`) or use `size:exception` |
| Check Issue Reference | ⏳ | PR body must contain `Closes/Fixes/Resolves #N` |
| Check Issue Has `status:approved` | ⏳ | Linked issue must have been approved before work began |
| Check PR Has `type:*` Label | ⏳ | Exactly one `type:*` label must be applied |
| Unit Tests | ⏳ | `go test ./...` must pass |
| E2E Tests | ⏳ | `cd e2e && ./docker-test.sh` must pass |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

Reviewer assignments intentionally remain omitted by the legacy single-SDD-mode injection path. The user-facing Configure Models path uses multi mode, and all five native review agents are global and unsuffixed, so this does not block the delivered configuration flow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable model assignments for all review agents, including the review refuter.
  * Expanded the model picker to display review-agent assignments with scrolling support.
  * Added support for reading review-agent assignments from JSONC configuration files.

* **Bug Fixes**
  * Improved model-picker navigation so separator rows are skipped correctly in all modes.
  * Preserved unrelated configuration fields when updating model assignments.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->