### PR TITLE
fix(sdd): detect git worktrees in findProjectRoot and resolve main repo root

### DIFF
--- a/internal/components/sdd/inject.go
+++ b/internal/components/sdd/inject.go
@@ -1,12 +1,15 @@
 package sdd
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/fs"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/gentleman-programming/gentle-ai/internal/agents"
 	"github.com/gentleman-programming/gentle-ai/internal/assets"
@@ -153,6 +156,99 @@ type bootstrapper interface {
 	BootstrapTemplate(homeDir string) error
 }
 
+// resolveWorktreeRoot resolves the main repository root from a git worktree
+// `.git` file. Git worktrees store a `.git` regular file (not a directory) at
+// the worktree checkout root containing a single `gitdir: <path>` line that
+// points to the shared worktree metadata directory
+// (`<main>/.git/worktrees/<name>`). This helper parses that line, walks up two
+// levels from the worktrees metadata directory to reach the shared `.git`
+// directory, resolves symlinks, and returns the parent of the shared `.git`
+// directory — i.e. the main repository root.
+//
+// Returns (root, true) on success and ("", false) on any failure (read error,
+// missing `gitdir:` prefix, non-directory resolved path, symlink failure). The
+// caller is expected to fall back to `git rev-parse --git-common-dir` when this
+// returns false.
+func resolveWorktreeRoot(gitPath string) (string, bool) {
+	content, err := os.ReadFile(gitPath)
+	if err != nil {
+		return "", false
+	}
+
+	// The .git file format is: "gitdir: <path>\n". Parse the first line.
+	lines := strings.SplitN(string(content), "\n", 2)
+	if len(lines) == 0 {
+		return "", false
+	}
+	firstLine := strings.TrimSpace(lines[0])
+	const gitdirPrefix = "gitdir: "
+	if !strings.HasPrefix(firstLine, gitdirPrefix) {
+		return "", false
+	}
+	parsedPath := strings.TrimSpace(strings.TrimPrefix(firstLine, gitdirPrefix))
+	if parsedPath == "" {
+		return "", false
+	}
+
+	// Normalize for cross-platform path separators (Git writes forward slashes
+	// even on Windows). filepath.FromSlash converts to the OS-native separator.
+	normalized := filepath.FromSlash(parsedPath)
+
+	// The parsed path points at `<main>/.git/worktrees/<name>`. Walking up two
+	// levels yields the shared `.git` directory: `<main>/.git`.
+	commonGitDir := filepath.Dir(filepath.Dir(normalized))
+
+	// Resolve symlinks defensively — some setups symlink the shared .git dir.
+	resolved, err := filepath.EvalSymlinks(commonGitDir)
+	if err != nil {
+		return "", false
+	}
+	info, err := os.Stat(resolved)
+	if err != nil || !info.IsDir() {
+		return "", false
+	}
+
+	// The parent of the shared `.git` directory is the main repository root.
+	return filepath.Dir(resolved), true
+}
+
+// resolveGitCommonDir is the fallback path for worktree detection: when the
+// `.git` file cannot be parsed directly, shell out to
+// `git rev-parse --git-common-dir` from the given directory to locate the
+// shared `.git` directory and return its parent (the main repo root).
+//
+// This is ONLY invoked when resolveWorktreeRoot fails, preserving NFR3 (happy
+// path does not shell out). A short timeout guards against hanging git
+// operations. Returns (root, true) on success and ("", false) on any failure.
+func resolveGitCommonDir(dir string) (string, bool) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "git", "-C", dir, "rev-parse", "--git-common-dir")
+	output, err := cmd.Output()
+	if err != nil {
+		return "", false
+	}
+	commonDir := strings.TrimSpace(string(output))
+	if commonDir == "" {
+		return "", false
+	}
+	// git rev-parse may return a relative or absolute path. Resolve it
+	// relative to dir when it is not absolute.
+	if !filepath.IsAbs(commonDir) {
+		commonDir = filepath.Join(dir, commonDir)
+	}
+	resolved, err := filepath.EvalSymlinks(commonDir)
+	if err != nil {
+		return "", false
+	}
+	info, err := os.Stat(resolved)
+	if err != nil || !info.IsDir() {
+		return "", false
+	}
+	return filepath.Dir(resolved), true
+}
+
 // findProjectRoot walks upward from dir, looking for the best project root.
 //
 // Priority order:
