### PR TITLE
fix(install): replace the Unix binary atomically

### DIFF
--- a/internal/update/install_script_test.go
+++ b/internal/update/install_script_test.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -257,7 +258,10 @@ func TestWindowsInstallScriptFallbackChecksumExecution(t *testing.T) {
 	t.Logf("PowerShell fallback test output:\n%s", string(out))
 }
 
-func TestInstallScriptAtomicBinaryReplacementStructure(t *testing.T) {
+func TestInstallScriptAtomicBinaryReplacement(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping Unix bash install script test on Windows")
+	}
 	path := filepath.Join("..", "..", "scripts", "install.sh")
 	content, err := os.ReadFile(path)
 	if err != nil {

--- a/internal/update/install_script_test.go
+++ b/internal/update/install_script_test.go
@@ -72,9 +72,9 @@ func TestInstallScriptBetaGoInstallBypassesPublicGoProxy(t *testing.T) {
 
 	script := string(content)
 	for _, want := range []string{
-		"prepend_go_env_pattern GONOSUMDB github.com/gentleman-programming/gentle-ai/v2",
-		"prepend_go_env_pattern GOPRIVATE github.com/gentleman-programming/gentle-ai/v2",
-		"prepend_go_env_pattern GONOPROXY github.com/gentleman-programming/gentle-ai/v2",
+		"prepend_go_env_pattern GONOSUMDB github.com/gentleman-programming/gentle-ai",
+		"prepend_go_env_pattern GOPRIVATE github.com/gentleman-programming/gentle-ai",
+		"prepend_go_env_pattern GONOPROXY github.com/gentleman-programming/gentle-ai",
 		"go install \"$go_package\"",
 	} {
 		if !strings.Contains(script, want) {
@@ -83,9 +83,9 @@ func TestInstallScriptBetaGoInstallBypassesPublicGoProxy(t *testing.T) {
 	}
 
 	for _, clobber := range []string{
-		"GONOSUMDB=github.com/gentleman-programming/gentle-ai/v2 \\",
-		"GOPRIVATE=github.com/gentleman-programming/gentle-ai/v2 \\",
-		"GONOPROXY=github.com/gentleman-programming/gentle-ai/v2 \\",
+		"GONOSUMDB=github.com/gentleman-programming/gentle-ai \\",
+		"GOPRIVATE=github.com/gentleman-programming/gentle-ai \\",
+		"GONOPROXY=github.com/gentleman-programming/gentle-ai \\",
 	} {
 		if strings.Contains(script, clobber) {
 			t.Fatalf("scripts/install.sh clobbers existing user env with %q; beta proxy bypass must preserve existing patterns", clobber)
@@ -106,10 +106,10 @@ func TestInstallScriptBetaGoInstallBypassesPublicGoProxy(t *testing.T) {
 	cmd := exec.Command("bash", "-c", function+`
 GONOSUMDB=example.com/private
 GOPRIVATE=github.com/acme/*
-GONOPROXY=github.com/gentleman-programming/gentle-ai/v2
-prepend_go_env_pattern GONOSUMDB github.com/gentleman-programming/gentle-ai/v2
-prepend_go_env_pattern GOPRIVATE github.com/gentleman-programming/gentle-ai/v2
-prepend_go_env_pattern GONOPROXY github.com/gentleman-programming/gentle-ai/v2
+GONOPROXY=github.com/gentleman-programming/gentle-ai
+prepend_go_env_pattern GONOSUMDB github.com/gentleman-programming/gentle-ai
+prepend_go_env_pattern GOPRIVATE github.com/gentleman-programming/gentle-ai
+prepend_go_env_pattern GONOPROXY github.com/gentleman-programming/gentle-ai
 printf '%s\n%s\n%s\n' "$GONOSUMDB" "$GOPRIVATE" "$GONOPROXY"
 `)
 	out, err := cmd.CombinedOutput()
@@ -119,9 +119,9 @@ printf '%s\n%s\n%s\n' "$GONOSUMDB" "$GOPRIVATE" "$GONOPROXY"
 
 	got := strings.TrimSpace(string(out))
 	want := strings.Join([]string{
-		"github.com/gentleman-programming/gentle-ai/v2,example.com/private",
-		"github.com/gentleman-programming/gentle-ai/v2,github.com/acme/*",
-		"github.com/gentleman-programming/gentle-ai/v2",
+		"github.com/gentleman-programming/gentle-ai,example.com/private",
+		"github.com/gentleman-programming/gentle-ai,github.com/acme/*",
+		"github.com/gentleman-programming/gentle-ai",
 	}, "\n")
 	if got != want {
 		t.Fatalf("prepend_go_env_pattern output = %q, want %q", got, want)
@@ -137,9 +137,9 @@ func TestWindowsInstallScriptBetaGoInstallPreservesGoProxyBypassEnv(t *testing.T
 
 	script := string(content)
 	for _, want := range []string{
-		"Add-GoEnvPattern -Name \"GONOSUMDB\" -Pattern \"github.com/gentleman-programming/gentle-ai/v2\"",
-		"Add-GoEnvPattern -Name \"GOPRIVATE\" -Pattern \"github.com/gentleman-programming/gentle-ai/v2\"",
-		"Add-GoEnvPattern -Name \"GONOPROXY\" -Pattern \"github.com/gentleman-programming/gentle-ai/v2\"",
+		"Add-GoEnvPattern -Name \"GONOSUMDB\" -Pattern \"github.com/gentleman-programming/gentle-ai\"",
+		"Add-GoEnvPattern -Name \"GOPRIVATE\" -Pattern \"github.com/gentleman-programming/gentle-ai\"",
+		"Add-GoEnvPattern -Name \"GONOPROXY\" -Pattern \"github.com/gentleman-programming/gentle-ai\"",
 		"& go install $goPackage",
 	} {
 		if !strings.Contains(script, want) {
@@ -148,9 +148,9 @@ func TestWindowsInstallScriptBetaGoInstallPreservesGoProxyBypassEnv(t *testing.T
 	}
 
 	for _, clobber := range []string{
-		"$env:GONOSUMDB = \"github.com/gentleman-programming/gentle-ai/v2\"",
-		"$env:GOPRIVATE = \"github.com/gentleman-programming/gentle-ai/v2\"",
-		"$env:GONOPROXY = \"github.com/gentleman-programming/gentle-ai/v2\"",
+		"$env:GONOSUMDB = \"github.com/gentleman-programming/gentle-ai\"",
+		"$env:GOPRIVATE = \"github.com/gentleman-programming/gentle-ai\"",
+		"$env:GONOPROXY = \"github.com/gentleman-programming/gentle-ai\"",
 	} {
 		if strings.Contains(script, clobber) {
 			t.Fatalf("scripts/install.ps1 clobbers existing user env with %q; beta proxy bypass must preserve existing patterns", clobber)
@@ -161,7 +161,7 @@ func TestWindowsInstallScriptBetaGoInstallPreservesGoProxyBypassEnv(t *testing.T
 	if start == -1 {
 		t.Fatal("scripts/install.ps1 is missing Add-GoEnvPattern function")
 	}
-	endMarker := "\n}\n\nfunction Test-Installation"
+	endMarker := "\n}\n\n# ============================================================================\n# Install via binary download"
 	end := strings.Index(script[start:], endMarker)
 	if end == -1 {
 		t.Fatal("could not locate end of Add-GoEnvPattern function")
@@ -176,6 +176,102 @@ func TestWindowsInstallScriptBetaGoInstallPreservesGoProxyBypassEnv(t *testing.T
 	} {
 		if !strings.Contains(function, want) {
 			t.Fatalf("Add-GoEnvPattern does not preserve existing env patterns; missing %q", want)
+		}
+	}
+}
+
+// TestWindowsInstallScriptChecksumCatchSurfacesRealError verifies that the catch
+// block around checksum download in install.ps1 includes the real exception message
+// ($_.Exception.Message) so the user sees the underlying cause, not a generic
+// "Could not download checksums.txt" message that hides connection errors,
+// TLS failures, etc. The secure-by-default behavior (Stop-WithError when not
+// -Insecure) must be preserved.
+func TestWindowsInstallScriptChecksumCatchSurfacesRealError(t *testing.T) {
+	path := filepath.Join("..", "..", "scripts", "install.ps1")
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", path, err)
+	}
+
+	script := string(content)
+
+	// The catch block must surface the real error via $_.Exception.Message.
+	if !strings.Contains(script, "$_.Exception.Message") {
+		t.Error("scripts/install.ps1 checksum catch block must include $_.Exception.Message to surface the real error; currently hides root cause")
+	}
+
+	// The catch block must still include the checksum URL so the user knows what failed.
+	if !strings.Contains(script, "$checksumsUrl") {
+		t.Error("scripts/install.ps1 checksum catch block must reference $checksumsUrl in the error message")
+	}
+
+	// The insecure skip path must still exist in the catch block.
+	if !strings.Contains(script, "checksum verification skipped") {
+		t.Error("scripts/install.ps1 checksum catch block must retain the -Insecure skip message")
+	}
+
+	// The secure-by-default path must still call Stop-WithError (hard failure).
+	// Locate the catch block and confirm Stop-WithError is present.
+	catchIdx := strings.Index(script, "} catch {")
+	if catchIdx < 0 {
+		t.Fatal("scripts/install.ps1 missing catch block around checksum download")
+	}
+	catchBlock := script[catchIdx:]
+	// Find the closing brace of the catch block (next standalone "}" at indent 0 relative to catch).
+	closeIdx := strings.Index(catchBlock, "\n        }")
+	if closeIdx < 0 {
+		t.Fatal("scripts/install.ps1 could not locate end of catch block")
+	}
+	catchBody := catchBlock[:closeIdx]
+
+	if !strings.Contains(catchBody, "Stop-WithError") {
+		t.Error("scripts/install.ps1 catch block must call Stop-WithError when not -Insecure; secure-by-default behavior must not be changed")
+	}
+}
+
+// TestWindowsInstallScriptFallbackChecksumExecution wires the PowerShell
+// fallback test (scripts/test-hash-fallback.ps1) into the CI validation
+// suite. If pwsh or powershell is available on the machine, it executes
+// the script to ensure the .NET fallback path computes correct SHA256
+// hashes and matches Get-FileHash when both are available.
+func TestWindowsInstallScriptFallbackChecksumExecution(t *testing.T) {
+	scriptPath := filepath.Join("..", "..", "scripts", "test-hash-fallback.ps1")
+	if _, err := os.Stat(scriptPath); err != nil {
+		t.Fatalf("test-hash-fallback.ps1 script not found at %s: %v", scriptPath, err)
+	}
+
+	var shell string
+	if _, err := exec.LookPath("pwsh"); err == nil {
+		shell = "pwsh"
+	} else if _, err := exec.LookPath("powershell"); err == nil {
+		shell = "powershell"
+	} else {
+		t.Skip("PowerShell (pwsh or powershell) not available; skipping fallback execution test")
+	}
+
+	cmd := exec.Command(shell, "-NoProfile", "-NonInteractive", "-File", scriptPath)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("PowerShell fallback test failed: %v\nOutput:\n%s", err, string(out))
+	}
+	t.Logf("PowerShell fallback test output:\n%s", string(out))
+}
+
+func TestInstallScriptAtomicBinaryReplacementStructure(t *testing.T) {
+	path := filepath.Join("..", "..", "scripts", "install.sh")
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", path, err)
+	}
+
+	script := string(content)
+	for _, want := range []string{
+		"local stage_file=",
+		"mv -f \"$stage_file\"",
+		"cleanup_stage",
+	} {
+		if !strings.Contains(script, want) {
+			t.Errorf("scripts/install.sh is missing %q for atomic binary replacement", want)
 		}
 	}
 }

--- a/internal/update/install_script_test.go
+++ b/internal/update/install_script_test.go
@@ -2,6 +2,7 @@ package update
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -73,9 +74,9 @@ func TestInstallScriptBetaGoInstallBypassesPublicGoProxy(t *testing.T) {
 
 	script := string(content)
 	for _, want := range []string{
-		"prepend_go_env_pattern GONOSUMDB github.com/gentleman-programming/gentle-ai",
-		"prepend_go_env_pattern GOPRIVATE github.com/gentleman-programming/gentle-ai",
-		"prepend_go_env_pattern GONOPROXY github.com/gentleman-programming/gentle-ai",
+		"prepend_go_env_pattern GONOSUMDB github.com/gentleman-programming/gentle-ai/v2",
+		"prepend_go_env_pattern GOPRIVATE github.com/gentleman-programming/gentle-ai/v2",
+		"prepend_go_env_pattern GONOPROXY github.com/gentleman-programming/gentle-ai/v2",
 		"go install \"$go_package\"",
 	} {
 		if !strings.Contains(script, want) {
@@ -84,9 +85,9 @@ func TestInstallScriptBetaGoInstallBypassesPublicGoProxy(t *testing.T) {
 	}
 
 	for _, clobber := range []string{
-		"GONOSUMDB=github.com/gentleman-programming/gentle-ai \\",
-		"GOPRIVATE=github.com/gentleman-programming/gentle-ai \\",
-		"GONOPROXY=github.com/gentleman-programming/gentle-ai \\",
+		"GONOSUMDB=github.com/gentleman-programming/gentle-ai/v2 \\",
+		"GOPRIVATE=github.com/gentleman-programming/gentle-ai/v2 \\",
+		"GONOPROXY=github.com/gentleman-programming/gentle-ai/v2 \\",
 	} {
 		if strings.Contains(script, clobber) {
 			t.Fatalf("scripts/install.sh clobbers existing user env with %q; beta proxy bypass must preserve existing patterns", clobber)
@@ -107,10 +108,10 @@ func TestInstallScriptBetaGoInstallBypassesPublicGoProxy(t *testing.T) {
 	cmd := exec.Command("bash", "-c", function+`
 GONOSUMDB=example.com/private
 GOPRIVATE=github.com/acme/*
-GONOPROXY=github.com/gentleman-programming/gentle-ai
-prepend_go_env_pattern GONOSUMDB github.com/gentleman-programming/gentle-ai
-prepend_go_env_pattern GOPRIVATE github.com/gentleman-programming/gentle-ai
-prepend_go_env_pattern GONOPROXY github.com/gentleman-programming/gentle-ai
+GONOPROXY=github.com/gentleman-programming/gentle-ai/v2
+prepend_go_env_pattern GONOSUMDB github.com/gentleman-programming/gentle-ai/v2
+prepend_go_env_pattern GOPRIVATE github.com/gentleman-programming/gentle-ai/v2
+prepend_go_env_pattern GONOPROXY github.com/gentleman-programming/gentle-ai/v2
 printf '%s\n%s\n%s\n' "$GONOSUMDB" "$GOPRIVATE" "$GONOPROXY"
 `)
 	out, err := cmd.CombinedOutput()
@@ -120,9 +121,9 @@ printf '%s\n%s\n%s\n' "$GONOSUMDB" "$GOPRIVATE" "$GONOPROXY"
 
 	got := strings.TrimSpace(string(out))
 	want := strings.Join([]string{
-		"github.com/gentleman-programming/gentle-ai,example.com/private",
-		"github.com/gentleman-programming/gentle-ai,github.com/acme/*",
-		"github.com/gentleman-programming/gentle-ai",
+		"github.com/gentleman-programming/gentle-ai/v2,example.com/private",
+		"github.com/gentleman-programming/gentle-ai/v2,github.com/acme/*",
+		"github.com/gentleman-programming/gentle-ai/v2",
 	}, "\n")
 	if got != want {
 		t.Fatalf("prepend_go_env_pattern output = %q, want %q", got, want)
@@ -138,9 +139,9 @@ func TestWindowsInstallScriptBetaGoInstallPreservesGoProxyBypassEnv(t *testing.T
 
 	script := string(content)
 	for _, want := range []string{
-		"Add-GoEnvPattern -Name \"GONOSUMDB\" -Pattern \"github.com/gentleman-programming/gentle-ai\"",
-		"Add-GoEnvPattern -Name \"GOPRIVATE\" -Pattern \"github.com/gentleman-programming/gentle-ai\"",
-		"Add-GoEnvPattern -Name \"GONOPROXY\" -Pattern \"github.com/gentleman-programming/gentle-ai\"",
+		"Add-GoEnvPattern -Name \"GONOSUMDB\" -Pattern \"github.com/gentleman-programming/gentle-ai/v2\"",
+		"Add-GoEnvPattern -Name \"GOPRIVATE\" -Pattern \"github.com/gentleman-programming/gentle-ai/v2\"",
+		"Add-GoEnvPattern -Name \"GONOPROXY\" -Pattern \"github.com/gentleman-programming/gentle-ai/v2\"",
 		"& go install $goPackage",
 	} {
 		if !strings.Contains(script, want) {
@@ -149,9 +150,9 @@ func TestWindowsInstallScriptBetaGoInstallPreservesGoProxyBypassEnv(t *testing.T
 	}
 
 	for _, clobber := range []string{
-		"$env:GONOSUMDB = \"github.com/gentleman-programming/gentle-ai\"",
-		"$env:GOPRIVATE = \"github.com/gentleman-programming/gentle-ai\"",
-		"$env:GONOPROXY = \"github.com/gentleman-programming/gentle-ai\"",
+		"$env:GONOSUMDB = \"github.com/gentleman-programming/gentle-ai/v2\"",
+		"$env:GOPRIVATE = \"github.com/gentleman-programming/gentle-ai/v2\"",
+		"$env:GONOPROXY = \"github.com/gentleman-programming/gentle-ai/v2\"",
 	} {
 		if strings.Contains(script, clobber) {
 			t.Fatalf("scripts/install.ps1 clobbers existing user env with %q; beta proxy bypass must preserve existing patterns", clobber)
@@ -162,7 +163,7 @@ func TestWindowsInstallScriptBetaGoInstallPreservesGoProxyBypassEnv(t *testing.T
 	if start == -1 {
 		t.Fatal("scripts/install.ps1 is missing Add-GoEnvPattern function")
 	}
-	endMarker := "\n}\n\n# ============================================================================\n# Install via binary download"
+	endMarker := "\n}\n\nfunction Test-Installation"
 	end := strings.Index(script[start:], endMarker)
 	if end == -1 {
 		t.Fatal("could not locate end of Add-GoEnvPattern function")
@@ -181,87 +182,11 @@ func TestWindowsInstallScriptBetaGoInstallPreservesGoProxyBypassEnv(t *testing.T
 	}
 }
 
-// TestWindowsInstallScriptChecksumCatchSurfacesRealError verifies that the catch
-// block around checksum download in install.ps1 includes the real exception message
-// ($_.Exception.Message) so the user sees the underlying cause, not a generic
-// "Could not download checksums.txt" message that hides connection errors,
-// TLS failures, etc. The secure-by-default behavior (Stop-WithError when not
-// -Insecure) must be preserved.
-func TestWindowsInstallScriptChecksumCatchSurfacesRealError(t *testing.T) {
-	path := filepath.Join("..", "..", "scripts", "install.ps1")
-	content, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("ReadFile(%q) error = %v", path, err)
-	}
-
-	script := string(content)
-
-	// The catch block must surface the real error via $_.Exception.Message.
-	if !strings.Contains(script, "$_.Exception.Message") {
-		t.Error("scripts/install.ps1 checksum catch block must include $_.Exception.Message to surface the real error; currently hides root cause")
-	}
-
-	// The catch block must still include the checksum URL so the user knows what failed.
-	if !strings.Contains(script, "$checksumsUrl") {
-		t.Error("scripts/install.ps1 checksum catch block must reference $checksumsUrl in the error message")
-	}
-
-	// The insecure skip path must still exist in the catch block.
-	if !strings.Contains(script, "checksum verification skipped") {
-		t.Error("scripts/install.ps1 checksum catch block must retain the -Insecure skip message")
-	}
-
-	// The secure-by-default path must still call Stop-WithError (hard failure).
-	// Locate the catch block and confirm Stop-WithError is present.
-	catchIdx := strings.Index(script, "} catch {")
-	if catchIdx < 0 {
-		t.Fatal("scripts/install.ps1 missing catch block around checksum download")
-	}
-	catchBlock := script[catchIdx:]
-	// Find the closing brace of the catch block (next standalone "}" at indent 0 relative to catch).
-	closeIdx := strings.Index(catchBlock, "\n        }")
-	if closeIdx < 0 {
-		t.Fatal("scripts/install.ps1 could not locate end of catch block")
-	}
-	catchBody := catchBlock[:closeIdx]
-
-	if !strings.Contains(catchBody, "Stop-WithError") {
-		t.Error("scripts/install.ps1 catch block must call Stop-WithError when not -Insecure; secure-by-default behavior must not be changed")
-	}
-}
-
-// TestWindowsInstallScriptFallbackChecksumExecution wires the PowerShell
-// fallback test (scripts/test-hash-fallback.ps1) into the CI validation
-// suite. If pwsh or powershell is available on the machine, it executes
-// the script to ensure the .NET fallback path computes correct SHA256
-// hashes and matches Get-FileHash when both are available.
-func TestWindowsInstallScriptFallbackChecksumExecution(t *testing.T) {
-	scriptPath := filepath.Join("..", "..", "scripts", "test-hash-fallback.ps1")
-	if _, err := os.Stat(scriptPath); err != nil {
-		t.Fatalf("test-hash-fallback.ps1 script not found at %s: %v", scriptPath, err)
-	}
-
-	var shell string
-	if _, err := exec.LookPath("pwsh"); err == nil {
-		shell = "pwsh"
-	} else if _, err := exec.LookPath("powershell"); err == nil {
-		shell = "powershell"
-	} else {
-		t.Skip("PowerShell (pwsh or powershell) not available; skipping fallback execution test")
-	}
-
-	cmd := exec.Command(shell, "-NoProfile", "-NonInteractive", "-File", scriptPath)
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("PowerShell fallback test failed: %v\nOutput:\n%s", err, string(out))
-	}
-	t.Logf("PowerShell fallback test output:\n%s", string(out))
-}
-
 func TestInstallScriptAtomicBinaryReplacement(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("skipping Unix bash install script test on Windows")
 	}
+
 	path := filepath.Join("..", "..", "scripts", "install.sh")
 	content, err := os.ReadFile(path)
 	if err != nil {
@@ -269,13 +194,118 @@ func TestInstallScriptAtomicBinaryReplacement(t *testing.T) {
 	}
 
 	script := string(content)
-	for _, want := range []string{
-		"local stage_file=",
-		"mv -f \"$stage_file\"",
-		"cleanup_stage",
-	} {
-		if !strings.Contains(script, want) {
-			t.Errorf("scripts/install.sh is missing %q for atomic binary replacement", want)
-		}
+	start := strings.Index(script, "    # Install binary\n")
+	if start < 0 {
+		t.Fatal("could not locate binary replacement block")
+	}
+	end := strings.Index(script[start:], "    success \"Installed ${BINARY_NAME}")
+	if end < 0 {
+		t.Fatal("could not locate end of binary replacement block")
+	}
+	replacement := script[start : start+end]
+
+	tests := []struct {
+		name        string
+		failCommand string
+		existing    bool
+		wantSuccess bool
+	}{
+		{name: "first install", wantSuccess: true},
+		{name: "replacement", existing: true, wantSuccess: true},
+		{name: "mktemp failure", failCommand: "mktemp", existing: true},
+		{name: "cp failure", failCommand: "cp", existing: true},
+		{name: "chmod failure", failCommand: "chmod", existing: true},
+		{name: "mv failure", failCommand: "mv", existing: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			installDir := filepath.Join(root, "install")
+			tmpDir := filepath.Join(root, "download")
+			fakeBin := filepath.Join(root, "bin")
+			for _, dir := range []string{installDir, tmpDir, fakeBin} {
+				if err := os.Mkdir(dir, 0o755); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			binary := filepath.Join(installDir, "gentle-ai")
+			if tt.existing {
+				if err := os.WriteFile(binary, []byte("old"), 0o755); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if err := os.WriteFile(filepath.Join(tmpDir, "gentle-ai"), []byte("new"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			for _, command := range []string{"cp", "chmod", "mv", "mktemp", "rm"} {
+				realCommand, err := exec.LookPath(command)
+				if err != nil {
+					t.Fatal(err)
+				}
+				wrapper := fmt.Sprintf("#!/bin/sh\n[ \"$FAIL_COMMAND\" = %q ] && exit 1\nexec %q \"$@\"\n", command, realCommand)
+				if err := os.WriteFile(filepath.Join(fakeBin, command), []byte(wrapper), 0o755); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			fixture := "set -eu\n" +
+				"BINARY_NAME=gentle-ai\ninstall_dir=$1\ntmpdir=$2\nstage_file=\nsudo_stage_file=\n" +
+				"info() { :; }\nwarn() { :; }\nfatal() { return 1; }\n" +
+				"cleanup_install() { rm -f \"${stage_file:-}\" 2>/dev/null; [ -n \"${tmpdir:-}\" ] && rm -rf \"$tmpdir\"; }\n" +
+				"trap cleanup_install EXIT\nreplace_binary() {\n" + replacement + "}\nreplace_binary\n"
+			cmd := exec.Command("bash", "-c", fixture, "bash", installDir, tmpDir)
+			cmd.Env = append(os.Environ(), "PATH="+fakeBin, "FAIL_COMMAND="+tt.failCommand)
+			out, runErr := cmd.CombinedOutput()
+			if tt.wantSuccess && runErr != nil {
+				t.Fatalf("replacement failed: %v\n%s", runErr, out)
+			}
+			if !tt.wantSuccess && runErr == nil {
+				t.Fatalf("replacement unexpectedly succeeded when %s failed", tt.failCommand)
+			}
+
+			got, readErr := os.ReadFile(binary)
+			if tt.wantSuccess {
+				if readErr != nil {
+					t.Fatal(readErr)
+				}
+				if string(got) != "new" {
+					t.Fatalf("installed binary = %q, want %q", got, "new")
+				}
+				info, statErr := os.Stat(binary)
+				if statErr != nil {
+					t.Fatal(statErr)
+				}
+				if info.Mode()&0o111 == 0 {
+					t.Fatal("installed binary is not executable")
+				}
+			} else {
+				if !tt.existing {
+					if !os.IsNotExist(readErr) {
+						t.Fatalf("failed first install left binary error = %v", readErr)
+					}
+				} else {
+					if readErr != nil {
+						t.Fatal(readErr)
+					}
+					if string(got) != "old" {
+						t.Fatalf("installed binary = %q, want old content preserved", got)
+					}
+				}
+			}
+
+			residue, globErr := filepath.Glob(filepath.Join(installDir, ".gentle-ai.tmp.*"))
+			if globErr != nil {
+				t.Fatal(globErr)
+			}
+			if len(residue) != 0 {
+				t.Fatalf("staging residue remains: %v", residue)
+			}
+			if _, statErr := os.Stat(tmpDir); !os.IsNotExist(statErr) {
+				t.Fatalf("download temp directory remains: %v", statErr)
+			}
+		})
 	}
 }

--- a/internal/update/install_script_test.go
+++ b/internal/update/install_script_test.go
@@ -208,6 +208,7 @@ func TestInstallScriptAtomicBinaryReplacement(t *testing.T) {
 		name        string
 		failCommand string
 		existing    bool
+		fakeSudo    bool
 		wantSuccess bool
 	}{
 		{name: "first install", wantSuccess: true},
@@ -216,6 +217,7 @@ func TestInstallScriptAtomicBinaryReplacement(t *testing.T) {
 		{name: "cp failure", failCommand: "cp", existing: true},
 		{name: "chmod failure", failCommand: "chmod", existing: true},
 		{name: "mv failure", failCommand: "mv", existing: true},
+		{name: "sudo fallback", failCommand: "cp", existing: true, fakeSudo: true, wantSuccess: true},
 	}
 
 	for _, tt := range tests {
@@ -245,8 +247,20 @@ func TestInstallScriptAtomicBinaryReplacement(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
-				wrapper := fmt.Sprintf("#!/bin/sh\n[ \"$FAIL_COMMAND\" = %q ] && exit 1\nexec %q \"$@\"\n", command, realCommand)
+				wrapper := fmt.Sprintf("#!/bin/sh\nif [ -z \"${INSTALL_TEST_PRIVILEGED:-}\" ] && [ \"$FAIL_COMMAND\" = %q ]; then exit 1; fi\nexec %q \"$@\"\n", command, realCommand)
 				if err := os.WriteFile(filepath.Join(fakeBin, command), []byte(wrapper), 0o755); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			sudoLog := filepath.Join(root, "sudo.log")
+			if tt.fakeSudo {
+				sudoScript := `#!/bin/sh
+printf '%s\n' "$1" >> "$SUDO_LOG"
+export INSTALL_TEST_PRIVILEGED=1
+exec "$@"
+`
+				if err := os.WriteFile(filepath.Join(fakeBin, "sudo"), []byte(sudoScript), 0o755); err != nil {
 					t.Fatal(err)
 				}
 			}
@@ -257,13 +271,34 @@ func TestInstallScriptAtomicBinaryReplacement(t *testing.T) {
 				"cleanup_install() { rm -f \"${stage_file:-}\" 2>/dev/null; [ -n \"${tmpdir:-}\" ] && rm -rf \"$tmpdir\"; }\n" +
 				"trap cleanup_install EXIT\nreplace_binary() {\n" + replacement + "}\nreplace_binary\n"
 			cmd := exec.Command("bash", "-c", fixture, "bash", installDir, tmpDir)
-			cmd.Env = append(os.Environ(), "PATH="+fakeBin, "FAIL_COMMAND="+tt.failCommand)
+			env := append(os.Environ(), "PATH="+fakeBin, "FAIL_COMMAND="+tt.failCommand, "INSTALL_TEST_PRIVILEGED=")
+			if tt.fakeSudo {
+				env = append(env, "SUDO_LOG="+sudoLog)
+			}
+			cmd.Env = env
 			out, runErr := cmd.CombinedOutput()
 			if tt.wantSuccess && runErr != nil {
 				t.Fatalf("replacement failed: %v\n%s", runErr, out)
 			}
 			if !tt.wantSuccess && runErr == nil {
 				t.Fatalf("replacement unexpectedly succeeded when %s failed", tt.failCommand)
+			}
+			if tt.fakeSudo {
+				delegated, err := os.ReadFile(sudoLog)
+				if err != nil {
+					t.Fatalf("read sudo command log: %v", err)
+				}
+				wantDelegated := "mktemp\ncp\nchmod\nmv"
+				if got := strings.TrimSpace(string(delegated)); got != wantDelegated {
+					t.Fatalf("sudo delegated commands = %q, want %q", got, wantDelegated)
+				}
+				sudoResidue, err := filepath.Glob(filepath.Join(installDir, ".gentle-ai.tmp.sudo.*"))
+				if err != nil {
+					t.Fatal(err)
+				}
+				if len(sudoResidue) != 0 {
+					t.Fatalf("sudo staging residue remains: %v", sudoResidue)
+				}
 			}
 
 			got, readErr := os.ReadFile(binary)

--- a/internal/update/install_script_test.go
+++ b/internal/update/install_script_test.go
@@ -2,6 +2,7 @@ package update
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"fmt"
 	"os"
 	"os/exec"
@@ -205,11 +206,14 @@ func TestInstallScriptAtomicBinaryReplacement(t *testing.T) {
 	replacement := script[start : start+end]
 
 	tests := []struct {
-		name        string
-		failCommand string
-		existing    bool
-		fakeSudo    bool
-		wantSuccess bool
+		name                  string
+		failCommand           string
+		privilegedFailCommand string
+		existing              bool
+		fakeSudo              bool
+		partialCopy           bool
+		wantPrivilegedCleanup bool
+		wantSuccess           bool
 	}{
 		{name: "first install", wantSuccess: true},
 		{name: "replacement", existing: true, wantSuccess: true},
@@ -218,6 +222,15 @@ func TestInstallScriptAtomicBinaryReplacement(t *testing.T) {
 		{name: "chmod failure", failCommand: "chmod", existing: true},
 		{name: "mv failure", failCommand: "mv", existing: true},
 		{name: "sudo fallback", failCommand: "cp", existing: true, fakeSudo: true, wantSuccess: true},
+		{
+			name:                  "privileged partial copy then mv failure",
+			failCommand:           "cp",
+			privilegedFailCommand: "mv",
+			existing:              true,
+			fakeSudo:              true,
+			partialCopy:           true,
+			wantPrivilegedCleanup: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -233,8 +246,10 @@ func TestInstallScriptAtomicBinaryReplacement(t *testing.T) {
 			}
 
 			binary := filepath.Join(installDir, "gentle-ai")
+			oldBinary := []byte("old")
+			oldDigest := sha256.Sum256(oldBinary)
 			if tt.existing {
-				if err := os.WriteFile(binary, []byte("old"), 0o755); err != nil {
+				if err := os.WriteFile(binary, oldBinary, 0o755); err != nil {
 					t.Fatal(err)
 				}
 			}
@@ -247,7 +262,7 @@ func TestInstallScriptAtomicBinaryReplacement(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
-				wrapper := fmt.Sprintf("#!/bin/sh\nif [ -z \"${INSTALL_TEST_PRIVILEGED:-}\" ] && [ \"$FAIL_COMMAND\" = %q ]; then exit 1; fi\nexec %q \"$@\"\n", command, realCommand)
+				wrapper := fmt.Sprintf("#!/bin/sh\nif [ -z \"${INSTALL_TEST_PRIVILEGED:-}\" ] && [ \"$FAIL_COMMAND\" = %q ]; then\n    if [ %t = true ]; then printf 'partial-copy' > \"$2\"; fi\n    exit 1\nfi\nif [ -n \"${INSTALL_TEST_PRIVILEGED:-}\" ] && [ \"$FAIL_PRIVILEGED_COMMAND\" = %q ]; then exit 1; fi\nexec %q \"$@\"\n", command, tt.partialCopy && command == "cp", command, realCommand)
 				if err := os.WriteFile(filepath.Join(fakeBin, command), []byte(wrapper), 0o755); err != nil {
 					t.Fatal(err)
 				}
@@ -268,10 +283,10 @@ exec "$@"
 			fixture := "set -eu\n" +
 				"BINARY_NAME=gentle-ai\ninstall_dir=$1\ntmpdir=$2\nstage_file=\nsudo_stage_file=\n" +
 				"info() { :; }\nwarn() { :; }\nfatal() { return 1; }\n" +
-				"cleanup_install() { rm -f \"${stage_file:-}\" 2>/dev/null; [ -n \"${tmpdir:-}\" ] && rm -rf \"$tmpdir\"; }\n" +
+				"cleanup_install() { rm -f \"${stage_file:-}\" 2>/dev/null; if [ -n \"${sudo_stage_file:-}\" ] && command -v sudo &>/dev/null; then sudo rm -f \"$sudo_stage_file\" 2>/dev/null; fi; [ -n \"${tmpdir:-}\" ] && rm -rf \"$tmpdir\"; }\n" +
 				"trap cleanup_install EXIT\nreplace_binary() {\n" + replacement + "}\nreplace_binary\n"
 			cmd := exec.Command("bash", "-c", fixture, "bash", installDir, tmpDir)
-			env := append(os.Environ(), "PATH="+fakeBin, "FAIL_COMMAND="+tt.failCommand, "INSTALL_TEST_PRIVILEGED=")
+			env := append(os.Environ(), "PATH="+fakeBin, "FAIL_COMMAND="+tt.failCommand, "FAIL_PRIVILEGED_COMMAND="+tt.privilegedFailCommand, "INSTALL_TEST_PRIVILEGED=")
 			if tt.fakeSudo {
 				env = append(env, "SUDO_LOG="+sudoLog)
 			}
@@ -289,15 +304,11 @@ exec "$@"
 					t.Fatalf("read sudo command log: %v", err)
 				}
 				wantDelegated := "mktemp\ncp\nchmod\nmv"
+				if tt.wantPrivilegedCleanup {
+					wantDelegated += "\nrm"
+				}
 				if got := strings.TrimSpace(string(delegated)); got != wantDelegated {
 					t.Fatalf("sudo delegated commands = %q, want %q", got, wantDelegated)
-				}
-				sudoResidue, err := filepath.Glob(filepath.Join(installDir, ".gentle-ai.tmp.sudo.*"))
-				if err != nil {
-					t.Fatal(err)
-				}
-				if len(sudoResidue) != 0 {
-					t.Fatalf("sudo staging residue remains: %v", sudoResidue)
 				}
 			}
 
@@ -325,18 +336,28 @@ exec "$@"
 					if readErr != nil {
 						t.Fatal(readErr)
 					}
-					if string(got) != "old" {
+					if string(got) != string(oldBinary) {
 						t.Fatalf("installed binary = %q, want old content preserved", got)
+					}
+					if gotDigest := sha256.Sum256(got); gotDigest != oldDigest {
+						t.Fatalf("installed binary digest = %x, want old digest %x", gotDigest, oldDigest)
 					}
 				}
 			}
 
-			residue, globErr := filepath.Glob(filepath.Join(installDir, ".gentle-ai.tmp.*"))
+			regularResidue, globErr := filepath.Glob(filepath.Join(installDir, ".gentle-ai.tmp.??????"))
 			if globErr != nil {
 				t.Fatal(globErr)
 			}
-			if len(residue) != 0 {
-				t.Fatalf("staging residue remains: %v", residue)
+			if len(regularResidue) != 0 {
+				t.Fatalf("regular staging residue remains: %v", regularResidue)
+			}
+			privilegedResidue, globErr := filepath.Glob(filepath.Join(installDir, ".gentle-ai.tmp.sudo.*"))
+			if globErr != nil {
+				t.Fatal(globErr)
+			}
+			if len(privilegedResidue) != 0 {
+				t.Fatalf("privileged staging residue remains: %v", privilegedResidue)
 			}
 			if _, statErr := os.Stat(tmpDir); !os.IsNotExist(statErr) {
 				t.Fatalf("download temp directory remains: %v", statErr)

--- a/internal/update/install_script_test.go
+++ b/internal/update/install_script_test.go
@@ -205,6 +205,30 @@ func TestInstallScriptAtomicBinaryReplacement(t *testing.T) {
 	}
 	replacement := script[start : start+end]
 
+	cleanupStartMarker := "    cleanup_install() {\n"
+	cleanupFunctionEndMarker := "    }\n"
+	tmpdirAssignmentMarker := "    tmpdir=\"$(mktemp -d)\"\n"
+	cleanupTrapMarker := "    trap cleanup_install EXIT\n"
+	cleanupStart := strings.Index(script, cleanupStartMarker)
+	if cleanupStart < 0 {
+		t.Fatal("scripts/install.sh is missing cleanup_install function")
+	}
+	cleanupBodyStart := cleanupStart + len(cleanupStartMarker)
+	cleanupFunctionEndRelative := strings.Index(script[cleanupBodyStart:], cleanupFunctionEndMarker)
+	if cleanupFunctionEndRelative < 0 {
+		t.Fatal("could not locate end of cleanup_install function")
+	}
+	cleanupFunctionEnd := cleanupBodyStart + cleanupFunctionEndRelative + len(cleanupFunctionEndMarker)
+	if !strings.HasPrefix(script[cleanupFunctionEnd:], tmpdirAssignmentMarker) {
+		t.Fatal("could not locate tmpdir assignment after cleanup_install function")
+	}
+	trapStart := cleanupFunctionEnd + len(tmpdirAssignmentMarker)
+	if !strings.HasPrefix(script[trapStart:], cleanupTrapMarker) {
+		t.Fatal("could not locate cleanup_install EXIT trap")
+	}
+	cleanupSnippet := script[cleanupStart:cleanupFunctionEnd] +
+		script[trapStart:trapStart+len(cleanupTrapMarker)]
+
 	tests := []struct {
 		name                  string
 		failCommand           string
@@ -262,7 +286,31 @@ func TestInstallScriptAtomicBinaryReplacement(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
-				wrapper := fmt.Sprintf("#!/bin/sh\nif [ -z \"${INSTALL_TEST_PRIVILEGED:-}\" ] && [ \"$FAIL_COMMAND\" = %q ]; then\n    if [ %t = true ]; then printf 'partial-copy' > \"$2\"; fi\n    exit 1\nfi\nif [ -n \"${INSTALL_TEST_PRIVILEGED:-}\" ] && [ \"$FAIL_PRIVILEGED_COMMAND\" = %q ]; then exit 1; fi\nexec %q \"$@\"\n", command, tt.partialCopy && command == "cp", command, realCommand)
+				wrapper := fmt.Sprintf(`#!/bin/sh
+if [ %q = "mktemp" ]; then
+    if [ -z "${INSTALL_TEST_INSTALL_DIR:-}" ]; then
+        printf 'missing INSTALL_TEST_INSTALL_DIR\n' >&2
+        exit 1
+    fi
+    if [ -n "${INSTALL_TEST_PRIVILEGED:-}" ]; then
+        expected="${INSTALL_TEST_INSTALL_DIR}/.gentle-ai.tmp.sudo.XXXXXX"
+    else
+        expected="${INSTALL_TEST_INSTALL_DIR}/.gentle-ai.tmp.XXXXXX"
+    fi
+    if [ "$#" -ne 1 ] || [ "${1:-}" != "$expected" ]; then
+        printf 'unexpected mktemp template: %%s (want %%s)\n' "${1:-}" "$expected" >&2
+        exit 1
+    fi
+fi
+if [ -z "${INSTALL_TEST_PRIVILEGED:-}" ] && [ "${FAIL_COMMAND:-}" = %q ]; then
+    if [ %t = true ]; then printf 'partial-copy' > "$2"; fi
+    exit 1
+fi
+if [ -n "${INSTALL_TEST_PRIVILEGED:-}" ] && [ "${FAIL_PRIVILEGED_COMMAND:-}" = %q ]; then
+    exit 1
+fi
+exec %q "$@"
+`, command, command, tt.partialCopy && command == "cp", command, realCommand)
 				if err := os.WriteFile(filepath.Join(fakeBin, command), []byte(wrapper), 0o755); err != nil {
 					t.Fatal(err)
 				}
@@ -281,12 +329,12 @@ exec "$@"
 			}
 
 			fixture := "set -eu\n" +
-				"BINARY_NAME=gentle-ai\ninstall_dir=$1\ntmpdir=$2\nstage_file=\nsudo_stage_file=\n" +
+				"BINARY_NAME=gentle-ai\ninstall_dir=\"$1\"\ntmpdir=\"$2\"\nstage_file=\nsudo_stage_file=\n" +
 				"info() { :; }\nwarn() { :; }\nfatal() { return 1; }\n" +
-				"cleanup_install() { rm -f \"${stage_file:-}\" 2>/dev/null; if [ -n \"${sudo_stage_file:-}\" ] && command -v sudo &>/dev/null; then sudo rm -f \"$sudo_stage_file\" 2>/dev/null; fi; [ -n \"${tmpdir:-}\" ] && rm -rf \"$tmpdir\"; }\n" +
-				"trap cleanup_install EXIT\nreplace_binary() {\n" + replacement + "}\nreplace_binary\n"
+				cleanupSnippet +
+				"replace_binary() {\n" + replacement + "}\nreplace_binary\n"
 			cmd := exec.Command("bash", "-c", fixture, "bash", installDir, tmpDir)
-			env := append(os.Environ(), "PATH="+fakeBin, "FAIL_COMMAND="+tt.failCommand, "FAIL_PRIVILEGED_COMMAND="+tt.privilegedFailCommand, "INSTALL_TEST_PRIVILEGED=")
+			env := append(os.Environ(), "PATH="+fakeBin, "FAIL_COMMAND="+tt.failCommand, "FAIL_PRIVILEGED_COMMAND="+tt.privilegedFailCommand, "INSTALL_TEST_INSTALL_DIR="+installDir, "INSTALL_TEST_PRIVILEGED=")
 			if tt.fakeSudo {
 				env = append(env, "SUDO_LOG="+sudoLog)
 			}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -458,13 +458,38 @@ install_binary() {
 
     # Install binary
     info "Installing to ${install_dir}/${BINARY_NAME}..."
-    if cp "${tmpdir}/${BINARY_NAME}" "${install_dir}/${BINARY_NAME}" 2>/dev/null; then
-        chmod +x "${install_dir}/${BINARY_NAME}"
+    local stage_file="${install_dir}/.${BINARY_NAME}.tmp.$$"
+
+    cleanup_stage() {
+        rm -f "$stage_file" 2>/dev/null
+    }
+    trap cleanup_stage EXIT
+
+    if cp "${tmpdir}/${BINARY_NAME}" "$stage_file" 2>/dev/null && \
+       chmod +x "$stage_file" 2>/dev/null && \
+       mv -f "$stage_file" "${install_dir}/${BINARY_NAME}" 2>/dev/null; then
+        trap - EXIT
     elif command -v sudo &>/dev/null; then
         warn "Permission denied. Trying with sudo..."
-        sudo cp "${tmpdir}/${BINARY_NAME}" "${install_dir}/${BINARY_NAME}"
-        sudo chmod +x "${install_dir}/${BINARY_NAME}"
+        local sudo_stage_file="${install_dir}/.${BINARY_NAME}.tmp.sudo.$$"
+        cleanup_sudo_stage() {
+            sudo rm -f "$sudo_stage_file" 2>/dev/null
+            rm -f "$stage_file" 2>/dev/null
+        }
+        trap cleanup_sudo_stage EXIT
+
+        if sudo cp "${tmpdir}/${BINARY_NAME}" "$sudo_stage_file" && \
+           sudo chmod +x "$sudo_stage_file" && \
+           sudo mv -f "$sudo_stage_file" "${install_dir}/${BINARY_NAME}"; then
+            trap - EXIT
+        else
+            cleanup_sudo_stage
+            trap - EXIT
+            fatal "Cannot write to ${install_dir} even with sudo."
+        fi
     else
+        cleanup_stage
+        trap - EXIT
         fatal "Cannot write to ${install_dir}. Run with sudo or use --dir to specify a writable directory."
     fi
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -371,9 +371,18 @@ install_binary() {
     local checksums_url="https://github.com/${GITHUB_OWNER}/${GITHUB_REPO}/releases/download/${LATEST_VERSION}/checksums.txt"
 
     # Create temp directory — clean up on exit
-    local tmpdir
+    local tmpdir=""
+    local stage_file=""
+    local sudo_stage_file=""
+    cleanup_install() {
+        rm -f "${stage_file:-}" 2>/dev/null
+        if [ -n "${sudo_stage_file:-}" ] && command -v sudo &>/dev/null; then
+            sudo rm -f "$sudo_stage_file" 2>/dev/null
+        fi
+        [ -n "${tmpdir:-}" ] && rm -rf "$tmpdir"
+    }
     tmpdir="$(mktemp -d)"
-    trap '[ -n "${tmpdir:-}" ] && rm -rf "$tmpdir"' EXIT
+    trap cleanup_install EXIT
 
     # Download archive
     info "Downloading ${archive_name}..."
@@ -458,41 +467,28 @@ install_binary() {
 
     # Install binary
     info "Installing to ${install_dir}/${BINARY_NAME}..."
-    local stage_file="${install_dir}/.${BINARY_NAME}.tmp.$$"
-
-    cleanup_stage() {
-        rm -f "$stage_file" 2>/dev/null
-    }
-    trap cleanup_stage EXIT
-
-    if cp "${tmpdir}/${BINARY_NAME}" "$stage_file" 2>/dev/null && \
+    if stage_file="$(mktemp "${install_dir}/.${BINARY_NAME}.tmp.XXXXXX" 2>/dev/null)" && \
+       cp "${tmpdir}/${BINARY_NAME}" "$stage_file" 2>/dev/null && \
        chmod +x "$stage_file" 2>/dev/null && \
        mv -f "$stage_file" "${install_dir}/${BINARY_NAME}" 2>/dev/null; then
-        trap - EXIT
+        stage_file=""
     elif command -v sudo &>/dev/null; then
+        rm -f "${stage_file:-}" 2>/dev/null
+        stage_file=""
         warn "Permission denied. Trying with sudo..."
-        local sudo_stage_file="${install_dir}/.${BINARY_NAME}.tmp.sudo.$$"
-        cleanup_sudo_stage() {
-            sudo rm -f "$sudo_stage_file" 2>/dev/null
-            rm -f "$stage_file" 2>/dev/null
-        }
-        trap cleanup_sudo_stage EXIT
-
-        if sudo cp "${tmpdir}/${BINARY_NAME}" "$sudo_stage_file" && \
+        if sudo_stage_file="$(sudo mktemp "${install_dir}/.${BINARY_NAME}.tmp.sudo.XXXXXX")" && \
+           sudo cp "${tmpdir}/${BINARY_NAME}" "$sudo_stage_file" && \
            sudo chmod +x "$sudo_stage_file" && \
            sudo mv -f "$sudo_stage_file" "${install_dir}/${BINARY_NAME}"; then
-            trap - EXIT
+            sudo_stage_file=""
         else
-            cleanup_sudo_stage
-            trap - EXIT
             fatal "Cannot write to ${install_dir} even with sudo."
         fi
     else
-        cleanup_stage
-        trap - EXIT
         fatal "Cannot write to ${install_dir}. Run with sudo or use --dir to specify a writable directory."
     fi
 
+    cleanup_install
     success "Installed ${BINARY_NAME} to ${install_dir}/${BINARY_NAME}"
 
     # Check if install dir is in PATH


### PR DESCRIPTION
### 🔗 Linked Issue

Fixes #1728

---

### 📝 Summary of Changes

The Unix binary installer previously copied directly over the destination executable (`cp "$candidate" "$install_dir/gentle-ai"`). If copying failed midway due to I/O errors, exhausted disk space, or privilege fallbacks, the destination was truncated and the previous working binary was lost.

#### Solution
Updated `scripts/install.sh` to use same-filesystem staging and atomic rename:
1. Copies the candidate into a staging file (`$install_dir/.$BINARY_NAME.tmp.$$`) within the target directory.
2. Sets executable permissions on the staging file.
3. Atomically replaces the target executable via `mv -f`.
4. Traps ensure staging files are removed on failure without clobbering any pre-existing binary.

---

### 🧪 Test Plan

- [x] Ran `go run ./internal/gofmtcheck` cleanly.
- [x] Ran unit tests: `go test ./internal/update/...` passed cleanly.
- [x] Added regression test `TestInstallScriptAtomicBinaryReplacementStructure` in `internal/update/install_script_test.go`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved binary installation reliability by staging files before replacement.
  * Prevented incomplete or partially written binaries during updates through atomic replacement.
  * Preserved existing installations when updates fail.
  * Added cleanup for failed installations and temporary files.
  * Ensured installed binaries retain executable permissions.
  * Improved handling when elevated permissions are required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->