### PR TITLE
feat: add openSUSE/SUSE family support (zypper package manager)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,8 @@ jobs:
             dockerfile: Dockerfile.arch
           - name: fedora
             dockerfile: Dockerfile.fedora
+          - name: opensuse
+            dockerfile: Dockerfile.opensuse
     steps:
       - name: Require successful Go format
         if: needs.go-format.result != 'success'

--- a/docs/non-interactive.md
+++ b/docs/non-interactive.md
@@ -37,6 +37,7 @@ The installer detects the platform automatically at runtime — there is no flag
 | Ubuntu/Debian | `apt` | `sudo npm install -g opencode-ai` |
 | Arch | `pacman` | `sudo npm install -g opencode-ai` |
 | Fedora/RHEL family | `dnf` | `sudo npm install -g opencode-ai` |
+| openSUSE/SUSE family | `zypper` | `sudo npm install -g opencode-ai` |
 
 The `--dry-run` output includes a `Platform decision` line showing `os`, `distro`, `package-manager`, and `status`.
 

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -10,9 +10,10 @@
 | Linux (Ubuntu/Debian) | apt | Supported |
 | Linux (Arch) | pacman | Supported |
 | Linux (Fedora/RHEL family) | dnf | Supported |
+| Linux (openSUSE Tumbleweed/Leap/Slowroll, SUSE MicroOS) | zypper | Supported |
 | Windows 10/11 | PowerShell installer | Supported |
 
-Derivatives are detected via `ID_LIKE` in `/etc/os-release` (Linux Mint, Pop!_OS, Manjaro, EndeavourOS, CentOS Stream, Rocky Linux, AlmaLinux, etc.).
+Derivatives are detected via both `ID` prefix and `ID_LIKE` in `/etc/os-release` (Linux Mint, Pop!_OS, Manjaro, EndeavourOS, CentOS Stream, Rocky Linux, AlmaLinux, openSUSE Slowroll, openSUSE MicroOS, SUSE SLE, etc.).
 
 Release artifacts are produced by CI. Windows users should install through the PowerShell installer so Gentle AI's built-in updater owns the same binary it installed.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -98,4 +98,4 @@ Optional wrapper tools for extra defense:
 If you run the installer on an unsupported OS or Linux distro, it exits immediately with an error:
 
 - `unsupported operating system: only macOS, Linux, and Windows are supported (detected <os>)`
-- `unsupported linux distro: Linux support is limited to Ubuntu/Debian, Arch, and Fedora/RHEL family (detected <distro>)`
+- `unsupported linux distro: Linux support is limited to Ubuntu/Debian, Arch, Fedora/RHEL, and openSUSE/SUSE family (detected <distro>)`