@@ -184,9 +280,29 @@ func findProjectRoot(dir string) (string, bool) {
 		}
 		// Check strong project markers — definitive roots; return immediately.
 		for _, marker := range strongProjectMarkers {
-			if _, err := os.Stat(filepath.Join(current, marker)); err == nil {
-				return current, true
+			markerPath := filepath.Join(current, marker)
+			fi, err := os.Stat(markerPath)
+			if err != nil {
+				continue
 			}
+			// `.git` can be a directory (normal repo) OR a regular file (git
+			// worktree pointer). For a directory, the current behavior is
+			// unchanged: return immediately. For a file, resolve the main
+			// repository root from the worktree pointer; on failure fall back
+			// to `git rev-parse --git-common-dir`. All other markers (go.mod,
+			// Cargo.toml, etc.) behave exactly as before.
+			if marker == ".git" && !fi.IsDir() {
+				if root, ok := resolveWorktreeRoot(markerPath); ok {
+					return root, true
+				}
+				if root, ok := resolveGitCommonDir(current); ok {
+					return root, true
+				}
+				// Both resolution paths failed: keep walking up rather than
+				// returning the worktree root as the project root.
+				continue
+			}
+			return current, true
 		}
 		// Weak marker: package.json — record but keep walking. Always update
 		// to the highest ancestor with a package.json, since in a JS project

--- a/internal/components/sdd/inject_test.go
+++ b/internal/components/sdd/inject_test.go
@@ -5174,6 +5174,105 @@ func TestFindProjectRootAllMarkers(t *testing.T) {
 	}
 }
 
