### PR TITLE
feat(review): add staged candidate projection

### DIFF
--- a/docs/review-authority-threat-model.md
+++ b/docs/review-authority-threat-model.md
@@ -25,6 +25,14 @@ The compact review store protects valid authority from accidental corruption and
 - Live-Git gate re-derivation rather than trusting persisted mirrors.
 - Checksums only where useful for detecting accidental corruption; they are not authentication.
 
+## Candidate Projections
+
+`gentle-ai review start` defaults to the legacy `workspace` projection. Use `gentle-ai review start --projection staged` to freeze exactly the Git index: unstaged and untracked worktree content is excluded, and the live index and worktree are not modified while deriving evidence. The selected projection is emitted in START JSON and retained by compact authority, receipts, corrections, recovery, and transport.
+
+After committing a staged candidate, use `gentle-ai review start --projection staged --base-ref <ref>` (and `--committed-only` when tracked workspace changes exist) to record immutable base-to-HEAD delivery provenance. It accepts no intended-untracked paths, remains domain-separated in the v2 identity, and can reuse only the matching staged authority; an otherwise identical workspace authority remains separate.
+
+For a staged authority, `post-apply` and `pre-commit` re-derive the exact index; a divergent worktree alone does not broaden or invalidate that candidate. `pre-push` and `pre-pr` continue to validate the delivered commit/base-diff tree against the same staged receipt.
+
 ## Review Input Schemas
 
 Run `gentle-ai review schema reviewer`, `gentle-ai review schema refuter`, or `gentle-ai review schema validator` to print the versioned JSON Schema and one accepted example for the existing strict facade input. Final verification evidence remains arbitrary non-empty bytes and therefore has no invented JSON contract. Unknown JSON fields and semantic violations remain rejected before authority changes.

