### PR TITLE
fix(opencode): detect custom providers in opencode.jsonc with JSONC comment support

### DIFF
--- a/internal/opencode/models.go
+++ b/internal/opencode/models.go
@@ -7,6 +7,9 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
+
+	"github.com/gentleman-programming/gentle-ai/internal/components/filemerge"
 )
 
 // DefaultCachePath returns the default path to the OpenCode models cache file.
@@ -331,27 +334,60 @@ type ConfigProvider struct {
 	Models map[string]ConfigModel `json:"models"`
 }
 
-// LoadConfigProviders reads the provider section from an opencode.json settings file.
-// Returns an empty map with nil error if the file is missing or has no provider key.
+// LoadConfigProviders reads the provider section from an opencode.json or opencode.jsonc settings file.
+// Supports JSONC comments and trailing commas. Returns an empty map with nil error if the file is missing or has no provider key.
 func LoadConfigProviders(path string) (map[string]ConfigProvider, error) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return map[string]ConfigProvider{}, nil
-		}
-		return map[string]ConfigProvider{}, err
+	paths := []string{path}
+	if strings.HasSuffix(path, ".json") {
+		paths = append(paths, strings.TrimSuffix(path, ".json")+".jsonc")
+	} else if strings.HasSuffix(path, ".jsonc") {
+		paths = append(paths, strings.TrimSuffix(path, ".jsonc")+".json")
 	}
 
-	var raw struct {
-		Provider map[string]ConfigProvider `json:"provider"`
+	var data []byte
+	var readPath string
+	var lastErr error
+
+	for _, p := range paths {
+		b, err := os.ReadFile(p)
+		if err == nil {
+			data = b
+			readPath = p
+			break
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			lastErr = err
+		}
 	}
-	if err := json.Unmarshal(data, &raw); err != nil {
-		return map[string]ConfigProvider{}, fmt.Errorf("parse opencode settings %q: %w", path, err)
-	}
-	if raw.Provider == nil {
+
+	if data == nil {
+		if lastErr != nil {
+			return map[string]ConfigProvider{}, lastErr
+		}
 		return map[string]ConfigProvider{}, nil
 	}
-	return raw.Provider, nil
+
+	root, err := filemerge.UnmarshalJSONObject(data)
+	if err != nil {
+		return map[string]ConfigProvider{}, fmt.Errorf("parse opencode settings %q: %w", readPath, err)
+	}
+
+	providerRaw, ok := root["provider"]
+	if !ok || providerRaw == nil {
+		return map[string]ConfigProvider{}, nil
+	}
+
+	providerBytes, err := json.Marshal(providerRaw)
+	if err != nil {
+		return map[string]ConfigProvider{}, fmt.Errorf("parse opencode settings %q: %w", readPath, err)
+	}
+
+	var configProviders map[string]ConfigProvider
+	if err := json.Unmarshal(providerBytes, &configProviders); err != nil {
+		return map[string]ConfigProvider{}, fmt.Errorf("parse opencode settings %q: %w", readPath, err)
+	}
+
+	return configProviders, nil
 }
 
 // MergeCustomProviders merges custom providers from opencode.json into the cache-loaded

--- a/internal/opencode/models_test.go
+++ b/internal/opencode/models_test.go
@@ -584,6 +584,79 @@ func TestLoadConfigProvidersInvalidJSON(t *testing.T) {
 	}
 }
 
