### PR TITLE
feat(install): make persona switching first-class

### DIFF
--- a/internal/cli/persona_helpers.go
+++ b/internal/cli/persona_helpers.go
@@ -2,6 +2,9 @@ package cli
 
 import "github.com/gentleman-programming/gentle-ai/v2/internal/model"
 
+// isGentlemanConversationPersona reports whether the persona keeps the voseo
+// conversation tone. The gentleman-neutral-artifacts legacy alias is remapped
+// to neutral (see normalizePersona) and is intentionally NOT gentleman here.
 func isGentlemanConversationPersona(persona model.PersonaID) bool {
-	return persona == model.PersonaGentleman || persona == model.PersonaGentlemanNeutralArtifacts
+	return persona == model.PersonaGentleman
 }

--- a/internal/cli/persona_language_contract_test.go
+++ b/internal/cli/persona_language_contract_test.go
@@ -1,17 +1,53 @@
 package cli
 
 import (
+	"bytes"
+	"strings"
 	"testing"
 
 	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/system"
 )
 
-func TestNormalizePersonaAcceptsGentlemanNeutralArtifacts(t *testing.T) {
-	got, err := normalizePersona("gentleman-neutral-artifacts")
+func TestNormalizePersonaRemapsGentlemanNeutralArtifacts(t *testing.T) {
+	got, remapped, err := normalizePersona("gentleman-neutral-artifacts")
 	if err != nil {
 		t.Fatalf("normalizePersona() error = %v", err)
 	}
-	if got != model.PersonaGentlemanNeutralArtifacts {
-		t.Fatalf("normalizePersona() = %q, want %q", got, model.PersonaGentlemanNeutralArtifacts)
+	if got != model.PersonaNeutral {
+		t.Fatalf("normalizePersona() = %q, want %q", got, model.PersonaNeutral)
+	}
+	if !remapped {
+		t.Fatal("normalizePersona() remapped = false, want true for the legacy alias")
+	}
+}
+
+func TestNormalizePersonaDoesNotFlagCanonicalPersonas(t *testing.T) {
+	for _, value := range []string{"", "gentleman", "neutral", "custom"} {
+		_, remapped, err := normalizePersona(value)
+		if err != nil {
+			t.Fatalf("normalizePersona(%q) error = %v", value, err)
+		}
+		if remapped {
+			t.Fatalf("normalizePersona(%q) remapped = true, want false", value)
+		}
+	}
+}
+
+func TestNormalizeInstallFlagsPrintsAliasRemapNotice(t *testing.T) {
+	var buf bytes.Buffer
+	previous := personaNoticeWriter
+	personaNoticeWriter = &buf
+	defer func() { personaNoticeWriter = previous }()
+
+	input, err := NormalizeInstallFlags(InstallFlags{Persona: "gentleman-neutral-artifacts"}, system.DetectionResult{})
+	if err != nil {
+		t.Fatalf("NormalizeInstallFlags() error = %v", err)
+	}
+	if input.Selection.Persona != model.PersonaNeutral {
+		t.Fatalf("Selection.Persona = %q, want %q", input.Selection.Persona, model.PersonaNeutral)
+	}
+	if !strings.Contains(buf.String(), personaAliasRemapNotice) {
+		t.Fatalf("notice not printed; got %q", buf.String())
 	}
 }

--- a/internal/cli/persona_language_contract_test.go
+++ b/internal/cli/persona_language_contract_test.go
@@ -51,3 +51,37 @@ func TestNormalizeInstallFlagsPrintsAliasRemapNotice(t *testing.T) {
 		t.Fatalf("notice not printed; got %q", buf.String())
 	}
 }
+
+func TestNormalizeInstallFlagsPersonaFlagForcesPersonaComponent(t *testing.T) {
+	input, err := NormalizeInstallFlags(InstallFlags{
+		Persona:    "neutral",
+		Components: []string{string(model.ComponentEngram)},
+	}, system.DetectionResult{})
+	if err != nil {
+		t.Fatalf("NormalizeInstallFlags() error = %v", err)
+	}
+	found := false
+	for _, component := range input.Selection.Components {
+		if component == model.ComponentPersona {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("explicit --persona must force the persona component; got %v", input.Selection.Components)
+	}
+}
+
+func TestNormalizeInstallFlagsCustomPersonaDoesNotForceComponent(t *testing.T) {
+	input, err := NormalizeInstallFlags(InstallFlags{
+		Persona:    "custom",
+		Components: []string{string(model.ComponentEngram)},
+	}, system.DetectionResult{})
+	if err != nil {
+		t.Fatalf("NormalizeInstallFlags() error = %v", err)
+	}
+	for _, component := range input.Selection.Components {
+		if component == model.ComponentPersona {
+			t.Fatal("--persona custom means unmanaged; it must not force the persona component")
+		}
+	}
+}

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1823,6 +1823,16 @@ func backupTargets(homeDir, workspaceDir string, scope InstallScope, selection m
 				}
 			}
 		}
+		// Persona backup captures every managed output-style file, not just the
+		// selected one, so a failed persona switch can restore the file its
+		// cleanup removed. Backup-only: verification stays on the selected file.
+		if component == model.ComponentPersona {
+			for _, path := range managedOutputStyleBackupPaths(selection, adapters, func(a agents.Adapter) string {
+				return a.OutputStyleDir(componentPathDirScoped(homeDir, workspaceDir, scope, a, model.ComponentPersona))
+			}) {
+				paths[path] = struct{}{}
+			}
+		}
 	}
 	// Routing guidance is delivered per agent outside the component loop, so a
 	// selection whose components do not happen to cover the same file would be

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -1378,6 +1378,22 @@ func applyResolvedPersona(selection *model.Selection, persisted string) {
 	selection.Persona = model.PersonaNeutral
 }
 
+// migratePersistedPersonaAlias rewrites a persisted legacy
+// gentleman-neutral-artifacts persona to neutral, printing the remap notice
+// once. State that predates persona persistence, explicit gentleman state,
+// and unreadable state are untouched.
+func migratePersistedPersonaAlias(homeDir string, persisted *state.InstallState, persistedErr error) error {
+	if persistedErr != nil || persisted.Persona != string(model.PersonaGentlemanNeutralArtifacts) {
+		return nil
+	}
+	fmt.Fprintln(personaNoticeWriter, personaAliasRemapNotice)
+	persisted.Persona = string(model.PersonaNeutral)
+	if err := state.Write(homeDir, *persisted); err != nil {
+		return fmt.Errorf("persist remapped persona: %w", err)
+	}
+	return nil
+}
+
 // RunSyncWithSelection is the programmatic entry point for sync.
 // It skips flag parsing and agent discovery — the caller provides the homeDir
 // and a fully-built Selection (agents + components + options).
