### PR TITLE
fix(review): reconcile multiple invalid recovery edges

### DIFF
--- a/contracts/review-integration/v1/fixtures/operation.fixture.json
+++ b/contracts/review-integration/v1/fixtures/operation.fixture.json
@@ -44,6 +44,10 @@
           "reason_code": "forbidden_finalize_requires_target_status"
         },
         {
+          "action": "review.reconcile-authority-batch",
+          "reason_code": "forbidden_finalize_requires_target_status"
+        },
+        {
           "action": "review.recover",
           "reason_code": "forbidden_finalize_requires_target_status"
         },

--- a/contracts/review-integration/v1/fixtures/status-ambiguous.fixture.json
+++ b/contracts/review-integration/v1/fixtures/status-ambiguous.fixture.json
@@ -63,6 +63,10 @@
         "reason_code": "forbidden_ambiguous_authority"
       },
       {
+        "action": "review.reconcile-authority-batch",
+        "reason_code": "forbidden_ambiguous_authority"
+      },
+      {
         "action": "review.recover",
         "reason_code": "forbidden_ambiguous_authority"
       },

--- a/contracts/review-integration/v1/fixtures/status-corrupted.fixture.json
+++ b/contracts/review-integration/v1/fixtures/status-corrupted.fixture.json
@@ -60,6 +60,10 @@
         "reason_code": "forbidden_corrupted_authority"
       },
       {
+        "action": "review.reconcile-authority-batch",
+        "reason_code": "forbidden_corrupted_authority"
+      },
+      {
         "action": "review.recover",
         "reason_code": "forbidden_corrupted_authority"
       },

--- a/contracts/review-integration/v1/fixtures/status-recover.fixture.json
+++ b/contracts/review-integration/v1/fixtures/status-recover.fixture.json
@@ -87,6 +87,10 @@
         "reason_code": "forbidden_not_selected_by_native_status"
       },
       {
+        "action": "review.reconcile-authority-batch",
+        "reason_code": "forbidden_not_selected_by_native_status"
+      },
+      {
         "action": "review.start",
         "reason_code": "forbidden_not_selected_by_native_status"
       },

--- a/contracts/review-integration/v1/fixtures/status-unrelated.fixture.json
+++ b/contracts/review-integration/v1/fixtures/status-unrelated.fixture.json
@@ -60,6 +60,10 @@
         "reason_code": "forbidden_unrelated_target"
       },
       {
+        "action": "review.reconcile-authority-batch",
+        "reason_code": "forbidden_unrelated_target"
+      },
+      {
         "action": "review.recover",
         "reason_code": "forbidden_unrelated_target"
       },

--- a/contracts/review-integration/v1/fixtures/status.fixture.json
+++ b/contracts/review-integration/v1/fixtures/status.fixture.json
@@ -72,6 +72,10 @@
         "reason_code": "forbidden_required_inputs_unavailable"
       },
       {
+        "action": "review.reconcile-authority-batch",
+        "reason_code": "forbidden_required_inputs_unavailable"
+      },
+      {
         "action": "review.recover",
         "reason_code": "forbidden_required_inputs_unavailable"
       },

