### PR TITLE
fix(review): keep scope-changed recovery composable at pre-PR

### DIFF
--- a/internal/reviewtransaction/compact_chain.go
+++ b/internal/reviewtransaction/compact_chain.go
@@ -149,7 +149,8 @@ func deriveCompactPrePRChain(ctx context.Context, repo string, input NativeGateR
 		leafSet[store.lineageID] = struct{}{}
 	}
 	authority := make([]compactPrePRChainAuthorityProof, 0, len(stores))
-	members := make([]compactPrePRChainMember, 0, len(stores))
+	approvedMembers := make(map[string]compactPrePRChainMember, len(stores))
+	leafMembers := make([]compactPrePRChainMember, 0, len(leaves))
 	for _, store := range stores {
 		statePayload, readErr := os.ReadFile(store.StatePath())
 		if readErr != nil {
@@ -175,8 +176,12 @@ func deriveCompactPrePRChain(ctx context.Context, repo string, input NativeGateR
 				return compactPrePRChainDerivation{}, true, fmt.Errorf("compact receipt %q does not match current authority", store.lineageID)
 			}
 			proof.ReceiptHash = compactPrePRChainPayloadHash("receipt", receiptPayload)
-			if _, leaf := leafSet[store.lineageID]; leaf && record.State.State == StateApproved {
-				members = append(members, compactPrePRChainMember{store: store, record: record, receipt: receipt})
+			if record.State.State == StateApproved {
+				member := compactPrePRChainMember{store: store, record: record, receipt: receipt}
+				approvedMembers[store.lineageID] = member
+				if _, leaf := leafSet[store.lineageID]; leaf {
+					leafMembers = append(leafMembers, member)
+				}
 			}
 		} else if receiptErr == nil {
 			return compactPrePRChainDerivation{}, true, fmt.Errorf("nonterminal compact authority %q has a receipt", store.lineageID)
@@ -184,6 +189,19 @@ func deriveCompactPrePRChain(ctx context.Context, repo string, input NativeGateR
 			return compactPrePRChainDerivation{}, true, receiptErr
 		}
 		authority = append(authority, proof)
+	}
+	members := make([]compactPrePRChainMember, 0, len(leafMembers))
+	for _, member := range leafMembers {
+		recovery := member.record.State.Recovery
+		if recovery != nil && recovery.Disposition == RecoveryScopeChanged &&
+			member.receipt.BaseTree == member.receipt.FinalCandidateTree && member.receipt.FixDeltaHash == EmptyFixDeltaHash {
+			predecessor, recovered := approvedMembers[recovery.PredecessorLineageID]
+			if recovered && predecessor.receipt.FinalCandidateTree == member.receipt.BaseTree {
+				members = append(members, predecessor)
+				continue
+			}
+		}
+		members = append(members, member)
 	}
 	if len(members) < 2 {
 		return compactPrePRChainDerivation{}, true, errors.New("no receipt chain contains at least two authoritative approved members")

--- a/internal/reviewtransaction/compact_chain_test.go
+++ b/internal/reviewtransaction/compact_chain_test.go
@@ -28,6 +28,23 @@ func TestCompactPrePRChainAllowsExactThreeReceiptComposition(t *testing.T) {
 	}
 }
 
+func TestCompactPrePRChainAllowsAcceptedDegenerateScopeRecovery(t *testing.T) {
+	fixture := newCompactPrePRChainFixture(t, 2)
+	successor, receipt := recoverApprovedCompactSuccessor(t, fixture.repo, fixture.states[1].LineageID, "compact-chain-recovery", 2)
+	if receipt.BaseTree != receipt.FinalCandidateTree {
+		t.Fatalf("recovery receipt is not degenerate: %#v", receipt)
+	}
+
+	got, attempted := EvaluateCompactPrePRChain(context.Background(), fixture.repo, fixture.input())
+
+	if !attempted || got.Result != GateAllow {
+		t.Fatalf("accepted degenerate scope recovery = %#v, attempted %t, successor %s", got, attempted, successor.LineageID)
+	}
+	if got.Context.BaseTree != fixture.receipts[0].BaseTree || got.Context.CandidateTree != fixture.receipts[1].FinalCandidateTree {
+		t.Fatalf("recovered composed proof context = %#v", got.Context)
+	}
+}
+
 func TestCompactPrePRChainLeavesExactSingleReceiptToDirectEvaluation(t *testing.T) {
 	fixture := newCompactPrePRChainFixture(t, 1)
 	input := fixture.input()


### PR DESCRIPTION
## Linked Issue

Closes #1563

---

## PR Type

- [x] `type:bug` - Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` - New feature
- [ ] `type:docs` - Documentation only
- [ ] `type:refactor` - Code refactoring
- [ ] `type:chore` - Build, CI, or tooling changes
- [ ] `type:breaking-change` - Breaking change

---

## Summary

- Preserve composability after an accepted clean `scope_changed` recovery produces a degenerate receipt.
- Rebind only the narrowly qualified recovery leaf to its validated approved predecessor delivery edge.
- Keep existing rejection behavior for genuine receipt cycles.

---

## Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/reviewtransaction/compact_chain.go` | Select the approved predecessor for clean degenerate recovery leaves with exact tree continuity. |
| `internal/reviewtransaction/compact_chain_test.go` | Add a Git-backed regression for successful unqualified PRE-PR composition after recovery. |

---

## Test Plan

- [x] Focused compact-chain suite passed: `go test ./internal/reviewtransaction -run ^TestCompactPrePRChain -count=1`
- [x] Non-mutating format check passed on both changed Go files with `gofmt -d`.
- [x] Diff whitespace check passed: `git diff --check`.
- [x] Native bounded review approved; `post-apply`, `pre-commit`, `pre-push`, and `pre-pr` gates returned `allow`.
- [ ] Full `go test ./...` was not used as final evidence because this Windows host has unrelated symlink-privilege and Git initial-branch fixture failures; CI remains authoritative.
- [ ] E2E Docker suite not run; this change is isolated to compact receipt-chain composition.

---

## Contributor Checklist

- [x] PR is linked to an issue with `status:approved`.
- [x] PR stays within 400 changed lines.
- [ ] `type:bug` label requires maintainer application because the contributor token cannot update labels.
- [x] Focused affected tests pass.
- [x] Changed Go files pass non-mutating formatting checks.
- [x] Documentation is not required for this internal correctness fix.
- [x] Commit follows Conventional Commits.
- [x] Commit contains no `Co-Authored-By` trailers.

---

## Notes for Reviewers

The implementation intentionally does not special-case arbitrary self-loops. Rebinding is limited to approved clean `scope_changed` recovery receipts where `BaseTree == FinalCandidateTree`, `FixDeltaHash` is empty, and the approved predecessor ends at that exact tree.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compact-chain recovery handling for accepted degenerate recovery receipts.
  * Ensures valid recovered chains are correctly authorized and composed with the expected proof context.

* **Tests**
  * Added coverage for compact-chain authorization when recovery uses a degenerate scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->