### PR TITLE
fix(sync): refresh persisted visual components

### DIFF
--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -22,6 +22,7 @@ import (
 	"github.com/gentleman-programming/gentle-ai/internal/components/filemerge"
 	"github.com/gentleman-programming/gentle-ai/internal/components/gga"
 	"github.com/gentleman-programming/gentle-ai/internal/components/mcp"
+	"github.com/gentleman-programming/gentle-ai/internal/components/opencodeplugin"
 	"github.com/gentleman-programming/gentle-ai/internal/components/permissions"
 	"github.com/gentleman-programming/gentle-ai/internal/components/persona"
 	"github.com/gentleman-programming/gentle-ai/internal/components/sdd"
@@ -923,8 +924,25 @@ func (s componentSyncStep) Run() error {
 		}
 		return nil
 
+	case model.ComponentClaudeTheme:
+		for _, adapter := range adapters {
+			res, err := theme.InjectClaudeTheme(s.homeDir, adapter)
+			if err != nil {
+				return fmt.Errorf("sync Claude theme for %q: %w", adapter.Agent(), err)
+			}
+			s.countChanged(boolToInt(res.Changed), res.Files...)
+		}
+		return nil
+
+	case model.ComponentOpenCodeGentleLogo:
+		res, err := opencodeplugin.Install(s.homeDir, model.OpenCodePluginGentleLogo)
+		if err != nil {
+			return fmt.Errorf("sync OpenCode Gentle Logo plugin: %w", err)
+		}
+		s.countChanged(boolToInt(res.Changed), res.Files...)
+		return nil
+
 	default:
-		// Persona and any unknown components are out of sync scope.
 		return fmt.Errorf("component %q is not supported in sync runtime", s.component)
 	}
 }

--- a/internal/cli/sync_test.go
+++ b/internal/cli/sync_test.go
@@ -640,6 +640,57 @@ func TestComponentSyncStepRunsGGAInjectWithoutBinaryInstall(t *testing.T) {
 	}
 }
 
+func TestRunSyncRefreshesPersistedVisualComponents(t *testing.T) {
+	home := t.TempDir()
+	if err := state.Write(home, state.InstallState{
+		InstalledAgents:     []string{"claude-code", "opencode"},
+		SelectionConfigured: true,
+		Components: []model.ComponentID{
+			model.ComponentClaudeTheme,
+			model.ComponentOpenCodeGentleLogo,
+		},
+		Persona: "neutral",
+	}); err != nil {
+		t.Fatalf("state.Write() error = %v", err)
+	}
+
+	restoreHome := osUserHomeDir
+	restoreBackupHome := backup.UserHomeDirFn
+	osUserHomeDir = func() (string, error) { return home, nil }
+	backup.UserHomeDirFn = func() (string, error) { return home, nil }
+	t.Cleanup(func() {
+		osUserHomeDir = restoreHome
+		backup.UserHomeDirFn = restoreBackupHome
+	})
+
+	wantFiles := []string{
+		filepath.Join(home, ".claude", "themes", "gentleman.json"),
+		filepath.Join(home, ".config", "opencode", "tui-plugins", "gentle-logo.tsx"),
+		filepath.Join(home, ".config", "opencode", "tui.json"),
+	}
+
+	first, err := RunSync([]string{"--agents", "claude-code,opencode"})
+	if err != nil {
+		t.Fatalf("RunSync() first error = %v", err)
+	}
+	if !reflect.DeepEqual(first.ChangedFiles, wantFiles) {
+		t.Fatalf("first ChangedFiles = %#v, want %#v", first.ChangedFiles, wantFiles)
+	}
+	for _, path := range wantFiles {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("managed visual component file %q was not refreshed: %v", path, err)
+		}
+	}
+
+	second, err := RunSync([]string{"--agents", "claude-code,opencode"})
+	if err != nil {
+		t.Fatalf("RunSync() second error = %v", err)
+	}
+	if !second.NoOp || second.FilesChanged != 0 || len(second.ChangedFiles) != 0 {
+		t.Fatalf("second sync = NoOp %v, FilesChanged %d, ChangedFiles %#v; want idempotent no-op", second.NoOp, second.FilesChanged, second.ChangedFiles)
+	}
+}
+
 func TestCodeGraphGuidanceSyncStepRefreshesOldMarkerWhenConfigured(t *testing.T) {
 	home := t.TempDir()
 	settingsPath := filepath.Join(home, ".config", "opencode", "opencode.json")


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1315

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)

---

## 📝 Summary

- Refresh persisted `claude-theme` and `opencode-gentle-logo` components during sync instead of rejecting them.
- Reuse the existing managed injectors so missing or stale visual assets are restored.
- Preserve changed-file accounting and idempotent repeated sync behavior.
- Credit @aparragithub for the original report, diagnosis, and PR #1276. The delivery commit retains them as Git author.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/cli/sync.go` | Adds managed sync handlers for the Claude theme and OpenCode Gentle Logo. |
| `internal/cli/sync_test.go` | Verifies first-run refresh and second-run idempotency through `RunSync`. |

---

## 🧪 Test Plan

```bash
go test ./internal/cli -run '^TestRunSyncRefreshesPersistedVisualComponents$' -count=1
go test ./internal/cli ./internal/components/theme ./internal/components/opencodeplugin
go test ./internal/...
git diff --check
```

- [x] Focused regression test passes
- [x] Relevant package tests pass
- [x] Full internal package suite passes
- [x] Production `RunSync` boundary is covered with isolated persisted state

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [x] Exactly one `type:*` label will be applied
- [x] Relevant unit and package tests pass
- [x] Documentation is not required for this bug fix
- [x] Commit follows Conventional Commits
- [x] Commit has no `Co-Authored-By` trailer

---

## 💬 Notes for Reviewers

PR #1276 correctly diagnosed the unsupported-component failure but treats both components as no-ops. This implementation goes further and reapplies their existing managed injectors, allowing sync to restore missing or stale assets while remaining idempotent.

Native bounded review lineage: `review-7b8d791cdcdce2a9`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sync now installs the Claude theme and OpenCode Gentle Logo plugin when selected.
  * Re-running sync after installation correctly detects that no further changes are needed.

* **Bug Fixes**
  * Improved synchronization of persisted visual components, including accurate reporting of changed files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->