### PR TITLE
fix(codegraph): clarify pending Pi health message

### DIFF
--- a/internal/cli/run_community_tool_test.go
+++ b/internal/cli/run_community_tool_test.go
@@ -472,7 +472,7 @@ func TestInstallPipelineDoesNotDuplicatePiPendingWhenSelected(t *testing.T) {
 		installCommunityToolWithHome = previousInstall
 		reconcilePiCodeGraph = previousReconcile
 	})
-	pending := communitytool.PiCodeGraphResult{ManualActions: []string{"Pi CodeGraph integration is pending: Pi 0.80.6 has no supported machine-verifiable adapter health signal. CodeGraph capability was not reported as configured."}}
+	pending := communitytool.PiCodeGraphResult{ManualActions: []string{"Pi CodeGraph integration remains pending: CodeGraph configuration was installed and preserved, and direct MCP capability was verified. Pi adapter activation health cannot be machine-verified on the detected Pi version."}}
 	installCommunityToolWithHome = func(_ model.CommunityToolID, _ string, _ string, _ communitytool.Runner, _ communitytool.Detector) (communitytool.Result, error) {
 		return communitytool.Result{Tool: model.CommunityToolCodeGraph, PiCodeGraph: &pending}, nil
 	}

--- a/internal/components/communitytool/pi_codegraph.go
+++ b/internal/components/communitytool/pi_codegraph.go
@@ -38,7 +38,7 @@ var piCodeGraphEffectiveMCPProbe PiCodeGraphEffectiveMCPProbe = probePiCodeGraph
 // verification remains separate capability evidence.
 var ErrPiCodeGraphAdapterHealthUnavailable = errors.New("Pi MCP adapter health is not machine-verifiable")
 
-const piCodeGraphPendingAction = "Pi CodeGraph integration is pending: Pi 0.80.6 has no supported machine-verifiable adapter health signal. CodeGraph capability was not reported as configured."
+const piCodeGraphPendingAction = "Pi CodeGraph integration remains pending: CodeGraph configuration was installed and preserved, and direct MCP capability was verified. Pi adapter activation health cannot be machine-verified on the detected Pi version."
 
 type PiChildClassification string
 

--- a/internal/components/communitytool/pi_codegraph_test.go
+++ b/internal/components/communitytool/pi_codegraph_test.go
@@ -504,8 +504,17 @@ func TestPiCodeGraphPendingProbePreservesConfiguredFiles(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReconcilePiCodeGraph() error = %v, want pending success", err)
 	}
-	if len(result.ManualActions) != 1 || !strings.Contains(result.ManualActions[0], "pending") {
+	if len(result.ManualActions) != 1 {
 		t.Fatalf("ManualActions = %#v, want one pending action", result.ManualActions)
+	}
+	action := result.ManualActions[0]
+	for _, want := range []string{"configuration was installed and preserved", "direct MCP capability was verified", "adapter activation health cannot be machine-verified", "remains pending"} {
+		if !strings.Contains(action, want) {
+			t.Fatalf("ManualActions[0] = %q, want %q", action, want)
+		}
+	}
+	if strings.Contains(strings.ToLower(action), "reinstall") {
+		t.Fatalf("ManualActions[0] = %q, should not instruct users to reinstall", action)
 	}
 	if got := string(mustReadPiFile(t, mcpPath)); !strings.Contains(got, `"codegraph"`) {
 		t.Fatalf("pending MCP config = %s, want preserved CodeGraph server", got)


### PR DESCRIPTION
Closes #1159

## Summary
- Clarify that CodeGraph configuration and direct MCP verification succeeded.
- Keep Pi adapter activation health explicitly pending when it cannot be verified.

## Copy
- Replace the misleading not-configured message with version-neutral activation-health guidance.

## Test plan
- [x] Existing receipt lineage review-c5efdbbb2f95d0da passed pre-push and pre-PR validation.
- [x] Focused Pi CodeGraph copy assertions cover the revised message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Pi integration status messaging to clarify that CodeGraph configuration is preserved and direct MCP capability is verified, while adapter activation health remains pending verification.
  * Improved guidance to avoid unnecessary reinstallation when configuration is already present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->