### PR TITLE
fix(sdd): support scanning subdirectories in sdd-init for monorepos

### DIFF
--- a/internal/assets/skills/sdd-init/SKILL.md
+++ b/internal/assets/skills/sdd-init/SKILL.md
@@ -57,7 +57,7 @@ Run this phase when the orchestrator/user asks to initialize SDD in a project. Y
 
 ## Execution Steps
 
-1. Inspect project files (`package.json`, `go.mod`, `pyproject.toml`, CI, lint/test config) and summarize stack/conventions.
+1. Inspect project files, including scanning subdirectories (up to 2 levels deep) for monorepos or multi-project structures (`package.json`, `go.mod`, `pyproject.toml`, `Cargo.toml`, `Project.toml`, CI/lint/test configs), and summarize the stack and conventions of each detected sub-project.
 2. Detect test runner, test layers, coverage, linter, type checker, and formatter.
 3. Resolve Strict TDD from agent marker, `openspec/config.yaml`, detected runner fallback, or no-runner fallback.
 4. Initialize persistence for the resolved mode.

--- a/internal/assets/skills/sdd-init/references/init-details.md
+++ b/internal/assets/skills/sdd-init/references/init-details.md
@@ -2,7 +2,7 @@
 
 ## Testing Capability Checklist
 
-- Test runner: `package.json` scripts/deps, `pyproject.toml`, `pytest.ini`, `go.mod`, `Cargo.toml`, `Makefile`.
+- Test runner: `package.json` scripts/deps, `pyproject.toml`, `pytest.ini`, `go.mod`, `Cargo.toml`, `Makefile`. For monorepos or multi-project layouts, recursively scan subdirectories (up to 2 levels deep) for project files (e.g. `subproject/pyproject.toml`, `subproject/Cargo.toml`, `subproject/package.json`).
 - Test layers: unit runner; integration libraries (`testing-library`, `httpx`, `httptest`, `WebApplicationFactory`); E2E tools (`playwright`, `cypress`, `selenium`, `chromedp`).
 - Coverage: `vitest --coverage`, `jest --coverage`, `c8`, `pytest-cov`, `go test -cover`, `coverlet`.
 - Quality: linter, type checker, formatter commands.

--- a/testdata/golden/sdd-antigravity-skill-sdd-init.golden
+++ b/testdata/golden/sdd-antigravity-skill-sdd-init.golden
@@ -57,7 +57,7 @@ Run this phase when the orchestrator/user asks to initialize SDD in a project. Y
 
 ## Execution Steps
 
-1. Inspect project files (`package.json`, `go.mod`, `pyproject.toml`, CI, lint/test config) and summarize stack/conventions.
+1. Inspect project files, including scanning subdirectories (up to 2 levels deep) for monorepos or multi-project structures (`package.json`, `go.mod`, `pyproject.toml`, `Cargo.toml`, `Project.toml`, CI/lint/test configs), and summarize the stack and conventions of each detected sub-project.
 2. Detect test runner, test layers, coverage, linter, type checker, and formatter.
 3. Resolve Strict TDD from agent marker, `openspec/config.yaml`, detected runner fallback, or no-runner fallback.
 4. Initialize persistence for the resolved mode.

--- a/testdata/golden/sdd-codex-skill-sdd-init.golden
+++ b/testdata/golden/sdd-codex-skill-sdd-init.golden
@@ -57,7 +57,7 @@ Run this phase when the orchestrator/user asks to initialize SDD in a project. Y
 
 ## Execution Steps
 
-1. Inspect project files (`package.json`, `go.mod`, `pyproject.toml`, CI, lint/test config) and summarize stack/conventions.
+1. Inspect project files, including scanning subdirectories (up to 2 levels deep) for monorepos or multi-project structures (`package.json`, `go.mod`, `pyproject.toml`, `Cargo.toml`, `Project.toml`, CI/lint/test configs), and summarize the stack and conventions of each detected sub-project.
 2. Detect test runner, test layers, coverage, linter, type checker, and formatter.
 3. Resolve Strict TDD from agent marker, `openspec/config.yaml`, detected runner fallback, or no-runner fallback.
 4. Initialize persistence for the resolved mode.

