### PR TITLE
fix(pi): accept block-list tools frontmatter

### DIFF
--- a/internal/components/communitytool/pi_codegraph.go
+++ b/internal/components/communitytool/pi_codegraph.go
@@ -348,13 +348,31 @@ func piChildTools(body string) ([]string, bool, bool) {
 		return nil, false, true
 	}
 	frontmatter := body[4 : 4+end]
-	for _, line := range strings.Split(frontmatter, "\n") {
+	lines := strings.Split(frontmatter, "\n")
+	for i, line := range lines {
 		key, value, ok := strings.Cut(line, ":")
 		if !ok || strings.TrimSpace(key) != "tools" {
 			continue
 		}
 		value = strings.TrimSpace(value)
-		if value == "" || (strings.HasPrefix(value, "[") != strings.HasSuffix(value, "]")) {
+		if value == "" {
+			var tools []string
+			for _, item := range lines[i+1:] {
+				trimmed := strings.TrimSpace(item)
+				if !strings.HasPrefix(item, " ") && !strings.HasPrefix(item, "\t") {
+					break
+				}
+				if !strings.HasPrefix(trimmed, "- ") || strings.TrimSpace(strings.TrimPrefix(trimmed, "- ")) == "" {
+					return nil, false, true
+				}
+				tools = append(tools, strings.Trim(strings.TrimSpace(strings.TrimPrefix(trimmed, "- ")), "\"'"))
+			}
+			if len(tools) == 0 {
+				return nil, false, true
+			}
+			return tools, true, false
+		}
+		if strings.HasPrefix(value, "[") != strings.HasSuffix(value, "]") {
 			return nil, false, true
 		}
 		tools := strings.FieldsFunc(strings.Trim(value, "[]"), func(r rune) bool { return r == ',' || r == ' ' })
@@ -393,6 +411,12 @@ func replacePiChildTools(body string, tools []string) string {
 	for i, line := range lines {
 		if key, _, ok := strings.Cut(line, ":"); ok && strings.TrimSpace(key) == "tools" {
 			lines[i] = "tools: " + strings.Join(tools, ", ")
+			end := i + 1
+			for end < len(lines) && (strings.HasPrefix(lines[end], " ") || strings.HasPrefix(lines[end], "\t")) {
+				end++
+			}
+			lines = append(lines[:i+1], lines[end:]...)
+			break
 		}
 	}
 	return strings.Join(lines, "\n") + body[frontEnd:]

--- a/internal/components/communitytool/pi_codegraph_test.go
+++ b/internal/components/communitytool/pi_codegraph_test.go
@@ -182,6 +182,23 @@ func TestPiCodeGraphReconcileIsByteIdempotentAndUninstallPreservesUserMCP(t *tes
 	}
 }
 
+func TestPiChildToolsAcceptsYAMLBlockList(t *testing.T) {
+	body := "---\ntools:\n  - read\n  - grep\n  - bash\n---\nwork\n"
+
+	tools, parseable, malformed := piChildTools(body)
+	if malformed || !parseable {
+		t.Fatalf("piChildTools() = %v, %v, %v; want parseable block list", tools, parseable, malformed)
+	}
+	if got, want := strings.Join(tools, ","), "read,grep,bash"; got != want {
+		t.Fatalf("piChildTools() tools = %q, want %q", got, want)
+	}
+
+	rendered := replacePiChildTools(body, append(tools, "mcp"))
+	if strings.Contains(rendered, "  - ") || !strings.Contains(rendered, "tools: read, grep, bash, mcp") {
+		t.Fatalf("replacePiChildTools() left malformed frontmatter:\n%s", rendered)
+	}
+}
+
 func TestPiCodeGraphUninstallRestoresAdoptedAndOwnedArtifacts(t *testing.T) {
 	home := t.TempDir()
 	mcpPath := filepath.Join(home, ".pi", "agent", "mcp.json")


### PR DESCRIPTION
## Linked Issue

Closes #1164

## PR Type

- [x] `type:bug` - Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` - New feature
- [ ] `type:docs` - Documentation only
- [ ] `type:refactor` - Code refactoring
- [ ] `type:chore` - Build, CI, or tooling changes
- [ ] `type:breaking-change` - Breaking change

## Summary

- Accept valid indented YAML block lists in Pi child `tools` frontmatter.
- Normalize block-list tools to the canonical inline format during reconciliation.
- Cover parsing and replacement behavior with a focused regression test.

## Changes

| File / Area | What Changed |
|-------------|--------------|
| `internal/components/communitytool/pi_codegraph.go` | Parses block-list tools and removes consumed list lines when rewriting frontmatter. |
| `internal/components/communitytool/pi_codegraph_test.go` | Adds regression coverage for block-list parsing and normalization. |

## Test Plan

- [x] Focused unit tests pass: `go test ./internal/components/communitytool`
- [x] Diff validation passes: `git diff --check`
- [ ] E2E tests pass: not run; the change is isolated to frontmatter parsing and covered by unit tests.
- [ ] Manually tested locally: not run beyond automated regression coverage.

## Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [x] Exactly one `type:*` label is applied
- [x] Relevant unit tests pass
- [ ] E2E tests pass: not applicable to this parser-only unit
- [x] Documentation is unchanged because external behavior and configuration remain documented
- [x] Commits follow Conventional Commits
- [x] Commits contain no `Co-Authored-By` trailers

## Notes for Reviewers

The parser remains intentionally narrow: malformed or empty block lists still fail closed, while valid lists are normalized to the existing inline representation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of multiline tool lists in Pi CodeGraph configuration.
  * Prevented malformed indentation and stale entries when updating tool definitions.
  * Added validation for empty or incorrectly formatted tool lists.

* **Tests**
  * Added coverage for parsing and rewriting YAML-style multiline tool lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->