### PR TITLE
fix(sdd): preserve compact remediation budget

### DIFF
--- a/internal/sddstatus/bounded_review_test.go
+++ b/internal/sddstatus/bounded_review_test.go
@@ -993,23 +993,49 @@ func TestResolveEngramRejectsForeignCompactAuthorityForStaleVerifyEvidence(t *te
 	}
 }
 
-func TestResolveKeepsFailedVerdictWithCurrentSpecTotalsMismatchOnRemediationRouting(t *testing.T) {
+func TestResolveGrantsCompactRemediationBudgetForFailedVerdictWithIncompleteScenarios(t *testing.T) {
 	root := t.TempDir()
 	changeRoot := seedReadyChange(t, root, "thin", "- [x] 1.1 Done\n")
 	write(t, filepath.Join(changeRoot, "specs", "auth", "spec.md"), "### Requirement: Auth\n#### Scenario: Valid login\n#### Scenario: Added after verification\n")
 	write(t, filepath.Join(changeRoot, "verify-report.md"), boundedVerifyEnvelope(shaID("d"), "fail"))
 	writeApprovedCompactAuthorityForChange(t, root, changeRoot, "compact-thin")
+	store, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), root, "compact-thin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	before, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	status, err := Resolve(ResolveOptions{CWD: root, ChangeName: "thin"})
 	if err != nil {
 		t.Fatalf("Resolve() error = %v", err)
 	}
-	if status.Dependencies.Verify != DependencyBlocked || status.NextRecommended != "resolve-review" {
-		t.Fatalf("verify=%q next=%q, want blocked/resolve-review for failed verdict", status.Dependencies.Verify, status.NextRecommended)
+	if status.Dependencies.Verify != DependencyBlocked || status.NextRecommended != "remediate" {
+		t.Fatalf("verify=%q next=%q, want blocked/remediate for failed verdict", status.Dependencies.Verify, status.NextRecommended)
 	}
-	want := "verify evidence cannot enter remediation: verify result total 1 does not match actual scenario count 2; bounded review transaction is missing"
-	if !strings.Contains(strings.Join(status.BlockedReasons, "\n"), want) {
-		t.Fatalf("BlockedReasons = %v, want containing %q", status.BlockedReasons, want)
+	wantBudget := before.State.CorrectionBudget - before.State.CumulativeCorrectionLines
+	if !status.RemediationState.Required || status.RemediationState.CorrectionBudget != wantBudget || wantBudget <= 0 || status.RemediationState.LineageID != "compact-thin" || status.RemediationState.FailedEvidenceRevision != shaID("d") {
+		t.Fatalf("RemediationState = %#v, want transaction-bound nonzero compact budget", status.RemediationState)
+	}
+	after, err := store.Load()
+	if err != nil || after.Revision != before.Revision {
+		t.Fatalf("compact authority changed during status resolution: before=%q after=%q err=%v", before.Revision, after.Revision, err)
+	}
+}
+
+func TestResolveRejectsCompactRemediationWhenFrozenBudgetIsZero(t *testing.T) {
+	compact := reviewtransaction.CompactState{
+		LineageID: "compact-thin", Generation: 1, State: reviewtransaction.StateApproved,
+		CorrectionBudget: 2, CumulativeCorrectionLines: 2,
+	}
+	state := resolveBoundedRemediation(true, verifyResultEvaluation{
+		EvidenceRevision: shaID("d"), Reason: "scenarios are incomplete",
+	}, nil, &compact, "bounded review transaction is missing", "")
+
+	if state.Required || !strings.Contains(state.Reason, "compact review authority has no correction budget") {
+		t.Fatalf("RemediationState = %#v, want fail-closed exhausted budget", state)
 	}
 }
 

--- a/internal/sddstatus/review_binding_test.go
+++ b/internal/sddstatus/review_binding_test.go
@@ -475,7 +475,7 @@ func TestBoundReviewRoutesStaleVerifyEvidenceToVerify(t *testing.T) {
 	}
 }
 
-func TestBoundReviewKeepsFailedVerdictWithCurrentSpecTotalsMismatchOnRemediationRouting(t *testing.T) {
+func TestBoundReviewGrantsCompactRemediationBudgetForFailedVerdictWithIncompleteScenarios(t *testing.T) {
 	root := t.TempDir()
 	changeRoot := seedReadyChange(t, root, "thin", "- [x] 1.1 Done\n")
 	write(t, filepath.Join(changeRoot, "specs", "auth", "spec.md"), "### Requirement: Binding\n#### Scenario: Exact authority\n#### Scenario: Added after verification\n")
@@ -489,12 +489,11 @@ func TestBoundReviewKeepsFailedVerdictWithCurrentSpecTotalsMismatchOnRemediation
 	if err != nil {
 		t.Fatal(err)
 	}
-	if status.Dependencies.Verify != DependencyBlocked || status.NextRecommended != "resolve-review" {
-		t.Fatalf("verify=%q next=%q, want blocked/resolve-review for failed verdict", status.Dependencies.Verify, status.NextRecommended)
+	if status.Dependencies.Verify != DependencyBlocked || status.NextRecommended != "remediate" {
+		t.Fatalf("verify=%q next=%q, want blocked/remediate for failed verdict", status.Dependencies.Verify, status.NextRecommended)
 	}
-	want := "verify evidence cannot enter remediation: verify result total 1 does not match actual scenario count 2; bounded review transaction is missing"
-	if !strings.Contains(strings.Join(status.BlockedReasons, "\n"), want) {
-		t.Fatalf("BlockedReasons = %v, want containing %q", status.BlockedReasons, want)
+	if !status.RemediationState.Required || status.RemediationState.CorrectionBudget <= 0 || status.RemediationState.LineageID != "approved-thin" || status.RemediationState.FailedEvidenceRevision != shaID("a") {
+		t.Fatalf("RemediationState = %#v, want transaction-bound nonzero compact budget", status.RemediationState)
 	}
 }
 

--- a/internal/sddstatus/review_gate.go
+++ b/internal/sddstatus/review_gate.go
@@ -179,9 +179,38 @@ func readReviewTransaction(path, content string) (*reviewtransaction.Transaction
 	return &transaction, ""
 }
 
-func resolveBoundedRemediation(required bool, verify verifyResultEvaluation, transaction *reviewtransaction.Transaction, transactionReason, applyProgress string) RemediationState {
+func resolveBoundedRemediation(required bool, verify verifyResultEvaluation, transaction *reviewtransaction.Transaction, compact *reviewtransaction.CompactState, transactionReason, applyProgress string) RemediationState {
 	if !required {
 		return RemediationState{}
+	}
+	if transaction == nil && compact != nil {
+		if verify.EvidenceRevision == "" {
+			return RemediationState{Reason: "compact remediation requires a failed evidence revision"}
+		}
+		remainingBudget := compact.CorrectionBudget - compact.CumulativeCorrectionLines
+		if remainingBudget <= 0 {
+			return RemediationState{Reason: "compact review authority has no correction budget remaining"}
+		}
+		if len(compact.CorrectionAttempts) >= reviewtransaction.MaxCompactCorrectionAttempts {
+			return RemediationState{Reason: "compact review authority has exhausted its correction attempts"}
+		}
+		state := RemediationState{
+			Required:               true,
+			FailedEvidenceRevision: verify.EvidenceRevision,
+			LineageID:              compact.LineageID,
+			Generation:             compact.Generation,
+			FixBatch:               len(compact.CorrectionAttempts) + 1,
+			CorrectionBudget:       remainingBudget,
+			Reason:                 fmt.Sprintf("verify evidence requires bounded compact remediation for %s: %s", verify.EvidenceRevision, verify.Reason),
+		}
+		binding := RemediationBinding{LineageID: state.LineageID, Generation: state.Generation, FixBatch: state.FixBatch}
+		evaluation := parseRemediationResult(applyProgress, verify.EvidenceRevision, binding)
+		state.Complete = evaluation.Complete
+		state.Required = !evaluation.Complete
+		if evaluation.Complete {
+			state.Reason = ""
+		}
+		return state
 	}
 	if transaction == nil {
 		return RemediationState{Reason: fmt.Sprintf("verify evidence cannot enter remediation: %s; %s", verify.Reason, transactionReason)}
@@ -235,8 +264,35 @@ func resolveBoundedRemediation(required bool, verify verifyResultEvaluation, tra
 }
 
 type reviewAuthorityEvaluation struct {
-	Result reviewtransaction.GateResult
-	Reason string
+	Result       reviewtransaction.GateResult
+	Reason       string
+	CompactState *reviewtransaction.CompactState
+}
+
+func resolveCompactRemediationAuthority(ctx context.Context, repo, change string, bindingPresent, required bool, receiptPath, receiptContent string) *reviewtransaction.CompactState {
+	if !required {
+		return nil
+	}
+	if bindingPresent {
+		binding, _, err := validateBoundReview(ctx, repo, change)
+		if err != nil {
+			return nil
+		}
+		store, err := reviewtransaction.CompactAuthoritativeStore(ctx, repo, binding.Lineage)
+		if err != nil {
+			return nil
+		}
+		record, err := store.Load()
+		if err != nil || record.Revision != binding.AuthorityRevision || record.State.State != reviewtransaction.StateApproved {
+			return nil
+		}
+		return &record.State
+	}
+	evaluation := resolveReviewAuthority(ctx, repo, receiptPath, receiptContent, change)
+	if evaluation.Result != reviewtransaction.GateAllow {
+		return nil
+	}
+	return evaluation.CompactState
 }
 
 func applyReviewGate(
@@ -268,6 +324,7 @@ func resolveReviewAuthority(ctx context.Context, repo, receiptPath, receiptConte
 		}
 	}
 	var evaluation reviewtransaction.NativeGateEvaluation
+	var compactState *reviewtransaction.CompactState
 	if reviewtransaction.CompactReceiptSchemaOf(receiptPayload) == reviewtransaction.CompactReceiptSchema {
 		receipt, err := reviewtransaction.ParseCompactReceipt(receiptPayload)
 		if err != nil {
@@ -289,6 +346,7 @@ func resolveReviewAuthority(ctx context.Context, repo, receiptPath, receiptConte
 				}
 				return reviewAuthorityEvaluation{Result: reviewtransaction.GateInvalidated, Reason: reason}
 			}
+			compactState = &record.State
 		}
 		evaluation = reviewtransaction.EvaluateCompactGate(ctx, repo, receipt, reviewtransaction.NativeGateRequestInput{
 			Gate: reviewtransaction.GatePostApply, LineageID: receipt.LineageID,
@@ -308,7 +366,7 @@ func resolveReviewAuthority(ctx context.Context, repo, receiptPath, receiptConte
 	}
 	switch evaluation.Result {
 	case reviewtransaction.GateAllow:
-		return reviewAuthorityEvaluation{Result: evaluation.Result, Reason: "approved receipt exactly matches authoritative native state and the current repository"}
+		return reviewAuthorityEvaluation{Result: evaluation.Result, Reason: "approved receipt exactly matches authoritative native state and the current repository", CompactState: compactState}
 	case reviewtransaction.GateScopeChanged:
 		return reviewAuthorityEvaluation{Result: evaluation.Result, Reason: "review scope changed; maintainer must create an explicit new lineage without reusing this budget"}
 	case reviewtransaction.GateEscalated:

--- a/internal/sddstatus/status.go
+++ b/internal/sddstatus/status.go
@@ -133,6 +133,7 @@ type RemediationState struct {
 	LineageID              string `json:"lineageId"`
 	Generation             int    `json:"generation"`
 	FixBatch               int    `json:"fixBatch"`
+	CorrectionBudget       int    `json:"correctionBudget,omitempty"`
 	Reason                 string `json:"reason"`
 }
 
@@ -323,10 +324,16 @@ func Resolve(options ResolveOptions) (Status, error) {
 			blockedReasons = append(blockedReasons, evaluation.Reason)
 		}
 	}
+	remediationRequired := staleAllowAuthority == nil && artifacts["verifyReport"] == ArtifactDone && !verifyResult.Passing && applyState == ApplyAllDone
+	compactRemediation := resolveCompactRemediationAuthority(
+		context.Background(), workspaceRoot, changeName, bindingPresent, remediationRequired && reviewState == nil,
+		firstPath(artifactPaths.ReviewReceipt), "",
+	)
 	remediationState := resolveBoundedRemediation(
-		staleAllowAuthority == nil && artifacts["verifyReport"] == ArtifactDone && !verifyResult.Passing && applyState == ApplyAllDone,
+		remediationRequired,
 		verifyResult,
 		reviewState,
+		compactRemediation,
 		reviewStateReason,
 		readText(firstPath(artifactPaths.ApplyProgress)),
 	)
@@ -522,10 +529,16 @@ func resolveEngramStatus(workspaceRoot string, requestedChange string, includeIn
 			blockedReasons = append(blockedReasons, evaluation.Reason)
 		}
 	}
+	remediationRequired := staleAllowAuthority == nil && artifacts["verifyReport"] == ArtifactDone && !verifyResult.Passing && applyState == ApplyAllDone
+	compactRemediation := resolveCompactRemediationAuthority(
+		context.Background(), workspaceRoot, changeName, false, remediationRequired && reviewState == nil,
+		"", artifactsByType["review/receipt"].Content,
+	)
 	remediationState := resolveBoundedRemediation(
-		staleAllowAuthority == nil && artifacts["verifyReport"] == ArtifactDone && !verifyResult.Passing && applyState == ApplyAllDone,
+		remediationRequired,
 		verifyResult,
 		reviewState,
+		compactRemediation,
 		reviewStateReason,
 		artifactsByType["apply-progress"].Content,
 	)


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1283

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

Allows SDD status to use validated approved compact review authority when a current failed verify report has incomplete scenarios. Bounded remediation reuses the frozen remaining correction budget and binds it to the existing lineage, generation, next fix batch, and failed evidence revision instead of reporting a missing legacy transaction or allocating a new budget.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/sddstatus/review_gate.go` | Resolves approved compact remediation authority and derives the remaining frozen budget and next bounded attempt. |
| `internal/sddstatus/status.go` | Exposes the transaction-bound correction budget and routes failed incomplete verification to remediation. |
| `internal/sddstatus/bounded_review_test.go` | Covers compact remediation routing, budget preservation, non-mutating status resolution, and exhausted-budget refusal. |
| `internal/sddstatus/review_binding_test.go` | Covers bound compact authority remediation with incomplete scenarios. |

---

## 🧪 Test Plan

**Focused Tests**
```bash
go test ./internal/sddstatus -run 'TestResolveGrantsCompactRemediationBudgetForFailedVerdictWithIncompleteScenarios|TestResolveRejectsCompactRemediationWhenFrozenBudgetIsZero|TestBoundReviewGrantsCompactRemediationBudgetForFailedVerdictWithIncompleteScenarios' -count=1
```

**Affected Package and Full Repository**
```bash
go test ./internal/sddstatus -count=1
go test ./... -count=1
git diff --check
```

- [x] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Manually tested locally

All four recorded candidate verification commands passed with zero failures.

---

## 🤖 Automated Checks

The following checks run automatically on this PR:

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | PR should stay within 400 changed lines (`additions + deletions`) or use `size:exception` |
| Check Issue Reference | ⏳ | PR body must contain `Closes/Fixes/Resolves #N` |
| Check Issue Has `status:approved` | ⏳ | Linked issue must have been approved before work began |
| Check PR Has `type:*` Label | ⏳ | Exactly one `type:*` label must be applied |
| Unit Tests | ⏳ | `go test ./...` must pass |
| E2E Tests | ⏳ | `cd e2e && ./docker-test.sh` must pass |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

Bounded review receipt: `review-108dbd92a1b9e973`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Failed reviews with incomplete scenarios can now proceed to bounded remediation.
  * Remediation details include a correction budget, authority lineage, and the related failed evidence revision.
  * Remediation is automatically blocked when the available correction budget is exhausted.
* **Bug Fixes**
  * Improved remediation routing and fail-closed behavior for failed verification results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->