--- a/testdata/golden/sdd-cursor-skill-sdd-init.golden
+++ b/testdata/golden/sdd-cursor-skill-sdd-init.golden
@@ -57,7 +57,7 @@ Run this phase when the orchestrator/user asks to initialize SDD in a project. Y
 
 ## Execution Steps
 
-1. Inspect project files (`package.json`, `go.mod`, `pyproject.toml`, CI, lint/test config) and summarize stack/conventions.
+1. Inspect project files, including scanning subdirectories (up to 2 levels deep) for monorepos or multi-project structures (`package.json`, `go.mod`, `pyproject.toml`, `Cargo.toml`, `Project.toml`, CI/lint/test configs), and summarize the stack and conventions of each detected sub-project.
 2. Detect test runner, test layers, coverage, linter, type checker, and formatter.
 3. Resolve Strict TDD from agent marker, `openspec/config.yaml`, detected runner fallback, or no-runner fallback.
 4. Initialize persistence for the resolved mode.

--- a/testdata/golden/sdd-gemini-skill-sdd-init.golden
+++ b/testdata/golden/sdd-gemini-skill-sdd-init.golden
@@ -57,7 +57,7 @@ Run this phase when the orchestrator/user asks to initialize SDD in a project. Y
 
 ## Execution Steps
 
-1. Inspect project files (`package.json`, `go.mod`, `pyproject.toml`, CI, lint/test config) and summarize stack/conventions.
+1. Inspect project files, including scanning subdirectories (up to 2 levels deep) for monorepos or multi-project structures (`package.json`, `go.mod`, `pyproject.toml`, `Cargo.toml`, `Project.toml`, CI/lint/test configs), and summarize the stack and conventions of each detected sub-project.
 2. Detect test runner, test layers, coverage, linter, type checker, and formatter.
 3. Resolve Strict TDD from agent marker, `openspec/config.yaml`, detected runner fallback, or no-runner fallback.
 4. Initialize persistence for the resolved mode.

--- a/testdata/golden/sdd-kiro-skill-sdd-init.golden
+++ b/testdata/golden/sdd-kiro-skill-sdd-init.golden
@@ -57,7 +57,7 @@ Run this phase when the orchestrator/user asks to initialize SDD in a project. Y
 
 ## Execution Steps
 
-1. Inspect project files (`package.json`, `go.mod`, `pyproject.toml`, CI, lint/test config) and summarize stack/conventions.
+1. Inspect project files, including scanning subdirectories (up to 2 levels deep) for monorepos or multi-project structures (`package.json`, `go.mod`, `pyproject.toml`, `Cargo.toml`, `Project.toml`, CI/lint/test configs), and summarize the stack and conventions of each detected sub-project.
 2. Detect test runner, test layers, coverage, linter, type checker, and formatter.
 3. Resolve Strict TDD from agent marker, `openspec/config.yaml`, detected runner fallback, or no-runner fallback.
 4. Initialize persistence for the resolved mode.

--- a/testdata/golden/sdd-opencode-skill-sdd-init.golden
+++ b/testdata/golden/sdd-opencode-skill-sdd-init.golden
@@ -57,7 +57,7 @@ Run this phase when the orchestrator/user asks to initialize SDD in a project. Y
 
 ## Execution Steps
 
-1. Inspect project files (`package.json`, `go.mod`, `pyproject.toml`, CI, lint/test config) and summarize stack/conventions.
+1. Inspect project files, including scanning subdirectories (up to 2 levels deep) for monorepos or multi-project structures (`package.json`, `go.mod`, `pyproject.toml`, `Cargo.toml`, `Project.toml`, CI/lint/test configs), and summarize the stack and conventions of each detected sub-project.
 2. Detect test runner, test layers, coverage, linter, type checker, and formatter.
 3. Resolve Strict TDD from agent marker, `openspec/config.yaml`, detected runner fallback, or no-runner fallback.
 4. Initialize persistence for the resolved mode.

