### PR TITLE
fix(review): terminate zero-edit corrections and classify invalidated

### DIFF
--- a/internal/cli/review_facade_invalidated_test.go
+++ b/internal/cli/review_facade_invalidated_test.go
@@ -1,0 +1,57 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/internal/reviewtransaction"
+)
+
+func TestReviewFacadeKeepsInvalidatedAuthorityNonPoisoningAndNonUsable(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	started := startFacadeReview(t, repo)
+	store, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, started.LineageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	record, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var output bytes.Buffer
+	if err := RunReviewInvalidate([]string{
+		"--cwd", repo, "--lineage", started.LineageID,
+		"--expected-revision", record.Revision, "--reason", "operator abandoned",
+	}, &output); err != nil {
+		t.Fatalf("invalidate pristine compact authority: %v", err)
+	}
+
+	output.Reset()
+	if err := RunReviewStatus([]string{"--cwd", repo}, &output); err != nil {
+		t.Fatal(err)
+	}
+	var report reviewtransaction.AuthorityStatusReport
+	if err := json.Unmarshal(output.Bytes(), &report); err != nil {
+		t.Fatal(err)
+	}
+	if !report.Complete || !report.Authoritative || report.Status != reviewtransaction.AuthorityStatusInvalidated {
+		t.Fatalf("invalidated authority poisoned status report = %#v", report)
+	}
+	if len(report.Entries) != 1 || report.Entries[0].Status != reviewtransaction.AuthorityStatusInvalidated || len(report.Entries[0].Problems) != 0 {
+		t.Fatalf("invalidated authority entry = %#v", report.Entries)
+	}
+
+	output.Reset()
+	err = RunReviewFacadeValidate([]string{"--cwd", repo, "--gate", string(reviewtransaction.GatePreCommit)}, &output)
+	if err == nil {
+		t.Fatal("invalidated authority was accepted as usable gate authority")
+	}
+	var denied ReviewGateDeniedError
+	if !errors.As(err, &denied) || denied.Context.Denial == nil ||
+		denied.Context.Denial.Stage != "receipt-discovery" || denied.Context.Denial.Code != string(ReviewReceiptMissing) {
+		t.Fatalf("invalidated authority gate denial = %#v, want receipt-discovery %q", err, ReviewReceiptMissing)
+	}
+}

