### PR TITLE
fix(review): quarantine malformed legacy freeze events

### DIFF
--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -338,7 +338,7 @@ func TestRunArgsDispatchesCompactReviewFacadeBeforePlatformValidation(t *testing
 	if err := RunArgs([]string{"review", "--help"}, &output); err != nil {
 		t.Fatalf("RunArgs(review --help) error = %v", err)
 	}
-	if !strings.Contains(output.String(), "review <capabilities|start|finalize|validate|status|invalidate|abandon|recover|reclaim|reconcile-authority|schema|bind-sdd>") {
+	if !strings.Contains(output.String(), "review <capabilities|start|finalize|validate|status|invalidate|abandon|recover|reclaim|reconcile-authority|quarantine-legacy|schema|bind-sdd>") {
 		t.Fatalf("compact review help missing:\n%s", output.String())
 	}
 }

--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -224,7 +224,7 @@ var reviewFacadeCommittedTransitionHook = func(context.Context, string, string, 
 
 func RunReview(args []string, stdout io.Writer) error {
 	if len(args) == 0 || args[0] == "help" || args[0] == "-h" || args[0] == "--help" {
-		_, _ = fmt.Fprintln(stdout, "Usage: gentle-ai review <capabilities|start|finalize|validate|status|invalidate|abandon|recover|reclaim|reconcile-authority|schema|bind-sdd> [flags]\n\nOrdinary review facade; repository scope, authority, canonical artifacts, and lifecycle transitions are derived by Go.")
+		_, _ = fmt.Fprintln(stdout, "Usage: gentle-ai review <capabilities|start|finalize|validate|status|invalidate|abandon|recover|reclaim|reconcile-authority|quarantine-legacy|schema|bind-sdd> [flags]\n\nOrdinary review facade; repository scope, authority, canonical artifacts, and lifecycle transitions are derived by Go.")
 		_, _ = fmt.Fprintln(stdout, "Additive headless capabilities: gentle-ai review capture-result (with --preflight) and gentle-ai review preserve-result.")
 		return nil
 	}
@@ -315,6 +315,8 @@ func runReviewCommand(args []string, stdout io.Writer) error {
 		return RunReviewReclaim(args[1:], stdout)
 	case "reconcile-authority":
 		return RunReviewReconcileAuthority(args[1:], stdout)
+	case "quarantine-legacy":
+		return RunReviewLegacyQuarantine(args[1:], stdout)
 	case "schema":
 		return RunReviewSchema(args[1:], stdout)
 	case "bind-sdd":

--- a/internal/cli/review_legacy_quarantine.go
+++ b/internal/cli/review_legacy_quarantine.go
@@ -1,0 +1,57 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/gentleman-programming/gentle-ai/internal/reviewtransaction"
+)
+
+type ReviewLegacyQuarantineResult struct {
+	Operation string                                 `json:"operation"`
+	Record    reviewtransaction.CompactReclaimRecord `json:"record"`
+}
+
+func RunReviewLegacyQuarantine(args []string, stdout io.Writer) error {
+	flags := newReviewFlagSet("review quarantine-legacy", stdout, "Quarantine one structurally intact legacy-v1 lineage whose historical review/freeze-findings event fails semantic replay only because it changed unrelated transaction state. The exact content-addressed history moves whole into audited quarantine and is never rewritten or accepted as valid. Other diagnostics, mixed-store identity, stale revisions, and active ownership are refused. Exact committed retries converge idempotently. On partial failure the prepared audit record JSON is emitted and the command exits non-zero.")
+	cwd := flags.String("cwd", ".", "repository path")
+	lineage := flags.String("lineage", "", "malformed legacy-v1 lineage to quarantine")
+	expected := flags.String("expected-revision", "", "exact current legacy HEAD revision")
+	diagnostic := flags.String("diagnostic", "", "exact inventory diagnostic")
+	disposition := flags.String("disposition", "", "exact supported quarantine disposition")
+	reason := flags.String("reason", "", "non-empty quarantine reason")
+	actor := flags.String("actor", "", "quarantine actor")
+	authorization := flags.String("maintainer-authorization", "", "exact eight-line LF-only binding: gentle-ai.review-legacy-quarantine-authorization/v1, repository, lineage, revision, diagnostic, disposition, actor, reason")
+	if err := parseReviewFlags(flags, args); err != nil {
+		return err
+	}
+	if reviewHelpRequested(args) {
+		return nil
+	}
+	if flags.NArg() != 0 {
+		return fmt.Errorf("unexpected review quarantine-legacy argument %q", flags.Arg(0))
+	}
+	for _, required := range []string{*lineage, *expected, *diagnostic, *disposition, *reason, *actor, *authorization} {
+		if strings.TrimSpace(required) == "" {
+			return errors.New("review quarantine-legacy requires --lineage, --expected-revision, --diagnostic, --disposition, --reason, --actor, and --maintainer-authorization")
+		}
+	}
+	root, err := (reviewtransaction.SnapshotBuilder{Repo: *cwd}).ResolveRepositoryRoot(context.Background())
+	if err != nil {
+		return fmt.Errorf("resolve review repository root: %w", err)
+	}
+	record, err := reviewtransaction.QuarantineMalformedLegacyFreeze(context.Background(), root, reviewtransaction.LegacyQuarantineRequest{
+		LineageID: *lineage, ExpectedRevision: *expected, ExpectedDiagnostic: *diagnostic,
+		Disposition: *disposition, Reason: *reason, Actor: *actor, MaintainerAuthorization: *authorization,
+	})
+	if err != nil {
+		if record.QuarantinePath != "" {
+			_ = encodeReviewJSON(stdout, ReviewLegacyQuarantineResult{Operation: "review/quarantine-legacy", Record: record})
+		}
+		return err
+	}
+	return encodeReviewJSON(stdout, ReviewLegacyQuarantineResult{Operation: "review/quarantine-legacy", Record: record})
+}

--- a/internal/cli/review_legacy_quarantine_test.go
+++ b/internal/cli/review_legacy_quarantine_test.go
@@ -1,0 +1,119 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/internal/reviewtransaction"
+)
+
+func malformedLegacyFreezeCLIFixture(t *testing.T) (repo, lineage, head string) {
+	t.Helper()
+	repo = initReviewCLIRepo(t)
+	lineage = "cli-malformed-legacy-freeze"
+	snapshot, err := (reviewtransaction.SnapshotBuilder{Repo: repo}).Build(context.Background(), reviewtransaction.Target{
+		Kind: reviewtransaction.TargetCurrentChanges, Projection: reviewtransaction.ProjectionWorkspace, IntendedUntracked: []string{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	tx, err := reviewtransaction.NewTransaction(reviewtransaction.Start{
+		LineageID: lineage, Mode: reviewtransaction.ModeOrdinary4R, Generation: 1,
+		Snapshot: snapshot, PolicyHash: "sha256:" + strings.Repeat("ab", 32),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := reviewtransaction.AuthoritativeStore(context.Background(), repo, lineage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.StartReview(); err != nil {
+		t.Fatal(err)
+	}
+	genesis := appendLegacyCLIRecord(t, store, "", "review/start", *tx)
+	ledger, err := reviewtransaction.CanonicalLedger([]reviewtransaction.Finding{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ledgerPath := filepath.Join(t.TempDir(), "ledger.json")
+	if err := os.WriteFile(ledgerPath, ledger, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ledgerHash, err := reviewtransaction.HashLedgerArtifact(ledgerPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.FreezeFindings([]reviewtransaction.Finding{}, ledger, ledgerHash); err != nil {
+		t.Fatal(err)
+	}
+	tx.EvidenceHash = "sha256:" + strings.Repeat("cd", 32)
+	record := reviewtransaction.Record{
+		Schema: reviewtransaction.RecordSchema, Operation: "review/freeze-findings",
+		PreviousRevision: genesis, Transaction: *tx,
+	}
+	payload, err := json.MarshalIndent(record, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload = append(payload, '\n')
+	sum := sha256.Sum256(payload)
+	head = "sha256:" + hex.EncodeToString(sum[:])
+	if err := os.MkdirAll(filepath.Join(store.Dir, "events"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(store.Dir, "events", strings.TrimPrefix(head, "sha256:")+".json"), payload, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(store.Dir, "HEAD"), []byte(head+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return repo, lineage, head
+}
+
+func TestReviewQuarantineLegacyRestoresAuthoritativeInventory(t *testing.T) {
+	repo, lineage, head := malformedLegacyFreezeCLIFixture(t)
+	diagnostic := "historical findings freeze changed unrelated transaction state"
+	disposition := reviewtransaction.LegacyMalformedFreezeQuarantineDisposition
+	reason, actor := "retire malformed shipped legacy history", "maintainer@example.com"
+	authorization := "gentle-ai.review-legacy-quarantine-authorization/v1\nrepository=" + repo +
+		"\nlineage=" + lineage + "\nrevision=" + head + "\ndiagnostic=" + diagnostic +
+		"\ndisposition=" + disposition + "\nactor=" + actor + "\nreason=" + reason
+
+	var output bytes.Buffer
+	if err := RunReview([]string{
+		"quarantine-legacy", "--cwd", repo, "--lineage", lineage,
+		"--expected-revision", head, "--diagnostic", diagnostic, "--disposition", disposition,
+		"--reason", reason, "--actor", actor, "--maintainer-authorization", authorization,
+	}, &output); err != nil {
+		t.Fatalf("review quarantine-legacy: %v\n%s", err, output.String())
+	}
+	var result ReviewLegacyQuarantineResult
+	decodeStrictReviewJSON(t, output.Bytes(), &result)
+	if result.Operation != "review/quarantine-legacy" || result.Record.Status != reviewtransaction.CompactReclaimCommitted ||
+		result.Record.MalformedLegacyFreeze == nil || result.Record.MalformedLegacyFreeze.EventRevision != head {
+		t.Fatalf("legacy quarantine result = %#v", result)
+	}
+	report, err := reviewtransaction.InventoryAuthority(context.Background(), repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !report.Complete || !report.Authoritative {
+		t.Fatalf("post-quarantine inventory = %#v", report)
+	}
+
+	var help bytes.Buffer
+	if err := RunReview([]string{"help"}, &help); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(help.String(), "quarantine-legacy") {
+		t.Fatalf("review help omits quarantine-legacy: %s", help.String())
+	}
+}

--- a/internal/reviewtransaction/compact_legacy_quarantine_test.go
+++ b/internal/reviewtransaction/compact_legacy_quarantine_test.go
@@ -1,0 +1,324 @@
+package reviewtransaction
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// malformedLegacyFreezeFixture persists one shipped legacy-v1 lineage whose
+// review/freeze-findings successor captured state the semantic replay
+// considers unrelated to the findings freeze — the #1311 corruption class.
+// The chain is structurally intact and content-addressed; only the semantic
+// historical replay fails.
+func malformedLegacyFreezeFixture(t *testing.T, repo, lineage string) (Store, string, string) {
+	t.Helper()
+	store, err := AuthoritativeStore(context.Background(), repo, lineage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tx, err := NewTransaction(Start{
+		LineageID: lineage, Mode: ModeOrdinary4R, Generation: 1,
+		Snapshot: Snapshot{
+			Kind: TargetCurrentChanges, BaseTree: tree("a"), CandidateTree: tree("b"),
+			PathsDigest: hash("a"), IntendedUntracked: []string{},
+			IntendedUntrackedProof: hash("b"), Paths: []string{"internal/example.go"}, Identity: hash("c"),
+		},
+		PolicyHash: hash("d"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.StartReview(); err != nil {
+		t.Fatal(err)
+	}
+	genesis := writeStoreEvent(t, store, Record{Operation: "review/start", Transaction: *tx})
+	freeze := historicalFreezeTransition(t, *tx)
+	// The persisted event also captured an evidence hash the freeze transition
+	// never writes, so the semantic historical replay reports that the freeze
+	// changed unrelated transaction state while the event stays structurally
+	// valid, content-addressed, and decodable.
+	freeze.EvidenceHash = hash("0")
+	malformed := writeStoreEvent(t, store, Record{Operation: "review/freeze-findings", PreviousRevision: genesis, Transaction: freeze})
+	if _, err := freeze.ClassifyEvidence([]FindingEvidence{}); err != nil {
+		t.Fatal(err)
+	}
+	head := writeStoreEvent(t, store, Record{Operation: "review/classify-evidence", PreviousRevision: malformed, Transaction: freeze})
+	return store, head, malformed
+}
+
+// TestMalformedLegacyFreezeEventBricksInventoryWithNoFamilyExit reproduces
+// #1311: one semantically invalid legacy freeze event marks the lineage
+// invalid, forces the whole inventory complete:false/authoritative:false, and
+// every existing quarantine-family member refuses the entry.
+func TestMalformedLegacyFreezeEventBricksInventoryWithNoFamilyExit(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	approvedCompactFixture(t, repo, "legacy-quarantine-unrelated-approved")
+	store, _, _ := malformedLegacyFreezeFixture(t, repo, "legacy-freeze-broken")
+
+	_, loadErr := store.LoadChain()
+	if loadErr == nil || !errors.Is(loadErr, ErrInvalidSuccessor) ||
+		!strings.Contains(loadErr.Error(), "historical findings freeze changed unrelated transaction state") {
+		t.Fatalf("malformed freeze load error = %v", loadErr)
+	}
+	t.Logf("verbatim load failure: %v", loadErr)
+
+	report, err := InventoryAuthority(context.Background(), repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.Complete || report.Authoritative || report.Status != AuthorityStatusInvalid ||
+		!hasAuthorityInventoryStatus(report.Entries, "legacy-freeze-broken", AuthorityStatusInvalid) {
+		t.Fatalf("bricked inventory = %#v", report)
+	}
+	for _, entry := range report.Entries {
+		if entry.LineageID != "legacy-freeze-broken" {
+			continue
+		}
+		if len(entry.Problems) != 1 || !strings.Contains(entry.Problems[0], "historical findings freeze changed unrelated transaction state") {
+			t.Fatalf("bricked entry problems = %#v", entry.Problems)
+		}
+		t.Logf("verbatim inventory classification: status=%s problems=%q", entry.Status, entry.Problems)
+	}
+
+	// The audited quarantine family routes the anomaly nowhere: reclaim,
+	// reconcile-authority, and abandon all operate on compact-v2 entries only.
+	if _, err := ReclaimIncompleteCompactStore(context.Background(), repo, CompactReclaimRequest{
+		LineageID: "legacy-freeze-broken", Reason: "retire malformed legacy history", Actor: "maintainer@example.com",
+	}); err == nil || !strings.Contains(err.Error(), "inspect reclaim target") {
+		t.Fatalf("reclaim refusal = %v", err)
+	} else {
+		t.Logf("verbatim reclaim refusal: %v", err)
+	}
+	if _, err := ReconcileInvalidRecoveryEdge(context.Background(), repo, CompactReconcileRequest{
+		PredecessorLineageID: "legacy-quarantine-unrelated-approved", ExpectedPredecessorRevision: hash("1"),
+		SuccessorLineageID: "legacy-freeze-broken", ExpectedSuccessorRevision: hash("2"),
+		Reason: "retire malformed legacy history", Actor: "maintainer@example.com",
+		MaintainerAuthorization: "irrelevant",
+	}); err == nil || !strings.Contains(err.Error(), "holds no compact authority state") {
+		t.Fatalf("reconcile-authority refusal = %v", err)
+	} else {
+		t.Logf("verbatim reconcile-authority refusal: %v", err)
+	}
+	if _, err := AbandonPristineCompactStore(context.Background(), repo, CompactAbandonRequest{
+		LineageID: "legacy-freeze-broken", ExpectedRevision: hash("3"),
+		Reason: "retire malformed legacy history", Actor: "maintainer@example.com",
+		MaintainerAuthorization: "irrelevant",
+	}); err == nil || !strings.Contains(err.Error(), "no committed abandonment record matches") {
+		t.Fatalf("abandon refusal = %v", err)
+	} else {
+		t.Logf("verbatim abandon refusal: %v", err)
+	}
+}
+
+func malformedLegacyFreezeQuarantineRequest(repo, lineage, head string) LegacyQuarantineRequest {
+	request := LegacyQuarantineRequest{
+		LineageID: lineage, ExpectedRevision: head,
+		ExpectedDiagnostic: "historical findings freeze changed unrelated transaction state",
+		Disposition:        LegacyMalformedFreezeQuarantineDisposition,
+		Reason:             "retire malformed shipped legacy history", Actor: "maintainer@example.com",
+	}
+	request.MaintainerAuthorization = legacyQuarantineAuthorizationBinding(
+		repo, request.LineageID, request.ExpectedRevision, request.ExpectedDiagnostic,
+		request.Disposition, request.Actor, request.Reason,
+	)
+	return request
+}
+
+func TestQuarantineMalformedLegacyFreezePreservesHistoryAndRestoresInventory(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	approved, approvedStore := approvedCompactFixture(t, repo, "legacy-quarantine-unrelated-approved")
+	store, head, malformed := malformedLegacyFreezeFixture(t, repo, "legacy-freeze-broken")
+	request := malformedLegacyFreezeQuarantineRequest(repo, "legacy-freeze-broken", head)
+
+	headBytes, err := os.ReadFile(filepath.Join(store.Dir, "HEAD"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	eventPath := filepath.Join(store.Dir, "events", strings.TrimPrefix(malformed, "sha256:")+".json")
+	eventBytes, err := os.ReadFile(eventPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	approvedStateBefore, err := os.ReadFile(approvedStore.StatePath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	approvedReceiptBefore, err := os.ReadFile(approvedStore.ReceiptPath())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	committed, err := QuarantineMalformedLegacyFreeze(context.Background(), repo, request)
+	if err != nil {
+		t.Fatalf("quarantine malformed legacy freeze: %v", err)
+	}
+	proof := committed.MalformedLegacyFreeze
+	if committed.Status != CompactReclaimCommitted || proof == nil ||
+		proof.LineageID != request.LineageID || proof.HeadRevision != head ||
+		proof.EventRevision != malformed || proof.Operation != "review/freeze-findings" ||
+		proof.Diagnostic != request.ExpectedDiagnostic || proof.Disposition != request.Disposition ||
+		!reflect.DeepEqual(proof.ChangedFields, []string{"evidence_hash"}) {
+		t.Fatalf("legacy quarantine record = %#v", committed)
+	}
+	if _, err := os.Stat(store.Dir); !os.IsNotExist(err) {
+		t.Fatalf("legacy source still present: %v", err)
+	}
+	movedHead, err := os.ReadFile(filepath.Join(committed.QuarantinePath, "residue", "HEAD"))
+	if err != nil || !bytes.Equal(movedHead, headBytes) {
+		t.Fatalf("quarantined HEAD = %q, %v", movedHead, err)
+	}
+	movedEvent, err := os.ReadFile(filepath.Join(committed.QuarantinePath, "residue", "events", filepath.Base(eventPath)))
+	if err != nil || !bytes.Equal(movedEvent, eventBytes) {
+		t.Fatalf("quarantined freeze event = %q, %v", movedEvent, err)
+	}
+	approvedStateAfter, _ := os.ReadFile(approvedStore.StatePath())
+	approvedReceiptAfter, _ := os.ReadFile(approvedStore.ReceiptPath())
+	if !bytes.Equal(approvedStateBefore, approvedStateAfter) || !bytes.Equal(approvedReceiptBefore, approvedReceiptAfter) {
+		t.Fatal("legacy quarantine changed unrelated compact authority")
+	}
+	report, err := InventoryAuthority(context.Background(), repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !report.Complete || !report.Authoritative ||
+		!hasAuthorityInventoryStatus(report.Entries, approved.State.LineageID, AuthorityStatusApproved) {
+		t.Fatalf("post-quarantine inventory = %#v", report)
+	}
+
+	replayed, err := QuarantineMalformedLegacyFreeze(context.Background(), repo, request)
+	if err != nil {
+		t.Fatalf("idempotent legacy quarantine replay: %v", err)
+	}
+	if replayed.QuarantinePath != committed.QuarantinePath || replayed.Status != CompactReclaimCommitted {
+		t.Fatalf("replayed legacy quarantine = %#v", replayed)
+	}
+}
+
+func TestQuarantineMalformedLegacyFreezeRefusesOutsideExactClass(t *testing.T) {
+	t.Run("stale revision", func(t *testing.T) {
+		repo := initSnapshotRepo(t)
+		store, head, _ := malformedLegacyFreezeFixture(t, repo, "legacy-freeze-stale")
+		request := malformedLegacyFreezeQuarantineRequest(repo, "legacy-freeze-stale", head)
+		request.ExpectedRevision = hash("f")
+		request.MaintainerAuthorization = legacyQuarantineAuthorizationBinding(
+			repo, request.LineageID, request.ExpectedRevision, request.ExpectedDiagnostic,
+			request.Disposition, request.Actor, request.Reason,
+		)
+		if _, err := QuarantineMalformedLegacyFreeze(context.Background(), repo, request); !errors.Is(err, ErrConcurrentUpdate) {
+			t.Fatalf("stale revision error = %v", err)
+		}
+		if _, err := os.Stat(store.Dir); err != nil {
+			t.Fatalf("stale request moved source: %v", err)
+		}
+	})
+
+	t.Run("unsupported diagnostic and disposition", func(t *testing.T) {
+		repo := initSnapshotRepo(t)
+		store, head, _ := malformedLegacyFreezeFixture(t, repo, "legacy-freeze-unsupported")
+		for _, mutate := range []func(*LegacyQuarantineRequest){
+			func(request *LegacyQuarantineRequest) { request.ExpectedDiagnostic = "different diagnostic" },
+			func(request *LegacyQuarantineRequest) { request.Disposition = "delete-history" },
+		} {
+			request := malformedLegacyFreezeQuarantineRequest(repo, "legacy-freeze-unsupported", head)
+			mutate(&request)
+			if _, err := QuarantineMalformedLegacyFreeze(context.Background(), repo, request); err == nil ||
+				!strings.Contains(err.Error(), "supports only") {
+				t.Fatalf("unsupported request error = %v", err)
+			}
+		}
+		if _, err := os.Stat(store.Dir); err != nil {
+			t.Fatalf("unsupported request moved source: %v", err)
+		}
+	})
+
+	t.Run("inexact authorization", func(t *testing.T) {
+		repo := initSnapshotRepo(t)
+		store, head, _ := malformedLegacyFreezeFixture(t, repo, "legacy-freeze-auth")
+		request := malformedLegacyFreezeQuarantineRequest(repo, "legacy-freeze-auth", head)
+		request.MaintainerAuthorization += "\n"
+		if _, err := QuarantineMalformedLegacyFreeze(context.Background(), repo, request); err == nil ||
+			!strings.Contains(err.Error(), "exact maintainer authorization binding") {
+			t.Fatalf("inexact authorization error = %v", err)
+		}
+		if _, err := os.Stat(store.Dir); err != nil {
+			t.Fatalf("inexact authorization moved source: %v", err)
+		}
+	})
+
+	t.Run("mixed store identity", func(t *testing.T) {
+		repo := initSnapshotRepo(t)
+		store, head, _ := malformedLegacyFreezeFixture(t, repo, "legacy-freeze-collision")
+		compact, err := CompactAuthoritativeStore(context.Background(), repo, "legacy-freeze-collision")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.MkdirAll(compact.Dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		request := malformedLegacyFreezeQuarantineRequest(repo, "legacy-freeze-collision", head)
+		if _, err := QuarantineMalformedLegacyFreeze(context.Background(), repo, request); err == nil ||
+			!strings.Contains(err.Error(), "also exists in compact-v2") {
+			t.Fatalf("mixed identity error = %v", err)
+		}
+		if _, err := os.Stat(store.Dir); err != nil {
+			t.Fatalf("mixed identity request moved source: %v", err)
+		}
+	})
+
+	t.Run("active ownership", func(t *testing.T) {
+		repo := initSnapshotRepo(t)
+		store, head, _ := malformedLegacyFreezeFixture(t, repo, "legacy-freeze-owned")
+		lock, err := acquireStoreLock(filepath.Join(store.Dir, "LOCK"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer lock.release()
+		request := malformedLegacyFreezeQuarantineRequest(repo, "legacy-freeze-owned", head)
+		if _, err := QuarantineMalformedLegacyFreeze(context.Background(), repo, request); !errors.Is(err, ErrConcurrentUpdate) ||
+			!strings.Contains(err.Error(), "active ownership") {
+			t.Fatalf("active ownership error = %v", err)
+		}
+	})
+
+	t.Run("valid legacy history", func(t *testing.T) {
+		repo := initSnapshotRepo(t)
+		store, err := AuthoritativeStore(context.Background(), repo, "legacy-freeze-valid")
+		if err != nil {
+			t.Fatal(err)
+		}
+		tx, err := NewTransaction(Start{
+			LineageID: "legacy-freeze-valid", Mode: ModeOrdinary4R, Generation: 1,
+			Snapshot: Snapshot{
+				Kind: TargetCurrentChanges, BaseTree: tree("a"), CandidateTree: tree("b"),
+				PathsDigest: hash("a"), IntendedUntracked: []string{}, IntendedUntrackedProof: hash("b"),
+				Paths: []string{"internal/example.go"}, Identity: hash("c"),
+			},
+			PolicyHash: hash("d"),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := tx.StartReview(); err != nil {
+			t.Fatal(err)
+		}
+		genesis := writeStoreEvent(t, store, Record{Operation: "review/start", Transaction: *tx})
+		head := writeStoreEvent(t, store, Record{
+			Operation: "review/freeze-findings", PreviousRevision: genesis,
+			Transaction: historicalFreezeTransition(t, *tx),
+		})
+		request := malformedLegacyFreezeQuarantineRequest(repo, "legacy-freeze-valid", head)
+		if _, err := QuarantineMalformedLegacyFreeze(context.Background(), repo, request); err == nil ||
+			!strings.Contains(err.Error(), "no supported malformed findings-freeze event") {
+			t.Fatalf("valid legacy refusal = %v", err)
+		}
+		if _, err := os.Stat(store.Dir); err != nil {
+			t.Fatalf("valid legacy request moved source: %v", err)
+		}
+	})
+}

--- a/internal/reviewtransaction/compact_reclaim.go
+++ b/internal/reviewtransaction/compact_reclaim.go
@@ -60,6 +60,9 @@ type CompactReclaimRecord struct {
 	// it is set only for review-abandon quarantines of pristine reviewing or
 	// pristine invalidated lineages.
 	PristineAbandonment *CompactPristineAbandonmentProof `json:"pristine_abandonment,omitempty"`
+	// MalformedLegacyFreeze carries the natively re-derived semantic replay
+	// failure for a shipped legacy-v1 findings-freeze event.
+	MalformedLegacyFreeze *LegacyMalformedFreezeProof `json:"malformed_legacy_freeze,omitempty"`
 }
 
 // compactAuthoritativeArtifact reports whether a store-entry name carries

--- a/internal/reviewtransaction/legacy_quarantine.go
+++ b/internal/reviewtransaction/legacy_quarantine.go
@@ -1,0 +1,261 @@
+package reviewtransaction
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	legacyQuarantineAuthorizationSchema        = "gentle-ai.review-legacy-quarantine-authorization/v1"
+	LegacyMalformedFreezeQuarantineDisposition = "quarantine-malformed-freeze-event"
+	legacyMalformedFreezeDiagnostic            = "historical findings freeze changed unrelated transaction state"
+)
+
+// LegacyQuarantineRequest identifies one exact legacy-v1 lineage revision
+// whose malformed findings-freeze event must be quarantined.
+type LegacyQuarantineRequest struct {
+	LineageID               string
+	ExpectedRevision        string
+	ExpectedDiagnostic      string
+	Disposition             string
+	Reason                  string
+	Actor                   string
+	MaintainerAuthorization string
+	QuarantinedAt           time.Time
+}
+
+// LegacyMalformedFreezeProof records the exact structurally valid event whose
+// historical findings-freeze replay changed unrelated transaction fields.
+type LegacyMalformedFreezeProof struct {
+	LineageID        string   `json:"lineage_id"`
+	HeadRevision     string   `json:"head_revision"`
+	ChainIdentity    string   `json:"chain_identity"`
+	EventRevision    string   `json:"event_revision"`
+	PreviousRevision string   `json:"previous_revision"`
+	Operation        string   `json:"operation"`
+	Diagnostic       string   `json:"diagnostic"`
+	Disposition      string   `json:"disposition"`
+	ChangedFields    []string `json:"changed_fields"`
+}
+
+func legacyQuarantineAuthorizationBinding(repository, lineage, revision, diagnostic, disposition, actor, reason string) string {
+	return legacyQuarantineAuthorizationSchema + "\nrepository=" + repository +
+		"\nlineage=" + lineage + "\nrevision=" + revision +
+		"\ndiagnostic=" + diagnostic + "\ndisposition=" + disposition +
+		"\nactor=" + strings.TrimSpace(actor) + "\nreason=" + strings.TrimSpace(reason)
+}
+
+// QuarantineMalformedLegacyFreeze moves one legacy-v1 lineage whose exact
+// content-addressed chain contains one supported malformed findings-freeze
+// event into audited quarantine. It never accepts the event as valid or
+// rewrites its bytes. Exact committed retries return the original record.
+func QuarantineMalformedLegacyFreeze(ctx context.Context, repo string, request LegacyQuarantineRequest) (CompactReclaimRecord, error) {
+	if err := ctx.Err(); err != nil {
+		return CompactReclaimRecord{}, err
+	}
+	if err := validateLineageID(request.LineageID); err != nil {
+		return CompactReclaimRecord{}, err
+	}
+	if !validSHA256(request.ExpectedRevision) {
+		return CompactReclaimRecord{}, errors.New("review quarantine-legacy requires an exact current HEAD revision")
+	}
+	if strings.TrimSpace(request.Reason) == "" || strings.TrimSpace(request.Actor) == "" {
+		return CompactReclaimRecord{}, errors.New("review quarantine-legacy requires a non-empty reason and actor")
+	}
+	if request.ExpectedDiagnostic != legacyMalformedFreezeDiagnostic || request.Disposition != LegacyMalformedFreezeQuarantineDisposition {
+		return CompactReclaimRecord{}, errors.New("review quarantine-legacy supports only the malformed historical findings-freeze diagnostic and disposition")
+	}
+	base, repository, err := reviewAuthorityRoot(ctx, repo)
+	if err != nil {
+		return CompactReclaimRecord{}, err
+	}
+	dir := filepath.Join(base, "v1", request.LineageID)
+	if _, err := os.Stat(dir); err != nil {
+		if os.IsNotExist(err) {
+			return replayCommittedLegacyQuarantine(base, repository, request)
+		}
+		return CompactReclaimRecord{}, fmt.Errorf("inspect legacy quarantine target: %w", err)
+	}
+	lock, err := acquireStoreLock(filepath.Join(dir, "LOCK"))
+	if err != nil {
+		return CompactReclaimRecord{}, fmt.Errorf("review quarantine-legacy refused active ownership: %w", err)
+	}
+	defer lock.release()
+	if _, err := os.Stat(filepath.Join(base, "v2", request.LineageID)); err == nil {
+		return CompactReclaimRecord{}, fmt.Errorf("review quarantine-legacy refused: lineage %q also exists in compact-v2 authority", request.LineageID)
+	} else if !os.IsNotExist(err) {
+		return CompactReclaimRecord{}, fmt.Errorf("inspect same-lineage compact authority: %w", err)
+	}
+	store := Store{Dir: dir, lineageID: request.LineageID, repo: repository, readOnly: true}
+	proof, err := inspectMalformedLegacyFreeze(ctx, store, request.ExpectedRevision)
+	if err != nil {
+		return CompactReclaimRecord{}, err
+	}
+	proof.Disposition = request.Disposition
+	if request.MaintainerAuthorization != legacyQuarantineAuthorizationBinding(
+		repository, request.LineageID, request.ExpectedRevision, request.ExpectedDiagnostic,
+		request.Disposition, request.Actor, request.Reason,
+	) {
+		return CompactReclaimRecord{}, fmt.Errorf("review quarantine-legacy requires an exact maintainer authorization binding (schema %s over repository, lineage, revision, diagnostic, disposition, actor, and reason)", legacyQuarantineAuthorizationSchema)
+	}
+	items, err := os.ReadDir(dir)
+	if err != nil {
+		return CompactReclaimRecord{}, fmt.Errorf("inspect legacy quarantine target: %w", err)
+	}
+	residue := make([]string, 0, len(items))
+	for _, item := range items {
+		residue = append(residue, item.Name())
+	}
+	sort.Strings(residue)
+	if request.QuarantinedAt.IsZero() {
+		request.QuarantinedAt = time.Now().UTC()
+	}
+	return quarantineCompactStoreEntry(base, dir, CompactReclaimRecord{
+		Schema: CompactReclaimRecordSchema, Status: CompactReclaimPrepared,
+		LineageID: request.LineageID, Reason: strings.TrimSpace(request.Reason),
+		Actor: strings.TrimSpace(request.Actor), ReclaimedAt: request.QuarantinedAt.UTC(),
+		SourcePath: dir, Residue: residue, MalformedLegacyFreeze: &proof,
+	})
+}
+
+func inspectMalformedLegacyFreeze(ctx context.Context, store Store, expectedHead string) (LegacyMalformedFreezeProof, error) {
+	head, err := readRevision(filepath.Join(store.Dir, "HEAD"))
+	if err != nil {
+		return LegacyMalformedFreezeProof{}, err
+	}
+	if head != expectedHead {
+		return LegacyMalformedFreezeProof{}, fmt.Errorf("%w: expected legacy HEAD %q, current %q", ErrConcurrentUpdate, expectedHead, head)
+	}
+	visited := map[string]bool{}
+	reverseRecords := []Record{}
+	reverseRevisions := []string{}
+	for revision := head; revision != ""; {
+		if visited[revision] {
+			return LegacyMalformedFreezeProof{}, errors.New("review quarantine-legacy refused: predecessor cycle")
+		}
+		visited[revision] = true
+		record, loaded, err := store.loadRevision(revision)
+		if err != nil {
+			return LegacyMalformedFreezeProof{}, fmt.Errorf("review quarantine-legacy refused: load revision %s: %w", revision, err)
+		}
+		reverseRecords = append(reverseRecords, record)
+		reverseRevisions = append(reverseRevisions, loaded)
+		revision = record.PreviousRevision
+	}
+	records := make([]Record, len(reverseRecords))
+	revisions := make([]string, len(reverseRevisions))
+	for index := range reverseRecords {
+		reverse := len(reverseRecords) - 1 - index
+		records[index], revisions[index] = reverseRecords[reverse], reverseRevisions[reverse]
+	}
+	if len(records) == 0 || !validInitialStoreRecord(records[0]) || records[0].Transaction.LineageID != store.lineageID {
+		return LegacyMalformedFreezeProof{}, errors.New("review quarantine-legacy refused: chain genesis is invalid")
+	}
+	var proof *LegacyMalformedFreezeProof
+	for index := 1; index < len(records); index++ {
+		if records[index].PreviousRevision != revisions[index-1] {
+			return LegacyMalformedFreezeProof{}, errors.New("review quarantine-legacy refused: predecessor revision is discontinuous")
+		}
+		err := validatePersistedV1Successor(records[index-1].Transaction, records[index].Transaction, records[index].Operation, index)
+		if err == nil {
+			continue
+		}
+		candidate := records[index]
+		if proof != nil || candidate.Operation != "review/freeze-findings" ||
+			err.Error() != ErrInvalidSuccessor.Error()+": "+legacyMalformedFreezeDiagnostic {
+			return LegacyMalformedFreezeProof{}, fmt.Errorf("review quarantine-legacy refused unsupported successor anomaly at %s: %w", revisions[index], err)
+		}
+		expected := historicalFreezeFindingsExpected(records[index-1].Transaction, candidate.Transaction)
+		changed, err := changedTransactionFields(expected, candidate.Transaction)
+		if err != nil || len(changed) == 0 {
+			return LegacyMalformedFreezeProof{}, fmt.Errorf("review quarantine-legacy could not derive changed fields: %w", err)
+		}
+		proof = &LegacyMalformedFreezeProof{
+			LineageID: store.lineageID, HeadRevision: head, ChainIdentity: chainIdentity(revisions),
+			EventRevision: revisions[index], PreviousRevision: revisions[index-1],
+			Operation: candidate.Operation, Diagnostic: legacyMalformedFreezeDiagnostic,
+			ChangedFields: changed,
+		}
+	}
+	if proof == nil {
+		return LegacyMalformedFreezeProof{}, errors.New("review quarantine-legacy refused: lineage has no supported malformed findings-freeze event")
+	}
+	if err := validateRepositoryBudgetEvidence(ctx, store.repo, records); err != nil {
+		return LegacyMalformedFreezeProof{}, fmt.Errorf("review quarantine-legacy refused repository evidence: %w", err)
+	}
+	return *proof, nil
+}
+
+func changedTransactionFields(expected, actual Transaction) ([]string, error) {
+	var left, right map[string]json.RawMessage
+	leftPayload, err := json.Marshal(expected)
+	if err != nil {
+		return nil, err
+	}
+	rightPayload, err := json.Marshal(actual)
+	if err != nil {
+		return nil, err
+	}
+	if err := json.Unmarshal(leftPayload, &left); err != nil {
+		return nil, err
+	}
+	if err := json.Unmarshal(rightPayload, &right); err != nil {
+		return nil, err
+	}
+	fields := make([]string, 0)
+	for field, expectedValue := range left {
+		if !reflect.DeepEqual(expectedValue, right[field]) {
+			fields = append(fields, field)
+		}
+	}
+	for field := range right {
+		if _, ok := left[field]; !ok {
+			fields = append(fields, field)
+		}
+	}
+	sort.Strings(fields)
+	return fields, nil
+}
+
+func replayCommittedLegacyQuarantine(base, repository string, request LegacyQuarantineRequest) (CompactReclaimRecord, error) {
+	quarantineRoot := filepath.Join(base, "quarantine")
+	entries, err := os.ReadDir(quarantineRoot)
+	if err != nil && !os.IsNotExist(err) {
+		return CompactReclaimRecord{}, fmt.Errorf("inspect quarantine for legacy replay: %w", err)
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		payload, readErr := os.ReadFile(filepath.Join(quarantineRoot, entry.Name(), "reclaim-record.json"))
+		if readErr != nil {
+			continue
+		}
+		var record CompactReclaimRecord
+		if json.Unmarshal(payload, &record) != nil || record.Status != CompactReclaimCommitted || record.MalformedLegacyFreeze == nil {
+			continue
+		}
+		proof := record.MalformedLegacyFreeze
+		if proof.LineageID != request.LineageID || proof.HeadRevision != request.ExpectedRevision ||
+			proof.Diagnostic != request.ExpectedDiagnostic || proof.Disposition != request.Disposition ||
+			record.Reason != strings.TrimSpace(request.Reason) || record.Actor != strings.TrimSpace(request.Actor) {
+			continue
+		}
+		if request.MaintainerAuthorization != legacyQuarantineAuthorizationBinding(
+			repository, proof.LineageID, proof.HeadRevision, proof.Diagnostic,
+			proof.Disposition, request.Actor, request.Reason,
+		) {
+			continue
+		}
+		return record, nil
+	}
+	return CompactReclaimRecord{}, fmt.Errorf("review quarantine-legacy refused: lineage %q is absent and no committed quarantine record matches; inspect prepared records under %s", request.LineageID, quarantineRoot)
+}

--- a/internal/reviewtransaction/store.go
+++ b/internal/reviewtransaction/store.go
@@ -648,6 +648,14 @@ func validateHistoricalFreezeFindings(previous, next Transaction) error {
 	if !validSHA256(next.LedgerHash) {
 		return fmt.Errorf("%w: historical findings freeze requires a ledger hash", ErrInvalidSuccessor)
 	}
+	expected := historicalFreezeFindingsExpected(previous, next)
+	if !transactionsEqual(expected, next) {
+		return fmt.Errorf("%w: historical findings freeze changed unrelated transaction state", ErrInvalidSuccessor)
+	}
+	return nil
+}
+
+func historicalFreezeFindingsExpected(previous, next Transaction) Transaction {
 	expected := previous
 	expected.Findings = nil
 	if next.Findings != nil {
@@ -665,10 +673,7 @@ func validateHistoricalFreezeFindings(previous, next Transaction) error {
 	expected.LedgerHash = next.LedgerHash
 	expected.LedgerFindingsHash = findingsHash(expected.Findings)
 	expected.State = StateFindingsFrozen
-	if !transactionsEqual(expected, next) {
-		return fmt.Errorf("%w: historical findings freeze changed unrelated transaction state", ErrInvalidSuccessor)
-	}
-	return nil
+	return expected
 }
 
 // transactionsEqual compares persisted transaction state. JSON omits empty


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1311

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

Adds the fourth audited quarantine class and `review quarantine-legacy` command for structurally intact legacy-v1 lineages containing exactly one malformed historical findings-freeze semantic replay event. The quarantine preserves original history bytes, records changed fields and exact event/chain proof, uses CAS, locking, and exact authorization, restores inventory authority, and supports idempotent committed replay.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/reviewtransaction` | Classifies and quarantines the exact malformed legacy freeze class while preserving history and failing closed for unsupported anomalies. |
| `internal/cli` | Adds the `review quarantine-legacy` command and facade routing. |
| `internal/app` | Updates review command help coverage. |

---

## 🧪 Test Plan

**Focused Tests**
```bash
go test ./internal/reviewtransaction -run '^(TestMalformedLegacyFreezeEventBricksInventoryWithNoFamilyExit|TestQuarantineMalformedLegacyFreezePreservesHistoryAndRestoresInventory|TestQuarantineMalformedLegacyFreezeRefusesOutsideExactClass)$'
go test ./internal/cli -run '^TestReviewQuarantineLegacyRestoresAuthoritativeInventory$'
go test ./internal/app -run '^TestRunArgsReviewSubcommandHelpExitsSuccessfully$'
```

**Affected Packages and Full Repository**
```bash
go test ./internal/reviewtransaction ./internal/cli ./internal/app
go test ./...
go vet ./internal/reviewtransaction ./internal/cli ./internal/app
git diff --check
```

- [x] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Manually tested locally

All seven recorded candidate verification commands passed with zero failures.

---

## 🤖 Automated Checks

The following checks run automatically on this PR:

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | PR should stay within 400 changed lines (`additions + deletions`) or use `size:exception` |
| Check Issue Reference | ⏳ | PR body must contain `Closes/Fixes/Resolves #N` |
| Check Issue Has `status:approved` | ⏳ | Linked issue must have been approved before work began |
| Check PR Has `type:*` Label | ⏳ | Exactly one `type:*` label must be applied |
| Unit Tests | ⏳ | `go test ./...` must pass |
| E2E Tests | ⏳ | `cd e2e && ./docker-test.sh` must pass |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [ ] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

Bounded review receipt: `review-8247398afbc1d882`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `review quarantine-legacy` command for authorized quarantine of specific malformed legacy review histories.
  * Added JSON audit results and proof details for quarantined legacy records.
  * Added safeguards for authorization, revision, diagnostic, repository state, and repeated requests.

* **Bug Fixes**
  * Improved validation and inventory handling for legacy findings-freeze histories with semantic replay failures.

* **Tests**
  * Added coverage for successful quarantine, preserved history, inventory restoration, idempotency, and rejected requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->