### PR TITLE
fix(review): classify service-token changes as high risk

### DIFF
--- a/internal/cli/review_facade_test.go
+++ b/internal/cli/review_facade_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -193,6 +194,55 @@ func TestReviewFacadeStartSupportsCommittedBaseDiff(t *testing.T) {
 	}
 	if denied.Allowed || denied.Context.LineageID != result.LineageID || denied.Context.PrePRBoundary == nil || denied.Context.PrePRBoundary.Selector != "missing-reviewed-base" || denied.Context.Denial == nil || denied.Context.Denial.Code != "unavailable" {
 		t.Fatalf("facade unavailable base denial = %#v", denied)
+	}
+}
+
+func TestReviewFacadeStartServiceTokenSelectsCanonicalHighRiskLenses(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	neutral := filepath.Join(repo, "neutral")
+	if err := os.MkdirAll(neutral, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(neutral, "service-token.ts"), []byte("export const token = 'candidate'\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	hostile := initReviewCLIRepo(t)
+	for name, value := range map[string]string{
+		"GIT_DIR": filepath.Join(hostile, ".git"), "GIT_WORK_TREE": hostile,
+		"GIT_COMMON_DIR": filepath.Join(hostile, ".git"), "GIT_INDEX_FILE": filepath.Join(hostile, ".git", "index"),
+		"GIT_REPLACE_REF_BASE": filepath.Join(hostile, "replace"),
+	} {
+		t.Setenv(name, value)
+	}
+	workingDirectory, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	relative, err := filepath.Rel(workingDirectory, repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{reviewtransaction.LensRisk, reviewtransaction.LensResilience, reviewtransaction.LensReadability, reviewtransaction.LensReliability}
+	for index, cwd := range []string{repo, neutral, relative} {
+		var output bytes.Buffer
+		if err := RunReviewFacadeStart([]string{"--cwd", cwd, "--lineage", fmt.Sprintf("service-token-%d", index)}, &output); err != nil {
+			t.Fatalf("facade start from %q: %v", cwd, err)
+		}
+		var started ReviewFacadeStartResult
+		if err := json.Unmarshal(output.Bytes(), &started); err != nil {
+			t.Fatal(err)
+		}
+		store, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, started.LineageID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		record, err := store.Load()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if record.State.RiskLevel != reviewtransaction.RiskHigh || !reflect.DeepEqual(record.State.SelectedLenses, want) {
+			t.Fatalf("facade service-token state from %q = risk %q lenses %v, want high %v", cwd, record.State.RiskLevel, record.State.SelectedLenses, want)
+		}
 	}
 }
 

--- a/internal/reviewtransaction/compact_store_test.go
+++ b/internal/reviewtransaction/compact_store_test.go
@@ -88,6 +88,43 @@ func TestCompactStoreFailsClosedForCorruptionAndIgnoresInvalidTempState(t *testi
 	}
 }
 
+func TestCompactStoreRejectsForgedServiceTokenRiskDowngrade(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	writeSnapshotFile(t, repo, "neutral/service-token.ts", "export const token = 'candidate'\n")
+	snapshot, err := (SnapshotBuilder{Repo: repo}).Build(context.Background(), Target{Kind: TargetCurrentChanges, IntendedUntracked: []string{"neutral/service-token.ts"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines, err := (SnapshotBuilder{Repo: repo}).ChangedLines(context.Background(), snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	state, err := NewCompactState(Start{
+		LineageID: "compact-service-token-forgery", Mode: ModeOrdinaryBounded, Generation: 1,
+		Snapshot: snapshot, PolicyHash: hash("1"), RiskLevel: RiskMedium,
+		SelectedLenses: []string{LensReliability}, OriginalChangedLines: &lines,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := CompactAuthoritativeStore(context.Background(), repo, state.LineageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Replace("", "review/start", state); err == nil || !errors.Is(err, ErrInvalidSuccessor) {
+		t.Fatalf("forged medium service-token state error = %v, want invalid successor", err)
+	}
+	for _, lenses := range [][]string{{LensRisk}, {LensReliability, LensReadability, LensResilience, LensRisk}} {
+		if _, err := NewCompactState(Start{
+			LineageID: "compact-service-token-invalid-high", Mode: ModeOrdinaryBounded, Generation: 1,
+			Snapshot: snapshot, PolicyHash: hash("1"), RiskLevel: RiskHigh,
+			SelectedLenses: lenses, OriginalChangedLines: &lines,
+		}); err == nil {
+			t.Fatalf("invalid high-risk lenses %v were accepted", lenses)
+		}
+	}
+}
+
 func TestCompactStateRejectsChecksumValidImpossibleSemantics(t *testing.T) {
 	repo := initSnapshotRepo(t)
 	valid := correctedCompactTestState(t, repo, "compact-semantic-invalid")

--- a/internal/reviewtransaction/risk.go
+++ b/internal/reviewtransaction/risk.go
@@ -12,6 +12,12 @@ import (
 const LargeChangeLines = 400
 const MaxCorrectionChangedLines = 200
 
+var semanticSourceExtensions = map[string]struct{}{
+	".c": {}, ".cc": {}, ".cpp": {}, ".cs": {}, ".go": {}, ".h": {}, ".hpp": {},
+	".java": {}, ".js": {}, ".jsx": {}, ".kt": {}, ".kts": {}, ".php": {}, ".py": {},
+	".rb": {}, ".rs": {}, ".sh": {}, ".bash": {}, ".zsh": {}, ".ts": {}, ".tsx": {},
+}
+
 type RiskLevel string
 
 const (
@@ -119,6 +125,7 @@ func (builder SnapshotBuilder) ClassifySnapshotRisk(ctx context.Context, snapsho
 	if err != nil {
 		return "", 0, err
 	}
+	signals := deriveSemanticRiskSignals(stats)
 	onlyNonExecutable := true
 	touchesConfiguration := false
 	for _, stat := range stats {
@@ -129,9 +136,71 @@ func (builder SnapshotBuilder) ClassifySnapshotRisk(ctx context.Context, snapsho
 		touchesConfiguration = touchesConfiguration || isConfigurationReviewPath(stat.Path)
 	}
 	risk, err := ClassifyRisk(RiskInput{
-		Stats: stats, OnlyNonExecutableChanges: onlyNonExecutable, TouchesConfiguration: touchesConfiguration,
+		Stats: stats, Signals: signals, OnlyNonExecutableChanges: onlyNonExecutable, TouchesConfiguration: touchesConfiguration,
 	})
 	return risk, changedLines, err
+}
+
+func deriveSemanticRiskSignals(stats []DiffStat) []RiskSignal {
+	for _, stat := range stats {
+		if !isSemanticRiskEligible(stat) {
+			continue
+		}
+		for _, segment := range strings.Split(stat.Path, "/") {
+			if hasAdjacentServiceTokenTokens(stripSemanticPathExtension(segment)) {
+				return []RiskSignal{SignalAuth}
+			}
+		}
+	}
+	return nil
+}
+
+func isSemanticRiskEligible(stat DiffStat) bool {
+	if stat.Additions+stat.Deletions == 0 || stat.Binary || stat.ModeOnly || stat.Generated || isGeneratedGoldenPath(stat.Path) {
+		return false
+	}
+	segments := strings.Split(stat.Path, "/")
+	for _, segment := range segments {
+		lower := asciiLower(segment)
+		if lower == "docs" || lower == "testdata" || lower == "fixture" || lower == "fixtures" || lower == "__fixtures__" {
+			return false
+		}
+	}
+	base := asciiLower(filepath.Base(stat.Path))
+	if strings.HasPrefix(base, "readme") {
+		return false
+	}
+	if _, ok := semanticSourceExtensions[asciiLower(filepath.Ext(stat.Path))]; ok {
+		return true
+	}
+	return isConfigurationReviewPath(stat.Path)
+}
+
+func stripSemanticPathExtension(segment string) string {
+	extension := asciiLower(filepath.Ext(segment))
+	if _, source := semanticSourceExtensions[extension]; source || isConfigurationReviewPath(segment) {
+		return strings.TrimSuffix(segment, filepath.Ext(segment))
+	}
+	return segment
+}
+
+func hasAdjacentServiceTokenTokens(segment string) bool {
+	tokens := strings.FieldsFunc(asciiLower(segment), func(r rune) bool { return r == '-' || r == '_' })
+	for index := 0; index+1 < len(tokens); index++ {
+		if tokens[index] == "service" && tokens[index+1] == "token" {
+			return true
+		}
+	}
+	return false
+}
+
+func asciiLower(value string) string {
+	return strings.Map(func(r rune) rune {
+		if r >= 'A' && r <= 'Z' {
+			return r + ('a' - 'A')
+		}
+		return r
+	}, value)
 }
 
 func (builder SnapshotBuilder) ChangedLines(ctx context.Context, snapshot Snapshot) (int, error) {

--- a/internal/reviewtransaction/risk_test.go
+++ b/internal/reviewtransaction/risk_test.go
@@ -1,8 +1,10 @@
 package reviewtransaction
 
 import (
+	"context"
 	"fmt"
 	"math"
+	"reflect"
 	"testing"
 )
 
@@ -86,6 +88,72 @@ func TestConfigurationReviewPathRecognizesDotEnvVariants(t *testing.T) {
 				t.Fatalf("isConfigurationReviewPath(%q) = %t, want %t", tt.path, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestDeriveSemanticRiskSignalsRecognizesEligibleServiceTokenPaths(t *testing.T) {
+	tests := []struct {
+		name  string
+		stats []DiffStat
+		want  []RiskSignal
+	}{
+		{name: "underscore Go source", stats: []DiffStat{{Path: "internal/identity/service_token.go", Additions: 1}}, want: []RiskSignal{SignalAuth}},
+		{name: "hyphen TypeScript source", stats: []DiffStat{{Path: "internal/identity/service-token.ts", Additions: 1}}, want: []RiskSignal{SignalAuth}},
+		{name: "configuration path", stats: []DiffStat{{Path: "config/service-token.yaml", Additions: 1}}, want: []RiskSignal{SignalAuth}},
+		{name: "deletion-only source", stats: []DiffStat{{Path: "internal/identity/service-token.ts", Deletions: 1}}, want: []RiskSignal{SignalAuth}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := deriveSemanticRiskSignals(tt.stats); !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("deriveSemanticRiskSignals() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDeriveSemanticRiskSignalsRejectsIneligibleAndAmbiguousPaths(t *testing.T) {
+	tests := []struct {
+		name string
+		stat DiffStat
+	}{
+		{name: "joined token", stat: DiffStat{Path: "internal/identity/servicetoken.go", Additions: 1}},
+		{name: "cross segment token", stat: DiffStat{Path: "internal/service/token.go", Additions: 1}},
+		{name: "zero change", stat: DiffStat{Path: "internal/identity/service-token.ts"}},
+		{name: "binary", stat: DiffStat{Path: "internal/identity/service-token.ts", Additions: 1, Binary: true}},
+		{name: "mode only", stat: DiffStat{Path: "internal/identity/service-token.ts", Additions: 1, ModeOnly: true}},
+		{name: "generated golden", stat: DiffStat{Path: "testdata/golden/service-token.golden", Additions: 1, Generated: true}},
+		{name: "fixture", stat: DiffStat{Path: "fixtures/service-token.ts", Additions: 1}},
+		{name: "testdata", stat: DiffStat{Path: "testdata/service-token.ts", Additions: 1}},
+		{name: "requirements prose", stat: DiffStat{Path: "service-token-requirements.txt", Additions: 1}},
+		{name: "CMake prose", stat: DiffStat{Path: "service-token-CMakeLists.txt", Additions: 1}},
+		{name: "executable MDX", stat: DiffStat{Path: "service-token.mdx", Additions: 1}},
+		{name: "README shell", stat: DiffStat{Path: "README-service-token.sh", Additions: 1}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := deriveSemanticRiskSignals([]DiffStat{tt.stat}); len(got) != 0 {
+				t.Fatalf("deriveSemanticRiskSignals() = %v, want no signals", got)
+			}
+		})
+	}
+}
+
+func TestClassifySnapshotRiskDerivesAuthAfterCountingCanonicalStats(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	writeSnapshotFile(t, repo, "neutral/service-token.ts", "export const token = 'candidate'\n")
+	snapshot, err := (SnapshotBuilder{Repo: repo}).Build(context.Background(), Target{Kind: TargetCurrentChanges, IntendedUntracked: []string{"neutral/service-token.ts"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	risk, lines, err := (SnapshotBuilder{Repo: repo}).ClassifySnapshotRisk(context.Background(), snapshot)
+	if err != nil || risk != RiskHigh || lines >= LargeChangeLines {
+		t.Fatalf("ClassifySnapshotRisk() = %q, %d, %v; want high below %d lines", risk, lines, err, LargeChangeLines)
+	}
+}
+
+func TestClassifySnapshotRiskRejectsMalformedStatsBeforeSemanticDerivation(t *testing.T) {
+	if _, err := CountChangedLines([]DiffStat{{Path: "neutral/../service-token.ts", Additions: 1}}); err == nil {
+		t.Fatal("CountChangedLines() accepted noncanonical path")
 	}
 }
 


### PR DESCRIPTION
## Linked Issue

Closes #1155

## PR Type

- [x] `type:bug` - Bug fix

## Summary

- Classifies eligible `service-token` and `service_token` source/config paths as authentication risk.
- Routes those snapshots to HIGH with the canonical four review lenses.
- Keeps docs, fixtures, generated files, binary/mode-only changes, and ambiguous names on existing risk rules.

## Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/reviewtransaction/risk.go` | Added deterministic path-based semantic signal derivation using existing immutable `DiffStat` evidence |
| Risk/store/facade tests | Covered positive routing, false-positive exclusions, forged downgrade rejection, and repository-context hardening |

## Test Plan

- [x] Focused reviewtransaction classifier/store tests
- [x] Focused facade runtime test
- [x] `go test -count=1 ./...`
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] Changed-file `gofmt` and `git diff --check`
- [x] SDD verification PASS: 1/1 requirement, 6/6 scenarios, 10/10 tasks

## Contributor Checklist

- [x] Linked issue #1155 has `status:approved`
- [x] Exactly one `type:*` label will be applied
- [x] PR stays below the 400 changed-line review budget
- [x] Commit follows Conventional Commits and has no `Co-Authored-By` trailer

## Notes for Reviewers

This deliberately adds no CLI override, policy DSL, Git subprocess, persisted signal, state transition, schema change, or lineage migration. Existing lineages remain untouched; future starts derive the corrected tier from immutable snapshot paths.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved detection of authentication-related risk in changes involving service and token paths.
  * Automatically selects canonical high-risk review lenses when service-token configuration is detected.

* **Bug Fixes**
  * Prevented invalid risk downgrades from being accepted.
  * Added validation to reject malformed or ambiguous change paths before risk classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->