--- a/testdata/golden/sdd-vscode-skill-sdd-init.golden
+++ b/testdata/golden/sdd-vscode-skill-sdd-init.golden
@@ -57,7 +57,7 @@ Run this phase when the orchestrator/user asks to initialize SDD in a project. Y
 
 ## Execution Steps
 
-1. Inspect project files (`package.json`, `go.mod`, `pyproject.toml`, CI, lint/test config) and summarize stack/conventions.
+1. Inspect project files, including scanning subdirectories (up to 2 levels deep) for monorepos or multi-project structures (`package.json`, `go.mod`, `pyproject.toml`, `Cargo.toml`, `Project.toml`, CI/lint/test configs), and summarize the stack and conventions of each detected sub-project.
 2. Detect test runner, test layers, coverage, linter, type checker, and formatter.
 3. Resolve Strict TDD from agent marker, `openspec/config.yaml`, detected runner fallback, or no-runner fallback.
 4. Initialize persistence for the resolved mode.

--- a/testdata/golden/sdd-windsurf-skill-sdd-init.golden
+++ b/testdata/golden/sdd-windsurf-skill-sdd-init.golden
@@ -57,7 +57,7 @@ Run this phase when the orchestrator/user asks to initialize SDD in a project. Y
 
 ## Execution Steps
 
-1. Inspect project files (`package.json`, `go.mod`, `pyproject.toml`, CI, lint/test config) and summarize stack/conventions.
+1. Inspect project files, including scanning subdirectories (up to 2 levels deep) for monorepos or multi-project structures (`package.json`, `go.mod`, `pyproject.toml`, `Cargo.toml`, `Project.toml`, CI/lint/test configs), and summarize the stack and conventions of each detected sub-project.
 2. Detect test runner, test layers, coverage, linter, type checker, and formatter.
 3. Resolve Strict TDD from agent marker, `openspec/config.yaml`, detected runner fallback, or no-runner fallback.
 4. Initialize persistence for the resolved mode.


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #810

---

## 🏷️ PR Type

- [ ] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [x] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

In monorepo or multi-project structures, sub-projects and their corresponding test runners are located in subdirectories (e.g. `subproject/pyproject.toml`, `subproject/Cargo.toml`).

Currently, the `sdd-init` skill is only instructed to inspect files in the root directory. As a result, running `/sdd-init` in a monorepo fails to detect any of the nested stacks, defaulting to an unclassified empty template.

This PR:
1. Updates the `sdd-init` skill instructions (`SKILL.md`) to explicitly direct the executor to recursively scan subdirectories up to 2 levels deep for project configuration files.
2. Updates `references/init-details.md` to specify that test runner configuration checks must scan nested subprojects (e.g., `pyproject.toml`, `Cargo.toml`, `package.json`).
3. Regenerates the affected `sdd-init` skill golden files so tests continue to pass.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/assets/skills/sdd-init/SKILL.md` | Directs the executor to scan subdirectories up to 2 levels deep for project configuration files. |
| `internal/assets/skills/sdd-init/references/init-details.md` | Directs recursive subdirectory scanning (up to 2 levels) for test runner configuration. |
| `testdata/golden/` | Updated regenerated `sdd-init` skill golden files. |

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./internal/components/... -v
```

- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Manually tested locally

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines (20 lines changed)
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] My commits do not include `Co-Authored-By` trailers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved project initialization guidance to inspect subdirectories up to two levels deep.
  * Added support for identifying monorepo and multi-project structures.
  * Expanded testing guidance to detect project configuration and test-runner files across nested projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->