### PR TITLE
fix(review): reject terminal captured evidence

### DIFF
--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -952,6 +952,9 @@ func runReviewFacadeFinalize(ctx context.Context, args []string, stdout io.Write
 		}
 	}
 	terminalAtEntry := facadeTerminalState(state.State)
+	if terminalAtEntry && !facadeFinalizeReplayInputsEmpty(resultPaths, resultArtifacts, *capturedResults, *capturedEvidence, *validationPath, *refuterPath, *evidencePath, *correctionLines, *failed, *tracePath) {
+		return errors.New("terminal review finalize accepts no review inputs; exact replay requires only --lineage")
+	}
 	if state.State != reviewtransaction.StateReviewing && (len(resultArtifacts) != 0 || len(resultPaths) != 0) {
 		pending, pendingErr := store.PendingFinalizeAttempt()
 		if pendingErr != nil {
@@ -986,14 +989,8 @@ func runReviewFacadeFinalize(ctx context.Context, args []string, stdout io.Write
 			if terminalPending == nil {
 				terminalComplete = true
 			}
-			if terminalPending != nil && !facadeFinalizeReplayInputsEmpty(resultPaths, resultArtifacts, *capturedResults, *validationPath, *refuterPath, *evidencePath, *correctionLines, *failed, *tracePath) {
-				return errors.New("terminal review finalize accepts no review inputs; exact replay requires only --lineage")
-			}
 		}
 		if !terminalReceiptExists {
-			if !facadeFinalizeReplayInputsEmpty(resultPaths, resultArtifacts, *capturedResults, *validationPath, *refuterPath, *evidencePath, *correctionLines, *failed, *tracePath) {
-				return errors.New("terminal review finalize accepts no review inputs; exact receipt replay requires only --lineage")
-			}
 			if *lineage != state.LineageID || strings.TrimSpace(*lineage) != *lineage {
 				return errors.New("receipt publication replay requires the exact explicit --lineage")
 			}
@@ -1320,8 +1317,8 @@ func facadeTerminalState(state reviewtransaction.State) bool {
 	return state == reviewtransaction.StateApproved || state == reviewtransaction.StateEscalated
 }
 
-func facadeFinalizeReplayInputsEmpty(results, artifacts []string, captured bool, validation, refuter, evidence string, correctionLines int, failed bool, trace string) bool {
-	return len(results) == 0 && len(artifacts) == 0 && !captured && strings.TrimSpace(validation) == "" && strings.TrimSpace(refuter) == "" &&
+func facadeFinalizeReplayInputsEmpty(results, artifacts []string, capturedResults, capturedEvidence bool, validation, refuter, evidence string, correctionLines int, failed bool, trace string) bool {
+	return len(results) == 0 && len(artifacts) == 0 && !capturedResults && !capturedEvidence && strings.TrimSpace(validation) == "" && strings.TrimSpace(refuter) == "" &&
 		strings.TrimSpace(evidence) == "" && correctionLines == 0 && !failed && strings.TrimSpace(trace) == ""
 }
 

--- a/internal/cli/review_facade_test.go
+++ b/internal/cli/review_facade_test.go
@@ -776,6 +776,44 @@ func TestReviewFacadeFinalizeReceiptReplayRejectsNonExactAndUnsafeRequests(t *te
 	})
 }
 
+func TestReviewFacadeFinalizeTerminalReplaysRejectCapturedEvidence(t *testing.T) {
+	for _, tt := range []struct {
+		name             string
+		publishReceipt   bool
+		completeTerminal bool
+	}{
+		{name: "terminal finalize replay", publishReceipt: true},
+		{name: "receipt publication replay"},
+		{name: "completed terminal replay", publishReceipt: true, completeTerminal: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			fixture := prepareFacadeReceiptPending(t)
+			if tt.publishReceipt {
+				receipt, err := fixture.pending.State.Receipt()
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err := reviewtransaction.WriteCompactReceiptAtomic(fixture.store.ReceiptPath(), receipt); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if tt.completeTerminal {
+				pending, err := fixture.store.PendingFinalizeAttempt()
+				if err != nil || pending == nil {
+					t.Fatalf("pending finalize attempt = %#v, %v", pending, err)
+				}
+				if err := fixture.store.MarkFinalizeAttemptReceiptPublished(pending.Request.RequestDigest); err != nil {
+					t.Fatal(err)
+				}
+				if err := fixture.store.CompleteFinalizeAttempt(pending.Request.RequestDigest); err != nil {
+					t.Fatal(err)
+				}
+			}
+			assertFacadeReceiptReplayRejected(t, fixture, []string{"--cwd", fixture.repo, "--lineage", fixture.started.LineageID, "--captured-evidence"})
+		})
+	}
+}
+
 func TestReviewFacadeDeniedGateRetainsObservedBoundaryWithoutAuthorizing(t *testing.T) {
 	var output bytes.Buffer
 	evaluation := reviewtransaction.NativeGateEvaluation{
@@ -1225,7 +1263,7 @@ func TestReviewFacadePersistsOverBudgetForecastAndActual(t *testing.T) {
 		if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("base\none\ntwo\nthree\nfixed\n"), 0o644); err != nil {
 			t.Fatal(err)
 		}
-		if err := RunReviewFacadeFinalize([]string{"--cwd", repo, "--correction-lines", "1"}, io.Discard); err != nil {
+		if err := RunReviewFacadeFinalize([]string{"--cwd", repo, "--lineage", started.LineageID}, io.Discard); err != nil {
 			t.Fatal(err)
 		}
 		after, _ := store.Load()
@@ -1516,7 +1554,7 @@ func TestReviewFacadeRejectsMalformedInputsWithoutConsumingTerminalValidator(t *
 	if err != nil || receipt.TerminalState != reviewtransaction.TerminalEscalated || receipt.FixDeltaHash != failed.State.FixDeltaHash {
 		t.Fatalf("failed validation receipt = %#v, %v", receipt, err)
 	}
-	if err := RunReviewFacadeFinalize([]string{"--cwd", repo, "--correction-lines", "1"}, io.Discard); err != nil {
+	if err := RunReviewFacadeFinalize([]string{"--cwd", repo, "--lineage", started.LineageID}, io.Discard); err != nil {
 		t.Fatal(err)
 	}
 	replayed, _ := store.Load()
@@ -2014,12 +2052,19 @@ func prepareFacadeReceiptPending(t *testing.T) facadeReceiptPendingFixture {
 	if err := os.WriteFile(evidencePath, []byte("focused tests pass\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	validating, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := RunReview([]string{"capture-evidence", "--cwd", repo, "--lineage", started.LineageID, "--target", validating.State.InitialSnapshot.Identity, "--expected-revision", validating.Revision, "--input", evidencePath}, io.Discard); err != nil {
+		t.Fatal(err)
+	}
 	sentinel := errors.New("injected receipt publication interruption")
 	original := writeCompactFacadeReceipt
 	writeCompactFacadeReceipt = func(context.Context, reviewtransaction.CompactStore, reviewtransaction.CompactReceipt) error {
 		return sentinel
 	}
-	err = RunReviewFacadeFinalize([]string{"--cwd", repo, "--lineage", started.LineageID, "--evidence", evidencePath}, io.Discard)
+	err = RunReviewFacadeFinalize([]string{"--cwd", repo, "--lineage", started.LineageID, "--captured-evidence"}, io.Discard)
 	writeCompactFacadeReceipt = original
 	if !errors.Is(err, sentinel) {
 		t.Fatalf("receipt publication error = %v, want injected cause", err)
@@ -2042,6 +2087,11 @@ func prepareFacadeReceiptPending(t *testing.T) facadeReceiptPendingFixture {
 
 func assertFacadeReceiptReplayRejected(t *testing.T, fixture facadeReceiptPendingFixture, args []string) {
 	t.Helper()
+	beforeReceipt, receiptErr := os.ReadFile(fixture.store.ReceiptPath())
+	if receiptErr != nil && !os.IsNotExist(receiptErr) {
+		t.Fatal(receiptErr)
+	}
+	receiptMissing := os.IsNotExist(receiptErr)
 	original := writeCompactFacadeReceipt
 	writes := 0
 	writeCompactFacadeReceipt = func(context.Context, reviewtransaction.CompactStore, reviewtransaction.CompactReceipt) error {
@@ -2062,5 +2112,9 @@ func assertFacadeReceiptReplayRejected(t *testing.T, fixture facadeReceiptPendin
 	}
 	if after.Revision != fixture.pending.Revision || !reflect.DeepEqual(after.State, fixture.pending.State) {
 		t.Fatalf("unsafe replay mutated authority: before %#v after %#v", fixture.pending, after)
+	}
+	afterReceipt, afterReceiptErr := os.ReadFile(fixture.store.ReceiptPath())
+	if os.IsNotExist(afterReceiptErr) != receiptMissing || (!receiptMissing && !bytes.Equal(afterReceipt, beforeReceipt)) {
+		t.Fatalf("unsafe replay mutated receipt: before %q/%v after %q/%v", beforeReceipt, receiptErr, afterReceipt, afterReceiptErr)
 	}
 }

--- a/internal/cli/review_next_transition_test.go
+++ b/internal/cli/review_next_transition_test.go
@@ -58,6 +58,11 @@ func TestValidatingEvidenceCollectionUnblocksFinalizeAndPreCommit(t *testing.T) 
 	if err := RunReviewFacadeFinalize([]string{"--contract", ReviewIntegrationContractV1, "--next-transition", "--cwd", repo, "--lineage", started.LineageID, "--captured-evidence"}, &terminal); err != nil {
 		t.Fatal(err)
 	}
+	var finalized ReviewIntegrationFinalizeResult
+	decodeStrictReviewJSON(t, decodeReviewOperationEnvelope(t, terminal.Bytes()).Result, &finalized)
+	if finalized.State != reviewtransaction.StateApproved {
+		t.Fatalf("captured evidence finalize state = %q, want approved", finalized.State)
+	}
 	runReviewCLIGit(t, repo, "add", "tracked.txt")
 	if err := RunReview([]string{"validate", "--cwd", repo, "--lineage", started.LineageID, "--gate", string(reviewtransaction.GatePreCommit)}, &bytes.Buffer{}); err != nil {
 		t.Fatalf("pre-commit after captured evidence: %v", err)


### PR DESCRIPTION
Closes #1560

## Summary
- reject every finalize input for pending and completed terminal authorities
- include captured final evidence in the exact-replay guard
- prove rejection with real captured evidence while preserving validating-state acceptance

## Verification
- focused terminal replay tests
- go test ./internal/cli
- go vet ./internal/cli
- gofmt and git diff checks
- bounded 4R review with no findings

## Review receipt
- lineage: review-af24e96ae722a493

This is a child PR of #1558 and targets its feature branch.