### PR TITLE
fix(review): recover bounded review lifecycles

### DIFF
--- a/docs/review-authority-threat-model.md
+++ b/docs/review-authority-threat-model.md
@@ -12,6 +12,7 @@ The compact review store protects valid authority from accidental corruption and
 | Interrupted replacement | Yes | Atomic replacement and filesystem synchronization preserve either the old or new valid record where practical. |
 | Concurrent or stale writer | Yes | A lock plus expected revision rejects stale transitions; an exact retry is idempotent. |
 | Repository changes after review | Yes | Gates re-derive evidence from live Git and reject incompatible scope or identity changes. |
+| Terminal authority needs another review | Yes | `review recover` creates a distinct audited successor; predecessor state and receipt bytes remain immutable. |
 | Malicious same-user local actor | No | No authenticity or tamper-resistance claim is made. |
 
 ## Retained Controls
@@ -24,6 +25,15 @@ The compact review store protects valid authority from accidental corruption and
 - Live-Git gate re-derivation rather than trusting persisted mirrors.
 - Checksums only where useful for detecting accidental corruption; they are not authentication.
 
+## Review Input Schemas
+
+Run `gentle-ai review schema reviewer`, `gentle-ai review schema refuter`, or `gentle-ai review schema validator` to print the versioned JSON Schema and one accepted example for the existing strict facade input. Final verification evidence remains arbitrary non-empty bytes and therefore has no invented JSON contract. Unknown JSON fields and semantic violations remain rejected before authority changes.
+
+Failed targeted validation stays in the same ordinary bounded lineage. The initial lenses and frozen finding IDs execute once, while each correction attempt records its snapshot, validation checks, and changed-line charge. Cumulative changed lines cannot exceed the original correction budget or expand immutable genesis paths.
+Three failed compact correction attempts exhaust the lineage even when their measured delta is zero; this bounds persisted retry history without rerunning review lenses or resetting the budget.
+
+Synthetic Git trees used by persisted snapshots remain subject to repository object pruning. Durable retention needs a separate Git-lifecycle design; this correction does not create hidden refs or weaken missing-object validation.
+
 ## Deleted Controls
 
 - Mandatory full transaction snapshots for every transition.
@@ -35,6 +45,9 @@ Legacy v1 chains and bundles remain readable for compatibility, but their histor
 
 ## Recovery And Rollback
 
