### PR TITLE
fix(pi): handle manifest permissions on Windows

### DIFF
--- a/internal/components/communitytool/pi_codegraph.go
+++ b/internal/components/communitytool/pi_codegraph.go
@@ -859,7 +859,7 @@ func readPiCodeGraphManifest(path string) (piCodeGraphManifest, error) {
 		return piCodeGraphManifest{}, fmt.Errorf("stat Pi CodeGraph manifest %q: %w", path, err)
 	}
 	if !piCodeGraphManifestPermissionsSafe(runtime.GOOS, info.Mode()) {
-		return piCodeGraphManifest{}, fmt.Errorf("Pi CodeGraph manifest %q has unsafe permissions", path)
+		return piCodeGraphManifest{}, fmt.Errorf("Pi CodeGraph manifest %q has unsafe permissions %#o", path, info.Mode().Perm())
 	}
 	var manifest piCodeGraphManifest
 	if err := json.Unmarshal(data, &manifest); err != nil {

--- a/internal/components/communitytool/pi_codegraph.go
+++ b/internal/components/communitytool/pi_codegraph.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"strings"
 	"time"
@@ -26,9 +27,10 @@ const (
 )
 
 var (
-	piCodeGraphAtomicWrite = filemerge.WriteFileAtomic
-	piCodeGraphReadFile    = os.ReadFile
-	piCodeGraphRemove      = os.Remove
+	piCodeGraphAtomicWrite  = filemerge.WriteFileAtomic
+	piCodeGraphReadFile     = os.ReadFile
+	piCodeGraphRemove       = os.Remove
+	piCodeGraphManifestStat = os.Stat
 )
 
 var piCodeGraphEffectiveMCPProbe PiCodeGraphEffectiveMCPProbe = probePiCodeGraphMCP
@@ -852,7 +854,11 @@ func readPiCodeGraphManifest(path string) (piCodeGraphManifest, error) {
 	if err != nil {
 		return piCodeGraphManifest{}, err
 	}
-	if info, statErr := os.Stat(path); statErr != nil || info.Mode().Perm()&0o077 != 0 {
+	info, err := piCodeGraphManifestStat(path)
+	if err != nil {
+		return piCodeGraphManifest{}, fmt.Errorf("stat Pi CodeGraph manifest %q: %w", path, err)
+	}
+	if !piCodeGraphManifestPermissionsSafe(runtime.GOOS, info.Mode()) {
 		return piCodeGraphManifest{}, fmt.Errorf("Pi CodeGraph manifest %q has unsafe permissions", path)
 	}
 	var manifest piCodeGraphManifest
@@ -860,6 +866,10 @@ func readPiCodeGraphManifest(path string) (piCodeGraphManifest, error) {
 		return piCodeGraphManifest{}, err
 	}
 	return manifest, nil
+}
+
+func piCodeGraphManifestPermissionsSafe(goos string, mode os.FileMode) bool {
+	return goos == "windows" || mode.Perm()&0o077 == 0
 }
 
 func restoreMissingPiChildren(children map[string]piCodeGraphOwnedFile, journal *piJournal, changed map[string]struct{}) error {

--- a/internal/components/communitytool/pi_codegraph_test.go
+++ b/internal/components/communitytool/pi_codegraph_test.go
@@ -346,6 +346,49 @@ func TestPiCodeGraphPathsExcludesUnsafeManifestPaths(t *testing.T) {
 	}
 }
 
+func TestPiCodeGraphManifestPermissionsSafe(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		goos string
+		mode os.FileMode
+		want bool
+	}{
+		{name: "Windows normal file", goos: "windows", mode: 0o666, want: true},
+		{name: "Windows read-only file", goos: "windows", mode: 0o444, want: true},
+		{name: "POSIX private file", goos: "linux", mode: 0o600, want: true},
+		{name: "POSIX group-readable file", goos: "linux", mode: 0o644, want: false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := piCodeGraphManifestPermissionsSafe(tt.goos, tt.mode); got != tt.want {
+				t.Fatalf("piCodeGraphManifestPermissionsSafe(%q, %o) = %v, want %v", tt.goos, tt.mode, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestReadPiCodeGraphManifestPreservesFileErrors(t *testing.T) {
+	t.Run("read error", func(t *testing.T) {
+		if _, err := readPiCodeGraphManifest(t.TempDir()); err == nil {
+			t.Fatal("readPiCodeGraphManifest() error = nil, want read error")
+		}
+	})
+
+	t.Run("stat error", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "manifest.json")
+		if err := os.WriteFile(path, []byte(`{"children":{}}`), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		wantErr := errors.New("stat failed")
+		previousStat := piCodeGraphManifestStat
+		piCodeGraphManifestStat = func(string) (os.FileInfo, error) { return nil, wantErr }
+		t.Cleanup(func() { piCodeGraphManifestStat = previousStat })
+
+		if _, err := readPiCodeGraphManifest(path); !errors.Is(err, wantErr) {
+			t.Fatalf("readPiCodeGraphManifest() error = %v, want wrapped %v", err, wantErr)
+		}
+	})
+}
+
 func TestVerifyPiCodeGraphRejectsNonCanonicalMCP(t *testing.T) {
 	home := t.TempDir()
 	mcpPath := filepath.Join(home, "mcp.json")


### PR DESCRIPTION
## Linked Issue

Closes #1177

## PR Type

- [x] 	ype:bug - Bug fix (non-breaking change that fixes an issue)
- [ ] 	ype:feature - New feature
- [ ] 	ype:docs - Documentation only
- [ ] 	ype:refactor - Code refactoring
- [ ] 	ype:chore - Build, CI, or tooling changes
- [ ] 	ype:breaking-change - Breaking change

## Summary

- Skip unsupported Unix permission-bit validation on Windows for the Pi CodeGraph manifest.
- Preserve strict POSIX 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Pi CodeGraph manifest permission validation on Windows with platform-appropriate safety checks.
  * Preserved and surfaced underlying file/stat errors so failures report clearer, more actionable diagnostics.
  * Strengthened non-Windows validation to reject unsafe permission configurations.
* **Tests**
  * Added coverage for permission-safety behavior across representative Windows/POSIX modes.
  * Added coverage to ensure manifest read errors keep original error identity and aren’t swallowed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->