### PR TITLE
fix(sdd): recover compact review authority

### DIFF
--- a/internal/assets/assets_test.go
+++ b/internal/assets/assets_test.go
@@ -335,6 +335,31 @@ func TestAllEmbeddedAssetsAreReadable(t *testing.T) {
 	}
 }
 
+func TestSDDVerifyAuthorityPreflightDenialEnvelopeContract(t *testing.T) {
+	const denialFields = `authority_only_failure: true
+missing_review_authority: true
+substantive_failure: false
+command_failed: false
+observed_authority_revision: sha256:{observed-authority-revision}`
+
+	for _, path := range []string{
+		"skills/sdd-verify/SKILL.md",
+		"skills/sdd-verify/references/report-format.md",
+	} {
+		content := MustRead(path)
+		for _, want := range []string{
+			denialFields,
+			"test_exit_code: 125",
+			"build_exit_code: 125",
+			"must not be executed",
+		} {
+			if !strings.Contains(content, want) {
+				t.Fatalf("%s missing authority-preflight denial contract %q", path, want)
+			}
+		}
+	}
+}
+
 func TestOpenCodeEmbeddedAssetLayout(t *testing.T) {
 	entries, err := FS.ReadDir("opencode")
 	if err != nil {

--- a/internal/assets/skills/sdd-verify/SKILL.md
+++ b/internal/assets/skills/sdd-verify/SKILL.md
@@ -52,6 +52,17 @@ The orchestrator should provide structured status from `skills/_shared/sdd-statu
 - This is the one independent requirements/runtime final verification. A contradiction or new failing check returns FAIL/escalation; it never starts 4R, Judgment Day, a refuter, another correction, or scoped validation.
 - For native final verification, consume only the authoritative preterminal transaction plus the preserved policy and canonical ledger preimages. Do not require `receipt.json`, `chain-bundle.json`, `gate-context.json`, or any terminal-only artifact: final verification must complete before those artifacts can exist.
 - Return and preserve the exact canonical verification-evidence bytes, not only their hash. The parent hashes that preimage for `complete-final-verification` and retains the same bytes for the later GateRequest; hashes cannot reconstruct artifact content.
+- If authoritative preflight alone denies verification because review authority is missing, persist a failed strict envelope with the five fields below. Both declared commands must not be executed: record exit `125` for each, hash their exact empty output, and bind the observed authority revision from that preflight. Do not use this envelope for substantive failures or command failures.
+
+```yaml
+authority_only_failure: true
+missing_review_authority: true
+substantive_failure: false
+command_failed: false
+observed_authority_revision: sha256:{observed-authority-revision}
+test_exit_code: 125
+build_exit_code: 125
+```
 
 ## Decision Gates
 
@@ -140,6 +151,17 @@ You are a VERIFY sub-agent. Your job: check implemented changes match spec accep
 - A contradiction or failing check escalates; never start another review/fix loop.
 - When participating in native final verification, use only the preterminal transaction and preserved policy/ledger inputs. Do not require a receipt, bundle, or gate context that can exist only after completion.
 - Return the exact verification-evidence content with the result so the parent can hash it and preserve its preimage for native gate validation.
+- For an authority-only preflight denial, both declared commands must not be executed. Record exit `125`, empty-output hashes, and exactly these five recovery fields in the strict envelope:
+
+```yaml
+authority_only_failure: true
+missing_review_authority: true
+substantive_failure: false
+command_failed: false
+observed_authority_revision: sha256:{observed-authority-revision}
+test_exit_code: 125
+build_exit_code: 125
+```
 - Return minimal report
 
 ## Return Minimal Report

--- a/internal/assets/skills/sdd-verify/references/report-format.md
+++ b/internal/assets/skills/sdd-verify/references/report-format.md
@@ -82,4 +82,18 @@ build_output_hash: sha256:{exact-output-digest}
 
 The YAML envelope MUST be the first non-empty content and contains every field exactly once. Counts come from the actual retrieved specs. Passing requires current test and build/type-check commands with zero exit codes and SHA-256 output digests. Invalid, unknown, missing, contradictory, blocker-bearing, critical-bearing, incomplete, or stale evidence fails closed. Human prose after the envelope never controls routing. Model/provider/profile/effort selection remains user-owned.
 
+## Authority-Only Preflight Denial
+
+When authoritative preflight alone denies entry because review authority is missing, emit the normal failed envelope plus exactly these five recovery fields:
+
+```yaml
+authority_only_failure: true
+missing_review_authority: true
+substantive_failure: false
+command_failed: false
+observed_authority_revision: sha256:{observed-authority-revision}
+```
+
+The observed revision is the authority revision read during the denied preflight. The declared test and build commands must not be executed; use `test_exit_code: 125` and `build_exit_code: 125`, with both output hashes set to the SHA-256 digest of exact empty output. Exit `125` describes preflight denial, so `command_failed` remains `false`. Never emit this recovery shape for substantive verification failures, executed command failures, malformed authority, or unknown authority.
+
 When Strict TDD is active, insert the TDD compliance, test layer distribution, changed-file coverage, and quality metrics sections from `strict-tdd-verify.md`.

--- a/internal/sddstatus/bounded_review_test.go
+++ b/internal/sddstatus/bounded_review_test.go
@@ -425,6 +425,288 @@ func TestResolveStartsBoundedReviewBeforeFinalVerification(t *testing.T) {
 	}
 }
 
+func TestDiscoverCompactPreVerifyAuthorityFailsClosedWithoutExactlyOneEligibleStore(t *testing.T) {
+	root := t.TempDir()
+	seedReadyChange(t, root, "thin", "- [x] 1.1 Done\n")
+	runSDDStatusGit(t, root, "init", "-q")
+	runSDDStatusGit(t, root, "config", "user.email", "status@example.com")
+	runSDDStatusGit(t, root, "config", "user.name", "Status Test")
+	runSDDStatusGit(t, root, "add", ".")
+	runSDDStatusGit(t, root, "commit", "-qm", "base")
+
+	bridge := discoverCompactPreVerifyAuthority(context.Background(), root, "thin", "")
+	if bridge.Eligible || !strings.Contains(bridge.Reason, "no eligible") {
+		t.Fatalf("empty compact bridge = %#v", bridge)
+	}
+}
+
+func TestResolveBridgesExactlyOnePathBoundCompactAuthorityToVerifyOnly(t *testing.T) {
+	root := t.TempDir()
+	changeRoot := seedReadyChange(t, root, "thin", "- [x] 1.1 Done\n")
+	writeApprovedCompactAuthorityForChange(t, root, changeRoot, "compact-thin")
+
+	status, err := Resolve(ResolveOptions{CWD: root, ChangeName: "thin"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.Dependencies.Verify != DependencyReady || status.Dependencies.Archive != DependencyBlocked || status.NextRecommended != "verify" || status.ReviewTransaction != nil {
+		t.Fatalf("compact bridge status = %#v", status)
+	}
+	if _, err := os.Stat(filepath.Join(changeRoot, "reviews", "transaction.json")); !os.IsNotExist(err) {
+		t.Fatalf("bridge synthesized local review mirror: %v", err)
+	}
+}
+
+const emptyOutputHash = "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+func TestAuthorityOnlyFailedReportRequiresStructuredFailClosedEvidence(t *testing.T) {
+	valid := authorityOnlyVerifyEnvelope(shaID("0"), "125", "125")
+	for _, tt := range []struct {
+		name   string
+		report string
+		want   bool
+	}{
+		{name: "valid authority-only preflight denial", report: valid, want: true},
+		{name: "zero exits are not preflight denial", report: authorityOnlyVerifyEnvelope(shaID("0"), "0", "0")},
+		{name: "arbitrary output hashes are not empty output", report: strings.Replace(valid, emptyOutputHash, shaID("2"), 1)},
+		{name: "markdown substrings are not evidence", report: boundedVerifyEnvelope(shaID("1"), "fail") + "\nauthority_only_failure: true\nmissing_review_authority: true\n"},
+		{name: "executed command failed", report: strings.Replace(valid, "test_exit_code: 125", "test_exit_code: 1", 1)},
+		{name: "substantive failure", report: strings.Replace(valid, "substantive_failure: false", "substantive_failure: true", 1)},
+		{name: "malformed blocker count", report: strings.Replace(valid, "blockers: 1", "blockers: unknown", 1)},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := authorityOnlyFailedReport(tt.report); got != tt.want {
+				t.Fatalf("authorityOnlyFailedReport() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+	if authorityChangedSinceReport(valid, shaID("0")) {
+		t.Fatal("unchanged authority revision must not permit recovery")
+	}
+}
+
+func TestResolveRecoversOnlyAuthorityMissingHistoricalVerification(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		testExit  string
+		wantReady bool
+	}{
+		{name: "new authority permits retry", testExit: "125", wantReady: true},
+		{name: "command failure remains denied", testExit: "1"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			changeRoot := seedReadyChange(t, root, "thin", "- [x] 1.1 Done\n")
+			write(t, filepath.Join(changeRoot, "specs", "auth", "spec.md"), "### Requirement: Auth\n#### Scenario: Valid login\n")
+			report := authorityOnlyVerifyEnvelope(shaID("0"), tt.testExit, "125")
+			write(t, filepath.Join(changeRoot, "verify-report.md"), report)
+			writeApprovedCompactAuthorityForChange(t, root, changeRoot, "compact-thin")
+
+			status, err := Resolve(ResolveOptions{CWD: root, ChangeName: "thin"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if tt.wantReady {
+				if status.Dependencies.Verify != DependencyReady || status.Dependencies.Archive != DependencyBlocked || status.NextRecommended != "verify" {
+					t.Fatalf("recovery status = %#v", status)
+				}
+				if status.RemediationState != (RemediationState{}) || strings.Contains(strings.Join(status.BlockedReasons, "\n"), "remediation") {
+					t.Fatalf("recovery retained remediation blockers: %#v", status)
+				}
+				if got := readText(filepath.Join(changeRoot, "verify-report.md")); got != report {
+					t.Fatal("recovery rewrote historical verification evidence")
+				}
+			} else if status.Dependencies.Verify != DependencyBlocked || status.NextRecommended == "verify" {
+				t.Fatalf("denied recovery status = %#v", status)
+			}
+		})
+	}
+}
+
+func TestResolveRecoversWithObservedStaleAndNewLiveCompactLineages(t *testing.T) {
+	root := t.TempDir()
+	changeRoot := seedReadyChange(t, root, "thin", "- [x] 1.1 Done\n")
+	write(t, filepath.Join(changeRoot, "specs", "auth", "spec.md"), "### Requirement: Auth\n#### Scenario: Valid login\n")
+	writeApprovedCompactAuthorityForChange(t, root, changeRoot, "compact-stale")
+	staleStore, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), root, "compact-stale")
+	if err != nil {
+		t.Fatal(err)
+	}
+	staleRecord, err := staleStore.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	report := authorityOnlyVerifyEnvelope(staleRecord.Revision, "125", "125")
+	write(t, filepath.Join(changeRoot, "verify-report.md"), report)
+
+	write(t, filepath.Join(changeRoot, "tasks.md"), "- [x] 1.1 Done\n# stale intermediate scope\n")
+	writeApprovedCompactAuthorityForChangeWithTasks(t, root, changeRoot, "compact-live", "- [x] 1.1 Done\n# new approved scope\n")
+
+	status, err := Resolve(ResolveOptions{CWD: root, ChangeName: "thin"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.Dependencies.Verify != DependencyReady || status.Dependencies.Archive != DependencyBlocked || status.NextRecommended != "verify" {
+		t.Fatalf("multi-lineage recovery status = %#v", status)
+	}
+	if got := readText(filepath.Join(changeRoot, "verify-report.md")); got != report {
+		t.Fatal("multi-lineage recovery rewrote historical verification evidence")
+	}
+}
+
+func TestObservedRevisionSkipsOnlyScopeChangedPredecessor(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		observed string
+		revision string
+		result   reviewtransaction.GateResult
+		want     bool
+	}{
+		{name: "matching scope changed predecessor", observed: shaID("a"), revision: shaID("a"), result: reviewtransaction.GateScopeChanged, want: true},
+		{name: "matching invalidated predecessor", observed: shaID("a"), revision: shaID("a"), result: reviewtransaction.GateInvalidated},
+		{name: "matching escalated predecessor", observed: shaID("a"), revision: shaID("a"), result: reviewtransaction.GateEscalated},
+		{name: "matching allow authority", observed: shaID("a"), revision: shaID("a"), result: reviewtransaction.GateAllow},
+		{name: "different scope changed authority", observed: shaID("a"), revision: shaID("b"), result: reviewtransaction.GateScopeChanged},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := skipsObservedStalePredecessor(tt.observed, tt.revision, tt.result); got != tt.want {
+				t.Fatalf("skipsObservedStalePredecessor(%q, %q, %q) = %v, want %v", tt.observed, tt.revision, tt.result, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCompactAuthorityPathBindingRejectsForeignAndTraversalOpenSpecPaths(t *testing.T) {
+	base := reviewtransaction.CompactState{GenesisPaths: []string{"openspec/changes/thin/tasks.md"}, InitialSnapshot: reviewtransaction.Snapshot{Paths: []string{"openspec/changes/thin/tasks.md"}}}
+	for _, tt := range []struct {
+		name       string
+		paths      []string
+		wantReason bool
+	}{
+		{name: "foreign change is irrelevant", paths: []string{"openspec/changes/other/tasks.md"}},
+		{name: "traversal", paths: []string{"openspec/changes/thin/../other/tasks.md"}, wantReason: true},
+		{name: "dot segment", paths: []string{"openspec/changes/thin/./tasks.md"}, wantReason: true},
+		{name: "duplicate separator", paths: []string{"openspec/changes/thin//tasks.md"}, wantReason: true},
+		{name: "mixed foreign path", paths: []string{"openspec/changes/thin/tasks.md", "openspec/config.yaml"}, wantReason: true},
+		{name: "mixed foreign change", paths: []string{"openspec/changes/thin/tasks.md", "openspec/changes/other/tasks.md"}, wantReason: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			state := base
+			state.GenesisPaths, state.InitialSnapshot.Paths = tt.paths, tt.paths
+			if bound, reason := compactAuthorityPathsBound(state, "thin"); bound || (reason != "") != tt.wantReason {
+				t.Fatalf("paths %v = bound=%v reason=%q, wantReason=%v", tt.paths, bound, reason, tt.wantReason)
+			}
+		})
+	}
+}
+
+func TestDiscoverCompactPreVerifyAuthorityIgnoresForeignChangeAuthority(t *testing.T) {
+	root := t.TempDir()
+	activeRoot := seedReadyChange(t, root, "thin", "- [x] 1.1 Done\n")
+	foreignRoot := seedReadyChange(t, root, "other", "- [x] 1.1 Done\n")
+	writeApprovedCompactAuthorityForChange(t, root, foreignRoot, "compact-other")
+	writeApprovedCompactAuthorityForChange(t, root, activeRoot, "compact-thin")
+
+	bridge := discoverCompactPreVerifyAuthority(context.Background(), root, "thin", "")
+	if !bridge.Eligible || bridge.Relevant || bridge.Reason != "" {
+		t.Fatalf("bridge with foreign authority = %#v, want one eligible active authority", bridge)
+	}
+}
+
+func TestResolveBlocksAmbiguousPathBoundCompactAuthorities(t *testing.T) {
+	root := t.TempDir()
+	changeRoot := seedReadyChange(t, root, "thin", "- [x] 1.1 Done\n")
+	writeApprovedCompactAuthorityForChange(t, root, changeRoot, "compact-one")
+	first, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), root, "compact-one")
+	if err != nil {
+		t.Fatal(err)
+	}
+	record, err := first.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := record.State.OriginalChangedLines
+	secondState, err := reviewtransaction.NewCompactState(reviewtransaction.Start{
+		LineageID: "compact-two", Mode: reviewtransaction.ModeOrdinaryBounded, Generation: 1,
+		Snapshot: record.State.InitialSnapshot, PolicyHash: record.State.PolicyHash, RiskLevel: record.State.RiskLevel,
+		SelectedLenses: record.State.SelectedLenses, OriginalChangedLines: &lines,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), root, secondState.LineageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	revision, err := second.Replace("", "review/start", secondState)
+	if err != nil {
+		t.Fatal(err)
+	}
+	results := make([]reviewtransaction.LensResult, len(secondState.SelectedLenses))
+	for index, lens := range secondState.SelectedLenses {
+		results[index] = reviewtransaction.LensResult{Lens: lens, Findings: []reviewtransaction.Finding{}, Evidence: []string{"review complete"}}
+	}
+	if err := secondState.CompleteReview(reviewtransaction.CompactReviewInput{LensResults: results, Classifications: []reviewtransaction.FindingEvidence{}, RefuterOutcomes: []reviewtransaction.EvidenceResult{}}); err != nil {
+		t.Fatal(err)
+	}
+	revision, err = second.Replace(revision, "review/complete-review", secondState)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := secondState.CompleteVerification([]byte("verification passed\n"), true); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := second.Replace(revision, "review/complete-verification", secondState); err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := secondState.Receipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := reviewtransaction.WriteCompactReceiptAtomic(second.ReceiptPath(), receipt); err != nil {
+		t.Fatal(err)
+	}
+	status, err := Resolve(ResolveOptions{CWD: root, ChangeName: "thin"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.Dependencies.Verify != DependencyBlocked || status.NextRecommended != "resolve-review" || !strings.Contains(strings.Join(status.BlockedReasons, "\n"), "multiple eligible") {
+		t.Fatalf("ambiguous compact bridge status = %#v", status)
+	}
+}
+
+func TestResolveRejectsReceiptMismatchAndNonAllowCompactBridge(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		mutate func(t *testing.T, root string)
+	}{
+		{name: "receipt mismatch", mutate: func(t *testing.T, root string) {
+			store, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), root, "compact-thin")
+			if err != nil {
+				t.Fatal(err)
+			}
+			write(t, store.ReceiptPath(), "{}\n")
+		}},
+		{name: "post apply gate denies", mutate: func(t *testing.T, root string) {
+			write(t, filepath.Join(root, "openspec", "changes", "thin", "tasks.md"), "- [x] 1.1 Done\n# changed after compact approval\n")
+		}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			changeRoot := seedReadyChange(t, root, "thin", "- [x] 1.1 Done\n")
+			writeApprovedCompactAuthorityForChange(t, root, changeRoot, "compact-thin")
+			tt.mutate(t, root)
+			status, err := Resolve(ResolveOptions{CWD: root, ChangeName: "thin"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if status.Dependencies.Verify != DependencyBlocked || status.NextRecommended != "resolve-review" || status.Dependencies.Archive != DependencyBlocked {
+				t.Fatalf("%s status = %#v", tt.name, status)
+			}
+		})
+	}
+}
+
 func TestResolveRemediationIsBoundToBudgetAndFailedEvidenceRevision(t *testing.T) {
 	root := t.TempDir()
 	changeRoot := seedReadyChange(t, root, "thin", "- [x] 1.1 Done\n")
@@ -579,6 +861,70 @@ func writeApprovedReviewArtifacts(t *testing.T, changeRoot string) {
 	writeJSON(t, filepath.Join(reviewsDir, "gate-context.json"), request)
 }
 
+func writeApprovedCompactAuthorityForChange(t *testing.T, repo, changeRoot, lineage string) {
+	writeApprovedCompactAuthorityForChangeWithTasks(t, repo, changeRoot, lineage, "- [x] 1.1 Done\n# approved compact scope\n")
+}
+
+func writeApprovedCompactAuthorityForChangeWithTasks(t *testing.T, repo, changeRoot, lineage, tasks string) {
+	t.Helper()
+	runSDDStatusGit(t, repo, "init", "-q")
+	runSDDStatusGit(t, repo, "config", "user.email", "status@example.com")
+	runSDDStatusGit(t, repo, "config", "user.name", "Status Test")
+	runSDDStatusGit(t, repo, "add", ".")
+	runSDDStatusGit(t, repo, "commit", "-qm", "base")
+	write(t, filepath.Join(changeRoot, "tasks.md"), tasks)
+	snapshot, err := (reviewtransaction.SnapshotBuilder{Repo: repo}).Build(context.Background(), reviewtransaction.Target{Kind: reviewtransaction.TargetCurrentChanges, IntendedUntracked: []string{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	risk, lines, err := (reviewtransaction.SnapshotBuilder{Repo: repo}).ClassifySnapshotRisk(context.Background(), snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lenses := []string{}
+	if risk == reviewtransaction.RiskMedium {
+		lenses = []string{reviewtransaction.LensReliability}
+	} else if risk == reviewtransaction.RiskHigh {
+		lenses = []string{reviewtransaction.LensRisk, reviewtransaction.LensResilience, reviewtransaction.LensReadability, reviewtransaction.LensReliability}
+	}
+	state, err := reviewtransaction.NewCompactState(reviewtransaction.Start{LineageID: lineage, Mode: reviewtransaction.ModeOrdinaryBounded, Generation: 1, Snapshot: snapshot, PolicyHash: shaID("c"), RiskLevel: risk, SelectedLenses: lenses, OriginalChangedLines: &lines})
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, lineage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	revision, err := store.Replace("", "review/start", state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	results := make([]reviewtransaction.LensResult, len(lenses))
+	for index, lens := range lenses {
+		results[index] = reviewtransaction.LensResult{Lens: lens, Findings: []reviewtransaction.Finding{}, Evidence: []string{"review complete"}}
+	}
+	if err := state.CompleteReview(reviewtransaction.CompactReviewInput{LensResults: results, Classifications: []reviewtransaction.FindingEvidence{}, RefuterOutcomes: []reviewtransaction.EvidenceResult{}}); err != nil {
+		t.Fatal(err)
+	}
+	revision, err = store.Replace(revision, "review/complete-review", state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := state.CompleteVerification([]byte("verification passed\n"), true); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Replace(revision, "review/complete-verification", state); err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := state.Receipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := reviewtransaction.WriteCompactReceiptAtomic(store.ReceiptPath(), receipt); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func writeAdditionalApprovedNativeReceipt(t *testing.T, repo, lineage string) {
 	t.Helper()
 	sourceStore, err := reviewtransaction.AuthoritativeStore(context.Background(), repo, "thin-lineage")
@@ -728,6 +1074,31 @@ func boundedVerifyEnvelope(revision, verdict string) string {
 		"build_output_hash: " + shaID("3"),
 		"```",
 	}, "\n")
