### PR TITLE
fix(review): bind frozen findings ledger in compact gate contexts

### DIFF
--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -1457,7 +1457,7 @@ func discoverCompactFacadeGateReview(ctx context.Context, repo, lineage string, 
 					StoreRevision: record.Revision, GenesisRevision: record.Revision, ChainIdentity: record.Revision, BundleDigest: record.Revision,
 					BaseTree: assessment.Actual.BaseTree, CandidateTree: assessment.Actual.CandidateTree, PathsDigest: assessment.Actual.PathsDigest,
 					FixDeltaHash: record.State.FixDeltaHash, PolicyHash: record.State.PolicyHash,
-					LedgerHash: reviewtransaction.EmptyFixDeltaHash, EvidenceHash: record.State.EvidenceHash,
+					LedgerHash: record.State.LedgerHash(), EvidenceHash: record.State.EvidenceHash,
 					Denial: &reviewtransaction.GateDenial{Stage: "receipt-binding", Code: "candidate-or-paths-mismatch"}, ScopeChange: &diagnostics,
 				},
 			})

--- a/internal/cli/review_ledger_context_test.go
+++ b/internal/cli/review_ledger_context_test.go
@@ -1,0 +1,120 @@
+package cli
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/internal/reviewtransaction"
+)
+
+// approveTrackedGoChangeWithWarningFinding persists an approved compact
+// authority over a tracked Go modification whose completed review froze one
+// non-severe finding, so the frozen findings ledger is non-empty without
+// requiring a correction transaction.
+func approveTrackedGoChangeWithWarningFinding(t *testing.T, repo, lineage string) reviewtransaction.CompactState {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(repo, "feature.go"), []byte("package feature\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runReviewCLIGit(t, repo, "add", "feature.go")
+	runReviewCLIGit(t, repo, "commit", "-qm", "add feature base")
+	if err := os.WriteFile(filepath.Join(repo, "feature.go"), []byte("package feature\n\nfunc Feature() int { return 1 }\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err := (reviewtransaction.SnapshotBuilder{Repo: repo}).Build(context.Background(), reviewtransaction.Target{Kind: reviewtransaction.TargetCurrentChanges, IntendedUntracked: []string{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	risk, lines, err := (reviewtransaction.SnapshotBuilder{Repo: repo}).ClassifySnapshotRisk(context.Background(), snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if risk != reviewtransaction.RiskMedium {
+		t.Fatalf("tracked Go change risk = %q, want medium", risk)
+	}
+	lenses := []string{reviewtransaction.LensReliability}
+	state, err := reviewtransaction.NewCompactState(reviewtransaction.Start{
+		LineageID: lineage, Mode: reviewtransaction.ModeOrdinaryBounded, Generation: 1, Snapshot: snapshot,
+		PolicyHash: "sha256:" + hexDigest("policy"), RiskLevel: risk, SelectedLenses: lenses, OriginalChangedLines: &lines,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, lineage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	revision, err := store.Replace("", "review/start", state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	finding := reviewtransaction.Finding{
+		ID: "R3-001", Lens: "reliability", Location: "feature.go:3", Severity: "WARNING",
+		Claim: "return value lacks a covering assertion", ProofRefs: []string{"feature.go:3 has no differential test"},
+	}
+	results := []reviewtransaction.LensResult{{Lens: reviewtransaction.LensReliability, Findings: []reviewtransaction.Finding{finding}, Evidence: []string{"review completed"}}}
+	if err := state.CompleteReview(reviewtransaction.CompactReviewInput{LensResults: results, Classifications: []reviewtransaction.FindingEvidence{}, RefuterOutcomes: []reviewtransaction.EvidenceResult{}}); err != nil {
+		t.Fatal(err)
+	}
+	revision, err = store.Replace(revision, "review/complete-review", state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := state.CompleteVerification([]byte("independent verification passed\n"), true); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Replace(revision, "review/complete-verification", state); err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := state.Receipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := reviewtransaction.WriteCompactReceiptAtomic(store.ReceiptPath(), receipt); err != nil {
+		t.Fatal(err)
+	}
+	return state
+}
+
+func hexDigest(seed string) string {
+	sum := sha256.Sum256([]byte(seed))
+	return hex.EncodeToString(sum[:])
+}
+
+func canonicalLedgerHash(t *testing.T, findings []reviewtransaction.Finding) string {
+	t.Helper()
+	ledger, err := reviewtransaction.CanonicalLedger(findings)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sum := sha256.Sum256(ledger)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+func TestFacadeScopeChangedDiscoveryContextBindsFrozenFindingsLedger(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	state := approveTrackedGoChangeWithWarningFinding(t, repo, "facade-ledger-scope")
+	if len(state.Findings) == 0 {
+		t.Fatalf("fixture must freeze findings: %#v", state)
+	}
+	want := canonicalLedgerHash(t, state.Findings)
+	if want == reviewtransaction.EmptyFixDeltaHash {
+		t.Fatalf("frozen findings ledger collides with empty-input hash %q", want)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "feature.go"), []byte("package feature\n\nfunc Feature() int { return 2 }\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, _, err := discoverCompactFacadeGateReview(context.Background(), repo, "", reviewtransaction.NativeGateRequestInput{Gate: reviewtransaction.GatePostApply})
+	var discovery *ReviewReceiptDiscoveryError
+	if !errors.As(err, &discovery) || discovery.Kind != ReviewReceiptScopeChanged || discovery.Context == nil {
+		t.Fatalf("drifted target discovery = %#v, %v", discovery, err)
+	}
+	if discovery.Context.LedgerHash != want {
+		t.Fatalf("scope-changed discovery context ledger_hash = %q, want frozen findings ledger %q", discovery.Context.LedgerHash, want)
+	}
+}

--- a/internal/reviewtransaction/compact.go
+++ b/internal/reviewtransaction/compact.go
@@ -267,6 +267,30 @@ func (state CompactState) Validate() error {
 	return nil
 }
 
+// LedgerHash derives the canonical findings-ledger binding of the
+// authoritative compact record. Compact authority never persists a separate
+// ledger artifact: the frozen findings themselves are the ledger, validated by
+// Validate as the exact concatenation of the completed lens results. When at
+// least one finding was frozen, the binding is the SHA-256 of the canonical
+// gentle-ai.review-ledger/v1 bytes for exactly those findings, so auditors can
+// reconstruct and verify it from the persisted state. A pristine lineage — one
+// whose completed review froze no findings at all — has no ledger content to
+// bind and keeps the honest empty-input hash (SHA-256 of zero bytes); it never
+// fabricates a canonical empty-ledger artifact that was not persisted.
+func (state CompactState) LedgerHash() string {
+	if len(state.Findings) == 0 {
+		return EmptyFixDeltaHash
+	}
+	// CanonicalLedger only fails for a nil findings array, which the length
+	// guard above already excludes.
+	ledger, err := CanonicalLedger(state.Findings)
+	if err != nil {
+		return EmptyFixDeltaHash
+	}
+	sum := sha256.Sum256(ledger)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
 func validateCompactSnapshotMetadata(snapshot Snapshot) error {
 	paths, err := canonicalPaths(snapshot.Paths)
 	if err != nil || !equalStrings(paths, snapshot.Paths) || snapshot.PathsDigest != digestPaths(paths) {

--- a/internal/reviewtransaction/compact_chain.go
+++ b/internal/reviewtransaction/compact_chain.go
@@ -227,6 +227,16 @@ func deriveCompactPrePRChain(ctx context.Context, repo string, input NativeGateR
 		evidenceHashes[index] = member.receipt.EvidenceHash
 	}
 	boundary := refs.Selection
+	// LedgerHash deliberately stays the empty-input hash while its siblings
+	// are compactPrePRChainValuesHash compositions: (a) no per-member receipt
+	// binds a ledger (CompactReceipt carries no ledger field), so a
+	// synthesized chain digest would be a fabricated value nothing verifies;
+	// (b) the only LedgerHash consumer that compares persisted contexts —
+	// sddstatus boundGateContextMatches — evaluates GatePostApply only, never
+	// GatePrePR; and (c) another version-divergent context field would widen
+	// the mixed-binary compatibility surface. If a future change composes
+	// compactPrePRChainValuesHash("ledger", ...) here, it must also consider
+	// the sddstatus legacy empty-ledger compatibility shim.
 	gateContext := GateContext{
 		Gate: GatePrePR, LineageID: last.receipt.LineageID, Generation: last.receipt.Generation,
 		StoreRevision: last.record.Revision, GenesisRevision: path[0].record.Revision,

--- a/internal/reviewtransaction/compact_gate.go
+++ b/internal/reviewtransaction/compact_gate.go
@@ -174,11 +174,14 @@ func EvaluateCompactGate(ctx context.Context, repo string, receipt CompactReceip
 	if err != nil || !compactReceiptEqual(authoritative, receipt) {
 		return invalid("compact receipt does not match current authority")
 	}
+	// The findings are immutable once loaded; derive their ledger binding once
+	// so every context emitted below is consistent by construction.
+	ledgerHash := record.State.LedgerHash()
 	denialContext := GateContext{
 		Gate: input.Gate, LineageID: receipt.LineageID, Generation: receipt.Generation,
 		StoreRevision: record.Revision, GenesisRevision: record.Revision, ChainIdentity: record.Revision, BundleDigest: record.Revision,
 		BaseTree: receipt.BaseTree, CandidateTree: receipt.FinalCandidateTree, PathsDigest: receipt.PathsDigest,
-		FixDeltaHash: receipt.FixDeltaHash, PolicyHash: receipt.PolicyHash, LedgerHash: EmptyFixDeltaHash, EvidenceHash: receipt.EvidenceHash,
+		FixDeltaHash: receipt.FixDeltaHash, PolicyHash: receipt.PolicyHash, LedgerHash: ledgerHash, EvidenceHash: receipt.EvidenceHash,
 	}
 	if input.Gate == GatePrePR && strings.TrimSpace(input.BaseRef) != "" {
 		denialContext.PrePRBoundary = &PrePRBoundarySelection{Source: PrePRBoundaryExplicit, Selector: strings.TrimSpace(input.BaseRef)}
@@ -275,7 +278,7 @@ func EvaluateCompactGate(ctx context.Context, repo string, receipt CompactReceip
 		StoreRevision: record.Revision, GenesisRevision: record.Revision, ChainIdentity: record.Revision, BundleDigest: record.Revision,
 		BaseTree: snapshot.BaseTree, CandidateTree: snapshot.CandidateTree, PathsDigest: snapshot.PathsDigest,
 		FixDeltaHash: record.State.FixDeltaHash, PolicyHash: record.State.PolicyHash,
-		LedgerHash: EmptyFixDeltaHash, EvidenceHash: record.State.EvidenceHash,
+		LedgerHash: ledgerHash, EvidenceHash: record.State.EvidenceHash,
 		BaseRelationshipValid: baseRelationshipValid, BaseAdvance: compatibility,
 	}
 	if request.Gate == GatePrePR && resolvedPrePR != nil {

--- a/internal/reviewtransaction/compact_ledger_binding_test.go
+++ b/internal/reviewtransaction/compact_ledger_binding_test.go
@@ -1,0 +1,105 @@
+package reviewtransaction
+
+import (
+	"context"
+	"testing"
+)
+
+// frozenCompactLedgerHash derives the canonical review-ledger hash for the
+// exact findings frozen by the authoritative compact state, independently of
+// the production code under test.
+func frozenCompactLedgerHash(t *testing.T, findings []Finding) string {
+	t.Helper()
+	ledger, err := CanonicalLedger(findings)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ledgerHash, _, err := validateCanonicalLedger(ledger, findings, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return ledgerHash
+}
+
+func TestCompactStateLedgerHashDistinguishesPristineFromFrozenFindings(t *testing.T) {
+	pristine := CompactState{Findings: []Finding{}}
+	if got := pristine.LedgerHash(); got != EmptyFixDeltaHash {
+		t.Fatalf("pristine ledger hash = %q, want honest empty hash %q", got, EmptyFixDeltaHash)
+	}
+	if got := (CompactState{}).LedgerHash(); got != EmptyFixDeltaHash {
+		t.Fatalf("nil-findings ledger hash = %q, want honest empty hash %q", got, EmptyFixDeltaHash)
+	}
+	findings := []Finding{{ID: "R3-001", Lens: "reliability", Location: "tracked.txt:1", Severity: "CRITICAL", Claim: "wrong value", ProofRefs: []string{"candidate-only failure"}}}
+	frozen := CompactState{Findings: findings}
+	if got, want := frozen.LedgerHash(), frozenCompactLedgerHash(t, findings); got != want || got == EmptyFixDeltaHash {
+		t.Fatalf("frozen ledger hash = %q, want canonical ledger hash %q", got, want)
+	}
+}
+
+func TestCompactAllowGateContextBindsFrozenFindingsLedger(t *testing.T) {
+	repo, state, receipt, _ := approvedCompactFixDiffFixture(t, "compact-ledger-allow")
+	if len(state.Findings) == 0 || len(state.FixFindingIDs) == 0 {
+		t.Fatalf("fixture must freeze severe findings with a completed correction: %#v", state)
+	}
+	want := frozenCompactLedgerHash(t, state.Findings)
+	if want == EmptyFixDeltaHash {
+		t.Fatalf("canonical ledger hash of frozen findings collides with the empty-input hash %q", want)
+	}
+	gitSnapshot(t, repo, "add", "other.txt")
+	got := EvaluateCompactGate(context.Background(), repo, receipt, NativeGateRequestInput{Gate: GatePreCommit, LineageID: state.LineageID})
+	if got.Result != GateAllow {
+		t.Fatalf("exact corrected pre-commit gate = %#v", got)
+	}
+	if got.Context.LedgerHash != want {
+		t.Fatalf("allow gate context ledger_hash = %q, want frozen findings ledger %q", got.Context.LedgerHash, want)
+	}
+}
+
+func TestCompactDenialGateContextBindsFrozenFindingsLedger(t *testing.T) {
+	repo, state, receipt, _ := approvedCompactFixDiffFixture(t, "compact-ledger-denial")
+	want := frozenCompactLedgerHash(t, state.Findings)
+	got := EvaluateCompactGate(context.Background(), repo, receipt, NativeGateRequestInput{Gate: GatePrePR, LineageID: state.LineageID, BaseRef: "missing-reviewed-base"})
+	if got.Result != GateInvalidated || got.Context.Denial == nil || got.Context.Denial.Stage != "boundary-selection" {
+		t.Fatalf("unavailable pre-PR boundary denial = %#v", got)
+	}
+	if got.Context.LedgerHash != want {
+		t.Fatalf("denial gate context ledger_hash = %q, want frozen findings ledger %q", got.Context.LedgerHash, want)
+	}
+}
+
+func TestCompactScopeChangedGateContextBindsFrozenFindingsLedger(t *testing.T) {
+	repo, state, receipt, _ := approvedCompactFixDiffFixture(t, "compact-ledger-scope")
+	want := frozenCompactLedgerHash(t, state.Findings)
+	gitSnapshot(t, repo, "add", "other.txt")
+	writeSnapshotFile(t, repo, "extra.go", "package extra\n")
+	gitSnapshot(t, repo, "add", "extra.go")
+	got := EvaluateCompactGate(context.Background(), repo, receipt, NativeGateRequestInput{Gate: GatePreCommit, LineageID: state.LineageID})
+	if got.Result != GateScopeChanged || got.Context.Denial == nil {
+		t.Fatalf("scope-changed pre-commit gate = %#v", got)
+	}
+	if got.Context.LedgerHash != want {
+		t.Fatalf("scope-changed gate context ledger_hash = %q, want frozen findings ledger %q", got.Context.LedgerHash, want)
+	}
+}
+
+func TestCompactPristineGateContextKeepsHonestEmptyLedgerHash(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	writeSnapshotFile(t, repo, "tracked.txt", "candidate\n")
+	gitSnapshot(t, repo, "add", "tracked.txt")
+	gitSnapshot(t, repo, "commit", "-m", "candidate")
+	state, _, receipt := approvedCompactRevisionFixture(t, repo, "compact-ledger-pristine")
+	if len(state.Findings) != 0 {
+		t.Fatalf("pristine fixture froze findings: %#v", state.Findings)
+	}
+	base := trimGit(gitSnapshot(t, repo, "rev-parse", "HEAD^"))
+	branch := currentBranch(context.Background(), repo)
+	remote := configurePublicationRemote(t, repo, branch)
+	gitSnapshot(t, repo, "--git-dir", remote, "branch", "reviewed-base", base)
+	got := EvaluateCompactGate(context.Background(), repo, receipt, NativeGateRequestInput{Gate: GatePrePR, LineageID: state.LineageID, BaseRef: "origin/reviewed-base"})
+	if got.Result != GateAllow {
+		t.Fatalf("pristine pre-PR gate = %#v", got)
+	}
+	if got.Context.LedgerHash != EmptyFixDeltaHash {
+		t.Fatalf("pristine gate context ledger_hash = %q, want honest empty hash %q", got.Context.LedgerHash, EmptyFixDeltaHash)
+	}
+}

--- a/internal/sddstatus/review_binding.go
+++ b/internal/sddstatus/review_binding.go
@@ -149,7 +149,7 @@ func validateBoundReview(ctx context.Context, repo, change string) (ReviewBindin
 		return ReviewBinding{}, reviewtransaction.NativeGateEvaluation{}, err
 	}
 	evaluation := reviewtransaction.EvaluateCompactGate(ctx, root, receipt, reviewtransaction.NativeGateRequestInput{Gate: reviewtransaction.GatePostApply, LineageID: binding.Lineage})
-	if evaluation.Result != reviewtransaction.GateAllow || !reflect.DeepEqual(evaluation.Context, binding.GateContext) {
+	if evaluation.Result != reviewtransaction.GateAllow || !boundGateContextMatches(binding.GateContext, evaluation.Context) {
 		return ReviewBinding{}, reviewtransaction.NativeGateEvaluation{}, errors.New("bound compact post-apply gate context changed")
 	}
 	bindingFinalAuthorizationHook()
@@ -166,10 +166,33 @@ func validateBoundReview(ctx context.Context, repo, change string) (ReviewBindin
 		return ReviewBinding{}, reviewtransaction.NativeGateEvaluation{}, errors.New("bound compact receipt does not match final authority")
 	}
 	finalGate := reviewtransaction.EvaluateCompactGate(ctx, root, finalReceiptValue, reviewtransaction.NativeGateRequestInput{Gate: reviewtransaction.GatePostApply, LineageID: binding.Lineage})
-	if finalGate.Result != reviewtransaction.GateAllow || !reflect.DeepEqual(finalGate.Context, binding.GateContext) {
+	if finalGate.Result != reviewtransaction.GateAllow || !boundGateContextMatches(binding.GateContext, finalGate.Context) {
 		return ReviewBinding{}, reviewtransaction.NativeGateEvaluation{}, errors.New("bound compact post-apply gate changed during final authorization")
 	}
 	return binding, finalGate, nil
+}
+
+// boundGateContextMatches compares a persisted binding gate context against
+// the live post-apply evaluation. Bindings persisted before compact gate
+// contexts bound the frozen findings ledger recorded the empty-input hash in
+// ledger_hash; they stay valid against a now-populated live context because
+// the findings ledger itself is still pinned by the authority state through
+// AuthorityRevision and ReceiptHash. Every other divergence — including any
+// non-empty ledger hash that does not match the live binding — still fails.
+// The reverse mix is a known residual this side cannot repair: a binding
+// written by a ledger-binding binary but validated by an older binary
+// deterministically fails closed here ("bound compact post-apply gate context
+// changed"), because the older binary hardcodes the empty hash in its live
+// context; the remedy is upgrading that older binary.
+func boundGateContextMatches(bound, live reviewtransaction.GateContext) bool {
+	if reflect.DeepEqual(bound, live) {
+		return true
+	}
+	if bound.LedgerHash != reviewtransaction.EmptyFixDeltaHash {
+		return false
+	}
+	bound.LedgerHash = live.LedgerHash
+	return reflect.DeepEqual(bound, live)
 }
 
 func bindingExists(ctx context.Context, repo, change string) (bool, error) {

--- a/internal/sddstatus/review_binding_ledger_test.go
+++ b/internal/sddstatus/review_binding_ledger_test.go
@@ -1,0 +1,148 @@
+package sddstatus
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/internal/reviewtransaction"
+)
+
+// writeApprovedCompactAuthorityWithWarningFinding persists an approved compact
+// authority whose completed review froze one non-severe finding, so the frozen
+// findings ledger is non-empty without a correction transaction.
+func writeApprovedCompactAuthorityWithWarningFinding(t *testing.T, repo, changeRoot, lineage string) reviewtransaction.CompactState {
+	t.Helper()
+	write(t, filepath.Join(repo, "feature.go"), "package feature\n")
+	runSDDStatusGit(t, repo, "init", "-q")
+	runSDDStatusGit(t, repo, "config", "user.email", "status@example.com")
+	runSDDStatusGit(t, repo, "config", "user.name", "Status Test")
+	runSDDStatusGit(t, repo, "add", ".")
+	runSDDStatusGit(t, repo, "commit", "-qm", "base")
+	write(t, filepath.Join(changeRoot, "tasks.md"), "- [x] 1.1 Done\n# approved compact scope\n")
+	write(t, filepath.Join(repo, "feature.go"), "package feature\n\nfunc Feature() int { return 1 }\n")
+	snapshot, err := (reviewtransaction.SnapshotBuilder{Repo: repo}).Build(context.Background(), reviewtransaction.Target{Kind: reviewtransaction.TargetCurrentChanges, IntendedUntracked: []string{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	risk, lines, err := (reviewtransaction.SnapshotBuilder{Repo: repo}).ClassifySnapshotRisk(context.Background(), snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if risk != reviewtransaction.RiskMedium {
+		t.Fatalf("tracked Go change risk = %q, want medium", risk)
+	}
+	state, err := reviewtransaction.NewCompactState(reviewtransaction.Start{
+		LineageID: lineage, Mode: reviewtransaction.ModeOrdinaryBounded, Generation: 1, Snapshot: snapshot,
+		PolicyHash: shaID("c"), RiskLevel: risk, SelectedLenses: []string{reviewtransaction.LensReliability}, OriginalChangedLines: &lines,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, lineage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	revision, err := store.Replace("", "review/start", state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	finding := reviewtransaction.Finding{
+		ID: "R3-001", Lens: "reliability", Location: "feature.go:3", Severity: "WARNING",
+		Claim: "return value lacks a covering assertion", ProofRefs: []string{"feature.go:3 has no differential test"},
+	}
+	results := []reviewtransaction.LensResult{{Lens: reviewtransaction.LensReliability, Findings: []reviewtransaction.Finding{finding}, Evidence: []string{"review completed"}}}
+	if err := state.CompleteReview(reviewtransaction.CompactReviewInput{LensResults: results, Classifications: []reviewtransaction.FindingEvidence{}, RefuterOutcomes: []reviewtransaction.EvidenceResult{}}); err != nil {
+		t.Fatal(err)
+	}
+	revision, err = store.Replace(revision, "review/complete-review", state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := state.CompleteVerification([]byte("verification passed\n"), true); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Replace(revision, "review/complete-verification", state); err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := state.Receipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := reviewtransaction.WriteCompactReceiptAtomic(store.ReceiptPath(), receipt); err != nil {
+		t.Fatal(err)
+	}
+	return state
+}
+
+func canonicalBindingLedgerHash(t *testing.T, findings []reviewtransaction.Finding) string {
+	t.Helper()
+	ledger, err := reviewtransaction.CanonicalLedger(findings)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sum := sha256.Sum256(ledger)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+func TestBoundReviewBindsLedgerAcceptsLegacyEmptyAndRejectsForgedHash(t *testing.T) {
+	root := t.TempDir()
+	changeRoot := seedReadyChange(t, root, "thin", "- [x] 1.1 Done\n")
+	state := writeApprovedCompactAuthorityWithWarningFinding(t, root, changeRoot, "approved-ledger")
+	want := canonicalBindingLedgerHash(t, state.Findings)
+	if want == reviewtransaction.EmptyFixDeltaHash {
+		t.Fatalf("frozen findings ledger collides with empty-input hash %q", want)
+	}
+
+	binding, err := BindApprovedReview(context.Background(), root, "thin", "approved-ledger", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if binding.GateContext.LedgerHash != want {
+		t.Fatalf("fresh binding ledger_hash = %q, want frozen findings ledger %q", binding.GateContext.LedgerHash, want)
+	}
+	if _, _, err := validateBoundReview(context.Background(), root, "thin"); err != nil {
+		t.Fatalf("fresh binding validation: %v", err)
+	}
+
+	store, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), root, "approved-ledger")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// A binding persisted before gate contexts bound the frozen findings
+	// ledger recorded the empty-input hash; it must keep validating against
+	// the now-populated live context.
+	legacy := binding
+	legacy.GateContext.LedgerHash = reviewtransaction.EmptyFixDeltaHash
+	legacy.Revision = bindingDigest(legacy)
+	payload, err := bindingBytes(legacy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(bindingPath(store, "thin"), payload, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := validateBoundReview(context.Background(), root, "thin"); err != nil {
+		t.Fatalf("legacy empty-ledger binding rejected: %v", err)
+	}
+
+	// Any other ledger hash is a real divergence and must stay rejected.
+	forged := binding
+	forged.GateContext.LedgerHash = "sha256:" + strings.Repeat("ab", 32)
+	forged.Revision = bindingDigest(forged)
+	payload, err = bindingBytes(forged)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(bindingPath(store, "thin"), payload, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := validateBoundReview(context.Background(), root, "thin"); err == nil {
+		t.Fatal("forged ledger hash binding was accepted")
+	}
+}


### PR DESCRIPTION
Fixes #1323

## Problem

Compact gate contexts always emitted `ledger_hash: sha256:e3b0c442...` (the empty-input hash) regardless of persisted findings — a lineage with frozen CRITICAL findings and a completed correction reported an empty findings ledger at every gate, breaking downstream consumers auditing the ledger binding.

## Fix

- New `CompactState.LedgerHash()`: frozen findings derive the SHA-256 of the canonical `gentle-ai.review-ledger/v1` bytes — byte-identical to the derivation the v1 `FreezeFindings` machinery binds; a pristine lineage keeps the honest empty-input hash (no fabricated canonical-empty-ledger artifact). Computed once per gate evaluation and threaded to both contexts, consistency by construction.
- All three emission sites bind it: the allow-path context, the denial context, and the facade's scope-changed discovery context.
- Receipt authority is untouched: `CompactReceipt` carries no ledger field, so no receipt comparison changes.
- SDD binding compatibility: `boundGateContextMatches` accepts legacy bindings that recorded the empty hash — the findings stay pinned transitively via `AuthorityRevision` (a full-state content hash covering `Findings`) and `ReceiptHash` — while any other mismatched hash stays rejected. The irreparable reverse direction (new binding validated by an older binary) deterministically fails closed and is documented at the shim.
- The composed pre-PR chain context deliberately keeps the empty sentinel (no per-member receipt binds a ledger; the only consumer evaluates post-apply only) — now documented in place with a maintenance trip-wire.

## Review

Native bounded review, two rounds (high risk, 4R). Round 2: zero findings across all four lenses — risk independently verified the transitive findings pinning and the absence of content leaks; reliability traced value-identity of the cached hash across every terminal path. All gates allow.

## Tests

Failing-first: all three emission sites reproduced the exact empty hash from the issue against a frozen-CRITICAL + completed-correction fixture. Now pinned: real binding at all three sites, pristine honesty, legacy-empty acceptance, forged-hash rejection. Full reviewtransaction + sddstatus + cli suites pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Review status checks now accurately track the findings ledger associated with a change.
  - Scope-change and approval decisions consistently reflect the latest frozen findings.
  - Invalid or tampered ledger information is rejected during review validation.
  - Existing reviews using legacy empty ledger information remain compatible.

- **Reliability**
  - Improved consistency of review decisions across approval, denial, and scope-change scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->