### PR TITLE
docs: mention Homebrew install path for the stable pre-RDD release

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@
 > **RDD is unstable.** Receipt-Driven Development started in `gentle-ai` `v1.47.0`. Every release from `v1.47.0` onward is part of the RDD development line and may change while remaining issues are fixed.
 >
 > For a stable installation without RDD, use the last version before RDD, `v1.46.0`:
+>
+> Homebrew (preferred for macOS and Linux users):
+> ```bash
+> brew install gentleman-programming/homebrew-tap/gentle-ai@1.46.0
+> ```
+>
+> Or from source (requires Go):
 > ```bash
 > go install github.com/gentleman-programming/gentle-ai/cmd/gentle-ai@v1.46.0
 > ```


### PR DESCRIPTION
The current README points non-Go users to `go install` to get the last pre-RDD release. Since `Gentleman-Programming/homebrew-tap` now ships a versioned formula for that same release, we can offer a one-liner for Homebrew users.

> [!IMPORTANT]
> **This PR depends on [Gentleman-Programming/homebrew-tap#7](https://github.com/Gentleman-Programming/homebrew-tap/pull/7).**
>
> The `brew install gentleman-programming/homebrew-tap/gentle-ai@1.46.0` command added to the README requires that formula to exist first in the tap. Without that PR merged, the README points to a tap that does not yet ship the formula.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Homebrew installation instructions for the stable `v1.46.0` release.
  * Clarified that Homebrew is the preferred installation method for macOS and Linux.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->