### PR TITLE
fix(review): read receiptless terminal legacy chains as historical

### DIFF
--- a/internal/cli/review_receipt_discovery_test.go
+++ b/internal/cli/review_receipt_discovery_test.go
@@ -57,6 +57,50 @@ func TestUnqualifiedGateDiscoverySelectsOneExactReceiptAcrossUnrelatedHistory(t 
 	}
 }
 
+func TestReceiptlessTerminalLegacyChainIsInventoryReadableButNeverGateAuthority(t *testing.T) {
+	fixture := newLegacyCLIFixture(t, "legacy-pre-receipt")
+	if err := os.Remove(fixture.receiptPath); err != nil {
+		t.Fatal(err)
+	}
+
+	report, err := reviewtransaction.InventoryAuthority(context.Background(), fixture.repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !report.Complete || !report.Authoritative {
+		t.Fatalf("receiptless terminal legacy chain forced incomplete inventory = %#v", report)
+	}
+	if len(report.Entries) != 1 || report.Entries[0].Status != reviewtransaction.AuthorityStatusHistorical {
+		t.Fatalf("receiptless terminal legacy entry = %#v", report.Entries)
+	}
+
+	gateInput := reviewtransaction.NativeGateRequestInput{Gate: reviewtransaction.GatePostApply}
+	_, _, discoveryErr := discoverCompactFacadeGateReview(context.Background(), fixture.repo, "", gateInput)
+	var discovery *ReviewReceiptDiscoveryError
+	if !errors.As(discoveryErr, &discovery) || discovery.Kind != ReviewReceiptMissing {
+		t.Fatalf("receiptless legacy gate discovery = %#v, %v", discovery, discoveryErr)
+	}
+	if exact := legacyExactFacadeGateLineages(context.Background(), fixture.repo, gateInput); exact != 0 {
+		t.Fatalf("receiptless legacy chain counted as exact gate lineage %d times", exact)
+	}
+	if _, _, _, legacyErr := discoverFacadeReview(context.Background(), fixture.repo, fixture.lineage, true); legacyErr == nil {
+		t.Fatal("receiptless legacy chain was discovered as terminal facade authority")
+	}
+
+	var output bytes.Buffer
+	err = RunReview([]string{
+		"validate", "--contract", ReviewIntegrationContractV1, "--cwd", fixture.repo,
+		"--gate", string(reviewtransaction.GatePostApply),
+	}, &output)
+	if err == nil {
+		t.Fatal("receiptless legacy chain acted as gate authority")
+	}
+	failure := decodeReviewIntegrationFailure(t, output.Bytes())
+	if failure.Code != "receipt_missing" || failure.MutationOutcome != ReviewMutationNotStarted || failure.RetrySafe {
+		t.Fatalf("receiptless legacy gate failure = %#v", failure)
+	}
+}
+
 func TestUnqualifiedGateDiscoveryReturnsTypedMissingAndScopeChanged(t *testing.T) {
 	t.Run("missing", func(t *testing.T) {
 		repo := initReviewCLIRepo(t)

--- a/internal/reviewtransaction/status.go
+++ b/internal/reviewtransaction/status.go
@@ -28,6 +28,12 @@ const (
 	AuthorityStatusSuperseded AuthorityStatus = "superseded"
 	AuthorityStatusRecovered  AuthorityStatus = "recovered"
 	AuthorityStatusCollision  AuthorityStatus = "same-lineage-mixed-collision"
+	// AuthorityStatusHistorical marks a structurally valid terminal legacy-v1
+	// chain that predates the receipt contract: its receipt file is absent
+	// (never corrupt or mismatched). Such chains stay inventory-readable
+	// without forcing the global inventory incomplete, but they are never
+	// discoverable as gate or receipt authority because no receipt exists.
+	AuthorityStatusHistorical AuthorityStatus = "historical-pre-receipt"
 )
 
 type AuthorityVersion string
@@ -266,7 +272,13 @@ func inventoryLineage(ctx context.Context, repo string, version AuthorityVersion
 			entry.Status, entry.Problems = AuthorityStatusInvalid, []string{"legacy receipt does not match terminal authority"}
 		}
 	} else if os.IsNotExist(err) && (transaction.State == StateApproved || transaction.State == StateEscalated) {
-		entry.Status, entry.Problems = AuthorityStatusInvalid, []string{"terminal legacy authority is missing its receipt"}
+		// A structurally valid terminal legacy-v1 chain whose receipt file is
+		// absent predates the receipt contract. It stays inventory-readable as
+		// historical context without forcing the global inventory incomplete,
+		// yet remains ineligible as gate or discovery authority because every
+		// receipt consumer requires the receipt file itself. A present-but-wrong
+		// receipt is handled above and stays invalid.
+		entry.Status = AuthorityStatusHistorical
 	} else if !os.IsNotExist(err) {
 		entry.Status, entry.Problems = AuthorityStatusInvalid, []string{"read legacy receipt: " + err.Error()}
 	}

--- a/internal/reviewtransaction/status_test.go
+++ b/internal/reviewtransaction/status_test.go
@@ -368,6 +368,95 @@ func TestInventoryAuthorityReportsRecoveredInvalidatedSuccessorAndSupersededPred
 	}
 }
 
+func TestInventoryAuthorityKeepsReceiptlessTerminalLegacyChainReadableAsHistorical(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	transaction, _, _ := nativeGateFixture(t, repo, "legacy-pre-receipt")
+	store, err := AuthoritativeStore(context.Background(), repo, transaction.LineageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	appendApprovedStoreChain(t, store, transaction)
+	root, _, err := reviewAuthorityRoot(context.Background(), repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	before := authorityBytes(t, root)
+
+	report, err := InventoryAuthority(context.Background(), repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !report.Complete || !report.Authoritative || report.Status != AuthorityStatusHistorical ||
+		!hasAuthorityInventoryStatus(report.Entries, "legacy-pre-receipt", AuthorityStatusHistorical) {
+		t.Fatalf("receiptless terminal legacy report = %#v", report)
+	}
+	for _, entry := range report.Entries {
+		if entry.LineageID == "legacy-pre-receipt" && len(entry.Problems) != 0 {
+			t.Fatalf("historical entry reported problems = %#v", entry.Problems)
+		}
+	}
+	if after := authorityBytes(t, root); !reflect.DeepEqual(before, after) {
+		t.Fatal("read-only authority inventory changed authority bytes")
+	}
+}
+
+func TestInventoryAuthorityKeepsPresentButMalformedLegacyReceiptInvalid(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	transaction, _, _ := nativeGateFixture(t, repo, "legacy-corrupt-receipt")
+	store, err := AuthoritativeStore(context.Background(), repo, transaction.LineageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	appendApprovedStoreChain(t, store, transaction)
+	receiptPath := filepath.Join(store.Dir, "artifacts", "receipt.json")
+	if err := os.MkdirAll(filepath.Dir(receiptPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(receiptPath, []byte("{broken\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	report, err := InventoryAuthority(context.Background(), repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.Complete || report.Authoritative || report.Status != AuthorityStatusInvalid ||
+		!hasAuthorityInventoryStatus(report.Entries, "legacy-corrupt-receipt", AuthorityStatusInvalid) {
+		t.Fatalf("malformed present receipt report = %#v", report)
+	}
+}
+
+func TestInventoryAuthorityKeepsNonTerminalReceiptlessLegacyChainActive(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	transaction, _, _ := nativeGateFixture(t, repo, "legacy-open-review")
+	store, err := AuthoritativeStore(context.Background(), repo, transaction.LineageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	reviewing := transaction
+	reviewing.LensResults = nil
+	for _, lens := range supportedLenses {
+		setLensCounter(&reviewing.Counters, lens, 0)
+	}
+	reviewing.State = StateReviewing
+	reviewing.LedgerHash = ""
+	reviewing.EvidenceHash = ""
+	reviewing.Release = nil
+	reviewing.Counters.FinalVerifications = 0
+	if _, err := store.Append("", Record{Operation: "review/start", Transaction: reviewing}); err != nil {
+		t.Fatal(err)
+	}
+
+	report, err := InventoryAuthority(context.Background(), repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !report.Complete || !report.Authoritative ||
+		!hasAuthorityInventoryStatus(report.Entries, "legacy-open-review", AuthorityStatusActive) {
+		t.Fatalf("non-terminal receiptless legacy report = %#v", report)
+	}
+}
+
 func authorityBytes(t *testing.T, root string) map[string][]byte {
 	t.Helper()
 	files := map[string][]byte{}


### PR DESCRIPTION
## Summary

Fixes #1354 (remaining symptoms): a terminal legacy-v1 chain created before the receipt contract, with no `artifacts/receipt.json`, was classified `invalid` ("terminal legacy authority is missing its receipt"), forcing repo-wide `complete:false/authoritative:false` and blocking every new ordinary review in a shared git common directory. (The v1 operation-alias replay the issue also mentions was already handled read-only by `validatePersistedV1Successor`.)

- New inventory status `historical-pre-receipt`, applied only when: legacy-v1 chain loads structurally (including alias replay), state is terminal, and the receipt read fails specifically with `os.IsNotExist`.
- Historical entries are inventory-readable and never force incomplete; they are structurally barred from being gate authority because every consumer (compact/facade discovery, legacy candidate counting, sdd-status receipt discovery, gate validation) independently requires the receipt file — pinned end-to-end by test.
- Present-but-corrupt or mismatched receipts, I/O errors, non-terminal receiptless chains, and compact-v2 missing receipts all keep today's fail-closed behavior; mixed v1/v2 collision marking still overrides.

The invalidated-state compact classification symptom is covered separately by #1314.

## Tests (TDD-first; the primary tests reproduced the issue's exact invalid classification before the fix)

- `TestInventoryAuthorityKeepsReceiptlessTerminalLegacyChainReadableAsHistorical`
- `TestInventoryAuthorityKeepsPresentButMalformedLegacyReceiptInvalid`
- `TestInventoryAuthorityKeepsNonTerminalReceiptlessLegacyChainActive`
- `TestReceiptlessTerminalLegacyChainIsInventoryReadableButNeverGateAuthority`

Refs #1354

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Legacy review histories without receipts are now recognized as readable historical records instead of being incorrectly marked invalid.
  * Terminal receiptless histories are not treated as authoritative gates.
  * Malformed receipts continue to be reported as invalid.
  * Non-terminal receiptless histories remain active and reviewable.

* **Tests**
  * Added coverage for legacy receipt handling, authority classification, and validation outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->