### PR TITLE
feat(opencode): show model used by background delegations

### DIFF
--- a/internal/assets/opencode/sdd-orchestrator.md
+++ b/internal/assets/opencode/sdd-orchestrator.md
@@ -353,6 +353,26 @@ Read the configured models from `opencode.json` at session start (or before firs
 - If a phase does not have an explicit model, use the default OpenCode runtime model for that agent and continue.
 - For named profiles, apply the same rule to the suffixed agent keys (for example, `sdd-apply-cheap`).
 
+### Background Delegation Model Output
+
+When reporting status for OpenCode background delegations, include the resolved model in task notifications and delegation list/read summaries:
+
+- **Task Notification format**:
+  ```text
+  [TASK NOTIFICATION]
+  ID: <delegation-id>
+  Status: <status>
+  Model: <resolved-model>
+  ```
+- **Delegation List format**: `• <delegation-id> [<status>] agent: <agent> model: <resolved-model>`
+- **Delegation Read format**:
+  ```text
+  ID: <delegation-id>
+  Agent: <agent>
+  Status: <status>
+  Model: <resolved-model>
+  ```
+
 <!-- /gentle-ai:sdd-model-assignments -->
 
 ### Sub-Agent Launch Deduplication (MANDATORY)


### PR DESCRIPTION
### Summary

OpenCode background delegations currently report task status without showing which model executed the task. For users running Gentle AI with per-phase model assignment, this makes it harder to understand and debug delegation behavior.

### Changes

- **`internal/assets/opencode/sdd-orchestrator.md`**:
  - Added specification under `Model Assignments` for **Background Delegation Model Output**.
  - Formatted `[TASK NOTIFICATION]`, `delegation_list`, and `delegation_read` outputs to include `Model: <resolved-model>` / `model: <resolved-model>`.

Fixes #707

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for displaying the resolved model in background task status updates.
  * Documented consistent output formats for task notifications, delegation lists, and task details, including status, agent, identifier, and model information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->