### PR TITLE
fix(review): stop stale lineages capturing unrelated candidates

### DIFF
--- a/internal/reviewtransaction/compact_scope_recovery_test.go
+++ b/internal/reviewtransaction/compact_scope_recovery_test.go
@@ -270,6 +270,100 @@ func TestCompactRecoveryContractsGenesisPaths(t *testing.T) {
 	}
 }
 
+// TestCompactRecoveryAddsGenesisPath pins the boundary between a genuine scope
+// expansion of the frozen work and an entirely unrelated candidate. Expansion
+// means the live scope still overlaps genesis and reaches past it. A live scope
+// disjoint from genesis is not an expansion of that lineage at all: it is
+// different work that happens to share a base tree, which is the ordinary case
+// for two Git worktrees of the same repository. Treating it as expansion let a
+// stale correction_required lineage capture an unrelated candidate, because the
+// very first live path already sits outside genesis.
+func TestCompactRecoveryAddsGenesisPath(t *testing.T) {
+	predecessor := CompactState{GenesisPaths: []string{"a.go", "b.go", "c.go"}}
+	tests := []struct {
+		name string
+		live []string
+		want bool
+	}{
+		{name: "superset", live: []string{"a.go", "b.go", "c.go", "d.go"}, want: true},
+		{name: "overlap reaching outside genesis", live: []string{"a.go", "x.go"}, want: true},
+		{name: "disjoint paths", live: []string{"x.go", "y.go"}, want: false},
+		{name: "equal set", live: []string{"a.go", "b.go", "c.go"}, want: false},
+		{name: "strict subset", live: []string{"a.go", "c.go"}, want: false},
+		{name: "empty live diff", live: []string{}, want: false},
+		{name: "non-canonical live paths", live: []string{"x.go", "a.go"}, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := compactRecoveryAddsGenesisPath(predecessor, Snapshot{Paths: tt.live}); got != tt.want {
+				t.Fatalf("compactRecoveryAddsGenesisPath(%v) = %v, want %v", tt.live, got, tt.want)
+			}
+		})
+	}
+	if compactRecoveryAddsGenesisPath(CompactState{GenesisPaths: []string{"b.go", "a.go"}}, Snapshot{Paths: []string{"a.go", "x.go"}}) {
+		t.Fatal("non-canonical genesis paths must not qualify as expansion")
+	}
+	if compactRecoveryAddsGenesisPath(CompactState{}, Snapshot{Paths: []string{"x.go"}}) {
+		t.Fatal("empty genesis scope must not be expanded by an unrelated candidate")
+	}
+}
+
+// TestCorrectionRequiredLineageDoesNotCaptureDisjointCandidate reproduces the
+// incident that motivated the retention rule. A stale correction_required
+// lineage frozen over tracked.txt must not capture a candidate that touches an
+// entirely different file, even though both share a base tree and projection.
+// That sharing is unavoidable in practice: Git worktrees of one repository
+// share the review store under the common dir, so a store holding several stuck
+// lineages would otherwise bind whichever one enumerated first to unrelated
+// work, and report that lineage's frozen scope as if it were the caller's.
+func TestCorrectionRequiredLineageDoesNotCaptureDisjointCandidate(t *testing.T) {
+	repo, predecessor, _, _ := correctionScopeRecoveryFixture(t, "review-correction-disjoint")
+
+	// Retire the frozen scope from the live diff and introduce unrelated work,
+	// leaving live paths disjoint from genesis rather than wider than it.
+	writeSnapshotFile(t, repo, "tracked.txt", "base\n")
+	writeSnapshotFile(t, repo, "unrelated.go", "package unrelated\n")
+	target := Target{Kind: TargetCurrentChanges, IntendedUntracked: []string{"unrelated.go"}}
+
+	requested := newCompactStartStateForTarget(t, repo, "review-correction-disjoint-new", target)
+	if got := requested.InitialSnapshot.Paths; len(got) != 1 || got[0] != "unrelated.go" {
+		t.Fatalf("candidate paths = %v, want exactly [unrelated.go]", got)
+	}
+	// The shared-store gates the classifier applies before scope must still
+	// pass, otherwise this would prove nothing about the retention rule.
+	if requested.InitialSnapshot.BaseTree != predecessor.InitialSnapshot.BaseTree {
+		t.Fatalf("fixture no longer shares a base tree with the predecessor")
+	}
+
+	started, err := StartCompactAuthority(context.Background(), repo, CompactStartRequest{State: requested})
+	if err != nil {
+		t.Fatalf("StartCompactAuthority() error = %v", err)
+	}
+	if started.Action != CompactStartCreated {
+		t.Fatalf("disjoint candidate start action = %q, want %q", started.Action, CompactStartCreated)
+	}
+	if started.Record.State.LineageID != requested.LineageID {
+		t.Fatalf("start bound lineage %q, want the caller's %q", started.Record.State.LineageID, requested.LineageID)
+	}
+	if got := started.Record.State.InitialSnapshot.Identity; got != requested.InitialSnapshot.Identity {
+		t.Fatalf("start reported target identity %q, want the caller's %q", got, requested.InitialSnapshot.Identity)
+	}
+
+	// The predecessor keeps its own authority: it is neither advanced nor
+	// consumed by unrelated work starting alongside it.
+	predecessorStore, err := CompactAuthoritativeStore(context.Background(), repo, predecessor.LineageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	after, err := predecessorStore.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after.State.State != StateCorrectionRequired || after.State.Generation != predecessor.Generation {
+		t.Fatalf("predecessor authority changed: state=%q generation=%d", after.State.State, after.State.Generation)
+	}
+}
+
 func recoveryAuthorizationFixture(request CompactRecoveryRequest) string {
 	return "gentle-ai.review-recovery-authorization/v1\npredecessor_lineage=" + request.PredecessorLineageID +
 		"\npredecessor_revision=" + request.ExpectedPredecessorRevision + "\ntarget_identity=" + request.Successor.InitialSnapshot.Identity +

--- a/internal/reviewtransaction/compact_store.go
+++ b/internal/reviewtransaction/compact_store.go
@@ -420,12 +420,22 @@ func compactRecoveryAddsGenesisPath(predecessor CompactState, live Snapshot) boo
 	for _, path := range genesis {
 		known[path] = struct{}{}
 	}
+	retained := false
+	reaches := false
 	for _, path := range paths {
-		if _, exists := known[path]; !exists {
-			return true
+		if _, exists := known[path]; exists {
+			retained = true
+			continue
 		}
+		reaches = true
 	}
-	return false
+	// An expansion must still be the frozen work: it retains at least one
+	// genesis path and reaches past the set. A live scope disjoint from genesis
+	// is unrelated work, not a wider view of this lineage, so it must not be
+	// admitted here. Worktrees of one repository share the review store and a
+	// base tree, so without the retention test an unrelated candidate would be
+	// captured by whichever stale lineage happened to be enumerated first.
+	return retained && reaches
 }
 
 // compactRecoveryContractsGenesisPaths reports whether the live repository


### PR DESCRIPTION
Closes #1536

## PR Type

- [x] Bug fix

## Summary

- An expansion of a frozen review scope must now retain at least one genesis path, not merely reach past the set.
- A candidate whose paths are disjoint from genesis is no longer classified as a recovery of that lineage, so `review start` freezes the caller's own candidate.
- Adds the disjoint-scope coverage that was missing at both the predicate and store level.

## Root cause

`compactRecoveryAddsGenesisPath` returned true as soon as any live path was absent from the frozen genesis set. For a disjoint candidate the very first path satisfied it, so unrelated work was classified `compactCorrectionTargetRecover`. The `pathsAreSubset` guard that would have rejected it sits after the expansion test and was unreachable for disjoint sets.

Git worktrees share the git common dir, therefore the review store, and freeze the same base tree. Every gate applied before scope passes between worktrees, so a fresh candidate bound to whichever stuck `correction_required` lineage enumerated first and reported that lineage's frozen paths, identity and risk as the caller's.

`internal/reviewtransaction/target_status.go:204` calls `classifyCompactCorrectionTarget` rather than duplicating it, so `review status` inherits the fix.

## Changes

| File | Change |
|------|--------|
| `internal/reviewtransaction/compact_store.go` | An expansion must retain a genesis path as well as reach past the set |
| `internal/reviewtransaction/compact_scope_recovery_test.go` | Predicate table for expansion, plus a store-level reproduction of the incident |

## Test Plan

- [x] `TestCorrectionRequiredLineageDoesNotCaptureDisjointCandidate` verified to fail without the fix (`action = "recover"` instead of `"created"`) by temporarily reverting the predicate
- [x] Existing recovery tests still pass, including legitimate expansion and contraction
- [x] `gofmt`, `go build ./...`, `go vet ./internal/...`, `go test ./...` all green

## Contributor Checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Docs updated if behavior changed
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compact recovery validation to distinguish legitimate path expansion from unrelated or disjoint candidates.
  * Prevented correction-required recovery state from being incorrectly advanced or consumed when candidate paths do not match the predecessor scope.
  * Preserved recovery lineage and identity accurately during compact authority transitions.

* **Tests**
  * Added coverage for genesis-path expansion boundaries, non-canonical ordering, empty scopes, and disjoint recovery candidates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->