### PR TITLE
feat(review): recover muestra el formato del binding en el error + acepta --maintainer-authorization-file

### DIFF
--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -475,6 +475,7 @@ func RunReviewRecover(args []string, stdout io.Writer) error {
 	actor := flags.String("actor", "", "recovery actor")
 	projectionFlag := flags.String("projection", "", "successor projection: workspace or staged (default: predecessor projection)")
 	authorization := flags.String("maintainer-authorization", "", "exact six-line LF-only binding: gentle-ai.review-recovery-authorization/v1, predecessor_lineage, predecessor_revision, target_identity, actor, reason")
+	authorizationFile := flags.String("maintainer-authorization-file", "", "read the maintainer authorization binding from this file, or - for stdin (avoids passing the multi-line value as a shell argument on Windows)")
 	policySource := flags.String("policy", "", "optional review policy file")
 	focus := flags.String("focus", "reliability", "dominant standard-risk focus; large pure documentation always uses readability")
 	baseRef := flags.String("base-ref", "", "optional base revision for immutable base-to-HEAD review")
@@ -488,6 +489,17 @@ func RunReviewRecover(args []string, stdout io.Writer) error {
 	}
 	if flags.NArg() != 0 {
 		return fmt.Errorf("unexpected review recover argument %q", flags.Arg(0))
+	}
+	if strings.TrimSpace(*authorizationFile) != "" {
+		if strings.TrimSpace(*authorization) != "" {
+			return errors.New("provide the maintainer authorization via either --maintainer-authorization or --maintainer-authorization-file, not both")
+		}
+		payload, readErr := readFacadeBytes(strings.TrimSpace(*authorizationFile))
+		if readErr != nil {
+			return fmt.Errorf("read maintainer authorization file: %w", readErr)
+		}
+		// The canonical binding has no trailing newline; strip one an editor may add.
+		*authorization = strings.TrimRight(string(payload), "\r\n")
 	}
 	if strings.TrimSpace(*predecessor) == "" || strings.TrimSpace(*expected) == "" || strings.TrimSpace(*successor) == "" || strings.TrimSpace(*reason) == "" || strings.TrimSpace(*actor) == "" || strings.TrimSpace(*disposition) == "" {
 		return errors.New("review recover requires --predecessor-lineage, --expected-predecessor-revision, --successor-lineage, --disposition, --reason, and --actor")

--- a/internal/reviewtransaction/compact_store.go
+++ b/internal/reviewtransaction/compact_store.go
@@ -44,7 +44,7 @@ var errCompactRecoveryTargetUnchanged = errors.New("escalated recovery successor
 // errCompactRecoveryAuthorizationInexact identifies the escalated-recovery
 // authorization-binding anomaly so reconcile-authority can gate quarantine of
 // historical pre-contract free-form authorizations to exactly this class.
-var errCompactRecoveryAuthorizationInexact = errors.New("escalated recovery requires an exact maintainer authorization binding")
+var errCompactRecoveryAuthorizationInexact = errors.New("escalated recovery requires an exact maintainer authorization binding: six LF-joined lines — line 1 is the literal schema " + compactRecoveryAuthorizationSchema + ", then key=value lines predecessor_lineage=<id>, predecessor_revision=<rev>, target_identity=<sha256>, actor=<actor>, reason=<text>")
 
 // compactRecoveryAuthorizationSchema is the first line of the exact six-line
 // escalated-recovery maintainer authorization binding.


### PR DESCRIPTION
Closes #1612

Dos mejoras contenidas a la UX de `review recover`, nacidas de un caso real: recuperar un review escalado por un falso positivo se volvió un bloqueo de horas por (1) no saber el formato del binding y (2) no poder pasar un argumento multilínea en Windows.

## Cambios

**1. El error del binding muestra el formato** (`internal/reviewtransaction/compact_store.go`)
`errCompactRecoveryAuthorizationInexact` ahora explica que son 6 líneas LF: línea 1 el schema literal (via la const `compactRecoveryAuthorizationSchema`, sin duplicar el string), líneas 2–6 en `clave=valor` (`predecessor_lineage=…`, etc.). Se conserva el substring original → los tests con `strings.Contains` (`compact_reconcile_test.go`, `review_reconcile_test.go`) siguen pasando.

**2. `--maintainer-authorization-file`** (`internal/cli/review_facade.go`)
Nuevo flag que lee el binding desde archivo o `-` (stdin) reusando el helper `readFacadeBytes`. Evita pasar el valor multilínea como argumento del shell (inviable de forma confiable en Git Bash y PowerShell 5.1). Exclusión mutua con `--maintainer-authorization` y strip del `\r\n` final. El flag literal existente queda intacto.

## Seguridad

Sin cambios en el modelo de seguridad ni en la escalación. Los valores del binding no son secretos (lineage/revision/target salen de `review status`; actor/reason los pasa el caller): exponer formato/valores no debilita ningún control — el binding es integridad/auditoría, no acceso.

## Testing

`go build ./...` y `go vet` en verde; los binarios de test compilan (`go test -c` exit 0). No pude ejecutar la suite en mi entorno (el sandbox bloquea la ejecución de `.exe` recién compilados con `Access is denied`) → validación runtime para CI. Verifiqué a mano que los tests que tocan el mensaje usan `Contains` con substring preservado.

---
Nota: sé que el flujo es issue-first con `status:approved` antes de codear; acá el código salió de diagnosticar el problema en vivo. Queda a tu criterio como maintainer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for providing maintainer authorization through a file or standard input when using `review recover`.
  * Added validation to prevent conflicting authorization inputs.

* **Bug Fixes**
  * Improved recovery authorization error messages with the expected binding format and required fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->