### PR TITLE
fix(review): reconcile current-changes receipts at pre-pr

### DIFF
--- a/internal/cli/review_receipt_discovery_test.go
+++ b/internal/cli/review_receipt_discovery_test.go
@@ -413,6 +413,40 @@ func TestUnqualifiedPrePRDiscoveryComposesSequentialReceiptsForSamePath(t *testi
 	}
 }
 
+func TestUnqualifiedPrePRDiscoveryReconcilesCurrentChangesReceiptAcrossDivergedBase(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	branch := strings.TrimSpace(runReviewCLIGit(t, repo, "symbolic-ref", "--short", "HEAD"))
+	initialCommit := strings.TrimSpace(runReviewCLIGit(t, repo, "rev-parse", "HEAD"))
+	remote := filepath.Join(t.TempDir(), "remote.git")
+	runReviewCLIGit(t, repo, "clone", "--bare", repo, remote)
+	runReviewCLIGit(t, repo, "remote", "add", "origin", remote)
+	started, _ := approveDiscoveryMarkdown(t, repo, "review-current-diverged-base", "docs/single.md", "reviewed\n")
+	runReviewCLIGit(t, repo, "add", "-A")
+	runReviewCLIGit(t, repo, "commit", "-qm", "deliver reviewed change")
+	runReviewCLIGit(t, repo, "checkout", "-qb", "base-advance", initialCommit)
+	if err := os.WriteFile(filepath.Join(repo, "base-only.txt"), []byte("base advance\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runReviewCLIGit(t, repo, "add", "base-only.txt")
+	runReviewCLIGit(t, repo, "commit", "-qm", "advance publication base")
+	runReviewCLIGit(t, repo, "push", "-q", "origin", "base-advance:refs/heads/"+branch)
+	runReviewCLIGit(t, repo, "checkout", "-q", branch)
+
+	var output bytes.Buffer
+	if err := RunReview([]string{
+		"validate", "--contract", ReviewIntegrationContractV1, "--cwd", repo,
+		"--gate", string(reviewtransaction.GatePrePR), "--base-ref", "origin/" + branch,
+	}, &output); err != nil {
+		t.Fatalf("diverged-base current-changes pre-PR validation: %v\n%s", err, output.String())
+	}
+	var result ReviewValidateResult
+	decodeStrictReviewJSON(t, decodeReviewOperationEnvelope(t, output.Bytes()).Result, &result)
+	if !result.Allowed || result.Context.LineageID != started.LineageID || result.Context.BaseAdvance == nil ||
+		!result.Context.BaseAdvance.Compatible || result.Context.BaseAdvance.Status != "current-changes-boundary-compatible" {
+		t.Fatalf("diverged-base current-changes pre-PR result = %#v", result)
+	}
+}
+
 func TestUnqualifiedPrePRDiscoveryKeepsExactSingleReceiptContext(t *testing.T) {
 	repo := initReviewCLIRepo(t)
 	branch := strings.TrimSpace(runReviewCLIGit(t, repo, "symbolic-ref", "--short", "HEAD"))

--- a/internal/reviewtransaction/compact_gate.go
+++ b/internal/reviewtransaction/compact_gate.go
@@ -80,8 +80,14 @@ func AssessCompactGateTarget(ctx context.Context, repo string, state CompactStat
 	if request.Gate == GatePrePR {
 		// A base advance is authorized only by the later evidence-bearing gate
 		// evaluation, but it still names this receipt when candidate and paths
-		// remain exact.
+		// remain exact, or when a current-changes receipt provably reaches the
+		// diverged publication boundary unchanged.
 		baseMatches = true
+		if !pathsMatch && snapshot.CandidateTree == state.CurrentSnapshot.CandidateTree {
+			if proof, proofErr := deriveCurrentChangesBoundaryCompatibility(ctx, repo, state, request, snapshot, resolvedPrePR); proofErr == nil && proof.Compatible {
+				pathsMatch = true
+			}
+		}
 	}
 	if snapshot.CandidateTree == state.CurrentSnapshot.CandidateTree && pathsMatch && baseMatches {
 		assessment.Applicability = CompactGateTargetExact
@@ -205,6 +211,9 @@ func EvaluateCompactGate(ctx context.Context, repo string, receipt CompactReceip
 	if request.Gate == GatePrePR && snapshot.BaseTree != receipt.BaseTree {
 		legacyShape := Receipt{BaseTree: receipt.BaseTree, FinalCandidateTree: receipt.FinalCandidateTree, PathsDigest: receipt.PathsDigest}
 		if proof, proofErr := deriveBaseAdvanceCompatibility(ctx, repo, legacyShape, request, snapshot, resolvedPrePR, preimages); proofErr == nil {
+			compatibility = &proof
+			compatibleAdvance = proof.Compatible
+		} else if proof, boundaryErr := deriveCurrentChangesBoundaryCompatibility(ctx, repo, record.State, request, snapshot, resolvedPrePR); boundaryErr == nil {
 			compatibility = &proof
 			compatibleAdvance = proof.Compatible
 		}

--- a/internal/reviewtransaction/prepr.go
+++ b/internal/reviewtransaction/prepr.go
@@ -47,12 +47,27 @@ type prePRCITrust struct {
 	Ed25519PublicKey string `json:"ed25519_public_key"`
 }
 
+const (
+	baseAdvanceCompatibleStatus            = "base-advanced-compatible"
+	currentChangesBoundaryCompatibleStatus = "current-changes-boundary-compatible"
+	currentChangesBoundaryCIStatus         = "not-required"
+)
+
 func (proof BaseAdvanceCompatibility) valid() bool {
-	return proof.Status == "base-advanced-compatible" && proof.Compatible && validGitTree(proof.OriginalMergeBaseTree) && validGitTree(proof.NewBaseTree) &&
+	core := proof.Compatible && validGitTree(proof.OriginalMergeBaseTree) && validGitTree(proof.NewBaseTree) &&
 		validSHA256(proof.OriginalPatchIdentity) && proof.OriginalPatchIdentity == proof.DeliveredPatchIdentity &&
 		validSHA256(proof.DeliveredPathsDigest) && validSHA256(proof.BaseAdvancePathsDigest) && proof.PathsDisjoint &&
-		validGitTree(proof.MergedResultTree) && validSHA256(proof.CIAttestationArtifactHash) &&
-		strings.TrimSpace(proof.CIAttestationIssuer) != "" && proof.CIStatus == "success"
+		validGitTree(proof.MergedResultTree)
+	switch proof.Status {
+	case baseAdvanceCompatibleStatus:
+		return core && validSHA256(proof.CIAttestationArtifactHash) &&
+			strings.TrimSpace(proof.CIAttestationIssuer) != "" && proof.CIStatus == "success"
+	case currentChangesBoundaryCompatibleStatus:
+		return core && proof.CIAttestationArtifactHash == "" && proof.CIAttestationIssuer == "" &&
+			proof.CIStatus == currentChangesBoundaryCIStatus
+	default:
+		return false
+	}
 }
 
 func deriveBaseAdvanceCompatibility(ctx context.Context, repo string, receipt Receipt, request GateRequest, snapshot Snapshot, refs *resolvedPrePRRefs, preimages gateArtifactPreimages) (BaseAdvanceCompatibility, error) {
@@ -126,7 +141,7 @@ func deriveBaseAdvanceCompatibility(ctx context.Context, repo string, receipt Re
 		return BaseAdvanceCompatibility{}, errors.New("HEAD advanced during validation")
 	}
 	proof := BaseAdvanceCompatibility{
-		Status: "base-advanced-compatible", Compatible: true, OriginalMergeBaseTree: receipt.BaseTree, NewBaseTree: snapshot.BaseTree,
+		Status: baseAdvanceCompatibleStatus, Compatible: true, OriginalMergeBaseTree: receipt.BaseTree, NewBaseTree: snapshot.BaseTree,
 		OriginalPatchIdentity: originalPatch, DeliveredPatchIdentity: currentPatch,
 		DeliveredPathsDigest: receipt.PathsDigest, BaseAdvancePathsDigest: digestPaths(basePaths), PathsDisjoint: true,
 		MergedResultTree: mergedFields[0], CIAttestationArtifactHash: attestationHash,
@@ -134,6 +149,104 @@ func deriveBaseAdvanceCompatibility(ctx context.Context, repo string, receipt Re
 	}
 	if !proof.valid() {
 		return BaseAdvanceCompatibility{}, errors.New("compatible base advance proof is incomplete")
+	}
+	return proof, nil
+}
+
+// deriveCurrentChangesBoundaryCompatibility reconciles an approved
+// current-changes receipt with a pre-PR publication boundary that advanced
+// past the frozen base (issue #1376). It is derived gate evidence only and
+// never mutates the receipt. It allows only when the approved bytes provably
+// reach the publication boundary unchanged:
+//   - the reviewed genesis scope is non-empty (an empty self-diff review can
+//     never authorize a non-empty publication),
+//   - the publication head tree is byte-identical to the approved candidate
+//     tree,
+//   - the frozen review base tree is exactly the publication merge-base tree,
+//   - the delivered paths are non-empty, stay inside the immutable genesis
+//     scope, and are disjoint from the boundary advance,
+//   - every path touched by the publication range stays inside the genesis
+//     scope (nothing unreviewed rides along in intermediate commits), and
+//   - the merge against the advanced boundary is conflict-free.
+func deriveCurrentChangesBoundaryCompatibility(ctx context.Context, repo string, state CompactState, request GateRequest, snapshot Snapshot, refs *resolvedPrePRRefs) (BaseAdvanceCompatibility, error) {
+	if refs == nil {
+		return BaseAdvanceCompatibility{}, errors.New("resolved pre-PR refs are missing")
+	}
+	if request.ExternalEvidence != ExternalEvidenceNone {
+		return BaseAdvanceCompatibility{}, errors.New("external evidence invalidates or escalates compatibility")
+	}
+	if state.InitialSnapshot.Kind != TargetCurrentChanges {
+		return BaseAdvanceCompatibility{}, errors.New("boundary reconciliation is limited to current-changes receipts")
+	}
+	if refs.DeliveredCommitCount != 1 {
+		return BaseAdvanceCompatibility{}, errors.New("boundary reconciliation requires exactly one delivery commit")
+	}
+	if len(state.GenesisPaths) == 0 {
+		return BaseAdvanceCompatibility{}, errors.New("an empty reviewed scope cannot authorize a publication")
+	}
+	frozenBaseTree := state.InitialSnapshot.BaseTree
+	if snapshot.CandidateTree != state.CurrentSnapshot.CandidateTree {
+		return BaseAdvanceCompatibility{}, errors.New("publication head does not match the approved candidate tree")
+	}
+	mergeBase, err := runGit(ctx, repo, nil, nil, "merge-base", refs.Selection.Commit, refs.HeadCommit)
+	if err != nil {
+		return BaseAdvanceCompatibility{}, fmt.Errorf("derive publication merge-base: %w", err)
+	}
+	builder := SnapshotBuilder{Repo: repo}
+	mergeBaseTree, err := builder.resolveTree(ctx, strings.TrimSpace(string(mergeBase)))
+	if err != nil || mergeBaseTree != frozenBaseTree {
+		return BaseAdvanceCompatibility{}, errors.New("approved review base is not the publication merge-base")
+	}
+	deliveredPaths, err := builder.changedPaths(ctx, frozenBaseTree, snapshot.CandidateTree)
+	if err != nil {
+		return BaseAdvanceCompatibility{}, err
+	}
+	if len(deliveredPaths) == 0 || pathsAreSubset(deliveredPaths, state.GenesisPaths) != nil {
+		return BaseAdvanceCompatibility{}, errors.New("delivered paths do not stay inside the reviewed genesis scope")
+	}
+	patch, err := patchIdentity(ctx, repo, frozenBaseTree, snapshot.CandidateTree)
+	if err != nil {
+		return BaseAdvanceCompatibility{}, err
+	}
+	basePaths, err := builder.changedPaths(ctx, frozenBaseTree, snapshot.BaseTree)
+	if err != nil {
+		return BaseAdvanceCompatibility{}, err
+	}
+	if !disjointPaths(deliveredPaths, basePaths) {
+		return BaseAdvanceCompatibility{}, errors.New("boundary advance overlaps delivered paths")
+	}
+	if err := validateCompactPublicationRange(ctx, repo, state.GenesisPaths, refs); err != nil {
+		return BaseAdvanceCompatibility{}, err
+	}
+	mergedOutput, err := runGit(ctx, repo, nil, nil, "merge-tree", "--write-tree", refs.Selection.Commit, refs.HeadCommit)
+	if err != nil {
+		return BaseAdvanceCompatibility{}, errors.New("merge against the advanced boundary is not conflict-free")
+	}
+	mergedFields := strings.Fields(string(mergedOutput))
+	if len(mergedFields) == 0 || !validGitTree(mergedFields[0]) {
+		return BaseAdvanceCompatibility{}, errors.New("merged result tree cannot be derived")
+	}
+	selector := ""
+	if refs.Selection.Source == PrePRBoundaryExplicit {
+		selector = refs.Selection.Selector
+	}
+	selectionNow, err := selectPrePRBoundary(ctx, repo, selector)
+	if err != nil || selectionNow != refs.Selection {
+		return BaseAdvanceCompatibility{}, errors.New("pre-PR base ref advanced during validation")
+	}
+	headNow, err := resolveCommit(ctx, repo, "HEAD")
+	if err != nil || headNow != refs.HeadCommit {
+		return BaseAdvanceCompatibility{}, errors.New("HEAD advanced during validation")
+	}
+	proof := BaseAdvanceCompatibility{
+		Status: currentChangesBoundaryCompatibleStatus, Compatible: true,
+		OriginalMergeBaseTree: frozenBaseTree, NewBaseTree: snapshot.BaseTree,
+		OriginalPatchIdentity: patch, DeliveredPatchIdentity: patch,
+		DeliveredPathsDigest: digestPaths(deliveredPaths), BaseAdvancePathsDigest: digestPaths(basePaths), PathsDisjoint: true,
+		MergedResultTree: mergedFields[0], CIStatus: currentChangesBoundaryCIStatus,
+	}
+	if !proof.valid() {
+		return BaseAdvanceCompatibility{}, errors.New("current-changes boundary proof is incomplete")
 	}
 	return proof, nil
 }

--- a/internal/reviewtransaction/prepr_current_changes_test.go
+++ b/internal/reviewtransaction/prepr_current_changes_test.go
@@ -1,0 +1,138 @@
+package reviewtransaction
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+// approvedCurrentChangesDivergedBaseFixture reproduces issue #1376: a
+// current-changes review approved on a feature branch, delivered byte-identical
+// in one commit, while the publication base advances with a disjoint change.
+func approvedCurrentChangesDivergedBaseFixture(t *testing.T, lineage string) (string, CompactState, CompactReceipt, string) {
+	t.Helper()
+	repo := initSnapshotRepo(t)
+	branch := currentBranch(context.Background(), repo)
+	configurePublicationRemote(t, repo, branch)
+	gitSnapshot(t, repo, "checkout", "-qb", "feature")
+	gitSnapshot(t, repo, "config", "branch.feature.remote", "origin")
+	gitSnapshot(t, repo, "config", "branch.feature.merge", "refs/heads/"+branch)
+	writeSnapshotFile(t, repo, "tracked.txt", "reviewed candidate\n")
+	state, _, receipt := approvedCompactCurrentChangesFixture(t, repo, lineage, []string{})
+	gitSnapshot(t, repo, "add", "-A")
+	gitSnapshot(t, repo, "commit", "-m", "reviewed delivery")
+	gitSnapshot(t, repo, "checkout", "-q", branch)
+	writeSnapshotFile(t, repo, "base-only.txt", "base advance\n")
+	gitSnapshot(t, repo, "add", "base-only.txt")
+	gitSnapshot(t, repo, "commit", "-m", "advance publication base")
+	gitSnapshot(t, repo, "push", "-q", "origin", branch)
+	gitSnapshot(t, repo, "checkout", "-q", "feature")
+	return repo, state, receipt, "origin/" + branch
+}
+
+func TestCompactPrePRGateReconcilesApprovedCurrentChangesReceiptAcrossDivergedBase(t *testing.T) {
+	repo, state, receipt, baseRef := approvedCurrentChangesDivergedBaseFixture(t, "compact-current-diverged-base")
+	got := EvaluateCompactGate(context.Background(), repo, receipt, NativeGateRequestInput{Gate: GatePrePR, LineageID: state.LineageID, BaseRef: baseRef})
+	if got.Result != GateAllow {
+		t.Fatalf("diverged-base current-changes pre-PR = %#v", got)
+	}
+	if got.Context.BaseAdvance == nil || !got.Context.BaseAdvance.Compatible || got.Context.BaseAdvance.Status != "current-changes-boundary-compatible" {
+		t.Fatalf("boundary compatibility proof = %#v", got.Context.BaseAdvance)
+	}
+	if got.Context.BaseAdvance.CIAttestationArtifactHash != "" || got.Context.BaseAdvance.CIAttestationIssuer != "" {
+		t.Fatalf("boundary compatibility must not claim CI attestation = %#v", got.Context.BaseAdvance)
+	}
+	payload, err := json.Marshal(got.Context)
+	if err != nil {
+		t.Fatal(err)
+	}
+	parsed, err := ParseGateContext(payload)
+	if err != nil || !reflect.DeepEqual(parsed, got.Context) {
+		t.Fatalf("reconciled pre-PR context round trip = %#v, %v", parsed, err)
+	}
+}
+
+func TestCompactPrePRAssessmentTreatsReconcilableCurrentChangesReceiptAsExact(t *testing.T) {
+	repo, state, _, baseRef := approvedCurrentChangesDivergedBaseFixture(t, "compact-current-diverged-assess")
+	store, err := CompactAuthoritativeStore(context.Background(), repo, state.LineageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	record, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	assessment, err := AssessCompactGateTarget(context.Background(), repo, record.State, NativeGateRequestInput{
+		Gate: GatePrePR, LineageID: state.LineageID, BaseRef: baseRef,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if assessment.Applicability != CompactGateTargetExact {
+		t.Fatalf("reconcilable current-changes applicability = %q; actual=%#v", assessment.Applicability, assessment.Actual)
+	}
+}
+
+func TestCompactPrePRGateFailsClosedWhenDeliveredContentDrifts(t *testing.T) {
+	repo, state, receipt, baseRef := approvedCurrentChangesDivergedBaseFixture(t, "compact-current-diverged-drift")
+	writeSnapshotFile(t, repo, "tracked.txt", "unreviewed drift\n")
+	gitSnapshot(t, repo, "add", "tracked.txt")
+	gitSnapshot(t, repo, "commit", "-m", "unreviewed drift")
+	got := EvaluateCompactGate(context.Background(), repo, receipt, NativeGateRequestInput{Gate: GatePrePR, LineageID: state.LineageID, BaseRef: baseRef})
+	if got.Result != GateScopeChanged {
+		t.Fatalf("drifted current-changes pre-PR = %#v, want scope changed", got)
+	}
+}
+
+func TestCompactPrePRGateFailsClosedForMultipleDeliveryCommits(t *testing.T) {
+	repo, state, receipt, baseRef := approvedCurrentChangesDivergedBaseFixture(t, "compact-current-diverged-commits")
+	writeSnapshotFile(t, repo, "tracked.txt", "temporary unreviewed bytes\n")
+	gitSnapshot(t, repo, "add", "tracked.txt")
+	gitSnapshot(t, repo, "commit", "-m", "temporary delivery")
+	writeSnapshotFile(t, repo, "tracked.txt", "reviewed candidate\n")
+	gitSnapshot(t, repo, "add", "tracked.txt")
+	gitSnapshot(t, repo, "commit", "-m", "restore approved candidate")
+	got := EvaluateCompactGate(context.Background(), repo, receipt, NativeGateRequestInput{Gate: GatePrePR, LineageID: state.LineageID, BaseRef: baseRef})
+	if got.Result != GateScopeChanged {
+		t.Fatalf("multiple delivery commits pre-PR = %#v, want scope changed", got)
+	}
+}
+
+func TestCompactPrePRGateFailsClosedWhenPublicationRangeExceedsGenesis(t *testing.T) {
+	repo, state, receipt, baseRef := approvedCurrentChangesDivergedBaseFixture(t, "compact-current-diverged-range")
+	writeSnapshotFile(t, repo, "secret.txt", "must never be published\n")
+	gitSnapshot(t, repo, "add", "secret.txt")
+	gitSnapshot(t, repo, "commit", "-m", "intermediate secret")
+	if err := os.Remove(filepath.Join(repo, "secret.txt")); err != nil {
+		t.Fatal(err)
+	}
+	gitSnapshot(t, repo, "add", "-A")
+	gitSnapshot(t, repo, "commit", "-m", "remove intermediate secret")
+	got := EvaluateCompactGate(context.Background(), repo, receipt, NativeGateRequestInput{Gate: GatePrePR, LineageID: state.LineageID, BaseRef: baseRef})
+	if got.Result != GateScopeChanged {
+		t.Fatalf("hidden publication-range path pre-PR = %#v, want scope changed", got)
+	}
+}
+
+func TestCompactPrePRGateFailsClosedForEmptyGenesisSelfDiffReceipt(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	branch := currentBranch(context.Background(), repo)
+	configurePublicationRemote(t, repo, branch)
+	gitSnapshot(t, repo, "checkout", "-qb", "feature")
+	gitSnapshot(t, repo, "config", "branch.feature.remote", "origin")
+	gitSnapshot(t, repo, "config", "branch.feature.merge", "refs/heads/"+branch)
+	writeSnapshotFile(t, repo, "tracked.txt", "unreviewed delivery\n")
+	gitSnapshot(t, repo, "add", "-A")
+	gitSnapshot(t, repo, "commit", "-m", "unreviewed delivery")
+	state, _, receipt := approvedCompactCurrentChangesFixture(t, repo, "compact-empty-genesis-self-diff", []string{})
+	if len(state.GenesisPaths) != 0 || state.InitialSnapshot.BaseTree != state.InitialSnapshot.CandidateTree {
+		t.Fatalf("fixture expected an empty self-diff review, got paths=%v", state.GenesisPaths)
+	}
+	got := EvaluateCompactGate(context.Background(), repo, receipt, NativeGateRequestInput{Gate: GatePrePR, LineageID: state.LineageID, BaseRef: "origin/" + branch})
+	if got.Result != GateScopeChanged {
+		t.Fatalf("empty-genesis self-diff pre-PR = %#v, want scope changed", got)
+	}
+}


### PR DESCRIPTION
Closes #1376

## Type
- [x] Bug fix

## Summary
- Reconcile an approved current-changes receipt with a safely advanced PR publication base.
- Preserve exact candidate, genesis scope, merge-base, path-disjointness, stable-ref, and single-delivery-commit guarantees.
- Keep semantic integration authority with required PR CI rather than reopening unchanged code review.

## Changes
| File | Change |
|------|--------|
| `internal/reviewtransaction/prepr.go` | Derive fail-closed current-changes publication-boundary compatibility. |
| `internal/reviewtransaction/compact_gate.go` | Apply the proof only to the exact pre-PR base mismatch. |
| `internal/reviewtransaction/prepr_current_changes_test.go` | Cover safe base advance and rejection paths, including intermediate commits. |
| `internal/cli/review_receipt_discovery_test.go` | Cover facade discovery behavior. |

## Test Plan
- [x] `go test ./internal/reviewtransaction ./internal/cli -count=1`
- [x] Formatting and diff checks
- [x] Native 4R review plus inferential refuter
- [x] Bounded correction validated
- [x] Pre-commit, pre-push, and pre-pr gates allowed

## Contributor Checklist
- [x] Linked an approved issue
- [x] Exactly one `type:*` label
- [x] Relevant checks passed
- [x] Conventional commit
- [x] No `Co-Authored-By` trailers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Pre-PR validation now reconciles approved current-change reviews when the publication base advances with unrelated changes.
  - Reconcilable changes are recognized as an exact validation target, preserving approval across compatible base updates.
  - Compatibility checks distinguish scenarios that require CI attestation from those that do not.

- **Bug Fixes**
  - Validation now fails closed when delivered content, commit count, publication range, or review scope is invalid.

- **Tests**
  - Added coverage for compatible base divergence and invalid reconciliation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->