+- Use `gentle-ai review recover` with an explicit predecessor lineage and revision, a distinct successor lineage, a disposition, reason, and actor. Approved predecessors require a proven scope change; invalidated predecessors remain terminal; escalated predecessors additionally require explicit maintainer authorization.
+- Recovery runs under the shared v2 store lock, records predecessor and operator provenance in the successor, and starts a new generation and correction budget without rewriting or deleting history.
+- Discovery authorizes only a unique valid unsuperseded leaf. Forks, dangling or mismatched predecessor links, cycles, and unrelated leaves fail closed. Explicitly selecting a superseded lineage permits historical inspection but not delivery authorization.
 - Recovery imports an explicitly exported compact authority record and binds it to the live delivered tree and original base-to-final path scope; it does not require or reconstruct obsolete intermediate trees or event history.
 - Invalid temporary or imported data never replaces the current valid authority.
 - Legacy v1 transport remains available only for legacy lineages.

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -371,7 +371,7 @@ func TestRunArgsDispatchesCompactReviewFacadeBeforePlatformValidation(t *testing
 	if err := RunArgs([]string{"review", "--help"}, &output); err != nil {
 		t.Fatalf("RunArgs(review --help) error = %v", err)
 	}
-	if !strings.Contains(output.String(), "review <start|finalize|validate|invalidate|bind-sdd>") {
+	if !strings.Contains(output.String(), "review <start|finalize|validate|invalidate|recover|schema|bind-sdd>") {
 		t.Fatalf("compact review help missing:\n%s", output.String())
 	}
 }

--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -49,6 +49,14 @@ type ReviewInvalidateResult struct {
 	StoreRevision string                  `json:"store_revision"`
 }
 
+type ReviewRecoverResult struct {
+	Operation     string                                      `json:"operation"`
+	LineageID     string                                      `json:"lineage_id"`
+	State         reviewtransaction.State                     `json:"state"`
+	StoreRevision string                                      `json:"store_revision"`
+	Recovery      reviewtransaction.CompactRecoveryProvenance `json:"recovery"`
+}
+
 type facadeFinding struct {
 	ID                string                              `json:"id,omitempty"`
 	Lens              string                              `json:"lens,omitempty"`
@@ -93,7 +101,7 @@ type facadeArtifacts struct {
 
 func RunReview(args []string, stdout io.Writer) error {
 	if len(args) == 0 || args[0] == "help" || args[0] == "-h" || args[0] == "--help" {
-		_, _ = fmt.Fprintln(stdout, "Usage: gentle-ai review <start|finalize|validate|invalidate|bind-sdd> [flags]\n\nOrdinary review facade; repository scope, authority, canonical artifacts, and lifecycle transitions are derived by Go.")
+		_, _ = fmt.Fprintln(stdout, "Usage: gentle-ai review <start|finalize|validate|invalidate|recover|schema|bind-sdd> [flags]\n\nOrdinary review facade; repository scope, authority, canonical artifacts, and lifecycle transitions are derived by Go.")
 		return nil
 	}
 	switch args[0] {
@@ -105,11 +113,89 @@ func RunReview(args []string, stdout io.Writer) error {
 		return RunReviewFacadeValidate(args[1:], stdout)
 	case "invalidate":
 		return RunReviewInvalidate(args[1:], stdout)
+	case "recover":
+		return RunReviewRecover(args[1:], stdout)
+	case "schema":
+		return RunReviewSchema(args[1:], stdout)
 	case "bind-sdd":
 		return RunReviewBindSDD(args[1:], stdout)
 	default:
 		return fmt.Errorf("unknown review command %q", args[0])
 	}
+}
+
+func RunReviewRecover(args []string, stdout io.Writer) error {
+	flags := newReviewFlagSet("review recover", stdout, "Create an auditable successor authority without changing its predecessor.")
+	cwd := flags.String("cwd", ".", "repository path")
+	predecessor := flags.String("predecessor-lineage", "", "explicit predecessor lineage")
+	expected := flags.String("expected-predecessor-revision", "", "exact predecessor revision")
+	successor := flags.String("successor-lineage", "", "distinct successor lineage")
+	disposition := flags.String("disposition", "", "scope_changed, invalidated, or escalated")
+	reason := flags.String("reason", "", "recovery reason")
+	actor := flags.String("actor", "", "recovery actor")
+	authorization := flags.String("maintainer-authorization", "", "explicit authorization required for escalated recovery")
+	policySource := flags.String("policy", "", "optional review policy file")
+	focus := flags.String("focus", "reliability", "dominant standard-risk focus")
+	if err := parseReviewFlags(flags, args); err != nil {
+		return err
+	}
+	if reviewHelpRequested(args) {
+		return nil
+	}
+	if flags.NArg() != 0 {
+		return fmt.Errorf("unexpected review recover argument %q", flags.Arg(0))
+	}
+	if strings.TrimSpace(*predecessor) == "" || strings.TrimSpace(*expected) == "" || strings.TrimSpace(*successor) == "" || strings.TrimSpace(*reason) == "" || strings.TrimSpace(*actor) == "" || strings.TrimSpace(*disposition) == "" {
+		return errors.New("review recover requires --predecessor-lineage, --expected-predecessor-revision, --successor-lineage, --disposition, --reason, and --actor")
+	}
+	builder := reviewtransaction.SnapshotBuilder{Repo: *cwd}
+	root, err := builder.ResolveRepositoryRoot(context.Background())
+	if err != nil {
+		return fmt.Errorf("resolve review repository root: %w", err)
+	}
+	predecessorStore, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), root, *predecessor)
+	if err != nil {
+		return err
+	}
+	predecessorRecord, err := predecessorStore.Load()
+	if err != nil {
+		return fmt.Errorf("load recovery predecessor: %w", err)
+	}
+	intended, err := builder.DiscoverIntendedUntracked(context.Background())
+	if err != nil {
+		return err
+	}
+	snapshot, err := (reviewtransaction.SnapshotBuilder{Repo: root}).Build(context.Background(), reviewtransaction.Target{Kind: reviewtransaction.TargetCurrentChanges, IntendedUntracked: intended})
+	if err != nil {
+		return err
+	}
+	risk, changedLines, err := (reviewtransaction.SnapshotBuilder{Repo: root}).ClassifySnapshotRisk(context.Background(), snapshot)
+	if err != nil {
+		return err
+	}
+	lenses, err := facadeSelectedLenses(risk, *focus)
+	if err != nil {
+		return err
+	}
+	policy, err := facadePolicyBytes(*policySource)
+	if err != nil {
+		return err
+	}
+	state, err := reviewtransaction.NewCompactState(reviewtransaction.Start{
+		LineageID: *successor, Mode: reviewtransaction.ModeOrdinaryBounded, Generation: predecessorRecord.State.Generation + 1,
+		Snapshot: snapshot, PolicyHash: facadePayloadHash(policy), RiskLevel: risk, SelectedLenses: lenses, OriginalChangedLines: &changedLines,
+	})
+	if err != nil {
+		return err
+	}
+	record, err := reviewtransaction.RecoverCompactAuthority(context.Background(), root, reviewtransaction.CompactRecoveryRequest{
+		PredecessorLineageID: *predecessor, ExpectedPredecessorRevision: *expected, Successor: state,
+		Disposition: reviewtransaction.RecoveryDisposition(*disposition), Reason: *reason, Actor: *actor, MaintainerAuthorization: *authorization,
+	})
+	if err != nil {
+		return err
+	}
+	return encodeReviewJSON(stdout, ReviewRecoverResult{Operation: "review/recover", LineageID: record.State.LineageID, State: record.State.State, StoreRevision: record.Revision, Recovery: *record.State.Recovery})
 }
 
 func RunReviewBindSDD(args []string, stdout io.Writer) error {
@@ -256,6 +342,11 @@ func RunReviewFacadeStart(args []string, stdout io.Writer) error {
 		return fmt.Errorf("derive facade review store: %w", err)
 	}
 	store.TracePath = strings.TrimSpace(*tracePath)
+	if existing, loadErr := store.Load(); loadErr == nil {
+		return fmt.Errorf("review lineage %q already exists at revision %s; use gentle-ai review recover with an explicit predecessor and distinct successor lineage", *lineage, existing.Revision)
+	} else if !os.IsNotExist(loadErr) {
+		return fmt.Errorf("load existing compact review lineage: %w", loadErr)
+	}
 	legacy, err := reviewtransaction.AuthoritativeStore(context.Background(), root, *lineage)
 	if err == nil {
 		if _, loadErr := legacy.LoadChain(); loadErr == nil {
@@ -640,7 +731,7 @@ func discoverCompactFacadeReview(ctx context.Context, repo, lineage string, term
 		}
 		return store, record, nil
 	}
-	stores, err := reviewtransaction.DiscoverCompactStores(ctx, repo)
+	stores, err := reviewtransaction.CompactAuthorityLeaves(ctx, repo)
 	if err != nil {
 		return reviewtransaction.CompactStore{}, reviewtransaction.CompactRecord{}, err
 	}

--- a/internal/cli/review_facade_test.go
+++ b/internal/cli/review_facade_test.go
@@ -408,7 +408,7 @@ func TestReviewFacadeCorrectionFlowResumesFromEachCompactIntermediateState(t *te
 	}
 }
 
-func TestReviewFacadePersistsOverBudgetForecastAndRejectsOverBudgetActual(t *testing.T) {
+func TestReviewFacadePersistsOverBudgetForecastAndActual(t *testing.T) {
 	newCandidate := func(t *testing.T) (string, ReviewFacadeStartResult, string) {
 		t.Helper()
 		repo := initReviewCLIRepo(t)
@@ -451,14 +451,24 @@ func TestReviewFacadePersistsOverBudgetForecastAndRejectsOverBudgetActual(t *tes
 			CorrectionRegression: facadeValidationCheck{Passed: true, Evidence: []string{"regression passes"}},
 			FollowUps:            []reviewtransaction.FollowUp{},
 		})
-		err := RunReviewFacadeFinalize([]string{"--cwd", repo, "--validation", validationPath}, io.Discard)
-		if err == nil || !strings.Contains(err.Error(), "exceeding the frozen budget") {
-			t.Fatalf("over-budget actual error = %v", err)
+		if err := RunReviewFacadeFinalize([]string{"--cwd", repo, "--validation", validationPath}, io.Discard); err != nil {
+			t.Fatal(err)
 		}
 		store, _ := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, started.LineageID)
 		record, loadErr := store.Load()
-		if loadErr != nil || record.State.State != reviewtransaction.StateCorrectionRequired || record.State.ActualCorrectionLines != nil || !reflect.DeepEqual(record.State.CurrentSnapshot, record.State.InitialSnapshot) {
-			t.Fatalf("over-budget actual changed authority = %#v, %v", record.State, loadErr)
+		if loadErr != nil || record.State.State != reviewtransaction.StateEscalated || record.State.CumulativeCorrectionLines <= record.State.CorrectionBudget || len(record.State.CorrectionAttempts) != 1 {
+			t.Fatalf("over-budget actual authority = %#v, %v", record.State, loadErr)
+		}
+		before := record.Revision
+		if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("base\none\ntwo\nthree\nfixed\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := RunReviewFacadeFinalize([]string{"--cwd", repo, "--correction-lines", "1"}, io.Discard); err != nil {
+			t.Fatal(err)
+		}
+		after, _ := store.Load()
+		if after.Revision != before || after.State.State != reviewtransaction.StateEscalated {
+			t.Fatalf("overflow authority resumed = %#v", after)
 		}
 	})
 }
@@ -490,11 +500,15 @@ func TestReviewFacadeCompactRefuterAndHostileGitSelection(t *testing.T) {
 }
 
 func TestReviewFacadeHelpAndFlatCompatibilityPathsRemainAvailable(t *testing.T) {
-	for _, subcommand := range []string{"start", "finalize", "validate"} {
+	for _, subcommand := range []string{"start", "finalize", "validate", "recover"} {
 		var output bytes.Buffer
 		if err := RunReview([]string{subcommand, "--help"}, &output); err != nil || !strings.Contains(output.String(), "Usage: gentle-ai review "+subcommand) {
 			t.Fatalf("facade %s help: %v\n%s", subcommand, err, output.String())
 		}
+	}
+	var validateHelp bytes.Buffer
+	if err := RunReview([]string{"validate", "--help"}, &validateHelp); err != nil || !strings.Contains(validateHelp.String(), "--lineage") {
+		t.Fatalf("review validate help must expose --lineage: %v\n%s", err, validateHelp.String())
 	}
 	for _, test := range []struct {
 		run  func([]string, io.Writer) error
@@ -509,6 +523,233 @@ func TestReviewFacadeHelpAndFlatCompatibilityPathsRemainAvailable(t *testing.T) 
 			t.Fatalf("flat compatibility help %q: %v\n%s", test.want, err, output.String())
 		}
 	}
+}
+
+func TestReviewSchemaExamplesMatchStrictFacadeContracts(t *testing.T) {
+	for _, kind := range []string{"reviewer", "refuter", "validator"} {
+		t.Run(kind, func(t *testing.T) {
+			var output bytes.Buffer
+			if err := RunReview([]string{"schema", kind}, &output); err != nil {
+				t.Fatal(err)
+			}
+			var document struct {
+				Schema   string            `json:"$schema"`
+				ID       string            `json:"$id"`
+				Examples []json.RawMessage `json:"examples"`
+			}
+			if err := json.Unmarshal(output.Bytes(), &document); err != nil || document.Schema == "" || document.ID == "" || len(document.Examples) != 1 {
+				t.Fatalf("schema document = %#v, %v", document, err)
+			}
+			path := filepath.Join(t.TempDir(), kind+".json")
+			if err := os.WriteFile(path, document.Examples[0], 0o600); err != nil {
+				t.Fatal(err)
+			}
+			switch kind {
+			case "reviewer":
+				if _, err := readFacadeReviewerResults([]string{path}); err != nil {
+					t.Fatal(err)
+				}
+			case "refuter":
+				var value facadeRefuterResult
+				if err := readFacadeJSON(path, &value); err != nil {
+					t.Fatal(err)
+				}
+			case "validator":
+				var value facadeValidationResult
+				if err := readFacadeJSON(path, &value); err != nil {
+					t.Fatal(err)
+				}
+				if _, err := value.compact(reviewtransaction.EmptyFixDeltaHash, []string{}); err != nil {
+					t.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func TestReviewerSchemaRequiresRuntimeMandatoryFindingEvidence(t *testing.T) {
+	var schema struct {
+		Properties map[string]struct {
+			MinItems int `json:"minItems"`
+			Items    struct {
+				Required []string `json:"required"`
+				AllOf    []struct {
+					Then struct {
+						Required []string `json:"required"`
+					} `json:"then"`
+				} `json:"allOf"`
+				Properties map[string]struct {
+					MinItems int `json:"minItems"`
+				} `json:"properties"`
+			} `json:"items"`
+		} `json:"properties"`
+	}
+	if err := json.Unmarshal(reviewInputSchemas["reviewer"], &schema); err != nil {
+		t.Fatal(err)
+	}
+	wantRequired := []string{"location", "severity", "claim", "proof_refs"}
+	wantSevere := []string{"evidence_class", "causal_disposition"}
+	if !reflect.DeepEqual(schema.Properties["findings"].Items.Required, wantRequired) || len(schema.Properties["findings"].Items.AllOf) != 1 || !reflect.DeepEqual(schema.Properties["findings"].Items.AllOf[0].Then.Required, wantSevere) || schema.Properties["evidence"].MinItems != 1 || schema.Properties["findings"].Items.Properties["proof_refs"].MinItems != 1 {
+		t.Fatalf("reviewer schema requirements = %#v", schema)
+	}
+
+	for name, payload := range map[string]string{
+		"missing location":              `{"findings":[{"severity":"CRITICAL","claim":"x","proof_refs":["proof"],"evidence_class":"deterministic","causal_disposition":"introduced"}],"evidence":["reviewed"]}`,
+		"empty evidence":                `{"findings":[],"evidence":[]}`,
+		"empty proof refs":              `{"findings":[{"location":"x.go:1","severity":"CRITICAL","claim":"x","proof_refs":[],"evidence_class":"deterministic","causal_disposition":"introduced"}],"evidence":["reviewed"]}`,
+		"missing severe classification": `{"findings":[{"location":"x.go:1","severity":"CRITICAL","claim":"x","proof_refs":["proof"]}],"evidence":["reviewed"]}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "reviewer.json")
+			if err := os.WriteFile(path, []byte(payload), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			results, err := readFacadeReviewerResults([]string{path})
+			if err != nil {
+				return
+			}
+			state := reviewtransaction.CompactState{SelectedLenses: []string{reviewtransaction.LensReliability}}
+			input, err := prepareCompactReviewerResults(state, results, facadeRefuterResult{})
+			if err == nil {
+				err = state.CompleteReview(input)
+			}
+			if err == nil {
+				t.Fatal("runtime accepted schema-invalid reviewer input")
+			}
+		})
+	}
+}
+
+func TestReviewSchemasRequireConcreteEvidenceStrings(t *testing.T) {
+	for _, kind := range []string{"reviewer", "refuter", "validator"} {
+		if !bytes.Contains(reviewInputSchemas[kind], []byte(`"pattern":"\\S"`)) {
+			t.Fatalf("%s schema lacks concrete-evidence pattern", kind)
+		}
+	}
+}
+
+func TestReviewFacadeRejectsMalformedInputsWithoutConsumingIterativeCorrection(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("base\n01\n02\n03\n04\n05\n06\n07\n08\n09\n10\n11\n12\n13\n14\n15\n16\n17\n18\n19\n20\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	started := startFacadeReview(t, repo)
+	store, _ := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, started.LineageID)
+	assertUnchanged := func(before string, err error) {
+		t.Helper()
+		if err == nil {
+			t.Fatal("malformed input was accepted")
+		}
+		after, loadErr := store.Load()
+		if loadErr != nil || after.Revision != before {
+			t.Fatalf("malformed input changed authority: %v, %#v", loadErr, after)
+		}
+	}
+	malformed := filepath.Join(t.TempDir(), "malformed.json")
+	if err := os.WriteFile(malformed, []byte(`{"findings":[],"evidence":[],"unknown":true}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	record, _ := store.Load()
+	assertUnchanged(record.Revision, RunReviewFacadeFinalize([]string{"--cwd", repo, "--result", malformed}, io.Discard))
+
+	reviewer := filepath.Join(t.TempDir(), "reviewer.json")
+	writeReviewCLIJSON(t, reviewer, facadeReviewerResult{Findings: []facadeFinding{{Location: "tracked.txt:5", Severity: "CRITICAL", Claim: "wrong value", ProofRefs: []string{"candidate-only failure"}, EvidenceClass: reviewtransaction.EvidenceInferential, CausalDisposition: reviewtransaction.CausalIntroduced}}, Evidence: []string{"reviewed once"}})
+	if err := os.WriteFile(malformed, []byte(`{"results":[],"unknown":true}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	assertUnchanged(record.Revision, RunReviewFacadeFinalize([]string{"--cwd", repo, "--result", reviewer, "--refuter", malformed}, io.Discard))
+	refuter := filepath.Join(t.TempDir(), "refuter.json")
+	writeReviewCLIJSON(t, refuter, facadeRefuterResult{Results: []facadeRefuterOutcome{{FindingID: "R3-001", Outcome: reviewtransaction.OutcomeCorroborated, ProofRefs: []string{"independent reproduction"}}}})
+	if err := RunReviewFacadeFinalize([]string{"--cwd", repo, "--result", reviewer, "--refuter", refuter, "--correction-lines", "6"}, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("base\n01\n02\n03\nfirst-fix\n05\n06\n07\n08\n09\n10\n11\n12\n13\n14\n15\n16\n17\n18\n19\n20\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(malformed, []byte(`{"original_criteria":{"passed":false,"evidence":["failed"]},"correction_regression":{"passed":false,"evidence":["failed"]},"follow_ups":[],"unknown":true}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	record, _ = store.Load()
+	assertUnchanged(record.Revision, RunReviewFacadeFinalize([]string{"--cwd", repo, "--validation", malformed}, io.Discard))
+	validator := filepath.Join(t.TempDir(), "validator.json")
+	writeReviewCLIJSON(t, validator, facadeValidationResult{OriginalCriteria: facadeValidationCheck{Passed: false, Evidence: []string{"acceptance still fails"}}, CorrectionRegression: facadeValidationCheck{Passed: false, Evidence: []string{"regression still fails"}}, FollowUps: []reviewtransaction.FollowUp{}})
+	if err := RunReviewFacadeFinalize([]string{"--cwd", repo, "--validation", validator}, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	failed, _ := store.Load()
+	if failed.State.State != reviewtransaction.StateCorrectionRequired || failed.State.CumulativeCorrectionLines <= 0 || len(failed.State.LensResults) != 1 {
+		t.Fatalf("failed validation state = %#v", failed.State)
+	}
+
+	remaining := failed.State.CorrectionBudget - failed.State.CumulativeCorrectionLines
+	if err := RunReviewFacadeFinalize([]string{"--cwd", repo, "--correction-lines", fmt.Sprint(remaining)}, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("base\n01\n02\n03\nfixed\n05\n06\n07\n08\n09\n10\n11\n12\n13\n14\n15\n16\n17\n18\n19\n20\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	writeReviewCLIJSON(t, validator, facadeValidationResult{OriginalCriteria: facadeValidationCheck{Passed: true, Evidence: []string{"acceptance passes"}}, CorrectionRegression: facadeValidationCheck{Passed: true, Evidence: []string{"regression passes"}}, FollowUps: []reviewtransaction.FollowUp{}})
+	if err := RunReviewFacadeFinalize([]string{"--cwd", repo, "--validation", validator}, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	corrected, _ := store.Load()
+	if corrected.State.State != reviewtransaction.StateValidating || corrected.State.CumulativeCorrectionLines > corrected.State.CorrectionBudget || len(corrected.State.CorrectionAttempts) != 2 || len(corrected.State.LensResults) != 1 {
+		t.Fatalf("corrected retry state = %#v", corrected.State)
+	}
+}
+
+func TestReviewRecoverCreatesSuccessorAndDiscoveryRejectsHistoricalAuthority(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("candidate\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	started := startFacadeReview(t, repo)
+	resultPath := filepath.Join(t.TempDir(), "review.json")
+	evidencePath := filepath.Join(t.TempDir(), "evidence.txt")
+	writeReviewCLIJSON(t, resultPath, facadeReviewerResult{Findings: []facadeFinding{}, Evidence: []string{"reviewed"}})
+	if err := os.WriteFile(evidencePath, []byte("tests pass\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := RunReviewFacadeFinalize([]string{"--cwd", repo, "--lineage", started.LineageID, "--result", resultPath}, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	if err := RunReviewFacadeFinalize([]string{"--cwd", repo, "--lineage", started.LineageID, "--evidence", evidencePath}, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	predecessorStore, _ := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, started.LineageID)
+	predecessor, _ := predecessorStore.Load()
+	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("changed scope\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var output bytes.Buffer
+	if err := RunReview([]string{"recover", "--cwd", repo, "--predecessor-lineage", started.LineageID,
+		"--expected-predecessor-revision", predecessor.Revision, "--successor-lineage", "review-recovered",
+		"--disposition", "scope_changed", "--reason", "candidate changed", "--actor", "maintainer"}, &output); err != nil {
+		t.Fatal(err)
+	}
+	var recovered ReviewRecoverResult
+	if err := json.Unmarshal(output.Bytes(), &recovered); err != nil {
+		t.Fatal(err)
+	}
+	if recovered.LineageID != "review-recovered" || recovered.Recovery.PredecessorRevision != predecessor.Revision {
+		t.Fatalf("recovered = %#v", recovered)
+	}
+	output.Reset()
+	if err := RunReviewFacadeValidate([]string{"--cwd", repo, "--lineage", started.LineageID, "--gate", string(reviewtransaction.GatePreCommit)}, &output); err == nil || !strings.Contains(output.String(), "superseded") {
+		t.Fatalf("historical authority validation = %v\n%s", err, output.String())
+	}
+	if err := RunReviewFacadeFinalize([]string{"--cwd", repo, "--lineage", recovered.LineageID, "--result", resultPath}, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	if err := RunReviewFacadeFinalize([]string{"--cwd", repo, "--lineage", recovered.LineageID, "--evidence", evidencePath}, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	output.Reset()
+	if err := RunReviewFacadeValidate([]string{"--cwd", repo, "--gate", string(reviewtransaction.GatePreCommit)}, &output); err != nil {
+		t.Fatalf("successor validation: %v\n%s", err, output.String())
+	}
+	assertReviewGateResult(t, output.Bytes(), reviewtransaction.GateAllow)
 }
 
 func TestReviewBindSDDRequiresExplicitInputs(t *testing.T) {

--- a/internal/cli/review_schema.go
+++ b/internal/cli/review_schema.go
@@ -1,0 +1,29 @@
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+)
+
+var reviewInputSchemas = map[string]json.RawMessage{
+	"reviewer":  json.RawMessage(`{"$schema":"https://json-schema.org/draft/2020-12/schema","$id":"https://gentle-ai.dev/schema/review/reviewer/v1","title":"Gentle AI reviewer result","type":"object","additionalProperties":false,"required":["findings","evidence"],"properties":{"lens":{"type":"string","enum":["risk","resilience","readability","reliability"]},"findings":{"type":"array","items":{"type":"object","additionalProperties":false,"required":["location","severity","claim","proof_refs"],"allOf":[{"if":{"properties":{"severity":{"enum":["BLOCKER","CRITICAL"]}},"required":["severity"]},"then":{"required":["evidence_class","causal_disposition"]}}],"properties":{"id":{"type":"string"},"lens":{"type":"string","enum":["risk","resilience","readability","reliability"]},"location":{"type":"string","minLength":1},"severity":{"type":"string","enum":["BLOCKER","CRITICAL","WARNING","SUGGESTION"]},"claim":{"type":"string","minLength":1},"proof_refs":{"type":"array","minItems":1,"items":{"type":"string","pattern":"\\S"}},"evidence_class":{"type":"string","enum":["deterministic","inferential","insufficient"]},"causal_disposition":{"type":"string","enum":["introduced","behavior-activated","worsened","pre-existing","base-only","unknown"]}}}},"evidence":{"type":"array","minItems":1,"items":{"type":"string","pattern":"\\S"}}},"examples":[{"findings":[],"evidence":["reviewed the complete candidate scope"]}]}`),
+	"refuter":   json.RawMessage(`{"$schema":"https://json-schema.org/draft/2020-12/schema","$id":"https://gentle-ai.dev/schema/review/refuter/v1","title":"Gentle AI refuter result","type":"object","additionalProperties":false,"required":["results"],"properties":{"results":{"type":"array","items":{"type":"object","additionalProperties":false,"required":["finding_id","outcome","proof_refs"],"properties":{"finding_id":{"type":"string"},"outcome":{"type":"string","enum":["corroborated","refuted","inconclusive"]},"proof_refs":{"type":"array","minItems":1,"items":{"type":"string","pattern":"\\S"}}}}}},"examples":[{"results":[]}]}`),
+	"validator": json.RawMessage(`{"$schema":"https://json-schema.org/draft/2020-12/schema","$id":"https://gentle-ai.dev/schema/review/validator/v1","title":"Gentle AI targeted validator result","type":"object","additionalProperties":false,"required":["original_criteria","correction_regression","follow_ups"],"properties":{"original_criteria":{"$ref":"#/$defs/check"},"correction_regression":{"$ref":"#/$defs/check"},"follow_ups":{"type":"array","items":{"type":"object","additionalProperties":false,"required":["observation","proof_refs"],"properties":{"observation":{"type":"string"},"proof_refs":{"type":"array","minItems":1,"items":{"type":"string","pattern":"\\S"}}}}}},"$defs":{"check":{"type":"object","additionalProperties":false,"required":["passed","evidence"],"properties":{"passed":{"type":"boolean"},"evidence":{"type":"array","minItems":1,"items":{"type":"string"}}}}},"examples":[{"original_criteria":{"passed":true,"evidence":["acceptance test passed"]},"correction_regression":{"passed":true,"evidence":["regression test passed"]},"follow_ups":[]}]}`),
+}
+
+func RunReviewSchema(args []string, stdout io.Writer) error {
+	if len(args) != 1 {
+		return errors.New("review schema requires exactly one of reviewer, refuter, or validator")
+	}
+	document, ok := reviewInputSchemas[args[0]]
+	if !ok {
+		return fmt.Errorf("unknown review schema %q", args[0])
+	}
+	var value any
+	if err := json.Unmarshal(document, &value); err != nil {
+		return err
+	}
+	return encodeReviewJSON(stdout, value)
+}

--- a/internal/reviewtransaction/compact.go
+++ b/internal/reviewtransaction/compact.go
@@ -11,42 +11,74 @@ import (
 	"reflect"
 	"sort"
 	"strings"
+	"time"
 )
 
 const CompactStateSchema = "gentle-ai.review-state/v2"
 const CompactReceiptSchema = "gentle-ai.review-receipt/v2"
 
 const (
-	StateCorrectionRequired State = "correction_required"
-	StateValidating         State = "validating"
+	StateCorrectionRequired      State = "correction_required"
+	StateValidating              State = "validating"
+	MaxCompactCorrectionAttempts       = 3
 )
 
 type CompactState struct {
-	Schema                  string                     `json:"schema"`
-	LineageID               string                     `json:"lineage_id"`
-	Generation              int                        `json:"generation"`
-	State                   State                      `json:"state"`
-	InitialSnapshot         Snapshot                   `json:"initial_snapshot"`
-	CurrentSnapshot         Snapshot                   `json:"current_snapshot"`
-	GenesisPaths            []string                   `json:"genesis_paths"`
-	PolicyHash              string                     `json:"policy_hash"`
-	RiskLevel               RiskLevel                  `json:"risk_level"`
-	SelectedLenses          []string                   `json:"selected_lenses"`
-	OriginalChangedLines    int                        `json:"original_changed_lines"`
-	CorrectionBudget        int                        `json:"correction_budget"`
-	LensResults             []LensResult               `json:"lens_results"`
-	Findings                []Finding                  `json:"findings"`
-	Classifications         map[string]FindingEvidence `json:"classifications"`
-	Outcomes                map[string]EvidenceOutcome `json:"outcomes"`
-	FixFindingIDs           []string                   `json:"fix_finding_ids"`
-	FollowUps               []FollowUp                 `json:"follow_ups"`
-	ProposedCorrectionLines *int                       `json:"proposed_correction_lines,omitempty"`
-	ActualCorrectionLines   *int                       `json:"actual_correction_lines,omitempty"`
-	FixDeltaHash            string                     `json:"fix_delta_hash"`
-	OriginalCriteria        *ValidationCheck           `json:"original_criteria,omitempty"`
-	CorrectionRegression    *ValidationCheck           `json:"correction_regression,omitempty"`
-	EvidenceHash            string                     `json:"evidence_hash,omitempty"`
-	InvalidationReason      string                     `json:"invalidation_reason,omitempty"`
+	Schema                    string                     `json:"schema"`
+	LineageID                 string                     `json:"lineage_id"`
+	Generation                int                        `json:"generation"`
+	State                     State                      `json:"state"`
+	InitialSnapshot           Snapshot                   `json:"initial_snapshot"`
+	CurrentSnapshot           Snapshot                   `json:"current_snapshot"`
+	GenesisPaths              []string                   `json:"genesis_paths"`
+	PolicyHash                string                     `json:"policy_hash"`
+	RiskLevel                 RiskLevel                  `json:"risk_level"`
+	SelectedLenses            []string                   `json:"selected_lenses"`
+	OriginalChangedLines      int                        `json:"original_changed_lines"`
+	CorrectionBudget          int                        `json:"correction_budget"`
+	LensResults               []LensResult               `json:"lens_results"`
+	Findings                  []Finding                  `json:"findings"`
+	Classifications           map[string]FindingEvidence `json:"classifications"`
+	Outcomes                  map[string]EvidenceOutcome `json:"outcomes"`
+	FixFindingIDs             []string                   `json:"fix_finding_ids"`
+	FollowUps                 []FollowUp                 `json:"follow_ups"`
+	ProposedCorrectionLines   *int                       `json:"proposed_correction_lines,omitempty"`
+	ActualCorrectionLines     *int                       `json:"actual_correction_lines,omitempty"`
+	FixDeltaHash              string                     `json:"fix_delta_hash"`
+	OriginalCriteria          *ValidationCheck           `json:"original_criteria,omitempty"`
+	CorrectionRegression      *ValidationCheck           `json:"correction_regression,omitempty"`
+	EvidenceHash              string                     `json:"evidence_hash,omitempty"`
+	InvalidationReason        string                     `json:"invalidation_reason,omitempty"`
+	Recovery                  *CompactRecoveryProvenance `json:"recovery,omitempty"`
+	CorrectionAttempts        []CompactCorrectionAttempt `json:"correction_attempts,omitempty"`
+	CumulativeCorrectionLines int                        `json:"cumulative_correction_lines,omitempty"`
+}
+
+type CompactCorrectionAttempt struct {
+	Snapshot             Snapshot        `json:"snapshot"`
+	ProposedLines        int             `json:"proposed_lines"`
+	ActualLines          int             `json:"actual_lines"`
+	FixDeltaHash         string          `json:"fix_delta_hash"`
+	OriginalCriteria     ValidationCheck `json:"original_criteria"`
+	CorrectionRegression ValidationCheck `json:"correction_regression"`
+}
+
+type RecoveryDisposition string
+
+const (
+	RecoveryScopeChanged RecoveryDisposition = "scope_changed"
+	RecoveryInvalidated  RecoveryDisposition = "invalidated"
+	RecoveryEscalated    RecoveryDisposition = "escalated"
+)
+
+type CompactRecoveryProvenance struct {
+	PredecessorLineageID    string              `json:"predecessor_lineage_id"`
+	PredecessorRevision     string              `json:"predecessor_revision"`
+	Disposition             RecoveryDisposition `json:"disposition"`
+	Reason                  string              `json:"reason"`
+	Actor                   string              `json:"actor"`
+	RecoveredAt             time.Time           `json:"recovered_at"`
+	MaintainerAuthorization string              `json:"maintainer_authorization,omitempty"`
 }
 
 type CompactReceipt struct {
@@ -121,6 +153,22 @@ func (state CompactState) Validate() error {
 	if state.Generation < 1 {
 		return errors.New("compact review state requires a positive generation")
 	}
+	if state.Recovery != nil {
+		recovery := state.Recovery
+		if validateLineageID(recovery.PredecessorLineageID) != nil || recovery.PredecessorLineageID == state.LineageID ||
+			!validSHA256(recovery.PredecessorRevision) || strings.TrimSpace(recovery.Reason) == "" || strings.TrimSpace(recovery.Actor) == "" || recovery.RecoveredAt.IsZero() {
+			return errors.New("compact recovery provenance is incomplete or invalid")
+		}
+		switch recovery.Disposition {
+		case RecoveryScopeChanged, RecoveryInvalidated:
+		case RecoveryEscalated:
+			if strings.TrimSpace(recovery.MaintainerAuthorization) == "" {
+				return errors.New("escalated recovery requires maintainer authorization")
+			}
+		default:
+			return errors.New("compact recovery disposition is invalid")
+		}
+	}
 	if err := validateSnapshot(state.InitialSnapshot); err != nil {
 		return fmt.Errorf("initial snapshot: %w", err)
 	}
@@ -175,7 +223,7 @@ func (state CompactState) Validate() error {
 	if state.ProposedCorrectionLines != nil && *state.ProposedCorrectionLines > state.CorrectionBudget && (state.State != StateEscalated || state.ActualCorrectionLines != nil) {
 		return errors.New("only a terminally escalated compact state may retain an over-budget forecast")
 	}
-	if state.ActualCorrectionLines != nil && (*state.ActualCorrectionLines < 0 || *state.ActualCorrectionLines > state.CorrectionBudget) {
+	if state.ActualCorrectionLines != nil && (*state.ActualCorrectionLines < 0 || *state.ActualCorrectionLines > state.CorrectionBudget && state.State != StateEscalated) {
 		return errors.New("compact actual correction lines must be within the frozen budget")
 	}
 	if err := validateCompactCorrection(state); err != nil {
@@ -355,6 +403,42 @@ func compactSevereFindingCount(findings []Finding) int {
 }
 
 func validateCompactCorrection(state CompactState) error {
+	if len(state.CorrectionAttempts) == 0 && state.CumulativeCorrectionLines != 0 {
+		return errors.New("compact cumulative correction lines require persisted attempts")
+	}
+	if len(state.CorrectionAttempts) > 0 {
+		base, cumulative := state.InitialSnapshot.CandidateTree, 0
+		for _, attempt := range state.CorrectionAttempts {
+			if attempt.ProposedLines <= 0 || attempt.ActualLines < 0 || attempt.Snapshot.Kind != TargetFixDiff || attempt.Snapshot.BaseTree != base ||
+				!equalStrings(attempt.Snapshot.LedgerIDs, state.FixFindingIDs) || pathsAreSubset(attempt.Snapshot.Paths, state.GenesisPaths) != nil ||
+				attempt.FixDeltaHash != FixDeltaHashForSnapshot(attempt.Snapshot) {
+				return errors.New("compact correction attempt is outside frozen scope")
+			}
+			result := ScopedValidationResult{OriginalCriteria: attempt.OriginalCriteria, CorrectionRegression: attempt.CorrectionRegression}
+			if err := validateTargetedValidation(result, attempt.FixDeltaHash); err != nil {
+				return err
+			}
+			base, cumulative = attempt.Snapshot.CandidateTree, cumulative+attempt.ActualLines
+		}
+		if cumulative != state.CumulativeCorrectionLines || cumulative > state.CorrectionBudget && state.State != StateEscalated || !snapshotsEqual(state.CurrentSnapshot, state.CorrectionAttempts[len(state.CorrectionAttempts)-1].Snapshot) {
+			return errors.New("compact cumulative correction accounting is invalid")
+		}
+		if state.State == StateCorrectionRequired {
+			if state.ProposedCorrectionLines != nil && state.CumulativeCorrectionLines+*state.ProposedCorrectionLines > state.CorrectionBudget {
+				return errors.New("compact correction forecast exceeds the remaining budget")
+			}
+			if state.ActualCorrectionLines != nil || state.OriginalCriteria != nil || state.CorrectionRegression != nil || state.FixDeltaHash != EmptyFixDeltaHash {
+				return errors.New("failed compact correction retained completed attempt state")
+			}
+			return nil
+		}
+		if state.State == StateEscalated && state.ProposedCorrectionLines != nil && state.CumulativeCorrectionLines+*state.ProposedCorrectionLines > state.CorrectionBudget && state.ActualCorrectionLines == nil {
+			return nil
+		}
+		if state.State == StateEscalated && len(state.CorrectionAttempts) >= MaxCompactCorrectionAttempts && state.ActualCorrectionLines == nil {
+			return nil
+		}
+	}
 	corrected := !snapshotsEqual(state.CurrentSnapshot, state.InitialSnapshot) || state.FixDeltaHash != EmptyFixDeltaHash || state.ActualCorrectionLines != nil || state.OriginalCriteria != nil || state.CorrectionRegression != nil
 	if !corrected {
 		if !snapshotsEqual(state.CurrentSnapshot, state.InitialSnapshot) || state.FixDeltaHash != EmptyFixDeltaHash || state.ActualCorrectionLines != nil || state.OriginalCriteria != nil || state.CorrectionRegression != nil {
@@ -379,7 +463,7 @@ func validateCompactCorrection(state CompactState) error {
 	if state.ProposedCorrectionLines == nil || *state.ProposedCorrectionLines > state.CorrectionBudget || state.ActualCorrectionLines == nil {
 		return errors.New("completed compact correction requires in-budget forecast and actual size")
 	}
-	if state.CurrentSnapshot.Kind != TargetFixDiff || state.CurrentSnapshot.BaseTree != state.InitialSnapshot.CandidateTree ||
+	if state.CurrentSnapshot.Kind != TargetFixDiff || len(state.CorrectionAttempts) == 0 && state.CurrentSnapshot.BaseTree != state.InitialSnapshot.CandidateTree ||
 		!equalStrings(state.CurrentSnapshot.LedgerIDs, state.FixFindingIDs) ||
 		!equalStrings(state.CurrentSnapshot.IntendedUntracked, state.InitialSnapshot.IntendedUntracked) {
 		return errors.New("completed compact correction snapshot is not bound to the original candidate and causal findings")
@@ -532,7 +616,7 @@ func (state *CompactState) BeginCorrection(proposed int) error {
 	}
 	value := proposed
 	state.ProposedCorrectionLines = &value
-	if proposed > state.CorrectionBudget {
+	if state.CumulativeCorrectionLines+proposed > state.CorrectionBudget {
 		state.State = StateEscalated
 	}
 	return state.Validate()
@@ -548,7 +632,7 @@ func (state *CompactState) CompleteCorrection(snapshot Snapshot, actual int, val
 	if err := pathsAreSubset(snapshot.Paths, state.GenesisPaths); err != nil {
 		return err
 	}
-	if actual < 0 || actual > state.CorrectionBudget {
+	if actual < 0 {
 		return fmt.Errorf("actual correction is %d changed lines, exceeding the frozen budget of %d", actual, state.CorrectionBudget)
 	}
 	fixHash := FixDeltaHashForSnapshot(snapshot)
@@ -558,16 +642,30 @@ func (state *CompactState) CompleteCorrection(snapshot Snapshot, actual int, val
 	if err := validateTargetedValidation(validation, fixHash); err != nil {
 		return err
 	}
+	attempt := CompactCorrectionAttempt{Snapshot: snapshot, ProposedLines: *state.ProposedCorrectionLines, ActualLines: actual, FixDeltaHash: fixHash,
+		OriginalCriteria: validation.OriginalCriteria, CorrectionRegression: validation.CorrectionRegression}
+	state.CorrectionAttempts = append(state.CorrectionAttempts, attempt)
+	state.CumulativeCorrectionLines += actual
 	state.CurrentSnapshot = snapshot
-	state.FixDeltaHash = fixHash
-	state.ActualCorrectionLines = &actual
-	original, regression := validation.OriginalCriteria, validation.CorrectionRegression
-	state.OriginalCriteria, state.CorrectionRegression = &original, &regression
 	state.FollowUps = append(state.FollowUps, validation.FollowUps...)
-	if original.Passed && regression.Passed {
+	if state.CumulativeCorrectionLines > state.CorrectionBudget {
+		state.FixDeltaHash, state.ActualCorrectionLines = fixHash, &actual
+		original, regression := validation.OriginalCriteria, validation.CorrectionRegression
+		state.OriginalCriteria, state.CorrectionRegression = &original, &regression
+		state.State = StateEscalated
+	} else if validation.OriginalCriteria.Passed && validation.CorrectionRegression.Passed {
+		state.FixDeltaHash, state.ActualCorrectionLines = fixHash, &actual
+		original, regression := validation.OriginalCriteria, validation.CorrectionRegression
+		state.OriginalCriteria, state.CorrectionRegression = &original, &regression
 		state.State = StateValidating
 	} else {
-		state.State = StateEscalated
+		state.State = StateCorrectionRequired
+		if len(state.CorrectionAttempts) >= MaxCompactCorrectionAttempts {
+			state.State = StateEscalated
+		}
+		state.ProposedCorrectionLines, state.ActualCorrectionLines = nil, nil
+		state.FixDeltaHash = EmptyFixDeltaHash
+		state.OriginalCriteria, state.CorrectionRegression = nil, nil
 	}
 	return state.Validate()
 }

--- a/internal/reviewtransaction/compact_gate.go
+++ b/internal/reviewtransaction/compact_gate.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 )
 
+var finalCompactGateAllowHook = func() {}
+
 func EvaluateCompactGate(ctx context.Context, repo string, receipt CompactReceipt, input NativeGateRequestInput) NativeGateEvaluation {
 	invalid := func(reason string) NativeGateEvaluation {
 		return NativeGateEvaluation{Result: GateInvalidated, Reason: reason}
@@ -26,6 +28,16 @@ func EvaluateCompactGate(ctx context.Context, repo string, receipt CompactReceip
 	record, err := store.Load()
 	if err != nil {
 		return invalid("compact review authority cannot be loaded: " + err.Error())
+	}
+	if _, err := CompactAuthorityLeaves(ctx, repo); err != nil {
+		return invalid(err.Error())
+	}
+	superseded, err := CompactLineageSuperseded(ctx, repo, receipt.LineageID)
+	if err != nil {
+		return invalid(err.Error())
+	}
+	if superseded {
+		return invalid("compact receipt belongs to superseded historical authority")
 	}
 	authoritative, err := record.State.Receipt()
 	if err != nil || !compactReceiptEqual(authoritative, receipt) {
@@ -109,10 +121,17 @@ func EvaluateCompactGate(ctx context.Context, repo string, receipt CompactReceip
 		release = &derived
 	}
 	gateContext.Release = release
+	lock, lockErr := acquireStoreLock(store.lockPath)
+	if lockErr != nil {
+		return invalid("compact authority changed during final authorization")
+	}
+	defer lock.release()
 	finalGateAuthorizationHook()
 	finalRecord, loadErr := store.Load()
 	finalSnapshot, finalRefs, snapshotErr := buildLifecycleSnapshot(ctx, repo, request)
-	if loadErr != nil || snapshotErr != nil || finalRecord.Revision != record.Revision || !reflect.DeepEqual(finalSnapshot, snapshot) || !sameResolvedPrePRRefs(finalRefs, resolvedPrePR) {
+	_, graphErr := CompactAuthorityLeaves(ctx, repo)
+	finalSuperseded, supersededErr := CompactLineageSuperseded(ctx, repo, receipt.LineageID)
+	if loadErr != nil || snapshotErr != nil || graphErr != nil || supersededErr != nil || finalSuperseded || finalRecord.Revision != record.Revision || !reflect.DeepEqual(finalSnapshot, snapshot) || !sameResolvedPrePRRefs(finalRefs, resolvedPrePR) {
 		return invalid("compact authority or repository target changed during final authorization")
 	}
 	if request.Gate == GateRelease {
@@ -122,6 +141,7 @@ func EvaluateCompactGate(ctx context.Context, repo string, receipt CompactReceip
 			return invalid("release evidence changed during final authorization")
 		}
 	}
+	finalCompactGateAllowHook()
 	return NativeGateEvaluation{Result: GateAllow, Reason: nativeGateReason(GateAllow), Context: gateContext}
 }
 

--- a/internal/reviewtransaction/compact_store.go
+++ b/internal/reviewtransaction/compact_store.go
@@ -51,6 +51,194 @@ type CompactTransport struct {
 	BundleDigest string          `json:"bundle_digest"`
 }
 
+type CompactRecoveryRequest struct {
+	PredecessorLineageID        string
+	ExpectedPredecessorRevision string
+	Successor                   CompactState
+	Disposition                 RecoveryDisposition
+	Reason                      string
+	Actor                       string
+	RecoveredAt                 time.Time
+	MaintainerAuthorization     string
+}
+
+func RecoverCompactAuthority(ctx context.Context, repo string, request CompactRecoveryRequest) (CompactRecord, error) {
+	predecessorStore, err := CompactAuthoritativeStore(ctx, repo, request.PredecessorLineageID)
+	if err != nil {
+		return CompactRecord{}, err
+	}
+	successorStore, err := CompactAuthoritativeStore(ctx, repo, request.Successor.LineageID)
+	if err != nil {
+		return CompactRecord{}, err
+	}
+	if request.PredecessorLineageID == request.Successor.LineageID {
+		return CompactRecord{}, errors.New("recovery requires a distinct successor lineage")
+	}
+	lock, err := acquireStoreLock(predecessorStore.lockPath)
+	if err != nil {
+		return CompactRecord{}, err
+	}
+	defer lock.release()
+	predecessor, err := predecessorStore.Load()
+	if err != nil {
+		return CompactRecord{}, fmt.Errorf("load recovery predecessor: %w", err)
+	}
+	if predecessor.Revision != request.ExpectedPredecessorRevision {
+		return CompactRecord{}, fmt.Errorf("%w: expected predecessor revision %q, current %q", ErrConcurrentUpdate, request.ExpectedPredecessorRevision, predecessor.Revision)
+	}
+	existing, existingErr := successorStore.Load()
+	if existingErr != nil && !os.IsNotExist(existingErr) {
+		return CompactRecord{}, existingErr
+	}
+	if request.RecoveredAt.IsZero() && existingErr == nil && existing.State.Recovery != nil {
+		request.RecoveredAt = existing.State.Recovery.RecoveredAt
+	}
+	if request.RecoveredAt.IsZero() {
+		request.RecoveredAt = time.Now().UTC()
+	}
+	request.Successor.Recovery = &CompactRecoveryProvenance{
+		PredecessorLineageID: request.PredecessorLineageID, PredecessorRevision: predecessor.Revision,
+		Disposition: request.Disposition, Reason: strings.TrimSpace(request.Reason), Actor: strings.TrimSpace(request.Actor),
+		RecoveredAt: request.RecoveredAt.UTC(), MaintainerAuthorization: strings.TrimSpace(request.MaintainerAuthorization),
+	}
+	stores, err := DiscoverCompactStores(ctx, repo)
+	if err != nil {
+		return CompactRecord{}, err
+	}
+	if _, err := CompactAuthorityLeaves(ctx, repo); err != nil {
+		return CompactRecord{}, err
+	}
+	if existingErr == nil {
+		if compactStateEqual(existing.State, request.Successor) {
+			return existing, nil
+		}
+		return CompactRecord{}, errors.New("recovery successor lineage already exists with different authority")
+	}
+	for _, store := range stores {
+		record, loadErr := store.Load()
+		if loadErr != nil {
+			return CompactRecord{}, fmt.Errorf("validate recovery graph: %w", loadErr)
+		}
+		if record.State.Recovery != nil && record.State.Recovery.PredecessorLineageID == request.PredecessorLineageID {
+			return CompactRecord{}, errors.New("recovery predecessor already has successor")
+		}
+	}
+	switch request.Disposition {
+	case RecoveryScopeChanged:
+		if predecessor.State.State != StateApproved {
+			return CompactRecord{}, errors.New("scope-changed recovery requires an approved predecessor")
+		}
+		if !compactRecoveryScopeChanged(predecessor.State.CurrentSnapshot, request.Successor.InitialSnapshot) {
+			return CompactRecord{}, errors.New("approved predecessor scope has not changed")
+		}
+	case RecoveryInvalidated:
+		if predecessor.State.State != StateInvalidated {
+			return CompactRecord{}, errors.New("recovery requires an invalidated predecessor")
+		}
+	case RecoveryEscalated:
+		if predecessor.State.State != StateEscalated {
+			return CompactRecord{}, errors.New("recovery requires an escalated predecessor")
+		}
+		if strings.TrimSpace(request.MaintainerAuthorization) == "" {
+			return CompactRecord{}, errors.New("escalated recovery requires explicit maintainer authorization")
+		}
+	default:
+		return CompactRecord{}, errors.New("unsupported recovery disposition")
+	}
+	if request.Successor.State != StateReviewing {
+		return CompactRecord{}, errors.New("recovery successor must start in reviewing state")
+	}
+	if request.Successor.Generation != predecessor.State.Generation+1 {
+		return CompactRecord{}, errors.New("recovery successor generation must follow predecessor")
+	}
+	if err := request.Successor.Validate(); err != nil {
+		return CompactRecord{}, err
+	}
+	if err := validateCompactRepositoryEvidence(ctx, successorStore.repo, nil, request.Successor, "review/start"); err != nil {
+		return CompactRecord{}, fmt.Errorf("%w: %v", ErrInvalidSuccessor, err)
+	}
+	record, payload, err := makeCompactRecord(request.Successor)
+	if err != nil {
+		return CompactRecord{}, err
+	}
+	if err := writeAtomic(successorStore.StatePath(), payload, 0o644); err != nil {
+		return CompactRecord{}, err
+	}
+	return record, nil
+}
+
+func compactRecoveryScopeChanged(previous, next Snapshot) bool {
+	return previous.CandidateTree != next.CandidateTree || previous.PathsDigest != next.PathsDigest || previous.Kind == next.Kind && previous.BaseTree != next.BaseTree
+}
+
+func CompactAuthorityLeaves(ctx context.Context, repo string) ([]CompactStore, error) {
+	stores, err := DiscoverCompactStores(ctx, repo)
+	if err != nil {
+		return nil, err
+	}
+	records := make(map[string]CompactRecord, len(stores))
+	storeByLineage := make(map[string]CompactStore, len(stores))
+	children := make(map[string]int)
+	for _, store := range stores {
+		record, loadErr := store.Load()
+		if loadErr != nil {
+			return nil, fmt.Errorf("invalid compact authority graph: %w", loadErr)
+		}
+		records[record.State.LineageID], storeByLineage[record.State.LineageID] = record, store
+	}
+	for lineage, record := range records {
+		if record.State.Recovery == nil {
+			continue
+		}
+		predecessor, ok := records[record.State.Recovery.PredecessorLineageID]
+		if !ok {
+			return nil, fmt.Errorf("invalid compact authority graph: dangling predecessor for %q", lineage)
+		}
+		if predecessor.Revision != record.State.Recovery.PredecessorRevision {
+			return nil, fmt.Errorf("invalid compact authority graph: predecessor revision mismatch for %q", lineage)
+		}
+		children[predecessor.State.LineageID]++
+		if children[predecessor.State.LineageID] > 1 {
+			return nil, fmt.Errorf("invalid compact authority graph: fork at %q", predecessor.State.LineageID)
+		}
+		seen := map[string]bool{lineage: true}
+		cursor := record
+		for cursor.State.Recovery != nil {
+			parent := cursor.State.Recovery.PredecessorLineageID
+			if seen[parent] {
+				return nil, errors.New("invalid compact authority graph: recovery cycle")
+			}
+			seen[parent] = true
+			cursor = records[parent]
+		}
+	}
+	leaves := []CompactStore{}
+	for lineage, store := range storeByLineage {
+		if children[lineage] == 0 {
+			leaves = append(leaves, store)
+		}
+	}
+	sort.Slice(leaves, func(i, j int) bool { return leaves[i].lineageID < leaves[j].lineageID })
+	return leaves, nil
+}
+
+func CompactLineageSuperseded(ctx context.Context, repo, lineageID string) (bool, error) {
+	stores, err := DiscoverCompactStores(ctx, repo)
+	if err != nil {
+		return false, err
+	}
+	for _, store := range stores {
+		record, loadErr := store.Load()
+		if loadErr != nil {
+			return false, loadErr
+		}
+		if record.State.Recovery != nil && record.State.Recovery.PredecessorLineageID == lineageID {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 func CompactAuthoritativeStore(ctx context.Context, repo, lineageID string) (CompactStore, error) {
 	if err := validateLineageID(lineageID); err != nil {
 		return CompactStore{}, err
@@ -82,8 +270,19 @@ func DiscoverCompactStores(ctx context.Context, repo string) ([]CompactStore, er
 		if !entry.IsDir() || validateLineageID(entry.Name()) != nil {
 			continue
 		}
+		dir := filepath.Join(versionRoot, entry.Name())
+		if _, statErr := os.Stat(filepath.Join(dir, "review-state.json")); os.IsNotExist(statErr) {
+			residue, readErr := os.ReadDir(dir)
+			unpublished := readErr == nil
+			for _, item := range residue {
+				unpublished = unpublished && strings.HasPrefix(item.Name(), ".atomic-")
+			}
+			if unpublished {
+				continue
+			}
+		}
 		stores = append(stores, CompactStore{
-			Dir: filepath.Join(versionRoot, entry.Name()), lineageID: entry.Name(), repo: root,
+			Dir: dir, lineageID: entry.Name(), repo: root,
 			lockPath: filepath.Join(versionRoot, "LOCK"),
 		})
 	}
@@ -182,11 +381,12 @@ func validateCompactRepositoryEvidence(ctx context.Context, repo string, current
 		}
 	}
 	if operation == "review/complete-fix" {
-		if err := builder.ValidateEvidence(ctx, next.CurrentSnapshot); err != nil {
+		attempt := next.CorrectionAttempts[len(next.CorrectionAttempts)-1]
+		if err := builder.ValidateEvidence(ctx, attempt.Snapshot); err != nil {
 			return errors.New("compact correction snapshot is not repository-derived")
 		}
-		lines, err := builder.ChangedLines(ctx, next.CurrentSnapshot)
-		if err != nil || next.ActualCorrectionLines == nil || lines != *next.ActualCorrectionLines {
+		lines, err := builder.ChangedLines(ctx, attempt.Snapshot)
+		if err != nil || lines != attempt.ActualLines {
 			return errors.New("compact correction size does not match repository evidence")
 		}
 	}
@@ -230,8 +430,11 @@ func validateCompactSuccessor(previous, next CompactState, operation string) err
 			return fmt.Errorf("%w: compact correction start changed unrelated state", ErrInvalidSuccessor)
 		}
 	case "review/complete-fix":
-		if previous.State != StateCorrectionRequired || previous.ProposedCorrectionLines == nil || next.State != StateValidating && next.State != StateEscalated || next.ActualCorrectionLines == nil {
+		if previous.State != StateCorrectionRequired || previous.ProposedCorrectionLines == nil || next.State != StateValidating && next.State != StateCorrectionRequired && next.State != StateEscalated || len(next.CorrectionAttempts) != len(previous.CorrectionAttempts)+1 {
 			return fmt.Errorf("%w: invalid compact correction completion", ErrInvalidSuccessor)
+		}
+		if len(previous.CorrectionAttempts) > 0 && !reflect.DeepEqual(previous.CorrectionAttempts, next.CorrectionAttempts[:len(previous.CorrectionAttempts)]) {
+			return fmt.Errorf("%w: compact correction attempt history is immutable", ErrInvalidSuccessor)
 		}
 		if !reflectCompactReviewData(previous, next) || previous.EvidenceHash != next.EvidenceHash {
 			return fmt.Errorf("%w: compact correction changed frozen review evidence", ErrInvalidSuccessor)

--- a/internal/reviewtransaction/compact_store_test.go
+++ b/internal/reviewtransaction/compact_store_test.go
@@ -1,6 +1,7 @@
 package reviewtransaction
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -9,7 +10,201 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 )
+
+func TestCompactStoreRecoverCreatesAuditableSuccessorWithoutChangingPredecessor(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	writeSnapshotFile(t, repo, "tracked.txt", "candidate\n")
+	predecessor, predecessorStore, _ := approvedCompactRevisionFixture(t, repo, "recovery-approved")
+	predecessorRecord, err := predecessorStore.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	predecessorRevision := predecessorRecord.Revision
+	receiptBefore, err := os.ReadFile(predecessorStore.ReceiptPath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	stateBefore, err := os.ReadFile(predecessorStore.StatePath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeSnapshotFile(t, repo, "tracked.txt", "changed scope\n")
+	successor := newCompactTestState(t, repo, "recovery-approved-g2")
+	successor.Generation = predecessor.Generation + 1
+	recoveredAt := time.Date(2026, 7, 13, 12, 0, 0, 0, time.UTC)
+	record, err := RecoverCompactAuthority(context.Background(), repo, CompactRecoveryRequest{
+		PredecessorLineageID: predecessor.LineageID, ExpectedPredecessorRevision: predecessorRevision,
+		Successor: successor, Disposition: RecoveryScopeChanged, Reason: "candidate scope changed after approval",
+		Actor: "maintainer@example.com", RecoveredAt: recoveredAt,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if record.State.Recovery == nil || record.State.Recovery.PredecessorLineageID != predecessor.LineageID ||
+		record.State.Recovery.PredecessorRevision != predecessorRevision || record.State.Recovery.Disposition != RecoveryScopeChanged ||
+		record.State.Recovery.Actor != "maintainer@example.com" || !record.State.Recovery.RecoveredAt.Equal(recoveredAt) {
+		t.Fatalf("recovery provenance = %#v", record.State.Recovery)
+	}
+	stateAfter, _ := os.ReadFile(predecessorStore.StatePath())
+	receiptAfter, _ := os.ReadFile(predecessorStore.ReceiptPath())
+	if !bytes.Equal(stateBefore, stateAfter) || !bytes.Equal(receiptBefore, receiptAfter) {
+		t.Fatal("recovery changed predecessor state or receipt bytes")
+	}
+	retryRequest := CompactRecoveryRequest{
+		PredecessorLineageID: predecessor.LineageID, ExpectedPredecessorRevision: predecessorRevision,
+		Successor: successor, Disposition: RecoveryScopeChanged, Reason: "candidate scope changed after approval",
+		Actor: "maintainer@example.com", RecoveredAt: recoveredAt,
+	}
+	retry, err := RecoverCompactAuthority(context.Background(), repo, retryRequest)
+	if err != nil || retry.Revision != record.Revision || !compactStateEqual(retry.State, record.State) {
+		t.Fatalf("exact recovery retry = %#v, %v", retry, err)
+	}
+	retryRequest.Reason = "different reason"
+	if _, err := RecoverCompactAuthority(context.Background(), repo, retryRequest); err == nil || !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("conflicting recovery retry error = %v", err)
+	}
+	if _, err := RecoverCompactAuthority(context.Background(), repo, CompactRecoveryRequest{
+		PredecessorLineageID: predecessor.LineageID, ExpectedPredecessorRevision: predecessorRevision,
+		Successor: newCompactTestState(t, repo, "recovery-approved-fork"), Disposition: RecoveryScopeChanged,
+		Reason: "second successor", Actor: "maintainer@example.com", RecoveredAt: recoveredAt,
+	}); err == nil || !strings.Contains(err.Error(), "already has successor") {
+		t.Fatalf("fork recovery error = %v", err)
+	}
+}
+
+func TestApprovedRecoveryTreatsBaseTreeMismatchAsScopeChange(t *testing.T) {
+	snapshot := Snapshot{BaseTree: strings.Repeat("a", 40), CandidateTree: strings.Repeat("c", 40), PathsDigest: hash("1")}
+	predecessor, successor := CompactState{State: StateApproved, CurrentSnapshot: snapshot}, CompactState{InitialSnapshot: snapshot}
+	successor.InitialSnapshot.BaseTree = strings.Repeat("b", 40)
+	predecessor.CurrentSnapshot.Kind, successor.InitialSnapshot.Kind = TargetCurrentChanges, TargetCurrentChanges
+	if !compactRecoveryScopeChanged(predecessor.CurrentSnapshot, successor.InitialSnapshot) {
+		t.Fatal("approved base-only mismatch was not recovery-eligible")
+	}
+	successor.InitialSnapshot.Kind = TargetFixDiff
+	if compactRecoveryScopeChanged(predecessor.CurrentSnapshot, successor.InitialSnapshot) {
+		t.Fatal("incompatible snapshot kinds created false base-only recovery")
+	}
+}
+
+func TestCompactGateFinalRecheckRejectsConcurrentRecoverySuccessor(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	writeSnapshotFile(t, repo, "tracked.txt", "candidate\n")
+	state, store, receipt := approvedCompactCurrentChangesFixture(t, repo, "compact-recovery-race", []string{})
+	predecessor, _ := store.Load()
+	originalHook := finalGateAuthorizationHook
+	t.Cleanup(func() { finalGateAuthorizationHook = originalHook })
+	finalGateAuthorizationHook = func() {
+		finalGateAuthorizationHook = originalHook
+		writeSnapshotFile(t, repo, "tracked.txt", "racing successor\n")
+		successor := newCompactTestState(t, repo, "compact-recovery-race-g2")
+		successor.Generation = state.Generation + 1
+		request := CompactRecoveryRequest{PredecessorLineageID: state.LineageID, ExpectedPredecessorRevision: predecessor.Revision,
+			Successor: successor, Disposition: RecoveryScopeChanged, Reason: "concurrent scope change", Actor: "maintainer"}
+		if _, err := RecoverCompactAuthority(context.Background(), repo, request); !errors.Is(err, ErrConcurrentUpdate) {
+			t.Fatalf("recovery during final recheck = %v", err)
+		}
+		writeSnapshotFile(t, repo, "tracked.txt", "candidate\n")
+	}
+	got := EvaluateCompactGate(context.Background(), repo, receipt, NativeGateRequestInput{Gate: GatePreCommit, LineageID: state.LineageID})
+	if got.Result != GateAllow {
+		t.Fatalf("concurrent recovery evaluation = %#v", got)
+	}
+}
+
+func TestCompactGateHoldsAuthorityLockThroughAllow(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	writeSnapshotFile(t, repo, "tracked.txt", "candidate\n")
+	state, store, receipt := approvedCompactCurrentChangesFixture(t, repo, "compact-allow-lock", []string{})
+	predecessor, _ := store.Load()
+	writeSnapshotFile(t, repo, "tracked.txt", "successor\n")
+	successor := newCompactTestState(t, repo, "compact-allow-lock-g2")
+	successor.Generation = state.Generation + 1
+	writeSnapshotFile(t, repo, "tracked.txt", "candidate\n")
+	original := finalCompactGateAllowHook
+	t.Cleanup(func() { finalCompactGateAllowHook = original })
+	finalCompactGateAllowHook = func() {
+		_, err := RecoverCompactAuthority(context.Background(), repo, CompactRecoveryRequest{PredecessorLineageID: state.LineageID, ExpectedPredecessorRevision: predecessor.Revision, Successor: successor, Disposition: RecoveryScopeChanged, Reason: "race", Actor: "maintainer"})
+		if !errors.Is(err, ErrConcurrentUpdate) {
+			t.Fatalf("publication during GateAllow = %v", err)
+		}
+	}
+	if got := EvaluateCompactGate(context.Background(), repo, receipt, NativeGateRequestInput{Gate: GatePreCommit, LineageID: state.LineageID}); got.Result != GateAllow {
+		t.Fatalf("gate result = %#v", got)
+	}
+	if _, err := os.Stat(filepath.Join(filepath.Dir(store.Dir), successor.LineageID, "review-state.json")); !os.IsNotExist(err) {
+		t.Fatalf("successor published after final check: %v", err)
+	}
+}
+
+func TestCompactStoreRecoverRejectsIneligibleOrUnprovenPredecessor(t *testing.T) {
+	tests := []struct {
+		name        string
+		disposition RecoveryDisposition
+		prepare     func(t *testing.T, repo string, state *CompactState, store CompactStore, revision *string)
+		authorizer  string
+		want        string
+	}{
+		{name: "approved without scope change", disposition: RecoveryScopeChanged, want: "scope has not changed"},
+		{name: "reviewing", disposition: RecoveryInvalidated, want: "requires an invalidated predecessor"},
+		{name: "escalated without authorization", disposition: RecoveryEscalated, authorizer: "", want: "maintainer authorization"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := initSnapshotRepo(t)
+			writeSnapshotFile(t, repo, "tracked.txt", "candidate\n")
+			var state CompactState
+			var store CompactStore
+			var revision string
+			var err error
+			if tt.name == "approved without scope change" {
+				state, store, _ = approvedCompactCurrentChangesFixture(t, repo, "recovery-predecessor", []string{})
+				record, loadErr := store.Load()
+				if loadErr != nil {
+					t.Fatal(loadErr)
+				}
+				revision = record.Revision
+			} else {
+				state = newCompactTestState(t, repo, "recovery-predecessor")
+				store, _ = CompactAuthoritativeStore(context.Background(), repo, state.LineageID)
+				revision, err = store.Replace("", "review/start", state)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+			if tt.name == "escalated without authorization" {
+				results := make([]LensResult, len(state.SelectedLenses))
+				for index, lens := range state.SelectedLenses {
+					results[index] = LensResult{Lens: lens, Findings: []Finding{}, Evidence: []string{"reviewed"}}
+				}
+				if err = state.CompleteReview(CompactReviewInput{LensResults: results, Classifications: []FindingEvidence{}, RefuterOutcomes: []EvidenceResult{}}); err != nil {
+					t.Fatal(err)
+				}
+				revision, err = store.Replace(revision, "review/complete-review", state)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err = state.CompleteVerification([]byte("failed verification"), false); err != nil {
+					t.Fatal(err)
+				}
+				revision, err = store.Replace(revision, "review/complete-verification", state)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+			successor := newCompactTestState(t, repo, "recovery-successor")
+			successor.Generation = state.Generation + 1
+			_, err = RecoverCompactAuthority(context.Background(), repo, CompactRecoveryRequest{
+				PredecessorLineageID: state.LineageID, ExpectedPredecessorRevision: revision, Successor: successor,
+				Disposition: tt.disposition, Reason: "recover authority", Actor: "operator", MaintainerAuthorization: tt.authorizer,
+			})
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("recovery error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}
 
 func TestCompactStoreReplacesCurrentStateWithCASAndExactRetry(t *testing.T) {
 	repo := initSnapshotRepo(t)
@@ -54,6 +249,77 @@ func TestCompactStoreReplacesCurrentStateWithCASAndExactRetry(t *testing.T) {
 	}
 }
 
+func TestCompactCorrectionRetriesWithinFrozenBudgetAndFindingScope(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	writeSnapshotFile(t, repo, "tracked.txt", "base\none\ntwo\nthree\nfour\n")
+	state := newCompactTestState(t, repo, "compact-iterative-correction")
+	finding := Finding{ID: "R3-001", Location: "tracked.txt:5", Severity: "CRITICAL", Claim: "wrong value", ProofRefs: []string{"candidate-only failure"}}
+	result := LensResult{Lens: state.SelectedLenses[0], Findings: []Finding{finding}, Evidence: []string{"reviewed once"}}
+	if err := state.CompleteReview(CompactReviewInput{LensResults: []LensResult{result}, Classifications: []FindingEvidence{{FindingID: finding.ID, Class: EvidenceDeterministic, Causality: CausalIntroduced, Proof: "changed hunk"}}, RefuterOutcomes: []EvidenceResult{}}); err != nil {
+		t.Fatal(err)
+	}
+	initialLenses := append([]LensResult(nil), state.LensResults...)
+
+	complete := func(content string, passed bool) error {
+		if err := state.BeginCorrection(1); err != nil {
+			return err
+		}
+		writeSnapshotFile(t, repo, "tracked.txt", content)
+		fix, err := (SnapshotBuilder{Repo: repo}).Build(context.Background(), Target{Kind: TargetFixDiff, BaseRef: state.CurrentSnapshot.CandidateTree, IntendedUntracked: state.InitialSnapshot.IntendedUntracked, LedgerIDs: state.FixFindingIDs})
+		if err != nil {
+			return err
+		}
+		fixHash := FixDeltaHashForSnapshot(fix)
+		return state.CompleteCorrection(fix, 1, ScopedValidationResult{LedgerIDs: []string{finding.ID}, FixCausedFindings: []Finding{}, FollowUps: []FollowUp{},
+			OriginalCriteria: ValidationCheck{EvidenceHash: hash("2"), FixDeltaHash: fixHash, Passed: passed}, CorrectionRegression: ValidationCheck{EvidenceHash: hash("3"), FixDeltaHash: fixHash, Passed: passed}})
+	}
+	if err := complete("base\none\ntwo\nthree\nfirst-fix\n", false); err != nil {
+		t.Fatal(err)
+	}
+	if state.State != StateCorrectionRequired || state.CumulativeCorrectionLines != 1 || len(state.CorrectionAttempts) != 1 {
+		t.Fatalf("failed attempt state = %#v", state)
+	}
+	if err := complete("base\none\ntwo\nthree\nfixed\n", true); err != nil {
+		t.Fatal(err)
+	}
+	if state.State != StateValidating || state.CumulativeCorrectionLines != 2 || len(state.CorrectionAttempts) != 2 || !reflect.DeepEqual(state.LensResults, initialLenses) || !reflect.DeepEqual(state.FixFindingIDs, []string{finding.ID}) {
+		t.Fatalf("successful retry state = %#v", state)
+	}
+	before := state
+	state.State, state.ProposedCorrectionLines = StateCorrectionRequired, nil
+	if err := state.BeginCorrection(state.CorrectionBudget); err != nil || state.State != StateEscalated {
+		t.Fatalf("cumulative overflow = %#v, %v", state, err)
+	}
+	state = before
+}
+
+func TestCompactZeroLineFailuresReachAttemptCap(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	writeSnapshotFile(t, repo, "tracked.txt", "base\none\ntwo\nthree\nfour\n")
+	state := newCompactTestState(t, repo, "compact-zero-attempt-cap")
+	finding := Finding{ID: "R3-001", Location: "tracked.txt:5", Severity: "CRITICAL", Claim: "wrong", ProofRefs: []string{"proof"}}
+	if err := state.CompleteReview(CompactReviewInput{LensResults: []LensResult{{Lens: state.SelectedLenses[0], Findings: []Finding{finding}, Evidence: []string{"reviewed"}}}, Classifications: []FindingEvidence{{FindingID: finding.ID, Class: EvidenceDeterministic, Causality: CausalIntroduced, Proof: "proof"}}, RefuterOutcomes: []EvidenceResult{}}); err != nil {
+		t.Fatal(err)
+	}
+	for attempt := 0; attempt < MaxCompactCorrectionAttempts; attempt++ {
+		if err := state.BeginCorrection(1); err != nil {
+			t.Fatal(err)
+		}
+		fix, err := (SnapshotBuilder{Repo: repo}).Build(context.Background(), Target{Kind: TargetFixDiff, BaseRef: state.CurrentSnapshot.CandidateTree, IntendedUntracked: state.InitialSnapshot.IntendedUntracked, LedgerIDs: state.FixFindingIDs})
+		if err != nil {
+			t.Fatal(err)
+		}
+		fixHash := FixDeltaHashForSnapshot(fix)
+		validation := ScopedValidationResult{LedgerIDs: state.FixFindingIDs, FixCausedFindings: []Finding{}, FollowUps: []FollowUp{}, OriginalCriteria: ValidationCheck{EvidenceHash: hash("2"), FixDeltaHash: fixHash}, CorrectionRegression: ValidationCheck{EvidenceHash: hash("3"), FixDeltaHash: fixHash}}
+		if err := state.CompleteCorrection(fix, 0, validation); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if state.State != StateEscalated || len(state.CorrectionAttempts) != MaxCompactCorrectionAttempts {
+		t.Fatalf("zero-line cap state = %#v", state)
+	}
+}
+
 func TestCompactStoreFailsClosedForCorruptionAndIgnoresInvalidTempState(t *testing.T) {
 	repo := initSnapshotRepo(t)
 	writeSnapshotFile(t, repo, "tracked.txt", "candidate\n")
@@ -85,6 +351,72 @@ func TestCompactStoreFailsClosedForCorruptionAndIgnoresInvalidTempState(t *testi
 	}
 	if _, err := store.Load(); err == nil || !strings.Contains(err.Error(), "checksum mismatch") {
 		t.Fatalf("corrupt compact state error = %v", err)
+	}
+}
+
+func TestCompactDiscoveryIgnoresOnlyUnpublishedCrashResidue(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	writeSnapshotFile(t, repo, "tracked.txt", "candidate\n")
+	state := newCompactTestState(t, repo, "compact-published")
+	store, _ := CompactAuthoritativeStore(context.Background(), repo, state.LineageID)
+	if _, err := store.Replace("", "review/start", state); err != nil {
+		t.Fatal(err)
+	}
+	residue, _ := CompactAuthoritativeStore(context.Background(), repo, "compact-crash-residue")
+	if err := os.MkdirAll(residue.Dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(residue.Dir, ".atomic-interrupted"), []byte("partial"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	leaves, err := CompactAuthorityLeaves(context.Background(), repo)
+	if err != nil || len(leaves) != 1 || leaves[0].lineageID != state.LineageID {
+		t.Fatalf("leaves with crash residue = %#v, %v", leaves, err)
+	}
+	if err := os.WriteFile(residue.StatePath(), []byte("corrupt published authority"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := CompactAuthorityLeaves(context.Background(), repo); err == nil {
+		t.Fatal("corrupt published authority was hidden as residue")
+	}
+}
+
+func TestCompactActualCumulativeOverflowPersistsTerminalAttempt(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	writeSnapshotFile(t, repo, "tracked.txt", "base\none\ntwo\nthree\nfour\n")
+	state := correctedCompactTestState(t, repo, "compact-cumulative-overflow")
+	prior := CompactCorrectionAttempt{Snapshot: state.CurrentSnapshot, ProposedLines: 1, ActualLines: state.CorrectionBudget - 1, FixDeltaHash: state.FixDeltaHash, OriginalCriteria: *state.OriginalCriteria, CorrectionRegression: *state.CorrectionRegression}
+	state.State, state.EvidenceHash = StateCorrectionRequired, ""
+	state.CorrectionAttempts, state.CumulativeCorrectionLines = []CompactCorrectionAttempt{prior}, state.CorrectionBudget-1
+	state.FixDeltaHash, state.ActualCorrectionLines = EmptyFixDeltaHash, nil
+	state.OriginalCriteria, state.CorrectionRegression, state.ProposedCorrectionLines = nil, nil, nil
+	if err := state.BeginCorrection(1); err != nil {
+		t.Fatal(err)
+	}
+	writeSnapshotFile(t, repo, "tracked.txt", "base\none\ntwo\nchanged\nexpanded\n")
+	fix, err := (SnapshotBuilder{Repo: repo}).Build(context.Background(), Target{Kind: TargetFixDiff, BaseRef: state.CurrentSnapshot.CandidateTree, IntendedUntracked: state.InitialSnapshot.IntendedUntracked, LedgerIDs: state.FixFindingIDs})
+	if err != nil {
+		t.Fatal(err)
+	}
+	actual, _ := (SnapshotBuilder{Repo: repo}).ChangedLines(context.Background(), fix)
+	fixHash := FixDeltaHashForSnapshot(fix)
+	validation := ScopedValidationResult{LedgerIDs: state.FixFindingIDs, FixCausedFindings: []Finding{}, FollowUps: []FollowUp{}, OriginalCriteria: ValidationCheck{EvidenceHash: hash("2"), FixDeltaHash: fixHash, Passed: true}, CorrectionRegression: ValidationCheck{EvidenceHash: hash("3"), FixDeltaHash: fixHash, Passed: true}}
+	if err := state.CompleteCorrection(fix, actual, validation); err != nil {
+		t.Fatal(err)
+	}
+	if state.State != StateEscalated || state.CumulativeCorrectionLines <= state.CorrectionBudget || len(state.CorrectionAttempts) != 2 {
+		t.Fatalf("overflow state = %#v", state)
+	}
+	_, payload, err := makeCompactRecord(state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := parseCompactRecord(payload, state.LineageID); err != nil {
+		t.Fatalf("persisted overflow record: %v", err)
+	}
+	writeSnapshotFile(t, repo, "tracked.txt", "base\none\ntwo\nthree\nfixed\n")
+	if err := state.BeginCorrection(1); err == nil {
+		t.Fatal("overflow lineage resumed after reducing the diff")
 	}
 }
 
@@ -509,6 +841,8 @@ func correctedCompactTestState(t *testing.T, repo, lineage string) CompactState 
 	if err := state.CompleteVerification([]byte("tests pass\n"), true); err != nil {
 		t.Fatal(err)
 	}
+	// Preserve the legacy compact fixture shape for backward-compatibility tests.
+	state.CorrectionAttempts, state.CumulativeCorrectionLines = nil, 0
 	return state
 }
 

--- a/internal/reviewtransaction/store_test.go
+++ b/internal/reviewtransaction/store_test.go
@@ -175,6 +175,28 @@ func TestStoreLockRecoversCrashAndCorruptOwnerRecords(t *testing.T) {
 	}
 }
 
+func TestStoreLockIsReleasedWhenOwnerProcessExits(t *testing.T) {
+	if os.Getenv("GENTLE_AI_LOCK_EXIT_HELPER") == "1" {
+		lock, err := acquireStoreLock(os.Getenv("GENTLE_AI_LOCK_EXIT_PATH"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		_ = lock
+		return
+	}
+	path := filepath.Join(t.TempDir(), "review-store", "LOCK")
+	command := exec.Command(os.Args[0], "-test.run=^TestStoreLockIsReleasedWhenOwnerProcessExits$")
+	command.Env = append(os.Environ(), "GENTLE_AI_LOCK_EXIT_HELPER=1", "GENTLE_AI_LOCK_EXIT_PATH="+path)
+	if output, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("lock owner helper: %v\n%s", err, output)
+	}
+	lock, err := acquireStoreLock(path)
+	if err != nil {
+		t.Fatalf("kernel lock remained held after process exit: %v", err)
+	}
+	defer lock.release()
+}
+
 func TestConcurrentStoreLockRecoverersCannotBothWin(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "review-store", "LOCK")
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {

--- a/internal/sddstatus/review_gate.go
+++ b/internal/sddstatus/review_gate.go
@@ -21,7 +21,7 @@ type compactPreVerifyBridge struct {
 }
 
 func discoverCompactPreVerifyAuthority(ctx context.Context, repo, changeName, observedRevision string) compactPreVerifyBridge {
-	stores, err := reviewtransaction.DiscoverCompactStores(ctx, repo)
+	stores, err := reviewtransaction.CompactAuthorityLeaves(ctx, repo)
 	if err != nil {
 		return compactPreVerifyBridge{Reason: "no eligible path-bound compact authority found"}
 	}
@@ -284,7 +284,7 @@ var evaluateNativeReviewGate = reviewtransaction.EvaluateNativeGate
 
 func discoverNativeReceipt(ctx context.Context, repo string) ([]byte, error) {
 	var matches [][]byte
-	compactStores, err := reviewtransaction.DiscoverCompactStores(ctx, repo)
+	compactStores, err := reviewtransaction.CompactAuthorityLeaves(ctx, repo)
 	if err != nil {
 		return nil, fmt.Errorf("discover compact review stores: %w", err)
 	}


### PR DESCRIPTION
Closes #1200

## Type
- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Add explicit, auditable successor recovery for wedged compact review authority.
- Keep failed targeted corrections inside one bounded lineage without rerunning 4R.
- Publish strict machine-readable reviewer, refuter, and validator schemas.

## Changes
| Area | Change |
|------|--------|
| Compact authority | Add successor provenance, recovery eligibility, graph discovery, and gate locking. |
| Bounded correction | Persist iterative attempts, cumulative accounting, escalation, and retry limits. |
| CLI contracts | Add `review schema reviewer|refuter|validator` with strict examples. |
| Tests and docs | Cover lifecycle recovery, races, crash residue, schema admission, and authority invariants. |

## Test Plan
- [x] `go test -count=1 ./...`
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `git diff --check`
- [x] Native bounded 4R receipt approved and pre-commit/pre-push/pre-PR gates passed.

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] No modified shell scripts
- [x] Runtime CLI schemas exercised
- [x] Documentation updated for behavior changes
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `review recover` to create an auditable successor review authority while preserving predecessor history.
  * Added `review schema` commands for versioned reviewer, refuter, and validator JSON Schemas.
  * Improved review discovery to select only valid, unsuperseded authority records.

* **Bug Fixes**
  * Enforced strict input validation before state or correction-budget changes.
  * Preserved correction history across retries and capped attempts at three.
  * Strengthened final authorization checks against concurrent changes and invalid authority states.

* **Documentation**
  * Expanded threat-model guidance for recovery, validation, correction tracking, and rollback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->