### PR TITLE
fix(gga): resolve Git Bash from Git installation

### DIFF
--- a/internal/assets/gga/gga.ps1
+++ b/internal/assets/gga/gga.ps1
@@ -3,9 +3,18 @@ if (-not $gitCmd) {
     Write-Error "Git not found on PATH. Install Git for Windows to use gga from PowerShell."
     exit 1
 }
-$bash = Join-Path (Split-Path (Split-Path $gitCmd.Source)) "bin\bash.exe"
-if (-not (Test-Path $bash)) {
-    Write-Error "Git Bash not found at '$bash'. Reinstall Git for Windows."
+$gitDir = Split-Path $gitCmd.Source
+$gitRoot = Split-Path $gitDir
+if ((Split-Path $gitDir -Leaf) -ieq "bin" -and (Split-Path $gitRoot -Leaf) -ieq "mingw64") {
+    $gitRoot = Split-Path $gitRoot
+}
+
+$bash = @(
+    (Join-Path $gitRoot "bin\bash.exe")
+    (Join-Path $gitRoot "usr\bin\bash.exe")
+) | Where-Object { Test-Path -LiteralPath $_ -PathType Leaf } | Select-Object -First 1
+if (-not $bash) {
+    Write-Error "Git Bash not found under '$gitRoot'. Reinstall Git for Windows."
     exit 1
 }
 & $bash -c "gga $args"

--- a/internal/components/gga/runtime_test.go
+++ b/internal/components/gga/runtime_test.go
@@ -1,8 +1,11 @@
 package gga
 
 import (
+	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -310,6 +313,138 @@ func TestEnsurePowerShellShimIsNoOpWhenContentMatches(t *testing.T) {
 	// replaced and the modification time must not change.
 	if stat2.ModTime() != stat1.ModTime() {
 		t.Fatalf("EnsurePowerShellShim re-wrote the file even though content was identical")
+	}
+}
+
+func TestPowerShellShimResolvesGitBash(t *testing.T) {
+	if os.Getenv("OS") != "Windows_NT" {
+		t.Skip("PowerShell shim is Windows-only")
+	}
+
+	powerShell, err := exec.LookPath("powershell.exe")
+	if err != nil {
+		t.Skip("Windows PowerShell is unavailable")
+	}
+	helper := buildWindowsShimHelper(t)
+
+	tests := []struct {
+		name          string
+		gitPath       string
+		bashPaths     []string
+		pathBash      bool
+		helperExit    int
+		wantBash      string
+		wantExit      int
+		wantErrorText string
+	}{
+		{name: "cmd Git uses root bin Bash", gitPath: `Git\cmd\git.exe`, bashPaths: []string{`Git\bin\bash.exe`}, wantBash: `Git\bin\bash.exe`},
+		{name: "bin Git uses root bin Bash", gitPath: `Git\bin\git.exe`, bashPaths: []string{`Git\bin\bash.exe`}, wantBash: `Git\bin\bash.exe`},
+		{name: "mingw64 bin Git uses root bin Bash case insensitively", gitPath: `Git\MINGW64\BIN\git.exe`, bashPaths: []string{`Git\bin\bash.exe`}, wantBash: `Git\bin\bash.exe`},
+		{name: "root bin is preferred", gitPath: `Git\cmd\git.exe`, bashPaths: []string{`Git\bin\bash.exe`, `Git\usr\bin\bash.exe`}, wantBash: `Git\bin\bash.exe`},
+		{name: "usr bin is fallback", gitPath: `Git\cmd\git.exe`, bashPaths: []string{`Git\usr\bin\bash.exe`}, wantBash: `Git\usr\bin\bash.exe`},
+		{name: "installation path may contain spaces", gitPath: `Git Install\cmd\git.exe`, bashPaths: []string{`Git Install\bin\bash.exe`}, wantBash: `Git Install\bin\bash.exe`},
+		{name: "Git absent", wantExit: 1, wantErrorText: "Git not found on PATH"},
+		{name: "Git Bash absent", gitPath: `Git\cmd\git.exe`, wantExit: 1, wantErrorText: "Git Bash not found"},
+		{name: "PATH Bash alias is not selected", gitPath: `Git\cmd\git.exe`, pathBash: true, wantExit: 1, wantErrorText: "Git Bash not found"},
+		{name: "helper exit code is propagated", gitPath: `Git\cmd\git.exe`, bashPaths: []string{`Git\bin\bash.exe`}, helperExit: 37, wantBash: `Git\bin\bash.exe`, wantExit: 37},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			shim := filepath.Join(root, "gga.ps1")
+			content, err := assets.Read("gga/gga.ps1")
+			if err != nil {
+				t.Fatalf("assets.Read() error = %v", err)
+			}
+			if err := os.WriteFile(shim, []byte(content), 0o644); err != nil {
+				t.Fatalf("WriteFile(shim) error = %v", err)
+			}
+
+			pathDirs := []string{filepath.Join(root, "empty-path")}
+			if tt.gitPath != "" {
+				git := filepath.Join(root, filepath.FromSlash(strings.ReplaceAll(tt.gitPath, `\`, "/")))
+				copyShimHelper(t, helper, git)
+				pathDirs = append([]string{filepath.Dir(git)}, pathDirs...)
+			}
+			for _, path := range tt.bashPaths {
+				copyShimHelper(t, helper, filepath.Join(root, filepath.FromSlash(strings.ReplaceAll(path, `\`, "/"))))
+			}
+			if tt.pathBash {
+				aliasDir := filepath.Join(root, "WindowsApps")
+				copyShimHelper(t, helper, filepath.Join(aliasDir, "bash.exe"))
+				pathDirs = append(pathDirs, aliasDir)
+			}
+
+			capture := filepath.Join(root, "selected-bash.txt")
+			cmd := exec.Command(powerShell, "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-File", shim)
+			cmd.Env = append(os.Environ(),
+				"PATH="+strings.Join(pathDirs, string(os.PathListSeparator)),
+				"GGA_TEST_CAPTURE="+capture,
+				"GGA_TEST_EXIT="+strconv.Itoa(tt.helperExit),
+			)
+			output, runErr := cmd.CombinedOutput()
+			gotExit := 0
+			if runErr != nil {
+				var exitErr *exec.ExitError
+				if !errors.As(runErr, &exitErr) {
+					t.Fatalf("PowerShell harness error = %v; output: %s", runErr, output)
+				}
+				gotExit = exitErr.ExitCode()
+			}
+			if gotExit != tt.wantExit {
+				t.Fatalf("exit code = %d, want %d; output: %s", gotExit, tt.wantExit, output)
+			}
+			if tt.wantErrorText != "" && !strings.Contains(strings.Join(strings.Fields(string(output)), " "), tt.wantErrorText) {
+				t.Fatalf("output = %q, want text %q", output, tt.wantErrorText)
+			}
+			if tt.wantBash != "" {
+				selected, err := os.ReadFile(capture)
+				if err != nil {
+					t.Fatalf("ReadFile(capture) error = %v; output: %s", err, output)
+				}
+				want := filepath.Join(root, filepath.FromSlash(strings.ReplaceAll(tt.wantBash, `\`, "/")))
+				if !strings.EqualFold(strings.TrimSpace(string(selected)), want) {
+					t.Fatalf("selected Bash = %q, want %q", selected, want)
+				}
+			}
+		})
+	}
+}
+
+func buildWindowsShimHelper(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	source := filepath.Join(dir, "main.go")
+	program := `package main
+import ("os"; "strconv")
+func main() {
+	if path := os.Getenv("GGA_TEST_CAPTURE"); path != "" { _ = os.WriteFile(path, []byte(os.Args[0]), 0644) }
+	code, _ := strconv.Atoi(os.Getenv("GGA_TEST_EXIT"))
+	os.Exit(code)
+}`
+	if err := os.WriteFile(source, []byte(program), 0o644); err != nil {
+		t.Fatalf("WriteFile(helper source) error = %v", err)
+	}
+	helper := filepath.Join(dir, "shim-helper.exe")
+	cmd := exec.Command("go", "build", "-o", helper, source)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("build shim helper: %v\n%s", err, output)
+	}
+	return helper
+}
+
+func copyShimHelper(t *testing.T, source, destination string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(destination), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q) error = %v", filepath.Dir(destination), err)
+	}
+	content, err := os.ReadFile(source)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", source, err)
+	}
+	if err := os.WriteFile(destination, content, 0o755); err != nil {
+		t.Fatalf("WriteFile(%q) error = %v", destination, err)
 	}
 }
 


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #932

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Resolve the Git for Windows installation root when `git.exe` comes from `cmd`, `bin`, or `mingw64/bin`.
- Select Git Bash deterministically from `bin/bash.exe` or `usr/bin/bash.exe` without falling back to PATH-level WSL launchers.
- Add native Windows regression coverage for path layouts, fallback order, spaces, missing dependencies, and exit-code propagation.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/assets/gga/gga.ps1` | Derives the Git installation root and probes Git-owned Bash executables with literal leaf checks. |
| `internal/components/gga/runtime_test.go` | Adds table-driven native Windows coverage for 10 resolution and failure scenarios. |

---

## 🧪 Test Plan

**Focused Windows contract**
```bash
go test ./internal/components/gga -run '^TestPowerShellShimResolvesGitBash$' -count=1 -v
```

**Package and asset checks**
```bash
go test ./internal/components/gga -count=1
go test ./internal/assets
go run ./internal/gofmtcheck
go vet ./...
git diff --check
```

**Full suite**
```bash
go test ./...
```

The focused tests, package tests, asset tests, formatting, vet, and diff checks pass. The local full suite has Windows environment failures involving symlink privilege, WSL without a distribution, unavailable Unix commands, and local model cache. Each failure was reproduced with the same scoped command on clean `upstream/main`; no candidate-only failure was found. Docker is not installed locally, so E2E is left to CI.

- [ ] Unit tests pass (`go test ./...`) — awaiting clean CI runners; local base has the same environmental failures
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — Docker unavailable locally; awaiting CI
- [x] Manually tested locally

---

## 🤖 Automated Checks

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | 150 authored changed lines |
| Check Issue Reference | ⏳ | `Closes #932` |
| Check Issue Has `status:approved` | ⏳ | Issue was approved before implementation |
| Check PR Has `type:*` Label | ⏳ | `type:bug` |
| Unit Tests | ⏳ | Awaiting CI |
| Go Format | ⏳ | Awaiting CI |
| E2E Tests | ⏳ | Awaiting CI |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [ ] Maintainer action required: please add the `type:bug` label (external contributors cannot apply upstream labels)
- [ ] Unit tests pass (`go test ./...`) — awaiting clean CI runners
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — awaiting CI
- [x] Documentation update is not necessary; behavior matches the approved issue and existing shim contract
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

Please focus on Git-root derivation for the case-insensitive `mingw64/bin` layout and the deterministic `bin` before `usr/bin` precedence. Argument forwarding remains unchanged and intentionally outside this issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Git Bash detection on Windows across common installation layouts.
  * Added fallback handling when Git Bash is located under either `bin` or `usr\bin`.
  * Updated error messaging when Git Bash cannot be found.

* **Tests**
  * Added Windows coverage to verify Git Bash path resolution and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->