### PR TITLE
fix(review): route dirty next-slice workspace as scope-changed

### DIFF
--- a/internal/cli/review_receipt_discovery_test.go
+++ b/internal/cli/review_receipt_discovery_test.go
@@ -177,6 +177,63 @@ func TestUnqualifiedGateDiscoveryReturnsTypedMissingAndScopeChanged(t *testing.T
 			t.Fatalf("unrelated receipt failure = %#v", failure)
 		}
 	})
+
+	t.Run("dirty next slice after committed approved", func(t *testing.T) {
+		repo := initReviewCLIRepo(t)
+		started, _ := approveDiscoveryMarkdown(t, repo, "review-discovery-next-slice", "docs/reviewed.md", "reviewed\n")
+		runReviewCLIGit(t, repo, "add", "-A")
+		runReviewCLIGit(t, repo, "commit", "-qm", "reviewed slice a")
+		if err := os.WriteFile(filepath.Join(repo, "docs", "reviewed.md"), []byte("slice b dirty tracked\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(repo, "docs", "next-slice.md"), []byte("slice b untracked\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		var unqualified bytes.Buffer
+		err := RunReview([]string{
+			"validate", "--contract", ReviewIntegrationContractV1, "--cwd", repo,
+			"--gate", string(reviewtransaction.GatePostApply),
+		}, &unqualified)
+		if err == nil {
+			t.Fatal("dirty next-slice unqualified validation succeeded")
+		}
+		failure := decodeReviewIntegrationFailure(t, unqualified.Bytes())
+		if failure.Code == "authority_corrupted" || strings.Contains(unqualified.String(), "committed approved target has dirty tracked changes") {
+			t.Fatalf("healthy committed predecessor misrouted as corrupted: %#v\n%s", failure, unqualified.String())
+		}
+		if failure.Code != "receipt_scope_changed" || failure.AuthorityApplicability != "current_target" || failure.RetrySafe ||
+			failure.Replayability != reviewtransaction.ReplayabilityManualActionRequired || failure.NextAction != "explicit-maintainer-action" {
+			t.Fatalf("dirty next-slice unqualified failure = %#v", failure)
+		}
+		if failure.Context == nil || failure.Context.ScopeChange == nil {
+			t.Fatalf("dirty next-slice missing scope-change recovery context: %#v", failure)
+		}
+		scope := failure.Context.ScopeChange
+		if scope.PredecessorLineageID != started.LineageID || scope.PredecessorRevision == "" || scope.DifferingPathCount < 1 ||
+			!reflect.DeepEqual(failure.RequiredInputs, []string{"predecessor_lineage_id", "expected_predecessor_revision", "successor_lineage_id", "disposition", "reason", "actor"}) {
+			t.Fatalf("dirty next-slice scope-change provenance = %#v", failure)
+		}
+		payload, marshalErr := json.Marshal(failure)
+		if marshalErr != nil || strings.Contains(string(payload), "docs/reviewed.md") || strings.Contains(string(payload), "docs/next-slice.md") ||
+			strings.Contains(string(payload), `"paths"`) || strings.Contains(string(payload), `"differing_paths"`) {
+			t.Fatalf("dirty next-slice failure exposed private paths: %s, %v", payload, marshalErr)
+		}
+
+		var explicit bytes.Buffer
+		err = RunReview([]string{
+			"validate", "--contract", ReviewIntegrationContractV1, "--cwd", repo,
+			"--lineage", started.LineageID, "--gate", string(reviewtransaction.GatePostApply),
+		}, &explicit)
+		if err == nil {
+			t.Fatal("dirty next-slice explicit lineage validation succeeded")
+		}
+		explicitFailure := decodeReviewIntegrationFailure(t, explicit.Bytes())
+		if explicitFailure.Code != "gate_scope_changed" || explicitFailure.NextAction != "explicit-maintainer-action" || explicitFailure.RetrySafe ||
+			strings.Contains(explicit.String(), "committed approved target has dirty tracked changes") || strings.Contains(explicit.String(), "authority_corrupted") {
+			t.Fatalf("explicit healthy predecessor misrouted: %#v\n%s", explicitFailure, explicit.String())
+		}
+	})
 }
 
 func TestUnqualifiedGateDiscoveryRejectsMultipleExactReceiptsButExplicitLineageIsDirect(t *testing.T) {

--- a/internal/reviewtransaction/compact_gate.go
+++ b/internal/reviewtransaction/compact_gate.go
@@ -60,15 +60,22 @@ func AssessCompactGateTarget(ctx context.Context, repo string, state CompactStat
 	if err != nil {
 		return assessment, fmt.Errorf("derive compact gate target: %w", err)
 	}
-	if err := validateCompactUntrackedScope(ctx, repo, state, request); err != nil {
-		assessment.Applicability = CompactGateTargetScopeChanged
-		return assessment, nil
-	}
+	untrackedScopeErr := validateCompactUntrackedScope(ctx, repo, state, request)
 	snapshot, resolvedPrePR, err := buildCompactLifecycleSnapshot(ctx, repo, request)
 	if err != nil {
+		if untrackedScopeErr != nil {
+			// Expanded untracked workspace is still a scope change against the
+			// frozen receipt even when the live candidate cannot be materialized.
+			assessment.Applicability = CompactGateTargetScopeChanged
+			return assessment, nil
+		}
 		return assessment, fmt.Errorf("build compact gate target: %w", err)
 	}
 	assessment.Actual = snapshot
+	if untrackedScopeErr != nil {
+		assessment.Applicability = CompactGateTargetScopeChanged
+		return assessment, nil
+	}
 	squashedFixDelivery := compactSquashedFixDelivery(request.Gate, state, snapshot, resolvedPrePR, state.CurrentSnapshot.CandidateTree)
 	strictBinding := request.Gate == GatePostApply || request.Gate == GatePreCommit ||
 		request.Gate == GatePrePush && state.InitialSnapshot.Kind != TargetCurrentChanges
@@ -175,11 +182,16 @@ func EvaluateCompactGate(ctx context.Context, repo string, receipt CompactReceip
 		return invalid("compact gate inputs cannot be derived: "+err.Error(), err)
 	}
 	if (request.Gate == GatePostApply || request.Gate == GatePreCommit) && !equalStrings(request.Target.IntendedUntracked, record.State.CurrentSnapshot.IntendedUntracked) {
-		return invalid("current repository target does not retain the authoritative intended-untracked paths")
+		// After an exact committed delivery, frozen intended-untracked may already
+		// be absorbed into HEAD. Live next-slice targets may therefore diverge
+		// and must be classified by candidate/path comparison, not rejected as
+		// corrupted authority.
+		headTree, headErr := (SnapshotBuilder{Repo: repo}).resolveTree(ctx, "HEAD")
+		if headErr != nil || headTree != record.State.CurrentSnapshot.CandidateTree {
+			return invalid("current repository target does not retain the authoritative intended-untracked paths")
+		}
 	}
-	if err := validateCompactUntrackedScope(ctx, repo, record.State, request); err != nil {
-		return invalid(err.Error())
-	}
+	untrackedScopeErr := validateCompactUntrackedScope(ctx, repo, record.State, request)
 	preimages, err := readGateArtifactPreimages(request)
 	if err != nil {
 		return invalid("compact gate evidence cannot be read: " + err.Error())
@@ -189,7 +201,25 @@ func EvaluateCompactGate(ctx context.Context, repo string, receipt CompactReceip
 	}
 	snapshot, resolvedPrePR, err := buildCompactLifecycleSnapshot(ctx, repo, request)
 	if err != nil {
+		if untrackedScopeErr != nil {
+			denialContext.Denial = &GateDenial{Stage: "receipt-binding", Code: "candidate-or-paths-mismatch"}
+			return NativeGateEvaluation{Result: GateScopeChanged, Reason: nativeGateReason(GateScopeChanged), Context: denialContext}
+		}
 		return invalid("current repository target cannot be derived: "+err.Error(), err)
+	}
+	if untrackedScopeErr != nil {
+		gateContext := denialContext
+		gateContext.BaseTree = snapshot.BaseTree
+		gateContext.CandidateTree = snapshot.CandidateTree
+		gateContext.PathsDigest = snapshot.PathsDigest
+		gateContext.Denial = &GateDenial{Stage: "receipt-binding", Code: "candidate-or-paths-mismatch"}
+		diagnostics, diagnosticsErr := buildCompactScopeChangeDiagnostics(ctx, repo, record.State, record.Revision, snapshot)
+		if diagnosticsErr != nil {
+			gateContext.Denial = &GateDenial{Stage: "receipt-binding", Code: "scope-diagnostics-unavailable"}
+			return NativeGateEvaluation{Result: GateInvalidated, Reason: "exact scope-change diagnostics cannot be derived: " + diagnosticsErr.Error(), Context: gateContext}
+		}
+		gateContext.ScopeChange = &diagnostics
+		return NativeGateEvaluation{Result: GateScopeChanged, Reason: nativeGateReason(GateScopeChanged), Context: gateContext}
 	}
 	if request.Gate == GatePrePush && record.State.InitialSnapshot.Kind == TargetCurrentChanges && snapshot.BaseTree == snapshot.CandidateTree {
 		return invalid("pre-push current-changes receipt requires a delivered tree change")
@@ -398,7 +428,21 @@ func buildCompactGateRequest(ctx context.Context, repo string, state CompactStat
 				return GateRequest{}, err
 			}
 			if dirty {
-				return GateRequest{}, errors.New("committed approved target has dirty tracked changes")
+				// Exact committed delivery plus a dirty next-slice workspace is a
+				// live current-changes target. Frozen intended-untracked may already
+				// be tracked in HEAD, so bind only still-live untracked paths.
+				// Assessment/evaluation compare the live candidate and route
+				// scope-changed/unrelated instead of treating healthy predecessor
+				// authority as corrupted.
+				liveIntended := []string{}
+				if projection != ProjectionStaged {
+					liveIntended, err = liveNextSliceIntendedUntracked(ctx, repo)
+					if err != nil {
+						return GateRequest{}, err
+					}
+				}
+				request.Target = Target{Kind: TargetCurrentChanges, Projection: projection, IntendedUntracked: liveIntended}
+				break
 			}
 			request.Target = Target{Kind: TargetBaseDiff, Projection: projection, BaseRef: current.BaseTree, IntendedUntracked: intended}
 			break
@@ -511,6 +555,27 @@ func validateCompactPublicationRange(ctx context.Context, repo string, genesis [
 func isPostReviewLifecycleArtifact(path string) bool {
 	parts := strings.Split(path, "/")
 	return len(parts) == 4 && parts[0] == "openspec" && parts[1] == "changes" && parts[3] == "verify-report.md"
+}
+
+// liveNextSliceIntendedUntracked returns still-untracked workspace paths that
+// belong to a live next-slice target after an exact committed delivery. Post-
+// review lifecycle artifacts are excluded so they do not inflate scope.
+func liveNextSliceIntendedUntracked(ctx context.Context, repo string) ([]string, error) {
+	live, err := (SnapshotBuilder{Repo: repo}).DiscoverIntendedUntracked(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("discover live next-slice untracked paths: %w", err)
+	}
+	intended := make([]string, 0, len(live))
+	for _, path := range live {
+		if isPostReviewLifecycleArtifact(path) || isChangeLocalReceiptMirror(path) {
+			continue
+		}
+		intended = append(intended, path)
+	}
+	if intended == nil {
+		intended = []string{}
+	}
+	return canonicalPaths(intended)
 }
 
 func isChangeLocalReceiptMirror(path string) bool {

--- a/internal/reviewtransaction/compact_gate_test.go
+++ b/internal/reviewtransaction/compact_gate_test.go
@@ -608,6 +608,72 @@ func TestCompactCommittedGateRechecksConcurrentDirtyTrackedTarget(t *testing.T) 
 	}
 }
 
+func TestCompactPostApplyRoutesDirtyNextSliceAfterCommittedApprovedTarget(t *testing.T) {
+	tests := []struct {
+		name       string
+		dirty      func(t *testing.T, repo string)
+		assessment CompactGateTargetApplicability
+		gateResult GateResult
+	}{
+		{
+			name: "dirty tracked reviewed path",
+			dirty: func(t *testing.T, repo string) {
+				writeSnapshotFile(t, repo, "tracked.txt", "next slice dirty tracked\n")
+			},
+			assessment: CompactGateTargetScopeChanged,
+			gateResult: GateScopeChanged,
+		},
+		{
+			name: "dirty tracked unrelated path",
+			dirty: func(t *testing.T, repo string) {
+				writeSnapshotFile(t, repo, "next-slice.txt", "next slice tracked\n")
+				gitSnapshot(t, repo, "add", "--", "next-slice.txt")
+			},
+			assessment: CompactGateTargetUnrelated,
+			gateResult: GateScopeChanged,
+		},
+		{
+			name: "dirty tracked and unbound untracked",
+			dirty: func(t *testing.T, repo string) {
+				writeSnapshotFile(t, repo, "tracked.txt", "next slice dirty tracked\n")
+				writeSnapshotFile(t, repo, "next-untracked.txt", "next slice untracked\n")
+			},
+			assessment: CompactGateTargetScopeChanged,
+			gateResult: GateScopeChanged,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := initSnapshotRepo(t)
+			writeSnapshotFile(t, repo, "tracked.txt", "approved candidate\n")
+			state := newCompactStartStateForTarget(t, repo, "compact-next-slice-"+strings.ReplaceAll(tt.name, " ", "-"), Target{Kind: TargetCurrentChanges, IntendedUntracked: []string{}})
+			state, receipt := persistApprovedCompactState(t, repo, state)
+			gitSnapshot(t, repo, "add", "tracked.txt")
+			gitSnapshot(t, repo, "commit", "-m", "reviewed candidate")
+			if control := EvaluateCompactGate(context.Background(), repo, receipt, NativeGateRequestInput{Gate: GatePostApply, LineageID: state.LineageID}); control.Result != GateAllow {
+				t.Fatalf("clean committed predecessor = %#v", control)
+			}
+
+			tt.dirty(t, repo)
+			input := NativeGateRequestInput{Gate: GatePostApply, LineageID: state.LineageID}
+			assessment, err := AssessCompactGateTarget(context.Background(), repo, state, input)
+			if err != nil {
+				t.Fatalf("assess dirty next-slice target: %v", err)
+			}
+			if assessment.Applicability != tt.assessment {
+				t.Fatalf("assessment = %#v, want %q", assessment, tt.assessment)
+			}
+			got := EvaluateCompactGate(context.Background(), repo, receipt, input)
+			if got.Result != tt.gateResult {
+				t.Fatalf("explicit lineage gate = %#v, want %q", got, tt.gateResult)
+			}
+			if strings.Contains(got.Reason, "committed approved target has dirty tracked changes") || strings.Contains(got.Reason, "authority") {
+				t.Fatalf("healthy predecessor misrouted as corruption: %#v", got)
+			}
+		})
+	}
+}
+
 func TestCompactReleaseGateUsesIndependentCompleteCurrentEvidence(t *testing.T) {
 	repo := initSnapshotRepo(t)
 	writeSnapshotFile(t, repo, "tracked.txt", "candidate\n")


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1401

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- After an approved candidate is committed exactly, a dirty next-slice workspace no longer fails compact gate input derivation as if authority were corrupted.
- Post-apply discovery builds a live `current-changes` target and classifies the next work unit as `scope-changed` (or unrelated), keeping the healthy predecessor intact.
- Explicit lineage validation returns `gate_scope_changed` with recovery context instead of `invalidated` / `authority_corrupted`.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/reviewtransaction/compact_gate.go` | On exact committed delivery + dirty workspace, bind live current-changes (still-untracked paths only); treat unbound untracked as scope-changed with diagnostics |
| `internal/reviewtransaction/compact_gate_test.go` | Cover dirty tracked, unrelated dirty path, and dirty+untracked next-slice routing after commit |
| `internal/cli/review_receipt_discovery_test.go` | Cover unqualified + explicit post-apply discovery after committed approved + dirty next slice |

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./internal/reviewtransaction/ -count=1
go test ./internal/cli/ -run 'Review|Receipt|Gate|Discovery|Compact' -count=1
```

**Go Format**
```bash
go run ./internal/gofmtcheck
```

- [x] Unit tests pass (`go test` on affected packages)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Manually verified via focused regression tests for the #1401 repro path

---

## 🤖 Automated Checks

The following checks run automatically on this PR:

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | PR should stay within 400 changed lines (`additions + deletions`) or use `size:exception` |
| Check Issue Reference | ⏳ | PR body must contain `Closes/Fixes/Resolves #N` |
| Check Issue Has `status:approved` | ⏳ | Linked issue must have been approved before work began |
| Check PR Has `type:*` Label | ⏳ | Exactly one `type:*` label must be applied |
| Unit Tests | ⏳ | `go test ./...` must pass |
| Go Format | ⏳ | `go run ./internal/gofmtcheck` must pass |
| E2E Tests | ⏳ | `cd e2e && ./docker-test.sh` must pass |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test` on affected packages)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

Root cause was early rejection in `buildCompactGateRequest` when `HEAD` equaled the approved candidate tree and dirty tracked changes existed. That prevented `AssessCompactGateTarget` from comparing the live candidate, so unqualified discovery mapped the sole unknown assessment to `authority_corrupted`.

After exact delivery, frozen intended-untracked may already be tracked in `HEAD`; the live next-slice target therefore discovers still-untracked paths only. Concurrent dirty TOCTOU on a clean committed `TargetBaseDiff` path remains invalidated via `validateCompactCommittedTrackedScope`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation when changes are detected after an approved state has been committed.
  * Correctly distinguishes scope changes from unrelated workspace changes.
  * Provides clearer recovery guidance without exposing private file paths or diff details.
  * Prevents healthy predecessor states from being incorrectly reported as corrupted.
  * Preserves intended untracked changes while excluding review-related artifacts from scope evaluation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->