### PR TITLE
fix(review): confine historical legacy lock corruption

### DIFF
--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -1506,30 +1506,42 @@ func discoverCompactFacadeGateReview(ctx context.Context, repo, lineage string, 
 }
 
 // reviewAuthorityCorruptionConfinedToLegacyEntries reports whether every cause
-// of a non-authoritative inventory is an invalid legacy-v1 entry, which can
-// never resolve as a compact discovery candidate. Inventory IO/layout
-// diagnostics, ambiguous locks, reset residue, mixed-store collisions, and any
-// compact-v2 problem keep lineage-less discovery fail-closed.
+// of a non-authoritative inventory is either an unreadable legacy-v1 entry or
+// ambiguous lock residue attached to terminal pre-receipt legacy history.
+// Inventory IO/layout diagnostics, active or invalidated authority, incomplete
+// entries, reset residue, mixed-store collisions, and every compact-v2 problem
+// keep lineage-less discovery fail-closed.
 func reviewAuthorityCorruptionConfinedToLegacyEntries(report reviewtransaction.AuthorityStatusReport, inventoryErr error) bool {
 	if inventoryErr != nil || len(report.Diagnostics) > 0 {
 		return false
 	}
-	for _, lock := range report.Locks {
-		if lock.Status == reviewtransaction.AuthorityLockAmbiguous {
-			return false
-		}
-	}
+	historicalLegacy := map[string]bool{}
 	confined := false
 	for _, entry := range report.Entries {
+		if entry.Version == reviewtransaction.AuthorityVersionLegacy &&
+			entry.Status == reviewtransaction.AuthorityStatusHistorical {
+			historicalLegacy[entry.LineageID] = true
+		}
 		switch entry.Status {
 		case reviewtransaction.AuthorityStatusInvalid:
-			if entry.Version != reviewtransaction.AuthorityVersionLegacy {
+			if entry.Version != reviewtransaction.AuthorityVersionLegacy ||
+				len(entry.Problems) == 0 ||
+				entry.State != "" && entry.State != reviewtransaction.StateApproved && entry.State != reviewtransaction.StateEscalated {
 				return false
 			}
 			confined = true
-		case reviewtransaction.AuthorityStatusReset, reviewtransaction.AuthorityStatusCollision:
+		case reviewtransaction.AuthorityStatusIncomplete, reviewtransaction.AuthorityStatusReset, reviewtransaction.AuthorityStatusCollision:
 			return false
 		}
+	}
+	for _, lock := range report.Locks {
+		if lock.Status != reviewtransaction.AuthorityLockAmbiguous {
+			continue
+		}
+		if lock.Version != reviewtransaction.AuthorityVersionLegacy || !historicalLegacy[lock.LineageID] {
+			return false
+		}
+		confined = true
 	}
 	return confined
 }

--- a/internal/cli/review_receipt_discovery_test.go
+++ b/internal/cli/review_receipt_discovery_test.go
@@ -436,6 +436,119 @@ func TestUnscopedGateDiscoveryToleratesCorruptedUnrelatedLegacyInventory(t *test
 	}
 }
 
