### PR TITLE
fix(install): surface Windows GGA temp cleanup failures

### DIFF
--- a/internal/components/gga/install_test.go
+++ b/internal/components/gga/install_test.go
@@ -85,7 +85,7 @@ func TestInstallCommandByProfile(t *testing.T) {
 			name:    "windows cleans temp dir and uses git bash",
 			profile: system.PlatformProfile{OS: "windows", PackageManager: "winget"},
 			want: [][]string{
-				{"powershell", "-NoProfile", "-Command", fmt.Sprintf("Remove-Item -Recurse -Force -ErrorAction SilentlyContinue '%s'; exit 0", cloneDst)},
+				{"powershell", "-NoProfile", "-Command", fmt.Sprintf("$ErrorActionPreference = 'Stop'; if (Test-Path -LiteralPath '%s') { Remove-Item -Recurse -Force -LiteralPath '%s' }", strings.ReplaceAll(cloneDst, "'", "''"), strings.ReplaceAll(cloneDst, "'", "''"))},
 				{"git", "clone", "https://github.com/Gentleman-Programming/gentleman-guardian-angel.git", cloneDst},
 				{bash, scriptPath},
 			},

--- a/internal/installcmd/resolver.go
+++ b/internal/installcmd/resolver.go
@@ -262,7 +262,6 @@ func resolveGGAInstall(profile system.PlatformProfile) (CommandSequence, error) 
 		}, nil
 	case "apt", "pacman", "dnf":
 		const tmpDir = "/tmp/gentleman-guardian-angel"
-		_ = os.RemoveAll(tmpDir)
 		return CommandSequence{
 			{"rm", "-rf", tmpDir},
 			{"git", "clone", "https://github.com/Gentleman-Programming/gentleman-guardian-angel.git", tmpDir},
@@ -275,10 +274,9 @@ func resolveGGAInstall(profile system.PlatformProfile) (CommandSequence, error) 
 		// PowerShell is used for cleanup to avoid cmd.exe quoting issues with
 		// embedded double quotes in the "if exist ... rmdir" approach.
 		cloneDst := filepath.Join(os.TempDir(), "gentleman-guardian-angel")
-		_ = os.RemoveAll(cloneDst)
 		bash := gitBashPath()
 		return CommandSequence{
-			{"powershell", "-NoProfile", "-Command", fmt.Sprintf("Remove-Item -Recurse -Force -ErrorAction SilentlyContinue '%s'; exit 0", cloneDst)},
+			{"powershell", "-NoProfile", "-Command", fmt.Sprintf("$ErrorActionPreference = 'Stop'; if (Test-Path -LiteralPath '%s') { Remove-Item -Recurse -Force -LiteralPath '%s' }", cloneDst, cloneDst)},
 			{"git", "clone", "https://github.com/Gentleman-Programming/gentleman-guardian-angel.git", cloneDst},
 			{bash, bashScriptPath(profile, filepath.Join(cloneDst, "install.sh"))},
 		}, nil

--- a/internal/installcmd/resolver.go
+++ b/internal/installcmd/resolver.go
@@ -274,9 +274,10 @@ func resolveGGAInstall(profile system.PlatformProfile) (CommandSequence, error) 
 		// PowerShell is used for cleanup to avoid cmd.exe quoting issues with
 		// embedded double quotes in the "if exist ... rmdir" approach.
 		cloneDst := filepath.Join(os.TempDir(), "gentleman-guardian-angel")
+		safeCloneDst := powerShellSingleQuotedValue(cloneDst)
 		bash := gitBashPath()
 		return CommandSequence{
-			{"powershell", "-NoProfile", "-Command", fmt.Sprintf("$ErrorActionPreference = 'Stop'; if (Test-Path -LiteralPath '%s') { Remove-Item -Recurse -Force -LiteralPath '%s' }", cloneDst, cloneDst)},
+			{"powershell", "-NoProfile", "-Command", fmt.Sprintf("$ErrorActionPreference = 'Stop'; if (Test-Path -LiteralPath '%s') { Remove-Item -Recurse -Force -LiteralPath '%s' }", safeCloneDst, safeCloneDst)},
 			{"git", "clone", "https://github.com/Gentleman-Programming/gentleman-guardian-angel.git", cloneDst},
 			{bash, bashScriptPath(profile, filepath.Join(cloneDst, "install.sh"))},
 		}, nil
@@ -286,6 +287,10 @@ func resolveGGAInstall(profile system.PlatformProfile) (CommandSequence, error) 
 			profile.OS, profile.LinuxDistro, profile.PackageManager,
 		)
 	}
