### PR TITLE
fix(claude): port SDD preflight and entry-routing hard gates

### DIFF
--- a/internal/assets/assets_test.go
+++ b/internal/assets/assets_test.go
@@ -763,6 +763,77 @@ func TestOpenCodeSDDOrchestratorPreflightDoesNotUseVisibleCodesOrCanonicalUIValu
 	}
 }
 
+func TestClaudeSDDWorkflowRequiresSessionPreflight(t *testing.T) {
+	content := MustRead("claude/sdd-orchestrator-workflow.md")
+
+	for _, required := range []string{
+		"### SDD Session Preflight (HARD GATE)",
+		"Before executing ANY SDD command or natural-language SDD request",
+		"**Execution mode**",
+		"**Artifact store**",
+		"**Chained PR strategy**",
+		"**Review budget**",
+		"`openspec/config.yaml`, existing SDD artifacts, previous `sdd-init` results, or installed SDD assets do NOT satisfy session preflight",
+		"Use the built-in `AskUserQuestion` tool for SDD Session Preflight",
+		"Do NOT render the full preflight menu as plain chat text",
+		"Ask all four preflight groups in one single `AskUserQuestion` tool call",
+		"Do NOT run this as a sequential wizard",
+		"Do NOT issue four separate `AskUserQuestion` tool calls",
+		"Match the user's current language and active persona",
+		"Do NOT show option codes",
+		"Do NOT show canonical values",
+		"map the selected human labels to canonical values internally",
+		"1. Pace: Interactive, Automatic.",
+		"2. Artifacts: OpenSpec, Engram, Both.",
+		"3. PRs: Ask me, Single PR, Chained, Auto.",
+		"4. Review: 400 lines, 800 lines, Other.",
+		"### SDD Entry Routing (MANDATORY)",
+		"Never launch `sdd-apply` just because the user asked to implement a feature",
+		"Only launch `sdd-apply` when all are true",
+		"If any dependency is missing, STOP and propose `/sdd-new` or `/sdd-ff`; do not implement",
+		"or `hybrid` when Engram is callable",
+		"Both -> `hybrid`",
+	} {
+		if !strings.Contains(content, required) {
+			t.Fatalf("claude/sdd-orchestrator-workflow.md missing required preflight wording %q", required)
+		}
+	}
+
+	for _, forbidden := range []string{
+		"`question` tool",
+		"groups as tabs",
+	} {
+		if strings.Contains(content, forbidden) {
+			t.Fatalf("claude/sdd-orchestrator-workflow.md must use Claude Code's AskUserQuestion mechanics, not OpenCode wording %q", forbidden)
+		}
+	}
+
+	if strings.Contains(content, "`both`") {
+		t.Fatal("claude/sdd-orchestrator-workflow.md must not use `both` as a canonical artifact-store value; the Claude asset vocabulary is `hybrid` end to end (Dispatcher Guard, Artifact Store Policy/Mode)")
+	}
+
+	for _, section := range []string{"### Execution Mode", "### Artifact Store Mode"} {
+		idx := strings.Index(content, section)
+		if idx < 0 {
+			t.Fatalf("claude/sdd-orchestrator-workflow.md missing section %q", section)
+		}
+		body := content[idx+len(section):]
+		if end := strings.Index(body, "\n### "); end >= 0 {
+			body = body[:end]
+		}
+		if !strings.Contains(body, "This is collected by `SDD Session Preflight`") {
+			t.Fatalf("claude/sdd-orchestrator-workflow.md section %q must state its value is collected by SDD Session Preflight instead of independently re-asking", section)
+		}
+	}
+
+	preflight := strings.Index(content, "### SDD Session Preflight (HARD GATE)")
+	routing := strings.Index(content, "### SDD Entry Routing (MANDATORY)")
+	initGuard := strings.Index(content, "### SDD Init Guard (MANDATORY)")
+	if !(preflight < routing && routing < initGuard) {
+		t.Fatalf("claude/sdd-orchestrator-workflow.md section order must be preflight (%d) < entry routing (%d) < init guard (%d)", preflight, routing, initGuard)
+	}
+}
+
 func TestSDDFFCommandsHonorInteractiveMode(t *testing.T) {
 	for _, path := range []string{
 		"opencode/commands/sdd-ff.md",

--- a/internal/assets/claude/sdd-orchestrator-workflow.md
+++ b/internal/assets/claude/sdd-orchestrator-workflow.md
@@ -36,6 +36,68 @@ Before routing, continuing, applying, verifying, or archiving an SDD change, fir
 - Route only by structured `nextRecommended`, dependency states, and `blockedReasons`; never infer from free text.
 - If blocked, stop and report the blocker. Do not proceed to apply, archive, or terminal work.
 
+### SDD Session Preflight (HARD GATE)
+
+Before executing ANY SDD command or natural-language SDD request, ensure this session has an explicit `SDD Session Preflight` decision block.
+
+This applies to `/sdd-new`, `/sdd-ff`, `/sdd-continue`, `/sdd-explore`, `/sdd-status`, `/sdd-apply`, `/sdd-verify`, `/sdd-archive`, and natural-language equivalents such as "use SDD to add dark mode" / "do it with SDD".
+
+Required preflight choices:
+
+1. **Execution mode**: `interactive` or `auto`.
+2. **Artifact store**: `openspec`, `engram`, or `hybrid` when Engram is callable. If Engram is unavailable, offer only file/inline-safe choices.
+3. **Chained PR strategy**: `auto-forecast`, `ask-always`, `single-pr-default`, or `force-chained`.
+4. **Review budget**: maximum changed lines before stopping for reviewer-burden approval.
+
+User-facing preflight question format:
+
+Use the built-in `AskUserQuestion` tool for SDD Session Preflight. Do NOT render the full preflight menu as plain chat text.
+
+Ask all four preflight groups in one single `AskUserQuestion` tool call so Claude Code can render the groups as one interactive prompt. Do NOT run this as a sequential wizard. Do NOT issue four separate `AskUserQuestion` tool calls.
+
+The single `AskUserQuestion` tool call must contain these four localized groups in this order:
+
+1. Pace: Interactive, Automatic.
+2. Artifacts: OpenSpec, Engram, Both.
+3. PRs: Ask me, Single PR, Chained, Auto.
+4. Review: 400 lines, 800 lines, Other.
+
+Match the user's current language and active persona for question labels and descriptions. Treat the preflight UI as direct orchestrator conversation, not as a generated technical artifact. Technical artifacts still default to English, but this UI follows the user's conversation language/persona. Do NOT mix languages inside one grouped question.
+
+Do NOT show option codes in the interactive UI. Do NOT show canonical values or other internal values in the interactive UI labels or descriptions.
+
+After the single grouped `AskUserQuestion` tool call returns, map the selected human labels to canonical values internally. Do not reveal the canonical values in the UI.
+
+If Other is selected for review budget, ask one follow-up question for the numeric budget.
+
+Only after all four preflight choices are collected, summarize them as the `SDD Session Preflight` decision block and continue with the SDD init guard/requested phase.
+
+Map answers to canonical values:
+
+- Pace: Interactive -> `interactive`; Automatic -> `auto`.
+- Artifacts: OpenSpec -> `openspec`; Engram -> `engram`; Both -> `hybrid`.
+- PRs: Ask me -> `ask-always`; Single PR -> `single-pr-default`; Chained -> `force-chained`; Auto -> `auto-forecast`.
+- Review: 400 lines -> `review_budget_lines: 400`; 800 lines -> `review_budget_lines: 800`; Other -> ask one follow-up for the number.
+
+Hard gate rules:
+
+- `openspec/config.yaml`, existing SDD artifacts, previous `sdd-init` results, or installed SDD assets do NOT satisfy session preflight.
+- If the session has no preflight block, ask the single grouped `AskUserQuestion` preflight above. Do not run init, delegate phases, edit files, or apply tasks until all four choices are collected.
+- Cache the choices for this session and include them in later phase prompts.
+- If the user explicitly provided all four choices in the current conversation, summarize them as the session preflight block and continue.
+
+### SDD Entry Routing (MANDATORY)
+
+For a new product/code change request that says to use SDD, start at preflight -> init guard -> explore/proposal (`/sdd-new` equivalent). Never launch `sdd-apply` just because the user asked to implement a feature.
+
+Only launch `sdd-apply` when all are true:
+
+1. Session preflight is complete.
+2. The active change has existing spec, design, and tasks artifacts.
+3. The user explicitly asked to apply/continue implementation, or the prior SDD planning phase completed and the orchestrator has passed the review workload guard.
+
+If any dependency is missing, STOP and propose `/sdd-new` or `/sdd-ff`; do not implement.
+
 ### SDD Init Guard (MANDATORY)
 
 Before executing any SDD command or meta-command, check whether `sdd-init` has run for this project:
@@ -48,7 +110,7 @@ This ensures testing capabilities, Strict TDD mode, and project context are avai
 
 ### Execution Mode
 
-On the first `/sdd-new`, `/sdd-ff`, `/sdd-continue`, or equivalent natural-language SDD request in a session, ask which execution mode the user wants and cache it:
+This is collected by `SDD Session Preflight`. If missing, enforce the hard gate before any phase work. Cache the collected mode for the session:
 
 - **Automatic** (`auto`): phases run back-to-back without pausing, but the orchestrator gatekeeper validates after each phase before launching the next.
 - **Interactive** (`interactive`): after each phase, show a concise summary and ask whether to adjust or continue.
@@ -79,7 +141,7 @@ On gate failure, re-run the same phase exactly once with specific corrective fee
 
 ### Artifact Store Mode
 
-On the first SDD chain request in a session, ask once which artifact store to use (`engram`, `openspec`, `hybrid`, or `none`) and cache it. If unspecified, default to `engram` when Engram is available; otherwise use `none` and explain the persistence limitation.
+This is collected by `SDD Session Preflight`. If missing, enforce the hard gate before any phase work. Cache the collected store (`engram`, `openspec`, `hybrid`, or `none`) for the session. If unspecified, default to `engram` when Engram is available; otherwise use `none` and explain the persistence limitation.
 
 Pass the artifact store mode to every SDD phase agent.
 


### PR DESCRIPTION
## Summary

Fixes #1424: the Claude orchestrator workflow asset lacked the `SDD Session Preflight (HARD GATE)` and `SDD Entry Routing (MANDATORY)` sections the OpenCode gentle-orchestrator prompt enforces (source: `internal/assets/opencode/sdd-orchestrator.md:159-219`), so the two runtimes applied different SDD entry contracts.

- Both sections ported near-verbatim, adapted to Claude Code mechanics: OpenCode's `question` tool → the built-in `AskUserQuestion` tool (four grouped questions in one interactive prompt); placed between the Native SDD Dispatcher Guard and the SDD Init Guard mirroring OpenCode's ordering. Same four preflight groups, canonical values, hard-gate rules, and entry-routing conditions.
- The bounded review caught a canonical-vocabulary drift in the first candidate — 'Both' mapped to `both`, which the Dispatcher Guard's literal `openspec`/`hybrid` matching would silently skip — fixed to `hybrid` end to end, with the downstream Execution Mode and Artifact Store Mode sections reconciled to reference the preflight exactly as OpenCode does.
- New `TestClaudeSDDWorkflowRequiresSessionPreflight` (failing-first) pins headings, groups, the AskUserQuestion adaptation, the `hybrid` canonicalization, section ordering, and forbids the OpenCode-only wording and any `both` canonical.

Review: approved bounded receipt over the exact candidate content (two rounds; the round-1 CRITICAL was the vocabulary drift above). Branch rebased onto current main post-approval (#1425 landed mid-flight; files disjoint, candidate bytes identical) — the installed 2.1.7 gate binary predates the just-merged #1376 reconciliation that covers exactly this base advance, so pre-pr was validated pre-rebase.

Known upstream follow-up (both platforms, out of scope): the preflight's PR canonicals differ from the Delivery Strategy values in the OpenCode source itself.

Refs #1424. Related: #1359 (installer refresh gap for this file on user machines).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a mandatory SDD session preflight that collects execution, artifact storage, pull request strategy, and review budget choices before SDD work begins.
  * Added session-level caching and validation of preflight selections.
  * Improved SDD entry routing and safeguards for applying changes, including required artifacts and explicit continuation approval.

* **Tests**
  * Added coverage to verify preflight requirements, workflow ordering, routing safeguards, and supported artifact storage values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->