### PR TITLE
feat(opencode): make background-agents timeout configurable

### DIFF
--- a/.codegraph/.gitignore
+++ b/.codegraph/.gitignore
@@ -1,0 +1,5 @@
+# CodeGraph data files — local to each machine, not for committing.
+# Ignore everything in .codegraph/ except this file itself, so transient
+# files (the database, daemon.pid, sockets, logs) never show up in git.
+*
+!.gitignore

--- a/internal/components/sdd/profiles.go
+++ b/internal/components/sdd/profiles.go
@@ -361,18 +361,19 @@ func GenerateProfileOverlay(profile model.Profile, homeDir string, fallbackPhase
 	for _, phase := range profilePhaseOrder {
 		key := phase + suffix
 		prompt := "{file:" + filepath.ToSlash(filepath.Join(promptDir, phase+".md")) + "}"
-		entry := map[string]any{
-			"mode":        "subagent",
-			"hidden":      true,
-			"description": phaseDescriptions[phase],
-			"prompt":      prompt,
-			"tools": map[string]any{
-				"read":  true,
-				"write": true,
-				"edit":  true,
-				"bash":  true,
-			},
-		}
+					entry := map[string]any{
+						"mode":        "subagent",
+						"hidden":      true,
+						"description": phaseDescriptions[phase],
+						"prompt":      prompt,
+						"tools": map[string]any{
+							"read":  true,
+							"write": true,
+							"edit":  true,
+							"bash":  true,
+						},
+						"timeout": 300,
+					}
 		// Issue #557: consult fallback when the profile did not set the phase,
 		// so generated *-{name} agents stay consistent with what the user sees
 		// in the gentle-ai TUI. Profile-level assignments still win.


### PR DESCRIPTION
Closes #416

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a 300-second timeout to generated SDD sub-agent profiles, helping limit how long each agent can run.

* **Chores**
  * Prevented machine-local CodeGraph data from being included in version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
Recommended Label: **type:feature** (to be added by maintainer)