### PR TITLE
fix(tui): isolate profile-only uninstall

### DIFF
--- a/.specs/features/profile-only-uninstall/context.md
+++ b/.specs/features/profile-only-uninstall/context.md
@@ -1,0 +1,30 @@
+# Profile-Only Uninstall Context
+
+**Gathered:** 2026-07-15
+**Spec:** `.specs/features/profile-only-uninstall/spec.md`
+**Status:** Ready for implementation
+
+## Feature Boundary
+
+The TUI's selected-profile path removes only the selected named OpenCode SDD profile agents from `opencode.json`. It does not perform an Engram or managed-component uninstall.
+
+## Implementation Decisions
+
+### Operation boundary
+
+- Reuse the existing `sdd.RemoveProfileAgents` capability already used by the dedicated profile-management screen.
+- Add a TUI callback for profile-only removal, keeping the managed uninstall callback for component uninstall only.
+
+### Interaction and result
+
+- Keep the current profile-selection and confirm screens; do not show Engram cleanup as part of profile-only removal.
+- Reuse the uninstall result screen for success/error feedback, with selected profile names as the observable result.
+
+### Failure and data safety
+
+- Stop at the first removal error and surface it through the existing TUI error/result route.
+- Do not introduce a backup mechanism in this bounded fix; direct profile deletion already uses this behavior.
+
+## Deferred Ideas
+
+- Review default component selections in a separate issue; this change guarantees the selected-profile action itself cannot invoke component or Engram cleanup.

--- a/.specs/features/profile-only-uninstall/spec.md
+++ b/.specs/features/profile-only-uninstall/spec.md
@@ -56,12 +56,12 @@ The uninstall flow currently combines OpenCode SDD profile removal with Engram c
 
 | Requirement ID | Story | Phase | Status |
 | --- | --- | --- | --- |
-| PROF-01 | P1: profile-only removal | Execute | Implementing |
-| PROF-02 | P1: protect Engram | Execute | Implementing |
-| PROF-03 | P1: preserve unrelated configuration | Execute | Implementing |
-| PROF-04 | P1: surface errors | Execute | Implementing |
+| PROF-01 | P1: profile-only removal | Execute | ✅ Verified |
+| PROF-02 | P1: protect Engram | Execute | ✅ Verified |
+| PROF-03 | P1: preserve unrelated configuration | Execute | ✅ Verified |
+| PROF-04 | P1: surface errors | Execute | ✅ Verified |
 
 ## Success Criteria
 
-- [ ] A selected profile is removed without calling managed uninstall or touching Engram.
-- [ ] Focused TUI tests and the complete Go test suite pass.
+- [x] A selected profile is removed without calling managed uninstall or touching Engram.
+- [x] Focused TUI tests and the complete Go test suite pass.

