### PR TITLE
test(review): avoid racy-clean receipt fixture

### DIFF
--- a/internal/cli/review_receipt_discovery_test.go
+++ b/internal/cli/review_receipt_discovery_test.go
@@ -394,7 +394,7 @@ func TestUnqualifiedPrePRDiscoveryComposesSequentialReceiptsForSamePath(t *testi
 	runReviewCLIGit(t, repo, "remote", "add", "origin", remote)
 
 	for index, lineage := range []string{"review-chain-overlap-first", "review-chain-overlap-second", "review-chain-overlap-third"} {
-		approveDiscoveryMarkdown(t, repo, lineage, "docs/shared.md", "reviewed "+string(rune('a'+index))+"\n")
+		approveDiscoveryMarkdown(t, repo, lineage, "docs/shared.md", "reviewed "+strings.Repeat(string(rune('a'+index)), index+1)+"\n")
 		runReviewCLIGit(t, repo, "add", "-A")
 		runReviewCLIGit(t, repo, "commit", "-qm", "deliver "+lineage)
 	}


### PR DESCRIPTION
## Linked Issue

Closes #1346

## PR Type

- [ ] `type:bug` - Bug fix
- [ ] `type:feature` - New feature
- [ ] `type:docs` - Documentation only
- [ ] `type:refactor` - Code refactoring
- [x] `type:chore` - Maintenance or tooling
- [ ] `type:breaking-change` - Breaking change

## Summary

- Prevents Git racy-clean ambiguity in the sequential same-path receipt fixture.
- Preserves the same-path composition scenario while making each committed payload a different size.

## Chain Context

This test-only PR is stacked on #1344 at `99ce6ff` and unblocks PR #1370's deterministic Unit Tests gate.

## Test Plan

- [x] Focused receipt composition test passed 100 consecutive runs.
- [x] Full Go test suite passed.
- [x] Vet, formatter, and diff checks passed.
- [x] Native reliability review approved lineage `receipt-racy-clean-v217`.

## Contributor Checklist

- [x] Linked approved issue #1346.
- [x] Exactly one type label requested: `type:chore`.
- [x] Conventional commit format used.
- [x] No `Co-Authored-By` trailer.
