### PR TITLE
feat(system): add Alpine Linux support with apk package manager

### DIFF
--- a/internal/installcmd/resolver.go
+++ b/internal/installcmd/resolver.go
@@ -260,7 +260,7 @@ func resolveGGAInstall(profile system.PlatformProfile) (CommandSequence, error) 
 			{"brew", "tap", "Gentleman-Programming/homebrew-tap"},
 			{"brew", "reinstall", "gga"},
 		}, nil
-	case "apt", "pacman", "dnf":
+	case "apt", "pacman", "dnf", "apk":
 		const tmpDir = "/tmp/gentleman-guardian-angel"
 		return CommandSequence{
 			{"rm", "-rf", tmpDir},

--- a/internal/system/detect.go
+++ b/internal/system/detect.go
@@ -31,6 +31,7 @@ const (
 	LinuxDistroDebian  = "debian"
 	LinuxDistroArch    = "arch"
 	LinuxDistroFedora  = "fedora"
+	LinuxDistroAlpine  = "alpine"
 )
 
 type DetectionResult struct {
@@ -148,6 +149,9 @@ func resolvePlatformProfile(goos, linuxOSRelease string, tools map[string]ToolSt
 		case LinuxDistroFedora:
 			profile.PackageManager = "dnf"
 			profile.Supported = true
+		case LinuxDistroAlpine:
+			profile.PackageManager = "apk"
+			profile.Supported = true
 		default:
 			profile.PackageManager = ""
 			profile.Supported = false
@@ -203,6 +207,9 @@ func detectLinuxDistro(linuxOSRelease string) string {
 	if isFedoraLike(id, idLike) {
 		return LinuxDistroFedora
 	}
+	if isAlpineLike(id, idLike) {
+		return LinuxDistroAlpine
+	}
 
 	return LinuxDistroUnknown
 }
@@ -246,5 +253,17 @@ func isFedoraLike(id, idLike string) bool {
 		}
 	}
 
+	return false
+}
+
+func isAlpineLike(id, idLike string) bool {
+	if id == LinuxDistroAlpine {
+		return true
+	}
+	for _, token := range strings.Fields(idLike) {
+		if token == LinuxDistroAlpine {
+			return true
+		}
+	}
 	return false
 }


### PR DESCRIPTION
Closes #334

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for automatically detecting Alpine Linux environments.
  * Alpine Linux installations now use the `apk` package manager.
  * Alpine users can install through the standard Linux clone-and-install workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
Recommended Label: **type:feature** (to be added by maintainer)