### PR TITLE
fix(review): secure local lock file opens

### DIFF
--- a/internal/reviewtransaction/secure_open.go
+++ b/internal/reviewtransaction/secure_open.go
@@ -1,0 +1,11 @@
+package reviewtransaction
+
+// secureOpenLocalStoreLockBeforeOpen gives tests a deterministic substitution
+// point immediately before the platform's atomic no-follow open.
+var secureOpenLocalStoreLockBeforeOpen func(string)
+
+func runSecureOpenLocalStoreLockBeforeOpen(path string) {
+	if hook := secureOpenLocalStoreLockBeforeOpen; hook != nil {
+		hook(path)
+	}
+}

--- a/internal/reviewtransaction/secure_open_unix.go
+++ b/internal/reviewtransaction/secure_open_unix.go
@@ -1,0 +1,63 @@
+//go:build unix
+
+package reviewtransaction
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/sys/unix"
+)
+
+func secureOpenLocalStoreLock(path string) (*os.File, error) {
+	runSecureOpenLocalStoreLockBeforeOpen(path)
+
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return nil, err
+	}
+	parentFD, err := secureOpenLockParent(filepath.Dir(absPath))
+	if err != nil {
+		return nil, err
+	}
+	defer unix.Close(parentFD)
+
+	fd, err := unix.Openat(parentFD, filepath.Base(absPath), unix.O_RDWR|unix.O_CREAT|unix.O_CLOEXEC|unix.O_NOFOLLOW|unix.O_NONBLOCK, 0o600)
+	if err != nil {
+		return nil, err
+	}
+
+	var stat unix.Stat_t
+	if err := unix.Fstat(fd, &stat); err != nil {
+		_ = unix.Close(fd)
+		return nil, err
+	}
+	if stat.Mode&unix.S_IFMT != unix.S_IFREG {
+		_ = unix.Close(fd)
+		return nil, fmt.Errorf("review store lock %q is not a regular file", path)
+	}
+
+	return os.NewFile(uintptr(fd), path), nil
+}
+
+func secureOpenLockParent(path string) (int, error) {
+	fd, err := unix.Open(string(filepath.Separator), unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return -1, err
+	}
+	for _, component := range strings.Split(strings.TrimPrefix(path, string(filepath.Separator)), string(filepath.Separator)) {
+		if component == "" {
+			continue
+		}
+		nextFD, err := unix.Openat(fd, component, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+		if err != nil {
+			_ = unix.Close(fd)
+			return -1, err
+		}
+		_ = unix.Close(fd)
+		fd = nextFD
+	}
+	return fd, nil
+}

--- a/internal/reviewtransaction/secure_open_windows.go
+++ b/internal/reviewtransaction/secure_open_windows.go
@@ -1,0 +1,73 @@
+//go:build windows
+
+package reviewtransaction
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+func secureOpenLocalStoreLock(path string) (*os.File, error) {
+	runSecureOpenLocalStoreLockBeforeOpen(path)
+
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return nil, err
+	}
+	objectName, err := windows.NewNTUnicodeString(ntPath(absPath))
+	if err != nil {
+		return nil, err
+	}
+	attributes := &windows.OBJECT_ATTRIBUTES{
+		Length:     uint32(unsafe.Sizeof(windows.OBJECT_ATTRIBUTES{})),
+		ObjectName: objectName,
+		Attributes: windows.OBJ_CASE_INSENSITIVE | windows.OBJ_DONT_REPARSE,
+	}
+	var handle windows.Handle
+	var status windows.IO_STATUS_BLOCK
+	err = windows.NtCreateFile(
+		&handle,
+		windows.FILE_GENERIC_READ|windows.FILE_GENERIC_WRITE,
+		attributes,
+		&status,
+		nil,
+		windows.FILE_ATTRIBUTE_NORMAL,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE,
+		windows.FILE_OPEN_IF,
+		windows.FILE_NON_DIRECTORY_FILE|windows.FILE_SYNCHRONOUS_IO_NONALERT|windows.FILE_OPEN_REPARSE_POINT,
+		0,
+		0,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	fileInfo := new(windows.ByHandleFileInformation)
+	if err := windows.GetFileInformationByHandle(handle, fileInfo); err != nil {
+		_ = windows.CloseHandle(handle)
+		return nil, err
+	}
+	fileType, err := windows.GetFileType(handle)
+	if err != nil {
+		_ = windows.CloseHandle(handle)
+		return nil, err
+	}
+	if fileType != windows.FILE_TYPE_DISK || fileInfo.FileAttributes&(windows.FILE_ATTRIBUTE_DIRECTORY|windows.FILE_ATTRIBUTE_REPARSE_POINT) != 0 {
+		_ = windows.CloseHandle(handle)
+		return nil, fmt.Errorf("review store lock %q is not a regular file", path)
+	}
+
+	return os.NewFile(uintptr(handle), path), nil
+}
+
+func ntPath(path string) string {
+	if strings.HasPrefix(path, `\\`) {
+		return `\??\UNC\` + strings.TrimPrefix(path, `\\`)
+	}
+	return `\??\` + path
+}

--- a/internal/reviewtransaction/store_lock.go
+++ b/internal/reviewtransaction/store_lock.go
@@ -110,7 +110,7 @@ func acquireLocalStoreLock(path string) (*storeLock, error) {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return nil, err
 	}
-	file, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0o600)
+	file, err := secureOpenLocalStoreLock(path)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/reviewtransaction/store_lock_unix_test.go
+++ b/internal/reviewtransaction/store_lock_unix_test.go
@@ -3,6 +3,7 @@
 package reviewtransaction
 
 import (
+	"bytes"
 	"errors"
 	"os"
 	"path/filepath"
@@ -10,6 +11,143 @@ import (
 	"syscall"
 	"testing"
 )
+
+func TestAcquireLocalStoreLockRejectsSymlinkAndPreservesTarget(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "external-target")
+	want := []byte("external data must not be lock metadata\n")
+	if err := os.WriteFile(target, want, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	path := filepath.Join(t.TempDir(), "review-store", "LOCK")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, path); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := acquireLocalStoreLock(path); err == nil {
+		t.Fatal("acquireLocalStoreLock(symlink) succeeded")
+	}
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("external target changed: got %q, want %q", got, want)
+	}
+}
+
+func TestAcquireLocalStoreLockRejectsSymlinkedParentAndPreservesTarget(t *testing.T) {
+	externalStore := filepath.Join(t.TempDir(), "external-store")
+	if err := os.MkdirAll(externalStore, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(externalStore, "LOCK")
+	want := []byte("external data must not be lock metadata\n")
+	if err := os.WriteFile(target, want, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	path := filepath.Join(t.TempDir(), "review-store", "LOCK")
+	if err := os.Symlink(externalStore, filepath.Dir(path)); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := acquireLocalStoreLock(path); err == nil {
+		t.Fatal("acquireLocalStoreLock(symlinked parent) succeeded")
+	}
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("external target changed through parent: got %q, want %q", got, want)
+	}
+}
+
+func TestAcquireLocalStoreLockRejectsSymlinkSwapAtOpenBoundary(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "external-target")
+	want := []byte("external data must not be lock metadata\n")
+	if err := os.WriteFile(target, want, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	path := filepath.Join(t.TempDir(), "review-store", "LOCK")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("old lock\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	previousHook := secureOpenLocalStoreLockBeforeOpen
+	secureOpenLocalStoreLockBeforeOpen = func(openPath string) {
+		if openPath != path {
+			t.Fatalf("secure open path = %q, want %q", openPath, path)
+		}
+		if err := os.Remove(path); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(target, path); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Cleanup(func() { secureOpenLocalStoreLockBeforeOpen = previousHook })
+
+	if _, err := acquireLocalStoreLock(path); err == nil {
+		t.Fatal("acquireLocalStoreLock(symlink swap) succeeded")
+	}
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("external target changed after swap: got %q, want %q", got, want)
+	}
+}
+
+func TestAcquireLocalStoreLockRejectsNonRegularUnixObject(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "review-store", "LOCK")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(path, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := acquireLocalStoreLock(path); err == nil {
+		t.Fatal("acquireLocalStoreLock(directory) succeeded")
+	}
+}
+
+func TestAcquireLocalStoreLockCreatesAndReopensWithoutChangingPermissions(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "review-store", "LOCK")
+	first, err := acquireLocalStoreLock(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := first.release(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(path, 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	second, err := acquireLocalStoreLock(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := second.release(); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o640 {
+		t.Fatalf("LOCK permissions = %#o, want 0640", got)
+	}
+}
 
 func TestBusyStoreLockProbePreservesExistingUnixInodeAndMetadata(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "review-store", "LOCK")

--- a/internal/reviewtransaction/store_lock_windows_test.go
+++ b/internal/reviewtransaction/store_lock_windows_test.go
@@ -3,10 +3,49 @@
 package reviewtransaction
 
 import (
+	"bytes"
 	"errors"
+	"os"
 	"path/filepath"
 	"testing"
 )
+
+func TestWindowsSecureStoreLockRejectsReparsePointAndPreservesTarget(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "external-target")
+	want := []byte("external data must not be lock metadata\n")
+	if err := os.WriteFile(target, want, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	path := filepath.Join(t.TempDir(), "review-store", "LOCK")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, path); err != nil {
+		t.Skipf("creating a file symlink is unavailable: %v", err)
+	}
+
+	if _, err := acquireLocalStoreLock(path); err == nil {
+		t.Fatal("acquireLocalStoreLock(reparse point) succeeded")
+	}
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("external target changed: got %q, want %q", got, want)
+	}
+}
+
+func TestWindowsSecureStoreLockRejectsDirectory(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "review-store", "LOCK")
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := acquireLocalStoreLock(path); err == nil {
+		t.Fatal("acquireLocalStoreLock(directory) succeeded")
+	}
+}
 
 func TestWindowsStoreLockUsesExistingInodeAdvisoryTruth(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "review-store", "LOCK")


### PR DESCRIPTION
Closes #1567

## Summary
- open Unix authority locks through descriptor-anchored no-follow traversal
- reject Windows reparse/non-disk lock objects through native handle validation
- preserve contention, metadata, timeout, and release behavior with deterministic regressions

## Verification
- go test ./...
- repeated race tests for internal/reviewtransaction
- go vet ./...
- native, Windows, and Darwin builds
- bounded native review with independent refutation

## Review receipt
- lineage: review-deb65745fa3e9fb5