### PR TITLE
fix(tui): preserve custom choices across sync

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -537,7 +537,7 @@ func tuiExecute(
 			agentIDs = append(agentIDs, string(a))
 		}
 		claudePhaseState := claudePhaseAssignmentsToState(selection.ClaudePhaseAssignments)
-		if writeErr := state.Write(homeDir, state.InstallState{
+		installState := state.InstallState{
 			InstalledAgents:             agentIDs,
 			CommunityTools:              appCommunityToolIDsToStrings(selection.CommunityTools),
 			CommunityToolsConfigured:    true,
@@ -550,7 +550,9 @@ func tuiExecute(
 			CodexPhaseModelAssignments:  selection.CodexPhaseModelAssignments,
 			ModelAssignments:            modelAssignmentsToState(selection.ModelAssignments),
 			Persona:                     string(selection.Persona),
-		}); writeErr != nil {
+		}
+		installState.SetSelection(selection)
+		if writeErr := state.Write(homeDir, installState); writeErr != nil {
 			execResult.Err = fmt.Errorf("persist install state: %w", writeErr)
 		}
 	}
@@ -667,6 +669,12 @@ func syncShouldIncludePermissions(agentIDs []model.AgentID) bool {
 }
 
 func syncArgsForDiscoveredAgents(homeDir string) []string {
+	if persisted, err := state.Read(homeDir); err == nil && persisted.SelectionConfigured {
+		if (model.Selection{Components: persisted.Components}).HasComponent(model.ComponentPermission) {
+			return []string{"--include-permissions"}
+		}
+		return nil
+	}
 	if syncShouldIncludePermissions(cli.DiscoverAgents(homeDir)) {
 		return []string{"--include-permissions"}
 	}
@@ -737,6 +745,7 @@ func loadPersistedAssignments(homeDir string, selection *model.Selection) {
 	if err != nil {
 		return
 	}
+	cli.RestorePersistedSelection(selection, s, cli.SyncFlags{})
 	if len(selection.ClaudePhaseAssignments) == 0 && len(s.ClaudePhaseAssignments) > 0 {
 		m := make(map[string]model.ClaudePhaseAssignment, len(s.ClaudePhaseAssignments))
 		for k, v := range s.ClaudePhaseAssignments {

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -512,6 +512,29 @@ func TestTuiSyncTargetAgentsFallsBackToDiscoveredAgents(t *testing.T) {
 	}
 }
 
+func TestTuiSyncSelectionPreservesCustomPermissionExclusion(t *testing.T) {
+	home := t.TempDir()
+	if err := state.Write(home, state.InstallState{InstalledAgents: []string{"opencode"}, SelectionConfigured: true, Components: []model.ComponentID{model.ComponentSkills}, Skills: []model.SkillID{model.SkillCommentWriter}, Preset: model.PresetCustom}); err != nil {
+		t.Fatal(err)
+	}
+	selection := model.Selection{Agents: []model.AgentID{model.AgentOpenCode}, Components: []model.ComponentID{model.ComponentPermission}, Preset: model.PresetFullGentleman}
+	loadPersistedAssignments(home, &selection)
+	if selection.HasComponent(model.ComponentPermission) || !reflect.DeepEqual(selection.Skills, []model.SkillID{model.SkillCommentWriter}) || selection.Preset != model.PresetCustom {
+		t.Fatalf("TUI sync replaced custom selection: %#v", selection)
+	}
+}
+
+func TestTUIExecutePersistsConfiguredSelection(t *testing.T) {
+	home := t.TempDir()
+	setupMockHome(t, home)
+	selection := model.Selection{Preset: model.PresetCustom, Components: []model.ComponentID{}, Skills: []model.SkillID{}, SDDMode: model.SDDModeMulti, StrictTDD: true}
+	result := tuiExecute(selection, planner.ResolvedPlan{}, system.DetectionResult{}, nil)
+	got, err := state.Read(home)
+	if result.Err != nil || err != nil || !got.SelectionConfigured || got.Preset != model.PresetCustom || got.SDDMode != model.SDDModeMulti || !got.StrictTDD || len(got.Components) != 0 || len(got.Skills) != 0 {
+		t.Fatalf("persisted selection = %#v, execute err = %v, read err = %v", got, result.Err, err)
+	}
+}
+
 func TestTuiSyncIncludesCodexPermissions(t *testing.T) {
 	t.Cleanup(codex.SetRuntimeVersionCommandForTest("codex-cli 0.144.0", nil))
 	home := t.TempDir()
@@ -628,10 +651,15 @@ func TestDeferredSyncIncludesCodexPermissionsArgs(t *testing.T) {
 	if err := state.Write(home, state.InstallState{InstalledAgents: []string{string(model.AgentCodex)}}); err != nil {
 		t.Fatalf("state.Write: %v", err)
 	}
-
-	args := syncArgsForDiscoveredAgents(home)
-	if len(args) != 1 || args[0] != "--include-permissions" {
-		t.Fatalf("syncArgsForDiscoveredAgents() = %v, want [--include-permissions]", args)
+	if args := syncArgsForDiscoveredAgents(home); len(args) != 1 || args[0] != "--include-permissions" {
+		t.Fatalf("legacy sync args = %v, want permissions", args)
+	}
+	configured := t.TempDir()
+	if err := state.Write(configured, state.InstallState{InstalledAgents: []string{"codex"}, SelectionConfigured: true, Components: []model.ComponentID{model.ComponentEngram}}); err != nil {
+		t.Fatal(err)
+	}
+	if args := syncArgsForDiscoveredAgents(configured); len(args) != 0 {
+		t.Fatalf("configured Custom sync args = %v, want none", args)
 	}
 }
 

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -219,8 +219,9 @@ func RunInstall(args []string, detection system.DetectionResult) (InstallResult,
 		ModelAssignments:            modelAssignmentsToState(input.Selection.ModelAssignments),
 		Persona:                     string(input.Selection.Persona),
 	}
+	newState.SetSelection(input.Selection)
 	if len(flags.Agents) > 0 {
-		merged, ok := mergeExplicitAgentInstallState(homeDir, newState, agentIDs)
+		merged, ok := mergeExplicitAgentInstallState(homeDir, newState, agentIDs, flags)
 		if !ok {
 			return result, nil
 		}
@@ -233,7 +234,7 @@ func RunInstall(args []string, detection system.DetectionResult) (InstallResult,
 	return result, nil
 }
 
-func mergeExplicitAgentInstallState(homeDir string, newState state.InstallState, agentIDs []string) (state.InstallState, bool) {
+func mergeExplicitAgentInstallState(homeDir string, newState state.InstallState, agentIDs []string, flags InstallFlags) (state.InstallState, bool) {
 	existing, readErr := state.Read(homeDir)
 	if readErr != nil {
 		if errors.Is(readErr, os.ErrNotExist) {
@@ -268,7 +269,21 @@ func mergeExplicitAgentInstallState(homeDir string, newState state.InstallState,
 	if newState.CodexPhaseModelAssignments != nil {
 		merged.CodexPhaseModelAssignments = newState.CodexPhaseModelAssignments
 	}
-	if merged.Persona == "" && newState.Persona != "" {
+	if merged.SelectionConfigured {
+		if len(flags.Components) > 0 {
+			merged.Components = newState.Components
+		}
+		if len(flags.Skills) > 0 {
+			merged.Skills = newState.Skills
+		}
+		if flags.Preset != "" {
+			merged.Preset = newState.Preset
+		}
+		if flags.SDDMode != "" {
+			merged.SDDMode = newState.SDDMode
+		}
+	}
+	if flags.Persona != "" || merged.Persona == "" {
 		merged.Persona = newState.Persona
 	}
 	return merged, true

--- a/internal/cli/run_state_test.go
+++ b/internal/cli/run_state_test.go
@@ -1,12 +1,14 @@
 package cli
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/gentleman-programming/gentle-ai/internal/model"
 	"github.com/gentleman-programming/gentle-ai/internal/state"
+	"github.com/gentleman-programming/gentle-ai/internal/system"
 )
 
 func TestMergeExplicitAgentInstallStatePreservesExistingAssignmentsWhenFreshStateIsEmpty(t *testing.T) {
@@ -36,7 +38,7 @@ func TestMergeExplicitAgentInstallStatePreservesExistingAssignmentsWhenFreshStat
 		t.Fatalf("state.Write: %v", err)
 	}
 
-	merged, ok := mergeExplicitAgentInstallState(home, state.InstallState{InstalledAgents: []string{"codex"}, Persona: "gentleman"}, []string{"codex"})
+	merged, ok := mergeExplicitAgentInstallState(home, state.InstallState{InstalledAgents: []string{"codex"}, Persona: "gentleman"}, []string{"codex"}, InstallFlags{})
 	if !ok {
 		t.Fatal("mergeExplicitAgentInstallState ok = false, want true")
 	}
@@ -66,6 +68,37 @@ func TestMergeExplicitAgentInstallStatePreservesExistingAssignmentsWhenFreshStat
 	}
 }
 
+func TestMergeExplicitAgentInstallStateMergesOnlyExplicitSelectionField(t *testing.T) {
+	original := state.InstallState{InstalledAgents: []string{"opencode"}, SelectionConfigured: true, Components: []model.ComponentID{model.ComponentEngram}, Skills: []model.SkillID{model.SkillCommentWriter}, Preset: model.PresetCustom, SDDMode: model.SDDModeSingle, StrictTDD: true, Persona: "neutral"}
+	fresh := state.InstallState{InstalledAgents: []string{"codex"}, SelectionConfigured: true, Components: []model.ComponentID{model.ComponentSDD}, Skills: []model.SkillID{model.SkillSDDInit}, Preset: model.PresetFullGentleman, SDDMode: model.SDDModeMulti, Persona: "gentleman"}
+	cases := []InstallFlags{{Components: []string{"sdd"}}, {Skills: []string{"sdd-init"}}, {Preset: "full-gentleman"}, {SDDMode: "multi"}, {Persona: "gentleman"}}
+	wants := []string{"[sdd]|[comment-writer]|custom|single|true|neutral", "[engram]|[sdd-init]|custom|single|true|neutral", "[engram]|[comment-writer]|full-gentleman|single|true|neutral", "[engram]|[comment-writer]|custom|multi|true|neutral", "[engram]|[comment-writer]|custom|single|true|gentleman"}
+	for i, flags := range cases {
+		home := t.TempDir()
+		if err := state.Write(home, original); err != nil {
+			t.Fatal(err)
+		}
+		got, ok := mergeExplicitAgentInstallState(home, fresh, []string{"codex"}, flags)
+		if key := fmt.Sprintf("%v|%v|%s|%s|%t|%s", got.Components, got.Skills, got.Preset, got.SDDMode, got.StrictTDD, got.Persona); !ok || key != wants[i] {
+			t.Errorf("flags %#v merged selection %s", flags, key)
+		}
+	}
+}
+
+func TestRunInstallPersistsConfiguredSelection(t *testing.T) {
+	home := t.TempDir()
+	original := osUserHomeDir
+	osUserHomeDir = func() (string, error) { return home, nil }
+	t.Cleanup(func() { osUserHomeDir = original })
+	if _, err := RunInstall([]string{"--agent", "cursor", "--preset", "custom", "--sdd-mode", "multi"}, system.DetectionResult{}); err != nil {
+		t.Fatal(err)
+	}
+	got, err := state.Read(home)
+	if err != nil || !got.SelectionConfigured || got.Preset != model.PresetCustom || got.SDDMode != model.SDDModeMulti || len(got.Components) != 0 {
+		t.Fatalf("persisted selection = %#v, err = %v", got, err)
+	}
+}
+
 func TestMergeExplicitAgentInstallStatePreservesFreshAssignments(t *testing.T) {
 	home := t.TempDir()
 	if err := state.Write(home, state.InstallState{
@@ -91,7 +124,7 @@ func TestMergeExplicitAgentInstallStatePreservesFreshAssignments(t *testing.T) {
 		Persona: "gentleman",
 	}
 
-	merged, ok := mergeExplicitAgentInstallState(home, fresh, []string{"codex"})
+	merged, ok := mergeExplicitAgentInstallState(home, fresh, []string{"codex"}, InstallFlags{})
 	if !ok {
 		t.Fatal("mergeExplicitAgentInstallState ok = false, want true")
 	}
@@ -122,7 +155,7 @@ func TestMergeExplicitAgentInstallStateSkipsCorruptState(t *testing.T) {
 		t.Fatalf("WriteFile: %v", err)
 	}
 
-	_, ok := mergeExplicitAgentInstallState(home, state.InstallState{InstalledAgents: []string{"codex"}}, []string{"codex"})
+	_, ok := mergeExplicitAgentInstallState(home, state.InstallState{InstalledAgents: []string{"codex"}}, []string{"codex"}, InstallFlags{})
 	if ok {
 		t.Fatal("mergeExplicitAgentInstallState ok = true for corrupt state, want false")
 	}

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -51,6 +51,11 @@ type SyncFlags struct {
 	// --profile and --profile-phase flags before parsing into model.Profile.
 	rawProfiles      []string
 	rawProfilePhases []string
+	skillsSet        bool
+	sddModeSet       bool
+	strictTDDSet     bool
+	permissionsSet   bool
+	themeSet         bool
 }
 
 // SyncResult holds the outcome of a sync execution.
@@ -97,6 +102,20 @@ func ParseSyncFlags(args []string) (SyncFlags, error) {
 	if err := fs.Parse(args); err != nil {
 		return SyncFlags{}, err
 	}
+	fs.Visit(func(f *flag.Flag) {
+		switch f.Name {
+		case "skill", "skills":
+			opts.skillsSet = true
+		case "sdd-mode":
+			opts.sddModeSet = true
+		case "strict-tdd":
+			opts.strictTDDSet = true
+		case "include-permissions":
+			opts.permissionsSet = true
+		case "include-theme":
+			opts.themeSet = true
+		}
+	})
 
 	if fs.NArg() > 0 {
 		return SyncFlags{}, fmt.Errorf("unexpected sync argument %q", fs.Arg(0))
@@ -319,6 +338,42 @@ func BuildSyncSelection(flags SyncFlags, agentIDs []model.AgentID) model.Selecti
 		// Persona is left as zero-value here. RunSync resolves it from state.json
 		// when present. Missing or invalid persisted persona resolves to neutral
 		// so sync does not silently reactivate regional persona behavior.
+	}
+}
+
+func RestorePersistedSelection(selection *model.Selection, persisted state.InstallState, flags SyncFlags) {
+	if !persisted.SelectionConfigured {
+		return
+	}
+	explicit := *selection
+	persisted.RestoreSelection(selection)
+	if flags.skillsSet {
+		selection.Skills = explicit.Skills
+		setSelectionComponent(selection, model.ComponentSkills, true, true)
+	}
+	if flags.sddModeSet {
+		selection.SDDMode = explicit.SDDMode
+	}
+	if flags.strictTDDSet {
+		selection.StrictTDD = explicit.StrictTDD
+	}
+	setSelectionComponent(selection, model.ComponentPermission, flags.permissionsSet, flags.IncludePermissions)
+	setSelectionComponent(selection, model.ComponentTheme, flags.themeSet, flags.IncludeTheme)
+}
+
+func setSelectionComponent(selection *model.Selection, component model.ComponentID, configured, included bool) {
+	if !configured {
+		return
+	}
+	filtered := selection.Components[:0]
+	for _, current := range selection.Components {
+		if current != component {
+			filtered = append(filtered, current)
+		}
+	}
+	selection.Components = filtered
+	if included {
+		selection.Components = append(selection.Components, component)
 	}
 }
 
@@ -1220,6 +1275,7 @@ func RunSync(args []string) (SyncResult, error) {
 	// On error (e.g. state.json absent), treat persisted values as empty — model
 	// maps stay as-is and persona falls back to neutral.
 	persistedState, _ := state.Read(homeDir)
+	RestorePersistedSelection(&selection, persistedState, flags)
 	restorePersistedCommunityTools(homeDir, &selection, persistedState)
 
 	// Load persisted model assignments from state when not provided via flags.

--- a/internal/cli/sync_test.go
+++ b/internal/cli/sync_test.go
@@ -2666,6 +2666,31 @@ func TestBuildSyncSelectionStrictTDD(t *testing.T) {
 	}
 }
 
+func TestRunSyncRestoresConfiguredSelectionAndExplicitOverrides(t *testing.T) {
+	home := t.TempDir()
+	if err := state.Write(home, state.InstallState{InstalledAgents: []string{"cursor"}, SelectionConfigured: true, Components: []model.ComponentID{model.ComponentEngram}, Skills: []model.SkillID{model.SkillCommentWriter}, Preset: model.PresetCustom}); err != nil {
+		t.Fatal(err)
+	}
+	original := osUserHomeDir
+	osUserHomeDir = func() (string, error) { return home, nil }
+	t.Cleanup(func() { osUserHomeDir = original })
+	plain, err := RunSync([]string{"--dry-run"})
+	if err != nil || !reflect.DeepEqual(plain.Selection.Components, []model.ComponentID{model.ComponentEngram}) || !reflect.DeepEqual(plain.Selection.Skills, []model.SkillID{model.SkillCommentWriter}) || plain.Selection.Preset != model.PresetCustom {
+		t.Fatalf("plain sync selection = %#v, err = %v", plain.Selection, err)
+	}
+	overridden, err := RunSync([]string{"--dry-run", "--skill", "sdd-init", "--sdd-mode", "multi", "--strict-tdd"})
+	if err != nil || !reflect.DeepEqual(overridden.Selection.Skills, []model.SkillID{model.SkillSDDInit}) || !overridden.Selection.HasComponent(model.ComponentSkills) || overridden.Selection.SDDMode != model.SDDModeMulti || !overridden.Selection.StrictTDD {
+		t.Fatalf("overridden sync selection = %#v, err = %v", overridden.Selection, err)
+	}
+	if err := state.Write(home, state.InstallState{InstalledAgents: []string{"cursor"}}); err != nil {
+		t.Fatal(err)
+	}
+	result, err := RunSync([]string{"--dry-run"})
+	if err != nil || result.Selection.Preset != model.PresetFullGentleman || !result.Selection.HasComponent(model.ComponentSkills) {
+		t.Fatalf("legacy sync selection = %#v, err = %v", result.Selection, err)
+	}
+}
+
 // ─── Phase 5: Profile CLI flags ───────────────────────────────────────────────
 
 // TestParseSyncFlagsProfileSingleModel verifies that --profile name:provider/model

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/gentleman-programming/gentle-ai/internal/components/filemerge"
+	"github.com/gentleman-programming/gentle-ai/internal/model"
 )
 
 const stateDir = ".gentle-ai"
@@ -38,7 +39,13 @@ type ClaudePhaseAssignmentState struct {
 
 // InstallState holds the persisted user selections from the last install run.
 type InstallState struct {
-	InstalledAgents []string `json:"installed_agents"`
+	InstalledAgents     []string            `json:"installed_agents"`
+	SelectionConfigured bool                `json:"selection_configured,omitempty"`
+	Components          []model.ComponentID `json:"components,omitempty"`
+	Skills              []model.SkillID     `json:"skills,omitempty"`
+	Preset              model.PresetID      `json:"preset,omitempty"`
+	SDDMode             model.SDDModeID     `json:"sdd_mode,omitempty"`
+	StrictTDD           bool                `json:"strict_tdd,omitempty"`
 	// CommunityTools records optional tools explicitly selected in the Gentle AI
 	// installer. Configured distinguishes a completed empty selection from legacy
 	// state files that predate persistence of this choice.
@@ -128,6 +135,22 @@ func Read(homeDir string) (InstallState, error) {
 	return s, nil
 }
 
+func (s *InstallState) SetSelection(selection model.Selection) {
+	s.SelectionConfigured = true
+	s.Components = append([]model.ComponentID(nil), selection.Components...)
+	s.Skills = append([]model.SkillID(nil), selection.Skills...)
+	s.Preset, s.SDDMode, s.StrictTDD = selection.Preset, selection.SDDMode, selection.StrictTDD
+}
+
+func (s InstallState) RestoreSelection(selection *model.Selection) {
+	if !s.SelectionConfigured {
+		return
+	}
+	selection.Components = append([]model.ComponentID(nil), s.Components...)
+	selection.Skills = append([]model.SkillID(nil), s.Skills...)
+	selection.Preset, selection.SDDMode, selection.StrictTDD = s.Preset, s.SDDMode, s.StrictTDD
+}
+
 // MergeAgents returns a new InstallState that combines existing with the
 // provided newAgents. The new agents are appended to existing.InstalledAgents
 // with deduplication. All other persisted selections, including community
@@ -156,6 +179,12 @@ func MergeAgents(existing InstallState, newAgents []string) InstallState {
 
 	return InstallState{
 		InstalledAgents:             merged,
+		SelectionConfigured:         existing.SelectionConfigured,
+		Components:                  existing.Components,
+		Skills:                      existing.Skills,
+		Preset:                      existing.Preset,
+		SDDMode:                     existing.SDDMode,
+		StrictTDD:                   existing.StrictTDD,
 		CommunityTools:              existing.CommunityTools,
 		CommunityToolsConfigured:    existing.CommunityToolsConfigured,
 		ModelAssignments:            existing.ModelAssignments,

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -4,8 +4,11 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"testing"
 	"time"
+
+	"github.com/gentleman-programming/gentle-ai/internal/model"
 )
 
 // TestMergeAgents verifies that MergeAgents appends new agents to existing
@@ -108,6 +111,24 @@ func TestCommunityToolsRoundTrip(t *testing.T) {
 	}
 	if !reflect.DeepEqual(got.CommunityTools, want.CommunityTools) || !got.CommunityToolsConfigured {
 		t.Fatalf("community tool state = (%v, %t), want (%v, true)", got.CommunityTools, got.CommunityToolsConfigured, want.CommunityTools)
+	}
+}
+
+func TestSelectionRoundTripPreservesPresenceAndExplicitEmpty(t *testing.T) {
+	tests := []InstallState{
+		{SelectionConfigured: true, Components: []model.ComponentID{model.ComponentSDD}, Skills: []model.SkillID{model.SkillSDDInit}, Preset: model.PresetCustom, SDDMode: model.SDDModeMulti, StrictTDD: true},
+		{SelectionConfigured: true, Components: []model.ComponentID{}, Skills: []model.SkillID{}, Preset: model.PresetCustom},
+		{InstalledAgents: []string{"opencode"}},
+	}
+	for i, want := range tests {
+		home := t.TempDir()
+		if err := Write(home, want); err != nil {
+			t.Fatal(err)
+		}
+		got, err := Read(home)
+		if err != nil || got.SelectionConfigured != want.SelectionConfigured || !slices.Equal(got.Components, want.Components) || !slices.Equal(got.Skills, want.Skills) || got.Preset != want.Preset || got.SDDMode != want.SDDMode || got.StrictTDD != want.StrictTDD {
+			t.Errorf("case %d selection = %#v, want %#v", i, got, want)
+		}
 	}
 }
 

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1152,7 +1152,7 @@ func (m Model) View() string {
 	case ScreenDependencyTree:
 		return screens.RenderDependencyTree(m.DependencyPlan, m.Selection, m.Cursor)
 	case ScreenSkillPicker:
-		return screens.RenderSkillPicker(m.SkillPicker, m.Cursor)
+		return screens.RenderSkillPicker(m.SkillPicker, m.Cursor, m.Height)
 	case ScreenReview:
 		return screens.RenderReview(m.Review, m.Cursor)
 	case ScreenInstalling:

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -4105,6 +4105,17 @@ func TestCustomPresetSkillPickerBackGoesToStrictTDD(t *testing.T) {
 	}
 }
 
+func TestSkillPickerToggleUsesCanonicalIndex(t *testing.T) {
+	all := screens.AllSkillsOrdered()
+	for i, skill := range all {
+		m := Model{Screen: ScreenSkillPicker, Cursor: i, SkillPicker: append([]model.SkillID(nil), all...)}
+		m.toggleCurrentSkill()
+		if slices.Contains(m.SkillPicker, skill) {
+			t.Errorf("cursor %d did not toggle canonical skill %q", i, skill)
+		}
+	}
+}
+
 // TestCustomPresetReviewBackGoesToStrictTDD verifies that in the custom preset,
 // pressing Back on ScreenReview when no Skills and StrictTDD should be shown
 // (SDD selected) goes back to ScreenStrictTDD.

--- a/internal/tui/screens/skill_picker.go
+++ b/internal/tui/screens/skill_picker.go
@@ -1,35 +1,13 @@
 package screens
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/gentleman-programming/gentle-ai/internal/components/skills"
 	"github.com/gentleman-programming/gentle-ai/internal/model"
 	"github.com/gentleman-programming/gentle-ai/internal/tui/styles"
 )
-
-// sddSkillIDs are the SDD orchestrator skills shown in the first group.
-var sddSkillIDs = []model.SkillID{
-	model.SkillSDDInit,
-	model.SkillSDDExplore,
-	model.SkillSDDPropose,
-	model.SkillSDDSpec,
-	model.SkillSDDDesign,
-	model.SkillSDDTasks,
-	model.SkillSDDApply,
-	model.SkillSDDVerify,
-	model.SkillSDDArchive,
-	model.SkillSDDOnboard,
-	model.SkillJudgmentDay,
-}
-
-// foundationSkillIDs are the baseline/learning skills shown in the second group.
-var foundationSkillIDs = []model.SkillID{
-	model.SkillGoTesting,
-	model.SkillCreator,
-	model.SkillBranchPR,
-	model.SkillIssueCreation,
-}
 
 // skillLabels maps each SkillID to a human-readable display label.
 var skillLabels = map[model.SkillID]string{
@@ -50,6 +28,15 @@ var skillLabels = map[model.SkillID]string{
 	model.SkillIssueCreation: "Issue Creation",
 }
 
+var additionalSkillLabels = map[model.SkillID]string{
+	model.SkillImprover:        "Skill Improver",
+	model.SkillSkillRegistry:   "Skill Registry",
+	model.SkillChainedPR:       "Chained PR",
+	model.SkillCognitiveDoc:    "Cognitive Doc Design",
+	model.SkillCommentWriter:   "Comment Writer",
+	model.SkillWorkUnitCommits: "Work Unit Commits",
+}
+
 // SkillPickerOptions returns the action buttons shown after the skill checkboxes.
 func SkillPickerOptions() []string {
 	return []string{"Continue", "Back"}
@@ -66,7 +53,7 @@ func SkillPickerOptionCount() int {
 }
 
 // RenderSkillPicker renders the skill selection screen for custom preset mode.
-func RenderSkillPicker(selectedSkills []model.SkillID, cursor int) string {
+func RenderSkillPicker(selectedSkills []model.SkillID, cursor, height int) string {
 	var b strings.Builder
 
 	b.WriteString(styles.TitleStyle.Render("Select Skills"))
@@ -79,47 +66,56 @@ func RenderSkillPicker(selectedSkills []model.SkillID, cursor int) string {
 		selectedSet[s] = struct{}{}
 	}
 
-	allSkills := AllSkillsOrdered()
-
-	// ── SDD Skills group ──────────────────────────────────────────────────────
-	b.WriteString(styles.HeadingStyle.Render("SDD Skills"))
-	b.WriteString("\n")
-
-	for idx, skillID := range sddSkillIDs {
-		_, checked := selectedSet[skillID]
-		focused := idx == cursor
-		label := skillLabelFor(skillID)
-		b.WriteString(renderCheckbox(label, checked, focused))
+	allSkills, actions := AllSkillsOrdered(), SkillPickerOptions()
+	total, sddCount := len(allSkills)+len(actions), len(skills.SkillsForPreset(model.PresetMinimal))
+	start, end := skillPickerWindow(cursor, height, total)
+	for idx := start; idx < end; idx++ {
+		if idx < len(allSkills) {
+			if idx == start || idx == sddCount {
+				heading := "SDD Skills"
+				if idx >= sddCount {
+					b.WriteString("\n")
+					heading = "Foundation Skills"
+				}
+				b.WriteString(styles.HeadingStyle.Render(heading) + "\n")
+			}
+			_, checked := selectedSet[allSkills[idx]]
+			b.WriteString(renderCheckbox(skillLabelFor(allSkills[idx]), checked, idx == cursor))
+		} else {
+			focus := -1
+			if idx == len(allSkills) {
+				b.WriteString("\n")
+			}
+			if idx == cursor {
+				focus = 0
+			}
+			b.WriteString(renderOptions([]string{actions[idx-len(allSkills)]}, focus))
+		}
 	}
-
-	b.WriteString("\n")
-
-	// ── Foundation Skills group ───────────────────────────────────────────────
-	b.WriteString(styles.HeadingStyle.Render("Foundation Skills"))
-	b.WriteString("\n")
-
-	for i, skillID := range foundationSkillIDs {
-		idx := len(sddSkillIDs) + i
-		_, checked := selectedSet[skillID]
-		focused := idx == cursor
-		label := skillLabelFor(skillID)
-		b.WriteString(renderCheckbox(label, checked, focused))
+	if start > 0 || end < total {
+		b.WriteString(styles.SubtextStyle.Render(fmt.Sprintf("Rows %d-%d of %d", start+1, end, total)) + "\n")
 	}
-
-	b.WriteString("\n")
-
-	// ── Action buttons ────────────────────────────────────────────────────────
-	actionOffset := cursor - len(allSkills)
-	b.WriteString(renderOptions(SkillPickerOptions(), actionOffset))
 	b.WriteString("\n")
 	b.WriteString(styles.HelpStyle.Render("j/k: navigate • space/enter: toggle • esc: back"))
 
 	return b.String()
 }
 
+func skillPickerWindow(cursor, height, total int) (int, int) {
+	if height <= 0 || total <= height-8 {
+		return 0, total
+	}
+	visible := max(1, height-8)
+	start := max(0, min(cursor-visible/2, total-visible))
+	return start, start + visible
+}
+
 // skillLabelFor returns the human-readable label for a skill ID.
 func skillLabelFor(id model.SkillID) string {
 	if label, ok := skillLabels[id]; ok {
+		return label
+	}
+	if label, ok := additionalSkillLabels[id]; ok {
 		return label
 	}
 	return string(id)

--- a/internal/tui/screens/skill_picker_test.go
+++ b/internal/tui/screens/skill_picker_test.go
@@ -1,0 +1,29 @@
+package screens
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/internal/tui/styles"
+)
+
+func TestSkillPickerCanonicalRowsAndActions(t *testing.T) {
+	skills := AllSkillsOrdered()
+	labels := []string{"SDD Init", "SDD Explore", "SDD Propose", "SDD Spec", "SDD Design", "SDD Tasks", "SDD Apply", "SDD Verify", "SDD Archive", "SDD Onboard", "Judgment Day", "Go Testing", "Skill Creator", "Skill Improver", "Branch & PR", "Issue Creation", "Skill Registry", "Chained PR", "Cognitive Doc Design", "Comment Writer", "Work Unit Commits"}
+	if len(skills) != len(labels) {
+		t.Fatalf("canonical skills = %d, want %d", len(skills), len(labels))
+	}
+	for i, skill := range skills {
+		if got := skillLabelFor(skill); got != labels[i] || !strings.Contains(RenderSkillPicker(skills, i, 0), styles.Cursor+"[x] "+labels[i]) {
+			t.Errorf("canonical row %d for %q has label %q or focus mismatch", i, skill, got)
+		}
+	}
+	for i, action := range SkillPickerOptions() {
+		if !strings.Contains(RenderSkillPicker(skills, len(skills)+i, 0), styles.Cursor+action) {
+			t.Errorf("cursor %d does not focus action %q", len(skills)+i, action)
+		}
+	}
+	if view := RenderSkillPicker(skills, len(skills)+1, 7); !strings.Contains(view, styles.Cursor+"Back") || strings.Contains(view, "SDD Init") || !strings.Contains(view, "Rows 23-23 of 23") {
+		t.Fatal("small viewport did not follow Back with a scroll hint")
+	}
+}

--- a/internal/tui/testdata/custom-no-opencode-sdd-skills-next.golden
+++ b/internal/tui/testdata/custom-no-opencode-sdd-skills-next.golden
@@ -18,8 +18,14 @@ SDD Skills
 Foundation Skills
   [x] Go Testing
   [x] Skill Creator
+  [x] Skill Improver
   [x] Branch & PR
   [x] Issue Creation
+  [x] Skill Registry
+  [x] Chained PR
+  [x] Cognitive Doc Design
+  [x] Comment Writer
+  [x] Work Unit Commits
 
   Continue
   Back

--- a/internal/tui/testdata/custom-opencode-sdd-skills-after-plugins-next.golden
+++ b/internal/tui/testdata/custom-opencode-sdd-skills-after-plugins-next.golden
@@ -18,8 +18,14 @@ SDD Skills
 Foundation Skills
   [x] Go Testing
   [x] Skill Creator
+  [x] Skill Improver
   [x] Branch & PR
   [x] Issue Creation
+  [x] Skill Registry
+  [x] Chained PR
+  [x] Cognitive Doc Design
+  [x] Comment Writer
+  [x] Work Unit Commits
 
   Continue
   Back


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1231

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Render and navigate every canonical Skill Picker row with cursor-derived scrolling on small terminals.
- Persist Custom components, skills, preset, SDD mode, and Strict TDD with explicit-empty and legacy-compatible semantics.
- Make plain, deferred, and explicitly overridden sync preserve the user's Custom exclusions, including Permissions.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/tui/screens/skill_picker*` | Canonical 21-skill rendering, labels, viewport, cursor/action regressions |
| `internal/state` | Presence-aware persisted selection snapshot and round-trip coverage |
| `internal/cli/run*` | Full install persistence and field-level additive-install merging |
| `internal/cli/sync*` | Persisted-selection restoration with explicit-flag precedence |
| `internal/app` | TUI persistence and deferred/plain sync permission preservation |
| TUI goldens | Include all Foundation skills |

---

## 🔗 Chain Context

```text
main
 └─ 📍 PR 1/2: Custom picker + persisted sync selection
     └─ PR 2/2: async navigation + Back/Esc safety (planned after merge)
```

- **Start:** v2.1.2 main; Custom install choices are not a durable sync source of truth.
- **Finish:** Skill Picker and `state.json` share one canonical selection; later sync preserves explicit exclusions.
- **Out of scope:** asynchronous/result-state navigation fixes tracked by #1232.
- **Rollback:** revert this single commit; no schema migration is required because legacy absence retains old defaults.

---

## 🧪 Test Plan

```bash
go test ./internal/tui/... -count=1
go test ./internal/state -count=1
go test ./internal/app -count=1
go test ./internal/cli -count=1
go test ./...
go vet ./...
go build ./...
```

- [x] Unit tests pass (`go test ./...`)
- [x] Focused headless Skill Picker and selection round-trip tests pass
- [x] Configured Custom/legacy/explicit override precedence tests pass
- [x] `go vet ./...`, `go build ./...`, and `git diff --check` pass
- [ ] E2E tests — required remote CI gate before merge

---

## 🤖 Automated Checks

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | Exactly 400 changed lines |
| Check Issue Reference | ⏳ | Closes approved issue #1231 |
| Check PR Has `type:*` Label | ⏳ | Exactly `type:bug` will be applied |
| Unit Tests | ⏳ | Local full suite passed; CI pending |
| E2E Tests | ⏳ | Remote matrix pending |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass — awaiting required CI
- [x] Documentation is not required; state compatibility is covered by tests
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

Native review lineage `review-fc70ee7ce4e39b2a` approved the exact 14-path candidate after one bounded 149-line correction. Pre-commit, pre-push, and pre-PR gates all allowed the same content-bound receipt.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Install and sync selections now persist across sessions, including presets, skills, components, and development modes.
  * Explicit command-line options correctly override restored settings.
  * Skill selection now supports scrolling, clearer grouping, row counts, and additional skill labels.

* **Bug Fixes**
  * Preserved custom permission exclusions and selection settings during installs, incremental updates, and synchronization.
  * Improved skill-picker focus and toggle behavior.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->