### PR TITLE
fix(sync): refresh managed OpenCode and Kilocode review plugins

### DIFF
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1714,11 +1714,13 @@ func sddSubAgentPaths(homeDir string, adapter agents.Adapter) []string {
 }
 
 func openCodeSDDPluginPaths(targetDir string) []string {
-	return []string{
-		filepath.Join(targetDir, ".config", "opencode", "plugins", "background-agents.ts"),
-		filepath.Join(targetDir, ".config", "opencode", "plugins", "model-variants.ts"),
-		filepath.Join(targetDir, ".config", "opencode", "plugins", "skill-registry.ts"),
+	// Legacy plugin first: installOpenCodePlugins removes it, and verification
+	// asserts its absence (isLegacyOpenCodeBackgroundAgentsPlugin).
+	paths := []string{filepath.Join(targetDir, ".config", "opencode", "plugins", "background-agents.ts")}
+	for _, name := range sdd.ManagedOpenCodePluginNames() {
+		paths = append(paths, filepath.Join(targetDir, ".config", "opencode", "plugins", name))
 	}
+	return paths
 }
 
 type postApplyVerificationInput struct {

--- a/internal/cli/run_component_paths_test.go
+++ b/internal/cli/run_component_paths_test.go
@@ -64,7 +64,7 @@ func TestComponentPathsSDDMultiIncludesOpenCodePlugins(t *testing.T) {
 
 	paths := componentPaths(home, model.Selection{SDDMode: model.SDDModeMulti}, adapters, model.ComponentSDD)
 
-	for _, plugin := range []string{"background-agents.ts", "model-variants.ts", "skill-registry.ts"} {
+	for _, plugin := range []string{"background-agents.ts", "model-variants.ts", "review-result-artifacts.ts", "skill-registry.ts"} {
 		path := filepath.Join(home, ".config", "opencode", "plugins", plugin)
 		if !containsPath(paths, path) {
 			t.Fatalf("componentPaths(sdd multi) missing OpenCode plugin path %q\npaths=%v", path, paths)
@@ -78,7 +78,7 @@ func TestComponentPathsSDDSingleIncludesOpenCodePlugins(t *testing.T) {
 
 	paths := componentPaths(home, model.Selection{SDDMode: model.SDDModeSingle}, adapters, model.ComponentSDD)
 
-	for _, plugin := range []string{"background-agents.ts", "model-variants.ts", "skill-registry.ts"} {
+	for _, plugin := range []string{"background-agents.ts", "model-variants.ts", "review-result-artifacts.ts", "skill-registry.ts"} {
 		path := filepath.Join(home, ".config", "opencode", "plugins", plugin)
 		if !containsPath(paths, path) {
 			t.Fatalf("componentPaths(sdd single) missing OpenCode plugin path %q\npaths=%v", path, paths)

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -488,6 +488,22 @@ func (r *syncRuntime) stagePlan() pipeline.StagePlan {
 		})
 	}
 
+	// Managed OpenCode-compatible plugins are versioned runtime artifacts tied
+	// to the installed binary (OpenCode and Kilocode receive them). When the
+	// persisted selection lacks the SDD component, no SDD step is planned and
+	// already-installed plugins would silently stay stale after upgrades
+	// (issue #1440). Refresh installed copies explicitly; the step never
+	// installs plugins that were never present. When SDD is selected, its
+	// inject step already rewrites the plugins.
+	if anyAgentReceivesManagedOpenCodePlugins(r.agentIDs) && !r.selection.HasComponent(model.ComponentSDD) {
+		apply = append(apply, openCodePluginRefreshSyncStep{
+			id:           "sync:opencode:managed-plugins",
+			homeDir:      r.homeDir,
+			agents:       r.agentIDs,
+			changedFiles: &r.changedFiles,
+		})
+	}
+
 	if r.selection.HasCommunityTool(model.CommunityToolCodeGraph) {
 		apply = append(apply, &codeGraphGuidanceSyncStep{
 			id:           "sync:community-tool:codegraph-guidance",
@@ -510,6 +526,19 @@ func syncBackupTargets(homeDir, workspaceDir string, selection model.Selection, 
 	for _, component := range selection.Components {
 		for _, path := range syncComponentPathsWithWorkspace(homeDir, workspaceDir, selection, adapters, component) {
 			paths[path] = struct{}{}
+		}
+	}
+	// Managed OpenCode-compatible plugin paths are part of sync's
+	// backup/snapshot contract whenever a plugin-receiving agent (OpenCode,
+	// Kilocode) is synced, independent of the SDD component: the
+	// openCodePluginRefreshSyncStep may rewrite installed copies (issue #1440).
+	for _, adapter := range adapters {
+		if !sdd.AgentReceivesManagedOpenCodePlugins(adapter.Agent()) {
+			continue
+		}
+		pluginsDir := filepath.Join(adapter.GlobalConfigDir(homeDir), "plugins")
+		for _, name := range sdd.ManagedOpenCodePluginNames() {
+			paths[filepath.Join(pluginsDir, name)] = struct{}{}
 		}
 	}
 	if selection.HasCommunityTool(model.CommunityToolCodeGraph) {
@@ -636,6 +665,46 @@ type codeGraphGuidanceSyncStep struct {
 type piCodeGraphSyncStep struct {
 	id, homeDir, workspaceDir string
 	changedFiles              *[]string
+}
+
+// openCodePluginRefreshSyncStep refreshes already-installed managed
+// OpenCode-compatible plugins (OpenCode, Kilocode) from the embedded assets
+// when the SDD component is not part of the sync selection (issue #1440).
+// It never creates plugins that were never installed.
+type openCodePluginRefreshSyncStep struct {
+	id           string
+	homeDir      string
+	agents       []model.AgentID
+	changedFiles *[]string
+}
+
+func (s openCodePluginRefreshSyncStep) ID() string { return s.id }
+
+func (s openCodePluginRefreshSyncStep) Run() error {
+	for _, adapter := range resolveAdapters(s.agents) {
+		if !sdd.AgentReceivesManagedOpenCodePlugins(adapter.Agent()) {
+			continue
+		}
+		res, err := sdd.RefreshInstalledOpenCodePlugins(s.homeDir, adapter)
+		if err != nil {
+			return fmt.Errorf("sync managed OpenCode plugins: %w", err)
+		}
+		if s.changedFiles != nil && res.Changed {
+			*s.changedFiles = append(*s.changedFiles, res.Files...)
+		}
+	}
+	return nil
+}
+
+// anyAgentReceivesManagedOpenCodePlugins reports whether any synced agent
+// receives the managed OpenCode-compatible plugins from the SDD injector.
+func anyAgentReceivesManagedOpenCodePlugins(agentIDs []model.AgentID) bool {
+	for _, id := range agentIDs {
+		if sdd.AgentReceivesManagedOpenCodePlugins(id) {
+			return true
+		}
+	}
+	return false
 }
 
 var refreshPiCodeGraphIfConfigured = communitytool.RefreshPiCodeGraphIfConfigured

--- a/internal/cli/sync_test.go
+++ b/internal/cli/sync_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/gentleman-programming/gentle-ai/internal/agents"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/codex"
+	"github.com/gentleman-programming/gentle-ai/internal/assets"
 	"github.com/gentleman-programming/gentle-ai/internal/backup"
 	"github.com/gentleman-programming/gentle-ai/internal/components/communitytool"
 	"github.com/gentleman-programming/gentle-ai/internal/components/filemerge"
@@ -689,6 +690,172 @@ func TestRunSyncRefreshesPersistedVisualComponents(t *testing.T) {
 	}
 	if !second.NoOp || second.FilesChanged != 0 || len(second.ChangedFiles) != 0 {
 		t.Fatalf("second sync = NoOp %v, FilesChanged %d, ChangedFiles %#v; want idempotent no-op", second.NoOp, second.FilesChanged, second.ChangedFiles)
+	}
+}
+
+// TestRunSyncRefreshesInstalledOpenCodeReviewPluginWithoutSDDComponent
+// reproduces issue #1440: when the persisted selection lacks the SDD component
+// but managed OpenCode plugins are already installed on disk, `gentle-ai sync`
+// must refresh them to the embedded assets of the running binary.
+func TestRunSyncRefreshesInstalledOpenCodeReviewPluginWithoutSDDComponent(t *testing.T) {
+	home := t.TempDir()
+	if err := state.Write(home, state.InstallState{
+		InstalledAgents:     []string{"opencode"},
+		SelectionConfigured: true,
+		Components:          []model.ComponentID{model.ComponentEngram},
+		Persona:             "neutral",
+	}); err != nil {
+		t.Fatalf("state.Write() error = %v", err)
+	}
+
+	pluginsDir := filepath.Join(home, ".config", "opencode", "plugins")
+	stalePlugins := map[string]string{
+		"review-result-artifacts.ts": filepath.Join(pluginsDir, "review-result-artifacts.ts"),
+		"model-variants.ts":          filepath.Join(pluginsDir, "model-variants.ts"),
+	}
+	for name, path := range stalePlugins {
+		mustWriteFile(t, path, []byte("// stale v2.1.7 managed plugin "+name))
+	}
+
+	restoreHome := osUserHomeDir
+	restoreBackupHome := backup.UserHomeDirFn
+	osUserHomeDir = func() (string, error) { return home, nil }
+	backup.UserHomeDirFn = func() (string, error) { return home, nil }
+	t.Cleanup(func() {
+		osUserHomeDir = restoreHome
+		backup.UserHomeDirFn = restoreBackupHome
+	})
+
+	result, err := RunSync(nil)
+	if err != nil {
+		t.Fatalf("RunSync() error = %v", err)
+	}
+
+	for name, path := range stalePlugins {
+		got, readErr := os.ReadFile(path)
+		if readErr != nil {
+			t.Fatalf("ReadFile(%q) error = %v", path, readErr)
+		}
+		want := assets.MustRead("opencode/plugins/" + name)
+		if string(got) != want {
+			t.Errorf("sync left installed managed OpenCode plugin %s stale; content must be byte-equal to the embedded asset", name)
+		}
+		if !containsPath(result.ChangedFiles, path) {
+			t.Errorf("ChangedFiles missing refreshed plugin path %q\nchanged = %#v", path, result.ChangedFiles)
+		}
+	}
+
+	// skill-registry.ts was never installed — sync must not create it.
+	skillRegistry := filepath.Join(pluginsDir, "skill-registry.ts")
+	if _, err := os.Stat(skillRegistry); !os.IsNotExist(err) {
+		t.Errorf("sync must not create never-installed plugin %q; stat err = %v", skillRegistry, err)
+	}
+}
+
+// TestRunSyncRefreshesInstalledKilocodePluginsWithoutSDDComponent covers the
+// Kilocode variant of issue #1440: the SDD injector installs the managed
+// OpenCode-compatible plugins for Kilocode too (under ~/.config/kilo/plugins),
+// so sync must refresh installed copies there as well — and still never create
+// plugins that were never installed.
+func TestRunSyncRefreshesInstalledKilocodePluginsWithoutSDDComponent(t *testing.T) {
+	home := t.TempDir()
+	if err := state.Write(home, state.InstallState{
+		InstalledAgents:     []string{"kilocode"},
+		SelectionConfigured: true,
+		Components:          []model.ComponentID{model.ComponentEngram},
+		Persona:             "neutral",
+	}); err != nil {
+		t.Fatalf("state.Write() error = %v", err)
+	}
+
+	pluginsDir := filepath.Join(home, ".config", "kilo", "plugins")
+	reviewPlugin := filepath.Join(pluginsDir, "review-result-artifacts.ts")
+	mustWriteFile(t, reviewPlugin, []byte("// stale v2.1.7 managed plugin"))
+
+	restoreHome := osUserHomeDir
+	restoreBackupHome := backup.UserHomeDirFn
+	osUserHomeDir = func() (string, error) { return home, nil }
+	backup.UserHomeDirFn = func() (string, error) { return home, nil }
+	t.Cleanup(func() {
+		osUserHomeDir = restoreHome
+		backup.UserHomeDirFn = restoreBackupHome
+	})
+
+	result, err := RunSync(nil)
+	if err != nil {
+		t.Fatalf("RunSync() error = %v", err)
+	}
+
+	got, readErr := os.ReadFile(reviewPlugin)
+	if readErr != nil {
+		t.Fatalf("ReadFile(%q) error = %v", reviewPlugin, readErr)
+	}
+	if string(got) != assets.MustRead("opencode/plugins/review-result-artifacts.ts") {
+		t.Errorf("sync left installed managed Kilocode plugin stale; content must be byte-equal to the embedded asset")
+	}
+	if !containsPath(result.ChangedFiles, reviewPlugin) {
+		t.Errorf("ChangedFiles missing refreshed Kilocode plugin path %q\nchanged = %#v", reviewPlugin, result.ChangedFiles)
+	}
+
+	// skill-registry.ts was never installed — sync must not create it.
+	skillRegistry := filepath.Join(pluginsDir, "skill-registry.ts")
+	if _, err := os.Stat(skillRegistry); !os.IsNotExist(err) {
+		t.Errorf("sync must not create never-installed plugin %q; stat err = %v", skillRegistry, err)
+	}
+}
+
+// TestRunSyncDoesNotCreateOpenCodeReviewPluginWhenNeverInstalled guards the
+// refresh behavior for issue #1440: users who never had the SDD/OpenCode
+// plugins installed must not receive them from a plain sync.
+func TestRunSyncDoesNotCreateOpenCodeReviewPluginWhenNeverInstalled(t *testing.T) {
+	home := t.TempDir()
+	if err := state.Write(home, state.InstallState{
+		InstalledAgents:     []string{"opencode"},
+		SelectionConfigured: true,
+		Components:          []model.ComponentID{model.ComponentEngram},
+		Persona:             "neutral",
+	}); err != nil {
+		t.Fatalf("state.Write() error = %v", err)
+	}
+
+	restoreHome := osUserHomeDir
+	restoreBackupHome := backup.UserHomeDirFn
+	osUserHomeDir = func() (string, error) { return home, nil }
+	backup.UserHomeDirFn = func() (string, error) { return home, nil }
+	t.Cleanup(func() {
+		osUserHomeDir = restoreHome
+		backup.UserHomeDirFn = restoreBackupHome
+	})
+
+	if _, err := RunSync(nil); err != nil {
+		t.Fatalf("RunSync() error = %v", err)
+	}
+
+	pluginPath := filepath.Join(home, ".config", "opencode", "plugins", "review-result-artifacts.ts")
+	if _, err := os.Stat(pluginPath); !os.IsNotExist(err) {
+		t.Errorf("sync must not install %q for users who never had it; stat err = %v", pluginPath, err)
+	}
+}
+
+// TestSyncBackupTargetsIncludeManagedOpenCodePluginsWithoutSDD verifies that
+// managed OpenCode plugin paths are part of sync's backup/snapshot contract
+// even when the selection lacks the SDD component (issue #1440).
+func TestSyncBackupTargetsIncludeManagedOpenCodePluginsWithoutSDD(t *testing.T) {
+	home := t.TempDir()
+	sel := model.Selection{
+		Agents:     []model.AgentID{model.AgentOpenCode, model.AgentKilocode},
+		Components: []model.ComponentID{model.ComponentEngram},
+	}
+
+	targets := syncBackupTargets(home, "", sel, resolveAdapters(sel.Agents))
+
+	for _, configDir := range []string{"opencode", "kilo"} {
+		for _, plugin := range []string{"model-variants.ts", "review-result-artifacts.ts", "skill-registry.ts"} {
+			want := filepath.Join(home, ".config", configDir, "plugins", plugin)
+			if !containsPath(targets, want) {
+				t.Errorf("syncBackupTargets missing managed plugin path %q\ntargets = %v", want, targets)
+			}
+		}
 	}
 }
 

--- a/internal/components/sdd/inject.go
+++ b/internal/components/sdd/inject.go
@@ -439,7 +439,7 @@ func Inject(homeDir string, adapter agents.Adapter, sddMode model.SDDModeID, opt
 	// os.ReadFile call due to VFS/NTFS metadata caching, which caused the spurious
 	// "post-check: .../opencode.json missing sdd-apply sub-agent" error.
 	var mergedSettingsBytes []byte
-	if adapter.Agent() == model.AgentOpenCode || adapter.Agent() == model.AgentKilocode {
+	if AgentReceivesManagedOpenCodePlugins(adapter.Agent()) {
 		settingsPath := adapter.SettingsPath(homeDir)
 		if settingsPath != "" {
 			overlayContent, err := assets.Read(overlayAssetPath(sddMode))
@@ -1594,6 +1594,61 @@ func claudeHookListContains(hookEntries []any, command string) bool {
 	return false
 }
 
+// ManagedOpenCodePluginNames lists the OpenCode plugin files gentle-ai manages
+// as versioned runtime artifacts. Their content is tied to the installed binary
+// version: install writes them and sync must keep already-installed copies
+// byte-equal to the embedded assets (issue #1440).
+func ManagedOpenCodePluginNames() []string {
+	return []string{"model-variants.ts", "review-result-artifacts.ts", "skill-registry.ts"}
+}
+
+// AgentReceivesManagedOpenCodePlugins reports whether the SDD injector
+// installs the managed OpenCode-compatible plugins for the given agent.
+// Inject's settings/plugins gate and sync's plugin refresh both use this
+// predicate so the two gates cannot drift (issue #1440).
+func AgentReceivesManagedOpenCodePlugins(agent model.AgentID) bool {
+	return agent == model.AgentOpenCode || agent == model.AgentKilocode
+}
+
+// RefreshInstalledOpenCodePlugins rewrites managed OpenCode plugins that are
+// already installed on disk so they track the embedded assets of the running
+// binary. It never creates a plugin that was not previously installed — users
+// who never received the SDD/OpenCode plugins must not get them from a plain
+// sync. Managed plugins carry no user content, so drift is resolved by
+// overwriting, matching installOpenCodePlugins.
+func RefreshInstalledOpenCodePlugins(homeDir string, adapter agents.Adapter) (InjectionResult, error) {
+	pluginsDir := filepath.Join(adapter.GlobalConfigDir(homeDir), "plugins")
+
+	var files []string
+	var changed bool
+
+	for _, name := range ManagedOpenCodePluginNames() {
+		pluginPath := filepath.Join(pluginsDir, name)
+		info, err := os.Lstat(pluginPath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return InjectionResult{}, fmt.Errorf("stat managed OpenCode plugin %s: %w", pluginPath, err)
+		}
+		if !info.Mode().IsRegular() {
+			continue
+		}
+
+		content := assets.MustRead("opencode/plugins/" + name)
+		writeResult, err := filemerge.WriteFileAtomic(pluginPath, []byte(content), 0o644)
+		if err != nil {
+			return InjectionResult{}, fmt.Errorf("refresh managed OpenCode plugin %s: %w", name, err)
+		}
+		if writeResult.Changed {
+			changed = true
+			files = append(files, pluginPath)
+		}
+	}
+
+	return InjectionResult{Changed: changed, Files: files}, nil
+}
+
 // installOpenCodePlugins copies the OpenCode-compatible plugins that gentle-ai
 // still manages by default. Native OpenCode subagents replace the legacy
 // background-agents plugin, so that legacy cleanup is scoped to OpenCode only.
@@ -1620,7 +1675,7 @@ func installOpenCodePlugins(homeDir string, adapter agents.Adapter) (InjectionRe
 		}
 	}
 
-	for _, name := range []string{"model-variants.ts", "review-result-artifacts.ts", "skill-registry.ts"} {
+	for _, name := range ManagedOpenCodePluginNames() {
 		content := assets.MustRead("opencode/plugins/" + name)
 		pluginPath := filepath.Join(pluginsDir, name)
 

--- a/internal/components/sdd/inject_test.go
+++ b/internal/components/sdd/inject_test.go
@@ -7016,3 +7016,74 @@ func TestMigrateLegacyOpenCodeCommandPromptNoOp(t *testing.T) {
 		}
 	}
 }
+
+// TestRefreshInstalledOpenCodePluginsSkipsSymlinksAndDirectories pins the
+// Lstat safety property of RefreshInstalledOpenCodePlugins: only regular
+// files at managed plugin paths are refreshed. A symlink must be skipped
+// without following it (the user-owned target must stay untouched) and a
+// directory at a plugin path must be left alone.
+func TestRefreshInstalledOpenCodePluginsSkipsSymlinksAndDirectories(t *testing.T) {
+	home := t.TempDir()
+	pluginsDir := filepath.Join(home, ".config", "opencode", "plugins")
+	if err := os.MkdirAll(pluginsDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(plugins) error = %v", err)
+	}
+
+	// Symlink at a managed plugin path, pointing at a user file.
+	userFile := filepath.Join(home, "user-owned.ts")
+	userContent := []byte("// user-owned content, must never be overwritten")
+	if err := os.WriteFile(userFile, userContent, 0o644); err != nil {
+		t.Fatalf("WriteFile(user file) error = %v", err)
+	}
+	symlinkPath := filepath.Join(pluginsDir, "review-result-artifacts.ts")
+	if err := os.Symlink(userFile, symlinkPath); err != nil {
+		t.Skipf("symlinks not supported on this platform: %v", err)
+	}
+
+	// Directory at a managed plugin path.
+	dirPath := filepath.Join(pluginsDir, "model-variants.ts")
+	if err := os.MkdirAll(dirPath, 0o755); err != nil {
+		t.Fatalf("MkdirAll(dir plugin path) error = %v", err)
+	}
+
+	// Stale regular file — the only one that must be refreshed.
+	regularPath := filepath.Join(pluginsDir, "skill-registry.ts")
+	if err := os.WriteFile(regularPath, []byte("// stale"), 0o644); err != nil {
+		t.Fatalf("WriteFile(regular plugin) error = %v", err)
+	}
+
+	result, err := RefreshInstalledOpenCodePlugins(home, opencodeAdapter())
+	if err != nil {
+		t.Fatalf("RefreshInstalledOpenCodePlugins() error = %v", err)
+	}
+
+	// Symlink stays a symlink and its target is untouched.
+	if info, lerr := os.Lstat(symlinkPath); lerr != nil || info.Mode()&os.ModeSymlink == 0 {
+		t.Errorf("symlink plugin path must remain a symlink; info = %v, err = %v", info, lerr)
+	}
+	if got, rerr := os.ReadFile(userFile); rerr != nil || !bytes.Equal(got, userContent) {
+		t.Errorf("symlink target was modified: content = %q, err = %v", got, rerr)
+	}
+
+	// Directory stays a directory.
+	if info, serr := os.Lstat(dirPath); serr != nil || !info.IsDir() {
+		t.Errorf("directory plugin path must remain a directory; info = %v, err = %v", info, serr)
+	}
+
+	// Regular stale file is refreshed byte-equal to the embedded asset.
+	got, rerr := os.ReadFile(regularPath)
+	if rerr != nil {
+		t.Fatalf("ReadFile(regular plugin) error = %v", rerr)
+	}
+	if string(got) != assets.MustRead("opencode/plugins/skill-registry.ts") {
+		t.Errorf("regular stale plugin was not refreshed to the embedded asset")
+	}
+	if !result.Changed {
+		t.Errorf("result.Changed = false, want true (regular plugin refreshed)")
+	}
+	for _, file := range result.Files {
+		if file == symlinkPath || file == dirPath {
+			t.Errorf("result.Files must not report skipped path %q; files = %v", file, result.Files)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #1440

## Problem

`gentle-ai sync` restores the persisted component selection wholesale; when `sdd` is absent from `state.json`, no step ever rewrites the managed OpenCode review plugin. Users in that state never received the v2.1.8 plugin (capture preflight, `GENTLE_AI_REVIEW_CWD`, incident preservation from #1434) — sync reported success while the plugin stayed stale. The plugin was also missing from install-time backup and verification coverage. The review confirmed Kilocode shares the same install path and the same gap.

## Fix

Managed plugins are versioned runtime artifacts, refreshed by sync independently of the SDD component:

- `ManagedOpenCodePluginNames()` is the single source of truth (model-variants, review-result-artifacts, skill-registry), and the new `AgentReceivesManagedOpenCodePlugins` predicate (OpenCode + Kilocode) drives both the inject gate and all three sync-side filters so they cannot drift.
- `RefreshInstalledOpenCodePlugins` is Lstat-gated: missing or non-regular files (symlinks, directories) are skipped — sync never installs plugins where they never existed and never follows a symlink onto user files; existing regular files are rewritten atomically, byte-equal being a no-op.
- The refresh step plans only when a plugin-receiving agent is synced and the selection lacks `sdd` (whose inject step already rewrites plugins). No silent mutation of persisted state.
- All plugin paths for both agents enter the sync backup snapshot (missing files tolerated for correct rollback), and `review-result-artifacts.ts` joins `openCodeSDDPluginPaths` for install/verify coverage.

## Review

Native bounded review, two rounds (medium risk, reliability lens). Round-1 findings fixed and re-verified: Kilocode coverage (failing-first reproduction of the identical stale-plugin signature under `.config/kilo`) and the Lstat safety property pinned by test. Remaining SUGGESTION (a pre-existing literal agent check in install-time `componentPaths`) routed as follow-up. All gates allow.

## Tests

Failing-first: sync left the installed plugin stale and unreported for both OpenCode and Kilocode. Now pinned: refresh byte-equal to the embedded asset with accurate ChangedFiles, never-installed guard, symlink/directory skip, backup-target inclusion for both agents, component-path coverage. Full cli + components suites pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Existing managed OpenCode and Kilocode plugins are now refreshed during sync, even when the SDD component is not selected.
  * Plugins that were never installed are not created unexpectedly.
  * User-managed symlinks and directories are preserved during plugin refreshes.
  * Managed plugin files are included in sync backups and snapshots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->