### PR TITLE
feat(opencode): default to gentle orchestrator

### DIFF
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -22,6 +22,7 @@ import (
 	"github.com/gentleman-programming/gentle-ai/internal/components/engram"
 	"github.com/gentleman-programming/gentle-ai/internal/components/gga"
 	"github.com/gentleman-programming/gentle-ai/internal/components/mcp"
+	"github.com/gentleman-programming/gentle-ai/internal/components/opencodedefault"
 	"github.com/gentleman-programming/gentle-ai/internal/components/opencodeplugin"
 	"github.com/gentleman-programming/gentle-ai/internal/components/permissions"
 	"github.com/gentleman-programming/gentle-ai/internal/components/persona"
@@ -1444,7 +1445,7 @@ func componentPathsWithWorkspaceScoped(homeDir, workspaceDir string, scope Insta
 			}
 			if adapter.Agent() == model.AgentOpenCode {
 				if p := adapter.SettingsPath(targetDir); p != "" {
-					paths = append(paths, p)
+					paths = append(paths, p, opencodedefault.OwnershipPath(p))
 				}
 				paths = append(paths, openCodeSDDPluginPaths(targetDir)...)
 				// Shared prompt files in the selected OpenCode config scope — back these up

--- a/internal/cli/sync_test.go
+++ b/internal/cli/sync_test.go
@@ -2357,6 +2357,13 @@ func TestRunSyncWithSelection_IsIdempotent(t *testing.T) {
 		Components: []model.ComponentID{model.ComponentSDD, model.ComponentEngram, model.ComponentContext7, model.ComponentGGA, model.ComponentSkills},
 		SDDMode:    model.SDDModeSingle,
 	}
+	settingsPath := filepath.Join(home, ".config", "opencode", "opencode.json")
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(settingsPath, []byte(`{"default_agent":"user-agent","keep":true}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	// Run 1: files written.
 	result1, err := RunSyncWithSelection(home, sel)
@@ -2365,6 +2372,10 @@ func TestRunSyncWithSelection_IsIdempotent(t *testing.T) {
 	}
 	if result1.FilesChanged == 0 {
 		t.Fatalf("run 1: FilesChanged = 0, expected > 0")
+	}
+	firstSettings, _ := os.ReadFile(settingsPath)
+	if !bytes.Contains(firstSettings, []byte(`"default_agent": "gentle-orchestrator"`)) {
+		t.Fatalf("TUI sync did not overwrite default_agent: %s", firstSettings)
 	}
 
 	// Run 2: nothing changed.
@@ -2377,6 +2388,10 @@ func TestRunSyncWithSelection_IsIdempotent(t *testing.T) {
 	}
 	if !result2.NoOp {
 		t.Errorf("run 2: NoOp = false, want true (all assets already current)")
+	}
+	secondSettings, _ := os.ReadFile(settingsPath)
+	if !bytes.Equal(firstSettings, secondSettings) {
+		t.Fatal("TUI sync was not byte-idempotent")
 	}
 }
 
@@ -2971,6 +2986,10 @@ func TestRunSyncDoesNotOverridePersistedAssignmentsOnSecondSync(t *testing.T) {
 	if err := os.MkdirAll(filepath.Join(home, ".config", "opencode"), 0o755); err != nil {
 		t.Fatalf("MkdirAll: %v", err)
 	}
+	settingsPath := filepath.Join(home, ".config", "opencode", "opencode.json")
+	if err := os.WriteFile(settingsPath, []byte(`{"default_agent":"user-agent","keep":true}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	err := state.Write(home, state.InstallState{
 		InstalledAgents: []string{"opencode"},
 		ClaudeModelAssignments: map[string]string{
@@ -2989,6 +3008,10 @@ func TestRunSyncDoesNotOverridePersistedAssignmentsOnSecondSync(t *testing.T) {
 	if err != nil {
 		t.Fatalf("RunSync(1) error = %v", err)
 	}
+	firstSettings, _ := os.ReadFile(settingsPath)
+	if !bytes.Contains(firstSettings, []byte(`"default_agent": "gentle-orchestrator"`)) {
+		t.Fatalf("CLI sync did not overwrite default_agent: %s", firstSettings)
+	}
 
 	// Second sync — should still have the assignments.
 	result, err := RunSync([]string{"--agents", "opencode", "--sdd-mode", "single"})
@@ -3002,6 +3025,10 @@ func TestRunSyncDoesNotOverridePersistedAssignmentsOnSecondSync(t *testing.T) {
 	ma := result.Selection.ModelAssignments["sdd-init"]
 	if ma.ProviderID != "anthropic" || ma.ModelID != "claude-sonnet-4" {
 		t.Errorf("After second sync: ModelAssignments[sdd-init] = %+v, want anthropic/claude-sonnet-4", ma)
+	}
+	secondSettings, _ := os.ReadFile(settingsPath)
+	if !bytes.Equal(firstSettings, secondSettings) {
+		t.Fatal("CLI sync was not byte-idempotent")
 	}
 }
 

--- a/internal/components/opencodedefault/ownership.go
+++ b/internal/components/opencodedefault/ownership.go
@@ -1,0 +1,219 @@
+package opencodedefault
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/gentleman-programming/gentle-ai/internal/components/filemerge"
+	"github.com/gentleman-programming/gentle-ai/internal/components/mutationjournal"
+)
+
+const (
+	ManagedAgent = "gentle-orchestrator"
+	schema       = "gentle-ai.opencode-default-agent"
+	version      = 1
+)
+type ownership struct {
+	Schema          string `json:"schema"`
+	Version         int    `json:"version"`
+	State           string `json:"state"`
+	PreviousState   string `json:"previous_state"`
+	PreviousDefault string `json:"previous_default,omitempty"`
+}
+type fieldValue struct {
+	present bool
+	value   string
+}
+type InstallPlan struct {
+	settingsPath string
+	owned        *ownership
+	recapture    bool
+}
+type UninstallPlan struct {
+	settingsPath  string
+	settingsExist bool
+	current       fieldValue
+	owned         *ownership
+}
+func OwnershipPath(settingsPath string) string {
+	return filepath.Join(filepath.Dir(settingsPath), ".gentle-ai-default-agent.json")
+}
+func PrepareInstall(settingsPath string) (*InstallPlan, error) {
+	root, _, exists, _, err := readSettings(settingsPath)
+	if err != nil {
+		return nil, err
+	}
+	owned, err := readOwnership(OwnershipPath(settingsPath))
+	if err != nil {
+		return nil, err
+	}
+	agents, _ := root["agent"].(map[string]any)
+	_, managedAgentPresent := agents[ManagedAgent]
+	return &InstallPlan{settingsPath: settingsPath, owned: owned, recapture: !exists || !managedAgentPresent}, nil
+}
+func (p *InstallPlan) Apply() (bool, error) {
+	root, raw, _, current, err := readSettings(p.settingsPath)
+	if err != nil {
+		return false, err
+	}
+	owned := p.owned
+	if owned == nil || p.recapture || !current.present || current.value != ManagedAgent {
+		owned = newOwnership(current)
+	}
+	root["default_agent"] = ManagedAgent
+	settings := encode(root)
+	metadata := encode(owned)
+	ownerPath := OwnershipPath(p.settingsPath)
+	ownerRaw, _ := os.ReadFile(ownerPath)
+	changed := !bytes.Equal(raw, settings) || !bytes.Equal(ownerRaw, metadata)
+	if err := writePair(p.settingsPath, settings, true, ownerPath, metadata, true); err != nil {
+		return false, err
+	}
+	return changed, nil
+}
+func PrepareUninstall(settingsPath string) (*UninstallPlan, error) {
+	_, _, exists, current, err := readSettings(settingsPath)
+	if err != nil {
+		return nil, err
+	}
+	owned, err := readOwnership(OwnershipPath(settingsPath))
+	if err != nil {
+		return nil, err
+	}
+	return &UninstallPlan{settingsPath: settingsPath, settingsExist: exists, current: current, owned: owned}, nil
+}
+func (p *UninstallPlan) Apply(cleaned []byte, settingsExist bool) (changed, removed bool, err error) {
+	root := map[string]any{}
+	if settingsExist {
+		if root, err = filemerge.UnmarshalJSONObject(cleaned); err != nil {
+			return false, false, fmt.Errorf("parse cleaned OpenCode settings: %w", err)
+		}
+	}
+	if p.settingsExist && p.current.present && p.current.value == ManagedAgent {
+		if p.owned == nil || p.owned.PreviousState == "absent" {
+			delete(root, "default_agent")
+		} else {
+			root["default_agent"] = p.owned.PreviousDefault
+		}
+	}
+	settingsExist = settingsExist && len(root) > 0
+	var settings []byte
+	if settingsExist {
+		settings = encode(root)
+	}
+	currentRaw, readErr := os.ReadFile(p.settingsPath)
+	currentExists := readErr == nil
+	if readErr != nil && !os.IsNotExist(readErr) {
+		return false, false, readErr
+	}
+	changed = currentExists != settingsExist || (settingsExist && !bytes.Equal(currentRaw, settings)) || p.owned != nil
+	if err := writePair(p.settingsPath, settings, settingsExist, OwnershipPath(p.settingsPath), nil, false); err != nil {
+		return false, false, err
+	}
+	return changed, currentExists && !settingsExist, nil
+}
+func readSettings(path string) (map[string]any, []byte, bool, fieldValue, error) {
+	raw, err := readRegular(path)
+	if os.IsNotExist(err) {
+		return map[string]any{}, nil, false, fieldValue{}, nil
+	}
+	if err != nil {
+		return nil, nil, false, fieldValue{}, fmt.Errorf("read OpenCode settings %q: %w", path, err)
+	}
+	root, err := filemerge.UnmarshalJSONObject(raw)
+	if err != nil {
+		return nil, nil, false, fieldValue{}, fmt.Errorf("parse OpenCode settings %q: %w", path, err)
+	}
+	current, err := defaultField(root)
+	if err != nil {
+		return nil, nil, false, fieldValue{}, err
+	}
+	return root, raw, true, current, nil
+}
+func readOwnership(path string) (*ownership, error) {
+	raw, err := readRegular(path)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read OpenCode default ownership %q: %w", path, err)
+	}
+	var owned ownership
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&owned); err != nil {
+		return nil, fmt.Errorf("decode OpenCode default ownership %q: %w", path, err)
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		return nil, fmt.Errorf("decode OpenCode default ownership %q: trailing data", path)
+	}
+	validPrevious := owned.PreviousState == "absent" && owned.PreviousDefault == "" || owned.PreviousState == "value"
+	if owned.Schema != schema || owned.Version != version || owned.State != "managed" || !validPrevious {
+		return nil, fmt.Errorf("invalid OpenCode default ownership %q", path)
+	}
+	return &owned, nil
+}
+func readRegular(path string) ([]byte, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return nil, err
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("not a regular file")
+	}
+	return os.ReadFile(path)
+}
+func defaultField(root map[string]any) (fieldValue, error) {
+	value, exists := root["default_agent"]
+	if !exists {
+		return fieldValue{}, nil
+	}
+	text, ok := value.(string)
+	if !ok {
+		return fieldValue{}, fmt.Errorf("OpenCode default_agent must be a string")
+	}
+	return fieldValue{present: true, value: text}, nil
+}
+func newOwnership(previous fieldValue) *ownership {
+	owned := &ownership{Schema: schema, Version: version, State: "managed", PreviousState: "absent"}
+	if previous.present {
+		owned.PreviousState = "value"
+		owned.PreviousDefault = previous.value
+	}
+	return owned
+}
+func encode(value any) []byte {
+	raw, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		panic(err) // Values are either decoded JSON or the fixed ownership struct.
+	}
+	return append(raw, '\n')
+}
+func writePair(settingsPath string, settings []byte, keepSettings bool, ownerPath string, owner []byte, keepOwner bool) error {
+	journal := mutationjournal.New(filepath.Dir(settingsPath))
+	if err := journal.Capture(settingsPath); err != nil {
+		return err
+	}
+	if err := journal.Capture(ownerPath); err != nil {
+		return err
+	}
+	mutate := func(path string, data []byte, keep bool) error {
+		if keep {
+			_, err := journal.WriteWithMode(path, data, 0o644)
+			return err
+		}
+		_, err := journal.Remove(path)
+		return err
+	}
+	if err := mutate(settingsPath, settings, keepSettings); err != nil {
+		return fmt.Errorf("update OpenCode settings: %w (rollback: %v)", err, journal.Restore())
+	}
+	if err := mutate(ownerPath, owner, keepOwner); err != nil {
+		return fmt.Errorf("update OpenCode default ownership: %w (rollback: %v)", err, journal.Restore())
+	}
+	return nil
+}

--- a/internal/components/opencodedefault/ownership_test.go
+++ b/internal/components/opencodedefault/ownership_test.go
@@ -1,0 +1,107 @@
+package opencodedefault
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+func check(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+func read(t *testing.T, path string) []byte {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	check(t, err)
+	return data
+}
+func TestOwnershipLifecycle(t *testing.T) {
+	settings := filepath.Join(t.TempDir(), "opencode.json")
+	write := func(body string) { check(t, os.WriteFile(settings, []byte(body), 0o644)) }
+	install := func() {
+		plan, err := PrepareInstall(settings)
+		check(t, err)
+		_, err = plan.Apply()
+		check(t, err)
+	}
+	uninstall := func() {
+		plan, err := PrepareUninstall(settings)
+		check(t, err)
+		raw, err := os.ReadFile(settings)
+		_, _, applyErr := plan.Apply(raw, err == nil)
+		check(t, applyErr)
+	}
+	wantDefault := func(want string) {
+		got := read(t, settings)
+		if !bytes.Contains(got, []byte(`"default_agent": "`+want+`"`)) {
+			t.Fatalf("default %q not restored: %s", want, got)
+		}
+	}
+	write(`{"default_agent":"build","agent":{"gentle-orchestrator":{}},"profile":true}`)
+	install()
+	install()
+	uninstall()
+	wantDefault("build")
+	write(`{"default_agent":"plan","profile":true}`)
+	install()
+	uninstall()
+	wantDefault("plan")
+	install()
+	check(t, os.Remove(settings))
+	write(`{"default_agent":"gentle-orchestrator","profile":true}`)
+	install()
+	uninstall()
+	wantDefault("gentle-orchestrator")
+	install()
+	check(t, os.Remove(settings))
+	uninstall()
+	if _, err := os.Stat(OwnershipPath(settings)); !os.IsNotExist(err) {
+		t.Fatalf("stale ownership remains: %v", err)
+	}
+	install()
+	uninstall()
+	if _, err := os.Stat(settings); !os.IsNotExist(err) {
+		t.Fatalf("fresh absence was not restored: %v", err)
+	}
+	write(`{"default_agent":"build"}`)
+	before := read(t, settings)
+	check(t, os.WriteFile(OwnershipPath(settings), []byte(`{"schema":"wrong"}`), 0o644))
+	if _, err := PrepareUninstall(settings); err == nil {
+		t.Fatal("malformed ownership was accepted")
+	}
+	if after := read(t, settings); !bytes.Equal(before, after) {
+		t.Fatalf("settings changed: %q", after)
+	}
+}
+
+func TestUninstallWithoutOwnershipHandlesDefaultAgent(t *testing.T) {
+	for _, tt := range []struct {
+		name         string
+		defaultAgent string
+		wantPresent  bool
+	}{
+		{name: "managed default is removed", defaultAgent: ManagedAgent},
+		{name: "user default is preserved", defaultAgent: "build", wantPresent: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			settings := filepath.Join(t.TempDir(), "opencode.json")
+			original := `{"default_agent":"` + tt.defaultAgent + `","agent":{"gentle-orchestrator":{}},"profile":true}`
+			check(t, os.WriteFile(settings, []byte(original), 0o644))
+			plan, err := PrepareUninstall(settings)
+			check(t, err)
+
+			cleaned := []byte(`{"default_agent":"` + tt.defaultAgent + `","profile":true}`)
+			_, _, err = plan.Apply(cleaned, true)
+			check(t, err)
+
+			got := read(t, settings)
+			present := bytes.Contains(got, []byte(`"default_agent"`))
+			if present != tt.wantPresent || present && !bytes.Contains(got, []byte(`"default_agent": "`+tt.defaultAgent+`"`)) {
+				t.Fatalf("settings = %s", got)
+			}
+		})
+	}
+}

--- a/internal/components/sdd/inject.go
+++ b/internal/components/sdd/inject.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gentleman-programming/gentle-ai/internal/assets"
 	"github.com/gentleman-programming/gentle-ai/internal/catalog"
 	"github.com/gentleman-programming/gentle-ai/internal/components/filemerge"
+	"github.com/gentleman-programming/gentle-ai/internal/components/opencodedefault"
 	"github.com/gentleman-programming/gentle-ai/internal/components/skills"
 	"github.com/gentleman-programming/gentle-ai/internal/model"
 	"github.com/gentleman-programming/gentle-ai/internal/opencode"
@@ -226,6 +227,14 @@ func Inject(homeDir string, adapter agents.Adapter, sddMode model.SDDModeID, opt
 	}
 	if err := validateOpenClawWorkspacePath(homeDir, adapter); err != nil {
 		return InjectionResult{}, err
+	}
+	var defaultPlan *opencodedefault.InstallPlan
+	if adapter.Agent() == model.AgentOpenCode {
+		var err error
+		defaultPlan, err = opencodedefault.PrepareInstall(adapter.SettingsPath(homeDir))
+		if err != nil {
+			return InjectionResult{}, err
+		}
 	}
 
 	var opts InjectOptions
@@ -540,6 +549,14 @@ func Inject(homeDir string, adapter agents.Adapter, sddMode model.SDDModeID, opt
 				}
 				changed = changed || profileResult.writeResult.Changed
 				mergedSettingsBytes = profileResult.merged
+			}
+			if defaultPlan != nil {
+				defaultChanged, defaultErr := defaultPlan.Apply()
+				if defaultErr != nil {
+					return InjectionResult{}, defaultErr
+				}
+				changed = changed || defaultChanged
+				files = append(files, opencodedefault.OwnershipPath(settingsPath))
 			}
 		}
 	}

