### PR TITLE
fix(review): support committed base diff reviews

### DIFF
--- a/internal/app/help.go
+++ b/internal/app/help.go
@@ -22,7 +22,7 @@ COMMANDS
                Print native SDD phase status for orchestrators
   sdd-continue [change]
                Print native SDD dispatcher routing output
-  review start [--cwd <repo>] [--focus <risk|resilience|readability|reliability>]
+  review start [--cwd <repo>] [--base-ref <ref>] [--focus <risk|resilience|readability|reliability>]
   review finalize [--cwd <repo>] [--result <review.json> ...] [--evidence <path>]
   review validate --gate <gate> [--cwd <repo>]
                Normal review path; ordinary authority is compact state plus receipt

--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -106,6 +106,7 @@ func RunReviewFacadeStart(args []string, stdout io.Writer) error {
 	lineage := flags.String("lineage", "", "optional explicit review lineage identifier")
 	policySource := flags.String("policy", "", "optional review policy file; the native bounded policy is used by default")
 	focus := flags.String("focus", "reliability", "dominant standard-risk focus: risk, resilience, readability, or reliability")
+	baseRef := flags.String("base-ref", "", "optional base revision for reviewing committed HEAD changes")
 	tracePath := flags.String("trace", "", "optional diagnostic operation metadata trace path")
 	if err := parseReviewFlags(flags, args); err != nil {
 		return err
@@ -125,9 +126,12 @@ func RunReviewFacadeStart(args []string, stdout io.Writer) error {
 	if err != nil {
 		return fmt.Errorf("discover intended untracked files: %w", err)
 	}
-	snapshot, err := (reviewtransaction.SnapshotBuilder{Repo: root}).Build(context.Background(), reviewtransaction.Target{
-		Kind: reviewtransaction.TargetCurrentChanges, IntendedUntracked: intended,
-	})
+	target := reviewtransaction.Target{Kind: reviewtransaction.TargetCurrentChanges, IntendedUntracked: intended}
+	if strings.TrimSpace(*baseRef) != "" {
+		target.Kind = reviewtransaction.TargetBaseDiff
+		target.BaseRef = strings.TrimSpace(*baseRef)
+	}
+	snapshot, err := (reviewtransaction.SnapshotBuilder{Repo: root}).Build(context.Background(), target)
 	if err != nil {
 		return fmt.Errorf("build facade review target: %w", err)
 	}

--- a/internal/cli/review_facade_test.go
+++ b/internal/cli/review_facade_test.go
@@ -126,6 +126,87 @@ func TestReviewFacadeCleanFlowReplacesOneCompactStateAndUsesOnlyReceipt(t *testi
 	}
 }
 
+func TestReviewFacadeStartSupportsCommittedBaseDiff(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	base := strings.TrimSpace(runReviewCLIGit(t, repo, "rev-parse", "HEAD"))
+	branch := strings.TrimSpace(runReviewCLIGit(t, repo, "symbolic-ref", "--short", "HEAD"))
+	configureCLIReviewPublicationRemote(t, repo, branch)
+	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("committed candidate\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "notes.txt"), []byte("intended untracked\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runReviewCLIGit(t, repo, "add", "tracked.txt")
+	runReviewCLIGit(t, repo, "commit", "-qm", "candidate")
+
+	var output bytes.Buffer
+	if err := RunReviewFacadeStart([]string{"--cwd", repo, "--base-ref", base}, &output); err != nil {
+		t.Fatal(err)
+	}
+	var result ReviewFacadeStartResult
+	if err := json.Unmarshal(output.Bytes(), &result); err != nil {
+		t.Fatal(err)
+	}
+	store, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, result.LineageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	record, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if record.State.InitialSnapshot.Kind != reviewtransaction.TargetBaseDiff || record.State.InitialSnapshot.BaseTree == record.State.InitialSnapshot.CandidateTree {
+		t.Fatalf("base diff snapshot = %#v", record.State.InitialSnapshot)
+	}
+	if !reflect.DeepEqual(record.State.InitialSnapshot.IntendedUntracked, []string{"notes.txt"}) {
+		t.Fatalf("intended untracked = %v", record.State.InitialSnapshot.IntendedUntracked)
+	}
+	resultPath := filepath.Join(t.TempDir(), "review.json")
+	evidencePath := filepath.Join(t.TempDir(), "evidence.txt")
+	writeReviewCLIJSON(t, resultPath, facadeReviewerResult{Findings: []facadeFinding{}, Evidence: []string{"committed diff reviewed"}})
+	if err := os.WriteFile(evidencePath, []byte("focused tests pass\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := RunReviewFacadeFinalize([]string{"--cwd", repo, "--lineage", result.LineageID, "--result", resultPath}, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	if err := RunReviewFacadeFinalize([]string{"--cwd", repo, "--lineage", result.LineageID, "--evidence", evidencePath}, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	output.Reset()
+	if err := RunReviewFacadeValidate([]string{"--cwd", repo, "--lineage", result.LineageID, "--gate", string(reviewtransaction.GatePrePR), "--base-ref", base}, &output); err != nil {
+		t.Fatalf("pre-pr base diff gate: %v\n%s", err, output.String())
+	}
+}
+
+func TestReviewFacadeStartRejectsInvalidBaseRefWithoutPersistingLineage(t *testing.T) {
+	tests := []struct {
+		name string
+		ref  string
+	}{
+		{name: "range", ref: "HEAD~1..HEAD"},
+		{name: "missing ref", ref: "refs/heads/does-not-exist"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := initReviewCLIRepo(t)
+			lineage := "invalid-base-ref"
+			err := RunReviewFacadeStart([]string{"--cwd", repo, "--lineage", lineage, "--base-ref", tt.ref}, io.Discard)
+			if err == nil {
+				t.Fatalf("base ref %q was accepted", tt.ref)
+			}
+			store, storeErr := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, lineage)
+			if storeErr != nil {
+				t.Fatal(storeErr)
+			}
+			if _, statErr := os.Stat(store.Dir); !os.IsNotExist(statErr) {
+				t.Fatalf("invalid base ref persisted lineage: %v", statErr)
+			}
+		})
+	}
+}
+
 func TestReadFacadeReviewerResultsRejectsNonNativeFields(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/reviewtransaction/compact_gate.go
+++ b/internal/reviewtransaction/compact_gate.go
@@ -131,7 +131,10 @@ func buildCompactGateRequest(ctx context.Context, repo string, state CompactStat
 				return GateRequest{}, errors.New("compact pre-PR base does not match the remote publication boundary")
 			}
 		}
-		request.Target = Target{Kind: TargetBaseDiff, BaseRef: baseCommit}
+		request.Target = Target{
+			Kind: TargetBaseDiff, BaseRef: baseCommit,
+			IntendedUntracked: append([]string(nil), state.InitialSnapshot.IntendedUntracked...),
+		}
 		if strings.TrimSpace(input.PrePRCIAttestation) != "" {
 			request.PrePR = &PrePRRequest{CIAttestationArtifact: input.PrePRCIAttestation}
 		}

--- a/internal/reviewtransaction/gate.go
+++ b/internal/reviewtransaction/gate.go
@@ -257,7 +257,9 @@ func buildLifecycleSnapshot(ctx context.Context, repo string, request GateReques
 	if err != nil {
 		return Snapshot{}, nil, err
 	}
-	snapshot, err = (SnapshotBuilder{Repo: repo}).Build(ctx, Target{Kind: TargetExactRevision, Revision: base + ".." + head})
+	snapshot, err = (SnapshotBuilder{Repo: repo}).Build(ctx, Target{
+		Kind: TargetBaseDiff, BaseRef: base, IntendedUntracked: target.IntendedUntracked,
+	})
 	if err != nil {
 		return Snapshot{}, nil, err
 	}
@@ -361,7 +363,10 @@ func lifecycleTargetForGate(ctx context.Context, repo string, request GateReques
 		if request.Target.Kind != TargetBaseDiff || strings.TrimSpace(request.Target.BaseRef) == "" {
 			return Target{}, errors.New("pre-PR validation requires an explicit base-diff target")
 		}
-		return Target{Kind: TargetBaseDiff, BaseRef: request.Target.BaseRef}, nil
+		return Target{
+			Kind: TargetBaseDiff, BaseRef: request.Target.BaseRef,
+			IntendedUntracked: append([]string(nil), request.Target.IntendedUntracked...),
+		}, nil
 	case GateRelease:
 		if request.Target.Kind != TargetExactRevision || request.Release == nil {
 			return Target{}, errors.New("release validation requires an exact current release revision")

--- a/internal/reviewtransaction/snapshot.go
+++ b/internal/reviewtransaction/snapshot.go
@@ -83,11 +83,17 @@ func (builder SnapshotBuilder) build(ctx context.Context, target Target, allowSt
 		if strings.TrimSpace(target.BaseRef) == "" {
 			return Snapshot{}, errors.New("base-diff requires base_ref")
 		}
+		if strings.Contains(target.BaseRef, "..") {
+			return Snapshot{}, errors.New("base-diff base_ref must be one revision, not a range")
+		}
+		intended, err = canonicalPaths(target.IntendedUntracked)
+		if err != nil {
+			return Snapshot{}, err
+		}
 		baseTree, err = builder.resolveTree(ctx, target.BaseRef)
 		if err == nil {
-			candidateTree, err = builder.resolveTree(ctx, "HEAD")
+			candidateTree, untrackedProof, err = builder.buildHeadWithIntended(ctx, intended)
 		}
-		untrackedProof = hashCanonical("gentle-ai.intended-untracked/v1")
 	case TargetExactRevision:
 		baseTree, candidateTree, err = builder.resolveExactRevision(ctx, target.Revision)
 		untrackedProof = hashCanonical("gentle-ai.intended-untracked/v1")
@@ -125,6 +131,40 @@ func (builder SnapshotBuilder) build(ctx context.Context, target Target, allowSt
 		IntendedUntrackedProof: untrackedProof, LedgerIDs: ledgerIDs,
 		Paths: paths, Identity: identity,
 	}, nil
+}
+
+func (builder SnapshotBuilder) buildHeadWithIntended(ctx context.Context, intended []string) (string, string, error) {
+	temp, err := os.CreateTemp("", "gentle-ai-review-index-*")
+	if err != nil {
+		return "", "", err
+	}
+	tempIndex := temp.Name()
+	if err := temp.Close(); err != nil {
+		return "", "", err
+	}
+	defer os.Remove(tempIndex)
+	env := []string{"GIT_INDEX_FILE=" + tempIndex}
+	if _, err := runGit(ctx, builder.Repo, env, nil, "read-tree", "HEAD"); err != nil {
+		return "", "", err
+	}
+	for _, logicalPath := range intended {
+		if _, err := runGit(ctx, builder.Repo, nil, nil, "ls-files", "--error-unmatch", "--", logicalPath); err == nil {
+			return "", "", fmt.Errorf("intended-untracked path %q is already tracked", logicalPath)
+		}
+	}
+	if len(intended) > 0 {
+		args := append([]string{"add", "--"}, intended...)
+		if _, err := runGit(ctx, builder.Repo, env, nil, args...); err != nil {
+			return "", "", err
+		}
+	}
+	output, err := runGit(ctx, builder.Repo, env, nil, "write-tree")
+	if err != nil {
+		return "", "", err
+	}
+	candidateTree := strings.TrimSpace(string(output))
+	proof, err := builder.untrackedProof(ctx, candidateTree, intended)
+	return candidateTree, proof, err
 }
 
 // ValidateEvidence binds snapshot metadata to repository object evidence.

--- a/internal/reviewtransaction/snapshot_test.go
+++ b/internal/reviewtransaction/snapshot_test.go
@@ -218,7 +218,8 @@ func TestSnapshotBuilderSupportsBaseDiffAndExactCommitRange(t *testing.T) {
 	secondCommit := strings.TrimSpace(gitSnapshot(t, repo, "rev-parse", "HEAD"))
 
 	builder := SnapshotBuilder{Repo: repo}
-	baseDiff, err := builder.Build(context.Background(), Target{Kind: TargetBaseDiff, BaseRef: firstCommit})
+	writeSnapshotFile(t, repo, "notes.txt", "intended untracked\n")
+	baseDiff, err := builder.Build(context.Background(), Target{Kind: TargetBaseDiff, BaseRef: firstCommit, IntendedUntracked: []string{"notes.txt"}})
 	if err != nil {
 		t.Fatalf("Build(base diff) error = %v", err)
 	}
@@ -226,8 +227,17 @@ func TestSnapshotBuilderSupportsBaseDiffAndExactCommitRange(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Build(exact range) error = %v", err)
 	}
-	if baseDiff.BaseTree != exact.BaseTree || baseDiff.CandidateTree != exact.CandidateTree {
-		t.Fatalf("base diff and exact range disagree: base=%#v exact=%#v", baseDiff, exact)
+	if baseDiff.BaseTree != exact.BaseTree {
+		t.Fatalf("base diff and exact range bases disagree: base=%#v exact=%#v", baseDiff, exact)
+	}
+	if !reflect.DeepEqual(baseDiff.Paths, []string{"notes.txt", "tracked.txt"}) {
+		t.Fatalf("base diff paths = %v", baseDiff.Paths)
+	}
+	if !reflect.DeepEqual(baseDiff.IntendedUntracked, []string{"notes.txt"}) {
+		t.Fatalf("base diff intended untracked = %v", baseDiff.IntendedUntracked)
+	}
+	if err := builder.ValidateEvidence(context.Background(), baseDiff); err != nil {
+		t.Fatalf("ValidateEvidence(base diff) error = %v", err)
 	}
 }
 


### PR DESCRIPTION
## Linked Issue

Closes #1166

---

## PR Type

- [x] `type:bug` - Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` - New feature (non-breaking change that adds functionality)
- [ ] `type:docs` - Documentation only
- [ ] `type:refactor` - Code refactoring (no functional changes)
- [ ] `type:chore` - Build, CI, or tooling changes
- [ ] `type:breaking-change` - Breaking change (fix or feature that changes existing behavior)

---

## Summary

- Adds `review start --base-ref <ref>` so committed branch changes can be reviewed against their publication base.
- Preserves intended untracked files when building and validating base-diff snapshots.
- Rejects revision ranges as base refs before persisting a lineage.

---

## Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/app/help.go` | Documents the new `--base-ref` option. |
| `internal/cli/review_facade.go` | Selects a base-diff target when a base ref is provided. |
| `internal/cli/review_facade_test.go` | Covers committed base-diff review flow and invalid refs. |
| `internal/reviewtransaction/compact_gate.go` | Carries intended untracked paths into pre-PR validation. |
| `internal/reviewtransaction/gate.go` | Rebuilds lifecycle snapshots as base diffs with intended untracked paths. |
| `internal/reviewtransaction/snapshot.go` | Builds base-diff candidate trees from HEAD plus intended untracked files. |
| `internal/reviewtransaction/snapshot_test.go` | Verifies base-diff evidence and intended untracked paths. |

---

## Test Plan

**Unit Tests**
```bash
go test ./...
```

**E2E Tests** (Docker required)
```bash
cd e2e && ./docker-test.sh
```

- [x] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Native bounded review approved the seven-file change
- [x] Pre-commit and pre-push publication gates allow receipt `review-c9c7bc13d12decc9`

E2E was not rerun because this change is isolated to the Go review facade and transaction snapshot logic; CI will execute the repository E2E suite.

---

## Automated Checks

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | Pending | PR contains 167 changed lines, below the 400-line limit. |
| Check Issue Reference | Pending | PR links `Closes #1166`. |
| Check Issue Has `status:approved` | Pending | Issue #1166 is approved. |
| Check PR Has `type:*` Label | Pending | PR will have exactly `type:bug`. |
| Unit Tests | Pending | CI will run `go test ./...`. |
| E2E Tests | Pending | CI will run `cd e2e && ./docker-test.sh`. |

---

## Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] I have updated documentation if necessary
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers

---

## Notes for Reviewers

Please focus on snapshot identity across `review start --base-ref`, pre-push, and pre-PR reconstruction, including intended untracked files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `--base-ref <ref>` option to `review start` for reviewing changes against a specified base reference.
  * Intended untracked files are now included when building base-diff reviews.
* **Bug Fixes**
  * Improved validation for invalid base references and unsupported commit-range syntax.
  * Pre-PR checks now consistently preserve the selected base reference and intended untracked files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->