+func TestLoadConfigProvidersJSONCFallback(t *testing.T) {
+	dir := t.TempDir()
+	jsoncPath := filepath.Join(dir, "opencode.jsonc")
+	content := `{
+		"provider": {
+			"custom-llm": {
+				"name": "Custom LLM",
+				"models": {
+					"custom-model": {"name": "Custom Model", "tool_call": true}
+				}
+			}
+		}
+	}`
+	if err := os.WriteFile(jsoncPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	// Request opencode.json path (which does not exist); should fall back to opencode.jsonc
+	jsonPath := filepath.Join(dir, "opencode.json")
+	config, err := LoadConfigProviders(jsonPath)
+	if err != nil {
+		t.Fatalf("LoadConfigProviders() error = %v", err)
+	}
+	if len(config) != 1 {
+		t.Fatalf("config provider count = %d, want 1", len(config))
+	}
+	if _, ok := config["custom-llm"]; !ok {
+		t.Fatal("missing custom-llm provider from jsonc fallback")
+	}
+}
+
+func TestLoadConfigProvidersJSONCComments(t *testing.T) {
+	dir := t.TempDir()
+	jsoncPath := filepath.Join(dir, "opencode.jsonc")
+	content := `{
+		// Top level comment for custom provider config
+		"provider": {
+			/* Multi-line comment
+			   describing custom provider setup */
+			"my-provider": {
+				"name": "My Provider",
+				"models": {
+					"my-model": {
+						"name": "My Model",
+						"tool_call": true, // trailing comma here
+					},
+				},
+			},
+		},
+	}`
+	if err := os.WriteFile(jsoncPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	config, err := LoadConfigProviders(jsoncPath)
+	if err != nil {
+		t.Fatalf("LoadConfigProviders() error = %v", err)
+	}
+	if len(config) != 1 {
+		t.Fatalf("config provider count = %d, want 1", len(config))
+	}
+	p, ok := config["my-provider"]
+	if !ok {
+		t.Fatal("missing my-provider provider from jsonc with comments")
+	}
+	if p.Name != "My Provider" {
+		t.Fatalf("provider name = %q, want %q", p.Name, "My Provider")
+	}
+	if m, ok := p.Models["my-model"]; !ok || !m.ToolCall {
+		t.Fatalf("model my-model not loaded correctly: %+v", m)
+	}
+}
+
 // MergeCustomProviders
 
 func TestMergeCustomProvidersNewProvider(t *testing.T) {

--- a/internal/tui/screens/model_picker_test.go
+++ b/internal/tui/screens/model_picker_test.go
@@ -1139,6 +1139,46 @@ func TestNewModelPickerStateCollisionCustomWins(t *testing.T) {
 	}
 }
 
+// TestNewModelPickerStateJSONCWithComments verifies that custom providers defined in
+// opencode.jsonc with comments are detected when NewModelPickerState is passed opencode.json.
+func TestNewModelPickerStateJSONCWithComments(t *testing.T) {
+	dir := t.TempDir()
+	cachePath := filepath.Join(dir, "models.json")
+	if err := os.WriteFile(cachePath, []byte(catalogJSON), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	jsoncPath := filepath.Join(dir, "opencode.jsonc")
+	jsoncContent := `{
+		// Custom provider setup for OpenCode JSONC
+		"provider": {
+			/* Multi-line comment */
+			"jsonc-provider": {
+				"name": "JSONC Provider",
+				"models": {
+					"jsonc-model": {"name": "JSONC Model", "tool_call": true},
+				},
+			},
+		},
+	}`
+	if err := os.WriteFile(jsoncPath, []byte(jsoncContent), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	// Pass opencode.json (which does not exist); should fall back to opencode.jsonc and parse comments
+	jsonPath := filepath.Join(dir, "opencode.json")
+	state := NewModelPickerState(cachePath, jsonPath)
+
+	p, ok := state.Providers["jsonc-provider"]
+	if !ok {
+		t.Fatalf("expected jsonc-provider in state, got providers: %v", providerKeys(state.Providers))
+	}
+	m, ok := p.Models["jsonc-model"]
+	if !ok || m.Name != "JSONC Model" {
+		t.Errorf("model jsonc-model = %+v, want JSONC Model", m)
+	}
+}
+
 // providerKeys returns the keys of a Provider map for test error messages.
 func providerKeys(providers map[string]opencode.Provider) []string {
 	keys := make([]string, 0, len(providers))


### PR DESCRIPTION
### Summary

When users configure OpenCode using `opencode.jsonc` (with single/multi-line comments or trailing commas), `LoadConfigProviders` previously failed to detect custom providers declared therein because it hardcoded reading `opencode.json` strictly via stdlib `json.Unmarshal`.

### Changes

- **`internal/opencode/models.go`**:
  - Updated `LoadConfigProviders(path)` to fall back to `opencode.jsonc` when `opencode.json` is requested but missing (and vice-versa).
  - Used `filemerge.UnmarshalJSONObject` to decode settings JSON, providing full JSONC comment (`//`, `/* */`) and trailing-comma tolerance.
- **`internal/opencode/models_test.go`**:
  - Added `TestLoadConfigProvidersJSONCFallback` and `TestLoadConfigProvidersJSONCComments` to test fallback and comment parsing.
- **`internal/tui/screens/model_picker_test.go`**:
  - Added `TestNewModelPickerStateJSONCWithComments` to verify custom provider detection in the TUI model picker.

Fixes #771

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for loading provider configurations from JSONC files when standard JSON files are unavailable.
  * JSONC configurations can now include comments, including nested and trailing comments.
  * Custom providers and model metadata are recognized in the model picker.

* **Tests**
  * Added coverage for JSONC fallback, comment parsing, and model picker provider loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->