### PR TITLE
fix(sdd): add explicit lineage routing

### DIFF
--- a/internal/app/help.go
+++ b/internal/app/help.go
@@ -18,9 +18,9 @@ COMMANDS
   sync         Sync agent configs and skills to current version
   skill-registry refresh
                Refresh .atl/skill-registry.md with cache-hit fast path
-  sdd-status [change]
+  sdd-status [change] [--lineage <id>]
                Print native SDD phase status for orchestrators
-  sdd-continue [change]
+  sdd-continue [change] [--lineage <id>]
                Print native SDD dispatcher routing output
   review start [--cwd <repo>] [--base-ref <ref>] [--focus <risk|resilience|readability|reliability>]
   review finalize [--cwd <repo>] [--result <review.json> ...] [--evidence <path>]

--- a/internal/app/help_test.go
+++ b/internal/app/help_test.go
@@ -17,6 +17,9 @@ func TestHelpContainsAllCommands(t *testing.T) {
 			t.Errorf("help output missing command %q", cmd)
 		}
 	}
+	if strings.Count(output, "[--lineage <id>]") < 2 {
+		t.Fatalf("help does not expose explicit lineage for both SDD commands:\n%s", output)
+	}
 }
 
 func TestHelpPresentsFlatReviewCommandsAsCompatibilityPaths(t *testing.T) {

--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"flag"
 	"fmt"
 	"io"
 	"os"
@@ -1106,8 +1107,13 @@ func runReviewFacadeValidate(ctx context.Context, args []string, stdout io.Write
 	if err := parseReviewFlags(flags, args); err != nil {
 		return err
 	}
+	lineageSet := false
+	flags.Visit(func(current *flag.Flag) { lineageSet = lineageSet || current.Name == "lineage" })
 	if reviewHelpRequested(args) {
 		return nil
+	}
+	if lineageSet && strings.TrimSpace(*lineage) == "" {
+		return errors.New("review validate --lineage requires a value")
 	}
 	if flags.NArg() != 0 {
 		return reviewPreflightError(fmt.Errorf("unexpected review validate argument %q", flags.Arg(0)))
@@ -1134,11 +1140,7 @@ func runReviewFacadeValidate(ctx context.Context, args []string, stdout io.Write
 	}
 	compactStore, compactRecord, compactErr := discoverCompactFacadeGateReview(ctx, root, *lineage, gateInput)
 	if compactErr == nil {
-		if strings.TrimSpace(*lineage) != "" {
-			if _, _, _, legacyErr := discoverFacadeReview(ctx, root, *lineage, true); legacyErr == nil {
-				return errors.New("review authority is ambiguous across compact v2 and legacy v1 stores; specify and clean up the intended lineage")
-			}
-		} else if legacyExactFacadeGateLineages(ctx, root, gateInput) > 0 {
+		if strings.TrimSpace(*lineage) == "" && legacyExactFacadeGateLineages(ctx, root, gateInput) > 0 {
 			return errors.New("review authority is ambiguous across compact v2 and legacy v1 stores; specify and clean up the intended lineage")
 		}
 		payload, err := os.ReadFile(compactStore.ReceiptPath())
@@ -1160,6 +1162,9 @@ func runReviewFacadeValidate(ctx context.Context, args []string, stdout io.Write
 			}
 		}
 		return emitFacadeGateEvaluationNegotiated(stdout, evaluation, negotiated)
+	}
+	if strings.TrimSpace(*lineage) != "" {
+		return compactErr
 	}
 	var compactDiscovery *ReviewReceiptDiscoveryError
 	if gateInput.Gate == reviewtransaction.GatePrePR && strings.TrimSpace(*lineage) == "" &&
@@ -1216,7 +1221,27 @@ func runReviewFacadeValidate(ctx context.Context, args []string, stdout io.Write
 
 func discoverCompactFacadeGateReview(ctx context.Context, repo, lineage string, input reviewtransaction.NativeGateRequestInput) (reviewtransaction.CompactStore, reviewtransaction.CompactRecord, error) {
 	if strings.TrimSpace(lineage) != "" {
-		return discoverCompactFacadeReview(ctx, repo, lineage, true)
+		store, record, err := discoverCompactFacadeReview(ctx, repo, lineage, true)
+		if err != nil {
+			return store, record, err
+		}
+		mismatch := errors.New("explicit compact review authority or receipt is not approved and content-bound")
+		if record.State.State != reviewtransaction.StateApproved {
+			return reviewtransaction.CompactStore{}, reviewtransaction.CompactRecord{}, mismatch
+		}
+		payload, err := os.ReadFile(store.ReceiptPath())
+		if err != nil {
+			return reviewtransaction.CompactStore{}, reviewtransaction.CompactRecord{}, mismatch
+		}
+		receipt, err := reviewtransaction.ParseCompactReceipt(payload)
+		if err != nil {
+			return reviewtransaction.CompactStore{}, reviewtransaction.CompactRecord{}, mismatch
+		}
+		derived, err := record.State.Receipt()
+		if err != nil || !reviewtransaction.CompactReceiptEqual(receipt, derived) {
+			return reviewtransaction.CompactStore{}, reviewtransaction.CompactRecord{}, mismatch
+		}
+		return store, record, nil
 	}
 	report, err := reviewtransaction.InventoryAuthority(ctx, repo)
 	if err != nil || !report.Complete || !report.Authoritative {

--- a/internal/cli/review_receipt_discovery_test.go
+++ b/internal/cli/review_receipt_discovery_test.go
@@ -179,6 +179,22 @@ func TestUnqualifiedGateDiscoveryRejectsMultipleExactReceiptsButExplicitLineageI
 	if err := reviewtransaction.WriteCompactReceiptAtomic(cloneStore.ReceiptPath(), cloneReceipt); err != nil {
 		t.Fatal(err)
 	}
+	if _, _, err := discoverCompactFacadeGateReview(context.Background(), repo, started.LineageID, reviewtransaction.NativeGateRequestInput{Gate: reviewtransaction.GatePostApply}); err != nil {
+		t.Fatalf("explicit exact receipt discovery: %v", err)
+	}
+	if err := reviewtransaction.WriteCompactReceiptAtomic(store.ReceiptPath(), cloneReceipt); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := discoverCompactFacadeGateReview(context.Background(), repo, started.LineageID, reviewtransaction.NativeGateRequestInput{Gate: reviewtransaction.GatePostApply}); err == nil {
+		t.Fatal("explicit lineage accepted a receipt from another authority")
+	}
+	receipt, err := record.State.Receipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := reviewtransaction.WriteCompactReceiptAtomic(store.ReceiptPath(), receipt); err != nil {
+		t.Fatal(err)
+	}
 
 	var output bytes.Buffer
 	err = RunReview([]string{
@@ -218,6 +234,19 @@ func TestUnqualifiedGateDiscoveryRequiresSelectionForMultipleScopeChangedReceipt
 			logicalPath := "docs/scope-" + tt.name + ".md"
 			_, first := approveDiscoveryMarkdownProjection(t, repo, lineages[0], logicalPath, "reviewed\n", tt.projection)
 			cloneApprovedDiscoveryAuthority(t, repo, first, lineages[1])
+			if tt.projection == reviewtransaction.ProjectionStaged {
+				beforeState, _ := os.ReadFile(first.StatePath())
+				beforeReceipt, _ := os.ReadFile(first.ReceiptPath())
+				var output bytes.Buffer
+				if err := RunReview([]string{"validate", "--contract", ReviewIntegrationContractV1, "--cwd", repo, "--lineage", lineages[0], "--gate", string(tt.gate)}, &output); err != nil {
+					t.Fatalf("explicit staged lineage failed: %v\n%s", err, output.String())
+				}
+				afterState, _ := os.ReadFile(first.StatePath())
+				afterReceipt, _ := os.ReadFile(first.ReceiptPath())
+				if !bytes.Equal(beforeState, afterState) || !bytes.Equal(beforeReceipt, afterReceipt) {
+					t.Fatal("explicit validation mutated authority or receipt")
+				}
+			}
 			if err := os.WriteFile(filepath.Join(repo, filepath.FromSlash(logicalPath)), []byte("drifted\n"), 0o644); err != nil {
 				t.Fatal(err)
 			}
@@ -274,6 +303,26 @@ func TestUnqualifiedGateDiscoveryRequiresSelectionForMultipleScopeChangedReceipt
 				assertScopeChangeRecovery(t, explicit, lineage, logicalPath)
 			}
 		})
+	}
+}
+
+func TestReviewValidateRejectsEmptyExplicitLineage(t *testing.T) {
+	for _, args := range [][]string{
+		{"validate", "--lineage", "   ", "--gate", string(reviewtransaction.GatePreCommit)},
+		{"validate", "-lineage", "   ", "--gate", string(reviewtransaction.GatePreCommit)},
+	} {
+		err := RunReview(args, &bytes.Buffer{})
+		if err == nil || !strings.Contains(err.Error(), "--lineage requires a value") {
+			t.Fatalf("empty lineage error = %v", err)
+		}
+	}
+	for _, args := range [][]string{
+		{"validate", "--policy", "--lineage", "--gate", string(reviewtransaction.GatePreCommit)},
+		{"validate", "positional", "--lineage"},
+	} {
+		if err := RunReview(args, &bytes.Buffer{}); err != nil && strings.Contains(err.Error(), "--lineage requires a value") {
+			t.Fatalf("lineage lookalike rejected as explicit flag: %v", err)
+		}
 	}
 }
 

--- a/internal/cli/sdd_status.go
+++ b/internal/cli/sdd_status.go
@@ -18,6 +18,7 @@ func RunSDDStatus(args []string, stdout io.Writer) error {
 	status, err := sddstatus.Resolve(sddstatus.ResolveOptions{
 		CWD:                 parsed.CWD,
 		ChangeName:          parsed.ChangeName,
+		LineageID:           parsed.LineageID,
 		IncludeInstructions: parsed.IncludeInstructions,
 	})
 	if err != nil {
@@ -44,6 +45,7 @@ func RunSDDContinue(args []string, stdout io.Writer) error {
 	status, err := sddstatus.Resolve(sddstatus.ResolveOptions{
 		CWD:                 parsed.CWD,
 		ChangeName:          parsed.ChangeName,
+		LineageID:           parsed.LineageID,
 		IncludeInstructions: true,
 	})
 	if err != nil {

--- a/internal/cli/sdd_status_test.go
+++ b/internal/cli/sdd_status_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"encoding/json"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -124,6 +125,35 @@ func TestRunSDDStatusRejectsCWDWithoutNonFlagValue(t *testing.T) {
 				t.Fatalf("RunSDDStatus(%v) expected error", tt.args)
 			}
 		})
+	}
+}
+
+func TestSDDCommandsParseAndForwardExplicitLineage(t *testing.T) {
+	parsed, err := sddstatus.ParseCommandArgs([]string{"thin", "--lineage", "compact-thin"})
+	if err != nil || parsed.LineageID != "compact-thin" {
+		t.Fatalf("ParseCommandArgs() = %#v, %v", parsed, err)
+	}
+	for _, run := range []struct {
+		name string
+		fn   func([]string, io.Writer) error
+	}{{name: "status", fn: RunSDDStatus}, {name: "continue", fn: RunSDDContinue}} {
+		t.Run(run.name, func(t *testing.T) {
+			root := t.TempDir()
+			seedSDDStatusReadyChange(t, root, "thin", "- [x] 1.1 Done\n")
+			var output bytes.Buffer
+			err := run.fn([]string{"thin", "--cwd", root, "--lineage", "missing"}, &output)
+			if err != nil || !strings.Contains(output.String(), "explicit lineage") {
+				t.Fatalf("command error = %v, output = %s", err, output.String())
+			}
+		})
+	}
+}
+
+func TestSDDCommandsRejectMissingLineageValue(t *testing.T) {
+	for _, args := range [][]string{{"--lineage"}, {"--lineage", "--json"}} {
+		if _, err := sddstatus.ParseCommandArgs(args); err == nil || !strings.Contains(err.Error(), "--lineage requires a value") {
+			t.Fatalf("ParseCommandArgs(%v) error = %v", args, err)
+		}
 	}
 }
 

--- a/internal/sddstatus/bounded_review_test.go
+++ b/internal/sddstatus/bounded_review_test.go
@@ -1,6 +1,7 @@
 package sddstatus
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -454,6 +455,106 @@ func TestResolveBridgesExactlyOnePathBoundCompactAuthorityToVerifyOnly(t *testin
 	}
 	if _, err := os.Stat(filepath.Join(changeRoot, "reviews", "transaction.json")); !os.IsNotExist(err) {
 		t.Fatalf("bridge synthesized local review mirror: %v", err)
+	}
+}
+
+func TestResolveExplicitCompactLineageRoutesWithoutMutation(t *testing.T) {
+	root := t.TempDir()
+	changeRoot := seedReadyChange(t, root, "thin", "- [x] 1.1 Done\n")
+	writeJSON(t, filepath.Join(changeRoot, "reviews", "transaction.json"), remediationTransaction(t, shaID("e"), false))
+	writeApprovedCompactAuthorityForChange(t, root, changeRoot, "compact-target")
+
+	target, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), root, "compact-target")
+	if err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.ReadFile(target.StatePath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	explicit, err := Resolve(ResolveOptions{CWD: root, ChangeName: "thin", LineageID: "compact-target"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if explicit.Dependencies.Verify != DependencyReady || explicit.NextRecommended != "verify" {
+		t.Fatalf("explicit status = %#v", explicit)
+	}
+	after, err := os.ReadFile(target.StatePath())
+	if err != nil || !bytes.Equal(before, after) {
+		t.Fatalf("explicit routing mutated authority: %v", err)
+	}
+}
+
+func TestResolveExplicitCompactLineageRejectsSelectedAuthority(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		lineage string
+		mutate  func(t *testing.T, root string)
+	}{
+		{name: "unknown", lineage: "missing"},
+		{name: "other change", lineage: "compact-other", mutate: func(t *testing.T, root string) {
+			other := seedReadyChange(t, root, "other", "- [x] 1.1 Done\n")
+			writeApprovedCompactAuthorityForChange(t, root, other, "compact-other")
+		}},
+		{name: "receipt mismatch", lineage: "compact-thin", mutate: func(t *testing.T, root string) {
+			store, _ := reviewtransaction.CompactAuthoritativeStore(context.Background(), root, "compact-thin")
+			write(t, store.ReceiptPath(), "{}\n")
+		}},
+		{name: "missing receipt", lineage: "compact-thin", mutate: func(t *testing.T, root string) {
+			store, _ := reviewtransaction.CompactAuthoritativeStore(context.Background(), root, "compact-thin")
+			_ = os.Remove(store.ReceiptPath())
+		}},
+		{name: "gate invalid", lineage: "compact-thin", mutate: func(t *testing.T, root string) {
+			write(t, filepath.Join(root, "openspec", "changes", "thin", "tasks.md"), "- [x] 1.1 Done\n# changed\n")
+		}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			changeRoot := seedReadyChange(t, root, "thin", "- [x] 1.1 Done\n")
+			if tt.lineage == "compact-thin" {
+				writeApprovedCompactAuthorityForChange(t, root, changeRoot, tt.lineage)
+			}
+			if tt.mutate != nil {
+				tt.mutate(t, root)
+			}
+			status, err := Resolve(ResolveOptions{CWD: root, ChangeName: "thin", LineageID: tt.lineage})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if status.Dependencies.Verify != DependencyBlocked || status.NextRecommended != "resolve-review" || !strings.Contains(strings.Join(status.BlockedReasons, "\n"), "explicit lineage") {
+				t.Fatalf("rejection status = %#v", status)
+			}
+		})
+	}
+}
+
+func TestResolveArchiveUsesExplicitCompactLineage(t *testing.T) {
+	root := t.TempDir()
+	changeRoot := seedBoundedReadyChange(t, root)
+	writeApprovedCompactAuthorityForChange(t, root, changeRoot, "compact-target")
+
+	status, err := Resolve(ResolveOptions{CWD: root, ChangeName: "thin", LineageID: "compact-target"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.ReviewGate == nil || status.ReviewGate.Result != reviewtransaction.GateAllow || status.Dependencies.Archive != DependencyReady || status.NextRecommended != "archive" {
+		t.Fatalf("explicit archive status = %#v", status)
+	}
+}
+
+func TestResolveEngramChangeRejectsExplicitNativeLineage(t *testing.T) {
+	root := t.TempDir()
+	mkdir(t, filepath.Join(root, ".engram"))
+	project := strings.ToLower(filepath.Base(root))
+	restore := stubEngramExport(t, []engramObservation{{Title: "sdd/thin/proposal", Content: "proposal", Project: project, Scope: "project"}})
+	defer restore()
+
+	status, err := Resolve(ResolveOptions{CWD: root, ChangeName: "thin", LineageID: "native-lineage"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.NextRecommended != "resolve-review" || !strings.Contains(strings.Join(status.BlockedReasons, "\n"), "repository-local OpenSpec change") {
+		t.Fatalf("Engram explicit-lineage status = %#v", status)
 	}
 }
 
@@ -1050,7 +1151,7 @@ func TestApplyReviewGateDiscoversCompactStateAndReceiptWithoutMirrors(t *testing
 		t.Fatal(err)
 	}
 	status := Status{Dependencies: Dependencies{Verify: DependencyAllDone, Archive: DependencyReady}, TaskProgress: TaskProgress{AllComplete: true}}
-	applyReviewGate(&status, repo, "", "")
+	applyReviewGate(&status, repo, "thin", "", "", "")
 	if status.ReviewGate == nil || status.ReviewGate.Result != reviewtransaction.GateAllow || status.Dependencies.Archive != DependencyReady {
 		t.Fatalf("compact SDD gate = %#v", status)
 	}

--- a/internal/sddstatus/review_gate.go
+++ b/internal/sddstatus/review_gate.go
@@ -14,10 +14,27 @@ import (
 )
 
 type compactPreVerifyBridge struct {
-	Eligible bool
-	Relevant bool
-	Reason   string
-	Revision string
+	Eligible   bool
+	Relevant   bool
+	Reason     string
+	Revision   string
+	Evaluation reviewtransaction.NativeGateEvaluation
+}
+
+func selectCompactPreVerifyAuthority(ctx context.Context, repo, changeName, lineage string) compactPreVerifyBridge {
+	store, err := reviewtransaction.CompactAuthoritativeStore(ctx, repo, lineage)
+	if err != nil {
+		return compactPreVerifyBridge{Relevant: true, Reason: "explicit lineage store is unavailable"}
+	}
+	bridge := evaluateCompactPreVerifyAuthority(ctx, repo, changeName, store)
+	if !bridge.Eligible {
+		if bridge.Reason == "" {
+			bridge.Reason = "authority is not bound to the selected change"
+		}
+		bridge.Relevant = true
+		bridge.Reason = "explicit lineage rejected: " + bridge.Reason
+	}
+	return bridge
 }
 
 func discoverCompactPreVerifyAuthority(ctx context.Context, repo, changeName, observedRevision string) compactPreVerifyBridge {
@@ -28,46 +45,21 @@ func discoverCompactPreVerifyAuthority(ctx context.Context, repo, changeName, ob
 	eligible := 0
 	candidateRevision := ""
 	for _, store := range stores {
-		record, err := store.Load()
-		if err != nil {
-			return compactPreVerifyBridge{Relevant: true, Reason: "compact authority record is malformed"}
-		}
-		bound, pathReason := compactAuthorityPathsBound(record.State, changeName)
-		if !bound {
-			if pathReason != "" {
-				return compactPreVerifyBridge{Relevant: true, Reason: pathReason}
-			}
-			continue
-		}
-		if record.State.State != reviewtransaction.StateApproved {
-			return compactPreVerifyBridge{Relevant: true, Reason: "path-bound compact authority is not approved"}
-		}
-		payload, err := os.ReadFile(store.ReceiptPath())
-		if err != nil {
-			return compactPreVerifyBridge{Relevant: true, Reason: "path-bound compact authority receipt is missing"}
-		}
-		receipt, err := reviewtransaction.ParseCompactReceipt(payload)
-		authoritative, receiptErr := record.State.Receipt()
-		if err != nil || receiptErr != nil || !reflect.DeepEqual(receipt, authoritative) {
-			return compactPreVerifyBridge{Relevant: true, Reason: "path-bound compact authority receipt does not equal approved state"}
-		}
-		evaluation := reviewtransaction.EvaluateCompactGate(ctx, repo, receipt, reviewtransaction.NativeGateRequestInput{Gate: reviewtransaction.GatePostApply, LineageID: receipt.LineageID})
-		finalRecord, finalErr := store.Load()
-		finalPayload, finalReadErr := os.ReadFile(store.ReceiptPath())
-		if finalErr != nil || finalReadErr != nil || finalRecord.Revision != record.Revision || !reflect.DeepEqual(finalPayload, payload) {
-			return compactPreVerifyBridge{Relevant: true, Reason: "compact authority changed during discovery"}
-		}
-		if evaluation.Result != reviewtransaction.GateAllow {
-			if skipsObservedStalePredecessor(observedRevision, record.Revision, evaluation.Result) {
+		bridge := evaluateCompactPreVerifyAuthority(ctx, repo, changeName, store)
+		if !bridge.Eligible {
+			if !bridge.Relevant {
 				continue
 			}
-			return compactPreVerifyBridge{Relevant: true, Reason: "path-bound compact authority post-apply gate is not allow"}
+			if skipsObservedStalePredecessor(observedRevision, bridge.Revision, bridge.Evaluation.Result) {
+				continue
+			}
+			return bridge
 		}
 		eligible++
 		if eligible == 1 {
 			// The revision is immutable store evidence used only for retry routing.
 			// It never authorizes a receipt by itself.
-			candidateRevision = record.Revision
+			candidateRevision = bridge.Revision
 		}
 	}
 	switch eligible {
@@ -78,6 +70,42 @@ func discoverCompactPreVerifyAuthority(ctx context.Context, repo, changeName, ob
 	default:
 		return compactPreVerifyBridge{Relevant: true, Reason: "multiple eligible path-bound compact authorities found"}
 	}
+}
+
+func evaluateCompactPreVerifyAuthority(ctx context.Context, repo, changeName string, store reviewtransaction.CompactStore) compactPreVerifyBridge {
+	record, err := store.Load()
+	if err != nil {
+		return compactPreVerifyBridge{Relevant: true, Reason: "compact authority record cannot be loaded"}
+	}
+	bound, pathReason := compactAuthorityPathsBound(record.State, changeName)
+	if !bound {
+		return compactPreVerifyBridge{Relevant: pathReason != "", Reason: pathReason, Revision: record.Revision}
+	}
+	if record.State.State != reviewtransaction.StateApproved {
+		return compactPreVerifyBridge{Relevant: true, Reason: "path-bound compact authority is not approved", Revision: record.Revision}
+	}
+	payload, err := os.ReadFile(store.ReceiptPath())
+	if err != nil {
+		return compactPreVerifyBridge{Relevant: true, Reason: "path-bound compact authority receipt is missing", Revision: record.Revision}
+	}
+	receipt, err := reviewtransaction.ParseCompactReceipt(payload)
+	authoritative, receiptErr := record.State.Receipt()
+	if err != nil || receiptErr != nil || !reflect.DeepEqual(receipt, authoritative) {
+		return compactPreVerifyBridge{Relevant: true, Reason: "path-bound compact authority receipt does not equal approved state", Revision: record.Revision}
+	}
+	evaluation := reviewtransaction.EvaluateCompactGate(ctx, repo, receipt, reviewtransaction.NativeGateRequestInput{Gate: reviewtransaction.GatePostApply, LineageID: receipt.LineageID})
+	if evaluation.Result != reviewtransaction.GateAllow {
+		return compactPreVerifyBridge{Relevant: true, Reason: "path-bound compact authority post-apply gate is not allow", Revision: record.Revision, Evaluation: evaluation}
+	}
+	finalRecord, finalErr := store.Load()
+	finalPayload, finalReadErr := os.ReadFile(store.ReceiptPath())
+	finalReceipt, finalParseErr := reviewtransaction.ParseCompactReceipt(finalPayload)
+	finalAuthority, finalAuthorityErr := finalRecord.State.Receipt()
+	finalGate := reviewtransaction.EvaluateCompactGate(ctx, repo, finalReceipt, reviewtransaction.NativeGateRequestInput{Gate: reviewtransaction.GatePostApply, LineageID: receipt.LineageID})
+	if finalErr != nil || finalReadErr != nil || finalParseErr != nil || finalAuthorityErr != nil || finalRecord.Revision != record.Revision || !reflect.DeepEqual(finalRecord.State, record.State) || !reflect.DeepEqual(finalPayload, payload) || !reflect.DeepEqual(finalReceipt, finalAuthority) || finalGate.Result != reviewtransaction.GateAllow || !reflect.DeepEqual(finalGate.Context, evaluation.Context) {
+		return compactPreVerifyBridge{Relevant: true, Reason: "compact authority or receipt changed during final authorization", Revision: record.Revision, Evaluation: evaluation}
+	}
+	return compactPreVerifyBridge{Eligible: true, Revision: record.Revision, Evaluation: finalGate}
 }
 
 func skipsObservedStalePredecessor(observedRevision, revision string, result reviewtransaction.GateResult) bool {
@@ -227,10 +255,19 @@ func resolveBoundedRemediation(required bool, verify verifyResultEvaluation, tra
 
 func applyReviewGate(
 	status *Status,
-	repo string,
+	repo, changeName, lineage string,
 	receiptPath, receiptContent string,
 ) {
 	if status.Dependencies.Verify != DependencyAllDone || !status.TaskProgress.AllComplete {
+		return
+	}
+	if lineage != "" {
+		bridge := selectCompactPreVerifyAuthority(context.Background(), repo, changeName, lineage)
+		if !bridge.Eligible {
+			blockReviewGate(status, reviewtransaction.GateInvalidated, bridge.Reason)
+			return
+		}
+		status.ReviewGate = &ReviewGateState{Result: reviewtransaction.GateAllow, Reason: "explicit lineage authority exactly matches the selected change and current repository"}
 		return
 	}
 	receiptPayload, ok := readReviewArtifact(receiptPath, receiptContent)

--- a/internal/sddstatus/status.go
+++ b/internal/sddstatus/status.go
@@ -168,12 +168,14 @@ type ResolveOptions struct {
 	CWD                 string
 	WorkspaceRoot       string
 	ChangeName          string
+	LineageID           string
 	IncludeInstructions bool
 }
 
 type CommandArgs struct {
 	ChangeName          string
 	CWD                 string
+	LineageID           string
 	JSON                bool
 	IncludeInstructions bool
 }
@@ -201,6 +203,15 @@ func ParseCommandArgs(args []string) (CommandArgs, error) {
 				return CommandArgs{}, fmt.Errorf("--cwd requires a value")
 			}
 			parsed.CWD = args[i+1]
+			i++
+		case "--lineage":
+			if i+1 >= len(args) || strings.HasPrefix(args[i+1], "-") {
+				return CommandArgs{}, fmt.Errorf("--lineage requires a value")
+			}
+			parsed.LineageID = strings.TrimSpace(args[i+1])
+			if parsed.LineageID == "" {
+				return CommandArgs{}, fmt.Errorf("--lineage requires a value")
+			}
 			i++
 		default:
 			if strings.HasPrefix(arg, "-") {
@@ -255,6 +266,9 @@ func Resolve(options ResolveOptions) (Status, error) {
 	if changeName == "" {
 		switch len(activeChanges) {
 		case 0:
+			if options.LineageID != "" && shouldTryEngram(workspaceRoot) {
+				return blockedStatus(workspaceRoot, nil, nil, "resolve-review", []string{"Explicit lineage selection requires a repository-local OpenSpec change."}, options.IncludeInstructions), nil
+			}
 			if status, ok, err := resolveEngramStatus(workspaceRoot, changeName, options.IncludeInstructions); ok || err != nil {
 				return status, err
 			}
@@ -267,6 +281,9 @@ func Resolve(options ResolveOptions) (Status, error) {
 	}
 
 	if !contains(activeChanges, changeName) {
+		if options.LineageID != "" && shouldTryEngram(workspaceRoot) {
+			return blockedStatus(workspaceRoot, &changeName, nil, "resolve-review", []string{"Explicit lineage selection requires a repository-local OpenSpec change."}, options.IncludeInstructions), nil
+		}
 		if status, ok, err := resolveEngramStatus(workspaceRoot, changeName, options.IncludeInstructions); ok || err != nil {
 			return status, err
 		}
@@ -324,7 +341,8 @@ func Resolve(options ResolveOptions) (Status, error) {
 	}
 	bridge := compactPreVerifyBridge{}
 	recoverable := authorityOnlyFailedReport(readText(firstPath(artifactPaths.VerifyReport)))
-	if bindingPresent {
+	useBinding := bindingPresent && options.LineageID == ""
+	if useBinding {
 		_, evaluation, bindingErr := validateBoundReview(context.Background(), workspaceRoot, changeName)
 		if bindingErr == nil {
 			if applyState == ApplyAllDone && artifacts["verifyReport"] != ArtifactDone {
@@ -339,11 +357,13 @@ func Resolve(options ResolveOptions) (Status, error) {
 			nextRecommended = "resolve-review"
 			blockedReasons = append(blockedReasons, bindingErr.Error())
 		}
+	} else if options.LineageID != "" && applyState == ApplyAllDone && (artifacts["verifyReport"] != ArtifactDone || recoverable) {
+		bridge = selectCompactPreVerifyAuthority(context.Background(), workspaceRoot, changeName, options.LineageID)
 	} else if applyState == ApplyAllDone && (artifacts["verifyReport"] != ArtifactDone || recoverable) && reviewState == nil {
 		fields, _ := authorityFailureFields(readText(firstPath(artifactPaths.VerifyReport)))
 		bridge = discoverCompactPreVerifyAuthority(context.Background(), workspaceRoot, changeName, fields["observed_authority_revision"])
 	}
-	if !bindingPresent && recoverable && bridge.Eligible && authorityChangedSinceReport(readText(firstPath(artifactPaths.VerifyReport)), bridge.Revision) {
+	if !useBinding && recoverable && bridge.Eligible && authorityChangedSinceReport(readText(firstPath(artifactPaths.VerifyReport)), bridge.Revision) {
 		dependencies.Verify = DependencyReady
 		dependencies.Archive = DependencyBlocked
 		nextRecommended = "verify"
@@ -352,10 +372,10 @@ func Resolve(options ResolveOptions) (Status, error) {
 	if remediationState.Reason != "" {
 		blockedReasons = append(blockedReasons, remediationState.Reason)
 	}
-	if !bindingPresent {
-		applyPreVerifyCompactBridgeRouting(&dependencies, &nextRecommended, &blockedReasons, applyState, artifacts["verifyReport"] == ArtifactDone, reviewState, bridge)
+	if !useBinding {
+		applyPreVerifyCompactBridgeRouting(&dependencies, &nextRecommended, &blockedReasons, applyState, artifacts["verifyReport"] == ArtifactDone, reviewState, bridge, options.LineageID != "")
 	}
-	if !bindingPresent && !bridge.Eligible && !bridge.Relevant {
+	if !useBinding && !bridge.Eligible && !bridge.Relevant {
 		applyPreVerifyReviewRouting(&dependencies, &nextRecommended, &blockedReasons, applyState, artifacts["verifyReport"] == ArtifactDone, reviewState, reviewStateReason)
 	}
 
@@ -368,10 +388,12 @@ func Resolve(options ResolveOptions) (Status, error) {
 	status.ApplyState = applyState
 	status.RemediationState = remediationState
 	status.ReviewTransaction = reviewState
-	if !bindingPresent {
+	if !useBinding {
 		applyReviewGate(
 			&status,
 			workspaceRoot,
+			changeName,
+			options.LineageID,
 			firstPath(artifactPaths.ReviewReceipt),
 			"",
 		)
@@ -516,6 +538,8 @@ func resolveEngramStatus(workspaceRoot string, requestedChange string, includeIn
 	applyReviewGate(
 		&status,
 		workspaceRoot,
+		changeName,
+		"",
 		"",
 		artifactsByType["review/receipt"].Content,
 	)
@@ -558,8 +582,8 @@ func applyPreVerifyReviewRouting(dependencies *Dependencies, next *string, block
 	}
 }
 
-func applyPreVerifyCompactBridgeRouting(dependencies *Dependencies, next *string, blockedReasons *[]string, applyState ApplyState, verifyReportDone bool, transaction *reviewtransaction.Transaction, bridge compactPreVerifyBridge) {
-	if applyState != ApplyAllDone || verifyReportDone || transaction != nil {
+func applyPreVerifyCompactBridgeRouting(dependencies *Dependencies, next *string, blockedReasons *[]string, applyState ApplyState, verifyReportDone bool, transaction *reviewtransaction.Transaction, bridge compactPreVerifyBridge, explicit bool) {
+	if applyState != ApplyAllDone || verifyReportDone || (!explicit && transaction != nil) {
 		return
 	}
 	if bridge.Eligible {

--- a/internal/sddstatus/status_test.go
+++ b/internal/sddstatus/status_test.go
@@ -782,11 +782,11 @@ func TestRenderNativePhasePromptIncludesAuthorityInstructionsJSONAndBlockedGuida
 }
 
 func TestParseCommandArgs(t *testing.T) {
-	got, err := ParseCommandArgs([]string{"add-auth", "--json", "--instructions", "--cwd", "/tmp/repo"})
+	got, err := ParseCommandArgs([]string{"add-auth", "--json", "--instructions", "--cwd", "/tmp/repo", "--lineage", " compact-auth "})
 	if err != nil {
 		t.Fatalf("ParseCommandArgs() error = %v", err)
 	}
-	want := CommandArgs{ChangeName: "add-auth", CWD: "/tmp/repo", JSON: true, IncludeInstructions: true}
+	want := CommandArgs{ChangeName: "add-auth", CWD: "/tmp/repo", LineageID: "compact-auth", JSON: true, IncludeInstructions: true}
 	if got != want {
 		t.Fatalf("ParseCommandArgs() = %#v, want %#v", got, want)
 	}
@@ -800,6 +800,8 @@ func TestParseCommandArgsRejectsInvalidInput(t *testing.T) {
 		{name: "missing cwd value", args: []string{"--cwd"}},
 		{name: "cwd followed by json flag", args: []string{"--cwd", "--json"}},
 		{name: "cwd followed by instructions flag", args: []string{"--cwd", "--instructions"}},
+		{name: "empty lineage", args: []string{"--lineage", ""}},
+		{name: "whitespace lineage", args: []string{"--lineage", "   "}},
 		{name: "unknown flag", args: []string{"--bogus"}},
 		{name: "extra positional", args: []string{"first", "second"}},
 	}


### PR DESCRIPTION
## Linked Issue

Closes #1209

Related: #1200, #1346

---

## PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change

---

## Summary

- Add optional `--lineage <id>` routing to `sdd-status` and `sdd-continue`.
- Resolve an exact repository-local approved compact authority without falling back to ambiguous global discovery.
- Keep the selected lineage through pre-verify, archive, and lifecycle gate evaluation while preserving unqualified behavior.
- Reject blank selectors, prioritize explicit lineage over stale mirrored state, and fail closed without compact-to-legacy fallback.

---

## Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/app` | Documented the selector and covered help output. |
| `internal/cli` | Forwarded lineage IDs through SDD commands and bound `review validate` to the exact selected receipt without legacy fallback. |
| `internal/sddstatus` | Added fail-closed exact-lineage selection, shared gate evaluation, archive continuity, and regression coverage. |

---

## Test Plan

- [x] Focused parser, help, CLI forwarding, routing, rejection, immutability, and archive tests pass with Go 1.25.10.
- [x] `go test -p=1 ./internal/app -count=1`
- [x] `go test -p=1 ./internal/sddstatus -count=1`
- [x] `go test -p=1 ./internal/cli -count=1`
- [x] `go vet -p=1 ./...`
- [x] Exact reviewed E2E and SharePoint candidates route to `verify` with explicit lineages in isolated acceptance workspaces.
- [x] Exact SharePoint lineage validates pre-commit, pre-push, and pre-PR against the same content-bound receipt.
- [x] CodeRabbit correctness findings for blank lineage, stale mirrored state, native flag detection, and receipt short-circuiting are covered by regressions.
- [ ] Full Docker E2E suite was not run locally.

---

## Review Evidence

- Native review lineage: `review-c8419a9d1504642a`
- Result: approved
- Pre-PR gate: allow against `origin/main` at `25ccc45c74b8fd7f3619e030058f21636c963751`
- Authored change size: 385 lines

---

## Contributor Checklist

- [x] PR is linked to an issue with `status:approved`.
- [x] PR stays within 400 changed lines.
- [x] Exactly one `type:*` label is requested.
- [x] Focused unit tests and static analysis pass.
- [ ] Full Docker E2E tests were not run locally.
- [x] User-facing help is updated.
- [x] Commit follows Conventional Commits.
- [x] Commit has no `Co-Authored-By` trailer.

## Notes for Reviewers

Please focus on fail-closed exact-lineage selection and the guarantee that omitting `--lineage` preserves existing conservative discovery behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional `--lineage <id>` support to `sdd-status` and `sdd-continue`, enabling lineage-aware status/continuation resolution.
- **Bug Fixes**
  - Improved `--lineage` parsing/validation with clear errors when the value is missing or empty.
  - Strengthened `review validate` with explicit-lineage receipt/content consistency checks.
  - Explicit lineage selection now enforces a repository-local OpenSpec change requirement and returns blocked results when incompatible.
- **Documentation**
  - Updated `sdd-status`/`sdd-continue` help text to document `--lineage <id>`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->