### PR TITLE
fix(codex): remove legacy gentle-dev config safely

### DIFF
--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
-	"runtime"
 	"sort"
 	"strings"
 	"testing"
@@ -25,39 +24,6 @@ import (
 	"github.com/gentleman-programming/gentle-ai/internal/update"
 	"github.com/gentleman-programming/gentle-ai/internal/update/upgrade"
 )
-
-func tomlSection(text, header string) string {
-	start := strings.Index(text, header)
-	if start == -1 {
-		return ""
-	}
-	section := text[start+len(header):]
-	if next := strings.Index(section, "\n["); next != -1 {
-		section = section[:next]
-	}
-	return section
-}
-
-func assertCodexWorkspaceWriteRulesScoped(t *testing.T, text string) {
-	t.Helper()
-
-	rootFilesystem := tomlSection(text, `[permissions.gentle-dev.filesystem]`)
-	for _, rule := range []string{`"." = "write"`, `".git/**" = "write"`} {
-		if strings.Contains(rootFilesystem, rule) {
-			t.Fatalf("root filesystem table contains workspace write rule %q; got:\n%s", rule, rootFilesystem)
-		}
-	}
-
-	scopedFilesystem := tomlSection(text, `[permissions.gentle-dev.filesystem.":workspace_roots"]`)
-	if scopedFilesystem == "" {
-		t.Fatalf("config.toml missing workspace-scoped filesystem table; got:\n%s", text)
-	}
-	for _, rule := range []string{`"." = "write"`, `".git/**" = "write"`} {
-		if !strings.Contains(scopedFilesystem, rule) {
-			t.Fatalf("workspace-scoped filesystem table missing workspace write rule %q; got:\n%s", rule, scopedFilesystem)
-		}
-	}
-}
 
 // TestListBackupsNewestFirst verifies that ListBackups returns manifests sorted
 // newest-first by CreatedAt timestamp, matching the spec "newest first" ordering.
@@ -536,7 +502,7 @@ func TestTUIExecutePersistsConfiguredSelection(t *testing.T) {
 	}
 }
 
