### PR TITLE
feat(review): compose sequential receipts at pre-pr

### DIFF
--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -1043,7 +1043,20 @@ func runReviewFacadeValidate(ctx context.Context, args []string, stdout io.Write
 		input.LineageID = compactRecord.State.LineageID
 		input.IntendedUntracked = append([]string(nil), compactRecord.State.InitialSnapshot.IntendedUntracked...)
 		evaluation := reviewtransaction.EvaluateCompactGate(ctx, root, receipt, input)
+		if gateInput.Gate == reviewtransaction.GatePrePR && strings.TrimSpace(*lineage) == "" &&
+			evaluation.Context.Denial != nil && evaluation.Context.Denial.Stage == "receipt-binding" && evaluation.Context.Denial.Code == "base-mismatch" {
+			if composed, attempted := reviewtransaction.EvaluateCompactPrePRChain(ctx, root, gateInput); attempted {
+				return emitFacadeGateEvaluationNegotiated(stdout, composed, negotiated)
+			}
+		}
 		return emitFacadeGateEvaluationNegotiated(stdout, evaluation, negotiated)
+	}
+	var compactDiscovery *ReviewReceiptDiscoveryError
+	if gateInput.Gate == reviewtransaction.GatePrePR && strings.TrimSpace(*lineage) == "" &&
+		errors.As(compactErr, &compactDiscovery) && compactDiscovery.Kind != ReviewAuthorityCorrupted && compactDiscovery.Kind != ReviewReceiptMissing {
+		if evaluation, attempted := reviewtransaction.EvaluateCompactPrePRChain(ctx, root, gateInput); attempted {
+			return emitFacadeGateEvaluationNegotiated(stdout, evaluation, negotiated)
+		}
 	}
 	if !negotiated {
 		var discovery *ReviewReceiptDiscoveryError

--- a/internal/cli/review_receipt_discovery_test.go
+++ b/internal/cli/review_receipt_discovery_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/gentleman-programming/gentle-ai/internal/reviewtransaction"
@@ -302,6 +303,98 @@ func TestUnscopedGateDiscoveryFailsClosedOnMalformedUnrelatedInventory(t *testin
 	failure := decodeReviewIntegrationFailure(t, unscoped.Bytes())
 	if failure.Code != "authority_corrupted" || failure.AuthorityApplicability != "corrupted" || failure.RetrySafe || failure.NextAction != "stop" {
 		t.Fatalf("corrupted inventory failure = %#v", failure)
+	}
+}
+
+func TestUnqualifiedPrePRDiscoveryComposesExactSequentialCompactReceipts(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	branch := strings.TrimSpace(runReviewCLIGit(t, repo, "symbolic-ref", "--short", "HEAD"))
+	remote := filepath.Join(t.TempDir(), "remote.git")
+	runReviewCLIGit(t, repo, "clone", "--bare", repo, remote)
+	runReviewCLIGit(t, repo, "remote", "add", "origin", remote)
+
+	lineages := []string{"review-chain-first", "review-chain-second", "review-chain-third"}
+	for index, lineage := range lineages {
+		approveDiscoveryMarkdown(t, repo, lineage, "docs/segment-"+string(rune('a'+index))+".md", "reviewed\n")
+		runReviewCLIGit(t, repo, "add", "-A")
+		runReviewCLIGit(t, repo, "commit", "-qm", "deliver "+lineage)
+	}
+
+	var output bytes.Buffer
+	if err := RunReview([]string{
+		"validate", "--contract", ReviewIntegrationContractV1, "--cwd", repo,
+		"--gate", string(reviewtransaction.GatePrePR), "--base-ref", "origin/" + branch,
+	}, &output); err != nil {
+		t.Fatalf("composed pre-PR facade validation: %v\n%s", err, output.String())
+	}
+	var result ReviewValidateResult
+	decodeStrictReviewJSON(t, decodeReviewOperationEnvelope(t, output.Bytes()).Result, &result)
+	if !result.Allowed || result.Context.LineageID != lineages[2] || result.Context.ChainIdentity == "" || result.Context.PrePRBoundary == nil {
+		t.Fatalf("composed pre-PR result = %#v", result)
+	}
+
+	output.Reset()
+	err := RunReview([]string{
+		"validate", "--contract", ReviewIntegrationContractV1, "--cwd", repo, "--lineage", lineages[2],
+		"--gate", string(reviewtransaction.GatePrePR), "--base-ref", "origin/" + branch,
+	}, &output)
+	if err == nil {
+		t.Fatal("explicit terminal lineage unexpectedly entered composition")
+	}
+}
+
+func TestUnqualifiedPrePRDiscoveryComposesSequentialReceiptsForSamePath(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	branch := strings.TrimSpace(runReviewCLIGit(t, repo, "symbolic-ref", "--short", "HEAD"))
+	remote := filepath.Join(t.TempDir(), "remote.git")
+	runReviewCLIGit(t, repo, "clone", "--bare", repo, remote)
+	runReviewCLIGit(t, repo, "remote", "add", "origin", remote)
+
+	for index, lineage := range []string{"review-chain-overlap-first", "review-chain-overlap-second", "review-chain-overlap-third"} {
+		approveDiscoveryMarkdown(t, repo, lineage, "docs/shared.md", "reviewed "+string(rune('a'+index))+"\n")
+		runReviewCLIGit(t, repo, "add", "-A")
+		runReviewCLIGit(t, repo, "commit", "-qm", "deliver "+lineage)
+	}
+
+	var output bytes.Buffer
+	if err := RunReview([]string{
+		"validate", "--contract", ReviewIntegrationContractV1, "--cwd", repo,
+		"--gate", string(reviewtransaction.GatePrePR), "--base-ref", "origin/" + branch,
+	}, &output); err != nil {
+		t.Fatalf("same-path composed pre-PR validation: %v\n%s", err, output.String())
+	}
+	var result ReviewValidateResult
+	decodeStrictReviewJSON(t, decodeReviewOperationEnvelope(t, output.Bytes()).Result, &result)
+	if !result.Allowed || result.Context.LineageID != "review-chain-overlap-third" {
+		t.Fatalf("same-path composed pre-PR result = %#v", result)
+	}
+}
+
+func TestUnqualifiedPrePRDiscoveryKeepsExactSingleReceiptContext(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	branch := strings.TrimSpace(runReviewCLIGit(t, repo, "symbolic-ref", "--short", "HEAD"))
+	remote := filepath.Join(t.TempDir(), "remote.git")
+	runReviewCLIGit(t, repo, "clone", "--bare", repo, remote)
+	runReviewCLIGit(t, repo, "remote", "add", "origin", remote)
+	started, store := approveDiscoveryMarkdown(t, repo, "review-single-pre-pr", "docs/single.md", "reviewed\n")
+	runReviewCLIGit(t, repo, "add", "-A")
+	runReviewCLIGit(t, repo, "commit", "-qm", "deliver exact single receipt")
+	record, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var output bytes.Buffer
+	if err := RunReview([]string{
+		"validate", "--contract", ReviewIntegrationContractV1, "--cwd", repo,
+		"--gate", string(reviewtransaction.GatePrePR), "--base-ref", "origin/" + branch,
+	}, &output); err != nil {
+		t.Fatalf("exact single pre-PR validation: %v\n%s", err, output.String())
+	}
+	var result ReviewValidateResult
+	decodeStrictReviewJSON(t, decodeReviewOperationEnvelope(t, output.Bytes()).Result, &result)
+	if !result.Allowed || result.Context.LineageID != started.LineageID || result.Context.StoreRevision != record.Revision || result.Context.ChainIdentity != record.Revision {
+		t.Fatalf("exact single receipt context changed = %#v", result.Context)
 	}
 }
 

--- a/internal/reviewtransaction/compact_chain.go
+++ b/internal/reviewtransaction/compact_chain.go
@@ -1,0 +1,534 @@
+package reviewtransaction
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"reflect"
+	"sort"
+	"strings"
+)
+
+const CompactPrePRChainProofDomain = "gentle-ai.compact-pre-pr-chain/v1"
+
+type compactPrePRChainMember struct {
+	store   CompactStore
+	record  CompactRecord
+	receipt CompactReceipt
+}
+
+type compactPrePRChainAuthorityProof struct {
+	LineageID   string `json:"lineage_id"`
+	Revision    string `json:"revision"`
+	StateHash   string `json:"state_hash"`
+	ReceiptHash string `json:"receipt_hash,omitempty"`
+}
+
+type compactPrePRChainMemberProof struct {
+	LineageID    string         `json:"lineage_id"`
+	Revision     string         `json:"revision"`
+	Receipt      CompactReceipt `json:"receipt"`
+	GenesisPaths []string       `json:"genesis_paths"`
+	ChangedPaths []string       `json:"changed_paths"`
+	TouchedPaths []string       `json:"touched_paths"`
+}
+
+type compactPrePRChainCommitProof struct {
+	Commit     string `json:"commit"`
+	Parent     string `json:"parent"`
+	ParentTree string `json:"parent_tree"`
+	Tree       string `json:"tree"`
+}
+
+type compactPrePRChainProof struct {
+	Domain             string                            `json:"domain"`
+	Boundary           PrePRBoundarySelection            `json:"boundary"`
+	PushRemote         string                            `json:"push_remote"`
+	PushRemoteIdentity string                            `json:"push_remote_identity"`
+	BaseCommit         string                            `json:"base_commit"`
+	HeadCommit         string                            `json:"head_commit"`
+	BaseTree           string                            `json:"base_tree"`
+	HeadTree           string                            `json:"head_tree"`
+	Authority          []compactPrePRChainAuthorityProof `json:"authority"`
+	Members            []compactPrePRChainMemberProof    `json:"members"`
+	Commits            []compactPrePRChainCommitProof    `json:"commits"`
+	ChangedPaths       []string                          `json:"changed_paths"`
+	TouchedPaths       []string                          `json:"touched_paths"`
+	PublicationPaths   []string                          `json:"publication_paths"`
+	BaseAdvance        *BaseAdvanceCompatibility         `json:"base_advance,omitempty"`
+}
+
+type compactPrePRChainDerivation struct {
+	proof    compactPrePRChainProof
+	identity string
+	context  GateContext
+	lockPath string
+}
+
+var errCompactPrePRChainNotApplicable = errors.New("compact pre-PR receipt composition is not applicable")
+
+// EvaluateCompactPrePRChain composes existing compact-v2 authority in memory.
+// It is intentionally unavailable for explicit lineage selection and every
+// gate except pre-PR, preserving direct single-receipt behavior.
+func EvaluateCompactPrePRChain(ctx context.Context, repo string, input NativeGateRequestInput) (NativeGateEvaluation, bool) {
+	invalid := func(reason string, cause error) NativeGateEvaluation {
+		return NativeGateEvaluation{
+			Result: GateInvalidated, Reason: reason, Cause: cause,
+			Context: GateContext{Gate: GatePrePR, Denial: &GateDenial{Stage: "receipt-composition", Code: "invalid-chain"}},
+		}
+	}
+	if input.Gate != GatePrePR || strings.TrimSpace(input.LineageID) != "" {
+		return invalid(errCompactPrePRChainNotApplicable.Error(), errCompactPrePRChainNotApplicable), false
+	}
+	derived, attempted, err := deriveCompactPrePRChain(ctx, repo, input)
+	if !attempted {
+		return invalid(errCompactPrePRChainNotApplicable.Error(), errCompactPrePRChainNotApplicable), false
+	}
+	if err != nil {
+		return invalid("compact pre-PR receipt composition denied: "+err.Error(), err), true
+	}
+	lock, err := acquireStoreLock(derived.lockPath)
+	if err != nil {
+		return invalid("compact pre-PR receipt composition changed during final authorization", err), true
+	}
+	defer lock.release()
+
+	finalGateAuthorizationHook()
+	final, finalAttempted, err := deriveCompactPrePRChain(ctx, repo, input)
+	if err != nil || !finalAttempted || final.identity != derived.identity || !reflect.DeepEqual(final.proof, derived.proof) {
+		return invalid("compact pre-PR receipt composition changed during final authorization", err), true
+	}
+	finalCompactGateAllowHook()
+	return NativeGateEvaluation{Result: GateAllow, Reason: nativeGateReason(GateAllow), Context: derived.context}, true
+}
+
+func deriveCompactPrePRChain(ctx context.Context, repo string, input NativeGateRequestInput) (compactPrePRChainDerivation, bool, error) {
+	target, prePR, err := buildPrePRTarget(ctx, repo, input.BaseRef, input.PrePRCIAttestation, nil)
+	if err != nil {
+		return compactPrePRChainDerivation{}, true, err
+	}
+	request := GateRequest{Schema: GateRequestSchema, Gate: GatePrePR, Target: target, PrePR: prePR, PolicyArtifact: input.PolicyArtifact}
+	preimages, err := readGateArtifactPreimages(request)
+	if err != nil {
+		return compactPrePRChainDerivation{}, true, err
+	}
+	snapshot, refs, err := buildCompactLifecycleSnapshot(ctx, repo, request)
+	if err != nil || refs == nil {
+		return compactPrePRChainDerivation{}, true, errors.Join(err, errors.New("resolved pre-PR publication boundary is unavailable"))
+	}
+	report, err := InventoryAuthority(ctx, repo)
+	if err != nil || !report.Complete || !report.Authoritative {
+		return compactPrePRChainDerivation{}, true, errors.Join(err, errors.New("complete authoritative review inventory is unavailable"))
+	}
+	for _, entry := range report.Entries {
+		if entry.Version == AuthorityVersionLegacy {
+			return compactPrePRChainDerivation{}, true, errors.New("compact receipt composition cannot mix legacy-v1 authority")
+		}
+	}
+
+	stores, err := DiscoverCompactStores(ctx, repo)
+	if err != nil {
+		return compactPrePRChainDerivation{}, true, err
+	}
+	if len(stores) < 2 {
+		return compactPrePRChainDerivation{}, false, errCompactPrePRChainNotApplicable
+	}
+	leaves, err := CompactAuthorityLeaves(ctx, repo)
+	if err != nil {
+		return compactPrePRChainDerivation{}, true, err
+	}
+	leafSet := make(map[string]struct{}, len(leaves))
+	for _, store := range leaves {
+		leafSet[store.lineageID] = struct{}{}
+	}
+	authority := make([]compactPrePRChainAuthorityProof, 0, len(stores))
+	members := make([]compactPrePRChainMember, 0, len(stores))
+	for _, store := range stores {
+		statePayload, readErr := os.ReadFile(store.StatePath())
+		if readErr != nil {
+			return compactPrePRChainDerivation{}, true, fmt.Errorf("read compact authority %q: %w", store.lineageID, readErr)
+		}
+		record, loadErr := store.Load()
+		if loadErr != nil {
+			return compactPrePRChainDerivation{}, true, fmt.Errorf("load compact authority %q: %w", store.lineageID, loadErr)
+		}
+		proof := compactPrePRChainAuthorityProof{
+			LineageID: record.State.LineageID, Revision: record.Revision,
+			StateHash: compactPrePRChainPayloadHash("state", statePayload),
+		}
+		receiptPayload, receiptErr := os.ReadFile(store.ReceiptPath())
+		terminal := record.State.State == StateApproved || record.State.State == StateEscalated
+		if terminal {
+			if receiptErr != nil {
+				return compactPrePRChainDerivation{}, true, fmt.Errorf("read terminal compact receipt %q: %w", store.lineageID, receiptErr)
+			}
+			receipt, parseErr := ParseCompactReceipt(receiptPayload)
+			authoritative, deriveErr := record.State.Receipt()
+			if parseErr != nil || deriveErr != nil || !compactReceiptEqual(receipt, authoritative) {
+				return compactPrePRChainDerivation{}, true, fmt.Errorf("compact receipt %q does not match current authority", store.lineageID)
+			}
+			proof.ReceiptHash = compactPrePRChainPayloadHash("receipt", receiptPayload)
+			if _, leaf := leafSet[store.lineageID]; leaf && record.State.State == StateApproved {
+				members = append(members, compactPrePRChainMember{store: store, record: record, receipt: receipt})
+			}
+		} else if receiptErr == nil {
+			return compactPrePRChainDerivation{}, true, fmt.Errorf("nonterminal compact authority %q has a receipt", store.lineageID)
+		} else if !os.IsNotExist(receiptErr) {
+			return compactPrePRChainDerivation{}, true, receiptErr
+		}
+		authority = append(authority, proof)
+	}
+	if len(members) < 2 {
+		return compactPrePRChainDerivation{}, true, errors.New("no receipt chain contains at least two authoritative approved members")
+	}
+
+	path, compatibility, err := selectCompactPrePRChain(ctx, repo, request, preimages, snapshot, refs, members)
+	if err != nil {
+		return compactPrePRChainDerivation{}, true, err
+	}
+	assessment, err := (SnapshotBuilder{Repo: repo}).AssessSnapshotRisk(ctx, snapshot)
+	if err != nil {
+		return compactPrePRChainDerivation{}, true, fmt.Errorf("assess complete composed target risk: %w", err)
+	}
+	if assessment.Level == RiskHigh {
+		return compactPrePRChainDerivation{}, true, errors.New("complete composed target is high risk; full-target review is required")
+	}
+	if len(preimages.policy) > 0 {
+		policyHash := hashArtifactPayload(preimages.policy)
+		for _, member := range path {
+			if member.record.State.PolicyHash != policyHash {
+				return compactPrePRChainDerivation{}, true, errors.New("explicit pre-PR policy is not bound to every composed receipt")
+			}
+		}
+	}
+
+	proof, err := buildCompactPrePRChainProof(ctx, repo, request, refs, snapshot, authority, path, compatibility)
+	if err != nil {
+		return compactPrePRChainDerivation{}, true, err
+	}
+	identity, err := compactPrePRChainProofIdentity(proof)
+	if err != nil {
+		return compactPrePRChainDerivation{}, true, err
+	}
+	last := path[len(path)-1]
+	fixHashes := make([]string, len(path))
+	policyHashes := make([]string, len(path))
+	evidenceHashes := make([]string, len(path))
+	for index, member := range path {
+		fixHashes[index] = member.receipt.FixDeltaHash
+		policyHashes[index] = member.receipt.PolicyHash
+		evidenceHashes[index] = member.receipt.EvidenceHash
+	}
+	boundary := refs.Selection
+	gateContext := GateContext{
+		Gate: GatePrePR, LineageID: last.receipt.LineageID, Generation: last.receipt.Generation,
+		StoreRevision: last.record.Revision, GenesisRevision: path[0].record.Revision,
+		ChainIdentity: identity, BundleDigest: identity,
+		BaseTree: proof.BaseTree, CandidateTree: proof.HeadTree, PathsDigest: digestPaths(proof.PublicationPaths),
+		FixDeltaHash: compactPrePRChainValuesHash("fix-delta", fixHashes),
+		PolicyHash:   compactPrePRChainValuesHash("policy", policyHashes),
+		LedgerHash:   EmptyFixDeltaHash, EvidenceHash: compactPrePRChainValuesHash("evidence", evidenceHashes),
+		BaseRelationshipValid: compatibility == nil, BaseAdvance: compatibility, PrePRBoundary: &boundary,
+	}
+	return compactPrePRChainDerivation{proof: proof, identity: identity, context: gateContext, lockPath: path[0].store.lockPath}, true, nil
+}
+
+func selectCompactPrePRChain(ctx context.Context, repo string, request GateRequest, preimages gateArtifactPreimages, snapshot Snapshot, refs *resolvedPrePRRefs, members []compactPrePRChainMember) ([]compactPrePRChainMember, *BaseAdvanceCompatibility, error) {
+	adjacency := make(map[string][]compactPrePRChainMember)
+	for _, member := range members {
+		adjacency[member.receipt.BaseTree] = append(adjacency[member.receipt.BaseTree], member)
+	}
+	for base := range adjacency {
+		sort.Slice(adjacency[base], func(i, j int) bool {
+			return adjacency[base][i].receipt.LineageID < adjacency[base][j].receipt.LineageID
+		})
+	}
+	if compactPrePRChainHasCycle(adjacency) {
+		return nil, nil, errors.New("compact receipt graph contains a cycle")
+	}
+	type candidate struct {
+		path          []compactPrePRChainMember
+		compatibility *BaseAdvanceCompatibility
+	}
+	candidates := []candidate{}
+	starts := make([]string, 0, len(adjacency))
+	for base := range adjacency {
+		starts = append(starts, base)
+	}
+	sort.Strings(starts)
+	for _, base := range starts {
+		var compatibility *BaseAdvanceCompatibility
+		if base != snapshot.BaseTree {
+			paths, err := (SnapshotBuilder{Repo: repo}).changedPaths(ctx, base, snapshot.CandidateTree)
+			if err != nil {
+				continue
+			}
+			synthetic := Receipt{BaseTree: base, FinalCandidateTree: snapshot.CandidateTree, PathsDigest: digestPaths(paths)}
+			proof, proofErr := deriveBaseAdvanceCompatibility(ctx, repo, synthetic, request, snapshot, refs, preimages)
+			if proofErr != nil {
+				continue
+			}
+			compatibility = &proof
+		}
+		paths := compactPrePRChainPaths(base, snapshot.CandidateTree, adjacency, map[string]bool{}, nil, len(members)+1)
+		for _, path := range paths {
+			if len(path) >= 2 {
+				candidates = append(candidates, candidate{path: path, compatibility: compatibility})
+			}
+		}
+	}
+	if len(candidates) == 0 {
+		return nil, nil, errors.New("no exact compact receipt chain covers the selected base through HEAD")
+	}
+	if len(candidates) != 1 {
+		return nil, nil, errors.New("multiple viable compact receipt chains cover the selected base through HEAD")
+	}
+	path := candidates[0].path
+	pathNodes := map[string]bool{path[0].receipt.BaseTree: true}
+	for _, member := range path {
+		pathNodes[member.receipt.FinalCandidateTree] = true
+	}
+	incoming := make(map[string]int)
+	for _, edges := range adjacency {
+		for _, edge := range edges {
+			incoming[edge.receipt.FinalCandidateTree]++
+		}
+	}
+	for node := range pathNodes {
+		wantOutgoing := 1
+		if node == snapshot.CandidateTree {
+			wantOutgoing = 0
+		}
+		if len(adjacency[node]) != wantOutgoing {
+			return nil, nil, errors.New("compact receipt chain contains a fork")
+		}
+		wantIncoming := 1
+		if node == path[0].receipt.BaseTree {
+			wantIncoming = 0
+		}
+		if incoming[node] != wantIncoming {
+			return nil, nil, errors.New("compact receipt chain contains a convergence")
+		}
+	}
+	return path, candidates[0].compatibility, nil
+}
+
+func compactPrePRChainPaths(current, target string, adjacency map[string][]compactPrePRChainMember, visiting map[string]bool, path []compactPrePRChainMember, limit int) [][]compactPrePRChainMember {
+	if current == target {
+		return [][]compactPrePRChainMember{append([]compactPrePRChainMember(nil), path...)}
+	}
+	if visiting[current] || limit <= 0 {
+		return nil
+	}
+	visiting[current] = true
+	defer delete(visiting, current)
+	result := [][]compactPrePRChainMember{}
+	for _, member := range adjacency[current] {
+		result = append(result, compactPrePRChainPaths(member.receipt.FinalCandidateTree, target, adjacency, visiting, append(path, member), limit-1)...)
+		if len(result) >= 2 {
+			return result
+		}
+	}
+	return result
+}
+
+func compactPrePRChainHasCycle(adjacency map[string][]compactPrePRChainMember) bool {
+	visited := map[string]bool{}
+	active := map[string]bool{}
+	var visit func(string) bool
+	visit = func(tree string) bool {
+		if active[tree] {
+			return true
+		}
+		if visited[tree] {
+			return false
+		}
+		visited[tree], active[tree] = true, true
+		for _, member := range adjacency[tree] {
+			if visit(member.receipt.FinalCandidateTree) {
+				return true
+			}
+		}
+		active[tree] = false
+		return false
+	}
+	for tree := range adjacency {
+		if visit(tree) {
+			return true
+		}
+	}
+	return false
+}
+
+func buildCompactPrePRChainProof(ctx context.Context, repo string, request GateRequest, refs *resolvedPrePRRefs, snapshot Snapshot, authority []compactPrePRChainAuthorityProof, members []compactPrePRChainMember, compatibility *BaseAdvanceCompatibility) (compactPrePRChainProof, error) {
+	baseCommit := refs.BaseCommit
+	if compatibility != nil {
+		mergeBase, err := runGit(ctx, repo, nil, nil, "merge-base", refs.Selection.Commit, refs.HeadCommit)
+		if err != nil {
+			return compactPrePRChainProof{}, err
+		}
+		baseCommit = strings.TrimSpace(string(mergeBase))
+	}
+	baseTree, err := (SnapshotBuilder{Repo: repo}).resolveTree(ctx, baseCommit)
+	if err != nil || baseTree != members[0].receipt.BaseTree {
+		return compactPrePRChainProof{}, errors.New("first compact receipt does not match the resolved publication base")
+	}
+	commits, err := compactPrePRLinearCommits(ctx, repo, baseCommit, refs.HeadCommit)
+	if err != nil {
+		return compactPrePRChainProof{}, err
+	}
+	memberProofs := make([]compactPrePRChainMemberProof, 0, len(members))
+	genesisUnion := []string{}
+	previousTree, previousIndex := baseTree, -1
+	for _, member := range members {
+		if member.receipt.BaseTree != previousTree {
+			return compactPrePRChainProof{}, errors.New("compact receipt chain contains a tree gap or reordered member")
+		}
+		boundary := -1
+		for index := previousIndex + 1; index < len(commits); index++ {
+			if commits[index].Tree == previousTree {
+				continue
+			}
+			if commits[index].Tree != member.receipt.FinalCandidateTree {
+				return compactPrePRChainProof{}, errors.New("publication commit does not match the next compact receipt boundary")
+			}
+			boundary = index
+			break
+		}
+		if boundary < 0 {
+			return compactPrePRChainProof{}, errors.New("compact receipt boundary is absent from publication history")
+		}
+		changed, err := (SnapshotBuilder{Repo: repo}).changedPaths(ctx, member.receipt.BaseTree, member.receipt.FinalCandidateTree)
+		if err != nil {
+			return compactPrePRChainProof{}, err
+		}
+		touched := []string{}
+		for index := previousIndex + 1; index <= boundary; index++ {
+			paths, err := (SnapshotBuilder{Repo: repo}).changedPaths(ctx, commits[index].ParentTree, commits[index].Tree)
+			if err != nil {
+				return compactPrePRChainProof{}, err
+			}
+			touched = append(touched, paths...)
+		}
+		touched, err = compactPrePRPathUnion(touched)
+		if err != nil || pathsAreSubset(changed, member.record.State.GenesisPaths) != nil || pathsAreSubset(touched, member.record.State.GenesisPaths) != nil {
+			return compactPrePRChainProof{}, errors.New("compact receipt segment exceeds its immutable genesis paths")
+		}
+		memberProofs = append(memberProofs, compactPrePRChainMemberProof{
+			LineageID: member.receipt.LineageID, Revision: member.record.Revision, Receipt: member.receipt,
+			GenesisPaths: append([]string(nil), member.record.State.GenesisPaths...),
+			ChangedPaths: changed, TouchedPaths: touched,
+		})
+		genesisUnion = append(genesisUnion, member.record.State.GenesisPaths...)
+		previousTree, previousIndex = member.receipt.FinalCandidateTree, boundary
+	}
+	for index := previousIndex + 1; index < len(commits); index++ {
+		if commits[index].Tree != previousTree {
+			return compactPrePRChainProof{}, errors.New("publication commit remains after all compact receipt boundaries")
+		}
+	}
+	if previousTree != snapshot.CandidateTree {
+		return compactPrePRChainProof{}, errors.New("compact receipt chain final tree does not equal live HEAD")
+	}
+	changed, err := (SnapshotBuilder{Repo: repo}).changedPaths(ctx, baseTree, snapshot.CandidateTree)
+	if err != nil {
+		return compactPrePRChainProof{}, err
+	}
+	touched := []string{}
+	for _, commit := range commits {
+		paths, err := (SnapshotBuilder{Repo: repo}).changedPaths(ctx, commit.ParentTree, commit.Tree)
+		if err != nil {
+			return compactPrePRChainProof{}, err
+		}
+		touched = append(touched, paths...)
+	}
+	touched, err = compactPrePRPathUnion(touched)
+	if err != nil {
+		return compactPrePRChainProof{}, err
+	}
+	publicationPaths, err := compactPrePRPathUnion(changed, touched)
+	if err != nil {
+		return compactPrePRChainProof{}, err
+	}
+	genesisUnion, err = compactPrePRPathUnion(genesisUnion)
+	if err != nil || pathsAreSubset(publicationPaths, genesisUnion) != nil {
+		return compactPrePRChainProof{}, errors.New("publication range contains paths outside composed receipt authority")
+	}
+	proof := compactPrePRChainProof{
+		Domain: CompactPrePRChainProofDomain, Boundary: refs.Selection,
+		PushRemote: request.PrePR.PushRemote, PushRemoteIdentity: request.PrePR.PushRemoteIdentity,
+		BaseCommit: baseCommit, HeadCommit: refs.HeadCommit, BaseTree: baseTree, HeadTree: snapshot.CandidateTree,
+		Authority: authority, Members: memberProofs, Commits: commits,
+		ChangedPaths: changed, TouchedPaths: touched, PublicationPaths: publicationPaths, BaseAdvance: compatibility,
+	}
+	return proof, nil
+}
+
+func compactPrePRLinearCommits(ctx context.Context, repo, baseCommit, headCommit string) ([]compactPrePRChainCommitProof, error) {
+	output, err := runGit(ctx, repo, nil, nil, "rev-list", "--reverse", "--parents", baseCommit+".."+headCommit)
+	if err != nil {
+		return nil, fmt.Errorf("inspect compact receipt publication commits: %w", err)
+	}
+	previousCommit := baseCommit
+	previousTree, err := (SnapshotBuilder{Repo: repo}).resolveTree(ctx, baseCommit)
+	if err != nil {
+		return nil, err
+	}
+	commits := []compactPrePRChainCommitProof{}
+	for _, line := range strings.Split(strings.TrimSpace(string(output)), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+		if len(fields) != 2 || fields[1] != previousCommit {
+			return nil, errors.New("compact receipt composition requires one exact linear publication ancestry")
+		}
+		tree, err := (SnapshotBuilder{Repo: repo}).resolveTree(ctx, fields[0])
+		if err != nil {
+			return nil, err
+		}
+		commits = append(commits, compactPrePRChainCommitProof{Commit: fields[0], Parent: previousCommit, ParentTree: previousTree, Tree: tree})
+		previousCommit, previousTree = fields[0], tree
+	}
+	if len(commits) == 0 || previousCommit != headCommit {
+		return nil, errors.New("compact receipt publication history does not reach live HEAD")
+	}
+	return commits, nil
+}
+
+func compactPrePRChainProofIdentity(proof compactPrePRChainProof) (string, error) {
+	payload, err := json.Marshal(proof)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(append([]byte(CompactPrePRChainProofDomain+"\x00"), payload...))
+	return "sha256:" + hex.EncodeToString(sum[:]), nil
+}
+
+func compactPrePRChainPayloadHash(kind string, payload []byte) string {
+	sum := sha256.Sum256(append([]byte(CompactPrePRChainProofDomain+"/"+kind+"\x00"), payload...))
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+func compactPrePRChainValuesHash(kind string, values []string) string {
+	payload, _ := json.Marshal(values)
+	return compactPrePRChainPayloadHash(kind, payload)
+}
+
+func compactPrePRPathUnion(groups ...[]string) ([]string, error) {
+	unique := map[string]struct{}{}
+	for _, group := range groups {
+		for _, path := range group {
+			unique[path] = struct{}{}
+		}
+	}
+	paths := make([]string, 0, len(unique))
+	for path := range unique {
+		paths = append(paths, path)
+	}
+	return canonicalPaths(paths)
+}

--- a/internal/reviewtransaction/compact_chain_test.go
+++ b/internal/reviewtransaction/compact_chain_test.go
@@ -1,0 +1,819 @@
+package reviewtransaction
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestCompactPrePRChainAllowsExactThreeReceiptComposition(t *testing.T) {
+	fixture := newCompactPrePRChainFixture(t, 3)
+
+	got, attempted := EvaluateCompactPrePRChain(context.Background(), fixture.repo, fixture.input())
+
+	if !attempted || got.Result != GateAllow {
+		t.Fatalf("three-receipt composition = %#v, attempted %t", got, attempted)
+	}
+	if got.Context.CandidateTree != fixture.receipts[2].FinalCandidateTree || got.Context.BaseTree != fixture.receipts[0].BaseTree || got.Context.ChainIdentity == "" {
+		t.Fatalf("composed proof context = %#v", got.Context)
+	}
+}
+
+func TestCompactPrePRChainLeavesExactSingleReceiptToDirectEvaluation(t *testing.T) {
+	fixture := newCompactPrePRChainFixture(t, 1)
+	input := fixture.input()
+	input.LineageID = fixture.states[0].LineageID
+
+	direct := EvaluateCompactGate(context.Background(), fixture.repo, fixture.receipts[0], input)
+	composed, attempted := EvaluateCompactPrePRChain(context.Background(), fixture.repo, fixture.input())
+
+	if direct.Result != GateAllow {
+		t.Fatalf("direct exact receipt = %#v", direct)
+	}
+	if attempted || composed.Result == GateAllow {
+		t.Fatalf("single receipt entered composition = %#v, attempted %t", composed, attempted)
+	}
+}
+
+func TestCompactPrePRChainRejectsInvalidMembersAndBindings(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(t *testing.T, fixture *compactPrePRChainFixture)
+	}{
+		{
+			name: "nonterminal member",
+			mutate: func(t *testing.T, fixture *compactPrePRChainFixture) {
+				replaceCompactChainState(t, fixture.stores[1], func(state *CompactState) {
+					state.State = StateReviewing
+					state.LensResults = []LensResult{}
+					state.Findings = []Finding{}
+					state.Classifications = map[string]FindingEvidence{}
+					state.Outcomes = map[string]EvidenceOutcome{}
+					state.FixFindingIDs = []string{}
+					state.FollowUps = []FollowUp{}
+					state.EvidenceHash = ""
+				})
+			},
+		},
+		{
+			name: "missing receipt",
+			mutate: func(t *testing.T, fixture *compactPrePRChainFixture) {
+				if err := os.Remove(fixture.stores[1].ReceiptPath()); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "tampered receipt",
+			mutate: func(t *testing.T, fixture *compactPrePRChainFixture) {
+				payload, err := os.ReadFile(fixture.stores[1].ReceiptPath())
+				if err != nil {
+					t.Fatal(err)
+				}
+				payload = bytes.Replace(payload, []byte(fixture.receipts[1].PolicyHash), []byte(hash("a")), 1)
+				if err := os.WriteFile(fixture.stores[1].ReceiptPath(), payload, 0o644); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "tampered state",
+			mutate: func(t *testing.T, fixture *compactPrePRChainFixture) {
+				payload, err := os.ReadFile(fixture.stores[1].StatePath())
+				if err != nil {
+					t.Fatal(err)
+				}
+				payload = bytes.Replace(payload, []byte(fixture.states[1].PolicyHash), []byte(hash("b")), 1)
+				if err := os.WriteFile(fixture.stores[1].StatePath(), payload, 0o644); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "policy substitution",
+			mutate: func(t *testing.T, fixture *compactPrePRChainFixture) {
+				replaceCompactChainReceipt(t, fixture.stores[1], func(receipt *CompactReceipt) { receipt.PolicyHash = hash("c") })
+			},
+		},
+		{
+			name: "evidence substitution",
+			mutate: func(t *testing.T, fixture *compactPrePRChainFixture) {
+				replaceCompactChainReceipt(t, fixture.stores[1], func(receipt *CompactReceipt) { receipt.EvidenceHash = hash("d") })
+			},
+		},
+		{
+			name: "fix substitution",
+			mutate: func(t *testing.T, fixture *compactPrePRChainFixture) {
+				replaceCompactChainReceipt(t, fixture.stores[1], func(receipt *CompactReceipt) { receipt.FixDeltaHash = hash("e") })
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fixture := newCompactPrePRChainFixture(t, 3)
+			tt.mutate(t, fixture)
+
+			got, attempted := EvaluateCompactPrePRChain(context.Background(), fixture.repo, fixture.input())
+
+			if !attempted || got.Result == GateAllow {
+				t.Fatalf("invalid member authorized = %#v, attempted %t", got, attempted)
+			}
+		})
+	}
+}
+
+func TestCompactPrePRChainRejectsGapFinalMismatchAndReorderedAuthority(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(t *testing.T, fixture *compactPrePRChainFixture)
+	}{
+		{
+			name: "gap",
+			mutate: func(t *testing.T, fixture *compactPrePRChainFixture) {
+				if err := os.RemoveAll(fixture.stores[1].Dir); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "final tree mismatch",
+			mutate: func(t *testing.T, fixture *compactPrePRChainFixture) {
+				writeSnapshotFile(t, fixture.repo, "unreviewed.txt", "unreviewed final tree\n")
+				gitSnapshot(t, fixture.repo, "add", "unreviewed.txt")
+				gitSnapshot(t, fixture.repo, "commit", "-m", "unreviewed final commit")
+			},
+		},
+		{
+			name: "reordered member",
+			mutate: func(t *testing.T, fixture *compactPrePRChainFixture) {
+				first, second := fixture.stores[0].ReceiptPath(), fixture.stores[1].ReceiptPath()
+				firstPayload, err := os.ReadFile(first)
+				if err != nil {
+					t.Fatal(err)
+				}
+				secondPayload, err := os.ReadFile(second)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(first, secondPayload, 0o644); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(second, firstPayload, 0o644); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fixture := newCompactPrePRChainFixture(t, 3)
+			tt.mutate(t, fixture)
+
+			got, attempted := EvaluateCompactPrePRChain(context.Background(), fixture.repo, fixture.input())
+
+			if !attempted || got.Result == GateAllow {
+				t.Fatalf("broken chain authorized = %#v, attempted %t", got, attempted)
+			}
+		})
+	}
+}
+
+func TestCompactPrePRChainRejectsSegmentAndPublicationPathsOutsideGenesis(t *testing.T) {
+	fixture := newCompactPrePRChainFixtureWithHiddenPath(t)
+
+	got, attempted := EvaluateCompactPrePRChain(context.Background(), fixture.repo, fixture.input())
+
+	if !attempted || got.Result == GateAllow {
+		t.Fatalf("touched-then-reverted path authorized = %#v, attempted %t", got, attempted)
+	}
+}
+
+func TestCompactPrePRChainRejectsTransientTreeWithinAuthorizedPath(t *testing.T) {
+	fixture := newCompactPrePRChainFixture(t, 0)
+	reviewed := "reviewed boundary\n"
+	fixture.addApprovedSegmentWithPolicy(t, 0, false, hash("1"), compactPrePRSegmentOptions{
+		content: reviewed,
+		beforeBoundary: func(path string) {
+			if err := os.WriteFile(path, []byte("transient secret\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			gitSnapshot(t, fixture.repo, "add", "-A")
+			gitSnapshot(t, fixture.repo, "commit", "-m", "transient secret")
+			if err := os.WriteFile(path, []byte(reviewed), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		},
+	})
+	fixture.addApprovedSegment(t, 1, false)
+
+	got, attempted := EvaluateCompactPrePRChain(context.Background(), fixture.repo, fixture.input())
+	if !attempted || got.Result == GateAllow {
+		t.Fatalf("transient tree within genesis path = %#v, attempted %t", got, attempted)
+	}
+}
+
+func TestCompactPrePRChainClassifiesCompleteAggregateRisk(t *testing.T) {
+	for _, tt := range []struct {
+		name        string
+		memberLines int
+		wantAllow   bool
+	}{
+		{name: "two 400-line low-risk receipts", memberLines: 400},
+		{name: "two 200-line low-risk receipts", memberLines: 200, wantAllow: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			fixture := newCompactPrePRChainFixture(t, 0)
+			for index := 0; index < 2; index++ {
+				fixture.addApprovedSegmentWithPolicy(t, index, false, hash("1"), compactPrePRSegmentOptions{
+					logicalPath: "segment-" + string(rune('a'+index)) + ".md",
+					content:     strings.Repeat("documentation\n", tt.memberLines),
+				})
+				state := fixture.states[index]
+				if state.RiskLevel != RiskLow || state.OriginalChangedLines != tt.memberLines {
+					t.Fatalf("member risk = %s, lines = %d", state.RiskLevel, state.OriginalChangedLines)
+				}
+			}
+
+			got, attempted := EvaluateCompactPrePRChain(context.Background(), fixture.repo, fixture.input())
+			if !attempted || (got.Result == GateAllow) != tt.wantAllow {
+				t.Fatalf("aggregate risk result = %#v, attempted %t", got, attempted)
+			}
+			if !tt.wantAllow && !strings.Contains(got.Reason, "full-target review") {
+				t.Fatalf("high aggregate risk reason = %q", got.Reason)
+			}
+		})
+	}
+}
+
+func TestCompactPrePRChainAllowsEmptyPublicationCommits(t *testing.T) {
+	fixture := newCompactPrePRChainFixture(t, 0)
+	fixture.addApprovedSegment(t, 0, false)
+	gitSnapshot(t, fixture.repo, "commit", "--allow-empty", "-m", "empty between boundaries")
+	fixture.addApprovedSegment(t, 1, false)
+	gitSnapshot(t, fixture.repo, "commit", "--allow-empty", "-m", "empty after final boundary")
+
+	got, attempted := EvaluateCompactPrePRChain(context.Background(), fixture.repo, fixture.input())
+	if !attempted || got.Result != GateAllow {
+		t.Fatalf("empty publication commits = %#v, attempted %t", got, attempted)
+	}
+}
+
+func TestCompactPrePRChainRejectsEscalatedAndSupersededMembers(t *testing.T) {
+	t.Run("escalated member", func(t *testing.T) {
+		fixture := newCompactPrePRChainFixture(t, 3)
+		record, err := fixture.stores[1].Load()
+		if err != nil {
+			t.Fatal(err)
+		}
+		record.State.State = StateEscalated
+		_, payload, err := makeCompactRecord(record.State)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(fixture.stores[1].StatePath(), payload, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		receipt, err := record.State.Receipt()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := WriteCompactReceiptAtomic(fixture.stores[1].ReceiptPath(), receipt); err != nil {
+			t.Fatal(err)
+		}
+
+		got, attempted := EvaluateCompactPrePRChain(context.Background(), fixture.repo, fixture.input())
+		if !attempted || got.Result == GateAllow {
+			t.Fatalf("escalated member authorized = %#v, attempted %t", got, attempted)
+		}
+	})
+
+	t.Run("superseded member", func(t *testing.T) {
+		fixture := newCompactPrePRChainFixture(t, 3)
+		successor := recoverCompactChainMember(t, fixture, 1)
+		defer os.Remove(filepath.Join(fixture.repo, "recovery-expansion.txt"))
+
+		got, attempted := EvaluateCompactPrePRChain(context.Background(), fixture.repo, fixture.input())
+		if !attempted || got.Result == GateAllow {
+			t.Fatalf("superseded member authorized = %#v, attempted %t, successor %s", got, attempted, successor.State.LineageID)
+		}
+	})
+
+	t.Run("invalid recovery ancestry", func(t *testing.T) {
+		fixture := newCompactPrePRChainFixture(t, 3)
+		successor := recoverCompactChainMember(t, fixture, 1)
+		store, err := CompactAuthoritativeStore(context.Background(), fixture.repo, successor.State.LineageID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		successor.State.Recovery.PredecessorRevision = hash("9")
+		_, payload, err := makeCompactRecord(successor.State)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(store.StatePath(), payload, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		defer os.Remove(filepath.Join(fixture.repo, "recovery-expansion.txt"))
+
+		got, attempted := EvaluateCompactPrePRChain(context.Background(), fixture.repo, fixture.input())
+		if !attempted || got.Result == GateAllow {
+			t.Fatalf("invalid recovery ancestry authorized = %#v, attempted %t", got, attempted)
+		}
+	})
+}
+
+func TestCompactPrePRChainRejectsForkConvergenceAndCycle(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(t *testing.T, fixture *compactPrePRChainFixture)
+	}{
+		{name: "fork", mutate: addCompactChainFork},
+		{name: "convergence", mutate: addCompactChainConvergence},
+		{name: "cycle", mutate: addCompactChainCycle},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fixture := newCompactPrePRChainFixture(t, 3)
+			tt.mutate(t, fixture)
+
+			got, attempted := EvaluateCompactPrePRChain(context.Background(), fixture.repo, fixture.input())
+			if !attempted || got.Result == GateAllow {
+				t.Fatalf("ambiguous graph authorized = %#v, attempted %t", got, attempted)
+			}
+		})
+	}
+}
+
+func TestCompactPrePRChainRejectsMultipleViableChains(t *testing.T) {
+	fixture := newCompactPrePRChainFixture(t, 3)
+	for index, state := range fixture.states {
+		cloneApprovedCompactChainState(t, fixture.repo, state, "compact-chain-duplicate-"+string(rune('a'+index)))
+	}
+
+	got, attempted := EvaluateCompactPrePRChain(context.Background(), fixture.repo, fixture.input())
+	if !attempted || got.Result == GateAllow || !strings.Contains(got.Reason, "multiple viable") {
+		t.Fatalf("multiple viable chains = %#v, attempted %t", got, attempted)
+	}
+}
+
+func TestCompactPrePRChainRejectsIncompatibleSelectedBase(t *testing.T) {
+	fixture := newCompactPrePRChainFixture(t, 3)
+	advanceCompactChainRemote(t, fixture, "segment-a.txt")
+
+	got, attempted := EvaluateCompactPrePRChain(context.Background(), fixture.repo, fixture.input())
+	if !attempted || got.Result == GateAllow {
+		t.Fatalf("incompatible selected base = %#v, attempted %t", got, attempted)
+	}
+}
+
+func TestCompactPrePRChainRequiresSignedCompatibleBaseAdvance(t *testing.T) {
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	policyPayload := []byte("pre_pr_ci_issuer: trusted-ci\npre_pr_ci_ed25519_public_key: " + base64.StdEncoding.EncodeToString(publicKey) + "\n")
+	policyPath := filepath.Join(dir, "policy.md")
+	if err := os.WriteFile(policyPath, policyPayload, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	fixture := newCompactPrePRChainFixtureWithPolicy(t, 3, hashArtifactPayload(policyPayload))
+	newBase := advanceCompactChainRemote(t, fixture, "base-only.txt")
+
+	unsigned, attempted := EvaluateCompactPrePRChain(context.Background(), fixture.repo, fixture.input())
+	if !attempted || unsigned.Result == GateAllow {
+		t.Fatalf("unsigned compatible base advance = %#v, attempted %t", unsigned, attempted)
+	}
+
+	mergedOutput, err := runGit(context.Background(), fixture.repo, nil, nil, "merge-tree", "--write-tree", newBase, fixture.commits[len(fixture.commits)-1])
+	if err != nil {
+		t.Fatal(err)
+	}
+	attestation := prePRCIAttestation{
+		Schema: prePRCIAttestationSchema, Issuer: "trusted-ci", MergedTree: strings.Fields(string(mergedOutput))[0], Status: "success",
+	}
+	attestation.Signature = base64.StdEncoding.EncodeToString(ed25519.Sign(privateKey, prePRCIAttestationPreimage(attestation)))
+	attestationPayload, err := json.Marshal(attestation)
+	if err != nil {
+		t.Fatal(err)
+	}
+	attestationPath := filepath.Join(dir, "attestation.json")
+	if err := os.WriteFile(attestationPath, attestationPayload, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	input := fixture.input()
+	input.PolicyArtifact = policyPath
+	input.PrePRCIAttestation = attestationPath
+
+	signed, attempted := EvaluateCompactPrePRChain(context.Background(), fixture.repo, input)
+	if !attempted || signed.Result != GateAllow || signed.Context.BaseAdvance == nil || !signed.Context.BaseAdvance.Compatible {
+		t.Fatalf("signed compatible base advance = %#v, attempted %t", signed, attempted)
+	}
+}
+
+func TestCompactPrePRChainRejectsMixedLegacyAuthority(t *testing.T) {
+	fixture := newCompactPrePRChainFixture(t, 3)
+	writeSnapshotFile(t, fixture.repo, "legacy.txt", "legacy authority\n")
+	transaction, _, _ := nativeGateFixture(t, fixture.repo, "mixed-legacy-authority")
+	store, err := AuthoritativeStore(context.Background(), fixture.repo, transaction.LineageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	appendApprovedStoreChain(t, store, transaction)
+	receipt, err := transaction.Receipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteReceiptAtomic(filepath.Join(store.Dir, "artifacts", "receipt.json"), receipt); err != nil {
+		t.Fatal(err)
+	}
+	gitSnapshot(t, fixture.repo, "reset", "--hard", "HEAD")
+
+	got, attempted := EvaluateCompactPrePRChain(context.Background(), fixture.repo, fixture.input())
+	if !attempted || got.Result == GateAllow || !strings.Contains(got.Reason, "legacy-v1") {
+		t.Fatalf("mixed legacy/compact authority = %#v, attempted %t", got, attempted)
+	}
+}
+
+func TestCompactPrePRChainRejectsMissingGitObjectDuringFinalAuthorization(t *testing.T) {
+	fixture := newCompactPrePRChainFixture(t, 3)
+	tree := fixture.receipts[len(fixture.receipts)-1].FinalCandidateTree
+	objectPath := filepath.Join(fixture.repo, ".git", "objects", tree[:2], tree[2:])
+	payload, err := os.ReadFile(objectPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	originalHook := finalGateAuthorizationHook
+	finalGateAuthorizationHook = func() {
+		finalGateAuthorizationHook = originalHook
+		if err := os.Remove(objectPath); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Cleanup(func() {
+		finalGateAuthorizationHook = originalHook
+		if err := os.WriteFile(objectPath, payload, 0o444); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	got, attempted := EvaluateCompactPrePRChain(context.Background(), fixture.repo, fixture.input())
+	if !attempted || got.Result == GateAllow || !strings.Contains(got.Reason, "final authorization") {
+		t.Fatalf("missing Git object = %#v, attempted %t", got, attempted)
+	}
+}
+
+func TestCompactPrePRChainFinalAuthorizationRejectsMutations(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(t *testing.T, fixture *compactPrePRChainFixture)
+	}{
+		{
+			name: "HEAD",
+			mutate: func(t *testing.T, fixture *compactPrePRChainFixture) {
+				gitSnapshot(t, fixture.repo, "commit", "--allow-empty", "-m", "move HEAD during authorization")
+			},
+		},
+		{
+			name: "selected base",
+			mutate: func(t *testing.T, fixture *compactPrePRChainFixture) {
+				gitSnapshot(t, fixture.repo, "push", "origin", fixture.commits[0]+":refs/heads/"+fixture.branch)
+			},
+		},
+		{
+			name: "remote identity",
+			mutate: func(t *testing.T, fixture *compactPrePRChainFixture) {
+				other := filepath.Join(t.TempDir(), "other.git")
+				gitSnapshot(t, fixture.repo, "init", "--bare", other)
+				gitSnapshot(t, fixture.repo, "remote", "set-url", "origin", other)
+			},
+		},
+		{
+			name: "authority",
+			mutate: func(t *testing.T, fixture *compactPrePRChainFixture) {
+				payload, err := os.ReadFile(fixture.stores[1].ReceiptPath())
+				if err != nil {
+					t.Fatal(err)
+				}
+				payload = bytes.Replace(payload, []byte(fixture.receipts[1].EvidenceHash), []byte(hash("f")), 1)
+				if err := os.WriteFile(fixture.stores[1].ReceiptPath(), payload, 0o644); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fixture := newCompactPrePRChainFixture(t, 3)
+			originalHook := finalGateAuthorizationHook
+			finalGateAuthorizationHook = func() {
+				finalGateAuthorizationHook = originalHook
+				tt.mutate(t, fixture)
+			}
+			t.Cleanup(func() { finalGateAuthorizationHook = originalHook })
+
+			got, attempted := EvaluateCompactPrePRChain(context.Background(), fixture.repo, fixture.input())
+
+			if !attempted || got.Result == GateAllow || !strings.Contains(got.Reason, "final authorization") {
+				t.Fatalf("concurrent %s mutation = %#v, attempted %t", tt.name, got, attempted)
+			}
+		})
+	}
+}
+
+func TestCompactPrePRChainValidationLeavesRepositoryAndAuthorityBytesUnchanged(t *testing.T) {
+	fixture := newCompactPrePRChainFixture(t, 3)
+	beforeStatus := gitSnapshot(t, fixture.repo, "status", "--porcelain=v1")
+	before := compactChainAuthorityBytes(t, fixture.stores)
+
+	first, attempted := EvaluateCompactPrePRChain(context.Background(), fixture.repo, fixture.input())
+	second, replayed := EvaluateCompactPrePRChain(context.Background(), fixture.repo, fixture.input())
+
+	if !attempted || !replayed || first.Result != GateAllow || !reflect.DeepEqual(first, second) {
+		t.Fatalf("deterministic composition = first %#v, second %#v", first, second)
+	}
+	if afterStatus := gitSnapshot(t, fixture.repo, "status", "--porcelain=v1"); afterStatus != beforeStatus {
+		t.Fatalf("repository status changed: before %q, after %q", beforeStatus, afterStatus)
+	}
+	if after := compactChainAuthorityBytes(t, fixture.stores); !reflect.DeepEqual(after, before) {
+		t.Fatal("composition changed authority or receipt bytes")
+	}
+}
+
+type compactPrePRChainFixture struct {
+	repo     string
+	remote   string
+	branch   string
+	base     string
+	commits  []string
+	states   []CompactState
+	stores   []CompactStore
+	receipts []CompactReceipt
+}
+
+type compactPrePRSegmentOptions struct {
+	logicalPath    string
+	content        string
+	beforeBoundary func(path string)
+}
+
+func newCompactPrePRChainFixture(t *testing.T, count int) *compactPrePRChainFixture {
+	return newCompactPrePRChainFixtureWithPolicy(t, count, hash("1"))
+}
+
+func newCompactPrePRChainFixtureWithPolicy(t *testing.T, count int, policyHash string) *compactPrePRChainFixture {
+	t.Helper()
+	repo := initSnapshotRepo(t)
+	branch := currentBranch(context.Background(), repo)
+	fixture := &compactPrePRChainFixture{
+		repo: repo, branch: branch, base: trimGit(gitSnapshot(t, repo, "rev-parse", "HEAD")),
+		commits: []string{}, states: []CompactState{}, stores: []CompactStore{}, receipts: []CompactReceipt{},
+	}
+	fixture.remote = configurePublicationRemote(t, repo, branch)
+	for index := 0; index < count; index++ {
+		fixture.addApprovedSegmentWithPolicy(t, index, false, policyHash)
+	}
+	return fixture
+}
+
+func newCompactPrePRChainFixtureWithHiddenPath(t *testing.T) *compactPrePRChainFixture {
+	t.Helper()
+	fixture := newCompactPrePRChainFixture(t, 0)
+	fixture.addApprovedSegment(t, 0, true)
+	fixture.addApprovedSegment(t, 1, false)
+	fixture.addApprovedSegment(t, 2, false)
+	return fixture
+}
+
+func (fixture *compactPrePRChainFixture) addApprovedSegment(t *testing.T, index int, hiddenPath bool) {
+	fixture.addApprovedSegmentWithPolicy(t, index, hiddenPath, hash("1"))
+}
+
+func (fixture *compactPrePRChainFixture) addApprovedSegmentWithPolicy(t *testing.T, index int, hiddenPath bool, policyHash string, overrides ...compactPrePRSegmentOptions) {
+	t.Helper()
+	options := compactPrePRSegmentOptions{logicalPath: "segment-" + string(rune('a'+index)) + ".txt", content: "reviewed segment\n"}
+	if len(overrides) > 1 {
+		t.Fatal("compact segment accepts at most one options value")
+	}
+	if len(overrides) == 1 {
+		if overrides[0].logicalPath != "" {
+			options.logicalPath = overrides[0].logicalPath
+		}
+		if overrides[0].content != "" {
+			options.content = overrides[0].content
+		}
+		options.beforeBoundary = overrides[0].beforeBoundary
+	}
+	path := filepath.Join(fixture.repo, options.logicalPath)
+	if err := os.WriteFile(path, []byte(options.content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	lineage := "compact-chain-segment-" + string(rune('a'+index))
+	state := newCompactStartStateForTarget(t, fixture.repo, lineage, Target{
+		Kind: TargetCurrentChanges, IntendedUntracked: []string{filepath.Base(path)},
+	})
+	state.PolicyHash = policyHash
+	state, receipt := persistApprovedCompactState(t, fixture.repo, state)
+	store, err := CompactAuthoritativeStore(context.Background(), fixture.repo, lineage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fixture.states = append(fixture.states, state)
+	fixture.stores = append(fixture.stores, store)
+	fixture.receipts = append(fixture.receipts, receipt)
+	if hiddenPath {
+		writeSnapshotFile(t, fixture.repo, "hidden.txt", "must not be published\n")
+		gitSnapshot(t, fixture.repo, "add", "-A")
+		gitSnapshot(t, fixture.repo, "commit", "-m", "touch hidden path")
+		if err := os.Remove(filepath.Join(fixture.repo, "hidden.txt")); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if options.beforeBoundary != nil {
+		options.beforeBoundary(path)
+	}
+	gitSnapshot(t, fixture.repo, "add", "-A")
+	gitSnapshot(t, fixture.repo, "commit", "-m", "deliver reviewed segment")
+	fixture.commits = append(fixture.commits, trimGit(gitSnapshot(t, fixture.repo, "rev-parse", "HEAD")))
+}
+
+func recoverCompactChainMember(t *testing.T, fixture *compactPrePRChainFixture, index int) CompactRecord {
+	t.Helper()
+	writeSnapshotFile(t, fixture.repo, "recovery-expansion.txt", "expanded recovery scope\n")
+	snapshot, err := (SnapshotBuilder{Repo: fixture.repo}).Build(context.Background(), Target{
+		Kind: TargetCurrentChanges, IntendedUntracked: []string{"recovery-expansion.txt"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	risk, lines, err := (SnapshotBuilder{Repo: fixture.repo}).ClassifySnapshotRisk(context.Background(), snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lenses := []string{}
+	if risk == RiskMedium {
+		lenses = []string{LensReliability}
+	} else if risk == RiskHigh {
+		lenses = append([]string(nil), supportedLenses...)
+	}
+	successor, err := NewCompactState(Start{
+		LineageID: "compact-chain-recovery", Mode: ModeOrdinaryBounded,
+		Generation: fixture.states[index].Generation + 1, Snapshot: snapshot,
+		PolicyHash: fixture.states[index].PolicyHash, RiskLevel: risk,
+		SelectedLenses: lenses, OriginalChangedLines: &lines,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	predecessor, err := fixture.stores[index].Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	record, err := RecoverCompactAuthority(context.Background(), fixture.repo, CompactRecoveryRequest{
+		PredecessorLineageID: predecessor.State.LineageID, ExpectedPredecessorRevision: predecessor.Revision,
+		Successor: successor, Disposition: RecoveryScopeChanged, Reason: "test scope expansion", Actor: "maintainer",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return record
+}
+
+func cloneApprovedCompactChainState(t *testing.T, repo string, source CompactState, lineage string) {
+	t.Helper()
+	clone := source
+	clone.LineageID = lineage
+	store, err := CompactAuthoritativeStore(context.Background(), repo, lineage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, payload, err := makeCompactRecord(clone)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(store.Dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(store.StatePath(), payload, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := clone.Receipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteCompactReceiptAtomic(store.ReceiptPath(), receipt); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func addCompactChainFork(t *testing.T, fixture *compactPrePRChainFixture) {
+	t.Helper()
+	head := trimGit(gitSnapshot(t, fixture.repo, "rev-parse", "HEAD"))
+	gitSnapshot(t, fixture.repo, "reset", "--hard", fixture.base)
+	writeSnapshotFile(t, fixture.repo, "alternate.txt", "alternate branch\n")
+	state := newCompactStartStateForTarget(t, fixture.repo, "compact-chain-fork", Target{
+		Kind: TargetCurrentChanges, IntendedUntracked: []string{"alternate.txt"},
+	})
+	persistApprovedCompactState(t, fixture.repo, state)
+	gitSnapshot(t, fixture.repo, "reset", "--hard", head)
+}
+
+func addCompactChainConvergence(t *testing.T, fixture *compactPrePRChainFixture) {
+	t.Helper()
+	state := newCompactStartStateForTarget(t, fixture.repo, "compact-chain-convergence", Target{
+		Kind: TargetBaseDiff, BaseRef: fixture.commits[0], IntendedUntracked: []string{},
+	})
+	persistApprovedCompactState(t, fixture.repo, state)
+}
+
+func addCompactChainCycle(t *testing.T, fixture *compactPrePRChainFixture) {
+	t.Helper()
+	for index := range fixture.receipts {
+		if err := os.Remove(filepath.Join(fixture.repo, "segment-"+string(rune('a'+index))+".txt")); err != nil {
+			t.Fatal(err)
+		}
+	}
+	state := newCompactStartStateForTarget(t, fixture.repo, "compact-chain-cycle", Target{
+		Kind: TargetCurrentChanges, IntendedUntracked: []string{},
+	})
+	persistApprovedCompactState(t, fixture.repo, state)
+	gitSnapshot(t, fixture.repo, "reset", "--hard", "HEAD")
+}
+
+func advanceCompactChainRemote(t *testing.T, fixture *compactPrePRChainFixture, path string) string {
+	t.Helper()
+	clone := filepath.Join(t.TempDir(), "base-clone")
+	gitSnapshot(t, fixture.repo, "clone", fixture.remote, clone)
+	gitSnapshot(t, clone, "config", "user.email", "test@example.com")
+	gitSnapshot(t, clone, "config", "user.name", "Test User")
+	writeSnapshotFile(t, clone, path, "advanced base\n")
+	gitSnapshot(t, clone, "add", path)
+	gitSnapshot(t, clone, "commit", "-m", "advance selected base")
+	gitSnapshot(t, clone, "push", "origin", fixture.branch)
+	newBase := trimGit(gitSnapshot(t, clone, "rev-parse", "HEAD"))
+	gitSnapshot(t, fixture.repo, "fetch", "origin", fixture.branch+":refs/remotes/origin/"+fixture.branch)
+	return newBase
+}
+
+func (fixture *compactPrePRChainFixture) input() NativeGateRequestInput {
+	return NativeGateRequestInput{Gate: GatePrePR, BaseRef: "origin/" + fixture.branch}
+}
+
+func replaceCompactChainState(t *testing.T, store CompactStore, mutate func(*CompactState)) {
+	t.Helper()
+	record, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	mutate(&record.State)
+	record, payload, err := makeCompactRecord(record.State)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(store.StatePath(), payload, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func replaceCompactChainReceipt(t *testing.T, store CompactStore, mutate func(*CompactReceipt)) {
+	t.Helper()
+	payload, err := os.ReadFile(store.ReceiptPath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := ParseCompactReceipt(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mutate(&receipt)
+	payload, err = json.MarshalIndent(receipt, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(store.ReceiptPath(), append(payload, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func compactChainAuthorityBytes(t *testing.T, stores []CompactStore) map[string]string {
+	t.Helper()
+	result := make(map[string]string, len(stores)*2)
+	for _, store := range stores {
+		for _, path := range []string{store.StatePath(), store.ReceiptPath()} {
+			payload, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			result[path] = string(payload)
+		}
+	}
+	return result
+}


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1326

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [ ] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [x] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Compose sequential approved compact-v2 receipts read-only during unqualified pre-PR validation, without persisting a synthetic receipt or weakening direct explicit-lineage validation.
- Prove the exact publication boundary by requiring each tree-changing commit to consume the next ordered receipt tree, covering every changed and touched publication path while allowing only repeated-tree empty commits.
- Enforce aggregate native risk across the complete composed target and fail closed on high-risk composition, tampered or ambiguous members, stale Git state, and a final proof recheck under the shared v2 lock.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/reviewtransaction/compact_chain.go` | Adds the read-only composition proof evaluator, exact tree and path history checks, aggregate risk enforcement, and locked final recheck. |
| `internal/reviewtransaction/compact_chain_test.go` | Adds adversarial coverage for ordered tree boundaries, transient and reverted content, path coverage, risk escalation, tampering, ambiguity, stale state, and lock-time revalidation. |
| `internal/cli/review_facade.go` | Falls back to composition only after the direct pre-PR receipt path reaches the eligible base-binding denial, preserving direct and explicit-lineage behavior. |
| `internal/cli/review_receipt_discovery_test.go` | Covers composed publication paths, same-path receipt chains, direct explicit lineage, stale HEAD, and fail-closed discovery behavior. |

The `size:exception` is required because this is a 1,459 insertion security-domain implementation dominated by adversarial tests and an inseparable proof evaluator. Splitting the evaluator from the tests that establish its fail-closed boundary would make either review slice incomplete and unsafe to merge independently.

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./...
go test -race ./internal/reviewtransaction ./internal/cli
go vet ./...
```

**Runtime and platform validation**
```bash
/tmp/gentle-ai-1326/runtime-proof.sh
GOOS=windows GOARCH=amd64 go build ./...
GOOS=windows GOARCH=arm64 go build ./...
GOOS=windows GOARCH=amd64 go test ./... -run '^$'
GOOS=windows GOARCH=arm64 go test ./... -run '^$'
```

- [x] Unit tests pass (`go test ./...`)
- [x] Race tests pass for `internal/reviewtransaction` and `internal/cli`
- [x] `go vet ./...`, formatting, diff checks, Linux builds, and self-host build pass
- [x] Disposable-repository runtime proofs cover allow and deny paths
- [x] Windows amd64 and arm64 binaries and test suites cross-compile
- [ ] Actual Windows runtime execution remains a follow-up; this Linux environment cannot execute the generated Windows binaries

---

## 🤖 Automated Checks

The following checks run automatically on this PR:

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | PR uses the documented `size:exception` rationale above |
| Check Issue Reference | ⏳ | PR body contains `Closes #1326` |
| Check Issue Has `status:approved` | ⏳ | Issue #1326 is approved |
| Check PR Has `type:*` Label | ⏳ | Exactly `type:feature` is applied |
| Unit Tests | ⏳ | `go test ./...` must pass |
| E2E Tests | ⏳ | Required GitHub checks must pass before merge |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR uses maintainer-approved `size:exception` with rationale documented
- [x] I have added exactly one `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [x] Runtime proof and platform cross-compilation pass
- [x] Documentation is not required because the public command contract is unchanged
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] My commits do not include `Co-Authored-By` trailers

---

## Chain Context

| Field | Value |
|-------|-------|
| Chain | Review finalize preflight |
| Tracker PR | Not needed |
| Position | Current follow-up slice |
| Base | `fix/review-finalize-preflight` |
| Depends on | The review finalize preflight branch |
| Follow-up | Actual Windows runtime execution evidence |
| Review budget | 1,459 / 400, `size:exception` |
| Starts at | `fix/review-finalize-preflight` at `b3ebcd9490e60fe245bf04187d7ed5eaf8038c45` |
| Ends with | Sequential approved receipts can authorize one exact pre-PR publication boundary |

### Chain Overview

```text
main
 └── fix/review-finalize-preflight
      └── 📍 feat/review-receipt-composition (this follow-up PR)
```

This PR targets `fix/review-finalize-preflight` as the current follow-up slice. It does not target `main` directly.

### Scope

- Includes: Read-only compact-v2 receipt composition at pre-PR, exact boundary proof, aggregate risk enforcement, and adversarial tests.
- Excludes: Merging `fix/review-finalize-preflight` to `main` and native Windows runtime execution.

### Autonomy

- [x] CI is expected to pass for this PR branch
- [x] This PR has one deliverable scope
- [x] This PR can be rolled back without unrelated changes
- [x] Tests and manual runtime verification cover this unit

---

## 💬 Notes for Reviewers

The mandatory native pre-PR gate allowed lineage `review-c6d0ff345b5266c5` at authority revision `sha256:5c858d016a07ddb5e997a799c6d07bf57e657564e80836e638ea402a6031b101` against explicit base `origin/fix/review-finalize-preflight`.
