### PR TITLE
fix(review): reject relative maintenance lock paths

### DIFF
--- a/internal/reviewtransaction/maintenance_lock_test.go
+++ b/internal/reviewtransaction/maintenance_lock_test.go
@@ -79,6 +79,30 @@ func TestMaintenanceLockRejectsSymlinksAndStaleBytesAreNotOwnership(t *testing.T
 	}
 }
 
+func TestEnsureMaintenanceLockPathRejectsRelativePaths(t *testing.T) {
+	for _, path := range []string{
+		"MAINTENANCE.lock",
+		"review-transactions/MAINTENANCE.lock",
+		"./review-transactions/MAINTENANCE.lock",
+	} {
+		t.Run(path, func(t *testing.T) {
+			if err := ensureMaintenanceLockPath(path); err == nil {
+				t.Fatal("relative maintenance lock path was accepted")
+			}
+		})
+	}
+}
+
+func TestEnsureMaintenanceLockPathAcceptsCanonicalAbsolutePath(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "gentle-ai", "REVIEW-MAINTENANCE.lock")
+	if err := ensureMaintenanceLockPath(path); err != nil {
+		t.Fatalf("canonical absolute maintenance lock path was rejected: %v", err)
+	}
+	if info, err := os.Stat(filepath.Dir(path)); err != nil || !info.IsDir() {
+		t.Fatalf("maintenance lock directory = %v, %v", info, err)
+	}
+}
+
 func TestMaintenanceLockHonorsCancellation(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "MAINTENANCE.lock")
 	held, err := acquireMaintenanceLock(context.Background(), path, maintenanceExclusive)

--- a/internal/reviewtransaction/store_lock.go
+++ b/internal/reviewtransaction/store_lock.go
@@ -38,8 +38,10 @@ type storeLock struct {
 	maintenance *MaintenanceLock
 }
 
-// MaintenanceLock is an advisory exclusive authority-maintenance lease.
-// Callers must supply a bounded context and always Release the lease.
+// MaintenanceLock is an advisory authority-maintenance lease. It may be shared
+// by review writers or exclusive for approved maintenance. Acquisition is
+// bounded by maintenanceLockTimeout, including context.Background callers.
+// Callers must always Release the lease.
 type MaintenanceLock struct{ lock *storeLock }
 
 func (lock *MaintenanceLock) Release() error {
@@ -206,6 +208,9 @@ func AcquireReviewMaintenanceExclusive(ctx context.Context, repo string) (*Maint
 }
 
 func ensureMaintenanceLockPath(path string) error {
+	if !filepath.IsAbs(path) {
+		return fmt.Errorf("maintenance lock path %q must be absolute", path)
+	}
 	root := filepath.Dir(path)
 	for current := root; ; current = filepath.Dir(current) {
 		info, err := os.Lstat(current)


### PR DESCRIPTION
Closes #1475

## Summary
- reject non-absolute maintenance-lock paths before upward traversal
- document shared, exclusive, and timeout-bounded lease semantics
- add focused relative-path and canonical absolute-path regressions

## Verification
- go test ./internal/reviewtransaction -run TestEnsureMaintenanceLockPath
- go test ./internal/reviewtransaction
- go test -race ./internal/reviewtransaction
- go vet ./...
- gofmt and git diff checks
- bounded 4R review with no findings

## Review receipt
- lineage: review-a9be1bdc816d01ce

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Maintenance lock paths must now use a canonical absolute path, preventing invalid relative paths.
  * Valid absolute lock paths continue to ensure their parent directory is available.

* **Documentation**
  * Clarified maintenance lease behavior, including shared or exclusive access, acquisition time limits, and the requirement to release leases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->