### PR TITLE
fix(theme): align settings theme value with installed theme identifier

### DIFF
--- a/e2e/e2e_test.sh
+++ b/e2e/e2e_test.sh
@@ -820,7 +820,7 @@ test_cc_theme_injection() {
         local settings="$HOME/.claude/settings.json"
         assert_file_exists "$settings" "Claude settings.json"
         assert_file_contains "$settings" '"theme"' "Has theme key"
-        assert_file_contains "$settings" 'gentleman-kanagawa' "Has gentleman-kanagawa theme"
+        assert_file_contains "$settings" 'gentleman' "Has gentleman theme"
         assert_valid_json "$settings" "settings.json is valid JSON"
     else
         log_fail "theme install command failed"
@@ -1031,7 +1031,7 @@ test_oc_theme_injection() {
         local settings="$HOME/.config/opencode/opencode.json"
         assert_file_exists "$settings" "OpenCode opencode.json"
         assert_file_contains "$settings" '"theme"' "Has theme key"
-        assert_file_contains "$settings" 'gentleman-kanagawa' "Has gentleman-kanagawa theme"
+        assert_file_contains "$settings" 'gentleman' "Has gentleman theme"
         assert_valid_json "$settings" "opencode.json is valid JSON"
     else
         log_fail "OpenCode theme install command failed"

--- a/internal/components/theme/inject.go
+++ b/internal/components/theme/inject.go
@@ -16,7 +16,7 @@ type InjectionResult struct {
 	Files   []string
 }
 
-var themeOverlayJSON = []byte("{\n  \"theme\": \"gentleman-kanagawa\"\n}\n")
+var themeOverlayJSON = []byte("{\n  \"theme\": \"gentleman\"\n}\n")
 
 type claudeTheme struct {
 	Name      string            `json:"name"`
@@ -25,7 +25,7 @@ type claudeTheme struct {
 }
 
 var gentlemanClaudeTheme = claudeTheme{
-	Name: "Gentleman",
+	Name: "gentleman",
 	Base: "dark",
 	Overrides: map[string]string{
 		"diffAdded":                 "#3F4A2D",

--- a/internal/components/theme/inject_test.go
+++ b/internal/components/theme/inject_test.go
@@ -55,8 +55,8 @@ func TestInjectMergesThemeOverlayIntoAdapterSettings(t *testing.T) {
 	if err := json.Unmarshal(data, &root); err != nil {
 		t.Fatalf("Unmarshal(settings) error = %v", err)
 	}
-	if root.Theme != "gentleman-kanagawa" {
-		t.Fatalf("theme = %q, want gentleman-kanagawa", root.Theme)
+	if root.Theme != "gentleman" {
+		t.Fatalf("theme = %q, want gentleman", root.Theme)
 	}
 	if got := root.Permissions["allow"]; len(got) != 1 || got[0] != "Bash(go test ./...)" {
 		t.Fatalf("permissions.allow = %#v, want preserved existing permission", got)
@@ -92,8 +92,8 @@ func TestInjectCreatesAdapterSettingsWhenMissing(t *testing.T) {
 	if err := json.Unmarshal(data, &root); err != nil {
 		t.Fatalf("Unmarshal(settings) error = %v", err)
 	}
-	if root.Theme != "gentleman-kanagawa" {
-		t.Fatalf("theme = %q, want gentleman-kanagawa", root.Theme)
+	if root.Theme != "gentleman" {
+		t.Fatalf("theme = %q, want gentleman", root.Theme)
 	}
 }
 
@@ -164,8 +164,8 @@ func TestInjectClaudeThemeWritesGentlemanThemeFile(t *testing.T) {
 		t.Fatalf("Unmarshal(theme) error = %v", err)
 	}
 
-	if root.Name != "Gentleman" || root.Base != "dark" {
-		t.Fatalf("theme identity = %q/%q, want Gentleman/dark", root.Name, root.Base)
+	if root.Name != "gentleman" || root.Base != "dark" {
+		t.Fatalf("theme identity = %q/%q, want gentleman/dark", root.Name, root.Base)
 	}
 	expected := map[string]string{
 		"diffAdded":                 "#3F4A2D",

--- a/internal/components/uninstall/cleaners_test.go
+++ b/internal/components/uninstall/cleaners_test.go
@@ -141,7 +141,7 @@ func TestRemoveMarkdownSections_RemovesSlimResidualPersonaViaMarkerNotFingerprin
 
 func TestRemoveJSONPaths_RemovesOnlyManagedKeys(t *testing.T) {
 	input := []byte(`{
-  "theme": "gentleman-kanagawa",
+  "theme": "gentleman",
   "permission": {
     "bash": {
       "*": "allow"

--- a/internal/components/uninstall/service_test.go
+++ b/internal/components/uninstall/service_test.go
@@ -231,7 +231,7 @@ func TestPartialUninstallVisualPolishSelectionRemovesThemeLogoGroup(t *testing.T
 	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
 		t.Fatalf("MkdirAll(opencode settings dir) error = %v", err)
 	}
-	if err := os.WriteFile(settingsPath, []byte(`{"theme":"gentleman-kanagawa","keep":true}`), 0o644); err != nil {
+	if err := os.WriteFile(settingsPath, []byte(`{"theme":"gentleman","keep":true}`), 0o644); err != nil {
 		t.Fatalf("WriteFile(opencode settings) error = %v", err)
 	}
 
@@ -247,7 +247,7 @@ func TestPartialUninstallVisualPolishSelectionRemovesThemeLogoGroup(t *testing.T
 	if err := os.MkdirAll(filepath.Dir(claudeThemePath), 0o755); err != nil {
 		t.Fatalf("MkdirAll(claude theme dir) error = %v", err)
 	}
-	if err := os.WriteFile(claudeThemePath, []byte(`{"name":"Gentleman"}`), 0o644); err != nil {
+	if err := os.WriteFile(claudeThemePath, []byte(`{"name":"gentleman"}`), 0o644); err != nil {
 		t.Fatalf("WriteFile(claude theme) error = %v", err)
 	}
 


### PR DESCRIPTION
Aligns the theme name value written to settings.json with the name ('gentleman') inside gentleman.json, ensuring Claude Code correctly recognizes and applies the theme.

Closes #896

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated theme configuration to consistently use the `gentleman` theme identifier (including Claude Code and OpenCode).
  * Improved theme overlay/injection behavior and ensured uninstall routines correctly recognize and remove the renamed theme settings.
* **Tests**
  * Updated end-to-end and theme/uninstall related tests to assert `gentleman` instead of the previous theme value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->