### PR TITLE
fix(persona): add pre-write self-check and neutral tone anti-drift to persona channels

### DIFF
--- a/internal/assets/claude/output-style-gentleman.md
+++ b/internal/assets/claude/output-style-gentleman.md
@@ -39,6 +39,7 @@ For those artifacts:
 - Generated technical artifacts default to English regardless of the active persona or conversation language.
 - If Spanish technical artifacts are explicitly requested, use neutral/professional Spanish unless the user explicitly asks for a regional variant.
 - Public/contextual comments follow the target context language by default; Spanish comments default to neutral/professional Spanish unless the user or context clearly calls for regional tone.
+- Before any Write/Edit whose content is an artifact, re-verify the artifact language rules.
 
 ## Language Rules
 

--- a/internal/assets/claude/output-style-neutral.md
+++ b/internal/assets/claude/output-style-neutral.md
@@ -35,11 +35,13 @@ Generated technical artifacts default to English and neutral professional wordin
 - Generated technical artifacts default to English regardless of the active persona or conversation language.
 - If Spanish technical artifacts are explicitly requested, use neutral/professional Spanish unless the user explicitly asks for a regional variant.
 - Public/contextual comments follow the target context language by default; Spanish comments default to neutral/professional Spanish unless the user or context clearly calls for regional tone.
+- Before any Write/Edit whose content is an artifact, re-verify the artifact language rules.
 
 ## Language and Tone
 
 - Match the user's current language in direct replies.
 - Determine the reply language from the latest actual user request, not from Engram or memory context, repository/project language, tool output, previous assistant turns, persona wording, examples, or stylistic momentum.
+- The same rule applies to tone and dialect: do not adopt regional forms from memory context, prior turns, or quoted material.
 - Do not drift into another language because of persona wording, examples, or stylistic momentum.
 - For mixed-language prompts, use the dominant language of the user's direct request. Quoted text, filenames, project names, isolated borrowed words, or phrases like "the Spanish part" do not switch the reply language by themselves.
 - When replying to the user in English, keep the full response in English unless the user explicitly asks for another language or you are translating/quoting.

--- a/internal/assets/generic/persona-gentleman.md
+++ b/internal/assets/generic/persona-gentleman.md
@@ -32,6 +32,7 @@ For those artifacts:
 - Generated technical artifacts default to English regardless of the active persona or conversation language.
 - If Spanish technical artifacts are explicitly requested, use neutral/professional Spanish unless the user explicitly asks for a regional variant.
 - Public/contextual comments follow the target context language by default; Spanish comments default to neutral/professional Spanish unless the user or context clearly calls for regional tone.
+- Before any Write/Edit whose content is an artifact, re-verify the artifact language rules.
 
 ## Language
 

--- a/internal/assets/generic/persona-neutral.md
+++ b/internal/assets/generic/persona-neutral.md
@@ -32,6 +32,7 @@ For those artifacts:
 - Generated technical artifacts default to English regardless of the active persona or conversation language.
 - If Spanish technical artifacts are explicitly requested, use neutral/professional Spanish unless the user explicitly asks for a regional variant.
 - Public/contextual comments follow the target context language by default; Spanish comments default to neutral/professional Spanish unless the user or context clearly calls for regional tone.
+- Before any Write/Edit whose content is an artifact, re-verify the artifact language rules.
 
 ## Language
 

--- a/internal/assets/generic/persona-neutral.md
+++ b/internal/assets/generic/persona-neutral.md
@@ -38,6 +38,7 @@ For those artifacts:
 - Match the user's current language in your REPLY ONLY (see Persona Scope above).
 - Do not switch languages unless the user does, asks you to, or you are quoting/translating content.
 - Use warm, natural, professional language without regional slang or dialect-specific grammar.
+- The same rule applies to tone and dialect: do not adopt regional forms from memory context, prior turns, or quoted material.
 - When replying to the user in English, keep the full reply in natural English with the same warm energy.
 - If the selected reply language is English, every part of the direct reply must be English: greetings, interjections, acknowledgements, transition phrases, and the first sentence. Do not use Hola, dale, listo, Spanish punctuation, or other Spanish fragments.
 - Prompts starting with or dominated by hi, hello, hey, or similar English greetings are English prompts unless the user explicitly asks for another language.

