### PR TITLE
fix(review): stabilize receipt delivery boundaries

### DIFF
--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -517,6 +517,9 @@ func RunReviewFacadeFinalize(args []string, stdout io.Writer) error {
 		if validation == nil {
 			return encodeCompactFacadeFinalize(stdout, state, record.Revision, store, "apply the bounded correction, then rerun with --validation and --evidence")
 		}
+		if err := rejectFacadeCorrectionUntracked(context.Background(), root, state); err != nil {
+			return err
+		}
 		fixSnapshot, err := (reviewtransaction.SnapshotBuilder{Repo: root}).Build(context.Background(), reviewtransaction.Target{
 			Kind: reviewtransaction.TargetFixDiff, Projection: state.InitialSnapshot.Projection,
 			BaseRef: state.CurrentSnapshot.CandidateTree, IntendedUntracked: state.InitialSnapshot.IntendedUntracked,
@@ -942,6 +945,30 @@ func encodeCompactFacadeFinalize(stdout io.Writer, state reviewtransaction.Compa
 		result.ReceiptPath = store.ReceiptPath()
 	}
 	return encodeReviewJSON(stdout, result)
+}
+
+func rejectFacadeCorrectionUntracked(ctx context.Context, repo string, state reviewtransaction.CompactState) error {
+	if state.InitialSnapshot.Projection == reviewtransaction.ProjectionStaged {
+		return nil
+	}
+	live, err := (reviewtransaction.SnapshotBuilder{Repo: repo}).DiscoverIntendedUntracked(ctx)
+	if err != nil {
+		return fmt.Errorf("discover correction untracked paths: %w", err)
+	}
+	allowed := make(map[string]struct{}, len(state.CurrentSnapshot.IntendedUntracked))
+	for _, path := range state.CurrentSnapshot.IntendedUntracked {
+		allowed[path] = struct{}{}
+	}
+	unexpected := make([]string, 0)
+	for _, path := range live {
+		if _, ok := allowed[path]; !ok {
+			unexpected = append(unexpected, path)
+		}
+	}
+	if len(unexpected) != 0 {
+		return fmt.Errorf("correction contains untracked paths outside the frozen review scope: %s", strings.Join(unexpected, ", "))
+	}
+	return nil
 }
 
 func emitFacadeGateEvaluation(stdout io.Writer, evaluation reviewtransaction.NativeGateEvaluation) error {

--- a/internal/cli/review_facade_test.go
+++ b/internal/cli/review_facade_test.go
@@ -658,6 +658,86 @@ func TestReviewFacadeCorrectionFlowResumesFromEachCompactIntermediateState(t *te
 	}
 }
 
+func TestReviewFacadeFinalizeRejectsCorrectionCreatedUntrackedPath(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("base\none\ntwo\nthree\nfour\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	started := startFacadeReview(t, repo)
+	resultPath := filepath.Join(t.TempDir(), "review.json")
+	writeReviewCLIJSON(t, resultPath, facadeReviewerResult{
+		Findings: []facadeFinding{{
+			Location: "tracked.txt:5", Severity: "CRITICAL", Claim: "candidate returns the wrong terminal value",
+			ProofRefs:     []string{"differential test passes on base and fails on candidate"},
+			EvidenceClass: reviewtransaction.EvidenceDeterministic, CausalDisposition: reviewtransaction.CausalIntroduced,
+		}},
+		Evidence: []string{"focused differential test failed on candidate"},
+	})
+	if err := RunReviewFacadeFinalize([]string{"--cwd", repo, "--result", resultPath, "--correction-lines", "2"}, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("base\none\ntwo\nthree\nfixed\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "correction-evidence.json"), []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	validationPath := filepath.Join(t.TempDir(), "validation.json")
+	writeReviewCLIJSON(t, validationPath, facadeValidationResult{
+		OriginalCriteria:     facadeValidationCheck{Passed: true, Evidence: []string{"original acceptance test passed for tracked.txt and correction-evidence.json"}},
+		CorrectionRegression: facadeValidationCheck{Passed: true, Evidence: []string{"targeted regression passed for tracked.txt and correction-evidence.json"}},
+		FollowUps:            []reviewtransaction.FollowUp{},
+	})
+
+	err := RunReviewFacadeFinalize([]string{"--cwd", repo, "--validation", validationPath}, io.Discard)
+	if err == nil || !strings.Contains(err.Error(), "untracked") || !strings.Contains(err.Error(), "correction-evidence.json") {
+		t.Fatalf("correction-created untracked path error = %v", err)
+	}
+	store, storeErr := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, started.LineageID)
+	if storeErr != nil {
+		t.Fatal(storeErr)
+	}
+	record, loadErr := store.Load()
+	if loadErr != nil {
+		t.Fatal(loadErr)
+	}
+	if record.State.State != reviewtransaction.StateCorrectionRequired {
+		t.Fatalf("rejected correction mutated authority to %q", record.State.State)
+	}
+	if _, statErr := os.Stat(store.ReceiptPath()); !os.IsNotExist(statErr) {
+		t.Fatalf("rejected correction materialized receipt: %v", statErr)
+	}
+
+	if err := os.Remove(filepath.Join(repo, "correction-evidence.json")); err != nil {
+		t.Fatal(err)
+	}
+	if err := RunReviewFacadeFinalize([]string{"--cwd", repo, "--validation", validationPath}, io.Discard); err != nil {
+		t.Fatalf("exact tracked correction: %v", err)
+	}
+	record, loadErr = store.Load()
+	if loadErr != nil || record.State.State != reviewtransaction.StateValidating {
+		t.Fatalf("exact correction authority = %#v, %v", record.State, loadErr)
+	}
+}
+
+func TestRejectFacadeCorrectionUntrackedRespectsStagedProjection(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	if err := os.WriteFile(filepath.Join(repo, "excluded.json"), []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	state := reviewtransaction.CompactState{
+		InitialSnapshot: reviewtransaction.Snapshot{Projection: reviewtransaction.ProjectionStaged},
+		CurrentSnapshot: reviewtransaction.Snapshot{IntendedUntracked: []string{}},
+	}
+	if err := rejectFacadeCorrectionUntracked(context.Background(), repo, state); err != nil {
+		t.Fatalf("staged projection excluded workspace path: %v", err)
+	}
+	state.InitialSnapshot.Projection = reviewtransaction.ProjectionWorkspace
+	if err := rejectFacadeCorrectionUntracked(context.Background(), repo, state); err == nil {
+		t.Fatal("workspace projection accepted unreviewed correction path")
+	}
+}
+
 func TestReviewFacadePersistsOverBudgetForecastAndActual(t *testing.T) {
 	newCandidate := func(t *testing.T) (string, ReviewFacadeStartResult, string) {
 		t.Helper()
@@ -1160,6 +1240,8 @@ func TestReviewBindSDDFeedsSelectedSDDStatusRuntime(t *testing.T) {
 	if err := RunReviewFacadeFinalize([]string{"--cwd", repo, "--lineage", started.LineageID, "--evidence", evidence}, io.Discard); err != nil {
 		t.Fatal(err)
 	}
+	runReviewCLIGit(t, repo, "add", "-A")
+	runReviewCLIGit(t, repo, "commit", "-qm", "exact approved SDD candidate")
 	var output bytes.Buffer
 	if err := RunReview([]string{"bind-sdd", "--cwd", repo, "--change", "thin", "--lineage", started.LineageID, "--expected-binding-revision", ""}, &output); err != nil {
 		t.Fatal(err)
@@ -1239,7 +1321,7 @@ func TestCompactTransportCommandsRoundTripWithoutEventReconstruction(t *testing.
 	assertCompactLineageFiles(t, cloneStore, []string{"review-receipt.json", "review-state.json"})
 }
 
-func TestCompactTransportRecoversCorrectedCurrentChangesWithoutIntermediateTrees(t *testing.T) {
+func TestCompactTransportAllowsCorrectedPrePushWithoutTransientBaseObject(t *testing.T) {
 	source := initReviewCLIRepo(t)
 	if err := os.WriteFile(filepath.Join(source, "tracked.txt"), []byte("base\none\ntwo\nthree\nfour\n"), 0o644); err != nil {
 		t.Fatal(err)
@@ -1318,6 +1400,13 @@ func TestCompactTransportRecoversCorrectedCurrentChangesWithoutIntermediateTrees
 	var output bytes.Buffer
 	if err := RunReviewFacadeValidate([]string{"--cwd", clone, "--lineage", started.LineageID, "--gate", string(reviewtransaction.GatePrePush), "--base-ref", "origin/reviewed-base"}, &output); err != nil {
 		t.Fatalf("corrected recovered gate: %v\n%s", err, output.String())
+	}
+	var denied ReviewValidateResult
+	if err := json.Unmarshal(output.Bytes(), &denied); err != nil {
+		t.Fatal(err)
+	}
+	if !denied.Allowed || !denied.Context.BaseRelationshipValid {
+		t.Fatalf("corrected recovered gate = %#v", denied)
 	}
 }
 

--- a/internal/reviewtransaction/compact_gate.go
+++ b/internal/reviewtransaction/compact_gate.go
@@ -66,6 +66,9 @@ func EvaluateCompactGate(ctx context.Context, repo string, receipt CompactReceip
 	if (request.Gate == GatePostApply || request.Gate == GatePreCommit) && !equalStrings(request.Target.IntendedUntracked, record.State.CurrentSnapshot.IntendedUntracked) {
 		return invalid("current repository target does not retain the authoritative intended-untracked paths")
 	}
+	if err := validateCompactUntrackedScope(ctx, repo, record.State, request); err != nil {
+		return invalid(err.Error())
+	}
 	preimages, err := readGateArtifactPreimages(request)
 	if err != nil {
 		return invalid("compact gate evidence cannot be read: " + err.Error())
@@ -86,6 +89,11 @@ func EvaluateCompactGate(ctx context.Context, repo string, receipt CompactReceip
 	if request.Gate == GatePrePush && record.State.InitialSnapshot.Kind == TargetCurrentChanges && resolvedPrePR.DeliveredCommitCount != 1 {
 		return invalid("pre-push current-changes receipt requires exactly one delivery commit")
 	}
+	if request.Gate == GatePrePush && record.State.InitialSnapshot.Kind == TargetBaseDiff {
+		if err := validateCompactPublicationRange(ctx, repo, record.State.GenesisPaths, resolvedPrePR); err != nil {
+			return invalid(err.Error())
+		}
+	}
 	compatibleAdvance := false
 	var compatibility *BaseAdvanceCompatibility
 	if request.Gate == GatePrePR && snapshot.BaseTree != receipt.BaseTree {
@@ -95,23 +103,37 @@ func EvaluateCompactGate(ctx context.Context, repo string, receipt CompactReceip
 			compatibleAdvance = proof.Compatible
 		}
 	}
+	binding := record.State.CurrentSnapshot
+	strictBinding := request.Gate == GatePostApply || request.Gate == GatePreCommit || request.Gate == GatePrePush && record.State.InitialSnapshot.Kind != TargetCurrentChanges
+	baseRelationshipValid := snapshot.BaseTree == receipt.BaseTree || request.Target.Kind == TargetFixDiff
+	if strictBinding {
+		baseRelationshipValid = snapshot.BaseTree == binding.BaseTree
+	}
 	gateContext := GateContext{
 		Gate: request.Gate, LineageID: receipt.LineageID, Generation: receipt.Generation,
 		StoreRevision: record.Revision, GenesisRevision: record.Revision, ChainIdentity: record.Revision, BundleDigest: record.Revision,
 		BaseTree: snapshot.BaseTree, CandidateTree: snapshot.CandidateTree, PathsDigest: snapshot.PathsDigest,
 		FixDeltaHash: record.State.FixDeltaHash, PolicyHash: record.State.PolicyHash,
 		LedgerHash: EmptyFixDeltaHash, EvidenceHash: record.State.EvidenceHash,
-		BaseRelationshipValid: snapshot.BaseTree == receipt.BaseTree || request.Target.Kind == TargetFixDiff, BaseAdvance: compatibility,
+		BaseRelationshipValid: baseRelationshipValid, BaseAdvance: compatibility,
 	}
 	if request.Gate == GatePrePR && resolvedPrePR != nil {
 		boundary := resolvedPrePR.Selection
 		gateContext.PrePRBoundary = &boundary
 	}
-	if snapshot.CandidateTree != receipt.FinalCandidateTree || pathsAreSubset(snapshot.Paths, record.State.GenesisPaths) != nil && !compatibleAdvance {
+	pathsMismatch := pathsAreSubset(snapshot.Paths, record.State.GenesisPaths) != nil && !compatibleAdvance
+	if strictBinding {
+		pathsMismatch = snapshot.PathsDigest != binding.PathsDigest
+	}
+	if snapshot.CandidateTree != receipt.FinalCandidateTree || pathsMismatch {
 		gateContext.Denial = &GateDenial{Stage: "receipt-binding", Code: "candidate-or-paths-mismatch"}
 		return NativeGateEvaluation{Result: GateScopeChanged, Reason: nativeGateReason(GateScopeChanged), Context: gateContext}
 	}
-	if snapshot.BaseTree != receipt.BaseTree && request.Target.Kind != TargetFixDiff && !compatibleAdvance {
+	baseMismatch := snapshot.BaseTree != receipt.BaseTree && request.Target.Kind != TargetFixDiff && !compatibleAdvance
+	if strictBinding {
+		baseMismatch = snapshot.BaseTree != binding.BaseTree
+	}
+	if baseMismatch {
 		gateContext.Denial = &GateDenial{Stage: "receipt-binding", Code: "base-mismatch"}
 		return NativeGateEvaluation{Result: GateInvalidated, Reason: "current repository base no longer matches compact authority", Context: gateContext}
 	}
@@ -135,9 +157,11 @@ func EvaluateCompactGate(ctx context.Context, repo string, receipt CompactReceip
 	finalGateAuthorizationHook()
 	finalRecord, loadErr := store.Load()
 	finalSnapshot, finalRefs, snapshotErr := buildCompactLifecycleSnapshot(ctx, repo, request)
+	finalUntrackedErr := validateCompactUntrackedScope(ctx, repo, record.State, request)
+	finalTrackedErr := validateCompactCommittedTrackedScope(ctx, repo, request)
 	_, graphErr := CompactAuthorityLeaves(ctx, repo)
 	finalSuperseded, supersededErr := CompactLineageSuperseded(ctx, repo, receipt.LineageID)
-	if loadErr != nil || snapshotErr != nil || graphErr != nil || supersededErr != nil || finalSuperseded || finalRecord.Revision != record.Revision || !reflect.DeepEqual(finalSnapshot, snapshot) || !sameResolvedPrePRRefs(finalRefs, resolvedPrePR) {
+	if loadErr != nil || snapshotErr != nil || finalUntrackedErr != nil || finalTrackedErr != nil || graphErr != nil || supersededErr != nil || finalSuperseded || finalRecord.Revision != record.Revision || !reflect.DeepEqual(finalSnapshot, snapshot) || !sameResolvedPrePRRefs(finalRefs, resolvedPrePR) {
 		return invalid("compact authority or repository target changed during final authorization")
 	}
 	if request.Gate == GateRelease {
@@ -152,7 +176,10 @@ func EvaluateCompactGate(ctx context.Context, repo string, receipt CompactReceip
 }
 
 func buildCompactLifecycleSnapshot(ctx context.Context, repo string, request GateRequest) (Snapshot, *resolvedPrePRRefs, error) {
-	if request.Target.Kind == TargetFixDiff {
+	if request.Gate == GatePreCommit && request.Target.Projection == ProjectionStaged {
+		request.Target.IntendedUntracked = []string{}
+	}
+	if request.Target.Kind == TargetFixDiff || request.Target.Kind == TargetBaseDiff && (request.Gate == GatePostApply || request.Gate == GatePreCommit) {
 		snapshot, err := (SnapshotBuilder{Repo: repo}).build(ctx, request.Target, request.Gate == GatePreCommit)
 		return snapshot, nil, err
 	}
@@ -170,7 +197,34 @@ func buildCompactGateRequest(ctx context.Context, repo string, state CompactStat
 		if intended == nil {
 			intended = []string{}
 		}
-		request.Target = Target{Kind: TargetCurrentChanges, Projection: state.InitialSnapshot.Projection, IntendedUntracked: intended}
+		current := state.CurrentSnapshot
+		projection := current.Projection
+		if input.Gate == GatePreCommit {
+			projection = ProjectionStaged
+		}
+		if current.Kind == TargetFixDiff {
+			request.Target = Target{
+				Kind: TargetFixDiff, Projection: projection, BaseRef: current.BaseTree,
+				IntendedUntracked: intended, LedgerIDs: append([]string(nil), current.LedgerIDs...),
+			}
+			break
+		}
+		headTree, err := (SnapshotBuilder{Repo: repo}).resolveTree(ctx, "HEAD")
+		if err != nil {
+			return GateRequest{}, err
+		}
+		if headTree == current.CandidateTree {
+			dirty, err := (SnapshotBuilder{Repo: repo}).HasDirtyTrackedChanges(ctx)
+			if err != nil {
+				return GateRequest{}, err
+			}
+			if dirty {
+				return GateRequest{}, errors.New("committed approved target has dirty tracked changes")
+			}
+			request.Target = Target{Kind: TargetBaseDiff, Projection: projection, BaseRef: current.BaseTree, IntendedUntracked: intended}
+			break
+		}
+		request.Target = Target{Kind: TargetCurrentChanges, Projection: projection, IntendedUntracked: intended}
 	case GatePrePush:
 		deliveryBaseTree := map[TargetKind]string{TargetCurrentChanges: state.InitialSnapshot.BaseTree}[state.InitialSnapshot.Kind]
 		target, push, err := buildPushTarget(ctx, repo, input.BaseRef, deliveryBaseTree)
@@ -211,4 +265,62 @@ func buildCompactGateRequest(ctx context.Context, repo string, state CompactStat
 		}
 	}
 	return request, nil
+}
+
+func validateCompactUntrackedScope(ctx context.Context, repo string, state CompactState, request GateRequest) error {
+	if request.Target.Projection == ProjectionStaged || request.Gate != GatePostApply && request.Gate != GatePreCommit {
+		return nil
+	}
+	live, err := (SnapshotBuilder{Repo: repo}).DiscoverIntendedUntracked(ctx)
+	if err != nil {
+		return fmt.Errorf("discover current untracked paths: %w", err)
+	}
+	allowed := make(map[string]struct{}, len(state.CurrentSnapshot.IntendedUntracked))
+	for _, path := range state.CurrentSnapshot.IntendedUntracked {
+		allowed[path] = struct{}{}
+	}
+	for _, path := range live {
+		if _, ok := allowed[path]; ok || isPostReviewLifecycleArtifact(path) {
+			continue
+		}
+		return errors.New("current repository contains untracked paths outside the authoritative review scope")
+	}
+	return nil
+}
+
+func validateCompactCommittedTrackedScope(ctx context.Context, repo string, request GateRequest) error {
+	if request.Target.Kind != TargetBaseDiff || request.Gate != GatePostApply && request.Gate != GatePreCommit {
+		return nil
+	}
+	dirty, err := (SnapshotBuilder{Repo: repo}).HasDirtyTrackedChanges(ctx)
+	if err != nil || !dirty {
+		return err
+	}
+	return errors.New("committed approved target has dirty tracked changes")
+}
+
+func validateCompactPublicationRange(ctx context.Context, repo string, genesis []string, refs *resolvedPrePRRefs) error {
+	output, err := runGit(ctx, repo, nil, nil, "log", "--format=", "--name-only", "-z", "--no-renames", refs.BaseCommit+".."+refs.HeadCommit)
+	if err != nil {
+		return fmt.Errorf("inspect complete publication range: %w", err)
+	}
+	paths := []string{}
+	for _, path := range strings.Split(string(output), "\x00") {
+		if path != "" {
+			paths = append(paths, path)
+		}
+	}
+	paths, err = canonicalPaths(paths)
+	if err == nil {
+		err = pathsAreSubset(paths, genesis)
+	}
+	if err != nil {
+		return fmt.Errorf("publication range exceeds immutable genesis scope: %w", err)
+	}
+	return nil
+}
+
+func isPostReviewLifecycleArtifact(path string) bool {
+	parts := strings.Split(path, "/")
+	return len(parts) == 4 && parts[0] == "openspec" && parts[1] == "changes" && parts[3] == "verify-report.md"
 }

--- a/internal/reviewtransaction/compact_gate_test.go
+++ b/internal/reviewtransaction/compact_gate_test.go
@@ -187,6 +187,143 @@ func TestCompactGateAllowsCorrectedFinalSnapshotWithIntendedUntracked(t *testing
 	}
 }
 
+func TestCompactPostApplyPreservesExactCommittedApprovedTarget(t *testing.T) {
+	tests := []struct {
+		name  string
+		start func(t *testing.T, repo, lineage string) CompactState
+	}{
+		{
+			name: "current changes",
+			start: func(t *testing.T, repo, lineage string) CompactState {
+				writeSnapshotFile(t, repo, "tracked.txt", "approved current changes\n")
+				return newCompactStartStateForTarget(t, repo, lineage, Target{Kind: TargetCurrentChanges, IntendedUntracked: []string{}})
+			},
+		},
+		{
+			name: "base diff",
+			start: func(t *testing.T, repo, lineage string) CompactState {
+				base := strings.TrimSpace(gitSnapshot(t, repo, "rev-parse", "HEAD"))
+				writeSnapshotFile(t, repo, "tracked.txt", "approved committed base diff\n")
+				gitSnapshot(t, repo, "add", "tracked.txt")
+				gitSnapshot(t, repo, "commit", "-m", "reviewed candidate")
+				return newCompactStartStateForTarget(t, repo, lineage, Target{Kind: TargetBaseDiff, BaseRef: base, IntendedUntracked: []string{}})
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := initSnapshotRepo(t)
+			state := tt.start(t, repo, "compact-committed-"+strings.ReplaceAll(tt.name, " ", "-"))
+			state, receipt := persistApprovedCompactState(t, repo, state)
+			if state.InitialSnapshot.Kind == TargetCurrentChanges {
+				gitSnapshot(t, repo, "add", "tracked.txt")
+				gitSnapshot(t, repo, "commit", "-m", "reviewed candidate")
+			}
+
+			got := EvaluateCompactGate(context.Background(), repo, receipt, NativeGateRequestInput{Gate: GatePostApply, LineageID: state.LineageID})
+			replayed := EvaluateCompactGate(context.Background(), repo, receipt, NativeGateRequestInput{Gate: GatePostApply, LineageID: state.LineageID})
+			if got.Result != GateAllow || !reflect.DeepEqual(got, replayed) || got.Context.BaseTree != state.CurrentSnapshot.BaseTree || got.Context.CandidateTree != state.CurrentSnapshot.CandidateTree || got.Context.PathsDigest != state.CurrentSnapshot.PathsDigest {
+				t.Fatalf("exact committed approved target = %#v", got)
+			}
+
+			writeSnapshotFile(t, repo, "tracked.txt", "base\n")
+			if missing := EvaluateCompactGate(context.Background(), repo, receipt, NativeGateRequestInput{Gate: GatePostApply, LineageID: state.LineageID}); missing.Result == GateAllow {
+				t.Fatalf("committed target with missing reviewed path = %#v", missing)
+			}
+			writeSnapshotFile(t, repo, "tracked.txt", "changed after approval\n")
+			if changed := EvaluateCompactGate(context.Background(), repo, receipt, NativeGateRequestInput{Gate: GatePostApply, LineageID: state.LineageID}); changed.Result == GateAllow {
+				t.Fatalf("changed committed tree = %#v", changed)
+			}
+		})
+	}
+}
+
+func TestCompactPostApplyRejectsUnboundUntrackedPathAfterCommit(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	writeSnapshotFile(t, repo, "tracked.txt", "approved candidate\n")
+	state := newCompactStartStateForTarget(t, repo, "compact-committed-extra-untracked", Target{Kind: TargetCurrentChanges, IntendedUntracked: []string{}})
+	state, receipt := persistApprovedCompactState(t, repo, state)
+	gitSnapshot(t, repo, "add", "tracked.txt")
+	gitSnapshot(t, repo, "commit", "-m", "reviewed candidate")
+	writeSnapshotFile(t, repo, "correction-evidence.json", "{}\n")
+
+	got := EvaluateCompactGate(context.Background(), repo, receipt, NativeGateRequestInput{Gate: GatePostApply, LineageID: state.LineageID})
+	if got.Result == GateAllow {
+		t.Fatalf("unbound untracked path = %#v", got)
+	}
+	if err := os.Remove(filepath.Join(repo, "correction-evidence.json")); err != nil {
+		t.Fatal(err)
+	}
+	verifyReport := filepath.Join(repo, "openspec", "changes", "thin", "verify-report.md")
+	if err := os.MkdirAll(filepath.Dir(verifyReport), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(verifyReport, []byte("# Verification\n\nPASS\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if lifecycle := EvaluateCompactGate(context.Background(), repo, receipt, NativeGateRequestInput{Gate: GatePostApply, LineageID: state.LineageID}); lifecycle.Result != GateAllow {
+		t.Fatalf("post-review verify report = %#v", lifecycle)
+	}
+}
+
+func TestCompactFixDiffUsesAuthoritativeCorrectionBindingAcrossDelivery(t *testing.T) {
+	t.Run("uncommitted pre-commit", func(t *testing.T) {
+		repo, state, receipt, _ := approvedCompactFixDiffFixture(t, "compact-fix-pre-commit")
+		gitSnapshot(t, repo, "add", "other.txt")
+		got := EvaluateCompactGate(context.Background(), repo, receipt, NativeGateRequestInput{Gate: GatePreCommit, LineageID: state.LineageID})
+		replayed := EvaluateCompactGate(context.Background(), repo, receipt, NativeGateRequestInput{Gate: GatePreCommit, LineageID: state.LineageID})
+		if got.Result != GateAllow || !reflect.DeepEqual(got, replayed) || got.Context.BaseTree != state.CurrentSnapshot.BaseTree || got.Context.CandidateTree != state.CurrentSnapshot.CandidateTree || got.Context.PathsDigest != state.CurrentSnapshot.PathsDigest {
+			t.Fatalf("exact uncommitted correction = %#v", got)
+		}
+	})
+
+	t.Run("committed pre-push", func(t *testing.T) {
+		repo, state, receipt, baseRef := approvedCompactFixDiffFixture(t, "compact-fix-pre-push")
+		gitSnapshot(t, repo, "add", "other.txt")
+		gitSnapshot(t, repo, "commit", "-m", "approved correction")
+		got := EvaluateCompactGate(context.Background(), repo, receipt, NativeGateRequestInput{Gate: GatePrePush, LineageID: state.LineageID, BaseRef: baseRef})
+		replayed := EvaluateCompactGate(context.Background(), repo, receipt, NativeGateRequestInput{Gate: GatePrePush, LineageID: state.LineageID, BaseRef: baseRef})
+		if got.Result != GateAllow || !reflect.DeepEqual(got, replayed) || got.Context.BaseTree != state.CurrentSnapshot.BaseTree || got.Context.CandidateTree != state.CurrentSnapshot.CandidateTree || got.Context.PathsDigest != state.CurrentSnapshot.PathsDigest {
+			t.Fatalf("exact committed correction = %#v", got)
+		}
+	})
+}
+
+func TestCompactFixDiffRejectsInexactCorrectionBinding(t *testing.T) {
+	tests := []struct {
+		name   string
+		gate   GateKind
+		mutate func(t *testing.T, repo string)
+	}{
+		{name: "pre-commit extra staged path", gate: GatePreCommit, mutate: func(t *testing.T, repo string) {
+			writeSnapshotFile(t, repo, "extra.go", "package extra\n")
+			gitSnapshot(t, repo, "add", "extra.go")
+		}},
+		{name: "pre-commit missing correction", gate: GatePreCommit, mutate: func(t *testing.T, repo string) {
+			writeSnapshotFile(t, repo, "other.txt", "reviewed other\n")
+		}},
+		{name: "pre-commit untracked path", gate: GatePreCommit, mutate: func(t *testing.T, repo string) {
+			writeSnapshotFile(t, repo, "extra.json", "{}\n")
+		}},
+		{name: "pre-push extra committed path", gate: GatePrePush, mutate: func(t *testing.T, repo string) {
+			gitSnapshot(t, repo, "add", "other.txt")
+			writeSnapshotFile(t, repo, "tracked.txt", "changed outside approved correction\n")
+			gitSnapshot(t, repo, "add", "tracked.txt")
+			gitSnapshot(t, repo, "commit", "-m", "inexact correction")
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo, state, receipt, baseRef := approvedCompactFixDiffFixture(t, "compact-inexact-"+strings.ReplaceAll(tt.name, " ", "-"))
+			tt.mutate(t, repo)
+			got := EvaluateCompactGate(context.Background(), repo, receipt, NativeGateRequestInput{Gate: tt.gate, LineageID: state.LineageID, BaseRef: baseRef})
+			if got.Result == GateAllow {
+				t.Fatalf("inexact correction binding = %#v", got)
+			}
+		})
+	}
+}
+
 func TestCompactPreCommitGateRejectsInexactStagedIntendedTransitions(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -280,6 +417,44 @@ func TestCompactPreCommitGateRechecksStagedIntendedTarget(t *testing.T) {
 	got := EvaluateCompactGate(context.Background(), repo, receipt, NativeGateRequestInput{Gate: GatePreCommit, LineageID: state.LineageID})
 	if got.Result != GateInvalidated || !strings.Contains(got.Reason, "changed during final authorization") {
 		t.Fatalf("staged intended TOCTOU evaluation = %#v", got)
+	}
+}
+
+func TestCompactGateFinalRecheckRejectsConcurrentUntrackedPath(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	writeSnapshotFile(t, repo, "tracked.txt", "reviewed candidate\n")
+	state, _, receipt := approvedCompactCurrentChangesFixture(t, repo, "compact-untracked-recheck", []string{})
+	originalHook := finalGateAuthorizationHook
+	finalGateAuthorizationHook = func() {
+		writeSnapshotFile(t, repo, "late-evidence.json", "{}\n")
+	}
+	t.Cleanup(func() { finalGateAuthorizationHook = originalHook })
+
+	got := EvaluateCompactGate(context.Background(), repo, receipt, NativeGateRequestInput{Gate: GatePostApply, LineageID: state.LineageID})
+	if got.Result != GateInvalidated || !strings.Contains(got.Reason, "changed during final authorization") {
+		t.Fatalf("concurrent untracked path = %#v", got)
+	}
+}
+
+func TestCompactCommittedGateRechecksConcurrentDirtyTrackedTarget(t *testing.T) {
+	for _, gate := range []GateKind{GatePostApply, GatePreCommit} {
+		t.Run(string(gate), func(t *testing.T) {
+			repo := initSnapshotRepo(t)
+			writeSnapshotFile(t, repo, "tracked.txt", "reviewed candidate\n")
+			state := newCompactStartStateForTarget(t, repo, "compact-dirty-recheck-"+string(gate), Target{Kind: TargetCurrentChanges, IntendedUntracked: []string{}})
+			state, receipt := persistApprovedCompactState(t, repo, state)
+			gitSnapshot(t, repo, "add", "tracked.txt")
+			gitSnapshot(t, repo, "commit", "-m", "reviewed candidate")
+			if control := EvaluateCompactGate(context.Background(), repo, receipt, NativeGateRequestInput{Gate: gate, LineageID: state.LineageID}); control.Result != GateAllow {
+				t.Fatalf("unchanged committed target = %#v", control)
+			}
+			originalHook := finalGateAuthorizationHook
+			finalGateAuthorizationHook = func() { writeSnapshotFile(t, repo, "tracked.txt", "concurrent mutation\n") }
+			t.Cleanup(func() { finalGateAuthorizationHook = originalHook })
+			if got := EvaluateCompactGate(context.Background(), repo, receipt, NativeGateRequestInput{Gate: gate, LineageID: state.LineageID}); got.Result != GateInvalidated {
+				t.Fatalf("concurrent dirty tracked target = %#v", got)
+			}
+		})
 	}
 }
 
@@ -437,15 +612,70 @@ func TestCompactPrePRGatePreservesBoundaryContextForExactAndUnavailableSelectors
 	}
 }
 
-func TestCompactDeliveryGatesAllowFinalSubsetOfGenesisPaths(t *testing.T) {
-	for _, gate := range []GateKind{GatePrePush, GatePrePR} {
-		t.Run(string(gate), func(t *testing.T) {
-			repo, state, receipt, baseRef := approvedCompactSubsetDeliveryFixture(t, "compact-subset-"+string(gate))
-			got := EvaluateCompactGate(context.Background(), repo, receipt, NativeGateRequestInput{Gate: gate, LineageID: state.LineageID, BaseRef: baseRef})
-			if got.Result != GateAllow {
-				t.Fatalf("subset delivery gate = %#v", got)
-			}
-		})
+func TestCompactPrePRGateAllowsFinalSubsetOfGenesisPaths(t *testing.T) {
+	repo, state, receipt, baseRef := approvedCompactSubsetDeliveryFixture(t, "compact-subset-pre-pr")
+	got := EvaluateCompactGate(context.Background(), repo, receipt, NativeGateRequestInput{Gate: GatePrePR, LineageID: state.LineageID, BaseRef: baseRef})
+	if got.Result != GateAllow {
+		t.Fatalf("subset pre-PR gate = %#v", got)
+	}
+}
+
+func TestCompactPrePushAllowsCurrentChangesWithoutTransientCorrectionBaseCommit(t *testing.T) {
+	repo, state, receipt, baseRef := approvedCompactSubsetDeliveryFixture(t, "compact-subset-pre-push")
+	got := EvaluateCompactGate(context.Background(), repo, receipt, NativeGateRequestInput{Gate: GatePrePush, LineageID: state.LineageID, BaseRef: baseRef})
+	if got.Result != GateAllow || !got.Context.BaseRelationshipValid {
+		t.Fatalf("pre-push final delivery binding = %#v", got)
+	}
+}
+
+func TestCompactCorrectedBaseDiffPrePushRejectsIntermediateUnreviewedPath(t *testing.T) {
+	repo, state, receipt, baseRef := approvedCompactFixDiffFixture(t, "compact-hidden-range-path")
+	writeSnapshotFile(t, repo, "secret.txt", "must never be published\n")
+	gitSnapshot(t, repo, "add", "other.txt", "secret.txt")
+	gitSnapshot(t, repo, "commit", "-m", "intermediate secret")
+	if err := os.Remove(filepath.Join(repo, "secret.txt")); err != nil {
+		t.Fatal(err)
+	}
+	gitSnapshot(t, repo, "add", "-A")
+	gitSnapshot(t, repo, "commit", "-m", "remove intermediate secret")
+	if got := EvaluateCompactGate(context.Background(), repo, receipt, NativeGateRequestInput{Gate: GatePrePush, LineageID: state.LineageID, BaseRef: baseRef}); got.Result == GateAllow {
+		t.Fatalf("publication range with hidden path = %#v", got)
+	}
+}
+func TestCompactCorrectedPreCommitBindsStagedIndexAndIgnoresWorkspace(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	state := correctedCompactTestStateWithIntended(t, repo, "compact-corrected-staged-index", []string{"new.txt"})
+	receipt := persistCorrectedCompactFixture(t, repo, state)
+	gitSnapshot(t, repo, "add", "tracked.txt", "new.txt")
+	writeSnapshotFile(t, repo, "tracked.txt", "unstaged workspace divergence\n")
+	writeSnapshotFile(t, repo, "excluded.txt", "outside staged projection\n")
+	input := NativeGateRequestInput{Gate: GatePreCommit, LineageID: state.LineageID}
+	if got := EvaluateCompactGate(context.Background(), repo, receipt, input); got.Result != GateAllow {
+		t.Fatalf("exact staged corrected target = %#v", got)
+	}
+	gitSnapshot(t, repo, "add", "tracked.txt")
+	if got := EvaluateCompactGate(context.Background(), repo, receipt, input); got.Result == GateAllow {
+		t.Fatalf("mutated staged correction = %#v", got)
+	}
+}
+
+func TestCompactCorrectedCurrentChangesPrePushUsesFinalDeliveryBinding(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	branch := currentBranch(context.Background(), repo)
+	configurePublicationRemote(t, repo, branch)
+	gitSnapshot(t, repo, "config", "branch."+branch+".remote", "origin")
+	gitSnapshot(t, repo, "config", "branch."+branch+".merge", "refs/heads/"+branch)
+	state := correctedCompactTestStateWithIntended(t, repo, "compact-corrected-current-delivery", []string{})
+	receipt := persistCorrectedCompactFixture(t, repo, state)
+	gitSnapshot(t, repo, "add", "tracked.txt")
+	gitSnapshot(t, repo, "commit", "-m", "corrected delivery")
+	input := NativeGateRequestInput{Gate: GatePrePush, LineageID: state.LineageID, BaseRef: "origin/" + branch}
+	if got := EvaluateCompactGate(context.Background(), repo, receipt, input); got.Result != GateAllow {
+		t.Fatalf("one-commit corrected delivery = %#v", got)
+	}
+	gitSnapshot(t, repo, "commit", "--allow-empty", "-m", "unreviewed extra commit")
+	if got := EvaluateCompactGate(context.Background(), repo, receipt, input); got.Result == GateAllow {
+		t.Fatalf("multi-commit current-changes delivery = %#v", got)
 	}
 }
 
@@ -541,6 +771,149 @@ func approvedCompactRevisionFixture(t *testing.T, repo, lineage string) (Compact
 		t.Fatal(err)
 	}
 	return state, store, receipt
+}
+
+func persistApprovedCompactState(t *testing.T, repo string, state CompactState) (CompactState, CompactReceipt) {
+	t.Helper()
+	store, err := CompactAuthoritativeStore(context.Background(), repo, state.LineageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	revision, err := store.Replace("", "review/start", state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	results := make([]LensResult, len(state.SelectedLenses))
+	for index, lens := range state.SelectedLenses {
+		results[index] = LensResult{Lens: lens, Findings: []Finding{}, Evidence: []string{"review completed"}}
+	}
+	if err := state.CompleteReview(CompactReviewInput{LensResults: results, Classifications: []FindingEvidence{}, RefuterOutcomes: []EvidenceResult{}}); err != nil {
+		t.Fatal(err)
+	}
+	revision, err = store.Replace(revision, "review/complete-review", state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := state.CompleteVerification([]byte("independent verification passed\n"), true); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Replace(revision, "review/complete-verification", state); err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := state.Receipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteCompactReceiptAtomic(store.ReceiptPath(), receipt); err != nil {
+		t.Fatal(err)
+	}
+	return state, receipt
+}
+
+func persistCorrectedCompactFixture(t *testing.T, repo string, state CompactState) CompactReceipt {
+	t.Helper()
+	state.CorrectionAttempts = []CompactCorrectionAttempt{{
+		Snapshot: state.CurrentSnapshot, ProposedLines: *state.ProposedCorrectionLines, ActualLines: *state.ActualCorrectionLines,
+		FixDeltaHash: state.FixDeltaHash, OriginalCriteria: *state.OriginalCriteria, CorrectionRegression: *state.CorrectionRegression,
+	}}
+	state.CumulativeCorrectionLines = *state.ActualCorrectionLines
+	store, _ := CompactAuthoritativeStore(context.Background(), repo, state.LineageID)
+	_, payload, err := makeCompactRecord(state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(store.Dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(store.StatePath(), payload, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := state.Receipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteCompactReceiptAtomic(store.ReceiptPath(), receipt); err != nil {
+		t.Fatal(err)
+	}
+	return receipt
+}
+
+func approvedCompactFixDiffFixture(t *testing.T, lineage string) (string, CompactState, CompactReceipt, string) {
+	t.Helper()
+	repo := initSnapshotRepo(t)
+	writeSnapshotFile(t, repo, "other.txt", "base other\n")
+	gitSnapshot(t, repo, "add", "other.txt")
+	gitSnapshot(t, repo, "commit", "-m", "add correction base path")
+	base := strings.TrimSpace(gitSnapshot(t, repo, "rev-parse", "HEAD"))
+	writeSnapshotFile(t, repo, "tracked.txt", "reviewed tracked\n")
+	writeSnapshotFile(t, repo, "other.txt", "reviewed other\n")
+	gitSnapshot(t, repo, "add", "tracked.txt", "other.txt")
+	gitSnapshot(t, repo, "commit", "-m", "reviewed candidate")
+	state := newCompactStartStateForTarget(t, repo, lineage, Target{Kind: TargetBaseDiff, BaseRef: base, IntendedUntracked: []string{}})
+	finding := Finding{ID: "R3-001", Lens: "reliability", Location: "other.txt:1", Severity: "CRITICAL", Claim: "candidate returns the wrong value", ProofRefs: []string{"differential test fails only on candidate"}}
+	results := make([]LensResult, len(state.SelectedLenses))
+	for index, lens := range state.SelectedLenses {
+		results[index] = LensResult{Lens: lens, Findings: []Finding{}, Evidence: []string{"reviewed"}}
+		if lens == LensReliability {
+			results[index].Findings = []Finding{finding}
+		}
+	}
+	if err := state.CompleteReview(CompactReviewInput{
+		LensResults:     results,
+		Classifications: []FindingEvidence{{FindingID: finding.ID, Class: EvidenceDeterministic, Causality: CausalIntroduced, Proof: "changed hunk causes the failure"}},
+		RefuterOutcomes: []EvidenceResult{},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.BeginCorrection(1); err != nil {
+		t.Fatal(err)
+	}
+	branch := currentBranch(context.Background(), repo)
+	configurePublicationRemote(t, repo, branch)
+	gitSnapshot(t, repo, "config", "branch."+branch+".remote", "origin")
+	gitSnapshot(t, repo, "config", "branch."+branch+".merge", "refs/heads/"+branch)
+	writeSnapshotFile(t, repo, "other.txt", "base other\n")
+	fix, err := (SnapshotBuilder{Repo: repo}).Build(context.Background(), Target{
+		Kind: TargetFixDiff, BaseRef: state.InitialSnapshot.CandidateTree,
+		IntendedUntracked: []string{}, LedgerIDs: state.FixFindingIDs,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	fixHash := FixDeltaHashForSnapshot(fix)
+	validation := ScopedValidationResult{
+		LedgerIDs: state.FixFindingIDs, FixCausedFindings: []Finding{}, FollowUps: []FollowUp{},
+		OriginalCriteria:     ValidationCheck{EvidenceHash: hash("2"), FixDeltaHash: fixHash, Passed: true},
+		CorrectionRegression: ValidationCheck{EvidenceHash: hash("3"), FixDeltaHash: fixHash, Passed: true},
+	}
+	if err := state.CompleteCorrection(fix, 1, validation); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.CompleteVerification([]byte("independent correction verification passed\n"), true); err != nil {
+		t.Fatal(err)
+	}
+	store, err := CompactAuthoritativeStore(context.Background(), repo, lineage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, payload, err := makeCompactRecord(state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(store.Dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(store.StatePath(), payload, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := state.Receipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteCompactReceiptAtomic(store.ReceiptPath(), receipt); err != nil {
+		t.Fatal(err)
+	}
+	return repo, state, receipt, "origin/" + branch
 }
 
 func approvedCompactSubsetDeliveryFixture(t *testing.T, lineage string) (string, CompactState, CompactReceipt, string) {


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1289
Closes #1203
Closes #1217
Closes #1226
Closes #1285

Related to #1242, which remains deferred to the target-scoped status contract.

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Reject correction-created paths that are absent from frozen authority before any incomplete receipt can authorize delivery.
- Preserve exact committed current-changes, base-diff, and TargetFixDiff candidates across post-apply, pre-commit, and pre-push boundaries.
- Bind corrected pre-commit to the real staged index and corrected publication to the complete commit/path range, with projection-aware untracked checks and final TOCTOU revalidation.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/cli/review_facade.go` | Fail closed before finalize when workspace corrections introduce paths outside frozen authority, while respecting staged projection. |
| `internal/cli/review_facade_test.go` | Cover correction completeness, staged projection, transport recovery, and exact rejection behavior. |
| `internal/reviewtransaction/compact_gate.go` | Derive gate-specific committed/corrected targets, bind the real index and publication range, and repeat final authorization checks. |
| `internal/reviewtransaction/compact_gate_test.go` | Add positive and negative lifecycle regressions for trees, paths, commits, replay, and concurrent mutation. |

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./...
go vet ./...
```

**Focused lifecycle tests**

- [x] Five frozen 4R blockers reproduced before correction and pass after correction.
- [x] Independent scoped fix validation passed original criteria and correction regression.
- [x] `go test -count=1 ./internal/reviewtransaction ./internal/cli`
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] Native bounded review receipt approved; pre-commit, pre-push, and pre-PR gates allowed.
- [ ] Local Docker E2E. The runner has no Docker binary, so `cd e2e && ./docker-test.sh` could not execute; required GitHub E2E checks must pass before merge.

---

## 🤖 Automated Checks

The required GitHub checks must pass before merge. Local Docker absence is not being treated as behavioral evidence.

---

## ✅ Contributor Checklist

- [x] PR is linked to approved issues.
- [x] Maintainer-approved `size:exception` requested: 633 changed lines are one atomic authority boundary; 482 lines are regression tests, and splitting code from its gate proofs would weaken reviewability.
- [x] Exactly one `type:*` label will be applied.
- [x] Unit tests and vet pass.
- [ ] Required E2E checks pass in GitHub Actions.
- [x] Documentation is not required for the preserved public contract; issue and PR acceptance criteria are updated.
- [x] Commit follows Conventional Commits.
- [x] Commit contains no `Co-Authored-By` trailer.

---

## 💬 Notes for Reviewers

The native high-risk 4R review found five deterministic critical defects in the first candidate. One bounded 200-line correction fixed all five, and the independent scoped validator passed with no follow-ups. Readability warnings about duplicated policy lists remain informational and are intentionally outside this stabilization correction.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Review finalization now rejects unexpected untracked files introduced during corrections.
  * Strengthened validation of staged, committed, and corrected changes against the approved review scope.
  * Added safeguards against concurrent tracked or untracked changes invalidating review results.
  * Improved pre-commit, post-apply, pre-review, and pre-push handling for corrected targets and delivery boundaries.
  * Prevented unreviewed intermediate paths and inexact correction bindings from being accepted.
* **Tests**
  * Expanded coverage for correction errors, scope enforcement, staged changes, publication ranges, and concurrent repository mutations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->