### PR TITLE
fix(opencode): dynamically discover loaded models from LM Studio /v1/models endpoint

### DIFF
--- a/internal/opencode/models.go
+++ b/internal/opencode/models.go
@@ -1,12 +1,16 @@
 package opencode
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
+	"time"
 )
 
 // DefaultCachePath returns the default path to the OpenCode models cache file.
@@ -328,7 +332,49 @@ type ConfigModel struct {
 // ConfigProvider represents a custom provider defined in opencode.json.
 type ConfigProvider struct {
 	Name   string                 `json:"name"`
+	URL    string                 `json:"url"`
 	Models map[string]ConfigModel `json:"models"`
+}
+
+type OpenAIModel struct {
+	ID string `json:"id"`
+}
+
+type OpenAIModelsResponse struct {
+	Data []OpenAIModel `json:"data"`
+}
+
+// FetchDynamicModels queries the OpenAI-compatible /v1/models endpoint of a local provider (like LM Studio or Ollama)
+// to fetch actually loaded models.
+func FetchDynamicModels(ctx context.Context, baseURL string) ([]ConfigModel, error) {
+	if baseURL == "" {
+		return nil, errors.New("empty baseURL")
+	}
+	client := &http.Client{Timeout: 1 * time.Second}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, strings.TrimRight(baseURL, "/")+"/models", nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("HTTP %d", resp.StatusCode)
+	}
+
+	var res OpenAIModelsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&res); err != nil {
+		return nil, err
+	}
+
+	models := make([]ConfigModel, 0, len(res.Data))
+	for _, m := range res.Data {
+		models = append(models, ConfigModel{Name: m.ID, ToolCall: true})
+	}
+	return models, nil
 }
 
 // LoadConfigProviders reads the provider section from an opencode.json settings file.

--- a/internal/opencode/models_test.go
+++ b/internal/opencode/models_test.go
@@ -1,12 +1,16 @@
 package opencode
 
 import (
+	"context"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 )
 
 const fixtureJSON = `{
@@ -581,6 +585,31 @@ func TestLoadConfigProvidersInvalidJSON(t *testing.T) {
 	}
 	if len(config) != 0 {
 		t.Fatalf("expected empty map on parse error, got %v", config)
+	}
+}
+
+// FetchDynamicModels
+func TestFetchDynamicModels(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{
+			"data": [
+				{"id": "qwen2.5-coder-7b-instruct", "object": "model", "owned_by": "lmstudio"}
+			]
+		}`))
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	models, err := FetchDynamicModels(ctx, server.URL)
+	if err != nil {
+		t.Fatalf("FetchDynamicModels failed: %v", err)
+	}
+
+	if len(models) != 1 || models[0].Name != "qwen2.5-coder-7b-instruct" || !models[0].ToolCall {
+		t.Fatalf("unexpected models returned: %v", models)
 	}
 }
 

--- a/internal/tui/screens/model_picker.go
+++ b/internal/tui/screens/model_picker.go
@@ -1,11 +1,13 @@
 package screens
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 	"unicode"
 
 	"github.com/gentleman-programming/gentle-ai/internal/model"
@@ -87,6 +89,25 @@ func NewModelPickerState(cachePath string, settingsPath string) ModelPickerState
 	}
 
 	configProviders, configErr := opencode.LoadConfigProviders(settingsPath)
+	if lm, ok := configProviders["lmstudio"]; ok {
+		url := lm.URL
+		if url == "" {
+			url = "http://127.0.0.1:1234/v1"
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		dynModels, err := opencode.FetchDynamicModels(ctx, url)
+		cancel()
+		if err == nil && len(dynModels) > 0 {
+			if lm.Models == nil {
+				lm.Models = make(map[string]opencode.ConfigModel)
+			}
+			for _, m := range dynModels {
+				lm.Models[m.Name] = m
+			}
+			configProviders["lmstudio"] = lm
+		}
+	}
+
 	if len(configProviders) > 0 {
 		providers = opencode.MergeCustomProviders(providers, configProviders)
 	}


### PR DESCRIPTION
Closes #375

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic model discovery for LM Studio providers.
  * The model picker now retrieves available models from LM Studio-compatible endpoints and adds them to the selectable model list.
  * Supports custom provider URLs, with a default local LM Studio address when none is configured.

* **Bug Fixes**
  * Model discovery failures no longer prevent existing provider configurations from loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
Recommended Label: **type:bug** (to be added by maintainer)