### PR TITLE
fix(review): escalate failed scoped validation

### DIFF
--- a/internal/cli/review_facade_test.go
+++ b/internal/cli/review_facade_test.go
@@ -851,13 +851,10 @@ func TestReviewFacadeEscalatesFalseIntroducedFindingOutsideGenesis(t *testing.T)
 func TestReviewFacadeStartCannotResetActiveCorrectionBudget(t *testing.T) {
 	tests := []struct {
 		name       string
-		consumed   bool
 		negotiated bool
 	}{
 		{name: "pre-forecast raw"},
 		{name: "pre-forecast negotiated", negotiated: true},
-		{name: "consumed attempt raw", consumed: true},
-		{name: "consumed attempt negotiated", consumed: true, negotiated: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -880,29 +877,11 @@ func TestReviewFacadeStartCannotResetActiveCorrectionBudget(t *testing.T) {
 				t.Fatal(err)
 			}
 			store, _ := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, started.LineageID)
-			if tt.consumed {
-				if err := RunReviewFacadeFinalize([]string{"--cwd", repo, "--correction-lines", "2"}, io.Discard); err != nil {
-					t.Fatal(err)
-				}
-				write("first-fix")
-				validator := filepath.Join(t.TempDir(), "validator.json")
-				writeReviewCLIJSON(t, validator, facadeValidationResult{
-					OriginalCriteria:     facadeValidationCheck{Passed: false, Evidence: []string{"acceptance still fails"}},
-					CorrectionRegression: facadeValidationCheck{Passed: false, Evidence: []string{"regression still fails"}}, FollowUps: []reviewtransaction.FollowUp{},
-				})
-				if err := RunReviewFacadeFinalize([]string{"--cwd", repo, "--validation", validator}, io.Discard); err != nil {
-					t.Fatal(err)
-				}
-			}
 			before, err := store.Load()
 			if err != nil {
 				t.Fatal(err)
 			}
-			wantAttempts, wantLines := 0, 0
-			if tt.consumed {
-				wantAttempts, wantLines = 1, 2
-			}
-			if before.State.State != reviewtransaction.StateCorrectionRequired || len(before.State.CorrectionAttempts) != wantAttempts || before.State.CumulativeCorrectionLines != wantLines {
+			if before.State.State != reviewtransaction.StateCorrectionRequired || len(before.State.CorrectionAttempts) != 0 || before.State.CumulativeCorrectionLines != 0 {
 				t.Fatalf("predecessor fixture = %#v", before.State)
 			}
 			write("second-byte-only-edit")
@@ -941,7 +920,7 @@ func TestReviewFacadeStartCannotResetActiveCorrectionBudget(t *testing.T) {
 			}
 			after, _ := store.Load()
 			stores, discoverErr := reviewtransaction.DiscoverCompactStores(context.Background(), repo)
-			if discoverErr != nil || after.Revision != before.Revision || after.State.CumulativeCorrectionLines != wantLines || len(after.State.CorrectionAttempts) != wantAttempts || len(stores) != 1 {
+			if discoverErr != nil || after.Revision != before.Revision || after.State.CumulativeCorrectionLines != 0 || len(after.State.CorrectionAttempts) != 0 || len(stores) != 1 {
 				t.Fatalf("START reset or mutated correction authority: before=%#v after=%#v stores=%d err=%v", before, after, len(stores), discoverErr)
 			}
 		})
@@ -1313,7 +1292,7 @@ func TestReviewSchemasRequireConcreteEvidenceStrings(t *testing.T) {
 	}
 }
 
-func TestReviewFacadeRejectsMalformedInputsWithoutConsumingIterativeCorrection(t *testing.T) {
+func TestReviewFacadeRejectsMalformedInputsWithoutConsumingTerminalValidator(t *testing.T) {
 	repo := initReviewCLIRepo(t)
 	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("base\n01\n02\n03\n04\n05\n06\n07\n08\n09\n10\n11\n12\n13\n14\n15\n16\n17\n18\n19\n20\n"), 0o644); err != nil {
 		t.Fatal(err)
@@ -1363,24 +1342,23 @@ func TestReviewFacadeRejectsMalformedInputsWithoutConsumingIterativeCorrection(t
 		t.Fatal(err)
 	}
 	failed, _ := store.Load()
-	if failed.State.State != reviewtransaction.StateCorrectionRequired || failed.State.CumulativeCorrectionLines <= 0 || len(failed.State.LensResults) != 1 {
+	if failed.State.State != reviewtransaction.StateEscalated || failed.State.CumulativeCorrectionLines <= 0 || len(failed.State.LensResults) != 1 || failed.State.OriginalCriteria == nil || failed.State.CorrectionRegression == nil {
 		t.Fatalf("failed validation state = %#v", failed.State)
 	}
-
-	remaining := failed.State.CorrectionBudget - failed.State.CumulativeCorrectionLines
-	if err := RunReviewFacadeFinalize([]string{"--cwd", repo, "--correction-lines", fmt.Sprint(remaining)}, io.Discard); err != nil {
+	receiptPayload, err := os.ReadFile(store.ReceiptPath())
+	if err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("base\n01\n02\n03\nfixed\n05\n06\n07\n08\n09\n10\n11\n12\n13\n14\n15\n16\n17\n18\n19\n20\n"), 0o644); err != nil {
+	receipt, err := reviewtransaction.ParseCompactReceipt(receiptPayload)
+	if err != nil || receipt.TerminalState != reviewtransaction.TerminalEscalated || receipt.FixDeltaHash != failed.State.FixDeltaHash {
+		t.Fatalf("failed validation receipt = %#v, %v", receipt, err)
+	}
+	if err := RunReviewFacadeFinalize([]string{"--cwd", repo, "--correction-lines", "1"}, io.Discard); err != nil {
 		t.Fatal(err)
 	}
-	writeReviewCLIJSON(t, validator, facadeValidationResult{OriginalCriteria: facadeValidationCheck{Passed: true, Evidence: []string{"acceptance passes"}}, CorrectionRegression: facadeValidationCheck{Passed: true, Evidence: []string{"regression passes"}}, FollowUps: []reviewtransaction.FollowUp{}})
-	if err := RunReviewFacadeFinalize([]string{"--cwd", repo, "--validation", validator}, io.Discard); err != nil {
-		t.Fatal(err)
-	}
-	corrected, _ := store.Load()
-	if corrected.State.State != reviewtransaction.StateValidating || corrected.State.CumulativeCorrectionLines > corrected.State.CorrectionBudget || len(corrected.State.CorrectionAttempts) != 2 || len(corrected.State.LensResults) != 1 {
-		t.Fatalf("corrected retry state = %#v", corrected.State)
+	replayed, _ := store.Load()
+	if replayed.Revision != failed.Revision || replayed.State.State != reviewtransaction.StateEscalated || len(replayed.State.CorrectionAttempts) != 1 {
+		t.Fatalf("terminal failed validator replay = %#v", replayed)
 	}
 }
 

--- a/internal/cli/review_status_contract_test.go
+++ b/internal/cli/review_status_contract_test.go
@@ -335,6 +335,19 @@ func TestNegotiatedRuntimeReplaysPublishedV149AuthorityReadOnly(t *testing.T) {
 	}
 }
 
+func TestNegotiatedStatusPreservesManualRecoveryAuthorityContext(t *testing.T) {
+	native := reviewtransaction.TargetStatusResult{
+		Applicability: reviewtransaction.TargetApplicabilityCurrent, AuthorityVersion: reviewtransaction.AuthorityVersionCompact,
+		LineageID: "historical-validator", State: reviewtransaction.StateCorrectionRequired, Generation: 1, Revision: "sha256:" + strings.Repeat("a", 64),
+		Action: reviewtransaction.TargetStatusActionRecover, Replayability: reviewtransaction.ReplayabilityManualActionRequired,
+	}
+	got := newReviewTargetStatusResult(native)
+	if got.Action != reviewtransaction.TargetStatusActionRecover || got.Replayability != reviewtransaction.ReplayabilityManualActionRequired ||
+		got.Authority == nil || got.Authority.LineageID != native.LineageID || got.Authority.Revision != native.Revision {
+		t.Fatalf("negotiated recovery status = %#v", got)
+	}
+}
+
 func TestNegotiatedLegacyReceiptStatusNeverUsesCompactPublicationPending(t *testing.T) {
 	native := reviewtransaction.TargetStatusResult{
 		Applicability:    reviewtransaction.TargetApplicabilityCurrent,

--- a/internal/reviewtransaction/compact.go
+++ b/internal/reviewtransaction/compact.go
@@ -648,6 +648,9 @@ func (state *CompactState) BeginCorrection(proposed int) error {
 	if state.State != StateCorrectionRequired || state.ProposedCorrectionLines != nil {
 		return fmt.Errorf("cannot begin correction from compact state %q", state.State)
 	}
+	if len(state.CorrectionAttempts) != 0 {
+		return errors.New("compact correction validator was already consumed; use authorized successor recovery")
+	}
 	if proposed <= 0 {
 		return errors.New("compact correction requires a positive changed-line forecast")
 	}
@@ -688,24 +691,13 @@ func (state *CompactState) CompleteCorrection(snapshot Snapshot, actual int, val
 	state.CumulativeCorrectionLines += actual
 	state.CurrentSnapshot = snapshot
 	state.FollowUps = append(state.FollowUps, validation.FollowUps...)
-	if state.CumulativeCorrectionLines > state.CorrectionBudget {
-		state.FixDeltaHash, state.ActualCorrectionLines = fixHash, &actual
-		original, regression := validation.OriginalCriteria, validation.CorrectionRegression
-		state.OriginalCriteria, state.CorrectionRegression = &original, &regression
+	state.FixDeltaHash, state.ActualCorrectionLines = fixHash, &actual
+	original, regression := validation.OriginalCriteria, validation.CorrectionRegression
+	state.OriginalCriteria, state.CorrectionRegression = &original, &regression
+	if state.CumulativeCorrectionLines > state.CorrectionBudget || !original.Passed || !regression.Passed {
 		state.State = StateEscalated
-	} else if validation.OriginalCriteria.Passed && validation.CorrectionRegression.Passed {
-		state.FixDeltaHash, state.ActualCorrectionLines = fixHash, &actual
-		original, regression := validation.OriginalCriteria, validation.CorrectionRegression
-		state.OriginalCriteria, state.CorrectionRegression = &original, &regression
-		state.State = StateValidating
 	} else {
-		state.State = StateCorrectionRequired
-		if len(state.CorrectionAttempts) >= MaxCompactCorrectionAttempts {
-			state.State = StateEscalated
-		}
-		state.ProposedCorrectionLines, state.ActualCorrectionLines = nil, nil
-		state.FixDeltaHash = EmptyFixDeltaHash
-		state.OriginalCriteria, state.CorrectionRegression = nil, nil
+		state.State = StateValidating
 	}
 	return state.Validate()
 }

--- a/internal/reviewtransaction/compact_store.go
+++ b/internal/reviewtransaction/compact_store.go
@@ -131,7 +131,7 @@ func RecoverCompactAuthority(ctx context.Context, repo string, request CompactRe
 	if predecessor.Revision != request.ExpectedPredecessorRevision {
 		return CompactRecord{}, fmt.Errorf("%w: expected predecessor revision %q, current %q", ErrConcurrentUpdate, request.ExpectedPredecessorRevision, predecessor.Revision)
 	}
-	if predecessor.State.State == StateCorrectionRequired && request.MaintainerAuthorization != compactRecoveryAuthorizationBinding(request.PredecessorLineageID, predecessor.Revision, request.Successor.InitialSnapshot.Identity, request.Actor, request.Reason) {
+	if predecessor.State.State == StateCorrectionRequired && request.Disposition != RecoveryEscalated && request.MaintainerAuthorization != compactRecoveryAuthorizationBinding(request.PredecessorLineageID, predecessor.Revision, request.Successor.InitialSnapshot.Identity, request.Actor, request.Reason) {
 		return CompactRecord{}, errors.New("correction-required scope recovery requires an exact maintainer authorization binding")
 	}
 	if predecessor.State.InitialSnapshot.Projection != request.Successor.InitialSnapshot.Projection {
@@ -233,16 +233,33 @@ func validateCompactRecoveryEdge(predecessor CompactRecord, successor CompactSta
 			return errors.New("recovery requires an invalidated predecessor")
 		}
 	case RecoveryEscalated:
-		if predecessor.State.State != StateEscalated {
+		historicalFailedValidator := compactHistoricalFailedValidator(predecessor.State)
+		if predecessor.State.State != StateEscalated && !historicalFailedValidator {
 			return errors.New("recovery requires an escalated predecessor")
 		}
-		if strings.TrimSpace(recovery.MaintainerAuthorization) == "" {
-			return errors.New("escalated recovery requires explicit maintainer authorization")
+		if !compactEscalatedRecoveryTargetChanged(predecessor.State.CurrentSnapshot, successor.InitialSnapshot) {
+			return errors.New("escalated recovery successor target has not changed")
+		}
+		if recovery.MaintainerAuthorization != compactRecoveryAuthorizationBinding(predecessor.State.LineageID, predecessor.Revision, successor.InitialSnapshot.Identity, recovery.Actor, recovery.Reason) {
+			return errors.New("escalated recovery requires an exact maintainer authorization binding")
 		}
 	default:
 		return errors.New("unsupported recovery disposition")
 	}
 	return nil
+}
+
+func compactEscalatedRecoveryTargetChanged(previous, next Snapshot) bool {
+	return previous.CandidateTree != next.CandidateTree && previous.Identity != next.Identity
+}
+
+func compactHistoricalFailedValidator(state CompactState) bool {
+	if state.State != StateCorrectionRequired || len(state.CorrectionAttempts) == 0 || state.ProposedCorrectionLines != nil || state.ActualCorrectionLines != nil ||
+		state.FixDeltaHash != EmptyFixDeltaHash || state.OriginalCriteria != nil || state.CorrectionRegression != nil {
+		return false
+	}
+	last := state.CorrectionAttempts[len(state.CorrectionAttempts)-1]
+	return !last.OriginalCriteria.Passed || !last.CorrectionRegression.Passed
 }
 
 func compactRecoveryAuthorizationBinding(lineage, revision, targetIdentity, actor, reason string) string {
@@ -434,6 +451,15 @@ func StartCompactAuthority(ctx context.Context, repo string, request CompactStar
 	requestedClaims := false
 	for _, store := range leaves {
 		existing := records[store.lineageID].State
+		if existing.State == StateEscalated && compactStartDeliveryScopeMatches(existing, request.State) {
+			if compactEscalatedRecoveryTargetChanged(existing.CurrentSnapshot, request.State.InitialSnapshot) {
+				recoveryCandidates = append(recoveryCandidates, store)
+			} else {
+				claimants = append(claimants, store)
+				requestedClaims = requestedClaims || store.lineageID == request.State.LineageID
+			}
+			continue
+		}
 		if existing.State == StateCorrectionRequired {
 			claim := classifyCompactCorrectionTarget(ctx, requestedStore.repo, existing, request.State)
 			switch claim {
@@ -608,6 +634,12 @@ func classifyCompactCorrectionTarget(ctx context.Context, repo string, existing,
 		existing.InitialSnapshot.BaseTree != live.BaseTree || len(live.LedgerIDs) != 0 ||
 		(SnapshotBuilder{Repo: repo}).ValidateEvidence(ctx, live) != nil {
 		return compactCorrectionTargetUnclaimed
+	}
+	if compactHistoricalFailedValidator(existing) {
+		if compactEscalatedRecoveryTargetChanged(existing.CurrentSnapshot, live) {
+			return compactCorrectionTargetRecover
+		}
+		return compactCorrectionTargetBlocked
 	}
 	if compactRecoveryAddsGenesisPath(existing, live) {
 		return compactCorrectionTargetRecover
@@ -1015,6 +1047,19 @@ func ImportCompactTransport(ctx context.Context, repo string, transport CompactT
 	if legacy, legacyErr := AuthoritativeStore(ctx, repo, validated.Record.State.LineageID); legacyErr == nil {
 		if _, loadErr := legacy.LoadChain(); loadErr == nil {
 			return CompactRecord{}, errors.New("cannot import compact authority over an existing legacy v1 lineage")
+		}
+	}
+	if recovery := validated.Record.State.Recovery; recovery != nil {
+		predecessorStore, predecessorErr := CompactAuthoritativeStore(ctx, repo, recovery.PredecessorLineageID)
+		if predecessorErr != nil {
+			return CompactRecord{}, predecessorErr
+		}
+		predecessor, predecessorErr := predecessorStore.Load()
+		if predecessorErr != nil {
+			return CompactRecord{}, fmt.Errorf("load imported recovery predecessor: %w", predecessorErr)
+		}
+		if err := validateCompactRecoveryEdge(predecessor, validated.Record.State); err != nil {
+			return CompactRecord{}, fmt.Errorf("validate imported recovery edge: %w", err)
 		}
 	}
 	if err := store.installTransportRecord(ctx, validated.Record); err != nil {

--- a/internal/reviewtransaction/compact_store_test.go
+++ b/internal/reviewtransaction/compact_store_test.go
@@ -645,7 +645,7 @@ func TestStartCompactAuthorityReusesApprovedReceiptAmongUnrelatedLeaves(t *testi
 	}
 }
 
-func TestStartCompactAuthorityResumesAuthorizedCorrectionContinuation(t *testing.T) {
+func TestStartCompactAuthorityPreservesTerminalFailedValidator(t *testing.T) {
 	repo := initSnapshotRepo(t)
 	writeSnapshotFile(t, repo, "tracked.txt", "base\nwrong\n")
 	state := newCompactTestState(t, repo, "compact-start-correction")
@@ -682,17 +682,21 @@ func TestStartCompactAuthorityResumesAuthorizedCorrectionContinuation(t *testing
 	if err != nil {
 		t.Fatal(err)
 	}
-	if state.ProposedCorrectionLines != nil || state.CurrentSnapshot.CandidateTree != fix.CandidateTree {
+	if state.State != StateEscalated || state.ProposedCorrectionLines == nil || state.CurrentSnapshot.CandidateTree != fix.CandidateTree {
 		t.Fatalf("failed correction state = %#v", state)
 	}
 	requested := newCompactTestState(t, repo, "compact-start-correction-request")
 	result, err := StartCompactAuthority(context.Background(), repo, CompactStartRequest{State: requested})
-	if err != nil || result.Action != CompactStartResumed || result.Record.State.LineageID != state.LineageID || result.Record.Revision != revision {
-		t.Fatalf("authorized correction continuation = %#v, %v", result, err)
+	if err != nil || result.Action != CompactStartCreated || result.Record.State.LineageID != requested.LineageID {
+		t.Fatalf("terminal validator start = %#v, %v", result, err)
+	}
+	predecessor, err := store.Load()
+	if err != nil || predecessor.Revision != revision || predecessor.State.State != StateEscalated {
+		t.Fatalf("terminal validator predecessor = %#v, %v", predecessor, err)
 	}
 	leaves, err := CompactAuthorityLeaves(context.Background(), repo)
-	if err != nil || len(leaves) != 1 {
-		t.Fatalf("correction replay leaves = %#v, %v", leaves, err)
+	if err != nil || len(leaves) != 2 {
+		t.Fatalf("terminal validator leaves = %#v, %v", leaves, err)
 	}
 }
 
@@ -884,85 +888,271 @@ func TestCompactStoreReplaceContextRejectsCancelledMutation(t *testing.T) {
 	}
 }
 
-func TestCompactCorrectionRetriesWithinFrozenBudgetAndFindingScope(t *testing.T) {
-	repo := initSnapshotRepo(t)
-	writeSnapshotFile(t, repo, "tracked.txt", "base\none\ntwo\nthree\nfour\n")
-	state := newCompactTestState(t, repo, "compact-iterative-correction")
-	finding := Finding{ID: "R3-001", Location: "tracked.txt:5", Severity: "CRITICAL", Claim: "wrong value", ProofRefs: []string{"candidate-only failure"}}
-	result := LensResult{Lens: state.SelectedLenses[0], Findings: []Finding{finding}, Evidence: []string{"reviewed once"}}
-	if err := state.CompleteReview(CompactReviewInput{LensResults: []LensResult{result}, Classifications: []FindingEvidence{{FindingID: finding.ID, Class: EvidenceDeterministic, Causality: CausalIntroduced, Proof: "changed hunk"}}, RefuterOutcomes: []EvidenceResult{}}); err != nil {
-		t.Fatal(err)
+func TestCompactFirstCompletedValidatorIsTerminal(t *testing.T) {
+	tests := []struct {
+		name               string
+		originalPassed     bool
+		regressionPassed   bool
+		regressionEvidence string
+		wantState          State
+	}{
+		{name: "false original criteria", regressionPassed: true, regressionEvidence: "2", wantState: StateEscalated},
+		{name: "false correction regression", originalPassed: true, regressionEvidence: "3", wantState: StateEscalated},
+		{name: "incomplete timeout is a failed regression", originalPassed: true, regressionEvidence: "4", wantState: StateEscalated},
+		{name: "approved path remains validating", originalPassed: true, regressionPassed: true, regressionEvidence: "2", wantState: StateValidating},
 	}
-	initialLenses := append([]LensResult(nil), state.LensResults...)
-
-	complete := func(content string, passed bool) error {
-		if err := state.BeginCorrection(1); err != nil {
-			return err
-		}
-		writeSnapshotFile(t, repo, "tracked.txt", content)
-		fix, err := (SnapshotBuilder{Repo: repo}).Build(context.Background(), Target{Kind: TargetFixDiff, BaseRef: state.CurrentSnapshot.CandidateTree, IntendedUntracked: state.InitialSnapshot.IntendedUntracked, LedgerIDs: state.FixFindingIDs})
-		if err != nil {
-			return err
-		}
-		fixHash := FixDeltaHashForSnapshot(fix)
-		return state.CompleteCorrection(fix, 1, ScopedValidationResult{LedgerIDs: []string{finding.ID}, FixCausedFindings: []Finding{}, FollowUps: []FollowUp{},
-			OriginalCriteria: ValidationCheck{EvidenceHash: hash("2"), FixDeltaHash: fixHash, Passed: passed}, CorrectionRegression: ValidationCheck{EvidenceHash: hash("3"), FixDeltaHash: fixHash, Passed: passed}})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := initSnapshotRepo(t)
+			state, fix := pendingCompactCorrection(t, repo, "validator-terminal")
+			fixHash := FixDeltaHashForSnapshot(fix)
+			validation := ScopedValidationResult{LedgerIDs: append([]string(nil), state.FixFindingIDs...), FixCausedFindings: []Finding{}, FollowUps: []FollowUp{},
+				OriginalCriteria:     ValidationCheck{EvidenceHash: hash("1"), FixDeltaHash: fixHash, Passed: tt.originalPassed},
+				CorrectionRegression: ValidationCheck{EvidenceHash: hash(tt.regressionEvidence), FixDeltaHash: fixHash, Passed: tt.regressionPassed}}
+			if err := state.CompleteCorrection(fix, 1, validation); err != nil {
+				t.Fatal(err)
+			}
+			if state.State != tt.wantState || state.ProposedCorrectionLines == nil || *state.ProposedCorrectionLines != 1 || state.ActualCorrectionLines == nil || *state.ActualCorrectionLines != 1 ||
+				state.FixDeltaHash != fixHash || !reflect.DeepEqual(state.OriginalCriteria, &validation.OriginalCriteria) || !reflect.DeepEqual(state.CorrectionRegression, &validation.CorrectionRegression) ||
+				len(state.CorrectionAttempts) != 1 || !snapshotsEqual(state.CurrentSnapshot, fix) || !equalStrings(state.CorrectionAttempts[0].Snapshot.LedgerIDs, state.FixFindingIDs) {
+				t.Fatalf("terminal validator bindings = %#v", state)
+			}
+			if tt.wantState == StateValidating {
+				if err := state.CompleteVerification([]byte("approved evidence\n"), true); err != nil {
+					t.Fatal(err)
+				}
+			} else {
+				before := state
+				if err := state.BeginCorrection(1); err == nil || !reflect.DeepEqual(state, before) {
+					t.Fatalf("terminal lineage accepted replay: %#v, %v", state, err)
+				}
+			}
+			receipt, err := state.Receipt()
+			if err != nil {
+				t.Fatal(err)
+			}
+			payload, _ := json.Marshal(receipt)
+			parsed, err := ParseCompactReceipt(payload)
+			if err != nil || !CompactReceiptEqual(parsed, receipt) {
+				t.Fatalf("terminal receipt replay = %#v, %v", parsed, err)
+			}
+		})
 	}
-	if err := complete("base\none\ntwo\nthree\nfirst-fix\n", false); err != nil {
-		t.Fatal(err)
-	}
-	if state.State != StateCorrectionRequired || state.CumulativeCorrectionLines != 1 || len(state.CorrectionAttempts) != 1 {
-		t.Fatalf("failed attempt state = %#v", state)
-	}
-	if err := complete("base\none\ntwo\nthree\nfixed\n", true); err != nil {
-		t.Fatal(err)
-	}
-	if state.State != StateValidating || state.CumulativeCorrectionLines != 2 || len(state.CorrectionAttempts) != 2 || !reflect.DeepEqual(state.LensResults, initialLenses) || !reflect.DeepEqual(state.FixFindingIDs, []string{finding.ID}) {
-		t.Fatalf("successful retry state = %#v", state)
-	}
-	before := state
-	state.State, state.ProposedCorrectionLines = StateCorrectionRequired, nil
-	if err := state.BeginCorrection(state.CorrectionBudget); err != nil || state.State != StateEscalated {
-		t.Fatalf("cumulative overflow = %#v, %v", state, err)
-	}
-	state = before
 }
 
-func TestCompactZeroLineFailuresReachAttemptCap(t *testing.T) {
+func TestCompactMalformedValidatorDoesNotConsumeAuthority(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	state, fix := pendingCompactCorrection(t, repo, "validator-malformed")
+	before := state
+	validation := ScopedValidationResult{LedgerIDs: state.FixFindingIDs, FixCausedFindings: []Finding{}, FollowUps: []FollowUp{},
+		OriginalCriteria:     ValidationCheck{EvidenceHash: "not-a-hash", FixDeltaHash: FixDeltaHashForSnapshot(fix)},
+		CorrectionRegression: ValidationCheck{EvidenceHash: hash("regression"), FixDeltaHash: FixDeltaHashForSnapshot(fix)}}
+	if err := state.CompleteCorrection(fix, 1, validation); err == nil || !reflect.DeepEqual(state, before) {
+		t.Fatalf("malformed validator consumed authority: %#v, %v", state, err)
+	}
+}
+
+func TestCompactHistoricalFailedValidatorRecoveryPreservesPredecessor(t *testing.T) {
 	if runtime.GOOS == "windows" {
-		t.Skip("fixture depends solely on Git executable-bit transitions")
+		t.Skip("legacy multi-attempt fixture uses a Git executable-bit transition")
 	}
 	repo := initSnapshotRepo(t)
-	writeSnapshotFile(t, repo, "tracked.txt", "base\none\ntwo\nthree\nfour\n")
-	state := newCompactTestState(t, repo, "compact-zero-attempt-cap")
-	finding := Finding{ID: "R3-001", Location: "tracked.txt:5", Severity: "CRITICAL", Claim: "wrong", ProofRefs: []string{"proof"}}
-	if err := state.CompleteReview(CompactReviewInput{LensResults: []LensResult{{Lens: state.SelectedLenses[0], Findings: []Finding{finding}, Evidence: []string{"reviewed"}}}, Classifications: []FindingEvidence{{FindingID: finding.ID, Class: EvidenceDeterministic, Causality: CausalIntroduced, Proof: "proof"}}, RefuterOutcomes: []EvidenceResult{}}); err != nil {
+	state, fix := pendingCompactCorrection(t, repo, "legacy-failed-validator")
+	fixHash := FixDeltaHashForSnapshot(fix)
+	failed := ScopedValidationResult{LedgerIDs: state.FixFindingIDs, FixCausedFindings: []Finding{}, FollowUps: []FollowUp{},
+		OriginalCriteria:     ValidationCheck{EvidenceHash: hash("2"), FixDeltaHash: fixHash, Passed: true},
+		CorrectionRegression: ValidationCheck{EvidenceHash: hash("3"), FixDeltaHash: fixHash}}
+	if err := state.CompleteCorrection(fix, 1, failed); err != nil {
 		t.Fatal(err)
 	}
-	for attempt := 0; attempt < MaxCompactCorrectionAttempts; attempt++ {
-		if err := state.BeginCorrection(1); err != nil {
-			t.Fatal(err)
-		}
-		mode := os.FileMode(0o755)
-		if attempt%2 != 0 {
-			mode = 0o644
-		}
-		if err := os.Chmod(filepath.Join(repo, "tracked.txt"), mode); err != nil {
-			t.Fatal(err)
-		}
-		fix, err := (SnapshotBuilder{Repo: repo}).Build(context.Background(), Target{Kind: TargetFixDiff, BaseRef: state.CurrentSnapshot.CandidateTree, IntendedUntracked: state.InitialSnapshot.IntendedUntracked, LedgerIDs: state.FixFindingIDs})
-		if err != nil {
-			t.Fatal(err)
-		}
-		fixHash := FixDeltaHashForSnapshot(fix)
-		validation := ScopedValidationResult{LedgerIDs: state.FixFindingIDs, FixCausedFindings: []Finding{}, FollowUps: []FollowUp{}, OriginalCriteria: ValidationCheck{EvidenceHash: hash("2"), FixDeltaHash: fixHash}, CorrectionRegression: ValidationCheck{EvidenceHash: hash("3"), FixDeltaHash: fixHash}}
-		if err := state.CompleteCorrection(fix, 0, validation); err != nil {
-			t.Fatal(err)
-		}
+	if err := os.Chmod(filepath.Join(repo, "tracked.txt"), 0o755); err != nil {
+		t.Fatal(err)
 	}
-	if state.State != StateEscalated || len(state.CorrectionAttempts) != MaxCompactCorrectionAttempts {
-		t.Fatalf("zero-line cap state = %#v", state)
+	second, err := (SnapshotBuilder{Repo: repo}).Build(context.Background(), Target{Kind: TargetFixDiff, BaseRef: state.CurrentSnapshot.CandidateTree, IntendedUntracked: state.InitialSnapshot.IntendedUntracked, LedgerIDs: state.FixFindingIDs})
+	if err != nil {
+		t.Fatal(err)
 	}
+	secondHash := FixDeltaHashForSnapshot(second)
+	state.CorrectionAttempts = append(state.CorrectionAttempts, CompactCorrectionAttempt{Snapshot: second, ProposedLines: 1, ActualLines: 0, FixDeltaHash: secondHash,
+		OriginalCriteria: ValidationCheck{EvidenceHash: hash("4"), FixDeltaHash: secondHash, Passed: true}, CorrectionRegression: ValidationCheck{EvidenceHash: hash("5"), FixDeltaHash: secondHash}})
+	state.State, state.CurrentSnapshot = StateCorrectionRequired, second
+	state.ProposedCorrectionLines, state.ActualCorrectionLines = nil, nil
+	state.FixDeltaHash, state.OriginalCriteria, state.CorrectionRegression = EmptyFixDeltaHash, nil, nil
+	if err := state.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	beforeRetry := state
+	if err := state.BeginCorrection(1); err == nil || !reflect.DeepEqual(state, beforeRetry) {
+		t.Fatalf("historical failed validator resumed correction: %#v, %v", state, err)
+	}
+	store, _ := CompactAuthoritativeStore(context.Background(), repo, state.LineageID)
+	record, payload, err := makeCompactRecord(state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(store.Dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(store.StatePath(), payload, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	before, _ := os.ReadFile(store.StatePath())
+	if _, err := store.Load(); err != nil {
+		t.Fatal(err)
+	}
+	afterLoad, _ := os.ReadFile(store.StatePath())
+	if !bytes.Equal(before, afterLoad) {
+		t.Fatal("legacy multi-attempt load migrated persisted bytes")
+	}
+	successor := newCompactTestState(t, repo, "legacy-failed-validator-g2")
+	successor.Generation = state.Generation + 1
+	request := CompactRecoveryRequest{PredecessorLineageID: state.LineageID, ExpectedPredecessorRevision: record.Revision, Successor: successor,
+		Disposition: RecoveryEscalated, Reason: "recover historical failed validator", Actor: "maintainer@example.com", RecoveredAt: time.Date(2026, 7, 17, 12, 0, 0, 0, time.UTC)}
+	request.MaintainerAuthorization = compactRecoveryAuthorizationBinding(state.LineageID, record.Revision, successor.InitialSnapshot.Identity, request.Actor, request.Reason)
+	if _, err := RecoverCompactAuthority(context.Background(), repo, request); err == nil || !strings.Contains(err.Error(), "target has not changed") {
+		t.Fatalf("historical recovery accepted same target: %v", err)
+	}
+	writeSnapshotFile(t, repo, "tracked.txt", "base\none\ntwo\nthree\nchanged-again\n")
+	request.Successor = newCompactTestState(t, repo, successor.LineageID)
+	request.Successor.Generation = state.Generation + 1
+	request.MaintainerAuthorization = compactRecoveryAuthorizationBinding(state.LineageID, record.Revision, request.Successor.InitialSnapshot.Identity, request.Actor, request.Reason)
+	recovered, err := RecoverCompactAuthority(context.Background(), repo, request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	retry, err := RecoverCompactAuthority(context.Background(), repo, request)
+	if err != nil || retry.Revision != recovered.Revision || recovered.State.Recovery == nil || recovered.State.Recovery.Disposition != RecoveryEscalated {
+		t.Fatalf("historical recovery replay = %#v, %v", retry, err)
+	}
+	afterRecovery, _ := os.ReadFile(store.StatePath())
+	if !bytes.Equal(before, afterRecovery) {
+		t.Fatal("historical recovery changed predecessor bytes")
+	}
+}
+
+func TestEscalatedRecoveryRequiresChangedTarget(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	state := correctedCompactTestState(t, repo, "escalated-target")
+	state.State = StateEscalated
+	store, _ := CompactAuthoritativeStore(context.Background(), repo, state.LineageID)
+	record, payload, err := makeCompactRecord(state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(store.Dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(store.StatePath(), payload, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	successor := newCompactTestState(t, repo, "escalated-target-g2")
+	successor.Generation = state.Generation + 1
+	request := CompactRecoveryRequest{PredecessorLineageID: state.LineageID, ExpectedPredecessorRevision: record.Revision, Successor: successor,
+		Disposition: RecoveryEscalated, Actor: "maintainer", Reason: "retry terminal validator"}
+	request.MaintainerAuthorization = compactRecoveryAuthorizationBinding(state.LineageID, record.Revision, successor.InitialSnapshot.Identity, request.Actor, request.Reason)
+	started, startErr := StartCompactAuthority(context.Background(), repo, CompactStartRequest{State: successor})
+	status, statusErr := AssessTargetStatus(context.Background(), repo, TargetStatusRequest{Target: Target{Kind: TargetCurrentChanges, IntendedUntracked: []string{}}, LineageID: state.LineageID})
+	if startErr != nil || statusErr != nil || started.Action != CompactStartBlocked || status.Action != TargetStatusActionStop || status.Replayability != ReplayabilityManualActionRequired {
+		t.Fatalf("same-target terminal actions: START=%#v status=%#v errors=%v/%v", started, status, startErr, statusErr)
+	}
+	if _, err := RecoverCompactAuthority(context.Background(), repo, request); err == nil || !strings.Contains(err.Error(), "target has not changed") {
+		t.Fatalf("same-target escalated recovery error = %v", err)
+	}
+	writeSnapshotFile(t, repo, "tracked.txt", "changed escalated target\n")
+	request.Successor = newCompactTestState(t, repo, successor.LineageID)
+	request.Successor.Generation = state.Generation + 1
+	request.MaintainerAuthorization = compactRecoveryAuthorizationBinding(state.LineageID, record.Revision, request.Successor.InitialSnapshot.Identity, request.Actor, request.Reason)
+	started, startErr = StartCompactAuthority(context.Background(), repo, CompactStartRequest{State: request.Successor})
+	status, statusErr = AssessTargetStatus(context.Background(), repo, TargetStatusRequest{Target: Target{Kind: TargetCurrentChanges, IntendedUntracked: []string{}}, LineageID: state.LineageID})
+	recovered, recoverErr := RecoverCompactAuthority(context.Background(), repo, request)
+	replayed, replayErr := RecoverCompactAuthority(context.Background(), repo, request)
+	after, _ := os.ReadFile(store.StatePath())
+	if startErr != nil || statusErr != nil || recoverErr != nil || replayErr != nil || started.Action != CompactStartRecover || status.Action != TargetStatusActionRecover ||
+		replayed.Revision != recovered.Revision || !bytes.Equal(payload, after) {
+		t.Fatalf("changed-target recovery: START=%#v status=%#v recovery=%v replay=%v", started, status, recoverErr, replayErr)
+	}
+}
+
+func TestCompactHistoricalFailedValidatorTransportRequiresExactBinding(t *testing.T) {
+	repo, state, predecessor, _ := historicalFailedValidatorFixture(t, "historical-transport")
+	gitSnapshot(t, repo, "add", "tracked.txt")
+	gitSnapshot(t, repo, "commit", "-m", "historical corrected candidate")
+	predecessorTransport := CompactTransport{Schema: CompactTransportSchema, Record: predecessor}
+	predecessorTransport.BundleDigest = compactTransportDigest(predecessorTransport)
+
+	for _, tt := range []struct {
+		name, want     string
+		changed, exact bool
+	}{{"same target", "target has not changed", false, true}, {"changed target", "", true, true}, {"wrong binding", "exact maintainer authorization", true, false}} {
+		t.Run(tt.name, func(t *testing.T) {
+			destination := filepath.Join(t.TempDir(), "clone")
+			gitSnapshot(t, repo, "clone", "--no-local", repo, destination)
+			if _, err := ImportCompactTransport(context.Background(), destination, predecessorTransport); err != nil {
+				t.Fatal(err)
+			}
+			if tt.changed {
+				writeSnapshotFile(t, destination, "tracked.txt", "changed imported target\n")
+				gitSnapshot(t, destination, "add", "tracked.txt")
+				gitSnapshot(t, destination, "config", "user.email", "test@example.com")
+				gitSnapshot(t, destination, "config", "user.name", "Test User")
+				gitSnapshot(t, destination, "commit", "-m", "changed recovery target")
+			}
+			successor := newCompactRevisionState(t, destination, "historical-transport-g2-"+strings.ReplaceAll(tt.name, " ", "-"))
+			successor.Generation = state.Generation + 1
+			successor.Recovery = &CompactRecoveryProvenance{PredecessorLineageID: state.LineageID, PredecessorRevision: predecessor.Revision,
+				Disposition: RecoveryEscalated, Actor: "maintainer", Reason: "recover failed validator", RecoveredAt: time.Now().UTC()}
+			successor.Recovery.MaintainerAuthorization = "wrong"
+			if tt.exact {
+				successor.Recovery.MaintainerAuthorization = compactRecoveryAuthorizationBinding(state.LineageID, predecessor.Revision, successor.InitialSnapshot.Identity, successor.Recovery.Actor, successor.Recovery.Reason)
+			}
+			record, _, err := makeCompactRecord(successor)
+			if err != nil {
+				t.Fatal(err)
+			}
+			transport := CompactTransport{Schema: CompactTransportSchema, Record: record}
+			transport.BundleDigest = compactTransportDigest(transport)
+			_, err = ImportCompactTransport(context.Background(), destination, transport)
+			store, _ := CompactAuthoritativeStore(context.Background(), destination, successor.LineageID)
+			if tt.want != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.want) {
+					t.Fatalf("import error = %v, want %q", err, tt.want)
+				}
+				if _, statErr := os.Stat(store.StatePath()); !os.IsNotExist(statErr) {
+					t.Fatalf("wrong binding installed successor: %v", statErr)
+				}
+			} else if err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func historicalFailedValidatorFixture(t *testing.T, lineage string) (string, CompactState, CompactRecord, []byte) {
+	t.Helper()
+	repo := initSnapshotRepo(t)
+	state, fix := pendingCompactCorrection(t, repo, lineage)
+	fixHash := FixDeltaHashForSnapshot(fix)
+	state.CorrectionAttempts = []CompactCorrectionAttempt{{Snapshot: fix, ProposedLines: 1, ActualLines: 1, FixDeltaHash: fixHash,
+		OriginalCriteria:     ValidationCheck{EvidenceHash: hash("6"), FixDeltaHash: fixHash, Passed: true},
+		CorrectionRegression: ValidationCheck{EvidenceHash: hash("7"), FixDeltaHash: fixHash}}}
+	state.State, state.CurrentSnapshot, state.CumulativeCorrectionLines = StateCorrectionRequired, fix, 1
+	state.ProposedCorrectionLines, state.ActualCorrectionLines = nil, nil
+	state.FixDeltaHash, state.OriginalCriteria, state.CorrectionRegression = EmptyFixDeltaHash, nil, nil
+	if err := state.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	record, payload, err := makeCompactRecord(state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, _ := CompactAuthoritativeStore(context.Background(), repo, lineage)
+	if err := os.MkdirAll(store.Dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(store.StatePath(), payload, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return repo, state, record, payload
 }
 
 func TestCompactStoreFailsClosedForCorruptionAndIgnoresInvalidTempState(t *testing.T) {
@@ -1028,28 +1218,14 @@ func TestCompactDiscoveryIgnoresOnlyUnpublishedCrashResidue(t *testing.T) {
 
 func TestCompactActualCumulativeOverflowPersistsTerminalAttempt(t *testing.T) {
 	repo := initSnapshotRepo(t)
-	writeSnapshotFile(t, repo, "tracked.txt", "base\none\ntwo\nthree\nfour\n")
-	state := correctedCompactTestState(t, repo, "compact-cumulative-overflow")
-	prior := CompactCorrectionAttempt{Snapshot: state.CurrentSnapshot, ProposedLines: 1, ActualLines: state.CorrectionBudget - 1, FixDeltaHash: state.FixDeltaHash, OriginalCriteria: *state.OriginalCriteria, CorrectionRegression: *state.CorrectionRegression}
-	state.State, state.EvidenceHash = StateCorrectionRequired, ""
-	state.CorrectionAttempts, state.CumulativeCorrectionLines = []CompactCorrectionAttempt{prior}, state.CorrectionBudget-1
-	state.FixDeltaHash, state.ActualCorrectionLines = EmptyFixDeltaHash, nil
-	state.OriginalCriteria, state.CorrectionRegression, state.ProposedCorrectionLines = nil, nil, nil
-	if err := state.BeginCorrection(1); err != nil {
-		t.Fatal(err)
-	}
-	writeSnapshotFile(t, repo, "tracked.txt", "base\none\ntwo\nchanged\nexpanded\n")
-	fix, err := (SnapshotBuilder{Repo: repo}).Build(context.Background(), Target{Kind: TargetFixDiff, BaseRef: state.CurrentSnapshot.CandidateTree, IntendedUntracked: state.InitialSnapshot.IntendedUntracked, LedgerIDs: state.FixFindingIDs})
-	if err != nil {
-		t.Fatal(err)
-	}
-	actual, _ := (SnapshotBuilder{Repo: repo}).ChangedLines(context.Background(), fix)
+	state, fix := pendingCompactCorrection(t, repo, "compact-cumulative-overflow")
+	actual := state.CorrectionBudget + 1
 	fixHash := FixDeltaHashForSnapshot(fix)
 	validation := ScopedValidationResult{LedgerIDs: state.FixFindingIDs, FixCausedFindings: []Finding{}, FollowUps: []FollowUp{}, OriginalCriteria: ValidationCheck{EvidenceHash: hash("2"), FixDeltaHash: fixHash, Passed: true}, CorrectionRegression: ValidationCheck{EvidenceHash: hash("3"), FixDeltaHash: fixHash, Passed: true}}
 	if err := state.CompleteCorrection(fix, actual, validation); err != nil {
 		t.Fatal(err)
 	}
-	if state.State != StateEscalated || state.CumulativeCorrectionLines <= state.CorrectionBudget || len(state.CorrectionAttempts) != 2 {
+	if state.State != StateEscalated || state.CumulativeCorrectionLines <= state.CorrectionBudget || len(state.CorrectionAttempts) != 1 {
 		t.Fatalf("overflow state = %#v", state)
 	}
 	_, payload, err := makeCompactRecord(state)
@@ -1059,7 +1235,6 @@ func TestCompactActualCumulativeOverflowPersistsTerminalAttempt(t *testing.T) {
 	if _, err := parseCompactRecord(payload, state.LineageID); err != nil {
 		t.Fatalf("persisted overflow record: %v", err)
 	}
-	writeSnapshotFile(t, repo, "tracked.txt", "base\none\ntwo\nthree\nfixed\n")
 	if err := state.BeginCorrection(1); err == nil {
 		t.Fatal("overflow lineage resumed after reducing the diff")
 	}
@@ -1658,6 +1833,28 @@ func newCompactTestStateWithIntended(t *testing.T, repo, lineage string, intende
 		t.Fatal(err)
 	}
 	return state
+}
+
+func pendingCompactCorrection(t *testing.T, repo, lineage string) (CompactState, Snapshot) {
+	t.Helper()
+	writeSnapshotFile(t, repo, "tracked.txt", "base\none\ntwo\nthree\nfour\n")
+	state := newCompactTestState(t, repo, lineage)
+	finding := Finding{ID: "R3-001", Lens: strings.TrimPrefix(state.SelectedLenses[0], "review-"), Location: "tracked.txt:5", Severity: "CRITICAL", Claim: "wrong value", ProofRefs: []string{"candidate-only failure"}}
+	if err := state.CompleteReview(CompactReviewInput{
+		LensResults:     []LensResult{{Lens: state.SelectedLenses[0], Findings: []Finding{finding}, Evidence: []string{"reviewed once"}}},
+		Classifications: []FindingEvidence{{FindingID: finding.ID, Class: EvidenceDeterministic, Causality: CausalIntroduced, Proof: "changed hunk"}}, RefuterOutcomes: []EvidenceResult{},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.BeginCorrection(1); err != nil {
+		t.Fatal(err)
+	}
+	writeSnapshotFile(t, repo, "tracked.txt", "base\none\ntwo\nthree\nfixed\n")
+	fix, err := (SnapshotBuilder{Repo: repo}).Build(context.Background(), Target{Kind: TargetFixDiff, BaseRef: state.CurrentSnapshot.CandidateTree, IntendedUntracked: state.InitialSnapshot.IntendedUntracked, LedgerIDs: state.FixFindingIDs})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return state, fix
 }
 
 func correctedCompactTestState(t *testing.T, repo, lineage string) CompactState {

--- a/internal/reviewtransaction/risk.go
+++ b/internal/reviewtransaction/risk.go
@@ -696,6 +696,9 @@ func touchesHotPath(stats []DiffStat) bool {
 
 func hotPathRiskSignals(logicalPath string) []RiskSignal {
 	signals := make([]RiskSignal, 0, 4)
+	if isNativeReviewAuthorityPath(logicalPath) {
+		signals = append(signals, SignalAuth)
+	}
 	for _, token := range strings.FieldsFunc(strings.ToLower(logicalPath), func(r rune) bool {
 		return r == '/' || r == '\\' || r == '.' || r == '-' || r == '_'
 	}) {
@@ -711,6 +714,17 @@ func hotPathRiskSignals(logicalPath string) []RiskSignal {
 		}
 	}
 	return canonicalRiskSignals(signals)
+}
+
+func isNativeReviewAuthorityPath(logicalPath string) bool {
+	switch logicalPath {
+	case "internal/reviewtransaction/compact.go", "internal/reviewtransaction/transaction.go",
+		"internal/reviewtransaction/compact_store.go", "internal/reviewtransaction/store.go",
+		"internal/reviewtransaction/compact_gate.go", "internal/reviewtransaction/gate.go":
+		return true
+	default:
+		return false
+	}
 }
 
 func normalizeLogicalPath(value string) (string, error) {

--- a/internal/reviewtransaction/risk_test.go
+++ b/internal/reviewtransaction/risk_test.go
@@ -82,6 +82,46 @@ func TestClassifyRiskUsesDeterministicFirstMatch(t *testing.T) {
 	}
 }
 
+func TestNativeReviewAuthorityPathsEmitCanonicalAuthHotPath(t *testing.T) {
+	tests := []struct {
+		path      string
+		authority bool
+	}{
+		{path: "internal/reviewtransaction/compact.go", authority: true},
+		{path: "internal/reviewtransaction/transaction.go", authority: true},
+		{path: "internal/reviewtransaction/compact_store.go", authority: true},
+		{path: "internal/reviewtransaction/store.go", authority: true},
+		{path: "internal/reviewtransaction/compact_gate.go", authority: true},
+		{path: "internal/reviewtransaction/gate.go", authority: true},
+		{path: "internal/reviewtransaction/compact_test.go"},
+		{path: "docs/internal/reviewtransaction/compact.go"},
+		{path: "internal/reviewtransaction/compact_chain.go"},
+		{path: "internal/reviewtransaction/snapshot.go"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			signals := hotPathRiskSignals(tt.path)
+			if got := len(signals) == 1 && signals[0] == SignalAuth; got != tt.authority {
+				t.Fatalf("hotPathRiskSignals(%q) = %v, authority = %t", tt.path, signals, tt.authority)
+			}
+			if tt.authority {
+				want := []RiskReason{{Code: RiskReasonHotPath, Signal: SignalAuth, Path: tt.path}}
+				if got := deriveSnapshotRiskReasons([]DiffStat{{Path: tt.path, Additions: 1}}, 1); !reflect.DeepEqual(got, want) {
+					t.Fatalf("deriveSnapshotRiskReasons(%q) = %#v, want %#v", tt.path, got, want)
+				}
+			}
+			want := RiskMedium
+			if tt.authority {
+				want = RiskHigh
+			}
+			got, err := ClassifyRisk(RiskInput{Stats: []DiffStat{{Path: tt.path, Additions: 1}}})
+			if err != nil || got != want {
+				t.Fatalf("ClassifyRisk(%q) = %q, %v; want %q", tt.path, got, err, want)
+			}
+		})
+	}
+}
+
 func TestPureDocumentationReviewPathExcludesOperationalMarkdown(t *testing.T) {
 	tests := []struct {
 		path string

--- a/internal/reviewtransaction/target_status.go
+++ b/internal/reviewtransaction/target_status.go
@@ -176,7 +176,15 @@ func AssessTargetStatus(ctx context.Context, repo string, request TargetStatusRe
 			continue
 		}
 		state := candidate.compact.State
-		if state.State == StateCorrectionRequired {
+		if state.State == StateEscalated {
+			requested := state
+			requested.InitialSnapshot = live
+			if compactStartDeliveryScopeMatches(state, requested) {
+				candidate.correctionRecovery = compactEscalatedRecoveryTargetChanged(state.CurrentSnapshot, live)
+				candidates = append(candidates, candidate)
+				continue
+			}
+		} else if state.State == StateCorrectionRequired {
 			requested := candidate.compact.State
 			requested.InitialSnapshot = live
 			switch classifyCompactCorrectionTarget(ctx, repo, state, requested) {
@@ -294,6 +302,10 @@ func targetStatusForCandidate(result TargetStatusResult, candidate targetStatusC
 		result.ReceiptIdentity = candidate.receiptIdentity
 		if candidate.correctionRecovery {
 			result.Action, result.Replayability = TargetStatusActionRecover, ReplayabilityManualActionRequired
+			return result
+		}
+		if state.State == StateEscalated || compactHistoricalFailedValidator(state) {
+			result.Action, result.Replayability = TargetStatusActionStop, ReplayabilityManualActionRequired
 			return result
 		}
 		if !candidate.receiptPublished && candidate.receiptReplayable {

--- a/internal/reviewtransaction/target_status_test.go
+++ b/internal/reviewtransaction/target_status_test.go
@@ -249,6 +249,33 @@ func TestAssessTargetStatusRecognizesAuthorizedCorrection(t *testing.T) {
 	}
 }
 
+func TestHistoricalFailedValidatorRequiresChangedTargetRecovery(t *testing.T) {
+	repo, state, record, before := historicalFailedValidatorFixture(t, "historical-status")
+	target := Target{Kind: TargetCurrentChanges, IntendedUntracked: []string{}}
+	requested := newCompactTestState(t, repo, "historical-status-new")
+	started, err := StartCompactAuthority(context.Background(), repo, CompactStartRequest{State: requested})
+	if err != nil || started.Action != CompactStartBlocked || started.Record.Revision != record.Revision {
+		t.Fatalf("same-target historical START = %#v, %v", started, err)
+	}
+	status, err := AssessTargetStatus(context.Background(), repo, TargetStatusRequest{Target: target, LineageID: state.LineageID})
+	if err != nil || status.Applicability != TargetApplicabilityCurrent || status.Action != TargetStatusActionStop ||
+		status.Replayability != ReplayabilityManualActionRequired || status.LineageID != state.LineageID || status.Revision != record.Revision {
+		t.Fatalf("same-target historical status = %#v, %v", status, err)
+	}
+	writeSnapshotFile(t, repo, "tracked.txt", "changed recovery target\n")
+	requested = newCompactTestState(t, repo, "historical-status-changed")
+	started, err = StartCompactAuthority(context.Background(), repo, CompactStartRequest{State: requested})
+	status, statusErr := AssessTargetStatus(context.Background(), repo, TargetStatusRequest{Target: target, LineageID: state.LineageID})
+	if err != nil || statusErr != nil || started.Action != CompactStartRecover || status.Action != TargetStatusActionRecover || status.Replayability != ReplayabilityManualActionRequired {
+		t.Fatalf("changed-target recovery: START=%#v status=%#v errors=%v/%v", started, status, err, statusErr)
+	}
+	store, _ := CompactAuthoritativeStore(context.Background(), repo, state.LineageID)
+	after, _ := os.ReadFile(store.StatePath())
+	if !bytes.Equal(before, after) {
+		t.Fatal("START/status migrated historical authority")
+	}
+}
+
 func TestCorrectionScopeExpansionGuidesStatusAndStartToRecovery(t *testing.T) {
 	repo, predecessor, _, _ := correctionScopeRecoveryFixture(t, "review-correction-expansion")
 	writeSnapshotFile(t, repo, "process_helper.go", "package processhelper\n")


### PR DESCRIPTION
## Linked Issues

Closes #1309

Canonical issue: #1309. Duplicate history: #1294.

Stack dependency: #1344.

---

## PR Type

- [x] `type:bug` - Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` - New feature (non-breaking change that adds functionality)
- [ ] `type:docs` - Documentation only
- [ ] `type:refactor` - Code refactoring (no functional changes)
- [ ] `type:chore` - Build, CI, or tooling changes
- [ ] `type:breaking-change` - Breaking change (fix or feature that changes existing behavior)

---

## Summary

- Makes the first scoped correction validator terminal: failed or incomplete validation escalates immediately instead of reopening correction.
- Preserves correction, validation, evidence, ledger, budget, and provenance bindings in the terminal escalated receipt.
- Keeps same-target recovery terminal while allowing only an exact, explicitly authorized changed-target successor, including historical/import/status paths.
- Corrects the high-risk classifier so these review-transaction changes receive canonical 4R review.

---

## Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/reviewtransaction/compact.go` | Transitions failed scoped validation directly to terminal escalation while retaining immutable bindings. |
| `internal/reviewtransaction/compact_store.go` | Enforces changed-target exact recovery and validates historical/import recovery edges. |
| `internal/reviewtransaction/target_status.go` | Keeps same-target escalations terminal/manual and routes eligible changed targets to recovery. |
| `internal/reviewtransaction/risk.go` | Classifies review transaction state-machine changes as high risk for canonical 4R review. |
| Review transaction and CLI tests | Covers original-criteria failure, regression failure, incomplete validation, receipt persistence, replay, history/import/status, same-target denial, changed-target recovery, and classifier behavior. |

---

## Stack Context

This is the reviewed terminal-validator slice stacked on the v2.1.7 release-blocker branch:

```text
main
  -> #1344 fix/v217-release-blockers-v2
       -> this PR fix/validator-terminal-escalation-release
```

Current boundary: validator escalation, immutable bindings, exact successor recovery, status/import/history handling, classifier correction, and their tests.

Out of scope: merging #1344, changing validator timeouts, retrying validators, reopening findings, or resetting correction budgets.

---

## Review Evidence

- Review tier: `high`
- Canonical 4R review: completed for risk, resilience, readability, and reliability
- Review corrections: completed within the authorized `88/160` correction budget
- Review result: approved
- Review lineage: `validator-escalation-release-v217`
- Terminal receipt SHA-256: `ed445679450394925eb0af5d37430fb94cbbd6912bac843222a4ab7ade7d9566`
- Pre-PR gate: `allow` / `continue`

---

## Test Plan

Completed on Go 1.25.10 with v2.1.7 contract metadata:

- [x] Focused correction and recovery tests
- [x] Full Go test suite
- [x] `go vet ./...`
- [x] Recursive Go format validation
- [x] Contract tests and capabilities
- [x] Component golden tests
- [x] Linux amd64 build
- [x] Windows amd64 build
- [x] Windows arm64 build
- [ ] Docker E2E suite was not rerun locally; required CI remains authoritative

---

## Size Exception

Review budget: 598 changed lines (`458` additions + `140` deletions) across nine files.

The maintainer approved `size:exception` because the necessary state-machine change must remain reviewable with its exhaustive terminal, replay, historical/import/status, exact-recovery, classifier, receipt, and CLI contract tests. Splitting those tests from the behavior would weaken the review boundary.

---

## Contributor Checklist

- [x] PR is linked to issue #1309 with `status:approved`
- [x] Maintainer-approved `size:exception` rationale is documented
- [x] Exactly one `type:*` label is applied
- [x] Unit tests pass (`go test ./...`)
- [x] Go format validation passes
- [ ] Docker E2E remains for CI
- [x] Documentation is not required; this restores the published terminal-validator lifecycle contract
- [x] Commit follows Conventional Commits format
- [x] Commit has no `Co-Authored-By` trailer

---

## Notes for Reviewers

Please review this after #1344. Do not merge this PR until its parent is ready and all required checks pass.
