### PR TITLE
feat(sdd): close delegated agent reports with Key Learnings for engram passive capture

### DIFF
--- a/internal/assets/claude/sdd-orchestrator-workflow.md
+++ b/internal/assets/claude/sdd-orchestrator-workflow.md
@@ -249,6 +249,8 @@ Pre-flight before every SDD/Judgment-Day Agent call:
 
 Resolve skills once per session, cache the registry, and pass exact `SKILL.md` paths. If a delegated result reports `skill_resolution` as `fallback-registry`, `fallback-path`, or `none`, re-read the registry before subsequent delegations.
 
+**Key Learnings closing (generic delegations):** When delegating to generic agents (Explore, general-purpose), instruct the sub-agent to close its final message with a `## Key Learnings` section containing 1–5 numbered items, each ≥4 words and ≥20 characters. This enables engram passive capture of learnings across delegation boundaries. SDD phase agents load this requirement from `~/.claude/skills/_shared/sdd-phase-common.md` section F automatically.
+
 ### Context Protocol
 
 Sub-agents start with fresh context. The orchestrator controls what context they receive.

--- a/internal/assets/claude/sdd-orchestrator-workflow.md
+++ b/internal/assets/claude/sdd-orchestrator-workflow.md
@@ -249,7 +249,7 @@ Pre-flight before every SDD/Judgment-Day Agent call:
 
 Resolve skills once per session, cache the registry, and pass exact `SKILL.md` paths. If a delegated result reports `skill_resolution` as `fallback-registry`, `fallback-path`, or `none`, re-read the registry before subsequent delegations.
 
-**Key Learnings closing (generic delegations):** When delegating to generic agents (Explore, general-purpose), instruct the sub-agent to close its final message with a `## Key Learnings` section containing 1–5 numbered items, each ≥4 words and ≥20 characters. This enables engram passive capture of learnings across delegation boundaries. SDD phase agents load this requirement from `~/.claude/skills/_shared/sdd-phase-common.md` section F automatically.
+**Key Learnings closing (generic delegations):** When delegating to generic agents (Explore, general-purpose), instruct the sub-agent to close its final message with a `## Key Learnings` section containing 1–5 numbered items, each a standalone factual sentence of ≥4 words and ≥20 characters. This enables engram passive capture of learnings across delegation boundaries. SDD phase agents load this requirement from `~/.claude/skills/_shared/sdd-phase-common.md` section F automatically.
 
 ### Context Protocol
 

--- a/internal/assets/skills/_shared/sdd-phase-common.md
+++ b/internal/assets/skills/_shared/sdd-phase-common.md
@@ -119,6 +119,7 @@ Close your **final report message** (the return envelope) with a `## Key Learnin
 **Format**: numbered list with 1–5 items. Each item is a standalone factual sentence that is ≥20 characters and ≥4 words.
 
 **Example**:
+
 ```markdown
 ## Key Learnings
 

--- a/internal/assets/skills/_shared/sdd-phase-common.md
+++ b/internal/assets/skills/_shared/sdd-phase-common.md
@@ -111,3 +111,20 @@ SDD must protect reviewer cognitive load, not only generate tasks.
 - In a Feature Branch Chain, PR #1 targets the feature/tracker branch and later child PRs target the immediate previous PR branch; if GitHub shows previous slices in a child diff, retarget/rebase until the diff is clean.
 
 This guard exists to reduce reviewer burnout and keep implementation delivery safe. Do not treat it as optional process noise.
+
+## F. Key Learnings Closing
+
+Close your **final report message** (the return envelope) with a `## Key Learnings` section to enable engram passive capture.
+
+**Format**: numbered list with 1–5 items. Each item is a standalone factual sentence that is ≥20 characters and ≥4 words.
+
+**Example**:
+```markdown
+## Key Learnings
+
+1. Async validation in the apply phase caught a race condition in concurrent writes.
+2. Golden test regeneration for system prompts requires the `-update` flag before re-run.
+3. Bounded review contracts must stay consistent across `sdd-phase-common.md` and `engram/protocol.md`.
+```
+
+This applies to your final text response to the orchestrator, not intermediate tool outputs or artifact content. Engram will automatically extract and persist these learnings.

--- a/internal/components/sdd/key_learnings_contract_test.go
+++ b/internal/components/sdd/key_learnings_contract_test.go
@@ -30,6 +30,7 @@ func TestKeyLearningsClosingRequiredForGenericDelegations(t *testing.T) {
 		"generic agents (Explore, general-purpose)",
 		"close its final message with a `## Key Learnings` section",
 		"1–5 numbered items",
+		"standalone factual sentence",
 		"≥4 words and ≥20 characters",
 		"enables engram passive capture",
 	} {
@@ -39,27 +40,66 @@ func TestKeyLearningsClosingRequiredForGenericDelegations(t *testing.T) {
 	}
 }
 