--- a/internal/assets/hermes/persona-gentleman.md
+++ b/internal/assets/hermes/persona-gentleman.md
@@ -32,6 +32,7 @@ For those artifacts:
 - Generated technical artifacts default to English regardless of the active persona or conversation language.
 - If Spanish technical artifacts are explicitly requested, use neutral/professional Spanish unless the user explicitly asks for a regional variant.
 - Public/contextual comments follow the target context language by default; Spanish comments default to neutral/professional Spanish unless the user or context clearly calls for regional tone.
+- Before any Write/Edit whose content is an artifact, re-verify the artifact language rules.
 
 ## Language
 

--- a/internal/assets/hermes/persona-neutral.md
+++ b/internal/assets/hermes/persona-neutral.md
@@ -32,6 +32,7 @@ For those artifacts:
 - Generated technical artifacts default to English regardless of the active persona or conversation language.
 - If Spanish technical artifacts are explicitly requested, use neutral/professional Spanish unless the user explicitly asks for a regional variant.
 - Public/contextual comments follow the target context language by default; Spanish comments default to neutral/professional Spanish unless the user or context clearly calls for regional tone.
+- Before any Write/Edit whose content is an artifact, re-verify the artifact language rules.
 
 ## Language
 

--- a/internal/assets/hermes/persona-neutral.md
+++ b/internal/assets/hermes/persona-neutral.md
@@ -38,6 +38,7 @@ For those artifacts:
 - Match the user's current language in your REPLY ONLY (see Persona Scope above).
 - Do not switch languages unless the user does, asks you to, or you are quoting/translating content.
 - Use warm, natural, professional language without regional slang or dialect-specific grammar.
+- The same rule applies to tone and dialect: do not adopt regional forms from memory context, prior turns, or quoted material.
 - When replying to the user in English, keep the full reply in natural English with the same warm energy.
 - If the selected reply language is English, every part of the direct reply must be English: greetings, interjections, acknowledgements, transition phrases, and the first sentence. Do not use Hola, dale, listo, Spanish punctuation, or other Spanish fragments.
 - Prompts starting with or dominated by hi, hello, hey, or similar English greetings are English prompts unless the user explicitly asks for another language.

--- a/internal/assets/kimi/output-style-gentleman.md
+++ b/internal/assets/kimi/output-style-gentleman.md
@@ -39,6 +39,7 @@ For those artifacts:
 - Generated technical artifacts default to English regardless of the active persona or conversation language.
 - If Spanish technical artifacts are explicitly requested, use neutral/professional Spanish unless the user explicitly asks for a regional variant.
 - Public/contextual comments follow the target context language by default; Spanish comments default to neutral/professional Spanish unless the user or context clearly calls for regional tone.
+- Before any Write/Edit whose content is an artifact, re-verify the artifact language rules.
 
 ## Language Rules
 

--- a/internal/assets/kimi/output-style-neutral.md
+++ b/internal/assets/kimi/output-style-neutral.md
@@ -35,11 +35,13 @@ Generated technical artifacts default to English and neutral professional wordin
 - Generated technical artifacts default to English regardless of the active persona or conversation language.
 - If Spanish technical artifacts are explicitly requested, use neutral/professional Spanish unless the user explicitly asks for a regional variant.
 - Public/contextual comments follow the target context language by default; Spanish comments default to neutral/professional Spanish unless the user or context clearly calls for regional tone.
+- Before any Write/Edit whose content is an artifact, re-verify the artifact language rules.
 
 ## Language and Tone
 
 - Match the user's current language in direct replies.
 - Determine the reply language from the latest actual user request, not from Engram or memory context, repository/project language, tool output, previous assistant turns, persona wording, examples, or stylistic momentum.