--- a/.specs/features/profile-only-uninstall/spec.md
+++ b/.specs/features/profile-only-uninstall/spec.md
@@ -1,0 +1,67 @@
+# Profile-Only Uninstall Specification
+
+## Problem Statement
+
+The uninstall flow currently combines OpenCode SDD profile removal with Engram cleanup. A user who selects a profile can therefore delete unrelated Engram data, even though profile removal should affect only that profile's entries in `opencode.json`.
+
+## Goals
+
+- [ ] Remove selected named OpenCode SDD profiles without invoking managed-component uninstall.
+- [ ] Preserve Engram files, configuration, and all non-selected profile/default-agent entries.
+- [ ] Keep the existing Uninstall flow's profile confirmation/result experience.
+
+## Out of Scope
+
+| Feature | Reason |
+| --- | --- |
+| Redesigning component uninstall selections | The bug is the profile-removal path, not the general component picker. |
+| Changing CLI uninstall semantics | The issue is limited to the TUI. |
+| Adding backup snapshots to profile management | Existing direct profile deletion is the established behavior and is not changed here. |
+
+---
+
+## Assumptions & Open Questions
+
+| Assumption / decision | Chosen default | Rationale | Confirmed? |
+| --- | --- | --- |
+| Selecting one or more named profiles in the uninstall flow means profile-only removal. | Call the existing profile-removal capability directly; do not call the managed uninstall callback. | This is the only interpretation that guarantees no Engram cleanup and matches the issue's expected behavior. | yes — issue #445 and approved implementation request |
+| Profile-only removal remains TUI-local. | No CLI flags or component-picker behavior change. | The issue identifies only the TUI flow. | yes — scoped issue |
+| A failed multi-profile deletion stops and reports the error. | Preserve existing deletion error behavior; do not silently continue. | Prevents claiming a complete removal after a partial failure. | assumption |
+
+**Open questions:** none — all resolved or logged above.
+
+## User Stories
+
+### P1: Remove a profile without deleting Engram ⭐ MVP
+
+**User Story**: As an OpenCode user, I want to remove selected SDD profiles from the uninstall flow so that stale profile agents disappear without affecting Engram or unrelated managed configuration.
+
+**Why P1**: This prevents unintended deletion of persistent project or global memory configuration.
+
+**Acceptance Criteria**:
+
+1. WHEN a user confirms one or more selected profiles on the uninstall profile-selection screen, THEN the system SHALL remove only the selected profiles' SDD agent keys from `opencode.json`.
+2. WHEN profile-only removal is confirmed, THEN the system SHALL NOT invoke the managed-component uninstall path and SHALL NOT delete or rewrite Engram artifacts.
+3. WHEN a selected profile is removed, THEN default SDD agents, unselected profiles, and unrelated `opencode.json` content SHALL remain unchanged.
+4. WHEN profile removal returns an error, THEN the TUI SHALL show the failure rather than reporting an uninstall success.
+
+**Independent Test**: Configure selected and unselected profile names, invoke the profile-only operation, and assert the selected names are sent only to the profile-removal callback while the component-uninstall callback is not called.
+
+## Edge Cases
+
+- WHEN no named profile is selected, THEN the normal managed-component uninstall flow SHALL remain available.
+- WHEN a selected profile cannot be removed, THEN the operation SHALL surface its error and SHALL NOT claim success.
+
+## Requirement Traceability
+
+| Requirement ID | Story | Phase | Status |
+| --- | --- | --- | --- |
+| PROF-01 | P1: profile-only removal | Execute | Implementing |
+| PROF-02 | P1: protect Engram | Execute | Implementing |
+| PROF-03 | P1: preserve unrelated configuration | Execute | Implementing |
+| PROF-04 | P1: surface errors | Execute | Implementing |
+
+## Success Criteria
+
+- [ ] A selected profile is removed without calling managed uninstall or touching Engram.
+- [ ] Focused TUI tests and the complete Go test suite pass.

