### PR TITLE
fix(opencode): preserve selected lens names during capture

### DIFF
--- a/internal/assets/assets_test.go
+++ b/internal/assets/assets_test.go
@@ -434,12 +434,17 @@ func TestReviewResultArtifactsPluginContract(t *testing.T) {
 		`"tool.execute.before"`,
 		`output.args.background === true`,
 		`!BINDING.test(input.args.prompt)`,
+		`const lens = input.args.subagent_type`,
+		`const binding = parseBinding(input.args.prompt, lens)`,
 		`output.output = await captureResult`,
 		`export default ReviewResultArtifactsPlugin`,
 	} {
 		if !strings.Contains(source, want) {
 			t.Fatalf("review-result-artifacts.ts missing %q", want)
 		}
+	}
+	if strings.Contains(source, `.slice("review-".length)`) {
+		t.Fatal("review-result-artifacts.ts must preserve the exact full selected lens; found review- prefix stripping")
 	}
 	for _, forbidden := range []string{"writeFile", "link(", "chmod(", "createHash", "export {", "export const"} {
 		if strings.Contains(source, forbidden) {

--- a/internal/assets/opencode/plugins/review-result-artifacts.ts
+++ b/internal/assets/opencode/plugins/review-result-artifacts.ts
@@ -85,7 +85,7 @@ const ReviewResultArtifactsPlugin: Plugin = async ({ directory, worktree }) => (
   "tool.execute.after": async (input, output) => {
     if (input.tool !== "task" || typeof input.args?.subagent_type !== "string" || !REVIEW_AGENTS.has(input.args.subagent_type)) return
     if (typeof input.args.prompt !== "string" || !BINDING.test(input.args.prompt)) return
-    const lens = input.args.subagent_type.slice("review-".length)
+    const lens = input.args.subagent_type
     const binding = parseBinding(input.args.prompt, lens)
     output.output = await captureResult(worktree || directory, binding, reviewerResult(output.output))
   },


### PR DESCRIPTION
Closes #1409

## Type
- [x] Bug fix

## Summary
- Preserve the exact native selected lens name from the OpenCode review subagent.
- Prevent plugin/native binding disagreement that blocked reviewer-result capture.
- Add an embedded asset contract regression against prefix stripping.

## Changes
| File | Change |
|------|--------|
| `internal/assets/opencode/plugins/review-result-artifacts.ts` | Pass the full allowlisted review agent name to binding validation and native capture. |
| `internal/assets/assets_test.go` | Enforce full selected-lens identity and reject prefix stripping. |

## Test Plan
- [x] `go test ./internal/assets -run ^'TestReviewResultArtifactsPluginContract$' -count=1`\n- [x] `go test ./internal/assets -count=1`\n- [x] `go vet ./internal/assets`\n- [x] Formatting and `git diff --check`\n- [x] Native bounded review approved and pre-commit/pre-push/pre-pr gates allowed\n\n## Contributor Checklist\n- [x] Linked an approved issue\n- [x] Added exactly one `type:*` label\n- [x] Relevant checks passed\n- [x] Skills tested in the target agent flow\n- [x] Documentation updated if behavior changed (not required)\n- [x] Conventional commit format\n- [x] No `Co-Authored-By` trailers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed review result artifact handling so the selected review lens is preserved in full.
  - Improved lens validation to correctly match complete review subagent types, such as `review-risk`.
  - Added safeguards to prevent accidental removal of the `review-` prefix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->