@@ -1459,6 +1475,10 @@ func RunSyncWithSelection(homeDir string, selection model.Selection) (SyncResult
 		if err := state.Write(homeDir, persistedState); err != nil {
 			return result, fmt.Errorf("persist migrated community tool selection: %w", err)
 		}
+	}
+
+	if err := migratePersistedPersonaAlias(homeDir, &persistedState, persistedStateErr); err != nil {
+		return result, err
 	}
 
 	return result, nil

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -1366,7 +1366,7 @@ func applyResolvedPersona(selection *model.Selection, persisted string) {
 		return
 	}
 	if persisted != "" {
-		if id, err := normalizePersona(persisted); err == nil {
+		if id, _, err := normalizePersona(persisted); err == nil {
 			selection.Persona = id
 			return
 		}

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -1386,11 +1386,13 @@ func migratePersistedPersonaAlias(homeDir string, persisted *state.InstallState,
 	if persistedErr != nil || persisted.Persona != string(model.PersonaGentlemanNeutralArtifacts) {
 		return nil
 	}
-	fmt.Fprintln(personaNoticeWriter, personaAliasRemapNotice)
 	persisted.Persona = string(model.PersonaNeutral)
 	if err := state.Write(homeDir, *persisted); err != nil {
 		return fmt.Errorf("persist remapped persona: %w", err)
 	}
+	// Notice only after the rewrite is durably persisted: a failed write must
+	// not tell the user the remap happened.
+	fmt.Fprintln(personaNoticeWriter, personaAliasRemapNotice)
 	return nil
 }
 
@@ -1412,6 +1414,14 @@ func RunSyncWithSelection(homeDir string, selection model.Selection) (SyncResult
 		var persistedPersona string
 		persistedPersona = persistedState.Persona
 		applyResolvedPersona(&selection, persistedPersona)
+	}
+
+	// Migrate a persisted legacy alias BEFORE any early return: a no-agent
+	// no-op sync and a failing pipeline must still leave state.json remapped,
+	// otherwise the one-time migration never fires for those users. State
+	// records intent — the next sync applies the neutral assets.
+	if err := migratePersistedPersonaAlias(homeDir, &persistedState, persistedStateErr); err != nil {
+		return SyncResult{Agents: agentIDs, Selection: selection}, err
 	}
 
 	result := SyncResult{
@@ -1475,10 +1485,6 @@ func RunSyncWithSelection(homeDir string, selection model.Selection) (SyncResult
 		if err := state.Write(homeDir, persistedState); err != nil {
 			return result, fmt.Errorf("persist migrated community tool selection: %w", err)
 		}
-	}
-
-	if err := migratePersistedPersonaAlias(homeDir, &persistedState, persistedStateErr); err != nil {
-		return result, err
 	}
 
 	return result, nil

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -569,7 +569,10 @@ func (r *syncRuntime) stagePlan() pipeline.StagePlan {
 // syncBackupTargets returns the file paths that need to be backed up
 // before sync executes. Uses syncComponentPaths so that the backup/verify
 // contract matches the actual files sync touches (which differ from install
-// for ComponentPersona — see syncComponentPaths).
+// for ComponentPersona, see syncComponentPaths). One deliberate exception:
+// persona backup also captures the non-selected managed output-style file so a
+// failed persona switch can be rolled back (verification still declares only
+// the selected file).
 func syncBackupTargets(homeDir, workspaceDir string, selection model.Selection, adapters []agents.Adapter) ([]string, error) {
 	paths := map[string]struct{}{}
 	for _, component := range selection.Components {
@@ -581,6 +584,13 @@ func syncBackupTargets(homeDir, workspaceDir string, selection model.Selection, 
 				if adapter.Agent() == model.AgentClaudeCode {
 					paths[adapter.MCPConfigPath(homeDir, "engram")] = struct{}{}
 				}
+			}
+		}
+		if component == model.ComponentPersona {
+			for _, path := range managedOutputStyleBackupPaths(selection, adapters, func(a agents.Adapter) string {
+				return a.OutputStyleDir(componentInjectionDir(homeDir, workspaceDir, a))
+			}) {
+				paths[path] = struct{}{}
 			}
 		}
 	}
@@ -753,6 +763,39 @@ func managedOutputStyleFile(persona model.PersonaID) string {
 	default:
 		return ""
 	}
+}
+
+// managedOutputStyleFiles returns every managed output-style filename.
+func managedOutputStyleFiles() []string {
+	return []string{"gentleman.md", "neutral.md"}
+}
+
+// managedOutputStyleBackupPaths returns the full set of managed output-style
+// file paths for the adapters. Backup enumeration needs all of them, not only
+// the selected persona's: switching personas removes the previously selected
+// file (persona inject step 3b), so the pre-run snapshot must hold it to roll a
+// failed switch back. This is intentionally backup-only. Post-apply
+// verification keeps declaring just the selected persona's file, since the other
+// one is correctly absent after a switch. outputStyleDir resolves the adapter's
+// output-style directory in the caller's scope (install and sync differ).
+func managedOutputStyleBackupPaths(selection model.Selection, adapters []agents.Adapter, outputStyleDir func(agents.Adapter) string) []string {
+	if managedOutputStyleName(selection.Persona) == "" {
+		return nil
+	}
+	var paths []string
+	for _, adapter := range adapters {
+		if !adapter.SupportsOutputStyles() {
+			continue
+		}
+		dir := outputStyleDir(adapter)
+		if dir == "" {
+			continue
+		}
+		for _, styleFile := range managedOutputStyleFiles() {
+			paths = append(paths, filepath.Join(dir, styleFile))
+		}
+	}
+	return paths
 }
 
 // componentSyncStep is the sync-specific apply step.

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -1426,7 +1426,7 @@ func applyResolvedPersona(selection *model.Selection, persisted string) {
 // once. State that predates persona persistence, explicit gentleman state,
 // and unreadable state are untouched.
 func migratePersistedPersonaAlias(homeDir string, persisted *state.InstallState, persistedErr error) error {
-	if persistedErr != nil || persisted.Persona != string(model.PersonaGentlemanNeutralArtifacts) {
+	if persistedErr != nil || persisted == nil || persisted.Persona != string(model.PersonaGentlemanNeutralArtifacts) {
 		return nil
 	}
 	persisted.Persona = string(model.PersonaNeutral)

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -737,7 +737,7 @@ func managedOutputStyleName(persona model.PersonaID) string {
 	switch {
 	case isGentlemanConversationPersona(persona):
 		return "Gentleman"
-	case persona == model.PersonaNeutral:
+	case persona == model.PersonaNeutral, persona == model.PersonaGentlemanNeutralArtifacts:
 		return "Neutral"
 	default:
 		return ""

--- a/internal/cli/sync_persona_migration_test.go
+++ b/internal/cli/sync_persona_migration_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/gentleman-programming/gentle-ai/internal/model"
-	"github.com/gentleman-programming/gentle-ai/internal/state"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/state"
 )
 
 var errStateUnreadableForTest = errors.New("state unreadable")

--- a/internal/cli/sync_persona_migration_test.go
+++ b/internal/cli/sync_persona_migration_test.go
@@ -55,3 +55,37 @@ func TestMigratePersistedPersonaAliasSkipsUnreadableState(t *testing.T) {
 		t.Fatalf("migrate with read error must be a no-op, got %v", err)
 	}
 }
+
+// TestRunSyncWithSelectionMigratesAliasOnNoOpSync pins the early-return path:
+// a sync that discovers zero agents must still migrate a persisted legacy
+// alias, otherwise the one-time migration never fires for those users.
+func TestRunSyncWithSelectionMigratesAliasOnNoOpSync(t *testing.T) {
+	var buf bytes.Buffer
+	previous := personaNoticeWriter
+	personaNoticeWriter = &buf
+	defer func() { personaNoticeWriter = previous }()
+
+	homeDir := t.TempDir()
+	if err := state.Write(homeDir, state.InstallState{Persona: string(model.PersonaGentlemanNeutralArtifacts)}); err != nil {
+		t.Fatalf("seed state: %v", err)
+	}
+
+	result, err := RunSyncWithSelection(homeDir, model.Selection{})
+	if err != nil {
+		t.Fatalf("RunSyncWithSelection() error = %v", err)
+	}
+	if !result.NoOp {
+		t.Fatal("zero-agent sync must report NoOp")
+	}
+
+	reread, err := state.Read(homeDir)
+	if err != nil {
+		t.Fatalf("re-read state: %v", err)
+	}
+	if reread.Persona != string(model.PersonaNeutral) {
+		t.Fatalf("persisted persona = %q, want %q after no-op sync", reread.Persona, model.PersonaNeutral)
+	}
+	if !strings.Contains(buf.String(), personaAliasRemapNotice) {
+		t.Fatalf("notice not printed on no-op sync; got %q", buf.String())
+	}
+}

--- a/internal/cli/sync_persona_migration_test.go
+++ b/internal/cli/sync_persona_migration_test.go
@@ -1,0 +1,57 @@
+package cli
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/internal/model"
+	"github.com/gentleman-programming/gentle-ai/internal/state"
+)
+
+var errStateUnreadableForTest = errors.New("state unreadable")
+
+func TestMigratePersistedPersonaAliasRewritesStateOnce(t *testing.T) {
+	var buf bytes.Buffer
+	previous := personaNoticeWriter
+	personaNoticeWriter = &buf
+	defer func() { personaNoticeWriter = previous }()
+
+	homeDir := t.TempDir()
+	persisted := state.InstallState{Persona: string(model.PersonaGentlemanNeutralArtifacts)}
+	if err := state.Write(homeDir, persisted); err != nil {
+		t.Fatalf("seed state: %v", err)
+	}
+
+	if err := migratePersistedPersonaAlias(homeDir, &persisted, nil); err != nil {
+		t.Fatalf("migratePersistedPersonaAlias() error = %v", err)
+	}
+
+	reread, err := state.Read(homeDir)
+	if err != nil {
+		t.Fatalf("re-read state: %v", err)
+	}
+	if reread.Persona != string(model.PersonaNeutral) {
+		t.Fatalf("persisted persona = %q, want %q", reread.Persona, model.PersonaNeutral)
+	}
+	if !strings.Contains(buf.String(), personaAliasRemapNotice) {
+		t.Fatalf("notice not printed; got %q", buf.String())
+	}
+
+	// Second run: state already neutral — no notice, no rewrite.
+	buf.Reset()
+	if err := migratePersistedPersonaAlias(homeDir, &reread, nil); err != nil {
+		t.Fatalf("second migrate: %v", err)
+	}
+	if buf.Len() != 0 {
+		t.Fatalf("second run printed %q, want silence", buf.String())
+	}
+}
+
+func TestMigratePersistedPersonaAliasSkipsUnreadableState(t *testing.T) {
+	persisted := state.InstallState{Persona: string(model.PersonaGentlemanNeutralArtifacts)}
+	if err := migratePersistedPersonaAlias(t.TempDir(), &persisted, errStateUnreadableForTest); err != nil {
+		t.Fatalf("migrate with read error must be a no-op, got %v", err)
+	}
+}

--- a/internal/cli/sync_test.go
+++ b/internal/cli/sync_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gentleman-programming/gentle-ai/v2/internal/components/filemerge"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/pipeline"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/planner"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/state"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/verify"
 )
@@ -3777,6 +3778,62 @@ func TestSyncPersonaPathsDeclareManagedClaudeOutputStyle(t *testing.T) {
 				t.Fatalf("syncPersonaPaths(%q) included wrong managed style %q; got %v", tt.persona, tt.unwanted, paths)
 			}
 		})
+	}
+}
+
+// TestSyncBackupTargetsCaptureBothManagedOutputStyles pins the persona-switch
+// backup fix: the pre-sync snapshot must capture BOTH managed output-style
+// files so switching personas (which removes the previously selected file) can
+// be rolled back. Verification stays on the selected file (asserted by
+// TestSyncPersonaPathsDeclareManagedClaudeOutputStyle).
+func TestSyncBackupTargetsCaptureBothManagedOutputStyles(t *testing.T) {
+	home := t.TempDir()
+	reg, _ := agents.NewDefaultRegistry()
+	a, _ := reg.Get(model.AgentClaudeCode)
+
+	gentleman := filepath.Join(home, ".claude", "output-styles", "gentleman.md")
+	neutral := filepath.Join(home, ".claude", "output-styles", "neutral.md")
+
+	for _, persona := range []model.PersonaID{model.PersonaGentleman, model.PersonaNeutral} {
+		selection := model.Selection{Persona: persona, Components: []model.ComponentID{model.ComponentPersona}}
+		targets, err := syncBackupTargets(home, "", selection, []agents.Adapter{a})
+		if err != nil {
+			t.Fatalf("syncBackupTargets(%q) error = %v", persona, err)
+		}
+
+		if !containsPath(targets, gentleman) {
+			t.Errorf("syncBackupTargets(%q) missing gentleman.md; got %v", persona, targets)
+		}
+		if !containsPath(targets, neutral) {
+			t.Errorf("syncBackupTargets(%q) missing neutral.md; got %v", persona, targets)
+		}
+	}
+}
+
+// TestBackupTargetsCaptureBothManagedOutputStyles is the install-side twin.
+func TestBackupTargetsCaptureBothManagedOutputStyles(t *testing.T) {
+	home := t.TempDir()
+
+	gentleman := filepath.Join(home, ".claude", "output-styles", "gentleman.md")
+	neutral := filepath.Join(home, ".claude", "output-styles", "neutral.md")
+
+	for _, persona := range []model.PersonaID{model.PersonaGentleman, model.PersonaNeutral} {
+		selection := model.Selection{Persona: persona, Components: []model.ComponentID{model.ComponentPersona}}
+		resolved := planner.ResolvedPlan{
+			Agents:            []model.AgentID{model.AgentClaudeCode},
+			OrderedComponents: []model.ComponentID{model.ComponentPersona},
+		}
+		targets, err := backupTargets(home, "", ScopeGlobal, selection, resolved)
+		if err != nil {
+			t.Fatalf("backupTargets(%q) error = %v", persona, err)
+		}
+
+		if !containsPath(targets, gentleman) {
+			t.Errorf("backupTargets(%q) missing gentleman.md; got %v", persona, targets)
+		}
+		if !containsPath(targets, neutral) {
+			t.Errorf("backupTargets(%q) missing neutral.md; got %v", persona, targets)
+		}
 	}
 }
 

