### PR TITLE
fix(upgrade): retry npm ERESOLVE conflicts safely

### DIFF
--- a/internal/update/upgrade/strategy.go
+++ b/internal/update/upgrade/strategy.go
@@ -162,12 +162,39 @@ func opencodePluginUpgrade(ctx context.Context, r update.UpdateResult) error {
 	cmd.Stdin = nil
 	cmd.Env = openCodePluginUpgradeEnv(cmd.Env)
 	if out, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("%s upgrade %s in %s: %w (output: %s)", pm, pkg, opencodeDir, err, string(out))
+		outStr := string(out)
+		if pm == "npm" && npmErrorCode(outStr) == "ERESOLVE" {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			default:
+			}
+			fmt.Fprintln(os.Stderr, "WARNING: npm reported an ERESOLVE peer dependency conflict; retrying with --legacy-peer-deps")
+			retryCmd := execCommand("npm", append([]string{"install", "--save", "--no-audit", "--no-fund", "--legacy-peer-deps"}, targets...)...)
+			retryCmd.Dir = opencodeDir
+			retryCmd.Stdin = nil
+			retryCmd.Env = openCodePluginUpgradeEnv(retryCmd.Env)
+			if retryOut, retryErr := retryCmd.CombinedOutput(); retryErr != nil {
+				return fmt.Errorf("%s upgrade %s in %s: retry with --legacy-peer-deps failed: %w (retry output: %s); original error: %v (original output: %s)", pm, pkg, opencodeDir, retryErr, string(retryOut), err, outStr)
+			}
+		} else {
+			return fmt.Errorf("%s upgrade %s in %s: %w (output: %s)", pm, pkg, opencodeDir, err, outStr)
+		}
 	}
 	if err := clearOpenCodePluginPackageCache(homeDir, pkg); err != nil {
 		return fmt.Errorf("clear OpenCode package cache for %s: %w", pkg, err)
 	}
 	return nil