+}
+
+func authorityOnlyVerifyEnvelope(revision, testExit, buildExit string) string {
+	return strings.ReplaceAll(strings.Join([]string{
+		"```yaml",
+		"schema: gentle-ai.verify-result/v1",
+		"evidence_revision: " + shaID("1"),
+		"verdict: fail",
+		"blockers: 1",
+		"critical_findings: 1",
+		"requirements: 0/1",
+		"scenarios: 0/1",
+		"test_command: go test ./...",
+		"test_exit_code: " + testExit,
+		"test_output_hash: " + emptyOutputHash,
+		"build_command: go vet ./...",
+		"build_exit_code: " + buildExit,
+		"build_output_hash: " + emptyOutputHash,
+		"authority_only_failure: true",
+		"missing_review_authority: true",
+		"substantive_failure: false",
+		"command_failed: false",
+		"observed_authority_revision: " + revision,
+		"```",
+	}, "\n"), "\r\n", "\n")
 }
 
 func remediationTransaction(t *testing.T, revision string, ready bool) reviewtransaction.Transaction {

--- a/internal/sddstatus/review_gate.go
+++ b/internal/sddstatus/review_gate.go
@@ -7,10 +7,115 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"sort"
 	"strings"
 
 	"github.com/gentleman-programming/gentle-ai/internal/reviewtransaction"
 )
