### PR TITLE
feat(mcp): CLI subcommand, config injection, orchestrator prompt, and catalog (Part 3 of 3)

### DIFF
--- a/internal/agents/claudedesktop/adapter.go
+++ b/internal/agents/claudedesktop/adapter.go
@@ -151,7 +151,6 @@ func (a *Adapter) MCPConfigPath(homeDir string, _ string) string {
 	return filepath.Join(GlobalConfigDir(homeDir), "claude_desktop_config.json")
 }
 
-
 // --- Optional capabilities ---
 
 // SupportsOutputStyles reports whether Claude Desktop supports custom output styles.
@@ -198,5 +197,3 @@ func defaultStat(path string) statResult {
 	info, err := os.Stat(path)
 	return statResult{isDir: err == nil && info.IsDir(), err: err}
 }
-
-

--- a/internal/agents/claudedesktop/adapter.go
+++ b/internal/agents/claudedesktop/adapter.go
@@ -140,9 +140,7 @@ func (a *Adapter) SupportsSkills() bool           { return true }
 func (a *Adapter) SupportsSystemPrompt() bool     { return true }
 func (a *Adapter) SupportsMCP() bool              { return true }
 
-type AgentNotInstallableError struct {
-	Agent model.AgentID
-}
+type AgentNotInstallableError struct{ Agent model.AgentID }
 
 func (e AgentNotInstallableError) Error() string {
 	return "agent " + string(e.Agent) + " is a desktop app and cannot be installed via CLI"
@@ -150,8 +148,5 @@ func (e AgentNotInstallableError) Error() string {
 
 func defaultStat(path string) statResult {
 	info, err := os.Stat(path)
-	if err != nil {
-		return statResult{err: err}
-	}
-	return statResult{isDir: info.IsDir()}
+	return statResult{isDir: err == nil && info.IsDir(), err: err}
 }

--- a/internal/agents/claudedesktop/adapter.go
+++ b/internal/agents/claudedesktop/adapter.go
@@ -1,0 +1,157 @@
+package claudedesktop
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"github.com/gentleman-programming/gentle-ai/internal/model"
+	"github.com/gentleman-programming/gentle-ai/internal/system"
+)
+
+type statResult struct {
+	isDir bool
+	err   error
+}
+
+// Adapter implements agents.Adapter for Claude Desktop (by Anthropic).
+//
+// Config path summary:
+//   - OS-specific Claude User config dir
+//     macOS:   ~/Library/Application Support/Claude/
+//     Linux:   ~/.config/Claude/   (respects XDG_CONFIG_HOME)
+//     Windows: %APPDATA%\Claude\
+//     → claude_desktop_config.json   MCP server configs and preferences
+//
+// Detection: Claude Desktop is a desktop app. If the Claude config directory or file exists, it is detected.
+type Adapter struct {
+	statPath func(string) statResult
+}
+
+func NewAdapter() *Adapter {
+	return &Adapter{statPath: defaultStat}
+}
+
+// --- Identity ---
+
+func (a *Adapter) Agent() model.AgentID    { return model.AgentClaudeDesktop }
+func (a *Adapter) Tier() model.SupportTier { return model.TierFull }
+
+// --- Detection ---
+
+// Detect checks for the Claude Desktop config directory or config file.
+func (a *Adapter) Detect(_ context.Context, homeDir string) (bool, string, string, bool, error) {
+	configDir := a.GlobalConfigDir(homeDir)
+	configFile := a.MCPConfigPath(homeDir, "")
+	
+	statFile := a.statPath(configFile)
+	if statFile.err == nil {
+		return true, "", configFile, true, nil
+	}
+
+	statDir := a.statPath(configDir)
+	if statDir.err != nil {
+		if os.IsNotExist(statDir.err) {
+			return false, "", configDir, false, nil
+		}
+		return false, "", "", false, statDir.err
+	}
+	return statDir.isDir, "", configDir, statDir.isDir, nil
+}
+
+// --- Installation ---
+
+func (a *Adapter) SupportsAutoInstall() bool { return false }
+
+func (a *Adapter) InstallCommand(_ system.PlatformProfile) ([][]string, error) {
+	return nil, AgentNotInstallableError{Agent: model.AgentClaudeDesktop}
+}
+
+// --- Config paths ---
+
+// GlobalConfigDir returns the OS-specific Claude Desktop config directory.
+func (a *Adapter) GlobalConfigDir(homeDir string) string {
+	return a.claudeUserDir(homeDir)
+}
+
+func (a *Adapter) SystemPromptDir(homeDir string) string {
+	return a.claudeUserDir(homeDir)
+}
+
+func (a *Adapter) SystemPromptFile(homeDir string) string {
+	return filepath.Join(a.claudeUserDir(homeDir), "instructions.md")
+}
+
+func (a *Adapter) SkillsDir(homeDir string) string {
+	return filepath.Join(a.claudeUserDir(homeDir), "skills")
+}
+
+func (a *Adapter) SettingsPath(homeDir string) string {
+	return filepath.Join(a.claudeUserDir(homeDir), "claude_desktop_config.json")
+}
+
+// --- Config strategies ---
+
+func (a *Adapter) SystemPromptStrategy() model.SystemPromptStrategy {
+	return model.StrategyInstructionsFile
+}
+
+func (a *Adapter) MCPStrategy() model.MCPStrategy {
+	return model.StrategyMergeIntoSettings
+}
+
+// --- MCP ---
+
+func (a *Adapter) MCPConfigPath(homeDir string, _ string) string {
+	return filepath.Join(a.claudeUserDir(homeDir), "claude_desktop_config.json")
+}
+
+// claudeUserDir returns the OS-specific Claude Desktop User config directory.
+func (a *Adapter) claudeUserDir(homeDir string) string {
+	switch runtime.GOOS {
+	case "darwin":
+		return filepath.Join(homeDir, "Library", "Application Support", "Claude")
+	case "windows":
+		appData := os.Getenv("APPDATA")
+		if appData == "" {
+			appData = filepath.Join(homeDir, "AppData", "Roaming")
+		}
+		return filepath.Join(appData, "Claude")
+	default: // linux and others
+		xdgConfigHome := os.Getenv("XDG_CONFIG_HOME")
+		if xdgConfigHome == "" {
+			xdgConfigHome = filepath.Join(homeDir, ".config")
+		}
+		return filepath.Join(xdgConfigHome, "Claude")
+	}
+}
+
+// --- Optional capabilities ---
+
+func (a *Adapter) SupportsOutputStyles() bool     { return false }
+func (a *Adapter) OutputStyleDir(_ string) string { return "" }
+func (a *Adapter) SupportsSlashCommands() bool    { return false }
+func (a *Adapter) CommandsDir(_ string) string    { return "" }
+func (a *Adapter) SupportsSubAgents() bool        { return false }
+func (a *Adapter) SubAgentsDir(_ string) string   { return "" }
+func (a *Adapter) EmbeddedSubAgentsDir() string   { return "" }
+func (a *Adapter) SupportsSkills() bool           { return true }
+func (a *Adapter) SupportsSystemPrompt() bool     { return true }
+func (a *Adapter) SupportsMCP() bool              { return true }
+
+type AgentNotInstallableError struct {
+	Agent model.AgentID
+}
+
+func (e AgentNotInstallableError) Error() string {
+	return "agent " + string(e.Agent) + " is a desktop app and cannot be installed via CLI"
+}
+
+func defaultStat(path string) statResult {
+	info, err := os.Stat(path)
+	if err != nil {
+		return statResult{err: err}
+	}
+	return statResult{isDir: info.IsDir()}
+}

--- a/internal/agents/claudedesktop/adapter.go
+++ b/internal/agents/claudedesktop/adapter.go
@@ -7,6 +7,7 @@ import (
 	"runtime"
 
 	"github.com/gentleman-programming/gentle-ai/internal/model"
+	"github.com/gentleman-programming/gentle-ai/internal/system"
 )
 
 type statResult struct {
@@ -71,7 +72,7 @@ func (a *Adapter) Detect(_ context.Context, homeDir string) (bool, string, strin
 func (a *Adapter) SupportsAutoInstall() bool { return false }
 
 // InstallCommand returns an error because Claude Desktop is a GUI app and cannot be installed via CLI.
-func (a *Adapter) InstallCommand(_ model.PlatformProfile) ([][]string, error) {
+func (a *Adapter) InstallCommand(_ system.PlatformProfile) ([][]string, error) {
 	return nil, AgentNotInstallableError{Agent: model.AgentClaudeDesktop}
 }
 
@@ -150,9 +151,6 @@ func (a *Adapter) MCPConfigPath(homeDir string, _ string) string {
 	return filepath.Join(GlobalConfigDir(homeDir), "claude_desktop_config.json")
 }
 
-func (a *Adapter) claudeUserDir(homeDir string) string {
-	return GlobalConfigDir(homeDir)
-}
 
 // --- Optional capabilities ---
 

--- a/internal/agents/claudedesktop/adapter.go
+++ b/internal/agents/claudedesktop/adapter.go
@@ -7,7 +7,6 @@ import (
 	"runtime"
 
 	"github.com/gentleman-programming/gentle-ai/internal/model"
-	"github.com/gentleman-programming/gentle-ai/internal/system"
 )
 
 type statResult struct {
@@ -29,13 +28,17 @@ type Adapter struct {
 	statPath func(string) statResult
 }
 
+// NewAdapter creates a new Adapter instance for Claude Desktop.
 func NewAdapter() *Adapter {
 	return &Adapter{statPath: defaultStat}
 }
 
 // --- Identity ---
 
-func (a *Adapter) Agent() model.AgentID    { return model.AgentClaudeDesktop }
+// Agent returns model.AgentClaudeDesktop.
+func (a *Adapter) Agent() model.AgentID { return model.AgentClaudeDesktop }
+
+// Tier returns model.TierFull.
 func (a *Adapter) Tier() model.SupportTier { return model.TierFull }
 
 // --- Detection ---
@@ -48,6 +51,8 @@ func (a *Adapter) Detect(_ context.Context, homeDir string) (bool, string, strin
 	statFile := a.statPath(configFile)
 	if statFile.err == nil && !statFile.isDir {
 		return true, "", configFile, true, nil
+	} else if statFile.err != nil && !os.IsNotExist(statFile.err) {
+		return false, "", "", false, statFile.err
 	}
 
 	statDir := a.statPath(configDir)
@@ -62,53 +67,18 @@ func (a *Adapter) Detect(_ context.Context, homeDir string) (bool, string, strin
 
 // --- Installation ---
 
+// SupportsAutoInstall reports whether Claude Desktop supports automated installation.
 func (a *Adapter) SupportsAutoInstall() bool { return false }
 
-func (a *Adapter) InstallCommand(_ system.PlatformProfile) ([][]string, error) {
+// InstallCommand returns an error because Claude Desktop is a GUI app and cannot be installed via CLI.
+func (a *Adapter) InstallCommand(_ model.PlatformProfile) ([][]string, error) {
 	return nil, AgentNotInstallableError{Agent: model.AgentClaudeDesktop}
 }
 
 // --- Config paths ---
 
-// GlobalConfigDir returns the OS-specific Claude Desktop config directory.
-func (a *Adapter) GlobalConfigDir(homeDir string) string {
-	return a.claudeUserDir(homeDir)
-}
-
-func (a *Adapter) SystemPromptDir(homeDir string) string {
-	return a.claudeUserDir(homeDir)
-}
-
-func (a *Adapter) SystemPromptFile(homeDir string) string {
-	return filepath.Join(a.claudeUserDir(homeDir), "instructions.md")
-}
-
-func (a *Adapter) SkillsDir(homeDir string) string {
-	return filepath.Join(a.claudeUserDir(homeDir), "skills")
-}
-
-func (a *Adapter) SettingsPath(homeDir string) string {
-	return filepath.Join(a.claudeUserDir(homeDir), "claude_desktop_config.json")
-}
-
-// --- Config strategies ---
-
-func (a *Adapter) SystemPromptStrategy() model.SystemPromptStrategy {
-	return model.StrategyInstructionsFile
-}
-
-func (a *Adapter) MCPStrategy() model.MCPStrategy {
-	return model.StrategyMergeIntoSettings
-}
-
-// --- MCP ---
-
-func (a *Adapter) MCPConfigPath(homeDir string, _ string) string {
-	return filepath.Join(a.claudeUserDir(homeDir), "claude_desktop_config.json")
-}
-
-// claudeUserDir returns the OS-specific Claude Desktop User config directory.
-func (a *Adapter) claudeUserDir(homeDir string) string {
+// GlobalConfigDir returns the OS-specific Claude Desktop User config directory.
+func GlobalConfigDir(homeDir string) string {
 	switch runtime.GOOS {
 	case "darwin":
 		return filepath.Join(homeDir, "Library", "Application Support", "Claude")
@@ -127,21 +97,92 @@ func (a *Adapter) claudeUserDir(homeDir string) string {
 	}
 }
 
+// GlobalConfigDir returns the OS-specific Claude Desktop config directory.
+func (a *Adapter) GlobalConfigDir(homeDir string) string {
+	return GlobalConfigDir(homeDir)
+}
+
+// SystemPromptDir returns the directory containing system prompt instructions for Claude Desktop.
+func (a *Adapter) SystemPromptDir(homeDir string) string {
+	return GlobalConfigDir(homeDir)
+}
+
+// SystemPromptFile returns the path to instructions.md for Claude Desktop.
+func (a *Adapter) SystemPromptFile(homeDir string) string {
+	return filepath.Join(GlobalConfigDir(homeDir), "instructions.md")
+}
+
+// SkillsDir returns the path to the skills directory for Claude Desktop.
+func (a *Adapter) SkillsDir(homeDir string) string {
+	return filepath.Join(GlobalConfigDir(homeDir), "skills")
+}
+
+// SettingsPath returns the path to claude_desktop_config.json.
+func (a *Adapter) SettingsPath(homeDir string) string {
+	return filepath.Join(GlobalConfigDir(homeDir), "claude_desktop_config.json")
+}
+
+// --- Config strategies ---
+
+// SystemPromptStrategy returns the system prompt strategy for Claude Desktop.
+func (a *Adapter) SystemPromptStrategy() model.SystemPromptStrategy {
+	return model.StrategyInstructionsFile
+}
+
+// MCPStrategy returns the MCP strategy for Claude Desktop.
+func (a *Adapter) MCPStrategy() model.MCPStrategy {
+	return model.StrategyMergeIntoSettings
+}
+
+// --- MCP ---
+
+// MCPConfigPath returns the path to the MCP configuration file for Claude Desktop.
+func (a *Adapter) MCPConfigPath(homeDir string, _ string) string {
+	return filepath.Join(GlobalConfigDir(homeDir), "claude_desktop_config.json")
+}
+
+func (a *Adapter) claudeUserDir(homeDir string) string {
+	return GlobalConfigDir(homeDir)
+}
+
 // --- Optional capabilities ---
 
-func (a *Adapter) SupportsOutputStyles() bool     { return false }
+// SupportsOutputStyles reports whether Claude Desktop supports custom output styles.
+func (a *Adapter) SupportsOutputStyles() bool { return false }
+
+// OutputStyleDir returns the directory for custom output styles.
 func (a *Adapter) OutputStyleDir(_ string) string { return "" }
-func (a *Adapter) SupportsSlashCommands() bool    { return false }
-func (a *Adapter) CommandsDir(_ string) string    { return "" }
-func (a *Adapter) SupportsSubAgents() bool        { return false }
-func (a *Adapter) SubAgentsDir(_ string) string   { return "" }
-func (a *Adapter) EmbeddedSubAgentsDir() string   { return "" }
-func (a *Adapter) SupportsSkills() bool           { return false }
-func (a *Adapter) SupportsSystemPrompt() bool     { return false }
-func (a *Adapter) SupportsMCP() bool              { return true }
 
-type AgentNotInstallableError struct{ Agent model.AgentID }
+// SupportsSlashCommands reports whether Claude Desktop supports slash commands.
+func (a *Adapter) SupportsSlashCommands() bool { return false }
 
+// CommandsDir returns the directory for slash commands.
+func (a *Adapter) CommandsDir(_ string) string { return "" }
+
+// SupportsSubAgents reports whether Claude Desktop supports sub-agents.
+func (a *Adapter) SupportsSubAgents() bool { return false }
+
+// SubAgentsDir returns the directory for sub-agents.
+func (a *Adapter) SubAgentsDir(_ string) string { return "" }
+
+// EmbeddedSubAgentsDir returns the directory for embedded sub-agents.
+func (a *Adapter) EmbeddedSubAgentsDir() string { return "" }
+
+// SupportsSkills reports whether Claude Desktop supports skills.
+func (a *Adapter) SupportsSkills() bool { return false }
+
+// SupportsSystemPrompt reports whether Claude Desktop supports system prompts.
+func (a *Adapter) SupportsSystemPrompt() bool { return false }
+
+// SupportsMCP reports whether Claude Desktop supports Model Context Protocol.
+func (a *Adapter) SupportsMCP() bool { return true }
+
+// AgentNotInstallableError is returned when InstallCommand is called on a desktop-only agent.
+type AgentNotInstallableError struct {
+	Agent model.AgentID
+}
+
+// Error formats the AgentNotInstallableError message.
 func (e AgentNotInstallableError) Error() string {
 	return "agent " + string(e.Agent) + " is a desktop app and cannot be installed via CLI"
 }
@@ -150,3 +191,5 @@ func defaultStat(path string) statResult {
 	info, err := os.Stat(path)
 	return statResult{isDir: err == nil && info.IsDir(), err: err}
 }
+
+

--- a/internal/agents/claudedesktop/adapter.go
+++ b/internal/agents/claudedesktop/adapter.go
@@ -44,7 +44,7 @@ func (a *Adapter) Tier() model.SupportTier { return model.TierFull }
 func (a *Adapter) Detect(_ context.Context, homeDir string) (bool, string, string, bool, error) {
 	configDir := a.GlobalConfigDir(homeDir)
 	configFile := a.MCPConfigPath(homeDir, "")
-	
+
 	statFile := a.statPath(configFile)
 	if statFile.err == nil {
 		return true, "", configFile, true, nil

--- a/internal/agents/claudedesktop/adapter.go
+++ b/internal/agents/claudedesktop/adapter.go
@@ -46,7 +46,7 @@ func (a *Adapter) Detect(_ context.Context, homeDir string) (bool, string, strin
 	configFile := a.MCPConfigPath(homeDir, "")
 
 	statFile := a.statPath(configFile)
-	if statFile.err == nil {
+	if statFile.err == nil && !statFile.isDir {
 		return true, "", configFile, true, nil
 	}
 
@@ -136,8 +136,8 @@ func (a *Adapter) CommandsDir(_ string) string    { return "" }
 func (a *Adapter) SupportsSubAgents() bool        { return false }
 func (a *Adapter) SubAgentsDir(_ string) string   { return "" }
 func (a *Adapter) EmbeddedSubAgentsDir() string   { return "" }
-func (a *Adapter) SupportsSkills() bool           { return true }
-func (a *Adapter) SupportsSystemPrompt() bool     { return true }
+func (a *Adapter) SupportsSkills() bool           { return false }
+func (a *Adapter) SupportsSystemPrompt() bool     { return false }
 func (a *Adapter) SupportsMCP() bool              { return true }
 
 type AgentNotInstallableError struct{ Agent model.AgentID }

--- a/internal/agents/claudedesktop/adapter.go
+++ b/internal/agents/claudedesktop/adapter.go
@@ -104,16 +104,25 @@ func (a *Adapter) GlobalConfigDir(homeDir string) string {
 
 // SystemPromptDir returns the directory containing system prompt instructions for Claude Desktop.
 func (a *Adapter) SystemPromptDir(homeDir string) string {
+	if !a.SupportsSystemPrompt() {
+		return ""
+	}
 	return GlobalConfigDir(homeDir)
 }
 
 // SystemPromptFile returns the path to instructions.md for Claude Desktop.
 func (a *Adapter) SystemPromptFile(homeDir string) string {
+	if !a.SupportsSystemPrompt() {
+		return ""
+	}
 	return filepath.Join(GlobalConfigDir(homeDir), "instructions.md")
 }
 
 // SkillsDir returns the path to the skills directory for Claude Desktop.
 func (a *Adapter) SkillsDir(homeDir string) string {
+	if !a.SupportsSkills() {
+		return ""
+	}
 	return filepath.Join(GlobalConfigDir(homeDir), "skills")
 }
 

--- a/internal/agents/claudedesktop/adapter_test.go
+++ b/internal/agents/claudedesktop/adapter_test.go
@@ -1,0 +1,86 @@
+package claudedesktop
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/internal/model"
+)
+
+func TestAdapter_Identity(t *testing.T) {
+	adapter := NewAdapter()
+	if got := adapter.Agent(); got != model.AgentClaudeDesktop {
+		t.Errorf("Agent() = %v, want %v", got, model.AgentClaudeDesktop)
+	}
+	if got := adapter.Tier(); got != model.TierFull {
+		t.Errorf("Tier() = %v, want %v", got, model.TierFull)
+	}
+}
+
+func TestAdapter_ConfigPaths(t *testing.T) {
+	adapter := NewAdapter()
+	home := "/home/user"
+	if runtime.GOOS == "windows" {
+		home = `C:\Users\user`
+	}
+
+	configDir := adapter.GlobalConfigDir(home)
+	if configDir == "" {
+		t.Error("GlobalConfigDir() is empty")
+	}
+
+	mcpPath := adapter.MCPConfigPath(home, "")
+	if filepath.Base(mcpPath) != "claude_desktop_config.json" {
+		t.Errorf("MCPConfigPath() base = %v, want claude_desktop_config.json", filepath.Base(mcpPath))
+	}
+}
+
+func TestAdapter_Strategies(t *testing.T) {
+	adapter := NewAdapter()
+	if got := adapter.SystemPromptStrategy(); got != model.StrategyInstructionsFile {
+		t.Errorf("SystemPromptStrategy() = %v, want %v", got, model.StrategyInstructionsFile)
+	}
+	if got := adapter.MCPStrategy(); got != model.StrategyMergeIntoSettings {
+		t.Errorf("MCPStrategy() = %v, want %v", got, model.StrategyMergeIntoSettings)
+	}
+}
+
+func TestAdapter_Capabilities(t *testing.T) {
+	adapter := NewAdapter()
+	if !adapter.SupportsMCP() {
+		t.Error("SupportsMCP() = false, want true")
+	}
+	if !adapter.SupportsSkills() {
+		t.Error("SupportsSkills() = false, want true")
+	}
+	if !adapter.SupportsSystemPrompt() {
+		t.Error("SupportsSystemPrompt() = false, want true")
+	}
+	if adapter.SupportsAutoInstall() {
+		t.Error("SupportsAutoInstall() = true, want false")
+	}
+}
+
+func TestAdapter_Detect(t *testing.T) {
+	adapter := NewAdapter()
+	adapter.statPath = func(p string) statResult {
+		if filepath.Base(p) == "claude_desktop_config.json" {
+			return statResult{isDir: false, err: nil}
+		}
+		return statResult{isDir: false, err: os.ErrNotExist}
+	}
+
+	installed, _, configPath, found, err := adapter.Detect(context.Background(), "/home/user")
+	if err != nil {
+		t.Fatalf("Detect() unexpected error: %v", err)
+	}
+	if !installed || !found {
+		t.Errorf("Detect() = (%v, %v), want (true, true)", installed, found)
+	}
+	if filepath.Base(configPath) != "claude_desktop_config.json" {
+		t.Errorf("Detect() configPath = %v, want base claude_desktop_config.json", configPath)
+	}
+}

--- a/internal/agents/claudedesktop/adapter_test.go
+++ b/internal/agents/claudedesktop/adapter_test.go
@@ -2,12 +2,14 @@ package claudedesktop
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
 
 	"github.com/gentleman-programming/gentle-ai/internal/model"
+	"github.com/gentleman-programming/gentle-ai/internal/system"
 )
 
 func TestAdapter_Identity(t *testing.T) {
@@ -97,5 +99,21 @@ func TestAdapter_UnsupportedDirsReturnEmpty(t *testing.T) {
 	}
 	if got := adapter.SkillsDir(home); got != "" {
 		t.Errorf("SkillsDir() = %q, want \"\"", got)
+	}
+}
+
+func TestAdapter_InstallCommand(t *testing.T) {
+	adapter := NewAdapter()
+	commands, err := adapter.InstallCommand(system.PlatformProfile{})
+	if err == nil {
+		t.Fatalf("InstallCommand() expected error, got nil")
+	}
+	if commands != nil {
+		t.Fatalf("InstallCommand() commands = %v, want nil", commands)
+	}
+
+	var notInstallable AgentNotInstallableError
+	if !errors.As(err, &notInstallable) {
+		t.Fatalf("InstallCommand() error type = %T, want AgentNotInstallableError", err)
 	}
 }

--- a/internal/agents/claudedesktop/adapter_test.go
+++ b/internal/agents/claudedesktop/adapter_test.go
@@ -84,3 +84,18 @@ func TestAdapter_Detect(t *testing.T) {
 		t.Errorf("Detect() configPath = %v, want base claude_desktop_config.json", configPath)
 	}
 }
+
+func TestAdapter_UnsupportedDirsReturnEmpty(t *testing.T) {
+	adapter := NewAdapter()
+	home := "/home/user"
+
+	if got := adapter.SystemPromptDir(home); got != "" {
+		t.Errorf("SystemPromptDir() = %q, want \"\"", got)
+	}
+	if got := adapter.SystemPromptFile(home); got != "" {
+		t.Errorf("SystemPromptFile() = %q, want \"\"", got)
+	}
+	if got := adapter.SkillsDir(home); got != "" {
+		t.Errorf("SkillsDir() = %q, want \"\"", got)
+	}
+}

--- a/internal/agents/claudedesktop/adapter_test.go
+++ b/internal/agents/claudedesktop/adapter_test.go
@@ -53,11 +53,11 @@ func TestAdapter_Capabilities(t *testing.T) {
 	if !adapter.SupportsMCP() {
 		t.Error("SupportsMCP() = false, want true")
 	}
-	if !adapter.SupportsSkills() {
-		t.Error("SupportsSkills() = false, want true")
+	if adapter.SupportsSkills() {
+		t.Error("SupportsSkills() = true, want false")
 	}
-	if !adapter.SupportsSystemPrompt() {
-		t.Error("SupportsSystemPrompt() = false, want true")
+	if adapter.SupportsSystemPrompt() {
+		t.Error("SupportsSystemPrompt() = true, want false")
 	}
 	if adapter.SupportsAutoInstall() {
 		t.Error("SupportsAutoInstall() = true, want false")

--- a/internal/agents/factory.go
+++ b/internal/agents/factory.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/gentleman-programming/gentle-ai/internal/agents/antigravity"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/claude"
+	"github.com/gentleman-programming/gentle-ai/internal/agents/claudedesktop"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/codex"
 	cursoradapter "github.com/gentleman-programming/gentle-ai/internal/agents/cursor"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/gemini"
@@ -39,6 +40,7 @@ var defaultAgentIDs = []model.AgentID{
 	model.AgentPi,
 	model.AgentTrae,
 	model.AgentHermes,
+	model.AgentClaudeDesktop,
 }
 
 func NewAdapter(agent model.AgentID) (Adapter, error) {
@@ -75,6 +77,8 @@ func NewAdapter(agent model.AgentID) (Adapter, error) {
 		return trae.NewAdapter(), nil
 	case model.AgentHermes:
 		return hermes.NewAdapter(), nil
+	case model.AgentClaudeDesktop:
+		return claudedesktop.NewAdapter(), nil
 	default:
 		return nil, AgentNotSupportedError{Agent: agent}
 	}

--- a/internal/agents/factory_test.go
+++ b/internal/agents/factory_test.go
@@ -71,6 +71,7 @@ func TestDefaultRegistrySupportedAgentsMatchesFactoryAgents(t *testing.T) {
 	want := []model.AgentID{
 		model.AgentAntigravity,
 		model.AgentClaudeCode,
+		model.AgentClaudeDesktop,
 		model.AgentCodex,
 		model.AgentCursor,
 		model.AgentGeminiCLI,
@@ -89,6 +90,33 @@ func TestDefaultRegistrySupportedAgentsMatchesFactoryAgents(t *testing.T) {
 
 	if got := registry.SupportedAgents(); !reflect.DeepEqual(got, want) {
 		t.Fatalf("SupportedAgents() = %v, want %v", got, want)
+	}
+}
+
+func TestFactoryResolvesClaudeDesktopAdapter(t *testing.T) {
+	adapter, err := NewAdapter(model.AgentClaudeDesktop)
+	if err != nil {
+		t.Fatalf("NewAdapter(%q) returned error: %v", model.AgentClaudeDesktop, err)
+	}
+
+	if got := adapter.Agent(); got != model.AgentClaudeDesktop {
+		t.Fatalf("adapter.Agent() = %q, want %q", got, model.AgentClaudeDesktop)
+	}
+}
+
+func TestDefaultRegistryIncludesClaudeDesktop(t *testing.T) {
+	registry, err := NewDefaultRegistry()
+	if err != nil {
+		t.Fatalf("NewDefaultRegistry() returned error: %v", err)
+	}
+
+	adapter, ok := registry.Get(model.AgentClaudeDesktop)
+	if !ok {
+		t.Fatalf("registry missing %s adapter", model.AgentClaudeDesktop)
+	}
+
+	if got := adapter.Agent(); got != model.AgentClaudeDesktop {
+		t.Fatalf("registry adapter.Agent() = %q, want %q", got, model.AgentClaudeDesktop)
 	}
 }
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -57,10 +57,12 @@ var (
 	}
 )
 
+// Run executes the gentle-ai CLI application using os.Args and os.Stdout.
 func Run() error {
 	return RunArgs(os.Args[1:], os.Stdout)
 }
 
+// RunArgs parses arguments and executes the requested gentle-ai command, outputting to stdout.
 func RunArgs(args []string, stdout io.Writer) error {
 	// Propagate the build-time version to the CLI and upgrade layers so backup
 	// manifests record which version of gentle-ai created them.
@@ -81,10 +83,10 @@ func RunArgs(args []string, stdout io.Writer) error {
 			return nil
 		case "mcp":
 			if hasHelpFlag(args[1:]) {
-				printHelp(stdout, Version)
+				printMCPHelp(stdout, Version)
 				return nil
 			}
-			server := mcp.NewServer()
+			server := mcp.NewServer(Version)
 			return server.Serve(os.Stdin, stdout)
 		case "uninstall":
 			if len(args) >= 2 && args[1] == "opencode-plugin" {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gentleman-programming/gentle-ai/internal/cli"
 	"github.com/gentleman-programming/gentle-ai/internal/components/opencodeplugin"
 	componentuninstall "github.com/gentleman-programming/gentle-ai/internal/components/uninstall"
+	"github.com/gentleman-programming/gentle-ai/internal/mcp"
 	"github.com/gentleman-programming/gentle-ai/internal/model"
 	"github.com/gentleman-programming/gentle-ai/internal/pipeline"
 	"github.com/gentleman-programming/gentle-ai/internal/planner"
@@ -78,6 +79,13 @@ func RunArgs(args []string, stdout io.Writer) error {
 		case "help", "--help", "-h":
 			printHelp(stdout, Version)
 			return nil
+		case "mcp":
+			if hasHelpFlag(args[1:]) {
+				printHelp(stdout, Version)
+				return nil
+			}
+			server := mcp.NewServer()
+			return server.Serve(os.Stdin, stdout)
 		case "uninstall":
 			if len(args) >= 2 && args[1] == "opencode-plugin" {
 				_, err := cli.RunUninstallOpenCodePlugin(args[2:], stdout)

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -2225,3 +2225,45 @@ func TestCustomClearRoundTripLeavesFutureSyncInPreserveMode(t *testing.T) {
 		t.Fatalf("future sync did not return to preserve mode: assignment=%#v clear=%v", future.CodexOrchestratorAssignment, future.ClearCodexOrchestratorAssignment)
 	}
 }
+
+// TestRunArgsMCPDispatchesServer verifies that `gentle-ai mcp` command is registered
+// and dispatches the stdio MCP server cleanly.
+func TestRunArgsMCPDispatchesServer(t *testing.T) {
+	var stdout bytes.Buffer
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("Pipe error = %v", err)
+	}
+	w.Close()
+
+	origStdin := os.Stdin
+	os.Stdin = r
+	t.Cleanup(func() { os.Stdin = origStdin })
+
+	runErr := RunArgs([]string{"mcp"}, &stdout)
+	if runErr != nil {
+		t.Fatalf("RunArgs(['mcp']) returned error: %v", runErr)
+	}
+}
+
+func TestRunArgsMCPHelp(t *testing.T) {
+	var stdout bytes.Buffer
+
+	runErr := RunArgs([]string{"mcp", "--help"}, &stdout)
+	if runErr != nil {
+		t.Fatalf("RunArgs(['mcp', '--help']) returned error: %v", runErr)
+	}
+	if !strings.Contains(stdout.String(), "USAGE") {
+		t.Fatalf("expected CLI help output for mcp --help, got: %q", stdout.String())
+	}
+
+	stdout.Reset()
+	runErr = RunArgs([]string{"mcp", "-h"}, &stdout)
+	if runErr != nil {
+		t.Fatalf("RunArgs(['mcp', '-h']) returned error: %v", runErr)
+	}
+	if !strings.Contains(stdout.String(), "USAGE") {
+		t.Fatalf("expected CLI help output for mcp -h, got: %q", stdout.String())
+	}
+}

--- a/internal/app/help.go
+++ b/internal/app/help.go
@@ -16,6 +16,7 @@ COMMANDS
   install      Configure AI coding agents on this machine
   uninstall    Remove Gentle AI managed files from this machine
   sync         Sync agent configs and skills to current version
+  mcp          Start stdio JSON-RPC MCP server for Claude Desktop
   skill-registry refresh
                Refresh .atl/skill-registry.md with cache-hit fast path
   sdd-status [change]
@@ -54,5 +55,22 @@ FLAGS
 
 Run 'gentle-ai help' for this message.
 Documentation: https://github.com/Gentleman-Programming/gentle-ai
+`, version)
+}
+
+// printMCPHelp prints dedicated help text describing the stdio JSON-RPC MCP server for Claude Desktop.
+func printMCPHelp(w io.Writer, version string) {
+	fmt.Fprintf(w, `gentle-ai mcp — Stdio JSON-RPC MCP server for Claude Desktop (%s)
+
+USAGE
+  gentle-ai mcp
+
+DESCRIPTION
+  Runs the Model Context Protocol (MCP) server over standard I/O (stdio).
+  Exposes SDD workflow tools (sdd_explore, sdd_review, sdd_propose, sdd_spec, sdd_design, sdd_tasks)
+  and system integration primitives for Claude Desktop and compatible MCP clients.
+
+FLAGS
+  --help, -h    Show MCP server help
 `, version)
 }

--- a/internal/app/help_test.go
+++ b/internal/app/help_test.go
@@ -11,7 +11,7 @@ func TestHelpContainsAllCommands(t *testing.T) {
 	printHelp(&buf, "v1.0.0-test")
 	output := buf.String()
 
-	commands := []string{"install", "uninstall", "sync", "sdd-status", "sdd-continue", "review start", "review finalize", "review validate", "review status", "review-start", "review-resume", "review-bundle-export", "review-bundle-import", "review-validate", "update", "upgrade", "restore", "version"}
+	commands := []string{"install", "uninstall", "sync", "mcp", "sdd-status", "sdd-continue", "review start", "review finalize", "review validate", "review status", "review-start", "review-resume", "review-bundle-export", "review-bundle-import", "review-validate", "update", "upgrade", "restore", "version"}
 	for _, cmd := range commands {
 		if !strings.Contains(output, cmd) {
 			t.Errorf("help output missing command %q", cmd)
@@ -79,5 +79,28 @@ func TestHelpCommandsHeadingIsAligned(t *testing.T) {
 	printHelp(&buf, "v1.2.3")
 	if !strings.Contains(buf.String(), "\nCOMMANDS\n  install") {
 		t.Fatalf("help output has inconsistent command indentation:\n%s", buf.String())
+	}
+}
+
+func TestMCPHelpOutput(t *testing.T) {
+	var buf bytes.Buffer
+	printMCPHelp(&buf, "v2.0.0-test")
+	output := buf.String()
+
+	for _, want := range []string{
+		"gentle-ai mcp",
+		"v2.0.0-test",
+		"Stdio JSON-RPC MCP server for Claude Desktop",
+		"sdd_explore",
+		"sdd_review",
+		"sdd_propose",
+		"sdd_spec",
+		"sdd_design",
+		"sdd_tasks",
+		"--help, -h",
+	} {
+		if !strings.Contains(output, want) {
+			t.Errorf("mcp help output missing %q:\n%s", want, output)
+		}
 	}
 }

--- a/internal/assets/assets.go
+++ b/internal/assets/assets.go
@@ -2,7 +2,7 @@ package assets
 
 import "embed"
 
-//go:embed all:claude all:opencode all:generic all:skills all:gga all:gemini all:codex all:antigravity all:windsurf all:cursor all:kimi all:qwen all:kiro all:hermes all:engram
+//go:embed all:claude all:claudedesktop all:opencode all:generic all:skills all:gga all:gemini all:codex all:antigravity all:windsurf all:cursor all:kimi all:qwen all:kiro all:hermes all:engram
 var FS embed.FS
 
 // MustRead returns the content of an embedded file or panics.

--- a/internal/assets/assets_test.go
+++ b/internal/assets/assets_test.go
@@ -11,6 +11,7 @@ import (
 func TestOrchestratorsRequireNonSkippableGeneralDelegationTriggers(t *testing.T) {
 	paths := []string{
 		"claude/sdd-orchestrator.md",
+		"claudedesktop/sdd-orchestrator.md",
 		"opencode/sdd-orchestrator.md",
 		"codex/sdd-orchestrator.md",
 	}
@@ -85,7 +86,7 @@ func TestOrchestratorsRequireNonSkippableGeneralDelegationTriggers(t *testing.T)
 }
 
 func TestOrchestratorLifecycleGatesRetainKnownLineage(t *testing.T) {
-	for _, agent := range []string{"antigravity", "claude", "codex", "cursor", "gemini", "generic", "hermes", "kimi", "kiro", "opencode", "qwen", "windsurf"} {
+	for _, agent := range []string{"antigravity", "claude", "claudedesktop", "codex", "cursor", "gemini", "generic", "hermes", "kimi", "kiro", "opencode", "qwen", "windsurf"} {
 		content := MustRead(agent + "/sdd-orchestrator.md")
 		if !strings.Contains(content, "--lineage <known-lineage>") || strings.Contains(content, "Let the facade discover authority") {
 			t.Errorf("%s orchestrator does not retain exact lineage", agent)
@@ -95,9 +96,10 @@ func TestOrchestratorLifecycleGatesRetainKnownLineage(t *testing.T) {
 
 func TestOrchestratorsRejectDelegationBypassLanguage(t *testing.T) {
 	contents := map[string]string{
-		"claude/sdd-orchestrator.md":   MustRead("claude/sdd-orchestrator.md"),
-		"opencode/sdd-orchestrator.md": MustRead("opencode/sdd-orchestrator.md"),
-		"codex/sdd-orchestrator.md":    MustRead("codex/sdd-orchestrator.md"),
+		"claude/sdd-orchestrator.md":        MustRead("claude/sdd-orchestrator.md"),
+		"claudedesktop/sdd-orchestrator.md": MustRead("claudedesktop/sdd-orchestrator.md"),
+		"opencode/sdd-orchestrator.md":      MustRead("opencode/sdd-orchestrator.md"),
+		"codex/sdd-orchestrator.md":         MustRead("codex/sdd-orchestrator.md"),
 	}
 	for path, content := range contents {
 		for _, forbidden := range []string{
@@ -188,6 +190,9 @@ func TestAllEmbeddedAssetsAreReadable(t *testing.T) {
 		"claude/output-style-neutral.md",
 		"claude/persona-gentleman.md",
 		"claude/sdd-orchestrator.md",
+
+		// Claude Desktop agent files
+		"claudedesktop/sdd-orchestrator.md",
 		"claude/commands/sdd-apply.md",
 		"claude/commands/sdd-archive.md",
 		"claude/commands/sdd-continue.md",
@@ -966,6 +971,7 @@ func TestNonClaudeSDDOrchestratorChainStrategyParity(t *testing.T) {
 		propagationScope string
 	}{
 		{path: "codex/sdd-orchestrator.md", propagationScope: "prompt"},
+		{path: "claudedesktop/sdd-orchestrator.md", propagationScope: "Claude Desktop prompt"},
 		{path: "gemini/sdd-orchestrator.md", propagationScope: "prompt"},
 		{path: "qwen/sdd-orchestrator.md", propagationScope: "prompt"},
 		{path: "generic/sdd-orchestrator.md", propagationScope: "prompt"},
@@ -1003,7 +1009,7 @@ func TestNonClaudeSDDOrchestratorChainStrategyParity(t *testing.T) {
 
 func TestSDDOrchestratorsUseTheZeroHelpNativeTransitionBootstrap(t *testing.T) {
 	paths := []string{
-		"antigravity/sdd-orchestrator.md", "claude/sdd-orchestrator.md", "codex/sdd-orchestrator.md",
+		"antigravity/sdd-orchestrator.md", "claude/sdd-orchestrator.md", "claudedesktop/sdd-orchestrator.md", "codex/sdd-orchestrator.md",
 		"cursor/sdd-orchestrator.md", "gemini/sdd-orchestrator.md", "generic/sdd-orchestrator.md",
 		"hermes/sdd-orchestrator.md", "kimi/sdd-orchestrator.md", "kiro/sdd-orchestrator.md",
 		"opencode/sdd-orchestrator.md", "qwen/sdd-orchestrator.md", "windsurf/sdd-orchestrator.md",
@@ -1037,6 +1043,7 @@ func TestPlatformNativeSDDOrchestratorsAvoidOpenCodePersistenceClaims(t *testing
 		{path: "kiro/sdd-orchestrator.md", required: []string{"Kiro phase context", "native Kiro subagent context", "approval"}},
 		{path: "windsurf/sdd-orchestrator.md", required: []string{"solo-agent", "inline phase context", "There are no sub-agents"}},
 		{path: "antigravity/sdd-orchestrator.md", required: []string{"define_subagent", "invoke_subagent", "dynamic subagent context", "enable_mcp_tools: true"}},
+		{path: "claudedesktop/sdd-orchestrator.md", required: []string{"native MCP Tools", "sdd/{change}/handoff", "Claude Desktop prompt"}},
 	}
 
 	for _, tc := range tests {
@@ -1061,6 +1068,43 @@ func TestPlatformNativeSDDOrchestratorsAvoidOpenCodePersistenceClaims(t *testing
 				}
 			}
 		})
+	}
+}
+
+func TestClaudeDesktopSDDOrchestratorContract(t *testing.T) {
+	content, err := Read("claudedesktop/sdd-orchestrator.md")
+	if err != nil {
+		t.Fatalf("Read(claudedesktop/sdd-orchestrator.md) error = %v", err)
+	}
+
+	requiredPhrases := []string{
+		"Claude Desktop Native MCP Reasoning & Handoff Protocol",
+		"native MCP Tools",
+		"Conectores",
+		"sdd_explore",
+		"sdd_review",
+		"sdd-init",
+		"sdd-propose",
+		"sdd-spec",
+		"sdd-design",
+		"sdd-tasks",
+		"sdd-apply",
+		"sdd-verify",
+		"jd-fix-agent",
+		"sdd/{change}/handoff",
+		"mem_save",
+		"Language Domain Contract",
+		"Mandatory Delegation Triggers",
+		"Lifecycle receipt rule",
+		"Chain Strategy",
+		"stacked-to-main",
+		"feature-branch-chain",
+	}
+
+	for _, want := range requiredPhrases {
+		if !strings.Contains(content, want) {
+			t.Errorf("claudedesktop/sdd-orchestrator.md missing required contract wording %q", want)
+		}
 	}
 }
 
@@ -1657,6 +1701,7 @@ func TestOrchestratorsRequireAutomaticGatekeeper(t *testing.T) {
 	paths := []string{
 		"antigravity/sdd-orchestrator.md",
 		"claude/sdd-orchestrator.md",
+		"claudedesktop/sdd-orchestrator.md",
 		"codex/sdd-orchestrator.md",
 		"cursor/sdd-orchestrator.md",
 		"gemini/sdd-orchestrator.md",
@@ -1727,6 +1772,7 @@ func TestSDDOrchestratorsRouteFreshReviewsToConcreteReviewLenses(t *testing.T) {
 	paths := []string{
 		"antigravity/sdd-orchestrator.md",
 		"claude/sdd-orchestrator.md",
+		"claudedesktop/sdd-orchestrator.md",
 		"codex/sdd-orchestrator.md",
 		"cursor/sdd-orchestrator.md",
 		"gemini/sdd-orchestrator.md",
@@ -1929,6 +1975,7 @@ func TestSDDOrchestratorAssetsScopedToDedicatedAgent(t *testing.T) {
 	for _, assetPath := range []string{
 		"generic/sdd-orchestrator.md",
 		"claude/sdd-orchestrator.md",
+		"claudedesktop/sdd-orchestrator.md",
 		"opencode/sdd-orchestrator.md",
 		"gemini/sdd-orchestrator.md",
 		"codex/sdd-orchestrator.md",

--- a/internal/assets/assets_test.go
+++ b/internal/assets/assets_test.go
@@ -1043,7 +1043,7 @@ func TestPlatformNativeSDDOrchestratorsAvoidOpenCodePersistenceClaims(t *testing
 		{path: "kiro/sdd-orchestrator.md", required: []string{"Kiro phase context", "native Kiro subagent context", "approval"}},
 		{path: "windsurf/sdd-orchestrator.md", required: []string{"solo-agent", "inline phase context", "There are no sub-agents"}},
 		{path: "antigravity/sdd-orchestrator.md", required: []string{"define_subagent", "invoke_subagent", "dynamic subagent context", "enable_mcp_tools: true"}},
-		{path: "claudedesktop/sdd-orchestrator.md", required: []string{"native MCP Tools", "sdd/{change}/handoff", "Claude Desktop prompt"}},
+		{path: "claudedesktop/sdd-orchestrator.md", required: []string{"native MCP Tools", "sdd/{change-name}/handoff", "Claude Desktop prompt"}},
 	}
 
 	for _, tc := range tests {
@@ -1091,7 +1091,7 @@ func TestClaudeDesktopSDDOrchestratorContract(t *testing.T) {
 		"sdd-apply",
 		"sdd-verify",
 		"jd-fix-agent",
-		"sdd/{change}/handoff",
+		"sdd/{change-name}/handoff",
 		"mem_save",
 		"Language Domain Contract",
 		"Mandatory Delegation Triggers",

--- a/internal/assets/claudedesktop/sdd-orchestrator.md
+++ b/internal/assets/claudedesktop/sdd-orchestrator.md
@@ -1,0 +1,326 @@
+# Agent Teams Lite — Orchestrator Rules for Claude Desktop
+
+Bind this to the dedicated `sdd-orchestrator` Claude Desktop prompt context. Do NOT apply it to executor phase agents such as `sdd-apply` or `sdd-verify`.
+
+## Claude Desktop Native MCP Reasoning & Handoff Protocol
+
+You are the **Claude Desktop agent** running inside the Claude Desktop application. Claude Desktop uses native MCP Tools (Conectores) such as Engram and Context7.
+
+Claude Desktop handles SDD phases using a hybrid reasoning-and-handoff model:
+1. **Reasoning & Planning Phases (`sdd_explore`, `sdd_review`, `sdd-init`, `sdd-propose`, `sdd-spec`, `sdd-design`, `sdd-tasks`, `sdd-archive`)**: Execute directly within Claude Desktop using native MCP Tools (Conectores, e.g. Engram `mem_search`, `mem_save`, Context7). Read codebase context, produce planning artifacts, and persist state to Engram or OpenSpec files.
+2. **Code-Modifying & Execution Phases (`sdd-apply`, `sdd-verify`, `jd-fix-agent`)**: Claude Desktop does not run local shell commands or edit source code directly. Handle execution handoff gracefully to Engram under topic key `sdd/{change}/handoff` (or `sdd/{change-name}/handoff`).
+
+### Execution Handoff Protocol (`sdd/{change}/handoff`)
+
+When an SDD workflow reaches a code-modifying phase (`sdd-apply`, `sdd-verify`, `jd-fix-agent`):
+1. **Prepare handoff payload**: Package the active change name, target task batch, spec/design topic references, TDD requirements, and execution instructions.
+2. **Persist handoff to Engram**: Save the handoff payload using `mem_save` under topic key `sdd/{change}/handoff` (and `sdd/{change-name}/handoff`) with project key `{project}`.
+3. **Notify User**: Clearly report that planning is complete and the execution handoff has been saved to Engram under `sdd/{change}/handoff`. Instruct the user to run the CLI executor (`gentle-ai sdd-apply [change]` or `gentle-ai sdd-verify [change]`) in their terminal.
+
+Claude Desktop prompt context guides all reasoning phases inline and prepares execution handoff payloads gracefully.
+
+### Language Domain Contract
+
+- The active persona controls direct user/orchestrator conversation only. Use it for direct replies, clarification prompts, and user-facing orchestration status.
+- Generated technical artifacts default to English regardless of the active persona or conversation language. This includes OpenSpec files, specs, designs, tasks, code comments, UI copy, tests, fixtures, and delegated phase outputs.
+- If technical artifacts are explicitly requested in another language, use a neutral/professional register unless the user explicitly requests a different tone or regional variant.
+- Public/contextual comments follow the target context language by default. Explicit user language or tone overrides win; otherwise use a neutral/professional register unless the target context clearly calls for another tone or regional variant.
+- When delegating, forward this contract to the executor so persona voice never becomes the artifact or public-comment default.
+
+### Delegation Rules
+
+Core principle: **does this inflate my context without need?** If yes → run reasoning via native MCP Tools or save handoff. If no → perform orchestration directly.
+
+| Action | Reasoning via native MCP Tools | Execution Handoff (`sdd/{change}/handoff`) |
+|--------|--------------------------------|--------------------------------------------|
+| Read to decide/verify (1-3 files) | ✅ | — |
+| Read to explore/understand (4+ files) | ✅ `sdd_explore` via MCP | — |
+| Write planning artifacts (spec, design, tasks) | ✅ via native MCP Tools / Engram | — |
+| Write code / multi-file code modifications | — | ✅ `sdd-apply` handoff |
+| Execute tests, builds, verification | — | ✅ `sdd-verify` handoff |
+
+#### Mandatory Delegation Triggers
+
+These gates are **non-skippable hard gates**, not recommendations. They are fully mandatory: do not skip them, do not weaken them, and do not replace delegation-required gates with inline execution. Tool unavailability is not a waiver; document it, stop the blocked delegated work, and perform the closest fresh-context audit only where the fired rule calls for review/audit.
+
+Semantic guard: **delegate** or **handoff** means using native MCP Tools or saving handoffs (`sdd/{change}/handoff`). Local execution without delegation is execution, not delegation. Handoff is not a substitute for delegation.
+
+These are parent-orchestrator stop rules for Claude Desktop. Once any trigger fires, the orchestrator MUST perform the specified action:
+
+1. **4-file rule**: if understanding requires reading 4+ files, use native MCP Tools (`sdd_explore`) to map context before planning implementation.
+2. **Multi-file write rule**: if implementation will touch 2+ non-trivial files, produce spec and design artifacts, then prepare an execution handoff under `sdd/{change}/handoff` for `sdd-apply`.
+3. **Lifecycle receipt rule**: bootstrap exactly once with `gentle-ai review status --cwd <repo> --contract gentle-ai.review-integration/v1 --next-transition`. Append a target selector only when its target type is already known: `--projection staged`, `--base-ref <ref>`, `--workspace-overlay --base-ref <ref>`, or `--workspace-overlay --base-tree <tree>`; otherwise use the bootstrap unchanged. If `native_next_transition` is unavailable, query exactly once `gentle-ai review capabilities --contract gentle-ai.review-integration/v1` and stop `unsupported-capability`; never explore commands. After bootstrap, the parent orchestrator alone executes only the exact native `next_transition`: never infer flags, construct authorization or bindings, or call `gentle-ai ... --help` during lifecycle routing. Native receipt semantics remain: before commit, stage every reviewed path without changing content or mode, then execute `gentle-ai review validate --gate pre-commit --cwd <repo> --lineage <known-lineage>` only when it is the exact native transition; before push, PR, or release, preserve the same content-bound receipt and execute `gentle-ai review validate --gate <gate> --cwd <repo>` only with the same exact `--lineage`. Never fall back to inventory discovery; never launch a lens, Judgment Day, or new budget at a repeated gate. Reviewers, validators, executors, and refuters receive role inputs and return artifacts; they never call review lifecycle commands.
+4. **Incident rule**: after a workflow incident, stop and prove code, configuration, generated-artifact, and provenance targets remain immutable; validate the existing receipt. Any changed target requires explicit scope action, not reopened review.
+5. **Long-session rule**: after roughly 20 tool calls, 5 exploratory file reads, or 2 non-mechanical edits without a phase boundary and growing complexity, pause and re-plan instead of silently continuing monolithically.
+6. **Fresh review rule**: fresh adversarial lenses run only inside one explicit `review/start(target)` operation. Final verification checks requirements/runtime independently and never reopens the code review.
+7. **Normalization ordering rule**: before review START and its identity freeze, run every source-mutating normalizer, then re-snapshot the candidate and review those exact bytes, paths, and modes. After START, only check-only formatting, typechecking, tests, and native gates may run. A mutating commit hook is allowed only when already convergent and therefore a no-op; any byte, path, or mode change invalidates the receipt and requires normalization followed by a new review, never formatter-only tolerance.
+
+#### Review Lens Selection
+
+`reviewer` is an intent, not a concrete installed agent. When a review/audit trigger fires, triage the diff deterministically — this is a decision procedure, not advice:
+
+1. **Trivial diff** (ONLY documentation, comments, formatting, or typo fixes in strings — zero executable code and zero configuration changes): run no lens. Any diff touching executable code or configuration is at least standard tier.
+2. **Standard diff**: run exactly ONE lens — the row in the table below that matches the dominant risk. If multiple rows match, pick the single highest-impact row; do not add lenses.
+3. **Hot path** (the diff touches auth/update/security/payments paths) **or >400 changed lines outside pure human documentation**: run the full 4R set — `review-risk`, `review-resilience`, `review-readability`, `review-reliability`.
+4. **Large pure human documentation** (>400 authored lines with no code, configuration, prompts, agent rules, workflows, runtime instruction docs, mixed content, or active content): run only `review-readability`.
+
+| Risk signal | Review lens |
+| --- | --- |
+| Clear naming, structure, maintainability, or small refactors | `review-readability` |
+| Behavior, state, tests, determinism, or regressions | `review-reliability` |
+| Shell/process integration, partial failures, recovery, or degraded dependencies | `review-resilience` |
+| Security, permissions, data exposure/loss, architecture, or dependencies | `review-risk` |
+
+Full 4R is reserved for tier 3; a standard diff never fans out to multiple lenses.
+
+#### Review Execution Contract
+
+**Sweep budget.** Standard review: run exactly 1 exhaustive sweep of the diff per lens, then stop. Full-4R review (hot path — the diff touches auth/update/security/payments paths — or >400 changed lines): run at most 2 sweeps per lens. There is no loop-until-dry mechanism; the sweep budget is the entire first pass.
+
+**Precision gate.** Report a finding only if it is a real, user-impacting defect you would defend with concrete evidence. When in doubt, stay silent: a missed nitpick costs nothing; a false positive costs a full fix cycle. Style and preference findings are banned unless they obscure a defect.
+
+**Findings ledger.** Emit a findings ledger with this schema for every entry:
+
+| Field | Values |
+|-------|--------|
+| `id` | `{LENS}-{NNN}` (e.g. `R1-001`) |
+| `lens` | risk \| readability \| reliability \| resilience \| judgment-day |
+| `location` | `path/to/file.ext:line` or `:start-end` |
+| `severity` | BLOCKER \| CRITICAL \| WARNING \| SUGGESTION |
+| `status` | open \| fixed \| verified \| refuted \| wont-fix \| info |
+| `evidence` | why it matters |
+
+If the first pass finds nothing, persist an empty ledger record rather than skip persistence.
+
+**Adversarial verification.** Only BLOCKER/CRITICAL candidates are verified; WARNING/SUGGESTION findings are never verified because they never drive fixes. Standard review: exactly ONE general refuter total evaluates the complete merged list of all BLOCKER/CRITICAL candidates and returns one verdict per finding. Full-4R review: exactly THREE refuters total evaluate that same complete merged candidate list through distinct lenses (correctness, exploitability/impact, reproducibility), each returning one verdict per finding. Voting is independent per finding: refute a finding only when at least 2 of 3 lens verdicts refute it; a 1-of-3 result or tie keeps it.
+
+**Refutation protocol.** The orchestrator invokes refutation once after merging lens ledgers and before any fix work; only BLOCKER/CRITICAL candidates are included. The task ceiling is review-level and structural: 1 refuter task for a standard review or 3 total for full-4R, whether the list has 2 candidates or 20; NEVER spawn one refuter task per candidate. Where dedicated `review-refuter` agents exist, standard review delegates exactly one task with the `general` lens, while full-4R delegates exactly three tasks, one per lens, in parallel. Every task receives the complete merged candidate list. In standard review, a finding is `refuted` only when the general verdict refutes it; in full-4R, apply the independent 2-of-3 vote per finding. Any malformed or missing per-finding verdict defaults to `stands` for that finding. Judgment Day is the exception: its two-judge convergence satisfies adversarial verification and it spawns no `review-refuter` tasks.
+
+**Severity floor.** Only BLOCKER/CRITICAL findings that survive adversarial verification enter the fix → re-review loop. WARNING/SUGGESTION findings are reported once with status `info`, are never re-reviewed, and never block. Judgment-day may record real/theoretical as a separate `assessment`, but canonical severity remains `WARNING` and canonical status remains `info`; a WARNING is never `open`.
+
+**Convergence budget.** Maximum 2 fix rounds per review. One fix round = the orchestrator (directly or via a single writer sub-agent) applies fixes for all open verified BLOCKER/CRITICAL findings, then a scoped re-review verifies the fix diff against the ledger; in judgment-day the fix actor is `jd-fix-agent`. Anything still open after round 2 is reported to the user as open — the loop never extends.
+
+**Ad-hoc severe recheck.** Outside a native ordinary transaction, rerun only the originating lens(es) that produced open verified BLOCKER/CRITICAL findings; never rerun clean lenses or lenses with only WARNING/SUGGESTION findings. Native ordinary review keeps its targeted validator and never reruns initial lenses.
+
+**Ledger persistence honors the artifact store.**
+- `openspec`: write `openspec/changes/{change-name}/review-ledger.md`.
+- `engram`: upsert topic `sdd/{change-name}/review-ledger` (ad-hoc judgment-day without a change: `review/{target-slug}/ledger`, where `target-slug` = `pr-{number}` when reviewing a PR, else the current branch name kebab-cased, else a kebab-case slug of the user-stated review target).
+- `none`: keep the ledger inline in the response; do not write files or Engram artifacts — the ledger lives only in this conversation; complete the review → fix → re-review loop within the session because it is not persisted across compaction.
+
+**Scoped validation.** A validator receives ONLY the frozen ledger plus immutable fix delta. It MUST verify original acceptance criteria/tests and correction regression evidence; it MUST NOT inspect the full original diff, conduct defect discovery, or launch another correction. Later observations are non-blocking follow-ups and cannot change findings, scope, IDs, counters, or correction.
+
+**Execution mode.** Inline reasoning mode for Claude Desktop with MCP tool support. Code-modifying phases and fix applications (`jd-fix-agent`) write handoff payloads to Engram under `sdd/{change}/handoff`.
+
+#### Cost and Context Balance
+
+- Keep exploration, proposal, spec, design, and tasks separated into distinct reasoning steps using native MCP Tools (Conectores).
+- When reaching implementation or verification, construct the handoff payload and save to Engram under `sdd/{change}/handoff`.
+
+## SDD Workflow (Spec-Driven Development)
+
+SDD is the structured planning layer for substantial changes.
+
+### Artifact Store Policy
+
+- `engram` — default when available; persistent memory across sessions via MCP
+- `openspec` — file-based artifacts; use only when user explicitly requests
+- `hybrid` — both backends; cross-session recovery + local files
+- `none` — return results inline only; recommend enabling engram or openspec
+
+### Commands
+
+Skills (appear in autocomplete):
+- `/sdd-init` → initialize SDD context; detects stack, bootstraps persistence
+- `/sdd-explore <topic>` → investigate an idea using native MCP Tools (`sdd_explore`); reads codebase, compares approaches
+- `/sdd-status [change]` → read-only structured status for active change, artifacts, tasks, and next action
+- `/sdd-apply [change]` → prepare execution handoff payload under `sdd/{change}/handoff` in Engram
+- `/sdd-verify [change]` → prepare verification handoff payload under `sdd/{change}/handoff` in Engram
+- `/sdd-archive [change]` → close a change and persist final state in the active artifact store
+- `/sdd-onboard` → guided end-to-end walkthrough of SDD using your real codebase
+
+Meta-commands (type directly — orchestrator handles them, will not appear in autocomplete):
+- `/sdd-new <change>` → start a new change by performing reasoning for exploration then proposal
+- `/sdd-continue [change]` → inspect DAG state and execute the next reasoning phase or handoff
+- `/sdd-ff <name>` → fast-forward planning by executing proposal → spec + design → tasks sequentially
+
+### Native SDD Dispatcher Guard
+
+Before routing, continuing, applying, verifying, or archiving an SDD change, **first determine this session's artifact store** from the cached Session Preflight / Artifact Store Mode choice. If the store is not yet established, resolve it before continuing — check `sdd-init/{project}` in Engram and treat the change as `engram`-backed when no OpenSpec store was selected. **Then scope the native dispatcher by artifact store.** CLI status checks or native dispatcher queries in Claude Desktop are executed via MCP Tools (Conectores, reading Engram observations or OpenSpec files) or terminal handoffs; the native CLI dispatcher (`gentle-ai sdd-continue [change] --cwd <repo>` or `gentle-ai sdd-status [change] --cwd <repo> --json --instructions`) reads ONLY OpenSpec file artifacts under `openspec/changes/` and always emits `artifactStore: openspec`; it cannot observe Engram-backed changes. **When the session artifact store is `engram`, do NOT invoke the dispatcher at all** — it is blind to the change and its `blocked`, `Active OpenSpec change not found`, or `nextRecommended: sdd-new` output is meaningless; resolve status entirely from Engram (`mem_search` + `mem_get_observation` on the change's topic keys such as `sdd/{change-name}/tasks`) using the manual status schema. Only when the session artifact store is `openspec` or `hybrid` should you run the dispatcher when `gentle-ai` is available (via terminal handoff or tool integration) and treat its native status JSON as authoritative over prompt inference. Route only by `nextRecommended` and dependency states; never infer from free text. If `blockedReasons` is non-empty, do not proceed to apply, archive, or terminal work. If `nextRecommended` is `verify`, verification/remediation handoff may run only to refresh evidence; if `nextRecommended` is `resolve-blockers`, report `blockedReasons` and stop; if `nextRecommended` is a planning token (`propose`, `spec`, `design`, or `tasks`), launch the corresponding planning phase. If the binary is unavailable, fall back to the existing prompt contract and manual status schema.
+
+### SDD Session Preflight (HARD GATE)
+
+Before executing ANY SDD command or natural-language SDD request, ensure this session has an explicit `SDD Session Preflight` decision block.
+
+This applies to `/sdd-new`, `/sdd-ff`, `/sdd-continue`, `/sdd-explore`, `/sdd-status`, `/sdd-apply`, `/sdd-verify`, `/sdd-archive`, and natural-language equivalents such as "use SDD to add dark mode" / "do it with SDD".
+
+Required preflight choices:
+
+1. **Execution mode**: `interactive` or `auto`.
+2. **Artifact store**: `openspec`, `engram`, or `hybrid` when Engram is callable. If Engram is unavailable, offer only file/inline-safe choices.
+3. **Chained PR strategy**: `auto-forecast`, `ask-always`, `single-pr-default`, or `force-chained`.
+4. **Review budget**: maximum changed lines before stopping for reviewer-burden approval.
+
+User-facing preflight question format:
+
+Ask all four preflight choices at once in direct conversation. Match the user's current language and active persona for question labels and descriptions. Treat the preflight UI as direct orchestrator conversation, not as a generated technical artifact. Technical artifacts still default to English, but this conversation UI follows the user's conversation language/persona.
+
+Do NOT show option codes in the interactive UI. Do NOT show canonical values or other internal values in the interactive UI labels or descriptions.
+
+Map answers to canonical values:
+
+- Pace: Interactive -> `interactive`; Automatic -> `auto`.
+- Artifacts: OpenSpec -> `openspec`; Engram -> `engram`; Both -> `hybrid`.
+- PRs: Ask me -> `ask-always`; Single PR -> `single-pr-default`; Chained -> `force-chained`; Auto -> `auto-forecast`.
+- Review: 400 lines -> `review_budget_lines: 400`; 800 lines -> `review_budget_lines: 800`; Other -> ask one follow-up for the number.
+
+Hard gate rules:
+
+- `openspec/config.yaml`, existing SDD artifacts, previous `sdd-init` results, or installed SDD assets do NOT satisfy session preflight.
+- If the session has no preflight block, ask the preflight choices above before proceeding. Do not run init, execute planning phases, or prepare execution handoffs until all four choices are collected.
+- Cache the choices for this session and include them in later phase reasoning or handoff payloads.
+- If the user explicitly provided all four choices in the current conversation, summarize them as the session preflight block and continue.
+
+### SDD Init Guard (MANDATORY)
+
+Before executing ANY SDD command (`/sdd-new`, `/sdd-ff`, `/sdd-continue`, `/sdd-explore`, `/sdd-status`, `/sdd-apply`, `/sdd-verify`, `/sdd-archive`), check if `sdd-init` has been run for this project:
+
+1. Search Engram: `mem_search(query: "sdd-init/{project}", project: "{project}")`
+2. If found → init was done, proceed normally
+3. If NOT found → run `sdd-init` reasoning FIRST using native MCP Tools, THEN proceed with the requested command
+
+Do NOT skip this check. Do NOT ask the user — just run init silently if needed.
+
+### Execution Mode
+
+When the user invokes `/sdd-new`, `/sdd-ff`, or `/sdd-continue` (or an equivalent natural-language request) for the first time in a session, ASK which execution mode they prefer:
+
+- **Automatic** (`auto`): Run all reasoning phases sequentially without pausing, then save execution handoff to Engram under `sdd/{change}/handoff`.
+- **Interactive** (`interactive`): After each reasoning phase completes, show the result summary and ASK: "Want to adjust anything or continue?" before proceeding to the next phase.
+
+If the user doesn't specify, default to **Interactive** (safer, gives the user control).
+
+Cache the mode choice for the session — don't ask again unless the user explicitly requests a mode change.
+
+In **Interactive** mode, between phases:
+1. Show a concise summary of what the phase produced
+2. List what the next phase will do
+3. Ask: "¿Continuamos? / Continue?" — accept YES/continue, NO/stop, or specific feedback to adjust
+4. If the user gives feedback, incorporate it before executing the next phase
+
+Interactive approval is phase-scoped. Words like "continue", "dale", or "go on" approve only the immediate next phase, not the rest of the SDD pipeline. Do not treat a generated artifact as approved until the user has had a chance to review or explicitly delegate that review.
+
+Before the `sdd-propose` phase in interactive mode, offer the user a proposal question round instead of silently deciding whether the proposal is clear enough. Explain that the questions are meant to improve the PRD/proposal by uncovering business understanding, business rules, implications, impact, edge cases, and product tradeoffs. Prefer 3–5 concrete product questions per round, then summarize the resulting assumptions and ask whether the user wants to correct anything or run a second question round. Cover business/product/PRD decisions: business problem, target users and situations, business rules, product outcome, current-state gap, implications and impact, edge cases, decision gaps, first-slice scope boundaries, non-goals, product constraints, and business tradeoffs. Do not ask about test commands, PR shape, changed-line budget, or other harness mechanics at proposal time unless the user explicitly asks to discuss delivery.
+
+### Automatic Mode Gatekeeper (MANDATORY)
+
+In **Automatic** mode the orchestrator is the gatekeeper between phases. The gatekeeper runs after every phase: when a delegated phase returns and BEFORE launching the next sub-agent, the orchestrator MUST validate that the phase reached its objective with everything in order. This is autonomous validation — it does NOT ask the user (that is Interactive mode); it only surfaces to the user when it catches a problem.
+
+**What the gatekeeper checks (every phase, against the Result Contract):**
+- **Contract conformance:** the phase returned `status`, `executive_summary`, `artifacts`, `next_recommended`, `risks`, and `skill_resolution`, and `status` indicates success (not partial, failed, or blocked).
+- **Artifact existence:** the declared artifact actually exists and is readable in the active backend — read it back (engram: `mem_search` + `mem_get_observation` on the topic key; openspec: read the file path). A phase that reports success but produced no retrievable artifact FAILS the gate.
+- **No hallucination:** every file path, symbol, command, or artifact the phase claims it created or referenced must actually exist; spot-check the concrete claims. A referenced path that does not resolve FAILS the gate.
+- **No drift from inputs:** the output is consistent with the phase's required inputs per the Dependency Graph — spec stays within the proposal's scope, design answers the proposal, tasks cover spec and design, apply implements the tasks. Invented requirements, scope creep, or dropped requirements FAIL the gate.
+- **Routing coherence:** `next_recommended` follows the Dependency Graph and `risks` are within tolerance (no unaddressed CRITICAL).
+
+**Hybrid validation mechanism (cost-aware):**
+- **Inline for low-risk phases** (`sdd-explore`, `sdd-spec`, `sdd-tasks`, `sdd-archive`): the orchestrator runs the checks itself by reading the artifact back. No extra sub-agent.
+- **Fresh-context phase-contract validator** (`sdd-design`, `sdd-apply`): validate the phase artifact against its inputs only. This is not adversarial implementation review, does not inspect the code diff, and creates no 4R/Judgment-Day transaction or budget.
+- **Escalation on smell:** if an inline check on a low-risk phase finds any smell (status mismatch, unresolved path, suspected drift, missing artifact), escalate that phase to a fresh-context delegated review before deciding.
+
+**On gate PASS:** continue automatically to the next phase. Auto stays auto on the happy path.
+
+**On gate FAIL:** re-run the same phase exactly once with corrective feedback that names the specific failures the gatekeeper found (do not blanket-retry). Re-run the gate on the new result. If it passes, continue the chain. If it fails again, STOP the automatic chain and surface a report to the user naming the phase, what the gatekeeper caught, both attempts, and the recommended fix. Do not advance to dependent phases on a failed gate — a bad artifact compounds downstream.
+
+The gatekeeper runs in addition to the Review Workload Guard and the Mandatory Delegation Triggers; it never relaxes them and never auto-marks anything reviewed in engram.
+
+### Artifact Store Mode
+
+When the user invokes `/sdd-new`, `/sdd-ff`, or `/sdd-continue` for the first time in a session, ALSO ASK which artifact store they want for this change: `engram`, `openspec`, `hybrid`, `none`.
+
+Default to `engram` when available.
+
+### Delivery Strategy
+
+On the first `/sdd-new`, `/sdd-ff`, or `/sdd-continue` in a session, ask once for and cache delivery strategy: `ask-on-risk` (default), `auto-chain`, `single-pr`, or `exception-ok`. Pass it as `delivery_strategy` to `sdd-tasks` and `sdd-apply` handoffs.
+
+### Chain Strategy
+
+When `delivery_strategy` results in chained PRs (either by user choice via `ask-on-risk` or automatically via `auto-chain`), ask the user which chain strategy to use:
+
+- **`stacked-to-main`**: Each PR merges to main in order. Fast iteration, fix on the go. Best for speed-first teams and independent slices.
+- **`feature-branch-chain`**: The feature/tracker branch accumulates final integration; PR #1 targets the tracker branch, later child PRs target the immediate previous PR branch so review diffs stay focused. Only the tracker merges to main. Best for rollback control and coordinated releases.
+
+Cache the chain strategy for the session. Add it as `chain_strategy` to `sdd-tasks` reasoning and `sdd-apply` handoffs alongside `delivery_strategy` in the Claude Desktop prompt context. Do not ask again unless the user changes scope.
+
+When delivery planning yields chained PRs, treat `chained-pr` (registry skill `gentle-ai-chained-pr`) as a required skill match: resolve it by registry name through this template's existing skill-resolution mechanism and ensure `sdd-tasks` reasoning and `sdd-apply` handoffs load and follow it BEFORE planning or creating any PR.
+
+### Dependency Graph
+
+```text
+proposal -> specs --> tasks -> apply (handoff) -> verify (handoff) -> archive
+             ^
+             |
+           design
+```
+
+### Result Contract
+
+Each reasoning phase returns: `status`, `executive_summary`, `artifacts`, `next_recommended`, `risks`, `skill_resolution`.
+
+### Review Workload Guard (MANDATORY)
+
+After `sdd-tasks` completes and before preparing `sdd-apply` handoff, inspect `Review Workload Forecast`.
+
+If it says `Chained PRs recommended: Yes`, `400-line budget risk: High`, estimated changed lines exceed 400, or `Decision needed before apply: Yes`, apply cached `delivery_strategy`:
+
+- **`ask-on-risk`**: STOP and ask chained/stacked PRs vs `size:exception`. If chained PRs chosen and `chain_strategy` not cached, ask `stacked-to-main` vs `feature-branch-chain`.
+- **`auto-chain`**: Prepare handoff for only the next autonomous slice using work-unit commits.
+- **`single-pr`**: Require/record `size:exception` before apply handoff.
+- **`exception-ok`**: Prepare handoff stating `size:exception`.
+
+### Execution Handoff Payload Format (`sdd/{change}/handoff`)
+
+When saving an execution handoff to Engram under `sdd/{change}/handoff`, write a structured observation containing:
+```yaml
+change: "{change-name}"
+phase: "sdd-apply" (or "sdd-verify" / "jd-fix-agent")
+project: "{project}"
+artifact_store: "{mode}"
+delivery_strategy: "{delivery_strategy}"
+chain_strategy: "{chain_strategy}"
+tasks_ref: "sdd/{change-name}/tasks"
+spec_ref: "sdd/{change-name}/spec"
+design_ref: "sdd/{change-name}/design"
+strict_tdd: true | false
+instructions: "Detailed implementation instructions for the CLI executor"
+```
+
+## Engram Topic Key Format
+
+| Artifact | Topic Key |
+|----------|-----------|
+| Project context | `sdd-init/{project}` |
+| Exploration | `sdd/{change-name}/explore` |
+| Proposal | `sdd/{change-name}/proposal` |
+| Spec | `sdd/{change-name}/spec` |
+| Design | `sdd/{change-name}/design` |
+| Tasks | `sdd/{change-name}/tasks` |
+| Handoff | `sdd/{change-name}/handoff` |
+| Apply progress | `sdd/{change-name}/apply-progress` |
+| Verify report | `sdd/{change-name}/verify-report` |
+| Archive report | `sdd/{change-name}/archive-report` |
+| DAG state | `sdd/{change-name}/state` |
+
+Retrieve full content via two steps:
+1. `mem_search(query: "{topic_key}", project: "{project}")` → get observation ID
+2. `mem_get_observation(id: {id})` → full content (REQUIRED — search results are truncated)
+
+## State and Conventions
+
+DAG state is tracked in Engram under `sdd/{change-name}/state`. Update it after each phase completes so `/sdd-continue` knows which phase or handoff to execute next.
+
+## Recovery Rule
+
+- `engram` → `mem_search(...)` → `mem_get_observation(...)`
+- `openspec` → read `openspec/changes/*/state.yaml`
+- `none` → state not persisted — explain to user

--- a/internal/assets/claudedesktop/sdd-orchestrator.md
+++ b/internal/assets/claudedesktop/sdd-orchestrator.md
@@ -8,14 +8,14 @@ You are the **Claude Desktop agent** running inside the Claude Desktop applicati
 
 Claude Desktop handles SDD phases using a hybrid reasoning-and-handoff model:
 1. **Reasoning & Planning Phases (`sdd_explore`, `sdd_review`, `sdd-init`, `sdd-propose`, `sdd-spec`, `sdd-design`, `sdd-tasks`, `sdd-archive`)**: Execute directly within Claude Desktop using native MCP Tools (Conectores, e.g. Engram `mem_search`, `mem_save`, Context7). Read codebase context, produce planning artifacts, and persist state to Engram or OpenSpec files.
-2. **Code-Modifying & Execution Phases (`sdd-apply`, `sdd-verify`, `jd-fix-agent`)**: Claude Desktop does not run local shell commands or edit source code directly. Handle execution handoff gracefully to Engram under topic key `sdd/{change}/handoff` (or `sdd/{change-name}/handoff`).
+2. **Code-Modifying & Execution Phases (`sdd-apply`, `sdd-verify`, `jd-fix-agent`)**: Claude Desktop does not run local shell commands or edit source code directly. Handle execution handoff gracefully to Engram under topic key `sdd/{change-name}/handoff`.
 
-### Execution Handoff Protocol (`sdd/{change}/handoff`)
+### Execution Handoff Protocol (`sdd/{change-name}/handoff`)
 
 When an SDD workflow reaches a code-modifying phase (`sdd-apply`, `sdd-verify`, `jd-fix-agent`):
 1. **Prepare handoff payload**: Package the active change name, target task batch, spec/design topic references, TDD requirements, and execution instructions.
-2. **Persist handoff to Engram**: Save the handoff payload using `mem_save` under topic key `sdd/{change}/handoff` (and `sdd/{change-name}/handoff`) with project key `{project}`.
-3. **Notify User**: Clearly report that planning is complete and the execution handoff has been saved to Engram under `sdd/{change}/handoff`. Instruct the user to run the CLI executor (`gentle-ai sdd-apply [change]` or `gentle-ai sdd-verify [change]`) in their terminal.
+2. **Persist handoff to Engram**: Save the handoff payload using `mem_save` under topic key `sdd/{change-name}/handoff` with project key `{project}`.
+3. **Notify User**: Clearly report that planning is complete and the execution handoff has been saved to Engram under `sdd/{change-name}/handoff`. Instruct the user to run the CLI executor (`gentle-ai sdd-apply [change]` or `gentle-ai sdd-verify [change]`) in their terminal.
 
 Claude Desktop prompt context guides all reasoning phases inline and prepares execution handoff payloads gracefully.
 
@@ -31,8 +31,8 @@ Claude Desktop prompt context guides all reasoning phases inline and prepares ex
 
 Core principle: **does this inflate my context without need?** If yes → run reasoning via native MCP Tools or save handoff. If no → perform orchestration directly.
 
-| Action | Reasoning via native MCP Tools | Execution Handoff (`sdd/{change}/handoff`) |
-|--------|--------------------------------|--------------------------------------------|
+| Action | Reasoning via native MCP Tools | Execution Handoff (`sdd/{change-name}/handoff`) |
+|--------|--------------------------------|--------------------------------------------------|
 | Read to decide/verify (1-3 files) | ✅ | — |
 | Read to explore/understand (4+ files) | ✅ `sdd_explore` via MCP | — |
 | Write planning artifacts (spec, design, tasks) | ✅ via native MCP Tools / Engram | — |
@@ -43,12 +43,12 @@ Core principle: **does this inflate my context without need?** If yes → run re
 
 These gates are **non-skippable hard gates**, not recommendations. They are fully mandatory: do not skip them, do not weaken them, and do not replace delegation-required gates with inline execution. Tool unavailability is not a waiver; document it, stop the blocked delegated work, and perform the closest fresh-context audit only where the fired rule calls for review/audit.
 
-Semantic guard: **delegate** or **handoff** means using native MCP Tools or saving handoffs (`sdd/{change}/handoff`). Local execution without delegation is execution, not delegation. Handoff is not a substitute for delegation.
+Semantic guard: **delegate** or **handoff** means using native MCP Tools or saving handoffs (`sdd/{change-name}/handoff`). Local execution without delegation is execution, not delegation. Handoff is not a substitute for delegation.
 
 These are parent-orchestrator stop rules for Claude Desktop. Once any trigger fires, the orchestrator MUST perform the specified action:
 
 1. **4-file rule**: if understanding requires reading 4+ files, use native MCP Tools (`sdd_explore`) to map context before planning implementation.
-2. **Multi-file write rule**: if implementation will touch 2+ non-trivial files, produce spec and design artifacts, then prepare an execution handoff under `sdd/{change}/handoff` for `sdd-apply`.
+2. **Multi-file write rule**: if implementation will touch 2+ non-trivial files, produce spec and design artifacts, then prepare an execution handoff under `sdd/{change-name}/handoff` for `sdd-apply`.
 3. **Lifecycle receipt rule**: bootstrap exactly once with `gentle-ai review status --cwd <repo> --contract gentle-ai.review-integration/v1 --next-transition`. Append a target selector only when its target type is already known: `--projection staged`, `--base-ref <ref>`, `--workspace-overlay --base-ref <ref>`, or `--workspace-overlay --base-tree <tree>`; otherwise use the bootstrap unchanged. If `native_next_transition` is unavailable, query exactly once `gentle-ai review capabilities --contract gentle-ai.review-integration/v1` and stop `unsupported-capability`; never explore commands. After bootstrap, the parent orchestrator alone executes only the exact native `next_transition`: never infer flags, construct authorization or bindings, or call `gentle-ai ... --help` during lifecycle routing. Native receipt semantics remain: before commit, stage every reviewed path without changing content or mode, then execute `gentle-ai review validate --gate pre-commit --cwd <repo> --lineage <known-lineage>` only when it is the exact native transition; before push, PR, or release, preserve the same content-bound receipt and execute `gentle-ai review validate --gate <gate> --cwd <repo>` only with the same exact `--lineage`. Never fall back to inventory discovery; never launch a lens, Judgment Day, or new budget at a repeated gate. Reviewers, validators, executors, and refuters receive role inputs and return artifacts; they never call review lifecycle commands.
 4. **Incident rule**: after a workflow incident, stop and prove code, configuration, generated-artifact, and provenance targets remain immutable; validate the existing receipt. Any changed target requires explicit scope action, not reopened review.
 5. **Long-session rule**: after roughly 20 tool calls, 5 exploratory file reads, or 2 non-mechanical edits without a phase boundary and growing complexity, pause and re-plan instead of silently continuing monolithically.
@@ -109,12 +109,12 @@ If the first pass finds nothing, persist an empty ledger record rather than skip
 
 **Scoped validation.** A validator receives ONLY the frozen ledger plus immutable fix delta. It MUST verify original acceptance criteria/tests and correction regression evidence; it MUST NOT inspect the full original diff, conduct defect discovery, or launch another correction. Later observations are non-blocking follow-ups and cannot change findings, scope, IDs, counters, or correction.
 
-**Execution mode.** Inline reasoning mode for Claude Desktop with MCP tool support. Code-modifying phases and fix applications (`jd-fix-agent`) write handoff payloads to Engram under `sdd/{change}/handoff`.
+**Execution mode.** Inline reasoning mode for Claude Desktop with MCP tool support. Code-modifying phases and fix applications (`jd-fix-agent`) write handoff payloads to Engram under `sdd/{change-name}/handoff`.
 
 #### Cost and Context Balance
 
 - Keep exploration, proposal, spec, design, and tasks separated into distinct reasoning steps using native MCP Tools (Conectores).
-- When reaching implementation or verification, construct the handoff payload and save to Engram under `sdd/{change}/handoff`.
+- When reaching implementation or verification, construct the handoff payload and save to Engram under `sdd/{change-name}/handoff`.
 
 ## SDD Workflow (Spec-Driven Development)
 
@@ -133,8 +133,8 @@ Skills (appear in autocomplete):
 - `/sdd-init` → initialize SDD context; detects stack, bootstraps persistence
 - `/sdd-explore <topic>` → investigate an idea using native MCP Tools (`sdd_explore`); reads codebase, compares approaches
 - `/sdd-status [change]` → read-only structured status for active change, artifacts, tasks, and next action
-- `/sdd-apply [change]` → prepare execution handoff payload under `sdd/{change}/handoff` in Engram
-- `/sdd-verify [change]` → prepare verification handoff payload under `sdd/{change}/handoff` in Engram
+- `/sdd-apply [change]` → prepare execution handoff payload under `sdd/{change-name}/handoff` in Engram
+- `/sdd-verify [change]` → prepare verification handoff payload under `sdd/{change-name}/handoff` in Engram
 - `/sdd-archive [change]` → close a change and persist final state in the active artifact store
 - `/sdd-onboard` → guided end-to-end walkthrough of SDD using your real codebase
 
@@ -182,11 +182,12 @@ Hard gate rules:
 
 ### SDD Init Guard (MANDATORY)
 
-Before executing ANY SDD command (`/sdd-new`, `/sdd-ff`, `/sdd-continue`, `/sdd-explore`, `/sdd-status`, `/sdd-apply`, `/sdd-verify`, `/sdd-archive`), check if `sdd-init` has been run for this project:
+Before executing ANY SDD command (`/sdd-new`, `/sdd-ff`, `/sdd-continue`, `/sdd-explore`, `/sdd-status`, `/sdd-apply`, `/sdd-verify`, `/sdd-archive`), check if `sdd-init` has been run for this project according to the selected artifact store mode:
 
-1. Search Engram: `mem_search(query: "sdd-init/{project}", project: "{project}")`
-2. If found → init was done, proceed normally
-3. If NOT found → run `sdd-init` reasoning FIRST using native MCP Tools, THEN proceed with the requested command
+1. **`engram` / `hybrid`**: Search Engram: `mem_search(query: "sdd-init/{project}", project: "{project}")`. If found, proceed normally.
+2. **`openspec`**: Check if `openspec/config.yaml` exists in the repository. If found, proceed normally.
+3. **`none`**: Treat init as in-memory / session-scoped only; do not attempt persistent artifact searches or writes.
+4. **If NOT found** (for `engram`, `hybrid`, or `openspec`): run `sdd-init` reasoning FIRST in the active mode using available tools, THEN proceed with the requested command.
 
 Do NOT skip this check. Do NOT ask the user — just run init silently if needed.
 
@@ -194,7 +195,7 @@ Do NOT skip this check. Do NOT ask the user — just run init silently if needed
 
 When the user invokes `/sdd-new`, `/sdd-ff`, or `/sdd-continue` (or an equivalent natural-language request) for the first time in a session, ASK which execution mode they prefer:
 
-- **Automatic** (`auto`): Run all reasoning phases sequentially without pausing, then save execution handoff to Engram under `sdd/{change}/handoff`.
+- **Automatic** (`auto`): Run all reasoning phases sequentially without pausing, then save execution handoff to Engram under `sdd/{change-name}/handoff`.
 - **Interactive** (`interactive`): After each reasoning phase completes, show the result summary and ASK: "Want to adjust anything or continue?" before proceeding to the next phase.
 
 If the user doesn't specify, default to **Interactive** (safer, gives the user control).
@@ -278,9 +279,9 @@ If it says `Chained PRs recommended: Yes`, `400-line budget risk: High`, estimat
 - **`single-pr`**: Require/record `size:exception` before apply handoff.
 - **`exception-ok`**: Prepare handoff stating `size:exception`.
 
-### Execution Handoff Payload Format (`sdd/{change}/handoff`)
+### Execution Handoff Payload Format (`sdd/{change-name}/handoff`)
 
-When saving an execution handoff to Engram under `sdd/{change}/handoff`, write a structured observation containing:
+When saving an execution handoff to Engram under `sdd/{change-name}/handoff`, write a structured observation containing:
 ```yaml
 change: "{change-name}"
 phase: "sdd-apply" (or "sdd-verify" / "jd-fix-agent")
@@ -291,9 +292,8 @@ chain_strategy: "{chain_strategy}"
 tasks_ref: "sdd/{change-name}/tasks"
 spec_ref: "sdd/{change-name}/spec"
 design_ref: "sdd/{change-name}/design"
-strict_tdd: true | false
-instructions: "Detailed implementation instructions for the CLI executor"
 ```
+
 
 ## Engram Topic Key Format
 

--- a/internal/assets/language_contract_test.go
+++ b/internal/assets/language_contract_test.go
@@ -128,6 +128,7 @@ func TestSupportedAgentSDDLanguageMatrix(t *testing.T) {
 		path  string
 	}{
 		{agent: "claude-code", path: "claude/sdd-orchestrator.md"},
+		{agent: "claude-desktop", path: "claudedesktop/sdd-orchestrator.md"},
 		{agent: "opencode", path: "opencode/sdd-orchestrator.md"},
 		{agent: "kilocode", path: "opencode/sdd-orchestrator.md"},
 		{agent: "gemini-cli", path: "gemini/sdd-orchestrator.md"},

--- a/internal/catalog/agents.go
+++ b/internal/catalog/agents.go
@@ -26,7 +26,7 @@ var allAgents = []Agent{
 	{ID: model.AgentPi, Name: "Pi", Tier: model.TierFull, ConfigPath: "~/.pi"},
 	{ID: model.AgentTrae, Name: "Trae IDE", Tier: model.TierFull, ConfigPath: "~/.trae"},
 	{ID: model.AgentHermes, Name: "Hermes", Tier: model.TierFull, ConfigPath: "~/.hermes"},
-	{ID: model.AgentClaudeDesktop, Name: "Claude Desktop", Tier: model.TierFull, ConfigPath: "~/Library/Application Support/Claude"},
+	{ID: model.AgentClaudeDesktop, Name: "Claude Desktop", Tier: model.TierFull, ConfigPath: "~/.config/Claude"},
 }
 
 // mvpAgents are the original MVP agents (Claude Code, OpenCode).

--- a/internal/catalog/agents.go
+++ b/internal/catalog/agents.go
@@ -26,6 +26,7 @@ var allAgents = []Agent{
 	{ID: model.AgentPi, Name: "Pi", Tier: model.TierFull, ConfigPath: "~/.pi"},
 	{ID: model.AgentTrae, Name: "Trae IDE", Tier: model.TierFull, ConfigPath: "~/.trae"},
 	{ID: model.AgentHermes, Name: "Hermes", Tier: model.TierFull, ConfigPath: "~/.hermes"},
+	{ID: model.AgentClaudeDesktop, Name: "Claude Desktop", Tier: model.TierFull, ConfigPath: "~/Library/Application Support/Claude"},
 }
 
 // mvpAgents are the original MVP agents (Claude Code, OpenCode).

--- a/internal/cli/install_test.go
+++ b/internal/cli/install_test.go
@@ -69,7 +69,7 @@ func TestNormalizeInstallFlagsDefaults(t *testing.T) {
 	}
 
 	want := model.Selection{
-		Agents:  []model.AgentID{model.AgentClaudeCode, model.AgentOpenCode, model.AgentKilocode, model.AgentGeminiCLI, model.AgentCodex, model.AgentCursor, model.AgentVSCodeCopilot, model.AgentAntigravity, model.AgentWindsurf, model.AgentKimi, model.AgentQwenCode, model.AgentKiroIDE, model.AgentOpenClaw, model.AgentPi, model.AgentTrae, model.AgentHermes},
+		Agents:  []model.AgentID{model.AgentClaudeCode, model.AgentOpenCode, model.AgentKilocode, model.AgentGeminiCLI, model.AgentCodex, model.AgentCursor, model.AgentVSCodeCopilot, model.AgentAntigravity, model.AgentWindsurf, model.AgentKimi, model.AgentQwenCode, model.AgentKiroIDE, model.AgentOpenClaw, model.AgentPi, model.AgentTrae, model.AgentHermes, model.AgentClaudeDesktop},
 		Persona: model.PersonaGentleman,
 		Preset:  model.PresetFullGentleman,
 		Components: []model.ComponentID{

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1045,11 +1045,14 @@ func (s componentApplyStep) Run() error {
 				}
 			}
 			engramOpts := engram.InjectOptions{
-				Version: engramVersion,
+				Version:                     engramVersion,
+				CodexOrchestratorAssignment: s.selection.CodexOrchestratorAssignment,
+				CodexCarrilModelAssignments: s.selection.CodexCarrilModelAssignments,
+				CodexModelAssignments:       s.selection.CodexModelAssignments,
 			}
 			var err error
 			if adapter.Agent() == model.AgentOpenClaw {
-				_, err = engram.InjectWithPromptDir(s.homeDir, s.workspaceDir, adapter)
+				_, err = engram.InjectWithPromptDirWithOptions(s.homeDir, s.workspaceDir, adapter, engramOpts)
 			} else {
 				targetDir := componentInjectionDirScoped(s.homeDir, s.workspaceDir, s.scope, adapter)
 				_, err = engram.InjectWithOptions(targetDir, adapter, engramOpts)

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1045,10 +1045,7 @@ func (s componentApplyStep) Run() error {
 				}
 			}
 			engramOpts := engram.InjectOptions{
-				CodexOrchestratorAssignment: s.selection.CodexOrchestratorAssignment,
-				CodexCarrilModelAssignments: s.selection.CodexCarrilModelAssignments,
-				CodexModelAssignments:       s.selection.CodexModelAssignments,
-				Version:                     engramVersion,
+				Version: engramVersion,
 			}
 			var err error
 			if adapter.Agent() == model.AgentOpenClaw {

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -823,11 +823,7 @@ func (s componentSyncStep) Run() error {
 	case model.ComponentEngram:
 		// Sync: inject MCP config + system prompt protocol only.
 		// NO binary install. NO engram setup.
-		engramOpts := engram.InjectOptions{
-			CodexOrchestratorAssignment: s.selection.CodexOrchestratorAssignment,
-			CodexCarrilModelAssignments: s.selection.CodexCarrilModelAssignments,
-			CodexModelAssignments:       s.selection.CodexModelAssignments,
-		}
+		engramOpts := engram.InjectOptions{}
 		for _, adapter := range adapters {
 			var res engram.InjectionResult
 			var err error

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -823,12 +823,16 @@ func (s componentSyncStep) Run() error {
 	case model.ComponentEngram:
 		// Sync: inject MCP config + system prompt protocol only.
 		// NO binary install. NO engram setup.
-		engramOpts := engram.InjectOptions{}
+		engramOpts := engram.InjectOptions{
+			CodexOrchestratorAssignment: s.selection.CodexOrchestratorAssignment,
+			CodexCarrilModelAssignments: s.selection.CodexCarrilModelAssignments,
+			CodexModelAssignments:       s.selection.CodexModelAssignments,
+		}
 		for _, adapter := range adapters {
 			var res engram.InjectionResult
 			var err error
 			if adapter.Agent() == model.AgentOpenClaw {
-				res, err = engram.InjectWithPromptDir(s.homeDir, s.workspaceDir, adapter)
+				res, err = engram.InjectWithPromptDirWithOptions(s.homeDir, s.workspaceDir, adapter, engramOpts)
 			} else {
 				targetDir := componentInjectionDir(s.homeDir, s.workspaceDir, adapter)
 				res, err = engram.InjectWithOptions(targetDir, adapter, engramOpts)

--- a/internal/components/communitytool/codegraph_contract.go
+++ b/internal/components/communitytool/codegraph_contract.go
@@ -48,6 +48,7 @@ var codeGraphCompatibilityTable = map[model.AgentID]codeGraphCompatibility{
 	model.AgentOpenClaw:      excludedCompatibility(model.AgentOpenClaw),
 	model.AgentPi:            reconciledCompatibility(model.AgentPi, ""),
 	model.AgentTrae:          excludedCompatibility(model.AgentTrae),
+	model.AgentClaudeDesktop: excludedCompatibility(model.AgentClaudeDesktop),
 	model.AgentHermes:        nativeCompatibility(model.AgentHermes, "hermes"),
 }
 

--- a/internal/components/communitytool/codegraph_contract_test.go
+++ b/internal/components/communitytool/codegraph_contract_test.go
@@ -51,7 +51,7 @@ func TestCodeGraphCompatibilityStrategies(t *testing.T) {
 	}{
 		{codeGraphNative, []model.AgentID{model.AgentClaudeCode, model.AgentCursor, model.AgentCodex, model.AgentGeminiCLI, model.AgentHermes, model.AgentAntigravity, model.AgentKiroIDE}},
 		{codeGraphReconciled, []model.AgentID{model.AgentOpenCode, model.AgentPi}},
-		{codeGraphExcluded, []model.AgentID{model.AgentKilocode, model.AgentVSCodeCopilot, model.AgentWindsurf, model.AgentKimi, model.AgentQwenCode, model.AgentOpenClaw, model.AgentTrae}},
+		{codeGraphExcluded, []model.AgentID{model.AgentClaudeDesktop, model.AgentKilocode, model.AgentVSCodeCopilot, model.AgentWindsurf, model.AgentKimi, model.AgentQwenCode, model.AgentOpenClaw, model.AgentTrae}},
 	}
 	for _, tt := range tests {
 		for _, id := range tt.agents {

--- a/internal/components/communitytool/pi_codegraph_test.go
+++ b/internal/components/communitytool/pi_codegraph_test.go
@@ -771,7 +771,7 @@ done`,
 				installFakeCodeGraphScript(t, tt.script)
 			}
 
-			ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 			defer cancel()
 			_, err := probePiCodeGraphMCPWithAgentDirContext(ctx, mcpPath, agentDir)
 			if !errors.Is(err, context.DeadlineExceeded) {

--- a/internal/components/engram/inject.go
+++ b/internal/components/engram/inject.go
@@ -217,6 +217,12 @@ func InjectWithPromptDir(configHomeDir, promptDir string, adapter agents.Adapter
 	return injectWithOptions(configHomeDir, promptDir, adapter, InjectOptions{})
 }
 
+// InjectWithPromptDirWithOptions is like InjectWithPromptDir but accepts additional options
+// such as Codex model assignments.
+func InjectWithPromptDirWithOptions(configHomeDir, promptDir string, adapter agents.Adapter, opts InjectOptions) (InjectionResult, error) {
+	return injectWithOptions(configHomeDir, promptDir, adapter, opts)
+}
+
 const antigravityEngramPluginJSON = `{
   "name": "gentle-ai-engram",
   "description": "Loads Engram MCP memory tools for Antigravity sessions.",

--- a/internal/components/engram/inject.go
+++ b/internal/components/engram/inject.go
@@ -322,6 +322,9 @@ func injectWithOptions(configHomeDir, promptDir string, adapter agents.Adapter, 
 		// present instead of silently overwriting it with the relative "engram".
 		// See: https://github.com/Gentleman-Programming/gentle-ai/issues (engram absolute path regression)
 		mcpPath := adapter.MCPConfigPath(configHomeDir, "engram")
+		if mcpPath == "" {
+			break
+		}
 		cmd := stableEngramCommandForMergedConfig(mcpPath, adapter.Agent())
 		content := buildSeparateMCPContent(mcpPath, engramServerJSONWithCmd(cmd))
 		mcpWrite, err := filemerge.WriteFileAtomic(mcpPath, content, 0o644)
@@ -384,6 +387,9 @@ func injectWithOptions(configHomeDir, promptDir string, adapter agents.Adapter, 
 		// Hermes: upsert the engram MCP server block under mcp_servers: in
 		// ~/.hermes/config.yaml via the comment-preserving YAML string helpers.
 		configPath := adapter.MCPConfigPath(configHomeDir, "engram")
+		if configPath == "" {
+			break
+		}
 		existing, readErr := readFileOrEmpty(configPath)
 		if readErr != nil {
 			return InjectionResult{}, readErr
@@ -448,7 +454,11 @@ func injectWithOptions(configHomeDir, promptDir string, adapter agents.Adapter, 
 		// orchestrator asset gracefully falls back to solo execution if the multi-agent
 		// tools are unavailable in the session. agents.max_threads/max_depth carry
 		// conservative defaults.
-		withFeatures := filemerge.UpsertTOMLTableKey(existing, "features", "multi_agent", "true")
+		multiAgentVal := "false"
+		if opts.CodexMultiAgent {
+			multiAgentVal = "true"
+		}
+		withFeatures := filemerge.UpsertTOMLTableKey(existing, "features", "multi_agent", multiAgentVal)
 		withMaxThreads := filemerge.UpsertTOMLTableKey(withFeatures, "agents", "max_threads", "4")
 		withMaxDepth := filemerge.UpsertTOMLTableKey(withMaxThreads, "agents", "max_depth", "2")
 
@@ -711,7 +721,7 @@ func existingMergedEngramCommand(raw []byte, agentID model.AgentID) (string, boo
 
 	var server any
 	switch agentID {
-	case model.AgentOpenCode:
+	case model.AgentOpenCode, model.AgentKilocode:
 		mcp, ok := root["mcp"].(map[string]any)
 		if !ok {
 			return "", false
@@ -772,7 +782,7 @@ func executableFromCommandValue(command any) (string, bool) {
 
 func isStandardAgent(id model.AgentID) bool {
 	switch id {
-	case model.AgentOpenCode, model.AgentQwenCode, model.AgentCodex, model.AgentGeminiCLI, model.AgentAntigravity, model.AgentClaudeCode, model.AgentOpenClaw, model.AgentHermes:
+	case model.AgentOpenCode, model.AgentKilocode, model.AgentQwenCode, model.AgentCodex, model.AgentGeminiCLI, model.AgentAntigravity, model.AgentClaudeCode, model.AgentOpenClaw, model.AgentHermes, model.AgentClaudeDesktop:
 		return true
 	default:
 		return false

--- a/internal/components/engram/inject_test.go
+++ b/internal/components/engram/inject_test.go
@@ -1097,10 +1097,9 @@ func TestProfileFallbackAgreesWithRenderFallback(t *testing.T) {
 
 // ─── Codex multi-agent config injection tests ────────────────────────────────
 
-// TestInjectCodexMultiAgentDefaultOn asserts that after a plain Inject call,
-// config.toml contains [features] with multi_agent = true. Codex SDD enables
-// multi-agent delegation by default so the per-phase reasoning_effort table applies.
-func TestInjectCodexMultiAgentDefaultOn(t *testing.T) {
+// TestInjectCodexMultiAgentDefaultOff asserts that after a plain Inject call
+// (CodexMultiAgent default false), config.toml contains [features] with multi_agent = false.
+func TestInjectCodexMultiAgentDefaultOff(t *testing.T) {
 	validCodexRuntime(t)
 	home := t.TempDir()
 
@@ -1117,11 +1116,11 @@ func TestInjectCodexMultiAgentDefaultOn(t *testing.T) {
 	if !strings.Contains(text, "[features]") {
 		t.Fatalf("config.toml missing [features] section; got:\n%s", text)
 	}
-	if !strings.Contains(text, "multi_agent = true") {
-		t.Fatalf("config.toml missing multi_agent = true (enabled by default); got:\n%s", text)
+	if !strings.Contains(text, "multi_agent = false") {
+		t.Fatalf("config.toml missing multi_agent = false (default value); got:\n%s", text)
 	}
-	if strings.Contains(text, "multi_agent = false") {
-		t.Fatalf("config.toml must NOT have multi_agent = false by default; got:\n%s", text)
+	if strings.Contains(text, "multi_agent = true") {
+		t.Fatalf("config.toml must NOT have multi_agent = true by default; got:\n%s", text)
 	}
 }
 
@@ -2285,5 +2284,27 @@ func TestInjectCodexNilOrchestratorAssignmentPreservesTopLevelModel(t *testing.T
 	}
 	if !strings.Contains(string(content), `model = "user-model"`) || !strings.Contains(string(content), `model_reasoning_effort = "high"`) {
 		t.Fatalf("nil assignment clobbered top-level model:\n%s", content)
+	}
+}
+
+func TestKilocodeEngramInjectionAndIsStandardAgent(t *testing.T) {
+	if !isStandardAgent(model.AgentKilocode) {
+		t.Fatalf("isStandardAgent(AgentKilocode) = false, want true")
+	}
+
+	raw := []byte(`{
+		"mcp": {
+			"engram": {
+				"type": "local",
+				"command": ["/custom/path/engram", "mcp", "--tools=agent"]
+			}
+		}
+	}`)
+	cmd, ok := existingMergedEngramCommand(raw, model.AgentKilocode)
+	if !ok {
+		t.Fatalf("existingMergedEngramCommand failed for AgentKilocode")
+	}
+	if cmd != "/custom/path/engram" {
+		t.Fatalf("existingMergedEngramCommand = %q, want /custom/path/engram", cmd)
 	}
 }

--- a/internal/components/mcp/context7.go
+++ b/internal/components/mcp/context7.go
@@ -1,6 +1,7 @@
 package mcp
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/gentleman-programming/gentle-ai/internal/versions"
@@ -76,4 +77,33 @@ func KimiContext7OverlayJSON() []byte {
 	content := make([]byte, len(kimiContext7OverlayJSON))
 	copy(content, kimiContext7OverlayJSON)
 	return content
+}
+
+// ClaudeDesktopOverlayJSON returns the overlay JSON for claude_desktop_config.json,
+// containing context7 and gentle-ai MCP server configurations.
+func ClaudeDesktopOverlayJSON(gentleAICmd string) []byte {
+	if gentleAICmd == "" {
+		gentleAICmd = "gentle-ai"
+	}
+	cfg := map[string]any{
+		"mcpServers": map[string]any{
+			"context7": map[string]any{
+				"command": "npx",
+				"args": []string{
+					"-y",
+					"--package=@upstash/context7-mcp@" + versions.Context7MCP,
+					"--",
+					"context7-mcp",
+				},
+			},
+			"gentle-ai": map[string]any{
+				"command": gentleAICmd,
+				"args": []string{
+					"mcp",
+				},
+			},
+		},
+	}
+	b, _ := json.MarshalIndent(cfg, "", "  ")
+	return append(b, '\n')
 }

--- a/internal/components/mcp/context7.go
+++ b/internal/components/mcp/context7.go
@@ -37,42 +37,49 @@ var antigravityContext7OverlayJSON = []byte("{\n  \"mcpServers\": {\n    \"conte
 // deep merge into this managed MCP server entry.
 var kimiContext7OverlayJSON = []byte("{\n  \"mcpServers\": {\n    \"context7\": {\n      \"__replace__\": {\n        \"transport\": \"http\",\n        \"url\": \"https://mcp.context7.com/mcp\"\n      }\n    }\n  }\n}\n")
 
+// DefaultContext7ServerJSON returns the default standalone Context7 server JSON configuration.
 func DefaultContext7ServerJSON() []byte {
 	content := make([]byte, len(defaultContext7ServerJSON))
 	copy(content, defaultContext7ServerJSON)
 	return content
 }
 
+// DefaultContext7OverlayJSON returns the default mcpServers overlay JSON containing Context7.
 func DefaultContext7OverlayJSON() []byte {
 	content := make([]byte, len(defaultContext7OverlayJSON))
 	copy(content, defaultContext7OverlayJSON)
 	return content
 }
 
+// OpenCodeContext7OverlayJSON returns the opencode.json overlay JSON for Context7.
 func OpenCodeContext7OverlayJSON() []byte {
 	content := make([]byte, len(openCodeContext7OverlayJSON))
 	copy(content, openCodeContext7OverlayJSON)
 	return content
 }
 
+// OpenClawContext7OverlayJSON returns the openclaw.json overlay JSON for Context7.
 func OpenClawContext7OverlayJSON() []byte {
 	content := make([]byte, len(openClawContext7OverlayJSON))
 	copy(content, openClawContext7OverlayJSON)
 	return content
 }
 
+// VSCodeContext7OverlayJSON returns the VS Code mcp.json overlay JSON for Context7.
 func VSCodeContext7OverlayJSON() []byte {
 	content := make([]byte, len(vsCodeContext7OverlayJSON))
 	copy(content, vsCodeContext7OverlayJSON)
 	return content
 }
 
+// AntigravityContext7OverlayJSON returns the Antigravity mcp_config.json overlay JSON for Context7.
 func AntigravityContext7OverlayJSON() []byte {
 	content := make([]byte, len(antigravityContext7OverlayJSON))
 	copy(content, antigravityContext7OverlayJSON)
 	return content
 }
 
+// KimiContext7OverlayJSON returns the Kimi mcp.json overlay JSON for Context7.
 func KimiContext7OverlayJSON() []byte {
 	content := make([]byte, len(kimiContext7OverlayJSON))
 	copy(content, kimiContext7OverlayJSON)

--- a/internal/components/mcp/inject.go
+++ b/internal/components/mcp/inject.go
@@ -205,18 +205,22 @@ func injectClaudeDesktopMergeIntoSettings(settingsPath string) (InjectionResult,
 		if existingCmd, ok := existingMergedGentleAICommand(baseJSON); ok {
 			cmd = stableGentleAICommandForExisting(existingCmd)
 		}
-		if err := os.WriteFile(backupPath, backupBytes, 0o644); err != nil {
+		if err := os.WriteFile(backupPath, backupBytes, 0o600); err != nil {
 			return InjectionResult{}, fmt.Errorf("write backup settings %q: %w", backupPath, err)
 		}
+		_ = os.Chmod(backupPath, 0o600)
 	}
 
 	overlay := ClaudeDesktopOverlayJSON(cmd)
-	settingsWrite, err := mergeJSONFile(settingsPath, overlay)
+	settingsWrite, err := mergeJSONFileMode(settingsPath, overlay, 0o600)
 	if err != nil {
 		if fileExisted {
-			if _, restoreErr := filemerge.WriteFileAtomic(settingsPath, backupBytes, 0o644); restoreErr != nil {
+			if _, restoreErr := filemerge.WriteFileAtomic(settingsPath, backupBytes, 0o600); restoreErr != nil {
+				_ = os.Remove(backupPath)
 				return InjectionResult{}, fmt.Errorf("merge json error: %w; restore backup failed: %v", err, restoreErr)
 			}
+			_ = os.Chmod(settingsPath, 0o600)
+			_ = os.Remove(backupPath)
 		} else {
 			if rmErr := os.Remove(settingsPath); rmErr != nil && !os.IsNotExist(rmErr) {
 				return InjectionResult{}, fmt.Errorf("merge json error: %w; remove settings failed: %v", err, rmErr)
@@ -227,6 +231,10 @@ func injectClaudeDesktopMergeIntoSettings(settingsPath string) (InjectionResult,
 
 	if fileExisted {
 		_ = os.Remove(backupPath)
+	}
+
+	if err := os.Chmod(settingsPath, 0o600); err != nil && !os.IsNotExist(err) {
+		return InjectionResult{}, fmt.Errorf("chmod settings %q: %w", settingsPath, err)
 	}
 
 	return InjectionResult{Changed: settingsWrite.Changed, Files: []string{settingsPath}}, nil
@@ -420,6 +428,10 @@ func injectMCPConfigFile(homeDir string, adapter agents.Adapter) (InjectionResul
 }
 
 func mergeJSONFile(path string, overlay []byte) (filemerge.WriteResult, error) {
+	return mergeJSONFileMode(path, overlay, 0o644)
+}
+
+func mergeJSONFileMode(path string, overlay []byte, mode os.FileMode) (filemerge.WriteResult, error) {
 	baseJSON, err := osReadFile(path)
 	if err != nil {
 		return filemerge.WriteResult{}, err
@@ -430,7 +442,7 @@ func mergeJSONFile(path string, overlay []byte) (filemerge.WriteResult, error) {
 		return filemerge.WriteResult{}, err
 	}
 
-	return filemerge.WriteFileAtomic(path, merged, 0o644)
+	return filemerge.WriteFileAtomic(path, merged, mode)
 }
 
 var osReadFile = func(path string) ([]byte, error) {

--- a/internal/components/mcp/inject.go
+++ b/internal/components/mcp/inject.go
@@ -146,7 +146,7 @@ func injectMergeIntoSettings(homeDir string, adapter agents.Adapter) (InjectionR
 	return InjectionResult{Changed: settingsWrite.Changed, Files: []string{settingsPath}}, nil
 }
 
-var GentleAILookPath = exec.LookPath
+var gentleAILookPath = exec.LookPath
 
 func isGentleAICommand(cmd string) bool {
 	if cmd == "" {
@@ -159,18 +159,13 @@ func isGentleAICommand(cmd string) bool {
 	return base == "gentle-ai"
 }
 
-func isVersionedHomebrewCellarPath(path string) bool {
-	clean := filepath.ToSlash(filepath.Clean(path))
-	return strings.Contains(clean, "/Cellar/gentle-ai/") && isGentleAICommand(clean)
-}
-
 func isStableHomebrewGentleAIPath(path string) bool {
 	clean := filepath.ToSlash(filepath.Clean(path))
 	return (clean == "/opt/homebrew/bin/gentle-ai" || clean == "/usr/local/bin/gentle-ai") && isGentleAICommand(clean)
 }
 
 func preferredStableGentleAICommand() string {
-	p, err := GentleAILookPath("gentle-ai")
+	p, err := gentleAILookPath("gentle-ai")
 	if err == nil && isStableHomebrewGentleAIPath(p) {
 		return p
 	}
@@ -178,27 +173,11 @@ func preferredStableGentleAICommand() string {
 }
 
 func resolveGentleAICommand() string {
-	p, err := GentleAILookPath("gentle-ai")
-	if err != nil || p == "" {
-		return "gentle-ai"
-	}
-	if isVersionedHomebrewCellarPath(p) {
-		if stable := preferredStableGentleAICommand(); stable != "" {
-			return stable
-		}
-		return "gentle-ai"
-	}
-	return p
+	return preferredStableGentleAICommand()
 }
 
-func stableGentleAICommandForExisting(cmd string) string {
-	if isVersionedHomebrewCellarPath(cmd) {
-		if stable := preferredStableGentleAICommand(); stable != "" {
-			return stable
-		}
-		return "gentle-ai"
-	}
-	return cmd
+func stableGentleAICommandForExisting(_ string) string {
+	return preferredStableGentleAICommand()
 }
 
 func injectClaudeDesktopMergeIntoSettings(settingsPath string) (InjectionResult, error) {

--- a/internal/components/mcp/inject.go
+++ b/internal/components/mcp/inject.go
@@ -15,11 +15,13 @@ import (
 	"github.com/gentleman-programming/gentle-ai/internal/versions"
 )
 
+// InjectionResult records the outcome of an MCP configuration injection operation.
 type InjectionResult struct {
 	Changed bool
 	Files   []string
 }
 
+// Inject configures MCP server settings for the given adapter according to its Strategy.
 func Inject(homeDir string, adapter agents.Adapter) (InjectionResult, error) {
 	if !adapter.SupportsMCP() {
 		return InjectionResult{}, nil
@@ -176,23 +178,55 @@ func resolveGentleAICommand() string {
 	return preferredStableGentleAICommand()
 }
 
-func stableGentleAICommandForExisting(_ string) string {
+func isVersionedHomebrewCellarPath(path string) bool {
+	clean := filepath.ToSlash(filepath.Clean(path))
+	return strings.Contains(clean, "/Cellar/")
+}
+
+func stableGentleAICommandForExisting(existing string) string {
+	if existing != "" && !isVersionedHomebrewCellarPath(existing) {
+		return existing
+	}
 	return preferredStableGentleAICommand()
 }
 
 func injectClaudeDesktopMergeIntoSettings(settingsPath string) (InjectionResult, error) {
 	cmd := resolveGentleAICommand()
 	baseJSON, err := osReadFile(settingsPath)
-	if err == nil && len(baseJSON) > 0 {
+	if err != nil {
+		return InjectionResult{}, err
+	}
+	fileExisted := baseJSON != nil
+	var backupBytes []byte
+	backupPath := settingsPath + ".bak"
+
+	if fileExisted {
+		backupBytes = baseJSON
 		if existingCmd, ok := existingMergedGentleAICommand(baseJSON); ok {
 			cmd = stableGentleAICommandForExisting(existingCmd)
+		}
+		if err := os.WriteFile(backupPath, backupBytes, 0o644); err != nil {
+			return InjectionResult{}, fmt.Errorf("write backup settings %q: %w", backupPath, err)
 		}
 	}
 
 	overlay := ClaudeDesktopOverlayJSON(cmd)
 	settingsWrite, err := mergeJSONFile(settingsPath, overlay)
 	if err != nil {
+		if fileExisted {
+			if _, restoreErr := filemerge.WriteFileAtomic(settingsPath, backupBytes, 0o644); restoreErr != nil {
+				return InjectionResult{}, fmt.Errorf("merge json error: %w; restore backup failed: %v", err, restoreErr)
+			}
+		} else {
+			if rmErr := os.Remove(settingsPath); rmErr != nil && !os.IsNotExist(rmErr) {
+				return InjectionResult{}, fmt.Errorf("merge json error: %w; remove settings failed: %v", err, rmErr)
+			}
+		}
 		return InjectionResult{}, err
+	}
+
+	if fileExisted {
+		_ = os.Remove(backupPath)
 	}
 
 	return InjectionResult{Changed: settingsWrite.Changed, Files: []string{settingsPath}}, nil

--- a/internal/components/mcp/inject.go
+++ b/internal/components/mcp/inject.go
@@ -4,6 +4,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
 
 	"github.com/gentleman-programming/gentle-ai/internal/agents"
 	"github.com/gentleman-programming/gentle-ai/internal/components/filemerge"
@@ -50,6 +54,9 @@ func context7Args() []string {
 // endpoint. The file is created if it does not yet exist.
 func injectTOMLFile(homeDir string, adapter agents.Adapter) (InjectionResult, error) {
 	configPath := adapter.MCPConfigPath(homeDir, "context7")
+	if configPath == "" {
+		return InjectionResult{}, nil
+	}
 
 	existingBytes, err := osReadFile(configPath)
 	if err != nil {
@@ -73,6 +80,9 @@ func injectTOMLFile(homeDir string, adapter agents.Adapter) (InjectionResult, er
 // comment-preserving — user content outside the managed block is untouched.
 func injectYAMLFile(homeDir string, adapter agents.Adapter) (InjectionResult, error) {
 	configPath := adapter.MCPConfigPath(homeDir, "context7")
+	if configPath == "" {
+		return InjectionResult{}, nil
+	}
 
 	raw, err := os.ReadFile(configPath)
 	var existingBytes []byte
@@ -99,6 +109,9 @@ func injectYAMLFile(homeDir string, adapter agents.Adapter) (InjectionResult, er
 // injectSeparateFile writes a standalone JSON file per MCP server.
 func injectSeparateFile(homeDir string, adapter agents.Adapter) (InjectionResult, error) {
 	path := adapter.MCPConfigPath(homeDir, "context7")
+	if path == "" {
+		return InjectionResult{}, nil
+	}
 	writeResult, err := filemerge.WriteFileAtomic(path, DefaultContext7ServerJSON(), 0o644)
 	if err != nil {
 		return InjectionResult{}, err
@@ -107,7 +120,7 @@ func injectSeparateFile(homeDir string, adapter agents.Adapter) (InjectionResult
 	return InjectionResult{Changed: writeResult.Changed, Files: []string{path}}, nil
 }
 
-// injectMergeIntoSettings merges MCP servers into a config file (OpenCode opencode.json, Gemini settings.json).
+// injectMergeIntoSettings merges MCP servers into a config file (OpenCode opencode.json, Gemini settings.json, Claude Desktop claude_desktop_config.json).
 func injectMergeIntoSettings(homeDir string, adapter agents.Adapter) (InjectionResult, error) {
 	settingsPath := adapter.SettingsPath(homeDir)
 	if settingsPath == "" {
@@ -121,6 +134,9 @@ func injectMergeIntoSettings(homeDir string, adapter agents.Adapter) (InjectionR
 	if adapter.Agent() == model.AgentOpenClaw {
 		return injectOpenClawMergeIntoSettings(settingsPath)
 	}
+	if adapter.Agent() == model.AgentClaudeDesktop {
+		return injectClaudeDesktopMergeIntoSettings(settingsPath)
+	}
 
 	settingsWrite, err := mergeJSONFile(settingsPath, overlay)
 	if err != nil {
@@ -128,6 +144,123 @@ func injectMergeIntoSettings(homeDir string, adapter agents.Adapter) (InjectionR
 	}
 
 	return InjectionResult{Changed: settingsWrite.Changed, Files: []string{settingsPath}}, nil
+}
+
+var GentleAILookPath = exec.LookPath
+
+func isGentleAICommand(cmd string) bool {
+	if cmd == "" {
+		return false
+	}
+	base := filepath.Base(cmd)
+	if runtime.GOOS == "windows" {
+		return strings.EqualFold(base, "gentle-ai.exe") || strings.EqualFold(base, "gentle-ai")
+	}
+	return base == "gentle-ai"
+}
+
+func isVersionedHomebrewCellarPath(path string) bool {
+	clean := filepath.ToSlash(filepath.Clean(path))
+	return strings.Contains(clean, "/Cellar/gentle-ai/") && isGentleAICommand(clean)
+}
+
+func isStableHomebrewGentleAIPath(path string) bool {
+	clean := filepath.ToSlash(filepath.Clean(path))
+	return (clean == "/opt/homebrew/bin/gentle-ai" || clean == "/usr/local/bin/gentle-ai") && isGentleAICommand(clean)
+}
+
+func preferredStableGentleAICommand() string {
+	p, err := GentleAILookPath("gentle-ai")
+	if err == nil && isStableHomebrewGentleAIPath(p) {
+		return p
+	}
+	return "gentle-ai"
+}
+
+func resolveGentleAICommand() string {
+	p, err := GentleAILookPath("gentle-ai")
+	if err != nil || p == "" {
+		return "gentle-ai"
+	}
+	if isVersionedHomebrewCellarPath(p) {
+		if stable := preferredStableGentleAICommand(); stable != "" {
+			return stable
+		}
+		return "gentle-ai"
+	}
+	return p
+}
+
+func stableGentleAICommandForExisting(cmd string) string {
+	if isVersionedHomebrewCellarPath(cmd) {
+		if stable := preferredStableGentleAICommand(); stable != "" {
+			return stable
+		}
+		return "gentle-ai"
+	}
+	return cmd
+}
+
+func injectClaudeDesktopMergeIntoSettings(settingsPath string) (InjectionResult, error) {
+	cmd := resolveGentleAICommand()
+	baseJSON, err := osReadFile(settingsPath)
+	if err == nil && len(baseJSON) > 0 {
+		if existingCmd, ok := existingMergedGentleAICommand(baseJSON); ok {
+			cmd = stableGentleAICommandForExisting(existingCmd)
+		}
+	}
+
+	overlay := ClaudeDesktopOverlayJSON(cmd)
+	settingsWrite, err := mergeJSONFile(settingsPath, overlay)
+	if err != nil {
+		return InjectionResult{}, err
+	}
+
+	return InjectionResult{Changed: settingsWrite.Changed, Files: []string{settingsPath}}, nil
+}
+
+func existingMergedGentleAICommand(baseJSON []byte) (string, bool) {
+	if len(baseJSON) == 0 {
+		return "", false
+	}
+	normalized, err := filemerge.MergeJSONObjects(baseJSON, []byte("{}"))
+	if err != nil {
+		return "", false
+	}
+	var root map[string]any
+	if err := json.Unmarshal(normalized, &root); err != nil {
+		return "", false
+	}
+	mcpServers, ok := root["mcpServers"].(map[string]any)
+	if !ok {
+		return "", false
+	}
+	server, ok := mcpServers["gentle-ai"].(map[string]any)
+	if !ok {
+		return "", false
+	}
+	return executableFromCommandValue(server["command"])
+}
+
+func executableFromCommandValue(command any) (string, bool) {
+	switch value := command.(type) {
+	case string:
+		if value == "" {
+			return "", false
+		}
+		return value, true
+	case []any:
+		if len(value) == 0 {
+			return "", false
+		}
+		first, ok := value[0].(string)
+		if !ok || first == "" {
+			return "", false
+		}
+		return first, true
+	default:
+		return "", false
+	}
 }
 
 func injectOpenCodeMergeIntoSettings(settingsPath string) (InjectionResult, error) {

--- a/internal/components/mcp/inject_test.go
+++ b/internal/components/mcp/inject_test.go
@@ -1213,3 +1213,125 @@ func TestInjectClaudeDesktopAvoidsStaleHomebrewCellarPath(t *testing.T) {
 		t.Fatalf("gentle-ai command = %#v; want /opt/homebrew/bin/gentle-ai", gentleAI["command"])
 	}
 }
+
+func TestInjectClaudeDesktopPreservesCustomAbsoluteNonCellarGentleAIPath(t *testing.T) {
+	home := t.TempDir()
+	adapter := claudeDesktopAdapter()
+	configPath := adapter.SettingsPath(home)
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll error = %v", err)
+	}
+
+	customCmd := filepath.Join(home, "custom", "bin", "gentle-ai")
+	existing := `{
+  "mcpServers": {
+    "gentle-ai": {
+      "command": "` + strings.ReplaceAll(customCmd, `\`, `\\`) + `",
+      "args": ["mcp"]
+    }
+  }
+}`
+	if err := os.WriteFile(configPath, []byte(existing), 0o644); err != nil {
+		t.Fatalf("WriteFile error = %v", err)
+	}
+
+	result, err := Inject(home, adapter)
+	if err != nil {
+		t.Fatalf("Inject(claude-desktop) error = %v", err)
+	}
+
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("ReadFile error = %v", err)
+	}
+
+	var parsed map[string]any
+	json.Unmarshal(content, &parsed)
+	mcpServers := parsed["mcpServers"].(map[string]any)
+	gentleAI := mcpServers["gentle-ai"].(map[string]any)
+	if gentleAI["command"] != customCmd {
+		t.Fatalf("gentle-ai command = %#v; want %q (custom absolute path preserved)", gentleAI["command"], customCmd)
+	}
+	_ = result
+}
+
+func TestInjectClaudeDesktopPreservesRelativeGentleAICommand(t *testing.T) {
+	home := t.TempDir()
+	adapter := claudeDesktopAdapter()
+	configPath := adapter.SettingsPath(home)
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll error = %v", err)
+	}
+
+	existing := `{
+  "mcpServers": {
+    "gentle-ai": {
+      "command": "gentle-ai",
+      "args": ["mcp"]
+    }
+  }
+}`
+	if err := os.WriteFile(configPath, []byte(existing), 0o644); err != nil {
+		t.Fatalf("WriteFile error = %v", err)
+	}
+
+	result, err := Inject(home, adapter)
+	if err != nil {
+		t.Fatalf("Inject(claude-desktop) error = %v", err)
+	}
+
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("ReadFile error = %v", err)
+	}
+
+	var parsed map[string]any
+	json.Unmarshal(content, &parsed)
+	mcpServers := parsed["mcpServers"].(map[string]any)
+	gentleAI := mcpServers["gentle-ai"].(map[string]any)
+	if gentleAI["command"] != "gentle-ai" {
+		t.Fatalf("gentle-ai command = %#v; want %q (relative command preserved)", gentleAI["command"], "gentle-ai")
+	}
+	_ = result
+}
+
+func TestInjectClaudeDesktopPreservesCustomWrapperPath(t *testing.T) {
+	home := t.TempDir()
+	adapter := claudeDesktopAdapter()
+	configPath := adapter.SettingsPath(home)
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll error = %v", err)
+	}
+
+	wrapperPath := "/usr/local/bin/gentle-ai-wrapper"
+	existing := `{
+  "mcpServers": {
+    "gentle-ai": {
+      "command": "` + wrapperPath + `",
+      "args": ["mcp"]
+    }
+  }
+}`
+	if err := os.WriteFile(configPath, []byte(existing), 0o644); err != nil {
+		t.Fatalf("WriteFile error = %v", err)
+	}
+
+	result, err := Inject(home, adapter)
+	if err != nil {
+		t.Fatalf("Inject(claude-desktop) error = %v", err)
+	}
+
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("ReadFile error = %v", err)
+	}
+
+	var parsed map[string]any
+	json.Unmarshal(content, &parsed)
+	mcpServers := parsed["mcpServers"].(map[string]any)
+	gentleAI := mcpServers["gentle-ai"].(map[string]any)
+	if gentleAI["command"] != wrapperPath {
+		t.Fatalf("gentle-ai command = %#v; want %q (custom wrapper path preserved)", gentleAI["command"], wrapperPath)
+	}
+	_ = result
+}

--- a/internal/components/mcp/inject_test.go
+++ b/internal/components/mcp/inject_test.go
@@ -1186,11 +1186,11 @@ func TestInjectClaudeDesktopAvoidsStaleHomebrewCellarPath(t *testing.T) {
 		t.Fatalf("WriteFile error = %v", err)
 	}
 
-	origLookPath := GentleAILookPath
-	GentleAILookPath = func(file string) (string, error) {
+	origLookPath := gentleAILookPath
+	gentleAILookPath = func(file string) (string, error) {
 		return "/opt/homebrew/bin/gentle-ai", nil
 	}
-	t.Cleanup(func() { GentleAILookPath = origLookPath })
+	t.Cleanup(func() { gentleAILookPath = origLookPath })
 
 	result, err := Inject(home, adapter)
 	if err != nil {

--- a/internal/components/mcp/inject_test.go
+++ b/internal/components/mcp/inject_test.go
@@ -2,8 +2,10 @@ package mcp
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -1095,6 +1097,67 @@ func TestInjectClaudeDesktopMergesGentleAIAndContext7AndIsIdempotent(t *testing.
 	}
 	if context7["command"] != "npx" {
 		t.Fatalf("context7 entry command = %#v; want npx", context7["command"])
+	}
+}
+
+func TestInjectClaudeDesktopEnforces0600Permissions(t *testing.T) {
+	home := t.TempDir()
+	adapter := claudeDesktopAdapter()
+	configPath := adapter.SettingsPath(home)
+
+	// 1. New file creation
+	if _, err := Inject(home, adapter); err != nil {
+		t.Fatalf("Inject(claude-desktop) error = %v", err)
+	}
+
+	info, err := os.Stat(configPath)
+	if err != nil {
+		t.Fatalf("Stat(%s) error = %v", configPath, err)
+	}
+	if runtime.GOOS != "windows" && info.Mode().Perm() != 0o600 {
+		t.Fatalf("configPath permission = %o; want 0600", info.Mode().Perm())
+	}
+
+	// 2. Existing file update (pre-existing 0644 file upgraded to 0600)
+	if err := os.WriteFile(configPath, []byte(`{"mcpServers":{}}`), 0o644); err != nil {
+		t.Fatalf("WriteFile error = %v", err)
+	}
+	if _, err := Inject(home, adapter); err != nil {
+		t.Fatalf("Inject(claude-desktop) error = %v", err)
+	}
+	info, err = os.Stat(configPath)
+	if err != nil {
+		t.Fatalf("Stat(%s) error = %v", configPath, err)
+	}
+	if runtime.GOOS != "windows" && info.Mode().Perm() != 0o600 {
+		t.Fatalf("updated configPath permission = %o; want 0600", info.Mode().Perm())
+	}
+
+	// 3. Backup file permissions created during merge and cleaned up on error
+	backupPath := configPath + ".bak"
+	if err := os.WriteFile(configPath, []byte(`{"mcpServers":{}}`), 0o644); err != nil {
+		t.Fatalf("WriteFile error = %v", err)
+	}
+
+	origReadFile := osReadFile
+	defer func() { osReadFile = origReadFile }()
+	calls := 0
+	osReadFile = func(path string) ([]byte, error) {
+		calls++
+		if calls == 2 {
+			return nil, fmt.Errorf("simulated error during merge")
+		}
+		return origReadFile(path)
+	}
+
+	_, err = Inject(home, adapter)
+	if err == nil {
+		t.Fatalf("expected error when osReadFile fails on second call")
+	}
+
+	// Backup file should be cleaned up on error
+	if _, err := os.Stat(backupPath); !os.IsNotExist(err) {
+		t.Fatalf("backup file %q should be removed on error", backupPath)
 	}
 }
 

--- a/internal/components/mcp/inject_test.go
+++ b/internal/components/mcp/inject_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gentleman-programming/gentle-ai/internal/agents"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/antigravity"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/claude"
+	"github.com/gentleman-programming/gentle-ai/internal/agents/claudedesktop"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/codex"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/hermes"
 	"github.com/gentleman-programming/gentle-ai/internal/agents/kilocode"
@@ -28,10 +29,11 @@ func cursorAdapter(t *testing.T) agents.Adapter {
 	return adapter
 }
 
-func antigravityAdapter() agents.Adapter { return antigravity.NewAdapter() }
-func claudeAdapter() agents.Adapter      { return claude.NewAdapter() }
-func hermesAdapter() agents.Adapter      { return hermes.NewAdapter() }
-func kilocodeAdapter() agents.Adapter    { return kilocode.NewAdapter() }
+func antigravityAdapter() agents.Adapter     { return antigravity.NewAdapter() }
+func claudeAdapter() agents.Adapter          { return claude.NewAdapter() }
+func claudeDesktopAdapter() agents.Adapter   { return claudedesktop.NewAdapter() }
+func hermesAdapter() agents.Adapter          { return hermes.NewAdapter() }
+func kilocodeAdapter() agents.Adapter        { return kilocode.NewAdapter() }
 func kimiAdapter() agents.Adapter        { return kimi.NewAdapter() }
 func openclawAdapter() agents.Adapter    { return openclaw.NewAdapter() }
 func opencodeAdapter() agents.Adapter    { return opencode.NewAdapter() }
@@ -1034,5 +1036,180 @@ func TestInjectHermesPreservesExistingTopLevelKeys(t *testing.T) {
 	text2 := string(content2)
 	if !strings.Contains(text2, "model: claude") {
 		t.Fatalf("config.yaml lost pre-existing key on second Inject:\n%s", text2)
+	}
+}
+
+// TestInjectClaudeDesktopMergesGentleAIAndContext7AndIsIdempotent verifies that Inject(claude-desktop)
+// auto-injects gentle-ai and context7 into claude_desktop_config.json, and is idempotent.
+func TestInjectClaudeDesktopMergesGentleAIAndContext7AndIsIdempotent(t *testing.T) {
+	home := t.TempDir()
+	adapter := claudeDesktopAdapter()
+	configPath := adapter.SettingsPath(home)
+
+	first, err := Inject(home, adapter)
+	if err != nil {
+		t.Fatalf("Inject(claude-desktop) first error = %v", err)
+	}
+	if !first.Changed {
+		t.Fatalf("Inject(claude-desktop) first changed = false; want true")
+	}
+
+	second, err := Inject(home, adapter)
+	if err != nil {
+		t.Fatalf("Inject(claude-desktop) second error = %v", err)
+	}
+	if second.Changed {
+		t.Fatalf("Inject(claude-desktop) second changed = true; want false (idempotent)")
+	}
+
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%s) error = %v", configPath, err)
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal(content, &parsed); err != nil {
+		t.Fatalf("Unmarshal(%s) error = %v", configPath, err)
+	}
+
+	mcpServers, ok := parsed["mcpServers"].(map[string]any)
+	if !ok {
+		t.Fatalf("%s missing mcpServers key; got %#v", configPath, parsed)
+	}
+
+	gentleAI, ok := mcpServers["gentle-ai"].(map[string]any)
+	if !ok {
+		t.Fatalf("%s mcpServers missing gentle-ai entry; got %#v", configPath, mcpServers)
+	}
+	if gentleAI["command"] == "" {
+		t.Fatalf("gentle-ai entry command is empty")
+	}
+	args, _ := gentleAI["args"].([]any)
+	if len(args) != 1 || args[0] != "mcp" {
+		t.Fatalf("gentle-ai entry args = %#v; want [mcp]", gentleAI["args"])
+	}
+
+	context7, ok := mcpServers["context7"].(map[string]any)
+	if !ok {
+		t.Fatalf("%s mcpServers missing context7 entry; got %#v", configPath, mcpServers)
+	}
+	if context7["command"] != "npx" {
+		t.Fatalf("context7 entry command = %#v; want npx", context7["command"])
+	}
+}
+
+// TestInjectClaudeDesktopPreservesExistingEngramAndCustomMCPEntries verifies that Inject(claude-desktop)
+// preserves existing engram and user-defined MCP server entries in claude_desktop_config.json.
+func TestInjectClaudeDesktopPreservesExistingEngramAndCustomMCPEntries(t *testing.T) {
+	home := t.TempDir()
+	adapter := claudeDesktopAdapter()
+	configPath := adapter.SettingsPath(home)
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll error = %v", err)
+	}
+
+	existing := `{
+  "mcpServers": {
+    "engram": {
+      "command": "/custom/path/engram",
+      "args": ["mcp", "--tools=agent"]
+    },
+    "custom-server": {
+      "command": "node",
+      "args": ["server.js"]
+    }
+  }
+}`
+	if err := os.WriteFile(configPath, []byte(existing), 0o644); err != nil {
+		t.Fatalf("WriteFile error = %v", err)
+	}
+
+	result, err := Inject(home, adapter)
+	if err != nil {
+		t.Fatalf("Inject(claude-desktop) error = %v", err)
+	}
+	if !result.Changed {
+		t.Fatalf("Inject(claude-desktop) changed = false; want true")
+	}
+
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("ReadFile error = %v", err)
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal(content, &parsed); err != nil {
+		t.Fatalf("Unmarshal error = %v", err)
+	}
+
+	mcpServers, ok := parsed["mcpServers"].(map[string]any)
+	if !ok {
+		t.Fatalf("missing mcpServers key")
+	}
+
+	if _, ok := mcpServers["gentle-ai"]; !ok {
+		t.Fatalf("missing gentle-ai entry after injection")
+	}
+	if _, ok := mcpServers["context7"]; !ok {
+		t.Fatalf("missing context7 entry after injection")
+	}
+	if _, ok := mcpServers["custom-server"]; !ok {
+		t.Fatalf("custom-server entry was lost after injection")
+	}
+
+	engram, ok := mcpServers["engram"].(map[string]any)
+	if !ok {
+		t.Fatalf("engram entry was lost after injection")
+	}
+	if engram["command"] != "/custom/path/engram" {
+		t.Fatalf("engram entry command = %#v; want /custom/path/engram (preserved)", engram["command"])
+	}
+}
+
+func TestInjectClaudeDesktopAvoidsStaleHomebrewCellarPath(t *testing.T) {
+	home := t.TempDir()
+	adapter := claudeDesktopAdapter()
+	configPath := adapter.SettingsPath(home)
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll error = %v", err)
+	}
+
+	existing := `{
+  "mcpServers": {
+    "gentle-ai": {
+      "command": "/opt/homebrew/Cellar/gentle-ai/1.2.3/bin/gentle-ai",
+      "args": ["mcp"]
+    }
+  }
+}`
+	if err := os.WriteFile(configPath, []byte(existing), 0o644); err != nil {
+		t.Fatalf("WriteFile error = %v", err)
+	}
+
+	origLookPath := GentleAILookPath
+	GentleAILookPath = func(file string) (string, error) {
+		return "/opt/homebrew/bin/gentle-ai", nil
+	}
+	t.Cleanup(func() { GentleAILookPath = origLookPath })
+
+	result, err := Inject(home, adapter)
+	if err != nil {
+		t.Fatalf("Inject(claude-desktop) error = %v", err)
+	}
+	if !result.Changed {
+		t.Fatalf("Inject(claude-desktop) changed = false; want true (should replace cellar path)")
+	}
+
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("ReadFile error = %v", err)
+	}
+
+	var parsed map[string]any
+	json.Unmarshal(content, &parsed)
+	mcpServers := parsed["mcpServers"].(map[string]any)
+	gentleAI := mcpServers["gentle-ai"].(map[string]any)
+	if gentleAI["command"] != "/opt/homebrew/bin/gentle-ai" {
+		t.Fatalf("gentle-ai command = %#v; want /opt/homebrew/bin/gentle-ai", gentleAI["command"])
 	}
 }

--- a/internal/components/mcp/inject_test.go
+++ b/internal/components/mcp/inject_test.go
@@ -29,14 +29,14 @@ func cursorAdapter(t *testing.T) agents.Adapter {
 	return adapter
 }
 
-func antigravityAdapter() agents.Adapter     { return antigravity.NewAdapter() }
-func claudeAdapter() agents.Adapter          { return claude.NewAdapter() }
-func claudeDesktopAdapter() agents.Adapter   { return claudedesktop.NewAdapter() }
-func hermesAdapter() agents.Adapter          { return hermes.NewAdapter() }
-func kilocodeAdapter() agents.Adapter        { return kilocode.NewAdapter() }
-func kimiAdapter() agents.Adapter        { return kimi.NewAdapter() }
-func openclawAdapter() agents.Adapter    { return openclaw.NewAdapter() }
-func opencodeAdapter() agents.Adapter    { return opencode.NewAdapter() }
+func antigravityAdapter() agents.Adapter   { return antigravity.NewAdapter() }
+func claudeAdapter() agents.Adapter        { return claude.NewAdapter() }
+func claudeDesktopAdapter() agents.Adapter { return claudedesktop.NewAdapter() }
+func hermesAdapter() agents.Adapter        { return hermes.NewAdapter() }
+func kilocodeAdapter() agents.Adapter      { return kilocode.NewAdapter() }
+func kimiAdapter() agents.Adapter          { return kimi.NewAdapter() }
+func openclawAdapter() agents.Adapter      { return openclaw.NewAdapter() }
+func opencodeAdapter() agents.Adapter      { return opencode.NewAdapter() }
 
 func assertOnlyKeys(t *testing.T, path string, object map[string]any, keys ...string) {
 	t.Helper()

--- a/internal/components/sdd/bounded_review_contract_test.go
+++ b/internal/components/sdd/bounded_review_contract_test.go
@@ -33,8 +33,8 @@ var boundedReviewRequiredClauses = []string{
 
 func TestBoundedReviewContractRendersForEverySupportedAgent(t *testing.T) {
 	agents := catalog.AllAgents()
-	if len(agents) != 16 {
-		t.Fatalf("catalog.AllAgents() = %d, want 16", len(agents))
+	if len(agents) != 17 {
+		t.Fatalf("catalog.AllAgents() = %d, want 17", len(agents))
 	}
 	for _, agent := range agents {
 		t.Run(string(agent.ID), func(t *testing.T) {

--- a/internal/components/sdd/inject_test.go
+++ b/internal/components/sdd/inject_test.go
@@ -6887,6 +6887,11 @@ func TestInjectTriggerRules_AllAdapters(t *testing.T) {
 				return readFileOrEmpty(a.SystemPromptFile(home))
 			},
 		},
+		{
+			name:       "claude-desktop",
+			agentID:    model.AgentClaudeDesktop,
+			getContent: nil, // skip content check
+		},
 	}
 
 	// Count guard: the test table must enumerate exactly as many adapters as the

--- a/internal/mcp/sdd_tools.go
+++ b/internal/mcp/sdd_tools.go
@@ -1,0 +1,271 @@
+package mcp
+
+import (
+	"fmt"
+	"strings"
+)
+
+// DefaultSDDTools returns all pre-packaged SDD reasoning tools for MCP.
+func DefaultSDDTools() []Tool {
+	return []Tool{
+		{
+			Name:        "sdd_explore",
+			Description: "Investigate ideas, codebase structure, architecture, and requirements before committing to a change.",
+			InputSchema: ToolSchema{
+				Type: "object",
+				Properties: map[string]PropertySchema{
+					"topic": {
+						Type:        "string",
+						Description: "The topic, feature idea, or problem to explore.",
+					},
+					"context": {
+						Type:        "string",
+						Description: "Optional background context, constraints, or specific files to inspect.",
+					},
+				},
+				Required: []string{"topic"},
+			},
+		},
+		{
+			Name:        "sdd_review",
+			Description: "Perform 4R review (Read, Reason, Reconcile, Report) or SDD artifact review.",
+			InputSchema: ToolSchema{
+				Type: "object",
+				Properties: map[string]PropertySchema{
+					"artifact": {
+						Type:        "string",
+						Description: "Optional SDD artifact content or path to review.",
+					},
+					"focus": {
+						Type:        "string",
+						Description: "Optional focus area for review (e.g. '4r', 'architecture', 'security', 'correctness').",
+					},
+				},
+			},
+		},
+		{
+			Name:        "sdd_propose",
+			Description: "Formulate an SDD proposal outlining change intent, scope, risks, and success criteria.",
+			InputSchema: ToolSchema{
+				Type: "object",
+				Properties: map[string]PropertySchema{
+					"change": {
+						Type:        "string",
+						Description: "Description of the proposed change.",
+					},
+					"scope": {
+						Type:        "string",
+						Description: "Optional scope boundaries and non-goals.",
+					},
+				},
+				Required: []string{"change"},
+			},
+		},
+		{
+			Name:        "sdd_spec",
+			Description: "Draft an SDD requirement specification with user stories and acceptance criteria.",
+			InputSchema: ToolSchema{
+				Type: "object",
+				Properties: map[string]PropertySchema{
+					"feature": {
+						Type:        "string",
+						Description: "Feature name or target functionality to specify.",
+					},
+					"requirements": {
+						Type:        "string",
+						Description: "Optional specific requirements or user stories.",
+					},
+				},
+				Required: []string{"feature"},
+			},
+		},
+		{
+			Name:        "sdd_design",
+			Description: "Draft an SDD technical design document detailing module architecture and data models.",
+			InputSchema: ToolSchema{
+				Type: "object",
+				Properties: map[string]PropertySchema{
+					"spec": {
+						Type:        "string",
+						Description: "Specification or target system architecture to design.",
+					},
+					"architecture": {
+						Type:        "string",
+						Description: "Optional architectural constraints or component details.",
+					},
+				},
+				Required: []string{"spec"},
+			},
+		},
+		{
+			Name:        "sdd_tasks",
+			Description: "Break down an SDD design into an actionable, sequential task checklist.",
+			InputSchema: ToolSchema{
+				Type: "object",
+				Properties: map[string]PropertySchema{
+					"design": {
+						Type:        "string",
+						Description: "Design document or system plan to break into tasks.",
+					},
+					"phases": {
+						Type:        "string",
+						Description: "Optional execution phases or sequencing guidance.",
+					},
+				},
+				Required: []string{"design"},
+			},
+		},
+	}
+}
+
+// HandleSDDExplore executes the sdd_explore reasoning tool.
+func HandleSDDExplore(args map[string]interface{}) (*ToolCallResult, error) {
+	topic, _ := args["topic"].(string)
+	if strings.TrimSpace(topic) == "" {
+		return &ToolCallResult{
+			Content: []TextContent{{Type: "text", Text: "Error: 'topic' parameter is required for sdd_explore"}},
+			IsError: true,
+		}, nil
+	}
+	ctxVal, _ := args["context"].(string)
+
+	var sb strings.Builder
+	sb.WriteString("## SDD Exploration Protocol (Reasoning Tool)\n\n")
+	sb.WriteString(fmt.Sprintf("**Topic**: %s\n", topic))
+	if ctxVal != "" {
+		sb.WriteString(fmt.Sprintf("**Context**: %s\n", ctxVal))
+	}
+	sb.WriteString("\n### Exploration Guidelines:\n")
+	sb.WriteString("1. **Codebase Inspection**: Locate relevant packages, interfaces, and entry points.\n")
+	sb.WriteString("2. **Contract Analysis**: Examine input/output data structures, errors, and side effects.\n")
+	sb.WriteString("3. **Risk Assessment**: Identify architectural dependencies and potential failure points.\n")
+	sb.WriteString("4. **Synthesis**: Document findings and prepare clear recommendations for proposal/design.\n")
+
+	return &ToolCallResult{
+		Content: []TextContent{{Type: "text", Text: sb.String()}},
+		IsError: false,
+	}, nil
+}
+
+// HandleSDDReview executes the sdd_review reasoning tool.
+func HandleSDDReview(args map[string]interface{}) (*ToolCallResult, error) {
+	artifact, _ := args["artifact"].(string)
+	focus, _ := args["focus"].(string)
+	if focus == "" {
+		focus = "4r"
+	}
+
+	var sb strings.Builder
+	sb.WriteString("## SDD 4R Review Protocol (Reasoning Tool)\n\n")
+	if artifact != "" {
+		sb.WriteString(fmt.Sprintf("**Target Artifact**: %s\n", artifact))
+	}
+	sb.WriteString(fmt.Sprintf("**Focus Area**: %s\n\n", focus))
+	sb.WriteString("### 4R Protocol Steps:\n")
+	sb.WriteString("- **Read**: Inspect source code and artifacts thoroughly without assumptions or line skipping.\n")
+	sb.WriteString("- **Reason**: Evaluate correctness, invariants, edge cases, error paths, and non-functional requirements.\n")
+	sb.WriteString("- **Reconcile**: Validate alignment with design specifications, interfaces, and project guidelines.\n")
+	sb.WriteString("- **Report**: Provide actionable, precise, and objective review feedback with line citations.\n")
+
+	return &ToolCallResult{
+		Content: []TextContent{{Type: "text", Text: sb.String()}},
+		IsError: false,
+	}, nil
+}
+
+// HandleSDDPropose executes the sdd_propose reasoning tool.
+func HandleSDDPropose(args map[string]interface{}) (*ToolCallResult, error) {
+	change, _ := args["change"].(string)
+	if strings.TrimSpace(change) == "" {
+		return &ToolCallResult{
+			Content: []TextContent{{Type: "text", Text: "Error: 'change' parameter is required for sdd_propose"}},
+			IsError: true,
+		}, nil
+	}
+	scope, _ := args["scope"].(string)
+
+	var sb strings.Builder
+	sb.WriteString("## SDD Proposal Protocol\n\n")
+	sb.WriteString(fmt.Sprintf("**Proposed Change**: %s\n", change))
+	if scope != "" {
+		sb.WriteString(fmt.Sprintf("**Scope & Boundaries**: %s\n", scope))
+	}
+	sb.WriteString("\n### Guidelines:\n")
+	sb.WriteString("- Define problem statement and motivation.\n")
+	sb.WriteString("- Outline key architectural decisions and alternative approaches considered.\n")
+	sb.WriteString("- List success criteria and explicit non-goals.\n")
+
+	return &ToolCallResult{
+		Content: []TextContent{{Type: "text", Text: sb.String()}},
+		IsError: false,
+	}, nil
+}
+
+// HandleSDDSpec executes the sdd_spec reasoning tool.
+func HandleSDDSpec(args map[string]interface{}) (*ToolCallResult, error) {
+	feature, _ := args["feature"].(string)
+	if strings.TrimSpace(feature) == "" {
+		return &ToolCallResult{
+			Content: []TextContent{{Type: "text", Text: "Error: 'feature' parameter is required for sdd_spec"}},
+			IsError: true,
+		}, nil
+	}
+
+	var sb strings.Builder
+	sb.WriteString("## SDD Specification Protocol\n\n")
+	sb.WriteString(fmt.Sprintf("**Feature**: %s\n", feature))
+	sb.WriteString("\n### Guidelines:\n")
+	sb.WriteString("- Formulate detailed functional requirements and acceptance criteria.\n")
+	sb.WriteString("- Define edge cases, error conditions, and API contracts.\n")
+
+	return &ToolCallResult{
+		Content: []TextContent{{Type: "text", Text: sb.String()}},
+		IsError: false,
+	}, nil
+}
+
+// HandleSDDDesign executes the sdd_design reasoning tool.
+func HandleSDDDesign(args map[string]interface{}) (*ToolCallResult, error) {
+	spec, _ := args["spec"].(string)
+	if strings.TrimSpace(spec) == "" {
+		return &ToolCallResult{
+			Content: []TextContent{{Type: "text", Text: "Error: 'spec' parameter is required for sdd_design"}},
+			IsError: true,
+		}, nil
+	}
+
+	var sb strings.Builder
+	sb.WriteString("## SDD Technical Design Protocol\n\n")
+	sb.WriteString(fmt.Sprintf("**Target Spec**: %s\n", spec))
+	sb.WriteString("\n### Guidelines:\n")
+	sb.WriteString("- Detail package layout, data structures, and function signatures.\n")
+	sb.WriteString("- Document concurrency, state management, and error handling strategies.\n")
+
+	return &ToolCallResult{
+		Content: []TextContent{{Type: "text", Text: sb.String()}},
+		IsError: false,
+	}, nil
+}
+
+// HandleSDDTasks executes the sdd_tasks reasoning tool.
+func HandleSDDTasks(args map[string]interface{}) (*ToolCallResult, error) {
+	design, _ := args["design"].(string)
+	if strings.TrimSpace(design) == "" {
+		return &ToolCallResult{
+			Content: []TextContent{{Type: "text", Text: "Error: 'design' parameter is required for sdd_tasks"}},
+			IsError: true,
+		}, nil
+	}
+
+	var sb strings.Builder
+	sb.WriteString("## SDD Task Breakdown Protocol\n\n")
+	sb.WriteString(fmt.Sprintf("**Design Reference**: %s\n", design))
+	sb.WriteString("\n### Guidelines:\n")
+	sb.WriteString("- Create incremental, testable tasks for implementation.\n")
+	sb.WriteString("- Mark tasks with verification criteria and dependencies.\n")
+
+	return &ToolCallResult{
+		Content: []TextContent{{Type: "text", Text: sb.String()}},
+		IsError: false,
+	}, nil
+}

--- a/internal/mcp/sdd_tools.go
+++ b/internal/mcp/sdd_tools.go
@@ -5,6 +5,16 @@ import (
 	"strings"
 )
 
+func requiredFromParams(params []sddParamConfig) []string {
+	var req []string
+	for _, p := range params {
+		if p.required {
+			req = append(req, p.key)
+		}
+	}
+	return req
+}
+
 // DefaultSDDTools returns all pre-packaged SDD reasoning tools for MCP.
 func DefaultSDDTools() []Tool {
 	return []Tool{
@@ -23,7 +33,7 @@ func DefaultSDDTools() []Tool {
 						Description: "Optional background context, constraints, or specific files to inspect.",
 					},
 				},
-				Required: []string{"topic"},
+				Required: requiredFromParams(sddExploreConfig.params),
 			},
 		},
 		{
@@ -39,8 +49,10 @@ func DefaultSDDTools() []Tool {
 					"focus": {
 						Type:        "string",
 						Description: "Optional focus area for review (e.g. '4r', 'architecture', 'security', 'correctness').",
+						Enum:        []string{"4r", "architecture", "security", "correctness"},
 					},
 				},
+				Required: requiredFromParams(sddReviewConfig.params),
 			},
 		},
 		{
@@ -58,7 +70,7 @@ func DefaultSDDTools() []Tool {
 						Description: "Optional scope boundaries and non-goals.",
 					},
 				},
-				Required: []string{"change"},
+				Required: requiredFromParams(sddProposeConfig.params),
 			},
 		},
 		{
@@ -76,7 +88,7 @@ func DefaultSDDTools() []Tool {
 						Description: "Optional specific requirements or user stories.",
 					},
 				},
-				Required: []string{"feature"},
+				Required: requiredFromParams(sddSpecConfig.params),
 			},
 		},
 		{
@@ -94,7 +106,7 @@ func DefaultSDDTools() []Tool {
 						Description: "Optional architectural constraints or component details.",
 					},
 				},
-				Required: []string{"spec"},
+				Required: requiredFromParams(sddDesignConfig.params),
 			},
 		},
 		{
@@ -112,7 +124,7 @@ func DefaultSDDTools() []Tool {
 						Description: "Optional execution phases or sequencing guidance.",
 					},
 				},
-				Required: []string{"design"},
+				Required: requiredFromParams(sddTasksConfig.params),
 			},
 		},
 	}

--- a/internal/mcp/sdd_tools.go
+++ b/internal/mcp/sdd_tools.go
@@ -118,16 +118,56 @@ func DefaultSDDTools() []Tool {
 	}
 }
 
+func getStringArg(args map[string]interface{}, key string, required bool) (string, error) {
+	if args == nil {
+		if required {
+			return "", &RPCError{
+				Code:    ErrCodeInvalidParams,
+				Message: fmt.Sprintf("missing required string parameter '%s'", key),
+			}
+		}
+		return "", nil
+	}
+
+	val, exists := args[key]
+	if !exists || val == nil {
+		if required {
+			return "", &RPCError{
+				Code:    ErrCodeInvalidParams,
+				Message: fmt.Sprintf("missing required string parameter '%s'", key),
+			}
+		}
+		return "", nil
+	}
+
+	strVal, ok := val.(string)
+	if !ok {
+		return "", &RPCError{
+			Code:    ErrCodeInvalidParams,
+			Message: fmt.Sprintf("parameter '%s' must be a string, got %T", key, val),
+		}
+	}
+
+	if required && strings.TrimSpace(strVal) == "" {
+		return "", &RPCError{
+			Code:    ErrCodeInvalidParams,
+			Message: fmt.Sprintf("required string parameter '%s' cannot be empty", key),
+		}
+	}
+
+	return strVal, nil
+}
+
 // HandleSDDExplore executes the sdd_explore reasoning tool.
 func HandleSDDExplore(args map[string]interface{}) (*ToolCallResult, error) {
-	topic, _ := args["topic"].(string)
-	if strings.TrimSpace(topic) == "" {
-		return &ToolCallResult{
-			Content: []TextContent{{Type: "text", Text: "Error: 'topic' parameter is required for sdd_explore"}},
-			IsError: true,
-		}, nil
+	topic, err := getStringArg(args, "topic", true)
+	if err != nil {
+		return nil, err
 	}
-	ctxVal, _ := args["context"].(string)
+	ctxVal, err := getStringArg(args, "context", false)
+	if err != nil {
+		return nil, err
+	}
 
 	var sb strings.Builder
 	sb.WriteString("## SDD Exploration Protocol (Reasoning Tool)\n\n")
@@ -149,8 +189,14 @@ func HandleSDDExplore(args map[string]interface{}) (*ToolCallResult, error) {
 
 // HandleSDDReview executes the sdd_review reasoning tool.
 func HandleSDDReview(args map[string]interface{}) (*ToolCallResult, error) {
-	artifact, _ := args["artifact"].(string)
-	focus, _ := args["focus"].(string)
+	artifact, err := getStringArg(args, "artifact", false)
+	if err != nil {
+		return nil, err
+	}
+	focus, err := getStringArg(args, "focus", false)
+	if err != nil {
+		return nil, err
+	}
 	if focus == "" {
 		focus = "4r"
 	}
@@ -175,14 +221,14 @@ func HandleSDDReview(args map[string]interface{}) (*ToolCallResult, error) {
 
 // HandleSDDPropose executes the sdd_propose reasoning tool.
 func HandleSDDPropose(args map[string]interface{}) (*ToolCallResult, error) {
-	change, _ := args["change"].(string)
-	if strings.TrimSpace(change) == "" {
-		return &ToolCallResult{
-			Content: []TextContent{{Type: "text", Text: "Error: 'change' parameter is required for sdd_propose"}},
-			IsError: true,
-		}, nil
+	change, err := getStringArg(args, "change", true)
+	if err != nil {
+		return nil, err
 	}
-	scope, _ := args["scope"].(string)
+	scope, err := getStringArg(args, "scope", false)
+	if err != nil {
+		return nil, err
+	}
 
 	var sb strings.Builder
 	sb.WriteString("## SDD Proposal Protocol\n\n")
@@ -203,17 +249,21 @@ func HandleSDDPropose(args map[string]interface{}) (*ToolCallResult, error) {
 
 // HandleSDDSpec executes the sdd_spec reasoning tool.
 func HandleSDDSpec(args map[string]interface{}) (*ToolCallResult, error) {
-	feature, _ := args["feature"].(string)
-	if strings.TrimSpace(feature) == "" {
-		return &ToolCallResult{
-			Content: []TextContent{{Type: "text", Text: "Error: 'feature' parameter is required for sdd_spec"}},
-			IsError: true,
-		}, nil
+	feature, err := getStringArg(args, "feature", true)
+	if err != nil {
+		return nil, err
+	}
+	reqsVal, err := getStringArg(args, "requirements", false)
+	if err != nil {
+		return nil, err
 	}
 
 	var sb strings.Builder
 	sb.WriteString("## SDD Specification Protocol\n\n")
 	sb.WriteString(fmt.Sprintf("**Feature**: %s\n", feature))
+	if reqsVal != "" {
+		sb.WriteString(fmt.Sprintf("**Requirements**: %s\n", reqsVal))
+	}
 	sb.WriteString("\n### Guidelines:\n")
 	sb.WriteString("- Formulate detailed functional requirements and acceptance criteria.\n")
 	sb.WriteString("- Define edge cases, error conditions, and API contracts.\n")
@@ -226,17 +276,21 @@ func HandleSDDSpec(args map[string]interface{}) (*ToolCallResult, error) {
 
 // HandleSDDDesign executes the sdd_design reasoning tool.
 func HandleSDDDesign(args map[string]interface{}) (*ToolCallResult, error) {
-	spec, _ := args["spec"].(string)
-	if strings.TrimSpace(spec) == "" {
-		return &ToolCallResult{
-			Content: []TextContent{{Type: "text", Text: "Error: 'spec' parameter is required for sdd_design"}},
-			IsError: true,
-		}, nil
+	spec, err := getStringArg(args, "spec", true)
+	if err != nil {
+		return nil, err
+	}
+	archVal, err := getStringArg(args, "architecture", false)
+	if err != nil {
+		return nil, err
 	}
 
 	var sb strings.Builder
 	sb.WriteString("## SDD Technical Design Protocol\n\n")
 	sb.WriteString(fmt.Sprintf("**Target Spec**: %s\n", spec))
+	if archVal != "" {
+		sb.WriteString(fmt.Sprintf("**Architecture**: %s\n", archVal))
+	}
 	sb.WriteString("\n### Guidelines:\n")
 	sb.WriteString("- Detail package layout, data structures, and function signatures.\n")
 	sb.WriteString("- Document concurrency, state management, and error handling strategies.\n")
@@ -249,17 +303,21 @@ func HandleSDDDesign(args map[string]interface{}) (*ToolCallResult, error) {
 
 // HandleSDDTasks executes the sdd_tasks reasoning tool.
 func HandleSDDTasks(args map[string]interface{}) (*ToolCallResult, error) {
-	design, _ := args["design"].(string)
-	if strings.TrimSpace(design) == "" {
-		return &ToolCallResult{
-			Content: []TextContent{{Type: "text", Text: "Error: 'design' parameter is required for sdd_tasks"}},
-			IsError: true,
-		}, nil
+	design, err := getStringArg(args, "design", true)
+	if err != nil {
+		return nil, err
+	}
+	phasesVal, err := getStringArg(args, "phases", false)
+	if err != nil {
+		return nil, err
 	}
 
 	var sb strings.Builder
 	sb.WriteString("## SDD Task Breakdown Protocol\n\n")
 	sb.WriteString(fmt.Sprintf("**Design Reference**: %s\n", design))
+	if phasesVal != "" {
+		sb.WriteString(fmt.Sprintf("**Phases**: %s\n", phasesVal))
+	}
 	sb.WriteString("\n### Guidelines:\n")
 	sb.WriteString("- Create incremental, testable tasks for implementation.\n")
 	sb.WriteString("- Mark tasks with verification criteria and dependencies.\n")

--- a/internal/mcp/sdd_tools.go
+++ b/internal/mcp/sdd_tools.go
@@ -158,172 +158,162 @@ func getStringArg(args map[string]interface{}, key string, required bool) (strin
 	return strVal, nil
 }
 
-// HandleSDDExplore executes the sdd_explore reasoning tool.
-func HandleSDDExplore(args map[string]interface{}) (*ToolCallResult, error) {
-	topic, err := getStringArg(args, "topic", true)
-	if err != nil {
-		return nil, err
-	}
-	ctxVal, err := getStringArg(args, "context", false)
-	if err != nil {
-		return nil, err
+type sddParamConfig struct {
+	key        string
+	label      string
+	required   bool
+	defaultVal string
+}
+
+type sddToolConfig struct {
+	title           string
+	params          []sddParamConfig
+	guidelinesTitle string
+	guidelines      []string
+}
+
+func handleSDDTool(cfg sddToolConfig, args map[string]interface{}) (*ToolCallResult, error) {
+	var sb strings.Builder
+	sb.WriteString(cfg.title)
+
+	for _, p := range cfg.params {
+		val, err := getStringArg(args, p.key, p.required)
+		if err != nil {
+			return nil, err
+		}
+		if val == "" && p.defaultVal != "" {
+			val = p.defaultVal
+		}
+		if val != "" {
+			sb.WriteString(fmt.Sprintf("**%s**: %s\n", p.label, val))
+		}
 	}
 
-	var sb strings.Builder
-	sb.WriteString("## SDD Exploration Protocol (Reasoning Tool)\n\n")
-	sb.WriteString(fmt.Sprintf("**Topic**: %s\n", topic))
-	if ctxVal != "" {
-		sb.WriteString(fmt.Sprintf("**Context**: %s\n", ctxVal))
+	if cfg.guidelinesTitle != "" {
+		sb.WriteString(fmt.Sprintf("\n%s\n", cfg.guidelinesTitle))
 	}
-	sb.WriteString("\n### Exploration Guidelines:\n")
-	sb.WriteString("1. **Codebase Inspection**: Locate relevant packages, interfaces, and entry points.\n")
-	sb.WriteString("2. **Contract Analysis**: Examine input/output data structures, errors, and side effects.\n")
-	sb.WriteString("3. **Risk Assessment**: Identify architectural dependencies and potential failure points.\n")
-	sb.WriteString("4. **Synthesis**: Document findings and prepare clear recommendations for proposal/design.\n")
+
+	for _, g := range cfg.guidelines {
+		sb.WriteString(fmt.Sprintf("%s\n", g))
+	}
 
 	return &ToolCallResult{
 		Content: []TextContent{{Type: "text", Text: sb.String()}},
 		IsError: false,
 	}, nil
+}
+
+var (
+	sddExploreConfig = sddToolConfig{
+		title: "## SDD Exploration Protocol (Reasoning Tool)\n\n",
+		params: []sddParamConfig{
+			{key: "topic", label: "Topic", required: true},
+			{key: "context", label: "Context", required: false},
+		},
+		guidelinesTitle: "### Exploration Guidelines:",
+		guidelines: []string{
+			"1. **Codebase Inspection**: Locate relevant packages, interfaces, and entry points.",
+			"2. **Contract Analysis**: Examine input/output data structures, errors, and side effects.",
+			"3. **Risk Assessment**: Identify architectural dependencies and potential failure points.",
+			"4. **Synthesis**: Document findings and prepare clear recommendations for proposal/design.",
+		},
+	}
+
+	sddReviewConfig = sddToolConfig{
+		title: "## SDD 4R Review Protocol (Reasoning Tool)\n\n",
+		params: []sddParamConfig{
+			{key: "artifact", label: "Target Artifact", required: false},
+			{key: "focus", label: "Focus Area", required: false, defaultVal: "4r"},
+		},
+		guidelinesTitle: "### 4R Protocol Steps:",
+		guidelines: []string{
+			"- **Read**: Inspect source code and artifacts thoroughly without assumptions or line skipping.",
+			"- **Reason**: Evaluate correctness, invariants, edge cases, error paths, and non-functional requirements.",
+			"- **Reconcile**: Validate alignment with design specifications, interfaces, and project guidelines.",
+			"- **Report**: Provide actionable, precise, and objective review feedback with line citations.",
+		},
+	}
+
+	sddProposeConfig = sddToolConfig{
+		title: "## SDD Proposal Protocol\n\n",
+		params: []sddParamConfig{
+			{key: "change", label: "Proposed Change", required: true},
+			{key: "scope", label: "Scope & Boundaries", required: false},
+		},
+		guidelinesTitle: "### Guidelines:",
+		guidelines: []string{
+			"- Define problem statement and motivation.",
+			"- Outline key architectural decisions and alternative approaches considered.",
+			"- List success criteria and explicit non-goals.",
+		},
+	}
+
+	sddSpecConfig = sddToolConfig{
+		title: "## SDD Specification Protocol\n\n",
+		params: []sddParamConfig{
+			{key: "feature", label: "Feature", required: true},
+			{key: "requirements", label: "Requirements", required: false},
+		},
+		guidelinesTitle: "### Guidelines:",
+		guidelines: []string{
+			"- Formulate detailed functional requirements and acceptance criteria.",
+			"- Define edge cases, error conditions, and API contracts.",
+		},
+	}
+
+	sddDesignConfig = sddToolConfig{
+		title: "## SDD Technical Design Protocol\n\n",
+		params: []sddParamConfig{
+			{key: "spec", label: "Target Spec", required: true},
+			{key: "architecture", label: "Architecture", required: false},
+		},
+		guidelinesTitle: "### Guidelines:",
+		guidelines: []string{
+			"- Detail package layout, data structures, and function signatures.",
+			"- Document concurrency, state management, and error handling strategies.",
+		},
+	}
+
+	sddTasksConfig = sddToolConfig{
+		title: "## SDD Task Breakdown Protocol\n\n",
+		params: []sddParamConfig{
+			{key: "design", label: "Design Reference", required: true},
+			{key: "phases", label: "Phases", required: false},
+		},
+		guidelinesTitle: "### Guidelines:",
+		guidelines: []string{
+			"- Create incremental, testable tasks for implementation.",
+			"- Mark tasks with verification criteria and dependencies.",
+		},
+	}
+)
+
+// HandleSDDExplore executes the sdd_explore reasoning tool.
+func HandleSDDExplore(args map[string]interface{}) (*ToolCallResult, error) {
+	return handleSDDTool(sddExploreConfig, args)
 }
 
 // HandleSDDReview executes the sdd_review reasoning tool.
 func HandleSDDReview(args map[string]interface{}) (*ToolCallResult, error) {
-	artifact, err := getStringArg(args, "artifact", false)
-	if err != nil {
-		return nil, err
-	}
-	focus, err := getStringArg(args, "focus", false)
-	if err != nil {
-		return nil, err
-	}
-	if focus == "" {
-		focus = "4r"
-	}
-
-	var sb strings.Builder
-	sb.WriteString("## SDD 4R Review Protocol (Reasoning Tool)\n\n")
-	if artifact != "" {
-		sb.WriteString(fmt.Sprintf("**Target Artifact**: %s\n", artifact))
-	}
-	sb.WriteString(fmt.Sprintf("**Focus Area**: %s\n\n", focus))
-	sb.WriteString("### 4R Protocol Steps:\n")
-	sb.WriteString("- **Read**: Inspect source code and artifacts thoroughly without assumptions or line skipping.\n")
-	sb.WriteString("- **Reason**: Evaluate correctness, invariants, edge cases, error paths, and non-functional requirements.\n")
-	sb.WriteString("- **Reconcile**: Validate alignment with design specifications, interfaces, and project guidelines.\n")
-	sb.WriteString("- **Report**: Provide actionable, precise, and objective review feedback with line citations.\n")
-
-	return &ToolCallResult{
-		Content: []TextContent{{Type: "text", Text: sb.String()}},
-		IsError: false,
-	}, nil
+	return handleSDDTool(sddReviewConfig, args)
 }
 
 // HandleSDDPropose executes the sdd_propose reasoning tool.
 func HandleSDDPropose(args map[string]interface{}) (*ToolCallResult, error) {
-	change, err := getStringArg(args, "change", true)
-	if err != nil {
-		return nil, err
-	}
-	scope, err := getStringArg(args, "scope", false)
-	if err != nil {
-		return nil, err
-	}
-
-	var sb strings.Builder
-	sb.WriteString("## SDD Proposal Protocol\n\n")
-	sb.WriteString(fmt.Sprintf("**Proposed Change**: %s\n", change))
-	if scope != "" {
-		sb.WriteString(fmt.Sprintf("**Scope & Boundaries**: %s\n", scope))
-	}
-	sb.WriteString("\n### Guidelines:\n")
-	sb.WriteString("- Define problem statement and motivation.\n")
-	sb.WriteString("- Outline key architectural decisions and alternative approaches considered.\n")
-	sb.WriteString("- List success criteria and explicit non-goals.\n")
-
-	return &ToolCallResult{
-		Content: []TextContent{{Type: "text", Text: sb.String()}},
-		IsError: false,
-	}, nil
+	return handleSDDTool(sddProposeConfig, args)
 }
 
 // HandleSDDSpec executes the sdd_spec reasoning tool.
 func HandleSDDSpec(args map[string]interface{}) (*ToolCallResult, error) {
-	feature, err := getStringArg(args, "feature", true)
-	if err != nil {
-		return nil, err
-	}
-	reqsVal, err := getStringArg(args, "requirements", false)
-	if err != nil {
-		return nil, err
-	}
-
-	var sb strings.Builder
-	sb.WriteString("## SDD Specification Protocol\n\n")
-	sb.WriteString(fmt.Sprintf("**Feature**: %s\n", feature))
-	if reqsVal != "" {
-		sb.WriteString(fmt.Sprintf("**Requirements**: %s\n", reqsVal))
-	}
-	sb.WriteString("\n### Guidelines:\n")
-	sb.WriteString("- Formulate detailed functional requirements and acceptance criteria.\n")
-	sb.WriteString("- Define edge cases, error conditions, and API contracts.\n")
-
-	return &ToolCallResult{
-		Content: []TextContent{{Type: "text", Text: sb.String()}},
-		IsError: false,
-	}, nil
+	return handleSDDTool(sddSpecConfig, args)
 }
 
 // HandleSDDDesign executes the sdd_design reasoning tool.
 func HandleSDDDesign(args map[string]interface{}) (*ToolCallResult, error) {
-	spec, err := getStringArg(args, "spec", true)
-	if err != nil {
-		return nil, err
-	}
-	archVal, err := getStringArg(args, "architecture", false)
-	if err != nil {
-		return nil, err
-	}
-
-	var sb strings.Builder
-	sb.WriteString("## SDD Technical Design Protocol\n\n")
-	sb.WriteString(fmt.Sprintf("**Target Spec**: %s\n", spec))
-	if archVal != "" {
-		sb.WriteString(fmt.Sprintf("**Architecture**: %s\n", archVal))
-	}
-	sb.WriteString("\n### Guidelines:\n")
-	sb.WriteString("- Detail package layout, data structures, and function signatures.\n")
-	sb.WriteString("- Document concurrency, state management, and error handling strategies.\n")
-
-	return &ToolCallResult{
-		Content: []TextContent{{Type: "text", Text: sb.String()}},
-		IsError: false,
-	}, nil
+	return handleSDDTool(sddDesignConfig, args)
 }
 
 // HandleSDDTasks executes the sdd_tasks reasoning tool.
 func HandleSDDTasks(args map[string]interface{}) (*ToolCallResult, error) {
-	design, err := getStringArg(args, "design", true)
-	if err != nil {
-		return nil, err
-	}
-	phasesVal, err := getStringArg(args, "phases", false)
-	if err != nil {
-		return nil, err
-	}
-
-	var sb strings.Builder
-	sb.WriteString("## SDD Task Breakdown Protocol\n\n")
-	sb.WriteString(fmt.Sprintf("**Design Reference**: %s\n", design))
-	if phasesVal != "" {
-		sb.WriteString(fmt.Sprintf("**Phases**: %s\n", phasesVal))
-	}
-	sb.WriteString("\n### Guidelines:\n")
-	sb.WriteString("- Create incremental, testable tasks for implementation.\n")
-	sb.WriteString("- Mark tasks with verification criteria and dependencies.\n")
-
-	return &ToolCallResult{
-		Content: []TextContent{{Type: "text", Text: sb.String()}},
-		IsError: false,
-	}, nil
+	return handleSDDTool(sddTasksConfig, args)
 }

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1,6 +1,8 @@
 package mcp
 
 import (
+	"bufio"
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -76,37 +78,78 @@ func (s *Server) registerDefaultTools() {
 }
 
 // Serve starts processing stdio JSON-RPC 2.0 requests from r and writing responses to w.
-// Uses json.NewDecoder to naturally handle multiline / pretty-printed JSON payloads.
+// Uses bufio.Reader to process stdio payloads line-by-line and recover cleanly from parse errors.
 func (s *Server) Serve(r io.Reader, w io.Writer) error {
 	s.mu.Lock()
 	s.writer = w
 	s.mu.Unlock()
 
-	dec := json.NewDecoder(r)
+	reader := bufio.NewReader(r)
+	var buf bytes.Buffer
+
 	for {
-		var raw json.RawMessage
-		if err := dec.Decode(&raw); err != nil {
-			if errors.Is(err, io.EOF) {
+		line, readErr := reader.ReadBytes('\n')
+		if len(line) == 0 && readErr != nil {
+			if errors.Is(readErr, io.EOF) {
 				return nil
 			}
+			return readErr
+		}
+
+		buf.Write(line)
+		trimmed := bytes.TrimSpace(buf.Bytes())
+		if len(trimmed) == 0 {
+			buf.Reset()
+			if readErr != nil {
+				if errors.Is(readErr, io.EOF) {
+					return nil
+				}
+				return readErr
+			}
+			continue
+		}
+
+		var raw json.RawMessage
+		if err := json.Unmarshal(trimmed, &raw); err != nil {
+			if isIncompleteJSON(err, trimmed) && readErr == nil {
+				continue
+			}
+			buf.Reset()
 			if writeErr := s.writeError(nil, ErrCodeParseError, "Parse error: invalid JSON payload", nil); writeErr != nil {
 				return writeErr
 			}
-			mr := io.MultiReader(dec.Buffered(), r)
-			buf := make([]byte, 1)
-			for {
-				_, readErr := mr.Read(buf)
-				if readErr != nil || buf[0] == '\n' {
-					break
+			if readErr != nil {
+				if errors.Is(readErr, io.EOF) {
+					return nil
 				}
+				return readErr
 			}
-			dec = json.NewDecoder(mr)
 			continue
 		}
+
+		buf.Reset()
 		if err := s.handleMessage(raw); err != nil {
 			return err
 		}
+
+		if readErr != nil {
+			if errors.Is(readErr, io.EOF) {
+				return nil
+			}
+			return readErr
+		}
 	}
+}
+
+func isIncompleteJSON(err error, data []byte) bool {
+	if errors.Is(err, io.ErrUnexpectedEOF) || errors.Is(err, io.EOF) {
+		return true
+	}
+	var syntaxErr *json.SyntaxError
+	if errors.As(err, &syntaxErr) {
+		return syntaxErr.Offset >= int64(len(data))
+	}
+	return false
 }
 
 func (s *Server) handleMessage(data []byte) error {

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1,0 +1,219 @@
+package mcp
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+	"sync"
+)
+
+// ToolHandler represents a function handling an MCP tool invocation.
+type ToolHandler func(args map[string]interface{}) (*ToolCallResult, error)
+
+// Server represents a stdio JSON-RPC 2.0 MCP server.
+type Server struct {
+	mu       sync.RWMutex
+	tools    map[string]Tool
+	handlers map[string]ToolHandler
+	writer   io.Writer
+}
+
+// NewServer creates a new Server pre-populated with standard SDD reasoning tools.
+func NewServer() *Server {
+	s := &Server{
+		tools:    make(map[string]Tool),
+		handlers: make(map[string]ToolHandler),
+	}
+
+	s.registerDefaultTools()
+	return s
+}
+
+// RegisterTool registers a new MCP tool with its execution handler.
+func (s *Server) RegisterTool(tool Tool, handler ToolHandler) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.tools[tool.Name] = tool
+	s.handlers[tool.Name] = handler
+}
+
+// registerDefaultTools populates default SDD reasoning tools into the server.
+func (s *Server) registerDefaultTools() {
+	defaultHandlers := map[string]ToolHandler{
+		"sdd_explore": HandleSDDExplore,
+		"sdd_review":  HandleSDDReview,
+		"sdd_propose": HandleSDDPropose,
+		"sdd_spec":    HandleSDDSpec,
+		"sdd_design":  HandleSDDDesign,
+		"sdd_tasks":   HandleSDDTasks,
+	}
+
+	for _, tool := range DefaultSDDTools() {
+		if handler, ok := defaultHandlers[tool.Name]; ok {
+			s.tools[tool.Name] = tool
+			s.handlers[tool.Name] = handler
+		}
+	}
+}
+
+// Serve starts processing stdio JSON-RPC 2.0 requests from r and writing responses to w.
+// Uses a 2MB buffer (MaxBufferSize) to prevent payload truncation for large payloads.
+func (s *Server) Serve(r io.Reader, w io.Writer) error {
+	s.mu.Lock()
+	s.writer = w
+	s.mu.Unlock()
+
+	scanner := bufio.NewScanner(r)
+	buf := make([]byte, 64*1024)
+	scanner.Buffer(buf, MaxBufferSize)
+
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		_ = s.handleMessage(line)
+	}
+
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("mcp scanner error: %w", err)
+	}
+	return nil
+}
+
+func (s *Server) handleMessage(data []byte) error {
+	var req Request
+	if err := json.Unmarshal(data, &req); err != nil {
+		return s.writeError(nil, ErrCodeParseError, "Parse error: invalid JSON payload", nil)
+	}
+
+	// Validate JSON-RPC version
+	if req.JSONRPC != JSONRPCVersion {
+		if req.ID != nil {
+			return s.writeError(req.ID, ErrCodeInvalidRequest, "Invalid JSON-RPC version, expected '2.0'", nil)
+		}
+		return nil
+	}
+
+	switch req.Method {
+	case "initialize":
+		result := InitializeResult{
+			ProtocolVersion: "2024-11-05",
+			Capabilities: ServerCapabilities{
+				Tools: map[string]interface{}{},
+			},
+			ServerInfo: ServerInfo{
+				Name:    "gentle-ai",
+				Version: "1.0.0",
+			},
+		}
+		return s.writeResult(req.ID, result)
+
+	case "notifications/initialized":
+		// Notification method, no response returned.
+		return nil
+
+	case "ping":
+		return s.writeResult(req.ID, map[string]interface{}{})
+
+	case "tools/list":
+		s.mu.RLock()
+		toolsList := make([]Tool, 0, len(s.tools))
+		for _, tool := range s.tools {
+			toolsList = append(toolsList, tool)
+		}
+		s.mu.RUnlock()
+
+		sort.Slice(toolsList, func(i, j int) bool {
+			return toolsList[i].Name < toolsList[j].Name
+		})
+
+		return s.writeResult(req.ID, ListToolsResult{Tools: toolsList})
+
+	case "tools/call":
+		var params ToolCallParams
+		if len(req.Params) > 0 {
+			if err := json.Unmarshal(req.Params, &params); err != nil {
+				return s.writeError(req.ID, ErrCodeInvalidParams, "Invalid params for tools/call", nil)
+			}
+		}
+
+		s.mu.RLock()
+		handler, exists := s.handlers[params.Name]
+		s.mu.RUnlock()
+
+		if !exists {
+			return s.writeResult(req.ID, ToolCallResult{
+				Content: []TextContent{{Type: "text", Text: fmt.Sprintf("Tool not found: %s", params.Name)}},
+				IsError: true,
+			})
+		}
+
+		res, err := handler(params.Arguments)
+		if err != nil {
+			return s.writeResult(req.ID, ToolCallResult{
+				Content: []TextContent{{Type: "text", Text: fmt.Sprintf("Tool execution error: %v", err)}},
+				IsError: true,
+			})
+		}
+
+		if res == nil {
+			res = &ToolCallResult{
+				Content: []TextContent{{Type: "text", Text: ""}},
+			}
+		}
+		return s.writeResult(req.ID, res)
+
+	default:
+		// If req.ID is present, return MethodNotFound error.
+		if req.ID != nil {
+			return s.writeError(req.ID, ErrCodeMethodNotFound, fmt.Sprintf("Method not found: %s", req.Method), nil)
+		}
+		return nil
+	}
+}
+
+func (s *Server) writeResult(id interface{}, result interface{}) error {
+	if id == nil {
+		return nil
+	}
+	resp := Response{
+		JSONRPC: JSONRPCVersion,
+		ID:      id,
+		Result:  result,
+	}
+	return s.sendResponse(resp)
+}
+
+func (s *Server) writeError(id interface{}, code int, message string, data interface{}) error {
+	resp := Response{
+		JSONRPC: JSONRPCVersion,
+		ID:      id,
+		Error: &RPCError{
+			Code:    code,
+			Message: message,
+			Data:    data,
+		},
+	}
+	return s.sendResponse(resp)
+}
+
+func (s *Server) sendResponse(resp Response) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.writer == nil {
+		return fmt.Errorf("server writer is nil")
+	}
+
+	data, err := json.Marshal(resp)
+	if err != nil {
+		return fmt.Errorf("marshal response error: %w", err)
+	}
+
+	data = append(data, '\n')
+	_, err = s.writer.Write(data)
+	return err
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -78,7 +78,7 @@ func (s *Server) Serve(r io.Reader, w io.Writer) error {
 			if writeErr := s.writeError(nil, ErrCodeParseError, "Parse error: invalid JSON payload", nil); writeErr != nil {
 				return writeErr
 			}
-			return nil
+			continue
 		}
 		if err := s.handleMessage(raw); err != nil {
 			return err
@@ -188,7 +188,7 @@ func (s *Server) writeResult(id interface{}, result interface{}) error {
 }
 
 func (s *Server) writeError(id interface{}, code int, message string, data interface{}) error {
-	if id == nil {
+	if id == nil && code != ErrCodeParseError {
 		return nil
 	}
 	resp := Response{

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"sort"
+	"strings"
 	"sync"
 )
 
@@ -97,6 +98,13 @@ func (s *Server) Serve(r io.Reader, w io.Writer) error {
 		}
 
 		buf.Write(line)
+		if buf.Len() > maxBufferCap {
+			buf.Reset()
+			if writeErr := s.writeError(nil, ErrCodeParseError, "Parse error: payload exceeds maximum allowed size", nil); writeErr != nil {
+				return writeErr
+			}
+			continue
+		}
 		trimmed := bytes.TrimSpace(buf.Bytes())
 		if len(trimmed) == 0 {
 			buf.Reset()
@@ -141,15 +149,14 @@ func (s *Server) Serve(r io.Reader, w io.Writer) error {
 	}
 }
 
+const maxBufferCap = 4 * 1024 * 1024 // 4MB
+
 func isIncompleteJSON(err error, data []byte) bool {
 	if errors.Is(err, io.ErrUnexpectedEOF) || errors.Is(err, io.EOF) {
 		return true
 	}
-	var syntaxErr *json.SyntaxError
-	if errors.As(err, &syntaxErr) {
-		return syntaxErr.Offset >= int64(len(data))
-	}
-	return false
+	msg := err.Error()
+	return strings.Contains(msg, "unexpected end of JSON input") || strings.Contains(msg, "unexpected EOF")
 }
 
 func (s *Server) handleMessage(data []byte) error {

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -18,17 +18,31 @@ type Server struct {
 	tools    map[string]Tool
 	handlers map[string]ToolHandler
 	writer   io.Writer
+	version  string
 }
 
 // NewServer creates a new Server pre-populated with standard SDD reasoning tools.
-func NewServer() *Server {
+// An optional build version string can be supplied; defaults to "1.0.0" if omitted.
+func NewServer(version ...string) *Server {
+	ver := "1.0.0"
+	if len(version) > 0 && version[0] != "" {
+		ver = version[0]
+	}
 	s := &Server{
 		tools:    make(map[string]Tool),
 		handlers: make(map[string]ToolHandler),
+		version:  ver,
 	}
 
 	s.registerDefaultTools()
 	return s
+}
+
+// SetVersion sets the build version string returned in serverInfo during initialize.
+func (s *Server) SetVersion(version string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.version = version
 }
 
 // RegisterTool registers a new MCP tool with its execution handler.
@@ -78,6 +92,15 @@ func (s *Server) Serve(r io.Reader, w io.Writer) error {
 			if writeErr := s.writeError(nil, ErrCodeParseError, "Parse error: invalid JSON payload", nil); writeErr != nil {
 				return writeErr
 			}
+			mr := io.MultiReader(dec.Buffered(), r)
+			buf := make([]byte, 1)
+			for {
+				_, readErr := mr.Read(buf)
+				if readErr != nil || buf[0] == '\n' {
+					break
+				}
+			}
+			dec = json.NewDecoder(mr)
 			continue
 		}
 		if err := s.handleMessage(raw); err != nil {
@@ -99,6 +122,23 @@ func (s *Server) handleMessage(data []byte) error {
 
 	switch req.Method {
 	case "initialize":
+		var params struct {
+			ProtocolVersion string `json:"protocolVersion"`
+		}
+		if len(req.Params) > 0 {
+			_ = json.Unmarshal(req.Params, &params)
+		}
+		if params.ProtocolVersion != "" && params.ProtocolVersion != "2024-11-05" {
+			return s.writeError(req.ID, ErrCodeInvalidParams, fmt.Sprintf("Unsupported protocol version: %s", params.ProtocolVersion), nil)
+		}
+
+		s.mu.RLock()
+		ver := s.version
+		s.mu.RUnlock()
+		if ver == "" {
+			ver = "1.0.0"
+		}
+
 		result := InitializeResult{
 			ProtocolVersion: "2024-11-05",
 			Capabilities: ServerCapabilities{
@@ -106,7 +146,7 @@ func (s *Server) handleMessage(data []byte) error {
 			},
 			ServerInfo: ServerInfo{
 				Name:    "gentle-ai",
-				Version: "1.0.0",
+				Version: ver,
 			},
 		}
 		return s.writeResult(req.ID, result)

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1,8 +1,8 @@
 package mcp
 
 import (
-	"bufio"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"sort"
@@ -41,6 +41,9 @@ func (s *Server) RegisterTool(tool Tool, handler ToolHandler) {
 
 // registerDefaultTools populates default SDD reasoning tools into the server.
 func (s *Server) registerDefaultTools() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	defaultHandlers := map[string]ToolHandler{
 		"sdd_explore": HandleSDDExplore,
 		"sdd_review":  HandleSDDReview,
@@ -59,28 +62,28 @@ func (s *Server) registerDefaultTools() {
 }
 
 // Serve starts processing stdio JSON-RPC 2.0 requests from r and writing responses to w.
-// Uses a 2MB buffer (MaxBufferSize) to prevent payload truncation for large payloads.
+// Uses json.NewDecoder to naturally handle multiline / pretty-printed JSON payloads.
 func (s *Server) Serve(r io.Reader, w io.Writer) error {
 	s.mu.Lock()
 	s.writer = w
 	s.mu.Unlock()
 
-	scanner := bufio.NewScanner(r)
-	buf := make([]byte, 64*1024)
-	scanner.Buffer(buf, MaxBufferSize)
-
-	for scanner.Scan() {
-		line := scanner.Bytes()
-		if len(line) == 0 {
-			continue
+	dec := json.NewDecoder(r)
+	for {
+		var raw json.RawMessage
+		if err := dec.Decode(&raw); err != nil {
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+			if writeErr := s.writeError(nil, ErrCodeParseError, "Parse error: invalid JSON payload", nil); writeErr != nil {
+				return writeErr
+			}
+			return nil
 		}
-		_ = s.handleMessage(line)
+		if err := s.handleMessage(raw); err != nil {
+			return err
+		}
 	}
-
-	if err := scanner.Err(); err != nil {
-		return fmt.Errorf("mcp scanner error: %w", err)
-	}
-	return nil
 }
 
 func (s *Server) handleMessage(data []byte) error {
@@ -91,10 +94,7 @@ func (s *Server) handleMessage(data []byte) error {
 
 	// Validate JSON-RPC version
 	if req.JSONRPC != JSONRPCVersion {
-		if req.ID != nil {
-			return s.writeError(req.ID, ErrCodeInvalidRequest, "Invalid JSON-RPC version, expected '2.0'", nil)
-		}
-		return nil
+		return s.writeError(req.ID, ErrCodeInvalidRequest, "Invalid JSON-RPC version, expected '2.0'", nil)
 	}
 
 	switch req.Method {
@@ -153,6 +153,10 @@ func (s *Server) handleMessage(data []byte) error {
 
 		res, err := handler(params.Arguments)
 		if err != nil {
+			var rpcErr *RPCError
+			if errors.As(err, &rpcErr) {
+				return s.writeError(req.ID, rpcErr.Code, rpcErr.Message, rpcErr.Data)
+			}
 			return s.writeResult(req.ID, ToolCallResult{
 				Content: []TextContent{{Type: "text", Text: fmt.Sprintf("Tool execution error: %v", err)}},
 				IsError: true,
@@ -167,11 +171,7 @@ func (s *Server) handleMessage(data []byte) error {
 		return s.writeResult(req.ID, res)
 
 	default:
-		// If req.ID is present, return MethodNotFound error.
-		if req.ID != nil {
-			return s.writeError(req.ID, ErrCodeMethodNotFound, fmt.Sprintf("Method not found: %s", req.Method), nil)
-		}
-		return nil
+		return s.writeError(req.ID, ErrCodeMethodNotFound, fmt.Sprintf("Method not found: %s", req.Method), nil)
 	}
 }
 
@@ -188,6 +188,9 @@ func (s *Server) writeResult(id interface{}, result interface{}) error {
 }
 
 func (s *Server) writeError(id interface{}, code int, message string, data interface{}) error {
+	if id == nil {
+		return nil
+	}
 	resp := Response{
 		JSONRPC: JSONRPCVersion,
 		ID:      id,

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -594,6 +594,39 @@ func TestServerRecoversFromMalformedJSON(t *testing.T) {
 	}
 }
 
+func TestServerRecoversFromConsecutiveMalformedJSON(t *testing.T) {
+	server := mcp.NewServer()
+
+	reqJSON := "invalid json 1\ninvalid json 2\ninvalid json 3\n" + `{"jsonrpc":"2.0","id":42,"method":"ping"}` + "\n"
+	in := strings.NewReader(reqJSON)
+	out := &bytes.Buffer{}
+
+	if err := server.Serve(in, out); err != nil {
+		t.Fatalf("Serve returned error: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	if len(lines) != 4 {
+		t.Fatalf("Expected 4 response lines, got %d: %s", len(lines), out.String())
+	}
+
+	for i := 0; i < 3; i++ {
+		resp := parseResponse(t, []byte(lines[i]))
+		if resp.Error == nil || resp.Error.Code != mcp.ErrCodeParseError {
+			t.Errorf("Expected response %d ErrCodeParseError, got: %v", i+1, resp.Error)
+		}
+	}
+
+	resp := parseResponse(t, []byte(lines[3]))
+	if resp.Error != nil {
+		t.Errorf("Expected last response no error, got: %v", resp.Error)
+	}
+	if resp.ID != float64(42) {
+		t.Errorf("Expected last response ID 42, got: %v", resp.ID)
+	}
+}
+
+
 func TestServerSetVersionAndProtocolVersionValidation(t *testing.T) {
 	t.Run("Custom version threaded into serverInfo", func(t *testing.T) {
 		server := mcp.NewServer()

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -472,15 +472,18 @@ func TestServer2MBPayloadHandling(t *testing.T) {
 func TestServerJSONRPCErrorHandling(t *testing.T) {
 	server := mcp.NewServer()
 
-	t.Run("Parse Error ignored for notification or handled cleanly", func(t *testing.T) {
+	t.Run("Parse Error emits response with id null", func(t *testing.T) {
 		reqJSON := `{"jsonrpc":"2.0", invalid json` + "\n"
 		in := strings.NewReader(reqJSON)
 		out := &bytes.Buffer{}
 
 		_ = server.Serve(in, out)
-		// Parse Error has id == nil so writeError returns nil (no reply to notifications / unparseable JSON without ID)
-		if out.Len() != 0 {
-			t.Errorf("Expected 0 bytes output for notification parse error, got: %s", out.String())
+		resp := parseResponse(t, out.Bytes())
+		if resp.Error == nil || resp.Error.Code != mcp.ErrCodeParseError {
+			t.Errorf("Expected ErrCodeParseError (-32700), got: %v", resp.Error)
+		}
+		if resp.ID != nil {
+			t.Errorf("Expected ID nil (null), got: %v", resp.ID)
 		}
 	})
 
@@ -555,5 +558,38 @@ func TestServerCustomToolRegistration(t *testing.T) {
 
 	if len(callResult.Content) == 0 || callResult.Content[0].Text != "Custom response" {
 		t.Errorf("Expected custom response text, got %v", callResult.Content)
+	}
+}
+
+func TestServerRecoversFromMalformedJSON(t *testing.T) {
+	server := mcp.NewServer()
+
+	reqJSON := "invalid json payload\n" + `{"jsonrpc":"2.0","id":42,"method":"ping"}` + "\n"
+	in := strings.NewReader(reqJSON)
+	out := &bytes.Buffer{}
+
+	if err := server.Serve(in, out); err != nil {
+		t.Fatalf("Serve returned error: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("Expected 2 response lines, got %d: %s", len(lines), out.String())
+	}
+
+	resp1 := parseResponse(t, []byte(lines[0]))
+	if resp1.Error == nil || resp1.Error.Code != mcp.ErrCodeParseError {
+		t.Errorf("Expected first response ErrCodeParseError, got: %v", resp1.Error)
+	}
+	if resp1.ID != nil {
+		t.Errorf("Expected first response ID nil, got: %v", resp1.ID)
+	}
+
+	resp2 := parseResponse(t, []byte(lines[1]))
+	if resp2.Error != nil {
+		t.Errorf("Expected second response no error, got: %v", resp2.Error)
+	}
+	if resp2.ID != float64(42) {
+		t.Errorf("Expected second response ID 42, got: %v", resp2.ID)
 	}
 }

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -3,6 +3,7 @@ package mcp_test
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -130,7 +131,7 @@ func TestServerToolsCallSDDExplore(t *testing.T) {
 		}
 	})
 
-	t.Run("Missing required topic argument", func(t *testing.T) {
+	t.Run("Missing required topic argument returns ErrCodeInvalidParams", func(t *testing.T) {
 		reqJSON := `{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"sdd_explore","arguments":{}}}` + "\n"
 		in := strings.NewReader(reqJSON)
 		out := &bytes.Buffer{}
@@ -140,12 +141,11 @@ func TestServerToolsCallSDDExplore(t *testing.T) {
 		}
 
 		resp := parseResponse(t, out.Bytes())
-		var callResult mcp.ToolCallResult
-		rawResult, _ := json.Marshal(resp.Result)
-		_ = json.Unmarshal(rawResult, &callResult)
-
-		if !callResult.IsError {
-			t.Errorf("Expected IsError true for missing required topic")
+		if resp.Error == nil {
+			t.Fatal("Expected error response for missing required topic, got nil")
+		}
+		if resp.Error.Code != mcp.ErrCodeInvalidParams {
+			t.Errorf("Expected code %d, got %d", mcp.ErrCodeInvalidParams, resp.Error.Code)
 		}
 	})
 }
@@ -202,7 +202,7 @@ func TestServerToolsCallAdditionalSDDTools(t *testing.T) {
 			name:        "sdd_propose missing change",
 			toolName:    "sdd_propose",
 			arguments:   `{}`,
-			wantText:    "parameter is required",
+			wantText:    "missing required string parameter",
 			expectError: true,
 		},
 		{
@@ -216,7 +216,7 @@ func TestServerToolsCallAdditionalSDDTools(t *testing.T) {
 			name:        "sdd_spec missing feature",
 			toolName:    "sdd_spec",
 			arguments:   `{}`,
-			wantText:    "parameter is required",
+			wantText:    "missing required string parameter",
 			expectError: true,
 		},
 		{
@@ -230,7 +230,7 @@ func TestServerToolsCallAdditionalSDDTools(t *testing.T) {
 			name:        "sdd_design missing spec",
 			toolName:    "sdd_design",
 			arguments:   `{}`,
-			wantText:    "parameter is required",
+			wantText:    "missing required string parameter",
 			expectError: true,
 		},
 		{
@@ -244,7 +244,7 @@ func TestServerToolsCallAdditionalSDDTools(t *testing.T) {
 			name:        "sdd_tasks missing design",
 			toolName:    "sdd_tasks",
 			arguments:   `{}`,
-			wantText:    "parameter is required",
+			wantText:    "missing required string parameter",
 			expectError: true,
 		},
 	}
@@ -260,15 +260,27 @@ func TestServerToolsCallAdditionalSDDTools(t *testing.T) {
 			}
 
 			resp := parseResponse(t, out.Bytes())
-			var callResult mcp.ToolCallResult
-			rawResult, _ := json.Marshal(resp.Result)
-			_ = json.Unmarshal(rawResult, &callResult)
+			if tt.expectError {
+				if resp.Error == nil {
+					t.Fatalf("Expected error response, got nil")
+				}
+				if resp.Error.Code != mcp.ErrCodeInvalidParams {
+					t.Errorf("Expected code %d, got %d", mcp.ErrCodeInvalidParams, resp.Error.Code)
+				}
+				if !strings.Contains(resp.Error.Message, tt.wantText) {
+					t.Errorf("Expected error message containing %q, got %q", tt.wantText, resp.Error.Message)
+				}
+			} else {
+				if resp.Error != nil {
+					t.Fatalf("Expected no error, got %v", resp.Error)
+				}
+				var callResult mcp.ToolCallResult
+				rawResult, _ := json.Marshal(resp.Result)
+				_ = json.Unmarshal(rawResult, &callResult)
 
-			if callResult.IsError != tt.expectError {
-				t.Errorf("IsError = %v, want %v", callResult.IsError, tt.expectError)
-			}
-			if len(callResult.Content) == 0 || !strings.Contains(callResult.Content[0].Text, tt.wantText) {
-				t.Errorf("Expected content to contain %q, got: %v", tt.wantText, callResult.Content)
+				if len(callResult.Content) == 0 || !strings.Contains(callResult.Content[0].Text, tt.wantText) {
+					t.Errorf("Expected content to contain %q, got: %v", tt.wantText, callResult.Content)
+				}
 			}
 		})
 	}
@@ -298,10 +310,141 @@ func TestServerToolsCallUnknownTool(t *testing.T) {
 	}
 }
 
+func TestServerMultilineJSON(t *testing.T) {
+	server := mcp.NewServer()
+
+	prettyJSON := `{
+		"jsonrpc": "2.0",
+		"id": 99,
+		"method": "ping"
+	}`
+	in := strings.NewReader(prettyJSON)
+	out := &bytes.Buffer{}
+
+	if err := server.Serve(in, out); err != nil {
+		t.Fatalf("Serve returned error for multiline JSON: %v", err)
+	}
+
+	resp := parseResponse(t, out.Bytes())
+	if resp.Error != nil {
+		t.Fatalf("Expected no error, got %v", resp.Error)
+	}
+	if resp.ID != float64(99) {
+		t.Errorf("Expected ID 99, got %v", resp.ID)
+	}
+}
+
+func TestServerNotificationErrors(t *testing.T) {
+	server := mcp.NewServer()
+
+	tests := []struct {
+		name string
+		json string
+	}{
+		{
+			name: "Notification with invalid JSON-RPC version",
+			json: `{"jsonrpc":"1.0","method":"ping"}`,
+		},
+		{
+			name: "Notification with unknown method",
+			json: `{"jsonrpc":"2.0","method":"non_existent_method"}`,
+		},
+		{
+			name: "Notification with invalid tool params",
+			json: `{"jsonrpc":"2.0","method":"tools/call","params":{"name":"sdd_explore","arguments":{}}}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			in := strings.NewReader(tt.json)
+			out := &bytes.Buffer{}
+
+			if err := server.Serve(in, out); err != nil {
+				t.Fatalf("Serve error: %v", err)
+			}
+
+			if out.Len() != 0 {
+				t.Errorf("Expected no response written for notification error, got: %s", out.String())
+			}
+		})
+	}
+}
+
+func TestServerInvalidParamsTypeSafety(t *testing.T) {
+	server := mcp.NewServer()
+
+	tests := []struct {
+		name string
+		json string
+	}{
+		{
+			name: "Non-string topic in sdd_explore",
+			json: `{"jsonrpc":"2.0","id":201,"method":"tools/call","params":{"name":"sdd_explore","arguments":{"topic":123}}}`,
+		},
+		{
+			name: "Whitespace-only topic in sdd_explore",
+			json: `{"jsonrpc":"2.0","id":202,"method":"tools/call","params":{"name":"sdd_explore","arguments":{"topic":"   "}}}`,
+		},
+		{
+			name: "Non-string context in sdd_explore",
+			json: `{"jsonrpc":"2.0","id":203,"method":"tools/call","params":{"name":"sdd_explore","arguments":{"topic":"Valid", "context": true}}}`,
+		},
+		{
+			name: "Non-string artifact in sdd_review",
+			json: `{"jsonrpc":"2.0","id":204,"method":"tools/call","params":{"name":"sdd_review","arguments":{"artifact": 999}}}`,
+		},
+		{
+			name: "Non-string focus in sdd_review",
+			json: `{"jsonrpc":"2.0","id":205,"method":"tools/call","params":{"name":"sdd_review","arguments":{"focus": []}}}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			in := strings.NewReader(tt.json)
+			out := &bytes.Buffer{}
+
+			if err := server.Serve(in, out); err != nil {
+				t.Fatalf("Serve error: %v", err)
+			}
+
+			resp := parseResponse(t, out.Bytes())
+			if resp.Error == nil {
+				t.Fatalf("Expected ErrCodeInvalidParams error response, got nil")
+			}
+			if resp.Error.Code != mcp.ErrCodeInvalidParams {
+				t.Errorf("Expected error code %d, got %d", mcp.ErrCodeInvalidParams, resp.Error.Code)
+			}
+		})
+	}
+}
+
+type errWriter struct{}
+
+func (e *errWriter) Write(p []byte) (n int, err error) {
+	return 0, errors.New("simulated write error")
+}
+
+func TestServerWriteError(t *testing.T) {
+	server := mcp.NewServer()
+
+	reqJSON := `{"jsonrpc":"2.0","id":1,"method":"ping"}` + "\n"
+	in := strings.NewReader(reqJSON)
+	out := &errWriter{}
+
+	err := server.Serve(in, out)
+	if err == nil {
+		t.Fatal("Expected Serve to return error on write error, got nil")
+	}
+	if !strings.Contains(err.Error(), "simulated write error") {
+		t.Errorf("Expected 'simulated write error', got %v", err)
+	}
+}
+
 func TestServer2MBPayloadHandling(t *testing.T) {
 	server := mcp.NewServer()
 
-	// Generate a 500KB string payload (exceeds default scanner limit of 64KB)
 	largeString := strings.Repeat("A", 500*1024)
 	reqJSON := fmt.Sprintf(`{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"sdd_explore","arguments":{"topic":"%s"}}}`, largeString) + "\n"
 
@@ -329,16 +472,15 @@ func TestServer2MBPayloadHandling(t *testing.T) {
 func TestServerJSONRPCErrorHandling(t *testing.T) {
 	server := mcp.NewServer()
 
-	t.Run("Parse Error (-32700)", func(t *testing.T) {
+	t.Run("Parse Error ignored for notification or handled cleanly", func(t *testing.T) {
 		reqJSON := `{"jsonrpc":"2.0", invalid json` + "\n"
 		in := strings.NewReader(reqJSON)
 		out := &bytes.Buffer{}
 
 		_ = server.Serve(in, out)
-
-		resp := parseResponse(t, out.Bytes())
-		if resp.Error == nil || resp.Error.Code != mcp.ErrCodeParseError {
-			t.Errorf("Expected ErrCodeParseError (-32700), got: %v", resp.Error)
+		// Parse Error has id == nil so writeError returns nil (no reply to notifications / unparseable JSON without ID)
+		if out.Len() != 0 {
+			t.Errorf("Expected 0 bytes output for notification parse error, got: %s", out.String())
 		}
 	})
 

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -593,3 +593,45 @@ func TestServerRecoversFromMalformedJSON(t *testing.T) {
 		t.Errorf("Expected second response ID 42, got: %v", resp2.ID)
 	}
 }
+
+func TestServerSetVersionAndProtocolVersionValidation(t *testing.T) {
+	t.Run("Custom version threaded into serverInfo", func(t *testing.T) {
+		server := mcp.NewServer()
+		server.SetVersion("2.5.0")
+
+		reqJSON := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05"}}` + "\n"
+		in := strings.NewReader(reqJSON)
+		out := &bytes.Buffer{}
+
+		if err := server.Serve(in, out); err != nil {
+			t.Fatalf("Serve error: %v", err)
+		}
+
+		resp := parseResponse(t, out.Bytes())
+		var initResult mcp.InitializeResult
+		rawResult, _ := json.Marshal(resp.Result)
+		_ = json.Unmarshal(rawResult, &initResult)
+
+		if initResult.ServerInfo.Version != "2.5.0" {
+			t.Errorf("Expected version '2.5.0', got %q", initResult.ServerInfo.Version)
+		}
+	})
+
+	t.Run("Unsupported protocol version returns error", func(t *testing.T) {
+		server := mcp.NewServer()
+
+		reqJSON := `{"jsonrpc":"2.0","id":2,"method":"initialize","params":{"protocolVersion":"1999-01-01"}}` + "\n"
+		in := strings.NewReader(reqJSON)
+		out := &bytes.Buffer{}
+
+		if err := server.Serve(in, out); err != nil {
+			t.Fatalf("Serve error: %v", err)
+		}
+
+		resp := parseResponse(t, out.Bytes())
+		if resp.Error == nil || resp.Error.Code != mcp.ErrCodeInvalidParams {
+			t.Errorf("Expected ErrCodeInvalidParams, got: %v", resp.Error)
+		}
+	})
+}
+

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -1,0 +1,417 @@
+package mcp_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/internal/mcp"
+)
+
+func parseResponse(t *testing.T, raw []byte) mcp.Response {
+	t.Helper()
+	var resp mcp.Response
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		t.Fatalf("Failed to parse JSON response: %v. Raw: %s", err, string(raw))
+	}
+	return resp
+}
+
+func TestServerInitialize(t *testing.T) {
+	server := mcp.NewServer()
+
+	reqJSON := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05"}}` + "\n"
+	in := strings.NewReader(reqJSON)
+	out := &bytes.Buffer{}
+
+	if err := server.Serve(in, out); err != nil {
+		t.Fatalf("Serve returned error: %v", err)
+	}
+
+	resp := parseResponse(t, out.Bytes())
+	if resp.JSONRPC != "2.0" {
+		t.Errorf("Expected jsonrpc '2.0', got %q", resp.JSONRPC)
+	}
+	if resp.Error != nil {
+		t.Fatalf("Expected no error, got %v", resp.Error)
+	}
+
+	var initResult mcp.InitializeResult
+	rawResult, err := json.Marshal(resp.Result)
+	if err != nil {
+		t.Fatalf("Failed to marshal result: %v", err)
+	}
+	if err := json.Unmarshal(rawResult, &initResult); err != nil {
+		t.Fatalf("Failed to unmarshal InitializeResult: %v", err)
+	}
+
+	if initResult.ServerInfo.Name != "gentle-ai" {
+		t.Errorf("Expected server name 'gentle-ai', got %q", initResult.ServerInfo.Name)
+	}
+	if initResult.ProtocolVersion == "" {
+		t.Error("Expected non-empty protocol version")
+	}
+}
+
+func TestServerToolsList(t *testing.T) {
+	server := mcp.NewServer()
+
+	reqJSON := `{"jsonrpc":"2.0","id":2,"method":"tools/list"}` + "\n"
+	in := strings.NewReader(reqJSON)
+	out := &bytes.Buffer{}
+
+	if err := server.Serve(in, out); err != nil {
+		t.Fatalf("Serve returned error: %v", err)
+	}
+
+	resp := parseResponse(t, out.Bytes())
+	if resp.Error != nil {
+		t.Fatalf("Expected no error, got %v", resp.Error)
+	}
+
+	var listResult mcp.ListToolsResult
+	rawResult, err := json.Marshal(resp.Result)
+	if err != nil {
+		t.Fatalf("Failed to marshal result: %v", err)
+	}
+	if err := json.Unmarshal(rawResult, &listResult); err != nil {
+		t.Fatalf("Failed to unmarshal ListToolsResult: %v", err)
+	}
+
+	toolNames := make(map[string]bool)
+	for _, tool := range listResult.Tools {
+		toolNames[tool.Name] = true
+	}
+
+	expectedTools := []string{"sdd_explore", "sdd_review", "sdd_propose", "sdd_spec", "sdd_design", "sdd_tasks"}
+	for _, name := range expectedTools {
+		if !toolNames[name] {
+			t.Errorf("Expected tool %q to be present in tools/list", name)
+		}
+	}
+}
+
+func TestServerToolsCallSDDExplore(t *testing.T) {
+	server := mcp.NewServer()
+
+	t.Run("Valid topic argument", func(t *testing.T) {
+		reqJSON := `{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"sdd_explore","arguments":{"topic":"MCP Integration","context":"Claude Desktop test"}}}` + "\n"
+		in := strings.NewReader(reqJSON)
+		out := &bytes.Buffer{}
+
+		if err := server.Serve(in, out); err != nil {
+			t.Fatalf("Serve returned error: %v", err)
+		}
+
+		resp := parseResponse(t, out.Bytes())
+		if resp.Error != nil {
+			t.Fatalf("Expected no error, got %v", resp.Error)
+		}
+
+		var callResult mcp.ToolCallResult
+		rawResult, err := json.Marshal(resp.Result)
+		if err != nil {
+			t.Fatalf("Failed to marshal result: %v", err)
+		}
+		if err := json.Unmarshal(rawResult, &callResult); err != nil {
+			t.Fatalf("Failed to unmarshal ToolCallResult: %v", err)
+		}
+
+		if callResult.IsError {
+			t.Errorf("Expected IsError false, got true")
+		}
+		if len(callResult.Content) == 0 {
+			t.Fatal("Expected non-empty content slice")
+		}
+		if !strings.Contains(callResult.Content[0].Text, "MCP Integration") {
+			t.Errorf("Expected output to contain topic, got: %s", callResult.Content[0].Text)
+		}
+	})
+
+	t.Run("Missing required topic argument", func(t *testing.T) {
+		reqJSON := `{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"sdd_explore","arguments":{}}}` + "\n"
+		in := strings.NewReader(reqJSON)
+		out := &bytes.Buffer{}
+
+		if err := server.Serve(in, out); err != nil {
+			t.Fatalf("Serve returned error: %v", err)
+		}
+
+		resp := parseResponse(t, out.Bytes())
+		var callResult mcp.ToolCallResult
+		rawResult, _ := json.Marshal(resp.Result)
+		_ = json.Unmarshal(rawResult, &callResult)
+
+		if !callResult.IsError {
+			t.Errorf("Expected IsError true for missing required topic")
+		}
+	})
+}
+
+func TestServerToolsCallSDDReview(t *testing.T) {
+	server := mcp.NewServer()
+
+	reqJSON := `{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"sdd_review","arguments":{"artifact":"internal/mcp/server.go","focus":"security"}}}` + "\n"
+	in := strings.NewReader(reqJSON)
+	out := &bytes.Buffer{}
+
+	if err := server.Serve(in, out); err != nil {
+		t.Fatalf("Serve returned error: %v", err)
+	}
+
+	resp := parseResponse(t, out.Bytes())
+	if resp.Error != nil {
+		t.Fatalf("Expected no error, got %v", resp.Error)
+	}
+
+	var callResult mcp.ToolCallResult
+	rawResult, _ := json.Marshal(resp.Result)
+	_ = json.Unmarshal(rawResult, &callResult)
+
+	if callResult.IsError {
+		t.Errorf("Expected IsError false")
+	}
+	if len(callResult.Content) == 0 {
+		t.Fatal("Expected non-empty content")
+	}
+	if !strings.Contains(callResult.Content[0].Text, "SDD 4R Review Protocol") {
+		t.Errorf("Expected 4R review protocol text, got: %s", callResult.Content[0].Text)
+	}
+}
+
+func TestServerToolsCallAdditionalSDDTools(t *testing.T) {
+	server := mcp.NewServer()
+
+	tests := []struct {
+		name        string
+		toolName    string
+		arguments   string
+		wantText    string
+		expectError bool
+	}{
+		{
+			name:        "sdd_propose valid",
+			toolName:    "sdd_propose",
+			arguments:   `{"change":"Add MCP server","scope":"internal/mcp"}`,
+			wantText:    "SDD Proposal Protocol",
+			expectError: false,
+		},
+		{
+			name:        "sdd_propose missing change",
+			toolName:    "sdd_propose",
+			arguments:   `{}`,
+			wantText:    "parameter is required",
+			expectError: true,
+		},
+		{
+			name:        "sdd_spec valid",
+			toolName:    "sdd_spec",
+			arguments:   `{"feature":"JSON-RPC Stdio"}`,
+			wantText:    "SDD Specification Protocol",
+			expectError: false,
+		},
+		{
+			name:        "sdd_spec missing feature",
+			toolName:    "sdd_spec",
+			arguments:   `{}`,
+			wantText:    "parameter is required",
+			expectError: true,
+		},
+		{
+			name:        "sdd_design valid",
+			toolName:    "sdd_design",
+			arguments:   `{"spec":"MCP stdio spec"}`,
+			wantText:    "SDD Technical Design Protocol",
+			expectError: false,
+		},
+		{
+			name:        "sdd_design missing spec",
+			toolName:    "sdd_design",
+			arguments:   `{}`,
+			wantText:    "parameter is required",
+			expectError: true,
+		},
+		{
+			name:        "sdd_tasks valid",
+			toolName:    "sdd_tasks",
+			arguments:   `{"design":"MCP Server Design"}`,
+			wantText:    "SDD Task Breakdown Protocol",
+			expectError: false,
+		},
+		{
+			name:        "sdd_tasks missing design",
+			toolName:    "sdd_tasks",
+			arguments:   `{}`,
+			wantText:    "parameter is required",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reqJSON := fmt.Sprintf(`{"jsonrpc":"2.0","id":100,"method":"tools/call","params":{"name":%q,"arguments":%s}}`+"\n", tt.toolName, tt.arguments)
+			in := strings.NewReader(reqJSON)
+			out := &bytes.Buffer{}
+
+			if err := server.Serve(in, out); err != nil {
+				t.Fatalf("Serve returned error: %v", err)
+			}
+
+			resp := parseResponse(t, out.Bytes())
+			var callResult mcp.ToolCallResult
+			rawResult, _ := json.Marshal(resp.Result)
+			_ = json.Unmarshal(rawResult, &callResult)
+
+			if callResult.IsError != tt.expectError {
+				t.Errorf("IsError = %v, want %v", callResult.IsError, tt.expectError)
+			}
+			if len(callResult.Content) == 0 || !strings.Contains(callResult.Content[0].Text, tt.wantText) {
+				t.Errorf("Expected content to contain %q, got: %v", tt.wantText, callResult.Content)
+			}
+		})
+	}
+}
+
+func TestServerToolsCallUnknownTool(t *testing.T) {
+	server := mcp.NewServer()
+
+	reqJSON := `{"jsonrpc":"2.0","id":6,"method":"tools/call","params":{"name":"unknown_tool","arguments":{}}}` + "\n"
+	in := strings.NewReader(reqJSON)
+	out := &bytes.Buffer{}
+
+	if err := server.Serve(in, out); err != nil {
+		t.Fatalf("Serve returned error: %v", err)
+	}
+
+	resp := parseResponse(t, out.Bytes())
+	var callResult mcp.ToolCallResult
+	rawResult, _ := json.Marshal(resp.Result)
+	_ = json.Unmarshal(rawResult, &callResult)
+
+	if !callResult.IsError {
+		t.Errorf("Expected IsError true for unknown tool")
+	}
+	if !strings.Contains(callResult.Content[0].Text, "Tool not found") {
+		t.Errorf("Expected 'Tool not found' text, got: %s", callResult.Content[0].Text)
+	}
+}
+
+func TestServer2MBPayloadHandling(t *testing.T) {
+	server := mcp.NewServer()
+
+	// Generate a 500KB string payload (exceeds default scanner limit of 64KB)
+	largeString := strings.Repeat("A", 500*1024)
+	reqJSON := fmt.Sprintf(`{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"sdd_explore","arguments":{"topic":"%s"}}}`, largeString) + "\n"
+
+	in := strings.NewReader(reqJSON)
+	out := &bytes.Buffer{}
+
+	if err := server.Serve(in, out); err != nil {
+		t.Fatalf("Serve failed on large payload (>64KB): %v", err)
+	}
+
+	resp := parseResponse(t, out.Bytes())
+	if resp.Error != nil {
+		t.Fatalf("Expected successful processing of large payload, got error: %v", resp.Error)
+	}
+
+	var callResult mcp.ToolCallResult
+	rawResult, _ := json.Marshal(resp.Result)
+	_ = json.Unmarshal(rawResult, &callResult)
+
+	if callResult.IsError {
+		t.Errorf("Expected successful tool call execution on large payload")
+	}
+}
+
+func TestServerJSONRPCErrorHandling(t *testing.T) {
+	server := mcp.NewServer()
+
+	t.Run("Parse Error (-32700)", func(t *testing.T) {
+		reqJSON := `{"jsonrpc":"2.0", invalid json` + "\n"
+		in := strings.NewReader(reqJSON)
+		out := &bytes.Buffer{}
+
+		_ = server.Serve(in, out)
+
+		resp := parseResponse(t, out.Bytes())
+		if resp.Error == nil || resp.Error.Code != mcp.ErrCodeParseError {
+			t.Errorf("Expected ErrCodeParseError (-32700), got: %v", resp.Error)
+		}
+	})
+
+	t.Run("Invalid JSON-RPC Version (-32600)", func(t *testing.T) {
+		reqJSON := `{"jsonrpc":"1.0","id":10,"method":"ping"}` + "\n"
+		in := strings.NewReader(reqJSON)
+		out := &bytes.Buffer{}
+
+		_ = server.Serve(in, out)
+
+		resp := parseResponse(t, out.Bytes())
+		if resp.Error == nil || resp.Error.Code != mcp.ErrCodeInvalidRequest {
+			t.Errorf("Expected ErrCodeInvalidRequest (-32600), got: %v", resp.Error)
+		}
+	})
+
+	t.Run("Unknown Method (-32601)", func(t *testing.T) {
+		reqJSON := `{"jsonrpc":"2.0","id":11,"method":"non_existent_method"}` + "\n"
+		in := strings.NewReader(reqJSON)
+		out := &bytes.Buffer{}
+
+		_ = server.Serve(in, out)
+
+		resp := parseResponse(t, out.Bytes())
+		if resp.Error == nil || resp.Error.Code != mcp.ErrCodeMethodNotFound {
+			t.Errorf("Expected ErrCodeMethodNotFound (-32601), got: %v", resp.Error)
+		}
+	})
+
+	t.Run("Notification ignored without response", func(t *testing.T) {
+		reqJSON := `{"jsonrpc":"2.0","method":"notifications/initialized"}` + "\n"
+		in := strings.NewReader(reqJSON)
+		out := &bytes.Buffer{}
+
+		if err := server.Serve(in, out); err != nil {
+			t.Fatalf("Serve error: %v", err)
+		}
+
+		if out.Len() != 0 {
+			t.Errorf("Expected no output for notification, got: %s", out.String())
+		}
+	})
+}
+
+func TestServerCustomToolRegistration(t *testing.T) {
+	server := mcp.NewServer()
+
+	customTool := mcp.Tool{
+		Name:        "custom_test_tool",
+		Description: "Custom test tool",
+		InputSchema: mcp.ToolSchema{Type: "object"},
+	}
+
+	server.RegisterTool(customTool, func(args map[string]interface{}) (*mcp.ToolCallResult, error) {
+		return &mcp.ToolCallResult{
+			Content: []mcp.TextContent{{Type: "text", Text: "Custom response"}},
+		}, nil
+	})
+
+	reqJSON := `{"jsonrpc":"2.0","id":12,"method":"tools/call","params":{"name":"custom_test_tool","arguments":{}}}` + "\n"
+	in := strings.NewReader(reqJSON)
+	out := &bytes.Buffer{}
+
+	if err := server.Serve(in, out); err != nil {
+		t.Fatalf("Serve error: %v", err)
+	}
+
+	resp := parseResponse(t, out.Bytes())
+	var callResult mcp.ToolCallResult
+	rawResult, _ := json.Marshal(resp.Result)
+	_ = json.Unmarshal(rawResult, &callResult)
+
+	if len(callResult.Content) == 0 || callResult.Content[0].Text != "Custom response" {
+		t.Errorf("Expected custom response text, got %v", callResult.Content)
+	}
+}

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -626,7 +626,6 @@ func TestServerRecoversFromConsecutiveMalformedJSON(t *testing.T) {
 	}
 }
 
-
 func TestServerSetVersionAndProtocolVersionValidation(t *testing.T) {
 	t.Run("Custom version threaded into serverInfo", func(t *testing.T) {
 		server := mcp.NewServer()
@@ -667,4 +666,3 @@ func TestServerSetVersionAndProtocolVersionValidation(t *testing.T) {
 		}
 	})
 }
-

--- a/internal/mcp/types.go
+++ b/internal/mcp/types.go
@@ -1,0 +1,107 @@
+package mcp
+
+import (
+	"encoding/json"
+)
+
+const (
+	// MaxBufferSize defines the maximum scanner buffer size (2MB) to prevent truncation of large payloads.
+	MaxBufferSize = 2 * 1024 * 1024
+
+	// JSONRPCVersion is the supported JSON-RPC version string.
+	JSONRPCVersion = "2.0"
+)
+
+// Standard JSON-RPC 2.0 error codes.
+const (
+	ErrCodeParseError     = -32700
+	ErrCodeInvalidRequest = -32600
+	ErrCodeMethodNotFound = -32601
+	ErrCodeInvalidParams  = -32602
+	ErrCodeInternalError  = -32603
+)
+
+// Request represents an incoming JSON-RPC 2.0 request or notification.
+type Request struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      interface{}     `json:"id,omitempty"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+// Response represents an outgoing JSON-RPC 2.0 response.
+type Response struct {
+	JSONRPC string      `json:"jsonrpc"`
+	ID      interface{} `json:"id"`
+	Result  interface{} `json:"result,omitempty"`
+	Error   *RPCError   `json:"error,omitempty"`
+}
+
+// RPCError represents a JSON-RPC 2.0 error object.
+type RPCError struct {
+	Code    int         `json:"code"`
+	Message string      `json:"message"`
+	Data    interface{} `json:"data,omitempty"`
+}
+
+// ServerInfo defines the server details returned during MCP initialize.
+type ServerInfo struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+// ServerCapabilities defines capabilities offered by the MCP server.
+type ServerCapabilities struct {
+	Tools map[string]interface{} `json:"tools"`
+}
+
+// InitializeResult defines the result payload for the initialize request.
+type InitializeResult struct {
+	ProtocolVersion string             `json:"protocolVersion"`
+	Capabilities    ServerCapabilities `json:"capabilities"`
+	ServerInfo      ServerInfo         `json:"serverInfo"`
+}
+
+// Tool defines an MCP tool schema.
+type Tool struct {
+	Name        string     `json:"name"`
+	Description string     `json:"description"`
+	InputSchema ToolSchema `json:"inputSchema"`
+}
+
+// ToolSchema defines the JSON Schema structure for tool parameters.
+type ToolSchema struct {
+	Type       string                    `json:"type"`
+	Properties map[string]PropertySchema `json:"properties,omitempty"`
+	Required   []string                  `json:"required,omitempty"`
+}
+
+// PropertySchema defines individual property attributes in a JSON schema.
+type PropertySchema struct {
+	Type        string   `json:"type"`
+	Description string   `json:"description,omitempty"`
+	Enum        []string `json:"enum,omitempty"`
+}
+
+// ListToolsResult defines the payload for tools/list response.
+type ListToolsResult struct {
+	Tools []Tool `json:"tools"`
+}
+
+// ToolCallParams defines the parameters for a tools/call request.
+type ToolCallParams struct {
+	Name      string                 `json:"name"`
+	Arguments map[string]interface{} `json:"arguments,omitempty"`
+}
+
+// TextContent represents a text item in an MCP tool response.
+type TextContent struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+// ToolCallResult defines the outcome returned by a tool execution.
+type ToolCallResult struct {
+	Content []TextContent `json:"content"`
+	IsError bool          `json:"isError,omitempty"`
+}

--- a/internal/mcp/types.go
+++ b/internal/mcp/types.go
@@ -44,6 +44,10 @@ type RPCError struct {
 	Data    interface{} `json:"data,omitempty"`
 }
 
+func (e *RPCError) Error() string {
+	return e.Message
+}
+
 // ServerInfo defines the server details returned during MCP initialize.
 type ServerInfo struct {
 	Name    string `json:"name"`

--- a/internal/mcp/types.go
+++ b/internal/mcp/types.go
@@ -5,9 +5,6 @@ import (
 )
 
 const (
-	// MaxBufferSize defines the maximum scanner buffer size (2MB) to prevent truncation of large payloads.
-	MaxBufferSize = 2 * 1024 * 1024
-
 	// JSONRPCVersion is the supported JSON-RPC version string.
 	JSONRPCVersion = "2.0"
 )

--- a/internal/mcp/types.go
+++ b/internal/mcp/types.go
@@ -41,6 +41,7 @@ type RPCError struct {
 	Data    interface{} `json:"data,omitempty"`
 }
 
+// Error returns the error message for RPCError.
 func (e *RPCError) Error() string {
 	return e.Message
 }

--- a/internal/model/platform.go
+++ b/internal/model/platform.go
@@ -1,0 +1,11 @@
+package model
+
+// PlatformProfile records OS, distribution, and package manager details.
+type PlatformProfile struct {
+	OS             string
+	LinuxDistro    string
+	PackageManager string
+	NpmWritable    bool // true when npm global prefix is user-writable (nvm/fnm/volta)
+	GoAvailable    bool // true when `go` is found on PATH (used for auto-detect: brew → go-install → binary)
+	Supported      bool
+}

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -19,6 +19,7 @@ const (
 	AgentPi            AgentID = "pi"
 	AgentTrae          AgentID = "trae-ide"
 	AgentHermes        AgentID = "hermes"
+	AgentClaudeDesktop AgentID = "claude-desktop"
 )
 
 // SupportTier indicates how fully an agent supports the Gentleman AI ecosystem.

--- a/internal/system/config_scan.go
+++ b/internal/system/config_scan.go
@@ -3,8 +3,7 @@ package system
 import (
 	"os"
 	"path/filepath"
-
-	"github.com/gentleman-programming/gentle-ai/internal/agents/claudedesktop"
+	"runtime"
 )
 
 // ConfigState records the filesystem presence of an agent's global config directory.
@@ -52,7 +51,22 @@ func knownAgentConfigDirs(homeDir string) []ConfigState {
 }
 
 func claudeDesktopGlobalConfigDir(homeDir string) string {
-	return claudedesktop.GlobalConfigDir(homeDir)
+	switch runtime.GOOS {
+	case "darwin":
+		return filepath.Join(homeDir, "Library", "Application Support", "Claude")
+	case "windows":
+		appData := os.Getenv("APPDATA")
+		if appData == "" {
+			appData = filepath.Join(homeDir, "AppData", "Roaming")
+		}
+		return filepath.Join(appData, "Claude")
+	default: // linux and others
+		xdgConfigHome := os.Getenv("XDG_CONFIG_HOME")
+		if xdgConfigHome == "" {
+			xdgConfigHome = filepath.Join(homeDir, ".config")
+		}
+		return filepath.Join(xdgConfigHome, "Claude")
+	}
 }
 
 // vscodeCopilotGlobalConfigDir returns ~/.copilot, the GlobalConfigDir used by

--- a/internal/system/config_scan.go
+++ b/internal/system/config_scan.go
@@ -3,6 +3,7 @@ package system
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 )
 
 // ConfigState records the filesystem presence of an agent's global config directory.
@@ -50,7 +51,22 @@ func knownAgentConfigDirs(homeDir string) []ConfigState {
 }
 
 func claudeDesktopGlobalConfigDir(homeDir string) string {
-	return filepath.Join(homeDir, "Library", "Application Support", "Claude")
+	switch runtime.GOOS {
+	case "darwin":
+		return filepath.Join(homeDir, "Library", "Application Support", "Claude")
+	case "windows":
+		appData := os.Getenv("APPDATA")
+		if appData == "" {
+			appData = filepath.Join(homeDir, "AppData", "Roaming")
+		}
+		return filepath.Join(appData, "Claude")
+	default: // linux and others
+		xdgConfigHome := os.Getenv("XDG_CONFIG_HOME")
+		if xdgConfigHome == "" {
+			xdgConfigHome = filepath.Join(homeDir, ".config")
+		}
+		return filepath.Join(xdgConfigHome, "Claude")
+	}
 }
 
 // vscodeCopilotGlobalConfigDir returns ~/.copilot, the GlobalConfigDir used by

--- a/internal/system/config_scan.go
+++ b/internal/system/config_scan.go
@@ -3,7 +3,8 @@ package system
 import (
 	"os"
 	"path/filepath"
-	"runtime"
+
+	"github.com/gentleman-programming/gentle-ai/internal/agents/claudedesktop"
 )
 
 // ConfigState records the filesystem presence of an agent's global config directory.
@@ -51,22 +52,7 @@ func knownAgentConfigDirs(homeDir string) []ConfigState {
 }
 
 func claudeDesktopGlobalConfigDir(homeDir string) string {
-	switch runtime.GOOS {
-	case "darwin":
-		return filepath.Join(homeDir, "Library", "Application Support", "Claude")
-	case "windows":
-		appData := os.Getenv("APPDATA")
-		if appData == "" {
-			appData = filepath.Join(homeDir, "AppData", "Roaming")
-		}
-		return filepath.Join(appData, "Claude")
-	default: // linux and others
-		xdgConfigHome := os.Getenv("XDG_CONFIG_HOME")
-		if xdgConfigHome == "" {
-			xdgConfigHome = filepath.Join(homeDir, ".config")
-		}
-		return filepath.Join(xdgConfigHome, "Claude")
-	}
+	return claudedesktop.GlobalConfigDir(homeDir)
 }
 
 // vscodeCopilotGlobalConfigDir returns ~/.copilot, the GlobalConfigDir used by

--- a/internal/system/config_scan.go
+++ b/internal/system/config_scan.go
@@ -45,7 +45,12 @@ func knownAgentConfigDirs(homeDir string) []ConfigState {
 		{Agent: "pi", Path: filepath.Join(homeDir, ".pi")},
 		{Agent: "trae-ide", Path: filepath.Join(homeDir, ".trae")},
 		{Agent: "hermes", Path: filepath.Join(homeDir, ".hermes")},
+		{Agent: "claude-desktop", Path: claudeDesktopGlobalConfigDir(homeDir)},
 	}
+}
+
+func claudeDesktopGlobalConfigDir(homeDir string) string {
+	return filepath.Join(homeDir, "Library", "Application Support", "Claude")
 }
 
 // vscodeCopilotGlobalConfigDir returns ~/.copilot, the GlobalConfigDir used by

--- a/internal/system/config_scan_test.go
+++ b/internal/system/config_scan_test.go
@@ -70,6 +70,7 @@ func TestScanConfigs_AgentFieldMatchesModelAgentID(t *testing.T) {
 	// These are the AgentID string values the TUI switch statements check.
 	knownAgents := map[string]bool{
 		"claude-code":    false,
+		"claude-desktop": false,
 		"opencode":       false,
 		"kilocode":       false,
 		"gemini-cli":     false,

--- a/internal/system/detect.go
+++ b/internal/system/detect.go
@@ -6,6 +6,8 @@ import (
 	"os/exec"
 	"runtime"
 	"strings"
+
+	"github.com/gentleman-programming/gentle-ai/internal/model"
 )
 
 type SystemInfo struct {
@@ -16,14 +18,8 @@ type SystemInfo struct {
 	Profile   PlatformProfile
 }
 
-type PlatformProfile struct {
-	OS             string
-	LinuxDistro    string
-	PackageManager string
-	NpmWritable    bool // true when npm global prefix is user-writable (nvm/fnm/volta)
-	GoAvailable    bool // true when `go` is found on PATH (used for auto-detect: brew → go-install → binary)
-	Supported      bool
-}
+// PlatformProfile is a type alias to model.PlatformProfile for backward compatibility.
+type PlatformProfile = model.PlatformProfile
 
 const (
 	LinuxDistroUnknown = "unknown"

--- a/internal/update/upgrade/strategy_test.go
+++ b/internal/update/upgrade/strategy_test.go
@@ -1153,7 +1153,15 @@ Homebrew's Linux sandbox requires rootless Bubblewrap and unprivileged user name
 // --- verify exec.Cmd.Run() failure is correctly wrapped ---
 func TestRunStrategy_ExecErrorWrapped(t *testing.T) {
 	origExecCommand := execCommand
-	t.Cleanup(func() { execCommand = origExecCommand })
+	origOwnership := homebrewOwnershipDetector
+	t.Cleanup(func() {
+		execCommand = origExecCommand
+		homebrewOwnershipDetector = origOwnership
+	})
+
+	homebrewOwnershipDetector = func(string) (update.HomebrewOwnership, error) {
+		return update.HomebrewFormula, nil
+	}
 
 	execCommand = func(name string, args ...string) *exec.Cmd {
 		return mockCmd("false")


### PR DESCRIPTION
## 🔗 Linked Issue

Fixes #1625

---

## 🏷️ PR Type

- [ ] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [x] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

Adds CLI subcommand `gentle-ai mcp`, idempotent `claude_desktop_config.json` injection, orchestrator prompt asset `claudedesktop/sdd-orchestrator.md`, and installer catalog registration (`internal/catalog/agents.go` & `internal/system/config_scan.go`). This is Part 3 of 3 in the Chained PR series for Issue #1625, stacked on top of PR #1654 (`feat/claude-desktop-mcp-part2`).

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/app/app.go` | Registered `gentle-ai mcp` subcommand with `--help` / `-h` handling |
| `internal/components/mcp/inject.go` | Idempotent merging into `claude_desktop_config.json` preserving `engram` |
| `internal/assets/claudedesktop/sdd-orchestrator.md` | Created Claude Desktop orchestrator prompt with reasoning inline + Engram handoff |
| `internal/catalog/agents.go` | Registered `AgentClaudeDesktop` in installer catalog (`allAgents`) |
| `internal/system/config_scan.go` | OS-aware presence scanning for Claude Desktop (`macOS`, `Windows`, `Linux`) |

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./internal/app/... ./internal/components/mcp/... ./internal/assets/... ./internal/catalog/... ./internal/system/...
```

**Go Format**
```bash
go run ./internal/gofmtcheck
```

- [x] Unit tests pass across all packages
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [x] Manually tested end-to-end with Claude Desktop

---

## 🤖 Automated Checks

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | 🟢 | Non-test code is under 400 lines (within limit) |
| Check Issue Reference | 🟢 | Body contains `Fixes #1625` |
| Check PR Has `type:*` Label | 🟢 | `type:feature` label selected |
| Unit Tests | 🟢 | `go test ./...` passes |
| Go Format | 🟢 | `go run ./internal/gofmtcheck` passes |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue (#1625)
- [x] PR stays within cognitive load limit
- [x] I have added the appropriate `type:feature` label
- [x] Unit tests pass across all packages
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [x] My commits follow Conventional Commits format
- [x] My commits do not include Co-Authored-By trailers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Claude Desktop support with automatic detection and OS-specific configuration paths.
  * Introduced an `mcp` CLI command that runs a stdio JSON-RPC server exposing built-in SDD tools (explore, review, propose, spec, design, tasks) with `--help`/`-h`.
* **Bug Fixes**
  * Improved Claude Desktop MCP settings injection with idempotent merges, preservation of existing MCP entries, safer overlay handling, and permission/backup recovery behavior.
* **Tests**
  * Added/extended unit and end-to-end coverage for Claude Desktop support, MCP server/tools, CLI `mcp` dispatch/help, and Claude Desktop SDD orchestrator contract.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->