### PR TITLE
fix(codegraph): harden OpenCode reconciliation

### DIFF
--- a/internal/agents/interface.go
+++ b/internal/agents/interface.go
@@ -58,3 +58,9 @@ type Adapter interface {
 	SupportsSystemPrompt() bool
 	SupportsMCP() bool
 }
+
+// EffectiveCodeGraphWiringDetector is an optional adapter capability for agents
+// whose configuration format requires semantic validation beyond marker checks.
+type EffectiveCodeGraphWiringDetector interface {
+	EffectiveCodeGraphWiring(homeDir string) (path string, configured bool)
+}

--- a/internal/agents/opencode/adapter.go
+++ b/internal/agents/opencode/adapter.go
@@ -5,7 +5,9 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
+	"github.com/gentleman-programming/gentle-ai/internal/components/filemerge"
 	"github.com/gentleman-programming/gentle-ai/internal/installcmd"
 	"github.com/gentleman-programming/gentle-ai/internal/model"
 	"github.com/gentleman-programming/gentle-ai/internal/system"
@@ -114,6 +116,44 @@ func (a *Adapter) MCPConfigPath(homeDir string, serverName string) string {
 	// OpenCode merges into opencode.json, but this provides the path
 	// for components that use the separate-file strategy fallback.
 	return filepath.Join(ConfigPath(homeDir), "opencode.json")
+}
+
+// EffectiveCodeGraphWiring validates OpenCode's effective MCP entry while
+// keeping OpenCode's JSON/JSONC schema behind the adapter boundary.
+func (a *Adapter) EffectiveCodeGraphWiring(homeDir string) (string, bool) {
+	settingsPath := a.SettingsPath(homeDir)
+	paths := []string{settingsPath}
+	if strings.HasSuffix(settingsPath, ".json") {
+		paths = append(paths, strings.TrimSuffix(settingsPath, ".json")+".jsonc")
+	}
+
+	for _, path := range paths {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		root, err := filemerge.UnmarshalJSONObject(data)
+		if err != nil {
+			continue
+		}
+		mcp, ok := root["mcp"].(map[string]any)
+		if ok && isEffectiveCodeGraphEntry(mcp["codegraph"]) {
+			return path, true
+		}
+	}
+	return "", false
+}
+
+func isEffectiveCodeGraphEntry(value any) bool {
+	entry, ok := value.(map[string]any)
+	if !ok || entry["type"] != "local" {
+		return false
+	}
+	if enabled, exists := entry["enabled"]; exists && enabled != true {
+		return false
+	}
+	command, ok := entry["command"].([]any)
+	return ok && len(command) == 3 && command[0] == "codegraph" && command[1] == "serve" && command[2] == "--mcp"
 }
 
 // --- Optional capabilities ---