+
+type compactPreVerifyBridge struct {
+	Eligible bool
+	Relevant bool
+	Reason   string
+	Revision string
+}
+
+func discoverCompactPreVerifyAuthority(ctx context.Context, repo, changeName, observedRevision string) compactPreVerifyBridge {
+	stores, err := reviewtransaction.DiscoverCompactStores(ctx, repo)
+	if err != nil {
+		return compactPreVerifyBridge{Reason: "no eligible path-bound compact authority found"}
+	}
+	eligible := 0
+	candidateRevision := ""
+	for _, store := range stores {
+		record, err := store.Load()
+		if err != nil {
+			return compactPreVerifyBridge{Relevant: true, Reason: "compact authority record is malformed"}
+		}
+		bound, pathReason := compactAuthorityPathsBound(record.State, changeName)
+		if !bound {
+			if pathReason != "" {
+				return compactPreVerifyBridge{Relevant: true, Reason: pathReason}
+			}
+			continue
+		}
+		if record.State.State != reviewtransaction.StateApproved {
+			return compactPreVerifyBridge{Relevant: true, Reason: "path-bound compact authority is not approved"}
+		}
+		payload, err := os.ReadFile(store.ReceiptPath())
+		if err != nil {
+			return compactPreVerifyBridge{Relevant: true, Reason: "path-bound compact authority receipt is missing"}
+		}
+		receipt, err := reviewtransaction.ParseCompactReceipt(payload)
+		authoritative, receiptErr := record.State.Receipt()
+		if err != nil || receiptErr != nil || !reflect.DeepEqual(receipt, authoritative) {
+			return compactPreVerifyBridge{Relevant: true, Reason: "path-bound compact authority receipt does not equal approved state"}
+		}
+		evaluation := reviewtransaction.EvaluateCompactGate(ctx, repo, receipt, reviewtransaction.NativeGateRequestInput{Gate: reviewtransaction.GatePostApply, LineageID: receipt.LineageID})
+		finalRecord, finalErr := store.Load()
+		finalPayload, finalReadErr := os.ReadFile(store.ReceiptPath())
+		if finalErr != nil || finalReadErr != nil || finalRecord.Revision != record.Revision || !reflect.DeepEqual(finalPayload, payload) {
+			return compactPreVerifyBridge{Relevant: true, Reason: "compact authority changed during discovery"}
+		}
+		if evaluation.Result != reviewtransaction.GateAllow {
+			if skipsObservedStalePredecessor(observedRevision, record.Revision, evaluation.Result) {
+				continue
+			}
+			return compactPreVerifyBridge{Relevant: true, Reason: "path-bound compact authority post-apply gate is not allow"}
+		}
+		eligible++
+		if eligible == 1 {
+			// The revision is immutable store evidence used only for retry routing.
+			// It never authorizes a receipt by itself.
+			candidateRevision = record.Revision
+		}
+	}
+	switch eligible {
+	case 1:
+		return compactPreVerifyBridge{Eligible: true, Revision: candidateRevision}
+	case 0:
+		return compactPreVerifyBridge{Reason: "no eligible path-bound compact authority found"}
+	default:
+		return compactPreVerifyBridge{Relevant: true, Reason: "multiple eligible path-bound compact authorities found"}
+	}
+}
+
+func skipsObservedStalePredecessor(observedRevision, revision string, result reviewtransaction.GateResult) bool {
+	return observedRevision != "" && observedRevision == revision && result == reviewtransaction.GateScopeChanged
+}
+
+func compactAuthorityPathsBound(state reviewtransaction.CompactState, changeName string) (bool, string) {
+	if !sameCanonicalPaths(state.GenesisPaths, state.InitialSnapshot.Paths) {
+		return false, "path-bound compact authority has inconsistent immutable paths"
+	}
+	prefix := "openspec/changes/" + changeName + "/"
+	matched := false
+	foreignOpenSpec := false
+	for _, raw := range state.GenesisPaths {
+		path := filepath.ToSlash(raw)
+		if filepath.IsAbs(raw) || path != filepath.ToSlash(filepath.Clean(raw)) {
+			return false, "path-bound compact authority contains a non-canonical OpenSpec path"
+		}
+		if strings.HasPrefix(path, "openspec/") {
+			if !strings.HasPrefix(path, prefix) {
+				foreignOpenSpec = true
+				continue
+			}
+			matched = true
+		}
+	}
+	if matched && foreignOpenSpec {
+		return false, "path-bound compact authority contains a foreign OpenSpec path"
+	}
+	return matched, ""
+}
+
+func sameCanonicalPaths(left, right []string) bool {
+	left, right = append([]string(nil), left...), append([]string(nil), right...)
+	sort.Strings(left)
+	sort.Strings(right)
+	return reflect.DeepEqual(left, right)
+}
 
 func readSpecCounts(paths []string) (SpecCounts, error) {
 	contents := make([]string, 0, len(paths))

--- a/internal/sddstatus/status.go
+++ b/internal/sddstatus/status.go
@@ -1,6 +1,7 @@
 package sddstatus
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -314,12 +315,26 @@ func Resolve(options ResolveOptions) (Status, error) {
 		reviewStateReason,
 		readText(firstPath(artifactPaths.ApplyProgress)),
 	)
-	if remediationState.Reason != "" {
-		blockedReasons = append(blockedReasons, remediationState.Reason)
-	}
 	dependencies := resolveDependencies(artifacts, taskProgress, applyState, coreReady, verifyResult.Passing, remediationState.Complete)
 	nextRecommended := resolveNextRecommended(dependencies, applyState, artifacts["verifyReport"] == ArtifactDone, remediationState)
-	applyPreVerifyReviewRouting(&dependencies, &nextRecommended, &blockedReasons, applyState, artifacts["verifyReport"] == ArtifactDone, reviewState, reviewStateReason)
+	bridge := compactPreVerifyBridge{}
+	recoverable := authorityOnlyFailedReport(readText(firstPath(artifactPaths.VerifyReport)))
+	if applyState == ApplyAllDone && (artifacts["verifyReport"] != ArtifactDone || recoverable) && reviewState == nil {
+		fields, _ := authorityFailureFields(readText(firstPath(artifactPaths.VerifyReport)))
+		bridge = discoverCompactPreVerifyAuthority(context.Background(), workspaceRoot, changeName, fields["observed_authority_revision"])
+	}
+	if recoverable && bridge.Eligible && authorityChangedSinceReport(readText(firstPath(artifactPaths.VerifyReport)), bridge.Revision) {
+		dependencies.Verify = DependencyReady
+		dependencies.Archive = DependencyBlocked
+		nextRecommended = "verify"
+		remediationState = RemediationState{}
+	} else if remediationState.Reason != "" {
+		blockedReasons = append(blockedReasons, remediationState.Reason)
+	}
+	applyPreVerifyCompactBridgeRouting(&dependencies, &nextRecommended, &blockedReasons, applyState, artifacts["verifyReport"] == ArtifactDone, reviewState, bridge)
+	if !bridge.Eligible && !bridge.Relevant {
+		applyPreVerifyReviewRouting(&dependencies, &nextRecommended, &blockedReasons, applyState, artifacts["verifyReport"] == ArtifactDone, reviewState, reviewStateReason)
+	}
 
 	status := baseStatus(workspaceRoot, &changeName, &changeRoot, nextRecommended, blockedReasons)
 	status.ArtifactPaths = artifactPaths
@@ -341,6 +356,58 @@ func Resolve(options ResolveOptions) (Status, error) {
 		status.PhaseInstructions = &instructions
 	}
 	return status, nil
+}
+
+func authorityOnlyFailedReport(report string) bool {
+	fields, ok := authorityFailureFields(report)
+	return ok && fields["authority_only_failure"] == "true" && fields["missing_review_authority"] == "true" &&
+		fields["substantive_failure"] == "false" && fields["command_failed"] == "false"
+}
+
+func authorityChangedSinceReport(report, revision string) bool {
+	fields, ok := authorityFailureFields(report)
+	return ok && fields["observed_authority_revision"] != revision
+}
+
+func authorityFailureFields(report string) (map[string]string, bool) {
+	const emptyOutputHash = "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+	lines, end, reason := parseLeadingEnvelope(report)
+	if reason != "" {
+		return nil, false
+	}
+	allowed := map[string]bool{
+		"schema": true, "evidence_revision": true, "verdict": true, "blockers": true, "critical_findings": true,
+		"requirements": true, "scenarios": true, "test_command": true, "test_exit_code": true, "test_output_hash": true,
+		"build_command": true, "build_exit_code": true, "build_output_hash": true, "authority_only_failure": true,
+		"missing_review_authority": true, "substantive_failure": true, "command_failed": true, "observed_authority_revision": true,
+	}
+	fields, reason := parseScalarFields(lines[1:end], allowed, "authority failure")
+	if reason != "" || len(fields) != len(allowed) || fields["schema"] != VerifyResultSchema || fields["verdict"] != "fail" {
+		return nil, false
+	}
+	for _, field := range []string{"evidence_revision", "test_output_hash", "build_output_hash", "observed_authority_revision"} {
+		if !sha256IdentityPattern.MatchString(fields[field]) {
+			return nil, false
+		}
+	}
+	if fields["test_output_hash"] != emptyOutputHash || fields["build_output_hash"] != emptyOutputHash {
+		return nil, false
+	}
+	testExit, testOK := parseNonnegativeInt(fields["test_exit_code"])
+	buildExit, buildOK := parseNonnegativeInt(fields["build_exit_code"])
+	blockers, blockersOK := parseNonnegativeInt(fields["blockers"])
+	critical, criticalOK := parseNonnegativeInt(fields["critical_findings"])
+	if !testOK || !buildOK || !blockersOK || !criticalOK || blockers == 0 || critical == 0 || testExit != 125 || buildExit != 125 {
+		return nil, false
+	}
+	if _, ok := parseVerifyCompletion(fields["requirements"]); !ok {
+		return nil, false
+	}
+	if _, ok := parseVerifyCompletion(fields["scenarios"]); !ok || !isConcreteEvidence(fields["test_command"]) || !isConcreteEvidence(fields["build_command"]) {
+		return nil, false
+	}
+	return fields, true
 }
 
 func resolveEngramStatus(workspaceRoot string, requestedChange string, includeInstructions bool) (Status, bool, error) {
@@ -460,6 +527,24 @@ func applyPreVerifyReviewRouting(dependencies *Dependencies, next *string, block
 		dependencies.Verify = DependencyBlocked
 		*next = "review"
 		*blockedReasons = append(*blockedReasons, fmt.Sprintf("bounded review transaction is %q; continue it without creating a new budget before final verification", transaction.State))
+	}
+}
+
+func applyPreVerifyCompactBridgeRouting(dependencies *Dependencies, next *string, blockedReasons *[]string, applyState ApplyState, verifyReportDone bool, transaction *reviewtransaction.Transaction, bridge compactPreVerifyBridge) {
+	if applyState != ApplyAllDone || verifyReportDone || transaction != nil {
+		return
+	}
+	if bridge.Eligible {
+		dependencies.Verify = DependencyReady
+		dependencies.Archive = DependencyBlocked
+		*next = "verify"
+		return
+	}
+	if bridge.Relevant {
+		dependencies.Verify = DependencyBlocked
+		dependencies.Archive = DependencyBlocked
+		*next = "resolve-review"
+		*blockedReasons = append(*blockedReasons, bridge.Reason)
 	}
 }
 