--- a/internal/cli/validate.go
+++ b/internal/cli/validate.go
@@ -2,6 +2,8 @@ package cli
 
 import (
 	"fmt"
+	"io"
+	"os"
 	"sort"
 	"strings"
 
@@ -30,9 +32,12 @@ func NormalizeInstallFlags(flags InstallFlags, detection system.DetectionResult)
 	}
 	selection.Agents = unique(agents)
 
-	persona, err := normalizePersona(flags.Persona)
+	persona, personaRemapped, err := normalizePersona(flags.Persona)
 	if err != nil {
 		return InstallInput{}, err
+	}
+	if personaRemapped {
+		fmt.Fprintln(personaNoticeWriter, personaAliasRemapNotice)
 	}
 	selection.Persona = persona
 
@@ -77,16 +82,29 @@ func NormalizeInstallFlags(flags InstallFlags, detection system.DetectionResult)
 	return InstallInput{Selection: selection, Scope: scope, Channel: channel, DryRun: flags.DryRun}, nil
 }
 
-func normalizePersona(value string) (model.PersonaID, error) {
+// personaAliasRemapNotice is printed whenever the legacy
+// gentleman-neutral-artifacts alias is remapped to the neutral persona.
+const personaAliasRemapNotice = `"gentleman-neutral-artifacts" now maps to "neutral". For a voseo conversation use --persona gentleman.`
+
+// personaNoticeWriter is swappable in tests.
+var personaNoticeWriter io.Writer = os.Stderr
+
+// normalizePersona resolves a --persona flag or persisted state value.
+// The second return is true when the legacy gentleman-neutral-artifacts
+// alias was remapped to neutral: its name promised a neutral tone, so the
+// name now wins; users who want voseo have --persona gentleman.
+func normalizePersona(value string) (model.PersonaID, bool, error) {
 	if strings.TrimSpace(value) == "" {
-		return model.PersonaGentleman, nil
+		return model.PersonaGentleman, false, nil
 	}
 
 	switch model.PersonaID(value) {
-	case model.PersonaGentleman, model.PersonaGentlemanNeutralArtifacts, model.PersonaNeutral, model.PersonaCustom:
-		return model.PersonaID(value), nil
+	case model.PersonaGentlemanNeutralArtifacts:
+		return model.PersonaNeutral, true, nil
+	case model.PersonaGentleman, model.PersonaNeutral, model.PersonaCustom:
+		return model.PersonaID(value), false, nil
 	default:
-		return "", fmt.Errorf("unsupported persona %q", value)
+		return "", false, fmt.Errorf("unsupported persona %q", value)
 	}
 }
 

--- a/internal/cli/validate.go
+++ b/internal/cli/validate.go
@@ -55,6 +55,21 @@ func NormalizeInstallFlags(flags InstallFlags, detection system.DetectionResult)
 		components = piOnlyComponents()
 	}
 
