### PR TITLE
fix(review): repair pre-contract recovery authorizations via reconcile-authority

### DIFF
--- a/internal/cli/review_reconcile.go
+++ b/internal/cli/review_reconcile.go
@@ -16,7 +16,7 @@ type ReviewReconcileAuthorityResult struct {
 }
 
 func RunReviewReconcileAuthority(args []string, stdout io.Writer) error {
-	flags := newReviewFlagSet("review reconcile-authority", stdout, "Quarantine one compact-v2 recovery successor whose recovery edge natively re-derives as invalid for exactly the unchanged-target class, with a persisted audit record carrying the re-derived proof; valid edges, incomplete entries, and non-recovery records are refused. On partial failure the prepared audit record JSON is still emitted to stdout and the command exits non-zero.")
+	flags := newReviewFlagSet("review reconcile-authority", stdout, "Quarantine one compact-v2 recovery successor whose recovery edge natively re-derives as invalid for exactly one supported class — an unchanged target, or a historical pre-contract free-form maintainer authorization on an otherwise structurally consistent edge — with a persisted audit record carrying the re-derived proof; valid edges, incomplete entries, non-recovery records, and structurally inconsistent edges are refused. On partial failure the prepared audit record JSON is still emitted to stdout and the command exits non-zero.")
 	cwd := flags.String("cwd", ".", "repository path")
 	predecessor := flags.String("predecessor-lineage", "", "exact recovery predecessor lineage; it stays untouched")
 	expectedPredecessor := flags.String("expected-predecessor-revision", "", "exact predecessor revision")

--- a/internal/cli/review_reconcile_test.go
+++ b/internal/cli/review_reconcile_test.go
@@ -199,6 +199,195 @@ func TestReviewReconcileAuthorityQuarantinesInvalidEdgeAndRestoresDiscovery(t *t
 	}
 }
 
