### PR TITLE
fix(sdd): route bound compact authority into failed-verify remediation

### DIFF
--- a/internal/sddstatus/review_binding.go
+++ b/internal/sddstatus/review_binding.go
@@ -84,55 +84,60 @@ func BindApprovedReview(ctx context.Context, repo, change, lineage, expected str
 }
 
 func validateBoundReview(ctx context.Context, repo, change string) (ReviewBinding, reviewtransaction.NativeGateEvaluation, error) {
+	binding, evaluation, _, err := validateBoundReviewWithState(ctx, repo, change)
+	return binding, evaluation, err
+}
+
+func validateBoundReviewWithState(ctx context.Context, repo, change string) (ReviewBinding, reviewtransaction.NativeGateEvaluation, reviewtransaction.CompactState, error) {
 	if !validReviewBindingChange(change) {
-		return ReviewBinding{}, reviewtransaction.NativeGateEvaluation{}, errors.New("invalid OpenSpec change name")
+		return ReviewBinding{}, reviewtransaction.NativeGateEvaluation{}, reviewtransaction.CompactState{}, errors.New("invalid OpenSpec change name")
 	}
 	root, err := (reviewtransaction.SnapshotBuilder{Repo: repo}).ResolveRepositoryRoot(ctx)
 	if err != nil {
-		return ReviewBinding{}, reviewtransaction.NativeGateEvaluation{}, err
+		return ReviewBinding{}, reviewtransaction.NativeGateEvaluation{}, reviewtransaction.CompactState{}, err
 	}
 	changeRoot, err := resolveBindingChangeRoot(root, repo, change)
 	if err != nil {
-		return ReviewBinding{}, reviewtransaction.NativeGateEvaluation{}, err
+		return ReviewBinding{}, reviewtransaction.NativeGateEvaluation{}, reviewtransaction.CompactState{}, err
 	}
 	probe, err := reviewtransaction.CompactAuthoritativeStore(ctx, root, "binding-probe")
 	if err != nil {
-		return ReviewBinding{}, reviewtransaction.NativeGateEvaluation{}, err
+		return ReviewBinding{}, reviewtransaction.NativeGateEvaluation{}, reviewtransaction.CompactState{}, err
 	}
 	payload, err := os.ReadFile(bindingPath(probe, change))
 	if err != nil {
-		return ReviewBinding{}, reviewtransaction.NativeGateEvaluation{}, fmt.Errorf("approved review binding is missing: %w", err)
+		return ReviewBinding{}, reviewtransaction.NativeGateEvaluation{}, reviewtransaction.CompactState{}, fmt.Errorf("approved review binding is missing: %w", err)
 	}
 	binding, err := parseBinding(payload)
 	if err != nil {
-		return ReviewBinding{}, reviewtransaction.NativeGateEvaluation{}, fmt.Errorf("approved review binding is invalid: %w", err)
+		return ReviewBinding{}, reviewtransaction.NativeGateEvaluation{}, reviewtransaction.CompactState{}, fmt.Errorf("approved review binding is invalid: %w", err)
 	}
 	if binding.Change != change {
-		return ReviewBinding{}, reviewtransaction.NativeGateEvaluation{}, errors.New("approved review binding change does not match selected change")
+		return ReviewBinding{}, reviewtransaction.NativeGateEvaluation{}, reviewtransaction.CompactState{}, errors.New("approved review binding change does not match selected change")
 	}
 	store, err := reviewtransaction.CompactAuthoritativeStore(ctx, root, binding.Lineage)
 	if err != nil {
-		return ReviewBinding{}, reviewtransaction.NativeGateEvaluation{}, err
+		return ReviewBinding{}, reviewtransaction.NativeGateEvaluation{}, reviewtransaction.CompactState{}, err
 	}
 	record, err := store.Load()
 	if err != nil || record.Revision != binding.AuthorityRevision || record.State.State != reviewtransaction.StateApproved {
-		return ReviewBinding{}, reviewtransaction.NativeGateEvaluation{}, errors.New("bound compact authority is stale or not approved")
+		return ReviewBinding{}, reviewtransaction.NativeGateEvaluation{}, reviewtransaction.CompactState{}, errors.New("bound compact authority is stale or not approved")
 	}
 	receiptPayload, err := os.ReadFile(store.ReceiptPath())
 	if err != nil || bindingHash(receiptPayload) != binding.ReceiptHash {
-		return ReviewBinding{}, reviewtransaction.NativeGateEvaluation{}, errors.New("bound compact receipt changed")
+		return ReviewBinding{}, reviewtransaction.NativeGateEvaluation{}, reviewtransaction.CompactState{}, errors.New("bound compact receipt changed")
 	}
 	receipt, err := reviewtransaction.ParseCompactReceipt(receiptPayload)
 	authoritative, receiptErr := record.State.Receipt()
 	if err != nil || receiptErr != nil || !reflect.DeepEqual(receipt, authoritative) {
-		return ReviewBinding{}, reviewtransaction.NativeGateEvaluation{}, errors.New("bound compact receipt does not match approved authority")
+		return ReviewBinding{}, reviewtransaction.NativeGateEvaluation{}, reviewtransaction.CompactState{}, errors.New("bound compact receipt does not match approved authority")
 	}
 	if err := verifyBindingLedger(changeRoot, record.State.Findings); err != nil {
-		return ReviewBinding{}, reviewtransaction.NativeGateEvaluation{}, err
+		return ReviewBinding{}, reviewtransaction.NativeGateEvaluation{}, reviewtransaction.CompactState{}, err
 	}
 	evaluation := reviewtransaction.EvaluateCompactGate(ctx, root, receipt, reviewtransaction.NativeGateRequestInput{Gate: reviewtransaction.GatePostApply, LineageID: binding.Lineage})
 	if evaluation.Result != reviewtransaction.GateAllow || !reflect.DeepEqual(evaluation.Context, binding.GateContext) {
-		return ReviewBinding{}, reviewtransaction.NativeGateEvaluation{}, errors.New("bound compact post-apply gate context changed")
+		return ReviewBinding{}, reviewtransaction.NativeGateEvaluation{}, reviewtransaction.CompactState{}, errors.New("bound compact post-apply gate context changed")
 	}
 	bindingFinalAuthorizationHook()
 	finalBinding, bindingErr := os.ReadFile(bindingPath(probe, change))
@@ -140,18 +145,18 @@ func validateBoundReview(ctx context.Context, repo, change string) (ReviewBindin
 	finalReceipt, receiptErr := os.ReadFile(store.ReceiptPath())
 	finalChangeRoot, changeErr := resolveBindingChangeRoot(root, repo, change)
 	if bindingErr != nil || recordErr != nil || receiptErr != nil || changeErr != nil || finalChangeRoot != changeRoot || !bytes.Equal(finalBinding, payload) || finalRecord.Revision != record.Revision || !reflect.DeepEqual(finalRecord.State, record.State) || finalRecord.State.State != reviewtransaction.StateApproved || !bytes.Equal(finalReceipt, receiptPayload) || bindingHash(finalReceipt) != binding.ReceiptHash {
-		return ReviewBinding{}, reviewtransaction.NativeGateEvaluation{}, errors.New("bound authority, receipt, or binding changed during final read")
+		return ReviewBinding{}, reviewtransaction.NativeGateEvaluation{}, reviewtransaction.CompactState{}, errors.New("bound authority, receipt, or binding changed during final read")
 	}
 	finalReceiptValue, parseErr := reviewtransaction.ParseCompactReceipt(finalReceipt)
 	finalAuthoritative, authorityErr := finalRecord.State.Receipt()
 	if parseErr != nil || authorityErr != nil || !reflect.DeepEqual(finalReceiptValue, finalAuthoritative) {
-		return ReviewBinding{}, reviewtransaction.NativeGateEvaluation{}, errors.New("bound compact receipt does not match final authority")
+		return ReviewBinding{}, reviewtransaction.NativeGateEvaluation{}, reviewtransaction.CompactState{}, errors.New("bound compact receipt does not match final authority")
 	}
 	finalGate := reviewtransaction.EvaluateCompactGate(ctx, root, finalReceiptValue, reviewtransaction.NativeGateRequestInput{Gate: reviewtransaction.GatePostApply, LineageID: binding.Lineage})
 	if finalGate.Result != reviewtransaction.GateAllow || !reflect.DeepEqual(finalGate.Context, binding.GateContext) {
-		return ReviewBinding{}, reviewtransaction.NativeGateEvaluation{}, errors.New("bound compact post-apply gate changed during final authorization")
+		return ReviewBinding{}, reviewtransaction.NativeGateEvaluation{}, reviewtransaction.CompactState{}, errors.New("bound compact post-apply gate changed during final authorization")
 	}
-	return binding, finalGate, nil
+	return binding, finalGate, finalRecord.State, nil
 }
 
 func bindingExists(ctx context.Context, repo, change string) (bool, error) {

--- a/internal/sddstatus/review_binding_test.go
+++ b/internal/sddstatus/review_binding_test.go
@@ -379,6 +379,133 @@ func TestBoundReviewUsesNormalVerifyThenArchiveRouting(t *testing.T) {
 	}
 }
 
+func TestBoundCompactAuthorityRoutesSubstantiveFailedVerifyIntoRemediation(t *testing.T) {
+	root := t.TempDir()
+	changeRoot := seedReadyChange(t, root, "thin", "- [x] 1.1 Done\n")
+	write(t, filepath.Join(changeRoot, "specs", "auth", "spec.md"), "### Requirement: Binding\n#### Scenario: Exact authority\n")
+	writeApprovedCompactAuthorityForChange(t, root, changeRoot, "approved-thin")
+	if _, err := BindApprovedReview(context.Background(), root, "thin", "approved-thin", ""); err != nil {
+		t.Fatal(err)
+	}
+	store, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), root, "approved-thin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	receiptPayload, err := os.ReadFile(store.ReceiptPath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := reviewtransaction.ParseCompactReceipt(receiptPayload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	failed := strings.ReplaceAll(boundedVerifyEnvelope(receipt.EvidenceHash, "fail"), "test_exit_code: 0", "test_exit_code: 1")
+	write(t, filepath.Join(changeRoot, "verify-report.md"), failed)
+
+	status, err := Resolve(ResolveOptions{CWD: root, ChangeName: "thin"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.ReviewGate == nil || status.ReviewGate.Result != reviewtransaction.GateAllow || !status.RemediationState.Required || status.RemediationState.FailedEvidenceRevision != receipt.EvidenceHash || status.RemediationState.LineageID != receipt.LineageID || status.RemediationState.Generation != receipt.Generation || status.RemediationState.FixBatch != 1 || status.NextRecommended != "remediate" {
+		t.Fatalf("bound failed verification status = %#v", status)
+	}
+}
+
+func TestBoundCompactRemediationDenialFailsClosed(t *testing.T) {
+	verify := verifyResultEvaluation{
+		Valid:            true,
+		EvidenceRevision: shaID("a"),
+		Reason:           "substantive verification failure",
+	}
+	for _, tt := range []struct {
+		name       string
+		authority  reviewtransaction.CompactState
+		wantReason string
+	}{
+		{
+			name: "cumulative correction budget exhausted",
+			authority: reviewtransaction.CompactState{
+				LineageID: "approved-thin", Generation: 1, EvidenceHash: verify.EvidenceRevision,
+				CorrectionBudget: 10, CumulativeCorrectionLines: 10,
+			},
+			wantReason: "no remaining correction budget",
+		},
+		{
+			name: "correction attempt budget exhausted",
+			authority: reviewtransaction.CompactState{
+				LineageID: "approved-thin", Generation: 1, EvidenceHash: verify.EvidenceRevision,
+				CorrectionBudget:   10,
+				CorrectionAttempts: make([]reviewtransaction.CompactCorrectionAttempt, reviewtransaction.MaxCompactCorrectionAttempts),
+			},
+			wantReason: "exhausted its correction attempt budget",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			remediation := resolveBoundCompactRemediation(true, verify, tt.authority)
+			if remediation.Required || remediation.Reason == "" || !strings.Contains(remediation.Reason, tt.wantReason) {
+				t.Fatalf("remediation = %#v", remediation)
+			}
+
+			dependencies := Dependencies{Verify: DependencyReady, Archive: DependencyBlocked}
+			nextRecommended := "verify"
+			applyBoundCompactRemediationRouting(&dependencies, &nextRecommended, ApplyAllDone, verify, remediation)
+			if dependencies.Verify != DependencyBlocked || dependencies.Archive != DependencyBlocked || nextRecommended != "resolve-review" {
+				t.Fatalf("dependencies=%#v next=%q, want verify/archive blocked and resolve-review", dependencies, nextRecommended)
+			}
+		})
+	}
+}
+
+func TestValidBindingSuppressesStaleLegacyReviewRouting(t *testing.T) {
+	for _, tt := range []struct {
+		name        string
+		verify      string
+		wantVerify  DependencyState
+		wantArchive DependencyState
+		wantNext    string
+	}{
+		{name: "missing verify result", wantVerify: DependencyReady, wantArchive: DependencyBlocked, wantNext: "verify"},
+		{name: "non-native stale verify result", verify: "# Verify\nVerdict: PASS\n", wantVerify: DependencyReady, wantArchive: DependencyBlocked, wantNext: "verify"},
+		{name: "passing native verify result", verify: boundedVerifyEnvelope(shaID("a"), "pass"), wantVerify: DependencyAllDone, wantArchive: DependencyReady, wantNext: "archive"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			changeRoot := seedReadyChange(t, root, "thin", "- [x] 1.1 Done\n")
+			write(t, filepath.Join(changeRoot, "specs", "auth", "spec.md"), "### Requirement: Binding\n#### Scenario: Exact authority\n")
+			stale, err := reviewtransaction.NewTransaction(reviewtransaction.Start{
+				LineageID: "legacy-thin", Mode: reviewtransaction.ModeOrdinary4R, Generation: 1,
+				Snapshot:   reviewtransaction.Snapshot{Kind: reviewtransaction.TargetCurrentChanges, BaseTree: strings.Repeat("a", 40), CandidateTree: strings.Repeat("b", 40), PathsDigest: shaID("1"), IntendedUntracked: []string{}, IntendedUntrackedProof: shaID("2"), Paths: []string{"openspec/changes/thin/tasks.md"}, Identity: shaID("3")},
+				PolicyHash: shaID("4"),
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := stale.StartReview(); err != nil {
+				t.Fatal(err)
+			}
+			writeJSON(t, filepath.Join(changeRoot, "reviews", "transaction.json"), stale)
+			if tt.verify != "" {
+				write(t, filepath.Join(changeRoot, "verify-report.md"), tt.verify)
+			}
+			writeApprovedCompactAuthorityForChange(t, root, changeRoot, "approved-thin")
+			if _, err := BindApprovedReview(context.Background(), root, "thin", "approved-thin", ""); err != nil {
+				t.Fatal(err)
+			}
+
+			status, err := Resolve(ResolveOptions{CWD: root, ChangeName: "thin"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if status.ReviewGate == nil || status.ReviewGate.Result != reviewtransaction.GateAllow || status.ReviewTransaction != nil || status.RemediationState != (RemediationState{}) || status.Dependencies.Verify != tt.wantVerify || status.Dependencies.Archive != tt.wantArchive || status.NextRecommended != tt.wantNext {
+				t.Fatalf("status = %#v", status)
+			}
+			if strings.Contains(strings.Join(status.BlockedReasons, "\n"), "does not match failed evidence revision") {
+				t.Fatalf("stale legacy remediation leaked into status: %#v", status)
+			}
+		})
+	}
+}
+
 func TestSelectedBindingSupersedesOnlyItsLegacyReviewAuthority(t *testing.T) {
 	root := t.TempDir()
 	changeRoot := seedReadyChange(t, root, "thin", "- [x] 1.1 Done\n")

--- a/internal/sddstatus/review_gate.go
+++ b/internal/sddstatus/review_gate.go
@@ -225,6 +225,50 @@ func resolveBoundedRemediation(required bool, verify verifyResultEvaluation, tra
 	return state
 }
 
+func resolveBoundCompactRemediation(required bool, verify verifyResultEvaluation, authority reviewtransaction.CompactState) RemediationState {
+	if !required {
+		return RemediationState{}
+	}
+	if !verify.Valid || verify.EvidenceRevision == "" || verify.EvidenceRevision != authority.EvidenceHash {
+		return RemediationState{Reason: "verify evidence does not exactly match the bound compact authority"}
+	}
+	if authority.CumulativeCorrectionLines >= authority.CorrectionBudget {
+		return RemediationState{Reason: "bound compact authority has no remaining correction budget"}
+	}
+	if len(authority.CorrectionAttempts) >= reviewtransaction.MaxCompactCorrectionAttempts {
+		return RemediationState{Reason: "bound compact authority exhausted its correction attempt budget"}
+	}
+	return RemediationState{
+		Required:               true,
+		FailedEvidenceRevision: verify.EvidenceRevision,
+		LineageID:              authority.LineageID,
+		Generation:             authority.Generation,
+		FixBatch:               len(authority.CorrectionAttempts) + 1,
+		Reason:                 fmt.Sprintf("verify evidence requires bounded remediation for %s: %s", verify.EvidenceRevision, verify.Reason),
+	}
+}
+
+func applyBoundCompactRemediationRouting(dependencies *Dependencies, nextRecommended *string, applyState ApplyState, verify verifyResultEvaluation, remediation RemediationState) {
+	if remediation.Required {
+		dependencies.Verify = DependencyBlocked
+		dependencies.Archive = DependencyBlocked
+		*nextRecommended = "remediate"
+		return
+	}
+	if applyState != ApplyAllDone || verify.Passing {
+		return
+	}
+	if remediation.Reason != "" {
+		dependencies.Verify = DependencyBlocked
+		dependencies.Archive = DependencyBlocked
+		*nextRecommended = "resolve-review"
+		return
+	}
+	dependencies.Verify = DependencyReady
+	dependencies.Archive = DependencyBlocked
+	*nextRecommended = "verify"
+}
+
 func applyReviewGate(
 	status *Status,
 	repo string,

--- a/internal/sddstatus/status.go
+++ b/internal/sddstatus/status.go
@@ -325,13 +325,17 @@ func Resolve(options ResolveOptions) (Status, error) {
 	bridge := compactPreVerifyBridge{}
 	recoverable := authorityOnlyFailedReport(readText(firstPath(artifactPaths.VerifyReport)))
 	if bindingPresent {
-		_, evaluation, bindingErr := validateBoundReview(context.Background(), workspaceRoot, changeName)
+		_, evaluation, authority, bindingErr := validateBoundReviewWithState(context.Background(), workspaceRoot, changeName)
 		if bindingErr == nil {
-			if applyState == ApplyAllDone && artifacts["verifyReport"] != ArtifactDone {
-				dependencies.Verify = DependencyReady
-				dependencies.Archive = DependencyBlocked
-				nextRecommended = "verify"
-			}
+			reviewState = nil
+			remediationState = resolveBoundCompactRemediation(
+				artifacts["verifyReport"] == ArtifactDone && !verifyResult.Passing && applyState == ApplyAllDone && !recoverable && verifyResult.Valid && verifyResult.EvidenceRevision == authority.EvidenceHash,
+				verifyResult,
+				authority,
+			)
+			dependencies = resolveDependencies(artifacts, taskProgress, applyState, coreReady, verifyResult.Passing, remediationState.Complete)
+			nextRecommended = resolveNextRecommended(dependencies, applyState, artifacts["verifyReport"] == ArtifactDone, remediationState)
+			applyBoundCompactRemediationRouting(&dependencies, &nextRecommended, applyState, verifyResult, remediationState)
 			boundGate = &ReviewGateState{Result: evaluation.Result, Reason: "explicit bound compact authority exactly matches the current repository"}
 		} else {
 			dependencies.Verify = DependencyBlocked

--- a/internal/sddstatus/verification.go
+++ b/internal/sddstatus/verification.go
@@ -24,6 +24,7 @@ type verifyCompletion struct {
 
 type verifyResultEvaluation struct {
 	Passing          bool
+	Valid            bool
 	Reason           string
 	EvidenceRevision string
 }
@@ -118,6 +119,7 @@ func parseVerifyResult(text string, expected SpecCounts) verifyResultEvaluation 
 		evaluation.Reason = fmt.Sprintf("invalid verdict %s", verdict)
 		return evaluation
 	}
+	evaluation.Valid = true
 	if testExit != 0 {
 		evaluation.Reason = "test_exit_code must be zero for archive readiness"
 		return evaluation


### PR DESCRIPTION
## Linked Issue

Closes #1243

## Summary

- Route substantive failed-verification remediation through the explicitly bound and validated compact authority.
- Stop stale legacy review mirrors from overriding a valid compact SDD binding.
- Preserve fail-closed behavior for invalid bindings, evidence mismatches, exhausted correction budgets, and exhausted correction attempts.

## Problem

`sdd-status` could validate an explicit compact binding and return:

- `reviewGate.result = allow`

while still computing remediation from the missing or stale legacy change-local review transaction.

This produced contradictory or blocked routing such as:

- valid compact authority;
- valid explicit SDD binding;
- substantive failed verification;
- `nextRecommended = resolve-review`;
- remediation unavailable because the legacy bounded transaction was missing or stale.

## Root Cause

The legacy review transaction and remediation state were resolved before the explicit compact binding was validated and given routing precedence.

The binding validation returned only the gate evaluation, so the status path could not derive bounded remediation directly from the authoritative compact state.

## Changes

- Return the validated compact state together with the bound gate evaluation.
- Derive remediation state from the bound compact authority when verification evidence exactly matches its evidence hash.
- Preserve lineage, generation, failed evidence revision, fix-batch sequencing, correction budget, and correction-attempt limits.
- Suppress stale legacy review state when a valid explicit compact binding governs the change.
- Distinguish structurally valid native verification envelopes from missing or non-native verification reports.
- Add regression coverage for substantive remediation, stale legacy mirrors, archive routing, and fail-closed budget exhaustion.

## Behavior Covered

- Substantive bound verification failure → `remediate`.
- Missing or non-native verification result → `verify`.
- Passing native verification result → `archive`.
- Stale legacy review mirror with valid compact binding → ignored.
- Correction budget exhausted → fail closed to `resolve-review`.
- Correction attempt budget exhausted → fail closed to `resolve-review`.
- Invalid, stale, or mismatched binding → blocked.

## Security and Compatibility

- Does not fabricate legacy review mirrors.
- Does not weaken binding CAS, receipt, ledger, snapshot, scope, or live-gate validation.
- Does not discard substantive failed verification evidence.
- Does not create a new review budget.
- Existing unbound legacy routing remains unchanged.

## Test Plan

- [x] Focused #1243 regression tests
- [x] Stale legacy mirror regression tests
- [x] Compact correction-budget and attempt-limit tests
- [x] `go test ./internal/sddstatus -count=1`
- [x] Related CLI review/SDD status tests
- [x] `go test ./internal/reviewtransaction -count=1`
- [x] `go test ./... -count=1 -timeout 30m`
- [x] `go vet ./...`
- [x] `gofmt`
- [x] `git diff --check`
- [x] Independent reliability review with no findings

## Real-World Validation

The patched binary was validated end-to-end against a real blocked OpenSpec change:

- the legacy authority was officially invalidated;
- the compact authority was approved and explicitly bound;
- the stale legacy mirror no longer controlled routing;
- `sdd-status` advanced correctly through verification and archive;
- the downstream project was archived and published without manually mutating review authority.

Repository-specific names, local paths, and private transaction identifiers have intentionally been omitted.