### PR TITLE
fix(review): invalidate approved compact authority on gate denial

### DIFF
--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -579,11 +579,20 @@ func runReviewBindSDD(ctx context.Context, args []string, stdout io.Writer) erro
 }
 
 func RunReviewInvalidate(args []string, stdout io.Writer) error {
-	flags := newReviewFlagSet("review invalidate", stdout, "Terminally invalidate one explicit pristine reviewing authority.")
+	flags := newReviewFlagSet("review invalidate", stdout, "Terminally invalidate one explicit pristine reviewing authority, or an approved compact authority whose lifecycle gate natively re-derives invalidated under LOCK.")
 	cwd := flags.String("cwd", "", "repository path")
 	lineage := flags.String("lineage", "", "explicit review lineage identifier")
 	expected := flags.String("expected-revision", "", "exact current authority revision")
-	reason := flags.String("reason", "", "non-empty terminal invalidation reason")
+	reason := flags.String("reason", "", "non-empty terminal invalidation reason for a pristine reviewing authority")
+	gate := flags.String("gate", "", "approved-authority lifecycle gate: post-apply, pre-commit, pre-push, pre-pr, or release")
+	baseRef := flags.String("base-ref", "", "optional expected remote publication base for pre-push or pre-pr")
+	ciAttestation := flags.String("pre-pr-ci-attestation", "", "signed exact-merged-tree CI attestation for a compatible base advance")
+	policy := flags.String("policy", "", "explicit custom policy containing compatible-base CI trust")
+	releaseConfiguration := flags.String("release-configuration", "", "release configuration artifact")
+	releaseGenerated := flags.String("release-generated", "", "generated artifact manifest")
+	releaseProvenance := flags.String("release-provenance", "", "release provenance artifact")
+	releaseBoundary := flags.String("release-publication-boundary", "", "sealed publication boundary artifact")
+	releaseFreshness := flags.String("release-evidence-freshness", "", "current release evidence freshness artifact")
 	if err := parseReviewFlags(flags, args); err != nil {
 		return err
 	}
@@ -593,8 +602,8 @@ func RunReviewInvalidate(args []string, stdout io.Writer) error {
 	if flags.NArg() != 0 {
 		return fmt.Errorf("unexpected review invalidate argument %q", flags.Arg(0))
 	}
-	if strings.TrimSpace(*cwd) == "" || strings.TrimSpace(*lineage) == "" || strings.TrimSpace(*expected) == "" || strings.TrimSpace(*reason) == "" {
-		return errors.New("review invalidate requires --cwd, --lineage, --expected-revision, and --reason")
+	if strings.TrimSpace(*cwd) == "" || strings.TrimSpace(*lineage) == "" || strings.TrimSpace(*expected) == "" {
+		return errors.New("review invalidate requires --cwd, --lineage, and --expected-revision")
 	}
 	root, err := (reviewtransaction.SnapshotBuilder{Repo: *cwd}).ResolveRepositoryRoot(context.Background())
 	if err != nil {
@@ -612,6 +621,32 @@ func RunReviewInvalidate(args []string, stdout io.Writer) error {
 				return errors.New("review authority is ambiguous across compact v2 and legacy v1 stores")
 			}
 		}
+		approvedInvalidation := record.State.State == reviewtransaction.StateApproved ||
+			record.State.State == reviewtransaction.StateInvalidated && record.State.InvalidationEvidence != nil
+		if approvedInvalidation {
+			if strings.TrimSpace(*gate) == "" {
+				return errors.New("approved review invalidation requires --gate")
+			}
+			input := reviewtransaction.NativeGateRequestInput{
+				Gate: reviewtransaction.GateKind(*gate), LineageID: *lineage, BaseRef: *baseRef,
+				PrePRCIAttestation: *ciAttestation, ReleaseConfiguration: *releaseConfiguration,
+				ReleaseGenerated: *releaseGenerated, ReleaseProvenance: *releaseProvenance,
+				ReleasePublicationBoundary: *releaseBoundary, ReleaseEvidenceFreshness: *releaseFreshness,
+			}
+			if strings.TrimSpace(*ciAttestation) != "" {
+				input.PolicyArtifact = *policy
+			}
+			invalidated, _, err := reviewtransaction.InvalidateApprovedCompactAuthority(context.Background(), root, reviewtransaction.CompactApprovedInvalidationRequest{
+				LineageID: *lineage, ExpectedRevision: *expected, Gate: input,
+			})
+			if err != nil {
+				return err
+			}
+			return encodeReviewJSON(stdout, ReviewInvalidateResult{Operation: "review/invalidate", LineageID: invalidated.State.LineageID, State: invalidated.State.State, StoreRevision: invalidated.Revision})
+		}
+		if strings.TrimSpace(*reason) == "" {
+			return errors.New("pristine review invalidation requires --reason")
+		}
 		state := record.State
 		if state.State != reviewtransaction.StateInvalidated || state.InvalidationReason != strings.TrimSpace(*reason) {
 			if err := state.Invalidate(*reason); err != nil {
@@ -626,6 +661,9 @@ func RunReviewInvalidate(args []string, stdout io.Writer) error {
 	}
 	if !errors.Is(loadErr, os.ErrNotExist) {
 		return fmt.Errorf("load explicit compact review lineage: %w", loadErr)
+	}
+	if strings.TrimSpace(*reason) == "" {
+		return errors.New("legacy review invalidation requires --reason")
 	}
 	legacy, err := reviewtransaction.AuthoritativeStore(context.Background(), root, *lineage)
 	if err != nil {

--- a/internal/cli/review_invalidate_test.go
+++ b/internal/cli/review_invalidate_test.go
@@ -151,6 +151,59 @@ func TestReviewInvalidateFailsClosedForCompetingAuthorities(t *testing.T) {
 	}
 }
 
+func TestReviewInvalidateRefusesHealthyApprovedLineage(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	started, store := approveDiscoveryMarkdown(t, repo, "invalidate-approved-healthy-cli", "approved.md", "approved\n")
+	runReviewCLIGit(t, repo, "add", "approved.md")
+	record, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	beforeState, _ := os.ReadFile(store.StatePath())
+	beforeReceipt, _ := os.ReadFile(store.ReceiptPath())
+
+	err = RunReview([]string{
+		"invalidate", "--cwd", repo, "--lineage", started.LineageID,
+		"--expected-revision", record.Revision, "--gate", string(reviewtransaction.GatePreCommit),
+	}, &bytes.Buffer{})
+	if err == nil || !strings.Contains(err.Error(), "healthy approved authority") {
+		t.Fatalf("healthy approved CLI invalidation error = %v", err)
+	}
+	afterState, _ := os.ReadFile(store.StatePath())
+	afterReceipt, _ := os.ReadFile(store.ReceiptPath())
+	if !bytes.Equal(afterState, beforeState) || !bytes.Equal(afterReceipt, beforeReceipt) {
+		t.Fatal("healthy approved CLI invalidation changed authority bytes")
+	}
+}
+
+func TestReviewInvalidateReplaysCompletedApprovedInvalidation(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	started, store := approveDiscoveryMarkdown(t, repo, "invalidate-approved-replay", "approved.md", "approved\n")
+	record, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "outside.txt"), []byte("outside frozen scope\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	args := []string{
+		"invalidate", "--cwd", repo, "--lineage", started.LineageID,
+		"--expected-revision", record.Revision, "--gate", string(reviewtransaction.GatePostApply),
+	}
+
+	var first bytes.Buffer
+	if err := RunReview(args, &first); err != nil {
+		t.Fatalf("first approved invalidation: %v", err)
+	}
+	var second bytes.Buffer
+	if err := RunReview(args, &second); err != nil {
+		t.Fatalf("replay approved invalidation: %v", err)
+	}
+	if first.String() != second.String() {
+		t.Fatalf("CLI replay output changed:\nfirst: %s\nsecond: %s", first.String(), second.String())
+	}
+}
+
 func addPristineLegacyAuthority(t *testing.T, repo, lineage string) reviewtransaction.Store {
 	t.Helper()
 	snapshot, _ := (reviewtransaction.SnapshotBuilder{Repo: repo}).Build(context.Background(), reviewtransaction.Target{Kind: reviewtransaction.TargetCurrentChanges, IntendedUntracked: []string{}})

--- a/internal/reviewtransaction/compact.go
+++ b/internal/reviewtransaction/compact.go
@@ -25,34 +25,35 @@ const (
 )
 
 type CompactState struct {
-	Schema                    string                     `json:"schema"`
-	LineageID                 string                     `json:"lineage_id"`
-	Generation                int                        `json:"generation"`
-	State                     State                      `json:"state"`
-	InitialSnapshot           Snapshot                   `json:"initial_snapshot"`
-	CurrentSnapshot           Snapshot                   `json:"current_snapshot"`
-	GenesisPaths              []string                   `json:"genesis_paths"`
-	PolicyHash                string                     `json:"policy_hash"`
-	RiskLevel                 RiskLevel                  `json:"risk_level"`
-	SelectedLenses            []string                   `json:"selected_lenses"`
-	OriginalChangedLines      int                        `json:"original_changed_lines"`
-	CorrectionBudget          int                        `json:"correction_budget"`
-	LensResults               []LensResult               `json:"lens_results"`
-	Findings                  []Finding                  `json:"findings"`
-	Classifications           map[string]FindingEvidence `json:"classifications"`
-	Outcomes                  map[string]EvidenceOutcome `json:"outcomes"`
-	FixFindingIDs             []string                   `json:"fix_finding_ids"`
-	FollowUps                 []FollowUp                 `json:"follow_ups"`
-	ProposedCorrectionLines   *int                       `json:"proposed_correction_lines,omitempty"`
-	ActualCorrectionLines     *int                       `json:"actual_correction_lines,omitempty"`
-	FixDeltaHash              string                     `json:"fix_delta_hash"`
-	OriginalCriteria          *ValidationCheck           `json:"original_criteria,omitempty"`
-	CorrectionRegression      *ValidationCheck           `json:"correction_regression,omitempty"`
-	EvidenceHash              string                     `json:"evidence_hash,omitempty"`
-	InvalidationReason        string                     `json:"invalidation_reason,omitempty"`
-	Recovery                  *CompactRecoveryProvenance `json:"recovery,omitempty"`
-	CorrectionAttempts        []CompactCorrectionAttempt `json:"correction_attempts,omitempty"`
-	CumulativeCorrectionLines int                        `json:"cumulative_correction_lines,omitempty"`
+	Schema                    string                       `json:"schema"`
+	LineageID                 string                       `json:"lineage_id"`
+	Generation                int                          `json:"generation"`
+	State                     State                        `json:"state"`
+	InitialSnapshot           Snapshot                     `json:"initial_snapshot"`
+	CurrentSnapshot           Snapshot                     `json:"current_snapshot"`
+	GenesisPaths              []string                     `json:"genesis_paths"`
+	PolicyHash                string                       `json:"policy_hash"`
+	RiskLevel                 RiskLevel                    `json:"risk_level"`
+	SelectedLenses            []string                     `json:"selected_lenses"`
+	OriginalChangedLines      int                          `json:"original_changed_lines"`
+	CorrectionBudget          int                          `json:"correction_budget"`
+	LensResults               []LensResult                 `json:"lens_results"`
+	Findings                  []Finding                    `json:"findings"`
+	Classifications           map[string]FindingEvidence   `json:"classifications"`
+	Outcomes                  map[string]EvidenceOutcome   `json:"outcomes"`
+	FixFindingIDs             []string                     `json:"fix_finding_ids"`
+	FollowUps                 []FollowUp                   `json:"follow_ups"`
+	ProposedCorrectionLines   *int                         `json:"proposed_correction_lines,omitempty"`
+	ActualCorrectionLines     *int                         `json:"actual_correction_lines,omitempty"`
+	FixDeltaHash              string                       `json:"fix_delta_hash"`
+	OriginalCriteria          *ValidationCheck             `json:"original_criteria,omitempty"`
+	CorrectionRegression      *ValidationCheck             `json:"correction_regression,omitempty"`
+	EvidenceHash              string                       `json:"evidence_hash,omitempty"`
+	InvalidationReason        string                       `json:"invalidation_reason,omitempty"`
+	InvalidationEvidence      *CompactInvalidationEvidence `json:"invalidation_evidence,omitempty"`
+	Recovery                  *CompactRecoveryProvenance   `json:"recovery,omitempty"`
+	CorrectionAttempts        []CompactCorrectionAttempt   `json:"correction_attempts,omitempty"`
+	CumulativeCorrectionLines int                          `json:"cumulative_correction_lines,omitempty"`
 }
 
 type CompactCorrectionAttempt struct {
@@ -62,6 +63,12 @@ type CompactCorrectionAttempt struct {
 	FixDeltaHash         string          `json:"fix_delta_hash"`
 	OriginalCriteria     ValidationCheck `json:"original_criteria"`
 	CorrectionRegression ValidationCheck `json:"correction_regression"`
+}
+
+type CompactInvalidationEvidence struct {
+	Gate    GateKind    `json:"gate"`
+	Reason  string      `json:"reason"`
+	Context GateContext `json:"context"`
 }
 
 type RecoveryDisposition string
@@ -170,6 +177,25 @@ func (state CompactState) Validate() error {
 		default:
 			return errors.New("compact recovery disposition is invalid")
 		}
+	}
+	if state.State != StateInvalidated && state.InvalidationEvidence != nil {
+		return errors.New("only an invalidated compact state may contain invalidation evidence")
+	}
+	if state.State == StateInvalidated && strings.TrimSpace(state.InvalidationReason) != "" && state.InvalidationEvidence != nil {
+		evidence := state.InvalidationEvidence
+		payload, err := json.Marshal(evidence.Context)
+		parsed, parseErr := ParseGateContext(payload)
+		if err != nil || parseErr != nil || !reflect.DeepEqual(parsed, evidence.Context) || evidence.Gate != evidence.Context.Gate ||
+			evidence.Reason != state.InvalidationReason || evidence.Context.LineageID != state.LineageID || evidence.Context.Generation != state.Generation {
+			return errors.New("approved compact invalidation evidence is incomplete or invalid")
+		}
+		approved := state
+		approved.State, approved.InvalidationReason, approved.InvalidationEvidence = StateApproved, "", nil
+		approvedRecord, _, recordErr := makeCompactRecord(approved)
+		if approved.Validate() == nil && recordErr == nil && evidence.Context.StoreRevision == approvedRecord.Revision {
+			return nil
+		}
+		return errors.New("approved compact invalidation evidence does not bind its predecessor revision")
 	}
 	if err := validateSnapshot(state.InitialSnapshot); err != nil {
 		return fmt.Errorf("initial snapshot: %w", err)
@@ -658,6 +684,22 @@ func (state *CompactState) Invalidate(reason string) error {
 	}
 	state.State, state.InvalidationReason = StateInvalidated, reason
 	return nil
+}
+
+func (state *CompactState) invalidateApproved(evaluation NativeGateEvaluation) error {
+	reason := strings.TrimSpace(evaluation.Reason)
+	if reason == "" {
+		return errors.New("approved invalidation reason is required")
+	}
+	if evaluation.Result != GateInvalidated {
+		return fmt.Errorf("approved invalidation requires an invalidated gate result, got %q", evaluation.Result)
+	}
+	if state.State != StateApproved {
+		return fmt.Errorf("cannot invalidate approved authority from compact state %q", state.State)
+	}
+	state.State, state.InvalidationReason = StateInvalidated, reason
+	state.InvalidationEvidence = &CompactInvalidationEvidence{Gate: evaluation.Context.Gate, Reason: reason, Context: evaluation.Context}
+	return state.Validate()
 }
 
 func compactPristineReviewing(state CompactState) bool {

--- a/internal/reviewtransaction/compact_approved_invalidation.go
+++ b/internal/reviewtransaction/compact_approved_invalidation.go
@@ -17,6 +17,7 @@ type CompactApprovedInvalidationRequest struct {
 	ExpectedRevision string
 	Gate             NativeGateRequestInput
 }
+
 var finalCompactInvalidationHook = func() {}
 
 // InvalidateApprovedCompactAuthority terminally revokes an approved lineage
@@ -108,16 +109,29 @@ func InvalidateApprovedCompactAuthority(ctx context.Context, repo string, reques
 	if evaluation.Result != GateInvalidated {
 		return CompactRecord{}, evaluation, fmt.Errorf("healthy approved authority cannot be invalidated: native gate result is %q", evaluation.Result)
 	}
-	deniedTarget, deniedUntracked, err := compactInvalidationTarget(ctx, store.repo, current.State, request.Gate)
-	if err != nil {
-		return CompactRecord{}, evaluation, fmt.Errorf("derive approved invalidation target: %w", err)
+	deniedTarget, deniedUntracked, deniedErr := compactInvalidationTarget(ctx, store.repo, current.State, request.Gate)
+	if deniedErr != nil && compactGateInfrastructureFailure(deniedErr) {
+		// A genuine git/process/context fault must fail closed and never
+		// terminate an approved authority on unreliable evidence.
+		return CompactRecord{}, evaluation, fmt.Errorf("derive approved invalidation target: %w", deniedErr)
 	}
 	finalCompactInvalidationHook()
 	finalEvaluation := evaluateCompactGate(ctx, store.repo, receipt, request.Gate, true)
-	finalTarget, finalUntracked, targetErr := compactInvalidationTarget(ctx, store.repo, current.State, request.Gate)
-	if finalEvaluation.Cause != nil || targetErr != nil || !reflect.DeepEqual(finalEvaluation, evaluation) ||
-		!snapshotsEqual(finalTarget, deniedTarget) || finalUntracked != deniedUntracked || !compactInvalidationDenialBound(finalEvaluation, current, request) {
-		cause := errors.Join(finalEvaluation.Cause, targetErr, ErrConcurrentUpdate)
+	finalTarget, finalUntracked, finalErr := compactInvalidationTarget(ctx, store.repo, current.State, request.Gate)
+	if finalErr != nil && compactGateInfrastructureFailure(finalErr) {
+		cause := errors.Join(finalEvaluation.Cause, finalErr, ErrConcurrentUpdate)
+		return CompactRecord{}, finalEvaluation, fmt.Errorf("approved invalidation target changed during final derivation: %w", cause)
+	}
+	// A denial whose cause is an underivable live target — a semantic scope
+	// violation such as a now-tracked intended-untracked path (issue #1269) —
+	// has no stable snapshot to compare. Its stability is proven instead by
+	// both target derivations failing with the identical semantic error and by
+	// the bound gate denial below. Infrastructure faults were already rejected
+	// above, so any error reaching the stability check here is semantic.
+	if finalEvaluation.Cause != nil ||
+		!compactInvalidationTargetStable(deniedTarget, deniedUntracked, deniedErr, finalTarget, finalUntracked, finalErr) ||
+		!reflect.DeepEqual(finalEvaluation, evaluation) || !compactInvalidationDenialBound(finalEvaluation, current, request) {
+		cause := errors.Join(finalEvaluation.Cause, deniedErr, finalErr, ErrConcurrentUpdate)
 		return CompactRecord{}, finalEvaluation, fmt.Errorf("approved invalidation target changed during final derivation: %w", cause)
 	}
 	evaluation = finalEvaluation
@@ -155,6 +169,20 @@ func compactInvalidationTarget(ctx context.Context, repo string, state CompactSt
 	}
 	untracked, err := (SnapshotBuilder{Repo: repo}).DiscoverIntendedUntracked(ctx)
 	return snapshot, digestPaths(untracked), err
+}
+
+// compactInvalidationTargetStable reports whether two live target derivations
+// observed the same denial across the final-derivation window. A derivable
+// target must match snapshot identity and untracked digest exactly. An
+// underivable target — a semantic scope violation that prevents lifecycle
+// snapshot derivation — is stable only when both derivations failed with the
+// identical semantic error. Infrastructure faults are rejected by the caller
+// before this comparison, so any non-nil error reaching here is semantic.
+func compactInvalidationTargetStable(deniedTarget Snapshot, deniedUntracked string, deniedErr error, finalTarget Snapshot, finalUntracked string, finalErr error) bool {
+	if deniedErr != nil || finalErr != nil {
+		return deniedErr != nil && finalErr != nil && deniedErr.Error() == finalErr.Error()
+	}
+	return snapshotsEqual(finalTarget, deniedTarget) && finalUntracked == deniedUntracked
 }
 
 func compactInvalidationDenialBound(evaluation NativeGateEvaluation, current CompactRecord, request CompactApprovedInvalidationRequest) bool {

--- a/internal/reviewtransaction/compact_approved_invalidation.go
+++ b/internal/reviewtransaction/compact_approved_invalidation.go
@@ -1,0 +1,167 @@
+package reviewtransaction
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"reflect"
+	"strings"
+	"time"
+)
+
+// CompactApprovedInvalidationRequest identifies one approved compact lineage
+// and the lifecycle gate whose live repository evidence must be re-derived.
+type CompactApprovedInvalidationRequest struct {
+	LineageID        string
+	ExpectedRevision string
+	Gate             NativeGateRequestInput
+}
+var finalCompactInvalidationHook = func() {}
+
+// InvalidateApprovedCompactAuthority terminally revokes an approved lineage
+// only when its requested lifecycle gate natively re-derives an invalidated
+// result while the repository-wide compact authority lock is held. Gate reads
+// remain pure; this explicit transition is the sole mutation boundary.
+func InvalidateApprovedCompactAuthority(ctx context.Context, repo string, request CompactApprovedInvalidationRequest) (CompactRecord, NativeGateEvaluation, error) {
+	if err := ctx.Err(); err != nil {
+		return CompactRecord{}, NativeGateEvaluation{}, err
+	}
+	if err := validateLineageID(request.LineageID); err != nil {
+		return CompactRecord{}, NativeGateEvaluation{}, err
+	}
+	if strings.TrimSpace(request.ExpectedRevision) == "" {
+		return CompactRecord{}, NativeGateEvaluation{}, errors.New("approved invalidation requires the exact current store revision")
+	}
+	if request.Gate.LineageID != "" && request.Gate.LineageID != request.LineageID {
+		return CompactRecord{}, NativeGateEvaluation{}, errors.New("approved invalidation gate lineage does not match the requested lineage")
+	}
+	switch request.Gate.Gate {
+	case GatePostApply, GatePreCommit, GatePrePush, GatePrePR, GateRelease:
+	default:
+		return CompactRecord{}, NativeGateEvaluation{}, fmt.Errorf("approved invalidation requires a supported lifecycle gate, got %q", request.Gate.Gate)
+	}
+	if request.Gate.Gate == GateRelease {
+		for _, path := range []string{
+			request.Gate.ReleaseConfiguration, request.Gate.ReleaseGenerated, request.Gate.ReleaseProvenance,
+			request.Gate.ReleasePublicationBoundary, request.Gate.ReleaseEvidenceFreshness,
+		} {
+			if strings.TrimSpace(path) == "" {
+				return CompactRecord{}, NativeGateEvaluation{}, errors.New("release gate requires complete independent release evidence")
+			}
+		}
+	}
+	request.Gate.LineageID = request.LineageID
+	store, err := CompactAuthoritativeStore(ctx, repo, request.LineageID)
+	if err != nil {
+		return CompactRecord{}, NativeGateEvaluation{}, err
+	}
+	lock, err := acquireStoreLock(store.lockPath)
+	if err != nil {
+		return CompactRecord{}, NativeGateEvaluation{}, err
+	}
+	defer lock.release()
+
+	current, err := store.Load()
+	if err != nil {
+		return CompactRecord{}, NativeGateEvaluation{}, fmt.Errorf("load approved invalidation target: %w", err)
+	}
+	if current.HistoricalCompat {
+		return CompactRecord{}, NativeGateEvaluation{}, fmt.Errorf("%w: review/invalidate for lineage %q", ErrHistoricalCompatReadOnly, request.LineageID)
+	}
+	if current.State.State == StateInvalidated && current.State.InvalidationEvidence != nil &&
+		current.State.InvalidationEvidence.Context.StoreRevision == request.ExpectedRevision &&
+		current.State.InvalidationEvidence.Gate == request.Gate.Gate {
+		evidence := current.State.InvalidationEvidence
+		evaluation := NativeGateEvaluation{Result: GateInvalidated, Reason: evidence.Reason, Context: evidence.Context}
+		if err := os.Remove(store.ReceiptPath()); err != nil && !os.IsNotExist(err) {
+			return current, evaluation, fmt.Errorf("remove invalidated compact receipt: %w", err)
+		}
+		return current, evaluation, nil
+	}
+	if current.Revision != request.ExpectedRevision {
+		return CompactRecord{}, NativeGateEvaluation{}, fmt.Errorf("%w: expected compact revision %q, current %q", ErrConcurrentUpdate, request.ExpectedRevision, current.Revision)
+	}
+	if current.State.State != StateApproved {
+		return CompactRecord{}, NativeGateEvaluation{}, fmt.Errorf("approved invalidation requires an approved authority, got %q", current.State.State)
+	}
+	receipt, err := current.State.Receipt()
+	if err != nil {
+		return CompactRecord{}, NativeGateEvaluation{}, err
+	}
+	published, err := os.ReadFile(store.ReceiptPath())
+	if err != nil {
+		return CompactRecord{}, NativeGateEvaluation{}, fmt.Errorf("load approved invalidation receipt: %w", err)
+	}
+	publishedReceipt, err := ParseCompactReceipt(published)
+	if err != nil || !compactReceiptEqual(publishedReceipt, receipt) {
+		return CompactRecord{}, NativeGateEvaluation{}, errors.New("approved invalidation receipt does not match current authority")
+	}
+
+	evaluation := evaluateCompactGate(ctx, store.repo, receipt, request.Gate, true)
+	if err := ctx.Err(); err != nil {
+		return CompactRecord{}, evaluation, fmt.Errorf("approved invalidation gate infrastructure failure: %w", err)
+	}
+	if evaluation.Cause != nil {
+		return CompactRecord{}, evaluation, fmt.Errorf("approved invalidation gate infrastructure failure: %w", evaluation.Cause)
+	}
+	if evaluation.Result != GateInvalidated {
+		return CompactRecord{}, evaluation, fmt.Errorf("healthy approved authority cannot be invalidated: native gate result is %q", evaluation.Result)
+	}
+	deniedTarget, deniedUntracked, err := compactInvalidationTarget(ctx, store.repo, current.State, request.Gate)
+	if err != nil {
+		return CompactRecord{}, evaluation, fmt.Errorf("derive approved invalidation target: %w", err)
+	}
+	finalCompactInvalidationHook()
+	finalEvaluation := evaluateCompactGate(ctx, store.repo, receipt, request.Gate, true)
+	finalTarget, finalUntracked, targetErr := compactInvalidationTarget(ctx, store.repo, current.State, request.Gate)
+	if finalEvaluation.Cause != nil || targetErr != nil || !reflect.DeepEqual(finalEvaluation, evaluation) ||
+		!snapshotsEqual(finalTarget, deniedTarget) || finalUntracked != deniedUntracked || !compactInvalidationDenialBound(finalEvaluation, current, request) {
+		cause := errors.Join(finalEvaluation.Cause, targetErr, ErrConcurrentUpdate)
+		return CompactRecord{}, finalEvaluation, fmt.Errorf("approved invalidation target changed during final derivation: %w", cause)
+	}
+	evaluation = finalEvaluation
+	next := current.State
+	if err := next.invalidateApproved(evaluation); err != nil {
+		return CompactRecord{}, evaluation, err
+	}
+	record, payload, err := makeCompactRecord(next)
+	if err != nil {
+		return CompactRecord{}, evaluation, err
+	}
+	if err := writeAtomic(store.StatePath(), payload, 0o644); err != nil {
+		return CompactRecord{}, evaluation, err
+	}
+	if store.TracePath != "" {
+		_ = appendCompactTrace(store.TracePath, CompactTraceEntry{
+			Operation: "review/invalidate-approved", PreviousRevision: current.Revision,
+			Revision: record.Revision, State: next.State, RecordedAt: time.Now().UTC().Format(time.RFC3339Nano),
+		})
+	}
+	if err := os.Remove(store.ReceiptPath()); err != nil && !os.IsNotExist(err) {
+		return record, evaluation, fmt.Errorf("remove invalidated compact receipt: %w", err)
+	}
+	return record, evaluation, nil
+}
+
+func compactInvalidationTarget(ctx context.Context, repo string, state CompactState, input NativeGateRequestInput) (Snapshot, string, error) {
+	request, _, err := buildCompactGateRequest(ctx, repo, state, input)
+	if err != nil {
+		return Snapshot{}, "", err
+	}
+	snapshot, _, err := buildCompactLifecycleSnapshot(ctx, repo, request)
+	if err != nil {
+		return Snapshot{}, "", err
+	}
+	untracked, err := (SnapshotBuilder{Repo: repo}).DiscoverIntendedUntracked(ctx)
+	return snapshot, digestPaths(untracked), err
+}
+
+func compactInvalidationDenialBound(evaluation NativeGateEvaluation, current CompactRecord, request CompactApprovedInvalidationRequest) bool {
+	context := evaluation.Context
+	return evaluation.Result == GateInvalidated && evaluation.Cause == nil && context.Denial != nil &&
+		context.Gate == request.Gate.Gate && context.LineageID == current.State.LineageID &&
+		context.Generation == current.State.Generation && context.StoreRevision == current.Revision &&
+		context.BaseTree != "" && context.CandidateTree != "" && context.PathsDigest != "" && context.PolicyHash == current.State.PolicyHash &&
+		context.LedgerHash == current.State.LedgerHash() && context.EvidenceHash == current.State.EvidenceHash
+}

--- a/internal/reviewtransaction/compact_approved_invalidation_test.go
+++ b/internal/reviewtransaction/compact_approved_invalidation_test.go
@@ -209,6 +209,72 @@ func TestInvalidateApprovedCompactAuthorityPersistsBoundSemanticDenial(t *testin
 		t.Fatalf("semantic invalidation retained receipt: %v", err)
 	}
 }
+func TestInvalidateApprovedCompactAuthorityPersistsStagedIntendedUntrackedDenial(t *testing.T) {
+	// Reproduces issue #1269: an approved current-changes lineage whose frozen
+	// intended-untracked path is later staged/tracked. The native gate derives
+	// an invalidated result from the buildCompactLifecycleSnapshot failure path
+	// ("intended-untracked path is already tracked"), which is a semantic scope
+	// denial rather than an infrastructure fault. Post-apply reaches this path
+	// because the staged path leaves DiscoverIntendedUntracked empty, so the
+	// earlier untracked-scope guard passes and the failure surfaces only at
+	// lifecycle snapshot derivation. The invalidation MUST persist so the
+	// authority becomes recovery-eligible instead of staying "approved".
+	repo := initSnapshotRepo(t)
+	writeSnapshotFile(t, repo, "intended.txt", "reviewed untracked\n")
+	state, store, _ := approvedCompactCurrentChangesFixture(t, repo, "invalidate-approved-staged-intended", []string{"intended.txt"})
+	before, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Stage the frozen intended-untracked path so it is tracked in the index but
+	// absent from HEAD: the exact live state issue #1269 reports.
+	gitSnapshot(t, repo, "add", "--", "intended.txt")
+
+	record, evaluation, err := InvalidateApprovedCompactAuthority(context.Background(), repo, CompactApprovedInvalidationRequest{
+		LineageID: state.LineageID, ExpectedRevision: before.Revision,
+		Gate: NativeGateRequestInput{Gate: GatePostApply, LineageID: state.LineageID},
+	})
+	if err != nil {
+		t.Fatalf("persist staged intended-untracked denial: %v", err)
+	}
+	if evaluation.Result != GateInvalidated || evaluation.Cause != nil {
+		t.Fatalf("staged intended-untracked denial = evaluation %#v", evaluation)
+	}
+	if !strings.Contains(evaluation.Reason, "current repository target cannot be derived") ||
+		!strings.Contains(evaluation.Reason, "already tracked") {
+		t.Fatalf("denial did not surface from lifecycle snapshot derivation: %q", evaluation.Reason)
+	}
+	if evaluation.Context.Denial == nil || evaluation.Context.Denial.Stage != "target-derivation" {
+		t.Fatalf("semantic denial lacked target-derivation stage: %#v", evaluation.Context.Denial)
+	}
+	// Authority must terminally transition to invalidated and drop the receipt.
+	if record.State.State != StateInvalidated || record.Revision == before.Revision ||
+		record.State.InvalidationReason != evaluation.Reason {
+		t.Fatalf("staged intended-untracked invalidation = record %#v", record)
+	}
+	if record.State.InvalidationEvidence == nil ||
+		!reflect.DeepEqual(record.State.InvalidationEvidence.Context, evaluation.Context) {
+		t.Fatalf("persisted staged-intended evidence = %#v", record.State.InvalidationEvidence)
+	}
+	if _, err := os.Stat(store.ReceiptPath()); !os.IsNotExist(err) {
+		t.Fatalf("staged intended-untracked invalidation retained receipt: %v", err)
+	}
+	loaded, err := store.Load()
+	if err != nil || !reflect.DeepEqual(loaded, record) {
+		t.Fatalf("persisted staged-intended invalidation = %#v, %v", loaded, err)
+	}
+	// The invalidated authority must be recovery-eligible.
+	successor := newCompactTestState(t, repo, "invalidate-approved-staged-intended-g2")
+	successor.Generation = record.State.Generation + 1
+	recovered, err := RecoverCompactAuthority(context.Background(), repo, CompactRecoveryRequest{
+		PredecessorLineageID: record.State.LineageID, ExpectedPredecessorRevision: record.Revision,
+		Successor: successor, Disposition: RecoveryInvalidated, Reason: "replace invalidated delivery", Actor: "maintainer",
+	})
+	if err != nil || recovered.State.Recovery == nil || recovered.State.Recovery.PredecessorRevision != record.Revision {
+		t.Fatalf("recover staged intended-untracked invalidated predecessor = %#v, %v", recovered, err)
+	}
+}
+
 func TestInvalidateApprovedCompactAuthorityAcceptsCanonicalZeroLensReceipt(t *testing.T) {
 	repo := initSnapshotRepo(t)
 	writeSnapshotFile(t, repo, "tracked.txt", "approved candidate\n")

--- a/internal/reviewtransaction/compact_approved_invalidation_test.go
+++ b/internal/reviewtransaction/compact_approved_invalidation_test.go
@@ -1,0 +1,337 @@
+package reviewtransaction
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestInvalidateApprovedCompactAuthorityPersistsNativeGateDenial(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	writeSnapshotFile(t, repo, "tracked.txt", "approved candidate\n")
+	gitSnapshot(t, repo, "add", "tracked.txt")
+	gitSnapshot(t, repo, "commit", "-m", "approved candidate")
+	state, store, _ := approvedCompactRevisionFixture(t, repo, "invalidate-approved-denied")
+	before, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	base := trimGit(gitSnapshot(t, repo, "rev-parse", "HEAD^"))
+	branch := currentBranch(context.Background(), repo)
+	remote := configurePublicationRemote(t, repo, branch)
+	gitSnapshot(t, repo, "--git-dir", remote, "branch", "reviewed-base", base)
+
+	record, evaluation, err := InvalidateApprovedCompactAuthority(context.Background(), repo, CompactApprovedInvalidationRequest{
+		LineageID: state.LineageID, ExpectedRevision: before.Revision,
+		Gate: NativeGateRequestInput{Gate: GatePrePR, LineageID: state.LineageID, BaseRef: "origin/" + branch},
+	})
+	if err != nil {
+		t.Fatalf("invalidate approved authority: %v", err)
+	}
+	if evaluation.Result != GateInvalidated || record.State.State != StateInvalidated ||
+		record.State.InvalidationReason != evaluation.Reason || record.Revision == before.Revision {
+		t.Fatalf("approved invalidation = record %#v, evaluation %#v", record, evaluation)
+	}
+	if record.State.InvalidationEvidence == nil || record.State.InvalidationEvidence.Gate != GatePrePR ||
+		!reflect.DeepEqual(record.State.InvalidationEvidence.Context, evaluation.Context) {
+		t.Fatalf("approved invalidation evidence = %#v", record.State.InvalidationEvidence)
+	}
+	if !reflect.DeepEqual(record.State.LensResults, before.State.LensResults) ||
+		record.State.EvidenceHash != before.State.EvidenceHash {
+		t.Fatal("approved invalidation discarded frozen review evidence")
+	}
+	if _, err := os.Stat(store.ReceiptPath()); !os.IsNotExist(err) {
+		t.Fatalf("invalidated authority retained an active receipt: %v", err)
+	}
+	loaded, err := store.Load()
+	if err != nil || !reflect.DeepEqual(loaded, record) {
+		t.Fatalf("persisted invalidation = %#v, %v", loaded, err)
+	}
+	replayed, replayEvaluation, err := InvalidateApprovedCompactAuthority(context.Background(), repo, CompactApprovedInvalidationRequest{
+		LineageID: state.LineageID, ExpectedRevision: before.Revision,
+		Gate: NativeGateRequestInput{Gate: GatePrePR, LineageID: state.LineageID, BaseRef: "origin/" + branch},
+	})
+	if err != nil || !reflect.DeepEqual(replayed, record) || !reflect.DeepEqual(replayEvaluation, evaluation) {
+		t.Fatalf("exact approved invalidation replay = %#v, %#v, %v", replayed, replayEvaluation, err)
+	}
+	successor := newCompactTestState(t, repo, "invalidate-approved-denied-g2")
+	successor.Generation = record.State.Generation + 1
+	recovered, err := RecoverCompactAuthority(context.Background(), repo, CompactRecoveryRequest{
+		PredecessorLineageID: record.State.LineageID, ExpectedPredecessorRevision: record.Revision,
+		Successor: successor, Disposition: RecoveryInvalidated, Reason: "replace invalidated delivery", Actor: "maintainer",
+	})
+	if err != nil || recovered.State.Recovery == nil || recovered.State.Recovery.PredecessorRevision != record.Revision {
+		t.Fatalf("recover invalidated approved predecessor = %#v, %v", recovered, err)
+	}
+}
+
+func TestInvalidateApprovedCompactAuthorityRefusesHealthyGateUnderLock(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	writeSnapshotFile(t, repo, "tracked.txt", "approved candidate\n")
+	state, store, _ := approvedCompactCurrentChangesFixture(t, repo, "invalidate-approved-healthy", []string{})
+	gitSnapshot(t, repo, "add", "tracked.txt")
+	beforeState, err := os.ReadFile(store.StatePath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	beforeReceipt, err := os.ReadFile(store.ReceiptPath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	record, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	originalHook := finalCompactGateAllowHook
+	t.Cleanup(func() { finalCompactGateAllowHook = originalHook })
+	finalCompactGateAllowHook = func() {
+		contender, lockErr := acquireStoreLock(store.lockPath)
+		if contender != nil {
+			_ = contender.release()
+		}
+		if !errors.Is(lockErr, ErrConcurrentUpdate) {
+			t.Fatalf("native derivation did not hold compact LOCK: %v", lockErr)
+		}
+	}
+
+	_, evaluation, err := InvalidateApprovedCompactAuthority(context.Background(), repo, CompactApprovedInvalidationRequest{
+		LineageID: state.LineageID, ExpectedRevision: record.Revision,
+		Gate: NativeGateRequestInput{Gate: GatePreCommit, LineageID: state.LineageID},
+	})
+	if err == nil || !strings.Contains(err.Error(), "healthy approved authority") || evaluation.Result != GateAllow {
+		t.Fatalf("healthy approved invalidation = evaluation %#v, error %v", evaluation, err)
+	}
+	afterState, _ := os.ReadFile(store.StatePath())
+	afterReceipt, _ := os.ReadFile(store.ReceiptPath())
+	if !reflect.DeepEqual(afterState, beforeState) || !reflect.DeepEqual(afterReceipt, beforeReceipt) {
+		t.Fatal("refused healthy invalidation changed authority bytes")
+	}
+}
+
+func TestInvalidateApprovedCompactAuthorityRejectsIncompleteReleaseRequestWithoutMutation(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	state, store, _ := approvedCompactRevisionFixture(t, repo, "invalidate-approved-release-request")
+	record, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	beforeState, _ := os.ReadFile(store.StatePath())
+	beforeReceipt, _ := os.ReadFile(store.ReceiptPath())
+
+	_, evaluation, err := InvalidateApprovedCompactAuthority(context.Background(), repo, CompactApprovedInvalidationRequest{
+		LineageID: state.LineageID, ExpectedRevision: record.Revision,
+		Gate: NativeGateRequestInput{Gate: GateRelease, LineageID: state.LineageID},
+	})
+	if err == nil || !strings.Contains(err.Error(), "release gate requires complete independent release evidence") || evaluation.Result != "" {
+		t.Fatalf("incomplete release invalidation = evaluation %#v, error %v", evaluation, err)
+	}
+	afterState, _ := os.ReadFile(store.StatePath())
+	afterReceipt, _ := os.ReadFile(store.ReceiptPath())
+	if !reflect.DeepEqual(afterState, beforeState) || !reflect.DeepEqual(afterReceipt, beforeReceipt) {
+		t.Fatal("incomplete release request changed approved authority")
+	}
+}
+
+func TestInvalidateApprovedCompactAuthorityPreservesAuthorityOnGitInfrastructureFailure(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	writeSnapshotFile(t, repo, "tracked.txt", "reviewed candidate\n")
+	writeSnapshotFile(t, repo, "intended.txt", "reviewed untracked\n")
+	state := newCompactStartStateForTarget(t, repo, "invalidate-approved-infra", Target{Kind: TargetCurrentChanges, IntendedUntracked: []string{"intended.txt"}})
+	state, store, _ := approvedCompactStateFixture(t, repo, state)
+	gitSnapshot(t, repo, "add", "tracked.txt", "intended.txt")
+	gitSnapshot(t, repo, "commit", "-m", "reviewed candidate")
+	writeSnapshotFile(t, repo, "deleted.txt", "next slice in progress\n")
+	record, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	beforeState, _ := os.ReadFile(store.StatePath())
+	beforeReceipt, _ := os.ReadFile(store.ReceiptPath())
+
+	originalStarter := gitProcessTreeStarter
+	t.Cleanup(func() { gitProcessTreeStarter = originalStarter })
+	gitProcessTreeStarter = func(command *exec.Cmd) (func() error, error) {
+		for _, arg := range command.Args {
+			if arg == "--error-unmatch" {
+				return nil, errors.New("job object creation rejected")
+			}
+		}
+		return originalStarter(command)
+	}
+
+	_, evaluation, err := InvalidateApprovedCompactAuthority(context.Background(), repo, CompactApprovedInvalidationRequest{
+		LineageID: state.LineageID, ExpectedRevision: record.Revision,
+		Gate: NativeGateRequestInput{Gate: GatePostApply, LineageID: state.LineageID},
+	})
+	var control *GitProcessControlError
+	if err == nil || evaluation.Result != GateInvalidated || !errors.As(evaluation.Cause, &control) {
+		t.Fatalf("infrastructure invalidation = evaluation %#v, error %v", evaluation, err)
+	}
+	afterState, _ := os.ReadFile(store.StatePath())
+	afterReceipt, _ := os.ReadFile(store.ReceiptPath())
+	if !reflect.DeepEqual(afterState, beforeState) || !reflect.DeepEqual(afterReceipt, beforeReceipt) {
+		t.Fatal("infrastructure failure changed approved authority")
+	}
+}
+
+func TestInvalidateApprovedCompactAuthorityPersistsBoundSemanticDenial(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	writeSnapshotFile(t, repo, "tracked.txt", "approved candidate\n")
+	state, store, _ := approvedCompactCurrentChangesFixture(t, repo, "invalidate-approved-untracked", []string{})
+	record, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeSnapshotFile(t, repo, "outside.txt", "outside frozen scope\n")
+
+	invalidated, evaluation, err := InvalidateApprovedCompactAuthority(context.Background(), repo, CompactApprovedInvalidationRequest{
+		LineageID: state.LineageID, ExpectedRevision: record.Revision,
+		Gate: NativeGateRequestInput{Gate: GatePostApply, LineageID: state.LineageID},
+	})
+	if err != nil {
+		t.Fatalf("persist semantic denial: %v", err)
+	}
+	if evaluation.Result != GateInvalidated || evaluation.Cause != nil || evaluation.Context.Gate != GatePostApply ||
+		evaluation.Context.LineageID != state.LineageID || evaluation.Context.Generation != state.Generation ||
+		evaluation.Context.StoreRevision != record.Revision || invalidated.State.State != StateInvalidated {
+		t.Fatalf("bound semantic denial = record %#v, evaluation %#v", invalidated, evaluation)
+	}
+	if invalidated.State.InvalidationEvidence == nil || !reflect.DeepEqual(invalidated.State.InvalidationEvidence.Context, evaluation.Context) {
+		t.Fatalf("persisted semantic evidence = %#v", invalidated.State.InvalidationEvidence)
+	}
+	if _, err := os.Stat(store.ReceiptPath()); !os.IsNotExist(err) {
+		t.Fatalf("semantic invalidation retained receipt: %v", err)
+	}
+}
+func TestInvalidateApprovedCompactAuthorityAcceptsCanonicalZeroLensReceipt(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	writeSnapshotFile(t, repo, "tracked.txt", "approved candidate\n")
+	state := newCompactTestState(t, repo, "invalidate-approved-zero-lens")
+	state, store, _ := approvedCompactStateFixture(t, repo, state)
+	record, _ := store.Load()
+	writeSnapshotFile(t, repo, "outside.txt", "outside scope\n")
+
+	invalidated, _, err := InvalidateApprovedCompactAuthority(context.Background(), repo, CompactApprovedInvalidationRequest{
+		LineageID: state.LineageID, ExpectedRevision: record.Revision,
+		Gate: NativeGateRequestInput{Gate: GatePostApply, LineageID: state.LineageID},
+	})
+	if err != nil || invalidated.State.State != StateInvalidated {
+		t.Fatalf("zero-lens receipt invalidation = %#v, %v", invalidated, err)
+	}
+}
+func TestInvalidateApprovedCompactAuthorityPreservesAuthorityWhenFinalReleaseDerivationFails(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	writeSnapshotFile(t, repo, "tracked.txt", "candidate\n")
+	gitSnapshot(t, repo, "add", "tracked.txt")
+	gitSnapshot(t, repo, "commit", "-m", "candidate")
+	state, store, _ := approvedCompactRevisionFixture(t, repo, "invalidate-approved-release-infra")
+	record, _ := store.Load()
+	beforeState, _ := os.ReadFile(store.StatePath())
+	beforeReceipt, _ := os.ReadFile(store.ReceiptPath())
+	dir := t.TempDir()
+	input := NativeGateRequestInput{Gate: GateRelease, LineageID: state.LineageID}
+	for path, target := range map[string]*string{
+		"configuration": &input.ReleaseConfiguration, "generated": &input.ReleaseGenerated,
+		"provenance": &input.ReleaseProvenance, "boundary": &input.ReleasePublicationBoundary,
+		"freshness": &input.ReleaseEvidenceFreshness,
+	} {
+		*target = filepath.Join(dir, path)
+		if err := os.WriteFile(*target, []byte(path+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	originalHook, originalStarter := finalGateAuthorizationHook, gitProcessTreeStarter
+	t.Cleanup(func() { finalGateAuthorizationHook, gitProcessTreeStarter = originalHook, originalStarter })
+	finalGateAuthorizationHook = func() {
+		calls := 0
+		gitProcessTreeStarter = func(command *exec.Cmd) (func() error, error) {
+			if strings.Contains(strings.Join(command.Args, " "), "rev-parse --verify") {
+				calls++
+				if calls == 2 {
+					return nil, errors.New("job object creation rejected")
+				}
+			}
+			return originalStarter(command)
+		}
+	}
+	_, evaluation, err := InvalidateApprovedCompactAuthority(context.Background(), repo, CompactApprovedInvalidationRequest{
+		LineageID: state.LineageID, ExpectedRevision: record.Revision, Gate: input,
+	})
+	var control *GitProcessControlError
+	if err == nil || !errors.As(evaluation.Cause, &control) {
+		t.Fatalf("final release derivation = %#v, %v", evaluation, err)
+	}
+	afterState, _ := os.ReadFile(store.StatePath())
+	afterReceipt, _ := os.ReadFile(store.ReceiptPath())
+	if !reflect.DeepEqual(afterState, beforeState) || !reflect.DeepEqual(afterReceipt, beforeReceipt) {
+		t.Fatal("release infrastructure failure changed approved authority")
+	}
+}
+func TestInvalidateApprovedCompactAuthorityRederivesSemanticDenialBeforePersist(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	writeSnapshotFile(t, repo, "tracked.txt", "approved candidate\n")
+	state, store, _ := approvedCompactCurrentChangesFixture(t, repo, "invalidate-approved-race", []string{})
+	record, _ := store.Load()
+	writeSnapshotFile(t, repo, "outside.txt", "outside scope\n")
+	beforeState, _ := os.ReadFile(store.StatePath())
+	beforeReceipt, _ := os.ReadFile(store.ReceiptPath())
+	originalHook := finalCompactInvalidationHook
+	t.Cleanup(func() { finalCompactInvalidationHook = originalHook })
+	finalCompactInvalidationHook = func() { writeSnapshotFile(t, repo, "late.txt", "concurrent change\n") }
+
+	_, evaluation, err := InvalidateApprovedCompactAuthority(context.Background(), repo, CompactApprovedInvalidationRequest{
+		LineageID: state.LineageID, ExpectedRevision: record.Revision,
+		Gate: NativeGateRequestInput{Gate: GatePostApply, LineageID: state.LineageID},
+	})
+	if err == nil || evaluation.Result != GateInvalidated {
+		t.Fatalf("concurrent denial rederivation = %#v, %v", evaluation, err)
+	}
+	afterState, _ := os.ReadFile(store.StatePath())
+	afterReceipt, _ := os.ReadFile(store.ReceiptPath())
+	if !reflect.DeepEqual(afterState, beforeState) || !reflect.DeepEqual(afterReceipt, beforeReceipt) {
+		t.Fatal("concurrent denial change mutated authority")
+	}
+}
+
+func approvedCompactStateFixture(t *testing.T, repo string, state CompactState) (CompactState, CompactStore, CompactReceipt) {
+	t.Helper()
+	store, err := CompactAuthoritativeStore(context.Background(), repo, state.LineageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	revision, err := store.Replace("", "review/start", state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	results := make([]LensResult, len(state.SelectedLenses))
+	for index, lens := range state.SelectedLenses {
+		results[index] = LensResult{Lens: lens, Findings: []Finding{}, Evidence: []string{"review completed"}}
+	}
+	if err := state.CompleteReview(CompactReviewInput{LensResults: results, Classifications: []FindingEvidence{}, RefuterOutcomes: []EvidenceResult{}}); err != nil {
+		t.Fatal(err)
+	}
+	revision, err = store.Replace(revision, "review/complete-review", state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := state.CompleteVerification([]byte("independent verification passed\n"), true); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Replace(revision, "review/complete-verification", state); err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := state.Receipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteCompactReceiptAtomic(store.ReceiptPath(), receipt); err != nil {
+		t.Fatal(err)
+	}
+	return state, store, receipt
+}

--- a/internal/reviewtransaction/compact_gate.go
+++ b/internal/reviewtransaction/compact_gate.go
@@ -251,7 +251,18 @@ func evaluateCompactGate(ctx context.Context, repo string, receipt CompactReceip
 	}
 	snapshot, resolvedPrePR, err := buildCompactLifecycleSnapshot(ctx, repo, request)
 	if err != nil {
-		return invalid("current repository target cannot be derived: "+err.Error(), err)
+		// A snapshot derivation failure is either a genuine infrastructure
+		// fault (git/process/context) or a semantic scope denial such as an
+		// intended-untracked path that is now tracked or only partially
+		// staged. Guard exactly like validateCompactUntrackedScope above:
+		// attach Cause only for infrastructure faults so they still fail
+		// closed, and otherwise mark a semantic denial so the invalidation
+		// persists through compactInvalidationDenialBound.
+		denialContext.Denial = &GateDenial{Stage: "target-derivation", Code: "unavailable"}
+		if compactGateInfrastructureFailure(err) {
+			return invalid("current repository target cannot be derived: "+err.Error(), err)
+		}
+		return invalid("current repository target cannot be derived: " + err.Error())
 	}
 	if request.Gate == GatePrePush && record.State.InitialSnapshot.Kind == TargetCurrentChanges && snapshot.BaseTree == snapshot.CandidateTree {
 		return invalid("pre-push current-changes receipt requires a delivered tree change")

--- a/internal/reviewtransaction/compact_gate.go
+++ b/internal/reviewtransaction/compact_gate.go
@@ -143,8 +143,13 @@ func compactSquashedFixDelivery(gate GateKind, state CompactState, snapshot Snap
 }
 
 func EvaluateCompactGate(ctx context.Context, repo string, receipt CompactReceipt, input NativeGateRequestInput) NativeGateEvaluation {
+	return evaluateCompactGate(ctx, repo, receipt, input, false)
+}
+
+func evaluateCompactGate(ctx context.Context, repo string, receipt CompactReceipt, input NativeGateRequestInput, authorityLockHeld bool) NativeGateEvaluation {
+	var denialContext GateContext
 	invalid := func(reason string, cause ...error) NativeGateEvaluation {
-		return NativeGateEvaluation{Result: GateInvalidated, Reason: reason, Cause: errors.Join(cause...)}
+		return NativeGateEvaluation{Result: GateInvalidated, Reason: reason, Context: denialContext, Cause: errors.Join(cause...)}
 	}
 	if err := receipt.Validate(); err != nil {
 		return invalid("compact review receipt is invalid: " + err.Error())
@@ -154,18 +159,18 @@ func EvaluateCompactGate(ctx context.Context, repo string, receipt CompactReceip
 	}
 	store, err := CompactAuthoritativeStore(ctx, repo, receipt.LineageID)
 	if err != nil {
-		return invalid("compact review store cannot be derived: " + err.Error())
+		return invalid("compact review store cannot be derived: "+err.Error(), err)
 	}
 	record, err := store.Load()
 	if err != nil {
-		return invalid("compact review authority cannot be loaded: " + err.Error())
+		return invalid("compact review authority cannot be loaded: "+err.Error(), err)
 	}
 	if _, err := CompactAuthorityLeaves(ctx, repo); err != nil {
-		return invalid(err.Error())
+		return invalid(err.Error(), err)
 	}
 	superseded, err := CompactLineageSuperseded(ctx, repo, receipt.LineageID)
 	if err != nil {
-		return invalid(err.Error())
+		return invalid(err.Error(), err)
 	}
 	if superseded {
 		return invalid("compact receipt belongs to superseded historical authority")
@@ -177,7 +182,7 @@ func EvaluateCompactGate(ctx context.Context, repo string, receipt CompactReceip
 	// The findings are immutable once loaded; derive their ledger binding once
 	// so every context emitted below is consistent by construction.
 	ledgerHash := record.State.LedgerHash()
-	denialContext := GateContext{
+	denialContext = GateContext{
 		Gate: input.Gate, LineageID: receipt.LineageID, Generation: receipt.Generation,
 		StoreRevision: record.Revision, GenesisRevision: record.Revision, ChainIdentity: record.Revision, BundleDigest: record.Revision,
 		BaseTree: receipt.BaseTree, CandidateTree: receipt.FinalCandidateTree, PathsDigest: receipt.PathsDigest,
@@ -227,14 +232,19 @@ func EvaluateCompactGate(ctx context.Context, repo string, receipt CompactReceip
 		expectedIntended = nextSliceIntended
 	}
 	if (request.Gate == GatePostApply || request.Gate == GatePreCommit) && !equalStrings(request.Target.IntendedUntracked, expectedIntended) {
+		denialContext.Denial = &GateDenial{Stage: "scope-validation", Code: "intended-untracked-mismatch"}
 		return invalid("current repository target does not retain the authoritative intended-untracked paths")
 	}
 	if err := validateCompactUntrackedScope(ctx, repo, record.State, request); err != nil {
+		denialContext.Denial = &GateDenial{Stage: "scope-validation", Code: "untracked-out-of-scope"}
+		if compactGateInfrastructureFailure(err) {
+			return invalid(err.Error(), err)
+		}
 		return invalid(err.Error())
 	}
 	preimages, err := readGateArtifactPreimages(request)
 	if err != nil {
-		return invalid("compact gate evidence cannot be read: " + err.Error())
+		return invalid("compact gate evidence cannot be read: "+err.Error(), err)
 	}
 	if len(preimages.policy) > 0 && hashArtifactPayload(preimages.policy) != record.State.PolicyHash {
 		return invalid("explicit policy does not match compact authority")
@@ -260,6 +270,9 @@ func EvaluateCompactGate(ctx context.Context, repo string, receipt CompactReceip
 		record.State.InitialSnapshot.Kind == TargetBaseWorkspaceOverlay && (request.Gate == GatePrePush || request.Gate == GatePrePR)
 	if validatePublicationRange {
 		if err := validateReviewedPublicationRange(ctx, repo, record.State.GenesisPaths, resolvedPrePR); err != nil {
+			if compactGateInfrastructureFailure(err) {
+				return invalid(err.Error(), err)
+			}
 			return invalid(err.Error())
 		}
 	}
@@ -326,7 +339,7 @@ func EvaluateCompactGate(ctx context.Context, repo string, receipt CompactReceip
 		diagnostics, diagnosticsErr := buildCompactScopeChangeDiagnostics(ctx, repo, record.State, record.Revision, snapshot)
 		if diagnosticsErr != nil {
 			gateContext.Denial = &GateDenial{Stage: "receipt-binding", Code: "scope-diagnostics-unavailable"}
-			return NativeGateEvaluation{Result: GateInvalidated, Reason: "exact scope-change diagnostics cannot be derived: " + diagnosticsErr.Error(), Context: gateContext}
+			return NativeGateEvaluation{Result: GateInvalidated, Reason: "exact scope-change diagnostics cannot be derived: " + diagnosticsErr.Error(), Context: gateContext, Cause: diagnosticsErr}
 		}
 		gateContext.ScopeChange = &diagnostics
 		return NativeGateEvaluation{Result: GateScopeChanged, Reason: nativeGateReason(GateScopeChanged), Context: gateContext}
@@ -339,7 +352,7 @@ func EvaluateCompactGate(ctx context.Context, repo string, receipt CompactReceip
 	if request.Gate == GateRelease {
 		derived, releaseErr := deriveReleaseEvidence(ctx, repo, request.Release, preimages)
 		if releaseErr != nil {
-			return invalid("release evidence cannot be derived: " + releaseErr.Error())
+			return invalid("release evidence cannot be derived: "+releaseErr.Error(), releaseErr)
 		}
 		if derived.ReleaseTree != snapshot.CandidateTree {
 			return invalid("release evidence does not match the current candidate tree")
@@ -347,11 +360,13 @@ func EvaluateCompactGate(ctx context.Context, repo string, receipt CompactReceip
 		release = &derived
 	}
 	gateContext.Release = release
-	lock, lockErr := acquireStoreLock(store.lockPath)
-	if lockErr != nil {
-		return invalid("compact authority changed during final authorization")
+	if !authorityLockHeld {
+		lock, lockErr := acquireStoreLock(store.lockPath)
+		if lockErr != nil {
+			return invalid("compact authority changed during final authorization")
+		}
+		defer lock.release()
 	}
-	defer lock.release()
 	finalGateAuthorizationHook()
 	finalRecord, loadErr := store.Load()
 	finalSnapshot, finalRefs, snapshotErr := buildCompactLifecycleSnapshot(ctx, repo, request)
@@ -360,23 +375,43 @@ func EvaluateCompactGate(ctx context.Context, repo string, receipt CompactReceip
 	_, graphErr := CompactAuthorityLeaves(ctx, repo)
 	finalSuperseded, supersededErr := CompactLineageSuperseded(ctx, repo, receipt.LineageID)
 	if loadErr != nil || snapshotErr != nil || finalUntrackedErr != nil || finalTrackedErr != nil || graphErr != nil || supersededErr != nil || finalSuperseded || finalRecord.Revision != record.Revision || !reflect.DeepEqual(finalSnapshot, snapshot) || !sameResolvedPrePRRefs(finalRefs, resolvedPrePR) {
-		return invalid("compact authority or repository target changed during final authorization")
+		cause := errors.Join(loadErr, snapshotErr, finalUntrackedErr, finalTrackedErr, graphErr, supersededErr)
+		if cause == nil {
+			cause = ErrConcurrentUpdate
+		}
+		return invalid("compact authority or repository target changed during final authorization", cause)
 	}
 	if recoveryRebind != nil {
 		finalChain, ok, chainErr := deriveCompactRecoveryBinding(ctx, repo, finalRecord.State)
 		if chainErr != nil || !ok || !reflect.DeepEqual(finalChain, *recoveryRebind) {
-			return invalid("compact authority or repository target changed during final authorization")
+			if chainErr == nil {
+				chainErr = ErrConcurrentUpdate
+			}
+			return invalid("compact authority or repository target changed during final authorization", chainErr)
 		}
 	}
 	if request.Gate == GateRelease {
 		finalPreimages, preimageErr := readGateArtifactPreimages(request)
 		finalRelease, releaseErr := deriveReleaseEvidence(ctx, repo, request.Release, finalPreimages)
 		if preimageErr != nil || releaseErr != nil || release == nil || finalRelease != *release {
-			return invalid("release evidence changed during final authorization")
+			cause := errors.Join(preimageErr, releaseErr)
+			if cause == nil {
+				cause = ErrConcurrentUpdate
+			}
+			return invalid("release evidence changed during final authorization", cause)
 		}
 	}
 	finalCompactGateAllowHook()
 	return NativeGateEvaluation{Result: GateAllow, Reason: nativeGateReason(GateAllow), Context: gateContext}
+}
+
+func compactGateInfrastructureFailure(err error) bool {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	var command *GitCommandError
+	var processControl *GitProcessControlError
+	return errors.As(err, &command) || errors.As(err, &processControl)
 }
 
 func buildCompactScopeChangeDiagnostics(ctx context.Context, repo string, state CompactState, revision string, actual Snapshot) (GateScopeChangeDiagnostics, error) {


### PR DESCRIPTION
Closes #1269

## Summary
- Invalidates an approved compact-v2 authority when a subsequent gate denial classifies the target as no longer deliverable, instead of leaving stale approved authority in place.
- Classifies gate denial causes (semantic vs fail-closed request/infrastructure) before mutating authority.

## Test Plan
- [x] `go test ./internal/cli/... ./internal/reviewtransaction/...`
- [x] Full suite `go test ./...` green


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for invalidating approved compact authorities using lifecycle gates.
  * Expanded `review invalidate` with optional base-advance evidence and release-related evidence/artifacts for approved invalidation workflows.
  * Approved invalidations now record structured evidence to support consistent replay.

* **Bug Fixes**
  * Rejects invalidation of healthy approved authorities and incomplete release-gate requests.
  * Tightened validation of invalidation evidence and exact store-revision binding.
  * Preserves stored authority and receipt files when infrastructure or final derivation fails; improves denial/cause handling.

* **Tests**
  * Added CLI and unit test coverage for replay, refusal, and immutability behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->