### PR TITLE
fix(persona): remap gentleman-neutral-artifacts alias to neutral

### DIFF
--- a/internal/cli/persona_helpers.go
+++ b/internal/cli/persona_helpers.go
@@ -2,6 +2,9 @@ package cli
 
 import "github.com/gentleman-programming/gentle-ai/v2/internal/model"
 
+// isGentlemanConversationPersona reports whether the persona keeps the voseo
+// conversation tone. The gentleman-neutral-artifacts legacy alias is remapped
+// to neutral (see normalizePersona) and is intentionally NOT gentleman here.
 func isGentlemanConversationPersona(persona model.PersonaID) bool {
-	return persona == model.PersonaGentleman || persona == model.PersonaGentlemanNeutralArtifacts
+	return persona == model.PersonaGentleman
 }

--- a/internal/cli/persona_language_contract_test.go
+++ b/internal/cli/persona_language_contract_test.go
@@ -1,17 +1,53 @@
 package cli
 
 import (
+	"bytes"
+	"strings"
 	"testing"
 
 	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/system"
 )
 
-func TestNormalizePersonaAcceptsGentlemanNeutralArtifacts(t *testing.T) {
-	got, err := normalizePersona("gentleman-neutral-artifacts")
+func TestNormalizePersonaRemapsGentlemanNeutralArtifacts(t *testing.T) {
+	got, remapped, err := normalizePersona("gentleman-neutral-artifacts")
 	if err != nil {
 		t.Fatalf("normalizePersona() error = %v", err)
 	}
-	if got != model.PersonaGentlemanNeutralArtifacts {
-		t.Fatalf("normalizePersona() = %q, want %q", got, model.PersonaGentlemanNeutralArtifacts)
+	if got != model.PersonaNeutral {
+		t.Fatalf("normalizePersona() = %q, want %q", got, model.PersonaNeutral)
+	}
+	if !remapped {
+		t.Fatal("normalizePersona() remapped = false, want true for the legacy alias")
+	}
+}
+
+func TestNormalizePersonaDoesNotFlagCanonicalPersonas(t *testing.T) {
+	for _, value := range []string{"", "gentleman", "neutral", "custom"} {
+		_, remapped, err := normalizePersona(value)
+		if err != nil {
+			t.Fatalf("normalizePersona(%q) error = %v", value, err)
+		}
+		if remapped {
+			t.Fatalf("normalizePersona(%q) remapped = true, want false", value)
+		}
+	}
+}
+
+func TestNormalizeInstallFlagsPrintsAliasRemapNotice(t *testing.T) {
+	var buf bytes.Buffer
+	previous := personaNoticeWriter
+	personaNoticeWriter = &buf
+	defer func() { personaNoticeWriter = previous }()
+
+	input, err := NormalizeInstallFlags(InstallFlags{Persona: "gentleman-neutral-artifacts"}, system.DetectionResult{})
+	if err != nil {
+		t.Fatalf("NormalizeInstallFlags() error = %v", err)
+	}
+	if input.Selection.Persona != model.PersonaNeutral {
+		t.Fatalf("Selection.Persona = %q, want %q", input.Selection.Persona, model.PersonaNeutral)
+	}
+	if !strings.Contains(buf.String(), personaAliasRemapNotice) {
+		t.Fatalf("notice not printed; got %q", buf.String())
 	}
 }

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -1315,11 +1315,13 @@ func migratePersistedPersonaAlias(homeDir string, persisted *state.InstallState,
 	if persistedErr != nil || persisted.Persona != string(model.PersonaGentlemanNeutralArtifacts) {
 		return nil
 	}
-	fmt.Fprintln(personaNoticeWriter, personaAliasRemapNotice)
 	persisted.Persona = string(model.PersonaNeutral)
 	if err := state.Write(homeDir, *persisted); err != nil {
 		return fmt.Errorf("persist remapped persona: %w", err)
 	}
+	// Notice only after the rewrite is durably persisted: a failed write must
+	// not tell the user the remap happened.
+	fmt.Fprintln(personaNoticeWriter, personaAliasRemapNotice)
 	return nil
 }
 
@@ -1341,6 +1343,14 @@ func RunSyncWithSelection(homeDir string, selection model.Selection) (SyncResult
 		var persistedPersona string
 		persistedPersona = persistedState.Persona
 		applyResolvedPersona(&selection, persistedPersona)
+	}
+
+	// Migrate a persisted legacy alias BEFORE any early return: a no-agent
+	// no-op sync and a failing pipeline must still leave state.json remapped,
+	// otherwise the one-time migration never fires for those users. State
+	// records intent — the next sync applies the neutral assets.
+	if err := migratePersistedPersonaAlias(homeDir, &persistedState, persistedStateErr); err != nil {
+		return SyncResult{Agents: agentIDs, Selection: selection}, err
 	}
 
 	result := SyncResult{
@@ -1404,10 +1414,6 @@ func RunSyncWithSelection(homeDir string, selection model.Selection) (SyncResult
 		if err := state.Write(homeDir, persistedState); err != nil {
 			return result, fmt.Errorf("persist migrated community tool selection: %w", err)
 		}
-	}
-
-	if err := migratePersistedPersonaAlias(homeDir, &persistedState, persistedStateErr); err != nil {
-		return result, err
 	}
 
 	return result, nil

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -1312,7 +1312,7 @@ func applyResolvedPersona(selection *model.Selection, persisted string) {
 // once. State that predates persona persistence, explicit gentleman state,
 // and unreadable state are untouched.
 func migratePersistedPersonaAlias(homeDir string, persisted *state.InstallState, persistedErr error) error {
-	if persistedErr != nil || persisted.Persona != string(model.PersonaGentlemanNeutralArtifacts) {
+	if persistedErr != nil || persisted == nil || persisted.Persona != string(model.PersonaGentlemanNeutralArtifacts) {
 		return nil
 	}
 	persisted.Persona = string(model.PersonaNeutral)

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -1295,7 +1295,7 @@ func applyResolvedPersona(selection *model.Selection, persisted string) {
 		return
 	}
 	if persisted != "" {
-		if id, err := normalizePersona(persisted); err == nil {
+		if id, _, err := normalizePersona(persisted); err == nil {
 			selection.Persona = id
 			return
 		}

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -667,7 +667,7 @@ func managedOutputStyleName(persona model.PersonaID) string {
 	switch {
 	case isGentlemanConversationPersona(persona):
 		return "Gentleman"
-	case persona == model.PersonaNeutral:
+	case persona == model.PersonaNeutral, persona == model.PersonaGentlemanNeutralArtifacts:
 		return "Neutral"
 	default:
 		return ""

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -1307,6 +1307,22 @@ func applyResolvedPersona(selection *model.Selection, persisted string) {
 	selection.Persona = model.PersonaNeutral
 }
 
+// migratePersistedPersonaAlias rewrites a persisted legacy
+// gentleman-neutral-artifacts persona to neutral, printing the remap notice
+// once. State that predates persona persistence, explicit gentleman state,
+// and unreadable state are untouched.
+func migratePersistedPersonaAlias(homeDir string, persisted *state.InstallState, persistedErr error) error {
+	if persistedErr != nil || persisted.Persona != string(model.PersonaGentlemanNeutralArtifacts) {
+		return nil
+	}
+	fmt.Fprintln(personaNoticeWriter, personaAliasRemapNotice)
+	persisted.Persona = string(model.PersonaNeutral)
+	if err := state.Write(homeDir, *persisted); err != nil {
+		return fmt.Errorf("persist remapped persona: %w", err)
+	}
+	return nil
+}
+
 // RunSyncWithSelection is the programmatic entry point for sync.
 // It skips flag parsing and agent discovery — the caller provides the homeDir
 // and a fully-built Selection (agents + components + options).
@@ -1388,6 +1404,10 @@ func RunSyncWithSelection(homeDir string, selection model.Selection) (SyncResult
 		if err := state.Write(homeDir, persistedState); err != nil {
 			return result, fmt.Errorf("persist migrated community tool selection: %w", err)
 		}
+	}
+
+	if err := migratePersistedPersonaAlias(homeDir, &persistedState, persistedStateErr); err != nil {
+		return result, err
 	}
 
 	return result, nil

--- a/internal/cli/sync_persona_migration_test.go
+++ b/internal/cli/sync_persona_migration_test.go
@@ -90,3 +90,37 @@ func TestApplyResolvedPersonaAliasResolution(t *testing.T) {
 		})
 	}
 }
+
+// TestRunSyncWithSelectionMigratesAliasOnNoOpSync pins the early-return path:
+// a sync that discovers zero agents must still migrate a persisted legacy
+// alias, otherwise the one-time migration never fires for those users.
+func TestRunSyncWithSelectionMigratesAliasOnNoOpSync(t *testing.T) {
+	var buf bytes.Buffer
+	previous := personaNoticeWriter
+	personaNoticeWriter = &buf
+	defer func() { personaNoticeWriter = previous }()
+
+	homeDir := t.TempDir()
+	if err := state.Write(homeDir, state.InstallState{Persona: string(model.PersonaGentlemanNeutralArtifacts)}); err != nil {
+		t.Fatalf("seed state: %v", err)
+	}
+
+	result, err := RunSyncWithSelection(homeDir, model.Selection{})
+	if err != nil {
+		t.Fatalf("RunSyncWithSelection() error = %v", err)
+	}
+	if !result.NoOp {
+		t.Fatal("zero-agent sync must report NoOp")
+	}
+
+	reread, err := state.Read(homeDir)
+	if err != nil {
+		t.Fatalf("re-read state: %v", err)
+	}
+	if reread.Persona != string(model.PersonaNeutral) {
+		t.Fatalf("persisted persona = %q, want %q after no-op sync", reread.Persona, model.PersonaNeutral)
+	}
+	if !strings.Contains(buf.String(), personaAliasRemapNotice) {
+		t.Fatalf("notice not printed on no-op sync; got %q", buf.String())
+	}
+}

--- a/internal/cli/sync_persona_migration_test.go
+++ b/internal/cli/sync_persona_migration_test.go
@@ -1,0 +1,92 @@
+package cli
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/state"
+)
+
+var errStateUnreadableForTest = errors.New("state unreadable")
+
+func TestMigratePersistedPersonaAliasRewritesStateOnce(t *testing.T) {
+	var buf bytes.Buffer
+	previous := personaNoticeWriter
+	personaNoticeWriter = &buf
+	defer func() { personaNoticeWriter = previous }()
+
+	homeDir := t.TempDir()
+	persisted := state.InstallState{Persona: string(model.PersonaGentlemanNeutralArtifacts)}
+	if err := state.Write(homeDir, persisted); err != nil {
+		t.Fatalf("seed state: %v", err)
+	}
+
+	if err := migratePersistedPersonaAlias(homeDir, &persisted, nil); err != nil {
+		t.Fatalf("migratePersistedPersonaAlias() error = %v", err)
+	}
+
+	reread, err := state.Read(homeDir)
+	if err != nil {
+		t.Fatalf("re-read state: %v", err)
+	}
+	if reread.Persona != string(model.PersonaNeutral) {
+		t.Fatalf("persisted persona = %q, want %q", reread.Persona, model.PersonaNeutral)
+	}
+	if !strings.Contains(buf.String(), personaAliasRemapNotice) {
+		t.Fatalf("notice not printed; got %q", buf.String())
+	}
+
+	// Second run: state already neutral — no notice, no rewrite.
+	buf.Reset()
+	if err := migratePersistedPersonaAlias(homeDir, &reread, nil); err != nil {
+		t.Fatalf("second migrate: %v", err)
+	}
+	if buf.Len() != 0 {
+		t.Fatalf("second run printed %q, want silence", buf.String())
+	}
+}
+
+func TestMigratePersistedPersonaAliasSkipsUnreadableState(t *testing.T) {
+	persisted := state.InstallState{Persona: string(model.PersonaGentlemanNeutralArtifacts)}
+	if err := migratePersistedPersonaAlias(t.TempDir(), &persisted, errStateUnreadableForTest); err != nil {
+		t.Fatalf("migrate with read error must be a no-op, got %v", err)
+	}
+}
+
+// TestApplyResolvedPersonaAliasResolution covers only what this change owns:
+// a persisted legacy alias resolves to neutral, valid persisted personas are
+// honored unchanged, an explicit selection wins over persisted state, and the
+// documented missing-field compatibility default still applies to state files
+// written before persona persistence existed.
+//
+// Resolution of unknown or unreadable persisted state is deliberately NOT
+// asserted here. That policy belongs to issue #1677, which makes it fail
+// closed; pinning today's fail-open behavior would codify a contract this
+// change does not intend to define.
+func TestApplyResolvedPersonaAliasResolution(t *testing.T) {
+	cases := []struct {
+		name      string
+		selection model.Selection
+		persisted string
+		want      model.PersonaID
+	}{
+		{name: "persisted legacy alias resolves to neutral", persisted: string(model.PersonaGentlemanNeutralArtifacts), want: model.PersonaNeutral},
+		{name: "persisted gentleman is honored", persisted: string(model.PersonaGentleman), want: model.PersonaGentleman},
+		{name: "persisted neutral is honored", persisted: string(model.PersonaNeutral), want: model.PersonaNeutral},
+		{name: "explicit selection wins over persisted alias", selection: model.Selection{Persona: model.PersonaGentleman}, persisted: string(model.PersonaGentlemanNeutralArtifacts), want: model.PersonaGentleman},
+		{name: "missing persona field uses the documented compatibility default", persisted: "", want: model.PersonaNeutral},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			selection := tc.selection
+			applyResolvedPersona(&selection, tc.persisted)
+			if selection.Persona != tc.want {
+				t.Fatalf("applyResolvedPersona(persisted=%q) = %q, want %q", tc.persisted, selection.Persona, tc.want)
+			}
+		})
+	}
+}

--- a/internal/cli/validate.go
+++ b/internal/cli/validate.go
@@ -2,6 +2,8 @@ package cli
 
 import (
 	"fmt"
+	"io"
+	"os"
 	"sort"
 	"strings"
 
@@ -30,9 +32,12 @@ func NormalizeInstallFlags(flags InstallFlags, detection system.DetectionResult)
 	}
 	selection.Agents = unique(agents)
 
-	persona, err := normalizePersona(flags.Persona)
+	persona, personaRemapped, err := normalizePersona(flags.Persona)
 	if err != nil {
 		return InstallInput{}, err
+	}
+	if personaRemapped {
+		fmt.Fprintln(personaNoticeWriter, personaAliasRemapNotice)
 	}
 	selection.Persona = persona
 
@@ -77,16 +82,29 @@ func NormalizeInstallFlags(flags InstallFlags, detection system.DetectionResult)
 	return InstallInput{Selection: selection, Scope: scope, Channel: channel, DryRun: flags.DryRun}, nil
 }
 
-func normalizePersona(value string) (model.PersonaID, error) {
+// personaAliasRemapNotice is printed whenever the legacy
+// gentleman-neutral-artifacts alias is remapped to the neutral persona.
+const personaAliasRemapNotice = `"gentleman-neutral-artifacts" now maps to "neutral". For a voseo conversation use --persona gentleman.`
+
+// personaNoticeWriter is swappable in tests.
+var personaNoticeWriter io.Writer = os.Stderr
+
+// normalizePersona resolves a --persona flag or persisted state value.
+// The second return is true when the legacy gentleman-neutral-artifacts
+// alias was remapped to neutral: its name promised a neutral tone, so the
+// name now wins; users who want voseo have --persona gentleman.
+func normalizePersona(value string) (model.PersonaID, bool, error) {
 	if strings.TrimSpace(value) == "" {
-		return model.PersonaGentleman, nil
+		return model.PersonaGentleman, false, nil
 	}
 
 	switch model.PersonaID(value) {
-	case model.PersonaGentleman, model.PersonaGentlemanNeutralArtifacts, model.PersonaNeutral, model.PersonaCustom:
-		return model.PersonaID(value), nil
+	case model.PersonaGentlemanNeutralArtifacts:
+		return model.PersonaNeutral, true, nil
+	case model.PersonaGentleman, model.PersonaNeutral, model.PersonaCustom:
+		return model.PersonaID(value), false, nil
 	default:
-		return "", fmt.Errorf("unsupported persona %q", value)
+		return "", false, fmt.Errorf("unsupported persona %q", value)
 	}
 }
 

--- a/internal/components/persona/inject.go
+++ b/internal/components/persona/inject.go
@@ -61,6 +61,14 @@ func InjectForSync(homeDir string, adapter agents.Adapter, persona model.Persona
 // syncManaged is the internal flag previously called `markdownOnly`.
 // When true the OpenCode/Kilocode agent overlay is skipped (see InjectForSync).
 func injectInternal(homeDir string, adapter agents.Adapter, persona model.PersonaID, syncManaged bool) (InjectionResult, error) {
+	// Normalize the legacy alias at the single entry point so every branch
+	// below (persona content, output-style write, Kimi module selection,
+	// cleanup) sees one canonical neutral identity. CLI callers already pass
+	// normalized IDs (cli.normalizePersona, internal/cli/validate.go); this
+	// guards direct callers.
+	if persona == model.PersonaGentlemanNeutralArtifacts {
+		persona = model.PersonaNeutral
+	}
 	if !adapter.SupportsSystemPrompt() {
 		return InjectionResult{}, nil
 	}
@@ -490,7 +498,8 @@ func shouldStripManagedLegacyPersona(existing string) bool {
 
 // isGentlemanConversationPersona reports whether the persona keeps the voseo
 // conversation tone. The gentleman-neutral-artifacts legacy alias is remapped
-// to neutral (see normalizePersona) and is intentionally NOT gentleman here.
+// to neutral (cli.normalizePersona in internal/cli/validate.go, mirrored at
+// the injectInternal entry) and is intentionally NOT gentleman here.
 func isGentlemanConversationPersona(persona model.PersonaID) bool {
 	return persona == model.PersonaGentleman
 }

--- a/internal/components/persona/inject.go
+++ b/internal/components/persona/inject.go
@@ -488,8 +488,11 @@ func shouldStripManagedLegacyPersona(existing string) bool {
 	return strings.Contains(existing, "<!-- gentle-ai:persona -->")
 }
 
+// isGentlemanConversationPersona reports whether the persona keeps the voseo
+// conversation tone. The gentleman-neutral-artifacts legacy alias is remapped
+// to neutral (see normalizePersona) and is intentionally NOT gentleman here.
 func isGentlemanConversationPersona(persona model.PersonaID) bool {
-	return persona == model.PersonaGentleman || persona == model.PersonaGentlemanNeutralArtifacts
+	return persona == model.PersonaGentleman
 }
 
 // residualChannel reports whether the adapter already delivers tone/language/
@@ -506,7 +509,7 @@ func residualChannel(adapter agents.Adapter) bool {
 // personaContent returns the persona asset for the given agent and persona.
 func personaContent(agent model.AgentID, persona model.PersonaID, residualContentAvailable bool) string {
 	switch persona {
-	case model.PersonaNeutral:
+	case model.PersonaNeutral, model.PersonaGentlemanNeutralArtifacts:
 		return neutralPersonaContent(agent, residualContentAvailable)
 	case model.PersonaCustom:
 		return ""

--- a/internal/components/persona/inject_test.go
+++ b/internal/components/persona/inject_test.go
@@ -2024,7 +2024,6 @@ func TestPersonaContentHermesGentleman(t *testing.T) {
 		persona model.PersonaID
 	}{
 		{"gentleman", model.PersonaGentleman},
-		{"gentleman-neutral-artifacts", model.PersonaGentlemanNeutralArtifacts},
 	}
 
 	for _, tt := range tests {
@@ -2047,6 +2046,19 @@ func TestPersonaContentHermesGentleman(t *testing.T) {
 				t.Fatal("hermes gentleman persona is byte-identical to generic — Hermes-specific asset not used")
 			}
 		})
+	}
+}
+
+// TestPersonaContentAliasRoutesToNeutral verifies that the gentleman-neutral-artifacts
+// alias is routed to neutral content, not gentleman content.
+func TestPersonaContentAliasRoutesToNeutral(t *testing.T) {
+	alias := personaContent(model.AgentClaudeCode, model.PersonaGentlemanNeutralArtifacts, false)
+	neutral := personaContent(model.AgentClaudeCode, model.PersonaNeutral, false)
+	if alias != neutral {
+		t.Fatal("gentleman-neutral-artifacts must produce identical content to neutral")
+	}
+	if alias == "" {
+		t.Fatal("alias persona content must not be empty")
 	}
 }
 

--- a/internal/components/persona/persona_language_contract_test.go
+++ b/internal/components/persona/persona_language_contract_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
 )
 
-func TestInjectGentlemanNeutralArtifactsUsesGentlemanConversationWithArtifactBoundary(t *testing.T) {
+func TestInjectGentlemanNeutralArtifactsRoutesToNeutralContent(t *testing.T) {
 	home := t.TempDir()
 
 	result, err := Inject(home, opencodeAdapter(), model.PersonaGentlemanNeutralArtifacts)
@@ -25,8 +25,14 @@ func TestInjectGentlemanNeutralArtifactsUsesGentlemanConversationWithArtifactBou
 		t.Fatalf("ReadFile() error = %v", err)
 	}
 	text := string(content)
+
+	// The alias routes to neutral content, not gentleman
+	if strings.Contains(text, "Rioplatense") {
+		t.Fatalf("alias should route to neutral — found gentleman tone marker 'Rioplatense'")
+	}
+
+	// Verify neutral content is present
 	for _, want := range []string{
-		"Rioplatense",
 		"Generated technical artifacts default to English",
 		"Public/contextual comments follow the target context language",
 		"If the selected reply language is English, every part of the direct reply must be English",

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -95,8 +95,8 @@ type PersonaID string
 const (
 	PersonaGentleman PersonaID = "gentleman"
 	// PersonaGentlemanNeutralArtifacts is a legacy alias accepted for backward
-	// compatibility and remapped to PersonaNeutral at normalization time (see
-	// cli.normalizePersona). It is never offered as a choice.
+	// compatibility. The CLI and sync normalization treat it as PersonaNeutral,
+	// and it is never offered as a selectable choice.
 	PersonaGentlemanNeutralArtifacts PersonaID = "gentleman-neutral-artifacts"
 	PersonaNeutral                   PersonaID = "neutral"
 	PersonaCustom                    PersonaID = "custom"

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -93,7 +93,10 @@ const (
 type PersonaID string
 
 const (
-	PersonaGentleman                 PersonaID = "gentleman"
+	PersonaGentleman PersonaID = "gentleman"
+	// PersonaGentlemanNeutralArtifacts is a legacy alias accepted for backward
+	// compatibility and remapped to PersonaNeutral at normalization time (see
+	// cli.normalizePersona). It is never offered as a choice.
 	PersonaGentlemanNeutralArtifacts PersonaID = "gentleman-neutral-artifacts"
 	PersonaNeutral                   PersonaID = "neutral"
 	PersonaCustom                    PersonaID = "custom"

--- a/internal/tui/screens/persona.go
+++ b/internal/tui/screens/persona.go
@@ -8,12 +8,15 @@ import (
 )
 
 func PersonaOptions() []model.PersonaID {
-	return []model.PersonaID{model.PersonaGentleman, model.PersonaGentlemanNeutralArtifacts, model.PersonaNeutral, model.PersonaCustom}
+	return []model.PersonaID{model.PersonaGentleman, model.PersonaNeutral, model.PersonaCustom}
 }
 
 var personaDescriptions = map[model.PersonaID]string{
-	model.PersonaGentleman:                 "Voseo conversation; English technical artifacts",
-	model.PersonaGentlemanNeutralArtifacts: "Voseo conversation; English technical artifacts (legacy alias)",
+	model.PersonaGentleman: "Voseo conversation; English technical artifacts",
+	// The legacy alias is remapped at normalization time and no longer offered
+	// in the picker; the entry stays so the review screen can label persisted
+	// state that has not been migrated yet.
+	model.PersonaGentlemanNeutralArtifacts: "No regional conversation tone; English technical artifacts (legacy alias, remapped)",
 	model.PersonaNeutral:                   "No regional conversation tone; English technical artifacts",
 	model.PersonaCustom:                    "Do not install a managed persona; choose themes/logo on the next screens",
 }

--- a/internal/tui/screens/persona_language_contract_test.go
+++ b/internal/tui/screens/persona_language_contract_test.go
@@ -7,16 +7,11 @@ import (
 	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
 )
 
-func TestPersonaOptionsIncludeGentlemanNeutralArtifacts(t *testing.T) {
-	options := PersonaOptions()
-	found := false
-	for _, option := range options {
+func TestPersonaOptionsExcludeGentlemanNeutralArtifacts(t *testing.T) {
+	for _, option := range PersonaOptions() {
 		if option == model.PersonaGentlemanNeutralArtifacts {
-			found = true
+			t.Fatalf("PersonaOptions() still offers the remapped legacy alias %q", option)
 		}
-	}
-	if !found {
-		t.Fatalf("PersonaOptions() = %v, missing %q", options, model.PersonaGentlemanNeutralArtifacts)
 	}
 }
 
@@ -57,15 +52,15 @@ func TestPersonaDescriptionsSeparateToneFromArtifactLanguage(t *testing.T) {
 			t.Fatalf("persona %q must state that technical artifacts are English: %q", persona, description)
 		}
 		mentionsVoseo := strings.Contains(strings.ToLower(description), "voseo")
-		isGentleman := persona == model.PersonaGentleman || persona == model.PersonaGentlemanNeutralArtifacts
+		isGentleman := persona == model.PersonaGentleman
 		if mentionsVoseo != isGentleman {
 			t.Fatalf("persona %q voseo claim = %v, want %v (only Gentleman personas carry a regional tone): %q",
 				persona, mentionsVoseo, isGentleman, description)
 		}
 	}
 
-	if personaDescriptions[model.PersonaGentleman] == personaDescriptions[model.PersonaGentlemanNeutralArtifacts] {
-		t.Fatal("the Gentleman persona and its legacy alias must stay distinguishable in the selector")
+	if personaDescriptions[model.PersonaNeutral] == personaDescriptions[model.PersonaGentlemanNeutralArtifacts] {
+		t.Fatal("the neutral persona and its legacy alias must stay distinguishable in the review label")
 	}
 }
 
@@ -75,7 +70,6 @@ func TestPersonaDescriptionsSeparateToneFromArtifactLanguage(t *testing.T) {
 func TestRenderPersonaShowsEveryManagedDescription(t *testing.T) {
 	for _, persona := range []model.PersonaID{
 		model.PersonaGentleman,
-		model.PersonaGentlemanNeutralArtifacts,
 		model.PersonaNeutral,
 	} {
 		out := RenderPersona(persona, 0)

--- a/internal/tui/screens/review_test.go
+++ b/internal/tui/screens/review_test.go
@@ -158,7 +158,7 @@ func TestRenderReviewSummarizesPersonaConversationAndArtifacts(t *testing.T) {
 		want    string
 	}{
 		{name: "Gentleman", persona: model.PersonaGentleman, want: "Voseo conversation; English technical artifacts"},
-		{name: "Gentleman with English artifacts", persona: model.PersonaGentlemanNeutralArtifacts, want: "Voseo conversation; English technical artifacts (legacy alias)"},
+		{name: "Gentleman with English artifacts", persona: model.PersonaGentlemanNeutralArtifacts, want: "No regional conversation tone; English technical artifacts (legacy alias, remapped)"},
 		{name: "Neutral", persona: model.PersonaNeutral, want: "No regional conversation tone; English technical artifacts"},
 	}
 


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1702

> Chained series: this is **PR1 of 5** under #1702. If this merge auto-closes the issue, please reopen — the series completes with PR5 (defects 4-5 are not addressed here).

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)

---

## 📝 Summary

Remaps the legacy `gentleman-neutral-artifacts` persona alias to `neutral` everywhere it is resolved, fixing defects 1 and 2 of #1702: the alias installed voseo conversation despite its name, and `gentle-ai sync` regenerated gentleman assets from persisted alias state on every run, permanently reverting attempted switches to neutral.

> **Scope note.** This PR was narrowed and split after review. It is now slice A of a
> chained series: alias remap only, 309 changed lines. Slice B (persona output-style
> backup rollback plus the `WriteFileAtomic` atomicity test, 155 lines) follows as a
> stacked PR once this lands. The earlier `225` figure in this body was wrong; the
> pre-split diff was 464 lines.
>
> Issue #1677 owns fail-closed handling for unknown or unreadable persisted persona
> state. This PR deliberately does not codify that behavior: `applyResolvedPersona` is
> unchanged from `main` apart from a mechanical `normalizePersona` arity change.

- `normalizePersona` now returns `(model.PersonaID, bool, error)`; the alias resolves to `PersonaNeutral` with a remap signal, and install prints: `"gentleman-neutral-artifacts" now maps to "neutral". For a voseo conversation use --persona gentleman.` Explicit `gentleman` is untouched.
- One-time sync migration (`migratePersistedPersonaAlias`) rewrites persisted alias state to `"neutral"` and prints the notice once; unreadable state is skipped (consistent with the fail-closed direction of #1677).
- Both `isGentlemanConversationPersona` helpers treat only `gentleman` as gentleman-family; `personaContent` and `managedOutputStyleName` route the alias to neutral defensively.
- TUI: alias removed from the persona picker; its `personaDescriptions` entry stays (reworded) so `reviewPersonaLabel` still renders unmigrated persisted state.

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/cli/validate.go` | Alias remap in `normalizePersona` (3-value signature), remap notice on install |
| `internal/cli/sync.go` | `migratePersistedPersonaAlias` one-time state write-back after the CommunityTools migration; alias → neutral in `managedOutputStyleName` |
| `internal/cli/persona_helpers.go` | `isGentlemanConversationPersona` true only for `gentleman` |
| `internal/components/persona/inject.go` | Same helper change; `personaContent` routes alias to neutral content |
| `internal/tui/screens/persona.go` | Alias removed from `PersonaOptions()`; description entry retained and reworded |
| `internal/model/types.go` | Alias constant documented as remapped legacy alias |
| `internal/cli/persona_language_contract_test.go`, `internal/cli/sync_persona_migration_test.go`, `internal/components/persona/*_test.go`, `internal/tui/screens/*_test.go` | New/updated tests: remap semantics, notice printing, one-time migration, alias-routes-to-neutral, picker exclusion |

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./...
```

**Go Format**
```bash
go run ./internal/gofmtcheck
```

**E2E Tests** (Docker required)
```bash
cd e2e && ./docker-test.sh
```

- [x] Unit tests pass for every package this PR touches (`internal/cli`, `internal/model`, `internal/tui/...`, `internal/components/persona`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests — deferring to CI (no local Docker run)
- [x] Manually tested locally (test-level; see note below)

Note on `go test ./...`: three `internal/cli` tests fail on this machine **at the base commit `89e06d24` as well** (pre-existing / environment-dependent, not introduced here): `TestRunInstallKimiMissingUVFailsBeforeExecutingInstallCommands`, `TestReviewReconcileAuthorityBatchHonorsLockCancellation`, and `TestNegotiatedStartPublishesStableOpaqueRepositoryContext` (macOS `/private/var` temp-dir symlink resolution). Deferring the authoritative full-suite verdict to CI.

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue — #1702 is currently `status:needs-review`; awaiting maintainer `status:approved` (the approval CI check will stay red until then)
- [x] PR stays within 400 changed lines (274 additions + 35 deletions = 309)
- [ ] `type:*` label — no triage rights from fork; maintainer: `type:bug`
- [x] Unit tests pass (touched packages; 3 pre-existing failures documented above)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests — deferring to CI
- [x] Documentation updated where necessary (constant doc comment; no user-docs impact)
- [x] Commits follow Conventional Commits
- [x] No `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

The switch-cleanup mechanics (removing `gentleman.md`, clearing `outputStyle`) already live on `main` via `aa881f2` and are NOT re-implemented here — PR2 of this series pins them with tests and adds the `--persona`-forces-component behavior (defect 3). The TUI description wording avoids the standalone word "neutral" deliberately: `TestPersonaDescriptionsNeverReuseNeutral` (issue #833) pins that invariant.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **User Experience**
  * Removed the legacy “Gentleman with English artifacts” alias from the persona picker.
  * If the legacy persona is detected in settings, it’s automatically remapped to Neutral and a remap notice is shown.
  * Persona language now consistently uses Neutral phrasing (no regional gentleman conversation tone).
  * Persisted legacy persona state is migrated to Neutral one time, including during no-op syncs.
* **Reliability / Sync**
  * Improved sync rollback coverage by capturing both managed output styles during persona switches.
* **Bug Fixes**
  * Fixed legacy persona classification and updated review summary wording accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
