### PR TITLE
test(review): stabilize legacy alias lock timing

### DIFF
--- a/internal/reviewtransaction/legacy_alias_repair_test.go
+++ b/internal/reviewtransaction/legacy_alias_repair_test.go
@@ -258,7 +258,7 @@ func TestRepairHistoricalLegacyAliasRespectsSharedMaintenanceLock(t *testing.T) 
 	}
 	defer lock.Release()
 	request := legacyAliasRepairRequest(t, repo, "alias-repair-maintenance-lock", head)
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 	if _, err := RepairHistoricalLegacyAlias(ctx, repo, request); !errors.Is(err, ErrAuthorityLockCancelled) {
 		t.Fatalf("maintenance contention error = %v", err)


### PR DESCRIPTION
Closes #1512

## Summary

- Keep the shared-maintenance-lock contention assertion bounded below the production two-second lock timeout.
- Give Windows enough time to complete prerequisite Git common-directory resolution before the contention deadline expires.
- Preserve the exact `ErrAuthorityLockCancelled` behavior assertion.

## Type

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [x] Maintenance/tooling
- [ ] Breaking change

## Changes

| File | Change |
|------|--------|
| `internal/reviewtransaction/legacy_alias_repair_test.go` | Increase only the contention-test context from 30 ms to 1 second |

## Test plan

- [x] Focused contention test passed 20 times
- [x] `go test ./...`
- [x] Focused race test passed three times
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] Native reliability review approved under `review-df89a9887b1eddb1`

## Contributor checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Tests pass
- [x] No production behavior changed
- [x] Conventional commit format
- [x] No AI attribution trailers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by allowing more time to acquire the shared maintenance lock during legacy alias repair validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->