### PR TITLE
fix(opencode): roll back Gentle Logo source when registration fails

### DIFF
--- a/internal/components/opencodeplugin/plugin.go
+++ b/internal/components/opencodeplugin/plugin.go
@@ -158,12 +158,24 @@ func installGentleLogo(homeDir string) (Result, error) {
 	pluginPath := filepath.Join(pluginDir, gentleLogoPluginFile)
 	tuiPath := filepath.Join(opencodeDir, "tui.json")
 
+	existed := false
+	var previousContent []byte
+	if data, err := os.ReadFile(pluginPath); err == nil {
+		existed = true
+		previousContent = data
+	}
+
 	pluginWrite, err := filemerge.WriteFileAtomic(pluginPath, []byte(gentleLogoPluginSource), 0o644)
 	if err != nil {
 		return Result{}, fmt.Errorf("write Gentle Logo TUI plugin: %w", err)
 	}
 	tuiChanged, err := ensureTUIPlugin(tuiPath, pluginPath)
 	if err != nil {
+		if existed {
+			_ = os.WriteFile(pluginPath, previousContent, 0o644)
+		} else {
+			_ = os.Remove(pluginPath)
+		}
 		return Result{}, err
 	}
 

--- a/internal/components/opencodeplugin/plugin.go
+++ b/internal/components/opencodeplugin/plugin.go
@@ -3,6 +3,7 @@ package opencodeplugin
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -49,6 +50,8 @@ var definitions = []Definition{
 }
 
 const gentleLogoPluginFile = "gentle-logo.tsx"
+
+var writeGentleLogoFileAtomic = filemerge.WriteFileAtomic
 
 const gentleLogoPluginSource = `// @ts-nocheck
 /** @jsxImportSource @opentui/solid */
@@ -158,25 +161,37 @@ func installGentleLogo(homeDir string) (Result, error) {
 	pluginPath := filepath.Join(pluginDir, gentleLogoPluginFile)
 	tuiPath := filepath.Join(opencodeDir, "tui.json")
 
-	existed := false
-	var previousContent []byte
-	if data, err := os.ReadFile(pluginPath); err == nil {
-		existed = true
-		previousContent = data
+	previousContent, readErr := os.ReadFile(pluginPath)
+	existed := readErr == nil
+	if readErr != nil && !os.IsNotExist(readErr) {
+		return Result{}, fmt.Errorf("read existing Gentle Logo TUI plugin: %w", readErr)
+	}
+	var previousMode os.FileMode
+	if existed {
+		info, statErr := os.Stat(pluginPath)
+		if statErr != nil {
+			return Result{}, fmt.Errorf("stat existing Gentle Logo TUI plugin: %w", statErr)
+		}
+		previousMode = info.Mode().Perm()
 	}
 
-	pluginWrite, err := filemerge.WriteFileAtomic(pluginPath, []byte(gentleLogoPluginSource), 0o644)
+	pluginWrite, err := writeGentleLogoFileAtomic(pluginPath, []byte(gentleLogoPluginSource), 0o644)
 	if err != nil {
 		return Result{}, fmt.Errorf("write Gentle Logo TUI plugin: %w", err)
 	}
 	tuiChanged, err := ensureTUIPlugin(tuiPath, pluginPath)
 	if err != nil {
+		var rollbackErr error
 		if existed {
-			_ = os.WriteFile(pluginPath, previousContent, 0o644)
+			if _, restoreErr := writeGentleLogoFileAtomic(pluginPath, previousContent, previousMode); restoreErr != nil {
+				rollbackErr = fmt.Errorf("restore Gentle Logo TUI plugin: %w", restoreErr)
+			}
 		} else {
-			_ = os.Remove(pluginPath)
+			if removeErr := os.Remove(pluginPath); removeErr != nil && !os.IsNotExist(removeErr) {
+				rollbackErr = fmt.Errorf("remove new Gentle Logo TUI plugin: %w", removeErr)
+			}
 		}
-		return Result{}, err
+		return Result{}, errors.Join(err, rollbackErr)
 	}
 
 	return Result{

--- a/internal/components/opencodeplugin/plugin_test.go
+++ b/internal/components/opencodeplugin/plugin_test.go
@@ -155,3 +155,50 @@ func TestInstallGentleLogoWritesLocalTUIPluginAndRegistersAbsolutePath(t *testin
 		t.Fatalf("plugin registration = %#v, want absolute %q", root.Plugin, pluginPath)
 	}
 }
+
+func TestInstallGentleLogoRollsBackSourceWhenRegistrationFails(t *testing.T) {
+	home := t.TempDir()
+	configDir := filepath.Join(home, ".config", "opencode")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create malformed tui.json so ensureTUIPlugin returns a JSON parse error
+	tuiPath := filepath.Join(configDir, "tui.json")
+	if err := os.WriteFile(tuiPath, []byte("invalid json {{"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	pluginPath := filepath.Join(configDir, "tui-plugins", "gentle-logo.tsx")
+
+	// Case 1: File did not exist before -> should be removed on failure
+	_, err := Install(home, model.OpenCodePluginGentleLogo)
+	if err == nil {
+		t.Fatal("Install(GentleLogo) error = nil, want parse error")
+	}
+	if _, statErr := os.Stat(pluginPath); !os.IsNotExist(statErr) {
+		t.Fatalf("Install(GentleLogo) left orphan plugin file after registration failure: %v", statErr)
+	}
+
+	// Case 2: File existed before -> should be restored to original content on failure
+	pluginDir := filepath.Join(configDir, "tui-plugins")
+	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	originalContent := []byte("// previous custom content")
+	if err := os.WriteFile(pluginPath, originalContent, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = Install(home, model.OpenCodePluginGentleLogo)
+	if err == nil {
+		t.Fatal("Install(GentleLogo) error = nil, want parse error")
+	}
+	data, readErr := os.ReadFile(pluginPath)
+	if readErr != nil {
+		t.Fatalf("ReadFile(pluginPath) error = %v", readErr)
+	}
+	if string(data) != string(originalContent) {
+		t.Fatalf("pluginPath content = %q, want restored original %q", string(data), string(originalContent))
+	}
+}

--- a/internal/components/opencodeplugin/plugin_test.go
+++ b/internal/components/opencodeplugin/plugin_test.go
@@ -7,6 +7,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -209,7 +210,7 @@ func TestInstallGentleLogoRollsBackSourceWhenRegistrationFails(t *testing.T) {
 	if statErr != nil {
 		t.Fatalf("Stat(pluginPath) error = %v", statErr)
 	}
-	if info.Mode().Perm() != 0o600 {
+	if runtime.GOOS != "windows" && info.Mode().Perm() != 0o600 {
 		t.Fatalf("pluginPath mode = %o, want restored 600", info.Mode().Perm())
 	}
 }

--- a/internal/components/opencodeplugin/plugin_test.go
+++ b/internal/components/opencodeplugin/plugin_test.go
@@ -1,12 +1,16 @@
 package opencodeplugin
 
 import (
+	"bytes"
 	"encoding/json"
+	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/gentleman-programming/gentle-ai/v2/internal/components/filemerge"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
 )
 
@@ -185,8 +189,8 @@ func TestInstallGentleLogoRollsBackSourceWhenRegistrationFails(t *testing.T) {
 	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	originalContent := []byte("// previous custom content")
-	if err := os.WriteFile(pluginPath, originalContent, 0o644); err != nil {
+	originalContent := []byte{0x00, 0xff, 'G', 'A', 'I', '\n'}
+	if err := os.WriteFile(pluginPath, originalContent, 0o600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -198,7 +202,46 @@ func TestInstallGentleLogoRollsBackSourceWhenRegistrationFails(t *testing.T) {
 	if readErr != nil {
 		t.Fatalf("ReadFile(pluginPath) error = %v", readErr)
 	}
-	if string(data) != string(originalContent) {
-		t.Fatalf("pluginPath content = %q, want restored original %q", string(data), string(originalContent))
+	if !bytes.Equal(data, originalContent) {
+		t.Fatalf("pluginPath content = %v, want restored original %v", data, originalContent)
+	}
+	info, statErr := os.Stat(pluginPath)
+	if statErr != nil {
+		t.Fatalf("Stat(pluginPath) error = %v", statErr)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("pluginPath mode = %o, want restored 600", info.Mode().Perm())
+	}
+}
+
+func TestInstallGentleLogoJoinsRegistrationAndRollbackErrors(t *testing.T) {
+	home := t.TempDir()
+	configDir := filepath.Join(home, ".config", "opencode")
+	pluginPath := filepath.Join(configDir, "tui-plugins", gentleLogoPluginFile)
+	if err := os.MkdirAll(filepath.Dir(pluginPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(pluginPath, []byte("original"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "tui.json"), []byte("invalid json {{"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	rollbackErr := errors.New("rollback write failed")
+	originalWrite := writeGentleLogoFileAtomic
+	writes := 0
+	writeGentleLogoFileAtomic = func(path string, content []byte, perm fs.FileMode) (filemerge.WriteResult, error) {
+		writes++
+		if writes == 2 {
+			return filemerge.WriteResult{}, rollbackErr
+		}
+		return originalWrite(path, content, perm)
+	}
+	t.Cleanup(func() { writeGentleLogoFileAtomic = originalWrite })
+
+	_, err := Install(home, model.OpenCodePluginGentleLogo)
+	if err == nil || !strings.Contains(err.Error(), "parse OpenCode TUI config") || !errors.Is(err, rollbackErr) {
+		t.Fatalf("Install(GentleLogo) error = %v, want joined registration and rollback errors", err)
 	}
 }


### PR DESCRIPTION
### 🔗 Linked Issue

Fixes #1678

---

### 📝 Summary of Changes

Gentle Logo installation wrote `~/.config/opencode/tui-plugins/gentle-logo.tsx` before registering that path in `tui.json`. If `ensureTUIPlugin` failed (e.g. `tui.json` was malformed or unreadable), `installGentleLogo` returned an error without restoring a pre-existing source file or removing a newly created one, leaving an orphan or overwritten source plugin.

#### Fix
Updated `installGentleLogo` in `internal/components/opencodeplugin/plugin.go` to capture pre-existing source state and restore or clean up `gentle-logo.tsx` when `ensureTUIPlugin` returns an error.

---

### 🧪 Test Plan

- [x] Ran `go run ./internal/gofmtcheck` cleanly.
- [x] Ran unit tests: `go test ./internal/components/opencodeplugin/...` passed cleanly.
- [x] Added unit test `TestInstallGentleLogoRollsBackSourceWhenRegistrationFails` in `plugin_test.go`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Failed Gentle Logo installations now automatically restore the previous plugin state.
  * Prevents incomplete plugin files from remaining after registration errors.

* **Tests**
  * Added coverage for rollback scenarios involving both new and previously existing plugin files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->