--- a/openspec/changes/sdd-compact-authority-recovery/apply-progress.md
+++ b/openspec/changes/sdd-compact-authority-recovery/apply-progress.md
@@ -1,0 +1,42 @@
+# Apply Progress: Recover SDD Verification from Compact Authority
+
+**Mode**: Strict TDD
+**Delivery**: Single PR `size:exception` (800 authored-line ceiling)
+
+## Completed Tasks
+
+- [x] 1.1 Add RED cases for absent, exact, invalid, denied, foreign, traversal, and ambiguous authority.
+- [x] 1.2 Add multi-lineage coverage for an observed stale predecessor and a newer live authority.
+- [x] 2.1 Implement canonical active-change path binding and stable compact authority discovery.
+- [x] 2.2 Route exactly one valid authority to verify only without synthesizing mirrors.
+- [x] 3.1 Parse strict authority-only failed-report evidence and require changed authority.
+- [x] 3.2 Keep substantive, command-failed, malformed, unchanged, and unrelated denied lineages blocked.
+- [x] 4.1 Update embedded `sdd-verify` instructions, report format, and asset contract tests.
+- [x] 5.1 Run focused tests, full tests, vet, formatting, and diff checks.
+
+## TDD Cycle Evidence
+
+| Task | Test File | Layer | Safety Net | RED | GREEN | TRIANGULATE | REFACTOR |
+|---|---|---|---|---|---|---|---|
+| 1.1 | `internal/sddstatus/bounded_review_test.go` | Integration | `go test ./internal/sddstatus ./internal/assets` — PASS before this remediation | Existing RED cases cover absent/exact/foreign/traversal/ambiguous authority | Focused compact-discovery cases pass | Exact authority plus fail-closed variants | `skipsObservedStalePredecessor` keeps the exceptional rule explicit; focused tests stay green |
+| 1.2 | `internal/sddstatus/bounded_review_test.go` | Integration | Same passing baseline | Added `TestObservedRevisionSkipsOnlyScopeChangedPredecessor` before production code; `go test ... -run '^TestObservedRevisionSkipsOnlyScopeChangedPredecessor$'` failed to build: undefined helper | Same command passed after the minimal helper | Matching scope-changed allows; matching invalidated, escalated, allow, and mismatched revisions deny | Extracted the narrow predicate, then reran focused recovery tests green |
+| 2.1 | `internal/sddstatus/bounded_review_test.go` | Integration | Same passing baseline | Existing RED fixtures exercise canonical active-change binding and unstable/invalid authority paths | Focused compact-discovery cases pass | Active, foreign, traversal, receipt-mismatch, denied, and ambiguous stores | No further refactor needed beyond the explicit stale-predecessor predicate |
+| 2.2 | `internal/sddstatus/bounded_review_test.go` | Integration | Same passing baseline | Existing RED fixture requires verify-only routing and no synthesized mirror | `TestResolveBridgesExactlyOnePathBoundCompactAuthorityToVerifyOnly` passes | Valid bridge versus invalid/ambiguous bridge routes | No behavior-changing refactor needed |
+| 3.1 | `internal/sddstatus/bounded_review_test.go` | Unit | Same passing baseline | Existing strict-envelope cases reject non-125 and non-empty-output evidence | `TestAuthorityOnlyFailedReportRequiresStructuredFailClosedEvidence` passes | Valid changed authority versus unchanged authority | No behavior-changing refactor needed |
+| 3.2 | `internal/sddstatus/bounded_review_test.go` | Integration | Same passing baseline | Existing denial cases plus the new observed-revision RED case define fail-closed routing | Recovery and rejection focused tests pass | Command failure, malformed evidence, unchanged authority, invalidated, escalated, and unrelated revisions remain denied | Narrow predicate removes the overbroad revision-only bypass |
+| 4.1 | `internal/assets/assets_test.go` | Unit | Same passing baseline | Existing asset contract test requires the strict authority-preflight envelope | `TestSDDVerifyAuthorityPreflightDenialEnvelopeContract` passes | Instructions and report-format assets assert the same fields and paired `125`/empty-output contract | No refactor needed; assets remain contract-aligned |
+| 5.1 | `internal/sddstatus/bounded_review_test.go`, `internal/assets/assets_test.go` | Integration | Same passing baseline | The remediation test was RED before its implementation helper existed | Focused tests pass after GREEN and refactor | Focused recovery, full suite, vet, format, and diff hygiene provide independent checks | Focused suite rerun after the helper extraction |
+
+## Work Unit Evidence
+
+| Evidence | Result |
+|---|---|
+| Focused test command | `go test ./internal/sddstatus -run '^(TestObservedRevisionSkipsOnlyScopeChangedPredecessor|TestResolveRecoversWithObservedStaleAndNewLiveCompactLineages|TestResolveRejectsReceiptMismatchAndNonAllowCompactBridge)$'` — PASS (0.226s) |
+| Runtime harness | Temporary Git repositories and compact stores in `bounded_review_test.go`; the multi-lineage resolver runs against real discovered stores — PASS |
+| Rollback boundary | Revert `internal/sddstatus/review_gate.go`, `internal/sddstatus/bounded_review_test.go`, and this apply-progress update; no authority store, receipt, or verify history is mutated |
+
+## Verification
+
+- The historical `verify-report.md` remains a **FAIL** record until a separate re-verification writes fresh evidence.
+- Final commands for this remediation are recorded after they run; their output is not retroactively substituted into the historical verify report.
+- E2E is N/A: this changes internal status routing and its runtime boundary is the temporary Git-store harness above.

