### PR TITLE
fix(review): load historical zero_edit_escalation records read-only

### DIFF
--- a/internal/cli/review.go
+++ b/internal/cli/review.go
@@ -228,7 +228,13 @@ func RunReviewBundleExport(args []string, stdout io.Writer) error {
 	}
 	compact, compactErr := reviewtransaction.CompactAuthoritativeStore(context.Background(), *cwd, *lineage)
 	if compactErr == nil {
-		if transport, loadErr := compact.ExportTransport(); loadErr == nil {
+		transport, loadErr := compact.ExportTransport()
+		if errors.Is(loadErr, reviewtransaction.ErrHistoricalCompatReadOnly) {
+			// A v2-only historical lineage has no legacy chain; the fallback
+			// would surface an unrelated missing-chain error.
+			return fmt.Errorf("export compact review transport: %w", loadErr)
+		}
+		if loadErr == nil {
 			legacy, legacyErr := reviewtransaction.AuthoritativeStore(context.Background(), *cwd, *lineage)
 			if legacyErr == nil {
 				if _, legacyLoadErr := legacy.LoadChain(); legacyLoadErr == nil {

--- a/internal/cli/review_historical_compat_test.go
+++ b/internal/cli/review_historical_compat_test.go
@@ -1,0 +1,143 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/internal/reviewtransaction"
+)
+
+func injectCLIRetiredZeroEditEscalation(t *testing.T, statePath string) {
+	t.Helper()
+	payload, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var record map[string]any
+	if err := json.Unmarshal(payload, &record); err != nil {
+		t.Fatal(err)
+	}
+	state, ok := record["state"].(map[string]any)
+	if !ok {
+		t.Fatal("compact record has no state object")
+	}
+	state["zero_edit_escalation"] = true
+	statePayload, err := json.Marshal(record["state"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	sum := sha256.Sum256(append([]byte(reviewtransaction.CompactStateSchema+"\x00"), statePayload...))
+	record["revision"] = "sha256:" + hex.EncodeToString(sum[:])
+	updated, err := json.MarshalIndent(record, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(statePath, append(updated, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestReviewBundleExportRefusesHistoricalZeroEditEscalationClearly(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("historical candidate\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	historical := startFacadeReview(t, repo)
+	store, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, historical.LineageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	injectCLIRetiredZeroEditEscalation(t, store.StatePath())
+	before, err := os.ReadFile(store.StatePath())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	out := filepath.Join(t.TempDir(), "bundle.json")
+	exportErr := RunReviewBundleExport([]string{"--cwd", repo, "--lineage", historical.LineageID, "--out", out}, io.Discard)
+	if exportErr == nil || !errors.Is(exportErr, reviewtransaction.ErrHistoricalCompatReadOnly) {
+		t.Fatalf("historical bundle export error = %v, want %v", exportErr, reviewtransaction.ErrHistoricalCompatReadOnly)
+	}
+	if strings.Contains(exportErr.Error(), "invalid compact review transport") {
+		t.Fatalf("historical bundle export masked the real cause: %v", exportErr)
+	}
+	if _, err := os.Stat(out); !os.IsNotExist(err) {
+		t.Fatalf("refused historical export left a bundle: %v", err)
+	}
+	if after, err := os.ReadFile(store.StatePath()); err != nil || !bytes.Equal(before, after) {
+		t.Fatalf("historical authority bytes changed: %v", err)
+	}
+}
+
+func TestReviewFacadeExplicitFinalizeCompletesWithHistoricalZeroEditEscalationRecord(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("historical candidate\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	historical := startFacadeReview(t, repo)
+	evidencePath := filepath.Join(t.TempDir(), "evidence.txt")
+	if err := os.WriteFile(evidencePath, []byte("go test ./...: pass\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	args := append([]string{"--cwd", repo, "--lineage", historical.LineageID}, facadeReviewerResultArgs(t, historical)...)
+	if err := RunReviewFacadeFinalize(append(args, "--evidence", evidencePath), io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	runReviewCLIGit(t, repo, "add", "tracked.txt")
+	runReviewCLIGit(t, repo, "commit", "-qm", "historical candidate")
+
+	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("current candidate\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	current := startFacadeReview(t, repo)
+	if current.LineageID == historical.LineageID {
+		t.Fatalf("current review reused historical lineage %q", current.LineageID)
+	}
+	historicalStore, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, historical.LineageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	injectCLIRetiredZeroEditEscalation(t, historicalStore.StatePath())
+	before, err := os.ReadFile(historicalStore.StatePath())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	currentEvidence := filepath.Join(t.TempDir(), "current-evidence.txt")
+	if err := os.WriteFile(currentEvidence, []byte("go test ./...: pass\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	finalizeArgs := append([]string{"--cwd", repo, "--lineage", current.LineageID}, facadeReviewerResultArgs(t, current)...)
+	var output bytes.Buffer
+	if err := RunReviewFacadeFinalize(append(finalizeArgs, "--evidence", currentEvidence), &output); err != nil {
+		t.Fatalf("explicit-lineage finalize with unrelated historical record: %v", err)
+	}
+	finalized := decodeFacadeFinalize(t, output.Bytes())
+	if finalized.State != reviewtransaction.StateApproved || finalized.LineageID != current.LineageID {
+		t.Fatalf("finalize result = %#v", finalized)
+	}
+	report, err := reviewtransaction.InventoryAuthority(context.Background(), repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !report.Complete {
+		t.Fatalf("historical record left status incomplete: %#v", report)
+	}
+	for _, entry := range report.Entries {
+		if entry.LineageID == historical.LineageID && entry.Status == reviewtransaction.AuthorityStatusInvalid {
+			t.Fatalf("historical entry reported invalid: %#v", entry)
+		}
+	}
+	if after, err := os.ReadFile(historicalStore.StatePath()); err != nil || !bytes.Equal(before, after) {
+		t.Fatalf("finalize rewrote historical authority bytes: %v", err)
+	}
+}

--- a/internal/reviewtransaction/compact_historical_compat_test.go
+++ b/internal/reviewtransaction/compact_historical_compat_test.go
@@ -1,0 +1,133 @@
+package reviewtransaction
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+)
+
+func injectRetiredCompactStateField(t *testing.T, statePath, field string) string {
+	t.Helper()
+	payload, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var record map[string]any
+	if err := json.Unmarshal(payload, &record); err != nil {
+		t.Fatal(err)
+	}
+	state, ok := record["state"].(map[string]any)
+	if !ok {
+		t.Fatal("compact record has no state object")
+	}
+	state[field] = true
+	statePayload, err := json.Marshal(record["state"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	sum := sha256.Sum256(append([]byte(CompactStateSchema+"\x00"), statePayload...))
+	record["revision"] = "sha256:" + hex.EncodeToString(sum[:])
+	updated, err := json.MarshalIndent(record, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(statePath, append(updated, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return record["revision"].(string)
+}
+
+func TestCompactStoreLoadsHistoricalZeroEditEscalationReadOnly(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	writeSnapshotFile(t, repo, "tracked.txt", "candidate\n")
+	state := newCompactTestState(t, repo, "historical-lineage")
+	store, err := CompactAuthoritativeStore(context.Background(), repo, state.LineageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Replace("", "review/start", state); err != nil {
+		t.Fatal(err)
+	}
+	revision := injectRetiredCompactStateField(t, store.StatePath(), "zero_edit_escalation")
+	before, err := os.ReadFile(store.StatePath())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	record, err := store.Load()
+	if err != nil {
+		t.Fatalf("load historical zero_edit_escalation record: %v", err)
+	}
+	if record.Revision != revision || record.State.LineageID != state.LineageID || !record.HistoricalCompat {
+		t.Fatalf("historical record = %#v, want read-only revision %s", record, revision)
+	}
+	if _, err := CompactAuthorityLeaves(context.Background(), repo); err != nil {
+		t.Fatalf("historical record poisoned the compact authority graph: %v", err)
+	}
+	report, err := InventoryAuthority(context.Background(), repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !report.Complete || !hasAuthorityInventoryStatus(report.Entries, state.LineageID, AuthorityStatusActive) {
+		t.Fatalf("historical inventory = %#v", report)
+	}
+	next := record.State
+	if err := next.Invalidate("historical maintenance"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Replace(record.Revision, "review/invalidate", next); err == nil || !errors.Is(err, ErrHistoricalCompatReadOnly) {
+		t.Fatalf("historical mutation error = %v", err)
+	}
+	if _, err := store.ExportTransport(); err == nil || !errors.Is(err, ErrHistoricalCompatReadOnly) {
+		t.Fatalf("historical transport export error = %v", err)
+	}
+	if after, err := os.ReadFile(store.StatePath()); err != nil || !bytes.Equal(before, after) {
+		t.Fatalf("historical authority bytes changed: %v", err)
+	}
+}
+
+func TestCompactStoreStillRejectsUnknownNonRetiredFields(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	writeSnapshotFile(t, repo, "tracked.txt", "candidate\n")
+	state := newCompactTestState(t, repo, "unknown-field-lineage")
+	store, err := CompactAuthoritativeStore(context.Background(), repo, state.LineageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Replace("", "review/start", state); err != nil {
+		t.Fatal(err)
+	}
+	injectRetiredCompactStateField(t, store.StatePath(), "future_unknown_field")
+	if _, err := store.Load(); err == nil || !strings.Contains(err.Error(), "unknown field") {
+		t.Fatalf("unknown non-retired field load error = %v", err)
+	}
+}
+
+func TestNewCompactAuthorityNeverPersistsRetiredZeroEditEscalation(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	writeSnapshotFile(t, repo, "tracked.txt", "candidate\n")
+	state := newCompactTestState(t, repo, "fresh-lineage")
+	record, payload, err := makeCompactRecord(state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(payload, []byte("zero_edit_escalation")) {
+		t.Fatal("new compact authority serialized a retired compatibility field")
+	}
+	if record.HistoricalCompat {
+		t.Fatal("new compact record is marked as historical compatibility authority")
+	}
+	statePayload, err := json.Marshal(state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(statePayload, []byte("zero_edit_escalation")) {
+		t.Fatal("new compact state serialization emitted a retired compatibility field")
+	}
+}

--- a/internal/reviewtransaction/compact_store.go
+++ b/internal/reviewtransaction/compact_store.go
@@ -26,6 +26,17 @@ var compactStartLockPollInterval = 25 * time.Millisecond
 
 var ErrLegacyReadOnly = errors.New("legacy v1 review lineage is read-only")
 
+// ErrHistoricalCompatReadOnly denies ordinary mutation of authority loaded
+// through the retired-field compatibility path.
+var ErrHistoricalCompatReadOnly = errors.New("historical compatibility authority is read-only")
+
+// compactRetiredStateFields lists top-level compact state fields persisted by
+// older builds and removed from the current schema. Historical records that
+// carry them load read-only; new authority state never persists them.
+var compactRetiredStateFields = map[string]struct{}{
+	"zero_edit_escalation": {},
+}
+
 // LegacyReadOnlyError is the typed ordinary-mutation denial for historical
 // legacy-v1 authority. Legacy authority remains available for read-only
 // compatibility and explicit maintenance transport operations only.
@@ -50,6 +61,9 @@ type CompactRecord struct {
 	Schema   string       `json:"schema"`
 	Revision string       `json:"revision"`
 	State    CompactState `json:"state"`
+	// HistoricalCompat marks a record loaded through the retired-field
+	// compatibility path; such authority is read-only.
+	HistoricalCompat bool `json:"-"`
 }
 
 type CompactStore struct {
@@ -902,6 +916,9 @@ func (store CompactStore) ReplaceContext(ctx context.Context, expectedRevision, 
 		if parseErr != nil {
 			return "", parseErr
 		}
+		if loaded.HistoricalCompat {
+			return "", fmt.Errorf("%w: %s for lineage %q", ErrHistoricalCompatReadOnly, operation, loaded.State.LineageID)
+		}
 		current = &loaded
 	} else if !os.IsNotExist(err) {
 		return "", err
@@ -1079,12 +1096,21 @@ func parseCompactRecord(payload []byte, lineageID string) (CompactRecord, error)
 	decoder := json.NewDecoder(bytes.NewReader(payload))
 	decoder.DisallowUnknownFields()
 	var record CompactRecord
-	if err := decoder.Decode(&record); err != nil {
-		return CompactRecord{}, err
-	}
-	var extra any
-	if err := decoder.Decode(&extra); err != io.EOF {
-		return CompactRecord{}, errors.New("multiple JSON values in compact review state")
+	if strictErr := decoder.Decode(&record); strictErr != nil {
+		if !retiredCompactFieldError(strictErr) {
+			return CompactRecord{}, strictErr
+		}
+		historical, historicalErr := parseHistoricalCompactRecord(payload)
+		if historicalErr != nil {
+			// Preserve the original strict decode wording for callers.
+			return CompactRecord{}, strictErr
+		}
+		record = historical
+	} else {
+		var extra any
+		if err := decoder.Decode(&extra); err != io.EOF {
+			return CompactRecord{}, errors.New("multiple JSON values in compact review state")
+		}
 	}
 	if record.Schema != compactRecordSchema || !validSHA256(record.Revision) {
 		return CompactRecord{}, errors.New("invalid compact review state record")
@@ -1095,11 +1121,87 @@ func parseCompactRecord(payload []byte, lineageID string) (CompactRecord, error)
 	if lineageID != "" && record.State.LineageID != lineageID {
 		return CompactRecord{}, errors.New("compact state lineage does not match its directory")
 	}
-	want, _, err := makeCompactRecord(record.State)
-	if err != nil || want.Revision != record.Revision {
-		return CompactRecord{}, errors.New("compact review state checksum mismatch")
+	if !record.HistoricalCompat {
+		want, _, err := makeCompactRecord(record.State)
+		if err != nil || want.Revision != record.Revision {
+			return CompactRecord{}, errors.New("compact review state checksum mismatch")
+		}
 	}
 	return record, nil
+}
+
+// retiredCompactFieldError reports whether a strict decode failure names a
+// retired compatibility field, so only genuine historical records pay the
+// tolerant second parse.
+func retiredCompactFieldError(err error) bool {
+	message := err.Error()
+	if !strings.Contains(message, "unknown field") {
+		return false
+	}
+	for name := range compactRetiredStateFields {
+		if strings.Contains(message, `"`+name+`"`) {
+			return true
+		}
+	}
+	return false
+}
+
+// parseHistoricalCompactRecord tolerates only retired top-level state fields
+// from older builds. The persisted revision must bind the exact historical
+// state bytes, so loading preserves revisions and provenance without ever
+// rewriting or re-hashing persisted authority.
+func parseHistoricalCompactRecord(payload []byte) (CompactRecord, error) {
+	var envelope struct {
+		Schema   string          `json:"schema"`
+		Revision string          `json:"revision"`
+		State    json.RawMessage `json:"state"`
+	}
+	decoder := json.NewDecoder(bytes.NewReader(payload))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&envelope); err != nil {
+		return CompactRecord{}, err
+	}
+	var extra any
+	if err := decoder.Decode(&extra); err != io.EOF {
+		return CompactRecord{}, errors.New("multiple JSON values in compact review state")
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(envelope.State, &fields); err != nil {
+		return CompactRecord{}, err
+	}
+	retired := false
+	for name := range compactRetiredStateFields {
+		if _, exists := fields[name]; exists {
+			retired = true
+			delete(fields, name)
+		}
+	}
+	if !retired {
+		return CompactRecord{}, errors.New("compact review state has no tolerated retired fields")
+	}
+	remaining, err := json.Marshal(fields)
+	if err != nil {
+		return CompactRecord{}, err
+	}
+	stateDecoder := json.NewDecoder(bytes.NewReader(remaining))
+	stateDecoder.DisallowUnknownFields()
+	var state CompactState
+	if err := stateDecoder.Decode(&state); err != nil {
+		return CompactRecord{}, err
+	}
+	var compacted bytes.Buffer
+	if err := json.Compact(&compacted, envelope.State); err != nil {
+		return CompactRecord{}, err
+	}
+	// makeCompactRecord hashes json.Marshal(state) while the record file is
+	// written with json.MarshalIndent, which is marshal-then-indent; Compact
+	// only inverts the added whitespace, so this reproduces the historical
+	// writer's exact revision preimage without re-marshaling the struct.
+	sum := sha256.Sum256(append([]byte(CompactStateSchema+"\x00"), compacted.Bytes()...))
+	if envelope.Revision != "sha256:"+hex.EncodeToString(sum[:]) {
+		return CompactRecord{}, errors.New("compact review state checksum mismatch")
+	}
+	return CompactRecord{Schema: envelope.Schema, Revision: envelope.Revision, State: state, HistoricalCompat: true}, nil
 }
 
 func appendCompactTrace(path string, entry CompactTraceEntry) error {
@@ -1125,6 +1227,12 @@ func (store CompactStore) ExportTransport() (CompactTransport, error) {
 	record, err := store.Load()
 	if err != nil {
 		return CompactTransport{}, err
+	}
+	if record.HistoricalCompat {
+		// Transport re-marshals the typed record, which cannot reproduce the
+		// retired historical bytes or their revision; refuse before a
+		// checksum failure would mask the cause.
+		return CompactTransport{}, fmt.Errorf("%w: lineage %q cannot be exported as compact transport", ErrHistoricalCompatReadOnly, record.State.LineageID)
 	}
 	transport := CompactTransport{Schema: CompactTransportSchema, Record: record}
 	if payload, readErr := os.ReadFile(store.ReceiptPath()); readErr == nil {


### PR DESCRIPTION
## Summary

Fixes #1388: a historical compact authority record containing the retired compatibility field `zero_edit_escalation` failed strict JSON decoding, marking the entry invalid in `review status` and aborting explicit-lineage `finalize` during global authority-graph validation — an unrelated healthy lineage could not complete.

- **Tolerant read-only load, bound to the persisted bytes**: strict decode still runs first; only when it fails with an unknown-field error naming a retired field does `parseHistoricalCompactRecord` strip the allowlisted retired top-level field and strict-decode the remainder (any other unknown field still fails exactly as before). The revision is verified against `sha256` of the ORIGINAL compacted state bytes — never a re-marshal — so historical revisions and provenance stay intact and nothing on disk is touched.
- **Read-only enforcement**: records loaded through the historical path carry an unforgeable `HistoricalCompat` marker (`json:"-"`); `ReplaceContext` rejects mutations with `ErrHistoricalCompatReadOnly`, and new state physically cannot emit the field (no struct member).
- **Transport**: `ExportTransport` refuses historical records fast with the same sentinel (transport re-marshaling cannot reproduce the historical bytes), and `review-bundle-export` surfaces that real cause instead of a masked "invalid compact review transport" — this closes a CRITICAL the bounded review caught in the first candidate.
- Single load point (`CompactStore.Load`) means status, finalize graph validation, discovery, gates, and superseded checks are all fixed at once.

## Tests (TDD-first; each failing run reproduced the issue's exact error)

- `TestCompactStoreLoadsHistoricalZeroEditEscalationReadOnly` — loads read-only, revision preserved, inventory reports it readable, mutation and export denied with the sentinel, on-disk bytes byte-identical.
- `TestCompactStoreStillRejectsUnknownNonRetiredFields` — non-allowlisted unknown fields keep the original strict error.
- `TestNewCompactAuthorityNeverPersistsRetiredZeroEditEscalation` — new state can never emit the field.
- `TestReviewFacadeExplicitFinalizeCompletesWithHistoricalZeroEditEscalationRecord` — healthy explicit-lineage finalize completes with the historical record present.
- `TestReviewBundleExportRefusesHistoricalZeroEditEscalationClearly` — CLI export surfaces the real cause, writes no bundle, leaves historical bytes unchanged.

Known informational note from the review: the fallback gate depends on Go's `json: unknown field %q` wording; it fails safe on any drift (records revert to the strict error) and the historical fixture test would surface such a toolchain change in CI.

Refs #1388


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Historical review records with retired compatibility data are now safely treated as read-only.
  * Compact transport export now reports a clear error instead of silently falling back to a legacy bundle.
  * Finalizing current reviews no longer modifies unrelated historical records.
  * New records no longer persist retired compatibility fields.
  * Invalid unknown fields continue to be rejected during record loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->