+func TestUnscopedReleaseGateDiscoveryConfinesHistoricalLegacyLockCorruption(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	started, _ := approveDiscoveryMarkdown(t, repo, "review-release-current", "docs/release.md", "release\n")
+	runReviewCLIGit(t, repo, "add", "-A")
+	runReviewCLIGit(t, repo, "commit", "-qm", "reviewed release target")
+	legacyStore, _ := approveLegacyDiscoveryChain(t, repo, "review-release-history")
+	if err := os.Remove(filepath.Join(legacyStore.Dir, "artifacts", "receipt.json")); err != nil {
+		t.Fatal(err)
+	}
+	lockPath := filepath.Join(legacyStore.Dir, "LOCK")
+	if err := os.WriteFile(lockPath, []byte("{broken\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	report, err := reviewtransaction.InventoryAuthority(context.Background(), repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.Complete || report.Authoritative {
+		t.Fatalf("historical lock fixture remained authoritative = %#v", report)
+	}
+	historical, ambiguous := false, false
+	for _, entry := range report.Entries {
+		historical = historical || entry.LineageID == "review-release-history" &&
+			entry.Status == reviewtransaction.AuthorityStatusHistorical
+	}
+	for _, lock := range report.Locks {
+		ambiguous = ambiguous || lock.LineageID == "review-release-history" &&
+			lock.Status == reviewtransaction.AuthorityLockAmbiguous
+	}
+	if !historical || !ambiguous {
+		t.Fatalf("historical lock fixture = %#v", report)
+	}
+
+	_, record, err := discoverCompactFacadeGateReview(context.Background(), repo, "", reviewtransaction.NativeGateRequestInput{
+		Gate: reviewtransaction.GateRelease,
+	})
+	if err != nil {
+		t.Fatalf("historical legacy lock poisoned release discovery: %v", err)
+	}
+	if record.State.LineageID != started.LineageID {
+		t.Fatalf("release discovery selected %q, want %q", record.State.LineageID, started.LineageID)
+	}
+}
+
+func TestReviewAuthorityCorruptionConfinementBoundary(t *testing.T) {
+	legacyAliasProblem := "invalid successor: unsupported historical v1 operation alias"
+	tests := []struct {
+		name   string
+		report reviewtransaction.AuthorityStatusReport
+		want   bool
+	}{
+		{
+			name: "active corruption",
+			report: reviewtransaction.AuthorityStatusReport{Entries: []reviewtransaction.AuthorityInventoryEntry{
+				{Version: reviewtransaction.AuthorityVersionLegacy, LineageID: "active", Status: reviewtransaction.AuthorityStatusInvalid, State: reviewtransaction.StateInvalidated},
+			}},
+		},
+		{
+			name: "legacy-only corruption",
+			report: reviewtransaction.AuthorityStatusReport{Entries: []reviewtransaction.AuthorityInventoryEntry{
+				{Version: reviewtransaction.AuthorityVersionLegacy, LineageID: "legacy-broken", Status: reviewtransaction.AuthorityStatusInvalid, Problems: []string{legacyAliasProblem}},
+			}},
+			want: true,
+		},
+		{
+			name: "mixed history",
+			report: reviewtransaction.AuthorityStatusReport{
+				Entries: []reviewtransaction.AuthorityInventoryEntry{
+					{Version: reviewtransaction.AuthorityVersionCompact, LineageID: "current", Status: reviewtransaction.AuthorityStatusApproved},
+					{Version: reviewtransaction.AuthorityVersionLegacy, LineageID: "legacy-broken", Status: reviewtransaction.AuthorityStatusInvalid, Problems: []string{legacyAliasProblem}},
+					{Version: reviewtransaction.AuthorityVersionLegacy, LineageID: "legacy-history", Status: reviewtransaction.AuthorityStatusHistorical},
+				},
+				Locks: []reviewtransaction.AuthorityLockEvidence{
+					{Version: reviewtransaction.AuthorityVersionLegacy, LineageID: "legacy-history", Status: reviewtransaction.AuthorityLockAmbiguous},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "valid state",
+			report: reviewtransaction.AuthorityStatusReport{Entries: []reviewtransaction.AuthorityInventoryEntry{
+				{Version: reviewtransaction.AuthorityVersionCompact, LineageID: "current", Status: reviewtransaction.AuthorityStatusApproved},
+			}},
+		},
+		{
+			name: "active legacy lock",
+			report: reviewtransaction.AuthorityStatusReport{
+				Entries: []reviewtransaction.AuthorityInventoryEntry{
+					{Version: reviewtransaction.AuthorityVersionLegacy, LineageID: "active", Status: reviewtransaction.AuthorityStatusActive},
+				},
+				Locks: []reviewtransaction.AuthorityLockEvidence{
+					{Version: reviewtransaction.AuthorityVersionLegacy, LineageID: "active", Status: reviewtransaction.AuthorityLockAmbiguous},
+				},
+			},
+		},
+		{
+			name: "incomplete current entry mixed with legacy corruption",
+			report: reviewtransaction.AuthorityStatusReport{Entries: []reviewtransaction.AuthorityInventoryEntry{
+				{Version: reviewtransaction.AuthorityVersionLegacy, LineageID: "legacy-broken", Status: reviewtransaction.AuthorityStatusInvalid, Problems: []string{legacyAliasProblem}},
+				{Version: reviewtransaction.AuthorityVersionCompact, LineageID: "current", Status: reviewtransaction.AuthorityStatusIncomplete},
+			}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := reviewAuthorityCorruptionConfinedToLegacyEntries(tt.report, nil); got != tt.want {
+				t.Fatalf("confinement = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestUnscopedGateDiscoveryExcludesTamperedLegacyReceiptFromCandidates(t *testing.T) {
 	repo := initReviewCLIRepo(t)
 	started, _ := approveDiscoveryMarkdown(t, repo, "review-discovery-valid", "docs/valid.md", "valid\n")


### PR DESCRIPTION
## Linked Issue

Closes #1439

## PR Type

- [x] `type:bug` - Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` - New feature (non-breaking change that adds functionality)
- [ ] `type:docs` - Documentation only
- [ ] `type:refactor` - Code refactoring (no functional changes)
- [ ] `type:chore` - Build, CI, or tooling changes
- [ ] `type:breaking-change` - Breaking change

## Summary

Confines release-gate inventory corruption only when it is provably historical legacy-v1 evidence. Ambiguous lock residue is tolerated only when it belongs to a terminal `historical-pre-receipt` lineage, while active or invalidated legacy authority, incomplete entries, mixed-store collisions, reset residue, diagnostics, and all compact-v2 corruption remain fail-closed.

## Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/cli/review_facade.go` | Classifies terminal historical legacy lock residue as confined without weakening current authority checks. |
| `internal/cli/review_receipt_discovery_test.go` | Adds deterministic release discovery and boundary coverage for active corruption, legacy-only corruption, mixed history, and valid state. |

## Test Plan

**Focused tests**
```bash
go test ./internal/cli -run '^(TestUnscopedReleaseGateDiscoveryConfinesHistoricalLegacyLockCorruption|TestReviewAuthorityCorruptionConfinementBoundary|TestUnscopedGateDiscoveryToleratesCorruptedUnrelatedLegacyInventory|TestUnscopedGateDiscoveryExcludesTamperedLegacyReceiptFromCandidates)$' -count=1 -v
go test -race ./internal/cli -run '^(TestUnscopedReleaseGateDiscoveryConfinesHistoricalLegacyLockCorruption|TestReviewAuthorityCorruptionConfinementBoundary|TestUnscopedGateDiscoveryToleratesCorruptedUnrelatedLegacyInventory|TestUnscopedGateDiscoveryExcludesTamperedLegacyReceiptFromCandidates)$' -count=1
```

**Repository checks**
```bash
go vet ./...
go run ./internal/gofmtcheck
go build ./...
cd e2e && ./docker-test.sh
```

- [ ] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [x] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Manually tested locally

Focused tests and focused race coverage pass. Docker E2E passes on Ubuntu, Arch, and Fedora (`3/3`; each platform `79 passed, 0 failed, 2 skipped`).

The full `go test ./...` run is not green on current `main` in this macOS environment due unrelated existing failures: malformed quarantine authorization fixtures, a CodeGraph deadline-phase timing assertion, a Kimi/`uv` environment expectation, and Git tests conflicting with the system `init.defaultBranch=main` setting. None touch this PR's files or behavior.

## Automated Checks

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | Pending | 136 changed lines, below the 400-line budget. |
| Check Issue Reference | Pending | `Closes #1439`. |
| Check Issue Has `status:approved` | Pending | Issue is approved. |
| Check PR Has `type:*` Label | Pending | `type:bug`. |
| Unit Tests | Pending | CI verification. |
| Go Format | Pending | Passed locally. |
| E2E Tests | Pending | Passed locally on all three Docker platforms. |

## Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [ ] Maintainer must add exactly one `type:*` label (`type:bug` requested)
- [ ] Full unit suite passes locally; unrelated current-main failures are documented above
- [x] E2E tests pass
- [x] Documentation is not required for this internal compatibility fix
- [x] Commit follows Conventional Commits format
- [x] Commit has no `Co-Authored-By` trailers

## Notes for Reviewers

The key review boundary is in `reviewAuthorityCorruptionConfinedToLegacyEntries`: historical legacy exceptions require either an unreadable legacy entry already covered by scoped discovery, a terminal approved/escalated legacy entry, or an ambiguous lock mapped to `historical-pre-receipt`. Current and compact authority never enter the exception path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release gate discovery when historical legacy records contain corrupted lock data.
  * Prevented invalid historical evidence from overriding the authority of the current release review.
  * Added stricter validation so only clearly confined legacy corruption is ignored; active or ambiguous corruption remains blocking.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->