### PR TITLE
fix(assets): grant Bash tool to sdd-archive agent and mandate real mv/cp command

### DIFF
--- a/internal/assets/claude/agents/sdd-archive.md
+++ b/internal/assets/claude/agents/sdd-archive.md
@@ -6,7 +6,7 @@ description: >
   and persists the final archive report. Completes the SDD cycle.
 model: {{CLAUDE_MODEL}}
 {{CLAUDE_EFFORT_FRONTMATTER}}
-tools: Read, Edit, Write, Glob, mcp__plugin_engram_engram__mem_search, mcp__plugin_engram_engram__mem_get_observation, mcp__plugin_engram_engram__mem_save
+tools: Read, Edit, Write, Glob, Bash, mcp__plugin_engram_engram__mem_search, mcp__plugin_engram_engram__mem_get_observation, mcp__plugin_engram_engram__mem_save
 ---
 
 You are the SDD **archive** executor. Do this phase's work yourself. Do NOT delegate further.

--- a/internal/assets/skills/sdd-archive/SKILL.md
+++ b/internal/assets/skills/sdd-archive/SKILL.md
@@ -125,8 +125,8 @@ The delta spec IS a full spec (not a delta). Copy it directly:
 
 ```bash
 # Copy new spec to main specs
-openspec/changes/{change-name}/specs/{domain}/spec.md
-  → openspec/specs/{domain}/spec.md
+mkdir -p openspec/specs/{domain}
+cp openspec/changes/{change-name}/specs/{domain}/spec.md    openspec/specs/{domain}/spec.md
 ```
 
 ### Step 3: Move to Archive
@@ -135,14 +135,18 @@ openspec/changes/{change-name}/specs/{domain}/spec.md
 
 **IF mode is `none`:** Skip — no filesystem operations.
 
-**IF mode is `openspec` or `hybrid`:** Move the entire change folder to archive with date prefix:
+**IF mode is `openspec` or `hybrid`:** Move the entire change folder to archive with date prefix (ONE rename command):
 
-```
-openspec/changes/{change-name}/
-  → openspec/changes/archive/YYYY-MM-DD-{change-name}/
+```bash
+# Move change folder to archive
+mkdir -p openspec/changes/archive
+mv openspec/changes/{change-name}    openspec/changes/archive/{YYYY-MM-DD}-{change-name}
 ```
 
 Use today's date in ISO format (e.g., `2026-02-16`).
+
+> [!IMPORTANT]
+> **PROHIBITED**: Performing a move by reading every file and writing it to the destination (Read+Write simulation) is strictly prohibited. You must use the `mv` command via `Bash` to perform a single directory rename. `Write` is reserved for editing main-spec content and the archive report.
 
 ### Step 4: Verify Archive
 

--- a/internal/components/sdd/inject_test.go
+++ b/internal/components/sdd/inject_test.go
@@ -5988,8 +5988,8 @@ func TestInjectClaudeSubAgentsScopedTools(t *testing.T) {
 		},
 		{
 			phase:       "sdd-archive",
-			mustContain: []string{"Read", "Edit", "Write", "mcp__plugin_engram_engram__mem_search", "mcp__plugin_engram_engram__mem_get_observation", "mcp__plugin_engram_engram__mem_save"},
-			mustNotHave: []string{"Bash", "Task"},
+			mustContain: []string{"Read", "Edit", "Write", "Bash", "mcp__plugin_engram_engram__mem_search", "mcp__plugin_engram_engram__mem_get_observation", "mcp__plugin_engram_engram__mem_save"},
+			mustNotHave: []string{"Task"},
 		},
 	}
 

--- a/testdata/golden/sdd-claude-agent-sdd-archive.golden
+++ b/testdata/golden/sdd-claude-agent-sdd-archive.golden
@@ -5,7 +5,7 @@ description: >
   needs to be closed — merges delta specs into main specs, moves change folder to archive,
   and persists the final archive report. Completes the SDD cycle.
 model: haiku
-tools: Read, Edit, Write, Glob, mcp__plugin_engram_engram__mem_search, mcp__plugin_engram_engram__mem_get_observation, mcp__plugin_engram_engram__mem_save
+tools: Read, Edit, Write, Glob, Bash, mcp__plugin_engram_engram__mem_search, mcp__plugin_engram_engram__mem_get_observation, mcp__plugin_engram_engram__mem_save
 ---
 
 You are the SDD **archive** executor. Do this phase's work yourself. Do NOT delegate further.


### PR DESCRIPTION
Closes #428

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified archive workflows, including creating missing specification directories and moving change folders using a single directory operation.
  * Updated the archive agent’s declared tool capabilities.

* **Tests**
  * Updated validation to reflect the archive agent’s ability to use shell commands while continuing to restrict task delegation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->