### PR TITLE
fix(filemerge): extract parent directory writability logic for Windows support

### DIFF
--- a/internal/components/filemerge/ensure_writable_unix.go
+++ b/internal/components/filemerge/ensure_writable_unix.go
@@ -1,0 +1,18 @@
+//go:build !windows
+
+package filemerge
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+)
+
+func ensureWritable(dir string, info fs.FileInfo, path string) error {
+	if info.Mode().Perm()&0o200 == 0 {
+		if err := os.Chmod(dir, 0o755); err != nil {
+			return fmt.Errorf("relax parent directory permissions for %q: %w", path, err)
+		}
+	}
+	return nil
+}

--- a/internal/components/filemerge/ensure_writable_windows.go
+++ b/internal/components/filemerge/ensure_writable_windows.go
@@ -1,0 +1,13 @@
+//go:build windows
+
+package filemerge
+
+import (
+	"io/fs"
+)
+
+func ensureWritable(dir string, info fs.FileInfo, path string) error {
+	// Windows directory write permissions are managed via ACLs.
+	// Bypasses Unix chmod 555 checks.
+	return nil
+}

--- a/internal/components/filemerge/writer.go
+++ b/internal/components/filemerge/writer.go
@@ -165,10 +165,5 @@ func ensureAtomicParentDir(dir, path string) error {
 	if !info.IsDir() {
 		return fmt.Errorf("parent path %q for %q is not a directory", dir, path)
 	}
-	if info.Mode().Perm()&0o200 == 0 {
-		if err := os.Chmod(dir, 0o755); err != nil {
-			return fmt.Errorf("relax parent directory permissions for %q: %w", path, err)
-		}
-	}
-	return nil
+	return ensureWritable(dir, info, path)
 }


### PR DESCRIPTION
Closes #298

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file merge reliability when the destination directory lacks owner-write permissions.
  * Added platform-specific handling so file merges work consistently across Windows and Unix-based systems.
  * Improved error reporting when directory permissions cannot be adjusted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->