### PR TITLE
fix(review): support staged review on unborn head

### DIFF
--- a/internal/cli/review_unborn_test.go
+++ b/internal/cli/review_unborn_test.go
@@ -1,0 +1,177 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/internal/reviewtransaction"
+)
+
+func initUnbornReviewCLIRepo(t *testing.T) string {
+	t.Helper()
+	repo := t.TempDir()
+	runReviewCLIGit(t, repo, "init", "-q")
+	runReviewCLIGit(t, repo, "config", "user.email", "test@example.com")
+	runReviewCLIGit(t, repo, "config", "user.name", "Test")
+	return repo
+}
+
+func reviewCLIEmptyTree(t *testing.T, repo string) string {
+	t.Helper()
+	command := exec.Command("git", "-C", repo, "mktree")
+	command.Stdin = strings.NewReader("")
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git mktree: %v\n%s", err, output)
+	}
+	return strings.TrimSpace(string(output))
+}
+
+func writeUnbornReviewCandidate(t *testing.T, repo string) {
+	t.Helper()
+	code := "package candidate\n\n// Reviewed reports the initial reviewed value.\nfunc Reviewed() int {\n\treturn 1\n}\n"
+	if err := os.WriteFile(filepath.Join(repo, "candidate.go"), []byte(code), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "candidate.md"), []byte("reviewed\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func finalizeUnbornFacadeReview(t *testing.T, repo string, started ReviewFacadeStartResult) {
+	t.Helper()
+	evidencePath := filepath.Join(t.TempDir(), "evidence.txt")
+	if err := os.WriteFile(evidencePath, []byte("tests pass\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	args := append([]string{"--cwd", repo, "--lineage", started.LineageID}, facadeReviewerResultArgs(t, started)...)
+	args = append(args, "--evidence", evidencePath)
+	if err := RunReviewFacadeFinalize(args, io.Discard); err != nil {
+		t.Fatalf("finalize unborn review: %v", err)
+	}
+}
+
+func TestReviewFacadeUnbornHeadStagedLifecycle(t *testing.T) {
+	repo := initUnbornReviewCLIRepo(t)
+	writeUnbornReviewCandidate(t, repo)
+	runReviewCLIGit(t, repo, "add", "--", "candidate.go", "candidate.md")
+
+	var output bytes.Buffer
+	if err := RunReviewFacadeStart([]string{"--cwd", repo, "--projection", "staged"}, &output); err != nil {
+		t.Fatalf("unborn staged review start: %v", err)
+	}
+	var started ReviewFacadeStartResult
+	if err := json.Unmarshal(output.Bytes(), &started); err != nil {
+		t.Fatal(err)
+	}
+	if started.Projection != reviewtransaction.ProjectionStaged || started.ChangedFiles != 2 {
+		t.Fatalf("unborn staged start = %#v, want staged projection over 2 files", started)
+	}
+	store, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, started.LineageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	record, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := reviewCLIEmptyTree(t, repo); record.State.InitialSnapshot.BaseTree != want {
+		t.Fatalf("frozen base tree = %q, want repository-native empty tree %q", record.State.InitialSnapshot.BaseTree, want)
+	}
+	if want := []string{"candidate.go", "candidate.md"}; !reflect.DeepEqual(record.State.GenesisPaths, want) {
+		t.Fatalf("genesis paths = %v, want every candidate path %v", record.State.GenesisPaths, want)
+	}
+
+	finalizeUnbornFacadeReview(t, repo, started)
+
+	for _, gate := range []reviewtransaction.GateKind{reviewtransaction.GatePostApply, reviewtransaction.GatePreCommit} {
+		output.Reset()
+		if err := RunReviewFacadeValidate([]string{"--cwd", repo, "--lineage", started.LineageID, "--gate", string(gate)}, &output); err != nil {
+			t.Fatalf("%s while unborn: %v\n%s", gate, err, output.String())
+		}
+		assertReviewGateResult(t, output.Bytes(), reviewtransaction.GateAllow)
+	}
+
+	runReviewCLIGit(t, repo, "commit", "-qm", "first commit")
+	if headTree := strings.TrimSpace(runReviewCLIGit(t, repo, "rev-parse", "HEAD^{tree}")); headTree != record.State.CurrentSnapshot.CandidateTree {
+		t.Fatalf("first commit tree = %q, want approved candidate %q", headTree, record.State.CurrentSnapshot.CandidateTree)
+	}
+	output.Reset()
+	if err := RunReviewFacadeValidate([]string{"--cwd", repo, "--lineage", started.LineageID, "--gate", "pre-commit"}, &output); err != nil {
+		t.Fatalf("pre-commit after the first commit: %v\n%s", err, output.String())
+	}
+	assertReviewGateResult(t, output.Bytes(), reviewtransaction.GateAllow)
+}
+
+func TestReviewFacadeUnbornHeadStagedWithNothingStagedRefusesActionably(t *testing.T) {
+	repo := initUnbornReviewCLIRepo(t)
+	writeUnbornReviewCandidate(t, repo)
+
+	err := RunReviewFacadeStart([]string{"--cwd", repo, "--projection", "staged"}, io.Discard)
+	if err == nil || !strings.Contains(err.Error(), "git add") {
+		t.Fatalf("unborn nothing-staged start error = %v, want actionable staging guidance", err)
+	}
+}
+
+func TestReviewFacadeUnbornReceiptDeniesFirstPublicationGates(t *testing.T) {
+	repo := initUnbornReviewCLIRepo(t)
+	writeUnbornReviewCandidate(t, repo)
+	runReviewCLIGit(t, repo, "add", "--", "candidate.go", "candidate.md")
+
+	var output bytes.Buffer
+	if err := RunReviewFacadeStart([]string{"--cwd", repo, "--projection", "staged"}, &output); err != nil {
+		t.Fatalf("unborn staged review start: %v", err)
+	}
+	var started ReviewFacadeStartResult
+	if err := json.Unmarshal(output.Bytes(), &started); err != nil {
+		t.Fatal(err)
+	}
+	finalizeUnbornFacadeReview(t, repo, started)
+	runReviewCLIGit(t, repo, "commit", "-qm", "first commit")
+	branch := strings.TrimSpace(runReviewCLIGit(t, repo, "symbolic-ref", "--short", "HEAD"))
+	configureCLIReviewPublicationRemote(t, repo, branch)
+
+	for _, gate := range []reviewtransaction.GateKind{reviewtransaction.GatePrePush, reviewtransaction.GatePrePR} {
+		output.Reset()
+		err := RunReviewFacadeValidate([]string{"--cwd", repo, "--lineage", started.LineageID, "--gate", string(gate), "--base-ref", "origin/" + branch}, &output)
+		if err == nil {
+			t.Fatalf("%s from an empty-base receipt must be denied\n%s", gate, output.String())
+		}
+		if combined := output.String() + err.Error(); !strings.Contains(combined, "first publication") {
+			t.Fatalf("%s denial = %v, want explicit first-publication denial\n%s", gate, err, output.String())
+		}
+	}
+}
+
+func TestReviewFacadeExistingRemoteEmptyCommitAllowsPublicationGates(t *testing.T) {
+	repo := initUnbornReviewCLIRepo(t)
+	runReviewCLIGit(t, repo, "commit", "--allow-empty", "-qm", "empty base")
+	branch := strings.TrimSpace(runReviewCLIGit(t, repo, "symbolic-ref", "--short", "HEAD"))
+	configureCLIReviewPublicationRemote(t, repo, branch)
+	writeUnbornReviewCandidate(t, repo)
+	runReviewCLIGit(t, repo, "add", "--", "candidate.go", "candidate.md")
+	var output bytes.Buffer
+	if err := RunReviewFacadeStart([]string{"--cwd", repo, "--projection", "staged"}, &output); err != nil {
+		t.Fatal(err)
+	}
+	var started ReviewFacadeStartResult
+	if err := json.Unmarshal(output.Bytes(), &started); err != nil {
+		t.Fatal(err)
+	}
+	finalizeUnbornFacadeReview(t, repo, started)
+	runReviewCLIGit(t, repo, "commit", "-qm", "deliver reviewed candidate")
+	for _, gate := range []reviewtransaction.GateKind{reviewtransaction.GatePrePush, reviewtransaction.GatePrePR} {
+		output.Reset()
+		if err := RunReviewFacadeValidate([]string{"--cwd", repo, "--lineage", started.LineageID, "--gate", string(gate), "--base-ref", "origin/" + branch}, &output); err != nil {
+			t.Fatalf("%s from existing empty commit: %v\n%s", gate, err, output.String())
+		}
+	}
+}

--- a/internal/reviewtransaction/compact_gate.go
+++ b/internal/reviewtransaction/compact_gate.go
@@ -189,6 +189,15 @@ func EvaluateCompactGate(ctx context.Context, repo string, receipt CompactReceip
 	if receipt.TerminalState == TerminalEscalated {
 		return NativeGateEvaluation{Result: GateEscalated, Reason: nativeGateReason(GateEscalated)}
 	}
+	if (input.Gate == GatePrePush || input.Gate == GatePrePR) && record.State.InitialSnapshot.Kind == TargetCurrentChanges {
+		emptyTree, emptyTreeErr := (SnapshotBuilder{Repo: repo}).emptyTree(ctx)
+		if emptyTreeErr != nil {
+			return invalid("repository empty tree cannot be derived: "+emptyTreeErr.Error(), emptyTreeErr)
+		}
+		if record.State.InitialSnapshot.UnbornHead && record.State.InitialSnapshot.BaseTree == emptyTree {
+			return invalid("first publication from an empty-base review receipt is not supported")
+		}
+	}
 	request, nextSliceIntended, err := buildCompactGateRequest(ctx, repo, record.State, input)
 	if err != nil && input.Gate == GatePrePush && record.State.Recovery != nil && record.State.InitialSnapshot.Kind == TargetCurrentChanges {
 		// A scope_changed recovery successor created after its predecessor's
@@ -479,7 +488,7 @@ func buildCompactGateRequestWithPushBase(ctx context.Context, repo string, state
 			request.Target = Target{Kind: TargetBaseWorkspaceOverlay, Projection: projection, BaseRef: current.BaseTree, IntendedUntracked: intended}
 			break
 		}
-		headTree, err := (SnapshotBuilder{Repo: repo}).resolveTree(ctx, "HEAD")
+		headTree, _, err := (SnapshotBuilder{Repo: repo}).resolveCurrentChangesBase(ctx, projection)
 		if err != nil {
 			return GateRequest{}, nil, err
 		}

--- a/internal/reviewtransaction/snapshot.go
+++ b/internal/reviewtransaction/snapshot.go
@@ -44,6 +44,7 @@ type Target struct {
 type Snapshot struct {
 	Kind                   TargetKind `json:"kind"`
 	Projection             Projection `json:"projection,omitempty"`
+	UnbornHead             bool       `json:"unborn_head,omitempty"`
 	BaseTree               string     `json:"base_tree"`
 	CandidateTree          string     `json:"candidate_tree"`
 	PathsDigest            string     `json:"paths_digest"`
@@ -55,7 +56,8 @@ type Snapshot struct {
 }
 
 type SnapshotBuilder struct {
-	Repo string
+	Repo       string
+	unbornHead bool
 }
 
 var exactObjectPattern = regexp.MustCompile(`^[0-9a-fA-F]{40}(?:[0-9a-fA-F]{24})?$`)
@@ -173,6 +175,7 @@ func (builder SnapshotBuilder) build(ctx context.Context, target Target, allowSt
 	identity := snapshotIdentityForProjection(target.Kind, projection, baseTree, candidateTree, pathsDigest, untrackedProof, intended, ledgerIDs)
 	return Snapshot{
 		Kind: target.Kind, Projection: projection, BaseTree: baseTree, CandidateTree: candidateTree,
+		UnbornHead:  builder.unbornHead,
 		PathsDigest: pathsDigest, IntendedUntracked: intended,
 		IntendedUntrackedProof: untrackedProof, LedgerIDs: ledgerIDs,
 		Paths: paths, Identity: identity,
@@ -539,11 +542,12 @@ func canonicalRepositoryPath(path string) (string, error) {
 	return filepath.Clean(resolved), nil
 }
 
-func (builder SnapshotBuilder) buildCurrentChanges(ctx context.Context, intended []string, allowStagedIntended bool, projection Projection) (string, string, string, error) {
-	baseTree, err := builder.resolveTree(ctx, "HEAD")
+func (builder *SnapshotBuilder) buildCurrentChanges(ctx context.Context, intended []string, allowStagedIntended bool, projection Projection) (string, string, string, error) {
+	baseTree, unborn, err := builder.resolveCurrentChangesBase(ctx, projection)
 	if err != nil {
 		return "", "", "", err
 	}
+	builder.unbornHead = unborn
 	indexPathOutput, err := runGit(ctx, builder.Repo, nil, nil, "rev-parse", "--git-path", "index")
 	if err != nil {
 		return "", "", "", fmt.Errorf("locate real index: %w", err)
@@ -553,7 +557,8 @@ func (builder SnapshotBuilder) buildCurrentChanges(ctx context.Context, intended
 		indexPath = filepath.Join(builder.Repo, indexPath)
 	}
 	indexContent, err := os.ReadFile(indexPath)
-	if err != nil {
+	missingIndex := errors.Is(err, os.ErrNotExist)
+	if err != nil && !missingIndex {
 		return "", "", "", fmt.Errorf("read real index: %w", err)
 	}
 
@@ -589,13 +594,20 @@ func (builder SnapshotBuilder) buildCurrentChanges(ctx context.Context, intended
 	}
 	tempIndex := temp.Name()
 	defer os.Remove(tempIndex)
-	if _, err := temp.Write(indexContent); err != nil {
-		return "", "", "", err
-	}
 	if err := temp.Close(); err != nil {
 		return "", "", "", err
 	}
 	env := []string{"GIT_INDEX_FILE=" + tempIndex}
+	if missingIndex {
+		if err := os.Remove(tempIndex); err != nil {
+			return "", "", "", err
+		}
+		if _, err := runGit(ctx, builder.Repo, env, nil, "read-tree", "--empty"); err != nil {
+			return "", "", "", err
+		}
+	} else if err := os.WriteFile(tempIndex, indexContent, 0o600); err != nil {
+		return "", "", "", err
+	}
 	if projection != ProjectionStaged {
 		if _, err := runGit(ctx, builder.Repo, env, nil, "add", "-u", "--", "."); err != nil {
 			return "", "", "", err
@@ -612,6 +624,9 @@ func (builder SnapshotBuilder) buildCurrentChanges(ctx context.Context, intended
 		return "", "", "", err
 	}
 	candidateTree := strings.TrimSpace(string(candidateOutput))
+	if unborn && candidateTree == baseTree {
+		return "", "", "", errors.New("unborn repository has no staged changes; stage the review candidate with git add")
+	}
 	if allowStagedIntended && projection != ProjectionStaged {
 		if _, err := runGit(ctx, builder.Repo, nil, nil, "diff", "--cached", "--quiet", candidateTree, "--"); err != nil {
 			return "", "", "", errors.New("staged tree does not exactly match the complete reviewed candidate")
@@ -622,6 +637,43 @@ func (builder SnapshotBuilder) buildCurrentChanges(ctx context.Context, intended
 		return "", "", "", err
 	}
 	return baseTree, candidateTree, proof, nil
+}
+
+func (builder SnapshotBuilder) resolveCurrentChangesBase(ctx context.Context, projection Projection) (string, bool, error) {
+	baseTree, headErr := builder.resolveTree(ctx, "HEAD")
+	if headErr == nil || projection != ProjectionStaged {
+		return baseTree, false, headErr
+	}
+
+	refOutput, err := runGit(ctx, builder.Repo, nil, nil, "symbolic-ref", "--quiet", "HEAD")
+	if err != nil {
+		return "", false, headErr
+	}
+	ref := strings.TrimSpace(string(refOutput))
+	if !strings.HasPrefix(ref, "refs/heads/") || strings.TrimPrefix(ref, "refs/heads/") == "" {
+		return "", false, headErr
+	}
+	if _, err := runGit(ctx, builder.Repo, nil, nil, "show-ref", "--verify", "--quiet", "--", ref); err == nil {
+		return "", false, headErr
+	} else {
+		var commandErr *GitCommandError
+		if !errors.As(err, &commandErr) || commandErr.ExitCode != 1 {
+			return "", false, err
+		}
+	}
+	emptyTree, err := builder.emptyTree(ctx)
+	if err != nil {
+		return "", false, err
+	}
+	return emptyTree, true, nil
+}
+
+func (builder SnapshotBuilder) emptyTree(ctx context.Context) (string, error) {
+	output, err := runGit(ctx, builder.Repo, nil, []byte{}, "mktree")
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(output)), nil
 }
 
 func (builder SnapshotBuilder) resolveExactRevision(ctx context.Context, revision string) (string, string, error) {

--- a/internal/reviewtransaction/snapshot_test.go
+++ b/internal/reviewtransaction/snapshot_test.go
@@ -1,7 +1,9 @@
 package reviewtransaction
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -725,6 +727,147 @@ func TestBaseWorkspaceOverlayFreezesFullBoundaryWithoutMutation(t *testing.T) {
 	}
 }
 
+func TestSnapshotBuilderCurrentChangesSupportsUnbornHeadStagedProjection(t *testing.T) {
+	requireSnapshotGit(t)
+	repo := initUnbornSnapshotRepo(t)
+	writeSnapshotFile(t, repo, "candidate.txt", "reviewed\n")
+	writeSnapshotFile(t, repo, "nested/inner.txt", "inner\n")
+	gitSnapshot(t, repo, "add", "--", "candidate.txt", "nested/inner.txt")
+	expectedCandidate := strings.TrimSpace(gitSnapshot(t, repo, "write-tree"))
+	indexPath := strings.TrimSpace(gitSnapshot(t, repo, "rev-parse", "--git-path", "index"))
+	if !filepath.IsAbs(indexPath) {
+		indexPath = filepath.Join(repo, indexPath)
+	}
+	indexBefore, err := os.ReadFile(indexPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	snapshot, err := (SnapshotBuilder{Repo: repo}).Build(context.Background(), Target{
+		Kind: TargetCurrentChanges, Projection: ProjectionStaged, IntendedUntracked: []string{},
+	})
+	if err != nil {
+		t.Fatalf("Build(unborn staged) error = %v", err)
+	}
+	if want := gitSnapshotEmptyTree(t, repo); snapshot.BaseTree != want {
+		t.Fatalf("BaseTree = %q, want repository-native empty tree %q", snapshot.BaseTree, want)
+	}
+	if snapshot.CandidateTree != expectedCandidate {
+		t.Fatalf("CandidateTree = %q, want staged index tree %q", snapshot.CandidateTree, expectedCandidate)
+	}
+	if want := []string{"candidate.txt", "nested/inner.txt"}; !reflect.DeepEqual(snapshot.Paths, want) {
+		t.Fatalf("Paths = %v, want every staged candidate path %v", snapshot.Paths, want)
+	}
+	indexAfter, err := os.ReadFile(indexPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(indexAfter, indexBefore) {
+		t.Fatal("snapshot construction mutated the real index")
+	}
+}
+
+func TestSnapshotBuilderUnbornHeadWithNothingStagedRefusesActionably(t *testing.T) {
+	requireSnapshotGit(t)
+	repo := initUnbornSnapshotRepo(t)
+	writeSnapshotFile(t, repo, "untracked.txt", "not staged\n")
+	indexPath := strings.TrimSpace(gitSnapshot(t, repo, "rev-parse", "--git-path", "index"))
+	if !filepath.IsAbs(indexPath) {
+		indexPath = filepath.Join(repo, indexPath)
+	}
+	if _, err := os.Stat(indexPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("real index unexpectedly exists before snapshot construction: %v", err)
+	}
+
+	_, err := (SnapshotBuilder{Repo: repo}).Build(context.Background(), Target{
+		Kind: TargetCurrentChanges, Projection: ProjectionStaged, IntendedUntracked: []string{},
+	})
+	if err == nil || !strings.Contains(err.Error(), "git add") {
+		t.Fatalf("unborn empty-candidate error = %v, want actionable staging guidance", err)
+	}
+	var commandErr *GitCommandError
+	if errors.As(err, &commandErr) {
+		t.Fatalf("unborn empty-candidate refusal surfaced a raw git failure: %v", err)
+	}
+	if _, err := os.Stat(indexPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("snapshot construction created the real index: %v", err)
+	}
+}
+
+func TestSnapshotBuilderRealGitFailuresAreNotTreatedAsUnborn(t *testing.T) {
+	requireSnapshotGit(t)
+	stagedTarget := Target{Kind: TargetCurrentChanges, Projection: ProjectionStaged, IntendedUntracked: []string{}}
+	t.Run("workspace projection", func(t *testing.T) {
+		repo := initUnbornSnapshotRepo(t)
+		writeSnapshotFile(t, repo, "candidate.txt", "reviewed\n")
+		gitSnapshot(t, repo, "add", "--", "candidate.txt")
+		_, err := (SnapshotBuilder{Repo: repo}).Build(context.Background(), Target{
+			Kind: TargetCurrentChanges, Projection: ProjectionWorkspace, IntendedUntracked: []string{},
+		})
+		var commandErr *GitCommandError
+		if err == nil || !errors.As(err, &commandErr) {
+			t.Fatalf("unborn workspace error = %v, want the raw git failure", err)
+		}
+	})
+	t.Run("detached HEAD at missing object", func(t *testing.T) {
+		repo := initUnbornSnapshotRepo(t)
+		writeSnapshotFile(t, repo, "candidate.txt", "reviewed\n")
+		gitSnapshot(t, repo, "add", "--", "candidate.txt")
+		if err := os.WriteFile(filepath.Join(repo, ".git", "HEAD"), []byte(strings.Repeat("1", 40)+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		_, err := (SnapshotBuilder{Repo: repo}).Build(context.Background(), stagedTarget)
+		var commandErr *GitCommandError
+		if err == nil || !errors.As(err, &commandErr) {
+			t.Fatalf("detached missing-object error = %v, want the raw git failure", err)
+		}
+	})
+	t.Run("existing branch ref at missing object", func(t *testing.T) {
+		repo := initUnbornSnapshotRepo(t)
+		writeSnapshotFile(t, repo, "candidate.txt", "reviewed\n")
+		gitSnapshot(t, repo, "add", "--", "candidate.txt")
+		ref := strings.TrimSpace(gitSnapshot(t, repo, "symbolic-ref", "HEAD"))
+		refPath := filepath.Join(repo, ".git", filepath.FromSlash(ref))
+		if err := os.MkdirAll(filepath.Dir(refPath), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(refPath, []byte(strings.Repeat("2", 40)+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		_, err := (SnapshotBuilder{Repo: repo}).Build(context.Background(), stagedTarget)
+		var commandErr *GitCommandError
+		if err == nil || !errors.As(err, &commandErr) {
+			t.Fatalf("existing-but-unresolvable branch error = %v, want the raw git failure", err)
+		}
+	})
+	t.Run("non-local symbolic ref", func(t *testing.T) {
+		repo := initUnbornSnapshotRepo(t)
+		writeSnapshotFile(t, repo, "candidate.txt", "reviewed\n")
+		gitSnapshot(t, repo, "add", "--", "candidate.txt")
+		if err := os.WriteFile(filepath.Join(repo, ".git", "HEAD"), []byte("ref: refs/remotes/origin/main\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		_, err := (SnapshotBuilder{Repo: repo}).Build(context.Background(), stagedTarget)
+		var commandErr *GitCommandError
+		if err == nil || !errors.As(err, &commandErr) {
+			t.Fatalf("non-local symbolic HEAD error = %v, want the raw git failure", err)
+		}
+	})
+	t.Run("malformed HEAD", func(t *testing.T) {
+		repo := initUnbornSnapshotRepo(t)
+		writeSnapshotFile(t, repo, "candidate.txt", "reviewed\n")
+		gitSnapshot(t, repo, "add", "--", "candidate.txt")
+		if err := os.WriteFile(filepath.Join(repo, ".git", "HEAD"), []byte("not a ref\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		_, err := (SnapshotBuilder{Repo: repo}).Build(context.Background(), stagedTarget)
+		var commandErr *GitCommandError
+		if err == nil || !errors.As(err, &commandErr) {
+			t.Fatalf("malformed HEAD error = %v, want the raw git failure", err)
+		}
+	})
+}
+
 func initSnapshotRepo(t *testing.T) string {
 	t.Helper()
 	repo := t.TempDir()
@@ -736,6 +879,26 @@ func initSnapshotRepo(t *testing.T) string {
 	gitSnapshot(t, repo, "add", "--", "tracked.txt", "deleted.txt")
 	gitSnapshot(t, repo, "commit", "-m", "base")
 	return repo
+}
+
+func initUnbornSnapshotRepo(t *testing.T) string {
+	t.Helper()
+	repo := t.TempDir()
+	gitSnapshot(t, repo, "init")
+	gitSnapshot(t, repo, "config", "user.email", "snapshot@example.com")
+	gitSnapshot(t, repo, "config", "user.name", "Snapshot Test")
+	return repo
+}
+
+func gitSnapshotEmptyTree(t *testing.T, repo string) string {
+	t.Helper()
+	cmd := exec.Command("git", "-C", repo, "mktree")
+	cmd.Stdin = strings.NewReader("")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git mktree: %v\n%s", err, output)
+	}
+	return strings.TrimSpace(string(output))
 }
 
 func requireSnapshotGit(t *testing.T) {


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1341

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

Supports staged bounded review before a repository's first commit by deriving Git's empty tree for a proven unborn local branch and preserving explicit `Snapshot.UnbornHead` provenance. Existing remote empty-tree commits remain publishable, while true unborn first publication, empty staged candidates, corrupt HEAD states, and unsupported workspace projection fail closed.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/reviewtransaction/snapshot.go` | Captures staged candidates from a missing index on a proven unborn branch without mutating the real index and records unborn provenance. |
| `internal/reviewtransaction/compact_gate.go` | Denies first-publication gates only when explicit unborn provenance and the empty-tree base both match. |
| `internal/reviewtransaction/snapshot_test.go` | Covers valid unborn staged capture, actionable empty candidates, and corrupt or unsupported HEAD states. |
| `internal/cli/review_unborn_test.go` | Covers the staged unborn lifecycle and distinguishes true unborn publication from an existing remote empty-tree commit. |

---

## 🧪 Test Plan

**Focused Tests**
```bash
go test ./internal/reviewtransaction -run 'TestSnapshotBuilder(CurrentChangesSupportsUnbornHeadStagedProjection|UnbornHeadWithNothingStagedRefusesActionably|RealGitFailuresAreNotTreatedAsUnborn)$' -count=1
go test ./internal/cli -run 'TestReviewFacade(UnbornHeadStagedLifecycle|UnbornHeadStagedWithNothingStagedRefusesActionably|UnbornReceiptDeniesFirstPublicationGates|ExistingRemoteEmptyCommitAllowsPublicationGates)$' -count=1
```

**Affected Packages and Full Repository**
```bash
go test ./internal/reviewtransaction ./internal/cli
go test ./...
git diff --check
```

- [x] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Manually tested locally

All five recorded candidate verification commands passed. The correction proves existing remote empty-tree commits publish successfully, true unborn receipts deny first publication, and malformed HEAD cases remain fail-closed.

---

## 🤖 Automated Checks

The following checks run automatically on this PR:

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | PR should stay within 400 changed lines (`additions + deletions`) or use `size:exception` |
| Check Issue Reference | ⏳ | PR body must contain `Closes/Fixes/Resolves #N` |
| Check Issue Has `status:approved` | ⏳ | Linked issue must have been approved before work began |
| Check PR Has `type:*` Label | ⏳ | Exactly one `type:*` label must be applied |
| Unit Tests | ⏳ | `go test ./...` must pass |
| E2E Tests | ⏳ | `cd e2e && ./docker-test.sh` must pass |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [ ] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

Bounded review receipt: `review-bc6f483b7e3a0e8d`; corrected frozen finding: `R4-001`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for reviewing staged changes in repositories without an initial commit.
  * Preserved accurate empty-repository snapshots and candidate file tracking.
  * Allowed post-apply and pre-commit validation during initial review workflows.
  * Allowed publication validation when the remote already has an initial empty commit.

* **Bug Fixes**
  * Added clear guidance to stage files when no changes are available for review.
  * Prevented first publication from being incorrectly approved when no prior base exists.
  * Improved handling of repositories with missing Git index files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->