--- a/internal/reviewtransaction/compact.go
+++ b/internal/reviewtransaction/compact.go
@@ -413,11 +413,23 @@ func validateCompactCorrection(state CompactState) error {
 	}
 	if len(state.CorrectionAttempts) > 0 {
 		base, cumulative := state.InitialSnapshot.CandidateTree, 0
-		for _, attempt := range state.CorrectionAttempts {
+		for index, attempt := range state.CorrectionAttempts {
 			if attempt.ProposedLines <= 0 || attempt.ActualLines < 0 || attempt.Snapshot.Kind != TargetFixDiff || attempt.Snapshot.Projection != state.InitialSnapshot.Projection || attempt.Snapshot.BaseTree != base ||
 				!equalStrings(attempt.Snapshot.LedgerIDs, state.FixFindingIDs) || pathsAreSubset(attempt.Snapshot.Paths, state.GenesisPaths) != nil ||
 				attempt.FixDeltaHash != FixDeltaHashForSnapshot(attempt.Snapshot) {
 				return errors.New("compact correction attempt is outside frozen scope")
+			}
+			// Load-time mirror of CompleteCorrection's zero-edit contract: an
+			// unchanged-tree attempt is only valid as a terminal escalation
+			// with zero actual lines, a failing original check, and a passing
+			// regression check.
+			if attempt.Snapshot.CandidateTree == attempt.Snapshot.BaseTree {
+				if attempt.ActualLines != 0 || attempt.OriginalCriteria.Passed || !attempt.CorrectionRegression.Passed {
+					return errors.New("zero-edit compact correction attempt requires zero actual lines, a failing original check, and a passing regression check")
+				}
+				if index != len(state.CorrectionAttempts)-1 || state.State != StateEscalated {
+					return errors.New("zero-edit compact correction must terminate in escalation")
+				}
 			}
 			result := ScopedValidationResult{OriginalCriteria: attempt.OriginalCriteria, CorrectionRegression: attempt.CorrectionRegression}
 			if err := validateTargetedValidation(result, attempt.FixDeltaHash); err != nil {
@@ -669,8 +681,15 @@ func (state *CompactState) CompleteCorrection(snapshot Snapshot, actual int, val
 	if snapshot.Kind != TargetFixDiff || snapshot.Projection != state.InitialSnapshot.Projection || snapshot.BaseTree != state.CurrentSnapshot.CandidateTree || !equalStrings(snapshot.LedgerIDs, state.FixFindingIDs) {
 		return errors.New("compact correction snapshot is not bound to the reviewed candidate, projection, and causal findings")
 	}
-	if snapshot.CandidateTree == snapshot.BaseTree {
-		return errors.New("compact correction has an unchanged candidate tree")
+	// A repository-derived zero-edit correction (candidate tree unchanged
+	// from its base) may terminate only as an explicit escalation: targeted
+	// validation must prove the original criteria still fail while the
+	// correction regression passes, with zero actual changed lines. Any
+	// other unchanged-tree submission remains rejected (issue #1314),
+	// consistent with the failed-validation escalation below.
+	if snapshot.CandidateTree == snapshot.BaseTree &&
+		(actual != 0 || validation.OriginalCriteria.Passed || !validation.CorrectionRegression.Passed) {
+		return errors.New("compact correction has an unchanged candidate tree without failing-original, passing-regression zero-edit validation")
 	}
 	if err := pathsAreSubset(snapshot.Paths, state.GenesisPaths); err != nil {
 		return err

--- a/internal/reviewtransaction/compact_zero_edit_test.go
+++ b/internal/reviewtransaction/compact_zero_edit_test.go
@@ -1,0 +1,199 @@
+package reviewtransaction
+
+import (
+	"context"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// newCompactZeroEditCorrectionState builds a medium-risk compact review that
+// reached correction_required with an authorized in-budget forecast, without
+// applying any candidate edit afterwards.
+func newCompactZeroEditCorrectionState(t *testing.T, repo, lineage string) CompactState {
+	t.Helper()
+	state := newCompactTestState(t, repo, lineage)
+	completeCompactZeroEditReview(t, &state)
+	if err := state.BeginCorrection(1); err != nil {
+		t.Fatal(err)
+	}
+	return state
+}
+
+func completeCompactZeroEditReview(t *testing.T, state *CompactState) {
+	t.Helper()
+	finding := Finding{ID: "R3-001", Lens: "reliability", Location: "tracked.txt:2", Severity: "CRITICAL", Claim: "wrong value", ProofRefs: []string{"candidate-only failure"}}
+	if err := state.CompleteReview(CompactReviewInput{
+		LensResults:     []LensResult{{Lens: LensReliability, Findings: []Finding{finding}, Evidence: []string{"reviewed"}}},
+		Classifications: []FindingEvidence{{FindingID: finding.ID, Class: EvidenceDeterministic, Causality: CausalIntroduced, Proof: "changed hunk causes failure"}},
+		RefuterOutcomes: []EvidenceResult{},
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func buildZeroEditFixSnapshot(t *testing.T, repo string, state CompactState) (Snapshot, int) {
+	t.Helper()
+	fix, err := (SnapshotBuilder{Repo: repo}).Build(context.Background(), Target{
+		Kind: TargetFixDiff, Projection: state.InitialSnapshot.Projection,
+		BaseRef: state.CurrentSnapshot.CandidateTree, IntendedUntracked: state.InitialSnapshot.IntendedUntracked,
+		LedgerIDs: state.FixFindingIDs,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fix.CandidateTree != fix.BaseTree {
+		t.Fatalf("expected repository-derived zero-edit fix snapshot, got base %s candidate %s", fix.BaseTree, fix.CandidateTree)
+	}
+	actual, err := (SnapshotBuilder{Repo: repo}).ChangedLines(context.Background(), fix)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if actual != 0 {
+		t.Fatalf("zero-edit fix snapshot changed lines = %d, want 0", actual)
+	}
+	return fix, actual
+}
+
+func zeroEditFailedValidation(fixHash string, findingIDs []string) ScopedValidationResult {
+	return ScopedValidationResult{
+		LedgerIDs: findingIDs, FixCausedFindings: []Finding{},
+		FollowUps:            []FollowUp{{Observation: "original criteria still failing without an in-scope fix", ProofRefs: []string{"targeted validation output"}}},
+		OriginalCriteria:     ValidationCheck{Passed: false, EvidenceHash: hash("2"), FixDeltaHash: fixHash},
+		CorrectionRegression: ValidationCheck{Passed: true, EvidenceHash: hash("3"), FixDeltaHash: fixHash},
+	}
+}
+
+func TestCompactZeroEditFailedCorrectionEscalatesTerminally(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	writeSnapshotFile(t, repo, "tracked.txt", "base\nwrong\n")
+	state := newCompactTestState(t, repo, "compact-zero-edit-escalate")
+	store := storeCompactStartAuthority(t, repo, state)
+	record, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	revision := record.Revision
+	completeCompactZeroEditReview(t, &state)
+	revision, err = store.Replace(revision, "review/complete-review", state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := state.BeginCorrection(1); err != nil {
+		t.Fatal(err)
+	}
+	revision, err = store.Replace(revision, "review/begin-fix", state)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fix, actual := buildZeroEditFixSnapshot(t, repo, state)
+	fixHash := FixDeltaHashForSnapshot(fix)
+	validation := zeroEditFailedValidation(fixHash, state.FixFindingIDs)
+	if err := state.CompleteCorrection(fix, actual, validation); err != nil {
+		t.Fatalf("zero-edit failed correction error = %v, want terminal escalation", err)
+	}
+	if state.State != StateEscalated {
+		t.Fatalf("zero-edit failed correction state = %q, want %q", state.State, StateEscalated)
+	}
+	if state.ActualCorrectionLines == nil || *state.ActualCorrectionLines != 0 || state.CumulativeCorrectionLines != 0 ||
+		len(state.CorrectionAttempts) != 1 || state.CorrectionAttempts[0].ActualLines != 0 ||
+		state.CorrectionAttempts[0].Snapshot.CandidateTree != state.CorrectionAttempts[0].Snapshot.BaseTree {
+		t.Fatalf("zero-edit escalation accounting = %#v", state)
+	}
+	if err := state.Validate(); err != nil {
+		t.Fatalf("zero-edit escalated state validate error = %v", err)
+	}
+
+	revision, err = store.Replace(revision, "review/complete-fix", state)
+	if err != nil {
+		t.Fatalf("persist zero-edit escalation: %v", err)
+	}
+	loaded, err := store.Load()
+	if err != nil || loaded.Revision != revision || loaded.State.State != StateEscalated {
+		t.Fatalf("reload zero-edit escalation = %#v, %v", loaded, err)
+	}
+
+	receipt, err := state.Receipt()
+	if err != nil || receipt.TerminalState != TerminalEscalated || receipt.FinalCandidateTree != state.InitialSnapshot.CandidateTree {
+		t.Fatalf("zero-edit escalation receipt = %#v, %v", receipt, err)
+	}
+	if err := WriteCompactReceiptAtomic(store.ReceiptPath(), receipt); err != nil {
+		t.Fatal(err)
+	}
+	report, err := InventoryAuthority(context.Background(), repo)
+	if err != nil || !report.Complete || !report.Authoritative ||
+		!hasAuthorityInventoryStatus(report.Entries, state.LineageID, AuthorityStatusEscalated) {
+		t.Fatalf("zero-edit escalated inventory = %#v, %v", report, err)
+	}
+}
+
+func TestCompactZeroEditCorrectionWithoutProvenFailedOriginalRemainsRejected(t *testing.T) {
+	for _, tt := range []struct {
+		name             string
+		originalPassed   bool
+		regressionPassed bool
+		actual           int
+	}{
+		{name: "passing original and regression", originalPassed: true, regressionPassed: true},
+		{name: "passing original failing regression", originalPassed: true, regressionPassed: false},
+		{name: "failing original failing regression", originalPassed: false, regressionPassed: false},
+		{name: "nonzero asserted lines", originalPassed: false, regressionPassed: true, actual: 2},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := initSnapshotRepo(t)
+			writeSnapshotFile(t, repo, "tracked.txt", "base\nwrong\n")
+			state := newCompactZeroEditCorrectionState(t, repo, "compact-zero-edit-guard")
+			fix, _ := buildZeroEditFixSnapshot(t, repo, state)
+			fixHash := FixDeltaHashForSnapshot(fix)
+			validation := zeroEditFailedValidation(fixHash, state.FixFindingIDs)
+			validation.OriginalCriteria.Passed = tt.originalPassed
+			validation.CorrectionRegression.Passed = tt.regressionPassed
+			before := state
+			err := state.CompleteCorrection(fix, tt.actual, validation)
+			if err == nil || !strings.Contains(err.Error(), "unchanged candidate") {
+				t.Fatalf("unproven zero-edit correction error = %v, want unchanged-candidate rejection", err)
+			}
+			if !reflect.DeepEqual(state, before) {
+				t.Fatalf("rejected zero-edit correction mutated state:\nbefore=%#v\nafter=%#v", before, state)
+			}
+		})
+	}
+}
+
+func TestCompactValidateFailsClosedForCraftedZeroEditAttempts(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	writeSnapshotFile(t, repo, "tracked.txt", "base\nwrong\n")
+	state := newCompactZeroEditCorrectionState(t, repo, "compact-zero-edit-crafted")
+	fix, actual := buildZeroEditFixSnapshot(t, repo, state)
+	fixHash := FixDeltaHashForSnapshot(fix)
+	if err := state.CompleteCorrection(fix, actual, zeroEditFailedValidation(fixHash, state.FixFindingIDs)); err != nil {
+		t.Fatal(err)
+	}
+
+	passingOriginal := state
+	passingOriginal.CorrectionAttempts = append([]CompactCorrectionAttempt{}, state.CorrectionAttempts...)
+	passingOriginal.CorrectionAttempts[0].OriginalCriteria.Passed = true
+	original := *state.OriginalCriteria
+	original.Passed = true
+	passingOriginal.OriginalCriteria = &original
+	if err := passingOriginal.Validate(); err == nil {
+		t.Fatal("crafted zero-edit attempt with passing original criteria validated")
+	}
+
+	nonzeroLines := state
+	nonzeroLines.CorrectionAttempts = append([]CompactCorrectionAttempt{}, state.CorrectionAttempts...)
+	nonzeroLines.CorrectionAttempts[0].ActualLines = 1
+	one := 1
+	nonzeroLines.ActualCorrectionLines = &one
+	nonzeroLines.CumulativeCorrectionLines = 1
+	if err := nonzeroLines.Validate(); err == nil {
+		t.Fatal("crafted zero-edit attempt with nonzero actual lines validated")
+	}
+
+	nonTerminal := state
+	nonTerminal.State = StateValidating
+	if err := nonTerminal.Validate(); err == nil {
+		t.Fatal("crafted zero-edit correction outside terminal escalation validated")
+	}
+}

--- a/internal/reviewtransaction/invalidated_status_test.go
+++ b/internal/reviewtransaction/invalidated_status_test.go
@@ -1,0 +1,115 @@
+package reviewtransaction
+
+import (
+	"context"
+	"testing"
+)
+
+func TestInventoryAuthorityKeepsValidInvalidatedAuthoritiesCompleteAndAuthoritative(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	writeSnapshotFile(t, repo, "tracked.txt", "candidate\n")
+
+	compact := newCompactTestState(t, repo, "invalidated-compact-standalone")
+	store, err := CompactAuthoritativeStore(context.Background(), repo, compact.LineageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	revision, err := store.Replace("", "review/start", compact)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := compact.Invalidate("candidate no longer applies"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Replace(revision, "review/invalidate", compact); err != nil {
+		t.Fatal(err)
+	}
+
+	report, err := InventoryAuthority(context.Background(), repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !report.Complete || !report.Authoritative || report.Status != AuthorityStatusInvalidated {
+		t.Fatalf("standalone invalidated compact report = %#v", report)
+	}
+	if len(report.Entries) != 1 || report.Entries[0].Status != AuthorityStatusInvalidated ||
+		report.Entries[0].State != StateInvalidated || len(report.Entries[0].Problems) != 0 {
+		t.Fatalf("standalone invalidated compact entry = %#v", report.Entries)
+	}
+
+	snapshot, err := (SnapshotBuilder{Repo: repo}).Build(context.Background(), Target{Kind: TargetCurrentChanges, IntendedUntracked: []string{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	transaction, err := NewTransaction(Start{LineageID: "invalidated-legacy-standalone", Mode: ModeOrdinary4R, Generation: 1, Snapshot: snapshot, PolicyHash: hash("a")})
+	if err != nil || transaction.StartReview() != nil {
+		t.Fatalf("create legacy review: %v", err)
+	}
+	legacy, err := AuthoritativeStore(context.Background(), repo, transaction.LineageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	genesis, err := legacy.Append("", Record{Operation: "review/start", Transaction: *transaction})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := transaction.Invalidate("candidate no longer applies"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := legacy.Append(genesis, Record{Operation: "review/invalidate", Transaction: *transaction}); err != nil {
+		t.Fatal(err)
+	}
+
+	report, err = InventoryAuthority(context.Background(), repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !report.Complete || !report.Authoritative || report.Status != AuthorityStatusActive || len(report.Entries) != 2 {
+		t.Fatalf("two-authority invalidated report = %#v", report)
+	}
+	for _, entry := range report.Entries {
+		if entry.Status != AuthorityStatusInvalidated || entry.State != StateInvalidated || len(entry.Problems) != 0 {
+			t.Fatalf("invalidated entry = %#v", entry)
+		}
+	}
+}
+
+func TestInventoryAuthorityKeepsMalformedInvalidatedAuthorityFailClosed(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	writeSnapshotFile(t, repo, "tracked.txt", "candidate\n")
+	state := newCompactTestState(t, repo, "invalidated-with-receipt")
+	store, err := CompactAuthoritativeStore(context.Background(), repo, state.LineageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	revision, err := store.Replace("", "review/start", state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := state.Invalidate("candidate no longer applies"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Replace(revision, "review/invalidate", state); err != nil {
+		t.Fatal(err)
+	}
+	// A receipt beside a non-terminal invalidated authority is a structural
+	// contradiction and must still poison the inventory.
+	terminal := newCompactTestState(t, repo, "invalidated-with-receipt-terminal")
+	terminal.State = StateEscalated
+	receipt, err := terminal.Receipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteCompactReceiptAtomic(store.ReceiptPath(), receipt); err != nil {
+		t.Fatal(err)
+	}
+
+	report, err := InventoryAuthority(context.Background(), repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.Complete || report.Authoritative ||
+		!hasAuthorityInventoryStatus(report.Entries, state.LineageID, AuthorityStatusInvalid) {
+		t.Fatalf("malformed invalidated report = %#v", report)
+	}
+}

--- a/internal/reviewtransaction/status.go
+++ b/internal/reviewtransaction/status.go
@@ -19,15 +19,20 @@ var probeExistingStoreLock = tryLockFile
 type AuthorityStatus string
 
 const (
-	AuthorityStatusClean      AuthorityStatus = "clean"
-	AuthorityStatusActive     AuthorityStatus = "active"
-	AuthorityStatusApproved   AuthorityStatus = "approved"
-	AuthorityStatusEscalated  AuthorityStatus = "escalated"
-	AuthorityStatusInvalid    AuthorityStatus = "invalid"
-	AuthorityStatusReset      AuthorityStatus = "reset-in-progress"
-	AuthorityStatusSuperseded AuthorityStatus = "superseded"
-	AuthorityStatusRecovered  AuthorityStatus = "recovered"
-	AuthorityStatusCollision  AuthorityStatus = "same-lineage-mixed-collision"
+	AuthorityStatusClean     AuthorityStatus = "clean"
+	AuthorityStatusActive    AuthorityStatus = "active"
+	AuthorityStatusApproved  AuthorityStatus = "approved"
+	AuthorityStatusEscalated AuthorityStatus = "escalated"
+	AuthorityStatusInvalid   AuthorityStatus = "invalid"
+	// AuthorityStatusInvalidated reports a structurally valid terminal
+	// StateInvalidated lifecycle record. It is distinct from malformed
+	// "invalid" authority and never poisons inventory completeness, while
+	// gates continue to treat it as unusable authority (issue #1314).
+	AuthorityStatusInvalidated AuthorityStatus = "invalidated"
+	AuthorityStatusReset       AuthorityStatus = "reset-in-progress"
+	AuthorityStatusSuperseded  AuthorityStatus = "superseded"
+	AuthorityStatusRecovered   AuthorityStatus = "recovered"
+	AuthorityStatusCollision   AuthorityStatus = "same-lineage-mixed-collision"
 	// AuthorityStatusHistorical marks a structurally valid terminal legacy-v1
 	// chain that predates the receipt contract: its receipt file is absent
 	// (never corrupt or mismatched). Such chains stay inventory-readable
@@ -292,7 +297,7 @@ func authorityStatusForState(state State) AuthorityStatus {
 	case StateEscalated:
 		return AuthorityStatusEscalated
 	case StateInvalidated:
-		return AuthorityStatusInvalid
+		return AuthorityStatusInvalidated
 	default:
 		return AuthorityStatusActive
 	}
@@ -353,8 +358,10 @@ func markCompactGraph(report *AuthorityStatusReport) {
 	children := map[string][]int{}
 	for index := range report.Entries {
 		entry := &report.Entries[index]
-		if entry.Version == AuthorityVersionCompact && entry.Status != AuthorityStatusReset &&
-			(entry.Status != AuthorityStatusInvalid || entry.State == StateInvalidated && len(entry.Problems) == 0) {
+		// Structurally valid StateInvalidated records classify as
+		// AuthorityStatusInvalidated (not Invalid), so they participate in
+		// the recovery graph here without a dedicated carve-out.
+		if entry.Version == AuthorityVersionCompact && entry.Status != AuthorityStatusReset && entry.Status != AuthorityStatusInvalid {
 			byLineage[entry.LineageID] = index
 		}
 	}
@@ -385,8 +392,7 @@ func markCompactGraph(report *AuthorityStatusReport) {
 			}
 			continue
 		}
-		if predecessor, ok := byLineage[lineage]; ok && (report.Entries[predecessor].Status != AuthorityStatusInvalid ||
-			report.Entries[predecessor].State == StateInvalidated && len(report.Entries[predecessor].Problems) == 0) {
+		if predecessor, ok := byLineage[lineage]; ok && report.Entries[predecessor].Status != AuthorityStatusInvalid {
 			report.Entries[predecessor].Status = AuthorityStatusSuperseded
 		}
 	}


### PR DESCRIPTION
## Summary

Fixes #1314 (both halves):

- **Zero-edit correction termination**: `CompleteCorrection` accepts an unchanged candidate tree only with repository-bound proof (snapshot-derived tree equality, `actual == 0` from the live repo diffstat, failing `OriginalCriteria`, passing `CorrectionRegression`) and terminates through the existing escalation branch as an auditable terminal `escalated` receipt, with a load-time mirror invariant so crafted states fail closed on reload. Escalated receipts still map to `GateEscalated` — never allow — so nothing can be laundered through this path.
- **Invalidated classification**: a structurally valid `StateInvalidated` lineage now classifies as a distinct `invalidated` authority status that no longer poisons repo-wide inventory completeness. Malformed invalidated records stay `invalid`; superseded handling is preserved; gates never treat invalidated as usable authority (denial: `receipt_missing`). The status is live-computed, never persisted — no cross-version surface.

## Tests (TDD-first; primary tests reproduced the issue's exact symptoms before the fix)

- `TestCompactZeroEditFailedCorrectionEscalatesTerminally`, `TestCompactZeroEditCorrectionWithoutProvenFailedOriginalRemainsRejected` (guard table + state immutability via DeepEqual), `TestCompactValidateFailsClosedForCraftedZeroEditAttempts`
- `TestInventoryAuthorityKeepsValidInvalidatedAuthoritiesCompleteAndAuthoritative`, `TestInventoryAuthorityKeepsMalformedInvalidatedAuthorityFailClosed`
- `TestReviewFacadeKeepsInvalidatedAuthorityNonPoisoningAndNonUsable` (CLI end-to-end)

4R bounded review, two rounds, zero severe findings across all eight lens emissions. Rebased onto current main post-review (union with #1354's `AuthorityStatusHistorical`; full suites green post-rebase).

Refs #1314. Related: #1354, #1397

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a distinct “Invalidated” authority status for completed, intentionally abandoned reviews.
  * Invalidated authorities are now clearly represented in status and inventory reporting.

* **Bug Fixes**
  * Improved validation handling for invalidated reviews, preventing them from being incorrectly accepted or treated as unusable.
  * Zero-edit corrections are now supported when required validation conditions are met.
  * Invalid or contradictory correction data is rejected safely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->