### PR TITLE
fix(cli): bridge Pi compact review authority into native SDD

### DIFF
--- a/internal/reviewtransaction/compact_store.go
+++ b/internal/reviewtransaction/compact_store.go
@@ -781,16 +781,20 @@ func BridgePiCompactAuthority(ctx context.Context, repo, lineage string) error {
 			return errors.New("conflicting existing native Go authority revision")
 		}
 		return nil
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("read existing Go compact state: %w", err)
 	}
 
 	if err := os.MkdirAll(goStoreDir, 0o755); err != nil {
 		return fmt.Errorf("create Go store directory: %w", err)
 	}
-	if err := os.WriteFile(filepath.Join(goStoreDir, compactStateFileName), goRecordBytes, 0o644); err != nil {
-		return fmt.Errorf("write Go compact state: %w", err)
-	}
+	// Write receipt before state so the state file acts as the completion marker:
+	// a reader that finds the state file can be sure the receipt is also present.
 	if err := os.WriteFile(filepath.Join(goStoreDir, compactReceiptFileName), goReceiptBytes, 0o644); err != nil {
 		return fmt.Errorf("write Go compact receipt: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(goStoreDir, compactStateFileName), goRecordBytes, 0o644); err != nil {
+		return fmt.Errorf("write Go compact state: %w", err)
 	}
 
 	return nil

--- a/internal/reviewtransaction/compact_store.go
+++ b/internal/reviewtransaction/compact_store.go
@@ -549,6 +549,253 @@ func CompactAuthoritativeStore(ctx context.Context, repo, lineageID string) (Com
 	return CompactStore{Dir: dir, lineageID: lineageID, repo: root, lockPath: filepath.Join(versionRoot, "LOCK"), maintenanceLockPath: compactMaintenanceLockPath(base)}, nil
 }
 
+type piSnapshot struct {
+	BaseTree          string   `json:"base_tree"`
+	InitialReviewTree string   `json:"initial_review_tree"`
+	IntendedUntracked []string `json:"intended_untracked"`
+	GenesisPaths      []string `json:"genesis_paths"`
+	ReviewProjection  struct {
+		Kind string `json:"kind"`
+	} `json:"review_projection"`
+}
+
+type piCompactState struct {
+	Schema               string            `json:"schema"`
+	LineageID            string            `json:"lineage_id"`
+	Generation           int               `json:"generation"`
+	State                string            `json:"state"`
+	InitialSnapshot      piSnapshot        `json:"initial_snapshot"`
+	CurrentCandidateTree string            `json:"current_candidate_tree"`
+	GenesisPaths         []string          `json:"genesis_paths"`
+	IntendedUntracked    []string          `json:"intended_untracked"`
+	PolicyHash           string            `json:"policy_hash"`
+	RiskTier             string            `json:"risk_tier"`
+	SelectedLenses       []string          `json:"selected_lenses"`
+	OriginalChangedLines int               `json:"original_changed_lines"`
+	CorrectionBudget     int               `json:"correction_budget"`
+	LensResults          []LensResult      `json:"lens_results"`
+	Findings             []Finding         `json:"findings"`
+	Outcomes             map[string]string `json:"outcomes"`
+	CorrectionIDs        []string          `json:"correction_ids"`
+	FollowUps            []FollowUp        `json:"follow_ups"`
+	FinalEvidenceHash    string            `json:"final_evidence_hash,omitempty"`
+}
+
+type piCompactStateRecord struct {
+	Schema   string         `json:"schema"`
+	Revision string         `json:"revision"`
+	State    piCompactState `json:"state"`
+}
+
+type piCompactReceiptBody struct {
+	Schema                string   `json:"schema"`
+	LineageID             string   `json:"lineage_id"`
+	Generation            int      `json:"generation"`
+	AuthorityRevision     string   `json:"authority_revision"`
+	BaseTree              string   `json:"base_tree"`
+	InitialReviewTree     string   `json:"initial_review_tree"`
+	FinalCandidateTree    string   `json:"final_candidate_tree"`
+	GenesisPathsHash      string   `json:"genesis_paths_hash"`
+	IntendedUntrackedHash string   `json:"intended_untracked_hash"`
+	PolicyHash            string   `json:"policy_hash"`
+	RiskTier              string   `json:"risk_tier"`
+	SelectedLenses        []string `json:"selected_lenses"`
+	OriginalChangedLines  int      `json:"original_changed_lines"`
+	CorrectionBudget      int      `json:"correction_budget"`
+	CorrectionIDs         []string `json:"correction_ids"`
+	FixDiffHash           string   `json:"fix_diff_hash"`
+	EvidenceHash          string   `json:"evidence_hash"`
+	TerminalState         string   `json:"terminal_state"`
+}
+
+type piCompactReceipt struct {
+	Body        piCompactReceiptBody `json:"body"`
+	ReceiptHash string               `json:"receipt_hash"`
+}
+
+func ensureSHA256Prefix(hash string) string {
+	if hash == "" {
+		return ""
+	}
+	if strings.HasPrefix(hash, "sha256:") {
+		return hash
+	}
+	return "sha256:" + hash
+}
+
+func BridgePiCompactAuthority(ctx context.Context, repo, lineage string) error {
+	base, root, err := reviewAuthorityRoot(ctx, repo)
+	if err != nil {
+		return err
+	}
+	piStorePath := filepath.Join(filepath.Dir(filepath.Dir(base)), "gentle-ai", "reviews", "compact-v2", lineage)
+	if _, err := os.Stat(piStorePath); os.IsNotExist(err) {
+		return nil
+	} else if err != nil {
+		return err
+	}
+
+	piStateBytes, err := os.ReadFile(filepath.Join(piStorePath, compactStateFileName))
+	if err != nil {
+		return fmt.Errorf("read Pi review-state.json: %w", err)
+	}
+	piReceiptBytes, err := os.ReadFile(filepath.Join(piStorePath, compactReceiptFileName))
+	if err != nil {
+		return fmt.Errorf("read Pi review-receipt.json: %w", err)
+	}
+
+	var piStateRecord piCompactStateRecord
+	if err := json.Unmarshal(piStateBytes, &piStateRecord); err != nil {
+		return fmt.Errorf("decode Pi review-state.json: %w", err)
+	}
+	var piReceipt piCompactReceipt
+	if err := json.Unmarshal(piReceiptBytes, &piReceipt); err != nil {
+		return fmt.Errorf("decode Pi review-receipt.json: %w", err)
+	}
+
+	if piStateRecord.State.State != "approved" || piReceipt.Body.TerminalState != "approved" {
+		return fmt.Errorf("explicit compact authority is not approved: state=%q, receipt=%q", piStateRecord.State.State, piReceipt.Body.TerminalState)
+	}
+
+	var proj Projection
+	if piStateRecord.State.InitialSnapshot.ReviewProjection.Kind == "intended-commit" {
+		proj = ProjectionStaged
+	}
+
+	builder := SnapshotBuilder{Repo: root}
+	initialSnapshot := Snapshot{
+		Kind:              TargetCurrentChanges,
+		Projection:        proj,
+		BaseTree:          piStateRecord.State.InitialSnapshot.BaseTree,
+		CandidateTree:     piStateRecord.State.InitialSnapshot.InitialReviewTree,
+		IntendedUntracked: piStateRecord.State.InitialSnapshot.IntendedUntracked,
+		Paths:             piStateRecord.State.InitialSnapshot.GenesisPaths,
+	}
+	initialSnapshot.PathsDigest = digestPaths(initialSnapshot.Paths)
+	initialSnapshot.IntendedUntrackedProof, err = builder.untrackedProof(ctx, initialSnapshot.CandidateTree, initialSnapshot.IntendedUntracked)
+	if err != nil {
+		return err
+	}
+	initialSnapshot.Identity = snapshotIdentityForProjection(
+		initialSnapshot.Kind, initialSnapshot.Projection,
+		initialSnapshot.BaseTree, initialSnapshot.CandidateTree,
+		initialSnapshot.PathsDigest, initialSnapshot.IntendedUntrackedProof,
+		initialSnapshot.IntendedUntracked, initialSnapshot.LedgerIDs,
+	)
+
+	currentSnapshot := Snapshot{
+		Kind:              TargetCurrentChanges,
+		Projection:        proj,
+		BaseTree:          piStateRecord.State.InitialSnapshot.BaseTree,
+		CandidateTree:     piStateRecord.State.CurrentCandidateTree,
+		IntendedUntracked: piStateRecord.State.IntendedUntracked,
+		Paths:             piStateRecord.State.GenesisPaths,
+	}
+	currentSnapshot.PathsDigest = digestPaths(currentSnapshot.Paths)
+	currentSnapshot.IntendedUntrackedProof, err = builder.untrackedProof(ctx, currentSnapshot.CandidateTree, currentSnapshot.IntendedUntracked)
+	if err != nil {
+		return err
+	}
+	currentSnapshot.Identity = snapshotIdentityForProjection(
+		currentSnapshot.Kind, currentSnapshot.Projection,
+		currentSnapshot.BaseTree, currentSnapshot.CandidateTree,
+		currentSnapshot.PathsDigest, currentSnapshot.IntendedUntrackedProof,
+		currentSnapshot.IntendedUntracked, currentSnapshot.LedgerIDs,
+	)
+
+	lensResults := make([]LensResult, len(piStateRecord.State.LensResults))
+	for idx, lr := range piStateRecord.State.LensResults {
+		canonical, err := CanonicalCompactLensResult(lr)
+		if err != nil {
+			return fmt.Errorf("canonicalize lens result: %w", err)
+		}
+		lensResults[idx] = canonical
+	}
+
+	goState := CompactState{
+		Schema:               CompactStateSchema,
+		LineageID:            piStateRecord.State.LineageID,
+		Generation:           piStateRecord.State.Generation,
+		State:                State(piStateRecord.State.State),
+		InitialSnapshot:      initialSnapshot,
+		CurrentSnapshot:      currentSnapshot,
+		GenesisPaths:         piStateRecord.State.GenesisPaths,
+		PolicyHash:           ensureSHA256Prefix(piStateRecord.State.PolicyHash),
+		RiskLevel:            RiskLevel(piStateRecord.State.RiskTier),
+		SelectedLenses:       piStateRecord.State.SelectedLenses,
+		OriginalChangedLines: piStateRecord.State.OriginalChangedLines,
+		CorrectionBudget:     piStateRecord.State.CorrectionBudget,
+		LensResults:          lensResults,
+		Findings:             piStateRecord.State.Findings,
+		Classifications:      make(map[string]FindingEvidence),
+		Outcomes:             make(map[string]EvidenceOutcome),
+		FixFindingIDs:        piStateRecord.State.CorrectionIDs,
+		FollowUps:            piStateRecord.State.FollowUps,
+		FixDeltaHash:         ensureSHA256Prefix(piReceipt.Body.FixDiffHash),
+		EvidenceHash:         ensureSHA256Prefix(piReceipt.Body.EvidenceHash),
+	}
+
+	for k, v := range piStateRecord.State.Outcomes {
+		goState.Outcomes[k] = EvidenceOutcome(v)
+	}
+
+	goRecord, goRecordBytes, err := makeCompactRecord(goState)
+	if err != nil {
+		return fmt.Errorf("make Go compact record: %w", err)
+	}
+
+	goReceipt := CompactReceipt{
+		Schema:             CompactReceiptSchema,
+		LineageID:          piReceipt.Body.LineageID,
+		Projection:         initialSnapshot.Projection,
+		Generation:         piReceipt.Body.Generation,
+		BaseTree:           piReceipt.Body.BaseTree,
+		InitialReviewTree:  piReceipt.Body.InitialReviewTree,
+		FinalCandidateTree: piReceipt.Body.FinalCandidateTree,
+		PathsDigest:        initialSnapshot.PathsDigest,
+		FixDeltaHash:       ensureSHA256Prefix(piReceipt.Body.FixDiffHash),
+		PolicyHash:         ensureSHA256Prefix(piReceipt.Body.PolicyHash),
+		EvidenceHash:       ensureSHA256Prefix(piReceipt.Body.EvidenceHash),
+		RiskLevel:          RiskLevel(piReceipt.Body.RiskTier),
+		SelectedLenses:     piReceipt.Body.SelectedLenses,
+		ResolvedFindingIDs: piReceipt.Body.CorrectionIDs,
+		TerminalState:      TerminalState(piReceipt.Body.TerminalState),
+	}
+	goReceiptBytes, err := json.MarshalIndent(goReceipt, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal Go compact receipt: %w", err)
+	}
+	goReceiptBytes = append(goReceiptBytes, '\n')
+
+	versionRoot := filepath.Join(base, "v2")
+	goStoreDir := filepath.Join(versionRoot, lineage)
+	lock, err := acquireStoreLock(filepath.Join(versionRoot, "LOCK"))
+	if err != nil {
+		return err
+	}
+	defer lock.release()
+
+	if existingRecord, err := os.ReadFile(filepath.Join(goStoreDir, compactStateFileName)); err == nil {
+		var existing CompactRecord
+		if json.Unmarshal(existingRecord, &existing) == nil && existing.Revision != goRecord.Revision {
+			return errors.New("conflicting existing native Go authority revision")
+		}
+		return nil
+	}
+
+	if err := os.MkdirAll(goStoreDir, 0o755); err != nil {
+		return fmt.Errorf("create Go store directory: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(goStoreDir, compactStateFileName), goRecordBytes, 0o644); err != nil {
+		return fmt.Errorf("write Go compact state: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(goStoreDir, compactReceiptFileName), goReceiptBytes, 0o644); err != nil {
+		return fmt.Errorf("write Go compact receipt: %w", err)
+	}
+
+	return nil
+}
+
 func compactMaintenanceLockPath(authorityRoot string) string {
 	return filepath.Join(filepath.Dir(authorityRoot), "REVIEW-MAINTENANCE.lock")
 }

--- a/internal/sddstatus/review_binding.go
+++ b/internal/sddstatus/review_binding.go
@@ -52,6 +52,9 @@ func BindApprovedReview(ctx context.Context, repo, change, lineage, expected str
 	if err != nil {
 		return ReviewBinding{}, err
 	}
+	if err := reviewtransaction.BridgePiCompactAuthority(ctx, root, lineage); err != nil {
+		return ReviewBinding{}, err
+	}
 	changeRoot, err := resolveBindingChangeRoot(root, repo, change)
 	if err != nil {
 		return ReviewBinding{}, err

--- a/internal/sddstatus/review_binding_test.go
+++ b/internal/sddstatus/review_binding_test.go
@@ -618,7 +618,7 @@ func TestBindApprovedReviewPiBridge(t *testing.T) {
 }
 
 func runGitCommandOutput(ctx context.Context, repo string, args ...string) (string, error) {
-	cmd := exec.Command("git", append([]string{"-C", repo}, args...)...)
+	cmd := exec.CommandContext(ctx, "git", append([]string{"-C", repo}, args...)...)
 	out, err := cmd.Output()
 	return string(out), err
 }

--- a/internal/sddstatus/review_binding_test.go
+++ b/internal/sddstatus/review_binding_test.go
@@ -2,8 +2,10 @@ package sddstatus
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -570,5 +572,216 @@ func TestBindApprovedReviewSanitizesHostileGitEnvironmentFromSubdirectory(t *tes
 	}
 	if _, err := os.Stat(bindingPath(store, "thin")); err != nil {
 		t.Fatalf("binding was not stored in the selected repository common dir: %v", err)
+	}
+}
+
+func TestBindApprovedReviewPiBridge(t *testing.T) {
+	root := t.TempDir()
+	changeRoot := seedReadyChange(t, root, "thin", "- [x] 1.1 Done\n")
+	write(t, filepath.Join(changeRoot, "specs", "auth", "spec.md"), "### Requirement: Binding\n#### Scenario: Exact authority\n")
+	writeApprovedPiCompactAuthorityForChange(t, root, changeRoot, "pi-approved-thin")
+
+	binding, err := BindApprovedReview(context.Background(), root, "thin", "pi-approved-thin", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if binding.Schema != reviewBindingSchema || binding.Lineage != "pi-approved-thin" || binding.ReceiptHash == "" {
+		t.Fatalf("invalid binding: %#v", binding)
+	}
+
+	// Idempotency: replaying doesn't fail
+	if _, err := BindApprovedReview(context.Background(), root, "thin", "pi-approved-thin", binding.Revision); err != nil {
+		t.Fatalf("idempotent retry failed: %v", err)
+	}
+
+	// Conflict validation: changing the base/candidate tree in Pi receipt makes it fail
+	piStoreRoot := filepath.Join(root, ".git", "gentle-ai", "reviews", "compact-v2", "pi-approved-thin")
+	piReceiptBytes, err := os.ReadFile(filepath.Join(piStoreRoot, "review-receipt.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var piReceipt map[string]interface{}
+	if err := json.Unmarshal(piReceiptBytes, &piReceipt); err == nil {
+		if body, ok := piReceipt["body"].(map[string]interface{}); ok {
+			body["final_candidate_tree"] = "0000000000000000000000000000000000000000"
+		}
+		corruptedBytes, _ := json.MarshalIndent(piReceipt, "", "  ")
+		_ = os.WriteFile(filepath.Join(piStoreRoot, "review-receipt.json"), corruptedBytes, 0o644)
+	}
+
+	// Since we corrupted the Pi files, if we run it again with a new expected revision or if we attempt to re-bridge a conflict, it should fail
+	// Let's clear the native Go store to force re-bridging
+	_ = os.RemoveAll(filepath.Join(root, ".git", "gentle-ai", "review-transactions", "v2", "pi-approved-thin"))
+	if _, err := BindApprovedReview(context.Background(), root, "thin", "pi-approved-thin", ""); err == nil {
+		t.Fatal("expected conflict or validation failure on corrupted Pi receipt, but succeeded")
+	}
+}
+
+func runGitCommandOutput(ctx context.Context, repo string, args ...string) (string, error) {
+	cmd := exec.Command("git", append([]string{"-C", repo}, args...)...)
+	out, err := cmd.Output()
+	return string(out), err
+}
+
+func writeApprovedPiCompactAuthorityForChange(t *testing.T, repo, changeRoot, lineage string) {
+	t.Helper()
+	runSDDStatusGit(t, repo, "init", "-q")
+	runSDDStatusGit(t, repo, "config", "user.email", "status@example.com")
+	runSDDStatusGit(t, repo, "config", "user.name", "Status Test")
+	runSDDStatusGit(t, repo, "add", ".")
+	runSDDStatusGit(t, repo, "commit", "-qm", "base")
+	write(t, filepath.Join(changeRoot, "tasks.md"), "- [x] 1.1 Done\n# approved compact scope\n")
+
+	snapshot, err := (reviewtransaction.SnapshotBuilder{Repo: repo}).Build(context.Background(), reviewtransaction.Target{Kind: reviewtransaction.TargetCurrentChanges, IntendedUntracked: []string{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	risk, lines, err := (reviewtransaction.SnapshotBuilder{Repo: repo}).ClassifySnapshotRisk(context.Background(), snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	budget := lines/2 + lines%2
+	if budget > 200 {
+		budget = 200
+	}
+
+	lenses := []string{}
+	if risk == reviewtransaction.RiskMedium {
+		lenses = []string{string(reviewtransaction.LensReliability)}
+	} else if risk == reviewtransaction.RiskHigh {
+		lenses = []string{string(reviewtransaction.LensRisk), string(reviewtransaction.LensResilience), string(reviewtransaction.LensReadability), string(reviewtransaction.LensReliability)}
+	}
+
+	results := []interface{}{}
+	for _, lens := range lenses {
+		results = append(results, map[string]interface{}{
+			"lens":     lens,
+			"findings": []interface{}{},
+			"evidence": []string{"review complete"},
+		})
+	}
+
+	commonDirOutput, err := runGitCommandOutput(context.Background(), repo, "rev-parse", "--git-common-dir")
+	if err != nil {
+		t.Fatal(err)
+	}
+	commonDir := strings.TrimSpace(commonDirOutput)
+	if !filepath.IsAbs(commonDir) {
+		commonDir = filepath.Join(repo, commonDir)
+	}
+	commonDir, _ = filepath.Abs(commonDir)
+
+	piStoreRoot := filepath.Join(commonDir, "gentle-ai", "reviews", "compact-v2", lineage)
+	if err := os.MkdirAll(piStoreRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	piState := map[string]interface{}{
+		"schema":     "gentle-ai.review-state/v2",
+		"lineage_id": lineage,
+		"generation": 1,
+		"mode":       "ordinary",
+		"state":      "approved",
+		"initial_snapshot": map[string]interface{}{
+			"schema":                 "gentle-ai.review-snapshot/v1",
+			"mode":                   "ordinary",
+			"repository_root":        repo,
+			"base_tree":              snapshot.BaseTree,
+			"complete_snapshot_tree": snapshot.CandidateTree,
+			"review_projection": map[string]interface{}{
+				"kind": "complete",
+			},
+			"initial_review_tree": snapshot.CandidateTree,
+			"genesis_paths":       snapshot.Paths,
+			"intended_untracked":  []string{},
+			"diff_evidence": map[string]interface{}{
+				"event":        "commit",
+				"changedLines": lines,
+				"triviality":   "non-trivial",
+			},
+			"route":                  "verify",
+			"lenses":                 lenses,
+			"risk_tier":              string(risk),
+			"original_changed_lines": lines,
+			"correction_budget":      budget,
+			"policy_hash":            shaID("c"),
+			"object_store": map[string]interface{}{
+				"snapshot_directory":         ".git/gentle-ai/reviews",
+				"object_directory":           ".git/objects",
+				"alternate_object_directory": "",
+				"metadata_path":              "",
+				"sensitivity":                "workspace-content",
+			},
+		},
+		"current_candidate_tree": snapshot.CandidateTree,
+		"genesis_paths":          snapshot.Paths,
+		"intended_untracked":     []string{},
+		"policy_hash":            shaID("c"),
+		"risk_tier":              string(risk),
+		"selected_lenses":        lenses,
+		"original_changed_lines": lines,
+		"correction_budget":      budget,
+		"lens_results":           results,
+		"findings":               []interface{}{},
+		"outcomes":               map[string]string{},
+		"correction_ids":         []string{},
+		"follow_ups":             []interface{}{},
+		"runtime_identity": map[string]interface{}{
+			"schema":             "gentle-ai.review-runtime-identity/v1",
+			"compact_contract":   "v2",
+			"operation_contract": "v2",
+			"state_schema":       "gentle-ai.review-state/v2",
+			"record_schema":      "gentle-ai.review-state-record/v2",
+			"receipt_schema":     "gentle-ai.review-receipt/v2",
+			"canonicalization":   "canonical-json/v1",
+			"identity_hash":      "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+		},
+		"escalation_reasons": []string{},
+	}
+
+	piRecord := map[string]interface{}{
+		"schema":   "gentle-ai.review-state-record/v2",
+		"revision": "ec089d36258560776b4969ca2ee7eee3a1463e43b98acf0556b9d325d1ab465a",
+		"state":    piState,
+	}
+
+	piRecordBytes, err := json.MarshalIndent(piRecord, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(piStoreRoot, "review-state.json"), piRecordBytes, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	piReceipt := map[string]interface{}{
+		"body": map[string]interface{}{
+			"schema":                  "gentle-ai.review-receipt-body/v2",
+			"lineage_id":              lineage,
+			"generation":              1,
+			"authority_revision":      "ec089d36258560776b4969ca2ee7eee3a1463e43b98acf0556b9d325d1ab465a",
+			"base_tree":               snapshot.BaseTree,
+			"initial_review_tree":     snapshot.CandidateTree,
+			"final_candidate_tree":    snapshot.CandidateTree,
+			"genesis_paths_hash":      "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+			"intended_untracked_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+			"policy_hash":             shaID("c"),
+			"risk_tier":               string(risk),
+			"selected_lenses":         lenses,
+			"original_changed_lines":  lines,
+			"correction_budget":       budget,
+			"correction_ids":          []string{},
+			"fix_diff_hash":           "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+			"evidence_hash":           "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+			"terminal_state":          "approved",
+		},
+		"receipt_hash": "d2383394d076ee3b15d80d7d124e45840bfdd2a3e7b2dd29446f69077eb0073b",
+	}
+
+	piReceiptBytes, err := json.MarshalIndent(piReceipt, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(piStoreRoot, "review-receipt.json"), piReceiptBytes, 0o644); err != nil {
+		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
### Summary
Bridges Pi's compact v2 store authority into native Go CLI `sdd-status` and `review bind-sdd`.

### Changes
- Implemented `BridgePiCompactAuthority` in `internal/reviewtransaction/compact_store.go` to dynamically read compact reviews from `<git-common-dir>/gentle-ai/reviews/compact-v2/<lineage>/`.
- Maps Pi's Compact v2 review state and receipt representations into Go's native schemas:
  - Translates bare 64-hex SHA-256 hashes into `sha256:<hex>` format.
  - Dynamically reconstructs snapshot fields (`PathsDigest`, `Identity`, and `IntendedUntrackedProof`).
  - Correctly maps Complete/Intended-Commit review projections to workspace/staged schemas.
  - Formats Risk Tiers, Selected Lenses, and Lens Results (including Canonical/ResultHash reconstruction).
- Integrates the bridge check directly into `BindApprovedReview` in `internal/sddstatus/review_binding.go`.
- Added comprehensive unit tests in `internal/sddstatus/review_binding_test.go` (`TestBindApprovedReviewPiBridge`) verifying successful imports, idempotency, and closed-failure validation on corrupted receipt payloads.

Closes #1227

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for importing approved legacy Pi compact reviews into the current review authority format.
  * Approved reviews can now be bound successfully even when they originate from a legacy Pi store.
  * Existing native review records are preserved, with revision mismatches reported as errors.

* **Bug Fixes**
  * Added validation for legacy review state, receipts, hashes, and snapshot data before binding.
  * Improved handling of repeated binding requests to remain idempotent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->