### PR TITLE
feat(tui): sort reasoning effort levels by intensity instead of alphabetically

### DIFF
--- a/internal/tui/screens/model_picker.go
+++ b/internal/tui/screens/model_picker.go
@@ -519,19 +519,45 @@ func selectedModelPickerAgent(state ModelPickerState) string {
 	return row
 }
 
+var effortRank = map[string]int{
+	"low":    1,
+	"medium": 2,
+	"high":   3,
+	"xhigh":  4,
+	"max":    5,
+}
+
 // effortOptionsFromLevels returns the effort picker options in display order.
 // The first entry ("default") maps to an empty Effort string (provider default).
-// Levels that are literally "default" are excluded to prevent a duplicate entry
-// that would produce Effort="default" (a non-empty string) instead of Effort=""
-// when the user selects the first item.
+// Levels that are literally "default" are excluded to prevent a duplicate entry.
+// Effort levels are sorted semantically by intensity (low -> medium -> high -> xhigh -> max).
 func effortOptionsFromLevels(levels []string) []string {
-	opts := make([]string, 0, len(levels)+1)
-	opts = append(opts, "default")
+	filtered := make([]string, 0, len(levels))
 	for _, level := range levels {
 		if level != "default" {
-			opts = append(opts, level)
+			filtered = append(filtered, level)
 		}
 	}
+
+	sort.SliceStable(filtered, func(i, j int) bool {
+		rI, hasI := effortRank[strings.ToLower(filtered[i])]
+		rJ, hasJ := effortRank[strings.ToLower(filtered[j])]
+
+		if hasI && hasJ {
+			return rI < rJ
+		}
+		if hasI {
+			return true
+		}
+		if hasJ {
+			return false
+		}
+		return filtered[i] < filtered[j]
+	})
+
+	opts := make([]string, 0, len(filtered)+1)
+	opts = append(opts, "default")
+	opts = append(opts, filtered...)
 	return opts
 }
 

--- a/internal/tui/screens/model_picker_test.go
+++ b/internal/tui/screens/model_picker_test.go
@@ -3,6 +3,7 @@ package screens
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -1322,5 +1323,17 @@ func TestModelPickerRowsForProfile(t *testing.T) {
 				t.Fatalf("profile rows must use global reviewer %q, got: %v", reviewAgent, rows)
 			}
 		}
+	}
+}
+
+func TestEffortOptionsFromLevels_SemanticIntensitySorting(t *testing.T) {
+	// Raw levels coming from plugin in alphabetical order
+	raw := []string{"max", "high", "low", "xhigh", "medium"}
+
+	got := effortOptionsFromLevels(raw)
+	want := []string{"default", "low", "medium", "high", "xhigh", "max"}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("effortOptionsFromLevels(%v) = %v, want %v", raw, got, want)
 	}
 }


### PR DESCRIPTION
### 🔗 Linked Issue

Fixes #1698

---

### 📝 Summary of Changes

In the OpenCode TUI Model Picker (`ModeEffortSelect`), reasoning effort levels were previously displayed in alphabetical order (`high`, `low`, `max`, `medium`, `xhigh`) because `model-variants.ts` sorts variant keys with `Object.keys().sort()`.

#### Solution
Updated `effortOptionsFromLevels` in `internal/tui/screens/model_picker.go` to sort effort levels semantically by effort intensity rank:

1. `default` (provider default)
2. `low`
3. `medium`
4. `high`
5. `xhigh`
6. `max`

Custom or unknown levels are sorted alphabetically after standard levels.

---

### 🧪 Test Plan

- [x] Ran `go run ./internal/gofmtcheck` cleanly.
- [x] Ran unit tests: `go test ./internal/tui/...` passed cleanly.
- [x] Added unit test `TestEffortOptionsFromLevels_SemanticIntensitySorting` in `internal/tui/screens/model_picker_test.go`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved effort-level ordering in the model picker.
  * Effort options now appear in increasing intensity: default, low, medium, high, xhigh, and max.

* **Tests**
  * Added coverage to verify the new effort-level ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->