+- The same rule applies to tone and dialect: do not adopt regional forms from memory context, prior turns, or quoted material.
 - Do not drift into another language because of persona wording, examples, or stylistic momentum.
 - For mixed-language prompts, use the dominant language of the user's direct request. Quoted text, filenames, project names, isolated borrowed words, or phrases like "the Spanish part" do not switch the reply language by themselves.
 - When replying to the user in English, keep the full response in English unless the user explicitly asks for another language or you are translating/quoting.

--- a/internal/assets/kiro/persona-gentleman.md
+++ b/internal/assets/kiro/persona-gentleman.md
@@ -28,6 +28,7 @@ For those artifacts:
 - Generated technical artifacts default to English regardless of the active persona or conversation language.
 - If Spanish technical artifacts are explicitly requested, use neutral/professional Spanish unless the user explicitly asks for a regional variant.
 - Public/contextual comments follow the target context language by default; Spanish comments default to neutral/professional Spanish unless the user or context clearly calls for regional tone.
+- Before any Write/Edit whose content is an artifact, re-verify the artifact language rules.
 
 ## Language
 

--- a/internal/assets/language_contract_test.go
+++ b/internal/assets/language_contract_test.go
@@ -461,3 +461,41 @@ func readRepoRootFile(t *testing.T, rel string) string {
 	}
 	return string(content)
 }
+
+var preWriteArtifactSelfCheckRequired = "Before any Write/Edit whose content is an artifact, re-verify the artifact language rules."
+
+var neutralToneDialectAntiDriftRequired = "The same rule applies to tone and dialect: do not adopt regional forms from memory context, prior turns, or quoted material."
+
+func TestPersonaChannelsCarryPreWriteArtifactSelfCheck(t *testing.T) {
+	paths := []string{
+		"claude/output-style-gentleman.md",
+		"claude/output-style-neutral.md",
+		"kimi/output-style-gentleman.md",
+		"kimi/output-style-neutral.md",
+		"generic/persona-gentleman.md",
+		"hermes/persona-gentleman.md",
+		"kiro/persona-gentleman.md",
+		"opencode/persona-gentleman.md",
+	}
+	for _, path := range paths {
+		content := MustRead(path)
+		if !strings.Contains(content, preWriteArtifactSelfCheckRequired) {
+			t.Errorf("%s: missing pre-write artifact self-check sentence", path)
+		}
+	}
+}
+
+func TestNeutralChannelsExtendAntiDriftToToneAndDialect(t *testing.T) {
+	paths := []string{
+		"claude/output-style-neutral.md",
+		"kimi/output-style-neutral.md",
+		"generic/persona-neutral.md",
+		"hermes/persona-neutral.md",
+	}
+	for _, path := range paths {
+		content := MustRead(path)
+		if !strings.Contains(content, neutralToneDialectAntiDriftRequired) {
+			t.Errorf("%s: missing tone/dialect anti-drift sentence", path)
+		}
+	}
+}

--- a/internal/assets/language_contract_test.go
+++ b/internal/assets/language_contract_test.go
@@ -462,9 +462,9 @@ func readRepoRootFile(t *testing.T, rel string) string {
 	return string(content)
 }
 
-var preWriteArtifactSelfCheckRequired = "Before any Write/Edit whose content is an artifact, re-verify the artifact language rules."
+const preWriteArtifactSelfCheckRequired = "Before any Write/Edit whose content is an artifact, re-verify the artifact language rules."
 
