### PR TITLE
fix(codex): finish gentle-dev migration for intermediate profiles

### DIFF
--- a/internal/components/permissions/inject.go
+++ b/internal/components/permissions/inject.go
@@ -3,6 +3,7 @@ package permissions
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/gentleman-programming/gentle-ai/internal/agents"
 	"github.com/gentleman-programming/gentle-ai/internal/components/filemerge"
@@ -139,6 +140,14 @@ var codexLegacyPermissionValues = [][2]string{
 	{`permissions.gentle-dev.filesystem.":workspace_roots"."."`, `"write"`},
 	{`permissions.gentle-dev.filesystem.":workspace_roots".".git/**"`, `"write"`},
 	{`permissions.gentle-dev.filesystem.":workspace_roots"."**/.env"`, `"deny"`},
+	{`permissions.gentle-dev.filesystem.":workspace_roots"."**/.env.local"`, `"deny"`},
+	{`permissions.gentle-dev.filesystem.":workspace_roots"."**/.env.*.local"`, `"deny"`},
+	{`permissions.gentle-dev.filesystem.":workspace_roots"."**/.ssh/**"`, `"deny"`},
+	{`permissions.gentle-dev.filesystem.":workspace_roots"."**/.credentials/**"`, `"deny"`},
+	{`permissions.gentle-dev.filesystem.":workspace_roots"."**/credentials.json"`, `"deny"`},
+	{`permissions.gentle-dev.filesystem.":workspace_roots"."**/.aws/credentials"`, `"deny"`},
+	{`permissions.gentle-dev.filesystem.":workspace_roots"."**/.config/gh/hosts.yml"`, `"deny"`},
+	{`permissions.gentle-dev.filesystem.":workspace_roots"."**/secrets/**"`, `"deny"`},
 	{`permissions.gentle-dev.filesystem.":workspace_roots"."**/*.pem"`, `"deny"`},
 	{`permissions.gentle-dev.filesystem.":workspace_roots"."**/*.key"`, `"deny"`},
 	{`permissions.gentle-dev.workspace_roots."~"`, `true`},
@@ -229,11 +238,13 @@ func injectCodexPermissions(homeDir string, adapter agents.Adapter) (InjectionRe
 	}
 
 	cleaned := filemerge.RemoveTopLevelTOMLKeyIfValue(string(baseTOML), "approval_policy", "\"on-request\"")
-	cleaned = filemerge.RemoveTopLevelTOMLKeyIfValue(cleaned, "default_permissions", "\"gentle-dev\"")
 	for _, legacy := range codexLegacyPermissionValues {
 		cleaned = filemerge.RemoveTOMLKeyIfValue(cleaned, legacy[0], legacy[1])
 	}
 	cleaned = filemerge.RemoveEmptyTOMLTableTree(cleaned, "permissions.gentle-dev")
+	if !codexConfigHasGentleDevPermissionProfile(cleaned) {
+		cleaned = filemerge.RemoveTopLevelTOMLKeyIfValue(cleaned, "default_permissions", "\"gentle-dev\"")
+	}
 	if cleaned == string(baseTOML) {
 		return InjectionResult{}, nil
 	}
@@ -244,6 +255,11 @@ func injectCodexPermissions(homeDir string, adapter agents.Adapter) (InjectionRe
 	}
 
 	return InjectionResult{Changed: writeResult.Changed, Files: []string{configPath}}, nil
+}
+
+func codexConfigHasGentleDevPermissionProfile(content string) bool {
+	return strings.Contains(content, "permissions.gentle-dev") ||
+		strings.Contains(content, `permissions."gentle-dev"`)
 }
 
 func mergeJSONFile(path string, overlay []byte) (filemerge.WriteResult, error) {

--- a/internal/components/permissions/inject_test.go
+++ b/internal/components/permissions/inject_test.go
@@ -374,6 +374,59 @@ func TestInjectAntigravitySkipsPermissions(t *testing.T) {
 	}
 }
 
