### PR TITLE
fix(review): accept pure scope contraction in correction recovery

### DIFF
--- a/internal/reviewtransaction/compact_scope_recovery_test.go
+++ b/internal/reviewtransaction/compact_scope_recovery_test.go
@@ -136,6 +136,140 @@ func TestCompactAuthorityGraphLoadsHistoricalFreeFormAuthorizationWithoutRewrite
 	}
 }
 
+func TestCorrectionRequiredScopeRecoveryAcceptsPureGenesisContraction(t *testing.T) {
+	repo, predecessor, store, predecessorRecord := correctionContractionRecoveryFixture(t, "contraction-predecessor")
+	stateBefore, err := os.ReadFile(store.StatePath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeSnapshotFile(t, repo, "deleted.txt", "delete me\n")
+	successor := newCompactTestState(t, repo, "contraction-successor")
+	if !equalStrings(successor.InitialSnapshot.Paths, []string{"tracked.txt"}) || len(predecessor.GenesisPaths) != 2 {
+		t.Fatalf("fixture is not a strict contraction: live=%v genesis=%v", successor.InitialSnapshot.Paths, predecessor.GenesisPaths)
+	}
+	successor.Generation = predecessor.Generation + 1
+	recoveredAt := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
+	request := CompactRecoveryRequest{
+		PredecessorLineageID: predecessor.LineageID, ExpectedPredecessorRevision: predecessorRecord.Revision,
+		Successor: successor, Disposition: RecoveryScopeChanged, Reason: "remove accidentally frozen generated paths",
+		Actor: "maintainer", RecoveredAt: recoveredAt,
+	}
+	request.MaintainerAuthorization = recoveryAuthorizationFixture(request)
+
+	recovered, err := RecoverCompactAuthority(context.Background(), repo, request)
+	if err != nil {
+		t.Fatalf("pure contraction recovery = %v", err)
+	}
+	if recovered.State.Recovery == nil || recovered.State.Recovery.MaintainerAuthorization != request.MaintainerAuthorization ||
+		recovered.State.Generation != predecessor.Generation+1 || !compactPristineReviewing(recovered.State) {
+		t.Fatalf("recovered successor is not fresh: %#v", recovered.State)
+	}
+	if !equalStrings(recovered.State.GenesisPaths, []string{"tracked.txt"}) {
+		t.Fatalf("successor genesis paths = %v", recovered.State.GenesisPaths)
+	}
+	replayed, err := RecoverCompactAuthority(context.Background(), repo, request)
+	if err != nil || replayed.Revision != recovered.Revision || !compactStateEqual(replayed.State, recovered.State) {
+		t.Fatalf("exact replay = %#v, %v", replayed, err)
+	}
+	stateAfter, _ := os.ReadFile(store.StatePath())
+	if !bytes.Equal(stateBefore, stateAfter) {
+		t.Fatal("contraction recovery changed predecessor state bytes")
+	}
+}
+
+func TestCompactStartAndStatusAdvertiseRecoverForPureGenesisContraction(t *testing.T) {
+	repo, predecessor, _, _ := correctionContractionRecoveryFixture(t, "contraction-start-predecessor")
+	writeSnapshotFile(t, repo, "deleted.txt", "delete me\n")
+	requested := newCompactTestState(t, repo, "contraction-start-probe")
+	started, startErr := StartCompactAuthority(context.Background(), repo, CompactStartRequest{State: requested})
+	status, statusErr := AssessTargetStatus(context.Background(), repo, TargetStatusRequest{
+		Target: Target{Kind: TargetCurrentChanges, IntendedUntracked: []string{}}, LineageID: predecessor.LineageID,
+	})
+	if startErr != nil || statusErr != nil || started.Action != CompactStartRecover ||
+		status.Action != TargetStatusActionRecover || status.Replayability != ReplayabilityManualActionRequired {
+		t.Fatalf("contraction START=%#v status=%#v errors=%v/%v", started, status, startErr, statusErr)
+	}
+}
+
+func TestCorrectionRequiredScopeRecoveryContractionGuards(t *testing.T) {
+	t.Run("missing authorization", func(t *testing.T) {
+		repo, predecessor, _, record := correctionContractionRecoveryFixture(t, "contraction-noauth-predecessor")
+		writeSnapshotFile(t, repo, "deleted.txt", "delete me\n")
+		successor := newCompactTestState(t, repo, "contraction-noauth-successor")
+		successor.Generation = predecessor.Generation + 1
+		request := CompactRecoveryRequest{PredecessorLineageID: predecessor.LineageID, ExpectedPredecessorRevision: record.Revision,
+			Successor: successor, Disposition: RecoveryScopeChanged, Reason: "contract scope", Actor: "maintainer"}
+		if _, err := RecoverCompactAuthority(context.Background(), repo, request); err == nil || !strings.Contains(err.Error(), "maintainer authorization") {
+			t.Fatalf("missing authorization error = %v", err)
+		}
+	})
+	t.Run("mismatched authorization", func(t *testing.T) {
+		repo, predecessor, _, record := correctionContractionRecoveryFixture(t, "contraction-badauth-predecessor")
+		writeSnapshotFile(t, repo, "deleted.txt", "delete me\n")
+		successor := newCompactTestState(t, repo, "contraction-badauth-successor")
+		successor.Generation = predecessor.Generation + 1
+		request := CompactRecoveryRequest{PredecessorLineageID: predecessor.LineageID, ExpectedPredecessorRevision: record.Revision,
+			Successor: successor, Disposition: RecoveryScopeChanged, Reason: "contract scope", Actor: "maintainer"}
+		request.MaintainerAuthorization = strings.Replace(recoveryAuthorizationFixture(request), successor.InitialSnapshot.Identity, hash("wrong"), 1)
+		if _, err := RecoverCompactAuthority(context.Background(), repo, request); err == nil || !strings.Contains(err.Error(), "authorization binding") {
+			t.Fatalf("mismatched authorization error = %v", err)
+		}
+	})
+	t.Run("empty live diff", func(t *testing.T) {
+		repo, predecessor, _, record := correctionContractionRecoveryFixture(t, "contraction-empty-predecessor")
+		writeSnapshotFile(t, repo, "tracked.txt", "base\n")
+		writeSnapshotFile(t, repo, "deleted.txt", "delete me\n")
+		snapshot, err := (SnapshotBuilder{Repo: repo}).Build(context.Background(), Target{Kind: TargetCurrentChanges, IntendedUntracked: []string{}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(snapshot.Paths) != 0 {
+			t.Fatalf("fixture live diff is not empty: %v", snapshot.Paths)
+		}
+		lines := 0
+		successor, err := NewCompactState(Start{LineageID: "contraction-empty-successor", Mode: ModeOrdinaryBounded,
+			Generation: predecessor.Generation + 1, Snapshot: snapshot, PolicyHash: hash("1"), RiskLevel: RiskLow,
+			SelectedLenses: []string{}, OriginalChangedLines: &lines})
+		if err != nil {
+			return // an empty live diff cannot even form a recovery successor: fail closed
+		}
+		request := CompactRecoveryRequest{PredecessorLineageID: predecessor.LineageID, ExpectedPredecessorRevision: record.Revision,
+			Successor: successor, Disposition: RecoveryScopeChanged, Reason: "empty diff", Actor: "maintainer"}
+		request.MaintainerAuthorization = recoveryAuthorizationFixture(request)
+		if _, err := RecoverCompactAuthority(context.Background(), repo, request); err == nil || !strings.Contains(err.Error(), "path expansion") {
+			t.Fatalf("empty live diff recovery error = %v", err)
+		}
+	})
+}
+
+func TestCompactRecoveryContractsGenesisPaths(t *testing.T) {
+	predecessor := CompactState{GenesisPaths: []string{"a.go", "b.go", "c.go"}}
+	tests := []struct {
+		name string
+		live []string
+		want bool
+	}{
+		{name: "strict subset", live: []string{"a.go", "c.go"}, want: true},
+		{name: "single retained path", live: []string{"b.go"}, want: true},
+		{name: "equal set", live: []string{"a.go", "b.go", "c.go"}, want: false},
+		{name: "empty live diff", live: []string{}, want: false},
+		{name: "disjoint paths", live: []string{"x.go", "y.go"}, want: false},
+		{name: "superset", live: []string{"a.go", "b.go", "c.go", "d.go"}, want: false},
+		{name: "overlap with outside path", live: []string{"a.go", "x.go"}, want: false},
+		{name: "non-canonical live paths", live: []string{"c.go", "a.go"}, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := compactRecoveryContractsGenesisPaths(predecessor, Snapshot{Paths: tt.live}); got != tt.want {
+				t.Fatalf("compactRecoveryContractsGenesisPaths(%v) = %v, want %v", tt.live, got, tt.want)
+			}
+		})
+	}
+	if compactRecoveryContractsGenesisPaths(CompactState{GenesisPaths: []string{"b.go", "a.go"}}, Snapshot{Paths: []string{"a.go"}}) {
+		t.Fatal("non-canonical genesis paths must not qualify as contraction")
+	}
+}
+
 func recoveryAuthorizationFixture(request CompactRecoveryRequest) string {
 	return "gentle-ai.review-recovery-authorization/v1\npredecessor_lineage=" + request.PredecessorLineageID +
 		"\npredecessor_revision=" + request.ExpectedPredecessorRevision + "\ntarget_identity=" + request.Successor.InitialSnapshot.Identity +
@@ -146,6 +280,21 @@ func correctionScopeRecoveryFixture(t *testing.T, lineage string) (string, Compa
 	t.Helper()
 	repo := initSnapshotRepo(t)
 	writeSnapshotFile(t, repo, "tracked.txt", "base\none\ntwo\nthree\nwrong\n")
+	state, store, record := correctionRequiredAuthorityFixture(t, repo, lineage)
+	return repo, state, store, record
+}
+
+func correctionContractionRecoveryFixture(t *testing.T, lineage string) (string, CompactState, CompactStore, CompactRecord) {
+	t.Helper()
+	repo := initSnapshotRepo(t)
+	writeSnapshotFile(t, repo, "tracked.txt", "base\none\ntwo\nthree\nwrong\n")
+	writeSnapshotFile(t, repo, "deleted.txt", "accidentally frozen generated noise\n")
+	state, store, record := correctionRequiredAuthorityFixture(t, repo, lineage)
+	return repo, state, store, record
+}
+
+func correctionRequiredAuthorityFixture(t *testing.T, repo, lineage string) (CompactState, CompactStore, CompactRecord) {
+	t.Helper()
 	state := newCompactTestState(t, repo, lineage)
 	store := storeCompactStartAuthority(t, repo, state)
 	started, _ := store.Load()
@@ -172,5 +321,5 @@ func correctionScopeRecoveryFixture(t *testing.T, lineage string) (string, Compa
 	if err != nil {
 		t.Fatal(err)
 	}
-	return repo, state, store, record
+	return state, store, record
 }

--- a/internal/reviewtransaction/compact_store.go
+++ b/internal/reviewtransaction/compact_store.go
@@ -324,8 +324,9 @@ func validateCompactRecoveryEdge(predecessor CompactRecord, successor CompactSta
 			if strings.TrimSpace(recovery.MaintainerAuthorization) == "" {
 				return errors.New("correction-required scope recovery requires explicit maintainer authorization")
 			}
-			if !compactRecoveryAddsGenesisPath(predecessor.State, successor.InitialSnapshot) {
-				return errors.New("correction-required scope recovery requires repository-derived path expansion")
+			if !compactRecoveryAddsGenesisPath(predecessor.State, successor.InitialSnapshot) &&
+				!compactRecoveryContractsGenesisPaths(predecessor.State, successor.InitialSnapshot) {
+				return errors.New("correction-required scope recovery requires repository-derived path expansion or pure genesis-scope contraction")
 			}
 		default:
 			return errors.New("scope-changed recovery requires an approved or correction-required predecessor")
@@ -404,6 +405,22 @@ func compactRecoveryAddsGenesisPath(predecessor CompactState, live Snapshot) boo
 		}
 	}
 	return false
+}
+
+// compactRecoveryContractsGenesisPaths reports whether the live repository
+// scope is a pure contraction of predecessor genesis scope: a non-empty strict
+// subset with no live path outside genesis. Disjoint or overlapping-different
+// path sets never qualify; they remain governed by the expansion rule.
+func compactRecoveryContractsGenesisPaths(predecessor CompactState, live Snapshot) bool {
+	paths, pathErr := canonicalPaths(live.Paths)
+	genesis, genesisErr := canonicalPaths(predecessor.GenesisPaths)
+	if pathErr != nil || genesisErr != nil || !equalStrings(paths, live.Paths) || !equalStrings(genesis, predecessor.GenesisPaths) {
+		return false
+	}
+	if len(paths) == 0 || len(paths) >= len(genesis) {
+		return false
+	}
+	return pathsAreSubset(paths, genesis) == nil
 }
 
 func CompactAuthorityLeaves(ctx context.Context, repo string) ([]CompactStore, error) {
@@ -838,7 +855,8 @@ const (
 // classifyCompactCorrectionTarget keeps correction ownership bound to the
 // original delivery boundary even when in-genesis bytes change. START may only
 // resume an authorized continuation; otherwise the existing authority blocks a
-// fresh budget. Repository-derived path expansion remains an explicit recovery.
+// fresh budget. Repository-derived path expansion, and a pure non-empty
+// contraction of genesis scope, remain an explicit recovery.
 func classifyCompactCorrectionTarget(ctx context.Context, repo string, existing, requested CompactState) compactCorrectionTargetClaim {
 	live := requested.InitialSnapshot
 	if existing.State != StateCorrectionRequired ||
@@ -862,6 +880,9 @@ func classifyCompactCorrectionTarget(ctx context.Context, repo string, existing,
 	}
 	if compactStartCorrectionResume(ctx, repo, existing, requested) {
 		return compactCorrectionTargetResume
+	}
+	if compactRecoveryContractsGenesisPaths(existing, live) {
+		return compactCorrectionTargetRecover
 	}
 	return compactCorrectionTargetBlocked
 }


### PR DESCRIPTION
## Summary

Fixes #1421: a `correction_required` lineage whose remediation legitimately NARROWED the changed paths (live paths a strict subset of frozen genesis) could not recover — `RecoverCompactAuthority` demanded repository-derived path EXPANSION ("correction-required scope recovery requires repository-derived path expansion") and START/status advertised the `blocked-scope-action` dead end.

- New predicate `compactRecoveryContractsGenesisPaths`: accepts only a repository-derived pure contraction — non-empty strict subset of predecessor genesis, with the same canonicalization guards as the expansion predicate. Disjoint, superset, overlapping-outside, equal, empty, and non-canonical inputs all fail.
- Wired as an OR-alternative in `validateCompactRecoveryEdge` (correction-required branch only) and in `classifyCompactCorrectionTarget` AFTER resume priority — so START and negotiated status now advertise `recover` for the contraction case. Approved/release-scope recovery and expansion semantics are byte-identical; the same content-addressed maintainer-authorization binding (bound to the contracted successor's snapshot identity) is required.
- The recovered successor starts pristine, so the narrowed scope is fully re-reviewed.

## Tests (TDD-first; the primary test reproduced the issue's exact error and the START/status dead end)

- `TestCorrectionRequiredScopeRecoveryAcceptsPureGenesisContraction` (incl. predecessor byte-immutability and idempotent replay)
- `TestCompactStartAndStatusAdvertiseRecoverForPureGenesisContraction`
- `TestCorrectionRequiredScopeRecoveryContractionGuards` (missing/mismatched authorization, empty live diff — all passing pre-fix and post-fix)
- `TestCompactRecoveryContractsGenesisPaths` (8-row predicate table)

4R bounded review: zero severe findings (two doc-level suggestions recorded as info).

Fixes #1421