### PR TITLE
fix(review): deduplicate publication range paths

### DIFF
--- a/internal/reviewtransaction/compact_gate.go
+++ b/internal/reviewtransaction/compact_gate.go
@@ -487,10 +487,16 @@ func validateCompactPublicationRange(ctx context.Context, repo string, genesis [
 		return fmt.Errorf("inspect complete publication range: %w", err)
 	}
 	paths := []string{}
+	seen := map[string]struct{}{}
 	for _, path := range strings.Split(string(output), "\x00") {
-		if path != "" {
-			paths = append(paths, path)
+		if path == "" {
+			continue
 		}
+		if _, ok := seen[path]; ok {
+			continue
+		}
+		seen[path] = struct{}{}
+		paths = append(paths, path)
 	}
 	paths, err = canonicalPaths(paths)
 	if err == nil {

--- a/internal/reviewtransaction/compact_gate_test.go
+++ b/internal/reviewtransaction/compact_gate_test.go
@@ -770,6 +770,76 @@ func TestCompactPrePRGateAllowsFinalSubsetOfGenesisPaths(t *testing.T) {
 	}
 }
 
+func TestValidateCompactPublicationRangeAllowsRepeatedApprovedPath(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	base := trimGit(gitSnapshot(t, repo, "rev-parse", "HEAD"))
+	writeSnapshotFile(t, repo, "tracked.txt", "red\n")
+	gitSnapshot(t, repo, "add", "tracked.txt")
+	gitSnapshot(t, repo, "commit", "-m", "red")
+	writeSnapshotFile(t, repo, "tracked.txt", "green\n")
+	gitSnapshot(t, repo, "add", "tracked.txt")
+	gitSnapshot(t, repo, "commit", "-m", "green")
+	head := trimGit(gitSnapshot(t, repo, "rev-parse", "HEAD"))
+
+	err := validateCompactPublicationRange(context.Background(), repo, []string{"tracked.txt"}, &resolvedPrePRRefs{
+		BaseCommit: base,
+		HeadCommit: head,
+	})
+	if err != nil {
+		t.Fatalf("repeated approved publication path: %v", err)
+	}
+}
+
+func TestValidateCompactPublicationRangeRejectsHiddenAddedAndRevertedPath(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	base := trimGit(gitSnapshot(t, repo, "rev-parse", "HEAD"))
+	writeSnapshotFile(t, repo, "secret.txt", "hidden\n")
+	gitSnapshot(t, repo, "add", "secret.txt")
+	gitSnapshot(t, repo, "commit", "-m", "add hidden path")
+	if err := os.Remove(filepath.Join(repo, "secret.txt")); err != nil {
+		t.Fatal(err)
+	}
+	gitSnapshot(t, repo, "add", "-A")
+	gitSnapshot(t, repo, "commit", "-m", "revert hidden path")
+	head := trimGit(gitSnapshot(t, repo, "rev-parse", "HEAD"))
+
+	err := validateCompactPublicationRange(context.Background(), repo, []string{"tracked.txt"}, &resolvedPrePRRefs{
+		BaseCommit: base,
+		HeadCommit: head,
+	})
+	if err == nil || !strings.Contains(err.Error(), `correction path "secret.txt" is outside immutable genesis scope`) {
+		t.Fatalf("hidden added and reverted publication path error = %v", err)
+	}
+}
+
+func TestValidateCompactPublicationRangeAllowsRepeatedApprovedPathAcrossMergeHistory(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	writeSnapshotFile(t, repo, "approved.txt", "first\nsecond\nthird\nfourth\nfifth\n")
+	gitSnapshot(t, repo, "add", "approved.txt")
+	gitSnapshot(t, repo, "commit", "-m", "add approved path")
+	base := trimGit(gitSnapshot(t, repo, "rev-parse", "HEAD"))
+	branch := currentBranch(context.Background(), repo)
+
+	gitSnapshot(t, repo, "checkout", "-qb", "merge-side")
+	writeSnapshotFile(t, repo, "approved.txt", "first\nsecond\nthird\nfourth\nside\n")
+	gitSnapshot(t, repo, "add", "approved.txt")
+	gitSnapshot(t, repo, "commit", "-m", "side approved change")
+	gitSnapshot(t, repo, "checkout", "-q", branch)
+	writeSnapshotFile(t, repo, "approved.txt", "main\nsecond\nthird\nfourth\nfifth\n")
+	gitSnapshot(t, repo, "add", "approved.txt")
+	gitSnapshot(t, repo, "commit", "-m", "main approved change")
+	gitSnapshot(t, repo, "merge", "--no-edit", "merge-side")
+	head := trimGit(gitSnapshot(t, repo, "rev-parse", "HEAD"))
+
+	err := validateCompactPublicationRange(context.Background(), repo, []string{"approved.txt"}, &resolvedPrePRRefs{
+		BaseCommit: base,
+		HeadCommit: head,
+	})
+	if err != nil {
+		t.Fatalf("repeated approved merge-history path: %v", err)
+	}
+}
+
 func TestCompactPrePushAllowsCurrentChangesWithoutTransientCorrectionBaseCommit(t *testing.T) {
 	repo, state, receipt, baseRef := approvedCompactSubsetDeliveryFixture(t, "compact-subset-pre-push")
 	got := EvaluateCompactGate(context.Background(), repo, receipt, NativeGateRequestInput{Gate: GatePrePush, LineageID: state.LineageID, BaseRef: baseRef})

--- a/internal/reviewtransaction/snapshot_test.go
+++ b/internal/reviewtransaction/snapshot_test.go
@@ -11,6 +11,12 @@ import (
 	"testing"
 )
 
+func TestCanonicalPathsRejectsDuplicateInput(t *testing.T) {
+	if _, err := canonicalPaths([]string{"tracked.txt", "tracked.txt"}); err == nil {
+		t.Fatal("canonicalPaths duplicate input error = nil")
+	}
+}
+
 func TestSnapshotBuilderCurrentChangesIsCompleteAndPreservesRealIndex(t *testing.T) {
 	if testing.Short() {
 		t.Skip("uses real git commands")


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1336

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)

## 📝 Summary

- Deduplicate byte-identical paths emitted repeatedly across the publication range.
- Keep strict canonical path validation and hidden add/revert detection unchanged.
- Cover linear and merge histories with focused regressions.

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/reviewtransaction/compact_gate.go` | Deduplicate raw Git path occurrences at the collector boundary. |
| `internal/reviewtransaction/compact_gate_test.go` | Add repeated-path, merge-history, and hidden add/revert regressions. |
| `internal/reviewtransaction/snapshot_test.go` | Prove `canonicalPaths` still rejects duplicate input. |

## 🧪 Test Plan

- [x] Focused issue #1336 regressions pass
- [x] `go test ./internal/reviewtransaction -count=1`
- [x] `go test ./... -count=1`
- [x] `go run ./internal/gofmtcheck`
- [x] `git diff --check`
- [x] Manually validated collector-boundary behavior

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [x] Appropriate `type:*` label added
- [x] Unit tests pass
- [x] Go format passes
- [x] E2E not applicable; no E2E behavior changed
- [x] Documentation not required for internal bug fix
- [x] Conventional commit format used
- [x] No `Co-Authored-By` trailers

## 💬 Notes for Reviewers

Deduplication is deliberately local to raw publication-range collection. Global canonicalization remains strict.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compact publication validation to handle repeated publication paths correctly.
  * Prevented hidden paths that are added and later reverted from bypassing approved scope checks.
  * Preserved correct validation across merge history.

* **Tests**
  * Added coverage for repeated paths, merge scenarios, hidden reverted paths, and duplicate path rejection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->