### PR TITLE
fix(review): bind Git common-directory identity

### DIFF
--- a/internal/reviewtransaction/frozen_candidate_context.go
+++ b/internal/reviewtransaction/frozen_candidate_context.go
@@ -236,11 +236,11 @@ func frozenRepositoryPathManifest(ctx context.Context, repo string, isolation []
 }
 
 func isolatedImmutableTreeGit(ctx context.Context, repo string) ([]string, func(), error) {
-	commonDir, err := resolveGitDirectory(ctx, repo, "--git-common-dir")
+	identity, err := reviewRepositoryIdentity(ctx, repo)
 	if err != nil {
 		return nil, func() {}, err
 	}
-	objectFormatOutput, err := runGit(ctx, repo, nil, nil, "rev-parse", "--show-object-format")
+	objectFormatOutput, err := runGit(ctx, identity.RepositoryRoot, nil, nil, "rev-parse", "--show-object-format")
 	if err != nil {
 		return nil, func() {}, err
 	}
@@ -276,7 +276,7 @@ func isolatedImmutableTreeGit(ctx context.Context, repo string) ([]string, func(
 	}
 	return []string{
 		"GIT_DIR=" + gitDir,
-		"GIT_OBJECT_DIRECTORY=" + filepath.Join(commonDir, "objects"),
+		"GIT_OBJECT_DIRECTORY=" + filepath.Join(identity.GitCommonDir, "objects"),
 		"GIT_CONFIG_NOSYSTEM=1",
 		"GIT_CONFIG_SYSTEM=" + os.DevNull,
 		"GIT_CONFIG_GLOBAL=" + os.DevNull,

--- a/internal/reviewtransaction/git_authority_path_test.go
+++ b/internal/reviewtransaction/git_authority_path_test.go
@@ -151,6 +151,51 @@ func TestReviewAuthorityRootPreservesSymlinkedGitDirectory(t *testing.T) {
 	}
 }
 
+func TestReviewRepositoryIdentityAcceptsSupportedGitTopologies(t *testing.T) {
+	requireSnapshotGit(t)
+	ordinary := initSnapshotRepo(t)
+	linked := filepath.Join(t.TempDir(), "linked")
+	if err := runSnapshotGit(ordinary, "worktree", "add", "-b", "common-dir-linked", linked, "HEAD"); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = runSnapshotGit(ordinary, "worktree", "remove", "--force", linked) })
+
+	separateParent := t.TempDir()
+	separate := filepath.Join(separateParent, "worktree")
+	separateGitDir := filepath.Join(separateParent, "metadata")
+	command := exec.Command("git", "init", "--separate-git-dir", separateGitDir, separate)
+	if output, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("git init --separate-git-dir: %v\n%s", err, output)
+	}
+
+	superproject := initSnapshotRepo(t)
+	moduleSource := initSnapshotRepo(t)
+	gitSnapshot(t, superproject, "-c", "protocol.file.allow=always", "submodule", "add", moduleSource, "module")
+	submodule := filepath.Join(superproject, "module")
+
+	for name, repo := range map[string]string{
+		"ordinary": ordinary, "linked worktree": linked, "separate Git directory": separate, "submodule": submodule,
+	} {
+		t.Run(name, func(t *testing.T) {
+			identity, err := reviewRepositoryIdentity(context.Background(), repo)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if identity.RepositoryRoot == "" || identity.GitCommonDir == "" || identity.GitDir == "" {
+				t.Fatalf("incomplete repository identity: %#v", identity)
+			}
+			isolation, cleanup, err := isolatedImmutableTreeGit(context.Background(), repo)
+			if err != nil {
+				t.Fatal(err)
+			}
+			cleanup()
+			if len(isolation) == 0 {
+				t.Fatal("isolated Git environment is empty")
+			}
+		})
+	}
+}
+
 func TestReviewRepositoryIdentityPreservesGitCommandError(t *testing.T) {
 	requireSnapshotGit(t)
 	repo := initSnapshotRepo(t)
@@ -175,11 +220,178 @@ func TestReviewRepositoryIdentityPreservesGitCommandError(t *testing.T) {
 	}
 }
 