--- a/openspec/changes/sdd-compact-authority-recovery/design.md
+++ b/openspec/changes/sdd-compact-authority-recovery/design.md
@@ -1,0 +1,21 @@
+# Design: Recover SDD Verification from Compact Authority
+
+## Approach
+
+Add a read-only pre-verification bridge in `sdd-status`. It enumerates repository-derived compact stores, validates immutable active-change path binding, loads approved state and its equal receipt, executes the live post-apply gate, and rechecks authority before routing. It never creates a transaction mirror.
+
+For an existing failed verify report, parse a strict leading envelope. Recovery is eligible only when missing review authority was the sole failure, neither declared command ran, both exits are `125`, and the newly eligible authority revision differs from the observed revision. During multi-lineage discovery, only that exact observed stale denied predecessor may be skipped; any unrelated malformed, denied, or competing live authority blocks.
+
+## Decisions
+
+| Decision | Rationale |
+|---|---|
+| Exact active-change OpenSpec prefix and canonical path equality | Prevent cross-change authority reuse and traversal aliases. |
+| Receipt equality plus live post-apply gate | A revision identifier alone is not authority. |
+| Verify-only routing with no mirror writes | Discovery cannot manufacture persisted review state or archive readiness. |
+| Strict authority-only envelope | Human prose cannot reclassify substantive or command failures. |
+| Skip only the report-observed stale denied revision | Supports real multi-lineage recovery without ignoring unrelated denial evidence. |
+
+## Rollback
+
+Revert `internal/sddstatus`, the three embedded asset changes, and this OpenSpec change. Existing reports and compact stores remain valid data.

