### PR TITLE
fix(review): validate overlapping recovery composition

### DIFF
--- a/internal/reviewtransaction/compact_gate.go
+++ b/internal/reviewtransaction/compact_gate.go
@@ -250,7 +250,13 @@ func EvaluateCompactGate(ctx context.Context, repo string, receipt CompactReceip
 	validatePublicationRange := request.Gate == GatePrePush && (record.State.InitialSnapshot.Kind == TargetBaseDiff || bootstrapPublication) ||
 		record.State.InitialSnapshot.Kind == TargetBaseWorkspaceOverlay && (request.Gate == GatePrePush || request.Gate == GatePrePR)
 	if validatePublicationRange {
-		if err := validateReviewedPublicationRange(ctx, repo, record.State.GenesisPaths, resolvedPrePR); err != nil {
+		publicationGenesis := record.State.GenesisPaths
+		if record.State.Recovery != nil {
+			if chain, ok, chainErr := deriveCompactRecoveryBinding(ctx, repo, record.State); chainErr == nil && ok {
+				publicationGenesis = chain.GenesisPaths
+			}
+		}
+		if err := validateReviewedPublicationRange(ctx, repo, publicationGenesis, resolvedPrePR); err != nil {
 			return invalid(err.Error())
 		}
 	}
@@ -292,6 +298,10 @@ func EvaluateCompactGate(ctx context.Context, repo string, receipt CompactReceip
 	baseMismatch := snapshot.BaseTree != receipt.BaseTree && request.Target.Kind != TargetFixDiff && !compatibleAdvance
 	if strictBinding {
 		baseMismatch = snapshot.BaseTree != binding.BaseTree && !squashedFixDelivery
+	}
+	recoveryBinding, recoveryBound, recoveryErr := deriveCompactRecoveryBinding(ctx, repo, record.State)
+	if recoveryErr != nil {
+		return invalid("compact recovery binding cannot be derived during authorization")
 	}
 	// A scope_changed recovery successor freezes only its own pristine scope,
 	// so a delivery already covered by its receipt-bound predecessors would be
@@ -353,10 +363,22 @@ func EvaluateCompactGate(ctx context.Context, repo string, receipt CompactReceip
 	if loadErr != nil || snapshotErr != nil || finalUntrackedErr != nil || finalTrackedErr != nil || graphErr != nil || supersededErr != nil || finalSuperseded || finalRecord.Revision != record.Revision || !reflect.DeepEqual(finalSnapshot, snapshot) || !sameResolvedPrePRRefs(finalRefs, resolvedPrePR) {
 		return invalid("compact authority or repository target changed during final authorization")
 	}
-	if recoveryRebind != nil {
+	finalCompactGateAllowHook()
+	if recoveryBound {
 		finalChain, ok, chainErr := deriveCompactRecoveryBinding(ctx, repo, finalRecord.State)
-		if chainErr != nil || !ok || !reflect.DeepEqual(finalChain, *recoveryRebind) {
+		if chainErr != nil || !ok || !reflect.DeepEqual(finalChain, recoveryBinding) {
 			return invalid("compact authority or repository target changed during final authorization")
+		}
+		if recoveryRebind == nil && finalRefs != nil && (request.Gate == GatePrePush || request.Gate == GatePrePR) {
+			baseCommit := finalRefs.BaseCommit
+			if request.Gate == GatePrePush {
+				baseCommit = request.Target.BaseRef
+			}
+			leaf := finalChain.Members[len(finalChain.Members)-1]
+			direct := compactRecoveryBinding{Members: []CompactRecord{leaf}, BaseTree: leaf.State.InitialSnapshot.BaseTree}
+			if verifyCompactRecoveryDelivery(ctx, repo, direct, receipt.FinalCandidateTree, baseCommit, finalRefs.HeadCommit) != nil {
+				return invalid("compact recovery delivery changed during final authorization")
+			}
 		}
 	}
 	if request.Gate == GateRelease {
@@ -366,7 +388,6 @@ func EvaluateCompactGate(ctx context.Context, repo string, receipt CompactReceip
 			return invalid("release evidence changed during final authorization")
 		}
 	}
-	finalCompactGateAllowHook()
 	return NativeGateEvaluation{Result: GateAllow, Reason: nativeGateReason(GateAllow), Context: gateContext}
 }
 

--- a/internal/reviewtransaction/compact_recovery_binding.go
+++ b/internal/reviewtransaction/compact_recovery_binding.go
@@ -17,14 +17,16 @@ const CompactRecoveryBindingDomain = "gentle-ai.compact-recovery-binding/v1"
 // unbroken scope_changed recovery chain. Recovery successors always start as
 // pristine reviewing authorities, so a successor created after its
 // predecessor's delivery was committed can never restate the original base
-// tree, genesis paths, or fix delta on its own. The binding restores exactly
-// those gate inputs from the persisted, receipt-bound predecessors without
-// ever mutating any authority. It is derived gate evidence only.
+// tree, genesis paths, or fix delta on its own. A successor may also re-review
+// an exact suffix of its predecessor's candidate when that suffix is wholly
+// inside predecessor genesis. The binding restores exactly those gate inputs
+// from the persisted, receipt-bound predecessors without ever mutating any
+// authority. It is derived gate evidence only.
 type compactRecoveryBinding struct {
 	// Members are ordered root..leaf. Every member is a terminally approved
 	// compact authority whose receipt file matches its state, and every edge
-	// is a validated scope_changed recovery whose successor initial base tree
-	// equals its predecessor's final candidate tree.
+	// is a validated scope_changed recovery with either exact tree continuity
+	// or a Git-verified, scope-contracting overlap ending at the same candidate.
 	Members []CompactRecord
 	// BaseTree is the root member's reviewed delivery base.
 	BaseTree string
@@ -69,10 +71,22 @@ func deriveCompactRecoveryBinding(ctx context.Context, repo string, leaf Compact
 		if edgeErr := validateCompactRecoveryEdge(predecessor, current); edgeErr != nil {
 			return compactRecoveryBinding{}, false, edgeErr
 		}
-		if predecessor.State.State != StateApproved ||
-			current.InitialSnapshot.BaseTree != predecessor.State.CurrentSnapshot.CandidateTree ||
-			!compactRecoveryReceiptBound(store, predecessor) {
+		continuous := current.InitialSnapshot.BaseTree == predecessor.State.CurrentSnapshot.CandidateTree
+		overlapping := compactOverlappingRecoveryMember(predecessor.State, current)
+		if overlapping {
+			builder := SnapshotBuilder{Repo: repo}
+			if evidenceErr := builder.ValidateEvidence(ctx, predecessor.State.CurrentSnapshot); evidenceErr != nil {
+				return compactRecoveryBinding{}, false, evidenceErr
+			}
+			if evidenceErr := builder.ValidateEvidence(ctx, current.InitialSnapshot); evidenceErr != nil {
+				return compactRecoveryBinding{}, false, evidenceErr
+			}
+		}
+		if predecessor.State.State != StateApproved || (!continuous && !overlapping) {
 			break
+		}
+		if !compactRecoveryReceiptBound(store, predecessor) {
+			return compactRecoveryBinding{}, false, errors.New("recovery predecessor receipt does not match authority")
 		}
 		members = append([]CompactRecord{predecessor}, members...)
 		current = predecessor.State
@@ -94,6 +108,15 @@ func deriveCompactRecoveryBinding(ctx context.Context, repo string, leaf Compact
 		Members: members, BaseTree: members[0].State.InitialSnapshot.BaseTree,
 		GenesisPaths: union, FixDeltaHash: compactRecoveryBindingValuesHash("fix-delta", fixDeltas),
 	}, true, nil
+}
+
+func compactOverlappingRecoveryMember(predecessor, successor CompactState) bool {
+	return successor.State == StateApproved &&
+		snapshotsEqual(successor.InitialSnapshot, successor.CurrentSnapshot) &&
+		successor.InitialSnapshot.BaseTree != predecessor.CurrentSnapshot.CandidateTree &&
+		successor.InitialSnapshot.CandidateTree == predecessor.CurrentSnapshot.CandidateTree &&
+		len(successor.GenesisPaths) > 0 &&
+		pathsAreSubset(successor.GenesisPaths, predecessor.GenesisPaths) == nil
 }
 
 // compactRecoveryReceiptBound reports whether the persisted receipt file of a
@@ -142,9 +165,14 @@ func verifyCompactRecoveryDelivery(ctx context.Context, repo string, binding com
 		return err
 	}
 	previousTree, previousIndex := baseTree, -1
-	for _, member := range binding.Members {
+	for memberIndex, member := range binding.Members {
 		memberFinal := member.State.CurrentSnapshot.CandidateTree
 		if memberFinal == previousTree {
+			if member.State.InitialSnapshot.BaseTree != previousTree {
+				if err := verifyCompactOverlappingRecoveryMember(ctx, builder, commits, previousIndex, member.State); err != nil {
+					return err
+				}
+			}
 			continue
 		}
 		boundary := -1
@@ -153,6 +181,11 @@ func verifyCompactRecoveryDelivery(ctx context.Context, repo string, binding com
 				continue
 			}
 			if commits[index].Tree != memberFinal {
+				if memberIndex+1 < len(binding.Members) &&
+					compactOverlappingRecoveryMember(member.State, binding.Members[memberIndex+1].State) &&
+					commits[index].Tree == binding.Members[memberIndex+1].State.InitialSnapshot.BaseTree {
+					continue
+				}
 				return errors.New("publication commit does not match the recovery chain boundary")
 			}
 			boundary = index
@@ -182,6 +215,35 @@ func verifyCompactRecoveryDelivery(ctx context.Context, repo string, binding com
 	}
 	if previousTree != finalTree {
 		return errors.New("recovery chain final tree does not equal the delivered candidate")
+	}
+	return nil
+}
+
+func verifyCompactOverlappingRecoveryMember(ctx context.Context, builder SnapshotBuilder, commits []compactPrePRChainCommitProof, finalIndex int, member CompactState) error {
+	boundary := -1
+	for index := 0; index <= finalIndex; index++ {
+		if commits[index].ParentTree != member.InitialSnapshot.BaseTree {
+			continue
+		}
+		if boundary >= 0 {
+			return errors.New("overlapping recovery base tree is ambiguous in publication history")
+		}
+		boundary = index
+	}
+	if boundary < 0 {
+		return errors.New("overlapping recovery base tree is absent from publication history")
+	}
+	touched := []string{}
+	for index := boundary; index <= finalIndex; index++ {
+		paths, err := builder.changedPaths(ctx, commits[index].ParentTree, commits[index].Tree)
+		if err != nil {
+			return err
+		}
+		touched = append(touched, paths...)
+	}
+	touched, err := compactPrePRPathUnion(touched)
+	if err != nil || pathsAreSubset(touched, member.GenesisPaths) != nil {
+		return errors.New("overlapping recovery suffix exceeds the member's immutable genesis paths")
 	}
 	return nil
 }

--- a/internal/reviewtransaction/compact_recovery_binding_test.go
+++ b/internal/reviewtransaction/compact_recovery_binding_test.go
@@ -3,6 +3,7 @@ package reviewtransaction
 import (
 	"context"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -64,6 +65,13 @@ func (fixture *chainedRecoveryFixture) extendWithSecondDelivery(t *testing.T) (C
 // authority; only gate binding may later compose the chain.
 func recoverApprovedCompactSuccessor(t *testing.T, repo, predecessorLineage, lineage string, generation int) (CompactState, CompactReceipt) {
 	t.Helper()
+	successor := newCompactTestState(t, repo, lineage)
+	successor.Generation = generation
+	return recoverApprovedCompactSuccessorState(t, repo, predecessorLineage, successor)
+}
+
+func recoverApprovedCompactSuccessorState(t *testing.T, repo, predecessorLineage string, successor CompactState) (CompactState, CompactReceipt) {
+	t.Helper()
 	predecessorStore, err := CompactAuthoritativeStore(context.Background(), repo, predecessorLineage)
 	if err != nil {
 		t.Fatal(err)
@@ -72,8 +80,6 @@ func recoverApprovedCompactSuccessor(t *testing.T, repo, predecessorLineage, lin
 	if err != nil {
 		t.Fatal(err)
 	}
-	successor := newCompactTestState(t, repo, lineage)
-	successor.Generation = generation
 	record, err := RecoverCompactAuthority(context.Background(), repo, CompactRecoveryRequest{
 		PredecessorLineageID: predecessorLineage, ExpectedPredecessorRevision: predecessorRecord.Revision,
 		Successor: successor, Disposition: RecoveryScopeChanged,
@@ -83,7 +89,7 @@ func recoverApprovedCompactSuccessor(t *testing.T, repo, predecessorLineage, lin
 		t.Fatal(err)
 	}
 	state := record.State
-	store, err := CompactAuthoritativeStore(context.Background(), repo, lineage)
+	store, err := CompactAuthoritativeStore(context.Background(), repo, successor.LineageID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -112,6 +118,133 @@ func recoverApprovedCompactSuccessor(t *testing.T, repo, predecessorLineage, lin
 		t.Fatal(err)
 	}
 	return state, receipt
+}
+
+func overlappingRecoveryFixture(t *testing.T) *chainedRecoveryFixture {
+	t.Helper()
+	repo := initSnapshotRepo(t)
+	branch := currentBranch(context.Background(), repo)
+	remote := configurePublicationRemote(t, repo, branch)
+	gitSnapshot(t, repo, "config", "branch."+branch+".remote", "origin")
+	gitSnapshot(t, repo, "config", "branch."+branch+".merge", "refs/heads/"+branch)
+	base := strings.TrimSpace(gitSnapshot(t, repo, "rev-parse", "HEAD"))
+
+	writeSnapshotFile(t, repo, "tracked.txt", "intermediate\n")
+	gitSnapshot(t, repo, "add", "tracked.txt")
+	gitSnapshot(t, repo, "commit", "-m", "intermediate boundary")
+	intermediate := strings.TrimSpace(gitSnapshot(t, repo, "rev-parse", "HEAD"))
+
+	writeSnapshotFile(t, repo, "deleted.txt", "final reviewed content\n")
+	gitSnapshot(t, repo, "add", "deleted.txt")
+	gitSnapshot(t, repo, "commit", "-m", "final reviewed candidate")
+
+	root := newCompactStartStateForTarget(t, repo, "overlapping-recovery-root", Target{
+		Kind: TargetBaseDiff, BaseRef: base, IntendedUntracked: []string{},
+	})
+	root, _ = persistApprovedCompactState(t, repo, root)
+	successor := newCompactStartStateForTarget(t, repo, "overlapping-recovery-leaf", Target{
+		Kind: TargetBaseDiff, BaseRef: intermediate, IntendedUntracked: []string{},
+	})
+	successor.Generation = 2
+	leaf, receipt := recoverApprovedCompactSuccessorState(t, repo, root.LineageID, successor)
+	rootStore, err := CompactAuthoritativeStore(context.Background(), repo, root.LineageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &chainedRecoveryFixture{
+		repo: repo, remote: remote, branch: branch, baseRef: "origin/" + branch,
+		root: root, rootStore: rootStore, leaf: leaf, receipt: receipt,
+	}
+}
+
+func TestCompactPrePRRecoveryChainPreservesCumulativeAuthority(t *testing.T) {
+	fixture := overlappingRecoveryFixture(t)
+	binding, ok, err := deriveCompactRecoveryBinding(context.Background(), fixture.repo, fixture.leaf)
+	if err != nil || !ok {
+		t.Fatalf("derive overlapping scope recovery binding: ok=%t err=%v", ok, err)
+	}
+	if binding.BaseTree != fixture.root.InitialSnapshot.BaseTree ||
+		!equalStrings(binding.GenesisPaths, fixture.root.GenesisPaths) || len(binding.Members) != 2 {
+		t.Fatalf("overlapping scope recovery binding = %#v", binding)
+	}
+	got := EvaluateCompactGate(context.Background(), fixture.repo, fixture.receipt, NativeGateRequestInput{
+		Gate: GatePrePR, LineageID: fixture.leaf.LineageID, BaseRef: fixture.baseRef,
+	})
+	if got.Result != GateAllow || !got.Context.BaseRelationshipValid || got.Context.Denial != nil {
+		t.Fatalf("overlapping scope recovery pre-pr = %#v", got)
+	}
+	got = EvaluateCompactGate(context.Background(), fixture.repo, fixture.receipt, NativeGateRequestInput{
+		Gate: GatePrePush, LineageID: fixture.leaf.LineageID, BaseRef: fixture.baseRef,
+	})
+	if got.Result != GateAllow || !got.Context.BaseRelationshipValid || got.Context.Denial != nil {
+		t.Fatalf("overlapping scope recovery pre-push = %#v", got)
+	}
+}
+
+func TestCompactOverlappingRecoveryRebindRejectsScopeOutsideCumulativeAuthority(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	branch := currentBranch(context.Background(), repo)
+	configurePublicationRemote(t, repo, branch)
+	base := strings.TrimSpace(gitSnapshot(t, repo, "rev-parse", "HEAD"))
+	writeSnapshotFile(t, repo, "transient.txt", "outside cumulative authority\n")
+	gitSnapshot(t, repo, "add", "transient.txt")
+	gitSnapshot(t, repo, "commit", "-m", "transient intermediate path")
+	intermediate := strings.TrimSpace(gitSnapshot(t, repo, "rev-parse", "HEAD"))
+	if err := os.Remove(filepath.Join(repo, "transient.txt")); err != nil {
+		t.Fatal(err)
+	}
+	writeSnapshotFile(t, repo, "deleted.txt", "final reviewed content\n")
+	gitSnapshot(t, repo, "add", "-A")
+	gitSnapshot(t, repo, "commit", "-m", "final reviewed candidate")
+
+	root := newCompactStartStateForTarget(t, repo, "overlap-outside-root", Target{Kind: TargetBaseDiff, BaseRef: base, IntendedUntracked: []string{}})
+	root, _ = persistApprovedCompactState(t, repo, root)
+	successor := newCompactStartStateForTarget(t, repo, "overlap-outside-leaf", Target{Kind: TargetBaseDiff, BaseRef: intermediate, IntendedUntracked: []string{}})
+	successor.Generation = 2
+	leaf, receipt := recoverApprovedCompactSuccessorState(t, repo, root.LineageID, successor)
+	if _, ok, err := deriveCompactRecoveryBinding(context.Background(), repo, leaf); err != nil || ok {
+		t.Fatalf("outside-scope overlap binding: ok=%t err=%v", ok, err)
+	}
+	got := EvaluateCompactGate(context.Background(), repo, receipt, NativeGateRequestInput{
+		Gate: GatePrePR, LineageID: leaf.LineageID, BaseRef: "origin/" + branch,
+	})
+	if got.Result == GateAllow {
+		t.Fatalf("outside-scope overlap rebind = %#v", got)
+	}
+}
+
+func TestCompactOverlappingRecoveryRebindRejectsBaseOutsidePublicationAncestry(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	branch := currentBranch(context.Background(), repo)
+	configurePublicationRemote(t, repo, branch)
+	base := strings.TrimSpace(gitSnapshot(t, repo, "rev-parse", "HEAD"))
+	gitSnapshot(t, repo, "checkout", "-b", "unpublished-recovery-base")
+	writeSnapshotFile(t, repo, "tracked.txt", "unpublished base\n")
+	gitSnapshot(t, repo, "add", "tracked.txt")
+	gitSnapshot(t, repo, "commit", "-m", "unpublished recovery base")
+	unpublishedBase := strings.TrimSpace(gitSnapshot(t, repo, "rev-parse", "HEAD"))
+	gitSnapshot(t, repo, "checkout", branch)
+	writeSnapshotFile(t, repo, "tracked.txt", "published intermediate\n")
+	gitSnapshot(t, repo, "add", "tracked.txt")
+	gitSnapshot(t, repo, "commit", "-m", "published intermediate")
+	writeSnapshotFile(t, repo, "deleted.txt", "final reviewed content\n")
+	gitSnapshot(t, repo, "add", "deleted.txt")
+	gitSnapshot(t, repo, "commit", "-m", "final reviewed candidate")
+
+	root := newCompactStartStateForTarget(t, repo, "overlap-order-root", Target{Kind: TargetBaseDiff, BaseRef: base, IntendedUntracked: []string{}})
+	root, _ = persistApprovedCompactState(t, repo, root)
+	successor := newCompactStartStateForTarget(t, repo, "overlap-order-leaf", Target{Kind: TargetBaseDiff, BaseRef: unpublishedBase, IntendedUntracked: []string{}})
+	successor.Generation = 2
+	leaf, receipt := recoverApprovedCompactSuccessorState(t, repo, root.LineageID, successor)
+	if _, ok, err := deriveCompactRecoveryBinding(context.Background(), repo, leaf); err != nil || !ok {
+		t.Fatalf("immutable off-ancestry overlap binding: ok=%t err=%v", ok, err)
+	}
+	got := EvaluateCompactGate(context.Background(), repo, receipt, NativeGateRequestInput{
+		Gate: GatePrePR, LineageID: leaf.LineageID, BaseRef: "origin/" + branch,
+	})
+	if got.Result == GateAllow {
+		t.Fatalf("off-ancestry overlap rebind = %#v", got)
+	}
 }
 
 func TestCompactPrePushBindsChainedScopeRecoveryDelivery(t *testing.T) {
@@ -211,14 +344,34 @@ func TestCompactPrePushDeriveFailureCarriesReceiptDenialContext(t *testing.T) {
 
 func TestCompactChainedRecoveryRebindFailsClosedWithoutBoundPredecessorReceipt(t *testing.T) {
 	fixture := chainedScopeRecoveryFixture(t)
-	if err := os.Remove(fixture.rootStore.ReceiptPath()); err != nil {
-		t.Fatal(err)
-	}
+	original := finalCompactGateAllowHook
+	t.Cleanup(func() { finalCompactGateAllowHook = original })
+	finalCompactGateAllowHook = func() { _ = os.Remove(fixture.rootStore.ReceiptPath()) }
 	got := EvaluateCompactGate(context.Background(), fixture.repo, fixture.receipt, NativeGateRequestInput{
 		Gate: GatePrePush, LineageID: fixture.leaf.LineageID, BaseRef: fixture.baseRef,
 	})
 	if got.Result == GateAllow {
 		t.Fatalf("receiptless predecessor rebind = %#v", got)
+	}
+}
+
+func TestCompactRecoveryDirectLeafRejectsUnreviewedChangeRevert(t *testing.T) {
+	fixture := chainedScopeRecoveryFixture(t)
+	gitSnapshot(t, fixture.repo, "push", "origin", "HEAD:"+fixture.branch)
+	state, receipt := fixture.extendWithSecondDelivery(t)
+	writeSnapshotFile(t, fixture.repo, "outside.txt", "unreviewed\n")
+	gitSnapshot(t, fixture.repo, "add", "outside.txt")
+	gitSnapshot(t, fixture.repo, "commit", "-m", "unreviewed intermediate")
+	if err := os.Remove(filepath.Join(fixture.repo, "outside.txt")); err != nil {
+		t.Fatal(err)
+	}
+	gitSnapshot(t, fixture.repo, "add", "-A")
+	gitSnapshot(t, fixture.repo, "commit", "-m", "revert unreviewed intermediate")
+	got := EvaluateCompactGate(context.Background(), fixture.repo, receipt, NativeGateRequestInput{
+		Gate: GatePrePR, LineageID: state.LineageID, BaseRef: fixture.baseRef,
+	})
+	if got.Result == GateAllow {
+		t.Fatalf("direct leaf with unreviewed change/revert = %#v", got)
 	}
 }
 


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1366

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

Composes cumulative receipt-bound authority across overlapping `scope_changed` recovery corrections when the successor re-reviews an exact predecessor suffix. Authorization validates each publication segment against immutable member scope, rejects hidden out-of-scope change/revert sequences, re-derives predecessor receipt validity during final authorization, and keeps safe fully reviewed successors allowed when composition is inapplicable.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/reviewtransaction/compact_recovery_binding.go` | Derives continuous or scope-contracting overlap chains and verifies publication ancestry, boundaries, and per-segment changed paths. |
| `internal/reviewtransaction/compact_gate.go` | Uses cumulative recovery genesis for publication validation and re-derives receipt and direct-leaf delivery evidence during final authorization. |
| `internal/reviewtransaction/compact_recovery_binding_test.go` | Covers cumulative overlap authority, out-of-scope and off-ancestry denial, stale predecessor receipts, hidden change/revert denial, and safe successors. |

---

## 🧪 Test Plan

**Focused Tests**
```bash
go test ./internal/reviewtransaction -run 'TestCompact(ChainedRecoveryRebindFailsClosedWithoutBoundPredecessorReceipt|RecoveryDirectLeafRejectsUnreviewedChangeRevert|PrePRRecoveryChainPreservesCumulativeAuthority)$' -count=1
```

**Package and Full Repository**
```bash
go test ./internal/reviewtransaction -count=1
go test ./... -count=1
git diff --check
```

- [x] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Manually tested locally

All four recorded candidate verification commands passed. Frozen findings `R4-001` and `R2-001` were independently validated.

---

## 🤖 Automated Checks

The following checks run automatically on this PR:

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | PR should stay within 400 changed lines (`additions + deletions`) or use `size:exception` |
| Check Issue Reference | ⏳ | PR body must contain `Closes/Fixes/Resolves #N` |
| Check Issue Has `status:approved` | ⏳ | Linked issue must have been approved before work began |
| Check PR Has `type:*` Label | ⏳ | Exactly one `type:*` label must be applied |
| Unit Tests | ⏳ | `go test ./...` must pass |
| E2E Tests | ⏳ | `cd e2e && ./docker-test.sh` must pass |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

Bounded review receipt: `review-68b095de252bdaa3`; corrected frozen findings: `R4-001`, `R2-001`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compact recovery validation for overlapping review scopes.
  - Preserved cumulative authorization across valid recovery chains.
  - Rejected recovery attempts that exceed approved scope or publication history.
  - Strengthened checks for missing recovery evidence and unreviewed reverted changes.
  - Added direct verification of recovery delivery before final authorization.

- **Tests**
  - Expanded coverage for overlapping recovery, authorization boundaries, ancestry validation, and reverted changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->