### PR TITLE
fix(review): release maintenance lease and canonicalize quarantine authorization in tests for Windows

### DIFF
--- a/internal/cli/review_legacy_quarantine_test.go
+++ b/internal/cli/review_legacy_quarantine_test.go
@@ -83,7 +83,16 @@ func TestReviewQuarantineLegacyRestoresAuthoritativeInventory(t *testing.T) {
 	diagnostic := "historical findings freeze changed unrelated transaction state"
 	disposition := reviewtransaction.LegacyMalformedFreezeQuarantineDisposition
 	reason, actor := "retire malformed shipped legacy history", "maintainer@example.com"
-	authorization := "gentle-ai.review-legacy-quarantine-authorization/v1\nrepository=" + repo +
+	// The command derives the binding over the canonical repository root
+	// (filepath.Abs -> EvalSymlinks -> Clean). On Windows CI t.TempDir()
+	// yields 8.3 short-name components (e.g. RUNNER~1) that EvalSymlinks
+	// expands, so a binding built from the raw repo path would never match.
+	// Resolve the same canonical root the command uses.
+	repository, err := (reviewtransaction.SnapshotBuilder{Repo: repo}).ResolveRepositoryRoot(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	authorization := "gentle-ai.review-legacy-quarantine-authorization/v1\nrepository=" + repository +
 		"\nlineage=" + lineage + "\nrevision=" + head + "\ndiagnostic=" + diagnostic +
 		"\ndisposition=" + disposition + "\nactor=" + actor + "\nreason=" + reason
 

--- a/internal/reviewtransaction/compact_legacy_quarantine_test.go
+++ b/internal/reviewtransaction/compact_legacy_quarantine_test.go
@@ -116,15 +116,25 @@ func TestMalformedLegacyFreezeEventBricksInventoryWithNoFamilyExit(t *testing.T)
 	}
 }
 
