### PR TITLE
fix(sdd-status): reject incompatible Engram review transaction artifacts

### DIFF
--- a/internal/sddstatus/bounded_review_test.go
+++ b/internal/sddstatus/bounded_review_test.go
@@ -359,6 +359,108 @@ func boundedEngramObservations(t *testing.T, project, changeRoot string) []engra
 	}
 }
 
+const incompatibleTransactionSummary = "# Native Review Transaction\n\n- lineage: thin-lineage\n- state: approved\n"
+
+func TestReadReviewTransactionRejectsIncompatibleNonJSONArtifact(t *testing.T) {
+	markdownPath := filepath.Join(t.TempDir(), "transaction.json")
+	write(t, markdownPath, incompatibleTransactionSummary)
+	for _, tt := range []struct {
+		name    string
+		path    string
+		content string
+	}{
+		{name: "engram markdown content", content: incompatibleTransactionSummary},
+		{name: "markdown transaction mirror", path: markdownPath},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			transaction, reason := readReviewTransaction(tt.path, tt.content)
+			if transaction != nil {
+				t.Fatalf("readReviewTransaction() = %#v, want nil transaction", transaction)
+			}
+			if strings.Contains(reason, "invalid character") {
+				t.Fatalf("readReviewTransaction() reason = %q, want compatibility reason instead of raw JSON parse error", reason)
+			}
+			if !strings.Contains(reason, "not a native JSON review transaction") {
+				t.Fatalf("readReviewTransaction() reason = %q, want incompatible-artifact reason", reason)
+			}
+		})
+	}
+}
+
+func TestResolveEngramBridgesCompactAuthorityOverIncompatibleTransactionArtifact(t *testing.T) {
+	root := t.TempDir()
+	changeRoot := seedReadyChange(t, root, "thin", "- [x] 1.1 Done\n")
+	writeApprovedCompactAuthorityForChange(t, root, changeRoot, "compact-thin")
+	mkdir(t, filepath.Join(root, ".engram"))
+	project := strings.ToLower(filepath.Base(root))
+	observation := func(title, path string) engramObservation {
+		payload, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return engramObservation{Title: title, Content: string(payload), Project: project, Scope: "project"}
+	}
+	observations := []engramObservation{
+		observation("sdd/thin/proposal", filepath.Join(changeRoot, "proposal.md")),
+		observation("sdd/thin/spec", filepath.Join(changeRoot, "specs", "auth", "spec.md")),
+		observation("sdd/thin/design", filepath.Join(changeRoot, "design.md")),
+		observation("sdd/thin/tasks", filepath.Join(changeRoot, "tasks.md")),
+		{Title: "sdd/thin/apply-progress", Content: "all work units complete", Project: project, Scope: "project"},
+		{Title: "sdd/thin/review/transaction", Content: incompatibleTransactionSummary, Project: project, Scope: "project"},
+	}
+	restore := stubEngramExport(t, observations)
+	defer restore()
+
+	status, ok, err := resolveEngramStatus(root, "thin", false)
+	if err != nil {
+		t.Fatalf("resolveEngramStatus() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("resolveEngramStatus() did not retain the Engram change")
+	}
+	if status.ReviewTransaction != nil {
+		t.Fatalf("ReviewTransaction = %#v, want incompatible artifact treated as missing", status.ReviewTransaction)
+	}
+	reasons := strings.Join(status.BlockedReasons, "\n")
+	if strings.Contains(reasons, "invalid character") {
+		t.Fatalf("BlockedReasons = %v, want no raw JSON parse error", status.BlockedReasons)
+	}
+	if status.Dependencies.Verify != DependencyReady || status.NextRecommended != "verify" {
+		t.Fatalf("verify=%q next=%q reasons=%v, want compact authority bridged to ready/verify", status.Dependencies.Verify, status.NextRecommended, status.BlockedReasons)
+	}
+}
+
+func TestResolveEngramFailsClosedOnIncompatibleTransactionWithoutNativeAuthority(t *testing.T) {
+	root := t.TempDir()
+	mkdir(t, filepath.Join(root, ".engram"))
+	project := strings.ToLower(filepath.Base(root))
+	observations := []engramObservation{
+		{Title: "sdd/thin/proposal", Content: "# Proposal\n", Project: project, Scope: "project"},
+		{Title: "sdd/thin/spec", Content: "### Requirement: Auth\n#### Scenario: Valid login\n", Project: project, Scope: "project"},
+		{Title: "sdd/thin/design", Content: "# Design\n", Project: project, Scope: "project"},
+		{Title: "sdd/thin/tasks", Content: "- [x] 1.1 Done\n", Project: project, Scope: "project"},
+		{Title: "sdd/thin/apply-progress", Content: "all work units complete", Project: project, Scope: "project"},
+		{Title: "sdd/thin/review/transaction", Content: incompatibleTransactionSummary, Project: project, Scope: "project"},
+	}
+	restore := stubEngramExport(t, observations)
+	defer restore()
+
+	status, ok, err := resolveEngramStatus(root, "thin", false)
+	if err != nil {
+		t.Fatalf("resolveEngramStatus() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("resolveEngramStatus() did not retain the Engram change")
+	}
+	reasons := strings.Join(status.BlockedReasons, "\n")
+	if strings.Contains(reasons, "invalid character") {
+		t.Fatalf("BlockedReasons = %v, want no raw JSON parse error", status.BlockedReasons)
+	}
+	if status.Dependencies.Verify != DependencyBlocked || !strings.Contains(reasons, "not a native JSON review transaction") {
+		t.Fatalf("verify=%q reasons=%v, want fail-closed compatibility reason", status.Dependencies.Verify, status.BlockedReasons)
+	}
+}
+
 func TestResolveFinalVerifyWaitsForAllTasks(t *testing.T) {
 	root := t.TempDir()
 	changeRoot := seedReadyChange(t, root, "thin", "- [x] 1.1 Done\n- [ ] 1.2 Pending\n")

--- a/internal/sddstatus/bounded_review_test.go
+++ b/internal/sddstatus/bounded_review_test.go
@@ -387,6 +387,17 @@ func TestReadReviewTransactionRejectsIncompatibleNonJSONArtifact(t *testing.T) {
 	}
 }
 
+func TestReadReviewTransactionRejectsJSONNonObjectsAsInvalid(t *testing.T) {
+	for _, payload := range []string{`[]`, `null`, `"legacy"`} {
+		t.Run(payload, func(t *testing.T) {
+			transaction, reason := readReviewTransaction("", payload)
+			if transaction != nil || !strings.Contains(reason, "bounded review transaction is invalid") {
+				t.Fatalf("readReviewTransaction() = (%#v, %q), want invalid native transaction", transaction, reason)
+			}
+		})
+	}
+}
+
 func TestResolveEngramBridgesCompactAuthorityOverIncompatibleTransactionArtifact(t *testing.T) {
 	root := t.TempDir()
 	changeRoot := seedReadyChange(t, root, "thin", "- [x] 1.1 Done\n")
@@ -467,6 +478,16 @@ func TestResolveEngramDoesNotBridgeCompactAuthorityOverMalformedJSONTransaction(
 	}
 	if !strings.Contains(reasons, "bounded review transaction is invalid") {
 		t.Fatalf("BlockedReasons = %v, want malformed JSON reason", status.BlockedReasons)
+	}
+	for _, payload := range []string{`[]`, `null`, `"legacy"`} {
+		observations[len(observations)-1].Content = payload
+		status, _, err = resolveEngramStatus(root, "thin", false)
+		if err != nil {
+			t.Fatalf("resolveEngramStatus(%s) error = %v", payload, err)
+		}
+		if status.Dependencies.Verify != DependencyBlocked || status.NextRecommended != "review" {
+			t.Fatalf("payload=%s verify=%q next=%q, want blocked/review", payload, status.Dependencies.Verify, status.NextRecommended)
+		}
 	}
 }
 

--- a/internal/sddstatus/bounded_review_test.go
+++ b/internal/sddstatus/bounded_review_test.go
@@ -430,6 +430,46 @@ func TestResolveEngramBridgesCompactAuthorityOverIncompatibleTransactionArtifact
 	}
 }
 