+func TestInjectCodexRemovesIntermediateGentleDevProfile(t *testing.T) {
+	home := t.TempDir()
+	initial := `model = "gpt-5.6-sol"
+
+[permissions.gentle-dev]
+
+[permissions.gentle-dev.network]
+
+[permissions.gentle-dev.network.domains]
+
+[permissions.gentle-dev.filesystem]
+
+[permissions.gentle-dev.filesystem.":workspace_roots"]
+"**/.config/gh/hosts.yml" = "deny"
+"**/.aws/credentials" = "deny"
+"**/credentials.json" = "deny"
+"**/.credentials/**" = "deny"
+"**/.ssh/**" = "deny"
+"**/secrets/**" = "deny"
+"**/.env.*.local" = "deny"
+"**/.env.local" = "deny"
+
+[permissions.gentle-dev.workspace_roots]
+
+[mcp_servers.engram]
+command = "engram"
+args = ["mcp", "--tools=agent"]
+`
+	want := `model = "gpt-5.6-sol"
+
+[mcp_servers.engram]
+command = "engram"
+args = ["mcp", "--tools=agent"]
+`
+	configPath := writeCodexConfig(t, home, initial)
+
+	result, err := Inject(home, codexAdapter())
+	if err != nil {
+		t.Fatalf("Inject() error = %v", err)
+	}
+	if !result.Changed {
+		t.Fatal("Inject() changed = false, want true")
+	}
+
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config.toml: %v", err)
+	}
+	if string(content) != want {
+		t.Fatalf("cleaned config.toml = %q, want %q", content, want)
+	}
+}
+
 func TestInjectCodexRemovesInjectedGentleDevProfile(t *testing.T) {
 	home := t.TempDir()
 	configPath := writeCodexConfig(t, home, codexInjectedLegacyConfig)
@@ -453,6 +506,7 @@ user_note = "keep"
 "~/custom" = "write"
 `
 	want := `approval_policy = "never"
+default_permissions = "gentle-dev"
 
 [permissions.custom]
 description = "user profile"
@@ -500,7 +554,7 @@ func TestInjectCodexPreservesUserOwnedDottedValue(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if want := "permissions.gentle-dev.custom_flag = true\n"; string(content) != want {
+	if want := "default_permissions = \"gentle-dev\"\npermissions.gentle-dev.custom_flag = true\n"; string(content) != want {
 		t.Fatalf("cleaned config.toml = %q, want %q", content, want)
 	}
 }


### PR DESCRIPTION
## Linked Issue

Closes #1546

---

## PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)

---

## Summary

- Completes Codex `gentle-dev` migration cleanup for the intermediate permission profile format (workspace-root secret deny globs).
- Removes `default_permissions = "gentle-dev"` only after the `permissions.gentle-dev` tree is fully gone, avoiding the invalid state that breaks Codex startup.
- Adds a regression test mirroring the broken `~/.codex/config.toml` shape seen on Windows after Gentle AI sync/upgrade.

---

## Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/components/permissions/inject.go` | Added intermediate legacy deny globs; deferred `default_permissions` removal until profile cleanup succeeds |
| `internal/components/permissions/inject_test.go` | Added regression test; updated expectations for user-owned `gentle-dev` profiles |

---

## Test Plan

- [x] Unit tests pass (`go test ./internal/components/permissions/...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [x] Manually tested locally

---

## Contributor Checklist

- [x] PR is linked to an issue with `status:approved` (pending maintainer approval on #1546)
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass
- [x] Go format passes
- [x] My commits follow Conventional Commits format
- [x] My commits do not include Co-Authored-By trailers

---

## Notes for Reviewers

Root cause: #1398 migration removed `default_permissions` before legacy cleanup finished. Intermediate injected profiles (secret deny globs under `:workspace_roots`) were not in `codexLegacyPermissionValues`, leaving orphaned `[permissions.gentle-dev]` tables and a Codex-invalid config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of legacy Codex permission settings while preserving user-owned configuration.
  * Added protection for sensitive files and directories, including environment files, SSH credentials, cloud credentials, and secrets.
  * Corrected handling of default permission profiles during configuration migration.

* **Tests**
  * Added regression coverage for removing intermediate permission profiles without affecting unrelated settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->