+// TestFindProjectRootWorktreeGitFile verifies that when the upward walk
+// encounters a `.git` FILE (a git worktree pointer) instead of a directory,
+// findProjectRoot resolves the main repository root via the `gitdir:` line and
+// returns it — not the worktree root.
+func TestFindProjectRootWorktreeGitFile(t *testing.T) {
+	mainRoot := t.TempDir()
+
+	// Main repo has a real .git directory with a worktrees subdirectory.
+	mainGitDir := filepath.Join(mainRoot, ".git")
+	worktreeGitDir := filepath.Join(mainGitDir, "worktrees", "wt")
+	if err := os.MkdirAll(worktreeGitDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(worktree git dir): %v", err)
+	}
+
+	// Worktree checkout lives in a sibling directory; its `.git` is a FILE
+	// pointing back at the shared worktrees metadata directory.
+	worktreeRoot := t.TempDir()
+	gitFile := filepath.Join(worktreeRoot, ".git")
+	gitdirLine := "gitdir: " + filepath.ToSlash(worktreeGitDir)
+	if err := os.WriteFile(gitFile, []byte(gitdirLine+"\n"), 0o644); err != nil {
+		t.Fatalf("write .git file: %v", err)
+	}
+
+	// Start from a subdirectory of the worktree.
+	startDir := filepath.Join(worktreeRoot, "src", "app")
+	if err := os.MkdirAll(startDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(startDir): %v", err)
+	}
+
+	got, ok := findProjectRoot(startDir)
+	if !ok {
+		t.Fatal("findProjectRoot returned false, want true")
+	}
+	if got != mainRoot {
+		t.Fatalf("findProjectRoot = %q, want main repo root %q", got, mainRoot)
+	}
+}
+
+// TestFindProjectRootWorktreeGitFileFallback verifies that a malformed `.git`
+// file (no `gitdir:` line) does not cause a panic and falls through gracefully —
+// either via the `git rev-parse` fallback or by continuing the upward walk.
+func TestFindProjectRootWorktreeGitFileFallback(t *testing.T) {
+	worktreeRoot := t.TempDir()
+
+	// Write a .git FILE with malformed content (no gitdir: prefix).
+	gitFile := filepath.Join(worktreeRoot, ".git")
+	if err := os.WriteFile(gitFile, []byte("not a valid worktree pointer\n"), 0o644); err != nil {
+		t.Fatalf("write .git file: %v", err)
+	}
+
+	// Also place a go.mod at the worktree root so the fallback path has a
+	// definitive marker to return if the worktree resolution fails. Without a
+	// real git repo, the `git rev-parse` fallback will either fail (no repo)
+	// or return something we cannot predict; the go.mod guarantees a stable
+	// outcome and proves no panic occurred.
+	if err := os.WriteFile(filepath.Join(worktreeRoot, "go.mod"), []byte("module wt\n"), 0o644); err != nil {
+		t.Fatalf("write go.mod: %v", err)
+	}
+
+	startDir := filepath.Join(worktreeRoot, "internal", "pkg")
+	if err := os.MkdirAll(startDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(startDir): %v", err)
+	}
+
+	// The critical assertion: no panic, and findProjectRoot returns a valid
+	// root (go.mod marker) rather than the worktree root being misreported.
+	got, ok := findProjectRoot(startDir)
+	if !ok {
+		t.Fatal("findProjectRoot returned false, want true (go.mod marker should be found)")
+	}
+	if got != worktreeRoot {
+		t.Fatalf("findProjectRoot = %q, want worktree root %q (go.mod marker)", got, worktreeRoot)
+	}
+}
+
+// TestFindProjectRootNormalGitDirUnchanged is a regression guard: a normal
+// `.git` directory (not a worktree file) must continue to return the directory
+// that contains `.git`, identical to the pre-change behavior.
+func TestFindProjectRootNormalGitDirUnchanged(t *testing.T) {
+	root := t.TempDir()
+
+	if err := os.MkdirAll(filepath.Join(root, ".git"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(.git): %v", err)
+	}
+
+	subDir := filepath.Join(root, "cmd", "server")
+	if err := os.MkdirAll(subDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(subDir): %v", err)
+	}
+
+	got, ok := findProjectRoot(subDir)
+	if !ok {
+		t.Fatal("findProjectRoot returned false, want true")
+	}
+	if got != root {
+		t.Fatalf("findProjectRoot = %q, want .git root %q", got, root)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Fix: SDD post-check disk fallback on Windows
 // ---------------------------------------------------------------------------

--- a/openspec/specs/sdd-orchestrator-assets/spec.md
+++ b/openspec/specs/sdd-orchestrator-assets/spec.md
@@ -314,3 +314,58 @@ The system MUST also keep direct static assertions and impacted golden fixtures 
 - WHEN compared with expected outputs
 - THEN fixtures include required strategy guidance and propagation where relevant
 - AND fixtures preserve accurate platform-native wording without unrelated churn
+
+---
+
+### Requirement: Project Root Resolution
+
+`findProjectRoot()` MUST walk upward from a starting directory and return the authoritative project root. When the walk encounters a `.git` entry, the system MUST distinguish between a directory (normal repository) and a regular file (git worktree) and resolve accordingly. The function contract (return project root or `false`) is preserved; only the resolution logic for `.git` worktrees is corrected.
+
+**Functional rules:**
+
+| # | Rule |
+|---|------|
+| FR1 | When `.git` is a FILE, the system MUST treat it as a worktree pointer and MUST NOT return the worktree root as the project root. |
+| FR2 | For a worktree `.git` file, the system MUST read the file, extract the path from the `gitdir:` line, resolve the shared `.git` directory (two levels up from the referenced worktrees path), and return its parent as the project root. |
+| FR3 | If reading or parsing the `.git` file fails, the system MUST fall back to `git rev-parse --git-common-dir` and return the parent of the resolved common git directory. |
+| FR4 | When `.git` is a DIRECTORY (normal repository), the system MUST return the directory containing `.git` as the project root — unchanged behavior. |
+| FR5 | The fix is limited to `findProjectRoot()`. No Engram-side changes are required; resolving the correct project root naturally prevents duplicate per-worktree Engram projects and avoids re-triggering `sdd-init`. |
+
+**Non-functional rules:**
+
+| # | Rule |
+|---|------|
+| NFR1 | The fix MUST NOT change behavior for non-worktree repositories. |
+| NFR2 | All existing `findProjectRoot` tests MUST pass unchanged (backward compatible). |
+| NFR3 | The happy path MUST NOT shell out to `git rev-parse`; the external command is ONLY a fallback when `.git` file parsing fails. |
+
+#### Scenario: Worktree with valid .git file
+
+- GIVEN a directory inside a git worktree where `.git` is a file containing `gitdir: /main/.git/worktrees/name`
+- WHEN `findProjectRoot` walks up and finds `.git` as a file
+- THEN it reads the `gitdir:` line and returns the main repository root (parent of `/main/.git`)
+- AND it MUST NOT return the worktree root
+
+#### Scenario: Normal repo with .git directory
+
+- GIVEN a directory inside a normal git repository where `.git` is a directory
+- WHEN `findProjectRoot` walks up and finds `.git` as a directory
+- THEN it returns the directory containing `.git` as the project root (unchanged behavior)
+
+#### Scenario: Worktree with unreadable .git file
+
+- GIVEN a worktree where the `.git` file exists but cannot be read (e.g. permission error)
+- WHEN `findProjectRoot` attempts to read the `.git` file
+- THEN it falls back to `git rev-parse --git-common-dir` and returns the parent of that directory
+
+#### Scenario: Worktree with malformed .git file
+
+- GIVEN a worktree where the `.git` file does not contain a valid `gitdir:` line
+- WHEN `findProjectRoot` reads the file content
+- THEN it falls back to `git rev-parse --git-common-dir` to resolve the shared git directory
+
+#### Scenario: No git at all
+
+- GIVEN a directory hierarchy with no `.git` entry at any ancestor level
+- WHEN `findProjectRoot` walks upward
+- THEN it behaves exactly as before — returns the best candidate (e.g. package.json) or `("", false)` when no markers are found


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #702

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)

---

## 📝 Summary

- `findProjectRoot()` now detects when `.git` is a regular file (git worktree) vs a directory (normal repo)
- When `.git` is a file, it reads the `gitdir:` line and resolves the main repository root
- Falls back to `git rev-parse --git-common-dir` if file parsing fails
- Normal `.git` directories are completely unaffected

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/components/sdd/inject.go` | Added `resolveWorktreeRoot()` and `resolveGitCommonDir()` helpers; modified `findProjectRoot()` to special-case `.git` file vs directory |
| `internal/components/sdd/inject_test.go` | Added 3 new tests: worktree `.git` file resolution, malformed fallback, normal `.git` dir regression guard |
| `openspec/specs/sdd-orchestrator-assets/spec.md` | Merged delta spec for Project Root Resolution requirement |

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./...
```

- [x] Unit tests pass (`go test ./...`) — 13/13 findProjectRoot tests pass (10 existing + 3 new)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Manually tested locally

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

The change is ~270 lines total (~120 code, ~99 tests, ~55 spec). Well under the 400-line budget. All existing tests pass unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project-root detection for Git worktrees.
  * Correctly identifies the main repository when a worktree uses a `.git` file.
  * Added safe fallback behavior for malformed Git metadata.

* **Tests**
  * Added coverage for valid and invalid worktree configurations.
  * Confirmed existing behavior remains unchanged for standard Git repositories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->