### PR TITLE
fix(spec): align findings-ledger lens fields with reviewer contract

### DIFF
--- a/openspec/specs/review-findings-ledger/spec.md
+++ b/openspec/specs/review-findings-ledger/spec.md
@@ -45,7 +45,7 @@ The current-changes target MUST combine tracked staged, unstaged, and deleted st
 
 ### Requirement: Initial findings freeze
 
-Each selected lens MUST run exactly one initial sweep and emit neutral claims with `id`, `lens`, `location`, `severity`, `claim`, `evidence_class`, `proof_refs`, and `status`. Full 4R means four initial lens sweeps. Findings MUST freeze after merge.
+Each selected lens MUST run exactly one initial sweep and emit neutral claims with `id`, `lens`, `location`, `severity`, `claim`, and `proof_refs`. `BLOCKER | CRITICAL` claims MUST additionally carry `evidence_class` and `causal_disposition`. Per-finding status is derived by the system into evidence outcomes and MUST NOT be emitted by a lens. Full 4R means four initial lens sweeps. Findings MUST freeze after merge.
 
 #### Scenario: Full 4R selects four lenses once
 


### PR DESCRIPTION
## Summary

Fixes #1313: `openspec/specs/review-findings-ledger/spec.md:48` mandated a lens-emitted `status` field that the shipped reviewer JSON schema rejects (`additionalProperties:false`), and omitted `causal_disposition`, which the schema requires for BLOCKER/CRITICAL findings.

The lens-emission sentence now matches the released contract exactly: neutral claims carry `id`, `lens`, `location`, `severity`, `claim`, `proof_refs`; BLOCKER/CRITICAL claims additionally carry `evidence_class` and `causal_disposition`; per-finding status is derived by the system into evidence outcomes and MUST NOT be emitted by a lens.

Audited the rest of the spec against all three schemas (reviewer, refuter, validator) — no other drift. Doc-only; no Go code touched.

Refs #1313