--- a/openspec/changes/sdd-compact-authority-recovery/proposal.md
+++ b/openspec/changes/sdd-compact-authority-recovery/proposal.md
@@ -1,0 +1,32 @@
+# Proposal: Recover SDD Verification from Compact Authority
+
+## Intent
+
+Allow `sdd-status` to discover exactly one approved, path-bound compact review authority before final verification and to retry a historical verification whose sole failure was missing authority. Preserve fail-closed routing, history, and archive protection.
+
+## Scope
+
+### In Scope
+- Discover compact stores from the repository Git common-dir after apply.
+- Bind authority to canonical paths under the active OpenSpec change.
+- Require approved state, equal receipt, stable revision, and live post-apply `allow`.
+- Handle foreign, stale, invalid, denied, and multiple lineages deterministically.
+- Route authority-only historical failures to re-verification only when authority changed.
+- Define the `sdd-verify` authority-preflight denial envelope and exit-125 contract.
+
+### Out of Scope
+- Pre-PR publication-boundary selection or authorization.
+- Compact/legacy gate implementation changes.
+- Mirror synthesis, authority repair, substantive-failure retry, or archive bypass.
+
+## Delivery
+
+The focused status fixtures exceed 400 lines. Use a single-PR `size:exception` with an 800 authored-line ceiling.
+
+## Success Criteria
+
+- [ ] Exactly one valid active-change authority makes only verify ready.
+- [ ] Multi-lineage history can ignore only the exact observed stale denied predecessor.
+- [ ] Invalid, ambiguous, unchanged, or substantive cases remain blocked.
+- [ ] Historical reports remain immutable and archive requires a new passing verification.
+- [ ] Embedded `sdd-verify` assets emit a strict machine-readable authority-only denial.

--- a/openspec/changes/sdd-compact-authority-recovery/specs/review-findings-ledger/spec.md
+++ b/openspec/changes/sdd-compact-authority-recovery/specs/review-findings-ledger/spec.md
@@ -1,0 +1,35 @@
+# Delta for review-findings-ledger
+
+## MODIFIED Requirements
+
+### Requirement: Compact authority pre-verification recovery
+
+After apply and before final verification, `sdd-status` MAY discover one approved compact authority when no local legacy transaction mirror exists. The authority MUST have canonical paths bound exclusively to the active change, an equal terminal receipt, a stable revision, and a live post-apply `allow`. Discovery MUST write nothing and MUST NOT make archive ready.
+
+A failed report MAY become verify-ready only when its strict envelope proves missing review authority was the sole blocker, no command or substantive verification failed, and a different valid authority is now live. Multi-lineage discovery MAY ignore only the exact stale denied revision observed by that report. All other invalid, denied, malformed, ambiguous, unchanged-authority, or substantive cases MUST remain blocked.
+
+#### Scenario: Exactly one valid authority
+- GIVEN one approved active-change compact authority returns live post-apply `allow`
+- WHEN apply is complete and final verification has not passed
+- THEN only verify becomes ready and no mirror is written
+
+#### Scenario: Multi-lineage authority recovery
+- GIVEN an authority-only report names a stale denied predecessor revision
+- AND one newer valid authority is exactly bound and live
+- WHEN readiness is resolved
+- THEN the predecessor is preserved and only re-verification becomes ready
+
+#### Scenario: Invalid or ambiguous authority
+- GIVEN authority is absent, malformed, denied, cross-change, traversal-shaped, receipt-mismatched, changed during discovery, or multiply eligible
+- WHEN readiness is resolved
+- THEN verify and archive remain blocked
+
+#### Scenario: Ineligible failed report
+- GIVEN commands failed, substantive verification failed, the envelope is malformed, or authority is unchanged
+- WHEN readiness is resolved
+- THEN recovery is denied
+
+#### Scenario: Authority-only verification envelope
+- GIVEN authority preflight alone denies before commands execute
+- WHEN `sdd-verify` records the failure
+- THEN it emits the five recovery fields, exit `125` for both commands, and exact empty-output hashes

