### PR TITLE
fix(installer): preserve custom and subagent contracts

### DIFF
--- a/internal/components/sdd/prompts.go
+++ b/internal/components/sdd/prompts.go
@@ -158,6 +158,10 @@ func injectCodeGraphGuidanceIntoOpenCodeSubagentPrompts(agentMap map[string]any,
 		if mode, _ := agent["mode"].(string); mode == "primary" {
 			continue
 		}
+		tools, _ := agent["tools"].(map[string]any)
+		if bash, explicitlySet := tools["bash"].(bool); explicitlySet && !bash {
+			continue
+		}
 		prompt, ok := agent["prompt"].(string)
 		if !ok || strings.HasPrefix(prompt, "{file:") {
 			continue

--- a/internal/components/sdd/prompts_test.go
+++ b/internal/components/sdd/prompts_test.go
@@ -75,6 +75,36 @@ func sddReviewSubAgentsForCodeGraphTest() []string {
 		"review-readability",
 		"review-reliability",
 		"review-resilience",
+		"review-refuter",
+	}
+}
+
+func sddShellDisabledSubAgentsForCodeGraphTest() []string {
+	agents := []string{"jd-judge-a", "jd-judge-b"}
+	return append(agents, sddReviewSubAgentsForCodeGraphTest()...)
+}
+
+func assertOpenCodeSubAgentReadOnlyTools(t *testing.T, agentsMap map[string]any, agentName string) {
+	t.Helper()
+	agent, ok := agentsMap[agentName].(map[string]any)
+	if !ok {
+		t.Fatalf("agent %q missing or not an object", agentName)
+	}
+	tools, ok := agent["tools"].(map[string]any)
+	if !ok {
+		t.Fatalf("agent %q tools have type %T, want object", agentName, agent["tools"])
+	}
+	for tool, want := range map[string]bool{
+		"read":  true,
+		"write": false,
+		"edit":  false,
+		"bash":  false,
+		"task":  false,
+	} {
+		got, ok := tools[tool].(bool)
+		if !ok || got != want {
+			t.Fatalf("agent %q tool %q = %v, want %t", agentName, tool, tools[tool], want)
+		}
 	}
 }
 
@@ -434,7 +464,7 @@ func TestInjectOpenCodeSingleModeSubagentPromptsOmitCodeGraphGuidanceByDefault(t
 	}
 }
 
