### PR TITLE
fix(review): bind FINALIZE selection to the live frozen target

### DIFF
--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -1106,7 +1106,7 @@ func runReviewFacadeFinalize(ctx context.Context, args []string, stdout io.Write
 	if err != nil {
 		return fmt.Errorf("resolve review repository root: %w", err)
 	}
-	store, record, err := discoverCompactFacadeReview(ctx, root, *lineage, false)
+	store, record, err := discoverCompactFacadeFinalize(ctx, root, *lineage)
 	if err != nil {
 		if _, chain, _, legacyErr := discoverFacadeReview(ctx, root, *lineage, false); legacyErr == nil {
 			legacyLineage := chain.Records[len(chain.Records)-1].Transaction.LineageID
@@ -1239,12 +1239,13 @@ func runReviewFacadeFinalize(ctx context.Context, args []string, stdout io.Write
 	}
 	var attempt reviewtransaction.FinalizeAttempt
 	attemptLoaded := false
+	var pendingAtEntry *reviewtransaction.FinalizeAttempt
 	if !terminalAtEntry {
-		pending, pendingErr := store.PendingFinalizeAttempt()
-		if pendingErr != nil {
-			return pendingErr
+		pendingAtEntry, err = store.PendingFinalizeAttempt()
+		if err != nil {
+			return err
 		}
-		if index := facadeFinalizeTransitionIndex(pending, record.Revision); index >= 0 {
+		if index := facadeFinalizeTransitionIndex(pendingAtEntry, record.Revision); index >= 0 {
 			replayEvidence := evidence
 			if len(replayEvidence) == 0 && facadeNativeLowRiskCandidate(state) {
 				replayEvidence, err = prepareFacadeNativeLowRiskVerification(ctx, root, state)
@@ -1265,11 +1266,33 @@ func runReviewFacadeFinalize(ctx context.Context, args []string, stdout io.Write
 			}
 		}
 	}
+	if !terminalAtEntry && pendingAtEntry == nil {
+		if err := (reviewtransaction.SnapshotBuilder{Repo: root}).ValidateEvidence(ctx, state.CurrentSnapshot); err != nil {
+			// Keep negotiated Git failures classified as preflight/not_started.
+			return reviewPreflightError(fmt.Errorf("validate FINALIZE current snapshot: %v", err))
+		}
+	}
 	plan, err := prepareFacadeFinalizePlan(ctx, root, record.Revision, state, reviewerResults, refuter, validation, evidence, *correctionLines, *failed)
 	if err != nil {
 		return reviewPreflightError(err)
 	}
+	// A zero-transition next-transition request is a read-only routing projection;
+	// correction routing may intentionally describe a live target not frozen yet.
+	if !terminalAtEntry && pendingAtEntry == nil && (len(plan.Transitions) > 0 || !*nextTransition) {
+		if err := (reviewtransaction.SnapshotBuilder{Repo: root}).ValidateLiveSnapshot(ctx, plan.Candidate); err != nil {
+			return reviewPreflightError(fmt.Errorf("validate FINALIZE live target: %v", err))
+		}
+	}
+	if !terminalAtEntry && pendingAtEntry == nil && len(plan.Transitions) == 0 {
+		return encodeCompactFacadeFinalize(stdout, negotiated, *actionEligibility, *nextTransition, state, record.Revision, store, "continue the current review state", reviewFinalizeOutputContext{Context: ctx, Repo: root})
+	}
 	request := facadeFinalizeAttemptRequestForCandidate(record, plan.Candidate, reviewerResults, validation, refuter, plan.Evidence, *correctionLines, *failed)
+	if !terminalAtEntry && pendingAtEntry != nil && !attemptLoaded {
+		attempt, attemptLoaded, err = store.ReconcileFinalizeAttempt(ctx, request)
+		if err != nil {
+			return err
+		}
+	}
 	if terminalAtEntry {
 		if terminalPending != nil {
 			attempt = *terminalPending
@@ -2099,6 +2122,59 @@ func nativeFacadeReviewerLens(lens string) (string, error) {
 	default:
 		return "", fmt.Errorf("unsupported reviewer lens %q", lens)
 	}
+}
+
+func discoverCompactFacadeFinalize(ctx context.Context, repo, lineage string) (reviewtransaction.CompactStore, reviewtransaction.CompactRecord, error) {
+	if strings.TrimSpace(lineage) != "" {
+		return discoverCompactFacadeReview(ctx, repo, lineage, false)
+	}
+	stores, err := reviewtransaction.CompactAuthorityLeaves(ctx, repo)
+	if err != nil {
+		return reviewtransaction.CompactStore{}, reviewtransaction.CompactRecord{}, err
+	}
+	type candidate struct {
+		store  reviewtransaction.CompactStore
+		record reviewtransaction.CompactRecord
+	}
+	candidates := []candidate{}
+	for _, store := range stores {
+		if record, loadErr := store.Load(); loadErr == nil {
+			candidates = append(candidates, candidate{store: store, record: record})
+		}
+	}
+	if len(candidates) > 1 {
+		active := candidates[:0]
+		for _, candidate := range candidates {
+			if !facadeTerminalState(candidate.record.State.State) {
+				active = append(active, candidate)
+			}
+		}
+		if len(active) > 0 {
+			candidates = active
+		}
+	}
+	if len(candidates) > 1 && facadeTerminalState(candidates[0].record.State.State) {
+		return discoverCompactFacadeReview(ctx, repo, "", false)
+	}
+	if len(candidates) > 1 {
+		exact := candidates[:0]
+		for _, candidate := range candidates {
+			if (reviewtransaction.SnapshotBuilder{Repo: repo}).ValidateLiveSnapshot(ctx, candidate.record.State.CurrentSnapshot) == nil {
+				exact = append(exact, candidate)
+			}
+		}
+		if len(exact) == 0 {
+			return reviewtransaction.CompactStore{}, reviewtransaction.CompactRecord{}, reviewPreflightError(errors.New("no compact FINALIZE authority matches the live target"))
+		}
+		candidates = exact
+	}
+	if len(candidates) == 0 {
+		return reviewtransaction.CompactStore{}, reviewtransaction.CompactRecord{}, errors.New("no discoverable compact facade review lineage found")
+	}
+	if len(candidates) != 1 {
+		return reviewtransaction.CompactStore{}, reviewtransaction.CompactRecord{}, errors.New("multiple compact facade review lineages found; specify --lineage")
+	}
+	return candidates[0].store, candidates[0].record, nil
 }
 
 func discoverCompactFacadeReview(ctx context.Context, repo, lineage string, terminal bool) (reviewtransaction.CompactStore, reviewtransaction.CompactRecord, error) {

--- a/internal/cli/review_facade_test.go
+++ b/internal/cli/review_facade_test.go
@@ -617,6 +617,7 @@ func TestReviewFacadeFinalizeReceiptPublicationFailureIsExactlyReplayable(t *tes
 		return reviewtransaction.WriteCompactReceiptAtomic(path, got)
 	}
 	defer func() { writeCompactFacadeReceipt = original }()
+	writeReviewStartCandidate(t, fixture.repo, "tracked.txt", "later worktree drift\n", 0o644)
 	var output bytes.Buffer
 	if err := RunReviewFacadeFinalize([]string{"--cwd", fixture.repo, "--lineage", fixture.started.LineageID}, &output); err != nil {
 		t.Fatalf("exact receipt replay: %v", err)
@@ -734,6 +735,7 @@ func TestReviewFacadeFinalizePlannedTransitionInterruptionResumesWithoutDuplicat
 		t.Fatalf("planned interruption journal = %#v, %v", pending, err)
 	}
 	reviewFacadePlannedTransitionHook = original
+	writeReviewStartCandidate(t, repo, "tracked.txt", "later worktree drift\n", 0o644)
 	if err := RunReviewFacadeFinalize(args, io.Discard); err != nil {
 		t.Fatalf("exact replay after planned interruption: %v", err)
 	}

--- a/internal/cli/review_finalize_preflight_test.go
+++ b/internal/cli/review_finalize_preflight_test.go
@@ -3,13 +3,328 @@ package cli
 import (
 	"bytes"
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/gentleman-programming/gentle-ai/internal/reviewtransaction"
 )
+
+func TestNegotiatedReviewFinalizeRejectsStaleLiveTargetWithoutMutation(t *testing.T) {
+	tests := []struct {
+		name     string
+		explicit bool
+		breakGit bool
+	}{
+		{name: "explicit stale reviewing lineage", explicit: true},
+		{name: "implicit sole stale reviewing lineage"},
+		{name: "frozen Git evidence is unavailable", explicit: true, breakGit: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := initReviewCLIRepo(t)
+			if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("candidate\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			started, store, resultArgs := startFinalizeLiveTarget(t, repo, "finalize-stale-"+reviewTestSlug(tt.name))
+			record, err := store.Load()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if tt.breakGit {
+				object := record.State.CurrentSnapshot.CandidateTree
+				if err := os.Remove(filepath.Join(repo, ".git", "objects", object[:2], object[2:])); err != nil {
+					t.Fatalf("remove frozen candidate tree: %v", err)
+				}
+			} else if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("drifted\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			lineage := ""
+			if tt.explicit {
+				lineage = started.LineageID
+			}
+			assertFinalizeLiveTargetDenied(t, repo, lineage, resultArgs)
+		})
+	}
+}
+
+func TestNegotiatedReviewFinalizeRejectsStaleZeroTransitionWithoutMutation(t *testing.T) {
+	for _, explicit := range []bool{true, false} {
+		name := "implicit sole lineage"
+		if explicit {
+			name = "explicit lineage"
+		}
+		t.Run(name, func(t *testing.T) {
+			repo := initReviewCLIRepo(t)
+			writeReviewStartCandidate(t, repo, "tracked.txt", "candidate\n", 0o644)
+			started, store, resultArgs := startFinalizeLiveTarget(t, repo, "finalize-zero-transition-"+reviewTestSlug(name))
+			args := []string{"finalize", "--contract", ReviewIntegrationContractV1, "--cwd", repo, "--lineage", started.LineageID}
+			args = append(args, resultArgs...)
+			if err := RunReview(args, &bytes.Buffer{}); err != nil {
+				t.Fatalf("advance to validating: %v", err)
+			}
+			record, err := store.Load()
+			if err != nil || record.State.State != reviewtransaction.StateValidating {
+				t.Fatalf("validating authority = %#v, %v", record, err)
+			}
+			writeReviewStartCandidate(t, repo, "tracked.txt", "drifted\n", 0o644)
+			lineage := ""
+			if explicit {
+				lineage = started.LineageID
+			}
+			assertFinalizeLiveTargetDenied(t, repo, lineage, nil)
+		})
+	}
+}
+
+func TestReviewFinalizeAcceptsExactLiveTargetSemantics(t *testing.T) {
+	tests := []struct {
+		name    string
+		prepare func(*testing.T, string) ([]string, func())
+	}{
+		{name: "workspace with intended untracked proof", prepare: func(t *testing.T, repo string) ([]string, func()) {
+			writeReviewStartCandidate(t, repo, "tracked.txt", "workspace\n", 0o644)
+			writeReviewStartCandidate(t, repo, "scope.txt", "included\n", 0o644)
+			return nil, nil
+		}},
+		{name: "staged with unrelated unstaged divergence", prepare: func(t *testing.T, repo string) ([]string, func()) {
+			writeReviewStartCandidate(t, repo, "tracked.txt", "staged\n", 0o644)
+			runReviewCLIGit(t, repo, "add", "tracked.txt")
+			return []string{"--projection", string(reviewtransaction.ProjectionStaged)}, func() {
+				writeReviewStartCandidate(t, repo, "tracked.txt", "unstaged divergence\n", 0o644)
+			}
+		}},
+		{name: "committed base diff with dirty workspace", prepare: func(t *testing.T, repo string) ([]string, func()) {
+			base := strings.TrimSpace(runReviewCLIGit(t, repo, "rev-parse", "HEAD"))
+			writeReviewStartCandidate(t, repo, "tracked.txt", "committed\n", 0o644)
+			runReviewCLIGit(t, repo, "add", "tracked.txt")
+			runReviewCLIGit(t, repo, "commit", "-qm", "candidate")
+			return []string{"--base-ref", base, "--committed-only"}, func() {
+				writeReviewStartCandidate(t, repo, "tracked.txt", "dirty but excluded\n", 0o644)
+			}
+		}},
+		{name: "base workspace overlay", prepare: func(t *testing.T, repo string) ([]string, func()) {
+			base := strings.TrimSpace(runReviewCLIGit(t, repo, "rev-parse", "HEAD"))
+			writeReviewStartCandidate(t, repo, "tracked.txt", "committed\n", 0o644)
+			runReviewCLIGit(t, repo, "add", "tracked.txt")
+			runReviewCLIGit(t, repo, "commit", "-qm", "branch change")
+			writeReviewStartCandidate(t, repo, "tracked.txt", "overlay\n", 0o644)
+			return []string{"--base-ref", base, "--workspace-overlay"}, nil
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := initReviewCLIRepo(t)
+			startArgs, afterStart := tt.prepare(t, repo)
+			started, store, resultArgs := startFinalizeLiveTarget(t, repo, "finalize-exact-"+reviewTestSlug(tt.name), startArgs...)
+			if afterStart != nil {
+				afterStart()
+			}
+			args := []string{"finalize", "--contract", ReviewIntegrationContractV1, "--cwd", repo, "--lineage", started.LineageID}
+			args = append(args, resultArgs...)
+			if err := RunReview(args, &bytes.Buffer{}); err != nil {
+				t.Fatalf("exact FINALIZE failed: %v", err)
+			}
+			record, err := store.Load()
+			if err != nil || record.State.State != reviewtransaction.StateValidating {
+				t.Fatalf("exact FINALIZE authority = %#v, %v", record, err)
+			}
+		})
+	}
+}
+
+func TestReviewFinalizeCrowdedStoreSelectsOnlyFullLiveSnapshotMatch(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	writeReviewStartCandidate(t, repo, "tracked.txt", "target\n", 0o644)
+	writeReviewStartCandidate(t, repo, "scope.txt", "scope\n", 0o644)
+	_, stale, staleResults := startFinalizeLiveTarget(t, repo, "finalize-crowded-stale")
+	staleRecord, err := stale.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	runReviewCLIGit(t, repo, "add", "tracked.txt", "scope.txt")
+	runReviewCLIGit(t, repo, "commit", "-qm", "stale candidate tree")
+	writeReviewStartCandidate(t, repo, "tracked.txt", "intermediate\n", 0o644)
+	runReviewCLIGit(t, repo, "add", "tracked.txt")
+	runReviewCLIGit(t, repo, "commit", "-qm", "new live base")
+	writeReviewStartCandidate(t, repo, "tracked.txt", "target\n", 0o644)
+	live, err := (reviewtransaction.SnapshotBuilder{Repo: repo}).Build(context.Background(), reviewtransaction.Target{
+		Kind: reviewtransaction.TargetCurrentChanges, Projection: reviewtransaction.ProjectionWorkspace, IntendedUntracked: []string{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if live.CandidateTree != staleRecord.State.CurrentSnapshot.CandidateTree || live.BaseTree == staleRecord.State.CurrentSnapshot.BaseTree ||
+		reflect.DeepEqual(live.Paths, staleRecord.State.CurrentSnapshot.Paths) || live.IntendedUntrackedProof == staleRecord.State.CurrentSnapshot.IntendedUntrackedProof {
+		t.Fatalf("fixture does not share only CandidateTree: stale=%#v live=%#v", staleRecord.State.CurrentSnapshot, live)
+	}
+	assertFinalizeLiveTargetDenied(t, repo, staleRecord.State.LineageID, staleResults)
+	changed, err := (reviewtransaction.SnapshotBuilder{Repo: repo}).ChangedLines(context.Background(), live)
+	if err != nil {
+		t.Fatal(err)
+	}
+	exactState, err := reviewtransaction.NewCompactState(reviewtransaction.Start{
+		LineageID: "finalize-crowded-exact", Mode: reviewtransaction.ModeOrdinaryBounded, Generation: 1, Snapshot: live,
+		PolicyHash: staleRecord.State.PolicyHash, RiskLevel: staleRecord.State.RiskLevel,
+		SelectedLenses: append([]string{}, staleRecord.State.SelectedLenses...), OriginalChangedLines: &changed,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	exact, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, exactState.LineageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := exact.Replace("", "review/start", exactState); err != nil {
+		t.Fatal(err)
+	}
+	staleBytes := readReviewOperationFile(t, stale.StatePath())
+	resultArgs := facadeReviewerResultArgs(t, ReviewFacadeStartResult{SelectedLenses: exactState.SelectedLenses})
+	args := []string{"finalize", "--contract", ReviewIntegrationContractV1, "--cwd", repo}
+	args = append(args, resultArgs...)
+	if err := RunReview(args, &bytes.Buffer{}); err != nil {
+		t.Fatalf("crowded exact FINALIZE failed: %v", err)
+	}
+	exactRecord, err := exact.Load()
+	if err != nil || exactRecord.State.State != reviewtransaction.StateValidating {
+		t.Fatalf("crowded exact authority = %#v, %v", exactRecord, err)
+	}
+	if got := readReviewOperationFile(t, stale.StatePath()); !bytes.Equal(got, staleBytes) {
+		t.Fatal("crowded FINALIZE mutated stale lineage")
+	}
+	assertCompactLineageFiles(t, stale, []string{"review-state.json"})
+}
+
+func TestReviewFinalizeConvergesCommittedPendingJournalAfterWorktreeDrift(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	writeReviewStartCandidate(t, repo, "tracked.txt", "candidate\n", 0o644)
+	started, store, resultArgs := startFinalizeLiveTarget(t, repo, "finalize-pending-drift")
+	args := append([]string{"--cwd", repo, "--lineage", started.LineageID}, resultArgs...)
+	sentinel := errors.New("interrupt after committed transition")
+	original := reviewFacadeCommittedTransitionHook
+	reviewFacadeCommittedTransitionHook = func(_ context.Context, _ string, operation, _ string) error {
+		if operation == "review/complete-review" {
+			return sentinel
+		}
+		return nil
+	}
+	t.Cleanup(func() { reviewFacadeCommittedTransitionHook = original })
+	if err := RunReviewFacadeFinalize(args, &bytes.Buffer{}); !errors.Is(err, sentinel) {
+		t.Fatalf("committed interruption = %v", err)
+	}
+	reviewFacadeCommittedTransitionHook = original
+	committed, err := store.Load()
+	if err != nil || committed.State.State != reviewtransaction.StateValidating {
+		t.Fatalf("committed pending authority = %#v, %v", committed, err)
+	}
+	writeReviewStartCandidate(t, repo, "tracked.txt", "later drift\n", 0o644)
+	if err := RunReviewFacadeFinalize(args, &bytes.Buffer{}); err != nil {
+		t.Fatalf("exact pending replay after drift: %v", err)
+	}
+	after, err := store.Load()
+	if err != nil || after.Revision != committed.Revision || !reflect.DeepEqual(after.State, committed.State) {
+		t.Fatalf("pending replay changed committed authority: before=%#v after=%#v err=%v", committed, after, err)
+	}
+	if pending, err := store.PendingFinalizeAttempt(); err != nil || pending != nil {
+		t.Fatalf("pending replay did not converge journal: %#v, %v", pending, err)
+	}
+}
+
+func TestReviewFinalizeBindsCorrectedRetrySuccessorToLiveFixDiff(t *testing.T) {
+	for _, drift := range []bool{false, true} {
+		name := "exact"
+		if drift {
+			name = "drift denied"
+		}
+		t.Run(name, func(t *testing.T) {
+			fixture := failedCorrectedFinalVerificationCLIFixture(t)
+			successor := "finalize-retry-" + reviewTestSlug(name)
+			if err := RunReview(finalVerificationRetryCLIArgs(t, fixture, successor, fixture.incidentPath), &bytes.Buffer{}); err != nil {
+				t.Fatal(err)
+			}
+			store, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), fixture.repo, successor)
+			if err != nil {
+				t.Fatal(err)
+			}
+			record, err := store.Load()
+			if err != nil || record.State.State != reviewtransaction.StateValidating || record.State.CurrentSnapshot.Kind != reviewtransaction.TargetFixDiff {
+				t.Fatalf("retry successor = %#v, %v", record, err)
+			}
+			evidence := filepath.Join(t.TempDir(), "evidence.txt")
+			if err := os.WriteFile(evidence, []byte("retry verification passed\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if drift {
+				writeReviewStartCandidate(t, fixture.repo, "tracked.txt", "retry drift\n", 0o644)
+			}
+			before := cliReviewAuthoritySnapshot(t, fixture.repo)
+			var output bytes.Buffer
+			err = RunReview([]string{"finalize", "--contract", ReviewIntegrationContractV1, "--cwd", fixture.repo,
+				"--lineage", successor, "--evidence", evidence}, &output)
+			if !drift {
+				if err != nil {
+					t.Fatalf("exact retry FINALIZE: %v", err)
+				}
+				terminal, loadErr := store.Load()
+				if loadErr != nil || terminal.State.State != reviewtransaction.StateApproved {
+					t.Fatalf("exact retry terminal = %#v, %v", terminal, loadErr)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("drifted retry FINALIZE succeeded: %s", output.String())
+			}
+			failure := decodeReviewIntegrationFailure(t, output.Bytes())
+			if failure.Phase != "preflight" || failure.MutationOutcome != ReviewMutationNotStarted || failure.LineageID != successor {
+				t.Fatalf("drifted retry failure = %#v", failure)
+			}
+			if after := cliReviewAuthoritySnapshot(t, fixture.repo); !reflect.DeepEqual(after, before) {
+				t.Fatalf("drifted retry mutated authority: before=%v after=%v", before, after)
+			}
+		})
+	}
+}
+
+func startFinalizeLiveTarget(t *testing.T, repo, lineage string, extra ...string) (ReviewFacadeStartResult, reviewtransaction.CompactStore, []string) {
+	t.Helper()
+	args := []string{"--cwd", repo, "--lineage", lineage}
+	args = append(args, extra...)
+	var output bytes.Buffer
+	if err := RunReviewFacadeStart(args, &output); err != nil {
+		t.Fatal(err)
+	}
+	var started ReviewFacadeStartResult
+	decodeStrictReviewJSON(t, output.Bytes(), &started)
+	store, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, started.LineageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return started, store, facadeReviewerResultArgs(t, started)
+}
+func assertFinalizeLiveTargetDenied(t *testing.T, repo, lineage string, resultArgs []string) {
+	t.Helper()
+	before := cliReviewAuthoritySnapshot(t, repo)
+	args := []string{"finalize", "--contract", ReviewIntegrationContractV1, "--cwd", repo}
+	if lineage != "" {
+		args = append(args, "--lineage", lineage)
+	}
+	args = append(args, resultArgs...)
+	var output bytes.Buffer
+	if err := RunReview(args, &output); err == nil {
+		t.Fatalf("stale FINALIZE succeeded: %s", output.String())
+	}
+	failure := decodeReviewIntegrationFailure(t, output.Bytes())
+	if failure.Operation != ReviewIntegrationOperationFinalize || failure.Phase != "preflight" ||
+		failure.MutationOutcome != ReviewMutationNotStarted || !failure.RetrySafe || lineage != "" && failure.LineageID != lineage {
+		t.Fatalf("stale FINALIZE failure = %#v", failure)
+	}
+	if after := cliReviewAuthoritySnapshot(t, repo); !reflect.DeepEqual(after, before) {
+		t.Fatalf("stale FINALIZE mutated durable authority: before=%v after=%v", before, after)
+	}
+}
 
 func TestNegotiatedReviewFinalizeRejectsReviewerPreflightWithoutAuthorityMutation(t *testing.T) {
 	tests := []struct {

--- a/internal/reviewtransaction/snapshot.go
+++ b/internal/reviewtransaction/snapshot.go
@@ -258,6 +258,33 @@ func (builder SnapshotBuilder) ValidateEvidence(ctx context.Context, snapshot Sn
 	return nil
 }
 
+// ValidateLiveSnapshot proves that a frozen snapshot still describes its exact live target.
+func (builder SnapshotBuilder) ValidateLiveSnapshot(ctx context.Context, expected Snapshot) error {
+	if err := builder.ValidateEvidence(ctx, expected); err != nil {
+		return fmt.Errorf("validate frozen snapshot Git evidence: %w", err)
+	}
+	target := Target{
+		Kind: expected.Kind, Projection: expected.Projection,
+		IntendedUntracked: append([]string{}, expected.IntendedUntracked...),
+		LedgerIDs:         append([]string(nil), expected.LedgerIDs...),
+	}
+	switch expected.Kind {
+	case TargetCurrentChanges:
+	case TargetBaseDiff, TargetBaseWorkspaceOverlay, TargetFixDiff:
+		target.BaseRef = expected.BaseTree
+	default:
+		return fmt.Errorf("unsupported live snapshot target kind %q", expected.Kind)
+	}
+	live, err := builder.Build(ctx, target)
+	if err != nil {
+		return fmt.Errorf("rebuild live snapshot target: %w", err)
+	}
+	if live.UnbornHead != expected.UnbornHead || !snapshotsEqual(live, expected) {
+		return fmt.Errorf("live repository snapshot no longer matches frozen target: expected %s, got %s", expected.Identity, live.Identity)
+	}
+	return nil
+}
+
 func (builder SnapshotBuilder) CandidateLocationSupportsCausality(ctx context.Context, snapshot Snapshot, location string, causality CausalDisposition) (bool, error) {
 	if err := builder.ValidateEvidence(ctx, snapshot); err != nil {
 		return false, err


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1379

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)

## 📝 Summary

Binds every new standalone FINALIZE operation to the exact live Git snapshot frozen by START. Stale explicit and implicit lineage selection now fails during preflight before any durable write, while deterministic pending-journal and terminal receipt-publication replay remains available after later workspace drift.

This block is 430 changed lines because the acceptance matrix must cover stale explicit/implicit selection, Git evidence failures, zero-transition routing, correction retry, and both replay exemptions together. Splitting those tests from the behavior would make neither review slice independently safe, so this PR requests `size:exception`.

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/cli/review_facade.go` | Validate the live frozen snapshot before every new FINALIZE transition, including the zero-transition path |
| `internal/reviewtransaction/snapshot.go` | Expose exact current-snapshot comparison used by FINALIZE preflight |
| `internal/cli/review_facade_test.go` | Cover explicit and implicit stale selection plus replay boundaries |
| `internal/cli/review_finalize_preflight_test.go` | Cover Git evidence failures, correction retry drift, and no-write guarantees |

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./... -count=1
```

**Go Format**
```bash
go run ./internal/gofmtcheck
```

**Focused Race Tests**
```bash
go test -race ./internal/cli ./internal/reviewtransaction
```

**Contract and Cross-Build Checks**
```bash
./scripts/check-review-contracts.sh
./scripts/check-review-capabilities.sh
GOOS=linux GOARCH=amd64 go build ./cmd/gentle-ai
GOOS=linux GOARCH=arm64 go build ./cmd/gentle-ai
GOOS=darwin GOARCH=amd64 go build ./cmd/gentle-ai
GOOS=darwin GOARCH=arm64 go build ./cmd/gentle-ai
GOOS=windows GOARCH=amd64 go build ./cmd/gentle-ai
```

- [x] Unit tests pass (`go test ./... -count=1`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [x] Focused race tests pass
- [x] Contract/capability checks and five cross-builds pass
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — local container runtime unavailable; required CI will execute them

## 🔍 Independent Review

- Reliability review found one stale zero-transition bypass.
- One bounded correction moved live validation before the early success return and added explicit/implicit regressions.
- The same reviewer revalidated the correction: PASS.
- Final candidate: `b47835c5604730b1ed3b6f7ab1ee7ecfa5ac1a07`
- Final tree: `9384fa77d94dfd23f18f691ffaecc966100f9691`
- Full diff SHA-256: `3d66709b523468c1a1e5687e4a68d2accf841c32fb154175c7aea7daad129403`

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] Maintainer-applied `size:exception` is requested with rationale above
- [x] I have added exactly one appropriate `type:*` label
- [x] Unit tests pass (`go test ./... -count=1`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — delegated to required CI because no local runtime exists
- [x] Documentation is not required for this internal correctness fix
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Finalize now validates that the live repository matches the expected snapshot before making changes.
  - Improved selection of the correct finalize target when multiple review states exist.
  - Finalize retries and pending operations now handle worktree changes more reliably.

- **Bug Fixes**
  - Prevented finalization against stale or ambiguous repository states.
  - Improved recovery after interrupted finalize operations.
  - Ensured failed preflight checks do not modify review state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->