### PR TITLE
fix(review): make git-command-timeout contract test robust to slow runners

### DIFF
--- a/internal/cli/review_failure_contract_test.go
+++ b/internal/cli/review_failure_contract_test.go
@@ -443,7 +443,16 @@ func TestNegotiatedFinalizePostTransitionGitTimeoutRequiresStatus(t *testing.T) 
 	t.Setenv(reviewGitHelperStatePathEnv, store.StatePath())
 	t.Cleanup(func() { _ = os.Setenv("PATH", oldPath) })
 	oldTimeout := reviewFacadeOperationTimeout
-	reviewFacadeOperationTimeout = time.Second
+	// The aggregate budget must comfortably exceed the per-git-command timeout
+	// (localGitCommandTimeout, 15s) plus the slowest-runner overhead of reaching
+	// the committed begin-fix transition. The injected helper stalls longer than
+	// the per-git-command timeout (see reviewGitProcessHelperExitCode), so the
+	// per-git-command timeout deterministically fires first and is classified as
+	// git_command_timeout in the native_committed phase. A tight 1s budget raced
+	// the aggregate operation_timeout ahead of that sub-operation timeout on slow
+	// Windows runners; 25s removes the race without slowing the exit, which is
+	// bounded by the 15s per-git-command timeout regardless of this budget.
+	reviewFacadeOperationTimeout = 25 * time.Second
 	t.Cleanup(func() { reviewFacadeOperationTimeout = oldTimeout })
 	oldTransitionHook := reviewFacadeCommittedTransitionHook
 	reviewFacadeCommittedTransitionHook = func(ctx context.Context, hookRepo, operation, _ string) error {
@@ -546,7 +555,12 @@ func reviewGitProcessHelperExitCode() (int, bool) {
 		return 0, false
 	}
 	if payload, err := os.ReadFile(os.Getenv(reviewGitHelperStatePathEnv)); err == nil && strings.Contains(string(payload), `"proposed_correction_lines":`) {
-		time.Sleep(10 * time.Second)
+		// Stall well beyond the per-git-command timeout (localGitCommandTimeout,
+		// 15s) so that the bounded Git subprocess is cut by that per-command
+		// timeout rather than completing on its own. This keeps the post-commit
+		// failure classified as git_command_timeout deterministically instead of
+		// racing the aggregate operation budget on slow runners.
+		time.Sleep(30 * time.Second)
 		return 0, true
 	}
 	command := exec.Command(os.Getenv(reviewGitHelperRealGitEnv), os.Args[1:]...)


### PR DESCRIPTION
Closes #1478

## PR Type
- [x] Bug fix (`type:bug`)

## Summary
Third and final follow-up unblocking the full Windows suite. `TestNegotiatedFinalizePostTransitionGitTimeoutRequiresStatus` failed on the slow Windows runner because its aggregate operation budget was 1s — too tight; slow-runner overhead consumed it before the intended 15s per-git-command timeout could fire, so the aggregate `operation_timeout` won the race instead of the expected `git_command_timeout`. Test-only; no production timeouts changed.

## Changes
| File | Change |
|------|--------|
| `internal/cli/review_failure_contract_test.go` | Raise the test aggregate budget 1s→25s (matching the production default) and the git-helper stall 10s→30s, so the 15s per-command timeout deterministically cuts the stall and classifies `git_command_timeout` regardless of runner speed. Assertions unchanged. |

## Review
Native bounded review (medium risk → `review-reliability` lens). **No findings.** Receipt `sha256:f8ac5725…`; `review validate --gate pre-pr` → allow.

## Test Plan
- [x] `go build ./...`, `gofmt -l internal/` clean, `go vet ./internal/...`
- [x] `go test ./internal/cli/... -count=1` ok; target test 5/5 (~15s, deterministic)
- [ ] Full Windows suite validated on push-to-main

## Contributor Checklist
- [x] Linked approved issue #1478
- [x] One `type:*` label; conventional commit; no Co-Authored-By

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability of post-commit failure classification tests.
  * Ensured Git command timeouts are reported consistently when a Git process stalls.
  * Reduced race conditions in timeout-related test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->