### PR TITLE
fix(test): accept Windows exec lookup error in process-control cause check

### DIFF
--- a/internal/reviewtransaction/git_process_control_test.go
+++ b/internal/reviewtransaction/git_process_control_test.go
@@ -27,7 +27,9 @@ func TestRunGitTypesProcessStartFailure(t *testing.T) {
 	if strings.Join(control.Args, " ") != "status --short" {
 		t.Fatalf("process control args = %#v", control.Args)
 	}
-	if !errors.Is(err, fs.ErrNotExist) {
+	// Unix exec start failures wrap ENOENT (fs.ErrNotExist); Windows lookup
+	// failures wrap exec.ErrNotFound. Either proves the cause chain survived.
+	if !errors.Is(err, fs.ErrNotExist) && !errors.Is(err, exec.ErrNotFound) {
 		t.Fatalf("process control cause lost: %v", err)
 	}
 	if message := err.Error(); !strings.Contains(message, "status --short") || !strings.Contains(message, filepath.Base(missing)) {


### PR DESCRIPTION
## Summary

Main's Windows Runtime suite is red: `TestRunGitTypesProcessStartFailure` (from #1406 / #1361) asserts `errors.Is(err, fs.ErrNotExist)`, which holds on Unix (ENOENT) but not on Windows, where exec lookup failures wrap `exec.ErrNotFound` ("executable file not found in %PATH%").

One-line portable fix: accept either sentinel — both prove the underlying cause chain survived the `GitProcessControlError` wrap, which is what the test exists to pin. Linux test suite green; `GOOS=windows go vet` clean.

Unblocks main CI for the pending release.

Fixes #1361

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved cross-platform test coverage for missing Git executable errors.
  * Tests now validate expected error details consistently on Unix and Windows systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
