### PR TITLE
fix(review): reconcile dual-anomaly recovery edge

### DIFF
--- a/internal/cli/review_reconcile.go
+++ b/internal/cli/review_reconcile.go
@@ -16,7 +16,7 @@ type ReviewReconcileAuthorityResult struct {
 }
 
 func RunReviewReconcileAuthority(args []string, stdout io.Writer) error {
-	flags := newReviewFlagSet("review reconcile-authority", stdout, "Quarantine one compact-v2 recovery successor whose recovery edge natively re-derives as invalid for exactly one supported class — an unchanged target, or a historical pre-contract free-form maintainer authorization on an otherwise structurally consistent edge — with a persisted audit record carrying the re-derived proof; valid edges, incomplete entries, non-recovery records, and structurally inconsistent edges are refused. On partial failure the prepared audit record JSON is still emitted to stdout and the command exits non-zero.")
+	flags := newReviewFlagSet("review reconcile-authority", stdout, "Quarantine one compact-v2 recovery successor whose recovery edge natively re-derives as invalid for either or both supported classes: an unchanged target and a historical pre-contract free-form maintainer authorization on an otherwise structurally consistent edge. The persisted audit record carries every re-derived proof; valid edges, incomplete entries, non-recovery records, and structurally inconsistent edges are refused. On partial failure the prepared audit record JSON is still emitted to stdout and the command exits non-zero.")
 	cwd := flags.String("cwd", ".", "repository path")
 	predecessor := flags.String("predecessor-lineage", "", "exact recovery predecessor lineage; it stays untouched")
 	expectedPredecessor := flags.String("expected-predecessor-revision", "", "exact predecessor revision")
@@ -24,7 +24,7 @@ func RunReviewReconcileAuthority(args []string, stdout io.Writer) error {
 	expectedSuccessor := flags.String("expected-successor-revision", "", "exact successor revision")
 	reason := flags.String("reason", "", "non-empty reconcile reason")
 	actor := flags.String("actor", "", "reconcile actor")
-	authorization := flags.String("maintainer-authorization", "", "exact seven-line LF-only binding: gentle-ai.review-reconcile-authorization/v1, predecessor_lineage, predecessor_revision, successor_lineage, successor_revision, actor, reason")
+	authorization := flags.String("maintainer-authorization", "", "exact LF-only binding: gentle-ai.review-reconcile-authorization/v1, predecessor_lineage, predecessor_revision, successor_lineage, successor_revision, actor, reason; combined repair appends anomalies=unchanged_target,malformed_recovery_authorization")
 	if err := parseReviewFlags(flags, args); err != nil {
 		return err
 	}

--- a/internal/cli/review_reconcile_test.go
+++ b/internal/cli/review_reconcile_test.go
@@ -43,9 +43,9 @@ func writeReconcileCLIRecord(t *testing.T, repo string, state reviewtransaction.
 }
 
 // invalidRecoveryEdgeCLIFixture persists an escalated docs-only predecessor
-// with its receipt and a recovery successor whose sole anomaly is an unchanged
-// target, then restores the clean workspace.
-func invalidRecoveryEdgeCLIFixture(t *testing.T, repo string) (predecessorRevision, successorRevision string) {
+// with its receipt and an unchanged-target recovery successor, then restores
+// the clean workspace. recoveryAuthorization can add the pre-contract anomaly.
+func invalidRecoveryEdgeCLIFixture(t *testing.T, repo, recoveryAuthorization string) (predecessorRevision, successorRevision string) {
 	t.Helper()
 	incident := filepath.Join(repo, "docs", "incident.md")
 	if err := os.MkdirAll(filepath.Dir(incident), 0o755); err != nil {
@@ -102,6 +102,9 @@ func invalidRecoveryEdgeCLIFixture(t *testing.T, repo string) (predecessorRevisi
 			"\npredecessor_revision=" + predecessorRevision + "\ntarget_identity=" + successorState.InitialSnapshot.Identity +
 			"\nactor=maintainer@example.com\nreason=retry after escalation",
 	}
+	if recoveryAuthorization != "" {
+		successorState.Recovery.MaintainerAuthorization = recoveryAuthorization
+	}
 	successorRevision = writeReconcileCLIRecord(t, repo, successorState)
 	if err := os.Remove(incident); err != nil {
 		t.Fatal(err)
@@ -125,10 +128,15 @@ func reconcileCLIBinding(predecessorRevision, successorRevision string) string {
 		"\nactor=maintainer@example.com\nreason=quarantine invalid unchanged-target recovery edge"
 }
 
+func combinedReconcileCLIBinding(predecessorRevision, successorRevision string) string {
+	return reconcileCLIBinding(predecessorRevision, successorRevision) +
+		"\nanomalies=unchanged_target,malformed_recovery_authorization"
+}
+
 func TestReviewReconcileAuthorityQuarantinesInvalidEdgeAndRestoresDiscovery(t *testing.T) {
 	repo := initReviewCLIRepo(t)
 	approveDiscoveryMarkdown(t, repo, "review-reconcile-valid", "docs/valid.md", "valid\n")
-	predecessorRevision, successorRevision := invalidRecoveryEdgeCLIFixture(t, repo)
+	predecessorRevision, successorRevision := invalidRecoveryEdgeCLIFixture(t, repo, "")
 
 	var statusOutput bytes.Buffer
 	if err := RunReview([]string{"status", "--cwd", repo}, &statusOutput); err != nil {
@@ -196,6 +204,30 @@ func TestReviewReconcileAuthorityQuarantinesInvalidEdgeAndRestoresDiscovery(t *t
 
 	if err := RunReview(reconcileCLIArgs(repo, predecessorRevision, successorRevision, reconcileCLIBinding(predecessorRevision, successorRevision)), &bytes.Buffer{}); err == nil {
 		t.Fatal("review reconcile-authority replayed after quarantine")
+	}
+}
+
+func TestReviewReconcileAuthorityQuarantinesCombinedRecoveryAnomalies(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	const recordedAuthorization = "maintainer approved incident retry per the 2.1.6 runbook"
+	predecessorRevision, successorRevision := invalidRecoveryEdgeCLIFixture(t, repo, recordedAuthorization)
+
+	var output bytes.Buffer
+	if err := RunReview(reconcileCLIArgs(repo, predecessorRevision, successorRevision, combinedReconcileCLIBinding(predecessorRevision, successorRevision)), &output); err != nil {
+		t.Fatalf("review reconcile-authority combined repair: %v\n%s", err, output.String())
+	}
+	var result ReviewReconcileAuthorityResult
+	decodeStrictReviewJSON(t, output.Bytes(), &result)
+	if result.Record.Status != reviewtransaction.CompactReclaimCommitted || result.Record.InvalidRecoveryEdge == nil ||
+		result.Record.MalformedRecoveryAuthorization == nil {
+		t.Fatalf("combined reconcile result = %#v", result)
+	}
+	recordedDigest := sha256.Sum256([]byte(recordedAuthorization))
+	if result.Record.MalformedRecoveryAuthorization.RecordedAuthorizationSHA256 != "sha256:"+hex.EncodeToString(recordedDigest[:]) {
+		t.Fatalf("combined authorization digest = %q", result.Record.MalformedRecoveryAuthorization.RecordedAuthorizationSHA256)
+	}
+	if _, err := os.Stat(filepath.Join(result.Record.QuarantinePath, "residue", "review-state.json")); err != nil {
+		t.Fatalf("combined quarantined successor state missing: %v", err)
 	}
 }
 
@@ -390,7 +422,7 @@ func TestReviewReconcileAuthorityRepairsPreContractAuthorizationAndRestoresLifec
 
 func TestReviewReconcileAuthorityRequiresFlagsAndExactBinding(t *testing.T) {
 	repo := initReviewCLIRepo(t)
-	predecessorRevision, successorRevision := invalidRecoveryEdgeCLIFixture(t, repo)
+	predecessorRevision, successorRevision := invalidRecoveryEdgeCLIFixture(t, repo, "")
 	statePath := filepath.Join(reviewCLIAuthorityRoot(t, repo), "v2", "reconcile-incident-g2", "review-state.json")
 	payload, err := os.ReadFile(statePath)
 	if err != nil {

--- a/internal/reviewtransaction/compact_reconcile.go
+++ b/internal/reviewtransaction/compact_reconcile.go
@@ -14,6 +14,7 @@ import (
 )
 
 const compactReconcileAuthorizationSchema = "gentle-ai.review-reconcile-authorization/v1"
+const compactCombinedRecoveryAnomalies = "unchanged_target,malformed_recovery_authorization"
 
 // CompactReconcileRequest identifies one recovery successor whose persisted
 // recovery edge must natively re-derive as invalid before quarantine, together
@@ -57,11 +58,16 @@ func compactReconcileAuthorizationBinding(predecessorLineage, predecessorRevisio
 		"\nactor=" + strings.TrimSpace(actor) + "\nreason=" + strings.TrimSpace(reason)
 }
 
+func compactCombinedReconcileAuthorizationBinding(predecessorLineage, predecessorRevision, successorLineage, successorRevision, actor, reason string) string {
+	return compactReconcileAuthorizationBinding(predecessorLineage, predecessorRevision, successorLineage, successorRevision, actor, reason) +
+		"\nanomalies=" + compactCombinedRecoveryAnomalies
+}
+
 // ReconcileInvalidRecoveryEdge quarantines one compact-v2 recovery successor
-// whose recovery edge natively re-derives as invalid for exactly one of two
-// supported classes: the unchanged-target class, and the pre-contract
-// malformed-recovery-authorization class in which a historical free-form
-// maintainer authorization predates the exact
+// whose recovery edge natively re-derives as invalid for either or both of two
+// supported classes: the unchanged-target class, and the pre-contract malformed-
+// recovery-authorization class in which a historical free-form maintainer
+// authorization predates the exact
 // gentle-ai.review-recovery-authorization/v1 binding while the edge is
 // otherwise structurally consistent. The predecessor and every unrelated
 // authority stay untouched; the successor entry moves whole — never deleted —
@@ -122,25 +128,43 @@ func ReconcileInvalidRecoveryEdge(ctx context.Context, repo string, request Comp
 	if successor.Revision != request.ExpectedSuccessorRevision {
 		return CompactReclaimRecord{}, fmt.Errorf("%w: expected successor revision %q, current %q", ErrConcurrentUpdate, request.ExpectedSuccessorRevision, successor.Revision)
 	}
-	if request.MaintainerAuthorization != compactReconcileAuthorizationBinding(request.PredecessorLineageID, predecessor.Revision, request.SuccessorLineageID, successor.Revision, request.Actor, request.Reason) {
-		return CompactReclaimRecord{}, fmt.Errorf("review reconcile-authority requires an exact maintainer authorization binding (schema %s over predecessor %s@%s and successor %s@%s)",
-			compactReconcileAuthorizationSchema, request.PredecessorLineageID, predecessor.Revision, request.SuccessorLineageID, successor.Revision)
-	}
 	edgeErr := validateCompactRecoveryEdge(predecessor, successor.State)
 	if edgeErr == nil {
 		return CompactReclaimRecord{}, fmt.Errorf("review reconcile-authority refused: recovery edge for %q validates; the successor remains authoritative", request.SuccessorLineageID)
 	}
 	exactRecordedBinding := compactRecoveryAuthorizationBinding(predecessor.State.LineageID, predecessor.Revision, successor.State.InitialSnapshot.Identity, recovery.Actor, recovery.Reason)
+	expectedReconcileAuthorization := compactReconcileAuthorizationBinding(
+		request.PredecessorLineageID, predecessor.Revision, request.SuccessorLineageID, successor.Revision,
+		request.Actor, request.Reason)
 	var invalidEdgeProof *CompactInvalidRecoveryEdgeProof
 	var malformedAuthorizationProof *CompactMalformedRecoveryAuthorizationProof
 	switch {
 	case errors.Is(edgeErr, errCompactRecoveryTargetUnchanged):
-		if recovery.MaintainerAuthorization != exactRecordedBinding {
-			return CompactReclaimRecord{}, errors.New("review reconcile-authority refused: unchanged target is not the sole anomaly; the recorded recovery authorization binding is inexact")
-		}
 		invalidEdgeProof = &CompactInvalidRecoveryEdgeProof{
 			PredecessorLineageID: request.PredecessorLineageID, PredecessorRevision: predecessor.Revision,
 			SuccessorRevision: successor.Revision, ValidationError: edgeErr.Error(),
+		}
+		if recovery.MaintainerAuthorization != exactRecordedBinding {
+			if strings.HasPrefix(recovery.MaintainerAuthorization, compactRecoveryAuthorizationSchema) {
+				return CompactReclaimRecord{}, fmt.Errorf("review reconcile-authority refused: unchanged target is not the sole anomaly; successor %q records a %s binding bound to different content, which is corruption rather than a pre-contract authorization", request.SuccessorLineageID, compactRecoveryAuthorizationSchema)
+			}
+			repaired := successor.State
+			provenance := *recovery
+			provenance.MaintainerAuthorization = exactRecordedBinding
+			repaired.Recovery = &provenance
+			if residualErr := validateCompactRecoveryEdge(predecessor, repaired); !errors.Is(residualErr, errCompactRecoveryTargetUnchanged) {
+				return CompactReclaimRecord{}, fmt.Errorf("review reconcile-authority refused: combined recovery anomalies do not re-derive exactly: %v", residualErr)
+			}
+			recorded := sha256.Sum256([]byte(recovery.MaintainerAuthorization))
+			malformedAuthorizationProof = &CompactMalformedRecoveryAuthorizationProof{
+				PredecessorLineageID: request.PredecessorLineageID, PredecessorRevision: predecessor.Revision,
+				SuccessorRevision:           successor.Revision,
+				RecordedAuthorizationSHA256: "sha256:" + hex.EncodeToString(recorded[:]),
+				ValidationError:             compactRecoveryAuthorizationError(successor.State.InitialSnapshot).Error(),
+			}
+			expectedReconcileAuthorization = compactCombinedReconcileAuthorizationBinding(
+				request.PredecessorLineageID, predecessor.Revision, request.SuccessorLineageID, successor.Revision,
+				request.Actor, request.Reason)
 		}
 	case errors.Is(edgeErr, errCompactRecoveryAuthorizationInexact):
 		if strings.HasPrefix(recovery.MaintainerAuthorization, compactRecoveryAuthorizationSchema) {
@@ -162,6 +186,10 @@ func ReconcileInvalidRecoveryEdge(ctx context.Context, repo string, request Comp
 		}
 	default:
 		return CompactReclaimRecord{}, fmt.Errorf("review reconcile-authority refused: recovery edge fails outside the unchanged-target class and the pre-contract authorization class: %v", edgeErr)
+	}
+	if request.MaintainerAuthorization != expectedReconcileAuthorization {
+		return CompactReclaimRecord{}, fmt.Errorf("review reconcile-authority requires an exact maintainer authorization binding (schema %s over predecessor %s@%s and successor %s@%s)",
+			compactReconcileAuthorizationSchema, request.PredecessorLineageID, predecessor.Revision, request.SuccessorLineageID, successor.Revision)
 	}
 	stores, err := DiscoverCompactStores(ctx, repo)
 	if err != nil {

--- a/internal/reviewtransaction/compact_reconcile_test.go
+++ b/internal/reviewtransaction/compact_reconcile_test.go
@@ -79,6 +79,25 @@ func reconcileFixtureRequest(predecessor, successor CompactRecord) CompactReconc
 	return request
 }
 
+func combinedRecoveryFixture(t *testing.T, repo string, mutate func(*CompactState)) (CompactRecord, CompactStore, CompactRecord, CompactStore) {
+	t.Helper()
+	return poisonedRecoveryFixture(t, repo, func(state *CompactState) {
+		state.Recovery.MaintainerAuthorization = preContractFixtureAuthorization
+		if mutate != nil {
+			mutate(state)
+		}
+	})
+}
+
+func combinedReconcileFixtureRequest(predecessor, successor CompactRecord) CompactReconcileRequest {
+	request := reconcileFixtureRequest(predecessor, successor)
+	request.Reason = "quarantine combined recovery anomalies"
+	request.MaintainerAuthorization = compactReconcileAuthorizationBinding(
+		request.PredecessorLineageID, predecessor.Revision, request.SuccessorLineageID, successor.Revision,
+		request.Actor, request.Reason) + "\nanomalies=unchanged_target,malformed_recovery_authorization"
+	return request
+}
+
 func TestReconcileInvalidRecoveryEdgeQuarantinesSuccessorAndRestoresAuthority(t *testing.T) {
 	repo := initSnapshotRepo(t)
 	predecessor, predecessorStore, successor, successorStore := poisonedRecoveryFixture(t, repo, nil)
@@ -176,6 +195,143 @@ func TestReconcileInvalidRecoveryEdgeQuarantinesSuccessorAndRestoresAuthority(t 
 	if err != nil || started.Action != CompactStartRecover || started.Record.State.LineageID != predecessor.State.LineageID {
 		t.Fatalf("post-reconcile lineage-less start = %#v, %v", started, err)
 	}
+}
+
+func TestReconcileCombinedRecoveryAnomaliesQuarantinesWithBothProofsAndRestoresAuthority(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	predecessor, predecessorStore, successor, successorStore := combinedRecoveryFixture(t, repo, nil)
+	if _, err := CompactAuthorityLeaves(context.Background(), repo); err == nil || !strings.Contains(err.Error(), "target has not changed") {
+		t.Fatalf("combined-anomaly graph leaves error = %v", err)
+	}
+	predecessorStateBefore, err := os.ReadFile(predecessorStore.StatePath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	successorPayload, err := os.ReadFile(successorStore.StatePath())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	request := combinedReconcileFixtureRequest(predecessor, successor)
+	record, err := ReconcileInvalidRecoveryEdge(context.Background(), repo, request)
+	if err != nil {
+		t.Fatalf("reconcile combined recovery anomalies: %v", err)
+	}
+	if record.Status != CompactReclaimCommitted || record.InvalidRecoveryEdge == nil ||
+		!strings.Contains(record.InvalidRecoveryEdge.ValidationError, "target has not changed") {
+		t.Fatalf("combined unchanged-target proof = %#v", record.InvalidRecoveryEdge)
+	}
+	recordedDigest := sha256.Sum256([]byte(preContractFixtureAuthorization))
+	if record.MalformedRecoveryAuthorization == nil ||
+		record.MalformedRecoveryAuthorization.RecordedAuthorizationSHA256 != "sha256:"+hex.EncodeToString(recordedDigest[:]) ||
+		!strings.Contains(record.MalformedRecoveryAuthorization.ValidationError, "exact maintainer authorization binding") {
+		t.Fatalf("combined malformed-authorization proof = %#v", record.MalformedRecoveryAuthorization)
+	}
+	moved, err := os.ReadFile(filepath.Join(record.QuarantinePath, "residue", "review-state.json"))
+	if err != nil || !bytes.Equal(moved, successorPayload) {
+		t.Fatalf("quarantined combined successor bytes = %q, %v", moved, err)
+	}
+	persistedPayload, err := os.ReadFile(filepath.Join(record.QuarantinePath, "reclaim-record.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var persisted CompactReclaimRecord
+	if err := json.Unmarshal(persistedPayload, &persisted); err != nil {
+		t.Fatal(err)
+	}
+	if persisted.InvalidRecoveryEdge == nil || persisted.MalformedRecoveryAuthorization == nil ||
+		persisted.MalformedRecoveryAuthorization.RecordedAuthorizationSHA256 != record.MalformedRecoveryAuthorization.RecordedAuthorizationSHA256 {
+		t.Fatalf("persisted combined audit record = %#v", persisted)
+	}
+	predecessorStateAfter, err := os.ReadFile(predecessorStore.StatePath())
+	if err != nil || !bytes.Equal(predecessorStateBefore, predecessorStateAfter) {
+		t.Fatal("combined reconcile changed predecessor authority bytes")
+	}
+	leaves, err := CompactAuthorityLeaves(context.Background(), repo)
+	if err != nil || len(leaves) != 1 || leaves[0].lineageID != predecessor.State.LineageID {
+		t.Fatalf("post-combined-reconcile leaves = %#v, %v", leaves, err)
+	}
+	writeSnapshotFile(t, repo, "tracked.txt", "post-combined-repair target\n")
+	started, err := StartCompactAuthority(context.Background(), repo, CompactStartRequest{State: newCompactTestState(t, repo, "reconcile-combined-fresh")})
+	if err != nil || started.Action != CompactStartRecover || started.Record.State.LineageID != predecessor.State.LineageID {
+		t.Fatalf("post-combined-reconcile start = %#v, %v", started, err)
+	}
+}
+
+func TestReconcileCombinedRecoveryAnomaliesRefusesWithoutMutation(t *testing.T) {
+	assertUntouched := func(t *testing.T, repo string, store CompactStore, payload []byte) {
+		t.Helper()
+		current, err := os.ReadFile(store.StatePath())
+		if err != nil || !bytes.Equal(current, payload) {
+			t.Fatalf("refused combined reconcile mutated successor bytes: %v", err)
+		}
+		root, _, err := reviewAuthorityRoot(context.Background(), repo)
+		if err != nil {
+			t.Fatal(err)
+		}
+		entries, err := os.ReadDir(filepath.Join(root, "quarantine"))
+		if err == nil && len(entries) != 0 {
+			t.Fatalf("refused combined reconcile left quarantine entries: %#v", entries)
+		}
+	}
+
+	t.Run("binding omits combined anomaly set", func(t *testing.T) {
+		repo := initSnapshotRepo(t)
+		predecessor, _, successor, successorStore := combinedRecoveryFixture(t, repo, nil)
+		payload, _ := os.ReadFile(successorStore.StatePath())
+		request := combinedReconcileFixtureRequest(predecessor, successor)
+		request.MaintainerAuthorization = compactReconcileAuthorizationBinding(
+			request.PredecessorLineageID, predecessor.Revision, request.SuccessorLineageID, successor.Revision,
+			request.Actor, request.Reason)
+		if _, err := ReconcileInvalidRecoveryEdge(context.Background(), repo, request); err == nil || !strings.Contains(err.Error(), "exact maintainer authorization binding") {
+			t.Fatalf("inexact combined binding error = %v", err)
+		}
+		assertUntouched(t, repo, successorStore, payload)
+	})
+
+	t.Run("declared classification changed", func(t *testing.T) {
+		repo := initSnapshotRepo(t)
+		predecessor, _, successor, successorStore := combinedRecoveryFixture(t, repo, func(state *CompactState) {
+			writeSnapshotFile(t, repo, "tracked.txt", "changed combined target\n")
+			changed := newCompactTestState(t, repo, state.LineageID)
+			state.InitialSnapshot = changed.InitialSnapshot
+			state.CurrentSnapshot = changed.CurrentSnapshot
+			state.GenesisPaths = changed.GenesisPaths
+		})
+		payload, _ := os.ReadFile(successorStore.StatePath())
+		if _, err := ReconcileInvalidRecoveryEdge(context.Background(), repo, combinedReconcileFixtureRequest(predecessor, successor)); err == nil || !strings.Contains(err.Error(), "exact maintainer authorization binding") {
+			t.Fatalf("changed combined classification error = %v", err)
+		}
+		assertUntouched(t, repo, successorStore, payload)
+	})
+
+	t.Run("stale successor revision", func(t *testing.T) {
+		repo := initSnapshotRepo(t)
+		predecessor, _, successor, successorStore := combinedRecoveryFixture(t, repo, nil)
+		payload, _ := os.ReadFile(successorStore.StatePath())
+		request := combinedReconcileFixtureRequest(predecessor, successor)
+		request.ExpectedSuccessorRevision = predecessor.Revision
+		if _, err := ReconcileInvalidRecoveryEdge(context.Background(), repo, request); !errors.Is(err, ErrConcurrentUpdate) {
+			t.Fatalf("stale combined revision error = %v", err)
+		}
+		assertUntouched(t, repo, successorStore, payload)
+	})
+
+	t.Run("unrelated graph defect", func(t *testing.T) {
+		repo := initSnapshotRepo(t)
+		predecessor, _, successor, successorStore := combinedRecoveryFixture(t, repo, nil)
+		payload, _ := os.ReadFile(successorStore.StatePath())
+		root, _, err := reviewAuthorityRoot(context.Background(), repo)
+		if err != nil {
+			t.Fatal(err)
+		}
+		writeReclaimFixtureFile(t, filepath.Join(root, "v2", "reconcile-unrelated", "review-state.json"), "not json\n")
+		if _, err := ReconcileInvalidRecoveryEdge(context.Background(), repo, combinedReconcileFixtureRequest(predecessor, successor)); err == nil ||
+			!strings.Contains(err.Error(), `related compact authority "reconcile-unrelated" does not load`) {
+			t.Fatalf("unrelated combined graph defect error = %v", err)
+		}
+		assertUntouched(t, repo, successorStore, payload)
+	})
 }
 
 func TestReconcileInvalidRecoveryEdgeRefusesIneligibleTargetsAndBindings(t *testing.T) {


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1460

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Allow `review reconcile-authority` to quarantine one recovery edge containing both supported anomaly classes: unchanged target and malformed pre-contract authorization.
- Bind combined repairs to an explicit anomaly-set authorization and preserve both audit proofs.
- Add transaction and CLI regression coverage for successful repair, graph restoration, and refusal without mutation.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/reviewtransaction/compact_reconcile.go` | Reconcile and audit the combined anomaly case with exact authorization binding. |
| `internal/reviewtransaction/compact_reconcile_test.go` | Cover quarantine, both proofs, graph recovery, and no-mutation refusals. |
| `internal/cli/review_reconcile.go` | Document the combined repair contract in CLI help. |
| `internal/cli/review_reconcile_test.go` | Exercise the combined path through the CLI facade. |

---

## 🧪 Test Plan

- [x] Unit tests pass (`go test -count=1 ./...` with Go 1.25.10)
- [x] Go format passes (`go run ./internal/gofmtcheck` with Go 1.25.10)
- [x] E2E tests pass (`cd e2e && ./docker-test.sh`, 3/3 environments)
- [x] Manually verified combined repair restores authority discovery and permits a subsequent review start

---

## ✅ Contributor Checklist

- [x] PR is linked to issue #1460 with `status:approved`
- [x] PR stays within 400 changed lines (252 changed lines)
- [ ] Maintainer: apply exactly one appropriate `type:*` label (contributor lacks label permission)
- [x] Unit tests pass (`go test -count=1 ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [x] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] CLI-facing behavior/help is updated; no additional documentation is required
- [x] My commits follow Conventional Commits
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

The combined authorization adds `anomalies=unchanged_target,malformed_recovery_authorization` to the existing exact reconciliation binding. Existing single-anomaly behavior remains unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reconciliation handling for recovery records with multiple anomalies.
  * Such records can now be quarantined with complete anomaly evidence while preserving audit details and restoring authority when valid.
  * Invalid or incomplete authorization bindings are rejected without modifying existing recovery data.
  * Updated command guidance to clearly describe the required authorization binding format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->