### PR TITLE
fix(review): classify process boundary risk

### DIFF
--- a/internal/cli/review_process_boundary_test.go
+++ b/internal/cli/review_process_boundary_test.go
@@ -1,0 +1,119 @@
+package cli
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/internal/reviewtransaction"
+)
+
+// TestReviewStartSelectsCanonicalFourRForSubprocessWrapper is the issue #1438
+// regression fixture: an unstaged, untracked subprocess.run wrapper at 318
+// authored changed lines (below the 400-line size rule) must classify high and
+// select the canonical 4R lens set, never a single-lens medium route.
+func TestReviewStartSelectsCanonicalFourRForSubprocessWrapper(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	writeReviewCLIModule(t, repo, "tools/procwrap/runner.py", issue1438WrapperModule(200))
+	writeReviewCLIModule(t, repo, "tools/procwrap/policy.py", paddedReviewCLIModule([]string{`"""Argv, cwd, timeout, and environment policy tables."""`}, 80))
+	writeReviewCLIModule(t, repo, "tools/procwrap/errors.py", paddedReviewCLIModule([]string{`"""Process output and error policy."""`}, 30))
+	writeReviewCLIModule(t, repo, "tools/procwrap/__init__.py", paddedReviewCLIModule([]string{`"""Package marker."""`}, 8))
+
+	var startOutput bytes.Buffer
+	if err := RunReview([]string{
+		"start", "--contract", ReviewIntegrationContractV1, "--cwd", repo,
+	}, &startOutput); err != nil {
+		t.Fatal(err)
+	}
+	var started ReviewIntegrationStartResult
+	decodeStrictReviewJSON(t, startOutput.Bytes(), &started)
+
+	if started.ChangedLines != 318 {
+		t.Fatalf("changed_lines = %d, want the 318-line reproduction", started.ChangedLines)
+	}
+	if started.RiskLevel != reviewtransaction.RiskHigh {
+		t.Fatalf("risk_level = %q with lenses %v and reasons %#v, want %q", started.RiskLevel, started.SelectedLenses, started.RiskReasons, reviewtransaction.RiskHigh)
+	}
+	wantLenses := []string{
+		reviewtransaction.LensRisk, reviewtransaction.LensResilience,
+		reviewtransaction.LensReadability, reviewtransaction.LensReliability,
+	}
+	if !reflect.DeepEqual(started.SelectedLenses, wantLenses) {
+		t.Fatalf("selected_lenses = %v, want canonical 4R %v", started.SelectedLenses, wantLenses)
+	}
+	wantReason := reviewtransaction.RiskReason{
+		Code: reviewtransaction.RiskReasonCode("process_boundary"), Signal: reviewtransaction.SignalShellProcess,
+		Path: "tools/procwrap/runner.py",
+	}
+	if !reflect.DeepEqual(started.RiskReasons, []reviewtransaction.RiskReason{wantReason}) {
+		t.Fatalf("risk_reasons = %#v, want %#v", started.RiskReasons, []reviewtransaction.RiskReason{wantReason})
+	}
+}
+
+func issue1438WrapperModule(lines int) string {
+	return paddedReviewCLIModule([]string{
+		`"""Executable module wrapping subprocess.run with argv/cwd/timeout/env policy."""`,
+		"import subprocess",
+		"",
+		"def run_command(argv, cwd, timeout, env):",
+		"    completed = subprocess.run(argv, cwd=cwd, timeout=timeout, env=env, capture_output=True, check=True)",
+		"    return completed.stdout, completed.stderr",
+		"",
+		"def ls_remote(url):",
+		`    return run_command(["git", "ls-remote", url], cwd=None, timeout=30, env={})`,
+	}, lines)
+}
+
+func paddedReviewCLIModule(header []string, lines int) string {
+	rendered := append([]string{}, header...)
+	for index := len(rendered); index < lines; index++ {
+		rendered = append(rendered, fmt.Sprintf("# policy line %03d", index+1))
+	}
+	return strings.Join(rendered[:lines], "\n") + "\n"
+}
+
+func writeReviewCLIModule(t *testing.T, repo, name, content string) {
+	t.Helper()
+	path := filepath.Join(repo, name)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestReviewStartContractValidatesProcessBoundaryReason(t *testing.T) {
+	valid := reviewtransaction.RiskReason{
+		Code: reviewtransaction.RiskReasonCode("process_boundary"), Signal: reviewtransaction.SignalShellProcess,
+		Path: "tools/runner.py",
+	}
+	if err := validateReviewStartRiskReasons([]reviewtransaction.RiskReason{valid}); err != nil {
+		t.Fatalf("validateReviewStartRiskReasons(valid process boundary) = %v", err)
+	}
+	if got := reviewStartRiskLevel([]reviewtransaction.RiskReason{valid}); got != reviewtransaction.RiskHigh {
+		t.Fatalf("reviewStartRiskLevel(process boundary) = %q, want %q", got, reviewtransaction.RiskHigh)
+	}
+	for name, malformed := range map[string]reviewtransaction.RiskReason{
+		"wrong signal": {Code: valid.Code, Signal: reviewtransaction.SignalAuth, Path: valid.Path},
+		"missing path": {Code: valid.Code, Signal: reviewtransaction.SignalShellProcess},
+		"stray modes":  {Code: valid.Code, Signal: reviewtransaction.SignalShellProcess, Path: valid.Path, OldMode: "100644", NewMode: "100755"},
+	} {
+		if err := validateReviewStartRiskReasons([]reviewtransaction.RiskReason{malformed}); err == nil {
+			t.Fatalf("validateReviewStartRiskReasons accepted malformed %s reason", name)
+		}
+	}
+}
+
+func TestNegotiatedReviewStartResumesFrozenMediumAuthorityAfterClassifierUpgrade(t *testing.T) {
+	legacy := ReviewFacadeStartResult{Action: string(reviewtransaction.CompactStartResumed), LineageID: "pre-upgrade", RiskLevel: reviewtransaction.RiskMedium, SelectedLenses: []string{reviewtransaction.LensReliability}, Projection: reviewtransaction.ProjectionWorkspace, ChangedFiles: 1, ChangedLines: 20, CorrectionBudget: 10}
+	assessment := reviewtransaction.RiskAssessment{Level: reviewtransaction.RiskHigh, ChangedLines: 20, Reasons: []reviewtransaction.RiskReason{{Code: reviewtransaction.RiskReasonCode("process_boundary"), Signal: reviewtransaction.SignalShellProcess, Path: "runner.py"}}}
+	result, err := newReviewIntegrationStartResult(legacy, assessment, "")
+	if err != nil || result.RiskLevel != reviewtransaction.RiskMedium || !reflect.DeepEqual(result.SelectedLenses, legacy.SelectedLenses) {
+		t.Fatalf("resumed authority = risk %q lenses %v error %v, want frozen medium %v", result.RiskLevel, result.SelectedLenses, err, legacy.SelectedLenses)
+	}
+}

--- a/internal/cli/review_start_contract.go
+++ b/internal/cli/review_start_contract.go
@@ -69,6 +69,13 @@ func reviewStartAssessmentForFrozenAuthority(legacy ReviewFacadeStartResult, ass
 	if assessment.Level == legacy.RiskLevel {
 		return assessment, nil
 	}
+	if legacy.Action == string(reviewtransaction.CompactStartResumed) && legacy.RiskLevel == reviewtransaction.RiskMedium &&
+		assessment.Level == reviewtransaction.RiskHigh && len(assessment.Reasons) > 0 && assessment.Reasons[0].Path != "" &&
+		validateReviewStartLenses(legacy.RiskLevel, legacy.SelectedLenses) == nil {
+		assessment.Level, assessment.DominantLens = legacy.RiskLevel, ""
+		assessment.Reasons = []reviewtransaction.RiskReason{{Code: reviewtransaction.RiskReasonExecutableChange, Path: assessment.Reasons[0].Path}}
+		return assessment, nil
+	}
 	// Authorities created before the pure-documentation policy remain valid and
 	// retain their frozen high/4R route when the same immutable snapshot replays.
 	if legacy.RiskLevel == reviewtransaction.RiskHigh && assessment.Level == reviewtransaction.RiskMedium &&
@@ -148,9 +155,9 @@ func validateReviewStartRiskReasons(reasons []reviewtransaction.RiskReason) erro
 			if reason.Signal != reviewtransaction.SignalAuth || reason.Path == "" || reason.OldMode != "" || reason.NewMode != "" {
 				return fmt.Errorf("invalid service-token risk reason %#v", reason)
 			}
-		case reviewtransaction.RiskReasonShellSource:
+		case reviewtransaction.RiskReasonShellSource, reviewtransaction.RiskReasonProcessBoundary, reviewtransaction.RiskReasonProcessScanLimit:
 			if reason.Signal != reviewtransaction.SignalShellProcess || reason.Path == "" || reason.OldMode != "" || reason.NewMode != "" {
-				return fmt.Errorf("invalid shell-source risk reason %#v", reason)
+				return fmt.Errorf("invalid shell/process risk reason %#v", reason)
 			}
 		case reviewtransaction.RiskReasonExecutableMode:
 			if reason.Signal != reviewtransaction.SignalPermissions || reason.Path == "" || reason.OldMode == "" || reason.NewMode == "" || reason.OldMode == reason.NewMode {

--- a/internal/reviewtransaction/risk.go
+++ b/internal/reviewtransaction/risk.go
@@ -231,7 +231,6 @@ func (builder SnapshotBuilder) processBoundaryRiskReasons(ctx context.Context, s
 	if err != nil {
 		return nil, err
 	}
-	builder.Repo = repo
 	paths := make([]string, 0, len(stats))
 	for _, stat := range stats {
 		if isSemanticRiskEligible(stat) {
@@ -289,36 +288,6 @@ func (builder SnapshotBuilder) processBoundaryRiskReasons(ctx context.Context, s
 		}
 	}
 	return canonicalRiskReasons(reasons), nil
-}
-
-func (builder SnapshotBuilder) snapshotPathContent(ctx context.Context, tree, logicalPath string) ([]byte, bool, error) {
-	entry, err := runGit(ctx, builder.Repo, nil, nil, "ls-tree", "-z", tree, "--", literalPathspec(logicalPath))
-	if err != nil {
-		return nil, false, err
-	}
-	if len(entry) == 0 {
-		return nil, false, nil
-	}
-	content, err := runGit(ctx, builder.Repo, nil, nil, "show", tree+":"+logicalPath)
-	if err != nil {
-		return nil, false, err
-	}
-	return content, true, nil
-}
-
-func hasProcessBoundaryContent(logicalPath string, content []byte) bool {
-	if _, supported := semanticSourceExtensions[asciiLower(path.Ext(logicalPath))]; !supported {
-		return false
-	}
-	identifiers := bytes.FieldsFunc(content, func(r rune) bool {
-		return !((r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_')
-	})
-	for _, identifier := range identifiers {
-		if bytes.EqualFold(identifier, []byte("subprocess")) || bytes.EqualFold(identifier, []byte("exec")) {
-			return true
-		}
-	}
-	return false
 }
 
 func removeFallbackRiskReasons(reasons []RiskReason) []RiskReason {

--- a/internal/reviewtransaction/risk.go
+++ b/internal/reviewtransaction/risk.go
@@ -15,6 +15,8 @@ import (
 const LargeChangeLines = 400
 const MaxCorrectionChangedLines = 200
 
+var processBoundaryScanByteLimit int64 = 8 << 20
+
 var semanticSourceExtensions = map[string]struct{}{
 	".c": {}, ".cc": {}, ".cpp": {}, ".cs": {}, ".go": {}, ".h": {}, ".hpp": {},
 	".java": {}, ".js": {}, ".jsx": {}, ".kt": {}, ".kts": {}, ".php": {}, ".py": {},
@@ -59,6 +61,8 @@ const (
 	RiskReasonHotPath             RiskReasonCode = "hot_path"
 	RiskReasonServiceToken        RiskReasonCode = "service_token"
 	RiskReasonShellSource         RiskReasonCode = "shell_source"
+	RiskReasonProcessBoundary     RiskReasonCode = "process_boundary"
+	RiskReasonProcessScanLimit    RiskReasonCode = "process_scan_limit"
 	RiskReasonExecutableMode      RiskReasonCode = "executable_mode"
 	RiskReasonLargeChange         RiskReasonCode = "large_change"
 	RiskReasonNonExecutableOnly   RiskReasonCode = "non_executable_only"
@@ -178,6 +182,14 @@ func (builder SnapshotBuilder) AssessSnapshotRisk(ctx context.Context, snapshot 
 		return RiskAssessment{}, err
 	}
 	reasons := deriveSnapshotRiskReasons(stats, changedLines)
+	processReasons, err := builder.processBoundaryRiskReasons(ctx, snapshot, stats)
+	if err != nil {
+		return RiskAssessment{}, err
+	}
+	if len(processReasons) > 0 {
+		reasons = removeFallbackRiskReasons(reasons)
+		reasons = canonicalRiskReasons(append(reasons, processReasons...))
+	}
 	onlyNonExecutable := true
 	onlyPureDocumentation := true
 	touchesConfiguration := false
@@ -212,6 +224,114 @@ func (builder SnapshotBuilder) AssessSnapshotRisk(ctx context.Context, snapshot 
 		dominantLens = LensReadability
 	}
 	return RiskAssessment{Level: risk, ChangedLines: changedLines, Reasons: reasons, DominantLens: dominantLens}, nil
+}
+
+func (builder SnapshotBuilder) processBoundaryRiskReasons(ctx context.Context, snapshot Snapshot, stats []DiffStat) ([]RiskReason, error) {
+	repo, err := builder.repositoryRoot(ctx)
+	if err != nil {
+		return nil, err
+	}
+	builder.Repo = repo
+	paths := make([]string, 0, len(stats))
+	for _, stat := range stats {
+		if isSemanticRiskEligible(stat) {
+			paths = append(paths, stat.Path)
+		}
+	}
+	if len(paths) == 0 {
+		return nil, nil
+	}
+	reasons, scanned := make([]RiskReason, 0), int64(0)
+	for _, tree := range []string{snapshot.BaseTree, snapshot.CandidateTree} {
+		args := []string{"ls-tree", "-r", "-l", "-z", tree, "--"}
+		for _, logicalPath := range paths {
+			args = append(args, literalPathspec(logicalPath))
+		}
+		entries, err := runGit(ctx, repo, nil, nil, args...)
+		if err != nil {
+			return nil, err
+		}
+		treePaths := make([]string, 0, len(paths))
+		for _, entry := range bytes.Split(entries, []byte{0}) {
+			tab := bytes.IndexByte(entry, '\t')
+			fields := strings.Fields(string(entry[:max(tab, 0)]))
+			if tab < 0 || len(fields) != 4 {
+				continue
+			}
+			size, parseErr := strconv.ParseInt(fields[3], 10, 64)
+			if parseErr != nil {
+				return nil, fmt.Errorf("parse source blob size: %w", parseErr)
+			}
+			logicalPath := string(entry[tab+1:])
+			scanned += size
+			if scanned > processBoundaryScanByteLimit {
+				return []RiskReason{{Code: RiskReasonProcessScanLimit, Signal: SignalShellProcess, Path: logicalPath}}, nil
+			}
+			treePaths = append(treePaths, logicalPath)
+		}
+		if len(treePaths) == 0 {
+			continue
+		}
+		args = []string{"grep", "-I", "-l", "-z", "-i", "-E", `(^|[^[:alnum:]_])(subprocess|exec)([^[:alnum:]_]|$)`, tree, "--"}
+		for _, logicalPath := range treePaths {
+			args = append(args, literalPathspec(logicalPath))
+		}
+		matches, err := runGit(ctx, repo, nil, nil, args...)
+		var gitErr *GitCommandError
+		if err != nil && (!errors.As(err, &gitErr) || gitErr.ExitCode != 1) {
+			return nil, err
+		}
+		for _, match := range bytes.Split(bytes.TrimSuffix(matches, []byte{0}), []byte{0}) {
+			logicalPath := strings.TrimPrefix(string(match), tree+":")
+			if logicalPath != "" {
+				reasons = append(reasons, RiskReason{Code: RiskReasonProcessBoundary, Signal: SignalShellProcess, Path: logicalPath})
+			}
+		}
+	}
+	return canonicalRiskReasons(reasons), nil
+}
+
+func (builder SnapshotBuilder) snapshotPathContent(ctx context.Context, tree, logicalPath string) ([]byte, bool, error) {
+	entry, err := runGit(ctx, builder.Repo, nil, nil, "ls-tree", "-z", tree, "--", literalPathspec(logicalPath))
+	if err != nil {
+		return nil, false, err
+	}
+	if len(entry) == 0 {
+		return nil, false, nil
+	}
+	content, err := runGit(ctx, builder.Repo, nil, nil, "show", tree+":"+logicalPath)
+	if err != nil {
+		return nil, false, err
+	}
+	return content, true, nil
+}
+
+func hasProcessBoundaryContent(logicalPath string, content []byte) bool {
+	if _, supported := semanticSourceExtensions[asciiLower(path.Ext(logicalPath))]; !supported {
+		return false
+	}
+	identifiers := bytes.FieldsFunc(content, func(r rune) bool {
+		return !((r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_')
+	})
+	for _, identifier := range identifiers {
+		if bytes.EqualFold(identifier, []byte("subprocess")) || bytes.EqualFold(identifier, []byte("exec")) {
+			return true
+		}
+	}
+	return false
+}
+
+func removeFallbackRiskReasons(reasons []RiskReason) []RiskReason {
+	filtered := make([]RiskReason, 0, len(reasons))
+	for _, reason := range reasons {
+		switch reason.Code {
+		case RiskReasonNonExecutableOnly, RiskReasonConfigurationChange, RiskReasonExecutableChange:
+			continue
+		default:
+			filtered = append(filtered, reason)
+		}
+	}
+	return filtered
 }
 
 func isLargePureDocumentation(input RiskInput, changedLines int) bool {

--- a/internal/reviewtransaction/risk_process_boundary_test.go
+++ b/internal/reviewtransaction/risk_process_boundary_test.go
@@ -63,41 +63,6 @@ func paddedPolicyModule(header []string, lines int) string {
 	return strings.Join(rendered[:lines], "\n") + "\n"
 }
 
-func TestHasProcessBoundaryContentUsesLanguageAgnosticIdentifiers(t *testing.T) {
-	tests := []struct {
-		name    string
-		path    string
-		content string
-		want    bool
-	}{
-		{name: "subprocess identifier", path: "a.py", content: "subprocess.run(argv)\n", want: true},
-		{name: "exec identifier", path: "a.rb", content: "exec(command)\n", want: true},
-		{name: "case insensitive identifier", path: "a.cs", content: "Exec(command);\n", want: true},
-		{name: "comment mention triggers conservatively", path: "a.go", content: "// never call exec directly\n", want: true},
-		{name: "subprocess identifier near miss", path: "a.py", content: "subprocessing.run(argv)\n", want: false},
-		{name: "exec identifier near miss", path: "a.ts", content: "executor.run(command)\n", want: false},
-		{name: "unsupported extension", path: "a.md", content: "Call subprocess.run with argv.\n", want: false},
-	}
-	for _, extension := range []string{
-		".c", ".cc", ".cpp", ".cs", ".go", ".h", ".hpp", ".java", ".js", ".jsx", ".kt",
-		".kts", ".php", ".py", ".rb", ".rs", ".sh", ".bash", ".zsh", ".ts", ".tsx",
-	} {
-		tests = append(tests, struct {
-			name    string
-			path    string
-			content string
-			want    bool
-		}{name: "supported " + extension, path: "runner" + extension, content: "exec(command)\n", want: true})
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := hasProcessBoundaryContent(tt.path, []byte(tt.content)); got != tt.want {
-				t.Fatalf("hasProcessBoundaryContent(%q, %q) = %t, want %t", tt.path, tt.content, got, tt.want)
-			}
-		})
-	}
-}
-
 // TestAssessSnapshotRiskClassifiesUntrackedSubprocessWrapperHigh captures the
 // issue #1438 reproduction verbatim: 318 authored changed lines across four
 // untracked paths, one of them a subprocess.run wrapper, must classify high
@@ -214,6 +179,22 @@ func TestAssessSnapshotRiskProcessBoundaryNegativesAndDocumentedConservatism(t *
 			name:    "neutral module without spawn constructs stays medium",
 			path:    "tools/helper.py",
 			content: "def subprocess_helper(value):\n    return value\n",
+			want:    RiskMedium,
+		},
+		{
+			// Near-miss: "subprocess" as a prefix of a longer identifier must
+			// not satisfy the standalone-token boundary and never escalates.
+			name:    "subprocess prefix near-miss stays medium",
+			path:    "tools/runner.py",
+			content: "def run(argv):\n    return subprocessing.run(argv)\n",
+			want:    RiskMedium,
+		},
+		{
+			// Near-miss: "exec" as a prefix of a longer identifier must not
+			// satisfy the standalone-token boundary and never escalates.
+			name:    "exec prefix near-miss stays medium",
+			path:    "tools/runner.ts",
+			content: "function run(command) {\n  return executor.run(command);\n}\n",
 			want:    RiskMedium,
 		},
 		{

--- a/internal/reviewtransaction/risk_process_boundary_test.go
+++ b/internal/reviewtransaction/risk_process_boundary_test.go
@@ -1,0 +1,278 @@
+package reviewtransaction
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestProcessBoundaryInspectionIsBatchedAndBounded(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	paths := []string{"tools/a.py", "tools/b.py"}
+	for _, path := range paths {
+		writeSnapshotFile(t, repo, path, "import subprocess\nsubprocess.run(argv)\n")
+	}
+	snapshot, _ := (SnapshotBuilder{Repo: repo}).Build(context.Background(), Target{Kind: TargetCurrentChanges, IntendedUntracked: paths})
+	original, inspections := gitCommandContext, 0
+	gitCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		if len(args) > 3 && (args[3] == "ls-tree" || args[3] == "grep" || args[3] == "show") {
+			inspections++
+		}
+		return original(ctx, name, args...)
+	}
+	_, _ = (SnapshotBuilder{Repo: repo}).AssessSnapshotRisk(context.Background(), snapshot)
+	if inspections > 4 {
+		t.Fatalf("source inspection used %d Git subprocesses, want at most 4", inspections)
+	}
+	processBoundaryScanByteLimit = 16
+	t.Cleanup(func() { gitCommandContext, processBoundaryScanByteLimit = original, 8<<20 })
+	assessment, _ := (SnapshotBuilder{Repo: repo}).AssessSnapshotRisk(context.Background(), snapshot)
+	if assessment.Level != RiskHigh || len(assessment.Reasons) == 0 || assessment.Reasons[0].Code != RiskReasonCode("process_scan_limit") {
+		t.Fatalf("cap exhaustion assessment = %#v, want explicit high-risk process_scan_limit", assessment)
+	}
+}
+
+// buildIssue1438Wrapper renders the issue #1438 reproduction module: a new
+// executable Python module wrapping subprocess.run with one network-capable
+// read-only Git command and an argv/cwd/timeout/environment policy surface.
+func buildIssue1438Wrapper(lines int) string {
+	header := []string{
+		`"""Executable module wrapping subprocess.run with argv/cwd/timeout/env policy."""`,
+		"import subprocess",
+		"",
+		"def run_command(argv, cwd, timeout, env):",
+		"    completed = subprocess.run(argv, cwd=cwd, timeout=timeout, env=env, capture_output=True, check=True)",
+		"    return completed.stdout, completed.stderr",
+		"",
+		"def ls_remote(url):",
+		`    return run_command(["git", "ls-remote", url], cwd=None, timeout=30, env={})`,
+	}
+	return paddedPolicyModule(header, lines)
+}
+
+// paddedPolicyModule pads a module to an exact authored line count with inert
+// policy comments that never contain a process-spawn construct.
+func paddedPolicyModule(header []string, lines int) string {
+	rendered := append([]string{}, header...)
+	for index := len(rendered); index < lines; index++ {
+		rendered = append(rendered, fmt.Sprintf("# policy line %03d", index+1))
+	}
+	return strings.Join(rendered[:lines], "\n") + "\n"
+}
+
+func TestHasProcessBoundaryContentUsesLanguageAgnosticIdentifiers(t *testing.T) {
+	tests := []struct {
+		name    string
+		path    string
+		content string
+		want    bool
+	}{
+		{name: "subprocess identifier", path: "a.py", content: "subprocess.run(argv)\n", want: true},
+		{name: "exec identifier", path: "a.rb", content: "exec(command)\n", want: true},
+		{name: "case insensitive identifier", path: "a.cs", content: "Exec(command);\n", want: true},
+		{name: "comment mention triggers conservatively", path: "a.go", content: "// never call exec directly\n", want: true},
+		{name: "subprocess identifier near miss", path: "a.py", content: "subprocessing.run(argv)\n", want: false},
+		{name: "exec identifier near miss", path: "a.ts", content: "executor.run(command)\n", want: false},
+		{name: "unsupported extension", path: "a.md", content: "Call subprocess.run with argv.\n", want: false},
+	}
+	for _, extension := range []string{
+		".c", ".cc", ".cpp", ".cs", ".go", ".h", ".hpp", ".java", ".js", ".jsx", ".kt",
+		".kts", ".php", ".py", ".rb", ".rs", ".sh", ".bash", ".zsh", ".ts", ".tsx",
+	} {
+		tests = append(tests, struct {
+			name    string
+			path    string
+			content string
+			want    bool
+		}{name: "supported " + extension, path: "runner" + extension, content: "exec(command)\n", want: true})
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hasProcessBoundaryContent(tt.path, []byte(tt.content)); got != tt.want {
+				t.Fatalf("hasProcessBoundaryContent(%q, %q) = %t, want %t", tt.path, tt.content, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestAssessSnapshotRiskClassifiesUntrackedSubprocessWrapperHigh captures the
+// issue #1438 reproduction verbatim: 318 authored changed lines across four
+// untracked paths, one of them a subprocess.run wrapper, must classify high
+// from the content-derived process-boundary signal, not the size rule.
+func TestAssessSnapshotRiskClassifiesUntrackedSubprocessWrapperHigh(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	writeSnapshotFile(t, repo, "tools/procwrap/runner.py", buildIssue1438Wrapper(200))
+	writeSnapshotFile(t, repo, "tools/procwrap/policy.py", paddedPolicyModule([]string{`"""Argv, cwd, timeout, and environment policy tables."""`}, 80))
+	writeSnapshotFile(t, repo, "tools/procwrap/errors.py", paddedPolicyModule([]string{`"""Process output and error policy."""`}, 30))
+	writeSnapshotFile(t, repo, "tools/procwrap/__init__.py", paddedPolicyModule([]string{`"""Package marker."""`}, 8))
+	untracked := []string{
+		"tools/procwrap/__init__.py", "tools/procwrap/errors.py",
+		"tools/procwrap/policy.py", "tools/procwrap/runner.py",
+	}
+	snapshot, err := (SnapshotBuilder{Repo: repo}).Build(context.Background(), Target{Kind: TargetCurrentChanges, IntendedUntracked: untracked})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assessment, err := (SnapshotBuilder{Repo: repo}).AssessSnapshotRisk(context.Background(), snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if assessment.ChangedLines != 318 {
+		t.Fatalf("ChangedLines = %d, want the 318-line reproduction", assessment.ChangedLines)
+	}
+	if assessment.Level != RiskHigh {
+		t.Fatalf("AssessSnapshotRisk() level = %q with reasons %#v, want %q from the process-boundary content signal", assessment.Level, assessment.Reasons, RiskHigh)
+	}
+	want := RiskReason{Code: RiskReasonCode("process_boundary"), Signal: SignalShellProcess, Path: "tools/procwrap/runner.py"}
+	if !reflect.DeepEqual(assessment.Reasons, []RiskReason{want}) {
+		t.Fatalf("Reasons = %#v, want %#v", assessment.Reasons, []RiskReason{want})
+	}
+	if assessment.DominantLens != "" {
+		t.Fatalf("DominantLens = %q, want empty for high risk", assessment.DominantLens)
+	}
+}
+
+func TestAssessSnapshotRiskDetectsProcessBoundaryAcrossSupportedLanguages(t *testing.T) {
+	tests := []struct {
+		name    string
+		path    string
+		content string
+	}{
+		{name: "Go exec", path: "tools/runner.go", content: "package tools\n\nfunc run() { exec(command) }\n"},
+		{name: "Python subprocess", path: "tools/runner.py", content: "import subprocess\n\nsubprocess.run(argv)\n"},
+		{name: "Ruby exec", path: "tools/runner.rb", content: "exec(command)\n"},
+		{name: "Rust exec", path: "tools/runner.rs", content: "exec(command);\n"},
+		{name: "C sharp Exec", path: "tools/runner.cs", content: "Exec(command);\n"},
+		{name: "TypeScript exec", path: "tools/runner.ts", content: "exec(command);\n"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := initSnapshotRepo(t)
+			writeSnapshotFile(t, repo, tt.path, tt.content)
+			snapshot, err := (SnapshotBuilder{Repo: repo}).Build(context.Background(), Target{Kind: TargetCurrentChanges, IntendedUntracked: []string{tt.path}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			assessment, err := (SnapshotBuilder{Repo: repo}).AssessSnapshotRisk(context.Background(), snapshot)
+			if err != nil {
+				t.Fatal(err)
+			}
+			want := RiskReason{Code: RiskReasonCode("process_boundary"), Signal: SignalShellProcess, Path: tt.path}
+			if assessment.Level != RiskHigh || !reflect.DeepEqual(assessment.Reasons, []RiskReason{want}) {
+				t.Fatalf("AssessSnapshotRisk(%s) = %#v, want high with %#v", tt.name, assessment, want)
+			}
+		})
+	}
+}
+
+func TestAssessSnapshotRiskDetectsProcessBoundaryInTrackedEdits(t *testing.T) {
+	t.Run("modification adds a spawn construct", func(t *testing.T) {
+		repo := initSnapshotRepo(t)
+		writeSnapshotFile(t, repo, "tools/runner.go", "package tools\n\nfunc Run() error {\n\treturn nil\n}\n")
+		gitSnapshot(t, repo, "add", "--", "tools/runner.go")
+		gitSnapshot(t, repo, "commit", "-m", "neutral runner")
+		writeSnapshotFile(t, repo, "tools/runner.go", "package tools\n\nimport \"os/exec\"\n\nfunc Run() error {\n\treturn exec.Command(\"git\", \"status\").Run()\n}\n")
+		assertProcessBoundaryHigh(t, repo, "tools/runner.go")
+	})
+	t.Run("deletion of a spawning module stays a process boundary", func(t *testing.T) {
+		repo := initSnapshotRepo(t)
+		writeSnapshotFile(t, repo, "tools/runner.py", "import subprocess\n\ndef run(argv):\n    return subprocess.run(argv)\n")
+		gitSnapshot(t, repo, "add", "--", "tools/runner.py")
+		gitSnapshot(t, repo, "commit", "-m", "spawning runner")
+		gitSnapshot(t, repo, "rm", "--", "tools/runner.py")
+		assertProcessBoundaryHigh(t, repo, "tools/runner.py")
+	})
+}
+
+func assertProcessBoundaryHigh(t *testing.T, repo, path string) {
+	t.Helper()
+	snapshot, err := (SnapshotBuilder{Repo: repo}).Build(context.Background(), Target{Kind: TargetCurrentChanges, IntendedUntracked: []string{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assessment, err := (SnapshotBuilder{Repo: repo}).AssessSnapshotRisk(context.Background(), snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := RiskReason{Code: RiskReasonCode("process_boundary"), Signal: SignalShellProcess, Path: path}
+	if assessment.Level != RiskHigh || !reflect.DeepEqual(assessment.Reasons, []RiskReason{want}) {
+		t.Fatalf("AssessSnapshotRisk() = %#v, want high with %#v", assessment, want)
+	}
+}
+
+func TestAssessSnapshotRiskProcessBoundaryNegativesAndDocumentedConservatism(t *testing.T) {
+	tests := []struct {
+		name    string
+		path    string
+		content string
+		want    RiskLevel
+	}{
+		{
+			name:    "neutral module without spawn constructs stays medium",
+			path:    "tools/helper.py",
+			content: "def subprocess_helper(value):\n    return value\n",
+			want:    RiskMedium,
+		},
+		{
+			name:    "fixture directories stay outside semantic content scanning",
+			path:    "fixtures/runner.py",
+			content: "import subprocess\n\ndef run(argv):\n    return subprocess.run(argv)\n",
+			want:    RiskMedium,
+		},
+		{
+			name:    "documentation mentioning subprocess stays low",
+			path:    "docs/spawning.md",
+			content: "Call subprocess.run with an explicit argv list.\n",
+			want:    RiskLow,
+		},
+		{
+			// Documented conservative contract: pattern presence triggers the
+			// signal even inside comments or strings. False positives only
+			// widen review; false negatives would skip the mandated 4R set.
+			name:    "comment-only mention still triggers the conservative signal",
+			path:    "tools/notes.py",
+			content: "# This module will wrap subprocess.run in a follow-up.\nVALUE = 1\n",
+			want:    RiskHigh,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := initSnapshotRepo(t)
+			writeSnapshotFile(t, repo, tt.path, tt.content)
+			snapshot, err := (SnapshotBuilder{Repo: repo}).Build(context.Background(), Target{Kind: TargetCurrentChanges, IntendedUntracked: []string{tt.path}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			assessment, err := (SnapshotBuilder{Repo: repo}).AssessSnapshotRisk(context.Background(), snapshot)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if assessment.Level != tt.want {
+				t.Fatalf("AssessSnapshotRisk() = %q with reasons %#v, want %q", assessment.Level, assessment.Reasons, tt.want)
+			}
+		})
+	}
+}
+
+func TestAssessSnapshotRiskProcessBoundaryIsDeterministic(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	writeSnapshotFile(t, repo, "tools/procwrap/runner.py", buildIssue1438Wrapper(120))
+	snapshot, err := (SnapshotBuilder{Repo: repo}).Build(context.Background(), Target{Kind: TargetCurrentChanges, IntendedUntracked: []string{"tools/procwrap/runner.py"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	first, err := (SnapshotBuilder{Repo: repo}).AssessSnapshotRisk(context.Background(), snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := (SnapshotBuilder{Repo: repo}).AssessSnapshotRisk(context.Background(), snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(first, second) {
+		t.Fatalf("same immutable snapshot produced different assessments:\n%#v\n%#v", first, second)
+	}
+}


### PR DESCRIPTION
Closes #1438

## PR Type

- [x] Bug fix (`type:bug`)

## Summary

- `review start` now classifies concrete subprocess/process-boundary integrations as high risk and selects the canonical 4R set, matching the documented deterministic rule that shell/process integration is high risk.
- Adds a bounded content scan (`processBoundaryScanByteLimit`, 8 MiB) that emits `process_boundary` risk reasons, plus a `process_scan_limit` reason when a candidate exceeds the scan ceiling so classification stays deterministic and fail-safe.

## Changes

| File | Change |
|------|--------|
| `internal/reviewtransaction/risk.go` | Add `RiskReasonProcessBoundary` / `RiskReasonProcessScanLimit`, `processBoundaryRiskReasons` scan, and byte-limit guard; fold process reasons into `AssessSnapshotRisk` |
| `internal/cli/review_start_contract.go` | Accept process-boundary risk reasons in `validateReviewStartRiskReasons`; preserve frozen-authority replay for the resumed-medium case |
| `internal/reviewtransaction/risk_process_boundary_test.go`, `internal/cli/review_process_boundary_test.go` | Coverage for detection, scan-limit behavior, and start-contract validation |

## Test Plan

- [x] `go test ./internal/reviewtransaction/... ./internal/cli/...` passes

## Notes

- This is ~526 changed lines and will exceed the 400-line Cognitive Load budget; it is one cohesive risk-classification feature and requests a `size:exception`.

## Contributor Checklist

- [x] Linked an approved issue (#1438, `status:approved`)
- [x] Added exactly one `type:*` label
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added detection for “process boundary” execution patterns and surface precise affected paths in risk assessments.
  - Introduced a bounded scan behavior that can emit a “process scan limit” reason when analysis hits safety limits.
  - Review start now selects the canonical 4R lenses for subprocess-wrapper scenarios and includes the appropriate process-boundary risk reason.
- **Bug Fixes**
  - Improved review-start risk negotiation to preserve “frozen medium authority” outcomes after classification upgrades.
  - Strengthened validation and normalization for process-boundary and process-scan-limit risk details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->