### PR TITLE
feat(review): persist native reviewer result artifacts

### DIFF
--- a/contracts/review-integration/v1/fixtures/capabilities.fixture.json
+++ b/contracts/review-integration/v1/fixtures/capabilities.fixture.json
@@ -54,6 +54,7 @@
     "gentle-ai.review-integration.status/v1",
     "gentle-ai.review-receipt/v1",
     "gentle-ai.review-receipt/v2",
+    "gentle-ai.review-result-artifact/v1",
     "https://gentle-ai.dev/schema/review/refuter/v1",
     "https://gentle-ai.dev/schema/review/reviewer/v1",
     "https://gentle-ai.dev/schema/review/validator/v1"

--- a/contracts/review-integration/v1/schemas/capabilities.schema.json
+++ b/contracts/review-integration/v1/schemas/capabilities.schema.json
@@ -100,8 +100,8 @@
     },
     "schemas": {
       "type": "array",
-      "minItems": 13,
-      "maxItems": 13,
+      "minItems": 14,
+      "maxItems": 14,
       "uniqueItems": true,
       "items": {
         "enum": [
@@ -115,6 +115,7 @@
           "gentle-ai.review-integration.status/v1",
           "gentle-ai.review-receipt/v1",
           "gentle-ai.review-receipt/v2",
+          "gentle-ai.review-result-artifact/v1",
           "https://gentle-ai.dev/schema/review/refuter/v1",
           "https://gentle-ai.dev/schema/review/reviewer/v1",
           "https://gentle-ai.dev/schema/review/validator/v1"
@@ -134,8 +135,8 @@
         },
         "optional": {
           "type": "array",
-          "minItems": 1,
-          "maxItems": 1,
+          "minItems": 5,
+          "maxItems": 5,
           "items": {"$ref": "#/$defs/feature"}
         }
       }
@@ -191,15 +192,19 @@
       "properties": {
         "name": {
           "enum": [
+            "bounded_process_waits",
             "compact_v2_authority",
             "exact_receipt_replay",
+            "exact_gate_receipt_discovery",
             "five_delivery_gates",
             "immutable_snapshot",
             "legacy_v1_target_scoped_read_only",
+            "native_low_risk_verification",
             "repository_independent_capabilities",
             "restart_safe_projection",
             "risk_reasons",
             "sdd_receipt_binding",
+            "scope_change_diagnostics",
             "target_scoped_status",
             "uniform_failure_envelope"
           ]

--- a/contracts/review-integration/v1/schemas/result-artifact.schema.json
+++ b/contracts/review-integration/v1/schemas/result-artifact.schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema", "$id": "https://gentle-ai.dev/contracts/review-integration/v1/schemas/result-artifact.schema.json",
+  "title": "Gentle AI native reviewer result artifact", "type": "object", "additionalProperties": false,
+  "required": ["schema", "capability", "path", "sha256", "lineage_id", "target_identity", "lens", "selected_order"],
+  "properties": {
+    "schema": {"const": "gentle-ai.review-result-artifact/v1"}, "capability": {"const": "review.native_result_artifact"},
+    "path": {"type": "string", "minLength": 1}, "sha256": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+    "lineage_id": {"type": "string", "minLength": 1},
+    "target_identity": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+    "lens": {"type": "string", "minLength": 1}, "selected_order": {"type": "integer", "minimum": 0}
+  }
+}

--- a/docs/review-integration.md
+++ b/docs/review-integration.md
@@ -55,7 +55,11 @@ Consumers MUST NOT reconstruct receipts, derive canonical hashes, inspect the Gi
 
 `review.start` is the only ordinary entry point that creates a review budget. Finalize continues that frozen lifecycle. Status, validation, and gates are read-only and never allocate a reviewer, actor, lineage, or correction budget.
 
+`gentle-ai review capture-result` is an additive headless command, not a negotiated `review-integration/v1` repository operation. It accepts no `--contract` and emits a manifest with capability `review.native_result_artifact` and schema `gentle-ai.review-result-artifact/v1`; that native artifact schema remains advertised for consumer validation.
+
 Reviewer results may omit the top-level `lens`; when present, it must match the selected-lens position returned by start. Both the short names (`risk`, `resilience`, `readability`, `reliability`) and the negotiated facade names (`review-risk`, `review-resilience`, `review-readability`, `review-reliability`) map to the same native lenses. A mismatch is rejected before authority mutation instead of being overwritten.
+
+Durable controllers capture each result with exact lineage, target, lens, and selected order, then pass the emitted manifests to FINALIZE as ordered `--result-artifact` values. Legacy `--result` files remain compatible but cannot be mixed with artifact manifests and are not a durable cross-agent handoff.
 
 Proof and evidence strings accept ordinary technical notation, including `HEAD^{tree}`, `{}`, `<A>`, and `=>`. Blank values and exact non-evidence sentinels such as `n/a`, `none`, `todo`, `tbd`, `pass`, `passed`, `success`, and `placeholder` remain invalid.
 
@@ -167,7 +171,7 @@ Pi adoption, fallback retirement, package pinning, and Pi release sequencing are
 
 Each release archive contains:
 
-- `contracts/review-integration/v1/schemas/` — six strict JSON Schemas.
+- `contracts/review-integration/v1/schemas/` — the original six strict JSON Schemas plus the result-artifact schema.
 - `contracts/review-integration/v1/fixtures/` — eight deterministic conformance fixtures, including all four target-applicability states.
 - `docs/review-integration.md` — this ownership and consumption guide.
 

--- a/internal/cli/review_artifact.go
+++ b/internal/cli/review_artifact.go
@@ -194,6 +194,10 @@ func readVerifiedReviewerArtifact(artifact reviewResultArtifact, storeDir string
 	if !pathInfo.Mode().IsRegular() || pathInfo.Mode()&os.ModeSymlink != 0 || !reviewArtifactModeSafe(pathInfo.Mode(), false) {
 		return nil, errors.New("artifact is not an owner-only regular file")
 	}
+	// Windows resolves file IDs lazily from the path; snapshot it before the path can be replaced.
+	if !os.SameFile(pathInfo, pathInfo) {
+		return nil, errors.New("artifact identity is unavailable")
+	}
 	reviewArtifactAfterLstat()
 	file, err := os.Open(artifact.Path)
 	if err != nil {

--- a/internal/cli/review_artifact.go
+++ b/internal/cli/review_artifact.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"syscall"
 
 	"github.com/gentleman-programming/gentle-ai/internal/reviewtransaction"
 )
@@ -33,6 +34,18 @@ type reviewResultArtifact struct {
 }
 
 var reviewArtifactAfterLstat = func() {}
+var reviewArtifactRuntimeGOOS = func() string { return runtime.GOOS }
+var syncReviewerArtifactDirectory = func(path string) error {
+	directory, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	if err := directory.Sync(); err != nil {
+		_ = directory.Close()
+		return err
+	}
+	return directory.Close()
+}
 
 func RunReviewCaptureResult(args []string, stdout io.Writer) error {
 	flags := newReviewFlagSet("review capture-result", stdout, "Capture one strict reviewer result in native authority and emit its bound manifest.")
@@ -133,6 +146,14 @@ func captureReviewerArtifact(storeDir string, state reviewtransaction.CompactSta
 			return artifact, nil
 		}
 		return reviewResultArtifact{}, fmt.Errorf("publish reviewer result atomically: %w", err)
+	}
+	if err := syncReviewerArtifactDirectory(dir); err != nil {
+		unsupported := errors.Is(err, syscall.EINVAL) || errors.Is(err, errors.ErrUnsupported) ||
+			reviewArtifactRuntimeGOOS() == "windows" && errors.Is(err, os.ErrPermission)
+		if !unsupported {
+			removeOwnedArtifact(path, owned)
+			return reviewResultArtifact{}, fmt.Errorf("sync reviewer result directory: %w", err)
+		}
 	}
 	if _, err := readVerifiedReviewerArtifact(artifact, storeDir, state); err != nil {
 		removeOwnedArtifact(path, owned)

--- a/internal/cli/review_artifact.go
+++ b/internal/cli/review_artifact.go
@@ -1,0 +1,245 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/gentleman-programming/gentle-ai/internal/reviewtransaction"
+)
+
+const (
+	reviewResultArtifactSchema     = "gentle-ai.review-result-artifact/v1"
+	reviewResultArtifactCapability = "review.native_result_artifact"
+	reviewResultArtifactLimit      = 4 << 20
+)
+
+type reviewResultArtifact struct {
+	Schema         string `json:"schema"`
+	Capability     string `json:"capability"`
+	Path           string `json:"path"`
+	SHA256         string `json:"sha256"`
+	LineageID      string `json:"lineage_id"`
+	TargetIdentity string `json:"target_identity"`
+	Lens           string `json:"lens"`
+	SelectedOrder  int    `json:"selected_order"`
+}
+
+var reviewArtifactAfterLstat = func() {}
+
+func RunReviewCaptureResult(args []string, stdout io.Writer) error {
+	flags := newReviewFlagSet("review capture-result", stdout, "Capture one strict reviewer result in native authority and emit its bound manifest.")
+	cwd := flags.String("cwd", ".", "repository path")
+	lineage := flags.String("lineage", "", "exact review lineage identifier")
+	target := flags.String("target", "", "exact frozen target identity")
+	lens := flags.String("lens", "", "exact selected lens")
+	order := flags.Int("order", -1, "zero-based selected lens order")
+	input := flags.String("input", "", "raw reviewer result JSON file or - for stdin")
+	if err := parseReviewFlags(flags, args); err != nil {
+		return err
+	}
+	if reviewHelpRequested(args) {
+		return nil
+	}
+	if flags.NArg() != 0 || strings.TrimSpace(*lineage) == "" || strings.TrimSpace(*target) == "" ||
+		strings.TrimSpace(*lens) == "" || *order < 0 || strings.TrimSpace(*input) == "" {
+		return reviewPreflightError(errors.New("review capture-result requires exact --cwd, --lineage, --target, --lens, --order, and --input"))
+	}
+	ctx := context.Background()
+	root, err := (reviewtransaction.SnapshotBuilder{Repo: *cwd}).ResolveRepositoryRoot(ctx)
+	if err != nil {
+		return fmt.Errorf("resolve review repository root: %w", err)
+	}
+	store, record, err := discoverCompactFacadeReview(ctx, root, *lineage, false)
+	if err != nil {
+		return err
+	}
+	state := record.State
+	if state.State != reviewtransaction.StateReviewing || state.LineageID != *lineage || state.InitialSnapshot.Identity != *target ||
+		*order >= len(state.SelectedLenses) || state.SelectedLenses[*order] != *lens {
+		return reviewPreflightError(errors.New("capture binding does not match the current reviewing authority"))
+	}
+	payload, err := readFacadeBytes(*input)
+	if err != nil {
+		return reviewPreflightError(fmt.Errorf("read reviewer result: %w", err))
+	}
+	var result facadeReviewerResult
+	if err := decodeFacadeJSONBytes(payload, &result); err != nil {
+		return reviewPreflightError(fmt.Errorf("decode reviewer result: %w", err))
+	}
+	if result.Findings == nil || result.Evidence == nil {
+		return reviewPreflightError(errors.New("reviewer result requires explicit findings and evidence arrays"))
+	}
+	if _, err := prepareCompactReviewerResults(reviewtransaction.CompactState{SelectedLenses: []string{*lens}}, []facadeReviewerResult{result}, facadeRefuterResult{}); err != nil {
+		return reviewPreflightError(err)
+	}
+	canonical, err := json.Marshal(result)
+	if err != nil {
+		return err
+	}
+	canonical = append(canonical, '\n')
+	artifact, err := captureReviewerArtifact(store.Dir, state, *order, canonical)
+	if err != nil {
+		return reviewPreflightError(err)
+	}
+	return encodeReviewJSON(stdout, artifact)
+}
+func captureReviewerArtifact(storeDir string, state reviewtransaction.CompactState, order int, payload []byte) (reviewResultArtifact, error) {
+	dir := filepath.Join(storeDir, "reviewer-results")
+	if err := ensureReviewerArtifactDir(dir); err != nil {
+		return reviewResultArtifact{}, err
+	}
+	path := filepath.Join(dir, fmt.Sprintf("%02d-%s.json", order, state.SelectedLenses[order]))
+	artifact := reviewResultArtifact{
+		Schema: reviewResultArtifactSchema, Capability: reviewResultArtifactCapability, Path: path,
+		SHA256: facadePayloadHash(payload), LineageID: state.LineageID,
+		TargetIdentity: state.InitialSnapshot.Identity, Lens: state.SelectedLenses[order], SelectedOrder: order,
+	}
+	if existing, err := readVerifiedReviewerArtifact(artifact, storeDir, state); err == nil {
+		if !bytes.Equal(existing, payload) {
+			return reviewResultArtifact{}, errors.New("captured reviewer result already exists with different canonical bytes")
+		}
+		return artifact, nil
+	} else if !os.IsNotExist(err) {
+		return reviewResultArtifact{}, err
+	}
+	temp, err := os.CreateTemp(dir, ".capture-*")
+	if err != nil {
+		return reviewResultArtifact{}, fmt.Errorf("create reviewer result temporary file: %w", err)
+	}
+	owned, _ := temp.Stat()
+	defer removeOwnedArtifact(temp.Name(), owned)
+	if err := temp.Chmod(0o600); err != nil {
+		return reviewResultArtifact{}, err
+	}
+	if _, err := temp.Write(payload); err != nil {
+		return reviewResultArtifact{}, err
+	}
+	if err := temp.Sync(); err != nil {
+		return reviewResultArtifact{}, err
+	}
+	if err := temp.Close(); err != nil {
+		return reviewResultArtifact{}, err
+	}
+	if err := os.Link(temp.Name(), path); err != nil {
+		if existing, readErr := readVerifiedReviewerArtifact(artifact, storeDir, state); readErr == nil && bytes.Equal(existing, payload) {
+			return artifact, nil
+		}
+		return reviewResultArtifact{}, fmt.Errorf("publish reviewer result atomically: %w", err)
+	}
+	if _, err := readVerifiedReviewerArtifact(artifact, storeDir, state); err != nil {
+		removeOwnedArtifact(path, owned)
+		return reviewResultArtifact{}, fmt.Errorf("read back reviewer result: %w", err)
+	}
+	return artifact, nil
+}
+func ensureReviewerArtifactDir(path string) error {
+	if err := os.Mkdir(path, 0o700); err != nil && !os.IsExist(err) {
+		return fmt.Errorf("create reviewer result directory: %w", err)
+	}
+	info, err := os.Lstat(path)
+	if err != nil || !info.IsDir() || info.Mode()&os.ModeSymlink != 0 || !reviewArtifactModeSafe(info.Mode(), true) {
+		return errors.New("reviewer result directory is not a private native directory")
+	}
+	return nil
+}
+func readFacadeReviewerArtifacts(raw []string, storeDir string, state reviewtransaction.CompactState) ([]facadeReviewerResult, error) {
+	if len(raw) != len(state.SelectedLenses) {
+		return nil, fmt.Errorf("review finalize requires all %d original reviewer artifact(s)", len(state.SelectedLenses))
+	}
+	results := make([]facadeReviewerResult, len(raw))
+	for index := range raw {
+		var artifact reviewResultArtifact
+		if err := decodeFacadeJSONBytes([]byte(raw[index]), &artifact); err != nil {
+			return nil, fmt.Errorf("decode reviewer artifact %d: %w", index+1, err)
+		}
+		if artifact.SelectedOrder != index {
+			return nil, fmt.Errorf("reviewer artifact %d is out of selected-lens order", index+1)
+		}
+		payload, err := readVerifiedReviewerArtifact(artifact, storeDir, state)
+		if err != nil {
+			return nil, fmt.Errorf("verify reviewer artifact %d: %w", index+1, err)
+		}
+		if err := decodeFacadeJSONBytes(payload, &results[index]); err != nil {
+			return nil, fmt.Errorf("parse reviewer artifact %d: %w", index+1, err)
+		}
+		if results[index].Findings == nil || results[index].Evidence == nil {
+			return nil, fmt.Errorf("reviewer artifact %d requires explicit findings and evidence arrays", index+1)
+		}
+	}
+	return results, nil
+}
+func readVerifiedReviewerArtifact(artifact reviewResultArtifact, storeDir string, state reviewtransaction.CompactState) ([]byte, error) {
+	if artifact.Schema != reviewResultArtifactSchema || artifact.Capability != reviewResultArtifactCapability ||
+		artifact.LineageID != state.LineageID || artifact.TargetIdentity != state.InitialSnapshot.Identity ||
+		artifact.SelectedOrder < 0 || artifact.SelectedOrder >= len(state.SelectedLenses) ||
+		artifact.Lens != state.SelectedLenses[artifact.SelectedOrder] || !validReviewCapabilitySHA256(artifact.SHA256) {
+		return nil, errors.New("artifact manifest does not match frozen lineage, target, lens, and order")
+	}
+	wantPath := filepath.Join(storeDir, "reviewer-results", fmt.Sprintf("%02d-%s.json", artifact.SelectedOrder, artifact.Lens))
+	if !filepath.IsAbs(artifact.Path) || filepath.Clean(artifact.Path) != artifact.Path || artifact.Path != wantPath {
+		return nil, errors.New("artifact path is outside native transaction ownership")
+	}
+	pathInfo, err := os.Lstat(artifact.Path)
+	if err != nil {
+		return nil, err
+	}
+	if !pathInfo.Mode().IsRegular() || pathInfo.Mode()&os.ModeSymlink != 0 || !reviewArtifactModeSafe(pathInfo.Mode(), false) {
+		return nil, errors.New("artifact is not an owner-only regular file")
+	}
+	reviewArtifactAfterLstat()
+	file, err := os.Open(artifact.Path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	opened, err := file.Stat()
+	if err != nil || !os.SameFile(pathInfo, opened) {
+		return nil, errors.New("artifact path changed before read")
+	}
+	payload, err := io.ReadAll(io.LimitReader(file, reviewResultArtifactLimit+1))
+	if err != nil || len(payload) > reviewResultArtifactLimit {
+		return nil, errors.New("artifact exceeds the native result size limit")
+	}
+	after, err := os.Lstat(artifact.Path)
+	if err != nil || !os.SameFile(opened, after) {
+		return nil, errors.New("artifact path changed during read")
+	}
+	if facadePayloadHash(payload) != artifact.SHA256 {
+		return nil, errors.New("artifact SHA-256 mismatch")
+	}
+	return payload, nil
+}
+func decodeFacadeJSONBytes(payload []byte, value any) error {
+	decoder := json.NewDecoder(bytes.NewReader(payload))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(value); err != nil {
+		return err
+	}
+	var extra any
+	if err := decoder.Decode(&extra); err != io.EOF {
+		return errors.New("input contains multiple JSON values")
+	}
+	return nil
+}
+func reviewArtifactModeSafe(mode os.FileMode, directory bool) bool {
+	return reviewArtifactModeSafeForOS(mode, directory, runtime.GOOS)
+}
+func reviewArtifactModeSafeForOS(mode os.FileMode, directory bool, goos string) bool {
+	return goos == "windows" || mode.Perm()&0o077 == 0 && (!directory || mode.Perm()&0o700 == 0o700)
+}
+func removeOwnedArtifact(path string, owned os.FileInfo) {
+	if owned == nil {
+		return
+	}
+	if current, err := os.Lstat(path); err == nil && os.SameFile(current, owned) {
+		_ = os.Remove(path)
+	}
+}

--- a/internal/cli/review_artifact_test.go
+++ b/internal/cli/review_artifact_test.go
@@ -1,0 +1,192 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/internal/reviewtransaction"
+)
+
+func TestReviewCaptureResultStrictBindingReplayAndFinalize(t *testing.T) {
+	repo, started, _, record := newArtifactReview(t, false)
+	input := filepath.Join(t.TempDir(), "result.json")
+	args := func(lineage, target, lens, order string) []string {
+		return []string{"--cwd", repo, "--lineage", lineage, "--target", target, "--lens", lens, "--order", order, "--input", input}
+	}
+	validArgs := args(started.LineageID, record.State.InitialSnapshot.Identity, record.State.SelectedLenses[0], "0")
+	for _, payload := range []string{"prose", `{}`, `{"findings":[],"evidence":[]} {}`, `{"findings":[],"evidence":[],"unknown":true}`} {
+		if err := os.WriteFile(input, []byte(payload), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := RunReviewCaptureResult(validArgs, io.Discard); err == nil {
+			t.Fatalf("invalid payload accepted: %s", payload)
+		}
+	}
+	if err := os.WriteFile(input, []byte(`{"findings":[],"evidence":["checked exact target"]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for _, bad := range [][]string{
+		args("wrong-lineage", record.State.InitialSnapshot.Identity, record.State.SelectedLenses[0], "0"),
+		args(started.LineageID, "sha256:"+strings.Repeat("0", 64), record.State.SelectedLenses[0], "0"),
+		args(started.LineageID, record.State.InitialSnapshot.Identity, "review-risk", "0"),
+		args(started.LineageID, record.State.InitialSnapshot.Identity, record.State.SelectedLenses[0], "1"),
+	} {
+		if err := RunReviewCaptureResult(bad, io.Discard); err == nil {
+			t.Fatal("wrong capture binding accepted")
+		}
+	}
+	var first, replay bytes.Buffer
+	if err := RunReviewCaptureResult(validArgs, &first); err != nil {
+		t.Fatal(err)
+	}
+	if err := RunReviewCaptureResult(validArgs, &replay); err != nil || first.String() != replay.String() {
+		t.Fatalf("exact replay changed: %v", err)
+	}
+	var artifact reviewResultArtifact
+	decodeStrictReviewJSON(t, first.Bytes(), &artifact)
+	if err := os.WriteFile(input, []byte(`{"findings":[],"evidence":["different"]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := RunReviewCaptureResult(validArgs, io.Discard); err == nil {
+		t.Fatal("mismatched replay accepted")
+	}
+	manifest := strings.TrimSpace(first.String())
+	for _, finalize := range [][]string{
+		{"--cwd", repo, "--lineage", started.LineageID, "--result-artifact", manifest, "--result", input},
+		{"--cwd", repo, "--lineage", started.LineageID, "--result-artifact", manifest, "--result-artifact", manifest},
+	} {
+		if err := RunReviewFacadeFinalize(finalize, io.Discard); err == nil {
+			t.Fatal("mixed or duplicate artifact accepted")
+		}
+	}
+	if err := RunReviewFacadeFinalize([]string{"--cwd", repo, "--lineage", started.LineageID, "--result-artifact", manifest}, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+}
+func TestReviewArtifactSubstitutionFailsBeforeMutation(t *testing.T) {
+	mutations := []struct {
+		name string
+		run  func(*reviewResultArtifact)
+	}{
+		{"lineage", func(a *reviewResultArtifact) { a.LineageID = "wrong" }},
+		{"target", func(a *reviewResultArtifact) { a.TargetIdentity = "sha256:" + strings.Repeat("0", 64) }},
+		{"lens", func(a *reviewResultArtifact) { a.Lens = "review-risk" }},
+		{"order", func(a *reviewResultArtifact) { a.SelectedOrder = 1 }},
+		{"hash", func(a *reviewResultArtifact) { a.SHA256 = "sha256:" + strings.Repeat("0", 64) }},
+		{"path", func(a *reviewResultArtifact) { a.Path = filepath.Join(t.TempDir(), "result.json") }},
+	}
+	for _, tt := range mutations {
+		t.Run(tt.name, func(t *testing.T) {
+			repo, started, store, record, artifact := capturedArtifact(t)
+			tt.run(&artifact)
+			assertArtifactFinalizeUnchanged(t, repo, started.LineageID, store, record.Revision, artifact)
+		})
+	}
+	for _, kind := range []string{"directory", "symlink", "mode", "bytes", "race"} {
+		t.Run(kind, func(t *testing.T) {
+			repo, started, store, record, artifact := capturedArtifact(t)
+			original, _ := os.ReadFile(artifact.Path)
+			switch kind {
+			case "directory":
+				_ = os.Remove(artifact.Path)
+				_ = os.Mkdir(artifact.Path, 0o700)
+			case "symlink":
+				_ = os.Remove(artifact.Path)
+				_ = os.Symlink(filepath.Join(t.TempDir(), "missing"), artifact.Path)
+			case "mode":
+				if runtime.GOOS == "windows" {
+					t.Skip("Windows ACLs do not map to Unix mode bits")
+				}
+				_ = os.Chmod(artifact.Path, 0o644)
+			case "bytes":
+				_ = os.WriteFile(artifact.Path, []byte("replacement"), 0o600)
+			case "race":
+				reviewArtifactAfterLstat = func() {
+					reviewArtifactAfterLstat = func() {}
+					_ = os.Rename(artifact.Path, artifact.Path+".old")
+					_ = os.WriteFile(artifact.Path, original, 0o600)
+				}
+				t.Cleanup(func() { reviewArtifactAfterLstat = func() {} })
+			}
+			assertArtifactFinalizeUnchanged(t, repo, started.LineageID, store, record.Revision, artifact)
+		})
+	}
+	if !reviewArtifactModeSafeForOS(0o666, false, "windows") || reviewArtifactModeSafeForOS(0o666, false, "linux") {
+		t.Fatal("platform permission semantics changed")
+	}
+}
+func TestReviewCaptureResultConcurrentSelectedLenses(t *testing.T) {
+	repo, started, store, record := newArtifactReview(t, true)
+	manifests := make([]string, len(record.State.SelectedLenses))
+	var wg sync.WaitGroup
+	for order, lens := range record.State.SelectedLenses {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			input := filepath.Join(t.TempDir(), fmt.Sprintf("%d.json", order))
+			_ = os.WriteFile(input, []byte(`{"findings":[],"evidence":["checked exact target"]}`), 0o600)
+			var output bytes.Buffer
+			err := RunReviewCaptureResult([]string{"--cwd", repo, "--lineage", started.LineageID, "--target", record.State.InitialSnapshot.Identity, "--lens", lens, "--order", fmt.Sprint(order), "--input", input}, &output)
+			if err != nil {
+				t.Errorf("capture %s: %v", lens, err)
+				return
+			}
+			manifests[order] = strings.TrimSpace(output.String())
+		}()
+	}
+	wg.Wait()
+	if _, err := readFacadeReviewerArtifacts(manifests, store.Dir, record.State); err != nil {
+		t.Fatal(err)
+	}
+}
+func newArtifactReview(t *testing.T, high bool) (string, ReviewFacadeStartResult, reviewtransaction.CompactStore, reviewtransaction.CompactRecord) {
+	t.Helper()
+	repo := initReviewCLIRepo(t)
+	name := "tracked.txt"
+	if high {
+		name = "service-token.ts"
+	}
+	if err := os.WriteFile(filepath.Join(repo, name), []byte("candidate\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	started := startFacadeReview(t, repo)
+	store, _ := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, started.LineageID)
+	record, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return repo, started, store, record
+}
+func capturedArtifact(t *testing.T) (string, ReviewFacadeStartResult, reviewtransaction.CompactStore, reviewtransaction.CompactRecord, reviewResultArtifact) {
+	t.Helper()
+	repo, started, store, record := newArtifactReview(t, false)
+	input := filepath.Join(t.TempDir(), "result.json")
+	_ = os.WriteFile(input, []byte(`{"findings":[],"evidence":["checked exact target"]}`), 0o600)
+	var output bytes.Buffer
+	if err := RunReviewCaptureResult([]string{"--cwd", repo, "--lineage", started.LineageID, "--target", record.State.InitialSnapshot.Identity, "--lens", record.State.SelectedLenses[0], "--order", "0", "--input", input}, &output); err != nil {
+		t.Fatal(err)
+	}
+	var artifact reviewResultArtifact
+	decodeStrictReviewJSON(t, output.Bytes(), &artifact)
+	return repo, started, store, record, artifact
+}
+func assertArtifactFinalizeUnchanged(t *testing.T, repo, lineage string, store reviewtransaction.CompactStore, revision string, artifact reviewResultArtifact) {
+	t.Helper()
+	payload, _ := json.Marshal(artifact)
+	if err := RunReviewFacadeFinalize([]string{"--cwd", repo, "--lineage", lineage, "--result-artifact", string(payload)}, io.Discard); err == nil {
+		t.Fatal("substituted artifact accepted")
+	}
+	after, _ := store.Load()
+	if after.Revision != revision {
+		t.Fatal("artifact mismatch mutated authority")
+	}
+}

--- a/internal/cli/review_artifact_test.go
+++ b/internal/cli/review_artifact_test.go
@@ -95,6 +95,10 @@ func TestReviewArtifactSubstitutionFailsBeforeMutation(t *testing.T) {
 		t.Run(kind, func(t *testing.T) {
 			repo, started, store, record, artifact := capturedArtifact(t)
 			original, _ := os.ReadFile(artifact.Path)
+			replacement := filepath.Join(t.TempDir(), "replacement.json")
+			if err := os.WriteFile(replacement, original, 0o600); err != nil {
+				t.Fatal(err)
+			}
 			switch kind {
 			case "directory":
 				_ = os.Remove(artifact.Path)
@@ -112,8 +116,12 @@ func TestReviewArtifactSubstitutionFailsBeforeMutation(t *testing.T) {
 			case "race":
 				reviewArtifactAfterLstat = func() {
 					reviewArtifactAfterLstat = func() {}
-					_ = os.Rename(artifact.Path, artifact.Path+".old")
-					_ = os.WriteFile(artifact.Path, original, 0o600)
+					if err := os.Rename(artifact.Path, artifact.Path+".old"); err != nil {
+						t.Fatal(err)
+					}
+					if err := os.Rename(replacement, artifact.Path); err != nil {
+						t.Fatal(err)
+					}
 				}
 				t.Cleanup(func() { reviewArtifactAfterLstat = func() {} })
 			}

--- a/internal/cli/review_artifact_test.go
+++ b/internal/cli/review_artifact_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -11,6 +12,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"syscall"
 	"testing"
 
 	"github.com/gentleman-programming/gentle-ai/internal/reviewtransaction"
@@ -154,6 +156,41 @@ func TestReviewCaptureResultConcurrentSelectedLenses(t *testing.T) {
 	wg.Wait()
 	if _, err := readFacadeReviewerArtifacts(manifests, store.Dir, record.State); err != nil {
 		t.Fatal(err)
+	}
+}
+func TestCaptureReviewerArtifactDirectorySync(t *testing.T) {
+	originalGOOS, originalSync := reviewArtifactRuntimeGOOS, syncReviewerArtifactDirectory
+	t.Cleanup(func() { reviewArtifactRuntimeGOOS, syncReviewerArtifactDirectory = originalGOOS, originalSync })
+	warning := []byte(`{"findings":[{"severity":"WARNING"}],"evidence":["unchanged"]}` + "\n")
+	cases := []struct {
+		name, goos string
+		err        error
+		wantOK     bool
+	}{
+		{"fatal", "linux", errors.New("disk sync failed"), false},
+		{"invalid", "linux", syscall.EINVAL, true},
+		{"unsupported", "linux", errors.ErrUnsupported, true},
+		{"windows permission", "windows", os.ErrPermission, true},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			storeDir := t.TempDir()
+			state := reviewtransaction.CompactState{LineageID: "lineage", InitialSnapshot: reviewtransaction.Snapshot{Identity: "target"}, SelectedLenses: []string{"review-correctness"}}
+			reviewArtifactRuntimeGOOS = func() string { return tt.goos }
+			syncReviewerArtifactDirectory = func(string) error { return tt.err }
+			artifact, err := captureReviewerArtifact(storeDir, state, 0, warning)
+			path := filepath.Join(storeDir, "reviewer-results", "00-review-correctness.json")
+			if !tt.wantOK {
+				if _, statErr := os.Stat(path); err == nil || artifact != (reviewResultArtifact{}) || !os.IsNotExist(statErr) {
+					t.Fatalf("fatal sync returned artifact or retained publication: artifact=%+v err=%v", artifact, err)
+				}
+				return
+			}
+			got, readErr := os.ReadFile(path)
+			if err != nil || readErr != nil || !bytes.Equal(got, warning) {
+				t.Fatalf("compatible sync changed WARNING result: capture=%v read=%v got=%q", err, readErr, got)
+			}
+		})
 	}
 }
 func newArtifactReview(t *testing.T, high bool) (string, ReviewFacadeStartResult, reviewtransaction.CompactStore, reviewtransaction.CompactRecord) {

--- a/internal/cli/review_capabilities.go
+++ b/internal/cli/review_capabilities.go
@@ -179,6 +179,7 @@ func reviewCapabilitiesStaticSurface() ReviewCapabilitiesResult {
 			ReviewIntegrationStatusSchema,
 			reviewtransaction.ReceiptSchema,
 			reviewtransaction.CompactReceiptSchema,
+			reviewResultArtifactSchema,
 			reviewRefuterSchemaID,
 			reviewReviewerSchemaID,
 			reviewValidatorSchemaID,

--- a/internal/cli/review_capabilities_test.go
+++ b/internal/cli/review_capabilities_test.go
@@ -127,8 +127,11 @@ func TestReviewCapabilitiesAdvertisesOnlyNativeSurface(t *testing.T) {
 	if !slices.Equal(result.Operations, wantOperations) || !slices.Equal(result.Gates, wantGates) || !slices.Equal(result.Projections, wantProjections) {
 		t.Fatalf("capability surface = operations %v gates %v projections %v", result.Operations, result.Gates, result.Projections)
 	}
-	if !slices.Contains(result.Schemas, ReviewIntegrationOperationSchema) || !slices.Contains(result.Schemas, ReviewIntegrationStartSchema) || !slices.Contains(result.Schemas, ReviewIntegrationStatusSchema) || !slices.Contains(result.Schemas, ReviewIntegrationProjectionSchema) {
+	if !slices.Contains(result.Schemas, reviewResultArtifactSchema) || !slices.Contains(result.Schemas, ReviewIntegrationOperationSchema) || !slices.Contains(result.Schemas, ReviewIntegrationStartSchema) || !slices.Contains(result.Schemas, ReviewIntegrationStatusSchema) || !slices.Contains(result.Schemas, ReviewIntegrationProjectionSchema) {
 		t.Fatalf("capability schemas do not advertise negotiated operations/START/status/projection: %v", result.Schemas)
+	}
+	if slices.Contains(result.Operations, "review.capture_result") {
+		t.Fatal("headless capture-result was advertised as a negotiated repository operation")
 	}
 	if result.Executable.Evidence != "self-reported" || result.Executable.Verification != "compare-with-published-manifest" || result.Executable.SHA256 != "sha256:dcc846103b16d365eaeeb9d7f289c23fc4f2897f23def1cb3fe7f05557b64705" {
 		t.Fatalf("executable identity = %#v", result.Executable)
@@ -168,6 +171,23 @@ func TestReviewCapabilitiesSchemaAndFixtureAreStrict(t *testing.T) {
 	}
 	if err := result.Validate(); err != nil {
 		t.Fatal(err)
+	}
+	featureSchema := schema["properties"].(map[string]any)["features"].(map[string]any)["properties"].(map[string]any)
+	optionalSchema := featureSchema["optional"].(map[string]any)
+	featureNames := schema["$defs"].(map[string]any)["feature"].(map[string]any)["properties"].(map[string]any)["name"].(map[string]any)["enum"].([]any)
+	accepted := make(map[string]bool, len(featureNames))
+	for _, name := range featureNames {
+		accepted[name.(string)] = true
+	}
+	for _, surface := range [][]ReviewCapabilityFeature{result.Features.Optional, reviewCapabilitiesStaticSurface().Features.Optional} {
+		if optionalSchema["minItems"] != float64(len(surface)) || optionalSchema["maxItems"] != float64(len(surface)) {
+			t.Fatalf("optional feature bounds do not accept provider surface: %#v", optionalSchema)
+		}
+		for _, feature := range surface {
+			if !accepted[feature.Name] {
+				t.Fatalf("feature schema rejects %q", feature.Name)
+			}
+		}
 	}
 	var raw map[string]any
 	if err := json.Unmarshal(fixture, &raw); err != nil {

--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -200,6 +200,7 @@ var reviewFacadeCommittedTransitionHook = func(context.Context, string, string, 
 func RunReview(args []string, stdout io.Writer) error {
 	if len(args) == 0 || args[0] == "help" || args[0] == "-h" || args[0] == "--help" {
 		_, _ = fmt.Fprintln(stdout, "Usage: gentle-ai review <capabilities|start|finalize|validate|status|invalidate|recover|schema|bind-sdd> [flags]\n\nOrdinary review facade; repository scope, authority, canonical artifacts, and lifecycle transitions are derived by Go.")
+		_, _ = fmt.Fprintln(stdout, "Additive headless capability: gentle-ai review capture-result.")
 		return nil
 	}
 	operation, negotiated, preflightFailure := reviewIntegrationFailureRoute(args)
@@ -265,6 +266,8 @@ func runReviewCommandContext(ctx context.Context, args []string, stdout io.Write
 
 func runReviewCommand(args []string, stdout io.Writer) error {
 	switch args[0] {
+	case "capture-result":
+		return RunReviewCaptureResult(args[1:], stdout)
 	case "capabilities":
 		return RunReviewCapabilities(args[1:], stdout)
 	case "start":
@@ -709,6 +712,8 @@ func runReviewFacadeFinalize(ctx context.Context, args []string, stdout io.Write
 	tracePath := flags.String("trace", "", "optional diagnostic operation metadata trace path")
 	var resultPaths repeatedString
 	flags.Var(&resultPaths, "result", "reviewer result JSON file or - for stdin; repeat in selected-lens order")
+	var resultArtifacts repeatedString
+	flags.Var(&resultArtifacts, "result-artifact", "native reviewer artifact manifest JSON; repeat in selected-lens order")
 	if err := parseReviewFlags(flags, args); err != nil {
 		return err
 	}
@@ -725,6 +730,9 @@ func runReviewFacadeFinalize(ctx context.Context, args []string, stdout io.Write
 	if countFacadeStdin(resultPaths, *validationPath, *refuterPath, *evidencePath) > 1 {
 		return reviewPreflightError(errors.New("review finalize accepts stdin for only one input"))
 	}
+	if len(resultPaths) != 0 && len(resultArtifacts) != 0 {
+		return reviewPreflightError(errors.New("review finalize cannot mix --result and --result-artifact"))
+	}
 	root, err := (reviewtransaction.SnapshotBuilder{Repo: *cwd}).ResolveRepositoryRoot(ctx)
 	if err != nil {
 		return fmt.Errorf("resolve review repository root: %w", err)
@@ -739,6 +747,9 @@ func runReviewFacadeFinalize(ctx context.Context, args []string, stdout io.Write
 	}
 	store.TracePath = strings.TrimSpace(*tracePath)
 	state := record.State
+	if len(resultArtifacts) != 0 && state.State != reviewtransaction.StateReviewing {
+		return reviewPreflightError(errors.New("reviewer artifacts are accepted only while the authority is reviewing"))
+	}
 	if strings.TrimSpace(*lineage) != "" {
 		leaves, err := reviewtransaction.CompactAuthorityLeaves(ctx, root)
 		if err != nil {
@@ -765,7 +776,7 @@ func runReviewFacadeFinalize(ctx context.Context, args []string, stdout io.Write
 			return err
 		}
 		if !terminalReceiptExists {
-			if !facadeFinalizeReplayInputsEmpty(resultPaths, *validationPath, *refuterPath, *evidencePath, *correctionLines, *failed, *tracePath) {
+			if !facadeFinalizeReplayInputsEmpty(resultPaths, resultArtifacts, *validationPath, *refuterPath, *evidencePath, *correctionLines, *failed, *tracePath) {
 				return errors.New("terminal review finalize accepts no review inputs; exact receipt replay requires only --lineage")
 			}
 			if *lineage != state.LineageID || strings.TrimSpace(*lineage) != *lineage {
@@ -798,7 +809,7 @@ func runReviewFacadeFinalize(ctx context.Context, args []string, stdout io.Write
 		}
 	}
 	exactNoInput := facadeFinalizeReplayInputsEmpty(
-		resultPaths, *validationPath, *refuterPath, *evidencePath, *correctionLines, *failed, *tracePath,
+		resultPaths, resultArtifacts, *validationPath, *refuterPath, *evidencePath, *correctionLines, *failed, *tracePath,
 	)
 	var nativeLowRiskEvidence []byte
 	if exactNoInput && facadeNativeLowRiskCandidate(state) {
@@ -809,6 +820,12 @@ func runReviewFacadeFinalize(ctx context.Context, args []string, stdout io.Write
 	}
 
 	if state.State == reviewtransaction.StateReviewing {
+		if len(resultArtifacts) != 0 {
+			reviewerResults, err = readFacadeReviewerArtifacts(resultArtifacts, store.Dir, state)
+			if err != nil {
+				return reviewPreflightError(err)
+			}
+		}
 		input, err := prepareCompactReviewerResults(state, reviewerResults, refuter, facadeRepositoryEvidence{ctx: ctx, repo: root})
 		if err != nil {
 			return reviewPreflightError(err)
@@ -965,8 +982,8 @@ func facadeTerminalState(state reviewtransaction.State) bool {
 	return state == reviewtransaction.StateApproved || state == reviewtransaction.StateEscalated
 }
 
-func facadeFinalizeReplayInputsEmpty(results []string, validation, refuter, evidence string, correctionLines int, failed bool, trace string) bool {
-	return len(results) == 0 && strings.TrimSpace(validation) == "" && strings.TrimSpace(refuter) == "" &&
+func facadeFinalizeReplayInputsEmpty(results, artifacts []string, validation, refuter, evidence string, correctionLines int, failed bool, trace string) bool {
+	return len(results) == 0 && len(artifacts) == 0 && strings.TrimSpace(validation) == "" && strings.TrimSpace(refuter) == "" &&
 		strings.TrimSpace(evidence) == "" && correctionLines == 0 && !failed && strings.TrimSpace(trace) == ""
 }
 

--- a/scripts/test-review-contract-package.sh
+++ b/scripts/test-review-contract-package.sh
@@ -28,6 +28,7 @@ expected_contract = [
     contract_root / "schemas/failure.schema.json",
     contract_root / "schemas/operation.schema.json",
     contract_root / "schemas/projection.schema.json",
+    contract_root / "schemas/result-artifact.schema.json",
     contract_root / "schemas/start.schema.json",
     contract_root / "schemas/status.schema.json",
 ]


### PR DESCRIPTION
## Linked Issue

Closes #1346

Related release blocker: #1339

## PR Type

- [ ] `type:bug` - Bug fix
- [x] `type:feature` - New feature
- [ ] `type:docs` - Documentation only
- [ ] `type:refactor` - Code refactoring
- [ ] `type:chore` - Maintenance or tooling
- [ ] `type:breaking-change` - Breaking change

## Summary

- Adds native `review capture-result` for strict, hash-bound reviewer result persistence.
- Binds ordered native artifact manifests into FINALIZE while preserving legacy bare result compatibility.
- Publishes the artifact capability/schema for trusted cross-agent controllers without expanding negotiated integration v1 operations.

## Changes

| Area | Change |
|------|--------|
| Native capture | Validates exact lineage, target, lens, selected order, and strict reviewer JSON before atomic private storage. |
| Artifact integrity | Enforces deterministic paths, owner-only modes, stable inode/readback, SHA-256 binding, exact replay, and substitution rejection. |
| FINALIZE | Accepts ordered `--result-artifact` manifests and rejects mixed, duplicate, stale, or mismatched inputs before authority mutation. |
| Capability contract | Adds the native result artifact schema and headless capability while keeping `capture-result` outside negotiated review-integration/v1 operations. |
| Tests and docs | Covers concurrency, replay, malformed JSON, symlinks, modes, replacement races, Windows semantics, and controller usage. |

## Chain Context

This PR is intentionally stacked on #1344 and PR #1369's merge commit. It MUST retain `fix/v217-release-blockers-v2` as its base until the integration branch lands.

| Field | Value |
|-------|-------|
| Chain | v2.1.7 release blockers |
| Base | `fix/v217-release-blockers-v2` at `99ce6ff90944b098c1ee0af2faa5b2cdebace8ba` |
| Depends on | #1344 and merged #1369 |
| Head | `d5c28f8` |
| Rollback | Revert this single commit; existing bare `--result` behavior remains available. |

## Size Exception

This work unit contains 508 additions and 10 deletions across 10 files. The native review froze a 499-line candidate and approved a 41-line bounded correction. Capture, manifest verification, FINALIZE binding, strict schema, tests, and docs form one security boundary; splitting them would expose an incomplete persistence contract.

## Review Evidence

- Native high-risk review ran risk, resilience, readability, and reliability under lineage `native-result-core-release-v217`.
- Real OpenCode plugin artifacts were captured by the new native API in canonical lens order.
- Two CRITICAL findings were corrected within immutable genesis scope: capabilities schema self-conformance and correct headless/unnegotiated capability classification.
- Final correction: 41 actual lines / 100 forecast / 200 budget.
- Final review state: `approved`.
- Review revision: `sha256:e07ce8ee2f6c200235beff48fc2d4928eb7621ca8e075b0f8e4f18ad9c72ab97`.
- `pre-commit`, `pre-push`, and `pre-pr` gates allowed the exact reviewed tree.

## Test Plan

- [x] `GOTOOLCHAIN=go1.25.10 go test -race ./internal/cli -run 'TestReview(CaptureResult|Artifact)' -count=1`
- [x] `GOTOOLCHAIN=go1.25.10 go test ./... -count=1 -timeout=18m`
- [x] `GOTOOLCHAIN=go1.25.10 go vet ./...`
- [x] `GOTOOLCHAIN=go1.25.10 go run ./internal/gofmtcheck`
- [x] `scripts/test-review-contract-package.sh`
- [x] `scripts/test-review-capabilities.sh`
- [x] Linux build
- [x] Windows amd64 and arm64 cross-builds
- [ ] Native Windows runtime and Docker E2E checks are delegated to CI

## Contributor Checklist

- [x] Linked approved issue #1346.
- [x] Exactly one type label requested: `type:feature`.
- [x] Tests and docs ship with the behavior.
- [x] Conventional commit format used.
- [x] No `Co-Authored-By` trailer.
