### PR TITLE
fix(review): release per-lineage lock before legacy quarantine rename on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,8 +82,8 @@ jobs:
       # schedule run the full Windows suite, mirroring the E2E tier policy.
       - name: Run full Windows suite
         shell: pwsh
-        timeout-minutes: 20
-        run: if ($env:GITHUB_EVENT_NAME -eq 'push' -or $env:GITHUB_EVENT_NAME -eq 'schedule') { go test ./... -count=1 -timeout=18m; exit $LASTEXITCODE } else { Write-Host 'Skipping full suite on pull_request; release-blocker tests already ran.' }
+        timeout-minutes: 35
+        run: if ($env:GITHUB_EVENT_NAME -eq 'push' -or $env:GITHUB_EVENT_NAME -eq 'schedule') { go test ./... -count=1 -timeout=30m; exit $LASTEXITCODE } else { Write-Host 'Skipping full suite on pull_request; release-blocker tests already ran.' }
 
   e2e-tests:
     name: E2E Tests (${{ matrix.platform.name }})

--- a/internal/reviewtransaction/legacy_quarantine.go
+++ b/internal/reviewtransaction/legacy_quarantine.go
@@ -84,11 +84,32 @@ func QuarantineMalformedLegacyFreeze(ctx context.Context, repo string, request L
 		}
 		return CompactReclaimRecord{}, fmt.Errorf("inspect legacy quarantine target: %w", err)
 	}
-	lock, err := acquireStoreLock(filepath.Join(dir, "LOCK"))
+	// Detect active lineage ownership with the per-lineage local lock only. Its
+	// handle lives inside dir, which is renamed into quarantine below; on Windows
+	// an open handle anywhere inside a directory makes the directory rename fail
+	// with "Access is denied", so this handle must be closed before the move.
+	localLock, err := acquireLocalStoreLock(filepath.Join(dir, "LOCK"))
 	if err != nil {
 		return CompactReclaimRecord{}, fmt.Errorf("review quarantine-legacy refused active ownership: %w", err)
 	}
-	defer lock.release()
+	localLockReleased := false
+	releaseLocalLock := func() error {
+		if localLockReleased {
+			return nil
+		}
+		localLockReleased = true
+		return localLock.release()
+	}
+	defer releaseLocalLock()
+	// Hold the authority-wide maintenance lock exclusively across the rename so
+	// mutual exclusion is still guaranteed once the per-lineage local lock is
+	// released. The maintenance lock lives above the lineage directory, so it is
+	// never an open handle inside the directory being moved.
+	maintenance, err := acquireMaintenanceLock(ctx, compactMaintenanceLockPath(base), maintenanceExclusive)
+	if err != nil {
+		return CompactReclaimRecord{}, err
+	}
+	defer maintenance.Release()
 	if _, err := os.Stat(filepath.Join(base, "v2", request.LineageID)); err == nil {
 		return CompactReclaimRecord{}, fmt.Errorf("review quarantine-legacy refused: lineage %q also exists in compact-v2 authority", request.LineageID)
 	} else if !os.IsNotExist(err) {
@@ -117,6 +138,13 @@ func QuarantineMalformedLegacyFreeze(ctx context.Context, repo string, request L
 	sort.Strings(residue)
 	if request.QuarantinedAt.IsZero() {
 		request.QuarantinedAt = time.Now().UTC()
+	}
+	// Close the per-lineage lock handle before renaming dir into quarantine so
+	// no open handle remains inside the directory on Windows. The exclusive
+	// maintenance lock, held until this function returns, preserves mutual
+	// exclusion across the rename.
+	if err := releaseLocalLock(); err != nil {
+		return CompactReclaimRecord{}, fmt.Errorf("release legacy lineage lock before quarantine: %w", err)
 	}
 	return quarantineCompactStoreEntry(base, dir, CompactReclaimRecord{
 		Schema: CompactReclaimRecordSchema, Status: CompactReclaimPrepared,


### PR DESCRIPTION
Closes #1478

## PR Type
- [x] Bug fix (`type:bug`)

## Summary
Fixes the real Windows production bug behind the full-suite failures (the test-only surface was addressed in #1479). Legacy quarantine held the per-lineage `<lineage>/LOCK` os.File handle open (via defer) while `os.Rename`-ing that same `v1/<lineage>` directory into a quarantine residue path — Windows refuses to rename a directory containing an open handle ("Access is denied"). v2 callers already lock at the version-root (above the lineage dir) so were unaffected.

## Changes
| File | Change |
|------|--------|
| `internal/reviewtransaction/legacy_quarantine.go` | Acquire the per-lineage local lock for active-ownership detection, acquire the authority-wide maintenance lock **exclusively** (it lives above the lineage dir), then release/close the in-dir local handle **before** the rename while the exclusive maintenance lock still guarantees exclusion. Unix behavior identical. |
| `.github/workflows/ci.yml` | Raise the full Windows suite `go test -timeout` to 30m (`timeout-minutes` to 35) for the maintenance-lock's bounded per-op latency accumulated across the suite. |

## Review
Reviewed via the native bounded **4R** lifecycle (risk/resilience/readability/reliability). No blocking findings (all WARNING/SUGGESTION). Receipt `sha256:1af7bc4c…`; `review validate --gate pre-pr` → **allow**.

## Test Plan
- [x] `go build ./...`, `gofmt -l internal/` (clean), `go vet ./internal/...`
- [x] `go test ./internal/reviewtransaction/... ./internal/cli/...` pass (`-race` on the targeted tests)
- [ ] Full Windows suite validated on push-to-main (only runs post-merge)

## Contributor Checklist
- [x] Linked an approved issue (#1478)
- [x] Exactly one `type:*` label
- [x] Conventional commits, no Co-Authored-By

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when quarantining malformed legacy data, particularly on Windows.
  * Prevented directory move failures by coordinating local and maintenance locking during quarantine operations.

* **Chores**
  * Increased the Windows full-suite execution time limits in automated validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->