-var neutralToneDialectAntiDriftRequired = "The same rule applies to tone and dialect: do not adopt regional forms from memory context, prior turns, or quoted material."
+const neutralToneDialectAntiDriftRequired = "The same rule applies to tone and dialect: do not adopt regional forms from memory context, prior turns, or quoted material."
 
 func TestPersonaChannelsCarryPreWriteArtifactSelfCheck(t *testing.T) {
 	paths := []string{

--- a/internal/assets/language_contract_test.go
+++ b/internal/assets/language_contract_test.go
@@ -473,15 +473,19 @@ func TestPersonaChannelsCarryPreWriteArtifactSelfCheck(t *testing.T) {
 		"kimi/output-style-gentleman.md",
 		"kimi/output-style-neutral.md",
 		"generic/persona-gentleman.md",
+		"generic/persona-neutral.md",
 		"hermes/persona-gentleman.md",
+		"hermes/persona-neutral.md",
 		"kiro/persona-gentleman.md",
 		"opencode/persona-gentleman.md",
 	}
 	for _, path := range paths {
-		content := MustRead(path)
-		if !strings.Contains(content, preWriteArtifactSelfCheckRequired) {
-			t.Errorf("%s: missing pre-write artifact self-check sentence", path)
-		}
+		t.Run(path, func(t *testing.T) {
+			content := MustRead(path)
+			if !strings.Contains(content, preWriteArtifactSelfCheckRequired) {
+				t.Fatalf("%s: missing pre-write artifact self-check sentence", path)
+			}
+		})
 	}
 }
 
@@ -493,9 +497,11 @@ func TestNeutralChannelsExtendAntiDriftToToneAndDialect(t *testing.T) {
 		"hermes/persona-neutral.md",
 	}
 	for _, path := range paths {
-		content := MustRead(path)
-		if !strings.Contains(content, neutralToneDialectAntiDriftRequired) {
-			t.Errorf("%s: missing tone/dialect anti-drift sentence", path)
-		}
+		t.Run(path, func(t *testing.T) {
+			content := MustRead(path)
+			if !strings.Contains(content, neutralToneDialectAntiDriftRequired) {
+				t.Fatalf("%s: missing tone/dialect anti-drift sentence", path)
+			}
+		})
 	}
 }

--- a/internal/assets/opencode/persona-gentleman.md
+++ b/internal/assets/opencode/persona-gentleman.md
@@ -32,6 +32,7 @@ For those artifacts:
 - Generated technical artifacts default to English regardless of the active persona or conversation language.
 - If Spanish technical artifacts are explicitly requested, use neutral/professional Spanish unless the user explicitly asks for a regional variant.
 - Public/contextual comments follow the target context language by default; Spanish comments default to neutral/professional Spanish unless the user or context clearly calls for regional tone.
+- Before any Write/Edit whose content is an artifact, re-verify the artifact language rules.
 
 ## Language
 

--- a/testdata/golden/combined-windsurf-global-rules.golden
+++ b/testdata/golden/combined-windsurf-global-rules.golden
@@ -33,6 +33,7 @@ For those artifacts:
 - Generated technical artifacts default to English regardless of the active persona or conversation language.
 - If Spanish technical artifacts are explicitly requested, use neutral/professional Spanish unless the user explicitly asks for a regional variant.
 - Public/contextual comments follow the target context language by default; Spanish comments default to neutral/professional Spanish unless the user or context clearly calls for regional tone.
+- Before any Write/Edit whose content is an artifact, re-verify the artifact language rules.
 
 ## Language
 

--- a/testdata/golden/persona-antigravity-gentleman.golden
+++ b/testdata/golden/persona-antigravity-gentleman.golden
@@ -33,6 +33,7 @@ For those artifacts:
 - Generated technical artifacts default to English regardless of the active persona or conversation language.
 - If Spanish technical artifacts are explicitly requested, use neutral/professional Spanish unless the user explicitly asks for a regional variant.
 - Public/contextual comments follow the target context language by default; Spanish comments default to neutral/professional Spanish unless the user or context clearly calls for regional tone.
+- Before any Write/Edit whose content is an artifact, re-verify the artifact language rules.
 
 ## Language
 

--- a/testdata/golden/persona-claude-gentleman-outputstyle.golden
+++ b/testdata/golden/persona-claude-gentleman-outputstyle.golden
@@ -39,6 +39,7 @@ For those artifacts:
 - Generated technical artifacts default to English regardless of the active persona or conversation language.
 - If Spanish technical artifacts are explicitly requested, use neutral/professional Spanish unless the user explicitly asks for a regional variant.
 - Public/contextual comments follow the target context language by default; Spanish comments default to neutral/professional Spanish unless the user or context clearly calls for regional tone.
+- Before any Write/Edit whose content is an artifact, re-verify the artifact language rules.
 
 ## Language Rules
 