-func TestInjectOpenCodeSingleModeSubagentPromptsIncludeCodeGraphGuidanceWhenEnabled(t *testing.T) {
+func TestInjectOpenCodeSingleModeSubagentPromptsRespectBashCapabilityWhenCodeGraphEnabled(t *testing.T) {
 	home := t.TempDir()
 	mockNoPackageManager(t)
 
@@ -443,7 +473,8 @@ func TestInjectOpenCodeSingleModeSubagentPromptsIncludeCodeGraphGuidanceWhenEnab
 	}
 
 	agentsMap := readOpenCodeAgents(t, filepath.Join(home, ".config", "opencode", "opencode.json"))
-	for _, agentName := range sddInstalledSubAgentsForCodeGraphTest() {
+	bashCapableAgents := append(SharedPromptPhases(), "jd-fix-agent")
+	for _, agentName := range bashCapableAgents {
 		prompt := agentPrompt(t, agentsMap, agentName)
 		if !strings.Contains(prompt, "<!-- gentle-ai:codegraph-guidance -->") || !strings.Contains(prompt, "gentle-ai codegraph init --cwd <project-root>") {
 			t.Fatalf("%s missing CodeGraph guidance when enabled", agentName)
@@ -451,6 +482,13 @@ func TestInjectOpenCodeSingleModeSubagentPromptsIncludeCodeGraphGuidanceWhenEnab
 		if count := strings.Count(prompt, "<!-- gentle-ai:codegraph-guidance -->"); count != 1 {
 			t.Fatalf("%s has %d CodeGraph guidance sections, want 1", agentName, count)
 		}
+	}
+	for _, agentName := range sddShellDisabledSubAgentsForCodeGraphTest() {
+		prompt := agentPrompt(t, agentsMap, agentName)
+		if strings.Contains(prompt, "<!-- gentle-ai:codegraph-guidance -->") || strings.Contains(prompt, "gentle-ai codegraph init --cwd <project-root>") {
+			t.Fatalf("%s contains shell-based CodeGraph guidance with bash disabled", agentName)
+		}
+		assertOpenCodeSubAgentReadOnlyTools(t, agentsMap, agentName)
 	}
 }
 
@@ -475,12 +513,16 @@ func TestInjectOpenCodeMultiModeSubagentPromptFilesIncludeCodeGraphGuidanceWhenE
 	}
 
 	agentsMap := readOpenCodeAgents(t, filepath.Join(home, ".config", "opencode", "opencode.json"))
-	inlineSubagents := append(sddJudgmentDaySubAgentsForCodeGraphTest(), sddReviewSubAgentsForCodeGraphTest()...)
-	for _, agentName := range inlineSubagents {
+	fixPrompt := agentPrompt(t, agentsMap, "jd-fix-agent")
+	if !strings.Contains(fixPrompt, "<!-- gentle-ai:codegraph-guidance -->") || !strings.Contains(fixPrompt, "gentle-ai codegraph init --cwd <project-root>") {
+		t.Fatal("jd-fix-agent missing CodeGraph guidance in multi-mode inline prompt when enabled")
+	}
+	for _, agentName := range sddShellDisabledSubAgentsForCodeGraphTest() {
 		prompt := agentPrompt(t, agentsMap, agentName)
-		if !strings.Contains(prompt, "<!-- gentle-ai:codegraph-guidance -->") || !strings.Contains(prompt, "gentle-ai codegraph init --cwd <project-root>") {
-			t.Fatalf("%s missing CodeGraph guidance in multi-mode inline prompt when enabled", agentName)
+		if strings.Contains(prompt, "<!-- gentle-ai:codegraph-guidance -->") || strings.Contains(prompt, "gentle-ai codegraph init --cwd <project-root>") {
+			t.Fatalf("%s contains shell-based CodeGraph guidance with bash disabled", agentName)
 		}
+		assertOpenCodeSubAgentReadOnlyTools(t, agentsMap, agentName)
 	}
 }
 

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -2027,10 +2027,9 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 			// truth. pickerNextScreen(ScreenPreset) returns the first chain member
 			// for the current selection (Claude → Kiro → Codex → SDDMode →
 			// ModelPicker → StrictTDD); applyPickerEntry initializes its state.
-			// DependencyTree is the slice's terminal anchor, not a "picker": when
-			// it is the only next member, no SDD/picker screen applies, so fall
-			// through to the OpenCodePlugins guard below.
-			if next, ok := m.pickerNextScreen(); ok && next != ScreenDependencyTree {
+			// DependencyTree is the initial component picker for Custom and the
+			// terminal anchor for every other preset.
+			if next, ok := m.pickerNextScreen(); ok && (next != ScreenDependencyTree || m.Selection.Preset == model.PresetCustom) {
 				m.applyPickerEntry(next)
 				return m, nil
 			}

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -2550,6 +2550,29 @@ func TestPresetConfirmEntersFirstPickerInFlow(t *testing.T) {
 	}
 }
 
+func TestPresetConfirmCustomEntersDependencyTreeComponentPicker(t *testing.T) {
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Screen = ScreenPreset
+	m.InstallFlowActive = true
+	m.Cursor = presetCursor(t, model.PresetCustom)
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	state := updated.(Model)
+
+	if state.Screen != ScreenDependencyTree {
+		t.Fatalf("screen = %v, want %v", state.Screen, ScreenDependencyTree)
+	}
+	if state.Cursor != 0 {
+		t.Fatalf("cursor = %d, want 0", state.Cursor)
+	}
+	if state.Selection.Preset != model.PresetCustom {
+		t.Fatalf("preset = %q, want %q", state.Selection.Preset, model.PresetCustom)
+	}
+	if len(state.Selection.Components) != 0 {
+		t.Fatalf("components = %v, want empty custom selection", state.Selection.Components)
+	}
+}
+
 // TestKiroPickerEscNonCustomWithClaudeGoesToClaudePicker verifies that Esc from
 // ScreenKiroModelPicker in a non-custom preset returns to ScreenClaudeModelPicker
 // when Claude is in the flow — keeping Esc consistent with Enter on "← Back".


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1229

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Route the TUI Custom preset into its component picker instead of falling through to Community Tools/CodeGraph.
- Keep shell-based CodeGraph guidance out of OpenCode subagents that explicitly disable `bash`.
- Preserve full CodeGraph guidance for bash-capable agents and the read-only contracts of all review/Judgment Day roles.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/tui/model.go` | Distinguish Custom's dependency-tree picker from the curated-preset terminal anchor |
| `internal/tui/model_test.go` | Prove the active-install Custom transition and empty initial component selection |
| `internal/components/sdd/prompts.go` | Make CodeGraph guidance injection aware of an explicit `tools.bash:false` capability |
| `internal/components/sdd/prompts_test.go` | Cover shell-disabled and bash-capable agents in OpenCode single and multi modes |

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./...
go vet ./...
go build ./...
```

**E2E Tests**
```bash
cd e2e && ./docker-test.sh
```

- [x] Unit tests pass (`go test ./...`)
- [x] E2E tests pass in CI on Arch, Fedora, and Ubuntu
- [x] Focused TUI and OpenCode generated-config regressions pass
- [x] `go vet ./...`, `go build ./...`, and `git diff --check` pass

---

## 🤖 Automated Checks

The following checks run automatically on this PR:

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ✅ | 88 changed lines, within the 400-line budget |
| Check Issue Reference | ✅ | PR closes approved issue #1229 |
| Check Issue Has `status:approved` | ✅ | Issue #1229 is approved |
| Check PR Has `type:*` Label | ✅ | Exactly `type:bug` is applied |
| Unit Tests | ✅ | Local and CI suites passed |
| E2E Tests | ✅ | Arch, Fedora, and Ubuntu passed |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [x] E2E tests pass in CI on Arch, Fedora, and Ubuntu
- [x] Documentation is not required for these corrective behavior changes
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

Native bounded review lineage `review-e035b3025b13a1d2` approved the exact four-file candidate. Pre-commit, pre-push, and pre-PR gates all allowed the same content-bound receipt.
