### PR TITLE
fix(review): make review start idempotent

### DIFF
--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -24,6 +24,8 @@ Only candidate-caused BLOCKER or CRITICAL findings may require correction. Pre-e
 
 type ReviewFacadeStartResult struct {
 	Operation        string                      `json:"operation"`
+	Action           string                      `json:"action"`
+	LensesRequired   bool                        `json:"lenses_required"`
 	LineageID        string                      `json:"lineage_id"`
 	State            reviewtransaction.State     `json:"state"`
 	RiskLevel        reviewtransaction.RiskLevel `json:"risk_level"`
@@ -298,6 +300,7 @@ func RunReviewFacadeStart(args []string, stdout io.Writer) error {
 	policySource := flags.String("policy", "", "optional review policy file; the native bounded policy is used by default")
 	focus := flags.String("focus", "reliability", "dominant standard-risk focus: risk, resilience, readability, or reliability")
 	baseRef := flags.String("base-ref", "", "optional base revision for reviewing committed HEAD changes")
+	committedOnly := flags.Bool("committed-only", false, "acknowledge that --base-ref excludes dirty tracked changes")
 	tracePath := flags.String("trace", "", "optional diagnostic operation metadata trace path")
 	if err := parseReviewFlags(flags, args); err != nil {
 		return err
@@ -312,6 +315,15 @@ func RunReviewFacadeStart(args []string, stdout io.Writer) error {
 	root, err := builder.ResolveRepositoryRoot(context.Background())
 	if err != nil {
 		return fmt.Errorf("resolve review repository root: %w", err)
+	}
+	if strings.TrimSpace(*baseRef) != "" {
+		dirtyTracked, dirtyErr := (reviewtransaction.SnapshotBuilder{Repo: root}).HasDirtyTrackedChanges(context.Background())
+		if dirtyErr != nil {
+			return fmt.Errorf("detect dirty tracked changes for committed review: %w", dirtyErr)
+		}
+		if dirtyTracked && !*committedOnly {
+			return errors.New("review start with --base-ref omits dirty tracked changes; rerun with --committed-only to acknowledge committed-only review scope")
+		}
 	}
 	intended, err := builder.DiscoverIntendedUntracked(context.Background())
 	if err != nil {
@@ -337,16 +349,6 @@ func RunReviewFacadeStart(args []string, stdout io.Writer) error {
 	if strings.TrimSpace(*lineage) == "" {
 		*lineage = "review-" + strings.TrimPrefix(snapshot.Identity, "sha256:")[:16]
 	}
-	store, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), root, *lineage)
-	if err != nil {
-		return fmt.Errorf("derive facade review store: %w", err)
-	}
-	store.TracePath = strings.TrimSpace(*tracePath)
-	if existing, loadErr := store.Load(); loadErr == nil {
-		return fmt.Errorf("review lineage %q already exists at revision %s; use gentle-ai review recover with an explicit predecessor and distinct successor lineage", *lineage, existing.Revision)
-	} else if !os.IsNotExist(loadErr) {
-		return fmt.Errorf("load existing compact review lineage: %w", loadErr)
-	}
 	legacy, err := reviewtransaction.AuthoritativeStore(context.Background(), root, *lineage)
 	if err == nil {
 		if _, loadErr := legacy.LoadChain(); loadErr == nil {
@@ -365,13 +367,18 @@ func RunReviewFacadeStart(args []string, stdout io.Writer) error {
 	if err != nil {
 		return fmt.Errorf("create compact facade review: %w", err)
 	}
-	if _, err := store.Replace("", "review/start", state); err != nil {
-		return fmt.Errorf("persist compact facade review: %w", err)
+	started, err := reviewtransaction.StartCompactAuthority(context.Background(), root, reviewtransaction.CompactStartRequest{
+		State: state, TracePath: strings.TrimSpace(*tracePath),
+	})
+	if err != nil {
+		return fmt.Errorf("start compact facade review: %w", err)
 	}
+	authority := started.Record.State
 	return encodeReviewJSON(stdout, ReviewFacadeStartResult{
-		Operation: "review/start", LineageID: state.LineageID, State: state.State,
-		RiskLevel: state.RiskLevel, SelectedLenses: state.SelectedLenses,
-		ChangedFiles: len(state.InitialSnapshot.Paths), ChangedLines: changedLines, CorrectionBudget: state.CorrectionBudget,
+		Operation: "review/start", Action: string(started.Action), LensesRequired: started.LensesRequired,
+		LineageID: authority.LineageID, State: authority.State, RiskLevel: authority.RiskLevel,
+		SelectedLenses: authority.SelectedLenses, ChangedFiles: len(authority.InitialSnapshot.Paths),
+		ChangedLines: authority.OriginalChangedLines, CorrectionBudget: authority.CorrectionBudget,
 	})
 }
 

--- a/internal/cli/review_facade_test.go
+++ b/internal/cli/review_facade_test.go
@@ -198,6 +198,107 @@ func TestReviewFacadeStartSupportsCommittedBaseDiff(t *testing.T) {
 	}
 }
 
+func TestReviewFacadeStartRequiresCommittedOnlyAndReusesEquivalentAuthority(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	base := strings.TrimSpace(runReviewCLIGit(t, repo, "rev-parse", "HEAD"))
+	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("committed candidate\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runReviewCLIGit(t, repo, "add", "tracked.txt")
+	runReviewCLIGit(t, repo, "commit", "-qm", "candidate")
+	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("dirty change outside committed target\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := RunReviewFacadeStart([]string{"--cwd", repo, "--base-ref", base}, io.Discard); err == nil || !strings.Contains(err.Error(), "--committed-only") {
+		t.Fatalf("dirty base-ref start error = %v, want committed-only acknowledgement", err)
+	}
+	if stores, err := reviewtransaction.CompactAuthorityLeaves(context.Background(), repo); err != nil || len(stores) != 0 {
+		t.Fatalf("rejected start persisted authority = %v, %v", stores, err)
+	}
+
+	start := func(args ...string) ReviewFacadeStartResult {
+		t.Helper()
+		var output bytes.Buffer
+		if err := RunReviewFacadeStart(append([]string{"--cwd", repo, "--base-ref", base, "--committed-only"}, args...), &output); err != nil {
+			t.Fatal(err)
+		}
+		var result ReviewFacadeStartResult
+		if err := json.Unmarshal(output.Bytes(), &result); err != nil {
+			t.Fatal(err)
+		}
+		return result
+	}
+	created := start()
+	if created.Action != "created" || !created.LensesRequired {
+		t.Fatalf("created start = %#v", created)
+	}
+	store, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, created.LineageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	before, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resumed := start("--lineage", "requested-different-lineage")
+	if resumed.Action != "resumed" || !resumed.LensesRequired || resumed.LineageID != created.LineageID {
+		t.Fatalf("equivalent start did not resume canonical authority: %#v", resumed)
+	}
+	after, err := store.Load()
+	if err != nil || after.Revision != before.Revision || after.State.CorrectionBudget != before.State.CorrectionBudget {
+		t.Fatalf("resume changed compact authority = %#v, %v", after, err)
+	}
+
+	policy := filepath.Join(t.TempDir(), "different-policy.md")
+	if err := os.WriteFile(policy, []byte("different policy\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var blockedOutput bytes.Buffer
+	if err := RunReviewFacadeStart([]string{"--cwd", repo, "--base-ref", base, "--committed-only", "--policy", policy}, &blockedOutput); err != nil {
+		t.Fatal(err)
+	}
+	var blocked ReviewFacadeStartResult
+	if err := json.Unmarshal(blockedOutput.Bytes(), &blocked); err != nil {
+		t.Fatal(err)
+	}
+	if blocked.Action != "blocked-scope-action" || blocked.LensesRequired {
+		t.Fatalf("changed policy start = %#v", blocked)
+	}
+	if unchanged, err := store.Load(); err != nil || unchanged.Revision != before.Revision {
+		t.Fatalf("blocked start changed authority = %#v, %v", unchanged, err)
+	}
+
+	resultPath := filepath.Join(t.TempDir(), "review.json")
+	evidencePath := filepath.Join(t.TempDir(), "evidence.txt")
+	writeReviewCLIJSON(t, resultPath, facadeReviewerResult{Findings: []facadeFinding{}, Evidence: []string{"committed target reviewed"}})
+	if err := os.WriteFile(evidencePath, []byte("focused tests pass\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := RunReviewFacadeFinalize([]string{"--cwd", repo, "--lineage", created.LineageID, "--result", resultPath, "--evidence", evidencePath}, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	reused := start()
+	if reused.Action != "reuse-receipt" || reused.LensesRequired || reused.LineageID != created.LineageID {
+		t.Fatalf("approved equivalent start = %#v", reused)
+	}
+	if err := os.WriteFile(store.ReceiptPath(), []byte("malformed receipt\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var malformedOutput bytes.Buffer
+	if err := RunReviewFacadeStart([]string{"--cwd", repo, "--base-ref", base, "--committed-only"}, &malformedOutput); err != nil {
+		t.Fatal(err)
+	}
+	var malformed ReviewFacadeStartResult
+	if err := json.Unmarshal(malformedOutput.Bytes(), &malformed); err != nil {
+		t.Fatal(err)
+	}
+	if malformed.Action != "blocked-scope-action" || malformed.LensesRequired {
+		t.Fatalf("malformed receipt start = %#v", malformed)
+	}
+}
+
 func TestReviewFacadeStartServiceTokenSelectsCanonicalHighRiskLenses(t *testing.T) {
 	repo := initReviewCLIRepo(t)
 	neutral := filepath.Join(repo, "neutral")
@@ -322,6 +423,7 @@ func TestReadFacadeReviewerResultsRejectsNonNativeFields(t *testing.T) {
 
 func TestReviewFacadeCorrectionFlowResumesFromEachCompactIntermediateState(t *testing.T) {
 	repo := initReviewCLIRepo(t)
+	base := strings.TrimSpace(runReviewCLIGit(t, repo, "rev-parse", "HEAD"))
 	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("base\none\ntwo\nthree\nfour\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -368,6 +470,10 @@ func TestReviewFacadeCorrectionFlowResumesFromEachCompactIntermediateState(t *te
 	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("base\none\ntwo\nthree\nfixed\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	resumed := startFacadeReview(t, repo)
+	if resumed.Action != "resumed" || resumed.LensesRequired || resumed.LineageID != started.LineageID || resumed.State != reviewtransaction.StateCorrectionRequired {
+		t.Fatalf("corrected in-scope start did not resume correction authority: %#v", resumed)
+	}
 	validationPath := filepath.Join(t.TempDir(), "validation.json")
 	writeReviewCLIJSON(t, validationPath, facadeValidationResult{
 		OriginalCriteria:     facadeValidationCheck{Passed: true, Evidence: []string{"original acceptance test passed"}},
@@ -402,9 +508,26 @@ func TestReviewFacadeCorrectionFlowResumesFromEachCompactIntermediateState(t *te
 		t.Fatalf("corrected approved result = %#v", got)
 	}
 	assertCompactLineageFiles(t, store, []string{"review-receipt.json", "review-state.json"})
+	reused := startFacadeReview(t, repo)
+	if reused.Action != "reuse-receipt" || reused.LensesRequired || reused.LineageID != started.LineageID || reused.State != reviewtransaction.StateApproved {
+		t.Fatalf("corrected approved target did not reuse receipt: %#v", reused)
+	}
 	output.Reset()
 	if err := RunReviewFacadeValidate([]string{"--cwd", repo, "--gate", string(reviewtransaction.GatePreCommit)}, &output); err != nil {
 		t.Fatalf("corrected compact gate: %v\n%s", err, output.String())
+	}
+	runReviewCLIGit(t, repo, "add", "tracked.txt")
+	runReviewCLIGit(t, repo, "commit", "-qm", "corrected delivery")
+	output.Reset()
+	if err := RunReviewFacadeStart([]string{"--cwd", repo, "--base-ref", base}, &output); err != nil {
+		t.Fatal(err)
+	}
+	var committedReuse ReviewFacadeStartResult
+	if err := json.Unmarshal(output.Bytes(), &committedReuse); err != nil {
+		t.Fatal(err)
+	}
+	if committedReuse.Action != "reuse-receipt" || committedReuse.LensesRequired || committedReuse.LineageID != started.LineageID || committedReuse.State != reviewtransaction.StateApproved {
+		t.Fatalf("equivalent committed corrected target did not reuse receipt: %#v", committedReuse)
 	}
 }
 

--- a/internal/reviewtransaction/compact_store.go
+++ b/internal/reviewtransaction/compact_store.go
@@ -36,6 +36,26 @@ type CompactStore struct {
 	TracePath string
 }
 
+type CompactStartAction string
+
+const (
+	CompactStartCreated      CompactStartAction = "created"
+	CompactStartResumed      CompactStartAction = "resumed"
+	CompactStartReuseReceipt CompactStartAction = "reuse-receipt"
+	CompactStartBlocked      CompactStartAction = "blocked-scope-action"
+)
+
+type CompactStartRequest struct {
+	State     CompactState
+	TracePath string
+}
+
+type CompactStartResult struct {
+	Record         CompactRecord
+	Action         CompactStartAction
+	LensesRequired bool
+}
+
 type CompactTraceEntry struct {
 	Operation        string `json:"operation"`
 	PreviousRevision string `json:"previous_revision,omitempty"`
@@ -178,7 +198,6 @@ func CompactAuthorityLeaves(ctx context.Context, repo string) ([]CompactStore, e
 	}
 	records := make(map[string]CompactRecord, len(stores))
 	storeByLineage := make(map[string]CompactStore, len(stores))
-	children := make(map[string]int)
 	for _, store := range stores {
 		record, loadErr := store.Load()
 		if loadErr != nil {
@@ -186,6 +205,11 @@ func CompactAuthorityLeaves(ctx context.Context, repo string) ([]CompactStore, e
 		}
 		records[record.State.LineageID], storeByLineage[record.State.LineageID] = record, store
 	}
+	return compactAuthorityLeaves(records, storeByLineage)
+}
+
+func compactAuthorityLeaves(records map[string]CompactRecord, storeByLineage map[string]CompactStore) ([]CompactStore, error) {
+	children := make(map[string]int)
 	for lineage, record := range records {
 		if record.State.Recovery == nil {
 			continue
@@ -288,6 +312,165 @@ func DiscoverCompactStores(ctx context.Context, repo string) ([]CompactStore, er
 	}
 	sort.Slice(stores, func(i, j int) bool { return stores[i].lineageID < stores[j].lineageID })
 	return stores, nil
+}
+
+// StartCompactAuthority serializes compact start discovery, equivalence
+// decisions, and the initial write under the repository-wide v2 lock.
+func StartCompactAuthority(ctx context.Context, repo string, request CompactStartRequest) (CompactStartResult, error) {
+	if err := request.State.Validate(); err != nil {
+		return CompactStartResult{}, fmt.Errorf("validate compact start: %w", err)
+	}
+	requestedStore, err := CompactAuthoritativeStore(ctx, repo, request.State.LineageID)
+	if err != nil {
+		return CompactStartResult{}, err
+	}
+	lock, err := acquireCompactStartLock(ctx, requestedStore.lockPath)
+	if err != nil {
+		return CompactStartResult{}, err
+	}
+	defer lock.release()
+
+	stores, err := DiscoverCompactStores(ctx, requestedStore.repo)
+	if err != nil {
+		return CompactStartResult{}, err
+	}
+	records := make(map[string]CompactRecord, len(stores))
+	storeByLineage := make(map[string]CompactStore, len(stores))
+	for _, store := range stores {
+		record, loadErr := store.Load()
+		if loadErr != nil {
+			return CompactStartResult{}, fmt.Errorf("load compact start authority: %w", loadErr)
+		}
+		records[record.State.LineageID], storeByLineage[record.State.LineageID] = record, store
+	}
+	leaves, err := compactAuthorityLeaves(records, storeByLineage)
+	if err != nil {
+		return CompactStartResult{}, err
+	}
+	if len(stores) > 0 && len(leaves) != 1 {
+		return CompactStartResult{}, errors.New("multiple compact authorities require explicit predecessor-bound recovery")
+	}
+	for _, store := range leaves {
+		record := records[store.lineageID]
+		switch record.State.State {
+		case StateReviewing:
+			if record.State.InitialSnapshot.CandidateTree != request.State.InitialSnapshot.CandidateTree {
+				continue
+			}
+			if !compactStartScopeEqual(record.State, request.State) {
+				return CompactStartResult{Record: record, Action: CompactStartBlocked}, nil
+			}
+		case StateCorrectionRequired:
+			if !compactStartCorrectionResume(ctx, requestedStore.repo, record.State, request.State) {
+				return CompactStartResult{Record: record, Action: CompactStartBlocked}, nil
+			}
+		case StateValidating:
+			if !compactStartLiveTargetMatches(ctx, requestedStore.repo, record.State, request.State, true) {
+				return CompactStartResult{Record: record, Action: CompactStartBlocked}, nil
+			}
+		case StateApproved:
+			if !compactStartLiveTargetMatches(ctx, requestedStore.repo, record.State, request.State, true) {
+				return CompactStartResult{Record: record, Action: CompactStartBlocked}, nil
+			}
+			payload, readErr := os.ReadFile(store.ReceiptPath())
+			if readErr != nil {
+				if os.IsNotExist(readErr) {
+					return CompactStartResult{Record: record, Action: CompactStartBlocked}, nil
+				}
+				return CompactStartResult{}, fmt.Errorf("load compact approved receipt: %w", readErr)
+			}
+			receipt, parseErr := ParseCompactReceipt(payload)
+			want, receiptErr := record.State.Receipt()
+			if parseErr != nil || receiptErr != nil || !compactReceiptEqual(receipt, want) {
+				return CompactStartResult{Record: record, Action: CompactStartBlocked}, nil
+			}
+			return CompactStartResult{Record: record, Action: CompactStartReuseReceipt}, nil
+		default:
+			return CompactStartResult{Record: record, Action: CompactStartBlocked}, nil
+		}
+		return CompactStartResult{Record: record, Action: CompactStartResumed,
+			LensesRequired: len(record.State.LensResults) < len(record.State.SelectedLenses)}, nil
+	}
+	if len(stores) > 0 {
+		return CompactStartResult{Record: records[leaves[0].lineageID], Action: CompactStartBlocked}, nil
+	}
+	if err := validateCompactRepositoryEvidence(ctx, requestedStore.repo, nil, request.State, "review/start"); err != nil {
+		return CompactStartResult{}, fmt.Errorf("validate compact start repository evidence: %w", err)
+	}
+	record, payload, err := makeCompactRecord(request.State)
+	if err != nil {
+		return CompactStartResult{}, err
+	}
+	if err := writeAtomic(requestedStore.StatePath(), payload, 0o644); err != nil {
+		return CompactStartResult{}, err
+	}
+	if request.TracePath != "" {
+		_ = appendCompactTrace(request.TracePath, CompactTraceEntry{
+			Operation: "review/start", Revision: record.Revision, State: request.State.State,
+			RecordedAt: time.Now().UTC().Format(time.RFC3339Nano),
+		})
+	}
+	return CompactStartResult{
+		Record: record, Action: CompactStartCreated,
+		LensesRequired: len(request.State.SelectedLenses) > 0,
+	}, nil
+}
+
+func acquireCompactStartLock(ctx context.Context, path string) (*storeLock, error) {
+	for {
+		lock, err := acquireStoreLock(path)
+		if err == nil || !errors.Is(err, ErrConcurrentUpdate) {
+			return lock, err
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(5 * time.Millisecond):
+		}
+	}
+}
+
+func compactStartCorrectionResume(ctx context.Context, repo string, existing, requested CompactState) bool {
+	if !compactStartLiveTargetMatches(ctx, repo, existing, requested, false) {
+		return false
+	}
+	if requested.InitialSnapshot.CandidateTree == existing.CurrentSnapshot.CandidateTree {
+		return true
+	}
+	if existing.ProposedCorrectionLines == nil {
+		return false
+	}
+	fix, err := (SnapshotBuilder{Repo: repo}).Build(ctx, Target{Kind: TargetFixDiff,
+		BaseRef: existing.CurrentSnapshot.CandidateTree, IntendedUntracked: existing.InitialSnapshot.IntendedUntracked,
+		LedgerIDs: existing.FixFindingIDs})
+	if err != nil || fix.CandidateTree != requested.InitialSnapshot.CandidateTree || pathsAreSubset(fix.Paths, existing.GenesisPaths) != nil {
+		return false
+	}
+	lines, err := (SnapshotBuilder{Repo: repo}).ChangedLines(ctx, fix)
+	return err == nil && lines <= existing.CorrectionBudget-existing.CumulativeCorrectionLines
+}
+
+func compactStartLiveTargetMatches(ctx context.Context, repo string, existing, requested CompactState, requireCurrentCandidate bool) bool {
+	live := requested.InitialSnapshot
+	if existing.Generation != requested.Generation || existing.PolicyHash != requested.PolicyHash ||
+		!reflect.DeepEqual(existing.Recovery, requested.Recovery) ||
+		(live.Kind != TargetCurrentChanges && live.Kind != TargetBaseDiff) ||
+		live.BaseTree != existing.InitialSnapshot.BaseTree ||
+		(requireCurrentCandidate && live.CandidateTree != existing.CurrentSnapshot.CandidateTree) ||
+		!equalStrings(live.Paths, existing.GenesisPaths) || !equalStrings(live.IntendedUntracked, existing.InitialSnapshot.IntendedUntracked) || len(live.LedgerIDs) != 0 {
+		return false
+	}
+	return (SnapshotBuilder{Repo: repo}).ValidateEvidence(ctx, live) == nil
+}
+
+func compactStartScopeEqual(existing, requested CompactState) bool {
+	return existing.Generation == requested.Generation &&
+		snapshotsEqual(existing.InitialSnapshot, requested.InitialSnapshot) &&
+		equalStrings(existing.GenesisPaths, requested.GenesisPaths) &&
+		existing.PolicyHash == requested.PolicyHash && existing.RiskLevel == requested.RiskLevel &&
+		equalStrings(existing.SelectedLenses, requested.SelectedLenses) &&
+		existing.OriginalChangedLines == requested.OriginalChangedLines &&
+		existing.CorrectionBudget == requested.CorrectionBudget && reflect.DeepEqual(existing.Recovery, requested.Recovery)
 }
 
 func (store CompactStore) StatePath() string { return filepath.Join(store.Dir, "review-state.json") }

--- a/internal/reviewtransaction/compact_store_test.go
+++ b/internal/reviewtransaction/compact_store_test.go
@@ -206,6 +206,83 @@ func TestCompactStoreRecoverRejectsIneligibleOrUnprovenPredecessor(t *testing.T)
 	}
 }
 
+func TestStartCompactAuthorityBlocksSupersededApprovedPredecessor(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	predecessor, store, _ := approvedCompactRevisionFixture(t, repo, "compact-start-a")
+	record, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeSnapshotFile(t, repo, "tracked.txt", "successor\n")
+	successor := newCompactTestState(t, repo, "compact-start-b")
+	successor.Generation = predecessor.Generation + 1
+	if _, err := RecoverCompactAuthority(context.Background(), repo, CompactRecoveryRequest{
+		PredecessorLineageID: predecessor.LineageID, ExpectedPredecessorRevision: record.Revision,
+		Successor: successor, Disposition: RecoveryScopeChanged, Reason: "scope changed", Actor: "maintainer",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	result, err := StartCompactAuthority(context.Background(), repo, CompactStartRequest{State: newCompactRevisionState(t, repo, "compact-start-c")})
+	if err != nil || result.Action != CompactStartBlocked || result.Record.State.LineageID != successor.LineageID {
+		t.Fatalf("start against superseded predecessor = %#v, %v", result, err)
+	}
+}
+
+func TestStartCompactAuthorityConcurrentlyConvergesOnOneEquivalentAuthority(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	writeSnapshotFile(t, repo, "tracked.txt", "candidate\n")
+	first := newCompactTestState(t, repo, "compact-start-first")
+	second := first
+	second.LineageID = "compact-start-second"
+
+	type outcome struct {
+		result CompactStartResult
+		err    error
+	}
+	results := make(chan outcome, 2)
+	for _, state := range []CompactState{first, second} {
+		go func(state CompactState) {
+			result, err := StartCompactAuthority(context.Background(), repo, CompactStartRequest{State: state})
+			results <- outcome{result: result, err: err}
+		}(state)
+	}
+	one, two := <-results, <-results
+	if one.err != nil || two.err != nil {
+		t.Fatalf("concurrent starts = %#v, %#v", one, two)
+	}
+	if one.result.Record.State.LineageID != two.result.Record.State.LineageID || one.result.Record.Revision != two.result.Record.Revision {
+		t.Fatalf("concurrent starts diverged: %#v, %#v", one.result, two.result)
+	}
+	actions := map[CompactStartAction]int{one.result.Action: 1, two.result.Action: 1}
+	if actions[CompactStartCreated] != 1 || actions[CompactStartResumed] != 1 {
+		t.Fatalf("concurrent start actions = %#v", actions)
+	}
+	leaves, err := CompactAuthorityLeaves(context.Background(), repo)
+	if err != nil || len(leaves) != 1 {
+		t.Fatalf("concurrent start leaves = %#v, %v", leaves, err)
+	}
+}
+
+func TestStartCompactAuthorityBlocksChangedTargetForExplicitRecovery(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	writeSnapshotFile(t, repo, "tracked.txt", "first candidate\n")
+	first := newCompactTestState(t, repo, "compact-start-original")
+	created, err := StartCompactAuthority(context.Background(), repo, CompactStartRequest{State: first})
+	if err != nil || created.Action != CompactStartCreated {
+		t.Fatalf("create original authority = %#v, %v", created, err)
+	}
+	writeSnapshotFile(t, repo, "tracked.txt", "changed candidate\n")
+	changed := newCompactTestState(t, repo, "compact-start-changed")
+	blocked, err := StartCompactAuthority(context.Background(), repo, CompactStartRequest{State: changed})
+	if err != nil || blocked.Action != CompactStartBlocked || blocked.Record.Revision != created.Record.Revision {
+		t.Fatalf("changed target start = %#v, %v", blocked, err)
+	}
+	leaves, err := CompactAuthorityLeaves(context.Background(), repo)
+	if err != nil || len(leaves) != 1 || leaves[0].lineageID != first.LineageID {
+		t.Fatalf("changed target created a new authority: %#v, %v", leaves, err)
+	}
+}
+
 func TestCompactStoreReplacesCurrentStateWithCASAndExactRetry(t *testing.T) {
 	repo := initSnapshotRepo(t)
 	writeSnapshotFile(t, repo, "tracked.txt", "candidate\n")

--- a/internal/reviewtransaction/snapshot.go
+++ b/internal/reviewtransaction/snapshot.go
@@ -343,6 +343,20 @@ func (builder SnapshotBuilder) DiscoverIntendedUntracked(ctx context.Context) ([
 	return canonicalPaths(paths)
 }
 
+// HasDirtyTrackedChanges reports whether the worktree or index differs from
+// HEAD, excluding untracked paths.
+func (builder SnapshotBuilder) HasDirtyTrackedChanges(ctx context.Context) (bool, error) {
+	root, err := builder.ResolveRepositoryRoot(ctx)
+	if err != nil {
+		return false, err
+	}
+	output, err := runGit(ctx, root, nil, nil, "diff", "--name-only", "-z", "HEAD", "--")
+	if err != nil {
+		return false, err
+	}
+	return len(output) != 0, nil
+}
+
 func canonicalRepositoryPath(path string) (string, error) {
 	abs, err := filepath.Abs(path)
 	if err != nil {


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1239

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)

## 📝 Summary

Makes native review start target-idempotent and fail closed when committed-only review would silently omit dirty tracked work.

Equivalent starts now converge on current repository authority, approved receipts are reused without new lenses, correction continuations resume their existing budget, and genuinely changed scope remains bound to explicit recovery.

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/cli/review_facade.go` | Added committed-only acknowledgement and machine-readable start routing |
| `internal/reviewtransaction/compact_store.go` | Added atomic repository-wide start reconciliation under the existing lock |
| `internal/reviewtransaction/snapshot.go` | Added dirty tracked worktree detection |
| Review tests | Covered concurrency, recovery history, correction continuation, receipt reuse, and fail-closed drift |

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./... -count=1
go test -race ./internal/cli ./internal/reviewtransaction -count=1
```

**E2E Tests**
```bash
cd e2e && ./docker-test.sh
```

- [x] Unit tests pass (`go test ./... -count=1`)
- [x] Race tests pass (`go test -race ./internal/cli ./internal/reviewtransaction -count=1`)
- [ ] Local E2E was unavailable because Docker is not installed; required CI E2E must pass before merge

## 📏 Review Workload

This atomic authority change is 436 authored lines after one bounded correction. Splitting state reconciliation from its concurrency and recovery regressions would make either work unit unsafe to merge independently, so this PR requests `size:exception`.

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] The `size:exception` rationale is documented above
- [x] Exactly one `type:*` label will be applied
- [x] Unit and race tests pass
- [ ] Required CI E2E passes
- [x] Documentation is not required for this internal safety fix
- [x] Commit follows Conventional Commits format
- [x] Commit contains no `Co-Authored-By` trailer


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a `--committed-only` option to review startup.
  - Review startup now reports whether lenses are required.
  - Existing review authorities can be resumed or reused when the scope and evidence match.

- **Bug Fixes**
  - Prevented reviews from starting against a base reference with uncommitted tracked changes unless explicitly acknowledged.
  - Added safeguards against conflicting, outdated, or invalid review recovery states.
  - Improved handling of concurrent review starts to avoid duplicate authorities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->