### PR TITLE
fix(review): admit unchanged-target invalidated recovery to package validation

### DIFF
--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -550,7 +550,8 @@ func RunReviewRecover(args []string, stdout io.Writer) error {
 	if !*releaseScope && (baseDiff || overlay) && snapshot.BaseTree != predecessorRecord.State.InitialSnapshot.BaseTree {
 		return errors.New("recovery base-ref does not match predecessor base")
 	}
-	if !*releaseScope && (baseDiff || overlay) && snapshot.Identity == predecessorRecord.State.InitialSnapshot.Identity {
+	if !*releaseScope && reviewtransaction.RecoveryDisposition(*disposition) != reviewtransaction.RecoveryInvalidated &&
+		(baseDiff || overlay) && snapshot.Identity == predecessorRecord.State.InitialSnapshot.Identity {
 		return errors.New("recovery scope has not changed")
 	}
 	assessment, err := (reviewtransaction.SnapshotBuilder{Repo: root}).AssessSnapshotRisk(context.Background(), snapshot)

--- a/internal/cli/review_recovery_unchanged_target_test.go
+++ b/internal/cli/review_recovery_unchanged_target_test.go
@@ -108,13 +108,32 @@ func TestUnchangedTargetRecovery_EscalatedStillBlocked(t *testing.T) {
 
 func TestUnchangedTargetRecovery_ScopeChangedStillBlocked(t *testing.T) {
 	repo, baseRef, predecessor := newUnchangedTargetRecoveryFixture(t)
+	predecessorStore, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, predecessor.State.LineageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.ReadFile(predecessorStore.StatePath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	successorLineage := "review-scope-changed-unchanged"
 	var output bytes.Buffer
-	err := RunReview([]string{"recover", "--cwd", repo, "--predecessor-lineage", predecessor.State.LineageID,
-		"--expected-predecessor-revision", predecessor.Revision, "--successor-lineage", "review-scope-changed-unchanged",
+	err = RunReview([]string{"recover", "--cwd", repo, "--predecessor-lineage", predecessor.State.LineageID,
+		"--expected-predecessor-revision", predecessor.Revision, "--successor-lineage", successorLineage,
 		"--disposition", "scope_changed", "--reason", "attempted scope-changed retry", "--actor", "maintainer",
 		"--base-ref", baseRef, "--committed-only"}, &output)
 	if err == nil || err.Error() != "recovery scope has not changed" {
 		t.Fatalf("unchanged-target scope_changed recovery = %v", err)
+	}
+	after, err := os.ReadFile(predecessorStore.StatePath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Fatalf("predecessor state mutated by rejected scope_changed recovery")
+	}
+	if _, statErr := os.Stat(filepath.Join(reviewCLIAuthorityRoot(t, repo), "v2", successorLineage)); !os.IsNotExist(statErr) {
+		t.Fatalf("successor persisted despite rejected scope_changed recovery: %v", statErr)
 	}
 }
 
@@ -133,6 +152,45 @@ func TestUnchangedTargetRecovery_BaseMismatchStillBlocked(t *testing.T) {
 		"--base-ref", advancedBaseRef, "--committed-only"}, &output)
 	if err == nil || err.Error() != "recovery base-ref does not match predecessor base" {
 		t.Fatalf("base mismatch invalidated recovery = %v", err)
+	}
+}
+
+func TestUnchangedTargetRecovery_BaseMismatchStillBlockedForScopeChanged(t *testing.T) {
+	repo, _, predecessor := newUnchangedTargetRecoveryFixture(t)
+	if err := os.WriteFile(filepath.Join(repo, "other.txt"), []byte("advanced base\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runReviewCLIGit(t, repo, "add", "--", "other.txt")
+	runReviewCLIGit(t, repo, "commit", "-qm", "advance base")
+	advancedBaseRef := strings.TrimSpace(runReviewCLIGit(t, repo, "rev-parse", "HEAD"))
+	var output bytes.Buffer
+	err := RunReview([]string{"recover", "--cwd", repo, "--predecessor-lineage", predecessor.State.LineageID,
+		"--expected-predecessor-revision", predecessor.Revision, "--successor-lineage", "review-base-mismatch-scope-changed",
+		"--disposition", "scope_changed", "--reason", "base mismatch check", "--actor", "maintainer",
+		"--base-ref", advancedBaseRef, "--committed-only"}, &output)
+	if err == nil || err.Error() != "recovery base-ref does not match predecessor base" {
+		t.Fatalf("base mismatch scope_changed recovery = %v", err)
+	}
+}
+
+func TestUnchangedTargetRecovery_BaseMismatchStillBlockedForEscalated(t *testing.T) {
+	repo, _, predecessor := newUnchangedTargetRecoveryFixture(t)
+	if err := os.WriteFile(filepath.Join(repo, "other.txt"), []byte("advanced base\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runReviewCLIGit(t, repo, "add", "--", "other.txt")
+	runReviewCLIGit(t, repo, "commit", "-qm", "advance base")
+	advancedBaseRef := strings.TrimSpace(runReviewCLIGit(t, repo, "rev-parse", "HEAD"))
+	authorization := "gentle-ai.review-recovery-authorization/v1\npredecessor_lineage=" + predecessor.State.LineageID +
+		"\npredecessor_revision=" + predecessor.Revision + "\ntarget_identity=" + predecessor.State.InitialSnapshot.Identity +
+		"\nactor=maintainer\nreason=base mismatch check"
+	var output bytes.Buffer
+	err := RunReview([]string{"recover", "--cwd", repo, "--predecessor-lineage", predecessor.State.LineageID,
+		"--expected-predecessor-revision", predecessor.Revision, "--successor-lineage", "review-base-mismatch-escalated",
+		"--disposition", "escalated", "--reason", "base mismatch check", "--actor", "maintainer",
+		"--maintainer-authorization", authorization, "--base-ref", advancedBaseRef, "--committed-only"}, &output)
+	if err == nil || err.Error() != "recovery base-ref does not match predecessor base" {
+		t.Fatalf("base mismatch escalated recovery = %v", err)
 	}
 }
 

--- a/internal/cli/review_recovery_unchanged_target_test.go
+++ b/internal/cli/review_recovery_unchanged_target_test.go
@@ -1,0 +1,154 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/internal/reviewtransaction"
+)
+
+// newUnchangedTargetRecoveryFixture builds a StateInvalidated predecessor with
+// a TargetBaseDiff initial snapshot, ready for a recovery attempt whose
+// recomputed successor target Identity is identical to the predecessor's
+// (same --base-ref, same candidate content).
+func newUnchangedTargetRecoveryFixture(t *testing.T) (repo, baseRef string, predecessor reviewtransaction.CompactRecord) {
+	t.Helper()
+	repo = initReviewCLIRepo(t)
+	baseRef = strings.TrimSpace(runReviewCLIGit(t, repo, "rev-parse", "HEAD"))
+	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("candidate\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runReviewCLIGit(t, repo, "add", "--", "tracked.txt")
+	runReviewCLIGit(t, repo, "commit", "-qm", "candidate")
+	var output bytes.Buffer
+	if err := RunReviewFacadeStart([]string{"--cwd", repo, "--base-ref", baseRef, "--committed-only"}, &output); err != nil {
+		t.Fatal(err)
+	}
+	var started ReviewFacadeStartResult
+	if err := json.Unmarshal(output.Bytes(), &started); err != nil {
+		t.Fatal(err)
+	}
+	predecessorStore, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, started.LineageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pristine, err := predecessorStore.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := RunReviewInvalidate([]string{"--cwd", repo, "--lineage", started.LineageID,
+		"--expected-revision", pristine.Revision, "--reason", "external evidence invalidation"}, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	invalidated, err := predecessorStore.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return repo, baseRef, invalidated
+}
+
+func TestUnchangedTargetRecovery_InvalidatedAdmitted(t *testing.T) {
+	repo, baseRef, predecessor := newUnchangedTargetRecoveryFixture(t)
+	var output bytes.Buffer
+	err := RunReview([]string{"recover", "--cwd", repo, "--predecessor-lineage", predecessor.State.LineageID,
+		"--expected-predecessor-revision", predecessor.Revision, "--successor-lineage", "review-invalidated-recovered",
+		"--disposition", "invalidated", "--reason", "redo after external evidence", "--actor", "maintainer",
+		"--base-ref", baseRef, "--committed-only"}, &output)
+	if err != nil {
+		t.Fatalf("unchanged-target invalidated recovery = %v", err)
+	}
+	var recovered ReviewRecoverResult
+	if unmarshalErr := json.Unmarshal(output.Bytes(), &recovered); unmarshalErr != nil {
+		t.Fatal(unmarshalErr)
+	}
+	if recovered.LineageID != "review-invalidated-recovered" || recovered.Recovery.Disposition != reviewtransaction.RecoveryInvalidated {
+		t.Fatalf("recovered = %#v", recovered)
+	}
+}
+
+func TestUnchangedTargetRecovery_EscalatedStillBlocked(t *testing.T) {
+	repo, baseRef, predecessor := newUnchangedTargetRecoveryFixture(t)
+	predecessorStore, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, predecessor.State.LineageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.ReadFile(predecessorStore.StatePath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	successorLineage := "review-escalated-unchanged"
+	authorization := "gentle-ai.review-recovery-authorization/v1\npredecessor_lineage=" + predecessor.State.LineageID +
+		"\npredecessor_revision=" + predecessor.Revision + "\ntarget_identity=" + predecessor.State.InitialSnapshot.Identity +
+		"\nactor=maintainer\nreason=escalated retry"
+	var output bytes.Buffer
+	err = RunReview([]string{"recover", "--cwd", repo, "--predecessor-lineage", predecessor.State.LineageID,
+		"--expected-predecessor-revision", predecessor.Revision, "--successor-lineage", successorLineage,
+		"--disposition", "escalated", "--reason", "escalated retry", "--actor", "maintainer",
+		"--maintainer-authorization", authorization, "--base-ref", baseRef, "--committed-only"}, &output)
+	if err == nil || err.Error() != "recovery scope has not changed" {
+		t.Fatalf("unchanged-target escalated recovery = %v", err)
+	}
+	after, err := os.ReadFile(predecessorStore.StatePath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Fatalf("predecessor state mutated by rejected escalated recovery")
+	}
+	if _, statErr := os.Stat(filepath.Join(reviewCLIAuthorityRoot(t, repo), "v2", successorLineage)); !os.IsNotExist(statErr) {
+		t.Fatalf("successor persisted despite rejected escalated recovery: %v", statErr)
+	}
+}
+
+func TestUnchangedTargetRecovery_ScopeChangedStillBlocked(t *testing.T) {
+	repo, baseRef, predecessor := newUnchangedTargetRecoveryFixture(t)
+	var output bytes.Buffer
+	err := RunReview([]string{"recover", "--cwd", repo, "--predecessor-lineage", predecessor.State.LineageID,
+		"--expected-predecessor-revision", predecessor.Revision, "--successor-lineage", "review-scope-changed-unchanged",
+		"--disposition", "scope_changed", "--reason", "attempted scope-changed retry", "--actor", "maintainer",
+		"--base-ref", baseRef, "--committed-only"}, &output)
+	if err == nil || err.Error() != "recovery scope has not changed" {
+		t.Fatalf("unchanged-target scope_changed recovery = %v", err)
+	}
+}
+
+func TestUnchangedTargetRecovery_BaseMismatchStillBlocked(t *testing.T) {
+	repo, _, predecessor := newUnchangedTargetRecoveryFixture(t)
+	if err := os.WriteFile(filepath.Join(repo, "other.txt"), []byte("advanced base\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runReviewCLIGit(t, repo, "add", "--", "other.txt")
+	runReviewCLIGit(t, repo, "commit", "-qm", "advance base")
+	advancedBaseRef := strings.TrimSpace(runReviewCLIGit(t, repo, "rev-parse", "HEAD"))
+	var output bytes.Buffer
+	err := RunReview([]string{"recover", "--cwd", repo, "--predecessor-lineage", predecessor.State.LineageID,
+		"--expected-predecessor-revision", predecessor.Revision, "--successor-lineage", "review-base-mismatch",
+		"--disposition", "invalidated", "--reason", "base mismatch check", "--actor", "maintainer",
+		"--base-ref", advancedBaseRef, "--committed-only"}, &output)
+	if err == nil || err.Error() != "recovery base-ref does not match predecessor base" {
+		t.Fatalf("base mismatch invalidated recovery = %v", err)
+	}
+}
+
+func TestUnchangedTargetRecovery_ChangedTargetInvalidatedStillSucceeds(t *testing.T) {
+	repo, baseRef, predecessor := newUnchangedTargetRecoveryFixture(t)
+	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("changed candidate\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runReviewCLIGit(t, repo, "add", "--", "tracked.txt")
+	runReviewCLIGit(t, repo, "commit", "-qm", "changed candidate")
+	var output bytes.Buffer
+	err := RunReview([]string{"recover", "--cwd", repo, "--predecessor-lineage", predecessor.State.LineageID,
+		"--expected-predecessor-revision", predecessor.Revision, "--successor-lineage", "review-changed-target-invalidated",
+		"--disposition", "invalidated", "--reason", "changed candidate recovery", "--actor", "maintainer",
+		"--base-ref", baseRef, "--committed-only"}, &output)
+	if err != nil {
+		t.Fatalf("changed-target invalidated recovery = %v", err)
+	}
+}

--- a/openspec/changes/1554-unchanged-target-recovery-invalidated/tasks.md
+++ b/openspec/changes/1554-unchanged-target-recovery-invalidated/tasks.md
@@ -34,13 +34,13 @@ Chain strategy: pending
 
 ## Phase 2: GREEN — Minimal Production Change
 
-- [ ] 2.1 In `internal/cli/review_facade.go` (~553-555), change the gate condition to add `&& reviewtransaction.RecoveryDisposition(*disposition) != reviewtransaction.RecoveryInvalidated`, matching the `RecoveryDisposition(*disposition)` conversion precedent at line 512. Do not touch lines 518-519 (`--committed-only`/`--base-ref` matching check) or line 550-552 (base-tree guard).
-- [ ] 2.2 Run `go test ./internal/cli/... -run TestUnchangedTargetRecovery -v`. Confirm 1.2 now passes (admitted, delegated to `validateCompactRecoveryEdge`'s `RecoveryInvalidated` case) and 1.3/1.4/1.5/1.6 still pass unchanged.
+- [x] 2.1 In `internal/cli/review_facade.go` (~553-555), change the gate condition to add `&& reviewtransaction.RecoveryDisposition(*disposition) != reviewtransaction.RecoveryInvalidated`, matching the `RecoveryDisposition(*disposition)` conversion precedent at line 512. Do not touch lines 518-519 (`--committed-only`/`--base-ref` matching check) or line 550-552 (base-tree guard).
+- [x] 2.2 Run `go test ./internal/cli/... -run TestUnchangedTargetRecovery -v`. Confirm 1.2 now passes (admitted, delegated to `validateCompactRecoveryEdge`'s `RecoveryInvalidated` case) and 1.3/1.4/1.5/1.6 still pass unchanged.
 
 ## Phase 3: Regression Safety Net
 
-- [ ] 3.1 Confirm `TestEscalatedRecoveryRequiresChangedTarget` (existing package-level test locking `errCompactRecoveryTargetUnchanged`) still passes unmodified — proves the #1419/#1429 invariant is untouched.
-- [ ] 3.2 Grep the diff for any edit outside the single conjunct on the gate line and outside the new test file; if found, revert and re-scope.
+- [x] 3.1 Confirm `TestEscalatedRecoveryRequiresChangedTarget` (existing package-level test locking `errCompactRecoveryTargetUnchanged`) still passes unmodified — proves the #1419/#1429 invariant is untouched.
+- [x] 3.2 Grep the diff for any edit outside the single conjunct on the gate line and outside the new test file; if found, revert and re-scope.
 
 ## Phase 4: Verification
 

--- a/openspec/changes/1554-unchanged-target-recovery-invalidated/tasks.md
+++ b/openspec/changes/1554-unchanged-target-recovery-invalidated/tasks.md
@@ -1,0 +1,51 @@
+# Tasks: Relax CLI unchanged-target recovery gate for `--disposition invalidated`
+
+## Review Workload Forecast
+
+| Field | Value |
+|-------|-------|
+| Estimated changed lines | ~60-90 (1 conjunct in `review_facade.go`; new test file with ~4-5 subtests) |
+| 400-line budget risk | Low |
+| Chained PRs recommended | No |
+| Suggested split | Single PR |
+| Delivery strategy | ask-on-risk |
+| Chain strategy | pending |
+
+Decision needed before apply: No
+Chained PRs recommended: No
+Chain strategy: pending
+400-line budget risk: Low
+
+### Suggested Work Units
+
+| Unit | Goal | Likely PR | Focused test command | Runtime harness | Rollback boundary |
+|------|------|-----------|----------------------|-----------------|-------------------|
+| 1 | RED tests + gate conjunct in `internal/cli/review_facade.go` (~553-555) | PR 1 | `go test ./internal/cli/... -run TestUnchangedTargetRecovery` | Real temp Git repo via `initReviewCLIRepo` + `RunReviewInvalidate`/`RunReviewRecover` (no mocks) | Revert the single conjunct and delete the new test file |
+
+## Phase 1: RED — Failing Tests First
+
+- [x] 1.1 Create `internal/cli/review_recovery_unchanged_target_test.go`. Add shared fixture helper building a `StateInvalidated` predecessor with `TargetBaseDiff` (or overlay) initial snapshot via `initReviewCLIRepo` + `RunReviewInvalidate`, then a recovery attempt producing an identical target `Identity` (same `--base-ref`/candidate).
+- [x] 1.2 `TestUnchangedTargetRecovery_InvalidatedAdmitted`: `RunReviewRecover(--disposition invalidated)` on the fixture. Assert it currently fails with `"recovery scope has not changed"` (proves RED — spec Scenario "Unchanged-target invalidated recovery succeeds").
+- [x] 1.3 `TestUnchangedTargetRecovery_EscalatedStillBlocked`: same fixture, `--disposition escalated` with a fully valid `--maintainer-authorization`. Assert error is exactly `"recovery scope has not changed"` AND no successor record is persisted (load predecessor store again, confirm state unchanged) — spec Scenario "Unchanged-target escalated still rejected at CLI level".
+- [x] 1.4 `TestUnchangedTargetRecovery_ScopeChangedStillBlocked`: same fixture, `--disposition scope_changed`. Assert error is exactly `"recovery scope has not changed"` — spec Scenario "Unchanged-target scope_changed still rejected at CLI level".
+- [x] 1.5 `TestUnchangedTargetRecovery_BaseMismatchStillBlocked`: same fixture, `--disposition invalidated` with a `--base-ref` resolving to a different base tree. Assert error is exactly `"recovery base-ref does not match predecessor base"` — spec Scenario "Base-tree mismatch still rejected for invalidated".
+- [x] 1.6 `TestUnchangedTargetRecovery_ChangedTargetInvalidatedStillSucceeds`: same predecessor kind, but successor snapshot has a genuinely different `Identity`, `--disposition invalidated`. Assert `RunReviewRecover` returns nil (no-regression happy path, unaffected by the conjunct).
+- [x] 1.7 Run `go test ./internal/cli/... -run TestUnchangedTargetRecovery -v`. Confirm 1.2 fails on `"recovery scope has not changed"` and 1.3/1.4/1.5/1.6 already pass pre-change (they document current behavior that must NOT regress).
+
+## Phase 2: GREEN — Minimal Production Change
+
+- [ ] 2.1 In `internal/cli/review_facade.go` (~553-555), change the gate condition to add `&& reviewtransaction.RecoveryDisposition(*disposition) != reviewtransaction.RecoveryInvalidated`, matching the `RecoveryDisposition(*disposition)` conversion precedent at line 512. Do not touch lines 518-519 (`--committed-only`/`--base-ref` matching check) or line 550-552 (base-tree guard).
+- [ ] 2.2 Run `go test ./internal/cli/... -run TestUnchangedTargetRecovery -v`. Confirm 1.2 now passes (admitted, delegated to `validateCompactRecoveryEdge`'s `RecoveryInvalidated` case) and 1.3/1.4/1.5/1.6 still pass unchanged.
+
+## Phase 3: Regression Safety Net
+
+- [ ] 3.1 Confirm `TestEscalatedRecoveryRequiresChangedTarget` (existing package-level test locking `errCompactRecoveryTargetUnchanged`) still passes unmodified — proves the #1419/#1429 invariant is untouched.
+- [ ] 3.2 Grep the diff for any edit outside the single conjunct on the gate line and outside the new test file; if found, revert and re-scope.
+
+## Phase 4: Verification
+
+- [ ] 4.1 Run `go test ./internal/cli/...` (full package) and `go test ./internal/reviewtransaction/...` — no regressions.
+- [ ] 4.2 Run `go test ./...` (full suite).
+- [ ] 4.3 Run `go vet ./...`.
+- [ ] 4.4 Run `git diff --stat` and confirm total changed lines stay well under the 400-line review budget.
+- [ ] 4.5 Confirm no `git push` or GitHub interaction occurred (hard constraint from proposal/spec).

--- a/openspec/changes/1554-unchanged-target-recovery-invalidated/tasks.md
+++ b/openspec/changes/1554-unchanged-target-recovery-invalidated/tasks.md
@@ -44,8 +44,8 @@ Chain strategy: pending
 
 ## Phase 4: Verification
 
-- [ ] 4.1 Run `go test ./internal/cli/...` (full package) and `go test ./internal/reviewtransaction/...` — no regressions.
-- [ ] 4.2 Run `go test ./...` (full suite).
-- [ ] 4.3 Run `go vet ./...`.
-- [ ] 4.4 Run `git diff --stat` and confirm total changed lines stay well under the 400-line review budget.
-- [ ] 4.5 Confirm no `git push` or GitHub interaction occurred (hard constraint from proposal/spec).
+- [x] 4.1 Run `go test ./internal/cli/...` (full package) and `go test ./internal/reviewtransaction/...` — no regressions.
+- [x] 4.2 Run `go test ./...` (full suite).
+- [x] 4.3 Run `go vet ./...`.
+- [x] 4.4 Run `git diff --stat` and confirm total changed lines stay well under the 400-line review budget.
+- [x] 4.5 Confirm no `git push` or GitHub interaction occurred (hard constraint from proposal/spec).


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1554

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)

---

## 📝 Summary

- `gentle-ai review recover` unconditionally rejected any recovery whose successor target identity equals the predecessor's, for **every** `--disposition`, at the CLI level in `RunReviewRecover`.
- The package-level `validateCompactRecoveryEdge`'s `RecoveryInvalidated` case already imposes no changed-target requirement — the CLI gate was blocking something the deeper validation already permits, preventing legitimate redo of an `invalidated` review against the same candidate (e.g. after external evidence like a base advance or a new CVE).
- This PR scopes the CLI gate so it no longer fires for `--disposition invalidated`, delegating to the existing package-level validation. It does **not** touch `--disposition escalated` or the `#1419`/`#1429` `errCompactRecoveryTargetUnchanged` security invariant, which remains fully enforced (see regression tests below).

**Scope note:** this addresses only the narrow `invalidated`-disposition sub-bug flagged as independently safe in the [first comment on #1554](https://github.com/Gentleman-Programming/gentle-ai/issues/1554#issuecomment-5024130040). It is a separate, smaller slice from the `--disposition escalated` / dedicated `review retry-final-verification` operation [approved in the second comment](https://github.com/Gentleman-Programming/gentle-ai/issues/1554#issuecomment-5048498357) — that larger piece is tracked separately and not part of this PR.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/cli/review_facade.go` | `RunReviewRecover`'s unchanged-target gate now skips when `--disposition invalidated`, delegating to package-level validation |
| `internal/cli/review_recovery_unchanged_target_test.go` | New regression suite: invalidated admitted; escalated/scope_changed still blocked with no state mutation; base-mismatch still blocked for all three dispositions; changed-target invalidated unaffected |
| `openspec/changes/1554-unchanged-target-recovery-invalidated/tasks.md` | SDD task tracking for this slice (RED→GREEN→regression→verification, all checked) |

---

## 🧪 Test Plan

```bash
go test ./internal/cli/... -run TestUnchangedTargetRecovery -v   # 7/7 PASS
go test ./internal/cli/... ./internal/reviewtransaction/...      # ok
go run ./internal/gofmtcheck                                     # clean
```

- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — not run locally (Docker), CI will cover
- [x] Manually tested locally, including native `gentle-ai review start/capture-result/finalize/validate --gate pre-commit` self-review (lens: review-reliability, 0 findings, receipt approved, gate allow)

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines (265 changed lines)
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — not run locally
- [x] I have updated documentation if necessary (SDD tasks.md included; proposal/design/spec follow in a chained PR, see below)
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers

---

## Chain Context

| Field | Value |
|-------|-------|
| Chain | 1554-unchanged-target-recovery-invalidated (stacked) |
| Tracker PR | Not needed |
| Position | 1 of 2 |
| Base | `main` |
| Depends on | None |
| Follow-up | PR 2 — SDD proposal/design/spec + verify-report docs for this same slice |
| Review budget | 265 / 400 |
| Starts at | `main` |
| Ends with | Standalone fix: `--disposition invalidated` recovery of an unchanged target now succeeds; `escalated`/`scope_changed` remain blocked |

### Chain Overview

```text
main
 └── 📍 This PR — fix + tests
      └── PR 2 (next) — SDD proposal/design/spec + verify-report
```

### Scope
- Includes: CLI gate fix for `--disposition invalidated`, regression test suite
- Excludes: SDD planning/verify docs (PR 2), `--disposition escalated` / `review retry-final-verification` (separate, larger, tracked against the same issue)

### Autonomy
- [x] CI is expected to pass for this PR branch
- [x] This PR has one deliverable scope
- [x] This PR can be rolled back without unrelated changes
- [x] Tests cover this unit

---

## 💬 Notes for Reviewers

This is PR 1 of a 2-PR stack for the `invalidated`-disposition slice of #1554 (split to stay under the 400-line review budget — the SDD docs alone are ~430 lines). PR 2 will add the proposal/design/spec/verify-report and will target `main` as well; please review PR 2 only for the docs, this PR for the actual behavior change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Invalidated recovery can now proceed when the recovery target remains unchanged.
  - Escalated and scope-changed recoveries remain blocked when the recovery scope has not changed.
  - Recovery requests with mismatched base references continue to be rejected.
  - Recovery succeeds when the candidate content produces a changed target identity.

- **Tests**
  - Added coverage for unchanged-target, changed-target, disposition, and base-reference recovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->