### PR TITLE
feat(review): add audited pristine-lineage abandonment

### DIFF
--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -338,7 +338,7 @@ func TestRunArgsDispatchesCompactReviewFacadeBeforePlatformValidation(t *testing
 	if err := RunArgs([]string{"review", "--help"}, &output); err != nil {
 		t.Fatalf("RunArgs(review --help) error = %v", err)
 	}
-	if !strings.Contains(output.String(), "review <capabilities|start|finalize|validate|status|invalidate|recover|reclaim|reconcile-authority|schema|bind-sdd>") {
+	if !strings.Contains(output.String(), "review <capabilities|start|finalize|validate|status|invalidate|abandon|recover|reclaim|reconcile-authority|schema|bind-sdd>") {
 		t.Fatalf("compact review help missing:\n%s", output.String())
 	}
 }

--- a/internal/cli/review_abandon.go
+++ b/internal/cli/review_abandon.go
@@ -1,0 +1,57 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/gentleman-programming/gentle-ai/internal/reviewtransaction"
+)
+
+type ReviewAbandonResult struct {
+	Operation string                                 `json:"operation"`
+	Record    reviewtransaction.CompactReclaimRecord `json:"record"`
+}
+
+func RunReviewAbandon(args []string, stdout io.Writer) error {
+	flags := newReviewFlagSet("review abandon", stdout, "Quarantine one pristine compact-v2 review lineage — a reviewing authority that never captured lens results or a pristine invalidated authority — with a persisted audit record carrying the natively re-derived pristineness proof. Pristineness is proven from persisted bytes and store topology, never the live worktree, so stale lineages remain abandonable. Terminal, corrected, artifact-holding, and superseded lineages are refused; an exact replay of a committed abandonment converges idempotently. On partial failure the prepared audit record JSON is still emitted to stdout and the command exits non-zero.")
+	cwd := flags.String("cwd", ".", "repository path")
+	lineage := flags.String("lineage", "", "pristine compact store lineage to abandon")
+	expected := flags.String("expected-revision", "", "exact current authority revision")
+	reason := flags.String("reason", "", "non-empty abandonment reason")
+	actor := flags.String("actor", "", "abandonment actor")
+	authorization := flags.String("maintainer-authorization", "", "exact six-line LF-only binding: gentle-ai.review-abandon-authorization/v1, lineage, revision, snapshot_identity, actor, reason")
+	if err := parseReviewFlags(flags, args); err != nil {
+		return err
+	}
+	if reviewHelpRequested(args) {
+		return nil
+	}
+	if flags.NArg() != 0 {
+		return fmt.Errorf("unexpected review abandon argument %q", flags.Arg(0))
+	}
+	for _, required := range []string{*lineage, *expected, *reason, *actor, *authorization} {
+		if strings.TrimSpace(required) == "" {
+			return errors.New("review abandon requires --lineage, --expected-revision, --reason, --actor, and --maintainer-authorization")
+		}
+	}
+	root, err := (reviewtransaction.SnapshotBuilder{Repo: *cwd}).ResolveRepositoryRoot(context.Background())
+	if err != nil {
+		return fmt.Errorf("resolve review repository root: %w", err)
+	}
+	record, err := reviewtransaction.AbandonPristineCompactStore(context.Background(), root, reviewtransaction.CompactAbandonRequest{
+		LineageID: *lineage, ExpectedRevision: *expected,
+		Reason: *reason, Actor: *actor, MaintainerAuthorization: *authorization,
+	})
+	if err != nil {
+		// A partial abandonment persisted the prepared audit record and may have
+		// moved the entry; surface the quarantine location for reconciliation.
+		if record.QuarantinePath != "" {
+			_ = encodeReviewJSON(stdout, ReviewAbandonResult{Operation: "review/abandon", Record: record})
+		}
+		return err
+	}
+	return encodeReviewJSON(stdout, ReviewAbandonResult{Operation: "review/abandon", Record: record})
+}

