### PR TITLE
fix(review): reject relative maintenance lock paths

### DIFF
--- a/internal/reviewtransaction/maintenance_lock_test.go
+++ b/internal/reviewtransaction/maintenance_lock_test.go
@@ -75,7 +75,11 @@ func TestEnsureMaintenanceLockPathRejectsRelativePathWithoutHanging(t *testing.T
 }
 
 func TestEnsureMaintenanceLockPathAcceptsCanonicalAbsolutePath(t *testing.T) {
-	dir := filepath.Join(t.TempDir(), "gentle-ai", "review-transactions")
+	tempDir, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatalf("resolve temporary directory symlinks: %v", err)
+	}
+	dir := filepath.Join(tempDir, "gentle-ai", "review-transactions")
 	path := filepath.Clean(filepath.Join(dir, "MAINTENANCE.lock"))
 	if err := ensureMaintenanceLockPath(path); err != nil {
 		t.Fatalf("canonical absolute maintenance lock path: %v", err)

--- a/internal/reviewtransaction/maintenance_lock_test.go
+++ b/internal/reviewtransaction/maintenance_lock_test.go
@@ -52,6 +52,39 @@ func TestMaintenanceLockModesAndRelease(t *testing.T) {
 	}
 }
 
+func TestEnsureMaintenanceLockPathRejectsRelativePathWithoutHanging(t *testing.T) {
+	if os.Getenv("GENTLE_AI_RELATIVE_MAINTENANCE_PATH_HELPER") == "1" {
+		if err := ensureMaintenanceLockPath(filepath.Join("relative", "MAINTENANCE.lock")); err == nil {
+			t.Fatal("relative maintenance lock path was accepted")
+		}
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	command := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestEnsureMaintenanceLockPathRejectsRelativePathWithoutHanging$")
+	command.Dir = t.TempDir()
+	command.Env = append(os.Environ(), "GENTLE_AI_RELATIVE_MAINTENANCE_PATH_HELPER=1")
+	output, err := command.CombinedOutput()
+	if ctx.Err() != nil {
+		t.Fatalf("relative maintenance lock path validation did not return: %v", ctx.Err())
+	}
+	if err != nil {
+		t.Fatalf("relative maintenance lock path helper: %v\n%s", err, output)
+	}
+}
+
+func TestEnsureMaintenanceLockPathAcceptsCanonicalAbsolutePath(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "gentle-ai", "review-transactions")
+	path := filepath.Clean(filepath.Join(dir, "MAINTENANCE.lock"))
+	if err := ensureMaintenanceLockPath(path); err != nil {
+		t.Fatalf("canonical absolute maintenance lock path: %v", err)
+	}
+	if info, err := os.Stat(dir); err != nil || !info.IsDir() {
+		t.Fatalf("maintenance lock directory = %v, %v", info, err)
+	}
+}
+
 func TestMaintenanceLockRejectsSymlinksAndStaleBytesAreNotOwnership(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "gentle-ai", "review-transactions", "MAINTENANCE.lock")

--- a/internal/reviewtransaction/store_lock.go
+++ b/internal/reviewtransaction/store_lock.go
@@ -38,8 +38,10 @@ type storeLock struct {
 	maintenance *MaintenanceLock
 }
 
-// MaintenanceLock is an advisory exclusive authority-maintenance lease.
-// Callers must supply a bounded context and always Release the lease.
+// MaintenanceLock is an advisory authority-maintenance lease. Review operations
+// acquire shared leases, while approved maintenance tools acquire exclusive leases.
+// Acquisition without a context deadline is bounded by maintenanceLockTimeout.
+// Callers must always Release the lease.
 type MaintenanceLock struct{ lock *storeLock }
 
 func (lock *MaintenanceLock) Release() error {
@@ -206,6 +208,9 @@ func AcquireReviewMaintenanceExclusive(ctx context.Context, repo string) (*Maint
 }
 
 func ensureMaintenanceLockPath(path string) error {
+	if !filepath.IsAbs(path) {
+		return errors.New("maintenance lock path must be absolute")
+	}
 	root := filepath.Dir(path)
 	for current := root; ; current = filepath.Dir(current) {
 		info, err := os.Lstat(current)


### PR DESCRIPTION
## Linked Issue

Closes #1475

---

## PR Type

What kind of change does this PR introduce?

- [x] `type:bug` - Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` - New feature (non-breaking change that adds functionality)
- [ ] `type:docs` - Documentation only
- [ ] `type:refactor` - Code refactoring (no functional changes)
- [ ] `type:chore` - Build, CI, or tooling changes
- [ ] `type:breaking-change` - Breaking change (fix or feature that changes existing behavior)

---

## Summary

- Reject relative maintenance-lock paths before directory traversal, preventing non-terminating parent traversal on platforms where a relative path reaches `.`.
- Correct the lease semantics documentation: reviews use shared leases, maintenance uses exclusive leases, and acquisition without a caller deadline is internally bounded.
- Add focused subprocess regression coverage for relative-path rejection and canonical absolute-path acceptance.

---

## Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/reviewtransaction/store_lock.go` | Add the absolute-path guard and correct maintenance lease semantics documentation. |
| `internal/reviewtransaction/maintenance_lock_test.go` | Cover relative-path rejection without hanging and canonical absolute-path acceptance. |

---

## Test Plan

**Unit Tests**
```bash
go test ./...
```

**Focused Regression Tests**
```bash
go test ./internal/reviewtransaction -run 'TestEnsureMaintenanceLockPath(RejectsRelativePathWithoutHanging|AcceptsCanonicalAbsolutePath)$' -count=1 -v
```

**Go Format**
```bash
go run ./internal/gofmtcheck
```

**E2E Tests** (Docker required)
```bash
cd e2e && ./docker-test.sh
```

- [ ] Unit tests pass (`go test ./...`) - not run; the full package is known to have unrelated Windows fixture failures.
- [x] Focused regression tests pass (`go test ./internal/reviewtransaction -run ... -count=1 -v`).
- [x] Go format passes (`go run ./internal/gofmtcheck`).
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) - not run; this bounded Go path-validation fix does not require the Docker harness.
- [ ] Manually tested locally

Runtime harness: N/A beyond the focused Go subprocess regression, which directly proves the previous hanging boundary returns within its timeout.

---

## Automated Checks

The following checks run automatically on this PR:

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | Pending | PR should stay within 400 changed lines (`additions + deletions`) or use `size:exception` |
| Check Issue Reference | Pending | PR body must contain `Closes/Fixes/Resolves #N` |
| Check Issue Has `status:approved` | Pending | Linked issue must have been approved before work began |
| Check PR Has `type:*` Label | Pending | Exactly one `type:*` label must be applied |
| Unit Tests | Pending | `go test ./...` must pass |
| Go Format | Pending | `go run ./internal/gofmtcheck` must pass |
| E2E Tests | Pending | `cd e2e && ./docker-test.sh` must pass |

---

## Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [ ] I have added the appropriate `type:*` label to this PR
- [ ] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] My commits do not include `Co-Authored-By` trailers

---

## Notes for Reviewers

The reviewed scope is 42 changed lines, below the 400-line cognitive-load threshold. No runtime harness applies beyond the focused Go subprocess regression.

Rollback boundary: revert commit `e9dd279c0bdd6d540cab22dc9b1c545e42456336`; this affects only `internal/reviewtransaction/store_lock.go` and `internal/reviewtransaction/maintenance_lock_test.go`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Maintenance lock paths must now be absolute, preventing invalid configurations from causing hangs.
  - Lock acquisition behavior and timeout expectations are now clearly documented.
  - Canonical lock paths are validated and created reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->