### PR TITLE
fix(review): emit START binding inputs and stop plugin lens rewrite

### DIFF
--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -34,6 +34,7 @@ type ReviewFacadeStartResult struct {
 	State            reviewtransaction.State      `json:"state"`
 	RiskLevel        reviewtransaction.RiskLevel  `json:"risk_level"`
 	SelectedLenses   []string                     `json:"selected_lenses"`
+	LensBindings     []ReviewFacadeLensBinding    `json:"lens_bindings"`
 	Projection       reviewtransaction.Projection `json:"projection"`
 	TargetMode       reviewtransaction.TargetKind `json:"target_mode,omitempty"`
 	TargetIdentity   string                       `json:"target_identity,omitempty"`
@@ -42,6 +43,21 @@ type ReviewFacadeStartResult struct {
 	ChangedFiles     int                          `json:"changed_files"`
 	ChangedLines     int                          `json:"changed_lines"`
 	CorrectionBudget int                          `json:"correction_budget"`
+}
+
+// ReviewFacadeLensBinding pairs one selected lens with its frozen zero-based
+// order so orchestrators build capture bindings exclusively from START output.
+type ReviewFacadeLensBinding struct {
+	Lens  string `json:"lens"`
+	Order int    `json:"order"`
+}
+
+func facadeLensBindings(lenses []string) []ReviewFacadeLensBinding {
+	bindings := make([]ReviewFacadeLensBinding, len(lenses))
+	for order, lens := range lenses {
+		bindings[order] = ReviewFacadeLensBinding{Lens: lens, Order: order}
+	}
+	return bindings
 }
 
 func facadeProjection(projection reviewtransaction.Projection) reviewtransaction.Projection {
@@ -726,13 +742,13 @@ func runReviewFacadeStart(ctx context.Context, args []string, stdout io.Writer) 
 	legacyResult := ReviewFacadeStartResult{
 		Operation: "review/start", Action: string(started.Action), LensesRequired: started.LensesRequired,
 		LineageID: authority.LineageID, State: authority.State, RiskLevel: authority.RiskLevel,
-		SelectedLenses: append([]string{}, authority.SelectedLenses...), Projection: facadeProjection(authority.InitialSnapshot.Projection),
-		ChangedFiles: len(authority.InitialSnapshot.Paths),
+		SelectedLenses: append([]string{}, authority.SelectedLenses...), LensBindings: facadeLensBindings(authority.SelectedLenses),
+		Projection:   facadeProjection(authority.InitialSnapshot.Projection),
+		ChangedFiles: len(authority.InitialSnapshot.Paths), TargetIdentity: authority.InitialSnapshot.Identity,
 		ChangedLines: authority.OriginalChangedLines, CorrectionBudget: authority.CorrectionBudget,
 	}
 	if authority.InitialSnapshot.Kind == reviewtransaction.TargetBaseWorkspaceOverlay {
 		legacyResult.TargetMode = authority.InitialSnapshot.Kind
-		legacyResult.TargetIdentity = authority.InitialSnapshot.Identity
 		legacyResult.BaseTree = authority.InitialSnapshot.BaseTree
 		legacyResult.CandidateTree = authority.InitialSnapshot.CandidateTree
 	}

--- a/internal/cli/review_facade_test.go
+++ b/internal/cli/review_facade_test.go
@@ -74,6 +74,38 @@ func TestReviewFacadeStartStagedProjectionFreezesOnlyIndex(t *testing.T) {
 	}
 }
 
+func TestReviewFacadeStartEmitsCaptureBindingInputs(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("base\ncandidate\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	started := startFacadeReview(t, repo)
+	store, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, started.LineageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	record, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if started.Action != "created" || started.TargetIdentity != record.State.InitialSnapshot.Identity {
+		t.Fatalf("start target identity = %q, want frozen %q (action %q)", started.TargetIdentity, record.State.InitialSnapshot.Identity, started.Action)
+	}
+	if len(started.SelectedLenses) == 0 || len(started.LensBindings) != len(started.SelectedLenses) {
+		t.Fatalf("start lens bindings = %#v, want one per selected lens %v", started.LensBindings, started.SelectedLenses)
+	}
+	for index, binding := range started.LensBindings {
+		if binding.Lens != started.SelectedLenses[index] || binding.Order != index {
+			t.Fatalf("lens binding[%d] = %#v, want {%q %d}", index, binding, started.SelectedLenses[index], index)
+		}
+	}
+	resumed := startFacadeReview(t, repo)
+	if resumed.Action != "resumed" || resumed.TargetIdentity != started.TargetIdentity ||
+		!reflect.DeepEqual(resumed.LensBindings, started.LensBindings) {
+		t.Fatalf("resumed binding inputs = %#v, want %#v", resumed, started)
+	}
+}
+
 func TestReviewFacadeStartReusesStagedAuthorityForCommittedBaseDiff(t *testing.T) {
 	repo := initReviewCLIRepo(t)
 	base := strings.TrimSpace(runReviewCLIGit(t, repo, "rev-parse", "HEAD"))
@@ -542,7 +574,7 @@ func TestReviewFacadeStartUnnegotiatedJSONFieldSetRemainsCompatible(t *testing.T
 	if err := json.Unmarshal(output.Bytes(), &fields); err != nil {
 		t.Fatal(err)
 	}
-	want := []string{"action", "changed_files", "changed_lines", "correction_budget", "lenses_required", "lineage_id", "operation", "projection", "risk_level", "selected_lenses", "state"}
+	want := []string{"action", "changed_files", "changed_lines", "correction_budget", "lens_bindings", "lenses_required", "lineage_id", "operation", "projection", "risk_level", "selected_lenses", "state", "target_identity"}
 	got := make([]string, 0, len(fields))
 	for field := range fields {
 		got = append(got, field)

--- a/internal/cli/review_start_contract_test.go
+++ b/internal/cli/review_start_contract_test.go
@@ -635,8 +635,8 @@ func TestNegotiatedReviewStartPreservesLegacyPayloadAndAuthorityIdentity(t *test
 	}
 	sortStrings(gotFields)
 	wantFields := []string{
-		"action", "changed_files", "changed_lines", "correction_budget", "lenses_required", "lineage_id",
-		"operation", "projection", "risk_level", "selected_lenses", "state",
+		"action", "changed_files", "changed_lines", "correction_budget", "lens_bindings", "lenses_required",
+		"lineage_id", "operation", "projection", "risk_level", "selected_lenses", "state", "target_identity",
 	}
 	if !reflect.DeepEqual(gotFields, wantFields) {
 		t.Fatalf("unnegotiated START fields = %v, want %v\n%s", gotFields, wantFields, legacyOutput.String())


### PR DESCRIPTION
## Summary

Fixes #1394: contract-conformant orchestrators could not complete a single lens capture — `review start` omitted the binding inputs the contract mandates, and the bundled OpenCode plugin rewrote lens names and rejected its own binding.

- **START contract**: the compact `review start` result now always emits `target_identity` (the frozen `InitialSnapshot.Identity`) and an additive `lens_bindings` array (`[{"lens":"review-risk","order":0}, ...]`, zero-based, `[]` for zero-lens starts) for every action that returns an active lineage. Orchestrators can now build `GENTLE_AI_REVIEW_BINDING` and `capture-result` invocations exclusively from START output instead of reading `.git/gentle-ai` state files. Additive only: no field removed or renamed; the negotiated `ReviewIntegrationStartResult` schema is untouched (its validator still forbids non-overlay `target_identity`).
- **OpenCode plugin**: `review-result-artifacts.ts` no longer strips the `review-` prefix. `parseBinding` validates the binding's lens against the full `subagent_type` (already gated by the full-name `REVIEW_AGENTS` set) and forwards the full name to `capture-result --lens`, matching native `SelectedLenses`. The Go side always expected full names, so this aligns the plugin with the pre-existing contract.

## Tests

- `TestReviewFacadeStartEmitsCaptureBindingInputs`: `target_identity` equals the persisted snapshot identity and `lens_bindings` match `SelectedLenses` indices, for both `created` and `resumed` actions.
- `TestReviewResultArtifactsPluginContract` (extended): requires the full-name `parseBinding` call and forbids the `slice("review-".length)` transformation in the embedded plugin bytes (the repo has no TS harness; embedded-asset assertions are its existing mechanism for plugin contracts).
- Field-pin tests updated additively (`TestReviewFacadeStartUnnegotiatedJSONFieldSetRemainsCompatible`, `TestNegotiatedReviewStartPreservesLegacyPayloadAndAuthorityIdentity`).
- Written TDD-first; both sides reproduced the issue's exact symptoms before the fix.

Known limitation (surfaced by the review lens as informational): plugin runtime behavior is pinned via embedded-asset assertions, not an executable TS test — adding a TS harness is out of scope here.

Refs #1394


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Review start results now include the selected lens order and binding details.
  * Target identity is consistently included in review start responses, including resumed reviews.
* **Compatibility**
  * Existing review start payloads remain supported while exposing the new metadata fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->