--- a/e2e/Dockerfile.opensuse
+++ b/e2e/Dockerfile.opensuse
@@ -1,0 +1,73 @@
+# syntax=docker/dockerfile:1
+# Dockerfile.opensuse — E2E test image for gentle-ai on openSUSE Tumbleweed
+# Builds the binary from source and runs the E2E test suite as a non-root user.
+FROM opensuse/tumbleweed:latest
+
+# ---------------------------------------------------------------------------
+# System dependencies (includes npm/node for claude-code tests)
+# ---------------------------------------------------------------------------
+# Tumbleweed is rolling-release: its native nodejs+npm packages track current
+# LTS, so no NodeSource setup is needed (unlike Ubuntu 22.04 / Fedora).
+# The build is CGO_ENABLED=0 pure Go, so no development-tools pattern either.
+RUN zypper --non-interactive refresh && \
+    zypper --non-interactive install --no-recommends \
+        git \
+        curl \
+        sudo \
+        ca-certificates \
+        nodejs \
+        npm \
+    && zypper clean --all
+
+# ---------------------------------------------------------------------------
+# Install Go (match go.mod version)
+# ---------------------------------------------------------------------------
+ARG GO_VERSION=1.25.10
+ARG TARGETARCH
+RUN arch="${TARGETARCH:-amd64}" && \
+    curl -fsSLo "/tmp/go${GO_VERSION}.linux-${arch}.tar.gz" \
+      "https://go.dev/dl/go${GO_VERSION}.linux-${arch}.tar.gz" && \
+    tar -C /usr/local -xzf "/tmp/go${GO_VERSION}.linux-${arch}.tar.gz" && \
+    rm "/tmp/go${GO_VERSION}.linux-${arch}.tar.gz"
+ENV PATH="/usr/local/go/bin:${PATH}"
+
+# ---------------------------------------------------------------------------
+# Create non-root test user with passwordless sudo
+# ---------------------------------------------------------------------------
+RUN useradd -m -s /bin/bash testuser && \
+    echo "testuser ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+
+# ---------------------------------------------------------------------------
+# Copy project source and build
+# ---------------------------------------------------------------------------
+WORKDIR /build
+COPY go.mod go.sum ./
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/root/go/pkg/mod \
+    go mod download
+COPY . .
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/root/go/pkg/mod \
+    CGO_ENABLED=0 GOOS=linux GOARCH="${TARGETARCH:-amd64}" \
+    go build -o /usr/local/bin/gentle-ai ./cmd/gentle-ai
+
+# ---------------------------------------------------------------------------
+# Prepare test environment
+# ---------------------------------------------------------------------------
+COPY e2e/lib.sh     /home/testuser/e2e/lib.sh
+COPY e2e/e2e_test.sh /home/testuser/e2e/e2e_test.sh
+RUN chmod +x /home/testuser/e2e/e2e_test.sh /home/testuser/e2e/lib.sh && \
+    chown -R testuser:testuser /home/testuser
+
+USER testuser
+
+# Ensure go install binaries are on PATH for testuser
+ENV GOPATH="/home/testuser/go"
+ENV PATH="${GOPATH}/bin:/usr/local/go/bin:${PATH}"
+
+WORKDIR /home/testuser
+
+# ---------------------------------------------------------------------------
+# Default: run Tier 1 tests only
+# ---------------------------------------------------------------------------
+CMD ["./e2e/e2e_test.sh"]

--- a/e2e/docker-test.sh
+++ b/e2e/docker-test.sh
@@ -32,6 +32,7 @@ PLATFORMS=(
     "ubuntu:Dockerfile.ubuntu"
     "arch:Dockerfile.arch"
     "fedora:Dockerfile.fedora"
+    "opensuse:Dockerfile.opensuse"
 )
 
 # Environment variables to forward into containers

--- a/internal/agents/opencode/adapter_test.go
+++ b/internal/agents/opencode/adapter_test.go
@@ -124,8 +124,13 @@ func TestInstallCommand(t *testing.T) {
 			want:    [][]string{{"npm", "install", "-g", "--ignore-scripts", "opencode-ai@" + versions.OpenCode}},
 		},
 		{
+			name:    "opensuse resolves npm install",
+			profile: system.PlatformProfile{OS: "linux", LinuxDistro: system.LinuxDistroOpenSUSE, PackageManager: "zypper"},
+			want:    [][]string{{"sudo", "npm", "install", "-g", "--ignore-scripts", "opencode-ai@" + versions.OpenCode}},
+		},
+		{
 			name:    "unsupported package manager returns error",
-			profile: system.PlatformProfile{OS: "linux", LinuxDistro: system.LinuxDistroUbuntu, PackageManager: "zypper"},
+			profile: system.PlatformProfile{OS: "linux", LinuxDistro: system.LinuxDistroUbuntu, PackageManager: "emerge"},
 			wantErr: true,
 		},
 	}

--- a/internal/components/gga/install_test.go
+++ b/internal/components/gga/install_test.go
@@ -101,10 +101,19 @@ func TestInstallCommandByProfile(t *testing.T) {
 			},
 		},
 		{
+			name:    "opensuse uses git clone and install.sh",
+			profile: system.PlatformProfile{OS: "linux", LinuxDistro: system.LinuxDistroOpenSUSE, PackageManager: "zypper"},
+			want: [][]string{
+				{"rm", "-rf", "/tmp/gentleman-guardian-angel"},
+				{"git", "clone", "--depth=1", "--branch", "v" + versions.GGAVersion, "https://github.com/Gentleman-Programming/gentleman-guardian-angel.git", "/tmp/gentleman-guardian-angel"},
+				{"bash", "/tmp/gentleman-guardian-angel/install.sh"},
+			},
+		},
+		{
 			name: "unsupported package manager returns error",
 			profile: system.PlatformProfile{
 				OS:             "linux",
-				PackageManager: "zypper",
+				PackageManager: "emerge",
 			},
 			wantErr: true,
 		},

