### PR TITLE
fix(tui): make async navigation state-safe

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -116,6 +116,7 @@ var readCurrentAssignmentsFn = func(settingsPath string) (map[string]model.Model
 var readProfilesFn = func(settingsPath string) ([]model.Profile, error) {
 	return sdd.DetectProfiles(settingsPath)
 }
+var removeProfileAgentsFn = sdd.RemoveProfileAgents
 
 func sanitizeKnownModelEfforts(assignments map[string]model.ModelAssignment, sddModels map[string][]opencode.Model) map[string]model.ModelAssignment {
 	if assignments == nil {
@@ -856,18 +857,27 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 	case OpenCodePluginRegistrationDoneMsg:
+		if m.Screen != ScreenOpenCodePlugins {
+			return m, nil
+		}
 		m.OperationRunning = false
 		m.OpenCodePluginRegistrationResults = msg.Results
 		m.OpenCodePluginRegistrationErr = msg.Err
 		m.setScreen(ScreenOpenCodePluginResult)
 		return m, nil
 	case OpenCodePluginUninstallDoneMsg:
+		if m.Screen != ScreenOpenCodePluginUninstallConfirm {
+			return m, nil
+		}
 		m.OperationRunning = false
 		m.OpenCodePluginUninstallResult = msg.Result
 		m.OpenCodePluginUninstallErr = msg.Err
 		m.setScreen(ScreenOpenCodePluginUninstallResult)
 		return m, nil
 	case CommunityToolInstallationDoneMsg:
+		if m.Screen != ScreenCommunityToolInstalling {
+			return m, nil
+		}
 		m.OperationRunning = false
 		m.CommunityToolResults = msg.Results
 		m.CommunityToolErr = msg.Err
@@ -884,6 +894,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case PipelineDoneMsg:
 		return m.handlePipelineDone(msg)
 	case BackupRestoreMsg:
+		if m.Screen != ScreenRestoreConfirm {
+			return m, nil
+		}
 		return m.handleBackupRestore(msg)
 	case UpdateCheckResultMsg:
 		m.UpdateResults = msg.Results
@@ -905,6 +918,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.AdvisoryScroll = 0
 		return m, nil
 	case UpgradeDoneMsg:
+		if m.Screen != ScreenUpgrade && m.Screen != ScreenUpdatePrompt {
+			return m, nil
+		}
 		m.OperationRunning = false
 		m.UpgradeErr = msg.Err
 		if msg.Err == nil {
@@ -918,6 +934,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.UpdateCheckDone = false
 		return m, m.Init()
 	case SyncDoneMsg:
+		if m.Screen != ScreenSync && m.Screen != ScreenUpgradeSync && m.Screen != ScreenProfiles {
+			return m, nil
+		}
 		m.OperationRunning = false
 		m.SyncFiles = msg.Files
 		m.SyncErr = msg.Err
@@ -939,6 +958,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		} // else keep existing list
 		return m, nil
 	case UninstallDoneMsg:
+		if m.Screen != ScreenUninstallConfirm {
+			return m, nil
+		}
 		m.OperationRunning = false
 		m.UninstallResult = msg.Result
 		m.UninstallErr = msg.Err
@@ -947,6 +969,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.setScreen(ScreenUninstallResult)
 		return m, nil
 	case UpgradePhaseCompletedMsg:
+		if m.Screen != ScreenUpgradeSync {
+			return m, nil
+		}
 		// Upgrade phase done; sync phase is about to start (OperationRunning stays true).
 		m.UpgradeErr = msg.Err
 		if msg.Err == nil {
@@ -1048,6 +1073,7 @@ func (m Model) handlePipelineDone(msg PipelineDoneMsg) (tea.Model, tea.Cmd) {
 }
 
 func (m Model) handleBackupRestore(msg BackupRestoreMsg) (tea.Model, tea.Cmd) {
+	m.OperationRunning = false
 	m.RestoreErr = msg.Err
 	// Navigate to the result screen regardless of success or failure.
 	// The result screen shows success or the error message.
@@ -1132,6 +1158,9 @@ func (m Model) View() string {
 	case ScreenStrictTDD:
 		return screens.RenderStrictTDD(m.Selection.StrictTDD, m.Cursor)
 	case ScreenOpenCodePlugins:
+		if m.OperationRunning {
+			return screens.RenderOperationRunning("Installing OpenCode Plugins", "Registering selected plugins...", m.SpinnerFrame)
+		}
 		return screens.RenderOpenCodePlugins(m.Selection.OpenCodePlugins, m.Cursor)
 	case ScreenOpenCodePluginResult:
 		return screens.RenderOpenCodePluginResult(m.OpenCodePluginRegistrationResults, m.OpenCodePluginRegistrationErr)
@@ -1172,6 +1201,9 @@ func (m Model) View() string {
 	case ScreenBackups:
 		return screens.RenderBackups(m.Backups, m.Cursor, m.BackupScroll, m.PinErr)
 	case ScreenRestoreConfirm:
+		if m.OperationRunning {
+			return screens.RenderOperationRunning("Restoring Backup", "Applying backup...", m.SpinnerFrame)
+		}
 		return screens.RenderRestoreConfirm(m.SelectedBackup, m.Cursor)
 	case ScreenRestoreResult:
 		return screens.RenderRestoreResult(m.SelectedBackup, m.RestoreErr)
@@ -1191,7 +1223,7 @@ func (m Model) View() string {
 		return screens.RenderABSDDPhase(screens.ABSDDPhases(), m.Cursor, m.AgentBuilder.SDDMode == agentbuilder.SDDNewPhase)
 	case ScreenAgentBuilderGenerating:
 		engineName := string(m.AgentBuilder.SelectedEngine)
-		return screens.RenderABGenerating(engineName, m.SpinnerFrame, m.AgentBuilder.GenerationErr)
+		return screens.RenderABGenerating(engineName, m.SpinnerFrame, m.AgentBuilder.GenerationErr, m.Cursor)
 	case ScreenAgentBuilderPreview:
 		targets := m.agentBuilderInstallTargets()
 		return screens.RenderABPreview(m.AgentBuilder.Generated, targets, m.AgentBuilder.PreviewScroll, m.Height, m.Cursor, m.AgentBuilder.InstallErr, m.AgentBuilder.ConflictWarning)
@@ -1275,7 +1307,7 @@ func (m Model) handleKeyPress(key tea.KeyMsg) (tea.Model, tea.Cmd) {
 		wasInCustomMode := m.KiroModelPicker.InCustomMode
 		handled, updated := screens.HandleKiroModelPickerNav(keyStr, &m.KiroModelPicker, m.Cursor)
 		if handled {
-			if wasInCustomMode && !m.KiroModelPicker.InCustomMode {
+			if wasInCustomMode != m.KiroModelPicker.InCustomMode {
 				m.Cursor = 0
 			}
 			if updated != nil {
@@ -1297,11 +1329,10 @@ func (m Model) handleKeyPress(key tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 
 	if m.Screen == ScreenCodexModelPicker {
-		wasInCustomSubMode := m.CodexModelPicker.CustomMode != screens.CodexCustomModeNone
+		previousMode := m.CodexModelPicker.CustomMode
 		handled, assignments := screens.HandleCodexModelPickerNav(keyStr, &m.CodexModelPicker, m.Cursor)
 		if handled {
-			// Reset cursor when exiting the Custom sub-mode back to the main picker.
-			if wasInCustomSubMode && m.CodexModelPicker.CustomMode == screens.CodexCustomModeNone {
+			if previousMode != m.CodexModelPicker.CustomMode {
 				m.Cursor = 0
 			}
 			if assignments != nil {
@@ -1367,6 +1398,9 @@ func (m Model) handleKeyPress(key tea.KeyMsg) (tea.Model, tea.Cmd) {
 	// here so the generic enter/esc/up/down logic is bypassed for this screen.
 	if m.Screen == ScreenUpdatePrompt {
 		return m.handleUpdatePromptKey(keyStr)
+	}
+	if m.OperationRunning && keyStr != "q" && keyStr != "ctrl+c" {
+		return m, nil
 	}
 	if m.Screen == ScreenWelcome {
 		pageSize, maxScroll := screens.WelcomeAdvisoryScrollBounds(m.AdvisoryMessage, m.AdvisoryURL, m.Width, m.Height)
@@ -1545,6 +1579,7 @@ func (m Model) handleKeyPress(key tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		// Delete on ScreenProfiles: only non-default profiles (those in ProfileList).
 		if m.Screen == ScreenProfiles && m.Cursor < len(m.ProfileList) {
+			m.ProfileDeleteErr = nil
 			m.ProfileDeleteTarget = m.ProfileList[m.Cursor].Name
 			m.setScreen(ScreenProfileDelete)
 			return m, nil
@@ -1747,7 +1782,7 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 		case m.Cursor == agentCount && len(m.UninstallAgents) > 0:
 			m.setScreen(ScreenUninstallComponents)
 		case m.Cursor == agentCount+1:
-			m.setScreen(ScreenWelcome)
+			m.setScreen(ScreenUninstallMode)
 		}
 		return m, nil
 	case ScreenUninstallComponents:
@@ -1879,6 +1914,9 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 			m.setScreen(ScreenWelcome)
 			return m, nil
 		}
+		if !m.UpdateCheckDone {
+			return m, nil
+		}
 		// Start upgrade+sync.
 		m.OperationRunning = true
 		m.OperationMode = "upgrade-sync"
@@ -1928,7 +1966,7 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 	case ScreenProfileDelete:
 		switch m.Cursor {
 		case 0: // "Delete & Sync"
-			if err := sdd.RemoveProfileAgents(opencode.DefaultSettingsPath(), m.ProfileDeleteTarget); err != nil {
+			if err := removeProfileAgentsFn(opencode.DefaultSettingsPath(), m.ProfileDeleteTarget); err != nil {
 				// Store the error so it can be displayed on ScreenProfiles.
 				m.ProfileDeleteErr = err
 				m.setScreen(ScreenProfiles)
@@ -1937,6 +1975,8 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 				m.PendingSyncOverrides = nil
 				m = m.withResetSyncState()
 				m.setScreen(ScreenSync)
+				m.OperationRunning = true
+				m.OperationMode = "sync"
 				return m, tea.Batch(tickCmd(), m.startSync(nil))
 			}
 		default: // "Cancel"
@@ -2118,9 +2158,13 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 		// When no providers are detected the screen offers Continue with defaults
 		// and Back. Handle that before the normal row logic.
 		if len(m.ModelPicker.AvailableIDs) == 0 {
-			if m.ModelConfigMode || m.Cursor == 1 {
+			if m.ModelConfigMode {
 				m.ModelConfigMode = false
 				m.setScreen(ScreenModelConfig)
+				return m, nil
+			}
+			if m.Cursor == 1 {
+				m.applyPickerEntry(ScreenSDDMode)
 				return m, nil
 			}
 			// Continue with OpenCode defaults when no providers are available yet.
@@ -2414,16 +2458,14 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 	case ScreenRestoreConfirm:
 		// Cursor 0 = "Restore", Cursor 1 = "Cancel".
 		if m.Cursor == 0 {
+			m.OperationRunning = true
 			return m.restoreBackup(m.SelectedBackup)
 		}
 		m.setScreen(ScreenBackups)
 	case ScreenRestoreResult:
 		// Enter on the result screen returns to backup selection.
 		// Refresh the backup list to reflect any changes from the restore.
-		if m.ListBackupsFn != nil {
-			m.Backups = m.ListBackupsFn()
-		}
-		m.setScreen(ScreenBackups)
+		m = m.finishBackupResult(false)
 	case ScreenDeleteConfirm:
 		// Cursor 0 = "Delete", Cursor 1 = "Cancel".
 		if m.Cursor == 0 {
@@ -2437,11 +2479,7 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 	case ScreenDeleteResult:
 		// Enter on the result screen returns to backup selection.
 		// Refresh the backup list to reflect any changes from the delete.
-		if m.ListBackupsFn != nil {
-			m.Backups = m.ListBackupsFn()
-		}
-		m.DeleteErr = nil
-		m.setScreen(ScreenBackups)
+		m = m.finishBackupResult(true)
 	case ScreenAgentBuilderEngine:
 		engines := m.AgentBuilder.AvailableEngines
 		if m.Cursor < len(engines) {
@@ -2645,6 +2683,9 @@ func (m Model) handleUpdatePromptKey(keyStr string) (tea.Model, tea.Cmd) {
 	switch keyStr {
 	case "ctrl+c", "q":
 		return m, tea.Quit
+	case "esc":
+		m.setScreen(ScreenWelcome)
+		return m, nil
 	case "up":
 		if m.Cursor > 0 {
 			m.Cursor--
@@ -3070,6 +3111,7 @@ func (m Model) GentleAIUpgradeVersion() (string, bool) {
 // restoreBackup triggers a backup restore in a goroutine.
 func (m Model) restoreBackup(manifest backup.Manifest) (tea.Model, tea.Cmd) {
 	if m.RestoreFn == nil {
+		m.OperationRunning = false
 		m.Err = fmt.Errorf("restore not available")
 		return m, nil
 	}
@@ -3079,6 +3121,17 @@ func (m Model) restoreBackup(manifest backup.Manifest) (tea.Model, tea.Cmd) {
 		err := restoreFn(manifest)
 		return BackupRestoreMsg{Err: err}
 	}
+}
+
+func (m Model) finishBackupResult(clearDeleteError bool) Model {
+	if m.ListBackupsFn != nil {
+		m.Backups = m.ListBackupsFn()
+	}
+	if clearDeleteError {
+		m.DeleteErr = nil
+	}
+	m.setScreen(ScreenBackups)
+	return m
 }
 
 // buildProgressLabels creates step labels from the resolved plan that match
@@ -3119,6 +3172,14 @@ func (m Model) goBack() Model {
 	// Esc on the update prompt dismisses it and proceeds to Welcome
 	// (equivalent to "Keep current version").
 	if m.Screen == ScreenUpdatePrompt {
+		m.setScreen(ScreenWelcome)
+		return m
+	}
+	if m.Screen == ScreenRestoreResult || m.Screen == ScreenDeleteResult {
+		return m.finishBackupResult(m.Screen == ScreenDeleteResult)
+	}
+	if m.Screen == ScreenUninstallResult {
+		m = m.withResetUninstallState()
 		m.setScreen(ScreenWelcome)
 		return m
 	}
@@ -3398,14 +3459,13 @@ func (m *Model) setScreen(next Screen) {
 		m.PinErr = nil
 	}
 	if next == ScreenProfiles {
-		// Clear stale delete error so it is not shown after Cancel/Esc from ScreenProfileDelete.
-		m.ProfileDeleteErr = nil
-		// Refresh profile list on entry. Surface errors via m.Err so callers can react.
+		// Refresh on entry without replacing valid data with an empty error state.
 		profiles, err := readProfilesFn(opencode.DefaultSettingsPath())
 		if err != nil {
 			m.Err = err
-			m.ProfileList = nil
+			m.ProfileDeleteErr = err
 		} else {
+			m.Err = nil
 			m.ProfileList = profiles
 		}
 		// Clamp cursor so it never points past the end of a refreshed list.
@@ -3470,20 +3530,29 @@ func (m Model) handleRenameInput(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 }
 
 func (m Model) optionCount() int {
+	if m.OperationRunning {
+		return 0
+	}
 	switch m.Screen {
 	case ScreenWelcome:
 		return len(screens.WelcomeOptions(m.UpdateResults, m.UpdateCheckDone, m.hasDetectedOpenCode(), len(m.ProfileList), m.hasAgentBuilderEngines()))
 	case ScreenUpgrade:
 		if m.UpgradeReport != nil || m.UpgradeErr != nil {
-			return 1 // "return" option in results/error state
+			return 0
 		}
 		if !m.UpdateCheckDone {
 			return 0 // no options while checking
 		}
 		return 1 // "upgrade all" or "return" when up to date
 	case ScreenSync:
+		if m.HasSyncRun {
+			return 0
+		}
 		return 1
 	case ScreenUpgradeSync:
+		if m.HasSyncRun || m.UpgradeReport != nil || m.UpgradeErr != nil {
+			return 0
+		}
 		return 1
 	case ScreenModelConfig:
 		return len(screens.ModelConfigOptions())
@@ -3502,7 +3571,7 @@ func (m Model) optionCount() int {
 	case ScreenUninstallConfirm:
 		return 2
 	case ScreenUninstallResult:
-		return 1
+		return 0
 	case ScreenDetection:
 		return len(screens.DetectionOptions())
 	case ScreenAgents:
@@ -3524,19 +3593,19 @@ func (m Model) optionCount() int {
 	case ScreenOpenCodePlugins:
 		return screens.OpenCodePluginsOptionCount()
 	case ScreenOpenCodePluginResult:
-		return 1
+		return 0
 	case ScreenOpenCodePluginUninstall:
 		return screens.OpenCodePluginUninstallOptionCount(m.OpenCodePluginUninstallInstalled)
 	case ScreenOpenCodePluginUninstallConfirm:
 		return 0
 	case ScreenOpenCodePluginUninstallResult:
-		return 1
+		return 0
 	case ScreenCommunityTools:
 		return screens.CommunityToolsOptionCount()
 	case ScreenCommunityToolInstalling:
 		return 0
 	case ScreenCommunityToolResult:
-		return 1
+		return 0
 	case ScreenModelPicker:
 		if len(m.ModelPicker.AvailableIDs) == 0 {
 			return 2 // Continue with defaults + Back
@@ -3552,19 +3621,19 @@ func (m Model) optionCount() int {
 	case ScreenReview:
 		return len(screens.ReviewOptions())
 	case ScreenInstalling:
-		return 1
+		return 0
 	case ScreenComplete:
-		return 1
+		return 0
 	case ScreenBackups:
 		return len(m.Backups) + 1
 	case ScreenRestoreConfirm:
 		return 2 // "Restore" + "Cancel"
 	case ScreenRestoreResult:
-		return 1 // "Done" / continue
+		return 0
 	case ScreenDeleteConfirm:
 		return 2 // "Delete" + "Cancel"
 	case ScreenDeleteResult:
-		return 1 // "Done" / continue
+		return 0
 	case ScreenRenameBackup:
 		return 0 // text input mode — no cursor navigation
 	case ScreenProfiles:
@@ -3591,7 +3660,7 @@ func (m Model) optionCount() int {
 	case ScreenAgentBuilderInstalling:
 		return 0 // no cursor navigation while installing
 	case ScreenAgentBuilderComplete:
-		return 1 // Done
+		return 0
 	case ScreenUpdatePrompt:
 		return len(screens.UpdatePromptOptions()) // Update now / View changes / Keep current
 	default:
@@ -3879,8 +3948,8 @@ func (m Model) confirmOpenCodePlugins() (tea.Model, tea.Cmd) {
 			m.OpenCodePluginRegistrationResults = nil
 			m.OpenCodePluginRegistrationErr = nil
 			m.OperationRunning = len(m.Selection.OpenCodePlugins) > 0
-			m.setScreen(ScreenOpenCodePluginResult)
 			if len(m.Selection.OpenCodePlugins) == 0 {
+				m.setScreen(ScreenOpenCodePluginResult)
 				return m, nil
 			}
 			return m, m.startOpenCodePluginRegistration()
@@ -4598,6 +4667,8 @@ func (m Model) confirmProfileCreate() (tea.Model, tea.Cmd) {
 			}
 			m = m.withResetSyncState()
 			m.setScreen(ScreenSync)
+			m.OperationRunning = true
+			m.OperationMode = "sync"
 			return m, tea.Batch(tickCmd(), m.startSync(m.PendingSyncOverrides))
 		default: // "Cancel"
 			m.setScreen(ScreenProfiles)

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1714,6 +1714,8 @@ func TestCommunityToolInstallationPreservesPartialResultOnError(t *testing.T) {
 	}
 
 	m := NewModel(system.DetectionResult{}, "dev")
+	m.Screen = ScreenCommunityToolInstalling
+	m.OperationRunning = true
 	m.Selection.CommunityTools = []model.CommunityToolID{model.CommunityToolCodeGraph}
 	cmd := m.startCommunityToolInstallation()
 	if cmd == nil {
@@ -1755,8 +1757,8 @@ func TestStandaloneOpenCodePluginsContinueRegistersSelectedPlugins(t *testing.T)
 
 	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	state := updated.(Model)
-	if state.Screen != ScreenOpenCodePluginResult {
-		t.Fatalf("screen = %v, want %v", state.Screen, ScreenOpenCodePluginResult)
+	if state.Screen != ScreenOpenCodePlugins {
+		t.Fatalf("screen = %v, want %v until registration completes", state.Screen, ScreenOpenCodePlugins)
 	}
 	if cmd == nil {
 		t.Fatal("expected registration command")

--- a/internal/tui/navigation_safety_test.go
+++ b/internal/tui/navigation_safety_test.go
@@ -1,0 +1,176 @@
+package tui
+
+import (
+	"errors"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/gentleman-programming/gentle-ai/internal/backup"
+	"github.com/gentleman-programming/gentle-ai/internal/model"
+	"github.com/gentleman-programming/gentle-ai/internal/system"
+	"github.com/gentleman-programming/gentle-ai/internal/tui/screens"
+)
+
+func TestRunningScreensRejectInputAndExposeNoOptions(t *testing.T) {
+	for _, screen := range []Screen{ScreenRestoreConfirm, ScreenSync, ScreenUpgradeSync, ScreenOpenCodePlugins, ScreenUninstallConfirm} {
+		t.Run(screenName(screen), func(t *testing.T) {
+			m := NewModel(system.DetectionResult{}, "dev")
+			m.Screen = screen
+			m.OperationRunning = true
+			m.Cursor = 1
+			updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+			got := updated.(Model)
+			if cmd != nil || got.Screen != screen || got.Cursor != 1 {
+				t.Fatalf("running input changed state: screen=%v cursor=%d cmd=%v", got.Screen, got.Cursor, cmd)
+			}
+			if got.optionCount() != 0 {
+				t.Fatalf("optionCount() = %d, want 0 while running", got.optionCount())
+			}
+			if got.View() == "" {
+				t.Fatal("running screen should render progress")
+			}
+		})
+	}
+}
+
+func TestResultScreensDoNotExposePhantomCursorRows(t *testing.T) {
+	for _, screen := range []Screen{ScreenRestoreResult, ScreenDeleteResult, ScreenUninstallResult, ScreenOpenCodePluginResult, ScreenCommunityToolResult, ScreenComplete} {
+		m := NewModel(system.DetectionResult{}, "dev")
+		m.Screen = screen
+		if got := m.optionCount(); got != 0 {
+			t.Errorf("%s optionCount() = %d, want 0", screenName(screen), got)
+		}
+	}
+}
+
+func TestProfileSyncActionsEnterRunningState(t *testing.T) {
+	tests := []struct {
+		name    string
+		prepare func(Model) Model
+	}{
+		{"create", func(m Model) Model {
+			m.Screen, m.ProfileCreateStep, m.Cursor = ScreenProfileCreate, 2, 0
+			return m
+		}},
+		{"delete", func(m Model) Model {
+			m.Screen, m.ProfileDeleteTarget, m.Cursor = ScreenProfileDelete, "old", 0
+			return m
+		}},
+	}
+	originalRemove := removeProfileAgentsFn
+	removeProfileAgentsFn = func(string, string) error { return nil }
+	t.Cleanup(func() { removeProfileAgentsFn = originalRemove })
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := tt.prepare(NewModel(system.DetectionResult{}, "dev"))
+			updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+			got := updated.(Model)
+			if got.Screen != ScreenSync || !got.OperationRunning || cmd == nil {
+				t.Fatalf("profile sync did not start safely: screen=%v running=%v cmd=%v", got.Screen, got.OperationRunning, cmd)
+			}
+		})
+	}
+}
+
+func TestConditionalPickerNavigationResetsState(t *testing.T) {
+	t.Run("empty model picker back returns to SDD mode", func(t *testing.T) {
+		m := NewModel(system.DetectionResult{}, "dev")
+		m.Screen, m.Selection.SDDMode, m.Cursor = ScreenModelPicker, model.SDDModeMulti, 1
+		updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+		if got := updated.(Model).Screen; got != ScreenSDDMode {
+			t.Fatalf("screen = %v, want %v", got, ScreenSDDMode)
+		}
+	})
+
+	for _, tc := range []struct {
+		name   string
+		screen Screen
+	}{
+		{"Kiro", ScreenKiroModelPicker},
+		{"Codex", ScreenCodexModelPicker},
+	} {
+		t.Run(tc.name+" custom starts at first phase", func(t *testing.T) {
+			m := NewModel(system.DetectionResult{}, "dev")
+			m.Screen, m.Cursor = tc.screen, 3
+			if tc.screen == ScreenKiroModelPicker {
+				m.KiroModelPicker = screens.NewKiroModelPickerState()
+			} else {
+				m.CodexModelPicker = screens.NewCodexModelPickerState()
+			}
+			updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+			if got := updated.(Model).Cursor; got != 0 {
+				t.Fatalf("cursor = %d, want 0", got)
+			}
+		})
+	}
+}
+
+func TestBackAndEscShareCleanupContracts(t *testing.T) {
+	for _, key := range []tea.KeyType{tea.KeyEnter, tea.KeyEsc} {
+		t.Run(key.String(), func(t *testing.T) {
+			refreshes := 0
+			m := NewModel(system.DetectionResult{}, "dev")
+			m.Screen, m.DeleteErr = ScreenDeleteResult, errors.New("old")
+			m.ListBackupsFn = func() []backup.Manifest { refreshes++; return nil }
+			updated, _ := m.Update(tea.KeyMsg{Type: key})
+			got := updated.(Model)
+			if got.Screen != ScreenBackups || got.DeleteErr != nil || refreshes != 1 {
+				t.Fatalf("delete result cleanup mismatch: screen=%v err=%v refreshes=%d", got.Screen, got.DeleteErr, refreshes)
+			}
+		})
+	}
+
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Screen, m.UninstallMode = ScreenUninstall, model.UninstallModePartial
+	m.Cursor = len(screens.UninstallAgentOptions()) + 1
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if got := updated.(Model).Screen; got != ScreenUninstallMode {
+		t.Fatalf("uninstall Back screen = %v, want %v", got, ScreenUninstallMode)
+	}
+
+	m.Screen = ScreenUpdatePrompt
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	if got := updated.(Model).Screen; got != ScreenWelcome {
+		t.Fatalf("update prompt Esc screen = %v, want %v", got, ScreenWelcome)
+	}
+}
+
+func TestAsyncCompletionCannotReenterAbandonedFlow(t *testing.T) {
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Screen, m.OperationRunning = ScreenWelcome, true
+	updated, _ := m.Update(BackupRestoreMsg{Err: errors.New("late")})
+	got := updated.(Model)
+	if got.Screen != ScreenWelcome || got.RestoreErr != nil {
+		t.Fatalf("late restore changed abandoned flow: screen=%v err=%v", got.Screen, got.RestoreErr)
+	}
+	updated, _ = m.Update(OpenCodePluginRegistrationDoneMsg{})
+	if got := updated.(Model); got.Screen != ScreenWelcome {
+		t.Fatalf("late plugin completion changed screen to %v", got.Screen)
+	}
+}
+
+func TestProfileLoadErrorPreservesVisibleProfiles(t *testing.T) {
+	originalRead := readProfilesFn
+	readProfilesFn = func(string) ([]model.Profile, error) { return nil, errors.New("load failed") }
+	t.Cleanup(func() { readProfilesFn = originalRead })
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.ProfileList = []model.Profile{{Name: "existing"}}
+	m.setScreen(ScreenProfiles)
+	if len(m.ProfileList) != 1 || m.ProfileDeleteErr == nil {
+		t.Fatalf("load error lost visible state: profiles=%v err=%v", m.ProfileList, m.ProfileDeleteErr)
+	}
+}
+
+func TestProfileDeleteErrorSurvivesListRefresh(t *testing.T) {
+	originalRead, originalRemove := readProfilesFn, removeProfileAgentsFn
+	readProfilesFn = func(string) ([]model.Profile, error) { return []model.Profile{{Name: "existing"}}, nil }
+	removeProfileAgentsFn = func(string, string) error { return errors.New("delete failed") }
+	t.Cleanup(func() { readProfilesFn, removeProfileAgentsFn = originalRead, originalRemove })
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Screen, m.ProfileDeleteTarget = ScreenProfileDelete, "existing"
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	got := updated.(Model)
+	if got.Screen != ScreenProfiles || got.ProfileDeleteErr == nil {
+		t.Fatalf("delete error was cleared: screen=%v err=%v", got.Screen, got.ProfileDeleteErr)
+	}
+}

--- a/internal/tui/screens/agent_builder_generating.go
+++ b/internal/tui/screens/agent_builder_generating.go
@@ -7,7 +7,7 @@ import (
 )
 
 // RenderABGenerating renders the generation-in-progress (or error) screen.
-func RenderABGenerating(engineName string, spinnerFrame int, genErr error) string {
+func RenderABGenerating(engineName string, spinnerFrame int, genErr error, cursor int) string {
 	var b strings.Builder
 
 	b.WriteString(styles.TitleStyle.Render("Generating Your Agent..."))
@@ -20,7 +20,7 @@ func RenderABGenerating(engineName string, spinnerFrame int, genErr error) strin
 		b.WriteString("\n")
 		b.WriteString(styles.ErrorStyle.Render("  Error: " + genErr.Error()))
 		b.WriteString("\n\n")
-		b.WriteString(renderOptions([]string{"Retry", "Back"}, 0))
+		b.WriteString(renderOptions([]string{"Retry", "Back"}, cursor))
 		b.WriteString("\n")
 		b.WriteString(styles.HelpStyle.Render("enter: select • esc: back"))
 		return b.String()

--- a/internal/tui/screens/agent_builder_generating_test.go
+++ b/internal/tui/screens/agent_builder_generating_test.go
@@ -7,21 +7,21 @@ import (
 )
 
 func TestRenderABGenerating_NonEmpty(t *testing.T) {
-	out := RenderABGenerating("claude-code", 0, nil)
+	out := RenderABGenerating("claude-code", 0, nil, 0)
 	if out == "" {
 		t.Fatal("RenderABGenerating returned empty string")
 	}
 }
 
 func TestRenderABGenerating_HeadingPresent(t *testing.T) {
-	out := RenderABGenerating("claude-code", 0, nil)
+	out := RenderABGenerating("claude-code", 0, nil, 0)
 	if !strings.Contains(out, "Generating Your Agent") {
 		t.Errorf("heading not found; output:\n%s", out)
 	}
 }
 
 func TestRenderABGenerating_ShowsEngineName(t *testing.T) {
-	out := RenderABGenerating("opencode", 2, nil)
+	out := RenderABGenerating("opencode", 2, nil, 0)
 	if !strings.Contains(out, "opencode") {
 		t.Errorf("engine name not found; output:\n%s", out)
 	}
@@ -29,7 +29,7 @@ func TestRenderABGenerating_ShowsEngineName(t *testing.T) {
 
 func TestRenderABGenerating_WithError_ShowsErrorMessage(t *testing.T) {
 	genErr := errors.New("connection timeout")
-	out := RenderABGenerating("claude-code", 0, genErr)
+	out := RenderABGenerating("claude-code", 0, genErr, 0)
 	if !strings.Contains(out, "connection timeout") {
 		t.Errorf("error message not found; output:\n%s", out)
 	}
@@ -40,15 +40,22 @@ func TestRenderABGenerating_WithError_ShowsErrorMessage(t *testing.T) {
 
 func TestRenderABGenerating_WithError_ShowsRetryOption(t *testing.T) {
 	genErr := errors.New("some error")
-	out := RenderABGenerating("claude-code", 0, genErr)
+	out := RenderABGenerating("claude-code", 0, genErr, 0)
 	if !strings.Contains(out, "Retry") {
 		t.Errorf("Retry option not found in error state; output:\n%s", out)
 	}
 }
 
+func TestRenderABGenerating_WithError_FocusesCursor(t *testing.T) {
+	out := RenderABGenerating("claude-code", 0, errors.New("failed"), 1)
+	if !strings.Contains(out, "▸ Back") {
+		t.Fatalf("Back should be focused for cursor 1; output:\n%s", out)
+	}
+}
+
 func TestRenderABGenerating_NoError_ShowsSpinner(t *testing.T) {
 	// Without error, should show spinner/loading text.
-	out := RenderABGenerating("gemini", 1, nil)
+	out := RenderABGenerating("gemini", 1, nil, 0)
 	if !strings.Contains(out, "Running") {
 		t.Errorf("expected 'Running' spinner text; output:\n%s", out)
 	}

--- a/internal/tui/screens/common.go
+++ b/internal/tui/screens/common.go
@@ -17,6 +17,12 @@ func renderOptions(options []string, cursor int) string {
 	return output
 }
 
+func RenderOperationRunning(title, detail string, spinnerFrame int) string {
+	return styles.TitleStyle.Render(title) + "\n\n" +
+		styles.WarningStyle.Render(SpinnerChar(spinnerFrame)+"  "+detail) + "\n\n" +
+		styles.HelpStyle.Render("Please wait...")
+}
+
 func renderCheckbox(label string, checked bool, focused bool) string {
 	marker := "[ ]"
 	markerStyle := styles.UnselectedStyle


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1232

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Reject duplicate input while profile sync, restore, plugin registration, update discovery, and other asynchronous TUI operations are running.
- Guard asynchronous completions so abandoned flows cannot jump into stale result screens.
- Align cursor/render/action contracts and make Enter-on-Back and Esc share navigation and cleanup behavior.
- Add behavior-first regression coverage for the audited navigation discrepancies.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/tui/model.go` | Running-state locks, async completion guards, coherent predecessors, and Back/Esc parity |
| `internal/tui/navigation_safety_test.go` | Table-driven behavioral regressions for navigation and async lifecycle contracts |
| `internal/tui/model_test.go` | Updated operation-state expectations |
| `internal/tui/screens/agent_builder_generating*` | Cursor-aligned Retry/Back rendering and dispatch |
| `internal/tui/screens/common.go` | Shared focusable-row behavior for running/result screens |

---

## 🔗 Chain Context

```text
main
 ├─ ✅ PR 1/2 #1235: Custom picker + persisted sync selection
 └─ 📍 PR 2/2: async navigation + Back/Esc safety
```

- **Start:** v2.1.2 navigation permits duplicate operations, stale completions, and inconsistent predecessors.
- **Finish:** asynchronous screens expose one coherent running/result lifecycle and navigation contract.
- **Dependency:** #1235 is merged; this branch also includes the unrelated current `main` advance from #1236.
- **Rollback:** revert the navigation commit; no persisted schema or migration changes are involved.

---

## 🧪 Test Plan

```bash
go test ./internal/tui/... -count=1
go test ./...
go vet ./...
go build ./...
git diff --check origin/main...HEAD
```

- [x] Focused TUI tests pass
- [x] Full unit suite passes
- [x] Vet and build pass
- [x] Diff integrity check passes
- [ ] Required remote E2E matrix — pending CI

---

## 🤖 Automated Checks

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | 346 changed lines |
| Check Issue Reference | ⏳ | Closes approved issue #1232 |
| Check PR Has `type:*` Label | ⏳ | Exactly `type:bug` will be applied |
| Unit Tests | ⏳ | Local full suite passed; CI pending |
| E2E Tests | ⏳ | Remote Ubuntu/Fedora/Arch matrix pending |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass — awaiting required CI
- [x] Behavior changes are covered by focused tests
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

Native review lineage `review-492670f78f5e6fa4` approved the exact six-path candidate after the base advanced to #1236. Full tests, vet, and build were rerun after that merge. Two non-blocking follow-ups were recorded around profile-load error wording/lifecycle; they do not reopen the bounded candidate review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented delayed background results from changing screens unexpectedly.
  - Fixed backup restore and profile deletion flows to preserve errors and clean up operation state correctly.
  - Improved navigation and cursor behavior across model selection, plugin setup, and result screens.
  - Prevented phantom selections and unintended actions during completed or failed operations.

- **User Experience**
  - Added progress overlays and “Please wait” messaging during active operations.
  - Disabled navigation while operations are running, while keeping quit available.
  - Added `Esc` support to leave the update prompt and improved error-state focus behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->