### PR TITLE
fix(review): add audited reclaim for incomplete compact store entries

### DIFF
--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -338,7 +338,7 @@ func TestRunArgsDispatchesCompactReviewFacadeBeforePlatformValidation(t *testing
 	if err := RunArgs([]string{"review", "--help"}, &output); err != nil {
 		t.Fatalf("RunArgs(review --help) error = %v", err)
 	}
-	if !strings.Contains(output.String(), "review <capabilities|start|finalize|validate|status|invalidate|recover|schema|bind-sdd>") {
+	if !strings.Contains(output.String(), "review <capabilities|start|finalize|validate|status|invalidate|recover|reclaim|schema|bind-sdd>") {
 		t.Fatalf("compact review help missing:\n%s", output.String())
 	}
 }

--- a/internal/cli/review_artifact.go
+++ b/internal/cli/review_artifact.go
@@ -105,7 +105,7 @@ func RunReviewCaptureResult(args []string, stdout io.Writer) error {
 	return encodeReviewJSON(stdout, artifact)
 }
 func captureReviewerArtifact(storeDir string, state reviewtransaction.CompactState, order int, payload []byte) (reviewResultArtifact, error) {
-	dir := filepath.Join(storeDir, "reviewer-results")
+	dir := filepath.Join(storeDir, reviewtransaction.CompactReviewerResultsDir)
 	if err := ensureReviewerArtifactDir(dir); err != nil {
 		return reviewResultArtifact{}, err
 	}
@@ -204,7 +204,7 @@ func readVerifiedReviewerArtifact(artifact reviewResultArtifact, storeDir string
 		artifact.Lens != state.SelectedLenses[artifact.SelectedOrder] || !validReviewCapabilitySHA256(artifact.SHA256) {
 		return nil, errors.New("artifact manifest does not match frozen lineage, target, lens, and order")
 	}
-	wantPath := filepath.Join(storeDir, "reviewer-results", fmt.Sprintf("%02d-%s.json", artifact.SelectedOrder, artifact.Lens))
+	wantPath := filepath.Join(storeDir, reviewtransaction.CompactReviewerResultsDir, fmt.Sprintf("%02d-%s.json", artifact.SelectedOrder, artifact.Lens))
 	if !filepath.IsAbs(artifact.Path) || filepath.Clean(artifact.Path) != artifact.Path || artifact.Path != wantPath {
 		return nil, errors.New("artifact path is outside native transaction ownership")
 	}

--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -208,7 +208,7 @@ var reviewFacadeCommittedTransitionHook = func(context.Context, string, string, 
 
 func RunReview(args []string, stdout io.Writer) error {
 	if len(args) == 0 || args[0] == "help" || args[0] == "-h" || args[0] == "--help" {
-		_, _ = fmt.Fprintln(stdout, "Usage: gentle-ai review <capabilities|start|finalize|validate|status|invalidate|recover|schema|bind-sdd> [flags]\n\nOrdinary review facade; repository scope, authority, canonical artifacts, and lifecycle transitions are derived by Go.")
+		_, _ = fmt.Fprintln(stdout, "Usage: gentle-ai review <capabilities|start|finalize|validate|status|invalidate|recover|reclaim|schema|bind-sdd> [flags]\n\nOrdinary review facade; repository scope, authority, canonical artifacts, and lifecycle transitions are derived by Go.")
 		_, _ = fmt.Fprintln(stdout, "Additive headless capability: gentle-ai review capture-result.")
 		return nil
 	}
@@ -291,6 +291,8 @@ func runReviewCommand(args []string, stdout io.Writer) error {
 		return RunReviewInvalidate(args[1:], stdout)
 	case "recover":
 		return RunReviewRecover(args[1:], stdout)
+	case "reclaim":
+		return RunReviewReclaim(args[1:], stdout)
 	case "schema":
 		return RunReviewSchema(args[1:], stdout)
 	case "bind-sdd":
@@ -1523,6 +1525,11 @@ func reviewAuthorityCauseCategory(report reviewtransaction.AuthorityStatusReport
 			return "reset_residue"
 		case reviewtransaction.AuthorityStatusInvalid, reviewtransaction.AuthorityStatusCollision:
 			return "record_or_graph_invalid"
+		}
+	}
+	for _, entry := range report.Entries {
+		if entry.Status == reviewtransaction.AuthorityStatusIncomplete {
+			return "incomplete_store_entry"
 		}
 	}
 	return "inventory_incomplete"

--- a/internal/cli/review_reclaim.go
+++ b/internal/cli/review_reclaim.go
@@ -1,0 +1,52 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/gentleman-programming/gentle-ai/internal/reviewtransaction"
+)
+
+type ReviewReclaimResult struct {
+	Operation string                                 `json:"operation"`
+	Record    reviewtransaction.CompactReclaimRecord `json:"record"`
+}
+
+func RunReviewReclaim(args []string, stdout io.Writer) error {
+	flags := newReviewFlagSet("review reclaim", stdout, "Quarantine one explicit incomplete compact-v2 store entry with a persisted audit record; entries holding any authoritative artifact are refused. On partial failure the prepared audit record JSON is still emitted to stdout and the command exits non-zero.")
+	cwd := flags.String("cwd", ".", "repository path")
+	lineage := flags.String("lineage", "", "explicit incomplete compact store lineage")
+	reason := flags.String("reason", "", "non-empty reclaim reason")
+	actor := flags.String("actor", "", "reclaim actor")
+	if err := parseReviewFlags(flags, args); err != nil {
+		return err
+	}
+	if reviewHelpRequested(args) {
+		return nil
+	}
+	if flags.NArg() != 0 {
+		return fmt.Errorf("unexpected review reclaim argument %q", flags.Arg(0))
+	}
+	if strings.TrimSpace(*lineage) == "" || strings.TrimSpace(*reason) == "" || strings.TrimSpace(*actor) == "" {
+		return errors.New("review reclaim requires --lineage, --reason, and --actor")
+	}
+	root, err := (reviewtransaction.SnapshotBuilder{Repo: *cwd}).ResolveRepositoryRoot(context.Background())
+	if err != nil {
+		return fmt.Errorf("resolve review repository root: %w", err)
+	}
+	record, err := reviewtransaction.ReclaimIncompleteCompactStore(context.Background(), root, reviewtransaction.CompactReclaimRequest{
+		LineageID: *lineage, Reason: *reason, Actor: *actor,
+	})
+	if err != nil {
+		// A partial reclaim persisted the prepared audit record and may have
+		// moved the residue; surface the quarantine location for reconciliation.
+		if record.QuarantinePath != "" {
+			_ = encodeReviewJSON(stdout, ReviewReclaimResult{Operation: "review/reclaim", Record: record})
+		}
+		return err
+	}
+	return encodeReviewJSON(stdout, ReviewReclaimResult{Operation: "review/reclaim", Record: record})
+}

--- a/internal/cli/review_reclaim_test.go
+++ b/internal/cli/review_reclaim_test.go
@@ -1,0 +1,134 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/internal/reviewtransaction"
+)
+
+func incompleteCompactResidueDir(t *testing.T, repo, lineage string) string {
+	t.Helper()
+	commonDir := filepath.Clean(strings.TrimSpace(runReviewCLIGit(t, repo, "rev-parse", "--path-format=absolute", "--git-common-dir")))
+	residue := filepath.Join(commonDir, "gentle-ai", "review-transactions", "v2", lineage)
+	if err := os.MkdirAll(residue, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return residue
+}
+
+func TestUnqualifiedGateDiscoveryDeniesIncompleteStoreEntryWithDistinctCause(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	approveDiscoveryMarkdown(t, repo, "review-reclaim-valid", "docs/valid.md", "valid\n")
+	incompleteCompactResidueDir(t, repo, "reclaim-audit")
+
+	var output bytes.Buffer
+	err := RunReview([]string{
+		"validate", "--contract", ReviewIntegrationContractV1, "--cwd", repo,
+		"--gate", string(reviewtransaction.GatePostApply),
+	}, &output)
+	if err == nil {
+		t.Fatal("incomplete store entry did not deny lineage-less gate validation")
+	}
+	failure := decodeReviewIntegrationFailure(t, output.Bytes())
+	if failure.Code != "authority_corrupted" || failure.CauseCategory != "incomplete_store_entry" {
+		t.Fatalf("incomplete store entry failure = %#v", failure)
+	}
+}
+
+func TestReviewReclaimQuarantinesResidueAndRestoresLineagelessDiscovery(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	approveDiscoveryMarkdown(t, repo, "review-reclaim-valid", "docs/valid.md", "valid\n")
+	residue := incompleteCompactResidueDir(t, repo, "reclaim-audit")
+
+	var reclaimOutput bytes.Buffer
+	if err := RunReview([]string{
+		"reclaim", "--cwd", repo, "--lineage", "reclaim-audit",
+		"--reason", "interrupted store write residue", "--actor", "maintainer@example.com",
+	}, &reclaimOutput); err != nil {
+		t.Fatalf("review reclaim: %v\n%s", err, reclaimOutput.String())
+	}
+	var result ReviewReclaimResult
+	decodeStrictReviewJSON(t, reclaimOutput.Bytes(), &result)
+	if result.Operation != "review/reclaim" || result.Record.LineageID != "reclaim-audit" || result.Record.QuarantinePath == "" {
+		t.Fatalf("review reclaim result = %#v", result)
+	}
+	if _, err := os.Stat(residue); !os.IsNotExist(err) {
+		t.Fatalf("reclaimed residue still present: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(result.Record.QuarantinePath, "reclaim-record.json")); err != nil {
+		t.Fatalf("reclaim audit record missing: %v", err)
+	}
+
+	var validateOutput bytes.Buffer
+	if err := RunReview([]string{
+		"validate", "--contract", ReviewIntegrationContractV1, "--cwd", repo,
+		"--gate", string(reviewtransaction.GatePostApply),
+	}, &validateOutput); err != nil {
+		t.Fatalf("post-reclaim lineage-less validation: %v\n%s", err, validateOutput.String())
+	}
+	var validated ReviewValidateResult
+	decodeStrictReviewJSON(t, decodeReviewOperationEnvelope(t, validateOutput.Bytes()).Result, &validated)
+	if !validated.Allowed || validated.Context.LineageID != "review-reclaim-valid" {
+		t.Fatalf("post-reclaim validation = %#v", validated)
+	}
+
+	var refusedOutput bytes.Buffer
+	if err := RunReview([]string{
+		"reclaim", "--cwd", repo, "--lineage", "review-reclaim-valid",
+		"--reason", "must refuse", "--actor", "maintainer@example.com",
+	}, &refusedOutput); err == nil {
+		t.Fatal("review reclaim touched a lineage with authoritative state")
+	}
+}
+
+func TestReviewStartSucceedsDespiteIncompleteStoreResidue(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	incompleteCompactResidueDir(t, repo, "reclaim-audit")
+	if err := os.MkdirAll(filepath.Join(repo, "docs"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "docs", "start.md"), []byte("start\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var output bytes.Buffer
+	if err := RunReviewFacadeStart([]string{"--cwd", repo, "--lineage", "review-reclaim-start"}, &output); err != nil {
+		t.Fatalf("review start with incomplete residue present: %v\n%s", err, output.String())
+	}
+}
+
+func TestReviewReclaimUnblocksStartPoisonedByEnumeratedResidue(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	residue := incompleteCompactResidueDir(t, repo, "reclaim-audit")
+	if err := os.WriteFile(filepath.Join(residue, "stray.tmp"), []byte("stray\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(repo, "docs"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "docs", "start.md"), []byte("start\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var output bytes.Buffer
+	err := RunReviewFacadeStart([]string{"--cwd", repo, "--lineage", "review-reclaim-start"}, &output)
+	if err == nil {
+		t.Fatal("review start ignored an enumerated incomplete store entry")
+	}
+	if !strings.Contains(err.Error(), "load compact start authority") {
+		t.Fatalf("start-time enumeration failure = %v", err)
+	}
+
+	if err := RunReview([]string{
+		"reclaim", "--cwd", repo, "--lineage", "reclaim-audit",
+		"--reason", "interrupted store write residue", "--actor", "maintainer@example.com",
+	}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("reclaim enumerated residue: %v", err)
+	}
+	output.Reset()
+	if err := RunReviewFacadeStart([]string{"--cwd", repo, "--lineage", "review-reclaim-start"}, &output); err != nil {
+		t.Fatalf("review start after reclaim: %v\n%s", err, output.String())
+	}
+}

--- a/internal/reviewtransaction/compact_reclaim.go
+++ b/internal/reviewtransaction/compact_reclaim.go
@@ -1,0 +1,156 @@
+package reviewtransaction
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+const CompactReclaimRecordSchema = "gentle-ai.review-reclaim-record/v1"
+
+const (
+	CompactReclaimPrepared  = "prepared"
+	CompactReclaimCommitted = "committed"
+)
+
+var reclaimQuarantineResidue = os.Rename
+var persistReclaimRecord = persistCompactReclaimRecord
+
+// CompactReclaimRequest identifies one explicit incomplete compact-v2 store
+// entry to quarantine, together with the maintainer audit inputs.
+type CompactReclaimRequest struct {
+	LineageID   string
+	Reason      string
+	Actor       string
+	ReclaimedAt time.Time
+}
+
+// CompactReclaimRecord is the persisted audit record for one quarantined
+// incomplete store entry; it mirrors the recovery provenance shape. Status is
+// "committed" only after the residue rename landed and the record rewrite
+// succeeded. A record stuck at "prepared" means the rename may or may not
+// have run; the discriminator is the residue/ subdirectory next to the
+// record: absent means the residue was never moved, present means it was
+// moved but the committed rewrite did not land.
+type CompactReclaimRecord struct {
+	Schema         string    `json:"schema"`
+	Status         string    `json:"status"`
+	LineageID      string    `json:"lineage_id"`
+	Reason         string    `json:"reason"`
+	Actor          string    `json:"actor"`
+	ReclaimedAt    time.Time `json:"reclaimed_at"`
+	SourcePath     string    `json:"source_path"`
+	QuarantinePath string    `json:"quarantine_path"`
+	Residue        []string  `json:"residue"`
+}
+
+// compactAuthoritativeArtifact reports whether a store-entry name carries
+// review authority: state, receipt, finalize journal, captured reviewer
+// results, or interrupted atomic-write payloads that may hold any of them.
+// It must cover every file the compact store writes under a lineage
+// directory; the shared names live beside CompactStore in compact_store.go.
+func compactAuthoritativeArtifact(name string) bool {
+	switch name {
+	case compactStateFileName, compactReceiptFileName, compactFinalizeJournalFileName, CompactReviewerResultsDir:
+		return true
+	}
+	return strings.HasPrefix(name, ".atomic-")
+}
+
+func compactStoreHoldsAuthority(items []os.DirEntry) bool {
+	for _, item := range items {
+		if compactAuthoritativeArtifact(item.Name()) {
+			return true
+		}
+	}
+	return false
+}
+
+// ReclaimIncompleteCompactStore moves one incomplete compact-v2 store entry —
+// no review-state.json and no other authoritative artifact — into an audited
+// quarantine directory under the review authority root. It never deletes
+// residue and never fabricates authority state. On partial failure after the
+// prepared record is persisted, it returns the populated prepared record
+// (QuarantinePath and Residue set) alongside a non-nil error; callers must
+// not discard the record on error — it locates the quarantine or orphan for
+// reconciliation.
+func ReclaimIncompleteCompactStore(ctx context.Context, repo string, request CompactReclaimRequest) (CompactReclaimRecord, error) {
+	if err := ctx.Err(); err != nil {
+		return CompactReclaimRecord{}, err
+	}
+	if err := validateLineageID(request.LineageID); err != nil {
+		return CompactReclaimRecord{}, err
+	}
+	if strings.TrimSpace(request.Reason) == "" || strings.TrimSpace(request.Actor) == "" {
+		return CompactReclaimRecord{}, errors.New("review reclaim requires a non-empty reason and actor")
+	}
+	base, _, err := reviewAuthorityRoot(ctx, repo)
+	if err != nil {
+		return CompactReclaimRecord{}, err
+	}
+	versionRoot := filepath.Join(base, "v2")
+	dir := filepath.Join(versionRoot, request.LineageID)
+	lock, err := acquireStoreLock(filepath.Join(versionRoot, "LOCK"))
+	if err != nil {
+		return CompactReclaimRecord{}, err
+	}
+	defer lock.release()
+	items, err := os.ReadDir(dir)
+	if err != nil {
+		return CompactReclaimRecord{}, fmt.Errorf("inspect reclaim target: %w", err)
+	}
+	residue := make([]string, 0, len(items))
+	for _, item := range items {
+		if compactAuthoritativeArtifact(item.Name()) {
+			return CompactReclaimRecord{}, fmt.Errorf("review reclaim refused: store entry %q holds authoritative artifact %q", request.LineageID, item.Name())
+		}
+		residue = append(residue, item.Name())
+	}
+	sort.Strings(residue)
+	if request.ReclaimedAt.IsZero() {
+		request.ReclaimedAt = time.Now().UTC()
+	}
+	quarantineRoot := filepath.Join(base, "quarantine")
+	if err := os.MkdirAll(quarantineRoot, 0o755); err != nil {
+		return CompactReclaimRecord{}, err
+	}
+	quarantineDir, err := os.MkdirTemp(quarantineRoot, request.LineageID+"-")
+	if err != nil {
+		return CompactReclaimRecord{}, err
+	}
+	record := CompactReclaimRecord{
+		Schema: CompactReclaimRecordSchema, Status: CompactReclaimPrepared, LineageID: request.LineageID,
+		Reason: strings.TrimSpace(request.Reason), Actor: strings.TrimSpace(request.Actor),
+		ReclaimedAt: request.ReclaimedAt.UTC(), SourcePath: dir,
+		QuarantinePath: quarantineDir, Residue: residue,
+	}
+	if err := persistReclaimRecord(record); err != nil {
+		return CompactReclaimRecord{}, err
+	}
+	if err := reclaimQuarantineResidue(dir, filepath.Join(quarantineDir, "residue")); err != nil {
+		return record, fmt.Errorf("reclaim was prepared at %s but quarantining the residue failed: %w", quarantineDir, err)
+	}
+	committed := record
+	committed.Status = CompactReclaimCommitted
+	if err := persistReclaimRecord(committed); err != nil {
+		return record, fmt.Errorf("residue was quarantined at %s but the reclaim audit record could not be marked committed: %w", quarantineDir, err)
+	}
+	return committed, nil
+}
+
+func persistCompactReclaimRecord(record CompactReclaimRecord) error {
+	payload, err := json.MarshalIndent(record, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := writeAtomic(filepath.Join(record.QuarantinePath, "reclaim-record.json"), append(payload, '\n'), 0o644); err != nil {
+		return fmt.Errorf("persist %s reclaim audit record: %w", record.Status, err)
+	}
+	return nil
+}

--- a/internal/reviewtransaction/compact_reclaim.go
+++ b/internal/reviewtransaction/compact_reclaim.go
@@ -120,9 +120,31 @@ func ReclaimIncompleteCompactStore(ctx context.Context, repo string, request Com
 	if err := os.MkdirAll(quarantineRoot, 0o755); err != nil {
 		return CompactReclaimRecord{}, err
 	}
+	quarantineRootInfo, err := os.Lstat(quarantineRoot)
+	if err != nil {
+		return CompactReclaimRecord{}, err
+	}
+	if quarantineRootInfo.Mode()&os.ModeSymlink != 0 || !quarantineRootInfo.IsDir() {
+		return CompactReclaimRecord{}, fmt.Errorf("review reclaim refused unsafe quarantine root %q", quarantineRoot)
+	}
+	if err := SyncReviewDirectory(base); err != nil {
+		return CompactReclaimRecord{}, fmt.Errorf("sync review authority root after quarantine creation: %w", err)
+	}
 	quarantineDir, err := os.MkdirTemp(quarantineRoot, request.LineageID+"-")
 	if err != nil {
 		return CompactReclaimRecord{}, err
+	}
+	cleanupUnprepared := func(cause error) error {
+		if removeErr := os.RemoveAll(quarantineDir); removeErr != nil {
+			return errors.Join(cause, fmt.Errorf("remove unidentified quarantine directory %q: %w", quarantineDir, removeErr))
+		}
+		if syncErr := SyncReviewDirectory(quarantineRoot); syncErr != nil {
+			return errors.Join(cause, fmt.Errorf("sync quarantine cleanup for %q: %w", quarantineDir, syncErr))
+		}
+		return cause
+	}
+	if err := SyncReviewDirectory(quarantineRoot); err != nil {
+		return CompactReclaimRecord{}, cleanupUnprepared(fmt.Errorf("sync quarantine root after reclaim directory creation: %w", err))
 	}
 	record := CompactReclaimRecord{
 		Schema: CompactReclaimRecordSchema, Status: CompactReclaimPrepared, LineageID: request.LineageID,
@@ -131,10 +153,16 @@ func ReclaimIncompleteCompactStore(ctx context.Context, repo string, request Com
 		QuarantinePath: quarantineDir, Residue: residue,
 	}
 	if err := persistReclaimRecord(record); err != nil {
-		return CompactReclaimRecord{}, err
+		return CompactReclaimRecord{}, cleanupUnprepared(err)
 	}
 	if err := reclaimQuarantineResidue(dir, filepath.Join(quarantineDir, "residue")); err != nil {
 		return record, fmt.Errorf("reclaim was prepared at %s but quarantining the residue failed: %w", quarantineDir, err)
+	}
+	if err := SyncReviewDirectory(versionRoot); err != nil {
+		return record, fmt.Errorf("residue was quarantined at %s but syncing the source version root failed: %w", quarantineDir, err)
+	}
+	if err := SyncReviewDirectory(quarantineDir); err != nil {
+		return record, fmt.Errorf("residue was quarantined at %s but syncing the quarantine directory failed: %w", quarantineDir, err)
 	}
 	committed := record
 	committed.Status = CompactReclaimCommitted

--- a/internal/reviewtransaction/compact_reclaim_test.go
+++ b/internal/reviewtransaction/compact_reclaim_test.go
@@ -1,0 +1,325 @@
+package reviewtransaction
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestInventoryClassifiesIncompleteCompactStoreEntry(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		populate func(t *testing.T, dir string)
+		status   AuthorityStatus
+	}{
+		{name: "empty entry", populate: func(*testing.T, string) {}, status: AuthorityStatusIncomplete},
+		{name: "non-authoritative residue", populate: func(t *testing.T, dir string) {
+			writeReclaimFixtureFile(t, filepath.Join(dir, "stray.tmp"), "stray\n")
+		}, status: AuthorityStatusIncomplete},
+		{name: "orphan receipt", populate: func(t *testing.T, dir string) {
+			writeReclaimFixtureFile(t, filepath.Join(dir, "review-receipt.json"), "{}\n")
+		}, status: AuthorityStatusInvalid},
+		{name: "orphan finalize journal", populate: func(t *testing.T, dir string) {
+			writeReclaimFixtureFile(t, filepath.Join(dir, "finalize-attempt-journal.json"), "{}\n")
+		}, status: AuthorityStatusInvalid},
+		{name: "orphan reviewer results", populate: func(t *testing.T, dir string) {
+			writeReclaimFixtureFile(t, filepath.Join(dir, "reviewer-results", "01-review-readability.json"), "{}\n")
+		}, status: AuthorityStatusInvalid},
+		{name: "interrupted atomic write", populate: func(t *testing.T, dir string) {
+			writeReclaimFixtureFile(t, filepath.Join(dir, ".atomic-partial"), "partial")
+		}, status: AuthorityStatusReset},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := initSnapshotRepo(t)
+			root, _, err := reviewAuthorityRoot(context.Background(), repo)
+			if err != nil {
+				t.Fatal(err)
+			}
+			dir := filepath.Join(root, "v2", "reclaim-audit")
+			if err := os.MkdirAll(dir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			tt.populate(t, dir)
+
+			report, err := InventoryAuthority(context.Background(), repo)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if report.Complete || report.Authoritative {
+				t.Fatalf("incomplete store entry left inventory authoritative: %#v", report)
+			}
+			if !hasAuthorityInventoryStatus(report.Entries, "reclaim-audit", tt.status) {
+				t.Fatalf("inventory entries = %#v", report.Entries)
+			}
+		})
+	}
+}
+
+func TestReclaimIncompleteCompactStoreQuarantinesResidueWithAuditRecord(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	root, _, err := reviewAuthorityRoot(context.Background(), repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(root, "v2", "reclaim-audit")
+	writeReclaimFixtureFile(t, filepath.Join(dir, "stray.tmp"), "stray\n")
+
+	record, err := ReclaimIncompleteCompactStore(context.Background(), repo, CompactReclaimRequest{
+		LineageID: "reclaim-audit", Reason: "interrupted store write residue", Actor: "maintainer@example.com",
+	})
+	if err != nil {
+		t.Fatalf("reclaim incomplete store entry: %v", err)
+	}
+	if _, statErr := os.Stat(dir); !os.IsNotExist(statErr) {
+		t.Fatalf("reclaimed store entry still present: %v", statErr)
+	}
+	if record.Schema != CompactReclaimRecordSchema || record.Status != CompactReclaimCommitted ||
+		record.LineageID != "reclaim-audit" ||
+		record.Reason != "interrupted store write residue" || record.Actor != "maintainer@example.com" ||
+		record.ReclaimedAt.IsZero() || record.SourcePath != dir {
+		t.Fatalf("reclaim record = %#v", record)
+	}
+	quarantineRoot := filepath.Join(root, "quarantine")
+	if !strings.HasPrefix(record.QuarantinePath, quarantineRoot+string(os.PathSeparator)) {
+		t.Fatalf("quarantine path %q is outside %q", record.QuarantinePath, quarantineRoot)
+	}
+	moved, err := os.ReadFile(filepath.Join(record.QuarantinePath, "residue", "stray.tmp"))
+	if err != nil || !bytes.Equal(moved, []byte("stray\n")) {
+		t.Fatalf("quarantined residue bytes = %q, %v", moved, err)
+	}
+	if len(record.Residue) != 1 || record.Residue[0] != "stray.tmp" {
+		t.Fatalf("reclaim residue manifest = %#v", record.Residue)
+	}
+	payload, err := os.ReadFile(filepath.Join(record.QuarantinePath, "reclaim-record.json"))
+	if err != nil {
+		t.Fatalf("read persisted reclaim audit record: %v", err)
+	}
+	var persisted CompactReclaimRecord
+	if err := json.Unmarshal(payload, &persisted); err != nil {
+		t.Fatalf("parse persisted reclaim audit record: %v", err)
+	}
+	if persisted.Schema != CompactReclaimRecordSchema || persisted.Status != CompactReclaimCommitted ||
+		persisted.LineageID != record.LineageID ||
+		persisted.Actor != record.Actor || persisted.Reason != record.Reason || persisted.ReclaimedAt.IsZero() {
+		t.Fatalf("persisted reclaim record = %#v", persisted)
+	}
+
+	report, err := InventoryAuthority(context.Background(), repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !report.Complete || !report.Authoritative || hasAuthorityInventoryStatus(report.Entries, "reclaim-audit", AuthorityStatusIncomplete) {
+		t.Fatalf("post-reclaim inventory = %#v", report)
+	}
+}
+
+func TestReclaimRefusesAuthoritativeArtifactsAndInvalidRequests(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		artifact string
+	}{
+		{name: "state file", artifact: "review-state.json"},
+		{name: "receipt", artifact: "review-receipt.json"},
+		{name: "finalize journal", artifact: "finalize-attempt-journal.json"},
+		{name: "reviewer results", artifact: filepath.Join("reviewer-results", "01-review-readability.json")},
+		{name: "interrupted atomic write", artifact: ".atomic-partial"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := initSnapshotRepo(t)
+			root, _, err := reviewAuthorityRoot(context.Background(), repo)
+			if err != nil {
+				t.Fatal(err)
+			}
+			dir := filepath.Join(root, "v2", "reclaim-audit")
+			path := filepath.Join(dir, tt.artifact)
+			writeReclaimFixtureFile(t, path, "artifact\n")
+
+			_, err = ReclaimIncompleteCompactStore(context.Background(), repo, CompactReclaimRequest{
+				LineageID: "reclaim-audit", Reason: "residue", Actor: "maintainer",
+			})
+			if err == nil {
+				t.Fatal("reclaim touched a store entry holding authority artifacts")
+			}
+			payload, readErr := os.ReadFile(path)
+			if readErr != nil || !bytes.Equal(payload, []byte("artifact\n")) {
+				t.Fatalf("refused reclaim mutated the store entry: %q, %v", payload, readErr)
+			}
+		})
+	}
+
+	t.Run("missing entry", func(t *testing.T) {
+		repo := initSnapshotRepo(t)
+		if _, err := ReclaimIncompleteCompactStore(context.Background(), repo, CompactReclaimRequest{
+			LineageID: "reclaim-absent", Reason: "residue", Actor: "maintainer",
+		}); err == nil {
+			t.Fatal("reclaim accepted a missing store entry")
+		}
+	})
+
+	t.Run("missing reason and actor", func(t *testing.T) {
+		repo := initSnapshotRepo(t)
+		root, _, err := reviewAuthorityRoot(context.Background(), repo)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.MkdirAll(filepath.Join(root, "v2", "reclaim-audit"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		for _, request := range []CompactReclaimRequest{
+			{LineageID: "reclaim-audit", Actor: "maintainer"},
+			{LineageID: "reclaim-audit", Reason: "residue"},
+			{LineageID: "Not A Lineage", Reason: "residue", Actor: "maintainer"},
+		} {
+			if _, err := ReclaimIncompleteCompactStore(context.Background(), repo, request); err == nil {
+				t.Fatalf("reclaim accepted invalid request %#v", request)
+			}
+		}
+	})
+}
+
+func TestReclaimCrashBeforeRenameLeavesPreparedOrphanAndRetrySucceeds(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	root, _, err := reviewAuthorityRoot(context.Background(), repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(root, "v2", "reclaim-audit")
+	writeReclaimFixtureFile(t, filepath.Join(dir, "stray.tmp"), "stray\n")
+
+	original := reclaimQuarantineResidue
+	reclaimQuarantineResidue = func(string, string) error {
+		return errors.New("simulated crash before residue rename")
+	}
+	t.Cleanup(func() { reclaimQuarantineResidue = original })
+	request := CompactReclaimRequest{LineageID: "reclaim-audit", Reason: "interrupted store write residue", Actor: "maintainer@example.com"}
+	prepared, err := ReclaimIncompleteCompactStore(context.Background(), repo, request)
+	if err == nil {
+		t.Fatal("interrupted reclaim reported success")
+	}
+	if prepared.Status != CompactReclaimPrepared || prepared.QuarantinePath == "" {
+		t.Fatalf("rename-failure record = %#v", prepared)
+	}
+	if !strings.Contains(err.Error(), prepared.QuarantinePath) {
+		t.Fatalf("rename failure hides the prepared quarantine location: %v", err)
+	}
+	payload, err := os.ReadFile(filepath.Join(dir, "stray.tmp"))
+	if err != nil || !bytes.Equal(payload, []byte("stray\n")) {
+		t.Fatalf("interrupted reclaim mutated the source entry: %q, %v", payload, err)
+	}
+	orphans, err := os.ReadDir(filepath.Join(root, "quarantine"))
+	if err != nil || len(orphans) != 1 {
+		t.Fatalf("orphan quarantine directories = %#v, %v", orphans, err)
+	}
+	var orphan CompactReclaimRecord
+	orphanPayload, err := os.ReadFile(filepath.Join(root, "quarantine", orphans[0].Name(), "reclaim-record.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(orphanPayload, &orphan); err != nil {
+		t.Fatal(err)
+	}
+	if orphan.Status != CompactReclaimPrepared {
+		t.Fatalf("orphan reclaim record status = %q", orphan.Status)
+	}
+	if _, err := os.Stat(filepath.Join(root, "quarantine", orphans[0].Name(), "residue")); !os.IsNotExist(err) {
+		t.Fatalf("orphan quarantine claims residue it never received: %v", err)
+	}
+
+	reclaimQuarantineResidue = original
+	record, err := ReclaimIncompleteCompactStore(context.Background(), repo, request)
+	if err != nil {
+		t.Fatalf("retry after interrupted reclaim: %v", err)
+	}
+	if record.Status != CompactReclaimCommitted || record.QuarantinePath == filepath.Join(root, "quarantine", orphans[0].Name()) {
+		t.Fatalf("retry reclaim record = %#v", record)
+	}
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Fatalf("retried reclaim left the source entry behind: %v", err)
+	}
+	moved, err := os.ReadFile(filepath.Join(record.QuarantinePath, "residue", "stray.tmp"))
+	if err != nil || !bytes.Equal(moved, []byte("stray\n")) {
+		t.Fatalf("retried quarantine residue bytes = %q, %v", moved, err)
+	}
+	var committed CompactReclaimRecord
+	committedPayload, err := os.ReadFile(filepath.Join(record.QuarantinePath, "reclaim-record.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(committedPayload, &committed); err != nil {
+		t.Fatal(err)
+	}
+	if committed.Status != CompactReclaimCommitted {
+		t.Fatalf("persisted retry reclaim record status = %q", committed.Status)
+	}
+}
+
+func TestReclaimCommitRewriteFailureReturnsPreparedRecordWithQuarantine(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	root, _, err := reviewAuthorityRoot(context.Background(), repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(root, "v2", "reclaim-audit")
+	writeReclaimFixtureFile(t, filepath.Join(dir, "stray.tmp"), "stray\n")
+
+	original := persistReclaimRecord
+	persistReclaimRecord = func(record CompactReclaimRecord) error {
+		if record.Status == CompactReclaimCommitted {
+			return errors.New("simulated crash before committed rewrite")
+		}
+		return original(record)
+	}
+	t.Cleanup(func() { persistReclaimRecord = original })
+	request := CompactReclaimRequest{LineageID: "reclaim-audit", Reason: "interrupted store write residue", Actor: "maintainer@example.com"}
+	record, err := ReclaimIncompleteCompactStore(context.Background(), repo, request)
+	if err == nil {
+		t.Fatal("failed committed rewrite reported success")
+	}
+	if record.Status != CompactReclaimPrepared || record.QuarantinePath == "" ||
+		len(record.Residue) != 1 || record.Residue[0] != "stray.tmp" {
+		t.Fatalf("committed-rewrite failure record = %#v", record)
+	}
+	if !strings.Contains(err.Error(), record.QuarantinePath) {
+		t.Fatalf("committed-rewrite failure hides the quarantine location: %v", err)
+	}
+	if _, statErr := os.Stat(dir); !os.IsNotExist(statErr) {
+		t.Fatalf("committed-rewrite failure left the source entry behind: %v", statErr)
+	}
+	moved, readErr := os.ReadFile(filepath.Join(record.QuarantinePath, "residue", "stray.tmp"))
+	if readErr != nil || !bytes.Equal(moved, []byte("stray\n")) {
+		t.Fatalf("quarantined residue bytes = %q, %v", moved, readErr)
+	}
+	var persisted CompactReclaimRecord
+	payload, readErr := os.ReadFile(filepath.Join(record.QuarantinePath, "reclaim-record.json"))
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if err := json.Unmarshal(payload, &persisted); err != nil {
+		t.Fatal(err)
+	}
+	if persisted.Status != CompactReclaimPrepared {
+		t.Fatalf("persisted record after failed committed rewrite = %#v", persisted)
+	}
+
+	// The source entry is gone, so the only reconciliation surface is the
+	// quarantine itself; a retry correctly refuses with the missing-entry error.
+	persistReclaimRecord = original
+	if _, retryErr := ReclaimIncompleteCompactStore(context.Background(), repo, request); !errors.Is(retryErr, os.ErrNotExist) {
+		t.Fatalf("retry after quarantined residue = %v", retryErr)
+	}
+}
+
+func writeReclaimFixtureFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/reviewtransaction/compact_reclaim_test.go
+++ b/internal/reviewtransaction/compact_reclaim_test.go
@@ -258,6 +258,163 @@ func TestReclaimCrashBeforeRenameLeavesPreparedOrphanAndRetrySucceeds(t *testing
 	}
 }
 
+func TestReclaimPreparedRecordFailureRemovesUnidentifiedQuarantine(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	root, _, err := reviewAuthorityRoot(context.Background(), repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(root, "v2", "reclaim-audit")
+	writeReclaimFixtureFile(t, filepath.Join(dir, "stray.tmp"), "stray\n")
+
+	original := persistReclaimRecord
+	persistReclaimRecord = func(CompactReclaimRecord) error {
+		return errors.New("simulated prepared record failure")
+	}
+	t.Cleanup(func() { persistReclaimRecord = original })
+
+	if _, err := ReclaimIncompleteCompactStore(context.Background(), repo, CompactReclaimRequest{
+		LineageID: "reclaim-audit", Reason: "residue", Actor: "maintainer",
+	}); err == nil {
+		t.Fatal("failed prepared record write reported success")
+	}
+	entries, err := os.ReadDir(filepath.Join(root, "quarantine"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("prepared record failure left unidentified quarantine entries: %#v", entries)
+	}
+	if payload, err := os.ReadFile(filepath.Join(dir, "stray.tmp")); err != nil || !bytes.Equal(payload, []byte("stray\n")) {
+		t.Fatalf("prepared record failure mutated source residue: %q, %v", payload, err)
+	}
+}
+
+func TestReclaimRefusesSymlinkedQuarantineRoot(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	root, _, err := reviewAuthorityRoot(context.Background(), repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(root, "v2", "reclaim-audit")
+	writeReclaimFixtureFile(t, filepath.Join(dir, "stray.tmp"), "stray\n")
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(root, "quarantine")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	if _, err := ReclaimIncompleteCompactStore(context.Background(), repo, CompactReclaimRequest{
+		LineageID: "reclaim-audit", Reason: "residue", Actor: "maintainer",
+	}); err == nil {
+		t.Fatal("reclaim followed a symlinked quarantine root")
+	}
+	entries, err := os.ReadDir(outside)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("reclaim escaped through quarantine symlink: %#v", entries)
+	}
+}
+
+func TestReclaimQuarantineCreationSyncFailureLeavesNoUnidentifiedDirectory(t *testing.T) {
+	for _, failedDirectory := range []string{"authority root", "quarantine root"} {
+		t.Run(failedDirectory, func(t *testing.T) {
+			repo := initSnapshotRepo(t)
+			root, _, err := reviewAuthorityRoot(context.Background(), repo)
+			if err != nil {
+				t.Fatal(err)
+			}
+			dir := filepath.Join(root, "v2", "reclaim-audit")
+			writeReclaimFixtureFile(t, filepath.Join(dir, "stray.tmp"), "stray\n")
+
+			originalSync := syncReviewDirectory
+			quarantineRootSyncs := 0
+			syncReviewDirectory = func(path string) error {
+				if path == filepath.Join(root, "quarantine") {
+					quarantineRootSyncs++
+				}
+				if failedDirectory == "authority root" && path == root ||
+					failedDirectory == "quarantine root" && path == filepath.Join(root, "quarantine") && quarantineRootSyncs == 1 {
+					return errors.New("simulated directory sync failure")
+				}
+				return nil
+			}
+			t.Cleanup(func() { syncReviewDirectory = originalSync })
+
+			if _, err := ReclaimIncompleteCompactStore(context.Background(), repo, CompactReclaimRequest{
+				LineageID: "reclaim-audit", Reason: "residue", Actor: "maintainer",
+			}); err == nil {
+				t.Fatal("quarantine creation sync failure reported success")
+			}
+			entries, err := os.ReadDir(filepath.Join(root, "quarantine"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(entries) != 0 {
+				t.Fatalf("quarantine creation sync failure left unidentified entries: %#v", entries)
+			}
+		})
+	}
+}
+
+func TestReclaimRenameSyncFailureLeavesPreparedRecord(t *testing.T) {
+	for _, tt := range []struct {
+		name       string
+		failedPath func(root, quarantineDir string) string
+	}{
+		{name: "source version root", failedPath: func(root, _ string) string { return filepath.Join(root, "v2") }},
+		{name: "quarantine directory", failedPath: func(_ string, quarantineDir string) string { return quarantineDir }},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := initSnapshotRepo(t)
+			root, _, err := reviewAuthorityRoot(context.Background(), repo)
+			if err != nil {
+				t.Fatal(err)
+			}
+			dir := filepath.Join(root, "v2", "reclaim-audit")
+			writeReclaimFixtureFile(t, filepath.Join(dir, "stray.tmp"), "stray\n")
+
+			originalSync := syncReviewDirectory
+			var quarantineDir string
+			quarantineDirSyncs := 0
+			syncReviewDirectory = func(path string) error {
+				if strings.HasPrefix(path, filepath.Join(root, "quarantine")+string(os.PathSeparator)) {
+					quarantineDir = path
+					quarantineDirSyncs++
+				}
+				if quarantineDir != "" && path == tt.failedPath(root, quarantineDir) &&
+					(path != quarantineDir || quarantineDirSyncs > 1) {
+					return errors.New("simulated rename directory sync failure")
+				}
+				return nil
+			}
+			t.Cleanup(func() { syncReviewDirectory = originalSync })
+
+			record, err := ReclaimIncompleteCompactStore(context.Background(), repo, CompactReclaimRequest{
+				LineageID: "reclaim-audit", Reason: "residue", Actor: "maintainer",
+			})
+			if err == nil {
+				t.Fatal("rename directory sync failure reported success")
+			}
+			if record.Status != CompactReclaimPrepared || record.QuarantinePath == "" {
+				t.Fatalf("rename sync failure record = %#v", record)
+			}
+			payload, readErr := os.ReadFile(filepath.Join(record.QuarantinePath, "reclaim-record.json"))
+			if readErr != nil {
+				t.Fatal(readErr)
+			}
+			var persisted CompactReclaimRecord
+			if err := json.Unmarshal(payload, &persisted); err != nil {
+				t.Fatal(err)
+			}
+			if persisted.Status != CompactReclaimPrepared {
+				t.Fatalf("rename sync failure published status %q", persisted.Status)
+			}
+		})
+	}
+}
+
 func TestReclaimCommitRewriteFailureReturnsPreparedRecordWithQuarantine(t *testing.T) {
 	repo := initSnapshotRepo(t)
 	root, _, err := reviewAuthorityRoot(context.Background(), repo)

--- a/internal/reviewtransaction/compact_store.go
+++ b/internal/reviewtransaction/compact_store.go
@@ -18,6 +18,17 @@ import (
 )
 
 const compactRecordSchema = "gentle-ai.review-state-record/v2"
+
+// Compact store entry artifact names. Every file the compact store writes
+// under a lineage directory must be named here so the reclaim authority
+// predicate stays in sync with the store layout.
+const (
+	compactStateFileName           = "review-state.json"
+	compactReceiptFileName         = "review-receipt.json"
+	compactFinalizeJournalFileName = "finalize-attempt-journal.json"
+	// CompactReviewerResultsDir holds captured reviewer result artifacts.
+	CompactReviewerResultsDir = "reviewer-results"
+)
 const CompactTransportSchema = "gentle-ai.review-transport/v2"
 const LegacyReadOnlyErrorCode = "legacy_v1_read_only"
 
@@ -502,7 +513,7 @@ func DiscoverCompactStores(ctx context.Context, repo string) ([]CompactStore, er
 			continue
 		}
 		dir := filepath.Join(versionRoot, entry.Name())
-		if _, statErr := os.Stat(filepath.Join(dir, "review-state.json")); os.IsNotExist(statErr) {
+		if _, statErr := os.Stat(filepath.Join(dir, compactStateFileName)); os.IsNotExist(statErr) {
 			residue, readErr := os.ReadDir(dir)
 			unpublished := readErr == nil
 			for _, item := range residue {
@@ -920,10 +931,10 @@ func compactStartScopeCompatible(ctx context.Context, repo string, existing, req
 		assessment.ChangedLines == requested.OriginalChangedLines
 }
 
-func (store CompactStore) StatePath() string { return filepath.Join(store.Dir, "review-state.json") }
+func (store CompactStore) StatePath() string { return filepath.Join(store.Dir, compactStateFileName) }
 
 func (store CompactStore) ReceiptPath() string {
-	return filepath.Join(store.Dir, "review-receipt.json")
+	return filepath.Join(store.Dir, compactReceiptFileName)
 }
 
 func (store CompactStore) Load() (CompactRecord, error) {

--- a/internal/reviewtransaction/finalize_attempt_journal.go
+++ b/internal/reviewtransaction/finalize_attempt_journal.go
@@ -71,7 +71,7 @@ func FinalizeAttemptRequestDigest(request FinalizeAttemptRequest) string {
 }
 
 func (store CompactStore) FinalizeAttemptJournalPath() string {
-	return filepath.Join(store.Dir, "finalize-attempt-journal.json")
+	return filepath.Join(store.Dir, compactFinalizeJournalFileName)
 }
 
 // PendingFinalizeAttempt returns the one unresolved request for this lineage.

--- a/internal/reviewtransaction/status.go
+++ b/internal/reviewtransaction/status.go
@@ -24,6 +24,7 @@ const (
 	AuthorityStatusApproved   AuthorityStatus = "approved"
 	AuthorityStatusEscalated  AuthorityStatus = "escalated"
 	AuthorityStatusInvalid    AuthorityStatus = "invalid"
+	AuthorityStatusIncomplete AuthorityStatus = "incomplete-store-entry"
 	AuthorityStatusReset      AuthorityStatus = "reset-in-progress"
 	AuthorityStatusSuperseded AuthorityStatus = "superseded"
 	AuthorityStatusRecovered  AuthorityStatus = "recovered"
@@ -131,7 +132,7 @@ func InventoryAuthority(ctx context.Context, repo string) (AuthorityStatusReport
 	markCompactGraph(&report)
 	markMixedCollisions(&report)
 	for _, entry := range report.Entries {
-		if entry.Status == AuthorityStatusInvalid || entry.Status == AuthorityStatusReset || entry.Status == AuthorityStatusCollision {
+		if entry.Status == AuthorityStatusInvalid || entry.Status == AuthorityStatusIncomplete || entry.Status == AuthorityStatusReset || entry.Status == AuthorityStatusCollision {
 			report.Complete = false
 		}
 	}
@@ -229,6 +230,11 @@ func inventoryLineage(ctx context.Context, repo string, version AuthorityVersion
 		return entry, locks
 	}
 	if version == AuthorityVersionCompact {
+		if _, statErr := os.Stat(filepath.Join(path, compactStateFileName)); os.IsNotExist(statErr) && !compactStoreHoldsAuthority(items) {
+			entry.Status = AuthorityStatusIncomplete
+			entry.Problems = []string{"compact store entry has no review-state.json and no authoritative artifacts; quarantine it with gentle-ai review reclaim"}
+			return entry, locks
+		}
 		store := CompactStore{Dir: path, lineageID: lineage, repo: repo}
 		record, err := store.Load()
 		if err != nil {
@@ -353,7 +359,7 @@ func markCompactGraph(report *AuthorityStatusReport) {
 	children := map[string][]int{}
 	for index := range report.Entries {
 		entry := &report.Entries[index]
-		if entry.Version == AuthorityVersionCompact && entry.Status != AuthorityStatusReset &&
+		if entry.Version == AuthorityVersionCompact && entry.Status != AuthorityStatusReset && entry.Status != AuthorityStatusIncomplete &&
 			(entry.Status != AuthorityStatusInvalid || entry.State == StateInvalidated && len(entry.Problems) == 0) {
 			byLineage[entry.LineageID] = index
 		}


### PR DESCRIPTION
## Summary

Fixes #1392: a compact-v2 store directory left without `review-state.json` (interrupted write residue) poisoned every lineage-less gate validation with `receipt-discovery/authority_corrupted` — and residue containing any stray non-atomic file also broke `review start` repo-wide — with no sanctioned way to act on it (deleting `.git/gentle-ai` or fabricating state would break the authority chain).

- **Inventory classification**: a compact-v2 directory with no `review-state.json` and no other authoritative artifact (`review-receipt.json`, `finalize-attempt-journal.json`, `reviewer-results/`, `.atomic-*`) is now classified as a distinct `incomplete-store-entry` cause. Fail-closed semantics unchanged: it still forces `Complete=false/Authoritative=false`, and gate denials now report `cause_category: incomplete_store_entry`.
- **Audited reclaim**: new `gentle-ai review reclaim --cwd <repo> --lineage <id> --reason <r> --actor <a>` quarantines the residue — move, never delete — under `.git/gentle-ai/review-transactions/quarantine/<lineage>-<nonce>/residue/` with a persisted audit record (`gentle-ai.review-reclaim-record/v1`: who/why/when/what). It refuses any entry holding an authoritative artifact and serializes under the same v2 `LOCK` as all authority writes.
- **Crash safety**: the audit record is two-phase (`status: prepared` before the move, atomically rewritten to `committed` after). Both partial-failure windows return the populated prepared record alongside the error (the CLI emits it and still exits non-zero), so the operator always learns the quarantine location; orphans self-describe via the `residue/` directory discriminator.
- After reclaim, lineage-less discovery, gate validation, and `review start` work again over the remaining valid authorities.

Artifact filenames are now single-sourced in shared constants beside the store, so the reclaim predicate cannot drift from the actual store layout.

## Tests (TDD-first throughout)

- Inventory classification (6 subtests), reclaim quarantine + audit record, refusal matrix (7 subtests), gate-denial cause category.
- End-to-end CLI: reclaim restores lineage-less discovery; `review start` succeeds with empty residue, fails when residue is enumerated, and is unblocked by reclaim (reproduces the real-world start failure).
- Crash injection via seams: rename failure (prepared orphan, source untouched, safe retry) and committed-rewrite failure (prepared record with quarantine path returned, retry refuses with missing-entry).

Known documented follow-up (deliberately out of scope): residue bearing authoritative-named files without a state file stays fail-closed and is not auto-reclaimable — quarantining a surviving receipt requires maintainer analysis.

Refs #1392. Related: #1334/#1335 (same audited-reclaim philosophy for lock metadata), #1387 (discovery tolerance for legacy-v1 corruption).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `review reclaim` to quarantine incomplete compact store residue.
  * Reclaim now writes `reclaim-record.json` with operation/audit details, including quarantine paths when relevant.
* **Bug Fixes**
  * Improved detection/reporting for incomplete compact store entries (`incomplete-store-entry`), preventing them from being treated as valid authority.
  * Updated reviewer result artifact location handling to use the standardized reviewer-results directory.
  * Refined authority inventory categorization for incomplete entries.
* **Tests**
  * Added integration and unit coverage for reclaim, validation gating, and crash/partial-failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->