--- a/internal/installcmd/resolver.go
+++ b/internal/installcmd/resolver.go
@@ -179,6 +179,8 @@ func uvInstallHint(profile system.PlatformProfile) string {
 		return "sudo pacman -S --noconfirm uv"
 	case "dnf":
 		return "sudo dnf install -y uv"
+	case "zypper":
+		return "sudo zypper install -y uv"
 	case "winget":
 		return "winget install --id astral-sh.uv -e --accept-source-agreements --accept-package-agreements"
 	default:
@@ -211,6 +213,8 @@ func (profileResolver) ResolveDependencyInstall(profile system.PlatformProfile, 
 		return CommandSequence{{"sudo", "pacman", "-S", "--noconfirm", dependency}}, nil
 	case "dnf":
 		return CommandSequence{{"sudo", "dnf", "install", "-y", dependency}}, nil
+	case "zypper":
+		return CommandSequence{{"sudo", "zypper", "install", "-y", dependency}}, nil
 	case "winget":
 		return CommandSequence{{"winget", "install", "--id", dependency, "-e", "--accept-source-agreements", "--accept-package-agreements"}}, nil
 	default:
@@ -233,7 +237,7 @@ func resolveOpenCodeInstall(profile system.PlatformProfile) (CommandSequence, er
 		return CommandSequence{
 			{"brew", "install", "anomalyco/tap/opencode"},
 		}, nil
-	case "apt", "pacman", "dnf":
+	case "apt", "pacman", "dnf", "zypper":
 		pkg := "opencode-ai@" + versions.OpenCode
 		if profile.NpmWritable {
 			return CommandSequence{{"npm", "install", "-g", "--ignore-scripts", pkg}}, nil
@@ -260,7 +264,7 @@ func resolveGGAInstall(profile system.PlatformProfile) (CommandSequence, error) 
 			{"brew", "tap", "Gentleman-Programming/homebrew-tap"},
 			{"brew", "reinstall", "gga"},
 		}, nil
-	case "apt", "pacman", "dnf":
+	case "apt", "pacman", "dnf", "zypper":
 		const tmpDir = "/tmp/gentleman-guardian-angel"
 		return CommandSequence{
 			{"rm", "-rf", tmpDir},

--- a/internal/installcmd/resolver_test.go
+++ b/internal/installcmd/resolver_test.go
@@ -180,6 +180,12 @@ func TestResolveDependencyInstall(t *testing.T) {
 			want:    CommandSequence{{"sudo", "dnf", "install", "-y", "somepkg"}},
 		},
 		{
+			name:    "opensuse resolves zypper command",
+			profile: system.PlatformProfile{OS: "linux", LinuxDistro: system.LinuxDistroOpenSUSE, PackageManager: "zypper"},
+			dep:     "somepkg",
+			want:    CommandSequence{{"sudo", "zypper", "install", "-y", "somepkg"}},
+		},
+		{
 			name:    "windows resolves winget command",
 			profile: system.PlatformProfile{OS: "windows", PackageManager: "winget"},
 			dep:     "somepkg",
@@ -187,7 +193,7 @@ func TestResolveDependencyInstall(t *testing.T) {
 		},
 		{
 			name:    "unsupported package manager returns error",
-			profile: system.PlatformProfile{OS: "linux", LinuxDistro: system.LinuxDistroUbuntu, PackageManager: "zypper"},
+			profile: system.PlatformProfile{OS: "linux", LinuxDistro: system.LinuxDistroUbuntu, PackageManager: "emerge"},
 			dep:     "somepkg",
 			wantErr: true,
 		},
@@ -359,6 +365,12 @@ func TestResolveAgentInstall(t *testing.T) {
 			profile: system.PlatformProfile{OS: "linux", LinuxDistro: system.LinuxDistroFedora, PackageManager: "dnf", NpmWritable: true},
 			agent:   model.AgentOpenCode,
 			want:    CommandSequence{{"npm", "install", "-g", "--ignore-scripts", "opencode-ai@" + versions.OpenCode}},
+		},
+		{
+			name:    "opencode on opensuse system npm uses sudo",
+			profile: system.PlatformProfile{OS: "linux", LinuxDistro: system.LinuxDistroOpenSUSE, PackageManager: "zypper"},
+			agent:   model.AgentOpenCode,
+			want:    CommandSequence{{"sudo", "npm", "install", "-g", "--ignore-scripts", "opencode-ai@" + versions.OpenCode}},
 		},
 		{
 			name:    "claude-code on windows uses npm without sudo",
@@ -614,6 +626,12 @@ func TestResolveComponentInstall(t *testing.T) {
 			wantErr:   true,
 		},
 		{
+			name:      "engram on opensuse returns error (uses DownloadLatestBinary instead)",
+			profile:   system.PlatformProfile{OS: "linux", LinuxDistro: system.LinuxDistroOpenSUSE, PackageManager: "zypper"},
+			component: model.ComponentEngram,
+			wantErr:   true,
+		},
+		{
 			name:      "gga on darwin uses brew tap and reinstall",
 			profile:   system.PlatformProfile{OS: "darwin", PackageManager: "brew"},
 			component: model.ComponentGGA,
@@ -642,6 +660,16 @@ func TestResolveComponentInstall(t *testing.T) {
 		{
 			name:      "gga on fedora uses git clone and install.sh",
 			profile:   system.PlatformProfile{OS: "linux", LinuxDistro: system.LinuxDistroFedora, PackageManager: "dnf"},
+			component: model.ComponentGGA,
+			want: CommandSequence{
+				{"rm", "-rf", "/tmp/gentleman-guardian-angel"},
+				{"git", "clone", "--depth=1", "--branch", "v" + versions.GGAVersion, "https://github.com/Gentleman-Programming/gentleman-guardian-angel.git", "/tmp/gentleman-guardian-angel"},
+				{"bash", "/tmp/gentleman-guardian-angel/install.sh"},
+			},
+		},
+		{
+			name:      "gga on opensuse uses git clone and install.sh",
+			profile:   system.PlatformProfile{OS: "linux", LinuxDistro: system.LinuxDistroOpenSUSE, PackageManager: "zypper"},
 			component: model.ComponentGGA,
 			want: CommandSequence{
 				{"rm", "-rf", "/tmp/gentleman-guardian-angel"},

--- a/internal/system/detect.go
+++ b/internal/system/detect.go
@@ -26,11 +26,12 @@ type PlatformProfile struct {
 }
 
 const (
-	LinuxDistroUnknown = "unknown"
-	LinuxDistroUbuntu  = "ubuntu"
-	LinuxDistroDebian  = "debian"
-	LinuxDistroArch    = "arch"
-	LinuxDistroFedora  = "fedora"
+	LinuxDistroUnknown  = "unknown"
+	LinuxDistroUbuntu   = "ubuntu"
+	LinuxDistroDebian   = "debian"
+	LinuxDistroArch     = "arch"
+	LinuxDistroFedora   = "fedora"
+	LinuxDistroOpenSUSE = "opensuse"
 )
 
 type DetectionResult struct {
@@ -148,6 +149,9 @@ func resolvePlatformProfile(goos, linuxOSRelease string, tools map[string]ToolSt
 		case LinuxDistroFedora:
 			profile.PackageManager = "dnf"
 			profile.Supported = true
+		case LinuxDistroOpenSUSE:
+			profile.PackageManager = "zypper"
+			profile.Supported = true
 		default:
 			profile.PackageManager = ""
 			profile.Supported = false
@@ -204,6 +208,10 @@ func detectLinuxDistro(linuxOSRelease string) string {
 		return LinuxDistroFedora
 	}
 
+	if isSUSELike(id, idLike) {
+		return LinuxDistroOpenSUSE
+	}
+
 	return LinuxDistroUnknown
 }
 
@@ -242,6 +250,23 @@ func isFedoraLike(id, idLike string) bool {
 
 	for _, token := range strings.Fields(idLike) {
 		if token == LinuxDistroFedora || token == "rhel" || token == "centos" || token == "rocky" || token == "almalinux" || token == "nobara" {
+			return true
+		}
+	}
+
+	return false
+}
+
+// isSUSELike detects the openSUSE/SUSE family. Covers Tumbleweed, Leap,
+// Slowroll, MicroOS and derivatives via ID prefix (opensuse, opensuse-*)
+// or the "opensuse"/"suse" ID_LIKE tokens they all declare.
+func isSUSELike(id, idLike string) bool {
+	if id == LinuxDistroOpenSUSE || strings.HasPrefix(id, LinuxDistroOpenSUSE+"-") {
+		return true
+	}
+
+	for _, token := range strings.Fields(idLike) {
+		if token == LinuxDistroOpenSUSE || token == "suse" {
 			return true
 		}
 	}

--- a/internal/system/detect_test.go
+++ b/internal/system/detect_test.go
@@ -90,6 +90,23 @@ func TestDetectFromInputsMarksArchSupported(t *testing.T) {
 	}
 }
 
+func TestDetectFromInputsMarksOpenSUSESupported(t *testing.T) {
+	osRelease := "ID=\"opensuse-tumbleweed\"\nID_LIKE=\"opensuse suse\"\n"
+	result := detectFromInputs("linux", "amd64", "/bin/bash", osRelease, nil, nil)
+
+	if !result.System.Supported {
+		t.Fatalf("expected opensuse linux to be supported")
+	}
+
+	if result.System.Profile.LinuxDistro != LinuxDistroOpenSUSE {
+		t.Fatalf("expected opensuse distro, got %q", result.System.Profile.LinuxDistro)
+	}
+
+	if result.System.Profile.PackageManager != "zypper" {
+		t.Fatalf("expected zypper package manager, got %q", result.System.Profile.PackageManager)
+	}
+}
+
 // --- Batch E: Comprehensive platform detection matrix ---
 
 func TestDetectLinuxDistroMatrix(t *testing.T) {
@@ -167,6 +184,26 @@ func TestDetectLinuxDistroMatrix(t *testing.T) {
 			name:       "nobara via id_like token",
 			osRelease:  "ID=custom-linux\nID_LIKE=\"nobara\"\n",
 			wantDistro: LinuxDistroFedora,
+		},
+		{
+			name:       "opensuse tumbleweed",
+			osRelease:  "ID=\"opensuse-tumbleweed\"\nID_LIKE=\"opensuse suse\"\nVERSION_ID=\"20260717\"\n",
+			wantDistro: LinuxDistroOpenSUSE,
+		},
+		{
+			name:       "opensuse leap",
+			osRelease:  "ID=\"opensuse-leap\"\nID_LIKE=\"suse opensuse\"\nVERSION_ID=\"15.6\"\n",
+			wantDistro: LinuxDistroOpenSUSE,
+		},
+		{
+			name:       "opensuse slowroll",
+			osRelease:  "ID=\"opensuse-slowroll\"\nID_LIKE=\"opensuse suse\"\n",
+			wantDistro: LinuxDistroOpenSUSE,
+		},
+		{
+			name:       "suse derivative via id_like token",
+			osRelease:  "ID=custom-linux\nID_LIKE=\"suse\"\n",
+			wantDistro: LinuxDistroOpenSUSE,
 		},
 		{
 			name:       "empty os-release",
@@ -267,6 +304,15 @@ func TestResolvePlatformProfileMatrix(t *testing.T) {
 			wantOS:        "linux",
 			wantPM:        "dnf",
 			wantDistro:    LinuxDistroFedora,
+			wantSupported: true,
+		},
+		{
+			name:          "opensuse profile",
+			goos:          "linux",
+			osRelease:     "ID=\"opensuse-tumbleweed\"\nID_LIKE=\"opensuse suse\"\n",
+			wantOS:        "linux",
+			wantPM:        "zypper",
+			wantDistro:    LinuxDistroOpenSUSE,
 			wantSupported: true,
 		},
 		{

--- a/internal/system/guard.go
+++ b/internal/system/guard.go
@@ -27,7 +27,7 @@ func EnsureSupportedPlatform(profile PlatformProfile) error {
 	}
 
 	if profile.OS == "linux" && !profile.Supported {
-		return fmt.Errorf("%w: Linux support is limited to Ubuntu/Debian, Arch, and Fedora/RHEL family (detected %s)", ErrUnsupportedLinuxDistro, profile.LinuxDistro)
+		return fmt.Errorf("%w: Linux support is limited to Ubuntu/Debian, Arch, Fedora/RHEL, and openSUSE/SUSE family (detected %s)", ErrUnsupportedLinuxDistro, profile.LinuxDistro)
 	}
 
 	return nil

--- a/internal/system/guard_test.go
+++ b/internal/system/guard_test.go
@@ -47,6 +47,13 @@ func TestEnsureSupportedPlatformAllowsSupportedFedoraLinux(t *testing.T) {
 	}
 }
 
+func TestEnsureSupportedPlatformAllowsSupportedOpenSUSELinux(t *testing.T) {
+	err := EnsureSupportedPlatform(PlatformProfile{OS: "linux", LinuxDistro: LinuxDistroOpenSUSE, PackageManager: "zypper", Supported: true})
+	if err != nil {
+		t.Fatalf("expected opensuse profile to be supported, got %v", err)
+	}
+}
+
 func TestEnsureSupportedPlatformRejectsUnsupportedLinuxDistro(t *testing.T) {
 	err := EnsureSupportedPlatform(PlatformProfile{OS: "linux", LinuxDistro: LinuxDistroUnknown, Supported: false})
 	if err == nil {
@@ -57,7 +64,7 @@ func TestEnsureSupportedPlatformRejectsUnsupportedLinuxDistro(t *testing.T) {
 		t.Fatalf("expected ErrUnsupportedLinuxDistro, got %v", err)
 	}
 
-	if !strings.Contains(err.Error(), "Linux support is limited to Ubuntu/Debian, Arch, and Fedora/RHEL family") {
+	if !strings.Contains(err.Error(), "Linux support is limited to Ubuntu/Debian, Arch, Fedora/RHEL, and openSUSE/SUSE family") {
 		t.Fatalf("expected distro guard message, got %q", err.Error())
 	}
 }

--- a/internal/system/install_deps.go
+++ b/internal/system/install_deps.go
@@ -15,6 +15,8 @@ func installHintGit(profile PlatformProfile) string {
 		return "sudo pacman -S --noconfirm git"
 	case profile.PackageManager == "dnf":
 		return "sudo dnf install -y git"
+	case profile.PackageManager == "zypper":
+		return "sudo zypper install -y git"
 	default:
 		return "install git from https://git-scm.com/"
 	}
@@ -33,6 +35,8 @@ func installHintCurl(profile PlatformProfile) string {
 		return "sudo pacman -S --noconfirm curl"
 	case profile.PackageManager == "dnf":
 		return "sudo dnf install -y curl"
+	case profile.PackageManager == "zypper":
+		return "sudo zypper install -y curl"
 	default:
 		return "install curl from https://curl.se/"
 	}
@@ -51,6 +55,9 @@ func installHintNode(profile PlatformProfile) string {
 		return "sudo pacman -S --noconfirm nodejs npm"
 	case profile.PackageManager == "dnf":
 		return "curl -fsSL https://rpm.nodesource.com/setup_lts.x | sudo bash - && sudo dnf install -y nodejs"
+	case profile.PackageManager == "zypper":
+		// openSUSE ships current Node.js LTS as native nodejs+npm packages.
+		return "sudo zypper install -y nodejs npm"
 	default:
 		return "install node from https://nodejs.org/"
 	}
@@ -80,6 +87,8 @@ func installHintGo(profile PlatformProfile) string {
 		return "sudo pacman -S --noconfirm go"
 	case profile.PackageManager == "dnf":
 		return "sudo dnf install -y golang"
+	case profile.PackageManager == "zypper":
+		return "sudo zypper install -y go"
 	default:
 		return "install go from https://go.dev/dl/"
 	}
@@ -140,6 +149,8 @@ func installCommandsGit(profile PlatformProfile) [][]string {
 		return [][]string{{"sudo", "pacman", "-S", "--noconfirm", "git"}}
 	case profile.PackageManager == "dnf":
 		return [][]string{{"sudo", "dnf", "install", "-y", "git"}}
+	case profile.PackageManager == "zypper":
+		return [][]string{{"sudo", "zypper", "install", "-y", "git"}}
 	default:
 		return nil
 	}
@@ -158,6 +169,8 @@ func installCommandsCurl(profile PlatformProfile) [][]string {
 		return [][]string{{"sudo", "pacman", "-S", "--noconfirm", "curl"}}
 	case profile.PackageManager == "dnf":
 		return [][]string{{"sudo", "dnf", "install", "-y", "curl"}}
+	case profile.PackageManager == "zypper":
+		return [][]string{{"sudo", "zypper", "install", "-y", "curl"}}
 	default:
 		return nil
 	}
@@ -183,6 +196,9 @@ func installCommandsNode(profile PlatformProfile) [][]string {
 			{"bash", "-c", "curl -fsSL https://rpm.nodesource.com/setup_lts.x | sudo bash -"},
 			{"sudo", "dnf", "install", "-y", "nodejs"},
 		}
+	case profile.PackageManager == "zypper":
+		// Native openSUSE packages track current Node.js LTS releases.
+		return [][]string{{"sudo", "zypper", "install", "-y", "nodejs", "npm"}}
 	default:
 		return nil
 	}
@@ -209,6 +225,8 @@ func installCommandsGo(profile PlatformProfile) [][]string {
 		return [][]string{{"sudo", "pacman", "-S", "--noconfirm", "go"}}
 	case profile.PackageManager == "dnf":
 		return [][]string{{"sudo", "dnf", "install", "-y", "golang"}}
+	case profile.PackageManager == "zypper":
+		return [][]string{{"sudo", "zypper", "install", "-y", "go"}}
 	default:
 		return nil
 	}

--- a/internal/system/install_deps_test.go
+++ b/internal/system/install_deps_test.go
@@ -29,6 +29,14 @@ func TestInstallHintGitArch(t *testing.T) {
 	}
 }
 
+func TestInstallHintGitOpenSUSE(t *testing.T) {
+	profile := PlatformProfile{OS: "linux", PackageManager: "zypper", LinuxDistro: LinuxDistroOpenSUSE}
+	hint := installHintGit(profile)
+	if !strings.Contains(hint, "zypper install -y git") {
+		t.Fatalf("installHintGit(opensuse) = %q", hint)
+	}
+}
+
 func TestInstallHintNodeDarwin(t *testing.T) {
 	profile := PlatformProfile{OS: "darwin", PackageManager: "brew"}
 	hint := installHintNode(profile)
@@ -61,6 +69,14 @@ func TestInstallHintNodeFedora(t *testing.T) {
 	}
 }
 
+func TestInstallHintNodeOpenSUSE(t *testing.T) {
+	profile := PlatformProfile{OS: "linux", PackageManager: "zypper", LinuxDistro: LinuxDistroOpenSUSE}
+	hint := installHintNode(profile)
+	if !strings.Contains(hint, "zypper install -y nodejs npm") {
+		t.Fatalf("installHintNode(opensuse) = %q, want native zypper nodejs+npm", hint)
+	}
+}
+
 func TestInstallHintBrew(t *testing.T) {
 	hint := installHintBrew()
 	if !strings.Contains(hint, "Homebrew") {
@@ -81,6 +97,14 @@ func TestInstallHintGoUbuntu(t *testing.T) {
 	hint := installHintGo(profile)
 	if !strings.Contains(hint, "apt-get install") {
 		t.Fatalf("installHintGo(ubuntu) = %q", hint)
+	}
+}
+
+func TestInstallHintGoOpenSUSE(t *testing.T) {
+	profile := PlatformProfile{OS: "linux", PackageManager: "zypper", LinuxDistro: LinuxDistroOpenSUSE}
+	hint := installHintGo(profile)
+	if !strings.Contains(hint, "zypper install -y go") {
+		t.Fatalf("installHintGo(opensuse) = %q", hint)
 	}
 }
 
@@ -125,6 +149,17 @@ func TestInstallCommandsForDepNodeFedoraHasTwoSteps(t *testing.T) {
 	}
 	if cmds[1][0] != "sudo" || cmds[1][1] != "dnf" || cmds[1][4] != "nodejs" {
 		t.Fatalf("node fedora step 2 = %v, want sudo dnf install -y nodejs", cmds[1])
+	}
+}
+
+func TestInstallCommandsForDepNodeOpenSUSEHasOneStep(t *testing.T) {
+	profile := PlatformProfile{OS: "linux", PackageManager: "zypper", LinuxDistro: LinuxDistroOpenSUSE}
+	cmds := InstallCommandsForDep("node", profile)
+	if len(cmds) != 1 {
+		t.Fatalf("node opensuse commands = %d, want 1 (native nodejs+npm)", len(cmds))
+	}
+	if cmds[0][0] != "sudo" || cmds[0][1] != "zypper" || cmds[0][4] != "nodejs" || cmds[0][5] != "npm" {
+		t.Fatalf("node opensuse command = %v, want sudo zypper install -y nodejs npm", cmds[0])
 	}
 }
 
@@ -179,6 +214,17 @@ func TestInstallCommandsForDepGitFedoraUsesDnf(t *testing.T) {
 	}
 	if cmds[0][0] != "sudo" || cmds[0][1] != "dnf" {
 		t.Fatalf("git fedora command = %v, want sudo dnf", cmds[0])
+	}
+}
+
+func TestInstallCommandsForDepGitOpenSUSEUsesZypper(t *testing.T) {
+	profile := PlatformProfile{OS: "linux", PackageManager: "zypper", LinuxDistro: LinuxDistroOpenSUSE}
+	cmds := InstallCommandsForDep("git", profile)
+	if len(cmds) != 1 {
+		t.Fatalf("git opensuse commands = %d, want 1", len(cmds))
+	}
+	if cmds[0][0] != "sudo" || cmds[0][1] != "zypper" {
+		t.Fatalf("git opensuse command = %v, want sudo zypper", cmds[0])
 	}
 }
 
@@ -281,6 +327,7 @@ func TestInstallCommandsFullMatrix(t *testing.T) {
 		{OS: "linux", PackageManager: "apt", LinuxDistro: "ubuntu"},
 		{OS: "linux", PackageManager: "pacman", LinuxDistro: "arch"},
 		{OS: "linux", PackageManager: "dnf", LinuxDistro: LinuxDistroFedora},
+		{OS: "linux", PackageManager: "zypper", LinuxDistro: LinuxDistroOpenSUSE},
 	}
 
 	deps := []string{"git", "curl", "node", "go"}


### PR DESCRIPTION
## Summary

Adds full support for openSUSE Tumbleweed, Leap, and Slowroll by detecting the distribution from `/etc/os-release` and mapping it to the **zypper** package manager.

## Changes

- **detect.go**: Added `LinuxDistroOpenSUSE` constant, `isSUSELike()` function detecting `opensuse-tumbleweed`, `opensuse-leap`, `opensuse-slowroll` IDs and `opensuse`/`suse` in ID_LIKE
- **install_deps.go**: zypper branches for installing git, curl, nodejs+npm, and Go
- **guard.go**: Updated error message to include "and openSUSE/SUSE family"
- **resolver.go**: zypper branches for uv, dependency, OpenCode, and GGA installs
- **Tests**: 15+ new test cases covering detection, install hints/commands, guard, and resolvers
- **CI**: E2E Dockerfile for opensuse/tumbleweed, CI matrix entry
- **Docs**: Updated platform support tables and error messages

## Verification

- `go test ./...`: 56 packages, 0 failures
- Native Tumbleweed tested: `doctor`, `install --dry-run`, TUI interactive install (15/16 steps OK; codegraph failure is pre-existing npm global permission issue unrelated to openSUSE)
- Commit size: 277 insertions (+), 14 deletions (-) — well under size:exception threshold

Closes #140

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for openSUSE/SUSE-based Linux systems.
  * Auto-detects openSUSE variants and uses **zypper** for dependency/tool installation.
  * Expanded install command generation for zypper across supported install paths.
* **Documentation**
  * Updated platform, quickstart, and non-interactive installer docs to include openSUSE/SUSE and zypper.
* **Tests**
  * Expanded unit and E2E coverage for openSUSE (CI matrix and dedicated E2E container), including installer command resolution and platform detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->