--- a/openspec/changes/sdd-compact-authority-recovery/tasks.md
+++ b/openspec/changes/sdd-compact-authority-recovery/tasks.md
@@ -1,0 +1,18 @@
+# Tasks: Recover SDD Verification from Compact Authority
+
+## Review Workload
+
+- Delivery: single PR with `size:exception`
+- Authored-line ceiling: 800
+- Runtime boundary: temporary Git repositories with compact stores and multiple lineages
+
+## Implementation
+
+- [x] 1.1 Add RED cases for absent, exact, invalid, denied, foreign, traversal, and ambiguous authority.
+- [x] 1.2 Add multi-lineage coverage for an observed stale predecessor and a newer live authority.
+- [x] 2.1 Implement canonical active-change path binding and stable compact authority discovery.
+- [x] 2.2 Route exactly one valid authority to verify only without synthesizing mirrors.
+- [x] 3.1 Parse strict authority-only failed-report evidence and require changed authority.
+- [x] 3.2 Keep substantive, command-failed, malformed, unchanged, and unrelated denied lineages blocked.
+- [x] 4.1 Update embedded `sdd-verify` instructions, report format, and asset contract tests.
+- [x] 5.1 Run focused tests, full tests, vet, formatting, and diff checks.

--- a/openspec/changes/sdd-compact-authority-recovery/verify-report.md
+++ b/openspec/changes/sdd-compact-authority-recovery/verify-report.md
@@ -1,0 +1,155 @@
+```yaml
+schema: gentle-ai.verify-result/v1
+evidence_revision: sha256:958e3224e858b6fc938f76ebe3ce7d4686ecdbec4c6c870bed8edf5a07dea472
+verdict: pass_with_warnings
+blockers: 0
+critical_findings: 0
+requirements: 1/1
+scenarios: 5/5
+test_command: go test -count=1 ./...
+test_exit_code: 0
+test_output_hash: sha256:581618575bb227e3684d3c408649ef915ac958a9fb507f33ced8a02073bbcfa0
+build_command: go vet ./...
+build_exit_code: 0
+build_output_hash: sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+```
+
+## Verification Report
+
+**Change**: `sdd-compact-authority-recovery`
+**Issue**: [#1179](https://github.com/Gentleman-Programming/gentle-ai/issues/1179)
+**Version**: N/A
+**Mode**: Strict TDD
+**Approved review authority**: `review-a690f3e160da0732`
+**Final verdict**: **PASS WITH WARNINGS**
+
+### Preflight and Routing Safety
+
+| Check | Result | Evidence |
+|---|---|---|
+| Persistence selection | ✅ | Auto-detected OpenSpec at `openspec/changes/sdd-compact-authority-recovery` |
+| Delivery strategy | ✅ | Single PR with explicit `size:exception`; effective maintainer ceiling is 950 authored lines |
+| Review authority | ✅ | Receipt `review-a690f3e160da0732` is approved; live `review validate --gate post-apply` returned `allow` |
+| Historical failed report classification | ✅ | The prior report was substantive, not authority-only: it had two substantive CRITICAL findings, command exits `0/0`, and none of the five authority-only recovery fields |
+| Automatic retry routing | ✅ Fail-closed | Native `sdd-status` kept verify/archive blocked and recommended `resolve-review`; a substantive report cannot enter the authority-only changed-revision bypass |
+| Independent rerun authorization | ✅ | This report is a fresh explicit post-remediation verification against the newly approved authority; it replaces the failed result rather than reclassifying its history |
+| Post-report routing | ✅ Fail-closed | Native status accepts this report as `verify: all_done` but keeps archive blocked because multiple terminal native receipts are discoverable without a change-local receipt mirror |
+
+The prior failed report was preserved until this independent rerun. Its safe blocked routing was validated before replacement.
+
+### Completeness
+
+| Metric | Value |
+|---|---:|
+| Requirements | 1 |
+| Scenarios | 5 |
+| Tasks total | 8 |
+| Tasks complete | 8 |
+| Tasks incomplete | 0 |
+
+Proposal, delta spec, design, tasks, apply progress, and the historical failed report were inspected. All task checkboxes are complete.
+
+### Build & Tests Execution
+
+| Check | Command | Exit | Output SHA-256 | Result |
+|---|---|---:|---|---|
+| Focused behavior | `go test -count=1 -v ./internal/sddstatus ./internal/assets -run 'Test(DiscoverCompactPreVerifyAuthorityFailsClosedWithoutExactlyOneEligibleStore|ResolveBridgesExactlyOnePathBoundCompactAuthorityToVerifyOnly|AuthorityOnlyFailedReportRequiresStructuredFailClosedEvidence|ResolveRecoversOnlyAuthorityMissingHistoricalVerification|ResolveRecoversWithObservedStaleAndNewLiveCompactLineages|ObservedRevisionSkipsOnlyScopeChangedPredecessor|CompactAuthorityPathBindingRejectsForeignAndTraversalOpenSpecPaths|DiscoverCompactPreVerifyAuthorityIgnoresForeignChangeAuthority|ResolveBlocksAmbiguousPathBoundCompactAuthorities|ResolveRejectsReceiptMismatchAndNonAllowCompactBridge|SDDVerifyAuthorityPreflightDenialEnvelopeContract)$'` | 0 | `sha256:a5ba0f1a7602e2b7dfcb53f05e5c1502d5cc29830f06a43f918205c202e4faeb` | ✅ 28 leaf cases passed |
+| Full test suite | `go test -count=1 ./...` | 0 | `sha256:581618575bb227e3684d3c408649ef915ac958a9fb507f33ced8a02073bbcfa0` | ✅ Passed |
+| Vet/type check | `go vet ./...` | 0 | `sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855` | ✅ Passed |
+| Coverage | `go test -count=1 -coverprofile=/tmp/opencode/sdd-compact-authority-recovery-final.coverage ./internal/sddstatus ./internal/assets` | 0 | `sha256:dcad941bb1f989bb224e66b570c0952c8885c7619c3c5fa1fbc1269c35fdc863` | ✅ Passed |
+| Formatting | `gofmt -l internal/assets/assets_test.go internal/sddstatus/bounded_review_test.go internal/sddstatus/review_gate.go internal/sddstatus/status.go` | 0 | `sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855` | ✅ No output |
+| Tracked diff hygiene | `git diff --check` | 0 | `sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855` | ✅ No output |
+| OpenSpec diff hygiene | `git diff --no-index --check /dev/null <artifact>` for each non-report change artifact | 0 findings | `sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855` | ✅ No whitespace findings |
+
+### Spec Compliance Matrix
+
+| Requirement | Scenario | Runtime evidence | Result |
+|---|---|---|---|
+| Compact authority pre-verification recovery | Exactly one valid authority | `TestResolveBridgesExactlyOnePathBoundCompactAuthorityToVerifyOnly` | ✅ COMPLIANT |
+| Compact authority pre-verification recovery | Multi-lineage authority recovery | `TestResolveRecoversWithObservedStaleAndNewLiveCompactLineages`; matching `scope-changed` case in `TestObservedRevisionSkipsOnlyScopeChangedPredecessor` | ✅ COMPLIANT |
+| Compact authority pre-verification recovery | Invalid or ambiguous authority | Discovery, path binding, ambiguity, receipt mismatch, non-allow, and matching `invalidated`/`escalated` deny cases all pass | ✅ COMPLIANT |
+| Compact authority pre-verification recovery | Ineligible failed report | `TestAuthorityOnlyFailedReportRequiresStructuredFailClosedEvidence`, `TestResolveRecoversOnlyAuthorityMissingHistoricalVerification`, and live native status against the prior substantive report | ✅ COMPLIANT |
+| Compact authority pre-verification recovery | Authority-only verification envelope | `TestSDDVerifyAuthorityPreflightDenialEnvelopeContract` plus strict parser cases for `125/125` and exact empty-output hashes | ✅ COMPLIANT |
+
+**Compliance summary**: 5/5 scenarios and 1/1 requirement compliant.
+
+### Correctness (Static Evidence)
+
+| Requirement area | Status | Evidence |
+|---|---|---|
+| Git common-dir compact discovery | ✅ Implemented | Compact stores are discovered only after apply when no local transaction mirror exists. |
+| Active-change path binding | ✅ Implemented | Immutable paths must be canonical, equal, and exclusively bound to the active OpenSpec change. |
+| Receipt/revision/live-target binding | ✅ Implemented | Approved state, receipt equality, live post-apply evaluation, and state/receipt stability recheck are enforced. |
+| Narrow predecessor exception | ✅ Implemented | `skipsObservedStalePredecessor` requires exact observed revision and `GateScopeChanged`; matching `invalidated`, `escalated`, or `allow` and mismatched revisions return false. |
+| Strict authority-only report parsing | ✅ Implemented | Exact fields, `125/125`, empty-output hashes, blocker counts, concrete commands, and changed authority are required. |
+| Verify-only routing and archive protection | ✅ Implemented | Eligible authority makes only verify ready; no mirror is synthesized and archive remains blocked until fresh passing evidence exists. |
+
+### Coherence (Design)
+
+| Decision | Followed? | Notes |
+|---|---|---|
+| Exact active-change canonical binding | ✅ Yes | Implemented and tested. |
+| Receipt equality plus live post-apply gate | ✅ Yes | Approved receipt returned live `allow`. |
+| Verify-only routing with no mirror writes | ✅ Yes | Runtime fixture checks both routing and absent mirror. |
+| Strict authority-only envelope | ✅ Yes | Parser and embedded assets agree on the five recovery fields. |
+| Skip only the report-observed stale denied revision | ✅ Yes | The exception is limited to exact `scope-changed`; invalidated and escalated are denied. |
+
+### TDD Compliance
+
+| Check | Result | Details |
+|---|---|---|
+| TDD Evidence reported | ✅ | Per-task `TDD Cycle Evidence` table is present in `apply-progress.md`. |
+| All tasks have tests | ✅ | 8/8 task rows map to existing test files. |
+| RED confirmed | ✅ | Test files exist; the remediation row records the focused undefined-helper RED build failure before production implementation. |
+| GREEN confirmed | ✅ | Focused behavior and full-suite executions pass now. |
+| Triangulation adequate | ✅ | Positive recovery and distinct absent, malformed, command-failed, foreign, traversal, ambiguous, receipt-mismatch, scope-changed, invalidated, escalated, allow, and revision-mismatch variants pass. |
+| Safety net for modified files | ✅ | Every task row records the passing pre-remediation focused baseline. |
+
+**TDD compliance**: 6/6 checks passed; 8/8 task rows contain cycle evidence.
+
+### Test Layer Distribution
+
+| Layer | Tests | Files | Tools |
+|---|---:|---:|---|
+| Unit | 19 leaf cases | 2 | Go `testing` |
+| Integration | 9 leaf cases | 1 | Go `testing`, temporary Git repositories, compact stores, real Git commands |
+| E2E | 0 | 0 | Not required; the specified runtime boundary is the temporary Git-store harness |
+| **Total** | **28 leaf cases** | **2** | |
+
+### Changed File Coverage
+
+| File | Statement coverage | Rating |
+|---|---:|---|
+| `internal/sddstatus/review_gate.go` | 81.6% | ⚠️ Acceptable |
+| `internal/sddstatus/status.go` | 73.1% | ⚠️ Low |
+| Embedded Markdown assets | Contract-tested | ➖ N/A |
+
+Coverage is informational. The changed high-risk predicates and routing functions have direct runtime coverage: `skipsObservedStalePredecessor` 100%, `authorityOnlyFailedReport` 100%, `authorityChangedSinceReport` 100%, and `applyPreVerifyCompactBridgeRouting` 100%.
+
+### Assertion Quality
+
+**Assertion quality**: ✅ All changed assertions execute production behavior and verify values, routing, side effects, or exact embedded contracts. No tautologies, orphan empty checks, ghost loops, smoke-only assertions, or mock-heavy files were found.
+
+### Quality Metrics
+
+**Linter**: ➖ No dedicated linter configured
+**Type checker / vet**: ✅ No errors
+**Formatter**: ✅ No changed Go files reported
+**Diff hygiene**: ✅ No tracked or OpenSpec artifact whitespace findings before this report rewrite
+
+### Issues Found
+
+**CRITICAL**: None.
+
+**WARNING**
+
+1. `internal/sddstatus/status.go` has 73.1% statement coverage. This is informational under Strict TDD; all changed authority-recovery decision points are directly covered.
+2. Archive remains intentionally blocked: native status reports multiple terminal receipts and requires explicit receipt reconciliation. Verification passed, but this report does not authorize archive by itself.
+
+**SUGGESTION**: None.
+
+### Verdict
+
+**PASS WITH WARNINGS**
+
+The remediation closes both prior CRITICAL findings. All requirements, scenarios, and tasks are satisfied; focused and full runtime checks pass; invalidated and escalated observed predecessors remain denied; and only the exact scope-changed predecessor can be skipped. Archive may be considered only through the normal post-verification receipt/evidence flow.


### PR DESCRIPTION
## Linked Issue

Closes #1179

## PR Type

- [x] `type:bug` - Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` - New feature (non-breaking change that adds functionality)
- [ ] `type:docs` - Documentation only
- [ ] `type:refactor` - Code refactoring (no functional changes)
- [ ] `type:chore` - Build, CI, or tooling changes
- [ ] `type:breaking-change` - Breaking change (fix or feature that changes existing behavior)

## Summary

- Recover pre-verification from one valid stale compact authority while rejecting invalidated, escalated, allowed, or revision-mismatched predecessors.
- Emit the structured `sdd-verify` result envelope and document the recovered authority behavior.
- Add focused regression coverage and the complete OpenSpec implementation and verification evidence.

## Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/sddstatus` | Recover compact predecessor authority only for a proven scope change and expose the structured verification result. |
| `internal/assets/skills/sdd-verify` | Document and embed the updated verification contract and report format. |
| `openspec/changes/sdd-compact-authority-recovery` | Record proposal, design, tasks, apply evidence, delta spec, and passing verification report. |

## Test Plan

- [x] Focused compact-authority recovery tests pass.
- [x] Full suite passes: `go test -count=1 ./...`.
- [x] Static analysis passes: `go vet ./...`.
- [x] Formatting and tracked/OpenSpec diff hygiene pass.
- [x] Runtime harness: N/A; this change affects CLI review-gate state transitions covered by Go integration tests rather than a separate runtime boundary.

## Contributor Checklist

- [x] PR is linked to issue #1179 with `status:approved`.
- [x] Maintainer approved a 950 authored-line ceiling; this reviewed change is 933 authored lines and carries `size:exception`.
- [x] Exactly one `type:*` label is applied: `type:bug`.
- [x] Unit tests pass.
- [x] E2E tests are not applicable; the affected CLI boundary is covered by focused and full Go tests.
- [x] Documentation is updated with the behavior change.
- [x] Commit follows Conventional Commits.
- [x] Commit contains no `Co-Authored-By` trailer.

## Notes for Reviewers

The bounded full-4R review was approved under receipt `review-b7c232eaba8256b2` with zero findings. The `pre-commit`, `pre-push`, and `pre-pr` publication gates all validated that same content-bound receipt; no new review was started.

Rollback boundary: revert commit `b3a1563611d3c257c91e9109bb8cf39f54f07203` to remove the compact-authority recovery behavior, tests, documentation, and OpenSpec evidence as one independent work unit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added compact review-authority discovery for verification workflows.
  - Verification can now proceed directly when exactly one valid, path-bound authority is available.
  - Added fail-closed handling for missing, ambiguous, stale, malformed, or mismatched authority records.
  - Added structured authority-only preflight denial reporting with required recovery details and exit codes.

- **Documentation**
  - Documented the authority-only preflight denial format, including command execution requirements and recovery fields.

- **Tests**
  - Added comprehensive coverage for authority discovery, validation, recovery, and routing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->