### PR TITLE
fix(codegraph): replace self-timing-out Pi probe

### DIFF
--- a/internal/cli/run_community_tool_test.go
+++ b/internal/cli/run_community_tool_test.go
@@ -77,7 +77,7 @@ func TestInstallRuntimeStagePlanDeselectionCleansOwnedPiIntegration(t *testing.T
 						"type": "object",
 						"properties": map[string]any{
 							"query":       map[string]any{"type": "string"},
-							"maxFiles":    map[string]any{"type": "number"},
+							"maxFiles":    map[string]any{"type": "integer"},
 							"projectPath": map[string]any{"type": "string"},
 						},
 						"required": []any{"query"},
@@ -498,21 +498,17 @@ func TestInstallPipelineDoesNotDuplicatePiPendingWhenSelected(t *testing.T) {
 	}
 }
 
-func TestPiCodeGraphRuntimeOutputClassification(t *testing.T) {
+func TestPiCodeGraphMCPRuntimeClassification(t *testing.T) {
 	if runtime.GOOS == "windows" {
-		t.Skip("fake Pi runtime uses a POSIX script")
+		t.Skip("fake CodeGraph runtime uses a POSIX script")
 	}
 	tests := []struct {
 		name    string
-		output  string
+		tools   string
 		pending bool
 	}{
-		{name: "session only", output: `{"type":"session","version":3}` + "\n", pending: true},
-		{name: "not ready", output: "codegraph: not ready\n"},
-		{name: "not running", output: "codegraph: not running\n"},
-		{name: "unloaded", output: "codegraph: unloaded\n"},
-		{name: "inactive", output: "codegraph: inactive\n"},
-		{name: "broken", output: "codegraph: broken\n"},
+		{name: "valid MCP capability", tools: `[{"name":"codegraph_explore","inputSchema":{"type":"object","properties":{"query":{"type":"string"},"maxFiles":{"type":"integer"},"projectPath":{"type":"string"}},"required":["query"]}}]`, pending: true},
+		{name: "malformed MCP response", tools: `not-json`},
 	}
 
 	for _, tc := range tests {
@@ -520,7 +516,7 @@ func TestPiCodeGraphRuntimeOutputClassification(t *testing.T) {
 			home := t.TempDir()
 			writePiInstallFixture(t, home)
 			mustWriteFile(t, filepath.Join(home, ".pi", "agent", "npm", "node_modules", "pi-mcp-adapter", "index.ts"), []byte("export default {}\n"))
-			installFakePiRuntime(t, tc.output)
+			installFakeCodeGraphMCP(t, tc.tools)
 
 			result, err := communitytool.ReconcilePiCodeGraph(communitytool.PiCodeGraphOptions{HomeDir: home, Selected: true})
 			result, err = communitytool.PreservePiCodeGraphPending(result, err)
@@ -584,12 +580,18 @@ func writePiInstallFixture(t *testing.T, home string) {
 	mustWriteFile(t, filepath.Join(home, ".pi", "agent", "subagents", "worker.md"), []byte("---\ntools: bash\n---\nwork\n"))
 }
 
-func installFakePiRuntime(t *testing.T, output string) {
+func installFakeCodeGraphMCP(t *testing.T, tools string) {
 	t.Helper()
 	binDir := t.TempDir()
-	piPath := filepath.Join(binDir, "pi")
-	quoted := strings.ReplaceAll(output, "'", "'\"'\"'")
-	if err := os.WriteFile(piPath, []byte("#!/bin/sh\nprintf '%s' '"+quoted+"'\n"), 0o755); err != nil {
+	codeGraphPath := filepath.Join(binDir, "codegraph")
+	script := "#!/bin/sh\n" +
+		"[ \"$1\" = serve ] && [ \"$2\" = --mcp ] || exit 64\n" +
+		"IFS= read -r initialize || exit 65\n" +
+		"printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"protocolVersion\":\"2025-03-26\",\"capabilities\":{},\"serverInfo\":{\"name\":\"fake-codegraph\",\"version\":\"1\"}}}'\n" +
+		"IFS= read -r initialized || exit 66\n" +
+		"IFS= read -r tools_list || exit 67\n" +
+		"printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":2,\"result\":{\"tools\":" + tools + "}}'\n"
+	if err := os.WriteFile(codeGraphPath, []byte(script), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))

--- a/internal/components/communitytool/pi_codegraph.go
+++ b/internal/components/communitytool/pi_codegraph.go
@@ -480,12 +480,16 @@ func probePiCodeGraphMCP(mcpPath string) (PiCodeGraphMCPProbeResult, error) {
 }
 
 func probePiCodeGraphMCPWithAgentDir(mcpPath, agentDir string) (PiCodeGraphMCPProbeResult, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	return probePiCodeGraphMCPWithAgentDirContext(ctx, mcpPath, agentDir)
+}
+
+func probePiCodeGraphMCPWithAgentDirContext(ctx context.Context, mcpPath, agentDir string) (probeResult PiCodeGraphMCPProbeResult, returnErr error) {
 	adapterPath := filepath.Join(agentDir, "npm", "node_modules", "pi-mcp-adapter", "index.ts")
 	if _, err := os.Stat(adapterPath); err != nil {
 		return PiCodeGraphMCPProbeResult{}, fmt.Errorf("Pi MCP adapter extension is unavailable at %q: %w", adapterPath, err)
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
 	command := exec.CommandContext(ctx, "codegraph", "serve", "--mcp")
 	stdin, err := command.StdinPipe()
 	if err != nil {
@@ -500,8 +504,19 @@ func probePiCodeGraphMCPWithAgentDir(mcpPath, agentDir string) (PiCodeGraphMCPPr
 	}
 	defer func() {
 		_ = stdin.Close()
-		_ = command.Process.Kill()
-		_ = command.Wait()
+		killErr := command.Process.Kill()
+		waitErr := command.Wait()
+		if errors.Is(returnErr, context.DeadlineExceeded) {
+			return
+		}
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			probeResult = PiCodeGraphMCPProbeResult{}
+			returnErr = fmt.Errorf("wait for CodeGraph MCP server: %w", context.DeadlineExceeded)
+			return
+		}
+		if returnErr == nil && errors.Is(killErr, os.ErrProcessDone) && waitErr != nil {
+			returnErr = fmt.Errorf("wait for CodeGraph MCP server: %w", waitErr)
+		}
 	}()
 
 	encoder := json.NewEncoder(stdin)
@@ -513,7 +528,7 @@ func probePiCodeGraphMCPWithAgentDir(mcpPath, agentDir string) (PiCodeGraphMCPPr
 		return PiCodeGraphMCPProbeResult{}, fmt.Errorf("send MCP initialize: %w", err)
 	}
 	if _, err := readPiMCPResponse(decoder, 1); err != nil {
-		return PiCodeGraphMCPProbeResult{}, fmt.Errorf("MCP initialize: %w", err)
+		return PiCodeGraphMCPProbeResult{}, fmt.Errorf("MCP initialize: %w", piCodeGraphMCPDeadlineError(ctx, "read response", err))
 	}
 	if err := encoder.Encode(map[string]any{"jsonrpc": "2.0", "method": "notifications/initialized", "params": map[string]any{}}); err != nil {
 		return PiCodeGraphMCPProbeResult{}, fmt.Errorf("send MCP initialized notification: %w", err)
@@ -523,7 +538,7 @@ func probePiCodeGraphMCPWithAgentDir(mcpPath, agentDir string) (PiCodeGraphMCPPr
 	}
 	response, err := readPiMCPResponse(decoder, 2)
 	if err != nil {
-		return PiCodeGraphMCPProbeResult{}, fmt.Errorf("MCP tools/list: %w", err)
+		return PiCodeGraphMCPProbeResult{}, fmt.Errorf("MCP tools/list: %w", piCodeGraphMCPDeadlineError(ctx, "read response", err))
 	}
 	result, _ := response["result"].(map[string]any)
 	rawTools, _ := result["tools"].([]any)
@@ -540,6 +555,13 @@ func probePiCodeGraphMCPWithAgentDir(mcpPath, agentDir string) (PiCodeGraphMCPPr
 		tools = append(tools, tool)
 	}
 	return PiCodeGraphMCPProbeResult{AdapterAvailable: true, Initialized: true, Tools: tools}, ErrPiCodeGraphAdapterHealthUnavailable
+}
+
+func piCodeGraphMCPDeadlineError(ctx context.Context, phase string, err error) error {
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		return fmt.Errorf("%s: %w", phase, context.DeadlineExceeded)
+	}
+	return err
 }
 
 func readPiMCPResponse(decoder *json.Decoder, id int) (map[string]any, error) {

--- a/internal/components/communitytool/pi_codegraph.go
+++ b/internal/components/communitytool/pi_codegraph.go
@@ -40,11 +40,6 @@ var ErrPiCodeGraphAdapterHealthUnavailable = errors.New("Pi MCP adapter health i
 
 const piCodeGraphPendingAction = "Pi CodeGraph integration is pending: Pi 0.80.6 has no supported machine-verifiable adapter health signal. CodeGraph capability was not reported as configured."
 
-// piCodeGraphAdapterRuntimeRunner is the Pi subprocess boundary. It captures
-// combined stdout/stderr so exit status alone cannot be mistaken for adapter
-// health.
-var piCodeGraphAdapterRuntimeRunner = defaultPiCodeGraphAdapterRuntimeRunner
-
 type PiChildClassification string
 
 const (
@@ -464,7 +459,7 @@ func verifyPiMCPWithProbe(mcpPath string, probe PiCodeGraphEffectiveMCPProbe) (P
 		return PiCodeGraphMCPVerification{}, fmt.Errorf("Pi CodeGraph MCP capability probe is not configured")
 	}
 	result, err := probe(mcpPath)
-	if err != nil {
+	if err != nil && !errors.Is(err, ErrPiCodeGraphAdapterHealthUnavailable) {
 		return PiCodeGraphMCPVerification{}, fmt.Errorf("Pi CodeGraph MCP capability probe failed: %w", err)
 	}
 	if !result.AdapterAvailable || !result.Initialized {
@@ -473,7 +468,11 @@ func verifyPiMCPWithProbe(mcpPath string, probe PiCodeGraphEffectiveMCPProbe) (P
 	if !isReadOnlyCodeGraphExploreSchema(result.Tools) {
 		return PiCodeGraphMCPVerification{}, fmt.Errorf("Pi CodeGraph MCP tools/list does not expose the required read-only codegraph_explore schema")
 	}
-	return PiCodeGraphMCPVerification{Adapter: true, ReadOnlyExplore: true, Tools: []string{"codegraph_explore"}}, nil
+	verification := PiCodeGraphMCPVerification{Adapter: true, ReadOnlyExplore: true, Tools: []string{"codegraph_explore"}}
+	if err != nil {
+		return verification, ErrPiCodeGraphAdapterHealthUnavailable
+	}
+	return verification, nil
 }
 
 func probePiCodeGraphMCP(mcpPath string) (PiCodeGraphMCPProbeResult, error) {
@@ -485,12 +484,6 @@ func probePiCodeGraphMCPWithAgentDir(mcpPath, agentDir string) (PiCodeGraphMCPPr
 	if _, err := os.Stat(adapterPath); err != nil {
 		return PiCodeGraphMCPProbeResult{}, fmt.Errorf("Pi MCP adapter extension is unavailable at %q: %w", adapterPath, err)
 	}
-	if result, err := probePiCodeGraphAdapterRuntime(agentDir, mcpPath); err != nil {
-		return PiCodeGraphMCPProbeResult{}, fmt.Errorf("Pi MCP adapter runtime is unavailable: %w", err)
-	} else if !result.AdapterAvailable || !result.Initialized {
-		return PiCodeGraphMCPProbeResult{}, fmt.Errorf("Pi MCP adapter runtime did not initialize")
-	}
-
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	command := exec.CommandContext(ctx, "codegraph", "serve", "--mcp")
@@ -546,62 +539,7 @@ func probePiCodeGraphMCPWithAgentDir(mcpPath, agentDir string) (PiCodeGraphMCPPr
 		}
 		tools = append(tools, tool)
 	}
-	return PiCodeGraphMCPProbeResult{AdapterAvailable: true, Initialized: true, Tools: tools}, nil
-}
-
-func probePiCodeGraphAdapterRuntime(agentDir, mcpPath string) (PiCodeGraphMCPProbeResult, error) {
-	// Pi 0.80.6 exposes --mcp-config and JSON print mode but no dedicated MCP
-	// status API. Ask its adapter status command and accept only explicit
-	// codegraph success evidence from the combined process output.
-	args := []string{"--mcp-config", mcpPath, "--mode", "json", "--no-session", "--offline", "--print", "/mcp status"}
-	output, err := piCodeGraphAdapterRuntimeRunner("pi", args, append(os.Environ(), "PI_CODING_AGENT_DIR="+agentDir))
-	if err != nil {
-		return PiCodeGraphMCPProbeResult{}, fmt.Errorf("run Pi MCP adapter for %q: %w: %s", mcpPath, err, strings.TrimSpace(string(output)))
-	}
-	if err := validatePiCodeGraphAdapterRuntimeOutput(output); err != nil {
-		return PiCodeGraphMCPProbeResult{}, err
-	}
-	return PiCodeGraphMCPProbeResult{}, ErrPiCodeGraphAdapterHealthUnavailable
-}
-
-func defaultPiCodeGraphAdapterRuntimeRunner(name string, args, env []string) ([]byte, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	cmd := exec.CommandContext(ctx, name, args...)
-	cmd.Env = env
-	return cmd.CombinedOutput()
-}
-
-func validatePiCodeGraphAdapterRuntimeOutput(output []byte) error {
-	status := strings.ToLower(strings.TrimSpace(string(output)))
-	if status == "" {
-		return fmt.Errorf("Pi MCP adapter runtime produced no capability evidence")
-	}
-	failureEvidence := []string{
-		"failed to load mcp config",
-		"failed to load mcp",
-		"failed to load extension",
-		"failed to load adapter",
-		"adapter load error",
-		"error loading mcp",
-		"mcp adapter error",
-		"not ready",
-		"not running",
-		"unloaded",
-		"inactive",
-		"broken",
-		"not connected",
-		"disconnected",
-	}
-	for _, evidence := range failureEvidence {
-		if strings.Contains(status, evidence) {
-			return fmt.Errorf("Pi MCP adapter runtime reported failure: %s", strings.TrimSpace(string(output)))
-		}
-	}
-	if strings.Contains(status, "unknown") && strings.Contains(status, "/mcp") {
-		return fmt.Errorf("Pi MCP adapter runtime does not recognize /mcp status: %s", strings.TrimSpace(string(output)))
-	}
-	return ErrPiCodeGraphAdapterHealthUnavailable
+	return PiCodeGraphMCPProbeResult{AdapterAvailable: true, Initialized: true, Tools: tools}, ErrPiCodeGraphAdapterHealthUnavailable
 }
 
 func readPiMCPResponse(decoder *json.Decoder, id int) (map[string]any, error) {
@@ -629,7 +567,9 @@ func isReadOnlyCodeGraphExploreSchema(tools []PiCodeGraphMCPTool) bool {
 		return false
 	}
 	properties, ok := schema["properties"].(map[string]any)
-	if !ok || len(properties) != 3 || !hasSchemaType(properties, "query", "string") || !hasSchemaType(properties, "maxFiles", "number") || !hasSchemaType(properties, "projectPath", "string") {
+	if !ok || len(properties) != 3 || !hasSchemaType(properties, "query", "string") ||
+		(!hasSchemaType(properties, "maxFiles", "integer") && !hasSchemaType(properties, "maxFiles", "number")) ||
+		!hasSchemaType(properties, "projectPath", "string") {
 		return false
 	}
 	required, ok := schema["required"].([]any)

--- a/internal/components/communitytool/pi_codegraph_test.go
+++ b/internal/components/communitytool/pi_codegraph_test.go
@@ -359,7 +359,7 @@ func TestVerifyPiMCPUsesInjectedEffectiveProbe(t *testing.T) {
 			"type": "object",
 			"properties": map[string]any{
 				"query":       map[string]any{"type": "string"},
-				"maxFiles":    map[string]any{"type": "number"},
+				"maxFiles":    map[string]any{"type": "integer"},
 				"projectPath": map[string]any{"type": "string"},
 			},
 			"required": []any{"query"},
@@ -367,9 +367,11 @@ func TestVerifyPiMCPUsesInjectedEffectiveProbe(t *testing.T) {
 	}
 
 	for _, tt := range []struct {
-		name    string
-		probe   PiCodeGraphMCPProbeResult
-		wantErr bool
+		name        string
+		probe       PiCodeGraphMCPProbeResult
+		probeErr    error
+		wantErr     bool
+		wantPending bool
 	}{
 		{name: "successful initialized read-only explore", probe: PiCodeGraphMCPProbeResult{AdapterAvailable: true, Initialized: true, Tools: []PiCodeGraphMCPTool{validTool}}},
 		{name: "successful unindexed initialized read-only explore requires project path", probe: PiCodeGraphMCPProbeResult{AdapterAvailable: true, Initialized: true, Tools: []PiCodeGraphMCPTool{{Name: validTool.Name, InputSchema: map[string]any{
@@ -381,6 +383,7 @@ func TestVerifyPiMCPUsesInjectedEffectiveProbe(t *testing.T) {
 		{name: "handshake failed", probe: PiCodeGraphMCPProbeResult{AdapterAvailable: true, Tools: []PiCodeGraphMCPTool{validTool}}, wantErr: true},
 		{name: "missing explore tool", probe: PiCodeGraphMCPProbeResult{AdapterAvailable: true, Initialized: true}, wantErr: true},
 		{name: "malformed explore schema", probe: PiCodeGraphMCPProbeResult{AdapterAvailable: true, Initialized: true, Tools: []PiCodeGraphMCPTool{{Name: "codegraph_explore", InputSchema: map[string]any{"type": "object"}}}}, wantErr: true},
+		{name: "incompatible maxFiles type", probe: PiCodeGraphMCPProbeResult{AdapterAvailable: true, Initialized: true, Tools: []PiCodeGraphMCPTool{{Name: validTool.Name, InputSchema: map[string]any{"type": "object", "properties": map[string]any{"query": map[string]any{"type": "string"}, "maxFiles": map[string]any{"type": "boolean"}, "projectPath": map[string]any{"type": "string"}}, "required": []any{"query"}}}}}, wantErr: true},
 		{name: "unknown required field", probe: PiCodeGraphMCPProbeResult{AdapterAvailable: true, Initialized: true, Tools: []PiCodeGraphMCPTool{{Name: validTool.Name, InputSchema: map[string]any{
 			"type":       "object",
 			"properties": validTool.InputSchema["properties"],
@@ -397,13 +400,25 @@ func TestVerifyPiMCPUsesInjectedEffectiveProbe(t *testing.T) {
 			"required":   []any{"query", "query"},
 		}}}}, wantErr: true},
 		{name: "unexpected writable tool", probe: PiCodeGraphMCPProbeResult{AdapterAvailable: true, Initialized: true, Tools: []PiCodeGraphMCPTool{validTool, {Name: "codegraph_write", InputSchema: validTool.InputSchema}}}, wantErr: true},
+		{name: "pending health with missing explore tool remains fatal", probe: PiCodeGraphMCPProbeResult{AdapterAvailable: true, Initialized: true}, probeErr: ErrPiCodeGraphAdapterHealthUnavailable, wantErr: true},
+		{name: "pending health with malformed explore schema remains fatal", probe: PiCodeGraphMCPProbeResult{AdapterAvailable: true, Initialized: true, Tools: []PiCodeGraphMCPTool{{Name: "codegraph_explore", InputSchema: map[string]any{"type": "object"}}}}, probeErr: ErrPiCodeGraphAdapterHealthUnavailable, wantErr: true},
+		{name: "validated capability with unavailable adapter health becomes pending", probe: PiCodeGraphMCPProbeResult{AdapterAvailable: true, Initialized: true, Tools: []PiCodeGraphMCPTool{validTool}}, probeErr: ErrPiCodeGraphAdapterHealthUnavailable, wantPending: true},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			previous := piCodeGraphEffectiveMCPProbe
-			piCodeGraphEffectiveMCPProbe = func(string) (PiCodeGraphMCPProbeResult, error) { return tt.probe, nil }
+			piCodeGraphEffectiveMCPProbe = func(string) (PiCodeGraphMCPProbeResult, error) { return tt.probe, tt.probeErr }
 			t.Cleanup(func() { piCodeGraphEffectiveMCPProbe = previous })
 
 			verification, err := verifyPiMCP(mcpPath)
+			if tt.wantPending {
+				if !errors.Is(err, ErrPiCodeGraphAdapterHealthUnavailable) {
+					t.Fatalf("verifyPiMCP() error = %v, want pending adapter health", err)
+				}
+				if !verification.Adapter || !verification.ReadOnlyExplore || len(verification.Tools) != 1 || verification.Tools[0] != "codegraph_explore" {
+					t.Fatalf("verification = %#v, want validated capability evidence", verification)
+				}
+				return
+			}
 			if tt.wantErr {
 				if err == nil {
 					t.Fatalf("verifyPiMCP() = %#v, nil error", verification)
@@ -477,11 +492,13 @@ func TestPiCodeGraphPendingProbePreservesConfiguredFiles(t *testing.T) {
 	childPath := filepath.Join(home, ".pi", "agent", "subagents", "worker.md")
 	manifestPath := filepath.Join(home, ".gentle-ai", "pi-codegraph.json")
 	writePiFile(t, childPath, "---\ntools: bash\n---\nwork\n")
-	pendingProbe := func(string) (PiCodeGraphMCPProbeResult, error) {
-		return PiCodeGraphMCPProbeResult{}, ErrPiCodeGraphAdapterHealthUnavailable
-	}
+	writePiFile(t, filepath.Join(home, ".pi", "agent", "npm", "node_modules", "pi-mcp-adapter", "index.ts"), "export default {}\n")
+	installFakeCodeGraph(t)
+	previousProbe := piCodeGraphEffectiveMCPProbe
+	piCodeGraphEffectiveMCPProbe = probePiCodeGraphMCP
+	t.Cleanup(func() { piCodeGraphEffectiveMCPProbe = previousProbe })
 
-	result, err := ReconcilePiCodeGraph(PiCodeGraphOptions{HomeDir: home, Selected: true, EffectiveMCPProbe: pendingProbe})
+	result, err := ReconcilePiCodeGraph(PiCodeGraphOptions{HomeDir: home, Selected: true})
 	if err != nil {
 		t.Fatalf("ReconcilePiCodeGraph() error = %v, want pending success", err)
 	}
@@ -605,139 +622,20 @@ func TestPiCodeGraphFailsClosedForBrokenProjectMCPOverride(t *testing.T) {
 	}
 }
 
-func TestPiCodeGraphProbeUsesAgentRuntimeForProjectMCPOverride(t *testing.T) {
+func TestPiCodeGraphProbeVerifiesDirectMCPWithoutPiProcess(t *testing.T) {
 	home := t.TempDir()
 	agentDir := filepath.Join(home, "custom-agent")
 	mcpPath := filepath.Join(home, "project", ".mcp.json")
 	writePiFile(t, filepath.Join(agentDir, "npm", "node_modules", "pi-mcp-adapter", "index.ts"), "export default {}\n")
 	writePiFile(t, mcpPath, `{"mcpServers":{"codegraph":{"command":"codegraph","args":["serve","--mcp"]}}}`)
+	installFakeCodeGraph(t)
 
-	previous := piCodeGraphAdapterRuntimeRunner
-	defer func() { piCodeGraphAdapterRuntimeRunner = previous }()
-	called := false
-	piCodeGraphAdapterRuntimeRunner = func(name string, args, env []string) ([]byte, error) {
-		called = name == "pi" && slices.Equal(args, []string{"--mcp-config", mcpPath, "--mode", "json", "--no-session", "--offline", "--print", "/mcp status"}) && slices.Contains(env, "PI_CODING_AGENT_DIR="+agentDir)
-		return []byte("MCP Servers:\n  codegraph: connected\n"), nil
+	result, err := probePiCodeGraphMCPWithAgentDir(mcpPath, agentDir)
+	if !errors.Is(err, ErrPiCodeGraphAdapterHealthUnavailable) {
+		t.Fatalf("probe error = %v, want unavailable adapter health", err)
 	}
-
-	if _, err := probePiCodeGraphMCPWithAgentDir(mcpPath, agentDir); !errors.Is(err, ErrPiCodeGraphAdapterHealthUnavailable) || !called {
-		t.Fatalf("probe error=%v called=%v, want fail-closed project config through Pi agent runtime", err, called)
-	}
-}
-
-func TestPiCodeGraphAdapterRuntimeFailsClosedWithoutPositiveCapabilityEvidence(t *testing.T) {
-	agentDir := t.TempDir()
-	mcpPath := filepath.Join(agentDir, "mcp.json")
-
-	tests := []struct {
-		name    string
-		output  string
-		wantErr bool
-	}{
-		{
-			name:    "exit zero with failed MCP config",
-			output:  "Failed to load MCP config: invalid JSON\n",
-			wantErr: true,
-		},
-		{
-			name:    "exit zero with adapter load error",
-			output:  "Failed to load extension pi-mcp-adapter: module not found\n",
-			wantErr: true,
-		},
-		{
-			name:    "exit zero with unknown MCP command",
-			output:  "Unknown command: /mcp\n",
-			wantErr: true,
-		},
-		{
-			name:    "exit zero without capability evidence",
-			output:  `{"type":"session","version":3}` + "\n",
-			wantErr: true,
-		},
-		{
-			name:    "rejects negated ready status",
-			output:  "MCP Servers:\n  codegraph: not ready\n",
-			wantErr: true,
-		},
-		{
-			name:    "rejects negated running status",
-			output:  "MCP Servers:\n  codegraph: not running\n",
-			wantErr: true,
-		},
-		{
-			name:    "rejects unloaded status",
-			output:  "MCP Servers:\n  codegraph: unloaded\n",
-			wantErr: true,
-		},
-		{
-			name:    "rejects inactive status",
-			output:  "MCP Servers:\n  codegraph: inactive\n",
-			wantErr: true,
-		},
-		{
-			name:    "rejects broken status containing ok",
-			output:  "MCP Servers:\n  codegraph: broken\n",
-			wantErr: true,
-		},
-		{
-			name:    "rejects malformed status",
-			output:  "MCP Servers:\n  codegraph connected\n",
-			wantErr: true,
-		},
-		{
-			name:    "rejects unrelated healthy status",
-			output:  "MCP Servers:\n  filesystem: ready\n",
-			wantErr: true,
-		},
-		{
-			name:    "rejects ambiguous codegraph statuses",
-			output:  "MCP Servers:\n  codegraph: connected\n  codegraph: not ready\n",
-			wantErr: true,
-		},
-		{
-			name:    "session-only status is not adapter health",
-			output:  "MCP Servers:\n  codegraph: connected\n",
-			wantErr: true,
-		},
-		{
-			name:    "ambiguous ready status is not adapter health",
-			output:  "MCP Servers:\n  codegraph: ready\n",
-			wantErr: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			previous := piCodeGraphAdapterRuntimeRunner
-			piCodeGraphAdapterRuntimeRunner = func(name string, args, env []string) ([]byte, error) {
-				if name != "pi" {
-					t.Fatalf("runtime = %q, want pi", name)
-				}
-				wantArgs := []string{"--mcp-config", mcpPath, "--mode", "json", "--no-session", "--offline", "--print", "/mcp status"}
-				if !slices.Equal(args, wantArgs) {
-					t.Fatalf("args = %q, want %q", args, wantArgs)
-				}
-				if !slices.Contains(env, "PI_CODING_AGENT_DIR="+agentDir) {
-					t.Fatalf("env = %q, want Pi agent directory", env)
-				}
-				return []byte(tt.output), nil
-			}
-			t.Cleanup(func() { piCodeGraphAdapterRuntimeRunner = previous })
-
-			result, err := probePiCodeGraphAdapterRuntime(agentDir, mcpPath)
-			if tt.wantErr {
-				if err == nil {
-					t.Fatalf("probe result = %#v, want rejected output", result)
-				}
-				return
-			}
-			if err != nil {
-				t.Fatalf("probe error = %v", err)
-			}
-			if !result.AdapterAvailable || !result.Initialized {
-				t.Fatalf("probe result = %#v, want initialized adapter", result)
-			}
-		})
+	if !result.AdapterAvailable || !result.Initialized || !isReadOnlyCodeGraphExploreSchema(result.Tools) {
+		t.Fatalf("probe result = %#v, want verified direct MCP capability", result)
 	}
 }
 
@@ -873,7 +771,7 @@ func piProbeForTest(string) (PiCodeGraphMCPProbeResult, error) {
 			"type": "object",
 			"properties": map[string]any{
 				"query":       map[string]any{"type": "string"},
-				"maxFiles":    map[string]any{"type": "number"},
+				"maxFiles":    map[string]any{"type": "integer"},
 				"projectPath": map[string]any{"type": "string"},
 			},
 			"required": []any{"query"},
@@ -898,4 +796,22 @@ func mustReadPiFile(t *testing.T, path string) []byte {
 		t.Fatal(err)
 	}
 	return data
+}
+
+func installFakeCodeGraph(t *testing.T) {
+	t.Helper()
+	binDir := t.TempDir()
+	script := `#!/bin/sh
+while IFS= read -r request; do
+  case "$request" in
+    *'"id":1'*) printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-03-26","capabilities":{},"serverInfo":{"name":"fake","version":"1"}}}' ;;
+    *'"id":2'*) printf '%s\n' '{"jsonrpc":"2.0","id":2,"result":{"tools":[{"name":"codegraph_explore","inputSchema":{"type":"object","properties":{"query":{"type":"string"},"maxFiles":{"type":"integer"},"projectPath":{"type":"string"}},"required":["query"]}}]}}' ;;
+  esac
+done
+`
+	path := filepath.Join(binDir, "codegraph")
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 }

--- a/internal/components/communitytool/pi_codegraph_test.go
+++ b/internal/components/communitytool/pi_codegraph_test.go
@@ -1,6 +1,7 @@
 package communitytool
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"os"
@@ -9,6 +10,7 @@ import (
 	"slices"
 	"strings"
 	"testing"
+	"time"
 
 	piagent "github.com/gentleman-programming/gentle-ai/internal/agents/pi"
 	"github.com/gentleman-programming/gentle-ai/internal/components/filemerge"
@@ -639,6 +641,48 @@ func TestPiCodeGraphProbeVerifiesDirectMCPWithoutPiProcess(t *testing.T) {
 	}
 }
 
+func TestPiCodeGraphProbeClassifiesStalledMCPResponsesAsDeadlineExceeded(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		script    string
+		wantPhase string
+	}{
+		{
+			name:      "initialize",
+			script:    `while IFS= read -r request; do while :; do :; done; done`,
+			wantPhase: "MCP initialize: read response",
+		},
+		{
+			name: "tools list",
+			script: `while IFS= read -r request; do
+  case "$request" in
+    *'"id":1'*) printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{}}' ;;
+    *'"id":2'*) while :; do :; done ;;
+  esac
+done`,
+			wantPhase: "MCP tools/list: read response",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			home := t.TempDir()
+			agentDir := filepath.Join(home, "custom-agent")
+			mcpPath := filepath.Join(home, "project", ".mcp.json")
+			writePiFile(t, filepath.Join(agentDir, "npm", "node_modules", "pi-mcp-adapter", "index.ts"), "export default {}\n")
+			installFakeCodeGraphScript(t, tt.script)
+
+			ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+			defer cancel()
+			_, err := probePiCodeGraphMCPWithAgentDirContext(ctx, mcpPath, agentDir)
+			if !errors.Is(err, context.DeadlineExceeded) {
+				t.Fatalf("probe error = %v, want context deadline exceeded", err)
+			}
+			if !strings.Contains(err.Error(), tt.wantPhase) {
+				t.Fatalf("probe error = %q, want phase %q", err, tt.wantPhase)
+			}
+		})
+	}
+}
+
 func TestPiCodeGraphRejectsMalformedMCPServersWithoutChangingBytes(t *testing.T) {
 	home := t.TempDir()
 	mcpPath := filepath.Join(home, ".pi", "agent", "mcp.json")
@@ -800,15 +844,18 @@ func mustReadPiFile(t *testing.T, path string) []byte {
 
 func installFakeCodeGraph(t *testing.T) {
 	t.Helper()
-	binDir := t.TempDir()
-	script := `#!/bin/sh
-while IFS= read -r request; do
+	installFakeCodeGraphScript(t, `while IFS= read -r request; do
   case "$request" in
     *'"id":1'*) printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-03-26","capabilities":{},"serverInfo":{"name":"fake","version":"1"}}}' ;;
     *'"id":2'*) printf '%s\n' '{"jsonrpc":"2.0","id":2,"result":{"tools":[{"name":"codegraph_explore","inputSchema":{"type":"object","properties":{"query":{"type":"string"},"maxFiles":{"type":"integer"},"projectPath":{"type":"string"}},"required":["query"]}}]}}' ;;
   esac
-done
-`
+done`)
+}
+
+func installFakeCodeGraphScript(t *testing.T, body string) {
+	t.Helper()
+	binDir := t.TempDir()
+	script := "#!/bin/sh\n" + body + "\n"
 	path := filepath.Join(binDir, "codegraph")
 	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
 		t.Fatal(err)

--- a/internal/components/communitytool/tool_test.go
+++ b/internal/components/communitytool/tool_test.go
@@ -35,7 +35,7 @@ func TestMain(m *testing.M) {
 					"type": "object",
 					"properties": map[string]any{
 						"query":       map[string]any{"type": "string"},
-						"maxFiles":    map[string]any{"type": "number"},
+						"maxFiles":    map[string]any{"type": "integer"},
 						"projectPath": map[string]any{"type": "string"},
 					},
 					"required": []any{"query"},
@@ -671,16 +671,12 @@ func TestInstallRunsCommandsAndReturnsLazyProjectIndexManualAction(t *testing.T)
 func TestInstallLeavesPiPendingWhenAdapterHealthIsNotMachineVerifiable(t *testing.T) {
 	home := t.TempDir()
 	mustWrite(t, filepath.Join(home, ".pi", "agent", "npm", "node_modules", "pi-mcp-adapter", "index.ts"), "export default {}\n")
-	previousRuntime := piCodeGraphAdapterRuntimeRunner
 	previousProbe := piCodeGraphEffectiveMCPProbe
-	piCodeGraphAdapterRuntimeRunner = func(string, []string, []string) ([]byte, error) {
-		return []byte(`{"type":"session","version":3}`), nil
-	}
-	piCodeGraphEffectiveMCPProbe = func(string) (PiCodeGraphMCPProbeResult, error) {
-		return PiCodeGraphMCPProbeResult{}, ErrPiCodeGraphAdapterHealthUnavailable
+	piCodeGraphEffectiveMCPProbe = func(path string) (PiCodeGraphMCPProbeResult, error) {
+		result, _ := piProbeForTest(path)
+		return result, ErrPiCodeGraphAdapterHealthUnavailable
 	}
 	t.Cleanup(func() {
-		piCodeGraphAdapterRuntimeRunner = previousRuntime
 		piCodeGraphEffectiveMCPProbe = previousProbe
 	})
 


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1149

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Removes the invalid non-interactive Pi `/mcp status` probe that waited until its own five-second timeout.
- Validates CodeGraph directly with bounded MCP `initialize` and `tools/list`, including the read-only `codegraph_explore` schema.
- Preserves configured files and reports Pi adapter health as pending when direct MCP capability is valid but adapter health remains unavailable.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/components/communitytool/pi_codegraph.go` | Replaced the Pi subprocess status probe with direct MCP capability validation and deferred pending-health classification until capability evidence is validated. |
| `internal/components/communitytool/pi_codegraph_test.go` | Added direct MCP, schema-failure, and pending-health regression coverage; removed obsolete Pi status-output tests. |
| `internal/cli/run_community_tool_test.go` | Replaced the fake Pi runtime fixture with deterministic MCP initialize/tools-list responses. |
| `internal/components/communitytool/tool_test.go` | Updated installation coverage to retain pending semantics after validated direct MCP capability. |

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./...
```

**Result:** PASS

**Focused Tests**
```bash
go test ./internal/components/communitytool ./internal/cli
```

**Result:** PASS

**E2E Tests** (Docker required)
```bash
cd e2e && ./docker-test.sh
```

- [x] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — not run locally
- [ ] Manually tested locally
- [x] Direct MCP `initialize` and `tools/list` behavior validated with deterministic process fixtures, including valid capability and malformed response paths.

---

## 🤖 Automated Checks

The following checks run automatically on this PR:

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | PR should stay within 400 changed lines (`additions + deletions`) or use `size:exception` |
| Check Issue Reference | ⏳ | PR body must contain `Closes/Fixes/Resolves #N` |
| Check Issue Has `status:approved` | ⏳ | Linked issue must have been approved before work began |
| Check PR Has `type:*` Label | ⏳ | Exactly one `type:*` label must be applied |
| Unit Tests | ⏳ | `go test ./...` must pass |
| E2E Tests | ⏳ | `cd e2e && ./docker-test.sh` must pass |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [ ] I have added the appropriate `type:*` label to this PR — blocked by repository label permissions (HTTP 403)
- [x] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

Review the direct MCP handshake and schema validation first. A successful `initialize` and `tools/list` proves CodeGraph capability, but Pi 0.80.6 still exposes no supported machine-verifiable adapter-health signal; reconciliation therefore remains pending and does not claim adapter runtime health.

E2E tests were not run locally. No documentation files changed because the user-facing pending behavior remains unchanged; this PR replaces the failing probe beneath it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Pi CodeGraph MCP verification when adapter health evidence is unavailable, marking health checks as pending while preserving read-only explore support.
  * Relaxed MCP capability/schema validation and corrected handling of malformed or stalled MCP responses.
  * Updated CodeGraph MCP input validation so `maxFiles` accepts `integer` values (not just `number`).

* **Tests**
  * Added/updated MCP probe coverage for direct verification, pending vs fatal classification, and deadline-exceeded behavior for stalled MCP reads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->