### PR TITLE
fix(codex): expose detected Linuxbrew prefix

### DIFF
--- a/internal/components/permissions/inject.go
+++ b/internal/components/permissions/inject.go
@@ -3,6 +3,8 @@ package permissions
 import (
 	"fmt"
 	"os"
+	"os/exec"
+	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
@@ -13,6 +15,7 @@ import (
 )
 
 var codexPermissionsGOOS = runtime.GOOS
+var codexPermissionsLookPath = exec.LookPath
 
 type InjectionResult struct {
 	Changed bool
@@ -224,6 +227,9 @@ func injectCodexPermissions(homeDir string, adapter agents.Adapter) (InjectionRe
 	if codexPermissionsGOOS != "windows" {
 		readPaths = append(readPaths, `"/nix/store"`)
 	}
+	if prefix, ok := existingLinuxbrewPrefix(); ok {
+		readPaths = append(readPaths, strconv.Quote(prefix))
+	}
 	for _, path := range readPaths {
 		merged = filemerge.UpsertTOMLTableKey(merged, "permissions.gentle-dev.filesystem", path, `"read"`)
 	}
@@ -250,6 +256,24 @@ func injectCodexPermissions(homeDir string, adapter agents.Adapter) (InjectionRe
 	}
 
 	return InjectionResult{Changed: writeResult.Changed, Files: []string{configPath}}, nil
+}
+
+func existingLinuxbrewPrefix() (string, bool) {
+	if codexPermissionsGOOS != "linux" {
+		return "", false
+	}
+
+	brewPath, err := codexPermissionsLookPath("brew")
+	if err != nil || !filepath.IsAbs(brewPath) || filepath.Base(brewPath) != "brew" || filepath.Base(filepath.Dir(brewPath)) != "bin" {
+		return "", false
+	}
+
+	prefix := filepath.Dir(filepath.Dir(brewPath))
+	info, err := os.Stat(prefix)
+	if err != nil || !info.IsDir() {
+		return "", false
+	}
+	return prefix, true
 }
 
 func removeCodexHomeWorkspaceRoot(content string) string {

--- a/internal/components/permissions/inject_test.go
+++ b/internal/components/permissions/inject_test.go
@@ -3,7 +3,9 @@ package permissions
 import (
 	"encoding/json"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -467,6 +469,104 @@ func TestInjectCodexPermissionsSkipsNixStoreOnWindows(t *testing.T) {
 		if !strings.Contains(text, want) {
 			t.Fatalf("Windows Codex config missing non-fatal Nix home path %q; got:\n%s", want, text)
 		}
+	}
+}
+
+func TestInjectCodexPermissionsIncludesExistingLinuxbrewPrefix(t *testing.T) {
+	home := t.TempDir()
+	prefix := filepath.Join(t.TempDir(), "linuxbrew")
+	binDir := filepath.Join(prefix, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("create Linuxbrew bin directory: %v", err)
+	}
+	brewPath := filepath.Join(binDir, "brew")
+	if err := os.WriteFile(brewPath, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("create brew executable: %v", err)
+	}
+
+	origGOOS := codexPermissionsGOOS
+	origLookPath := codexPermissionsLookPath
+	codexPermissionsGOOS = "linux"
+	codexPermissionsLookPath = func(string) (string, error) { return brewPath, nil }
+	t.Cleanup(func() {
+		codexPermissionsGOOS = origGOOS
+		codexPermissionsLookPath = origLookPath
+	})
+
+	if _, err := Inject(home, codexAdapter()); err != nil {
+		t.Fatalf("Inject() error = %v", err)
+	}
+	content, err := os.ReadFile(filepath.Join(home, ".codex", "config.toml"))
+	if err != nil {
+		t.Fatalf("read config.toml: %v", err)
+	}
+	if !strings.Contains(string(content), strconv.Quote(prefix)+` = "read"`) {
+		t.Fatalf("Codex config missing Linuxbrew prefix %q; got:\n%s", prefix, content)
+	}
+}
+
+func TestInjectCodexPermissionsSkipsLinuxbrewPrefix(t *testing.T) {
+	tests := []struct {
+		name     string
+		goos     string
+		brewPath func(t *testing.T) string
+	}{
+		{
+			name: "brew is absent on Linux",
+			goos: "linux",
+		},
+		{
+			name: "detected prefix does not exist",
+			goos: "linux",
+			brewPath: func(t *testing.T) string {
+				return filepath.Join(t.TempDir(), "missing", "bin", "brew")
+			},
+		},
+		{
+			name: "macOS remains unchanged",
+			goos: "darwin",
+			brewPath: func(t *testing.T) string {
+				prefix := t.TempDir()
+				return filepath.Join(prefix, "bin", "brew")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home := t.TempDir()
+			brewPath := ""
+			if tt.brewPath != nil {
+				brewPath = tt.brewPath(t)
+			}
+			origGOOS := codexPermissionsGOOS
+			origLookPath := codexPermissionsLookPath
+			codexPermissionsGOOS = tt.goos
+			codexPermissionsLookPath = func(string) (string, error) {
+				if brewPath == "" {
+					return "", exec.ErrNotFound
+				}
+				return brewPath, nil
+			}
+			t.Cleanup(func() {
+				codexPermissionsGOOS = origGOOS
+				codexPermissionsLookPath = origLookPath
+			})
+
+			if _, err := Inject(home, codexAdapter()); err != nil {
+				t.Fatalf("Inject() error = %v", err)
+			}
+			content, err := os.ReadFile(filepath.Join(home, ".codex", "config.toml"))
+			if err != nil {
+				t.Fatalf("read config.toml: %v", err)
+			}
+			if brewPath != "" {
+				prefix := filepath.Dir(filepath.Dir(brewPath))
+				if strings.Contains(string(content), strconv.Quote(prefix)+` = "read"`) {
+					t.Fatalf("Codex config unexpectedly includes Linuxbrew prefix %q; got:\n%s", prefix, content)
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Linked Issue

Closes #1163

## PR Type

- [x] `type:bug` - Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` - New feature (non-breaking change that adds functionality)
- [ ] `type:docs` - Documentation only
- [ ] `type:refactor` - Code refactoring (no functional changes)
- [ ] `type:chore` - Build, CI, or tooling changes
- [ ] `type:breaking-change` - Breaking change (fix or feature that changes existing behavior)

## Summary

- Detect the active Linuxbrew installation from the resolved `brew` executable on Linux.
- Add only an existing detected Linuxbrew prefix to the Codex `gentle-dev` read-only filesystem permissions.
- Preserve existing behavior when `brew` is absent, the prefix is invalid, or the platform is not Linux.

## Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/components/permissions/inject.go` | Detect and inject an existing Linuxbrew prefix as read-only on Linux. |
| `internal/components/permissions/inject_test.go` | Cover valid, absent, invalid, and non-Linux detection paths. |

## Test Plan

**Unit Tests**
```bash
go test ./internal/components/permissions
```

- [x] Focused unit tests pass (`go test ./internal/components/permissions`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) - not applicable to this permission injection unit fix; official CI remains authoritative
- [ ] Manually tested locally - behavior is covered through injected platform and executable lookup boundaries

## Automated Checks

The repository's official PR checks remain authoritative.

## Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [x] I have added the appropriate `type:*` label to this PR
- [x] Focused unit tests pass
- [x] Documentation is not necessary because this restores existing Linuxbrew executability inside the generated sandbox profile
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers

## Notes for Reviewers

The Linuxbrew prefix is derived from the resolved `brew` path rather than hardcoded, is accepted only when it exists as a directory, and is granted read-only access.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Linux permission handling when an existing Linuxbrew installation is detected.
  * Codex configurations now grant read access to the valid Linuxbrew installation path.
  * Invalid, missing, or unsupported Linuxbrew paths are safely excluded from permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->