+	// An explicit --persona is a direct request to apply that persona: force
+	// the persona component even when --component narrows the set. PersonaCustom
+	// means "keep the persona unmanaged", so it never forces the component.
+	if strings.TrimSpace(flags.Persona) != "" && persona != model.PersonaCustom {
+		hasPersona := false
+		for _, component := range components {
+			if component == model.ComponentPersona {
+				hasPersona = true
+			}
+		}
+		if !hasPersona {
+			components = append(components, model.ComponentPersona)
+		}
+	}
+
 	selection.Components = components
 
 	skills, err := normalizeSkills(flags.Skills)

--- a/internal/components/filemerge/writer_test.go
+++ b/internal/components/filemerge/writer_test.go
@@ -250,3 +250,46 @@ func TestWriteFileAtomicPropagatesUnexpectedSyncDirErrorOnWindows(t *testing.T) 
 		t.Fatalf("WriteFileAtomic() error = %v, want wrapped boom", err)
 	}
 }
+
+// TestWriteFileAtomicPreservesOriginalOnRenameFailure proves the atomicity
+// guarantee a reviewer worried about: when the rename step fails, the existing
+// file is left byte-identical, never partially written or corrupted.
+func TestWriteFileAtomicPreservesOriginalOnRenameFailure(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	original := []byte("{\"original\":true}\n")
+	if err := os.WriteFile(path, original, 0o644); err != nil {
+		t.Fatalf("seed original file: %v", err)
+	}
+
+	boom := errors.New("rename boom")
+	origRename := renameFn
+	t.Cleanup(func() { renameFn = origRename })
+	renameFn = func(string, string) error { return boom }
+
+	_, err := WriteFileAtomic(path, []byte("{\"new\":true}\n"), 0o644)
+	if err == nil {
+		t.Fatal("WriteFileAtomic() error = nil, want rename failure")
+	}
+	if !errors.Is(err, boom) {
+		t.Fatalf("WriteFileAtomic() error = %v, want wrapped rename boom", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read file after failed rename: %v", err)
+	}
+	if !bytes.Equal(got, original) {
+		t.Fatalf("file after failed rename = %q, want the untouched original %q", got, original)
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read dir: %v", err)
+	}
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), ".gentle-ai-") {
+			t.Fatalf("temp file %q left behind after failed rename", entry.Name())
+		}
+	}
+}

