### PR TITLE
fix(review): recover complete release scope

### DIFF
--- a/docs/review-authority-threat-model.md
+++ b/docs/review-authority-threat-model.md
@@ -54,6 +54,7 @@ Legacy v1 chains and bundles remain readable for compatibility, but their histor
 ## Recovery And Rollback
 
 - Use `gentle-ai review recover` with an explicit predecessor lineage and revision, a distinct successor lineage, a disposition, reason, and actor. Approved predecessors require a proven scope change; invalidated predecessors remain terminal; escalated predecessors additionally require explicit maintainer authorization.
+- `review recover --release-scope` is the only recovery target-kind expansion with dedicated constraints: an approved `current-changes` predecessor may become a repository-derived first-parent `base-diff` only when the candidate tree and projection are unchanged and every predecessor path remains covered by a strictly larger release scope.
 - Recovery runs under the shared v2 store lock, records predecessor and operator provenance in the successor, and starts a new generation and correction budget without rewriting or deleting history.
 - Discovery authorizes only a unique valid unsuperseded leaf. Forks, dangling or mismatched predecessor links, cycles, and unrelated leaves fail closed. Explicitly selecting a superseded lineage permits historical inspection but not delivery authorization.
 - Recovery imports an explicitly exported compact authority record and binds it to the live delivered tree and original base-to-final path scope; it does not require or reconstruct obsolete intermediate trees or event history.

--- a/docs/review-integration.md
+++ b/docs/review-integration.md
@@ -137,6 +137,8 @@ An ambiguous or lost transport result is never proof of `not_started`. Reconcile
 
 For `gate_scope_changed` or `receipt_scope_changed`, use the strict `context.scope_change` evidence to present the exact drift. Recovery remains explicit: pass `predecessor_lineage_id`, `expected_predecessor_revision`, a distinct `successor_lineage_id`, `disposition`, `reason`, and `actor` to `review.recover`. Diagnostics never create a successor, allocate another budget, or mutate the predecessor.
 
+When a release merge retains an approved `current-changes` candidate but expands its path scope, add `--release-scope` to that explicit `scope_changed` recovery. The provider derives an immutable `HEAD^1..HEAD` base-diff; it rejects caller-selected base flags, candidate-tree changes, projection changes, omitted predecessor paths, and non-expanding scopes. The fresh successor must complete its newly derived review tier before the release gate can allow publication.
+
 Malformed reviewer JSON, missing required reviewer arrays, canonicalization failures, and selected-lens mismatches are deterministic preflight failures. Negotiated finalize reports `invalid_request`, `mutation_outcome: not_started`, `retry_safe: true`, `replayability: not_replayable`, and `next_action: correct_request`, while preserving a valid requested lineage for target-scoped recovery. Correct the payload before retrying; do not run authority repair.
 
 ## Preserve compatibility without reopening legacy mutation

