### PR TITLE
fix(review): bind chained scope-changed recovery deliveries at publication gates

### DIFF
--- a/internal/cli/review_recovery_gate_binding_test.go
+++ b/internal/cli/review_recovery_gate_binding_test.go
@@ -1,0 +1,129 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/internal/reviewtransaction"
+)
+
+// TestValidateBindsScopeChangedRecoveryChainAtPublicationGates covers
+// gentle-ai issue #1422 end to end: an approved review is delivered as one
+// commit, its scope_changed recovery successor is created from the live
+// repository (a pristine, degenerate snapshot), and `review validate` must
+// still bind and allow pre-push and pre-pr through the composed recovery
+// chain instead of denying with candidate-or-paths-mismatch or the empty
+// one-commit topology context.
+func TestValidateBindsScopeChangedRecoveryChainAtPublicationGates(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	branch := strings.TrimSpace(runReviewCLIGit(t, repo, "symbolic-ref", "--short", "HEAD"))
+	remote := filepath.Join(t.TempDir(), "remote.git")
+	runReviewCLIGit(t, repo, "clone", "--bare", repo, remote)
+	runReviewCLIGit(t, repo, "remote", "add", "origin", remote)
+	runReviewCLIGit(t, repo, "--git-dir", remote, "symbolic-ref", "HEAD", "refs/heads/"+branch)
+	runReviewCLIGit(t, repo, "config", "branch."+branch+".remote", "origin")
+	runReviewCLIGit(t, repo, "config", "branch."+branch+".merge", "refs/heads/"+branch)
+
+	_, store := approveDiscoveryMarkdown(t, repo, "chained-cli-root", "docs/reviewed.md", "reviewed\n")
+	runReviewCLIGit(t, repo, "add", "-A")
+	runReviewCLIGit(t, repo, "commit", "-qm", "reviewed delivery")
+	record, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := RunReviewRecover([]string{
+		"--cwd", repo, "--predecessor-lineage", "chained-cli-root",
+		"--expected-predecessor-revision", record.Revision, "--successor-lineage", "chained-cli-root-r1",
+		"--disposition", "scope_changed", "--reason", "delivery committed after approval", "--actor", "maintainer@example.com",
+	}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("recover scope_changed successor: %v", err)
+	}
+	if err := RunReviewFacadeFinalize([]string{"--cwd", repo, "--lineage", "chained-cli-root-r1"}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("finalize recovered successor: %v", err)
+	}
+
+	for _, gate := range []reviewtransaction.GateKind{reviewtransaction.GatePrePush, reviewtransaction.GatePrePR} {
+		t.Run(string(gate), func(t *testing.T) {
+			var output bytes.Buffer
+			if err := RunReview([]string{
+				"validate", "--contract", ReviewIntegrationContractV1, "--cwd", repo,
+				"--gate", string(gate), "--base-ref", "origin/" + branch,
+			}, &output); err != nil {
+				t.Fatalf("chained recovery %s validation: %v\n%s", gate, err, output.String())
+			}
+			var result ReviewValidateResult
+			decodeStrictReviewJSON(t, decodeReviewOperationEnvelope(t, output.Bytes()).Result, &result)
+			if !result.Allowed || result.Context.LineageID != "chained-cli-root-r1" {
+				t.Fatalf("chained recovery %s result = %#v", gate, result)
+			}
+			if result.Context.FixDeltaHash == reviewtransaction.EmptyFixDeltaHash || result.Context.FixDeltaHash == "" {
+				t.Fatalf("chained recovery %s fix delta = %q", gate, result.Context.FixDeltaHash)
+			}
+			if !result.Context.BaseRelationshipValid {
+				t.Fatalf("chained recovery %s base relationship = %#v", gate, result.Context)
+			}
+		})
+	}
+
+	t.Run("tampered predecessor receipt fails closed", func(t *testing.T) {
+		if err := os.Remove(store.ReceiptPath()); err != nil {
+			t.Fatal(err)
+		}
+		var output bytes.Buffer
+		err := RunReview([]string{
+			"validate", "--contract", ReviewIntegrationContractV1, "--cwd", repo,
+			"--gate", string(reviewtransaction.GatePrePush), "--base-ref", "origin/" + branch,
+		}, &output)
+		if err == nil {
+			var result ReviewValidateResult
+			decodeStrictReviewJSON(t, decodeReviewOperationEnvelope(t, output.Bytes()).Result, &result)
+			if result.Allowed {
+				t.Fatalf("receiptless predecessor still allowed = %#v", result)
+			}
+		}
+	})
+}
+
+// TestValidatePrePushDeriveFailureReportsReceiptDigests locks the denial
+// context of an underivable pre-push delivery: the receipt digests must be
+// reported instead of an all-blank context (issue #1422 / #1248).
+func TestValidatePrePushDeriveFailureReportsReceiptDigests(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	branch := strings.TrimSpace(runReviewCLIGit(t, repo, "symbolic-ref", "--short", "HEAD"))
+	remote := filepath.Join(t.TempDir(), "remote.git")
+	runReviewCLIGit(t, repo, "clone", "--bare", repo, remote)
+	runReviewCLIGit(t, repo, "remote", "add", "origin", remote)
+	runReviewCLIGit(t, repo, "--git-dir", remote, "symbolic-ref", "HEAD", "refs/heads/"+branch)
+	runReviewCLIGit(t, repo, "config", "branch."+branch+".remote", "origin")
+	runReviewCLIGit(t, repo, "config", "branch."+branch+".merge", "refs/heads/"+branch)
+
+	_, store := approveDiscoveryMarkdown(t, repo, "underivable-pre-push", "docs/reviewed.md", "reviewed\n")
+	runReviewCLIGit(t, repo, "add", "-A")
+	runReviewCLIGit(t, repo, "commit", "-qm", "reviewed delivery")
+	runReviewCLIGit(t, repo, "commit", "-q", "--allow-empty", "-m", "unreviewed extra commit")
+	record, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := record.State.Receipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	evaluation := reviewtransaction.EvaluateCompactGate(context.Background(), repo, receipt, reviewtransaction.NativeGateRequestInput{
+		Gate: reviewtransaction.GatePrePush, LineageID: record.State.LineageID, BaseRef: "origin/" + branch,
+	})
+	if evaluation.Result != reviewtransaction.GateInvalidated ||
+		!strings.Contains(evaluation.Reason, "reviewed delivery is not exactly one commit") {
+		t.Fatalf("underivable pre-push evaluation = %#v", evaluation)
+	}
+	if evaluation.Context.LineageID != record.State.LineageID || evaluation.Context.BaseTree != receipt.BaseTree ||
+		evaluation.Context.CandidateTree != receipt.FinalCandidateTree || evaluation.Context.Denial == nil {
+		t.Fatalf("underivable pre-push context = %#v", evaluation.Context)
+	}
+}