--- a/.specs/features/profile-only-uninstall/validation.md
+++ b/.specs/features/profile-only-uninstall/validation.md
@@ -1,0 +1,94 @@
+# Profile-Only Uninstall Validation
+
+**Date**: 2026-07-15
+**Spec**: `.specs/features/profile-only-uninstall/spec.md`
+**Diff range**: `3b5da78^..9e9b2ec` (both implementation and follow-up test commit)
+**Verifier**: independent sub-agent (author != verifier)
+
+---
+
+## Task Completion
+
+No `tasks.md` exists: this is a small feature. The verified implementation is
+`3b5da78` (`fix(tui): isolate profile-only uninstall`); `9e9b2ec`
+adds the outcome tests required by the prior validation pass.
+
+## Spec-Anchored Acceptance Criteria
+
+| Requirement | Criterion and spec-defined outcome | `file:line` + assertion expression | Result |
+| --- | --- | --- | --- |
+| PROF-01 | Confirming selected profiles removes only their SDD-agent keys: the selected names are passed to profile removal, and the removal test leaves no selected SDD/JD keys. | `internal/tui/model_test.go:2216-2247` — managed callbacks call `t.Fatal`; `reflect.DeepEqual(removedProfiles, []string{"cheap", "fast"})`. `internal/components/sdd/profiles_test.go:900-914` — exactly 11 default agents remain and no `-cheap` SDD/JD key remains. | ✅ PASS |
+| PROF-02 | Profile-only confirmation neither invokes managed-component uninstall nor deletes/rewrites Engram artifacts. | `internal/tui/model_test.go:2232-2238` — both managed callbacks fail the test if called. `internal/tui/model_test.go:2309-2315` and `internal/tui/screens/uninstall_result_test.go:88-92` — profile-only UI omits the Engram cleanup scope while identifying profile-only removal. | ✅ PASS |
+| PROF-03 | Default SDD agents, an unselected profile, and unrelated `opencode.json` content remain unchanged. | `internal/components/sdd/profiles_test.go:917-932` — every default key remains; `theme == "custom-theme"`; `reflect.DeepEqual(root["mcp"], unrelatedMCP)`. `internal/components/sdd/profiles_lifecycle_test.go:266-270` — after removing `cheap`, only `premium` remains. | ✅ PASS |
+| PROF-04 | A profile-removal error is reported as failure, never success. | `internal/tui/model_test.go:2265-2270` — `errors.Is(msg.Err, removalErr)` and stops after `cheap`. `internal/tui/model_test.go:2282-2297` — result screen, failure marker and exact error are present; success marker is absent. | ✅ PASS |
+
+**Status**: ✅ 4/4 requirements have test assertions matching their
+spec-defined outcomes; no spec-precision gaps.
+
+## Edge Cases
+
+| Edge case | Evidence | Result |
+| --- | --- | --- |
+| No named profile selected keeps the ordinary managed uninstall available. | `internal/tui/model_test.go:1937-1949` reaches confirmation without profiles; `internal/tui/model_test.go:1992-2025` invokes `UninstallFn` for that normal partial flow. Full-mode profile selection remains managed as asserted at `internal/tui/model_test.go:2183-2212`. | ✅ PASS |
+| A selected profile cannot be removed: surface the error and do not claim success. | `internal/tui/model_test.go:2250-2297`. | ✅ PASS |
+
+## Gate Check
+
+- **Gate command**: `go test ./...` (no feature `tasks.md`; this is the full
+  unit-suite command in `CONTRIBUTING.md:103-120`).
+- **Result**: ✅ PASS — exit code 0; all 57 listed Go packages completed, with
+  no test failures.
+- **Test integrity**: 2,938 declared `Test*` functions at `3b5da78^`;
+  2,943 at `9e9b2ec` (**+5**). The range adds six test functions and renames
+  one existing test; it removes none. No skips or weakened assertions were
+  reported/introduced in the range.
+
+## Discrimination Sensor
+
+All mutations ran in a detached temporary git worktree at `9e9b2ec`. Each
+targeted test was run with `-count=1`; the mutation was then reversed, the
+scratch worktree verified clean, and removed. The real worktree was not
+mutated.
+
+| # | File:line | Behavior-level mutation | Targeted test | Result |
+| --- | --- | --- | --- | --- |
+| 1 | `internal/tui/model.go:2948` | Changed the profile-only branch from partial mode to full mode, re-enabling managed uninstall for a selected partial profile. | `go test ./internal/tui -run '^TestStartUninstall_PartialProfileRemovalDoesNotRunManagedUninstall$' -count=1` | ✅ Killed — `UninstallWithProfilesFn must not run for profile-only removal`. |
+| 2 | `internal/components/sdd/profiles.go:738` | Deleted the unrelated `mcp` root entry before serializing `opencode.json`. | `go test ./internal/components/sdd -run '^TestRemoveProfileAgents_RemovesProfileSDDAndJDAgents$' -count=1` | ✅ Killed — unrelated MCP configuration was missing. |
+| 3 | `internal/tui/model.go:2951` | Suppressed the returned profile-removal error and returned a success message. | `go test ./internal/tui -run '^TestStartUninstall_PartialProfileRemovalReturnsError$' -count=1` | ✅ Killed — expected removal error was nil. |
+
+**Sensor depth**: lightweight (3 behavior-level mutations)
+**Result**: ✅ 3/3 killed; 0 survived.
+
+## Code Quality
+
+| Check | Result |
+| --- | --- |
+| No scope creep; only TUI profile routing, presentation, and supporting tests changed | ✅ |
+| No single-use abstraction or unnecessary flexibility | ✅ |
+| Surgical change matching existing callback/rendering patterns | ✅ |
+| Tests are non-shallow and map to requirements/edge cases | ✅ |
+| Spec-anchored asserted outcomes match the spec | ✅ |
+| Coverage expectations met: callback/domain preservation and TUI success/error paths are covered | ✅ |
+| Every changed test is claimed | ✅ — profile-only routing, Engram suppression, error presentation, data preservation, or retained managed flow |
+| Documented quality/testing guidance | ✅ — `CONTRIBUTING.md:103-120` |
+
+## Requirement Traceability
+
+| Requirement | Previous status | Validation status |
+| --- | --- | --- |
+| PROF-01 | Implementing | ✅ Verified |
+| PROF-02 | Implementing | ✅ Verified |
+| PROF-03 | Implementing | ✅ Verified |
+| PROF-04 | Implementing | ✅ Verified |
+
+## Lessons
+
+Clean PASS: no lesson recorded. `scripts/lessons.py` is absent in this
+repository, and no manual lesson artifact was created.
+
+## Summary
+
+**Overall**: ✅ Ready
+**Spec-anchored check**: 4/4 requirements matched exact asserted outcomes
+**Gate**: `go test ./...` passed
+**Sensor**: 3/3 mutations killed

