### PR TITLE
fix(review): verify explicit pre-PR publication boundaries

### DIFF
--- a/internal/cli/review_facade_test.go
+++ b/internal/cli/review_facade_test.go
@@ -183,6 +183,42 @@ func TestReviewFacadeStartSupportsCommittedBaseDiff(t *testing.T) {
 	if err := RunReviewFacadeValidate([]string{"--cwd", repo, "--lineage", result.LineageID, "--gate", string(reviewtransaction.GatePrePR), "--base-ref", base}, &output); err != nil {
 		t.Fatalf("pre-pr base diff gate: %v\n%s", err, output.String())
 	}
+	output.Reset()
+	if err := RunReviewFacadeValidate([]string{"--cwd", repo, "--lineage", result.LineageID, "--gate", string(reviewtransaction.GatePrePR), "--base-ref", "missing-reviewed-base"}, &output); err == nil {
+		t.Fatal("unavailable pre-PR base was authorized")
+	}
+	var denied ReviewValidateResult
+	if err := json.Unmarshal(output.Bytes(), &denied); err != nil {
+		t.Fatal(err)
+	}
+	if denied.Allowed || denied.Context.LineageID != result.LineageID || denied.Context.PrePRBoundary == nil || denied.Context.PrePRBoundary.Selector != "missing-reviewed-base" || denied.Context.Denial == nil || denied.Context.Denial.Code != "unavailable" {
+		t.Fatalf("facade unavailable base denial = %#v", denied)
+	}
+}
+
+func TestReviewFacadeDeniedGateRetainsObservedBoundaryWithoutAuthorizing(t *testing.T) {
+	var output bytes.Buffer
+	evaluation := reviewtransaction.NativeGateEvaluation{
+		Result: reviewtransaction.GateInvalidated,
+		Reason: "current repository target cannot be derived: explicit base is unavailable",
+		Context: reviewtransaction.GateContext{
+			Gate: reviewtransaction.GatePrePR, LineageID: "review-boundary-context", Generation: 1,
+			PrePRBoundary: &reviewtransaction.PrePRBoundarySelection{
+				Source: reviewtransaction.PrePRBoundaryExplicit, Selector: "reviewed-base", Commit: strings.Repeat("a", 40),
+			},
+			Denial: &reviewtransaction.GateDenial{Stage: "boundary-selection", Code: "unavailable"},
+		},
+	}
+	if err := emitFacadeGateEvaluation(&output, evaluation); err == nil {
+		t.Fatal("denied gate returned success")
+	}
+	var result ReviewValidateResult
+	if err := json.Unmarshal(output.Bytes(), &result); err != nil {
+		t.Fatal(err)
+	}
+	if result.Allowed || result.Result != reviewtransaction.GateInvalidated || result.Context.PrePRBoundary == nil || result.Context.PrePRBoundary.Commit != strings.Repeat("a", 40) || result.Context.Denial == nil || result.Context.Denial.Code != "unavailable" {
+		t.Fatalf("denied boundary result = %#v", result)
+	}
 }
 
 func TestReviewFacadeStartRejectsInvalidBaseRefWithoutPersistingLineage(t *testing.T) {

--- a/internal/reviewtransaction/compact_gate.go
+++ b/internal/reviewtransaction/compact_gate.go
@@ -31,11 +31,24 @@ func EvaluateCompactGate(ctx context.Context, repo string, receipt CompactReceip
 	if err != nil || !compactReceiptEqual(authoritative, receipt) {
 		return invalid("compact receipt does not match current authority")
 	}
+	denialContext := GateContext{
+		Gate: input.Gate, LineageID: receipt.LineageID, Generation: receipt.Generation,
+		StoreRevision: record.Revision, GenesisRevision: record.Revision, ChainIdentity: record.Revision, BundleDigest: record.Revision,
+		BaseTree: receipt.BaseTree, CandidateTree: receipt.FinalCandidateTree, PathsDigest: receipt.PathsDigest,
+		FixDeltaHash: receipt.FixDeltaHash, PolicyHash: receipt.PolicyHash, LedgerHash: EmptyFixDeltaHash, EvidenceHash: receipt.EvidenceHash,
+	}
+	if input.Gate == GatePrePR && strings.TrimSpace(input.BaseRef) != "" {
+		denialContext.PrePRBoundary = &PrePRBoundarySelection{Source: PrePRBoundaryExplicit, Selector: strings.TrimSpace(input.BaseRef)}
+	}
 	if receipt.TerminalState == TerminalEscalated {
 		return NativeGateEvaluation{Result: GateEscalated, Reason: nativeGateReason(GateEscalated)}
 	}
 	request, err := buildCompactGateRequest(ctx, repo, record.State, input)
 	if err != nil {
+		if input.Gate == GatePrePR {
+			denialContext.Denial = &GateDenial{Stage: "boundary-selection", Code: "unavailable"}
+			return NativeGateEvaluation{Result: GateInvalidated, Reason: "compact gate inputs cannot be derived: " + err.Error(), Context: denialContext}
+		}
 		return invalid("compact gate inputs cannot be derived: " + err.Error())
 	}
 	if (request.Gate == GatePostApply || request.Gate == GatePreCommit) && !equalStrings(request.Target.IntendedUntracked, record.State.CurrentSnapshot.IntendedUntracked) {
@@ -64,11 +77,25 @@ func EvaluateCompactGate(ctx context.Context, repo string, receipt CompactReceip
 			compatibleAdvance = proof.Compatible
 		}
 	}
+	gateContext := GateContext{
+		Gate: request.Gate, LineageID: receipt.LineageID, Generation: receipt.Generation,
+		StoreRevision: record.Revision, GenesisRevision: record.Revision, ChainIdentity: record.Revision, BundleDigest: record.Revision,
+		BaseTree: snapshot.BaseTree, CandidateTree: snapshot.CandidateTree, PathsDigest: snapshot.PathsDigest,
+		FixDeltaHash: record.State.FixDeltaHash, PolicyHash: record.State.PolicyHash,
+		LedgerHash: EmptyFixDeltaHash, EvidenceHash: record.State.EvidenceHash,
+		BaseRelationshipValid: snapshot.BaseTree == receipt.BaseTree, BaseAdvance: compatibility,
+	}
+	if request.Gate == GatePrePR && resolvedPrePR != nil {
+		boundary := resolvedPrePR.Selection
+		gateContext.PrePRBoundary = &boundary
+	}
 	if (snapshot.CandidateTree != receipt.FinalCandidateTree || snapshot.PathsDigest != receipt.PathsDigest) && !compatibleAdvance {
-		return NativeGateEvaluation{Result: GateScopeChanged, Reason: nativeGateReason(GateScopeChanged)}
+		gateContext.Denial = &GateDenial{Stage: "receipt-binding", Code: "candidate-or-paths-mismatch"}
+		return NativeGateEvaluation{Result: GateScopeChanged, Reason: nativeGateReason(GateScopeChanged), Context: gateContext}
 	}
 	if snapshot.BaseTree != receipt.BaseTree && !compatibleAdvance {
-		return invalid("current repository base no longer matches compact authority")
+		gateContext.Denial = &GateDenial{Stage: "receipt-binding", Code: "base-mismatch"}
+		return NativeGateEvaluation{Result: GateInvalidated, Reason: "current repository base no longer matches compact authority", Context: gateContext}
 	}
 	var release *ReleaseEvidence
 	if request.Gate == GateRelease {
@@ -81,14 +108,7 @@ func EvaluateCompactGate(ctx context.Context, repo string, receipt CompactReceip
 		}
 		release = &derived
 	}
-	gateContext := GateContext{
-		Gate: request.Gate, LineageID: receipt.LineageID, Generation: receipt.Generation,
-		StoreRevision: record.Revision, GenesisRevision: record.Revision, ChainIdentity: record.Revision, BundleDigest: record.Revision,
-		BaseTree: snapshot.BaseTree, CandidateTree: snapshot.CandidateTree, PathsDigest: snapshot.PathsDigest,
-		FixDeltaHash: record.State.FixDeltaHash, PolicyHash: record.State.PolicyHash,
-		LedgerHash: EmptyFixDeltaHash, EvidenceHash: record.State.EvidenceHash,
-		BaseRelationshipValid: snapshot.BaseTree == receipt.BaseTree, BaseAdvance: compatibility, Release: release,
-	}
+	gateContext.Release = release
 	finalGateAuthorizationHook()
 	finalRecord, loadErr := store.Load()
 	finalSnapshot, finalRefs, snapshotErr := buildLifecycleSnapshot(ctx, repo, request)
@@ -121,23 +141,11 @@ func buildCompactGateRequest(ctx context.Context, repo string, state CompactStat
 		}
 		request.Target = Target{Kind: TargetExactRevision, Revision: head}
 	case GatePrePR:
-		_, _, baseCommit, err := resolveAuthoritativePublicationBase(ctx, repo)
+		target, prePR, err := buildPrePRTarget(ctx, repo, input.BaseRef, input.PrePRCIAttestation, state.InitialSnapshot.IntendedUntracked)
 		if err != nil {
 			return GateRequest{}, err
 		}
-		if strings.TrimSpace(input.BaseRef) != "" {
-			expected, expectedErr := resolveCommit(ctx, repo, input.BaseRef)
-			if expectedErr != nil || expected != baseCommit {
-				return GateRequest{}, errors.New("compact pre-PR base does not match the remote publication boundary")
-			}
-		}
-		request.Target = Target{
-			Kind: TargetBaseDiff, BaseRef: baseCommit,
-			IntendedUntracked: append([]string(nil), state.InitialSnapshot.IntendedUntracked...),
-		}
-		if strings.TrimSpace(input.PrePRCIAttestation) != "" {
-			request.PrePR = &PrePRRequest{CIAttestationArtifact: input.PrePRCIAttestation}
-		}
+		request.Target, request.PrePR = target, prePR
 	case GateRelease:
 		head, err := resolveCommit(ctx, repo, "HEAD")
 		if err != nil {

--- a/internal/reviewtransaction/compact_gate_test.go
+++ b/internal/reviewtransaction/compact_gate_test.go
@@ -274,6 +274,86 @@ func TestCompactGateFinalRecheckRejectsConcurrentAuthorityAndGitChanges(t *testi
 	}
 }
 
+func TestCompactPrePRGatePreservesBoundaryContextForExactAndUnavailableSelectors(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	writeSnapshotFile(t, repo, "tracked.txt", "candidate\n")
+	gitSnapshot(t, repo, "add", "tracked.txt")
+	gitSnapshot(t, repo, "commit", "-m", "candidate")
+	state, _, receipt := approvedCompactRevisionFixture(t, repo, "compact-pre-pr-boundary")
+	base := trimGit(gitSnapshot(t, repo, "rev-parse", "HEAD^"))
+
+	exact := EvaluateCompactGate(context.Background(), repo, receipt, NativeGateRequestInput{Gate: GatePrePR, LineageID: state.LineageID, BaseRef: base})
+	if exact.Result != GateAllow || exact.Context.PrePRBoundary == nil || exact.Context.PrePRBoundary.Commit != base {
+		t.Fatalf("exact compact pre-PR boundary = %#v", exact)
+	}
+
+	unavailable := EvaluateCompactGate(context.Background(), repo, receipt, NativeGateRequestInput{Gate: GatePrePR, LineageID: state.LineageID, BaseRef: "missing-reviewed-base"})
+	if unavailable.Result != GateInvalidated || unavailable.Context.LineageID != state.LineageID || unavailable.Context.PrePRBoundary == nil || unavailable.Context.PrePRBoundary.Selector != "missing-reviewed-base" || unavailable.Context.Denial == nil || unavailable.Context.Denial.Code != "unavailable" {
+		t.Fatalf("unavailable compact pre-PR boundary = %#v", unavailable)
+	}
+	payload, err := json.Marshal(unavailable.Context)
+	if err != nil {
+		t.Fatal(err)
+	}
+	parsed, err := ParseGateContext(payload)
+	if err != nil || !reflect.DeepEqual(parsed, unavailable.Context) {
+		t.Fatalf("unavailable compact pre-PR context round trip = %#v, %v", parsed, err)
+	}
+
+	mismatched := EvaluateCompactGate(context.Background(), repo, receipt, NativeGateRequestInput{Gate: GatePrePR, LineageID: state.LineageID, BaseRef: "HEAD"})
+	if mismatched.Result == GateAllow || mismatched.Context.PrePRBoundary == nil || mismatched.Context.PrePRBoundary.Selector != "HEAD" || mismatched.Context.Denial == nil || mismatched.Context.Denial.Stage != "receipt-binding" {
+		t.Fatalf("mismatched compact pre-PR boundary = %#v", mismatched)
+	}
+}
+
+func TestCompactPrePRGateAllowsOnlyAttestedCompatibleSelectedBaseAdvance(t *testing.T) {
+	fixture := newCompatiblePrePRFixture(t, "delivery.txt", "base-only.txt")
+	state, receipt := approvedCompactPrePRFixture(t, fixture)
+	input := NativeGateRequestInput{
+		Gate: GatePrePR, LineageID: state.LineageID, BaseRef: "main",
+		PolicyArtifact: fixture.request.PolicyArtifact, PrePRCIAttestation: fixture.attestationPath,
+	}
+	allowed := EvaluateCompactGate(context.Background(), fixture.repo, receipt, input)
+	if allowed.Result != GateAllow || allowed.Context.BaseAdvance == nil || !allowed.Context.BaseAdvance.Compatible || allowed.Context.PrePRBoundary == nil || allowed.Context.PrePRBoundary.Commit == fixture.originalBaseCommit {
+		t.Fatalf("attested compact compatible advance = %#v", allowed)
+	}
+	input.PrePRCIAttestation = ""
+	if denied := EvaluateCompactGate(context.Background(), fixture.repo, receipt, input); denied.Result == GateAllow {
+		t.Fatalf("unattested compact compatible advance = %#v", denied)
+	}
+}
+
+func TestCompactPrePRGateInvalidatesSelectedBaseAndHeadRaces(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		mutate func(t *testing.T, fixture *compatiblePrePRFixture)
+	}{
+		{name: "selected base moves", mutate: func(t *testing.T, fixture *compatiblePrePRFixture) {
+			gitSnapshot(t, fixture.repo, "update-ref", "refs/heads/main", fixture.originalBaseCommit)
+		}},
+		{name: "head moves", mutate: func(t *testing.T, fixture *compatiblePrePRFixture) {
+			gitSnapshot(t, fixture.repo, "commit", "--allow-empty", "-m", "move head")
+		}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			fixture := newCompatiblePrePRFixture(t, "delivery.txt", "base-only.txt")
+			state, receipt := approvedCompactPrePRFixture(t, fixture)
+			originalHook := finalGateAuthorizationHook
+			finalGateAuthorizationHook = func() {
+				finalGateAuthorizationHook = originalHook
+				tt.mutate(t, fixture)
+			}
+			t.Cleanup(func() { finalGateAuthorizationHook = originalHook })
+			got := EvaluateCompactGate(context.Background(), fixture.repo, receipt, NativeGateRequestInput{
+				Gate: GatePrePR, LineageID: state.LineageID, BaseRef: "main", PolicyArtifact: fixture.request.PolicyArtifact, PrePRCIAttestation: fixture.attestationPath,
+			})
+			if got.Result != GateInvalidated {
+				t.Fatalf("compact %s = %#v", tt.name, got)
+			}
+		})
+	}
+}
+
 func approvedCompactRevisionFixture(t *testing.T, repo, lineage string) (CompactState, CompactStore, CompactReceipt) {
 	t.Helper()
 	state := newCompactRevisionState(t, repo, lineage)
@@ -345,4 +425,60 @@ func approvedCompactCurrentChangesFixture(t *testing.T, repo, lineage string, in
 		t.Fatal(err)
 	}
 	return state, store, receipt
+}
+
+func approvedCompactPrePRFixture(t *testing.T, fixture *compatiblePrePRFixture) (CompactState, CompactReceipt) {
+	t.Helper()
+	snapshot, err := (SnapshotBuilder{Repo: fixture.repo}).Build(context.Background(), Target{Kind: TargetBaseDiff, BaseRef: fixture.originalBaseCommit})
+	if err != nil {
+		t.Fatal(err)
+	}
+	risk, lines, err := (SnapshotBuilder{Repo: fixture.repo}).ClassifySnapshotRisk(context.Background(), snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lenses := []string{}
+	if risk == RiskMedium {
+		lenses = []string{LensReliability}
+	} else if risk == RiskHigh {
+		lenses = append([]string(nil), supportedLenses...)
+	}
+	policyHash, err := HashArtifact(fixture.request.PolicyArtifact)
+	if err != nil {
+		t.Fatal(err)
+	}
+	state, err := NewCompactState(Start{LineageID: "compact-compatible-base", Mode: ModeOrdinaryBounded, Generation: 1, Snapshot: snapshot, PolicyHash: policyHash, RiskLevel: risk, SelectedLenses: lenses, OriginalChangedLines: &lines})
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := CompactAuthoritativeStore(context.Background(), fixture.repo, state.LineageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	revision, err := store.Replace("", "review/start", state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	results := make([]LensResult, len(state.SelectedLenses))
+	for index, lens := range state.SelectedLenses {
+		results[index] = LensResult{Lens: lens, Findings: []Finding{}, Evidence: []string{"review complete"}}
+	}
+	if err := state.CompleteReview(CompactReviewInput{LensResults: results, Classifications: []FindingEvidence{}, RefuterOutcomes: []EvidenceResult{}}); err != nil {
+		t.Fatal(err)
+	}
+	revision, err = store.Replace(revision, "review/complete-review", state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := state.CompleteVerification([]byte("independent verification passed\n"), true); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Replace(revision, "review/complete-verification", state); err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := state.Receipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return state, receipt
 }

--- a/internal/reviewtransaction/gate.go
+++ b/internal/reviewtransaction/gate.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 )
@@ -40,7 +41,25 @@ type GateRequest struct {
 }
 
 type PrePRRequest struct {
-	CIAttestationArtifact string `json:"ci_attestation_artifact"`
+	CIAttestationArtifact string                  `json:"ci_attestation_artifact"`
+	Boundary              *PrePRBoundarySelection `json:"boundary,omitempty"`
+}
+
+type PrePRBoundarySource string
+
+const (
+	PrePRBoundaryExplicit           PrePRBoundarySource = "explicit"
+	PrePRBoundaryPublicationDefault PrePRBoundarySource = "publication-default"
+)
+
+// PrePRBoundarySelection records how the immutable pre-PR range boundary was
+// selected. It is evidence only; receipt binding still authorizes the range.
+type PrePRBoundarySelection struct {
+	Source    PrePRBoundarySource `json:"source"`
+	Selector  string              `json:"selector"`
+	Commit    string              `json:"commit"`
+	Remote    string              `json:"remote,omitempty"`
+	RemoteRef string              `json:"remote_ref,omitempty"`
 }
 
 type ReleaseRequest struct {
@@ -144,6 +163,16 @@ func EvaluateNativeGate(ctx context.Context, repo string, receipt Receipt, reque
 	if !reflect.DeepEqual(authoritativeReceipt, receipt) {
 		return invalid("receipt does not match the authoritative transaction revision")
 	}
+	denialContext := GateContext{
+		Gate: request.Gate, LineageID: record.Transaction.LineageID, Generation: record.Transaction.Generation,
+		StoreRevision: revision, GenesisRevision: chain.GenesisRevision, ChainIdentity: chain.Identity, BundleDigest: bundleDigest,
+		BaseTree: receipt.BaseTree, CandidateTree: receipt.FinalCandidateTree, PathsDigest: receipt.PathsDigest,
+		FixDeltaHash: receipt.FixDeltaHash, PolicyHash: receipt.PolicyHash, LedgerHash: receipt.LedgerHash, EvidenceHash: receipt.EvidenceHash,
+	}
+	if request.Gate == GatePrePR && request.PrePR != nil && request.PrePR.Boundary != nil {
+		boundary := *request.PrePR.Boundary
+		denialContext.PrePRBoundary = &boundary
+	}
 	if request.Gate == GatePreCommit && request.Target.Kind != TargetCurrentChanges {
 		return invalid("pre-commit target must derive current repository changes")
 	}
@@ -157,6 +186,10 @@ func EvaluateNativeGate(ctx context.Context, repo string, receipt Receipt, reque
 	artifactPreimagesReadHook()
 	snapshot, resolvedPrePR, err := buildLifecycleSnapshot(ctx, repo, request)
 	if err != nil {
+		if request.Gate == GatePrePR {
+			denialContext.Denial = &GateDenial{Stage: "boundary-selection", Code: "unavailable"}
+			return NativeGateEvaluation{Result: GateInvalidated, Reason: "current repository target cannot be derived: " + err.Error(), Context: denialContext}
+		}
 		return invalid("current repository target cannot be derived: " + err.Error())
 	}
 	if request.Gate == GatePrePush && record.Transaction.Snapshot.Kind == TargetCurrentChanges && snapshot.BaseTree == snapshot.CandidateTree {
@@ -201,6 +234,10 @@ func EvaluateNativeGate(ctx context.Context, repo string, receipt Receipt, reque
 		BaseRelationshipValid: snapshot.BaseTree == receipt.BaseTree,
 		ExternalEvidence:      request.ExternalEvidence,
 	}
+	if request.Gate == GatePrePR && resolvedPrePR != nil {
+		boundary := resolvedPrePR.Selection
+		gateContext.PrePRBoundary = &boundary
+	}
 	if request.Gate == GatePrePR && snapshot.BaseTree != receipt.BaseTree {
 		if compatibility, compatibilityErr := deriveBaseAdvanceCompatibility(ctx, repo, receipt, request, snapshot, resolvedPrePR, preimages); compatibilityErr == nil {
 			gateContext.BaseAdvance = &compatibility
@@ -217,6 +254,9 @@ func EvaluateNativeGate(ctx context.Context, repo string, receipt Receipt, reque
 		gateContext.Release = &release
 	}
 	result := validateDerivedGate(receipt, gateContext)
+	if request.Gate == GatePrePR && result != GateAllow {
+		gateContext.Denial = &GateDenial{Stage: "receipt-binding", Code: string(result)}
+	}
 	if result == GateAllow {
 		finalGateAuthorizationHook()
 		finalSnapshot, finalRefs, err := buildLifecycleSnapshot(ctx, repo, request)
@@ -229,9 +269,7 @@ func EvaluateNativeGate(ctx context.Context, repo string, receipt Receipt, reque
 }
 
 type resolvedPrePRRefs struct {
-	BaseRef    string
-	Remote     string
-	BaseCommit string
+	Selection  PrePRBoundarySelection
 	HeadCommit string
 }
 
@@ -245,11 +283,7 @@ func buildLifecycleSnapshot(ctx context.Context, repo string, request GateReques
 	if err != nil || request.Gate != GatePrePR {
 		return snapshot, nil, err
 	}
-	configured, err := publicationRemoteConfigured(ctx, repo)
-	if err != nil || !configured {
-		return snapshot, nil, err
-	}
-	baseRef, remote, base, err := resolveAuthoritativePublicationBase(ctx, repo)
+	selection, err := prePRBoundaryForRequest(ctx, repo, request)
 	if err != nil {
 		return Snapshot{}, nil, err
 	}
@@ -258,12 +292,66 @@ func buildLifecycleSnapshot(ctx context.Context, repo string, request GateReques
 		return Snapshot{}, nil, err
 	}
 	snapshot, err = (SnapshotBuilder{Repo: repo}).Build(ctx, Target{
-		Kind: TargetBaseDiff, BaseRef: base, IntendedUntracked: target.IntendedUntracked,
+		Kind: TargetBaseDiff, BaseRef: selection.Commit, IntendedUntracked: target.IntendedUntracked,
 	})
 	if err != nil {
 		return Snapshot{}, nil, err
 	}
-	return snapshot, &resolvedPrePRRefs{BaseRef: baseRef, Remote: remote, BaseCommit: base, HeadCommit: head}, nil
+	return snapshot, &resolvedPrePRRefs{Selection: selection, HeadCommit: head}, nil
+}
+
+func prePRBoundaryForRequest(ctx context.Context, repo string, request GateRequest) (PrePRBoundarySelection, error) {
+	if request.PrePR != nil && request.PrePR.Boundary != nil {
+		selection := *request.PrePR.Boundary
+		selector := ""
+		switch selection.Source {
+		case PrePRBoundaryExplicit:
+			selector = selection.Selector
+		case PrePRBoundaryPublicationDefault:
+		default:
+			return PrePRBoundarySelection{}, errors.New("unsupported pre-PR boundary source")
+		}
+		resolved, err := selectPrePRBoundary(ctx, repo, selector)
+		if err != nil {
+			return PrePRBoundarySelection{}, err
+		}
+		if resolved != selection {
+			return PrePRBoundarySelection{}, errors.New("pre-PR boundary changed during validation")
+		}
+		return resolved, nil
+	}
+	if request.PrePR == nil && strings.TrimSpace(request.Target.BaseRef) != "" {
+		return selectPrePRBoundary(ctx, repo, request.Target.BaseRef)
+	}
+	return selectPrePRBoundary(ctx, repo, "")
+}
+
+func selectPrePRBoundary(ctx context.Context, repo, selector string) (PrePRBoundarySelection, error) {
+	selector = strings.TrimSpace(selector)
+	if selector != "" {
+		if filepath.IsAbs(selector) {
+			return PrePRBoundarySelection{}, errors.New("explicit pre-PR base selector must not be an absolute path")
+		}
+		commit, err := resolveCommit(ctx, repo, selector)
+		if err != nil {
+			return PrePRBoundarySelection{}, fmt.Errorf("resolve explicit pre-PR base %q: %w", selector, err)
+		}
+		return PrePRBoundarySelection{Source: PrePRBoundaryExplicit, Selector: selector, Commit: commit}, nil
+	}
+	ref, remote, commit, err := resolveAuthoritativePublicationBase(ctx, repo)
+	if err != nil {
+		return PrePRBoundarySelection{}, err
+	}
+	return PrePRBoundarySelection{Source: PrePRBoundaryPublicationDefault, Selector: ref, Commit: commit, Remote: remote, RemoteRef: ref}, nil
+}
+
+func buildPrePRTarget(ctx context.Context, repo, selector, ciAttestation string, intendedUntracked []string) (Target, *PrePRRequest, error) {
+	selection, err := selectPrePRBoundary(ctx, repo, selector)
+	if err != nil {
+		return Target{}, nil, err
+	}
+	return Target{Kind: TargetBaseDiff, BaseRef: selection.Commit, IntendedUntracked: append([]string(nil), intendedUntracked...)},
+		&PrePRRequest{CIAttestationArtifact: ciAttestation, Boundary: &selection}, nil
 }
 
 func publicationRemoteConfigured(ctx context.Context, repo string) (bool, error) {

--- a/internal/reviewtransaction/gate_test.go
+++ b/internal/reviewtransaction/gate_test.go
@@ -228,6 +228,182 @@ func TestExplicitPrePRRequestWithoutRemotePreservesUnchangedBase(t *testing.T) {
 	}
 }
 
+func TestSelectPrePRBoundaryUsesExactExplicitOrPublicationDefaultCommit(t *testing.T) {
+	fixture := newCompatiblePrePRFixture(t, "delivery.txt", "base-only.txt")
+
+	tests := []struct {
+		name     string
+		selector string
+		want     PrePRBoundarySelection
+	}{
+		{
+			name:     "explicit old reviewed base",
+			selector: fixture.originalBaseCommit,
+			want: PrePRBoundarySelection{
+				Source: PrePRBoundaryExplicit, Selector: fixture.originalBaseCommit, Commit: fixture.originalBaseCommit,
+			},
+		},
+		{
+			name: "publication default without selector",
+			want: PrePRBoundarySelection{
+				Source: PrePRBoundaryPublicationDefault, Selector: "refs/heads/main", Commit: trimGit(gitSnapshot(t, fixture.repo, "rev-parse", "main")), Remote: "origin", RemoteRef: "refs/heads/main",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := selectPrePRBoundary(context.Background(), fixture.repo, tt.selector)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tt.want {
+				t.Fatalf("selectPrePRBoundary(%q) = %#v, want %#v", tt.selector, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSelectPrePRBoundaryRejectsAbsolutePathLikeSelector(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	if _, err := selectPrePRBoundary(context.Background(), repo, filepath.Join(repo, "outside")); err == nil {
+		t.Fatal("absolute path-like selector was accepted")
+	}
+}
+
+func TestSelectPrePRBoundaryUsesRepositoryRootForSubdirectoriesAndRelativeSelectors(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	writeSnapshotFile(t, repo, "tracked.txt", "candidate\n")
+	gitSnapshot(t, repo, "add", "tracked.txt")
+	gitSnapshot(t, repo, "commit", "-m", "candidate")
+	want := trimGit(gitSnapshot(t, repo, "rev-parse", "HEAD~1"))
+	subdirectory := filepath.Join(repo, "nested", "work")
+	if err := os.MkdirAll(subdirectory, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, location := range []string{repo, subdirectory} {
+		selection, err := selectPrePRBoundary(context.Background(), location, "HEAD~1")
+		if err != nil || selection.Source != PrePRBoundaryExplicit || selection.Commit != want {
+			t.Fatalf("selectPrePRBoundary(%q) = %#v, %v", location, selection, err)
+		}
+	}
+}
+
+func TestBuildNativePrePRRequestKeepsExplicitReviewedBaseWhenDefaultAdvanced(t *testing.T) {
+	fixture := newCompatiblePrePRFixture(t, "delivery.txt", "base-only.txt")
+
+	request, err := BuildNativeGateRequest(context.Background(), fixture.repo, NativeGateRequestInput{
+		Gate: GatePrePR, LineageID: fixture.receipt.LineageID, BaseRef: fixture.originalBaseCommit,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if request.Target.BaseRef != fixture.originalBaseCommit || request.PrePR == nil || request.PrePR.Boundary == nil || *request.PrePR.Boundary != (PrePRBoundarySelection{
+		Source: PrePRBoundaryExplicit, Selector: fixture.originalBaseCommit, Commit: fixture.originalBaseCommit,
+	}) {
+		t.Fatalf("explicit pre-PR request = %#v", request)
+	}
+	if evaluation := EvaluateNativeGate(context.Background(), fixture.repo, fixture.receipt, request); evaluation.Result != GateAllow || evaluation.Context.PrePRBoundary == nil || *evaluation.Context.PrePRBoundary != *request.PrePR.Boundary {
+		t.Fatalf("explicit pre-PR evaluation = %#v", evaluation)
+	}
+}
+
+func TestNativePrePRGateInvalidatesWhenExplicitSelectorMoves(t *testing.T) {
+	fixture := newCompatiblePrePRFixture(t, "delivery.txt", "base-only.txt")
+	request, err := BuildNativeGateRequest(context.Background(), fixture.repo, NativeGateRequestInput{
+		Gate: GatePrePR, LineageID: fixture.receipt.LineageID, BaseRef: "main",
+		PolicyArtifact: fixture.request.PolicyArtifact, LedgerArtifact: fixture.request.LedgerArtifact,
+		EvidenceArtifact: fixture.request.EvidenceArtifact, PrePRCIAttestation: fixture.attestationPath,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	originalHook := finalGateAuthorizationHook
+	finalGateAuthorizationHook = func() {
+		finalGateAuthorizationHook = originalHook
+		gitSnapshot(t, fixture.repo, "update-ref", "refs/heads/main", fixture.originalBaseCommit)
+	}
+	t.Cleanup(func() { finalGateAuthorizationHook = originalHook })
+
+	if got := EvaluateNativeGate(context.Background(), fixture.repo, fixture.receipt, request); got.Result != GateInvalidated {
+		t.Fatalf("moving explicit selector = %#v", got)
+	}
+}
+
+func TestNativePrePRGateInvalidatesWhenCommitAMovesHead(t *testing.T) {
+	fixture := newCompatiblePrePRFixture(t, "delivery.txt", "base-only.txt")
+	request, err := BuildNativeGateRequest(context.Background(), fixture.repo, NativeGateRequestInput{
+		Gate: GatePrePR, LineageID: fixture.receipt.LineageID, BaseRef: fixture.originalBaseCommit,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	originalHook := finalGateAuthorizationHook
+	finalGateAuthorizationHook = func() {
+		finalGateAuthorizationHook = originalHook
+		writeSnapshotFile(t, fixture.repo, fixture.deliveryPath, "changed after review\n")
+		gitSnapshot(t, fixture.repo, "commit", "-am", "move head")
+	}
+	t.Cleanup(func() { finalGateAuthorizationHook = originalHook })
+
+	if got := EvaluateNativeGate(context.Background(), fixture.repo, fixture.receipt, request); got.Result != GateInvalidated {
+		t.Fatalf("commit -a head movement = %#v", got)
+	}
+}
+
+func TestNativePrePRGateIgnoresStagedAndEmptyIndexState(t *testing.T) {
+	fixture := newCompatiblePrePRFixture(t, "delivery.txt", "base-only.txt")
+	request, err := BuildNativeGateRequest(context.Background(), fixture.repo, NativeGateRequestInput{
+		Gate: GatePrePR, LineageID: fixture.receipt.LineageID, BaseRef: fixture.originalBaseCommit,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeSnapshotFile(t, fixture.repo, "staged-only.txt", "index does not authorize\n")
+	gitSnapshot(t, fixture.repo, "add", "staged-only.txt")
+	if staged := EvaluateNativeGate(context.Background(), fixture.repo, fixture.receipt, request); staged.Result != GateAllow || staged.Context.CandidateTree != fixture.receipt.FinalCandidateTree {
+		t.Fatalf("staged-only pre-PR gate = %#v", staged)
+	}
+	gitSnapshot(t, fixture.repo, "reset", "--", "staged-only.txt")
+	if empty := EvaluateNativeGate(context.Background(), fixture.repo, fixture.receipt, request); empty.Result != GateAllow || empty.Context.CandidateTree != fixture.receipt.FinalCandidateTree {
+		t.Fatalf("empty-index pre-PR gate = %#v", empty)
+	}
+}
+
+func TestNativePrePRGateDenialRetainsAuthorityAndObservedBoundary(t *testing.T) {
+	fixture := newCompatiblePrePRFixture(t, "delivery.txt", "base-only.txt")
+	request, err := BuildNativeGateRequest(context.Background(), fixture.repo, NativeGateRequestInput{
+		Gate: GatePrePR, LineageID: fixture.receipt.LineageID, BaseRef: fixture.originalBaseCommit,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.PrePR.Boundary.Selector = "missing-reviewed-base"
+
+	got := EvaluateNativeGate(context.Background(), fixture.repo, fixture.receipt, request)
+	if got.Result != GateInvalidated || got.Context.LineageID != fixture.receipt.LineageID || got.Context.PrePRBoundary == nil || got.Context.PrePRBoundary.Selector != "missing-reviewed-base" || got.Context.Denial == nil || got.Context.Denial.Stage != "boundary-selection" || got.Context.Denial.Code != "unavailable" {
+		t.Fatalf("unavailable explicit boundary = %#v", got)
+	}
+}
+
+func TestNativePrePRGateAnnotatesReceiptBindingDenial(t *testing.T) {
+	fixture := newCompatiblePrePRFixture(t, "delivery.txt", "base-only.txt")
+	request, err := BuildNativeGateRequest(context.Background(), fixture.repo, NativeGateRequestInput{
+		Gate: GatePrePR, LineageID: fixture.receipt.LineageID, BaseRef: "main",
+		PolicyArtifact: fixture.request.PolicyArtifact, LedgerArtifact: fixture.request.LedgerArtifact,
+		EvidenceArtifact: fixture.request.EvidenceArtifact, PrePRCIAttestation: fixture.attestationPath,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeSnapshotFile(t, fixture.repo, fixture.deliveryPath, "changed delivery\n")
+	gitSnapshot(t, fixture.repo, "commit", "-am", "change delivery")
+	got := EvaluateNativeGate(context.Background(), fixture.repo, fixture.receipt, request)
+	if got.Result == GateAllow || got.Context.PrePRBoundary == nil || got.Context.Denial == nil || got.Context.Denial.Stage != "receipt-binding" {
+		t.Fatalf("receipt-binding denial = %#v", got)
+	}
+}
+
 func TestPublicationRemoteUsesGitPushPrecedence(t *testing.T) {
 	repo := initSnapshotRepo(t)
 	branch := strings.TrimSpace(gitSnapshot(t, repo, "symbolic-ref", "--short", "HEAD"))
@@ -243,6 +419,46 @@ func TestPublicationRemoteUsesGitPushPrecedence(t *testing.T) {
 	remote, configured, err := publicationRemote(context.Background(), repo)
 	if err != nil || !configured || remote != "branch-push" {
 		t.Fatalf("publicationRemote() = %q, %v, %v", remote, configured, err)
+	}
+}
+
+func TestPublicationRemotePreservesTrackingFirstPushAndExplicitRefspecAuthority(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		configure func(t *testing.T, repo, branch string)
+		want      string
+	}{
+		{
+			name: "tracking branch", want: "tracking",
+			configure: func(t *testing.T, repo, branch string) {
+				gitSnapshot(t, repo, "remote", "add", "tracking", filepath.Join(t.TempDir(), "tracking.git"))
+				gitSnapshot(t, repo, "config", "branch."+branch+".remote", "tracking")
+			},
+		},
+		{
+			name: "first push configuration", want: "publish",
+			configure: func(t *testing.T, repo, branch string) {
+				gitSnapshot(t, repo, "remote", "add", "publish", filepath.Join(t.TempDir(), "publish.git"))
+				gitSnapshot(t, repo, "config", "branch."+branch+".pushRemote", "publish")
+			},
+		},
+		{
+			name: "explicit refspec retains origin", want: "origin",
+			configure: func(t *testing.T, repo, _ string) {
+				gitSnapshot(t, repo, "remote", "add", "origin", filepath.Join(t.TempDir(), "origin.git"))
+				gitSnapshot(t, repo, "config", "remote.origin.push", "refs/heads/main:refs/heads/main")
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := initSnapshotRepo(t)
+			branch := strings.TrimSpace(gitSnapshot(t, repo, "symbolic-ref", "--short", "HEAD"))
+			tt.configure(t, repo, branch)
+			got, configured, err := publicationRemote(context.Background(), repo)
+			if err != nil || !configured || got != tt.want {
+				t.Fatalf("publicationRemote() = %q, %v, %v; want %q", got, configured, err, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/reviewtransaction/native_request.go
+++ b/internal/reviewtransaction/native_request.go
@@ -85,20 +85,11 @@ func BuildNativeGateRequest(ctx context.Context, repo string, input NativeGateRe
 		}
 		request.Target = Target{Kind: TargetExactRevision, Revision: head}
 	case GatePrePR:
-		_, _, baseCommit, err := resolveAuthoritativePublicationBase(ctx, repo)
+		target, prePR, err := buildPrePRTarget(ctx, repo, input.BaseRef, input.PrePRCIAttestation, nil)
 		if err != nil {
 			return GateRequest{}, err
 		}
-		if strings.TrimSpace(input.BaseRef) != "" {
-			expected, expectedErr := resolveCommit(ctx, repo, input.BaseRef)
-			if expectedErr != nil || expected != baseCommit {
-				return GateRequest{}, errors.New("native pre-PR base does not match the remote publication boundary")
-			}
-		}
-		request.Target = Target{Kind: TargetBaseDiff, BaseRef: baseCommit}
-		if strings.TrimSpace(input.PrePRCIAttestation) != "" {
-			request.PrePR = &PrePRRequest{CIAttestationArtifact: input.PrePRCIAttestation}
-		}
+		request.Target, request.PrePR = target, prePR
 	case GateRelease:
 		head, err := resolveCommit(ctx, repo, "HEAD")
 		if err != nil {

--- a/internal/reviewtransaction/prepr.go
+++ b/internal/reviewtransaction/prepr.go
@@ -65,7 +65,7 @@ func deriveBaseAdvanceCompatibility(ctx context.Context, repo string, receipt Re
 	if request.PrePR == nil || strings.TrimSpace(request.PrePR.CIAttestationArtifact) == "" {
 		return BaseAdvanceCompatibility{}, errors.New("trusted CI attestation is required")
 	}
-	mergeBase, err := runGit(ctx, repo, nil, nil, "merge-base", refs.BaseCommit, refs.HeadCommit)
+	mergeBase, err := runGit(ctx, repo, nil, nil, "merge-base", refs.Selection.Commit, refs.HeadCommit)
 	if err != nil {
 		return BaseAdvanceCompatibility{}, fmt.Errorf("derive original merge-base: %w", err)
 	}
@@ -101,7 +101,7 @@ func deriveBaseAdvanceCompatibility(ctx context.Context, repo string, receipt Re
 	if !disjointPaths(originalPaths, basePaths) {
 		return BaseAdvanceCompatibility{}, errors.New("base advance overlaps delivered paths")
 	}
-	mergedOutput, err := runGit(ctx, repo, nil, nil, "merge-tree", "--write-tree", refs.BaseCommit, refs.HeadCommit)
+	mergedOutput, err := runGit(ctx, repo, nil, nil, "merge-tree", "--write-tree", refs.Selection.Commit, refs.HeadCommit)
 	if err != nil {
 		return BaseAdvanceCompatibility{}, errors.New("merge against new base is not conflict-free")
 	}
@@ -113,8 +113,12 @@ func deriveBaseAdvanceCompatibility(ctx context.Context, repo string, receipt Re
 	if err != nil {
 		return BaseAdvanceCompatibility{}, err
 	}
-	baseRefNow, remoteNow, baseNow, err := resolveAuthoritativePublicationBase(ctx, repo)
-	if err != nil || baseRefNow != refs.BaseRef || remoteNow != refs.Remote || baseNow != refs.BaseCommit {
+	selector := ""
+	if refs.Selection.Source == PrePRBoundaryExplicit {
+		selector = refs.Selection.Selector
+	}
+	selectionNow, err := selectPrePRBoundary(ctx, repo, selector)
+	if err != nil || selectionNow != refs.Selection {
 		return BaseAdvanceCompatibility{}, errors.New("pre-PR base ref advanced during validation")
 	}
 	headNow, err := resolveCommit(ctx, repo, "HEAD")

--- a/internal/reviewtransaction/receipt.go
+++ b/internal/reviewtransaction/receipt.go
@@ -164,6 +164,15 @@ type GateContext struct {
 	ExternalEvidence      ExternalEvidenceDisposition `json:"external_evidence,omitempty"`
 	BaseAdvance           *BaseAdvanceCompatibility   `json:"base_advanced_compatible,omitempty"`
 	Release               *ReleaseEvidence            `json:"release,omitempty"`
+	PrePRBoundary         *PrePRBoundarySelection     `json:"pre_pr_boundary,omitempty"`
+	Denial                *GateDenial                 `json:"denial,omitempty"`
+}
+
+// GateDenial identifies the non-authorizing validation stage that rejected a
+// gate request. Its presence never changes the gate result.
+type GateDenial struct {
+	Stage string `json:"stage"`
+	Code  string `json:"code"`
 }
 
 func validateDerivedGate(receipt Receipt, context GateContext) GateResult {
@@ -238,6 +247,17 @@ func ParseGateContext(payload []byte) (GateContext, error) {
 		if context.Gate != GatePrePR || !context.BaseAdvance.valid() {
 			return GateContext{}, errors.New("gate context contains invalid compatible base advance evidence")
 		}
+	}
+	if context.PrePRBoundary != nil {
+		boundary := context.PrePRBoundary
+		unavailable := boundary.Commit == "" && context.Denial != nil && context.Denial.Stage == "boundary-selection" && context.Denial.Code == "unavailable"
+		if context.Gate != GatePrePR || (!validGitTree(boundary.Commit) && !unavailable) || strings.TrimSpace(boundary.Selector) == "" ||
+			(boundary.Source != PrePRBoundaryExplicit && boundary.Source != PrePRBoundaryPublicationDefault) {
+			return GateContext{}, errors.New("gate context contains invalid pre-PR boundary evidence")
+		}
+	}
+	if context.Denial != nil && (strings.TrimSpace(context.Denial.Stage) == "" || strings.TrimSpace(context.Denial.Code) == "") {
+		return GateContext{}, errors.New("gate context denial requires stage and code")
 	}
 	switch context.ExternalEvidence {
 	case ExternalEvidenceNone, ExternalEvidenceInvalidating, ExternalEvidenceEscalating:


### PR DESCRIPTION
## Linked Issue

Closes #1167

## PR Type

- [x] `type:bug` - Bug fix

## Summary

- Resolves explicit pre-PR base selectors to immutable commits for stacked PRs.
- Keeps exact receipt binding or the existing signed compatible-base proof as the only authorization paths.
- Preserves actionable boundary and denial context while rechecking refs, HEAD, snapshots, and authority before allow.

## Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/reviewtransaction` | Shared explicit/default boundary selection, authorization rechecks, denial context, and regression coverage |
| `internal/cli` | Verified facade JSON retains non-authorizing boundary context |

## Test Plan

- [x] `go test -count=1 ./internal/reviewtransaction ./internal/cli`
- [x] `go test -count=1 ./...`
- [x] `go vet ./...`
- [x] Changed Go files pass `gofmt`; `git diff --check` passes
- [ ] Local Docker E2E unavailable because Docker is not installed; required GitHub E2E checks must pass before merge

## Contributor Checklist

- [x] PR is linked to issue #1167 with `status:approved`
- [x] Maintainer-approved `size:exception` requested for cross-gate Git fixtures and TOCTOU coverage
- [x] Exactly one `type:*` label will be applied
- [x] Unit tests pass
- [x] Documentation is not required for this internal gate correction
- [x] Commit follows Conventional Commits and has no `Co-Authored-By` trailer

## Notes for Reviewers

The review found and fixed one additional contract bug: unavailable explicit selectors emit an empty commit by definition, so `ParseGateContext` now accepts that shape only for `boundary-selection/unavailable` denials.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Pre-PR reviews now retain and report the selected base boundary, including when the referenced base is unavailable.
  * Gate results provide clearer denial details and distinguish unavailable, scope-changed, and invalidated states.
  * Pre-PR advancement is permitted only when the selected base remains compatible and has the required attestation.
  * Reviews are invalidated when the selected base or review head changes during authorization.
  * Boundary and denial evidence is validated when review results are parsed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->