### PR TITLE
fix(review): scope binding discovery to Git candidates

### DIFF
--- a/internal/reviewtransaction/snapshot.go
+++ b/internal/reviewtransaction/snapshot.go
@@ -551,6 +551,34 @@ func (builder SnapshotBuilder) DiscoverIntendedUntracked(ctx context.Context) ([
 	return canonicalPaths(paths)
 }
 
+// DiscoverTrackedAndUnignoredPaths returns the canonical Git-owned workspace
+// inventory: every cached path plus every unignored untracked path.
+func (builder SnapshotBuilder) DiscoverTrackedAndUnignoredPaths(ctx context.Context) ([]string, error) {
+	root, err := builder.ResolveRepositoryRoot(ctx)
+	if err != nil {
+		return nil, err
+	}
+	output, err := runGitInventory(ctx, root, "ls-files", "--cached", "--others", "--exclude-standard", "-z")
+	if err != nil {
+		return nil, err
+	}
+	parts := bytes.Split(output, []byte{0})
+	paths := make([]string, 0, len(parts))
+	for _, item := range parts {
+		if len(item) > 0 {
+			value := string(item)
+			if strings.HasSuffix(value, "/") {
+				value = strings.TrimSuffix(value, "/")
+				if value == "" || strings.HasSuffix(value, "/") {
+					return nil, fmt.Errorf("invalid opaque Git inventory path %q", item)
+				}
+			}
+			paths = append(paths, value)
+		}
+	}
+	return canonicalPaths(paths)
+}
+
 // HasDirtyTrackedChanges reports whether the worktree or index differs from
 // HEAD, excluding untracked paths.
 func (builder SnapshotBuilder) HasDirtyTrackedChanges(ctx context.Context) (bool, error) {
@@ -1122,21 +1150,25 @@ var gitCommandContext = exec.CommandContext
 var gitProcessTreeStarter = startGitProcessTree
 
 func runGit(ctx context.Context, repo string, extraEnv []string, stdin []byte, args ...string) ([]byte, error) {
-	return runGitCaptured(ctx, repo, extraEnv, stdin, 0, false, args...)
+	return runGitCaptured(ctx, repo, extraEnv, stdin, 0, false, false, args...)
+}
+
+func runGitInventory(ctx context.Context, repo string, args ...string) ([]byte, error) {
+	return runGitCaptured(ctx, repo, nil, nil, 0, false, true, args...)
 }
 
 func runGitIsolated(ctx context.Context, repo string, extraEnv []string, stdin []byte, args ...string) ([]byte, error) {
-	return runGitCaptured(ctx, repo, extraEnv, stdin, 0, true, args...)
+	return runGitCaptured(ctx, repo, extraEnv, stdin, 0, true, false, args...)
 }
 
 func runGitLimited(ctx context.Context, repo string, extraEnv []string, stdin []byte, outputLimit int, args ...string) ([]byte, error) {
 	if outputLimit <= 0 {
 		return nil, &GitOutputLimitError{Args: append([]string{}, args...), Limit: outputLimit}
 	}
-	return runGitCaptured(ctx, repo, extraEnv, stdin, outputLimit, true, args...)
+	return runGitCaptured(ctx, repo, extraEnv, stdin, outputLimit, true, false, args...)
 }
 
-func runGitCaptured(ctx context.Context, repo string, extraEnv []string, stdin []byte, outputLimit int, isolateConfig bool, args ...string) ([]byte, error) {
+func runGitCaptured(ctx context.Context, repo string, extraEnv []string, stdin []byte, outputLimit int, isolateConfig, rejectStderr bool, args ...string) ([]byte, error) {
 	remote := len(args) > 0 && args[0] == "ls-remote"
 	timeout := localGitCommandTimeout
 	if remote {
@@ -1151,12 +1183,14 @@ func runGitCaptured(ctx context.Context, repo string, extraEnv []string, stdin [
 	if stdin != nil {
 		command.Stdin = bytes.NewReader(stdin)
 	}
-	var combined bytes.Buffer
+	var combined, machineStdout, machineStderr bytes.Buffer
 	var stdout, stderr *boundedGitOutput
 	if outputLimit > 0 {
 		stdout = &boundedGitOutput{limit: outputLimit}
 		stderr = &boundedGitOutput{limit: 64 << 10}
 		command.Stdout, command.Stderr = stdout, stderr
+	} else if rejectStderr {
+		command.Stdout, command.Stderr = &machineStdout, &machineStderr
 	} else {
 		command.Stdout, command.Stderr = &combined, &combined
 	}
@@ -1182,6 +1216,8 @@ func runGitCaptured(ctx context.Context, repo string, extraEnv []string, stdin [
 	output, diagnostic := combined.Bytes(), combined.Bytes()
 	if stdout != nil {
 		output, diagnostic = stdout.Bytes(), stderr.Bytes()
+	} else if rejectStderr {
+		output, diagnostic = machineStdout.Bytes(), machineStderr.Bytes()
 	}
 	if errors.Is(err, exec.ErrWaitDelay) && commandContext.Err() == nil {
 		err = nil
@@ -1212,6 +1248,9 @@ func runGitCaptured(ctx context.Context, repo string, extraEnv []string, stdin [
 	}
 	if stdout != nil && stdout.exceeded {
 		return nil, &GitOutputLimitError{Args: append([]string{}, args...), Limit: outputLimit}
+	}
+	if rejectStderr && len(diagnostic) != 0 {
+		return nil, fmt.Errorf("git inventory produced diagnostics: %s", strings.TrimSpace(string(diagnostic)))
 	}
 	return output, nil
 }

--- a/internal/reviewtransaction/snapshot_inventory_test.go
+++ b/internal/reviewtransaction/snapshot_inventory_test.go
@@ -1,0 +1,51 @@
+package reviewtransaction
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestSnapshotBuilderDiscoversTrackedAndUnignoredPathsInLinkedWorktree(t *testing.T) {
+	requireSnapshotGit(t)
+	parent := t.TempDir()
+	repo := filepath.Join(parent, "main")
+	if err := os.Mkdir(repo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	gitSnapshot(t, repo, "init", "-q")
+	gitSnapshot(t, repo, "config", "user.email", "snapshot@example.com")
+	gitSnapshot(t, repo, "config", "user.name", "Snapshot Test")
+	writeSnapshotFile(t, repo, ".gitignore", "git-ignored.txt\n")
+	writeSnapshotFile(t, repo, "tracked.txt", "tracked\n")
+	gitSnapshot(t, repo, "add", "--", ".gitignore", "tracked.txt")
+	gitSnapshot(t, repo, "commit", "-qm", "base")
+
+	linked := filepath.Join(parent, "linked")
+	gitSnapshot(t, repo, "worktree", "add", "-q", "-b", "inventory-test", linked)
+	exclude := filepath.Join(repo, ".git", "info", "exclude")
+	if err := os.WriteFile(exclude, []byte("info-ignored.txt\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	writeSnapshotFile(t, linked, "untracked.txt", "untracked\n")
+	writeSnapshotFile(t, linked, "git-ignored.txt", "ignored\n")
+	writeSnapshotFile(t, linked, "info-ignored.txt", "ignored\n")
+	for _, nested := range []string{"vendor", "openspec/changes/thin"} {
+		path := filepath.Join(linked, filepath.FromSlash(nested))
+		if err := os.MkdirAll(path, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		gitSnapshot(t, path, "init", "-q")
+	}
+
+	got, err := (SnapshotBuilder{Repo: linked}).DiscoverTrackedAndUnignoredPaths(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{".gitignore", "openspec/changes/thin", "tracked.txt", "untracked.txt", "vendor"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("DiscoverTrackedAndUnignoredPaths() = %v, want %v", got, want)
+	}
+}

--- a/internal/sddstatus/review_binding.go
+++ b/internal/sddstatus/review_binding.go
@@ -51,6 +51,9 @@ func BindApprovedReview(ctx context.Context, repo, change, lineage, expected str
 	if err != nil {
 		return ReviewBinding{}, err
 	}
+	if _, err := resolveBindingChangeRoot(ctx, root, repo, change); err != nil {
+		return ReviewBinding{}, err
+	}
 	if err := rejectHistoricalLegacyBinding(ctx, root, lineage); err != nil {
 		return ReviewBinding{}, err
 	}
@@ -100,7 +103,7 @@ func rejectHistoricalLegacyBinding(ctx context.Context, root, lineage string) er
 }
 
 func prepareApprovedReviewBinding(ctx context.Context, root, workspace, change, lineage string) (ReviewBinding, error) {
-	changeRoot, err := resolveBindingChangeRoot(root, workspace, change)
+	changeRoot, err := resolveBindingChangeRoot(ctx, root, workspace, change)
 	if err != nil {
 		return ReviewBinding{}, err
 	}
@@ -142,7 +145,7 @@ func prepareApprovedReviewBinding(ctx context.Context, root, workspace, change, 
 	final, finalErr := store.Load()
 	finalPayload, readErr := os.ReadFile(store.ReceiptPath())
 	finalGate := reviewtransaction.EvaluateCompactGate(ctx, root, receipt, input)
-	finalChangeRoot, changeErr := resolveBindingChangeRoot(root, workspace, change)
+	finalChangeRoot, changeErr := resolveBindingChangeRoot(ctx, root, workspace, change)
 	if finalErr != nil || readErr != nil || changeErr != nil || finalChangeRoot != changeRoot || final.Revision != record.Revision || !bytes.Equal(payload, finalPayload) || finalGate.Result != reviewtransaction.GateAllow || !reflect.DeepEqual(gate.Context, finalGate.Context) {
 		return ReviewBinding{}, errors.New("authority or live gate changed before binding publish")
 	}
@@ -154,7 +157,7 @@ func prepareApprovedReviewBinding(ctx context.Context, root, workspace, change, 
 // not have such a root, so their already-approved compact authority and live
 // post-apply gate are the complete native successor provenance.
 func prepareApprovedRuntimeSuccessorBinding(ctx context.Context, root, workspace, change, lineage string) (ReviewBinding, error) {
-	matches, err := bindingChangeRoots(root, change)
+	matches, err := bindingChangeRoots(ctx, root, change)
 	if err != nil {
 		return ReviewBinding{}, err
 	}
@@ -337,7 +340,7 @@ func validateBoundReview(ctx context.Context, repo, change string) (ReviewBindin
 	if err != nil {
 		return ReviewBinding{}, reviewtransaction.NativeGateEvaluation{}, err
 	}
-	changeRoot, err := resolveBindingChangeRoot(root, repo, change)
+	changeRoot, err := resolveBindingChangeRoot(ctx, root, repo, change)
 	if err != nil {
 		return ReviewBinding{}, reviewtransaction.NativeGateEvaluation{}, err
 	}
@@ -376,7 +379,7 @@ func validateBoundReview(ctx context.Context, repo, change string) (ReviewBindin
 	finalBinding, bindingErr := loadEffectiveReviewBinding(ctx, root, change)
 	finalRecord, recordErr := store.Load()
 	finalReceipt, receiptErr := os.ReadFile(store.ReceiptPath())
-	finalChangeRoot, changeErr := resolveBindingChangeRoot(root, repo, change)
+	finalChangeRoot, changeErr := resolveBindingChangeRoot(ctx, root, repo, change)
 	if bindingErr != nil || recordErr != nil || receiptErr != nil || changeErr != nil || finalChangeRoot != changeRoot || !reflect.DeepEqual(finalBinding, binding) || finalRecord.Revision != record.Revision || !reflect.DeepEqual(finalRecord.State, record.State) || finalRecord.State.State != reviewtransaction.StateApproved || !bytes.Equal(finalReceipt, receiptPayload) || bindingHash(finalReceipt) != binding.ReceiptHash {
 		return ReviewBinding{}, reviewtransaction.NativeGateEvaluation{}, errors.New("bound authority, receipt, or binding changed during final read")
 	}
@@ -461,7 +464,7 @@ func loadEffectiveReviewBinding(ctx context.Context, repo, change string) (Revie
 	return *legacy, nil
 }
 
-func resolveBindingChangeRoot(root, workspace, change string) (string, error) {
+func resolveBindingChangeRoot(ctx context.Context, root, workspace, change string) (string, error) {
 	workspace, err := filepath.Abs(workspace)
 	if err != nil {
 		return "", err
@@ -530,7 +533,7 @@ func resolveBindingChangeRoot(root, workspace, change string) (string, error) {
 		return "", errors.New("selected OpenSpec change uses a symlinked path")
 	}
 
-	matches, err := bindingChangeRoots(root, change)
+	matches, err := bindingChangeRoots(ctx, root, change)
 	if err != nil {
 		return "", err
 	}
@@ -540,40 +543,42 @@ func resolveBindingChangeRoot(root, workspace, change string) (string, error) {
 	return selected, nil
 }
 
-func bindingChangeRoots(root, change string) ([]string, error) {
+func bindingChangeRoots(ctx context.Context, root, change string) ([]string, error) {
+	paths, err := (reviewtransaction.SnapshotBuilder{Repo: root}).DiscoverTrackedAndUnignoredPaths(ctx)
+	if err != nil {
+		return nil, err
+	}
+	seen := map[string]struct{}{}
 	matches := []string{}
-	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
+	for _, logicalPath := range paths {
+		parts := strings.Split(logicalPath, "/")
+		if parts[len(parts)-1] == "openspec" {
+			parts = append(parts, "changes", change)
 		}
-		if entry.IsDir() && entry.Name() == ".git" && path != root {
-			return filepath.SkipDir
-		}
-		if entry.Type()&os.ModeSymlink != 0 {
-			if entry.Name() == "openspec" {
-				candidate := filepath.Join(path, "changes", change)
-				if info, err := os.Stat(candidate); err == nil && info.IsDir() {
-					matches = append(matches, candidate)
-				} else if err != nil && !os.IsNotExist(err) {
-					return err
-				}
-			} else if isBindingChangePath(path, change) {
-				matches = append(matches, path)
+		for index := 0; index+2 < len(parts); index++ {
+			if parts[index] != "openspec" || parts[index+1] != "changes" || parts[index+2] != change {
+				continue
 			}
-			return nil
+			rootPath := strings.Join(parts[:index+3], "/")
+			if _, duplicate := seen[rootPath]; duplicate {
+				break
+			}
+			seen[rootPath] = struct{}{}
+			candidate := filepath.Join(root, filepath.FromSlash(rootPath))
+			info, statErr := os.Lstat(candidate)
+			if os.IsNotExist(statErr) {
+				break
+			}
+			if statErr != nil {
+				return nil, statErr
+			}
+			if info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+				matches = append(matches, filepath.Clean(candidate))
+			}
+			break
 		}
-		if !entry.IsDir() || !isBindingChangePath(path, change) {
-			return nil
-		}
-		matches = append(matches, filepath.Clean(path))
-		return filepath.SkipDir
-	})
-	return matches, err
-}
-
-func isBindingChangePath(path, change string) bool {
-	changesRoot := filepath.Dir(path)
-	return filepath.Base(path) == change && filepath.Base(changesRoot) == "changes" && filepath.Base(filepath.Dir(changesRoot)) == "openspec"
+	}
+	return matches, nil
 }
 
 func pathWithinBindingRoot(root, path string) bool {

--- a/internal/sddstatus/review_binding_test.go
+++ b/internal/sddstatus/review_binding_test.go
@@ -93,6 +93,18 @@ func TestBindApprovedReviewRejectsAmbiguousPlanningChanges(t *testing.T) {
 			seedReadyChange(t, planningRoot, "thin", "- [x] 1.1 App\n")
 			seedReadyChange(t, filepath.Join(root, "packages", "api"), "thin", "- [x] 1.1 API\n")
 		}},
+		{name: "symlinked sibling collision", seed: func(t *testing.T, root, planningRoot string) {
+			seedReadyChange(t, planningRoot, "thin", "- [x] 1.1 App\n")
+			outside := t.TempDir()
+			seedReadyChange(t, outside, "thin", "- [x] 1.1 API\n")
+			link := filepath.Join(root, "packages", "api", "openspec")
+			if err := os.MkdirAll(filepath.Dir(link), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Symlink(filepath.Join(outside, "openspec"), link); err != nil {
+				t.Skipf("symlink fixture unavailable: %v", err)
+			}
+		}},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			root := t.TempDir()
@@ -122,6 +134,110 @@ func TestBindApprovedReviewRejectsOpenSpecSymlinkEscape(t *testing.T) {
 
 	if _, err := BindApprovedReview(context.Background(), planningRoot, "thin", "approved-thin", ""); err == nil || !strings.Contains(err.Error(), "outside repository") {
 		t.Fatalf("OpenSpec symlink escape error = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, ".git", "gentle-ai")); !os.IsNotExist(err) {
+		t.Fatalf("symlink escape created runtime authority: %v", err)
+	}
+}
+
+func TestBindApprovedReviewIgnoresGitExcludedUnreadableCollision(t *testing.T) {
+	root := t.TempDir()
+	changeRoot := seedReadyChange(t, root, "thin", "- [x] 1.1 Done\n")
+	write(t, filepath.Join(root, ".gitignore"), ".data/\nignored/\n")
+	seedReadyChange(t, filepath.Join(root, "ignored"), "thin", "- [x] ignored\n")
+	unreadable := filepath.Join(root, ".data", "postgres")
+	write(t, filepath.Join(unreadable, "base", "state"), "runtime\n")
+	if err := os.Chmod(unreadable, 0); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(unreadable, 0o755) })
+	writeApprovedCompactAuthorityForChange(t, root, changeRoot, "approved-thin")
+
+	if _, err := BindApprovedReview(context.Background(), root, "thin", "approved-thin", ""); err != nil {
+		t.Fatalf("Git-excluded runtime path affected binding: %v", err)
+	}
+}
+
+func TestBindingChangeRootsSkipsDeletedCachedRoot(t *testing.T) {
+	root := t.TempDir()
+	selected := seedReadyChange(t, root, "thin", "- [x] selected\n")
+	deleted := seedReadyChange(t, filepath.Join(root, "packages", "api"), "thin", "- [x] deleted\n")
+	runSDDStatusGit(t, root, "init", "-q")
+	runSDDStatusGit(t, root, "add", ".")
+	if err := os.RemoveAll(deleted); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := bindingChangeRoots(context.Background(), root, "thin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(got, []string{selected}) {
+		t.Fatalf("bindingChangeRoots() = %v, want only %q", got, selected)
+	}
+}
+
+func TestBindingChangeRootsUsesFirstRootAndIncludesSymlink(t *testing.T) {
+	root := t.TempDir()
+	outer := filepath.Join(root, "openspec", "changes", "thin")
+	write(t, filepath.Join(outer, "openspec", "changes", "thin", "tasks.md"), "nested\n")
+	outside := t.TempDir()
+	seedReadyChange(t, outside, "thin", "- [x] linked\n")
+	linkedOpenSpec := filepath.Join(root, "packages", "api", "openspec")
+	if err := os.MkdirAll(filepath.Dir(linkedOpenSpec), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join(outside, "openspec"), linkedOpenSpec); err != nil {
+		t.Skipf("symlink fixture unavailable: %v", err)
+	}
+	linked := filepath.Join(linkedOpenSpec, "changes", "thin")
+	opaque := filepath.Join(root, "packages", "web", "openspec", "changes", "thin")
+	if err := os.MkdirAll(opaque, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runSDDStatusGit(t, opaque, "init", "-q")
+	runSDDStatusGit(t, root, "init", "-q")
+
+	got, err := bindingChangeRoots(context.Background(), root, "thin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{outer, linked, opaque}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("bindingChangeRoots() = %v, want %v", got, want)
+	}
+}
+
+func TestBindApprovedReviewRejectsSuccessfulGitDiagnosticsBeforeRuntimeMutation(t *testing.T) {
+	root := t.TempDir()
+	seedReadyChange(t, root, "thin", "- [x] done\n")
+	runSDDStatusGit(t, root, "init", "-q")
+	runSDDStatusGit(t, root, "config", "core.fsmonitor", "/nonexistent")
+
+	_, err := BindApprovedReview(context.Background(), root, "thin", "approved-thin", "")
+	if err == nil || !strings.Contains(err.Error(), "diagnostics") {
+		t.Fatalf("BindApprovedReview() diagnostic error = %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(root, ".git", "gentle-ai")); !os.IsNotExist(statErr) {
+		t.Fatalf("Git diagnostic created runtime authority: %v", statErr)
+	}
+}
+
+func TestBindApprovedReviewPreflightsGitInventoryBeforeRuntimeMutation(t *testing.T) {
+	root := t.TempDir()
+	seedReadyChange(t, root, "thin", "- [x] done\n")
+	runSDDStatusGit(t, root, "init", "-q")
+	if err := os.WriteFile(filepath.Join(root, ".git", "index"), []byte("corrupt index\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := BindApprovedReview(context.Background(), root, "thin", "approved-thin", "")
+	var commandErr *reviewtransaction.GitCommandError
+	if !errors.As(err, &commandErr) {
+		t.Fatalf("BindApprovedReview() error = %T %v, want typed Git failure", err, err)
+	}
+	if _, statErr := os.Stat(filepath.Join(root, ".git", "gentle-ai")); !os.IsNotExist(statErr) {
+		t.Fatalf("Git inventory failure created runtime authority: %v", statErr)
 	}
 }
 

--- a/internal/sddstatus/runtime_ledger_remediation_test.go
+++ b/internal/sddstatus/runtime_ledger_remediation_test.go
@@ -121,6 +121,21 @@ func TestRuntimeRemediationFinishSupportsEngramWithoutOpenSpecRoot(t *testing.T)
 	}
 }
 
+func TestRuntimeRemediationRejectsSymlinkedOpenSpecInsteadOfEngramFallback(t *testing.T) {
+	fixture := newRuntimeEngramRemediationFixture(t)
+	outside := t.TempDir()
+	seedReadyChange(t, outside, "engram-runtime", "- [x] linked\n")
+	if err := os.Symlink(filepath.Join(outside, "openspec"), filepath.Join(fixture.repo, "openspec")); err != nil {
+		t.Skipf("symlink fixture unavailable: %v", err)
+	}
+	before := countRuntimeRecords(t, fixture.store.Dir)
+	_, err := fixture.store.Finish(context.Background(), fixture.finishRequest("reject-symlinked-openspec"))
+	if err == nil || !strings.Contains(err.Error(), "outside repository") {
+		t.Fatalf("symlinked OpenSpec successor error = %v", err)
+	}
+	assertRuntimeRemediationUnchanged(t, fixture, before)
+}
+
 func TestRuntimeRemediationFinishChargesButDoesNotSelectAnOverBudgetSuccessor(t *testing.T) {
 	fixture := newRuntimeRemediationFixtureConfigured(t, true, true, 1, 2)
 	beforeRecords := countRuntimeRecords(t, fixture.store.Dir)


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1616

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)

## 📝 Summary

Replaces whole-repository filesystem traversal for OpenSpec binding discovery with the exact Git candidate set: tracked plus unignored-untracked paths. Ignored runtime, build, vendor, and excluded directories can no longer poison binding selection, and Git inventory/selection now completes before runtime directories or locks are created.

The implementation preserves linked-worktree excludes, ambiguity semantics, deleted cached paths, symlink-root validation, typed Git failures, and final live revalidation under the runtime lock.

## 📂 Changes

| Area | What Changed |
|------|-------------|
| Git candidate inventory | Added NUL-delimited tracked/unignored discovery with separate diagnostics |
| OpenSpec root selection | Derive roots from Git records, including opaque nested-repository markers and symlink ancestors |
| Binding preflight | Resolve inventory/selection before runtime directory or lock creation |
| Regression tests | Cover ignores, linked worktrees, deleted cache entries, stderr/partial inventory, nested repos, symlinks, ambiguity, and zero mutation |

## 🧪 Test Plan

- [x] Focused RED→GREEN regression matrix passes
- [x] Focused and full race suites pass
- [x] `go test ./... -count=1`
- [x] `go run ./internal/gofmtcheck`
- [x] `go vet ./...`
- [x] `go mod verify` and review contract checks pass
- [x] Linux, macOS, and Windows builds pass
- [ ] Local container E2E — Docker/Podman unavailable; required CI executes the matrix

## 🔍 Independent Review

Full integrity, resilience, reliability, and readability review found three blockers: successful Git diagnostics contaminated machine output, embedded repositories used opaque trailing-slash records, and symlinked `openspec` ancestors could disappear into pure-Engram fallback. One bounded correction fixed all three; the targeted validator returned PASS after a byte-compatible base advance.

- Candidate: `7fb3fdd5528da2ac93282b70a97726342e78c708`
- Tree: `dcd24f62c24407d1356df0ba168db4eada1899de`
- Diff SHA-256: `fb6f6bfa05881865c224e7341f9b1133fb378c7256cbd0912d7a6ac85e026afc`
- Correction: 106/111 allowed lines

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [x] Exactly one `type:*` label is applied
- [x] Unit, race, format, vet, module, contract, and cross-build checks pass
- [ ] E2E tests pass — delegated to required CI because no local container runtime exists
- [x] Documentation is not required for this internal discovery fix
- [x] Commits follow Conventional Commits format
- [x] Commits contain no `Co-Authored-By` trailers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved review binding validation for tracked, unignored, cached, and linked-worktree paths.
  * Rejects ambiguous or unsafe OpenSpec symlink paths, including paths that escape the repository.
  * Prevents runtime state from being created or changed when validation or Git inventory checks fail.
  * Handles deleted cached roots and excluded unreadable directories more reliably.

* **Reliability**
  * Improved Git diagnostic and inventory handling for more predictable validation results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->