### PR TITLE
feat(agent): deprecate legacy gemini-cli in favor of antigravity (agy)

### DIFF
--- a/internal/catalog/agents.go
+++ b/internal/catalog/agents.go
@@ -13,7 +13,7 @@ var allAgents = []Agent{
 	{ID: model.AgentClaudeCode, Name: "Claude Code", Tier: model.TierFull, ConfigPath: "~/.claude"},
 	{ID: model.AgentOpenCode, Name: "OpenCode", Tier: model.TierFull, ConfigPath: "~/.config/opencode"},
 	{ID: model.AgentKilocode, Name: "Kilo Code", Tier: model.TierFull, ConfigPath: "~/.config/kilo"},
-	{ID: model.AgentGeminiCLI, Name: "Gemini CLI", Tier: model.TierFull, ConfigPath: "~/.gemini"},
+	{ID: model.AgentGeminiCLI, Name: "Gemini CLI (deprecated -> Antigravity)", Tier: model.TierFull, ConfigPath: "~/.gemini"},
 	{ID: model.AgentCodex, Name: "Codex", Tier: model.TierFull, ConfigPath: "~/.codex"},
 	{ID: model.AgentCursor, Name: "Cursor", Tier: model.TierFull, ConfigPath: "~/.cursor"},
 	{ID: model.AgentVSCodeCopilot, Name: "VS Code Copilot", Tier: model.TierFull, ConfigPath: "~/.copilot"},

--- a/internal/cli/install_test.go
+++ b/internal/cli/install_test.go
@@ -369,7 +369,7 @@ func TestDefaultAgentsFromDetection_AllAgentsMappedCorrectly(t *testing.T) {
 		{"claude-code", model.AgentClaudeCode},
 		{"opencode", model.AgentOpenCode},
 		{"kilocode", model.AgentKilocode},
-		{"gemini-cli", model.AgentGeminiCLI},
+		{"gemini-cli", model.AgentAntigravity},
 		{"cursor", model.AgentCursor},
 		{"vscode-copilot", model.AgentVSCodeCopilot},
 		{"codex", model.AgentCodex},

--- a/internal/cli/validate.go
+++ b/internal/cli/validate.go
@@ -218,7 +218,7 @@ func defaultAgentsFromDetection(detection system.DetectionResult) []model.AgentI
 func asAgentIDs(values []string) []model.AgentID {
 	agents := make([]model.AgentID, 0, len(values))
 	for _, value := range values {
-		agents = append(agents, model.AgentID(value))
+		agents = append(agents, model.NormalizeAgentID(value))
 	}
 
 	return agents

--- a/internal/cli/validate.go
+++ b/internal/cli/validate.go
@@ -166,39 +166,12 @@ func defaultAgentsFromDetection(detection system.DetectionResult) []model.AgentI
 			continue
 		}
 
-		switch strings.TrimSpace(state.Agent) {
-		case string(model.AgentClaudeCode):
-			agents = append(agents, model.AgentClaudeCode)
-		case string(model.AgentOpenCode):
-			agents = append(agents, model.AgentOpenCode)
-		case string(model.AgentKilocode):
-			agents = append(agents, model.AgentKilocode)
-		case string(model.AgentGeminiCLI):
-			agents = append(agents, model.AgentGeminiCLI)
-		case string(model.AgentCursor):
-			agents = append(agents, model.AgentCursor)
-		case string(model.AgentVSCodeCopilot):
-			agents = append(agents, model.AgentVSCodeCopilot)
-		case string(model.AgentCodex):
-			agents = append(agents, model.AgentCodex)
-		case string(model.AgentAntigravity):
-			agents = append(agents, model.AgentAntigravity)
-		case string(model.AgentWindsurf):
-			agents = append(agents, model.AgentWindsurf)
-		case string(model.AgentKimi):
-			agents = append(agents, model.AgentKimi)
-		case string(model.AgentQwenCode):
-			agents = append(agents, model.AgentQwenCode)
-		case string(model.AgentKiroIDE):
-			agents = append(agents, model.AgentKiroIDE)
-		case string(model.AgentOpenClaw):
-			agents = append(agents, model.AgentOpenClaw)
-		case string(model.AgentPi):
-			agents = append(agents, model.AgentPi)
-		case string(model.AgentTrae):
-			agents = append(agents, model.AgentTrae)
-		case string(model.AgentHermes):
-			agents = append(agents, model.AgentHermes)
+		switch normalized := model.NormalizeAgentID(state.Agent); normalized {
+		case model.AgentClaudeCode, model.AgentOpenCode, model.AgentKilocode, model.AgentCursor,
+			model.AgentVSCodeCopilot, model.AgentCodex, model.AgentAntigravity, model.AgentWindsurf,
+			model.AgentKimi, model.AgentQwenCode, model.AgentKiroIDE, model.AgentOpenClaw,
+			model.AgentPi, model.AgentTrae, model.AgentHermes:
+			agents = append(agents, normalized)
 		}
 	}
 

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -1,5 +1,7 @@
 package model
 
+import "strings"
+
 type AgentID string
 
 const (
@@ -20,6 +22,18 @@ const (
 	AgentTrae          AgentID = "trae-ide"
 	AgentHermes        AgentID = "hermes"
 )
+
+// NormalizeAgentID maps deprecated or alias agent identifiers to their canonical AgentID.
+// Specifically, "gemini-cli" and "gemini" map to AgentAntigravity ("antigravity").
+func NormalizeAgentID(input string) AgentID {
+	trimmed := strings.TrimSpace(input)
+	switch AgentID(trimmed) {
+	case AgentGeminiCLI, "gemini":
+		return AgentAntigravity
+	default:
+		return AgentID(trimmed)
+	}
+}
 
 // SupportTier indicates how fully an agent supports the Gentleman AI ecosystem.
 // All current agents receive the full SDD orchestrator, skill files, MCP config,

--- a/internal/model/types_test.go
+++ b/internal/model/types_test.go
@@ -8,6 +8,26 @@ func TestAgentAntigravity(t *testing.T) {
 	}
 }
 
+func TestNormalizeAgentID(t *testing.T) {
+	tests := []struct {
+		input string
+		want  AgentID
+	}{
+		{"gemini-cli", AgentAntigravity},
+		{"gemini", AgentAntigravity},
+		{"antigravity", AgentAntigravity},
+		{"opencode", AgentOpenCode},
+		{"claude-code", AgentClaudeCode},
+	}
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			if got := NormalizeAgentID(tc.input); got != tc.want {
+				t.Errorf("NormalizeAgentID(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
 // Unit 1 — TriggerEvent, TriggerMode, TriggerWhen, TriggerBinding, TriggerRuleSet
 
 // 1.1 — all six TriggerEvent constants exist with correct string values.

--- a/internal/model/types_test.go
+++ b/internal/model/types_test.go
@@ -14,10 +14,12 @@ func TestNormalizeAgentID(t *testing.T) {
 		want  AgentID
 	}{
 		{"gemini-cli", AgentAntigravity},
+		{"  gemini-cli  ", AgentAntigravity},
 		{"gemini", AgentAntigravity},
 		{"antigravity", AgentAntigravity},
 		{"opencode", AgentOpenCode},
 		{"claude-code", AgentClaudeCode},
+		{"  custom-agent  ", "custom-agent"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.input, func(t *testing.T) {


### PR DESCRIPTION
### 🔗 Linked Issue

Closes #1690

---

### 📝 Summary of Changes

Deprecates the legacy `gemini-cli` preview agent identifier in favor of official **Google Antigravity** (`antigravity` / `agy`).

1. **Agent Identifier Normalization**:
   - Added `model.NormalizeAgentID()` in `internal/model/types.go` mapping legacy `gemini-cli` and `gemini` to `model.AgentAntigravity` (`antigravity`).
   - Updated `asAgentIDs()` in `internal/cli/validate.go` to pass all input agent identifiers through `model.NormalizeAgentID()`.

2. **Catalog Metadata**:
   - Updated catalog entry in `internal/catalog/agents.go` to indicate deprecation status (`Gemini CLI (deprecated -> Antigravity)`).

3. **Testing**:
   - Added unit test `TestNormalizeAgentID` in `internal/model/types_test.go`.

---

### 🧪 Test Plan

- [x] Ran `go run ./internal/gofmtcheck` cleanly.
- [x] Ran unit tests: `go test ./internal/model/... ./internal/catalog/... ./internal/cli/...` passed cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added agent name/ID normalization with support for aliases and extra whitespace.
  - Deprecated Gemini identifiers (`gemini`, `gemini-cli`) are now mapped to the Antigravity agent automatically.
- **Bug Fixes**
  - Improved accuracy when interpreting user-provided agent values during installation.
  - Updated the Gemini CLI label to clearly indicate its transition to Antigravity.
- **Tests**
  - Added unit coverage for agent ID normalization and adjusted the installer default mapping expectation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->