### PR TITLE
fix(sdd): bind approved replacement reviews

### DIFF
--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -371,7 +371,7 @@ func TestRunArgsDispatchesCompactReviewFacadeBeforePlatformValidation(t *testing
 	if err := RunArgs([]string{"review", "--help"}, &output); err != nil {
 		t.Fatalf("RunArgs(review --help) error = %v", err)
 	}
-	if !strings.Contains(output.String(), "review <start|finalize|validate|invalidate>") {
+	if !strings.Contains(output.String(), "review <start|finalize|validate|invalidate|bind-sdd>") {
 		t.Fatalf("compact review help missing:\n%s", output.String())
 	}
 }

--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/gentleman-programming/gentle-ai/internal/reviewtransaction"
+	"github.com/gentleman-programming/gentle-ai/internal/sddstatus"
 )
 
 const facadeReviewPolicy = `Gentle AI native bounded review policy.
@@ -92,7 +93,7 @@ type facadeArtifacts struct {
 
 func RunReview(args []string, stdout io.Writer) error {
 	if len(args) == 0 || args[0] == "help" || args[0] == "-h" || args[0] == "--help" {
-		_, _ = fmt.Fprintln(stdout, "Usage: gentle-ai review <start|finalize|validate|invalidate> [flags]\n\nOrdinary review facade; repository scope, authority, canonical artifacts, and lifecycle transitions are derived by Go.")
+		_, _ = fmt.Fprintln(stdout, "Usage: gentle-ai review <start|finalize|validate|invalidate|bind-sdd> [flags]\n\nOrdinary review facade; repository scope, authority, canonical artifacts, and lifecycle transitions are derived by Go.")
 		return nil
 	}
 	switch args[0] {
@@ -104,9 +105,40 @@ func RunReview(args []string, stdout io.Writer) error {
 		return RunReviewFacadeValidate(args[1:], stdout)
 	case "invalidate":
 		return RunReviewInvalidate(args[1:], stdout)
+	case "bind-sdd":
+		return RunReviewBindSDD(args[1:], stdout)
 	default:
 		return fmt.Errorf("unknown review command %q", args[0])
 	}
+}
+
+func RunReviewBindSDD(args []string, stdout io.Writer) error {
+	flags := newReviewFlagSet("review bind-sdd", stdout, "Bind an explicit approved compact lineage to an OpenSpec change.")
+	cwd := flags.String("cwd", "", "repository path")
+	change := flags.String("change", "", "OpenSpec change")
+	lineage := flags.String("lineage", "", "approved lineage")
+	expected := flags.String("expected-binding-revision", "", "binding revision")
+	if err := parseReviewFlags(flags, args); err != nil {
+		return err
+	}
+	if reviewHelpRequested(args) {
+		return nil
+	}
+	if flags.NArg() != 0 {
+		return fmt.Errorf("unexpected review bind-sdd argument %q", flags.Arg(0))
+	}
+	hasExpected := false
+	for _, arg := range args {
+		hasExpected = hasExpected || arg == "--expected-binding-revision" || strings.HasPrefix(arg, "--expected-binding-revision=")
+	}
+	if strings.TrimSpace(*cwd) == "" || strings.TrimSpace(*change) == "" || strings.TrimSpace(*lineage) == "" || !hasExpected {
+		return errors.New("review bind-sdd requires --cwd, --change, --lineage, and --expected-binding-revision")
+	}
+	binding, err := sddstatus.BindApprovedReview(context.Background(), *cwd, *change, *lineage, *expected)
+	if err != nil {
+		return err
+	}
+	return encodeReviewJSON(stdout, binding)
 }
 
 func RunReviewInvalidate(args []string, stdout io.Writer) error {

--- a/internal/cli/review_facade_test.go
+++ b/internal/cli/review_facade_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 
 	"github.com/gentleman-programming/gentle-ai/internal/reviewtransaction"
+	"github.com/gentleman-programming/gentle-ai/internal/sddstatus"
 )
 
 func TestReviewFacadeCleanFlowReplacesOneCompactStateAndUsesOnlyReceipt(t *testing.T) {
@@ -507,6 +508,88 @@ func TestReviewFacadeHelpAndFlatCompatibilityPathsRemainAvailable(t *testing.T) 
 		if err := test.run([]string{"--help"}, &output); err != nil || !strings.Contains(output.String(), test.want) {
 			t.Fatalf("flat compatibility help %q: %v\n%s", test.want, err, output.String())
 		}
+	}
+}
+
+func TestReviewBindSDDRequiresExplicitInputs(t *testing.T) {
+	err := RunReview([]string{"bind-sdd", "--cwd", t.TempDir(), "--change", "thin", "--lineage", "approved"}, io.Discard)
+	if err == nil || !strings.Contains(err.Error(), "expected-binding-revision") {
+		t.Fatalf("bind-sdd missing explicit CAS input error = %v", err)
+	}
+}
+
+func TestReviewBindSDDAcceptsEqualsFormForEmptyExpectedRevision(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	change := filepath.Join(repo, "openspec", "changes", "thin")
+	for path, content := range map[string]string{"tasks.md": "- [x] 1.1 Done\n", "proposal.md": "# Proposal\n", "design.md": "# Design\n", "specs/binding/spec.md": "# Spec\n"} {
+		fullPath := filepath.Join(change, path)
+		if err := os.MkdirAll(filepath.Dir(fullPath), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(fullPath, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	started := startFacadeReview(t, repo)
+	evidence := filepath.Join(t.TempDir(), "evidence.txt")
+	if err := os.WriteFile(evidence, []byte("tests pass\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := RunReviewFacadeFinalize([]string{"--cwd", repo, "--lineage", started.LineageID, "--evidence", evidence}, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	if err := RunReview([]string{"bind-sdd", "--cwd", repo, "--change", "thin", "--lineage", started.LineageID, "--expected-binding-revision="}, io.Discard); err != nil {
+		t.Fatalf("equals-form expected revision was rejected: %v", err)
+	}
+}
+
+func TestReviewBindSDDFeedsSelectedSDDStatusRuntime(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	change := filepath.Join(repo, "openspec", "changes", "thin")
+	if err := os.MkdirAll(change, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(change, "tasks.md"), []byte("- [x] 1.1 Done\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for path, content := range map[string]string{
+		"proposal.md":           "# Proposal\n",
+		"design.md":             "# Design\n",
+		"specs/binding/spec.md": "# Spec\n",
+	} {
+		fullPath := filepath.Join(change, path)
+		if err := os.MkdirAll(filepath.Dir(fullPath), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(fullPath, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	started := startFacadeReview(t, repo)
+	evidence := filepath.Join(t.TempDir(), "evidence.txt")
+	if err := os.WriteFile(evidence, []byte("tests pass\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := RunReviewFacadeFinalize([]string{"--cwd", repo, "--lineage", started.LineageID, "--evidence", evidence}, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	var output bytes.Buffer
+	if err := RunReview([]string{"bind-sdd", "--cwd", repo, "--change", "thin", "--lineage", started.LineageID, "--expected-binding-revision", ""}, &output); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(output.String(), "gentle-ai.sdd-review-binding/v1") {
+		t.Fatalf("binding output = %s", output.String())
+	}
+	output.Reset()
+	if err := RunSDDStatus([]string{"thin", "--cwd", repo, "--json"}, &output); err != nil {
+		t.Fatal(err)
+	}
+	var status sddstatus.Status
+	if err := json.Unmarshal(output.Bytes(), &status); err != nil {
+		t.Fatal(err)
+	}
+	if status.NextRecommended != "verify" || status.Dependencies.Verify != sddstatus.DependencyReady || status.Dependencies.Archive != sddstatus.DependencyBlocked || status.ReviewGate == nil || status.ReviewGate.Result != reviewtransaction.GateAllow {
+		t.Fatalf("bound runtime status = %#v", status)
 	}
 }
 

--- a/internal/sddstatus/review_binding.go
+++ b/internal/sddstatus/review_binding.go
@@ -1,0 +1,266 @@
+package sddstatus
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"regexp"
+
+	"github.com/gentleman-programming/gentle-ai/internal/reviewtransaction"
+)
+
+const reviewBindingSchema = "gentle-ai.sdd-review-binding/v1"
+
+var reviewBindingChange = regexp.MustCompile(`^[a-z0-9]+(?:-[a-z0-9]+)*$`)
+var reviewBindingHash = regexp.MustCompile(`^sha256:[a-f0-9]{64}$`)
+var bindingFinalAuthorizationHook = func() {}
+
+type ReviewBinding struct {
+	Schema            string                        `json:"schema"`
+	Revision          string                        `json:"revision"`
+	Change            string                        `json:"change"`
+	Lineage           string                        `json:"lineage"`
+	AuthorityRevision string                        `json:"authority_revision"`
+	ReceiptHash       string                        `json:"receipt_hash"`
+	GateContext       reviewtransaction.GateContext `json:"gate_context"`
+}
+
+func BindApprovedReview(ctx context.Context, repo, change, lineage, expected string) (ReviewBinding, error) {
+	if !validReviewBindingChange(change) {
+		return ReviewBinding{}, errors.New("invalid OpenSpec change name")
+	}
+	root, err := (reviewtransaction.SnapshotBuilder{Repo: repo}).ResolveRepositoryRoot(ctx)
+	if err != nil {
+		return ReviewBinding{}, err
+	}
+	if info, statErr := os.Stat(filepath.Join(root, "openspec", "changes", change)); statErr != nil || !info.IsDir() {
+		return ReviewBinding{}, errors.New("selected OpenSpec change does not exist")
+	}
+	store, err := reviewtransaction.CompactAuthoritativeStore(ctx, root, lineage)
+	if err != nil {
+		return ReviewBinding{}, err
+	}
+	record, err := store.Load()
+	if err != nil || record.State.State != reviewtransaction.StateApproved {
+		return ReviewBinding{}, errors.New("explicit compact authority is not approved")
+	}
+	payload, err := os.ReadFile(store.ReceiptPath())
+	if err != nil {
+		return ReviewBinding{}, err
+	}
+	receipt, err := reviewtransaction.ParseCompactReceipt(payload)
+	authoritative, receiptErr := record.State.Receipt()
+	if err != nil || receiptErr != nil || !reflect.DeepEqual(receipt, authoritative) {
+		return ReviewBinding{}, errors.New("compact receipt does not match approved authority")
+	}
+	if err := verifyBindingLedger(root, change, record.State.Findings); err != nil {
+		return ReviewBinding{}, err
+	}
+	input := reviewtransaction.NativeGateRequestInput{Gate: reviewtransaction.GatePostApply, LineageID: lineage}
+	gate := reviewtransaction.EvaluateCompactGate(ctx, root, receipt, input)
+	if gate.Result != reviewtransaction.GateAllow {
+		return ReviewBinding{}, errors.New("compact post-apply gate is not allow")
+	}
+	binding := ReviewBinding{Schema: reviewBindingSchema, Change: change, Lineage: lineage, AuthorityRevision: record.Revision, ReceiptHash: bindingHash(payload), GateContext: gate.Context}
+	binding.Revision = bindingDigest(binding)
+	final, finalErr := store.Load()
+	finalPayload, readErr := os.ReadFile(store.ReceiptPath())
+	finalGate := reviewtransaction.EvaluateCompactGate(ctx, root, receipt, input)
+	if finalErr != nil || readErr != nil || final.Revision != record.Revision || !bytes.Equal(payload, finalPayload) || finalGate.Result != reviewtransaction.GateAllow || !reflect.DeepEqual(gate.Context, finalGate.Context) {
+		return ReviewBinding{}, errors.New("authority or live gate changed before binding publish")
+	}
+	return binding, writeBinding(bindingPath(store, change), expected, binding)
+}
+
+func validateBoundReview(ctx context.Context, repo, change string) (ReviewBinding, reviewtransaction.NativeGateEvaluation, error) {
+	if !validReviewBindingChange(change) {
+		return ReviewBinding{}, reviewtransaction.NativeGateEvaluation{}, errors.New("invalid OpenSpec change name")
+	}
+	root, err := (reviewtransaction.SnapshotBuilder{Repo: repo}).ResolveRepositoryRoot(ctx)
+	if err != nil {
+		return ReviewBinding{}, reviewtransaction.NativeGateEvaluation{}, err
+	}
+	probe, err := reviewtransaction.CompactAuthoritativeStore(ctx, root, "binding-probe")
+	if err != nil {
+		return ReviewBinding{}, reviewtransaction.NativeGateEvaluation{}, err
+	}
+	payload, err := os.ReadFile(bindingPath(probe, change))
+	if err != nil {
+		return ReviewBinding{}, reviewtransaction.NativeGateEvaluation{}, fmt.Errorf("approved review binding is missing: %w", err)
+	}
+	binding, err := parseBinding(payload)
+	if err != nil {
+		return ReviewBinding{}, reviewtransaction.NativeGateEvaluation{}, fmt.Errorf("approved review binding is invalid: %w", err)
+	}
+	if binding.Change != change {
+		return ReviewBinding{}, reviewtransaction.NativeGateEvaluation{}, errors.New("approved review binding change does not match selected change")
+	}
+	store, err := reviewtransaction.CompactAuthoritativeStore(ctx, root, binding.Lineage)
+	if err != nil {
+		return ReviewBinding{}, reviewtransaction.NativeGateEvaluation{}, err
+	}
+	record, err := store.Load()
+	if err != nil || record.Revision != binding.AuthorityRevision || record.State.State != reviewtransaction.StateApproved {
+		return ReviewBinding{}, reviewtransaction.NativeGateEvaluation{}, errors.New("bound compact authority is stale or not approved")
+	}
+	receiptPayload, err := os.ReadFile(store.ReceiptPath())
+	if err != nil || bindingHash(receiptPayload) != binding.ReceiptHash {
+		return ReviewBinding{}, reviewtransaction.NativeGateEvaluation{}, errors.New("bound compact receipt changed")
+	}
+	receipt, err := reviewtransaction.ParseCompactReceipt(receiptPayload)
+	authoritative, receiptErr := record.State.Receipt()
+	if err != nil || receiptErr != nil || !reflect.DeepEqual(receipt, authoritative) {
+		return ReviewBinding{}, reviewtransaction.NativeGateEvaluation{}, errors.New("bound compact receipt does not match approved authority")
+	}
+	if err := verifyBindingLedger(root, change, record.State.Findings); err != nil {
+		return ReviewBinding{}, reviewtransaction.NativeGateEvaluation{}, err
+	}
+	evaluation := reviewtransaction.EvaluateCompactGate(ctx, root, receipt, reviewtransaction.NativeGateRequestInput{Gate: reviewtransaction.GatePostApply, LineageID: binding.Lineage})
+	if evaluation.Result != reviewtransaction.GateAllow || !reflect.DeepEqual(evaluation.Context, binding.GateContext) {
+		return ReviewBinding{}, reviewtransaction.NativeGateEvaluation{}, errors.New("bound compact post-apply gate context changed")
+	}
+	bindingFinalAuthorizationHook()
+	finalBinding, bindingErr := os.ReadFile(bindingPath(probe, change))
+	finalRecord, recordErr := store.Load()
+	finalReceipt, receiptErr := os.ReadFile(store.ReceiptPath())
+	if bindingErr != nil || recordErr != nil || receiptErr != nil || !bytes.Equal(finalBinding, payload) || finalRecord.Revision != record.Revision || !reflect.DeepEqual(finalRecord.State, record.State) || finalRecord.State.State != reviewtransaction.StateApproved || !bytes.Equal(finalReceipt, receiptPayload) || bindingHash(finalReceipt) != binding.ReceiptHash {
+		return ReviewBinding{}, reviewtransaction.NativeGateEvaluation{}, errors.New("bound authority, receipt, or binding changed during final read")
+	}
+	finalReceiptValue, parseErr := reviewtransaction.ParseCompactReceipt(finalReceipt)
+	finalAuthoritative, authorityErr := finalRecord.State.Receipt()
+	if parseErr != nil || authorityErr != nil || !reflect.DeepEqual(finalReceiptValue, finalAuthoritative) {
+		return ReviewBinding{}, reviewtransaction.NativeGateEvaluation{}, errors.New("bound compact receipt does not match final authority")
+	}
+	finalGate := reviewtransaction.EvaluateCompactGate(ctx, root, finalReceiptValue, reviewtransaction.NativeGateRequestInput{Gate: reviewtransaction.GatePostApply, LineageID: binding.Lineage})
+	if finalGate.Result != reviewtransaction.GateAllow || !reflect.DeepEqual(finalGate.Context, binding.GateContext) {
+		return ReviewBinding{}, reviewtransaction.NativeGateEvaluation{}, errors.New("bound compact post-apply gate changed during final authorization")
+	}
+	return binding, finalGate, nil
+}
+
+func bindingExists(ctx context.Context, repo, change string) (bool, error) {
+	root, err := (reviewtransaction.SnapshotBuilder{Repo: repo}).ResolveRepositoryRoot(ctx)
+	if err != nil {
+		return false, nil
+	}
+	probe, err := reviewtransaction.CompactAuthoritativeStore(ctx, root, "binding-probe")
+	if err != nil {
+		return false, err
+	}
+	_, err = os.Stat(bindingPath(probe, change))
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return err == nil, err
+}
+
+func verifyBindingLedger(root, change string, findings []reviewtransaction.Finding) error {
+	payload, err := os.ReadFile(filepath.Join(root, "openspec", "changes", change, "reviews", "ledger.json"))
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	want, err := reviewtransaction.CanonicalLedger(findings)
+	if err != nil || !bytes.Equal(payload, want) {
+		return errors.New("SDD review ledger does not equal compact findings")
+	}
+	return nil
+}
+func bindingPath(store reviewtransaction.CompactStore, change string) string {
+	return filepath.Join(filepath.Dir(filepath.Dir(filepath.Dir(filepath.Dir(store.Dir)))), "gentle-ai", "sdd-review-bindings", "v1", change, "binding.json")
+}
+func bindingHash(payload []byte) string {
+	sum := sha256.Sum256(payload)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+func bindingDigest(b ReviewBinding) string {
+	b.Revision = ""
+	payload, _ := json.Marshal(b)
+	return bindingHash(payload)
+}
+
+func validReviewBindingChange(change string) bool {
+	return len(change) <= 96 && reviewBindingChange.MatchString(change)
+}
+
+func bindingBytes(binding ReviewBinding) ([]byte, error) {
+	payload, err := json.Marshal(binding)
+	if err != nil {
+		return nil, err
+	}
+	return append(payload, '\n'), nil
+}
+
+func parseBinding(payload []byte) (ReviewBinding, error) {
+	var binding ReviewBinding
+	decoder := json.NewDecoder(bytes.NewReader(payload))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&binding); err != nil {
+		return ReviewBinding{}, err
+	}
+	var extra any
+	if err := decoder.Decode(&extra); err != io.EOF {
+		return ReviewBinding{}, errors.New("multiple binding values")
+	}
+	canonical, err := bindingBytes(binding)
+	if err != nil || !bytes.Equal(payload, canonical) || binding.Schema != reviewBindingSchema || !validReviewBindingChange(binding.Change) || !reviewBindingHash.MatchString(binding.Revision) || !reviewBindingHash.MatchString(binding.AuthorityRevision) || !reviewBindingHash.MatchString(binding.ReceiptHash) || binding.Revision != bindingDigest(binding) || binding.GateContext.Gate != reviewtransaction.GatePostApply || binding.GateContext.LineageID != binding.Lineage || binding.GateContext.StoreRevision != binding.AuthorityRevision {
+		return ReviewBinding{}, errors.New("invalid binding")
+	}
+	return binding, nil
+}
+
+func writeBinding(path, expected string, binding ReviewBinding) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	lock, err := acquireBindingLock(filepath.Join(filepath.Dir(path), "LOCK"))
+	if err != nil {
+		return err
+	}
+	defer lock.release()
+	current := ""
+	if payload, err := os.ReadFile(path); err == nil {
+		old, parseErr := parseBinding(payload)
+		if parseErr != nil || old.Change != binding.Change {
+			return errors.New("invalid existing binding")
+		}
+		current = old.Revision
+		if current == binding.Revision {
+			return nil
+		}
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+	if current != expected {
+		return fmt.Errorf("binding revision conflict: expected %q, current %q", expected, current)
+	}
+	payload, err := bindingBytes(binding)
+	if err != nil {
+		return err
+	}
+	temp, err := os.CreateTemp(filepath.Dir(path), ".binding-")
+	if err != nil {
+		return err
+	}
+	if _, err = temp.Write(payload); err == nil {
+		err = temp.Sync()
+	}
+	if closeErr := temp.Close(); err == nil {
+		err = closeErr
+	}
+	if err != nil {
+		_ = os.Remove(temp.Name())
+		return err
+	}
+	return os.Rename(temp.Name(), path)
+}

--- a/internal/sddstatus/review_binding_lock.go
+++ b/internal/sddstatus/review_binding_lock.go
@@ -1,0 +1,43 @@
+package sddstatus
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+type bindingLock struct{ file *os.File }
+
+func acquireBindingLock(path string) (*bindingLock, error) {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return nil, err
+	}
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	locked, err := tryLockBindingFile(file)
+	if err != nil {
+		_ = file.Close()
+		return nil, fmt.Errorf("lock SDD review binding: %w", err)
+	}
+	if !locked {
+		_ = file.Close()
+		return nil, errors.New("SDD review binding is concurrently updated")
+	}
+	return &bindingLock{file: file}, nil
+}
+
+func (lock *bindingLock) release() error {
+	if lock == nil || lock.file == nil {
+		return nil
+	}
+	err := unlockBindingFile(lock.file)
+	closeErr := lock.file.Close()
+	lock.file = nil
+	if err != nil {
+		return err
+	}
+	return closeErr
+}

--- a/internal/sddstatus/review_binding_lock_unix.go
+++ b/internal/sddstatus/review_binding_lock_unix.go
@@ -1,0 +1,22 @@
+//go:build unix
+
+package sddstatus
+
+import (
+	"errors"
+	"os"
+	"syscall"
+)
+
+func tryLockBindingFile(file *os.File) (bool, error) {
+	err := syscall.Flock(int(file.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, syscall.EWOULDBLOCK) || errors.Is(err, syscall.EAGAIN) {
+		return false, nil
+	}
+	return false, err
+}
+
+func unlockBindingFile(file *os.File) error { return syscall.Flock(int(file.Fd()), syscall.LOCK_UN) }

--- a/internal/sddstatus/review_binding_lock_windows.go
+++ b/internal/sddstatus/review_binding_lock_windows.go
@@ -1,0 +1,25 @@
+//go:build windows
+
+package sddstatus
+
+import (
+	"errors"
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+func tryLockBindingFile(file *os.File) (bool, error) {
+	err := windows.LockFileEx(windows.Handle(file.Fd()), windows.LOCKFILE_EXCLUSIVE_LOCK|windows.LOCKFILE_FAIL_IMMEDIATELY, 0, 1, 0, new(windows.Overlapped))
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, windows.ERROR_LOCK_VIOLATION) {
+		return false, nil
+	}
+	return false, err
+}
+
+func unlockBindingFile(file *os.File) error {
+	return windows.UnlockFileEx(windows.Handle(file.Fd()), 0, 1, 0, new(windows.Overlapped))
+}

--- a/internal/sddstatus/review_binding_test.go
+++ b/internal/sddstatus/review_binding_test.go
@@ -1,0 +1,354 @@
+package sddstatus
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/internal/reviewtransaction"
+)
+
+func TestBindApprovedReviewRejectsInvalidChangeBeforePublishing(t *testing.T) {
+	if _, err := BindApprovedReview(context.Background(), t.TempDir(), "../escape", "approved", ""); err == nil {
+		t.Fatal("traversal change name was accepted")
+	}
+}
+
+func TestBindApprovedReviewCASAndLiveEvidence(t *testing.T) {
+	root := t.TempDir()
+	changeRoot := seedReadyChange(t, root, "thin", "- [x] 1.1 Done\n")
+	writeApprovedCompactAuthorityForChange(t, root, changeRoot, "approved-thin")
+	binding, err := BindApprovedReview(context.Background(), root, "thin", "approved-thin", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if binding.Schema != reviewBindingSchema || binding.AuthorityRevision == "" || binding.ReceiptHash == "" || binding.GateContext.Gate != "post-apply" {
+		t.Fatalf("binding = %#v", binding)
+	}
+	if _, err := BindApprovedReview(context.Background(), filepath.Join(root, "openspec", "changes", "thin"), "thin", "approved-thin", ""); err != nil {
+		t.Fatalf("exact retry with original empty expected revision: %v", err)
+	}
+	if _, err := BindApprovedReview(context.Background(), root, "thin", "other", binding.Revision); err == nil {
+		t.Fatal("conflicting lineage accepted")
+	}
+	if _, err := BindApprovedReview(context.Background(), root, "thin", "approved-thin", "sha256:deadbeef"); err != nil {
+		t.Fatalf("identical candidate retry must precede expected revision conflict: %v", err)
+	}
+	store, _ := reviewtransaction.CompactAuthoritativeStore(context.Background(), root, "approved-thin")
+	path := bindingPath(store, "thin")
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("common-dir binding: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("corrupt"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := BindApprovedReview(context.Background(), root, "thin", "approved-thin", binding.Revision); err == nil {
+		t.Fatal("corrupt binding accepted")
+	}
+	if err := os.WriteFile(filepath.Join(changeRoot, "tasks.md"), []byte("- [x] 1.1 Done\n# drift\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := BindApprovedReview(context.Background(), root, "thin", "approved-thin", ""); err == nil {
+		t.Fatal("working-tree drift bound authority")
+	}
+}
+
+func TestResolveConsumesOnlyAnExplicitValidBinding(t *testing.T) {
+	root := t.TempDir()
+	changeRoot := seedReadyChange(t, root, "thin", "- [x] 1.1 Done\n")
+	writeApprovedCompactAuthorityForChange(t, root, changeRoot, "approved-thin")
+
+	withoutBinding, err := Resolve(ResolveOptions{CWD: root, ChangeName: "thin"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if withoutBinding.NextRecommended != "verify" || withoutBinding.Dependencies.Verify != DependencyReady {
+		t.Fatalf("unbound authority status = %#v", withoutBinding)
+	}
+
+	if _, err := BindApprovedReview(context.Background(), root, "thin", "approved-thin", ""); err != nil {
+		t.Fatal(err)
+	}
+	bound, err := Resolve(ResolveOptions{CWD: root, ChangeName: "thin"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bound.NextRecommended != "verify" || bound.Dependencies.Verify != DependencyReady || bound.Dependencies.Archive != DependencyBlocked || bound.ReviewGate == nil || bound.ReviewGate.Result != reviewtransaction.GateAllow {
+		t.Fatalf("bound authority status = %#v", bound)
+	}
+}
+
+func TestBindApprovedReviewRequiresTheSelectedCanonicalChange(t *testing.T) {
+	for _, change := range []string{"../escape", "thin-", "thin--binding", strings.Repeat("a", 129)} {
+		if _, err := BindApprovedReview(context.Background(), t.TempDir(), change, "approved", ""); err == nil {
+			t.Fatalf("invalid change %q was accepted", change)
+		}
+	}
+}
+
+func TestValidateBoundReviewFailsClosedWhenFinalGateChanges(t *testing.T) {
+	root := t.TempDir()
+	changeRoot := seedReadyChange(t, root, "thin", "- [x] 1.1 Done\n")
+	writeApprovedCompactAuthorityForChange(t, root, changeRoot, "approved-thin")
+	if _, err := BindApprovedReview(context.Background(), root, "thin", "approved-thin", ""); err != nil {
+		t.Fatal(err)
+	}
+	original := bindingFinalAuthorizationHook
+	bindingFinalAuthorizationHook = func() { write(t, filepath.Join(changeRoot, "tasks.md"), "- [x] 1.1 Done\n# final gate drift\n") }
+	t.Cleanup(func() { bindingFinalAuthorizationHook = original })
+	if _, _, err := validateBoundReview(context.Background(), root, "thin"); err == nil {
+		t.Fatal("final live gate mutation was accepted")
+	}
+}
+
+func TestValidateBoundReviewFailsClosedForFinalAuthorityArtifacts(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		mutate func(t *testing.T, store reviewtransaction.CompactStore)
+	}{
+		{name: "receipt bytes", mutate: func(t *testing.T, store reviewtransaction.CompactStore) {
+			if err := os.WriteFile(store.ReceiptPath(), []byte("{}\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+		}},
+		{name: "authority state", mutate: func(t *testing.T, store reviewtransaction.CompactStore) {
+			if err := os.WriteFile(store.StatePath(), []byte("{}\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+		}},
+		{name: "binding bytes", mutate: func(t *testing.T, store reviewtransaction.CompactStore) {
+			if err := os.WriteFile(bindingPath(store, "thin"), []byte("{}\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+		}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			changeRoot := seedReadyChange(t, root, "thin", "- [x] 1.1 Done\n")
+			writeApprovedCompactAuthorityForChange(t, root, changeRoot, "approved-thin")
+			if _, err := BindApprovedReview(context.Background(), root, "thin", "approved-thin", ""); err != nil {
+				t.Fatal(err)
+			}
+			store, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), root, "approved-thin")
+			if err != nil {
+				t.Fatal(err)
+			}
+			original := bindingFinalAuthorizationHook
+			bindingFinalAuthorizationHook = func() { tt.mutate(t, store) }
+			t.Cleanup(func() { bindingFinalAuthorizationHook = original })
+			if _, _, err := validateBoundReview(context.Background(), root, "thin"); err == nil {
+				t.Fatal("final artifact mutation was accepted")
+			}
+		})
+	}
+}
+
+func TestBindingLockRejectsConcurrentWriter(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "binding.lock")
+	first, err := acquireBindingLock(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer first.release()
+	if second, err := acquireBindingLock(path); err == nil || second != nil {
+		t.Fatalf("concurrent binding lock = %#v, %v", second, err)
+	}
+}
+
+func TestBindingFailsClosedForLedgerDriftAndChangedLiveEvidence(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		mutate func(t *testing.T, root, changeRoot string)
+	}{
+		{name: "mismatched external ledger", mutate: func(t *testing.T, _ string, changeRoot string) {
+			if err := os.MkdirAll(filepath.Join(changeRoot, "reviews"), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(changeRoot, "reviews", "ledger.json"), []byte(`{"schema":"gentle-ai.review-ledger/v1","findings":[{"id":"wrong"}]}`), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}},
+		{name: "staged candidate drift", mutate: func(t *testing.T, root, changeRoot string) {
+			if err := os.WriteFile(filepath.Join(changeRoot, "tasks.md"), []byte("- [x] 1.1 Done\n# staged drift\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			runSDDStatusGit(t, root, "add", "openspec/changes/thin/tasks.md")
+		}},
+		{name: "committed candidate drift", mutate: func(t *testing.T, root, changeRoot string) {
+			if err := os.WriteFile(filepath.Join(changeRoot, "tasks.md"), []byte("- [x] 1.1 Done\n# committed drift\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			runSDDStatusGit(t, root, "add", "openspec/changes/thin/tasks.md")
+			runSDDStatusGit(t, root, "commit", "-qm", "drift")
+		}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			changeRoot := seedReadyChange(t, root, "thin", "- [x] 1.1 Done\n")
+			writeApprovedCompactAuthorityForChange(t, root, changeRoot, "approved-thin")
+			tt.mutate(t, root, changeRoot)
+			if _, err := BindApprovedReview(context.Background(), root, "thin", "approved-thin", ""); err == nil {
+				t.Fatal("changed live evidence created a binding")
+			}
+			store, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), root, "approved-thin")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := os.Stat(bindingPath(store, "thin")); !os.IsNotExist(err) {
+				t.Fatalf("failed bind mutated canonical path: %v", err)
+			}
+		})
+	}
+}
+
+func TestResolveRejectsCorruptOrChangedBoundEvidence(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		mutate func(t *testing.T, root string, store reviewtransaction.CompactStore, binding ReviewBinding)
+	}{
+		{name: "corrupt binding", mutate: func(t *testing.T, _ string, store reviewtransaction.CompactStore, _ ReviewBinding) {
+			if err := os.WriteFile(bindingPath(store, "thin"), []byte("{}\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+		}},
+		{name: "changed receipt", mutate: func(t *testing.T, _ string, store reviewtransaction.CompactStore, _ ReviewBinding) {
+			if err := os.WriteFile(store.ReceiptPath(), []byte("{}\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+		}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			changeRoot := seedReadyChange(t, root, "thin", "- [x] 1.1 Done\n")
+			writeApprovedCompactAuthorityForChange(t, root, changeRoot, "approved-thin")
+			binding, err := BindApprovedReview(context.Background(), root, "thin", "approved-thin", "")
+			if err != nil {
+				t.Fatal(err)
+			}
+			store, _ := reviewtransaction.CompactAuthoritativeStore(context.Background(), root, "approved-thin")
+			tt.mutate(t, root, store, binding)
+			status, err := Resolve(ResolveOptions{CWD: root, ChangeName: "thin"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if status.NextRecommended != "resolve-review" || status.Dependencies.Verify != DependencyBlocked {
+				t.Fatalf("%s status = %#v", tt.name, status)
+			}
+		})
+	}
+}
+
+func TestBoundReviewUsesNormalVerifyThenArchiveRouting(t *testing.T) {
+	root := t.TempDir()
+	changeRoot := seedReadyChange(t, root, "thin", "- [x] 1.1 Done\n")
+	write(t, filepath.Join(changeRoot, "specs", "auth", "spec.md"), "### Requirement: Binding\n#### Scenario: Exact authority\n")
+	writeApprovedCompactAuthorityForChange(t, root, changeRoot, "approved-thin")
+	if _, err := BindApprovedReview(context.Background(), root, "thin", "approved-thin", ""); err != nil {
+		t.Fatal(err)
+	}
+	write(t, filepath.Join(changeRoot, "verify-report.md"), boundedVerifyEnvelope(shaID("a"), "pass"))
+
+	status, err := Resolve(ResolveOptions{CWD: root, ChangeName: "thin"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.Dependencies.Verify != DependencyAllDone || status.Dependencies.Archive != DependencyReady || status.NextRecommended != "archive" || status.ReviewGate == nil || status.ReviewGate.Result != reviewtransaction.GateAllow {
+		t.Fatalf("bound completed verification status = %#v", status)
+	}
+	store, _ := reviewtransaction.CompactAuthoritativeStore(context.Background(), root, "approved-thin")
+	if err := os.WriteFile(bindingPath(store, "thin"), []byte("{}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	status, err = Resolve(ResolveOptions{CWD: root, ChangeName: "thin"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.Dependencies.Archive != DependencyBlocked || status.NextRecommended != "resolve-review" {
+		t.Fatalf("corrupt completed binding status = %#v", status)
+	}
+}
+
+func TestSelectedBindingSupersedesOnlyItsLegacyReviewAuthority(t *testing.T) {
+	root := t.TempDir()
+	changeRoot := seedReadyChange(t, root, "thin", "- [x] 1.1 Done\n")
+	write(t, filepath.Join(changeRoot, "specs", "auth", "spec.md"), "### Requirement: Binding\n#### Scenario: Exact authority\n")
+	write(t, filepath.Join(changeRoot, "verify-report.md"), boundedVerifyEnvelope(shaID("a"), "pass"))
+	writeApprovedReviewArtifacts(t, changeRoot)
+	if err := os.Remove(filepath.Join(changeRoot, "verify-report.md")); err != nil {
+		t.Fatal(err)
+	}
+	writeApprovedCompactAuthorityForChange(t, root, changeRoot, "approved-thin")
+	if _, err := BindApprovedReview(context.Background(), root, "thin", "approved-thin", ""); err != nil {
+		t.Fatal(err)
+	}
+	legacy, err := reviewtransaction.AuthoritativeStore(context.Background(), root, "thin-lineage")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := legacy.LoadChain(); err != nil {
+		t.Fatalf("binding removed or changed legacy authority: %v", err)
+	}
+	status, err := Resolve(ResolveOptions{CWD: root, ChangeName: "thin"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.NextRecommended != "verify" || status.Dependencies.Verify != DependencyReady || status.ReviewGate == nil || status.ReviewGate.Result != reviewtransaction.GateAllow {
+		t.Fatalf("selected binding did not supersede only the selected legacy authority: %#v", status)
+	}
+}
+
+func TestValidBindingDoesNotAdvanceIncompleteApply(t *testing.T) {
+	root := t.TempDir()
+	changeRoot := seedReadyChange(t, root, "thin", "- [ ] 1.1 Pending\n")
+	writeApprovedCompactAuthorityForChangeWithTasks(t, root, changeRoot, "approved-thin", "- [ ] 1.1 Pending\n")
+	if _, err := BindApprovedReview(context.Background(), root, "thin", "approved-thin", ""); err != nil {
+		t.Fatal(err)
+	}
+	status, err := Resolve(ResolveOptions{CWD: root, ChangeName: "thin"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.ApplyState != ApplyReady || status.Dependencies.Apply != DependencyReady || status.Dependencies.Verify != DependencyBlocked || status.Dependencies.Archive != DependencyBlocked || status.NextRecommended != "apply" {
+		t.Fatalf("incomplete bound status = %#v", status)
+	}
+}
+
+func TestBindApprovedReviewSanitizesHostileGitEnvironmentFromSubdirectory(t *testing.T) {
+	root := t.TempDir()
+	changeRoot := seedReadyChange(t, root, "thin", "- [x] 1.1 Done\n")
+	writeApprovedCompactAuthorityForChange(t, root, changeRoot, "approved-thin")
+	subdirectory := filepath.Join(root, "nested")
+	if err := os.MkdirAll(subdirectory, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	hostile := t.TempDir()
+	runSDDStatusGit(t, hostile, "init", "-q")
+	for name, value := range map[string]string{
+		"GIT_DIR":        filepath.Join(hostile, ".git"),
+		"GIT_WORK_TREE":  hostile,
+		"GIT_COMMON_DIR": filepath.Join(hostile, ".git"),
+		"GIT_INDEX_FILE": filepath.Join(hostile, ".git", "index"),
+	} {
+		t.Setenv(name, value)
+	}
+	workingDirectory, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	relative, err := filepath.Rel(workingDirectory, subdirectory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := BindApprovedReview(context.Background(), relative, "thin", "approved-thin", ""); err != nil {
+		t.Fatal(err)
+	}
+	store, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), root, "approved-thin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(bindingPath(store, "thin")); err != nil {
+		t.Fatalf("binding was not stored in the selected repository common dir: %v", err)
+	}
+}

--- a/internal/sddstatus/status.go
+++ b/internal/sddstatus/status.go
@@ -317,22 +317,45 @@ func Resolve(options ResolveOptions) (Status, error) {
 	)
 	dependencies := resolveDependencies(artifacts, taskProgress, applyState, coreReady, verifyResult.Passing, remediationState.Complete)
 	nextRecommended := resolveNextRecommended(dependencies, applyState, artifacts["verifyReport"] == ArtifactDone, remediationState)
+	var boundGate *ReviewGateState
+	bindingPresent, bindingPathErr := bindingExists(context.Background(), workspaceRoot, changeName)
+	if bindingPathErr != nil {
+		return Status{}, bindingPathErr
+	}
 	bridge := compactPreVerifyBridge{}
 	recoverable := authorityOnlyFailedReport(readText(firstPath(artifactPaths.VerifyReport)))
-	if applyState == ApplyAllDone && (artifacts["verifyReport"] != ArtifactDone || recoverable) && reviewState == nil {
+	if bindingPresent {
+		_, evaluation, bindingErr := validateBoundReview(context.Background(), workspaceRoot, changeName)
+		if bindingErr == nil {
+			if applyState == ApplyAllDone && artifacts["verifyReport"] != ArtifactDone {
+				dependencies.Verify = DependencyReady
+				dependencies.Archive = DependencyBlocked
+				nextRecommended = "verify"
+			}
+			boundGate = &ReviewGateState{Result: evaluation.Result, Reason: "explicit bound compact authority exactly matches the current repository"}
+		} else {
+			dependencies.Verify = DependencyBlocked
+			dependencies.Archive = DependencyBlocked
+			nextRecommended = "resolve-review"
+			blockedReasons = append(blockedReasons, bindingErr.Error())
+		}
+	} else if applyState == ApplyAllDone && (artifacts["verifyReport"] != ArtifactDone || recoverable) && reviewState == nil {
 		fields, _ := authorityFailureFields(readText(firstPath(artifactPaths.VerifyReport)))
 		bridge = discoverCompactPreVerifyAuthority(context.Background(), workspaceRoot, changeName, fields["observed_authority_revision"])
 	}
-	if recoverable && bridge.Eligible && authorityChangedSinceReport(readText(firstPath(artifactPaths.VerifyReport)), bridge.Revision) {
+	if !bindingPresent && recoverable && bridge.Eligible && authorityChangedSinceReport(readText(firstPath(artifactPaths.VerifyReport)), bridge.Revision) {
 		dependencies.Verify = DependencyReady
 		dependencies.Archive = DependencyBlocked
 		nextRecommended = "verify"
 		remediationState = RemediationState{}
-	} else if remediationState.Reason != "" {
+	}
+	if remediationState.Reason != "" {
 		blockedReasons = append(blockedReasons, remediationState.Reason)
 	}
-	applyPreVerifyCompactBridgeRouting(&dependencies, &nextRecommended, &blockedReasons, applyState, artifacts["verifyReport"] == ArtifactDone, reviewState, bridge)
-	if !bridge.Eligible && !bridge.Relevant {
+	if !bindingPresent {
+		applyPreVerifyCompactBridgeRouting(&dependencies, &nextRecommended, &blockedReasons, applyState, artifacts["verifyReport"] == ArtifactDone, reviewState, bridge)
+	}
+	if !bindingPresent && !bridge.Eligible && !bridge.Relevant {
 		applyPreVerifyReviewRouting(&dependencies, &nextRecommended, &blockedReasons, applyState, artifacts["verifyReport"] == ArtifactDone, reviewState, reviewStateReason)
 	}
 
@@ -345,12 +368,17 @@ func Resolve(options ResolveOptions) (Status, error) {
 	status.ApplyState = applyState
 	status.RemediationState = remediationState
 	status.ReviewTransaction = reviewState
-	applyReviewGate(
-		&status,
-		workspaceRoot,
-		firstPath(artifactPaths.ReviewReceipt),
-		"",
-	)
+	if !bindingPresent {
+		applyReviewGate(
+			&status,
+			workspaceRoot,
+			firstPath(artifactPaths.ReviewReceipt),
+			"",
+		)
+	}
+	if boundGate != nil {
+		status.ReviewGate = boundGate
+	}
 	if options.IncludeInstructions {
 		instructions := renderPhaseInstructions(status)
 		status.PhaseInstructions = &instructions


### PR DESCRIPTION
## Linked Issue

Closes #1150

## PR Type

- [x] `type:bug` - Bug fix

## Summary

- Adds explicit `gentle-ai review bind-sdd` for binding one OpenSpec change to an approved compact replacement lineage.
- Persists a canonical CAS binding under the Git common directory with portable Unix/Windows locking.
- Revalidates exact binding, authority, receipt, optional ledger, live Git snapshot, and post-apply gate before every use.
- Lets `sdd-status` use the selected binding without bypassing apply, verification, archive dependencies, or existing #1179 recovery.

## Security Boundaries

- No lineage auto-discovery for binding creation.
- Exact-repeat binding is idempotent; conflicting/stale writes fail closed.
- Malformed or stale present bindings block instead of falling back.
- Final authorization rereads binding, authority, and receipt, then reruns the gate on post-hook evidence.
- Legacy authority remains immutable; only the selected change is explicitly rebound.

## Test Plan

- [x] Binding CAS, corruption, idempotency, ledger mismatch, drift, and race tests
- [x] Selected legacy-authority replacement and unrelated-authority isolation
- [x] Normal apply, verify, and archive routing tests
- [x] Existing #1179 behavior/files preserved unchanged
- [x] Relative/subdirectory and hostile Git environment tests
- [x] Real `review bind-sdd` to `sdd-status` runtime path
- [x] `go test -count=1 ./...`
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `GOOS=windows GOARCH=amd64 go build ./cmd/gentle-ai`
- [x] `gofmt` and `git diff --check`
- [x] Behavioral SDD verification: 3/3 requirements, 7/7 scenarios

## Review Size

This PR intentionally uses `size:exception`. The maintainer explicitly chose one coherent authority boundary over splitting production from its security and runtime coverage. The 866 additions include the binding store, platform locks, CLI/status integration, and adversarial tests.

## Verification Note

The SDD verifier reports no behavioral or security blockers. Its remaining FAIL is incomplete historical per-task Strict TDD provenance across the multi-session change. That provenance cannot be reconstructed honestly; it is disclosed rather than fabricated. Final direct review, full tests, vet, native/Windows builds, and race remediation all pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `review bind-sdd` command to create a validated binding for an approved review.
  * Added required inputs for working directory, change, lineage, and expected revision.
  * Review status now reflects valid bindings and recommends verification when appropriate.

* **Bug Fixes**
  * Invalid, changed, incomplete, or concurrently modified review data now fails safely and blocks further progression.
  * Improved handling of review routing when binding evidence is missing or no longer valid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->