### PR TITLE
fix(sdd): route stale verify evidence to verify under compact authority

### DIFF
--- a/internal/sddstatus/bounded_review_test.go
+++ b/internal/sddstatus/bounded_review_test.go
@@ -895,6 +895,26 @@ func TestResolveRoutesStaleVerifyEvidenceToVerifyUnderApprovedCompactAuthority(t
 	}
 }
 
+func TestResolveRejectsForeignCompactAuthorityForStaleVerifyEvidence(t *testing.T) {
+	root := t.TempDir()
+	changeRoot := seedReadyChange(t, root, "thin", "- [x] 1.1 Done\n")
+	foreignRoot := seedReadyChange(t, root, "other", "- [x] 1.1 Done\n")
+	write(t, filepath.Join(changeRoot, "specs", "auth", "spec.md"), "### Requirement: Auth\n#### Scenario: Valid login\n#### Scenario: Rejected login\n")
+	write(t, filepath.Join(changeRoot, "verify-report.md"), boundedVerifyEnvelope(shaID("d"), "pass"))
+	writeApprovedCompactAuthorityForChange(t, root, foreignRoot, "compact-other")
+
+	status, err := Resolve(ResolveOptions{CWD: root, ChangeName: "thin"})
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if status.Dependencies.Verify != DependencyBlocked || status.NextRecommended != "resolve-review" {
+		t.Fatalf("verify=%q next=%q, want blocked/resolve-review", status.Dependencies.Verify, status.NextRecommended)
+	}
+	if !strings.Contains(strings.Join(status.BlockedReasons, "\n"), `compact review authority is not bound to selected change "thin"`) {
+		t.Fatalf("BlockedReasons = %v, want foreign-authority rejection", status.BlockedReasons)
+	}
+}
+
 func TestResolveEngramRoutesStaleVerifyEvidenceToVerifyUnderApprovedCompactAuthority(t *testing.T) {
 	root := t.TempDir()
 	changeRoot := seedReadyChange(t, root, "thin", "- [x] 1.1 Done\n")
@@ -937,6 +957,39 @@ func TestResolveEngramRoutesStaleVerifyEvidenceToVerifyUnderApprovedCompactAutho
 	}
 	if status.RemediationState != (RemediationState{}) {
 		t.Fatalf("RemediationState = %#v, want empty for stale evidence", status.RemediationState)
+	}
+}
+
+func TestResolveEngramRejectsForeignCompactAuthorityForStaleVerifyEvidence(t *testing.T) {
+	root := t.TempDir()
+	foreignRoot := seedReadyChange(t, root, "other", "- [x] 1.1 Done\n")
+	writeApprovedCompactAuthorityForChange(t, root, foreignRoot, "compact-other")
+	store, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), root, "compact-other")
+	if err != nil {
+		t.Fatal(err)
+	}
+	receiptPayload := readText(store.ReceiptPath())
+	mkdir(t, filepath.Join(root, ".engram"))
+	project := strings.ToLower(filepath.Base(root))
+	restore := stubEngramExport(t, []engramObservation{
+		{Title: "sdd/thin/proposal", Content: "# Proposal\n", Project: project, Scope: "project"},
+		{Title: "sdd/thin/spec", Content: "### Requirement: Auth\n#### Scenario: Valid login\n#### Scenario: Rejected login\n", Project: project, Scope: "project"},
+		{Title: "sdd/thin/design", Content: "# Design\n", Project: project, Scope: "project"},
+		{Title: "sdd/thin/tasks", Content: "- [x] 1.1 Done\n", Project: project, Scope: "project"},
+		{Title: "sdd/thin/verify-report", Content: boundedVerifyEnvelope(shaID("d"), "pass"), Project: project, Scope: "project"},
+		{Title: "sdd/thin/review/receipt", Content: receiptPayload, Project: project, Scope: "project"},
+	})
+	defer restore()
+
+	status, ok, err := resolveEngramStatus(root, "thin", false)
+	if err != nil || !ok {
+		t.Fatalf("resolveEngramStatus() = ok %v, error %v", ok, err)
+	}
+	if status.Dependencies.Verify != DependencyBlocked || status.NextRecommended != "resolve-review" {
+		t.Fatalf("verify=%q next=%q, want blocked/resolve-review", status.Dependencies.Verify, status.NextRecommended)
+	}
+	if !strings.Contains(strings.Join(status.BlockedReasons, "\n"), `compact review authority is not bound to selected change "thin"`) {
+		t.Fatalf("BlockedReasons = %v, want foreign-authority rejection", status.BlockedReasons)
 	}
 }
 

--- a/internal/sddstatus/bounded_review_test.go
+++ b/internal/sddstatus/bounded_review_test.go
@@ -870,6 +870,95 @@ func TestResolveRejectsReceiptMismatchAndNonAllowCompactBridge(t *testing.T) {
 	}
 }
 
