### PR TITLE
fix(review): quarantine legacy fix scope expansion

### DIFF
--- a/docs/review-authority-threat-model.md
+++ b/docs/review-authority-threat-model.md
@@ -60,6 +60,16 @@ The maintainer authorization is an exact LF-only eight-line binding with schema 
 
 On success it moves the complete immutable lineage into `review-transactions/quarantine/`, writes a prepared then committed audit record with the re-derived chain identity and alias-event revisions, and reads the inventory back. It does not delete or rewrite authority. The status becomes complete/authoritative only if the remaining inventory is independently clean; unrelated invalid, incomplete, compact-v2, or graph authority continues to fail closed.
 
+## Historical Complete-Fix Scope Quarantine
+
+`gentle-ai review quarantine-legacy-fix-scope` is a separate narrow maintenance operation for immutable legacy-v1 `ordinary_4r` history whose sole semantic anomaly is a historical `review/complete-fix` expanding correction paths beyond frozen genesis scope. It is a quarantine, never validation, rewrite, migration, or repair.
+
+It accepts exactly two literal anomaly sets: `complete_fix_scope_expansion`, or `complete_fix_scope_expansion,validate_fix_alias`. The combined set additionally binds the exact alias event revision and literal `review/validate-fix` operation. Reordered, missing, extra, or unrelated anomalies fail closed.
+
+The only accepted disposition is `quarantine-historical-complete-fix-scope-expansion`. The exact LF-only eleven-line authorization order is `gentle-ai.review-legacy-fix-scope-quarantine-authorization/v2`, `repository`, `lineage`, `revision`, `diagnostic`, `disposition`, `anomaly_set`, `validate_fix_alias_revision`, `validate_fix_alias_operation`, `actor`, `reason`. The command recomputes the complete chain, fix delta, frozen and expanded paths, source lineage, and HEAD under the exclusive maintenance lock before atomically publishing an audited quarantine record. It rejects symlinks, unexpected components, and non-chain event residue at `gentle-ai`, `review-transactions`, `v1`, `quarantine`, lineage, and residue components.
+
+When the source is already absent, replay takes the same exclusive lock, rechecks both source and same-lineage compact-v2 authority, strictly decodes the unique committed audit JSON, re-derives the full physical residue proof, and reads the inventory back. A prepared record found while that lock is held is stale or orphaned, never a successful replay; it cannot hide malformed or conflicting committed data. Fabricated, partial, stale-only, duplicate, or path-mismatched audit records are refused.
+
 ## Recovery And Rollback
 
 - Use `gentle-ai review recover` with an explicit predecessor lineage and revision, a distinct successor lineage, a disposition, reason, and actor. `--projection workspace|staged` selects the successor target; omission preserves the predecessor projection for compatibility. Approved predecessors require a proven scope change; invalidated predecessors remain terminal. Only escalated recovery may cross projections, and it requires the exact six-line maintainer authorization binding built from the selected projection's target identity. Authorization diagnostics identify the projection and target identity without exposing repository paths.

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -363,7 +363,7 @@ func TestRunArgsDispatchesCompactReviewFacadeBeforePlatformValidation(t *testing
 	if err := RunArgs([]string{"review", "--help"}, &output); err != nil {
 		t.Fatalf("RunArgs(review --help) error = %v", err)
 	}
-	if !strings.Contains(output.String(), "review <capabilities|start|finalize|validate|status|invalidate|abandon|recover|reclaim|reconcile-authority|dispose-result|quarantine-legacy|repair-legacy-alias|schema|bind-sdd>") {
+	if !strings.Contains(output.String(), "review <capabilities|start|finalize|validate|status|invalidate|abandon|recover|reclaim|reconcile-authority|dispose-result|quarantine-legacy|quarantine-legacy-fix-scope|repair-legacy-alias|schema|bind-sdd>") {
 		t.Fatalf("compact review help missing:\n%s", output.String())
 	}
 }

--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -226,7 +226,7 @@ var reviewFacadeCommittedTransitionHook = func(context.Context, string, string, 
 
 func RunReview(args []string, stdout io.Writer) error {
 	if len(args) == 0 || args[0] == "help" || args[0] == "-h" || args[0] == "--help" {
-		_, _ = fmt.Fprintln(stdout, "Usage: gentle-ai review <capabilities|start|finalize|validate|status|invalidate|abandon|recover|reclaim|reconcile-authority|dispose-result|quarantine-legacy|repair-legacy-alias|schema|bind-sdd> [flags]\n\nOrdinary review facade; repository scope, authority, canonical artifacts, and lifecycle transitions are derived by Go.")
+		_, _ = fmt.Fprintln(stdout, "Usage: gentle-ai review <capabilities|start|finalize|validate|status|invalidate|abandon|recover|reclaim|reconcile-authority|dispose-result|quarantine-legacy|quarantine-legacy-fix-scope|repair-legacy-alias|schema|bind-sdd> [flags]\n\nOrdinary review facade; repository scope, authority, canonical artifacts, and lifecycle transitions are derived by Go.")
 		_, _ = fmt.Fprintln(stdout, "Additive headless capabilities: gentle-ai review capture-result (with --preflight) and gentle-ai review preserve-result.")
 		return nil
 	}
@@ -323,6 +323,8 @@ func runReviewCommand(args []string, stdout io.Writer) error {
 		return RunReviewDisposeResult(args[1:], stdout)
 	case "quarantine-legacy":
 		return RunReviewLegacyQuarantine(args[1:], stdout)
+	case "quarantine-legacy-fix-scope":
+		return RunReviewLegacyFixScopeQuarantine(args[1:], stdout)
 	case "repair-legacy-alias":
 		return RunReviewLegacyAliasRepair(args[1:], stdout)
 	case "schema":

--- a/internal/cli/review_legacy_fix_scope_quarantine.go
+++ b/internal/cli/review_legacy_fix_scope_quarantine.go
@@ -1,0 +1,57 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/gentleman-programming/gentle-ai/internal/reviewtransaction"
+)
+
+type ReviewLegacyFixScopeQuarantineResult struct {
+	Operation string                                 `json:"operation"`
+	Record    reviewtransaction.CompactReclaimRecord `json:"record"`
+}
+
+func RunReviewLegacyFixScopeQuarantine(args []string, stdout io.Writer) error {
+	flags := newReviewFlagSet("review quarantine-legacy-fix-scope", stdout, "Quarantine one immutable legacy-v1 ordinary_4r lineage for exactly one authorized anomaly set: complete_fix_scope_expansion, or complete_fix_scope_expansion,validate_fix_alias with its exact historical review/validate-fix event. History is never rewritten or accepted as valid. Exact committed retries converge idempotently.")
+	cwd := flags.String("cwd", ".", "repository path")
+	lineage := flags.String("lineage", "", "legacy-v1 lineage to quarantine")
+	expected := flags.String("expected-revision", "", "exact current legacy HEAD revision")
+	diagnostic := flags.String("diagnostic", "", "exact inventory diagnostic")
+	disposition := flags.String("disposition", "", "must be quarantine-historical-complete-fix-scope-expansion")
+	anomalySet := flags.String("anomaly-set", "", "exact canonical anomaly set")
+	aliasRevision := flags.String("validate-fix-alias-revision", "", "exact historical review/validate-fix event revision")
+	aliasOperation := flags.String("validate-fix-alias-operation", "", "exact historical alias operation")
+	reason := flags.String("reason", "", "non-empty quarantine reason")
+	actor := flags.String("actor", "", "quarantine actor")
+	authorization := flags.String("maintainer-authorization", "", "exact eleven-line LF-only binding: gentle-ai.review-legacy-fix-scope-quarantine-authorization/v2, repository, lineage, revision, diagnostic, disposition, anomaly_set, validate_fix_alias_revision, validate_fix_alias_operation, actor, reason")
+	if err := parseReviewFlags(flags, args); err != nil {
+		return err
+	}
+	if reviewHelpRequested(args) {
+		return nil
+	}
+	if flags.NArg() != 0 {
+		return fmt.Errorf("unexpected review quarantine-legacy-fix-scope argument %q", flags.Arg(0))
+	}
+	for _, required := range []string{*lineage, *expected, *diagnostic, *disposition, *anomalySet, *reason, *actor, *authorization} {
+		if strings.TrimSpace(required) == "" {
+			return errors.New("review quarantine-legacy-fix-scope requires --lineage, --expected-revision, --diagnostic, --disposition, --anomaly-set, --reason, --actor, and --maintainer-authorization")
+		}
+	}
+	root, err := (reviewtransaction.SnapshotBuilder{Repo: *cwd}).ResolveRepositoryRoot(context.Background())
+	if err != nil {
+		return fmt.Errorf("resolve review repository root: %w", err)
+	}
+	record, err := reviewtransaction.QuarantineHistoricalLegacyFixScope(context.Background(), root, reviewtransaction.LegacyFixScopeQuarantineRequest{LineageID: *lineage, ExpectedRevision: *expected, ExpectedDiagnostic: *diagnostic, Disposition: *disposition, ExpectedAnomalySet: *anomalySet, ExpectedValidateFixAliasRevision: *aliasRevision, ExpectedValidateFixAliasOperation: *aliasOperation, Reason: *reason, Actor: *actor, MaintainerAuthorization: *authorization})
+	if err != nil {
+		if record.QuarantinePath != "" {
+			_ = encodeReviewJSON(stdout, ReviewLegacyFixScopeQuarantineResult{Operation: "review/quarantine-legacy-fix-scope", Record: record})
+		}
+		return err
+	}
+	return encodeReviewJSON(stdout, ReviewLegacyFixScopeQuarantineResult{Operation: "review/quarantine-legacy-fix-scope", Record: record})
+}

--- a/internal/cli/review_legacy_fix_scope_quarantine_test.go
+++ b/internal/cli/review_legacy_fix_scope_quarantine_test.go
@@ -1,0 +1,22 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestReviewQuarantineLegacyFixScopeContract(t *testing.T) {
+	var output bytes.Buffer
+	if err := RunReview([]string{"quarantine-legacy-fix-scope"}, &output); err == nil || !strings.Contains(err.Error(), "requires --lineage") {
+		t.Fatalf("missing input error = %v", err)
+	}
+	if err := RunReview([]string{"quarantine-legacy-fix-scope", "--help"}, &output); err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"complete_fix_scope_expansion", "validate_fix_alias", "quarantine-historical-complete-fix-scope-expansion", "gentle-ai.review-legacy-fix-scope-quarantine-authorization/v2, repository, lineage, revision, diagnostic, disposition, anomaly_set, validate_fix_alias_revision, validate_fix_alias_operation, actor, reason"} {
+		if !strings.Contains(output.String(), want) {
+			t.Fatalf("help missing %q", want)
+		}
+	}
+}

--- a/internal/reviewtransaction/compact_reclaim.go
+++ b/internal/reviewtransaction/compact_reclaim.go
@@ -66,6 +66,9 @@ type CompactReclaimRecord struct {
 	// LegacyAliasRepair carries the natively re-derived proof for the narrow
 	// historical v1 operation-alias quarantine.
 	LegacyAliasRepair *LegacyAliasRepairProof `json:"legacy_alias_repair,omitempty"`
+	// LegacyFixScopeQuarantine carries the proof for the narrowly authorized
+	// complete-fix scope-expansion quarantine.
+	LegacyFixScopeQuarantine *LegacyFixScopeQuarantineProof `json:"legacy_fix_scope_quarantine,omitempty"`
 }
 
 // compactAuthoritativeArtifact reports whether a store-entry name carries
@@ -148,15 +151,14 @@ func ReclaimIncompleteCompactStore(ctx context.Context, repo string, request Com
 // populated prepared record alongside a non-nil error.
 func quarantineCompactStoreEntry(base, dir string, record CompactReclaimRecord) (CompactReclaimRecord, error) {
 	quarantineRoot := filepath.Join(base, "quarantine")
+	if err := ensureCanonicalReviewQuarantineRoot(base, quarantineRoot); err != nil {
+		return CompactReclaimRecord{}, err
+	}
 	if err := os.MkdirAll(quarantineRoot, 0o755); err != nil {
 		return CompactReclaimRecord{}, err
 	}
-	quarantineRootInfo, err := os.Lstat(quarantineRoot)
-	if err != nil {
+	if err := ensureCanonicalReviewQuarantineRoot(base, quarantineRoot); err != nil {
 		return CompactReclaimRecord{}, err
-	}
-	if quarantineRootInfo.Mode()&os.ModeSymlink != 0 || !quarantineRootInfo.IsDir() {
-		return CompactReclaimRecord{}, fmt.Errorf("review quarantine refused unsafe quarantine root %q", quarantineRoot)
 	}
 	if err := SyncReviewDirectory(base); err != nil {
 		return CompactReclaimRecord{}, fmt.Errorf("sync review authority root after quarantine creation: %w", err)
@@ -196,6 +198,40 @@ func quarantineCompactStoreEntry(base, dir string, record CompactReclaimRecord) 
 		return record, fmt.Errorf("residue was quarantined at %s but the reclaim audit record could not be marked committed: %w", quarantineDir, err)
 	}
 	return committed, nil
+}
+
+// ensureCanonicalReviewQuarantineRoot rejects symlinked authority components
+// before a quarantine operation can create, inspect, or rename inside them.
+func ensureCanonicalReviewQuarantineRoot(base, quarantineRoot string) error {
+	commonDir := filepath.Dir(filepath.Dir(base))
+	if filepath.Clean(base) != filepath.Join(commonDir, "gentle-ai", "review-transactions") ||
+		filepath.Clean(quarantineRoot) != filepath.Join(base, "quarantine") {
+		return errors.New("review quarantine refused noncanonical authority root")
+	}
+	for _, component := range []string{"gentle-ai", "review-transactions", "quarantine"} {
+		path := filepath.Join(commonDir, component)
+		if component == "review-transactions" {
+			path = base
+		}
+		if component == "quarantine" {
+			path = quarantineRoot
+		}
+		info, err := os.Lstat(path)
+		if os.IsNotExist(err) {
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("inspect review quarantine root component %q: %w", component, err)
+		}
+		if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+			return fmt.Errorf("review quarantine refused unsafe authority root component %q", component)
+		}
+		canonical, err := filepath.EvalSymlinks(path)
+		if err != nil || filepath.Clean(canonical) != path {
+			return fmt.Errorf("review quarantine refused noncanonical authority root component %q", component)
+		}
+	}
+	return nil
 }
 
 func persistCompactReclaimRecord(record CompactReclaimRecord) error {

--- a/internal/reviewtransaction/legacy_fix_scope_quarantine.go
+++ b/internal/reviewtransaction/legacy_fix_scope_quarantine.go
@@ -1,0 +1,606 @@
+package reviewtransaction
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	legacyFixScopeQuarantineAuthorizationSchema = "gentle-ai.review-legacy-fix-scope-quarantine-authorization/v2"
+	LegacyFixScopeQuarantineDisposition         = "quarantine-historical-complete-fix-scope-expansion"
+	legacyFixScopeScopeOnlyAnomalySet           = "complete_fix_scope_expansion"
+	legacyFixScopeCombinedAnomalySet            = "complete_fix_scope_expansion,validate_fix_alias"
+)
+
+var legacyFixScopeBeforeMaintenance = func() {}
+var legacyFixScopeAfterMaintenance = func() {}
+
+// LegacyFixScopeQuarantineRequest names an exact immutable legacy-v1 source.
+type LegacyFixScopeQuarantineRequest struct {
+	LineageID, ExpectedRevision, ExpectedDiagnostic, Disposition string
+	ExpectedAnomalySet, ExpectedValidateFixAliasRevision         string
+	ExpectedValidateFixAliasOperation, Reason, Actor             string
+	MaintainerAuthorization                                      string
+	QuarantinedAt                                                time.Time
+}
+
+// LegacyFixScopeQuarantineProof is fully re-derived from the immutable chain.
+type LegacyFixScopeQuarantineProof struct {
+	LineageID               string                  `json:"lineage_id"`
+	HeadRevision            string                  `json:"head_revision"`
+	ChainIdentity           string                  `json:"chain_identity"`
+	EventRevision           string                  `json:"event_revision"`
+	PreviousRevision        string                  `json:"previous_revision"`
+	Operation               string                  `json:"operation"`
+	FrozenGenesisPaths      []string                `json:"frozen_genesis_paths"`
+	ExpandedCorrectionPaths []string                `json:"expanded_correction_paths"`
+	FixDeltaHash            string                  `json:"fix_delta_hash"`
+	Diagnostic              string                  `json:"diagnostic"`
+	Disposition             string                  `json:"disposition"`
+	AnomalySet              string                  `json:"anomaly_set"`
+	Anomalies               []LegacyFixScopeAnomaly `json:"anomalies"`
+}
+
+type LegacyFixScopeAnomaly struct {
+	Kind               string `json:"kind"`
+	EventRevision      string `json:"event_revision"`
+	Operation          string `json:"operation"`
+	CanonicalOperation string `json:"canonical_operation"`
+}
+
+func legacyFixScopeQuarantineAuthorizationBinding(repository, lineage, revision, diagnostic, disposition, anomalySet, aliasRevision, aliasOperation, actor, reason string) string {
+	return legacyFixScopeQuarantineAuthorizationSchema + "\nrepository=" + repository +
+		"\nlineage=" + lineage + "\nrevision=" + revision + "\ndiagnostic=" + diagnostic +
+		"\ndisposition=" + disposition + "\nanomaly_set=" + anomalySet +
+		"\nvalidate_fix_alias_revision=" + aliasRevision + "\nvalidate_fix_alias_operation=" + aliasOperation +
+		"\nactor=" + strings.TrimSpace(actor) + "\nreason=" + strings.TrimSpace(reason)
+}
+
+// QuarantineHistoricalLegacyFixScope quarantines, but never validates, the
+// only approved complete-fix scope-expansion classes.
+func QuarantineHistoricalLegacyFixScope(ctx context.Context, repo string, request LegacyFixScopeQuarantineRequest) (CompactReclaimRecord, error) {
+	if err := ctx.Err(); err != nil {
+		return CompactReclaimRecord{}, err
+	}
+	if err := validateLineageID(request.LineageID); err != nil {
+		return CompactReclaimRecord{}, err
+	}
+	if !validSHA256(request.ExpectedRevision) {
+		return CompactReclaimRecord{}, errors.New("review quarantine-legacy-fix-scope requires an exact current HEAD revision")
+	}
+	if strings.TrimSpace(request.Reason) == "" || strings.TrimSpace(request.Actor) == "" || strings.ContainsAny(request.Reason, "\r\n") || strings.ContainsAny(request.Actor, "\r\n") {
+		return CompactReclaimRecord{}, errors.New("review quarantine-legacy-fix-scope requires non-empty LF-only single-line actor and reason authorization fields")
+	}
+	if request.Disposition != LegacyFixScopeQuarantineDisposition {
+		return CompactReclaimRecord{}, errors.New("review quarantine-legacy-fix-scope supports only the historical complete-fix scope-expansion diagnostic and disposition")
+	}
+	if err := validateLegacyFixScopeAuthorizationClass(request); err != nil {
+		return CompactReclaimRecord{}, err
+	}
+	base, repository, err := reviewAuthorityRoot(ctx, repo)
+	if err != nil {
+		return CompactReclaimRecord{}, err
+	}
+	if err := canonicalLegacyFixScopeAuthorityRoots(base); err != nil {
+		return CompactReclaimRecord{}, err
+	}
+	legacyFixScopeBeforeMaintenance()
+	maintenance, err := acquireMaintenanceLock(ctx, compactMaintenanceLockPath(base), maintenanceExclusive)
+	if err != nil {
+		return CompactReclaimRecord{}, err
+	}
+	defer maintenance.Release()
+	// The exclusive authority lock covers both the source/replay decision and the
+	// prepared-to-committed publication window.
+	legacyFixScopeAfterMaintenance()
+	if err := canonicalLegacyFixScopeAuthorityRoots(base); err != nil {
+		return CompactReclaimRecord{}, err
+	}
+	dir, exists, err := canonicalLegacyFixScopeDir(base, request.LineageID)
+	if err != nil {
+		return CompactReclaimRecord{}, err
+	}
+	if err := rejectLegacyFixScopeCompactAuthority(base, request.LineageID); err != nil {
+		return CompactReclaimRecord{}, err
+	}
+	if !exists {
+		record, err := replayCommittedLegacyFixScopeQuarantine(base, repository, request)
+		if err != nil {
+			return CompactReclaimRecord{}, err
+		}
+		return record, verifyHistoricalLegacyFixScopeReadback(ctx, repo, request.LineageID, record)
+	}
+	if err := validateLegacyFixScopePhysicalStore(dir); err != nil {
+		return CompactReclaimRecord{}, err
+	}
+	localLock, err := acquireLocalStoreLock(filepath.Join(dir, "LOCK"))
+	if err != nil {
+		return CompactReclaimRecord{}, fmt.Errorf("review quarantine-legacy-fix-scope refused active ownership: %w", err)
+	}
+	locked := true
+	defer func() {
+		if locked {
+			_ = localLock.release()
+		}
+	}()
+	if err := validateLegacyFixScopePhysicalStore(dir); err != nil {
+		return CompactReclaimRecord{}, err
+	}
+	proof, err := inspectHistoricalLegacyFixScope(Store{Dir: dir, lineageID: request.LineageID, repo: repository, readOnly: true}, request.ExpectedRevision)
+	if err != nil {
+		return CompactReclaimRecord{}, err
+	}
+	proof.Disposition = request.Disposition
+	if request.ExpectedDiagnostic != proof.Diagnostic {
+		return CompactReclaimRecord{}, errors.New("review quarantine-legacy-fix-scope supports only the exact inventory diagnostic for the historical complete-fix scope-expansion")
+	}
+	if !legacyFixScopeAuthorizationMatchesProof(request, proof) {
+		return CompactReclaimRecord{}, errors.New("review quarantine-legacy-fix-scope requires an exact anomaly set and validate-fix alias event binding")
+	}
+	if request.MaintainerAuthorization != legacyFixScopeQuarantineAuthorizationBinding(repository, request.LineageID, request.ExpectedRevision, request.ExpectedDiagnostic, request.Disposition, request.ExpectedAnomalySet, request.ExpectedValidateFixAliasRevision, request.ExpectedValidateFixAliasOperation, request.Actor, request.Reason) {
+		return CompactReclaimRecord{}, errors.New("review quarantine-legacy-fix-scope requires an exact maintainer authorization binding")
+	}
+	items, err := os.ReadDir(dir)
+	if err != nil {
+		return CompactReclaimRecord{}, err
+	}
+	residue := make([]string, 0, len(items))
+	for _, item := range items {
+		residue = append(residue, item.Name())
+	}
+	sort.Strings(residue)
+	if request.QuarantinedAt.IsZero() {
+		request.QuarantinedAt = time.Now().UTC()
+	}
+	if err := localLock.release(); err != nil {
+		return CompactReclaimRecord{}, fmt.Errorf("release legacy lineage lock before quarantine: %w", err)
+	}
+	locked = false
+	if err := canonicalLegacyFixScopeAuthorityRoots(base); err != nil {
+		return CompactReclaimRecord{}, err
+	}
+	record, err := quarantineCompactStoreEntry(base, dir, CompactReclaimRecord{Schema: CompactReclaimRecordSchema, Status: CompactReclaimPrepared, LineageID: request.LineageID, Reason: strings.TrimSpace(request.Reason), Actor: strings.TrimSpace(request.Actor), ReclaimedAt: request.QuarantinedAt.UTC(), SourcePath: dir, Residue: residue, LegacyFixScopeQuarantine: &proof})
+	if err != nil {
+		return record, err
+	}
+	if err := validateCommittedLegacyFixScopeReplay(record, record.QuarantinePath, filepath.Join(base, "v1"), repository, request); err != nil {
+		return record, err
+	}
+	if err := verifyHistoricalLegacyFixScopeReadback(ctx, repo, request.LineageID, record); err != nil {
+		return record, err
+	}
+	return record, nil
+}
+
+func rejectLegacyFixScopeCompactAuthority(base, lineage string) error {
+	if _, err := os.Lstat(filepath.Join(base, "v2", lineage)); err == nil {
+		return fmt.Errorf("review quarantine-legacy-fix-scope refused: lineage %q also exists in compact-v2 authority", lineage)
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("inspect same-lineage compact authority: %w", err)
+	}
+	return nil
+}
+
+func canonicalLegacyFixScopeAuthorityRoots(base string) error {
+	if err := ensureCanonicalReviewQuarantineRoot(base, filepath.Join(base, "quarantine")); err != nil {
+		return err
+	}
+	for _, component := range []string{"v1"} {
+		path := filepath.Join(base, component)
+		info, err := os.Lstat(path)
+		if os.IsNotExist(err) {
+			continue
+		}
+		if err != nil {
+			return err
+		}
+		if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+			return fmt.Errorf("review quarantine-legacy-fix-scope refused unsafe authority root component %q", component)
+		}
+		canonical, err := filepath.EvalSymlinks(path)
+		if err != nil || filepath.Clean(canonical) != path {
+			return fmt.Errorf("review quarantine-legacy-fix-scope refused noncanonical authority root component %q", component)
+		}
+	}
+	return nil
+}
+
+func canonicalLegacyFixScopeDir(base, lineage string) (string, bool, error) {
+	root := filepath.Join(base, "v1")
+	info, err := os.Lstat(root)
+	if os.IsNotExist(err) {
+		return filepath.Join(root, lineage), false, nil
+	}
+	if err != nil {
+		return "", false, err
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		return "", false, errors.New("review quarantine-legacy-fix-scope refused unsafe authority root component \"v1\"")
+	}
+	dir := filepath.Join(root, lineage)
+	info, err = os.Lstat(dir)
+	if os.IsNotExist(err) {
+		return dir, false, nil
+	}
+	if err != nil {
+		return "", false, err
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		return "", false, errors.New("review quarantine-legacy-fix-scope refused symlinked or non-directory lineage component")
+	}
+	canonical, err := filepath.EvalSymlinks(dir)
+	if err != nil || filepath.Clean(canonical) != dir {
+		return "", false, errors.New("review quarantine-legacy-fix-scope refused noncanonical lineage component")
+	}
+	return dir, true, nil
+}
+
+func validateLegacyFixScopePhysicalStore(dir string) error {
+	info, err := os.Lstat(dir)
+	if err != nil || info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		return errors.New("review quarantine-legacy-fix-scope refused unsafe physical lineage directory")
+	}
+	canonical, err := filepath.EvalSymlinks(dir)
+	if err != nil || filepath.Clean(canonical) != dir {
+		return errors.New("review quarantine-legacy-fix-scope refused noncanonical physical lineage directory")
+	}
+	for _, name := range []string{"HEAD", "events", "LOCK"} {
+		directory := name == "events"
+		path := filepath.Join(dir, name)
+		info, err := os.Lstat(path)
+		if os.IsNotExist(err) && name == "LOCK" {
+			continue
+		}
+		if err != nil || info.Mode()&os.ModeSymlink != 0 || info.IsDir() != directory || !directory && !info.Mode().IsRegular() {
+			return fmt.Errorf("review quarantine-legacy-fix-scope refused unsafe physical lineage child %q", name)
+		}
+		canonical, err := filepath.EvalSymlinks(path)
+		if err != nil || filepath.Clean(canonical) != path {
+			return fmt.Errorf("review quarantine-legacy-fix-scope refused noncanonical physical lineage child %q", name)
+		}
+	}
+	items, err := os.ReadDir(dir)
+	if err != nil {
+		return err
+	}
+	for _, item := range items {
+		if item.Name() != "HEAD" && item.Name() != "events" && item.Name() != "LOCK" {
+			return fmt.Errorf("review quarantine-legacy-fix-scope refused unexpected physical lineage child %q", item.Name())
+		}
+	}
+	return nil
+}
+
+func validateLegacyFixScopePhysicalEvent(store Store, revision string) error {
+	path := filepath.Join(store.Dir, "events", strings.TrimPrefix(revision, "sha256:")+".json")
+	info, err := os.Lstat(path)
+	if err != nil || info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+		return fmt.Errorf("review quarantine-legacy-fix-scope refused unsafe physical event %q", revision)
+	}
+	canonical, err := filepath.EvalSymlinks(path)
+	if err != nil || filepath.Clean(canonical) != path {
+		return fmt.Errorf("review quarantine-legacy-fix-scope refused noncanonical physical event %q", revision)
+	}
+	return nil
+}
+
+func inspectHistoricalLegacyFixScope(store Store, expectedHead string) (LegacyFixScopeQuarantineProof, error) {
+	if err := validateLegacyFixScopePhysicalStore(store.Dir); err != nil {
+		return LegacyFixScopeQuarantineProof{}, err
+	}
+	head, err := readRevision(filepath.Join(store.Dir, "HEAD"))
+	if err != nil {
+		return LegacyFixScopeQuarantineProof{}, err
+	}
+	if head != expectedHead {
+		return LegacyFixScopeQuarantineProof{}, fmt.Errorf("%w: expected legacy HEAD %q, current %q", ErrConcurrentUpdate, expectedHead, head)
+	}
+	var reverseRecords []Record
+	var reverseRevisions []string
+	visited := map[string]bool{}
+	for revision := head; revision != ""; {
+		if visited[revision] {
+			return LegacyFixScopeQuarantineProof{}, errors.New("review quarantine-legacy-fix-scope refused: predecessor cycle")
+		}
+		visited[revision] = true
+		if err := validateLegacyFixScopePhysicalEvent(store, revision); err != nil {
+			return LegacyFixScopeQuarantineProof{}, err
+		}
+		record, loaded, err := store.loadRevision(revision)
+		if err != nil {
+			return LegacyFixScopeQuarantineProof{}, fmt.Errorf("review quarantine-legacy-fix-scope refused: load revision %s: %w", revision, err)
+		}
+		reverseRecords, reverseRevisions, revision = append(reverseRecords, record), append(reverseRevisions, loaded), record.PreviousRevision
+	}
+	if err := validateLegacyFixScopePhysicalEvents(store, reverseRevisions); err != nil {
+		return LegacyFixScopeQuarantineProof{}, err
+	}
+	records, revisions := make([]Record, len(reverseRecords)), make([]string, len(reverseRevisions))
+	for i := range reverseRecords {
+		n := len(reverseRecords) - 1 - i
+		records[i], revisions[i] = reverseRecords[n], reverseRevisions[n]
+	}
+	if len(records) == 0 || !validInitialStoreRecord(records[0]) || records[0].Transaction.LineageID != store.lineageID {
+		return LegacyFixScopeQuarantineProof{}, errors.New("review quarantine-legacy-fix-scope refused: chain genesis is invalid")
+	}
+	var proof *LegacyFixScopeQuarantineProof
+	for i := 1; i < len(records); i++ {
+		if records[i].PreviousRevision != revisions[i-1] {
+			return LegacyFixScopeQuarantineProof{}, errors.New("review quarantine-legacy-fix-scope refused: predecessor revision is discontinuous")
+		}
+		err := validatePersistedV1Successor(records[i-1].Transaction, records[i].Transaction, records[i].Operation, i)
+		if err == nil {
+			continue
+		}
+		if proof != nil && proof.AnomalySet == legacyFixScopeScopeOnlyAnomalySet && validateHistoricalFixScopeSuccessor(records[i-1].Transaction, records[i].Transaction, records[i].Operation) == nil {
+			proof.AnomalySet = legacyFixScopeCombinedAnomalySet
+			proof.Anomalies = append(proof.Anomalies, LegacyFixScopeAnomaly{"validate_fix_alias", revisions[i], records[i].Operation, "review/validate-fix-delta"})
+			continue
+		}
+		expanded, frozen, scopeErr := historicalCompleteFixScopeExpansion(records[i-1].Transaction, records[i].Transaction, records[i].Operation)
+		if scopeErr != nil || proof != nil {
+			return LegacyFixScopeQuarantineProof{}, fmt.Errorf("review quarantine-legacy-fix-scope refused unsupported successor anomaly at %s: %w", revisions[i], err)
+		}
+		proof = &LegacyFixScopeQuarantineProof{LineageID: store.lineageID, HeadRevision: head, ChainIdentity: chainIdentity(revisions), EventRevision: revisions[i], PreviousRevision: revisions[i-1], Operation: records[i].Operation, FrozenGenesisPaths: frozen, ExpandedCorrectionPaths: expanded, FixDeltaHash: records[i].Transaction.FixDeltaHash, Diagnostic: legacyFixScopeInventoryDiagnostic(revisions[i]), AnomalySet: legacyFixScopeScopeOnlyAnomalySet, Anomalies: []LegacyFixScopeAnomaly{{"complete_fix_scope_expansion", revisions[i], records[i].Operation, "review/complete-fix"}}}
+	}
+	if proof == nil {
+		return LegacyFixScopeQuarantineProof{}, errors.New("review quarantine-legacy-fix-scope refused: lineage has no supported historical complete-fix scope expansion")
+	}
+	return *proof, nil
+}
+
+func validateLegacyFixScopePhysicalEvents(store Store, revisions []string) error {
+	expected := make(map[string]bool, len(revisions))
+	for _, revision := range revisions {
+		expected[strings.TrimPrefix(revision, "sha256:")+".json"] = true
+	}
+	items, err := os.ReadDir(filepath.Join(store.Dir, "events"))
+	if err != nil {
+		return err
+	}
+	for _, item := range items {
+		path := filepath.Join(store.Dir, "events", item.Name())
+		info, err := os.Lstat(path)
+		if err != nil || info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+			return fmt.Errorf("review quarantine-legacy-fix-scope refused unsafe physical event component %q", item.Name())
+		}
+		if !expected[item.Name()] {
+			return fmt.Errorf("review quarantine-legacy-fix-scope refused non-HEAD-chain physical event %q", item.Name())
+		}
+		delete(expected, item.Name())
+	}
+	if len(expected) != 0 {
+		return errors.New("review quarantine-legacy-fix-scope refused missing physical chain event")
+	}
+	return nil
+}
+
+func legacyFixScopeInventoryDiagnostic(revision string) string {
+	return "review chain successor " + revision + ": " + ErrInvalidSuccessor.Error() + ": unsupported historical v1 operation alias"
+}
+
+func validateHistoricalFixScopeSuccessor(previous, next Transaction, operation string) error {
+	if operation != "review/validate-fix" || previous.Mode != ModeOrdinary4R || previous.State != StateFixValidating || (next.State != StateReadyFinalVerification && next.State != StateEscalated) || next.OriginalCriteria != nil || next.CorrectionRegression != nil {
+		return errors.New("not a historical fix-scope successor")
+	}
+	return validateSuccessor(previous, next, "review/validate-fix-delta")
+}
+
+func historicalCompleteFixScopeExpansion(previous, next Transaction, operation string) ([]string, []string, error) {
+	if operation != "review/complete-fix" || previous.Mode != ModeOrdinary4R || previous.State != StateFixing || next.State != StateFixValidating || !equalStrings(previous.GenesisPaths, next.GenesisPaths) {
+		return nil, nil, errors.New("not an ordinary_4r complete-fix scope expansion")
+	}
+	frozen := previous.GenesisPaths
+	if frozen == nil {
+		frozen = previous.Snapshot.Paths
+	}
+	canonicalFrozen, err := canonicalPaths(frozen)
+	if err != nil || !equalStrings(canonicalFrozen, frozen) {
+		return nil, nil, errors.New("frozen genesis paths are malformed")
+	}
+	canonicalNext, err := canonicalPaths(next.Snapshot.Paths)
+	if err != nil || !equalStrings(canonicalNext, next.Snapshot.Paths) {
+		return nil, nil, errors.New("correction paths are malformed")
+	}
+	allowed := map[string]struct{}{}
+	for _, path := range frozen {
+		allowed[path] = struct{}{}
+	}
+	expanded := []string{}
+	for _, path := range next.Snapshot.Paths {
+		if _, ok := allowed[path]; !ok {
+			expanded = append(expanded, path)
+		}
+	}
+	if len(expanded) == 0 {
+		return nil, nil, errors.New("correction does not expand frozen genesis scope")
+	}
+	derived, err := canonicalPaths(append(append([]string{}, frozen...), expanded...))
+	if err != nil {
+		return nil, nil, err
+	}
+	left, right := previous, next
+	left.GenesisPaths, right.GenesisPaths = derived, derived
+	if err := validateSuccessor(left, right, operation); err != nil {
+		return nil, nil, err
+	}
+	return expanded, append([]string{}, frozen...), nil
+}
+
+func validateLegacyFixScopeAuthorizationClass(request LegacyFixScopeQuarantineRequest) error {
+	switch request.ExpectedAnomalySet {
+	case legacyFixScopeScopeOnlyAnomalySet:
+		if request.ExpectedValidateFixAliasRevision != "" || request.ExpectedValidateFixAliasOperation != "" {
+			return errors.New("review quarantine-legacy-fix-scope scope-only anomaly set forbids validate-fix alias fields")
+		}
+	case legacyFixScopeCombinedAnomalySet:
+		if !validSHA256(request.ExpectedValidateFixAliasRevision) || request.ExpectedValidateFixAliasOperation != "review/validate-fix" {
+			return errors.New("review quarantine-legacy-fix-scope combined anomaly set requires the exact validate-fix alias revision and operation")
+		}
+	default:
+		return errors.New("review quarantine-legacy-fix-scope supports only canonical scope-only or scope-plus-validate-fix anomaly sets")
+	}
+	return nil
+}
+
+func legacyFixScopeAuthorizationMatchesProof(request LegacyFixScopeQuarantineRequest, proof LegacyFixScopeQuarantineProof) bool {
+	if request.ExpectedAnomalySet != proof.AnomalySet || len(proof.Anomalies) == 0 || proof.Anomalies[0].Kind != "complete_fix_scope_expansion" {
+		return false
+	}
+	if proof.AnomalySet == legacyFixScopeScopeOnlyAnomalySet {
+		return len(proof.Anomalies) == 1
+	}
+	return len(proof.Anomalies) == 2 && proof.Anomalies[1].Kind == "validate_fix_alias" && request.ExpectedValidateFixAliasRevision == proof.Anomalies[1].EventRevision && request.ExpectedValidateFixAliasOperation == proof.Anomalies[1].Operation
+}
+
+func verifyHistoricalLegacyFixScopeReadback(ctx context.Context, repo, lineage string, record CompactReclaimRecord) error {
+	if record.Status != CompactReclaimCommitted || record.LegacyFixScopeQuarantine == nil {
+		return errors.New("review quarantine-legacy-fix-scope did not commit an auditable quarantine record")
+	}
+	report, err := InventoryAuthority(ctx, repo)
+	if err != nil {
+		return fmt.Errorf("read back authority inventory after fix-scope quarantine: %w", err)
+	}
+	if !report.Complete || !report.Authoritative {
+		return errors.New("read back authority inventory after fix-scope quarantine is incomplete or non-authoritative")
+	}
+	for _, entry := range report.Entries {
+		if entry.LineageID == lineage {
+			return fmt.Errorf("read back authority inventory still contains quarantined lineage %q", lineage)
+		}
+	}
+	return nil
+}
+
+func replayCommittedLegacyFixScopeQuarantine(base, repository string, request LegacyFixScopeQuarantineRequest) (CompactReclaimRecord, error) {
+	if err := canonicalLegacyFixScopeAuthorityRoots(base); err != nil {
+		return CompactReclaimRecord{}, err
+	}
+	versionRoot, quarantineRoot := filepath.Join(base, "v1"), filepath.Join(base, "quarantine")
+	entries, err := os.ReadDir(quarantineRoot)
+	if err != nil {
+		return CompactReclaimRecord{}, fmt.Errorf("inspect quarantine for legacy fix-scope replay: %w", err)
+	}
+	var matched *CompactReclaimRecord
+	stalePrepared := false
+	for _, entry := range entries {
+		path := filepath.Join(quarantineRoot, entry.Name())
+		info, err := os.Lstat(path)
+		candidate := strings.HasPrefix(entry.Name(), request.LineageID+"-")
+		canonical, canonicalErr := filepath.EvalSymlinks(path)
+		if err != nil || canonicalErr != nil || info.Mode()&os.ModeSymlink != 0 || !info.IsDir() || filepath.Clean(canonical) != path {
+			if candidate {
+				return CompactReclaimRecord{}, errors.New("review quarantine-legacy-fix-scope refused unsafe quarantine record directory")
+			}
+			continue
+		}
+		recordPath := filepath.Join(path, "reclaim-record.json")
+		recordInfo, recordErr := os.Lstat(recordPath)
+		if recordErr != nil || recordInfo.Mode()&os.ModeSymlink != 0 || !recordInfo.Mode().IsRegular() {
+			if candidate {
+				return CompactReclaimRecord{}, errors.New("review quarantine-legacy-fix-scope refused unsafe committed replay record")
+			}
+			continue
+		}
+		payload, err := os.ReadFile(recordPath)
+		if err != nil {
+			if candidate {
+				return CompactReclaimRecord{}, fmt.Errorf("review quarantine-legacy-fix-scope refused unreadable committed replay record: %w", err)
+			}
+			continue
+		}
+		record, err := decodeLegacyFixScopeReclaimRecord(payload)
+		if err != nil {
+			if candidate {
+				return CompactReclaimRecord{}, fmt.Errorf("review quarantine-legacy-fix-scope refused corrupt replay record: %w", err)
+			}
+			continue
+		}
+		if record.LineageID != request.LineageID && (record.LegacyFixScopeQuarantine == nil || record.LegacyFixScopeQuarantine.LineageID != request.LineageID) {
+			continue
+		}
+		if record.Status == CompactReclaimPrepared {
+			// Under the caller's exclusive maintenance lock, this is an orphan,
+			// not an in-flight replay, and cannot prove a successful quarantine.
+			stalePrepared = true
+			continue
+		}
+		if err := validateCommittedLegacyFixScopeReplay(record, path, versionRoot, repository, request); err != nil {
+			return CompactReclaimRecord{}, err
+		}
+		if matched != nil {
+			return CompactReclaimRecord{}, errors.New("review quarantine-legacy-fix-scope refused duplicate committed replay records")
+		}
+		copy := record
+		matched = &copy
+	}
+	if matched == nil {
+		if stalePrepared {
+			return CompactReclaimRecord{}, errors.New("review quarantine-legacy-fix-scope refused: stale or orphan prepared quarantine record has no committed replay")
+		}
+		return CompactReclaimRecord{}, fmt.Errorf("review quarantine-legacy-fix-scope refused: lineage %q is absent and no committed quarantine record matches", request.LineageID)
+	}
+	return *matched, nil
+}
+
+func decodeLegacyFixScopeReclaimRecord(payload []byte) (CompactReclaimRecord, error) {
+	decoder := json.NewDecoder(bytes.NewReader(payload))
+	decoder.DisallowUnknownFields()
+	var record CompactReclaimRecord
+	if err := decoder.Decode(&record); err != nil {
+		return CompactReclaimRecord{}, err
+	}
+	if err := decoder.Decode(new(struct{})); err != io.EOF {
+		if err == nil {
+			return CompactReclaimRecord{}, errors.New("multiple JSON values")
+		}
+		return CompactReclaimRecord{}, err
+	}
+	return record, nil
+}
+
+func validateCommittedLegacyFixScopeReplay(record CompactReclaimRecord, quarantinePath, versionRoot, repository string, request LegacyFixScopeQuarantineRequest) error {
+	proof := record.LegacyFixScopeQuarantine
+	if record.Schema != CompactReclaimRecordSchema || record.Status != CompactReclaimCommitted || record.LineageID != request.LineageID || record.ReclaimedAt.IsZero() || proof == nil || record.InvalidRecoveryEdge != nil || record.MalformedRecoveryAuthorization != nil || record.PristineAbandonment != nil || record.MalformedLegacyFreeze != nil || record.LegacyAliasRepair != nil {
+		return errors.New("review quarantine-legacy-fix-scope refused incomplete or mismatched committed replay record")
+	}
+	if record.SourcePath != filepath.Join(versionRoot, request.LineageID) || record.QuarantinePath != quarantinePath || record.Reason != strings.TrimSpace(request.Reason) || record.Actor != strings.TrimSpace(request.Actor) {
+		return errors.New("review quarantine-legacy-fix-scope refused mismatched committed replay audit path or authorization")
+	}
+	residuePath := filepath.Join(quarantinePath, "residue")
+	info, err := os.Lstat(residuePath)
+	if err != nil || info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		return errors.New("review quarantine-legacy-fix-scope refused missing or unsafe committed replay residue")
+	}
+	items, err := os.ReadDir(residuePath)
+	if err != nil {
+		return err
+	}
+	residue := make([]string, 0, len(items))
+	for _, item := range items {
+		residue = append(residue, item.Name())
+	}
+	sort.Strings(residue)
+	if !reflect.DeepEqual(record.Residue, residue) {
+		return errors.New("review quarantine-legacy-fix-scope refused mismatched committed replay residue")
+	}
+	derived, err := inspectHistoricalLegacyFixScope(Store{Dir: residuePath, lineageID: request.LineageID, repo: repository, readOnly: true}, request.ExpectedRevision)
+	if err != nil {
+		return fmt.Errorf("review quarantine-legacy-fix-scope refused invalid committed replay residue: %w", err)
+	}
+	derived.Disposition = request.Disposition
+	if !reflect.DeepEqual(*proof, derived) || proof.Diagnostic != request.ExpectedDiagnostic || proof.Disposition != request.Disposition || !legacyFixScopeAuthorizationMatchesProof(request, *proof) || request.MaintainerAuthorization != legacyFixScopeQuarantineAuthorizationBinding(repository, proof.LineageID, proof.HeadRevision, proof.Diagnostic, proof.Disposition, request.ExpectedAnomalySet, request.ExpectedValidateFixAliasRevision, request.ExpectedValidateFixAliasOperation, request.Actor, request.Reason) {
+		return errors.New("review quarantine-legacy-fix-scope refused mismatched committed replay proof or authorization")
+	}
+	return nil
+}

