### PR TITLE
fix(review): block same-scope changed targets from bypassing recovery provenance

### DIFF
--- a/internal/reviewtransaction/compact_store.go
+++ b/internal/reviewtransaction/compact_store.go
@@ -669,6 +669,14 @@ func StartCompactAuthority(ctx context.Context, repo string, request CompactStar
 		if compactStartClaimsTarget(ctx, requestedStore.repo, existing, request.State) {
 			claimants = append(claimants, store)
 			requestedClaims = requestedClaims || store.lineageID == request.State.LineageID
+			continue
+		}
+		// If an approved leaf has matching delivery scope but a changed candidate tree,
+		// it requires explicit predecessor-bound recovery — block creation.
+		if existing.State == StateApproved && compactStartDeliveryScopeMatches(existing, request.State) &&
+			request.State.InitialSnapshot.CandidateTree != existing.InitialSnapshot.CandidateTree &&
+			request.State.InitialSnapshot.CandidateTree != existing.CurrentSnapshot.CandidateTree {
+			return CompactStartResult{Record: records[store.lineageID], Action: CompactStartBlocked}, nil
 		}
 	}
 	if len(recoveryCandidates) > 0 {

--- a/internal/reviewtransaction/compact_store_test.go
+++ b/internal/reviewtransaction/compact_store_test.go
@@ -2264,3 +2264,60 @@ func newCompactRevisionState(t *testing.T, repo, lineage string) CompactState {
 	}
 	return state
 }
+
+func TestStartCompactAuthorityBlocksSameScopeChangedCandidateWithoutRecovery(t *testing.T) {
+	repo := initSnapshotRepo(t)
+
+	// Create base files
+	writeSnapshotFile(t, repo, "path_1.txt", "one\n")
+	writeSnapshotFile(t, repo, "path_2.txt", "two\n")
+	writeSnapshotFile(t, repo, "path_3.txt", "three\n")
+	writeSnapshotFile(t, repo, "path_4.txt", "four\n")
+	gitSnapshot(t, repo, "add", ".")
+	gitSnapshot(t, repo, "commit", "-m", "base")
+
+	// Change all files to create an approved leaf with 4-path scope
+	writeSnapshotFile(t, repo, "path_1.txt", "one-changed\n")
+	writeSnapshotFile(t, repo, "path_2.txt", "two-changed\n")
+	writeSnapshotFile(t, repo, "path_3.txt", "three-changed\n")
+	writeSnapshotFile(t, repo, "path_4.txt", "four-changed\n")
+
+	// Create an approved leaf
+	approved, _, _ := approvedCompactCurrentChangesFixture(t, repo, "compact-start-approved-same-scope", []string{})
+
+	// Change content in 2 of those 4 paths (same paths, different candidate tree)
+	writeSnapshotFile(t, repo, "path_1.txt", "one-changed-again\n")
+	writeSnapshotFile(t, repo, "path_2.txt", "two-changed-again\n")
+
+	requested := newCompactTestState(t, repo, "compact-start-requested")
+
+	result, err := StartCompactAuthority(context.Background(), repo, CompactStartRequest{State: requested})
+	if err != nil || result.Action != CompactStartBlocked || result.Record.State.LineageID != approved.LineageID {
+		t.Fatalf("start same scope changed candidate = %#v, %v", result, err)
+	}
+}
+
+func TestStartCompactAuthorityCreatesUnrelatedTargetWithChangedPaths(t *testing.T) {
+	repo := initSnapshotRepo(t)
+
+	// Create base files
+	writeSnapshotFile(t, repo, "path_1.txt", "one\n")
+	writeSnapshotFile(t, repo, "path_2.txt", "two\n")
+	gitSnapshot(t, repo, "add", ".")
+	gitSnapshot(t, repo, "commit", "-m", "base")
+
+	// Change path_1.txt to create an approved leaf with 1-path scope
+	writeSnapshotFile(t, repo, "path_1.txt", "one-changed\n")
+	approvedCompactCurrentChangesFixture(t, repo, "compact-start-approved-path1", []string{})
+
+	// Revert path_1.txt and change path_2.txt instead (completely different path scope)
+	writeSnapshotFile(t, repo, "path_1.txt", "one\n")
+	writeSnapshotFile(t, repo, "path_2.txt", "two-changed\n")
+
+	requested := newCompactTestState(t, repo, "compact-start-requested-path2")
+
+	result, err := StartCompactAuthority(context.Background(), repo, CompactStartRequest{State: requested})
+	if err != nil || result.Action != CompactStartCreated {
+		t.Fatalf("start unrelated target = %#v, %v", result, err)
+	}
+}


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1476

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

Regression of the predecessor-bound scope-transition contract from #1239/#1245. When an approved leaf existed with the same delivery scope (same base, paths, projection) but a changed candidate tree, implicit `review start` reached the create branch and opened a fresh independent authority with no recovery provenance. The new authority could later pass gates without ever going through `review recover`.

The fix adds a pre-create check in `StartCompactAuthority`: if any approved leaf has matching delivery scope but a different candidate tree, return `CompactStartBlocked` before the create path is reached. Truly unrelated targets (different paths or projection) still result in `CompactStartCreated` as intended by #1255/#1258.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/reviewtransaction/compact_store.go` | Added same-scope changed-candidate detection before the create branch in `StartCompactAuthority` |
| `internal/reviewtransaction/compact_store_test.go` | Added `TestStartCompactAuthorityBlocksSameScopeChangedCandidateWithoutRecovery` and test confirming unrelated targets still create |

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./internal/reviewtransaction/...
```

**Go Format**
```bash
go run ./internal/gofmtcheck
```

- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Manually tested locally

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines (65 total)
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

The check fires only when delivery scope matches (`compactStartDeliveryScopeMatches`) but the candidate tree differs. The `StateApproved` leaf must exist as a leaf (no successor). If there is no approved leaf, or the candidate is identical, or the paths differ, the existing create path runs as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented compact operations from starting when an approved authority’s candidate content has changed within the same delivery scope.
  * Ensured changes to unrelated paths can correctly create a new compact target instead of resuming an existing authority.

* **Tests**
  * Added coverage for same-scope candidate changes and unrelated path changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->