### PR TITLE
fix(review): harden Git authority-root resolution

### DIFF
--- a/internal/reviewtransaction/frozen_candidate_context.go
+++ b/internal/reviewtransaction/frozen_candidate_context.go
@@ -236,7 +236,7 @@ func frozenRepositoryPathManifest(ctx context.Context, repo string, isolation []
 }
 
 func isolatedImmutableTreeGit(ctx context.Context, repo string) ([]string, func(), error) {
-	commonOutput, err := runGit(ctx, repo, nil, nil, "rev-parse", "--path-format=absolute", "--git-common-dir")
+	commonDir, err := resolveGitDirectory(ctx, repo, "--git-common-dir")
 	if err != nil {
 		return nil, func() {}, err
 	}
@@ -274,7 +274,6 @@ func isolatedImmutableTreeGit(ctx context.Context, repo string) ([]string, func(
 		cleanup()
 		return nil, func() {}, err
 	}
-	commonDir := strings.TrimSpace(string(commonOutput))
 	return []string{
 		"GIT_DIR=" + gitDir,
 		"GIT_OBJECT_DIRECTORY=" + filepath.Join(commonDir, "objects"),

--- a/internal/reviewtransaction/git_authority_path_test.go
+++ b/internal/reviewtransaction/git_authority_path_test.go
@@ -1,0 +1,201 @@
+package reviewtransaction
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCanonicalGitDirectoryRejectsMalformedRecords(t *testing.T) {
+	repo := t.TempDir()
+	gitDir := filepath.Join(repo, ".git")
+	if err := os.Mkdir(gitDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	outside := t.TempDir()
+
+	tests := []struct {
+		name    string
+		output  []byte
+		want    string
+		wantErr bool
+	}{
+		{name: "relative directory", output: []byte(".git\n"), want: gitDir},
+		{name: "absolute linked worktree common directory", output: []byte(outside + "\n"), want: outside},
+		{name: "unsupported option echo", output: []byte("--path-format=absolute\n"), wantErr: true},
+		{name: "option echo plus path", output: []byte("--path-format=absolute\n.git\n"), wantErr: true},
+		{name: "multiple paths", output: []byte(".git\nother\n"), wantErr: true},
+		{name: "empty", output: []byte("\n"), wantErr: true},
+		{name: "nul", output: []byte(".git\x00outside\n"), wantErr: true},
+		{name: "relative escape", output: []byte("../" + filepath.Base(outside) + "\n"), wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := canonicalGitDirectory(repo, tt.output)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("canonicalGitDirectory() = %q, want error", got)
+				}
+				return
+			}
+			if err != nil || got != filepath.Clean(tt.want) {
+				t.Fatalf("canonicalGitDirectory() = %q, %v; want %q", got, err, filepath.Clean(tt.want))
+			}
+		})
+	}
+}
+
+func TestGitAuthorityResolversDoNotUsePathFormatAbsolute(t *testing.T) {
+	requireSnapshotGit(t)
+	repo := initSnapshotRepo(t)
+	original := gitCommandContext
+	var forbidden [][]string
+	gitCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		for _, arg := range args {
+			if arg == "--path-format=absolute" {
+				forbidden = append(forbidden, append([]string(nil), args...))
+				break
+			}
+		}
+		return original(ctx, name, args...)
+	}
+	t.Cleanup(func() { gitCommandContext = original })
+
+	if _, _, err := reviewAuthorityRoot(context.Background(), repo); err != nil {
+		t.Fatal(err)
+	}
+	isolation, cleanup, err := isolatedImmutableTreeGit(context.Background(), repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(isolation) == 0 {
+		t.Fatal("isolatedImmutableTreeGit() returned no environment")
+	}
+	cleanup()
+	if _, err := reviewRepositoryIdentity(context.Background(), repo); err != nil {
+		t.Fatal(err)
+	}
+	if len(forbidden) != 0 {
+		t.Fatalf("runtime Git authority resolution used --path-format=absolute: %v", forbidden)
+	}
+}
+
+func TestReviewAuthorityRootRejectsLegacyOptionEchoWithoutMutation(t *testing.T) {
+	requireSnapshotGit(t)
+	repo := initSnapshotRepo(t)
+	original := gitCommandContext
+	t.Setenv("GENTLE_AI_TEST_GIT_PATH_OUTPUT", base64.StdEncoding.EncodeToString([]byte("--path-format=absolute\n.git\n")))
+	gitCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		if slicesContain(args, "--git-common-dir") {
+			return exec.CommandContext(ctx, os.Args[0], "-test.run=^TestGitAuthorityPathHelperProcess$")
+		}
+		return original(ctx, name, args...)
+	}
+	t.Cleanup(func() { gitCommandContext = original })
+
+	if _, _, err := reviewAuthorityRoot(context.Background(), repo); err == nil {
+		t.Fatal("reviewAuthorityRoot() accepted legacy option echo")
+	}
+	for _, path := range []string{
+		filepath.Join(repo, "--path-format=absolute\n.git"),
+		filepath.Join(repo, "gentle-ai"),
+	} {
+		if _, err := os.Lstat(path); !os.IsNotExist(err) {
+			t.Fatalf("malformed Git output created %q", path)
+		}
+	}
+}
+
+func TestResolveRepositoryRootRejectsUnrelatedAbsoluteOutput(t *testing.T) {
+	requireSnapshotGit(t)
+	repo := initSnapshotRepo(t)
+	outside := t.TempDir()
+	original := gitCommandContext
+	t.Setenv("GENTLE_AI_TEST_GIT_PATH_OUTPUT", base64.StdEncoding.EncodeToString([]byte(outside+"\n")))
+	gitCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		if slicesContain(args, "--show-toplevel") {
+			return exec.CommandContext(ctx, os.Args[0], "-test.run=^TestGitAuthorityPathHelperProcess$")
+		}
+		return original(ctx, name, args...)
+	}
+	t.Cleanup(func() { gitCommandContext = original })
+
+	if root, err := (SnapshotBuilder{Repo: repo}).ResolveRepositoryRoot(context.Background()); err == nil {
+		t.Fatalf("ResolveRepositoryRoot() = %q, want unrelated-root error", root)
+	}
+}
+
+func TestReviewAuthorityRootPreservesSymlinkedGitDirectory(t *testing.T) {
+	requireSnapshotGit(t)
+	repo := initSnapshotRepo(t)
+	externalGitDir := filepath.Join(t.TempDir(), "git-dir")
+	if err := os.Rename(filepath.Join(repo, ".git"), externalGitDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(externalGitDir, filepath.Join(repo, ".git")); err != nil {
+		t.Skipf("symlinked Git directories are unavailable: %v", err)
+	}
+
+	root, resolvedRepo, err := reviewAuthorityRoot(context.Background(), repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(externalGitDir, "gentle-ai", "review-transactions")
+	if root != want || resolvedRepo != repo {
+		t.Fatalf("reviewAuthorityRoot() = %q, %q; want %q, %q", root, resolvedRepo, want, repo)
+	}
+}
+
+func TestReviewRepositoryIdentityPreservesGitCommandError(t *testing.T) {
+	requireSnapshotGit(t)
+	repo := initSnapshotRepo(t)
+	original := gitCommandContext
+	showTopLevelCalls := 0
+	t.Setenv("GENTLE_AI_TEST_GIT_PATH_FAIL", "1")
+	gitCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		if slicesContain(args, "--show-toplevel") {
+			showTopLevelCalls++
+			if showTopLevelCalls == 2 {
+				return exec.CommandContext(ctx, os.Args[0], "-test.run=^TestGitAuthorityPathHelperProcess$")
+			}
+		}
+		return original(ctx, name, args...)
+	}
+	t.Cleanup(func() { gitCommandContext = original })
+
+	_, err := reviewRepositoryIdentity(context.Background(), repo)
+	var commandErr *GitCommandError
+	if !errors.As(err, &commandErr) {
+		t.Fatalf("reviewRepositoryIdentity() error = %T %v, want *GitCommandError", err, err)
+	}
+}
+
+func TestGitAuthorityPathHelperProcess(t *testing.T) {
+	if os.Getenv("GENTLE_AI_TEST_GIT_PATH_FAIL") == "1" {
+		os.Exit(23)
+	}
+	encoded := os.Getenv("GENTLE_AI_TEST_GIT_PATH_OUTPUT")
+	if encoded == "" {
+		return
+	}
+	payload, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		os.Exit(2)
+	}
+	_, _ = os.Stdout.Write(payload)
+	os.Exit(0)
+}
+
+func slicesContain(values []string, target string) bool {
+	for _, value := range values {
+		if strings.EqualFold(value, target) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/reviewtransaction/repository_locator.go
+++ b/internal/reviewtransaction/repository_locator.go
@@ -381,27 +381,18 @@ func reviewRepositoryIdentity(ctx context.Context, repo string) (reviewRepositor
 	if err != nil {
 		return reviewRepositoryIdentityRecord{}, err
 	}
-	topPayload, err := runGit(ctx, root, nil, nil, "rev-parse", "--path-format=absolute", "--show-toplevel")
+	top, err := resolveGitDirectory(ctx, root, "--show-toplevel")
 	if err != nil {
 		return reviewRepositoryIdentityRecord{}, err
 	}
-	top, err := canonicalLocatorDirectory(strings.TrimSpace(string(topPayload)))
-	if err != nil || !sameLocatorDirectory(root, top) {
+	if !sameLocatorDirectory(root, top) {
 		return reviewRepositoryIdentityRecord{}, errors.New("repository root identity changed")
 	}
-	commonPayload, err := runGit(ctx, root, nil, nil, "rev-parse", "--path-format=absolute", "--git-common-dir")
+	commonDir, err := resolveGitDirectory(ctx, root, "--git-common-dir")
 	if err != nil {
 		return reviewRepositoryIdentityRecord{}, err
 	}
-	commonDir, err := canonicalLocatorDirectory(strings.TrimSpace(string(commonPayload)))
-	if err != nil {
-		return reviewRepositoryIdentityRecord{}, err
-	}
-	gitPayload, err := runGit(ctx, root, nil, nil, "rev-parse", "--path-format=absolute", "--git-dir")
-	if err != nil {
-		return reviewRepositoryIdentityRecord{}, err
-	}
-	gitDir, err := canonicalLocatorDirectory(strings.TrimSpace(string(gitPayload)))
+	gitDir, err := resolveGitDirectory(ctx, root, "--git-dir")
 	if err != nil {
 		return reviewRepositoryIdentityRecord{}, err
 	}

--- a/internal/reviewtransaction/snapshot.go
+++ b/internal/reviewtransaction/snapshot.go
@@ -519,13 +519,13 @@ func (builder SnapshotBuilder) ResolveRepositoryRoot(ctx context.Context) (strin
 	if err != nil {
 		return "", err
 	}
-	output, err := runGit(ctx, abs, nil, nil, "rev-parse", "--show-toplevel")
+	root, err := resolveGitDirectory(ctx, abs, "--show-toplevel")
 	if err != nil {
 		return "", err
 	}
-	root, err := canonicalRepositoryPath(strings.TrimSpace(string(output)))
-	if err != nil {
-		return "", err
+	relative, err := filepath.Rel(root, abs)
+	if err != nil || relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) || filepath.IsAbs(relative) {
+		return "", errors.New("resolved repository root does not contain the requested path")
 	}
 	return root, nil
 }
@@ -575,6 +575,57 @@ func canonicalRepositoryPath(path string) (string, error) {
 		return "", err
 	}
 	return filepath.Clean(resolved), nil
+}
+
+func resolveGitDirectory(ctx context.Context, repo, selector string) (string, error) {
+	switch selector {
+	case "--show-toplevel", "--git-common-dir", "--git-dir":
+	default:
+		return "", fmt.Errorf("unsupported Git directory selector %q", selector)
+	}
+	output, err := runGit(ctx, repo, nil, nil, "rev-parse", selector)
+	if err != nil {
+		return "", err
+	}
+	return canonicalGitDirectory(repo, output)
+}
+
+func canonicalGitDirectory(repo string, output []byte) (string, error) {
+	if len(output) == 0 || bytes.IndexByte(output, 0) >= 0 {
+		return "", errors.New("Git directory output is empty or contains NUL")
+	}
+	record := output
+	if record[len(record)-1] == '\n' {
+		record = record[:len(record)-1]
+		if len(record) > 0 && record[len(record)-1] == '\r' {
+			record = record[:len(record)-1]
+		}
+	}
+	if len(record) == 0 || bytes.ContainsAny(record, "\r\n") || strings.TrimSpace(string(record)) == "" || bytes.HasPrefix(record, []byte("--")) {
+		return "", errors.New("Git directory output is not exactly one valid path record")
+	}
+	root, err := canonicalRepositoryPath(repo)
+	if err != nil {
+		return "", err
+	}
+	directory := string(record)
+	relative := !filepath.IsAbs(directory)
+	if relative {
+		directory = filepath.Join(root, directory)
+		rel, relErr := filepath.Rel(root, directory)
+		if relErr != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
+			return "", errors.New("relative Git directory escapes the repository root")
+		}
+	}
+	directory, err = canonicalRepositoryPath(directory)
+	if err != nil {
+		return "", err
+	}
+	info, err := os.Stat(directory)
+	if err != nil || !info.IsDir() {
+		return "", errors.New("Git directory output is not a directory")
+	}
+	return filepath.Clean(directory), nil
 }
 
 func readSnapshotIndex(path string) ([]byte, time.Time, error) {

--- a/internal/reviewtransaction/store.go
+++ b/internal/reviewtransaction/store.go
@@ -152,25 +152,9 @@ func reviewAuthorityRoot(ctx context.Context, repo string) (string, string, erro
 	if err != nil {
 		return "", "", fmt.Errorf("resolve authoritative review repository: %w", err)
 	}
-	output, err := runGit(ctx, root, nil, nil, "rev-parse", "--path-format=absolute", "--git-common-dir")
+	commonDir, err := resolveGitDirectory(ctx, root, "--git-common-dir")
 	if err != nil {
 		return "", "", fmt.Errorf("resolve repository Git common directory: %w", err)
-	}
-	commonDir := strings.TrimSpace(string(output))
-	if !filepath.IsAbs(commonDir) {
-		commonDir = filepath.Join(root, commonDir)
-	}
-	commonDir, err = filepath.Abs(commonDir)
-	if err != nil {
-		return "", "", err
-	}
-	commonDir, err = filepath.EvalSymlinks(commonDir)
-	if err != nil {
-		return "", "", fmt.Errorf("resolve repository Git common directory symlinks: %w", err)
-	}
-	info, err := os.Stat(commonDir)
-	if err != nil || !info.IsDir() {
-		return "", "", errors.New("repository Git common directory is not a directory")
 	}
 	authorityRoot := filepath.Join(filepath.Clean(commonDir), "gentle-ai", "review-transactions")
 	return authorityRoot, root, nil


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1261

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)

## 📝 Summary

Makes Git authority-root discovery independent of `git rev-parse --path-format=absolute`, which older Git versions can echo into stdout as a fake path. Runtime root resolution now accepts exactly one valid path record and rejects empty, NUL, multiline, option-echo, relative-escape, nonexistent, or unrelated-root output before transaction locks, stores, or artifacts are created.

The implementation preserves ordinary repositories, linked worktrees, symlinked `.git` directories, separate common directories, and typed Git/cancellation failures.

## 📂 Changes

| Area | What Changed |
|------|-------------|
| Git directory resolution | Centralized strict single-record parsing and canonical path validation |
| Authority/store callers | Removed every runtime use of `--path-format=absolute` and reused the strict resolver |
| Repository identity checks | Preserve typed Git and timeout errors before identity comparison |
| Regression tests | Cover legacy option echo, zero-mutation rejection, linked worktrees, external physical `.git` symlinks, and typed failures |

## 🧪 Test Plan

- [x] Focused RED→GREEN regressions pass
- [x] `go test -race ./internal/reviewtransaction -count=1`
- [x] `go test ./... -count=1`
- [x] `go run ./internal/gofmtcheck`
- [x] `go vet ./...`
- [x] `go mod tidy -diff`
- [x] Review contract and capability checks pass
- [x] Linux amd64, macOS arm64, and Windows amd64 cross-builds pass
- [ ] Local container E2E — Docker/Podman unavailable; required CI executes the E2E matrix

## 🔍 Independent Review

Full integrity, resilience, reliability, and readability review found two corroborated regressions: valid external physical `.git` symlinks were rejected and typed Git failures were masked. One bounded correction fixed both, and the scoped validator returned PASS.

- Candidate: `2abbd88189c435a57c8e701debc339a4200a1242`
- Tree: `475fcfbdc4305eab2928092a244ea79a858ade1a`
- Diff SHA-256: `8d82108dfc445a2228d97c5bb5145b72cb540e5eb5cea8b8484e4a90067c3812`
- Correction: 64/126 allowed lines
- A distinct pre-existing absolute common-directory binding gap was routed to #1705 and does not expand this PR.

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [x] Exactly one `type:*` label is applied
- [x] Unit, race, format, vet, module, contract, and cross-build checks pass
- [ ] E2E tests pass — delegated to required CI because no local container runtime exists
- [x] Documentation is not required for this internal compatibility fix
- [x] Commits follow Conventional Commits format
- [x] Commits contain no `Co-Authored-By` trailers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Git repository path detection and validation for review transactions.
  - Rejects malformed, ambiguous, or unsafe repository paths, including traversal attempts.
  - Preserves correct behavior for repositories using symlinked Git directories.
  - Prevents unrelated or invalid Git command output from being treated as repository information.
  - Maintains original Git command errors, making failures more accurate and actionable.

- **Tests**
  - Added coverage for repository path validation, symlink handling, traversal protection, and Git command failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->