+func TestResolveEngramDoesNotBridgeCompactAuthorityOverMalformedJSONTransaction(t *testing.T) {
+	root := t.TempDir()
+	changeRoot := seedReadyChange(t, root, "thin", "- [x] 1.1 Done\n")
+	writeApprovedCompactAuthorityForChange(t, root, changeRoot, "compact-thin")
+	mkdir(t, filepath.Join(root, ".engram"))
+	project := strings.ToLower(filepath.Base(root))
+	observation := func(title, path string) engramObservation {
+		payload, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return engramObservation{Title: title, Content: string(payload), Project: project, Scope: "project"}
+	}
+	observations := []engramObservation{
+		observation("sdd/thin/proposal", filepath.Join(changeRoot, "proposal.md")),
+		observation("sdd/thin/spec", filepath.Join(changeRoot, "specs", "auth", "spec.md")),
+		observation("sdd/thin/design", filepath.Join(changeRoot, "design.md")),
+		observation("sdd/thin/tasks", filepath.Join(changeRoot, "tasks.md")),
+		{Title: "sdd/thin/apply-progress", Content: "all work units complete", Project: project, Scope: "project"},
+		{Title: "sdd/thin/review/transaction", Content: `{"state":`, Project: project, Scope: "project"},
+	}
+	restore := stubEngramExport(t, observations)
+	defer restore()
+
+	status, ok, err := resolveEngramStatus(root, "thin", false)
+	if err != nil {
+		t.Fatalf("resolveEngramStatus() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("resolveEngramStatus() did not retain the Engram change")
+	}
+	reasons := strings.Join(status.BlockedReasons, "\n")
+	if status.Dependencies.Verify != DependencyBlocked || status.NextRecommended != "review" {
+		t.Fatalf("verify=%q next=%q reasons=%v, want malformed JSON to remain blocked on review", status.Dependencies.Verify, status.NextRecommended, status.BlockedReasons)
+	}
+	if !strings.Contains(reasons, "bounded review transaction is invalid") {
+		t.Fatalf("BlockedReasons = %v, want malformed JSON reason", status.BlockedReasons)
+	}
+}
+
 func TestResolveEngramFailsClosedOnIncompatibleTransactionWithoutNativeAuthority(t *testing.T) {
 	root := t.TempDir()
 	mkdir(t, filepath.Join(root, ".engram"))

--- a/internal/sddstatus/review_gate.go
+++ b/internal/sddstatus/review_gate.go
@@ -2,6 +2,7 @@ package sddstatus
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -166,6 +167,9 @@ func readReviewTransaction(path, content string) (*reviewtransaction.Transaction
 		payload = read
 	}
 	if !strings.HasPrefix(strings.TrimSpace(string(payload)), "{") {
+		if json.Valid(payload) {
+			return nil, "bounded review transaction is invalid: native review transaction must be a JSON object"
+		}
 		return nil, incompatibleReviewTransactionReason
 	}
 	transaction, err := reviewtransaction.ParseTransaction(payload)

--- a/internal/sddstatus/review_gate.go
+++ b/internal/sddstatus/review_gate.go
@@ -163,6 +163,9 @@ func readReviewTransaction(path, content string) (*reviewtransaction.Transaction
 		}
 		payload = read
 	}
+	if !strings.HasPrefix(strings.TrimSpace(string(payload)), "{") {
+		return nil, "bounded review transaction artifact is not a native JSON review transaction; regenerate it from native review authority"
+	}
 	transaction, err := reviewtransaction.ParseTransaction(payload)
 	if err != nil {
 		return nil, fmt.Sprintf("bounded review transaction is invalid: %v", err)

--- a/internal/sddstatus/review_gate.go
+++ b/internal/sddstatus/review_gate.go
@@ -151,6 +151,8 @@ func readText(path string) string {
 	return string(content)
 }
 
+const incompatibleReviewTransactionReason = "bounded review transaction artifact is not a native JSON review transaction; regenerate it from native review authority"
+
 func readReviewTransaction(path, content string) (*reviewtransaction.Transaction, string) {
 	if path == "" && strings.TrimSpace(content) == "" {
 		return nil, "bounded review transaction is missing"
@@ -164,7 +166,7 @@ func readReviewTransaction(path, content string) (*reviewtransaction.Transaction
 		payload = read
 	}
 	if !strings.HasPrefix(strings.TrimSpace(string(payload)), "{") {
-		return nil, "bounded review transaction artifact is not a native JSON review transaction; regenerate it from native review authority"
+		return nil, incompatibleReviewTransactionReason
 	}
 	transaction, err := reviewtransaction.ParseTransaction(payload)
 	if err != nil {

--- a/internal/sddstatus/status.go
+++ b/internal/sddstatus/status.go
@@ -499,7 +499,14 @@ func resolveEngramStatus(workspaceRoot string, requestedChange string, includeIn
 	}
 	dependencies := resolveDependencies(artifacts, taskProgress, applyState, coreReady, verifyResult.Passing, remediationState.Complete)
 	nextRecommended := resolveNextRecommended(dependencies, applyState, artifacts["verifyReport"] == ArtifactDone, remediationState)
-	applyPreVerifyReviewRouting(&dependencies, &nextRecommended, &blockedReasons, applyState, artifacts["verifyReport"] == ArtifactDone, reviewState, reviewStateReason)
+	bridge := compactPreVerifyBridge{}
+	if applyState == ApplyAllDone && artifacts["verifyReport"] != ArtifactDone && reviewState == nil {
+		bridge = discoverCompactPreVerifyAuthority(context.Background(), workspaceRoot, changeName, "")
+	}
+	applyPreVerifyCompactBridgeRouting(&dependencies, &nextRecommended, &blockedReasons, applyState, artifacts["verifyReport"] == ArtifactDone, reviewState, bridge)
+	if !bridge.Eligible && !bridge.Relevant {
+		applyPreVerifyReviewRouting(&dependencies, &nextRecommended, &blockedReasons, applyState, artifacts["verifyReport"] == ArtifactDone, reviewState, reviewStateReason)
+	}
 
 	changeRoot := fmt.Sprintf("engram:sdd/%s", changeName)
 	status := baseStatus(workspaceRoot, &changeName, &changeRoot, nextRecommended, blockedReasons)

--- a/internal/sddstatus/status.go
+++ b/internal/sddstatus/status.go
@@ -339,7 +339,7 @@ func Resolve(options ResolveOptions) (Status, error) {
 			nextRecommended = "resolve-review"
 			blockedReasons = append(blockedReasons, bindingErr.Error())
 		}
-	} else if applyState == ApplyAllDone && (artifacts["verifyReport"] != ArtifactDone || recoverable) && reviewState == nil {
+	} else if applyState == ApplyAllDone && (artifacts["verifyReport"] != ArtifactDone || recoverable) && compactBridgeableReviewArtifact(artifacts["reviewState"], reviewStateReason) {
 		fields, _ := authorityFailureFields(readText(firstPath(artifactPaths.VerifyReport)))
 		bridge = discoverCompactPreVerifyAuthority(context.Background(), workspaceRoot, changeName, fields["observed_authority_revision"])
 	}
@@ -500,7 +500,7 @@ func resolveEngramStatus(workspaceRoot string, requestedChange string, includeIn
 	dependencies := resolveDependencies(artifacts, taskProgress, applyState, coreReady, verifyResult.Passing, remediationState.Complete)
 	nextRecommended := resolveNextRecommended(dependencies, applyState, artifacts["verifyReport"] == ArtifactDone, remediationState)
 	bridge := compactPreVerifyBridge{}
-	if applyState == ApplyAllDone && artifacts["verifyReport"] != ArtifactDone && reviewState == nil {
+	if applyState == ApplyAllDone && artifacts["verifyReport"] != ArtifactDone && compactBridgeableReviewArtifact(artifacts["reviewState"], reviewStateReason) {
 		bridge = discoverCompactPreVerifyAuthority(context.Background(), workspaceRoot, changeName, "")
 	}
 	applyPreVerifyCompactBridgeRouting(&dependencies, &nextRecommended, &blockedReasons, applyState, artifacts["verifyReport"] == ArtifactDone, reviewState, bridge)
@@ -531,6 +531,10 @@ func resolveEngramStatus(workspaceRoot string, requestedChange string, includeIn
 		status.PhaseInstructions = &instructions
 	}
 	return status, true, nil
+}
+
+func compactBridgeableReviewArtifact(state ArtifactState, reason string) bool {
+	return state == ArtifactMissing || reason == incompatibleReviewTransactionReason
 }
 
 func blockedEngramStatus(workspaceRoot string, changeName *string, next string, reasons []string, includeInstructions bool) Status {


### PR DESCRIPTION
## Summary

Fixes #1272: `sdd-status` fed Engram `review/transaction` artifacts straight into the strict JSON decoder, so an incompatible Markdown summary (`# Native Review Transaction ...`) surfaced as the misleading blocker `bounded review transaction is invalid: invalid character '#' looking for beginning of value` and falsely demanded a new review while native authority was healthy.

- `readReviewTransaction` now sniffs the payload before strict decoding: content that is not a JSON object returns an accurate compatibility reason (`bounded review transaction artifact is not a native JSON review transaction; regenerate it from native review authority`) and is treated like a missing transaction. JSON-shaped-but-malformed content still surfaces the real parse error. The sniff covers both Engram content and filesystem transaction mirrors.
- `resolveEngramStatus` now mirrors the filesystem resolver's native-authority fallback: with apply all-done, no verify report, and a missing/incompatible transaction, it discovers path-bound approved compact authority and routes to `verify` through the existing bridge machinery instead of demanding a new review. Without eligible authority it fails closed carrying the accurate compatibility reason.

Deliberately out of scope: lineage-aware selection among multiple same-title Engram observations — the export schema carries no lineage metadata, and the concrete harm (a stale Markdown summary winning selection) is neutralized because non-JSON artifacts now defer to native successor authority.

## Tests

- `TestReadReviewTransactionRejectsIncompatibleNonJSONArtifact` (Engram content + on-disk mirror variants)
- `TestResolveEngramBridgesCompactAuthorityOverIncompatibleTransactionArtifact` (valid successor compact authority → verify ready, no parse error)
- `TestResolveEngramFailsClosedOnIncompatibleTransactionWithoutNativeAuthority` (no authority → blocked with the compatibility reason)
- Written TDD-first; all three reproduced the issue's exact symptom before the fix.

Refs #1272


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of incompatible (non-native JSON) review artifacts so they’re treated as unavailable rather than surfacing parsing errors.
  * Updated verification status routing to more accurately account for when compact authority bridging should occur, preventing incorrect advancement.
  * Ensured fail-closed behavior when compatible artifacts aren’t available and no native authority can be used.
* **Tests**
  * Added/extended coverage for rejecting incompatible artifacts (including invalid JSON shapes), compact-authority bridging behavior, and fail-closed scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->