+func TestResolveRoutesStaleVerifyEvidenceToVerifyUnderApprovedCompactAuthority(t *testing.T) {
+	root := t.TempDir()
+	changeRoot := seedReadyChange(t, root, "thin", "- [x] 1.1 Done\n")
+	write(t, filepath.Join(changeRoot, "specs", "auth", "spec.md"), "### Requirement: Auth\n#### Scenario: Valid login\n#### Scenario: Rejected login\n")
+	write(t, filepath.Join(changeRoot, "verify-report.md"), boundedVerifyEnvelope(shaID("d"), "pass"))
+	writeApprovedCompactAuthorityForChange(t, root, changeRoot, "compact-thin")
+
+	status, err := Resolve(ResolveOptions{CWD: root, ChangeName: "thin"})
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if status.ReviewGate == nil || status.ReviewGate.Result != reviewtransaction.GateAllow {
+		t.Fatalf("ReviewGate = %#v, want allow", status.ReviewGate)
+	}
+	if len(status.BlockedReasons) != 0 {
+		t.Fatalf("BlockedReasons = %v, want empty", status.BlockedReasons)
+	}
+	if status.Dependencies.Verify != DependencyReady || status.Dependencies.Archive != DependencyBlocked || status.NextRecommended != "verify" {
+		t.Fatalf("verify=%q archive=%q next=%q, want ready/blocked/verify", status.Dependencies.Verify, status.Dependencies.Archive, status.NextRecommended)
+	}
+	if status.RemediationState != (RemediationState{}) {
+		t.Fatalf("RemediationState = %#v, want empty for stale evidence", status.RemediationState)
+	}
+}
+
+func TestResolveEngramRoutesStaleVerifyEvidenceToVerifyUnderApprovedCompactAuthority(t *testing.T) {
+	root := t.TempDir()
+	changeRoot := seedReadyChange(t, root, "thin", "- [x] 1.1 Done\n")
+	writeApprovedCompactAuthorityForChange(t, root, changeRoot, "compact-thin")
+	store, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), root, "compact-thin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	receiptPayload := readText(store.ReceiptPath())
+	if receiptPayload == "" {
+		t.Fatal("compact receipt payload is empty")
+	}
+	mkdir(t, filepath.Join(root, ".engram"))
+	project := strings.ToLower(filepath.Base(root))
+	restore := stubEngramExport(t, []engramObservation{
+		{Title: "sdd/thin/proposal", Content: "# Proposal\n", Project: project, Scope: "project"},
+		{Title: "sdd/thin/spec", Content: "### Requirement: Auth\n#### Scenario: Valid login\n#### Scenario: Rejected login\n", Project: project, Scope: "project"},
+		{Title: "sdd/thin/design", Content: "# Design\n", Project: project, Scope: "project"},
+		{Title: "sdd/thin/tasks", Content: "- [x] 1.1 Done\n", Project: project, Scope: "project"},
+		{Title: "sdd/thin/verify-report", Content: boundedVerifyEnvelope(shaID("d"), "pass"), Project: project, Scope: "project"},
+		{Title: "sdd/thin/review/receipt", Content: receiptPayload, Project: project, Scope: "project"},
+	})
+	defer restore()
+
+	status, ok, err := resolveEngramStatus(root, "thin", false)
+	if err != nil {
+		t.Fatalf("resolveEngramStatus() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("resolveEngramStatus() did not retain the Engram change")
+	}
+	if status.ReviewGate == nil || status.ReviewGate.Result != reviewtransaction.GateAllow {
+		t.Fatalf("ReviewGate = %#v, want allow", status.ReviewGate)
+	}
+	if len(status.BlockedReasons) != 0 {
+		t.Fatalf("BlockedReasons = %v, want empty", status.BlockedReasons)
+	}
+	if status.Dependencies.Verify != DependencyReady || status.Dependencies.Archive != DependencyBlocked || status.NextRecommended != "verify" {
+		t.Fatalf("verify=%q archive=%q next=%q, want ready/blocked/verify", status.Dependencies.Verify, status.Dependencies.Archive, status.NextRecommended)
+	}
+	if status.RemediationState != (RemediationState{}) {
+		t.Fatalf("RemediationState = %#v, want empty for stale evidence", status.RemediationState)
+	}
+}
+
+func TestResolveKeepsFailedVerdictRemediationRoutingUnderApprovedCompactAuthority(t *testing.T) {
+	root := t.TempDir()
+	changeRoot := seedReadyChange(t, root, "thin", "- [x] 1.1 Done\n")
+	write(t, filepath.Join(changeRoot, "verify-report.md"), boundedVerifyEnvelope(shaID("d"), "fail"))
+	writeApprovedCompactAuthorityForChange(t, root, changeRoot, "compact-thin")
+
+	status, err := Resolve(ResolveOptions{CWD: root, ChangeName: "thin"})
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if status.Dependencies.Verify != DependencyBlocked || status.NextRecommended != "resolve-review" {
+		t.Fatalf("verify=%q next=%q, want blocked/resolve-review for failed verdict", status.Dependencies.Verify, status.NextRecommended)
+	}
+	want := "verify evidence cannot enter remediation: verdict requires remediation; bounded review transaction is missing"
+	if !strings.Contains(strings.Join(status.BlockedReasons, "\n"), want) {
+		t.Fatalf("BlockedReasons = %v, want containing %q", status.BlockedReasons, want)
+	}
+}
+
 func TestResolveRemediationIsBoundToBudgetAndFailedEvidenceRevision(t *testing.T) {
 	root := t.TempDir()
 	changeRoot := seedReadyChange(t, root, "thin", "- [x] 1.1 Done\n")

--- a/internal/sddstatus/bounded_review_test.go
+++ b/internal/sddstatus/bounded_review_test.go
@@ -940,9 +940,10 @@ func TestResolveEngramRoutesStaleVerifyEvidenceToVerifyUnderApprovedCompactAutho
 	}
 }
 
