### PR TITLE
chore(codex): raise preset orchestrator effort to medium

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -144,7 +144,7 @@ Kiro uses native custom agents in `~/.kiro/agents/`. `gentle-ai` writes phase ag
 - MCP servers (Engram and Context7) are upserted as `[mcp_servers.<name>]` blocks in `~/.codex/config.toml`
 - SDD model-selection profiles written as separate files at `~/.codex/<name>.config.toml`. GPT-5.6 defaults require Codex >= 0.144.0 (the separate-file mechanism itself is available since 0.134.0). Select a profile at runtime via `codex --profile <name>`:
 
-  Model and effort defaults vary together by preset. These effort levels are Gentle AI workload policy, not Codex defaults. Every curated preset also assigns the main orchestrator/session to `gpt-5.6-sol` / `low`; Custom and legacy state preserve existing top-level settings:
+  Model and effort defaults vary together by preset. These effort levels are Gentle AI workload policy, not Codex defaults. Every curated preset also assigns the main orchestrator/session to `gpt-5.6-sol` / `medium`; Custom and legacy state preserve existing top-level settings:
 
   | Profile | Low-cost | Recommended | Powerful | SDD phases |
   |---------|----------|-------------|----------|------------|

--- a/internal/components/engram/inject_test.go
+++ b/internal/components/engram/inject_test.go
@@ -2261,7 +2261,7 @@ func TestInjectCodexOrchestratorAssignmentWritesTopLevelModel(t *testing.T) {
 		t.Fatal(err)
 	}
 	text := string(content)
-	if !strings.Contains(text, `model = "gpt-5.6-sol"`) || !strings.Contains(text, `model_reasoning_effort = "low"`) {
+	if !strings.Contains(text, `model = "gpt-5.6-sol"`) || !strings.Contains(text, `model_reasoning_effort = "medium"`) {
 		t.Fatalf("top-level orchestrator assignment missing:\n%s", text)
 	}
 }

--- a/internal/model/codex_model.go
+++ b/internal/model/codex_model.go
@@ -106,13 +106,17 @@ type CodexOrchestratorAssignment struct {
 }
 
 // CodexPresetOrchestratorAssignment returns the main-session policy for a
-// named preset. All curated presets keep orchestration responsive at low effort.
-// Unknown keys intentionally fall back to Recommended.
+// named preset. All curated presets share one orchestration policy: the
+// main session runs at medium effort. The orchestrator plans, routes and
+// adjudicates rather than doing the delegated work, so low effort made it
+// the weakest link in the chain; medium keeps it responsive while giving it
+// enough reasoning to route correctly. Unknown keys intentionally fall back
+// to Recommended.
 func CodexPresetOrchestratorAssignment(preset string) *CodexOrchestratorAssignment {
 	if _, ok := codexPresetMatrix[CodexPresetKey(preset)]; !ok {
 		preset = string(CodexPresetRecommended)
 	}
-	return &CodexOrchestratorAssignment{Model: "gpt-5.6-sol", Effort: CodexEffortLow}
+	return &CodexOrchestratorAssignment{Model: "gpt-5.6-sol", Effort: CodexEffortMedium}
 }
 
 // CodexPresetCarrilDefaults returns a defensive copy of the selected preset's

--- a/internal/model/codex_model_test.go
+++ b/internal/model/codex_model_test.go
@@ -617,11 +617,11 @@ func checkCarrilRowModel(t *testing.T, table string, profile string, wantModel s
 	}
 }
 
-func TestCodexPresetOrchestratorAssignment_AllPresetsUseSolLow(t *testing.T) {
+func TestCodexPresetOrchestratorAssignment_AllPresetsUseSolMedium(t *testing.T) {
 	for _, preset := range []model.CodexPresetKey{model.CodexPresetLowCost, model.CodexPresetRecommended, model.CodexPresetPowerful} {
 		a := model.CodexPresetOrchestratorAssignment(string(preset))
-		if a.Model != "gpt-5.6-sol" || a.Effort != model.CodexEffortLow {
-			t.Errorf("preset %q orchestrator = %s/%s, want gpt-5.6-sol/low", preset, a.Model, a.Effort)
+		if a.Model != "gpt-5.6-sol" || a.Effort != model.CodexEffortMedium {
+			t.Errorf("preset %q orchestrator = %s/%s, want gpt-5.6-sol/medium", preset, a.Model, a.Effort)
 		}
 	}
 }

--- a/internal/tui/screens/codex_model_picker.go
+++ b/internal/tui/screens/codex_model_picker.go
@@ -544,7 +544,7 @@ func codexModelSearchDisplay(query string) string {
 // Labels are self-describing: they include the model id and effort tier per
 // carril so the user can see what will be written to profile files.
 //
-// All presets also set the main orchestrator to gpt-5.6-sol/low.
+// All presets also set the main orchestrator to gpt-5.6-sol/medium.
 // Format: "<Plan> — Orquestador <model>/<effort> · Razonamiento <model>/<effort> · Código <model>/<effort> · Liviano <model>/<effort>"
 func CodexPresetLabel(preset CodexModelPreset) string {
 	defaults := model.CodexPresetCarrilDefaults(string(preset))


### PR DESCRIPTION
Closes #1537

## PR Type

- [x] Maintenance/tooling

## Summary

- All three curated Codex presets now assign the main orchestrator session `gpt-5.6-sol` / `medium` instead of `low`.
- Per-carril defaults are unchanged, including `sdd-cheap` at `luna` / `low`.
- Custom and legacy state continue to preserve existing top-level settings.

## Rationale

The orchestrator plans, routes and adjudicates rather than doing the delegated work. At `low` it reasoned below every carril it delegates to, making it the weakest link in the chain. Medium keeps the main session responsive while giving it enough reasoning to route correctly.

## Changes

| File | Change |
|------|--------|
| `internal/model/codex_model.go` | `CodexEffortLow` to `CodexEffortMedium`, with the rationale in the doc comment |
| `internal/model/codex_model_test.go` | Policy assertion renamed and updated |
| `internal/components/engram/inject_test.go` | Emitted `model_reasoning_effort` assertion updated |
| `internal/tui/screens/codex_model_picker.go` | Comment |
| `docs/agents.md` | Documented preset table note |

`CodexPresetLabel` reads the effort from `CodexPresetOrchestratorAssignment` rather than hardcoding it, so the picker label follows automatically.

Seeded persisted-state fixtures in `internal/app/app_test.go` and `internal/cli/sync_test.go` intentionally keep `"low"`: they exercise clear/preserve round-trips, and `low` remains a valid persisted user value rather than an assertion about preset policy.

## Test Plan

- [x] `gofmt`, `go build ./...`, `go vet ./internal/...`, `go test ./...` all green
- [x] No golden files affected

## Contributor Checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Docs updated if behavior changed
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updated Behavior**
  * Curated Codex presets now use medium reasoning effort for the main orchestrator.
  * The orchestrator continues to use the `gpt-5.6-sol` model across Low Cost, Recommended, and Powerful presets.
  * Existing custom and legacy settings remain unchanged.
* **Documentation**
  * Updated preset descriptions and labels to reflect the medium-effort orchestration setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->