### PR TITLE
fix(review): tolerate retired nested recovered-start field read-only

### DIFF
--- a/internal/cli/review_historical_compat_test.go
+++ b/internal/cli/review_historical_compat_test.go
@@ -46,6 +46,109 @@ func injectCLIRetiredZeroEditEscalation(t *testing.T, statePath string) {
 	}
 }
 
+func injectCLIRetiredRecoveryReviewStart(t *testing.T, statePath string) {
+	t.Helper()
+	payload, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var record map[string]any
+	if err := json.Unmarshal(payload, &record); err != nil {
+		t.Fatal(err)
+	}
+	state, ok := record["state"].(map[string]any)
+	if !ok {
+		t.Fatal("compact record has no state object")
+	}
+	recovery, ok := state["recovery"].(map[string]any)
+	if !ok {
+		t.Fatal("compact state has no recovery object")
+	}
+	recovery["review_start"] = map[string]any{"operation": "review/start", "resumed": true}
+	statePayload, err := json.Marshal(record["state"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	sum := sha256.Sum256(append([]byte(reviewtransaction.CompactStateSchema+"\x00"), statePayload...))
+	record["revision"] = "sha256:" + hex.EncodeToString(sum[:])
+	updated, err := json.MarshalIndent(record, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(statePath, append(updated, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestReviewStatusReportsHistoricalRecoveredStartLineage(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("recovered candidate\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	predecessor := startFacadeReview(t, repo)
+	predecessorStore, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, predecessor.LineageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	record, err := predecessorStore.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := RunReviewInvalidate([]string{"--cwd", repo, "--lineage", predecessor.LineageID,
+		"--expected-revision", record.Revision, "--reason", "recovered-start fixture"}, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	invalidated, err := predecessorStore.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	successorLineage := "recovered-start-successor"
+	if err := RunReviewRecover([]string{"--cwd", repo, "--predecessor-lineage", predecessor.LineageID,
+		"--expected-predecessor-revision", invalidated.Revision, "--successor-lineage", successorLineage,
+		"--disposition", "invalidated", "--reason", "resume recovered start", "--actor", "maintainer"}, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	successorStore, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, successorLineage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	injectCLIRetiredRecoveryReviewStart(t, successorStore.StatePath())
+	before, err := os.ReadFile(successorStore.StatePath())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var output bytes.Buffer
+	if err := RunReviewStatus([]string{"--cwd", repo}, &output); err != nil {
+		t.Fatalf("review status with historical recovered-start record: %v", err)
+	}
+	if strings.Contains(output.String(), "unknown field") {
+		t.Fatalf("review status surfaced a strict-decode failure: %s", output.String())
+	}
+	var report reviewtransaction.AuthorityStatusReport
+	if err := json.Unmarshal(output.Bytes(), &report); err != nil {
+		t.Fatal(err)
+	}
+	if !report.Complete || !report.Authoritative {
+		t.Fatalf("historical recovered-start report = %#v", report)
+	}
+	found := false
+	for _, entry := range report.Entries {
+		if entry.LineageID == successorLineage {
+			found = true
+			if entry.Status != reviewtransaction.AuthorityStatusRecovered {
+				t.Fatalf("historical recovered-start entry = %#v", entry)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("historical recovered-start lineage missing from report: %#v", report)
+	}
+	if after, err := os.ReadFile(successorStore.StatePath()); err != nil || !bytes.Equal(before, after) {
+		t.Fatalf("review status rewrote historical authority bytes: %v", err)
+	}
+}
+
 func TestReviewBundleExportRefusesHistoricalZeroEditEscalationClearly(t *testing.T) {
 	repo := initReviewCLIRepo(t)
 	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("historical candidate\n"), 0o644); err != nil {

--- a/internal/reviewtransaction/compact_historical_compat_test.go
+++ b/internal/reviewtransaction/compact_historical_compat_test.go
@@ -43,6 +43,176 @@ func injectRetiredCompactStateField(t *testing.T, statePath, field string) strin
 	return record["revision"].(string)
 }
 
+func injectRetiredCompactNestedStateField(t *testing.T, statePath, parent, field string, value any) string {
+	t.Helper()
+	payload, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var record map[string]any
+	if err := json.Unmarshal(payload, &record); err != nil {
+		t.Fatal(err)
+	}
+	state, ok := record["state"].(map[string]any)
+	if !ok {
+		t.Fatal("compact record has no state object")
+	}
+	nested, ok := state[parent].(map[string]any)
+	if !ok {
+		t.Fatalf("compact state has no %q object", parent)
+	}
+	nested[field] = value
+	statePayload, err := json.Marshal(record["state"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	sum := sha256.Sum256(append([]byte(CompactStateSchema+"\x00"), statePayload...))
+	record["revision"] = "sha256:" + hex.EncodeToString(sum[:])
+	updated, err := json.MarshalIndent(record, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(statePath, append(updated, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return record["revision"].(string)
+}
+
+// historicalRecoveredSuccessorFixture builds an invalidated predecessor and a
+// real recovered successor so tests can retrofit the retired nested
+// recovery.review_start field older builds persisted.
+func historicalRecoveredSuccessorFixture(t *testing.T, repo string) (CompactState, CompactState, CompactStore) {
+	t.Helper()
+	writeSnapshotFile(t, repo, "tracked.txt", "candidate\n")
+	predecessor := newCompactTestState(t, repo, "recovered-start-predecessor")
+	predecessorStore, err := CompactAuthoritativeStore(context.Background(), repo, predecessor.LineageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	revision, err := predecessorStore.Replace("", "review/start", predecessor)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := predecessor.Invalidate("recovered-start fixture predecessor"); err != nil {
+		t.Fatal(err)
+	}
+	revision, err = predecessorStore.Replace(revision, "review/invalidate", predecessor)
+	if err != nil {
+		t.Fatal(err)
+	}
+	successor := newCompactTestState(t, repo, "recovered-start-successor")
+	successor.Generation = predecessor.Generation + 1
+	if _, err := RecoverCompactAuthority(context.Background(), repo, CompactRecoveryRequest{
+		PredecessorLineageID: predecessor.LineageID, ExpectedPredecessorRevision: revision,
+		Successor: successor, Disposition: RecoveryInvalidated, Reason: "verification invalidated authority", Actor: "maintainer",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	successorStore, err := CompactAuthoritativeStore(context.Background(), repo, successor.LineageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return predecessor, successor, successorStore
+}
+
+// retiredRecoveryReviewStartValue mimics the recovered-start provenance object
+// a pre-release local build nested under state.recovery.
+func retiredRecoveryReviewStartValue() map[string]any {
+	return map[string]any{"operation": "review/start", "resumed": true}
+}
+
+func TestCompactStoreLoadsHistoricalRecoveryReviewStartReadOnly(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	predecessor, successor, store := historicalRecoveredSuccessorFixture(t, repo)
+	revision := injectRetiredCompactNestedStateField(t, store.StatePath(), "recovery", "review_start", retiredRecoveryReviewStartValue())
+	before, err := os.ReadFile(store.StatePath())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	record, err := store.Load()
+	if err != nil {
+		t.Fatalf("load historical recovery.review_start record: %v", err)
+	}
+	if record.Revision != revision || record.State.LineageID != successor.LineageID || !record.HistoricalCompat {
+		t.Fatalf("historical record = %#v, want read-only revision %s", record, revision)
+	}
+	if record.State.Recovery == nil || record.State.Recovery.PredecessorLineageID != predecessor.LineageID {
+		t.Fatalf("historical record dropped recovery provenance: %#v", record.State.Recovery)
+	}
+	if _, err := CompactAuthorityLeaves(context.Background(), repo); err != nil {
+		t.Fatalf("historical record poisoned the compact authority graph: %v", err)
+	}
+	report, err := InventoryAuthority(context.Background(), repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !report.Complete || !hasAuthorityInventoryStatus(report.Entries, successor.LineageID, AuthorityStatusRecovered) ||
+		!hasAuthorityInventoryStatus(report.Entries, predecessor.LineageID, AuthorityStatusSuperseded) {
+		t.Fatalf("historical recovered inventory = %#v", report)
+	}
+	next := record.State
+	if err := next.Invalidate("historical maintenance"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Replace(record.Revision, "review/invalidate", next); err == nil || !errors.Is(err, ErrHistoricalCompatReadOnly) {
+		t.Fatalf("historical mutation error = %v", err)
+	}
+	if _, err := store.ExportTransport(); err == nil || !errors.Is(err, ErrHistoricalCompatReadOnly) {
+		t.Fatalf("historical transport export error = %v", err)
+	}
+	if after, err := os.ReadFile(store.StatePath()); err != nil || !bytes.Equal(before, after) {
+		t.Fatalf("historical authority bytes changed: %v", err)
+	}
+}
+
+func TestCompactStoreStillRejectsUnknownNestedRecoveryFields(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	_, _, store := historicalRecoveredSuccessorFixture(t, repo)
+	injectRetiredCompactNestedStateField(t, store.StatePath(), "recovery", "bogus", true)
+	if _, err := store.Load(); err == nil || !strings.Contains(err.Error(), "unknown field") {
+		t.Fatalf("unknown nested non-retired field load error = %v", err)
+	}
+}
+
+func TestCompactStoreStillRejectsTopLevelReviewStartField(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	writeSnapshotFile(t, repo, "tracked.txt", "candidate\n")
+	state := newCompactTestState(t, repo, "top-level-review-start-lineage")
+	store, err := CompactAuthoritativeStore(context.Background(), repo, state.LineageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Replace("", "review/start", state); err != nil {
+		t.Fatal(err)
+	}
+	// review_start is retired only nested under recovery; the same name at the
+	// top level was never persisted and must stay strictly rejected.
+	injectRetiredCompactStateField(t, store.StatePath(), "review_start")
+	if _, err := store.Load(); err == nil || !strings.Contains(err.Error(), `unknown field "review_start"`) {
+		t.Fatalf("top-level review_start load error = %v", err)
+	}
+}
+
+func TestNewCompactAuthorityNeverPersistsRetiredRecoveryReviewStart(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	_, successor, store := historicalRecoveredSuccessorFixture(t, repo)
+	record, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, payload, err := makeCompactRecord(record.State)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(payload, []byte("review_start")) {
+		t.Fatal("new compact authority serialized the retired recovery.review_start field")
+	}
+	if record.HistoricalCompat {
+		t.Fatalf("clean recovered successor %q is marked as historical compatibility authority", successor.LineageID)
+	}
+}
+
 func TestCompactStoreLoadsHistoricalZeroEditEscalationReadOnly(t *testing.T) {
 	repo := initSnapshotRepo(t)
 	writeSnapshotFile(t, repo, "tracked.txt", "candidate\n")

--- a/internal/reviewtransaction/compact_store.go
+++ b/internal/reviewtransaction/compact_store.go
@@ -54,11 +54,18 @@ const compactRecoveryAuthorizationSchema = "gentle-ai.review-recovery-authorizat
 // through the retired-field compatibility path.
 var ErrHistoricalCompatReadOnly = errors.New("historical compatibility authority is read-only")
 
-// compactRetiredStateFields lists top-level compact state fields persisted by
-// older builds and removed from the current schema. Historical records that
-// carry them load read-only; new authority state never persists them.
-var compactRetiredStateFields = map[string]struct{}{
-	"zero_edit_escalation": {},
+// compactRetiredStateFieldPaths lists dot-separated compact state field paths
+// persisted by older builds and removed from the current schema. Each path is
+// tolerated only at its exact nesting level: "zero_edit_escalation" at the
+// state top level and "recovery.review_start" nested inside the recovery
+// provenance object. Historical records that carry them load read-only with
+// the retired content dropped from the in-memory view only; the persisted
+// bytes, including the retired recovered-start provenance, remain untouched
+// on disk because the tolerant read never rewrites authority. New authority
+// state never persists these fields.
+var compactRetiredStateFieldPaths = map[string]struct{}{
+	"zero_edit_escalation":  {},
+	"recovery.review_start": {},
 }
 
 // LegacyReadOnlyError is the typed ordinary-mutation denial for historical
@@ -1241,24 +1248,28 @@ func parseCompactRecord(payload []byte, lineageID string) (CompactRecord, error)
 
 // retiredCompactFieldError reports whether a strict decode failure names a
 // retired compatibility field, so only genuine historical records pay the
-// tolerant second parse.
+// tolerant second parse. The decoder error only carries the leaf field name;
+// the tolerant parse then enforces the exact nesting level of each path.
 func retiredCompactFieldError(err error) bool {
 	message := err.Error()
 	if !strings.Contains(message, "unknown field") {
 		return false
 	}
-	for name := range compactRetiredStateFields {
-		if strings.Contains(message, `"`+name+`"`) {
+	for path := range compactRetiredStateFieldPaths {
+		segments := strings.Split(path, ".")
+		if strings.Contains(message, `"`+segments[len(segments)-1]+`"`) {
 			return true
 		}
 	}
 	return false
 }
 
-// parseHistoricalCompactRecord tolerates only retired top-level state fields
-// from older builds. The persisted revision must bind the exact historical
-// state bytes, so loading preserves revisions and provenance without ever
-// rewriting or re-hashing persisted authority.
+// parseHistoricalCompactRecord tolerates only retired state field paths from
+// older builds, each removed at its exact nesting level. The persisted
+// revision must bind the exact historical state bytes, so loading preserves
+// revisions and provenance without ever rewriting or re-hashing persisted
+// authority; retired content such as recovery.review_start stays intact on
+// disk and is only dropped from the decoded in-memory view.
 func parseHistoricalCompactRecord(payload []byte) (CompactRecord, error) {
 	var envelope struct {
 		Schema   string          `json:"schema"`
@@ -1279,10 +1290,13 @@ func parseHistoricalCompactRecord(payload []byte) (CompactRecord, error) {
 		return CompactRecord{}, err
 	}
 	retired := false
-	for name := range compactRetiredStateFields {
-		if _, exists := fields[name]; exists {
+	for path := range compactRetiredStateFieldPaths {
+		deleted, deleteErr := deleteRetiredCompactField(fields, strings.Split(path, "."))
+		if deleteErr != nil {
+			return CompactRecord{}, deleteErr
+		}
+		if deleted {
 			retired = true
-			delete(fields, name)
 		}
 	}
 	if !retired {
@@ -1311,6 +1325,36 @@ func parseHistoricalCompactRecord(payload []byte) (CompactRecord, error) {
 		return CompactRecord{}, errors.New("compact review state checksum mismatch")
 	}
 	return CompactRecord{Schema: envelope.Schema, Revision: envelope.Revision, State: state, HistoricalCompat: true}, nil
+}
+
+// deleteRetiredCompactField removes one retired field at the exact nesting
+// level its dot-path names, mutating only the in-memory field view used for
+// the tolerant re-decode. A retired leaf name appearing at any other level
+// stays in place and keeps failing strict decoding.
+func deleteRetiredCompactField(fields map[string]json.RawMessage, path []string) (bool, error) {
+	name := path[0]
+	raw, exists := fields[name]
+	if !exists {
+		return false, nil
+	}
+	if len(path) == 1 {
+		delete(fields, name)
+		return true, nil
+	}
+	var nested map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &nested); err != nil {
+		return false, err
+	}
+	deleted, err := deleteRetiredCompactField(nested, path[1:])
+	if err != nil || !deleted {
+		return deleted, err
+	}
+	updated, err := json.Marshal(nested)
+	if err != nil {
+		return false, err
+	}
+	fields[name] = updated
+	return true, nil
 }
 
 func appendCompactTrace(path string, entry CompactTraceEntry) error {


### PR DESCRIPTION
Fixes #1322

## Problem

Compact-v2 records written by older gentle-ai versions carry a retired nested field `recovery.review_start`. Current strict decoding fails with `json: unknown field "review_start"`, marking the lineage invalid and bricking `review status` and gate validation for the entire repository.

## Fix

The tolerant historical read (shipped for `zero_edit_escalation` in #1397) now accepts retired field **paths** at their exact nesting level:

- `compactRetiredStateFieldPaths` holds dot-separated paths (`zero_edit_escalation`, `recovery.review_start`), each tolerated only at its recorded position.
- The decoder error only names the leaf, so `retiredCompactFieldError` routes on the leaf segment as a cheap pre-filter; the recursive `deleteRetiredCompactField` then walks the exact path — a same-named field at any other nesting level survives into the strict re-decode and still fails, preserving the original strict error.
- Tolerated records inherit the full historical-compat contract: `HistoricalCompat` marking, mutation and `ExportTransport` refused with `ErrHistoricalCompatReadOnly`, revision hashed over the original raw bytes (retired field included), and on-disk provenance bytes untouched — only the in-memory view drops the field.

## Review

Native bounded review (high risk, 4R): zero blocking findings. Risk verified the exact-nesting enforcement is load-bearing (leaf-name collisions fail closed through the residual strict re-decode) and that nothing security-relevant reads the retired field. Follow-ups: dedicated malformed-recovery-shape regression tests and test-helper dedup.

## Tests

Failing-first reproduction of the exact issue symptom (status `invalid` + unknown-field error) from a real invalidated-predecessor → recovered-successor fixture. Guards: `recovery.bogus` still strict, top-level `review_start` (wrong nesting) still strict, clean successors never serialize the field, read-only refusals asserted, on-disk bytes byte-identical. Full suites pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility when reading historical authority records containing retired nested recovery metadata.
  * Historical records are recognized as read-only and protected from accidental modification.
  * Preserved strict validation for unknown or incorrectly placed fields.
  * Confirmed status reporting remains complete and authoritative for recovered historical lineages.
* **Tests**
  * Added coverage for legacy record loading, status reporting, read-only behavior, and prevention of retired fields in newly created records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->