### PR TITLE
fix(context7): preserve OpenCode headers during injection

### DIFF
--- a/internal/components/mcp/inject.go
+++ b/internal/components/mcp/inject.go
@@ -116,13 +116,54 @@ func injectMergeIntoSettings(homeDir string, adapter agents.Adapter) (InjectionR
 
 	overlay := DefaultContext7OverlayJSON()
 	if adapter.Agent() == model.AgentOpenCode || adapter.Agent() == model.AgentKilocode {
-		overlay = OpenCodeContext7OverlayJSON()
+		return injectOpenCodeMergeIntoSettings(settingsPath)
 	}
 	if adapter.Agent() == model.AgentOpenClaw {
 		return injectOpenClawMergeIntoSettings(settingsPath)
 	}
 
 	settingsWrite, err := mergeJSONFile(settingsPath, overlay)
+	if err != nil {
+		return InjectionResult{}, err
+	}
+
+	return InjectionResult{Changed: settingsWrite.Changed, Files: []string{settingsPath}}, nil
+}
+
+func injectOpenCodeMergeIntoSettings(settingsPath string) (InjectionResult, error) {
+	baseJSON, err := osReadFile(settingsPath)
+	if err != nil {
+		return InjectionResult{}, err
+	}
+
+	overlay := OpenCodeContext7OverlayJSON()
+	if settings, parseErr := filemerge.UnmarshalJSONObject(baseJSON); parseErr == nil {
+		mcp, _ := settings["mcp"].(map[string]any)
+		context7, _ := mcp["context7"].(map[string]any)
+		if headers, ok := context7["headers"].(map[string]any); ok {
+			replacement := map[string]any{
+				"type":    "remote",
+				"url":     "https://mcp.context7.com/mcp",
+				"enabled": true,
+				"headers": headers,
+			}
+			overlay, err = json.Marshal(map[string]any{
+				"mcp": map[string]any{
+					"context7": map[string]any{"__replace__": replacement},
+				},
+			})
+			if err != nil {
+				return InjectionResult{}, fmt.Errorf("marshal opencode context7 overlay: %w", err)
+			}
+		}
+	}
+
+	merged, err := filemerge.MergeJSONObjects(baseJSON, overlay)
+	if err != nil {
+		return InjectionResult{}, err
+	}
+
+	settingsWrite, err := filemerge.WriteFileAtomic(settingsPath, merged, 0o644)
 	if err != nil {
 		return InjectionResult{}, err
 	}

--- a/internal/components/mcp/inject_test.go
+++ b/internal/components/mcp/inject_test.go
@@ -102,7 +102,11 @@ func assertOpenCodeRemoteContext7Schema(t *testing.T, path string) {
 		t.Fatalf("%q mcp.context7.enabled = %#v; want true", path, got)
 	}
 
-	assertOnlyKeys(t, path, context7, "type", "url", "enabled")
+	for _, key := range []string{"command", "args", "env", "environment"} {
+		if _, exists := context7[key]; exists {
+			t.Fatalf("%q mcp.context7 contains legacy local key %q; got %#v", path, key, context7)
+		}
+	}
 }
 
 // readMCPServersContext7Entry reads the mcpServers.context7 object used by
@@ -277,15 +281,24 @@ func TestInjectOpenClawMergesContext7UnderMCPDotServersAndMigratesLegacyMCPServe
 	}
 }
 
