### PR TITLE
fix(upgrade): detect pwsh before falling back to legacy powershell on Windows

### DIFF
--- a/internal/components/engram/download.go
+++ b/internal/components/engram/download.go
@@ -587,6 +587,19 @@ func extractZipBinary(data []byte, binaryName, outPath string) error {
 	return fmt.Errorf("binary %q not found in zip archive", binaryName)
 }
 
+var engramLookPathFn = exec.LookPath
+
+// resolvePowerShell returns the name of the PowerShell executable to use for
+// Windows-specific tasks. It prefers "pwsh" (PowerShell Core 6+) when it is
+// available in PATH because it is the modern cross-platform shell. Falls back
+// to "powershell.exe" (Windows PowerShell 5.1) when pwsh is not found.
+func resolvePowerShell() string {
+	if _, err := engramLookPathFn("pwsh"); err == nil {
+		return "pwsh"
+	}
+	return "powershell.exe"
+}
+
 // engramStopScript returns the PowerShell script that stops running Engram
 // processes so Windows can replace engram.exe during an upgrade.
 //
@@ -618,24 +631,40 @@ exit 0
 `
 }
 
+var engramRunCommandFn = func(name string, args ...string) ([]byte, error) {
+	cmd := exec.Command(name, args...)
+	cmd.Stdin = nil
+	return cmd.CombinedOutput()
+}
+
 // stopEngramProcesses runs the defensive stop script (see engramStopScript) and
-// returns a non-nil error only when powershell.exe itself fails to launch or
+// returns a non-nil error only when the PowerShell host itself fails to launch or
 // exits non-zero. A WARNING line (processes found but not all stopped) is
 // surfaced to stderr but is treated as non-fatal.
+//
+// pwsh (PowerShell Core 6+) is preferred over powershell.exe (Windows PowerShell
+// 5.1) because it is the modern shell and may be the only PowerShell available on
+// newer Windows Server editions or developer machines that install only Core.
+// If pwsh fails to launch or execute, it falls back to powershell.exe.
 func stopEngramProcesses() error {
-	cmd := exec.Command("powershell.exe",
+	psExe := resolvePowerShell()
+	args := []string{
 		"-NoProfile",
 		"-NonInteractive",
 		"-Command",
 		engramStopScript(),
-	)
-	cmd.Stdin = nil
-	out, err := cmd.CombinedOutput()
+	}
+	out, err := engramRunCommandFn(psExe, args...)
+	if err != nil && psExe == "pwsh" {
+		pwshErr := err
+		psExe = "powershell.exe"
+		out, err = engramRunCommandFn(psExe, args...)
+		if err != nil {
+			return fmt.Errorf("pwsh Stop-Process engram: %v; %s Stop-Process engram: %w (output: %s)", pwshErr, psExe, err, strings.TrimSpace(string(out)))
+		}
+	}
 	if err != nil {
-		// powershell itself failed to launch or returned non-zero despite
-		// our SilentlyContinue guards — surface the raw output so the user
-		// has something actionable.
-		return fmt.Errorf("powershell Stop-Process engram: %w (output: %s)", err, strings.TrimSpace(string(out)))
+		return fmt.Errorf("%s Stop-Process engram: %w (output: %s)", psExe, err, strings.TrimSpace(string(out)))
 	}
 	// If the script emitted a WARNING line, surface it but do not fail.
 	// The caller decides whether to abort based on the returned error being nil.

--- a/internal/components/engram/download_test.go
+++ b/internal/components/engram/download_test.go
@@ -1433,3 +1433,25 @@ func TestSHA256ChecksumContract(t *testing.T) {
 	t.Logf("SHA256 contract: Go produces %q format (64 lowercase hex chars)", goDigest)
 	t.Logf("PowerShell fallback must produce identical format using .NET SHA256")
 }
+
+func TestStopEngramProcessesFallsBackAfterPwshFailure(t *testing.T) {
+	originalLookPath, originalRun := engramLookPathFn, engramRunCommandFn
+	t.Cleanup(func() { engramLookPathFn, engramRunCommandFn = originalLookPath, originalRun })
+
+	engramLookPathFn = func(string) (string, error) { return "pwsh", nil }
+	var hosts []string
+	engramRunCommandFn = func(name string, _ ...string) ([]byte, error) {
+		hosts = append(hosts, name)
+		if name == "pwsh" {
+			return nil, errors.New("launch failed")
+		}
+		return nil, nil
+	}
+
+	if err := stopEngramProcesses(); err != nil {
+		t.Fatalf("stopEngramProcesses() error = %v, want nil", err)
+	}
+	if got, want := strings.Join(hosts, ","), "pwsh,powershell.exe"; got != want {
+		t.Fatalf("PowerShell hosts = %q, want %q", got, want)
+	}
+}

--- a/internal/update/upgrade/strategy.go
+++ b/internal/update/upgrade/strategy.go
@@ -577,6 +577,18 @@ func binaryUpgrade(ctx context.Context, r update.UpdateResult, profile system.Pl
 	return downloadAndReplace(ctx, r, profile)
 }
 
+// detectPowerShell returns the name of the PowerShell executable available on
+// the current Windows system. It prefers "pwsh" (PowerShell Core 6+) over the
+// legacy "powershell" (Windows PowerShell 5.1) because pwsh is faster, has
+// better UTF-8 support, and is the modern cross-platform shell. Falls back to
+// "powershell" when pwsh is not found in PATH.
+func detectPowerShell() string {
+	if _, err := lookPathFn("pwsh"); err == nil {
+		return "pwsh"
+	}
+	return "powershell"
+}
+
 // installerUpgradeArgs builds the PowerShell command argument list for launching
 // install.ps1 as a detached process. When beta is true, "-Channel beta" is
 // appended after "-File <tmpPath>" so install.ps1 routes to go install @main
@@ -586,7 +598,7 @@ func installerUpgradeArgs(tmpPath string, beta bool) []string {
 		"/C",
 		"start",
 		"",
-		"powershell",
+		detectPowerShell(),
 		"-NoProfile",
 		"-NoExit",
 		"-ExecutionPolicy", "Bypass",

--- a/internal/update/upgrade/strategy_test.go
+++ b/internal/update/upgrade/strategy_test.go
@@ -1792,6 +1792,54 @@ func TestInstallerUpgradeArgs(t *testing.T) {
 	}
 }
 
+// TestDetectPowerShell verifies that detectPowerShell prefers pwsh when present
+// and falls back to powershell when pwsh is not found in PATH.
+func TestDetectPowerShell(t *testing.T) {
+	origLookPath := lookPathFn
+	t.Cleanup(func() { lookPathFn = origLookPath })
+
+	t.Run("pwsh present", func(t *testing.T) {
+		lookPathFn = func(cmd string) (string, error) {
+			if cmd == "pwsh" {
+				return "/usr/bin/pwsh", nil
+			}
+			return "", errors.New("not found")
+		}
+		if got := detectPowerShell(); got != "pwsh" {
+			t.Errorf("detectPowerShell() = %q, want \"pwsh\"", got)
+		}
+	})
+
+	t.Run("pwsh absent", func(t *testing.T) {
+		lookPathFn = func(cmd string) (string, error) {
+			return "", errors.New("not found")
+		}
+		if got := detectPowerShell(); got != "powershell" {
+			t.Errorf("detectPowerShell() = %q, want \"powershell\"", got)
+		}
+	})
+}
+
+// TestInstallerUpgradeArgsPwshPreferred verifies that installerUpgradeArgs places
+// the PowerShell binary returned by detectPowerShell() at the correct position
+// in the command-line slice, so the detached start command targets the right
+// shell regardless of whether pwsh or the legacy powershell is installed.
+func TestInstallerUpgradeArgsPwshPreferred(t *testing.T) {
+	const tmpPath = `C:\Temp\gentle-ai-install.ps1`
+	args := installerUpgradeArgs(tmpPath, false)
+	// args layout: ["/C", "start", "", <psExe>, "-NoProfile", "-NoExit", ...]
+	if len(args) < 4 {
+		t.Fatalf("installerUpgradeArgs returned too few args: %v", args)
+	}
+	psExe := args[3]
+	if psExe != "pwsh" && psExe != "powershell" {
+		t.Errorf("installerUpgradeArgs args[3] = %q, want \"pwsh\" or \"powershell\"", psExe)
+	}
+	if psExe != detectPowerShell() {
+		t.Errorf("installerUpgradeArgs args[3] = %q but detectPowerShell() = %q — must be consistent", psExe, detectPowerShell())
+	}
+}
+
 // TestRunStrategy_BetaGentleAIWindowsInstallerIncludesChannelBeta verifies the
 // full runStrategy path: on Windows, a beta gentle-ai upgrade via InstallInstaller
 // must pass -Channel beta to the PowerShell installer command.


### PR DESCRIPTION
### Summary

On Windows machines that only have PowerShell Core (`pwsh`) installed, or where `pwsh` is preferred over the legacy Windows PowerShell 5.1 (`powershell`), the upgrade path fails because the binary name was hardcoded as `"powershell"`.

This PR introduces a detection helper that probes `pwsh` first via `exec.LookPath` and falls back to `powershell` only when Core is not found, applying this consistently across two sites:

### Changes

- **`internal/update/upgrade/strategy.go`**: Added `detectPowerShell()` helper. `installerUpgradeArgs` now uses it instead of the hardcoded `"powershell"` string.
- **`internal/components/engram/download.go`**: Added parallel `resolvePowerShell()` helper. `stopEngramProcesses` now uses it instead of `"powershell.exe"`.
- **`internal/update/upgrade/strategy_test.go`**: Added `TestDetectPowerShell` and `TestInstallerUpgradeArgsPwshPreferred` to cover the detection contract.

Fixes #910

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows upgrade behavior to prefer PowerShell Core (`pwsh`) when available, with an automatic fallback to Windows PowerShell.
  * Updated the process-stopping step to use the resolved PowerShell host, retrying once if `pwsh` fails; script warnings remain non-fatal.
* **Tests**
  * Added unit tests covering PowerShell detection, correct installer PowerShell argument selection, and fallback behavior after a `pwsh` launch failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->