### PR TITLE
fix(review): repair historical legacy aliases

### DIFF
--- a/docs/review-authority-threat-model.md
+++ b/docs/review-authority-threat-model.md
@@ -50,7 +50,15 @@ Synthetic Git trees used by persisted snapshots remain subject to repository obj
 - A local hash chain presented as protection from the out-of-scope actor.
 - Mandatory bundles, policy mirrors, ledger mirrors, evidence mirrors, fix-delta mirrors, or gate-context mirrors for ordinary review.
 
-Legacy v1 chains and bundles remain readable for compatibility, but their history cannot be appended, rewritten, repaired, or migrated in place.
+Legacy v1 chains and bundles remain readable for compatibility, but their history cannot be appended, rewritten, or migrated in place. The sole repair exception is an audited whole-lineage quarantine described below; it never makes the historical bytes valid.
+
+## Historical Alias Quarantine
+
+`gentle-ai review repair-legacy-alias` is a narrow maintenance operation for a legacy-v1 lineage whose replay fails solely with `unsupported historical v1 operation alias`. It accepts only the approved historical aliases `review/validate-fix` and `review/complete-fix`, replays every other event normally, and requires the exact current `HEAD` revision, diagnostic `unsupported historical v1 operation alias`, and disposition `quarantine-approved-historical-alias`.
+
+The maintainer authorization is an exact LF-only eight-line binding with schema `gentle-ai.review-legacy-alias-repair-authorization/v1`, followed by `repository`, `lineage`, `revision`, `diagnostic`, `disposition`, `actor`, and `reason`. The operation refuses unknown aliases, semantic corruption, mixed v1/v2 lineage identity, malformed authorization, stale revisions, and active or shared-maintenance-lock contention.
+
+On success it moves the complete immutable lineage into `review-transactions/quarantine/`, writes a prepared then committed audit record with the re-derived chain identity and alias-event revisions, and reads the inventory back. It does not delete or rewrite authority. The status becomes complete/authoritative only if the remaining inventory is independently clean; unrelated invalid, incomplete, compact-v2, or graph authority continues to fail closed.
 
 ## Recovery And Rollback
 

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -338,7 +338,7 @@ func TestRunArgsDispatchesCompactReviewFacadeBeforePlatformValidation(t *testing
 	if err := RunArgs([]string{"review", "--help"}, &output); err != nil {
 		t.Fatalf("RunArgs(review --help) error = %v", err)
 	}
-	if !strings.Contains(output.String(), "review <capabilities|start|finalize|validate|status|invalidate|abandon|recover|reclaim|reconcile-authority|quarantine-legacy|schema|bind-sdd>") {
+	if !strings.Contains(output.String(), "review <capabilities|start|finalize|validate|status|invalidate|abandon|recover|reclaim|reconcile-authority|quarantine-legacy|repair-legacy-alias|schema|bind-sdd>") {
 		t.Fatalf("compact review help missing:\n%s", output.String())
 	}
 }

--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -226,7 +226,7 @@ var reviewFacadeCommittedTransitionHook = func(context.Context, string, string, 
 
 func RunReview(args []string, stdout io.Writer) error {
 	if len(args) == 0 || args[0] == "help" || args[0] == "-h" || args[0] == "--help" {
-		_, _ = fmt.Fprintln(stdout, "Usage: gentle-ai review <capabilities|start|finalize|validate|status|invalidate|abandon|recover|reclaim|reconcile-authority|quarantine-legacy|schema|bind-sdd> [flags]\n\nOrdinary review facade; repository scope, authority, canonical artifacts, and lifecycle transitions are derived by Go.")
+		_, _ = fmt.Fprintln(stdout, "Usage: gentle-ai review <capabilities|start|finalize|validate|status|invalidate|abandon|recover|reclaim|reconcile-authority|quarantine-legacy|repair-legacy-alias|schema|bind-sdd> [flags]\n\nOrdinary review facade; repository scope, authority, canonical artifacts, and lifecycle transitions are derived by Go.")
 		_, _ = fmt.Fprintln(stdout, "Additive headless capabilities: gentle-ai review capture-result (with --preflight) and gentle-ai review preserve-result.")
 		return nil
 	}
@@ -319,6 +319,8 @@ func runReviewCommand(args []string, stdout io.Writer) error {
 		return RunReviewReconcileAuthority(args[1:], stdout)
 	case "quarantine-legacy":
 		return RunReviewLegacyQuarantine(args[1:], stdout)
+	case "repair-legacy-alias":
+		return RunReviewLegacyAliasRepair(args[1:], stdout)
 	case "schema":
 		return RunReviewSchema(args[1:], stdout)
 	case "bind-sdd":

--- a/internal/cli/review_legacy_alias_repair.go
+++ b/internal/cli/review_legacy_alias_repair.go
@@ -1,0 +1,57 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/gentleman-programming/gentle-ai/internal/reviewtransaction"
+)
+
+type ReviewLegacyAliasRepairResult struct {
+	Operation string                                 `json:"operation"`
+	Record    reviewtransaction.CompactReclaimRecord `json:"record"`
+}
+
+func RunReviewLegacyAliasRepair(args []string, stdout io.Writer) error {
+	flags := newReviewFlagSet("review repair-legacy-alias", stdout, "Quarantine one immutable legacy-v1 lineage rejected solely because of approved historical operation aliases. The chain is revalidated against its exact approved historical semantics, moved whole into audited quarantine, and never rewritten or accepted as valid. Unknown aliases, unrelated corruption, mixed authority, stale revisions, and active ownership are refused. Exact committed retries converge idempotently.")
+	cwd := flags.String("cwd", ".", "repository path")
+	lineage := flags.String("lineage", "", "legacy-v1 lineage to repair by quarantine")
+	expected := flags.String("expected-revision", "", "exact current legacy HEAD revision")
+	diagnostic := flags.String("diagnostic", "", "exact inventory diagnostic")
+	disposition := flags.String("disposition", "", "exact supported quarantine disposition")
+	reason := flags.String("reason", "", "non-empty repair reason")
+	actor := flags.String("actor", "", "repair actor")
+	authorization := flags.String("maintainer-authorization", "", "exact eight-line LF-only binding: gentle-ai.review-legacy-alias-repair-authorization/v1, repository, lineage, revision, diagnostic, disposition, actor, reason")
+	if err := parseReviewFlags(flags, args); err != nil {
+		return err
+	}
+	if reviewHelpRequested(args) {
+		return nil
+	}
+	if flags.NArg() != 0 {
+		return fmt.Errorf("unexpected review repair-legacy-alias argument %q", flags.Arg(0))
+	}
+	for _, required := range []string{*lineage, *expected, *diagnostic, *disposition, *reason, *actor, *authorization} {
+		if strings.TrimSpace(required) == "" {
+			return errors.New("review repair-legacy-alias requires --lineage, --expected-revision, --diagnostic, --disposition, --reason, --actor, and --maintainer-authorization")
+		}
+	}
+	root, err := (reviewtransaction.SnapshotBuilder{Repo: *cwd}).ResolveRepositoryRoot(context.Background())
+	if err != nil {
+		return fmt.Errorf("resolve review repository root: %w", err)
+	}
+	record, err := reviewtransaction.RepairHistoricalLegacyAlias(context.Background(), root, reviewtransaction.LegacyAliasRepairRequest{
+		LineageID: *lineage, ExpectedRevision: *expected, ExpectedDiagnostic: *diagnostic,
+		Disposition: *disposition, Reason: *reason, Actor: *actor, MaintainerAuthorization: *authorization,
+	})
+	if err != nil {
+		if record.QuarantinePath != "" {
+			_ = encodeReviewJSON(stdout, ReviewLegacyAliasRepairResult{Operation: "review/repair-legacy-alias", Record: record})
+		}
+		return err
+	}
+	return encodeReviewJSON(stdout, ReviewLegacyAliasRepairResult{Operation: "review/repair-legacy-alias", Record: record})
+}

--- a/internal/cli/review_legacy_alias_repair_test.go
+++ b/internal/cli/review_legacy_alias_repair_test.go
@@ -1,0 +1,27 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestReviewRepairLegacyAliasRequiresExactBoundAuthorization(t *testing.T) {
+	var output bytes.Buffer
+	err := RunReview([]string{"repair-legacy-alias"}, &output)
+	if err == nil || !strings.Contains(err.Error(), "requires --lineage, --expected-revision, --diagnostic, --disposition, --reason, --actor, and --maintainer-authorization") {
+		t.Fatalf("missing repair input error = %v", err)
+	}
+}
+
+func TestReviewRepairLegacyAliasHelpDocumentsNarrowContract(t *testing.T) {
+	var help bytes.Buffer
+	if err := RunReview([]string{"repair-legacy-alias", "--help"}, &help); err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"approved historical operation aliases", "exact eight-line LF-only binding", "idempotently"} {
+		if !strings.Contains(help.String(), want) {
+			t.Fatalf("repair help missing %q: %s", want, help.String())
+		}
+	}
+}

--- a/internal/reviewtransaction/compact_reclaim.go
+++ b/internal/reviewtransaction/compact_reclaim.go
@@ -63,6 +63,9 @@ type CompactReclaimRecord struct {
 	// MalformedLegacyFreeze carries the natively re-derived semantic replay
 	// failure for a shipped legacy-v1 findings-freeze event.
 	MalformedLegacyFreeze *LegacyMalformedFreezeProof `json:"malformed_legacy_freeze,omitempty"`
+	// LegacyAliasRepair carries the natively re-derived proof for the narrow
+	// historical v1 operation-alias quarantine.
+	LegacyAliasRepair *LegacyAliasRepairProof `json:"legacy_alias_repair,omitempty"`
 }
 
 // compactAuthoritativeArtifact reports whether a store-entry name carries

--- a/internal/reviewtransaction/legacy_alias_repair.go
+++ b/internal/reviewtransaction/legacy_alias_repair.go
@@ -1,0 +1,269 @@
+package reviewtransaction
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	legacyAliasRepairAuthorizationSchema = "gentle-ai.review-legacy-alias-repair-authorization/v1"
+	LegacyAliasRepairDisposition         = "quarantine-approved-historical-alias"
+	legacyAliasRepairDiagnostic          = "unsupported historical v1 operation alias"
+)
+
+// LegacyAliasRepairRequest identifies one exact invalid legacy-v1 lineage.
+// It is intentionally a quarantine operation, never a rewrite or reset.
+type LegacyAliasRepairRequest struct {
+	LineageID               string
+	ExpectedRevision        string
+	ExpectedDiagnostic      string
+	Disposition             string
+	Reason                  string
+	Actor                   string
+	MaintainerAuthorization string
+	RepairedAt              time.Time
+}
+
+// LegacyAliasRepairProof captures the re-derived chain identity and only the
+// approved historical aliases found while replaying its immutable history.
+type LegacyAliasRepairProof struct {
+	LineageID      string   `json:"lineage_id"`
+	HeadRevision   string   `json:"head_revision"`
+	ChainIdentity  string   `json:"chain_identity"`
+	EventRevisions []string `json:"event_revisions"`
+	Operations     []string `json:"operations"`
+	Diagnostic     string   `json:"diagnostic"`
+	Disposition    string   `json:"disposition"`
+}
+
+func legacyAliasRepairAuthorizationBinding(repository, lineage, revision, diagnostic, disposition, actor, reason string) string {
+	return legacyAliasRepairAuthorizationSchema + "\nrepository=" + repository +
+		"\nlineage=" + lineage + "\nrevision=" + revision +
+		"\ndiagnostic=" + diagnostic + "\ndisposition=" + disposition +
+		"\nactor=" + strings.TrimSpace(actor) + "\nreason=" + strings.TrimSpace(reason)
+}
+
+// RepairHistoricalLegacyAlias quarantines one historical legacy-v1 lineage
+// rejected solely by an approved operation alias. It requires the exact HEAD,
+// a complete LF authorization binding, a re-derived chain proof, and the
+// authority-wide maintenance lease. It never makes historical events valid.
+func RepairHistoricalLegacyAlias(ctx context.Context, repo string, request LegacyAliasRepairRequest) (CompactReclaimRecord, error) {
+	if err := ctx.Err(); err != nil {
+		return CompactReclaimRecord{}, err
+	}
+	if err := validateLineageID(request.LineageID); err != nil {
+		return CompactReclaimRecord{}, err
+	}
+	if !validSHA256(request.ExpectedRevision) {
+		return CompactReclaimRecord{}, errors.New("review repair-legacy-alias requires an exact current HEAD revision")
+	}
+	if strings.TrimSpace(request.Reason) == "" || strings.TrimSpace(request.Actor) == "" {
+		return CompactReclaimRecord{}, errors.New("review repair-legacy-alias requires a non-empty reason and actor")
+	}
+	if request.ExpectedDiagnostic != legacyAliasRepairDiagnostic || request.Disposition != LegacyAliasRepairDisposition {
+		return CompactReclaimRecord{}, errors.New("review repair-legacy-alias supports only the approved unsupported historical v1 operation alias diagnostic and disposition")
+	}
+	base, repository, err := reviewAuthorityRoot(ctx, repo)
+	if err != nil {
+		return CompactReclaimRecord{}, err
+	}
+	dir := filepath.Join(base, "v1", request.LineageID)
+	if _, err := os.Stat(dir); err != nil {
+		if os.IsNotExist(err) {
+			return replayCommittedLegacyAliasRepair(base, repository, request)
+		}
+		return CompactReclaimRecord{}, fmt.Errorf("inspect legacy alias repair target: %w", err)
+	}
+
+	localLock, err := acquireLocalStoreLock(filepath.Join(dir, "LOCK"))
+	if err != nil {
+		return CompactReclaimRecord{}, fmt.Errorf("review repair-legacy-alias refused active ownership: %w", err)
+	}
+	localLockReleased := false
+	releaseLocalLock := func() error {
+		if localLockReleased {
+			return nil
+		}
+		localLockReleased = true
+		return localLock.release()
+	}
+	defer releaseLocalLock()
+
+	maintenance, err := acquireMaintenanceLock(ctx, compactMaintenanceLockPath(base), maintenanceExclusive)
+	if err != nil {
+		return CompactReclaimRecord{}, err
+	}
+	defer maintenance.Release()
+	if _, err := os.Stat(filepath.Join(base, "v2", request.LineageID)); err == nil {
+		return CompactReclaimRecord{}, fmt.Errorf("review repair-legacy-alias refused: lineage %q also exists in compact-v2 authority", request.LineageID)
+	} else if !os.IsNotExist(err) {
+		return CompactReclaimRecord{}, fmt.Errorf("inspect same-lineage compact authority: %w", err)
+	}
+
+	store := Store{Dir: dir, lineageID: request.LineageID, repo: repository, readOnly: true}
+	proof, err := inspectHistoricalLegacyAlias(store, request.ExpectedRevision)
+	if err != nil {
+		return CompactReclaimRecord{}, err
+	}
+	proof.Disposition = request.Disposition
+	if request.MaintainerAuthorization != legacyAliasRepairAuthorizationBinding(
+		repository, request.LineageID, request.ExpectedRevision, request.ExpectedDiagnostic,
+		request.Disposition, request.Actor, request.Reason,
+	) {
+		return CompactReclaimRecord{}, fmt.Errorf("review repair-legacy-alias requires an exact maintainer authorization binding (schema %s over repository, lineage, revision, diagnostic, disposition, actor, and reason)", legacyAliasRepairAuthorizationSchema)
+	}
+	items, err := os.ReadDir(dir)
+	if err != nil {
+		return CompactReclaimRecord{}, fmt.Errorf("inspect legacy alias repair target: %w", err)
+	}
+	residue := make([]string, 0, len(items))
+	for _, item := range items {
+		residue = append(residue, item.Name())
+	}
+	sort.Strings(residue)
+	if request.RepairedAt.IsZero() {
+		request.RepairedAt = time.Now().UTC()
+	}
+	if err := releaseLocalLock(); err != nil {
+		return CompactReclaimRecord{}, fmt.Errorf("release legacy lineage lock before alias repair: %w", err)
+	}
+	record, err := quarantineCompactStoreEntry(base, dir, CompactReclaimRecord{
+		Schema: CompactReclaimRecordSchema, Status: CompactReclaimPrepared,
+		LineageID: request.LineageID, Reason: strings.TrimSpace(request.Reason), Actor: strings.TrimSpace(request.Actor),
+		ReclaimedAt: request.RepairedAt.UTC(), SourcePath: dir, Residue: residue, LegacyAliasRepair: &proof,
+	})
+	if err != nil {
+		return record, err
+	}
+	if err := verifyHistoricalLegacyAliasRepairReadback(ctx, repo, request.LineageID, record); err != nil {
+		return record, err
+	}
+	return record, nil
+}
+
+func inspectHistoricalLegacyAlias(store Store, expectedHead string) (LegacyAliasRepairProof, error) {
+	head, err := readRevision(filepath.Join(store.Dir, "HEAD"))
+	if err != nil {
+		return LegacyAliasRepairProof{}, err
+	}
+	if head != expectedHead {
+		return LegacyAliasRepairProof{}, fmt.Errorf("%w: expected legacy HEAD %q, current %q", ErrConcurrentUpdate, expectedHead, head)
+	}
+	visited := map[string]bool{}
+	reverseRecords := []Record{}
+	reverseRevisions := []string{}
+	for revision := head; revision != ""; {
+		if visited[revision] {
+			return LegacyAliasRepairProof{}, errors.New("review repair-legacy-alias refused: predecessor cycle")
+		}
+		visited[revision] = true
+		record, loaded, err := store.loadRevision(revision)
+		if err != nil {
+			return LegacyAliasRepairProof{}, fmt.Errorf("review repair-legacy-alias refused: load revision %s: %w", revision, err)
+		}
+		reverseRecords = append(reverseRecords, record)
+		reverseRevisions = append(reverseRevisions, loaded)
+		revision = record.PreviousRevision
+	}
+	records := make([]Record, len(reverseRecords))
+	revisions := make([]string, len(reverseRevisions))
+	for index := range reverseRecords {
+		reverse := len(reverseRecords) - 1 - index
+		records[index], revisions[index] = reverseRecords[reverse], reverseRevisions[reverse]
+	}
+	if len(records) == 0 || !validInitialStoreRecord(records[0]) || records[0].Transaction.LineageID != store.lineageID {
+		return LegacyAliasRepairProof{}, errors.New("review repair-legacy-alias refused: chain genesis is invalid")
+	}
+	proof := LegacyAliasRepairProof{
+		LineageID: store.lineageID, HeadRevision: head, ChainIdentity: chainIdentity(revisions),
+		EventRevisions: []string{}, Operations: []string{}, Diagnostic: legacyAliasRepairDiagnostic,
+	}
+	for index := 1; index < len(records); index++ {
+		if records[index].PreviousRevision != revisions[index-1] {
+			return LegacyAliasRepairProof{}, errors.New("review repair-legacy-alias refused: predecessor revision is discontinuous")
+		}
+		operation := records[index].Operation
+		err := validatePersistedV1Successor(records[index-1].Transaction, records[index].Transaction, operation, index)
+		if err == nil {
+			continue
+		}
+		canonical, approved := approvedHistoricalAliasCanonicalOperation(operation)
+		if !approved || err.Error() != ErrInvalidSuccessor.Error()+": "+legacyAliasRepairDiagnostic ||
+			validateSuccessor(records[index-1].Transaction, records[index].Transaction, canonical) != nil {
+			return LegacyAliasRepairProof{}, fmt.Errorf("review repair-legacy-alias refused unsupported successor anomaly at %s: %w", revisions[index], err)
+		}
+		proof.EventRevisions = append(proof.EventRevisions, revisions[index])
+		proof.Operations = append(proof.Operations, operation)
+	}
+	if len(proof.EventRevisions) == 0 {
+		return LegacyAliasRepairProof{}, errors.New("review repair-legacy-alias refused: lineage has no approved unsupported historical operation alias")
+	}
+	return proof, nil
+}
+
+func approvedHistoricalAliasCanonicalOperation(operation string) (string, bool) {
+	switch operation {
+	case "review/validate-fix":
+		return "review/validate-fix-delta", true
+	case "review/complete-fix":
+		return "review/validate-fix-delta", true
+	default:
+		return "", false
+	}
+}
+
+func verifyHistoricalLegacyAliasRepairReadback(ctx context.Context, repo, lineage string, record CompactReclaimRecord) error {
+	if record.Status != CompactReclaimCommitted || record.LegacyAliasRepair == nil {
+		return errors.New("review repair-legacy-alias did not commit an auditable quarantine record")
+	}
+	report, err := InventoryAuthority(ctx, repo)
+	if err != nil {
+		return fmt.Errorf("read back authority inventory after alias repair: %w", err)
+	}
+	for _, entry := range report.Entries {
+		if entry.LineageID == lineage {
+			return fmt.Errorf("read back authority inventory still contains repaired lineage %q", lineage)
+		}
+	}
+	return nil
+}
+
+func replayCommittedLegacyAliasRepair(base, repository string, request LegacyAliasRepairRequest) (CompactReclaimRecord, error) {
+	entries, err := os.ReadDir(filepath.Join(base, "quarantine"))
+	if err != nil && !os.IsNotExist(err) {
+		return CompactReclaimRecord{}, fmt.Errorf("inspect quarantine for legacy alias replay: %w", err)
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		payload, readErr := os.ReadFile(filepath.Join(base, "quarantine", entry.Name(), "reclaim-record.json"))
+		if readErr != nil {
+			continue
+		}
+		var record CompactReclaimRecord
+		if json.Unmarshal(payload, &record) != nil || record.Status != CompactReclaimCommitted || record.LegacyAliasRepair == nil {
+			continue
+		}
+		proof := record.LegacyAliasRepair
+		if proof.LineageID != request.LineageID || proof.HeadRevision != request.ExpectedRevision ||
+			proof.Diagnostic != request.ExpectedDiagnostic || proof.Disposition != request.Disposition ||
+			record.Reason != strings.TrimSpace(request.Reason) || record.Actor != strings.TrimSpace(request.Actor) {
+			continue
+		}
+		if request.MaintainerAuthorization != legacyAliasRepairAuthorizationBinding(
+			repository, proof.LineageID, proof.HeadRevision, proof.Diagnostic, proof.Disposition, request.Actor, request.Reason,
+		) {
+			continue
+		}
+		return record, nil
+	}
+	return CompactReclaimRecord{}, fmt.Errorf("review repair-legacy-alias refused: lineage %q is absent and no committed repair record matches; inspect prepared records under %s", request.LineageID, filepath.Join(base, "quarantine"))
+}

--- a/internal/reviewtransaction/legacy_alias_repair_test.go
+++ b/internal/reviewtransaction/legacy_alias_repair_test.go
@@ -1,0 +1,311 @@
+package reviewtransaction
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func legacyAliasRepairFixture(t *testing.T, repo, lineage string, operation ...string) (Store, string, string) {
+	t.Helper()
+	store, err := AuthoritativeStore(context.Background(), repo, lineage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tx := newTestTransaction(t, ModeOrdinary4R)
+	tx.LineageID = lineage
+	if err := tx.StartReview(); err != nil {
+		t.Fatal(err)
+	}
+	head := writeStoreEvent(t, store, Record{Operation: "review/start", Transaction: *tx})
+	if err := freezeTestFindings(tx, []Finding{{ID: "R1-ALIAS", Severity: "CRITICAL"}}); err != nil {
+		t.Fatal(err)
+	}
+	head = writeStoreEvent(t, store, Record{Operation: "review/freeze-findings", PreviousRevision: head, Transaction: *tx})
+	if _, err := tx.ClassifyEvidence([]FindingEvidence{{FindingID: "R1-ALIAS", Class: EvidenceDeterministic, Causality: CausalIntroduced, Proof: "historical proof"}}); err != nil {
+		t.Fatal(err)
+	}
+	head = writeStoreEvent(t, store, Record{Operation: "review/classify-evidence", PreviousRevision: head, Transaction: *tx})
+	if err := tx.BeginFix(hash("a")); err != nil {
+		t.Fatal(err)
+	}
+	head = writeStoreEvent(t, store, Record{Operation: "review/begin-fix", PreviousRevision: head, Transaction: *tx})
+	fix := tx.Snapshot
+	fix.Kind, fix.BaseTree, fix.CandidateTree, fix.LedgerIDs, fix.Identity = TargetFixDiff, tx.FinalCandidateTree, tree("c"), []string{"R1-ALIAS"}, hash("b")
+	if err := tx.CompleteFix(fix, hash("c"), fix.LedgerIDs); err != nil {
+		t.Fatal(err)
+	}
+	// review/complete-fix is the historically valid predecessor used by the
+	// affected gentle-pi chains; the following alias is the sole invalid event.
+	head = writeStoreEvent(t, store, Record{Operation: "review/complete-fix", PreviousRevision: head, Transaction: *tx})
+	legacy := historicalValidationTransition(*tx)
+	alias := "review/validate-fix"
+	if len(operation) == 1 {
+		alias = operation[0]
+	}
+	bad := writeStoreEvent(t, store, Record{Operation: alias, PreviousRevision: head, Transaction: legacy})
+	return store, bad, bad
+}
+
+func legacyAliasRepairRequest(t *testing.T, repo, lineage, revision string) LegacyAliasRepairRequest {
+	t.Helper()
+	_, repository, err := reviewAuthorityRoot(context.Background(), repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := LegacyAliasRepairRequest{
+		LineageID: lineage, ExpectedRevision: revision,
+		ExpectedDiagnostic: "unsupported historical v1 operation alias",
+		Disposition:        LegacyAliasRepairDisposition,
+		Reason:             "quarantine exact approved historical alias chain", Actor: "maintainer@example.com",
+	}
+	request.MaintainerAuthorization = legacyAliasRepairAuthorizationBinding(
+		repository, request.LineageID, request.ExpectedRevision, request.ExpectedDiagnostic,
+		request.Disposition, request.Actor, request.Reason,
+	)
+	return request
+}
+
+func TestRepairHistoricalLegacyAliasPreservesEvidenceAndRestoresOnlySafeInventory(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	approved, approvedStore := approvedCompactFixture(t, repo, "alias-repair-approved")
+	store, head, event := legacyAliasRepairFixture(t, repo, "alias-repair-broken")
+	request := legacyAliasRepairRequest(t, repo, "alias-repair-broken", head)
+
+	eventPath := filepath.Join(store.Dir, "events", strings.TrimPrefix(event, "sha256:")+".json")
+	eventBytes, err := os.ReadFile(eventPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	approvedState, err := os.ReadFile(approvedStore.StatePath())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	committed, err := RepairHistoricalLegacyAlias(context.Background(), repo, request)
+	if err != nil {
+		t.Fatalf("repair historical alias: %v", err)
+	}
+	proof := committed.LegacyAliasRepair
+	if committed.Status != CompactReclaimCommitted || proof == nil ||
+		proof.LineageID != request.LineageID || proof.HeadRevision != head ||
+		!strings.Contains(strings.Join(proof.Operations, ","), "review/validate-fix") ||
+		proof.Diagnostic != request.ExpectedDiagnostic || proof.Disposition != request.Disposition {
+		t.Fatalf("repair record = %#v", committed)
+	}
+	moved, err := os.ReadFile(filepath.Join(committed.QuarantinePath, "residue", "events", filepath.Base(eventPath)))
+	if err != nil || !bytes.Equal(moved, eventBytes) {
+		t.Fatalf("quarantined alias event = %q, %v", moved, err)
+	}
+	if after, err := os.ReadFile(approvedStore.StatePath()); err != nil || !bytes.Equal(after, approvedState) {
+		t.Fatalf("unrelated approved authority changed: %v", err)
+	}
+	report, err := InventoryAuthority(context.Background(), repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !report.Complete || !report.Authoritative || !hasAuthorityInventoryStatus(report.Entries, approved.State.LineageID, AuthorityStatusApproved) {
+		t.Fatalf("post-repair inventory = %#v", report)
+	}
+
+	replayed, err := RepairHistoricalLegacyAlias(context.Background(), repo, request)
+	if err != nil || replayed.QuarantinePath != committed.QuarantinePath {
+		t.Fatalf("idempotent repair = %#v, %v", replayed, err)
+	}
+}
+
+func TestRepairHistoricalLegacyCompleteFixAliasUsesValidationCanonicalOperation(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	store, head, event := legacyAliasRepairFixture(t, repo, "alias-repair-historical-complete", "review/complete-fix")
+	request := legacyAliasRepairRequest(t, repo, "alias-repair-historical-complete", head)
+
+	committed, err := RepairHistoricalLegacyAlias(context.Background(), repo, request)
+	if err != nil {
+		t.Fatalf("repair historical complete-fix alias: %v", err)
+	}
+	if committed.LegacyAliasRepair == nil || !strings.Contains(strings.Join(committed.LegacyAliasRepair.Operations, ","), "review/complete-fix") {
+		t.Fatalf("complete-fix repair record = %#v", committed)
+	}
+	if _, err := os.Stat(store.Dir); !os.IsNotExist(err) {
+		t.Fatalf("historical complete-fix source remains: %v", err)
+	}
+	moved, err := os.ReadFile(filepath.Join(committed.QuarantinePath, "residue", "events", strings.TrimPrefix(event, "sha256:")+".json"))
+	if err != nil || len(moved) == 0 {
+		t.Fatalf("quarantined historical complete-fix event = %q, %v", moved, err)
+	}
+}
+
+func TestRepairHistoricalLegacyAliasLeavesInventoryFailClosedForOtherCorruption(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	_, head, _ := legacyAliasRepairFixture(t, repo, "alias-repair-first")
+	legacyAliasRepairFixture(t, repo, "alias-repair-unhandled", "review/unknown-fix")
+	request := legacyAliasRepairRequest(t, repo, "alias-repair-first", head)
+	if _, err := RepairHistoricalLegacyAlias(context.Background(), repo, request); err != nil {
+		t.Fatal(err)
+	}
+	report, err := InventoryAuthority(context.Background(), repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.Complete || report.Authoritative || !hasAuthorityInventoryStatus(report.Entries, "alias-repair-unhandled", AuthorityStatusInvalid) {
+		t.Fatalf("repair incorrectly made mixed inventory authoritative: %#v", report)
+	}
+}
+
+func TestRepairHistoricalLegacyAliasRefusesOutsideApprovedClass(t *testing.T) {
+	tests := []struct {
+		name    string
+		prepare func(t *testing.T, repo string, store Store, request *LegacyAliasRepairRequest)
+		want    string
+	}{
+		{name: "wrong revision", prepare: func(_ *testing.T, _ string, _ Store, request *LegacyAliasRepairRequest) {
+			request.ExpectedRevision = hash("f")
+		}, want: ErrConcurrentUpdate.Error()},
+		{name: "malformed authorization", prepare: func(_ *testing.T, _ string, _ Store, request *LegacyAliasRepairRequest) {
+			request.MaintainerAuthorization += "\n"
+		}, want: "exact maintainer authorization binding"},
+		{name: "unsupported disposition", prepare: func(_ *testing.T, _ string, _ Store, request *LegacyAliasRepairRequest) {
+			request.Disposition = "delete-history"
+		}, want: "supports only"},
+		{name: "mixed compact authority", prepare: func(t *testing.T, repo string, _ Store, _ *LegacyAliasRepairRequest) {
+			compact, err := CompactAuthoritativeStore(context.Background(), repo, "alias-repair-refusal")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := os.MkdirAll(compact.Dir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+		}, want: "also exists in compact-v2"},
+		{name: "active ownership", prepare: func(t *testing.T, _ string, store Store, _ *LegacyAliasRepairRequest) {
+			lock, err := acquireStoreLock(filepath.Join(store.Dir, "LOCK"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { _ = lock.release() })
+		}, want: "active ownership"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := initSnapshotRepo(t)
+			store, head, _ := legacyAliasRepairFixture(t, repo, "alias-repair-refusal")
+			request := legacyAliasRepairRequest(t, repo, "alias-repair-refusal", head)
+			tt.prepare(t, repo, store, &request)
+			_, err := RepairHistoricalLegacyAlias(context.Background(), repo, request)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("repair error = %v, want %q", err, tt.want)
+			}
+			if _, statErr := os.Stat(store.Dir); statErr != nil {
+				t.Fatalf("refused request moved source: %v", statErr)
+			}
+		})
+	}
+
+	t.Run("unknown alias", func(t *testing.T) {
+		repo := initSnapshotRepo(t)
+		store, head, _ := legacyAliasRepairFixture(t, repo, "alias-repair-unknown", "review/unknown-fix")
+		request := legacyAliasRepairRequest(t, repo, "alias-repair-unknown", head)
+		if _, err := RepairHistoricalLegacyAlias(context.Background(), repo, request); err == nil || !strings.Contains(err.Error(), "unsupported successor anomaly") {
+			t.Fatalf("unknown alias repair error = %v", err)
+		}
+		if _, err := os.Stat(store.Dir); err != nil {
+			t.Fatalf("unknown alias moved source: %v", err)
+		}
+	})
+
+	t.Run("valid chain is a no-op refusal", func(t *testing.T) {
+		repo := initSnapshotRepo(t)
+		store, head, _ := legacyAliasRepairFixture(t, repo, "alias-repair-valid", "review/validate-fix-delta")
+		request := legacyAliasRepairRequest(t, repo, "alias-repair-valid", head)
+		if _, err := RepairHistoricalLegacyAlias(context.Background(), repo, request); err == nil || !strings.Contains(err.Error(), "no approved unsupported") {
+			t.Fatalf("valid chain repair error = %v", err)
+		}
+		if _, err := os.Stat(store.Dir); err != nil {
+			t.Fatalf("valid no-op moved source: %v", err)
+		}
+	})
+}
+
+func TestRepairHistoricalLegacyAliasLeavesPreparedAuditOnPartialFailure(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	store, head, _ := legacyAliasRepairFixture(t, repo, "alias-repair-partial")
+	request := legacyAliasRepairRequest(t, repo, "alias-repair-partial", head)
+	original := reclaimQuarantineResidue
+	reclaimQuarantineResidue = func(_, _ string) error { return errors.New("rename failed") }
+	t.Cleanup(func() { reclaimQuarantineResidue = original })
+
+	record, err := RepairHistoricalLegacyAlias(context.Background(), repo, request)
+	if err == nil || record.Status != CompactReclaimPrepared || record.QuarantinePath == "" {
+		t.Fatalf("partial repair = %#v, %v", record, err)
+	}
+	if _, statErr := os.Stat(store.Dir); statErr != nil {
+		t.Fatalf("partial failure moved source: %v", statErr)
+	}
+}
+
+func TestRepairHistoricalLegacyAliasRespectsSharedMaintenanceLock(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	_, head, _ := legacyAliasRepairFixture(t, repo, "alias-repair-maintenance-lock")
+	lockContext, cancelLock := context.WithTimeout(context.Background(), time.Second)
+	defer cancelLock()
+	lock, err := AcquireReviewMaintenanceExclusive(lockContext, repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer lock.Release()
+	request := legacyAliasRepairRequest(t, repo, "alias-repair-maintenance-lock", head)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
+	if _, err := RepairHistoricalLegacyAlias(ctx, repo, request); !errors.Is(err, ErrAuthorityLockCancelled) {
+		t.Fatalf("maintenance contention error = %v", err)
+	}
+}
+
+func TestRepairHistoricalLegacyAliasUsesCommonAuthorityAcrossWorktrees(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	_, head, _ := legacyAliasRepairFixture(t, repo, "alias-repair-linked-worktree")
+	linked := filepath.Join(t.TempDir(), "linked")
+	gitSnapshot(t, repo, "worktree", "add", "--detach", linked)
+	t.Cleanup(func() { gitSnapshot(t, repo, "worktree", "remove", "--force", linked) })
+	request := legacyAliasRepairRequest(t, linked, "alias-repair-linked-worktree", head)
+	if _, err := RepairHistoricalLegacyAlias(context.Background(), linked, request); err != nil {
+		t.Fatalf("repair through linked worktree: %v", err)
+	}
+	report, err := InventoryAuthority(context.Background(), repo)
+	if err != nil || !report.Complete || !report.Authoritative {
+		t.Fatalf("primary worktree inventory after linked repair = %#v, %v", report, err)
+	}
+}
+
+func TestRepairHistoricalLegacyAliasConcurrentRequestsDoNotCorruptAuthority(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	_, head, _ := legacyAliasRepairFixture(t, repo, "alias-repair-concurrent")
+	request := legacyAliasRepairRequest(t, repo, "alias-repair-concurrent", head)
+	results := make(chan error, 2)
+	start := make(chan struct{})
+	for range 2 {
+		go func() {
+			<-start
+			_, err := RepairHistoricalLegacyAlias(context.Background(), repo, request)
+			results <- err
+		}()
+	}
+	close(start)
+	successes := 0
+	for range 2 {
+		if err := <-results; err == nil {
+			successes++
+		}
+	}
+	if successes == 0 {
+		t.Fatal("concurrent repair did not commit or replay")
+	}
+	report, err := InventoryAuthority(context.Background(), repo)
+	if err != nil || !report.Complete || !report.Authoritative {
+		t.Fatalf("inventory after concurrent repair = %#v, %v", report, err)
+	}
+}


### PR DESCRIPTION
Closes #1439

## Summary

- Add a narrowly scoped `review repair-legacy-alias` maintenance operation for historical v1 aliases that poison complete authority inventory.
- Bind repair to the exact repository, lineage, revision, diagnostic, actor, reason, disposition, and LF-only maintainer authorization.
- Preserve unrelated authority and verify quarantine through semantic replay, maintenance locking, audited persistence, and readback.

## Type

- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Changes

| File | Change |
|------|--------|
| `internal/reviewtransaction/legacy_alias_repair.go` | Implement bounded legacy-alias eligibility, quarantine, audit, idempotency, and readback |
| `internal/reviewtransaction/legacy_alias_repair_test.go` | Cover historical aliases, malformed authority, races, partial failure, locks, and replay |
| `internal/cli/review_legacy_alias_repair.go` | Add the CLI command and exact authorization contract |
| `internal/cli/review_legacy_alias_repair_test.go` | Verify parsing and fail-closed CLI behavior |
| `internal/cli/review_facade.go` | Register the maintenance command |
| `docs/review-authority-threat-model.md` | Document the bounded repair ceremony and refusal boundary |

## Test plan

- [x] `go test ./...`
- [x] `go test -race ./internal/reviewtransaction -run 'TestRepairHistoricalLegacy(Alias|CompleteFixAlias)' -count=1`
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `git diff --check`
- [x] Native High-tier 4R completed under `review-8599c629acfbddf3`
- [x] Scoped correction validation approved

## Contributor checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Tests pass
- [x] Documentation updated for behavior changes
- [x] Conventional commit format
- [x] No AI attribution trailers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `review repair-legacy-alias` for narrowly scoped recovery of approved legacy history issues.
  * Repairs quarantine affected legacy lineage while preserving evidence and recording an audit result.
  * Added strict validation for authorization, revisions, diagnostics, dispositions, and maintenance-lock conditions.
  * Updated `gentle-ai review --help` to include the new command.

* **Documentation**
  * Documented legacy alias quarantine behavior, permitted scenarios, refusal conditions, and outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->