--- a/testdata/golden/persona-claude-neutral-outputstyle.golden
+++ b/testdata/golden/persona-claude-neutral-outputstyle.golden
@@ -35,11 +35,13 @@ Generated technical artifacts default to English and neutral professional wordin
 - Generated technical artifacts default to English regardless of the active persona or conversation language.
 - If Spanish technical artifacts are explicitly requested, use neutral/professional Spanish unless the user explicitly asks for a regional variant.
 - Public/contextual comments follow the target context language by default; Spanish comments default to neutral/professional Spanish unless the user or context clearly calls for regional tone.
+- Before any Write/Edit whose content is an artifact, re-verify the artifact language rules.
 
 ## Language and Tone
 
 - Match the user's current language in direct replies.
 - Determine the reply language from the latest actual user request, not from Engram or memory context, repository/project language, tool output, previous assistant turns, persona wording, examples, or stylistic momentum.
+- The same rule applies to tone and dialect: do not adopt regional forms from memory context, prior turns, or quoted material.
 - Do not drift into another language because of persona wording, examples, or stylistic momentum.
 - For mixed-language prompts, use the dominant language of the user's direct request. Quoted text, filenames, project names, isolated borrowed words, or phrases like "the Spanish part" do not switch the reply language by themselves.
 - When replying to the user in English, keep the full response in English unless the user explicitly asks for another language or you are translating/quoting.

--- a/testdata/golden/persona-kiro-gentleman.golden
+++ b/testdata/golden/persona-kiro-gentleman.golden
@@ -32,6 +32,7 @@ For those artifacts:
 - Generated technical artifacts default to English regardless of the active persona or conversation language.
 - If Spanish technical artifacts are explicitly requested, use neutral/professional Spanish unless the user explicitly asks for a regional variant.
 - Public/contextual comments follow the target context language by default; Spanish comments default to neutral/professional Spanish unless the user or context clearly calls for regional tone.
+- Before any Write/Edit whose content is an artifact, re-verify the artifact language rules.
 
 ## Language
 

--- a/testdata/golden/persona-opencode-gentleman.golden
+++ b/testdata/golden/persona-opencode-gentleman.golden
@@ -33,6 +33,7 @@ For those artifacts:
 - Generated technical artifacts default to English regardless of the active persona or conversation language.
 - If Spanish technical artifacts are explicitly requested, use neutral/professional Spanish unless the user explicitly asks for a regional variant.
 - Public/contextual comments follow the target context language by default; Spanish comments default to neutral/professional Spanish unless the user or context clearly calls for regional tone.
+- Before any Write/Edit whose content is an artifact, re-verify the artifact language rules.
 
 ## Language
 

--- a/testdata/golden/persona-opencode-neutral.golden
+++ b/testdata/golden/persona-opencode-neutral.golden
@@ -33,6 +33,7 @@ For those artifacts:
 - Generated technical artifacts default to English regardless of the active persona or conversation language.
 - If Spanish technical artifacts are explicitly requested, use neutral/professional Spanish unless the user explicitly asks for a regional variant.
 - Public/contextual comments follow the target context language by default; Spanish comments default to neutral/professional Spanish unless the user or context clearly calls for regional tone.
+- Before any Write/Edit whose content is an artifact, re-verify the artifact language rules.
 
 ## Language
 

--- a/testdata/golden/persona-opencode-neutral.golden
+++ b/testdata/golden/persona-opencode-neutral.golden
@@ -39,6 +39,7 @@ For those artifacts:
 - Match the user's current language in your REPLY ONLY (see Persona Scope above).
 - Do not switch languages unless the user does, asks you to, or you are quoting/translating content.
 - Use warm, natural, professional language without regional slang or dialect-specific grammar.
+- The same rule applies to tone and dialect: do not adopt regional forms from memory context, prior turns, or quoted material.
 - When replying to the user in English, keep the full reply in natural English with the same warm energy.
 - If the selected reply language is English, every part of the direct reply must be English: greetings, interjections, acknowledgements, transition phrases, and the first sentence. Do not use Hola, dale, listo, Spanish punctuation, or other Spanish fragments.
 - Prompts starting with or dominated by hi, hello, hey, or similar English greetings are English prompts unless the user explicitly asks for another language.