+// preContractAuthorizationCLIFixture persists an escalated docs-only
+// predecessor with its receipt and a changed-target escalated recovery
+// successor whose sole edge anomaly is a pre-contract free-form maintainer
+// authorization, then restores the clean workspace.
+func preContractAuthorizationCLIFixture(t *testing.T, repo string) (predecessorRevision, successorRevision string) {
+	t.Helper()
+	incident := filepath.Join(repo, "docs", "incident.md")
+	if err := os.MkdirAll(filepath.Dir(incident), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(incident, []byte("incident\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	builder := reviewtransaction.SnapshotBuilder{Repo: repo}
+	predecessorSnapshot, err := builder.Build(context.Background(), reviewtransaction.Target{
+		Kind: reviewtransaction.TargetCurrentChanges, IntendedUntracked: []string{"docs/incident.md"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	risk, lines, err := builder.ClassifySnapshotRisk(context.Background(), predecessorSnapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if risk != reviewtransaction.RiskLow {
+		t.Fatalf("pre-contract fixture risk = %q", risk)
+	}
+	policy := sha256.Sum256([]byte("reconcile-policy"))
+	policyHash := "sha256:" + hex.EncodeToString(policy[:])
+	predecessorState, err := reviewtransaction.NewCompactState(reviewtransaction.Start{
+		LineageID: "reconcile-incident", Mode: reviewtransaction.ModeOrdinaryBounded, Generation: 1,
+		Snapshot: predecessorSnapshot, PolicyHash: policyHash, RiskLevel: risk, SelectedLenses: []string{}, OriginalChangedLines: &lines,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	predecessorState.State = reviewtransaction.StateEscalated
+	predecessorRevision = writeReconcileCLIRecord(t, repo, predecessorState)
+	receipt, err := predecessorState.Receipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	receiptPath := filepath.Join(reviewCLIAuthorityRoot(t, repo), "v2", predecessorState.LineageID, "review-receipt.json")
+	if err := reviewtransaction.WriteCompactReceiptAtomic(receiptPath, receipt); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(incident, []byte("incident retried with a changed target\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	successorSnapshot, err := builder.Build(context.Background(), reviewtransaction.Target{
+		Kind: reviewtransaction.TargetCurrentChanges, IntendedUntracked: []string{"docs/incident.md"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	successorRisk, successorLines, err := builder.ClassifySnapshotRisk(context.Background(), successorSnapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	successorState, err := reviewtransaction.NewCompactState(reviewtransaction.Start{
+		LineageID: "reconcile-incident-g2", Mode: reviewtransaction.ModeOrdinaryBounded, Generation: 2,
+		Snapshot: successorSnapshot, PolicyHash: policyHash, RiskLevel: successorRisk, SelectedLenses: []string{}, OriginalChangedLines: &successorLines,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	successorState.Recovery = &reviewtransaction.CompactRecoveryProvenance{
+		PredecessorLineageID: predecessorState.LineageID, PredecessorRevision: predecessorRevision,
+		Disposition: reviewtransaction.RecoveryEscalated, Reason: "retry after escalation", Actor: "maintainer@example.com",
+		RecoveredAt:             time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC),
+		MaintainerAuthorization: "maintainer approved incident retry per the 2.1.6 runbook",
+	}
+	successorRevision = writeReconcileCLIRecord(t, repo, successorState)
+	if err := os.Remove(incident); err != nil {
+		t.Fatal(err)
+	}
+	return predecessorRevision, successorRevision
+}
+
+func preContractReconcileCLIArgs(repo, predecessorRevision, successorRevision, authorization string) []string {
+	return []string{
+		"reconcile-authority", "--cwd", repo,
+		"--predecessor-lineage", "reconcile-incident", "--expected-predecessor-revision", predecessorRevision,
+		"--successor-lineage", "reconcile-incident-g2", "--expected-successor-revision", successorRevision,
+		"--reason", "quarantine pre-contract recovery authorization", "--actor", "maintainer@example.com",
+		"--maintainer-authorization", authorization,
+	}
+}
+
+func preContractReconcileCLIBinding(predecessorRevision, successorRevision string) string {
+	return "gentle-ai.review-reconcile-authorization/v1\npredecessor_lineage=reconcile-incident\npredecessor_revision=" + predecessorRevision +
+		"\nsuccessor_lineage=reconcile-incident-g2\nsuccessor_revision=" + successorRevision +
+		"\nactor=maintainer@example.com\nreason=quarantine pre-contract recovery authorization"
+}
+
+func TestReviewReconcileAuthorityRepairsPreContractAuthorizationAndRestoresLifecycle(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	approveDiscoveryMarkdown(t, repo, "review-reconcile-valid", "docs/valid.md", "valid\n")
+	predecessorRevision, successorRevision := preContractAuthorizationCLIFixture(t, repo)
+
+	var statusOutput bytes.Buffer
+	if err := RunReview([]string{"status", "--cwd", repo}, &statusOutput); err != nil {
+		t.Fatalf("review status over pre-contract graph: %v", err)
+	}
+	var before reviewtransaction.AuthorityStatusReport
+	decodeStrictReviewJSON(t, statusOutput.Bytes(), &before)
+	if before.Complete || before.Authoritative {
+		t.Fatalf("pre-contract status = complete %v authoritative %v", before.Complete, before.Authoritative)
+	}
+	malformedProblem := false
+	for _, entry := range before.Entries {
+		if entry.LineageID != "reconcile-incident-g2" {
+			continue
+		}
+		for _, problem := range entry.Problems {
+			malformedProblem = malformedProblem || strings.Contains(problem, "escalated recovery requires an exact maintainer authorization binding")
+		}
+	}
+	if !malformedProblem {
+		t.Fatalf("pre-contract status problems = %#v", before.Entries)
+	}
+
+	var blockedOutput bytes.Buffer
+	err := RunReview([]string{
+		"validate", "--contract", ReviewIntegrationContractV1, "--cwd", repo,
+		"--gate", string(reviewtransaction.GatePostApply),
+	}, &blockedOutput)
+	if err == nil {
+		t.Fatal("pre-contract recovery edge did not deny lineage-less gate validation")
+	}
+	failure := decodeReviewIntegrationFailure(t, blockedOutput.Bytes())
+	if failure.Code != "authority_corrupted" {
+		t.Fatalf("pre-contract gate failure = %#v", failure)
+	}
+
+	var reconcileOutput bytes.Buffer
+	if err := RunReview(preContractReconcileCLIArgs(repo, predecessorRevision, successorRevision, preContractReconcileCLIBinding(predecessorRevision, successorRevision)), &reconcileOutput); err != nil {
+		t.Fatalf("review reconcile-authority pre-contract repair: %v\n%s", err, reconcileOutput.String())
+	}
+	var result ReviewReconcileAuthorityResult
+	decodeStrictReviewJSON(t, reconcileOutput.Bytes(), &result)
+	if result.Operation != "review/reconcile-authority" || result.Record.LineageID != "reconcile-incident-g2" ||
+		result.Record.Status != reviewtransaction.CompactReclaimCommitted || result.Record.InvalidRecoveryEdge != nil {
+		t.Fatalf("review reconcile-authority pre-contract result = %#v", result)
+	}
+	recordedDigest := sha256.Sum256([]byte("maintainer approved incident retry per the 2.1.6 runbook"))
+	if result.Record.MalformedRecoveryAuthorization == nil ||
+		result.Record.MalformedRecoveryAuthorization.PredecessorLineageID != "reconcile-incident" ||
+		result.Record.MalformedRecoveryAuthorization.PredecessorRevision != predecessorRevision ||
+		result.Record.MalformedRecoveryAuthorization.SuccessorRevision != successorRevision ||
+		result.Record.MalformedRecoveryAuthorization.RecordedAuthorizationSHA256 != "sha256:"+hex.EncodeToString(recordedDigest[:]) ||
+		!strings.Contains(result.Record.MalformedRecoveryAuthorization.ValidationError, "exact maintainer authorization binding") {
+		t.Fatalf("review reconcile-authority pre-contract proof = %#v", result.Record.MalformedRecoveryAuthorization)
+	}
+	if _, err := os.Stat(filepath.Join(result.Record.QuarantinePath, "residue", "review-state.json")); err != nil {
+		t.Fatalf("quarantined successor state missing: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(reviewCLIAuthorityRoot(t, repo), "v2", "reconcile-incident-g2")); !os.IsNotExist(err) {
+		t.Fatalf("reconciled successor entry still present: %v", err)
+	}
+
+	statusOutput.Reset()
+	if err := RunReview([]string{"status", "--cwd", repo}, &statusOutput); err != nil {
+		t.Fatalf("review status after pre-contract repair: %v", err)
+	}
+	var after reviewtransaction.AuthorityStatusReport
+	decodeStrictReviewJSON(t, statusOutput.Bytes(), &after)
+	if !after.Complete || !after.Authoritative {
+		t.Fatalf("post-repair status = complete %v authoritative %v", after.Complete, after.Authoritative)
+	}
+
+	var validateOutput bytes.Buffer
+	if err := RunReview([]string{
+		"validate", "--contract", ReviewIntegrationContractV1, "--cwd", repo,
+		"--gate", string(reviewtransaction.GatePostApply),
+	}, &validateOutput); err != nil {
+		t.Fatalf("post-repair lineage-less validation: %v\n%s", err, validateOutput.String())
+	}
+	var validated ReviewValidateResult
+	decodeStrictReviewJSON(t, decodeReviewOperationEnvelope(t, validateOutput.Bytes()).Result, &validated)
+	if !validated.Allowed || validated.Context.LineageID != "review-reconcile-valid" {
+		t.Fatalf("post-repair validation = %#v", validated)
+	}
+
+	if err := RunReview(preContractReconcileCLIArgs(repo, predecessorRevision, successorRevision, preContractReconcileCLIBinding(predecessorRevision, successorRevision)), &bytes.Buffer{}); err == nil {
+		t.Fatal("pre-contract reconcile-authority replayed after quarantine")
+	}
+}
+
 func TestReviewReconcileAuthorityRequiresFlagsAndExactBinding(t *testing.T) {
 	repo := initReviewCLIRepo(t)
 	predecessorRevision, successorRevision := invalidRecoveryEdgeCLIFixture(t, repo)

--- a/internal/reviewtransaction/compact_reclaim.go
+++ b/internal/reviewtransaction/compact_reclaim.go
@@ -49,8 +49,13 @@ type CompactReclaimRecord struct {
 	QuarantinePath string    `json:"quarantine_path"`
 	Residue        []string  `json:"residue"`
 	// InvalidRecoveryEdge carries the natively re-derived edge-invalidity
-	// proof; it is set only for reconcile-authority quarantines.
+	// proof; it is set only for reconcile-authority quarantines of the
+	// unchanged-target class.
 	InvalidRecoveryEdge *CompactInvalidRecoveryEdgeProof `json:"invalid_recovery_edge,omitempty"`
+	// MalformedRecoveryAuthorization carries the natively re-derived
+	// pre-contract authorization proof; it is set only for reconcile-authority
+	// quarantines of the malformed-recovery-authorization class.
+	MalformedRecoveryAuthorization *CompactMalformedRecoveryAuthorizationProof `json:"malformed_recovery_authorization,omitempty"`
 }
 
 // compactAuthoritativeArtifact reports whether a store-entry name carries

--- a/internal/reviewtransaction/compact_reconcile.go
+++ b/internal/reviewtransaction/compact_reconcile.go
@@ -2,6 +2,8 @@ package reviewtransaction
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"os"
@@ -36,6 +38,18 @@ type CompactInvalidRecoveryEdgeProof struct {
 	ValidationError      string `json:"validation_error"`
 }
 
+// CompactMalformedRecoveryAuthorizationProof records the natively re-derived
+// pre-contract authorization anomaly inside the quarantine audit record. The
+// recorded free-form authorization stays byte-preserved in the quarantined
+// residue; the proof binds it by digest.
+type CompactMalformedRecoveryAuthorizationProof struct {
+	PredecessorLineageID        string `json:"predecessor_lineage_id"`
+	PredecessorRevision         string `json:"predecessor_revision"`
+	SuccessorRevision           string `json:"successor_revision"`
+	RecordedAuthorizationSHA256 string `json:"recorded_authorization_sha256"`
+	ValidationError             string `json:"validation_error"`
+}
+
 func compactReconcileAuthorizationBinding(predecessorLineage, predecessorRevision, successorLineage, successorRevision, actor, reason string) string {
 	return compactReconcileAuthorizationSchema + "\npredecessor_lineage=" + predecessorLineage +
 		"\npredecessor_revision=" + predecessorRevision + "\nsuccessor_lineage=" + successorLineage +
@@ -44,12 +58,17 @@ func compactReconcileAuthorizationBinding(predecessorLineage, predecessorRevisio
 }
 
 // ReconcileInvalidRecoveryEdge quarantines one compact-v2 recovery successor
-// whose recovery edge natively re-derives as invalid for exactly the
-// unchanged-target class. The predecessor and every unrelated authority stay
-// untouched; the successor entry moves whole — never deleted — into the
-// audited quarantine together with the re-derived proof. Valid edges,
-// incomplete entries, non-recovery records, stale revisions, inexact
-// authorization, and any additional graph defect are refused.
+// whose recovery edge natively re-derives as invalid for exactly one of two
+// supported classes: the unchanged-target class, and the pre-contract
+// malformed-recovery-authorization class in which a historical free-form
+// maintainer authorization predates the exact
+// gentle-ai.review-recovery-authorization/v1 binding while the edge is
+// otherwise structurally consistent. The predecessor and every unrelated
+// authority stay untouched; the successor entry moves whole — never deleted —
+// into the audited quarantine together with the re-derived proof. Valid
+// edges, incomplete entries, non-recovery records, stale revisions, inexact
+// authorization, structurally inconsistent edges, and any additional graph
+// defect are refused.
 func ReconcileInvalidRecoveryEdge(ctx context.Context, repo string, request CompactReconcileRequest) (CompactReclaimRecord, error) {
 	if err := ctx.Err(); err != nil {
 		return CompactReclaimRecord{}, err
@@ -111,11 +130,38 @@ func ReconcileInvalidRecoveryEdge(ctx context.Context, repo string, request Comp
 	if edgeErr == nil {
 		return CompactReclaimRecord{}, fmt.Errorf("review reconcile-authority refused: recovery edge for %q validates; the successor remains authoritative", request.SuccessorLineageID)
 	}
-	if !errors.Is(edgeErr, errCompactRecoveryTargetUnchanged) {
-		return CompactReclaimRecord{}, fmt.Errorf("review reconcile-authority refused: recovery edge fails outside the unchanged-target class: %v", edgeErr)
-	}
-	if recovery.MaintainerAuthorization != compactRecoveryAuthorizationBinding(predecessor.State.LineageID, predecessor.Revision, successor.State.InitialSnapshot.Identity, recovery.Actor, recovery.Reason) {
-		return CompactReclaimRecord{}, errors.New("review reconcile-authority refused: unchanged target is not the sole anomaly; the recorded recovery authorization binding is inexact")
+	exactRecordedBinding := compactRecoveryAuthorizationBinding(predecessor.State.LineageID, predecessor.Revision, successor.State.InitialSnapshot.Identity, recovery.Actor, recovery.Reason)
+	var invalidEdgeProof *CompactInvalidRecoveryEdgeProof
+	var malformedAuthorizationProof *CompactMalformedRecoveryAuthorizationProof
+	switch {
+	case errors.Is(edgeErr, errCompactRecoveryTargetUnchanged):
+		if recovery.MaintainerAuthorization != exactRecordedBinding {
+			return CompactReclaimRecord{}, errors.New("review reconcile-authority refused: unchanged target is not the sole anomaly; the recorded recovery authorization binding is inexact")
+		}
+		invalidEdgeProof = &CompactInvalidRecoveryEdgeProof{
+			PredecessorLineageID: request.PredecessorLineageID, PredecessorRevision: predecessor.Revision,
+			SuccessorRevision: successor.Revision, ValidationError: edgeErr.Error(),
+		}
+	case errors.Is(edgeErr, errCompactRecoveryAuthorizationInexact):
+		if strings.HasPrefix(recovery.MaintainerAuthorization, compactRecoveryAuthorizationSchema) {
+			return CompactReclaimRecord{}, fmt.Errorf("review reconcile-authority refused: successor %q records a %s binding bound to different content; that is corruption, not a pre-contract authorization", request.SuccessorLineageID, compactRecoveryAuthorizationSchema)
+		}
+		repaired := successor.State
+		provenance := *recovery
+		provenance.MaintainerAuthorization = exactRecordedBinding
+		repaired.Recovery = &provenance
+		if residualErr := validateCompactRecoveryEdge(predecessor, repaired); residualErr != nil {
+			return CompactReclaimRecord{}, fmt.Errorf("review reconcile-authority refused: the pre-contract authorization is not the sole edge anomaly: %v", residualErr)
+		}
+		recorded := sha256.Sum256([]byte(recovery.MaintainerAuthorization))
+		malformedAuthorizationProof = &CompactMalformedRecoveryAuthorizationProof{
+			PredecessorLineageID: request.PredecessorLineageID, PredecessorRevision: predecessor.Revision,
+			SuccessorRevision:           successor.Revision,
+			RecordedAuthorizationSHA256: "sha256:" + hex.EncodeToString(recorded[:]),
+			ValidationError:             edgeErr.Error(),
+		}
+	default:
+		return CompactReclaimRecord{}, fmt.Errorf("review reconcile-authority refused: recovery edge fails outside the unchanged-target class and the pre-contract authorization class: %v", edgeErr)
 	}
 	stores, err := DiscoverCompactStores(ctx, repo)
 	if err != nil {
@@ -163,9 +209,7 @@ func ReconcileInvalidRecoveryEdge(ctx context.Context, repo string, request Comp
 		Schema: CompactReclaimRecordSchema, Status: CompactReclaimPrepared, LineageID: request.SuccessorLineageID,
 		Reason: strings.TrimSpace(request.Reason), Actor: strings.TrimSpace(request.Actor),
 		ReclaimedAt: request.ReconciledAt.UTC(), SourcePath: dir, Residue: residue,
-		InvalidRecoveryEdge: &CompactInvalidRecoveryEdgeProof{
-			PredecessorLineageID: request.PredecessorLineageID, PredecessorRevision: predecessor.Revision,
-			SuccessorRevision: successor.Revision, ValidationError: edgeErr.Error(),
-		},
+		InvalidRecoveryEdge:            invalidEdgeProof,
+		MalformedRecoveryAuthorization: malformedAuthorizationProof,
 	})
 }

--- a/internal/reviewtransaction/compact_reconcile_test.go
+++ b/internal/reviewtransaction/compact_reconcile_test.go
@@ -3,6 +3,8 @@ package reviewtransaction
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"os"
@@ -468,6 +470,339 @@ func TestReconcileInvalidRecoveryEdgeRefusesIneligibleTargetsAndBindings(t *test
 		}
 		if _, err := ReconcileInvalidRecoveryEdge(context.Background(), repo, reconcileFixtureRequest(predecessor, successor)); err == nil || !strings.Contains(err.Error(), "sole anomaly") {
 			t.Fatalf("inexact recorded binding reconcile error = %v", err)
+		}
+		assertUntouched(t, repo, successorStore, payload)
+	})
+}
+
+// preContractRecoveryFixture persists an escalated predecessor with its
+// receipt and a changed-target escalated recovery successor whose sole edge
+// anomaly is a pre-contract free-form maintainer authorization written before
+// the exact gentle-ai.review-recovery-authorization/v1 binding existed.
+// mutate, when non-nil, adjusts the successor before it is persisted.
+func preContractRecoveryFixture(t *testing.T, repo, authorization string, mutate func(*CompactState)) (CompactRecord, CompactStore, CompactRecord, CompactStore) {
+	t.Helper()
+	state := correctedCompactTestState(t, repo, "reconcile-predecessor")
+	state.State = StateEscalated
+	predecessorStore, err := CompactAuthoritativeStore(context.Background(), repo, state.LineageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	predecessor := writeCompactFixtureRecord(t, predecessorStore, state)
+	receipt, err := state.Receipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteCompactReceiptAtomic(predecessorStore.ReceiptPath(), receipt); err != nil {
+		t.Fatal(err)
+	}
+	writeSnapshotFile(t, repo, "tracked.txt", "pre-contract recovery target\n")
+	successorState := newCompactTestState(t, repo, "reconcile-successor")
+	successorState.Generation = state.Generation + 1
+	successorState.Recovery = &CompactRecoveryProvenance{
+		PredecessorLineageID: state.LineageID, PredecessorRevision: predecessor.Revision,
+		Disposition: RecoveryEscalated, Reason: "retry terminal validator", Actor: "maintainer@example.com",
+		RecoveredAt:             time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC),
+		MaintainerAuthorization: authorization,
+	}
+	if mutate != nil {
+		mutate(&successorState)
+	}
+	successorStore, err := CompactAuthoritativeStore(context.Background(), repo, successorState.LineageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	successor := writeCompactFixtureRecord(t, successorStore, successorState)
+	return predecessor, predecessorStore, successor, successorStore
+}
+
+const preContractFixtureAuthorization = "maintainer approved incident retry per the 2.1.6 runbook"
+
+func preContractReconcileRequest(predecessor, successor CompactRecord) CompactReconcileRequest {
+	request := CompactReconcileRequest{
+		PredecessorLineageID: predecessor.State.LineageID, ExpectedPredecessorRevision: predecessor.Revision,
+		SuccessorLineageID: successor.State.LineageID, ExpectedSuccessorRevision: successor.Revision,
+		Reason: "quarantine pre-contract recovery authorization", Actor: "maintainer@example.com",
+	}
+	request.MaintainerAuthorization = compactReconcileAuthorizationBinding(
+		request.PredecessorLineageID, predecessor.Revision, request.SuccessorLineageID, successor.Revision,
+		request.Actor, request.Reason)
+	return request
+}
+
+func TestReconcilePreContractAuthorizationRepairsRecoveryDeadlock(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	predecessor, predecessorStore, successor, successorStore := preContractRecoveryFixture(t, repo, preContractFixtureAuthorization, nil)
+
+	// The historical free-form authorization bricks whole-graph validation.
+	if _, err := CompactAuthorityLeaves(context.Background(), repo); err == nil ||
+		!strings.Contains(err.Error(), "invalid compact authority graph: escalated recovery requires an exact maintainer authorization binding") {
+		t.Fatalf("poisoned graph leaves error = %v", err)
+	}
+	before, err := InventoryAuthority(context.Background(), repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if before.Complete || before.Authoritative || !hasAuthorityInventoryStatus(before.Entries, successor.State.LineageID, AuthorityStatusInvalid) {
+		t.Fatalf("poisoned inventory = %#v", before)
+	}
+	// START fails closed for any fresh target.
+	writeSnapshotFile(t, repo, "tracked.txt", "fresh start target\n")
+	if _, err := StartCompactAuthority(context.Background(), repo, CompactStartRequest{State: newCompactTestState(t, repo, "reconcile-fresh")}); err == nil ||
+		!strings.Contains(err.Error(), "exact maintainer authorization binding") {
+		t.Fatalf("poisoned start error = %v", err)
+	}
+	// RECOVER deadlocks: publishing an exactly bound successor still reaches
+	// whole-graph validation before the successor can be written.
+	writeSnapshotFile(t, repo, "tracked.txt", "recover repair target\n")
+	deadlocked := newCompactTestState(t, repo, "reconcile-repair")
+	deadlocked.Generation = predecessor.State.Generation + 1
+	deadlockedRecovery := CompactRecoveryRequest{
+		PredecessorLineageID: predecessor.State.LineageID, ExpectedPredecessorRevision: predecessor.Revision,
+		Successor: deadlocked, Disposition: RecoveryEscalated,
+		Reason: "retry terminal validator", Actor: "maintainer@example.com",
+	}
+	deadlockedRecovery.MaintainerAuthorization = compactRecoveryAuthorizationBinding(
+		predecessor.State.LineageID, predecessor.Revision, deadlocked.InitialSnapshot.Identity,
+		deadlockedRecovery.Actor, deadlockedRecovery.Reason)
+	if _, err := RecoverCompactAuthority(context.Background(), repo, deadlockedRecovery); err == nil ||
+		!strings.Contains(err.Error(), "exact maintainer authorization binding") {
+		t.Fatalf("poisoned recover error = %v", err)
+	}
+
+	predecessorStateBefore, err := os.ReadFile(predecessorStore.StatePath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	predecessorReceiptBefore, err := os.ReadFile(predecessorStore.ReceiptPath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	successorPayload, err := os.ReadFile(successorStore.StatePath())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	request := preContractReconcileRequest(predecessor, successor)
+	record, err := ReconcileInvalidRecoveryEdge(context.Background(), repo, request)
+	if err != nil {
+		t.Fatalf("reconcile pre-contract authorization: %v", err)
+	}
+	if record.Schema != CompactReclaimRecordSchema || record.Status != CompactReclaimCommitted ||
+		record.LineageID != successor.State.LineageID || record.SourcePath != successorStore.Dir ||
+		record.Reason != request.Reason || record.Actor != request.Actor || record.ReclaimedAt.IsZero() {
+		t.Fatalf("pre-contract reconcile record = %#v", record)
+	}
+	if record.InvalidRecoveryEdge != nil {
+		t.Fatalf("pre-contract reconcile carries the unchanged-target proof class: %#v", record.InvalidRecoveryEdge)
+	}
+	recordedDigest := sha256.Sum256([]byte(preContractFixtureAuthorization))
+	if record.MalformedRecoveryAuthorization == nil ||
+		record.MalformedRecoveryAuthorization.PredecessorLineageID != predecessor.State.LineageID ||
+		record.MalformedRecoveryAuthorization.PredecessorRevision != predecessor.Revision ||
+		record.MalformedRecoveryAuthorization.SuccessorRevision != successor.Revision ||
+		record.MalformedRecoveryAuthorization.RecordedAuthorizationSHA256 != "sha256:"+hex.EncodeToString(recordedDigest[:]) ||
+		!strings.Contains(record.MalformedRecoveryAuthorization.ValidationError, "exact maintainer authorization binding") {
+		t.Fatalf("pre-contract reconcile proof = %#v", record.MalformedRecoveryAuthorization)
+	}
+	if len(record.Residue) != 1 || record.Residue[0] != "review-state.json" {
+		t.Fatalf("pre-contract reconcile residue manifest = %#v", record.Residue)
+	}
+	persistedPayload, err := os.ReadFile(filepath.Join(record.QuarantinePath, "reclaim-record.json"))
+	if err != nil {
+		t.Fatalf("read persisted pre-contract audit record: %v", err)
+	}
+	var persisted CompactReclaimRecord
+	if err := json.Unmarshal(persistedPayload, &persisted); err != nil {
+		t.Fatalf("parse persisted pre-contract audit record: %v", err)
+	}
+	if persisted.Status != CompactReclaimCommitted || persisted.InvalidRecoveryEdge != nil ||
+		persisted.MalformedRecoveryAuthorization == nil ||
+		persisted.MalformedRecoveryAuthorization.RecordedAuthorizationSHA256 != record.MalformedRecoveryAuthorization.RecordedAuthorizationSHA256 ||
+		!strings.Contains(persisted.MalformedRecoveryAuthorization.ValidationError, "exact maintainer authorization binding") {
+		t.Fatalf("persisted pre-contract audit record = %#v", persisted)
+	}
+	if _, statErr := os.Stat(successorStore.Dir); !os.IsNotExist(statErr) {
+		t.Fatalf("reconciled successor entry still present: %v", statErr)
+	}
+	moved, err := os.ReadFile(filepath.Join(record.QuarantinePath, "residue", "review-state.json"))
+	if err != nil || !bytes.Equal(moved, successorPayload) {
+		t.Fatalf("quarantined successor bytes = %q, %v", moved, err)
+	}
+	predecessorStateAfter, _ := os.ReadFile(predecessorStore.StatePath())
+	predecessorReceiptAfter, _ := os.ReadFile(predecessorStore.ReceiptPath())
+	if !bytes.Equal(predecessorStateBefore, predecessorStateAfter) || !bytes.Equal(predecessorReceiptBefore, predecessorReceiptAfter) {
+		t.Fatal("pre-contract reconcile changed predecessor state or receipt bytes")
+	}
+
+	// STATUS, START, and RECOVER all work again.
+	leaves, err := CompactAuthorityLeaves(context.Background(), repo)
+	if err != nil || len(leaves) != 1 || leaves[0].lineageID != predecessor.State.LineageID {
+		t.Fatalf("post-reconcile leaves = %#v, %v", leaves, err)
+	}
+	after, err := InventoryAuthority(context.Background(), repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !after.Complete || !after.Authoritative {
+		t.Fatalf("post-reconcile inventory = %#v", after)
+	}
+	if _, err := ReconcileInvalidRecoveryEdge(context.Background(), repo, request); err == nil {
+		t.Fatal("pre-contract reconcile replayed after the successor entry was quarantined")
+	}
+	writeSnapshotFile(t, repo, "tracked.txt", "post-repair target\n")
+	started, err := StartCompactAuthority(context.Background(), repo, CompactStartRequest{State: newCompactTestState(t, repo, "reconcile-post-repair")})
+	if err != nil || started.Action != CompactStartRecover || started.Record.State.LineageID != predecessor.State.LineageID {
+		t.Fatalf("post-reconcile lineage-less start = %#v, %v", started, err)
+	}
+	repair := newCompactTestState(t, repo, "reconcile-repair")
+	repair.Generation = predecessor.State.Generation + 1
+	recovery := CompactRecoveryRequest{
+		PredecessorLineageID: predecessor.State.LineageID, ExpectedPredecessorRevision: predecessor.Revision,
+		Successor: repair, Disposition: RecoveryEscalated,
+		Reason: "retry terminal validator", Actor: "maintainer@example.com",
+	}
+	recovery.MaintainerAuthorization = compactRecoveryAuthorizationBinding(
+		predecessor.State.LineageID, predecessor.Revision, repair.InitialSnapshot.Identity, recovery.Actor, recovery.Reason)
+	published, err := RecoverCompactAuthority(context.Background(), repo, recovery)
+	if err != nil {
+		t.Fatalf("post-reconcile recover: %v", err)
+	}
+	leaves, err = CompactAuthorityLeaves(context.Background(), repo)
+	if err != nil || len(leaves) != 1 || leaves[0].lineageID != published.State.LineageID {
+		t.Fatalf("post-recover leaves = %#v, %v", leaves, err)
+	}
+}
+
+func TestReconcilePreContractAuthorizationRefusesIneligibleEdges(t *testing.T) {
+	assertUntouched := func(t *testing.T, repo string, store CompactStore, payload []byte) {
+		t.Helper()
+		current, err := os.ReadFile(store.StatePath())
+		if err != nil || !bytes.Equal(current, payload) {
+			t.Fatalf("refused pre-contract reconcile mutated the successor entry: %q, %v", current, err)
+		}
+		root, _, err := reviewAuthorityRoot(context.Background(), repo)
+		if err != nil {
+			t.Fatal(err)
+		}
+		entries, err := os.ReadDir(filepath.Join(root, "quarantine"))
+		if err == nil && len(entries) != 0 {
+			t.Fatalf("refused pre-contract reconcile left quarantine entries: %#v", entries)
+		}
+	}
+
+	t.Run("structurally inconsistent edge is corruption, not legacy format", func(t *testing.T) {
+		repo := initSnapshotRepo(t)
+		predecessor, _, successor, successorStore := preContractRecoveryFixture(t, repo, preContractFixtureAuthorization, func(state *CompactState) {
+			state.Generation = 1
+		})
+		payload, err := os.ReadFile(successorStore.StatePath())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := ReconcileInvalidRecoveryEdge(context.Background(), repo, preContractReconcileRequest(predecessor, successor)); err == nil ||
+			!strings.Contains(err.Error(), "outside the unchanged-target class and the pre-contract authorization class") ||
+			!strings.Contains(err.Error(), "generation must follow predecessor") {
+			t.Fatalf("structurally inconsistent pre-contract reconcile error = %v", err)
+		}
+		assertUntouched(t, repo, successorStore, payload)
+	})
+
+	t.Run("v1 binding bound to different content is corruption", func(t *testing.T) {
+		repo := initSnapshotRepo(t)
+		predecessor, _, successor, successorStore := preContractRecoveryFixture(t, repo, "placeholder", func(state *CompactState) {
+			state.Recovery.MaintainerAuthorization = compactRecoveryAuthorizationBinding(
+				state.Recovery.PredecessorLineageID, state.Recovery.PredecessorRevision,
+				state.InitialSnapshot.Identity, state.Recovery.Actor, "different reason")
+		})
+		payload, err := os.ReadFile(successorStore.StatePath())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := ReconcileInvalidRecoveryEdge(context.Background(), repo, preContractReconcileRequest(predecessor, successor)); err == nil ||
+			!strings.Contains(err.Error(), "corruption, not a pre-contract authorization") {
+			t.Fatalf("wrong-content v1 binding reconcile error = %v", err)
+		}
+		assertUntouched(t, repo, successorStore, payload)
+	})
+
+	t.Run("malformed successor has its own successor", func(t *testing.T) {
+		repo := initSnapshotRepo(t)
+		predecessor, _, successor, successorStore := preContractRecoveryFixture(t, repo, preContractFixtureAuthorization, nil)
+		payload, err := os.ReadFile(successorStore.StatePath())
+		if err != nil {
+			t.Fatal(err)
+		}
+		writeSnapshotFile(t, repo, "tracked.txt", "grandchild target\n")
+		grandchild := newCompactTestState(t, repo, "reconcile-grandchild")
+		grandchild.Generation = successor.State.Generation + 1
+		grandchild.Recovery = &CompactRecoveryProvenance{
+			PredecessorLineageID: successor.State.LineageID, PredecessorRevision: successor.Revision,
+			Disposition: RecoveryEscalated, Reason: "descendant of the malformed successor", Actor: "maintainer@example.com",
+			RecoveredAt:             time.Date(2026, 7, 18, 14, 0, 0, 0, time.UTC),
+			MaintainerAuthorization: compactRecoveryAuthorizationBinding(successor.State.LineageID, successor.Revision, grandchild.InitialSnapshot.Identity, "maintainer@example.com", "descendant of the malformed successor"),
+		}
+		grandchildStore, err := CompactAuthoritativeStore(context.Background(), repo, grandchild.LineageID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		writeCompactFixtureRecord(t, grandchildStore, grandchild)
+		if _, err := ReconcileInvalidRecoveryEdge(context.Background(), repo, preContractReconcileRequest(predecessor, successor)); err == nil ||
+			!strings.Contains(err.Error(), `has its own successor "reconcile-grandchild"`) {
+			t.Fatalf("descendant pre-contract reconcile error = %v", err)
+		}
+		assertUntouched(t, repo, successorStore, payload)
+	})
+
+	t.Run("malformed edge is not the sole graph anomaly", func(t *testing.T) {
+		repo := initSnapshotRepo(t)
+		predecessor, _, successor, successorStore := preContractRecoveryFixture(t, repo, preContractFixtureAuthorization, nil)
+		payload, err := os.ReadFile(successorStore.StatePath())
+		if err != nil {
+			t.Fatal(err)
+		}
+		root, _, err := reviewAuthorityRoot(context.Background(), repo)
+		if err != nil {
+			t.Fatal(err)
+		}
+		writeReclaimFixtureFile(t, filepath.Join(root, "v2", "reconcile-unrelated", "review-state.json"), "not json\n")
+		if _, err := ReconcileInvalidRecoveryEdge(context.Background(), repo, preContractReconcileRequest(predecessor, successor)); err == nil ||
+			!strings.Contains(err.Error(), `related compact authority "reconcile-unrelated" does not load`) {
+			t.Fatalf("unrelated-anomaly pre-contract reconcile error = %v", err)
+		}
+		assertUntouched(t, repo, successorStore, payload)
+	})
+
+	t.Run("missing repair authorization", func(t *testing.T) {
+		repo := initSnapshotRepo(t)
+		predecessor, _, successor, successorStore := preContractRecoveryFixture(t, repo, preContractFixtureAuthorization, nil)
+		payload, err := os.ReadFile(successorStore.StatePath())
+		if err != nil {
+			t.Fatal(err)
+		}
+		request := preContractReconcileRequest(predecessor, successor)
+		request.MaintainerAuthorization = ""
+		if _, err := ReconcileInvalidRecoveryEdge(context.Background(), repo, request); err == nil ||
+			!strings.Contains(err.Error(), "exact maintainer authorization binding") {
+			t.Fatalf("missing repair authorization reconcile error = %v", err)
+		}
+		assertUntouched(t, repo, successorStore, payload)
+	})
+
+	t.Run("repair authorization bound to different content", func(t *testing.T) {
+		repo := initSnapshotRepo(t)
+		predecessor, _, successor, successorStore := preContractRecoveryFixture(t, repo, preContractFixtureAuthorization, nil)
+		payload, err := os.ReadFile(successorStore.StatePath())
+		if err != nil {
+			t.Fatal(err)
+		}
+		request := preContractReconcileRequest(predecessor, successor)
+		request.MaintainerAuthorization = compactReconcileAuthorizationBinding(
+			request.PredecessorLineageID, successor.Revision, request.SuccessorLineageID, predecessor.Revision,
+			request.Actor, request.Reason)
+		if _, err := ReconcileInvalidRecoveryEdge(context.Background(), repo, request); err == nil ||
+			!strings.Contains(err.Error(), "exact maintainer authorization binding") {
+			t.Fatalf("mismatched repair authorization reconcile error = %v", err)
 		}
 		assertUntouched(t, repo, successorStore, payload)
 	})

--- a/internal/reviewtransaction/compact_store.go
+++ b/internal/reviewtransaction/compact_store.go
@@ -41,6 +41,15 @@ var ErrLegacyReadOnly = errors.New("legacy v1 review lineage is read-only")
 // anomaly so reconcile-authority can gate quarantine to exactly this class.
 var errCompactRecoveryTargetUnchanged = errors.New("escalated recovery successor target has not changed")
 
+// errCompactRecoveryAuthorizationInexact identifies the escalated-recovery
+// authorization-binding anomaly so reconcile-authority can gate quarantine of
+// historical pre-contract free-form authorizations to exactly this class.
+var errCompactRecoveryAuthorizationInexact = errors.New("escalated recovery requires an exact maintainer authorization binding")
+
+// compactRecoveryAuthorizationSchema is the first line of the exact six-line
+// escalated-recovery maintainer authorization binding.
+const compactRecoveryAuthorizationSchema = "gentle-ai.review-recovery-authorization/v1"
+
 // ErrHistoricalCompatReadOnly denies ordinary mutation of authority loaded
 // through the retired-field compatibility path.
 var ErrHistoricalCompatReadOnly = errors.New("historical compatibility authority is read-only")
@@ -370,7 +379,7 @@ func compactHistoricalFailedValidator(state CompactState) bool {
 }
 
 func compactRecoveryAuthorizationBinding(lineage, revision, targetIdentity, actor, reason string) string {
-	return "gentle-ai.review-recovery-authorization/v1\npredecessor_lineage=" + lineage +
+	return compactRecoveryAuthorizationSchema + "\npredecessor_lineage=" + lineage +
 		"\npredecessor_revision=" + revision + "\ntarget_identity=" + targetIdentity +
 		"\nactor=" + strings.TrimSpace(actor) + "\nreason=" + strings.TrimSpace(reason)
 }
@@ -390,7 +399,7 @@ func compactRecoveryAuthorizationError(snapshot Snapshot) error {
 	if projection == "" {
 		projection = ProjectionWorkspace
 	}
-	return fmt.Errorf("escalated recovery requires an exact maintainer authorization binding (projection=%s target_identity=%s)", projection, snapshot.Identity)
+	return fmt.Errorf("%w (projection=%s target_identity=%s)", errCompactRecoveryAuthorizationInexact, projection, snapshot.Identity)
 }
 
 func compactRecoveryAddsGenesisPath(predecessor CompactState, live Snapshot) bool {


### PR DESCRIPTION
Fixes #1393

## Problem

A compact-v2 authority inventory containing a historical escalated-recovery edge whose free-form `maintainer_authorization` predates the exact six-line `gentle-ai.review-recovery-authorization/v1` binding (2.1.6-era stores) is permanently bricked on 2.1.7: whole-graph validation rejects the historical edge, so `review status`, `review start`, and `review validate` all fail closed for the entire inventory, and `review recover` cannot repair it because it validates the graph before publishing a successor.

## Fix

`gentle-ai review reconcile-authority` now admits a second class, `malformed_recovery_authorization`, through the same explicit evidence-bound ceremony as the invalid unchanged-target class:

- Admission requires that the recorded authorization does **not** claim the v1 schema (a v1-prefixed binding bound to different content is corruption and stays refused) and that the edge revalidates clean with the exact binding substituted, proving the authorization format is the sole anomaly.
- The repair reuses the shared fail-closed machinery unchanged: sole-anomaly whole-graph checks, sibling-fork and descendant refusal, two-phase byte-preserving quarantine, and the same 7-line maintainer repair binding. A distinct `CompactMalformedRecoveryAuthorizationProof` (recorded-authorization digest plus verbatim validation error) lands on the reclaim record.
- Validation itself stays fail-closed: no legacy tolerance was added to `validateCompactRecoveryEdge`; the sentinel wrapping keeps the error message byte-identical and no other `errors.Is` caller changes behavior.

## Review

Native bounded review (high risk, 4R): zero blocking findings. WARNINGs routed as follow-ups: a BOM-prefix edge in the schema discriminator reachable only via direct store-file tampering, the residual revalidation being tautological under the current check ordering (defense-in-depth against future reordering), and test-helper duplication. All gates allow.

## Tests

Failing-first: `TestReconcilePreContractAuthorizationRepairsRecoveryDeadlock` and `TestReviewReconcileAuthorityRepairsPreContractAuthorizationAndRestoresLifecycle` reproduced the exact deadlock on current main (status/start/validate/recover all failing closed, reconcile refusing with the wrong-class message). Fail-closed guards: structurally inconsistent edges refused as corruption, v1-claiming mismatches refused, descendant successors refused, non-sole anomalies refused, missing repair binding refused — each asserting zero mutation and empty quarantine. Full suites pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reconciliation can now repair eligible legacy recovery records with malformed maintainer authorizations.
  * Invalid or ineligible recovery edges continue to be refused and quarantined safely.
  * Repaired recovery flows can resume normal authority validation and lifecycle operations.

* **Auditability**
  * Reconciliation records now preserve proof of the original malformed authorization using a cryptographic digest.
  * Enhanced status and error details clarify recovery authorization issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->