--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -23,16 +23,24 @@ Only candidate-caused BLOCKER or CRITICAL findings may require correction. Pre-e
 `
 
 type ReviewFacadeStartResult struct {
-	Operation        string                      `json:"operation"`
-	Action           string                      `json:"action"`
-	LensesRequired   bool                        `json:"lenses_required"`
-	LineageID        string                      `json:"lineage_id"`
-	State            reviewtransaction.State     `json:"state"`
-	RiskLevel        reviewtransaction.RiskLevel `json:"risk_level"`
-	SelectedLenses   []string                    `json:"selected_lenses"`
-	ChangedFiles     int                         `json:"changed_files"`
-	ChangedLines     int                         `json:"changed_lines"`
-	CorrectionBudget int                         `json:"correction_budget"`
+	Operation        string                       `json:"operation"`
+	Action           string                       `json:"action"`
+	LensesRequired   bool                         `json:"lenses_required"`
+	LineageID        string                       `json:"lineage_id"`
+	State            reviewtransaction.State      `json:"state"`
+	RiskLevel        reviewtransaction.RiskLevel  `json:"risk_level"`
+	SelectedLenses   []string                     `json:"selected_lenses"`
+	Projection       reviewtransaction.Projection `json:"projection"`
+	ChangedFiles     int                          `json:"changed_files"`
+	ChangedLines     int                          `json:"changed_lines"`
+	CorrectionBudget int                          `json:"correction_budget"`
+}
+
+func facadeProjection(projection reviewtransaction.Projection) reviewtransaction.Projection {
+	if projection == "" {
+		return reviewtransaction.ProjectionWorkspace
+	}
+	return projection
 }
 
 type ReviewFacadeFinalizeResult struct {
@@ -163,11 +171,15 @@ func RunReviewRecover(args []string, stdout io.Writer) error {
 	if err != nil {
 		return fmt.Errorf("load recovery predecessor: %w", err)
 	}
-	intended, err := builder.DiscoverIntendedUntracked(context.Background())
-	if err != nil {
-		return err
+	projection := predecessorRecord.State.InitialSnapshot.Projection
+	intended := []string{}
+	if projection != reviewtransaction.ProjectionStaged {
+		intended, err = builder.DiscoverIntendedUntracked(context.Background())
+		if err != nil {
+			return err
+		}
 	}
-	snapshot, err := (reviewtransaction.SnapshotBuilder{Repo: root}).Build(context.Background(), reviewtransaction.Target{Kind: reviewtransaction.TargetCurrentChanges, IntendedUntracked: intended})
+	snapshot, err := (reviewtransaction.SnapshotBuilder{Repo: root}).Build(context.Background(), reviewtransaction.Target{Kind: reviewtransaction.TargetCurrentChanges, Projection: projection, IntendedUntracked: intended})
 	if err != nil {
 		return err
 	}
@@ -299,7 +311,8 @@ func RunReviewFacadeStart(args []string, stdout io.Writer) error {
 	lineage := flags.String("lineage", "", "optional explicit review lineage identifier")
 	policySource := flags.String("policy", "", "optional review policy file; the native bounded policy is used by default")
 	focus := flags.String("focus", "reliability", "dominant standard-risk focus: risk, resilience, readability, or reliability")
-	baseRef := flags.String("base-ref", "", "optional base revision for reviewing committed HEAD changes")
+	baseRef := flags.String("base-ref", "", "optional base revision for immutable base-to-HEAD review")
+	projection := flags.String("projection", string(reviewtransaction.ProjectionWorkspace), "candidate projection: workspace or staged; staged base-diff records post-commit delivery provenance")
 	committedOnly := flags.Bool("committed-only", false, "acknowledge that --base-ref excludes dirty tracked changes")
 	tracePath := flags.String("trace", "", "optional diagnostic operation metadata trace path")
 	if err := parseReviewFlags(flags, args); err != nil {
@@ -316,6 +329,10 @@ func RunReviewFacadeStart(args []string, stdout io.Writer) error {
 	if err != nil {
 		return fmt.Errorf("resolve review repository root: %w", err)
 	}
+	selectedProjection := reviewtransaction.Projection(strings.TrimSpace(*projection))
+	if selectedProjection != reviewtransaction.ProjectionWorkspace && selectedProjection != reviewtransaction.ProjectionStaged {
+		return fmt.Errorf("unsupported review projection %q", *projection)
+	}
 	if strings.TrimSpace(*baseRef) != "" {
 		dirtyTracked, dirtyErr := (reviewtransaction.SnapshotBuilder{Repo: root}).HasDirtyTrackedChanges(context.Background())
 		if dirtyErr != nil {
@@ -325,11 +342,14 @@ func RunReviewFacadeStart(args []string, stdout io.Writer) error {
 			return errors.New("review start with --base-ref omits dirty tracked changes; rerun with --committed-only to acknowledge committed-only review scope")
 		}
 	}
-	intended, err := builder.DiscoverIntendedUntracked(context.Background())
-	if err != nil {
-		return fmt.Errorf("discover intended untracked files: %w", err)
+	intended := []string{}
+	if selectedProjection != reviewtransaction.ProjectionStaged {
+		intended, err = builder.DiscoverIntendedUntracked(context.Background())
+		if err != nil {
+			return fmt.Errorf("discover intended untracked files: %w", err)
+		}
 	}
-	target := reviewtransaction.Target{Kind: reviewtransaction.TargetCurrentChanges, IntendedUntracked: intended}
+	target := reviewtransaction.Target{Kind: reviewtransaction.TargetCurrentChanges, Projection: selectedProjection, IntendedUntracked: intended}
 	if strings.TrimSpace(*baseRef) != "" {
 		target.Kind = reviewtransaction.TargetBaseDiff
 		target.BaseRef = strings.TrimSpace(*baseRef)
@@ -377,7 +397,8 @@ func RunReviewFacadeStart(args []string, stdout io.Writer) error {
 	return encodeReviewJSON(stdout, ReviewFacadeStartResult{
 		Operation: "review/start", Action: string(started.Action), LensesRequired: started.LensesRequired,
 		LineageID: authority.LineageID, State: authority.State, RiskLevel: authority.RiskLevel,
-		SelectedLenses: authority.SelectedLenses, ChangedFiles: len(authority.InitialSnapshot.Paths),
+		SelectedLenses: authority.SelectedLenses, Projection: facadeProjection(authority.InitialSnapshot.Projection),
+		ChangedFiles: len(authority.InitialSnapshot.Paths),
 		ChangedLines: authority.OriginalChangedLines, CorrectionBudget: authority.CorrectionBudget,
 	})
 }
@@ -476,8 +497,9 @@ func RunReviewFacadeFinalize(args []string, stdout io.Writer) error {
 			return encodeCompactFacadeFinalize(stdout, state, record.Revision, store, "apply the bounded correction, then rerun with --validation and --evidence")
 		}
 		fixSnapshot, err := (reviewtransaction.SnapshotBuilder{Repo: root}).Build(context.Background(), reviewtransaction.Target{
-			Kind: reviewtransaction.TargetFixDiff, BaseRef: state.CurrentSnapshot.CandidateTree,
-			IntendedUntracked: state.InitialSnapshot.IntendedUntracked, LedgerIDs: state.FixFindingIDs,
+			Kind: reviewtransaction.TargetFixDiff, Projection: state.InitialSnapshot.Projection,
+			BaseRef: state.CurrentSnapshot.CandidateTree, IntendedUntracked: state.InitialSnapshot.IntendedUntracked,
+			LedgerIDs: state.FixFindingIDs,
 		})
 		if err != nil {
 			return fmt.Errorf("derive facade correction snapshot: %w", err)
@@ -778,7 +800,8 @@ func discoverCompactFacadeReview(ctx context.Context, repo, lineage string, term
 		matching := candidates[:0]
 		for _, candidate := range candidates {
 			snapshot, buildErr := (reviewtransaction.SnapshotBuilder{Repo: repo}).Build(ctx, reviewtransaction.Target{
-				Kind: reviewtransaction.TargetCurrentChanges, IntendedUntracked: candidate.record.State.InitialSnapshot.IntendedUntracked,
+				Kind: reviewtransaction.TargetCurrentChanges, Projection: candidate.record.State.InitialSnapshot.Projection,
+				IntendedUntracked: candidate.record.State.InitialSnapshot.IntendedUntracked,
 			})
 			if buildErr == nil && snapshot.CandidateTree == candidate.record.State.CurrentSnapshot.CandidateTree {
 				matching = append(matching, candidate)
@@ -863,7 +886,8 @@ func discoverFacadeReview(ctx context.Context, repo, lineage string, terminal bo
 		for _, candidate := range candidates {
 			tx := candidate.chain.Records[len(candidate.chain.Records)-1].Transaction
 			snapshot, err := (reviewtransaction.SnapshotBuilder{Repo: repo}).Build(ctx, reviewtransaction.Target{
-				Kind: reviewtransaction.TargetCurrentChanges, IntendedUntracked: tx.Snapshot.IntendedUntracked,
+				Kind: reviewtransaction.TargetCurrentChanges, Projection: tx.Snapshot.Projection,
+				IntendedUntracked: tx.Snapshot.IntendedUntracked,
 			})
 			if err == nil && snapshot.CandidateTree == tx.FinalCandidateTree {
 				matching = append(matching, candidate)

--- a/internal/cli/review_facade_test.go
+++ b/internal/cli/review_facade_test.go
@@ -18,6 +18,131 @@ import (
 	"github.com/gentleman-programming/gentle-ai/internal/sddstatus"
 )
 
+func TestReviewFacadeStartStagedProjectionFreezesOnlyIndex(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	base := strings.TrimSpace(runReviewCLIGit(t, repo, "rev-parse", "HEAD"))
+	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("staged\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runReviewCLIGit(t, repo, "add", "--", "tracked.txt")
+	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("unstaged\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "untracked.txt"), []byte("untracked\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	indexTree := strings.TrimSpace(runReviewCLIGit(t, repo, "write-tree"))
+
+	var output bytes.Buffer
+	if err := RunReviewFacadeStart([]string{"--cwd", repo, "--projection", "staged"}, &output); err != nil {
+		t.Fatal(err)
+	}
+	var started ReviewFacadeStartResult
+	if err := json.Unmarshal(output.Bytes(), &started); err != nil {
+		t.Fatal(err)
+	}
+	if started.Projection != reviewtransaction.ProjectionStaged {
+		t.Fatalf("start projection = %q", started.Projection)
+	}
+	store, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, started.LineageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	record, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if record.State.InitialSnapshot.Projection != reviewtransaction.ProjectionStaged || record.State.InitialSnapshot.CandidateTree != indexTree {
+		t.Fatalf("staged authority = %#v, want index tree %s", record.State.InitialSnapshot, indexTree)
+	}
+	if err := RunReviewFacadeStart([]string{"--cwd", repo, "--projection", "future"}, io.Discard); err == nil || !strings.Contains(err.Error(), "unsupported review projection") {
+		t.Fatalf("invalid projection error = %v", err)
+	}
+	runReviewCLIGit(t, repo, "commit", "-qm", "staged candidate")
+	output.Reset()
+	if err := RunReviewFacadeStart([]string{"--cwd", repo, "--projection", "staged", "--base-ref", base, "--committed-only"}, &output); err != nil {
+		t.Fatalf("staged base-diff continuation error = %v", err)
+	}
+	var continued ReviewFacadeStartResult
+	if err := json.Unmarshal(output.Bytes(), &continued); err != nil {
+		t.Fatal(err)
+	}
+	if continued.Action != "resumed" || continued.LineageID != started.LineageID || continued.Projection != reviewtransaction.ProjectionStaged {
+		t.Fatalf("staged base-diff continuation = %#v", continued)
+	}
+}
+
+func TestReviewFacadeStartReusesStagedAuthorityForCommittedBaseDiff(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	base := strings.TrimSpace(runReviewCLIGit(t, repo, "rev-parse", "HEAD"))
+	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("staged candidate\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runReviewCLIGit(t, repo, "add", "--", "tracked.txt")
+	var output bytes.Buffer
+	if err := RunReviewFacadeStart([]string{"--cwd", repo, "--projection", "staged"}, &output); err != nil {
+		t.Fatal(err)
+	}
+	var staged ReviewFacadeStartResult
+	if err := json.Unmarshal(output.Bytes(), &staged); err != nil {
+		t.Fatal(err)
+	}
+	runReviewCLIGit(t, repo, "commit", "-qm", "staged candidate")
+	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("unstaged divergence\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	output.Reset()
+	if err := RunReviewFacadeStart([]string{"--cwd", repo, "--projection", "staged", "--base-ref", base, "--committed-only", "--lineage", "staged-base-request"}, &output); err != nil {
+		t.Fatal(err)
+	}
+	var resumed ReviewFacadeStartResult
+	if err := json.Unmarshal(output.Bytes(), &resumed); err != nil {
+		t.Fatal(err)
+	}
+	if resumed.Action != "resumed" || resumed.LineageID != staged.LineageID || resumed.Projection != reviewtransaction.ProjectionStaged {
+		t.Fatalf("staged committed base-diff reuse = %#v", resumed)
+	}
+}
+
+func TestReviewFacadeStagedReceiptAllowsDeliveredTreePrePushAndPrePR(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	branch := strings.TrimSpace(runReviewCLIGit(t, repo, "symbolic-ref", "--short", "HEAD"))
+	configureCLIReviewPublicationRemote(t, repo, branch)
+	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("staged candidate\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runReviewCLIGit(t, repo, "add", "--", "tracked.txt")
+	var output bytes.Buffer
+	if err := RunReviewFacadeStart([]string{"--cwd", repo, "--projection", "staged"}, &output); err != nil {
+		t.Fatal(err)
+	}
+	var started ReviewFacadeStartResult
+	if err := json.Unmarshal(output.Bytes(), &started); err != nil {
+		t.Fatal(err)
+	}
+	resultPath := filepath.Join(t.TempDir(), "review.json")
+	evidencePath := filepath.Join(t.TempDir(), "evidence.txt")
+	writeReviewCLIJSON(t, resultPath, facadeReviewerResult{Findings: []facadeFinding{}, Evidence: []string{"reviewed staged candidate"}})
+	if err := os.WriteFile(evidencePath, []byte("tests pass\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := RunReviewFacadeFinalize([]string{"--cwd", repo, "--lineage", started.LineageID, "--result", resultPath, "--evidence", evidencePath}, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	runReviewCLIGit(t, repo, "commit", "-qm", "staged candidate")
+	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("unstaged workspace divergence\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, gate := range []reviewtransaction.GateKind{reviewtransaction.GatePrePush, reviewtransaction.GatePrePR} {
+		output.Reset()
+		if err := RunReviewFacadeValidate([]string{"--cwd", repo, "--lineage", started.LineageID, "--gate", string(gate), "--base-ref", "origin/" + branch}, &output); err != nil {
+			t.Fatalf("%s delivered-tree validation: %v\n%s", gate, err, output.String())
+		}
+		assertReviewGateResult(t, output.Bytes(), reviewtransaction.GateAllow)
+	}
+}
+
 func TestReviewFacadeCleanFlowReplacesOneCompactStateAndUsesOnlyReceipt(t *testing.T) {
 	repo := initReviewCLIRepo(t)
 	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("candidate behavior\n"), 0o644); err != nil {
@@ -876,6 +1001,58 @@ func TestReviewRecoverCreatesSuccessorAndDiscoveryRejectsHistoricalAuthority(t *
 		t.Fatalf("successor validation: %v\n%s", err, output.String())
 	}
 	assertReviewGateResult(t, output.Bytes(), reviewtransaction.GateAllow)
+}
+
+func TestReviewRecoverRetainsStagedProjectionAndIgnoresUnstagedWorkspace(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("candidate\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runReviewCLIGit(t, repo, "add", "--", "tracked.txt")
+	var output bytes.Buffer
+	if err := RunReviewFacadeStart([]string{"--cwd", repo, "--projection", "staged"}, &output); err != nil {
+		t.Fatal(err)
+	}
+	var started ReviewFacadeStartResult
+	if err := json.Unmarshal(output.Bytes(), &started); err != nil {
+		t.Fatal(err)
+	}
+	resultPath := filepath.Join(t.TempDir(), "review.json")
+	evidencePath := filepath.Join(t.TempDir(), "evidence.txt")
+	writeReviewCLIJSON(t, resultPath, facadeReviewerResult{Findings: []facadeFinding{}, Evidence: []string{"reviewed"}})
+	if err := os.WriteFile(evidencePath, []byte("tests pass\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := RunReviewFacadeFinalize([]string{"--cwd", repo, "--lineage", started.LineageID, "--result", resultPath, "--evidence", evidencePath}, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	predecessorStore, _ := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, started.LineageID)
+	predecessor, err := predecessorStore.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("recovered staged\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runReviewCLIGit(t, repo, "add", "--", "tracked.txt")
+	stagedTree := strings.TrimSpace(runReviewCLIGit(t, repo, "write-tree"))
+	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("unstaged workspace\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	output.Reset()
+	if err := RunReview([]string{"recover", "--cwd", repo, "--predecessor-lineage", started.LineageID,
+		"--expected-predecessor-revision", predecessor.Revision, "--successor-lineage", "review-staged-recovered",
+		"--disposition", "scope_changed", "--reason", "staged scope changed", "--actor", "maintainer"}, &output); err != nil {
+		t.Fatal(err)
+	}
+	store, _ := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, "review-staged-recovered")
+	recovered, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if recovered.State.InitialSnapshot.Projection != reviewtransaction.ProjectionStaged || recovered.State.InitialSnapshot.CandidateTree != stagedTree {
+		t.Fatalf("recovered staged authority = %#v, want index tree %s", recovered.State.InitialSnapshot, stagedTree)
+	}
 }
 
 func TestReviewBindSDDRequiresExplicitInputs(t *testing.T) {

--- a/internal/reviewtransaction/compact.go
+++ b/internal/reviewtransaction/compact.go
@@ -84,6 +84,7 @@ type CompactRecoveryProvenance struct {
 type CompactReceipt struct {
 	Schema             string        `json:"schema"`
 	LineageID          string        `json:"lineage_id"`
+	Projection         Projection    `json:"projection,omitempty"`
 	Generation         int           `json:"generation"`
 	BaseTree           string        `json:"base_tree"`
 	InitialReviewTree  string        `json:"initial_review_tree"`
@@ -181,6 +182,9 @@ func (state CompactState) Validate() error {
 	if err := validateCompactSnapshotMetadata(state.CurrentSnapshot); err != nil {
 		return fmt.Errorf("current snapshot: %w", err)
 	}
+	if state.CurrentSnapshot.Projection != state.InitialSnapshot.Projection {
+		return errors.New("compact current snapshot must retain the initial projection")
+	}
 	if state.CurrentSnapshot.BaseTree != state.InitialSnapshot.BaseTree && state.CurrentSnapshot.Kind != TargetFixDiff {
 		return errors.New("compact current snapshot must retain the original base or be a fix diff")
 	}
@@ -275,7 +279,7 @@ func validateCompactSnapshotMetadata(snapshot Snapshot) error {
 	if err != nil || !equalStrings(ledgerIDs, snapshot.LedgerIDs) {
 		return errors.New("compact snapshot ledger IDs are not canonical")
 	}
-	wantIdentity := snapshotIdentity(snapshot.Kind, snapshot.BaseTree, snapshot.CandidateTree, snapshot.PathsDigest, snapshot.IntendedUntrackedProof, snapshot.IntendedUntracked, snapshot.LedgerIDs)
+	wantIdentity := snapshotIdentityForProjection(snapshot.Kind, snapshot.Projection, snapshot.BaseTree, snapshot.CandidateTree, snapshot.PathsDigest, snapshot.IntendedUntrackedProof, snapshot.IntendedUntracked, snapshot.LedgerIDs)
 	if snapshot.Identity != wantIdentity {
 		return errors.New("compact snapshot identity does not match its metadata")
 	}
@@ -409,7 +413,7 @@ func validateCompactCorrection(state CompactState) error {
 	if len(state.CorrectionAttempts) > 0 {
 		base, cumulative := state.InitialSnapshot.CandidateTree, 0
 		for _, attempt := range state.CorrectionAttempts {
-			if attempt.ProposedLines <= 0 || attempt.ActualLines < 0 || attempt.Snapshot.Kind != TargetFixDiff || attempt.Snapshot.BaseTree != base ||
+			if attempt.ProposedLines <= 0 || attempt.ActualLines < 0 || attempt.Snapshot.Kind != TargetFixDiff || attempt.Snapshot.Projection != state.InitialSnapshot.Projection || attempt.Snapshot.BaseTree != base ||
 				!equalStrings(attempt.Snapshot.LedgerIDs, state.FixFindingIDs) || pathsAreSubset(attempt.Snapshot.Paths, state.GenesisPaths) != nil ||
 				attempt.FixDeltaHash != FixDeltaHashForSnapshot(attempt.Snapshot) {
 				return errors.New("compact correction attempt is outside frozen scope")
@@ -626,8 +630,11 @@ func (state *CompactState) CompleteCorrection(snapshot Snapshot, actual int, val
 	if state.State != StateCorrectionRequired || state.ProposedCorrectionLines == nil {
 		return fmt.Errorf("cannot complete correction from compact state %q", state.State)
 	}
-	if snapshot.Kind != TargetFixDiff || snapshot.BaseTree != state.CurrentSnapshot.CandidateTree || !equalStrings(snapshot.LedgerIDs, state.FixFindingIDs) {
-		return errors.New("compact correction snapshot is not bound to the reviewed candidate and causal findings")
+	if snapshot.Kind != TargetFixDiff || snapshot.Projection != state.InitialSnapshot.Projection || snapshot.BaseTree != state.CurrentSnapshot.CandidateTree || !equalStrings(snapshot.LedgerIDs, state.FixFindingIDs) {
+		return errors.New("compact correction snapshot is not bound to the reviewed candidate, projection, and causal findings")
+	}
+	if snapshot.CandidateTree == snapshot.BaseTree {
+		return errors.New("compact correction has an unchanged candidate tree")
 	}
 	if err := pathsAreSubset(snapshot.Paths, state.GenesisPaths); err != nil {
 		return err
@@ -703,7 +710,8 @@ func (state CompactState) Receipt() (CompactReceipt, error) {
 	}
 	receipt := CompactReceipt{
 		Schema: CompactReceiptSchema, LineageID: state.LineageID, Generation: state.Generation,
-		BaseTree: state.InitialSnapshot.BaseTree, InitialReviewTree: state.InitialSnapshot.CandidateTree,
+		Projection: state.InitialSnapshot.Projection,
+		BaseTree:   state.InitialSnapshot.BaseTree, InitialReviewTree: state.InitialSnapshot.CandidateTree,
 		FinalCandidateTree: state.CurrentSnapshot.CandidateTree, PathsDigest: state.InitialSnapshot.PathsDigest,
 		FixDeltaHash: state.FixDeltaHash, PolicyHash: state.PolicyHash, EvidenceHash: evidence,
 		RiskLevel: state.RiskLevel, SelectedLenses: append([]string(nil), state.SelectedLenses...),
@@ -713,6 +721,10 @@ func (state CompactState) Receipt() (CompactReceipt, error) {
 }
 
 func (receipt CompactReceipt) Validate() error {
+	projection, err := canonicalProjection(receipt.Projection)
+	if err != nil || projection != receipt.Projection {
+		return errors.New("compact receipt projection is unsupported or non-canonical")
+	}
 	if receipt.Schema != CompactReceiptSchema || validateLineageID(receipt.LineageID) != nil || receipt.Generation < 1 {
 		return errors.New("invalid compact review receipt identity")
 	}

--- a/internal/reviewtransaction/compact_gate.go
+++ b/internal/reviewtransaction/compact_gate.go
@@ -159,7 +159,7 @@ func buildCompactGateRequest(ctx context.Context, repo string, state CompactStat
 		if intended == nil {
 			intended = append([]string(nil), state.CurrentSnapshot.IntendedUntracked...)
 		}
-		request.Target = Target{Kind: TargetCurrentChanges, IntendedUntracked: intended}
+		request.Target = Target{Kind: TargetCurrentChanges, Projection: state.InitialSnapshot.Projection, IntendedUntracked: intended}
 	case GatePrePush:
 		deliveryBaseTree := map[TargetKind]string{TargetCurrentChanges: state.InitialSnapshot.BaseTree}[state.InitialSnapshot.Kind]
 		target, push, err := buildPushTarget(ctx, repo, input.BaseRef, deliveryBaseTree)

--- a/internal/reviewtransaction/compact_gate_test.go
+++ b/internal/reviewtransaction/compact_gate_test.go
@@ -11,6 +11,80 @@ import (
 	"testing"
 )
 
+func TestLegacyCurrentChangesGateRejectsCallerProjectionMismatch(t *testing.T) {
+	for _, gate := range []GateKind{GatePostApply, GatePreCommit} {
+		t.Run(string(gate), func(t *testing.T) {
+			repo := initSnapshotRepo(t)
+			writeSnapshotFile(t, repo, "tracked.txt", "reviewed candidate\n")
+			transaction, receipt, request := nativeGateFixture(t, repo, "legacy-projection-mismatch-"+string(gate))
+			store, err := AuthoritativeStore(context.Background(), repo, transaction.LineageID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			appendApprovedStoreChain(t, store, transaction)
+			bindGateRequestToStore(t, &request, store)
+			request.Gate = gate
+			request.Target.Projection = ProjectionStaged
+
+			if got := EvaluateNativeGate(context.Background(), repo, receipt, request); got.Result != GateInvalidated || !strings.Contains(got.Reason, "projection") {
+				t.Fatalf("caller-selected projection = %#v", got)
+			}
+		})
+	}
+}
+
+func TestCompactStagedPreCommitBindsIndexDespiteWorkspaceDivergence(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	writeSnapshotFile(t, repo, "tracked.txt", "staged candidate\n")
+	gitSnapshot(t, repo, "add", "--", "tracked.txt")
+	state := newCompactStartStateForTarget(t, repo, "compact-staged-precommit", Target{Kind: TargetCurrentChanges, Projection: ProjectionStaged, IntendedUntracked: []string{}})
+	store, err := CompactAuthoritativeStore(context.Background(), repo, state.LineageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	revision, err := store.Replace("", "review/start", state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	results := make([]LensResult, len(state.SelectedLenses))
+	for index, lens := range state.SelectedLenses {
+		results[index] = LensResult{Lens: lens, Findings: []Finding{}, Evidence: []string{"reviewed"}}
+	}
+	if err := state.CompleteReview(CompactReviewInput{LensResults: results, Classifications: []FindingEvidence{}, RefuterOutcomes: []EvidenceResult{}}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Replace(revision, "review/complete-review", state); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.CompleteVerification([]byte("tests pass\n"), true); err != nil {
+		t.Fatal(err)
+	}
+	record, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Replace(record.Revision, "review/complete-verification", state); err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := state.Receipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("unstaged workspace divergence\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := EvaluateCompactGate(context.Background(), repo, receipt, NativeGateRequestInput{Gate: GatePreCommit, LineageID: state.LineageID}); got.Result != GateAllow {
+		t.Fatalf("matching staged index with divergent workspace = %#v", got)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("mutated index\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitSnapshot(t, repo, "add", "--", "tracked.txt")
+	if got := EvaluateCompactGate(context.Background(), repo, receipt, NativeGateRequestInput{Gate: GatePreCommit, LineageID: state.LineageID}); got.Result != GateScopeChanged {
+		t.Fatalf("mutated staged index = %#v, want scope changed", got)
+	}
+}
+
 func TestCompactPreCommitGatePreservesExactStagedIntendedTransition(t *testing.T) {
 	repo := initSnapshotRepo(t)
 	writeSnapshotFile(t, repo, "tracked.txt", "reviewed tracked change\n")

--- a/internal/reviewtransaction/compact_store.go
+++ b/internal/reviewtransaction/compact_store.go
@@ -106,6 +106,9 @@ func RecoverCompactAuthority(ctx context.Context, repo string, request CompactRe
 	if predecessor.Revision != request.ExpectedPredecessorRevision {
 		return CompactRecord{}, fmt.Errorf("%w: expected predecessor revision %q, current %q", ErrConcurrentUpdate, request.ExpectedPredecessorRevision, predecessor.Revision)
 	}
+	if predecessor.State.InitialSnapshot.Projection != request.Successor.InitialSnapshot.Projection {
+		return CompactRecord{}, errors.New("recovery successor must retain the predecessor projection")
+	}
 	existing, existingErr := successorStore.Load()
 	if existingErr != nil && !os.IsNotExist(existingErr) {
 		return CompactRecord{}, existingErr
@@ -461,7 +464,8 @@ func compactStartClaimsTarget(ctx context.Context, repo string, existing, reques
 // representations for the same base-to-candidate tree range.
 func compactStartDeliveryScopeMatches(existing, requested CompactState) bool {
 	original, live := existing.InitialSnapshot, requested.InitialSnapshot
-	return compactStartTargetKindsCompatible(original.Kind, live.Kind) &&
+	return original.Projection == live.Projection &&
+		compactStartTargetKindsCompatible(original.Kind, live.Kind) &&
 		live.BaseTree == original.BaseTree &&
 		live.PathsDigest == original.PathsDigest &&
 		equalStrings(live.Paths, existing.GenesisPaths) &&
@@ -493,8 +497,8 @@ func compactStartCorrectionCandidateMatches(ctx context.Context, repo string, ex
 		return false
 	}
 	fix, err := (SnapshotBuilder{Repo: repo}).Build(ctx, Target{Kind: TargetFixDiff,
-		BaseRef: existing.CurrentSnapshot.CandidateTree, IntendedUntracked: existing.InitialSnapshot.IntendedUntracked,
-		LedgerIDs: existing.FixFindingIDs})
+		Projection: existing.InitialSnapshot.Projection, BaseRef: existing.CurrentSnapshot.CandidateTree,
+		IntendedUntracked: existing.InitialSnapshot.IntendedUntracked, LedgerIDs: existing.FixFindingIDs})
 	if err != nil || fix.CandidateTree != requested.InitialSnapshot.CandidateTree || pathsAreSubset(fix.Paths, existing.GenesisPaths) != nil {
 		return false
 	}
@@ -506,6 +510,7 @@ func compactStartLiveTargetMatches(ctx context.Context, repo string, existing, r
 	live := requested.InitialSnapshot
 	if existing.Generation != requested.Generation || existing.PolicyHash != requested.PolicyHash ||
 		!reflect.DeepEqual(existing.Recovery, requested.Recovery) ||
+		existing.InitialSnapshot.Projection != live.Projection ||
 		!compactStartTargetKindsCompatible(existing.InitialSnapshot.Kind, live.Kind) ||
 		live.BaseTree != existing.InitialSnapshot.BaseTree ||
 		(requireCurrentCandidate && live.CandidateTree != existing.CurrentSnapshot.CandidateTree) ||

--- a/internal/reviewtransaction/compact_store_test.go
+++ b/internal/reviewtransaction/compact_store_test.go
@@ -74,6 +74,37 @@ func TestCompactStoreRecoverCreatesAuditableSuccessorWithoutChangingPredecessor(
 	}
 }
 
+func TestRecoverCompactAuthorityRejectsProjectionChange(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	writeSnapshotFile(t, repo, "tracked.txt", "candidate\n")
+	gitSnapshot(t, repo, "add", "--", "tracked.txt")
+	state, store, _ := approvedCompactCurrentChangesFixture(t, repo, "recovery-staged-projection", []string{})
+	state.InitialSnapshot.Projection = ProjectionStaged
+	state.CurrentSnapshot.Projection = ProjectionStaged
+	state.InitialSnapshot.Identity = snapshotIdentityForProjection(state.InitialSnapshot.Kind, state.InitialSnapshot.Projection, state.InitialSnapshot.BaseTree, state.InitialSnapshot.CandidateTree, state.InitialSnapshot.PathsDigest, state.InitialSnapshot.IntendedUntrackedProof, state.InitialSnapshot.IntendedUntracked, state.InitialSnapshot.LedgerIDs)
+	state.CurrentSnapshot.Identity = snapshotIdentityForProjection(state.CurrentSnapshot.Kind, state.CurrentSnapshot.Projection, state.CurrentSnapshot.BaseTree, state.CurrentSnapshot.CandidateTree, state.CurrentSnapshot.PathsDigest, state.CurrentSnapshot.IntendedUntrackedProof, state.CurrentSnapshot.IntendedUntracked, state.CurrentSnapshot.LedgerIDs)
+	record, payload, err := makeCompactRecord(state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(store.StatePath(), payload, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := state.Receipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteCompactReceiptAtomic(store.ReceiptPath(), receipt); err != nil {
+		t.Fatal(err)
+	}
+	writeSnapshotFile(t, repo, "tracked.txt", "new workspace scope\n")
+	successor := newCompactTestState(t, repo, "recovery-workspace-projection")
+	successor.Generation = state.Generation + 1
+	if _, err := RecoverCompactAuthority(context.Background(), repo, CompactRecoveryRequest{PredecessorLineageID: state.LineageID, ExpectedPredecessorRevision: record.Revision, Successor: successor, Disposition: RecoveryScopeChanged, Reason: "scope changed", Actor: "maintainer"}); err == nil || !strings.Contains(err.Error(), "projection") {
+		t.Fatalf("cross-projection recovery error = %v", err)
+	}
+}
+
 func TestApprovedRecoveryTreatsBaseTreeMismatchAsScopeChange(t *testing.T) {
 	snapshot := Snapshot{BaseTree: strings.Repeat("a", 40), CandidateTree: strings.Repeat("c", 40), PathsDigest: hash("1")}
 	predecessor, successor := CompactState{State: StateApproved, CurrentSnapshot: snapshot}, CompactState{InitialSnapshot: snapshot}
@@ -228,6 +259,145 @@ func TestStartCompactAuthorityBlocksSupersededApprovedPredecessor(t *testing.T) 
 	result, err := StartCompactAuthority(context.Background(), repo, CompactStartRequest{State: requested})
 	if err != nil || result.Action != CompactStartCreated || result.Record.State.LineageID != requested.LineageID {
 		t.Fatalf("start with superseded unrelated authority = %#v, %v", result, err)
+	}
+}
+
+func TestStartCompactAuthorityKeepsStagedAndWorkspaceAuthoritiesDistinct(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	writeSnapshotFile(t, repo, "tracked.txt", "candidate\n")
+	gitSnapshot(t, repo, "add", "--", "tracked.txt")
+
+	staged := newCompactStartStateForTarget(t, repo, "compact-start-staged", Target{Kind: TargetCurrentChanges, Projection: ProjectionStaged, IntendedUntracked: []string{}})
+	workspace := newCompactStartStateForTarget(t, repo, "compact-start-workspace", Target{Kind: TargetCurrentChanges, Projection: ProjectionWorkspace, IntendedUntracked: []string{}})
+	if staged.InitialSnapshot.CandidateTree != workspace.InitialSnapshot.CandidateTree || staged.InitialSnapshot.Identity == workspace.InitialSnapshot.Identity {
+		t.Fatalf("projection snapshots do not share tree with distinct identity: staged=%#v workspace=%#v", staged.InitialSnapshot, workspace.InitialSnapshot)
+	}
+	storeCompactStartAuthority(t, repo, staged)
+
+	created, err := StartCompactAuthority(context.Background(), repo, CompactStartRequest{State: workspace})
+	if err != nil || created.Action != CompactStartCreated || created.Record.State.LineageID != workspace.LineageID {
+		t.Fatalf("workspace start against staged authority = %#v, %v", created, err)
+	}
+	replayed, err := StartCompactAuthority(context.Background(), repo, CompactStartRequest{State: staged})
+	if err != nil || replayed.Action != CompactStartResumed || replayed.Record.State.LineageID != staged.LineageID {
+		t.Fatalf("staged replay = %#v, %v", replayed, err)
+	}
+}
+
+func TestStartCompactAuthoritySelectsProjectionSpecificBaseDiffAuthorityAfterCommit(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	base := strings.TrimSpace(gitSnapshot(t, repo, "rev-parse", "HEAD"))
+	writeSnapshotFile(t, repo, "tracked.txt", "candidate\n")
+	gitSnapshot(t, repo, "add", "--", "tracked.txt")
+
+	staged := newCompactStartStateForTarget(t, repo, "compact-start-staged-base", Target{Kind: TargetCurrentChanges, Projection: ProjectionStaged, IntendedUntracked: []string{}})
+	workspace := newCompactStartStateForTarget(t, repo, "compact-start-workspace-base", Target{Kind: TargetCurrentChanges, Projection: ProjectionWorkspace, IntendedUntracked: []string{}})
+	if staged.InitialSnapshot.CandidateTree != workspace.InitialSnapshot.CandidateTree {
+		t.Fatalf("same candidate tree required for projection selection: staged=%s workspace=%s", staged.InitialSnapshot.CandidateTree, workspace.InitialSnapshot.CandidateTree)
+	}
+	storeCompactStartAuthority(t, repo, staged)
+	storeCompactStartAuthority(t, repo, workspace)
+	gitSnapshot(t, repo, "commit", "-m", "deliver candidate")
+
+	for _, tt := range []struct {
+		name       string
+		projection Projection
+		want       string
+	}{
+		{name: "staged", projection: ProjectionStaged, want: staged.LineageID},
+		{name: "workspace", projection: ProjectionWorkspace, want: workspace.LineageID},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			requested := newCompactStartStateForTarget(t, repo, "compact-start-"+tt.name+"-base-request", Target{Kind: TargetBaseDiff, Projection: tt.projection, BaseRef: base, IntendedUntracked: []string{}})
+			result, err := StartCompactAuthority(context.Background(), repo, CompactStartRequest{State: requested})
+			if err != nil || result.Action != CompactStartResumed || result.Record.State.LineageID != tt.want {
+				t.Fatalf("%s base-diff authority selection = %#v, %v", tt.name, result, err)
+			}
+		})
+	}
+}
+
+func TestCompactStagedCorrectionAcceptsIndexFixDespiteWorkspaceDivergence(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	writeSnapshotFile(t, repo, "tracked.txt", "base\none\ntwo\nthree\nwrong\n")
+	gitSnapshot(t, repo, "add", "--", "tracked.txt")
+	state := newCompactStartStateForTarget(t, repo, "compact-staged-correction-accept", Target{Kind: TargetCurrentChanges, Projection: ProjectionStaged, IntendedUntracked: []string{}})
+	finding := Finding{ID: "R3-001", Lens: strings.TrimPrefix(state.SelectedLenses[0], "review-"), Location: "tracked.txt:5", Severity: "CRITICAL", Claim: "wrong staged value", ProofRefs: []string{"candidate-only failure"}}
+	results := make([]LensResult, len(state.SelectedLenses))
+	for index, lens := range state.SelectedLenses {
+		results[index] = LensResult{Lens: lens, Findings: []Finding{}, Evidence: []string{"reviewed"}}
+	}
+	results[0].Findings = []Finding{finding}
+	if err := state.CompleteReview(CompactReviewInput{LensResults: results, Classifications: []FindingEvidence{{FindingID: finding.ID, Class: EvidenceDeterministic, Causality: CausalIntroduced, Proof: "changed hunk"}}, RefuterOutcomes: []EvidenceResult{}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.BeginCorrection(2); err != nil {
+		t.Fatal(err)
+	}
+	writeSnapshotFile(t, repo, "tracked.txt", "base\none\ntwo\nthree\nfixed\n")
+	gitSnapshot(t, repo, "add", "--", "tracked.txt")
+	writeSnapshotFile(t, repo, "tracked.txt", "unstaged workspace divergence\n")
+
+	fix, err := (SnapshotBuilder{Repo: repo}).Build(context.Background(), Target{Kind: TargetFixDiff, Projection: ProjectionStaged, BaseRef: state.CurrentSnapshot.CandidateTree, IntendedUntracked: []string{}, LedgerIDs: state.FixFindingIDs})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := gitSnapshot(t, repo, "show", fix.CandidateTree+":tracked.txt"); got != "base\none\ntwo\nthree\nfixed\n" {
+		t.Fatalf("staged correction candidate = %q", got)
+	}
+	fixHash := FixDeltaHashForSnapshot(fix)
+	validation := ScopedValidationResult{LedgerIDs: state.FixFindingIDs, FixCausedFindings: []Finding{}, FollowUps: []FollowUp{}, OriginalCriteria: ValidationCheck{Passed: true, EvidenceHash: hash("2"), FixDeltaHash: fixHash}, CorrectionRegression: ValidationCheck{Passed: true, EvidenceHash: hash("3"), FixDeltaHash: fixHash}}
+	if err := state.CompleteCorrection(fix, 2, validation); err != nil {
+		t.Fatalf("CompleteCorrection(staged fix) error = %v", err)
+	}
+	if state.State != StateValidating {
+		t.Fatalf("staged correction state = %#v", state)
+	}
+}
+
+func TestCompactStagedCorrectionRejectsWorkspaceSnapshotWithoutMutatingState(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	writeSnapshotFile(t, repo, "tracked.txt", "base\nwrong\n")
+	gitSnapshot(t, repo, "add", "--", "tracked.txt")
+	state := newCompactStartStateForTarget(t, repo, "compact-staged-correction", Target{Kind: TargetCurrentChanges, Projection: ProjectionStaged, IntendedUntracked: []string{}})
+	finding := Finding{ID: "R3-001", Lens: strings.TrimPrefix(state.SelectedLenses[0], "review-"), Location: "tracked.txt:2", Severity: "CRITICAL", Claim: "wrong staged value", ProofRefs: []string{"candidate-only failure"}}
+	results := make([]LensResult, len(state.SelectedLenses))
+	for index, lens := range state.SelectedLenses {
+		results[index] = LensResult{Lens: lens, Findings: []Finding{}, Evidence: []string{"reviewed"}}
+	}
+	results[0].Findings = []Finding{finding}
+	if err := state.CompleteReview(CompactReviewInput{LensResults: results, Classifications: []FindingEvidence{{FindingID: finding.ID, Class: EvidenceDeterministic, Causality: CausalIntroduced, Proof: "changed hunk"}}, RefuterOutcomes: []EvidenceResult{}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.BeginCorrection(1); err != nil {
+		t.Fatal(err)
+	}
+	before := state
+	writeSnapshotFile(t, repo, "tracked.txt", "base\nfixed\n")
+	workspaceFix, err := (SnapshotBuilder{Repo: repo}).Build(context.Background(), Target{Kind: TargetFixDiff, BaseRef: state.CurrentSnapshot.CandidateTree, IntendedUntracked: []string{}, LedgerIDs: state.FixFindingIDs})
+	if err != nil {
+		t.Fatal(err)
+	}
+	fixHash := FixDeltaHashForSnapshot(workspaceFix)
+	validation := ScopedValidationResult{LedgerIDs: state.FixFindingIDs, FixCausedFindings: []Finding{}, FollowUps: []FollowUp{}, OriginalCriteria: ValidationCheck{Passed: true, EvidenceHash: hash("2"), FixDeltaHash: fixHash}, CorrectionRegression: ValidationCheck{Passed: true, EvidenceHash: hash("3"), FixDeltaHash: fixHash}}
+	if err := state.CompleteCorrection(workspaceFix, 1, validation); err == nil || !strings.Contains(err.Error(), "projection") {
+		t.Fatalf("workspace correction error = %v", err)
+	}
+	if !reflect.DeepEqual(state, before) {
+		t.Fatalf("rejected workspace correction mutated staged state:\nbefore=%#v\nafter=%#v", before, state)
+	}
+
+	stagedFix, err := (SnapshotBuilder{Repo: repo}).Build(context.Background(), Target{Kind: TargetFixDiff, Projection: ProjectionStaged, BaseRef: state.CurrentSnapshot.CandidateTree, IntendedUntracked: []string{}, LedgerIDs: state.FixFindingIDs})
+	if err != nil {
+		t.Fatal(err)
+	}
+	fixHash = FixDeltaHashForSnapshot(stagedFix)
+	validation.OriginalCriteria.FixDeltaHash, validation.CorrectionRegression.FixDeltaHash = fixHash, fixHash
+	if err := state.CompleteCorrection(stagedFix, 0, validation); err == nil || !strings.Contains(err.Error(), "unchanged candidate") {
+		t.Fatalf("unchanged staged correction error = %v", err)
+	}
+	if !reflect.DeepEqual(state, before) {
+		t.Fatalf("rejected unchanged staged correction mutated state:\nbefore=%#v\nafter=%#v", before, state)
 	}
 }
 
@@ -654,6 +824,13 @@ func TestCompactZeroLineFailuresReachAttemptCap(t *testing.T) {
 		if err := state.BeginCorrection(1); err != nil {
 			t.Fatal(err)
 		}
+		mode := os.FileMode(0o755)
+		if attempt%2 != 0 {
+			mode = 0o644
+		}
+		if err := os.Chmod(filepath.Join(repo, "tracked.txt"), mode); err != nil {
+			t.Fatal(err)
+		}
 		fix, err := (SnapshotBuilder{Repo: repo}).Build(context.Background(), Target{Kind: TargetFixDiff, BaseRef: state.CurrentSnapshot.CandidateTree, IntendedUntracked: state.InitialSnapshot.IntendedUntracked, LedgerIDs: state.FixFindingIDs})
 		if err != nil {
 			t.Fatal(err)
@@ -994,6 +1171,76 @@ func TestCompactTransportRoundTripRecoversEquivalentCurrentAuthority(t *testing.
 	}
 	if _, err := os.Stat(filepath.Join(destinationStore.Dir, "events")); !os.IsNotExist(err) {
 		t.Fatalf("compact import reconstructed event history: %v", err)
+	}
+}
+
+func TestCompactStagedTransportRoundTripRejectsProjectionTampering(t *testing.T) {
+	source := initSnapshotRepo(t)
+	writeSnapshotFile(t, source, "tracked.txt", "staged candidate\n")
+	gitSnapshot(t, source, "add", "--", "tracked.txt")
+	state := newCompactStartStateForTarget(t, source, "compact-staged-transport", Target{Kind: TargetCurrentChanges, Projection: ProjectionStaged, IntendedUntracked: []string{}})
+	store, err := CompactAuthoritativeStore(context.Background(), source, state.LineageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	revision, err := store.Replace("", "review/start", state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	results := make([]LensResult, len(state.SelectedLenses))
+	for index, lens := range state.SelectedLenses {
+		results[index] = LensResult{Lens: lens, Findings: []Finding{}, Evidence: []string{"reviewed"}}
+	}
+	if err := state.CompleteReview(CompactReviewInput{LensResults: results, Classifications: []FindingEvidence{}, RefuterOutcomes: []EvidenceResult{}}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Replace(revision, "review/complete-review", state); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.CompleteVerification([]byte("tests pass\n"), true); err != nil {
+		t.Fatal(err)
+	}
+	record, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Replace(record.Revision, "review/complete-verification", state); err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := state.Receipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if receipt.Projection != ProjectionStaged {
+		t.Fatalf("staged receipt projection = %q", receipt.Projection)
+	}
+	if err := WriteCompactReceiptAtomic(store.ReceiptPath(), receipt); err != nil {
+		t.Fatal(err)
+	}
+	gitSnapshot(t, source, "commit", "-qm", "staged candidate")
+	transport, err := store.ExportTransport()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if transport.Record.State.InitialSnapshot.Projection != ProjectionStaged || transport.Receipt == nil || transport.Receipt.Projection != ProjectionStaged {
+		t.Fatalf("staged transport = %#v", transport)
+	}
+	clone := filepath.Join(t.TempDir(), "clone")
+	gitSnapshot(t, source, "clone", "--no-local", source, clone)
+	if _, err := ImportCompactTransport(context.Background(), clone, transport); err != nil {
+		t.Fatal(err)
+	}
+	tampered := transport
+	tamperedReceipt := *transport.Receipt
+	tamperedReceipt.Projection = ProjectionWorkspace
+	tampered.Receipt = &tamperedReceipt
+	tampered.BundleDigest = compactTransportDigest(tampered)
+	payload, err := json.Marshal(tampered)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ParseCompactTransport(payload); err == nil || !strings.Contains(err.Error(), "receipt does not match state") {
+		t.Fatalf("projection-tampered transport error = %v", err)
 	}
 }
 

--- a/internal/reviewtransaction/gate.go
+++ b/internal/reviewtransaction/gate.go
@@ -176,6 +176,13 @@ func EvaluateNativeGate(ctx context.Context, repo string, receipt Receipt, reque
 	if !reflect.DeepEqual(authoritativeReceipt, receipt) {
 		return invalid("receipt does not match the authoritative transaction revision")
 	}
+	if request.Gate == GatePostApply || request.Gate == GatePreCommit {
+		requestedProjection, requestErr := canonicalProjection(request.Target.Projection)
+		authoritativeProjection, authorityErr := canonicalProjection(record.Transaction.Snapshot.Projection)
+		if requestErr != nil || authorityErr != nil || requestedProjection != authoritativeProjection {
+			return invalid("current repository target projection does not match the authoritative transaction snapshot")
+		}
+	}
 	denialContext := GateContext{
 		Gate: request.Gate, LineageID: record.Transaction.LineageID, Generation: record.Transaction.Generation,
 		StoreRevision: revision, GenesisRevision: chain.GenesisRevision, ChainIdentity: chain.Identity, BundleDigest: bundleDigest,
@@ -723,7 +730,7 @@ func lifecycleTargetForGate(ctx context.Context, repo string, request GateReques
 		if intended == nil {
 			intended = []string{}
 		}
-		return Target{Kind: TargetCurrentChanges, IntendedUntracked: intended}, nil
+		return Target{Kind: TargetCurrentChanges, Projection: request.Target.Projection, IntendedUntracked: intended}, nil
 	case GatePrePush:
 		head, err := runGit(ctx, repo, nil, nil, "rev-parse", "HEAD")
 		if err != nil {

--- a/internal/reviewtransaction/snapshot.go
+++ b/internal/reviewtransaction/snapshot.go
@@ -18,15 +18,21 @@ import (
 
 type TargetKind string
 
+type Projection string
+
 const (
 	TargetCurrentChanges TargetKind = "current-changes"
 	TargetBaseDiff       TargetKind = "base-diff"
 	TargetExactRevision  TargetKind = "commit-range"
 	TargetFixDiff        TargetKind = "fix-diff"
+
+	ProjectionWorkspace Projection = "workspace"
+	ProjectionStaged    Projection = "staged"
 )
 
 type Target struct {
 	Kind              TargetKind `json:"kind"`
+	Projection        Projection `json:"projection,omitempty"`
 	BaseRef           string     `json:"base_ref,omitempty"`
 	Revision          string     `json:"revision,omitempty"`
 	IntendedUntracked []string   `json:"intended_untracked"`
@@ -35,6 +41,7 @@ type Target struct {
 
 type Snapshot struct {
 	Kind                   TargetKind `json:"kind"`
+	Projection             Projection `json:"projection,omitempty"`
 	BaseTree               string     `json:"base_tree"`
 	CandidateTree          string     `json:"candidate_tree"`
 	PathsDigest            string     `json:"paths_digest"`
@@ -62,6 +69,14 @@ func (builder SnapshotBuilder) build(ctx context.Context, target Target, allowSt
 	}
 	builder.Repo = repo
 
+	projection, err := canonicalProjection(target.Projection)
+	if err != nil {
+		return Snapshot{}, err
+	}
+	if projection == ProjectionStaged && target.Kind != TargetCurrentChanges && target.Kind != TargetBaseDiff && target.Kind != TargetFixDiff {
+		return Snapshot{}, errors.New("staged projection is only supported for current-changes, base-diff, and fix-diff targets")
+	}
+
 	var baseTree, candidateTree, untrackedProof string
 	intended := []string{}
 	ledgerIDs, err := canonicalStrings(target.LedgerIDs, "ledger id")
@@ -78,7 +93,10 @@ func (builder SnapshotBuilder) build(ctx context.Context, target Target, allowSt
 		if err != nil {
 			return Snapshot{}, err
 		}
-		baseTree, candidateTree, untrackedProof, err = builder.buildCurrentChanges(ctx, intended, allowStagedIntended)
+		if projection == ProjectionStaged && len(intended) != 0 {
+			return Snapshot{}, errors.New("staged projection does not accept intended-untracked paths")
+		}
+		baseTree, candidateTree, untrackedProof, err = builder.buildCurrentChanges(ctx, intended, allowStagedIntended, projection)
 	case TargetBaseDiff:
 		if strings.TrimSpace(target.BaseRef) == "" {
 			return Snapshot{}, errors.New("base-diff requires base_ref")
@@ -90,8 +108,16 @@ func (builder SnapshotBuilder) build(ctx context.Context, target Target, allowSt
 		if err != nil {
 			return Snapshot{}, err
 		}
+		if projection == ProjectionStaged && len(intended) != 0 {
+			return Snapshot{}, errors.New("staged projection does not accept intended-untracked paths")
+		}
 		baseTree, err = builder.resolveTree(ctx, target.BaseRef)
-		if err == nil {
+		if err == nil && projection == ProjectionStaged {
+			candidateTree, err = builder.resolveTree(ctx, "HEAD")
+			if err == nil {
+				untrackedProof, err = builder.untrackedProof(ctx, candidateTree, intended)
+			}
+		} else if err == nil {
 			candidateTree, untrackedProof, err = builder.buildHeadWithIntended(ctx, intended)
 		}
 	case TargetExactRevision:
@@ -108,7 +134,10 @@ func (builder SnapshotBuilder) build(ctx context.Context, target Target, allowSt
 		if err != nil {
 			return Snapshot{}, err
 		}
-		_, candidateTree, untrackedProof, err = builder.buildCurrentChanges(ctx, intended, false)
+		if projection == ProjectionStaged && len(intended) != 0 {
+			return Snapshot{}, errors.New("staged projection does not accept intended-untracked paths")
+		}
+		_, candidateTree, untrackedProof, err = builder.buildCurrentChanges(ctx, intended, false, projection)
 		if err == nil {
 			baseTree, err = builder.resolveTree(ctx, target.BaseRef)
 		}
@@ -124,9 +153,9 @@ func (builder SnapshotBuilder) build(ctx context.Context, target Target, allowSt
 		return Snapshot{}, err
 	}
 	pathsDigest := digestPaths(paths)
-	identity := snapshotIdentity(target.Kind, baseTree, candidateTree, pathsDigest, untrackedProof, intended, ledgerIDs)
+	identity := snapshotIdentityForProjection(target.Kind, projection, baseTree, candidateTree, pathsDigest, untrackedProof, intended, ledgerIDs)
 	return Snapshot{
-		Kind: target.Kind, BaseTree: baseTree, CandidateTree: candidateTree,
+		Kind: target.Kind, Projection: projection, BaseTree: baseTree, CandidateTree: candidateTree,
 		PathsDigest: pathsDigest, IntendedUntracked: intended,
 		IntendedUntrackedProof: untrackedProof, LedgerIDs: ledgerIDs,
 		Paths: paths, Identity: identity,
@@ -197,7 +226,11 @@ func (builder SnapshotBuilder) ValidateEvidence(ctx context.Context, snapshot Sn
 		return err
 	}
 	digest := digestPaths(paths)
-	identity := snapshotIdentity(snapshot.Kind, snapshot.BaseTree, snapshot.CandidateTree, digest, proof, snapshot.IntendedUntracked, snapshot.LedgerIDs)
+	projection, err := canonicalProjection(snapshot.Projection)
+	if err != nil {
+		return err
+	}
+	identity := snapshotIdentityForProjection(snapshot.Kind, projection, snapshot.BaseTree, snapshot.CandidateTree, digest, proof, snapshot.IntendedUntracked, snapshot.LedgerIDs)
 	if !equalStrings(paths, snapshot.Paths) || digest != snapshot.PathsDigest || proof != snapshot.IntendedUntrackedProof || identity != snapshot.Identity {
 		return errors.New("snapshot paths, digests, or identity do not match Git tree evidence")
 	}
@@ -208,7 +241,7 @@ func rebuildCurrentSnapshotEvidence(ctx context.Context, repo string, snapshot S
 	if strings.TrimSpace(repo) == "" {
 		return errors.New("repository evidence is required for invalidation")
 	}
-	target := Target{Kind: snapshot.Kind, IntendedUntracked: append([]string(nil), snapshot.IntendedUntracked...)}
+	target := Target{Kind: snapshot.Kind, Projection: snapshot.Projection, IntendedUntracked: append([]string(nil), snapshot.IntendedUntracked...)}
 	if target.IntendedUntracked == nil {
 		target.IntendedUntracked = []string{}
 	}
@@ -369,7 +402,7 @@ func canonicalRepositoryPath(path string) (string, error) {
 	return filepath.Clean(resolved), nil
 }
 
-func (builder SnapshotBuilder) buildCurrentChanges(ctx context.Context, intended []string, allowStagedIntended bool) (string, string, string, error) {
+func (builder SnapshotBuilder) buildCurrentChanges(ctx context.Context, intended []string, allowStagedIntended bool, projection Projection) (string, string, string, error) {
 	baseTree, err := builder.resolveTree(ctx, "HEAD")
 	if err != nil {
 		return "", "", "", err
@@ -426,13 +459,15 @@ func (builder SnapshotBuilder) buildCurrentChanges(ctx context.Context, intended
 		return "", "", "", err
 	}
 	env := []string{"GIT_INDEX_FILE=" + tempIndex}
-	if _, err := runGit(ctx, builder.Repo, env, nil, "add", "-u", "--", "."); err != nil {
-		return "", "", "", err
-	}
-	if len(intended) > 0 {
-		args := append([]string{"add", "--"}, literalPathspecs(intended)...)
-		if _, err := runGit(ctx, builder.Repo, env, nil, args...); err != nil {
+	if projection != ProjectionStaged {
+		if _, err := runGit(ctx, builder.Repo, env, nil, "add", "-u", "--", "."); err != nil {
 			return "", "", "", err
+		}
+		if len(intended) > 0 {
+			args := append([]string{"add", "--"}, literalPathspecs(intended)...)
+			if _, err := runGit(ctx, builder.Repo, env, nil, args...); err != nil {
+				return "", "", "", err
+			}
 		}
 	}
 	candidateOutput, err := runGit(ctx, builder.Repo, env, nil, "write-tree")
@@ -440,7 +475,7 @@ func (builder SnapshotBuilder) buildCurrentChanges(ctx context.Context, intended
 		return "", "", "", err
 	}
 	candidateTree := strings.TrimSpace(string(candidateOutput))
-	if allowStagedIntended {
+	if allowStagedIntended && projection != ProjectionStaged {
 		if _, err := runGit(ctx, builder.Repo, nil, nil, "diff", "--cached", "--quiet", candidateTree, "--"); err != nil {
 			return "", "", "", errors.New("staged tree does not exactly match the complete reviewed candidate")
 		}
@@ -637,10 +672,33 @@ func digestPaths(paths []string) string {
 	return "sha256:" + hex.EncodeToString(hash.Sum(nil))
 }
 
+func canonicalProjection(projection Projection) (Projection, error) {
+	switch projection {
+	case "", ProjectionWorkspace:
+		return "", nil
+	case ProjectionStaged:
+		return ProjectionStaged, nil
+	default:
+		return "", fmt.Errorf("unsupported projection %q", projection)
+	}
+}
+
 func snapshotIdentity(kind TargetKind, baseTree, candidateTree, pathsDigest, proof string, intended, ledgerIDs []string) string {
+	return snapshotIdentityForProjection(kind, "", baseTree, candidateTree, pathsDigest, proof, intended, ledgerIDs)
+}
+
+func snapshotIdentityForProjection(kind TargetKind, projection Projection, baseTree, candidateTree, pathsDigest, proof string, intended, ledgerIDs []string) string {
 	hash := sha256.New()
-	hash.Write([]byte("gentle-ai.review-snapshot/v1\x00"))
-	for _, value := range []string{string(kind), baseTree, candidateTree, pathsDigest, proof} {
+	if projection == ProjectionStaged {
+		hash.Write([]byte("gentle-ai.review-snapshot/v2\x00"))
+	} else {
+		hash.Write([]byte("gentle-ai.review-snapshot/v1\x00"))
+	}
+	values := []string{string(kind), baseTree, candidateTree, pathsDigest, proof}
+	if projection == ProjectionStaged {
+		values = []string{string(kind), string(projection), baseTree, candidateTree, pathsDigest, proof}
+	}
+	for _, value := range values {
 		writeLengthPrefixed(hash, []byte(value))
 	}
 	for _, value := range intended {

--- a/internal/reviewtransaction/snapshot_test.go
+++ b/internal/reviewtransaction/snapshot_test.go
@@ -90,6 +90,152 @@ func TestSnapshotBuilderCurrentChangesIsCompleteAndPreservesRealIndex(t *testing
 	}
 }
 
+func TestSnapshotBuilderStagedProjectionUsesExactIndexAndPreservesWorkspace(t *testing.T) {
+	requireSnapshotGit(t)
+	repo := initSnapshotRepo(t)
+	writeSnapshotFile(t, repo, "tracked.txt", "staged\n")
+	writeSnapshotFile(t, repo, "added.txt", "added\n")
+	gitSnapshot(t, repo, "add", "--", "tracked.txt", "added.txt")
+	writeSnapshotFile(t, repo, "tracked.txt", "unstaged\n")
+	writeSnapshotFile(t, repo, "untracked.txt", "untracked\n")
+
+	beforeIndex := gitSnapshot(t, repo, "diff", "--cached", "--binary")
+	snapshot, err := (SnapshotBuilder{Repo: repo}).Build(context.Background(), Target{
+		Kind: TargetCurrentChanges, Projection: ProjectionStaged, IntendedUntracked: []string{},
+	})
+	if err != nil {
+		t.Fatalf("Build(staged) error = %v", err)
+	}
+	if snapshot.Projection != ProjectionStaged {
+		t.Fatalf("Projection = %q, want %q", snapshot.Projection, ProjectionStaged)
+	}
+	if got := gitSnapshot(t, repo, "show", snapshot.CandidateTree+":tracked.txt"); got != "staged\n" {
+		t.Fatalf("staged candidate tracked.txt = %q", got)
+	}
+	if got := gitSnapshot(t, repo, "show", snapshot.CandidateTree+":added.txt"); got != "added\n" {
+		t.Fatalf("staged candidate added.txt = %q", got)
+	}
+	if gitSnapshotSucceeds(repo, "show", snapshot.CandidateTree+":untracked.txt") {
+		t.Fatal("staged candidate included an untracked worktree path")
+	}
+	if afterIndex := gitSnapshot(t, repo, "diff", "--cached", "--binary"); afterIndex != beforeIndex {
+		t.Fatalf("staged snapshot mutated index:\nbefore:\n%s\nafter:\n%s", beforeIndex, afterIndex)
+	}
+	if got, err := os.ReadFile(filepath.Join(repo, "tracked.txt")); err != nil || string(got) != "unstaged\n" {
+		t.Fatalf("staged snapshot mutated worktree: %q, %v", got, err)
+	}
+	if err := (SnapshotBuilder{Repo: repo}).ValidateEvidence(context.Background(), snapshot); err != nil {
+		t.Fatalf("ValidateEvidence(staged) error = %v", err)
+	}
+}
+
+func TestSnapshotBuilderStagedProjectionPreservesExactIndexFidelity(t *testing.T) {
+	requireSnapshotGit(t)
+	repo := initSnapshotRepo(t)
+	writeSnapshotFile(t, repo, "tracked.txt", "one\ntwo\nthree\nfour\nfive\n")
+	writeSnapshotFile(t, repo, "rename-old.txt", "rename me\n")
+	writeSnapshotFile(t, repo, "mode.txt", "mode me\n")
+	gitSnapshot(t, repo, "add", "--", "tracked.txt", "rename-old.txt", "mode.txt")
+	gitSnapshot(t, repo, "commit", "-m", "fidelity baseline")
+
+	writeSnapshotFile(t, repo, "tracked.txt", "ONE\ntwo\nthree\nfour\nFIVE\n")
+	patch := filepath.Join(t.TempDir(), "partial.patch")
+	if err := os.WriteFile(patch, []byte("diff --git a/tracked.txt b/tracked.txt\nindex b2f931a..b3c5a95 100644\n--- a/tracked.txt\n+++ b/tracked.txt\n@@ -1,4 +1,4 @@\n-one\n+ONE\n two\n three\n four\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	gitSnapshot(t, repo, "apply", "--cached", patch)
+	writeSnapshotFile(t, repo, "added.txt", "added\n")
+	gitSnapshot(t, repo, "add", "--", "added.txt")
+	if err := os.Remove(filepath.Join(repo, "deleted.txt")); err != nil {
+		t.Fatal(err)
+	}
+	gitSnapshot(t, repo, "add", "-u", "--", "deleted.txt")
+	if err := os.Rename(filepath.Join(repo, "rename-old.txt"), filepath.Join(repo, "renamed.txt")); err != nil {
+		t.Fatal(err)
+	}
+	gitSnapshot(t, repo, "add", "-A", "--", "rename-old.txt", "renamed.txt")
+	if err := os.Chmod(filepath.Join(repo, "mode.txt"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	gitSnapshot(t, repo, "add", "--", "mode.txt")
+	if err := os.Symlink("tracked.txt", filepath.Join(repo, "link.txt")); err != nil {
+		t.Fatal(err)
+	}
+	gitSnapshot(t, repo, "add", "--", "link.txt")
+	writeSnapshotFile(t, repo, "untracked.txt", "ignore me\n")
+
+	beforeIndex := gitSnapshot(t, repo, "diff", "--cached", "--binary")
+	indexTree := strings.TrimSpace(gitSnapshot(t, repo, "write-tree"))
+	snapshot, err := (SnapshotBuilder{Repo: repo}).Build(context.Background(), Target{Kind: TargetCurrentChanges, Projection: ProjectionStaged, IntendedUntracked: []string{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if snapshot.CandidateTree != indexTree {
+		t.Fatalf("staged candidate tree = %s, want exact index %s", snapshot.CandidateTree, indexTree)
+	}
+	if got := gitSnapshot(t, repo, "show", snapshot.CandidateTree+":tracked.txt"); got != "ONE\ntwo\nthree\nfour\nfive\n" {
+		t.Fatalf("partial staged hunk = %q", got)
+	}
+	if !gitSnapshotSucceeds(repo, "cat-file", "-e", snapshot.CandidateTree+":added.txt") || gitSnapshotSucceeds(repo, "cat-file", "-e", snapshot.CandidateTree+":deleted.txt") || !gitSnapshotSucceeds(repo, "cat-file", "-e", snapshot.CandidateTree+":renamed.txt") || gitSnapshotSucceeds(repo, "cat-file", "-e", snapshot.CandidateTree+":rename-old.txt") {
+		t.Fatal("staged candidate does not retain add/delete/rename index entries")
+	}
+	if got := gitSnapshot(t, repo, "ls-tree", snapshot.CandidateTree, "mode.txt"); !strings.HasPrefix(got, "100755 ") {
+		t.Fatalf("staged mode entry = %q", got)
+	}
+	if got := gitSnapshot(t, repo, "ls-tree", snapshot.CandidateTree, "link.txt"); !strings.HasPrefix(got, "120000 ") {
+		t.Fatalf("staged symlink entry = %q", got)
+	}
+	if gitSnapshotSucceeds(repo, "cat-file", "-e", snapshot.CandidateTree+":untracked.txt") {
+		t.Fatal("staged candidate included untracked worktree content")
+	}
+	if afterIndex := gitSnapshot(t, repo, "diff", "--cached", "--binary"); afterIndex != beforeIndex {
+		t.Fatal("building staged projection mutated the real index")
+	}
+}
+
+func TestSnapshotProjectionValidationAndIdentity(t *testing.T) {
+	requireSnapshotGit(t)
+	repo := initSnapshotRepo(t)
+	writeSnapshotFile(t, repo, "tracked.txt", "changed\n")
+	gitSnapshot(t, repo, "add", "--", "tracked.txt")
+	builder := SnapshotBuilder{Repo: repo}
+
+	workspace, err := builder.Build(context.Background(), Target{Kind: TargetCurrentChanges, IntendedUntracked: []string{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	explicitWorkspace, err := builder.Build(context.Background(), Target{Kind: TargetCurrentChanges, Projection: ProjectionWorkspace, IntendedUntracked: []string{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(workspace, explicitWorkspace) || workspace.Projection != "" {
+		t.Fatalf("explicit workspace changed legacy identity:\nimplicit=%#v\nexplicit=%#v", workspace, explicitWorkspace)
+	}
+	staged, err := builder.Build(context.Background(), Target{Kind: TargetCurrentChanges, Projection: ProjectionStaged, IntendedUntracked: []string{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if staged.CandidateTree != workspace.CandidateTree || staged.Identity == workspace.Identity {
+		t.Fatalf("projection identity was not domain-separated: workspace=%#v staged=%#v", workspace, staged)
+	}
+	if _, err := builder.Build(context.Background(), Target{Kind: TargetCurrentChanges, Projection: Projection("future"), IntendedUntracked: []string{}}); err == nil || !strings.Contains(err.Error(), "unsupported projection") {
+		t.Fatalf("unknown projection error = %v", err)
+	}
+	stagedBaseDiff, err := builder.Build(context.Background(), Target{Kind: TargetBaseDiff, Projection: ProjectionStaged, BaseRef: "HEAD", IntendedUntracked: []string{}})
+	if err != nil || stagedBaseDiff.Projection != ProjectionStaged || stagedBaseDiff.CandidateTree != strings.TrimSpace(gitSnapshot(t, repo, "rev-parse", "HEAD^{tree}")) {
+		t.Fatalf("staged base-diff snapshot = %#v, err=%v", stagedBaseDiff, err)
+	}
+	if _, err := builder.Build(context.Background(), Target{Kind: TargetBaseDiff, Projection: ProjectionStaged, BaseRef: "HEAD", IntendedUntracked: []string{"untracked.txt"}}); err == nil || !strings.Contains(err.Error(), "does not accept intended-untracked") {
+		t.Fatalf("staged base-diff intended-untracked error = %v", err)
+	}
+	if _, err := builder.Build(context.Background(), Target{Kind: TargetExactRevision, Projection: ProjectionStaged, Revision: "HEAD", IntendedUntracked: []string{}}); err == nil || !strings.Contains(err.Error(), "only supported") {
+		t.Fatalf("staged exact-revision/release error = %v", err)
+	}
+	if _, err := builder.Build(context.Background(), Target{Kind: TargetCurrentChanges, Projection: ProjectionStaged, IntendedUntracked: []string{"untracked.txt"}}); err == nil || !strings.Contains(err.Error(), "does not accept intended-untracked") {
+		t.Fatalf("staged intended-untracked error = %v", err)
+	}
+}
+
 func TestPreCommitSnapshotAllowsOnlyCompleteStagedIntendedTransition(t *testing.T) {
 	requireSnapshotGit(t)
 	repo := initSnapshotRepo(t)

--- a/internal/reviewtransaction/store.go
+++ b/internal/reviewtransaction/store.go
@@ -747,6 +747,7 @@ func validateSuccessorCounters(previous, next Transaction) error {
 
 func snapshotsEqual(previous, next Snapshot) bool {
 	return previous.Kind == next.Kind &&
+		previous.Projection == next.Projection &&
 		previous.BaseTree == next.BaseTree &&
 		previous.CandidateTree == next.CandidateTree &&
 		previous.PathsDigest == next.PathsDigest &&

--- a/internal/reviewtransaction/transaction.go
+++ b/internal/reviewtransaction/transaction.go
@@ -1194,6 +1194,16 @@ func (transaction *Transaction) escalateBudget(name string) error {
 }
 
 func validateSnapshot(snapshot Snapshot) error {
+	projection, err := canonicalProjection(snapshot.Projection)
+	if err != nil || projection != snapshot.Projection {
+		return errors.New("snapshot projection is unsupported or non-canonical")
+	}
+	if projection == ProjectionStaged && snapshot.Kind != TargetCurrentChanges && snapshot.Kind != TargetBaseDiff && snapshot.Kind != TargetFixDiff {
+		return errors.New("staged snapshot projection requires current-changes, base-diff, or fix-diff")
+	}
+	if projection == ProjectionStaged && len(snapshot.IntendedUntracked) != 0 {
+		return errors.New("staged snapshot projection cannot contain intended-untracked paths")
+	}
 	if snapshot.Kind == "" || !validGitTree(snapshot.BaseTree) || !validGitTree(snapshot.CandidateTree) {
 		return errors.New("snapshot requires kind, base_tree, and candidate_tree")
 	}


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1254

## 🏷️ PR Type

- [x] `type:feature` — New feature (non-breaking change that adds functionality)

## 📝 Summary

Adds `gentle-ai review start --projection staged` so maintainers can freeze the exact Git index while unrelated worktree changes remain outside review authority.

The projection is preserved across snapshot identity, compact authority, correction, recovery, transport, and delivery gates. Legacy records with no projection retain their existing workspace identity and behavior.

## 📂 Changes

| Area | What Changed |
|------|-------------|
| Snapshot model | Added versioned workspace/staged projection identity and exact-index candidate construction |
| Review lifecycle | Propagated projection through START, correction, recovery, receipts, CAS, and transport |
| Delivery gates | Bound post-apply/pre-commit to authoritative projection and preserved staged delivery equivalence |
| CLI and docs | Added the projection flag, JSON output, help text, and threat-model guidance |
| Tests | Covered partial hunks, additions, deletions, renames, modes, symlinks, authority isolation, corrections, transport, and gates |

## 🧪 Test Plan

- [x] Focused staged projection regressions pass
- [x] `go test ./internal/reviewtransaction ./internal/cli` passes
- [x] `go test ./...` passes
- [x] Race-enabled reviewtransaction tests pass
- [x] `git diff --check` passes
- [ ] CI E2E matrix passes

## 🔍 Review Evidence

- Native bounded review: `review-b72ffd9ce1f114b9`
- Tier: high; all four 4R lenses executed once
- Two CRITICAL findings corrected and independently validated
- Correction delta: 52 lines within the 100-line forecast
- Final receipt tree: `d4d2ed3bce5ffe0029d489649dbccaf01e2c8544`

## 📏 Size Exception

Maintainer explicitly approved `size:exception` for this single 871-line PR. The feature changes review authority identity, exact-index fidelity, persistence, correction, recovery, transport, and lifecycle gates; omitting any layer would produce a partial and unsafe protocol. Most authored lines are focused regression coverage.

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] Maintainer explicitly approved and documented `size:exception`
- [x] Exactly one `type:*` label will be applied
- [x] Unit tests pass
- [x] Documentation is updated
- [x] Commit follows Conventional Commits
- [x] Commit has no `Co-Authored-By` trailer


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a staged review projection that evaluates exactly the Git index while excluding unstaged and untracked worktree changes.
  * Added `--projection staged` support to review start, including projection details in review output.
  * Preserved staged review authority through recovery, corrections, and delivery validation.
  * Added support for recording base-to-HEAD provenance with `--base-ref` and `--committed-only`.

* **Bug Fixes**
  * Prevented mismatched projections from being accepted during review gates, recovery, corrections, or transport validation.
  * Ensured staged reviews remain stable when the worktree changes afterward.

* **Documentation**
  * Documented projection behavior and lifecycle rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->