### PR TITLE
fix(upgrade): route active Scoop installs through Scoop

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ brew install gentle-ai
 go install github.com/gentleman-programming/gentle-ai/cmd/gentle-ai@latest
 ```
 
-**Scoop (Windows)** — this is a manual-update path; update it with `scoop update gentle-ai`.
+**Scoop (Windows)** — active Scoop installs are upgraded through `scoop update gentle-ai` by `gentle-ai upgrade`; the command also remains available for manual updates.
 
 ```powershell
 scoop bucket add gentleman https://github.com/Gentleman-Programming/scoop-bucket

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -23,7 +23,7 @@ Release artifacts are produced by CI. Windows users should install through the P
 - **PowerShell installer** is the recommended Windows install path for Gentle AI:
   `irm https://raw.githubusercontent.com/Gentleman-Programming/gentle-ai/<version>/scripts/install.ps1 | iex`
   Replace `<version>` with the latest stable release tag. For stricter environments, download the script and verify it against the release checksums before running it.
-- **Scoop** is supported as a manual-update alternative. If installed through Scoop, update with `scoop update gentle-ai`; do not rely on Gentle AI's built-in updater for the Scoop shim.
+- **Scoop** installs are ownership-aware: when the active `gentle-ai` binary is Scoop-managed, `gentle-ai upgrade` runs `scoop update gentle-ai`. The same Scoop command remains available for manual updates.
 - **npm global installs** do not require `sudo` on Windows (user-writable by default).
 - **curl** is pre-installed on Windows 10+ and does not require separate installation.
 - **PowerShell** is the default shell when `$SHELL` is not set.