--- a/internal/reviewtransaction/compact_gate.go
+++ b/internal/reviewtransaction/compact_gate.go
@@ -48,6 +48,13 @@ func AssessCompactGateTarget(ctx context.Context, repo string, state CompactStat
 	// intended-retention guard; applicability here derives purely from the
 	// request target and snapshot comparison, so the signal is discarded.
 	request, _, err := buildCompactGateRequest(ctx, repo, state, input)
+	if err != nil && input.Gate == GatePrePush && state.Recovery != nil && state.InitialSnapshot.Kind == TargetCurrentChanges {
+		if chain, ok, chainErr := deriveCompactRecoveryBinding(ctx, repo, state); chainErr == nil && ok && chain.BaseTree != state.InitialSnapshot.BaseTree {
+			if retried, _, retryErr := buildCompactGateRequestWithPushBase(ctx, repo, state, input, chain.BaseTree); retryErr == nil {
+				request, err = retried, nil
+			}
+		}
+	}
 	if err != nil && input.Gate == GateRelease {
 		head, headErr := resolveCommit(ctx, repo, "HEAD")
 		if headErr == nil {
@@ -96,6 +103,16 @@ func AssessCompactGateTarget(ctx context.Context, repo string, state CompactStat
 	if snapshot.CandidateTree == state.CurrentSnapshot.CandidateTree && pathsMatch && baseMatches {
 		assessment.Applicability = CompactGateTargetExact
 		return assessment, nil
+	}
+	if (request.Gate == GatePrePush || request.Gate == GatePrePR) && state.Recovery != nil && resolvedPrePR != nil {
+		rebindBaseCommit := resolvedPrePR.BaseCommit
+		if request.Gate == GatePrePush {
+			rebindBaseCommit = request.Target.BaseRef
+		}
+		if _, ok := rebindCompactRecoveryDelivery(ctx, repo, state, snapshot, state.CurrentSnapshot.CandidateTree, rebindBaseCommit, resolvedPrePR.HeadCommit); ok {
+			assessment.Applicability = CompactGateTargetExact
+			return assessment, nil
+		}
 	}
 	if snapshot.BaseTree == state.CurrentSnapshot.BaseTree || snapshot.PathsDigest == state.CurrentSnapshot.PathsDigest ||
 		hasAnyReviewPath(snapshot.Paths, state.GenesisPaths) {
@@ -170,12 +187,25 @@ func EvaluateCompactGate(ctx context.Context, repo string, receipt CompactReceip
 		return NativeGateEvaluation{Result: GateEscalated, Reason: nativeGateReason(GateEscalated)}
 	}
 	request, nextSliceIntended, err := buildCompactGateRequest(ctx, repo, record.State, input)
+	if err != nil && input.Gate == GatePrePush && record.State.Recovery != nil && record.State.InitialSnapshot.Kind == TargetCurrentChanges {
+		// A scope_changed recovery successor created after its predecessor's
+		// delivery was committed can only restate the delivered tree as its
+		// own base, so its one-commit delivery derivation always fails. Retry
+		// once from the composed chain base; the later receipt binding still
+		// re-verifies the complete delivery before any authorization.
+		if chain, ok, chainErr := deriveCompactRecoveryBinding(ctx, repo, record.State); chainErr == nil && ok && chain.BaseTree != record.State.InitialSnapshot.BaseTree {
+			if retried, retriedNextSlice, retryErr := buildCompactGateRequestWithPushBase(ctx, repo, record.State, input, chain.BaseTree); retryErr == nil {
+				request, nextSliceIntended, err = retried, retriedNextSlice, nil
+			}
+		}
+	}
 	if err != nil {
 		if input.Gate == GatePrePR {
 			denialContext.Denial = &GateDenial{Stage: "boundary-selection", Code: "unavailable"}
 			return NativeGateEvaluation{Result: GateInvalidated, Reason: "compact gate inputs cannot be derived: " + err.Error(), Context: denialContext, Cause: err}
 		}
-		return invalid("compact gate inputs cannot be derived: "+err.Error(), err)
+		denialContext.Denial = &GateDenial{Stage: "delivery-derivation", Code: "unavailable"}
+		return NativeGateEvaluation{Result: GateInvalidated, Reason: "compact gate inputs cannot be derived: " + err.Error(), Context: denialContext, Cause: err}
 	}
 	expectedIntended := record.State.CurrentSnapshot.IntendedUntracked
 	if nextSliceIntended != nil {
@@ -252,6 +282,29 @@ func EvaluateCompactGate(ctx context.Context, repo string, receipt CompactReceip
 	if strictBinding {
 		pathsMismatch = snapshot.PathsDigest != binding.PathsDigest && !squashedFixDelivery
 	}
+	baseMismatch := snapshot.BaseTree != receipt.BaseTree && request.Target.Kind != TargetFixDiff && !compatibleAdvance
+	if strictBinding {
+		baseMismatch = snapshot.BaseTree != binding.BaseTree && !squashedFixDelivery
+	}
+	// A scope_changed recovery successor freezes only its own pristine scope,
+	// so a delivery already covered by its receipt-bound predecessors would be
+	// denied here forever. Rebind through the composed recovery chain when the
+	// leaf's approved candidate is exactly the delivered tree and native Git
+	// evidence proves the chain covers the complete publication range.
+	var recoveryRebind *compactRecoveryBinding
+	if (request.Gate == GatePrePush || request.Gate == GatePrePR) && record.State.Recovery != nil && resolvedPrePR != nil &&
+		(pathsMismatch || baseMismatch) && snapshot.CandidateTree == receipt.FinalCandidateTree {
+		rebindBaseCommit := resolvedPrePR.BaseCommit
+		if request.Gate == GatePrePush {
+			rebindBaseCommit = request.Target.BaseRef
+		}
+		if chain, ok := rebindCompactRecoveryDelivery(ctx, repo, record.State, snapshot, receipt.FinalCandidateTree, rebindBaseCommit, resolvedPrePR.HeadCommit); ok {
+			recoveryRebind = &chain
+			pathsMismatch = false
+			gateContext.BaseRelationshipValid = true
+			gateContext.FixDeltaHash = chain.FixDeltaHash
+		}
+	}
 	if snapshot.CandidateTree != receipt.FinalCandidateTree || pathsMismatch {
 		gateContext.Denial = &GateDenial{Stage: "receipt-binding", Code: "candidate-or-paths-mismatch"}
 		diagnostics, diagnosticsErr := buildCompactScopeChangeDiagnostics(ctx, repo, record.State, record.Revision, snapshot)
@@ -262,11 +315,7 @@ func EvaluateCompactGate(ctx context.Context, repo string, receipt CompactReceip
 		gateContext.ScopeChange = &diagnostics
 		return NativeGateEvaluation{Result: GateScopeChanged, Reason: nativeGateReason(GateScopeChanged), Context: gateContext}
 	}
-	baseMismatch := snapshot.BaseTree != receipt.BaseTree && request.Target.Kind != TargetFixDiff && !compatibleAdvance
-	if strictBinding {
-		baseMismatch = snapshot.BaseTree != binding.BaseTree && !squashedFixDelivery
-	}
-	if baseMismatch {
+	if baseMismatch && recoveryRebind == nil {
 		gateContext.Denial = &GateDenial{Stage: "receipt-binding", Code: "base-mismatch"}
 		return NativeGateEvaluation{Result: GateInvalidated, Reason: "current repository base no longer matches compact authority", Context: gateContext}
 	}
@@ -296,6 +345,12 @@ func EvaluateCompactGate(ctx context.Context, repo string, receipt CompactReceip
 	finalSuperseded, supersededErr := CompactLineageSuperseded(ctx, repo, receipt.LineageID)
 	if loadErr != nil || snapshotErr != nil || finalUntrackedErr != nil || finalTrackedErr != nil || graphErr != nil || supersededErr != nil || finalSuperseded || finalRecord.Revision != record.Revision || !reflect.DeepEqual(finalSnapshot, snapshot) || !sameResolvedPrePRRefs(finalRefs, resolvedPrePR) {
 		return invalid("compact authority or repository target changed during final authorization")
+	}
+	if recoveryRebind != nil {
+		finalChain, ok, chainErr := deriveCompactRecoveryBinding(ctx, repo, finalRecord.State)
+		if chainErr != nil || !ok || !reflect.DeepEqual(finalChain, *recoveryRebind) {
+			return invalid("compact authority or repository target changed during final authorization")
+		}
 	}
 	if request.Gate == GateRelease {
 		finalPreimages, preimageErr := readGateArtifactPreimages(request)
@@ -379,6 +434,17 @@ func buildCompactLifecycleSnapshot(ctx context.Context, repo string, request Gat
 // authoritative intended-untracked paths that remain untracked, computed once
 // so callers never repeat the per-path index lookups.
 func buildCompactGateRequest(ctx context.Context, repo string, state CompactState, input NativeGateRequestInput) (GateRequest, []string, error) {
+	return buildCompactGateRequestWithPushBase(ctx, repo, state, input, compactPushDeliveryBaseTree(state))
+}
+
+// compactPushDeliveryBaseTree derives the reviewed delivery base a pre-push
+// target must be exactly one commit from. Only current-changes reviews bind a
+// one-commit delivery to their own frozen base.
+func compactPushDeliveryBaseTree(state CompactState) string {
+	return map[TargetKind]string{TargetCurrentChanges: state.InitialSnapshot.BaseTree}[state.InitialSnapshot.Kind]
+}
+
+func buildCompactGateRequestWithPushBase(ctx context.Context, repo string, state CompactState, input NativeGateRequestInput, deliveryBaseTree string) (GateRequest, []string, error) {
 	request := GateRequest{Schema: GateRequestSchema, Gate: input.Gate, PolicyArtifact: input.PolicyArtifact}
 	var nextSliceIntended []string
 	switch input.Gate {
@@ -440,7 +506,6 @@ func buildCompactGateRequest(ctx context.Context, repo string, state CompactStat
 		}
 		request.Target = Target{Kind: TargetCurrentChanges, Projection: projection, IntendedUntracked: intended}
 	case GatePrePush:
-		deliveryBaseTree := map[TargetKind]string{TargetCurrentChanges: state.InitialSnapshot.BaseTree}[state.InitialSnapshot.Kind]
 		target, push, err := buildPushTarget(ctx, repo, input.BaseRef, deliveryBaseTree)
 		if err != nil {
 			return GateRequest{}, nil, err

--- a/internal/reviewtransaction/compact_recovery_binding.go
+++ b/internal/reviewtransaction/compact_recovery_binding.go
@@ -1,0 +1,211 @@
+package reviewtransaction
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"os"
+)
+
+// CompactRecoveryBindingDomain separates every hash the composed
+// scope_changed recovery binding derives from other review identities.
+const CompactRecoveryBindingDomain = "gentle-ai.compact-recovery-binding/v1"
+
+// compactRecoveryBinding composes the publication-binding inputs of one
+// unbroken scope_changed recovery chain. Recovery successors always start as
+// pristine reviewing authorities, so a successor created after its
+// predecessor's delivery was committed can never restate the original base
+// tree, genesis paths, or fix delta on its own. The binding restores exactly
+// those gate inputs from the persisted, receipt-bound predecessors without
+// ever mutating any authority. It is derived gate evidence only.
+type compactRecoveryBinding struct {
+	// Members are ordered root..leaf. Every member is a terminally approved
+	// compact authority whose receipt file matches its state, and every edge
+	// is a validated scope_changed recovery whose successor initial base tree
+	// equals its predecessor's final candidate tree.
+	Members []CompactRecord
+	// BaseTree is the root member's reviewed delivery base.
+	BaseTree string
+	// GenesisPaths is the canonical union of every member's frozen genesis.
+	GenesisPaths []string
+	// FixDeltaHash commits to the ordered per-member fix delta hashes so a
+	// recovered lineage inherits its predecessors' correction identity
+	// instead of carrying the empty-input hash forever.
+	FixDeltaHash string
+}
+
+// deriveCompactRecoveryBinding walks the scope_changed recovery chain of the
+// given leaf state backwards and composes the publication binding. It returns
+// ok=false when nothing can be composed: the leaf is not a scope_changed
+// recovery successor, or no predecessor satisfies every fail-closed
+// requirement (terminal approval, receipt bound to authority, exact revision,
+// valid recovery edge, and delivery-tree continuity). A hard error reports a
+// corrupt or racing authority graph; callers must then keep the original
+// denial.
+func deriveCompactRecoveryBinding(ctx context.Context, repo string, leaf CompactState) (compactRecoveryBinding, bool, error) {
+	if leaf.Recovery == nil || leaf.Recovery.Disposition != RecoveryScopeChanged {
+		return compactRecoveryBinding{}, false, nil
+	}
+	leafRecord, _, err := makeCompactRecord(leaf)
+	if err != nil {
+		return compactRecoveryBinding{}, false, err
+	}
+	members := []CompactRecord{leafRecord}
+	current := leaf
+	for current.Recovery != nil && current.Recovery.Disposition == RecoveryScopeChanged {
+		store, storeErr := CompactAuthoritativeStore(ctx, repo, current.Recovery.PredecessorLineageID)
+		if storeErr != nil {
+			return compactRecoveryBinding{}, false, storeErr
+		}
+		predecessor, loadErr := store.Load()
+		if loadErr != nil {
+			return compactRecoveryBinding{}, false, loadErr
+		}
+		if predecessor.Revision != current.Recovery.PredecessorRevision {
+			return compactRecoveryBinding{}, false, errors.New("recovery predecessor revision does not match successor provenance")
+		}
+		if edgeErr := validateCompactRecoveryEdge(predecessor, current); edgeErr != nil {
+			return compactRecoveryBinding{}, false, edgeErr
+		}
+		if predecessor.State.State != StateApproved ||
+			current.InitialSnapshot.BaseTree != predecessor.State.CurrentSnapshot.CandidateTree ||
+			!compactRecoveryReceiptBound(store, predecessor) {
+			break
+		}
+		members = append([]CompactRecord{predecessor}, members...)
+		current = predecessor.State
+	}
+	if len(members) < 2 {
+		return compactRecoveryBinding{}, false, nil
+	}
+	genesis := make([][]string, 0, len(members))
+	fixDeltas := make([]string, 0, len(members))
+	for _, member := range members {
+		genesis = append(genesis, member.State.GenesisPaths)
+		fixDeltas = append(fixDeltas, member.State.FixDeltaHash)
+	}
+	union, err := compactPrePRPathUnion(genesis...)
+	if err != nil {
+		return compactRecoveryBinding{}, false, err
+	}
+	return compactRecoveryBinding{
+		Members: members, BaseTree: members[0].State.InitialSnapshot.BaseTree,
+		GenesisPaths: union, FixDeltaHash: compactRecoveryBindingValuesHash("fix-delta", fixDeltas),
+	}, true, nil
+}
+
+// compactRecoveryReceiptBound reports whether the persisted receipt file of a
+// terminal predecessor matches the receipt derived from its authority.
+func compactRecoveryReceiptBound(store CompactStore, record CompactRecord) bool {
+	payload, err := os.ReadFile(store.ReceiptPath())
+	if err != nil {
+		return false
+	}
+	receipt, err := ParseCompactReceipt(payload)
+	if err != nil {
+		return false
+	}
+	authoritative, err := record.State.Receipt()
+	if err != nil {
+		return false
+	}
+	return compactReceiptEqual(receipt, authoritative)
+}
+
+func compactRecoveryBindingValuesHash(kind string, values []string) string {
+	payload, _ := json.Marshal(values)
+	sum := sha256.Sum256(append([]byte(CompactRecoveryBindingDomain+"/"+kind+"\x00"), payload...))
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+// verifyCompactRecoveryDelivery re-derives from live Git that the composed
+// recovery chain's approved content is exactly the delivery being validated:
+// the publication base commit carries the composed base tree, the linear
+// publication history progresses only through member final candidate trees,
+// every commit inside a member's segment stays inside that member's frozen
+// genesis paths, and the final tree equals the delivered candidate. Members
+// whose final tree equals the already delivered tree consume no commits: they
+// re-reviewed content that was already published by an earlier member.
+func verifyCompactRecoveryDelivery(ctx context.Context, repo string, binding compactRecoveryBinding, finalTree, baseCommit, headCommit string) error {
+	builder := SnapshotBuilder{Repo: repo}
+	baseTree, err := builder.resolveTree(ctx, baseCommit)
+	if err != nil {
+		return err
+	}
+	if baseTree != binding.BaseTree {
+		return errors.New("publication base does not carry the composed recovery base tree")
+	}
+	commits, err := compactPrePRLinearCommits(ctx, repo, baseCommit, headCommit)
+	if err != nil {
+		return err
+	}
+	previousTree, previousIndex := baseTree, -1
+	for _, member := range binding.Members {
+		memberFinal := member.State.CurrentSnapshot.CandidateTree
+		if memberFinal == previousTree {
+			continue
+		}
+		boundary := -1
+		for index := previousIndex + 1; index < len(commits); index++ {
+			if commits[index].Tree == previousTree {
+				continue
+			}
+			if commits[index].Tree != memberFinal {
+				return errors.New("publication commit does not match the recovery chain boundary")
+			}
+			boundary = index
+			break
+		}
+		if boundary < 0 {
+			return errors.New("recovery chain boundary is absent from publication history")
+		}
+		touched := []string{}
+		for index := previousIndex + 1; index <= boundary; index++ {
+			paths, pathsErr := builder.changedPaths(ctx, commits[index].ParentTree, commits[index].Tree)
+			if pathsErr != nil {
+				return pathsErr
+			}
+			touched = append(touched, paths...)
+		}
+		touched, err = compactPrePRPathUnion(touched)
+		if err != nil || pathsAreSubset(touched, member.State.GenesisPaths) != nil {
+			return errors.New("publication segment exceeds the recovery member's immutable genesis paths")
+		}
+		previousTree, previousIndex = memberFinal, boundary
+	}
+	for index := previousIndex + 1; index < len(commits); index++ {
+		if commits[index].Tree != previousTree {
+			return errors.New("publication commit remains after all recovery chain boundaries")
+		}
+	}
+	if previousTree != finalTree {
+		return errors.New("recovery chain final tree does not equal the delivered candidate")
+	}
+	return nil
+}
+
+// rebindCompactRecoveryDelivery derives and fully re-verifies the composed
+// recovery binding for one already derived gate snapshot. It never relaxes
+// the delivered candidate: the leaf receipt's final candidate tree must equal
+// the live delivered tree, the live base must equal the composed base, the
+// live changed paths must stay inside the composed genesis union, and the
+// full publication history must be covered by the chain. Any failure keeps
+// the caller's original denial.
+func rebindCompactRecoveryDelivery(ctx context.Context, repo string, state CompactState, snapshot Snapshot, finalTree, baseCommit, headCommit string) (compactRecoveryBinding, bool) {
+	if snapshot.CandidateTree != finalTree || baseCommit == "" || headCommit == "" {
+		return compactRecoveryBinding{}, false
+	}
+	binding, ok, err := deriveCompactRecoveryBinding(ctx, repo, state)
+	if err != nil || !ok {
+		return compactRecoveryBinding{}, false
+	}
+	if snapshot.BaseTree != binding.BaseTree || pathsAreSubset(snapshot.Paths, binding.GenesisPaths) != nil {
+		return compactRecoveryBinding{}, false
+	}
+	if verifyCompactRecoveryDelivery(ctx, repo, binding, finalTree, baseCommit, headCommit) != nil {
+		return compactRecoveryBinding{}, false
+	}
+	return binding, true
+}

--- a/internal/reviewtransaction/compact_recovery_binding_test.go
+++ b/internal/reviewtransaction/compact_recovery_binding_test.go
@@ -1,0 +1,268 @@
+package reviewtransaction
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+)
+
+// chainedRecoveryFixture reproduces gentle-ai issue #1422: a corrected and
+// approved current-changes review (non-empty fix delta) is delivered as one
+// commit, and its scope_changed recovery successor is created from the live
+// repository after the delivery. The successor's pristine snapshot degenerates
+// to base == candidate with empty genesis paths, so its receipt alone can
+// never rebind the publication gates even though every tree matches live Git.
+type chainedRecoveryFixture struct {
+	repo      string
+	remote    string
+	branch    string
+	baseRef   string
+	root      CompactState
+	rootStore CompactStore
+	leaf      CompactState
+	receipt   CompactReceipt
+}
+
+func chainedScopeRecoveryFixture(t *testing.T) *chainedRecoveryFixture {
+	t.Helper()
+	repo := initSnapshotRepo(t)
+	branch := currentBranch(context.Background(), repo)
+	remote := configurePublicationRemote(t, repo, branch)
+	gitSnapshot(t, repo, "config", "branch."+branch+".remote", "origin")
+	gitSnapshot(t, repo, "config", "branch."+branch+".merge", "refs/heads/"+branch)
+	root := correctedCompactTestState(t, repo, "chained-recovery-root")
+	persistCorrectedCompactFixture(t, repo, root)
+	rootStore, err := CompactAuthoritativeStore(context.Background(), repo, root.LineageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gitSnapshot(t, repo, "add", "tracked.txt")
+	gitSnapshot(t, repo, "commit", "-m", "reviewed delivery")
+	leaf, receipt := recoverApprovedCompactSuccessor(t, repo, root.LineageID, "chained-recovery-r1", 2)
+	return &chainedRecoveryFixture{
+		repo: repo, remote: remote, branch: branch, baseRef: "origin/" + branch,
+		root: root, rootStore: rootStore, leaf: leaf, receipt: receipt,
+	}
+}
+
+// extendWithSecondDelivery reviews and delivers a second in-chain change so
+// the recovery chain spans two delivery commits: root covers the first commit,
+// the degenerate r1 covers nothing, and r2 covers the second commit.
+func (fixture *chainedRecoveryFixture) extendWithSecondDelivery(t *testing.T) (CompactState, CompactReceipt) {
+	t.Helper()
+	writeSnapshotFile(t, fixture.repo, "deleted.txt", "second reviewed delivery\n")
+	state, receipt := recoverApprovedCompactSuccessor(t, fixture.repo, fixture.leaf.LineageID, "chained-recovery-r2", 3)
+	gitSnapshot(t, fixture.repo, "add", "deleted.txt")
+	gitSnapshot(t, fixture.repo, "commit", "-m", "second reviewed delivery")
+	return state, receipt
+}
+
+// recoverApprovedCompactSuccessor creates a scope_changed recovery successor
+// from the live repository and approves it through the ordinary compact
+// lifecycle. The successor itself always starts as a pristine reviewing
+// authority; only gate binding may later compose the chain.
+func recoverApprovedCompactSuccessor(t *testing.T, repo, predecessorLineage, lineage string, generation int) (CompactState, CompactReceipt) {
+	t.Helper()
+	predecessorStore, err := CompactAuthoritativeStore(context.Background(), repo, predecessorLineage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	predecessorRecord, err := predecessorStore.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	successor := newCompactTestState(t, repo, lineage)
+	successor.Generation = generation
+	record, err := RecoverCompactAuthority(context.Background(), repo, CompactRecoveryRequest{
+		PredecessorLineageID: predecessorLineage, ExpectedPredecessorRevision: predecessorRecord.Revision,
+		Successor: successor, Disposition: RecoveryScopeChanged,
+		Reason: "delivery scope changed after approval", Actor: "maintainer@example.com",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	state := record.State
+	store, err := CompactAuthoritativeStore(context.Background(), repo, lineage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	results := make([]LensResult, len(state.SelectedLenses))
+	for index, lens := range state.SelectedLenses {
+		results[index] = LensResult{Lens: lens, Findings: []Finding{}, Evidence: []string{"reviewed"}}
+	}
+	if err := state.CompleteReview(CompactReviewInput{LensResults: results, Classifications: []FindingEvidence{}, RefuterOutcomes: []EvidenceResult{}}); err != nil {
+		t.Fatal(err)
+	}
+	revision, err := store.Replace(record.Revision, "review/complete-review", state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := state.CompleteVerification([]byte("independent verification passed\n"), true); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Replace(revision, "review/complete-verification", state); err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := state.Receipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteCompactReceiptAtomic(store.ReceiptPath(), receipt); err != nil {
+		t.Fatal(err)
+	}
+	return state, receipt
+}
+
+func TestCompactPrePushBindsChainedScopeRecoveryDelivery(t *testing.T) {
+	fixture := chainedScopeRecoveryFixture(t)
+	got := EvaluateCompactGate(context.Background(), fixture.repo, fixture.receipt, NativeGateRequestInput{
+		Gate: GatePrePush, LineageID: fixture.leaf.LineageID, BaseRef: fixture.baseRef,
+	})
+	if got.Result != GateAllow || !got.Context.BaseRelationshipValid {
+		t.Fatalf("chained scope recovery pre-push = %#v", got)
+	}
+	if got.Context.FixDeltaHash == EmptyFixDeltaHash || !validSHA256(got.Context.FixDeltaHash) {
+		t.Fatalf("chained scope recovery pre-push fix delta = %q", got.Context.FixDeltaHash)
+	}
+}
+
+func TestCompactPrePRBindsChainedScopeRecoveryDelivery(t *testing.T) {
+	fixture := chainedScopeRecoveryFixture(t)
+	state, receipt := fixture.extendWithSecondDelivery(t)
+	got := EvaluateCompactGate(context.Background(), fixture.repo, receipt, NativeGateRequestInput{
+		Gate: GatePrePR, LineageID: state.LineageID, BaseRef: fixture.baseRef,
+	})
+	if got.Result != GateAllow || !got.Context.BaseRelationshipValid || got.Context.Denial != nil {
+		t.Fatalf("chained scope recovery pre-pr = %#v", got)
+	}
+	if got.Context.FixDeltaHash == EmptyFixDeltaHash || !validSHA256(got.Context.FixDeltaHash) {
+		t.Fatalf("chained scope recovery pre-pr fix delta = %q", got.Context.FixDeltaHash)
+	}
+	precommit := EvaluateCompactGate(context.Background(), fixture.repo, receipt, NativeGateRequestInput{
+		Gate: GatePreCommit, LineageID: state.LineageID,
+	})
+	if precommit.Result != GateAllow {
+		t.Fatalf("chained scope recovery pre-commit = %#v", precommit)
+	}
+}
+
+func TestCompactGateAssessmentBindsChainedScopeRecovery(t *testing.T) {
+	t.Run("pre-push", func(t *testing.T) {
+		fixture := chainedScopeRecoveryFixture(t)
+		store, err := CompactAuthoritativeStore(context.Background(), fixture.repo, fixture.leaf.LineageID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		record, err := store.Load()
+		if err != nil {
+			t.Fatal(err)
+		}
+		assessment, err := AssessCompactGateTarget(context.Background(), fixture.repo, record.State, NativeGateRequestInput{
+			Gate: GatePrePush, LineageID: record.State.LineageID, BaseRef: fixture.baseRef,
+		})
+		if err != nil || assessment.Applicability != CompactGateTargetExact {
+			t.Fatalf("chained recovery pre-push assessment = %q, %v", assessment.Applicability, err)
+		}
+	})
+	t.Run("pre-pr", func(t *testing.T) {
+		fixture := chainedScopeRecoveryFixture(t)
+		state, _ := fixture.extendWithSecondDelivery(t)
+		store, err := CompactAuthoritativeStore(context.Background(), fixture.repo, state.LineageID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		record, err := store.Load()
+		if err != nil {
+			t.Fatal(err)
+		}
+		assessment, err := AssessCompactGateTarget(context.Background(), fixture.repo, record.State, NativeGateRequestInput{
+			Gate: GatePrePR, LineageID: record.State.LineageID, BaseRef: fixture.baseRef,
+		})
+		if err != nil || assessment.Applicability != CompactGateTargetExact {
+			t.Fatalf("chained recovery pre-pr assessment = %q, %v", assessment.Applicability, err)
+		}
+	})
+}
+
+func TestCompactPrePushDeriveFailureCarriesReceiptDenialContext(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	branch := currentBranch(context.Background(), repo)
+	configurePublicationRemote(t, repo, branch)
+	gitSnapshot(t, repo, "config", "branch."+branch+".remote", "origin")
+	gitSnapshot(t, repo, "config", "branch."+branch+".merge", "refs/heads/"+branch)
+	state := correctedCompactTestState(t, repo, "compact-derive-denial-context")
+	receipt := persistCorrectedCompactFixture(t, repo, state)
+	gitSnapshot(t, repo, "add", "tracked.txt")
+	gitSnapshot(t, repo, "commit", "-m", "corrected delivery")
+	gitSnapshot(t, repo, "commit", "--allow-empty", "-m", "unreviewed extra commit")
+	got := EvaluateCompactGate(context.Background(), repo, receipt, NativeGateRequestInput{
+		Gate: GatePrePush, LineageID: state.LineageID, BaseRef: "origin/" + branch,
+	})
+	if got.Result != GateInvalidated || !strings.Contains(got.Reason, "reviewed delivery is not exactly one commit") {
+		t.Fatalf("underivable pre-push delivery = %#v", got)
+	}
+	if got.Context.LineageID != state.LineageID || got.Context.BaseTree != receipt.BaseTree ||
+		got.Context.CandidateTree != receipt.FinalCandidateTree || got.Context.FixDeltaHash != receipt.FixDeltaHash ||
+		got.Context.Denial == nil {
+		t.Fatalf("underivable pre-push denial context = %#v", got.Context)
+	}
+}
+
+func TestCompactChainedRecoveryRebindFailsClosedWithoutBoundPredecessorReceipt(t *testing.T) {
+	fixture := chainedScopeRecoveryFixture(t)
+	if err := os.Remove(fixture.rootStore.ReceiptPath()); err != nil {
+		t.Fatal(err)
+	}
+	got := EvaluateCompactGate(context.Background(), fixture.repo, fixture.receipt, NativeGateRequestInput{
+		Gate: GatePrePush, LineageID: fixture.leaf.LineageID, BaseRef: fixture.baseRef,
+	})
+	if got.Result == GateAllow {
+		t.Fatalf("receiptless predecessor rebind = %#v", got)
+	}
+}
+
+func TestCompactChainedRecoveryRebindRejectsExtraDeliveryCommit(t *testing.T) {
+	fixture := chainedScopeRecoveryFixture(t)
+	gitSnapshot(t, fixture.repo, "commit", "--allow-empty", "-m", "unreviewed extra commit")
+	got := EvaluateCompactGate(context.Background(), fixture.repo, fixture.receipt, NativeGateRequestInput{
+		Gate: GatePrePush, LineageID: fixture.leaf.LineageID, BaseRef: fixture.baseRef,
+	})
+	if got.Result == GateAllow {
+		t.Fatalf("multi-commit chained recovery delivery = %#v", got)
+	}
+}
+
+func TestCompactChainedRecoveryRebindRejectsUncoveredPublicationPath(t *testing.T) {
+	fixture := chainedScopeRecoveryFixture(t)
+	state, receipt := fixture.extendWithSecondDelivery(t)
+	writeSnapshotFile(t, fixture.repo, "outside.txt", "unreviewed\n")
+	gitSnapshot(t, fixture.repo, "add", "outside.txt")
+	gitSnapshot(t, fixture.repo, "commit", "-m", "unreviewed path")
+	got := EvaluateCompactGate(context.Background(), fixture.repo, receipt, NativeGateRequestInput{
+		Gate: GatePrePR, LineageID: state.LineageID, BaseRef: fixture.baseRef,
+	})
+	if got.Result == GateAllow {
+		t.Fatalf("uncovered publication path rebind = %#v", got)
+	}
+}
+
+func TestCompactChainedRecoveryRebindRejectsAdvancedBoundary(t *testing.T) {
+	fixture := chainedScopeRecoveryFixture(t)
+	state, receipt := fixture.extendWithSecondDelivery(t)
+	side := t.TempDir()
+	gitSnapshot(t, fixture.repo, "clone", fixture.remote, side)
+	gitSnapshot(t, side, "config", "user.email", "side@example.com")
+	gitSnapshot(t, side, "config", "user.name", "Side")
+	writeSnapshotFile(t, side, "base-only.txt", "unrelated boundary advance\n")
+	gitSnapshot(t, side, "add", "base-only.txt")
+	gitSnapshot(t, side, "commit", "-m", "boundary advance")
+	gitSnapshot(t, side, "push", "origin", "HEAD:"+fixture.branch)
+	gitSnapshot(t, fixture.repo, "fetch", "origin")
+	got := EvaluateCompactGate(context.Background(), fixture.repo, receipt, NativeGateRequestInput{
+		Gate: GatePrePR, LineageID: state.LineageID, BaseRef: fixture.baseRef,
+	})
+	if got.Result == GateAllow {
+		t.Fatalf("advanced boundary rebind = %#v", got)
+	}
+}


### PR DESCRIPTION
Fixes #1422

## Problem

A `scope_changed` recovery successor created after its predecessor's delivery was committed is forced pristine, so it can only restate the delivered tree as its own base. Its receipt then carries base==candidate, empty genesis paths, and the empty-input fix delta hash forever. Pre-push failed one-commit derivation with a fully empty denial context, and pre-pr denied `receipt-binding/candidate-or-paths-mismatch` with `base_relationship_valid:false` even though the delivered candidate tree matched the receipt exactly. Only pre-commit bound.

## Fix

New `compactRecoveryBinding` (internal/reviewtransaction/compact_recovery_binding.go), engaged only at pre-push/pre-pr, only when `Recovery != nil`, and only when the direct binding would deny while the delivered candidate still equals `receipt.FinalCandidateTree`:

- **Chain composition**: walks `scope_changed` edges leafward-to-root; every composed predecessor must be terminally approved, its persisted receipt must equal the authority-derived receipt, revision and tree continuity must hold, and the edge must pass `validateCompactRecoveryEdge`. Composed values: root's reviewed base, canonical genesis union, and a domain-separated fix delta hash over the ordered member hashes.
- **Fail-closed native re-derivation**: linear history whose trees progress exactly through member final-candidate trees, per-member segment paths within that member's frozen genesis, final tree equal to the delivered candidate, pre-push one-commit retry against the composed base, and an under-lock re-derivation requiring exact equality with the pre-lock binding.
- Every failure path degrades to the original denial; derive failures now carry receipt-digest denial context instead of an empty one. Non-recovery lineages and direct-binding recovery lineages are behavior-identical.

## Review

Native bounded review (high risk, 4R): zero blocking findings. WARNINGs routed as follow-ups: unbounded chain-walk depth on Assess path (reachable only via direct store tampering), duplicated retry block lacking the WHY comment on one site, and the uncovered-path guard test denying via the earlier candidate-mismatch check. All gates allow (pre-pr validated with a main-built binary including the #1376 compatible-base-advance fix).

## Tests

Failing-first: `TestCompactPrePushBindsChainedScopeRecoveryDelivery`, `TestCompactPrePRBindsChainedScopeRecoveryDelivery`, `TestCompactGateAssessmentBindsChainedScopeRecovery`, `TestCompactPrePushDeriveFailureCarriesReceiptDenialContext`, plus CLI end-to-end `TestValidateBindsScopeChangedRecoveryChainAtPublicationGates`. Fail-closed guards: tampered predecessor receipt, extra delivery commit, uncovered publication path, advanced boundary. Full `internal/reviewtransaction` + `internal/cli` suites pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved pre-push and pre-PR validation for chained scope-changed recovery deliveries using compact binding.
  * Added recovery rebind behavior so gates can be reassessed when delivery derivation initially fails but the chained lineage remains consistent.
  * Validation now surfaces richer denial context for compact gate failures.
* **Bug Fixes**
  * Prevented acceptance when predecessor receipts, exact commit boundaries, publication paths, or base relationships are missing or inconsistent.
  * Refined invalidation to report delivery-derivation issues with clearer denial stage and reasons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->