--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -397,6 +397,7 @@ func RunReviewRecover(args []string, stdout io.Writer) error {
 	focus := flags.String("focus", "reliability", "dominant standard-risk focus; large pure documentation always uses readability")
 	baseRef := flags.String("base-ref", "", "optional base revision for immutable base-to-HEAD review")
 	committedOnly := flags.Bool("committed-only", false, "acknowledge that --base-ref excludes dirty tracked changes")
+	releaseScope := flags.Bool("release-scope", false, "recover an approved current-changes review into the immutable HEAD first-parent release scope")
 	if err := parseReviewFlags(flags, args); err != nil {
 		return err
 	}
@@ -425,7 +426,16 @@ func RunReviewRecover(args []string, stdout io.Writer) error {
 	base := strings.TrimSpace(*baseRef)
 	baseDiff := predecessorRecord.State.InitialSnapshot.Kind == reviewtransaction.TargetBaseDiff
 	overlay := predecessorRecord.State.InitialSnapshot.Kind == reviewtransaction.TargetBaseWorkspaceOverlay
-	if *committedOnly != (base != "") || baseDiff != *committedOnly {
+	if *releaseScope && (base != "" || *committedOnly) {
+		return errors.New("--release-scope cannot be combined with --base-ref or --committed-only")
+	}
+	if *releaseScope && reviewtransaction.RecoveryDisposition(*disposition) != reviewtransaction.RecoveryScopeChanged {
+		return errors.New("--release-scope requires --disposition scope_changed")
+	}
+	if *releaseScope && predecessorRecord.State.InitialSnapshot.Kind != reviewtransaction.TargetCurrentChanges {
+		return errors.New("--release-scope requires a current-changes predecessor")
+	}
+	if !*releaseScope && (*committedOnly != (base != "") || baseDiff != *committedOnly) {
 		return errors.New("base-diff recovery requires matching --base-ref and --committed-only")
 	}
 	projection := predecessorRecord.State.InitialSnapshot.Projection
@@ -442,14 +452,19 @@ func RunReviewRecover(args []string, stdout io.Writer) error {
 	} else if overlay {
 		target.Kind, target.BaseRef = reviewtransaction.TargetBaseWorkspaceOverlay, predecessorRecord.State.InitialSnapshot.BaseTree
 	}
-	snapshot, err := (reviewtransaction.SnapshotBuilder{Repo: root}).Build(context.Background(), target)
+	var snapshot reviewtransaction.Snapshot
+	if *releaseScope {
+		snapshot, err = reviewtransaction.BuildReleaseScopeSnapshot(context.Background(), root)
+	} else {
+		snapshot, err = builder.Build(context.Background(), target)
+	}
 	if err != nil {
 		return err
 	}
-	if (baseDiff || overlay) && snapshot.BaseTree != predecessorRecord.State.InitialSnapshot.BaseTree {
+	if !*releaseScope && (baseDiff || overlay) && snapshot.BaseTree != predecessorRecord.State.InitialSnapshot.BaseTree {
 		return errors.New("recovery base-ref does not match predecessor base")
 	}
-	if (baseDiff || overlay) && snapshot.Identity == predecessorRecord.State.InitialSnapshot.Identity {
+	if !*releaseScope && (baseDiff || overlay) && snapshot.Identity == predecessorRecord.State.InitialSnapshot.Identity {
 		return errors.New("recovery scope has not changed")
 	}
 	assessment, err := (reviewtransaction.SnapshotBuilder{Repo: root}).AssessSnapshotRisk(context.Background(), snapshot)
@@ -471,6 +486,9 @@ func RunReviewRecover(args []string, stdout io.Writer) error {
 	})
 	if err != nil {
 		return err
+	}
+	if *releaseScope {
+		*authorization = reviewtransaction.ReleaseScopeRecoveryAuthorization
 	}
 	record, err := reviewtransaction.RecoverCompactAuthority(context.Background(), root, reviewtransaction.CompactRecoveryRequest{
 		PredecessorLineageID: *predecessor, ExpectedPredecessorRevision: *expected, Successor: state,

--- a/internal/cli/review_start_contract_test.go
+++ b/internal/cli/review_start_contract_test.go
@@ -379,6 +379,92 @@ func TestReviewRecoverRetainsWorkspaceOverlayBaseAndScope(t *testing.T) {
 	}
 }
 
+func TestReviewRecoverReleaseScopeExpandsMergedSliceToFirstParentDiff(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	mainBranch := strings.TrimSpace(runReviewCLIGit(t, repo, "branch", "--show-current"))
+	runReviewCLIGit(t, repo, "checkout", "-qb", "release-candidate")
+	if err := os.MkdirAll(filepath.Join(repo, ".github", "workflows"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, ".github", "workflows", "release.yml"), []byte("name: Release\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runReviewCLIGit(t, repo, "add", ".github/workflows/release.yml")
+	runReviewCLIGit(t, repo, "commit", "-qm", "release workflow")
+	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("reviewed slice\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	lineage := "release-slice-predecessor"
+	if err := RunReviewFacadeStart([]string{"--cwd", repo, "--lineage", lineage}, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	store, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, lineage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	predecessor, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	state := predecessor.State
+	results := make([]reviewtransaction.LensResult, len(state.SelectedLenses))
+	for index, lens := range state.SelectedLenses {
+		results[index] = reviewtransaction.LensResult{Lens: lens, Findings: []reviewtransaction.Finding{}, Evidence: []string{"reviewed"}}
+	}
+	if err := state.CompleteReview(reviewtransaction.CompactReviewInput{LensResults: results}); err != nil {
+		t.Fatal(err)
+	}
+	revision, err := store.Replace(predecessor.Revision, "review/complete-review", state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := state.CompleteVerification([]byte("verified\n"), true); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Replace(revision, "review/complete-verification", state); err != nil {
+		t.Fatal(err)
+	}
+	predecessor, err = store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	runReviewCLIGit(t, repo, "add", "tracked.txt")
+	runReviewCLIGit(t, repo, "commit", "-qm", "reviewed slice")
+	runReviewCLIGit(t, repo, "checkout", "-q", mainBranch)
+	runReviewCLIGit(t, repo, "merge", "--no-ff", "-qm", "release candidate", "release-candidate")
+	mergedTree := strings.TrimSpace(runReviewCLIGit(t, repo, "rev-parse", "HEAD^{tree}"))
+	if mergedTree != predecessor.State.CurrentSnapshot.CandidateTree {
+		t.Fatalf("merged tree = %s, reviewed candidate = %s", mergedTree, predecessor.State.CurrentSnapshot.CandidateTree)
+	}
+
+	args := []string{"--cwd", repo, "--predecessor-lineage", lineage, "--expected-predecessor-revision", predecessor.Revision,
+		"--successor-lineage", "release-scope-successor", "--disposition", "scope_changed", "--reason", "prepare complete release scope", "--actor", "maintainer", "--release-scope"}
+	conflicting := append(append([]string{}, args...), "--base-ref", "HEAD^1")
+	if err := RunReviewRecover(conflicting, io.Discard); err == nil || !strings.Contains(err.Error(), "cannot be combined") {
+		t.Fatalf("release-scope selector conflict error = %v", err)
+	}
+	if err := RunReviewRecover(args, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	successorStore, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, "release-scope-successor")
+	if err != nil {
+		t.Fatal(err)
+	}
+	successor, err := successorStore.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshot := successor.State.InitialSnapshot
+	wantBase := strings.TrimSpace(runReviewCLIGit(t, repo, "rev-parse", "HEAD^1^{tree}"))
+	wantPaths := []string{".github/workflows/release.yml", "tracked.txt"}
+	if snapshot.Kind != reviewtransaction.TargetBaseDiff || snapshot.BaseTree != wantBase || snapshot.CandidateTree != mergedTree ||
+		!reflect.DeepEqual(snapshot.Paths, wantPaths) || successor.State.RiskLevel != reviewtransaction.RiskHigh || len(successor.State.SelectedLenses) != 4 {
+		t.Fatalf("release-scope successor = %#v", successor.State)
+	}
+}
+
 func TestNegotiatedReviewStartPreservesLegacyPayloadAndAuthorityIdentity(t *testing.T) {
 	legacyRepo := initReviewCLIRepo(t)
 	negotiatedRepo := initReviewCLIRepo(t)

--- a/internal/reviewtransaction/compact_store.go
+++ b/internal/reviewtransaction/compact_store.go
@@ -108,6 +108,31 @@ type CompactRecoveryRequest struct {
 	MaintainerAuthorization     string
 }
 
+const ReleaseScopeRecoveryAuthorization = "gentle-ai.release-scope-recovery/v1"
+
+func BuildReleaseScopeSnapshot(ctx context.Context, repo string) (Snapshot, error) {
+	builder := SnapshotBuilder{Repo: repo}
+	root, err := builder.repositoryRoot(ctx)
+	if err != nil {
+		return Snapshot{}, err
+	}
+	commitOutput, err := runGit(ctx, root, nil, nil, "rev-parse", "--verify", "HEAD^{commit}")
+	if err != nil {
+		return Snapshot{}, err
+	}
+	commit := strings.TrimSpace(string(commitOutput))
+	if _, err := runGit(ctx, root, nil, nil, "rev-parse", "--verify", commit+"^2^{commit}"); err != nil {
+		return Snapshot{}, errors.New("release-scope recovery requires HEAD to be a merge commit")
+	}
+	snapshot, err := (SnapshotBuilder{Repo: root}).Build(ctx, Target{Kind: TargetExactRevision, Revision: commit})
+	if err != nil {
+		return Snapshot{}, err
+	}
+	snapshot.Kind = TargetBaseDiff
+	snapshot.Identity = snapshotIdentityForProjection(snapshot.Kind, snapshot.Projection, snapshot.BaseTree, snapshot.CandidateTree, snapshot.PathsDigest, snapshot.IntendedUntrackedProof, snapshot.IntendedUntracked, snapshot.LedgerIDs)
+	return snapshot, nil
+}
+
 func RecoverCompactAuthority(ctx context.Context, repo string, request CompactRecoveryRequest) (CompactRecord, error) {
 	predecessorStore, err := CompactAuthoritativeStore(ctx, repo, request.PredecessorLineageID)
 	if err != nil {
@@ -184,6 +209,11 @@ func RecoverCompactAuthority(ctx context.Context, repo string, request CompactRe
 	if err := validateCompactRecoveryEdge(predecessor, request.Successor); err != nil {
 		return CompactRecord{}, err
 	}
+	if request.MaintainerAuthorization == ReleaseScopeRecoveryAuthorization {
+		if live, liveErr := BuildReleaseScopeSnapshot(ctx, successorStore.repo); liveErr != nil || !snapshotsEqual(live, request.Successor.InitialSnapshot) {
+			return CompactRecord{}, fmt.Errorf("%w: live release scope no longer matches successor", ErrInvalidSuccessor)
+		}
+	}
 	if err := validateCompactRepositoryEvidence(ctx, successorStore.repo, nil, request.Successor, "review/start"); err != nil {
 		return CompactRecord{}, fmt.Errorf("%w: %v", ErrInvalidSuccessor, err)
 	}
@@ -201,6 +231,17 @@ func compactRecoveryScopeChanged(previous, next Snapshot) bool {
 	return previous.CandidateTree != next.CandidateTree || previous.PathsDigest != next.PathsDigest || previous.Kind == next.Kind && previous.BaseTree != next.BaseTree
 }
 
+func compactReleaseScopeRecovery(predecessor CompactState, next Snapshot) bool {
+	previous := predecessor.CurrentSnapshot
+	if predecessor.InitialSnapshot.Kind != TargetCurrentChanges ||
+		(previous.Kind != TargetCurrentChanges && previous.Kind != TargetFixDiff) || next.Kind != TargetBaseDiff ||
+		previous.Projection != next.Projection || previous.CandidateTree != next.CandidateTree ||
+		len(next.Paths) <= len(predecessor.GenesisPaths) {
+		return false
+	}
+	return pathsAreSubset(predecessor.GenesisPaths, next.Paths) == nil
+}
+
 func validateCompactRecoveryEdge(predecessor CompactRecord, successor CompactState) error {
 	recovery := successor.Recovery
 	if recovery == nil || recovery.PredecessorLineageID != predecessor.State.LineageID {
@@ -216,7 +257,12 @@ func validateCompactRecoveryEdge(predecessor CompactRecord, successor CompactSta
 	case RecoveryScopeChanged:
 		switch predecessor.State.State {
 		case StateApproved:
-			if !compactRecoveryScopeChanged(predecessor.State.CurrentSnapshot, successor.InitialSnapshot) {
+			previous, next := predecessor.State.CurrentSnapshot, successor.InitialSnapshot
+			releaseScope := recovery.MaintainerAuthorization == ReleaseScopeRecoveryAuthorization
+			if releaseScope && !compactReleaseScopeRecovery(predecessor.State, next) {
+				return errors.New("approved recovery target-kind transition is not a complete release scope expansion")
+			}
+			if !releaseScope && !compactRecoveryScopeChanged(previous, next) {
 				return errors.New("approved predecessor scope has not changed")
 			}
 		case StateCorrectionRequired:

--- a/internal/reviewtransaction/compact_store_test.go
+++ b/internal/reviewtransaction/compact_store_test.go
@@ -220,6 +220,43 @@ func TestApprovedRecoveryTreatsBaseTreeMismatchAsScopeChange(t *testing.T) {
 	}
 }
 
+func TestCompactReleaseScopeRecoveryRequiresStrictSameCandidateExpansion(t *testing.T) {
+	candidate := strings.Repeat("c", 40)
+	previous := Snapshot{
+		Kind: TargetCurrentChanges, Projection: ProjectionWorkspace, CandidateTree: candidate,
+		Paths: []string{"reviewed.go"},
+	}
+	valid := Snapshot{
+		Kind: TargetBaseDiff, Projection: ProjectionWorkspace, CandidateTree: candidate,
+		Paths: []string{"release.go", "reviewed.go"},
+	}
+	predecessor := CompactState{InitialSnapshot: previous, CurrentSnapshot: previous, GenesisPaths: previous.Paths}
+	predecessor.CurrentSnapshot.Kind = TargetFixDiff
+	tests := []struct {
+		name   string
+		mutate func(*Snapshot)
+	}{
+		{name: "candidate changed", mutate: func(snapshot *Snapshot) { snapshot.CandidateTree = strings.Repeat("d", 40) }},
+		{name: "predecessor path omitted", mutate: func(snapshot *Snapshot) { snapshot.Paths = []string{"release.go", "unrelated.go"} }},
+		{name: "scope did not expand", mutate: func(snapshot *Snapshot) { snapshot.Paths = []string{"reviewed.go"} }},
+		{name: "projection changed", mutate: func(snapshot *Snapshot) { snapshot.Projection = ProjectionStaged }},
+		{name: "target kind is arbitrary", mutate: func(snapshot *Snapshot) { snapshot.Kind = TargetBaseWorkspaceOverlay }},
+	}
+	if !compactReleaseScopeRecovery(predecessor, valid) {
+		t.Fatal("corrected current-changes release scope expansion was rejected")
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			candidate := valid
+			candidate.Paths = append([]string(nil), valid.Paths...)
+			tt.mutate(&candidate)
+			if compactReleaseScopeRecovery(predecessor, candidate) {
+				t.Fatalf("invalid release scope expansion accepted: %#v", candidate)
+			}
+		})
+	}
+}
+
 func TestCompactGateFinalRecheckRejectsConcurrentRecoverySuccessor(t *testing.T) {
 	repo := initSnapshotRepo(t)
 	writeSnapshotFile(t, repo, "tracked.txt", "candidate\n")


### PR DESCRIPTION
## Linked Issue

Closes #1377

## PR Type

- [x] `type:bug` - Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` - New feature (non-breaking change that adds functionality)
- [ ] `type:docs` - Documentation only
- [ ] `type:refactor` - Code refactoring (no functional changes)
- [ ] `type:chore` - Build, CI, or tooling changes
- [ ] `type:breaking-change` - Breaking change (fix or feature that changes existing behavior)

## Summary

- Adds explicit `review recover --release-scope` recovery for reviewed slices merged into a larger release commit.
- Freezes the exact merge commit, derives its first-parent diff, and revalidates the boundary under the authority lock.
- Preserves candidate tree, projection, and genesis coverage while requiring a fresh review for the expanded scope.

## Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/cli/review_facade.go` | Adds the fail-closed release-scope selector and flag constraints. |
| `internal/reviewtransaction/compact_store.go` | Derives and validates exact merge scope with compatibility-safe provenance. |
| `internal/**/*_test.go` | Covers merged slice expansion, corrected predecessors, and invalid transitions. |
| `docs/review-*.md` | Documents release recovery and authority constraints. |

## Test Plan

- [x] `go test ./... -count=1`
- [x] `go vet ./...`
- [x] `go run ./internal/gofmtcheck`
- [x] `bash scripts/test-review-contract-package.sh`
- [x] Native high-risk 4R review and `post-apply`, `pre-commit`, `pre-push`, and `pre-pr` gates
- [x] Remote Ubuntu, Arch, Fedora, and Windows checks
- [ ] Local Docker E2E: Docker is unavailable on this machine; required remote Ubuntu, Arch, and Fedora E2E checks must pass before merge.

## Contributor Checklist

- [x] PR is linked to issue #1377 with `status:approved`
- [x] PR stays within 400 changed lines
- [x] Exactly one `type:*` label will be applied
- [x] Unit tests and Go format pass
- [x] E2E checks pass remotely
- [x] Documentation is updated
- [x] Commit follows Conventional Commits
- [x] Commit has no `Co-Authored-By` trailer

## Notes for Reviewers

Native review lineage: `review-release-scope-recovery-v217`  
Approved revision: `sha256:812351f80887ed6244f4e0a1764b680715d831cf86cb5ff0ea475207930fc5c1`

Please focus on exact-commit/first-parent binding and historical recovery compatibility. The old slice receipt remains insufficient for release; this command creates a fresh full-scope review rather than bypassing it.
