### PR TITLE
fix(review): bind receipts to publication topology

### DIFF
--- a/internal/cli/review_facade_test.go
+++ b/internal/cli/review_facade_test.go
@@ -182,7 +182,7 @@ func TestReviewFacadeStartSupportsCommittedBaseDiff(t *testing.T) {
 		t.Fatal(err)
 	}
 	output.Reset()
-	if err := RunReviewFacadeValidate([]string{"--cwd", repo, "--lineage", result.LineageID, "--gate", string(reviewtransaction.GatePrePR), "--base-ref", base}, &output); err != nil {
+	if err := RunReviewFacadeValidate([]string{"--cwd", repo, "--lineage", result.LineageID, "--gate", string(reviewtransaction.GatePrePR), "--base-ref", "origin/" + branch}, &output); err != nil {
 		t.Fatalf("pre-pr base diff gate: %v\n%s", err, output.String())
 	}
 	output.Reset()
@@ -947,6 +947,7 @@ func TestCompactTransportRecoversCorrectedCurrentChangesWithoutIntermediateTrees
 	}
 	clone := filepath.Join(t.TempDir(), "clone")
 	runReviewCLIGit(t, source, "clone", "--no-local", source, clone)
+	runReviewCLIGit(t, source, "branch", "reviewed-base", "HEAD^")
 	for _, tree := range []string{initial.State.InitialSnapshot.CandidateTree, sourceRecord.State.CurrentSnapshot.BaseTree} {
 		command := exec.Command("git", "-C", clone, "cat-file", "-e", tree+"^{tree}")
 		if err := command.Run(); err == nil {
@@ -969,7 +970,7 @@ func TestCompactTransportRecoversCorrectedCurrentChangesWithoutIntermediateTrees
 		t.Fatal("corrected compact recovery changed state or receipt")
 	}
 	var output bytes.Buffer
-	if err := RunReviewFacadeValidate([]string{"--cwd", clone, "--lineage", started.LineageID, "--gate", string(reviewtransaction.GatePrePush)}, &output); err != nil {
+	if err := RunReviewFacadeValidate([]string{"--cwd", clone, "--lineage", started.LineageID, "--gate", string(reviewtransaction.GatePrePush), "--base-ref", "origin/reviewed-base"}, &output); err != nil {
 		t.Fatalf("corrected recovered gate: %v\n%s", err, output.String())
 	}
 }

--- a/internal/cli/review_test.go
+++ b/internal/cli/review_test.go
@@ -88,6 +88,7 @@ func TestLegacyV1ResumeValidateExportImportRemainUsable(t *testing.T) {
 	request.BundleDigest = bundle.BundleDigest
 	requestPath := filepath.Join(t.TempDir(), "request.json")
 	writeReviewCLIJSON(t, requestPath, request)
+	runReviewCLIGit(t, fixture.repo, "branch", "reviewed-base", "HEAD^")
 	clone := filepath.Join(t.TempDir(), "clone")
 	runReviewCLIGit(t, fixture.repo, "clone", "--no-local", fixture.repo, clone)
 	if err := RunReviewBundleImport([]string{
@@ -101,7 +102,7 @@ func TestLegacyV1ResumeValidateExportImportRemainUsable(t *testing.T) {
 	output.Reset()
 	if err := RunReviewValidate([]string{
 		"--cwd", clone, "--receipt", fixture.receiptPath,
-		"--lineage", fixture.lineage, "--gate", string(reviewtransaction.GatePrePush),
+		"--lineage", fixture.lineage, "--gate", string(reviewtransaction.GatePrePush), "--base-ref", "origin/reviewed-base",
 	}, &output); err != nil {
 		t.Fatalf("imported legacy validate: %v\n%s", err, output.String())
 	}
@@ -209,6 +210,8 @@ type legacyCLIFixture struct {
 func newLegacyCLIFixture(t *testing.T, lineage string) legacyCLIFixture {
 	t.Helper()
 	repo := initReviewCLIRepo(t)
+	branch := strings.TrimSpace(runReviewCLIGit(t, repo, "symbolic-ref", "--short", "HEAD"))
+	configureCLIReviewPublicationRemote(t, repo, branch)
 	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("candidate\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/reviewtransaction/compact_gate.go
+++ b/internal/reviewtransaction/compact_gate.go
@@ -80,6 +80,12 @@ func EvaluateCompactGate(ctx context.Context, repo string, receipt CompactReceip
 	if request.Gate == GatePrePush && record.State.InitialSnapshot.Kind == TargetCurrentChanges && snapshot.BaseTree == snapshot.CandidateTree {
 		return invalid("pre-push current-changes receipt requires a delivered tree change")
 	}
+	if request.Gate == GatePrePush && (resolvedPrePR == nil || resolvedPrePR.DeliveredCommitCount < 1) {
+		return invalid("pre-push validation requires at least one delivered commit")
+	}
+	if request.Gate == GatePrePush && record.State.InitialSnapshot.Kind == TargetCurrentChanges && resolvedPrePR.DeliveredCommitCount != 1 {
+		return invalid("pre-push current-changes receipt requires exactly one delivery commit")
+	}
 	compatibleAdvance := false
 	var compatibility *BaseAdvanceCompatibility
 	if request.Gate == GatePrePR && snapshot.BaseTree != receipt.BaseTree {
@@ -155,11 +161,12 @@ func buildCompactGateRequest(ctx context.Context, repo string, state CompactStat
 		}
 		request.Target = Target{Kind: TargetCurrentChanges, IntendedUntracked: intended}
 	case GatePrePush:
-		head, err := resolveCommit(ctx, repo, "HEAD")
+		deliveryBaseTree := map[TargetKind]string{TargetCurrentChanges: state.InitialSnapshot.BaseTree}[state.InitialSnapshot.Kind]
+		target, push, err := buildPushTarget(ctx, repo, input.BaseRef, deliveryBaseTree)
 		if err != nil {
 			return GateRequest{}, err
 		}
-		request.Target = Target{Kind: TargetExactRevision, Revision: head}
+		request.Target, request.Push = target, push
 	case GatePrePR:
 		target, prePR, err := buildPrePRTarget(ctx, repo, input.BaseRef, input.PrePRCIAttestation, state.InitialSnapshot.IntendedUntracked)
 		if err != nil {

--- a/internal/reviewtransaction/compact_gate_test.go
+++ b/internal/reviewtransaction/compact_gate_test.go
@@ -281,8 +281,11 @@ func TestCompactPrePRGatePreservesBoundaryContextForExactAndUnavailableSelectors
 	gitSnapshot(t, repo, "commit", "-m", "candidate")
 	state, _, receipt := approvedCompactRevisionFixture(t, repo, "compact-pre-pr-boundary")
 	base := trimGit(gitSnapshot(t, repo, "rev-parse", "HEAD^"))
+	branch := currentBranch(context.Background(), repo)
+	remote := configurePublicationRemote(t, repo, branch)
+	gitSnapshot(t, repo, "--git-dir", remote, "branch", "reviewed-base", base)
 
-	exact := EvaluateCompactGate(context.Background(), repo, receipt, NativeGateRequestInput{Gate: GatePrePR, LineageID: state.LineageID, BaseRef: base})
+	exact := EvaluateCompactGate(context.Background(), repo, receipt, NativeGateRequestInput{Gate: GatePrePR, LineageID: state.LineageID, BaseRef: "origin/reviewed-base"})
 	if exact.Result != GateAllow || exact.Context.PrePRBoundary == nil || exact.Context.PrePRBoundary.Commit != base {
 		t.Fatalf("exact compact pre-PR boundary = %#v", exact)
 	}
@@ -300,8 +303,8 @@ func TestCompactPrePRGatePreservesBoundaryContextForExactAndUnavailableSelectors
 		t.Fatalf("unavailable compact pre-PR context round trip = %#v, %v", parsed, err)
 	}
 
-	mismatched := EvaluateCompactGate(context.Background(), repo, receipt, NativeGateRequestInput{Gate: GatePrePR, LineageID: state.LineageID, BaseRef: "HEAD"})
-	if mismatched.Result == GateAllow || mismatched.Context.PrePRBoundary == nil || mismatched.Context.PrePRBoundary.Selector != "HEAD" || mismatched.Context.Denial == nil || mismatched.Context.Denial.Stage != "receipt-binding" {
+	mismatched := EvaluateCompactGate(context.Background(), repo, receipt, NativeGateRequestInput{Gate: GatePrePR, LineageID: state.LineageID, BaseRef: "origin/" + branch})
+	if mismatched.Result == GateAllow || mismatched.Context.PrePRBoundary == nil || mismatched.Context.Denial == nil || mismatched.Context.Denial.Stage != "receipt-binding" {
 		t.Fatalf("mismatched compact pre-PR boundary = %#v", mismatched)
 	}
 }
@@ -329,7 +332,7 @@ func TestCompactPrePRGateInvalidatesSelectedBaseAndHeadRaces(t *testing.T) {
 		mutate func(t *testing.T, fixture *compatiblePrePRFixture)
 	}{
 		{name: "selected base moves", mutate: func(t *testing.T, fixture *compatiblePrePRFixture) {
-			gitSnapshot(t, fixture.repo, "update-ref", "refs/heads/main", fixture.originalBaseCommit)
+			gitSnapshot(t, fixture.repo, "--git-dir", fixture.remote, "update-ref", "refs/heads/main", fixture.originalBaseCommit)
 		}},
 		{name: "head moves", mutate: func(t *testing.T, fixture *compatiblePrePRFixture) {
 			gitSnapshot(t, fixture.repo, "commit", "--allow-empty", "-m", "move head")

--- a/internal/reviewtransaction/gate.go
+++ b/internal/reviewtransaction/gate.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -35,6 +36,7 @@ type GateRequest struct {
 	EvidenceArtifact string                      `json:"evidence_artifact"`
 	EvidenceContent  string                      `json:"evidence_content,omitempty"`
 	ExternalEvidence ExternalEvidenceDisposition `json:"external_evidence,omitempty"`
+	Push             *PushRequest                `json:"push,omitempty"`
 	PrePR            *PrePRRequest               `json:"pre_pr,omitempty"`
 	Release          *ReleaseRequest             `json:"release,omitempty"`
 	preimages        *gateArtifactPreimages
@@ -43,6 +45,16 @@ type GateRequest struct {
 type PrePRRequest struct {
 	CIAttestationArtifact string                  `json:"ci_attestation_artifact"`
 	Boundary              *PrePRBoundarySelection `json:"boundary,omitempty"`
+	PushRemote            string                  `json:"push_remote,omitempty"`
+	PushRemoteIdentity    string                  `json:"push_remote_identity,omitempty"`
+}
+
+type PushRequest struct {
+	Boundary           PrePRBoundarySelection `json:"boundary"`
+	MergeBase          string                 `json:"merge_base"`
+	PushRemote         string                 `json:"push_remote"`
+	PushRemoteIdentity string                 `json:"push_remote_identity"`
+	DeliveryBaseTree   string                 `json:"delivery_base_tree,omitempty"`
 }
 
 type PrePRBoundarySource string
@@ -55,11 +67,12 @@ const (
 // PrePRBoundarySelection records how the immutable pre-PR range boundary was
 // selected. It is evidence only; receipt binding still authorizes the range.
 type PrePRBoundarySelection struct {
-	Source    PrePRBoundarySource `json:"source"`
-	Selector  string              `json:"selector"`
-	Commit    string              `json:"commit"`
-	Remote    string              `json:"remote,omitempty"`
-	RemoteRef string              `json:"remote_ref,omitempty"`
+	Source         PrePRBoundarySource `json:"source"`
+	Selector       string              `json:"selector"`
+	Commit         string              `json:"commit"`
+	Remote         string              `json:"remote,omitempty"`
+	RemoteRef      string              `json:"remote_ref,omitempty"`
+	RemoteIdentity string              `json:"remote_identity,omitempty"`
 }
 
 type ReleaseRequest struct {
@@ -195,6 +208,12 @@ func EvaluateNativeGate(ctx context.Context, repo string, receipt Receipt, reque
 	if request.Gate == GatePrePush && record.Transaction.Snapshot.Kind == TargetCurrentChanges && snapshot.BaseTree == snapshot.CandidateTree {
 		return invalid("pre-push current-changes receipt requires a delivered tree change")
 	}
+	if request.Gate == GatePrePush && (resolvedPrePR == nil || resolvedPrePR.DeliveredCommitCount < 1) {
+		return invalid("pre-push validation requires at least one delivered commit")
+	}
+	if request.Gate == GatePrePush && record.Transaction.Snapshot.Kind == TargetCurrentChanges && resolvedPrePR.DeliveredCommitCount != 1 {
+		return invalid("pre-push current-changes receipt requires exactly one delivery commit")
+	}
 	policyHash := authoritativeReceipt.PolicyHash
 	if hasArtifactSource(request.PolicyArtifact, request.PolicyContent) {
 		policyHash = hashArtifactPayload(preimages.policy)
@@ -269,11 +288,22 @@ func EvaluateNativeGate(ctx context.Context, repo string, receipt Receipt, reque
 }
 
 type resolvedPrePRRefs struct {
-	Selection  PrePRBoundarySelection
-	HeadCommit string
+	Selection            PrePRBoundarySelection
+	HeadCommit           string
+	BaseCommit           string
+	DeliveredCommitCount int
+	PushRemote           string
 }
 
 func buildLifecycleSnapshot(ctx context.Context, repo string, request GateRequest) (Snapshot, *resolvedPrePRRefs, error) {
+	if request.Gate == GatePrePush {
+		target, refs, err := prePushTargetForRequest(ctx, repo, request)
+		if err != nil {
+			return Snapshot{}, nil, err
+		}
+		snapshot, err := (SnapshotBuilder{Repo: repo}).Build(ctx, target)
+		return snapshot, refs, err
+	}
 	target, err := lifecycleTargetForGate(ctx, repo, request)
 	if err != nil {
 		return Snapshot{}, nil, err
@@ -297,7 +327,16 @@ func buildLifecycleSnapshot(ctx context.Context, repo string, request GateReques
 	if err != nil {
 		return Snapshot{}, nil, err
 	}
-	return snapshot, &resolvedPrePRRefs{Selection: selection, HeadCommit: head}, nil
+	count, err := commitCount(ctx, repo, selection.Commit, head)
+	if err != nil {
+		return Snapshot{}, nil, err
+	}
+	pushRemote, _, _ := publicationRemote(ctx, repo)
+	pushIdentity, err := pushRepositoryIdentity(ctx, repo, pushRemote)
+	if err != nil || request.PrePR.PushRemote != pushRemote || request.PrePR.PushRemoteIdentity != pushIdentity {
+		return Snapshot{}, nil, errors.New("push destination remote changed during validation")
+	}
+	return snapshot, &resolvedPrePRRefs{Selection: selection, HeadCommit: head, BaseCommit: selection.Commit, DeliveredCommitCount: count, PushRemote: pushRemote}, nil
 }
 
 func prePRBoundaryForRequest(ctx context.Context, repo string, request GateRequest) (PrePRBoundarySelection, error) {
@@ -328,21 +367,34 @@ func prePRBoundaryForRequest(ctx context.Context, repo string, request GateReque
 
 func selectPrePRBoundary(ctx context.Context, repo, selector string) (PrePRBoundarySelection, error) {
 	selector = strings.TrimSpace(selector)
+	var selection PrePRBoundarySelection
+	var err error
 	if selector != "" {
 		if filepath.IsAbs(selector) {
 			return PrePRBoundarySelection{}, errors.New("explicit pre-PR base selector must not be an absolute path")
 		}
-		commit, err := resolveCommit(ctx, repo, selector)
-		if err != nil {
-			return PrePRBoundarySelection{}, fmt.Errorf("resolve explicit pre-PR base %q: %w", selector, err)
+		selection, err = resolveAdvertisedSelector(ctx, repo, selector, PrePRBoundaryExplicit)
+	} else {
+		var ref, remote, commit string
+		ref, remote, commit, err = resolveAuthoritativePublicationBase(ctx, repo)
+		identity, identityErr := remoteRepositoryIdentity(ctx, repo, remote)
+		if err == nil {
+			err = identityErr
 		}
-		return PrePRBoundarySelection{Source: PrePRBoundaryExplicit, Selector: selector, Commit: commit}, nil
+		selection = PrePRBoundarySelection{Source: PrePRBoundaryPublicationDefault, Selector: ref, Commit: commit, Remote: remote, RemoteRef: ref, RemoteIdentity: identity}
 	}
-	ref, remote, commit, err := resolveAuthoritativePublicationBase(ctx, repo)
 	if err != nil {
 		return PrePRBoundarySelection{}, err
 	}
-	return PrePRBoundarySelection{Source: PrePRBoundaryPublicationDefault, Selector: ref, Commit: commit, Remote: remote, RemoteRef: ref}, nil
+	head, err := resolveCommit(ctx, repo, "HEAD")
+	if err != nil {
+		return PrePRBoundarySelection{}, err
+	}
+	bases, mergeErr := runGit(ctx, repo, nil, nil, "merge-base", "--all", head, selection.Commit)
+	if mergeBases := strings.Fields(string(bases)); mergeErr != nil || len(mergeBases) != 1 {
+		return PrePRBoundarySelection{}, fmt.Errorf("publication base has %d merge bases; pass --base-ref <remote>/<branch>", len(mergeBases))
+	}
+	return selection, nil
 }
 
 func buildPrePRTarget(ctx context.Context, repo, selector, ciAttestation string, intendedUntracked []string) (Target, *PrePRRequest, error) {
@@ -350,8 +402,13 @@ func buildPrePRTarget(ctx context.Context, repo, selector, ciAttestation string,
 	if err != nil {
 		return Target{}, nil, err
 	}
+	pushRemote, _, _ := publicationRemote(ctx, repo)
+	pushIdentity, err := pushRepositoryIdentity(ctx, repo, pushRemote)
+	if err != nil {
+		return Target{}, nil, err
+	}
 	return Target{Kind: TargetBaseDiff, BaseRef: selection.Commit, IntendedUntracked: append([]string(nil), intendedUntracked...)},
-		&PrePRRequest{CIAttestationArtifact: ciAttestation, Boundary: &selection}, nil
+		&PrePRRequest{CIAttestationArtifact: ciAttestation, Boundary: &selection, PushRemote: pushRemote, PushRemoteIdentity: pushIdentity}, nil
 }
 
 func publicationRemoteConfigured(ctx context.Context, repo string) (bool, error) {
@@ -361,34 +418,148 @@ func publicationRemoteConfigured(ctx context.Context, repo string) (bool, error)
 
 func resolveAuthoritativePublicationBase(ctx context.Context, repo string) (string, string, string, error) {
 	remote, configured, err := publicationRemote(ctx, repo)
-	if err != nil {
-		return "", "", "", err
-	}
-	if !configured {
-		return "", "", "", errors.New("publication remote is not configured")
+	if err != nil || !configured {
+		return "", "", "", errors.New("publication target remote is not configured; pass --base-ref <remote>/<branch>")
 	}
 	output, err := runGit(ctx, repo, nil, nil, "ls-remote", "--symref", remote, "HEAD")
 	if err != nil {
-		return "", "", "", fmt.Errorf("query publication remote %q: %w", remote, err)
+		return "", "", "", fmt.Errorf("query publication target default branch: %w", err)
 	}
-	var baseRef, commit string
+	ref := ""
 	for _, line := range strings.Split(string(output), "\n") {
 		fields := strings.Fields(line)
-		if len(fields) == 3 && fields[0] == "ref:" && fields[2] == "HEAD" {
-			baseRef = fields[1]
-		}
-		if len(fields) == 2 && fields[1] == "HEAD" && validGitTree(fields[0]) {
-			commit = fields[0]
+		if len(fields) == 3 && fields[0] == "ref:" && fields[2] == "HEAD" && strings.HasPrefix(fields[1], "refs/heads/") {
+			ref = fields[1]
 		}
 	}
-	if !strings.HasPrefix(baseRef, "refs/heads/") || !validGitTree(commit) {
-		return "", "", "", errors.New("publication remote does not advertise a default branch HEAD")
+	if ref == "" {
+		return "", "", "", errors.New("publication target default branch is unavailable; pass --base-ref <remote>/<branch>")
 	}
-	local, err := resolveCommit(ctx, repo, commit)
-	if err != nil || local != commit {
-		return "", "", "", errors.New("publication base commit is not available locally; fetch before validation")
+	selection, err := advertisedRemoteRef(ctx, repo, remote, ref, remote+"/"+strings.TrimPrefix(ref, "refs/heads/"), PrePRBoundaryPublicationDefault)
+	if err != nil {
+		return "", "", "", err
 	}
-	return baseRef, remote, commit, nil
+	return selection.RemoteRef, selection.Remote, selection.Commit, nil
+}
+
+func resolveTrackingUpstreamBase(ctx context.Context, repo string) (string, string, string, error) {
+	branch := currentBranch(ctx, repo)
+	if branch == "" {
+		return "", "", "", errors.New("configured upstream is unavailable on detached HEAD; pass --base-ref <remote>/<branch>")
+	}
+	output, err := runGit(ctx, repo, nil, nil, "for-each-ref", "--format=%(upstream:remotename)%00%(upstream:remoteref)", "refs/heads/"+branch)
+	parts := strings.SplitN(strings.TrimSpace(string(output)), "\x00", 2)
+	if err != nil || len(parts) != 2 || parts[0] == "" || !strings.HasPrefix(parts[1], "refs/heads/") {
+		return "", "", "", errors.New("configured upstream is missing or ambiguous; pass --base-ref <remote>/<branch>")
+	}
+	selection, err := advertisedRemoteRef(ctx, repo, parts[0], parts[1], parts[0]+"/"+strings.TrimPrefix(parts[1], "refs/heads/"), PrePRBoundaryPublicationDefault)
+	if err != nil {
+		return "", "", "", err
+	}
+	return selection.RemoteRef, selection.Remote, selection.Commit, nil
+}
+
+func resolveAdvertisedSelector(ctx context.Context, repo, selector string, source PrePRBoundarySource) (PrePRBoundarySelection, error) {
+	output, err := runGit(ctx, repo, nil, nil, "remote")
+	if err != nil {
+		return PrePRBoundarySelection{}, err
+	}
+	remotes := strings.Fields(string(output))
+	matches := []PrePRBoundarySelection{}
+	for _, remote := range remotes {
+		identity, identityErr := remoteRepositoryIdentity(ctx, repo, remote)
+		if identityErr != nil {
+			continue
+		}
+		branch := selector
+		if strings.HasPrefix(selector, remote+"/") {
+			branch = strings.TrimPrefix(selector, remote+"/")
+		} else if strings.Contains(selector, "/") {
+			continue
+		}
+		if validGitTree(selector) {
+			branch = ""
+		} else if _, err := runGit(ctx, repo, nil, nil, "check-ref-format", "--branch", branch); err != nil {
+			continue
+		}
+		remoteOutput, queryErr := runGit(ctx, repo, nil, nil, "ls-remote", "--heads", remote, branch)
+		if queryErr != nil {
+			continue
+		}
+		for _, line := range strings.Split(string(remoteOutput), "\n") {
+			fields := strings.Fields(line)
+			if len(fields) == 2 && strings.HasPrefix(fields[1], "refs/heads/") &&
+				(validGitTree(selector) && fields[0] == selector || !validGitTree(selector) && fields[1] == "refs/heads/"+branch) {
+				matches = append(matches, PrePRBoundarySelection{Source: source, Selector: selector, Commit: fields[0], Remote: remote, RemoteRef: fields[1], RemoteIdentity: identity})
+			}
+		}
+	}
+	if len(matches) != 1 {
+		return PrePRBoundarySelection{}, fmt.Errorf("explicit pre-PR base %q is missing or ambiguous on advertised remote branches; pass --base-ref <remote>/<branch>", selector)
+	}
+	local, err := resolveCommit(ctx, repo, matches[0].Commit)
+	if err != nil || local != matches[0].Commit {
+		return PrePRBoundarySelection{}, errors.New("advertised base commit is not available locally; fetch before validation")
+	}
+	return matches[0], nil
+}
+
+func advertisedRemoteRef(ctx context.Context, repo, remote, ref, selector string, source PrePRBoundarySource) (PrePRBoundarySelection, error) {
+	identity, err := remoteRepositoryIdentity(ctx, repo, remote)
+	if err != nil {
+		return PrePRBoundarySelection{}, err
+	}
+	output, err := runGit(ctx, repo, nil, nil, "ls-remote", "--heads", remote, ref)
+	if err != nil {
+		return PrePRBoundarySelection{}, fmt.Errorf("query base remote %q: %w", remote, err)
+	}
+	fields := strings.Fields(string(output))
+	if len(fields) != 2 || fields[1] != ref || !validGitTree(fields[0]) {
+		return PrePRBoundarySelection{}, fmt.Errorf("base selector %q is not a current advertised remote branch; pass --base-ref <remote>/<branch>", selector)
+	}
+	local, err := resolveCommit(ctx, repo, fields[0])
+	if err != nil || local != fields[0] {
+		return PrePRBoundarySelection{}, errors.New("advertised base commit is not available locally; fetch before validation")
+	}
+	return PrePRBoundarySelection{Source: source, Selector: selector, Commit: fields[0], Remote: remote, RemoteRef: ref, RemoteIdentity: identity}, nil
+}
+
+func remoteRepositoryIdentity(ctx context.Context, repo, remote string) (string, error) {
+	output, err := runGit(ctx, repo, nil, nil, "config", "--get", "remote."+remote+".url")
+	if err != nil || strings.TrimSpace(string(output)) == "" {
+		return "", errors.New("publication remote URL is not configured")
+	}
+	return repositoryLocationIdentity(ctx, repo, strings.TrimSpace(string(output)))
+}
+
+func pushRepositoryIdentity(ctx context.Context, repo, remote string) (string, error) {
+	output, err := runGit(ctx, repo, nil, nil, "config", "--get", "remote."+remote+".pushurl")
+	if err != nil || strings.TrimSpace(string(output)) == "" {
+		return remoteRepositoryIdentity(ctx, repo, remote)
+	}
+	return repositoryLocationIdentity(ctx, repo, strings.TrimSpace(string(output)))
+}
+
+func repositoryLocationIdentity(ctx context.Context, repo, value string) (string, error) {
+	if parsed, parseErr := url.Parse(value); parseErr == nil && parsed.Scheme != "" && parsed.Opaque == "" {
+		value = strings.ToLower(parsed.Host) + "/" + strings.Trim(parsed.Path, "/")
+	} else {
+		if colon := strings.Index(value, ":"); colon > 0 && !strings.Contains(value[:colon], "/") {
+			host := value[:colon]
+			if at := strings.LastIndex(host, "@"); at >= 0 {
+				host = host[at+1:]
+			}
+			value = strings.ToLower(host) + "/" + value[colon+1:]
+		} else if !filepath.IsAbs(value) {
+			root, rootErr := runGit(ctx, repo, nil, nil, "rev-parse", "--show-toplevel")
+			if rootErr != nil {
+				return "", errors.New("publication remote identity cannot be derived")
+			}
+			value = filepath.Clean(filepath.Join(strings.TrimSpace(string(root)), value))
+		}
+	}
+	sum := sha256.Sum256([]byte(strings.TrimSuffix(strings.TrimRight(value, "/"), ".git")))
+	return "sha256:" + hex.EncodeToString(sum[:]), nil
 }
 
 func publicationRemote(ctx context.Context, repo string) (string, bool, error) {
@@ -420,6 +591,118 @@ func sameResolvedPrePRRefs(left, right *resolvedPrePRRefs) bool {
 		return left == right
 	}
 	return *left == *right
+}
+
+func currentBranch(ctx context.Context, repo string) string {
+	output, _ := runGit(ctx, repo, nil, nil, "symbolic-ref", "--quiet", "--short", "HEAD")
+	return strings.TrimSpace(string(output))
+}
+
+func buildPushTarget(ctx context.Context, repo, selector, deliveryBaseTree string) (Target, *PushRequest, error) {
+	selection, err := selectPrePushBoundary(ctx, repo, selector)
+	if err != nil {
+		return Target{}, nil, err
+	}
+	head, err := resolveCommit(ctx, repo, "HEAD")
+	if err != nil {
+		return Target{}, nil, err
+	}
+	bases, err := runGit(ctx, repo, nil, nil, "merge-base", "--all", head, selection.Commit)
+	mergeBases := strings.Fields(string(bases))
+	if err != nil || len(mergeBases) != 1 {
+		return Target{}, nil, fmt.Errorf("publication base has %d merge bases; pass --base-ref <remote>/<branch>", len(mergeBases))
+	}
+	pushRemote, configured, err := publicationRemote(ctx, repo)
+	if err != nil || !configured {
+		return Target{}, nil, errors.New("push destination remote is not configured")
+	}
+	pushIdentity, err := pushRepositoryIdentity(ctx, repo, pushRemote)
+	if err != nil {
+		return Target{}, nil, err
+	}
+	push := &PushRequest{Boundary: selection, MergeBase: mergeBases[0], PushRemote: pushRemote, PushRemoteIdentity: pushIdentity, DeliveryBaseTree: deliveryBaseTree}
+	base := push.MergeBase
+	if deliveryBaseTree != "" {
+		base, err = reviewedDeliveryBase(ctx, repo, push.MergeBase, head, deliveryBaseTree)
+		count, countErr := commitCount(ctx, repo, base, head)
+		if err != nil || countErr != nil || count != 1 {
+			return Target{}, nil, errors.New("reviewed delivery is not exactly one commit from its reviewed base")
+		}
+	}
+	return Target{Kind: TargetBaseDiff, BaseRef: base, IntendedUntracked: []string{}}, push, nil
+}
+
+func selectPrePushBoundary(ctx context.Context, repo, selector string) (PrePRBoundarySelection, error) {
+	if strings.TrimSpace(selector) != "" {
+		return selectPrePRBoundary(ctx, repo, selector)
+	}
+	ref, remote, commit, err := resolveTrackingUpstreamBase(ctx, repo)
+	if err != nil {
+		return PrePRBoundarySelection{}, err
+	}
+	identity, err := remoteRepositoryIdentity(ctx, repo, remote)
+	return PrePRBoundarySelection{Source: PrePRBoundaryPublicationDefault, Selector: ref, Commit: commit, Remote: remote, RemoteRef: ref, RemoteIdentity: identity}, err
+}
+
+func reviewedDeliveryBase(ctx context.Context, repo, publicationBase, head, reviewedTree string) (string, error) {
+	output, err := runGit(ctx, repo, nil, nil, "rev-list", head, "^"+publicationBase)
+	if err != nil {
+		return "", err
+	}
+	matches := []string{}
+	for _, commit := range append(strings.Fields(string(output)), publicationBase) {
+		tree, treeErr := runGit(ctx, repo, nil, nil, "rev-parse", commit+"^{tree}")
+		if treeErr != nil {
+			return "", treeErr
+		}
+		if strings.TrimSpace(string(tree)) == reviewedTree {
+			matches = append(matches, commit)
+		}
+	}
+	if len(matches) != 1 {
+		return "", errors.New("reviewed delivery base commit is missing or ambiguous in publication range")
+	}
+	return matches[0], nil
+}
+
+func prePushTargetForRequest(ctx context.Context, repo string, request GateRequest) (Target, *resolvedPrePRRefs, error) {
+	selector := ""
+	if request.Push != nil && request.Push.Boundary.Source == PrePRBoundaryExplicit {
+		selector = request.Push.Boundary.Selector
+	}
+	deliveryBaseTree := ""
+	if request.Push != nil {
+		deliveryBaseTree = request.Push.DeliveryBaseTree
+	}
+	target, push, err := buildPushTarget(ctx, repo, selector, deliveryBaseTree)
+	if err != nil {
+		return Target{}, nil, err
+	}
+	if request.Push != nil && *request.Push != *push {
+		return Target{}, nil, errors.New("push publication boundary changed during validation")
+	}
+	if request.Target.Kind == TargetBaseDiff && request.Target.BaseRef != "" && request.Target.BaseRef != target.BaseRef {
+		return Target{}, nil, errors.New("committed publication merge base changed during validation")
+	}
+	head, err := resolveCommit(ctx, repo, "HEAD")
+	if err != nil {
+		return Target{}, nil, err
+	}
+	count, err := commitCount(ctx, repo, target.BaseRef, head)
+	if err != nil {
+		return Target{}, nil, err
+	}
+	return target, &resolvedPrePRRefs{Selection: push.Boundary, HeadCommit: head, BaseCommit: push.MergeBase, DeliveredCommitCount: count, PushRemote: push.PushRemote}, nil
+}
+
+func commitCount(ctx context.Context, repo, base, head string) (int, error) {
+	output, err := runGit(ctx, repo, nil, nil, "rev-list", "--count", base+".."+head)
+	if err != nil {
+		return 0, err
+	}
+	var count int
+	_, err = fmt.Sscan(strings.TrimSpace(string(output)), &count)
+	return count, err
 }
 
 func resolveCommit(ctx context.Context, repo, revision string) (string, error) {
@@ -492,6 +775,15 @@ func validateGateRequest(request GateRequest) error {
 	}
 	if request.Gate != GatePrePR && request.PrePR != nil {
 		return errors.New("pre-PR evidence is only valid at the pre-PR gate")
+	}
+	if request.Gate != GatePrePush && request.Push != nil {
+		return errors.New("push evidence is only valid at the pre-push gate")
+	}
+	if request.Gate == GatePrePush && (request.Push == nil || request.Push.PushRemoteIdentity == "" || request.Push.Boundary.RemoteIdentity == "") {
+		return errors.New("pre-push gate requires repository-bound push evidence")
+	}
+	if request.Gate == GatePrePR && (request.PrePR == nil || request.PrePR.Boundary == nil || request.PrePR.PushRemoteIdentity == "" || request.PrePR.Boundary.RemoteIdentity == "") {
+		return errors.New("pre-PR gate requires repository-bound publication evidence; pass --base-ref <remote>/<branch>")
 	}
 	switch request.ExternalEvidence {
 	case ExternalEvidenceNone, ExternalEvidenceInvalidating, ExternalEvidenceEscalating:

--- a/internal/reviewtransaction/gate_test.go
+++ b/internal/reviewtransaction/gate_test.go
@@ -65,7 +65,7 @@ func TestPrePRGateFailsClosedForUnprovenBaseAdvance(t *testing.T) {
 		mutate       func(t *testing.T, fixture *compatiblePrePRFixture)
 		want         GateResult
 	}{
-		{name: "missing attestation", mutate: func(t *testing.T, fixture *compatiblePrePRFixture) { fixture.request.PrePR = nil }, want: GateScopeChanged},
+		{name: "missing attestation", mutate: func(t *testing.T, fixture *compatiblePrePRFixture) { fixture.request.PrePR.CIAttestationArtifact = "" }, want: GateScopeChanged},
 		{name: "missing receipt-bound trust policy", mutate: func(t *testing.T, fixture *compatiblePrePRFixture) { fixture.request.PolicyArtifact = "" }, want: GateScopeChanged},
 		{name: "invalid signature", mutate: func(t *testing.T, fixture *compatiblePrePRFixture) {
 			fixture.attestation.Signature = base64.StdEncoding.EncodeToString(make([]byte, ed25519.SignatureSize))
@@ -156,6 +156,11 @@ func TestPrePRGateRechecksMovingPublicationInputs(t *testing.T) {
 		{name: "remote base moves", mutate: func(t *testing.T, fixture *compatiblePrePRFixture) {
 			gitSnapshot(t, fixture.repo, "--git-dir", fixture.remote, "update-ref", "refs/heads/main", fixture.originalBaseCommit)
 		}},
+		{name: "remote URL redirects to same commits", mutate: func(t *testing.T, fixture *compatiblePrePRFixture) {
+			redirect := filepath.Join(t.TempDir(), "redirect.git")
+			gitSnapshot(t, fixture.repo, "clone", "--bare", fixture.remote, redirect)
+			gitSnapshot(t, fixture.repo, "remote", "set-url", "origin", redirect)
+		}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -173,7 +178,7 @@ func TestPrePRGateRechecksMovingPublicationInputs(t *testing.T) {
 	}
 }
 
-func TestExplicitPrePRRequestWithoutRemotePreservesUnchangedBase(t *testing.T) {
+func TestExplicitPrePRRequestWithoutRemoteFailsClosed(t *testing.T) {
 	repo := initSnapshotRepo(t)
 	baseCommit := trimGit(gitSnapshot(t, repo, "rev-parse", "HEAD"))
 	gitSnapshot(t, repo, "branch", "main", baseCommit)
@@ -223,8 +228,8 @@ func TestExplicitPrePRRequestWithoutRemotePreservesUnchangedBase(t *testing.T) {
 		PolicyArtifact: policyPath, LedgerArtifact: ledgerPath, EvidenceArtifact: evidencePath,
 	}
 	bindGateRequestToStore(t, &request, store)
-	if got := EvaluateNativeGate(context.Background(), repo, receipt, request); got.Result != GateAllow || got.Context.BaseAdvance != nil {
-		t.Fatalf("unchanged explicit PRE-PR request = %#v", got)
+	if got := EvaluateNativeGate(context.Background(), repo, receipt, request); got.Result != GateInvalidated || !strings.Contains(got.Reason, "--base-ref") {
+		t.Fatalf("unadvertised explicit PRE-PR request = %#v", got)
 	}
 }
 
@@ -237,10 +242,10 @@ func TestSelectPrePRBoundaryUsesExactExplicitOrPublicationDefaultCommit(t *testi
 		want     PrePRBoundarySelection
 	}{
 		{
-			name:     "explicit old reviewed base",
-			selector: fixture.originalBaseCommit,
+			name:     "explicit current chained base",
+			selector: "origin/reviewed-base",
 			want: PrePRBoundarySelection{
-				Source: PrePRBoundaryExplicit, Selector: fixture.originalBaseCommit, Commit: fixture.originalBaseCommit,
+				Source: PrePRBoundaryExplicit, Selector: "origin/reviewed-base", Commit: fixture.originalBaseCommit, Remote: "origin", RemoteRef: "refs/heads/reviewed-base",
 			},
 		},
 		{
@@ -253,6 +258,7 @@ func TestSelectPrePRBoundaryUsesExactExplicitOrPublicationDefaultCommit(t *testi
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := selectPrePRBoundary(context.Background(), fixture.repo, tt.selector)
+			got.RemoteIdentity = ""
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -263,6 +269,26 @@ func TestSelectPrePRBoundaryUsesExactExplicitOrPublicationDefaultCommit(t *testi
 	}
 }
 
+func TestDefaultBoundariesSeparatePrePRTargetFromPrePushTracking(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	base := trimGit(gitSnapshot(t, repo, "rev-parse", "HEAD"))
+	gitSnapshot(t, repo, "branch", "main", base)
+	gitSnapshot(t, repo, "branch", "feature", base)
+	configurePublicationRemote(t, repo, "main")
+	gitSnapshot(t, repo, "checkout", "feature")
+	gitSnapshot(t, repo, "config", "branch.feature.remote", "origin")
+	gitSnapshot(t, repo, "config", "branch.feature.merge", "refs/heads/feature")
+
+	prePR, err := selectPrePRBoundary(context.Background(), repo, "")
+	if err != nil || prePR.RemoteRef != "refs/heads/main" {
+		t.Fatalf("default PRE-PR boundary = %#v, %v", prePR, err)
+	}
+	_, prePush, err := buildPushTarget(context.Background(), repo, "", "")
+	if err != nil || prePush.Boundary.RemoteRef != "refs/heads/feature" {
+		t.Fatalf("default PRE-PUSH boundary = %#v, %v", prePush, err)
+	}
+}
+
 func TestSelectPrePRBoundaryRejectsAbsolutePathLikeSelector(t *testing.T) {
 	repo := initSnapshotRepo(t)
 	if _, err := selectPrePRBoundary(context.Background(), repo, filepath.Join(repo, "outside")); err == nil {
@@ -270,19 +296,42 @@ func TestSelectPrePRBoundaryRejectsAbsolutePathLikeSelector(t *testing.T) {
 	}
 }
 
-func TestSelectPrePRBoundaryUsesRepositoryRootForSubdirectoriesAndRelativeSelectors(t *testing.T) {
+func TestSelectPrePRBoundaryRejectsAdvertisedUnrelatedSameTree(t *testing.T) {
 	repo := initSnapshotRepo(t)
-	writeSnapshotFile(t, repo, "tracked.txt", "candidate\n")
-	gitSnapshot(t, repo, "add", "tracked.txt")
-	gitSnapshot(t, repo, "commit", "-m", "candidate")
-	want := trimGit(gitSnapshot(t, repo, "rev-parse", "HEAD~1"))
+	branch := currentBranch(context.Background(), repo)
+	remote := configurePublicationRemote(t, repo, branch)
+	writeSnapshotFile(t, repo, "delivery.txt", "delivery\n")
+	gitSnapshot(t, repo, "add", "delivery.txt")
+	gitSnapshot(t, repo, "commit", "-m", "delivery")
+	wantTree := trimGit(gitSnapshot(t, repo, "rev-parse", "HEAD^{tree}"))
+	if _, err := selectPrePRBoundary(context.Background(), repo, "origin/"+branch); err != nil {
+		t.Fatalf("valid chained base rejected: %v", err)
+	}
+
+	gitSnapshot(t, repo, "checkout", "--orphan", "unrelated")
+	gitSnapshot(t, repo, "commit", "-m", "unrelated same tree")
+	if got := trimGit(gitSnapshot(t, repo, "rev-parse", "HEAD^{tree}")); got != wantTree {
+		t.Fatalf("unrelated tree = %s, want %s", got, wantTree)
+	}
+	gitSnapshot(t, repo, "push", remote, "HEAD:refs/heads/unrelated")
+	gitSnapshot(t, repo, "checkout", branch)
+	if _, err := selectPrePRBoundary(context.Background(), repo, "origin/unrelated"); err == nil || !strings.Contains(err.Error(), "0 merge bases") {
+		t.Fatalf("advertised unrelated same-tree base error = %v", err)
+	}
+}
+
+func TestSelectPrePRBoundaryUsesRepositoryRootForSubdirectories(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	want := trimGit(gitSnapshot(t, repo, "rev-parse", "HEAD"))
+	branch := currentBranch(context.Background(), repo)
+	configurePublicationRemote(t, repo, branch)
 	subdirectory := filepath.Join(repo, "nested", "work")
 	if err := os.MkdirAll(subdirectory, 0o755); err != nil {
 		t.Fatal(err)
 	}
 
 	for _, location := range []string{repo, subdirectory} {
-		selection, err := selectPrePRBoundary(context.Background(), location, "HEAD~1")
+		selection, err := selectPrePRBoundary(context.Background(), location, "origin/"+branch)
 		if err != nil || selection.Source != PrePRBoundaryExplicit || selection.Commit != want {
 			t.Fatalf("selectPrePRBoundary(%q) = %#v, %v", location, selection, err)
 		}
@@ -293,13 +342,13 @@ func TestBuildNativePrePRRequestKeepsExplicitReviewedBaseWhenDefaultAdvanced(t *
 	fixture := newCompatiblePrePRFixture(t, "delivery.txt", "base-only.txt")
 
 	request, err := BuildNativeGateRequest(context.Background(), fixture.repo, NativeGateRequestInput{
-		Gate: GatePrePR, LineageID: fixture.receipt.LineageID, BaseRef: fixture.originalBaseCommit,
+		Gate: GatePrePR, LineageID: fixture.receipt.LineageID, BaseRef: "origin/reviewed-base",
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if request.Target.BaseRef != fixture.originalBaseCommit || request.PrePR == nil || request.PrePR.Boundary == nil || *request.PrePR.Boundary != (PrePRBoundarySelection{
-		Source: PrePRBoundaryExplicit, Selector: fixture.originalBaseCommit, Commit: fixture.originalBaseCommit,
+		Source: PrePRBoundaryExplicit, Selector: "origin/reviewed-base", Commit: fixture.originalBaseCommit, Remote: "origin", RemoteRef: "refs/heads/reviewed-base", RemoteIdentity: request.PrePR.Boundary.RemoteIdentity,
 	}) {
 		t.Fatalf("explicit pre-PR request = %#v", request)
 	}
@@ -321,7 +370,7 @@ func TestNativePrePRGateInvalidatesWhenExplicitSelectorMoves(t *testing.T) {
 	originalHook := finalGateAuthorizationHook
 	finalGateAuthorizationHook = func() {
 		finalGateAuthorizationHook = originalHook
-		gitSnapshot(t, fixture.repo, "update-ref", "refs/heads/main", fixture.originalBaseCommit)
+		gitSnapshot(t, fixture.repo, "--git-dir", fixture.remote, "update-ref", "refs/heads/main", fixture.originalBaseCommit)
 	}
 	t.Cleanup(func() { finalGateAuthorizationHook = originalHook })
 
@@ -333,7 +382,7 @@ func TestNativePrePRGateInvalidatesWhenExplicitSelectorMoves(t *testing.T) {
 func TestNativePrePRGateInvalidatesWhenCommitAMovesHead(t *testing.T) {
 	fixture := newCompatiblePrePRFixture(t, "delivery.txt", "base-only.txt")
 	request, err := BuildNativeGateRequest(context.Background(), fixture.repo, NativeGateRequestInput{
-		Gate: GatePrePR, LineageID: fixture.receipt.LineageID, BaseRef: fixture.originalBaseCommit,
+		Gate: GatePrePR, LineageID: fixture.receipt.LineageID, BaseRef: "origin/reviewed-base",
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -354,7 +403,7 @@ func TestNativePrePRGateInvalidatesWhenCommitAMovesHead(t *testing.T) {
 func TestNativePrePRGateIgnoresStagedAndEmptyIndexState(t *testing.T) {
 	fixture := newCompatiblePrePRFixture(t, "delivery.txt", "base-only.txt")
 	request, err := BuildNativeGateRequest(context.Background(), fixture.repo, NativeGateRequestInput{
-		Gate: GatePrePR, LineageID: fixture.receipt.LineageID, BaseRef: fixture.originalBaseCommit,
+		Gate: GatePrePR, LineageID: fixture.receipt.LineageID, BaseRef: "origin/reviewed-base",
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -373,7 +422,7 @@ func TestNativePrePRGateIgnoresStagedAndEmptyIndexState(t *testing.T) {
 func TestNativePrePRGateDenialRetainsAuthorityAndObservedBoundary(t *testing.T) {
 	fixture := newCompatiblePrePRFixture(t, "delivery.txt", "base-only.txt")
 	request, err := BuildNativeGateRequest(context.Background(), fixture.repo, NativeGateRequestInput{
-		Gate: GatePrePR, LineageID: fixture.receipt.LineageID, BaseRef: fixture.originalBaseCommit,
+		Gate: GatePrePR, LineageID: fixture.receipt.LineageID, BaseRef: "origin/reviewed-base",
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -462,8 +511,159 @@ func TestPublicationRemotePreservesTrackingFirstPushAndExplicitRefspecAuthority(
 	}
 }
 
+func TestPublicationTargetBindsAdvertisedUpstreamSeparatelyFromPushRemote(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	branch := currentBranch(context.Background(), repo)
+	base := trimGit(gitSnapshot(t, repo, "rev-parse", "HEAD"))
+	upstream, origin := filepath.Join(t.TempDir(), "upstream.git"), filepath.Join(t.TempDir(), "origin.git")
+	gitSnapshot(t, repo, "clone", "--bare", repo, upstream)
+	gitSnapshot(t, repo, "clone", "--bare", repo, origin)
+	gitSnapshot(t, repo, "--git-dir", upstream, "branch", "main", base)
+	gitSnapshot(t, repo, "remote", "add", "upstream", upstream)
+	gitSnapshot(t, repo, "remote", "add", "origin", origin)
+	gitSnapshot(t, repo, "config", "branch."+branch+".remote", "upstream")
+	gitSnapshot(t, repo, "config", "branch."+branch+".merge", "refs/heads/main")
+	gitSnapshot(t, repo, "config", "branch."+branch+".pushRemote", "origin")
+
+	writeSnapshotFile(t, repo, "one.txt", "one\n")
+	gitSnapshot(t, repo, "add", "one.txt")
+	gitSnapshot(t, repo, "commit", "-m", "one")
+	target, push, err := buildPushTarget(context.Background(), repo, "", "")
+	if err != nil || target.BaseRef != base || push.Boundary.Remote != "upstream" || push.PushRemote != "origin" {
+		t.Fatalf("one-commit fork target = %#v, %#v, %v", target, push, err)
+	}
+	_, refs, err := prePushTargetForRequest(context.Background(), repo, GateRequest{Gate: GatePrePush, Target: target, Push: push})
+	if err != nil || refs.DeliveredCommitCount != 1 {
+		t.Fatalf("one delivered commit = %#v, %v", refs, err)
+	}
+	writeSnapshotFile(t, repo, "two.txt", "two\n")
+	gitSnapshot(t, repo, "add", "two.txt")
+	gitSnapshot(t, repo, "commit", "-m", "two")
+	_, refs, err = prePushTargetForRequest(context.Background(), repo, GateRequest{Gate: GatePrePush})
+	if err != nil || refs.DeliveredCommitCount != 2 {
+		t.Fatalf("two delivered commits = %#v, %v", refs, err)
+	}
+	selection, err := selectPrePRBoundary(context.Background(), repo, "upstream/main")
+	if err != nil || selection.Remote != "upstream" || selection.Commit != base {
+		t.Fatalf("explicit chained base = %#v, %v", selection, err)
+	}
+	gitSnapshot(t, repo, "--git-dir", origin, "branch", "main", base)
+	if _, err := selectPrePRBoundary(context.Background(), repo, "main"); err == nil || !strings.Contains(err.Error(), "ambiguous") {
+		t.Fatalf("ambiguous explicit selector error = %v", err)
+	}
+	gitSnapshot(t, repo, "branch", "stale-local", base)
+	for _, selector := range []string{"stale-local", trimGit(gitSnapshot(t, repo, "rev-parse", "HEAD"))} {
+		if _, err := selectPrePRBoundary(context.Background(), repo, selector); err == nil {
+			t.Fatalf("unadvertised selector %q was accepted", selector)
+		}
+	}
+	frozen := *push
+	gitSnapshot(t, repo, "push", "upstream", "HEAD:refs/heads/main")
+	if _, _, err := prePushTargetForRequest(context.Background(), repo, GateRequest{Gate: GatePrePush, Target: target, Push: &frozen}); err == nil {
+		t.Fatal("advertised upstream advance preserved stale authorization")
+	}
+	gitSnapshot(t, repo, "config", "--unset", "branch."+branch+".merge")
+	if _, _, err := buildPushTarget(context.Background(), repo, "", ""); err == nil || !strings.Contains(err.Error(), "--base-ref") {
+		t.Fatalf("missing upstream error = %v", err)
+	}
+}
+
+func TestPrePushFinalAuthorizationRejectsEmptyHeadAdvanceWithGateParity(t *testing.T) {
+	legacyRepo, legacyReceipt, legacyRequest := approvedCurrentChangesGateFixture(t, "legacy-empty-final-head")
+	gitSnapshot(t, legacyRepo, "add", "tracked.txt")
+	gitSnapshot(t, legacyRepo, "commit", "-m", "delivery")
+	legacyRequest = nativePrePushRequest(t, legacyRepo, legacyReceipt, legacyRequest)
+
+	compactRepo := initSnapshotRepo(t)
+	branch := currentBranch(context.Background(), compactRepo)
+	configurePublicationRemote(t, compactRepo, branch)
+	gitSnapshot(t, compactRepo, "config", "branch."+branch+".remote", "origin")
+	gitSnapshot(t, compactRepo, "config", "branch."+branch+".merge", "refs/heads/"+branch)
+	writeSnapshotFile(t, compactRepo, "tracked.txt", "reviewed delivery\n")
+	state, _, compactReceipt := approvedCompactCurrentChangesFixture(t, compactRepo, "compact-empty-final-head", []string{})
+	gitSnapshot(t, compactRepo, "add", "tracked.txt")
+	gitSnapshot(t, compactRepo, "commit", "-m", "delivery")
+
+	for _, tt := range []struct {
+		name string
+		repo string
+		run  func() NativeGateEvaluation
+	}{
+		{name: "legacy", repo: legacyRepo, run: func() NativeGateEvaluation {
+			return EvaluateNativeGate(context.Background(), legacyRepo, legacyReceipt, legacyRequest)
+		}},
+		{name: "compact", repo: compactRepo, run: func() NativeGateEvaluation {
+			return EvaluateCompactGate(context.Background(), compactRepo, compactReceipt, NativeGateRequestInput{Gate: GatePrePush, LineageID: state.LineageID})
+		}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			originalHook := finalGateAuthorizationHook
+			finalGateAuthorizationHook = func() { gitSnapshot(t, tt.repo, "commit", "--allow-empty", "-m", "concurrent empty") }
+			t.Cleanup(func() { finalGateAuthorizationHook = originalHook })
+			if got := tt.run(); got.Result != GateInvalidated || !strings.Contains(got.Reason, "final authorization") {
+				t.Fatalf("empty final HEAD advance = %#v", got)
+			}
+			finalGateAuthorizationHook = originalHook
+		})
+	}
+}
+
+func TestPrePushRejectsHiddenCommitsBeforeReviewedDelivery(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		hidden func(t *testing.T, repo string)
+	}{
+		{name: "empty", hidden: func(t *testing.T, repo string) {
+			gitSnapshot(t, repo, "commit", "--allow-empty", "-m", "hidden empty")
+		}},
+		{name: "change and revert", hidden: func(t *testing.T, repo string) {
+			writeSnapshotFile(t, repo, "hidden.txt", "hidden\n")
+			gitSnapshot(t, repo, "add", "hidden.txt")
+			gitSnapshot(t, repo, "commit", "-m", "hidden change")
+			gitSnapshot(t, repo, "revert", "--no-edit", "HEAD")
+		}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			repo, receipt, request := approvedCurrentChangesGateFixture(t, "hidden-"+strings.ReplaceAll(tt.name, " ", "-"))
+			tt.hidden(t, repo)
+			gitSnapshot(t, repo, "add", "tracked.txt")
+			gitSnapshot(t, repo, "commit", "-m", "reviewed delivery")
+			if _, err := BuildNativeGateRequest(context.Background(), repo, NativeGateRequestInput{Gate: GatePrePush, LineageID: receipt.LineageID, PolicyArtifact: request.PolicyArtifact, LedgerArtifact: request.LedgerArtifact, EvidenceArtifact: request.EvidenceArtifact}); err == nil {
+				t.Fatal("hidden publication commits were accepted")
+			}
+		})
+	}
+}
+
+func TestPushIdentityUsesPushURLAndRechecksIt(t *testing.T) {
+	repo, receipt, artifacts := approvedCurrentChangesGateFixture(t, "pushurl-recheck")
+	gitSnapshot(t, repo, "add", "tracked.txt")
+	gitSnapshot(t, repo, "commit", "-m", "reviewed delivery")
+	redirect := filepath.Join(t.TempDir(), "redirect.git")
+	gitSnapshot(t, repo, "clone", "--bare", repo, redirect)
+	gitSnapshot(t, repo, "config", "remote.origin.pushurl", redirect)
+	request := nativePrePushRequest(t, repo, receipt, artifacts)
+	fetchIdentity, _ := remoteRepositoryIdentity(context.Background(), repo, "origin")
+	pushIdentity, _ := pushRepositoryIdentity(context.Background(), repo, "origin")
+	if request.Push.PushRemoteIdentity != pushIdentity || pushIdentity == fetchIdentity || !strings.HasPrefix(pushIdentity, "sha256:") {
+		t.Fatalf("push identity = %q, fetch identity = %q, request = %#v", pushIdentity, fetchIdentity, request.Push)
+	}
+	originalHook := finalGateAuthorizationHook
+	finalGateAuthorizationHook = func() {
+		gitSnapshot(t, repo, "config", "remote.origin.pushurl", filepath.Join(t.TempDir(), "changed.git"))
+	}
+	t.Cleanup(func() { finalGateAuthorizationHook = originalHook })
+	if got := EvaluateNativeGate(context.Background(), repo, receipt, request); got.Result != GateInvalidated || !strings.Contains(got.Reason, "final authorization") {
+		t.Fatalf("changed pushurl evaluation = %#v", got)
+	}
+}
+
 func TestCanonicalCorrectedRequestPreservesExplicitNativeParity(t *testing.T) {
 	repo := initSnapshotRepo(t)
+	branch := currentBranch(context.Background(), repo)
+	configurePublicationRemote(t, repo, branch)
+	gitSnapshot(t, repo, "config", "branch."+branch+".remote", "origin")
+	gitSnapshot(t, repo, "config", "branch."+branch+".merge", "refs/heads/"+branch)
 	fixture := correctedBundleFixture(t, repo, "corrected-request-parity")
 	fixPayload, err := json.Marshal(fixture.Transaction.Snapshot)
 	if err != nil {
@@ -534,6 +734,9 @@ func newCompatiblePrePRFixtureMode(t *testing.T, deliveryPath, basePath string, 
 	gitSnapshot(t, repo, "branch", "main", baseCommit)
 	remote := configurePublicationRemote(t, repo, "main")
 	gitSnapshot(t, repo, "checkout", "-qb", "feature")
+	gitSnapshot(t, repo, "config", "branch.feature.remote", "origin")
+	gitSnapshot(t, repo, "config", "branch.feature.merge", "refs/heads/main")
+	gitSnapshot(t, repo, "--git-dir", remote, "branch", "reviewed-base", baseCommit)
 	writeSnapshotFile(t, repo, deliveryPath, "reviewed delivery\n")
 	gitSnapshot(t, repo, "add", "--", deliveryPath)
 	gitSnapshot(t, repo, "commit", "-m", "delivery")
@@ -623,7 +826,11 @@ func newCompatiblePrePRFixtureMode(t *testing.T, deliveryPath, basePath string, 
 			PolicyArtifact: policyPath, LedgerArtifact: ledgerPath, EvidenceArtifact: evidencePath,
 		},
 	}
-	fixture.request.PrePR = &PrePRRequest{CIAttestationArtifact: fixture.attestationPath}
+	target, prePR, err := buildPrePRTarget(context.Background(), repo, "", fixture.attestationPath, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fixture.request.Target, fixture.request.PrePR = target, prePR
 	bindGateRequestToStore(t, &fixture.request, store)
 	fixture.signAndWriteAttestation(t)
 	return fixture
@@ -648,8 +855,12 @@ func (fixture *compatiblePrePRFixture) writeAttestation(t *testing.T) {
 
 func TestBuildNativeGateRequestDerivesAuthorityForEveryGate(t *testing.T) {
 	repo := initSnapshotRepo(t)
+	branch := currentBranch(context.Background(), repo)
 	gitSnapshot(t, repo, "branch", "main", "HEAD")
 	configurePublicationRemote(t, repo, "main")
+	gitSnapshot(t, repo, "config", "branch."+branch+".remote", "origin")
+	gitSnapshot(t, repo, "config", "branch."+branch+".merge", "refs/heads/main")
+	writeSnapshotFile(t, repo, "tracked.txt", "reviewed delivery\n")
 	tx, _, fixture := nativeGateFixture(t, repo, "native-request-all-gates")
 	store, err := AuthoritativeStore(context.Background(), repo, tx.LineageID)
 	if err != nil {
@@ -680,8 +891,10 @@ func TestBuildNativeGateRequestDerivesAuthorityForEveryGate(t *testing.T) {
 				t.Fatalf("pre-commit target = %#v", request.Target)
 			}
 		}},
-		{gate: GatePrePush, assert: func(t *testing.T, request GateRequest) {
-			if request.Target.Kind != TargetExactRevision || request.Target.Revision == "" {
+		{gate: GatePrePush, prepare: func(*NativeGateRequestInput) {
+			gitSnapshot(t, repo, "commit", "-am", "delivery")
+		}, assert: func(t *testing.T, request GateRequest) {
+			if request.Target.Kind != TargetBaseDiff || request.Target.BaseRef == "" || request.Push == nil {
 				t.Fatalf("pre-push target = %#v", request.Target)
 			}
 		}},
@@ -875,7 +1088,7 @@ func TestNativePrePushGateAcceptsCommittedCurrentChangesReceipt(t *testing.T) {
 
 	gitSnapshot(t, repo, "add", "tracked.txt")
 	gitSnapshot(t, repo, "commit", "-m", "deliver reviewed current changes")
-	request.Gate = GatePrePush
+	request = nativePrePushRequest(t, repo, receipt, request)
 	if got := EvaluateNativeGate(context.Background(), repo, receipt, request); got.Result != GateAllow {
 		t.Fatalf("EvaluateNativeGate(pre-push committed current changes) = %#v", got)
 	}
@@ -908,7 +1121,7 @@ func TestNativePrePushGateRejectsChangedOrAdvancedHead(t *testing.T) {
 				gitSnapshot(t, repo, "add", "tracked.txt")
 				gitSnapshot(t, repo, "commit", "-m", "alter reviewed delivery")
 			},
-			want: GateScopeChanged,
+			want: GateInvalidated,
 		},
 		{
 			name:    "advanced head",
@@ -926,8 +1139,8 @@ func TestNativePrePushGateRejectsChangedOrAdvancedHead(t *testing.T) {
 			repo, receipt, request := approvedCurrentChangesGateFixture(t, tt.lineage)
 			gitSnapshot(t, repo, "add", "tracked.txt")
 			gitSnapshot(t, repo, "commit", "-m", "deliver reviewed current changes")
+			request = nativePrePushRequest(t, repo, receipt, request)
 			tt.advance(t, repo)
-			request.Gate = GatePrePush
 
 			if got := EvaluateNativeGate(context.Background(), repo, receipt, request); got.Result != tt.want {
 				t.Fatalf("EvaluateNativeGate(%s) = %#v, want %q", tt.name, got, tt.want)
@@ -1121,6 +1334,13 @@ func nativeGateFixtureWithIntended(t *testing.T, repo, lineage string, intended 
 func approvedCurrentChangesGateFixture(t *testing.T, lineage string) (string, Receipt, GateRequest) {
 	t.Helper()
 	repo := initSnapshotRepo(t)
+	branch := currentBranch(context.Background(), repo)
+	configurePublicationRemote(t, repo, branch)
+	gitSnapshot(t, repo, "config", "branch."+branch+".remote", "origin")
+	gitSnapshot(t, repo, "config", "branch."+branch+".merge", "refs/heads/"+branch)
+	writeSnapshotFile(t, repo, "historical.txt", "pre-existing branch work\n")
+	gitSnapshot(t, repo, "add", "historical.txt")
+	gitSnapshot(t, repo, "commit", "-m", "historical branch work")
 	writeSnapshotFile(t, repo, "tracked.txt", "reviewed delivery\n")
 	transaction, receipt, request := nativeGateFixture(t, repo, lineage)
 	store, err := AuthoritativeStore(context.Background(), repo, transaction.LineageID)
@@ -1136,6 +1356,10 @@ func approvedCurrentChangesGateFixture(t *testing.T, lineage string) (string, Re
 func approvedEmptyCurrentChangesGateFixture(t *testing.T, lineage string) (string, Receipt, GateRequest) {
 	t.Helper()
 	repo := initSnapshotRepo(t)
+	branch := currentBranch(context.Background(), repo)
+	configurePublicationRemote(t, repo, branch)
+	gitSnapshot(t, repo, "config", "branch."+branch+".remote", "origin")
+	gitSnapshot(t, repo, "config", "branch."+branch+".merge", "refs/heads/"+branch)
 	transaction, receipt, request := nativeGateFixture(t, repo, lineage)
 	store, err := AuthoritativeStore(context.Background(), repo, transaction.LineageID)
 	if err != nil {
@@ -1258,4 +1482,14 @@ func bindGateRequestToStore(t *testing.T, request *GateRequest, store Store) {
 	request.GenesisRevision = bundle.GenesisRevision
 	request.ChainIdentity = bundle.ChainIdentity
 	request.BundleDigest = bundle.BundleDigest
+}
+
+func nativePrePushRequest(t *testing.T, repo string, receipt Receipt, artifacts GateRequest) GateRequest {
+	t.Helper()
+	input := NativeGateRequestInput{Gate: GatePrePush, LineageID: receipt.LineageID, PolicyArtifact: artifacts.PolicyArtifact, LedgerArtifact: artifacts.LedgerArtifact, EvidenceArtifact: artifacts.EvidenceArtifact}
+	request, err := BuildNativeGateRequest(context.Background(), repo, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return request
 }

--- a/internal/reviewtransaction/native_request.go
+++ b/internal/reviewtransaction/native_request.go
@@ -41,6 +41,7 @@ func BuildNativeGateRequest(ctx context.Context, repo string, input NativeGateRe
 	if err != nil {
 		return GateRequest{}, fmt.Errorf("load authoritative review chain: %w", err)
 	}
+	transaction := chain.Records[len(chain.Records)-1].Transaction
 	bundleDigest := chain.Identity
 	if strings.TrimSpace(input.BundleArtifact) != "" {
 		authoritative, err := store.ExportBundle()
@@ -71,7 +72,6 @@ func BuildNativeGateRequest(ctx context.Context, repo string, input NativeGateRe
 	case GatePostApply, GatePreCommit:
 		intended := input.IntendedUntracked
 		if intended == nil {
-			transaction := chain.Records[len(chain.Records)-1].Transaction
 			intended = append([]string(nil), transaction.Snapshot.IntendedUntracked...)
 			if intended == nil {
 				intended = []string{}
@@ -79,11 +79,12 @@ func BuildNativeGateRequest(ctx context.Context, repo string, input NativeGateRe
 		}
 		request.Target = Target{Kind: TargetCurrentChanges, IntendedUntracked: intended}
 	case GatePrePush:
-		head, err := resolveCommit(ctx, repo, "HEAD")
+		deliveryBaseTree := map[TargetKind]string{TargetCurrentChanges: transaction.Snapshot.BaseTree}[transaction.Snapshot.Kind]
+		target, push, err := buildPushTarget(ctx, repo, input.BaseRef, deliveryBaseTree)
 		if err != nil {
 			return GateRequest{}, err
 		}
-		request.Target = Target{Kind: TargetExactRevision, Revision: head}
+		request.Target, request.Push = target, push
 	case GatePrePR:
 		target, prePR, err := buildPrePRTarget(ctx, repo, input.BaseRef, input.PrePRCIAttestation, nil)
 		if err != nil {


### PR DESCRIPTION
## Linked Issue

Closes #1211

## PR Type

- [x] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change

## Summary

- Bind pre-push and pre-PR receipts to explicit publication topology, ancestry, complete commit ranges, and credential-free repository identity.
- Separate push-upstream and PR-base resolution, including forks and chained PRs.
- Recheck HEAD, base, remote identity/ref, candidate evidence, and delivered commit count after the final TOCTOU boundary.

## Test Plan

- [x] Hermetic ordinary, multi-commit, fork, chained, stale/unrelated, redirect, and concurrent-advance tests
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `git diff --check`

## Contributor Checklist

- [x] Approved issue and exactly one type label
- [x] Maintainer-approved `size:exception` for the cohesive publication-boundary state machine
- [x] Conventional commit, no AI attribution

## Review Evidence

Native HIGH lineage `review-16efed87624338ed` completed 4R review, one bounded 161-line correction, scoped validation, and approved the exact candidate. Pre-commit, pre-push, and pre-PR gates passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pre-push and pre-PR validation to ensure changes are evaluated against the correct published base and destination.
  * Added stronger checks for missing, ambiguous, or outdated review boundaries and delivery evidence.
  * Prevented stale approvals when upstream or push destinations change.
  * Improved handling of current-change reviews and legacy review workflows.
  * Validation now fails safely when repository or remote information cannot be verified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->