### PR TITLE
fix(review): preserve missing-upstream target errors

### DIFF
--- a/contracts/review-integration/v1/schemas/failure.schema.json
+++ b/contracts/review-integration/v1/schemas/failure.schema.json
@@ -49,7 +49,8 @@
           "reason",
           "actor",
           "incident",
-          "maintainer_authorization"
+          "maintainer_authorization",
+          "base_ref"
         ]
       }
     },

--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -1755,6 +1755,15 @@ func runReviewFacadeValidate(ctx context.Context, args []string, stdout io.Write
 		}
 	}
 	if !negotiated {
+		var targetResolution *reviewtransaction.GateTargetResolutionError
+		if errors.As(compactErr, &targetResolution) {
+			return emitFacadeGateEvaluationNegotiated(stdout, reviewtransaction.NativeGateEvaluation{
+				Result: reviewtransaction.GateInvalidated, Reason: targetResolution.Error(), Cause: compactErr,
+				Context: reviewtransaction.GateContext{
+					Gate: gateInput.Gate, Denial: &reviewtransaction.GateDenial{Stage: "target-resolution", Code: "target_resolution_failed"},
+				},
+			}, false)
+		}
 		var discovery *ReviewReceiptDiscoveryError
 		if errors.As(compactErr, &discovery) {
 			result := reviewtransaction.GateInvalidated
@@ -1822,6 +1831,11 @@ func discoverCompactFacadeGateReview(ctx context.Context, repo, lineage string, 
 	scopeChanged := []candidate{}
 	scopeWithoutContext := []string{}
 	assessmentUnknown := []string{}
+	type targetResolutionFailure struct {
+		lineage string
+		err     error
+	}
+	targetResolution := []targetResolutionFailure{}
 	terminalCount := 0
 	allLineages := []string{}
 	for _, store := range stores {
@@ -1848,6 +1862,11 @@ func discoverCompactFacadeGateReview(ctx context.Context, repo, lineage string, 
 		candidateInput.IntendedUntracked = append([]string(nil), record.State.CurrentSnapshot.IntendedUntracked...)
 		assessment, assessErr := reviewtransaction.AssessCompactGateTarget(ctx, repo, record.State, candidateInput)
 		if assessErr != nil {
+			var targetErr *reviewtransaction.GateTargetResolutionError
+			if errors.As(assessErr, &targetErr) {
+				targetResolution = append(targetResolution, targetResolutionFailure{lineage: record.State.LineageID, err: assessErr})
+				continue
+			}
 			assessmentUnknown = append(assessmentUnknown, record.State.LineageID)
 			continue
 		}
@@ -1888,23 +1907,32 @@ func discoverCompactFacadeGateReview(ctx context.Context, repo, lineage string, 
 		return reviewtransaction.CompactStore{}, reviewtransaction.CompactRecord{}, &ReviewReceiptDiscoveryError{Kind: ReviewReceiptMissing}
 	}
 	scopeCandidateCount := len(scopeChanged) + len(scopeWithoutContext)
-	if scopeCandidateCount > 0 && scopeCandidateCount+len(assessmentUnknown) > 1 {
-		lineages := make([]string, 0, scopeCandidateCount+len(assessmentUnknown))
+	if scopeCandidateCount > 0 && scopeCandidateCount+len(assessmentUnknown)+len(targetResolution) > 1 {
+		lineages := make([]string, 0, scopeCandidateCount+len(assessmentUnknown)+len(targetResolution))
 		for index := range scopeChanged {
 			lineages = append(lineages, scopeChanged[index].record.State.LineageID)
 		}
 		lineages = append(lineages, scopeWithoutContext...)
 		lineages = append(lineages, assessmentUnknown...)
+		for _, failure := range targetResolution {
+			lineages = append(lineages, failure.lineage)
+		}
 		sort.Strings(lineages)
 		return reviewtransaction.CompactStore{}, reviewtransaction.CompactRecord{}, &ReviewReceiptDiscoveryError{Kind: ReviewReceiptAmbiguous, Candidates: lineages}
 	}
-	if len(scopeChanged) == 1 && len(scopeWithoutContext) == 0 && len(assessmentUnknown) == 0 {
+	if len(scopeChanged) == 1 && len(scopeWithoutContext) == 0 && len(assessmentUnknown) == 0 && len(targetResolution) == 0 {
 		context := scopeChanged[0].context
 		return reviewtransaction.CompactStore{}, reviewtransaction.CompactRecord{}, &ReviewReceiptDiscoveryError{
 			Kind: ReviewReceiptScopeChanged, Candidates: []string{scopeChanged[0].record.State.LineageID}, Context: &context,
 		}
 	}
 	if len(scopeWithoutContext) > 0 || len(assessmentUnknown) > 0 {
+		return reviewtransaction.CompactStore{}, reviewtransaction.CompactRecord{}, &ReviewReceiptDiscoveryError{Kind: ReviewAuthorityCorrupted}
+	}
+	if len(targetResolution) == terminalCount {
+		return reviewtransaction.CompactStore{}, reviewtransaction.CompactRecord{}, targetResolution[0].err
+	}
+	if len(targetResolution) > 0 {
 		return reviewtransaction.CompactStore{}, reviewtransaction.CompactRecord{}, &ReviewReceiptDiscoveryError{Kind: ReviewAuthorityCorrupted}
 	}
 	sort.Strings(allLineages)

--- a/internal/cli/review_failure_contract_test.go
+++ b/internal/cli/review_failure_contract_test.go
@@ -947,6 +947,10 @@ func TestReviewIntegrationFailureSchemaAndFixtureAreStrict(t *testing.T) {
 		schema["$id"] != ReviewIntegrationFailureSchemaID || schema["additionalProperties"] != false {
 		t.Fatalf("failure schema header = %#v", schema)
 	}
+	inputs := schemaStringArray(t, schema["properties"].(map[string]any)["required_inputs"].(map[string]any)["items"].(map[string]any)["enum"])
+	if !containsString(inputs, "base_ref") {
+		t.Fatalf("failure required_inputs vocabulary = %v", inputs)
+	}
 	fixture, err := os.ReadFile(filepath.Join(root, "fixtures", "failure.fixture.json"))
 	if err != nil {
 		t.Fatal(err)
@@ -1004,6 +1008,27 @@ func TestReviewIntegrationFailureSchemaAndFixtureAreStrict(t *testing.T) {
 	bindingDecoder.DisallowUnknownFields()
 	if err := bindingDecoder.Decode(&ReviewIntegrationFailure{}); err == nil {
 		t.Fatal("strict failure decoder accepted a private binding-revision field")
+	}
+}
+
+func TestReviewIntegrationFailureMapsTargetResolutionBeforeGateDenial(t *testing.T) {
+	targetErr := &reviewtransaction.GateTargetResolutionError{
+		RequiredInput: "base_ref",
+		Err:           errors.New("configured upstream is missing; pass --base-ref <remote>/<branch>"),
+	}
+	failure := newReviewIntegrationFailure(ReviewIntegrationOperationValidate, nil, ReviewGateDeniedError{
+		Result: reviewtransaction.GateInvalidated,
+		Cause:  targetErr,
+	})
+	if failure.Phase != "pre_native" || failure.Code != "target_resolution_failed" ||
+		failure.MutationOutcome != ReviewMutationNotStarted || failure.AuthorityApplicability != "not_evaluated" ||
+		!failure.RetrySafe || failure.Replayability != reviewtransaction.ReplayabilityNotReplayable ||
+		!reflect.DeepEqual(failure.RequiredInputs, []string{"base_ref"}) || failure.NextAction != "correct_request" ||
+		!strings.Contains(failure.Message, "--base-ref") {
+		t.Fatalf("target-resolution failure mapping = %#v", failure)
+	}
+	if err := failure.Validate(); err != nil {
+		t.Fatalf("target-resolution failure validation = %v", err)
 	}
 }
 

--- a/internal/cli/review_operation_contract.go
+++ b/internal/cli/review_operation_contract.go
@@ -483,6 +483,19 @@ func newReviewIntegrationFailure(operation string, args []string, runErr error) 
 		}
 		return failure
 	}
+	var targetResolution *reviewtransaction.GateTargetResolutionError
+	if errors.As(runErr, &targetResolution) {
+		failure.Phase = "pre_native"
+		failure.Code = "target_resolution_failed"
+		failure.Message = "The pre-push target cannot be resolved; configure an upstream or pass --base-ref <remote>/<branch>."
+		failure.MutationOutcome = ReviewMutationNotStarted
+		failure.AuthorityApplicability = "not_evaluated"
+		failure.RetrySafe = true
+		failure.Replayability = reviewtransaction.ReplayabilityNotReplayable
+		failure.RequiredInputs = []string{"base_ref"}
+		failure.NextAction = "correct_request"
+		return failure
+	}
 	var denied ReviewGateDeniedError
 	if errors.As(runErr, &denied) {
 		failure.Phase = "preflight"
@@ -864,7 +877,7 @@ func validOptionalReviewSHA256(value string) bool {
 
 func supportedReviewIntegrationFailureInput(input string) bool {
 	switch input {
-	case "lineage_id", "change", "expected_binding_revision", "predecessor_lineage_id", "expected_predecessor_revision", "successor_lineage_id", "disposition", "reason", "actor", "incident", "maintainer_authorization":
+	case "lineage_id", "change", "expected_binding_revision", "predecessor_lineage_id", "expected_predecessor_revision", "successor_lineage_id", "disposition", "reason", "actor", "incident", "maintainer_authorization", "base_ref":
 		return true
 	default:
 		return false

--- a/internal/cli/review_receipt_discovery_test.go
+++ b/internal/cli/review_receipt_discovery_test.go
@@ -179,6 +179,94 @@ func TestUnqualifiedGateDiscoveryReturnsTypedMissingAndScopeChanged(t *testing.T
 	})
 }
 
+func TestUnqualifiedPrePushDiscoveryReportsTargetResolutionWithoutMutation(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	_, store := approveDiscoveryMarkdown(t, repo, "review-discovery-missing-upstream", "docs/reviewed.md", "reviewed\n")
+	runReviewCLIGit(t, repo, "add", "-A")
+	runReviewCLIGit(t, repo, "commit", "-qm", "deliver reviewed target")
+	stateBefore, err := os.ReadFile(store.StatePath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	receiptBefore, err := os.ReadFile(store.ReceiptPath())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var first bytes.Buffer
+	runErr := RunReview([]string{
+		"validate", "--contract", ReviewIntegrationContractV1, "--cwd", repo,
+		"--gate", string(reviewtransaction.GatePrePush),
+	}, &first)
+	if runErr == nil {
+		t.Fatal("missing-upstream pre-push validation succeeded")
+	}
+	failure := decodeReviewIntegrationFailure(t, first.Bytes())
+	if failure.Phase != "pre_native" || failure.Code != "target_resolution_failed" ||
+		failure.MutationOutcome != ReviewMutationNotStarted || failure.AuthorityApplicability != "not_evaluated" ||
+		!failure.RetrySafe || failure.Replayability != reviewtransaction.ReplayabilityNotReplayable ||
+		!reflect.DeepEqual(failure.RequiredInputs, []string{"base_ref"}) || failure.NextAction != "correct_request" ||
+		!strings.Contains(failure.Message, "--base-ref") {
+		t.Fatalf("target-resolution failure = %#v", failure)
+	}
+	var targetErr *reviewtransaction.GateTargetResolutionError
+	if !errors.As(runErr, &targetErr) {
+		t.Fatalf("target-resolution cause = %T %v", runErr, runErr)
+	}
+
+	var second bytes.Buffer
+	if err := RunReview([]string{
+		"validate", "--contract", ReviewIntegrationContractV1, "--cwd", repo,
+		"--gate", string(reviewtransaction.GatePrePush),
+	}, &second); err == nil || !bytes.Equal(first.Bytes(), second.Bytes()) {
+		t.Fatalf("repeated target-resolution failure changed: %v\nfirst=%s\nsecond=%s", err, first.String(), second.String())
+	}
+	stateAfter, stateErr := os.ReadFile(store.StatePath())
+	receiptAfter, receiptErr := os.ReadFile(store.ReceiptPath())
+	if stateErr != nil || receiptErr != nil || !bytes.Equal(stateBefore, stateAfter) || !bytes.Equal(receiptBefore, receiptAfter) {
+		t.Fatalf("target resolution mutated authority: state=%v receipt=%v", stateErr, receiptErr)
+	}
+
+	var raw bytes.Buffer
+	rawErr := RunReviewFacadeValidate([]string{"--cwd", repo, "--gate", string(reviewtransaction.GatePrePush)}, &raw)
+	var evaluation ReviewValidateResult
+	decodeStrictReviewJSON(t, raw.Bytes(), &evaluation)
+	if rawErr == nil || evaluation.Result != reviewtransaction.GateInvalidated || evaluation.Context.Denial == nil ||
+		evaluation.Context.Denial.Stage != "target-resolution" || evaluation.Context.Denial.Code != "target_resolution_failed" ||
+		!errors.As(rawErr, &targetErr) {
+		t.Fatalf("non-negotiated target resolution = %#v, %T %v", evaluation, rawErr, rawErr)
+	}
+}
+
+func TestUnqualifiedPrePushDiscoveryKeepsCorruptAuthorityPrecedence(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	approveDiscoveryMarkdown(t, repo, "review-discovery-target-and-corruption", "docs/reviewed.md", "reviewed\n")
+	runReviewCLIGit(t, repo, "add", "-A")
+	runReviewCLIGit(t, repo, "commit", "-qm", "deliver reviewed target")
+	commonDir := filepath.Clean(strings.TrimSpace(runReviewCLIGit(t, repo, "rev-parse", "--path-format=absolute", "--git-common-dir")))
+	broken := filepath.Join(commonDir, "gentle-ai", "review-transactions", "v2", "corrupt-target-candidate")
+	if err := os.MkdirAll(broken, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(broken, "review-state.json"), []byte("{\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var output bytes.Buffer
+	runErr := RunReview([]string{
+		"validate", "--contract", ReviewIntegrationContractV1, "--cwd", repo,
+		"--gate", string(reviewtransaction.GatePrePush),
+	}, &output)
+	if runErr == nil {
+		t.Fatal("corrupt authority with missing upstream validated")
+	}
+	failure := decodeReviewIntegrationFailure(t, output.Bytes())
+	var targetErr *reviewtransaction.GateTargetResolutionError
+	if failure.Code != "authority_corrupted" || failure.AuthorityApplicability != "corrupted" || errors.As(runErr, &targetErr) {
+		t.Fatalf("corrupt-authority precedence = %#v, %T %v", failure, runErr, runErr)
+	}
+}
+
 func TestUnqualifiedGateDiscoveryRoutesCommittedNextSliceWorkspace(t *testing.T) {
 	// #1401: after one approved slice is committed exactly as reviewed, new
 	// dirty tracked work on top must classify as unrelated or scope-changed,

--- a/internal/reviewtransaction/gate.go
+++ b/internal/reviewtransaction/gate.go
@@ -471,14 +471,51 @@ func resolveAuthoritativePublicationBase(ctx context.Context, repo string) (stri
 	return selection.RemoteRef, selection.Remote, selection.Commit, nil
 }
 
-func resolveTrackingUpstreamBase(ctx context.Context, repo string) (string, string, string, error) {
-	branch := currentBranch(ctx, repo)
-	if branch == "" {
-		return "", "", "", errors.New("configured upstream is unavailable on detached HEAD; pass --base-ref <remote>/<branch>")
+// GateTargetResolutionError reports a semantic target-selection failure that
+// the caller can correct by supplying the named input. It does not represent
+// receipt-authority corruption or a Git process failure.
+type GateTargetResolutionError struct {
+	RequiredInput string
+	Err           error
+}
+
+func (err *GateTargetResolutionError) Error() string {
+	if err == nil || err.Err == nil {
+		return "review gate target resolution failed"
 	}
-	remote, ref, ok := configuredUpstreamRef(ctx, repo, branch)
+	return err.Err.Error()
+}
+
+func (err *GateTargetResolutionError) Unwrap() error {
+	if err == nil {
+		return nil
+	}
+	return err.Err
+}
+
+func prePushTargetResolutionError(message string) error {
+	return &GateTargetResolutionError{RequiredInput: "base_ref", Err: errors.New(message)}
+}
+
+func resolveTrackingUpstreamBase(ctx context.Context, repo string) (string, string, string, error) {
+	branchOutput, err := runGit(ctx, repo, nil, nil, "symbolic-ref", "--quiet", "--short", "HEAD")
+	if err != nil {
+		var commandErr *GitCommandError
+		if errors.As(err, &commandErr) && commandErr.ExitCode == 1 {
+			return "", "", "", prePushTargetResolutionError("configured upstream is unavailable on detached HEAD; pass --base-ref <remote>/<branch>")
+		}
+		return "", "", "", fmt.Errorf("resolve configured tracking branch: %w", err)
+	}
+	branch := strings.TrimSpace(string(branchOutput))
+	if branch == "" {
+		return "", "", "", prePushTargetResolutionError("configured upstream is unavailable on detached HEAD; pass --base-ref <remote>/<branch>")
+	}
+	remote, ref, ok, err := configuredUpstreamRef(ctx, repo, branch)
+	if err != nil {
+		return "", "", "", fmt.Errorf("resolve configured tracking ref: %w", err)
+	}
 	if !ok {
-		return "", "", "", errors.New("configured upstream is missing or ambiguous; pass --base-ref <remote>/<branch>")
+		return "", "", "", prePushTargetResolutionError("configured upstream is missing or ambiguous; pass --base-ref <remote>/<branch>")
 	}
 	selection, err := advertisedRemoteRef(ctx, repo, remote, ref, remote+"/"+strings.TrimPrefix(ref, "refs/heads/"), PrePRBoundaryPublicationDefault)
 	if err != nil {
@@ -721,14 +758,17 @@ func resolvePrePushTrackingBoundary(ctx context.Context, repo string, selected P
 
 // configuredUpstreamRef resolves the configured upstream remote and branch
 // ref for a local branch. It reports false when the upstream is missing,
-// ambiguous, or not a branch ref.
-func configuredUpstreamRef(ctx context.Context, repo, branch string) (string, string, bool) {
+// ambiguous, or not a branch ref, and preserves Git execution failures.
+func configuredUpstreamRef(ctx context.Context, repo, branch string) (string, string, bool, error) {
 	output, err := runGit(ctx, repo, nil, nil, "for-each-ref", "--format=%(upstream:remotename)%00%(upstream:remoteref)", "refs/heads/"+branch)
-	parts := strings.SplitN(strings.TrimSpace(string(output)), "\x00", 2)
-	if err != nil || len(parts) != 2 || parts[0] == "" || !strings.HasPrefix(parts[1], "refs/heads/") {
-		return "", "", false
+	if err != nil {
+		return "", "", false, err
 	}
-	return parts[0], parts[1], true
+	parts := strings.SplitN(strings.TrimSpace(string(output)), "\x00", 2)
+	if len(parts) != 2 || parts[0] == "" || !strings.HasPrefix(parts[1], "refs/heads/") {
+		return "", "", false, nil
+	}
+	return parts[0], parts[1], true, nil
 }
 
 // emptyRemoteBootstrapBoundary recognizes the first-publication case only:
@@ -745,8 +785,8 @@ func emptyRemoteBootstrapBoundary(ctx context.Context, repo string) (PrePRBounda
 	if branch == "" {
 		return PrePRBoundarySelection{}, false
 	}
-	remote, ref, ok := configuredUpstreamRef(ctx, repo, branch)
-	if !ok {
+	remote, ref, ok, err := configuredUpstreamRef(ctx, repo, branch)
+	if err != nil || !ok {
 		return PrePRBoundarySelection{}, false
 	}
 	advertised, err := runGit(ctx, repo, nil, nil, "ls-remote", remote)

--- a/internal/reviewtransaction/gate_test.go
+++ b/internal/reviewtransaction/gate_test.go
@@ -617,6 +617,52 @@ func TestExplicitPrePushBaseAllowsAbsentTracking(t *testing.T) {
 	}
 }
 
+func TestDefaultPrePushBaseReportsTypedTargetResolution(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		prepare func(*testing.T, string, string)
+	}{
+		{name: "missing upstream"},
+		{name: "detached head", prepare: func(t *testing.T, repo, _ string) {
+			gitSnapshot(t, repo, "checkout", "--detach")
+		}},
+		{name: "non-branch upstream", prepare: func(t *testing.T, repo, branch string) {
+			configurePublicationRemote(t, repo, branch)
+			gitSnapshot(t, repo, "config", "branch."+branch+".remote", "origin")
+			gitSnapshot(t, repo, "config", "branch."+branch+".merge", "refs/tags/not-a-branch")
+		}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := initSnapshotRepo(t)
+			branch := currentBranch(context.Background(), repo)
+			if tt.prepare != nil {
+				tt.prepare(t, repo, branch)
+			}
+			_, _, _, err := resolveTrackingUpstreamBase(context.Background(), repo)
+			var targetErr *GateTargetResolutionError
+			if !errors.As(err, &targetErr) || targetErr.RequiredInput != "base_ref" || !strings.Contains(err.Error(), "--base-ref") {
+				t.Fatalf("target resolution error = %T %v", err, err)
+			}
+		})
+	}
+}
+
+func TestDefaultPrePushBaseKeepsInfrastructureErrorsUntyped(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	branch := currentBranch(context.Background(), repo)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, _, _, err := resolveTrackingUpstreamBase(ctx, repo)
+	var targetErr *GateTargetResolutionError
+	if !errors.Is(err, context.Canceled) || errors.As(err, &targetErr) {
+		t.Fatalf("cancelled target resolution error = %T %v", err, err)
+	}
+	_, _, _, upstreamErr := configuredUpstreamRef(ctx, repo, branch)
+	if !errors.Is(upstreamErr, context.Canceled) || errors.As(upstreamErr, &targetErr) {
+		t.Fatalf("cancelled upstream lookup error = %T %v", upstreamErr, upstreamErr)
+	}
+}
+
 func TestExplicitPrePushBasePropagatesConfiguredTrackingResolutionError(t *testing.T) {
 	repo := initSnapshotRepo(t)
 	branch := currentBranch(context.Background(), repo)


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1551

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)

## 📝 Summary

Preserve actionable pre-push target-resolution failures when compact receipt discovery cannot derive a tracking upstream. Semantic missing, detached, or non-branch upstream states now remain distinct from Git/process failures and from corrupted review authority.

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/reviewtransaction/gate.go` | Added a typed semantic target-resolution boundary while preserving infrastructure failures and first-publication bootstrap behavior |
| `internal/cli/review_facade.go` | Preserved typed failures across all receipt candidates without masking corrupted authority |
| `internal/cli/review_operation_contract.go` | Mapped negotiated failures to actionable `base_ref` input metadata |
| `contracts/review-integration/v1/schemas/failure.schema.json` | Added `base_ref` to the existing required-input vocabulary |
| Regression tests | Covered detached/missing upstreams, infrastructure errors, candidate precedence, immutability, and failure envelopes |

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./...
```

**Go Format**
```bash
go run ./internal/gofmtcheck
```

**Additional verification**
```bash
go vet ./...
./scripts/test-review-contract-package.sh
./scripts/test-review-capabilities.sh
```

- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — delegated to required CI
- [x] Manually tested locally

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — delegated to required CI
- [x] Documentation is not required for this internal failure-classification change
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers

## Review Evidence

- Candidate: `1b67fc2c277bdb2d49ae5707f2268c057952d7be`
- Tree: `f2f043ab5e6464a2f4ee3d09400e6b54b25fd2f8`
- Independent risk, resilience, reliability, and readability lenses found no blockers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved pre-push validation when the target branch cannot be determined.
  * Failures now identify `base_ref` as a required input and provide guidance to configure an upstream or use `--base-ref`.
  * Target-resolution failures are reported with clearer status, retry guidance, and denial details.

* **Bug Fixes**
  * Preserved authority-corruption classification when target resolution fails.
  * Prevented failed validation attempts from modifying authority state or receipt files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->