### PR TITLE
fix(engram): support remote engram host via ENGRAM_BASE_URL env var

### DIFF
--- a/internal/components/engram/verify.go
+++ b/internal/components/engram/verify.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"os"
 	"os/exec"
 	"strings"
 	"time"
@@ -102,6 +103,9 @@ func CountVersionCallsForTest(t interface {
 }
 
 func VerifyHealth(ctx context.Context, baseURL string) error {
+	if strings.TrimSpace(baseURL) == "" {
+		baseURL = os.Getenv("ENGRAM_BASE_URL")
+	}
 	if strings.TrimSpace(baseURL) == "" {
 		baseURL = "http://127.0.0.1:7437"
 	}

--- a/internal/components/engram/verify_test.go
+++ b/internal/components/engram/verify_test.go
@@ -44,6 +44,19 @@ func TestVerifyHealth(t *testing.T) {
 	}
 }
 
+func TestVerifyHealthEnvVar(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	t.Setenv("ENGRAM_BASE_URL", server.URL)
+
+	if err := VerifyHealth(context.Background(), ""); err != nil {
+		t.Fatalf("VerifyHealth() with ENGRAM_BASE_URL error = %v", err)
+	}
+}
+
 func TestVerifyVersionCommandUsesTimeoutAndProvidedBinary(t *testing.T) {
 	original := runVersionCommand
 	t.Cleanup(func() { runVersionCommand = original })


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #315

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

Currently, `VerifyHealth()` in `internal/components/engram/verify.go` hardcodes `http://127.0.0.1:7437` when the passed `baseURL` parameter is empty. This prevents using gentle-ai in environments where engram runs on a remote host (e.g. inside a shared Kubernetes service in coder-workspaces).

This PR adds support for reading the `ENGRAM_BASE_URL` environment variable if the passed `baseURL` parameter is empty, mirroring the behavior already present in `doctor.go`. If that variable is also empty, it falls back to the hardcoded localhost address as before.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/components/engram/verify.go` | Added `ENGRAM_BASE_URL` env var check inside `VerifyHealth` when `baseURL` is empty. |
| `internal/components/engram/verify_test.go` | Added `TestVerifyHealthEnvVar` to verify that `VerifyHealth` successfully resolves the server URL from the environment variable. |

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./internal/components/engram/... -v
```

- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Manually tested locally

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines (17 total)
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] My commits do not include `Co-Authored-By` trailers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Health verification can now use the `ENGRAM_BASE_URL` environment setting when no URL is provided.
  * If the setting is unavailable, the existing local default remains in effect.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->