### PR TITLE
fix(review): align recovery with selected projection

### DIFF
--- a/docs/review-authority-threat-model.md
+++ b/docs/review-authority-threat-model.md
@@ -27,7 +27,7 @@ The compact review store protects valid authority from accidental corruption and
 
 ## Candidate Projections
 
-`gentle-ai review start` defaults to the legacy `workspace` projection. Use `gentle-ai review start --projection staged` to freeze exactly the Git index: unstaged and untracked worktree content is excluded, and the live index and worktree are not modified while deriving evidence. The selected projection is emitted in START JSON and retained by compact authority, receipts, corrections, recovery, and transport.
+`gentle-ai review start` defaults to the legacy `workspace` projection. Use `gentle-ai review start --projection staged` to freeze exactly the Git index: unstaged and untracked worktree content is excluded, and the live index and worktree are not modified while deriving evidence. The selected projection is emitted in START JSON and retained by compact authority, receipts, corrections, recovery, and transport. Recovery inherits the predecessor projection when `--projection` is omitted; an explicit cross-projection successor is accepted only for escalated recovery with the canonical authorization bound to that successor's exact target identity.
 
 After committing a staged candidate, use `gentle-ai review start --projection staged --base-ref <ref>` (and `--committed-only` when tracked workspace changes exist) to record immutable base-to-HEAD delivery provenance. It accepts no intended-untracked paths, remains domain-separated in the v2 identity, and can reuse only the matching staged authority; an otherwise identical workspace authority remains separate.
 
@@ -53,7 +53,7 @@ Legacy v1 chains and bundles remain readable for compatibility, but their histor
 
 ## Recovery And Rollback
 
-- Use `gentle-ai review recover` with an explicit predecessor lineage and revision, a distinct successor lineage, a disposition, reason, and actor. Approved predecessors require a proven scope change; invalidated predecessors remain terminal; escalated predecessors additionally require explicit maintainer authorization.
+- Use `gentle-ai review recover` with an explicit predecessor lineage and revision, a distinct successor lineage, a disposition, reason, and actor. `--projection workspace|staged` selects the successor target; omission preserves the predecessor projection for compatibility. Approved predecessors require a proven scope change; invalidated predecessors remain terminal. Only escalated recovery may cross projections, and it requires the exact six-line maintainer authorization binding built from the selected projection's target identity. Authorization diagnostics identify the projection and target identity without exposing repository paths.
 - `review recover --release-scope` is the only recovery target-kind expansion with dedicated constraints: an approved `current-changes` predecessor may become a repository-derived first-parent `base-diff` only when the candidate tree and projection are unchanged and every predecessor path remains covered by a strictly larger release scope.
 - Recovery runs under the shared v2 store lock, records predecessor and operator provenance in the successor, and starts a new generation and correction budget without rewriting or deleting history.
 - Discovery authorizes only a unique valid unsuperseded leaf. Forks, dangling or mismatched predecessor links, cycles, and unrelated leaves fail closed. Explicitly selecting a superseded lineage permits historical inspection but not delivery authorization.

--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -140,6 +140,7 @@ func (err *reviewFacadeOperationProgressError) record(lineage, revision string) 
 
 var writeCompactFacadeReceipt = reviewtransaction.WriteCompactReceiptAtomic
 var reviewFacadeSyncDirectory = reviewtransaction.SyncReviewDirectory