-func TestTuiSyncIncludesCodexPermissions(t *testing.T) {
+func TestTuiSyncRemovesCodexGentleDevProfile(t *testing.T) {
 	t.Cleanup(codex.SetRuntimeVersionCommandForTest("codex-cli 0.144.0", nil))
 	home := t.TempDir()
 	if err := state.Write(home, state.InstallState{InstalledAgents: []string{string(model.AgentCodex)}}); err != nil {
@@ -546,7 +512,10 @@ func TestTuiSyncIncludesCodexPermissions(t *testing.T) {
 	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
 		t.Fatalf("MkdirAll() error = %v", err)
 	}
-	initial := `[permissions.gentle-dev.filesystem]
+	initial := `model = "gpt-5.5"
+default_permissions = "gentle-dev"
+
+[permissions.gentle-dev.filesystem]
 ":slash_tmp" = "write"
 ":tmpdir" = "write"
 
@@ -563,7 +532,7 @@ func TestTuiSyncIncludesCodexPermissions(t *testing.T) {
 		t.Fatalf("tuiSync Codex permissions error: %v", err)
 	}
 	if len(changed) == 0 {
-		t.Fatal("tuiSync Codex permissions changed 0 files, want config.toml updated")
+		t.Fatal("tuiSync Codex permissions changed 0 files, want config.toml cleaned")
 	}
 
 	body, err := os.ReadFile(configPath)
@@ -571,37 +540,26 @@ func TestTuiSyncIncludesCodexPermissions(t *testing.T) {
 		t.Fatalf("ReadFile(%s): %v", configPath, err)
 	}
 	text := string(body)
-	if !strings.Contains(text, `[permissions.gentle-dev.filesystem]`) || !strings.Contains(text, `":minimal" = "read"`) || !strings.Contains(text, `":tmpdir" = "write"`) || !strings.Contains(text, `":slash_tmp" = "write"`) || !strings.Contains(text, `[permissions.gentle-dev.filesystem.":workspace_roots"]`) || !strings.Contains(text, `"**/*.key" = "deny"`) {
-		t.Fatalf("Codex permissions sync should add valid filesystem reads; got:\n%s", text)
+	if strings.Contains(text, "gentle-dev") {
+		t.Fatalf("Codex permissions sync should remove the gentle-dev profile; got:\n%s", text)
 	}
-	assertCodexWorkspaceWriteRulesScoped(t, text)
-	rootFilesystem := tomlSection(text, `[permissions.gentle-dev.filesystem]`)
-	if strings.Contains(rootFilesystem, `"**/*.key" = "deny"`) || strings.Contains(rootFilesystem, `"**/*.pem" = "deny"`) {
-		t.Fatalf("Codex root filesystem table should not contain secret glob denies; got:\n%s", rootFilesystem)
-	}
-	for _, invalid := range []string{`"**/.git" = "write"`, `"**/.git/**" = "write"`} {
-		if strings.Contains(text, invalid) {
-			t.Fatalf("Codex permissions sync should remove invalid entry %q; got:\n%s", invalid, text)
-		}
+	if !strings.Contains(text, `model = "gpt-5.5"`) {
+		t.Fatalf("Codex permissions sync should preserve user config; got:\n%s", text)
 	}
 
-	changed, err = tuiSync(home)(nil)
-	if err != nil {
+	if _, err := tuiSync(home)(nil); err != nil {
 		t.Fatalf("second tuiSync Codex permissions error: %v", err)
 	}
-	body, err = os.ReadFile(configPath)
+	second, err := os.ReadFile(configPath)
 	if err != nil {
 		t.Fatalf("ReadFile(%s) after second sync: %v", configPath, err)
 	}
-	text = string(body)
-	for _, invalid := range []string{`"**/.git" = "write"`, `"**/.git/**" = "write"`} {
-		if strings.Contains(text, invalid) {
-			t.Fatalf("second sync should keep invalid entry %q removed; got:\n%s", invalid, text)
-		}
+	if string(second) != text {
+		t.Fatalf("second sync modified cleaned config:\nfirst:\n%s\nsecond:\n%s", text, second)
 	}
 }
 
-func TestTuiSyncIncludesCodexPermissionsForTargetedOverrides(t *testing.T) {
+func TestTuiSyncRemovesCodexGentleDevProfileForTargetedOverrides(t *testing.T) {
 	t.Cleanup(codex.SetRuntimeVersionCommandForTest("codex-cli 0.144.0", nil))
 	home := t.TempDir()
 	if err := state.Write(home, state.InstallState{InstalledAgents: []string{string(model.AgentPi)}}); err != nil {
@@ -611,7 +569,10 @@ func TestTuiSyncIncludesCodexPermissionsForTargetedOverrides(t *testing.T) {
 	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
 		t.Fatalf("MkdirAll() error = %v", err)
 	}
-	initial := `[permissions.gentle-dev.filesystem]
+	initial := `model = "gpt-5.5"
+approval_policy = "on-request"
+
+[permissions.gentle-dev.filesystem]
 ":slash_tmp" = "write"
 ":tmpdir" = "write"
 
@@ -632,18 +593,11 @@ func TestTuiSyncIncludesCodexPermissionsForTargetedOverrides(t *testing.T) {
 		t.Fatalf("ReadFile(%s): %v", configPath, err)
 	}
 	text := string(body)
-	if !strings.Contains(text, `":minimal" = "read"`) || !strings.Contains(text, `":tmpdir" = "write"`) || !strings.Contains(text, `":slash_tmp" = "write"`) || runtime.GOOS != "windows" && !strings.Contains(text, `[permissions.gentle-dev.workspace_roots]`) || !strings.Contains(text, `[permissions.gentle-dev.filesystem.":workspace_roots"]`) || !strings.Contains(text, `"**/*.key" = "deny"`) {
-		t.Fatalf("targeted sync should add valid Codex permissions profile; got:\n%s", text)
+	if strings.Contains(text, "gentle-dev") || strings.Contains(text, `approval_policy = "on-request"`) {
+		t.Fatalf("targeted sync should remove the injected Codex permissions profile; got:\n%s", text)
 	}
-	assertCodexWorkspaceWriteRulesScoped(t, text)
-	rootFilesystem := tomlSection(text, `[permissions.gentle-dev.filesystem]`)
-	if strings.Contains(rootFilesystem, `"**/*.key" = "deny"`) {
-		t.Fatalf("targeted sync root filesystem table should not contain secret glob denies; got:\n%s", rootFilesystem)
-	}
-	for _, invalid := range []string{`"**/.git" = "write"`, `"**/.git/**" = "write"`} {
-		if strings.Contains(text, invalid) {
-			t.Fatalf("targeted sync should remove invalid entry %q; got:\n%s", invalid, text)
-		}
+	if !strings.Contains(text, `model = "gpt-5.5"`) {
+		t.Fatalf("targeted sync should preserve user config; got:\n%s", text)
 	}
 }
 
@@ -1936,7 +1890,7 @@ func TestRunArgs_PendingSync_RunsSyncAndClearsFlag(t *testing.T) {
 	}
 }
 
-func TestRunArgsPendingSyncRepairsCodexPermissions(t *testing.T) {
+func TestRunArgsPendingSyncCleansCodexPermissions(t *testing.T) {
 	t.Cleanup(codex.SetRuntimeVersionCommandForTest("codex-cli 0.144.0", nil))
 	home := t.TempDir()
 	setupMockHome(t, home)
@@ -1951,7 +1905,10 @@ func TestRunArgsPendingSyncRepairsCodexPermissions(t *testing.T) {
 	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
 		t.Fatalf("MkdirAll() error = %v", err)
 	}
-	initial := `[permissions.gentle-dev.filesystem]
+	initial := `model = "gpt-5.5"
+default_permissions = "gentle-dev"
+
+[permissions.gentle-dev.filesystem]
 ":slash_tmp" = "write"
 ":tmpdir" = "write"
 
@@ -1995,18 +1952,11 @@ func TestRunArgsPendingSyncRepairsCodexPermissions(t *testing.T) {
 		t.Fatalf("ReadFile(%s): %v", configPath, err)
 	}
 	text := string(body)
-	if !strings.Contains(text, `":minimal" = "read"`) || !strings.Contains(text, `":tmpdir" = "write"`) || !strings.Contains(text, `":slash_tmp" = "write"`) || runtime.GOOS != "windows" && !strings.Contains(text, `[permissions.gentle-dev.workspace_roots]`) || !strings.Contains(text, `[permissions.gentle-dev.filesystem.":workspace_roots"]`) || !strings.Contains(text, `"**/*.key" = "deny"`) {
-		t.Fatalf("deferred sync should add valid Codex permissions profile; got:\n%s", text)
+	if strings.Contains(text, "gentle-dev") {
+		t.Fatalf("deferred sync should remove the gentle-dev profile; got:\n%s", text)
 	}
-	assertCodexWorkspaceWriteRulesScoped(t, text)
-	rootFilesystem := tomlSection(text, `[permissions.gentle-dev.filesystem]`)
-	if strings.Contains(rootFilesystem, `"**/*.key" = "deny"`) || strings.Contains(rootFilesystem, `"**/*.pem" = "deny"`) {
-		t.Fatalf("deferred sync root filesystem table should not contain secret glob denies; got:\n%s", rootFilesystem)
-	}
-	for _, invalid := range []string{`"**/.git" = "write"`, `"**/.git/**" = "write"`} {
-		if strings.Contains(text, invalid) {
-			t.Fatalf("deferred sync should remove invalid entry %q; got:\n%s", invalid, text)
-		}
+	if !strings.Contains(text, `model = "gpt-5.5"`) {
+		t.Fatalf("deferred sync should preserve user config; got:\n%s", text)
 	}
 
 	s, err := state.Read(home)

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1557,6 +1557,16 @@ func componentPathsWithWorkspaceScoped(homeDir, workspaceDir string, scope Insta
 			if p := permissions.TargetPath(homeDir, adapter); p != "" {
 				paths = append(paths, p)
 			}
+			// Codex permission cleanup mutates an existing config.toml but
+			// never creates one. Include the file when it exists — or when
+			// Stat fails without confirming absence — so backup/rollback
+			// covers the migration while post-apply verification never
+			// requires a file the cleanup does not write.
+			if p := permissions.CleanupPath(homeDir, adapter); p != "" {
+				if _, err := os.Stat(p); err == nil || !os.IsNotExist(err) {
+					paths = append(paths, p)
+				}
+			}
 		case model.ComponentGGA:
 			paths = append(paths, gga.ConfigPath(homeDir))
 			paths = append(paths, gga.AgentsTemplatePath(homeDir))

--- a/internal/cli/run_component_paths_test.go
+++ b/internal/cli/run_component_paths_test.go
@@ -1,7 +1,9 @@
 package cli
 
 import (
+	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/gentleman-programming/gentle-ai/internal/model"
@@ -376,17 +378,63 @@ func TestComponentPathsEngramCodexIncludesConfigTOML(t *testing.T) {
 	}
 }
 
-// TestComponentPathsPermissionsCodexIncludesConfigTOML verifies that
-// ComponentPermission + Codex reports ~/.codex/config.toml as a backup target.
-func TestComponentPathsPermissionsCodexIncludesConfigTOML(t *testing.T) {
+// TestComponentPathsPermissionsCodexExcludesMissingConfigTOML verifies that
+// ComponentPermission + Codex does not report ~/.codex/config.toml when the
+// file does not exist: cleanup never creates it, so post-apply verification
+// must not require it.
+func TestComponentPathsPermissionsCodexExcludesMissingConfigTOML(t *testing.T) {
 	home := t.TempDir()
 	adapters := resolveAdapters([]model.AgentID{model.AgentCodex})
 
 	paths := componentPaths(home, model.Selection{}, adapters, model.ComponentPermission)
 
-	want := filepath.Join(home, ".codex", "config.toml")
-	if !containsPath(paths, want) {
-		t.Fatalf("componentPaths(permissions,codex) missing %q\npaths=%v", want, paths)
+	unwanted := filepath.Join(home, ".codex", "config.toml")
+	if containsPath(paths, unwanted) {
+		t.Fatalf("componentPaths(permissions,codex) must not include missing %q\npaths=%v", unwanted, paths)
+	}
+}
+
+// TestComponentPathsPermissionsCodexIncludesConfigTOMLOnUnconfirmedStat pins
+// the fail-toward-backup direction: when Stat fails with an error that does
+// not confirm absence (here ENOTDIR because ~/.codex is a file), the path must
+// still be included so backup coverage is never silently dropped.
+func TestComponentPathsPermissionsCodexIncludesConfigTOMLOnUnconfirmedStat(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Stat under a file path does not yield a non-IsNotExist error on Windows")
+	}
+	home := t.TempDir()
+	if err := os.WriteFile(filepath.Join(home, ".codex"), []byte(""), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	adapters := resolveAdapters([]model.AgentID{model.AgentCodex})
+
+	paths := componentPaths(home, model.Selection{}, adapters, model.ComponentPermission)
+
+	configPath := filepath.Join(home, ".codex", "config.toml")
+	if !containsPath(paths, configPath) {
+		t.Fatalf("componentPaths(permissions,codex) missing %q on unconfirmed stat\npaths=%v", configPath, paths)
+	}
+}
+
+// TestComponentPathsPermissionsCodexIncludesExistingConfigTOML pins backup and
+// rollback coverage: Codex permission cleanup mutates an existing
+// ~/.codex/config.toml, so a Permission-selected run must snapshot it when it
+// exists.
+func TestComponentPathsPermissionsCodexIncludesExistingConfigTOML(t *testing.T) {
+	home := t.TempDir()
+	configPath := filepath.Join(home, ".codex", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(configPath, []byte("model = \"gpt-5.5\"\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	adapters := resolveAdapters([]model.AgentID{model.AgentCodex})
+
+	paths := componentPaths(home, model.Selection{}, adapters, model.ComponentPermission)
+
+	if !containsPath(paths, configPath) {
+		t.Fatalf("componentPaths(permissions,codex) missing existing %q\npaths=%v", configPath, paths)
 	}
 }
 
@@ -420,16 +468,12 @@ func TestComponentPathsPermissionsIncludesAgentsWithInjectionTarget(t *testing.T
 		model.AgentGeminiCLI,
 		model.AgentQwenCode,
 		model.AgentVSCodeCopilot,
-		model.AgentCodex,
 	})
 
 	paths := componentPaths(home, model.Selection{}, adapters, model.ComponentPermission)
 
 	for _, adapter := range adapters {
 		want := adapter.SettingsPath(home)
-		if adapter.Agent() == model.AgentCodex {
-			want = filepath.Join(home, ".codex", "config.toml")
-		}
 		if !containsPath(paths, want) {
 			t.Fatalf("componentPaths(permissions) missing supported injection path %q\npaths=%v", want, paths)
 		}

--- a/internal/components/filemerge/toml.go
+++ b/internal/components/filemerge/toml.go
@@ -2,6 +2,7 @@ package filemerge
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -291,6 +292,10 @@ func RemoveTOMLTableKeys(content, section string, keys []string) string {
 // RemoveTOMLTable removes a complete single TOML table and its key-value lines.
 // It preserves every other table and top-level key verbatim, normalizing CRLF to
 // LF like the other string-based TOML merge helpers in this package.
+//
+// It matches only the exactly-spelled [tableName] header and leaves subtables
+// alone. Use RemoveTOMLTableTree instead to remove a table together with all
+// of its subtables with quote-aware segment matching.
 func RemoveTOMLTable(content, tableName string) string {
 	content = strings.ReplaceAll(content, "\r\n", "\n")
 	lines := strings.Split(content, "\n")
@@ -315,6 +320,462 @@ func RemoveTOMLTable(content, tableName string) string {
 	}
 
 	return strings.Join(kept, "\n")
+}
+
+// RemoveTOMLTableTree removes the named table and every subtable beneath it —
+// the [tableName] header, all [tableName.*] headers, and their key-value
+// lines — plus dotted assignments whose effective key path falls under the
+// same prefix. Header and key segments are compared after TOML unquoting, so
+// [permissions."gentle-dev"] matches permissions.gentle-dev. Every other line
+// is preserved byte-for-byte so user-authored content, spacing, and comments
+// stay untouched. If tableName itself does not parse as a TOML key path, the
+// content is returned unchanged (silent no-op) — removal never guesses.
+//
+// Use RemoveTOMLTable instead when a single exactly-spelled [header] block
+// should be replaced or dropped without touching its subtables.
+func RemoveTOMLTableTree(content, tableName string) string {
+	target, ok := parseTOMLKeyPath(tableName)
+	if !ok {
+		return content
+	}
+
+	lines := strings.SplitAfter(content, "\n")
+	kept := make([]string, 0, len(lines))
+	var tablePath []string
+	tableKnown := true
+	removing := false
+	var multilineQuote byte
+	removingMultilineValue := false
+	removingArrayDepth := 0
+	for _, line := range lines {
+		if removingArrayDepth > 0 {
+			advanceTOMLLexicalState(line, &multilineQuote, &removingArrayDepth)
+			continue
+		}
+		insideMultiline := multilineQuote != 0
+		advanceTOMLMultilineState(line, &multilineQuote)
+		if removingMultilineValue {
+			removingMultilineValue = multilineQuote != 0
+			continue
+		}
+		if removing {
+			if equals := tomlIndexOutsideQuotes(line, '='); equals != -1 &&
+				strings.HasPrefix(strings.TrimSpace(line[equals+1:]), "[") {
+				var valueMultiline byte
+				advanceTOMLLexicalState(line[equals+1:], &valueMultiline, &removingArrayDepth)
+				multilineQuote = valueMultiline
+			}
+		}
+		if !insideMultiline && strings.HasPrefix(strings.TrimSpace(line), "[") {
+			if path, isHeader := parseTOMLTableHeader(line); isHeader {
+				tablePath = path
+				tableKnown = true
+				removing = hasTOMLKeyPathPrefix(path, target)
+				if removing {
+					continue
+				}
+			} else {
+				// Malformed header-like line: the table context is now
+				// unknown, so stop removing and keep every following
+				// assignment until a well-formed header re-establishes
+				// context. User content is never silently consumed.
+				removing = false
+				tableKnown = false
+			}
+			kept = append(kept, line)
+			continue
+		}
+		if removing {
+			continue
+		}
+		if tableKnown {
+			if keyPath, isAssignment := parseTOMLAssignmentKey(line); isAssignment {
+				fullPath := append(append([]string(nil), tablePath...), keyPath...)
+				if hasTOMLKeyPathPrefix(fullPath, target) {
+					if equals := tomlIndexOutsideQuotes(line, '='); equals != -1 &&
+						strings.HasPrefix(strings.TrimSpace(line[equals+1:]), "[") {
+						var valueMultiline byte
+						advanceTOMLLexicalState(line[equals+1:], &valueMultiline, &removingArrayDepth)
+						multilineQuote = valueMultiline
+					} else {
+						removingMultilineValue = multilineQuote != 0
+					}
+					continue
+				}
+			}
+		}
+		kept = append(kept, line)
+	}
+	return strings.Join(kept, "")
+}
+
+// RemoveEmptyTOMLTableTree removes a target tree only when it contains no
+// assignments, comments, or malformed content. Anything else may be
+// user-authored and is preserved.
+func RemoveEmptyTOMLTableTree(content, tableName string) string {
+	target, ok := parseTOMLKeyPath(tableName)
+	if !ok {
+		return content
+	}
+
+	inTarget := false
+	var tablePath []string
+	for _, line := range strings.SplitAfter(content, "\n") {
+		if path, isHeader := parseTOMLTableHeader(line); isHeader {
+			tablePath = path
+			inTarget = hasTOMLKeyPathPrefix(path, target)
+			continue
+		}
+		if keyPath, isAssignment := parseTOMLAssignmentKey(line); isAssignment {
+			fullPath := append(append([]string(nil), tablePath...), keyPath...)
+			if hasTOMLKeyPathPrefix(fullPath, target) {
+				return content
+			}
+		}
+		if inTarget && strings.TrimSpace(line) != "" {
+			return content
+		}
+	}
+	return RemoveTOMLTableTree(content, tableName)
+}
+
+// RemoveTopLevelTOMLKeyIfValue removes a top-level `key = rawValue` assignment
+// only when its right-hand side matches rawValue exactly (after trimming
+// whitespace). The key is matched after TOML unquoting, so "approval_policy"
+// matches approval_policy. Scanning stops at the first table header so
+// identical keys inside tables are never touched, and a user-customized value
+// — including one annotated with a trailing comment — is preserved. All other
+// lines stay byte-for-byte identical.
+func RemoveTopLevelTOMLKeyIfValue(content, key, rawValue string) string {
+	lines := strings.SplitAfter(content, "\n")
+	kept := make([]string, 0, len(lines))
+	topLevel := true
+	var multilineQuote byte
+	arrayDepth := 0
+	for _, line := range lines {
+		if topLevel && arrayDepth > 0 {
+			advanceTOMLLexicalState(line, &multilineQuote, &arrayDepth)
+			kept = append(kept, line)
+			continue
+		}
+		insideMultiline := multilineQuote != 0
+		advanceTOMLMultilineState(line, &multilineQuote)
+		if topLevel && !insideMultiline {
+			code := tomlCodeBeforeComment(line)
+			if equals := tomlIndexOutsideQuotes(code, '='); equals != -1 {
+				keyPath, isKey := parseTOMLKeyPath(line[:equals])
+				if isKey && len(keyPath) == 1 && keyPath[0] == key &&
+					strings.TrimSpace(line[equals+1:]) == rawValue {
+					continue
+				}
+				if isKey && strings.HasPrefix(strings.TrimSpace(code[equals+1:]), "[") {
+					var arrayQuote byte
+					advanceTOMLLexicalState(line[equals+1:], &arrayQuote, &arrayDepth)
+				}
+			} else if strings.HasPrefix(strings.TrimSpace(line), "[") {
+				topLevel = false
+			}
+		}
+		kept = append(kept, line)
+	}
+	return strings.Join(kept, "")
+}
+
+// RemoveTOMLKeyIfValue removes one fully-qualified assignment only when its
+// value matches exactly. Unknown values and neighboring keys remain untouched.
+func RemoveTOMLKeyIfValue(content, key, rawValue string) string {
+	target, ok := parseTOMLKeyPath(key)
+	if !ok {
+		return content
+	}
+
+	lines := strings.SplitAfter(content, "\n")
+	kept := make([]string, 0, len(lines))
+	var tablePath []string
+	tableKnown := true
+	var multilineQuote byte
+	arrayDepth := 0
+	for _, line := range lines {
+		if arrayDepth > 0 {
+			advanceTOMLLexicalState(line, &multilineQuote, &arrayDepth)
+			kept = append(kept, line)
+			continue
+		}
+		insideMultiline := multilineQuote != 0
+		advanceTOMLMultilineState(line, &multilineQuote)
+		if !insideMultiline {
+			code := tomlCodeBeforeComment(line)
+			if equals := tomlIndexOutsideQuotes(code, '='); equals != -1 {
+				keyPath, isAssignment := parseTOMLKeyPath(code[:equals])
+				fullPath := append(append([]string(nil), tablePath...), keyPath...)
+				if tableKnown && isAssignment && len(fullPath) == len(target) &&
+					hasTOMLKeyPathPrefix(fullPath, target) && strings.TrimSpace(line[equals+1:]) == rawValue {
+					continue
+				}
+				if isAssignment && strings.HasPrefix(strings.TrimSpace(code[equals+1:]), "[") {
+					var valueMultiline byte
+					advanceTOMLLexicalState(line[equals+1:], &valueMultiline, &arrayDepth)
+					multilineQuote = valueMultiline
+				}
+			} else if strings.HasPrefix(strings.TrimSpace(line), "[") {
+				path, isHeader := parseTOMLTableHeader(line)
+				tablePath, tableKnown = path, isHeader
+			}
+		}
+		kept = append(kept, line)
+	}
+	return strings.Join(kept, "")
+}
+
+// The helpers below are a minimal quote-aware TOML key-path parser used by the
+// removal helpers. They handle bare, single-quoted, and double-quoted key
+// segments plus comments outside quotes, without a TOML parser dependency.
+
+func parseTOMLTableHeader(line string) ([]string, bool) {
+	code := strings.TrimSpace(tomlCodeBeforeComment(line))
+	if len(code) < 3 || code[0] != '[' {
+		return nil, false
+	}
+
+	if strings.HasPrefix(code, "[[") {
+		if len(code) < 5 || !strings.HasSuffix(code, "]]") {
+			return nil, false
+		}
+		return parseTOMLKeyPath(code[2 : len(code)-2])
+	}
+	if !strings.HasSuffix(code, "]") {
+		return nil, false
+	}
+	return parseTOMLKeyPath(code[1 : len(code)-1])
+}
+
+func parseTOMLAssignmentKey(line string) ([]string, bool) {
+	code := tomlCodeBeforeComment(line)
+	equals := tomlIndexOutsideQuotes(code, '=')
+	if equals == -1 {
+		return nil, false
+	}
+	return parseTOMLKeyPath(code[:equals])
+}
+
+func tomlCodeBeforeComment(line string) string {
+	if comment := tomlIndexOutsideQuotes(line, '#'); comment != -1 {
+		return line[:comment]
+	}
+	return line
+}
+
+func tomlIndexOutsideQuotes(text string, target byte) int {
+	var quote byte
+	escaped := false
+	for i := 0; i < len(text); i++ {
+		char := text[i]
+		if quote == '"' && escaped {
+			escaped = false
+			continue
+		}
+		if quote == '"' && char == '\\' {
+			escaped = true
+			continue
+		}
+		if char == '"' || char == '\'' {
+			if quote == 0 {
+				quote = char
+			} else if quote == char {
+				quote = 0
+			}
+			continue
+		}
+		if quote == 0 && char == target {
+			return i
+		}
+	}
+	return -1
+}
+
+// advanceTOMLMultilineState tracks whether subsequent lines are inside a TOML
+// multiline basic or literal string. Single-line strings and comments are
+// skipped so quote-like text in either cannot alter the lexical state.
+func advanceTOMLMultilineState(line string, multilineQuote *byte) {
+	advanceTOMLLexicalState(line, multilineQuote, nil)
+}
+
+func advanceTOMLLexicalState(line string, multilineQuote *byte, arrayDepth *int) {
+	var quote byte
+	for pos := 0; pos < len(line); {
+		char := line[pos]
+		if *multilineQuote != 0 {
+			if char == *multilineQuote && pos+2 < len(line) &&
+				line[pos+1] == char && line[pos+2] == char {
+				for pos < len(line) && line[pos] == char {
+					pos++
+				}
+				*multilineQuote = 0
+				continue
+			}
+			if *multilineQuote == '"' && char == '\\' && pos+1 < len(line) {
+				pos += 2
+				continue
+			}
+			pos++
+			continue
+		}
+
+		if quote != 0 {
+			if quote == '"' && char == '\\' && pos+1 < len(line) {
+				pos += 2
+				continue
+			}
+			if char == quote {
+				quote = 0
+			}
+			pos++
+			continue
+		}
+
+		if char == '#' {
+			return
+		}
+		if (char == '"' || char == '\'') && pos+2 < len(line) &&
+			line[pos+1] == char && line[pos+2] == char {
+			*multilineQuote = char
+			pos += 3
+			continue
+		}
+		if char == '"' || char == '\'' {
+			quote = char
+		}
+		if arrayDepth != nil {
+			switch char {
+			case '[':
+				(*arrayDepth)++
+			case ']':
+				if *arrayDepth > 0 {
+					(*arrayDepth)--
+				}
+			}
+		}
+		pos++
+	}
+}
+
+func parseTOMLKeyPath(text string) ([]string, bool) {
+	var path []string
+	for pos := 0; ; {
+		pos = skipTOMLKeyWhitespace(text, pos)
+		part, next, ok := parseTOMLKeyPart(text, pos)
+		if !ok {
+			return nil, false
+		}
+		path = append(path, part)
+		pos = skipTOMLKeyWhitespace(text, next)
+		if pos == len(text) {
+			return path, true
+		}
+		if text[pos] != '.' {
+			return nil, false
+		}
+		pos++
+	}
+}
+
+func skipTOMLKeyWhitespace(text string, pos int) int {
+	for pos < len(text) && (text[pos] == ' ' || text[pos] == '\t') {
+		pos++
+	}
+	return pos
+}
+
+func parseTOMLKeyPart(text string, pos int) (string, int, bool) {
+	if pos >= len(text) {
+		return "", pos, false
+	}
+	if text[pos] == '\'' {
+		if end := strings.IndexByte(text[pos+1:], '\''); end != -1 {
+			return text[pos+1 : pos+1+end], pos + end + 2, true
+		}
+		return "", pos, false
+	}
+	if text[pos] == '"' {
+		for end := pos + 1; end < len(text); end++ {
+			if text[end] == '\\' {
+				end++
+				continue
+			}
+			if text[end] == '"' {
+				value, ok := unquoteTOMLBasicKey(text[pos : end+1])
+				return value, end + 1, ok
+			}
+		}
+		return "", pos, false
+	}
+
+	end := pos
+	for end < len(text) && isBareTOMLKeyByte(text[end]) {
+		end++
+	}
+	if end == pos {
+		return "", pos, false
+	}
+	return text[pos:end], end, true
+}
+
+func unquoteTOMLBasicKey(text string) (string, bool) {
+	for pos := 1; pos < len(text)-1; pos++ {
+		if text[pos] != '\\' {
+			continue
+		}
+		pos++
+		if pos >= len(text)-1 {
+			return "", false
+		}
+		switch text[pos] {
+		case 'b', 't', 'n', 'f', 'r', '"', '\\':
+		case 'u':
+			if !hasTOMLHexDigits(text, pos+1, 4) {
+				return "", false
+			}
+			pos += 4
+		case 'U':
+			if !hasTOMLHexDigits(text, pos+1, 8) {
+				return "", false
+			}
+			pos += 8
+		default:
+			return "", false
+		}
+	}
+
+	value, err := strconv.Unquote(text)
+	return value, err == nil
+}
+
+func hasTOMLHexDigits(text string, start, count int) bool {
+	if start+count > len(text)-1 {
+		return false
+	}
+	for _, char := range text[start : start+count] {
+		if !(char >= '0' && char <= '9' || char >= 'a' && char <= 'f' || char >= 'A' && char <= 'F') {
+			return false
+		}
+	}
+	return true
+}
+
+func isBareTOMLKeyByte(char byte) bool {
+	return char >= 'A' && char <= 'Z' || char >= 'a' && char <= 'z' || char >= '0' && char <= '9' || char == '_' || char == '-'
+}
+
+func hasTOMLKeyPathPrefix(path, prefix []string) bool {
+	if len(path) < len(prefix) {
+		return false
+	}
+	for i := range prefix {
+		if path[i] != prefix[i] {
+			return false
+		}
+	}
+	return true
 }
 
 // UpsertTopLevelTOMLString inserts or replaces a top-level key = "value" pair

--- a/internal/components/filemerge/toml_test.go
+++ b/internal/components/filemerge/toml_test.go
@@ -557,3 +557,331 @@ func TestRemoveTOMLTableKeys_Idempotent(t *testing.T) {
 		t.Fatalf("RemoveTOMLTableKeys is not idempotent:\nfirst:\n%s\nsecond:\n%s", first, second)
 	}
 }
+
+func TestRemoveTOMLTableTreeRemovesTableAndSubtables(t *testing.T) {
+	input := `model = "gpt-5.5"
+
+[permissions.gentle-dev]
+description = "injected"
+
+[permissions.gentle-dev.network]
+enabled = true
+
+[permissions.gentle-dev.filesystem.":workspace_roots"]
+"." = "write"
+
+[mcp_servers.engram]
+command = "engram"
+`
+	want := `model = "gpt-5.5"
+
+[mcp_servers.engram]
+command = "engram"
+`
+	if got := RemoveTOMLTableTree(input, "permissions.gentle-dev"); got != want {
+		t.Fatalf("RemoveTOMLTableTree() = %q, want %q", got, want)
+	}
+}
+
+func TestRemoveTOMLTableTreePreservesSimilarlyNamedTables(t *testing.T) {
+	input := `[permissions.gentle-dev]
+a = 1
+
+[permissions.gentle-devtools]
+b = 2
+
+[permissions.custom]
+c = 3
+`
+	want := `[permissions.gentle-devtools]
+b = 2
+
+[permissions.custom]
+c = 3
+`
+	if got := RemoveTOMLTableTree(input, "permissions.gentle-dev"); got != want {
+		t.Fatalf("RemoveTOMLTableTree() = %q, want %q", got, want)
+	}
+}
+
+func TestRemoveTOMLTableTreeWithoutTargetIsByteIdentical(t *testing.T) {
+	input := "custom = true\n\n[other] # keep\nkey = \"value\""
+	if got := RemoveTOMLTableTree(input, "permissions.gentle-dev"); got != input {
+		t.Fatalf("RemoveTOMLTableTree() = %q, want untouched %q", got, input)
+	}
+}
+
+func TestRemoveTOMLTableTreeRemovesTopLevelDottedKeys(t *testing.T) {
+	input := `permissions.gentle-dev.workspace_roots."~" = true
+permissions.custom.workspace_roots."~" = true
+
+[other]
+permissions.gentle-dev.x = 1
+`
+	want := `permissions.custom.workspace_roots."~" = true
+
+[other]
+permissions.gentle-dev.x = 1
+`
+	if got := RemoveTOMLTableTree(input, "permissions.gentle-dev"); got != want {
+		t.Fatalf("RemoveTOMLTableTree() = %q, want %q", got, want)
+	}
+}
+
+func TestRemoveTopLevelTOMLKeyIfValueRemovesExactMatch(t *testing.T) {
+	input := `model = "gpt-5.5"
+approval_policy = "on-request"
+
+[table]
+approval_policy = "on-request"
+`
+	want := `model = "gpt-5.5"
+
+[table]
+approval_policy = "on-request"
+`
+	if got := RemoveTopLevelTOMLKeyIfValue(input, "approval_policy", "\"on-request\""); got != want {
+		t.Fatalf("RemoveTopLevelTOMLKeyIfValue() = %q, want %q", got, want)
+	}
+}
+
+func TestRemoveTopLevelTOMLKeyIfValueKeepsCustomizedValue(t *testing.T) {
+	input := "approval_policy = \"never\"\ndefault_permissions = \"other\"\n"
+	got := RemoveTopLevelTOMLKeyIfValue(input, "approval_policy", "\"on-request\"")
+	got = RemoveTopLevelTOMLKeyIfValue(got, "default_permissions", "\"gentle-dev\"")
+	if got != input {
+		t.Fatalf("RemoveTopLevelTOMLKeyIfValue() = %q, want untouched %q", got, input)
+	}
+}
+
+func TestRemoveTOMLTableTreeRecognizesQuotedHeaderSegments(t *testing.T) {
+	input := `[permissions."gentle-dev".workspace_roots]
+"~" = true
+
+[permissions.'gentle-dev'.filesystem]
+":minimal" = "read"
+
+[permissions."custom".workspace_roots]
+"~" = true
+`
+	want := `[permissions."custom".workspace_roots]
+"~" = true
+`
+	if got := RemoveTOMLTableTree(input, "permissions.gentle-dev"); got != want {
+		t.Fatalf("RemoveTOMLTableTree() = %q, want %q", got, want)
+	}
+}
+
+func TestRemoveTOMLTableTreeRemovesQuotedDottedKeys(t *testing.T) {
+	input := `permissions."gentle-dev".workspace_roots."~" = true
+permissions.gentle-dev.workspace_roots."~/project" = true
+permissions."custom".workspace_roots."~" = true
+
+[other]
+"gentle-dev" = true
+`
+	want := `permissions."custom".workspace_roots."~" = true
+
+[other]
+"gentle-dev" = true
+`
+	if got := RemoveTOMLTableTree(input, "permissions.gentle-dev"); got != want {
+		t.Fatalf("RemoveTOMLTableTree() = %q, want %q", got, want)
+	}
+}
+
+func TestRemoveTOMLTableTreeKeepsUserContentAfterMalformedHeader(t *testing.T) {
+	input := "[permissions.gentle-dev]\na = 1\n\n[bad header no closing bracket\nb = 2\n"
+	want := "[bad header no closing bracket\nb = 2\n"
+	if got := RemoveTOMLTableTree(input, "permissions.gentle-dev"); got != want {
+		t.Fatalf("RemoveTOMLTableTree() = %q, want %q", got, want)
+	}
+}
+
+func TestRemoveTOMLTableTreeMalformedHeaderBeforeMatchIsByteIdentical(t *testing.T) {
+	input := "[broken header\npermissions.gentle-dev.x = 1\n"
+	if got := RemoveTOMLTableTree(input, "permissions.gentle-dev"); got != input {
+		t.Fatalf("RemoveTOMLTableTree() = %q, want untouched %q", got, input)
+	}
+}
+
+func TestRemoveTopLevelTOMLKeyIfValueRecognizesQuotedKey(t *testing.T) {
+	input := `"approval_policy" = "on-request"
+model = "gpt-5.5"
+`
+	want := `model = "gpt-5.5"
+`
+	if got := RemoveTopLevelTOMLKeyIfValue(input, "approval_policy", "\"on-request\""); got != want {
+		t.Fatalf("RemoveTopLevelTOMLKeyIfValue() = %q, want %q", got, want)
+	}
+}
+
+func TestRemoveTOMLTableTreeIgnoresHeadersInsideMultilineBasicStrings(t *testing.T) {
+	input := `message = """
+[permissions.gentle-dev]
+user content
+"""
+permissions.gentle-dev.workspace_roots."~" = true
+[other]
+keep = true
+`
+	want := `message = """
+[permissions.gentle-dev]
+user content
+"""
+[other]
+keep = true
+`
+	if got := RemoveTOMLTableTree(input, "permissions.gentle-dev"); got != want {
+		t.Fatalf("RemoveTOMLTableTree() = %q, want %q", got, want)
+	}
+}
+
+func TestRemoveTopLevelTOMLKeyIfValueIgnoresHeadersInsideMultilineLiteralStrings(t *testing.T) {
+	input := `message = '''
+[table]
+user content
+'''
+approval_policy = "on-request"
+`
+	want := `message = '''
+[table]
+user content
+'''
+`
+	if got := RemoveTopLevelTOMLKeyIfValue(input, "approval_policy", "\"on-request\""); got != want {
+		t.Fatalf("RemoveTopLevelTOMLKeyIfValue() = %q, want %q", got, want)
+	}
+}
+
+func TestTOMLRemovalRejectsGoOnlyEscapesInQuotedKeys(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		remove func(string) string
+	}{
+		{
+			name:  "top-level key with hexadecimal escape",
+			input: "\"approval\\x5fpolicy\" = \"on-request\"\n",
+			remove: func(input string) string {
+				return RemoveTopLevelTOMLKeyIfValue(input, "approval_policy", "\"on-request\"")
+			},
+		},
+		{
+			name:  "table key part with hexadecimal escape",
+			input: "[permissions.\"gentle\\x2ddev\"]\nkeep = true\n",
+			remove: func(input string) string {
+				return RemoveTOMLTableTree(input, "permissions.gentle-dev")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.remove(tt.input); got != tt.input {
+				t.Fatalf("removal changed malformed TOML to %q, want untouched %q", got, tt.input)
+			}
+		})
+	}
+}
+
+func TestRemoveTOMLTableTreeRemovesMultilineDottedAssignments(t *testing.T) {
+	tests := []struct {
+		name, assignment string
+	}{
+		{"basic", "permissions.gentle-dev.note = \"\"\"\n[target content]\n\"\"\"\n"},
+		{"literal", "permissions.gentle-dev.note = '''\n[target content]\n'''\n"},
+	}
+	want := `message = """
+[not-a-header]
+"""
+[other]
+keep = true
+`
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := RemoveTOMLTableTree(tt.assignment+want, "permissions.gentle-dev"); got != want {
+				t.Fatalf("RemoveTOMLTableTree() = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+func TestRemoveTOMLTableTreeRemovesMultilineArrayAssignment(t *testing.T) {
+	input := `permissions.gentle-dev.rules = ["""
+  ] multiline string bracket
+  """,
+  "[string bracket]",
+  # ] comment bracket
+  [
+    "nested",
+  ],
+]
+unrelated = [
+  "]",
+  # [ comment bracket
+  "keep",
+]
+[other]
+keep = true
+`
+	want := `unrelated = [
+  "]",
+  # [ comment bracket
+  "keep",
+]
+[other]
+keep = true
+`
+	if got := RemoveTOMLTableTree(input, "permissions.gentle-dev"); got != want {
+		t.Fatalf("RemoveTOMLTableTree() = %q, want %q", got, want)
+	}
+}
+
+func TestRemoveTOMLTableTreeRemovesNestedArrayInsideTargetTable(t *testing.T) {
+	input := `[permissions.gentle-dev]
+rules = [
+  ["nested"],
+]
+[other]
+keep = true
+`
+	want := `[other]
+keep = true
+`
+	if got := RemoveTOMLTableTree(input, "permissions.gentle-dev"); got != want {
+		t.Fatalf("RemoveTOMLTableTree() = %q, want %q", got, want)
+	}
+}
+
+func TestRemoveTopLevelTOMLKeysAfterNestedArray(t *testing.T) {
+	input := `matrix = [
+  ["[string bracket]"],
+  # ] comment bracket
+  [
+    "nested",
+  ],
+]
+approval_policy = "on-request"
+default_permissions = "gentle-dev"
+[other]
+approval_policy = "on-request"
+default_permissions = "gentle-dev"
+`
+	want := `matrix = [
+  ["[string bracket]"],
+  # ] comment bracket
+  [
+    "nested",
+  ],
+]
+[other]
+approval_policy = "on-request"
+default_permissions = "gentle-dev"
+`
+	got := RemoveTopLevelTOMLKeyIfValue(input, "approval_policy", "\"on-request\"")
+	got = RemoveTopLevelTOMLKeyIfValue(got, "default_permissions", "\"gentle-dev\"")
+	if got != want {
+		t.Fatalf("top-level cleanup = %q, want %q", got, want)
+	}
+}

--- a/internal/components/permissions/inject.go
+++ b/internal/components/permissions/inject.go
@@ -3,19 +3,11 @@ package permissions
 import (
 	"fmt"
 	"os"
-	"os/exec"
-	"path/filepath"
-	"runtime"
-	"strconv"
-	"strings"
 
 	"github.com/gentleman-programming/gentle-ai/internal/agents"
 	"github.com/gentleman-programming/gentle-ai/internal/components/filemerge"
 	"github.com/gentleman-programming/gentle-ai/internal/model"
 )
-
-var codexPermissionsGOOS = runtime.GOOS
-var codexPermissionsLookPath = exec.LookPath
 
 type InjectionResult struct {
 	Changed bool
@@ -24,15 +16,27 @@ type InjectionResult struct {
 
 // TargetPath returns the file path that permission injection creates or updates
 // for the adapter, or an empty string when the agent has no supported
-// permission injection target.
+// permission injection target. Codex has no target: gentle-ai relies on
+// Codex's built-in default permissions and only cleans up the previously
+// injected profile from an existing config.
 func TargetPath(homeDir string, adapter agents.Adapter) string {
-	if adapter.Agent() == model.AgentCodex {
-		return adapter.MCPConfigPath(homeDir, "")
-	}
 	if agentOverlay(adapter.Agent()) == nil {
 		return ""
 	}
 	return adapter.SettingsPath(homeDir)
+}
+
+// CleanupPath returns the file that permission cleanup may modify for the
+// adapter without ever creating it, or an empty string when the agent has no
+// cleanup target. Unlike TargetPath it is not an injection output: callers
+// that snapshot files for backup/rollback should include it when it exists or
+// when its absence cannot be confirmed, and it must never be treated as a
+// required post-apply file.
+func CleanupPath(homeDir string, adapter agents.Adapter) string {
+	if adapter.Agent() == model.AgentCodex {
+		return adapter.MCPConfigPath(homeDir, "")
+	}
+	return ""
 }
 
 // claudeCodeOverlayJSON sets Claude Code to bypassPermissions mode (auto-accept all).
@@ -118,6 +122,28 @@ var qwenCodeOverlayJSON = []byte(`{
 }
 `)
 
+var codexLegacyPermissionValues = [][2]string{
+	{`permissions.gentle-dev.description`, `"Comfortable local development profile with workspace writes, network access, and read-only access to Git and Nix/Home Manager metadata."`},
+	{`permissions.gentle-dev.network.enabled`, `true`},
+	{`permissions.gentle-dev.network.domains."*"`, `"allow"`},
+	{`permissions.gentle-dev.filesystem.glob_scan_max_depth`, `6`},
+	{`permissions.gentle-dev.filesystem.":minimal"`, `"read"`},
+	{`permissions.gentle-dev.filesystem."~/.config/git"`, `"read"`},
+	{`permissions.gentle-dev.filesystem."~/.gitconfig"`, `"read"`},
+	{`permissions.gentle-dev.filesystem."~/.local/state/nix/profiles/home-manager/home-path"`, `"read"`},
+	{`permissions.gentle-dev.filesystem."~/.nix-profile"`, `"read"`},
+	{`permissions.gentle-dev.filesystem."/nix/store"`, `"read"`},
+	{`permissions.gentle-dev.filesystem.":tmpdir"`, `"write"`},
+	{`permissions.gentle-dev.filesystem.":slash_tmp"`, `"write"`},
+	{`permissions.gentle-dev.filesystem.":root"."."`, `"read"`},
+	{`permissions.gentle-dev.filesystem.":workspace_roots"."."`, `"write"`},
+	{`permissions.gentle-dev.filesystem.":workspace_roots".".git/**"`, `"write"`},
+	{`permissions.gentle-dev.filesystem.":workspace_roots"."**/.env"`, `"deny"`},
+	{`permissions.gentle-dev.filesystem.":workspace_roots"."**/*.pem"`, `"deny"`},
+	{`permissions.gentle-dev.filesystem.":workspace_roots"."**/*.key"`, `"deny"`},
+	{`permissions.gentle-dev.workspace_roots."~"`, `true`},
+}
+
 // vscodeCopilotOverlayJSON enables auto-approve for VS Code Copilot chat tools.
 var vscodeCopilotOverlayJSON = []byte(`{
   "chat.tools.autoApprove": true
@@ -146,7 +172,8 @@ func agentOverlay(id model.AgentID) []byte {
 		// Cursor manages permissions via cli-config.json, not settings.json.
 		return nil
 	case model.AgentCodex:
-		// Codex has no known settings.json path; permissions are skipped.
+		// Codex relies on its built-in default permissions; no overlay is
+		// injected. Inject only cleans up the retired gentle-dev profile.
 		return nil
 	case model.AgentHermes:
 		// Hermes permission format is undocumented — no overlay is injected (§14).
@@ -179,261 +206,44 @@ func Inject(homeDir string, adapter agents.Adapter) (InjectionResult, error) {
 	return InjectionResult{Changed: writeResult.Changed, Files: []string{settingsPath}}, nil
 }
 
+// injectCodexPermissions no longer writes a permission profile: gentle-ai
+// relies on Codex's built-in default permissions, which stay compatible with
+// toolchains the retired restrictive gentle-dev profile broke (#1398). It only
+// migrates an existing config by removing exactly what gentle-ai previously
+// injected — the "on-request" approval policy, the "gentle-dev" default
+// profile pointer, and exact legacy permission entries — leaving user-authored
+// or modified values byte-untouched even under permissions.gentle-dev.
+//
+// Deprecated path: this is a migration-only cleanup. Once a deprecation
+// window has passed and installed configs no longer carry the injected
+// profile, it can be removed together with CleanupPath.
 func injectCodexPermissions(homeDir string, adapter agents.Adapter) (InjectionResult, error) {
 	configPath := adapter.MCPConfigPath(homeDir, "")
-	baseTOML, err := osReadFile(configPath)
+	baseTOML, err := os.ReadFile(configPath)
 	if err != nil {
-		return InjectionResult{}, err
+		if os.IsNotExist(err) {
+			// No config file: nothing to clean, and cleanup never creates one.
+			return InjectionResult{}, nil
+		}
+		return InjectionResult{}, fmt.Errorf("read Codex config TOML %q: %w", configPath, err)
 	}
 
-	merged := filemerge.UpsertTopLevelTOMLString(string(baseTOML), "approval_policy", "on-request")
-	merged = filemerge.UpsertTopLevelTOMLString(merged, "default_permissions", "gentle-dev")
-	merged = filemerge.RemoveTOMLTableKeys(merged, "permissions.gentle-dev", []string{"extends"})
-	merged = filemerge.UpsertTOMLTableKey(merged, "permissions.gentle-dev", "description", `"Comfortable local development profile with workspace writes, network access, and read-only access to Git and Nix/Home Manager metadata."`)
-	merged = filemerge.RemoveTOMLTableKeys(merged, "permissions.gentle-dev", []string{"glob_scan_max_depth"})
-	merged = filemerge.UpsertTOMLTableKey(merged, "permissions.gentle-dev.network", "enabled", "true")
-	merged = filemerge.UpsertTOMLTableKey(merged, "permissions.gentle-dev.network.domains", `"*"`, `"allow"`)
-
-	merged = filemerge.RemoveTOMLTableKeys(merged, `permissions.gentle-dev.filesystem.":root"`, []string{`"."`})
-	secretDenyPaths := []string{
-		`"**/.env"`,
-		`"**/.env.local"`,
-		`"**/.env.*.local"`,
-		`"**/*.pem"`,
-		`"**/*.key"`,
-		`"**/secrets/**"`,
-		`"**/.ssh/**"`,
-		`"**/.credentials/**"`,
-		`"**/credentials.json"`,
-		`"**/.aws/credentials"`,
-		`"**/.config/gh/hosts.yml"`,
+	cleaned := filemerge.RemoveTopLevelTOMLKeyIfValue(string(baseTOML), "approval_policy", "\"on-request\"")
+	cleaned = filemerge.RemoveTopLevelTOMLKeyIfValue(cleaned, "default_permissions", "\"gentle-dev\"")
+	for _, legacy := range codexLegacyPermissionValues {
+		cleaned = filemerge.RemoveTOMLKeyIfValue(cleaned, legacy[0], legacy[1])
 	}
-	merged = filemerge.RemoveTOMLTableKeys(merged, "permissions.gentle-dev.filesystem", secretDenyPaths)
-	merged = filemerge.RemoveTOMLTableKeys(merged, `permissions.gentle-dev.filesystem.":workspace_roots"`, []string{
-		`"**/.git"`,
-		`"**/.git/**"`,
-		`"**/.env.*"`,
-		`"*.env.*"`,
-		`"**/secrets/*"`,
-	})
-
-	readPaths := []string{
-		`":minimal"`,
-		`"~/.config/git"`,
-		`"~/.gitconfig"`,
-		`"~/.local/state/nix/profiles/home-manager/home-path"`,
-		`"~/.nix-profile"`,
-	}
-	if codexPermissionsGOOS != "windows" {
-		readPaths = append(readPaths, `"/nix/store"`)
-	}
-	if prefix, ok := existingLinuxbrewPrefix(); ok {
-		readPaths = append(readPaths, strconv.Quote(prefix))
-	}
-	for _, path := range readPaths {
-		merged = filemerge.UpsertTOMLTableKey(merged, "permissions.gentle-dev.filesystem", path, `"read"`)
-	}
-	for _, path := range []string{`":tmpdir"`, `":slash_tmp"`} {
-		merged = filemerge.UpsertTOMLTableKey(merged, "permissions.gentle-dev.filesystem", path, `"write"`)
-	}
-	merged = filemerge.UpsertTOMLTableKey(merged, "permissions.gentle-dev.filesystem", "glob_scan_max_depth", "6")
-	for _, path := range []string{`"."`, `".git/**"`} {
-		merged = filemerge.UpsertTOMLTableKey(merged, `permissions.gentle-dev.filesystem.":workspace_roots"`, path, `"write"`)
-	}
-	for _, path := range secretDenyPaths {
-		merged = filemerge.UpsertTOMLTableKey(merged, `permissions.gentle-dev.filesystem.":workspace_roots"`, path, `"deny"`)
+	cleaned = filemerge.RemoveEmptyTOMLTableTree(cleaned, "permissions.gentle-dev")
+	if cleaned == string(baseTOML) {
+		return InjectionResult{}, nil
 	}
 
-	if codexPermissionsGOOS == "windows" {
-		merged = removeCodexHomeWorkspaceRoot(merged)
-	} else {
-		merged = filemerge.UpsertTOMLTableKey(merged, "permissions.gentle-dev.workspace_roots", `"~"`, "true")
-	}
-
-	writeResult, err := filemerge.WriteFileAtomic(configPath, []byte(merged), 0o644)
+	writeResult, err := filemerge.WriteFileAtomic(configPath, []byte(cleaned), 0o644)
 	if err != nil {
 		return InjectionResult{}, err
 	}
 
 	return InjectionResult{Changed: writeResult.Changed, Files: []string{configPath}}, nil
-}
-
-func existingLinuxbrewPrefix() (string, bool) {
-	if codexPermissionsGOOS != "linux" {
-		return "", false
-	}
-
-	brewPath, err := codexPermissionsLookPath("brew")
-	if err != nil || !filepath.IsAbs(brewPath) || filepath.Base(brewPath) != "brew" || filepath.Base(filepath.Dir(brewPath)) != "bin" {
-		return "", false
-	}
-
-	prefix := filepath.Dir(filepath.Dir(brewPath))
-	info, err := os.Stat(prefix)
-	if err != nil || !info.IsDir() {
-		return "", false
-	}
-	return prefix, true
-}
-
-func removeCodexHomeWorkspaceRoot(content string) string {
-	targetPath := []string{"permissions", "gentle-dev", "workspace_roots", "~"}
-	var tablePath []string
-	lines := strings.SplitAfter(content, "\n")
-	kept := make([]string, 0, len(lines))
-	for _, line := range lines {
-		if path, ok := parseTOMLTableHeader(line); ok {
-			tablePath = path
-			kept = append(kept, line)
-			continue
-		}
-		keyPath, ok := parseTOMLAssignmentKey(line)
-		if ok && equalTOMLKeyPath(append(tablePath, keyPath...), targetPath) {
-			continue
-		}
-		kept = append(kept, line)
-	}
-
-	return strings.Join(kept, "")
-}
-
-func parseTOMLTableHeader(line string) ([]string, bool) {
-	code := strings.TrimSpace(tomlCodeBeforeComment(line))
-	if len(code) < 3 || code[0] != '[' {
-		return nil, false
-	}
-
-	if strings.HasPrefix(code, "[[") {
-		if len(code) < 5 || !strings.HasSuffix(code, "]]") {
-			return nil, false
-		}
-		return parseTOMLKeyPath(code[2 : len(code)-2])
-	}
-	if !strings.HasSuffix(code, "]") {
-		return nil, false
-	}
-	return parseTOMLKeyPath(code[1 : len(code)-1])
-}
-
-func parseTOMLAssignmentKey(line string) ([]string, bool) {
-	code := tomlCodeBeforeComment(line)
-	equals := tomlIndexOutsideQuotes(code, '=')
-	if equals == -1 {
-		return nil, false
-	}
-	return parseTOMLKeyPath(code[:equals])
-}
-
-func tomlCodeBeforeComment(line string) string {
-	if comment := tomlIndexOutsideQuotes(line, '#'); comment != -1 {
-		return line[:comment]
-	}
-	return line
-}
-
-func tomlIndexOutsideQuotes(text string, target byte) int {
-	var quote byte
-	escaped := false
-	for i := 0; i < len(text); i++ {
-		char := text[i]
-		if quote == '"' && escaped {
-			escaped = false
-			continue
-		}
-		if quote == '"' && char == '\\' {
-			escaped = true
-			continue
-		}
-		if char == '"' || char == '\'' {
-			if quote == 0 {
-				quote = char
-			} else if quote == char {
-				quote = 0
-			}
-			continue
-		}
-		if quote == 0 && char == target {
-			return i
-		}
-	}
-	return -1
-}
-
-func parseTOMLKeyPath(text string) ([]string, bool) {
-	var path []string
-	for pos := 0; ; {
-		pos = skipTOMLKeyWhitespace(text, pos)
-		part, next, ok := parseTOMLKeyPart(text, pos)
-		if !ok {
-			return nil, false
-		}
-		path = append(path, part)
-		pos = skipTOMLKeyWhitespace(text, next)
-		if pos == len(text) {
-			return path, true
-		}
-		if text[pos] != '.' {
-			return nil, false
-		}
-		pos++
-	}
-}
-
-func skipTOMLKeyWhitespace(text string, pos int) int {
-	for pos < len(text) && (text[pos] == ' ' || text[pos] == '\t') {
-		pos++
-	}
-	return pos
-}
-
-func parseTOMLKeyPart(text string, pos int) (string, int, bool) {
-	if pos >= len(text) {
-		return "", pos, false
-	}
-	if text[pos] == '\'' {
-		if end := strings.IndexByte(text[pos+1:], '\''); end != -1 {
-			return text[pos+1 : pos+1+end], pos + end + 2, true
-		}
-		return "", pos, false
-	}
-	if text[pos] == '"' {
-		for end := pos + 1; end < len(text); end++ {
-			if text[end] == '\\' {
-				end++
-				continue
-			}
-			if text[end] == '"' {
-				value, err := strconv.Unquote(text[pos : end+1])
-				return value, end + 1, err == nil
-			}
-		}
-		return "", pos, false
-	}
-
-	end := pos
-	for end < len(text) && isBareTOMLKeyByte(text[end]) {
-		end++
-	}
-	if end == pos {
-		return "", pos, false
-	}
-	return text[pos:end], end, true
-}
-
-func isBareTOMLKeyByte(char byte) bool {
-	return char >= 'A' && char <= 'Z' || char >= 'a' && char <= 'z' || char >= '0' && char <= '9' || char == '_' || char == '-'
-}
-
-func equalTOMLKeyPath(left, right []string) bool {
-	if len(left) != len(right) {
-		return false
-	}
-	for i := range left {
-		if left[i] != right[i] {
-			return false
-		}
-	}
-	return true
 }
 
 func mergeJSONFile(path string, overlay []byte) (filemerge.WriteResult, error) {

--- a/internal/components/permissions/inject_test.go
+++ b/internal/components/permissions/inject_test.go
@@ -2,10 +2,9 @@ package permissions
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
-	"os/exec"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"testing"
 
@@ -30,41 +29,69 @@ func codexAdapter() agents.Adapter       { return codex.NewAdapter() }
 func antigravityAdapter() agents.Adapter { return antigravity.NewAdapter() }
 func hermesAdapter() agents.Adapter      { return hermes.NewAdapter() }
 
-func tomlSection(text, header string) string {
-	start := strings.Index(text, header)
-	if start == -1 {
-		return ""
-	}
-	section := text[start+len(header):]
-	if next := strings.Index(section, "\n["); next != -1 {
-		section = section[:next]
-	}
-	return section
-}
+// codexInjectedLegacyConfig mirrors a config.toml produced by the retired
+// gentle-dev permission profile injection, wrapped in user-authored content.
+const codexInjectedLegacyConfig = `model = "gpt-5.5"
+approval_policy = "on-request"
+default_permissions = "gentle-dev"
 
-func assertCodexWorkspaceWriteRulesScoped(t *testing.T, text string) {
+[permissions.gentle-dev]
+description = "Comfortable local development profile with workspace writes, network access, and read-only access to Git and Nix/Home Manager metadata."
+
+[permissions.gentle-dev.network]
+enabled = true
+
+[permissions.gentle-dev.network.domains]
+"*" = "allow"
+
+[permissions.gentle-dev.filesystem]
+glob_scan_max_depth = 6
+":minimal" = "read"
+"~/.config/git" = "read"
+"~/.gitconfig" = "read"
+"~/.local/state/nix/profiles/home-manager/home-path" = "read"
+"~/.nix-profile" = "read"
+"/nix/store" = "read"
+":tmpdir" = "write"
+":slash_tmp" = "write"
+
+[permissions.gentle-dev.filesystem.":root"]
+"." = "read"
+
+[permissions.gentle-dev.filesystem.":workspace_roots"]
+"." = "write"
+".git/**" = "write"
+"**/.env" = "deny"
+"**/*.pem" = "deny"
+"**/*.key" = "deny"
+
+[permissions.gentle-dev.workspace_roots]
+"~" = true
+
+[mcp_servers.engram]
+command = "engram"
+args = ["mcp", "--tools=agent"]
+`
+
+// codexCleanedConfig is codexInjectedLegacyConfig with every previously
+// injected key and table removed and user content preserved byte-for-byte.
+const codexCleanedConfig = `model = "gpt-5.5"
+
+[mcp_servers.engram]
+command = "engram"
+args = ["mcp", "--tools=agent"]
+`
+
+func writeCodexConfig(t *testing.T, home, content string) string {
 	t.Helper()
-
-	rootFilesystem := tomlSection(text, `[permissions.gentle-dev.filesystem]`)
-	for _, rule := range []string{`"." = "write"`, `".git/**" = "write"`} {
-		if strings.Contains(rootFilesystem, rule) {
-			t.Fatalf("root filesystem table contains workspace write rule %q; got:\n%s", rule, rootFilesystem)
-		}
+	configPath := filepath.Join(home, ".codex", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
 	}
-
-	scopedFilesystem := tomlSection(text, `[permissions.gentle-dev.filesystem.":workspace_roots"]`)
-	if scopedFilesystem == "" {
-		t.Fatalf("config.toml missing workspace-scoped filesystem table; got:\n%s", text)
+	if err := os.WriteFile(configPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
 	}
-	for _, rule := range []string{`"." = "write"`, `".git/**" = "write"`} {
-		if !strings.Contains(scopedFilesystem, rule) {
-			t.Fatalf("workspace-scoped filesystem table missing workspace write rule %q; got:\n%s", rule, scopedFilesystem)
-		}
-	}
-}
-
-func codexWorkspaceRootsSection(text string) string {
-	return tomlSection(text, `[permissions.gentle-dev.workspace_roots]`)
+	return configPath
 }
 
 // TestInjectHermesSkipsPermissions verifies that Hermes returns nil (no file written)
@@ -347,21 +374,17 @@ func TestInjectAntigravitySkipsPermissions(t *testing.T) {
 	}
 }
 
-func TestInjectCodexWritesGentleDevPermissionsProfile(t *testing.T) {
+func TestInjectCodexRemovesInjectedGentleDevProfile(t *testing.T) {
 	home := t.TempDir()
-	origGOOS := codexPermissionsGOOS
-	codexPermissionsGOOS = "linux"
-	t.Cleanup(func() { codexPermissionsGOOS = origGOOS })
+	configPath := writeCodexConfig(t, home, codexInjectedLegacyConfig)
 
 	result, err := Inject(home, codexAdapter())
 	if err != nil {
 		t.Fatalf("Inject() error = %v", err)
 	}
 	if !result.Changed {
-		t.Fatal("Inject() for Codex changed = false")
+		t.Fatal("Inject() changed = false, want true")
 	}
-
-	configPath := filepath.Join(home, ".codex", "config.toml")
 	if len(result.Files) != 1 || result.Files[0] != configPath {
 		t.Fatalf("Inject() files = %v, want [%q]", result.Files, configPath)
 	}
@@ -370,428 +393,17 @@ func TestInjectCodexWritesGentleDevPermissionsProfile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read config.toml: %v", err)
 	}
-	text := string(content)
-
-	wantSubstrings := []string{
-		`approval_policy = "on-request"`,
-		`default_permissions = "gentle-dev"`,
-		`[permissions.gentle-dev]`,
-		`[permissions.gentle-dev.network]`,
-		`enabled = true`,
-		`[permissions.gentle-dev.network.domains]`,
-		`"*" = "allow"`,
-		`[permissions.gentle-dev.filesystem]`,
-		`":minimal" = "read"`,
-		`"~/.config/git" = "read"`,
-		`"~/.gitconfig" = "read"`,
-		`"~/.local/state/nix/profiles/home-manager/home-path" = "read"`,
-		`"~/.nix-profile" = "read"`,
-		`"/nix/store" = "read"`,
-		`":tmpdir" = "write"`,
-		`":slash_tmp" = "write"`,
-		`glob_scan_max_depth = 6`,
-		`[permissions.gentle-dev.filesystem.":workspace_roots"]`,
-		`"**/.env" = "deny"`,
-		`"**/.env.local" = "deny"`,
-		`"**/.env.*.local" = "deny"`,
-		`"**/*.pem" = "deny"`,
-		`"**/*.key" = "deny"`,
-		`"**/secrets/**" = "deny"`,
-		`"**/.ssh/**" = "deny"`,
-		`"**/.credentials/**" = "deny"`,
-		`"**/credentials.json" = "deny"`,
-		`"**/.aws/credentials" = "deny"`,
-		`"**/.config/gh/hosts.yml" = "deny"`,
-		`[permissions.gentle-dev.workspace_roots]`,
-		`"~" = true`,
+	if string(content) != codexCleanedConfig {
+		t.Fatalf("cleaned config.toml = %q, want %q", content, codexCleanedConfig)
 	}
-	for _, want := range wantSubstrings {
-		if !strings.Contains(text, want) {
-			t.Fatalf("config.toml missing %q; got:\n%s", want, text)
-		}
-	}
-	rootFilesystem := tomlSection(text, `[permissions.gentle-dev.filesystem]`)
-	if !strings.Contains(rootFilesystem, `glob_scan_max_depth = 6`) {
-		t.Fatalf("root filesystem table missing glob_scan_max_depth; got:\n%s", rootFilesystem)
-	}
-	for _, invalidRootGlob := range []string{`"**/.env" = "deny"`, `"**/*.pem" = "deny"`, `"**/*.key" = "deny"`} {
-		if strings.Contains(rootFilesystem, invalidRootGlob) {
-			t.Fatalf("root filesystem table contains scoped secret deny %q; got:\n%s", invalidRootGlob, rootFilesystem)
-		}
-	}
-	assertCodexWorkspaceWriteRulesScoped(t, text)
-	scopedFilesystem := tomlSection(text, `[permissions.gentle-dev.filesystem.":workspace_roots"]`)
-	if scopedFilesystem == "" {
-		t.Fatalf("config.toml missing workspace-scoped filesystem table; got:\n%s", text)
-	}
-	for _, want := range []string{`"**/.env" = "deny"`, `"**/*.pem" = "deny"`, `"**/*.key" = "deny"`} {
-		if !strings.Contains(scopedFilesystem, want) {
-			t.Fatalf("workspace-scoped filesystem table missing %q; got:\n%s", want, scopedFilesystem)
-		}
-	}
-	for _, invalid := range []string{
-		`"**/.git" = "write"`,
-		`"**/.git/**" = "write"`,
-	} {
-		if strings.Contains(text, invalid) {
-			t.Fatalf("config.toml contains invalid Codex permission entry %q; got:\n%s", invalid, text)
-		}
-	}
-	if strings.Contains(text, `extends = ":workspace"`) {
-		t.Fatalf("config.toml should not inherit :workspace because it keeps Codex .git protections; got:\n%s", text)
+	if strings.Contains(string(content), "gentle-dev") {
+		t.Fatalf("cleaned config.toml still mentions gentle-dev; got:\n%s", content)
 	}
 }
 
-func TestInjectCodexPermissionsSkipsNixStoreOnWindows(t *testing.T) {
+func TestInjectCodexCleanupIsIdempotent(t *testing.T) {
 	home := t.TempDir()
-	origGOOS := codexPermissionsGOOS
-	codexPermissionsGOOS = "windows"
-	t.Cleanup(func() { codexPermissionsGOOS = origGOOS })
-
-	if _, err := Inject(home, codexAdapter()); err != nil {
-		t.Fatalf("Inject() error = %v", err)
-	}
-
-	configPath := filepath.Join(home, ".codex", "config.toml")
-	content, err := os.ReadFile(configPath)
-	if err != nil {
-		t.Fatalf("read config.toml: %v", err)
-	}
-	text := string(content)
-
-	if strings.Contains(text, `"/nix/store"`) {
-		t.Fatalf("Windows Codex config should not include /nix/store; got:\n%s", text)
-	}
-	for _, want := range []string{
-		`"~/.local/state/nix/profiles/home-manager/home-path" = "read"`,
-		`"~/.nix-profile" = "read"`,
-	} {
-		if !strings.Contains(text, want) {
-			t.Fatalf("Windows Codex config missing non-fatal Nix home path %q; got:\n%s", want, text)
-		}
-	}
-}
-
-func TestInjectCodexPermissionsIncludesExistingLinuxbrewPrefix(t *testing.T) {
-	home := t.TempDir()
-	prefix := filepath.Join(t.TempDir(), "linuxbrew")
-	binDir := filepath.Join(prefix, "bin")
-	if err := os.MkdirAll(binDir, 0o755); err != nil {
-		t.Fatalf("create Linuxbrew bin directory: %v", err)
-	}
-	brewPath := filepath.Join(binDir, "brew")
-	if err := os.WriteFile(brewPath, []byte("#!/bin/sh\n"), 0o755); err != nil {
-		t.Fatalf("create brew executable: %v", err)
-	}
-
-	origGOOS := codexPermissionsGOOS
-	origLookPath := codexPermissionsLookPath
-	codexPermissionsGOOS = "linux"
-	codexPermissionsLookPath = func(string) (string, error) { return brewPath, nil }
-	t.Cleanup(func() {
-		codexPermissionsGOOS = origGOOS
-		codexPermissionsLookPath = origLookPath
-	})
-
-	if _, err := Inject(home, codexAdapter()); err != nil {
-		t.Fatalf("Inject() error = %v", err)
-	}
-	content, err := os.ReadFile(filepath.Join(home, ".codex", "config.toml"))
-	if err != nil {
-		t.Fatalf("read config.toml: %v", err)
-	}
-	if !strings.Contains(string(content), strconv.Quote(prefix)+` = "read"`) {
-		t.Fatalf("Codex config missing Linuxbrew prefix %q; got:\n%s", prefix, content)
-	}
-}
-
-func TestInjectCodexPermissionsSkipsLinuxbrewPrefix(t *testing.T) {
-	tests := []struct {
-		name     string
-		goos     string
-		brewPath func(t *testing.T) string
-	}{
-		{
-			name: "brew is absent on Linux",
-			goos: "linux",
-		},
-		{
-			name: "detected prefix does not exist",
-			goos: "linux",
-			brewPath: func(t *testing.T) string {
-				return filepath.Join(t.TempDir(), "missing", "bin", "brew")
-			},
-		},
-		{
-			name: "macOS remains unchanged",
-			goos: "darwin",
-			brewPath: func(t *testing.T) string {
-				prefix := t.TempDir()
-				return filepath.Join(prefix, "bin", "brew")
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			home := t.TempDir()
-			brewPath := ""
-			if tt.brewPath != nil {
-				brewPath = tt.brewPath(t)
-			}
-			origGOOS := codexPermissionsGOOS
-			origLookPath := codexPermissionsLookPath
-			codexPermissionsGOOS = tt.goos
-			codexPermissionsLookPath = func(string) (string, error) {
-				if brewPath == "" {
-					return "", exec.ErrNotFound
-				}
-				return brewPath, nil
-			}
-			t.Cleanup(func() {
-				codexPermissionsGOOS = origGOOS
-				codexPermissionsLookPath = origLookPath
-			})
-
-			if _, err := Inject(home, codexAdapter()); err != nil {
-				t.Fatalf("Inject() error = %v", err)
-			}
-			content, err := os.ReadFile(filepath.Join(home, ".codex", "config.toml"))
-			if err != nil {
-				t.Fatalf("read config.toml: %v", err)
-			}
-			if brewPath != "" {
-				prefix := filepath.Dir(filepath.Dir(brewPath))
-				if strings.Contains(string(content), strconv.Quote(prefix)+` = "read"`) {
-					t.Fatalf("Codex config unexpectedly includes Linuxbrew prefix %q; got:\n%s", prefix, content)
-				}
-			}
-		})
-	}
-}
-
-func TestInjectCodexPermissionsExcludesHomeWorkspaceRootOnWindows(t *testing.T) {
-	home := t.TempDir()
-	origGOOS := codexPermissionsGOOS
-	codexPermissionsGOOS = "windows"
-	t.Cleanup(func() { codexPermissionsGOOS = origGOOS })
-
-	if _, err := Inject(home, codexAdapter()); err != nil {
-		t.Fatalf("Inject() error = %v", err)
-	}
-
-	configPath := filepath.Join(home, ".codex", "config.toml")
-	content, err := os.ReadFile(configPath)
-	if err != nil {
-		t.Fatalf("ReadFile() error = %v", err)
-	}
-	workspaceRoots := codexWorkspaceRootsSection(string(content))
-	if strings.Contains(workspaceRoots, `"~" = true`) {
-		t.Fatalf("Windows Codex config should not include the home workspace root; got:\n%s", workspaceRoots)
-	}
-}
-
-func TestInjectCodexPermissionsRemovesHomeWorkspaceRootOnWindows(t *testing.T) {
-	origGOOS := codexPermissionsGOOS
-	codexPermissionsGOOS = "windows"
-	t.Cleanup(func() { codexPermissionsGOOS = origGOOS })
-
-	tests := []struct {
-		name         string
-		homeRoot     string
-		prefixedRoot string
-	}{
-		{name: "canonical double-quoted key", homeRoot: `"~" = true`, prefixedRoot: `"~/Documents/project" = true`},
-		{name: "single-quoted key", homeRoot: `'~' = true`, prefixedRoot: `'~/Documents/project' = true`},
-		{name: "tab before equals", homeRoot: "\"~\"\t=\ttrue", prefixedRoot: "\"~/Documents/project\"\t=\ttrue"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			home := t.TempDir()
-			configPath := filepath.Join(home, ".codex", "config.toml")
-			if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
-				t.Fatalf("MkdirAll() error = %v", err)
-			}
-			initial := "[permissions.gentle-dev.workspace_roots]\n" + tt.homeRoot + "\n" + tt.prefixedRoot + "\n\n[unrelated]\n'~'\t= true\n"
-			if err := os.WriteFile(configPath, []byte(initial), 0o644); err != nil {
-				t.Fatalf("WriteFile() error = %v", err)
-			}
-
-			if _, err := Inject(home, codexAdapter()); err != nil {
-				t.Fatalf("Inject() error = %v", err)
-			}
-
-			content, err := os.ReadFile(configPath)
-			if err != nil {
-				t.Fatalf("ReadFile() error = %v", err)
-			}
-			workspaceRoots := codexWorkspaceRootsSection(string(content))
-			if strings.Contains(workspaceRoots, tt.homeRoot) {
-				t.Fatalf("Windows Codex config still contains home workspace root %q; got:\n%s", tt.homeRoot, workspaceRoots)
-			}
-			if !strings.Contains(workspaceRoots, tt.prefixedRoot) {
-				t.Fatalf("Windows Codex config did not preserve prefixed workspace root %q; got:\n%s", tt.prefixedRoot, workspaceRoots)
-			}
-			if !strings.Contains(tomlSection(string(content), "[unrelated]"), "'~'\t= true") {
-				t.Fatalf("Windows Codex migration removed the home key from an unrelated table; got:\n%s", content)
-			}
-		})
-	}
-}
-
-func TestInjectCodexPermissionsRemovesDottedHomeWorkspaceRootOnWindows(t *testing.T) {
-	home := t.TempDir()
-	configPath := filepath.Join(home, ".codex", "config.toml")
-	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
-		t.Fatalf("MkdirAll() error = %v", err)
-	}
-	initial := "permissions.\"gentle-dev\".workspace_roots.\"~\" = true\npermissions.gentle-dev.workspace_roots.\"~/project\" = true\n"
-	if err := os.WriteFile(configPath, []byte(initial), 0o644); err != nil {
-		t.Fatalf("WriteFile() error = %v", err)
-	}
-
-	origGOOS := codexPermissionsGOOS
-	codexPermissionsGOOS = "windows"
-	t.Cleanup(func() { codexPermissionsGOOS = origGOOS })
-
-	if _, err := Inject(home, codexAdapter()); err != nil {
-		t.Fatalf("Inject() error = %v", err)
-	}
-	content, err := os.ReadFile(configPath)
-	if err != nil {
-		t.Fatalf("ReadFile() error = %v", err)
-	}
-	if strings.Contains(string(content), `workspace_roots."~" = true`) {
-		t.Fatalf("Windows Codex config still contains dotted home workspace root; got:\n%s", content)
-	}
-	if !strings.Contains(string(content), `workspace_roots."~/project" = true`) {
-		t.Fatalf("Windows Codex config did not preserve dotted prefixed workspace root; got:\n%s", content)
-	}
-}
-
-func TestInjectCodexPermissionsRecognizesQuotedWorkspaceRootsHeader(t *testing.T) {
-	home := t.TempDir()
-	configPath := filepath.Join(home, ".codex", "config.toml")
-	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
-		t.Fatalf("MkdirAll() error = %v", err)
-	}
-	initial := "[permissions.\"gentle-dev\".workspace_roots]\n\"~\" = true\n\"~/project\" = true\n"
-	if err := os.WriteFile(configPath, []byte(initial), 0o644); err != nil {
-		t.Fatalf("WriteFile() error = %v", err)
-	}
-
-	origGOOS := codexPermissionsGOOS
-	codexPermissionsGOOS = "windows"
-	t.Cleanup(func() { codexPermissionsGOOS = origGOOS })
-
-	if _, err := Inject(home, codexAdapter()); err != nil {
-		t.Fatalf("Inject() error = %v", err)
-	}
-	content, err := os.ReadFile(configPath)
-	if err != nil {
-		t.Fatalf("ReadFile() error = %v", err)
-	}
-	if strings.Contains(string(content), `"~" = true`) {
-		t.Fatalf("Windows Codex config still contains home root under quoted table header; got:\n%s", content)
-	}
-	if !strings.Contains(string(content), `"~/project" = true`) {
-		t.Fatalf("Windows Codex config did not preserve prefixed root under quoted table header; got:\n%s", content)
-	}
-}
-
-func TestInjectCodexPermissionsRecognizesWorkspaceRootsHeaderWithComment(t *testing.T) {
-	home := t.TempDir()
-	configPath := filepath.Join(home, ".codex", "config.toml")
-	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
-		t.Fatalf("MkdirAll() error = %v", err)
-	}
-	initial := "[permissions.gentle-dev.workspace_roots] # managed roots\n'~' = true\n'~/project' = true\n"
-	if err := os.WriteFile(configPath, []byte(initial), 0o644); err != nil {
-		t.Fatalf("WriteFile() error = %v", err)
-	}
-
-	origGOOS := codexPermissionsGOOS
-	codexPermissionsGOOS = "windows"
-	t.Cleanup(func() { codexPermissionsGOOS = origGOOS })
-
-	if _, err := Inject(home, codexAdapter()); err != nil {
-		t.Fatalf("Inject() error = %v", err)
-	}
-	content, err := os.ReadFile(configPath)
-	if err != nil {
-		t.Fatalf("ReadFile() error = %v", err)
-	}
-	if strings.Contains(string(content), `'~' = true`) {
-		t.Fatalf("Windows Codex config still contains home root under commented table header; got:\n%s", content)
-	}
-	if !strings.Contains(string(content), `'~/project' = true`) {
-		t.Fatalf("Windows Codex config did not preserve prefixed root under commented table header; got:\n%s", content)
-	}
-}
-
-func TestInjectCodexPermissionsStopsAtCommentedFollowingHeader(t *testing.T) {
-	home := t.TempDir()
-	configPath := filepath.Join(home, ".codex", "config.toml")
-	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
-		t.Fatalf("MkdirAll() error = %v", err)
-	}
-	initial := "[permissions.gentle-dev.workspace_roots]\n\"~\" = true\n\n[unrelated] # preserve this table\n\"~\" = true\n"
-	if err := os.WriteFile(configPath, []byte(initial), 0o644); err != nil {
-		t.Fatalf("WriteFile() error = %v", err)
-	}
-
-	origGOOS := codexPermissionsGOOS
-	codexPermissionsGOOS = "windows"
-	t.Cleanup(func() { codexPermissionsGOOS = origGOOS })
-
-	if _, err := Inject(home, codexAdapter()); err != nil {
-		t.Fatalf("Inject() error = %v", err)
-	}
-	content, err := os.ReadFile(configPath)
-	if err != nil {
-		t.Fatalf("ReadFile() error = %v", err)
-	}
-	unrelated := tomlSection(string(content), "[unrelated] # preserve this table")
-	if !strings.Contains(unrelated, `"~" = true`) {
-		t.Fatalf("Windows Codex migration removed home key from following commented table; got:\n%s", content)
-	}
-}
-
-func TestInjectCodexPermissionsRetainsHomeWorkspaceRootOutsideWindows(t *testing.T) {
-	home := t.TempDir()
-	origGOOS := codexPermissionsGOOS
-	codexPermissionsGOOS = "linux"
-	t.Cleanup(func() { codexPermissionsGOOS = origGOOS })
-
-	if _, err := Inject(home, codexAdapter()); err != nil {
-		t.Fatalf("Inject() error = %v", err)
-	}
-
-	configPath := filepath.Join(home, ".codex", "config.toml")
-	content, err := os.ReadFile(configPath)
-	if err != nil {
-		t.Fatalf("ReadFile() error = %v", err)
-	}
-	workspaceRoots := codexWorkspaceRootsSection(string(content))
-	if !strings.Contains(workspaceRoots, `"~" = true`) {
-		t.Fatalf("non-Windows Codex config missing the home workspace root; got:\n%s", workspaceRoots)
-	}
-}
-
-func TestInjectCodexPermissionsWindowsWorkspaceRootMigrationIsIdempotent(t *testing.T) {
-	home := t.TempDir()
-	configPath := filepath.Join(home, ".codex", "config.toml")
-	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
-		t.Fatalf("MkdirAll() error = %v", err)
-	}
-	initial := "[permissions.gentle-dev.workspace_roots]\n'~'\t=\ttrue\n"
-	if err := os.WriteFile(configPath, []byte(initial), 0o644); err != nil {
-		t.Fatalf("WriteFile() error = %v", err)
-	}
-
-	origGOOS := codexPermissionsGOOS
-	codexPermissionsGOOS = "windows"
-	t.Cleanup(func() { codexPermissionsGOOS = origGOOS })
+	configPath := writeCodexConfig(t, home, codexInjectedLegacyConfig)
 
 	first, err := Inject(home, codexAdapter())
 	if err != nil {
@@ -810,225 +422,182 @@ func TestInjectCodexPermissionsWindowsWorkspaceRootMigrationIsIdempotent(t *test
 		t.Fatalf("Inject() second error = %v", err)
 	}
 	if second.Changed {
-		t.Fatal("Inject() second changed = true")
+		t.Fatal("Inject() second changed = true, want false")
 	}
 	secondContent, err := os.ReadFile(configPath)
 	if err != nil {
 		t.Fatalf("ReadFile() second error = %v", err)
 	}
 	if string(firstContent) != string(secondContent) {
-		t.Fatalf("Windows Codex workspace root migration is not idempotent:\nfirst:\n%s\nsecond:\n%s", firstContent, secondContent)
+		t.Fatalf("Codex cleanup is not idempotent:\nfirst:\n%s\nsecond:\n%s", firstContent, secondContent)
 	}
 }
 
-func TestInjectCodexPermissionsAllowsEnvExamples(t *testing.T) {
+func TestInjectCodexPreservesUserOwnedGentleDevContent(t *testing.T) {
 	home := t.TempDir()
+	initial := `approval_policy = "never"
+default_permissions = "gentle-dev"
 
-	if _, err := Inject(home, codexAdapter()); err != nil {
+[permissions.custom]
+description = "user profile"
+
+[permissions.custom.filesystem]
+":minimal" = "read"
+
+[permissions.gentle-dev] # user-owned
+description = "user profile"
+user_note = "keep"
+
+[permissions.gentle-dev.filesystem]
+":minimal" = "read"
+"~/custom" = "write"
+`
+	want := `approval_policy = "never"
+
+[permissions.custom]
+description = "user profile"
+
+[permissions.custom.filesystem]
+":minimal" = "read"
+
+[permissions.gentle-dev] # user-owned
+description = "user profile"
+user_note = "keep"
+
+[permissions.gentle-dev.filesystem]
+"~/custom" = "write"
+`
+	configPath := writeCodexConfig(t, home, initial)
+
+	result, err := Inject(home, codexAdapter())
+	if err != nil {
 		t.Fatalf("Inject() error = %v", err)
 	}
+	if !result.Changed {
+		t.Fatal("Inject() changed = false, want true")
+	}
 
-	configPath := filepath.Join(home, ".codex", "config.toml")
 	content, err := os.ReadFile(configPath)
 	if err != nil {
 		t.Fatalf("read config.toml: %v", err)
 	}
-	text := string(content)
-
-	for _, forbidden := range []string{
-		`"**/.env.*" = "deny"`,
-		`"*.env.*" = "deny"`,
-	} {
-		if strings.Contains(text, forbidden) {
-			t.Fatalf("config.toml contains over-broad env deny rule %q; got:\n%s", forbidden, text)
-		}
+	if string(content) != want {
+		t.Fatalf("cleaned config.toml = %q, want %q", content, want)
 	}
-
-	for _, allowedExample := range []string{".env.example", ".env.template"} {
-		if strings.Contains(text, allowedExample) {
-			t.Fatalf("config.toml should not mention versioned env template %q; got:\n%s", allowedExample, text)
-		}
-	}
-}
-
-func TestInjectCodexPermissionsProfileIsIdempotent(t *testing.T) {
-	home := t.TempDir()
-	configPath := filepath.Join(home, ".codex", "config.toml")
-	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
-		t.Fatalf("MkdirAll() error = %v", err)
-	}
-	initial := `model = "gpt-5.5"
-
-[permissions.gentle-dev]
-glob_scan_max_depth = 6
-
-[mcp_servers.engram]
-command = "engram"
-args = ["mcp", "--tools=agent"]
-`
-	if err := os.WriteFile(configPath, []byte(initial), 0o644); err != nil {
-		t.Fatalf("WriteFile() error = %v", err)
-	}
-
-	first, err := Inject(home, codexAdapter())
-	if err != nil {
-		t.Fatalf("Inject() first error = %v", err)
-	}
-	if !first.Changed {
-		t.Fatal("Inject() first changed = false")
-	}
-
-	firstContent, err := os.ReadFile(configPath)
-	if err != nil {
-		t.Fatalf("ReadFile() first error = %v", err)
-	}
-
 	second, err := Inject(home, codexAdapter())
-	if err != nil {
-		t.Fatalf("Inject() second error = %v", err)
+	if err != nil || second.Changed {
+		t.Fatalf("second Inject() = %#v, %v; want unchanged", second, err)
 	}
-	if second.Changed {
-		t.Fatal("Inject() second changed = true")
-	}
-
-	secondContent, err := os.ReadFile(configPath)
-	if err != nil {
-		t.Fatalf("ReadFile() second error = %v", err)
-	}
-	if string(firstContent) != string(secondContent) {
-		t.Fatalf("Codex permissions injection is not idempotent:\nfirst:\n%s\nsecond:\n%s", firstContent, secondContent)
-	}
-
-	text := string(secondContent)
-	if !strings.Contains(text, `model = "gpt-5.5"`) || !strings.Contains(text, `[mcp_servers.engram]`) {
-		t.Fatalf("Codex permissions injection did not preserve existing config; got:\n%s", text)
-	}
-	for _, section := range []string{
-		"[permissions.gentle-dev]",
-		"[permissions.gentle-dev.filesystem]",
-		`[permissions.gentle-dev.filesystem.":workspace_roots"]`,
-		"[permissions.gentle-dev.network]",
-		"[permissions.gentle-dev.network.domains]",
-	} {
-		if count := strings.Count(text, section); count != 1 {
-			t.Fatalf("section %q count = %d, want 1; got:\n%s", section, count, text)
-		}
-	}
-	homeRoots := "[permissions.gentle-dev.workspace_roots]"
-	wantHomeRoots := 0
-	if codexPermissionsGOOS != "windows" {
-		wantHomeRoots = 1
-	}
-	if got := strings.Count(text, homeRoots); got != wantHomeRoots {
-		t.Fatalf("section %q count = %d for %s; got:\n%s", homeRoots, got, codexPermissionsGOOS, text)
-	}
-	rootFilesystem := tomlSection(text, `[permissions.gentle-dev.filesystem]`)
-	for _, invalid := range []string{`"**/*.key" = "deny"`, `"**/*.pem" = "deny"`} {
-		if strings.Contains(rootFilesystem, invalid) {
-			t.Fatalf("root filesystem table should not contain invalid/stale entry %q; got:\n%s", invalid, rootFilesystem)
-		}
-	}
-	for _, want := range []string{`":tmpdir" = "write"`, `":slash_tmp" = "write"`} {
-		if !strings.Contains(text, want) {
-			t.Fatalf("config.toml missing compatible Codex permission entry %q; got:\n%s", want, text)
-		}
-	}
-	assertCodexWorkspaceWriteRulesScoped(t, text)
 }
 
-func TestInjectCodexPermissionsRelocatesSecretDeniesToWorkspaceRootsTable(t *testing.T) {
+func TestInjectCodexPreservesUserOwnedDottedValue(t *testing.T) {
+	home := t.TempDir()
+	configPath := writeCodexConfig(t, home, "default_permissions = \"gentle-dev\"\npermissions.gentle-dev.custom_flag = true\n")
+	if _, err := Inject(home, codexAdapter()); err != nil {
+		t.Fatal(err)
+	}
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := "permissions.gentle-dev.custom_flag = true\n"; string(content) != want {
+		t.Fatalf("cleaned config.toml = %q, want %q", content, want)
+	}
+}
+
+func TestInjectCodexMissingConfigDoesNothing(t *testing.T) {
+	home := t.TempDir()
+
+	result, err := Inject(home, codexAdapter())
+	if err != nil {
+		t.Fatalf("Inject() error = %v", err)
+	}
+	if result.Changed {
+		t.Fatal("Inject() changed = true, want false for missing config")
+	}
+	if len(result.Files) != 0 {
+		t.Fatalf("Inject() files = %v, want none for missing config", result.Files)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".codex")); !os.IsNotExist(err) {
+		t.Fatalf("Inject() created ~/.codex (stat err = %v), want no file creation", err)
+	}
+}
+
+func TestInjectCodexReadErrorHasTOMLContext(t *testing.T) {
 	home := t.TempDir()
 	configPath := filepath.Join(home, ".codex", "config.toml")
-	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
-		t.Fatalf("MkdirAll() error = %v", err)
+	if err := os.MkdirAll(configPath, 0o755); err != nil {
+		t.Fatalf("MkdirAll(config path): %v", err)
 	}
 
-	initial := `[permissions.gentle-dev.filesystem]
-"**/*.key" = "deny"
-"**/*.pem" = "deny"
+	_, err := Inject(home, codexAdapter())
+	if err == nil {
+		t.Fatal("Inject() error = nil, want config read error")
+	}
+	if !strings.Contains(err.Error(), "read Codex config TOML") {
+		t.Fatalf("Inject() error = %q, want TOML read context", err)
+	}
+	var pathErr *os.PathError
+	if !errors.As(err, &pathErr) {
+		t.Fatalf("Inject() error = %T, want wrapped *os.PathError", err)
+	}
+	if pathErr.Path != configPath {
+		t.Fatalf("wrapped path = %q, want %q", pathErr.Path, configPath)
+	}
+}
 
-[permissions.gentle-dev.filesystem.":workspace_roots"]
-"**/.git" = "write"
-"**/.git/**" = "write"
-"**/.env" = "deny"
-"**/.env.local" = "deny"
-"**/.env.*.local" = "deny"
-"**/*.pem" = "deny"
-"**/*.key" = "deny"
-"**/secrets/*" = "deny"
+func TestInjectCodexRemovesQuotedGentleDevForms(t *testing.T) {
+	home := t.TempDir()
+	initial := `permissions."gentle-dev".workspace_roots."~" = true
+
+[permissions."gentle-dev".workspace_roots]
+"~" = true
+"~/project" = true
+
+[unrelated]
+"~" = true
 `
-	if err := os.WriteFile(configPath, []byte(initial), 0o644); err != nil {
-		t.Fatalf("WriteFile() error = %v", err)
-	}
+	want := `
+[permissions."gentle-dev".workspace_roots]
+"~/project" = true
 
-	if _, err := Inject(home, codexAdapter()); err != nil {
+[unrelated]
+"~" = true
+`
+	configPath := writeCodexConfig(t, home, initial)
+
+	result, err := Inject(home, codexAdapter())
+	if err != nil {
 		t.Fatalf("Inject() error = %v", err)
+	}
+	if !result.Changed {
+		t.Fatal("Inject() changed = false, want true for quoted gentle-dev forms")
 	}
 
 	content, err := os.ReadFile(configPath)
 	if err != nil {
-		t.Fatalf("ReadFile() error = %v", err)
+		t.Fatalf("read config.toml: %v", err)
 	}
-	text := string(content)
-
-	rootFilesystem := tomlSection(text, `[permissions.gentle-dev.filesystem]`)
-	for _, invalid := range []string{`"**/*.key" = "deny"`, `"**/*.pem" = "deny"`} {
-		if strings.Contains(rootFilesystem, invalid) {
-			t.Fatalf("root filesystem table still contains stale secret deny %q; got:\n%s", invalid, rootFilesystem)
-		}
-	}
-
-	scopedFilesystem := tomlSection(text, `[permissions.gentle-dev.filesystem.":workspace_roots"]`)
-	if scopedFilesystem == "" {
-		t.Fatalf("config.toml should keep workspace-scoped table for secret denies; got:\n%s", text)
-	}
-	for _, want := range []string{`"**/.env" = "deny"`, `"**/*.key" = "deny"`, `"**/*.pem" = "deny"`} {
-		if !strings.Contains(scopedFilesystem, want) {
-			t.Fatalf("workspace-scoped table missing relocated secret deny %q; got:\n%s", want, scopedFilesystem)
-		}
-	}
-	for _, invalid := range []string{`"**/.git" = "write"`, `"**/.git/**" = "write"`} {
-		if strings.Contains(text, invalid) {
-			t.Fatalf("config.toml still contains invalid git write rule %q; got:\n%s", invalid, text)
-		}
+	if string(content) != want {
+		t.Fatalf("cleaned config.toml = %q, want %q", content, want)
 	}
 }
 
-func TestInjectCodexPermissionsRemovesObsoleteWorkspaceRootDenyRules(t *testing.T) {
+func TestTargetPathCodexHasNoInjectionTarget(t *testing.T) {
 	home := t.TempDir()
-	configPath := filepath.Join(home, ".codex", "config.toml")
-	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
-		t.Fatalf("MkdirAll() error = %v", err)
+	if got := TargetPath(home, codexAdapter()); got != "" {
+		t.Fatalf("TargetPath(codex) = %q, want empty (Codex relies on built-in defaults)", got)
 	}
+}
 
-	initial := `[permissions.gentle-dev.filesystem.":workspace_roots"]
-"**/.env.*" = "deny"
-"*.env.*" = "deny"
-"**/.env" = "deny"
-"**/.env.local" = "deny"
-"**/.env.*.local" = "deny"
-`
-	if err := os.WriteFile(configPath, []byte(initial), 0o644); err != nil {
-		t.Fatalf("WriteFile() error = %v", err)
+func TestCleanupPathCodexReturnsConfigTOML(t *testing.T) {
+	home := t.TempDir()
+	want := filepath.Join(home, ".codex", "config.toml")
+	if got := CleanupPath(home, codexAdapter()); got != want {
+		t.Fatalf("CleanupPath(codex) = %q, want %q", got, want)
 	}
-
-	if _, err := Inject(home, codexAdapter()); err != nil {
-		t.Fatalf("Inject() error = %v", err)
-	}
-
-	content, err := os.ReadFile(configPath)
-	if err != nil {
-		t.Fatalf("ReadFile() error = %v", err)
-	}
-	text := string(content)
-
-	for _, obsolete := range []string{
-		`"**/.env.*" = "deny"`,
-		`"*.env.*" = "deny"`,
-	} {
-		if strings.Contains(text, obsolete) {
-			t.Fatalf("config.toml still contains obsolete workspace root deny entry %q; got:\n%s", obsolete, text)
-		}
+	if got := CleanupPath(home, claudeAdapter()); got != "" {
+		t.Fatalf("CleanupPath(claude) = %q, want empty (only Codex has a cleanup target)", got)
 	}
 }
 


### PR DESCRIPTION
## Linked Issue

Closes #1398

---

## PR Type

What kind of change does this PR introduce?

- [x] `type:bug` - Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` - New feature (non-breaking change that adds functionality)
- [ ] `type:docs` - Documentation only
- [ ] `type:refactor` - Code refactoring (no functional changes)
- [ ] `type:chore` - Build, CI, or tooling changes
- [ ] `type:breaking-change` - Breaking change (fix or feature that changes existing behavior)

---

## Summary

- Removes the retired restrictive Codex `gentle-dev` permission defaults and relies on Codex's built-in defaults.
- Migrates only exact legacy Gentle AI-owned values while preserving user-authored, modified, dotted, and commented permission content.
- Hardens TOML cleanup for quoted keys, multiline values, nested arrays, and repeatable sync execution.
- Supersedes #1404 with the same approved final candidate tree on a clean branch rooted at current `main`; this avoids force-pushing the original PR branch whose merge history causes duplicate-path publication-range validation.

---

## Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/app/app_test.go` | Covers TUI, targeted, and deferred Codex permission cleanup flows. |
| `internal/cli/run.go` | Includes the existing Codex config in cleanup backup and rollback paths. |
| `internal/cli/run_component_paths_test.go` | Verifies Codex cleanup-path selection without creating a required output. |
| `internal/components/filemerge/toml.go` | Adds exact, quote-aware TOML key and table cleanup with safe multiline and nested-array handling. |
| `internal/components/filemerge/toml_test.go` | Adds regressions for malformed input, quoted forms, nested arrays, and byte preservation. |
| `internal/components/permissions/inject.go` | Removes exact legacy Codex defaults while preserving user-owned configuration. |
| `internal/components/permissions/inject_test.go` | Covers ownership, idempotence, missing files, quoted forms, and legacy cleanup. |

---

## Test Plan

**Unit Tests**
```bash
go test -count=1 ./...
go test -count=1 ./internal/components/filemerge ./internal/components/permissions ./internal/cli
go test -count=1 ./internal/app -run 'Test(TuiSyncRemovesCodexGentleDevProfile|TuiSyncRemovesCodexGentleDevProfileForTargetedOverrides|RunArgsPendingSyncCleansCodexPermissions)$'
```

**Go Format**
```bash
go run ./internal/gofmtcheck
git diff --check origin/main...HEAD
```

**E2E Tests** (Docker required)
```bash
cd e2e && ./docker-test.sh
```

- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [x] E2E tests pass (`cd e2e && ./docker-test.sh`) through required CI
- [x] Manually tested locally with an isolated two-run sync matrix and TOML parser validation

---

## Automated Checks

The following checks run automatically on this PR:

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | Pass | Approved `size:exception` documents the review-size exception. |
| Check Issue Reference | Pass | PR body contains `Closes #1398`. |
| Check Issue Has `status:approved` | Pass | Linked issue was approved before this replacement PR. |
| Check PR Has `type:*` Label | Pass | Exactly one `type:*` label is applied. |
| Unit Tests | Pass | `go test ./...` passed. |
| Go Format | Pass | Formatting validation passed with the unit-test workflow. |
| E2E Tests | Pass | Required Arch, Fedora, and Ubuntu jobs passed. |

---

## Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] Maintainer-approved `size:exception` is applied because this exact reviewed candidate exceeds 400 changed lines
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [x] E2E tests pass (`cd e2e && ./docker-test.sh`) through required CI
- [x] Documentation is not required because this removes obsolete injected configuration without changing user-facing commands
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers

---

## Notes for Reviewers

This PR supersedes #1404 without rewriting or force-pushing its branch. The original PR remains open until this replacement completes its required checks and review. The replacement commit tree is the previously approved full-review candidate tree `bb623c8da3aabb9895b24f967f27db65b741b74f`.

Please focus on ownership-safe migration in `injectCodexPermissions` and nested multiline-array handling in `RemoveTOMLTableTree`.