--- a/testdata/golden/persona-windsurf-gentleman.golden
+++ b/testdata/golden/persona-windsurf-gentleman.golden
@@ -33,6 +33,7 @@ For those artifacts:
 - Generated technical artifacts default to English regardless of the active persona or conversation language.
 - If Spanish technical artifacts are explicitly requested, use neutral/professional Spanish unless the user explicitly asks for a regional variant.
 - Public/contextual comments follow the target context language by default; Spanish comments default to neutral/professional Spanish unless the user or context clearly calls for regional tone.
+- Before any Write/Edit whose content is an artifact, re-verify the artifact language rules.
 
 ## Language
 


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1702

> Chained series: this is **PR4 of 4** — the final slice under #1702 (series consolidated from the 5 announced PRs; see #1749). Independent of the other PRs — based directly on `main`.

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)

---

## 📝 Summary

Fixes defect 5 of #1702: the main thread leaks conversation dialect into markdown deliverables under stylistic momentum in long Spanish sessions, because the Persona Scope rules are declarative only. Two sentence-level hardenings, pinned by required-strings tests:

- **Pre-write self-check** (10 persona channels — claude/kimi output-styles for both personas, generic/hermes `persona-{gentleman,neutral}.md`, kiro/opencode `persona-gentleman.md`): `Before any Write/Edit whose content is an artifact, re-verify the artifact language rules.`
- **Neutral tone/dialect anti-drift** (4 neutral channels): `The same rule applies to tone and dialect: do not adopt regional forms from memory context, prior turns, or quoted material.` — extends the existing language anti-drift rule (which covered reply LANGUAGE but not dialect; field evidence in #1702: voseo in a neutral session induced by recalled memory context).

No hardcoded dialect marker lists — principle-level wording only, per the issue's design discussion.

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/assets/{claude,kimi}/output-style-{gentleman,neutral}.md` | Self-check sentence; neutral variants also get the anti-drift sentence |
| `internal/assets/{generic,hermes,kiro,opencode}/persona-gentleman.md` | Self-check sentence |
| `internal/assets/{generic,hermes}/persona-neutral.md` | Self-check sentence + anti-drift sentence |
| `internal/assets/language_contract_test.go` | `TestPersonaChannelsCarryPreWriteArtifactSelfCheck` + `TestNeutralChannelsExtendAntiDriftToToneAndDialect` (required-strings, following the file's existing pattern) |
| `testdata/golden/*` (6) | Sentence-only regenerations |

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./...
```

**Go Format**
```bash
go run ./internal/gofmtcheck
```

**E2E Tests** (Docker required)
```bash
cd e2e && ./docker-test.sh
```

- [x] Unit tests pass (`go test ./internal/assets/ ./internal/components/...`; `./internal/cli` excluded locally — 3 machine-local pre-existing failures documented in #1712, deferring to CI)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests — deferring to CI (no local Docker run)
- [x] Manually tested locally (test-level; golden diffs inspected to be sentence-only)

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue — #1702 is currently `status:needs-review`; awaiting maintainer `status:approved`
- [x] PR stays within 400 changed lines (59 additions, 0 deletions, goldens included)
- [ ] `type:*` label — no triage rights from fork; maintainer: `type:bug`
- [x] Unit tests pass (as scoped above)
- [x] Go format passes
- [ ] E2E tests — deferring to CI
- [x] Documentation — asset wording IS the deliverable; no separate docs impact
- [x] Commits follow Conventional Commits
- [x] No `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

Kimi's neutral channel is `output-style-neutral.md` (no `persona-neutral.md` — Decision 1 residual architecture), and kiro/opencode have no neutral persona file at all, which is why the anti-drift set is 4 files, not 8. The sentences are asserted verbatim by the new tests, so future rewording must update both sides deliberately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Strengthened language handling by requiring a fresh verification of artifact language rules before any operation that generates artifact content.
  - Ensured reply tone and dialect are derived only from the latest actual user request, not from prior context or quoted text.

- **Tests**
  - Added automated checks to confirm the artifact-language and tone/dialect anti-drift guidance is present across supported assistant styles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