--- a/internal/components/sdd/inject_test.go
+++ b/internal/components/sdd/inject_test.go
@@ -538,6 +538,11 @@ func TestInjectOpenCodeIsIdempotent(t *testing.T) {
 	if !first.Changed {
 		t.Fatalf("Inject() first changed = false")
 	}
+	settingsPath := opencodeAdapter().SettingsPath(home)
+	firstSettings, err := os.ReadFile(settingsPath)
+	if err != nil || !bytes.Contains(firstSettings, []byte(`"default_agent": "gentle-orchestrator"`)) {
+		t.Fatalf("first settings missing managed default: %s, err = %v", firstSettings, err)
+	}
 
 	second, err := Inject(home, opencodeAdapter(), "")
 	if err != nil {
@@ -5661,7 +5666,7 @@ func TestInjectOpenCodeWithProfile_StaleJDCleanupAcceptsJSONCSettings(t *testing
 	}
 }
 
-func TestInjectOpenCodeWithProfile_StaleJDCleanupDoesNotRejectMalformedSettings(t *testing.T) {
+func TestInjectOpenCodeRejectsMalformedSettingsBeforeWrites(t *testing.T) {
 	home := t.TempDir()
 	mockNoPackageManager(t)
 
@@ -5677,20 +5682,16 @@ func TestInjectOpenCodeWithProfile_StaleJDCleanupDoesNotRejectMalformedSettings(
 		Name:              "cheap",
 		OrchestratorModel: model.ModelAssignment{ProviderID: "anthropic", ModelID: "claude-haiku-3-5"},
 	}
-	if _, err := Inject(home, opencodeAdapter(), model.SDDModeMulti, InjectOptions{Profiles: []model.Profile{profileWithoutJD}}); err != nil {
-		t.Fatalf("Inject() should preserve merge behavior for malformed opencode settings: %v", err)
+	before, _ := os.ReadFile(settingsPath)
+	if _, err := Inject(home, opencodeAdapter(), model.SDDModeMulti, InjectOptions{Profiles: []model.Profile{profileWithoutJD}}); err == nil {
+		t.Fatal("Inject() accepted malformed opencode settings")
 	}
-
-	content, err := os.ReadFile(settingsPath)
-	if err != nil {
-		t.Fatalf("ReadFile(opencode.json): %v", err)
+	after, _ := os.ReadFile(settingsPath)
+	if !bytes.Equal(before, after) {
+		t.Fatalf("malformed settings changed: %q", after)
 	}
-	var root map[string]any
-	if err := json.Unmarshal(content, &root); err != nil {
-		t.Fatalf("opencode.json should be recovered as valid JSON: %v", err)
-	}
-	if _, ok := root["agent"].(map[string]any)["sdd-orchestrator-cheap"]; !ok {
-		t.Fatal("profile orchestrator missing after malformed settings recovery")
+	if _, err := os.Stat(filepath.Join(home, ".config", "opencode", "commands")); !os.IsNotExist(err) {
+		t.Fatalf("commands were written before settings validation: %v", err)
 	}
 }
 

--- a/internal/components/uninstall/service.go
+++ b/internal/components/uninstall/service.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gentleman-programming/gentle-ai/internal/components/communitytool"
 	"github.com/gentleman-programming/gentle-ai/internal/components/filemerge"
 	"github.com/gentleman-programming/gentle-ai/internal/components/gga"
+	"github.com/gentleman-programming/gentle-ai/internal/components/opencodedefault"
 	"github.com/gentleman-programming/gentle-ai/internal/components/sdd"
 	"github.com/gentleman-programming/gentle-ai/internal/model"
 	"github.com/gentleman-programming/gentle-ai/internal/state"
@@ -610,7 +611,11 @@ func (s *Service) componentOperations(adapter agents.Adapter, componentID model.
 			ops = append(ops, rewriteSkillRegistryHook(path))
 		}
 		if path := adapter.SettingsPath(homeDir); path != "" && adapter.Agent() == model.AgentOpenCode {
-			targets = append(targets, path)
+			defaultPlan, err := opencodedefault.PrepareUninstall(path)
+			if err != nil {
+				return nil, nil, err
+			}
+			targets = append(targets, path, opencodedefault.OwnershipPath(path))
 			paths := make([]jsonPath, 0, len(configuredAgents))
 			for _, agentKey := range configuredAgents {
 				paths = append(paths, jsonPath{"agent", agentKey})
@@ -633,7 +638,7 @@ func (s *Service) componentOperations(adapter agents.Adapter, componentID model.
 				}
 			}
 
-			ops = append(ops, rewriteJSONFile(path, paths...))
+			ops = append(ops, rewriteOpenCodeSDDSettings(path, defaultPlan, paths...))
 
 			pluginDir := filepath.Join(homeDir, ".config", "opencode", "plugins")
 			for _, pluginPath := range []string{
@@ -870,6 +875,24 @@ func rewriteJSONFile(path string, jsonPaths ...jsonPath) operation {
 			return true, false, nil
 		},
 	}
+}
+
+func rewriteOpenCodeSDDSettings(path string, plan *opencodedefault.UninstallPlan, jsonPaths ...jsonPath) operation {
+	return operation{typeID: opRewriteFile, path: path, apply: func(path string) (bool, bool, error) {
+		raw, err := readManagedFile(path)
+		exists := err == nil
+		if err != nil && !os.IsNotExist(err) {
+			return false, false, err
+		}
+		updated := raw
+		if exists {
+			updated, _, err = removeJSONPaths(raw, jsonPaths...)
+			if err != nil {
+				return false, false, err
+			}
+		}
+		return plan.Apply(updated, exists)
+	}}
 }
 
 func rewriteSkillRegistryHook(path string) operation {

--- a/testdata/golden/sdd-opencode-multi-settings.golden
+++ b/testdata/golden/sdd-opencode-multi-settings.golden
@@ -263,5 +263,6 @@
       }
     }
   },
+  "default_agent": "gentle-orchestrator",
   "share": "disabled"
 }


### PR DESCRIPTION
## Linked Issue

Closes #1208

## PR Type

- [ ] `type:bug` — Bug fix
- [x] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change

## Summary

- Make `gentle-orchestrator` OpenCode's default agent when OpenCode+SDD is installed or synced from CLI/TUI.
- Preserve and transactionally manage the user's previous default through schema-versioned ownership metadata.
- Restore/remove the managed default safely on uninstall while preserving later user changes.

## Test Plan

- [x] Install, CLI sync and TUI sync overwrite/idempotence coverage
- [x] Malformed/missing ownership, settings recreation, workspace/global scope, rollback and uninstall coverage
- [x] `go test ./... -count=1`
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] Golden update and verification
- [x] `git diff --check`

## Contributor Checklist

- [x] Approved issue and exactly one type label
- [x] Maintainer-approved `size:exception` for atomic settings/ownership lifecycle and integration tests
- [x] Conventional commit, no AI attribution

## Review Evidence

Native lineage `review-089e2083defb1bb6` completed reliability review, bounded correction, scoped validation, and approved the exact candidate. Pre-commit/pre-push passed; pre-PR passed using the candidate native facade containing merged #1214 intended-untracked transition support.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OpenCode installations now manage the default agent setting and preserve any previous user-selected value.
  * Uninstalling OpenCode restores the previous default agent or removes the setting when appropriate.
  * Installation and removal now track ownership metadata for safer configuration management.

* **Bug Fixes**
  * Synchronization is now idempotent and preserves settings on repeat runs.
  * Malformed OpenCode settings are rejected before any files are changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->