--- a/internal/cli/review_abandon_test.go
+++ b/internal/cli/review_abandon_test.go
@@ -1,0 +1,211 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/internal/reviewtransaction"
+)
+
+// pristineInvalidatedCLIFixture persists one pristine invalidated docs-only
+// compact lineage directly into the v2 store, then restores the clean
+// workspace so the lineage is also stale relative to the live worktree.
+func pristineInvalidatedCLIFixture(t *testing.T, repo string) (revision, snapshotIdentity string) {
+	t.Helper()
+	accidental := filepath.Join(repo, "docs", "accidental.md")
+	if err := os.MkdirAll(filepath.Dir(accidental), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(accidental, []byte("accidental\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	builder := reviewtransaction.SnapshotBuilder{Repo: repo}
+	snapshot, err := builder.Build(context.Background(), reviewtransaction.Target{
+		Kind: reviewtransaction.TargetCurrentChanges, IntendedUntracked: []string{"docs/accidental.md"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	risk, lines, err := builder.ClassifySnapshotRisk(context.Background(), snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	state, err := reviewtransaction.NewCompactState(reviewtransaction.Start{
+		LineageID: "abandon-accidental", Mode: reviewtransaction.ModeOrdinaryBounded, Generation: 1,
+		Snapshot: snapshot, PolicyHash: "sha256:" + strings.Repeat("ab", 32), RiskLevel: risk,
+		SelectedLenses: []string{}, OriginalChangedLines: &lines,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := state.Invalidate("accidental empty lineage"); err != nil {
+		t.Fatal(err)
+	}
+	revision = writeReconcileCLIRecord(t, repo, state)
+	if err := os.Remove(accidental); err != nil {
+		t.Fatal(err)
+	}
+	return revision, state.InitialSnapshot.Identity
+}
+
+// TestPristineInvalidatedLineagePoisonsLineagelessGateDiscovery reproduces
+// the #1441 discovery half on the CLI surface: one pristine invalidated
+// compact entry denies lineage-less gate validation for an unrelated approved
+// lineage whose receipt exactly matches the live target.
+func TestPristineInvalidatedLineagePoisonsLineagelessGateDiscovery(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	approveDiscoveryMarkdown(t, repo, "review-abandon-valid", "docs/valid.md", "valid\n")
+	pristineInvalidatedCLIFixture(t, repo)
+
+	var statusOutput bytes.Buffer
+	if err := RunReview([]string{"status", "--cwd", repo}, &statusOutput); err != nil {
+		t.Fatalf("review status over poisoned inventory: %v", err)
+	}
+	var report reviewtransaction.AuthorityStatusReport
+	decodeStrictReviewJSON(t, statusOutput.Bytes(), &report)
+	if report.Complete || report.Authoritative {
+		t.Fatalf("poisoned status = complete %v authoritative %v", report.Complete, report.Authoritative)
+	}
+
+	var blockedOutput bytes.Buffer
+	err := RunReview([]string{
+		"validate", "--contract", ReviewIntegrationContractV1, "--cwd", repo,
+		"--gate", string(reviewtransaction.GatePostApply),
+	}, &blockedOutput)
+	if err == nil {
+		t.Fatal("pristine invalidated entry did not deny lineage-less gate validation")
+	}
+	failure := decodeReviewIntegrationFailure(t, blockedOutput.Bytes())
+	if failure.Code != "authority_corrupted" {
+		t.Fatalf("poisoned gate failure = %#v", failure)
+	}
+}
+
+func abandonCLIArgs(repo, revision, authorization string) []string {
+	return []string{
+		"abandon", "--cwd", repo,
+		"--lineage", "abandon-accidental", "--expected-revision", revision,
+		"--reason", "retire accidental pristine lineage", "--actor", "maintainer@example.com",
+		"--maintainer-authorization", authorization,
+	}
+}
+
+func abandonCLIBinding(revision, snapshotIdentity string) string {
+	return "gentle-ai.review-abandon-authorization/v1\nlineage=abandon-accidental\nrevision=" + revision +
+		"\nsnapshot_identity=" + snapshotIdentity +
+		"\nactor=maintainer@example.com\nreason=retire accidental pristine lineage"
+}
+
+func TestReviewAbandonQuarantinesPristineLineageAndRestoresLifecycle(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	approveDiscoveryMarkdown(t, repo, "review-abandon-valid", "docs/valid.md", "valid\n")
+	revision, snapshotIdentity := pristineInvalidatedCLIFixture(t, repo)
+
+	var blockedOutput bytes.Buffer
+	err := RunReview([]string{
+		"validate", "--contract", ReviewIntegrationContractV1, "--cwd", repo,
+		"--gate", string(reviewtransaction.GatePostApply),
+	}, &blockedOutput)
+	if err == nil {
+		t.Fatal("pristine invalidated entry did not deny lineage-less gate validation")
+	}
+	if failure := decodeReviewIntegrationFailure(t, blockedOutput.Bytes()); failure.Code != "authority_corrupted" {
+		t.Fatalf("pre-abandon gate failure = %#v", failure)
+	}
+
+	var abandonOutput bytes.Buffer
+	if err := RunReview(abandonCLIArgs(repo, revision, abandonCLIBinding(revision, snapshotIdentity)), &abandonOutput); err != nil {
+		t.Fatalf("review abandon: %v\n%s", err, abandonOutput.String())
+	}
+	var result ReviewAbandonResult
+	decodeStrictReviewJSON(t, abandonOutput.Bytes(), &result)
+	if result.Operation != "review/abandon" || result.Record.LineageID != "abandon-accidental" ||
+		result.Record.Status != reviewtransaction.CompactReclaimCommitted ||
+		result.Record.PristineAbandonment == nil ||
+		result.Record.PristineAbandonment.State != reviewtransaction.StateInvalidated ||
+		result.Record.PristineAbandonment.InvalidationReason != "accidental empty lineage" ||
+		result.Record.PristineAbandonment.Revision != revision ||
+		result.Record.PristineAbandonment.SnapshotIdentity != snapshotIdentity {
+		t.Fatalf("review abandon result = %#v", result)
+	}
+	if _, err := os.Stat(filepath.Join(result.Record.QuarantinePath, "residue", "review-state.json")); err != nil {
+		t.Fatalf("quarantined pristine state missing: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(reviewCLIAuthorityRoot(t, repo), "v2", "abandon-accidental")); !os.IsNotExist(err) {
+		t.Fatalf("abandoned entry still present: %v", err)
+	}
+
+	var statusOutput bytes.Buffer
+	if err := RunReview([]string{"status", "--cwd", repo}, &statusOutput); err != nil {
+		t.Fatalf("review status after abandon: %v", err)
+	}
+	var after reviewtransaction.AuthorityStatusReport
+	decodeStrictReviewJSON(t, statusOutput.Bytes(), &after)
+	if !after.Complete || !after.Authoritative {
+		t.Fatalf("post-abandon status = complete %v authoritative %v", after.Complete, after.Authoritative)
+	}
+
+	var validateOutput bytes.Buffer
+	if err := RunReview([]string{
+		"validate", "--contract", ReviewIntegrationContractV1, "--cwd", repo,
+		"--gate", string(reviewtransaction.GatePostApply),
+	}, &validateOutput); err != nil {
+		t.Fatalf("post-abandon lineage-less validation: %v\n%s", err, validateOutput.String())
+	}
+	var validated ReviewValidateResult
+	decodeStrictReviewJSON(t, decodeReviewOperationEnvelope(t, validateOutput.Bytes()).Result, &validated)
+	if !validated.Allowed || validated.Context.LineageID != "review-abandon-valid" {
+		t.Fatalf("post-abandon validation = %#v", validated)
+	}
+
+	var replayOutput bytes.Buffer
+	if err := RunReview(abandonCLIArgs(repo, revision, abandonCLIBinding(revision, snapshotIdentity)), &replayOutput); err != nil {
+		t.Fatalf("idempotent review abandon replay: %v\n%s", err, replayOutput.String())
+	}
+	var replayed ReviewAbandonResult
+	decodeStrictReviewJSON(t, replayOutput.Bytes(), &replayed)
+	if replayed.Record.Status != reviewtransaction.CompactReclaimCommitted ||
+		replayed.Record.QuarantinePath != result.Record.QuarantinePath {
+		t.Fatalf("replayed review abandon result = %#v", replayed)
+	}
+}
+
+func TestReviewAbandonRequiresFlagsAndExactBinding(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	revision, snapshotIdentity := pristineInvalidatedCLIFixture(t, repo)
+	statePath := filepath.Join(reviewCLIAuthorityRoot(t, repo), "v2", "abandon-accidental", "review-state.json")
+	payload, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := RunReview([]string{
+		"abandon", "--cwd", repo, "--lineage", "abandon-accidental",
+	}, &bytes.Buffer{}); err == nil || !strings.Contains(err.Error(), "requires") {
+		t.Fatalf("incomplete abandon flags error = %v", err)
+	}
+
+	wrong := abandonCLIBinding(snapshotIdentity, revision)
+	if err := RunReview(abandonCLIArgs(repo, revision, wrong), &bytes.Buffer{}); err == nil ||
+		!strings.Contains(err.Error(), "exact maintainer authorization binding") {
+		t.Fatalf("inexact abandon binding error = %v", err)
+	}
+	current, err := os.ReadFile(statePath)
+	if err != nil || !bytes.Equal(current, payload) {
+		t.Fatalf("refused abandon mutated the entry: %v", err)
+	}
+}
+
+func TestReviewHelpListsAbandon(t *testing.T) {
+	var output bytes.Buffer
+	if err := RunReview([]string{"help"}, &output); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(output.String(), "abandon") {
+		t.Fatalf("review help does not list abandon: %s", output.String())
+	}
+}

--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -224,7 +224,7 @@ var reviewFacadeCommittedTransitionHook = func(context.Context, string, string, 
 
 func RunReview(args []string, stdout io.Writer) error {
 	if len(args) == 0 || args[0] == "help" || args[0] == "-h" || args[0] == "--help" {
-		_, _ = fmt.Fprintln(stdout, "Usage: gentle-ai review <capabilities|start|finalize|validate|status|invalidate|recover|reclaim|reconcile-authority|schema|bind-sdd> [flags]\n\nOrdinary review facade; repository scope, authority, canonical artifacts, and lifecycle transitions are derived by Go.")
+		_, _ = fmt.Fprintln(stdout, "Usage: gentle-ai review <capabilities|start|finalize|validate|status|invalidate|abandon|recover|reclaim|reconcile-authority|schema|bind-sdd> [flags]\n\nOrdinary review facade; repository scope, authority, canonical artifacts, and lifecycle transitions are derived by Go.")
 		_, _ = fmt.Fprintln(stdout, "Additive headless capabilities: gentle-ai review capture-result (with --preflight) and gentle-ai review preserve-result.")
 		return nil
 	}
@@ -307,6 +307,8 @@ func runReviewCommand(args []string, stdout io.Writer) error {
 		return RunReviewStatus(args[1:], stdout)
 	case "invalidate":
 		return RunReviewInvalidate(args[1:], stdout)
+	case "abandon":
+		return RunReviewAbandon(args[1:], stdout)
 	case "recover":
 		return RunReviewRecover(args[1:], stdout)
 	case "reclaim":

--- a/internal/reviewtransaction/compact_abandon.go
+++ b/internal/reviewtransaction/compact_abandon.go
@@ -1,0 +1,212 @@
+package reviewtransaction
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// compactAbandonAuthorizationSchema is the first line of the exact six-line
+// LF-only abandonment maintainer authorization binding; the remaining lines
+// are, in order: lineage, revision, snapshot_identity, actor, and reason.
+const compactAbandonAuthorizationSchema = "gentle-ai.review-abandon-authorization/v1"
+
+// CompactAbandonRequest identifies one pristine compact-v2 review lineage to
+// quarantine, together with the exact maintainer authorization binding for
+// that content.
+type CompactAbandonRequest struct {
+	LineageID               string
+	ExpectedRevision        string
+	Reason                  string
+	Actor                   string
+	MaintainerAuthorization string
+	AbandonedAt             time.Time
+}
+
+// CompactPristineAbandonmentProof records the natively re-derived pristineness
+// of one abandoned lineage inside the quarantine audit record. Pristineness is
+// a property of the persisted bytes and store topology only; the live worktree
+// is never rebuilt, so stale lineages remain abandonable.
+type CompactPristineAbandonmentProof struct {
+	LineageID          string `json:"lineage_id"`
+	Revision           string `json:"revision"`
+	SnapshotIdentity   string `json:"snapshot_identity"`
+	State              State  `json:"state"`                         // "reviewing" or "invalidated"
+	InvalidationReason string `json:"invalidation_reason,omitempty"` // when pre-invalidated
+}
+
+func compactAbandonAuthorizationBinding(lineage, revision, snapshotIdentity, actor, reason string) string {
+	return compactAbandonAuthorizationSchema + "\nlineage=" + lineage + "\nrevision=" + revision +
+		"\nsnapshot_identity=" + snapshotIdentity +
+		"\nactor=" + strings.TrimSpace(actor) + "\nreason=" + strings.TrimSpace(reason)
+}
+
+// AbandonPristineCompactStore quarantines one compact-v2 review lineage that
+// natively re-derives as pristine: a reviewing authority that never captured
+// lens results, findings, corrections, or evidence, or an invalidated
+// authority whose underlying reviewing projection is equally pristine. The
+// entry moves whole — never deleted — into the audited quarantine together
+// with the re-derived proof, so it leaves the walked inventory without
+// destroying history. Terminal, corrected, artifact-holding, superseded, and
+// stale-revision targets are refused, as is any move that would invalidate
+// the remaining authority graph. Pristineness is proven from persisted bytes
+// and store topology alone; the live worktree is never consulted. An exact
+// replay of a committed abandonment converges on the committed record.
+func AbandonPristineCompactStore(ctx context.Context, repo string, request CompactAbandonRequest) (CompactReclaimRecord, error) {
+	if err := ctx.Err(); err != nil {
+		return CompactReclaimRecord{}, err
+	}
+	if err := validateLineageID(request.LineageID); err != nil {
+		return CompactReclaimRecord{}, err
+	}
+	if strings.TrimSpace(request.Reason) == "" || strings.TrimSpace(request.Actor) == "" {
+		return CompactReclaimRecord{}, errors.New("review abandon requires a non-empty reason and actor")
+	}
+	if strings.TrimSpace(request.ExpectedRevision) == "" {
+		return CompactReclaimRecord{}, errors.New("review abandon requires the exact current store revision")
+	}
+	base, _, err := reviewAuthorityRoot(ctx, repo)
+	if err != nil {
+		return CompactReclaimRecord{}, err
+	}
+	versionRoot := filepath.Join(base, "v2")
+	dir := filepath.Join(versionRoot, request.LineageID)
+	lock, err := acquireStoreLock(filepath.Join(versionRoot, "LOCK"))
+	if err != nil {
+		return CompactReclaimRecord{}, err
+	}
+	defer lock.release()
+	store := CompactStore{Dir: dir, lineageID: request.LineageID}
+	record, err := store.Load()
+	if err != nil {
+		if os.IsNotExist(err) {
+			return replayCommittedCompactAbandonment(base, request)
+		}
+		return CompactReclaimRecord{}, fmt.Errorf("load abandon target: %w", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(base, "v1", request.LineageID)); statErr == nil {
+		return CompactReclaimRecord{}, fmt.Errorf("review abandon refused: lineage %q also exists in the legacy-v1 authority store; mixed-store collisions require explicit maintainer reconciliation", request.LineageID)
+	} else if !os.IsNotExist(statErr) {
+		return CompactReclaimRecord{}, fmt.Errorf("inspect same-lineage legacy authority: %w", statErr)
+	}
+	switch record.State.State {
+	case StateReviewing:
+		if !compactPristineReviewing(record.State) {
+			return CompactReclaimRecord{}, fmt.Errorf("review abandon refused: reviewing lineage %q is not pristine; it carries review or correction data", request.LineageID)
+		}
+	case StateInvalidated:
+		// compactPristineReviewing hard-requires State == StateReviewing and an
+		// empty InvalidationReason, so the invalidated record must be projected
+		// back onto its underlying reviewing authority before the pristineness
+		// re-derivation; resetting exactly those two fields is load-bearing. The
+		// paired non-empty-InvalidationReason check doubles as a structural
+		// corruption guard: a persisted invalidated state without a reason never
+		// came from Invalidate.
+		reviewing := record.State
+		reviewing.State, reviewing.InvalidationReason = StateReviewing, ""
+		if strings.TrimSpace(record.State.InvalidationReason) == "" || !compactPristineReviewing(reviewing) {
+			return CompactReclaimRecord{}, fmt.Errorf("review abandon refused: invalidated lineage %q does not project to a pristine reviewing authority", request.LineageID)
+		}
+	default:
+		return CompactReclaimRecord{}, fmt.Errorf("review abandon refused: lineage %q holds %q authority; only a pristine reviewing or pristine invalidated lineage may be abandoned", request.LineageID, record.State.State)
+	}
+	items, err := os.ReadDir(dir)
+	if err != nil {
+		return CompactReclaimRecord{}, fmt.Errorf("inspect abandon target: %w", err)
+	}
+	residue := make([]string, 0, len(items))
+	for _, item := range items {
+		if item.Name() != compactStateFileName && compactAuthoritativeArtifact(item.Name()) {
+			return CompactReclaimRecord{}, fmt.Errorf("review abandon refused: store entry %q holds authoritative artifact %q beyond its pristine state", request.LineageID, item.Name())
+		}
+		residue = append(residue, item.Name())
+	}
+	if record.Revision != request.ExpectedRevision {
+		return CompactReclaimRecord{}, fmt.Errorf("%w: expected compact revision %q, current %q", ErrConcurrentUpdate, request.ExpectedRevision, record.Revision)
+	}
+	if request.MaintainerAuthorization != compactAbandonAuthorizationBinding(request.LineageID, record.Revision, record.State.InitialSnapshot.Identity, request.Actor, request.Reason) {
+		return CompactReclaimRecord{}, fmt.Errorf("review abandon requires an exact maintainer authorization binding (schema %s over lineage %s@%s and snapshot %s)",
+			compactAbandonAuthorizationSchema, request.LineageID, record.Revision, record.State.InitialSnapshot.Identity)
+	}
+	stores, err := DiscoverCompactStores(ctx, repo)
+	if err != nil {
+		return CompactReclaimRecord{}, err
+	}
+	records := make(map[string]CompactRecord, len(stores))
+	storeByLineage := make(map[string]CompactStore, len(stores))
+	for _, related := range stores {
+		relatedRecord, loadErr := related.Load()
+		if loadErr != nil {
+			return CompactReclaimRecord{}, fmt.Errorf("review abandon refused: related compact authority %q does not load: %w", related.lineageID, loadErr)
+		}
+		records[relatedRecord.State.LineageID], storeByLineage[relatedRecord.State.LineageID] = relatedRecord, related
+	}
+	for lineage, related := range records {
+		if related.State.Recovery != nil && related.State.Recovery.PredecessorLineageID == request.LineageID {
+			return CompactReclaimRecord{}, fmt.Errorf("review abandon refused: lineage %q is superseded by recovery successor %q; superseded history is never abandoned", request.LineageID, lineage)
+		}
+	}
+	delete(records, request.LineageID)
+	delete(storeByLineage, request.LineageID)
+	if _, err := compactAuthorityLeaves(records, storeByLineage); err != nil {
+		return CompactReclaimRecord{}, fmt.Errorf("review abandon refused: remaining authority graph is invalid: %w", err)
+	}
+	sort.Strings(residue)
+	if request.AbandonedAt.IsZero() {
+		request.AbandonedAt = time.Now().UTC()
+	}
+	return quarantineCompactStoreEntry(base, dir, CompactReclaimRecord{
+		Schema: CompactReclaimRecordSchema, Status: CompactReclaimPrepared, LineageID: request.LineageID,
+		Reason: strings.TrimSpace(request.Reason), Actor: strings.TrimSpace(request.Actor),
+		ReclaimedAt: request.AbandonedAt.UTC(), SourcePath: dir, Residue: residue,
+		PristineAbandonment: &CompactPristineAbandonmentProof{
+			LineageID: request.LineageID, Revision: record.Revision,
+			SnapshotIdentity: record.State.InitialSnapshot.Identity,
+			State:            record.State.State, InvalidationReason: record.State.InvalidationReason,
+		},
+	})
+}
+
+// replayCommittedCompactAbandonment resolves an abandon request whose lineage
+// no longer holds a v2 entry: an exact replay of a committed abandonment
+// re-emits the committed record so repeated identical requests converge
+// without minting a second quarantine; anything else is refused.
+func replayCommittedCompactAbandonment(base string, request CompactAbandonRequest) (CompactReclaimRecord, error) {
+	quarantineRoot := filepath.Join(base, "quarantine")
+	entries, err := os.ReadDir(quarantineRoot)
+	if err != nil && !os.IsNotExist(err) {
+		return CompactReclaimRecord{}, fmt.Errorf("inspect quarantine for abandonment replay: %w", err)
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		payload, readErr := os.ReadFile(filepath.Join(quarantineRoot, entry.Name(), "reclaim-record.json"))
+		if readErr != nil {
+			continue
+		}
+		var record CompactReclaimRecord
+		if json.Unmarshal(payload, &record) != nil {
+			continue
+		}
+		proof := record.PristineAbandonment
+		if record.Status != CompactReclaimCommitted || proof == nil {
+			continue
+		}
+		if proof.LineageID != request.LineageID || proof.Revision != request.ExpectedRevision ||
+			record.Reason != strings.TrimSpace(request.Reason) || record.Actor != strings.TrimSpace(request.Actor) {
+			continue
+		}
+		if request.MaintainerAuthorization != compactAbandonAuthorizationBinding(proof.LineageID, proof.Revision, proof.SnapshotIdentity, request.Actor, request.Reason) {
+			continue
+		}
+		return record, nil
+	}
+	return CompactReclaimRecord{}, fmt.Errorf("review abandon refused: lineage %q holds no compact authority state and no committed abandonment record matches the request; if a prior abandonment was interrupted, the prepared reclaim-record.json under %s locates the moved residue for manual reconciliation", request.LineageID, quarantineRoot)
+}

--- a/internal/reviewtransaction/compact_abandon_test.go
+++ b/internal/reviewtransaction/compact_abandon_test.go
@@ -1,0 +1,594 @@
+package reviewtransaction
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// pristineReviewingFixture persists one pristine reviewing compact lineage
+// through the real store write path (repository evidence validated at start).
+func pristineReviewingFixture(t *testing.T, repo, lineage string) (CompactRecord, CompactStore) {
+	t.Helper()
+	state := newCompactTestState(t, repo, lineage)
+	store, err := CompactAuthoritativeStore(context.Background(), repo, lineage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Replace("", "review/start", state); err != nil {
+		t.Fatal(err)
+	}
+	record, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return record, store
+}
+
+// TestStalePristineReviewingLineageHasNoSanctionedExit reproduces the #1441
+// deadlock on the pre-abandon remedy surface: once HEAD advances past a
+// pristine reviewing lineage, review/invalidate refuses because the live
+// snapshot no longer matches, reclaim refuses because the entry holds
+// review-state.json, and reconcile-authority refuses because the entry is not
+// a recovery successor. The lineage is permanently unretirable.
+func TestStalePristineReviewingLineageHasNoSanctionedExit(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	writeSnapshotFile(t, repo, "tracked.txt", "base\naccidental change\n")
+	record, store := pristineReviewingFixture(t, repo, "abandon-stale-pristine")
+
+	// HEAD advances; the frozen current-changes snapshot goes stale.
+	gitSnapshot(t, repo, "add", "-A")
+	gitSnapshot(t, repo, "commit", "-m", "advance past the accidental lineage")
+
+	invalidated := record.State
+	if err := invalidated.Invalidate("obsolete accidental lineage"); err != nil {
+		t.Fatalf("in-memory invalidation: %v", err)
+	}
+	if _, err := store.Replace(record.Revision, "review/invalidate", invalidated); err == nil ||
+		!strings.Contains(err.Error(), "live repository snapshot no longer matches the reviewing authority") {
+		t.Fatalf("stale pristine invalidate error = %v", err)
+	}
+
+	if _, err := ReclaimIncompleteCompactStore(context.Background(), repo, CompactReclaimRequest{
+		LineageID: "abandon-stale-pristine", Reason: "retire accidental lineage", Actor: "maintainer@example.com",
+	}); err == nil || !strings.Contains(err.Error(), "holds authoritative artifact") {
+		t.Fatalf("reclaim refusal = %v", err)
+	}
+
+	if _, err := ReconcileInvalidRecoveryEdge(context.Background(), repo, CompactReconcileRequest{
+		PredecessorLineageID: "abandon-unrelated-predecessor", ExpectedPredecessorRevision: record.Revision,
+		SuccessorLineageID: "abandon-stale-pristine", ExpectedSuccessorRevision: record.Revision,
+		Reason: "retire accidental lineage", Actor: "maintainer@example.com",
+		MaintainerAuthorization: "irrelevant",
+	}); err == nil || !strings.Contains(err.Error(), "is not a recovery successor") {
+		t.Fatalf("reconcile-authority refusal = %v", err)
+	}
+}
+
+// TestPristineInvalidatedLineagePoisonsInventory reproduces the second #1441
+// deadlock: a successfully invalidated pristine lineage with no recovery
+// successor maps to AuthorityStatusInvalid, forcing Complete=false on the
+// whole inventory forever, with reclaim and reconcile both refusing to
+// retire it.
+func TestPristineInvalidatedLineagePoisonsInventory(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	writeSnapshotFile(t, repo, "tracked.txt", "base\naccidental change\n")
+	record, store := pristineReviewingFixture(t, repo, "abandon-pristine-invalidated")
+	invalidated := record.State
+	if err := invalidated.Invalidate("obsolete accidental lineage"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Replace(record.Revision, "review/invalidate", invalidated); err != nil {
+		t.Fatalf("live-matching invalidate: %v", err)
+	}
+
+	report, err := InventoryAuthority(context.Background(), repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.Complete || report.Authoritative ||
+		!hasAuthorityInventoryStatus(report.Entries, "abandon-pristine-invalidated", AuthorityStatusInvalid) {
+		t.Fatalf("invalidated lineage inventory = %#v", report)
+	}
+
+	if _, err := ReclaimIncompleteCompactStore(context.Background(), repo, CompactReclaimRequest{
+		LineageID: "abandon-pristine-invalidated", Reason: "retire invalidated lineage", Actor: "maintainer@example.com",
+	}); err == nil || !strings.Contains(err.Error(), "holds authoritative artifact") {
+		t.Fatalf("reclaim refusal = %v", err)
+	}
+}
+
+// approvedCompactFixture persists one terminal approved compact lineage with
+// its authoritative receipt.
+func approvedCompactFixture(t *testing.T, repo, lineage string) (CompactRecord, CompactStore) {
+	t.Helper()
+	state := correctedCompactTestState(t, repo, lineage)
+	store, err := CompactAuthoritativeStore(context.Background(), repo, lineage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	record := writeCompactFixtureRecord(t, store, state)
+	receipt, err := state.Receipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteCompactReceiptAtomic(store.ReceiptPath(), receipt); err != nil {
+		t.Fatal(err)
+	}
+	return record, store
+}
+
+func abandonFixtureRequest(record CompactRecord) CompactAbandonRequest {
+	request := CompactAbandonRequest{
+		LineageID: record.State.LineageID, ExpectedRevision: record.Revision,
+		Reason: "retire obsolete accidental lineage", Actor: "maintainer@example.com",
+	}
+	request.MaintainerAuthorization = compactAbandonAuthorizationBinding(
+		request.LineageID, record.Revision, record.State.InitialSnapshot.Identity, request.Actor, request.Reason)
+	return request
+}
+
+func TestAbandonStalePristineReviewingQuarantinesEntryAndRestoresInventory(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	approved, approvedStore := approvedCompactFixture(t, repo, "abandon-unrelated-approved")
+	writeSnapshotFile(t, repo, "tracked.txt", "base\naccidental change\n")
+	record, store := pristineReviewingFixture(t, repo, "abandon-stale-pristine")
+
+	// HEAD advances; abandonment must not require the live worktree to match.
+	gitSnapshot(t, repo, "add", "-A")
+	gitSnapshot(t, repo, "commit", "-m", "advance past the accidental lineage")
+
+	approvedStateBefore, err := os.ReadFile(approvedStore.StatePath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	approvedReceiptBefore, err := os.ReadFile(approvedStore.ReceiptPath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	pristinePayload, err := os.ReadFile(store.StatePath())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	request := abandonFixtureRequest(record)
+	committed, err := AbandonPristineCompactStore(context.Background(), repo, request)
+	if err != nil {
+		t.Fatalf("abandon stale pristine reviewing lineage: %v", err)
+	}
+	if committed.Schema != CompactReclaimRecordSchema || committed.Status != CompactReclaimCommitted ||
+		committed.LineageID != record.State.LineageID || committed.SourcePath != store.Dir ||
+		committed.Reason != request.Reason || committed.Actor != request.Actor || committed.ReclaimedAt.IsZero() {
+		t.Fatalf("abandonment record = %#v", committed)
+	}
+	if committed.PristineAbandonment == nil || committed.PristineAbandonment.LineageID != record.State.LineageID ||
+		committed.PristineAbandonment.Revision != record.Revision ||
+		committed.PristineAbandonment.SnapshotIdentity != record.State.InitialSnapshot.Identity ||
+		committed.PristineAbandonment.State != StateReviewing || committed.PristineAbandonment.InvalidationReason != "" {
+		t.Fatalf("abandonment proof = %#v", committed.PristineAbandonment)
+	}
+	if len(committed.Residue) != 1 || committed.Residue[0] != "review-state.json" {
+		t.Fatalf("abandonment residue manifest = %#v", committed.Residue)
+	}
+	root, _, err := reviewAuthorityRoot(context.Background(), repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(committed.QuarantinePath, filepath.Join(root, "quarantine")+string(os.PathSeparator)) {
+		t.Fatalf("quarantine path %q is outside the quarantine root", committed.QuarantinePath)
+	}
+	if _, statErr := os.Stat(store.Dir); !os.IsNotExist(statErr) {
+		t.Fatalf("abandoned entry still present: %v", statErr)
+	}
+	moved, err := os.ReadFile(filepath.Join(committed.QuarantinePath, "residue", "review-state.json"))
+	if err != nil || !bytes.Equal(moved, pristinePayload) {
+		t.Fatalf("quarantined pristine bytes = %q, %v", moved, err)
+	}
+	var persisted CompactReclaimRecord
+	persistedPayload, err := os.ReadFile(filepath.Join(committed.QuarantinePath, "reclaim-record.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(persistedPayload, &persisted); err != nil {
+		t.Fatal(err)
+	}
+	if persisted.Status != CompactReclaimCommitted || persisted.PristineAbandonment == nil ||
+		persisted.PristineAbandonment.Revision != record.Revision {
+		t.Fatalf("persisted abandonment record = %#v", persisted)
+	}
+	approvedStateAfter, _ := os.ReadFile(approvedStore.StatePath())
+	approvedReceiptAfter, _ := os.ReadFile(approvedStore.ReceiptPath())
+	if !bytes.Equal(approvedStateBefore, approvedStateAfter) || !bytes.Equal(approvedReceiptBefore, approvedReceiptAfter) {
+		t.Fatal("abandonment changed unrelated approved state or receipt bytes")
+	}
+
+	leaves, err := CompactAuthorityLeaves(context.Background(), repo)
+	if err != nil || len(leaves) != 1 || leaves[0].lineageID != approved.State.LineageID {
+		t.Fatalf("post-abandon leaves = %#v, %v", leaves, err)
+	}
+	report, err := InventoryAuthority(context.Background(), repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !report.Complete || !report.Authoritative {
+		t.Fatalf("post-abandon inventory = %#v", report)
+	}
+
+	// Exact replay converges on the committed record without a second quarantine.
+	replayed, err := AbandonPristineCompactStore(context.Background(), repo, request)
+	if err != nil {
+		t.Fatalf("idempotent abandonment replay: %v", err)
+	}
+	if replayed.Status != CompactReclaimCommitted || replayed.QuarantinePath != committed.QuarantinePath {
+		t.Fatalf("replayed abandonment record = %#v", replayed)
+	}
+	quarantined, err := os.ReadDir(filepath.Join(root, "quarantine"))
+	if err != nil || len(quarantined) != 1 {
+		t.Fatalf("replay minted quarantine directories = %#v, %v", quarantined, err)
+	}
+
+	// A differing request over the quarantined lineage is refused.
+	differing := request
+	differing.Reason = "different reason"
+	differing.MaintainerAuthorization = compactAbandonAuthorizationBinding(
+		differing.LineageID, record.Revision, record.State.InitialSnapshot.Identity, differing.Actor, differing.Reason)
+	if _, err := AbandonPristineCompactStore(context.Background(), repo, differing); err == nil ||
+		!strings.Contains(err.Error(), "no committed abandonment record matches") {
+		t.Fatalf("differing abandonment replay = %v", err)
+	}
+
+	writeSnapshotFile(t, repo, "tracked.txt", "base\nfresh work\n")
+	if _, err := StartCompactAuthority(context.Background(), repo, CompactStartRequest{State: newCompactTestState(t, repo, "abandon-fresh")}); err != nil {
+		t.Fatalf("post-abandon lineage-less start: %v", err)
+	}
+}
+
+func TestAbandonPristineInvalidatedRestoresInventory(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	approvedCompactFixture(t, repo, "abandon-unrelated-approved")
+	writeSnapshotFile(t, repo, "tracked.txt", "base\naccidental change\n")
+	record, store := pristineReviewingFixture(t, repo, "abandon-pristine-invalidated")
+	invalidated := record.State
+	if err := invalidated.Invalidate("obsolete accidental lineage"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Replace(record.Revision, "review/invalidate", invalidated); err != nil {
+		t.Fatalf("live-matching invalidate: %v", err)
+	}
+	record, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	before, err := InventoryAuthority(context.Background(), repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if before.Complete || before.Authoritative {
+		t.Fatalf("pre-abandon poisoned inventory = %#v", before)
+	}
+
+	committed, err := AbandonPristineCompactStore(context.Background(), repo, abandonFixtureRequest(record))
+	if err != nil {
+		t.Fatalf("abandon pristine invalidated lineage: %v", err)
+	}
+	if committed.Status != CompactReclaimCommitted || committed.PristineAbandonment == nil ||
+		committed.PristineAbandonment.State != StateInvalidated ||
+		committed.PristineAbandonment.InvalidationReason != "obsolete accidental lineage" {
+		t.Fatalf("invalidated abandonment proof = %#v", committed)
+	}
+	after, err := InventoryAuthority(context.Background(), repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !after.Complete || !after.Authoritative {
+		t.Fatalf("post-abandon inventory = %#v", after)
+	}
+}
+
+func TestAbandonRefusesIneligibleTargetsAndBindings(t *testing.T) {
+	repo := initSnapshotRepo(t)
+
+	t.Run("terminal approved lineage", func(t *testing.T) {
+		record, store := approvedCompactFixture(t, repo, "abandon-terminal-approved")
+		if _, err := AbandonPristineCompactStore(context.Background(), repo, abandonFixtureRequest(record)); err == nil ||
+			!strings.Contains(err.Error(), `holds "approved" authority`) {
+			t.Fatalf("terminal approved refusal = %v", err)
+		}
+		if _, err := os.Stat(store.StatePath()); err != nil {
+			t.Fatalf("refused abandonment moved the terminal entry: %v", err)
+		}
+	})
+
+	t.Run("terminal escalated lineage", func(t *testing.T) {
+		state := correctedCompactTestState(t, repo, "abandon-terminal-escalated")
+		state.State = StateEscalated
+		store, err := CompactAuthoritativeStore(context.Background(), repo, state.LineageID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		record := writeCompactFixtureRecord(t, store, state)
+		receipt, err := state.Receipt()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := WriteCompactReceiptAtomic(store.ReceiptPath(), receipt); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := AbandonPristineCompactStore(context.Background(), repo, abandonFixtureRequest(record)); err == nil ||
+			!strings.Contains(err.Error(), `holds "escalated" authority`) {
+			t.Fatalf("terminal escalated refusal = %v", err)
+		}
+	})
+
+	t.Run("lineage with captured review data", func(t *testing.T) {
+		state, _ := pendingCompactCorrection(t, repo, "abandon-corrected")
+		store, err := CompactAuthoritativeStore(context.Background(), repo, state.LineageID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		record := writeCompactFixtureRecord(t, store, state)
+		if _, err := AbandonPristineCompactStore(context.Background(), repo, abandonFixtureRequest(record)); err == nil ||
+			!strings.Contains(err.Error(), `holds "correction_required" authority`) {
+			t.Fatalf("captured review data refusal = %v", err)
+		}
+	})
+
+	t.Run("captured reviewer-results artifact", func(t *testing.T) {
+		writeSnapshotFile(t, repo, "tracked.txt", "base\ncaptured results change\n")
+		record, store := pristineReviewingFixture(t, repo, "abandon-captured-results")
+		if err := os.MkdirAll(filepath.Join(store.Dir, CompactReviewerResultsDir), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := AbandonPristineCompactStore(context.Background(), repo, abandonFixtureRequest(record)); err == nil ||
+			!strings.Contains(err.Error(), `authoritative artifact "reviewer-results"`) {
+			t.Fatalf("captured reviewer-results refusal = %v", err)
+		}
+	})
+
+	t.Run("finalize journal artifact", func(t *testing.T) {
+		writeSnapshotFile(t, repo, "tracked.txt", "base\nfinalize journal change\n")
+		record, store := pristineReviewingFixture(t, repo, "abandon-finalize-journal")
+		if err := os.WriteFile(filepath.Join(store.Dir, "finalize-attempt-journal.json"), []byte("{}\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := AbandonPristineCompactStore(context.Background(), repo, abandonFixtureRequest(record)); err == nil ||
+			!strings.Contains(err.Error(), `authoritative artifact "finalize-attempt-journal.json"`) {
+			t.Fatalf("finalize journal refusal = %v", err)
+		}
+	})
+
+	t.Run("interrupted atomic residue", func(t *testing.T) {
+		writeSnapshotFile(t, repo, "tracked.txt", "base\natomic residue change\n")
+		record, store := pristineReviewingFixture(t, repo, "abandon-atomic-residue")
+		if err := os.WriteFile(filepath.Join(store.Dir, ".atomic-12345"), []byte("partial\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := AbandonPristineCompactStore(context.Background(), repo, abandonFixtureRequest(record)); err == nil ||
+			!strings.Contains(err.Error(), `authoritative artifact ".atomic-12345"`) {
+			t.Fatalf("atomic residue refusal = %v", err)
+		}
+	})
+
+	t.Run("stale expected revision and inexact binding", func(t *testing.T) {
+		writeSnapshotFile(t, repo, "tracked.txt", "base\ncas change\n")
+		record, store := pristineReviewingFixture(t, repo, "abandon-cas")
+		payload, err := os.ReadFile(store.StatePath())
+		if err != nil {
+			t.Fatal(err)
+		}
+		stale := abandonFixtureRequest(record)
+		stale.ExpectedRevision = "sha256:" + strings.Repeat("00", 32)
+		if _, err := AbandonPristineCompactStore(context.Background(), repo, stale); !errors.Is(err, ErrConcurrentUpdate) {
+			t.Fatalf("stale expected revision = %v", err)
+		}
+		inexact := abandonFixtureRequest(record)
+		inexact.MaintainerAuthorization = compactAbandonAuthorizationBinding(
+			record.State.LineageID, record.State.InitialSnapshot.Identity, record.Revision, inexact.Actor, inexact.Reason)
+		if _, err := AbandonPristineCompactStore(context.Background(), repo, inexact); err == nil ||
+			!strings.Contains(err.Error(), "exact maintainer authorization binding") {
+			t.Fatalf("inexact binding = %v", err)
+		}
+		missing := abandonFixtureRequest(record)
+		missing.Reason = "  "
+		if _, err := AbandonPristineCompactStore(context.Background(), repo, missing); err == nil ||
+			!strings.Contains(err.Error(), "non-empty reason and actor") {
+			t.Fatalf("missing reason = %v", err)
+		}
+		current, err := os.ReadFile(store.StatePath())
+		if err != nil || !bytes.Equal(current, payload) {
+			t.Fatalf("refused abandonment mutated the entry: %v", err)
+		}
+	})
+
+	t.Run("superseded lineage", func(t *testing.T) {
+		writeSnapshotFile(t, repo, "tracked.txt", "base\nsuperseded change\n")
+		record, _ := pristineReviewingFixture(t, repo, "abandon-superseded")
+		predecessorState := record.State
+		if err := predecessorState.Invalidate("superseded by explicit recovery"); err != nil {
+			t.Fatal(err)
+		}
+		predecessorStore, err := CompactAuthoritativeStore(context.Background(), repo, predecessorState.LineageID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		predecessor := writeCompactFixtureRecord(t, predecessorStore, predecessorState)
+		writeSnapshotFile(t, repo, "tracked.txt", "base\nsuperseded successor change\n")
+		successorState := newCompactTestState(t, repo, "abandon-superseded-g2")
+		successorState.Generation = predecessorState.Generation + 1
+		successorState.Recovery = &CompactRecoveryProvenance{
+			PredecessorLineageID: predecessorState.LineageID, PredecessorRevision: predecessor.Revision,
+			Disposition: RecoveryInvalidated, Reason: "superseded by explicit recovery", Actor: "maintainer@example.com",
+			RecoveredAt:             time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC),
+			MaintainerAuthorization: compactRecoveryAuthorizationBinding(predecessorState.LineageID, predecessor.Revision, successorState.InitialSnapshot.Identity, "maintainer@example.com", "superseded by explicit recovery"),
+		}
+		successorStore, err := CompactAuthoritativeStore(context.Background(), repo, successorState.LineageID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		writeCompactFixtureRecord(t, successorStore, successorState)
+		if _, err := AbandonPristineCompactStore(context.Background(), repo, abandonFixtureRequest(predecessor)); err == nil ||
+			!strings.Contains(err.Error(), "superseded by recovery successor") {
+			t.Fatalf("superseded refusal = %v", err)
+		}
+	})
+
+	t.Run("absent lineage without committed record", func(t *testing.T) {
+		request := CompactAbandonRequest{
+			LineageID: "abandon-never-existed", ExpectedRevision: "sha256:" + strings.Repeat("11", 32),
+			Reason: "retire ghost", Actor: "maintainer@example.com",
+			MaintainerAuthorization: "irrelevant",
+		}
+		if _, err := AbandonPristineCompactStore(context.Background(), repo, request); err == nil ||
+			!strings.Contains(err.Error(), "no committed abandonment record matches") {
+			t.Fatalf("absent lineage refusal = %v", err)
+		}
+	})
+}
+
+func TestAbandonCrashBeforeRenameLeavesPreparedRecordAndRetrySucceeds(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	writeSnapshotFile(t, repo, "tracked.txt", "base\ninterrupted change\n")
+	record, store := pristineReviewingFixture(t, repo, "abandon-interrupted")
+	request := abandonFixtureRequest(record)
+
+	original := reclaimQuarantineResidue
+	reclaimQuarantineResidue = func(string, string) error {
+		return errors.New("simulated crash before residue rename")
+	}
+	t.Cleanup(func() { reclaimQuarantineResidue = original })
+	prepared, err := AbandonPristineCompactStore(context.Background(), repo, request)
+	if err == nil {
+		t.Fatal("interrupted abandonment reported success")
+	}
+	if prepared.Status != CompactReclaimPrepared || prepared.QuarantinePath == "" || prepared.PristineAbandonment == nil {
+		t.Fatalf("rename-failure record = %#v", prepared)
+	}
+	if _, statErr := os.Stat(store.StatePath()); statErr != nil {
+		t.Fatalf("interrupted abandonment mutated the source entry: %v", statErr)
+	}
+
+	reclaimQuarantineResidue = original
+	committed, err := AbandonPristineCompactStore(context.Background(), repo, request)
+	if err != nil {
+		t.Fatalf("retry after interrupted abandonment: %v", err)
+	}
+	if committed.Status != CompactReclaimCommitted || committed.QuarantinePath == prepared.QuarantinePath {
+		t.Fatalf("retry abandonment record = %#v", committed)
+	}
+	if _, statErr := os.Stat(store.Dir); !os.IsNotExist(statErr) {
+		t.Fatalf("retried abandonment left the source entry behind: %v", statErr)
+	}
+}
+
+// TestAbandonCommitRewriteFailureRefusesReplayAgainstPreparedOrphan exercises
+// the renamed-but-uncommitted crash window: the entry left v2/ but the audit
+// record never reached committed. The replay gate must refuse that orphaned
+// prepared state instead of silently reporting the abandonment as committed.
+func TestAbandonCommitRewriteFailureRefusesReplayAgainstPreparedOrphan(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	writeSnapshotFile(t, repo, "tracked.txt", "base\ncommit rewrite change\n")
+	record, store := pristineReviewingFixture(t, repo, "abandon-commit-rewrite")
+	pristinePayload, err := os.ReadFile(store.StatePath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := abandonFixtureRequest(record)
+
+	original := persistReclaimRecord
+	persistReclaimRecord = func(record CompactReclaimRecord) error {
+		if record.Status == CompactReclaimCommitted {
+			return errors.New("simulated crash before committed rewrite")
+		}
+		return original(record)
+	}
+	t.Cleanup(func() { persistReclaimRecord = original })
+	prepared, err := AbandonPristineCompactStore(context.Background(), repo, request)
+	if err == nil {
+		t.Fatal("failed committed rewrite reported success")
+	}
+	if prepared.Status != CompactReclaimPrepared || prepared.QuarantinePath == "" || prepared.PristineAbandonment == nil {
+		t.Fatalf("committed-rewrite failure record = %#v", prepared)
+	}
+	if !strings.Contains(err.Error(), prepared.QuarantinePath) {
+		t.Fatalf("committed-rewrite failure hides the quarantine location: %v", err)
+	}
+	if _, statErr := os.Stat(store.Dir); !os.IsNotExist(statErr) {
+		t.Fatalf("committed-rewrite failure left the source entry behind: %v", statErr)
+	}
+	moved, readErr := os.ReadFile(filepath.Join(prepared.QuarantinePath, "residue", "review-state.json"))
+	if readErr != nil || !bytes.Equal(moved, pristinePayload) {
+		t.Fatalf("quarantined pristine bytes = %q, %v", moved, readErr)
+	}
+	var orphan CompactReclaimRecord
+	orphanPayload, err := os.ReadFile(filepath.Join(prepared.QuarantinePath, "reclaim-record.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(orphanPayload, &orphan); err != nil {
+		t.Fatal(err)
+	}
+	if orphan.Status != CompactReclaimPrepared || orphan.PristineAbandonment == nil {
+		t.Fatalf("orphan abandonment record = %#v", orphan)
+	}
+
+	// The entry is gone but only a prepared record exists: an exact replay of
+	// the same request must refuse and point at the quarantine root for manual
+	// reconciliation, never converge on the uncommitted orphan.
+	persistReclaimRecord = original
+	root, _, err := reviewAuthorityRoot(context.Background(), repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, replayErr := AbandonPristineCompactStore(context.Background(), repo, request); replayErr == nil ||
+		!strings.Contains(replayErr.Error(), "no committed abandonment record matches") ||
+		!strings.Contains(replayErr.Error(), filepath.Join(root, "quarantine")) {
+		t.Fatalf("replay against prepared orphan = %v", replayErr)
+	}
+}
+
+// TestAbandonRefusesCorruptedNonPristineInvalidatedRecord feeds a hand-crafted
+// invalidated record that retains captured review data — a shape Invalidate
+// can never produce — directly into the store and asserts abandonment fails
+// closed without mutating the entry. The refusal fires at the load boundary
+// (parseCompactRecord re-runs CompactState.Validate, whose invalidated case
+// re-proves the pristine projection); the in-branch recheck in
+// AbandonPristineCompactStore is layered defense behind that same predicate.
+func TestAbandonRefusesCorruptedNonPristineInvalidatedRecord(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	writeSnapshotFile(t, repo, "tracked.txt", "base\none\ntwo\nthree\nfour\n")
+	state := newCompactTestState(t, repo, "abandon-corrupted-invalidated")
+	// Hand-craft the corruption: flip to invalidated while retaining captured
+	// review data, a shape Invalidate can never produce because it requires
+	// pristineness before the transition. FollowUps survive every structural
+	// validator that runs before the invalidated pristineness re-derivation,
+	// so this exercises exactly that class.
+	state.FollowUps = []FollowUp{{Observation: "captured review observation", ProofRefs: []string{"proof"}}}
+	state.State, state.InvalidationReason = StateInvalidated, "hand-crafted corruption"
+	store, err := CompactAuthoritativeStore(context.Background(), repo, state.LineageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	record := writeCompactFixtureRecord(t, store, state)
+	payload, err := os.ReadFile(store.StatePath())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := AbandonPristineCompactStore(context.Background(), repo, abandonFixtureRequest(record)); err == nil ||
+		!strings.Contains(err.Error(), "pristine reviewing authority") {
+		t.Fatalf("corrupted invalidated refusal = %v", err)
+	}
+	current, err := os.ReadFile(store.StatePath())
+	if err != nil || !bytes.Equal(current, payload) {
+		t.Fatalf("refused abandonment mutated the corrupted entry: %v", err)
+	}
+	if _, statErr := os.Stat(store.Dir); statErr != nil {
+		t.Fatalf("refused abandonment moved the corrupted entry: %v", statErr)
+	}
+}

--- a/internal/reviewtransaction/compact_reclaim.go
+++ b/internal/reviewtransaction/compact_reclaim.go
@@ -56,6 +56,10 @@ type CompactReclaimRecord struct {
 	// pre-contract authorization proof; it is set only for reconcile-authority
 	// quarantines of the malformed-recovery-authorization class.
 	MalformedRecoveryAuthorization *CompactMalformedRecoveryAuthorizationProof `json:"malformed_recovery_authorization,omitempty"`
+	// PristineAbandonment carries the natively re-derived pristineness proof;
+	// it is set only for review-abandon quarantines of pristine reviewing or
+	// pristine invalidated lineages.
+	PristineAbandonment *CompactPristineAbandonmentProof `json:"pristine_abandonment,omitempty"`
 }
 
 // compactAuthoritativeArtifact reports whether a store-entry name carries


### PR DESCRIPTION
Fixes #1441
Fixes #1304

## Problem

There was no sanctioned exit for an obsolete pristine lineage: `review invalidate` requires the live snapshot to still match the frozen one, so once HEAD advances the lineage is un-invalidatable; `reclaim` refuses entries holding `review-state.json`; `reconcile-authority` admits only its two recovery-edge classes. Worse, a successfully invalidated lineage (`StateInvalidated`) poisons lineage-less discovery forever — gates report `authority_corrupted` for every other lineage.

## Fix

`gentle-ai review abandon` — the third audited-quarantine family member (reclaim → reconcile → abandon):

- **Admission (fail-closed, under the shared v2 LOCK, no live-worktree rebuild)**: pristine `reviewing` lineages, or `invalidated` lineages whose reviewing projection is pristine; terminal and in-flight states refuse with class errors; any authoritative artifact beyond the state file (receipt, finalize journal, captured reviewer results, atomic residue) refuses; CAS on the expected revision; an exact six-line `gentle-ai.review-abandon-authorization/v1` binding (revision inside the binding defeats stale authorizations); supersession and post-removal whole-graph checks.
- **Absence, not annotation**: the two-phase byte-preserving quarantine moves the entry out of the inventory, so discovery, status, start, recover, and gates all recover structurally — no gate or inventory code was touched.
- **Idempotency**: committed-record replay re-emits the original result for an exact repeat; prepared orphans from crash windows are refused with a pointer to the quarantine root, never reported as committed.

## Review

Native bounded review, two rounds (high risk, 4R). Round 2: zero findings across all four lenses. Risk verified the four attack vectors closed deterministically (state slip-through, pristineness bypass, replay forgery, LOCK race); reliability independently traced the load-boundary defense layering and confirmed the corrupted-record test isolates the intended predicate. All gates allow.

## Tests

Failing-first reproductions of both deadlocks on unmodified code. Ten tests including byte-preservation, replay idempotency, both crash windows (pre-rename retry succeeds; post-rename orphan replay refused), inventory restoration, post-abandon start, nine fail-closed refusal subtests, and CLI end-to-end gate recovery. Full suites pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `review abandon` command to quarantine eligible pristine review entries.
  * Added strict flag validation for lineage, expected revision, reason, actor, and maintainer authorization (exact match).
  * Produces a `review/abandon` JSON result on success and, when applicable, also on failure; includes pristine abandonment proof details.
  * Supports idempotent replay and restores post-abandon lifecycle/authority state.

* **Bug Fixes**
  * Prevents abandonment of corrupted, ineligible, or mismatched entries without altering stored state.
  * Restores authoritative, complete review status after abandonment.

* **Tests**
  * Added CLI and transaction test coverage for quarantine, replay, validation, and refusal behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->