### PR TITLE
fix(review): accept exact change-local receipt mirror in untracked scope

### DIFF
--- a/internal/reviewtransaction/compact_gate.go
+++ b/internal/reviewtransaction/compact_gate.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"reflect"
 	"sort"
 	"strings"
@@ -452,6 +453,9 @@ func validateCompactUntrackedScope(ctx context.Context, repo string, state Compa
 		if _, ok := allowed[path]; ok || isPostReviewLifecycleArtifact(path) {
 			continue
 		}
+		if isChangeLocalReceiptMirror(path) && matchesAuthoritativeReceipt(repo, state, path) {
+			continue
+		}
 		return errors.New("current repository contains untracked paths outside the authoritative review scope")
 	}
 	return nil
@@ -492,4 +496,28 @@ func validateCompactPublicationRange(ctx context.Context, repo string, genesis [
 func isPostReviewLifecycleArtifact(path string) bool {
 	parts := strings.Split(path, "/")
 	return len(parts) == 4 && parts[0] == "openspec" && parts[1] == "changes" && parts[3] == "verify-report.md"
+}
+
+func isChangeLocalReceiptMirror(path string) bool {
+	parts := strings.Split(path, "/")
+	return len(parts) == 5 && parts[0] == "openspec" && parts[1] == "changes" && parts[3] == "reviews" && parts[4] == "receipt.json"
+}
+
+// matchesAuthoritativeReceipt exempts only a change-local mirror whose content
+// equals the receipt derived from the terminal authority; anything else stays
+// outside the authoritative review scope and fails closed.
+func matchesAuthoritativeReceipt(repo string, state CompactState, path string) bool {
+	authoritative, err := state.Receipt()
+	if err != nil {
+		return false
+	}
+	payload, err := os.ReadFile(filepath.Join(repo, filepath.FromSlash(path)))
+	if err != nil {
+		return false
+	}
+	mirror, err := ParseCompactReceipt(payload)
+	if err != nil {
+		return false
+	}
+	return CompactReceiptEqual(mirror, authoritative)
 }

--- a/internal/reviewtransaction/compact_gate_test.go
+++ b/internal/reviewtransaction/compact_gate_test.go
@@ -315,6 +315,71 @@ func TestCompactPostApplyRejectsUnboundUntrackedPathAfterCommit(t *testing.T) {
 	}
 }
 
+func TestCompactPostApplyExemptsExactChangeLocalReceiptMirror(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	writeSnapshotFile(t, repo, "tracked.txt", "approved candidate\n")
+	state := newCompactStartStateForTarget(t, repo, "compact-receipt-mirror-exact", Target{Kind: TargetCurrentChanges, IntendedUntracked: []string{}})
+	state, receipt := persistApprovedCompactState(t, repo, state)
+	gitSnapshot(t, repo, "add", "tracked.txt")
+	gitSnapshot(t, repo, "commit", "-m", "reviewed candidate")
+
+	mirror := filepath.Join(repo, "openspec", "changes", "thin", "reviews", "receipt.json")
+	if err := os.MkdirAll(filepath.Dir(mirror), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteCompactReceiptAtomic(mirror, receipt); err != nil {
+		t.Fatal(err)
+	}
+
+	got := EvaluateCompactGate(context.Background(), repo, receipt, NativeGateRequestInput{Gate: GatePostApply, LineageID: state.LineageID})
+	if got.Result != GateAllow {
+		t.Fatalf("exact change-local receipt mirror = %#v", got)
+	}
+}
+
+func TestCompactPostApplyRejectsMismatchedChangeLocalReceiptMirror(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload func(t *testing.T, receipt CompactReceipt) []byte
+	}{
+		{name: "divergent receipt", payload: func(t *testing.T, receipt CompactReceipt) []byte {
+			tampered := receipt
+			tampered.Generation++
+			payload, err := json.MarshalIndent(tampered, "", "  ")
+			if err != nil {
+				t.Fatal(err)
+			}
+			return append(payload, '\n')
+		}},
+		{name: "malformed payload", payload: func(t *testing.T, receipt CompactReceipt) []byte {
+			return []byte("{\"schema\":\"tampered\"}\n")
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := initSnapshotRepo(t)
+			writeSnapshotFile(t, repo, "tracked.txt", "approved candidate\n")
+			state := newCompactStartStateForTarget(t, repo, "compact-receipt-mirror-"+strings.ReplaceAll(tt.name, " ", "-"), Target{Kind: TargetCurrentChanges, IntendedUntracked: []string{}})
+			state, receipt := persistApprovedCompactState(t, repo, state)
+			gitSnapshot(t, repo, "add", "tracked.txt")
+			gitSnapshot(t, repo, "commit", "-m", "reviewed candidate")
+
+			mirror := filepath.Join(repo, "openspec", "changes", "thin", "reviews", "receipt.json")
+			if err := os.MkdirAll(filepath.Dir(mirror), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(mirror, tt.payload(t, receipt), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			got := EvaluateCompactGate(context.Background(), repo, receipt, NativeGateRequestInput{Gate: GatePostApply, LineageID: state.LineageID})
+			if got.Result == GateAllow {
+				t.Fatalf("mismatched change-local receipt mirror = %#v", got)
+			}
+		})
+	}
+}
+
 func TestCompactFixDiffUsesAuthoritativeCorrectionBindingAcrossDelivery(t *testing.T) {
 	t.Run("uncommitted pre-commit", func(t *testing.T) {
 		repo, state, receipt, _ := approvedCompactFixDiffFixture(t, "compact-fix-pre-commit")


### PR DESCRIPTION
## Summary

Fixes #1362: the change-local receipt mirror `openspec/changes/<change>/reviews/receipt.json` — which `sdd-status` requires to disambiguate multiple terminal native receipts — was rejected by `validateCompactUntrackedScope` at post-apply/pre-commit as an untracked path outside the authoritative review scope, recursively invalidating the very authority it selects.

`validateCompactUntrackedScope` now exempts a live untracked receipt mirror only when its parsed content equals the receipt derived from the terminal authority (`state.Receipt()` + `ParseCompactReceipt` + `CompactReceiptEqual`, the same parsed-vs-derived identity mechanism the facade already uses). Everything else stays fail-closed:

- A divergent receipt (different lineage, generation, or terminal state) still fails.
- A malformed payload still fails.
- A non-terminal authority still fails (`state.Receipt()` errors → deny).
- The exemption fires only inside the existing post-apply/pre-commit non-staged path; staged projection, ambiguity, and every other gate are unchanged.

## Tests

- `TestCompactPostApplyExemptsExactChangeLocalReceiptMirror`: approved compact state, committed candidate, exact mirror → gate allows.
- `TestCompactPostApplyRejectsMismatchedChangeLocalReceiptMirror`: divergent-receipt and malformed-payload subtests → gate keeps failing closed.
- Written TDD-first: the exemption test failed on the v2.1.7 baseline with exactly the recursion from the issue (`current repository contains untracked paths outside the authoritative review scope`) while both fail-closed guards already passed.

Refs #1362


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated compact review scope validation to allow exact change-local `receipt.json` mirrors under `openspec/changes/*/reviews/` when the mirrored receipt matches the authoritative receipt.
  * Receipt mirrors that are mismatched, tampered, or malformed are still rejected.

* **Tests**
  * Added Post-Apply gate tests covering acceptance of exact mirrors and rejection of altered or invalid mirror contents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->