### PR TITLE
fix(review): route committed next-slice workspace to fresh review

### DIFF
--- a/internal/cli/review_receipt_discovery_test.go
+++ b/internal/cli/review_receipt_discovery_test.go
@@ -179,6 +179,63 @@ func TestUnqualifiedGateDiscoveryReturnsTypedMissingAndScopeChanged(t *testing.T
 	})
 }
 
+func TestUnqualifiedGateDiscoveryRoutesCommittedNextSliceWorkspace(t *testing.T) {
+	// #1401: after one approved slice is committed exactly as reviewed, new
+	// dirty tracked work on top must classify as unrelated or scope-changed,
+	// never as authority_corrupted against the healthy predecessor.
+	t.Run("unrelated dirty tracked next slice", func(t *testing.T) {
+		repo := initReviewCLIRepo(t)
+		_, _ = approveDiscoveryMarkdown(t, repo, "review-discovery-next-slice", "docs/reviewed.md", "reviewed\n")
+		runReviewCLIGit(t, repo, "add", "-A")
+		runReviewCLIGit(t, repo, "commit", "-qm", "reviewed target")
+		if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("next slice\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		var output bytes.Buffer
+		err := RunReview([]string{
+			"validate", "--contract", ReviewIntegrationContractV1, "--cwd", repo,
+			"--gate", string(reviewtransaction.GatePostApply),
+		}, &output)
+		if err == nil {
+			t.Fatal("next-slice workspace validation succeeded")
+		}
+		failure := decodeReviewIntegrationFailure(t, output.Bytes())
+		if failure.Code == "authority_corrupted" {
+			t.Fatalf("healthy committed receipt misrouted as corrupted: %#v", failure)
+		}
+		if failure.Code != "receipt_unrelated" || failure.AuthorityApplicability != "unrelated" || failure.RetrySafe || failure.NextAction != "stop" {
+			t.Fatalf("committed next-slice workspace failure = %#v", failure)
+		}
+	})
+
+	t.Run("overlapping dirty tracked next slice", func(t *testing.T) {
+		repo := initReviewCLIRepo(t)
+		_, _ = approveDiscoveryMarkdown(t, repo, "review-discovery-next-slice-overlap", "docs/reviewed.md", "reviewed\n")
+		runReviewCLIGit(t, repo, "add", "-A")
+		runReviewCLIGit(t, repo, "commit", "-qm", "reviewed target")
+		if err := os.WriteFile(filepath.Join(repo, "docs", "reviewed.md"), []byte("drifted after commit\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		var output bytes.Buffer
+		err := RunReview([]string{
+			"validate", "--contract", ReviewIntegrationContractV1, "--cwd", repo,
+			"--gate", string(reviewtransaction.GatePostApply),
+		}, &output)
+		if err == nil {
+			t.Fatal("overlapping next-slice validation succeeded")
+		}
+		failure := decodeReviewIntegrationFailure(t, output.Bytes())
+		if failure.Code == "authority_corrupted" {
+			t.Fatalf("healthy committed receipt misrouted as corrupted: %#v", failure)
+		}
+		if failure.Code != "receipt_scope_changed" || failure.AuthorityApplicability != "current_target" || failure.RetrySafe ||
+			failure.Replayability != reviewtransaction.ReplayabilityManualActionRequired || failure.NextAction != "explicit-maintainer-action" {
+			t.Fatalf("overlapping next-slice failure = %#v", failure)
+		}
+		assertScopeChangeRecovery(t, failure, "review-discovery-next-slice-overlap", "docs/reviewed.md")
+	})
+}
+
 func TestUnqualifiedGateDiscoveryRejectsMultipleExactReceiptsButExplicitLineageIsDirect(t *testing.T) {
 	repo := initReviewCLIRepo(t)
 	started, store := approveDiscoveryMarkdown(t, repo, "review-discovery-exact-a", "docs/exact.md", "exact\n")

--- a/internal/reviewtransaction/compact_gate.go
+++ b/internal/reviewtransaction/compact_gate.go
@@ -44,7 +44,10 @@ func AssessCompactGateTarget(ctx context.Context, repo string, state CompactStat
 	if input.IntendedUntracked == nil {
 		input.IntendedUntracked = append([]string{}, state.CurrentSnapshot.IntendedUntracked...)
 	}
-	request, err := buildCompactGateRequest(ctx, repo, state, input)
+	// The next-slice intended set is only meaningful to EvaluateCompactGate's
+	// intended-retention guard; applicability here derives purely from the
+	// request target and snapshot comparison, so the signal is discarded.
+	request, _, err := buildCompactGateRequest(ctx, repo, state, input)
 	if err != nil && input.Gate == GateRelease {
 		head, headErr := resolveCommit(ctx, repo, "HEAD")
 		if headErr == nil {
@@ -166,7 +169,7 @@ func EvaluateCompactGate(ctx context.Context, repo string, receipt CompactReceip
 	if receipt.TerminalState == TerminalEscalated {
 		return NativeGateEvaluation{Result: GateEscalated, Reason: nativeGateReason(GateEscalated)}
 	}
-	request, err := buildCompactGateRequest(ctx, repo, record.State, input)
+	request, nextSliceIntended, err := buildCompactGateRequest(ctx, repo, record.State, input)
 	if err != nil {
 		if input.Gate == GatePrePR {
 			denialContext.Denial = &GateDenial{Stage: "boundary-selection", Code: "unavailable"}
@@ -174,7 +177,14 @@ func EvaluateCompactGate(ctx context.Context, repo string, receipt CompactReceip
 		}
 		return invalid("compact gate inputs cannot be derived: "+err.Error(), err)
 	}
-	if (request.Gate == GatePostApply || request.Gate == GatePreCommit) && !equalStrings(request.Target.IntendedUntracked, record.State.CurrentSnapshot.IntendedUntracked) {
+	expectedIntended := record.State.CurrentSnapshot.IntendedUntracked
+	if nextSliceIntended != nil {
+		// The approved candidate is committed exactly and its frozen intended
+		// paths are tracked in HEAD; only the already-computed still-untracked
+		// subset can be retained by the live next-slice target.
+		expectedIntended = nextSliceIntended
+	}
+	if (request.Gate == GatePostApply || request.Gate == GatePreCommit) && !equalStrings(request.Target.IntendedUntracked, expectedIntended) {
 		return invalid("current repository target does not retain the authoritative intended-untracked paths")
 	}
 	if err := validateCompactUntrackedScope(ctx, repo, record.State, request); err != nil {
@@ -361,8 +371,16 @@ func buildCompactLifecycleSnapshot(ctx context.Context, repo string, request Gat
 	return buildLifecycleSnapshot(ctx, repo, request)
 }
 
-func buildCompactGateRequest(ctx context.Context, repo string, state CompactState, input NativeGateRequestInput) (GateRequest, error) {
+// buildCompactGateRequest derives the live gate request for the authoritative
+// state. A non-nil second result reports the committed next-slice topology —
+// the approved candidate tree equals HEAD while new dirty tracked work sits
+// on top, so the request names the live current-changes target for
+// classification instead of the delivered base-diff target — and carries the
+// authoritative intended-untracked paths that remain untracked, computed once
+// so callers never repeat the per-path index lookups.
+func buildCompactGateRequest(ctx context.Context, repo string, state CompactState, input NativeGateRequestInput) (GateRequest, []string, error) {
 	request := GateRequest{Schema: GateRequestSchema, Gate: input.Gate, PolicyArtifact: input.PolicyArtifact}
+	var nextSliceIntended []string
 	switch input.Gate {
 	case GatePostApply, GatePreCommit:
 		intended := input.IntendedUntracked
@@ -390,37 +408,54 @@ func buildCompactGateRequest(ctx context.Context, repo string, state CompactStat
 		}
 		headTree, err := (SnapshotBuilder{Repo: repo}).resolveTree(ctx, "HEAD")
 		if err != nil {
-			return GateRequest{}, err
+			return GateRequest{}, nil, err
 		}
 		if headTree == current.CandidateTree {
 			dirty, err := (SnapshotBuilder{Repo: repo}).HasDirtyTrackedChanges(ctx)
 			if err != nil {
-				return GateRequest{}, err
+				return GateRequest{}, nil, err
 			}
-			if dirty {
-				return GateRequest{}, errors.New("committed approved target has dirty tracked changes")
+			if !dirty {
+				request.Target = Target{Kind: TargetBaseDiff, Projection: projection, BaseRef: current.BaseTree, IntendedUntracked: intended}
+				break
 			}
-			request.Target = Target{Kind: TargetBaseDiff, Projection: projection, BaseRef: current.BaseTree, IntendedUntracked: intended}
-			break
+			// The approved target is committed exactly as reviewed and new
+			// dirty tracked work sits on top: the next-slice topology. Route
+			// to the live current-changes target so assessment compares
+			// candidate and path scope and classifies the new work as
+			// scope-changed or unrelated instead of failing input derivation.
+			// A dirty worktree can never reproduce the approved candidate
+			// tree, so this path can never re-authorize the receipt. Frozen
+			// intended paths delivered by the approved commit are tracked now
+			// and cannot join a live current-changes target; a caller-supplied
+			// set that differs from the authoritative one is kept verbatim so
+			// the intended-retention guard rejects it.
+			nextSliceIntended, err = compactStillUntrackedIntended(ctx, repo, current.IntendedUntracked)
+			if err != nil {
+				return GateRequest{}, nil, err
+			}
+			if equalStrings(intended, current.IntendedUntracked) {
+				intended = nextSliceIntended
+			}
 		}
 		request.Target = Target{Kind: TargetCurrentChanges, Projection: projection, IntendedUntracked: intended}
 	case GatePrePush:
 		deliveryBaseTree := map[TargetKind]string{TargetCurrentChanges: state.InitialSnapshot.BaseTree}[state.InitialSnapshot.Kind]
 		target, push, err := buildPushTarget(ctx, repo, input.BaseRef, deliveryBaseTree)
 		if err != nil {
-			return GateRequest{}, err
+			return GateRequest{}, nil, err
 		}
 		request.Target, request.Push = target, push
 	case GatePrePR:
 		target, prePR, err := buildPrePRTarget(ctx, repo, input.BaseRef, input.PrePRCIAttestation, state.InitialSnapshot.IntendedUntracked)
 		if err != nil {
-			return GateRequest{}, err
+			return GateRequest{}, nil, err
 		}
 		request.Target, request.PrePR = target, prePR
 	case GateRelease:
 		head, err := resolveCommit(ctx, repo, "HEAD")
 		if err != nil {
-			return GateRequest{}, err
+			return GateRequest{}, nil, err
 		}
 		request.Target = Target{Kind: TargetExactRevision, Revision: head}
 		request.Release = &ReleaseRequest{
@@ -431,19 +466,42 @@ func buildCompactGateRequest(ctx context.Context, repo string, state CompactStat
 			PublicationState:            PublicationStateSealed, EvidenceFreshnessState: EvidenceFreshnessCurrent,
 		}
 	default:
-		return GateRequest{}, fmt.Errorf("unsupported review gate %q", input.Gate)
+		return GateRequest{}, nil, fmt.Errorf("unsupported review gate %q", input.Gate)
 	}
 	if request.Gate == GateRelease {
 		for _, path := range []string{input.ReleaseConfiguration, input.ReleaseGenerated, input.ReleaseProvenance, input.ReleasePublicationBoundary, input.ReleaseEvidenceFreshness} {
 			if strings.TrimSpace(path) == "" {
-				return GateRequest{}, errors.New("release gate requires complete independent release evidence")
+				return GateRequest{}, nil, errors.New("release gate requires complete independent release evidence")
 			}
 			if _, err := os.Stat(path); err != nil {
-				return GateRequest{}, err
+				return GateRequest{}, nil, err
 			}
 		}
 	}
-	return request, nil
+	return request, nextSliceIntended, nil
+}
+
+// compactStillUntrackedIntended keeps only the intended-untracked paths that
+// remain untracked. After an approved candidate is committed exactly as
+// reviewed, its frozen intended paths are tracked in HEAD and can no longer
+// participate in the live current-changes target of the next work unit. Only
+// the expected not-in-index lookup exit reclassifies a path as untracked;
+// git infrastructure failures (timeouts, process control, unexpected exits)
+// propagate so the gate fails instead of misclassifying scope.
+func compactStillUntrackedIntended(ctx context.Context, repo string, intended []string) ([]string, error) {
+	remaining := []string{}
+	for _, logicalPath := range intended {
+		_, err := runGit(ctx, repo, nil, nil, "ls-files", "--error-unmatch", "--", literalPathspec(logicalPath))
+		if err == nil {
+			continue
+		}
+		var lookup *GitCommandError
+		if !errors.As(err, &lookup) || lookup.ExitCode != 1 {
+			return nil, fmt.Errorf("classify intended-untracked path %q: %w", logicalPath, err)
+		}
+		remaining = append(remaining, logicalPath)
+	}
+	return remaining, nil
 }
 
 func validateCompactUntrackedScope(ctx context.Context, repo string, state CompactState, request GateRequest) error {

--- a/internal/reviewtransaction/compact_gate_test.go
+++ b/internal/reviewtransaction/compact_gate_test.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"runtime"
@@ -605,6 +607,91 @@ func TestCompactCommittedGateRechecksConcurrentDirtyTrackedTarget(t *testing.T) 
 				t.Fatalf("concurrent dirty tracked target = %#v", got)
 			}
 		})
+	}
+}
+
+func TestCompactCommittedNextSliceWorkspaceRoutesLiveCurrentChanges(t *testing.T) {
+	// A committed approved receipt whose candidate tree equals HEAD plus new
+	// dirty tracked work is the next-slice topology (#1401). Gate input
+	// derivation must construct the live current-changes target so the new
+	// work classifies as scope-changed or unrelated instead of failing with
+	// "committed approved target has dirty tracked changes".
+	tests := []struct {
+		name   string
+		mutate func(t *testing.T, repo string)
+		want   CompactGateTargetApplicability
+	}{
+		{name: "unrelated dirty tracked path", mutate: func(t *testing.T, repo string) {
+			writeSnapshotFile(t, repo, "deleted.txt", "next slice in progress\n")
+		}, want: CompactGateTargetUnrelated},
+		{name: "overlapping dirty tracked path", mutate: func(t *testing.T, repo string) {
+			writeSnapshotFile(t, repo, "tracked.txt", "next slice on reviewed path\n")
+		}, want: CompactGateTargetScopeChanged},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := initSnapshotRepo(t)
+			writeSnapshotFile(t, repo, "tracked.txt", "reviewed candidate\n")
+			state := newCompactStartStateForTarget(t, repo, "compact-next-slice-"+strings.ReplaceAll(tt.name, " ", "-"), Target{Kind: TargetCurrentChanges, IntendedUntracked: []string{}})
+			state, receipt := persistApprovedCompactState(t, repo, state)
+			gitSnapshot(t, repo, "add", "tracked.txt")
+			gitSnapshot(t, repo, "commit", "-m", "reviewed candidate")
+			tt.mutate(t, repo)
+
+			input := NativeGateRequestInput{Gate: GatePostApply, LineageID: state.LineageID}
+			assessment, err := AssessCompactGateTarget(context.Background(), repo, state, input)
+			if err != nil {
+				t.Fatalf("next-slice workspace assessment failed input derivation: %v", err)
+			}
+			if assessment.Applicability != tt.want {
+				t.Fatalf("next-slice applicability = %q, want %q", assessment.Applicability, tt.want)
+			}
+
+			got := EvaluateCompactGate(context.Background(), repo, receipt, input)
+			if got.Result == GateAllow {
+				t.Fatalf("committed target with dirty tracked changes was allowed: %#v", got)
+			}
+			if got.Result != GateScopeChanged || strings.Contains(got.Reason, "cannot be derived") {
+				t.Fatalf("next-slice explicit-lineage evaluation = %#v", got)
+			}
+		})
+	}
+}
+
+func TestCompactCommittedNextSliceIntendedFilterPropagatesGitInfraFailure(t *testing.T) {
+	// A git infrastructure failure while checking whether frozen intended
+	// paths remain untracked must fail gate input derivation like every other
+	// git call, never silently reclassify the path as untracked.
+	repo := initSnapshotRepo(t)
+	writeSnapshotFile(t, repo, "tracked.txt", "reviewed candidate\n")
+	writeSnapshotFile(t, repo, "intended.txt", "reviewed untracked\n")
+	state := newCompactStartStateForTarget(t, repo, "compact-next-slice-infra", Target{Kind: TargetCurrentChanges, IntendedUntracked: []string{"intended.txt"}})
+	state, receipt := persistApprovedCompactState(t, repo, state)
+	gitSnapshot(t, repo, "add", "tracked.txt", "intended.txt")
+	gitSnapshot(t, repo, "commit", "-m", "reviewed candidate")
+	writeSnapshotFile(t, repo, "deleted.txt", "next slice in progress\n")
+
+	originalStarter := gitProcessTreeStarter
+	t.Cleanup(func() { gitProcessTreeStarter = originalStarter })
+	gitProcessTreeStarter = func(command *exec.Cmd) (func() error, error) {
+		for _, arg := range command.Args {
+			if arg == "--error-unmatch" {
+				return nil, errors.New("job object creation rejected")
+			}
+		}
+		return originalStarter(command)
+	}
+
+	input := NativeGateRequestInput{Gate: GatePostApply, LineageID: state.LineageID}
+	_, err := AssessCompactGateTarget(context.Background(), repo, state, input)
+	var control *GitProcessControlError
+	if !errors.As(err, &control) {
+		t.Fatalf("git infra failure during intended filtering was reclassified instead of failing the assessment: %v", err)
+	}
+
+	got := EvaluateCompactGate(context.Background(), repo, receipt, input)
+	if got.Result != GateInvalidated || !strings.Contains(got.Reason, "cannot be derived") || !errors.As(got.Cause, &control) {
+		t.Fatalf("git infra failure evaluation = %#v", got)
 	}
 }
 


### PR DESCRIPTION
Fixes #1401

## Problem

After an approved committed receipt, starting the next slice of work (new dirty tracked changes, or intended-untracked transitions, on top of the delivered commit) poisoned gate evaluation instead of routing to a fresh review: `review validate` failed with opaque derivation errors rather than classifying the workspace as `receipt_unrelated` / `receipt_scope_changed`.

## Fix

- `buildCompactGateRequest` now detects the committed next-slice topology (approved candidate tree == HEAD plus new dirt) and returns the authoritative filtered intended-untracked set, computed once and reused by `EvaluateCompactGate`'s retention guard.
- New `compactStillUntrackedIntended` classifies each frozen intended-untracked path via `git ls-files --error-unmatch`: exit 1 keeps the path untracked; any other git failure (timeout, process-control, repo fatal) propagates as "compact gate inputs cannot be derived" with the typed cause preserved, instead of silently flipping the classification.
- Unqualified gate discovery routes the next-slice workspace to `receipt_unrelated` (disjoint dirt) or `receipt_scope_changed` (overlapping dirt) with explicit maintainer action, never `authority_corrupted`.

## Review

Native bounded review (high risk, 4R): risk and readability clean; resilience and reliability WARNINGs (double Assess+Evaluate subprocess pass latency; a GatePreCommit staged-projection edge with non-empty intended sets) routed as follow-ups, non-blocking. All gates allow.

## Tests

Failing-first: `TestCompactCommittedNextSliceIntendedFilterPropagatesGitInfraFailure` (git-infra failure was silently reclassified before the fix), plus `TestUnqualifiedGateDiscoveryRoutesCommittedNextSliceWorkspace`, `TestCompactCommittedNextSliceWorkspaceRoutesLiveCurrentChanges`, and retention-guard regressions. Full `internal/reviewtransaction` + `internal/cli` suites pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved review gate handling for committed workspaces with subsequent tracked changes.
  * Correctly distinguishes unrelated changes from changes that overlap the reviewed scope.
  * Provides scope-change recovery details when reviewed workspace contents drift.
  * Prevents healthy committed receipts from being incorrectly classified as corrupted.
  * Invalidates gate evaluation when workspace state cannot be reliably determined.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->