+}
+
+func powerShellSingleQuotedValue(value string) string {
+	return strings.ReplaceAll(value, "'", "''")
 }
 
 func bashScriptPath(profile system.PlatformProfile, path string) string {

--- a/internal/installcmd/resolver.go
+++ b/internal/installcmd/resolver.go
@@ -262,6 +262,7 @@ func resolveGGAInstall(profile system.PlatformProfile) (CommandSequence, error) 
 		}, nil
 	case "apt", "pacman", "dnf":
 		const tmpDir = "/tmp/gentleman-guardian-angel"
+		_ = os.RemoveAll(tmpDir)
 		return CommandSequence{
 			{"rm", "-rf", tmpDir},
 			{"git", "clone", "https://github.com/Gentleman-Programming/gentleman-guardian-angel.git", tmpDir},
@@ -274,6 +275,7 @@ func resolveGGAInstall(profile system.PlatformProfile) (CommandSequence, error) 
 		// PowerShell is used for cleanup to avoid cmd.exe quoting issues with
 		// embedded double quotes in the "if exist ... rmdir" approach.
 		cloneDst := filepath.Join(os.TempDir(), "gentleman-guardian-angel")
+		_ = os.RemoveAll(cloneDst)
 		bash := gitBashPath()
 		return CommandSequence{
 			{"powershell", "-NoProfile", "-Command", fmt.Sprintf("Remove-Item -Recurse -Force -ErrorAction SilentlyContinue '%s'; exit 0", cloneDst)},

--- a/internal/installcmd/resolver_test.go
+++ b/internal/installcmd/resolver_test.go
@@ -3,6 +3,7 @@ package installcmd
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -658,7 +659,7 @@ func TestResolveComponentInstall(t *testing.T) {
 			profile:   system.PlatformProfile{OS: "windows", PackageManager: "winget"},
 			component: model.ComponentGGA,
 			want: CommandSequence{
-				{"powershell", "-NoProfile", "-Command", fmt.Sprintf("Remove-Item -Recurse -Force -ErrorAction SilentlyContinue '%s'; exit 0", filepath.Join(os.TempDir(), "gentleman-guardian-angel"))},
+				{"powershell", "-NoProfile", "-Command", fmt.Sprintf("$ErrorActionPreference = 'Stop'; if (Test-Path -LiteralPath '%s') { Remove-Item -Recurse -Force -LiteralPath '%s' }", filepath.Join(os.TempDir(), "gentleman-guardian-angel"), filepath.Join(os.TempDir(), "gentleman-guardian-angel"))},
 				{"git", "clone", "https://github.com/Gentleman-Programming/gentleman-guardian-angel.git", filepath.Join(os.TempDir(), "gentleman-guardian-angel")},
 				{gitBashPath(), bashScriptPath(system.PlatformProfile{OS: "windows"}, filepath.Join(os.TempDir(), "gentleman-guardian-angel", "install.sh"))},
 			},
@@ -686,5 +687,77 @@ func TestResolveComponentInstall(t *testing.T) {
 				t.Fatalf("ResolveComponentInstall() = %v, want %v", command, tt.want)
 			}
 		})
+	}
+}
+
+func TestGGAInstall_CleanupCommandBehavior(t *testing.T) {
+	// Create a temp directory to simulate the clone destination.
+	tmpDir := t.TempDir()
+	staleDir := filepath.Join(tmpDir, "gentleman-guardian-angel")
+	if err := os.MkdirAll(staleDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Write a file to make it non-empty.
+	staleFile := filepath.Join(staleDir, "stale_file.txt")
+	if err := os.WriteFile(staleFile, []byte("stale content"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Resolve the installation command sequence to get the cleanup command.
+	r := NewResolver()
+	var profile system.PlatformProfile
+	if os.Getenv("OS") == "Windows_NT" {
+		profile = system.PlatformProfile{OS: "windows", PackageManager: "winget"}
+	} else {
+		profile = system.PlatformProfile{OS: "linux", LinuxDistro: "ubuntu", PackageManager: "apt"}
+	}
+
+	cmds, err := r.ResolveComponentInstall(profile, model.ComponentGGA)
+	if err != nil {
+		t.Fatalf("failed to resolve GGA install: %v", err)
+	}
+	if len(cmds) < 2 {
+		t.Fatalf("expected at least 2 commands, got %d", len(cmds))
+	}
+
+	// Replace the resolved target path with our test staleDir in the cleanup command.
+	cleanupCmd := cmds[0]
+	var testCmd []string
+	if profile.OS == "windows" {
+		// Cleanup command: powershell -NoProfile -Command "..."
+		// Substitute the system Temp path with our local staleDir.
+		systemTemp := filepath.Join(os.TempDir(), "gentleman-guardian-angel")
+		cmdStr := strings.ReplaceAll(cleanupCmd[3], systemTemp, staleDir)
+		testCmd = []string{cleanupCmd[0], cleanupCmd[1], cleanupCmd[2], cmdStr}
+	} else {
+		// Cleanup command: rm -rf /tmp/gentleman-guardian-angel
+		// Substitute /tmp/... with our local staleDir.
+		testCmd = []string{cleanupCmd[0], cleanupCmd[1], staleDir}
+	}
+
+	// Run the cleanup command.
+	var execCmd *exec.Cmd
+	if len(testCmd) > 1 {
+		execCmd = exec.Command(testCmd[0], testCmd[1:]...)
+	} else {
+		execCmd = exec.Command(testCmd[0])
+	}
+	if out, err := execCmd.CombinedOutput(); err != nil {
+		t.Fatalf("cleanup command failed: %v, output: %s", err, string(out))
+	}
+
+	// Assert the stale directory has been deleted.
+	if _, err := os.Stat(staleDir); !os.IsNotExist(err) {
+		t.Fatalf("expected stale directory %q to be deleted, but it still exists", staleDir)
+	}
+
+	// Run the cleanup command again (when directory doesn't exist) to verify no-op/success.
+	if len(testCmd) > 1 {
+		execCmd = exec.Command(testCmd[0], testCmd[1:]...)
+	} else {
+		execCmd = exec.Command(testCmd[0])
+	}
+	if out, err := execCmd.CombinedOutput(); err != nil {
+		t.Fatalf("cleanup command failed on non-existent directory: %v, output: %s", err, string(out))
 	}
 }

--- a/internal/installcmd/resolver_test.go
+++ b/internal/installcmd/resolver_test.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -659,7 +660,7 @@ func TestResolveComponentInstall(t *testing.T) {
 			profile:   system.PlatformProfile{OS: "windows", PackageManager: "winget"},
 			component: model.ComponentGGA,
 			want: CommandSequence{
-				{"powershell", "-NoProfile", "-Command", fmt.Sprintf("$ErrorActionPreference = 'Stop'; if (Test-Path -LiteralPath '%s') { Remove-Item -Recurse -Force -LiteralPath '%s' }", filepath.Join(os.TempDir(), "gentleman-guardian-angel"), filepath.Join(os.TempDir(), "gentleman-guardian-angel"))},
+				{"powershell", "-NoProfile", "-Command", fmt.Sprintf("$ErrorActionPreference = 'Stop'; if (Test-Path -LiteralPath '%s') { Remove-Item -Recurse -Force -LiteralPath '%s' }", powerShellSingleQuotedValue(filepath.Join(os.TempDir(), "gentleman-guardian-angel")), powerShellSingleQuotedValue(filepath.Join(os.TempDir(), "gentleman-guardian-angel")))},
 				{"git", "clone", "https://github.com/Gentleman-Programming/gentleman-guardian-angel.git", filepath.Join(os.TempDir(), "gentleman-guardian-angel")},
 				{gitBashPath(), bashScriptPath(system.PlatformProfile{OS: "windows"}, filepath.Join(os.TempDir(), "gentleman-guardian-angel", "install.sh"))},
 			},
@@ -706,7 +707,7 @@ func TestGGAInstall_CleanupCommandBehavior(t *testing.T) {
 	// Resolve the installation command sequence to get the cleanup command.
 	r := NewResolver()
 	var profile system.PlatformProfile
-	if os.Getenv("OS") == "Windows_NT" {
+	if runtime.GOOS == "windows" {
 		profile = system.PlatformProfile{OS: "windows", PackageManager: "winget"}
 	} else {
 		profile = system.PlatformProfile{OS: "linux", LinuxDistro: "ubuntu", PackageManager: "apt"}
@@ -726,8 +727,8 @@ func TestGGAInstall_CleanupCommandBehavior(t *testing.T) {
 	if profile.OS == "windows" {
 		// Cleanup command: powershell -NoProfile -Command "..."
 		// Substitute the system Temp path with our local staleDir.
-		systemTemp := filepath.Join(os.TempDir(), "gentleman-guardian-angel")
-		cmdStr := strings.ReplaceAll(cleanupCmd[3], systemTemp, staleDir)
+		systemTemp := powerShellSingleQuotedValue(filepath.Join(os.TempDir(), "gentleman-guardian-angel"))
+		cmdStr := strings.ReplaceAll(cleanupCmd[3], systemTemp, powerShellSingleQuotedValue(staleDir))
 		testCmd = []string{cleanupCmd[0], cleanupCmd[1], cleanupCmd[2], cmdStr}
 	} else {
 		// Cleanup command: rm -rf /tmp/gentleman-guardian-angel
@@ -759,5 +760,11 @@ func TestGGAInstall_CleanupCommandBehavior(t *testing.T) {
 	}
 	if out, err := execCmd.CombinedOutput(); err != nil {
 		t.Fatalf("cleanup command failed on non-existent directory: %v, output: %s", err, string(out))
+	}
+}
+
+func TestPowerShellSingleQuotedValue(t *testing.T) {
+	if got, want := powerShellSingleQuotedValue(`C:\Users\O'Brien\Temp`), `C:\Users\O''Brien\Temp`; got != want {
+		t.Fatalf("powerShellSingleQuotedValue() = %q, want %q", got, want)
 	}
 }


### PR DESCRIPTION
## Linked Issue

Closes #31

---

## PR Type

- [x] `type:bug` - Bug fix
- [ ] `type:feature` - New feature
- [ ] `type:docs` - Documentation only
- [ ] `type:refactor` - Code refactoring
- [ ] `type:chore` - Build, CI, or tooling changes
- [ ] `type:breaking-change` - Breaking change

---

## Summary

- Makes Windows GGA temp cleanup fail closed instead of hiding `Remove-Item` failures before `git clone`.
- Keeps the resolver pure and verifies real cleanup behavior for stale and already-absent directories.
- Escapes PowerShell single-quoted paths, including usernames such as `O'Brien`.

This replacement preserves both contributor-authored commits from #961 and adds one maintainer hardening commit on current `main`.

The second bug reported in #31 is already resolved on `main`: Enter on `ScreenBackups` assigns `SelectedBackup` and opens `ScreenRestoreConfirm`; restore, rename, and delete actions are available from that flow.

---

## Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/installcmd/resolver.go` | Fail-closed PowerShell cleanup with `Test-Path`, `LiteralPath`, and safe path quoting |
| `internal/installcmd/resolver_test.go` | Command contract, runtime platform detection, real cleanup/idempotency, quote escaping |
| `internal/components/gga/install_test.go` | Synchronizes the component-level Windows command expectation |

---

## Test Plan

```bash
go test ./...
go vet ./...
go build ./...
GOOS=windows GOARCH=amd64 go build ./...
```

- [x] Focused resolver and GGA tests pass
- [x] Full unit suite passes
- [x] Vet and native/Windows builds pass
- [ ] Official E2E workflows pending

---

## Contributor Checklist

- [x] PR is linked to approved issue #31
- [x] PR stays within 400 changed lines
- [x] Exactly one `type:*` label will be applied
- [x] Unit tests pass
- [ ] E2E tests pass - official workflows pending
- [x] No documentation update is required for this internal install correction
- [x] Commits follow Conventional Commits
- [x] Commits contain no `Co-Authored-By` trailers

---

## Notes for Reviewers

Original contributor: @decode2.

Review the first command returned by `resolveGGAInstall` and the behavior test. Cleanup errors now stop the command sequence, so `git clone` cannot mask the actual removal failure with a secondary destination-collision error.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Windows installation cleanup to safely handle paths containing special characters.
  - Cleanup now reports unexpected errors while remaining safe when the temporary directory is already absent.
  - Prevented potential issues caused by interpreting destination paths as PowerShell expressions.

- **Tests**
  - Added coverage for successful cleanup, repeated cleanup, and PowerShell path escaping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->