--- a/internal/reviewtransaction/legacy_fix_scope_quarantine_test.go
+++ b/internal/reviewtransaction/legacy_fix_scope_quarantine_test.go
@@ -1,0 +1,387 @@
+package reviewtransaction
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// legacyFixScopeFixture reproduces the three historical Gentle Pi shapes: two
+// terminal complete-fix records and one followed by validate-fix.
+func legacyFixScopeFixture(t *testing.T, repo, lineage string, added []string, successor bool) (Store, string, string) {
+	t.Helper()
+	store, err := AuthoritativeStore(context.Background(), repo, lineage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tx := newTestTransaction(t, ModeOrdinary4R)
+	tx.LineageID, tx.GenesisPaths = lineage, nil
+	if err := tx.StartReview(); err != nil {
+		t.Fatal(err)
+	}
+	head := writeStoreEvent(t, store, Record{Operation: "review/start", Transaction: *tx})
+	if err := freezeTestFindings(tx, []Finding{{ID: "R1-SCOPE", Severity: "CRITICAL"}}); err != nil {
+		t.Fatal(err)
+	}
+	head = writeStoreEvent(t, store, Record{Operation: "review/freeze-findings", PreviousRevision: head, Transaction: *tx})
+	if _, err := tx.ClassifyEvidence([]FindingEvidence{{FindingID: "R1-SCOPE", Class: EvidenceDeterministic, Causality: CausalIntroduced, Proof: "historical proof"}}); err != nil {
+		t.Fatal(err)
+	}
+	head = writeStoreEvent(t, store, Record{Operation: "review/classify-evidence", PreviousRevision: head, Transaction: *tx})
+	if err := tx.BeginFix(hash("a")); err != nil {
+		t.Fatal(err)
+	}
+	head = writeStoreEvent(t, store, Record{Operation: "review/begin-fix", PreviousRevision: head, Transaction: *tx})
+	fix := tx.Snapshot
+	fix.Kind, fix.BaseTree, fix.CandidateTree, fix.LedgerIDs = TargetFixDiff, tx.FinalCandidateTree, tree("c"), []string{"R1-SCOPE"}
+	fix.Paths, err = canonicalPaths(append(append([]string{}, fix.Paths...), added...))
+	if err != nil {
+		t.Fatal(err)
+	}
+	fix.PathsDigest, fix.Identity = digestPaths(fix.Paths), hash("c")
+	completed := *tx
+	completed.Snapshot, completed.FinalCandidateTree, completed.FixDeltaHash, completed.State, completed.GenesisPaths = fix, fix.CandidateTree, FixDeltaHashForSnapshot(fix), StateFixValidating, nil
+	complete := writeStoreEvent(t, store, Record{Operation: "review/complete-fix", PreviousRevision: head, Transaction: completed})
+	head = complete
+	if successor {
+		validated := historicalValidationTransition(completed)
+		head = writeStoreEvent(t, store, Record{Operation: "review/validate-fix", PreviousRevision: head, Transaction: validated})
+	}
+	return store, head, complete
+}
+
+func legacyFixScopeRequest(t *testing.T, repo, lineage, head, event, alias string) LegacyFixScopeQuarantineRequest {
+	t.Helper()
+	_, repository, err := reviewAuthorityRoot(context.Background(), repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := LegacyFixScopeQuarantineRequest{LineageID: lineage, ExpectedRevision: head, ExpectedDiagnostic: legacyFixScopeInventoryDiagnostic(event), Disposition: LegacyFixScopeQuarantineDisposition, ExpectedAnomalySet: legacyFixScopeScopeOnlyAnomalySet, Reason: "quarantine exact historical complete-fix scope expansion", Actor: "maintainer@example.com"}
+	if alias != "" {
+		r.ExpectedAnomalySet, r.ExpectedValidateFixAliasRevision, r.ExpectedValidateFixAliasOperation = legacyFixScopeCombinedAnomalySet, alias, "review/validate-fix"
+	}
+	r.MaintainerAuthorization = legacyFixScopeQuarantineAuthorizationBinding(repository, r.LineageID, r.ExpectedRevision, r.ExpectedDiagnostic, r.Disposition, r.ExpectedAnomalySet, r.ExpectedValidateFixAliasRevision, r.ExpectedValidateFixAliasOperation, r.Actor, r.Reason)
+	return r
+}
+
+func legacyFixScopeAliasRevision(t *testing.T, store Store, head string) string {
+	t.Helper()
+	for revision := head; revision != ""; {
+		record, loaded, err := store.loadRevision(revision)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if record.Operation == "review/validate-fix" {
+			return loaded
+		}
+		revision = record.PreviousRevision
+	}
+	t.Fatal("missing validate-fix alias")
+	return ""
+}
+
+func TestQuarantineHistoricalLegacyFixScopeReproducesPiShapes(t *testing.T) {
+	for _, tt := range []struct {
+		name, lineage string
+		added         []string
+		successor     bool
+	}{
+		{"complete target", "issue-1099-complete-target-review-20260710", []string{"lib/sdd-preflight.ts"}, false},
+		{"final complete", "issue-1099-final-complete-review-20260710", []string{"assets/agents/gentle-ai-worker.md"}, false},
+		{"corrected candidate", "issue-1099-corrected-candidate-review-20260710", []string{"extensions/gentle-ai.ts", "tests/gentle-ai.test.ts"}, true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := initSnapshotRepo(t)
+			store, head, event := legacyFixScopeFixture(t, repo, tt.lineage, tt.added, tt.successor)
+			alias := ""
+			if tt.successor {
+				alias = legacyFixScopeAliasRevision(t, store, head)
+			}
+			request := legacyFixScopeRequest(t, repo, tt.lineage, head, event, alias)
+			report, err := InventoryAuthority(context.Background(), repo)
+			if err != nil || len(report.Entries) != 1 || !reflect.DeepEqual(report.Entries[0].Problems, []string{request.ExpectedDiagnostic}) {
+				t.Fatalf("inventory diagnostic = %#v, %v", report, err)
+			}
+			committed, err := QuarantineHistoricalLegacyFixScope(context.Background(), repo, request)
+			if err != nil {
+				t.Fatal(err)
+			}
+			proof := committed.LegacyFixScopeQuarantine
+			if committed.Status != CompactReclaimCommitted || proof == nil || proof.EventRevision != event || proof.HeadRevision != head || !reflect.DeepEqual(proof.ExpandedCorrectionPaths, tt.added) || proof.AnomalySet != request.ExpectedAnomalySet {
+				t.Fatalf("invalid quarantine proof: %#v", committed)
+			}
+			if _, err := os.Lstat(store.Dir); !os.IsNotExist(err) {
+				t.Fatalf("source remains: %v", err)
+			}
+			replayed, err := QuarantineHistoricalLegacyFixScope(context.Background(), repo, request)
+			if err != nil || !reflect.DeepEqual(replayed, committed) {
+				t.Fatalf("replay = %#v, %v", replayed, err)
+			}
+		})
+	}
+}
+
+func legacyFixScopePhysicalChild(store Store, head, name string) string {
+	if name == "event" {
+		return filepath.Join(store.Dir, "events", strings.TrimPrefix(head, "sha256:")+".json")
+	}
+	return filepath.Join(store.Dir, name)
+}
+
+func TestQuarantineHistoricalLegacyFixScopeRejectsSymlinkedPhysicalChildren(t *testing.T) {
+	for _, tt := range []struct {
+		name, child string
+		residue     bool
+	}{
+		{"source HEAD", "HEAD", false}, {"source events", "events", false}, {"source event", "event", false}, {"source LOCK", "LOCK", false},
+		{"residue HEAD", "HEAD", true}, {"residue events", "events", true}, {"residue event", "event", true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := initSnapshotRepo(t)
+			store, head, event := legacyFixScopeFixture(t, repo, "symlink-"+strings.ReplaceAll(strings.ToLower(tt.name), " ", "-"), []string{"lib/scope.go"}, false)
+			request := legacyFixScopeRequest(t, repo, store.lineageID, head, event, "")
+			if tt.residue {
+				record, err := QuarantineHistoricalLegacyFixScope(context.Background(), repo, request)
+				if err != nil {
+					t.Fatal(err)
+				}
+				store.Dir = filepath.Join(record.QuarantinePath, "residue")
+			}
+			target := filepath.Join(t.TempDir(), "target")
+			if err := os.WriteFile(target, []byte("must not change"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			path := legacyFixScopePhysicalChild(store, head, tt.child)
+			if err := os.RemoveAll(path); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Symlink(target, path); err != nil {
+				t.Skipf("symlinks unavailable: %v", err)
+			}
+			if _, err := QuarantineHistoricalLegacyFixScope(context.Background(), repo, request); err == nil || !strings.Contains(err.Error(), "unsafe physical") {
+				t.Fatalf("symlink refusal = %v", err)
+			}
+			if payload, err := os.ReadFile(target); err != nil || string(payload) != "must not change" {
+				t.Fatalf("symlink target was changed: %q, %v", payload, err)
+			}
+		})
+	}
+}
+
+func TestQuarantineHistoricalLegacyFixScopeRejectsUnauthorizedClasses(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		mutate func(*LegacyFixScopeQuarantineRequest)
+		want   string
+	}{
+		{"stale CAS", func(r *LegacyFixScopeQuarantineRequest) { r.ExpectedRevision = hash("f") }, ErrConcurrentUpdate.Error()},
+		{"reordered anomalies", func(r *LegacyFixScopeQuarantineRequest) {
+			r.ExpectedAnomalySet = "validate_fix_alias,complete_fix_scope_expansion"
+		}, "supports only canonical"},
+		{"scope alias fields", func(r *LegacyFixScopeQuarantineRequest) { r.ExpectedValidateFixAliasOperation = "review/validate-fix" }, "scope-only anomaly set forbids"},
+		{"wrong diagnostic", func(r *LegacyFixScopeQuarantineRequest) { r.ExpectedDiagnostic = "other" }, "supports only"},
+		{"multiline actor", func(r *LegacyFixScopeQuarantineRequest) { r.Actor += "\nextra" }, "LF-only"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := initSnapshotRepo(t)
+			store, head, event := legacyFixScopeFixture(t, repo, "reject-"+strings.ReplaceAll(strings.ToLower(tt.name), " ", "-"), []string{"lib/scope.go"}, false)
+			request := legacyFixScopeRequest(t, repo, store.lineageID, head, event, "")
+			tt.mutate(&request)
+			if _, err := QuarantineHistoricalLegacyFixScope(context.Background(), repo, request); err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("error = %v, want %q", err, tt.want)
+			}
+			if _, err := os.Lstat(store.Dir); err != nil {
+				t.Fatalf("refusal moved source: %v", err)
+			}
+		})
+	}
+}
+
+func TestQuarantineHistoricalLegacyFixScopeRejectsFabricatedReplayAndRace(t *testing.T) {
+	t.Run("fabricated audit", func(t *testing.T) {
+		repo := initSnapshotRepo(t)
+		store, head, event := legacyFixScopeFixture(t, repo, "replay-fabricated", []string{"lib/scope.go"}, false)
+		request := legacyFixScopeRequest(t, repo, store.lineageID, head, event, "")
+		record, err := QuarantineHistoricalLegacyFixScope(context.Background(), repo, request)
+		if err != nil {
+			t.Fatal(err)
+		}
+		prepared := record
+		prepared.Status, prepared.QuarantinePath = CompactReclaimPrepared, filepath.Join(filepath.Dir(record.QuarantinePath), store.lineageID+"-prepared")
+		payload, err := json.Marshal(prepared)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.MkdirAll(prepared.QuarantinePath, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(prepared.QuarantinePath, "reclaim-record.json"), payload, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if replayed, err := QuarantineHistoricalLegacyFixScope(context.Background(), repo, request); err != nil || !reflect.DeepEqual(replayed, record) {
+			t.Fatalf("prepared replay = %#v, %v", replayed, err)
+		}
+		conflictPath := filepath.Join(filepath.Dir(record.QuarantinePath), store.lineageID+"-conflict")
+		payload, err = json.Marshal(record)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.MkdirAll(conflictPath, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(conflictPath, "reclaim-record.json"), payload, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := QuarantineHistoricalLegacyFixScope(context.Background(), repo, request); err == nil || !strings.Contains(err.Error(), "mismatched committed replay audit path") {
+			t.Fatalf("conflicting committed replay = %v", err)
+		}
+		if err := os.RemoveAll(conflictPath); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(record.QuarantinePath, "reclaim-record.json"), []byte(`{"schema":"gentle-ai.review-reclaim-record/v1","status":"committed","lineage_id":"`+record.LineageID+`"}`), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := QuarantineHistoricalLegacyFixScope(context.Background(), repo, request); err == nil || !strings.Contains(err.Error(), "incomplete or mismatched") {
+			t.Fatalf("fabricated replay = %v", err)
+		}
+	})
+	t.Run("maintenance before local lock rechecks source", func(t *testing.T) {
+		repo := initSnapshotRepo(t)
+		store, head, event := legacyFixScopeFixture(t, repo, "recheck-source", []string{"lib/scope.go"}, false)
+		request := legacyFixScopeRequest(t, repo, store.lineageID, head, event, "")
+		entered, release := make(chan struct{}), make(chan struct{})
+		var gate sync.Mutex
+		blocked := false
+		original := legacyFixScopeBeforeMaintenance
+		legacyFixScopeBeforeMaintenance = func() {
+			gate.Lock()
+			wait := !blocked
+			blocked = true
+			gate.Unlock()
+			if wait {
+				close(entered)
+				<-release
+			}
+		}
+		t.Cleanup(func() { legacyFixScopeBeforeMaintenance = original })
+		result := make(chan CompactReclaimRecord, 1)
+		resultErr := make(chan error, 1)
+		go func() {
+			record, err := QuarantineHistoricalLegacyFixScope(context.Background(), repo, request)
+			result <- record
+			resultErr <- err
+		}()
+		<-entered
+		committed, err := QuarantineHistoricalLegacyFixScope(context.Background(), repo, request)
+		if err != nil {
+			t.Fatal(err)
+		}
+		close(release)
+		if err := <-resultErr; err != nil {
+			t.Fatal(err)
+		}
+		if replayed := <-result; !reflect.DeepEqual(replayed, committed) {
+			t.Fatalf("concurrent retry = %#v, want %#v", replayed, committed)
+		}
+	})
+	t.Run("active lock", func(t *testing.T) {
+		repo := initSnapshotRepo(t)
+		store, head, event := legacyFixScopeFixture(t, repo, "active-lock", []string{"lib/scope.go"}, false)
+		lock, err := acquireStoreLock(filepath.Join(store.Dir, "LOCK"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer lock.release()
+		_, err = QuarantineHistoricalLegacyFixScope(context.Background(), repo, legacyFixScopeRequest(t, repo, store.lineageID, head, event, ""))
+		if !errors.Is(err, ErrAuthorityLockTimeout) {
+			t.Fatalf("lock error = %v", err)
+		}
+	})
+}
+
+func TestQuarantineHistoricalLegacyFixScopeReplayRejectsV2AndStaleResidue(t *testing.T) {
+	t.Run("post-lock compact v2", func(t *testing.T) {
+		repo := initSnapshotRepo(t)
+		store, head, event := legacyFixScopeFixture(t, repo, "replay-v2-race", []string{"lib/scope.go"}, false)
+		request := legacyFixScopeRequest(t, repo, store.lineageID, head, event, "")
+		if _, err := QuarantineHistoricalLegacyFixScope(context.Background(), repo, request); err != nil {
+			t.Fatal(err)
+		}
+		entered, release := make(chan struct{}), make(chan struct{})
+		original := legacyFixScopeAfterMaintenance
+		legacyFixScopeAfterMaintenance = func() { close(entered); <-release }
+		t.Cleanup(func() { legacyFixScopeAfterMaintenance = original })
+		result := make(chan error, 1)
+		go func() {
+			_, err := QuarantineHistoricalLegacyFixScope(context.Background(), repo, request)
+			result <- err
+		}()
+		<-entered
+		base, _, err := reviewAuthorityRoot(context.Background(), repo)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.MkdirAll(filepath.Join(base, "v2", store.lineageID), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		close(release)
+		if err := <-result; err == nil || !strings.Contains(err.Error(), "also exists in compact-v2 authority") {
+			t.Fatalf("replay compact-v2 exclusion = %v", err)
+		}
+	})
+	t.Run("orphan prepared", func(t *testing.T) {
+		repo := initSnapshotRepo(t)
+		store, head, event := legacyFixScopeFixture(t, repo, "stale-prepared", []string{"lib/scope.go"}, false)
+		request := legacyFixScopeRequest(t, repo, store.lineageID, head, event, "")
+		base, _, err := reviewAuthorityRoot(context.Background(), repo)
+		if err != nil {
+			t.Fatal(err)
+		}
+		path := filepath.Join(base, "quarantine", store.lineageID+"-prepared")
+		if err := os.MkdirAll(path, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		payload, err := json.Marshal(CompactReclaimRecord{Schema: CompactReclaimRecordSchema, Status: CompactReclaimPrepared, LineageID: store.lineageID})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(path, "reclaim-record.json"), payload, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.RemoveAll(store.Dir); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := QuarantineHistoricalLegacyFixScope(context.Background(), repo, request); err == nil || !strings.Contains(err.Error(), "stale or orphan prepared") {
+			t.Fatalf("orphan prepared = %v", err)
+		}
+	})
+}
+
+func TestQuarantineHistoricalLegacyFixScopeRejectsUnexpectedPhysicalResidue(t *testing.T) {
+	for _, residue := range []bool{false, true} {
+		t.Run(map[bool]string{false: "source", true: "replay residue"}[residue], func(t *testing.T) {
+			repo := initSnapshotRepo(t)
+			store, head, event := legacyFixScopeFixture(t, repo, "unexpected-residue-"+map[bool]string{false: "source", true: "replay"}[residue], []string{"lib/scope.go"}, false)
+			request := legacyFixScopeRequest(t, repo, store.lineageID, head, event, "")
+			if residue {
+				record, err := QuarantineHistoricalLegacyFixScope(context.Background(), repo, request)
+				if err != nil {
+					t.Fatal(err)
+				}
+				store.Dir = filepath.Join(record.QuarantinePath, "residue")
+			}
+			if err := os.WriteFile(filepath.Join(store.Dir, "events", "orphan.json"), []byte("{}"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := QuarantineHistoricalLegacyFixScope(context.Background(), repo, request); err == nil || !strings.Contains(err.Error(), "non-HEAD-chain physical event") {
+				t.Fatalf("unexpected nested residue = %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #1535

## Summary
- add a narrowly authorized maintenance command for historical complete-fix scope expansion
- quarantine legacy authority instead of validating it, with exact anomaly/CAS/proof bindings
- serialize fresh and replay paths, validate physical residue, and converge exact committed retries

## Verification
- go test ./...
- affected race tests
- go vet ./...
- Linux, Windows, and Darwin builds
- bounded 4R review with one 200-line correction transaction

## Review receipt
- lineage: review-c56b8c5fbce7736d
- maintainer-approved size:exception

## Prerequisites
- #1571 secure no-follow local lock acquisition
- #1573 cross-platform lock path compatibility

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a review command to quarantine authorized legacy fix-scope anomalies without modifying historical records.
  - Added JSON results with auditable quarantine proof and deterministic replay support.
  - Added strict validation for authorization, anomaly types, repository state, and filesystem safety.

- **Documentation**
  - Documented the legacy fix-scope quarantine process, constraints, authorization format, and replay behavior.

- **Bug Fixes**
  - Improved protection against symlinked paths, fabricated audit records, stale artifacts, and unexpected residue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->