-func TestResolveKeepsFailedVerdictRemediationRoutingUnderApprovedCompactAuthority(t *testing.T) {
+func TestResolveKeepsFailedVerdictWithCurrentSpecTotalsMismatchOnRemediationRouting(t *testing.T) {
 	root := t.TempDir()
 	changeRoot := seedReadyChange(t, root, "thin", "- [x] 1.1 Done\n")
+	write(t, filepath.Join(changeRoot, "specs", "auth", "spec.md"), "### Requirement: Auth\n#### Scenario: Valid login\n#### Scenario: Added after verification\n")
 	write(t, filepath.Join(changeRoot, "verify-report.md"), boundedVerifyEnvelope(shaID("d"), "fail"))
 	writeApprovedCompactAuthorityForChange(t, root, changeRoot, "compact-thin")
 
@@ -953,7 +954,7 @@ func TestResolveKeepsFailedVerdictRemediationRoutingUnderApprovedCompactAuthorit
 	if status.Dependencies.Verify != DependencyBlocked || status.NextRecommended != "resolve-review" {
 		t.Fatalf("verify=%q next=%q, want blocked/resolve-review for failed verdict", status.Dependencies.Verify, status.NextRecommended)
 	}
-	want := "verify evidence cannot enter remediation: verdict requires remediation; bounded review transaction is missing"
+	want := "verify evidence cannot enter remediation: verify result total 1 does not match actual scenario count 2; bounded review transaction is missing"
 	if !strings.Contains(strings.Join(status.BlockedReasons, "\n"), want) {
 		t.Fatalf("BlockedReasons = %v, want containing %q", status.BlockedReasons, want)
 	}

--- a/internal/sddstatus/review_binding_test.go
+++ b/internal/sddstatus/review_binding_test.go
@@ -447,6 +447,57 @@ func TestBoundReviewUsesNormalVerifyThenArchiveRouting(t *testing.T) {
 	}
 }
 
+func TestBoundReviewRoutesStaleVerifyEvidenceToVerify(t *testing.T) {
+	root := t.TempDir()
+	changeRoot := seedReadyChange(t, root, "thin", "- [x] 1.1 Done\n")
+	write(t, filepath.Join(changeRoot, "specs", "auth", "spec.md"), "### Requirement: Binding\n#### Scenario: Exact authority\n#### Scenario: Added after verification\n")
+	writeApprovedCompactAuthorityForChange(t, root, changeRoot, "approved-thin")
+	if _, err := BindApprovedReview(context.Background(), root, "thin", "approved-thin", ""); err != nil {
+		t.Fatal(err)
+	}
+	write(t, filepath.Join(changeRoot, "verify-report.md"), boundedVerifyEnvelope(shaID("a"), "pass"))
+
+	status, err := Resolve(ResolveOptions{CWD: root, ChangeName: "thin"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.ReviewGate == nil || status.ReviewGate.Result != reviewtransaction.GateAllow {
+		t.Fatalf("ReviewGate = %#v, want allow", status.ReviewGate)
+	}
+	if len(status.BlockedReasons) != 0 {
+		t.Fatalf("BlockedReasons = %v, want empty", status.BlockedReasons)
+	}
+	if status.Dependencies.Verify != DependencyReady || status.Dependencies.Archive != DependencyBlocked || status.NextRecommended != "verify" {
+		t.Fatalf("verify=%q archive=%q next=%q, want ready/blocked/verify", status.Dependencies.Verify, status.Dependencies.Archive, status.NextRecommended)
+	}
+	if status.RemediationState != (RemediationState{}) {
+		t.Fatalf("RemediationState = %#v, want empty for stale evidence", status.RemediationState)
+	}
+}
+
+func TestBoundReviewKeepsFailedVerdictRemediationRouting(t *testing.T) {
+	root := t.TempDir()
+	changeRoot := seedReadyChange(t, root, "thin", "- [x] 1.1 Done\n")
+	write(t, filepath.Join(changeRoot, "specs", "auth", "spec.md"), "### Requirement: Binding\n#### Scenario: Exact authority\n")
+	writeApprovedCompactAuthorityForChange(t, root, changeRoot, "approved-thin")
+	if _, err := BindApprovedReview(context.Background(), root, "thin", "approved-thin", ""); err != nil {
+		t.Fatal(err)
+	}
+	write(t, filepath.Join(changeRoot, "verify-report.md"), boundedVerifyEnvelope(shaID("a"), "fail"))
+
+	status, err := Resolve(ResolveOptions{CWD: root, ChangeName: "thin"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.Dependencies.Verify != DependencyBlocked || status.NextRecommended != "resolve-review" {
+		t.Fatalf("verify=%q next=%q, want blocked/resolve-review for failed verdict", status.Dependencies.Verify, status.NextRecommended)
+	}
+	want := "verify evidence cannot enter remediation: verdict requires remediation; bounded review transaction is missing"
+	if !strings.Contains(strings.Join(status.BlockedReasons, "\n"), want) {
+		t.Fatalf("BlockedReasons = %v, want containing %q", status.BlockedReasons, want)
+	}
+}
+
 func TestSelectedBindingSupersedesOnlyItsLegacyReviewAuthority(t *testing.T) {
 	root := t.TempDir()
 	changeRoot := seedReadyChange(t, root, "thin", "- [x] 1.1 Done\n")

--- a/internal/sddstatus/review_binding_test.go
+++ b/internal/sddstatus/review_binding_test.go
@@ -475,10 +475,10 @@ func TestBoundReviewRoutesStaleVerifyEvidenceToVerify(t *testing.T) {
 	}
 }
 
-func TestBoundReviewKeepsFailedVerdictRemediationRouting(t *testing.T) {
+func TestBoundReviewKeepsFailedVerdictWithCurrentSpecTotalsMismatchOnRemediationRouting(t *testing.T) {
 	root := t.TempDir()
 	changeRoot := seedReadyChange(t, root, "thin", "- [x] 1.1 Done\n")
-	write(t, filepath.Join(changeRoot, "specs", "auth", "spec.md"), "### Requirement: Binding\n#### Scenario: Exact authority\n")
+	write(t, filepath.Join(changeRoot, "specs", "auth", "spec.md"), "### Requirement: Binding\n#### Scenario: Exact authority\n#### Scenario: Added after verification\n")
 	writeApprovedCompactAuthorityForChange(t, root, changeRoot, "approved-thin")
 	if _, err := BindApprovedReview(context.Background(), root, "thin", "approved-thin", ""); err != nil {
 		t.Fatal(err)
@@ -492,7 +492,7 @@ func TestBoundReviewKeepsFailedVerdictRemediationRouting(t *testing.T) {
 	if status.Dependencies.Verify != DependencyBlocked || status.NextRecommended != "resolve-review" {
 		t.Fatalf("verify=%q next=%q, want blocked/resolve-review for failed verdict", status.Dependencies.Verify, status.NextRecommended)
 	}
-	want := "verify evidence cannot enter remediation: verdict requires remediation; bounded review transaction is missing"
+	want := "verify evidence cannot enter remediation: verify result total 1 does not match actual scenario count 2; bounded review transaction is missing"
 	if !strings.Contains(strings.Join(status.BlockedReasons, "\n"), want) {
 		t.Fatalf("BlockedReasons = %v, want containing %q", status.BlockedReasons, want)
 	}

--- a/internal/sddstatus/review_gate.go
+++ b/internal/sddstatus/review_gate.go
@@ -247,7 +247,7 @@ func applyReviewGate(
 	if status.Dependencies.Verify != DependencyAllDone || !status.TaskProgress.AllComplete {
 		return
 	}
-	applyReviewGateEvaluation(status, resolveReviewAuthority(context.Background(), repo, receiptPath, receiptContent))
+	applyReviewGateEvaluation(status, resolveReviewAuthority(context.Background(), repo, receiptPath, receiptContent, ""))
 }
 
 func applyReviewGateEvaluation(status *Status, evaluation reviewAuthorityEvaluation) {
@@ -258,7 +258,7 @@ func applyReviewGateEvaluation(status *Status, evaluation reviewAuthorityEvaluat
 	blockReviewGate(status, evaluation.Result, evaluation.Reason)
 }
 
-func resolveReviewAuthority(ctx context.Context, repo, receiptPath, receiptContent string) reviewAuthorityEvaluation {
+func resolveReviewAuthority(ctx context.Context, repo, receiptPath, receiptContent, changeName string) reviewAuthorityEvaluation {
 	receiptPayload, ok := readReviewArtifact(receiptPath, receiptContent)
 	if !ok {
 		var err error
@@ -272,6 +272,23 @@ func resolveReviewAuthority(ctx context.Context, repo, receiptPath, receiptConte
 		receipt, err := reviewtransaction.ParseCompactReceipt(receiptPayload)
 		if err != nil {
 			return reviewAuthorityEvaluation{Result: reviewtransaction.GateInvalidated, Reason: fmt.Sprintf("compact review receipt is invalid or non-terminal: %v", err)}
+		}
+		if changeName != "" {
+			store, storeErr := reviewtransaction.CompactAuthoritativeStore(ctx, repo, receipt.LineageID)
+			if storeErr != nil {
+				return reviewAuthorityEvaluation{Result: reviewtransaction.GateInvalidated, Reason: "selected change compact authority cannot be loaded"}
+			}
+			record, loadErr := store.Load()
+			if loadErr != nil {
+				return reviewAuthorityEvaluation{Result: reviewtransaction.GateInvalidated, Reason: "selected change compact authority cannot be loaded"}
+			}
+			bound, reason := compactAuthorityPathsBound(record.State, changeName)
+			if !bound {
+				if reason == "" {
+					reason = fmt.Sprintf("compact review authority is not bound to selected change %q", changeName)
+				}
+				return reviewAuthorityEvaluation{Result: reviewtransaction.GateInvalidated, Reason: reason}
+			}
 		}
 		evaluation = reviewtransaction.EvaluateCompactGate(ctx, repo, receipt, reviewtransaction.NativeGateRequestInput{
 			Gate: reviewtransaction.GatePostApply, LineageID: receipt.LineageID,

--- a/internal/sddstatus/review_gate.go
+++ b/internal/sddstatus/review_gate.go
@@ -234,6 +234,11 @@ func resolveBoundedRemediation(required bool, verify verifyResultEvaluation, tra
 	return state
 }
 
+type reviewAuthorityEvaluation struct {
+	Result reviewtransaction.GateResult
+	Reason string
+}
+
 func applyReviewGate(
 	status *Status,
 	repo string,
@@ -242,50 +247,57 @@ func applyReviewGate(
 	if status.Dependencies.Verify != DependencyAllDone || !status.TaskProgress.AllComplete {
 		return
 	}
+	applyReviewGateEvaluation(status, resolveReviewAuthority(context.Background(), repo, receiptPath, receiptContent))
+}
+
+func applyReviewGateEvaluation(status *Status, evaluation reviewAuthorityEvaluation) {
+	if evaluation.Result == reviewtransaction.GateAllow {
+		status.ReviewGate = &ReviewGateState{Result: evaluation.Result, Reason: evaluation.Reason}
+		return
+	}
+	blockReviewGate(status, evaluation.Result, evaluation.Reason)
+}
+
+func resolveReviewAuthority(ctx context.Context, repo, receiptPath, receiptContent string) reviewAuthorityEvaluation {
 	receiptPayload, ok := readReviewArtifact(receiptPath, receiptContent)
 	if !ok {
 		var err error
-		receiptPayload, err = discoverNativeReceipt(context.Background(), repo)
+		receiptPayload, err = discoverNativeReceipt(ctx, repo)
 		if err != nil {
-			blockReviewGate(status, reviewtransaction.GateInvalidated, err.Error())
-			return
+			return reviewAuthorityEvaluation{Result: reviewtransaction.GateInvalidated, Reason: err.Error()}
 		}
 	}
 	var evaluation reviewtransaction.NativeGateEvaluation
 	if reviewtransaction.CompactReceiptSchemaOf(receiptPayload) == reviewtransaction.CompactReceiptSchema {
 		receipt, err := reviewtransaction.ParseCompactReceipt(receiptPayload)
 		if err != nil {
-			blockReviewGate(status, reviewtransaction.GateInvalidated, fmt.Sprintf("compact review receipt is invalid or non-terminal: %v", err))
-			return
+			return reviewAuthorityEvaluation{Result: reviewtransaction.GateInvalidated, Reason: fmt.Sprintf("compact review receipt is invalid or non-terminal: %v", err)}
 		}
-		evaluation = reviewtransaction.EvaluateCompactGate(context.Background(), repo, receipt, reviewtransaction.NativeGateRequestInput{
+		evaluation = reviewtransaction.EvaluateCompactGate(ctx, repo, receipt, reviewtransaction.NativeGateRequestInput{
 			Gate: reviewtransaction.GatePostApply, LineageID: receipt.LineageID,
 		})
 	} else {
 		receipt, err := reviewtransaction.ParseReceipt(receiptPayload)
 		if err != nil {
-			blockReviewGate(status, reviewtransaction.GateInvalidated, fmt.Sprintf("review receipt is invalid or non-terminal: %v", err))
-			return
+			return reviewAuthorityEvaluation{Result: reviewtransaction.GateInvalidated, Reason: fmt.Sprintf("review receipt is invalid or non-terminal: %v", err)}
 		}
-		request, err := reviewtransaction.BuildNativeGateRequest(context.Background(), repo, reviewtransaction.NativeGateRequestInput{
+		request, err := reviewtransaction.BuildNativeGateRequest(ctx, repo, reviewtransaction.NativeGateRequestInput{
 			Gate: reviewtransaction.GatePostApply, LineageID: receipt.LineageID,
 		})
 		if err != nil {
-			blockReviewGate(status, reviewtransaction.GateInvalidated, fmt.Sprintf("native review gate request cannot be derived: %v", err))
-			return
+			return reviewAuthorityEvaluation{Result: reviewtransaction.GateInvalidated, Reason: fmt.Sprintf("native review gate request cannot be derived: %v", err)}
 		}
-		evaluation = evaluateNativeReviewGate(context.Background(), repo, receipt, request)
+		evaluation = evaluateNativeReviewGate(ctx, repo, receipt, request)
 	}
-	result := evaluation.Result
-	switch result {
+	switch evaluation.Result {
 	case reviewtransaction.GateAllow:
-		status.ReviewGate = &ReviewGateState{Result: result, Reason: "approved receipt exactly matches authoritative native state and the current repository"}
+		return reviewAuthorityEvaluation{Result: evaluation.Result, Reason: "approved receipt exactly matches authoritative native state and the current repository"}
 	case reviewtransaction.GateScopeChanged:
-		blockReviewGate(status, result, "review scope changed; maintainer must create an explicit new lineage without reusing this budget")
+		return reviewAuthorityEvaluation{Result: evaluation.Result, Reason: "review scope changed; maintainer must create an explicit new lineage without reusing this budget"}
 	case reviewtransaction.GateEscalated:
-		blockReviewGate(status, result, "new external evidence or terminal transaction state escalated the receipt without reopening review")
+		return reviewAuthorityEvaluation{Result: evaluation.Result, Reason: "new external evidence or terminal transaction state escalated the receipt without reopening review"}
 	default:
-		blockReviewGate(status, reviewtransaction.GateInvalidated, "review receipt was invalidated by content relationship, policy, ledger, evidence, or publication state; explicit maintainer action is required and no budget resets")
+		return reviewAuthorityEvaluation{Result: reviewtransaction.GateInvalidated, Reason: "review receipt was invalidated by content relationship, policy, ledger, evidence, or publication state; explicit maintainer action is required and no budget resets"}
 	}
 }
 

--- a/internal/sddstatus/status.go
+++ b/internal/sddstatus/status.go
@@ -316,9 +316,11 @@ func Resolve(options ResolveOptions) (Status, error) {
 	// not legacy remediation classification against a missing transaction.
 	var staleAllowAuthority *reviewAuthorityEvaluation
 	if !bindingPresent && reviewState == nil && applyState == ApplyAllDone && artifacts["verifyReport"] == ArtifactDone && verifyResult.Stale {
-		evaluation := resolveReviewAuthority(context.Background(), workspaceRoot, firstPath(artifactPaths.ReviewReceipt), "")
+		evaluation := resolveReviewAuthority(context.Background(), workspaceRoot, firstPath(artifactPaths.ReviewReceipt), "", changeName)
 		if evaluation.Result == reviewtransaction.GateAllow {
 			staleAllowAuthority = &evaluation
+		} else {
+			blockedReasons = append(blockedReasons, evaluation.Reason)
 		}
 	}
 	remediationState := resolveBoundedRemediation(
@@ -513,9 +515,11 @@ func resolveEngramStatus(workspaceRoot string, requestedChange string, includeIn
 	// not legacy remediation classification against a missing transaction.
 	var staleAllowAuthority *reviewAuthorityEvaluation
 	if reviewState == nil && applyState == ApplyAllDone && artifacts["verifyReport"] == ArtifactDone && verifyResult.Stale {
-		evaluation := resolveReviewAuthority(context.Background(), workspaceRoot, "", artifactsByType["review/receipt"].Content)
+		evaluation := resolveReviewAuthority(context.Background(), workspaceRoot, "", artifactsByType["review/receipt"].Content, changeName)
 		if evaluation.Result == reviewtransaction.GateAllow {
 			staleAllowAuthority = &evaluation
+		} else {
+			blockedReasons = append(blockedReasons, evaluation.Reason)
 		}
 	}
 	remediationState := resolveBoundedRemediation(

--- a/internal/sddstatus/status.go
+++ b/internal/sddstatus/status.go
@@ -308,8 +308,21 @@ func Resolve(options ResolveOptions) (Status, error) {
 	coreReady := artifacts["proposal"] == ArtifactDone && artifacts["specs"] == ArtifactDone && artifacts["design"] == ArtifactDone && artifacts["tasks"] == ArtifactDone && taskProgress.Total > 0
 	applyState := resolveApplyState(coreReady, taskProgress)
 	blockedReasons := artifactBlockedReasons(artifacts, taskProgress)
+	bindingPresent, bindingPathErr := bindingExists(context.Background(), workspaceRoot, changeName)
+	if bindingPathErr != nil {
+		return Status{}, bindingPathErr
+	}
+	// Stale evidence under a live allow authority needs a fresh verification,
+	// not legacy remediation classification against a missing transaction.
+	var staleAllowAuthority *reviewAuthorityEvaluation
+	if !bindingPresent && reviewState == nil && applyState == ApplyAllDone && artifacts["verifyReport"] == ArtifactDone && verifyResult.Stale {
+		evaluation := resolveReviewAuthority(context.Background(), workspaceRoot, firstPath(artifactPaths.ReviewReceipt), "")
+		if evaluation.Result == reviewtransaction.GateAllow {
+			staleAllowAuthority = &evaluation
+		}
+	}
 	remediationState := resolveBoundedRemediation(
-		artifacts["verifyReport"] == ArtifactDone && !verifyResult.Passing && applyState == ApplyAllDone,
+		staleAllowAuthority == nil && artifacts["verifyReport"] == ArtifactDone && !verifyResult.Passing && applyState == ApplyAllDone,
 		verifyResult,
 		reviewState,
 		reviewStateReason,
@@ -317,20 +330,25 @@ func Resolve(options ResolveOptions) (Status, error) {
 	)
 	dependencies := resolveDependencies(artifacts, taskProgress, applyState, coreReady, verifyResult.Passing, remediationState.Complete)
 	nextRecommended := resolveNextRecommended(dependencies, applyState, artifacts["verifyReport"] == ArtifactDone, remediationState)
-	var boundGate *ReviewGateState
-	bindingPresent, bindingPathErr := bindingExists(context.Background(), workspaceRoot, changeName)
-	if bindingPathErr != nil {
-		return Status{}, bindingPathErr
+	if staleAllowAuthority != nil {
+		dependencies.Verify = DependencyReady
+		dependencies.Archive = DependencyBlocked
+		nextRecommended = "verify"
 	}
+	var boundGate *ReviewGateState
 	bridge := compactPreVerifyBridge{}
 	recoverable := authorityOnlyFailedReport(readText(firstPath(artifactPaths.VerifyReport)))
 	if bindingPresent {
 		_, evaluation, bindingErr := validateBoundReview(context.Background(), workspaceRoot, changeName)
 		if bindingErr == nil {
-			if applyState == ApplyAllDone && artifacts["verifyReport"] != ArtifactDone {
+			staleEvidence := artifacts["verifyReport"] == ArtifactDone && verifyResult.Stale && reviewState == nil
+			if applyState == ApplyAllDone && (artifacts["verifyReport"] != ArtifactDone || staleEvidence) {
 				dependencies.Verify = DependencyReady
 				dependencies.Archive = DependencyBlocked
 				nextRecommended = "verify"
+				if staleEvidence {
+					remediationState = RemediationState{}
+				}
 			}
 			boundGate = &ReviewGateState{Result: evaluation.Result, Reason: "explicit bound compact authority exactly matches the current repository"}
 		} else {
@@ -369,12 +387,16 @@ func Resolve(options ResolveOptions) (Status, error) {
 	status.RemediationState = remediationState
 	status.ReviewTransaction = reviewState
 	if !bindingPresent {
-		applyReviewGate(
-			&status,
-			workspaceRoot,
-			firstPath(artifactPaths.ReviewReceipt),
-			"",
-		)
+		if staleAllowAuthority != nil {
+			status.ReviewGate = &ReviewGateState{Result: staleAllowAuthority.Result, Reason: staleAllowAuthority.Reason}
+		} else {
+			applyReviewGate(
+				&status,
+				workspaceRoot,
+				firstPath(artifactPaths.ReviewReceipt),
+				"",
+			)
+		}
 	}
 	if boundGate != nil {
 		status.ReviewGate = boundGate
@@ -487,8 +509,17 @@ func resolveEngramStatus(workspaceRoot string, requestedChange string, includeIn
 	coreReady := artifacts["proposal"] == ArtifactDone && artifacts["specs"] == ArtifactDone && artifacts["design"] == ArtifactDone && artifacts["tasks"] == ArtifactDone && taskProgress.Total > 0
 	applyState := resolveApplyState(coreReady, taskProgress)
 	blockedReasons := artifactBlockedReasons(artifacts, taskProgress)
+	// Stale evidence under a live allow authority needs a fresh verification,
+	// not legacy remediation classification against a missing transaction.
+	var staleAllowAuthority *reviewAuthorityEvaluation
+	if reviewState == nil && applyState == ApplyAllDone && artifacts["verifyReport"] == ArtifactDone && verifyResult.Stale {
+		evaluation := resolveReviewAuthority(context.Background(), workspaceRoot, "", artifactsByType["review/receipt"].Content)
+		if evaluation.Result == reviewtransaction.GateAllow {
+			staleAllowAuthority = &evaluation
+		}
+	}
 	remediationState := resolveBoundedRemediation(
-		artifacts["verifyReport"] == ArtifactDone && !verifyResult.Passing && applyState == ApplyAllDone,
+		staleAllowAuthority == nil && artifacts["verifyReport"] == ArtifactDone && !verifyResult.Passing && applyState == ApplyAllDone,
 		verifyResult,
 		reviewState,
 		reviewStateReason,
@@ -499,6 +530,11 @@ func resolveEngramStatus(workspaceRoot string, requestedChange string, includeIn
 	}
 	dependencies := resolveDependencies(artifacts, taskProgress, applyState, coreReady, verifyResult.Passing, remediationState.Complete)
 	nextRecommended := resolveNextRecommended(dependencies, applyState, artifacts["verifyReport"] == ArtifactDone, remediationState)
+	if staleAllowAuthority != nil {
+		dependencies.Verify = DependencyReady
+		dependencies.Archive = DependencyBlocked
+		nextRecommended = "verify"
+	}
 	bridge := compactPreVerifyBridge{}
 	if applyState == ApplyAllDone && artifacts["verifyReport"] != ArtifactDone && compactBridgeableReviewArtifact(artifacts["reviewState"], reviewStateReason) {
 		bridge = discoverCompactPreVerifyAuthority(context.Background(), workspaceRoot, changeName, "")
@@ -520,12 +556,16 @@ func resolveEngramStatus(workspaceRoot string, requestedChange string, includeIn
 	status.ApplyState = applyState
 	status.RemediationState = remediationState
 	status.ReviewTransaction = reviewState
-	applyReviewGate(
-		&status,
-		workspaceRoot,
-		"",
-		artifactsByType["review/receipt"].Content,
-	)
+	if staleAllowAuthority != nil {
+		status.ReviewGate = &ReviewGateState{Result: staleAllowAuthority.Result, Reason: staleAllowAuthority.Reason}
+	} else {
+		applyReviewGate(
+			&status,
+			workspaceRoot,
+			"",
+			artifactsByType["review/receipt"].Content,
+		)
+	}
 	if includeInstructions {
 		instructions := renderPhaseInstructions(status)
 		status.PhaseInstructions = &instructions

--- a/internal/sddstatus/verification.go
+++ b/internal/sddstatus/verification.go
@@ -23,7 +23,10 @@ type verifyCompletion struct {
 }
 
 type verifyResultEvaluation struct {
-	Passing          bool
+	Passing bool
+	// Stale marks evidence whose only defect is a totals mismatch against the
+	// current spec counts; failed verdicts, nonzero exits, and findings never are.
+	Stale            bool
 	Reason           string
 	EvidenceRevision string
 }
@@ -126,11 +129,14 @@ func parseVerifyResult(text string, expected SpecCounts) verifyResultEvaluation 
 		evaluation.Reason = "build_exit_code must be zero for archive readiness"
 		return evaluation
 	}
+	stale := verdict != "fail" && blockers == 0 && critical == 0
 	if requirements.Total != expected.Requirements {
+		evaluation.Stale = stale
 		evaluation.Reason = fmt.Sprintf("verify result total %d does not match actual requirement count %d", requirements.Total, expected.Requirements)
 		return evaluation
 	}
 	if scenarios.Total != expected.Scenarios {
+		evaluation.Stale = stale
 		evaluation.Reason = fmt.Sprintf("verify result total %d does not match actual scenario count %d", scenarios.Total, expected.Scenarios)
 		return evaluation
 	}

--- a/internal/sddstatus/verification.go
+++ b/internal/sddstatus/verification.go
@@ -24,8 +24,8 @@ type verifyCompletion struct {
 
 type verifyResultEvaluation struct {
 	Passing bool
-	// Stale marks evidence whose only defect is a totals mismatch against the
-	// current spec counts; failed verdicts, nonzero exits, and findings never are.
+	// Stale marks internally complete evidence whose only defect is a totals
+	// mismatch against the current spec counts.
 	Stale            bool
 	Reason           string
 	EvidenceRevision string
@@ -129,14 +129,16 @@ func parseVerifyResult(text string, expected SpecCounts) verifyResultEvaluation 
 		evaluation.Reason = "build_exit_code must be zero for archive readiness"
 		return evaluation
 	}
-	stale := verdict != "fail" && blockers == 0 && critical == 0
+	internallyComplete := requirements.Completed == requirements.Total && scenarios.Completed == scenarios.Total
+	totalsMatch := requirements.Total == expected.Requirements && scenarios.Total == expected.Scenarios
+	if !totalsMatch {
+		evaluation.Stale = verdict != "fail" && blockers == 0 && critical == 0 && internallyComplete
+	}
 	if requirements.Total != expected.Requirements {
-		evaluation.Stale = stale
 		evaluation.Reason = fmt.Sprintf("verify result total %d does not match actual requirement count %d", requirements.Total, expected.Requirements)
 		return evaluation
 	}
 	if scenarios.Total != expected.Scenarios {
-		evaluation.Stale = stale
 		evaluation.Reason = fmt.Sprintf("verify result total %d does not match actual scenario count %d", scenarios.Total, expected.Scenarios)
 		return evaluation
 	}

--- a/internal/sddstatus/verification_test.go
+++ b/internal/sddstatus/verification_test.go
@@ -12,6 +12,7 @@ func TestParseVerifyResultFailsClosedAndRequiresCurrentExecutionEvidence(t *test
 		report     string
 		expected   SpecCounts
 		wantPass   bool
+		wantStale  bool
 		wantReason string
 	}{
 		{name: "valid measured result", report: valid, expected: SpecCounts{Requirements: 2, Scenarios: 3}, wantPass: true},
@@ -20,8 +21,10 @@ func TestParseVerifyResultFailsClosedAndRequiresCurrentExecutionEvidence(t *test
 		{name: "missing build command fails closed", report: strings.Replace(valid, "build_command: go test ./cmd/gentle-ai\n", "", 1), expected: SpecCounts{Requirements: 2, Scenarios: 3}, wantReason: "missing build_command"},
 		{name: "failed tests cannot pass", report: testVerifyEnvelope("pass", 0, 0, "2/2", "3/3", 1, 0), expected: SpecCounts{Requirements: 2, Scenarios: 3}, wantReason: "test_exit_code"},
 		{name: "failed build cannot pass", report: testVerifyEnvelope("pass", 0, 0, "2/2", "3/3", 0, 1), expected: SpecCounts{Requirements: 2, Scenarios: 3}, wantReason: "build_exit_code"},
-		{name: "invented requirement total fails", report: valid, expected: SpecCounts{Requirements: 3, Scenarios: 3}, wantReason: "actual requirement count"},
-		{name: "invented scenario total fails", report: valid, expected: SpecCounts{Requirements: 2, Scenarios: 4}, wantReason: "actual scenario count"},
+		{name: "complete requirement total mismatch is stale", report: valid, expected: SpecCounts{Requirements: 3, Scenarios: 3}, wantStale: true, wantReason: "actual requirement count"},
+		{name: "complete scenario total mismatch is stale", report: valid, expected: SpecCounts{Requirements: 2, Scenarios: 4}, wantStale: true, wantReason: "actual scenario count"},
+		{name: "incomplete requirements are not stale", report: testVerifyEnvelope("pass", 0, 0, "1/2", "3/3", 0, 0), expected: SpecCounts{Requirements: 3, Scenarios: 3}, wantReason: "actual requirement count"},
+		{name: "incomplete scenarios are not stale", report: testVerifyEnvelope("pass", 0, 0, "2/2", "2/3", 0, 0), expected: SpecCounts{Requirements: 2, Scenarios: 4}, wantReason: "actual scenario count"},
 	}
 
 	for _, tt := range tests {
@@ -29,6 +32,9 @@ func TestParseVerifyResultFailsClosedAndRequiresCurrentExecutionEvidence(t *test
 			got := parseVerifyResult(tt.report, tt.expected)
 			if got.Passing != tt.wantPass {
 				t.Fatalf("Passing = %v, want %v (reason %q)", got.Passing, tt.wantPass, got.Reason)
+			}
+			if got.Stale != tt.wantStale {
+				t.Fatalf("Stale = %v, want %v (reason %q)", got.Stale, tt.wantStale, got.Reason)
 			}
 			if tt.wantReason != "" && !strings.Contains(got.Reason, tt.wantReason) {
 				t.Fatalf("Reason = %q, want containing %q", got.Reason, tt.wantReason)


### PR DESCRIPTION
Fixes #1396

## Summary

Fixes the stale-evidence variant reported in #1243: the SDD dispatcher routed to `resolve-review` with contradictory state (`reviewGate.result: allow` + `verify: blocked`) when a valid compact review authority existed but the verify report's requirement/scenario totals no longer matched the current spec.

The dispatcher now resolves compact authority before classifying verification remediation:

- `parseVerifyResult` marks evidence as stale when its only defect is a totals mismatch against current spec counts. Failed verdicts, nonzero exit codes, and open findings are never stale.
- With a valid explicit compact binding, or a discovered approved compact receipt whose gate evaluates to `allow`, stale evidence routes to `verify` (fresh verification) instead of the legacy remediation path, so `bounded review transaction is missing` is no longer emitted for a transaction the compact model never creates.
- Archive stays blocked until fresh verification passes.
- Without valid compact authority, behavior is unchanged, including all legacy remediation messages.

## Routing after this change

| State | Before | After |
| --- | --- | --- |
| Valid compact authority + stale verify report | `resolve-review`, verify blocked | `verify`, verify ready |
| Valid compact authority + failed verdict | unchanged | unchanged |
| No compact authority + stale verify report | unchanged | unchanged |

## Tests

- Regression tests for the OpenSpec and Engram resolvers: approved compact receipt, all tasks complete, spec with 17 scenarios, verify report declaring 16, no legacy `reviews/transaction.json` → `reviewGate: allow`, `blockedReasons: []`, `nextRecommended: verify`, `verify: ready`, `archive: blocked`.
- Guard test: failed verdict with matching totals keeps the existing remediation classification.
- Written TDD-first; each regression test failed for the expected reason before the fix.

Refs #1243 (stale-evidence variant; the failed-verdict remediation routing remains in scope for that issue's existing fix).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved review/remediation routing when verification evidence is stale under approved compact authority: the review gate can proceed to verification without triggering remediation.
  * For foreign (not-bound) compact authority or failed bounded verification, verification remains blocked and the next step is shifted to resolve-review (not remediation), with clear blocked reasons.
  * Improved totals-mismatch handling by more reliably classifying certain mismatches as stale vs failed based on evidence completeness.
* **Tests**
  * Added/expanded coverage for stale/failed bounded verification and review-gate routing across both native and Engram flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->