+var reviewRecoverBeforePersist = func() {}
 
 type ReviewInvalidateResult struct {
 	Operation     string                  `json:"operation"`
@@ -149,11 +150,13 @@ type ReviewInvalidateResult struct {
 }
 
 type ReviewRecoverResult struct {
-	Operation     string                                      `json:"operation"`
-	LineageID     string                                      `json:"lineage_id"`
-	State         reviewtransaction.State                     `json:"state"`
-	StoreRevision string                                      `json:"store_revision"`
-	Recovery      reviewtransaction.CompactRecoveryProvenance `json:"recovery"`
+	Operation      string                                      `json:"operation"`
+	LineageID      string                                      `json:"lineage_id"`
+	State          reviewtransaction.State                     `json:"state"`
+	StoreRevision  string                                      `json:"store_revision"`
+	Projection     reviewtransaction.Projection                `json:"projection"`
+	TargetIdentity string                                      `json:"target_identity"`
+	Recovery       reviewtransaction.CompactRecoveryProvenance `json:"recovery"`
 }
 
 type facadeFinding struct {
@@ -394,7 +397,8 @@ func RunReviewRecover(args []string, stdout io.Writer) error {
 	disposition := flags.String("disposition", "", "scope_changed, invalidated, or escalated")
 	reason := flags.String("reason", "", "recovery reason")
 	actor := flags.String("actor", "", "recovery actor")
-	authorization := flags.String("maintainer-authorization", "", "explicit authorization required for escalated or correction-required scope recovery")
+	projectionFlag := flags.String("projection", "", "successor projection: workspace or staged (default: predecessor projection)")
+	authorization := flags.String("maintainer-authorization", "", "exact six-line LF-only binding: gentle-ai.review-recovery-authorization/v1, predecessor_lineage, predecessor_revision, target_identity, actor, reason")
 	policySource := flags.String("policy", "", "optional review policy file")
 	focus := flags.String("focus", "reliability", "dominant standard-risk focus; large pure documentation always uses readability")
 	baseRef := flags.String("base-ref", "", "optional base revision for immutable base-to-HEAD review")
@@ -441,6 +445,12 @@ func RunReviewRecover(args []string, stdout io.Writer) error {
 		return errors.New("base-diff recovery requires matching --base-ref and --committed-only")
 	}
 	projection := predecessorRecord.State.InitialSnapshot.Projection
+	if selected := strings.TrimSpace(*projectionFlag); selected != "" {
+		projection = reviewtransaction.Projection(selected)
+		if projection != reviewtransaction.ProjectionWorkspace && projection != reviewtransaction.ProjectionStaged {
+			return fmt.Errorf("unsupported review recovery projection %q", selected)
+		}
+	}
 	intended := []string{}
 	if projection != reviewtransaction.ProjectionStaged {
 		intended, err = builder.DiscoverIntendedUntracked(context.Background())
@@ -492,6 +502,7 @@ func RunReviewRecover(args []string, stdout io.Writer) error {
 	if *releaseScope {
 		*authorization = reviewtransaction.ReleaseScopeRecoveryAuthorization
 	}
+	reviewRecoverBeforePersist()
 	record, err := reviewtransaction.RecoverCompactAuthority(context.Background(), root, reviewtransaction.CompactRecoveryRequest{
 		PredecessorLineageID: *predecessor, ExpectedPredecessorRevision: *expected, Successor: state,
 		Disposition: reviewtransaction.RecoveryDisposition(*disposition), Reason: *reason, Actor: *actor, MaintainerAuthorization: *authorization,
@@ -499,7 +510,8 @@ func RunReviewRecover(args []string, stdout io.Writer) error {
 	if err != nil {
 		return err
 	}
-	return encodeReviewJSON(stdout, ReviewRecoverResult{Operation: "review/recover", LineageID: record.State.LineageID, State: record.State.State, StoreRevision: record.Revision, Recovery: *record.State.Recovery})
+	return encodeReviewJSON(stdout, ReviewRecoverResult{Operation: "review/recover", LineageID: record.State.LineageID, State: record.State.State,
+		StoreRevision: record.Revision, Projection: facadeProjection(snapshot.Projection), TargetIdentity: snapshot.Identity, Recovery: *record.State.Recovery})
 }
 
 func RunReviewBindSDD(args []string, stdout io.Writer) error {

--- a/internal/cli/review_start_contract_test.go
+++ b/internal/cli/review_start_contract_test.go
@@ -379,6 +379,153 @@ func TestReviewRecoverRetainsWorkspaceOverlayBaseAndScope(t *testing.T) {
 	}
 }
 
+func TestReviewRecoverSelectsAuthorizedStagedProjection(t *testing.T) {
+	repo, predecessor, status := escalatedRecoveryProjectionFixture(t, "staged-projection-success")
+	reason, actor := "select exact staged target", "maintainer"
+	authorization := reviewRecoveryAuthorization(predecessor.State.LineageID, predecessor.Revision, status.TargetIdentity, actor, reason)
+	args := recoveryProjectionArgs(repo, predecessor, "staged-projection-successor", reason, actor)
+	args = append(args, "--projection", "staged", "--maintainer-authorization", authorization)
+
+	var output bytes.Buffer
+	if err := RunReviewRecover(args, &output); err != nil {
+		t.Fatal(err)
+	}
+	var result ReviewRecoverResult
+	decodeStrictReviewJSON(t, output.Bytes(), &result)
+	store, _ := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, result.LineageID)
+	recovered, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if recovered.State.InitialSnapshot.Projection != reviewtransaction.ProjectionStaged || recovered.State.InitialSnapshot.Identity != status.TargetIdentity {
+		t.Fatalf("selected recovery target = %#v, status identity = %s", recovered.State.InitialSnapshot, status.TargetIdentity)
+	}
+}
+
+func TestReviewRecoverProjectionFailuresDoNotMutateAuthority(t *testing.T) {
+	for _, tt := range []struct {
+		name       string
+		projection string
+		authorize  func(ReviewTargetStatusResult, reviewtransaction.CompactRecord, string, string) string
+		want       string
+	}{
+		{name: "omitted projection defaults to predecessor", want: "projection=workspace", authorize: func(status ReviewTargetStatusResult, predecessor reviewtransaction.CompactRecord, actor, reason string) string {
+			return reviewRecoveryAuthorization(predecessor.State.LineageID, predecessor.Revision, status.TargetIdentity, actor, reason)
+		}},
+		{name: "wrong authorization", projection: "staged", want: "projection=staged", authorize: func(_ ReviewTargetStatusResult, _ reviewtransaction.CompactRecord, _, _ string) string {
+			return "wrong"
+		}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			repo, predecessor, status := escalatedRecoveryProjectionFixture(t, "staged-projection-"+strings.ReplaceAll(tt.name, " ", "-"))
+			reason, actor := "select exact staged target", "maintainer"
+			successor := "failed-" + strings.ReplaceAll(tt.name, " ", "-")
+			args := recoveryProjectionArgs(repo, predecessor, successor, reason, actor)
+			if tt.projection != "" {
+				args = append(args, "--projection", tt.projection)
+			}
+			args = append(args, "--maintainer-authorization", tt.authorize(status, predecessor, actor, reason))
+			err := RunReviewRecover(args, io.Discard)
+			if err == nil || !strings.Contains(err.Error(), tt.want) || strings.Contains(err.Error(), repo) {
+				t.Fatalf("recovery error = %v, want path-free %q", err, tt.want)
+			}
+			store, _ := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, successor)
+			if _, statErr := os.Stat(store.StatePath()); !os.IsNotExist(statErr) {
+				t.Fatalf("failed recovery created successor: %v", statErr)
+			}
+		})
+	}
+}
+
+func TestReviewRecoverRejectsStagedIndexMutationBeforePersistence(t *testing.T) {
+	repo, predecessor, status := escalatedRecoveryProjectionFixture(t, "staged-projection-race")
+	reason, actor := "select exact staged target", "maintainer"
+	successor := "staged-projection-race-successor"
+	authorization := reviewRecoveryAuthorization(predecessor.State.LineageID, predecessor.Revision, status.TargetIdentity, actor, reason)
+	args := append(recoveryProjectionArgs(repo, predecessor, successor, reason, actor), "--projection", "staged", "--maintainer-authorization", authorization)
+
+	original := reviewRecoverBeforePersist
+	reviewRecoverBeforePersist = func() {
+		if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("raced index\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		runReviewCLIGit(t, repo, "add", "tracked.txt")
+	}
+	t.Cleanup(func() { reviewRecoverBeforePersist = original })
+	if err := RunReviewRecover(args, io.Discard); err == nil || !strings.Contains(err.Error(), "repository evidence") {
+		t.Fatalf("index race error = %v", err)
+	}
+	store, _ := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, successor)
+	if _, statErr := os.Stat(store.StatePath()); !os.IsNotExist(statErr) {
+		t.Fatalf("index race created successor: %v", statErr)
+	}
+}
+
+func TestReviewRecoverHelpDocumentsProjectionAndCanonicalAuthorization(t *testing.T) {
+	var output bytes.Buffer
+	if err := RunReviewRecover([]string{"--help"}, &output); err != nil {
+		t.Fatal(err)
+	}
+	help := output.String()
+	for _, required := range []string{"--projection", "default: predecessor projection", "gentle-ai.review-recovery-authorization/v1", "target_identity"} {
+		if !strings.Contains(help, required) {
+			t.Fatalf("review recover help missing %q:\n%s", required, help)
+		}
+	}
+}
+
+func escalatedRecoveryProjectionFixture(t *testing.T, lineage string) (string, reviewtransaction.CompactRecord, ReviewTargetStatusResult) {
+	t.Helper()
+	repo := initReviewCLIRepo(t)
+	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("candidate\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := RunReviewFacadeStart([]string{"--cwd", repo, "--lineage", lineage}, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	store, _ := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, lineage)
+	record, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	state := record.State
+	finding := reviewtransaction.Finding{ID: "R3-001", Lens: "reliability", Location: "tracked.txt:1", Severity: "CRITICAL", Claim: "observable failure", ProofRefs: []string{"reproduced"}}
+	if err := state.CompleteReview(reviewtransaction.CompactReviewInput{
+		LensResults:     []reviewtransaction.LensResult{{Lens: "reliability", Findings: []reviewtransaction.Finding{finding}, Evidence: []string{"reviewed"}}},
+		Classifications: []reviewtransaction.FindingEvidence{{FindingID: finding.ID, Class: reviewtransaction.EvidenceDeterministic, Causality: reviewtransaction.CausalUnknown, Proof: "requires maintainer recovery"}}, RefuterOutcomes: []reviewtransaction.EvidenceResult{},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Replace(record.Revision, "review/complete-review", state); err != nil {
+		t.Fatal(err)
+	}
+	predecessor, _ := store.Load()
+	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("staged successor\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runReviewCLIGit(t, repo, "add", "tracked.txt")
+	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("unstaged divergence\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var output bytes.Buffer
+	if err := RunReviewStatus([]string{"--contract", ReviewIntegrationContractV1, "--cwd", repo, "--projection", "staged"}, &output); err != nil {
+		t.Fatal(err)
+	}
+	var status ReviewTargetStatusResult
+	decodeStrictReviewJSON(t, output.Bytes(), &status)
+	return repo, predecessor, status
+}
+
+func recoveryProjectionArgs(repo string, predecessor reviewtransaction.CompactRecord, successor, reason, actor string) []string {
+	return []string{"--cwd", repo, "--predecessor-lineage", predecessor.State.LineageID, "--expected-predecessor-revision", predecessor.Revision,
+		"--successor-lineage", successor, "--disposition", "escalated", "--reason", reason, "--actor", actor}
+}
+
+func reviewRecoveryAuthorization(lineage, revision, identity, actor, reason string) string {
+	return "gentle-ai.review-recovery-authorization/v1\npredecessor_lineage=" + lineage + "\npredecessor_revision=" + revision +
+		"\ntarget_identity=" + identity + "\nactor=" + actor + "\nreason=" + reason
+}
+
 func TestReviewRecoverReleaseScopeExpandsMergedSliceToFirstParentDiff(t *testing.T) {
 	repo := initReviewCLIRepo(t)
 	mainBranch := strings.TrimSpace(runReviewCLIGit(t, repo, "branch", "--show-current"))

--- a/internal/reviewtransaction/compact_store.go
+++ b/internal/reviewtransaction/compact_store.go
@@ -160,8 +160,12 @@ func RecoverCompactAuthority(ctx context.Context, repo string, request CompactRe
 	if predecessor.State.State == StateCorrectionRequired && request.Disposition != RecoveryEscalated && request.MaintainerAuthorization != compactRecoveryAuthorizationBinding(request.PredecessorLineageID, predecessor.Revision, request.Successor.InitialSnapshot.Identity, request.Actor, request.Reason) {
 		return CompactRecord{}, errors.New("correction-required scope recovery requires an exact maintainer authorization binding")
 	}
-	if predecessor.State.InitialSnapshot.Projection != request.Successor.InitialSnapshot.Projection {
+	if !sameRecoveryProjection(predecessor.State.InitialSnapshot.Projection, request.Successor.InitialSnapshot.Projection) && request.Disposition != RecoveryEscalated {
 		return CompactRecord{}, errors.New("recovery successor must retain the predecessor projection")
+	}
+	if !sameRecoveryProjection(predecessor.State.InitialSnapshot.Projection, request.Successor.InitialSnapshot.Projection) &&
+		request.MaintainerAuthorization != compactRecoveryAuthorizationBinding(request.PredecessorLineageID, predecessor.Revision, request.Successor.InitialSnapshot.Identity, request.Actor, request.Reason) {
+		return CompactRecord{}, compactRecoveryAuthorizationError(request.Successor.InitialSnapshot)
 	}
 	existing, existingErr := successorStore.Load()
 	if existingErr != nil && !os.IsNotExist(existingErr) {
@@ -214,6 +218,11 @@ func RecoverCompactAuthority(ctx context.Context, repo string, request CompactRe
 			return CompactRecord{}, fmt.Errorf("%w: live release scope no longer matches successor", ErrInvalidSuccessor)
 		}
 	}
+	if !sameRecoveryProjection(predecessor.State.InitialSnapshot.Projection, request.Successor.InitialSnapshot.Projection) {
+		if err := validateLiveRecoverySuccessor(ctx, successorStore.repo, request.Successor.InitialSnapshot); err != nil {
+			return CompactRecord{}, fmt.Errorf("%w: repository evidence for selected recovery projection changed: %v", ErrInvalidSuccessor, err)
+		}
+	}
 	if err := validateCompactRepositoryEvidence(ctx, successorStore.repo, nil, request.Successor, "review/start"); err != nil {
 		return CompactRecord{}, fmt.Errorf("%w: %v", ErrInvalidSuccessor, err)
 	}
@@ -225,6 +234,24 @@ func RecoverCompactAuthority(ctx context.Context, repo string, request CompactRe
 		return CompactRecord{}, err
 	}
 	return record, nil
+}
+
+func validateLiveRecoverySuccessor(ctx context.Context, repo string, expected Snapshot) error {
+	target := Target{
+		Kind: expected.Kind, Projection: expected.Projection, IntendedUntracked: expected.IntendedUntracked,
+		LedgerIDs: expected.LedgerIDs,
+	}
+	if expected.Kind == TargetBaseDiff || expected.Kind == TargetBaseWorkspaceOverlay || expected.Kind == TargetFixDiff {
+		target.BaseRef = expected.BaseTree
+	}
+	live, err := (SnapshotBuilder{Repo: repo}).Build(ctx, target)
+	if err != nil {
+		return err
+	}
+	if !snapshotsEqual(live, expected) {
+		return errors.New("live target no longer matches the prepared successor")
+	}
+	return nil
 }
 
 func compactRecoveryScopeChanged(previous, next Snapshot) bool {
@@ -252,6 +279,9 @@ func validateCompactRecoveryEdge(predecessor CompactRecord, successor CompactSta
 	}
 	if successor.Generation != predecessor.State.Generation+1 {
 		return errors.New("recovery successor generation must follow predecessor")
+	}
+	if !sameRecoveryProjection(predecessor.State.InitialSnapshot.Projection, successor.InitialSnapshot.Projection) && recovery.Disposition != RecoveryEscalated {
+		return errors.New("recovery successor must retain the predecessor projection")
 	}
 	switch recovery.Disposition {
 	case RecoveryScopeChanged:
@@ -288,7 +318,7 @@ func validateCompactRecoveryEdge(predecessor CompactRecord, successor CompactSta
 			return errors.New("escalated recovery successor target has not changed")
 		}
 		if recovery.MaintainerAuthorization != compactRecoveryAuthorizationBinding(predecessor.State.LineageID, predecessor.Revision, successor.InitialSnapshot.Identity, recovery.Actor, recovery.Reason) {
-			return errors.New("escalated recovery requires an exact maintainer authorization binding")
+			return compactRecoveryAuthorizationError(successor.InitialSnapshot)
 		}
 	default:
 		return errors.New("unsupported recovery disposition")
@@ -313,6 +343,24 @@ func compactRecoveryAuthorizationBinding(lineage, revision, targetIdentity, acto
 	return "gentle-ai.review-recovery-authorization/v1\npredecessor_lineage=" + lineage +
 		"\npredecessor_revision=" + revision + "\ntarget_identity=" + targetIdentity +
 		"\nactor=" + strings.TrimSpace(actor) + "\nreason=" + strings.TrimSpace(reason)
+}
+
+func sameRecoveryProjection(left, right Projection) bool {
+	if left == "" {
+		left = ProjectionWorkspace
+	}
+	if right == "" {
+		right = ProjectionWorkspace
+	}
+	return left == right
+}
+
+func compactRecoveryAuthorizationError(snapshot Snapshot) error {
+	projection := snapshot.Projection
+	if projection == "" {
+		projection = ProjectionWorkspace
+	}
+	return fmt.Errorf("escalated recovery requires an exact maintainer authorization binding (projection=%s target_identity=%s)", projection, snapshot.Identity)
 }
 
 func compactRecoveryAddsGenesisPath(predecessor CompactState, live Snapshot) bool {

--- a/internal/reviewtransaction/compact_store_test.go
+++ b/internal/reviewtransaction/compact_store_test.go
@@ -205,6 +205,70 @@ func TestRecoverCompactAuthorityRejectsProjectionChange(t *testing.T) {
 	}
 }
 
+func TestCorrectionRecoveryRejectsAuthorizedProjectionChange(t *testing.T) {
+	repo, predecessor, _, record := correctionScopeRecoveryFixture(t, "correction-projection-predecessor")
+	writeSnapshotFile(t, repo, "new-helper.go", "package helper\n")
+	gitSnapshot(t, repo, "add", "new-helper.go")
+	successor := newCompactStartStateForTarget(t, repo, "correction-projection-successor", Target{
+		Kind: TargetCurrentChanges, Projection: ProjectionStaged, IntendedUntracked: []string{},
+	})
+	successor.Generation = predecessor.Generation + 1
+	request := CompactRecoveryRequest{
+		PredecessorLineageID: predecessor.LineageID, ExpectedPredecessorRevision: record.Revision, Successor: successor,
+		Disposition: RecoveryScopeChanged, Reason: "expand correction scope", Actor: "maintainer",
+	}
+	request.MaintainerAuthorization = compactRecoveryAuthorizationBinding(predecessor.LineageID, record.Revision, successor.InitialSnapshot.Identity, request.Actor, request.Reason)
+	if _, err := RecoverCompactAuthority(context.Background(), repo, request); err == nil || !strings.Contains(err.Error(), "retain the predecessor projection") {
+		t.Fatalf("correction cross-projection error = %v", err)
+	}
+	successorStore, _ := CompactAuthoritativeStore(context.Background(), repo, successor.LineageID)
+	if _, err := os.Stat(successorStore.StatePath()); !os.IsNotExist(err) {
+		t.Fatalf("correction cross-projection recovery mutated successor: %v", err)
+	}
+}
+
+func TestRecoverCompactAuthorityAllowsAuthorizedEscalatedProjectionChange(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	state := correctedCompactTestState(t, repo, "recovery-workspace-escalated")
+	state.State = StateEscalated
+	store, _ := CompactAuthoritativeStore(context.Background(), repo, state.LineageID)
+	record, payload, err := makeCompactRecord(state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(store.Dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(store.StatePath(), payload, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	writeSnapshotFile(t, repo, "tracked.txt", "staged successor\n")
+	gitSnapshot(t, repo, "add", "tracked.txt")
+	writeSnapshotFile(t, repo, "tracked.txt", "unstaged divergence\n")
+	successor := newCompactStartStateForTarget(t, repo, "recovery-staged-successor", Target{Kind: TargetCurrentChanges, Projection: ProjectionStaged, IntendedUntracked: []string{}})
+	successor.Generation = state.Generation + 1
+	if state.InitialSnapshot.Projection != "" && state.InitialSnapshot.Projection != ProjectionWorkspace || successor.InitialSnapshot.Projection != ProjectionStaged {
+		t.Fatalf("fixture projections = %q -> %q", state.InitialSnapshot.Projection, successor.InitialSnapshot.Projection)
+	}
+	request := CompactRecoveryRequest{
+		PredecessorLineageID: state.LineageID, ExpectedPredecessorRevision: record.Revision, Successor: successor,
+		Disposition: RecoveryEscalated, Actor: "maintainer", Reason: "select exact staged target",
+	}
+	request.MaintainerAuthorization = compactRecoveryAuthorizationBinding(state.LineageID, record.Revision, successor.InitialSnapshot.Identity, request.Actor, request.Reason)
+
+	recovered, err := RecoverCompactAuthority(context.Background(), repo, request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if recovered.State.InitialSnapshot.Projection != ProjectionStaged || recovered.State.InitialSnapshot.CandidateTree != successor.InitialSnapshot.CandidateTree {
+		t.Fatalf("cross-projection successor = %#v", recovered.State.InitialSnapshot)
+	}
+	if leaves, err := CompactAuthorityLeaves(context.Background(), repo); err != nil || len(leaves) != 1 || leaves[0].lineageID != successor.LineageID {
+		t.Fatalf("reloaded recovery graph = %#v, %v", leaves, err)
+	}
+}
+
 func TestApprovedRecoveryTreatsBaseTreeMismatchAsScopeChange(t *testing.T) {
 	snapshot := Snapshot{BaseTree: strings.Repeat("a", 40), CandidateTree: strings.Repeat("c", 40), PathsDigest: hash("1")}
 	predecessor, successor := CompactState{State: StateApproved, CurrentSnapshot: snapshot}, CompactState{InitialSnapshot: snapshot}
@@ -1324,9 +1388,10 @@ func TestCompactHistoricalFailedValidatorTransportRequiresExactBinding(t *testin
 	predecessorTransport.BundleDigest = compactTransportDigest(predecessorTransport)
 
 	for _, tt := range []struct {
-		name, want     string
-		changed, exact bool
-	}{{"same target", "target has not changed", false, true}, {"changed target", "", true, true}, {"wrong binding", "exact maintainer authorization", true, false}} {
+		name, want                 string
+		changed, exact, projection bool
+	}{{"same target", "target has not changed", false, true, false}, {"changed target", "", true, true, false},
+		{"authorized projection change", "", true, true, true}, {"wrong projection binding", "exact maintainer authorization", true, false, true}} {
 		t.Run(tt.name, func(t *testing.T) {
 			destination := filepath.Join(t.TempDir(), "clone")
 			gitSnapshot(t, repo, "clone", "--no-local", repo, destination)
@@ -1342,6 +1407,14 @@ func TestCompactHistoricalFailedValidatorTransportRequiresExactBinding(t *testin
 			}
 			successor := newCompactRevisionState(t, destination, "historical-transport-g2-"+strings.ReplaceAll(tt.name, " ", "-"))
 			successor.Generation = state.Generation + 1
+			if tt.projection {
+				successor.InitialSnapshot.Kind = TargetBaseDiff
+				successor.CurrentSnapshot.Kind = TargetBaseDiff
+				successor.InitialSnapshot.Projection = ProjectionStaged
+				successor.CurrentSnapshot.Projection = ProjectionStaged
+				successor.InitialSnapshot.Identity = snapshotIdentityForProjection(successor.InitialSnapshot.Kind, ProjectionStaged, successor.InitialSnapshot.BaseTree, successor.InitialSnapshot.CandidateTree, successor.InitialSnapshot.PathsDigest, successor.InitialSnapshot.IntendedUntrackedProof, successor.InitialSnapshot.IntendedUntracked, successor.InitialSnapshot.LedgerIDs)
+				successor.CurrentSnapshot.Identity = snapshotIdentityForProjection(successor.CurrentSnapshot.Kind, ProjectionStaged, successor.CurrentSnapshot.BaseTree, successor.CurrentSnapshot.CandidateTree, successor.CurrentSnapshot.PathsDigest, successor.CurrentSnapshot.IntendedUntrackedProof, successor.CurrentSnapshot.IntendedUntracked, successor.CurrentSnapshot.LedgerIDs)
+			}
 			successor.Recovery = &CompactRecoveryProvenance{PredecessorLineageID: state.LineageID, PredecessorRevision: predecessor.Revision,
 				Disposition: RecoveryEscalated, Actor: "maintainer", Reason: "recover failed validator", RecoveredAt: time.Now().UTC()}
 			successor.Recovery.MaintainerAuthorization = "wrong"


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1407

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Add explicit `review recover --projection workspace|staged`, defaulting to the predecessor projection for compatibility.
- Permit cross-projection successors only for escalated recovery with exact identity-bound maintainer authorization.
- Keep non-escalated, unauthorized, raced-index, reload, and import paths fail-closed with path-free diagnostics.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/cli/review_facade.go` | Selects the recovery projection, documents canonical authorization, and emits projection/target identity. |
| `internal/reviewtransaction/compact_store.go` | Enforces cross-projection authorization, locked live-target validation, and reload/import rules. |
| `internal/cli/review_start_contract_test.go` | Covers staged recovery, compatibility defaults, no-mutation failures, help, and index races. |
| `internal/reviewtransaction/compact_store_test.go` | Covers escalated success, non-escalated rejection, graph reload, and transport validation. |
| `docs/review-authority-threat-model.md` | Documents the constrained recovery projection contract. |

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./...
```

**Go Format**
```bash
go run ./internal/gofmtcheck
```

**E2E Tests** (Docker required)
```bash
cd e2e && ./docker-test.sh
```

- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Manually tested locally

Focused `internal/reviewtransaction` and `internal/cli` tests exercise the recovery boundary. Docker E2E was not run locally because this change does not modify installer/E2E behavior; required CI remains authoritative.

---

## 🤖 Automated Checks

The following checks run automatically on this PR:

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | PR should stay within 400 changed lines (`additions + deletions`) or use `size:exception` |
| Check Issue Reference | ⏳ | PR body must contain `Closes/Fixes/Resolves #N` |
| Check Issue Has `status:approved` | ⏳ | Linked issue must have been approved before work began |
| Check PR Has `type:*` Label | ⏳ | Exactly one `type:*` label must be applied |
| Unit Tests | ⏳ | `go test ./...` must pass |
| Go Format | ⏳ | `go run ./internal/gofmtcheck` must pass |
| E2E Tests | ⏳ | `cd e2e && ./docker-test.sh` must pass |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

Review the authorization boundary in `RecoverCompactAuthority`: semantic workspace compatibility is preserved, while explicit workspace-to-staged recovery remains limited to escalated authority and exact successor identity. No `size:exception` is required because the PR contains 308 changed lines.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Recovery now supports selecting the workspace or staged projection.
  * Escalated recovery can change projections when authorized for the selected target.
  * Recovery results now report the selected projection and target identity.

* **Bug Fixes**
  * Prevented unauthorized cross-projection recovery.
  * Added safeguards to reject recovery when repository evidence changes before completion.
  * Improved authorization errors with projection and target identity details.

* **Documentation**
  * Clarified projection selection, defaulting, recovery restrictions, and authorization requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->