### PR TITLE
fix(opencode): EnrichWithVariants fails on provider ID mismatch, skipping effort picker in OpenCode TUI

### DIFF
--- a/internal/opencode/models.go
+++ b/internal/opencode/models.go
@@ -304,6 +304,8 @@ func EnrichWithVariants(cached map[string]Provider, variantsPath string) {
 	if err != nil {
 		return
 	}
+
+	// Pass 1: Process exact provider matches first.
 	for provID, models := range variants {
 		cachedProv, ok := cached[provID]
 		if !ok {
@@ -316,6 +318,41 @@ func EnrichWithVariants(cached map[string]Provider, variantsPath string) {
 			}
 		}
 		cached[provID] = cachedProv
+	}
+
+	// Pass 2: Deterministic fallback for models that remain unassigned.
+	// Sort keys to eliminate Go map iteration nondeterminism.
+	variantKeys := make([]string, 0, len(variants))
+	for provID := range variants {
+		variantKeys = append(variantKeys, provID)
+	}
+	sort.Strings(variantKeys)
+
+	cachedKeys := make([]string, 0, len(cached))
+	for cachedID := range cached {
+		cachedKeys = append(cachedKeys, cachedID)
+	}
+	sort.Strings(cachedKeys)
+
+	for _, provID := range variantKeys {
+		models := variants[provID]
+		modelKeys := make([]string, 0, len(models))
+		for modelID := range models {
+			modelKeys = append(modelKeys, modelID)
+		}
+		sort.Strings(modelKeys)
+
+		for _, modelID := range modelKeys {
+			levels := models[modelID]
+			for _, cachedID := range cachedKeys {
+				p := cached[cachedID]
+				if cachedModel, ok := p.Models[modelID]; ok && len(cachedModel.Variants) == 0 {
+					cachedModel.Variants = levels
+					p.Models[modelID] = cachedModel
+					cached[cachedID] = p
+				}
+			}
+		}
 	}
 }
 

--- a/internal/opencode/models_test.go
+++ b/internal/opencode/models_test.go
@@ -974,3 +974,57 @@ func TestFixOpenRouterModels(t *testing.T) {
 		}
 	})
 }
+
+func TestEnrichWithVariantsFallbackProviderMismatch(t *testing.T) {
+	dir := t.TempDir()
+	variantsPath := filepath.Join(dir, "model-variants.json")
+	// Plugin cached variants under provider "openai"
+	variantsData := `{
+		"openai": {
+			"gpt-5.6-luna": ["low", "medium", "high", "max"]
+		}
+	}`
+	if err := os.WriteFile(variantsPath, []byte(variantsData), 0o644); err != nil {
+		t.Fatalf("write variants fixture: %v", err)
+	}
+
+	// Cached providers in gentle-ai has both "openai" (exact match) and "opencode" (built-in/custom alias)
+	cached := map[string]Provider{
+		"openai": {
+			ID:   "openai",
+			Name: "OpenAI",
+			Models: map[string]Model{
+				"gpt-5.6-luna": {
+					ID:       "gpt-5.6-luna",
+					Name:     "GPT-5.6 Luna",
+					ToolCall: true,
+				},
+			},
+		},
+		"opencode": {
+			ID:   "opencode",
+			Name: "OpenCode",
+			Models: map[string]Model{
+				"gpt-5.6-luna": {
+					ID:       "gpt-5.6-luna",
+					Name:     "GPT-5.6 Luna",
+					ToolCall: true,
+				},
+			},
+		},
+	}
+
+	EnrichWithVariants(cached, variantsPath)
+
+	wantLevels := []string{"low", "medium", "high", "max"}
+
+	modelOpenAI := cached["openai"].Models["gpt-5.6-luna"]
+	if !reflect.DeepEqual(modelOpenAI.Variants, wantLevels) {
+		t.Fatalf("exact match openai model variants = %v, want %v", modelOpenAI.Variants, wantLevels)
+	}
+
+	modelOpenCode := cached["opencode"].Models["gpt-5.6-luna"]
+	if !reflect.DeepEqual(modelOpenCode.Variants, wantLevels) {
+		t.Fatalf("fallback opencode model variants = %v, want %v", modelOpenCode.Variants, wantLevels)
+	}
+}


### PR DESCRIPTION
### 🔗 Linked Issue

Fixes #1648

---

### 📝 Summary of Changes

In the OpenCode TUI Model Picker (`internal/tui/screens/model_picker.go`), selecting reasoning models such as `gpt-5.6-luna` under the built-in `opencode` provider (or custom provider aliases) silently skipped the reasoning effort selection screen (`ModeEffortSelect`).

#### Root Cause & Fix
1. **Provider Key Mismatch**: The OpenCode `model-variants` plugin caches variants under internal provider IDs (e.g. `openai`), whereas Gentle AI loads providers under their built-in or configured ID (e.g. `opencode` or custom aliases).
2. **Fallback Matching**: Updated `EnrichWithVariants` in `internal/opencode/models.go` to fall back to matching model IDs across all cached providers when the provider ID does not match directly.
3. **Unit Test Coverage**: Added `TestEnrichWithVariantsFallbackProviderMismatch` in `internal/opencode/models_test.go`.

---

### 🧪 Test Plan

- [x] Ran `go run ./internal/gofmtcheck` cleanly.
- [x] Ran unit tests: `go test ./internal/opencode/... ./internal/tui/...` passed cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed missing model variant options when cached provider identifiers didn’t match plugin-provided provider data.
  * Model variants are now reliably enriched using a deterministic fallback for unmatched provider entries.
* **Tests**
  * Added test coverage for provider identifier mismatch scenarios to prevent regressions in variant enrichment behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->