### PR TITLE
fix(review): invalidate pristine authority

### DIFF
--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -371,7 +371,7 @@ func TestRunArgsDispatchesCompactReviewFacadeBeforePlatformValidation(t *testing
 	if err := RunArgs([]string{"review", "--help"}, &output); err != nil {
 		t.Fatalf("RunArgs(review --help) error = %v", err)
 	}
-	if !strings.Contains(output.String(), "review <start|finalize|validate>") {
+	if !strings.Contains(output.String(), "review <start|finalize|validate|invalidate>") {
 		t.Fatalf("compact review help missing:\n%s", output.String())
 	}
 }

--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -41,6 +41,13 @@ type ReviewFacadeFinalizeResult struct {
 	ReceiptPath   string                  `json:"receipt_path,omitempty"`
 }
 
+type ReviewInvalidateResult struct {
+	Operation     string                  `json:"operation"`
+	LineageID     string                  `json:"lineage_id"`
+	State         reviewtransaction.State `json:"state"`
+	StoreRevision string                  `json:"store_revision"`
+}
+
 type facadeFinding struct {
 	ID                string                              `json:"id,omitempty"`
 	Lens              string                              `json:"lens,omitempty"`
@@ -85,7 +92,7 @@ type facadeArtifacts struct {
 
 func RunReview(args []string, stdout io.Writer) error {
 	if len(args) == 0 || args[0] == "help" || args[0] == "-h" || args[0] == "--help" {
-		_, _ = fmt.Fprintln(stdout, "Usage: gentle-ai review <start|finalize|validate> [flags]\n\nOrdinary review facade; repository scope, authority, canonical artifacts, and lifecycle transitions are derived by Go.")
+		_, _ = fmt.Fprintln(stdout, "Usage: gentle-ai review <start|finalize|validate|invalidate> [flags]\n\nOrdinary review facade; repository scope, authority, canonical artifacts, and lifecycle transitions are derived by Go.")
 		return nil
 	}
 	switch args[0] {
@@ -95,9 +102,75 @@ func RunReview(args []string, stdout io.Writer) error {
 		return RunReviewFacadeFinalize(args[1:], stdout)
 	case "validate":
 		return RunReviewFacadeValidate(args[1:], stdout)
+	case "invalidate":
+		return RunReviewInvalidate(args[1:], stdout)
 	default:
 		return fmt.Errorf("unknown review command %q", args[0])
 	}
+}
+
+func RunReviewInvalidate(args []string, stdout io.Writer) error {
+	flags := newReviewFlagSet("review invalidate", stdout, "Terminally invalidate one explicit pristine reviewing authority.")
+	cwd := flags.String("cwd", "", "repository path")
+	lineage := flags.String("lineage", "", "explicit review lineage identifier")
+	expected := flags.String("expected-revision", "", "exact current authority revision")
+	reason := flags.String("reason", "", "non-empty terminal invalidation reason")
+	if err := parseReviewFlags(flags, args); err != nil {
+		return err
+	}
+	if reviewHelpRequested(args) {
+		return nil
+	}
+	if flags.NArg() != 0 {
+		return fmt.Errorf("unexpected review invalidate argument %q", flags.Arg(0))
+	}
+	if strings.TrimSpace(*cwd) == "" || strings.TrimSpace(*lineage) == "" || strings.TrimSpace(*expected) == "" || strings.TrimSpace(*reason) == "" {
+		return errors.New("review invalidate requires --cwd, --lineage, --expected-revision, and --reason")
+	}
+	root, err := (reviewtransaction.SnapshotBuilder{Repo: *cwd}).ResolveRepositoryRoot(context.Background())
+	if err != nil {
+		return fmt.Errorf("resolve review repository root: %w", err)
+	}
+	compact, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), root, *lineage)
+	if err != nil {
+		return err
+	}
+	record, loadErr := compact.Load()
+	if loadErr == nil {
+		legacy, legacyErr := reviewtransaction.AuthoritativeStore(context.Background(), root, *lineage)
+		if legacyErr == nil {
+			if _, legacyLoadErr := legacy.LoadChain(); legacyLoadErr == nil {
+				return errors.New("review authority is ambiguous across compact v2 and legacy v1 stores")
+			}
+		}
+		state := record.State
+		if state.State != reviewtransaction.StateInvalidated || state.InvalidationReason != strings.TrimSpace(*reason) {
+			if err := state.Invalidate(*reason); err != nil {
+				return err
+			}
+		}
+		revision, err := compact.Replace(*expected, "review/invalidate", state)
+		if err != nil {
+			return err
+		}
+		return encodeReviewJSON(stdout, ReviewInvalidateResult{Operation: "review/invalidate", LineageID: state.LineageID, State: state.State, StoreRevision: revision})
+	}
+	if !errors.Is(loadErr, os.ErrNotExist) {
+		return fmt.Errorf("load explicit compact review lineage: %w", loadErr)
+	}
+	legacy, err := reviewtransaction.AuthoritativeStore(context.Background(), root, *lineage)
+	if err != nil {
+		return err
+	}
+	chain, err := legacy.LoadChain()
+	if err != nil {
+		return fmt.Errorf("load explicit review lineage: %w", err)
+	}
+	revision, err := legacy.InvalidatePristine(*expected, *reason, chain.Records[len(chain.Records)-1].Transaction.Snapshot)
+	if err != nil {
+		return err
+	}
+	return encodeReviewJSON(stdout, ReviewInvalidateResult{Operation: "review/invalidate", LineageID: *lineage, State: reviewtransaction.StateInvalidated, StoreRevision: revision})
 }
 
 func RunReviewFacadeStart(args []string, stdout io.Writer) error {

--- a/internal/cli/review_invalidate_test.go
+++ b/internal/cli/review_invalidate_test.go
@@ -1,0 +1,59 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/internal/reviewtransaction"
+)
+
+func TestReviewInvalidateFailsClosedForCompetingAuthorities(t *testing.T) {
+	for _, corrupt := range []bool{true, false} {
+		t.Run(map[bool]string{true: "corrupt compact", false: "dual valid"}[corrupt], func(t *testing.T) {
+			repo := initReviewCLIRepo(t)
+			started := startFacadeReview(t, repo)
+			compact, _ := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, started.LineageID)
+			record, _ := compact.Load()
+			legacy := addPristineLegacyAuthority(t, repo, started.LineageID)
+			legacyChain, _ := legacy.LoadChain()
+			if corrupt && os.WriteFile(compact.StatePath(), []byte("corrupt"), 0o644) != nil {
+				t.Fatal("corrupt compact authority")
+			}
+			expected := record.Revision
+			if corrupt {
+				expected = legacyChain.HeadRevision
+			}
+			err := RunReview([]string{"invalidate", "--cwd", repo, "--lineage", started.LineageID, "--expected-revision", expected, "--reason", "operator abandoned"}, &bytes.Buffer{})
+			if err == nil {
+				t.Fatal("competing authority was mutated")
+			}
+			chain, loadErr := legacy.LoadChain()
+			if loadErr != nil || chain.HeadRevision == "" || (!corrupt && record.Revision != compactRevision(t, compact)) {
+				t.Fatalf("authority changed: %v", loadErr)
+			}
+		})
+	}
+}
+
+func addPristineLegacyAuthority(t *testing.T, repo, lineage string) reviewtransaction.Store {
+	t.Helper()
+	snapshot, _ := (reviewtransaction.SnapshotBuilder{Repo: repo}).Build(context.Background(), reviewtransaction.Target{Kind: reviewtransaction.TargetCurrentChanges, IntendedUntracked: []string{}})
+	tx, _ := reviewtransaction.NewTransaction(reviewtransaction.Start{LineageID: lineage, Mode: reviewtransaction.ModeOrdinary4R, Generation: 1, Snapshot: snapshot, PolicyHash: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"})
+	_ = tx.StartReview()
+	store, _ := reviewtransaction.AuthoritativeStore(context.Background(), repo, lineage)
+	if _, err := store.Append("", reviewtransaction.Record{Operation: "review/start", Transaction: *tx}); err != nil {
+		t.Fatal(err)
+	}
+	return store
+}
+
+func compactRevision(t *testing.T, store reviewtransaction.CompactStore) string {
+	t.Helper()
+	record, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return record.Revision
+}

--- a/internal/reviewtransaction/compact.go
+++ b/internal/reviewtransaction/compact.go
@@ -46,6 +46,7 @@ type CompactState struct {
 	OriginalCriteria        *ValidationCheck           `json:"original_criteria,omitempty"`
 	CorrectionRegression    *ValidationCheck           `json:"correction_regression,omitempty"`
 	EvidenceHash            string                     `json:"evidence_hash,omitempty"`
+	InvalidationReason      string                     `json:"invalidation_reason,omitempty"`
 }
 
 type CompactReceipt struct {
@@ -185,6 +186,15 @@ func (state CompactState) Validate() error {
 		if len(state.Findings) != 0 || len(state.Classifications) != 0 || len(state.Outcomes) != 0 || len(state.FixFindingIDs) != 0 || state.ProposedCorrectionLines != nil || state.ActualCorrectionLines != nil || state.EvidenceHash != "" {
 			return errors.New("reviewing compact state contains post-review data")
 		}
+		if state.InvalidationReason != "" {
+			return errors.New("reviewing compact state cannot contain an invalidation reason")
+		}
+	case StateInvalidated:
+		reviewing := state
+		reviewing.State, reviewing.InvalidationReason = StateReviewing, ""
+		if strings.TrimSpace(state.InvalidationReason) == "" || !compactPristineReviewing(reviewing) {
+			return errors.New("invalidated compact state must retain only a pristine reviewing authority and reason")
+		}
 	case StateCorrectionRequired:
 		if len(state.LensResults) != len(state.SelectedLenses) || len(state.FixFindingIDs) == 0 || state.EvidenceHash != "" {
 			return errors.New("correction-required compact state is incomplete")
@@ -225,7 +235,7 @@ func validateCompactSnapshotMetadata(snapshot Snapshot) error {
 }
 
 func validateCompactFindings(state CompactState) error {
-	if state.State == StateReviewing {
+	if state.State == StateReviewing || state.State == StateInvalidated {
 		return nil
 	}
 	if len(state.LensResults) != len(state.SelectedLenses) {
@@ -492,6 +502,25 @@ func (state *CompactState) CompleteReview(input CompactReviewInput) error {
 		state.State = StateValidating
 	}
 	return state.Validate()
+}
+
+func (state *CompactState) Invalidate(reason string) error {
+	reason = strings.TrimSpace(reason)
+	if reason == "" {
+		return errors.New("invalidation reason is required")
+	}
+	if !compactPristineReviewing(*state) {
+		return errors.New("only a pristine reviewing compact authority may be invalidated")
+	}
+	state.State, state.InvalidationReason = StateInvalidated, reason
+	return nil
+}
+
+func compactPristineReviewing(state CompactState) bool {
+	return state.State == StateReviewing && snapshotsEqual(state.CurrentSnapshot, state.InitialSnapshot) &&
+		len(state.LensResults) == 0 && len(state.Findings) == 0 && len(state.Classifications) == 0 && len(state.Outcomes) == 0 &&
+		len(state.FixFindingIDs) == 0 && len(state.FollowUps) == 0 && state.ProposedCorrectionLines == nil && state.ActualCorrectionLines == nil &&
+		state.FixDeltaHash == EmptyFixDeltaHash && state.OriginalCriteria == nil && state.CorrectionRegression == nil && state.EvidenceHash == "" && state.InvalidationReason == ""
 }
 
 func (state *CompactState) BeginCorrection(proposed int) error {

--- a/internal/reviewtransaction/compact_store.go
+++ b/internal/reviewtransaction/compact_store.go
@@ -190,6 +190,11 @@ func validateCompactRepositoryEvidence(ctx context.Context, repo string, current
 			return errors.New("compact correction size does not match repository evidence")
 		}
 	}
+	if operation == "review/invalidate" {
+		if err := rebuildCurrentSnapshotEvidence(ctx, repo, next.InitialSnapshot); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -202,6 +207,11 @@ func validateCompactSuccessor(previous, next CompactState, operation string) err
 		return fmt.Errorf("%w: compact review scope, tier, policy, and budget are immutable", ErrInvalidSuccessor)
 	}
 	switch operation {
+	case "review/invalidate":
+		expected := previous
+		if err := expected.Invalidate(next.InvalidationReason); err != nil || !compactStateEqual(expected, next) {
+			return fmt.Errorf("%w: invalidation must retain a pristine reviewing authority", ErrInvalidSuccessor)
+		}
 	case "review/complete-review":
 		if previous.State != StateReviewing || next.State != StateCorrectionRequired && next.State != StateValidating && next.State != StateEscalated {
 			return fmt.Errorf("%w: invalid compact review completion", ErrInvalidSuccessor)

--- a/internal/reviewtransaction/invalidation_test.go
+++ b/internal/reviewtransaction/invalidation_test.go
@@ -1,0 +1,102 @@
+package reviewtransaction
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestInvalidatePristineLegacyAndCompactAreTerminalAndIdempotent(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	writeSnapshotFile(t, repo, "tracked.txt", "candidate\n")
+
+	legacy, err := AuthoritativeStore(context.Background(), repo, "invalidate-legacy")
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err := (SnapshotBuilder{Repo: repo}).Build(context.Background(), Target{Kind: TargetCurrentChanges, IntendedUntracked: []string{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	transaction, err := NewTransaction(Start{LineageID: "invalidate-legacy", Mode: ModeOrdinary4R, Generation: 1, Snapshot: snapshot, PolicyHash: hash("a")})
+	if err != nil || transaction.StartReview() != nil {
+		t.Fatalf("create legacy review: %v", err)
+	}
+	genesis, err := legacy.Append("", Record{Operation: "review/start", Transaction: *transaction})
+	if err != nil {
+		t.Fatal(err)
+	}
+	legacy, _ = AuthoritativeStore(context.Background(), repo, transaction.LineageID)
+	invalidated, err := legacy.InvalidatePristine(genesis, "operator abandoned", snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if retry, err := legacy.InvalidatePristine(genesis, "operator abandoned", snapshot); err != nil || retry != invalidated {
+		t.Fatalf("legacy exact retry = %q, %v", retry, err)
+	}
+	if _, err := legacy.InvalidatePristine(genesis, "different reason", snapshot); !errors.Is(err, ErrConcurrentUpdate) {
+		t.Fatalf("legacy conflicting retry error = %v", err)
+	}
+	if record, _, err := legacy.Load(); err != nil || record.Transaction.State != StateInvalidated || record.Transaction.InvalidationReason != "operator abandoned" {
+		t.Fatalf("legacy invalidation = %#v, %v", record.Transaction, err)
+	}
+
+	compact := newCompactTestState(t, repo, "invalidate-compact")
+	compactStore, _ := CompactAuthoritativeStore(context.Background(), repo, compact.LineageID)
+	revision, err := compactStore.Replace("", "review/start", compact)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := compact.Invalidate("operator abandoned"); err != nil {
+		t.Fatal(err)
+	}
+	invalidated, err = compactStore.Replace(revision, "review/invalidate", compact)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if retry, err := compactStore.Replace(revision, "review/invalidate", compact); err != nil || retry != invalidated {
+		t.Fatalf("compact exact retry = %q, %v", retry, err)
+	}
+	if _, err := compact.Receipt(); err == nil {
+		t.Fatal("invalidated compact review produced a receipt")
+	}
+}
+
+func TestInvalidatePristineRejectsLiveCandidateDriftWithoutMutation(t *testing.T) {
+	for _, mutate := range []struct {
+		name  string
+		apply func(t *testing.T, repo string)
+	}{
+		{"unstaged", func(t *testing.T, repo string) { writeSnapshotFile(t, repo, "tracked.txt", "changed after review\n") }},
+		{"staged", func(t *testing.T, repo string) {
+			writeSnapshotFile(t, repo, "tracked.txt", "changed after review\n")
+			gitSnapshot(t, repo, "add", "tracked.txt")
+		}},
+		{"commit-a", func(t *testing.T, repo string) {
+			writeSnapshotFile(t, repo, "tracked.txt", "changed after review\n")
+			gitSnapshot(t, repo, "commit", "-am", "drift")
+		}},
+	} {
+		t.Run(mutate.name, func(t *testing.T) {
+			repo := initSnapshotRepo(t)
+			writeSnapshotFile(t, repo, "tracked.txt", "candidate\n")
+			state := newCompactTestState(t, repo, "invalidate-drift-"+mutate.name)
+			store, _ := CompactAuthoritativeStore(context.Background(), repo, state.LineageID)
+			revision, err := store.Replace("", "review/start", state)
+			if err != nil {
+				t.Fatal(err)
+			}
+			mutate.apply(t, repo)
+			if err := state.Invalidate("operator abandoned"); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := store.Replace(revision, "review/invalidate", state); err == nil {
+				t.Fatal("live candidate drift was accepted")
+			}
+			loaded, err := store.Load()
+			if err != nil || loaded.Revision != revision || loaded.State.State != StateReviewing {
+				t.Fatalf("drift changed compact authority: %#v, %v", loaded, err)
+			}
+		})
+	}
+}

--- a/internal/reviewtransaction/snapshot.go
+++ b/internal/reviewtransaction/snapshot.go
@@ -190,6 +190,31 @@ func (builder SnapshotBuilder) ValidateEvidence(ctx context.Context, snapshot Sn
 	return nil
 }
 
+func rebuildCurrentSnapshotEvidence(ctx context.Context, repo string, snapshot Snapshot) error {
+	if strings.TrimSpace(repo) == "" {
+		return errors.New("repository evidence is required for invalidation")
+	}
+	target := Target{Kind: snapshot.Kind, IntendedUntracked: append([]string(nil), snapshot.IntendedUntracked...)}
+	if target.IntendedUntracked == nil {
+		target.IntendedUntracked = []string{}
+	}
+	switch snapshot.Kind {
+	case TargetCurrentChanges:
+	case TargetBaseDiff:
+		target.BaseRef = snapshot.BaseTree
+	default:
+		return errors.New("invalidation supports only live current-changes or base-diff snapshots")
+	}
+	live, err := (SnapshotBuilder{Repo: repo}).Build(ctx, target)
+	if err != nil {
+		return err
+	}
+	if !snapshotsEqual(live, snapshot) {
+		return fmt.Errorf("live repository snapshot no longer matches the reviewing authority: expected %s, got %s", snapshot.Identity, live.Identity)
+	}
+	return nil
+}
+
 // DiffStats returns the canonical base-to-candidate numstat for a validated
 // snapshot boundary. It rejects any mismatch with the snapshot path set.
 func (builder SnapshotBuilder) DiffStats(ctx context.Context, snapshot Snapshot) ([]DiffStat, error) {

--- a/internal/reviewtransaction/store.go
+++ b/internal/reviewtransaction/store.go
@@ -141,7 +141,11 @@ func validateLineageID(lineageID string) error {
 }
 
 func (store Store) Append(expectedRevision string, record Record) (string, error) {
-	if store.readOnly {
+	return store.append(expectedRevision, record, false)
+}
+
+func (store Store) append(expectedRevision string, record Record, allowInvalidate bool) (string, error) {
+	if store.readOnly && !allowInvalidate {
 		return "", ErrLegacyReadOnly
 	}
 	if strings.TrimSpace(store.Dir) == "" {
@@ -271,6 +275,33 @@ func (store Store) Append(expectedRevision string, record Record) (string, error
 		return "", err
 	}
 	return revision, nil
+}
+
+// InvalidatePristine is the sole legacy write compatibility path. It appends
+// exactly review/invalidate without remarshal or modification of prior events.
+func (store Store) InvalidatePristine(expectedRevision, reason string, snapshot Snapshot) (string, error) {
+	chain, err := store.LoadChain()
+	if err != nil {
+		return "", err
+	}
+	current := chain.Records[len(chain.Records)-1].Transaction
+	if current.State == StateInvalidated {
+		if len(chain.Revisions) == 2 && expectedRevision == chain.Revisions[0] && current.InvalidationReason == strings.TrimSpace(reason) && snapshotsEqual(current.Snapshot, snapshot) {
+			return chain.HeadRevision, nil
+		}
+		return "", ErrConcurrentUpdate
+	}
+	if chain.HeadRevision != expectedRevision || !snapshotsEqual(current.Snapshot, snapshot) {
+		return "", ErrConcurrentUpdate
+	}
+	if err := rebuildCurrentSnapshotEvidence(context.Background(), store.repo, snapshot); err != nil {
+		return "", err
+	}
+	next := current
+	if err := next.Invalidate(reason); err != nil {
+		return "", err
+	}
+	return store.append(expectedRevision, Record{Operation: "review/invalidate", Transaction: next}, true)
 }
 
 func (store Store) Load() (Record, string, error) {
@@ -407,6 +438,13 @@ func (store Store) loadRevision(revision string) (Record, string, error) {
 }
 
 func validateSuccessor(previous, next Transaction, operation string) error {
+	if operation == "review/invalidate" {
+		expected := previous
+		if err := expected.Invalidate(next.InvalidationReason); err != nil || !transactionsEqual(expected, next) {
+			return fmt.Errorf("%w: invalidation must retain a pristine reviewing authority", ErrInvalidSuccessor)
+		}
+		return nil
+	}
 	if previous.LineageID != next.LineageID || previous.Generation != next.Generation || previous.Mode != next.Mode {
 		return fmt.Errorf("%w: lineage, generation, and mode are immutable", ErrInvalidSuccessor)
 	}

--- a/internal/reviewtransaction/transaction.go
+++ b/internal/reviewtransaction/transaction.go
@@ -46,6 +46,7 @@ const (
 	StateFinalVerifying         State = "final_verifying"
 	StateApproved               State = "approved"
 	StateEscalated              State = "escalated"
+	StateInvalidated            State = "invalidated"
 )
 
 type EvidenceClass string
@@ -187,6 +188,7 @@ type Transaction struct {
 	LedgerHash              string                     `json:"ledger_hash"`
 	LedgerFindingsHash      string                     `json:"ledger_findings_hash"`
 	EvidenceHash            string                     `json:"evidence_hash"`
+	InvalidationReason      string                     `json:"invalidation_reason,omitempty"`
 	JudgeProofHash          string                     `json:"judge_proof_hash,omitempty"`
 	JudgeAgreementHash      string                     `json:"judge_agreement_hash,omitempty"`
 	JudgeProofs             []JudgeProof               `json:"judge_proofs"`
@@ -280,6 +282,21 @@ func (transaction *Transaction) StartReview() error {
 		transaction.Counters.FullReviews++
 	}
 	transaction.State = StateReviewing
+	return nil
+}
+
+// Invalidate terminates only a pristine reviewing authority. It deliberately
+// has no inverse: callers must create a distinct lineage for another review.
+func (transaction *Transaction) Invalidate(reason string) error {
+	reason = strings.TrimSpace(reason)
+	if reason == "" {
+		return errors.New("invalidation reason is required")
+	}
+	if !pristineReviewing(*transaction) {
+		return errors.New("only a pristine reviewing authority may be invalidated")
+	}
+	transaction.State = StateInvalidated
+	transaction.InvalidationReason = reason
 	return nil
 }
 
@@ -1049,12 +1066,23 @@ func (transaction *Transaction) validate() error {
 	switch transaction.State {
 	case StateUnreviewed, StateReviewing, StateJudgesConfirmed, StateFindingsFrozen, StateEvidenceClassified,
 		StateFixRequired, StateFixing, StateFixValidating, StateReadyFinalVerification,
-		StateFinalVerifying, StateApproved, StateEscalated:
+		StateFinalVerifying, StateApproved, StateEscalated, StateInvalidated:
 	default:
 		return fmt.Errorf("invalid transaction state %q", transaction.State)
 	}
 	if err := validateCounters(transaction.Mode, transaction.Counters); err != nil {
 		return err
+	}
+	if transaction.State == StateInvalidated {
+		reviewing := *transaction
+		reviewing.State, reviewing.InvalidationReason = StateReviewing, ""
+		if !pristineReviewing(reviewing) || strings.TrimSpace(transaction.InvalidationReason) == "" {
+			return errors.New("invalidated transaction must retain only a pristine reviewing authority and reason")
+		}
+		return nil
+	}
+	if transaction.InvalidationReason != "" {
+		return errors.New("only an invalidated transaction may contain an invalidation reason")
 	}
 	if err := transaction.validateLensState(); err != nil {
 		return err
@@ -1081,6 +1109,20 @@ func (transaction *Transaction) validate() error {
 
 func (transaction *Transaction) hasCorrectionBudget() bool {
 	return transaction.Mode == ModeOrdinaryBounded && transaction.OriginalChangedLines != nil && transaction.CorrectionBudget != nil
+}
+
+func pristineReviewing(transaction Transaction) bool {
+	if transaction.State != StateReviewing || transaction.LedgerHash != "" || transaction.LedgerFindingsHash != "" ||
+		transaction.EvidenceHash != "" || transaction.JudgeProofHash != "" || transaction.JudgeAgreementHash != "" ||
+		transaction.Release != nil || transaction.FailedEvidenceRevision != "" || transaction.FixDeltaHash != EmptyFixDeltaHash ||
+		!snapshotsEqual(transaction.Snapshot, Snapshot{Kind: transaction.Snapshot.Kind, BaseTree: transaction.BaseTree, CandidateTree: transaction.InitialReviewTree, PathsDigest: transaction.PathsDigest, IntendedUntracked: transaction.Snapshot.IntendedUntracked, IntendedUntrackedProof: transaction.Snapshot.IntendedUntrackedProof, LedgerIDs: transaction.Snapshot.LedgerIDs, Paths: transaction.Snapshot.Paths, Identity: transaction.Snapshot.Identity}) ||
+		transaction.FinalCandidateTree != transaction.InitialReviewTree || len(transaction.LensResults) != 0 || len(transaction.Findings) != 0 ||
+		len(transaction.Classifications) != 0 || len(transaction.Outcomes) != 0 || len(transaction.FixFindingIDs) != 0 || len(transaction.PendingRefuterIDs) != 0 ||
+		len(transaction.FixCausedFindings) != 0 || len(transaction.FollowUps) != 0 || len(transaction.JudgeProofs) != 0 ||
+		transaction.OriginalCriteria != nil || transaction.CorrectionRegression != nil || transaction.ProposedCorrectionLines != nil || transaction.ActualCorrectionLines != nil {
+		return false
+	}
+	return validInitialStoreRecord(Record{Operation: "review/start", Transaction: transaction})
 }
 
 func (transaction *Transaction) validateCorrectionBudget() error {
@@ -1468,7 +1510,7 @@ func (transaction *Transaction) validateFindingRouting() error {
 	if hasStringIntersection(fixIDs, pendingIDs) {
 		return errors.New("a severe finding cannot be both correction-bound and pending refutation")
 	}
-	if transaction.State != StateUnreviewed && transaction.State != StateReviewing && transaction.State != StateJudgesConfirmed && (!validSHA256(transaction.LedgerHash) || !validSHA256(transaction.LedgerFindingsHash) || transaction.LedgerFindingsHash != findingsHash(transaction.Findings)) {
+	if transaction.State != StateUnreviewed && transaction.State != StateReviewing && transaction.State != StateJudgesConfirmed && transaction.State != StateInvalidated && (!validSHA256(transaction.LedgerHash) || !validSHA256(transaction.LedgerFindingsHash) || transaction.LedgerFindingsHash != findingsHash(transaction.Findings)) {
 		return errors.New("frozen review state requires a content-bound ledger hash")
 	}
 	return transaction.validateFindingState(findings, severe)
@@ -1481,7 +1523,7 @@ func findingsHash(findings []Finding) string {
 }
 
 func (transaction *Transaction) validateFindingState(findings, severe map[string]Finding) error {
-	beforeFreeze := transaction.State == StateUnreviewed || transaction.State == StateReviewing || transaction.State == StateJudgesConfirmed
+	beforeFreeze := transaction.State == StateUnreviewed || transaction.State == StateReviewing || transaction.State == StateJudgesConfirmed || transaction.State == StateInvalidated
 	if beforeFreeze {
 		if len(findings) != 0 || len(transaction.Classifications) != 0 || len(transaction.Outcomes) != 0 || len(transaction.FixFindingIDs) != 0 || len(transaction.PendingRefuterIDs) != 0 {
 			return errors.New("pre-freeze transaction cannot contain findings or evidence routing")


### PR DESCRIPTION
## Linked Issue

Closes #1131

## PR Type

- [x] `type:bug` - Bug fix

## Summary

- Adds `gentle-ai review invalidate` for one explicit pristine v1 or compact lineage.
- Requires an exact authority revision, unchanged live snapshot, and persisted non-empty reason.
- Keeps legacy writes read-only except for the dedicated `review/invalidate` append.
- Rejects late, stale, changed, corrupt, or ambiguous authority without mutation.

## Scope

This is slice 2 of the recovery-lifecycle design, based on merged slice 1 (#1189). It does not add SDD approved-lineage binding or terminal compact lineage reset/reuse.

## Test Plan

- [x] Pristine v1 and compact invalidation
- [x] Exact retry and conflicting retry semantics
- [x] Unstaged, staged, committed, relative/subdirectory, and hostile-Git cases
- [x] Corrupt compact and dual-authority fail-closed cases
- [x] Invalidated authority cannot produce a receipt
- [x] Real CLI `review start` to `review invalidate` harness
- [x] `go test -count=1 ./...`
- [x] `go vet ./...`
- [x] `go build ./cmd/gentle-ai`
- [x] Changed-file `gofmt` and `git diff --check`

## Contributor Checklist

- [x] Issue #1131 has `status:approved`
- [x] Exactly one `type:*` label will be applied
- [x] 392 authored changed lines stay below the 400-line review budget
- [x] Existing event bytes remain immutable and invalidated lineages cannot be reused


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `gentle-ai review invalidate` command to invalidate a pristine review lineage with a required reason.
  * Invalidation results now report the operation, lineage, state, and revision in JSON.
  * Invalidated reviews retain their reason and become terminal, preventing further review changes.

* **Bug Fixes**
  * Added safeguards against conflicting review authorities and repository changes during invalidation.
  * Repeated invalidation with the same details is safely idempotent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->