+// keyLearningsSection extracts the "## F. Key Learnings Closing" section of
+// sdd-phase-common.md (from its header to the next same-level header or EOF).
+func keyLearningsSection(t *testing.T, content string) string {
+	t.Helper()
+	const header = "## F. Key Learnings Closing"
+	start := strings.Index(content, header)
+	if start < 0 {
+		t.Fatalf("sdd-phase-common.md missing section %q", header)
+	}
+	section := content[start:]
+	// Stop at the next lettered section header (e.g. "## G. ..."); a plain
+	// "\n## " boundary would truncate at the `## Key Learnings` line inside
+	// the fenced example.
+	if loc := regexp.MustCompile(`\n## [A-Z]\. `).FindStringIndex(section[len(header):]); loc != nil {
+		section = section[:len(header)+loc[0]]
+	}
+	return section
+}
+
+// passiveCaptureSection extracts the marked passive-capture block of
+// engram/protocol.md.
+func passiveCaptureSection(t *testing.T, content string) string {
+	t.Helper()
+	const open, close = "<!-- section:passive-capture -->", "<!-- /section:passive-capture -->"
+	start := strings.Index(content, open)
+	end := strings.Index(content, close)
+	if start < 0 || end < 0 || end <= start {
+		t.Fatalf("engram/protocol.md missing marked passive-capture section")
+	}
+	return content[start:end]
+}
+
 func TestKeyLearningsContractConsistencyWithEngramProtocol(t *testing.T) {
-	sddCommon := assets.MustRead("skills/_shared/sdd-phase-common.md")
-	engramProtocol := assets.MustRead("engram/protocol.md")
+	sddSection := keyLearningsSection(t, assets.MustRead("skills/_shared/sdd-phase-common.md"))
+	engramSection := passiveCaptureSection(t, assets.MustRead("engram/protocol.md"))
 
-	// Both must use the exact header token "## Key Learnings"
-	if !strings.Contains(sddCommon, "## Key Learnings") {
-		t.Errorf("sdd-phase-common.md does not use header token '## Key Learnings'")
+	// Both contract blocks must use the same header token; the engram
+	// extractor treats the trailing colon as optional.
+	headerToken := regexp.MustCompile("## Key Learnings:?")
+	if !headerToken.MatchString(sddSection) {
+		t.Errorf("sdd-phase-common.md Key Learnings section does not use header token '## Key Learnings'")
 	}
-	if !strings.Contains(engramProtocol, "## Key Learnings:") && !strings.Contains(engramProtocol, "## Key Learnings") {
-		t.Errorf("engram/protocol.md does not contain 'Key Learnings' header variant")
+	if !headerToken.MatchString(engramSection) {
+		t.Errorf("engram/protocol.md passive-capture section does not use header token '## Key Learnings'")
 	}
 
-	// sdd-phase-common.md must document the minimum length/word requirement for items
+	// The SDD contract block must document the minimum length/word rules.
 	hasLengthRule := regexp.MustCompile(`(?i)(\d+\s+character|\d+\s+word)`)
-	if !hasLengthRule.MatchString(sddCommon) {
-		t.Errorf("sdd-phase-common.md missing minimum-length rules for items")
+	if !hasLengthRule.MatchString(sddSection) {
+		t.Errorf("sdd-phase-common.md Key Learnings section missing minimum-length rules for items")
 	}
 
-	// engram/protocol.md section must describe passive capture with examples
-	if !strings.Contains(engramProtocol, "PASSIVE CAPTURE") && !strings.Contains(engramProtocol, "passive-capture") {
-		t.Errorf("engram/protocol.md missing passive-capture section")
+	// Both contract blocks must describe automatic extraction by engram.
+	for name, section := range map[string]string{
+		"sdd-phase-common.md": sddSection,
+		"engram/protocol.md":  engramSection,
+	} {
+		if !strings.Contains(section, "automatically extract") {
+			t.Errorf("%s contract block missing automatic-extraction wording", name)
+		}
 	}
 }
 

--- a/internal/components/sdd/key_learnings_contract_test.go
+++ b/internal/components/sdd/key_learnings_contract_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/gentleman-programming/gentle-ai/internal/assets"
+	"github.com/gentleman-programming/gentle-ai/internal/components/filemerge"
 )
 
 func TestKeyLearningsClosingContractExistsInSddPhaseCommon(t *testing.T) {
@@ -41,7 +42,8 @@ func TestKeyLearningsClosingRequiredForGenericDelegations(t *testing.T) {
 }
 
 // keyLearningsSection extracts the "## F. Key Learnings Closing" section of
-// sdd-phase-common.md (from its header to the next same-level header or EOF).
+// sdd-phase-common.md (from its header to the next lettered section header,
+// e.g. "## G. ...", or EOF).
 func keyLearningsSection(t *testing.T, content string) string {
 	t.Helper()
 	const header = "## F. Key Learnings Closing"
@@ -59,20 +61,20 @@ func keyLearningsSection(t *testing.T, content string) string {
 	return section
 }
 
-// passiveCaptureSection extracts the marked passive-capture block of
-// engram/protocol.md.
+// passiveCaptureSection extracts the passive-capture section body of
+// engram/protocol.md using the same extractor as production. The extractor
+// silently returns the full content when markers are missing or malformed,
+// so assert that a real extraction happened.
 func passiveCaptureSection(t *testing.T, content string) string {
 	t.Helper()
-	const open, close = "<!-- section:passive-capture -->", "<!-- /section:passive-capture -->"
-	start := strings.Index(content, open)
-	end := strings.Index(content, close)
-	if start < 0 || end < 0 || end <= start {
-		t.Fatalf("engram/protocol.md missing marked passive-capture section")
+	section := filemerge.ExtractHTMLCommentSection(content, "passive-capture")
+	if section == content {
+		t.Fatalf("engram/protocol.md missing or malformed passive-capture section markers")
 	}
-	return content[start:end]
+	return section
 }
 
-func TestKeyLearningsContractConsistencyWithEngramProtocol(t *testing.T) {
+func TestKeyLearningsHeaderAndWordingConsistencyWithEngramProtocol(t *testing.T) {
 	sddSection := keyLearningsSection(t, assets.MustRead("skills/_shared/sdd-phase-common.md"))
 	engramSection := passiveCaptureSection(t, assets.MustRead("engram/protocol.md"))
 

--- a/internal/components/sdd/key_learnings_contract_test.go
+++ b/internal/components/sdd/key_learnings_contract_test.go
@@ -1,0 +1,82 @@
+package sdd
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/internal/assets"
+)
+
+func TestKeyLearningsClosingContractExistsInSddPhaseCommon(t *testing.T) {
+	content := assets.MustRead("skills/_shared/sdd-phase-common.md")
+	for _, clause := range []string{
+		"## F. Key Learnings Closing",
+		"## Key Learnings",
+		"1–5 items",
+		"standalone factual sentence",
+		"≥20 characters and ≥4 words",
+	} {
+		if !strings.Contains(content, clause) {
+			t.Errorf("sdd-phase-common.md missing required clause %q", clause)
+		}
+	}
+}
+
+func TestKeyLearningsClosingRequiredForGenericDelegations(t *testing.T) {
+	content := assets.MustRead("claude/sdd-orchestrator-workflow.md")
+	for _, clause := range []string{
+		"Key Learnings closing (generic delegations)",
+		"generic agents (Explore, general-purpose)",
+		"close its final message with a `## Key Learnings` section",
+		"1–5 numbered items",
+		"≥4 words and ≥20 characters",
+		"enables engram passive capture",
+	} {
+		if !strings.Contains(content, clause) {
+			t.Errorf("sdd-orchestrator-workflow.md missing required clause %q", clause)
+		}
+	}
+}
+
+func TestKeyLearningsContractConsistencyWithEngramProtocol(t *testing.T) {
+	sddCommon := assets.MustRead("skills/_shared/sdd-phase-common.md")
+	engramProtocol := assets.MustRead("engram/protocol.md")
+
+	// Both must use the exact header token "## Key Learnings"
+	if !strings.Contains(sddCommon, "## Key Learnings") {
+		t.Errorf("sdd-phase-common.md does not use header token '## Key Learnings'")
+	}
+	if !strings.Contains(engramProtocol, "## Key Learnings:") && !strings.Contains(engramProtocol, "## Key Learnings") {
+		t.Errorf("engram/protocol.md does not contain 'Key Learnings' header variant")
+	}
+
+	// sdd-phase-common.md must document the minimum length/word requirement for items
+	hasLengthRule := regexp.MustCompile(`(?i)(\d+\s+character|\d+\s+word)`)
+	if !hasLengthRule.MatchString(sddCommon) {
+		t.Errorf("sdd-phase-common.md missing minimum-length rules for items")
+	}
+
+	// engram/protocol.md section must describe passive capture with examples
+	if !strings.Contains(engramProtocol, "PASSIVE CAPTURE") && !strings.Contains(engramProtocol, "passive-capture") {
+		t.Errorf("engram/protocol.md missing passive-capture section")
+	}
+}
+
+func TestKeyLearningsReferenceIsConsistentAcrossAssets(t *testing.T) {
+	sddCommon := assets.MustRead("skills/_shared/sdd-phase-common.md")
+	orchestratorWorkflow := assets.MustRead("claude/sdd-orchestrator-workflow.md")
+
+	// Orchestrator workflow should reference that phase agents load from sdd-phase-common.md
+	if !strings.Contains(orchestratorWorkflow, "sdd-phase-common.md") {
+		t.Errorf("sdd-orchestrator-workflow.md does not cross-reference sdd-phase-common.md for Key Learnings")
+	}
+
+	// Both should agree on the header token
+	if !strings.Contains(sddCommon, "## Key Learnings") {
+		t.Errorf("sdd-phase-common.md Key Learnings header mismatch")
+	}
+	if !strings.Contains(orchestratorWorkflow, "## Key Learnings") {
+		t.Errorf("sdd-orchestrator-workflow.md Key Learnings header mismatch")
+	}
+}

--- a/internal/components/sdd/key_learnings_contract_test.go
+++ b/internal/components/sdd/key_learnings_contract_test.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/gentleman-programming/gentle-ai/internal/assets"
-	"github.com/gentleman-programming/gentle-ai/internal/components/filemerge"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/assets"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/components/filemerge"
 )
 
 func TestKeyLearningsClosingContractExistsInSddPhaseCommon(t *testing.T) {


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1703

---

## 🏷️ PR Type

- [x] `type:feature` — New feature (non-breaking change that adds functionality)

---

## 📝 Summary

Engram's passive subagent capture only persists content that closes with a `## Key Learnings` header plus numbered/bulleted items (each ≥20 chars, ≥4 words); anything else is silently dropped (`{"extracted":0,"saved":0}`). gentle-ai already ships that contract for the main thread in `internal/assets/engram/protocol.md`, but the agents it manufactures never receive it, so every subagent completion is a dead capture.

This PR extends the existing contract to delegated agents: SDD phase agents (all harnesses) and generic delegations launched by the Claude orchestrator now close their final report with an engram-extractable `## Key Learnings` section.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/assets/skills/_shared/sdd-phase-common.md` | New section **F. Key Learnings Closing**: phase agents end their final report with `## Key Learnings` + 1–5 numbered items (≥20 chars, ≥4 words each). Single shared file → covers all 10 `sdd-*` agents on every harness via the existing injection path. |
| `internal/assets/claude/sdd-orchestrator-workflow.md` | Sub-Agent Launch Protocol now requires the same closing section in delegation prompts for generic agents (Explore, general-purpose) — the case with zero instruction today. |
| `internal/components/sdd/key_learnings_contract_test.go` | New contract test mirroring `review_ledger_contract_test.go`: asserts the shared asset carries the contract, the orchestrator workflow requires it for generic delegations, and the formulation stays consistent with `engram/protocol.md` (`section:passive-capture`). |

No golden regeneration needed: agents reference `sdd-phase-common.md` by path, not embedded content.

Deliberate v1 exclusions (see issue): `review-*` agents (native `review capture-result` parsing + CAS persistence) and `jd-*` agents (orchestrator synthesizes verdicts).

---

## 🧪 Test Plan

- [x] Unit tests pass (`go test ./...`) — note: `internal/components/communitytool` `TestPiCodeGraphProbeClassifiesStalledMCPResponsesAsDeadlineExceeded` fails identically on a clean `origin/main` checkout in my environment (pre-existing, unrelated; same class as #1645)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — not run locally; deferring to CI
- [x] Manually tested locally — live-validated the extraction contract against engram: a final report without the header returns `extracted:0`; the same content with the header persists 2 observations

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines (101 authored lines)
- [ ] I have added the appropriate `type:*` label to this PR (no triage rights — maintainer: `type:feature`)
- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — deferring to CI
- [x] I have updated documentation if necessary (the asset docs are the change)
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

The wording in section F deliberately mirrors `internal/assets/engram/protocol.md` `section:passive-capture` so the repo keeps a single formulation of the contract; the new test pins that consistency. The engram extractor's header regex accepts the section with or without a trailing colon (`learningHeaderPattern`, optional `:?`).

https://claude.ai/code/session_01HDDC5PAyitDax6mT8M54B9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a standardized **“Key Learnings”** closing requirement for SDD phase completion and generic (non-SDD) delegations.
  * Final agent responses must end with a **`## Key Learnings`** section containing **1–5** numbered, standalone factual statements that follow the documented length/format rules.
  * Ensures alignment across the relevant protocol documents for consistent engram passive-capture behavior.
* **Tests**
  * Added automated checks to verify required headings, wording/constraints, and cross-asset consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->