--- a/internal/components/persona/inject.go
+++ b/internal/components/persona/inject.go
@@ -61,6 +61,14 @@ func InjectForSync(homeDir string, adapter agents.Adapter, persona model.Persona
 // syncManaged is the internal flag previously called `markdownOnly`.
 // When true the OpenCode/Kilocode agent overlay is skipped (see InjectForSync).
 func injectInternal(homeDir string, adapter agents.Adapter, persona model.PersonaID, syncManaged bool) (InjectionResult, error) {
+	// Normalize the legacy alias at the single entry point so every branch
+	// below (persona content, output-style write, Kimi module selection,
+	// cleanup) sees one canonical neutral identity. CLI callers already pass
+	// normalized IDs (cli.normalizePersona, internal/cli/validate.go); this
+	// guards direct callers.
+	if persona == model.PersonaGentlemanNeutralArtifacts {
+		persona = model.PersonaNeutral
+	}
 	if !adapter.SupportsSystemPrompt() {
 		return InjectionResult{}, nil
 	}
@@ -490,7 +498,8 @@ func shouldStripManagedLegacyPersona(existing string) bool {
 
 // isGentlemanConversationPersona reports whether the persona keeps the voseo
 // conversation tone. The gentleman-neutral-artifacts legacy alias is remapped
-// to neutral (see normalizePersona) and is intentionally NOT gentleman here.
+// to neutral (cli.normalizePersona in internal/cli/validate.go, mirrored at
+// the injectInternal entry) and is intentionally NOT gentleman here.
 func isGentlemanConversationPersona(persona model.PersonaID) bool {
 	return persona == model.PersonaGentleman
 }

--- a/internal/components/persona/inject.go
+++ b/internal/components/persona/inject.go
@@ -488,8 +488,11 @@ func shouldStripManagedLegacyPersona(existing string) bool {
 	return strings.Contains(existing, "<!-- gentle-ai:persona -->")
 }
 
+// isGentlemanConversationPersona reports whether the persona keeps the voseo
+// conversation tone. The gentleman-neutral-artifacts legacy alias is remapped
+// to neutral (see normalizePersona) and is intentionally NOT gentleman here.
 func isGentlemanConversationPersona(persona model.PersonaID) bool {
-	return persona == model.PersonaGentleman || persona == model.PersonaGentlemanNeutralArtifacts
+	return persona == model.PersonaGentleman
 }
 
 // residualChannel reports whether the adapter already delivers tone/language/
@@ -506,7 +509,7 @@ func residualChannel(adapter agents.Adapter) bool {
 // personaContent returns the persona asset for the given agent and persona.
 func personaContent(agent model.AgentID, persona model.PersonaID, residualContentAvailable bool) string {
 	switch persona {
-	case model.PersonaNeutral:
+	case model.PersonaNeutral, model.PersonaGentlemanNeutralArtifacts:
 		return neutralPersonaContent(agent, residualContentAvailable)
 	case model.PersonaCustom:
 		return ""

--- a/internal/components/persona/inject_switch_test.go
+++ b/internal/components/persona/inject_switch_test.go
@@ -1,0 +1,216 @@
+package persona
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/internal/model"
+	"github.com/gentleman-programming/gentle-ai/internal/system"
+)
+
+// testOutputStyleAdapter is a minimal test adapter that supports output styles.
+type testOutputStyleAdapter struct {
+	homeDir string
+}
+
+func newOutputStyleTestAdapter(t *testing.T, homeDir string) *testOutputStyleAdapter {
+	// Ensure directories exist.
+	outputStyleDir := filepath.Join(homeDir, ".test", "output-styles")
+	if err := os.MkdirAll(outputStyleDir, 0o755); err != nil {
+		t.Fatalf("create output style dir: %v", err)
+	}
+
+	settingsDir := filepath.Join(homeDir, ".test")
+	if err := os.MkdirAll(settingsDir, 0o755); err != nil {
+		t.Fatalf("create settings dir: %v", err)
+	}
+
+	// Seed empty settings.json.
+	settingsPath := filepath.Join(settingsDir, "settings.json")
+	if err := os.WriteFile(settingsPath, []byte("{}"), 0o644); err != nil {
+		t.Fatalf("seed settings.json: %v", err)
+	}
+
+	return &testOutputStyleAdapter{homeDir: homeDir}
+}
+
+// --- Adapter interface implementation ---
+
+func (a *testOutputStyleAdapter) Agent() model.AgentID {
+	return model.AgentClaudeCode
+}
+
+func (a *testOutputStyleAdapter) Tier() model.SupportTier {
+	return model.TierFull
+}
+
+func (a *testOutputStyleAdapter) Detect(_ context.Context, _ string) (bool, string, string, bool, error) {
+	return false, "", "", false, nil
+}
+
+func (a *testOutputStyleAdapter) SupportsAutoInstall() bool {
+	return false
+}
+
+func (a *testOutputStyleAdapter) InstallCommand(_ system.PlatformProfile) ([][]string, error) {
+	return nil, nil
+}
+
+func (a *testOutputStyleAdapter) GlobalConfigDir(_ string) string {
+	return ""
+}
+
+func (a *testOutputStyleAdapter) SystemPromptDir(_ string) string {
+	return ""
+}
+
+func (a *testOutputStyleAdapter) SystemPromptFile(_ string) string {
+	return filepath.Join(a.homeDir, ".test", "SYSTEM.md")
+}
+
+func (a *testOutputStyleAdapter) SkillsDir(_ string) string {
+	return ""
+}
+
+func (a *testOutputStyleAdapter) SettingsPath(_ string) string {
+	return filepath.Join(a.homeDir, ".test", "settings.json")
+}
+
+func (a *testOutputStyleAdapter) SystemPromptStrategy() model.SystemPromptStrategy {
+	return model.StrategyMarkdownSections
+}
+
+func (a *testOutputStyleAdapter) MCPStrategy() model.MCPStrategy {
+	return model.StrategyMCPConfigFile
+}
+
+func (a *testOutputStyleAdapter) MCPConfigPath(_ string, _ string) string {
+	return ""
+}
+
+func (a *testOutputStyleAdapter) SupportsOutputStyles() bool {
+	return true
+}
+
+func (a *testOutputStyleAdapter) OutputStyleDir(_ string) string {
+	return filepath.Join(a.homeDir, ".test", "output-styles")
+}
+
+func (a *testOutputStyleAdapter) SupportsSlashCommands() bool {
+	return false
+}
+
+func (a *testOutputStyleAdapter) CommandsDir(_ string) string {
+	return ""
+}
+
+func (a *testOutputStyleAdapter) SupportsSubAgents() bool {
+	return false
+}
+
+func (a *testOutputStyleAdapter) SubAgentsDir(_ string) string {
+	return ""
+}
+
+func (a *testOutputStyleAdapter) EmbeddedSubAgentsDir() string {
+	return ""
+}
+
+func (a *testOutputStyleAdapter) SupportsSkills() bool {
+	return false
+}
+
+func (a *testOutputStyleAdapter) SupportsSystemPrompt() bool {
+	return true
+}
+
+func (a *testOutputStyleAdapter) SupportsMCP() bool {
+	return false
+}
+
+// --- Tests ---
+
+// TestInjectSwitchGentlemanToNeutralRemovesGentlemanArtifacts pins the switch
+// scenario end to end: after a gentleman install, injecting neutral must leave
+// no gentleman output style and must select the Neutral managed style.
+func TestInjectSwitchGentlemanToNeutralRemovesGentlemanArtifacts(t *testing.T) {
+	homeDir := t.TempDir()
+	adapter := newOutputStyleTestAdapter(t, homeDir)
+
+	if _, err := Inject(homeDir, adapter, model.PersonaGentleman); err != nil {
+		t.Fatalf("gentleman install: %v", err)
+	}
+	gentlemanStyle := filepath.Join(adapter.OutputStyleDir(homeDir), "gentleman.md")
+	if _, err := os.Stat(gentlemanStyle); err != nil {
+		t.Fatalf("precondition: gentleman.md missing after gentleman install: %v", err)
+	}
+
+	if _, err := Inject(homeDir, adapter, model.PersonaNeutral); err != nil {
+		t.Fatalf("neutral switch: %v", err)
+	}
+
+	if _, err := os.Stat(gentlemanStyle); !os.IsNotExist(err) {
+		t.Fatalf("gentleman.md must be removed on switch to neutral, stat err = %v", err)
+	}
+	neutralStyle := filepath.Join(adapter.OutputStyleDir(homeDir), "neutral.md")
+	if _, err := os.Stat(neutralStyle); err != nil {
+		t.Fatalf("neutral.md missing after switch: %v", err)
+	}
+	settings, err := os.ReadFile(adapter.SettingsPath(homeDir))
+	if err != nil {
+		t.Fatalf("read settings: %v", err)
+	}
+	if !strings.Contains(string(settings), `"outputStyle": "Neutral"`) {
+		t.Fatalf("settings must select the Neutral style, got:\n%s", settings)
+	}
+	if strings.Contains(string(settings), `"outputStyle": "Gentleman"`) {
+		t.Fatal("settings still selects the Gentleman style after switch")
+	}
+}
+
+// TestInjectNeutralTwiceIsIdempotent pins sync stability: a second neutral
+// injection must not report changes.
+func TestInjectNeutralTwiceIsIdempotent(t *testing.T) {
+	homeDir := t.TempDir()
+	adapter := newOutputStyleTestAdapter(t, homeDir)
+
+	if _, err := Inject(homeDir, adapter, model.PersonaNeutral); err != nil {
+		t.Fatalf("first inject: %v", err)
+	}
+	second, err := Inject(homeDir, adapter, model.PersonaNeutral)
+	if err != nil {
+		t.Fatalf("second inject: %v", err)
+	}
+	if second.Changed {
+		t.Fatalf("second neutral inject reported changes: %v", second.Files)
+	}
+}
+
+// TestInjectSwitchToleratesMalformedSettings pins the PR #289 review finding:
+// JSONC or otherwise malformed settings.json must not make the switch hard-fail,
+// and the gentleman output-style file must still be removed (the file cleanup
+// does not depend on settings parsing).
+func TestInjectSwitchToleratesMalformedSettings(t *testing.T) {
+	homeDir := t.TempDir()
+	adapter := newOutputStyleTestAdapter(t, homeDir)
+
+	if _, err := Inject(homeDir, adapter, model.PersonaGentleman); err != nil {
+		t.Fatalf("gentleman install: %v", err)
+	}
+	// Simulate a user-managed JSONC settings file (comments are invalid JSON).
+	malformed := []byte("{\n  // user comment\n  \"outputStyle\": \"Gentleman\"\n}\n")
+	if err := os.WriteFile(adapter.SettingsPath(homeDir), malformed, 0o644); err != nil {
+		t.Fatalf("seed malformed settings: %v", err)
+	}
+
+	if _, err := Inject(homeDir, adapter, model.PersonaNeutral); err != nil {
+		t.Fatalf("neutral switch over malformed settings must not hard-fail: %v", err)
+	}
+	gentlemanStyle := filepath.Join(adapter.OutputStyleDir(homeDir), "gentleman.md")
+	if _, err := os.Stat(gentlemanStyle); !os.IsNotExist(err) {
+		t.Fatalf("gentleman.md must be removed even when settings are malformed, stat err = %v", err)
+	}
+}

--- a/internal/components/persona/inject_switch_test.go
+++ b/internal/components/persona/inject_switch_test.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/gentleman-programming/gentle-ai/internal/model"
-	"github.com/gentleman-programming/gentle-ai/internal/system"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/system"
 )
 
 // testOutputStyleAdapter is a minimal test adapter that supports output styles.
@@ -200,8 +200,10 @@ func TestInjectSwitchToleratesMalformedSettings(t *testing.T) {
 	if _, err := Inject(homeDir, adapter, model.PersonaGentleman); err != nil {
 		t.Fatalf("gentleman install: %v", err)
 	}
-	// Simulate a user-managed JSONC settings file (comments are invalid JSON).
-	malformed := []byte("{\n  // user comment\n  \"outputStyle\": \"Gentleman\"\n}\n")
+	// Seed genuinely non-JSON content. JSONC comments and trailing commas are
+	// normalized by the merge helper (filemerge.normalizeJSON), so they would
+	// not exercise the tolerate-malformed path. Bare text does.
+	malformed := []byte("this is not json at all\n")
 	if err := os.WriteFile(adapter.SettingsPath(homeDir), malformed, 0o644); err != nil {
 		t.Fatalf("seed malformed settings: %v", err)
 	}

--- a/internal/components/persona/inject_test.go
+++ b/internal/components/persona/inject_test.go
@@ -2024,7 +2024,6 @@ func TestPersonaContentHermesGentleman(t *testing.T) {
 		persona model.PersonaID
 	}{
 		{"gentleman", model.PersonaGentleman},
-		{"gentleman-neutral-artifacts", model.PersonaGentlemanNeutralArtifacts},
 	}
 
 	for _, tt := range tests {
@@ -2047,6 +2046,19 @@ func TestPersonaContentHermesGentleman(t *testing.T) {
 				t.Fatal("hermes gentleman persona is byte-identical to generic — Hermes-specific asset not used")
 			}
 		})
+	}
+}
+
+// TestPersonaContentAliasRoutesToNeutral verifies that the gentleman-neutral-artifacts
+// alias is routed to neutral content, not gentleman content.
+func TestPersonaContentAliasRoutesToNeutral(t *testing.T) {
+	alias := personaContent(model.AgentClaudeCode, model.PersonaGentlemanNeutralArtifacts, false)
+	neutral := personaContent(model.AgentClaudeCode, model.PersonaNeutral, false)
+	if alias != neutral {
+		t.Fatal("gentleman-neutral-artifacts must produce identical content to neutral")
+	}
+	if alias == "" {
+		t.Fatal("alias persona content must not be empty")
 	}
 }
 

--- a/internal/components/persona/persona_language_contract_test.go
+++ b/internal/components/persona/persona_language_contract_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
 )
 
-func TestInjectGentlemanNeutralArtifactsUsesGentlemanConversationWithArtifactBoundary(t *testing.T) {
+func TestInjectGentlemanNeutralArtifactsRoutesToNeutralContent(t *testing.T) {
 	home := t.TempDir()
 
 	result, err := Inject(home, opencodeAdapter(), model.PersonaGentlemanNeutralArtifacts)
@@ -25,8 +25,14 @@ func TestInjectGentlemanNeutralArtifactsUsesGentlemanConversationWithArtifactBou
 		t.Fatalf("ReadFile() error = %v", err)
 	}
 	text := string(content)
+
+	// The alias routes to neutral content, not gentleman
+	if strings.Contains(text, "Rioplatense") {
+		t.Fatalf("alias should route to neutral — found gentleman tone marker 'Rioplatense'")
+	}
+
+	// Verify neutral content is present
 	for _, want := range []string{
-		"Rioplatense",
 		"Generated technical artifacts default to English",
 		"Public/contextual comments follow the target context language",
 		"If the selected reply language is English, every part of the direct reply must be English",

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -95,7 +95,10 @@ const (
 type PersonaID string
 
 const (
-	PersonaGentleman                 PersonaID = "gentleman"
+	PersonaGentleman PersonaID = "gentleman"
+	// PersonaGentlemanNeutralArtifacts is a legacy alias accepted for backward
+	// compatibility and remapped to PersonaNeutral at normalization time (see
+	// cli.normalizePersona). It is never offered as a choice.
 	PersonaGentlemanNeutralArtifacts PersonaID = "gentleman-neutral-artifacts"
 	PersonaNeutral                   PersonaID = "neutral"
 	PersonaCustom                    PersonaID = "custom"

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -97,8 +97,8 @@ type PersonaID string
 const (
 	PersonaGentleman PersonaID = "gentleman"
 	// PersonaGentlemanNeutralArtifacts is a legacy alias accepted for backward
-	// compatibility and remapped to PersonaNeutral at normalization time (see
-	// cli.normalizePersona). It is never offered as a choice.
+	// compatibility. The CLI and sync normalization treat it as PersonaNeutral,
+	// and it is never offered as a selectable choice.
 	PersonaGentlemanNeutralArtifacts PersonaID = "gentleman-neutral-artifacts"
 	PersonaNeutral                   PersonaID = "neutral"
 	PersonaCustom                    PersonaID = "custom"

--- a/internal/tui/screens/persona.go
+++ b/internal/tui/screens/persona.go
@@ -8,12 +8,15 @@ import (
 )
 
 func PersonaOptions() []model.PersonaID {
-	return []model.PersonaID{model.PersonaGentleman, model.PersonaGentlemanNeutralArtifacts, model.PersonaNeutral, model.PersonaCustom}
+	return []model.PersonaID{model.PersonaGentleman, model.PersonaNeutral, model.PersonaCustom}
 }
 
 var personaDescriptions = map[model.PersonaID]string{
-	model.PersonaGentleman:                 "Voseo conversation; English technical artifacts",
-	model.PersonaGentlemanNeutralArtifacts: "Voseo conversation; English technical artifacts (legacy alias)",
+	model.PersonaGentleman: "Voseo conversation; English technical artifacts",
+	// The legacy alias is remapped at normalization time and no longer offered
+	// in the picker; the entry stays so the review screen can label persisted
+	// state that has not been migrated yet.
+	model.PersonaGentlemanNeutralArtifacts: "No regional conversation tone; English technical artifacts (legacy alias, remapped)",
 	model.PersonaNeutral:                   "No regional conversation tone; English technical artifacts",
 	model.PersonaCustom:                    "Do not install a managed persona; choose themes/logo on the next screens",
 }

--- a/internal/tui/screens/persona_language_contract_test.go
+++ b/internal/tui/screens/persona_language_contract_test.go
@@ -7,16 +7,11 @@ import (
 	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
 )
 
-func TestPersonaOptionsIncludeGentlemanNeutralArtifacts(t *testing.T) {
-	options := PersonaOptions()
-	found := false
-	for _, option := range options {
+func TestPersonaOptionsExcludeGentlemanNeutralArtifacts(t *testing.T) {
+	for _, option := range PersonaOptions() {
 		if option == model.PersonaGentlemanNeutralArtifacts {
-			found = true
+			t.Fatalf("PersonaOptions() still offers the remapped legacy alias %q", option)
 		}
-	}
-	if !found {
-		t.Fatalf("PersonaOptions() = %v, missing %q", options, model.PersonaGentlemanNeutralArtifacts)
 	}
 }
 
@@ -57,15 +52,15 @@ func TestPersonaDescriptionsSeparateToneFromArtifactLanguage(t *testing.T) {
 			t.Fatalf("persona %q must state that technical artifacts are English: %q", persona, description)
 		}
 		mentionsVoseo := strings.Contains(strings.ToLower(description), "voseo")
-		isGentleman := persona == model.PersonaGentleman || persona == model.PersonaGentlemanNeutralArtifacts
+		isGentleman := persona == model.PersonaGentleman
 		if mentionsVoseo != isGentleman {
 			t.Fatalf("persona %q voseo claim = %v, want %v (only Gentleman personas carry a regional tone): %q",
 				persona, mentionsVoseo, isGentleman, description)
 		}
 	}
 
-	if personaDescriptions[model.PersonaGentleman] == personaDescriptions[model.PersonaGentlemanNeutralArtifacts] {
-		t.Fatal("the Gentleman persona and its legacy alias must stay distinguishable in the selector")
+	if personaDescriptions[model.PersonaNeutral] == personaDescriptions[model.PersonaGentlemanNeutralArtifacts] {
+		t.Fatal("the neutral persona and its legacy alias must stay distinguishable in the review label")
 	}
 }
 
@@ -75,7 +70,6 @@ func TestPersonaDescriptionsSeparateToneFromArtifactLanguage(t *testing.T) {
 func TestRenderPersonaShowsEveryManagedDescription(t *testing.T) {
 	for _, persona := range []model.PersonaID{
 		model.PersonaGentleman,
-		model.PersonaGentlemanNeutralArtifacts,
 		model.PersonaNeutral,
 	} {
 		out := RenderPersona(persona, 0)

--- a/internal/tui/screens/review_test.go
+++ b/internal/tui/screens/review_test.go
@@ -158,7 +158,7 @@ func TestRenderReviewSummarizesPersonaConversationAndArtifacts(t *testing.T) {
 		want    string
 	}{
 		{name: "Gentleman", persona: model.PersonaGentleman, want: "Voseo conversation; English technical artifacts"},
-		{name: "Gentleman with English artifacts", persona: model.PersonaGentlemanNeutralArtifacts, want: "Voseo conversation; English technical artifacts (legacy alias)"},
+		{name: "Gentleman with English artifacts", persona: model.PersonaGentlemanNeutralArtifacts, want: "No regional conversation tone; English technical artifacts (legacy alias, remapped)"},
 		{name: "Neutral", persona: model.PersonaNeutral, want: "No regional conversation tone; English technical artifacts"},
 	}
 


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1702

> Chained series: this is **PR2 of 5** under #1702, **stacked on #1712** (PR1). Its diff includes PR1's five commits until #1712 merges — review only the last two commits (`8f95569c`, `08f14a84`). If this merge auto-closes the issue, please reopen — the series completes with PR5.

---

## 🏷️ PR Type

- [x] `type:feature` — New feature (non-breaking change that adds functionality)

---

## 📝 Summary

Makes persona switching first-class, fixing defect 3 of #1702: an explicit `--persona X` (except `custom`, which means "keep unmanaged") now always applies the persona component, even when `--components` narrows the set — previously the flag was accepted and silently ignored. Also pins the existing switch-cleanup mechanics (landed on `main` via `aa881f2`, previously attempted in #289/#682) with regression tests so the manual-cleanup era cannot return, including the JSONC/malformed-settings silent-skip found in #289's review.

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/cli/validate.go` | `NormalizeInstallFlags`: explicit `--persona` (non-custom) forces `model.ComponentPersona` into the selection |
| `internal/cli/persona_language_contract_test.go` | Two tests: persona flag forces the component; `custom` does not |
| `internal/components/persona/inject_switch_test.go` | New — three switch tests: gentleman→neutral removes `gentleman.md`/flips `outputStyle`; second neutral inject is a no-op (`Changed==false`); malformed/JSONC settings never hard-fail the switch and file cleanup still runs |

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./...
```

**Go Format**
```bash
go run ./internal/gofmtcheck
```

**E2E Tests** (Docker required)
```bash
cd e2e && ./docker-test.sh
```

- [x] Unit tests pass for touched packages (`go test ./internal/cli/ -run TestNormalizeInstallFlags`, `go test ./internal/components/persona/ -run TestInject`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests — deferring to CI (no local Docker run)
- [x] Manually tested locally (test-level)

Same note as #1712: three `internal/cli` tests fail on this machine at the base commit `89e06d24` as well (pre-existing / environment-dependent); deferring the authoritative full-suite verdict to CI.

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue — #1702 is currently `status:needs-review`; awaiting maintainer `status:approved` (the approval CI check will stay red until then)
- [x] PR stays within 400 changed lines (own commits: 265 additions, 0 deletions)
- [ ] `type:*` label — no triage rights from fork; maintainer: `type:feature`
- [x] Unit tests pass (touched packages; pre-existing failures documented above)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests — deferring to CI
- [x] Documentation updated if necessary (none needed — behavior documented in code comments and tests)
- [x] Commits follow Conventional Commits
- [x] No `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

No production change was needed for the malformed-settings case: `removeJSONKeyIfValue` already returns false on unparseable JSON, leaving the settings file untouched while the independent file cleanup proceeds — the new test pins exactly that behavior so a future refactor cannot regress it into a hard failure (the regression #289's adversarial review caught).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Persona switching backup coverage now restores both Neutral and Gentleman managed output-style files, improving rollback reliability.
- **Bug Fixes**
  - Legacy **“gentleman-neutral-artifacts”** now remaps to **Neutral** (with a one-time remap notice), renders Neutral assets/content, and no longer applies Gentleman conversation tone.
  - Persisted legacy persona state is automatically migrated to Neutral on sync (even for no-agent runs).
  - Switching **Gentleman → Neutral** remains idempotent and tolerates malformed `settings.json`.
  - Persona picker no longer offers the legacy alias.
- **Tests**
  - Expanded coverage for remapping, migration, UI/picker rules, sync rollback targets, and atomic write failure safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->