### PR TITLE
fix(review): preserve secure lock path compatibility

### DIFF
--- a/internal/reviewtransaction/secure_open_directory_darwin.go
+++ b/internal/reviewtransaction/secure_open_directory_darwin.go
@@ -1,0 +1,9 @@
+//go:build darwin
+
+package reviewtransaction
+
+import "golang.org/x/sys/unix"
+
+func secureDirectoryOpenFlags() int {
+	return unix.O_EVTONLY | unix.O_DIRECTORY | unix.O_CLOEXEC
+}

--- a/internal/reviewtransaction/secure_open_directory_linux.go
+++ b/internal/reviewtransaction/secure_open_directory_linux.go
@@ -1,0 +1,9 @@
+//go:build linux
+
+package reviewtransaction
+
+import "golang.org/x/sys/unix"
+
+func secureDirectoryOpenFlags() int {
+	return unix.O_PATH | unix.O_DIRECTORY | unix.O_CLOEXEC
+}

--- a/internal/reviewtransaction/secure_open_directory_other_unix.go
+++ b/internal/reviewtransaction/secure_open_directory_other_unix.go
@@ -1,0 +1,9 @@
+//go:build unix && !linux && !darwin && !aix && !freebsd && !solaris
+
+package reviewtransaction
+
+import "golang.org/x/sys/unix"
+
+func secureDirectoryOpenFlags() int {
+	return unix.O_RDONLY | unix.O_DIRECTORY | unix.O_CLOEXEC
+}

--- a/internal/reviewtransaction/secure_open_directory_search.go
+++ b/internal/reviewtransaction/secure_open_directory_search.go
@@ -1,0 +1,9 @@
+//go:build aix || freebsd || solaris
+
+package reviewtransaction
+
+import "golang.org/x/sys/unix"
+
+func secureDirectoryOpenFlags() int {
+	return unix.O_SEARCH | unix.O_DIRECTORY | unix.O_CLOEXEC
+}

--- a/internal/reviewtransaction/secure_open_unix.go
+++ b/internal/reviewtransaction/secure_open_unix.go
@@ -43,7 +43,7 @@ func secureOpenLocalStoreLock(path string) (*os.File, error) {
 }
 
 func secureOpenLockParent(path string) (int, error) {
-	fd, err := unix.Open(string(filepath.Separator), unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC, 0)
+	fd, err := unix.Open(string(filepath.Separator), secureDirectoryOpenFlags(), 0)
 	if err != nil {
 		return -1, err
 	}
@@ -51,7 +51,7 @@ func secureOpenLockParent(path string) (int, error) {
 		if component == "" {
 			continue
 		}
-		nextFD, err := unix.Openat(fd, component, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+		nextFD, err := unix.Openat(fd, component, secureDirectoryOpenFlags()|unix.O_NOFOLLOW, 0)
 		if err != nil {
 			_ = unix.Close(fd)
 			return -1, err

--- a/internal/reviewtransaction/secure_open_windows.go
+++ b/internal/reviewtransaction/secure_open_windows.go
@@ -66,6 +66,12 @@ func secureOpenLocalStoreLock(path string) (*os.File, error) {
 }
 
 func ntPath(path string) string {
+	if strings.HasPrefix(path, `\\?\UNC\`) {
+		return `\??\UNC\` + strings.TrimPrefix(path, `\\?\UNC\`)
+	}
+	if strings.HasPrefix(path, `\\?\`) {
+		return `\??\` + strings.TrimPrefix(path, `\\?\`)
+	}
 	if strings.HasPrefix(path, `\\`) {
 		return `\??\UNC\` + strings.TrimPrefix(path, `\\`)
 	}

--- a/internal/reviewtransaction/store_lock_unix_test.go
+++ b/internal/reviewtransaction/store_lock_unix_test.go
@@ -12,6 +12,15 @@ import (
 	"testing"
 )
 
+func canonicalTempDir(t *testing.T) string {
+	t.Helper()
+	root, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
 func TestAcquireLocalStoreLockRejectsSymlinkAndPreservesTarget(t *testing.T) {
 	target := filepath.Join(t.TempDir(), "external-target")
 	want := []byte("external data must not be lock metadata\n")
@@ -121,7 +130,7 @@ func TestAcquireLocalStoreLockRejectsNonRegularUnixObject(t *testing.T) {
 }
 
 func TestAcquireLocalStoreLockCreatesAndReopensWithoutChangingPermissions(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "review-store", "LOCK")
+	path := filepath.Join(canonicalTempDir(t), "review-store", "LOCK")
 	first, err := acquireLocalStoreLock(path)
 	if err != nil {
 		t.Fatal(err)
@@ -149,8 +158,33 @@ func TestAcquireLocalStoreLockCreatesAndReopensWithoutChangingPermissions(t *tes
 	}
 }
 
+func TestAcquireLocalStoreLockAllowsSearchOnlyAncestor(t *testing.T) {
+	root := canonicalTempDir(t)
+	ancestor := filepath.Join(root, "search-only")
+	path := filepath.Join(ancestor, "review-store", "LOCK")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(ancestor, 0o111); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chmod(ancestor, 0o700); err != nil {
+			t.Error(err)
+		}
+	})
+
+	lock, err := acquireLocalStoreLock(path)
+	if err != nil {
+		t.Fatalf("acquireLocalStoreLock(search-only ancestor): %v", err)
+	}
+	if err := lock.release(); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestBusyStoreLockProbePreservesExistingUnixInodeAndMetadata(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "review-store", "LOCK")
+	path := filepath.Join(canonicalTempDir(t), "review-store", "LOCK")
 	held, err := acquireStoreLock(path)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/reviewtransaction/store_lock_windows_test.go
+++ b/internal/reviewtransaction/store_lock_windows_test.go
@@ -10,6 +10,43 @@ import (
 	"testing"
 )
 
+func TestNTPath(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{
+			name: "drive path",
+			path: `C:\review-store\LOCK`,
+			want: `\??\C:\review-store\LOCK`,
+		},
+		{
+			name: "UNC path",
+			path: `\\server\share\review-store\LOCK`,
+			want: `\??\UNC\server\share\review-store\LOCK`,
+		},
+		{
+			name: "extended drive path",
+			path: `\\?\C:\review-store\LOCK`,
+			want: `\??\C:\review-store\LOCK`,
+		},
+		{
+			name: "extended UNC path",
+			path: `\\?\UNC\server\share\review-store\LOCK`,
+			want: `\??\UNC\server\share\review-store\LOCK`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ntPath(tt.path); got != tt.want {
+				t.Fatalf("ntPath(%q) = %q, want %q", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestWindowsSecureStoreLockRejectsReparsePointAndPreservesTarget(t *testing.T) {
 	target := filepath.Join(t.TempDir(), "external-target")
 	want := []byte("external data must not be lock metadata\n")


### PR DESCRIPTION
Closes #1572

## Summary
- preserve Unix search-only ancestor traversal with platform-appropriate descriptors
- correctly normalize ordinary and extended Windows drive/UNC paths
- canonicalize macOS temporary test roots while retaining explicit symlink rejection

## Verification
- go test ./...
- repeated reviewtransaction race tests
- go vet ./...
- Windows and Darwin cross-compilation
- clean native reliability review

## Review receipt
- lineage: review-29224f087a28ae63

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cross-platform directory access for secure review-store locking.
  * Added support for Windows extended-length and UNC paths.
  * Enabled locking when ancestor directories provide search-only permissions.

* **Tests**
  * Added coverage for Windows path conversion and Unix permission scenarios.
  * Improved test path handling by resolving symbolic links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->