-func malformedLegacyFreezeQuarantineRequest(repo, lineage, head string) LegacyQuarantineRequest {
+func malformedLegacyFreezeQuarantineRequest(t *testing.T, repo, lineage, head string) LegacyQuarantineRequest {
+	t.Helper()
 	request := LegacyQuarantineRequest{
 		LineageID: lineage, ExpectedRevision: head,
 		ExpectedDiagnostic: "historical findings freeze changed unrelated transaction state",
 		Disposition:        LegacyMalformedFreezeQuarantineDisposition,
 		Reason:             "retire malformed shipped legacy history", Actor: "maintainer@example.com",
 	}
+	// The command derives the authorization binding over the canonical
+	// repository root (filepath.Abs -> EvalSymlinks -> Clean). On Windows CI
+	// t.TempDir() yields 8.3 short-name components (e.g. RUNNER~1) that
+	// EvalSymlinks expands, so a binding built from the raw repo path would
+	// never match. Bind over the same canonical root the command uses.
+	_, repository, err := reviewAuthorityRoot(context.Background(), repo)
+	if err != nil {
+		t.Fatal(err)
+	}
 	request.MaintainerAuthorization = legacyQuarantineAuthorizationBinding(
-		repo, request.LineageID, request.ExpectedRevision, request.ExpectedDiagnostic,
+		repository, request.LineageID, request.ExpectedRevision, request.ExpectedDiagnostic,
 		request.Disposition, request.Actor, request.Reason,
 	)
 	return request
@@ -134,7 +144,7 @@ func TestQuarantineMalformedLegacyFreezePreservesHistoryAndRestoresInventory(t *
 	repo := initSnapshotRepo(t)
 	approved, approvedStore := approvedCompactFixture(t, repo, "legacy-quarantine-unrelated-approved")
 	store, head, malformed := malformedLegacyFreezeFixture(t, repo, "legacy-freeze-broken")
-	request := malformedLegacyFreezeQuarantineRequest(repo, "legacy-freeze-broken", head)
+	request := malformedLegacyFreezeQuarantineRequest(t, repo, "legacy-freeze-broken", head)
 
 	headBytes, err := os.ReadFile(filepath.Join(store.Dir, "HEAD"))
 	if err != nil {
@@ -204,7 +214,7 @@ func TestQuarantineMalformedLegacyFreezeRefusesOutsideExactClass(t *testing.T) {
 	t.Run("stale revision", func(t *testing.T) {
 		repo := initSnapshotRepo(t)
 		store, head, _ := malformedLegacyFreezeFixture(t, repo, "legacy-freeze-stale")
-		request := malformedLegacyFreezeQuarantineRequest(repo, "legacy-freeze-stale", head)
+		request := malformedLegacyFreezeQuarantineRequest(t, repo, "legacy-freeze-stale", head)
 		request.ExpectedRevision = hash("f")
 		request.MaintainerAuthorization = legacyQuarantineAuthorizationBinding(
 			repo, request.LineageID, request.ExpectedRevision, request.ExpectedDiagnostic,
@@ -225,7 +235,7 @@ func TestQuarantineMalformedLegacyFreezeRefusesOutsideExactClass(t *testing.T) {
 			func(request *LegacyQuarantineRequest) { request.ExpectedDiagnostic = "different diagnostic" },
 			func(request *LegacyQuarantineRequest) { request.Disposition = "delete-history" },
 		} {
-			request := malformedLegacyFreezeQuarantineRequest(repo, "legacy-freeze-unsupported", head)
+			request := malformedLegacyFreezeQuarantineRequest(t, repo, "legacy-freeze-unsupported", head)
 			mutate(&request)
 			if _, err := QuarantineMalformedLegacyFreeze(context.Background(), repo, request); err == nil ||
 				!strings.Contains(err.Error(), "supports only") {
@@ -240,7 +250,7 @@ func TestQuarantineMalformedLegacyFreezeRefusesOutsideExactClass(t *testing.T) {
 	t.Run("inexact authorization", func(t *testing.T) {
 		repo := initSnapshotRepo(t)
 		store, head, _ := malformedLegacyFreezeFixture(t, repo, "legacy-freeze-auth")
-		request := malformedLegacyFreezeQuarantineRequest(repo, "legacy-freeze-auth", head)
+		request := malformedLegacyFreezeQuarantineRequest(t, repo, "legacy-freeze-auth", head)
 		request.MaintainerAuthorization += "\n"
 		if _, err := QuarantineMalformedLegacyFreeze(context.Background(), repo, request); err == nil ||
 			!strings.Contains(err.Error(), "exact maintainer authorization binding") {
@@ -261,7 +271,7 @@ func TestQuarantineMalformedLegacyFreezeRefusesOutsideExactClass(t *testing.T) {
 		if err := os.MkdirAll(compact.Dir, 0o755); err != nil {
 			t.Fatal(err)
 		}
-		request := malformedLegacyFreezeQuarantineRequest(repo, "legacy-freeze-collision", head)
+		request := malformedLegacyFreezeQuarantineRequest(t, repo, "legacy-freeze-collision", head)
 		if _, err := QuarantineMalformedLegacyFreeze(context.Background(), repo, request); err == nil ||
 			!strings.Contains(err.Error(), "also exists in compact-v2") {
 			t.Fatalf("mixed identity error = %v", err)
@@ -279,7 +289,7 @@ func TestQuarantineMalformedLegacyFreezeRefusesOutsideExactClass(t *testing.T) {
 			t.Fatal(err)
 		}
 		defer lock.release()
-		request := malformedLegacyFreezeQuarantineRequest(repo, "legacy-freeze-owned", head)
+		request := malformedLegacyFreezeQuarantineRequest(t, repo, "legacy-freeze-owned", head)
 		if _, err := QuarantineMalformedLegacyFreeze(context.Background(), repo, request); !errors.Is(err, ErrConcurrentUpdate) ||
 			!strings.Contains(err.Error(), "active ownership") {
 			t.Fatalf("active ownership error = %v", err)
@@ -312,7 +322,7 @@ func TestQuarantineMalformedLegacyFreezeRefusesOutsideExactClass(t *testing.T) {
 			Operation: "review/freeze-findings", PreviousRevision: genesis,
 			Transaction: historicalFreezeTransition(t, *tx),
 		})
-		request := malformedLegacyFreezeQuarantineRequest(repo, "legacy-freeze-valid", head)
+		request := malformedLegacyFreezeQuarantineRequest(t, repo, "legacy-freeze-valid", head)
 		if _, err := QuarantineMalformedLegacyFreeze(context.Background(), repo, request); err == nil ||
 			!strings.Contains(err.Error(), "no supported malformed findings-freeze event") {
 			t.Fatalf("valid legacy refusal = %v", err)

--- a/internal/reviewtransaction/maintenance_lock_test.go
+++ b/internal/reviewtransaction/maintenance_lock_test.go
@@ -43,8 +43,12 @@ func TestMaintenanceLockModesAndRelease(t *testing.T) {
 	if err := exclusive.Release(); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := acquireMaintenanceLock(context.Background(), path, maintenanceShared); err != nil {
+	reacquired, err := acquireMaintenanceLock(context.Background(), path, maintenanceShared)
+	if err != nil {
 		t.Fatalf("shared after release: %v", err)
+	}
+	if err := reacquired.Release(); err != nil {
+		t.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
Closes #1478

## PR Type
- [x] Bug fix (`type:bug`)

## Summary
Fixes three Windows-only failures in the full Windows suite introduced alongside #1474. All are test-only; production code (lock release path, authorization derivation) is unchanged and already Windows-safe.

## Changes
| File | Change |
|------|--------|
| `internal/reviewtransaction/maintenance_lock_test.go` | Release the reacquired shared `MaintenanceLock` so no `MAINTENANCE.lock` handle stays open at `t.TempDir()` cleanup (Windows can't delete an open file) |
| `internal/cli/review_legacy_quarantine_test.go` | Build the authorization binding over the canonical repo root via `SnapshotBuilder.ResolveRepositoryRoot` (matches the command; survives Windows 8.3 short-name expansion) |
| `internal/reviewtransaction/compact_legacy_quarantine_test.go` | Same canonicalization via `reviewAuthorityRoot` in the shared quarantine-request helper |

## Test Plan
- [x] `go build ./...`, `gofmt -l internal/` (clean), `go vet ./internal/...`
- [x] `go test ./internal/reviewtransaction/... ./internal/cli/...` pass; the three named tests pass individually
- [ ] Full Windows suite validated on push-to-main (only runs post-merge)

## Contributor Checklist
- [x] Linked an approved issue (#1478)
- [x] Exactly one `type:*` label
- [x] Conventional commit, no Co-Authored-By

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved validation of legacy quarantine authorization using the canonical repository path.
  * Added clearer failure handling when repository-root resolution fails.
  * Ensured reacquired shared maintenance locks are explicitly released during testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->