### PR TITLE
fix(review): confine legacy lock tolerance

### DIFF
--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -1505,15 +1505,17 @@ func discoverCompactFacadeGateReview(ctx context.Context, repo, lineage string, 
 
 // reviewAuthorityCorruptionConfinedToLegacyEntries reports whether every cause
 // of a non-authoritative inventory is an invalid legacy-v1 entry, which can
-// never resolve as a compact discovery candidate. Inventory IO/layout
-// diagnostics, ambiguous locks, reset residue, mixed-store collisions, and any
-// compact-v2 problem keep lineage-less discovery fail-closed.
+// never resolve as a compact discovery candidate. Ambiguous lock residue is
+// tolerated only when it belongs to such an already-invalid legacy entry;
+// inventory IO/layout diagnostics, shared or live-entry ambiguous locks, reset
+// residue, mixed-store collisions, and any compact-v2 problem keep
+// lineage-less discovery fail-closed.
 func reviewAuthorityCorruptionConfinedToLegacyEntries(report reviewtransaction.AuthorityStatusReport, inventoryErr error) bool {
 	if inventoryErr != nil || len(report.Diagnostics) > 0 {
 		return false
 	}
 	for _, lock := range report.Locks {
-		if lock.Status == reviewtransaction.AuthorityLockAmbiguous {
+		if lock.Status == reviewtransaction.AuthorityLockAmbiguous && !reviewAmbiguousLockConfinedToInvalidLegacyEntry(report, lock) {
 			return false
 		}
 	}
@@ -1525,11 +1527,29 @@ func reviewAuthorityCorruptionConfinedToLegacyEntries(report reviewtransaction.A
 				return false
 			}
 			confined = true
-		case reviewtransaction.AuthorityStatusReset, reviewtransaction.AuthorityStatusCollision:
+		case reviewtransaction.AuthorityStatusIncomplete, reviewtransaction.AuthorityStatusReset, reviewtransaction.AuthorityStatusCollision:
 			return false
 		}
 	}
 	return confined
+}
+
+// reviewAmbiguousLockConfinedToInvalidLegacyEntry reports whether ambiguous
+// lock evidence is part of the corruption of a legacy-v1 lineage entry that
+// the inventory has already classified invalid. Only that residue is confined:
+// the shared compact-v2 store lock carries no owning lineage, and any lock
+// attached to a live, historical, collided, or missing entry stays a
+// fail-closed corruption cause because it may still guard real authority.
+func reviewAmbiguousLockConfinedToInvalidLegacyEntry(report reviewtransaction.AuthorityStatusReport, lock reviewtransaction.AuthorityLockEvidence) bool {
+	if lock.Version != reviewtransaction.AuthorityVersionLegacy || strings.TrimSpace(lock.LineageID) == "" {
+		return false
+	}
+	for _, entry := range report.Entries {
+		if entry.Version == reviewtransaction.AuthorityVersionLegacy && entry.LineageID == lock.LineageID {
+			return entry.Status == reviewtransaction.AuthorityStatusInvalid
+		}
+	}
+	return false
 }
 
 func reviewAuthorityCauseCategory(report reviewtransaction.AuthorityStatusReport, inventoryErr error) string {
@@ -1537,7 +1557,7 @@ func reviewAuthorityCauseCategory(report reviewtransaction.AuthorityStatusReport
 		return "inventory_io_or_layout"
 	}
 	for _, lock := range report.Locks {
-		if lock.Status == reviewtransaction.AuthorityLockAmbiguous {
+		if lock.Status == reviewtransaction.AuthorityLockAmbiguous && !reviewAmbiguousLockConfinedToInvalidLegacyEntry(report, lock) {
 			return "lock_ambiguous"
 		}
 	}

--- a/internal/cli/review_receipt_discovery_test.go
+++ b/internal/cli/review_receipt_discovery_test.go
@@ -436,6 +436,141 @@ func TestUnscopedGateDiscoveryToleratesCorruptedUnrelatedLegacyInventory(t *test
 	}
 }
 
+func TestReleaseGateToleratesCorruptionConfinedToLegacyEntriesIncludingLockResidue(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	started, _ := approveDiscoveryMarkdown(t, repo, "review-release-tolerance", "docs/valid.md", "valid\n")
+	runReviewCLIGit(t, repo, "add", "-A")
+	runReviewCLIGit(t, repo, "commit", "-qm", "deliver reviewed candidate")
+
+	evidenceDir := t.TempDir()
+	releaseArgs := []string{}
+	for _, artifact := range [][2]string{
+		{"--release-configuration", "release configuration\n"},
+		{"--release-generated", "generated manifest\n"},
+		{"--release-provenance", "release provenance\n"},
+		{"--release-publication-boundary", "sealed publication boundary\n"},
+		{"--release-evidence-freshness", "current release evidence\n"},
+	} {
+		path := filepath.Join(evidenceDir, strings.TrimPrefix(artifact[0], "--"))
+		if err := os.WriteFile(path, []byte(artifact[1]), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		releaseArgs = append(releaseArgs, artifact[0], path)
+	}
+	validateRelease := func() (*bytes.Buffer, error) {
+		var output bytes.Buffer
+		err := RunReview(append([]string{
+			"validate", "--contract", ReviewIntegrationContractV1, "--cwd", repo,
+			"--gate", string(reviewtransaction.GateRelease),
+		}, releaseArgs...), &output)
+		return &output, err
+	}
+
+	control, err := validateRelease()
+	if err != nil {
+		t.Fatalf("healthy release-gate control denied: %v\n%s", err, control.String())
+	}
+
+	commonDir := filepath.Clean(strings.TrimSpace(runReviewCLIGit(t, repo, "rev-parse", "--path-format=absolute", "--git-common-dir")))
+	legacyBroken := filepath.Join(commonDir, "gentle-ai", "review-transactions", "v1", "legacy-alias-broken")
+	if err := os.MkdirAll(legacyBroken, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(legacyBroken, "HEAD"), []byte("not-a-revision\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(legacyBroken, "LOCK"), []byte("not-json\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	report, err := reviewtransaction.InventoryAuthority(context.Background(), repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.Complete || report.Authoritative {
+		t.Fatalf("legacy lock residue fixture left the inventory authoritative = %#v", report)
+	}
+	invalidLegacy, ambiguousLegacyLock := false, false
+	for _, entry := range report.Entries {
+		if entry.LineageID == "legacy-alias-broken" && entry.Version == reviewtransaction.AuthorityVersionLegacy && entry.Status == reviewtransaction.AuthorityStatusInvalid {
+			invalidLegacy = true
+		}
+	}
+	for _, lock := range report.Locks {
+		if lock.LineageID == "legacy-alias-broken" && lock.Version == reviewtransaction.AuthorityVersionLegacy && lock.Status == reviewtransaction.AuthorityLockAmbiguous {
+			ambiguousLegacyLock = true
+		}
+	}
+	if !invalidLegacy || !ambiguousLegacyLock {
+		t.Fatalf("fixture did not confine ambiguous lock residue to an invalid legacy entry: entries=%#v locks=%#v", report.Entries, report.Locks)
+	}
+
+	tolerated, err := validateRelease()
+	if err != nil {
+		t.Fatalf("release gate denied corruption confined to legacy entries: %v\n%s", err, tolerated.String())
+	}
+	var result ReviewValidateResult
+	decodeStrictReviewJSON(t, decodeReviewOperationEnvelope(t, tolerated.Bytes()).Result, &result)
+	if !result.Allowed || result.Context.LineageID != started.LineageID {
+		t.Fatalf("release gate across legacy-confined corruption = %#v", result)
+	}
+	incompleteCompact := filepath.Join(commonDir, "gentle-ai", "review-transactions", "v2", "compact-incomplete")
+	if err := os.MkdirAll(incompleteCompact, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	incompleteDenied, err := validateRelease()
+	if err == nil {
+		t.Fatalf("legacy lock masked an independent incomplete compact-v2 entry:\n%s", incompleteDenied.String())
+	}
+	if err := os.Remove(incompleteCompact); err != nil {
+		t.Fatal(err)
+	}
+	brokenHead, err := os.ReadFile(filepath.Join(legacyBroken, "HEAD"))
+	if err != nil || string(brokenHead) != "not-a-revision\n" {
+		t.Fatalf("release validation mutated legacy residue head: %v", err)
+	}
+	brokenLock, err := os.ReadFile(filepath.Join(legacyBroken, "LOCK"))
+	if err != nil || string(brokenLock) != "not-json\n" {
+		t.Fatalf("release validation mutated legacy lock residue: %v", err)
+	}
+
+	sharedLock := filepath.Join(commonDir, "gentle-ai", "review-transactions", "v2", "LOCK")
+	originalSharedLock, err := os.ReadFile(sharedLock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(sharedLock, []byte("not-json\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sharedDenied, err := validateRelease()
+	if err == nil {
+		t.Fatalf("shared compact-v2 ambiguous lock was tolerated at the release gate:\n%s", sharedDenied.String())
+	}
+	sharedFailure := decodeReviewIntegrationFailure(t, sharedDenied.Bytes())
+	if sharedFailure.Code != "authority_corrupted" || sharedFailure.AuthorityApplicability != "corrupted" || sharedFailure.CauseCategory != "lock_ambiguous" {
+		t.Fatalf("shared ambiguous lock failure = %#v", sharedFailure)
+	}
+	if err := os.WriteFile(sharedLock, originalSharedLock, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	compactBroken := filepath.Join(commonDir, "gentle-ai", "review-transactions", "v2", "compact-broken")
+	if err := os.MkdirAll(compactBroken, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(compactBroken, "review-state.json"), []byte("{\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	compactDenied, err := validateRelease()
+	if err == nil {
+		t.Fatalf("live compact corruption was tolerated at the release gate:\n%s", compactDenied.String())
+	}
+	compactFailure := decodeReviewIntegrationFailure(t, compactDenied.Bytes())
+	if compactFailure.Code != "authority_corrupted" || compactFailure.AuthorityApplicability != "corrupted" || compactFailure.CauseCategory != "record_or_graph_invalid" {
+		t.Fatalf("live compact corruption failure = %#v", compactFailure)
+	}
+}
+
 func TestUnscopedGateDiscoveryExcludesTamperedLegacyReceiptFromCandidates(t *testing.T) {
 	repo := initReviewCLIRepo(t)
 	started, _ := approveDiscoveryMarkdown(t, repo, "review-discovery-valid", "docs/valid.md", "valid\n")


### PR DESCRIPTION
Closes #1439

## PR Type

- [x] Bug fix (`type:bug`)

## Summary

- The release gate no longer fails closed when the only corruption in the shared common dir is an ambiguous lock attached to an already-`Invalid` legacy-v1 entry (the #1439 scenario, where the successor carries an unsupported historical v1 operation alias so `LoadChain` errors and the entry is classified `Invalid`).
- Genuine current corruption still fails closed: `AuthorityStatusIncomplete` is added to the deny switch, and the shared compact-v2 store lock (no owning lineage), reset/collision residue, and any live/compact-v2 problem all keep lineage-less discovery fail-closed.

## Changes

| File | Change |
|------|--------|
| `internal/cli/review_facade.go` | Add `reviewAmbiguousLockConfinedToInvalidLegacyEntry` helper; tolerate an ambiguous lock only when it maps to a legacy entry whose `Status == AuthorityStatusInvalid`; add `AuthorityStatusIncomplete` to the fail-closed switch |
| `internal/cli/review_receipt_discovery_test.go` | Cover the Invalid-legacy-entry-plus-ambiguous-lock scenario and prove fail-closed for incomplete compact-v2, the shared compact-v2 lock, and live compact corruption |

## Test Plan

- [x] `go test ./internal/cli/...` passes
- [x] New test builds the real #1439 shape (Invalid legacy entry with `HEAD="not-a-revision"` plus an ambiguous LOCK) and asserts fail-closed for non-legacy corruption

## Contributor Checklist

- [x] Linked an approved issue (#1439, `status:approved`)
- [x] Added exactly one `type:*` label
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release validation when corruption is limited to obsolete legacy records.
  * Release checks now fail safely when corruption affects active inventory, shared lock state, incomplete data, or record relationships.
  * Ambiguous lock residue is tolerated only when it can be conclusively linked to an invalid legacy entry.
  * Release validation preserves existing legacy residue and does not modify affected files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->