-func TestInjectOpenCodeReplacesLegacyContext7LocalConfig(t *testing.T) {
-	home := t.TempDir()
-	adapter := opencodeAdapter()
-	configPath := adapter.SettingsPath(home)
-	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
-		t.Fatalf("MkdirAll error = %v", err)
+func TestInjectOpenCodeAndKilocodePreserveContext7Headers(t *testing.T) {
+	tests := []struct {
+		name    string
+		adapter agents.Adapter
+	}{
+		{name: "OpenCode", adapter: opencodeAdapter()},
+		{name: "KiloCode", adapter: kilocodeAdapter()},
 	}
 
-	legacy := `{
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home := t.TempDir()
+			configPath := tt.adapter.SettingsPath(home)
+			if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+				t.Fatalf("MkdirAll error = %v", err)
+			}
+
+			existing := `{
 	  "mcp": {
 	    "context7": {
 	      "type": "local",
@@ -293,80 +306,101 @@ func TestInjectOpenCodeReplacesLegacyContext7LocalConfig(t *testing.T) {
 	      "args": ["legacy"],
 	      "env": {"TOKEN": "x"},
 	      "environment": {"TOKEN": "y"},
-	      "headers": {"Authorization": "Bearer old"},
+	      "headers": {"CONTEXT7_API_KEY": "{env:CONTEXT7_API_KEY}"},
 	      "enabled": false
+	    },
+	    "engram": {
+	      "type": "local",
+	      "command": ["engram-server"]
 	    }
 	  }
 	}`
-	if err := os.WriteFile(configPath, []byte(legacy), 0o644); err != nil {
-		t.Fatalf("WriteFile(opencode.json) error = %v", err)
-	}
+			if err := os.WriteFile(configPath, []byte(existing), 0o644); err != nil {
+				t.Fatalf("WriteFile(opencode.json) error = %v", err)
+			}
 
-	first, err := Inject(home, adapter)
-	if err != nil {
-		t.Fatalf("Inject() first error = %v", err)
-	}
-	if !first.Changed {
-		t.Fatalf("Inject() first changed = false; expected migration to rewrite legacy context7")
-	}
+			first, err := Inject(home, tt.adapter)
+			if err != nil {
+				t.Fatalf("Inject() first error = %v", err)
+			}
+			if !first.Changed {
+				t.Fatal("Inject() first changed = false")
+			}
 
-	assertOpenCodeRemoteContext7Schema(t, configPath)
+			assertOpenCodeRemoteContext7Schema(t, configPath)
+			context7 := readOpenCodeContext7Entry(t, configPath)
+			headers, ok := context7["headers"].(map[string]any)
+			if !ok || headers["CONTEXT7_API_KEY"] != "{env:CONTEXT7_API_KEY}" {
+				t.Fatalf("mcp.context7.headers = %#v; want existing API key header", context7["headers"])
+			}
 
-	second, err := Inject(home, adapter)
-	if err != nil {
-		t.Fatalf("Inject() second error = %v", err)
-	}
-	if second.Changed {
-		t.Fatalf("Inject() second changed = true; expected idempotent context7 rewrite")
-	}
+			content, err := os.ReadFile(configPath)
+			if err != nil {
+				t.Fatalf("ReadFile(opencode.json) error = %v", err)
+			}
+			if !strings.Contains(string(content), `"engram"`) {
+				t.Fatal("opencode.json missing existing mcp.engram entry")
+			}
 
-	assertOpenCodeRemoteContext7Schema(t, configPath)
+			second, err := Inject(home, tt.adapter)
+			if err != nil {
+				t.Fatalf("Inject() second error = %v", err)
+			}
+			if second.Changed {
+				t.Fatal("Inject() second changed = true")
+			}
+		})
+	}
 }
 
-func TestInjectKilocodeReplacesLegacyContext7LocalConfig(t *testing.T) {
-	home := t.TempDir()
-	adapter := kilocodeAdapter()
-	configPath := adapter.SettingsPath(home)
-	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
-		t.Fatalf("MkdirAll error = %v", err)
+func TestInjectOpenCodeAndKilocodeRecoverMalformedSettingsAndDiscardInvalidHeaders(t *testing.T) {
+	tests := []struct {
+		name     string
+		adapter  agents.Adapter
+		existing string
+	}{
+		{name: "OpenCode malformed settings", adapter: opencodeAdapter(), existing: `{malformed`},
+		{name: "KiloCode malformed settings", adapter: kilocodeAdapter(), existing: `{malformed`},
+		{name: "OpenCode malformed headers", adapter: opencodeAdapter(), existing: `{"mcp":{"context7":{"headers":`},
+		{name: "KiloCode malformed headers", adapter: kilocodeAdapter(), existing: `{"mcp":{"context7":{"headers":`},
+		{name: "OpenCode non-object headers", adapter: opencodeAdapter(), existing: `{"mcp":{"context7":{"headers":["secret"]}}}`},
+		{name: "KiloCode non-object headers", adapter: kilocodeAdapter(), existing: `{"mcp":{"context7":{"headers":"secret"}}}`},
 	}
 
-	legacy := `{
-	  "mcp": {
-	    "context7": {
-	      "type": "local",
-	      "command": ["npx", "-y", "@upstash/context7-mcp"],
-	      "args": ["legacy"],
-	      "env": {"TOKEN": "x"},
-	      "environment": {"TOKEN": "y"},
-	      "headers": {"Authorization": "Bearer old"},
-	      "enabled": false
-	    }
-	  }
-	}`
-	if err := os.WriteFile(configPath, []byte(legacy), 0o644); err != nil {
-		t.Fatalf("WriteFile(kilo opencode.json) error = %v", err)
-	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home := t.TempDir()
+			configPath := tt.adapter.SettingsPath(home)
+			if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+				t.Fatalf("MkdirAll error = %v", err)
+			}
+			if err := os.WriteFile(configPath, []byte(tt.existing), 0o644); err != nil {
+				t.Fatalf("WriteFile(opencode.json) error = %v", err)
+			}
 
-	first, err := Inject(home, adapter)
-	if err != nil {
-		t.Fatalf("Inject() first error = %v", err)
-	}
-	if !first.Changed {
-		t.Fatalf("Inject() first changed = false; expected migration to rewrite legacy context7")
-	}
+			first, err := Inject(home, tt.adapter)
+			if err != nil {
+				t.Fatalf("Inject() first error = %v", err)
+			}
+			if !first.Changed {
+				t.Fatal("Inject() first changed = false")
+			}
 
-	assertOpenCodeRemoteContext7Schema(t, configPath)
+			assertOpenCodeRemoteContext7Schema(t, configPath)
+			context7 := readOpenCodeContext7Entry(t, configPath)
+			if _, exists := context7["headers"]; exists {
+				t.Fatalf("mcp.context7.headers = %#v; want invalid headers discarded", context7["headers"])
+			}
 
-	second, err := Inject(home, adapter)
-	if err != nil {
-		t.Fatalf("Inject() second error = %v", err)
+			second, err := Inject(home, tt.adapter)
+			if err != nil {
+				t.Fatalf("Inject() second error = %v", err)
+			}
+			if second.Changed {
+				t.Fatal("Inject() second changed = true")
+			}
+		})
 	}
-	if second.Changed {
-		t.Fatalf("Inject() second changed = true; expected idempotent context7 rewrite")
-	}
-
-	assertOpenCodeRemoteContext7Schema(t, configPath)
 }
 
 func TestInjectOpenCodePreservesOtherMCPEntriesWhenReplacingContext7(t *testing.T) {


### PR DESCRIPTION
## Linked Issue

Closes #1186

## PR Type

- [x] 	type:bug - Bug fix (non-breaking change that fixes an issue)

## Summary

- Preserve valid OpenCode and KiloCode Context7 headers while replacing managed fields.
- Recover malformed settings and discard invalid header values without retaining secrets.
- Keep unrelated MCP entries intact and preserve idempotent injection.

## Changes

| File / Area | What Changed |
|-------------|-------------|
| internal/components/mcp/inject.go | Added OpenCode/KiloCode replacement logic that preserves valid headers. |
| internal/components/mcp/inject_test.go | Added coverage for preservation, recovery, replacement, idempotency, and secret removal. |

## Test Plan

- [x] Focused Context7 injection tests pass.
- [x] MCP package tests pass.
- [x] Project build passes.
- [ ] E2E tests (cd e2e && ./docker-test.sh) not run locally; CI will validate.

## Contributor Checklist

- [x] PR is linked to an issue with status:approved.
- [x] PR stays within 400 changed lines.
- [x] Added exactly one 	ype:* label.
- [x] Relevant unit tests pass.
- [ ] E2E tests pass; pending CI.
- [x] Documentation is not required for this internal bug fix.
- [x] Commit follows Conventional Commits format.
- [x] Commit has no Co-Authored-By trailer.

## Notes for Reviewers

Review lineage: 
eview-2dede22a66207f5a.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved MCP configuration updates for OpenCode and KiloCode.
  - Existing Context7 headers and unrelated MCP entries are now preserved during configuration injection.
  - Legacy local configurations are converted to valid remote Context7 settings.
  - Malformed settings or invalid headers are recovered automatically without preventing configuration updates.
  - Reapplying the configuration no longer causes unnecessary changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->