### PR TITLE
fix(review): reconcile invalid unchanged-target recovery edges

### DIFF
--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -338,7 +338,7 @@ func TestRunArgsDispatchesCompactReviewFacadeBeforePlatformValidation(t *testing
 	if err := RunArgs([]string{"review", "--help"}, &output); err != nil {
 		t.Fatalf("RunArgs(review --help) error = %v", err)
 	}
-	if !strings.Contains(output.String(), "review <capabilities|start|finalize|validate|status|invalidate|recover|reclaim|schema|bind-sdd>") {
+	if !strings.Contains(output.String(), "review <capabilities|start|finalize|validate|status|invalidate|recover|reclaim|reconcile-authority|schema|bind-sdd>") {
 		t.Fatalf("compact review help missing:\n%s", output.String())
 	}
 }

--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -224,7 +224,7 @@ var reviewFacadeCommittedTransitionHook = func(context.Context, string, string, 
 
 func RunReview(args []string, stdout io.Writer) error {
 	if len(args) == 0 || args[0] == "help" || args[0] == "-h" || args[0] == "--help" {
-		_, _ = fmt.Fprintln(stdout, "Usage: gentle-ai review <capabilities|start|finalize|validate|status|invalidate|recover|reclaim|schema|bind-sdd> [flags]\n\nOrdinary review facade; repository scope, authority, canonical artifacts, and lifecycle transitions are derived by Go.")
+		_, _ = fmt.Fprintln(stdout, "Usage: gentle-ai review <capabilities|start|finalize|validate|status|invalidate|recover|reclaim|reconcile-authority|schema|bind-sdd> [flags]\n\nOrdinary review facade; repository scope, authority, canonical artifacts, and lifecycle transitions are derived by Go.")
 		_, _ = fmt.Fprintln(stdout, "Additive headless capability: gentle-ai review capture-result.")
 		return nil
 	}
@@ -309,6 +309,8 @@ func runReviewCommand(args []string, stdout io.Writer) error {
 		return RunReviewRecover(args[1:], stdout)
 	case "reclaim":
 		return RunReviewReclaim(args[1:], stdout)
+	case "reconcile-authority":
+		return RunReviewReconcileAuthority(args[1:], stdout)
 	case "schema":
 		return RunReviewSchema(args[1:], stdout)
 	case "bind-sdd":

--- a/internal/cli/review_reclaim.go
+++ b/internal/cli/review_reclaim.go
@@ -16,7 +16,7 @@ type ReviewReclaimResult struct {
 }
 
 func RunReviewReclaim(args []string, stdout io.Writer) error {
-	flags := newReviewFlagSet("review reclaim", stdout, "Quarantine one explicit incomplete compact-v2 store entry with a persisted audit record; entries holding any authoritative artifact are refused. On partial failure the prepared audit record JSON is still emitted to stdout and the command exits non-zero.")
+	flags := newReviewFlagSet("review reclaim", stdout, "Quarantine one explicit incomplete compact-v2 store entry with a persisted audit record; entries holding any authoritative artifact are refused — an invalid recovery successor is quarantined with review reconcile-authority instead. On partial failure the prepared audit record JSON is still emitted to stdout and the command exits non-zero.")
 	cwd := flags.String("cwd", ".", "repository path")
 	lineage := flags.String("lineage", "", "explicit incomplete compact store lineage")
 	reason := flags.String("reason", "", "non-empty reclaim reason")

--- a/internal/cli/review_reconcile.go
+++ b/internal/cli/review_reconcile.go
@@ -1,0 +1,60 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/gentleman-programming/gentle-ai/internal/reviewtransaction"
+)
+
+type ReviewReconcileAuthorityResult struct {
+	Operation string                                 `json:"operation"`
+	Record    reviewtransaction.CompactReclaimRecord `json:"record"`
+}
+
+func RunReviewReconcileAuthority(args []string, stdout io.Writer) error {
+	flags := newReviewFlagSet("review reconcile-authority", stdout, "Quarantine one compact-v2 recovery successor whose recovery edge natively re-derives as invalid for exactly the unchanged-target class, with a persisted audit record carrying the re-derived proof; valid edges, incomplete entries, and non-recovery records are refused. On partial failure the prepared audit record JSON is still emitted to stdout and the command exits non-zero.")
+	cwd := flags.String("cwd", ".", "repository path")
+	predecessor := flags.String("predecessor-lineage", "", "exact recovery predecessor lineage; it stays untouched")
+	expectedPredecessor := flags.String("expected-predecessor-revision", "", "exact predecessor revision")
+	successor := flags.String("successor-lineage", "", "invalid recovery successor lineage to quarantine")
+	expectedSuccessor := flags.String("expected-successor-revision", "", "exact successor revision")
+	reason := flags.String("reason", "", "non-empty reconcile reason")
+	actor := flags.String("actor", "", "reconcile actor")
+	authorization := flags.String("maintainer-authorization", "", "exact seven-line LF-only binding: gentle-ai.review-reconcile-authorization/v1, predecessor_lineage, predecessor_revision, successor_lineage, successor_revision, actor, reason")
+	if err := parseReviewFlags(flags, args); err != nil {
+		return err
+	}
+	if reviewHelpRequested(args) {
+		return nil
+	}
+	if flags.NArg() != 0 {
+		return fmt.Errorf("unexpected review reconcile-authority argument %q", flags.Arg(0))
+	}
+	for _, required := range []string{*predecessor, *expectedPredecessor, *successor, *expectedSuccessor, *reason, *actor, *authorization} {
+		if strings.TrimSpace(required) == "" {
+			return errors.New("review reconcile-authority requires --predecessor-lineage, --expected-predecessor-revision, --successor-lineage, --expected-successor-revision, --reason, --actor, and --maintainer-authorization")
+		}
+	}
+	root, err := (reviewtransaction.SnapshotBuilder{Repo: *cwd}).ResolveRepositoryRoot(context.Background())
+	if err != nil {
+		return fmt.Errorf("resolve review repository root: %w", err)
+	}
+	record, err := reviewtransaction.ReconcileInvalidRecoveryEdge(context.Background(), root, reviewtransaction.CompactReconcileRequest{
+		PredecessorLineageID: *predecessor, ExpectedPredecessorRevision: *expectedPredecessor,
+		SuccessorLineageID: *successor, ExpectedSuccessorRevision: *expectedSuccessor,
+		Reason: *reason, Actor: *actor, MaintainerAuthorization: *authorization,
+	})
+	if err != nil {
+		// A partial reconcile persisted the prepared audit record and may have
+		// moved the successor; surface the quarantine location for reconciliation.
+		if record.QuarantinePath != "" {
+			_ = encodeReviewJSON(stdout, ReviewReconcileAuthorityResult{Operation: "review/reconcile-authority", Record: record})
+		}
+		return err
+	}
+	return encodeReviewJSON(stdout, ReviewReconcileAuthorityResult{Operation: "review/reconcile-authority", Record: record})
+}

--- a/internal/cli/review_reconcile_test.go
+++ b/internal/cli/review_reconcile_test.go
@@ -1,0 +1,225 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gentleman-programming/gentle-ai/internal/reviewtransaction"
+)
+
+func reviewCLIAuthorityRoot(t *testing.T, repo string) string {
+	t.Helper()
+	commonDir := filepath.Clean(strings.TrimSpace(runReviewCLIGit(t, repo, "rev-parse", "--path-format=absolute", "--git-common-dir")))
+	return filepath.Join(commonDir, "gentle-ai", "review-transactions")
+}
+
+func writeReconcileCLIRecord(t *testing.T, repo string, state reviewtransaction.CompactState) string {
+	t.Helper()
+	revision, err := reviewtransaction.CompactRevisionForState(state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	record := reviewtransaction.CompactRecord{Schema: "gentle-ai.review-state-record/v2", Revision: revision, State: state}
+	payload, err := json.MarshalIndent(record, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(reviewCLIAuthorityRoot(t, repo), "v2", state.LineageID)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "review-state.json"), append(payload, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return revision
+}
+
+// invalidRecoveryEdgeCLIFixture persists an escalated docs-only predecessor
+// with its receipt and a recovery successor whose sole anomaly is an unchanged
+// target, then restores the clean workspace.
+func invalidRecoveryEdgeCLIFixture(t *testing.T, repo string) (predecessorRevision, successorRevision string) {
+	t.Helper()
+	incident := filepath.Join(repo, "docs", "incident.md")
+	if err := os.MkdirAll(filepath.Dir(incident), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(incident, []byte("incident\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	builder := reviewtransaction.SnapshotBuilder{Repo: repo}
+	snapshot, err := builder.Build(context.Background(), reviewtransaction.Target{
+		Kind: reviewtransaction.TargetCurrentChanges, IntendedUntracked: []string{"docs/incident.md"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	risk, lines, err := builder.ClassifySnapshotRisk(context.Background(), snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if risk != reviewtransaction.RiskLow {
+		t.Fatalf("reconcile fixture risk = %q", risk)
+	}
+	policy := sha256.Sum256([]byte("reconcile-policy"))
+	policyHash := "sha256:" + hex.EncodeToString(policy[:])
+	predecessorState, err := reviewtransaction.NewCompactState(reviewtransaction.Start{
+		LineageID: "reconcile-incident", Mode: reviewtransaction.ModeOrdinaryBounded, Generation: 1,
+		Snapshot: snapshot, PolicyHash: policyHash, RiskLevel: risk, SelectedLenses: []string{}, OriginalChangedLines: &lines,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	predecessorState.State = reviewtransaction.StateEscalated
+	predecessorRevision = writeReconcileCLIRecord(t, repo, predecessorState)
+	receipt, err := predecessorState.Receipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	receiptPath := filepath.Join(reviewCLIAuthorityRoot(t, repo), "v2", predecessorState.LineageID, "review-receipt.json")
+	if err := reviewtransaction.WriteCompactReceiptAtomic(receiptPath, receipt); err != nil {
+		t.Fatal(err)
+	}
+	successorState, err := reviewtransaction.NewCompactState(reviewtransaction.Start{
+		LineageID: "reconcile-incident-g2", Mode: reviewtransaction.ModeOrdinaryBounded, Generation: 2,
+		Snapshot: snapshot, PolicyHash: policyHash, RiskLevel: risk, SelectedLenses: []string{}, OriginalChangedLines: &lines,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	successorState.Recovery = &reviewtransaction.CompactRecoveryProvenance{
+		PredecessorLineageID: predecessorState.LineageID, PredecessorRevision: predecessorRevision,
+		Disposition: reviewtransaction.RecoveryEscalated, Reason: "retry after escalation", Actor: "maintainer@example.com",
+		RecoveredAt: time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC),
+		MaintainerAuthorization: "gentle-ai.review-recovery-authorization/v1\npredecessor_lineage=" + predecessorState.LineageID +
+			"\npredecessor_revision=" + predecessorRevision + "\ntarget_identity=" + successorState.InitialSnapshot.Identity +
+			"\nactor=maintainer@example.com\nreason=retry after escalation",
+	}
+	successorRevision = writeReconcileCLIRecord(t, repo, successorState)
+	if err := os.Remove(incident); err != nil {
+		t.Fatal(err)
+	}
+	return predecessorRevision, successorRevision
+}
+
+func reconcileCLIArgs(repo, predecessorRevision, successorRevision, authorization string) []string {
+	return []string{
+		"reconcile-authority", "--cwd", repo,
+		"--predecessor-lineage", "reconcile-incident", "--expected-predecessor-revision", predecessorRevision,
+		"--successor-lineage", "reconcile-incident-g2", "--expected-successor-revision", successorRevision,
+		"--reason", "quarantine invalid unchanged-target recovery edge", "--actor", "maintainer@example.com",
+		"--maintainer-authorization", authorization,
+	}
+}
+
+func reconcileCLIBinding(predecessorRevision, successorRevision string) string {
+	return "gentle-ai.review-reconcile-authorization/v1\npredecessor_lineage=reconcile-incident\npredecessor_revision=" + predecessorRevision +
+		"\nsuccessor_lineage=reconcile-incident-g2\nsuccessor_revision=" + successorRevision +
+		"\nactor=maintainer@example.com\nreason=quarantine invalid unchanged-target recovery edge"
+}
+
+func TestReviewReconcileAuthorityQuarantinesInvalidEdgeAndRestoresDiscovery(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	approveDiscoveryMarkdown(t, repo, "review-reconcile-valid", "docs/valid.md", "valid\n")
+	predecessorRevision, successorRevision := invalidRecoveryEdgeCLIFixture(t, repo)
+
+	var statusOutput bytes.Buffer
+	if err := RunReview([]string{"status", "--cwd", repo}, &statusOutput); err != nil {
+		t.Fatalf("review status over poisoned graph: %v", err)
+	}
+	var before reviewtransaction.AuthorityStatusReport
+	decodeStrictReviewJSON(t, statusOutput.Bytes(), &before)
+	if before.Complete || before.Authoritative {
+		t.Fatalf("poisoned status = complete %v authoritative %v", before.Complete, before.Authoritative)
+	}
+
+	var blockedOutput bytes.Buffer
+	err := RunReview([]string{
+		"validate", "--contract", ReviewIntegrationContractV1, "--cwd", repo,
+		"--gate", string(reviewtransaction.GatePostApply),
+	}, &blockedOutput)
+	if err == nil {
+		t.Fatal("invalid recovery edge did not deny lineage-less gate validation")
+	}
+	failure := decodeReviewIntegrationFailure(t, blockedOutput.Bytes())
+	if failure.Code != "authority_corrupted" {
+		t.Fatalf("poisoned gate failure = %#v", failure)
+	}
+
+	var reconcileOutput bytes.Buffer
+	if err := RunReview(reconcileCLIArgs(repo, predecessorRevision, successorRevision, reconcileCLIBinding(predecessorRevision, successorRevision)), &reconcileOutput); err != nil {
+		t.Fatalf("review reconcile-authority: %v\n%s", err, reconcileOutput.String())
+	}
+	var result ReviewReconcileAuthorityResult
+	decodeStrictReviewJSON(t, reconcileOutput.Bytes(), &result)
+	if result.Operation != "review/reconcile-authority" || result.Record.LineageID != "reconcile-incident-g2" ||
+		result.Record.Status != reviewtransaction.CompactReclaimCommitted || result.Record.InvalidRecoveryEdge == nil ||
+		!strings.Contains(result.Record.InvalidRecoveryEdge.ValidationError, "target has not changed") {
+		t.Fatalf("review reconcile-authority result = %#v", result)
+	}
+	if _, err := os.Stat(filepath.Join(result.Record.QuarantinePath, "residue", "review-state.json")); err != nil {
+		t.Fatalf("quarantined successor state missing: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(reviewCLIAuthorityRoot(t, repo), "v2", "reconcile-incident-g2")); !os.IsNotExist(err) {
+		t.Fatalf("reconciled successor entry still present: %v", err)
+	}
+
+	statusOutput.Reset()
+	if err := RunReview([]string{"status", "--cwd", repo}, &statusOutput); err != nil {
+		t.Fatalf("review status after reconcile: %v", err)
+	}
+	var after reviewtransaction.AuthorityStatusReport
+	decodeStrictReviewJSON(t, statusOutput.Bytes(), &after)
+	if !after.Complete || !after.Authoritative {
+		t.Fatalf("post-reconcile status = complete %v authoritative %v", after.Complete, after.Authoritative)
+	}
+
+	var validateOutput bytes.Buffer
+	if err := RunReview([]string{
+		"validate", "--contract", ReviewIntegrationContractV1, "--cwd", repo,
+		"--gate", string(reviewtransaction.GatePostApply),
+	}, &validateOutput); err != nil {
+		t.Fatalf("post-reconcile lineage-less validation: %v\n%s", err, validateOutput.String())
+	}
+	var validated ReviewValidateResult
+	decodeStrictReviewJSON(t, decodeReviewOperationEnvelope(t, validateOutput.Bytes()).Result, &validated)
+	if !validated.Allowed || validated.Context.LineageID != "review-reconcile-valid" {
+		t.Fatalf("post-reconcile validation = %#v", validated)
+	}
+
+	if err := RunReview(reconcileCLIArgs(repo, predecessorRevision, successorRevision, reconcileCLIBinding(predecessorRevision, successorRevision)), &bytes.Buffer{}); err == nil {
+		t.Fatal("review reconcile-authority replayed after quarantine")
+	}
+}
+
+func TestReviewReconcileAuthorityRequiresFlagsAndExactBinding(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	predecessorRevision, successorRevision := invalidRecoveryEdgeCLIFixture(t, repo)
+	statePath := filepath.Join(reviewCLIAuthorityRoot(t, repo), "v2", "reconcile-incident-g2", "review-state.json")
+	payload, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := RunReview([]string{
+		"reconcile-authority", "--cwd", repo, "--successor-lineage", "reconcile-incident-g2",
+	}, &bytes.Buffer{}); err == nil || !strings.Contains(err.Error(), "requires") {
+		t.Fatalf("incomplete reconcile-authority flags error = %v", err)
+	}
+
+	wrong := reconcileCLIBinding(successorRevision, predecessorRevision)
+	if err := RunReview(reconcileCLIArgs(repo, predecessorRevision, successorRevision, wrong), &bytes.Buffer{}); err == nil || !strings.Contains(err.Error(), "exact maintainer authorization binding") {
+		t.Fatalf("inexact reconcile-authority binding error = %v", err)
+	}
+	current, err := os.ReadFile(statePath)
+	if err != nil || !bytes.Equal(current, payload) {
+		t.Fatalf("refused reconcile-authority mutated the successor entry: %v", err)
+	}
+}

--- a/internal/reviewtransaction/compact_reclaim.go
+++ b/internal/reviewtransaction/compact_reclaim.go
@@ -48,6 +48,9 @@ type CompactReclaimRecord struct {
 	SourcePath     string    `json:"source_path"`
 	QuarantinePath string    `json:"quarantine_path"`
 	Residue        []string  `json:"residue"`
+	// InvalidRecoveryEdge carries the natively re-derived edge-invalidity
+	// proof; it is set only for reconcile-authority quarantines.
+	InvalidRecoveryEdge *CompactInvalidRecoveryEdgeProof `json:"invalid_recovery_edge,omitempty"`
 }
 
 // compactAuthoritativeArtifact reports whether a store-entry name carries
@@ -108,7 +111,7 @@ func ReclaimIncompleteCompactStore(ctx context.Context, repo string, request Com
 	residue := make([]string, 0, len(items))
 	for _, item := range items {
 		if compactAuthoritativeArtifact(item.Name()) {
-			return CompactReclaimRecord{}, fmt.Errorf("review reclaim refused: store entry %q holds authoritative artifact %q", request.LineageID, item.Name())
+			return CompactReclaimRecord{}, fmt.Errorf("review reclaim refused: store entry %q holds authoritative artifact %q; an invalid recovery successor is quarantined with review reconcile-authority", request.LineageID, item.Name())
 		}
 		residue = append(residue, item.Name())
 	}
@@ -116,6 +119,19 @@ func ReclaimIncompleteCompactStore(ctx context.Context, repo string, request Com
 	if request.ReclaimedAt.IsZero() {
 		request.ReclaimedAt = time.Now().UTC()
 	}
+	return quarantineCompactStoreEntry(base, dir, CompactReclaimRecord{
+		Schema: CompactReclaimRecordSchema, Status: CompactReclaimPrepared, LineageID: request.LineageID,
+		Reason: strings.TrimSpace(request.Reason), Actor: strings.TrimSpace(request.Actor),
+		ReclaimedAt: request.ReclaimedAt.UTC(), SourcePath: dir, Residue: residue,
+	})
+}
+
+// quarantineCompactStoreEntry runs the shared two-phase audited move for one
+// store entry: create the quarantine directory, persist the prepared record,
+// rename the entry into residue/, then rewrite the record as committed. On
+// partial failure after the prepared record persisted, it returns the
+// populated prepared record alongside a non-nil error.
+func quarantineCompactStoreEntry(base, dir string, record CompactReclaimRecord) (CompactReclaimRecord, error) {
 	quarantineRoot := filepath.Join(base, "quarantine")
 	if err := os.MkdirAll(quarantineRoot, 0o755); err != nil {
 		return CompactReclaimRecord{}, err
@@ -125,12 +141,12 @@ func ReclaimIncompleteCompactStore(ctx context.Context, repo string, request Com
 		return CompactReclaimRecord{}, err
 	}
 	if quarantineRootInfo.Mode()&os.ModeSymlink != 0 || !quarantineRootInfo.IsDir() {
-		return CompactReclaimRecord{}, fmt.Errorf("review reclaim refused unsafe quarantine root %q", quarantineRoot)
+		return CompactReclaimRecord{}, fmt.Errorf("review quarantine refused unsafe quarantine root %q", quarantineRoot)
 	}
 	if err := SyncReviewDirectory(base); err != nil {
 		return CompactReclaimRecord{}, fmt.Errorf("sync review authority root after quarantine creation: %w", err)
 	}
-	quarantineDir, err := os.MkdirTemp(quarantineRoot, request.LineageID+"-")
+	quarantineDir, err := os.MkdirTemp(quarantineRoot, record.LineageID+"-")
 	if err != nil {
 		return CompactReclaimRecord{}, err
 	}
@@ -146,19 +162,14 @@ func ReclaimIncompleteCompactStore(ctx context.Context, repo string, request Com
 	if err := SyncReviewDirectory(quarantineRoot); err != nil {
 		return CompactReclaimRecord{}, cleanupUnprepared(fmt.Errorf("sync quarantine root after reclaim directory creation: %w", err))
 	}
-	record := CompactReclaimRecord{
-		Schema: CompactReclaimRecordSchema, Status: CompactReclaimPrepared, LineageID: request.LineageID,
-		Reason: strings.TrimSpace(request.Reason), Actor: strings.TrimSpace(request.Actor),
-		ReclaimedAt: request.ReclaimedAt.UTC(), SourcePath: dir,
-		QuarantinePath: quarantineDir, Residue: residue,
-	}
+	record.QuarantinePath = quarantineDir
 	if err := persistReclaimRecord(record); err != nil {
 		return CompactReclaimRecord{}, cleanupUnprepared(err)
 	}
 	if err := reclaimQuarantineResidue(dir, filepath.Join(quarantineDir, "residue")); err != nil {
 		return record, fmt.Errorf("reclaim was prepared at %s but quarantining the residue failed: %w", quarantineDir, err)
 	}
-	if err := SyncReviewDirectory(versionRoot); err != nil {
+	if err := SyncReviewDirectory(filepath.Dir(dir)); err != nil {
 		return record, fmt.Errorf("residue was quarantined at %s but syncing the source version root failed: %w", quarantineDir, err)
 	}
 	if err := SyncReviewDirectory(quarantineDir); err != nil {

--- a/internal/reviewtransaction/compact_reconcile.go
+++ b/internal/reviewtransaction/compact_reconcile.go
@@ -1,0 +1,171 @@
+package reviewtransaction
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+const compactReconcileAuthorizationSchema = "gentle-ai.review-reconcile-authorization/v1"
+
+// CompactReconcileRequest identifies one recovery successor whose persisted
+// recovery edge must natively re-derive as invalid before quarantine, together
+// with the exact maintainer authorization binding for that content.
+type CompactReconcileRequest struct {
+	PredecessorLineageID        string
+	ExpectedPredecessorRevision string
+	SuccessorLineageID          string
+	ExpectedSuccessorRevision   string
+	Reason                      string
+	Actor                       string
+	MaintainerAuthorization     string
+	ReconciledAt                time.Time
+}
+
+// CompactInvalidRecoveryEdgeProof records the natively re-derived edge
+// invalidity inside the quarantine audit record.
+type CompactInvalidRecoveryEdgeProof struct {
+	PredecessorLineageID string `json:"predecessor_lineage_id"`
+	PredecessorRevision  string `json:"predecessor_revision"`
+	SuccessorRevision    string `json:"successor_revision"`
+	ValidationError      string `json:"validation_error"`
+}
+
+func compactReconcileAuthorizationBinding(predecessorLineage, predecessorRevision, successorLineage, successorRevision, actor, reason string) string {
+	return compactReconcileAuthorizationSchema + "\npredecessor_lineage=" + predecessorLineage +
+		"\npredecessor_revision=" + predecessorRevision + "\nsuccessor_lineage=" + successorLineage +
+		"\nsuccessor_revision=" + successorRevision +
+		"\nactor=" + strings.TrimSpace(actor) + "\nreason=" + strings.TrimSpace(reason)
+}
+
+// ReconcileInvalidRecoveryEdge quarantines one compact-v2 recovery successor
+// whose recovery edge natively re-derives as invalid for exactly the
+// unchanged-target class. The predecessor and every unrelated authority stay
+// untouched; the successor entry moves whole — never deleted — into the
+// audited quarantine together with the re-derived proof. Valid edges,
+// incomplete entries, non-recovery records, stale revisions, inexact
+// authorization, and any additional graph defect are refused.
+func ReconcileInvalidRecoveryEdge(ctx context.Context, repo string, request CompactReconcileRequest) (CompactReclaimRecord, error) {
+	if err := ctx.Err(); err != nil {
+		return CompactReclaimRecord{}, err
+	}
+	if err := validateLineageID(request.PredecessorLineageID); err != nil {
+		return CompactReclaimRecord{}, err
+	}
+	if err := validateLineageID(request.SuccessorLineageID); err != nil {
+		return CompactReclaimRecord{}, err
+	}
+	if request.PredecessorLineageID == request.SuccessorLineageID {
+		return CompactReclaimRecord{}, errors.New("review reconcile-authority requires distinct predecessor and successor lineages")
+	}
+	if strings.TrimSpace(request.Reason) == "" || strings.TrimSpace(request.Actor) == "" {
+		return CompactReclaimRecord{}, errors.New("review reconcile-authority requires a non-empty reason and actor")
+	}
+	base, _, err := reviewAuthorityRoot(ctx, repo)
+	if err != nil {
+		return CompactReclaimRecord{}, err
+	}
+	versionRoot := filepath.Join(base, "v2")
+	dir := filepath.Join(versionRoot, request.SuccessorLineageID)
+	lock, err := acquireStoreLock(filepath.Join(versionRoot, "LOCK"))
+	if err != nil {
+		return CompactReclaimRecord{}, err
+	}
+	defer lock.release()
+	successorStore := CompactStore{Dir: dir, lineageID: request.SuccessorLineageID}
+	successor, err := successorStore.Load()
+	if err != nil {
+		if os.IsNotExist(err) {
+			return CompactReclaimRecord{}, fmt.Errorf("review reconcile-authority refused: successor %q holds no compact authority state. If the entry never held authority, quarantine its residue with review reclaim; if a prior reconcile was interrupted after moving the entry, the prepared reclaim-record.json under %s locates the moved residue for manual reconciliation: %w", request.SuccessorLineageID, filepath.Join(base, "quarantine"), err)
+		}
+		return CompactReclaimRecord{}, fmt.Errorf("load reconcile successor: %w", err)
+	}
+	recovery := successor.State.Recovery
+	if recovery == nil {
+		return CompactReclaimRecord{}, fmt.Errorf("review reconcile-authority refused: successor %q is not a recovery successor", request.SuccessorLineageID)
+	}
+	if recovery.PredecessorLineageID != request.PredecessorLineageID {
+		return CompactReclaimRecord{}, fmt.Errorf("review reconcile-authority refused: successor %q names predecessor %q", request.SuccessorLineageID, recovery.PredecessorLineageID)
+	}
+	predecessorStore := CompactStore{Dir: filepath.Join(versionRoot, request.PredecessorLineageID), lineageID: request.PredecessorLineageID}
+	predecessor, err := predecessorStore.Load()
+	if err != nil {
+		return CompactReclaimRecord{}, fmt.Errorf("load reconcile predecessor: %w", err)
+	}
+	if predecessor.Revision != request.ExpectedPredecessorRevision {
+		return CompactReclaimRecord{}, fmt.Errorf("%w: expected predecessor revision %q, current %q", ErrConcurrentUpdate, request.ExpectedPredecessorRevision, predecessor.Revision)
+	}
+	if successor.Revision != request.ExpectedSuccessorRevision {
+		return CompactReclaimRecord{}, fmt.Errorf("%w: expected successor revision %q, current %q", ErrConcurrentUpdate, request.ExpectedSuccessorRevision, successor.Revision)
+	}
+	if request.MaintainerAuthorization != compactReconcileAuthorizationBinding(request.PredecessorLineageID, predecessor.Revision, request.SuccessorLineageID, successor.Revision, request.Actor, request.Reason) {
+		return CompactReclaimRecord{}, fmt.Errorf("review reconcile-authority requires an exact maintainer authorization binding (schema %s over predecessor %s@%s and successor %s@%s)",
+			compactReconcileAuthorizationSchema, request.PredecessorLineageID, predecessor.Revision, request.SuccessorLineageID, successor.Revision)
+	}
+	edgeErr := validateCompactRecoveryEdge(predecessor, successor.State)
+	if edgeErr == nil {
+		return CompactReclaimRecord{}, fmt.Errorf("review reconcile-authority refused: recovery edge for %q validates; the successor remains authoritative", request.SuccessorLineageID)
+	}
+	if !errors.Is(edgeErr, errCompactRecoveryTargetUnchanged) {
+		return CompactReclaimRecord{}, fmt.Errorf("review reconcile-authority refused: recovery edge fails outside the unchanged-target class: %v", edgeErr)
+	}
+	if recovery.MaintainerAuthorization != compactRecoveryAuthorizationBinding(predecessor.State.LineageID, predecessor.Revision, successor.State.InitialSnapshot.Identity, recovery.Actor, recovery.Reason) {
+		return CompactReclaimRecord{}, errors.New("review reconcile-authority refused: unchanged target is not the sole anomaly; the recorded recovery authorization binding is inexact")
+	}
+	stores, err := DiscoverCompactStores(ctx, repo)
+	if err != nil {
+		return CompactReclaimRecord{}, err
+	}
+	records := make(map[string]CompactRecord, len(stores))
+	storeByLineage := make(map[string]CompactStore, len(stores))
+	for _, store := range stores {
+		record, loadErr := store.Load()
+		if loadErr != nil {
+			return CompactReclaimRecord{}, fmt.Errorf("review reconcile-authority refused: related compact authority %q does not load: %w", store.lineageID, loadErr)
+		}
+		records[record.State.LineageID], storeByLineage[record.State.LineageID] = record, store
+	}
+	for lineage, record := range records {
+		related := record.State.Recovery
+		if related == nil {
+			continue
+		}
+		if related.PredecessorLineageID == request.PredecessorLineageID && lineage != request.SuccessorLineageID {
+			return CompactReclaimRecord{}, fmt.Errorf("review reconcile-authority refused: predecessor %q has another successor %q", request.PredecessorLineageID, lineage)
+		}
+		if related.PredecessorLineageID == request.SuccessorLineageID {
+			return CompactReclaimRecord{}, fmt.Errorf("review reconcile-authority refused: successor %q has its own successor %q", request.SuccessorLineageID, lineage)
+		}
+	}
+	delete(records, request.SuccessorLineageID)
+	delete(storeByLineage, request.SuccessorLineageID)
+	if _, err := compactAuthorityLeaves(records, storeByLineage); err != nil {
+		return CompactReclaimRecord{}, fmt.Errorf("review reconcile-authority refused: remaining authority graph is invalid: %w", err)
+	}
+	items, err := os.ReadDir(dir)
+	if err != nil {
+		return CompactReclaimRecord{}, fmt.Errorf("inspect reconcile target: %w", err)
+	}
+	residue := make([]string, 0, len(items))
+	for _, item := range items {
+		residue = append(residue, item.Name())
+	}
+	sort.Strings(residue)
+	if request.ReconciledAt.IsZero() {
+		request.ReconciledAt = time.Now().UTC()
+	}
+	return quarantineCompactStoreEntry(base, dir, CompactReclaimRecord{
+		Schema: CompactReclaimRecordSchema, Status: CompactReclaimPrepared, LineageID: request.SuccessorLineageID,
+		Reason: strings.TrimSpace(request.Reason), Actor: strings.TrimSpace(request.Actor),
+		ReclaimedAt: request.ReconciledAt.UTC(), SourcePath: dir, Residue: residue,
+		InvalidRecoveryEdge: &CompactInvalidRecoveryEdgeProof{
+			PredecessorLineageID: request.PredecessorLineageID, PredecessorRevision: predecessor.Revision,
+			SuccessorRevision: successor.Revision, ValidationError: edgeErr.Error(),
+		},
+	})
+}

--- a/internal/reviewtransaction/compact_reconcile_test.go
+++ b/internal/reviewtransaction/compact_reconcile_test.go
@@ -1,0 +1,581 @@
+package reviewtransaction
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// poisonedRecoveryFixture persists an escalated predecessor with its receipt
+// and a recovery successor whose sole structural anomaly is an unchanged
+// target. mutate, when non-nil, adjusts the successor before it is persisted.
+func poisonedRecoveryFixture(t *testing.T, repo string, mutate func(*CompactState)) (CompactRecord, CompactStore, CompactRecord, CompactStore) {
+	t.Helper()
+	state := correctedCompactTestState(t, repo, "reconcile-predecessor")
+	state.State = StateEscalated
+	predecessorStore, err := CompactAuthoritativeStore(context.Background(), repo, state.LineageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	predecessor := writeCompactFixtureRecord(t, predecessorStore, state)
+	receipt, err := state.Receipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteCompactReceiptAtomic(predecessorStore.ReceiptPath(), receipt); err != nil {
+		t.Fatal(err)
+	}
+	successorState := newCompactTestState(t, repo, "reconcile-successor")
+	successorState.Generation = state.Generation + 1
+	successorState.Recovery = &CompactRecoveryProvenance{
+		PredecessorLineageID: state.LineageID, PredecessorRevision: predecessor.Revision,
+		Disposition: RecoveryEscalated, Reason: "retry terminal validator", Actor: "maintainer@example.com",
+		RecoveredAt:             time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC),
+		MaintainerAuthorization: compactRecoveryAuthorizationBinding(state.LineageID, predecessor.Revision, successorState.InitialSnapshot.Identity, "maintainer@example.com", "retry terminal validator"),
+	}
+	if mutate != nil {
+		mutate(&successorState)
+	}
+	successorStore, err := CompactAuthoritativeStore(context.Background(), repo, successorState.LineageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	successor := writeCompactFixtureRecord(t, successorStore, successorState)
+	return predecessor, predecessorStore, successor, successorStore
+}
+
+func writeCompactFixtureRecord(t *testing.T, store CompactStore, state CompactState) CompactRecord {
+	t.Helper()
+	record, payload, err := makeCompactRecord(state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(store.Dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(store.StatePath(), payload, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return record
+}
+
+func reconcileFixtureRequest(predecessor, successor CompactRecord) CompactReconcileRequest {
+	request := CompactReconcileRequest{
+		PredecessorLineageID: predecessor.State.LineageID, ExpectedPredecessorRevision: predecessor.Revision,
+		SuccessorLineageID: successor.State.LineageID, ExpectedSuccessorRevision: successor.Revision,
+		Reason: "quarantine invalid unchanged-target recovery edge", Actor: "maintainer@example.com",
+	}
+	request.MaintainerAuthorization = compactReconcileAuthorizationBinding(
+		request.PredecessorLineageID, predecessor.Revision, request.SuccessorLineageID, successor.Revision,
+		request.Actor, request.Reason)
+	return request
+}
+
+func TestReconcileInvalidRecoveryEdgeQuarantinesSuccessorAndRestoresAuthority(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	predecessor, predecessorStore, successor, successorStore := poisonedRecoveryFixture(t, repo, nil)
+	if _, err := CompactAuthorityLeaves(context.Background(), repo); err == nil || !strings.Contains(err.Error(), "target has not changed") {
+		t.Fatalf("poisoned graph leaves error = %v", err)
+	}
+	before, err := InventoryAuthority(context.Background(), repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if before.Complete || before.Authoritative || !hasAuthorityInventoryStatus(before.Entries, successor.State.LineageID, AuthorityStatusInvalid) {
+		t.Fatalf("poisoned inventory = %#v", before)
+	}
+	predecessorStateBefore, err := os.ReadFile(predecessorStore.StatePath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	predecessorReceiptBefore, err := os.ReadFile(predecessorStore.ReceiptPath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	successorPayload, err := os.ReadFile(successorStore.StatePath())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	request := reconcileFixtureRequest(predecessor, successor)
+	record, err := ReconcileInvalidRecoveryEdge(context.Background(), repo, request)
+	if err != nil {
+		t.Fatalf("reconcile invalid recovery edge: %v", err)
+	}
+	if record.Schema != CompactReclaimRecordSchema || record.Status != CompactReclaimCommitted ||
+		record.LineageID != successor.State.LineageID || record.SourcePath != successorStore.Dir ||
+		record.Reason != request.Reason || record.Actor != request.Actor || record.ReclaimedAt.IsZero() {
+		t.Fatalf("reconcile record = %#v", record)
+	}
+	if record.InvalidRecoveryEdge == nil || record.InvalidRecoveryEdge.PredecessorLineageID != predecessor.State.LineageID ||
+		record.InvalidRecoveryEdge.PredecessorRevision != predecessor.Revision ||
+		record.InvalidRecoveryEdge.SuccessorRevision != successor.Revision ||
+		!strings.Contains(record.InvalidRecoveryEdge.ValidationError, "target has not changed") {
+		t.Fatalf("reconcile edge proof = %#v", record.InvalidRecoveryEdge)
+	}
+	if len(record.Residue) != 1 || record.Residue[0] != "review-state.json" {
+		t.Fatalf("reconcile residue manifest = %#v", record.Residue)
+	}
+	root, _, err := reviewAuthorityRoot(context.Background(), repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(record.QuarantinePath, filepath.Join(root, "quarantine")+string(os.PathSeparator)) {
+		t.Fatalf("quarantine path %q is outside the quarantine root", record.QuarantinePath)
+	}
+	if _, statErr := os.Stat(successorStore.Dir); !os.IsNotExist(statErr) {
+		t.Fatalf("reconciled successor entry still present: %v", statErr)
+	}
+	moved, err := os.ReadFile(filepath.Join(record.QuarantinePath, "residue", "review-state.json"))
+	if err != nil || !bytes.Equal(moved, successorPayload) {
+		t.Fatalf("quarantined successor bytes = %q, %v", moved, err)
+	}
+	payload, err := os.ReadFile(filepath.Join(record.QuarantinePath, "reclaim-record.json"))
+	if err != nil {
+		t.Fatalf("read persisted reconcile audit record: %v", err)
+	}
+	var persisted CompactReclaimRecord
+	if err := json.Unmarshal(payload, &persisted); err != nil {
+		t.Fatalf("parse persisted reconcile audit record: %v", err)
+	}
+	if persisted.Status != CompactReclaimCommitted || persisted.InvalidRecoveryEdge == nil ||
+		persisted.InvalidRecoveryEdge.SuccessorRevision != successor.Revision ||
+		!strings.Contains(persisted.InvalidRecoveryEdge.ValidationError, "target has not changed") {
+		t.Fatalf("persisted reconcile record = %#v", persisted)
+	}
+	predecessorStateAfter, _ := os.ReadFile(predecessorStore.StatePath())
+	predecessorReceiptAfter, _ := os.ReadFile(predecessorStore.ReceiptPath())
+	if !bytes.Equal(predecessorStateBefore, predecessorStateAfter) || !bytes.Equal(predecessorReceiptBefore, predecessorReceiptAfter) {
+		t.Fatal("reconcile changed predecessor state or receipt bytes")
+	}
+
+	leaves, err := CompactAuthorityLeaves(context.Background(), repo)
+	if err != nil || len(leaves) != 1 || leaves[0].lineageID != predecessor.State.LineageID {
+		t.Fatalf("post-reconcile leaves = %#v, %v", leaves, err)
+	}
+	after, err := InventoryAuthority(context.Background(), repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !after.Complete || !after.Authoritative {
+		t.Fatalf("post-reconcile inventory = %#v", after)
+	}
+	if _, err := ReconcileInvalidRecoveryEdge(context.Background(), repo, request); err == nil {
+		t.Fatal("reconcile replayed after the successor entry was quarantined")
+	}
+	writeSnapshotFile(t, repo, "tracked.txt", "reconciled target\n")
+	started, err := StartCompactAuthority(context.Background(), repo, CompactStartRequest{State: newCompactTestState(t, repo, "reconcile-fresh")})
+	if err != nil || started.Action != CompactStartRecover || started.Record.State.LineageID != predecessor.State.LineageID {
+		t.Fatalf("post-reconcile lineage-less start = %#v, %v", started, err)
+	}
+}
+
+func TestReconcileInvalidRecoveryEdgeRefusesIneligibleTargetsAndBindings(t *testing.T) {
+	assertUntouched := func(t *testing.T, repo string, store CompactStore, payload []byte) {
+		t.Helper()
+		current, err := os.ReadFile(store.StatePath())
+		if err != nil || !bytes.Equal(current, payload) {
+			t.Fatalf("refused reconcile mutated the successor entry: %q, %v", current, err)
+		}
+		root, _, err := reviewAuthorityRoot(context.Background(), repo)
+		if err != nil {
+			t.Fatal(err)
+		}
+		entries, err := os.ReadDir(filepath.Join(root, "quarantine"))
+		if err == nil && len(entries) != 0 {
+			t.Fatalf("refused reconcile left quarantine entries: %#v", entries)
+		}
+	}
+
+	t.Run("valid recovery edge", func(t *testing.T) {
+		repo := initSnapshotRepo(t)
+		state := correctedCompactTestState(t, repo, "reconcile-predecessor")
+		state.State = StateEscalated
+		predecessorStore, err := CompactAuthoritativeStore(context.Background(), repo, state.LineageID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		predecessor := writeCompactFixtureRecord(t, predecessorStore, state)
+		receipt, err := state.Receipt()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := WriteCompactReceiptAtomic(predecessorStore.ReceiptPath(), receipt); err != nil {
+			t.Fatal(err)
+		}
+		writeSnapshotFile(t, repo, "tracked.txt", "changed reconcile target\n")
+		successorState := newCompactTestState(t, repo, "reconcile-successor")
+		successorState.Generation = state.Generation + 1
+		recovery := CompactRecoveryRequest{
+			PredecessorLineageID: state.LineageID, ExpectedPredecessorRevision: predecessor.Revision,
+			Successor: successorState, Disposition: RecoveryEscalated,
+			Reason: "retry terminal validator", Actor: "maintainer@example.com",
+		}
+		recovery.MaintainerAuthorization = compactRecoveryAuthorizationBinding(state.LineageID, predecessor.Revision, successorState.InitialSnapshot.Identity, recovery.Actor, recovery.Reason)
+		successor, err := RecoverCompactAuthority(context.Background(), repo, recovery)
+		if err != nil {
+			t.Fatal(err)
+		}
+		successorStore, err := CompactAuthoritativeStore(context.Background(), repo, successor.State.LineageID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		payload, err := os.ReadFile(successorStore.StatePath())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := ReconcileInvalidRecoveryEdge(context.Background(), repo, reconcileFixtureRequest(predecessor, successor)); err == nil || !strings.Contains(err.Error(), "validates") {
+			t.Fatalf("claimed-invalid valid edge error = %v", err)
+		}
+		assertUntouched(t, repo, successorStore, payload)
+	})
+
+	t.Run("successor names a different predecessor", func(t *testing.T) {
+		repo := initSnapshotRepo(t)
+		predecessor, _, successor, successorStore := poisonedRecoveryFixture(t, repo, nil)
+		payload, err := os.ReadFile(successorStore.StatePath())
+		if err != nil {
+			t.Fatal(err)
+		}
+		request := reconcileFixtureRequest(predecessor, successor)
+		request.PredecessorLineageID = "reconcile-other"
+		if _, err := ReconcileInvalidRecoveryEdge(context.Background(), repo, request); err == nil || !strings.Contains(err.Error(), `names predecessor "reconcile-predecessor"`) {
+			t.Fatalf("mismatched predecessor lineage reconcile error = %v", err)
+		}
+		assertUntouched(t, repo, successorStore, payload)
+	})
+
+	t.Run("stale predecessor revision", func(t *testing.T) {
+		repo := initSnapshotRepo(t)
+		predecessor, _, successor, successorStore := poisonedRecoveryFixture(t, repo, nil)
+		payload, err := os.ReadFile(successorStore.StatePath())
+		if err != nil {
+			t.Fatal(err)
+		}
+		request := reconcileFixtureRequest(predecessor, successor)
+		request.ExpectedPredecessorRevision = successor.Revision
+		if _, err := ReconcileInvalidRecoveryEdge(context.Background(), repo, request); !errors.Is(err, ErrConcurrentUpdate) || !strings.Contains(err.Error(), "expected predecessor revision") {
+			t.Fatalf("stale predecessor revision reconcile error = %v", err)
+		}
+		assertUntouched(t, repo, successorStore, payload)
+	})
+
+	t.Run("predecessor does not load", func(t *testing.T) {
+		repo := initSnapshotRepo(t)
+		predecessor, predecessorStore, successor, successorStore := poisonedRecoveryFixture(t, repo, nil)
+		payload, err := os.ReadFile(successorStore.StatePath())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(predecessorStore.StatePath(), []byte("not json\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := ReconcileInvalidRecoveryEdge(context.Background(), repo, reconcileFixtureRequest(predecessor, successor)); err == nil || !strings.Contains(err.Error(), "load reconcile predecessor") {
+			t.Fatalf("unloadable predecessor reconcile error = %v", err)
+		}
+		assertUntouched(t, repo, successorStore, payload)
+	})
+
+	t.Run("unrelated authority does not load", func(t *testing.T) {
+		repo := initSnapshotRepo(t)
+		predecessor, _, successor, successorStore := poisonedRecoveryFixture(t, repo, nil)
+		payload, err := os.ReadFile(successorStore.StatePath())
+		if err != nil {
+			t.Fatal(err)
+		}
+		root, _, err := reviewAuthorityRoot(context.Background(), repo)
+		if err != nil {
+			t.Fatal(err)
+		}
+		writeReclaimFixtureFile(t, filepath.Join(root, "v2", "reconcile-unrelated", "review-state.json"), "not json\n")
+		if _, err := ReconcileInvalidRecoveryEdge(context.Background(), repo, reconcileFixtureRequest(predecessor, successor)); err == nil || !strings.Contains(err.Error(), `related compact authority "reconcile-unrelated" does not load`) {
+			t.Fatalf("unloadable unrelated authority reconcile error = %v", err)
+		}
+		assertUntouched(t, repo, successorStore, payload)
+	})
+
+	t.Run("predecessor has a sibling successor", func(t *testing.T) {
+		repo := initSnapshotRepo(t)
+		predecessor, _, successor, successorStore := poisonedRecoveryFixture(t, repo, nil)
+		payload, err := os.ReadFile(successorStore.StatePath())
+		if err != nil {
+			t.Fatal(err)
+		}
+		sibling := newCompactTestState(t, repo, "reconcile-sibling")
+		sibling.Generation = predecessor.State.Generation + 1
+		sibling.Recovery = &CompactRecoveryProvenance{
+			PredecessorLineageID: predecessor.State.LineageID, PredecessorRevision: predecessor.Revision,
+			Disposition: RecoveryEscalated, Reason: "sibling fork", Actor: "maintainer@example.com",
+			RecoveredAt:             time.Date(2026, 7, 18, 13, 0, 0, 0, time.UTC),
+			MaintainerAuthorization: compactRecoveryAuthorizationBinding(predecessor.State.LineageID, predecessor.Revision, sibling.InitialSnapshot.Identity, "maintainer@example.com", "sibling fork"),
+		}
+		siblingStore, err := CompactAuthoritativeStore(context.Background(), repo, sibling.LineageID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		writeCompactFixtureRecord(t, siblingStore, sibling)
+		if _, err := ReconcileInvalidRecoveryEdge(context.Background(), repo, reconcileFixtureRequest(predecessor, successor)); err == nil || !strings.Contains(err.Error(), `has another successor "reconcile-sibling"`) {
+			t.Fatalf("sibling fork reconcile error = %v", err)
+		}
+		assertUntouched(t, repo, successorStore, payload)
+	})
+
+	t.Run("successor has its own successor", func(t *testing.T) {
+		repo := initSnapshotRepo(t)
+		predecessor, _, successor, successorStore := poisonedRecoveryFixture(t, repo, nil)
+		payload, err := os.ReadFile(successorStore.StatePath())
+		if err != nil {
+			t.Fatal(err)
+		}
+		grandchild := newCompactTestState(t, repo, "reconcile-grandchild")
+		grandchild.Generation = successor.State.Generation + 1
+		grandchild.Recovery = &CompactRecoveryProvenance{
+			PredecessorLineageID: successor.State.LineageID, PredecessorRevision: successor.Revision,
+			Disposition: RecoveryEscalated, Reason: "descendant of the invalid successor", Actor: "maintainer@example.com",
+			RecoveredAt:             time.Date(2026, 7, 18, 14, 0, 0, 0, time.UTC),
+			MaintainerAuthorization: compactRecoveryAuthorizationBinding(successor.State.LineageID, successor.Revision, grandchild.InitialSnapshot.Identity, "maintainer@example.com", "descendant of the invalid successor"),
+		}
+		grandchildStore, err := CompactAuthoritativeStore(context.Background(), repo, grandchild.LineageID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		writeCompactFixtureRecord(t, grandchildStore, grandchild)
+		if _, err := ReconcileInvalidRecoveryEdge(context.Background(), repo, reconcileFixtureRequest(predecessor, successor)); err == nil || !strings.Contains(err.Error(), `has its own successor "reconcile-grandchild"`) {
+			t.Fatalf("descendant successor reconcile error = %v", err)
+		}
+		assertUntouched(t, repo, successorStore, payload)
+	})
+
+	t.Run("incomplete entry", func(t *testing.T) {
+		repo := initSnapshotRepo(t)
+		root, _, err := reviewAuthorityRoot(context.Background(), repo)
+		if err != nil {
+			t.Fatal(err)
+		}
+		writeReclaimFixtureFile(t, filepath.Join(root, "v2", "reconcile-successor", "stray.tmp"), "stray\n")
+		request := CompactReconcileRequest{
+			PredecessorLineageID: "reconcile-predecessor", ExpectedPredecessorRevision: hash("1"),
+			SuccessorLineageID: "reconcile-successor", ExpectedSuccessorRevision: hash("2"),
+			Reason: "residue", Actor: "maintainer",
+		}
+		if _, err := ReconcileInvalidRecoveryEdge(context.Background(), repo, request); err == nil || !strings.Contains(err.Error(), "review reclaim") {
+			t.Fatalf("incomplete entry reconcile error = %v", err)
+		}
+	})
+
+	t.Run("non-recovery record", func(t *testing.T) {
+		repo := initSnapshotRepo(t)
+		writeSnapshotFile(t, repo, "tracked.txt", "candidate\n")
+		state := newCompactTestState(t, repo, "reconcile-successor")
+		store, err := CompactAuthoritativeStore(context.Background(), repo, state.LineageID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		record := writeCompactFixtureRecord(t, store, state)
+		payload, err := os.ReadFile(store.StatePath())
+		if err != nil {
+			t.Fatal(err)
+		}
+		request := CompactReconcileRequest{
+			PredecessorLineageID: "reconcile-predecessor", ExpectedPredecessorRevision: hash("1"),
+			SuccessorLineageID: state.LineageID, ExpectedSuccessorRevision: record.Revision,
+			Reason: "residue", Actor: "maintainer",
+		}
+		if _, err := ReconcileInvalidRecoveryEdge(context.Background(), repo, request); err == nil || !strings.Contains(err.Error(), "not a recovery successor") {
+			t.Fatalf("non-recovery reconcile error = %v", err)
+		}
+		assertUntouched(t, repo, store, payload)
+	})
+
+	t.Run("missing authorization", func(t *testing.T) {
+		repo := initSnapshotRepo(t)
+		predecessor, _, successor, successorStore := poisonedRecoveryFixture(t, repo, nil)
+		payload, err := os.ReadFile(successorStore.StatePath())
+		if err != nil {
+			t.Fatal(err)
+		}
+		request := reconcileFixtureRequest(predecessor, successor)
+		request.MaintainerAuthorization = ""
+		if _, err := ReconcileInvalidRecoveryEdge(context.Background(), repo, request); err == nil || !strings.Contains(err.Error(), "exact maintainer authorization binding") {
+			t.Fatalf("missing authorization reconcile error = %v", err)
+		}
+		assertUntouched(t, repo, successorStore, payload)
+	})
+
+	t.Run("authorization bound to different content", func(t *testing.T) {
+		repo := initSnapshotRepo(t)
+		predecessor, _, successor, successorStore := poisonedRecoveryFixture(t, repo, nil)
+		payload, err := os.ReadFile(successorStore.StatePath())
+		if err != nil {
+			t.Fatal(err)
+		}
+		request := reconcileFixtureRequest(predecessor, successor)
+		request.MaintainerAuthorization = compactReconcileAuthorizationBinding(
+			request.PredecessorLineageID, successor.Revision, request.SuccessorLineageID, predecessor.Revision,
+			request.Actor, request.Reason)
+		if _, err := ReconcileInvalidRecoveryEdge(context.Background(), repo, request); err == nil || !strings.Contains(err.Error(), "exact maintainer authorization binding") {
+			t.Fatalf("mismatched authorization reconcile error = %v", err)
+		}
+		assertUntouched(t, repo, successorStore, payload)
+	})
+
+	t.Run("stale successor revision", func(t *testing.T) {
+		repo := initSnapshotRepo(t)
+		predecessor, _, successor, successorStore := poisonedRecoveryFixture(t, repo, nil)
+		payload, err := os.ReadFile(successorStore.StatePath())
+		if err != nil {
+			t.Fatal(err)
+		}
+		request := reconcileFixtureRequest(predecessor, successor)
+		request.ExpectedSuccessorRevision = predecessor.Revision
+		if _, err := ReconcileInvalidRecoveryEdge(context.Background(), repo, request); !errors.Is(err, ErrConcurrentUpdate) {
+			t.Fatalf("stale successor revision reconcile error = %v", err)
+		}
+		assertUntouched(t, repo, successorStore, payload)
+	})
+
+	t.Run("edge invalid outside the unchanged-target class", func(t *testing.T) {
+		repo := initSnapshotRepo(t)
+		predecessor, _, successor, successorStore := poisonedRecoveryFixture(t, repo, func(state *CompactState) {
+			state.Generation = 1
+		})
+		payload, err := os.ReadFile(successorStore.StatePath())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := ReconcileInvalidRecoveryEdge(context.Background(), repo, reconcileFixtureRequest(predecessor, successor)); err == nil || !strings.Contains(err.Error(), "outside the unchanged-target class") {
+			t.Fatalf("other-class reconcile error = %v", err)
+		}
+		assertUntouched(t, repo, successorStore, payload)
+	})
+
+	t.Run("recorded recovery binding inexact", func(t *testing.T) {
+		repo := initSnapshotRepo(t)
+		predecessor, _, successor, successorStore := poisonedRecoveryFixture(t, repo, func(state *CompactState) {
+			state.Recovery.MaintainerAuthorization = compactRecoveryAuthorizationBinding(
+				state.Recovery.PredecessorLineageID, state.Recovery.PredecessorRevision,
+				state.InitialSnapshot.Identity, state.Recovery.Actor, "different reason")
+		})
+		payload, err := os.ReadFile(successorStore.StatePath())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := ReconcileInvalidRecoveryEdge(context.Background(), repo, reconcileFixtureRequest(predecessor, successor)); err == nil || !strings.Contains(err.Error(), "sole anomaly") {
+			t.Fatalf("inexact recorded binding reconcile error = %v", err)
+		}
+		assertUntouched(t, repo, successorStore, payload)
+	})
+}
+
+func TestReconcileCrashBeforeRenameLeavesPreparedOrphanAndRetrySucceeds(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	predecessor, _, successor, successorStore := poisonedRecoveryFixture(t, repo, nil)
+	root, _, err := reviewAuthorityRoot(context.Background(), repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	original := reclaimQuarantineResidue
+	reclaimQuarantineResidue = func(string, string) error {
+		return errors.New("simulated crash before residue rename")
+	}
+	t.Cleanup(func() { reclaimQuarantineResidue = original })
+	request := reconcileFixtureRequest(predecessor, successor)
+	prepared, err := ReconcileInvalidRecoveryEdge(context.Background(), repo, request)
+	if err == nil {
+		t.Fatal("interrupted reconcile reported success")
+	}
+	if prepared.Status != CompactReclaimPrepared || prepared.QuarantinePath == "" || prepared.InvalidRecoveryEdge == nil {
+		t.Fatalf("rename-failure reconcile record = %#v", prepared)
+	}
+	if !strings.Contains(err.Error(), prepared.QuarantinePath) {
+		t.Fatalf("rename failure hides the prepared quarantine location: %v", err)
+	}
+	if _, statErr := os.Stat(successorStore.StatePath()); statErr != nil {
+		t.Fatalf("interrupted reconcile mutated the successor entry: %v", statErr)
+	}
+	var orphan CompactReclaimRecord
+	orphanPayload, err := os.ReadFile(filepath.Join(prepared.QuarantinePath, "reclaim-record.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(orphanPayload, &orphan); err != nil {
+		t.Fatal(err)
+	}
+	if orphan.Status != CompactReclaimPrepared || orphan.InvalidRecoveryEdge == nil ||
+		!strings.Contains(orphan.InvalidRecoveryEdge.ValidationError, "target has not changed") {
+		t.Fatalf("orphan reconcile record = %#v", orphan)
+	}
+	if _, err := os.Stat(filepath.Join(prepared.QuarantinePath, "residue")); !os.IsNotExist(err) {
+		t.Fatalf("orphan quarantine claims residue it never received: %v", err)
+	}
+
+	reclaimQuarantineResidue = original
+	record, err := ReconcileInvalidRecoveryEdge(context.Background(), repo, request)
+	if err != nil {
+		t.Fatalf("retry after interrupted reconcile: %v", err)
+	}
+	if record.Status != CompactReclaimCommitted || record.QuarantinePath == prepared.QuarantinePath {
+		t.Fatalf("retry reconcile record = %#v", record)
+	}
+	if _, err := os.Stat(successorStore.Dir); !os.IsNotExist(err) {
+		t.Fatalf("retried reconcile left the successor entry behind: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "quarantine")); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestReconcileCommitRewriteFailureReturnsPreparedRecordWithQuarantine(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	predecessor, _, successor, successorStore := poisonedRecoveryFixture(t, repo, nil)
+	successorPayload, err := os.ReadFile(successorStore.StatePath())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	original := persistReclaimRecord
+	persistReclaimRecord = func(record CompactReclaimRecord) error {
+		if record.Status == CompactReclaimCommitted {
+			return errors.New("simulated crash before committed rewrite")
+		}
+		return original(record)
+	}
+	t.Cleanup(func() { persistReclaimRecord = original })
+	record, err := ReconcileInvalidRecoveryEdge(context.Background(), repo, reconcileFixtureRequest(predecessor, successor))
+	if err == nil {
+		t.Fatal("failed committed rewrite reported success")
+	}
+	if record.Status != CompactReclaimPrepared || record.QuarantinePath == "" || record.InvalidRecoveryEdge == nil {
+		t.Fatalf("committed-rewrite failure reconcile record = %#v", record)
+	}
+	if !strings.Contains(err.Error(), record.QuarantinePath) {
+		t.Fatalf("committed-rewrite failure hides the quarantine location: %v", err)
+	}
+	if _, statErr := os.Stat(successorStore.Dir); !os.IsNotExist(statErr) {
+		t.Fatalf("committed-rewrite failure left the successor entry behind: %v", statErr)
+	}
+	moved, readErr := os.ReadFile(filepath.Join(record.QuarantinePath, "residue", "review-state.json"))
+	if readErr != nil || !bytes.Equal(moved, successorPayload) {
+		t.Fatalf("quarantined successor bytes = %q, %v", moved, readErr)
+	}
+
+	// The successor entry is gone, so a retry must refuse and point the
+	// operator at the quarantine root where the prepared record lives.
+	persistReclaimRecord = original
+	root, _, err := reviewAuthorityRoot(context.Background(), repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, retryErr := ReconcileInvalidRecoveryEdge(context.Background(), repo, reconcileFixtureRequest(predecessor, successor))
+	if !errors.Is(retryErr, os.ErrNotExist) || !strings.Contains(retryErr.Error(), filepath.Join(root, "quarantine")) ||
+		!strings.Contains(retryErr.Error(), "reclaim-record.json") {
+		t.Fatalf("retry after quarantined successor = %v", retryErr)
+	}
+}

--- a/internal/reviewtransaction/compact_store.go
+++ b/internal/reviewtransaction/compact_store.go
@@ -37,6 +37,10 @@ var compactStartLockPollInterval = 25 * time.Millisecond
 
 var ErrLegacyReadOnly = errors.New("legacy v1 review lineage is read-only")
 
+// errCompactRecoveryTargetUnchanged identifies the unchanged-target recovery
+// anomaly so reconcile-authority can gate quarantine to exactly this class.
+var errCompactRecoveryTargetUnchanged = errors.New("escalated recovery successor target has not changed")
+
 // ErrHistoricalCompatReadOnly denies ordinary mutation of authority loaded
 // through the retired-field compatibility path.
 var ErrHistoricalCompatReadOnly = errors.New("historical compatibility authority is read-only")
@@ -340,7 +344,7 @@ func validateCompactRecoveryEdge(predecessor CompactRecord, successor CompactSta
 			return errors.New("recovery requires an escalated predecessor")
 		}
 		if !compactEscalatedRecoveryTargetChanged(predecessor.State.CurrentSnapshot, successor.InitialSnapshot) {
-			return errors.New("escalated recovery successor target has not changed")
+			return errCompactRecoveryTargetUnchanged
 		}
 		if recovery.MaintainerAuthorization != compactRecoveryAuthorizationBinding(predecessor.State.LineageID, predecessor.Revision, successor.InitialSnapshot.Identity, recovery.Actor, recovery.Reason) {
 			return compactRecoveryAuthorizationError(successor.InitialSnapshot)


### PR DESCRIPTION
## Summary

Fixes #1419: a PRESENT, parseable recovery successor whose edge fails semantic validation (unchanged-target class) poisoned the entire authority graph — `CompactAuthorityLeaves` validates every historical edge, so status/start/validate failed closed repo-wide, and `review reclaim` deliberately refuses entries holding authoritative state. No sanctioned escape existed.

New audited `gentle-ai review reconcile-authority` (the issue's named operation):

- **Native re-derivation, never trusts the caller**: under the shared v2 LOCK it re-runs the exact graph validation; eligible only when the edge fails with the promoted `errCompactRecoveryTargetUnchanged` sentinel (`errors.Is`, single unwrapped producer), the recorded provenance authorization recomputes exactly (an inexact binding means the unchanged target is NOT the sole anomaly → refused — the #1393 class boundary), the successor is the predecessor's sole child with no successors of its own, and the remaining graph validates without it. A claimed-invalid edge that actually validates is a hard refusal.
- **Seven-line content-addressed maintainer authorization** — unreplayable; stale expected revisions fail `ErrConcurrentUpdate` before binding comparison.
- **Shared two-phase quarantine machinery** with reclaim (extracted `quarantineCompactStoreEntry`): move-never-delete, prepared→committed audited record extended with the `invalid_recovery_edge` proof. Predecessor bytes pinned untouched; post-reconcile, leaves/status/lineage-less start work again.
- Bidirectional reclaim↔reconcile cross-references and an accurate two-way remedy for the interrupted-reconcile retry window.

## Tests

12 refusal subtests (every eligibility condition pinned with byte-immutability + empty-quarantine assertions; guard tests proven to bite via a mutation check), 3 crash-window tests on the shared seams, end-to-end CLI tests (poisoned → denied → reconcile → authoritative → replay refused).

4R bounded review, two rounds, zero severe findings; round 2 verified no-drift line-by-line and on-disk after a mid-delta rewrite incident. Rebased onto current main post-approval (base advance only; the installed 2.1.7 gate binary predates the merged #1376 reconciliation covering this).

Fixes #1419. Related: #1393, #1392.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `review reconcile-authority` to reconcile invalid recovery edges and quarantine affected authority data.
  - `gentle-ai review --help` now lists `reconcile-authority`.
  - Emits JSON audit output on success, and on certain failure outcomes where quarantine is produced.
- **Bug Fixes**
  - Improved messaging/handling for “unchanged-target” invalid recovery anomalies.
  - Better restores authority discovery/state after quarantining invalid successors.
  - Clarified `review reclaim` help for quarantined invalid successors.
- **Tests**
  - Added end-to-end CLI and transaction-level coverage, including strict required flag and exact binding validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->