### PR TITLE
fix(cli): Context7 MCP injection ignores --scope flag

### DIFF
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1348,7 +1348,8 @@ func (s componentApplyStep) Run() error {
 		return nil
 	case model.ComponentContext7:
 		for _, adapter := range adapters {
-			if _, err := mcp.Inject(s.homeDir, adapter); err != nil {
+			targetDir := componentInjectionDirScoped(s.homeDir, s.workspaceDir, s.scope, adapter)
+			if _, err := mcp.Inject(targetDir, adapter); err != nil {
 				return fmt.Errorf("inject context7 for %q: %w", adapter.Agent(), err)
 			}
 		}
@@ -1827,22 +1828,22 @@ func componentPathsWithWorkspaceScoped(homeDir, workspaceDir string, scope Insta
 			switch adapter.MCPStrategy() {
 			case model.StrategySeparateMCPFiles:
 				if adapter.Agent() == model.AgentClaudeCode {
-					if p := adapter.SettingsPath(homeDir); p != "" {
+					if p := adapter.SettingsPath(targetDir); p != "" {
 						paths = append(paths, p)
 					}
 					break
 				}
-				paths = append(paths, adapter.MCPConfigPath(homeDir, "context7"))
+				paths = append(paths, adapter.MCPConfigPath(targetDir, "context7"))
 			case model.StrategyMergeIntoSettings:
-				if p := adapter.SettingsPath(homeDir); p != "" {
+				if p := adapter.SettingsPath(targetDir); p != "" {
 					paths = append(paths, p)
 				}
 			case model.StrategyMCPConfigFile:
-				if p := adapter.MCPConfigPath(homeDir, "context7"); p != "" {
+				if p := adapter.MCPConfigPath(targetDir, "context7"); p != "" {
 					paths = append(paths, p)
 				}
 			case model.StrategyTOMLFile:
-				if p := adapter.MCPConfigPath(homeDir, "context7"); p != "" {
+				if p := adapter.MCPConfigPath(targetDir, "context7"); p != "" {
 					paths = append(paths, p)
 				}
 			}
@@ -2002,7 +2003,7 @@ func componentPathDir(homeDir, workspaceDir string, adapter agents.Adapter, comp
 
 func componentPathDirScoped(homeDir, workspaceDir string, scope InstallScope, adapter agents.Adapter, component model.ComponentID) string {
 	switch component {
-	case model.ComponentEngram, model.ComponentSDD, model.ComponentPersona, model.ComponentSkills:
+	case model.ComponentEngram, model.ComponentSDD, model.ComponentPersona, model.ComponentSkills, model.ComponentContext7:
 		return componentInjectionDirScoped(homeDir, workspaceDir, scope, adapter)
 	default:
 		return homeDir

--- a/internal/cli/run_component_paths_test.go
+++ b/internal/cli/run_component_paths_test.go
@@ -371,6 +371,19 @@ func TestComponentPathsContext7ClaudeUsesSettingsFile(t *testing.T) {
 	}
 }
 
+func TestComponentPathsContext7ClaudeRespectsWorkspaceScope(t *testing.T) {
+	home := t.TempDir()
+	workspace := t.TempDir()
+	adapters := resolveAdapters([]model.AgentID{model.AgentClaudeCode})
+
+	paths := componentPathsWithWorkspaceScoped(home, workspace, ScopeWorkspace, model.Selection{}, adapters, model.ComponentContext7)
+
+	want := filepath.Join(workspace, ".claude", "settings.json")
+	if !containsPath(paths, want) {
+		t.Fatalf("componentPathsWithWorkspaceScoped(context7,claude) with ScopeWorkspace missing %q\npaths=%v", want, paths)
+	}
+}
+
 // TestComponentPathsEngramCodexIncludesConfigTOML verifies that componentPaths
 // for ComponentEngram + Codex reports ~/.codex/config.toml as a backup target.
 func TestComponentPathsEngramCodexIncludesConfigTOML(t *testing.T) {

--- a/internal/cli/run_integration_test.go
+++ b/internal/cli/run_integration_test.go
@@ -2396,3 +2396,122 @@ func TestRunInstallWorkspaceScopeVerification(t *testing.T) {
 		t.Errorf("unexpected skill file found in home directory: %q", unexpectedHomeSkillFile)
 	}
 }
+
+// TestRunInstall_Context7WorkspaceScope_PersistsToWorkspace verifies that executing
+// a real workspace operation with --scope workspace and Context7 component:
+// 1. Returns a successful result with verification ready.
+// 2. Persists Context7 MCP configuration directly into the workspace-managed settings file.
+// 3. Leaves the user's home directory settings untouched.
+func TestRunInstall_Context7WorkspaceScope_PersistsToWorkspace(t *testing.T) {
+	home := t.TempDir()
+	workspace := t.TempDir()
+
+	restoreHome := osUserHomeDir
+	restoreCommand := runCommand
+	restoreLookPath := cmdLookPath
+	originalCwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get current working directory: %v", err)
+	}
+
+	t.Cleanup(func() {
+		osUserHomeDir = restoreHome
+		runCommand = restoreCommand
+		cmdLookPath = restoreLookPath
+		if err := os.Chdir(originalCwd); err != nil {
+			t.Errorf("failed to restore working directory: %v", err)
+		}
+	})
+
+	osUserHomeDir = func() (string, error) { return home, nil }
+	runCommand = func(string, ...string) error { return nil }
+	cmdLookPath = func(name string) (string, error) {
+		return "/usr/local/bin/" + name, nil
+	}
+
+	if err := os.Chdir(workspace); err != nil {
+		t.Fatalf("failed to change working directory to temp workspace: %v", err)
+	}
+
+	args := []string{
+		"--scope", "workspace",
+		"--agent", "claude-code",
+		"--component", "context7",
+		"--preset", "custom",
+	}
+
+	result, err := RunInstall(args, system.DetectionResult{})
+	if err != nil {
+		t.Fatalf("RunInstall() error = %v", err)
+	}
+
+	if !result.Verify.Ready {
+		t.Fatalf("post-apply verification failed for Context7 workspace scope: %#v", result.Verify)
+	}
+
+	// Assert that Context7 MCP configuration was persisted to workspace-scoped Claude settings.
+	workspaceSettingsFile := filepath.Join(workspace, ".claude", "settings.json")
+	assertFileContains(t, workspaceSettingsFile, "context7")
+
+	// Assert that no Context7 configuration was written to home directory settings.
+	homeSettingsFile := filepath.Join(home, ".claude", "settings.json")
+	if _, err := os.Stat(homeSettingsFile); err == nil {
+		content, _ := os.ReadFile(homeSettingsFile)
+		if strings.Contains(string(content), "context7") {
+			t.Errorf("unexpected Context7 MCP config found in home settings file: %q", homeSettingsFile)
+		}
+	}
+}
+
+// TestRunInstall_Context7WorkspaceScope_FailurePath verifies that executing
+// Context7 workspace installation when workspace target is unwriteable fails gracefully,
+// returning an error and reporting verification failure.
+func TestRunInstall_Context7WorkspaceScope_FailurePath(t *testing.T) {
+	home := t.TempDir()
+	workspace := t.TempDir()
+
+	restoreHome := osUserHomeDir
+	restoreCommand := runCommand
+	restoreLookPath := cmdLookPath
+	originalCwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get current working directory: %v", err)
+	}
+
+	t.Cleanup(func() {
+		osUserHomeDir = restoreHome
+		runCommand = restoreCommand
+		cmdLookPath = restoreLookPath
+		if err := os.Chdir(originalCwd); err != nil {
+			t.Errorf("failed to restore working directory: %v", err)
+		}
+	})
+
+	osUserHomeDir = func() (string, error) { return home, nil }
+	runCommand = func(string, ...string) error { return nil }
+	cmdLookPath = func(name string) (string, error) {
+		return "/usr/local/bin/" + name, nil
+	}
+
+	if err := os.Chdir(workspace); err != nil {
+		t.Fatalf("failed to change working directory to temp workspace: %v", err)
+	}
+
+	// Create .claude as a read-only file (not directory) so writing settings.json fails.
+	claudePath := filepath.Join(workspace, ".claude")
+	if err := os.WriteFile(claudePath, []byte("blocking directory creation"), 0o444); err != nil {
+		t.Fatalf("failed to block workspace .claude path: %v", err)
+	}
+
+	args := []string{
+		"--scope", "workspace",
+		"--agent", "claude-code",
+		"--component", "context7",
+		"--preset", "custom",
+	}
+
+	_, err = RunInstall(args, system.DetectionResult{})
+	if err == nil {
+		t.Fatalf("RunInstall() with unwriteable workspace target expected error, got nil")
+	}
+}

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -896,7 +896,8 @@ func (s componentSyncStep) Run() error {
 
 	case model.ComponentContext7:
 		for _, adapter := range adapters {
-			res, err := mcp.Inject(s.homeDir, adapter)
+			targetDir := componentInjectionDir(s.homeDir, s.workspaceDir, adapter)
+			res, err := mcp.Inject(targetDir, adapter)
 			if err != nil {
 				return fmt.Errorf("sync context7 for %q: %w", adapter.Agent(), err)
 			}


### PR DESCRIPTION
Closes #736.

### Summary
Context7 always writes to the global config root (~/.config/opencode/opencode.json) instead of the workspace config root, ignoring the '--scope=workspace' flag.

This PR makes Context7 MCP config injection scope-aware by:
1. Resolving the target directory using componentInjectionDirScoped/componentInjectionDir.
2. Routing ComponentContext7 path resolution through componentPathDirScoped so backup, verification, and uninstall find the correct file paths.
3. Adding a unit test to verify workspace-scoped path generation for Context7.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Context7 MCP configuration placement for workspace-scoped installations.
  * Ensured Context7 settings and configuration files are consistently stored in the appropriate adapter-specific directory during installation and synchronization.

* **Tests**
  * Added coverage verifying correct workspace-scoped Context7 settings paths for Claude installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->