+}
+
+func npmErrorCode(output string) string {
+	for _, line := range strings.Split(output, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) == 4 && fields[0] == "npm" && fields[1] == "error" && fields[2] == "code" {
+			return fields[3]
+		}
+	}
+	return ""
 }
 
 func openCodePluginRegisteredOrMaterialized(opencodeDir, pkg string) (bool, bool, error) {

--- a/internal/update/upgrade/strategy_test.go
+++ b/internal/update/upgrade/strategy_test.go
@@ -3,8 +3,7 @@ package upgrade
 import (
 	"context"
 	"errors"
-	"github.com/gentleman-programming/gentle-ai/internal/system"
-	"github.com/gentleman-programming/gentle-ai/internal/update"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -13,6 +12,9 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/internal/system"
+	"github.com/gentleman-programming/gentle-ai/internal/update"
 )
 
 func TestMain(m *testing.M) {
@@ -688,6 +690,153 @@ func TestRunStrategyOpenCodePluginRegisteredPendingRunsPackageManager(t *testing
 	if strings.Join(gotArgs, " ") != strings.Join(wantArgs, " ") {
 		t.Fatalf("exec args = %v, want %v", gotArgs, wantArgs)
 	}
+}
+
+func TestRunStrategyOpenCodePluginNpmERESOLVERetriesWithLegacyPeerDeps(t *testing.T) {
+	var callHistory [][]string
+	configureOpenCodeNpmTest(t, func(name string, args ...string) *exec.Cmd {
+		callHistory = append(callHistory, append([]string{name}, args...))
+		if len(callHistory) == 1 {
+			return failingCmd("npm error code ERESOLVE\nnpm error ERESOLVE could not resolve")
+		}
+		return mockCmd("true")
+	})
+
+	readStderr, writeStderr, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	origStderr := os.Stderr
+	os.Stderr = writeStderr
+	t.Cleanup(func() { os.Stderr = origStderr })
+
+	_, upgradeErr := runStrategy(context.Background(), openCodePluginUpdateResult("opencode-sdd-engram-manage"), system.PlatformProfile{})
+	os.Stderr = origStderr
+	if err := writeStderr.Close(); err != nil {
+		t.Fatal(err)
+	}
+	warning, err := io.ReadAll(readStderr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := readStderr.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if upgradeErr != nil {
+		t.Fatalf("unexpected error on retry: %v", upgradeErr)
+	}
+	if !strings.Contains(string(warning), "WARNING:") || !strings.Contains(string(warning), "--legacy-peer-deps") {
+		t.Fatalf("stderr = %q, want visible legacy peer dependency warning", warning)
+	}
+	if len(callHistory) != 2 {
+		t.Fatalf("expected 2 exec calls (initial + retry), got %d", len(callHistory))
+	}
+	wantRetry := []string{"npm", "install", "--save", "--no-audit", "--no-fund", "--legacy-peer-deps", "opencode-sdd-engram-manage@latest", "@opencode-ai/plugin@latest"}
+	if strings.Join(callHistory[1], " ") != strings.Join(wantRetry, " ") {
+		t.Fatalf("retry command = %v, want %v", callHistory[1], wantRetry)
+	}
+}
+
+func TestRunStrategyOpenCodePluginNpmERESOLVERetryFailurePreservesBothErrors(t *testing.T) {
+	configureOpenCodeNpmTest(t, func(name string, args ...string) *exec.Cmd {
+		if slicesContain(args, "--legacy-peer-deps") {
+			return failingCmd("retry failed")
+		}
+		return failingCmd("npm error code ERESOLVE\noriginal conflict")
+	})
+
+	_, err := runStrategy(context.Background(), openCodePluginUpdateResult("opencode-sdd-engram-manage"), system.PlatformProfile{})
+	if err == nil {
+		t.Fatal("expected retry failure")
+	}
+	for _, want := range []string{"retry failed", "original conflict", "original error", "retry with --legacy-peer-deps failed"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not contain %q", err, want)
+		}
+	}
+}
+
+func TestRunStrategyOpenCodePluginNpmNonERESOLVEDoesNotRetry(t *testing.T) {
+	calls := 0
+	configureOpenCodeNpmTest(t, func(name string, args ...string) *exec.Cmd {
+		calls++
+		return failingCmd("npm error package code ERESOLVE helper failed")
+	})
+
+	_, err := runStrategy(context.Background(), openCodePluginUpdateResult("opencode-sdd-engram-manage"), system.PlatformProfile{})
+	if err == nil {
+		t.Fatal("expected npm failure")
+	}
+	if calls != 1 {
+		t.Fatalf("exec calls = %d, want 1 without retry", calls)
+	}
+}
+
+func TestRunStrategyOpenCodePluginNpmERESOLVEDoesNotRetryAfterCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var callHistory [][]string
+	configureOpenCodeNpmTest(t, func(name string, args ...string) *exec.Cmd {
+		callHistory = append(callHistory, append([]string{name}, args...))
+		cancel()
+		return failingCmd("npm error code ERESOLVE")
+	})
+
+	_, err := runStrategy(ctx, openCodePluginUpdateResult("opencode-sdd-engram-manage"), system.PlatformProfile{})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want context.Canceled", err)
+	}
+	if len(callHistory) != 1 {
+		t.Fatalf("exec calls = %d, want 1 without retry", len(callHistory))
+	}
+	if slicesContain(callHistory[0], "--legacy-peer-deps") {
+		t.Fatalf("initial command unexpectedly includes --legacy-peer-deps: %v", callHistory[0])
+	}
+}
+
+func configureOpenCodeNpmTest(t *testing.T, command func(string, ...string) *exec.Cmd) {
+	t.Helper()
+	origHomeDir, origLookPath, origExecCommand := openCodeHomeDir, lookPathCommand, execCommand
+	t.Cleanup(func() {
+		openCodeHomeDir, lookPathCommand, execCommand = origHomeDir, origLookPath, origExecCommand
+	})
+	home := t.TempDir()
+	opencodeDir := filepath.Join(home, ".config", "opencode")
+	if err := os.MkdirAll(opencodeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(opencodeDir, "tui.json"), []byte(`{"plugin":["opencode-sdd-engram-manage"]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	openCodeHomeDir = func() (string, error) { return home, nil }
+	lookPathCommand = func(file string) (string, error) {
+		if file == "npm" {
+			return file, nil
+		}
+		return "", errors.New("not found")
+	}
+	execCommand = command
+}
+
+func openCodePluginUpdateResult(pkg string) update.UpdateResult {
+	return update.UpdateResult{Tool: update.ToolInfo{Name: pkg, InstallMethod: update.InstallOpenCodePlugin, NpmPackage: pkg}, Status: update.RegisteredNotMaterialized}
+}
+
+func slicesContain(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+func failingCmd(output string) *exec.Cmd {
+	if runtime.GOOS == "windows" {
+		return exec.Command("cmd", "/c", "echo "+strings.ReplaceAll(output, "\n", " & echo ")+" & exit /b 1")
+	}
+	return exec.Command("sh", "-c", "printf '%s\\n' \"$1\"; exit 1", "sh", output)
 }
 
 func TestRunStrategyOpenCodePluginFallsBackWithoutPackageManager(t *testing.T) {


### PR DESCRIPTION
## Linked Issue

Closes #831

Supersedes #977 with the unrelated #962 Windows-test scope removed.

## PR Type

- [x] `type:bug` - Bug fix

## Summary

- Retries npm OpenCode plugin upgrades with `--legacy-peer-deps` only after an exact `ERESOLVE` error code.
- Emits a visible warning and rechecks cancellation before entering the fallback.
- Preserves both original and retry failures when the fallback also fails.

## Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/update/upgrade/strategy.go` | Added tightly scoped npm ERESOLVE fallback and exact error-code parsing |
| `internal/update/upgrade/strategy_test.go` | Covered success, warning, retry failure, unrelated errors, exact arguments, and cancellation |

## Test Plan

- [x] `go test -count=1 ./internal/update/upgrade`
- [x] `go test -count=1 ./...`
- [x] `go vet ./...`
- [x] `GOOS=windows GOARCH=amd64 go test -c ./internal/update/upgrade`
- [x] `gofmt` and `git diff --check`

## Contributor Checklist

- [x] Linked issue #831 has `status:approved`
- [x] Exactly one `type:*` label will be applied
- [x] PR stays below the 400 changed-line review budget
- [x] Tests and documentation requirements are satisfied
- [x] Commit follows Conventional Commits and has no `Co-Authored-By` trailer

## Notes for Reviewers

This replacement preserves Matías as the commit author. The implementation is derived from #977's ERESOLVE commits, with one added cancellation regression requested during the final maintainer review. It intentionally excludes every file and commit from #962.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved plugin upgrades affected by npm peer-dependency conflicts.
  * Automatically retries failed upgrades with legacy peer-dependency handling when appropriate.
  * Displays a warning when the fallback retry is used.
  * Preserves both the original and retry errors when an upgrade still fails.
  * Avoids unnecessary retries for unrelated failures or cancelled operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->