### PR TITLE
fix(review): preflight capture bindings and preserve failed lens results

### DIFF
--- a/internal/assets/assets_test.go
+++ b/internal/assets/assets_test.go
@@ -426,17 +426,39 @@ func TestReviewResultArtifactsPluginContract(t *testing.T) {
 	for _, want := range []string{
 		`spawn("gentle-ai"`,
 		`"review", "capture-result"`,
+		`"review", "preserve-result"`,
 		`"--lineage", binding.lineage`,
 		`"--target", binding.target`,
 		`"--lens", binding.lens`,
 		`"--order", String(binding.order)`,
 		`"--input", "-"`,
+		`"--preflight"`,
+		`GENTLE_AI_REVIEW_CWD`,
 		`"tool.execute.before"`,
 		`output.args.background === true`,
+		`await preflightCapture(captureCwd(worktree, directory), parseBinding(output.args.prompt, output.args.subagent_type))`,
 		`!BINDING.test(input.args.prompt)`,
 		`const lens = input.args.subagent_type`,
 		`const binding = parseBinding(input.args.prompt, lens)`,
-		`output.output = await captureResult`,
+		`const cwd = captureCwd(worktree, directory)`,
+		// The replayable payload is extracted exactly once before capture, so a
+		// capture failure preserves the extracted strict JSON, never the task
+		// envelope that `review capture-result --input` would reject on replay.
+		`result = reviewerResult(output.output)`,
+		`output.output = await captureResult(cwd, binding, result)`,
+		`throw await preservedCaptureFailure(cwd, binding, result, cause)`,
+		// Envelope extraction itself can fail; only then is the raw envelope
+		// preserved, under a distinct extraction-failure cause.
+		`throw await preservedCaptureFailure(cwd, binding, output.output, cause)`,
+		`raw reviewer result preserved for recovery`,
+		`raw reviewer result could not be preserved`,
+		// Double failure (capture and preserve both failed) must embed the
+		// bounded raw payload in the thrown error so the transcript retains it.
+		`raw reviewer result follows for manual recovery`,
+		`PRESERVE_EMBED_LIMIT`,
+		// An older installed gentle-ai without --preflight must degrade
+		// gracefully instead of hard-blocking every bound lens launch.
+		`flag provided but not defined`,
 		`export default ReviewResultArtifactsPlugin`,
 	} {
 		if !strings.Contains(source, want) {

--- a/internal/assets/opencode/plugins/review-result-artifacts.ts
+++ b/internal/assets/opencode/plugins/review-result-artifacts.ts
@@ -51,13 +51,15 @@ function reviewerResult(output: unknown): string {
   return envelope[1]
 }
 
-function captureResult(cwd: string, binding: ReviewBinding, result: string): Promise<string> {
+function captureCwd(worktree: string | undefined, directory: string): string {
+  const override = process.env["GENTLE_AI_REVIEW_CWD"]
+  if (typeof override === "string" && override.trim() !== "") return override.trim()
+  return worktree || directory
+}
+
+function runNative(cwd: string, args: string[], stdin: string): Promise<string> {
   return new Promise((resolve, reject) => {
-    const child = spawn("gentle-ai", [
-      "review", "capture-result", "--cwd", cwd,
-      "--lineage", binding.lineage, "--target", binding.target,
-      "--lens", binding.lens, "--order", String(binding.order), "--input", "-",
-    ], { cwd, stdio: ["pipe", "pipe", "pipe"] })
+    const child = spawn("gentle-ai", args, { cwd, stdio: ["pipe", "pipe", "pipe"] })
     const stdout: Buffer[] = []
     const stderr: Buffer[] = []
     child.stdout.on("data", (chunk: Buffer) => stdout.push(chunk))
@@ -69,25 +71,125 @@ function captureResult(cwd: string, binding: ReviewBinding, result: string): Pro
         resolve(Buffer.concat(stdout).toString("utf8").trim())
         return
       }
-      reject(new Error(`gentle-ai review capture-result failed (${code ?? "signal"}): ${Buffer.concat(stderr).toString("utf8").trim()}`))
+      reject(new Error(`gentle-ai ${args[0]} ${args[1]} failed (${code ?? "signal"}): ${Buffer.concat(stderr).toString("utf8").trim()}`))
     })
-    child.stdin.end(result)
+    child.stdin.end(stdin)
   })
+}
+
+function captureResult(cwd: string, binding: ReviewBinding, result: string): Promise<string> {
+  return runNative(cwd, [
+    "review", "capture-result", "--cwd", cwd,
+    "--lineage", binding.lineage, "--target", binding.target,
+    "--lens", binding.lens, "--order", String(binding.order), "--input", "-",
+  ], result)
+}
+
+async function preflightCapture(cwd: string, binding: ReviewBinding): Promise<void> {
+  try {
+    await runNative(cwd, [
+      "review", "capture-result", "--cwd", cwd,
+      "--lineage", binding.lineage, "--target", binding.target,
+      "--lens", binding.lens, "--order", String(binding.order), "--preflight",
+    ], "")
+  } catch (cause) {
+    // An older installed gentle-ai binary rejects the flag itself ("flag
+    // provided but not defined: -preflight"). That is version skew, not a
+    // binding problem: degrade gracefully and let the real capture path
+    // behave exactly as it did before preflight existed.
+    const message = errorMessage(cause)
+    if (message.includes("flag provided but not defined") && message.includes("-preflight")) return
+    throw new Error(
+      `review capture preflight failed for lens ${binding.lens} under ${cwd}: ${errorMessage(cause)}. ` +
+      `The reviewer was not launched, so its exactly-once invocation is preserved. ` +
+      `If lineage ${binding.lineage} was started in a different repository (for example a nested one), ` +
+      `set GENTLE_AI_REVIEW_CWD to that repository and relaunch the lens.`,
+    )
+  }
+}
+
+function preserveResult(cwd: string, binding: ReviewBinding, raw: string): Promise<string> {
+  return runNative(cwd, [
+    "review", "preserve-result", "--cwd", cwd,
+    "--lineage", binding.lineage, "--target", binding.target,
+    "--lens", binding.lens, "--order", String(binding.order), "--input", "-",
+  ], raw)
+}
+
+function errorMessage(cause: unknown): string {
+  return cause instanceof Error ? cause.message : String(cause)
+}
+
+function preservedReference(manifest: string): string {
+  try {
+    const parsed = JSON.parse(manifest) as { path?: unknown }
+    if (parsed && typeof parsed.path === "string" && parsed.path !== "") return parsed.path
+  } catch {
+    // fall through to the full manifest
+  }
+  return manifest
+}
+
+// Bound on the raw payload embedded in a double-failure error message. The
+// native side already caps preserved payloads at 4 MiB; embedding is a last
+// resort into the session transcript, so keep it far smaller.
+const PRESERVE_EMBED_LIMIT = 64 * 1024
+
+function embeddedRawPayload(raw: string): string {
+  if (raw.length <= PRESERVE_EMBED_LIMIT) return raw
+  return `${raw.slice(0, PRESERVE_EMBED_LIMIT)}\n[truncated: first ${PRESERVE_EMBED_LIMIT} of ${raw.length} characters embedded]`
+}
+
+async function preservedCaptureFailure(cwd: string, binding: ReviewBinding, raw: unknown, cause: unknown): Promise<Error> {
+  if (typeof raw !== "string" || raw.trim() === "") {
+    return new Error(`${errorMessage(cause)}; no raw reviewer result was available to preserve`)
+  }
+  try {
+    const manifest = await preserveResult(cwd, binding, raw)
+    return new Error(`${errorMessage(cause)}; raw reviewer result preserved for recovery at ${preservedReference(manifest)}`)
+  } catch (preserveCause) {
+    // Double failure: durable preservation itself failed, so the transcript
+    // is the only remaining copy — embed the bounded payload in the error.
+    return new Error(
+      `${errorMessage(cause)}; raw reviewer result could not be preserved: ${errorMessage(preserveCause)}; ` +
+      `raw reviewer result follows for manual recovery:\n${embeddedRawPayload(raw)}`,
+    )
+  }
 }
 
 const ReviewResultArtifactsPlugin: Plugin = async ({ directory, worktree }) => ({
   "tool.execute.before": async (input, output) => {
-    if (input.tool === "task" && typeof output.args?.subagent_type === "string" &&
-        REVIEW_AGENTS.has(output.args.subagent_type) && BINDING.test(output.args.prompt) && output.args.background === true) {
+    if (input.tool !== "task" || typeof output.args?.subagent_type !== "string" ||
+        !REVIEW_AGENTS.has(output.args.subagent_type) || !BINDING.test(output.args.prompt)) return
+    if (output.args.background === true) {
       throw new Error("bound review tasks must run in the foreground for native result capture")
     }
+    await preflightCapture(captureCwd(worktree, directory), parseBinding(output.args.prompt, output.args.subagent_type))
   },
   "tool.execute.after": async (input, output) => {
     if (input.tool !== "task" || typeof input.args?.subagent_type !== "string" || !REVIEW_AGENTS.has(input.args.subagent_type)) return
     if (typeof input.args.prompt !== "string" || !BINDING.test(input.args.prompt)) return
     const lens = input.args.subagent_type
     const binding = parseBinding(input.args.prompt, lens)
-    output.output = await captureResult(worktree || directory, binding, reviewerResult(output.output))
+    const cwd = captureCwd(worktree, directory)
+    // Extract the replayable payload exactly once, BEFORE capture: recovery
+    // re-runs `review capture-result --input <preserved file>`, whose strict
+    // decoder rejects the task envelope, so a capture failure must preserve
+    // the extracted strict JSON — never the enveloped output.output.
+    let result: string
+    try {
+      result = reviewerResult(output.output)
+    } catch (cause) {
+      // Extraction itself failed (malformed envelope): there is no extracted
+      // payload, so preserve the raw envelope under the distinct extraction
+      // cause for manual inspection.
+      throw await preservedCaptureFailure(cwd, binding, output.output, cause)
+    }
+    try {
+      output.output = await captureResult(cwd, binding, result)
+    } catch (cause) {
+      throw await preservedCaptureFailure(cwd, binding, result, cause)
+    }
   },
 })
 

--- a/internal/cli/review_artifact.go
+++ b/internal/cli/review_artifact.go
@@ -55,6 +55,7 @@ func RunReviewCaptureResult(args []string, stdout io.Writer) error {
 	lens := flags.String("lens", "", "exact selected lens")
 	order := flags.Int("order", -1, "zero-based selected lens order")
 	input := flags.String("input", "", "raw reviewer result JSON file or - for stdin")
+	preflight := flags.Bool("preflight", false, "verify the capture binding against the current reviewing authority without reading or persisting any result")
 	if err := parseReviewFlags(flags, args); err != nil {
 		return err
 	}
@@ -62,8 +63,11 @@ func RunReviewCaptureResult(args []string, stdout io.Writer) error {
 		return nil
 	}
 	if flags.NArg() != 0 || strings.TrimSpace(*lineage) == "" || strings.TrimSpace(*target) == "" ||
-		strings.TrimSpace(*lens) == "" || *order < 0 || strings.TrimSpace(*input) == "" {
-		return reviewPreflightError(errors.New("review capture-result requires exact --cwd, --lineage, --target, --lens, --order, and --input"))
+		strings.TrimSpace(*lens) == "" || *order < 0 || (!*preflight && strings.TrimSpace(*input) == "") {
+		return reviewPreflightError(errors.New("review capture-result requires exact --cwd, --lineage, --target, --lens, --order, and --input (or --preflight)"))
+	}
+	if *preflight && strings.TrimSpace(*input) != "" {
+		return reviewPreflightError(errors.New("review capture-result --preflight verifies the binding only and does not accept --input"))
 	}
 	ctx := context.Background()
 	root, err := (reviewtransaction.SnapshotBuilder{Repo: *cwd}).ResolveRepositoryRoot(ctx)
@@ -72,12 +76,18 @@ func RunReviewCaptureResult(args []string, stdout io.Writer) error {
 	}
 	store, record, err := discoverCompactFacadeReview(ctx, root, *lineage, false)
 	if err != nil {
-		return err
+		return reviewPreflightError(fmt.Errorf("resolve reviewing authority for lineage %q under repository %q: %w; if the review was started in a different repository (for example a nested one), re-run with --cwd set to that repository", *lineage, root, err))
 	}
 	state := record.State
 	if state.State != reviewtransaction.StateReviewing || state.LineageID != *lineage || state.InitialSnapshot.Identity != *target ||
 		*order >= len(state.SelectedLenses) || state.SelectedLenses[*order] != *lens {
-		return reviewPreflightError(errors.New("capture binding does not match the current reviewing authority"))
+		return reviewPreflightError(fmt.Errorf("capture binding does not match the current reviewing authority under repository %q; verify the frozen lineage, target, lens, and order for that repository, or re-run with --cwd set to the repository where the review was started", root))
+	}
+	if *preflight {
+		return encodeReviewJSON(stdout, reviewCapturePreflightResult{
+			Schema: reviewCapturePreflightSchema, Capability: reviewCapturePreflightCapability, RepositoryRoot: root,
+			LineageID: state.LineageID, TargetIdentity: state.InitialSnapshot.Identity, Lens: *lens, SelectedOrder: *order,
+		})
 	}
 	payload, err := readFacadeBytes(*input)
 	if err != nil {

--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -225,7 +225,7 @@ var reviewFacadeCommittedTransitionHook = func(context.Context, string, string, 
 func RunReview(args []string, stdout io.Writer) error {
 	if len(args) == 0 || args[0] == "help" || args[0] == "-h" || args[0] == "--help" {
 		_, _ = fmt.Fprintln(stdout, "Usage: gentle-ai review <capabilities|start|finalize|validate|status|invalidate|recover|reclaim|reconcile-authority|schema|bind-sdd> [flags]\n\nOrdinary review facade; repository scope, authority, canonical artifacts, and lifecycle transitions are derived by Go.")
-		_, _ = fmt.Fprintln(stdout, "Additive headless capability: gentle-ai review capture-result.")
+		_, _ = fmt.Fprintln(stdout, "Additive headless capabilities: gentle-ai review capture-result (with --preflight) and gentle-ai review preserve-result.")
 		return nil
 	}
 	operation, negotiated, preflightFailure := reviewIntegrationFailureRoute(args)
@@ -293,6 +293,8 @@ func runReviewCommand(args []string, stdout io.Writer) error {
 	switch args[0] {
 	case "capture-result":
 		return RunReviewCaptureResult(args[1:], stdout)
+	case "preserve-result":
+		return RunReviewPreserveResult(args[1:], stdout)
 	case "capabilities":
 		return RunReviewCapabilities(args[1:], stdout)
 	case "start":

--- a/internal/cli/review_incident.go
+++ b/internal/cli/review_incident.go
@@ -1,0 +1,160 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+
+	"github.com/gentleman-programming/gentle-ai/internal/reviewtransaction"
+)
+
+const (
+	reviewCapturePreflightSchema     = "gentle-ai.review-capture-preflight/v1"
+	reviewCapturePreflightCapability = "review.native_capture_preflight"
+	reviewIncidentArtifactSchema     = "gentle-ai.review-incident-artifact/v1"
+	reviewIncidentArtifactCapability = "review.native_incident_artifact"
+)
+
+// reviewCapturePreflightResult confirms that one capture binding matches the
+// reviewing authority reachable from the resolved repository root, before a
+// bound reviewer consumes its exactly-once invocation.
+type reviewCapturePreflightResult struct {
+	Schema         string `json:"schema"`
+	Capability     string `json:"capability"`
+	RepositoryRoot string `json:"repository_root"`
+	LineageID      string `json:"lineage_id"`
+	TargetIdentity string `json:"target_identity"`
+	Lens           string `json:"lens"`
+	SelectedOrder  int    `json:"selected_order"`
+}
+
+// reviewIncidentArtifact references one durably preserved raw reviewer result.
+// Its schema is distinct from the captured-result artifact schema on purpose:
+// finalize rejects it, so a preserved incident can never masquerade as a
+// verified lens capture.
+type reviewIncidentArtifact struct {
+	Schema         string `json:"schema"`
+	Capability     string `json:"capability"`
+	Path           string `json:"path"`
+	SHA256         string `json:"sha256"`
+	LineageID      string `json:"lineage_id"`
+	TargetIdentity string `json:"target_identity"`
+	Lens           string `json:"lens"`
+	SelectedOrder  int    `json:"selected_order"`
+}
+
+// RunReviewPreserveResult durably preserves one raw reviewer result as an
+// incident artifact beside the compact review authority root after a failed
+// capture. It never validates the payload against the reviewing authority and
+// never counts as a captured lens result; recovery re-runs
+// `review capture-result` with the preserved payload from the reviewing
+// repository, which performs full native verification.
+func RunReviewPreserveResult(args []string, stdout io.Writer) error {
+	flags := newReviewFlagSet("review preserve-result", stdout, "Durably preserve one raw reviewer result as an incident artifact after a failed capture; never a captured lens result.")
+	cwd := flags.String("cwd", ".", "repository path")
+	lineage := flags.String("lineage", "", "exact review lineage identifier from the capture binding")
+	target := flags.String("target", "", "exact frozen target identity from the capture binding")
+	lens := flags.String("lens", "", "exact selected lens from the capture binding")
+	order := flags.Int("order", -1, "zero-based selected lens order from the capture binding")
+	input := flags.String("input", "", "raw reviewer result file or - for stdin")
+	if err := parseReviewFlags(flags, args); err != nil {
+		return err
+	}
+	if reviewHelpRequested(args) {
+		return nil
+	}
+	if flags.NArg() != 0 || strings.TrimSpace(*input) == "" {
+		return reviewPreflightError(errors.New("review preserve-result requires exact --cwd, --lineage, --target, --lens, --order, and --input"))
+	}
+	switch *lens {
+	case reviewtransaction.LensRisk, reviewtransaction.LensResilience, reviewtransaction.LensReadability, reviewtransaction.LensReliability:
+	default:
+		return reviewPreflightError(fmt.Errorf("review preserve-result requires one exact canonical lens; got %q", *lens))
+	}
+	if !validReviewCapabilitySHA256(*target) || *order < 0 || *order >= 4 {
+		return reviewPreflightError(errors.New("review preserve-result requires the exact frozen target identity and selected lens order"))
+	}
+	dir, err := reviewtransaction.CompactIncidentsDir(context.Background(), *cwd, *lineage)
+	if err != nil {
+		return reviewPreflightError(fmt.Errorf("resolve incident preservation directory: %w", err))
+	}
+	payload, err := readFacadeBytes(*input)
+	if err != nil {
+		return reviewPreflightError(fmt.Errorf("read raw reviewer result: %w", err))
+	}
+	if len(payload) == 0 || len(payload) > reviewResultArtifactLimit {
+		return reviewPreflightError(errors.New("raw reviewer result must be non-empty and within the native result size limit"))
+	}
+	artifact, err := preserveIncidentArtifact(dir, *lineage, *target, *lens, *order, payload)
+	if err != nil {
+		return reviewPreflightError(err)
+	}
+	return encodeReviewJSON(stdout, artifact)
+}
+
+func preserveIncidentArtifact(dir, lineage, target, lens string, order int, payload []byte) (reviewIncidentArtifact, error) {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return reviewIncidentArtifact{}, fmt.Errorf("create incident preservation directory: %w", err)
+	}
+	info, err := os.Lstat(dir)
+	if err != nil || !info.IsDir() || info.Mode()&os.ModeSymlink != 0 || !reviewArtifactModeSafe(info.Mode(), true) {
+		return reviewIncidentArtifact{}, errors.New("incident preservation directory is not a private native directory")
+	}
+	hash := facadePayloadHash(payload)
+	path := filepath.Join(dir, fmt.Sprintf("%02d-%s-%s.raw", order, lens, strings.TrimPrefix(hash, "sha256:")[:12]))
+	artifact := reviewIncidentArtifact{
+		Schema: reviewIncidentArtifactSchema, Capability: reviewIncidentArtifactCapability, Path: path,
+		SHA256: hash, LineageID: lineage, TargetIdentity: target, Lens: lens, SelectedOrder: order,
+	}
+	if existing, readErr := os.ReadFile(path); readErr == nil {
+		if !bytes.Equal(existing, payload) {
+			return reviewIncidentArtifact{}, errors.New("incident artifact already exists with different bytes")
+		}
+		return artifact, nil
+	} else if !os.IsNotExist(readErr) {
+		return reviewIncidentArtifact{}, readErr
+	}
+	temp, err := os.CreateTemp(dir, ".incident-*")
+	if err != nil {
+		return reviewIncidentArtifact{}, fmt.Errorf("create incident temporary file: %w", err)
+	}
+	owned, _ := temp.Stat()
+	defer removeOwnedArtifact(temp.Name(), owned)
+	if err := temp.Chmod(0o600); err != nil {
+		return reviewIncidentArtifact{}, err
+	}
+	if _, err := temp.Write(payload); err != nil {
+		return reviewIncidentArtifact{}, err
+	}
+	if err := temp.Sync(); err != nil {
+		return reviewIncidentArtifact{}, err
+	}
+	if err := temp.Close(); err != nil {
+		return reviewIncidentArtifact{}, err
+	}
+	if err := reviewtransaction.PublishFileNoReplace(temp.Name(), path); err != nil {
+		if existing, readErr := os.ReadFile(path); readErr == nil && bytes.Equal(existing, payload) {
+			return artifact, nil
+		}
+		return reviewIncidentArtifact{}, fmt.Errorf("publish incident artifact atomically: %w", err)
+	}
+	if err := syncReviewerArtifactDirectory(dir); err != nil {
+		unsupported := errors.Is(err, syscall.EINVAL) || errors.Is(err, errors.ErrUnsupported) ||
+			reviewArtifactRuntimeGOOS() == "windows" && errors.Is(err, os.ErrPermission)
+		if !unsupported {
+			removeOwnedArtifact(path, owned)
+			return reviewIncidentArtifact{}, fmt.Errorf("sync incident preservation directory: %w", err)
+		}
+	}
+	if preserved, err := os.ReadFile(path); err != nil || !bytes.Equal(preserved, payload) {
+		removeOwnedArtifact(path, owned)
+		return reviewIncidentArtifact{}, fmt.Errorf("read back incident artifact: %w", err)
+	}
+	return artifact, nil
+}

--- a/internal/cli/review_incident_test.go
+++ b/internal/cli/review_incident_test.go
@@ -1,0 +1,266 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/internal/reviewtransaction"
+)
+
+func TestReviewCaptureResultPreflightVerifiesBindingWithoutMutation(t *testing.T) {
+	repo, started, store, record := newArtifactReview(t, false)
+	bindingArgs := func(lens string, order string) []string {
+		return []string{
+			"--cwd", repo, "--lineage", started.LineageID, "--target", record.State.InitialSnapshot.Identity,
+			"--lens", lens, "--order", order, "--preflight",
+		}
+	}
+	var output bytes.Buffer
+	if err := RunReviewCaptureResult(bindingArgs(record.State.SelectedLenses[0], "0"), &output); err != nil {
+		t.Fatalf("valid preflight failed: %v", err)
+	}
+	var preflight reviewCapturePreflightResult
+	decodeStrictReviewJSON(t, output.Bytes(), &preflight)
+	if preflight.Schema != reviewCapturePreflightSchema || preflight.Capability != reviewCapturePreflightCapability ||
+		preflight.RepositoryRoot == "" ||
+		preflight.LineageID != started.LineageID || preflight.TargetIdentity != record.State.InitialSnapshot.Identity ||
+		preflight.Lens != record.State.SelectedLenses[0] || preflight.SelectedOrder != 0 {
+		t.Fatalf("preflight result = %+v", preflight)
+	}
+	if _, err := os.Stat(filepath.Join(store.Dir, reviewtransaction.CompactReviewerResultsDir)); !os.IsNotExist(err) {
+		t.Fatal("preflight persisted a reviewer result artifact")
+	}
+	after, err := store.Load()
+	if err != nil || after.Revision != record.Revision {
+		t.Fatalf("preflight mutated review authority: %v", err)
+	}
+	if err := RunReviewCaptureResult(append(bindingArgs(record.State.SelectedLenses[0], "0"), "--input", "-"), io.Discard); err == nil {
+		t.Fatal("preflight combined with --input was accepted")
+	}
+	if err := RunReviewCaptureResult(bindingArgs("review-risk", "0"), io.Discard); err == nil {
+		t.Fatal("wrong-lens preflight was accepted")
+	}
+}
+
+func TestReviewCaptureResultNestedRepositoryFailsActionablyAndStaysRetriable(t *testing.T) {
+	parent, child := initNestedReviewCLIRepo(t)
+	if err := os.WriteFile(filepath.Join(child, "tracked.txt"), []byte("candidate\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	started := startFacadeReview(t, child)
+	store, _ := reviewtransaction.CompactAuthoritativeStore(context.Background(), child, started.LineageID)
+	record, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	input := filepath.Join(t.TempDir(), "result.json")
+	if err := os.WriteFile(input, []byte(`{"findings":[],"evidence":["checked exact target"]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	args := func(cwd string, rest ...string) []string {
+		return append([]string{
+			"--cwd", cwd, "--lineage", started.LineageID, "--target", record.State.InitialSnapshot.Identity,
+			"--lens", record.State.SelectedLenses[0], "--order", "0",
+		}, rest...)
+	}
+	parentRoot, err := (reviewtransaction.SnapshotBuilder{Repo: parent}).ResolveRepositoryRoot(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, mode := range [][]string{{"--input", input}, {"--preflight"}} {
+		err := RunReviewCaptureResult(args(parent, mode...), io.Discard)
+		if err == nil {
+			t.Fatalf("nested-repo capture %v from parent repository was accepted", mode)
+		}
+		if !strings.Contains(err.Error(), parentRoot) || !strings.Contains(err.Error(), "--cwd") {
+			t.Fatalf("nested-repo capture error is not actionable: %v", err)
+		}
+	}
+	// The failed parent-repository capture must not consume the exactly-once
+	// native lens slot: the same capture succeeds from the reviewing repository.
+	var output bytes.Buffer
+	if err := RunReviewCaptureResult(args(child, "--input", input), &output); err != nil {
+		t.Fatalf("retry from reviewing repository failed: %v", err)
+	}
+	manifest := strings.TrimSpace(output.String())
+	if err := RunReviewFacadeFinalize([]string{"--cwd", child, "--lineage", started.LineageID, "--result-artifact", manifest}, io.Discard); err != nil {
+		t.Fatalf("finalize after recovered capture failed: %v", err)
+	}
+}
+
+func TestReviewPreserveResultDurableIncidentArtifact(t *testing.T) {
+	parent, child := initNestedReviewCLIRepo(t)
+	if err := os.WriteFile(filepath.Join(child, "tracked.txt"), []byte("candidate\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	started := startFacadeReview(t, child)
+	store, _ := reviewtransaction.CompactAuthoritativeStore(context.Background(), child, started.LineageID)
+	record, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw := "raw reviewer output\nthat is not JSON"
+	input := filepath.Join(t.TempDir(), "raw.txt")
+	if err := os.WriteFile(input, []byte(raw), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	args := []string{
+		"--cwd", parent, "--lineage", started.LineageID, "--target", record.State.InitialSnapshot.Identity,
+		"--lens", record.State.SelectedLenses[0], "--order", "0", "--input", input,
+	}
+	var first, replay bytes.Buffer
+	if err := RunReviewPreserveResult(args, &first); err != nil {
+		t.Fatalf("preserve under the non-reviewing repository failed: %v", err)
+	}
+	var artifact reviewIncidentArtifact
+	decodeStrictReviewJSON(t, first.Bytes(), &artifact)
+	if artifact.Schema != reviewIncidentArtifactSchema || artifact.Capability != reviewIncidentArtifactCapability ||
+		artifact.LineageID != started.LineageID || artifact.TargetIdentity != record.State.InitialSnapshot.Identity ||
+		artifact.Lens != record.State.SelectedLenses[0] || artifact.SelectedOrder != 0 {
+		t.Fatalf("incident artifact = %+v", artifact)
+	}
+	if !strings.Contains(artifact.Path, filepath.Join("gentle-ai", "review-transactions", "incidents", started.LineageID)) {
+		t.Fatalf("incident artifact path %q is outside the durable incidents area", artifact.Path)
+	}
+	preserved, err := os.ReadFile(artifact.Path)
+	if err != nil || string(preserved) != raw {
+		t.Fatalf("preserved bytes mismatch: %v %q", err, preserved)
+	}
+	if runtime.GOOS != "windows" {
+		info, err := os.Lstat(artifact.Path)
+		if err != nil || info.Mode().Perm() != 0o600 {
+			t.Fatalf("incident artifact is not owner-only: %v %v", err, info.Mode())
+		}
+	}
+	if err := RunReviewPreserveResult(args, &replay); err != nil || first.String() != replay.String() {
+		t.Fatalf("preserve replay changed: %v", err)
+	}
+	// A different raw result for the same slot is preserved separately instead
+	// of overwriting the first incident.
+	if err := os.WriteFile(input, []byte("second distinct raw output"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var second bytes.Buffer
+	if err := RunReviewPreserveResult(args, &second); err != nil {
+		t.Fatal(err)
+	}
+	var other reviewIncidentArtifact
+	decodeStrictReviewJSON(t, second.Bytes(), &other)
+	if other.Path == artifact.Path || other.SHA256 == artifact.SHA256 {
+		t.Fatal("distinct raw result reused the first incident artifact")
+	}
+	// An incident artifact is never a captured lens result: finalize must
+	// reject its manifest.
+	if err := RunReviewFacadeFinalize([]string{"--cwd", child, "--lineage", started.LineageID, "--result-artifact", strings.TrimSpace(first.String())}, io.Discard); err == nil {
+		t.Fatal("finalize accepted an incident artifact as a captured lens result")
+	}
+}
+
+// TestReviewPreservedResultReplaysThroughCaptureAndFinalize pins the recovery
+// contract documented on RunReviewPreserveResult: a preserved incident payload
+// must replay through `review capture-result --input <preserved path>` and
+// finalize. The plugin must therefore preserve the EXTRACTED strict reviewer
+// JSON on capture failure — a preserved raw task envelope (what the plugin
+// held in output.output before extraction) is rejected by the strict replay
+// decoder and is not a recoverable artifact.
+func TestReviewPreservedResultReplaysThroughCaptureAndFinalize(t *testing.T) {
+	repo, started, _, record := newArtifactReview(t, false)
+	extracted := `{"findings":[],"evidence":["checked exact target"]}`
+	envelope := "<task id=\"lens-1\" state=\"completed\">\n<task_result>\n" + extracted + "\n</task_result>\n</task>"
+	preserve := func(raw string) string {
+		t.Helper()
+		input := filepath.Join(t.TempDir(), "raw.txt")
+		if err := os.WriteFile(input, []byte(raw), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		var output bytes.Buffer
+		if err := RunReviewPreserveResult([]string{
+			"--cwd", repo, "--lineage", started.LineageID, "--target", record.State.InitialSnapshot.Identity,
+			"--lens", record.State.SelectedLenses[0], "--order", "0", "--input", input,
+		}, &output); err != nil {
+			t.Fatalf("preserve failed: %v", err)
+		}
+		var artifact reviewIncidentArtifact
+		decodeStrictReviewJSON(t, output.Bytes(), &artifact)
+		return artifact.Path
+	}
+	captureArgs := func(preserved string) []string {
+		return []string{
+			"--cwd", repo, "--lineage", started.LineageID, "--target", record.State.InitialSnapshot.Identity,
+			"--lens", record.State.SelectedLenses[0], "--order", "0", "--input", preserved,
+		}
+	}
+	// An envelope-wrapped preserved payload is unrecoverable: strict replay
+	// decoding rejects it, and the failed replay must not consume the slot.
+	if err := RunReviewCaptureResult(captureArgs(preserve(envelope)), io.Discard); err == nil {
+		t.Fatal("envelope-wrapped preserved payload replayed through capture-result")
+	}
+	// The extracted strict JSON — what the plugin preserves on capture
+	// failure — replays and finalizes.
+	var output bytes.Buffer
+	if err := RunReviewCaptureResult(captureArgs(preserve(extracted)), &output); err != nil {
+		t.Fatalf("extracted preserved payload failed replay: %v", err)
+	}
+	manifest := strings.TrimSpace(output.String())
+	if err := RunReviewFacadeFinalize([]string{"--cwd", repo, "--lineage", started.LineageID, "--result-artifact", manifest}, io.Discard); err != nil {
+		t.Fatalf("finalize after preserved-result replay failed: %v", err)
+	}
+}
+
+func TestReviewPreserveResultRejectsUnsafeBindings(t *testing.T) {
+	repo, started, _, record := newArtifactReview(t, false)
+	input := filepath.Join(t.TempDir(), "raw.txt")
+	if err := os.WriteFile(input, []byte("raw output"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	valid := map[string]string{
+		"cwd": repo, "lineage": started.LineageID, "target": record.State.InitialSnapshot.Identity,
+		"lens": record.State.SelectedLenses[0], "order": "0", "input": input,
+	}
+	cases := map[string]map[string]string{
+		"lineage":     {"lineage": "Not_A/Lineage"},
+		"target":      {"target": "sha256:xyz"},
+		"lens":        {"lens": "risk"},
+		"order":       {"order": "9"},
+		"empty input": {"input": filepath.Join(t.TempDir(), "missing.txt")},
+	}
+	for name, override := range cases {
+		t.Run(name, func(t *testing.T) {
+			args := []string{}
+			for _, key := range []string{"cwd", "lineage", "target", "lens", "order", "input"} {
+				value := valid[key]
+				if replacement, ok := override[key]; ok {
+					value = replacement
+				}
+				args = append(args, "--"+key, value)
+			}
+			if err := RunReviewPreserveResult(args, io.Discard); err == nil {
+				t.Fatalf("unsafe preserve binding %q was accepted", name)
+			}
+		})
+	}
+}
+
+func initNestedReviewCLIRepo(t *testing.T) (string, string) {
+	t.Helper()
+	parent := initReviewCLIRepo(t)
+	child := filepath.Join(parent, "nested")
+	if err := os.Mkdir(child, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runReviewCLIGit(t, child, "init", "-q")
+	runReviewCLIGit(t, child, "config", "user.email", "test@example.com")
+	runReviewCLIGit(t, child, "config", "user.name", "Test")
+	if err := os.WriteFile(filepath.Join(child, "tracked.txt"), []byte("base\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runReviewCLIGit(t, child, "add", "tracked.txt")
+	runReviewCLIGit(t, child, "commit", "-qm", "base")
+	return parent, child
+}

--- a/internal/reviewtransaction/compact_store.go
+++ b/internal/reviewtransaction/compact_store.go
@@ -515,6 +515,22 @@ func CompactAuthoritativeStore(ctx context.Context, repo, lineageID string) (Com
 	return CompactStore{Dir: dir, lineageID: lineageID, repo: root, lockPath: filepath.Join(versionRoot, "LOCK")}, nil
 }
 
+// CompactIncidentsDir returns the durable raw-result incident directory for
+// one lineage beside the compact authority root. It validates only the
+// lineage shape and never requires the lineage to hold authority under repo,
+// so incident preservation still works when capture was attempted from a
+// repository that does not own the reviewing lineage.
+func CompactIncidentsDir(ctx context.Context, repo, lineageID string) (string, error) {
+	if err := validateLineageID(lineageID); err != nil {
+		return "", err
+	}
+	base, _, err := reviewAuthorityRoot(ctx, repo)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(base, "incidents", lineageID), nil
+}
+
 func DiscoverCompactStores(ctx context.Context, repo string) ([]CompactStore, error) {
 	base, root, err := reviewAuthorityRoot(ctx, repo)
 	if err != nil {


### PR DESCRIPTION
Fixes #1411

## Problem

Lens results were silently lost when `capture-result` failed: OpenCode sessions started from HOME or a parent repository resolved the wrong `--cwd`, the reviewer's exactly-once invocation was consumed, and the raw result vanished with a generic error.

## Fix

- **Preflight before launch**: the bundled plugin runs `capture-result --preflight` before each bound reviewer launches, verifying the binding against the reviewing authority without side effects. Wrong-repository sessions fail fast with an actionable message before the lens run is spent. When the installed binary predates `--preflight`, the plugin degrades silently to pre-preflight behavior instead of hard-blocking lens launches.
- **`GENTLE_AI_REVIEW_CWD`**: explicit override for nested-repository sessions, applied uniformly to preflight, capture, and preserve.
- **Incident preservation**: on capture failure the plugin preserves the extracted reviewer JSON via new `gentle-ai review preserve-result` under `review-transactions/incidents/<lineage>/` (0600, atomic no-replace, content-addressed). The incident schema is distinct from captured results and finalize rejects it; recovery replays the preserved payload through `capture-result` with full native verification. A failed capture never consumes the exactly-once lens slot. If preservation itself fails, a bounded copy of the payload is embedded in the error rather than lost.

## Review

Native bounded review, three rounds (high risk, 4R). Round-1 CRITICALs fixed and re-verified: envelope-wrapped payloads are no longer preserved (extraction happens once, before capture — pinned by a Go round-trip replay test), double preservation failure embeds the payload instead of losing it, and version skew degrades instead of blocking. Remaining WARNINGs (env override validation, incident retention policy, stderr-based skew detection) routed as follow-ups. All gates allow.

## Tests

`TestReviewCaptureResultPreflightVerifiesBindingWithoutMutation`, `TestReviewCaptureResultNestedRepositoryFailsActionablyAndStaysRetriable`, `TestReviewPreserveResultDurableIncidentArtifact`, `TestReviewPreserveResultRejectsUnsafeBindings`, `TestReviewPreservedResultReplaysThroughCaptureAndFinalize` (failing-first for the replay contract). Full assets/reviewtransaction/cli suites pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `review capture-result --preflight` to validate repository and review bindings before capture.
  - Added `review preserve-result` to securely preserve reviewer output for recovery and replay.
  - Added durable incident artifacts with duplicate-safe storage and exact payload retention.

- **Bug Fixes**
  - Improved handling of capture and extraction failures, preserving recoverable reviewer output.
  - Added graceful compatibility with installations that do not support preflight mode.
  - Improved diagnostics for nested repositories and invalid review bindings.

- **Documentation**
  - Updated review command help with the new capture and preservation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->