--- a/internal/agents/opencode/adapter_test.go
+++ b/internal/agents/opencode/adapter_test.go
@@ -166,6 +166,57 @@ func TestConfigPathsRespectXDGConfigHome(t *testing.T) {
 	if got := a.SystemPromptFile(home); got != filepath.Join(wantDir, "AGENTS.md") {
 		t.Fatalf("SystemPromptFile() = %q, want XDG path", got)
 	}
+	if got := a.SystemPromptDir(home); got != wantDir {
+		t.Fatalf("SystemPromptDir() = %q, want %q", got, wantDir)
+	}
+	if got := a.SkillsDir(home); got != filepath.Join(wantDir, "skills") {
+		t.Fatalf("SkillsDir() = %q, want XDG path", got)
+	}
+	if got := a.CommandsDir(home); got != filepath.Join(wantDir, "commands") {
+		t.Fatalf("CommandsDir() = %q, want XDG path", got)
+	}
+	if got := a.MCPConfigPath(home, "codegraph"); got != filepath.Join(wantDir, "opencode.json") {
+		t.Fatalf("MCPConfigPath() = %q, want XDG path", got)
+	}
+}
+
+func TestEffectiveCodeGraphWiring(t *testing.T) {
+	tests := []struct {
+		name       string
+		fileName   string
+		content    string
+		configured bool
+	}{
+		{name: "effective JSON", fileName: "opencode.json", content: `{"mcp":{"codegraph":{"type":"local","command":["codegraph","serve","--mcp"],"enabled":true}}}`, configured: true},
+		{name: "effective JSONC", fileName: "opencode.jsonc", content: "{\n// preserved comment\n\"mcp\": {\"codegraph\": {\"type\": \"local\", \"command\": [\"codegraph\", \"serve\", \"--mcp\"],},},\n}", configured: true},
+		{name: "disabled entry", fileName: "opencode.json", content: `{"mcp":{"codegraph":{"type":"local","command":["codegraph","serve","--mcp"],"enabled":false}}}`},
+		{name: "wrong command", fileName: "opencode.json", content: `{"mcp":{"codegraph":{"type":"local","command":["other","serve","--mcp"]}}}`},
+		{name: "malformed config", fileName: "opencode.json", content: `{"mcp":`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			t.Setenv("USERPROFILE", home)
+			t.Setenv("XDG_CONFIG_HOME", "")
+			path := filepath.Join(ConfigPath(home), tt.fileName)
+			if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(path, []byte(tt.content), 0o600); err != nil {
+				t.Fatal(err)
+			}
+
+			gotPath, configured := NewAdapter().EffectiveCodeGraphWiring(home)
+			if configured != tt.configured {
+				t.Fatalf("EffectiveCodeGraphWiring() configured = %v, want %v", configured, tt.configured)
+			}
+			if configured && gotPath != path {
+				t.Fatalf("EffectiveCodeGraphWiring() path = %q, want %q", gotPath, path)
+			}
+		})
+	}
 }
 
 func TestConfigPathIgnoresRelativeXDGConfigHome(t *testing.T) {

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/gentleman-programming/gentle-ai/internal/agents"
+	opencodeagent "github.com/gentleman-programming/gentle-ai/internal/agents/opencode"
 	"github.com/gentleman-programming/gentle-ai/internal/backup"
 	"github.com/gentleman-programming/gentle-ai/internal/components/communitytool"
 	"github.com/gentleman-programming/gentle-ai/internal/components/engram"
@@ -665,7 +666,7 @@ func (r codeGraphHomeRunner) Run(name string, args ...string) error {
 	if filepath.Clean(r.homeDir) != filepath.Clean(actualHome) {
 		command.Env = overrideCommandEnvironment(os.Environ(), map[string]string{
 			"HOME":            r.homeDir,
-			"XDG_CONFIG_HOME": filepath.Join(r.homeDir, ".config"),
+			"XDG_CONFIG_HOME": codeGraphConfigHome(r.homeDir),
 		})
 	}
 	output, err := command.CombinedOutput()
@@ -676,6 +677,10 @@ func (r codeGraphHomeRunner) Run(name string, args ...string) error {
 		}
 	}
 	return err
+}
+
+func codeGraphConfigHome(homeDir string) string {
+	return filepath.Dir(opencodeagent.ConfigPath(homeDir))
 }
 
 func overrideCommandEnvironment(environment []string, overrides map[string]string) []string {
@@ -918,6 +923,15 @@ type syncFileSnapshot struct {
 	targetExists bool
 }
 
+var writeSyncFileAtomic = filemerge.WriteFileAtomic
+
+func syncRestoreWriteMode(mode os.FileMode) os.FileMode {
+	if mode.Perm() == 0 {
+		return 0o600
+	}
+	return mode
+}
+
 func snapshotSyncFiles(paths []string) (map[string]syncFileSnapshot, error) {
 	snapshots := make(map[string]syncFileSnapshot, len(paths))
 	for _, path := range dedupPaths(paths) {
@@ -1013,9 +1027,10 @@ func restoreSyncFiles(snapshots map[string]syncFileSnapshot) error {
 			continue
 		}
 		mode := snapshot.mode
+		writeMode := syncRestoreWriteMode(mode)
 		if snapshot.symlink {
 			if snapshot.targetExists {
-				if _, err := filemerge.WriteFileAtomic(snapshot.targetPath, snapshot.data, mode); err != nil {
+				if _, err := writeSyncFileAtomic(snapshot.targetPath, snapshot.data, writeMode); err != nil {
 					restoreErr = errors.Join(restoreErr, fmt.Errorf("restore sync symlink target %q: %w", snapshot.targetPath, err))
 					continue
 				}
@@ -1038,7 +1053,7 @@ func restoreSyncFiles(snapshots map[string]syncFileSnapshot) error {
 			}
 			continue
 		}
-		if _, err := filemerge.WriteFileAtomic(path, snapshot.data, mode); err != nil {
+		if _, err := writeSyncFileAtomic(path, snapshot.data, writeMode); err != nil {
 			restoreErr = errors.Join(restoreErr, fmt.Errorf("restore sync file %q: %w", path, err))
 			continue
 		}

--- a/internal/cli/sync_test.go
+++ b/internal/cli/sync_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gentleman-programming/gentle-ai/internal/agents/codex"
 	"github.com/gentleman-programming/gentle-ai/internal/backup"
 	"github.com/gentleman-programming/gentle-ai/internal/components/communitytool"
+	"github.com/gentleman-programming/gentle-ai/internal/components/filemerge"
 	"github.com/gentleman-programming/gentle-ai/internal/model"
 	"github.com/gentleman-programming/gentle-ai/internal/pipeline"
 	"github.com/gentleman-programming/gentle-ai/internal/state"
@@ -870,20 +871,91 @@ func TestCodeGraphGuidanceSyncStepPreservesBrokenSymlinkChain(t *testing.T) {
 	}
 }
 
-func TestRestoreSyncFilesPreservesZeroMode(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "managed.json")
-	mustWriteFile(t, path, []byte("changed"))
-	if err := restoreSyncFiles(map[string]syncFileSnapshot{
-		path: {exists: true, data: []byte("original"), mode: 0},
-	}); err != nil {
-		t.Fatalf("restoreSyncFiles() error = %v", err)
+func TestRestoreSyncFilesNeverWidensZeroMode(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func(t *testing.T) (string, syncFileSnapshot)
+	}{
+		{
+			name: "regular file",
+			setup: func(t *testing.T) (string, syncFileSnapshot) {
+				path := filepath.Join(t.TempDir(), "managed.json")
+				mustWriteFile(t, path, []byte("changed"))
+				return path, syncFileSnapshot{exists: true, data: []byte("original"), mode: 0}
+			},
+		},
+		{
+			name: "symlink chain target",
+			setup: func(t *testing.T) (string, syncFileSnapshot) {
+				root := t.TempDir()
+				targetPath := filepath.Join(root, "versions", "managed.json")
+				innerPath := filepath.Join(root, "current.json")
+				path := filepath.Join(root, "config", "managed.json")
+				mustWriteFile(t, targetPath, []byte("changed"))
+				if err := os.Symlink(targetPath, innerPath); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Symlink(innerPath, path); err != nil {
+					t.Fatal(err)
+				}
+				return path, syncFileSnapshot{exists: true, data: []byte("original"), mode: 0, symlink: true, linkTarget: innerPath, targetPath: targetPath, targetExists: true}
+			},
+		},
 	}
-	info, err := os.Stat(path)
-	if err != nil {
-		t.Fatal(err)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path, snapshot := tt.setup(t)
+			originalWriter := writeSyncFileAtomic
+			t.Cleanup(func() { writeSyncFileAtomic = originalWriter })
+			writeSyncFileAtomic = func(path string, content []byte, mode os.FileMode) (filemerge.WriteResult, error) {
+				if mode != 0o600 {
+					t.Fatalf("atomic restore mode = %o, want restrictive 0600", mode)
+				}
+				result, err := originalWriter(path, content, mode)
+				if err == nil {
+					info, statErr := os.Stat(path)
+					if statErr != nil {
+						t.Fatal(statErr)
+					}
+					if got := info.Mode().Perm(); got != 0o600 {
+						t.Fatalf("mode immediately after atomic replace = %o, want 0600", got)
+					}
+				}
+				return result, err
+			}
+
+			if err := restoreSyncFiles(map[string]syncFileSnapshot{path: snapshot}); err != nil {
+				t.Fatalf("restoreSyncFiles() error = %v", err)
+			}
+			info, err := os.Stat(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := info.Mode().Perm(); got != 0 {
+				t.Fatalf("restored mode = %o, want exact 000", got)
+			}
+		})
 	}
-	if info.Mode().Perm() != 0 {
-		t.Fatalf("restored mode = %o, want 000", info.Mode().Perm())
+}
+
+func TestCodeGraphConfigHomeMatchesOpenCodePathResolution(t *testing.T) {
+	actualHome := t.TempDir()
+	xdg := filepath.Join(t.TempDir(), "xdg")
+	t.Setenv("HOME", actualHome)
+	t.Setenv("USERPROFILE", actualHome)
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+
+	if got := codeGraphConfigHome(actualHome); got != xdg {
+		t.Fatalf("codeGraphConfigHome(actual home) = %q, want %q", got, xdg)
+	}
+	alternateHome := t.TempDir()
+	wantAlternate := filepath.Join(alternateHome, ".config")
+	if got := codeGraphConfigHome(alternateHome); got != wantAlternate {
+		t.Fatalf("codeGraphConfigHome(alternate home) = %q, want %q", got, wantAlternate)
 	}
 }
 

--- a/internal/components/communitytool/tool.go
+++ b/internal/components/communitytool/tool.go
@@ -1,7 +1,6 @@
 package communitytool
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -433,10 +432,10 @@ func hasDetectedCodeGraphToolWiring(homeDir string) bool {
 }
 
 func hasCodeGraphToolWiring(homeDir string, adapter agents.Adapter) (string, bool) {
-	paths := codeGraphToolWiringPaths(homeDir, adapter)
-	if adapter.Agent() == model.AgentOpenCode {
-		return hasOpenCodeCodeGraphWiring(paths)
+	if detector, ok := adapter.(agents.EffectiveCodeGraphWiringDetector); ok {
+		return detector.EffectiveCodeGraphWiring(homeDir)
 	}
+	paths := codeGraphToolWiringPaths(homeDir, adapter)
 	seen := map[string]struct{}{}
 	for _, path := range paths {
 		if path == "" {
@@ -458,137 +457,12 @@ func hasCodeGraphToolWiring(homeDir string, adapter agents.Adapter) (string, boo
 	return "", false
 }
 
-func hasOpenCodeCodeGraphWiring(paths []string) (string, bool) {
-	seen := map[string]struct{}{}
-	for _, path := range paths {
-		if path == "" {
-			continue
-		}
-		if _, exists := seen[path]; exists {
-			continue
-		}
-		seen[path] = struct{}{}
-		data, err := os.ReadFile(path)
-		if err != nil {
-			continue
-		}
-		var root map[string]any
-		if json.Unmarshal(normalizeJSONC(data), &root) != nil {
-			continue
-		}
-		mcp, ok := root["mcp"].(map[string]any)
-		if !ok || !isEffectiveOpenCodeCodeGraphEntry(mcp["codegraph"]) {
-			continue
-		}
-		return path, true
-	}
-	return "", false
-}
-
-func isEffectiveOpenCodeCodeGraphEntry(value any) bool {
-	entry, ok := value.(map[string]any)
-	if !ok || entry["type"] != "local" {
-		return false
-	}
-	if enabled, exists := entry["enabled"]; exists && enabled != true {
-		return false
-	}
-	command, ok := entry["command"].([]any)
-	if !ok || len(command) != 3 {
-		return false
-	}
-	return command[0] == "codegraph" && command[1] == "serve" && command[2] == "--mcp"
-}
-
-func normalizeJSONC(data []byte) []byte {
-	withoutComments := append([]byte(nil), data...)
-	inString := false
-	escaped := false
-	for i := 0; i < len(withoutComments); i++ {
-		current := withoutComments[i]
-		if inString {
-			switch {
-			case escaped:
-				escaped = false
-			case current == '\\':
-				escaped = true
-			case current == '"':
-				inString = false
-			}
-			continue
-		}
-		if current == '"' {
-			inString = true
-			continue
-		}
-		if current != '/' || i+1 >= len(withoutComments) {
-			continue
-		}
-		switch withoutComments[i+1] {
-		case '/':
-			withoutComments[i], withoutComments[i+1] = ' ', ' '
-			i += 2
-			for ; i < len(withoutComments) && withoutComments[i] != '\n'; i++ {
-				withoutComments[i] = ' '
-			}
-			i--
-		case '*':
-			withoutComments[i], withoutComments[i+1] = ' ', ' '
-			i += 2
-			for ; i+1 < len(withoutComments); i++ {
-				if withoutComments[i] == '*' && withoutComments[i+1] == '/' {
-					withoutComments[i], withoutComments[i+1] = ' ', ' '
-					i++
-					break
-				}
-				if withoutComments[i] != '\n' && withoutComments[i] != '\r' {
-					withoutComments[i] = ' '
-				}
-			}
-		}
-	}
-
-	normalized := make([]byte, 0, len(withoutComments))
-	inString = false
-	escaped = false
-	for i, current := range withoutComments {
-		if inString {
-			normalized = append(normalized, current)
-			switch {
-			case escaped:
-				escaped = false
-			case current == '\\':
-				escaped = true
-			case current == '"':
-				inString = false
-			}
-			continue
-		}
-		if current == '"' {
-			inString = true
-			normalized = append(normalized, current)
-			continue
-		}
-		if current == ',' {
-			next := i + 1
-			for next < len(withoutComments) && (withoutComments[next] == ' ' || withoutComments[next] == '\t' || withoutComments[next] == '\r' || withoutComments[next] == '\n') {
-				next++
-			}
-			if next < len(withoutComments) && (withoutComments[next] == '}' || withoutComments[next] == ']') {
-				continue
-			}
-		}
-		normalized = append(normalized, current)
-	}
-	return normalized
-}
-
 func codeGraphToolWiringPaths(homeDir string, adapter agents.Adapter) []string {
 	paths := []string{
 		adapter.MCPConfigPath(homeDir, "codegraph"),
 		adapter.SettingsPath(homeDir),
 	}
-	if adapter.Agent() == model.AgentOpenCode {
+	if _, ok := adapter.(agents.EffectiveCodeGraphWiringDetector); ok {
 		settingsPath := adapter.SettingsPath(homeDir)
 		if strings.HasSuffix(settingsPath, ".json") {
 			paths = append(paths, strings.TrimSuffix(settingsPath, ".json")+".jsonc")

--- a/internal/components/communitytool/tool_test.go
+++ b/internal/components/communitytool/tool_test.go
@@ -9,6 +9,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gentleman-programming/gentle-ai/internal/agents"
+	"github.com/gentleman-programming/gentle-ai/internal/agents/claude"
+	"github.com/gentleman-programming/gentle-ai/internal/agents/opencode"
 	"github.com/gentleman-programming/gentle-ai/internal/model"
 )
 
@@ -769,6 +772,28 @@ func TestDetectStatusRejectsDisabledOpenCodeWiring(t *testing.T) {
 	opencode := findAgentStatus(t, status, model.AgentOpenCode)
 	if opencode.Configured || opencode.Status != AgentStatusMissing {
 		t.Fatalf("opencode status = %#v, want disabled MCP reported missing", opencode)
+	}
+}
+
+func TestCodeGraphEffectiveWiringCapabilityIsOptional(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("XDG_CONFIG_HOME", "")
+
+	var openCodeAdapter agents.Adapter = opencode.NewAdapter()
+	if _, ok := openCodeAdapter.(agents.EffectiveCodeGraphWiringDetector); !ok {
+		t.Fatal("OpenCode adapter does not expose effective CodeGraph wiring detection")
+	}
+
+	var claudeAdapter agents.Adapter = claude.NewAdapter()
+	if _, ok := claudeAdapter.(agents.EffectiveCodeGraphWiringDetector); ok {
+		t.Fatal("Claude adapter unexpectedly exposes OpenCode-specific wiring detection")
+	}
+	path := claudeAdapter.MCPConfigPath(home, "codegraph")
+	mustWrite(t, path, `{"command":"codegraph"}`)
+	if gotPath, configured := hasCodeGraphToolWiring(home, claudeAdapter); !configured || gotPath != path {
+		t.Fatalf("fallback marker detection = (%q, %v), want (%q, true)", gotPath, configured, path)
 	}
 }
 


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1145

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

This is the bounded release-hardening follow-up to merged PR #1138. It prevents rollback of captured mode-000 files and symlink targets from transiently writing restored bytes with mode 0644, centralizes effective CodeGraph JSON/JSONC wiring detection in the OpenCode adapter, and keeps OpenCode path resolution consistent with its configured XDG root.

The seven-file candidate is based directly on current `main` at `f8772812c7a5aa13071190177cd5491f5736fdff`. It preserves all `internal/app` files byte-for-byte and does not alter the critical correction delivered by #1138.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/cli` | Restores rollback content with restrictive intermediate permissions before applying the exact captured mode. |
| `internal/agents/opencode` | Owns canonical OpenCode paths and effective CodeGraph wiring detection through an optional agent capability. |
| `internal/components/communitytool` | Delegates effective wiring checks to capable adapters instead of parsing OpenCode configuration generically. |
| Tests | Covers mode-000 rollback, symlink targets, alternate XDG roots, JSON/JSONC detection, and capability delegation. |

---

## 🧪 Test Plan

**Focused Tests**
```bash
env -u GENTLE_AI_CHANNEL go test ./internal/agents ./internal/agents/opencode ./internal/cli ./internal/components/communitytool -count=1
```

**Full Verification**
```bash
env -u GENTLE_AI_CHANNEL go test ./... -count=1
go vet ./...
go build ./...
git diff --check
```

- [x] Focused tests pass
- [x] Full unit test suite passes
- [x] `go vet ./...` passes
- [x] `go build ./...` passes
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — required CI check pending
- [x] Reviewed candidate tree matches `b28c033216be7e04e9c4adcf0725137bf9907cc9`
- [x] `internal/app` matches `main` byte-for-byte

---

## 🤖 Automated Checks

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | 373 changed lines, within the 400-line budget |
| Check Issue Reference | ⏳ | PR body contains `Closes #1145` |
| Check Issue Has `status:approved` | ⏳ | Linked issue is approved |
| Check PR Has `type:*` Label | ⏳ | Exactly `type:bug` is applied |
| Unit Tests | ⏳ | Required CI check pending |
| E2E Tests | ⏳ | Required CI check pending |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [x] I have added exactly one `type:*` label: `type:bug`
- [x] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — required CI check pending
- [x] Documentation changes are not required for this internal hardening fix
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

Non-blocking warning: the shared JSONC comment stripper currently accepts an invalid token-spliced boolean such as `tr/**/ue` by removing the block comment without inserting whitespace. The runtime reproduction passes and logs the warning. This pre-existing parser behavior is not introduced by this PR and does not block the reviewed hardening candidate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved detection of active CodeGraph integration in OpenCode configuration files, including JSONC settings.
  - Added support for adapter-specific configuration checks while retaining fallback detection for other environments.

- **Bug Fixes**
  - Restores files without accidentally broadening restrictive permissions.
  - Aligns CodeGraph configuration paths with XDG configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->