--- a/internal/update/types.go
+++ b/internal/update/types.go
@@ -24,6 +24,7 @@ type InstallMethod string
 
 const (
 	InstallBrew      InstallMethod = "brew"
+	InstallScoop     InstallMethod = "scoop"
 	InstallGoInstall InstallMethod = "go-install"
 	InstallBinary    InstallMethod = "binary"
 	InstallInstaller InstallMethod = "installer"

--- a/internal/update/upgrade/executor.go
+++ b/internal/update/upgrade/executor.go
@@ -584,16 +584,7 @@ func executeOneWithMethod(ctx context.Context, r update.UpdateResult, profile sy
 		return base
 	}
 
-	var exitReq bool
-	var err error
-	switch method {
-	case update.InstallScoop:
-		err = scoopUpgrade(ctx)
-	case update.InstallInstaller:
-		exitReq, err = installerUpgrade(ctx, r.Tool, r.ReleaseURL, isBetaGentleAIUpgrade(r))
-	default:
-		exitReq, err = runStrategy(ctx, r, profile)
-	}
+	exitReq, err := runStrategy(ctx, r, profile, method)
 	if err != nil {
 		// Distinguish manual fallback (informational skip) from real failures.
 		if hint, ok := AsManualFallback(err); ok {

--- a/internal/update/upgrade/executor.go
+++ b/internal/update/upgrade/executor.go
@@ -520,7 +520,7 @@ func ExecuteWithOptions(ctx context.Context, results []update.UpdateResult, prof
 		method := effectiveMethod(r.Tool, profile)
 		msg := fmt.Sprintf("Upgrading %s via %s (%s → %s)", r.Tool.Name, method, r.InstalledVersion, r.LatestVersion)
 		sp := NewSpinner(pw, msg)
-		toolResult := executeOne(ctx, r, profile, dryRun)
+		toolResult := executeOneWithMethod(ctx, r, profile, dryRun, method)
 
 		// Check if the upgrade succeeded but requires immediate exit (Windows self-replace).
 		// This must be handled BEFORE calling sp.Finish() so the spinner can terminate properly.
@@ -568,11 +568,15 @@ func detectCommandHint(tool update.ToolInfo) string {
 
 // executeOne runs the upgrade for a single tool.
 func executeOne(ctx context.Context, r update.UpdateResult, profile system.PlatformProfile, dryRun bool) ToolUpgradeResult {
+	return executeOneWithMethod(ctx, r, profile, dryRun, effectiveMethod(r.Tool, profile))
+}
+
+func executeOneWithMethod(ctx context.Context, r update.UpdateResult, profile system.PlatformProfile, dryRun bool, method update.InstallMethod) ToolUpgradeResult {
 	base := ToolUpgradeResult{
 		ToolName:   r.Tool.Name,
 		OldVersion: r.InstalledVersion,
 		NewVersion: r.LatestVersion,
-		Method:     effectiveMethod(r.Tool, profile),
+		Method:     method,
 	}
 
 	if dryRun {
@@ -580,7 +584,16 @@ func executeOne(ctx context.Context, r update.UpdateResult, profile system.Platf
 		return base
 	}
 
-	exitReq, err := runStrategy(ctx, r, profile)
+	var exitReq bool
+	var err error
+	switch method {
+	case update.InstallScoop:
+		err = scoopUpgrade(ctx)
+	case update.InstallInstaller:
+		exitReq, err = installerUpgrade(ctx, r.Tool, r.ReleaseURL, isBetaGentleAIUpgrade(r))
+	default:
+		exitReq, err = runStrategy(ctx, r, profile)
+	}
 	if err != nil {
 		// Distinguish manual fallback (informational skip) from real failures.
 		if hint, ok := AsManualFallback(err); ok {
@@ -615,8 +628,10 @@ func effectiveMethod(tool update.ToolInfo, profile system.PlatformProfile) updat
 	if profile.PackageManager == "brew" && homebrewPackageInstalled(tool.Name) {
 		return update.InstallBrew
 	}
-	// Use installer method for gentle-ai on Windows (launches PowerShell installer).
 	if profile.OS == "windows" && tool.Name == "gentle-ai" {
+		if scoopOwnershipDetector() {
+			return update.InstallScoop
+		}
 		return update.InstallInstaller
 	}
 	if profile.GoAvailable && tool.GoImportPath != "" {

--- a/internal/update/upgrade/render.go
+++ b/internal/update/upgrade/render.go
@@ -3,6 +3,8 @@ package upgrade
 import (
 	"fmt"
 	"strings"
+
+	"github.com/gentleman-programming/gentle-ai/internal/update"
 )
 
 // RenderUpgradeReport produces a plain-text report of upgrade results.
@@ -48,6 +50,8 @@ func RenderUpgradeReport(report UpgradeReport) string {
 		case UpgradeSkipped:
 			if r.ManualHint != "" {
 				fmt.Fprintf(&b, "  manual update required: %s\n", r.ManualHint)
+			} else if report.DryRun && r.Method == update.InstallScoop {
+				fmt.Fprintf(&b, "  %s → %s  (dry-run; via scoop; would run: scoop update gentle-ai)\n", r.OldVersion, r.NewVersion)
 			} else if report.DryRun {
 				fmt.Fprintf(&b, "  %s → %s  (dry-run)\n", r.OldVersion, r.NewVersion)
 			} else {

--- a/internal/update/upgrade/scoop.go
+++ b/internal/update/upgrade/scoop.go
@@ -162,8 +162,12 @@ func scoopUpgrade(ctx context.Context) error {
 	}
 	cmd := execCommand("scoop", "update", "gentle-ai")
 	cmd.Stdin = nil
-	if out, err := cmd.CombinedOutput(); err != nil {
+	out, err := cmd.CombinedOutput()
+	if err != nil {
 		return fmt.Errorf("scoop update gentle-ai: %w (output: %s)", err, strings.TrimSpace(string(out)))
+	}
+	if strings.Contains(strings.ToLower(string(out)), "running process detected, skip updating") {
+		return fmt.Errorf("scoop update gentle-ai: running process prevented update (output: %s)", strings.TrimSpace(string(out)))
 	}
 	return nil
 }

--- a/internal/update/upgrade/scoop.go
+++ b/internal/update/upgrade/scoop.go
@@ -6,10 +6,16 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 )
+
+var scoopExecCommand = exec.CommandContext
+
+const scoopCleanupTimeout = 5 * time.Second
 
 const gentleAIHomepage = "https://github.com/gentleman-programming/gentle-ai"
 
@@ -157,11 +163,14 @@ func windowsPathWithin(candidate, root string) bool {
 	return candidateOK && rootOK && candidateVolume == rootVolume && (candidatePath == rootPath || strings.HasPrefix(candidatePath, rootPath+`\`))
 }
 
-func scoopCommand(args ...string) ([]byte, error) {
-	cmd := execCommand("scoop", args...)
+func scoopCommand(ctx context.Context, args ...string) ([]byte, error) {
+	cmd := scoopExecCommand(ctx, "scoop", args...)
 	cmd.Stdin = nil
 	out, err := cmd.CombinedOutput()
 	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return out, fmt.Errorf("scoop %s: %w (command error: %v, output: %s)", strings.Join(args, " "), ctxErr, err, strings.TrimSpace(string(out)))
+		}
 		return out, fmt.Errorf("scoop %s: %w (output: %s)", strings.Join(args, " "), err, strings.TrimSpace(string(out)))
 	}
 	return out, nil
@@ -171,7 +180,7 @@ func scoopUpgrade(ctx context.Context) (err error) {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	priorOut, err := scoopCommand("config", "IGNORE_RUNNING_PROCESSES")
+	priorOut, err := scoopCommand(ctx, "config", "IGNORE_RUNNING_PROCESSES")
 	if err != nil {
 		return err
 	}
@@ -183,14 +192,16 @@ func scoopUpgrade(ctx context.Context) (err error) {
 		return fmt.Errorf("read Scoop IGNORE_RUNNING_PROCESSES: unexpected output %q", strings.TrimSpace(string(priorOut)))
 	}
 	defer func() {
-		if _, restoreErr := scoopCommand(restore...); restoreErr != nil {
+		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), scoopCleanupTimeout)
+		defer cancel()
+		if _, restoreErr := scoopCommand(cleanupCtx, restore...); restoreErr != nil {
 			err = errors.Join(err, fmt.Errorf("restore Scoop setting: %w", restoreErr))
 		}
 	}()
-	if _, err = scoopCommand("config", "IGNORE_RUNNING_PROCESSES", "true"); err != nil {
+	if _, err = scoopCommand(ctx, "config", "IGNORE_RUNNING_PROCESSES", "true"); err != nil {
 		return err
 	}
-	out, err := scoopCommand("update", "gentle-ai")
+	out, err := scoopCommand(ctx, "update", "gentle-ai")
 	if err != nil {
 		return err
 	}

--- a/internal/update/upgrade/scoop.go
+++ b/internal/update/upgrade/scoop.go
@@ -1,0 +1,169 @@
+package upgrade
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+const gentleAIHomepage = "https://github.com/gentleman-programming/gentle-ai"
+
+var scoopOwnershipDetector = defaultScoopOwnershipDetector
+
+func defaultScoopOwnershipDetector() bool {
+	if runtime.GOOS != "windows" {
+		return false
+	}
+	active, err := os.Executable()
+	if err != nil {
+		return false
+	}
+	return scoopOwnsExecutable(active, scoopRoots(os.Getenv, os.UserHomeDir), os.ReadFile, filepath.EvalSymlinks)
+}
+
+func scoopRoots(getenv func(string) string, userHome func() (string, error)) []string {
+	userRoot := strings.TrimSpace(getenv("SCOOP"))
+	if userRoot == "" {
+		home := strings.TrimSpace(getenv("USERPROFILE"))
+		if home == "" {
+			home, _ = userHome()
+		}
+		if home != "" {
+			userRoot = joinWindows(home, "scoop")
+		}
+	}
+	roots := make([]string, 0, 1)
+	seen := map[string]bool{}
+	for _, root := range []string{userRoot} {
+		canonical, _, ok := canonicalWindowsPath(root)
+		if ok && !seen[canonical] {
+			seen[canonical] = true
+			roots = append(roots, root)
+		}
+	}
+	return roots
+}
+
+func scoopOwnsExecutable(active string, roots []string, readFile func(string) ([]byte, error), evalSymlinks func(string) (string, error)) bool {
+	resolvedActive, err := evalSymlinks(active)
+	if err != nil {
+		return false
+	}
+	activeCanonical, _, ok := canonicalWindowsPath(resolvedActive)
+	if !ok || !strings.HasSuffix(activeCanonical, `\gentle-ai.exe`) {
+		return false
+	}
+
+	for _, root := range roots {
+		appBase := joinWindows(root, "apps", "gentle-ai")
+		current := joinWindows(appBase, "current")
+		resolvedBase, baseErr := evalSymlinks(appBase)
+		resolvedCurrent, currentErr := evalSymlinks(current)
+		if baseErr != nil || currentErr != nil || !windowsPathWithin(resolvedCurrent, resolvedBase) || !windowsPathWithin(resolvedActive, resolvedCurrent) {
+			continue
+		}
+		data, readErr := readFile(joinWindows(resolvedCurrent, "manifest.json"))
+		if readErr != nil || !officialScoopManifest(data) {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+func officialScoopManifest(data []byte) bool {
+	var manifest struct {
+		Version  string `json:"version"`
+		Homepage string `json:"homepage"`
+	}
+	if json.Unmarshal(data, &manifest) != nil || strings.TrimSpace(manifest.Version) == "" {
+		return false
+	}
+	homepage := strings.TrimSuffix(strings.ToLower(strings.TrimSpace(manifest.Homepage)), "/")
+	return homepage == gentleAIHomepage
+}
+
+func joinWindows(parts ...string) string {
+	if len(parts) == 0 {
+		return ""
+	}
+	joined := strings.TrimRight(strings.TrimSpace(parts[0]), `\/`)
+	for _, part := range parts[1:] {
+		part = strings.Trim(strings.TrimSpace(part), `\/`)
+		if part != "" {
+			joined += `\` + part
+		}
+	}
+	return joined
+}
+
+func canonicalWindowsPath(raw string) (string, string, bool) {
+	if strings.ContainsRune(raw, 0) || strings.Contains(raw, `"`) {
+		return "", "", false
+	}
+	value := strings.ReplaceAll(strings.TrimSpace(raw), "/", `\`)
+	lower := strings.ToLower(value)
+	if strings.HasPrefix(lower, `\\?\unc\`) {
+		value = `\\` + value[len(`\\?\UNC\`):]
+	} else if strings.HasPrefix(lower, `\\?\`) {
+		value = value[len(`\\?\`):]
+	} else if strings.HasPrefix(lower, `\\.\`) {
+		return "", "", false
+	}
+
+	var volume string
+	var rest string
+	if len(value) >= 3 && value[1] == ':' && value[2] == '\\' && ((value[0] >= 'a' && value[0] <= 'z') || (value[0] >= 'A' && value[0] <= 'Z')) {
+		volume, rest = strings.ToLower(value[:2]), value[3:]
+	} else if strings.HasPrefix(value, `\\`) {
+		items := strings.FieldsFunc(value[2:], func(r rune) bool { return r == '\\' })
+		if len(items) < 2 || items[0] == "." || items[1] == "." {
+			return "", "", false
+		}
+		volume = `\\` + strings.ToLower(items[0]) + `\` + strings.ToLower(items[1])
+		rest = strings.Join(items[2:], `\`)
+	} else {
+		return "", "", false
+	}
+
+	segments := make([]string, 0)
+	for _, segment := range strings.Split(rest, `\`) {
+		switch segment {
+		case "", ".":
+		case "..":
+			if len(segments) == 0 {
+				return "", "", false
+			}
+			segments = segments[:len(segments)-1]
+		default:
+			segments = append(segments, strings.ToLower(segment))
+		}
+	}
+	canonical := volume + `\`
+	if len(segments) > 0 {
+		canonical += strings.Join(segments, `\`)
+	}
+	return strings.TrimSuffix(canonical, `\`), volume, true
+}
+
+func windowsPathWithin(candidate, root string) bool {
+	candidatePath, candidateVolume, candidateOK := canonicalWindowsPath(candidate)
+	rootPath, rootVolume, rootOK := canonicalWindowsPath(root)
+	return candidateOK && rootOK && candidateVolume == rootVolume && (candidatePath == rootPath || strings.HasPrefix(candidatePath, rootPath+`\`))
+}
+
+func scoopUpgrade(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	cmd := execCommand("scoop", "update", "gentle-ai")
+	cmd.Stdin = nil
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("scoop update gentle-ai: %w (output: %s)", err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}

--- a/internal/update/upgrade/scoop.go
+++ b/internal/update/upgrade/scoop.go
@@ -3,6 +3,7 @@ package upgrade
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -156,15 +157,42 @@ func windowsPathWithin(candidate, root string) bool {
 	return candidateOK && rootOK && candidateVolume == rootVolume && (candidatePath == rootPath || strings.HasPrefix(candidatePath, rootPath+`\`))
 }
 
-func scoopUpgrade(ctx context.Context) error {
-	if err := ctx.Err(); err != nil {
-		return err
-	}
-	cmd := execCommand("scoop", "update", "gentle-ai")
+func scoopCommand(args ...string) ([]byte, error) {
+	cmd := execCommand("scoop", args...)
 	cmd.Stdin = nil
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("scoop update gentle-ai: %w (output: %s)", err, strings.TrimSpace(string(out)))
+		return out, fmt.Errorf("scoop %s: %w (output: %s)", strings.Join(args, " "), err, strings.TrimSpace(string(out)))
+	}
+	return out, nil
+}
+
+func scoopUpgrade(ctx context.Context) (err error) {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	priorOut, err := scoopCommand("config", "IGNORE_RUNNING_PROCESSES")
+	if err != nil {
+		return err
+	}
+	prior := strings.ToLower(strings.TrimSpace(string(priorOut)))
+	restore := []string{"config", "rm", "IGNORE_RUNNING_PROCESSES"}
+	if prior == "true" || prior == "false" {
+		restore = []string{"config", "IGNORE_RUNNING_PROCESSES", prior}
+	} else if !strings.Contains(prior, "is not set") {
+		return fmt.Errorf("read Scoop IGNORE_RUNNING_PROCESSES: unexpected output %q", strings.TrimSpace(string(priorOut)))
+	}
+	defer func() {
+		if _, restoreErr := scoopCommand(restore...); restoreErr != nil {
+			err = errors.Join(err, fmt.Errorf("restore Scoop setting: %w", restoreErr))
+		}
+	}()
+	if _, err = scoopCommand("config", "IGNORE_RUNNING_PROCESSES", "true"); err != nil {
+		return err
+	}
+	out, err := scoopCommand("update", "gentle-ai")
+	if err != nil {
+		return err
 	}
 	if strings.Contains(strings.ToLower(string(out)), "running process detected, skip updating") {
 		return fmt.Errorf("scoop update gentle-ai: running process prevented update (output: %s)", strings.TrimSpace(string(out)))

--- a/internal/update/upgrade/scoop_test.go
+++ b/internal/update/upgrade/scoop_test.go
@@ -1,0 +1,182 @@
+package upgrade
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/internal/system"
+	"github.com/gentleman-programming/gentle-ai/internal/update"
+)
+
+func TestWindowsPathWithin(t *testing.T) {
+	tests := []struct {
+		name, candidate, root string
+		want                  bool
+	}{
+		{"drive child", `C:\Users\me\scoop\apps\gentle-ai\2.1.4\gentle-ai.exe`, `c:/users/me/scoop/apps/gentle-ai/2.1.4`, true},
+		{"same path", `C:\Scoop\Apps\gentle-ai`, `c:\scoop\apps\gentle-ai\`, true},
+		{"extended drive", `\\?\C:\scoop\apps\gentle-ai\current\gentle-ai.exe`, `c:\scoop\apps\gentle-ai\current`, true},
+		{"UNC child", `\\server\share\scoop\apps\gentle-ai\current\gentle-ai.exe`, `\\SERVER\SHARE\scoop\apps\gentle-ai\current`, true},
+		{"extended UNC", `\\?\UNC\server\share\scoop\gentle-ai.exe`, `\\server\share\scoop`, true},
+		{"sibling prefix", `C:\scoop\apps\gentle-ai-other\gentle-ai.exe`, `C:\scoop\apps\gentle-ai`, false},
+		{"cross drive", `D:\scoop\gentle-ai.exe`, `C:\scoop`, false},
+		{"relative", `scoop\gentle-ai.exe`, `C:\scoop`, false},
+		{"device path", `\\.\C:\scoop\gentle-ai.exe`, `C:\scoop`, false},
+		{"escape root", `C:\..\scoop\gentle-ai.exe`, `C:\scoop`, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := windowsPathWithin(tc.candidate, tc.root); got != tc.want {
+				t.Fatalf("windowsPathWithin(%q, %q) = %v, want %v", tc.candidate, tc.root, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestScoopRoots(t *testing.T) {
+	env := map[string]string{
+		"SCOOP":       `D:\custom-scoop`,
+		"USERPROFILE": `C:\Users\me`,
+	}
+	getenv := func(key string) string { return env[key] }
+	got := scoopRoots(getenv, func() (string, error) { return `C:\fallback`, nil })
+	want := []string{`D:\custom-scoop`}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("scoopRoots() = %#v, want %#v", got, want)
+	}
+
+	delete(env, "SCOOP")
+	got = scoopRoots(getenv, func() (string, error) { return `C:\fallback`, nil })
+	want = []string{`C:\Users\me\scoop`}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("default scoopRoots() = %#v, want %#v", got, want)
+	}
+}
+
+func TestScoopOwnsExecutable(t *testing.T) {
+	manifest := []byte(`{"version":"2.1.4","homepage":"https://github.com/Gentleman-Programming/gentle-ai"}`)
+	eval := func(path string) (string, error) {
+		switch path {
+		case `D:\scoop\apps\gentle-ai`:
+			return `D:\scoop\apps\gentle-ai`, nil
+		case `D:\scoop\apps\gentle-ai\current`:
+			return `D:\scoop\apps\gentle-ai\2.1.4`, nil
+		default:
+			return path, nil
+		}
+	}
+	read := func(path string) ([]byte, error) { return manifest, nil }
+
+	if !scoopOwnsExecutable(`D:\scoop\apps\gentle-ai\2.1.4\gentle-ai.exe`, []string{`D:\scoop`}, read, eval) {
+		t.Fatal("expected current Scoop executable to be owned")
+	}
+	if scoopOwnsExecutable(`C:\Users\me\AppData\Local\gentle-ai\bin\gentle-ai.exe`, []string{`D:\scoop`}, read, eval) {
+		t.Fatal("AppData executable must not be Scoop-owned")
+	}
+	if scoopOwnsExecutable(`D:\scoop\shims\gentle-ai.exe`, []string{`D:\scoop`}, read, eval) {
+		t.Fatal("generated shim is not the running package executable")
+	}
+	for _, invalid := range [][]byte{
+		[]byte(`not-json`),
+		[]byte(`{"version":"","homepage":"https://github.com/Gentleman-Programming/gentle-ai"}`),
+		[]byte(`{"version":"2.1.4","homepage":"https://example.com"}`),
+	} {
+		readInvalid := func(string) ([]byte, error) { return invalid, nil }
+		if scoopOwnsExecutable(`D:\scoop\apps\gentle-ai\2.1.4\gentle-ai.exe`, []string{`D:\scoop`}, readInvalid, eval) {
+			t.Fatal("invalid manifest must not prove ownership")
+		}
+	}
+	if scoopOwnsExecutable(`D:\scoop\apps\gentle-ai\2.1.3\gentle-ai.exe`, []string{`D:\scoop`}, read, eval) {
+		t.Fatal("stale version directory must not prove current ownership")
+	}
+	escapedCurrent := func(path string) (string, error) {
+		if strings.HasSuffix(path, `\current`) {
+			return `D:\other\2.1.4`, nil
+		}
+		return path, nil
+	}
+	if scoopOwnsExecutable(`D:\other\2.1.4\gentle-ai.exe`, []string{`D:\scoop`}, read, escapedCurrent) {
+		t.Fatal("escaped current junction must not prove ownership")
+	}
+	failedEval := func(string) (string, error) { return "", errors.New("no junction access") }
+	if scoopOwnsExecutable(`D:\scoop\apps\gentle-ai\2.1.4\gentle-ai.exe`, []string{`D:\scoop`}, read, failedEval) {
+		t.Fatal("resolution failure must be inconclusive")
+	}
+}
+
+func TestEffectiveMethodWindowsGentleAIScoopOwnership(t *testing.T) {
+	original := scoopOwnershipDetector
+	t.Cleanup(func() { scoopOwnershipDetector = original })
+	profile := system.PlatformProfile{OS: "windows"}
+	tool := update.ToolInfo{Name: "gentle-ai", InstallMethod: update.InstallBinary}
+
+	scoopOwnershipDetector = func() bool { return true }
+	if got := effectiveMethod(tool, profile); got != update.InstallScoop {
+		t.Fatalf("owned method = %q, want scoop", got)
+	}
+	scoopOwnershipDetector = func() bool { return false }
+	if got := effectiveMethod(tool, profile); got != update.InstallInstaller {
+		t.Fatalf("fallback method = %q, want installer", got)
+	}
+
+	scoopOwnershipDetector = func() bool {
+		t.Fatal("detector called for non-target tool")
+		return false
+	}
+	if got := effectiveMethod(update.ToolInfo{Name: "engram", InstallMethod: update.InstallBinary}, profile); got != update.InstallBinary {
+		t.Fatalf("non-target method = %q, want binary", got)
+	}
+}
+
+func TestScoopUpgradeRunsExactCommand(t *testing.T) {
+	original := execCommand
+	t.Cleanup(func() { execCommand = original })
+	var gotName string
+	var gotArgs []string
+	var gotCmd *exec.Cmd
+	execCommand = func(name string, args ...string) *exec.Cmd {
+		gotName, gotArgs = name, append([]string(nil), args...)
+		gotCmd = mockCmd("true")
+		return gotCmd
+	}
+	if err := scoopUpgrade(context.Background()); err != nil {
+		t.Fatalf("scoopUpgrade() error = %v", err)
+	}
+	if gotName != "scoop" || !reflect.DeepEqual(gotArgs, []string{"update", "gentle-ai"}) {
+		t.Fatalf("command = %q %v, want scoop update gentle-ai", gotName, gotArgs)
+	}
+	if gotCmd.Stdin != nil {
+		t.Fatal("scoop command stdin must be nil")
+	}
+}
+
+func TestScoopUpgradeHonorsCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := scoopUpgrade(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("scoopUpgrade() error = %v, want context.Canceled", err)
+	}
+}
+
+func TestScoopUpgradeReportsCommandFailure(t *testing.T) {
+	original := execCommand
+	execCommand = func(string, ...string) *exec.Cmd { return mockCmd("false") }
+	t.Cleanup(func() { execCommand = original })
+	if err := scoopUpgrade(context.Background()); err == nil {
+		t.Fatal("expected Scoop command failure")
+	}
+}
+
+func TestRenderUpgradeReportShowsScoopDryRunCommand(t *testing.T) {
+	report := UpgradeReport{DryRun: true, Results: []ToolUpgradeResult{{
+		ToolName: "gentle-ai", OldVersion: "2.1.3", NewVersion: "2.1.4",
+		Method: update.InstallScoop, Status: UpgradeSkipped,
+	}}}
+	if got := RenderUpgradeReport(report); !strings.Contains(got, "would run: scoop update gentle-ai") {
+		t.Fatalf("dry-run report missing Scoop command:\n%s", got)
+	}
+}

--- a/internal/update/upgrade/scoop_test.go
+++ b/internal/update/upgrade/scoop_test.go
@@ -132,28 +132,53 @@ func TestEffectiveMethodWindowsGentleAIScoopOwnership(t *testing.T) {
 	}
 }
 
-func TestScoopUpgradeRunsExactCommand(t *testing.T) {
-	original := execCommand
-	t.Cleanup(func() { execCommand = original })
-	var gotName string
-	var gotArgs []string
-	var gotCmd *exec.Cmd
-	execCommand = func(name string, args ...string) *exec.Cmd {
-		gotName, gotArgs = name, append([]string(nil), args...)
-		gotCmd = mockCmd("true")
-		return gotCmd
+func TestScoopUpgradeTemporarilyIgnoresRunningProcess(t *testing.T) {
+	tests := []struct {
+		name, prior, fail, wantErr string
+		wantRestore                []string
+	}{
+		{"unset", "'IGNORE_RUNNING_PROCESSES' is not set", "", "", []string{"config", "rm", "IGNORE_RUNNING_PROCESSES"}},
+		{"false", "False", "", "", []string{"config", "IGNORE_RUNNING_PROCESSES", "false"}},
+		{"true", "True", "", "", []string{"config", "IGNORE_RUNNING_PROCESSES", "true"}},
+		{"update failure", "False", "update", "scoop update gentle-ai", []string{"config", "IGNORE_RUNNING_PROCESSES", "false"}},
+		{"restore failure", "False", "restore", "restore Scoop setting", []string{"config", "IGNORE_RUNNING_PROCESSES", "false"}},
+		{"false success", "False", "skip", "running process", []string{"config", "IGNORE_RUNNING_PROCESSES", "false"}},
 	}
-	if err := scoopUpgrade(context.Background()); err != nil {
-		t.Fatalf("scoopUpgrade() error = %v", err)
-	}
-	if gotName != "scoop" || !reflect.DeepEqual(gotArgs, []string{"update", "gentle-ai"}) {
-		t.Fatalf("command = %q %v, want scoop update gentle-ai", gotName, gotArgs)
-	}
-	if gotCmd.Stdin != nil {
-		t.Fatal("scoop command stdin must be nil")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			original := execCommand
+			t.Cleanup(func() { execCommand = original })
+			var calls [][]string
+			execCommand = func(name string, args ...string) *exec.Cmd {
+				calls = append(calls, append([]string{name}, args...))
+				switch len(calls) {
+				case 1:
+					return mockCmd("echo", tt.prior)
+				case 3:
+					if tt.fail == "update" {
+						return mockCmd("false")
+					}
+					if tt.fail == "skip" {
+						return mockCmd("echo", "Running process detected, skip updating.")
+					}
+				case 4:
+					if tt.fail == "restore" {
+						return mockCmd("false")
+					}
+				}
+				return mockCmd("true")
+			}
+			err := scoopUpgrade(context.Background())
+			if (err == nil) != (tt.wantErr == "") || err != nil && !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("scoopUpgrade() error = %v, want containing %q", err, tt.wantErr)
+			}
+			want := [][]string{{"scoop", "config", "IGNORE_RUNNING_PROCESSES"}, {"scoop", "config", "IGNORE_RUNNING_PROCESSES", "true"}, {"scoop", "update", "gentle-ai"}, append([]string{"scoop"}, tt.wantRestore...)}
+			if !reflect.DeepEqual(calls, want) {
+				t.Fatalf("commands = %#v, want %#v", calls, want)
+			}
+		})
 	}
 }
-
 func TestScoopUpgradeHonorsCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -168,19 +193,6 @@ func TestScoopUpgradeReportsCommandFailure(t *testing.T) {
 	t.Cleanup(func() { execCommand = original })
 	if err := scoopUpgrade(context.Background()); err == nil {
 		t.Fatal("expected Scoop command failure")
-	}
-}
-
-func TestScoopUpgradeReportsRunningProcessSkip(t *testing.T) {
-	original := execCommand
-	execCommand = func(string, ...string) *exec.Cmd {
-		return mockCmd("echo", "Running process detected, skip updating.")
-	}
-	t.Cleanup(func() { execCommand = original })
-
-	err := scoopUpgrade(context.Background())
-	if err == nil || !strings.Contains(err.Error(), "running process") {
-		t.Fatalf("scoopUpgrade() error = %v, want running process failure", err)
 	}
 }
 

--- a/internal/update/upgrade/scoop_test.go
+++ b/internal/update/upgrade/scoop_test.go
@@ -171,6 +171,19 @@ func TestScoopUpgradeReportsCommandFailure(t *testing.T) {
 	}
 }
 
+func TestScoopUpgradeReportsRunningProcessSkip(t *testing.T) {
+	original := execCommand
+	execCommand = func(string, ...string) *exec.Cmd {
+		return mockCmd("echo", "Running process detected, skip updating.")
+	}
+	t.Cleanup(func() { execCommand = original })
+
+	err := scoopUpgrade(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "running process") {
+		t.Fatalf("scoopUpgrade() error = %v, want running process failure", err)
+	}
+}
+
 func TestRenderUpgradeReportShowsScoopDryRunCommand(t *testing.T) {
 	report := UpgradeReport{DryRun: true, Results: []ToolUpgradeResult{{
 		ToolName: "gentle-ai", OldVersion: "2.1.3", NewVersion: "2.1.4",

--- a/internal/update/upgrade/scoop_test.go
+++ b/internal/update/upgrade/scoop_test.go
@@ -3,6 +3,8 @@ package upgrade
 import (
 	"context"
 	"errors"
+	"fmt"
+	"os"
 	"os/exec"
 	"reflect"
 	"strings"
@@ -146,10 +148,10 @@ func TestScoopUpgradeTemporarilyIgnoresRunningProcess(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			original := execCommand
-			t.Cleanup(func() { execCommand = original })
+			original := scoopExecCommand
+			t.Cleanup(func() { scoopExecCommand = original })
 			var calls [][]string
-			execCommand = func(name string, args ...string) *exec.Cmd {
+			scoopExecCommand = func(_ context.Context, name string, args ...string) *exec.Cmd {
 				calls = append(calls, append([]string{name}, args...))
 				switch len(calls) {
 				case 1:
@@ -187,10 +189,60 @@ func TestScoopUpgradeHonorsCancellation(t *testing.T) {
 	}
 }
 
+func TestScoopUpgradeCancelsSubprocessAndRestoresConfig(t *testing.T) {
+	original := scoopExecCommand
+	t.Cleanup(func() { scoopExecCommand = original })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	updateStarted := make(chan struct{})
+	var restoreContextLive, restoreHasDeadline bool
+	scoopExecCommand = func(commandCtx context.Context, _ string, args ...string) *exec.Cmd {
+		if reflect.DeepEqual(args, []string{"update", "gentle-ai"}) {
+			close(updateStarted)
+		}
+		if reflect.DeepEqual(args, []string{"config", "IGNORE_RUNNING_PROCESSES", "false"}) {
+			restoreContextLive = commandCtx.Err() == nil
+			_, restoreHasDeadline = commandCtx.Deadline()
+		}
+		cmd := exec.CommandContext(commandCtx, os.Args[0], "-test.run=TestScoopCommandHelper", "--")
+		cmd.Env = append(os.Environ(), "GO_WANT_SCOOP_HELPER=1", "SCOOP_HELPER_ARGS="+strings.Join(args, "|"))
+		return cmd
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- scoopUpgrade(ctx) }()
+	<-updateStarted
+	cancel()
+	err := <-done
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("scoopUpgrade() error = %v, want context.Canceled", err)
+	}
+	if !restoreContextLive {
+		t.Fatal("restore command must receive a live cleanup context")
+	}
+	if !restoreHasDeadline {
+		t.Fatal("restore context must have a cleanup deadline")
+	}
+}
+
+func TestScoopCommandHelper(t *testing.T) {
+	if os.Getenv("GO_WANT_SCOOP_HELPER") != "1" {
+		return
+	}
+	switch os.Getenv("SCOOP_HELPER_ARGS") {
+	case "config|IGNORE_RUNNING_PROCESSES":
+		fmt.Print("False")
+	case "update|gentle-ai":
+		select {}
+	}
+	os.Exit(0)
+}
+
 func TestScoopUpgradeReportsCommandFailure(t *testing.T) {
-	original := execCommand
-	execCommand = func(string, ...string) *exec.Cmd { return mockCmd("false") }
-	t.Cleanup(func() { execCommand = original })
+	original := scoopExecCommand
+	scoopExecCommand = func(context.Context, string, ...string) *exec.Cmd { return mockCmd("false") }
+	t.Cleanup(func() { scoopExecCommand = original })
 	if err := scoopUpgrade(context.Background()); err == nil {
 		t.Fatal("expected Scoop command failure")
 	}

--- a/internal/update/upgrade/strategy.go
+++ b/internal/update/upgrade/strategy.go
@@ -86,6 +86,8 @@ func runStrategy(ctx context.Context, r update.UpdateResult, profile system.Plat
 	switch method {
 	case update.InstallBrew:
 		return false, brewUpgrade(ctx, r, ownership)
+	case update.InstallScoop:
+		return false, scoopUpgrade(ctx)
 	case update.InstallGoInstall:
 		return false, goInstallUpgrade(ctx, r.Tool, r.LatestVersion)
 	case update.InstallBinary:

--- a/internal/update/upgrade/strategy.go
+++ b/internal/update/upgrade/strategy.go
@@ -65,9 +65,17 @@ const maxScriptSize = 1 * 1024 * 1024 // 1 MB
 //   - script method + windows → manualFallback
 //   - OpenCode plugin method → update materialized package in ~/.config/opencode when possible
 //   - unknown method → manualFallback with explicit message
-func runStrategy(ctx context.Context, r update.UpdateResult, profile system.PlatformProfile) (bool, error) {
+func runStrategy(ctx context.Context, r update.UpdateResult, profile system.PlatformProfile, resolvedMethod ...update.InstallMethod) (bool, error) {
+	method := r.Tool.InstallMethod
+	hasResolvedMethod := len(resolvedMethod) > 0
+	if hasResolvedMethod {
+		method = resolvedMethod[0]
+	} else {
+		method = effectiveMethod(r.Tool, profile)
+	}
+
 	ownership := update.HomebrewNone
-	if profile.PackageManager == "brew" && r.Tool.InstallMethod != update.InstallOpenCodePlugin {
+	if method == update.InstallBrew || !hasResolvedMethod && profile.PackageManager == "brew" && r.Tool.InstallMethod != update.InstallOpenCodePlugin {
 		var err error
 		ownership, err = homebrewOwnershipDetector(r.Tool.Name)
 		if err != nil {
@@ -78,7 +86,6 @@ func runStrategy(ctx context.Context, r update.UpdateResult, profile system.Plat
 		return false, goInstallMainUpgrade(r.Tool)
 	}
 
-	method := effectiveMethod(r.Tool, profile)
 	if ownership != update.HomebrewNone {
 		method = update.InstallBrew
 	}

--- a/internal/update/upgrade/strategy_test.go
+++ b/internal/update/upgrade/strategy_test.go
@@ -101,6 +101,31 @@ func TestRunStrategy_GoInstallUpgrade(t *testing.T) {
 	}
 }
 
+func TestRunStrategyUsesResolvedScoopMethod(t *testing.T) {
+	originalExec := scoopExecCommand
+	originalDetector := scoopOwnershipDetector
+	t.Cleanup(func() {
+		scoopExecCommand = originalExec
+		scoopOwnershipDetector = originalDetector
+	})
+
+	scoopOwnershipDetector = func() bool {
+		t.Fatal("resolved strategy must not detect Scoop ownership again")
+		return false
+	}
+	scoopExecCommand = func(_ context.Context, _ string, args ...string) *exec.Cmd {
+		if len(args) == 2 && args[0] == "config" && args[1] == "IGNORE_RUNNING_PROCESSES" {
+			return mockCmd("echo", "False")
+		}
+		return mockCmd("true")
+	}
+
+	r := update.UpdateResult{Tool: update.ToolInfo{Name: "gentle-ai", InstallMethod: update.InstallBinary}}
+	if _, err := runStrategy(context.Background(), r, system.PlatformProfile{OS: "windows"}, update.InstallScoop); err != nil {
+		t.Fatalf("runStrategy resolved Scoop method: %v", err)
+	}
+}
+
 func TestRunStrategy_BetaGentleAISelfUpgradeUsesGoInstallMain(t *testing.T) {
 	origExecCommand := execCommand
 	t.Cleanup(func() { execCommand = origExecCommand })

--- a/internal/update/upgrade/strategy_test.go
+++ b/internal/update/upgrade/strategy_test.go
@@ -274,6 +274,10 @@ func TestRunStrategy_GoInstallFailure(t *testing.T) {
 // TestEffectiveMethod_GentleAIOnWindowsUsesInstaller verifies that gentle-ai
 // on Windows uses InstallInstaller (auto-upgrade via PowerShell)
 func TestEffectiveMethod_GentleAIOnWindowsUsesInstaller(t *testing.T) {
+	original := scoopOwnershipDetector
+	scoopOwnershipDetector = func() bool { return false }
+	t.Cleanup(func() { scoopOwnershipDetector = original })
+
 	tests := []struct {
 		name string
 		tool update.ToolInfo


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #541

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Detects whether the running Windows `gentle-ai.exe` is owned by the current official user-scope Scoop installation.
- Routes positively proven Scoop installs through exactly `scoop update gentle-ai`; every inconclusive or AppData-owned case keeps the existing detached installer path.
- Adds host-independent Windows path, ownership, routing, command, cancellation, failure, and dry-run regression coverage.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/update/upgrade/scoop.go` | Adds fail-safe official Scoop ownership proof and exact update command execution. |
| `internal/update/upgrade/scoop_test.go` | Covers Windows paths, custom/default Scoop roots, official manifest identity, shadowing, stale versions, escaped junctions, routing, command execution, failures, and reporting. |
| `internal/update/upgrade/executor.go` | Selects Scoop only for positively owned Windows Gentle AI installations and reuses the selected method for execution/reporting. |
| `internal/update/upgrade/strategy.go` | Supports Scoop dispatch for direct strategy callers. |
| `internal/update/types.go` | Adds the explicit `scoop` install method. |
| `internal/update/upgrade/render.go` | Shows the exact Scoop operation in dry-run output. |
| `README.md`, `docs/platforms.md` | Documents ownership-aware Scoop upgrades. |

---

## 🧪 Test Plan

```bash
go test ./internal/update/upgrade
go vet ./...
git diff --check
```

- [x] Focused upgrade package passes (`go test ./internal/update/upgrade`)
- [x] Static analysis passes (`go vet ./...`)
- [x] Diff validation passes (`git diff --check`)
- [ ] Full Windows suite passes locally (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)

The full suite currently reproduces unchanged Windows baseline failures on `upstream/main`, including symlink-privilege and platform-path assertions. The affected package is green. Linux CI remains the authoritative full-suite signal. No shell scripts or E2E behavior changed.

Manual scenario reproduced before the fix: with Scoop first on PATH, upgrading v2.1.3 to v2.1.4 updated `%LOCALAPPDATA%\gentle-ai\bin` while the active Scoop installation remained stale.

---

## 🤖 Automated Checks

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | 389 authored changed lines, below the 400-line budget. |
| Check Issue Reference | ⏳ | `Closes #541`. |
| Check Issue Has `status:approved` | ⏳ | #541 is approved. |
| Check PR Has `type:*` Label | ⏳ | Exactly `type:bug` will be applied. |
| Unit Tests | ⏳ | Awaiting CI. |
| E2E Tests | ⏳ | Awaiting CI. |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [x] Exactly one appropriate `type:*` label is planned
- [x] Affected unit tests pass
- [ ] Full CI unit suite passes
- [ ] E2E CI passes
- [x] Documentation is updated
- [x] Commit follows Conventional Commits
- [x] Commit has no `Co-Authored-By` trailer

---

## 💬 Notes for Reviewers

Please focus on the ownership boundary: package presence alone is insufficient. The running executable must resolve under the official current Scoop package directory and validate the installed manifest identity. Detection failures intentionally preserve the existing AppData installer; after ownership is proven, a Scoop command failure is surfaced rather than falling back and recreating the duplicate-install problem.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Windows installations managed by Scoop can now be upgraded via `gentle-ai upgrade`.
  - When Scoop ownership is detected, upgrades use `scoop update gentle-ai` automatically.
  - Dry-run mode now shows the method-specific Scoop command that would run.
- **Bug Fixes**
  - Upgrade execution now properly handles cancellation and restores previous configuration after Scoop update attempts (including failure cases and running-process blocking).
- **Documentation**
  - Updated Windows Scoop guidance to reflect the automatic `gentle-ai upgrade` path and the available manual update command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->