### PR TITLE
fix(sync): skip install-only visual components in sync runtime

### DIFF
--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -923,8 +923,14 @@ func (s componentSyncStep) Run() error {
 		}
 		return nil
 
+	case model.ComponentClaudeTheme, model.ComponentOpenCodeGentleLogo:
+		// Install-only visual components. The installer persists them in
+		// state.json, so sync builds a step for them, but they have nothing
+		// to re-apply — skip instead of failing the pipeline.
+		return nil
+
 	default:
-		// Persona and any unknown components are out of sync scope.
+		// Any unknown components are out of sync scope.
 		return fmt.Errorf("component %q is not supported in sync runtime", s.component)
 	}
 }

--- a/internal/cli/sync_test.go
+++ b/internal/cli/sync_test.go
@@ -478,6 +478,37 @@ func TestComponentSyncStepSkipsEngramBinaryInstall(t *testing.T) {
 	}
 }
 
+func TestComponentSyncStepSkipsInstallOnlyComponents(t *testing.T) {
+	// Install-only visual components (claude-theme, opencode-gentle-logo) are
+	// persisted in state.json by the installer, so sync builds a step for them.
+	// They have nothing to re-apply on sync and must no-op instead of failing
+	// the whole pipeline (regression: "component X is not supported in sync
+	// runtime" aborted sync for every full-gentleman install).
+	for _, component := range []model.ComponentID{
+		model.ComponentClaudeTheme,
+		model.ComponentOpenCodeGentleLogo,
+	} {
+		t.Run(string(component), func(t *testing.T) {
+			home := t.TempDir()
+			var changed []string
+			step := componentSyncStep{
+				id:           "sync:component:" + string(component),
+				component:    component,
+				homeDir:      home,
+				agents:       []model.AgentID{model.AgentClaudeCode, model.AgentOpenCode},
+				changedFiles: &changed,
+			}
+
+			if err := step.Run(); err != nil {
+				t.Fatalf("componentSyncStep.Run() with %s = %v, want nil (install-only components must no-op in sync)", component, err)
+			}
+			if len(changed) != 0 {
+				t.Errorf("install-only component %s reported changed files in sync: %v", component, changed)
+			}
+		})
+	}
+}
+
 func TestComponentSyncStepCodexRuntimeGate(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
Closes #1275

## PR Type

- [x] Bug fix (`type:bug`)

## Summary

- `gentle-ai sync` aborted with `component "claude-theme" is not supported in sync runtime` for every full-gentleman install: the installer persists `claude-theme` and `opencode-gentle-logo` in `state.json`, sync builds a `componentSyncStep` per persisted component, and the switch never handled them, so they hit the default error branch and killed the whole pipeline.
- Adds a no-op case for both install-only visual components — they have nothing to re-apply on sync.
- Adds a regression test that reproduces the exact production error before the fix.

## Changes

| File | Change |
|------|--------|
| `internal/cli/sync.go` | No-op case for `ComponentClaudeTheme` and `ComponentOpenCodeGentleLogo` before the default error branch |
| `internal/cli/sync_test.go` | `TestComponentSyncStepSkipsInstallOnlyComponents`: `Run()` returns nil and reports no changed files for both components |

## Test Plan

- [x] TDD: test written first and reproduced the exact error (`component "claude-theme" is not supported in sync runtime`), green after the fix
- [x] `go test ./internal/cli/` passes
- [x] End-to-end: patched binary ran a real `gentle-ai sync` on a machine with the full-gentleman selection persisted — pipeline completed across all 5 configured agents (previously aborted)
- [x] Native bounded review: lineage `review-d3944a9b347bff3b`, risk medium, `review-reliability` lens, 0 findings, receipt approved; pre-commit/pre-push/pre-pr gates allow

## Contributor Checklist

- [x] Linked an approved issue (#1275 — pending `status:approved` from a maintainer)
- [x] Exactly one `type:*` label (needs maintainer to apply `type:bug` — no triage permission)
- [x] No shell scripts modified (shellcheck n/a)
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Synchronization now safely skips install-only visual components instead of reporting them as unsupported or out of sync.
  * Unknown components continue to be handled with an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->