### PR TITLE
fix(review): correct merged publication scope

### DIFF
--- a/internal/reviewtransaction/compact_gate.go
+++ b/internal/reviewtransaction/compact_gate.go
@@ -719,8 +719,9 @@ func validateCompactCommittedTrackedScope(ctx context.Context, repo string, requ
 // validateReviewedPublicationRange enforces the governing publication
 // invariant: nothing newly published may exceed what review authorized. The
 // receipt's authority is the reviewed base→candidate delta plus the immutable
-// base tree it binds, so every path touched anywhere in the delivered range
-// base..head must stay inside the immutable genesis scope. For an empty-remote
+// base tree it binds, so every path touched in HEAD outside the reviewed and
+// tracking reachability boundaries must stay inside the immutable genesis
+// scope. For an empty-remote
 // bootstrap the range base is the resolved reviewed delivery base commit —
 // never the zero-OID sentinel — and the pre-base ancestry published in full by
 // the first push must additionally satisfy the reviewed base tree disclosure
@@ -731,11 +732,35 @@ func validateReviewedPublicationRange(ctx context.Context, repo string, genesis 
 			return err
 		}
 	}
-	output, err := runGit(ctx, repo, nil, nil, "log", "-m", "--format=", "--name-only", "-z", "--no-renames", refs.BaseCommit+".."+refs.HeadCommit)
-	if err != nil {
-		return fmt.Errorf("inspect complete publication range: %w", err)
+	reviewed := refs.Selection.Commit
+	if reviewed == "" || refs.Selection.Source == PrePRBoundaryEmptyRemoteBootstrap {
+		reviewed = refs.BaseCommit
 	}
-	paths, err := canonicalPaths(splitNullSeparatedPaths(output))
+	revisions := []string{refs.HeadCommit}
+	exclusions := []string{reviewed}
+	if refs.TrackingPresent {
+		exclusions = append(exclusions, refs.TrackingBoundary.Commit)
+	}
+	seen := map[string]struct{}{}
+	for _, excluded := range exclusions {
+		if excluded == "" {
+			continue
+		}
+		if _, duplicate := seen[excluded]; duplicate {
+			continue
+		}
+		seen[excluded] = struct{}{}
+		_, err := runGit(ctx, repo, nil, nil, "merge-base", "--is-ancestor", refs.HeadCommit, excluded)
+		if err == nil {
+			return errors.New("publication exclusion contains HEAD and would erase the publication range")
+		}
+		var commandErr *GitCommandError
+		if !errors.As(err, &commandErr) || commandErr.ExitCode != 1 {
+			return fmt.Errorf("validate publication exclusion ancestry: %w", err)
+		}
+		revisions = append(revisions, "^"+excluded)
+	}
+	paths, err := collectReviewedPublicationPaths(ctx, repo, revisions)
 	if err == nil {
 		err = pathsAreSubset(paths, genesis)
 	}
@@ -743,6 +768,76 @@ func validateReviewedPublicationRange(ctx context.Context, repo string, genesis 
 		return fmt.Errorf("publication range exceeds immutable genesis scope: %w", err)
 	}
 	return nil
+}
+
+func collectReviewedPublicationPaths(ctx context.Context, repo string, revisions []string) ([]string, error) {
+	pathSet := func(args ...string) (map[string]bool, error) {
+		output, err := runGit(ctx, repo, nil, nil, args...)
+		if err != nil {
+			return nil, err
+		}
+		paths := map[string]bool{}
+		for _, path := range splitNullSeparatedPaths(output) {
+			paths[path] = true
+		}
+		return paths, nil
+	}
+	args := append([]string{"log", "--no-merges", "--format=", "--name-only", "-z", "--no-renames"}, revisions...)
+	paths, err := pathSet(args...)
+	if err != nil {
+		return nil, err
+	}
+	args = append([]string{"rev-list", "--merges"}, revisions...)
+	output, err := runGit(ctx, repo, nil, nil, args...)
+	if err != nil {
+		return nil, err
+	}
+	for _, merge := range strings.Fields(string(output)) {
+		output, err = runGit(ctx, repo, nil, nil, "rev-list", "--parents", "-n", "1", merge)
+		if err != nil {
+			return nil, err
+		}
+		parents := strings.Fields(string(output))
+		if len(parents) != 3 || parents[0] != merge {
+			return nil, fmt.Errorf("publication merge %s must have exactly two parents", merge)
+		}
+		output, err = runGit(ctx, repo, nil, nil, "merge-base", "--all", parents[1], parents[2])
+		if err != nil {
+			return nil, err
+		}
+		bases := strings.Fields(string(output))
+		if len(bases) != 1 {
+			return nil, fmt.Errorf("publication merge %s must have exactly one merge base", merge)
+		}
+		pairs := [][2]string{{bases[0], parents[1]}, {bases[0], parents[2]}, {parents[1], merge}, {parents[2], merge}}
+		sets := make([]map[string]bool, len(pairs))
+		for i, pair := range pairs {
+			sets[i], err = pathSet("diff-tree", "--no-commit-id", "--name-only", "-z", "--no-renames", "-r", pair[0], pair[1])
+			if err != nil {
+				return nil, err
+			}
+		}
+		candidates := map[string]bool{}
+		for path := range sets[2] {
+			candidates[path] = true
+		}
+		for path := range sets[3] {
+			candidates[path] = true
+		}
+		for path := range candidates {
+			// Exclude only a path carried unchanged from exactly one parent;
+			// every other merge delta is candidate-authored publication scope.
+			if (sets[0][path] && !sets[1][path] && !sets[2][path]) || (sets[1][path] && !sets[0][path] && !sets[3][path]) {
+				continue
+			}
+			paths[path] = true
+		}
+	}
+	result := make([]string, 0, len(paths))
+	for path := range paths {
+		result = append(result, path)
+	}
+	return canonicalPaths(result)
 }
 
 func isPostReviewLifecycleArtifact(path string) bool {

--- a/internal/reviewtransaction/compact_gate_test.go
+++ b/internal/reviewtransaction/compact_gate_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -924,6 +925,105 @@ func TestValidateReviewedPublicationRangeAllowsRepeatedApprovedPathAcrossMergeHi
 	})
 	if err != nil {
 		t.Fatalf("repeated approved merge-history path: %v", err)
+	}
+}
+
+func TestValidateReviewedPublicationRangeExcludesReviewedAndTrackingHistory(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	base := trimGit(gitSnapshot(t, repo, "rev-parse", "HEAD"))
+
+	gitSnapshot(t, repo, "checkout", "-qb", "reviewed-base", base)
+	writeSnapshotFile(t, repo, "reviewed-only.txt", "reviewed ancestry\n")
+	gitSnapshot(t, repo, "add", "reviewed-only.txt")
+	gitSnapshot(t, repo, "commit", "-m", "reviewed ancestry")
+	reviewed := trimGit(gitSnapshot(t, repo, "rev-parse", "HEAD"))
+
+	gitSnapshot(t, repo, "checkout", "-qb", "tracking-tip", base)
+	writeSnapshotFile(t, repo, "upstream-only.txt", "tracking ancestry\n")
+	gitSnapshot(t, repo, "add", "upstream-only.txt")
+	gitSnapshot(t, repo, "commit", "-m", "tracking ancestry")
+	tracking := trimGit(gitSnapshot(t, repo, "rev-parse", "HEAD"))
+
+	gitSnapshot(t, repo, "checkout", "-qb", "feature", reviewed)
+	writeSnapshotFile(t, repo, "approved.txt", "reviewed feature\n")
+	gitSnapshot(t, repo, "add", "approved.txt")
+	gitSnapshot(t, repo, "commit", "-m", "reviewed feature")
+	gitSnapshot(t, repo, "merge", "--no-edit", "tracking-tip")
+	head := trimGit(gitSnapshot(t, repo, "rev-parse", "HEAD"))
+
+	refs := &resolvedPrePRRefs{
+		Selection:  PrePRBoundarySelection{Source: PrePRBoundaryExplicit, Commit: reviewed},
+		HeadCommit: head, BaseCommit: reviewed,
+		TrackingBoundary: PrePRBoundarySelection{Source: PrePRBoundaryPublicationDefault, Commit: tracking},
+		TrackingPresent:  true,
+	}
+	if err := validateReviewedPublicationRange(context.Background(), repo, []string{"approved.txt"}, refs); err != nil {
+		t.Fatalf("dual-anchor publication range: %v", err)
+	}
+
+	gitSnapshot(t, repo, "reset", "--hard", "HEAD^")
+	gitSnapshot(t, repo, "merge", "--no-commit", "tracking-tip")
+	if err := os.Remove(filepath.Join(repo, "upstream-only.txt")); err != nil {
+		t.Fatal(err)
+	}
+	gitSnapshot(t, repo, "add", "-A")
+	gitSnapshot(t, repo, "commit", "-m", "delete tracking path in merge")
+	refs.HeadCommit = trimGit(gitSnapshot(t, repo, "rev-parse", "HEAD"))
+	if err := validateReviewedPublicationRange(context.Background(), repo, []string{"approved.txt"}, refs); err == nil || !strings.Contains(err.Error(), "upstream-only.txt") {
+		t.Fatalf("one-parent-equal merge deletion = %v", err)
+	}
+
+	gitSnapshot(t, repo, "checkout", "-qb", "tracking-ahead", refs.HeadCommit)
+	gitSnapshot(t, repo, "commit", "--allow-empty", "-m", "tracking ahead")
+	refs.TrackingBoundary.Commit = trimGit(gitSnapshot(t, repo, "rev-parse", "HEAD"))
+	if err := validateReviewedPublicationRange(context.Background(), repo, []string{"approved.txt"}, refs); err == nil || !strings.Contains(err.Error(), "contains HEAD") {
+		t.Fatalf("tracking descendant exclusion = %v", err)
+	}
+}
+
+func TestSplitNullSeparatedPathsPreservesNewline(t *testing.T) {
+	want := []string{"line\nbreak.txt", "space name.txt"}
+	if got := splitNullSeparatedPaths([]byte("line\nbreak.txt\x00space name.txt\x00")); !reflect.DeepEqual(got, want) {
+		t.Fatalf("NUL path parsing = %#v, want %#v", got, want)
+	}
+}
+
+func TestValidateReviewedPublicationRangePreservesPathSemantics(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	writeSnapshotFile(t, repo, "old.txt", "rename me\n")
+	writeSnapshotFile(t, repo, "deleted.txt", "delete me\n")
+	gitSnapshot(t, repo, "add", "old.txt", "deleted.txt")
+	gitSnapshot(t, repo, "commit", "-m", "path base")
+	base := trimGit(gitSnapshot(t, repo, "rev-parse", "HEAD"))
+
+	if err := os.Rename(filepath.Join(repo, "old.txt"), filepath.Join(repo, "renamed.txt")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(filepath.Join(repo, "deleted.txt")); err != nil {
+		t.Fatal(err)
+	}
+	special := "space name.txt"
+	writeSnapshotFile(t, repo, special, "NUL-delimited path\n")
+	gitSnapshot(t, repo, "add", "-A")
+	gitSnapshot(t, repo, "commit", "-m", "rename delete and special path")
+	head := trimGit(gitSnapshot(t, repo, "rev-parse", "HEAD"))
+	refs := &resolvedPrePRRefs{
+		Selection:  PrePRBoundarySelection{Source: PrePRBoundaryExplicit, Commit: base},
+		BaseCommit: base, HeadCommit: head,
+	}
+	all, err := canonicalPaths([]string{"old.txt", "renamed.txt", "deleted.txt", special})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := validateReviewedPublicationRange(context.Background(), repo, all, refs); err != nil {
+		t.Fatalf("complete rename/delete/special-path scope: %v", err)
+	}
+	for index, missing := range all {
+		genesis := append([]string{}, all[:index]...)
+		genesis = append(genesis, all[index+1:]...)
+		if err := validateReviewedPublicationRange(context.Background(), repo, genesis, refs); err == nil || !strings.Contains(err.Error(), fmt.Sprintf("correction path %q", missing)) {
+			t.Fatalf("missing path %q error = %v", missing, err)
+		}
 	}
 }
 

--- a/internal/reviewtransaction/gate.go
+++ b/internal/reviewtransaction/gate.go
@@ -316,6 +316,8 @@ func EvaluateNativeGate(ctx context.Context, repo string, receipt Receipt, reque
 
 type resolvedPrePRRefs struct {
 	Selection            PrePRBoundarySelection
+	TrackingBoundary     PrePRBoundarySelection
+	TrackingPresent      bool
 	HeadCommit           string
 	BaseCommit           string
 	DeliveredCommitCount int
@@ -676,6 +678,47 @@ func selectPrePushBoundary(ctx context.Context, repo, selector string) (PrePRBou
 	return PrePRBoundarySelection{Source: PrePRBoundaryPublicationDefault, Selector: ref, Commit: commit, Remote: remote, RemoteRef: ref, RemoteIdentity: identity}, err
 }
 
+func resolvePrePushTrackingBoundary(ctx context.Context, repo string, selected PrePRBoundarySelection) (PrePRBoundarySelection, bool, error) {
+	switch selected.Source {
+	case PrePRBoundaryEmptyRemoteBootstrap:
+		return PrePRBoundarySelection{}, false, nil
+	case PrePRBoundaryPublicationDefault:
+		return selected, true, nil
+	case PrePRBoundaryExplicit:
+	default:
+		return PrePRBoundarySelection{}, false, errors.New("unsupported pre-push boundary source")
+	}
+	branchOutput, err := runGit(ctx, repo, nil, nil, "symbolic-ref", "--quiet", "--short", "HEAD")
+	if err != nil {
+		var commandErr *GitCommandError
+		if errors.As(err, &commandErr) && commandErr.ExitCode == 1 {
+			return PrePRBoundarySelection{}, false, nil
+		}
+		return PrePRBoundarySelection{}, false, fmt.Errorf("resolve configured tracking branch: %w", err)
+	}
+	branch := strings.TrimSpace(string(branchOutput))
+	upstream, err := runGit(ctx, repo, nil, nil, "for-each-ref", "--format=%(upstream:remotename)%00%(upstream:remoteref)", "refs/heads/"+branch)
+	if err != nil {
+		return PrePRBoundarySelection{}, false, fmt.Errorf("resolve configured tracking ref: %w", err)
+	}
+	parts := strings.SplitN(strings.TrimSpace(string(upstream)), "\x00", 2)
+	if len(parts) == 2 && parts[0] == "" && parts[1] == "" {
+		return PrePRBoundarySelection{}, false, nil
+	}
+	if len(parts) != 2 || parts[0] == "" || !strings.HasPrefix(parts[1], "refs/heads/") {
+		return PrePRBoundarySelection{}, false, errors.New("configured tracking upstream is not a remote branch")
+	}
+	remote, ref := parts[0], parts[1]
+	if _, empty := emptyRemoteBootstrapBoundary(ctx, repo); empty {
+		return PrePRBoundarySelection{}, false, nil
+	}
+	tracking, err := advertisedRemoteRef(ctx, repo, remote, ref, remote+"/"+strings.TrimPrefix(ref, "refs/heads/"), PrePRBoundaryPublicationDefault)
+	if err != nil {
+		return PrePRBoundarySelection{}, false, fmt.Errorf("resolve configured tracking boundary: %w", err)
+	}
+	return tracking, true, nil
+}
+
 // configuredUpstreamRef resolves the configured upstream remote and branch
 // ref for a local branch. It reports false when the upstream is missing,
 // ambiguous, or not a branch ref.
@@ -1013,6 +1056,10 @@ func prePushTargetForRequest(ctx context.Context, repo string, request GateReque
 	if request.Target.Kind == TargetBaseDiff && request.Target.BaseRef != "" && request.Target.BaseRef != target.BaseRef {
 		return Target{}, nil, errors.New("committed publication merge base changed during validation")
 	}
+	tracking, trackingPresent, err := resolvePrePushTrackingBoundary(ctx, repo, push.Boundary)
+	if err != nil {
+		return Target{}, nil, err
+	}
 	head, err := resolveCommit(ctx, repo, "HEAD")
 	if err != nil {
 		return Target{}, nil, err
@@ -1029,7 +1076,10 @@ func prePushTargetForRequest(ctx context.Context, repo string, request GateReque
 		// that publication-range and ancestry-disclosure checks scope to.
 		baseCommit = target.BaseRef
 	}
-	return target, &resolvedPrePRRefs{Selection: push.Boundary, HeadCommit: head, BaseCommit: baseCommit, DeliveredCommitCount: count, PushRemote: push.PushRemote}, nil
+	return target, &resolvedPrePRRefs{
+		Selection: push.Boundary, TrackingBoundary: tracking, TrackingPresent: trackingPresent,
+		HeadCommit: head, BaseCommit: baseCommit, DeliveredCommitCount: count, PushRemote: push.PushRemote,
+	}, nil
 }
 
 func commitCount(ctx context.Context, repo, base, head string) (int, error) {

--- a/internal/reviewtransaction/gate_test.go
+++ b/internal/reviewtransaction/gate_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -565,6 +566,115 @@ func TestPublicationTargetBindsAdvertisedUpstreamSeparatelyFromPushRemote(t *tes
 	gitSnapshot(t, repo, "config", "--unset", "branch."+branch+".merge")
 	if _, _, err := buildPushTarget(context.Background(), repo, "", "", ""); err == nil || !strings.Contains(err.Error(), "--base-ref") {
 		t.Fatalf("missing upstream error = %v", err)
+	}
+}
+
+func TestPrePushRefsKeepReviewedAndTrackingBoundariesIndependent(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	branch := currentBranch(context.Background(), repo)
+	base := trimGit(gitSnapshot(t, repo, "rev-parse", "HEAD"))
+	remote := configurePublicationRemote(t, repo, branch)
+	gitSnapshot(t, repo, "config", "branch."+branch+".remote", "origin")
+	gitSnapshot(t, repo, "config", "branch."+branch+".merge", "refs/heads/"+branch)
+	gitSnapshot(t, repo, "--git-dir", remote, "branch", "reviewed-base", base)
+	writeSnapshotFile(t, repo, "upstream.txt", "tracking advance\n")
+	gitSnapshot(t, repo, "add", "upstream.txt")
+	gitSnapshot(t, repo, "commit", "-m", "tracking advance")
+	tracking := trimGit(gitSnapshot(t, repo, "rev-parse", "HEAD"))
+	gitSnapshot(t, repo, "push", "origin", "HEAD:refs/heads/"+branch)
+	writeSnapshotFile(t, repo, "approved.txt", "reviewed delivery\n")
+	gitSnapshot(t, repo, "add", "approved.txt")
+	gitSnapshot(t, repo, "commit", "-m", "reviewed delivery")
+
+	target, push, err := buildPushTarget(context.Background(), repo, "origin/reviewed-base", "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, refs, err := prePushTargetForRequest(context.Background(), repo, GateRequest{Gate: GatePrePush, Target: target, Push: push})
+	if err != nil || refs.Selection.Commit != base || !refs.TrackingPresent || refs.TrackingBoundary.Commit != tracking {
+		t.Fatalf("independent reviewed/tracking refs = %#v, %v", refs, err)
+	}
+}
+
+func TestExplicitPrePushBaseAllowsAbsentTracking(t *testing.T) {
+	for _, detached := range []bool{false, true} {
+		t.Run(map[bool]string{false: "missing", true: "detached"}[detached], func(t *testing.T) {
+			repo := initSnapshotRepo(t)
+			branch := currentBranch(context.Background(), repo)
+			configurePublicationRemote(t, repo, branch)
+			if detached {
+				gitSnapshot(t, repo, "checkout", "--detach")
+			}
+			target, push, err := buildPushTarget(context.Background(), repo, "origin/"+branch, "", "")
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, refs, err := prePushTargetForRequest(context.Background(), repo, GateRequest{Gate: GatePrePush, Target: target, Push: push})
+			if err != nil || refs.TrackingPresent {
+				t.Fatalf("explicit base with absent tracking = %#v, %v", refs, err)
+			}
+		})
+	}
+}
+
+func TestExplicitPrePushBasePropagatesConfiguredTrackingResolutionError(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	branch := currentBranch(context.Background(), repo)
+	configurePublicationRemote(t, repo, branch)
+	gitSnapshot(t, repo, "remote", "add", "tracking", filepath.Join(t.TempDir(), "missing.git"))
+	gitSnapshot(t, repo, "config", "branch."+branch+".remote", "tracking")
+	gitSnapshot(t, repo, "config", "branch."+branch+".merge", "refs/heads/main")
+	gitSnapshot(t, repo, "config", "branch."+branch+".pushRemote", "origin")
+	target, push, err := buildPushTarget(context.Background(), repo, "origin/"+branch, "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _, err = prePushTargetForRequest(context.Background(), repo, GateRequest{Gate: GatePrePush, Target: target, Push: push})
+	var gitErr *GitCommandError
+	if !errors.As(err, &gitErr) {
+		t.Fatalf("configured tracking resolution error = %T %v", err, err)
+	}
+}
+
+func TestExplicitPrePushBasePropagatesTrackingContextCancellation(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, _, err := resolvePrePushTrackingBoundary(ctx, repo, PrePRBoundarySelection{Source: PrePRBoundaryExplicit})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("tracking context cancellation = %T %v", err, err)
+	}
+}
+
+func TestPrePushFinalAuthorizationRechecksTrackingBesidesExplicitBase(t *testing.T) {
+	repo, receipt, artifacts := approvedCurrentChangesGateFixture(t, "pre-push-tracking-recheck")
+	branch := currentBranch(context.Background(), repo)
+	reviewed := trimGit(gitSnapshot(t, repo, "rev-parse", "HEAD"))
+	remote := trimGit(gitSnapshot(t, repo, "remote", "get-url", "origin"))
+	gitSnapshot(t, repo, "branch", "reviewed-base", reviewed)
+	gitSnapshot(t, repo, "push", "origin", "reviewed-base:refs/heads/reviewed-base")
+	gitSnapshot(t, repo, "add", "tracked.txt")
+	gitSnapshot(t, repo, "commit", "-m", "reviewed delivery")
+	request, err := BuildNativeGateRequest(context.Background(), repo, NativeGateRequestInput{
+		Gate: GatePrePush, LineageID: receipt.LineageID, BaseRef: "origin/reviewed-base",
+		PolicyArtifact: artifacts.PolicyArtifact, LedgerArtifact: artifacts.LedgerArtifact, EvidenceArtifact: artifacts.EvidenceArtifact,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, refs, err := prePushTargetForRequest(context.Background(), repo, request)
+	if err != nil || !refs.TrackingPresent || refs.TrackingBoundary.Commit == refs.Selection.Commit {
+		t.Fatalf("distinct frozen tracking setup = %#v, %v", refs, err)
+	}
+
+	originalHook := finalGateAuthorizationHook
+	finalGateAuthorizationHook = func() {
+		finalGateAuthorizationHook = originalHook
+		gitSnapshot(t, repo, "--git-dir", remote, "update-ref", "refs/heads/"+branch, reviewed)
+	}
+	t.Cleanup(func() { finalGateAuthorizationHook = originalHook })
+	if got := EvaluateNativeGate(context.Background(), repo, receipt, request); got.Result != GateInvalidated || !strings.Contains(got.Reason, "final authorization") {
+		t.Fatalf("moving tracking boundary = %#v", got)
 	}
 }
 
@@ -1581,6 +1691,10 @@ func TestBuildPushTargetBootstrapsFirstPublicationOnEmptyRemote(t *testing.T) {
 	}
 	if target.BaseRef != reviewedBase {
 		t.Fatalf("bootstrap target base = %q, want reviewed base %q", target.BaseRef, reviewedBase)
+	}
+	_, refs, err := prePushTargetForRequest(context.Background(), repo, GateRequest{Gate: GatePrePush, Target: target, Push: push})
+	if err != nil || refs.TrackingPresent {
+		t.Fatalf("empty-remote tracking boundary = %#v, %v", refs, err)
 	}
 }
 


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1605

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)

## 📝 Summary

Corrects pre-push publication scope for merged histories. Reviewed and configured tracking boundaries are frozen independently, and publication paths are derived from reachable non-merge commits plus explicit binary-merge analysis that excludes only clean one-parent carries while retaining feature history, corrections, and manual merge resolutions.

Unsafe negative anchors, octopus merges, multiple merge bases, malformed topology, and Git failures now fail closed. Strict bootstrap ancestry disclosure remains unchanged.

## 📂 Changes

| Area | What Changed |
|------|-------------|
| Pre-push refs | Freeze reviewed and tracking anchors independently and detect either moving before authorization |
| Publication collector | Replace per-parent synthetic history with legacy-safe nonmerge/merge path classification |
| Topology guards | Reject exclusions containing HEAD and unsupported/ambiguous merge structures |
| Regression tests | Cover upstream-only history, one-parent-equal deletion, add/revert, rename/delete, special paths, anchor movement, bootstrap, and Windows portability |

## 🧪 Test Plan

- [x] Focused RED→GREEN topology regressions pass
- [x] Focused and full `reviewtransaction` race suites pass
- [x] `go test ./... -count=1`
- [x] `go run ./internal/gofmtcheck`
- [x] `go vet ./...`
- [x] Module and review contract/capability checks pass
- [x] Linux, macOS, and Windows cross-builds pass
- [x] Windows package tests cross-compile
- [ ] Native Windows execution unavailable locally; required CI executes it

## 🔍 Independent Review

Full resilience, integrity, reliability, and readability review found that dense combined diffs hid one-parent-equal merge deletions, descendant tracking anchors could erase the walk, and one filename fixture was invalid on Windows. One bounded correction implemented a legacy-safe three-way classifier and portable tests; targeted validation returned PASS.

- Candidate: `ddd7ba78e344baf7d0744f09d8298a0a26b235eb`
- Tree: `9bc7061992b64c17e15dbde4c993e38240a6cf2d`
- Diff SHA-256: `288015e6f753ea657339ef90c003c8c700bf46dbcb3a4b1409e601664a4bcb12`
- Correction: 120/134 allowed lines

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [x] Exactly one `type:*` label is applied
- [x] Unit, race, format, vet, module, contract, and cross-build checks pass
- [ ] Native Windows/E2E validation — delegated to required CI
- [x] Documentation is not required for this internal publication topology fix
- [x] Commits follow Conventional Commits format
- [x] Commits contain no `Co-Authored-By` trailers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved publication-range validation for merged histories, including correct handling of renames, deletions, and special-character paths.
  * Ensured reviewed and tracking history can’t incorrectly widen or erase the validated publication scope.
  * Enhanced pre-push validation to more reliably resolve and separate explicit base selection vs tracking boundary behavior, including empty-remote bootstrap and detached states.
  * Added safeguards to re-check tracking during final authorization so requests become invalid if the tracking boundary moves.
* **Tests**
  * Expanded coverage for reviewed/tracking boundary scenarios and stricter path parsing/canonicalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
