### PR TITLE
fix(tui): decouple engram cleanup from profile removal in uninstall flow

### DIFF
--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -56,13 +56,13 @@ const (
 	UninstallModeCleanInstall UninstallMode = "clean-install"
 )
 
-// EngramUninstallScope selects the scope of Engram cleanup performed by the
-// uninstall flow. The zero value (empty string) represents "None" — the user
-// explicitly opted out of any Engram cleanup, so neither the workspace's
-// .engram/ directory nor the global Engram MCP/system prompt integration
-// is removed. The service layer treats "" as a sentinel for no-op Engram
-// removal, which lets the TUI skip the Engram step without changing service
-// signatures.
+// EngramUninstallScope selects the scope of Engram cleanup. The zero
+// value ("") represents "None" — the user opted out of any Engram cleanup.
+// IMPORTANT: "" is NOT a service-level no-op. The uninstall service
+// treats an empty component list as "all components" and would still
+// trigger global Engram cleanup if ComponentEngram reached it. The TUI
+// enforces None via startUninstall's engramCleanupSkipped branch;
+// callers MUST NOT pass "" as a service cleanup request.
 type EngramUninstallScope string
 
 const (

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -56,10 +56,21 @@ const (
 	UninstallModeCleanInstall UninstallMode = "clean-install"
 )
 
+// EngramUninstallScope selects the scope of Engram cleanup performed by the
+// uninstall flow. The zero value (empty string) represents "None" — the user
+// explicitly opted out of any Engram cleanup, so neither the workspace's
+// .engram/ directory nor the global Engram MCP/system prompt integration
+// is removed. The service layer treats "" as a sentinel for no-op Engram
+// removal, which lets the TUI skip the Engram step without changing service
+// signatures.
 type EngramUninstallScope string
 
 const (
-	EngramUninstallScopeGlobal  EngramUninstallScope = "global"
+	// EngramUninstallScopeGlobal removes global Engram MCP/system prompt
+	// integration across all agents.
+	EngramUninstallScopeGlobal EngramUninstallScope = "global"
+	// EngramUninstallScopeProject removes only the .engram/ directory inside
+	// the current workspace.
 	EngramUninstallScopeProject EngramUninstallScope = "project"
 )
 

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -56,21 +56,14 @@ const (
 	UninstallModeCleanInstall UninstallMode = "clean-install"
 )
 
-// EngramUninstallScope selects the scope of Engram cleanup. The zero
-// value ("") represents "None" — the user opted out of any Engram cleanup.
-// IMPORTANT: "" is NOT a service-level no-op. The uninstall service
-// treats an empty component list as "all components" and would still
-// trigger global Engram cleanup if ComponentEngram reached it. The TUI
-// enforces None via startUninstall's engramCleanupSkipped branch;
-// callers MUST NOT pass "" as a service cleanup request.
+// EngramUninstallScope selects Engram cleanup scope. Its zero value means
+// no cleanup; callers must not pass it to the uninstall service.
 type EngramUninstallScope string
 
 const (
-	// EngramUninstallScopeGlobal removes global Engram MCP/system prompt
-	// integration across all agents.
+	// EngramUninstallScopeGlobal removes global Engram integration.
 	EngramUninstallScopeGlobal EngramUninstallScope = "global"
-	// EngramUninstallScopeProject removes only the .engram/ directory inside
-	// the current workspace.
+	// EngramUninstallScopeProject removes the workspace .engram directory.
 	EngramUninstallScopeProject EngramUninstallScope = "project"
 )
 

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1134,7 +1134,7 @@ func (m Model) View() string {
 	case ScreenUninstallComponents:
 		return screens.RenderUninstallComponents(m.UninstallComponents, m.Cursor)
 	case ScreenUninstallProfiles:
-		return screens.RenderUninstallProfiles(m.UninstallProfilesAvailable, m.UninstallProfilesToRemove, m.UninstallEngramProjectScopeAvailable, m.UninstallEngramScope, m.Cursor)
+		return screens.RenderUninstallProfiles(m.UninstallProfilesAvailable, m.UninstallProfilesToRemove, m.UninstallEngramProjectScopeAvailable, m.UninstallComponents, m.UninstallEngramScope, m.Cursor)
 	case ScreenUninstallConfirm:
 		return screens.RenderUninstallConfirm(m.UninstallMode, m.UninstallAgents, m.UninstallComponents, m.UninstallProfilesToRemove, m.UninstallEngramScope, m.UninstallEngramProjectScopeAvailable, m.Cursor, m.OperationRunning, m.SpinnerFrame)
 	case ScreenUninstallResult:

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -665,13 +665,14 @@ func NewModel(detection system.DetectionResult, version string, installState ...
 	}
 
 	return Model{
-		Screen:               ScreenWelcome,
-		Version:              version,
-		Selection:            selection,
-		Detection:            detection,
-		UninstallAgents:      agents,
-		UninstallComponents:  defaultUninstallComponents(),
-		UninstallEngramScope: model.EngramUninstallScopeGlobal,
+		Screen:              ScreenWelcome,
+		Version:             version,
+		Selection:           selection,
+		Detection:           detection,
+		UninstallAgents:     agents,
+		UninstallComponents: defaultUninstallComponents(),
+		// Default to "" (None) so the user opts in to Engram cleanup explicitly.
+		UninstallEngramScope: "",
 		Progress: NewProgressState([]string{
 			"Install dependencies",
 			"Configure selected agents",
@@ -2657,7 +2658,8 @@ func (m Model) withResetUninstallState() Model {
 	m.UninstallProfilesToRemove = nil
 	m.UninstallProfileSelection = false
 	m.UninstallEngramProjectScopeAvailable = false
-	m.UninstallEngramScope = model.EngramUninstallScopeGlobal
+	// Reset to "" (None) so a fresh uninstall flow starts with no Engram cleanup.
+	m.UninstallEngramScope = ""
 	m.UninstallResult = componentuninstall.Result{}
 	m.UninstallErr = nil
 	m.SyncCleanInstallFiles = nil
@@ -3014,9 +3016,15 @@ func (m Model) startUninstall() tea.Cmd {
 	}
 }
 
+// refreshUninstallProfiles re-reads the project's OpenCode SDD profiles and
+// re-evaluates whether a project-scoped .engram/ directory exists. It also
+// resets UninstallEngramScope to the empty ("None") default, so a fresh entry
+// into the uninstall flow requires the user to opt in to Engram cleanup
+// explicitly — preventing accidental data loss when the user only wanted
+// profile removal.
 func (m *Model) refreshUninstallProfiles() {
 	m.UninstallEngramProjectScopeAvailable = m.detectProjectEngramData()
-	m.UninstallEngramScope = model.EngramUninstallScopeGlobal
+	m.UninstallEngramScope = ""
 
 	if !m.hasDetectedOpenCode() {
 		m.UninstallProfilesAvailable = nil
@@ -3503,7 +3511,7 @@ func (m *Model) setScreen(next Screen) {
 		m.refreshUninstallProfiles()
 		m.UninstallProfilesToRemove = nil
 		m.UninstallProfileSelection = false
-		m.UninstallEngramScope = model.EngramUninstallScopeGlobal
+		// UninstallEngramScope is already reset to "" by refreshUninstallProfiles.
 	}
 }
 

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1796,6 +1796,10 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 			m.toggleCurrentUninstallComponent()
 		case m.Cursor == componentCount && len(m.UninstallComponents) > 0:
 			m.refreshUninstallProfiles()
+			// Partial-mode routing: when no profiles exist but ComponentEngram
+			// is selected, scope selection still must be reachable so the user
+			// can opt in or out (None vs Global) instead of being silently
+			// dropped on Confirm with a default scope they never chose.
 			if m.shouldShowUninstallSubSelection() {
 				m.selectAllUninstallProfiles()
 				m.UninstallProfileSelection = true
@@ -2985,6 +2989,14 @@ func (m Model) startUninstall() tea.Cmd {
 				}
 			}
 			if len(componentsWithoutEngram) > 0 {
+				// Defensive guard: the initial nil check covers both UninstallFn
+				// and UninstallWithProfilesFn together, but in this branch we
+				// call UninstallFn directly when the filtered slice is non-empty.
+				// Mirroring the initial guard locally keeps the surface area
+				// explicit even if the unified check changes later.
+				if uninstallFn == nil {
+					return UninstallDoneMsg{Err: fmt.Errorf("uninstall function not configured")}
+				}
 				result, err = uninstallFn(agentIDs, componentsWithoutEngram)
 			}
 			if err == nil && len(profileNamesToRemove) > 0 {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1762,7 +1762,10 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 				for _, component := range allComponents {
 					m.UninstallComponents = append(m.UninstallComponents, component.ID)
 				}
-				if m.shouldShowUninstallSubSelection() {
+				// Full modes imply global Engram cleanup; auto-route only when
+				// profiles exist. ComponentEngram reachability is handled by
+				// shouldShowUninstallSubSelection (Partial-mode routing).
+				if m.shouldShowUninstallProfilesSelection() {
 					m.selectAllUninstallProfiles()
 					m.UninstallProfileSelection = true
 					m.setScreen(ScreenUninstallProfiles)
@@ -2971,17 +2974,19 @@ func (m Model) startUninstall() tea.Cmd {
 		)
 		switch {
 		case engramCleanupSkipped:
-			// None: filter ComponentEngram out of componentIDs before delegating
-			// to uninstallFn — the service treats Engram as a global cleanup
-			// target, so leaving it in would wipe the user's Engram data
-			// despite the explicit opt-out. Profile removal runs separately.
+			// None: filter ComponentEngram out of componentIDs — service treats
+			// Engram as a global cleanup target. Skip uninstallFn when the
+			// filtered slice is empty (service treats [] as "all components"
+			// and would still trigger Global cleanup). Profile removal runs.
 			componentsWithoutEngram := make([]model.ComponentID, 0, len(componentIDs))
 			for _, c := range componentIDs {
 				if c != model.ComponentEngram {
 					componentsWithoutEngram = append(componentsWithoutEngram, c)
 				}
 			}
-			result, err = uninstallFn(agentIDs, componentsWithoutEngram)
+			if len(componentsWithoutEngram) > 0 {
+				result, err = uninstallFn(agentIDs, componentsWithoutEngram)
+			}
 			if err == nil && len(profileNamesToRemove) > 0 {
 				settingsPath := opencode.DefaultSettingsPath()
 				for _, profileName := range profileNamesToRemove {
@@ -4542,8 +4547,15 @@ func (m Model) shouldShowUninstallEngramScopeSelection() bool {
 	return m.UninstallEngramProjectScopeAvailable
 }
 
+// shouldShowUninstallSubSelection reports whether the uninstall flow must
+// route through ScreenUninstallProfiles. Reachable when profiles exist
+// OR ComponentEngram is selected — without project scope, the user still
+// must choose None vs Global.
 func (m Model) shouldShowUninstallSubSelection() bool {
-	return m.shouldShowUninstallProfilesSelection() || m.shouldShowUninstallEngramScopeSelection()
+	if m.shouldShowUninstallProfilesSelection() {
+		return true
+	}
+	return hasSelectedComponent(m.UninstallComponents, model.ComponentEngram)
 }
 
 func (m *Model) selectAllUninstallProfiles() {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -665,13 +665,12 @@ func NewModel(detection system.DetectionResult, version string, installState ...
 	}
 
 	return Model{
-		Screen:              ScreenWelcome,
-		Version:             version,
-		Selection:           selection,
-		Detection:           detection,
-		UninstallAgents:     agents,
-		UninstallComponents: defaultUninstallComponents(),
-		// Default to "" (None) so the user opts in to Engram cleanup explicitly.
+		Screen:               ScreenWelcome,
+		Version:              version,
+		Selection:            selection,
+		Detection:            detection,
+		UninstallAgents:      agents,
+		UninstallComponents:  defaultUninstallComponents(),
 		UninstallEngramScope: "",
 		Progress: NewProgressState([]string{
 			"Install dependencies",
@@ -1762,10 +1761,7 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 				for _, component := range allComponents {
 					m.UninstallComponents = append(m.UninstallComponents, component.ID)
 				}
-				// Full modes imply global Engram cleanup; auto-route only when
-				// profiles exist. ComponentEngram reachability is handled by
-				// shouldShowUninstallSubSelection (Partial-mode routing).
-				if m.shouldShowUninstallProfilesSelection() {
+				if m.shouldShowUninstallSubSelection() {
 					m.selectAllUninstallProfiles()
 					m.UninstallProfileSelection = true
 					m.setScreen(ScreenUninstallProfiles)
@@ -1796,10 +1792,7 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 			m.toggleCurrentUninstallComponent()
 		case m.Cursor == componentCount && len(m.UninstallComponents) > 0:
 			m.refreshUninstallProfiles()
-			// Partial-mode routing: when no profiles exist but ComponentEngram
-			// is selected, scope selection still must be reachable so the user
-			// can opt in or out (None vs Global) instead of being silently
-			// dropped on Confirm with a default scope they never chose.
+			// Engram selection always requires an explicit scope decision.
 			if m.shouldShowUninstallSubSelection() {
 				m.selectAllUninstallProfiles()
 				m.UninstallProfileSelection = true
@@ -1815,9 +1808,7 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 	case ScreenUninstallProfiles:
 		profileCount := len(m.UninstallProfilesAvailable)
 		engramScopeOptionCount := 0
-		// Scope row count: 3 (None/Project/Global) if project scope available,
-		// 2 (None/Global) otherwise. See RenderUninstallProfiles for the matching
-		// render-side predicate.
+		// Scope rows are None/Global, plus Project when available.
 		if hasSelectedComponent(m.UninstallComponents, model.ComponentEngram) {
 			if m.UninstallEngramProjectScopeAvailable {
 				engramScopeOptionCount = 3
@@ -2672,7 +2663,6 @@ func (m Model) withResetUninstallState() Model {
 	m.UninstallProfilesToRemove = nil
 	m.UninstallProfileSelection = false
 	m.UninstallEngramProjectScopeAvailable = false
-	// Reset to "" (None) so a fresh uninstall flow starts with no Engram cleanup.
 	m.UninstallEngramScope = ""
 	m.UninstallResult = componentuninstall.Result{}
 	m.UninstallErr = nil
@@ -2948,14 +2938,8 @@ func executeExternalCommand(commandFn func(string, ...string) *exec.Cmd, name st
 	return nil
 }
 
-// startUninstall builds the tea.Cmd that runs the uninstall pipeline against
-// the captured agent/component/profile selections. The "None" scope path
-// (empty UninstallEngramScope) routes through uninstallFn for agents and
-// components without invoking the Engram step, then removes profiles via a
-// direct removeProfileAgentsFn call. This avoids calling
-// uninstallWithProfilesFn with a nil scope — the service treats that as
-// Global cleanup, which would wipe the user's Engram data even when they
-// opted out.
+// startUninstall runs the captured uninstall selection. Empty Engram scope
+// filters Engram from service dispatch and removes profiles separately.
 func (m Model) startUninstall() tea.Cmd {
 	uninstallFn := m.UninstallFn
 	uninstallWithProfilesFn := m.UninstallWithProfilesFn
@@ -2978,10 +2962,8 @@ func (m Model) startUninstall() tea.Cmd {
 		)
 		switch {
 		case engramCleanupSkipped:
-			// None: filter ComponentEngram out of componentIDs — service treats
-			// Engram as a global cleanup target. Skip uninstallFn when the
-			// filtered slice is empty (service treats [] as "all components"
-			// and would still trigger Global cleanup). Profile removal runs.
+			// Service treats empty component slices as all components, so skip
+			// dispatch when filtering Engram leaves nothing.
 			componentsWithoutEngram := make([]model.ComponentID, 0, len(componentIDs))
 			for _, c := range componentIDs {
 				if c != model.ComponentEngram {
@@ -2989,11 +2971,6 @@ func (m Model) startUninstall() tea.Cmd {
 				}
 			}
 			if len(componentsWithoutEngram) > 0 {
-				// Defensive guard: the initial nil check covers both UninstallFn
-				// and UninstallWithProfilesFn together, but in this branch we
-				// call UninstallFn directly when the filtered slice is non-empty.
-				// Mirroring the initial guard locally keeps the surface area
-				// explicit even if the unified check changes later.
 				if uninstallFn == nil {
 					return UninstallDoneMsg{Err: fmt.Errorf("uninstall function not configured")}
 				}
@@ -3003,8 +2980,6 @@ func (m Model) startUninstall() tea.Cmd {
 				settingsPath := opencode.DefaultSettingsPath()
 				for _, profileName := range profileNamesToRemove {
 					if removeErr := removeProfileAgentsFn(settingsPath, profileName); removeErr != nil {
-						// Surface the profile removal failure but don't fail the
-						// uninstall — agents/components are already gone.
 						result.ManualActions = append(result.ManualActions,
 							fmt.Sprintf("Profile %q removal failed (%s); remove manually with 'gentle-ai profile delete'.", profileName, removeErr.Error()))
 					}
@@ -3048,12 +3023,8 @@ func (m Model) startUninstall() tea.Cmd {
 	}
 }
 
-// refreshUninstallProfiles re-reads the project's OpenCode SDD profiles and
-// re-evaluates whether a project-scoped .engram/ directory exists. It also
-// resets UninstallEngramScope to the empty ("None") default, so a fresh entry
-// into the uninstall flow requires the user to opt in to Engram cleanup
-// explicitly — preventing accidental data loss when the user only wanted
-// profile removal.
+// refreshUninstallProfiles reloads profiles and project scope availability,
+// resetting Engram cleanup to None for a fresh decision.
 func (m *Model) refreshUninstallProfiles() {
 	m.UninstallEngramProjectScopeAvailable = m.detectProjectEngramData()
 	m.UninstallEngramScope = ""
@@ -3543,7 +3514,6 @@ func (m *Model) setScreen(next Screen) {
 		m.refreshUninstallProfiles()
 		m.UninstallProfilesToRemove = nil
 		m.UninstallProfileSelection = false
-		// UninstallEngramScope is already reset to "" by refreshUninstallProfiles.
 	}
 }
 
@@ -3629,8 +3599,7 @@ func (m Model) optionCount() int {
 		return len(screens.UninstallComponentOptions()) + 2
 	case ScreenUninstallProfiles:
 		count := len(m.UninstallProfilesAvailable) + 2
-		// Scope row count: 3 (None/Project/Global) if project scope available,
-		// 2 (None/Global) otherwise. Matches the render-side predicate.
+		// Scope rows match ScreenUninstallProfiles rendering.
 		if hasSelectedComponent(m.UninstallComponents, model.ComponentEngram) {
 			if m.UninstallEngramProjectScopeAvailable {
 				count += 3
@@ -3855,10 +3824,7 @@ func (m *Model) toggleCurrentUninstallProfile() {
 	m.UninstallProfilesToRemove = append(m.UninstallProfilesToRemove, profileName)
 }
 
-// toggleCurrentUninstallEngramScope advances UninstallEninstallScope through
-// None -> Project -> Global -> None when the cursor sits on the scope
-// section. When no project-scoped Engram data exists, the Project row is
-// not rendered and the cycle collapses to None -> Global -> None.
+// toggleCurrentUninstallEngramScope cycles None, available Project, and Global.
 func (m *Model) toggleCurrentUninstallEngramScope() {
 	profileCount := len(m.UninstallProfilesAvailable)
 	if m.Cursor < profileCount || !hasSelectedComponent(m.UninstallComponents, model.ComponentEngram) {
@@ -3874,7 +3840,6 @@ func (m *Model) toggleCurrentUninstallEngramScope() {
 	case model.EngramUninstallScopeProject:
 		m.UninstallEngramScope = model.EngramUninstallScopeGlobal
 	default:
-		// Includes EngramUninstallScopeGlobal and any future value: wrap to None.
 		m.UninstallEngramScope = ""
 	}
 }
@@ -4559,10 +4524,7 @@ func (m Model) shouldShowUninstallEngramScopeSelection() bool {
 	return m.UninstallEngramProjectScopeAvailable
 }
 
-// shouldShowUninstallSubSelection reports whether the uninstall flow must
-// route through ScreenUninstallProfiles. Reachable when profiles exist
-// OR ComponentEngram is selected — without project scope, the user still
-// must choose None vs Global.
+// shouldShowUninstallSubSelection requires a profile or Engram scope decision.
 func (m Model) shouldShowUninstallSubSelection() bool {
 	if m.shouldShowUninstallProfilesSelection() {
 		return true

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1808,7 +1808,7 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 		profileCount := len(m.UninstallProfilesAvailable)
 		engramScopeOptionCount := 0
 		if m.shouldShowUninstallEngramScopeSelection() {
-			engramScopeOptionCount = 2
+			engramScopeOptionCount = 3
 		}
 		continueIdx := profileCount + engramScopeOptionCount
 		switch {
@@ -2932,6 +2932,14 @@ func executeExternalCommand(commandFn func(string, ...string) *exec.Cmd, name st
 	return nil
 }
 
+// startUninstall builds the tea.Cmd that runs the uninstall pipeline against
+// the captured agent/component/profile selections. The "None" scope path
+// (empty UninstallEngramScope) routes through uninstallFn for agents and
+// components without invoking the Engram step, then removes profiles via a
+// direct removeProfileAgentsFn call. This avoids calling
+// uninstallWithProfilesFn with a nil scope — the service treats that as
+// Global cleanup, which would wipe the user's Engram data even when they
+// opted out.
 func (m Model) startUninstall() tea.Cmd {
 	uninstallFn := m.UninstallFn
 	uninstallWithProfilesFn := m.UninstallWithProfilesFn
@@ -2941,6 +2949,7 @@ func (m Model) startUninstall() tea.Cmd {
 	profileNamesToRemove := append([]string(nil), m.UninstallProfilesToRemove...)
 	engramScope := m.UninstallEngramScope
 	profileSelectionUsed := m.UninstallProfileSelection || len(profileNamesToRemove) > 0
+	engramCleanupSkipped := engramScope == ""
 	mode := m.UninstallMode
 	return func() tea.Msg {
 		if uninstallFn == nil && uninstallWithProfilesFn == nil {
@@ -2951,9 +2960,25 @@ func (m Model) startUninstall() tea.Cmd {
 			result componentuninstall.Result
 			err    error
 		)
-		if uninstallWithProfilesFn != nil && profileSelectionUsed {
+		switch {
+		case engramCleanupSkipped:
+			// None: do not invoke the Engram step at all. Use uninstallFn for
+			// agents/components; remove profiles separately if requested.
+			result, err = uninstallFn(agentIDs, componentIDs)
+			if err == nil && len(profileNamesToRemove) > 0 {
+				settingsPath := opencode.DefaultSettingsPath()
+				for _, profileName := range profileNamesToRemove {
+					if removeErr := removeProfileAgentsFn(settingsPath, profileName); removeErr != nil {
+						// Surface the profile removal failure but don't fail the
+						// uninstall — agents/components are already gone.
+						result.ManualActions = append(result.ManualActions,
+							fmt.Sprintf("Profile %q removal failed (%s); remove manually with 'gentle-ai profile delete'.", profileName, removeErr.Error()))
+					}
+				}
+			}
+		case uninstallWithProfilesFn != nil && profileSelectionUsed:
 			result, err = uninstallWithProfilesFn(agentIDs, componentIDs, profileNamesToRemove, engramScope)
-		} else {
+		default:
 			result, err = uninstallFn(agentIDs, componentIDs)
 		}
 		if err != nil {
@@ -3565,7 +3590,7 @@ func (m Model) optionCount() int {
 	case ScreenUninstallProfiles:
 		count := len(m.UninstallProfilesAvailable) + 2
 		if m.shouldShowUninstallEngramScopeSelection() {
-			count += 2
+			count += 3
 		}
 		return count
 	case ScreenUninstallConfirm:
@@ -3784,18 +3809,24 @@ func (m *Model) toggleCurrentUninstallProfile() {
 	m.UninstallProfilesToRemove = append(m.UninstallProfilesToRemove, profileName)
 }
 
+// toggleCurrentUninstallEngramScope advances UninstallEngramScope through the
+// three-state cycle None -> Project -> Global -> None when the cursor sits on
+// the scope section. The cycle preserves the cursor position on the same row;
+// the radio-button rendering reflects the current scope regardless of which
+// row the cursor is on within the section.
 func (m *Model) toggleCurrentUninstallEngramScope() {
 	profileCount := len(m.UninstallProfilesAvailable)
 	if m.Cursor < profileCount || !m.shouldShowUninstallEngramScopeSelection() {
 		return
 	}
-	idx := m.Cursor - profileCount
-	if idx == 0 {
+	switch m.UninstallEngramScope {
+	case "":
 		m.UninstallEngramScope = model.EngramUninstallScopeProject
-		return
-	}
-	if idx == 1 {
+	case model.EngramUninstallScopeProject:
 		m.UninstallEngramScope = model.EngramUninstallScopeGlobal
+	default:
+		// Includes EngramUninstallScopeGlobal and any future value: wrap to None.
+		m.UninstallEngramScope = ""
 	}
 }
 

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1808,8 +1808,15 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 	case ScreenUninstallProfiles:
 		profileCount := len(m.UninstallProfilesAvailable)
 		engramScopeOptionCount := 0
-		if m.shouldShowUninstallEngramScopeSelection() {
-			engramScopeOptionCount = 3
+		// Scope row count: 3 (None/Project/Global) if project scope available,
+		// 2 (None/Global) otherwise. See RenderUninstallProfiles for the matching
+		// render-side predicate.
+		if hasSelectedComponent(m.UninstallComponents, model.ComponentEngram) {
+			if m.UninstallEngramProjectScopeAvailable {
+				engramScopeOptionCount = 3
+			} else {
+				engramScopeOptionCount = 2
+			}
 		}
 		continueIdx := profileCount + engramScopeOptionCount
 		switch {
@@ -2964,9 +2971,17 @@ func (m Model) startUninstall() tea.Cmd {
 		)
 		switch {
 		case engramCleanupSkipped:
-			// None: do not invoke the Engram step at all. Use uninstallFn for
-			// agents/components; remove profiles separately if requested.
-			result, err = uninstallFn(agentIDs, componentIDs)
+			// None: filter ComponentEngram out of componentIDs before delegating
+			// to uninstallFn — the service treats Engram as a global cleanup
+			// target, so leaving it in would wipe the user's Engram data
+			// despite the explicit opt-out. Profile removal runs separately.
+			componentsWithoutEngram := make([]model.ComponentID, 0, len(componentIDs))
+			for _, c := range componentIDs {
+				if c != model.ComponentEngram {
+					componentsWithoutEngram = append(componentsWithoutEngram, c)
+				}
+			}
+			result, err = uninstallFn(agentIDs, componentsWithoutEngram)
 			if err == nil && len(profileNamesToRemove) > 0 {
 				settingsPath := opencode.DefaultSettingsPath()
 				for _, profileName := range profileNamesToRemove {
@@ -3597,8 +3612,14 @@ func (m Model) optionCount() int {
 		return len(screens.UninstallComponentOptions()) + 2
 	case ScreenUninstallProfiles:
 		count := len(m.UninstallProfilesAvailable) + 2
-		if m.shouldShowUninstallEngramScopeSelection() {
-			count += 3
+		// Scope row count: 3 (None/Project/Global) if project scope available,
+		// 2 (None/Global) otherwise. Matches the render-side predicate.
+		if hasSelectedComponent(m.UninstallComponents, model.ComponentEngram) {
+			if m.UninstallEngramProjectScopeAvailable {
+				count += 3
+			} else {
+				count += 2
+			}
 		}
 		return count
 	case ScreenUninstallConfirm:
@@ -3817,19 +3838,22 @@ func (m *Model) toggleCurrentUninstallProfile() {
 	m.UninstallProfilesToRemove = append(m.UninstallProfilesToRemove, profileName)
 }
 
-// toggleCurrentUninstallEngramScope advances UninstallEngramScope through the
-// three-state cycle None -> Project -> Global -> None when the cursor sits on
-// the scope section. The cycle preserves the cursor position on the same row;
-// the radio-button rendering reflects the current scope regardless of which
-// row the cursor is on within the section.
+// toggleCurrentUninstallEngramScope advances UninstallEninstallScope through
+// None -> Project -> Global -> None when the cursor sits on the scope
+// section. When no project-scoped Engram data exists, the Project row is
+// not rendered and the cycle collapses to None -> Global -> None.
 func (m *Model) toggleCurrentUninstallEngramScope() {
 	profileCount := len(m.UninstallProfilesAvailable)
-	if m.Cursor < profileCount || !m.shouldShowUninstallEngramScopeSelection() {
+	if m.Cursor < profileCount || !hasSelectedComponent(m.UninstallComponents, model.ComponentEngram) {
 		return
 	}
 	switch m.UninstallEngramScope {
 	case "":
-		m.UninstallEngramScope = model.EngramUninstallScopeProject
+		if m.UninstallEngramProjectScopeAvailable {
+			m.UninstallEngramScope = model.EngramUninstallScopeProject
+		} else {
+			m.UninstallEngramScope = model.EngramUninstallScopeGlobal
+		}
 	case model.EngramUninstallScopeProject:
 		m.UninstallEngramScope = model.EngramUninstallScopeGlobal
 	default:

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -2213,6 +2213,135 @@ func TestStartUninstall_UsesProfileAwareUninstallWhenConfigured(t *testing.T) {
 	}
 }
 
+// TestStartUninstall_NoneScopeSkipsEngramAndRemovesProfilesSeparately verifies
+// that when the user opts out of Engram cleanup (empty UninstallEngramScope),
+// startUninstall routes through uninstallFn for agents/components without
+// invoking the Engram step, and removes profiles via removeProfileAgentsFn
+// for each requested profile name.
+func TestStartUninstall_NoneScopeSkipsEngramAndRemovesProfilesSeparately(t *testing.T) {
+	originalRemove := removeProfileAgentsFn
+	removedNames := []string{}
+	removeProfileAgentsFn = func(settingsPath, profileName string) error {
+		removedNames = append(removedNames, profileName)
+		return nil
+	}
+	t.Cleanup(func() { removeProfileAgentsFn = originalRemove })
+
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.UninstallMode = model.UninstallModePartial
+	m.UninstallAgents = []model.AgentID{model.AgentOpenCode}
+	m.UninstallComponents = []model.ComponentID{model.ComponentSDD, model.ComponentEngram}
+	m.UninstallProfilesToRemove = []string{"cheap", "fast"}
+	m.UninstallEngramScope = ""
+
+	withProfilesCalled := false
+	m.UninstallWithProfilesFn = func(agentIDs []model.AgentID, componentIDs []model.ComponentID, profileNames []string, engramScope model.EngramUninstallScope) (componentuninstall.Result, error) {
+		withProfilesCalled = true
+		return componentuninstall.Result{}, nil
+	}
+	uninstallFnCalled := false
+	m.UninstallFn = func(agentIDs []model.AgentID, componentIDs []model.ComponentID) (componentuninstall.Result, error) {
+		uninstallFnCalled = true
+		return componentuninstall.Result{}, nil
+	}
+
+	msg := m.startUninstall()().(UninstallDoneMsg)
+	if msg.Err != nil {
+		t.Fatalf("UninstallDoneMsg.Err = %v, want nil", msg.Err)
+	}
+	if withProfilesCalled {
+		t.Fatal("UninstallWithProfilesFn must NOT be called when UninstallEngramScope is empty (None)")
+	}
+	if !uninstallFnCalled {
+		t.Fatal("UninstallFn should be called for agents/components when scope is None")
+	}
+	if !reflect.DeepEqual(removedNames, []string{"cheap", "fast"}) {
+		t.Fatalf("removeProfileAgentsFn removed %v, want [cheap fast]", removedNames)
+	}
+	if len(msg.Result.ManualActions) != 0 {
+		t.Fatalf("ManualActions = %v, want empty (no profile removal errors)", msg.Result.ManualActions)
+	}
+}
+
+// TestStartUninstall_NoneScopeProfileRemovalFailureSurfacesAsManualAction
+// verifies that when removeProfileAgentsFn fails for a profile under the
+// None-scope path, the failure is surfaced via result.ManualActions instead
+// of failing the whole uninstall.
+func TestStartUninstall_NoneScopeProfileRemovalFailureSurfacesAsManualAction(t *testing.T) {
+	originalRemove := removeProfileAgentsFn
+	removeProfileAgentsFn = func(settingsPath, profileName string) error {
+		return errors.New("disk full")
+	}
+	t.Cleanup(func() { removeProfileAgentsFn = originalRemove })
+
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.UninstallMode = model.UninstallModePartial
+	m.UninstallAgents = []model.AgentID{model.AgentOpenCode}
+	m.UninstallComponents = []model.ComponentID{model.ComponentSDD, model.ComponentEngram}
+	m.UninstallProfilesToRemove = []string{"cheap"}
+	m.UninstallEngramScope = ""
+	m.UninstallWithProfilesFn = func(agentIDs []model.AgentID, componentIDs []model.ComponentID, profileNames []string, engramScope model.EngramUninstallScope) (componentuninstall.Result, error) {
+		t.Fatal("UninstallWithProfilesFn must NOT be called when scope is None")
+		return componentuninstall.Result{}, nil
+	}
+	m.UninstallFn = func(agentIDs []model.AgentID, componentIDs []model.ComponentID) (componentuninstall.Result, error) {
+		return componentuninstall.Result{}, nil
+	}
+
+	msg := m.startUninstall()().(UninstallDoneMsg)
+	if msg.Err != nil {
+		t.Fatalf("UninstallDoneMsg.Err = %v, want nil (profile removal failures must not fail the uninstall)", msg.Err)
+	}
+	if len(msg.Result.ManualActions) == 0 {
+		t.Fatal("ManualActions should describe the profile removal failure")
+	}
+}
+
+// TestToggleUninstallEninstallEngramScope_CyclesNoneProjectGlobal verifies
+// that toggleCurrentUninstallEngramScope advances UninstallEngramScope
+// through the three-state cycle None -> Project -> Global -> None.
+func TestToggleUninstallEngramScope_CyclesNoneProjectGlobal(t *testing.T) {
+	tempWorkspace := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(tempWorkspace, ".engram"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(.engram) error = %v", err)
+	}
+	restoreGetwd := setOSGetwdForTest(tempWorkspace, nil)
+	defer restoreGetwd()
+
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Screen = ScreenUninstallProfiles
+	m.UninstallMode = model.UninstallModePartial
+	m.UninstallAgents = []model.AgentID{model.AgentOpenCode}
+	m.UninstallComponents = []model.ComponentID{model.ComponentEngram}
+	m.UninstallProfilesAvailable = []string{"cheap", "fast"}
+	m.UninstallProfilesToRemove = nil
+	m.UninstallEngramScope = ""
+	// Refresh so UninstallEngramProjectScopeAvailable reflects the .engram/ dir
+	// in the mocked cwd; the toggle guards on this flag.
+	m.refreshUninstallProfiles()
+	if !m.shouldShowUninstallEngramScopeSelection() {
+		t.Fatalf("setup: scope selection should be available after refresh, got ProjectScopeAvailable=%v", m.UninstallEngramProjectScopeAvailable)
+	}
+	m.Cursor = len(m.UninstallProfilesAvailable) // cursor on first scope row (None)
+
+	cases := []struct {
+		name string
+		want model.EngramUninstallScope
+	}{
+		{"None -> Project", model.EngramUninstallScopeProject},
+		{"Project -> Global", model.EngramUninstallScopeGlobal},
+		{"Global -> None", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m.toggleCurrentUninstallEngramScope()
+			if m.UninstallEngramScope != tc.want {
+				t.Fatalf("UninstallEngramScope = %q, want %q", m.UninstallEngramScope, tc.want)
+			}
+		})
+	}
+}
+
 func TestUninstallComponents_ContinueWithEngramProjectScopeNavigatesToSubSelection(t *testing.T) {
 	tempWorkspace := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(tempWorkspace, ".engram"), 0o755); err != nil {
@@ -2237,8 +2366,8 @@ func TestUninstallComponents_ContinueWithEngramProjectScopeNavigatesToSubSelecti
 	if !state.UninstallEngramProjectScopeAvailable {
 		t.Fatal("UninstallEngramProjectScopeAvailable = false, want true")
 	}
-	if state.UninstallEngramScope != model.EngramUninstallScopeGlobal {
-		t.Fatalf("UninstallEngramScope = %q, want %q", state.UninstallEngramScope, model.EngramUninstallScopeGlobal)
+	if state.UninstallEngramScope != "" {
+		t.Fatalf("UninstallEngramScope = %q, want %q (None default)", state.UninstallEngramScope, "")
 	}
 }
 

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1979,7 +1979,12 @@ func TestUninstallProfiles_ContinueNavigatesToConfirm(t *testing.T) {
 	m.Screen = ScreenUninstallProfiles
 	m.UninstallProfilesAvailable = []string{"cheap"}
 	m.UninstallProfilesToRemove = []string{"cheap"}
-	m.Cursor = len(m.UninstallProfilesAvailable)
+	// NewModel initializes UninstallComponents to the full default set (which
+	// includes ComponentEngram) and leaves UninstallEngramProjectScopeAvailable
+	// false. With the scope section now rendered whenever ComponentEngram is
+	// selected, the layout is: 1 profile row + 2 scope rows (None/Global) +
+	// Continue. Cursor 3 lands on Continue.
+	m.Cursor = len(m.UninstallProfilesAvailable) + 2
 
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	state := updated.(Model)
@@ -2217,7 +2222,9 @@ func TestStartUninstall_UsesProfileAwareUninstallWhenConfigured(t *testing.T) {
 // that when the user opts out of Engram cleanup (empty UninstallEngramScope),
 // startUninstall routes through uninstallFn for agents/components without
 // invoking the Engram step, and removes profiles via removeProfileAgentsFn
-// for each requested profile name.
+// for each requested profile name. The componentIDs handed to UninstallFn
+// must NOT contain ComponentEngram — leaving it in would trigger a global
+// Engram cleanup via the service layer and wipe the user's opt-out.
 func TestStartUninstall_NoneScopeSkipsEngramAndRemovesProfilesSeparately(t *testing.T) {
 	originalRemove := removeProfileAgentsFn
 	removedNames := []string{}
@@ -2230,7 +2237,7 @@ func TestStartUninstall_NoneScopeSkipsEngramAndRemovesProfilesSeparately(t *test
 	m := NewModel(system.DetectionResult{}, "dev")
 	m.UninstallMode = model.UninstallModePartial
 	m.UninstallAgents = []model.AgentID{model.AgentOpenCode}
-	m.UninstallComponents = []model.ComponentID{model.ComponentSDD, model.ComponentEngram}
+	m.UninstallComponents = []model.ComponentID{model.ComponentSDD, model.ComponentEngram, model.ComponentPersona}
 	m.UninstallProfilesToRemove = []string{"cheap", "fast"}
 	m.UninstallEngramScope = ""
 
@@ -2240,8 +2247,10 @@ func TestStartUninstall_NoneScopeSkipsEngramAndRemovesProfilesSeparately(t *test
 		return componentuninstall.Result{}, nil
 	}
 	uninstallFnCalled := false
+	var uninstallFnComponents []model.ComponentID
 	m.UninstallFn = func(agentIDs []model.AgentID, componentIDs []model.ComponentID) (componentuninstall.Result, error) {
 		uninstallFnCalled = true
+		uninstallFnComponents = append([]model.ComponentID(nil), componentIDs...)
 		return componentuninstall.Result{}, nil
 	}
 
@@ -2254,6 +2263,13 @@ func TestStartUninstall_NoneScopeSkipsEngramAndRemovesProfilesSeparately(t *test
 	}
 	if !uninstallFnCalled {
 		t.Fatal("UninstallFn should be called for agents/components when scope is None")
+	}
+	if hasSelectedComponent(uninstallFnComponents, model.ComponentEngram) {
+		t.Fatalf("UninstallFn received components %v; ComponentEngram must be filtered out when scope is None", uninstallFnComponents)
+	}
+	wantComponents := []model.ComponentID{model.ComponentSDD, model.ComponentPersona}
+	if !reflect.DeepEqual(uninstallFnComponents, wantComponents) {
+		t.Fatalf("UninstallFn components = %v, want %v (Engram filtered, others preserved)", uninstallFnComponents, wantComponents)
 	}
 	if !reflect.DeepEqual(removedNames, []string{"cheap", "fast"}) {
 		t.Fatalf("removeProfileAgentsFn removed %v, want [cheap fast]", removedNames)

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1830,7 +1830,7 @@ func TestUninstallModeScreen_PartialNavigatesToAgentSelection(t *testing.T) {
 	}
 }
 
-func TestUninstallModeScreen_FullNavigatesToConfirm(t *testing.T) {
+func TestUninstallModeScreen_FullRequiresEngramScopeDecision(t *testing.T) {
 	m := NewModel(system.DetectionResult{}, "dev")
 	m.Screen = ScreenUninstallMode
 	m.Cursor = 1 // Full Uninstall option
@@ -1838,8 +1838,8 @@ func TestUninstallModeScreen_FullNavigatesToConfirm(t *testing.T) {
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	state := updated.(Model)
 
-	if state.Screen != ScreenUninstallConfirm {
-		t.Fatalf("screen = %v, want %v", state.Screen, ScreenUninstallConfirm)
+	if state.Screen != ScreenUninstallProfiles {
+		t.Fatalf("screen = %v, want %v", state.Screen, ScreenUninstallProfiles)
 	}
 	if state.UninstallMode != model.UninstallModeFull {
 		t.Fatalf("UninstallMode = %v, want %v", state.UninstallMode, model.UninstallModeFull)
@@ -1851,9 +1851,10 @@ func TestUninstallModeScreen_FullNavigatesToConfirm(t *testing.T) {
 	if len(state.UninstallComponents) == 0 {
 		t.Fatal("UninstallComponents should be populated for Full mode")
 	}
+	assertFullModeEngramScopeFlow(t, state)
 }
 
-func TestUninstallModeScreen_FullRemoveNavigatesToConfirm(t *testing.T) {
+func TestUninstallModeScreen_FullRemoveRequiresEngramScopeDecision(t *testing.T) {
 	m := NewModel(system.DetectionResult{}, "dev")
 	m.Screen = ScreenUninstallMode
 	m.Cursor = 2 // Full Uninstall & Remove Binary option
@@ -1861,8 +1862,8 @@ func TestUninstallModeScreen_FullRemoveNavigatesToConfirm(t *testing.T) {
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	state := updated.(Model)
 
-	if state.Screen != ScreenUninstallConfirm {
-		t.Fatalf("screen = %v, want %v", state.Screen, ScreenUninstallConfirm)
+	if state.Screen != ScreenUninstallProfiles {
+		t.Fatalf("screen = %v, want %v", state.Screen, ScreenUninstallProfiles)
 	}
 	if state.UninstallMode != model.UninstallModeFullRemove {
 		t.Fatalf("UninstallMode = %v, want %v", state.UninstallMode, model.UninstallModeFullRemove)
@@ -1873,9 +1874,10 @@ func TestUninstallModeScreen_FullRemoveNavigatesToConfirm(t *testing.T) {
 	if len(state.UninstallComponents) == 0 {
 		t.Fatal("UninstallComponents should be populated for FullRemove mode")
 	}
+	assertFullModeEngramScopeFlow(t, state)
 }
 
-func TestUninstallModeScreen_CleanInstallNavigatesToConfirm(t *testing.T) {
+func TestUninstallModeScreen_CleanInstallRequiresEngramScopeDecision(t *testing.T) {
 	m := NewModel(system.DetectionResult{}, "dev")
 	m.Screen = ScreenUninstallMode
 	m.Cursor = 3 // Full Uninstall + Clean Install option
@@ -1883,8 +1885,8 @@ func TestUninstallModeScreen_CleanInstallNavigatesToConfirm(t *testing.T) {
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	state := updated.(Model)
 
-	if state.Screen != ScreenUninstallConfirm {
-		t.Fatalf("screen = %v, want %v", state.Screen, ScreenUninstallConfirm)
+	if state.Screen != ScreenUninstallProfiles {
+		t.Fatalf("screen = %v, want %v", state.Screen, ScreenUninstallProfiles)
 	}
 	if state.UninstallMode != model.UninstallModeCleanInstall {
 		t.Fatalf("UninstallMode = %v, want %v", state.UninstallMode, model.UninstallModeCleanInstall)
@@ -1894,6 +1896,52 @@ func TestUninstallModeScreen_CleanInstallNavigatesToConfirm(t *testing.T) {
 	}
 	if len(state.UninstallComponents) == 0 {
 		t.Fatal("UninstallComponents should be populated for CleanInstall mode")
+	}
+	assertFullModeEngramScopeFlow(t, state)
+}
+
+func assertFullModeEngramScopeFlow(t *testing.T, state Model) {
+	t.Helper()
+	if len(state.UninstallProfilesAvailable) != 0 || state.UninstallEngramScope != "" {
+		t.Fatalf("initial profiles/scope = (%v, %q), want (none, None)", state.UninstallProfilesAvailable, state.UninstallEngramScope)
+	}
+	state.Cursor = 0
+	updated, _ := state.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	state = updated.(Model)
+	if state.UninstallEngramProjectScopeAvailable {
+		updated, _ = state.Update(tea.KeyMsg{Type: tea.KeyEnter})
+		state = updated.(Model)
+	}
+	if state.UninstallEngramScope != model.EngramUninstallScopeGlobal {
+		t.Fatalf("scope = %q, want %q", state.UninstallEngramScope, model.EngramUninstallScopeGlobal)
+	}
+	state.Cursor = 2
+	if state.UninstallEngramProjectScopeAvailable {
+		state.Cursor++
+	}
+	updated, _ = state.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	state = updated.(Model)
+	if state.Screen != ScreenUninstallConfirm {
+		t.Fatalf("screen = %v, want %v", state.Screen, ScreenUninstallConfirm)
+	}
+
+	var dispatchedScope model.EngramUninstallScope
+	state.UninstallWithProfilesFn = func(_ []model.AgentID, _ []model.ComponentID, _ []string, scope model.EngramUninstallScope) (componentuninstall.Result, error) {
+		dispatchedScope = scope
+		return componentuninstall.Result{}, nil
+	}
+	state.UninstallFn = func([]model.AgentID, []model.ComponentID) (componentuninstall.Result, error) {
+		t.Fatal("UninstallFn should not handle explicit Global scope")
+		return componentuninstall.Result{}, nil
+	}
+	state.SyncFn = func(*model.SyncOverrides) ([]string, error) { return nil, nil }
+	restoreExecutable := setOSExecutableForTest("gentle-ai", nil)
+	restoreRemove := setOSRemoveForTest(func(string) error { return nil })
+	defer restoreExecutable()
+	defer restoreRemove()
+	msg := state.startUninstall()().(UninstallDoneMsg)
+	if msg.Err != nil || msg.SyncErr != nil || dispatchedScope != model.EngramUninstallScopeGlobal {
+		t.Fatalf("dispatch = (scope %q, err %v, sync err %v), want (Global, nil, nil)", dispatchedScope, msg.Err, msg.SyncErr)
 	}
 }
 
@@ -1979,11 +2027,7 @@ func TestUninstallProfiles_ContinueNavigatesToConfirm(t *testing.T) {
 	m.Screen = ScreenUninstallProfiles
 	m.UninstallProfilesAvailable = []string{"cheap"}
 	m.UninstallProfilesToRemove = []string{"cheap"}
-	// NewModel initializes UninstallComponents to the full default set (which
-	// includes ComponentEngram) and leaves UninstallEngramProjectScopeAvailable
-	// false. With the scope section now rendered whenever ComponentEngram is
-	// selected, the layout is: 1 profile row + 2 scope rows (None/Global) +
-	// Continue. Cursor 3 lands on Continue.
+	// One profile, None/Global scope rows, then Continue.
 	m.Cursor = len(m.UninstallProfilesAvailable) + 2
 
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
@@ -2218,13 +2262,8 @@ func TestStartUninstall_UsesProfileAwareUninstallWhenConfigured(t *testing.T) {
 	}
 }
 
-// TestStartUninstall_NoneScopeSkipsEngramAndRemovesProfilesSeparately verifies
-// that when the user opts out of Engram cleanup (empty UninstallEngramScope),
-// startUninstall routes through uninstallFn for agents/components without
-// invoking the Engram step, and removes profiles via removeProfileAgentsFn
-// for each requested profile name. The componentIDs handed to UninstallFn
-// must NOT contain ComponentEngram — leaving it in would trigger a global
-// Engram cleanup via the service layer and wipe the user's opt-out.
+// None scope removes profiles separately and never dispatches Engram to the
+// uninstall service.
 func TestStartUninstall_NoneScopeSkipsEngramAndRemovesProfilesSeparately(t *testing.T) {
 	originalRemove := removeProfileAgentsFn
 	removedNames := []string{}
@@ -2279,10 +2318,7 @@ func TestStartUninstall_NoneScopeSkipsEngramAndRemovesProfilesSeparately(t *test
 	}
 }
 
-// TestStartUninstall_NoneScopeProfileRemovalFailureSurfacesAsManualAction
-// verifies that when removeProfileAgentsFn fails for a profile under the
-// None-scope path, the failure is surfaced via result.ManualActions instead
-// of failing the whole uninstall.
+// Profile removal failures under None scope become manual actions.
 func TestStartUninstall_NoneScopeProfileRemovalFailureSurfacesAsManualAction(t *testing.T) {
 	originalRemove := removeProfileAgentsFn
 	removeProfileAgentsFn = func(settingsPath, profileName string) error {
@@ -2313,10 +2349,8 @@ func TestStartUninstall_NoneScopeProfileRemovalFailureSurfacesAsManualAction(t *
 	}
 }
 
-// TestStartUninstall_NoneScopeEngramOnlySkipsUninstallFn (C1 regression):
-// with only ComponentEngram selected and scope=None, the filtered slice
-// is empty. Service treats [] as "all components"; startUninstall must
-// skip UninstallFn entirely while still removing requested profiles.
+// Engram-only None scope must not dispatch an empty component slice, which
+// the service interprets as all components.
 func TestStartUninstall_NoneScopeEngramOnlySkipsUninstallFn(t *testing.T) {
 	originalRemove := removeProfileAgentsFn
 	removedNames := []string{}
@@ -2346,9 +2380,7 @@ func TestStartUninstall_NoneScopeEngramOnlySkipsUninstallFn(t *testing.T) {
 	}
 }
 
-// TestToggleUninstallEninstallEngramScope_CyclesNoneProjectGlobal verifies
-// that toggleCurrentUninstallEngramScope advances UninstallEngramScope
-// through the three-state cycle None -> Project -> Global -> None.
+// Scope cycles None -> Project -> Global -> None.
 func TestToggleUninstallEngramScope_CyclesNoneProjectGlobal(t *testing.T) {
 	tempWorkspace := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(tempWorkspace, ".engram"), 0o755); err != nil {
@@ -2365,8 +2397,6 @@ func TestToggleUninstallEngramScope_CyclesNoneProjectGlobal(t *testing.T) {
 	m.UninstallProfilesAvailable = []string{"cheap", "fast"}
 	m.UninstallProfilesToRemove = nil
 	m.UninstallEngramScope = ""
-	// Refresh so UninstallEngramProjectScopeAvailable reflects the .engram/ dir
-	// in the mocked cwd; the toggle guards on this flag.
 	m.refreshUninstallProfiles()
 	if !m.shouldShowUninstallEngramScopeSelection() {
 		t.Fatalf("setup: scope selection should be available after refresh, got ProjectScopeAvailable=%v", m.UninstallEngramProjectScopeAvailable)
@@ -2420,11 +2450,7 @@ func TestUninstallComponents_ContinueWithEngramProjectScopeNavigatesToSubSelecti
 	}
 }
 
-// TestUninstallComponents_ContinueWithEngramNoProjectScopeStillReachable
-// (C2 regression): ComponentEngram selected, no .engram/ directory —
-// user must STILL reach the profile/scope screen to choose None/Global.
-// Old gate via shouldShowUninstallEngramScopeSelection hid the screen
-// exactly when the user most needs to opt in or out.
+// Without project scope, Partial mode still offers None and Global.
 func TestUninstallComponents_ContinueWithEngramNoProjectScopeStillReachable(t *testing.T) {
 	tempWorkspace := t.TempDir() // no .engram/ directory
 	restoreGetwd := setOSGetwdForTest(tempWorkspace, nil)

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -2313,6 +2313,39 @@ func TestStartUninstall_NoneScopeProfileRemovalFailureSurfacesAsManualAction(t *
 	}
 }
 
+// TestStartUninstall_NoneScopeEngramOnlySkipsUninstallFn (C1 regression):
+// with only ComponentEngram selected and scope=None, the filtered slice
+// is empty. Service treats [] as "all components"; startUninstall must
+// skip UninstallFn entirely while still removing requested profiles.
+func TestStartUninstall_NoneScopeEngramOnlySkipsUninstallFn(t *testing.T) {
+	originalRemove := removeProfileAgentsFn
+	removedNames := []string{}
+	removeProfileAgentsFn = func(settingsPath, profileName string) error {
+		removedNames = append(removedNames, profileName)
+		return nil
+	}
+	t.Cleanup(func() { removeProfileAgentsFn = originalRemove })
+
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.UninstallMode = model.UninstallModePartial
+	m.UninstallAgents = []model.AgentID{model.AgentOpenCode}
+	m.UninstallComponents = []model.ComponentID{model.ComponentEngram}
+	m.UninstallProfilesToRemove = []string{"cheap"}
+	m.UninstallEngramScope = ""
+	m.UninstallFn = func(agentIDs []model.AgentID, componentIDs []model.ComponentID) (componentuninstall.Result, error) {
+		t.Fatalf("UninstallFn must NOT be called when Engram-only selection + scope=None (would expand to all components via service). Got agentIDs=%v componentIDs=%v", agentIDs, componentIDs)
+		return componentuninstall.Result{}, nil
+	}
+
+	msg := m.startUninstall()().(UninstallDoneMsg)
+	if msg.Err != nil {
+		t.Fatalf("UninstallDoneMsg.Err = %v, want nil (no managed-component uninstall was performed)", msg.Err)
+	}
+	if !reflect.DeepEqual(removedNames, []string{"cheap"}) {
+		t.Fatalf("removeProfileAgentsFn removed %v, want [cheap] (profile removal must still run when Engram is the only selected component)", removedNames)
+	}
+}
+
 // TestToggleUninstallEninstallEngramScope_CyclesNoneProjectGlobal verifies
 // that toggleCurrentUninstallEngramScope advances UninstallEngramScope
 // through the three-state cycle None -> Project -> Global -> None.
@@ -2381,6 +2414,37 @@ func TestUninstallComponents_ContinueWithEngramProjectScopeNavigatesToSubSelecti
 	}
 	if !state.UninstallEngramProjectScopeAvailable {
 		t.Fatal("UninstallEngramProjectScopeAvailable = false, want true")
+	}
+	if state.UninstallEngramScope != "" {
+		t.Fatalf("UninstallEngramScope = %q, want %q (None default)", state.UninstallEngramScope, "")
+	}
+}
+
+// TestUninstallComponents_ContinueWithEngramNoProjectScopeStillReachable
+// (C2 regression): ComponentEngram selected, no .engram/ directory —
+// user must STILL reach the profile/scope screen to choose None/Global.
+// Old gate via shouldShowUninstallEngramScopeSelection hid the screen
+// exactly when the user most needs to opt in or out.
+func TestUninstallComponents_ContinueWithEngramNoProjectScopeStillReachable(t *testing.T) {
+	tempWorkspace := t.TempDir() // no .engram/ directory
+	restoreGetwd := setOSGetwdForTest(tempWorkspace, nil)
+	defer restoreGetwd()
+
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Screen = ScreenUninstallComponents
+	m.UninstallMode = model.UninstallModePartial
+	m.UninstallAgents = []model.AgentID{model.AgentOpenCode}
+	m.UninstallComponents = []model.ComponentID{model.ComponentEngram}
+	m.Cursor = len(screens.UninstallComponentOptions())
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	state := updated.(Model)
+
+	if state.Screen != ScreenUninstallProfiles {
+		t.Fatalf("screen = %v, want %v (profile/scope screen must be reachable even without project scope)", state.Screen, ScreenUninstallProfiles)
+	}
+	if state.UninstallEngramProjectScopeAvailable {
+		t.Fatal("UninstallEngramProjectScopeAvailable = true, want false")
 	}
 	if state.UninstallEngramScope != "" {
 		t.Fatalf("UninstallEngramScope = %q, want %q (None default)", state.UninstallEngramScope, "")

--- a/internal/tui/screens/uninstall.go
+++ b/internal/tui/screens/uninstall.go
@@ -171,14 +171,8 @@ func RenderUninstallComponents(selected []model.ComponentID, cursor int) string 
 	return b.String()
 }
 
-// uninstallEngramScopeOptions returns the cleanup options offered to the user
-// during uninstall. The "None" option (empty scope) is always prepended so
-// the user can explicitly skip Engram cleanup even when both Project and
-// Global cleanup are available; the Project option only appears when the
-// current workspace has a .engram/ directory to remove.
-//
-// Note: the caller decides whether to display these options at all by
-// gating on ComponentEngram selection in UninstallComponents.
+// uninstallEngramScopeOptions always offers None and Global, plus Project
+// when the workspace has project-scoped Engram data.
 func uninstallEngramScopeOptions(projectScopeAvailable bool) []UninstallEngramScopeOption {
 	options := make([]UninstallEngramScopeOption, 0, 3)
 	options = append(options, UninstallEngramScopeOption{
@@ -201,12 +195,8 @@ func uninstallEngramScopeOptions(projectScopeAvailable bool) []UninstallEngramSc
 	return options
 }
 
-// RenderUninstallProfiles renders the ScreenUninstallProfiles view: a list of
-// removable OpenCode SDD profiles followed (when applicable) by the Engram
-// cleanup scope picker. The scope section is displayed whenever the user has
-// selected ComponentEngram in UninstallComponents; the Project option is only
-// listed when the workspace exposes a project-scoped Engram directory
-// (engramProjectScopeAvailable), while None and Global are always available.
+// RenderUninstallProfiles renders profile removal and the selected Engram
+// cleanup scope when ComponentEngram is selected.
 func RenderUninstallProfiles(available []string, selected []string, engramProjectScopeAvailable bool, uninstallComponents []model.ComponentID, selectedEngramScope model.EngramUninstallScope, cursor int) string {
 	var b strings.Builder
 

--- a/internal/tui/screens/uninstall.go
+++ b/internal/tui/screens/uninstall.go
@@ -171,8 +171,21 @@ func RenderUninstallComponents(selected []model.ComponentID, cursor int) string 
 	return b.String()
 }
 
+// uninstallEngramScopeOptions returns the cleanup options offered to the user
+// during uninstall. The "None" option (empty scope) is always prepended so
+// the user can explicitly skip Engram cleanup even when both Project and
+// Global cleanup are available; the Project option only appears when the
+// current workspace has a .engram/ directory to remove.
+//
+// Note: the caller decides whether to display these options at all by
+// gating on ComponentEngram selection in UninstallComponents.
 func uninstallEngramScopeOptions(projectScopeAvailable bool) []UninstallEngramScopeOption {
-	options := make([]UninstallEngramScopeOption, 0, 2)
+	options := make([]UninstallEngramScopeOption, 0, 3)
+	options = append(options, UninstallEngramScopeOption{
+		Scope:       "",
+		Label:       "No Engram cleanup",
+		Description: "Skip Engram cleanup; remove profiles only",
+	})
 	if projectScopeAvailable {
 		options = append(options, UninstallEngramScopeOption{
 			Scope:       model.EngramUninstallScopeProject,
@@ -188,7 +201,13 @@ func uninstallEngramScopeOptions(projectScopeAvailable bool) []UninstallEngramSc
 	return options
 }
 
-func RenderUninstallProfiles(available []string, selected []string, engramProjectScopeAvailable bool, selectedEngramScope model.EngramUninstallScope, cursor int) string {
+// RenderUninstallProfiles renders the ScreenUninstallProfiles view: a list of
+// removable OpenCode SDD profiles followed (when applicable) by the Engram
+// cleanup scope picker. The scope section is only displayed when the user has
+// selected ComponentEngram in UninstallComponents AND the workspace exposes a
+// project-scoped Engram directory; this avoids presenting a meaningless choice
+// when Engram cleanup is not in play.
+func RenderUninstallProfiles(available []string, selected []string, engramProjectScopeAvailable bool, uninstallComponents []model.ComponentID, selectedEngramScope model.EngramUninstallScope, cursor int) string {
 	var b strings.Builder
 
 	b.WriteString(styles.TitleStyle.Render("Uninstall Scope Selection"))
@@ -213,8 +232,9 @@ func RenderUninstallProfiles(available []string, selected []string, engramProjec
 	}
 
 	engramScopeOptions := uninstallEngramScopeOptions(engramProjectScopeAvailable)
+	showEngramScopeSection := hasSelectedComponent(uninstallComponents, model.ComponentEngram) && engramProjectScopeAvailable
 	engramScopeDisplayed := 0
-	if len(engramScopeOptions) > 1 {
+	if showEngramScopeSection {
 		engramScopeDisplayed = len(engramScopeOptions)
 		if len(available) > 0 {
 			b.WriteString("\n")
@@ -223,7 +243,7 @@ func RenderUninstallProfiles(available []string, selected []string, engramProjec
 		b.WriteString("\n")
 		for idx, option := range engramScopeOptions {
 			focused := len(available)+idx == cursor
-			checked := selectedEngramScope == option.Scope
+			checked := string(selectedEngramScope) == string(option.Scope)
 			b.WriteString(renderCheckbox(option.Label, checked, focused))
 			b.WriteString(styles.SubtextStyle.Render("    " + option.Description))
 			b.WriteString("\n")

--- a/internal/tui/screens/uninstall.go
+++ b/internal/tui/screens/uninstall.go
@@ -203,10 +203,10 @@ func uninstallEngramScopeOptions(projectScopeAvailable bool) []UninstallEngramSc
 
 // RenderUninstallProfiles renders the ScreenUninstallProfiles view: a list of
 // removable OpenCode SDD profiles followed (when applicable) by the Engram
-// cleanup scope picker. The scope section is only displayed when the user has
-// selected ComponentEngram in UninstallComponents AND the workspace exposes a
-// project-scoped Engram directory; this avoids presenting a meaningless choice
-// when Engram cleanup is not in play.
+// cleanup scope picker. The scope section is displayed whenever the user has
+// selected ComponentEngram in UninstallComponents; the Project option is only
+// listed when the workspace exposes a project-scoped Engram directory
+// (engramProjectScopeAvailable), while None and Global are always available.
 func RenderUninstallProfiles(available []string, selected []string, engramProjectScopeAvailable bool, uninstallComponents []model.ComponentID, selectedEngramScope model.EngramUninstallScope, cursor int) string {
 	var b strings.Builder
 
@@ -232,7 +232,7 @@ func RenderUninstallProfiles(available []string, selected []string, engramProjec
 	}
 
 	engramScopeOptions := uninstallEngramScopeOptions(engramProjectScopeAvailable)
-	showEngramScopeSection := hasSelectedComponent(uninstallComponents, model.ComponentEngram) && engramProjectScopeAvailable
+	showEngramScopeSection := hasSelectedComponent(uninstallComponents, model.ComponentEngram)
 	engramScopeDisplayed := 0
 	if showEngramScopeSection {
 		engramScopeDisplayed = len(engramScopeOptions)


### PR DESCRIPTION
## Linked Issue

Closes #445

## PR Type

- [x] `type:bug` - chosen PR type; the GitHub label is pending maintainer action
- [ ] `type:feature`
- [ ] `type:docs`
- [ ] `type:refactor`
- [ ] `type:chore`
- [ ] `type:breaking-change`

## Summary

This PR decouples profile removal from optional Engram cleanup by making `None` an explicit Engram scope, so removing profiles no longer implies deleting Engram data; review caught two data-loss corner cases (Engram-only selection with an empty filtered component list, and Engram selection without project scope), and the local PR-A hardening closes both while keeping the single PR at 383 changed lines within the 400-line review budget.

## Changes

Counts are from `git diff --numstat 0b069c7d..HEAD` at local PR-A tip `5ba1acee`.

| File / Area | Additions | Deletions | What Changed |
|---|---:|---:|---|
| `internal/model/types.go` | 12 | 1 | Documents the `EngramUninstallScope` zero value and the TUI safety boundary for `None`. |
| `internal/tui/model.go` | 101 | 26 | Defaults fresh uninstall state to `None`, filters Engram from skipped cleanup, avoids calling uninstall with an empty component slice, and hardens routing, scope cycling, and option counts. |
| `internal/tui/model_test.go` | 212 | 3 | Updates uninstall-flow coverage and includes the two C1/C2 regression tests `TestStartUninstall_NoneScopeEngramOnlySkipsUninstallFn` and `TestUninstallComponents_ContinueWithEngramNoProjectScopeStillReachable`. |
| `internal/tui/screens/uninstall.go` | 24 | 4 | Adds the explicit no-cleanup option and renders reachable scope choices according to selected components and project-scope availability. |

Total: 349 additions + 34 deletions = 383 changed lines across 4 files.

## Test Plan

All commands below were run locally on Windows in Standard Mode using direct `m.Update()` paths; no `teatest` was used.

| Command actually run | Result | PASS / SKIP count |
|---|---|---|
| `go test -count=1 ./internal/tui/screens/... ./internal/model/... ./internal/components/uninstall/...` | PASS | 3 packages PASS / 0 SKIP |
| `go test -count=1 -run 'TestStartUninstall_NoneScope|TestToggleUninstallEngramScope|TestUninstallProfiles_ContinueNavigatesToConfirm|TestUninstallComponents_ContinueWithEngram|TestUninstallComponents_ContinueWithEngramNoProjectScopeStillReachable|TestStartUninstall_NoneScopeEngramOnlySkipsUninstallFn' -v ./internal/tui/` | PASS | 10 PASS events (7 top-level tests + 3 subtests) / 0 SKIP |
| `go test -count=1 ./internal/tui/...` | BASELINED FAILURE | 1 package PASS / 0 SKIP; `internal/tui` has the 3 pre-existing failures listed below; `styles` has no test files |
| `go -C "<disposable-clean-checkout-of-0b069c7d>" test -count=1 ./internal/tui/...` | BASELINE REPRODUCED | 1 package PASS / 0 SKIP; the same 3 failures reproduced |

A first disposable-checkout invocation ran `go test -count=1 ./internal/tui/...` from the temporary parent rather than the module root and stopped during package discovery (`directory prefix internal\tui does not contain main module or its selected dependencies`): 0 tests executed, 0 PASS, 0 SKIP. It was corrected with `go -C` in the next row. The clean-checkout baseline was disposable and left the existing stash and canonical worktree untouched.

Additional validation:

| Command actually run | Result |
|---|---|
| `go run ./internal/gofmtcheck` | PASS |
| `go build -o NUL ./cmd/gentle-ai` | PASS |
| `go vet ./...` | PASS |

The new C1/C2 tests live in `internal/tui/model_test.go` and both pass:

- `TestStartUninstall_NoneScopeEngramOnlySkipsUninstallFn`
- `TestUninstallComponents_ContinueWithEngramNoProjectScopeStillReachable`

> **Pre-existing test failures (not blocking this PR)**
>
> Verified by creating a disposable clean checkout at `0b069c7d` and re-running `go test -count=1 ./internal/tui/...`; the existing stash was not touched. The messages reproduced unchanged. Current local PR-A line numbers are:
>
> - `TestSDDModeMultiShowsModelPickerWhenCacheMissing` - `internal/tui/model_test.go:994`: `ModelPicker.AvailableIDs should be empty when cache missing, got: [anthropic google minimax-coding-plan openai opencode openrouter]`
> - `TestSDDModeMultiEmptyModelPickerCanContinueWithDefaults` - `internal/tui/model_test.go:1018`: `screen = 20, want ScreenStrictTDD after continuing with defaults`
> - `TestPickerFlowSlice/non-custom_all_agents_SDDMode_Multi_cache_absent_excludes_ModelPicker` - `internal/tui/model_test.go:6950`: `pickerFlowSlice() len = 8, want 7`; `got:  [5 6 7 8 9 20 10 16]`; `want: [5 6 7 8 9 10 16]`
>
> The clean base has the same messages; only the third location is earlier (`model_test.go:6741`) because PR-A adds tests. These failures concern SDD/model-picker routing and do not touch `ScreenUninstallProfiles`, `EngramUninstallScope`, `RenderUninstallProfiles`, `startUninstall`, `toggleCurrentUninstallEngramScope`, `shouldShowUninstallSubSelection`, or `refreshUninstallProfiles`.

## Automated Checks

These are the four checks defined by `.github/workflows/pr-check.yml`:

| Check | Status | Evidence |
|---|---|---|
| Check Issue Reference | PASS | This body uses `Closes #445`. |
| Check Issue Has `status:approved` | PASS | Issue #445 is open and has `status:approved` and `priority:high`. |
| Check PR Has `type:*` Label | FAILING - pending maintainer | GitHub currently reports no PR labels; the selected type is `type:bug`, but contributors cannot apply it. |
| Check PR Cognitive Load | PASS | Local PR-A is 383 / 400 changed lines; GitHub still shows the old 253-line head until an explicit push. |

## Contributor Checklist

- [x] PR is linked to issue #445, which has `status:approved`
- [x] Local PR-A stays within the 400-line review budget: 383 / 400 changed lines
- [ ] Appropriate `type:*` label added - pending maintainer; do not read the checked PR Type choice above as an API label claim
- [ ] `size:exception` added - not requested and not required
- [ ] Full unit suite passes - the three baselined pre-existing failures above remain
- [x] Required focused uninstall/model test commands pass, including the new C1/C2 tests
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass - not run in this Standard Mode session
- [x] Documentation impact was handled in the changed scope comments; no external documentation change is required
- [x] All six local PR-A commits follow Conventional Commits format
- [x] Local PR-A commits contain no `Co-Authored-By` trailers

## Notes for Reviewers

**Dependency diagram - single-PR chain (force-chained DORMANT)**

```text
main
  ^
  |
PR #1624 / PR-A: fix/tui-uninstall-engram-decouple
  GitHub head: b378de3d (old)
  local tip:   5ba1acee (not pushed, 383 / 400 lines)

optional local-only follow-up (not active in the chain):
  fix/tui-uninstall-engram-none-scope-edge-cases @ c2eb011d
  based on c47e7bbf; intentionally not rebased onto 5ba1acee; not pushed
```

PR-B exists only locally and carries the deferred cycle test `TestToggleUninstallEngramScope_NoneAdvancesToGlobalWhenNoProjectScope`. It is optional: if the reviewer wants that cycle test now, the maintainer can ask for PR-B to be rebased onto `5ba1acee` and pushed; otherwise it can be dropped without changing this PR's C1/C2 hardening.

`internal/components/uninstall/service.go` remains intentionally untouched. The TUI enforces `None` before service delegation, filters `ComponentEngram`, and skips the uninstall call when filtering leaves no components, preventing the service's empty-selection expansion from turning an opt-out into global cleanup.

## Pending maintainer actions

- [ ] Apply the `type:bug` label to this PR to satisfy `Check PR Has type:* Label`.
- [ ] Optional: confirm whether to fold or drop local stacked branch `fix/tui-uninstall-engram-none-scope-edge-cases` at `c2eb011d`.
- [ ] Optional: rebase and push PR-B only if the deferred cycle test is desired at the same time.
- [ ] Optional (not requested): no `size:exception` is required; PR-A is 383 / 400 lines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added **Project-only Engram cleanup** as a selectable uninstall scope.
  * Added an explicit **“No Engram cleanup”** option, selected by default.
  * Updated the uninstall UI to support **None / Project / Global** Engram cleanup, requiring an explicit scope decision for Engram-enabled installs.

* **Bug Fixes**
  * Prevented **“No Engram cleanup”** from being treated as **Global** cleanup.
  * Improved profile-removal error handling: failures now surface as **manual actions**.
  * Kept the uninstall confirmation flow reachable even when **project Engram data** is unavailable.

* **Tests**
  * Added/expanded regression tests for None-scope behavior, UI navigation, and profile-removal outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->