### PR TITLE
fix(sdd): support nested OpenSpec review binding

### DIFF
--- a/internal/sddstatus/review_binding.go
+++ b/internal/sddstatus/review_binding.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"regexp"
+	"strings"
 
 	"github.com/gentleman-programming/gentle-ai/internal/reviewtransaction"
 )
@@ -41,8 +42,9 @@ func BindApprovedReview(ctx context.Context, repo, change, lineage, expected str
 	if err != nil {
 		return ReviewBinding{}, err
 	}
-	if info, statErr := os.Stat(filepath.Join(root, "openspec", "changes", change)); statErr != nil || !info.IsDir() {
-		return ReviewBinding{}, errors.New("selected OpenSpec change does not exist")
+	changeRoot, err := resolveBindingChangeRoot(root, repo, change)
+	if err != nil {
+		return ReviewBinding{}, err
 	}
 	store, err := reviewtransaction.CompactAuthoritativeStore(ctx, root, lineage)
 	if err != nil {
@@ -61,7 +63,7 @@ func BindApprovedReview(ctx context.Context, repo, change, lineage, expected str
 	if err != nil || receiptErr != nil || !reflect.DeepEqual(receipt, authoritative) {
 		return ReviewBinding{}, errors.New("compact receipt does not match approved authority")
 	}
-	if err := verifyBindingLedger(root, change, record.State.Findings); err != nil {
+	if err := verifyBindingLedger(changeRoot, record.State.Findings); err != nil {
 		return ReviewBinding{}, err
 	}
 	input := reviewtransaction.NativeGateRequestInput{Gate: reviewtransaction.GatePostApply, LineageID: lineage}
@@ -74,7 +76,8 @@ func BindApprovedReview(ctx context.Context, repo, change, lineage, expected str
 	final, finalErr := store.Load()
 	finalPayload, readErr := os.ReadFile(store.ReceiptPath())
 	finalGate := reviewtransaction.EvaluateCompactGate(ctx, root, receipt, input)
-	if finalErr != nil || readErr != nil || final.Revision != record.Revision || !bytes.Equal(payload, finalPayload) || finalGate.Result != reviewtransaction.GateAllow || !reflect.DeepEqual(gate.Context, finalGate.Context) {
+	finalChangeRoot, changeErr := resolveBindingChangeRoot(root, repo, change)
+	if finalErr != nil || readErr != nil || changeErr != nil || finalChangeRoot != changeRoot || final.Revision != record.Revision || !bytes.Equal(payload, finalPayload) || finalGate.Result != reviewtransaction.GateAllow || !reflect.DeepEqual(gate.Context, finalGate.Context) {
 		return ReviewBinding{}, errors.New("authority or live gate changed before binding publish")
 	}
 	return binding, writeBinding(bindingPath(store, change), expected, binding)
@@ -85,6 +88,10 @@ func validateBoundReview(ctx context.Context, repo, change string) (ReviewBindin
 		return ReviewBinding{}, reviewtransaction.NativeGateEvaluation{}, errors.New("invalid OpenSpec change name")
 	}
 	root, err := (reviewtransaction.SnapshotBuilder{Repo: repo}).ResolveRepositoryRoot(ctx)
+	if err != nil {
+		return ReviewBinding{}, reviewtransaction.NativeGateEvaluation{}, err
+	}
+	changeRoot, err := resolveBindingChangeRoot(root, repo, change)
 	if err != nil {
 		return ReviewBinding{}, reviewtransaction.NativeGateEvaluation{}, err
 	}
@@ -120,7 +127,7 @@ func validateBoundReview(ctx context.Context, repo, change string) (ReviewBindin
 	if err != nil || receiptErr != nil || !reflect.DeepEqual(receipt, authoritative) {
 		return ReviewBinding{}, reviewtransaction.NativeGateEvaluation{}, errors.New("bound compact receipt does not match approved authority")
 	}
-	if err := verifyBindingLedger(root, change, record.State.Findings); err != nil {
+	if err := verifyBindingLedger(changeRoot, record.State.Findings); err != nil {
 		return ReviewBinding{}, reviewtransaction.NativeGateEvaluation{}, err
 	}
 	evaluation := reviewtransaction.EvaluateCompactGate(ctx, root, receipt, reviewtransaction.NativeGateRequestInput{Gate: reviewtransaction.GatePostApply, LineageID: binding.Lineage})
@@ -131,7 +138,8 @@ func validateBoundReview(ctx context.Context, repo, change string) (ReviewBindin
 	finalBinding, bindingErr := os.ReadFile(bindingPath(probe, change))
 	finalRecord, recordErr := store.Load()
 	finalReceipt, receiptErr := os.ReadFile(store.ReceiptPath())
-	if bindingErr != nil || recordErr != nil || receiptErr != nil || !bytes.Equal(finalBinding, payload) || finalRecord.Revision != record.Revision || !reflect.DeepEqual(finalRecord.State, record.State) || finalRecord.State.State != reviewtransaction.StateApproved || !bytes.Equal(finalReceipt, receiptPayload) || bindingHash(finalReceipt) != binding.ReceiptHash {
+	finalChangeRoot, changeErr := resolveBindingChangeRoot(root, repo, change)
+	if bindingErr != nil || recordErr != nil || receiptErr != nil || changeErr != nil || finalChangeRoot != changeRoot || !bytes.Equal(finalBinding, payload) || finalRecord.Revision != record.Revision || !reflect.DeepEqual(finalRecord.State, record.State) || finalRecord.State.State != reviewtransaction.StateApproved || !bytes.Equal(finalReceipt, receiptPayload) || bindingHash(finalReceipt) != binding.ReceiptHash {
 		return ReviewBinding{}, reviewtransaction.NativeGateEvaluation{}, errors.New("bound authority, receipt, or binding changed during final read")
 	}
 	finalReceiptValue, parseErr := reviewtransaction.ParseCompactReceipt(finalReceipt)
@@ -162,8 +170,128 @@ func bindingExists(ctx context.Context, repo, change string) (bool, error) {
 	return err == nil, err
 }
 
-func verifyBindingLedger(root, change string, findings []reviewtransaction.Finding) error {
-	payload, err := os.ReadFile(filepath.Join(root, "openspec", "changes", change, "reviews", "ledger.json"))
+func resolveBindingChangeRoot(root, workspace, change string) (string, error) {
+	workspace, err := filepath.Abs(workspace)
+	if err != nil {
+		return "", err
+	}
+	workspace, err = filepath.EvalSymlinks(workspace)
+	if err != nil {
+		return "", err
+	}
+	root = filepath.Clean(root)
+	workspace = filepath.Clean(workspace)
+	if !pathWithinBindingRoot(root, workspace) {
+		return "", errors.New("planning workspace is outside selected repository")
+	}
+
+	planningRoot := ""
+	for current := workspace; pathWithinBindingRoot(root, current); current = filepath.Dir(current) {
+		openspecRoot := filepath.Join(current, "openspec")
+		info, statErr := os.Stat(openspecRoot)
+		if statErr == nil {
+			if !info.IsDir() {
+				return "", errors.New("selected OpenSpec root is not a directory")
+			}
+			resolved, resolveErr := filepath.EvalSymlinks(openspecRoot)
+			if resolveErr != nil {
+				return "", resolveErr
+			}
+			resolved = filepath.Clean(resolved)
+			if !pathWithinBindingRoot(root, resolved) {
+				return "", errors.New("selected OpenSpec root resolves outside repository")
+			}
+			if resolved != filepath.Clean(openspecRoot) {
+				return "", errors.New("selected OpenSpec root uses a symlinked path")
+			}
+			planningRoot = current
+			break
+		} else if !os.IsNotExist(statErr) {
+			return "", statErr
+		}
+		if current == root {
+			break
+		}
+	}
+	if planningRoot == "" {
+		return "", errors.New("selected OpenSpec change does not exist")
+	}
+	candidate := filepath.Join(planningRoot, "openspec", "changes", change)
+	info, err := os.Stat(candidate)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", errors.New("selected OpenSpec change does not exist")
+		}
+		return "", err
+	}
+	if !info.IsDir() {
+		return "", errors.New("selected OpenSpec change is not a directory")
+	}
+	selected, err := filepath.EvalSymlinks(candidate)
+	if err != nil {
+		return "", err
+	}
+	selected = filepath.Clean(selected)
+	if !pathWithinBindingRoot(root, selected) {
+		return "", errors.New("selected OpenSpec change resolves outside repository")
+	}
+	if selected != filepath.Clean(candidate) {
+		return "", errors.New("selected OpenSpec change uses a symlinked path")
+	}
+
+	matches, err := bindingChangeRoots(root, change)
+	if err != nil {
+		return "", err
+	}
+	if len(matches) != 1 || matches[0] != selected {
+		return "", errors.New("selected OpenSpec change is ambiguous within repository")
+	}
+	return selected, nil
+}
+
+func bindingChangeRoots(root, change string) ([]string, error) {
+	matches := []string{}
+	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() && entry.Name() == ".git" && path != root {
+			return filepath.SkipDir
+		}
+		if entry.Type()&os.ModeSymlink != 0 {
+			if entry.Name() == "openspec" {
+				candidate := filepath.Join(path, "changes", change)
+				if info, err := os.Stat(candidate); err == nil && info.IsDir() {
+					matches = append(matches, candidate)
+				} else if err != nil && !os.IsNotExist(err) {
+					return err
+				}
+			} else if isBindingChangePath(path, change) {
+				matches = append(matches, path)
+			}
+			return nil
+		}
+		if !entry.IsDir() || !isBindingChangePath(path, change) {
+			return nil
+		}
+		matches = append(matches, filepath.Clean(path))
+		return filepath.SkipDir
+	})
+	return matches, err
+}
+
+func isBindingChangePath(path, change string) bool {
+	changesRoot := filepath.Dir(path)
+	return filepath.Base(path) == change && filepath.Base(changesRoot) == "changes" && filepath.Base(filepath.Dir(changesRoot)) == "openspec"
+}
+
+func pathWithinBindingRoot(root, path string) bool {
+	relative, err := filepath.Rel(root, path)
+	return err == nil && relative != ".." && !strings.HasPrefix(relative, ".."+string(filepath.Separator)) && !filepath.IsAbs(relative)
+}
+
+func verifyBindingLedger(changeRoot string, findings []reviewtransaction.Finding) error {
+	payload, err := os.ReadFile(filepath.Join(changeRoot, "reviews", "ledger.json"))
 	if os.IsNotExist(err) {
 		return nil
 	}

--- a/internal/sddstatus/review_binding_test.go
+++ b/internal/sddstatus/review_binding_test.go
@@ -55,6 +55,115 @@ func TestBindApprovedReviewCASAndLiveEvidence(t *testing.T) {
 	}
 }
 
+func TestBindApprovedReviewUsesNestedOpenSpecPlanningWorkspace(t *testing.T) {
+	root := t.TempDir()
+	planningRoot := filepath.Join(root, "packages", "app")
+	changeRoot := seedReadyChange(t, planningRoot, "thin", "- [x] 1.1 Done\n")
+	writeApprovedCompactAuthorityForChange(t, root, changeRoot, "approved-thin")
+
+	binding, err := BindApprovedReview(context.Background(), planningRoot, "thin", "approved-thin", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	deeperPath := filepath.Join(planningRoot, "src", "feature")
+	if err := os.MkdirAll(deeperPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := BindApprovedReview(context.Background(), deeperPath, "thin", "approved-thin", binding.Revision); err != nil {
+		t.Fatalf("bind from deeper package path: %v", err)
+	}
+	store, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), root, "approved-thin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(bindingPath(store, "thin")); err != nil {
+		t.Fatalf("binding was not stored in the repository common dir: %v", err)
+	}
+	status, err := Resolve(ResolveOptions{CWD: planningRoot, ChangeName: "thin"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.PlanningHome.Path != filepath.Join(planningRoot, "openspec") || status.ReviewGate == nil || status.ReviewGate.Result != reviewtransaction.GateAllow {
+		t.Fatalf("nested planning status did not consume canonical binding: %#v", status)
+	}
+}
+
+func TestBindApprovedReviewRejectsAmbiguousPlanningChanges(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		seed func(t *testing.T, root, planningRoot string)
+	}{
+		{name: "ancestor collision", seed: func(t *testing.T, root, planningRoot string) {
+			seedReadyChange(t, root, "thin", "- [x] 1.1 Root\n")
+			seedReadyChange(t, planningRoot, "thin", "- [x] 1.1 Package\n")
+		}},
+		{name: "sibling collision", seed: func(t *testing.T, root, planningRoot string) {
+			seedReadyChange(t, planningRoot, "thin", "- [x] 1.1 App\n")
+			seedReadyChange(t, filepath.Join(root, "packages", "api"), "thin", "- [x] 1.1 API\n")
+		}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			planningRoot := filepath.Join(root, "packages", "app")
+			tt.seed(t, root, planningRoot)
+			runSDDStatusGit(t, root, "init", "-q")
+
+			if _, err := BindApprovedReview(context.Background(), planningRoot, "thin", "approved-thin", ""); err == nil || !strings.Contains(err.Error(), "ambiguous") {
+				t.Fatalf("ambiguous planning changes error = %v", err)
+			}
+		})
+	}
+}
+
+func TestBindApprovedReviewRejectsOpenSpecSymlinkEscape(t *testing.T) {
+	root := t.TempDir()
+	planningRoot := filepath.Join(root, "packages", "app")
+	if err := os.MkdirAll(planningRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	outside := t.TempDir()
+	seedReadyChange(t, outside, "thin", "- [x] 1.1 Outside\n")
+	if err := os.Symlink(filepath.Join(outside, "openspec"), filepath.Join(planningRoot, "openspec")); err != nil {
+		t.Fatal(err)
+	}
+	runSDDStatusGit(t, root, "init", "-q")
+
+	if _, err := BindApprovedReview(context.Background(), planningRoot, "thin", "approved-thin", ""); err == nil || !strings.Contains(err.Error(), "outside repository") {
+		t.Fatalf("OpenSpec symlink escape error = %v", err)
+	}
+}
+
+func TestBindApprovedReviewDoesNotFallBackPastNestedPlanningWorkspace(t *testing.T) {
+	root := t.TempDir()
+	planningRoot := filepath.Join(root, "packages", "app")
+	seedReadyChange(t, root, "thin", "- [x] 1.1 Root\n")
+	seedReadyChange(t, planningRoot, "other", "- [x] 1.1 Package\n")
+	runSDDStatusGit(t, root, "init", "-q")
+
+	if _, err := BindApprovedReview(context.Background(), planningRoot, "thin", "approved-thin", ""); err == nil || !strings.Contains(err.Error(), "does not exist") {
+		t.Fatalf("nested planning workspace fallback error = %v", err)
+	}
+}
+
+func TestBindApprovedReviewChecksNestedPlanningLedger(t *testing.T) {
+	root := t.TempDir()
+	planningRoot := filepath.Join(root, "packages", "app")
+	changeRoot := seedReadyChange(t, planningRoot, "thin", "- [x] 1.1 Done\n")
+	writeApprovedCompactAuthorityForChange(t, root, changeRoot, "approved-thin")
+	write(t, filepath.Join(changeRoot, "reviews", "ledger.json"), `{"schema":"gentle-ai.review-ledger/v1","findings":[{"id":"wrong"}]}`)
+
+	if _, err := BindApprovedReview(context.Background(), planningRoot, "thin", "approved-thin", ""); err == nil || !strings.Contains(err.Error(), "ledger does not equal") {
+		t.Fatalf("nested planning ledger error = %v", err)
+	}
+	store, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), root, "approved-thin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(bindingPath(store, "thin")); !os.IsNotExist(err) {
+		t.Fatalf("failed nested bind mutated canonical binding path: %v", err)
+	}
+}
+
 func TestResolveConsumesOnlyAnExplicitValidBinding(t *testing.T) {
 	root := t.TempDir()
 	changeRoot := seedReadyChange(t, root, "thin", "- [x] 1.1 Done\n")


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1233

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Resolve the selected OpenSpec change from the nearest enclosing planning workspace in a monorepo.
- Keep review authority, receipts, gates, and binding publication rooted in the canonical Git common directory.
- Fail closed for ambiguous changes, path escapes, symlinked OpenSpec roots, and binding-time drift.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/sddstatus/review_binding.go` | Separates planning-root discovery from canonical repository authority and revalidates the selected change before publication. |
| `internal/sddstatus/review_binding_test.go` | Adds nested-workspace, compatibility, ambiguity, symlink, ledger, and canonical-authority regression coverage. |

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./internal/sddstatus -run '^TestBindApprovedReviewUsesNestedOpenSpecPlanningWorkspace$' -count=1
go test ./internal/sddstatus -run '^TestBindApprovedReview' -count=1
go test ./internal/sddstatus -count=1
go test ./... -count=1
git diff --check
```

**E2E Tests**

Not run locally; the affected boundary is covered with real temporary Git repositories and filesystem integration tests. Repository E2E remains an authoritative CI gate.

- [x] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Manually tested locally through the nested OpenSpec binding regression

---

## 🤖 Automated Checks

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | 253 changed lines, within the 400-line limit |
| Check Issue Reference | ⏳ | Linked with `Closes #1233` |
| Check Issue Has `status:approved` | ⏳ | Issue #1233 is approved |
| Check PR Has `type:*` Label | ⏳ | `type:bug` will be applied |
| Unit Tests | ⏳ | `go test ./...` passed locally |
| E2E Tests | ⏳ | Awaiting CI |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Documentation is not required; public commands and flags are unchanged
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

Native bounded review lineage `review-150d842a79c573ad` approved the current `origin/main...HEAD` candidate. One non-blocking warning remains: a nested Git repository with the same OpenSpec change name is treated as ambiguous by the outer repository scan.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved approved-review binding in nested planning workspaces.
  * Ledger validation now consistently uses the correct canonical change location.
  * Prevented incorrect bindings caused by ambiguous change paths, missing nested changes, or symlinked paths escaping the repository.
  * Added safeguards to detect changes during final validation and prevent publishing inconsistent or unauthorized bindings.
* **Tests**
  * Expanded coverage for nested workspaces, ledger validation, path ambiguity, and repository-boundary protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->