--- a/internal/components/sdd/profiles_test.go
+++ b/internal/components/sdd/profiles_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"reflect"
 	"sort"
 	"strings"
 	"testing"
@@ -863,7 +864,13 @@ func buildSettingsWithProfiles(t *testing.T) (path string) {
 		agents[key] = map[string]any{"mode": "subagent"}
 	}
 
-	root := map[string]any{"agent": agents}
+	root := map[string]any{
+		"agent": agents,
+		"mcp": map[string]any{
+			"unrelated-server": map[string]any{"command": "unrelated-command"},
+		},
+		"theme": "custom-theme",
+	}
 	data, _ := json.MarshalIndent(root, "", "  ")
 	if err := os.WriteFile(settingsPath, data, 0o644); err != nil {
 		t.Fatalf("write settings: %v", err)
@@ -914,6 +921,15 @@ func TestRemoveProfileAgents_RemovesProfileSDDAndJDAgents(t *testing.T) {
 		if _, ok := agentMap[key]; !ok {
 			t.Errorf("default key %q was removed — should be preserved", key)
 		}
+	}
+
+	if got := root["theme"]; got != "custom-theme" {
+		t.Errorf("theme = %v, want custom-theme", got)
+	}
+	if got := root["mcp"]; !reflect.DeepEqual(got, map[string]any{
+		"unrelated-server": map[string]any{"command": "unrelated-command"},
+	}) {
+		t.Errorf("mcp = %#v, want unrelated MCP configuration preserved", got)
 	}
 }
 

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1134,9 +1134,10 @@ func (m Model) View() string {
 	case ScreenUninstallComponents:
 		return screens.RenderUninstallComponents(m.UninstallComponents, m.Cursor)
 	case ScreenUninstallProfiles:
-		return screens.RenderUninstallProfiles(m.UninstallProfilesAvailable, m.UninstallProfilesToRemove, m.UninstallEngramProjectScopeAvailable, m.UninstallEngramScope, m.Cursor)
+		engramProjectScopeAvailable := m.UninstallEngramProjectScopeAvailable && m.shouldShowUninstallEngramScopeSelection()
+		return screens.RenderUninstallProfiles(m.UninstallProfilesAvailable, m.UninstallProfilesToRemove, engramProjectScopeAvailable, m.UninstallEngramScope, m.Cursor)
 	case ScreenUninstallConfirm:
-		return screens.RenderUninstallConfirm(m.UninstallMode, m.UninstallAgents, m.UninstallComponents, m.UninstallProfilesToRemove, m.UninstallEngramScope, m.UninstallEngramProjectScopeAvailable, m.Cursor, m.OperationRunning, m.SpinnerFrame)
+		return screens.RenderUninstallConfirm(m.UninstallMode, m.UninstallAgents, m.UninstallComponents, m.UninstallProfilesToRemove, m.UninstallEngramScope, m.UninstallEngramProjectScopeAvailable, m.isProfileOnlyUninstall(), m.Cursor, m.OperationRunning, m.SpinnerFrame)
 	case ScreenUninstallResult:
 		return screens.RenderUninstallResult(m.UninstallResult, m.UninstallErr, m.UninstallMode, m.UninstallProfilesToRemove, m.UninstallEngramScope, m.UninstallEngramProjectScopeAvailable, m.SyncCleanInstallFiles, m.SyncCleanInstallErr)
 	case ScreenDetection:
@@ -2935,6 +2936,7 @@ func executeExternalCommand(commandFn func(string, ...string) *exec.Cmd, name st
 func (m Model) startUninstall() tea.Cmd {
 	uninstallFn := m.UninstallFn
 	uninstallWithProfilesFn := m.UninstallWithProfilesFn
+	profileRemovalFn := removeProfileAgentsFn
 	syncFn := m.SyncFn
 	agentIDs := append([]model.AgentID(nil), m.UninstallAgents...)
 	componentIDs := append([]model.ComponentID(nil), m.UninstallComponents...)
@@ -2943,6 +2945,15 @@ func (m Model) startUninstall() tea.Cmd {
 	profileSelectionUsed := m.UninstallProfileSelection || len(profileNamesToRemove) > 0
 	mode := m.UninstallMode
 	return func() tea.Msg {
+		if mode == model.UninstallModePartial && len(profileNamesToRemove) > 0 {
+			for _, profileName := range profileNamesToRemove {
+				if err := profileRemovalFn(opencode.DefaultSettingsPath(), profileName); err != nil {
+					return UninstallDoneMsg{Err: err}
+				}
+			}
+			return UninstallDoneMsg{}
+		}
+
 		if uninstallFn == nil && uninstallWithProfilesFn == nil {
 			return UninstallDoneMsg{Err: fmt.Errorf("uninstall function not configured")}
 		}
@@ -4473,6 +4484,9 @@ func (m Model) shouldShowUninstallProfilesSelection() bool {
 }
 
 func (m Model) shouldShowUninstallEngramScopeSelection() bool {
+	if m.UninstallMode == model.UninstallModePartial && m.shouldShowUninstallProfilesSelection() {
+		return false
+	}
 	if !hasSelectedComponent(m.UninstallComponents, model.ComponentEngram) {
 		return false
 	}
@@ -4481,6 +4495,10 @@ func (m Model) shouldShowUninstallEngramScopeSelection() bool {
 
 func (m Model) shouldShowUninstallSubSelection() bool {
 	return m.shouldShowUninstallProfilesSelection() || m.shouldShowUninstallEngramScopeSelection()
+}
+
+func (m Model) isProfileOnlyUninstall() bool {
+	return m.UninstallMode == model.UninstallModePartial && len(m.UninstallProfilesToRemove) > 0
 }
 
 func (m *Model) selectAllUninstallProfiles() {

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -2271,6 +2271,32 @@ func TestStartUninstall_PartialProfileRemovalReturnsError(t *testing.T) {
 	}
 }
 
+func TestUninstallDoneMsg_ProfileRemovalErrorRendersFailure(t *testing.T) {
+	removalErr := errors.New("cannot update opencode settings")
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Screen = ScreenUninstallConfirm
+	m.UninstallMode = model.UninstallModePartial
+	m.UninstallProfilesToRemove = []string{"cheap"}
+	m.OperationRunning = true
+
+	updated, _ := m.Update(UninstallDoneMsg{Err: removalErr})
+	state := updated.(Model)
+	if state.Screen != ScreenUninstallResult {
+		t.Fatalf("screen = %v, want %v", state.Screen, ScreenUninstallResult)
+	}
+
+	out := state.View()
+	if !strings.Contains(out, "✗ Uninstall failed") {
+		t.Fatalf("profile-removal error must render failure; got:\n%s", out)
+	}
+	if !strings.Contains(out, removalErr.Error()) {
+		t.Fatalf("profile-removal error must be shown; got:\n%s", out)
+	}
+	if strings.Contains(out, "✓ Uninstall complete") {
+		t.Fatalf("profile-removal error must not render success; got:\n%s", out)
+	}
+}
+
 func TestUninstallProfiles_PartialProfileRemovalHidesEngramCleanup(t *testing.T) {
 	m := NewModel(system.DetectionResult{}, "dev")
 	m.Screen = ScreenUninstallProfiles

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -2180,9 +2180,9 @@ func TestStartUninstall_FullRemoveNonBrewRemovesBinary(t *testing.T) {
 	}
 }
 
-func TestStartUninstall_UsesProfileAwareUninstallWhenConfigured(t *testing.T) {
+func TestStartUninstall_FullProfileSelectionUsesManagedUninstall(t *testing.T) {
 	m := NewModel(system.DetectionResult{}, "dev")
-	m.UninstallMode = model.UninstallModePartial
+	m.UninstallMode = model.UninstallModeFull
 	m.UninstallAgents = []model.AgentID{model.AgentOpenCode}
 	m.UninstallComponents = []model.ComponentID{model.ComponentSDD}
 	m.UninstallProfilesToRemove = []string{"cheap"}
@@ -2210,6 +2210,82 @@ func TestStartUninstall_UsesProfileAwareUninstallWhenConfigured(t *testing.T) {
 	}
 	if !called {
 		t.Fatal("UninstallWithProfilesFn was not called")
+	}
+}
+
+func TestStartUninstall_PartialProfileRemovalDoesNotRunManagedUninstall(t *testing.T) {
+	originalRemoveProfileAgentsFn := removeProfileAgentsFn
+	t.Cleanup(func() { removeProfileAgentsFn = originalRemoveProfileAgentsFn })
+
+	removedProfiles := make([]string, 0, 2)
+	removeProfileAgentsFn = func(settingsPath, profileName string) error {
+		if settingsPath != opencode.DefaultSettingsPath() {
+			t.Fatalf("settingsPath = %q, want %q", settingsPath, opencode.DefaultSettingsPath())
+		}
+		removedProfiles = append(removedProfiles, profileName)
+		return nil
+	}
+
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.UninstallMode = model.UninstallModePartial
+	m.UninstallProfilesToRemove = []string{"cheap", "fast"}
+	m.UninstallFn = func([]model.AgentID, []model.ComponentID) (componentuninstall.Result, error) {
+		t.Fatal("UninstallFn must not run for profile-only removal")
+		return componentuninstall.Result{}, nil
+	}
+	m.UninstallWithProfilesFn = func([]model.AgentID, []model.ComponentID, []string, model.EngramUninstallScope) (componentuninstall.Result, error) {
+		t.Fatal("UninstallWithProfilesFn must not run for profile-only removal")
+		return componentuninstall.Result{}, nil
+	}
+
+	msg := m.startUninstall()().(UninstallDoneMsg)
+	if msg.Err != nil {
+		t.Fatalf("UninstallDoneMsg.Err = %v, want nil", msg.Err)
+	}
+	if !reflect.DeepEqual(removedProfiles, []string{"cheap", "fast"}) {
+		t.Fatalf("removed profiles = %v, want [cheap fast]", removedProfiles)
+	}
+}
+
+func TestStartUninstall_PartialProfileRemovalReturnsError(t *testing.T) {
+	originalRemoveProfileAgentsFn := removeProfileAgentsFn
+	t.Cleanup(func() { removeProfileAgentsFn = originalRemoveProfileAgentsFn })
+
+	removalErr := errors.New("cannot update opencode settings")
+	removedProfiles := make([]string, 0, 2)
+	removeProfileAgentsFn = func(_ string, profileName string) error {
+		removedProfiles = append(removedProfiles, profileName)
+		return removalErr
+	}
+
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.UninstallMode = model.UninstallModePartial
+	m.UninstallProfilesToRemove = []string{"cheap", "fast"}
+
+	msg := m.startUninstall()().(UninstallDoneMsg)
+	if !errors.Is(msg.Err, removalErr) {
+		t.Fatalf("UninstallDoneMsg.Err = %v, want %v", msg.Err, removalErr)
+	}
+	if !reflect.DeepEqual(removedProfiles, []string{"cheap"}) {
+		t.Fatalf("removed profiles = %v, want [cheap]", removedProfiles)
+	}
+}
+
+func TestUninstallProfiles_PartialProfileRemovalHidesEngramCleanup(t *testing.T) {
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Screen = ScreenUninstallProfiles
+	m.UninstallMode = model.UninstallModePartial
+	m.UninstallComponents = []model.ComponentID{model.ComponentSDD, model.ComponentEngram}
+	m.UninstallProfilesAvailable = []string{"cheap"}
+	m.UninstallProfilesToRemove = []string{"cheap"}
+	m.UninstallEngramProjectScopeAvailable = true
+
+	out := m.View()
+	if strings.Contains(out, "Select Engram cleanup scope") {
+		t.Fatalf("profile-only uninstall must not show Engram cleanup; got:\n%s", out)
+	}
+	if strings.Contains(out, "Project-only cleanup") {
+		t.Fatalf("profile-only uninstall must not offer project cleanup; got:\n%s", out)
 	}
 }
 

--- a/internal/tui/screens/uninstall.go
+++ b/internal/tui/screens/uninstall.go
@@ -239,7 +239,7 @@ func RenderUninstallProfiles(available []string, selected []string, engramProjec
 	return b.String()
 }
 
-func RenderUninstallConfirm(mode model.UninstallMode, selected []model.AgentID, components []model.ComponentID, profilesToRemove []string, engramScope model.EngramUninstallScope, engramProjectScopeAvailable bool, cursor int, operationRunning bool, spinnerFrame int) string {
+func RenderUninstallConfirm(mode model.UninstallMode, selected []model.AgentID, components []model.ComponentID, profilesToRemove []string, engramScope model.EngramUninstallScope, engramProjectScopeAvailable bool, profileOnly bool, cursor int, operationRunning bool, spinnerFrame int) string {
 	var b strings.Builder
 
 	b.WriteString(styles.TitleStyle.Render("Confirm Uninstall"))
@@ -255,6 +255,11 @@ func RenderUninstallConfirm(mode model.UninstallMode, selected []model.AgentID, 
 	// Render mode-specific information
 	switch mode {
 	case model.UninstallModePartial:
+		if profileOnly {
+			b.WriteString(styles.SubtextStyle.Render("Mode: Profile-only removal"))
+			b.WriteString("\n\n")
+			break
+		}
 		if len(selected) == 0 {
 			b.WriteString(styles.WarningStyle.Render("No agents selected."))
 			b.WriteString("\n\n")
@@ -311,7 +316,7 @@ func RenderUninstallConfirm(mode model.UninstallMode, selected []model.AgentID, 
 		}
 	}
 
-	if hasSelectedComponent(components, model.ComponentEngram) {
+	if !profileOnly && hasSelectedComponent(components, model.ComponentEngram) {
 		b.WriteString("\n")
 		b.WriteString(styles.SubtextStyle.Render("Engram cleanup scope:"))
 		b.WriteString("\n")

--- a/internal/tui/screens/uninstall_result_test.go
+++ b/internal/tui/screens/uninstall_result_test.go
@@ -32,6 +32,7 @@ func TestRenderUninstallConfirmIncludesSelectedProfiles(t *testing.T) {
 		[]string{"cheap"},
 		model.EngramUninstallScopeGlobal,
 		false,
+		true,
 		0,
 		false,
 		0,
@@ -53,6 +54,7 @@ func TestRenderUninstallConfirmIncludesEngramProjectScopeDetails(t *testing.T) {
 		nil,
 		model.EngramUninstallScopeProject,
 		true,
+		false,
 		0,
 		false,
 		0,
@@ -66,6 +68,28 @@ func TestRenderUninstallConfirmIncludesEngramProjectScopeDetails(t *testing.T) {
 	}
 	if !strings.Contains(out, ".engram/") {
 		t.Fatalf("RenderUninstallConfirm() should mention .engram project data removal; got:\n%s", out)
+	}
+}
+
+func TestRenderUninstallConfirm_ProfileOnlyOmitsEngramCleanup(t *testing.T) {
+	out := RenderUninstallConfirm(
+		model.UninstallModePartial,
+		[]model.AgentID{model.AgentOpenCode},
+		[]model.ComponentID{model.ComponentSDD, model.ComponentEngram},
+		[]string{"cheap"},
+		model.EngramUninstallScopeProject,
+		true,
+		true,
+		0,
+		false,
+		0,
+	)
+
+	if strings.Contains(out, "Engram cleanup scope") {
+		t.Fatalf("profile-only confirmation must not include Engram cleanup; got:\n%s", out)
+	}
+	if !strings.Contains(out, "Profile-only removal") {
+		t.Fatalf("profile-only confirmation must identify its scope; got:\n%s", out)
 	}
 }
 


### PR DESCRIPTION
## 🔗 Linked Issue


---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

Separates partial OpenCode SDD profile removal from managed-component uninstall so removing selected profiles cannot clean up Engram. The normal managed uninstall path remains available when no profile is selected, and Full uninstall behavior is unchanged.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/tui/model.go` | Routes partial selected-profile removal through the profile remover instead of managed uninstall. |
| `internal/tui/screens/uninstall.go` | Identifies profile-only confirmation and omits Engram cleanup controls. |
| `internal/tui/*_test.go`, `internal/components/sdd/profiles_test.go` | Covers profile-only routing, errors, Engram isolation, and preservation of unrelated OpenCode settings. |
| `.specs/features/profile-only-uninstall/` | Records specification and independent validation evidence. |

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./...
```

**E2E Tests** (Docker required)
```bash
cd e2e && ./docker-test.sh
```

- [x] Unit tests pass (`go test ./...`)
- [x] E2E tests pass (`cd e2e && ./docker-test.sh`) — Ubuntu, Arch, and Fedora
- [x] Manually tested locally through TUI state and rendering tests

---

## 🤖 Automated Checks

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ✅ | 370 changed lines (within 400-line budget) |
| Check Issue Reference | ✅ | Closes #445 |
| Check Issue Has `status:approved` | ✅ | Issue #445 is approved |
| Check PR Has `type:*` Label | ✅ | `type:bug` applied |
| Unit Tests | ✅ | `go test ./...` passed |
| E2E Tests | ✅ | `cd e2e && ./docker-test.sh` passed on 3 platforms |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines; no `size:exception` required
- [x] I have added the appropriate `type:*` label
- [x] Unit tests pass (`go test ./...`)
- [x] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] I have updated documentation where needed
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

Independent validation covered all four acceptance criteria and killed 3/3 targeted behavior mutations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added profile-only removal for selected OpenCode SDD profiles.
  * Preserves unrelated settings, default agents, and unselected profiles.
  * Profile-only confirmation omits Engram cleanup options.
  * Removal errors are displayed as failures and stop further removal.

* **Tests**
  * Added coverage for profile-only behavior, error handling, UI messaging, and preservation of unrelated configuration.

* **Documentation**
  * Added feature specifications, validation criteria, and acceptance documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->