--- a/contracts/review-integration/v1/schemas/status.schema.json
+++ b/contracts/review-integration/v1/schemas/status.schema.json
@@ -170,7 +170,7 @@
             "additionalProperties": false,
             "required": ["action", "reason_code"],
             "properties": {
-              "action": { "enum": ["review.abandon", "review.finalize", "review.invalidate", "review.quarantine-legacy", "review.reclaim", "review.reconcile-authority", "review.recover", "review.start", "review.validate"] },
+              "action": { "enum": ["review.abandon", "review.finalize", "review.invalidate", "review.quarantine-legacy", "review.reclaim", "review.reconcile-authority", "review.reconcile-authority-batch", "review.recover", "review.start", "review.validate"] },
               "reason_code": { "type": "string", "pattern": "^[a-z0-9_]+$" }
             }
           }

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -363,7 +363,7 @@ func TestRunArgsDispatchesCompactReviewFacadeBeforePlatformValidation(t *testing
 	if err := RunArgs([]string{"review", "--help"}, &output); err != nil {
 		t.Fatalf("RunArgs(review --help) error = %v", err)
 	}
-	if !strings.Contains(output.String(), "review <capabilities|start|finalize|validate|status|invalidate|abandon|recover|reclaim|inspect-authority|reconcile-authority|dispose-result|quarantine-legacy|quarantine-legacy-fix-scope|repair-legacy-alias|schema|bind-sdd>") {
+	if !strings.Contains(output.String(), "review <capabilities|start|finalize|validate|status|invalidate|abandon|recover|reclaim|inspect-authority|reconcile-authority|reconcile-authority-batch|dispose-result|quarantine-legacy|quarantine-legacy-fix-scope|repair-legacy-alias|schema|bind-sdd>") {
 		t.Fatalf("compact review help missing:\n%s", output.String())
 	}
 }

--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -226,7 +226,7 @@ var reviewFacadeCommittedTransitionHook = func(context.Context, string, string, 
 
 func RunReview(args []string, stdout io.Writer) error {
 	if len(args) == 0 || args[0] == "help" || args[0] == "-h" || args[0] == "--help" {
-		_, _ = fmt.Fprintln(stdout, "Usage: gentle-ai review <capabilities|start|finalize|validate|status|invalidate|abandon|recover|reclaim|inspect-authority|reconcile-authority|dispose-result|quarantine-legacy|quarantine-legacy-fix-scope|repair-legacy-alias|schema|bind-sdd> [flags]\n\nOrdinary review facade; repository scope, authority, canonical artifacts, and lifecycle transitions are derived by Go.")
+		_, _ = fmt.Fprintln(stdout, "Usage: gentle-ai review <capabilities|start|finalize|validate|status|invalidate|abandon|recover|reclaim|inspect-authority|reconcile-authority|reconcile-authority-batch|dispose-result|quarantine-legacy|quarantine-legacy-fix-scope|repair-legacy-alias|schema|bind-sdd> [flags]\n\nOrdinary review facade; repository scope, authority, canonical artifacts, and lifecycle transitions are derived by Go.")
 		_, _ = fmt.Fprintln(stdout, "Additive headless capabilities: gentle-ai review capture-result (with --preflight) and gentle-ai review preserve-result.")
 		return nil
 	}
@@ -286,6 +286,8 @@ func runReviewCommandContext(ctx context.Context, args []string, stdout io.Write
 		return runReviewFacadeValidate(ctx, args[1:], stdout)
 	case "bind-sdd":
 		return runReviewBindSDD(ctx, args[1:], stdout)
+	case "reconcile-authority-batch":
+		return runReviewReconcileAuthorityBatch(ctx, args[1:], stdout)
 	default:
 		return runReviewCommand(args, stdout)
 	}
@@ -321,6 +323,8 @@ func runReviewCommand(args []string, stdout io.Writer) error {
 		return RunReviewInspectAuthority(args[1:], stdout)
 	case "reconcile-authority":
 		return RunReviewReconcileAuthority(args[1:], stdout)
+	case "reconcile-authority-batch":
+		return RunReviewReconcileAuthorityBatch(args[1:], stdout)
 	case "dispose-result":
 		return RunReviewDisposeResult(args[1:], stdout)
 	case "quarantine-legacy":

--- a/internal/cli/review_reconcile_batch.go
+++ b/internal/cli/review_reconcile_batch.go
@@ -1,0 +1,110 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/gentleman-programming/gentle-ai/internal/reviewtransaction"
+)
+
+const ReviewReconcileAuthorityBatchPreparationInputSchema = "gentle-ai.review-batch-reconcile-preparation-input/v1"
+const ReviewReconcileAuthorityBatchResultSchema = "gentle-ai.review-batch-reconcile-result/v1"
+
+// ReviewReconcileAuthorityBatchPreparationInput declares the complete invalid
+// edge set and the maintainer identity used to derive an exact authorization.
+type ReviewReconcileAuthorityBatchPreparationInput struct {
+	Schema               string                                            `json:"schema"`
+	DeclaredInvalidEdges []reviewtransaction.CompactRecoveryEdgeInspection `json:"declared_invalid_edges"`
+	Actor                string                                            `json:"actor"`
+	Reason               string                                            `json:"reason"`
+}
+
+// ReviewReconcileAuthorityBatchResult carries either a read-only preparation
+// or the durable journal returned by an apply or exact replay.
+type ReviewReconcileAuthorityBatchResult struct {
+	Schema      string                                              `json:"schema"`
+	Operation   string                                              `json:"operation"`
+	Mode        string                                              `json:"mode"`
+	Preparation *reviewtransaction.CompactBatchReconcilePreparation `json:"preparation,omitempty"`
+	Journal     *reviewtransaction.CompactBatchReconcileJournal     `json:"journal,omitempty"`
+}
+
+func RunReviewReconcileAuthorityBatch(args []string, stdout io.Writer) error {
+	return runReviewReconcileAuthorityBatch(context.Background(), args, stdout)
+}
+
+func runReviewReconcileAuthorityBatch(ctx context.Context, args []string, stdout io.Writer) error {
+	flags := newReviewFlagSet(
+		"review reconcile-authority-batch",
+		stdout,
+		"Prepare or atomically apply one exact batch reconciliation for the complete declared set of supported invalid compact-v2 recovery edges. Preparation performs no authority mutation and emits the byte-exact maintainer authorization. Apply revalidates the locked authority snapshot, durably journals every whole-entry quarantine move, fails closed after partial progress, and permits only exact replay.",
+	)
+	cwd := flags.String("cwd", ".", "repository path")
+	input := flags.String("input", "", "strict JSON input file, or - for stdin")
+	prepare := flags.Bool("prepare", false, "derive the exact plan and maintainer authorization without mutating authority")
+	if err := parseReviewFlags(flags, args); err != nil {
+		return err
+	}
+	if reviewHelpRequested(args) {
+		return nil
+	}
+	if flags.NArg() != 0 {
+		return fmt.Errorf("unexpected review reconcile-authority-batch argument %q", flags.Arg(0))
+	}
+	if strings.TrimSpace(*input) == "" {
+		return errors.New("review reconcile-authority-batch requires --input")
+	}
+	root, err := (reviewtransaction.SnapshotBuilder{Repo: *cwd}).ResolveRepositoryRoot(ctx)
+	if err != nil {
+		return fmt.Errorf("resolve review repository root: %w", err)
+	}
+
+	if *prepare {
+		var preparationInput ReviewReconcileAuthorityBatchPreparationInput
+		if err := readFacadeJSON(*input, &preparationInput); err != nil {
+			return fmt.Errorf("read review reconcile-authority-batch preparation input: %w", err)
+		}
+		if preparationInput.Schema != ReviewReconcileAuthorityBatchPreparationInputSchema {
+			return errors.New("review reconcile-authority-batch preparation requires the exact input schema")
+		}
+		if preparationInput.DeclaredInvalidEdges == nil {
+			return errors.New("review reconcile-authority-batch preparation requires declared invalid edges")
+		}
+		preparation, err := reviewtransaction.PrepareCompactBatchReconciliation(
+			ctx,
+			root,
+			preparationInput.DeclaredInvalidEdges,
+			preparationInput.Actor,
+			preparationInput.Reason,
+		)
+		if err != nil {
+			return err
+		}
+		return encodeReviewJSON(stdout, ReviewReconcileAuthorityBatchResult{
+			Schema: ReviewReconcileAuthorityBatchResultSchema, Operation: "review/reconcile-authority-batch",
+			Mode: "prepared", Preparation: &preparation,
+		})
+	}
+
+	var request reviewtransaction.CompactBatchReconcileRequest
+	if err := readFacadeJSON(*input, &request); err != nil {
+		return fmt.Errorf("read review reconcile-authority-batch request: %w", err)
+	}
+	journal, err := reviewtransaction.ReconcileInvalidRecoveryEdges(ctx, root, request)
+	if err != nil {
+		if journal.Status != "" {
+			_ = encodeReviewJSON(stdout, ReviewReconcileAuthorityBatchResult{
+				Schema: ReviewReconcileAuthorityBatchResultSchema, Operation: "review/reconcile-authority-batch",
+				Mode: "prepared", Journal: &journal,
+			})
+		}
+		return err
+	}
+	return encodeReviewJSON(stdout, ReviewReconcileAuthorityBatchResult{
+		Schema: ReviewReconcileAuthorityBatchResultSchema, Operation: "review/reconcile-authority-batch",
+		Mode: "committed", Journal: &journal,
+	})
+}

--- a/internal/cli/review_reconcile_batch_test.go
+++ b/internal/cli/review_reconcile_batch_test.go
@@ -1,0 +1,263 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gentleman-programming/gentle-ai/internal/reviewtransaction"
+)
+
+const batchReconcileCLIActor = "maintainer@example.com"
+const batchReconcileCLIReason = "atomically quarantine every declared invalid recovery edge"
+
+func TestReviewReconcileAuthorityBatchPrepareAndApply(t *testing.T) {
+	repo, declarations := batchReconcileCLIFixture(t)
+	preparation := runBatchReconcileCLIPrepare(t, repo, declarations)
+	if preparation.Schema != reviewtransaction.CompactBatchReconcilePreparationSchema ||
+		len(preparation.Plan.InvalidEdges) != 2 || preparation.RequiredMaintainerAuthorization == "" {
+		t.Fatalf("batch preparation = %#v", preparation)
+	}
+
+	request := batchReconcileCLIRequest(preparation)
+	input := writeBatchReconcileCLIJSON(t, request)
+	var output bytes.Buffer
+	if err := RunReview([]string{"reconcile-authority-batch", "--cwd", repo, "--input", input}, &output); err != nil {
+		t.Fatalf("review reconcile-authority-batch: %v\n%s", err, output.String())
+	}
+	var result ReviewReconcileAuthorityBatchResult
+	decodeStrictReviewJSON(t, output.Bytes(), &result)
+	if result.Schema != ReviewReconcileAuthorityBatchResultSchema || result.Operation != "review/reconcile-authority-batch" ||
+		result.Mode != "committed" || result.Journal == nil || result.Journal.Status != reviewtransaction.CompactBatchReconcileCommitted || result.Preparation != nil {
+		t.Fatalf("batch reconcile result = %#v", result)
+	}
+	if _, err := reviewtransaction.CompactAuthorityLeaves(context.Background(), repo); err != nil {
+		t.Fatalf("post-batch authority graph: %v", err)
+	}
+
+	output.Reset()
+	if err := RunReview([]string{"reconcile-authority-batch", "--cwd", repo, "--input", input}, &output); err != nil {
+		t.Fatalf("exact CLI replay: %v", err)
+	}
+	var replay ReviewReconcileAuthorityBatchResult
+	decodeStrictReviewJSON(t, output.Bytes(), &replay)
+	if replay.Journal == nil || replay.Journal.RequestSHA256 != result.Journal.RequestSHA256 || replay.Journal.ReconciledAt != result.Journal.ReconciledAt {
+		t.Fatalf("exact CLI replay = %#v", replay)
+	}
+}
+
+func TestReviewReconcileAuthorityBatchRefusesInvalidDeclarationAndStalePlanWithoutMutation(t *testing.T) {
+	t.Run("incomplete declaration", func(t *testing.T) {
+		repo, declarations := batchReconcileCLIFixture(t)
+		input := writeBatchReconcileCLIJSON(t, ReviewReconcileAuthorityBatchPreparationInput{
+			Schema:               ReviewReconcileAuthorityBatchPreparationInputSchema,
+			DeclaredInvalidEdges: declarations[:1], Actor: batchReconcileCLIActor, Reason: batchReconcileCLIReason,
+		})
+		if err := RunReview([]string{"reconcile-authority-batch", "--prepare", "--cwd", repo, "--input", input}, &bytes.Buffer{}); err == nil || !strings.Contains(err.Error(), "declaration set is incomplete") {
+			t.Fatalf("incomplete declaration error = %v", err)
+		}
+		assertBatchReconcileCLISourcesPresent(t, repo, declarations)
+	})
+
+	t.Run("stale prepared revision", func(t *testing.T) {
+		repo, declarations := batchReconcileCLIFixture(t)
+		preparation := runBatchReconcileCLIPrepare(t, repo, declarations)
+		lineage := preparation.Plan.QuarantineEntries[0].LineageID
+		store, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, lineage)
+		if err != nil {
+			t.Fatal(err)
+		}
+		record, err := store.Load()
+		if err != nil {
+			t.Fatal(err)
+		}
+		record.State.Recovery.RecoveredAt = record.State.Recovery.RecoveredAt.Add(time.Minute)
+		writeReconcileCLIRecord(t, repo, record.State)
+
+		input := writeBatchReconcileCLIJSON(t, batchReconcileCLIRequest(preparation))
+		if err := RunReview([]string{"reconcile-authority-batch", "--cwd", repo, "--input", input}, &bytes.Buffer{}); !errors.Is(err, reviewtransaction.ErrConcurrentUpdate) {
+			t.Fatalf("stale batch plan error = %v", err)
+		}
+		assertBatchReconcileCLISourcesPresent(t, repo, declarations)
+	})
+}
+
+func TestReviewReconcileAuthorityBatchHonorsLockCancellation(t *testing.T) {
+	repo, declarations := batchReconcileCLIFixture(t)
+	input := writeBatchReconcileCLIJSON(t, ReviewReconcileAuthorityBatchPreparationInput{
+		Schema:               ReviewReconcileAuthorityBatchPreparationInputSchema,
+		DeclaredInvalidEdges: declarations, Actor: batchReconcileCLIActor, Reason: batchReconcileCLIReason,
+	})
+	holdCtx, release := context.WithTimeout(context.Background(), 2*time.Second)
+	defer release()
+	held, err := reviewtransaction.AcquireReviewMaintenanceExclusive(holdCtx, repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer held.Release()
+	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
+	defer cancel()
+	var output bytes.Buffer
+	if err := runReviewReconcileAuthorityBatch(ctx, []string{"--prepare", "--cwd", repo, "--input", input}, &output); !errors.Is(err, reviewtransaction.ErrAuthorityLockCancelled) || output.Len() != 0 {
+		t.Fatalf("batch lock cancellation = %v, output=%q", err, output.String())
+	}
+}
+
+func TestReviewReconcileAuthorityBatchHelpAndInputContract(t *testing.T) {
+	var help bytes.Buffer
+	if err := RunReview([]string{"reconcile-authority-batch", "--help"}, &help); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(help.String(), "Usage: gentle-ai review reconcile-authority-batch [flags]") || !strings.Contains(help.String(), "--prepare") {
+		t.Fatalf("batch reconcile help:\n%s", help.String())
+	}
+	for _, tt := range []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"missing input", []string{"reconcile-authority-batch"}, "requires --input"},
+		{"positional", []string{"reconcile-authority-batch", "extra", "--input", "ignored"}, `unexpected review reconcile-authority-batch argument "extra"`},
+		{"unknown flag", []string{"reconcile-authority-batch", "--unknown"}, "flag provided but not defined"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := RunReview(tt.args, &bytes.Buffer{}); err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("input error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func runBatchReconcileCLIPrepare(t *testing.T, repo string, declarations []reviewtransaction.CompactRecoveryEdgeInspection) reviewtransaction.CompactBatchReconcilePreparation {
+	t.Helper()
+	input := writeBatchReconcileCLIJSON(t, ReviewReconcileAuthorityBatchPreparationInput{
+		Schema:               ReviewReconcileAuthorityBatchPreparationInputSchema,
+		DeclaredInvalidEdges: declarations, Actor: batchReconcileCLIActor, Reason: batchReconcileCLIReason,
+	})
+	var output bytes.Buffer
+	if err := RunReview([]string{"reconcile-authority-batch", "--prepare", "--cwd", repo, "--input", input}, &output); err != nil {
+		t.Fatalf("prepare review reconcile-authority-batch: %v\n%s", err, output.String())
+	}
+	var result ReviewReconcileAuthorityBatchResult
+	decodeStrictReviewJSON(t, output.Bytes(), &result)
+	if result.Mode != "prepared" || result.Preparation == nil || result.Journal != nil {
+		t.Fatalf("batch preparation result = %#v", result)
+	}
+	return *result.Preparation
+}
+
+func batchReconcileCLIRequest(preparation reviewtransaction.CompactBatchReconcilePreparation) reviewtransaction.CompactBatchReconcileRequest {
+	return reviewtransaction.CompactBatchReconcileRequest{
+		Schema:               reviewtransaction.CompactBatchReconcileRequestSchema,
+		DeclaredInvalidEdges: preparation.DeclaredInvalidEdges,
+		ExpectedPlan:         preparation.Plan, ExpectedPlanSHA256: preparation.PlanSHA256,
+		Actor: batchReconcileCLIActor, Reason: batchReconcileCLIReason,
+		MaintainerAuthorization: preparation.RequiredMaintainerAuthorization,
+	}
+}
+
+func batchReconcileCLIFixture(t *testing.T) (string, []reviewtransaction.CompactRecoveryEdgeInspection) {
+	t.Helper()
+	repo := initReviewCLIRepo(t)
+	batchReconcileCLIInvalidPair(t, repo, "batch-a")
+	batchReconcileCLIInvalidPair(t, repo, "batch-b")
+	report, err := reviewtransaction.InspectCompactRecoveryEdges(context.Background(), repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	declarations := []reviewtransaction.CompactRecoveryEdgeInspection{}
+	for _, edge := range report.Edges {
+		if !edge.Valid {
+			declarations = append(declarations, edge)
+		}
+	}
+	if len(declarations) != 2 {
+		t.Fatalf("batch CLI invalid edges = %#v", report)
+	}
+	return repo, declarations
+}
+
+func batchReconcileCLIInvalidPair(t *testing.T, repo, prefix string) {
+	t.Helper()
+	logicalPath := "docs/" + prefix + ".md"
+	path := filepath.Join(repo, filepath.FromSlash(logicalPath))
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(prefix+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	builder := reviewtransaction.SnapshotBuilder{Repo: repo}
+	snapshot, err := builder.Build(context.Background(), reviewtransaction.Target{
+		Kind: reviewtransaction.TargetCurrentChanges, IntendedUntracked: []string{logicalPath},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	risk, lines, err := builder.ClassifySnapshotRisk(context.Background(), snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	policy := sha256.Sum256([]byte("batch-reconcile-cli-" + prefix))
+	policyHash := "sha256:" + hex.EncodeToString(policy[:])
+	predecessor, err := reviewtransaction.NewCompactState(reviewtransaction.Start{
+		LineageID: prefix + "-predecessor", Mode: reviewtransaction.ModeOrdinaryBounded, Generation: 1,
+		Snapshot: snapshot, PolicyHash: policyHash, RiskLevel: risk, SelectedLenses: []string{}, OriginalChangedLines: &lines,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	predecessor.State = reviewtransaction.StateEscalated
+	predecessorRevision := writeReconcileCLIRecord(t, repo, predecessor)
+	successor, err := reviewtransaction.NewCompactState(reviewtransaction.Start{
+		LineageID: prefix + "-successor", Mode: reviewtransaction.ModeOrdinaryBounded, Generation: 2,
+		Snapshot: snapshot, PolicyHash: policyHash, RiskLevel: risk, SelectedLenses: []string{}, OriginalChangedLines: &lines,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	successor.Recovery = &reviewtransaction.CompactRecoveryProvenance{
+		PredecessorLineageID: predecessor.LineageID, PredecessorRevision: predecessorRevision,
+		Disposition: reviewtransaction.RecoveryEscalated, Reason: "retry batch incident", Actor: batchReconcileCLIActor,
+		RecoveredAt:             time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC),
+		MaintainerAuthorization: "historical maintainer approval",
+	}
+	writeReconcileCLIRecord(t, repo, successor)
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeBatchReconcileCLIJSON(t *testing.T, value any) string {
+	t.Helper()
+	payload, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "batch-reconcile.json")
+	if err := os.WriteFile(path, append(payload, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func assertBatchReconcileCLISourcesPresent(t *testing.T, repo string, declarations []reviewtransaction.CompactRecoveryEdgeInspection) {
+	t.Helper()
+	for _, edge := range declarations {
+		store, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, edge.SuccessorLineageID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := store.Load(); err != nil {
+			t.Fatalf("source %q mutated after refusal: %v", edge.SuccessorLineageID, err)
+		}
+	}
+}

--- a/internal/cli/review_status_contract.go
+++ b/internal/cli/review_status_contract.go
@@ -80,6 +80,7 @@ var reviewManagedActions = []string{
 	"review.quarantine-legacy",
 	"review.reclaim",
 	"review.reconcile-authority",
+	"review.reconcile-authority-batch",
 	"review.recover",
 	"review.start",
 	"review.validate",

--- a/internal/reviewtransaction/compact_batch_reconcile_guard.go
+++ b/internal/reviewtransaction/compact_batch_reconcile_guard.go
@@ -1,0 +1,323 @@
+package reviewtransaction
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+)
+
+const CompactBatchReconcilePreparationSchema = "gentle-ai.review-batch-reconcile-preparation/v1"
+const CompactBatchReconcileRequestSchema = "gentle-ai.review-batch-reconcile-request/v1"
+const compactBatchReconcileAuthorizationSchema = "gentle-ai.review-batch-reconcile-authorization/v1"
+
+// CompactBatchReconcilePreparation is the immutable authorization template
+// produced from one exclusively locked authority snapshot.
+type CompactBatchReconcilePreparation struct {
+	Schema                          string                          `json:"schema"`
+	RepositorySHA256                string                          `json:"repository_sha256"`
+	PlanSHA256                      string                          `json:"plan_sha256"`
+	InvalidEdgesSHA256              string                          `json:"invalid_edges_sha256"`
+	ValidDescendantSuffixesSHA256   string                          `json:"valid_descendant_suffixes_sha256"`
+	QuarantineEntriesSHA256         string                          `json:"quarantine_entries_sha256"`
+	DeclaredInvalidEdges            []CompactRecoveryEdgeInspection `json:"declared_invalid_edges"`
+	Plan                            CompactBatchReconcilePlan       `json:"plan"`
+	RequiredMaintainerAuthorization string                          `json:"required_maintainer_authorization"`
+}
+
+// CompactBatchReconcileRequest carries the exact prepared plan and the
+// maintainer's byte-exact authorization for a later locked revalidation.
+type CompactBatchReconcileRequest struct {
+	Schema                  string                          `json:"schema"`
+	DeclaredInvalidEdges    []CompactRecoveryEdgeInspection `json:"declared_invalid_edges"`
+	ExpectedPlan            CompactBatchReconcilePlan       `json:"expected_plan"`
+	ExpectedPlanSHA256      string                          `json:"expected_plan_sha256"`
+	Actor                   string                          `json:"actor"`
+	Reason                  string                          `json:"reason"`
+	MaintainerAuthorization string                          `json:"maintainer_authorization"`
+}
+
+type compactBatchReconcileLocks struct {
+	base        string
+	repository  string
+	versionRoot string
+	maintenance *MaintenanceLock
+	store       *storeLock
+}
+
+// PrepareCompactBatchReconciliation obtains exclusive maintenance ownership,
+// then the compact-v2 lock, and derives the exact plan and authorization
+// template. It performs no authority mutation.
+func PrepareCompactBatchReconciliation(ctx context.Context, repo string, declaredInvalid []CompactRecoveryEdgeInspection, actor, reason string) (CompactBatchReconcilePreparation, error) {
+	actor, reason, err := validateCompactBatchReconcileIdentity(actor, reason)
+	if err != nil {
+		return CompactBatchReconcilePreparation{}, err
+	}
+	locks, err := acquireCompactBatchReconcileLocks(ctx, repo, false)
+	if err != nil {
+		return CompactBatchReconcilePreparation{}, err
+	}
+	defer locks.release()
+	snapshot, err := loadCompactBatchReconcileSnapshotLocked(ctx, locks)
+	if err != nil {
+		return CompactBatchReconcilePreparation{}, err
+	}
+	plan, err := PlanCompactBatchReconciliation(snapshot, declaredInvalid)
+	if err != nil {
+		return CompactBatchReconcilePreparation{}, err
+	}
+	return newCompactBatchReconcilePreparation(locks.repository, plan, actor, reason)
+}
+
+// validateCompactBatchReconcileRequest repeats preparation under the same lock
+// order and refuses any stale record, classification, declaration, suffix, or
+// authorization. Mutation code calls the locked variant without releasing the
+// guards between validation and publication.
+func validateCompactBatchReconcileRequest(ctx context.Context, repo string, request CompactBatchReconcileRequest) (CompactBatchReconcilePlan, error) {
+	if err := validateCompactBatchReconcileRequestShape(request); err != nil {
+		return CompactBatchReconcilePlan{}, err
+	}
+	locks, err := acquireCompactBatchReconcileLocks(ctx, repo, false)
+	if err != nil {
+		return CompactBatchReconcilePlan{}, err
+	}
+	defer locks.release()
+	return validateCompactBatchReconcileRequestLocked(ctx, locks, request)
+}
+
+func validateCompactBatchReconcileRequestLocked(ctx context.Context, locks *compactBatchReconcileLocks, request CompactBatchReconcileRequest) (CompactBatchReconcilePlan, error) {
+	snapshot, err := loadCompactBatchReconcileSnapshotLocked(ctx, locks)
+	if err != nil {
+		return CompactBatchReconcilePlan{}, err
+	}
+	if !snapshot.Inspection.Complete {
+		return CompactBatchReconcilePlan{}, compactBatchPlanErrorf("inspection is incomplete")
+	}
+	if err := rejectCompactBatchStaleDeclarations(snapshot.Inspection, request.DeclaredInvalidEdges); err != nil {
+		return CompactBatchReconcilePlan{}, err
+	}
+	plan, err := PlanCompactBatchReconciliation(snapshot, request.DeclaredInvalidEdges)
+	if err != nil {
+		return CompactBatchReconcilePlan{}, err
+	}
+	if !reflect.DeepEqual(plan, request.ExpectedPlan) {
+		return CompactBatchReconcilePlan{}, fmt.Errorf("%w: locked authority plan no longer matches the prepared plan", ErrConcurrentUpdate)
+	}
+	actor, reason, err := validateCompactBatchReconcileIdentity(request.Actor, request.Reason)
+	if err != nil {
+		return CompactBatchReconcilePlan{}, err
+	}
+	preparation, err := newCompactBatchReconcilePreparation(locks.repository, plan, actor, reason)
+	if err != nil {
+		return CompactBatchReconcilePlan{}, err
+	}
+	if request.ExpectedPlanSHA256 != preparation.PlanSHA256 {
+		return CompactBatchReconcilePlan{}, fmt.Errorf("%w: locked plan digest changed", ErrConcurrentUpdate)
+	}
+	if request.MaintainerAuthorization != preparation.RequiredMaintainerAuthorization {
+		return CompactBatchReconcilePlan{}, fmt.Errorf("review reconcile-authority-batch requires an exact maintainer authorization binding (schema %s over repository, plan, declared invalid edges, valid descendant suffixes, quarantine entries, actor, and reason)", compactBatchReconcileAuthorizationSchema)
+	}
+	return plan, nil
+}
+
+func validateCompactBatchReconcileRequestShape(request CompactBatchReconcileRequest) error {
+	if request.Schema != CompactBatchReconcileRequestSchema {
+		return errors.New("review reconcile-authority-batch requires the exact request schema")
+	}
+	if request.DeclaredInvalidEdges == nil || request.ExpectedPlan.InvalidEdges == nil ||
+		strings.TrimSpace(request.ExpectedPlanSHA256) == "" || strings.TrimSpace(request.MaintainerAuthorization) == "" {
+		return errors.New("review reconcile-authority-batch requires declared invalid edges, an expected plan and digest, and maintainer authorization")
+	}
+	if _, _, err := validateCompactBatchReconcileIdentity(request.Actor, request.Reason); err != nil {
+		return err
+	}
+	digest, err := compactBatchReconcileDigest("plan", request.ExpectedPlan)
+	if err != nil {
+		return err
+	}
+	if request.ExpectedPlanSHA256 != digest {
+		return errors.New("review reconcile-authority-batch expected plan digest does not bind the supplied plan")
+	}
+	return nil
+}
+
+func validateCompactBatchReconcileIdentity(actor, reason string) (string, string, error) {
+	actor, reason = strings.TrimSpace(actor), strings.TrimSpace(reason)
+	if actor == "" || reason == "" {
+		return "", "", errors.New("review reconcile-authority-batch requires a non-empty actor and reason")
+	}
+	if strings.ContainsAny(actor, "\r\n") || strings.ContainsAny(reason, "\r\n") {
+		return "", "", errors.New("review reconcile-authority-batch actor and reason must each fit on one LF binding line")
+	}
+	return actor, reason, nil
+}
+
+func acquireCompactBatchReconcileLocks(ctx context.Context, repo string, allowPreparedBatch bool) (*compactBatchReconcileLocks, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	base, repository, err := reviewAuthorityRoot(ctx, repo)
+	if err != nil {
+		return nil, err
+	}
+	var maintenance *MaintenanceLock
+	if allowPreparedBatch {
+		maintenance, err = acquireMaintenanceLockForCompactBatch(ctx, compactMaintenanceLockPath(base))
+	} else {
+		maintenance, err = acquireMaintenanceLock(ctx, compactMaintenanceLockPath(base), maintenanceExclusive)
+	}
+	if err != nil {
+		return nil, err
+	}
+	versionRoot := filepath.Join(base, "v2")
+	local, err := acquireLocalStoreLock(filepath.Join(versionRoot, "LOCK"))
+	if err != nil {
+		_ = maintenance.Release()
+		return nil, err
+	}
+	if err := ctx.Err(); err != nil {
+		_ = local.release()
+		_ = maintenance.Release()
+		return nil, err
+	}
+	return &compactBatchReconcileLocks{
+		base: base, repository: repository, versionRoot: versionRoot,
+		maintenance: maintenance, store: local,
+	}, nil
+}
+
+func (locks *compactBatchReconcileLocks) release() error {
+	if locks == nil {
+		return nil
+	}
+	var storeErr, maintenanceErr error
+	if locks.store != nil {
+		storeErr = locks.store.release()
+		locks.store = nil
+	}
+	if locks.maintenance != nil {
+		maintenanceErr = locks.maintenance.Release()
+		locks.maintenance = nil
+	}
+	return errors.Join(storeErr, maintenanceErr)
+}
+
+func loadCompactBatchReconcileSnapshotLocked(ctx context.Context, locks *compactBatchReconcileLocks) (CompactBatchReconcileSnapshot, error) {
+	report := CompactRecoveryInspectionReport{
+		Complete: true, Valid: true, Edges: []CompactRecoveryEdgeInspection{},
+		EntryDiagnostics: []CompactRecoveryEntryDiagnostic{},
+	}
+	entries, err := os.ReadDir(locks.versionRoot)
+	if os.IsNotExist(err) {
+		return CompactBatchReconcileSnapshot{Inspection: report, Records: []CompactRecord{}}, nil
+	}
+	if err != nil {
+		return CompactBatchReconcileSnapshot{}, fmt.Errorf("inspect compact batch authority: %w", err)
+	}
+	records := make(map[string]CompactRecord, len(entries))
+	ordered := make([]CompactRecord, 0, len(entries))
+	for _, entry := range entries {
+		if err := ctx.Err(); err != nil {
+			return CompactBatchReconcileSnapshot{}, err
+		}
+		if !entry.IsDir() {
+			if entry.Name() != "LOCK" {
+				report.EntryDiagnostics = append(report.EntryDiagnostics, CompactRecoveryEntryDiagnostic{
+					LineageID: entry.Name(), Problem: compactInspectionEntryUnexpected,
+				})
+			}
+			continue
+		}
+		report.Totals.CompactEntries++
+		store := CompactStore{Dir: filepath.Join(locks.versionRoot, entry.Name()), lineageID: entry.Name(), repo: locks.repository}
+		record, loadErr := store.loadCompactRecordLocked()
+		if loadErr != nil {
+			report.EntryDiagnostics = append(report.EntryDiagnostics, CompactRecoveryEntryDiagnostic{
+				LineageID: entry.Name(), Problem: compactRecoveryEntryProblem(loadErr),
+			})
+			continue
+		}
+		report.Totals.LoadedEntries++
+		records[record.State.LineageID] = record
+		ordered = append(ordered, record)
+	}
+	report, err = inspectCompactRecoveryRecordSet(ctx, records, report)
+	if err != nil {
+		return CompactBatchReconcileSnapshot{}, err
+	}
+	return CompactBatchReconcileSnapshot{Inspection: report, Records: ordered}, nil
+}
+
+func rejectCompactBatchStaleDeclarations(inspection CompactRecoveryInspectionReport, declared []CompactRecoveryEdgeInspection) error {
+	current := make(map[string]CompactRecoveryEdgeInspection, len(inspection.Edges))
+	for _, edge := range inspection.Edges {
+		current[edge.SuccessorLineageID] = edge
+	}
+	for _, expected := range declared {
+		observed, found := current[expected.SuccessorLineageID]
+		if !found {
+			return fmt.Errorf("%w: declared recovery successor %q is absent", ErrConcurrentUpdate, expected.SuccessorLineageID)
+		}
+		if expected.PredecessorLineageID != observed.PredecessorLineageID ||
+			expected.RecordedPredecessorRevision != observed.RecordedPredecessorRevision ||
+			expected.ObservedPredecessorRevision != observed.ObservedPredecessorRevision ||
+			expected.SuccessorRevision != observed.SuccessorRevision ||
+			!reflect.DeepEqual(expected.AnomalyClasses, observed.AnomalyClasses) {
+			return fmt.Errorf("%w: locked recovery edge %q changed revision, identity, or anomaly classification", ErrConcurrentUpdate, expected.SuccessorLineageID)
+		}
+	}
+	return nil
+}
+
+func newCompactBatchReconcilePreparation(repository string, plan CompactBatchReconcilePlan, actor, reason string) (CompactBatchReconcilePreparation, error) {
+	repositorySHA256, err := compactBatchReconcileDigest("repository", filepath.Clean(repository))
+	if err != nil {
+		return CompactBatchReconcilePreparation{}, err
+	}
+	planSHA256, err := compactBatchReconcileDigest("plan", plan)
+	if err != nil {
+		return CompactBatchReconcilePreparation{}, err
+	}
+	invalidEdgesSHA256, err := compactBatchReconcileDigest("invalid-edges", plan.InvalidEdges)
+	if err != nil {
+		return CompactBatchReconcilePreparation{}, err
+	}
+	suffixesSHA256, err := compactBatchReconcileDigest("valid-descendant-suffixes", plan.ValidDescendantSuffixes)
+	if err != nil {
+		return CompactBatchReconcilePreparation{}, err
+	}
+	quarantineSHA256, err := compactBatchReconcileDigest("quarantine-entries", plan.QuarantineEntries)
+	if err != nil {
+		return CompactBatchReconcilePreparation{}, err
+	}
+	preparation := CompactBatchReconcilePreparation{
+		Schema:           CompactBatchReconcilePreparationSchema,
+		RepositorySHA256: repositorySHA256, PlanSHA256: planSHA256,
+		InvalidEdgesSHA256: invalidEdgesSHA256, ValidDescendantSuffixesSHA256: suffixesSHA256,
+		QuarantineEntriesSHA256: quarantineSHA256,
+		DeclaredInvalidEdges:    cloneCompactRecoveryEdges(plan.InvalidEdges), Plan: plan,
+	}
+	preparation.RequiredMaintainerAuthorization = compactBatchReconcileAuthorizationSchema +
+		"\nrepository_sha256=" + repositorySHA256 +
+		"\nplan_sha256=" + planSHA256 +
+		"\ninvalid_edges_sha256=" + invalidEdgesSHA256 +
+		"\nvalid_descendant_suffixes_sha256=" + suffixesSHA256 +
+		"\nquarantine_entries_sha256=" + quarantineSHA256 +
+		"\nactor=" + actor + "\nreason=" + reason
+	return preparation, nil
+}
+
+func compactBatchReconcileDigest(domain string, value any) (string, error) {
+	payload, err := json.Marshal(value)
+	if err != nil {
+		return "", fmt.Errorf("marshal compact batch %s digest: %w", domain, err)
+	}
+	sum := sha256.Sum256(append([]byte("gentle-ai.review-batch-reconcile-"+domain+"/v1\x00"), payload...))
+	return "sha256:" + hex.EncodeToString(sum[:]), nil
+}

--- a/internal/reviewtransaction/compact_batch_reconcile_journal.go
+++ b/internal/reviewtransaction/compact_batch_reconcile_journal.go
@@ -1,0 +1,592 @@
+package reviewtransaction
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"time"
+)
+
+const CompactBatchReconcileJournalSchema = "gentle-ai.review-batch-reconcile-journal/v1"
+
+const (
+	CompactBatchReconcilePrepared  = "prepared"
+	CompactBatchReconcileCommitted = "committed"
+	compactBatchReconcileMarker    = "batch-reconcile-journal.json"
+	compactBatchReconcileAudit     = "batch-reconcile-journal.json"
+)
+
+var ErrCompactBatchReconcilePrepared = errors.New("compact batch reconciliation is prepared; exact replay is required")
+
+var writeCompactBatchReconcileJournalAtomic = writeAtomic
+var renameCompactBatchReconcileEntry = os.Rename
+var syncCompactBatchReconcileDirectory = SyncReviewDirectory
+var removeCompactBatchReconcileMarker = os.Remove
+
+// CompactBatchReconcileMove binds one whole compact-v2 entry move by relative
+// canonical paths, content-addressed state identity, and exact residue names.
+type CompactBatchReconcileMove struct {
+	LineageID              string   `json:"lineage_id"`
+	Revision               string   `json:"revision"`
+	InitialTargetIdentity  string   `json:"initial_target_identity"`
+	CurrentTargetIdentity  string   `json:"current_target_identity"`
+	SourceRelativePath     string   `json:"source_relative_path"`
+	QuarantineRelativePath string   `json:"quarantine_relative_path"`
+	Residue                []string `json:"residue"`
+}
+
+// CompactBatchReconcileJournal is both the global fail-closed marker while an
+// operation is prepared and the durable audit record after it commits.
+type CompactBatchReconcileJournal struct {
+	Schema                        string                          `json:"schema"`
+	Status                        string                          `json:"status"`
+	RequestSHA256                 string                          `json:"request_sha256"`
+	RepositorySHA256              string                          `json:"repository_sha256"`
+	PlanSHA256                    string                          `json:"plan_sha256"`
+	InvalidEdgesSHA256            string                          `json:"invalid_edges_sha256"`
+	ValidDescendantSuffixesSHA256 string                          `json:"valid_descendant_suffixes_sha256"`
+	QuarantineEntriesSHA256       string                          `json:"quarantine_entries_sha256"`
+	MaintainerAuthorizationSHA256 string                          `json:"maintainer_authorization_sha256"`
+	Actor                         string                          `json:"actor"`
+	Reason                        string                          `json:"reason"`
+	ReconciledAt                  time.Time                       `json:"reconciled_at"`
+	AuditRelativePath             string                          `json:"audit_relative_path"`
+	DeclaredInvalidEdges          []CompactRecoveryEdgeInspection `json:"declared_invalid_edges"`
+	Plan                          CompactBatchReconcilePlan       `json:"plan"`
+	Moves                         []CompactBatchReconcileMove     `json:"moves"`
+}
+
+// ReconcileInvalidRecoveryEdges executes or exactly replays one prepared
+// all-or-nothing batch while holding the authority maintenance lock exclusively
+// and the compact-v2 lock. A non-nil error may return the prepared journal;
+// callers must preserve it because it identifies the only admissible replay.
+func ReconcileInvalidRecoveryEdges(ctx context.Context, repo string, request CompactBatchReconcileRequest) (CompactBatchReconcileJournal, error) {
+	if err := validateCompactBatchReconcileRequestShape(request); err != nil {
+		return CompactBatchReconcileJournal{}, err
+	}
+	locks, err := acquireCompactBatchReconcileLocks(ctx, repo, true)
+	if err != nil {
+		return CompactBatchReconcileJournal{}, err
+	}
+	defer locks.release()
+
+	expected, err := newCompactBatchReconcileJournal(locks, request)
+	if err != nil {
+		return CompactBatchReconcileJournal{}, err
+	}
+	markerPath := compactBatchReconcileMarkerPath(locks.base)
+	marker, markerErr := readCompactBatchReconcileJournal(markerPath)
+	switch {
+	case markerErr == nil:
+		if !compactBatchJournalMatchesRequest(marker, expected) {
+			return CompactBatchReconcileJournal{}, fmt.Errorf("%w: a different prepared batch owns authority maintenance", ErrCompactBatchReconcilePrepared)
+		}
+		return replayCompactBatchReconcileJournalLocked(ctx, locks, marker)
+	case !os.IsNotExist(markerErr):
+		return CompactBatchReconcileJournal{}, fmt.Errorf("%w: global marker is unreadable", ErrCompactBatchReconcilePrepared)
+	}
+
+	auditPath := filepath.Join(locks.base, filepath.FromSlash(expected.AuditRelativePath))
+	audit, auditErr := readCompactBatchReconcileJournal(auditPath)
+	if auditErr == nil {
+		if !compactBatchJournalMatchesRequest(audit, expected) {
+			return CompactBatchReconcileJournal{}, errors.New("review reconcile-authority-batch refused a conflicting deterministic audit directory")
+		}
+		if audit.Status == CompactBatchReconcileCommitted {
+			if err := verifyCompactBatchMovesAndRetainedGraphLocked(ctx, locks, audit); err != nil {
+				return CompactBatchReconcileJournal{}, err
+			}
+			return audit, nil
+		}
+		if err := persistCompactBatchReconcileJournal(markerPath, audit); err != nil {
+			return audit, err
+		}
+		return replayCompactBatchReconcileJournalLocked(ctx, locks, audit)
+	}
+	if !os.IsNotExist(auditErr) {
+		return CompactBatchReconcileJournal{}, fmt.Errorf("inspect deterministic compact batch audit: %w", auditErr)
+	}
+
+	plan, err := validateCompactBatchReconcileRequestLocked(ctx, locks, request)
+	if err != nil {
+		return CompactBatchReconcileJournal{}, err
+	}
+	if !reflect.DeepEqual(plan, expected.Plan) {
+		return CompactBatchReconcileJournal{}, fmt.Errorf("%w: prepared plan changed before journal creation", ErrConcurrentUpdate)
+	}
+	journal, err := bindCompactBatchReconcileMovesLocked(locks, expected)
+	if err != nil {
+		return CompactBatchReconcileJournal{}, err
+	}
+	if err := persistCompactBatchReconcileJournal(markerPath, journal); err != nil {
+		return journal, err
+	}
+	return replayCompactBatchReconcileJournalLocked(ctx, locks, journal)
+}
+
+func newCompactBatchReconcileJournal(locks *compactBatchReconcileLocks, request CompactBatchReconcileRequest) (CompactBatchReconcileJournal, error) {
+	actor, reason, err := validateCompactBatchReconcileIdentity(request.Actor, request.Reason)
+	if err != nil {
+		return CompactBatchReconcileJournal{}, err
+	}
+	preparation, err := newCompactBatchReconcilePreparation(locks.repository, request.ExpectedPlan, actor, reason)
+	if err != nil {
+		return CompactBatchReconcileJournal{}, err
+	}
+	authorizationSHA256, err := compactBatchReconcileDigest("maintainer-authorization", request.MaintainerAuthorization)
+	if err != nil {
+		return CompactBatchReconcileJournal{}, err
+	}
+	identity := compactBatchReconcileRequestIdentity{
+		Schema:           CompactBatchReconcileRequestSchema,
+		RepositorySHA256: preparation.RepositorySHA256, PlanSHA256: preparation.PlanSHA256,
+		InvalidEdgesSHA256:            preparation.InvalidEdgesSHA256,
+		ValidDescendantSuffixesSHA256: preparation.ValidDescendantSuffixesSHA256,
+		QuarantineEntriesSHA256:       preparation.QuarantineEntriesSHA256,
+		MaintainerAuthorizationSHA256: authorizationSHA256,
+		Actor:                         actor, Reason: reason,
+	}
+	requestSHA256, err := compactBatchReconcileDigest("request", identity)
+	if err != nil {
+		return CompactBatchReconcileJournal{}, err
+	}
+	plan, err := cloneCompactBatchReconcilePlan(request.ExpectedPlan)
+	if err != nil {
+		return CompactBatchReconcileJournal{}, err
+	}
+	batchName := "batch-" + strings.TrimPrefix(requestSHA256, "sha256:")
+	return CompactBatchReconcileJournal{
+		Schema: CompactBatchReconcileJournalSchema, Status: CompactBatchReconcilePrepared,
+		RequestSHA256: requestSHA256, RepositorySHA256: preparation.RepositorySHA256,
+		PlanSHA256: preparation.PlanSHA256, InvalidEdgesSHA256: preparation.InvalidEdgesSHA256,
+		ValidDescendantSuffixesSHA256: preparation.ValidDescendantSuffixesSHA256,
+		QuarantineEntriesSHA256:       preparation.QuarantineEntriesSHA256,
+		MaintainerAuthorizationSHA256: authorizationSHA256,
+		Actor:                         actor, Reason: reason, ReconciledAt: time.Now().UTC(),
+		AuditRelativePath:    filepath.ToSlash(filepath.Join("quarantine", batchName, compactBatchReconcileAudit)),
+		DeclaredInvalidEdges: cloneCompactRecoveryEdges(plan.InvalidEdges), Plan: plan,
+		Moves: []CompactBatchReconcileMove{},
+	}, nil
+}
+
+type compactBatchReconcileRequestIdentity struct {
+	Schema                        string `json:"schema"`
+	RepositorySHA256              string `json:"repository_sha256"`
+	PlanSHA256                    string `json:"plan_sha256"`
+	InvalidEdgesSHA256            string `json:"invalid_edges_sha256"`
+	ValidDescendantSuffixesSHA256 string `json:"valid_descendant_suffixes_sha256"`
+	QuarantineEntriesSHA256       string `json:"quarantine_entries_sha256"`
+	MaintainerAuthorizationSHA256 string `json:"maintainer_authorization_sha256"`
+	Actor                         string `json:"actor"`
+	Reason                        string `json:"reason"`
+}
+
+func bindCompactBatchReconcileMovesLocked(locks *compactBatchReconcileLocks, journal CompactBatchReconcileJournal) (CompactBatchReconcileJournal, error) {
+	batchRoot := filepath.Dir(filepath.Join(locks.base, filepath.FromSlash(journal.AuditRelativePath)))
+	entriesRoot := filepath.Join(batchRoot, "entries")
+	journal.Moves = make([]CompactBatchReconcileMove, 0, len(journal.Plan.QuarantineEntries))
+	for _, entry := range journal.Plan.QuarantineEntries {
+		source := filepath.Join(locks.versionRoot, entry.LineageID)
+		if err := ensureCompactBatchSourceIdentity(source, entry); err != nil {
+			return CompactBatchReconcileJournal{}, err
+		}
+		items, err := os.ReadDir(source)
+		if err != nil {
+			return CompactBatchReconcileJournal{}, fmt.Errorf("inspect compact batch source %q: %w", entry.LineageID, err)
+		}
+		residue := make([]string, len(items))
+		for index, item := range items {
+			residue[index] = item.Name()
+		}
+		sort.Strings(residue)
+		journal.Moves = append(journal.Moves, CompactBatchReconcileMove{
+			LineageID: entry.LineageID, Revision: entry.Revision,
+			InitialTargetIdentity: entry.InitialTargetIdentity, CurrentTargetIdentity: entry.CurrentTargetIdentity,
+			SourceRelativePath:     filepath.ToSlash(filepath.Join("v2", entry.LineageID)),
+			QuarantineRelativePath: filepath.ToSlash(filepath.Join(strings.TrimSuffix(journal.AuditRelativePath, "/"+compactBatchReconcileAudit), "entries", entry.LineageID)),
+			Residue:                residue,
+		})
+	}
+	if err := ensureCompactBatchJournalDirectories(locks.base, batchRoot, entriesRoot); err != nil {
+		return journal, err
+	}
+	return journal, nil
+}
+
+func replayCompactBatchReconcileJournalLocked(ctx context.Context, locks *compactBatchReconcileLocks, journal CompactBatchReconcileJournal) (CompactBatchReconcileJournal, error) {
+	batchRoot := filepath.Dir(filepath.Join(locks.base, filepath.FromSlash(journal.AuditRelativePath)))
+	entriesRoot := filepath.Join(batchRoot, "entries")
+	if err := ensureCompactBatchJournalDirectories(locks.base, batchRoot, entriesRoot); err != nil {
+		return journal, err
+	}
+	auditPath := filepath.Join(locks.base, filepath.FromSlash(journal.AuditRelativePath))
+	if existing, err := readCompactBatchReconcileJournal(auditPath); err == nil {
+		if !compactBatchJournalMatchesRequest(existing, journal) {
+			return journal, errors.New("review reconcile-authority-batch found a conflicting audit record")
+		}
+		if existing.Status == CompactBatchReconcileCommitted {
+			if err := verifyCompactBatchMovesAndRetainedGraphLocked(ctx, locks, existing); err != nil {
+				return journal, err
+			}
+			if err := clearCompactBatchReconcileMarker(locks.base); err != nil {
+				return journal, err
+			}
+			return existing, nil
+		}
+	} else if !os.IsNotExist(err) {
+		return journal, err
+	} else if err := persistCompactBatchReconcileJournal(auditPath, journal); err != nil {
+		return journal, err
+	}
+
+	for _, move := range journal.Moves {
+		if err := ctx.Err(); err != nil {
+			return journal, err
+		}
+		if err := executeCompactBatchReconcileMove(locks, move); err != nil {
+			return journal, err
+		}
+	}
+	if err := verifyCompactBatchMovesAndRetainedGraphLocked(ctx, locks, journal); err != nil {
+		return journal, err
+	}
+	committed := journal
+	committed.Status = CompactBatchReconcileCommitted
+	if err := persistCompactBatchReconcileJournal(auditPath, committed); err != nil {
+		return journal, err
+	}
+	if err := clearCompactBatchReconcileMarker(locks.base); err != nil {
+		return journal, err
+	}
+	return committed, nil
+}
+
+func executeCompactBatchReconcileMove(locks *compactBatchReconcileLocks, move CompactBatchReconcileMove) error {
+	source := filepath.Join(locks.base, filepath.FromSlash(move.SourceRelativePath))
+	destination := filepath.Join(locks.base, filepath.FromSlash(move.QuarantineRelativePath))
+	sourceInfo, sourceErr := os.Lstat(source)
+	destinationInfo, destinationErr := os.Lstat(destination)
+	sourceExists, destinationExists := sourceErr == nil, destinationErr == nil
+	if sourceErr != nil && !os.IsNotExist(sourceErr) {
+		return sourceErr
+	}
+	if destinationErr != nil && !os.IsNotExist(destinationErr) {
+		return destinationErr
+	}
+	if sourceExists && destinationExists {
+		return fmt.Errorf("compact batch move %q has both source and quarantine destination", move.LineageID)
+	}
+	if !sourceExists && !destinationExists {
+		return fmt.Errorf("compact batch move %q has neither source nor quarantine destination", move.LineageID)
+	}
+	identity := CompactBatchReconcileEntryIdentity{
+		LineageID: move.LineageID, Revision: move.Revision,
+		InitialTargetIdentity: move.InitialTargetIdentity, CurrentTargetIdentity: move.CurrentTargetIdentity,
+	}
+	if destinationExists {
+		if !destinationInfo.IsDir() || destinationInfo.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("compact batch destination %q is unsafe", move.LineageID)
+		}
+		return verifyCompactBatchMovedEntry(destination, identity, move.Residue)
+	}
+	if !sourceInfo.IsDir() || sourceInfo.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("compact batch source %q is unsafe", move.LineageID)
+	}
+	if err := ensureCompactBatchSourceIdentity(source, identity); err != nil {
+		return err
+	}
+	if err := verifyCompactBatchResidue(source, move.Residue); err != nil {
+		return err
+	}
+	if err := renameCompactBatchReconcileEntry(source, destination); err != nil {
+		return fmt.Errorf("move compact batch source %q into quarantine: %w", move.LineageID, err)
+	}
+	if err := syncCompactBatchReconcileDirectory(locks.versionRoot); err != nil {
+		return fmt.Errorf("sync compact-v2 after moving %q: %w", move.LineageID, err)
+	}
+	if err := syncCompactBatchReconcileDirectory(filepath.Dir(destination)); err != nil {
+		return fmt.Errorf("sync compact batch quarantine after moving %q: %w", move.LineageID, err)
+	}
+	return verifyCompactBatchMovedEntry(destination, identity, move.Residue)
+}
+
+func verifyCompactBatchMovesAndRetainedGraphLocked(ctx context.Context, locks *compactBatchReconcileLocks, journal CompactBatchReconcileJournal) error {
+	for _, move := range journal.Moves {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		source := filepath.Join(locks.base, filepath.FromSlash(move.SourceRelativePath))
+		if _, err := os.Lstat(source); !os.IsNotExist(err) {
+			return fmt.Errorf("compact batch source %q still exists after planned moves", move.LineageID)
+		}
+		destination := filepath.Join(locks.base, filepath.FromSlash(move.QuarantineRelativePath))
+		identity := CompactBatchReconcileEntryIdentity{
+			LineageID: move.LineageID, Revision: move.Revision,
+			InitialTargetIdentity: move.InitialTargetIdentity, CurrentTargetIdentity: move.CurrentTargetIdentity,
+		}
+		if err := verifyCompactBatchMovedEntry(destination, identity, move.Residue); err != nil {
+			return err
+		}
+	}
+	snapshot, err := loadCompactBatchReconcileSnapshotLocked(ctx, locks)
+	if err != nil {
+		return err
+	}
+	if !snapshot.Inspection.Complete || !snapshot.Inspection.Valid {
+		return errors.New("review reconcile-authority-batch retained authority graph is incomplete or invalid")
+	}
+	records := make(map[string]CompactRecord, len(snapshot.Records))
+	for _, record := range snapshot.Records {
+		records[record.State.LineageID] = record
+	}
+	if err := validateCompactBatchRetainedGraph(records); err != nil {
+		return err
+	}
+	chains, err := orderCompactBatchChains(records)
+	if err != nil {
+		return err
+	}
+	retained := []CompactBatchReconcileEntryIdentity{}
+	for _, chain := range chains {
+		for _, lineage := range chain {
+			retained = append(retained, compactBatchEntryIdentity(records[lineage]))
+		}
+	}
+	if !reflect.DeepEqual(retained, journal.Plan.RetainedEntries) {
+		return errors.New("review reconcile-authority-batch retained graph identity differs from the prepared plan")
+	}
+	return nil
+}
+
+func ensureCompactBatchSourceIdentity(path string, expected CompactBatchReconcileEntryIdentity) error {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return err
+	}
+	if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("compact batch source %q is not a canonical directory", expected.LineageID)
+	}
+	store := CompactStore{Dir: path, lineageID: expected.LineageID}
+	record, err := store.loadCompactRecordLocked()
+	if err != nil {
+		return fmt.Errorf("load compact batch source %q: %w", expected.LineageID, err)
+	}
+	identity := compactBatchEntryIdentity(record)
+	if identity.LineageID != expected.LineageID || identity.Revision != expected.Revision ||
+		identity.InitialTargetIdentity != expected.InitialTargetIdentity || identity.CurrentTargetIdentity != expected.CurrentTargetIdentity {
+		return fmt.Errorf("%w: compact batch source %q changed revision or target identity", ErrConcurrentUpdate, expected.LineageID)
+	}
+	return nil
+}
+
+func verifyCompactBatchMovedEntry(path string, expected CompactBatchReconcileEntryIdentity, residue []string) error {
+	if err := ensureCompactBatchSourceIdentity(path, expected); err != nil {
+		return fmt.Errorf("verify quarantined compact batch source: %w", err)
+	}
+	return verifyCompactBatchResidue(path, residue)
+}
+
+func verifyCompactBatchResidue(path string, expected []string) error {
+	items, err := os.ReadDir(path)
+	if err != nil {
+		return err
+	}
+	actual := make([]string, len(items))
+	for index, item := range items {
+		actual[index] = item.Name()
+	}
+	sort.Strings(actual)
+	if !reflect.DeepEqual(actual, expected) {
+		return errors.New("compact batch residue changed from the prepared audit")
+	}
+	return nil
+}
+
+func ensureCompactBatchJournalDirectories(base, batchRoot, entriesRoot string) error {
+	quarantineRoot := filepath.Join(base, "quarantine")
+	if err := ensureCanonicalReviewQuarantineRoot(base, quarantineRoot); err != nil {
+		return err
+	}
+	wantPrefix := filepath.Join(quarantineRoot, "batch-")
+	if !strings.HasPrefix(filepath.Clean(batchRoot), wantPrefix) || filepath.Dir(batchRoot) != quarantineRoot || filepath.Dir(entriesRoot) != batchRoot {
+		return errors.New("review reconcile-authority-batch refused noncanonical quarantine paths")
+	}
+	for _, path := range []string{quarantineRoot, batchRoot, entriesRoot} {
+		if err := os.MkdirAll(path, 0o700); err != nil {
+			return err
+		}
+		info, err := os.Lstat(path)
+		if err != nil || !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+			return errors.New("review reconcile-authority-batch quarantine path is unsafe")
+		}
+		if err := syncCompactBatchReconcileDirectory(filepath.Dir(path)); err != nil {
+			return fmt.Errorf("sync compact batch quarantine parent: %w", err)
+		}
+	}
+	return nil
+}
+
+func clearCompactBatchReconcileMarker(base string) error {
+	path := compactBatchReconcileMarkerPath(base)
+	if err := removeCompactBatchReconcileMarker(path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove committed compact batch marker: %w", err)
+	}
+	if err := syncCompactBatchReconcileDirectory(base); err != nil {
+		return fmt.Errorf("sync authority root after compact batch marker removal: %w", err)
+	}
+	return nil
+}
+
+func compactBatchReconcileMarkerPath(base string) string {
+	return filepath.Join(base, compactBatchReconcileMarker)
+}
+
+func persistCompactBatchReconcileJournal(path string, journal CompactBatchReconcileJournal) error {
+	payload, err := marshalCompactBatchReconcileJournal(journal)
+	if err != nil {
+		return err
+	}
+	writeErr := writeCompactBatchReconcileJournalAtomic(path, payload, 0o600)
+	var syncErr *directorySyncError
+	if errors.As(writeErr, &syncErr) {
+		return writeErr
+	}
+	reloaded, err := readCompactBatchReconcileJournal(path)
+	if err != nil {
+		if writeErr != nil {
+			return writeErr
+		}
+		return fmt.Errorf("reread compact batch reconciliation journal: %w", err)
+	}
+	if !reflect.DeepEqual(reloaded, journal) {
+		if writeErr != nil {
+			return writeErr
+		}
+		return errors.New("compact batch reconciliation journal replacement is ambiguous")
+	}
+	return nil
+}
+
+func marshalCompactBatchReconcileJournal(journal CompactBatchReconcileJournal) ([]byte, error) {
+	if err := validateCompactBatchReconcileJournal(journal); err != nil {
+		return nil, err
+	}
+	payload, err := json.MarshalIndent(journal, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return append(payload, '\n'), nil
+}
+
+func readCompactBatchReconcileJournal(path string) (CompactBatchReconcileJournal, error) {
+	payload, err := os.ReadFile(path)
+	if err != nil {
+		return CompactBatchReconcileJournal{}, err
+	}
+	decoder := json.NewDecoder(bytes.NewReader(payload))
+	decoder.DisallowUnknownFields()
+	var journal CompactBatchReconcileJournal
+	if err := decoder.Decode(&journal); err != nil {
+		return CompactBatchReconcileJournal{}, err
+	}
+	var extra any
+	if err := decoder.Decode(&extra); err != io.EOF {
+		return CompactBatchReconcileJournal{}, errors.New("multiple JSON values in compact batch reconciliation journal")
+	}
+	if err := validateCompactBatchReconcileJournal(journal); err != nil {
+		return CompactBatchReconcileJournal{}, err
+	}
+	return journal, nil
+}
+
+func validateCompactBatchReconcileJournal(journal CompactBatchReconcileJournal) error {
+	if journal.Schema != CompactBatchReconcileJournalSchema ||
+		(journal.Status != CompactBatchReconcilePrepared && journal.Status != CompactBatchReconcileCommitted) ||
+		!validSHA256(journal.RequestSHA256) || !validSHA256(journal.RepositorySHA256) || !validSHA256(journal.PlanSHA256) ||
+		!validSHA256(journal.InvalidEdgesSHA256) || !validSHA256(journal.ValidDescendantSuffixesSHA256) ||
+		!validSHA256(journal.QuarantineEntriesSHA256) || !validSHA256(journal.MaintainerAuthorizationSHA256) ||
+		journal.ReconciledAt.IsZero() || journal.DeclaredInvalidEdges == nil || journal.Plan.InvalidEdges == nil || journal.Moves == nil {
+		return errors.New("invalid compact batch reconciliation journal")
+	}
+	planSHA256, err := compactBatchReconcileDigest("plan", journal.Plan)
+	if err != nil || planSHA256 != journal.PlanSHA256 || !reflect.DeepEqual(journal.DeclaredInvalidEdges, journal.Plan.InvalidEdges) {
+		return errors.New("compact batch reconciliation journal plan binding is invalid")
+	}
+	invalidSHA256, _ := compactBatchReconcileDigest("invalid-edges", journal.Plan.InvalidEdges)
+	suffixesSHA256, _ := compactBatchReconcileDigest("valid-descendant-suffixes", journal.Plan.ValidDescendantSuffixes)
+	quarantineSHA256, _ := compactBatchReconcileDigest("quarantine-entries", journal.Plan.QuarantineEntries)
+	if invalidSHA256 != journal.InvalidEdgesSHA256 || suffixesSHA256 != journal.ValidDescendantSuffixesSHA256 || quarantineSHA256 != journal.QuarantineEntriesSHA256 {
+		return errors.New("compact batch reconciliation journal guard digest is invalid")
+	}
+	identity := compactBatchReconcileRequestIdentity{
+		Schema:           CompactBatchReconcileRequestSchema,
+		RepositorySHA256: journal.RepositorySHA256, PlanSHA256: journal.PlanSHA256,
+		InvalidEdgesSHA256:            journal.InvalidEdgesSHA256,
+		ValidDescendantSuffixesSHA256: journal.ValidDescendantSuffixesSHA256,
+		QuarantineEntriesSHA256:       journal.QuarantineEntriesSHA256,
+		MaintainerAuthorizationSHA256: journal.MaintainerAuthorizationSHA256,
+		Actor:                         journal.Actor, Reason: journal.Reason,
+	}
+	requestSHA256, _ := compactBatchReconcileDigest("request", identity)
+	batchName := "batch-" + strings.TrimPrefix(journal.RequestSHA256, "sha256:")
+	wantAudit := filepath.ToSlash(filepath.Join("quarantine", batchName, compactBatchReconcileAudit))
+	if requestSHA256 != journal.RequestSHA256 || journal.AuditRelativePath != wantAudit ||
+		len(journal.Moves) != 0 && len(journal.Moves) != len(journal.Plan.QuarantineEntries) {
+		return errors.New("compact batch reconciliation journal request identity is invalid")
+	}
+	for index, move := range journal.Moves {
+		entry := journal.Plan.QuarantineEntries[index]
+		if move.LineageID != entry.LineageID || move.Revision != entry.Revision ||
+			move.InitialTargetIdentity != entry.InitialTargetIdentity || move.CurrentTargetIdentity != entry.CurrentTargetIdentity ||
+			move.SourceRelativePath != filepath.ToSlash(filepath.Join("v2", entry.LineageID)) ||
+			move.QuarantineRelativePath != filepath.ToSlash(filepath.Join("quarantine", batchName, "entries", entry.LineageID)) ||
+			move.Residue == nil || !sort.StringsAreSorted(move.Residue) {
+			return errors.New("compact batch reconciliation journal move binding is invalid")
+		}
+		for _, name := range move.Residue {
+			if name == "" || filepath.Base(name) != name || name == "." || name == ".." {
+				return errors.New("compact batch reconciliation journal residue name is invalid")
+			}
+		}
+	}
+	return nil
+}
+
+func compactBatchJournalMatchesRequest(left, right CompactBatchReconcileJournal) bool {
+	return left.RequestSHA256 == right.RequestSHA256 && left.RepositorySHA256 == right.RepositorySHA256 &&
+		left.PlanSHA256 == right.PlanSHA256 && left.InvalidEdgesSHA256 == right.InvalidEdgesSHA256 &&
+		left.ValidDescendantSuffixesSHA256 == right.ValidDescendantSuffixesSHA256 &&
+		left.QuarantineEntriesSHA256 == right.QuarantineEntriesSHA256 &&
+		left.MaintainerAuthorizationSHA256 == right.MaintainerAuthorizationSHA256 &&
+		left.Actor == right.Actor && left.Reason == right.Reason &&
+		left.AuditRelativePath == right.AuditRelativePath && reflect.DeepEqual(left.Plan, right.Plan)
+}
+
+func cloneCompactBatchReconcilePlan(plan CompactBatchReconcilePlan) (CompactBatchReconcilePlan, error) {
+	payload, err := json.Marshal(plan)
+	if err != nil {
+		return CompactBatchReconcilePlan{}, err
+	}
+	var cloned CompactBatchReconcilePlan
+	if err := json.Unmarshal(payload, &cloned); err != nil {
+		return CompactBatchReconcilePlan{}, err
+	}
+	return cloned, nil
+}
+
+func ensureNoPreparedCompactBatchReconciliation(base string) error {
+	if _, err := os.Lstat(compactBatchReconcileMarkerPath(base)); err == nil {
+		return ErrCompactBatchReconcilePrepared
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("%w: inspect global marker", ErrCompactBatchReconcilePrepared)
+	}
+	return nil
+}

--- a/internal/reviewtransaction/compact_batch_reconcile_journal_test.go
+++ b/internal/reviewtransaction/compact_batch_reconcile_journal_test.go
@@ -1,0 +1,340 @@
+package reviewtransaction
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestReconcileInvalidRecoveryEdgesCommitsAtomicallyAndReplaysExactly(t *testing.T) {
+	repo, request := compactBatchPreparedRequest(t)
+	base, _, err := reviewAuthorityRoot(context.Background(), repo)
+	inspectNoError(t, err)
+	firstMove := request.ExpectedPlan.QuarantineEntries[0]
+	statePath := filepath.Join(base, "v2", firstMove.LineageID, compactStateFileName)
+	wantState, err := os.ReadFile(statePath)
+	inspectNoError(t, err)
+
+	journal, err := ReconcileInvalidRecoveryEdges(context.Background(), repo, request)
+	if err != nil {
+		t.Fatalf("reconcile invalid recovery edges: %v", err)
+	}
+	if journal.Schema != CompactBatchReconcileJournalSchema || journal.Status != CompactBatchReconcileCommitted ||
+		journal.RequestSHA256 == "" || len(journal.Moves) != len(request.ExpectedPlan.QuarantineEntries) ||
+		!reflect.DeepEqual(journal.Plan, request.ExpectedPlan) {
+		t.Fatalf("committed batch journal = %#v", journal)
+	}
+	if _, err := os.Stat(compactBatchReconcileMarkerPath(base)); !os.IsNotExist(err) {
+		t.Fatalf("committed batch left global marker: %v", err)
+	}
+	auditPath := filepath.Join(base, filepath.FromSlash(journal.AuditRelativePath))
+	persisted, err := readCompactBatchReconcileJournal(auditPath)
+	if err != nil || !reflect.DeepEqual(persisted, journal) {
+		t.Fatalf("persisted committed journal = %#v, %v", persisted, err)
+	}
+	gotState, err := os.ReadFile(filepath.Join(base, filepath.FromSlash(journal.Moves[0].QuarantineRelativePath), compactStateFileName))
+	if err != nil || !bytes.Equal(gotState, wantState) {
+		t.Fatalf("quarantined source bytes changed: %v", err)
+	}
+	for _, move := range journal.Moves {
+		if _, err := os.Stat(filepath.Join(base, filepath.FromSlash(move.SourceRelativePath))); !os.IsNotExist(err) {
+			t.Fatalf("source %q remains after commit: %v", move.SourceRelativePath, err)
+		}
+	}
+	leaves, err := CompactAuthorityLeaves(context.Background(), repo)
+	if err != nil || len(leaves) == 0 {
+		t.Fatalf("retained authority leaves = %#v, %v", leaves, err)
+	}
+
+	replayed, err := ReconcileInvalidRecoveryEdges(context.Background(), repo, request)
+	if err != nil || !reflect.DeepEqual(replayed, journal) {
+		t.Fatalf("exact committed replay = %#v, %v", replayed, err)
+	}
+	entries, err := os.ReadDir(filepath.Join(base, "quarantine"))
+	if err != nil || len(entries) != 1 {
+		t.Fatalf("exact replay minted another quarantine: %#v, %v", entries, err)
+	}
+}
+
+func TestReconcileInvalidRecoveryEdgesRejectsUnexpectedV2ResidueBeforeMutation(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	predecessor, predecessorStore, _, successorStore := poisonedRecoveryFixture(t, repo, nil)
+	if _, err := os.Stat(predecessorStore.ReceiptPath()); err != nil {
+		t.Fatalf("valid predecessor receipt: %v", err)
+	}
+	report, err := InspectCompactRecoveryEdges(context.Background(), repo)
+	inspectNoError(t, err)
+	preparation, err := PrepareCompactBatchReconciliation(
+		context.Background(), repo, compactBatchInvalidEdges(report), compactBatchTestActor, compactBatchTestReason,
+	)
+	inspectNoError(t, err)
+	request := compactBatchRequestFromPreparation(preparation)
+	base, _, err := reviewAuthorityRoot(context.Background(), repo)
+	inspectNoError(t, err)
+	residue := filepath.Join(base, "v2", "unexpected-residue")
+	inspectNoError(t, os.WriteFile(residue, []byte("not authority\n"), 0o644))
+	incomplete, err := InspectCompactRecoveryEdges(context.Background(), repo)
+	inspectNoError(t, err)
+	if incomplete.Complete || !reflect.DeepEqual(incomplete.EntryDiagnostics, []CompactRecoveryEntryDiagnostic{{
+		LineageID: "unexpected-residue", Problem: compactInspectionEntryUnexpected,
+	}}) {
+		t.Fatalf("unexpected v2 residue inspection = %#v", incomplete)
+	}
+
+	journal, err := ReconcileInvalidRecoveryEdges(context.Background(), repo, request)
+	if err == nil || !strings.Contains(err.Error(), "inspection is incomplete") || journal.Status != "" {
+		t.Fatalf("unexpected v2 residue reconcile = %#v, %v", journal, err)
+	}
+	if _, err := os.Stat(successorStore.StatePath()); err != nil {
+		t.Fatalf("refused batch moved invalid successor: %v", err)
+	}
+	if _, err := os.Stat(compactBatchReconcileMarkerPath(base)); !os.IsNotExist(err) {
+		t.Fatalf("refused batch persisted a marker: %v", err)
+	}
+	if predecessor.State.State != StateEscalated {
+		t.Fatalf("fixture predecessor state = %q", predecessor.State.State)
+	}
+}
+
+func TestReconcileInvalidRecoveryEdgesFinalVerificationRejectsLateUnexpectedV2Residue(t *testing.T) {
+	repo, request := compactBatchPreparedRequest(t)
+	base, _, err := reviewAuthorityRoot(context.Background(), repo)
+	inspectNoError(t, err)
+
+	originalRename := renameCompactBatchReconcileEntry
+	injected := false
+	renameCompactBatchReconcileEntry = func(source, destination string) error {
+		if err := os.Rename(source, destination); err != nil {
+			return err
+		}
+		if !injected {
+			injected = true
+			return os.WriteFile(filepath.Join(base, "v2", "unexpected-residue"), []byte("late residue\n"), 0o644)
+		}
+		return nil
+	}
+	t.Cleanup(func() { renameCompactBatchReconcileEntry = originalRename })
+
+	journal, err := ReconcileInvalidRecoveryEdges(context.Background(), repo, request)
+	if err == nil || !strings.Contains(err.Error(), "retained authority graph is incomplete or invalid") ||
+		journal.Status != CompactBatchReconcilePrepared || !injected {
+		t.Fatalf("late unexpected v2 residue reconcile = %#v, injected=%v, err=%v", journal, injected, err)
+	}
+	if _, err := os.Stat(compactBatchReconcileMarkerPath(base)); err != nil {
+		t.Fatalf("late residue failure lost prepared marker: %v", err)
+	}
+}
+
+func TestCompactStoreStaleReadHandlesFailClosedDuringPreparedBatch(t *testing.T) {
+	repo, request := compactBatchPreparedRequest(t)
+	retained := request.ExpectedPlan.RetainedEntries[0]
+	stale, err := CompactAuthoritativeStore(context.Background(), repo, retained.LineageID)
+	inspectNoError(t, err)
+
+	originalRename := renameCompactBatchReconcileEntry
+	readErrors := map[string]error{}
+	renameCompactBatchReconcileEntry = func(source, destination string) error {
+		if err := os.Rename(source, destination); err != nil {
+			return err
+		}
+		if len(readErrors) == 0 {
+			_, readErrors["load"] = stale.Load()
+			_, readErrors["pending-finalize-read-only"] = stale.PendingFinalizeAttemptReadOnly()
+			_, readErrors["export-transport"] = stale.ExportTransport()
+		}
+		return nil
+	}
+	t.Cleanup(func() { renameCompactBatchReconcileEntry = originalRename })
+
+	journal, err := ReconcileInvalidRecoveryEdges(context.Background(), repo, request)
+	if err != nil || journal.Status != CompactBatchReconcileCommitted {
+		t.Fatalf("batch with stale read probes = %#v, %v", journal, err)
+	}
+	for operation, readErr := range readErrors {
+		if !errors.Is(readErr, ErrCompactBatchReconcilePrepared) {
+			t.Errorf("stale %s error = %v", operation, readErr)
+		}
+	}
+}
+
+func TestReconcileInvalidRecoveryEdgesPartialMoveStaysFailClosedUntilExactReplay(t *testing.T) {
+	repo, request := compactBatchPreparedRequest(t)
+	base, _, err := reviewAuthorityRoot(context.Background(), repo)
+	inspectNoError(t, err)
+
+	originalRename := renameCompactBatchReconcileEntry
+	moves := 0
+	renameCompactBatchReconcileEntry = func(source, destination string) error {
+		if moves == 1 {
+			return errors.New("injected second move failure")
+		}
+		moves++
+		return os.Rename(source, destination)
+	}
+	t.Cleanup(func() { renameCompactBatchReconcileEntry = originalRename })
+
+	prepared, err := ReconcileInvalidRecoveryEdges(context.Background(), repo, request)
+	if err == nil || prepared.Status != CompactBatchReconcilePrepared || moves != 1 || !strings.Contains(err.Error(), "injected second move failure") {
+		t.Fatalf("partial move result = %#v, moves=%d, err=%v", prepared, moves, err)
+	}
+	if _, err := os.Stat(compactBatchReconcileMarkerPath(base)); err != nil {
+		t.Fatalf("partial move lost prepared marker: %v", err)
+	}
+	if _, err := DiscoverCompactStores(context.Background(), repo); !errors.Is(err, ErrCompactBatchReconcilePrepared) {
+		t.Fatalf("partial authority discovery error = %v", err)
+	}
+	status, err := InventoryAuthority(context.Background(), repo)
+	if err != nil || status.Complete || status.Authoritative {
+		t.Fatalf("partial authority status = %#v, %v", status, err)
+	}
+
+	different := request
+	different.Reason = "different operation"
+	if _, err := ReconcileInvalidRecoveryEdges(context.Background(), repo, different); err == nil || !strings.Contains(err.Error(), "different prepared batch") {
+		t.Fatalf("different replay error = %v", err)
+	}
+
+	renameCompactBatchReconcileEntry = originalRename
+	committed, err := ReconcileInvalidRecoveryEdges(context.Background(), repo, request)
+	if err != nil || committed.Status != CompactBatchReconcileCommitted {
+		t.Fatalf("exact partial replay = %#v, %v", committed, err)
+	}
+	if _, err := os.Stat(compactBatchReconcileMarkerPath(base)); !os.IsNotExist(err) {
+		t.Fatalf("exact replay left marker: %v", err)
+	}
+}
+
+func TestReconcileInvalidRecoveryEdgesRetriesEveryDurabilityBoundary(t *testing.T) {
+	tests := []struct {
+		name   string
+		inject func(*testing.T, string)
+	}{
+		{
+			name: "prepared marker write",
+			inject: func(t *testing.T, base string) {
+				original := writeCompactBatchReconcileJournalAtomic
+				writeCompactBatchReconcileJournalAtomic = func(path string, payload []byte, mode os.FileMode) error {
+					if path == compactBatchReconcileMarkerPath(base) {
+						return errors.New("injected marker write failure")
+					}
+					return original(path, payload, mode)
+				}
+				t.Cleanup(func() { writeCompactBatchReconcileJournalAtomic = original })
+			},
+		},
+		{
+			name: "prepared audit write",
+			inject: func(t *testing.T, base string) {
+				original := writeCompactBatchReconcileJournalAtomic
+				writeCompactBatchReconcileJournalAtomic = func(path string, payload []byte, mode os.FileMode) error {
+					var journal CompactBatchReconcileJournal
+					_ = json.Unmarshal(payload, &journal)
+					if path != compactBatchReconcileMarkerPath(base) && journal.Status == CompactBatchReconcilePrepared {
+						return errors.New("injected prepared audit write failure")
+					}
+					return original(path, payload, mode)
+				}
+				t.Cleanup(func() { writeCompactBatchReconcileJournalAtomic = original })
+			},
+		},
+		{
+			name: "post-move directory sync",
+			inject: func(t *testing.T, base string) {
+				original := syncCompactBatchReconcileDirectory
+				failed := false
+				syncCompactBatchReconcileDirectory = func(path string) error {
+					if !failed && path == filepath.Join(base, "v2") {
+						failed = true
+						return errors.New("injected v2 sync failure")
+					}
+					return original(path)
+				}
+				t.Cleanup(func() { syncCompactBatchReconcileDirectory = original })
+			},
+		},
+		{
+			name: "committed audit write",
+			inject: func(t *testing.T, base string) {
+				original := writeCompactBatchReconcileJournalAtomic
+				writeCompactBatchReconcileJournalAtomic = func(path string, payload []byte, mode os.FileMode) error {
+					var journal CompactBatchReconcileJournal
+					_ = json.Unmarshal(payload, &journal)
+					if path != compactBatchReconcileMarkerPath(base) && journal.Status == CompactBatchReconcileCommitted {
+						return errors.New("injected committed audit write failure")
+					}
+					return original(path, payload, mode)
+				}
+				t.Cleanup(func() { writeCompactBatchReconcileJournalAtomic = original })
+			},
+		},
+		{
+			name: "prepared marker removal",
+			inject: func(t *testing.T, _ string) {
+				original := removeCompactBatchReconcileMarker
+				removeCompactBatchReconcileMarker = func(string) error { return errors.New("injected marker removal failure") }
+				t.Cleanup(func() { removeCompactBatchReconcileMarker = original })
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo, request := compactBatchPreparedRequest(t)
+			base, _, err := reviewAuthorityRoot(context.Background(), repo)
+			inspectNoError(t, err)
+			tt.inject(t, base)
+			prepared, err := ReconcileInvalidRecoveryEdges(context.Background(), repo, request)
+			if err == nil {
+				t.Fatal("injected durability failure was accepted")
+			}
+			if prepared.Status != "" && prepared.Status != CompactBatchReconcilePrepared {
+				t.Fatalf("failure returned non-prepared journal: %#v", prepared)
+			}
+
+			writeCompactBatchReconcileJournalAtomic = writeAtomic
+			syncCompactBatchReconcileDirectory = SyncReviewDirectory
+			removeCompactBatchReconcileMarker = os.Remove
+			committed, err := ReconcileInvalidRecoveryEdges(context.Background(), repo, request)
+			if err != nil || committed.Status != CompactBatchReconcileCommitted {
+				t.Fatalf("retry after durability failure = %#v, %v", committed, err)
+			}
+		})
+	}
+}
+
+func TestReconcileInvalidRecoveryEdgesCancellationLeavesReplayableMarker(t *testing.T) {
+	repo, request := compactBatchPreparedRequest(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	originalRename := renameCompactBatchReconcileEntry
+	renameCompactBatchReconcileEntry = func(source, destination string) error {
+		err := os.Rename(source, destination)
+		cancel()
+		return err
+	}
+	t.Cleanup(func() { renameCompactBatchReconcileEntry = originalRename })
+
+	prepared, err := ReconcileInvalidRecoveryEdges(ctx, repo, request)
+	if !errors.Is(err, context.Canceled) || prepared.Status != CompactBatchReconcilePrepared {
+		t.Fatalf("canceled batch = %#v, %v", prepared, err)
+	}
+	renameCompactBatchReconcileEntry = originalRename
+	committed, err := ReconcileInvalidRecoveryEdges(context.Background(), repo, request)
+	if err != nil || committed.Status != CompactBatchReconcileCommitted {
+		t.Fatalf("replay canceled batch = %#v, %v", committed, err)
+	}
+}
+
+func compactBatchPreparedRequest(t *testing.T) (string, CompactBatchReconcileRequest) {
+	t.Helper()
+	repo := initSnapshotRepo(t)
+	_, declarations := compactBatchPlanningFixtureInRepo(t, repo)
+	preparation, err := PrepareCompactBatchReconciliation(context.Background(), repo, declarations, compactBatchTestActor, compactBatchTestReason)
+	inspectNoError(t, err)
+	return repo, compactBatchRequestFromPreparation(preparation)
+}

--- a/internal/reviewtransaction/compact_batch_reconcile_lock_test.go
+++ b/internal/reviewtransaction/compact_batch_reconcile_lock_test.go
@@ -1,0 +1,183 @@
+package reviewtransaction
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+const compactBatchTestActor = "maintainer@example.com"
+const compactBatchTestReason = "atomically quarantine the declared invalid recovery edges"
+
+func TestPrepareCompactBatchReconciliationLocksAndBindsExactPlan(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	_, declarations := compactBatchPlanningFixtureInRepo(t, repo)
+	wantDeclarations := cloneCompactRecoveryEdges(declarations)
+
+	preparation, err := PrepareCompactBatchReconciliation(
+		context.Background(), repo, declarations, compactBatchTestActor, compactBatchTestReason,
+	)
+	if err != nil {
+		t.Fatalf("prepare compact batch reconciliation: %v", err)
+	}
+	if preparation.Schema != CompactBatchReconcilePreparationSchema ||
+		!validSHA256(preparation.RepositorySHA256) || !validSHA256(preparation.PlanSHA256) ||
+		!validSHA256(preparation.InvalidEdgesSHA256) || !validSHA256(preparation.ValidDescendantSuffixesSHA256) ||
+		!validSHA256(preparation.QuarantineEntriesSHA256) {
+		t.Fatalf("preparation guards = %#v", preparation)
+	}
+	if !reflect.DeepEqual(declarations, wantDeclarations) ||
+		!reflect.DeepEqual(preparation.DeclaredInvalidEdges, preparation.Plan.InvalidEdges) {
+		t.Fatalf("preparation declarations/plan = %#v", preparation)
+	}
+	if preparation.RequiredMaintainerAuthorization == "" ||
+		strings.Contains(preparation.RequiredMaintainerAuthorization, preContractFixtureAuthorization) ||
+		!strings.Contains(preparation.RequiredMaintainerAuthorization, "plan_sha256="+preparation.PlanSHA256) ||
+		!strings.Contains(preparation.RequiredMaintainerAuthorization, "valid_descendant_suffixes_sha256="+preparation.ValidDescendantSuffixesSHA256) {
+		t.Fatalf("preparation authorization binding = %q", preparation.RequiredMaintainerAuthorization)
+	}
+
+	request := compactBatchRequestFromPreparation(preparation)
+	validated, err := validateCompactBatchReconcileRequest(context.Background(), repo, request)
+	if err != nil {
+		t.Fatalf("validate exact compact batch request: %v", err)
+	}
+	if !reflect.DeepEqual(validated, preparation.Plan) {
+		t.Fatalf("validated plan = %#v, want %#v", validated, preparation.Plan)
+	}
+
+	preparedDeclarations := cloneCompactRecoveryEdges(preparation.DeclaredInvalidEdges)
+	declarations[0].AnomalyClasses[0] = "mutated-input"
+	if !reflect.DeepEqual(preparation.DeclaredInvalidEdges, preparedDeclarations) {
+		t.Fatal("preparation aliases declaration input")
+	}
+}
+
+func TestValidateCompactBatchReconciliationRejectsGuardAndSnapshotDrift(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(*testing.T, string, *CompactBatchReconcileRequest)
+		wantErr string
+	}{
+		{
+			name: "plan digest changed",
+			mutate: func(_ *testing.T, _ string, request *CompactBatchReconcileRequest) {
+				request.ExpectedPlanSHA256 = hash("different-plan")
+			},
+			wantErr: "expected plan digest does not bind the supplied plan",
+		},
+		{
+			name: "valid descendant suffix changed",
+			mutate: func(_ *testing.T, _ string, request *CompactBatchReconcileRequest) {
+				request.ExpectedPlan.ValidDescendantSuffixes[0].Entries[0].Revision = hash("different-suffix")
+			},
+			wantErr: "expected plan digest does not bind the supplied plan",
+		},
+		{
+			name: "maintainer binding changed",
+			mutate: func(_ *testing.T, _ string, request *CompactBatchReconcileRequest) {
+				request.MaintainerAuthorization += "\nextra=true"
+			},
+			wantErr: "exact maintainer authorization binding",
+		},
+		{
+			name: "new undeclared anomaly",
+			mutate: func(t *testing.T, repo string, _ *CompactBatchReconcileRequest) {
+				inspectRecoveryPair(t, repo, "late-invalid", false, preContractFixtureAuthorization)
+			},
+			wantErr: "declaration set is incomplete",
+		},
+		{
+			name: "stale source revision",
+			mutate: func(t *testing.T, repo string, request *CompactBatchReconcileRequest) {
+				lineage := "independent-successor"
+				store, err := CompactAuthoritativeStore(context.Background(), repo, lineage)
+				inspectNoError(t, err)
+				record, err := store.Load()
+				inspectNoError(t, err)
+				record.State.Recovery.RecoveredAt = record.State.Recovery.RecoveredAt.Add(time.Minute)
+				writeCompactFixtureRecord(t, store, record.State)
+			},
+			wantErr: "locked recovery edge",
+		},
+		{
+			name: "corrupt compact evidence",
+			mutate: func(t *testing.T, repo string, request *CompactBatchReconcileRequest) {
+				lineage := request.ExpectedPlan.QuarantineEntries[0].LineageID
+				store, err := CompactAuthoritativeStore(context.Background(), repo, lineage)
+				inspectNoError(t, err)
+				inspectNoError(t, os.WriteFile(store.StatePath(), []byte("not json\n"), 0o644))
+			},
+			wantErr: "inspection is incomplete",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := initSnapshotRepo(t)
+			_, declarations := compactBatchPlanningFixtureInRepo(t, repo)
+			preparation, err := PrepareCompactBatchReconciliation(context.Background(), repo, declarations, compactBatchTestActor, compactBatchTestReason)
+			if err != nil {
+				t.Fatal(err)
+			}
+			request := compactBatchRequestFromPreparation(preparation)
+			tt.mutate(t, repo, &request)
+			if _, err := validateCompactBatchReconcileRequest(context.Background(), repo, request); err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("validation error = %v, want %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestPrepareCompactBatchReconciliationCoordinatesMaintenanceThenV2Lock(t *testing.T) {
+	t.Run("maintenance contention honors cancellation", func(t *testing.T) {
+		repo := initSnapshotRepo(t)
+		_, declarations := compactBatchPlanningFixtureInRepo(t, repo)
+		base, _, err := reviewAuthorityRoot(context.Background(), repo)
+		inspectNoError(t, err)
+		held, err := acquireMaintenanceLock(context.Background(), compactMaintenanceLockPath(base), maintenanceExclusive)
+		inspectNoError(t, err)
+		defer held.Release()
+		ctx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
+		defer cancel()
+		if _, err := PrepareCompactBatchReconciliation(ctx, repo, declarations, compactBatchTestActor, compactBatchTestReason); !errors.Is(err, ErrAuthorityLockCancelled) {
+			t.Fatalf("maintenance contention error = %v", err)
+		}
+	})
+
+	t.Run("v2 contention releases the exclusive maintenance lease", func(t *testing.T) {
+		repo := initSnapshotRepo(t)
+		_, declarations := compactBatchPlanningFixtureInRepo(t, repo)
+		base, _, err := reviewAuthorityRoot(context.Background(), repo)
+		inspectNoError(t, err)
+		v2LockPath := filepath.Join(base, "v2", "LOCK")
+		held, err := acquireLocalStoreLock(v2LockPath)
+		inspectNoError(t, err)
+		if _, err := PrepareCompactBatchReconciliation(context.Background(), repo, declarations, compactBatchTestActor, compactBatchTestReason); !errors.Is(err, ErrConcurrentUpdate) {
+			t.Fatalf("v2 contention error = %v", err)
+		}
+		inspectNoError(t, held.release())
+		shared, err := acquireMaintenanceLock(context.Background(), compactMaintenanceLockPath(base), maintenanceShared)
+		if err != nil {
+			t.Fatalf("exclusive maintenance lease leaked after v2 contention: %v", err)
+		}
+		inspectNoError(t, shared.Release())
+	})
+}
+
+func compactBatchRequestFromPreparation(preparation CompactBatchReconcilePreparation) CompactBatchReconcileRequest {
+	return CompactBatchReconcileRequest{
+		Schema:                  CompactBatchReconcileRequestSchema,
+		DeclaredInvalidEdges:    cloneCompactRecoveryEdges(preparation.DeclaredInvalidEdges),
+		ExpectedPlan:            preparation.Plan,
+		ExpectedPlanSHA256:      preparation.PlanSHA256,
+		Actor:                   compactBatchTestActor,
+		Reason:                  compactBatchTestReason,
+		MaintainerAuthorization: preparation.RequiredMaintainerAuthorization,
+	}
+}

--- a/internal/reviewtransaction/compact_batch_reconcile_plan.go
+++ b/internal/reviewtransaction/compact_batch_reconcile_plan.go
@@ -1,0 +1,350 @@
+package reviewtransaction
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+)
+
+// CompactBatchReconcileSnapshot binds the operator-visible recovery inspection
+// to the exact compact records re-read by the caller. Planning rejects the
+// snapshot unless the inspection can be reproduced exactly from these records.
+type CompactBatchReconcileSnapshot struct {
+	Inspection CompactRecoveryInspectionReport `json:"inspection"`
+	Records    []CompactRecord                 `json:"records"`
+}
+
+// CompactBatchReconcileEntryIdentity binds one source entry without retaining
+// or aliasing its mutable CompactState. The content-addressed revision binds the
+// full state, while both target identities make later mutation plans auditable.
+type CompactBatchReconcileEntryIdentity struct {
+	LineageID             string `json:"lineage_id"`
+	Revision              string `json:"revision"`
+	Generation            int    `json:"generation"`
+	InitialTargetIdentity string `json:"initial_target_identity"`
+	CurrentTargetIdentity string `json:"current_target_identity"`
+}
+
+// CompactBatchReconcileSuffix names the first invalid successor in one chain
+// and the contiguous valid descendant suffix that must move with it. Consecutive
+// invalid successors remain represented by InvalidEdges and QuarantineEntries.
+type CompactBatchReconcileSuffix struct {
+	InvalidRoot CompactBatchReconcileEntryIdentity   `json:"invalid_root"`
+	Entries     []CompactBatchReconcileEntryIdentity `json:"entries"`
+}
+
+// CompactBatchReconcilePlan is an owned, deterministic plan over exact source
+// revisions. Its slices do not alias either the snapshot or declarations.
+type CompactBatchReconcilePlan struct {
+	InvalidEdges            []CompactRecoveryEdgeInspection      `json:"invalid_edges"`
+	InvalidRoots            []CompactBatchReconcileEntryIdentity `json:"invalid_roots"`
+	ValidDescendantSuffixes []CompactBatchReconcileSuffix        `json:"valid_descendant_suffixes"`
+	QuarantineEntries       []CompactBatchReconcileEntryIdentity `json:"quarantine_entries"`
+	RetainedEntries         []CompactBatchReconcileEntryIdentity `json:"retained_entries"`
+	RetainedEdges           []CompactRecoveryEdgeInspection      `json:"retained_edges"`
+}
+
+// PlanCompactBatchReconciliation derives an all-or-nothing batch plan without
+// locks, filesystem access, or mutation. Mutating callers must obtain their
+// locks and re-read the exact records before invoking this function.
+func PlanCompactBatchReconciliation(snapshot CompactBatchReconcileSnapshot, declaredInvalid []CompactRecoveryEdgeInspection) (CompactBatchReconcilePlan, error) {
+	records, inspection, err := validateCompactBatchSnapshot(snapshot)
+	if err != nil {
+		return CompactBatchReconcilePlan{}, err
+	}
+	invalidEdges, err := validateCompactBatchDeclarations(inspection, records, declaredInvalid)
+	if err != nil {
+		return CompactBatchReconcilePlan{}, err
+	}
+	if len(invalidEdges) == 0 {
+		return CompactBatchReconcilePlan{}, compactBatchPlanErrorf("at least one currently invalid recovery edge must be declared")
+	}
+
+	chains, err := orderCompactBatchChains(records)
+	if err != nil {
+		return CompactBatchReconcilePlan{}, err
+	}
+	invalidSuccessors := make(map[string]bool, len(invalidEdges))
+	for _, edge := range invalidEdges {
+		invalidSuccessors[edge.SuccessorLineageID] = true
+	}
+
+	plan := CompactBatchReconcilePlan{
+		InvalidEdges:            cloneCompactRecoveryEdges(invalidEdges),
+		InvalidRoots:            []CompactBatchReconcileEntryIdentity{},
+		ValidDescendantSuffixes: []CompactBatchReconcileSuffix{},
+		QuarantineEntries:       []CompactBatchReconcileEntryIdentity{},
+		RetainedEntries:         []CompactBatchReconcileEntryIdentity{},
+		RetainedEdges:           []CompactRecoveryEdgeInspection{},
+	}
+	quarantine := make(map[string]bool)
+	for _, chain := range chains {
+		firstInvalid, lastInvalid := -1, -1
+		seenValidDescendant := false
+		for index, lineage := range chain {
+			if invalidSuccessors[lineage] {
+				if seenValidDescendant {
+					return CompactBatchReconcilePlan{}, compactBatchPlanErrorf("chain rooted at %q has a non-contiguous invalid edge closure at %q", chain[0], lineage)
+				}
+				if firstInvalid < 0 {
+					firstInvalid = index
+				}
+				lastInvalid = index
+				continue
+			}
+			if firstInvalid >= 0 {
+				seenValidDescendant = true
+			}
+		}
+		if firstInvalid < 0 {
+			for _, lineage := range chain {
+				plan.RetainedEntries = append(plan.RetainedEntries, compactBatchEntryIdentity(records[lineage]))
+			}
+			continue
+		}
+
+		root := compactBatchEntryIdentity(records[chain[firstInvalid]])
+		plan.InvalidRoots = append(plan.InvalidRoots, root)
+		for _, lineage := range chain[:firstInvalid] {
+			plan.RetainedEntries = append(plan.RetainedEntries, compactBatchEntryIdentity(records[lineage]))
+		}
+		for _, lineage := range chain[firstInvalid:] {
+			quarantine[lineage] = true
+			plan.QuarantineEntries = append(plan.QuarantineEntries, compactBatchEntryIdentity(records[lineage]))
+		}
+		if lastInvalid+1 < len(chain) {
+			entries := make([]CompactBatchReconcileEntryIdentity, 0, len(chain)-lastInvalid-1)
+			for _, lineage := range chain[lastInvalid+1:] {
+				entries = append(entries, compactBatchEntryIdentity(records[lineage]))
+			}
+			plan.ValidDescendantSuffixes = append(plan.ValidDescendantSuffixes, CompactBatchReconcileSuffix{
+				InvalidRoot: root,
+				Entries:     entries,
+			})
+		}
+	}
+
+	retainedRecords := make(map[string]CompactRecord, len(records)-len(quarantine))
+	for lineage, record := range records {
+		if !quarantine[lineage] {
+			retainedRecords[lineage] = record
+		}
+	}
+	if err := validateCompactBatchRetainedGraph(retainedRecords); err != nil {
+		return CompactBatchReconcilePlan{}, err
+	}
+	for _, edge := range inspection.Edges {
+		if !quarantine[edge.SuccessorLineageID] {
+			plan.RetainedEdges = append(plan.RetainedEdges, cloneCompactRecoveryEdge(edge))
+		}
+	}
+	return plan, nil
+}
+
+func validateCompactBatchSnapshot(snapshot CompactBatchReconcileSnapshot) (map[string]CompactRecord, CompactRecoveryInspectionReport, error) {
+	if !snapshot.Inspection.Complete || len(snapshot.Inspection.EntryDiagnostics) != 0 {
+		return nil, CompactRecoveryInspectionReport{}, compactBatchPlanErrorf("inspection is incomplete")
+	}
+	records := make(map[string]CompactRecord, len(snapshot.Records))
+	for _, record := range snapshot.Records {
+		lineage := record.State.LineageID
+		if err := validateLineageID(lineage); err != nil {
+			return nil, CompactRecoveryInspectionReport{}, compactBatchPlanErrorf("record lineage %q is invalid: %v", lineage, err)
+		}
+		if _, duplicate := records[lineage]; duplicate {
+			return nil, CompactRecoveryInspectionReport{}, compactBatchPlanErrorf("snapshot repeats compact record %q", lineage)
+		}
+		if record.Schema != compactRecordSchema || !validSHA256(record.Revision) {
+			return nil, CompactRecoveryInspectionReport{}, compactBatchPlanErrorf("record %q has invalid schema or revision", lineage)
+		}
+		if err := record.State.Validate(); err != nil {
+			return nil, CompactRecoveryInspectionReport{}, compactBatchPlanErrorf("record %q is invalid: %v", lineage, err)
+		}
+		if !record.HistoricalCompat {
+			revision, err := CompactRevisionForState(record.State)
+			if err != nil || revision != record.Revision {
+				return nil, CompactRecoveryInspectionReport{}, compactBatchPlanErrorf("record %q revision does not bind its state", lineage)
+			}
+		}
+		records[lineage] = record
+	}
+	inspection, err := inspectCompactRecoveryRecordSet(context.Background(), records, CompactRecoveryInspectionReport{
+		Complete: true,
+		Valid:    true,
+		Totals: CompactRecoveryInspectionTotals{
+			CompactEntries: len(records),
+			LoadedEntries:  len(records),
+		},
+		Edges:            []CompactRecoveryEdgeInspection{},
+		EntryDiagnostics: []CompactRecoveryEntryDiagnostic{},
+	})
+	if err != nil {
+		return nil, CompactRecoveryInspectionReport{}, compactBatchPlanErrorf("re-inspect exact records: %v", err)
+	}
+	if !reflect.DeepEqual(snapshot.Inspection, inspection) {
+		return nil, CompactRecoveryInspectionReport{}, compactBatchPlanErrorf("inspection does not match the exact records")
+	}
+	return records, inspection, nil
+}
+
+func validateCompactBatchDeclarations(inspection CompactRecoveryInspectionReport, records map[string]CompactRecord, declared []CompactRecoveryEdgeInspection) ([]CompactRecoveryEdgeInspection, error) {
+	currentBySuccessor := make(map[string]CompactRecoveryEdgeInspection, len(inspection.Edges))
+	invalid := make([]CompactRecoveryEdgeInspection, 0, inspection.Totals.InvalidEdges)
+	for _, edge := range inspection.Edges {
+		currentBySuccessor[edge.SuccessorLineageID] = edge
+		if edge.Valid {
+			continue
+		}
+		if err := validateSupportedCompactBatchEdge(edge, records); err != nil {
+			return nil, err
+		}
+		invalid = append(invalid, edge)
+	}
+
+	seen := make(map[string]bool, len(declared))
+	for _, edge := range declared {
+		if seen[edge.SuccessorLineageID] {
+			return nil, compactBatchPlanErrorf("duplicate declaration for successor %q", edge.SuccessorLineageID)
+		}
+		seen[edge.SuccessorLineageID] = true
+		current, found := currentBySuccessor[edge.SuccessorLineageID]
+		if !found || current.Valid {
+			return nil, compactBatchPlanErrorf("declared successor %q is not currently invalid", edge.SuccessorLineageID)
+		}
+		if err := validateCompactBatchAnomalyClasses(edge.AnomalyClasses); err != nil {
+			return nil, compactBatchPlanErrorf("declaration for %q: %v", edge.SuccessorLineageID, err)
+		}
+		if !reflect.DeepEqual(edge, current) {
+			return nil, compactBatchPlanErrorf("declaration for successor %q does not match the current invalid edge", edge.SuccessorLineageID)
+		}
+	}
+	if len(seen) < len(invalid) {
+		return nil, compactBatchPlanErrorf("declaration set is incomplete: declared %d of %d invalid recovery edges", len(seen), len(invalid))
+	}
+	if len(seen) != len(invalid) {
+		return nil, compactBatchPlanErrorf("declaration set does not exactly match the %d invalid recovery edges", len(invalid))
+	}
+	for _, edge := range invalid {
+		if !seen[edge.SuccessorLineageID] {
+			return nil, compactBatchPlanErrorf("declaration set is incomplete: missing successor %q", edge.SuccessorLineageID)
+		}
+	}
+	return invalid, nil
+}
+
+func validateSupportedCompactBatchEdge(edge CompactRecoveryEdgeInspection, records map[string]CompactRecord) error {
+	predecessor, predecessorFound := records[edge.PredecessorLineageID]
+	successor, successorFound := records[edge.SuccessorLineageID]
+	if !predecessorFound || !successorFound {
+		return compactBatchPlanErrorf("invalid recovery edge %q is outside supported reconciliation classes: %s", edge.SuccessorLineageID, strings.Join(edge.Problems, "; "))
+	}
+	classification := classifyCompactRecoveryEdgeAnomalies(predecessor, successor)
+	if classification.Valid || classification.NonReconcilableError != nil || validateCompactBatchAnomalyClasses(classification.Anomalies) != nil {
+		problem := strings.Join(edge.Problems, "; ")
+		if problem == "" && classification.NonReconcilableError != nil {
+			problem = classification.NonReconcilableError.Error()
+		}
+		return compactBatchPlanErrorf("invalid recovery edge %q is outside supported reconciliation classes: %s", edge.SuccessorLineageID, problem)
+	}
+	wantProblems := []string{classification.ValidationError.Error()}
+	sort.Strings(wantProblems)
+	if !reflect.DeepEqual(edge.Problems, wantProblems) || !reflect.DeepEqual(edge.AnomalyClasses, classification.Anomalies) {
+		return compactBatchPlanErrorf("invalid recovery edge %q is outside supported reconciliation classes: %s", edge.SuccessorLineageID, strings.Join(edge.Problems, "; "))
+	}
+	return nil
+}
+
+func validateCompactBatchAnomalyClasses(classes []string) error {
+	if len(classes) == 0 {
+		return fmt.Errorf("unsupported anomaly class set")
+	}
+	seen := make(map[string]bool, len(classes))
+	for _, class := range classes {
+		if class != compactRecoveryEdgeUnchangedTarget && class != compactRecoveryEdgeMalformedAuthorization {
+			return fmt.Errorf("unsupported anomaly class %q", class)
+		}
+		if seen[class] {
+			return fmt.Errorf("duplicate anomaly class %q", class)
+		}
+		seen[class] = true
+	}
+	return nil
+}
+
+func orderCompactBatchChains(records map[string]CompactRecord) ([][]string, error) {
+	children := make(map[string]string, len(records))
+	roots := make([]string, 0, len(records))
+	for lineage, record := range records {
+		if record.State.Recovery == nil {
+			roots = append(roots, lineage)
+			continue
+		}
+		predecessor := record.State.Recovery.PredecessorLineageID
+		if _, found := records[predecessor]; !found {
+			return nil, compactBatchPlanErrorf("recovery graph has missing predecessor %q for %q", predecessor, lineage)
+		}
+		if previous, duplicate := children[predecessor]; duplicate {
+			return nil, compactBatchPlanErrorf("recovery graph is ambiguous: predecessor %q has successors %q and %q", predecessor, previous, lineage)
+		}
+		children[predecessor] = lineage
+	}
+	sort.Strings(roots)
+	chains := make([][]string, 0, len(roots))
+	visited := make(map[string]bool, len(records))
+	for _, root := range roots {
+		chain := []string{}
+		for lineage := root; lineage != ""; lineage = children[lineage] {
+			if visited[lineage] {
+				return nil, compactBatchPlanErrorf("recovery graph has a cycle at %q", lineage)
+			}
+			visited[lineage] = true
+			chain = append(chain, lineage)
+		}
+		chains = append(chains, chain)
+	}
+	if len(visited) != len(records) {
+		return nil, compactBatchPlanErrorf("recovery graph has an ambiguous or cyclic descendant closure")
+	}
+	return chains, nil
+}
+
+func validateCompactBatchRetainedGraph(records map[string]CompactRecord) error {
+	stores := make(map[string]CompactStore, len(records))
+	for lineage := range records {
+		stores[lineage] = CompactStore{lineageID: lineage}
+	}
+	if _, err := compactAuthorityLeaves(records, stores); err != nil {
+		return compactBatchPlanErrorf("retained graph remains invalid: %v", err)
+	}
+	return nil
+}
+
+func compactBatchEntryIdentity(record CompactRecord) CompactBatchReconcileEntryIdentity {
+	return CompactBatchReconcileEntryIdentity{
+		LineageID:             record.State.LineageID,
+		Revision:              record.Revision,
+		Generation:            record.State.Generation,
+		InitialTargetIdentity: record.State.InitialSnapshot.Identity,
+		CurrentTargetIdentity: record.State.CurrentSnapshot.Identity,
+	}
+}
+
+func cloneCompactRecoveryEdges(edges []CompactRecoveryEdgeInspection) []CompactRecoveryEdgeInspection {
+	cloned := make([]CompactRecoveryEdgeInspection, len(edges))
+	for index, edge := range edges {
+		cloned[index] = cloneCompactRecoveryEdge(edge)
+	}
+	return cloned
+}
+
+func cloneCompactRecoveryEdge(edge CompactRecoveryEdgeInspection) CompactRecoveryEdgeInspection {
+	edge.AnomalyClasses = append([]string(nil), edge.AnomalyClasses...)
+	edge.Problems = append([]string(nil), edge.Problems...)
+	return edge
+}
+
+func compactBatchPlanErrorf(format string, args ...any) error {
+	return fmt.Errorf("plan compact batch reconciliation refused: "+format, args...)
+}

--- a/internal/reviewtransaction/compact_batch_reconcile_plan_test.go
+++ b/internal/reviewtransaction/compact_batch_reconcile_plan_test.go
@@ -1,0 +1,330 @@
+package reviewtransaction
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestPlanCompactBatchReconciliationBindsExactGraph(t *testing.T) {
+	snapshot, declarations := compactBatchPlanningFixture(t)
+	wantSnapshot := compactBatchJSON(t, snapshot)
+	wantDeclarations := compactBatchJSON(t, declarations)
+
+	plan, err := PlanCompactBatchReconciliation(snapshot, declarations)
+	if err != nil {
+		t.Fatalf("plan compact batch reconciliation: %v", err)
+	}
+	if got := compactBatchJSON(t, snapshot); got != wantSnapshot {
+		t.Fatal("planning mutated the snapshot input")
+	}
+	if got := compactBatchJSON(t, declarations); got != wantDeclarations {
+		t.Fatal("planning mutated the declaration input")
+	}
+	if got, want := compactBatchEntryLineages(plan.InvalidRoots), []string{"chain-invalid-a", "independent-successor"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid roots = %#v, want %#v", got, want)
+	}
+	if got, want := compactBatchEntryLineages(plan.QuarantineEntries), []string{"chain-invalid-a", "chain-invalid-b", "chain-valid-descendant", "independent-successor"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("quarantine entries = %#v, want %#v", got, want)
+	}
+	if len(plan.ValidDescendantSuffixes) != 1 || plan.ValidDescendantSuffixes[0].InvalidRoot.LineageID != "chain-invalid-a" {
+		t.Fatalf("valid descendant suffixes = %#v", plan.ValidDescendantSuffixes)
+	}
+	if got, want := compactBatchEntryLineages(plan.ValidDescendantSuffixes[0].Entries), []string{"chain-valid-descendant"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("valid descendant suffix = %#v, want %#v", got, want)
+	}
+	if got, want := compactBatchEntryLineages(plan.RetainedEntries), []string{"chain-predecessor", "independent-predecessor", "retained-predecessor", "retained-successor"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("retained entries = %#v, want %#v", got, want)
+	}
+	if len(plan.InvalidEdges) != 3 || len(plan.RetainedEdges) != 1 || plan.RetainedEdges[0].SuccessorLineageID != "retained-successor" {
+		t.Fatalf("planned graph = invalid %#v, retained %#v", plan.InvalidEdges, plan.RetainedEdges)
+	}
+	for _, entry := range append(append([]CompactBatchReconcileEntryIdentity{}, plan.QuarantineEntries...), plan.RetainedEntries...) {
+		if entry.LineageID == "" || entry.Revision == "" || entry.InitialTargetIdentity == "" || entry.CurrentTargetIdentity == "" {
+			t.Fatalf("entry identity is not fully bound: %#v", entry)
+		}
+	}
+
+	wantPlan := compactBatchJSON(t, plan)
+	slices.Reverse(snapshot.Records)
+	slices.Reverse(declarations)
+	reordered, err := PlanCompactBatchReconciliation(snapshot, declarations)
+	if err != nil {
+		t.Fatalf("plan reordered compact batch reconciliation: %v", err)
+	}
+	if got := compactBatchJSON(t, reordered); got != wantPlan {
+		t.Fatalf("reordered plan is not deterministic:\n%s\n%s", wantPlan, got)
+	}
+
+	snapshot.Records[0].State.LineageID = "mutated-input"
+	declarations[0].AnomalyClasses[0] = "mutated-input"
+	if got := compactBatchJSON(t, plan); got != wantPlan {
+		t.Fatal("plan aliases mutable snapshot or declaration input")
+	}
+}
+
+func TestPlanCompactBatchReconciliationRejectsInexactDeclarationsAndEvidence(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(*CompactBatchReconcileSnapshot, *[]CompactRecoveryEdgeInspection)
+		wantErr string
+	}{
+		{
+			name: "incomplete declaration",
+			mutate: func(_ *CompactBatchReconcileSnapshot, declarations *[]CompactRecoveryEdgeInspection) {
+				*declarations = (*declarations)[1:]
+			},
+			wantErr: "declaration set is incomplete",
+		},
+		{
+			name: "extra declaration for valid edge",
+			mutate: func(snapshot *CompactBatchReconcileSnapshot, declarations *[]CompactRecoveryEdgeInspection) {
+				for _, edge := range snapshot.Inspection.Edges {
+					if edge.Valid {
+						*declarations = append(*declarations, edge)
+						return
+					}
+				}
+			},
+			wantErr: "is not currently invalid",
+		},
+		{
+			name: "duplicate declaration",
+			mutate: func(_ *CompactBatchReconcileSnapshot, declarations *[]CompactRecoveryEdgeInspection) {
+				*declarations = append(*declarations, (*declarations)[0])
+			},
+			wantErr: "duplicate declaration",
+		},
+		{
+			name: "unknown declared anomaly class",
+			mutate: func(_ *CompactBatchReconcileSnapshot, declarations *[]CompactRecoveryEdgeInspection) {
+				(*declarations)[0].AnomalyClasses = []string{"future_anomaly"}
+			},
+			wantErr: "unsupported anomaly class",
+		},
+		{
+			name: "stale inspection revision",
+			mutate: func(snapshot *CompactBatchReconcileSnapshot, _ *[]CompactRecoveryEdgeInspection) {
+				snapshot.Inspection.Edges[0].SuccessorRevision = hash("stale")
+			},
+			wantErr: "inspection does not match the exact records",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			snapshot, declarations := compactBatchPlanningFixture(t)
+			tt.mutate(&snapshot, &declarations)
+			if _, err := PlanCompactBatchReconciliation(snapshot, declarations); err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("planning error = %v, want %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestPlanCompactBatchReconciliationRejectsUnsupportedGraphShapes(t *testing.T) {
+	tests := []struct {
+		name    string
+		fixture func(*testing.T) CompactBatchReconcileSnapshot
+		wantErr string
+	}{
+		{
+			name: "malformed entry",
+			fixture: func(t *testing.T) CompactBatchReconcileSnapshot {
+				repo := initSnapshotRepo(t)
+				inspectRecoveryPair(t, repo, "valid", false, "")
+				base, _, err := reviewAuthorityRoot(context.Background(), repo)
+				inspectNoError(t, err)
+				broken := filepath.Join(base, "v2", "broken-entry")
+				inspectNoError(t, os.MkdirAll(broken, 0o755))
+				inspectNoError(t, os.WriteFile(filepath.Join(broken, compactStateFileName), []byte("not json\n"), 0o644))
+				return loadCompactBatchPlanningSnapshot(t, repo)
+			},
+			wantErr: "inspection is incomplete",
+		},
+		{
+			name: "dangling predecessor",
+			fixture: func(t *testing.T) CompactBatchReconcileSnapshot {
+				repo := initSnapshotRepo(t)
+				_, predecessorStore, _, _ := inspectRecoveryPair(t, repo, "dangling", false, "")
+				inspectNoError(t, os.RemoveAll(predecessorStore.Dir))
+				return loadCompactBatchPlanningSnapshot(t, repo)
+			},
+			wantErr: "missing predecessor",
+		},
+		{
+			name: "recovery fork",
+			fixture: func(t *testing.T) CompactBatchReconcileSnapshot {
+				repo := initSnapshotRepo(t)
+				predecessor, _, _, _ := inspectRecoveryPair(t, repo, "fork", false, "")
+				writeSnapshotFile(t, repo, "tracked.txt", "fork sibling\n")
+				inspectRecoverySuccessor(t, repo, predecessor, "fork-sibling", "")
+				return loadCompactBatchPlanningSnapshot(t, repo)
+			},
+			wantErr: "recovery fork",
+		},
+		{
+			name: "recovery cycle",
+			fixture: func(t *testing.T) CompactBatchReconcileSnapshot {
+				repo := initSnapshotRepo(t)
+				inspectRecoveryCycle(t, repo)
+				return loadCompactBatchPlanningSnapshot(t, repo)
+			},
+			wantErr: "recovery cycle",
+		},
+		{
+			name: "unsupported edge corruption",
+			fixture: func(t *testing.T) CompactBatchReconcileSnapshot {
+				repo := initSnapshotRepo(t)
+				_, _, successor, store := inspectRecoveryPair(t, repo, "corrupt", false, "")
+				successor.State.Generation += 2
+				writeCompactFixtureRecord(t, store, successor.State)
+				return loadCompactBatchPlanningSnapshot(t, repo)
+			},
+			wantErr: "outside supported reconciliation classes",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			snapshot := tt.fixture(t)
+			declarations := compactBatchInvalidEdges(snapshot.Inspection)
+			if _, err := PlanCompactBatchReconciliation(snapshot, declarations); err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("planning error = %v, want %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestPlanCompactBatchReconciliationRejectsNonContiguousDescendantClosure(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	rootState := correctedCompactTestState(t, repo, "noncontiguous-root")
+	rootState.State = StateEscalated
+	rootStore, err := CompactAuthoritativeStore(context.Background(), repo, rootState.LineageID)
+	inspectNoError(t, err)
+	root := writeCompactFixtureRecord(t, rootStore, rootState)
+
+	first, _ := compactBatchRecoverySuccessor(t, repo, root, "noncontiguous-invalid-a", []string{"noncontiguous-a.txt"}, preContractFixtureAuthorization, true)
+	middle, _ := compactBatchRecoverySuccessor(t, repo, first, "noncontiguous-valid", []string{"noncontiguous-a.txt", "noncontiguous-b.txt"}, "", true)
+	compactBatchRecoverySuccessor(t, repo, middle, "noncontiguous-invalid-b", []string{"noncontiguous-a.txt", "noncontiguous-b.txt", "noncontiguous-c.txt"}, preContractFixtureAuthorization, false)
+
+	snapshot := loadCompactBatchPlanningSnapshot(t, repo)
+	if _, err := PlanCompactBatchReconciliation(snapshot, compactBatchInvalidEdges(snapshot.Inspection)); err == nil || !strings.Contains(err.Error(), "non-contiguous invalid edge closure") {
+		t.Fatalf("non-contiguous planning error = %v", err)
+	}
+}
+
+func TestValidateCompactBatchRetainedGraphRejectsInvalidResult(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	_, predecessorStore, _, _ := inspectRecoveryPair(t, repo, "retained-dangling", false, "")
+	inspectNoError(t, os.RemoveAll(predecessorStore.Dir))
+	snapshot := loadCompactBatchPlanningSnapshot(t, repo)
+	records := make(map[string]CompactRecord, len(snapshot.Records))
+	for _, record := range snapshot.Records {
+		records[record.State.LineageID] = record
+	}
+	if err := validateCompactBatchRetainedGraph(records); err == nil || !strings.Contains(err.Error(), "retained graph remains invalid") {
+		t.Fatalf("retained graph validation error = %v", err)
+	}
+}
+
+func compactBatchPlanningFixture(t *testing.T) (CompactBatchReconcileSnapshot, []CompactRecoveryEdgeInspection) {
+	t.Helper()
+	repo := initSnapshotRepo(t)
+	return compactBatchPlanningFixtureInRepo(t, repo)
+}
+
+func compactBatchPlanningFixtureInRepo(t *testing.T, repo string) (CompactBatchReconcileSnapshot, []CompactRecoveryEdgeInspection) {
+	t.Helper()
+	inspectRecoveryPair(t, repo, "retained", false, "")
+	inspectRecoveryPair(t, repo, "independent", false, preContractFixtureAuthorization)
+
+	rootState := correctedCompactTestState(t, repo, "chain-predecessor")
+	rootState.State = StateEscalated
+	rootStore, err := CompactAuthoritativeStore(context.Background(), repo, rootState.LineageID)
+	inspectNoError(t, err)
+	root := writeCompactFixtureRecord(t, rootStore, rootState)
+	invalidA, _ := compactBatchRecoverySuccessor(t, repo, root, "chain-invalid-a", []string{"chain-a.txt"}, preContractFixtureAuthorization, true)
+	invalidB, _ := compactBatchRecoverySuccessor(t, repo, invalidA, "chain-invalid-b", []string{"chain-a.txt", "chain-b.txt"}, preContractFixtureAuthorization, true)
+	compactBatchRecoverySuccessor(t, repo, invalidB, "chain-valid-descendant", []string{"chain-a.txt", "chain-b.txt", "chain-c.txt"}, "", false)
+
+	snapshot := loadCompactBatchPlanningSnapshot(t, repo)
+	declarations := compactBatchInvalidEdges(snapshot.Inspection)
+	slices.Reverse(declarations)
+	return snapshot, declarations
+}
+
+func loadCompactBatchPlanningSnapshot(t *testing.T, repo string) CompactBatchReconcileSnapshot {
+	t.Helper()
+	report, err := InspectCompactRecoveryEdges(context.Background(), repo)
+	inspectNoError(t, err)
+	stores, err := DiscoverCompactStores(context.Background(), repo)
+	inspectNoError(t, err)
+	records := make([]CompactRecord, 0, len(stores))
+	for _, store := range stores {
+		record, loadErr := store.Load()
+		if loadErr == nil {
+			records = append(records, record)
+		}
+	}
+	return CompactBatchReconcileSnapshot{Inspection: report, Records: records}
+}
+
+func compactBatchInvalidEdges(report CompactRecoveryInspectionReport) []CompactRecoveryEdgeInspection {
+	edges := make([]CompactRecoveryEdgeInspection, 0, report.Totals.InvalidEdges)
+	for _, edge := range report.Edges {
+		if !edge.Valid {
+			edges = append(edges, edge)
+		}
+	}
+	return edges
+}
+
+func compactBatchRecoverySuccessor(t *testing.T, repo string, predecessor CompactRecord, lineage string, intended []string, authorization string, escalated bool) (CompactRecord, CompactStore) {
+	t.Helper()
+	state := correctedCompactTestStateWithIntended(t, repo, lineage, intended)
+	if escalated {
+		state.State = StateEscalated
+	}
+	state.Generation = predecessor.State.Generation + 1
+	state.Recovery = &CompactRecoveryProvenance{
+		PredecessorLineageID:    predecessor.State.LineageID,
+		PredecessorRevision:     predecessor.Revision,
+		Disposition:             RecoveryEscalated,
+		Reason:                  "batch recovery fixture",
+		Actor:                   "maintainer@example.com",
+		RecoveredAt:             time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC),
+		MaintainerAuthorization: authorization,
+	}
+	if authorization == "" {
+		state.Recovery.MaintainerAuthorization = compactRecoveryAuthorizationBinding(
+			predecessor.State.LineageID, predecessor.Revision, state.InitialSnapshot.Identity,
+			state.Recovery.Actor, state.Recovery.Reason)
+	}
+	store, err := CompactAuthoritativeStore(context.Background(), repo, lineage)
+	inspectNoError(t, err)
+	return writeCompactFixtureRecord(t, store, state), store
+}
+
+func compactBatchEntryLineages(entries []CompactBatchReconcileEntryIdentity) []string {
+	lineages := make([]string, len(entries))
+	for index, entry := range entries {
+		lineages[index] = entry.LineageID
+	}
+	return lineages
+}
+
+func compactBatchJSON(t *testing.T, value any) string {
+	t.Helper()
+	payload, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(payload)
+}

--- a/internal/reviewtransaction/compact_inspect.go
+++ b/internal/reviewtransaction/compact_inspect.go
@@ -14,6 +14,7 @@ const (
 	compactInspectionEntryMissing    = "missing_compact_state"
 	compactInspectionEntryUnreadable = "unreadable_compact_state"
 	compactInspectionEntryMalformed  = "malformed_compact_state"
+	compactInspectionEntryUnexpected = "unexpected_authority_root_entry"
 )
 
 type CompactRecoveryInspectionReport struct {
@@ -46,11 +47,16 @@ type CompactRecoveryEntryDiagnostic struct {
 	Problem   string `json:"problem"`
 }
 
-// InspectCompactRecoveryEdges is lock-free and read-only; Complete covers the initial directory pass, not an atomic snapshot, so mutating consumers must re-read revisions under lock/CAS.
+// InspectCompactRecoveryEdges is read-only and coordinates each record read
+// against authority maintenance. Complete covers the initial directory pass,
+// not an atomic snapshot, so mutating consumers must re-read under lock/CAS.
 func InspectCompactRecoveryEdges(ctx context.Context, repo string) (CompactRecoveryInspectionReport, error) {
 	report := CompactRecoveryInspectionReport{Complete: true, Valid: true, Edges: []CompactRecoveryEdgeInspection{}, EntryDiagnostics: []CompactRecoveryEntryDiagnostic{}}
 	base, root, err := reviewAuthorityRoot(ctx, repo)
 	if err != nil {
+		return report, err
+	}
+	if err := ensureNoPreparedCompactBatchReconciliation(base); err != nil {
 		return report, err
 	}
 	versionRoot := filepath.Join(base, "v2")
@@ -67,6 +73,11 @@ func InspectCompactRecoveryEdges(ctx context.Context, repo string) (CompactRecov
 			return report, err
 		}
 		if !entry.IsDir() {
+			if entry.Name() != "LOCK" {
+				report.EntryDiagnostics = append(report.EntryDiagnostics, CompactRecoveryEntryDiagnostic{
+					LineageID: entry.Name(), Problem: compactInspectionEntryUnexpected,
+				})
+			}
 			continue
 		}
 		report.Totals.CompactEntries++
@@ -82,6 +93,13 @@ func InspectCompactRecoveryEdges(ctx context.Context, repo string) (CompactRecov
 		report.Totals.LoadedEntries++
 		records[record.State.LineageID] = record
 	}
+	return inspectCompactRecoveryRecordSet(ctx, records, report)
+}
+
+// inspectCompactRecoveryRecordSet applies the canonical all-edge inspection to
+// an already loaded record set. Read-only consumers use it to prove that an
+// inspection still describes the exact records they hold.
+func inspectCompactRecoveryRecordSet(ctx context.Context, records map[string]CompactRecord, report CompactRecoveryInspectionReport) (CompactRecoveryInspectionReport, error) {
 	for lineage, successor := range records {
 		if err := ctx.Err(); err != nil {
 			return report, err

--- a/internal/reviewtransaction/compact_store.go
+++ b/internal/reviewtransaction/compact_store.go
@@ -537,6 +537,9 @@ func CompactAuthoritativeStore(ctx context.Context, repo, lineageID string) (Com
 	if err != nil {
 		return CompactStore{}, err
 	}
+	if err := ensureNoPreparedCompactBatchReconciliation(base); err != nil {
+		return CompactStore{}, err
+	}
 	versionRoot := filepath.Join(base, "v2")
 	dir := filepath.Join(versionRoot, lineageID)
 	return CompactStore{Dir: dir, lineageID: lineageID, repo: root, lockPath: filepath.Join(versionRoot, "LOCK"), maintenanceLockPath: compactMaintenanceLockPath(base)}, nil
@@ -565,6 +568,9 @@ func CompactIncidentsDir(ctx context.Context, repo, lineageID string) (string, e
 func DiscoverCompactStores(ctx context.Context, repo string) ([]CompactStore, error) {
 	base, root, err := reviewAuthorityRoot(ctx, repo)
 	if err != nil {
+		return nil, err
+	}
+	if err := ensureNoPreparedCompactBatchReconciliation(base); err != nil {
 		return nil, err
 	}
 	versionRoot := filepath.Join(base, "v2")
@@ -1035,6 +1041,45 @@ func (store CompactStore) ReceiptPath() string {
 }
 
 func (store CompactStore) Load() (CompactRecord, error) {
+	maintenance, err := store.acquireReadMaintenance(context.Background())
+	if err != nil {
+		return CompactRecord{}, err
+	}
+	if maintenance != nil {
+		defer maintenance.Release()
+	}
+	return store.loadCompactRecordLocked()
+}
+
+// acquireReadMaintenance prevents a stale CompactStore handle from observing
+// a partially applied authority-maintenance transaction. The first marker
+// check refuses an already-prepared batch without waiting on its exclusive
+// lease; the maintenance acquisition closes the race with a batch that starts
+// after that check and repeats the marker check once shared access is held.
+func (store CompactStore) acquireReadMaintenance(ctx context.Context) (*MaintenanceLock, error) {
+	if store.maintenanceLockPath == "" {
+		return nil, nil
+	}
+	authorityRoot := filepath.Join(filepath.Dir(store.maintenanceLockPath), "review-transactions")
+	if err := ensureNoPreparedCompactBatchReconciliation(authorityRoot); err != nil {
+		return nil, err
+	}
+	// Preserve the historical read-only behavior for a handle whose compact
+	// authority record does not exist. There is no batch-owned record to
+	// coordinate in that case, and creating REVIEW-MAINTENANCE.lock would make
+	// a failed legacy fallback observably mutate authority metadata.
+	if _, err := os.Lstat(store.StatePath()); os.IsNotExist(err) {
+		return nil, nil
+	} else if err != nil {
+		return nil, err
+	}
+	return acquireMaintenanceLock(ctx, store.maintenanceLockPath, maintenanceShared)
+}
+
+// loadCompactRecordLocked is the uncoordinated record read for callers that
+// already hold the required maintenance/store coordination. It is also used by
+// batch reconciliation while its exclusive maintenance lease is held.
+func (store CompactStore) loadCompactRecordLocked() (CompactRecord, error) {
 	payload, err := os.ReadFile(store.StatePath())
 	if err != nil {
 		return CompactRecord{}, err
@@ -1502,7 +1547,14 @@ func appendCompactTrace(path string, entry CompactTraceEntry) error {
 }
 
 func (store CompactStore) ExportTransport() (CompactTransport, error) {
-	record, err := store.Load()
+	maintenance, err := store.acquireReadMaintenance(context.Background())
+	if err != nil {
+		return CompactTransport{}, err
+	}
+	if maintenance != nil {
+		defer maintenance.Release()
+	}
+	record, err := store.loadCompactRecordLocked()
 	if err != nil {
 		return CompactTransport{}, err
 	}
@@ -1608,11 +1660,11 @@ func ImportCompactTransport(ctx context.Context, repo string, transport CompactT
 			return CompactRecord{}, err
 		}
 	}
-	return store.Load()
+	return store.loadCompactRecordLocked()
 }
 
 func (store CompactStore) installTransportRecordLocked(ctx context.Context, record CompactRecord) error {
-	if existing, loadErr := store.Load(); loadErr == nil {
+	if existing, loadErr := store.loadCompactRecordLocked(); loadErr == nil {
 		if existing.Revision == record.Revision && compactStateEqual(existing.State, record.State) {
 			return nil
 		}
@@ -1642,7 +1694,7 @@ func (store CompactStore) WriteReceipt(ctx context.Context, receipt CompactRecei
 }
 
 func (store CompactStore) writeReceiptLocked(receipt CompactReceipt) error {
-	record, err := store.Load()
+	record, err := store.loadCompactRecordLocked()
 	if err != nil {
 		return err
 	}

--- a/internal/reviewtransaction/finalize_attempt_journal.go
+++ b/internal/reviewtransaction/finalize_attempt_journal.go
@@ -99,6 +99,13 @@ func (store CompactStore) PendingFinalizeAttempt() (*FinalizeAttempt, error) {
 // PendingFinalizeAttemptReadOnly never acquires or rewrites LOCK, so status
 // remains observational even while a writer owns the compact authority.
 func (store CompactStore) PendingFinalizeAttemptReadOnly() (*FinalizeAttempt, error) {
+	maintenance, err := store.acquireReadMaintenance(context.Background())
+	if err != nil {
+		return nil, err
+	}
+	if maintenance != nil {
+		defer maintenance.Release()
+	}
 	payload, err := os.ReadFile(store.FinalizeAttemptJournalPath())
 	if errors.Is(err, os.ErrNotExist) {
 		return nil, nil
@@ -179,14 +186,6 @@ func sameFinalizeAttemptPayload(left, right FinalizeAttemptRequest) bool {
 		left.ReviewerResultsDigest == right.ReviewerResultsDigest && left.CorrectionForecastDigest == right.CorrectionForecastDigest &&
 		left.ValidationDigest == right.ValidationDigest && left.RefuterDigest == right.RefuterDigest &&
 		left.EvidenceDigest == right.EvidenceDigest && left.FailedDigest == right.FailedDigest
-}
-
-func (store CompactStore) loadCompactRecordLocked() (CompactRecord, error) {
-	payload, err := os.ReadFile(store.StatePath())
-	if err != nil {
-		return CompactRecord{}, err
-	}
-	return parseCompactRecord(payload, store.lineageID)
 }
 
 func finalizeAttemptMayResume(attempt FinalizeAttempt, request FinalizeAttemptRequest, current CompactRecord) bool {

--- a/internal/reviewtransaction/status.go
+++ b/internal/reviewtransaction/status.go
@@ -112,6 +112,12 @@ func InventoryAuthority(ctx context.Context, repo string) (AuthorityStatusReport
 		report.Diagnostics = append(report.Diagnostics, AuthorityInventoryDiagnostic{Path: root, Problem: "inspect review authority root: " + err.Error()})
 		return report, nil
 	}
+	if err := ensureNoPreparedCompactBatchReconciliation(root); err != nil {
+		report.Complete, report.Authoritative, report.Status = false, false, AuthorityStatusInvalid
+		report.Diagnostics = append(report.Diagnostics, AuthorityInventoryDiagnostic{
+			Path: compactBatchReconcileMarkerPath(root), Problem: ErrCompactBatchReconcilePrepared.Error(),
+		})
+	}
 
 	legacy := inventoryVersion(ctx, repository, root, "v1", AuthorityVersionLegacy)
 	compact := inventoryVersion(ctx, repository, root, "v2", AuthorityVersionCompact)

--- a/internal/reviewtransaction/store_lock.go
+++ b/internal/reviewtransaction/store_lock.go
@@ -155,6 +155,14 @@ func acquireLocalStoreLock(path string) (*storeLock, error) {
 }
 
 func acquireMaintenanceLock(ctx context.Context, path string, mode maintenanceLockMode) (*MaintenanceLock, error) {
+	return acquireMaintenanceLockInternal(ctx, path, mode, false)
+}
+
+func acquireMaintenanceLockForCompactBatch(ctx context.Context, path string) (*MaintenanceLock, error) {
+	return acquireMaintenanceLockInternal(ctx, path, maintenanceExclusive, true)
+}
+
+func acquireMaintenanceLockInternal(ctx context.Context, path string, mode maintenanceLockMode, allowPreparedBatch bool) (*MaintenanceLock, error) {
 	if err := ensureMaintenanceLockPath(path); err != nil {
 		return nil, err
 	}
@@ -181,7 +189,15 @@ func acquireMaintenanceLock(ctx context.Context, path string, mode maintenanceLo
 			return nil, err
 		}
 		if locked {
-			return &MaintenanceLock{lock: &storeLock{file: file}}, nil
+			lock := &MaintenanceLock{lock: &storeLock{file: file}}
+			if !allowPreparedBatch && filepath.Base(path) == "REVIEW-MAINTENANCE.lock" {
+				base := filepath.Join(filepath.Dir(path), "review-transactions")
+				if err := ensureNoPreparedCompactBatchReconciliation(base); err != nil {
+					_ = lock.Release()
+					return nil, err
+				}
+			}
+			return lock, nil
 		}
 		_ = file.Close()
 		select {


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1452

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

Reconciles the complete declared set of invalid compact recovery edges as one deterministic, durable operation. The command refuses stale, incomplete, unknown, or changed authority evidence before mutation and supports exact recovery after interruption without exposing partially repaired logical authority.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/reviewtransaction/compact_batch_reconcile_plan.go` | Plans and validates the complete invalid-edge set and descendant quarantine closure. |
| `internal/reviewtransaction/compact_batch_reconcile_guard.go` | Coordinates exclusive maintenance, locked reinspection, and exact request authorization. |
| `internal/reviewtransaction/compact_batch_reconcile_journal.go` | Persists prepared/committed state, deterministic moves, and exact replay. |
| `internal/reviewtransaction/compact_store.go` | Makes ordinary store access fail closed during an active prepared batch. |
| `internal/cli/review_reconcile_batch.go` | Adds strict JSON prepare/apply handling and deterministic responses. |
| `contracts/review-integration/v1` | Negotiates the new managed batch-reconciliation action. |
| Tests | Covers planning, locking, stale evidence, residue, partial progress, replay, cancellation, and CLI contracts. |

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./... -count=1
```

**Go Vet**
```bash
go vet ./...
```

**Go Format**
```bash
go run ./internal/gofmtcheck
```

**Focused Race Tests**
```bash
go test -race ./internal/reviewtransaction -run 'Batch|ReconcileInvalidRecoveryEdges'
```

- [x] Unit tests pass
- [x] Go vet passes
- [x] Go format passes
- [x] Focused race tests pass
- [x] Windows and Darwin cross-compilation passes
- [ ] Docker E2E passes locally (Docker CLI unavailable; required GitHub CI will run it)
- [x] Direct CLI handler scenarios pass locally

---

## 🤖 Automated Checks

All repository-required checks must pass before merge. CodeRabbit is advisory and is not a merge gate.

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] Maintainer `size:exception` requested: the 2,645-line change is one atomic crash-consistency boundary whose intermediate slices would expose incomplete semantics
- [x] Exactly one `type:*` label will be applied
- [x] Unit tests pass
- [x] Go format passes
- [x] Documentation impact reviewed; no additional user guide is required for the negotiated maintenance action
- [x] Commit follows Conventional Commits
- [x] Commit contains no `Co-Authored-By` trailer

---

## 💬 Notes for Reviewers

Review the planner, exclusive coordination, durable journal, and stale-handle fail-closed behavior as one invariant. An independent final review found and corrected two issues involving unexpected v2 residue and reads through pre-existing store handles; targeted re-validation and the complete Go suite then passed with no remaining findings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `review reconcile-authority-batch` command with preparation and commit workflows.
  * Supports deterministic reconciliation of invalid recovery edges with auditable results.
  * Added safeguards for stale plans, incomplete declarations, unexpected state, and interrupted operations.
  * Review status and help output now recognize the new action.

* **Bug Fixes**
  * Improved authority reads, inspection, inventory, and transport operations during maintenance reconciliation.
  * Updated status contracts to accurately report the new action’s eligibility across review states.

* **Tests**
  * Added comprehensive coverage for successful reconciliation, replay, cancellation, locking, durability failures, and validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->