### PR TITLE
fix(pi): expose Engram tools to Pi SDD subagents

### DIFF
--- a/internal/components/sdd/profiles.go
+++ b/internal/components/sdd/profiles.go
@@ -366,12 +366,13 @@ func GenerateProfileOverlay(profile model.Profile, homeDir string, fallbackPhase
 			"hidden":      true,
 			"description": phaseDescriptions[phase],
 			"prompt":      prompt,
-			"tools": map[string]any{
-				"read":  true,
-				"write": true,
-				"edit":  true,
-				"bash":  true,
-			},
+							"tools": map[string]any{
+								"read":  true,
+								"write": true,
+								"edit":  true,
+								"bash":  true,
+								"mcp":   true,
+							},
 		}
 		// Issue #557: consult fallback when the profile did not set the phase,
 		// so generated *-{name} agents stay consistent with what the user sees

--- a/internal/components/sdd/profiles.go
+++ b/internal/components/sdd/profiles.go
@@ -366,13 +366,13 @@ func GenerateProfileOverlay(profile model.Profile, homeDir string, fallbackPhase
 			"hidden":      true,
 			"description": phaseDescriptions[phase],
 			"prompt":      prompt,
-							"tools": map[string]any{
-								"read":  true,
-								"write": true,
-								"edit":  true,
-								"bash":  true,
-								"mcp":   true,
-							},
+			"tools": map[string]any{
+				"read":  true,
+				"write": true,
+				"edit":  true,
+				"bash":  true,
+				"mcp":   true,
+			},
 		}
 		// Issue #557: consult fallback when the profile did not set the phase,
 		// so generated *-{name} agents stay consistent with what the user sees


### PR DESCRIPTION
Closes #602

---
Recommended Label: **type:bug** (to be added by maintainer)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sub-agent profile overlays now allow MCP tool usage in addition to the existing read, write, edit, and bash capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->