### PR TITLE
fix(context7): preserve valid OpenCode headers

### DIFF
--- a/internal/components/mcp/inject.go
+++ b/internal/components/mcp/inject.go
@@ -116,13 +116,54 @@ func injectMergeIntoSettings(homeDir string, adapter agents.Adapter) (InjectionR
 
 	overlay := DefaultContext7OverlayJSON()
 	if adapter.Agent() == model.AgentOpenCode || adapter.Agent() == model.AgentKilocode {
-		overlay = OpenCodeContext7OverlayJSON()
+		return injectOpenCodeMergeIntoSettings(settingsPath)
 	}
 	if adapter.Agent() == model.AgentOpenClaw {
 		return injectOpenClawMergeIntoSettings(settingsPath)
 	}
 
 	settingsWrite, err := mergeJSONFile(settingsPath, overlay)
+	if err != nil {
+		return InjectionResult{}, err
+	}
+
+	return InjectionResult{Changed: settingsWrite.Changed, Files: []string{settingsPath}}, nil
+}
+
+func injectOpenCodeMergeIntoSettings(settingsPath string) (InjectionResult, error) {
+	baseJSON, err := osReadFile(settingsPath)
+	if err != nil {
+		return InjectionResult{}, err
+	}
+
+	overlay := OpenCodeContext7OverlayJSON()
+	if settings, parseErr := filemerge.UnmarshalJSONObject(baseJSON); parseErr == nil {
+		mcp, _ := settings["mcp"].(map[string]any)
+		context7, _ := mcp["context7"].(map[string]any)
+		if headers, ok := context7["headers"].(map[string]any); ok {
+			replacement := map[string]any{
+				"type":    "remote",
+				"url":     "https://mcp.context7.com/mcp",
+				"enabled": true,
+				"headers": headers,
+			}
+			overlay, err = json.Marshal(map[string]any{
+				"mcp": map[string]any{
+					"context7": map[string]any{"__replace__": replacement},
+				},
+			})
+			if err != nil {
+				return InjectionResult{}, fmt.Errorf("marshal opencode context7 overlay: %w", err)
+			}
+		}
+	}
+
+	merged, err := filemerge.MergeJSONObjects(baseJSON, overlay)
+	if err != nil {
+		return InjectionResult{}, err
+	}
+
+	settingsWrite, err := filemerge.WriteFileAtomic(settingsPath, merged, 0o644)
 	if err != nil {
 		return InjectionResult{}, err
 	}

--- a/internal/components/mcp/inject.go
+++ b/internal/components/mcp/inject.go
@@ -141,11 +141,19 @@ func injectOpenCodeMergeIntoSettings(settingsPath string) (InjectionResult, erro
 		mcp, _ := settings["mcp"].(map[string]any)
 		context7, _ := mcp["context7"].(map[string]any)
 		if headers, ok := context7["headers"].(map[string]any); ok {
+			validHeaders := make(map[string]string, len(headers))
+			for name, value := range headers {
+				if header, valid := value.(string); valid {
+					validHeaders[name] = header
+				}
+			}
 			replacement := map[string]any{
 				"type":    "remote",
 				"url":     "https://mcp.context7.com/mcp",
 				"enabled": true,
-				"headers": headers,
+			}
+			if len(validHeaders) > 0 {
+				replacement["headers"] = validHeaders
 			}
 			overlay, err = json.Marshal(map[string]any{
 				"mcp": map[string]any{

--- a/internal/components/mcp/inject_test.go
+++ b/internal/components/mcp/inject_test.go
@@ -102,7 +102,11 @@ func assertOpenCodeRemoteContext7Schema(t *testing.T, path string) {
 		t.Fatalf("%q mcp.context7.enabled = %#v; want true", path, got)
 	}
 
-	assertOnlyKeys(t, path, context7, "type", "url", "enabled")
+	for _, key := range []string{"command", "args", "env", "environment"} {
+		if _, exists := context7[key]; exists {
+			t.Fatalf("%q mcp.context7 contains legacy local key %q; got %#v", path, key, context7)
+		}
+	}
 }
 
 // readMCPServersContext7Entry reads the mcpServers.context7 object used by
@@ -277,15 +281,24 @@ func TestInjectOpenClawMergesContext7UnderMCPDotServersAndMigratesLegacyMCPServe
 	}
 }
 
-func TestInjectOpenCodeReplacesLegacyContext7LocalConfig(t *testing.T) {
-	home := t.TempDir()
-	adapter := opencodeAdapter()
-	configPath := adapter.SettingsPath(home)
-	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
-		t.Fatalf("MkdirAll error = %v", err)
+func TestInjectOpenCodeAndKilocodePreserveContext7Headers(t *testing.T) {
+	tests := []struct {
+		name    string
+		adapter agents.Adapter
+	}{
+		{name: "OpenCode", adapter: opencodeAdapter()},
+		{name: "KiloCode", adapter: kilocodeAdapter()},
 	}
 
-	legacy := `{
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home := t.TempDir()
+			configPath := tt.adapter.SettingsPath(home)
+			if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+				t.Fatalf("MkdirAll error = %v", err)
+			}
+
+			existing := `{
 	  "mcp": {
 	    "context7": {
 	      "type": "local",
@@ -293,80 +306,101 @@ func TestInjectOpenCodeReplacesLegacyContext7LocalConfig(t *testing.T) {
 	      "args": ["legacy"],
 	      "env": {"TOKEN": "x"},
 	      "environment": {"TOKEN": "y"},
-	      "headers": {"Authorization": "Bearer old"},
+	      "headers": {"CONTEXT7_API_KEY": "{env:CONTEXT7_API_KEY}"},
 	      "enabled": false
+	    },
+	    "engram": {
+	      "type": "local",
+	      "command": ["engram-server"]
 	    }
 	  }
 	}`
-	if err := os.WriteFile(configPath, []byte(legacy), 0o644); err != nil {
-		t.Fatalf("WriteFile(opencode.json) error = %v", err)
-	}
+			if err := os.WriteFile(configPath, []byte(existing), 0o644); err != nil {
+				t.Fatalf("WriteFile(opencode.json) error = %v", err)
+			}
 
-	first, err := Inject(home, adapter)
-	if err != nil {
-		t.Fatalf("Inject() first error = %v", err)
-	}
-	if !first.Changed {
-		t.Fatalf("Inject() first changed = false; expected migration to rewrite legacy context7")
-	}
+			first, err := Inject(home, tt.adapter)
+			if err != nil {
+				t.Fatalf("Inject() first error = %v", err)
+			}
+			if !first.Changed {
+				t.Fatal("Inject() first changed = false")
+			}
 
-	assertOpenCodeRemoteContext7Schema(t, configPath)
+			assertOpenCodeRemoteContext7Schema(t, configPath)
+			context7 := readOpenCodeContext7Entry(t, configPath)
+			headers, ok := context7["headers"].(map[string]any)
+			if !ok || headers["CONTEXT7_API_KEY"] != "{env:CONTEXT7_API_KEY}" {
+				t.Fatalf("mcp.context7.headers = %#v; want existing API key header", context7["headers"])
+			}
 
-	second, err := Inject(home, adapter)
-	if err != nil {
-		t.Fatalf("Inject() second error = %v", err)
-	}
-	if second.Changed {
-		t.Fatalf("Inject() second changed = true; expected idempotent context7 rewrite")
-	}
+			content, err := os.ReadFile(configPath)
+			if err != nil {
+				t.Fatalf("ReadFile(opencode.json) error = %v", err)
+			}
+			if !strings.Contains(string(content), `"engram"`) {
+				t.Fatal("opencode.json missing existing mcp.engram entry")
+			}
 
-	assertOpenCodeRemoteContext7Schema(t, configPath)
+			second, err := Inject(home, tt.adapter)
+			if err != nil {
+				t.Fatalf("Inject() second error = %v", err)
+			}
+			if second.Changed {
+				t.Fatal("Inject() second changed = true")
+			}
+		})
+	}
 }
 
-func TestInjectKilocodeReplacesLegacyContext7LocalConfig(t *testing.T) {
-	home := t.TempDir()
-	adapter := kilocodeAdapter()
-	configPath := adapter.SettingsPath(home)
-	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
-		t.Fatalf("MkdirAll error = %v", err)
+func TestInjectOpenCodeAndKilocodeRecoverMalformedSettingsAndDiscardInvalidHeaders(t *testing.T) {
+	tests := []struct {
+		name     string
+		adapter  agents.Adapter
+		existing string
+	}{
+		{name: "OpenCode malformed settings", adapter: opencodeAdapter(), existing: `{malformed`},
+		{name: "KiloCode malformed settings", adapter: kilocodeAdapter(), existing: `{malformed`},
+		{name: "OpenCode malformed headers", adapter: opencodeAdapter(), existing: `{"mcp":{"context7":{"headers":`},
+		{name: "KiloCode malformed headers", adapter: kilocodeAdapter(), existing: `{"mcp":{"context7":{"headers":`},
+		{name: "OpenCode non-object headers", adapter: opencodeAdapter(), existing: `{"mcp":{"context7":{"headers":["secret"]}}}`},
+		{name: "KiloCode non-object headers", adapter: kilocodeAdapter(), existing: `{"mcp":{"context7":{"headers":"secret"}}}`},
 	}
 
-	legacy := `{
-	  "mcp": {
-	    "context7": {
-	      "type": "local",
-	      "command": ["npx", "-y", "@upstash/context7-mcp"],
-	      "args": ["legacy"],
-	      "env": {"TOKEN": "x"},
-	      "environment": {"TOKEN": "y"},
-	      "headers": {"Authorization": "Bearer old"},
-	      "enabled": false
-	    }
-	  }
-	}`
-	if err := os.WriteFile(configPath, []byte(legacy), 0o644); err != nil {
-		t.Fatalf("WriteFile(kilo opencode.json) error = %v", err)
-	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home := t.TempDir()
+			configPath := tt.adapter.SettingsPath(home)
+			if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+				t.Fatalf("MkdirAll error = %v", err)
+			}
+			if err := os.WriteFile(configPath, []byte(tt.existing), 0o644); err != nil {
+				t.Fatalf("WriteFile(opencode.json) error = %v", err)
+			}
 
-	first, err := Inject(home, adapter)
-	if err != nil {
-		t.Fatalf("Inject() first error = %v", err)
-	}
-	if !first.Changed {
-		t.Fatalf("Inject() first changed = false; expected migration to rewrite legacy context7")
-	}
+			first, err := Inject(home, tt.adapter)
+			if err != nil {
+				t.Fatalf("Inject() first error = %v", err)
+			}
+			if !first.Changed {
+				t.Fatal("Inject() first changed = false")
+			}
 
-	assertOpenCodeRemoteContext7Schema(t, configPath)
+			assertOpenCodeRemoteContext7Schema(t, configPath)
+			context7 := readOpenCodeContext7Entry(t, configPath)
+			if _, exists := context7["headers"]; exists {
+				t.Fatalf("mcp.context7.headers = %#v; want invalid headers discarded", context7["headers"])
+			}
 
-	second, err := Inject(home, adapter)
-	if err != nil {
-		t.Fatalf("Inject() second error = %v", err)
+			second, err := Inject(home, tt.adapter)
+			if err != nil {
+				t.Fatalf("Inject() second error = %v", err)
+			}
+			if second.Changed {
+				t.Fatal("Inject() second changed = true")
+			}
+		})
 	}
-	if second.Changed {
-		t.Fatalf("Inject() second changed = true; expected idempotent context7 rewrite")
-	}
-
-	assertOpenCodeRemoteContext7Schema(t, configPath)
 }
 
 func TestInjectOpenCodePreservesOtherMCPEntriesWhenReplacingContext7(t *testing.T) {

--- a/internal/components/mcp/inject_test.go
+++ b/internal/components/mcp/inject_test.go
@@ -306,7 +306,12 @@ func TestInjectOpenCodeAndKilocodePreserveContext7Headers(t *testing.T) {
 	      "args": ["legacy"],
 	      "env": {"TOKEN": "x"},
 	      "environment": {"TOKEN": "y"},
-	      "headers": {"CONTEXT7_API_KEY": "{env:CONTEXT7_API_KEY}"},
+	      "headers": {
+	        "CONTEXT7_API_KEY": "{env:CONTEXT7_API_KEY}",
+	        "number": 42,
+	        "nested": {"secret": "value"},
+	        "list": ["secret"]
+	      },
 	      "enabled": false
 	    },
 	    "engram": {
@@ -332,6 +337,11 @@ func TestInjectOpenCodeAndKilocodePreserveContext7Headers(t *testing.T) {
 			headers, ok := context7["headers"].(map[string]any)
 			if !ok || headers["CONTEXT7_API_KEY"] != "{env:CONTEXT7_API_KEY}" {
 				t.Fatalf("mcp.context7.headers = %#v; want existing API key header", context7["headers"])
+			}
+			for _, key := range []string{"number", "nested", "list"} {
+				if _, exists := headers[key]; exists {
+					t.Fatalf("mcp.context7.headers[%q] = %#v; want invalid value discarded", key, headers[key])
+				}
 			}
 
 			content, err := os.ReadFile(configPath)


### PR DESCRIPTION
## Linked Issue

Closes #1186

## PR Type

- [x] `type:bug` - Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` - New feature (non-breaking change that adds functionality)
- [ ] `type:docs` - Documentation only
- [ ] `type:refactor` - Code refactoring (no functional changes)
- [ ] `type:chore` - Build, CI, or tooling changes
- [ ] `type:breaking-change` - Breaking change (fix or feature that changes existing behavior)

## Summary

- Preserve valid OpenCode and KiloCode Context7 headers while replacing managed transport fields.
- Recover malformed settings and discard invalid header structures and non-string values.
- Keep unrelated MCP entries intact and preserve idempotent injection.
- Preserve the original contributor commit and authorship from #1196.

## Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/components/mcp/inject.go` | Preserves only schema-valid string headers while atomically replacing managed Context7 fields. |
| `internal/components/mcp/inject_test.go` | Covers preservation, recovery, invalid values, unrelated entries, and idempotency for OpenCode and KiloCode. |

## Test Plan

**Unit Tests**
```bash
go test -count=1 ./...
```

**E2E Tests**

Not run locally; CI runs the supported platform matrix.

- [x] Unit tests pass (`go test -count=1 ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Manually reproduced valid header preservation and invalid-value removal

## Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test -count=1 ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Documentation is not required for this internal bug fix
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers

## Notes for Reviewers

Direct review found that OpenCode's `McpRemoteConfig.headers` is `Record<string, string>`. The replacement filters non-string values rather than carrying invalid JSON into `opencode.json`.

Original contribution: #1196 by @decode2.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OpenCode and KiloCode MCP configuration updates.
  * Preserves valid Context7 request headers during configuration changes.
  * Removes obsolete local configuration fields and restores valid remote settings when configuration data is malformed.
  * Repeated configuration updates now produce consistent results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->