### PR TITLE
fix(review): validate first publications to empty remotes

### DIFF
--- a/internal/reviewtransaction/compact_gate.go
+++ b/internal/reviewtransaction/compact_gate.go
@@ -240,10 +240,14 @@ func EvaluateCompactGate(ctx context.Context, repo string, receipt CompactReceip
 	if request.Gate == GatePrePush && record.State.InitialSnapshot.Kind == TargetCurrentChanges && resolvedPrePR.DeliveredCommitCount != 1 {
 		return invalid("pre-push current-changes receipt requires exactly one delivery commit")
 	}
-	validatePublicationRange := request.Gate == GatePrePush && record.State.InitialSnapshot.Kind == TargetBaseDiff ||
+	// An empty-remote bootstrap publishes the candidate's complete history,
+	// so publication-range validation is mandatory for every target kind —
+	// including current-changes; no kind may skip it.
+	bootstrapPublication := resolvedPrePR != nil && resolvedPrePR.Selection.Source == PrePRBoundaryEmptyRemoteBootstrap
+	validatePublicationRange := request.Gate == GatePrePush && (record.State.InitialSnapshot.Kind == TargetBaseDiff || bootstrapPublication) ||
 		record.State.InitialSnapshot.Kind == TargetBaseWorkspaceOverlay && (request.Gate == GatePrePush || request.Gate == GatePrePR)
 	if validatePublicationRange {
-		if err := validateCompactPublicationRange(ctx, repo, record.State.GenesisPaths, resolvedPrePR); err != nil {
+		if err := validateReviewedPublicationRange(ctx, repo, record.State.GenesisPaths, resolvedPrePR); err != nil {
 			return invalid(err.Error())
 		}
 	}
@@ -506,7 +510,7 @@ func buildCompactGateRequestWithPushBase(ctx context.Context, repo string, state
 		}
 		request.Target = Target{Kind: TargetCurrentChanges, Projection: projection, IntendedUntracked: intended}
 	case GatePrePush:
-		target, push, err := buildPushTarget(ctx, repo, input.BaseRef, deliveryBaseTree)
+		target, push, err := buildPushTarget(ctx, repo, input.BaseRef, deliveryBaseTree, state.InitialSnapshot.BaseTree)
 		if err != nil {
 			return GateRequest{}, nil, err
 		}
@@ -604,24 +608,26 @@ func validateCompactCommittedTrackedScope(ctx context.Context, repo string, requ
 	return errors.New("committed approved target has dirty tracked changes")
 }
 
-func validateCompactPublicationRange(ctx context.Context, repo string, genesis []string, refs *resolvedPrePRRefs) error {
+// validateReviewedPublicationRange enforces the governing publication
+// invariant: nothing newly published may exceed what review authorized. The
+// receipt's authority is the reviewed base→candidate delta plus the immutable
+// base tree it binds, so every path touched anywhere in the delivered range
+// base..head must stay inside the immutable genesis scope. For an empty-remote
+// bootstrap the range base is the resolved reviewed delivery base commit —
+// never the zero-OID sentinel — and the pre-base ancestry published in full by
+// the first push must additionally satisfy the reviewed base tree disclosure
+// invariant.
+func validateReviewedPublicationRange(ctx context.Context, repo string, genesis []string, refs *resolvedPrePRRefs) error {
+	if refs.Selection.Source == PrePRBoundaryEmptyRemoteBootstrap {
+		if err := validateBootstrapAncestryDisclosure(ctx, repo, refs.BaseCommit); err != nil {
+			return err
+		}
+	}
 	output, err := runGit(ctx, repo, nil, nil, "log", "-m", "--format=", "--name-only", "-z", "--no-renames", refs.BaseCommit+".."+refs.HeadCommit)
 	if err != nil {
 		return fmt.Errorf("inspect complete publication range: %w", err)
 	}
-	paths := []string{}
-	seen := map[string]struct{}{}
-	for _, path := range strings.Split(string(output), "\x00") {
-		if path == "" {
-			continue
-		}
-		if _, ok := seen[path]; ok {
-			continue
-		}
-		seen[path] = struct{}{}
-		paths = append(paths, path)
-	}
-	paths, err = canonicalPaths(paths)
+	paths, err := canonicalPaths(splitNullSeparatedPaths(output))
 	if err == nil {
 		err = pathsAreSubset(paths, genesis)
 	}

--- a/internal/reviewtransaction/compact_gate_test.go
+++ b/internal/reviewtransaction/compact_gate_test.go
@@ -857,7 +857,7 @@ func TestCompactPrePRGateAllowsFinalSubsetOfGenesisPaths(t *testing.T) {
 	}
 }
 
-func TestValidateCompactPublicationRangeAllowsRepeatedApprovedPath(t *testing.T) {
+func TestValidateReviewedPublicationRangeAllowsRepeatedApprovedPath(t *testing.T) {
 	repo := initSnapshotRepo(t)
 	base := trimGit(gitSnapshot(t, repo, "rev-parse", "HEAD"))
 	writeSnapshotFile(t, repo, "tracked.txt", "red\n")
@@ -868,7 +868,7 @@ func TestValidateCompactPublicationRangeAllowsRepeatedApprovedPath(t *testing.T)
 	gitSnapshot(t, repo, "commit", "-m", "green")
 	head := trimGit(gitSnapshot(t, repo, "rev-parse", "HEAD"))
 
-	err := validateCompactPublicationRange(context.Background(), repo, []string{"tracked.txt"}, &resolvedPrePRRefs{
+	err := validateReviewedPublicationRange(context.Background(), repo, []string{"tracked.txt"}, &resolvedPrePRRefs{
 		BaseCommit: base,
 		HeadCommit: head,
 	})
@@ -877,7 +877,7 @@ func TestValidateCompactPublicationRangeAllowsRepeatedApprovedPath(t *testing.T)
 	}
 }
 
-func TestValidateCompactPublicationRangeRejectsHiddenAddedAndRevertedPath(t *testing.T) {
+func TestValidateReviewedPublicationRangeRejectsHiddenAddedAndRevertedPath(t *testing.T) {
 	repo := initSnapshotRepo(t)
 	base := trimGit(gitSnapshot(t, repo, "rev-parse", "HEAD"))
 	writeSnapshotFile(t, repo, "secret.txt", "hidden\n")
@@ -890,7 +890,7 @@ func TestValidateCompactPublicationRangeRejectsHiddenAddedAndRevertedPath(t *tes
 	gitSnapshot(t, repo, "commit", "-m", "revert hidden path")
 	head := trimGit(gitSnapshot(t, repo, "rev-parse", "HEAD"))
 
-	err := validateCompactPublicationRange(context.Background(), repo, []string{"tracked.txt"}, &resolvedPrePRRefs{
+	err := validateReviewedPublicationRange(context.Background(), repo, []string{"tracked.txt"}, &resolvedPrePRRefs{
 		BaseCommit: base,
 		HeadCommit: head,
 	})
@@ -899,7 +899,7 @@ func TestValidateCompactPublicationRangeRejectsHiddenAddedAndRevertedPath(t *tes
 	}
 }
 
-func TestValidateCompactPublicationRangeAllowsRepeatedApprovedPathAcrossMergeHistory(t *testing.T) {
+func TestValidateReviewedPublicationRangeAllowsRepeatedApprovedPathAcrossMergeHistory(t *testing.T) {
 	repo := initSnapshotRepo(t)
 	writeSnapshotFile(t, repo, "approved.txt", "first\nsecond\nthird\nfourth\nfifth\n")
 	gitSnapshot(t, repo, "add", "approved.txt")
@@ -918,7 +918,7 @@ func TestValidateCompactPublicationRangeAllowsRepeatedApprovedPathAcrossMergeHis
 	gitSnapshot(t, repo, "merge", "--no-edit", "merge-side")
 	head := trimGit(gitSnapshot(t, repo, "rev-parse", "HEAD"))
 
-	err := validateCompactPublicationRange(context.Background(), repo, []string{"approved.txt"}, &resolvedPrePRRefs{
+	err := validateReviewedPublicationRange(context.Background(), repo, []string{"approved.txt"}, &resolvedPrePRRefs{
 		BaseCommit: base,
 		HeadCommit: head,
 	})
@@ -1485,4 +1485,205 @@ func approvedCompactPrePRFixture(t *testing.T, fixture *compatiblePrePRFixture) 
 		t.Fatal(err)
 	}
 	return state, receipt
+}
+
+func emptyRemoteCompactBaseDiffFixture(t *testing.T, lineage string) (string, CompactState, CompactReceipt) {
+	t.Helper()
+	repo := t.TempDir()
+	gitSnapshot(t, repo, "init")
+	gitSnapshot(t, repo, "config", "user.email", "snapshot@example.com")
+	gitSnapshot(t, repo, "config", "user.name", "Snapshot Test")
+	writeSnapshotFile(t, repo, "tracked.txt", "base\n")
+	gitSnapshot(t, repo, "add", "tracked.txt")
+	gitSnapshot(t, repo, "commit", "-m", "base")
+	base := trimGit(gitSnapshot(t, repo, "rev-parse", "HEAD"))
+	branch := currentBranch(context.Background(), repo)
+	remote := filepath.Join(t.TempDir(), "empty-remote.git")
+	gitSnapshot(t, repo, "init", "--bare", remote)
+	gitSnapshot(t, repo, "remote", "add", "origin", remote)
+	gitSnapshot(t, repo, "config", "branch."+branch+".remote", "origin")
+	gitSnapshot(t, repo, "config", "branch."+branch+".merge", "refs/heads/"+branch)
+	writeSnapshotFile(t, repo, "tracked.txt", "reviewed delivery\n")
+	gitSnapshot(t, repo, "commit", "-am", "reviewed delivery")
+	state := newCompactStartStateForTarget(t, repo, lineage, Target{Kind: TargetBaseDiff, BaseRef: base, IntendedUntracked: []string{}})
+	state, receipt := persistApprovedCompactState(t, repo, state)
+	return repo, state, receipt
+}
+
+func TestCompactBaseDiffPrePushAllowsFirstPublicationToEmptyRemote(t *testing.T) {
+	repo, state, receipt := emptyRemoteCompactBaseDiffFixture(t, "compact-empty-remote-first-publication")
+	got := EvaluateCompactGate(context.Background(), repo, receipt, NativeGateRequestInput{Gate: GatePrePush, LineageID: state.LineageID})
+	if got.Result != GateAllow || !got.Context.BaseRelationshipValid {
+		t.Fatalf("compact first-publication pre-push = %#v", got)
+	}
+}
+
+func TestCompactCurrentChangesFirstPublicationRejectsUndisclosedAncestorPath(t *testing.T) {
+	repo := t.TempDir()
+	gitSnapshot(t, repo, "init")
+	gitSnapshot(t, repo, "config", "user.email", "snapshot@example.com")
+	gitSnapshot(t, repo, "config", "user.name", "Snapshot Test")
+	writeSnapshotFile(t, repo, "tracked.txt", "one\n")
+	gitSnapshot(t, repo, "add", "tracked.txt")
+	gitSnapshot(t, repo, "commit", "-m", "one")
+	writeSnapshotFile(t, repo, "secret.txt", "must never be published\n")
+	gitSnapshot(t, repo, "add", "secret.txt")
+	gitSnapshot(t, repo, "commit", "-m", "pre-base secret")
+	gitSnapshot(t, repo, "rm", "-q", "secret.txt")
+	writeSnapshotFile(t, repo, "tracked.txt", "base\n")
+	gitSnapshot(t, repo, "add", "tracked.txt")
+	gitSnapshot(t, repo, "commit", "-m", "remove pre-base secret")
+	branch := currentBranch(context.Background(), repo)
+	remote := filepath.Join(t.TempDir(), "empty-remote.git")
+	gitSnapshot(t, repo, "init", "--bare", remote)
+	gitSnapshot(t, repo, "remote", "add", "origin", remote)
+	gitSnapshot(t, repo, "config", "branch."+branch+".remote", "origin")
+	gitSnapshot(t, repo, "config", "branch."+branch+".merge", "refs/heads/"+branch)
+	writeSnapshotFile(t, repo, "tracked.txt", "reviewed delivery\n")
+	state := newCompactStartStateForTarget(t, repo, "compact-bootstrap-undisclosed-ancestor", Target{Kind: TargetCurrentChanges, IntendedUntracked: []string{}})
+	state, receipt := persistApprovedCompactState(t, repo, state)
+	gitSnapshot(t, repo, "add", "tracked.txt")
+	gitSnapshot(t, repo, "commit", "-m", "reviewed delivery")
+	got := EvaluateCompactGate(context.Background(), repo, receipt, NativeGateRequestInput{Gate: GatePrePush, LineageID: state.LineageID})
+	if got.Result == GateAllow || !strings.Contains(got.Reason, "not disclosed by the reviewed base tree") || !strings.Contains(got.Reason, "squash pre-publication history") {
+		t.Fatalf("current-changes bootstrap with undisclosed ancestor path = %#v", got)
+	}
+}
+
+func TestCompactCurrentChangesFirstPublicationRejectsOverwrittenSecretBlob(t *testing.T) {
+	repo := t.TempDir()
+	gitSnapshot(t, repo, "init")
+	gitSnapshot(t, repo, "config", "user.email", "snapshot@example.com")
+	gitSnapshot(t, repo, "config", "user.name", "Snapshot Test")
+	writeSnapshotFile(t, repo, "tracked.txt", "SECRET_API_KEY=sk-abc123\n")
+	gitSnapshot(t, repo, "add", "tracked.txt")
+	gitSnapshot(t, repo, "commit", "-m", "pre-base secret revision")
+	writeSnapshotFile(t, repo, "tracked.txt", "hello\n")
+	gitSnapshot(t, repo, "add", "tracked.txt")
+	gitSnapshot(t, repo, "commit", "-m", "overwrite secret before review")
+	branch := currentBranch(context.Background(), repo)
+	remote := filepath.Join(t.TempDir(), "empty-remote.git")
+	gitSnapshot(t, repo, "init", "--bare", remote)
+	gitSnapshot(t, repo, "remote", "add", "origin", remote)
+	gitSnapshot(t, repo, "config", "branch."+branch+".remote", "origin")
+	gitSnapshot(t, repo, "config", "branch."+branch+".merge", "refs/heads/"+branch)
+	writeSnapshotFile(t, repo, "tracked.txt", "reviewed delivery\n")
+	state := newCompactStartStateForTarget(t, repo, "compact-bootstrap-overwritten-secret-blob", Target{Kind: TargetCurrentChanges, IntendedUntracked: []string{}})
+	state, receipt := persistApprovedCompactState(t, repo, state)
+	gitSnapshot(t, repo, "add", "tracked.txt")
+	gitSnapshot(t, repo, "commit", "-m", "reviewed delivery")
+	got := EvaluateCompactGate(context.Background(), repo, receipt, NativeGateRequestInput{Gate: GatePrePush, LineageID: state.LineageID})
+	if got.Result == GateAllow || !strings.Contains(got.Reason, "publishes pre-base history blob") || !strings.Contains(got.Reason, "tracked.txt") || !strings.Contains(got.Reason, "squash pre-publication history") {
+		t.Fatalf("current-changes bootstrap with overwritten secret blob = %#v", got)
+	}
+}
+
+func TestCompactBaseDiffFirstPublicationAllowsAncestorsDisclosedByBaseTree(t *testing.T) {
+	repo := t.TempDir()
+	gitSnapshot(t, repo, "init")
+	gitSnapshot(t, repo, "config", "user.email", "snapshot@example.com")
+	gitSnapshot(t, repo, "config", "user.name", "Snapshot Test")
+	writeSnapshotFile(t, repo, "docs/README.md", "pre-existing documentation\n")
+	gitSnapshot(t, repo, "add", "docs/README.md")
+	gitSnapshot(t, repo, "commit", "-m", "docs")
+	writeSnapshotFile(t, repo, "tracked.txt", "base\n")
+	gitSnapshot(t, repo, "add", "tracked.txt")
+	gitSnapshot(t, repo, "commit", "-m", "base")
+	base := trimGit(gitSnapshot(t, repo, "rev-parse", "HEAD"))
+	branch := currentBranch(context.Background(), repo)
+	remote := filepath.Join(t.TempDir(), "empty-remote.git")
+	gitSnapshot(t, repo, "init", "--bare", remote)
+	gitSnapshot(t, repo, "remote", "add", "origin", remote)
+	gitSnapshot(t, repo, "config", "branch."+branch+".remote", "origin")
+	gitSnapshot(t, repo, "config", "branch."+branch+".merge", "refs/heads/"+branch)
+	writeSnapshotFile(t, repo, "tracked.txt", "reviewed delivery\n")
+	gitSnapshot(t, repo, "commit", "-am", "reviewed delivery")
+	state := newCompactStartStateForTarget(t, repo, "compact-bootstrap-disclosed-ancestors", Target{Kind: TargetBaseDiff, BaseRef: base, IntendedUntracked: []string{}})
+	state, receipt := persistApprovedCompactState(t, repo, state)
+	got := EvaluateCompactGate(context.Background(), repo, receipt, NativeGateRequestInput{Gate: GatePrePush, LineageID: state.LineageID})
+	if got.Result != GateAllow || !got.Context.BaseRelationshipValid {
+		t.Fatalf("bootstrap with base tree containing pre-existing unreviewed files = %#v", got)
+	}
+}
+
+func TestCompactBaseDiffFirstPublicationRejectsHistoryOutsideGenesis(t *testing.T) {
+	repo, state, receipt := emptyRemoteCompactBaseDiffFixture(t, "compact-empty-remote-genesis-exceed")
+	writeSnapshotFile(t, repo, "secret.txt", "must never be published\n")
+	gitSnapshot(t, repo, "add", "secret.txt")
+	gitSnapshot(t, repo, "commit", "-m", "intermediate secret")
+	if err := os.Remove(filepath.Join(repo, "secret.txt")); err != nil {
+		t.Fatal(err)
+	}
+	gitSnapshot(t, repo, "add", "-A")
+	gitSnapshot(t, repo, "commit", "-m", "remove intermediate secret")
+	got := EvaluateCompactGate(context.Background(), repo, receipt, NativeGateRequestInput{Gate: GatePrePush, LineageID: state.LineageID})
+	if got.Result == GateAllow || !strings.Contains(got.Reason, "publication range exceeds immutable genesis scope") {
+		t.Fatalf("first-publication range outside genesis = %#v", got)
+	}
+}
+
+func TestCompactBaseDiffFirstPublicationRejectsOverwrittenSecretBlob(t *testing.T) {
+	repo := t.TempDir()
+	gitSnapshot(t, repo, "init")
+	gitSnapshot(t, repo, "config", "user.email", "snapshot@example.com")
+	gitSnapshot(t, repo, "config", "user.name", "Snapshot Test")
+	writeSnapshotFile(t, repo, "tracked.txt", "SECRET_API_KEY=sk-abc123\n")
+	gitSnapshot(t, repo, "add", "tracked.txt")
+	gitSnapshot(t, repo, "commit", "-m", "pre-base secret revision")
+	writeSnapshotFile(t, repo, "tracked.txt", "hello\n")
+	gitSnapshot(t, repo, "add", "tracked.txt")
+	gitSnapshot(t, repo, "commit", "-m", "overwrite secret before review")
+	base := trimGit(gitSnapshot(t, repo, "rev-parse", "HEAD"))
+	branch := currentBranch(context.Background(), repo)
+	remote := filepath.Join(t.TempDir(), "empty-remote.git")
+	gitSnapshot(t, repo, "init", "--bare", remote)
+	gitSnapshot(t, repo, "remote", "add", "origin", remote)
+	gitSnapshot(t, repo, "config", "branch."+branch+".remote", "origin")
+	gitSnapshot(t, repo, "config", "branch."+branch+".merge", "refs/heads/"+branch)
+	writeSnapshotFile(t, repo, "tracked.txt", "reviewed delivery\n")
+	gitSnapshot(t, repo, "commit", "-am", "reviewed delivery")
+	state := newCompactStartStateForTarget(t, repo, "compact-base-diff-overwritten-secret-blob", Target{Kind: TargetBaseDiff, BaseRef: base, IntendedUntracked: []string{}})
+	state, receipt := persistApprovedCompactState(t, repo, state)
+	got := EvaluateCompactGate(context.Background(), repo, receipt, NativeGateRequestInput{Gate: GatePrePush, LineageID: state.LineageID})
+	if got.Result == GateAllow || !strings.Contains(got.Reason, "publishes pre-base history blob") || !strings.Contains(got.Reason, "tracked.txt") || !strings.Contains(got.Reason, "squash pre-publication history") {
+		t.Fatalf("base-diff bootstrap with overwritten secret blob = %#v", got)
+	}
+}
+
+// TestCompactBootstrapDisclosureScopeExcludesCommitMetadata pins the same
+// documented contract boundary as the native
+// TestBootstrapDisclosureScopeExcludesCommitMetadata through the compact
+// entry point: disclosure covers repository content — tracked paths and blob
+// bytes — and never commit metadata, so a pre-base `--allow-empty` commit
+// with a secret message passes both disclosure rules even though its commit
+// object is transferred by the bootstrap push. Messages are not review-bound
+// anywhere in the gate model (see validateBootstrapAncestryDisclosure);
+// closing this boundary requires consciously flipping this test.
+func TestCompactBootstrapDisclosureScopeExcludesCommitMetadata(t *testing.T) {
+	repo := t.TempDir()
+	gitSnapshot(t, repo, "init")
+	gitSnapshot(t, repo, "config", "user.email", "snapshot@example.com")
+	gitSnapshot(t, repo, "config", "user.name", "Snapshot Test")
+	writeSnapshotFile(t, repo, "tracked.txt", "base\n")
+	gitSnapshot(t, repo, "add", "tracked.txt")
+	gitSnapshot(t, repo, "commit", "-m", "base")
+	gitSnapshot(t, repo, "commit", "--allow-empty", "-m", "SECRET-COMMIT-MESSAGE-MARKER token=hunter2")
+	writeSnapshotFile(t, repo, "reviewed-base.txt", "reviewed base\n")
+	gitSnapshot(t, repo, "add", "reviewed-base.txt")
+	gitSnapshot(t, repo, "commit", "-m", "reviewed base")
+	base := trimGit(gitSnapshot(t, repo, "rev-parse", "HEAD"))
+	branch := currentBranch(context.Background(), repo)
+	remote := filepath.Join(t.TempDir(), "empty-remote.git")
+	gitSnapshot(t, repo, "init", "--bare", remote)
+	gitSnapshot(t, repo, "remote", "add", "origin", remote)
+	gitSnapshot(t, repo, "config", "branch."+branch+".remote", "origin")
+	gitSnapshot(t, repo, "config", "branch."+branch+".merge", "refs/heads/"+branch)
+	writeSnapshotFile(t, repo, "tracked.txt", "reviewed delivery\n")
+	gitSnapshot(t, repo, "commit", "-am", "reviewed delivery")
+	state := newCompactStartStateForTarget(t, repo, "compact-bootstrap-commit-metadata-scope", Target{Kind: TargetBaseDiff, BaseRef: base, IntendedUntracked: []string{}})
+	state, receipt := persistApprovedCompactState(t, repo, state)
+	got := EvaluateCompactGate(context.Background(), repo, receipt, NativeGateRequestInput{Gate: GatePrePush, LineageID: state.LineageID})
+	if got.Result != GateAllow || !got.Context.BaseRelationshipValid {
+		t.Fatalf("compact bootstrap with secret pre-base commit message = %#v", got)
+	}
 }

--- a/internal/reviewtransaction/gate.go
+++ b/internal/reviewtransaction/gate.go
@@ -55,6 +55,10 @@ type PushRequest struct {
 	PushRemote         string                 `json:"push_remote"`
 	PushRemoteIdentity string                 `json:"push_remote_identity"`
 	DeliveryBaseTree   string                 `json:"delivery_base_tree,omitempty"`
+	// ReviewedBaseTree is set only for empty-remote bootstrap boundaries and
+	// carries the authoritative reviewed base tree so re-derivation can locate
+	// the same delivery base without a remote publication boundary.
+	ReviewedBaseTree string `json:"reviewed_base_tree,omitempty"`
 }
 
 type PrePRBoundarySource string
@@ -62,6 +66,11 @@ type PrePRBoundarySource string
 const (
 	PrePRBoundaryExplicit           PrePRBoundarySource = "explicit"
 	PrePRBoundaryPublicationDefault PrePRBoundarySource = "publication-default"
+	// PrePRBoundaryEmptyRemoteBootstrap marks a pre-push first-publication
+	// boundary: the configured upstream remote advertises no refs at all, so
+	// the publication base is the explicit zero OID instead of an advertised
+	// remote commit.
+	PrePRBoundaryEmptyRemoteBootstrap PrePRBoundarySource = "empty-remote-bootstrap"
 )
 
 // PrePRBoundarySelection records how the immutable pre-PR range boundary was
@@ -221,6 +230,16 @@ func EvaluateNativeGate(ctx context.Context, repo string, receipt Receipt, reque
 	}
 	if request.Gate == GatePrePush && record.Transaction.Snapshot.Kind == TargetCurrentChanges && resolvedPrePR.DeliveredCommitCount != 1 {
 		return invalid("pre-push current-changes receipt requires exactly one delivery commit")
+	}
+	if request.Gate == GatePrePush && resolvedPrePR.Selection.Source == PrePRBoundaryEmptyRemoteBootstrap {
+		// A first publication to an empty remote transfers the candidate's
+		// complete history, so it must satisfy the same publication invariant
+		// as the compact path: the delivered range stays inside the reviewed
+		// paths and pre-base ancestry stays disclosed by the reviewed base
+		// tree.
+		if err := validateReviewedPublicationRange(ctx, repo, record.Transaction.Snapshot.Paths, resolvedPrePR); err != nil {
+			return invalid(err.Error())
+		}
 	}
 	policyHash := authoritativeReceipt.PolicyHash
 	if hasArtifactSource(request.PolicyArtifact, request.PolicyContent) {
@@ -455,12 +474,11 @@ func resolveTrackingUpstreamBase(ctx context.Context, repo string) (string, stri
 	if branch == "" {
 		return "", "", "", errors.New("configured upstream is unavailable on detached HEAD; pass --base-ref <remote>/<branch>")
 	}
-	output, err := runGit(ctx, repo, nil, nil, "for-each-ref", "--format=%(upstream:remotename)%00%(upstream:remoteref)", "refs/heads/"+branch)
-	parts := strings.SplitN(strings.TrimSpace(string(output)), "\x00", 2)
-	if err != nil || len(parts) != 2 || parts[0] == "" || !strings.HasPrefix(parts[1], "refs/heads/") {
+	remote, ref, ok := configuredUpstreamRef(ctx, repo, branch)
+	if !ok {
 		return "", "", "", errors.New("configured upstream is missing or ambiguous; pass --base-ref <remote>/<branch>")
 	}
-	selection, err := advertisedRemoteRef(ctx, repo, parts[0], parts[1], parts[0]+"/"+strings.TrimPrefix(parts[1], "refs/heads/"), PrePRBoundaryPublicationDefault)
+	selection, err := advertisedRemoteRef(ctx, repo, remote, ref, remote+"/"+strings.TrimPrefix(ref, "refs/heads/"), PrePRBoundaryPublicationDefault)
 	if err != nil {
 		return "", "", "", err
 	}
@@ -606,7 +624,7 @@ func currentBranch(ctx context.Context, repo string) string {
 	return strings.TrimSpace(string(output))
 }
 
-func buildPushTarget(ctx context.Context, repo, selector, deliveryBaseTree string) (Target, *PushRequest, error) {
+func buildPushTarget(ctx context.Context, repo, selector, deliveryBaseTree, reviewedBaseTree string) (Target, *PushRequest, error) {
 	selection, err := selectPrePushBoundary(ctx, repo, selector)
 	if err != nil {
 		return Target{}, nil, err
@@ -614,6 +632,9 @@ func buildPushTarget(ctx context.Context, repo, selector, deliveryBaseTree strin
 	head, err := resolveCommit(ctx, repo, "HEAD")
 	if err != nil {
 		return Target{}, nil, err
+	}
+	if selection.Source == PrePRBoundaryEmptyRemoteBootstrap {
+		return buildBootstrapPushTarget(ctx, repo, selection, head, deliveryBaseTree, reviewedBaseTree)
 	}
 	bases, err := runGit(ctx, repo, nil, nil, "merge-base", "--all", head, selection.Commit)
 	mergeBases := strings.Fields(string(bases))
@@ -646,10 +667,309 @@ func selectPrePushBoundary(ctx context.Context, repo, selector string) (PrePRBou
 	}
 	ref, remote, commit, err := resolveTrackingUpstreamBase(ctx, repo)
 	if err != nil {
+		if bootstrap, ok := emptyRemoteBootstrapBoundary(ctx, repo); ok {
+			return bootstrap, nil
+		}
 		return PrePRBoundarySelection{}, err
 	}
 	identity, err := remoteRepositoryIdentity(ctx, repo, remote)
 	return PrePRBoundarySelection{Source: PrePRBoundaryPublicationDefault, Selector: ref, Commit: commit, Remote: remote, RemoteRef: ref, RemoteIdentity: identity}, err
+}
+
+// configuredUpstreamRef resolves the configured upstream remote and branch
+// ref for a local branch. It reports false when the upstream is missing,
+// ambiguous, or not a branch ref.
+func configuredUpstreamRef(ctx context.Context, repo, branch string) (string, string, bool) {
+	output, err := runGit(ctx, repo, nil, nil, "for-each-ref", "--format=%(upstream:remotename)%00%(upstream:remoteref)", "refs/heads/"+branch)
+	parts := strings.SplitN(strings.TrimSpace(string(output)), "\x00", 2)
+	if err != nil || len(parts) != 2 || parts[0] == "" || !strings.HasPrefix(parts[1], "refs/heads/") {
+		return "", "", false
+	}
+	return parts[0], parts[1], true
+}
+
+// emptyRemoteBootstrapBoundary recognizes the first-publication case only:
+// the current branch has a configured upstream whose remote advertises no
+// refs at all (no HEAD, branches, or tags). The boundary content-binds the
+// destination remote identity and intended ref with the explicit zero OID as
+// publication base. Any other condition declines so the original fail-closed
+// error is preserved: detached HEAD, a missing or ambiguous configured
+// upstream, an unreachable remote or failed ls-remote, a remote with any
+// advertised ref, an unresolvable remote identity, or an unresolvable HEAD
+// commit.
+func emptyRemoteBootstrapBoundary(ctx context.Context, repo string) (PrePRBoundarySelection, bool) {
+	branch := currentBranch(ctx, repo)
+	if branch == "" {
+		return PrePRBoundarySelection{}, false
+	}
+	remote, ref, ok := configuredUpstreamRef(ctx, repo, branch)
+	if !ok {
+		return PrePRBoundarySelection{}, false
+	}
+	advertised, err := runGit(ctx, repo, nil, nil, "ls-remote", remote)
+	if err != nil || strings.TrimSpace(string(advertised)) != "" {
+		return PrePRBoundarySelection{}, false
+	}
+	identity, err := remoteRepositoryIdentity(ctx, repo, remote)
+	if err != nil {
+		return PrePRBoundarySelection{}, false
+	}
+	head, err := resolveCommit(ctx, repo, "HEAD")
+	if err != nil {
+		return PrePRBoundarySelection{}, false
+	}
+	return PrePRBoundarySelection{
+		Source: PrePRBoundaryEmptyRemoteBootstrap, Selector: ref, Commit: strings.Repeat("0", len(head)),
+		Remote: remote, RemoteRef: ref, RemoteIdentity: identity,
+	}, true
+}
+
+// buildBootstrapPushTarget derives the pre-push target for a first
+// publication to a verified empty remote. The reviewed base commit must be
+// uniquely present in the candidate's complete history and, for
+// current-changes receipts, the delivery must be exactly one commit beyond
+// it. The gate evaluation then enforces the bootstrap publication invariant
+// for every target kind: the delivered range reviewedBase..head must stay
+// inside the immutable genesis scope, and pre-base ancestry — published in
+// full by the first push — must satisfy both content-disclosure rules of
+// validateBootstrapAncestryDisclosure: every path it ever named must exist in
+// the reviewed base tree, and every blob object it reaches must be
+// byte-identical to a blob that tree contains. Disclosure covers repository
+// content only — tracked paths and blob bytes; commit and tag metadata
+// (messages, author/committer identities, timestamps) is not review-bound
+// anywhere in the gate model, on bootstrap or ordinary publication alike —
+// see the scope note on validateBootstrapAncestryDisclosure. Everything else
+// fails closed.
+func buildBootstrapPushTarget(ctx context.Context, repo string, selection PrePRBoundarySelection, head, deliveryBaseTree, reviewedBaseTree string) (Target, *PushRequest, error) {
+	// Both parameters originate from the receipt snapshot's BaseTree field:
+	// deliveryBaseTree is the same value gated to current-changes receipts so
+	// the one-commit delivery constraint below applies. The override can
+	// therefore never select a genuinely divergent tree.
+	bootstrapTree := reviewedBaseTree
+	if deliveryBaseTree != "" {
+		bootstrapTree = deliveryBaseTree
+	}
+	if bootstrapTree == "" {
+		return Target{}, nil, errors.New("empty-remote bootstrap requires the authoritative reviewed base tree; pass --base-ref <remote>/<branch> once the remote is published")
+	}
+	pushRemote, configured, err := publicationRemote(ctx, repo)
+	if err != nil || !configured {
+		return Target{}, nil, errors.New("push destination remote is not configured")
+	}
+	if pushRemote != selection.Remote {
+		return Target{}, nil, errors.New("empty-remote bootstrap requires the push destination to be the verified empty upstream remote")
+	}
+	pushIdentity, err := pushRepositoryIdentity(ctx, repo, pushRemote)
+	if err != nil {
+		return Target{}, nil, err
+	}
+	if pushIdentity != selection.RemoteIdentity {
+		return Target{}, nil, errors.New("empty-remote bootstrap requires the push destination identity to match the verified empty remote")
+	}
+	push := &PushRequest{Boundary: selection, MergeBase: selection.Commit, PushRemote: pushRemote, PushRemoteIdentity: pushIdentity, DeliveryBaseTree: deliveryBaseTree, ReviewedBaseTree: reviewedBaseTree}
+	base, err := bootstrapReviewedDeliveryBase(ctx, repo, head, bootstrapTree)
+	if err != nil {
+		return Target{}, nil, err
+	}
+	if deliveryBaseTree != "" {
+		count, countErr := commitCount(ctx, repo, base, head)
+		if countErr != nil || count != 1 {
+			return Target{}, nil, errors.New("reviewed delivery is not exactly one commit from its reviewed base")
+		}
+	}
+	return Target{Kind: TargetBaseDiff, BaseRef: base, IntendedUntracked: []string{}}, push, nil
+}
+
+// bootstrapReviewedDeliveryBase locates the reviewed delivery base commit in
+// the candidate's complete history because an empty remote provides no
+// publication range boundary. A single subprocess lists every commit with its
+// tree so the walk stays one call regardless of history length.
+func bootstrapReviewedDeliveryBase(ctx context.Context, repo, head, reviewedTree string) (string, error) {
+	output, err := runGit(ctx, repo, nil, nil, "log", "--format=%H %T", head)
+	if err != nil {
+		return "", err
+	}
+	matches := []string{}
+	for _, line := range strings.Split(strings.TrimSpace(string(output)), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) != 2 {
+			return "", errors.New("publication history listing is malformed")
+		}
+		if fields[1] == reviewedTree {
+			matches = append(matches, fields[0])
+		}
+	}
+	if len(matches) != 1 {
+		return "", errors.New("reviewed delivery base commit is missing or ambiguous in publication range")
+	}
+	return matches[0], nil
+}
+
+// validateBootstrapAncestryDisclosure enforces the bootstrap publication
+// invariant for pre-base history. A push to an empty remote transfers every
+// object reachable from HEAD, including ancestry behind the reviewed delivery
+// base that no publication gate ever examined. That ancestry is admissible
+// only under two disclosure rules bound to the reviewed base tree — exactly
+// the immutable context the receipt binds:
+//
+//  1. Path disclosure: every path pre-base history ever named must exist in
+//     the reviewed base tree, so no published tree entry carries a file name
+//     review never saw.
+//  2. Blob disclosure: every blob object reachable from the reviewed base
+//     commit must be byte-identical to some blob the reviewed base tree
+//     contains, path-agnostic. Renaming disclosed content is admissible; any
+//     historical content revision absent from the base tree — for example a
+//     secret later overwritten at the same path — fails closed even though
+//     its path is disclosed.
+//
+// Symlink entries are blobs and participate in both rules. Gitlink
+// (submodule) entries disclose only their path: their commit OIDs reference
+// external objects that history traversal never transfers, so they are
+// excluded from blob disclosure. Failing either rule requires squashing
+// pre-publication history (or re-creating an orphan first commit) so the
+// first publication contains only reviewed content.
+//
+// Scope: disclosure covers repository CONTENT — tracked paths and blob bytes
+// — and nothing else. Commit and tag metadata (messages, author/committer
+// identities, timestamps) is not review-bound anywhere in the gate model: no
+// receipt hashes or binds message text, and an ordinary (non-bootstrap)
+// pre-push equally publishes the reviewed delivery commit's message without
+// any review binding it. A pre-base commit created with `git commit
+// --allow-empty` therefore passes both rules even when its message contains a
+// secret, and the bootstrap push transfers that commit object; bootstrap does
+// not widen a guarantee that never existed. Operators who need message
+// hygiene should follow the same remediation the deny messages give — squash
+// pre-publication history or re-create an orphan first commit — which reduces
+// pre-base history to messages the operator wrote deliberately at publication
+// time. TestBootstrapDisclosureScopeExcludesCommitMetadata pins this
+// boundary.
+func validateBootstrapAncestryDisclosure(ctx context.Context, repo, baseCommit string) error {
+	touchedOutput, err := runGit(ctx, repo, nil, nil, "log", "-m", "--format=", "--name-only", "-z", "--no-renames", baseCommit)
+	if err != nil {
+		return fmt.Errorf("inspect bootstrap pre-base history: %w", err)
+	}
+	touched, err := canonicalPaths(splitNullSeparatedPaths(touchedOutput))
+	if err != nil {
+		return fmt.Errorf("bootstrap pre-base history paths are not canonical: %w", err)
+	}
+	disclosedPaths, disclosedBlobs, err := reviewedBaseTreeDisclosure(ctx, repo, baseCommit)
+	if err != nil {
+		return err
+	}
+	for _, path := range touched {
+		if _, ok := disclosedPaths[path]; !ok {
+			return fmt.Errorf("empty-remote bootstrap publishes pre-base history path %q that is not disclosed by the reviewed base tree; squash pre-publication history (or re-create an orphan first commit) so the first publication contains only reviewed content, then re-run review", path)
+		}
+	}
+	return validateBootstrapReachableBlobs(ctx, repo, baseCommit, disclosedBlobs)
+}
+
+// reviewedBaseTreeDisclosure lists the reviewed base tree once and returns
+// its canonical path set and its blob OID set. Symlink entries are blobs and
+// join both sets; gitlink entries contribute only their path because their
+// commit OIDs reference objects outside this repository.
+func reviewedBaseTreeDisclosure(ctx context.Context, repo, baseCommit string) (map[string]struct{}, map[string]struct{}, error) {
+	output, err := runGit(ctx, repo, nil, nil, "ls-tree", "-r", "-z", "--full-tree", baseCommit)
+	if err != nil {
+		return nil, nil, fmt.Errorf("inspect reviewed bootstrap base tree: %w", err)
+	}
+	names := []string{}
+	blobs := map[string]struct{}{}
+	for _, entry := range splitNullSeparatedPaths(output) {
+		meta, path, found := strings.Cut(entry, "\t")
+		fields := strings.Fields(meta)
+		if !found || path == "" || len(fields) != 3 {
+			return nil, nil, errors.New("reviewed bootstrap base tree listing is malformed")
+		}
+		names = append(names, path)
+		if fields[1] == "blob" {
+			blobs[fields[2]] = struct{}{}
+		}
+	}
+	canonical, err := canonicalPaths(names)
+	if err != nil {
+		return nil, nil, fmt.Errorf("reviewed bootstrap base tree paths are not canonical: %w", err)
+	}
+	paths := make(map[string]struct{}, len(canonical))
+	for _, path := range canonical {
+		paths[path] = struct{}{}
+	}
+	return paths, blobs, nil
+}
+
+// validateBootstrapReachableBlobs enforces blob-level disclosure: every blob
+// object reachable from the reviewed base commit must be a member of the
+// reviewed base tree's blob set. The subprocess count stays constant
+// regardless of history size: rev-list enumerates each reachable object once
+// with a representative path, and one cat-file batch resolves every object
+// type; anything unresolvable fails closed.
+//
+// The cat-file --batch-check pass exists deliberately: do not "simplify" this
+// to `git rev-list --objects --filter=object:type=blob`. Filter semantics
+// proved version-shaky during design probing — git 2.55 dropped a traversed
+// commit's line while keeping the provided one — so type resolution through
+// one batch-check invocation is the version-stable approach.
+func validateBootstrapReachableBlobs(ctx context.Context, repo, baseCommit string, disclosed map[string]struct{}) error {
+	output, err := runGit(ctx, repo, nil, nil, "rev-list", "--objects", baseCommit)
+	if err != nil {
+		return fmt.Errorf("enumerate bootstrap pre-base objects: %w", err)
+	}
+	oids := []string{}
+	representative := map[string]string{}
+	for _, line := range strings.Split(strings.TrimSpace(string(output)), "\n") {
+		if line == "" {
+			continue
+		}
+		oid, path, _ := strings.Cut(line, " ")
+		oids = append(oids, oid)
+		representative[oid] = path
+	}
+	if len(oids) == 0 {
+		return errors.New("bootstrap pre-base object listing is empty")
+	}
+	typed, err := runGit(ctx, repo, nil, []byte(strings.Join(oids, "\n")+"\n"), "cat-file", "--batch-check=%(objectname) %(objecttype)")
+	if err != nil {
+		return fmt.Errorf("resolve bootstrap pre-base object types: %w", err)
+	}
+	types := map[string]string{}
+	for _, line := range strings.Split(strings.TrimSpace(string(typed)), "\n") {
+		oid, objectType, found := strings.Cut(line, " ")
+		switch {
+		case found && (objectType == "commit" || objectType == "tree" || objectType == "blob" || objectType == "tag"):
+			types[oid] = objectType
+		default:
+			return errors.New("bootstrap pre-base object types are unresolvable")
+		}
+	}
+	for _, oid := range oids {
+		objectType, resolved := types[oid]
+		if !resolved {
+			return errors.New("bootstrap pre-base object types are incomplete")
+		}
+		if objectType != "blob" {
+			continue
+		}
+		if _, ok := disclosed[oid]; !ok {
+			return fmt.Errorf("empty-remote bootstrap publishes pre-base history blob %s at %q whose content is not disclosed by the reviewed base tree; squash pre-publication history (or re-create an orphan first commit) so the first publication contains only reviewed content, then re-run review", oid, representative[oid])
+		}
+	}
+	return nil
+}
+
+func splitNullSeparatedPaths(output []byte) []string {
+	paths := []string{}
+	seen := map[string]struct{}{}
+	for _, path := range strings.Split(string(output), "\x00") {
+		if path == "" {
+			continue
+		}
+		if _, ok := seen[path]; ok {
+			continue
+		}
+		seen[path] = struct{}{}
+		paths = append(paths, path)
+	}
+	return paths
 }
 
 func reviewedDeliveryBase(ctx context.Context, repo, publicationBase, head, reviewedTree string) (string, error) {
@@ -678,11 +998,12 @@ func prePushTargetForRequest(ctx context.Context, repo string, request GateReque
 	if request.Push != nil && request.Push.Boundary.Source == PrePRBoundaryExplicit {
 		selector = request.Push.Boundary.Selector
 	}
-	deliveryBaseTree := ""
+	deliveryBaseTree, reviewedBaseTree := "", ""
 	if request.Push != nil {
 		deliveryBaseTree = request.Push.DeliveryBaseTree
+		reviewedBaseTree = request.Push.ReviewedBaseTree
 	}
-	target, push, err := buildPushTarget(ctx, repo, selector, deliveryBaseTree)
+	target, push, err := buildPushTarget(ctx, repo, selector, deliveryBaseTree, reviewedBaseTree)
 	if err != nil {
 		return Target{}, nil, err
 	}
@@ -700,7 +1021,15 @@ func prePushTargetForRequest(ctx context.Context, repo string, request GateReque
 	if err != nil {
 		return Target{}, nil, err
 	}
-	return target, &resolvedPrePRRefs{Selection: push.Boundary, HeadCommit: head, BaseCommit: push.MergeBase, DeliveredCommitCount: count, PushRemote: push.PushRemote}, nil
+	baseCommit := push.MergeBase
+	if push.Boundary.Source == PrePRBoundaryEmptyRemoteBootstrap {
+		// The zero-OID boundary sentinel only records that no advertised
+		// publication base exists; it must never anchor validation. The
+		// resolved reviewed delivery base commit is the real range boundary
+		// that publication-range and ancestry-disclosure checks scope to.
+		baseCommit = target.BaseRef
+	}
+	return target, &resolvedPrePRRefs{Selection: push.Boundary, HeadCommit: head, BaseCommit: baseCommit, DeliveredCommitCount: count, PushRemote: push.PushRemote}, nil
 }
 
 func commitCount(ctx context.Context, repo, base, head string) (int, error) {

--- a/internal/reviewtransaction/gate_test.go
+++ b/internal/reviewtransaction/gate_test.go
@@ -283,7 +283,7 @@ func TestDefaultBoundariesSeparatePrePRTargetFromPrePushTracking(t *testing.T) {
 	if err != nil || prePR.RemoteRef != "refs/heads/main" {
 		t.Fatalf("default PRE-PR boundary = %#v, %v", prePR, err)
 	}
-	_, prePush, err := buildPushTarget(context.Background(), repo, "", "")
+	_, prePush, err := buildPushTarget(context.Background(), repo, "", "", "")
 	if err != nil || prePush.Boundary.RemoteRef != "refs/heads/feature" {
 		t.Fatalf("default PRE-PUSH boundary = %#v, %v", prePush, err)
 	}
@@ -528,7 +528,7 @@ func TestPublicationTargetBindsAdvertisedUpstreamSeparatelyFromPushRemote(t *tes
 	writeSnapshotFile(t, repo, "one.txt", "one\n")
 	gitSnapshot(t, repo, "add", "one.txt")
 	gitSnapshot(t, repo, "commit", "-m", "one")
-	target, push, err := buildPushTarget(context.Background(), repo, "", "")
+	target, push, err := buildPushTarget(context.Background(), repo, "", "", "")
 	if err != nil || target.BaseRef != base || push.Boundary.Remote != "upstream" || push.PushRemote != "origin" {
 		t.Fatalf("one-commit fork target = %#v, %#v, %v", target, push, err)
 	}
@@ -563,7 +563,7 @@ func TestPublicationTargetBindsAdvertisedUpstreamSeparatelyFromPushRemote(t *tes
 		t.Fatal("advertised upstream advance preserved stale authorization")
 	}
 	gitSnapshot(t, repo, "config", "--unset", "branch."+branch+".merge")
-	if _, _, err := buildPushTarget(context.Background(), repo, "", ""); err == nil || !strings.Contains(err.Error(), "--base-ref") {
+	if _, _, err := buildPushTarget(context.Background(), repo, "", "", ""); err == nil || !strings.Contains(err.Error(), "--base-ref") {
 		t.Fatalf("missing upstream error = %v", err)
 	}
 }
@@ -1545,4 +1545,280 @@ func nativePrePushRequest(t *testing.T, repo string, receipt Receipt, artifacts 
 		t.Fatal(err)
 	}
 	return request
+}
+
+func emptyRemoteTrackingRepo(t *testing.T) (string, string) {
+	t.Helper()
+	repo := initSnapshotRepo(t)
+	branch := currentBranch(context.Background(), repo)
+	remote := filepath.Join(t.TempDir(), "empty-remote.git")
+	gitSnapshot(t, repo, "init", "--bare", remote)
+	gitSnapshot(t, repo, "remote", "add", "origin", remote)
+	gitSnapshot(t, repo, "config", "branch."+branch+".remote", "origin")
+	gitSnapshot(t, repo, "config", "branch."+branch+".merge", "refs/heads/"+branch)
+	return repo, remote
+}
+
+func TestBuildPushTargetBootstrapsFirstPublicationOnEmptyRemote(t *testing.T) {
+	repo, _ := emptyRemoteTrackingRepo(t)
+	branch := currentBranch(context.Background(), repo)
+	reviewedBase := trimGit(gitSnapshot(t, repo, "rev-parse", "HEAD"))
+	reviewedBaseTree := trimGit(gitSnapshot(t, repo, "rev-parse", "HEAD^{tree}"))
+	writeSnapshotFile(t, repo, "tracked.txt", "reviewed delivery\n")
+	gitSnapshot(t, repo, "commit", "-am", "reviewed delivery")
+
+	target, push, err := buildPushTarget(context.Background(), repo, "", reviewedBaseTree, "")
+	if err != nil {
+		t.Fatalf("buildPushTarget(empty remote) error = %v", err)
+	}
+	zero := strings.Repeat("0", len(reviewedBase))
+	if push.Boundary.Source != PrePRBoundaryEmptyRemoteBootstrap || push.Boundary.Commit != zero ||
+		push.Boundary.Remote != "origin" || push.Boundary.RemoteRef != "refs/heads/"+branch || push.Boundary.RemoteIdentity == "" {
+		t.Fatalf("bootstrap boundary = %#v", push.Boundary)
+	}
+	if push.MergeBase != zero || push.PushRemote != "origin" || push.PushRemoteIdentity != push.Boundary.RemoteIdentity {
+		t.Fatalf("bootstrap push request = %#v", push)
+	}
+	if target.BaseRef != reviewedBase {
+		t.Fatalf("bootstrap target base = %q, want reviewed base %q", target.BaseRef, reviewedBase)
+	}
+}
+
+func TestNativePrePushGateAllowsFirstPublicationToEmptyRemote(t *testing.T) {
+	repo, _ := emptyRemoteTrackingRepo(t)
+	writeSnapshotFile(t, repo, "tracked.txt", "reviewed delivery\n")
+	transaction, receipt, artifacts := nativeGateFixture(t, repo, "empty-remote-first-publication")
+	store, err := AuthoritativeStore(context.Background(), repo, transaction.LineageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	appendApprovedStoreChain(t, store, transaction)
+	gitSnapshot(t, repo, "add", "tracked.txt")
+	gitSnapshot(t, repo, "commit", "-m", "reviewed delivery")
+
+	request := nativePrePushRequest(t, repo, receipt, artifacts)
+	if request.Push == nil || request.Push.Boundary.Source != PrePRBoundaryEmptyRemoteBootstrap {
+		t.Fatalf("first-publication pre-push request = %#v", request.Push)
+	}
+	if got := EvaluateNativeGate(context.Background(), repo, receipt, request); got.Result != GateAllow {
+		t.Fatalf("first-publication pre-push gate = %#v", got)
+	}
+}
+
+func TestNativePrePushFirstPublicationRejectsUndisclosedAncestorPath(t *testing.T) {
+	repo, _ := emptyRemoteTrackingRepo(t)
+	writeSnapshotFile(t, repo, "secret.txt", "must never be published\n")
+	gitSnapshot(t, repo, "add", "secret.txt")
+	gitSnapshot(t, repo, "commit", "-m", "pre-base secret")
+	gitSnapshot(t, repo, "rm", "-q", "secret.txt")
+	writeSnapshotFile(t, repo, "tracked.txt", "reviewed base\n")
+	gitSnapshot(t, repo, "add", "tracked.txt")
+	gitSnapshot(t, repo, "commit", "-m", "remove pre-base secret")
+	writeSnapshotFile(t, repo, "tracked.txt", "reviewed delivery\n")
+	transaction, receipt, artifacts := nativeGateFixture(t, repo, "empty-remote-undisclosed-ancestor")
+	store, err := AuthoritativeStore(context.Background(), repo, transaction.LineageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	appendApprovedStoreChain(t, store, transaction)
+	gitSnapshot(t, repo, "add", "tracked.txt")
+	gitSnapshot(t, repo, "commit", "-m", "reviewed delivery")
+
+	request := nativePrePushRequest(t, repo, receipt, artifacts)
+	if request.Push == nil || request.Push.Boundary.Source != PrePRBoundaryEmptyRemoteBootstrap {
+		t.Fatalf("undisclosed-ancestor pre-push request = %#v", request.Push)
+	}
+	got := EvaluateNativeGate(context.Background(), repo, receipt, request)
+	if got.Result == GateAllow || !strings.Contains(got.Reason, "not disclosed by the reviewed base tree") || !strings.Contains(got.Reason, "squash pre-publication history") {
+		t.Fatalf("native bootstrap with undisclosed ancestor path = %#v", got)
+	}
+}
+
+func TestNativePrePushFirstPublicationRejectsOverwrittenSecretBlob(t *testing.T) {
+	repo, _ := emptyRemoteTrackingRepo(t)
+	writeSnapshotFile(t, repo, "tracked.txt", "SECRET_API_KEY=sk-abc123\n")
+	gitSnapshot(t, repo, "add", "tracked.txt")
+	gitSnapshot(t, repo, "commit", "-m", "pre-base secret revision")
+	writeSnapshotFile(t, repo, "tracked.txt", "hello\n")
+	gitSnapshot(t, repo, "add", "tracked.txt")
+	gitSnapshot(t, repo, "commit", "-m", "overwrite secret before review")
+	writeSnapshotFile(t, repo, "tracked.txt", "reviewed delivery\n")
+	transaction, receipt, artifacts := nativeGateFixture(t, repo, "empty-remote-overwritten-secret-blob")
+	store, err := AuthoritativeStore(context.Background(), repo, transaction.LineageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	appendApprovedStoreChain(t, store, transaction)
+	gitSnapshot(t, repo, "add", "tracked.txt")
+	gitSnapshot(t, repo, "commit", "-m", "reviewed delivery")
+
+	request := nativePrePushRequest(t, repo, receipt, artifacts)
+	if request.Push == nil || request.Push.Boundary.Source != PrePRBoundaryEmptyRemoteBootstrap {
+		t.Fatalf("overwritten-secret pre-push request = %#v", request.Push)
+	}
+	got := EvaluateNativeGate(context.Background(), repo, receipt, request)
+	if got.Result == GateAllow || !strings.Contains(got.Reason, "publishes pre-base history blob") || !strings.Contains(got.Reason, "tracked.txt") || !strings.Contains(got.Reason, "squash pre-publication history") {
+		t.Fatalf("native bootstrap with overwritten secret blob = %#v", got)
+	}
+}
+
+func TestNativePrePushGateInvalidatesWhenEmptyRemoteGainsRefsDuringValidation(t *testing.T) {
+	repo, _ := emptyRemoteTrackingRepo(t)
+	branch := currentBranch(context.Background(), repo)
+	writeSnapshotFile(t, repo, "tracked.txt", "reviewed delivery\n")
+	transaction, receipt, artifacts := nativeGateFixture(t, repo, "empty-remote-drift")
+	store, err := AuthoritativeStore(context.Background(), repo, transaction.LineageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	appendApprovedStoreChain(t, store, transaction)
+	gitSnapshot(t, repo, "add", "tracked.txt")
+	gitSnapshot(t, repo, "commit", "-m", "reviewed delivery")
+	request := nativePrePushRequest(t, repo, receipt, artifacts)
+
+	originalHook := finalGateAuthorizationHook
+	finalGateAuthorizationHook = func() {
+		finalGateAuthorizationHook = originalHook
+		gitSnapshot(t, repo, "push", "origin", "HEAD:refs/heads/"+branch)
+	}
+	t.Cleanup(func() { finalGateAuthorizationHook = originalHook })
+	if got := EvaluateNativeGate(context.Background(), repo, receipt, request); got.Result != GateInvalidated || !strings.Contains(got.Reason, "final authorization") {
+		t.Fatalf("remote bootstrap drift evaluation = %#v", got)
+	}
+}
+
+func TestBuildPushTargetEmptyRemoteBootstrapRequiresReviewedDeliveryBase(t *testing.T) {
+	repo, _ := emptyRemoteTrackingRepo(t)
+	writeSnapshotFile(t, repo, "tracked.txt", "reviewed delivery\n")
+	gitSnapshot(t, repo, "commit", "-am", "reviewed delivery")
+	if _, _, err := buildPushTarget(context.Background(), repo, "", "", ""); err == nil || !strings.Contains(err.Error(), "reviewed base tree") {
+		t.Fatalf("bootstrap without reviewed base tree error = %v", err)
+	}
+}
+
+func TestBuildPushTargetKeepsFailingClosedWhenRemoteAdvertisesOnlyOtherRefs(t *testing.T) {
+	repo, _ := emptyRemoteTrackingRepo(t)
+	reviewedBaseTree := trimGit(gitSnapshot(t, repo, "rev-parse", "HEAD^{tree}"))
+	gitSnapshot(t, repo, "push", "origin", "HEAD:refs/heads/other")
+	writeSnapshotFile(t, repo, "tracked.txt", "reviewed delivery\n")
+	gitSnapshot(t, repo, "commit", "-am", "reviewed delivery")
+	if _, _, err := buildPushTarget(context.Background(), repo, "", reviewedBaseTree, ""); err == nil || !strings.Contains(err.Error(), "advertised remote branch") {
+		t.Fatalf("non-empty remote without tracked branch error = %v", err)
+	}
+}
+
+func TestBuildPushTargetKeepsFailingClosedOnUnrelatedAdvertisedHistory(t *testing.T) {
+	repo, _ := emptyRemoteTrackingRepo(t)
+	branch := currentBranch(context.Background(), repo)
+	reviewedBaseTree := trimGit(gitSnapshot(t, repo, "rev-parse", "HEAD^{tree}"))
+	gitSnapshot(t, repo, "checkout", "--orphan", "unrelated")
+	writeSnapshotFile(t, repo, "unrelated.txt", "unrelated\n")
+	gitSnapshot(t, repo, "add", "unrelated.txt")
+	gitSnapshot(t, repo, "commit", "-m", "unrelated")
+	gitSnapshot(t, repo, "push", "origin", "HEAD:refs/heads/"+branch)
+	gitSnapshot(t, repo, "checkout", branch)
+	writeSnapshotFile(t, repo, "tracked.txt", "reviewed delivery\n")
+	gitSnapshot(t, repo, "commit", "-am", "reviewed delivery")
+	if _, _, err := buildPushTarget(context.Background(), repo, "", reviewedBaseTree, ""); err == nil || !strings.Contains(err.Error(), "0 merge bases") {
+		t.Fatalf("unrelated advertised history error = %v", err)
+	}
+}
+
+func TestBuildPushTargetEmptyRemoteBootstrapRequiresMatchingPushDestination(t *testing.T) {
+	repo, _ := emptyRemoteTrackingRepo(t)
+	branch := currentBranch(context.Background(), repo)
+	reviewedBaseTree := trimGit(gitSnapshot(t, repo, "rev-parse", "HEAD^{tree}"))
+	other := filepath.Join(t.TempDir(), "other.git")
+	gitSnapshot(t, repo, "init", "--bare", other)
+	gitSnapshot(t, repo, "remote", "add", "publish", other)
+	gitSnapshot(t, repo, "config", "branch."+branch+".pushRemote", "publish")
+	writeSnapshotFile(t, repo, "tracked.txt", "reviewed delivery\n")
+	gitSnapshot(t, repo, "commit", "-am", "reviewed delivery")
+	if _, _, err := buildPushTarget(context.Background(), repo, "", reviewedBaseTree, ""); err == nil || !strings.Contains(err.Error(), "bootstrap") {
+		t.Fatalf("mismatched bootstrap push destination error = %v", err)
+	}
+}
+
+func TestBuildPushTargetEmptyRemoteKeepsDetachedHeadFailClosed(t *testing.T) {
+	repo, _ := emptyRemoteTrackingRepo(t)
+	reviewedBaseTree := trimGit(gitSnapshot(t, repo, "rev-parse", "HEAD^{tree}"))
+	writeSnapshotFile(t, repo, "tracked.txt", "reviewed delivery\n")
+	gitSnapshot(t, repo, "commit", "-am", "reviewed delivery")
+	gitSnapshot(t, repo, "checkout", "--detach")
+	if _, _, err := buildPushTarget(context.Background(), repo, "", reviewedBaseTree, ""); err == nil || !strings.Contains(err.Error(), "--base-ref") {
+		t.Fatalf("detached HEAD with empty remote error = %v", err)
+	}
+}
+
+func TestValidGitTreeRejectsNullOID(t *testing.T) {
+	for _, value := range []string{strings.Repeat("0", 40), strings.Repeat("0", 64)} {
+		if validGitTree(value) {
+			t.Fatalf("validGitTree(%q) accepted the reserved null OID", value)
+		}
+	}
+	if !validGitTree(strings.Repeat("0", 39) + "1") {
+		t.Fatal("validGitTree rejected a valid non-null object ID")
+	}
+}
+
+func TestBuildPushTargetEmptyRemoteRejectsAmbiguousReviewedDeliveryBase(t *testing.T) {
+	repo, _ := emptyRemoteTrackingRepo(t)
+	reviewedBaseTree := trimGit(gitSnapshot(t, repo, "rev-parse", "HEAD^{tree}"))
+	writeSnapshotFile(t, repo, "tracked.txt", "temporary change\n")
+	gitSnapshot(t, repo, "commit", "-am", "temporary change")
+	gitSnapshot(t, repo, "revert", "--no-edit", "HEAD")
+	writeSnapshotFile(t, repo, "tracked.txt", "reviewed delivery\n")
+	gitSnapshot(t, repo, "commit", "-am", "reviewed delivery")
+	if _, _, err := buildPushTarget(context.Background(), repo, "", reviewedBaseTree, ""); err == nil || !strings.Contains(err.Error(), "missing or ambiguous") {
+		t.Fatalf("ambiguous reviewed delivery base error = %v", err)
+	}
+}
+
+// TestBootstrapDisclosureScopeExcludesCommitMetadata pins the documented
+// contract boundary of bootstrap ancestry disclosure: review authority covers
+// repository CONTENT — tracked paths and blob bytes — and never commit or tag
+// metadata. A pre-base commit created with `git commit --allow-empty` touches
+// zero paths and introduces zero blobs, so it passes both disclosure rules
+// even though its commit OBJECT — including the secret message below — is
+// transferred by the bootstrap push. Commit messages are not review-bound
+// anywhere in the gate model: an ordinary (non-bootstrap) pre-push equally
+// publishes the reviewed delivery commit's message without any receipt
+// binding it, so bootstrap widens no guarantee that ever existed (see the
+// validateBootstrapAncestryDisclosure doc). Any future change that intends
+// to close this boundary must consciously flip this test.
+func TestBootstrapDisclosureScopeExcludesCommitMetadata(t *testing.T) {
+	repo, _ := emptyRemoteTrackingRepo(t)
+	gitSnapshot(t, repo, "commit", "--allow-empty", "-m", "SECRET-COMMIT-MESSAGE-MARKER token=hunter2")
+	secretCommit := trimGit(gitSnapshot(t, repo, "rev-parse", "HEAD"))
+	gitSnapshot(t, repo, "tag", "-a", "-m", "SECRET-TAG-MESSAGE-MARKER", "pre-base-secret")
+	writeSnapshotFile(t, repo, "reviewed-base.txt", "reviewed base\n")
+	gitSnapshot(t, repo, "add", "reviewed-base.txt")
+	gitSnapshot(t, repo, "commit", "-m", "reviewed base")
+	writeSnapshotFile(t, repo, "tracked.txt", "reviewed delivery\n")
+	transaction, receipt, artifacts := nativeGateFixture(t, repo, "bootstrap-commit-metadata-scope")
+	store, err := AuthoritativeStore(context.Background(), repo, transaction.LineageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	appendApprovedStoreChain(t, store, transaction)
+	gitSnapshot(t, repo, "add", "tracked.txt")
+	gitSnapshot(t, repo, "commit", "-m", "reviewed delivery")
+
+	request := nativePrePushRequest(t, repo, receipt, artifacts)
+	if request.Push == nil || request.Push.Boundary.Source != PrePRBoundaryEmptyRemoteBootstrap {
+		t.Fatalf("commit-metadata scope pre-push request = %#v", request.Push)
+	}
+	if got := EvaluateNativeGate(context.Background(), repo, receipt, request); got.Result != GateAllow {
+		t.Fatalf("bootstrap with secret pre-base commit message = %#v", got)
+	}
+	if !strings.Contains(gitSnapshot(t, repo, "rev-list", "HEAD"), secretCommit) {
+		t.Fatal("secret pre-base commit is not part of the published history")
+	}
+	// Annotated tag objects point AT commits; nothing reachable from a
+	// commit points back at a tag, so a branch bootstrap push transfers no
+	// tag objects and therefore no tag messages.
+	tagObject := trimGit(gitSnapshot(t, repo, "rev-parse", "pre-base-secret"))
+	if strings.Contains(gitSnapshot(t, repo, "rev-list", "--objects", "HEAD"), tagObject) {
+		t.Fatal("annotated tag object is reachable from the published history")
+	}
 }

--- a/internal/reviewtransaction/native_request.go
+++ b/internal/reviewtransaction/native_request.go
@@ -80,7 +80,7 @@ func BuildNativeGateRequest(ctx context.Context, repo string, input NativeGateRe
 		request.Target = Target{Kind: TargetCurrentChanges, IntendedUntracked: intended}
 	case GatePrePush:
 		deliveryBaseTree := map[TargetKind]string{TargetCurrentChanges: transaction.Snapshot.BaseTree}[transaction.Snapshot.Kind]
-		target, push, err := buildPushTarget(ctx, repo, input.BaseRef, deliveryBaseTree)
+		target, push, err := buildPushTarget(ctx, repo, input.BaseRef, deliveryBaseTree, transaction.Snapshot.BaseTree)
 		if err != nil {
 			return GateRequest{}, err
 		}

--- a/internal/reviewtransaction/prepr.go
+++ b/internal/reviewtransaction/prepr.go
@@ -215,7 +215,7 @@ func deriveCurrentChangesBoundaryCompatibility(ctx context.Context, repo string,
 	if !disjointPaths(deliveredPaths, basePaths) {
 		return BaseAdvanceCompatibility{}, errors.New("boundary advance overlaps delivered paths")
 	}
-	if err := validateCompactPublicationRange(ctx, repo, state.GenesisPaths, refs); err != nil {
+	if err := validateReviewedPublicationRange(ctx, repo, state.GenesisPaths, refs); err != nil {
 		return BaseAdvanceCompatibility{}, err
 	}
 	mergedOutput, err := runGit(ctx, repo, nil, nil, "merge-tree", "--write-tree", refs.Selection.Commit, refs.HeadCommit)

--- a/internal/reviewtransaction/receipt.go
+++ b/internal/reviewtransaction/receipt.go
@@ -408,5 +408,7 @@ func validSHA256(value string) bool {
 }
 
 func validGitTree(value string) bool {
-	return gitTreePattern.MatchString(value)
+	// Git reserves the all-zero OID as the null object; it never names a real
+	// tree or commit, so it is rejected even though it is syntactically hex.
+	return gitTreePattern.MatchString(value) && strings.Trim(value, "0") != ""
 }


### PR DESCRIPTION
Fixes #1399

## Problem

`review validate --gate pre-push` dead-ended for first publications: a remote with zero advertised refs produced "advertised base commit is not available locally" (or a zero-OID range crash risk) for every receipt kind, making gentle-ai unusable for a repository's first push.

## Fix

Empty-remote bootstrap boundaries are now first-class, with a fail-closed content-disclosure invariant enforced uniformly across `TargetCurrentChanges`, `TargetBaseDiff`, and `TargetBaseWorkspaceOverlay` on **both** the native and compact gates:

- **Boundary detection**: `emptyRemoteBootstrapBoundary` engages only when an upstream is configured, `ls-remote` succeeds with zero refs, and the remote identity resolves; the zero-OID sentinel is boundary evidence only and never reaches a git revision range (`validGitTree` also rejects the null OID).
- **Real resolved base**: `bootstrapReviewedDeliveryBase` resolves the unique commit whose tree matches the reviewed base (single-subprocess history scan); that commit — not the sentinel — anchors publication-range validation.
- **Delivered range**: every path in `resolvedBase..head` must be within immutable genesis scope (`validateReviewedPublicationRange`, now shared by both gates).
- **Pre-base ancestry disclosure**: every path touched anywhere in pre-base history must exist in the reviewed base tree, and every reachable blob must be byte-identical to a blob the base tree contains (path-agnostic OID membership; symlinks participate, gitlinks are path-only). An overwritten pre-base secret fails closed naming the path and blob, with squash/orphan-first-commit remediation. `rev-list --objects` + one `cat-file --batch-check` keeps subprocess count O(1).
- **Contract boundary**: commit/tag metadata (messages, identities, timestamps) is not review-bound anywhere in the gate model — ordinary pre-push equally publishes the delivery commit's message unbound. The scope is documented and pinned by `TestBootstrapDisclosureScopeExcludesCommitMetadata` (native + compact), which also proves annotated tag objects are never transferred by a branch bootstrap.

## Review

Native bounded review, seven rounds (high risk, 4R) — each round's CRITICAL was fixed and adversarially re-verified: the compact dead-end, the kind gap (CurrentChanges skipping validation), the over-strict full-history scan, path-only disclosure admitting overwritten secret blobs, and the metadata contract. Final round: zero severe findings. Follow-ups routed: 15s local-git timeout may deny very large first publications (fail-closed availability limit), and `buildBootstrapPushTarget`'s pre-#1432 "never diverge" comment is stale now that recovery-retry legitimately passes a composed chain base (behavior verified correct and receipt-bound by the independent rebind check; comment fix queued). All gates allow.

## Tests

17 bootstrap/publication-range tests including failing-first reproductions for every round's finding, uniform-kind negatives, ambiguity, null-OID, and scope pins. Full `internal/reviewtransaction` + `internal/cli` suites pass, including all #1401/#1432 cross-feature tests on the merged code.