+func TestGitCommonDirectoryMismatchFailsBeforeAuthorityMutation(t *testing.T) {
+	requireSnapshotGit(t)
+	operations := []struct {
+		name string
+		run  func(context.Context, string) error
+	}{
+		{name: "authoritative store", run: func(ctx context.Context, repo string) error {
+			_, err := AuthoritativeStore(ctx, repo, "unrelated-common-v1")
+			return err
+		}},
+		{name: "compact store", run: func(ctx context.Context, repo string) error {
+			_, err := CompactAuthoritativeStore(ctx, repo, "unrelated-common-v2")
+			return err
+		}},
+		{name: "maintenance lock", run: func(ctx context.Context, repo string) error {
+			lock, err := AcquireReviewMaintenanceExclusive(ctx, repo)
+			if lock != nil {
+				_ = lock.Release()
+			}
+			return err
+		}},
+		{name: "frozen Git isolation", run: func(ctx context.Context, repo string) error {
+			_, cleanup, err := isolatedImmutableTreeGit(ctx, repo)
+			cleanup()
+			return err
+		}},
+		{name: "provider publication", run: func(ctx context.Context, repo string) error {
+			_, err := PublishReviewRepositoryContext(ctx, repo, ReviewRepositoryContextBinding{
+				LineageID: "unrelated-common-provider", TargetIdentity: "sha256:" + strings.Repeat("a", 64),
+				Revision: "sha256:" + strings.Repeat("b", 64),
+			})
+			return err
+		}},
+	}
+
+	for _, operation := range operations {
+		t.Run(operation.name, func(t *testing.T) {
+			repo := initSnapshotRepo(t)
+			unrelated := t.TempDir()
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			t.Setenv("USERPROFILE", home)
+			overrideGitDirectoryOutputs(t, repo, unrelated, filepath.Join(repo, ".git"), nil)
+			ctx, cancel := context.WithTimeout(context.Background(), maintenanceLockTimeout)
+			defer cancel()
+
+			if err := operation.run(ctx, repo); err == nil {
+				t.Error("operation accepted an unrelated Git common directory")
+			}
+			for _, path := range []string{filepath.Join(unrelated, "gentle-ai"), filepath.Join(home, ".gentle-ai")} {
+				if _, err := os.Lstat(path); !os.IsNotExist(err) {
+					t.Errorf("rejected common directory mutated %q: %v", path, err)
+				}
+			}
+		})
+	}
+}
+
+func TestReviewRepositoryIdentityRejectsReplacedCommonDirectory(t *testing.T) {
+	requireSnapshotGit(t)
+	repo := initSnapshotRepo(t)
+	common := filepath.Join(t.TempDir(), "common")
+	if err := os.Mkdir(common, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.Stat(common)
+	if err != nil {
+		t.Fatal(err)
+	}
+	replaced := false
+	overrideGitDirectoryOutputs(t, repo, common, common+"-old", func() {
+		if replaced {
+			return
+		}
+		replaced = true
+		if err := os.Rename(common, common+"-old"); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Mkdir(common, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	if _, err := reviewRepositoryIdentity(context.Background(), repo); err == nil {
+		t.Fatal("reviewRepositoryIdentity() accepted a replaced Git common directory")
+	}
+	after, err := os.Stat(common)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !replaced || os.SameFile(before, after) {
+		t.Fatal("replacement fixture did not change the common-directory file identity")
+	}
+}
+
+func TestReviewAuthorityRootRejectsMidQueryGitControlReplacement(t *testing.T) {
+	repo, replacement := initSnapshotRepo(t), initSnapshotRepo(t)
+	original := gitCommandContext
+	gitCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		combined := slicesContain(args, "--show-toplevel") && slicesContain(args, "--git-common-dir") && slicesContain(args, "--git-dir")
+		if combined || slicesContain(args, "--git-common-dir") && !slicesContain(args, "--git-dir") {
+			if err := errors.Join(
+				os.Rename(filepath.Join(repo, ".git"), filepath.Join(repo, ".git-old")),
+				os.Rename(filepath.Join(replacement, ".git"), filepath.Join(repo, ".git")),
+			); err != nil {
+				t.Fatal(err)
+			}
+		}
+		return original(ctx, name, args...)
+	}
+	t.Cleanup(func() { gitCommandContext = original })
+	if _, _, err := reviewAuthorityRoot(context.Background(), repo); err == nil {
+		t.Fatal("mid-query Git control replacement derived an authority root")
+	}
+	if _, err := os.Lstat(filepath.Join(repo, ".git", "gentle-ai")); !os.IsNotExist(err) {
+		t.Fatalf("rejected replacement mutated authority: %v", err)
+	}
+}
+
+func TestReviewRepositoryIdentityAcceptsDisjointCommonDirectory(t *testing.T) {
+	repo, parent := initSnapshotRepo(t), t.TempDir()
+	gitDir, commonDir := filepath.Join(parent, "git-dir"), filepath.Join(parent, "common")
+	for _, path := range []string{gitDir, commonDir} {
+		if err := os.Mkdir(path, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(gitDir, "commondir"), []byte("../common\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	overrideGitDirectoryOutputs(t, repo, commonDir, gitDir, nil)
+	identity, err := reviewRepositoryIdentity(context.Background(), repo)
+	if err != nil || identity.GitCommonDir != commonDir || identity.GitDir != gitDir {
+		t.Fatalf("disjoint identity = %#v, %v", identity, err)
+	}
+}
+
+func overrideGitDirectoryOutputs(t *testing.T, repo, commonDir, gitDir string, beforeGitDir func()) {
+	t.Helper()
+	original := gitCommandContext
+	gitCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		output := ""
+		switch {
+		case slicesContain(args, "--show-toplevel") && slicesContain(args, "--git-common-dir") && slicesContain(args, "--git-dir"):
+			if beforeGitDir != nil {
+				beforeGitDir()
+			}
+			output = strings.Join([]string{repo, commonDir, gitDir}, "\n")
+		case commonDir != "" && slicesContain(args, "--git-common-dir"):
+			output = commonDir
+		case gitDir != "" && slicesContain(args, "--git-dir"):
+			if beforeGitDir != nil {
+				beforeGitDir()
+			}
+			output = gitDir
+		default:
+			return original(ctx, name, args...)
+		}
+		encoded := base64.StdEncoding.EncodeToString([]byte(output + "\n"))
+		return exec.CommandContext(ctx, os.Args[0], "-test.run=^TestGitAuthorityPathHelperProcess$", "--", encoded)
+	}
+	t.Cleanup(func() { gitCommandContext = original })
+}
+
 func TestGitAuthorityPathHelperProcess(t *testing.T) {
 	if os.Getenv("GENTLE_AI_TEST_GIT_PATH_FAIL") == "1" {
 		os.Exit(23)
 	}
 	encoded := os.Getenv("GENTLE_AI_TEST_GIT_PATH_OUTPUT")
+	if encoded == "" && len(os.Args) > 2 && os.Args[len(os.Args)-2] == "--" {
+		encoded = os.Args[len(os.Args)-1]
+	}
 	if encoded == "" {
 		return
 	}

--- a/internal/reviewtransaction/repository_locator.go
+++ b/internal/reviewtransaction/repository_locator.go
@@ -39,6 +39,11 @@ type reviewRepositoryIdentityRecord struct {
 	RepositoryIdentity string `json:"repository_identity"`
 }
 
+type reviewRepositoryDirectoryIdentity struct {
+	path string
+	info fs.FileInfo
+}
+
 type reviewRepositoryContextFile struct {
 	Schema             string `json:"schema"`
 	Handle             string `json:"handle"`
@@ -377,31 +382,117 @@ func reviewRepositoryIdentity(ctx context.Context, repo string) (reviewRepositor
 	if err != nil {
 		return reviewRepositoryIdentityRecord{}, err
 	}
-	root, err = canonicalLocatorDirectory(root)
+	return reviewRepositoryIdentityAtRoot(ctx, root)
+}
+
+func reviewRepositoryIdentityAtRoot(ctx context.Context, root string) (reviewRepositoryIdentityRecord, error) {
+	if err := ctx.Err(); err != nil {
+		return reviewRepositoryIdentityRecord{}, err
+	}
+	rootIdentity, err := captureReviewRepositoryDirectory(root)
 	if err != nil {
 		return reviewRepositoryIdentityRecord{}, err
 	}
-	top, err := resolveGitDirectory(ctx, root, "--show-toplevel")
+	control, err := os.Lstat(filepath.Join(rootIdentity.path, ".git"))
 	if err != nil {
 		return reviewRepositoryIdentityRecord{}, err
 	}
-	if !sameLocatorDirectory(root, top) {
+	controlData, _ := os.ReadFile(filepath.Join(rootIdentity.path, ".git"))
+	directories, err := resolveReviewRepositoryDirectories(ctx, rootIdentity.path)
+	if err != nil {
+		return reviewRepositoryIdentityRecord{}, err
+	}
+	top, commonDir, gitDir := directories[0], directories[1], directories[2]
+	if !os.SameFile(rootIdentity.info, top.info) {
 		return reviewRepositoryIdentityRecord{}, errors.New("repository root identity changed")
 	}
-	commonDir, err := resolveGitDirectory(ctx, root, "--git-common-dir")
-	if err != nil {
+	if err := validateReviewGitCommonDirectory(gitDir, commonDir); err != nil {
 		return reviewRepositoryIdentityRecord{}, err
 	}
-	gitDir, err := resolveGitDirectory(ctx, root, "--git-dir")
-	if err != nil {
+	if err := ctx.Err(); err != nil {
 		return reviewRepositoryIdentityRecord{}, err
 	}
-	if !sameLocatorDirectory(gitDir, commonDir) && !locatorPathWithin(commonDir, gitDir) {
-		return reviewRepositoryIdentityRecord{}, errors.New("Git directory escapes its common directory")
+	for _, directory := range []reviewRepositoryDirectoryIdentity{rootIdentity, top, commonDir, gitDir} {
+		current, statErr := os.Stat(directory.path)
+		if statErr != nil || !current.IsDir() || !os.SameFile(directory.info, current) {
+			return reviewRepositoryIdentityRecord{}, errors.New("repository directory identity changed during resolution")
+		}
 	}
-	identity := reviewRepositoryIdentityRecord{RepositoryRoot: root, GitCommonDir: commonDir, GitDir: gitDir}
+	currentControl, controlErr := os.Lstat(filepath.Join(rootIdentity.path, ".git"))
+	currentData, currentDataErr := os.ReadFile(filepath.Join(rootIdentity.path, ".git"))
+	if controlErr != nil || !os.SameFile(control, currentControl) ||
+		control.Mode().IsRegular() && (currentDataErr != nil || !bytes.Equal(controlData, currentData)) {
+		return reviewRepositoryIdentityRecord{}, errors.New("repository Git control entry changed during resolution")
+	}
+	identity := reviewRepositoryIdentityRecord{
+		RepositoryRoot: rootIdentity.path, GitCommonDir: commonDir.path, GitDir: gitDir.path,
+	}
 	identity.RepositoryIdentity = reviewRepositoryIdentityHash(identity)
 	return identity, nil
+}
+
+func captureReviewRepositoryDirectory(path string) (reviewRepositoryDirectoryIdentity, error) {
+	canonical, err := canonicalLocatorDirectory(path)
+	if err != nil {
+		return reviewRepositoryDirectoryIdentity{}, err
+	}
+	info, err := os.Stat(canonical)
+	if err != nil || !info.IsDir() {
+		return reviewRepositoryDirectoryIdentity{}, errors.New("review repository identity path is not a directory")
+	}
+	return reviewRepositoryDirectoryIdentity{path: canonical, info: info}, nil
+}
+
+func resolveReviewRepositoryDirectory(ctx context.Context, root, selector string) (reviewRepositoryDirectoryIdentity, error) {
+	path, err := resolveGitDirectory(ctx, root, selector)
+	if err != nil {
+		return reviewRepositoryDirectoryIdentity{}, err
+	}
+	return captureReviewRepositoryDirectory(path)
+}
+
+func resolveReviewRepositoryDirectories(ctx context.Context, root string) ([]reviewRepositoryDirectoryIdentity, error) {
+	output, err := runGit(ctx, root, nil, nil, "rev-parse", "--show-toplevel", "--git-common-dir", "--git-dir")
+	if err != nil {
+		return nil, err
+	}
+	records := bytes.Split(bytes.TrimSuffix(output, []byte{'\n'}), []byte{'\n'})
+	if len(records) != 3 {
+		return nil, errors.New("Git repository selection must return exactly three path records")
+	}
+	directories := make([]reviewRepositoryDirectoryIdentity, 3)
+	for index, record := range records {
+		path, pathErr := canonicalGitDirectory(root, bytes.TrimSuffix(record, []byte{'\r'}))
+		if pathErr != nil {
+			return nil, pathErr
+		}
+		directories[index], pathErr = captureReviewRepositoryDirectory(path)
+		if pathErr != nil {
+			return nil, pathErr
+		}
+	}
+	return directories, nil
+}
+
+func validateReviewGitCommonDirectory(gitDir, commonDir reviewRepositoryDirectoryIdentity) error {
+	if os.SameFile(gitDir.info, commonDir.info) {
+		return nil
+	}
+	record, err := os.ReadFile(filepath.Join(gitDir.path, "commondir"))
+	record = bytes.TrimSuffix(bytes.TrimSuffix(record, []byte{'\n'}), []byte{'\r'})
+	if err != nil || len(record) == 0 || bytes.IndexByte(record, 0) >= 0 || bytes.ContainsAny(record, "\r\n") ||
+		strings.TrimSpace(string(record)) == "" || bytes.HasPrefix(record, []byte("--")) {
+		return errors.New("Git common directory relationship is invalid")
+	}
+	path := string(record)
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(gitDir.path, path)
+	}
+	resolved, err := captureReviewRepositoryDirectory(path)
+	if err != nil || !os.SameFile(resolved.info, commonDir.info) {
+		return errors.New("Git common directory relationship is invalid")
+	}
+	return nil
 }
 
 func reviewRepositoryIdentityHash(identity reviewRepositoryIdentityRecord) string {
@@ -495,6 +586,12 @@ func privateLocatorFileModeSafe(mode fs.FileMode) bool {
 func locatorPathWithin(base, candidate string) bool {
 	relative, err := filepath.Rel(filepath.Clean(base), filepath.Clean(candidate))
 	return err == nil && relative != ".." && !strings.HasPrefix(relative, ".."+string(filepath.Separator)) && !filepath.IsAbs(relative)
+}
+
+func locatorPathStrictlyWithin(base, candidate string) bool {
+	relative, err := filepath.Rel(filepath.Clean(base), filepath.Clean(candidate))
+	return err == nil && relative != "." && relative != ".." &&
+		!strings.HasPrefix(relative, ".."+string(filepath.Separator)) && !filepath.IsAbs(relative)
 }
 
 func sameLocatorDirectory(left, right string) bool {

--- a/internal/reviewtransaction/store.go
+++ b/internal/reviewtransaction/store.go
@@ -152,12 +152,12 @@ func reviewAuthorityRoot(ctx context.Context, repo string) (string, string, erro
 	if err != nil {
 		return "", "", fmt.Errorf("resolve authoritative review repository: %w", err)
 	}
-	commonDir, err := resolveGitDirectory(ctx, root, "--git-common-dir")
+	identity, err := reviewRepositoryIdentityAtRoot(ctx, root)
 	if err != nil {
-		return "", "", fmt.Errorf("resolve repository Git common directory: %w", err)
+		return "", "", fmt.Errorf("resolve repository Git identity: %w", err)
 	}
-	authorityRoot := filepath.Join(filepath.Clean(commonDir), "gentle-ai", "review-transactions")
-	return authorityRoot, root, nil
+	authorityRoot := filepath.Join(identity.GitCommonDir, "gentle-ai", "review-transactions")
+	return authorityRoot, identity.RepositoryRoot, nil
 }
 
 func validateLineageID(lineageID string) error {


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1705

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)

## 📝 Summary

Binds every writable review authority path to one coherent Git repository identity. The selected top-level, Git directory, and common directory are now resolved through one strict three-record Git invocation, semantically related through Git's `commondir` control file, and revalidated before stores, maintenance locks, isolated Git directories, or provider contexts can write.

This rejects unrelated or replaced absolute metadata directories while preserving ordinary repositories, linked worktrees, submodules, separate Git directories, canonical symlink aliases, and valid disjoint common-directory layouts.

## 📂 Changes

| Area | What Changed |
|------|-------------|
| Repository identity | Resolve and strictly parse one coherent top-level/common-dir/git-dir tuple |
| Git topology validation | Use semantic `commondir` identity rather than lexical ancestry |
| Mutation boundaries | Derive stores, locks, frozen isolation, and provider paths only after tuple/control revalidation |
| Regression tests | Cover coherent metadata substitution, disjoint common-dir, replacement races, typed failures, and zero mutation |

## 🧪 Test Plan

- [x] Focused RED→GREEN repository-identity regressions pass
- [x] Focused and full `internal/reviewtransaction` race suites pass
- [x] `go test ./... -count=1`
- [x] `go run ./internal/gofmtcheck`
- [x] `go vet ./...`
- [x] Module tidy/verify and review contract/capability harnesses pass
- [x] Linux amd64, macOS arm64, and Windows amd64 builds pass
- [ ] Local container E2E — Docker/Podman unavailable; required CI executes the matrix

## 🔍 Independent Review

Full integrity, resilience, reliability, and readability review found two blockers: split Git probes permitted coherent metadata replacement, and lexical containment rejected valid disjoint common directories. One bounded correction resolved both and the targeted validator returned PASS after a byte-compatible base advance.

- Candidate: `f3bdc117168764f6ef5ca2b3f10cb3cf8e465d70`
- Tree: `364b787c5dd6a57b1762786097e6b618c75b0dc6`
- Diff SHA-256: `6b70d49ce4c6b6199257a27d92999483ce82d7c5c66f312a3e4fec197d11345a`
- Correction: exactly 121/121 allowed lines

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [x] Exactly one `type:*` label is applied
- [x] Unit, race, format, vet, module, contract, and cross-build checks pass
- [ ] E2E tests pass — delegated to required CI because no local container runtime exists
- [x] Documentation is not required for this internal repository-identity fix
- [x] Commits follow Conventional Commits format
- [x] Commits contain no `Co-Authored-By` trailers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of repositories using linked worktrees, separate Git directories, submodules, and other supported layouts.
  * Added safeguards to detect inconsistent or replaced Git metadata during repository operations.
  * Prevented repository authority state from being changed when Git directory relationships are invalid or change unexpectedly.
  * Improved reliability when resolving repository and Git directory locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->