### PR TITLE
test(upgrade): use platform GGA backup paths

### DIFF
--- a/internal/update/upgrade/executor_test.go
+++ b/internal/update/upgrade/executor_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/gentleman-programming/gentle-ai/internal/backup"
+	"github.com/gentleman-programming/gentle-ai/internal/components/gga"
 	"github.com/gentleman-programming/gentle-ai/internal/model"
 	"github.com/gentleman-programming/gentle-ai/internal/state"
 	"github.com/gentleman-programming/gentle-ai/internal/system"
@@ -856,8 +857,12 @@ func TestConfigPathsForBackup_CoversRegistryAgentsNotInOldList(t *testing.T) {
 func TestConfigPathsForBackup_GGAExtrasAreIncluded(t *testing.T) {
 	homeDir := t.TempDir()
 
-	// Create GGA config file at ~/.config/gga/config
-	ggaConfigFile := filepath.Join(homeDir, ".config", "gga", "config")
+	if runtime.GOOS == "windows" {
+		t.Setenv("APPDATA", filepath.Join(homeDir, "AppData", "Roaming"))
+	}
+
+	// Create GGA config file at the platform-appropriate path
+	ggaConfigFile := gga.ConfigPath(homeDir)
 	if err := os.MkdirAll(filepath.Dir(ggaConfigFile), 0o755); err != nil {
 		t.Fatalf("MkdirAll gga config: %v", err)
 	}
@@ -865,8 +870,8 @@ func TestConfigPathsForBackup_GGAExtrasAreIncluded(t *testing.T) {
 		t.Fatalf("WriteFile gga config: %v", err)
 	}
 
-	// Create GGA runtime lib file at ~/.local/share/gga/lib/pr_mode.sh
-	ggaLibFile := filepath.Join(homeDir, ".local", "share", "gga", "lib", "pr_mode.sh")
+	// Create GGA runtime lib file at the platform-appropriate path
+	ggaLibFile := gga.RuntimePRModePath(homeDir)
 	if err := os.MkdirAll(filepath.Dir(ggaLibFile), 0o755); err != nil {
 		t.Fatalf("MkdirAll gga lib: %v", err)
 	}


### PR DESCRIPTION
## Linked Issue

Closes #960

Supersedes #962 with its unrelated Windows test-isolation scope removed.

## PR Type

- [x] `type:bug` - Bug fix

## Summary

- Builds the GGA backup fixture with the same platform-aware path helpers used by production.
- Isolates Windows `APPDATA` inside the test home.
- Keeps the approved fix to one test file.

## Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/update/upgrade/executor_test.go` | Replaced hardcoded Unix GGA paths with `gga.ConfigPath` and `gga.RuntimePRModePath` |

## Test Plan

- [x] Focused GGA backup-path test passes
- [x] `go test -count=1 ./...`
- [x] `go vet ./...`
- [x] Windows amd64 package test compilation passes
- [x] `gofmt` and `git diff --check`

## Contributor Checklist

- [x] Linked issue #960 has `status:approved`
- [x] Exactly one `type:*` label will be applied
- [x] PR stays below the 400 changed-line review budget
- [x] Commit follows Conventional Commits and has no `Co-Authored-By` trailer

## Notes for Reviewers

This replacement preserves Matías as the commit author and contains only the specific path correction approved in #960. The other nine files from #962 remain intentionally excluded.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved cross-platform coverage for GGA backup-path validation.
  * Updated test setup to use platform-appropriate configuration and runtime file locations, including Windows-specific environment handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->