### PR TITLE
fix(codegraph): replace self-timing-out Pi probe

### DIFF
--- a/internal/cli/run_community_tool_test.go
+++ b/internal/cli/run_community_tool_test.go
@@ -77,7 +77,7 @@ func TestInstallRuntimeStagePlanDeselectionCleansOwnedPiIntegration(t *testing.T
 						"type": "object",
 						"properties": map[string]any{
 							"query":       map[string]any{"type": "string"},
-							"maxFiles":    map[string]any{"type": "number"},
+							"maxFiles":    map[string]any{"type": "integer"},
 							"projectPath": map[string]any{"type": "string"},
 						},
 						"required": []any{"query"},
@@ -498,21 +498,17 @@ func TestInstallPipelineDoesNotDuplicatePiPendingWhenSelected(t *testing.T) {
 	}
 }
 
-func TestPiCodeGraphRuntimeOutputClassification(t *testing.T) {
+func TestPiCodeGraphMCPRuntimeClassification(t *testing.T) {
 	if runtime.GOOS == "windows" {
-		t.Skip("fake Pi runtime uses a POSIX script")
+		t.Skip("fake CodeGraph runtime uses a POSIX script")
 	}
 	tests := []struct {
 		name    string
-		output  string
+		tools   string
 		pending bool
 	}{
-		{name: "session only", output: `{"type":"session","version":3}` + "\n", pending: true},
-		{name: "not ready", output: "codegraph: not ready\n"},
-		{name: "not running", output: "codegraph: not running\n"},
-		{name: "unloaded", output: "codegraph: unloaded\n"},
-		{name: "inactive", output: "codegraph: inactive\n"},
-		{name: "broken", output: "codegraph: broken\n"},
+		{name: "valid MCP capability", tools: `[{"name":"codegraph_explore","inputSchema":{"type":"object","properties":{"query":{"type":"string"},"maxFiles":{"type":"integer"},"projectPath":{"type":"string"}},"required":["query"]}}]`, pending: true},
+		{name: "malformed MCP response", tools: `not-json`},
 	}
 
 	for _, tc := range tests {
@@ -520,7 +516,7 @@ func TestPiCodeGraphRuntimeOutputClassification(t *testing.T) {
 			home := t.TempDir()
 			writePiInstallFixture(t, home)
 			mustWriteFile(t, filepath.Join(home, ".pi", "agent", "npm", "node_modules", "pi-mcp-adapter", "index.ts"), []byte("export default {}\n"))
-			installFakePiRuntime(t, tc.output)
+			installFakeCodeGraphMCP(t, tc.tools)
 
 			result, err := communitytool.ReconcilePiCodeGraph(communitytool.PiCodeGraphOptions{HomeDir: home, Selected: true})
 			result, err = communitytool.PreservePiCodeGraphPending(result, err)
@@ -584,12 +580,18 @@ func writePiInstallFixture(t *testing.T, home string) {
 	mustWriteFile(t, filepath.Join(home, ".pi", "agent", "subagents", "worker.md"), []byte("---\ntools: bash\n---\nwork\n"))
 }
 
-func installFakePiRuntime(t *testing.T, output string) {
+func installFakeCodeGraphMCP(t *testing.T, tools string) {
 	t.Helper()
 	binDir := t.TempDir()
-	piPath := filepath.Join(binDir, "pi")
-	quoted := strings.ReplaceAll(output, "'", "'\"'\"'")
-	if err := os.WriteFile(piPath, []byte("#!/bin/sh\nprintf '%s' '"+quoted+"'\n"), 0o755); err != nil {
+	codeGraphPath := filepath.Join(binDir, "codegraph")
+	script := "#!/bin/sh\n" +
+		"[ \"$1\" = serve ] && [ \"$2\" = --mcp ] || exit 64\n" +
+		"IFS= read -r initialize || exit 65\n" +
+		"printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"protocolVersion\":\"2025-03-26\",\"capabilities\":{},\"serverInfo\":{\"name\":\"fake-codegraph\",\"version\":\"1\"}}}'\n" +
+		"IFS= read -r initialized || exit 66\n" +
+		"IFS= read -r tools_list || exit 67\n" +
+		"printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":2,\"result\":{\"tools\":" + tools + "}}'\n"
+	if err := os.WriteFile(codeGraphPath, []byte(script), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))

--- a/internal/components/communitytool/pi_codegraph.go
+++ b/internal/components/communitytool/pi_codegraph.go
@@ -40,11 +40,6 @@ var ErrPiCodeGraphAdapterHealthUnavailable = errors.New("Pi MCP adapter health i
 
 const piCodeGraphPendingAction = "Pi CodeGraph integration is pending: Pi 0.80.6 has no supported machine-verifiable adapter health signal. CodeGraph capability was not reported as configured."
 
-// piCodeGraphAdapterRuntimeRunner is the Pi subprocess boundary. It captures
-// combined stdout/stderr so exit status alone cannot be mistaken for adapter
-// health.
-var piCodeGraphAdapterRuntimeRunner = defaultPiCodeGraphAdapterRuntimeRunner
-
 type PiChildClassification string
 
 const (
@@ -425,9 +420,6 @@ func verifyPiCodeGraph(mcpPath string, children []PiCodeGraphChild) error {
 }
 
 func verifyPiCodeGraphWithProbe(mcpPath string, children []PiCodeGraphChild, probe PiCodeGraphEffectiveMCPProbe) error {
-	if _, err := verifyPiMCPWithProbe(mcpPath, probe); err != nil {
-		return err
-	}
 	for _, child := range children {
 		if child.Classification == PiChildMisconfigured {
 			return fmt.Errorf("Pi child %q is misconfigured: %s", child.Name, child.Reason)
@@ -442,6 +434,9 @@ func verifyPiCodeGraphWithProbe(mcpPath string, children []PiCodeGraphChild, pro
 		if child.Classification == PiChildCompatible && (!strings.Contains(string(body), piCodeGraphToolMarker) || !slices.Contains(child.Tools, "bash") || !slices.Contains(child.Tools, "mcp")) {
 			return fmt.Errorf("Pi child %q lacks verified CodeGraph tools", child.Name)
 		}
+	}
+	if _, err := verifyPiMCPWithProbe(mcpPath, probe); err != nil {
+		return err
 	}
 	return nil
 }
@@ -464,7 +459,7 @@ func verifyPiMCPWithProbe(mcpPath string, probe PiCodeGraphEffectiveMCPProbe) (P
 		return PiCodeGraphMCPVerification{}, fmt.Errorf("Pi CodeGraph MCP capability probe is not configured")
 	}
 	result, err := probe(mcpPath)
-	if err != nil {
+	if err != nil && !errors.Is(err, ErrPiCodeGraphAdapterHealthUnavailable) {
 		return PiCodeGraphMCPVerification{}, fmt.Errorf("Pi CodeGraph MCP capability probe failed: %w", err)
 	}
 	if !result.AdapterAvailable || !result.Initialized {
@@ -473,7 +468,11 @@ func verifyPiMCPWithProbe(mcpPath string, probe PiCodeGraphEffectiveMCPProbe) (P
 	if !isReadOnlyCodeGraphExploreSchema(result.Tools) {
 		return PiCodeGraphMCPVerification{}, fmt.Errorf("Pi CodeGraph MCP tools/list does not expose the required read-only codegraph_explore schema")
 	}
-	return PiCodeGraphMCPVerification{Adapter: true, ReadOnlyExplore: true, Tools: []string{"codegraph_explore"}}, nil
+	verification := PiCodeGraphMCPVerification{Adapter: true, ReadOnlyExplore: true, Tools: []string{"codegraph_explore"}}
+	if err != nil {
+		return verification, ErrPiCodeGraphAdapterHealthUnavailable
+	}
+	return verification, nil
 }
 
 func probePiCodeGraphMCP(mcpPath string) (PiCodeGraphMCPProbeResult, error) {
@@ -481,18 +480,16 @@ func probePiCodeGraphMCP(mcpPath string) (PiCodeGraphMCPProbeResult, error) {
 }
 
 func probePiCodeGraphMCPWithAgentDir(mcpPath, agentDir string) (PiCodeGraphMCPProbeResult, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	return probePiCodeGraphMCPWithAgentDirContext(ctx, mcpPath, agentDir)
+}
+
+func probePiCodeGraphMCPWithAgentDirContext(ctx context.Context, mcpPath, agentDir string) (probeResult PiCodeGraphMCPProbeResult, returnErr error) {
 	adapterPath := filepath.Join(agentDir, "npm", "node_modules", "pi-mcp-adapter", "index.ts")
 	if _, err := os.Stat(adapterPath); err != nil {
 		return PiCodeGraphMCPProbeResult{}, fmt.Errorf("Pi MCP adapter extension is unavailable at %q: %w", adapterPath, err)
 	}
-	if result, err := probePiCodeGraphAdapterRuntime(agentDir, mcpPath); err != nil {
-		return PiCodeGraphMCPProbeResult{}, fmt.Errorf("Pi MCP adapter runtime is unavailable: %w", err)
-	} else if !result.AdapterAvailable || !result.Initialized {
-		return PiCodeGraphMCPProbeResult{}, fmt.Errorf("Pi MCP adapter runtime did not initialize")
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
 	command := exec.CommandContext(ctx, "codegraph", "serve", "--mcp")
 	stdin, err := command.StdinPipe()
 	if err != nil {
@@ -507,8 +504,19 @@ func probePiCodeGraphMCPWithAgentDir(mcpPath, agentDir string) (PiCodeGraphMCPPr
 	}
 	defer func() {
 		_ = stdin.Close()
-		_ = command.Process.Kill()
-		_ = command.Wait()
+		killErr := command.Process.Kill()
+		waitErr := command.Wait()
+		if errors.Is(returnErr, context.DeadlineExceeded) {
+			return
+		}
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			probeResult = PiCodeGraphMCPProbeResult{}
+			returnErr = fmt.Errorf("wait for CodeGraph MCP server: %w", context.DeadlineExceeded)
+			return
+		}
+		if returnErr == nil && errors.Is(killErr, os.ErrProcessDone) && waitErr != nil {
+			returnErr = fmt.Errorf("wait for CodeGraph MCP server: %w", waitErr)
+		}
 	}()
 
 	encoder := json.NewEncoder(stdin)
@@ -519,8 +527,14 @@ func probePiCodeGraphMCPWithAgentDir(mcpPath, agentDir string) (PiCodeGraphMCPPr
 	}); err != nil {
 		return PiCodeGraphMCPProbeResult{}, fmt.Errorf("send MCP initialize: %w", err)
 	}
-	if _, err := readPiMCPResponse(decoder, 1); err != nil {
-		return PiCodeGraphMCPProbeResult{}, fmt.Errorf("MCP initialize: %w", err)
+	initializeResponse, err := readPiMCPResponse(decoder, 1)
+	if err != nil {
+		return PiCodeGraphMCPProbeResult{}, fmt.Errorf("MCP initialize: %w", piCodeGraphMCPDeadlineError(ctx, "read response", err))
+	}
+	initializeResult, ok := initializeResponse["result"].(map[string]any)
+	protocolVersion, versionOK := initializeResult["protocolVersion"].(string)
+	if initializeResponse["jsonrpc"] != "2.0" || !ok || !versionOK || strings.TrimSpace(protocolVersion) == "" {
+		return PiCodeGraphMCPProbeResult{}, fmt.Errorf("MCP initialize: invalid JSON-RPC 2.0 result")
 	}
 	if err := encoder.Encode(map[string]any{"jsonrpc": "2.0", "method": "notifications/initialized", "params": map[string]any{}}); err != nil {
 		return PiCodeGraphMCPProbeResult{}, fmt.Errorf("send MCP initialized notification: %w", err)
@@ -530,7 +544,7 @@ func probePiCodeGraphMCPWithAgentDir(mcpPath, agentDir string) (PiCodeGraphMCPPr
 	}
 	response, err := readPiMCPResponse(decoder, 2)
 	if err != nil {
-		return PiCodeGraphMCPProbeResult{}, fmt.Errorf("MCP tools/list: %w", err)
+		return PiCodeGraphMCPProbeResult{}, fmt.Errorf("MCP tools/list: %w", piCodeGraphMCPDeadlineError(ctx, "read response", err))
 	}
 	result, _ := response["result"].(map[string]any)
 	rawTools, _ := result["tools"].([]any)
@@ -546,62 +560,14 @@ func probePiCodeGraphMCPWithAgentDir(mcpPath, agentDir string) (PiCodeGraphMCPPr
 		}
 		tools = append(tools, tool)
 	}
-	return PiCodeGraphMCPProbeResult{AdapterAvailable: true, Initialized: true, Tools: tools}, nil
+	return PiCodeGraphMCPProbeResult{AdapterAvailable: true, Initialized: true, Tools: tools}, ErrPiCodeGraphAdapterHealthUnavailable
 }
 
-func probePiCodeGraphAdapterRuntime(agentDir, mcpPath string) (PiCodeGraphMCPProbeResult, error) {
-	// Pi 0.80.6 exposes --mcp-config and JSON print mode but no dedicated MCP
-	// status API. Ask its adapter status command and accept only explicit
-	// codegraph success evidence from the combined process output.
-	args := []string{"--mcp-config", mcpPath, "--mode", "json", "--no-session", "--offline", "--print", "/mcp status"}
-	output, err := piCodeGraphAdapterRuntimeRunner("pi", args, append(os.Environ(), "PI_CODING_AGENT_DIR="+agentDir))
-	if err != nil {
-		return PiCodeGraphMCPProbeResult{}, fmt.Errorf("run Pi MCP adapter for %q: %w: %s", mcpPath, err, strings.TrimSpace(string(output)))
+func piCodeGraphMCPDeadlineError(ctx context.Context, phase string, err error) error {
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		return fmt.Errorf("%s: %w", phase, context.DeadlineExceeded)
 	}
-	if err := validatePiCodeGraphAdapterRuntimeOutput(output); err != nil {
-		return PiCodeGraphMCPProbeResult{}, err
-	}
-	return PiCodeGraphMCPProbeResult{}, ErrPiCodeGraphAdapterHealthUnavailable
-}
-
-func defaultPiCodeGraphAdapterRuntimeRunner(name string, args, env []string) ([]byte, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	cmd := exec.CommandContext(ctx, name, args...)
-	cmd.Env = env
-	return cmd.CombinedOutput()
-}
-
-func validatePiCodeGraphAdapterRuntimeOutput(output []byte) error {
-	status := strings.ToLower(strings.TrimSpace(string(output)))
-	if status == "" {
-		return fmt.Errorf("Pi MCP adapter runtime produced no capability evidence")
-	}
-	failureEvidence := []string{
-		"failed to load mcp config",
-		"failed to load mcp",
-		"failed to load extension",
-		"failed to load adapter",
-		"adapter load error",
-		"error loading mcp",
-		"mcp adapter error",
-		"not ready",
-		"not running",
-		"unloaded",
-		"inactive",
-		"broken",
-		"not connected",
-		"disconnected",
-	}
-	for _, evidence := range failureEvidence {
-		if strings.Contains(status, evidence) {
-			return fmt.Errorf("Pi MCP adapter runtime reported failure: %s", strings.TrimSpace(string(output)))
-		}
-	}
-	if strings.Contains(status, "unknown") && strings.Contains(status, "/mcp") {
-		return fmt.Errorf("Pi MCP adapter runtime does not recognize /mcp status: %s", strings.TrimSpace(string(output)))
-	}
-	return ErrPiCodeGraphAdapterHealthUnavailable
+	return err
 }
 
 func readPiMCPResponse(decoder *json.Decoder, id int) (map[string]any, error) {
@@ -629,7 +595,9 @@ func isReadOnlyCodeGraphExploreSchema(tools []PiCodeGraphMCPTool) bool {
 		return false
 	}
 	properties, ok := schema["properties"].(map[string]any)
-	if !ok || len(properties) != 3 || !hasSchemaType(properties, "query", "string") || !hasSchemaType(properties, "maxFiles", "number") || !hasSchemaType(properties, "projectPath", "string") {
+	if !ok || len(properties) != 3 || !hasSchemaType(properties, "query", "string") ||
+		(!hasSchemaType(properties, "maxFiles", "integer") && !hasSchemaType(properties, "maxFiles", "number")) ||
+		!hasSchemaType(properties, "projectPath", "string") {
 		return false
 	}
 	required, ok := schema["required"].([]any)

--- a/internal/components/communitytool/pi_codegraph_test.go
+++ b/internal/components/communitytool/pi_codegraph_test.go
@@ -1,6 +1,7 @@
 package communitytool
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"os"
@@ -9,6 +10,7 @@ import (
 	"slices"
 	"strings"
 	"testing"
+	"time"
 
 	piagent "github.com/gentleman-programming/gentle-ai/internal/agents/pi"
 	"github.com/gentleman-programming/gentle-ai/internal/components/filemerge"
@@ -359,7 +361,7 @@ func TestVerifyPiMCPUsesInjectedEffectiveProbe(t *testing.T) {
 			"type": "object",
 			"properties": map[string]any{
 				"query":       map[string]any{"type": "string"},
-				"maxFiles":    map[string]any{"type": "number"},
+				"maxFiles":    map[string]any{"type": "integer"},
 				"projectPath": map[string]any{"type": "string"},
 			},
 			"required": []any{"query"},
@@ -367,9 +369,11 @@ func TestVerifyPiMCPUsesInjectedEffectiveProbe(t *testing.T) {
 	}
 
 	for _, tt := range []struct {
-		name    string
-		probe   PiCodeGraphMCPProbeResult
-		wantErr bool
+		name        string
+		probe       PiCodeGraphMCPProbeResult
+		probeErr    error
+		wantErr     bool
+		wantPending bool
 	}{
 		{name: "successful initialized read-only explore", probe: PiCodeGraphMCPProbeResult{AdapterAvailable: true, Initialized: true, Tools: []PiCodeGraphMCPTool{validTool}}},
 		{name: "successful unindexed initialized read-only explore requires project path", probe: PiCodeGraphMCPProbeResult{AdapterAvailable: true, Initialized: true, Tools: []PiCodeGraphMCPTool{{Name: validTool.Name, InputSchema: map[string]any{
@@ -381,6 +385,7 @@ func TestVerifyPiMCPUsesInjectedEffectiveProbe(t *testing.T) {
 		{name: "handshake failed", probe: PiCodeGraphMCPProbeResult{AdapterAvailable: true, Tools: []PiCodeGraphMCPTool{validTool}}, wantErr: true},
 		{name: "missing explore tool", probe: PiCodeGraphMCPProbeResult{AdapterAvailable: true, Initialized: true}, wantErr: true},
 		{name: "malformed explore schema", probe: PiCodeGraphMCPProbeResult{AdapterAvailable: true, Initialized: true, Tools: []PiCodeGraphMCPTool{{Name: "codegraph_explore", InputSchema: map[string]any{"type": "object"}}}}, wantErr: true},
+		{name: "incompatible maxFiles type", probe: PiCodeGraphMCPProbeResult{AdapterAvailable: true, Initialized: true, Tools: []PiCodeGraphMCPTool{{Name: validTool.Name, InputSchema: map[string]any{"type": "object", "properties": map[string]any{"query": map[string]any{"type": "string"}, "maxFiles": map[string]any{"type": "boolean"}, "projectPath": map[string]any{"type": "string"}}, "required": []any{"query"}}}}}, wantErr: true},
 		{name: "unknown required field", probe: PiCodeGraphMCPProbeResult{AdapterAvailable: true, Initialized: true, Tools: []PiCodeGraphMCPTool{{Name: validTool.Name, InputSchema: map[string]any{
 			"type":       "object",
 			"properties": validTool.InputSchema["properties"],
@@ -397,13 +402,25 @@ func TestVerifyPiMCPUsesInjectedEffectiveProbe(t *testing.T) {
 			"required":   []any{"query", "query"},
 		}}}}, wantErr: true},
 		{name: "unexpected writable tool", probe: PiCodeGraphMCPProbeResult{AdapterAvailable: true, Initialized: true, Tools: []PiCodeGraphMCPTool{validTool, {Name: "codegraph_write", InputSchema: validTool.InputSchema}}}, wantErr: true},
+		{name: "pending health with missing explore tool remains fatal", probe: PiCodeGraphMCPProbeResult{AdapterAvailable: true, Initialized: true}, probeErr: ErrPiCodeGraphAdapterHealthUnavailable, wantErr: true},
+		{name: "pending health with malformed explore schema remains fatal", probe: PiCodeGraphMCPProbeResult{AdapterAvailable: true, Initialized: true, Tools: []PiCodeGraphMCPTool{{Name: "codegraph_explore", InputSchema: map[string]any{"type": "object"}}}}, probeErr: ErrPiCodeGraphAdapterHealthUnavailable, wantErr: true},
+		{name: "validated capability with unavailable adapter health becomes pending", probe: PiCodeGraphMCPProbeResult{AdapterAvailable: true, Initialized: true, Tools: []PiCodeGraphMCPTool{validTool}}, probeErr: ErrPiCodeGraphAdapterHealthUnavailable, wantPending: true},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			previous := piCodeGraphEffectiveMCPProbe
-			piCodeGraphEffectiveMCPProbe = func(string) (PiCodeGraphMCPProbeResult, error) { return tt.probe, nil }
+			piCodeGraphEffectiveMCPProbe = func(string) (PiCodeGraphMCPProbeResult, error) { return tt.probe, tt.probeErr }
 			t.Cleanup(func() { piCodeGraphEffectiveMCPProbe = previous })
 
 			verification, err := verifyPiMCP(mcpPath)
+			if tt.wantPending {
+				if !errors.Is(err, ErrPiCodeGraphAdapterHealthUnavailable) {
+					t.Fatalf("verifyPiMCP() error = %v, want pending adapter health", err)
+				}
+				if !verification.Adapter || !verification.ReadOnlyExplore || len(verification.Tools) != 1 || verification.Tools[0] != "codegraph_explore" {
+					t.Fatalf("verification = %#v, want validated capability evidence", verification)
+				}
+				return
+			}
 			if tt.wantErr {
 				if err == nil {
 					t.Fatalf("verifyPiMCP() = %#v, nil error", verification)
@@ -477,11 +494,13 @@ func TestPiCodeGraphPendingProbePreservesConfiguredFiles(t *testing.T) {
 	childPath := filepath.Join(home, ".pi", "agent", "subagents", "worker.md")
 	manifestPath := filepath.Join(home, ".gentle-ai", "pi-codegraph.json")
 	writePiFile(t, childPath, "---\ntools: bash\n---\nwork\n")
-	pendingProbe := func(string) (PiCodeGraphMCPProbeResult, error) {
-		return PiCodeGraphMCPProbeResult{}, ErrPiCodeGraphAdapterHealthUnavailable
-	}
+	writePiFile(t, filepath.Join(home, ".pi", "agent", "npm", "node_modules", "pi-mcp-adapter", "index.ts"), "export default {}\n")
+	installFakeCodeGraph(t)
+	previousProbe := piCodeGraphEffectiveMCPProbe
+	piCodeGraphEffectiveMCPProbe = probePiCodeGraphMCP
+	t.Cleanup(func() { piCodeGraphEffectiveMCPProbe = previousProbe })
 
-	result, err := ReconcilePiCodeGraph(PiCodeGraphOptions{HomeDir: home, Selected: true, EffectiveMCPProbe: pendingProbe})
+	result, err := ReconcilePiCodeGraph(PiCodeGraphOptions{HomeDir: home, Selected: true})
 	if err != nil {
 		t.Fatalf("ReconcilePiCodeGraph() error = %v, want pending success", err)
 	}
@@ -496,6 +515,27 @@ func TestPiCodeGraphPendingProbePreservesConfiguredFiles(t *testing.T) {
 	}
 	if _, err := os.Stat(manifestPath); err != nil {
 		t.Fatalf("pending manifest was not persisted: %v", err)
+	}
+}
+
+func TestPiCodeGraphPendingProbeRejectsConflictingChildAndRollsBack(t *testing.T) {
+	home := t.TempDir()
+	childPath := filepath.Join(home, ".pi", "agent", "subagents", "worker.md")
+	original := "---\ntools: read\n---\nwork\n" + piCodeGraphToolMarker + "\nstale tool block\n" + piCodeGraphEndMarker + "\n"
+	writePiFile(t, childPath, original)
+
+	_, err := ReconcilePiCodeGraph(PiCodeGraphOptions{HomeDir: home, Selected: true, EffectiveMCPProbe: func(string) (PiCodeGraphMCPProbeResult, error) {
+		result, _ := piProbeForTest("unused")
+		return result, ErrPiCodeGraphAdapterHealthUnavailable
+	}})
+	if err == nil || !strings.Contains(err.Error(), "misconfigured") {
+		t.Fatalf("ReconcilePiCodeGraph() error = %v, want conflicting child failure", err)
+	}
+	if got := string(mustReadPiFile(t, childPath)); got != original {
+		t.Fatalf("child after rollback = %q, want %q", got, original)
+	}
+	if _, statErr := os.Stat(filepath.Join(home, ".gentle-ai", "pi-codegraph.json")); !os.IsNotExist(statErr) {
+		t.Fatalf("pending manifest persisted after child failure: %v", statErr)
 	}
 }
 
@@ -605,137 +645,82 @@ func TestPiCodeGraphFailsClosedForBrokenProjectMCPOverride(t *testing.T) {
 	}
 }
 
-func TestPiCodeGraphProbeUsesAgentRuntimeForProjectMCPOverride(t *testing.T) {
+func TestPiCodeGraphProbeVerifiesDirectMCPWithoutPiProcess(t *testing.T) {
 	home := t.TempDir()
 	agentDir := filepath.Join(home, "custom-agent")
 	mcpPath := filepath.Join(home, "project", ".mcp.json")
 	writePiFile(t, filepath.Join(agentDir, "npm", "node_modules", "pi-mcp-adapter", "index.ts"), "export default {}\n")
 	writePiFile(t, mcpPath, `{"mcpServers":{"codegraph":{"command":"codegraph","args":["serve","--mcp"]}}}`)
+	installFakeCodeGraph(t)
 
-	previous := piCodeGraphAdapterRuntimeRunner
-	defer func() { piCodeGraphAdapterRuntimeRunner = previous }()
-	called := false
-	piCodeGraphAdapterRuntimeRunner = func(name string, args, env []string) ([]byte, error) {
-		called = name == "pi" && slices.Equal(args, []string{"--mcp-config", mcpPath, "--mode", "json", "--no-session", "--offline", "--print", "/mcp status"}) && slices.Contains(env, "PI_CODING_AGENT_DIR="+agentDir)
-		return []byte("MCP Servers:\n  codegraph: connected\n"), nil
+	result, err := probePiCodeGraphMCPWithAgentDir(mcpPath, agentDir)
+	if !errors.Is(err, ErrPiCodeGraphAdapterHealthUnavailable) {
+		t.Fatalf("probe error = %v, want unavailable adapter health", err)
 	}
-
-	if _, err := probePiCodeGraphMCPWithAgentDir(mcpPath, agentDir); !errors.Is(err, ErrPiCodeGraphAdapterHealthUnavailable) || !called {
-		t.Fatalf("probe error=%v called=%v, want fail-closed project config through Pi agent runtime", err, called)
+	if !result.AdapterAvailable || !result.Initialized || !isReadOnlyCodeGraphExploreSchema(result.Tools) {
+		t.Fatalf("probe result = %#v, want verified direct MCP capability", result)
 	}
 }
 
-func TestPiCodeGraphAdapterRuntimeFailsClosedWithoutPositiveCapabilityEvidence(t *testing.T) {
-	agentDir := t.TempDir()
-	mcpPath := filepath.Join(agentDir, "mcp.json")
-
-	tests := []struct {
-		name    string
-		output  string
-		wantErr bool
+func TestPiCodeGraphProbeClassifiesStalledMCPResponsesAsDeadlineExceeded(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		script    string
+		wantPhase string
 	}{
 		{
-			name:    "exit zero with failed MCP config",
-			output:  "Failed to load MCP config: invalid JSON\n",
-			wantErr: true,
+			name:      "initialize",
+			script:    `while IFS= read -r request; do while :; do :; done; done`,
+			wantPhase: "MCP initialize: read response",
 		},
 		{
-			name:    "exit zero with adapter load error",
-			output:  "Failed to load extension pi-mcp-adapter: module not found\n",
-			wantErr: true,
+			name: "tools list",
+			script: `while IFS= read -r request; do
+  case "$request" in
+	    *'"id":1'*) printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-03-26"}}' ;;
+    *'"id":2'*) while :; do :; done ;;
+  esac
+done`,
+			wantPhase: "MCP tools/list: read response",
 		},
-		{
-			name:    "exit zero with unknown MCP command",
-			output:  "Unknown command: /mcp\n",
-			wantErr: true,
-		},
-		{
-			name:    "exit zero without capability evidence",
-			output:  `{"type":"session","version":3}` + "\n",
-			wantErr: true,
-		},
-		{
-			name:    "rejects negated ready status",
-			output:  "MCP Servers:\n  codegraph: not ready\n",
-			wantErr: true,
-		},
-		{
-			name:    "rejects negated running status",
-			output:  "MCP Servers:\n  codegraph: not running\n",
-			wantErr: true,
-		},
-		{
-			name:    "rejects unloaded status",
-			output:  "MCP Servers:\n  codegraph: unloaded\n",
-			wantErr: true,
-		},
-		{
-			name:    "rejects inactive status",
-			output:  "MCP Servers:\n  codegraph: inactive\n",
-			wantErr: true,
-		},
-		{
-			name:    "rejects broken status containing ok",
-			output:  "MCP Servers:\n  codegraph: broken\n",
-			wantErr: true,
-		},
-		{
-			name:    "rejects malformed status",
-			output:  "MCP Servers:\n  codegraph connected\n",
-			wantErr: true,
-		},
-		{
-			name:    "rejects unrelated healthy status",
-			output:  "MCP Servers:\n  filesystem: ready\n",
-			wantErr: true,
-		},
-		{
-			name:    "rejects ambiguous codegraph statuses",
-			output:  "MCP Servers:\n  codegraph: connected\n  codegraph: not ready\n",
-			wantErr: true,
-		},
-		{
-			name:    "session-only status is not adapter health",
-			output:  "MCP Servers:\n  codegraph: connected\n",
-			wantErr: true,
-		},
-		{
-			name:    "ambiguous ready status is not adapter health",
-			output:  "MCP Servers:\n  codegraph: ready\n",
-			wantErr: true,
-		},
-	}
-
-	for _, tt := range tests {
+	} {
 		t.Run(tt.name, func(t *testing.T) {
-			previous := piCodeGraphAdapterRuntimeRunner
-			piCodeGraphAdapterRuntimeRunner = func(name string, args, env []string) ([]byte, error) {
-				if name != "pi" {
-					t.Fatalf("runtime = %q, want pi", name)
-				}
-				wantArgs := []string{"--mcp-config", mcpPath, "--mode", "json", "--no-session", "--offline", "--print", "/mcp status"}
-				if !slices.Equal(args, wantArgs) {
-					t.Fatalf("args = %q, want %q", args, wantArgs)
-				}
-				if !slices.Contains(env, "PI_CODING_AGENT_DIR="+agentDir) {
-					t.Fatalf("env = %q, want Pi agent directory", env)
-				}
-				return []byte(tt.output), nil
-			}
-			t.Cleanup(func() { piCodeGraphAdapterRuntimeRunner = previous })
+			home := t.TempDir()
+			agentDir := filepath.Join(home, "custom-agent")
+			mcpPath := filepath.Join(home, "project", ".mcp.json")
+			writePiFile(t, filepath.Join(agentDir, "npm", "node_modules", "pi-mcp-adapter", "index.ts"), "export default {}\n")
+			installFakeCodeGraphScript(t, tt.script)
 
-			result, err := probePiCodeGraphAdapterRuntime(agentDir, mcpPath)
-			if tt.wantErr {
-				if err == nil {
-					t.Fatalf("probe result = %#v, want rejected output", result)
-				}
-				return
+			ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+			defer cancel()
+			_, err := probePiCodeGraphMCPWithAgentDirContext(ctx, mcpPath, agentDir)
+			if !errors.Is(err, context.DeadlineExceeded) {
+				t.Fatalf("probe error = %v, want context deadline exceeded", err)
 			}
-			if err != nil {
-				t.Fatalf("probe error = %v", err)
+			if !strings.Contains(err.Error(), tt.wantPhase) {
+				t.Fatalf("probe error = %q, want phase %q", err, tt.wantPhase)
 			}
-			if !result.AdapterAvailable || !result.Initialized {
-				t.Fatalf("probe result = %#v, want initialized adapter", result)
+		})
+	}
+}
+
+func TestPiCodeGraphProbeRejectsInvalidInitializeResponses(t *testing.T) {
+	responses := []string{
+		`{"id":1,"result":{"protocolVersion":"2025-03-26"}}`,
+		`{"jsonrpc":"2.0","id":1}`,
+		`{"jsonrpc":"2.0","id":1,"result":[]}`,
+		`{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":""}}`,
+	}
+	for _, response := range responses {
+		t.Run(response, func(t *testing.T) {
+			home := t.TempDir()
+			agentDir := filepath.Join(home, "custom-agent")
+			writePiFile(t, filepath.Join(agentDir, "npm", "node_modules", "pi-mcp-adapter", "index.ts"), "export default {}\n")
+			installFakeCodeGraphScript(t, `while IFS= read -r request; do printf '%s\n' '`+response+`'; done`)
+
+			_, err := probePiCodeGraphMCPWithAgentDir(filepath.Join(home, "mcp.json"), agentDir)
+			if err == nil || !strings.Contains(err.Error(), "invalid JSON-RPC 2.0 result") {
+				t.Fatalf("probe error = %v, want invalid initialize response", err)
 			}
 		})
 	}
@@ -873,7 +858,7 @@ func piProbeForTest(string) (PiCodeGraphMCPProbeResult, error) {
 			"type": "object",
 			"properties": map[string]any{
 				"query":       map[string]any{"type": "string"},
-				"maxFiles":    map[string]any{"type": "number"},
+				"maxFiles":    map[string]any{"type": "integer"},
 				"projectPath": map[string]any{"type": "string"},
 			},
 			"required": []any{"query"},
@@ -898,4 +883,25 @@ func mustReadPiFile(t *testing.T, path string) []byte {
 		t.Fatal(err)
 	}
 	return data
+}
+
+func installFakeCodeGraph(t *testing.T) {
+	t.Helper()
+	installFakeCodeGraphScript(t, `while IFS= read -r request; do
+  case "$request" in
+    *'"id":1'*) printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-03-26","capabilities":{},"serverInfo":{"name":"fake","version":"1"}}}' ;;
+    *'"id":2'*) printf '%s\n' '{"jsonrpc":"2.0","id":2,"result":{"tools":[{"name":"codegraph_explore","inputSchema":{"type":"object","properties":{"query":{"type":"string"},"maxFiles":{"type":"integer"},"projectPath":{"type":"string"}},"required":["query"]}}]}}' ;;
+  esac
+done`)
+}
+
+func installFakeCodeGraphScript(t *testing.T, body string) {
+	t.Helper()
+	binDir := t.TempDir()
+	script := "#!/bin/sh\n" + body + "\n"
+	path := filepath.Join(binDir, "codegraph")
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 }

--- a/internal/components/communitytool/tool_test.go
+++ b/internal/components/communitytool/tool_test.go
@@ -35,7 +35,7 @@ func TestMain(m *testing.M) {
 					"type": "object",
 					"properties": map[string]any{
 						"query":       map[string]any{"type": "string"},
-						"maxFiles":    map[string]any{"type": "number"},
+						"maxFiles":    map[string]any{"type": "integer"},
 						"projectPath": map[string]any{"type": "string"},
 					},
 					"required": []any{"query"},
@@ -671,16 +671,12 @@ func TestInstallRunsCommandsAndReturnsLazyProjectIndexManualAction(t *testing.T)
 func TestInstallLeavesPiPendingWhenAdapterHealthIsNotMachineVerifiable(t *testing.T) {
 	home := t.TempDir()
 	mustWrite(t, filepath.Join(home, ".pi", "agent", "npm", "node_modules", "pi-mcp-adapter", "index.ts"), "export default {}\n")
-	previousRuntime := piCodeGraphAdapterRuntimeRunner
 	previousProbe := piCodeGraphEffectiveMCPProbe
-	piCodeGraphAdapterRuntimeRunner = func(string, []string, []string) ([]byte, error) {
-		return []byte(`{"type":"session","version":3}`), nil
-	}
-	piCodeGraphEffectiveMCPProbe = func(string) (PiCodeGraphMCPProbeResult, error) {
-		return PiCodeGraphMCPProbeResult{}, ErrPiCodeGraphAdapterHealthUnavailable
+	piCodeGraphEffectiveMCPProbe = func(path string) (PiCodeGraphMCPProbeResult, error) {
+		result, _ := piProbeForTest(path)
+		return result, ErrPiCodeGraphAdapterHealthUnavailable
 	}
 	t.Cleanup(func() {
-		piCodeGraphAdapterRuntimeRunner = previousRuntime
 		piCodeGraphEffectiveMCPProbe = previousProbe
 	})
 


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1149

## 🏷️ PR Type

- [x] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring
- [ ] `type:chore` — Maintenance/tooling
- [ ] `type:breaking-change` — Breaking change

## 📝 Summary

- Replaces the self-timing-out Pi status probe with bounded direct CodeGraph MCP verification.
- Preserves configuration as pending when Pi adapter health cannot be verified safely.
- Keeps concrete child, process, protocol, and schema failures fatal with rollback.

This replacement is based on AndySabina's community contribution in #1152. Andy remains the Git author of the reviewed delivery commit; the replacement was necessary to apply the bounded corrections on current `main` without rewriting the contributor's branch.

## 📂 Changes

| File / Area | What Changed |
|-------------|--------------|
| `internal/components/communitytool/pi_codegraph.go` | Uses direct MCP capability validation, strict initialize handling, child validation before pending conversion, and explicit deadline classification. |
| `internal/components/communitytool/pi_codegraph_test.go` | Covers valid capability, malformed protocol responses, pending health, rollback, and child conflicts. |
| `internal/cli/run_community_tool_test.go` | Updates deterministic CLI pending/fatal behavior coverage. |
| `internal/components/communitytool/tool_test.go` | Preserves installer pending semantics after validated direct capability. |

## 🧪 Test Plan

- [x] Focused CodeGraph regressions.
- [x] `go test ./internal/components/communitytool ./internal/cli`
- [x] `env GENTLE_AI_CHANNEL=beta go test ./... -count=1`
- [x] `env -u GENTLE_AI_CHANNEL go test ./... -count=1`
- [x] `go vet ./...`
- [x] `git diff --check`

## ✅ Contributor Checklist

- [x] Linked an approved issue.
- [x] Added exactly one `type:*` label.
- [x] Reviewed under the high-risk 4R workflow.
- [x] Community author attribution is preserved.
- [x] Commit follows Conventional Commits.
- [x] No `Co-Authored-By` trailers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CodeGraph MCP verification and capability detection.
  * Correctly handles unavailable adapter health as a pending verification state.
  * Improved timeout and stalled-response handling to prevent spurious failures.
  * Rejects malformed MCP initialization and tools responses.
  * Accepts valid `maxFiles` schemas using either integer or number types.
  * Preserves configuration during pending verification and rolls back conflicting changes safely.

* **Tests**
  * Expanded coverage for MCP verification, timeout behavior, invalid responses, and rollback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->