### PR TITLE
fix(sdd): validate reports before persistence

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -92,6 +92,8 @@ func RunArgs(args []string, stdout io.Writer) error {
 			return cli.RunSDDContinue(args[1:], stdout)
 		case "sdd-attempt":
 			return cli.RunSDDAttempt(args[1:], stdout)
+		case "sdd-verify-validate":
+			return cli.RunSDDVerifyValidate(args[1:], stdout)
 		case "codegraph":
 			return cli.RunCodeGraph(args[1:], stdout)
 		case "review":

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -293,6 +293,13 @@ func TestRunArgsSDDStatusIsDispatchedBeforePlatformValidation(t *testing.T) {
 	}
 }
 
+func TestRunArgsSDDVerifyValidateIsDispatchedBeforePlatformValidation(t *testing.T) {
+	err := RunArgs([]string{"sdd-verify-validate", "--input", filepath.Join(t.TempDir(), "missing"), "--requirements", "1", "--scenarios", "1"}, io.Discard)
+	if err == nil || !strings.Contains(err.Error(), "read verify report") {
+		t.Fatalf("RunArgs(sdd-verify-validate) error = %v", err)
+	}
+}
+
 func TestRunArgsSDDAttemptIsDispatchedBeforePlatformValidation(t *testing.T) {
 	origEnsure := ensureCurrentOSSupported
 	t.Cleanup(func() { ensureCurrentOSSupported = origEnsure })

--- a/internal/app/help.go
+++ b/internal/app/help.go
@@ -24,6 +24,8 @@ COMMANDS
                Print native SDD dispatcher routing output
   sdd-attempt <status|begin|finish|reset> --cwd <repo> --change <change>
                Read or mutate the artifact-store-agnostic runtime-attempt ledger
+  sdd-verify-validate --input <path|-> --requirements <n> --scenarios <n>
+               Validate exact verification-report bytes without persistence
   review start [--cwd <repo>] [--base-ref <ref>] [--focus <risk|resilience|readability|reliability>]
   review finalize [--cwd <repo>] [--result <review.json> ...] [--evidence <path>]
   review validate --gate <gate> [--cwd <repo>]

--- a/internal/app/help_test.go
+++ b/internal/app/help_test.go
@@ -11,7 +11,7 @@ func TestHelpContainsAllCommands(t *testing.T) {
 	printHelp(&buf, "v1.0.0-test")
 	output := buf.String()
 
-	commands := []string{"install", "uninstall", "sync", "sdd-status", "sdd-continue", "sdd-attempt", "review start", "review finalize", "review validate", "review status", "review repair", "review-start", "review-resume", "review-bundle-export", "review-bundle-import", "review-validate", "update", "upgrade", "restore", "version"}
+	commands := []string{"install", "uninstall", "sync", "sdd-status", "sdd-continue", "sdd-attempt", "sdd-verify-validate", "review start", "review finalize", "review validate", "review status", "review repair", "review-start", "review-resume", "review-bundle-export", "review-bundle-import", "review-validate", "update", "upgrade", "restore", "version"}
 	for _, cmd := range commands {
 		if !strings.Contains(output, cmd) {
 			t.Errorf("help output missing command %q", cmd)

--- a/internal/assets/assets_test.go
+++ b/internal/assets/assets_test.go
@@ -372,6 +372,32 @@ observed_authority_revision: sha256:{observed-authority-revision}`
 	}
 }
 
+func TestSDDVerifyAdmissionPrecedesPersistence(t *testing.T) {
+	for _, path := range []string{"skills/sdd-verify/SKILL.md", "skills/sdd-verify/references/report-format.md", "skills/_shared/sdd-phase-common.md", "skills/_shared/persistence-contract.md"} {
+		content := MustRead(path)
+		for _, want := range []string{"sdd-verify-validate", "exact candidate bytes", "before any OpenSpec or Engram write", "validator is unavailable", "valid `fail`"} {
+			if !strings.Contains(content, want) {
+				t.Fatalf("%s missing admission contract %q", path, want)
+			}
+		}
+	}
+	contract := MustRead("skills/_shared/persistence-contract.md")
+	for _, want := range []string{"Do not create, truncate, delete, or overwrite any prior `verify-report`", "A valid `fail` report must be persisted", "validator is unavailable"} {
+		if !strings.Contains(contract, want) {
+			t.Fatalf("persistence contract missing %q", want)
+		}
+	}
+	if count := strings.Count(MustRead("skills/sdd-verify/SKILL.md"), "sdd-verify-validate"); count < 2 {
+		t.Fatalf("both sdd-verify model sections require admission, got %d occurrences", count)
+	}
+	for _, path := range []string{"claude/agents/sdd-verify.md", "claude/commands/sdd-verify.md", "cursor/agents/sdd-verify.md", "kimi/agents/sdd-verify.md", "kiro/agents/sdd-verify.md"} {
+		content := MustRead(path)
+		if skill, save := strings.Index(content, "sdd-verify/SKILL.md"), strings.LastIndex(content, "mem_save"); skill < 0 || save < 0 || skill > save {
+			t.Fatalf("%s must load the shared verify contract before persistence", path)
+		}
+	}
+}
+
 func TestOpenCodeEmbeddedAssetLayout(t *testing.T) {
 	entries, err := FS.ReadDir("opencode")
 	if err != nil {

--- a/internal/assets/skills/_shared/persistence-contract.md
+++ b/internal/assets/skills/_shared/persistence-contract.md
@@ -73,6 +73,12 @@ The orchestrator persists DAG state after each phase transition to enable SDD re
 - NEVER force `openspec/` creation unless orchestrator explicitly passed `openspec` or `hybrid`
 - If unsure which mode to use, default to `none`
 
+### Verify-report admission
+
+Build a complete `verify-report` in memory as exact candidate bytes. Count authoritative requirements and scenarios, then run `gentle-ai sdd-verify-validate` on those bytes before any OpenSpec or Engram write.
+
+If admission fails or the validator is unavailable, STOP with zero persistence calls. Do not create, truncate, delete, or overwrite any prior `verify-report`. On success, persist the same candidate bytes for the selected mode; hybrid preflights once before both writes. A valid `fail` report must be persisted because validity and archive readiness are separate decisions.
+
 ## Sub-Agent Context Rules
 
 Sub-agents launch with a fresh context and NO access to the orchestrator's instructions or memory protocol.

--- a/internal/assets/skills/_shared/sdd-phase-common.md
+++ b/internal/assets/skills/_shared/sdd-phase-common.md
@@ -38,6 +38,8 @@ Do NOT use search previews as source material.
 
 Every phase that produces an artifact MUST persist it. Skipping this BREAKS the pipeline — downstream phases will not find your output.
 
+For `verify-report`, first build exact candidate bytes and run `gentle-ai sdd-verify-validate` with authoritative requirement/scenario counts before any OpenSpec or Engram write. If the validator is unavailable or denies admission, make zero writes and leave the prior report untouched; otherwise persist only the same admitted bytes, including a valid `fail`.
+
 ### Engram mode
 
 ```

--- a/internal/assets/skills/sdd-verify/SKILL.md
+++ b/internal/assets/skills/sdd-verify/SKILL.md
@@ -43,6 +43,7 @@ The orchestrator should provide structured status from `skills/_shared/sdd-statu
 - A spec scenario is compliant only when a covering test passed at runtime.
 - Compare specs first, design second, task completion third.
 - Do not fix issues; report them for the orchestrator/user.
+- Build the complete report as exact candidate bytes, then run `gentle-ai sdd-verify-validate` with authoritative spec counts before any OpenSpec or Engram write. If the validator is unavailable or denies admission, make zero writes and leave the prior report untouched; otherwise persist the same bytes, including a valid `fail`.
 - Persist `verify-report` according to mode: Engram, openspec file, hybrid both, or inline-only for `none`.
 - If Strict TDD is active, load `strict-tdd-verify.md` from this skill directory; if inactive, never load it.
 - Return the Section D envelope from `../_shared/sdd-phase-common.md`.
@@ -151,6 +152,7 @@ You are a VERIFY sub-agent. Your job: check implemented changes match spec accep
 - A contradiction or failing check escalates; never start another review/fix loop.
 - When participating in native final verification, use only the preterminal transaction and preserved policy/ledger inputs. Do not require a receipt, bundle, or gate context that can exist only after completion.
 - Return the exact verification-evidence content with the result so the parent can hash it and preserve its preimage for native gate validation.
+- Build the complete report as exact candidate bytes, then run `gentle-ai sdd-verify-validate` with authoritative spec counts before any OpenSpec or Engram write. If the validator is unavailable or denies admission, make zero writes and leave the prior report untouched; otherwise persist the same bytes, including a valid `fail`.
 - For an authority-only preflight denial, both declared commands must not be executed. Record exit `125`, empty-output hashes, and exactly these five recovery fields in the strict envelope:
 
 ```yaml

--- a/internal/assets/skills/sdd-verify/references/report-format.md
+++ b/internal/assets/skills/sdd-verify/references/report-format.md
@@ -80,7 +80,9 @@ build_output_hash: sha256:{exact-output-digest}
 {one-line reason}
 ~~~
 
-The YAML envelope MUST be the first non-empty content and contains every field exactly once. Counts come from the actual retrieved specs. Passing requires current test and build/type-check commands with zero exit codes and SHA-256 output digests. Invalid, unknown, missing, contradictory, blocker-bearing, critical-bearing, incomplete, or stale evidence fails closed. Human prose after the envelope never controls routing. Model/provider/profile/effort selection remains user-owned.
+The YAML envelope MUST be the first non-empty content and contains every field exactly once. Counts come from the actual retrieved specs. Admission rejects malformed, unknown, missing, contradictory, or count-mismatched evidence. A canonical failure with blocker, critical, command-exit, or incomplete evidence is valid and persistable but not archive-ready. Human prose after the envelope never controls routing. Model/provider/profile/effort selection remains user-owned.
+
+Before persistence, hold the complete report as exact candidate bytes and run `gentle-ai sdd-verify-validate --input <path|-> --requirements <n> --scenarios <n>` before any OpenSpec or Engram write. If the validator is unavailable or denies admission, make zero writes and preserve the prior report; otherwise persist the same bytes, including a valid `fail`.
 
 ## Authority-Only Preflight Denial
 

--- a/internal/cli/sdd_verify_validate.go
+++ b/internal/cli/sdd_verify_validate.go
@@ -1,0 +1,69 @@
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/gentleman-programming/gentle-ai/internal/sddstatus"
+)
+
+const maxVerifyReportBytes = 1 << 20
+
+// RunSDDVerifyValidate validates a complete report without touching an artifact store.
+func RunSDDVerifyValidate(args []string, stdout io.Writer) error {
+	return runSDDVerifyValidate(args, os.Stdin, stdout)
+}
+
+func runSDDVerifyValidate(args []string, stdin io.Reader, stdout io.Writer) error {
+	flags := flag.NewFlagSet("sdd-verify-validate", flag.ContinueOnError)
+	flags.SetOutput(io.Discard)
+	input := flags.String("input", "", "report path or - for stdin")
+	requirements := flags.Int("requirements", -2, "authoritative requirement count")
+	scenarios := flags.Int("scenarios", -2, "authoritative scenario count")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return fmt.Errorf("unexpected sdd-verify-validate argument %q", flags.Arg(0))
+	}
+	if strings.TrimSpace(*input) == "" {
+		return errors.New("sdd-verify-validate requires --input")
+	}
+	if *requirements == -2 {
+		return errors.New("sdd-verify-validate requires --requirements")
+	}
+	if *scenarios == -2 {
+		return errors.New("sdd-verify-validate requires --scenarios")
+	}
+	if *requirements < 0 || *scenarios < 0 {
+		return errors.New("requirement and scenario counts must be nonnegative")
+	}
+	reader := stdin
+	if *input != "-" {
+		file, err := os.Open(*input)
+		if err != nil {
+			return fmt.Errorf("read verify report: %w", err)
+		}
+		defer file.Close()
+		reader = file
+	}
+	payload, err := io.ReadAll(io.LimitReader(reader, maxVerifyReportBytes+1))
+	if err != nil {
+		return fmt.Errorf("read verify report: %w", err)
+	}
+	if len(payload) > maxVerifyReportBytes {
+		return fmt.Errorf("verify report exceeds %d-byte limit", maxVerifyReportBytes)
+	}
+	admission := sddstatus.ValidateVerifyReportAdmission(string(payload), sddstatus.SpecCounts{Requirements: *requirements, Scenarios: *scenarios})
+	if !admission.Valid {
+		return fmt.Errorf("verify report admission denied: %s", admission.Reason)
+	}
+	encoder := json.NewEncoder(stdout)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(admission)
+}

--- a/internal/cli/sdd_verify_validate_test.go
+++ b/internal/cli/sdd_verify_validate_test.go
@@ -1,0 +1,46 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunSDDVerifyValidate(t *testing.T) {
+	report := "```yaml\nschema: gentle-ai.verify-result/v1\nevidence_revision: sha256:" + strings.Repeat("a", 64) + "\nverdict: fail\nblockers: 1\ncritical_findings: 0\nrequirements: 1/1\nscenarios: 1/1\ntest_command: go test ./...\ntest_exit_code: 0\ntest_output_hash: sha256:" + strings.Repeat("b", 64) + "\nbuild_command: go vet ./...\nbuild_exit_code: 0\nbuild_output_hash: sha256:" + strings.Repeat("c", 64) + "\n```"
+	var output bytes.Buffer
+	if err := runSDDVerifyValidate([]string{"--input", "-", "--requirements", "1", "--scenarios", "1"}, strings.NewReader(report), &output); err != nil {
+		t.Fatalf("valid failure: %v", err)
+	}
+	if got := output.String(); !strings.Contains(got, `"valid": true`) || !strings.Contains(got, `"verdict": "fail"`) {
+		t.Fatalf("output = %s", got)
+	}
+	path := filepath.Join(t.TempDir(), "report.md")
+	if err := os.WriteFile(path, []byte(report), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := runSDDVerifyValidate([]string{"--input", path, "--requirements", "1", "--scenarios", "1"}, strings.NewReader("unused"), &bytes.Buffer{}); err != nil {
+		t.Fatalf("file input: %v", err)
+	}
+
+	for _, tt := range []struct {
+		name        string
+		args        []string
+		input, want string
+	}{
+		{"front matter", []string{"--input", "-", "--requirements", "1", "--scenarios", "1"}, "---\n" + report, "front matter"},
+		{"missing count", []string{"--input", "-", "--requirements", "1"}, report, "requires --scenarios"},
+		{"negative count", []string{"--input", "-", "--requirements", "-1", "--scenarios", "1"}, report, "nonnegative"},
+		{"unexpected argument", []string{"--input", "-", "--requirements", "1", "--scenarios", "1", "extra"}, report, "unexpected"},
+		{"oversized", []string{"--input", "-", "--requirements", "1", "--scenarios", "1"}, strings.Repeat("x", 1<<20+1), "exceeds"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			err := runSDDVerifyValidate(tt.args, strings.NewReader(tt.input), &bytes.Buffer{})
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}

--- a/internal/sddstatus/bounded_review_test.go
+++ b/internal/sddstatus/bounded_review_test.go
@@ -1085,6 +1085,31 @@ func TestResolveRemediationIsBoundToBudgetAndFailedEvidenceRevision(t *testing.T
 	}
 }
 
+func TestResolveMalformedFailedEvidenceKeepsMatchingRevisionBound(t *testing.T) {
+	root := t.TempDir()
+	changeRoot := seedReadyChange(t, root, "thin", "- [x] 1.1 Done\n")
+	revision := shaID("d")
+	report := strings.Replace(boundedVerifyEnvelope(revision, "fail"), "blockers: 0", "blockers: 1", 1)
+	report = strings.Replace(report, "test_output_hash: "+shaID("2"), "test_output_hash: sha256:invalid", 1)
+	admission := ValidateVerifyReportAdmission(report, SpecCounts{Requirements: 1, Scenarios: 1})
+	if admission.Valid || !strings.Contains(admission.Reason, "invalid test_output_hash") {
+		t.Fatalf("admission = %#v, want denied malformed hash", admission)
+	}
+	write(t, filepath.Join(changeRoot, "verify-report.md"), report)
+	writeJSON(t, filepath.Join(changeRoot, "reviews", "transaction.json"), remediationTransaction(t, revision, false))
+
+	status, err := Resolve(ResolveOptions{CWD: root, ChangeName: "thin"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.NextRecommended != "remediate" || !status.RemediationState.Required || status.RemediationState.FailedEvidenceRevision != revision {
+		t.Fatalf("next=%q remediation=%#v, want matching bounded remediation", status.NextRecommended, status.RemediationState)
+	}
+	if status.Dependencies.Archive != DependencyBlocked {
+		t.Fatalf("archive=%q, malformed report must not become archive-ready", status.Dependencies.Archive)
+	}
+}
+
 func seedBoundedReadyChange(t *testing.T, root string) string {
 	t.Helper()
 	changeRoot := seedReadyChange(t, root, "thin", "- [x] 1.1 Work\n")

--- a/internal/sddstatus/status.go
+++ b/internal/sddstatus/status.go
@@ -542,44 +542,11 @@ func authorityChangedSinceReport(report, revision string) bool {
 }
 
 func authorityFailureFields(report string) (map[string]string, bool) {
-	const emptyOutputHash = "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-
-	lines, end, reason := parseLeadingEnvelope(report)
-	if reason != "" {
+	parsed, reason := parseVerifyReport(report)
+	if reason != "" || !parsed.AuthorityOnly {
 		return nil, false
 	}
-	allowed := map[string]bool{
-		"schema": true, "evidence_revision": true, "verdict": true, "blockers": true, "critical_findings": true,
-		"requirements": true, "scenarios": true, "test_command": true, "test_exit_code": true, "test_output_hash": true,
-		"build_command": true, "build_exit_code": true, "build_output_hash": true, "authority_only_failure": true,
-		"missing_review_authority": true, "substantive_failure": true, "command_failed": true, "observed_authority_revision": true,
-	}
-	fields, reason := parseScalarFields(lines[1:end], allowed, "authority failure")
-	if reason != "" || len(fields) != len(allowed) || fields["schema"] != VerifyResultSchema || fields["verdict"] != "fail" {
-		return nil, false
-	}
-	for _, field := range []string{"evidence_revision", "test_output_hash", "build_output_hash", "observed_authority_revision"} {
-		if !sha256IdentityPattern.MatchString(fields[field]) {
-			return nil, false
-		}
-	}
-	if fields["test_output_hash"] != emptyOutputHash || fields["build_output_hash"] != emptyOutputHash {
-		return nil, false
-	}
-	testExit, testOK := parseNonnegativeInt(fields["test_exit_code"])
-	buildExit, buildOK := parseNonnegativeInt(fields["build_exit_code"])
-	blockers, blockersOK := parseNonnegativeInt(fields["blockers"])
-	critical, criticalOK := parseNonnegativeInt(fields["critical_findings"])
-	if !testOK || !buildOK || !blockersOK || !criticalOK || blockers == 0 || critical == 0 || testExit != 125 || buildExit != 125 {
-		return nil, false
-	}
-	if _, ok := parseVerifyCompletion(fields["requirements"]); !ok {
-		return nil, false
-	}
-	if _, ok := parseVerifyCompletion(fields["scenarios"]); !ok || !isConcreteEvidence(fields["test_command"]) || !isConcreteEvidence(fields["build_command"]) {
-		return nil, false
-	}
-	return fields, true
+	return parsed.Fields, true
 }
 
 func resolveEngramStatus(workspaceRoot string, requestedChange string, includeInstructions bool) (Status, bool, error) {

--- a/internal/sddstatus/verification.go
+++ b/internal/sddstatus/verification.go
@@ -11,6 +11,7 @@ import (
 
 const VerifyResultSchema = "gentle-ai.verify-result/v1"
 const RemediationResultSchema = "gentle-ai.remediation-result/v1"
+const verifyEmptyOutputHash = "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
 type SpecCounts struct {
 	Requirements int
@@ -31,6 +32,22 @@ type verifyResultEvaluation struct {
 	EvidenceRevision string
 }
 
+// VerifyReportAdmission is the pure, pre-persistence validity decision.
+type VerifyReportAdmission struct {
+	Valid            bool   `json:"valid"`
+	Reason           string `json:"reason,omitempty"`
+	Verdict          string `json:"verdict,omitempty"`
+	EvidenceRevision string `json:"evidence_revision,omitempty"`
+}
+
+type verifyReport struct {
+	Fields                                  map[string]string
+	Verdict, EvidenceRevision               string
+	Blockers, Critical, TestExit, BuildExit int
+	Requirements, Scenarios                 verifyCompletion
+	AuthorityOnly                           bool
+}
+
 var sha256IdentityPattern = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
 var requirementHeadingPattern = regexp.MustCompile(`(?m)^### Requirement:\s+\S`)
 var scenarioHeadingPattern = regexp.MustCompile(`(?m)^#### Scenario:\s+\S`)
@@ -45,120 +62,49 @@ func countSpecRequirementsAndScenarios(specs []string) SpecCounts {
 }
 
 func parseVerifyResult(text string, expected SpecCounts) verifyResultEvaluation {
-	lines, end, reason := parseLeadingEnvelope(text)
+	report, reason := parseVerifyReport(text)
 	if reason != "" {
-		return verifyResultEvaluation{Reason: reason}
+		return verifyResultEvaluation{Reason: reason, EvidenceRevision: report.EvidenceRevision}
 	}
-	allowed := map[string]bool{
-		"schema": true, "evidence_revision": true, "verdict": true,
-		"blockers": true, "critical_findings": true, "requirements": true, "scenarios": true,
-		"test_command": true, "test_exit_code": true, "test_output_hash": true,
-		"build_command": true, "build_exit_code": true, "build_output_hash": true,
-	}
-	fields, reason := parseScalarFields(lines[1:end], allowed, "verify result")
-	if reason != "" {
-		return verifyResultEvaluation{Reason: reason}
-	}
-	for _, required := range []string{
-		"schema", "evidence_revision", "verdict", "blockers", "critical_findings",
-		"requirements", "scenarios", "test_command", "test_exit_code", "test_output_hash",
-		"build_command", "build_exit_code", "build_output_hash",
-	} {
-		if _, ok := fields[required]; !ok {
-			return verifyResultEvaluation{Reason: fmt.Sprintf("missing %s in verify result envelope", required)}
-		}
-	}
-
-	evaluation := verifyResultEvaluation{EvidenceRevision: fields["evidence_revision"]}
-	if fields["schema"] != VerifyResultSchema {
-		evaluation.Reason = fmt.Sprintf("unsupported verify result schema %s", fields["schema"])
-		return evaluation
-	}
-	for _, field := range []string{"evidence_revision", "test_output_hash", "build_output_hash"} {
-		if !sha256IdentityPattern.MatchString(fields[field]) {
-			evaluation.Reason = fmt.Sprintf("invalid %s in verify result envelope", field)
-			return evaluation
-		}
-	}
-	if !isConcreteEvidence(fields["test_command"]) || !isConcreteEvidence(fields["build_command"]) {
-		evaluation.Reason = "test_command and build_command require concrete current execution evidence"
-		return evaluation
-	}
-
-	blockers, ok := parseNonnegativeInt(fields["blockers"])
-	if !ok {
-		evaluation.Reason = "invalid blockers in verify result envelope"
-		return evaluation
-	}
-	critical, ok := parseNonnegativeInt(fields["critical_findings"])
-	if !ok {
-		evaluation.Reason = "invalid critical_findings in verify result envelope"
-		return evaluation
-	}
-	testExit, ok := parseNonnegativeInt(fields["test_exit_code"])
-	if !ok {
-		evaluation.Reason = "invalid test_exit_code in verify result envelope"
-		return evaluation
-	}
-	buildExit, ok := parseNonnegativeInt(fields["build_exit_code"])
-	if !ok {
-		evaluation.Reason = "invalid build_exit_code in verify result envelope"
-		return evaluation
-	}
-	requirements, ok := parseVerifyCompletion(fields["requirements"])
-	if !ok {
-		evaluation.Reason = "invalid requirements in verify result envelope"
-		return evaluation
-	}
-	scenarios, ok := parseVerifyCompletion(fields["scenarios"])
-	if !ok {
-		evaluation.Reason = "invalid scenarios in verify result envelope"
-		return evaluation
-	}
-
-	verdict := fields["verdict"]
-	if verdict != "pass" && verdict != "pass_with_warnings" && verdict != "fail" {
-		evaluation.Reason = fmt.Sprintf("invalid verdict %s", verdict)
-		return evaluation
-	}
-	if testExit != 0 {
+	evaluation := verifyResultEvaluation{EvidenceRevision: report.EvidenceRevision}
+	if report.TestExit != 0 {
 		evaluation.Reason = "test_exit_code must be zero for archive readiness"
 		return evaluation
 	}
-	if buildExit != 0 {
+	if report.BuildExit != 0 {
 		evaluation.Reason = "build_exit_code must be zero for archive readiness"
 		return evaluation
 	}
-	internallyComplete := requirements.Completed == requirements.Total && scenarios.Completed == scenarios.Total
-	totalsMatch := requirements.Total == expected.Requirements && scenarios.Total == expected.Scenarios
+	internallyComplete := report.Requirements.Completed == report.Requirements.Total && report.Scenarios.Completed == report.Scenarios.Total
+	totalsMatch := report.Requirements.Total == expected.Requirements && report.Scenarios.Total == expected.Scenarios
 	if !totalsMatch {
-		evaluation.Stale = verdict != "fail" && blockers == 0 && critical == 0 && internallyComplete
+		evaluation.Stale = report.Verdict != "fail" && report.Blockers == 0 && report.Critical == 0 && internallyComplete
 	}
-	if requirements.Total != expected.Requirements {
-		evaluation.Reason = fmt.Sprintf("verify result total %d does not match actual requirement count %d", requirements.Total, expected.Requirements)
+	if report.Requirements.Total != expected.Requirements {
+		evaluation.Reason = fmt.Sprintf("verify result total %d does not match actual requirement count %d", report.Requirements.Total, expected.Requirements)
 		return evaluation
 	}
-	if scenarios.Total != expected.Scenarios {
-		evaluation.Reason = fmt.Sprintf("verify result total %d does not match actual scenario count %d", scenarios.Total, expected.Scenarios)
+	if report.Scenarios.Total != expected.Scenarios {
+		evaluation.Reason = fmt.Sprintf("verify result total %d does not match actual scenario count %d", report.Scenarios.Total, expected.Scenarios)
 		return evaluation
 	}
-	if blockers != 0 {
+	if report.Blockers != 0 {
 		evaluation.Reason = "blockers must be zero for archive readiness"
 		return evaluation
 	}
-	if critical != 0 {
+	if report.Critical != 0 {
 		evaluation.Reason = "critical_findings must be zero for archive readiness"
 		return evaluation
 	}
-	if requirements.Completed != requirements.Total {
+	if report.Requirements.Completed != report.Requirements.Total {
 		evaluation.Reason = "requirements are incomplete"
 		return evaluation
 	}
-	if scenarios.Completed != scenarios.Total {
+	if report.Scenarios.Completed != report.Scenarios.Total {
 		evaluation.Reason = "scenarios are incomplete"
 		return evaluation
 	}
-	if verdict == "fail" {
+	if report.Verdict == "fail" {
 		evaluation.Reason = "verdict requires remediation"
 		return evaluation
 	}
@@ -166,11 +112,132 @@ func parseVerifyResult(text string, expected SpecCounts) verifyResultEvaluation 
 	return evaluation
 }
 
+// ValidateVerifyReportAdmission validates exact report bytes before persistence.
+func ValidateVerifyReportAdmission(text string, expected SpecCounts) VerifyReportAdmission {
+	report, reason := parseVerifyReport(text)
+	result := VerifyReportAdmission{Reason: reason}
+	if reason != "" {
+		return result
+	}
+	result.Verdict, result.EvidenceRevision = report.Verdict, report.EvidenceRevision
+	if expected.Requirements < 0 || expected.Scenarios < 0 {
+		result.Reason = "expected requirement and scenario counts must be nonnegative"
+		return result
+	}
+	if report.Requirements.Total != expected.Requirements {
+		result.Reason = fmt.Sprintf("verify result total %d does not match actual requirement count %d", report.Requirements.Total, expected.Requirements)
+		return result
+	}
+	if report.Scenarios.Total != expected.Scenarios {
+		result.Reason = fmt.Sprintf("verify result total %d does not match actual scenario count %d", report.Scenarios.Total, expected.Scenarios)
+		return result
+	}
+	complete := report.Requirements.Completed == report.Requirements.Total && report.Scenarios.Completed == report.Scenarios.Total
+	if report.Verdict != "fail" {
+		if report.TestExit != 0 || report.BuildExit != 0 || report.Blockers != 0 || report.Critical != 0 || !complete {
+			result.Reason = "passing verdict contradicts failing or incomplete evidence"
+			return result
+		}
+	} else if !report.AuthorityOnly {
+		if report.TestExit == 125 || report.BuildExit == 125 {
+			result.Reason = "exit code 125 requires the exact authority-only extension"
+			return result
+		}
+		if report.TestExit == 0 && report.BuildExit == 0 && report.Blockers == 0 && report.Critical == 0 && complete {
+			result.Reason = "fail verdict is contradictory with all-green evidence"
+			return result
+		}
+	}
+	result.Valid, result.Reason = true, ""
+	return result
+}
+
+func parseVerifyReport(text string) (verifyReport, string) {
+	lines, end, reason := parseLeadingEnvelope(text)
+	if reason != "" {
+		return verifyReport{}, reason
+	}
+	base := []string{"schema", "evidence_revision", "verdict", "blockers", "critical_findings", "requirements", "scenarios", "test_command", "test_exit_code", "test_output_hash", "build_command", "build_exit_code", "build_output_hash"}
+	extension := []string{"authority_only_failure", "missing_review_authority", "substantive_failure", "command_failed", "observed_authority_revision"}
+	allowed := make(map[string]bool, len(base)+len(extension))
+	for _, field := range append(base, extension...) {
+		allowed[field] = true
+	}
+	fields, reason := parseScalarFields(lines[1:end], allowed, "verify result")
+	report := verifyReport{Fields: fields}
+	if fields["schema"] == VerifyResultSchema && sha256IdentityPattern.MatchString(fields["evidence_revision"]) {
+		report.EvidenceRevision = fields["evidence_revision"]
+	}
+	if reason != "" {
+		return report, reason
+	}
+	for _, required := range base {
+		if _, ok := fields[required]; !ok {
+			return report, fmt.Sprintf("missing %s in verify result envelope", required)
+		}
+	}
+	extensionCount := 0
+	for _, field := range extension {
+		if _, ok := fields[field]; ok {
+			extensionCount++
+		}
+	}
+	if extensionCount != 0 && extensionCount != len(extension) {
+		return report, "authority-only extension must contain exactly five fields"
+	}
+	if fields["schema"] != VerifyResultSchema {
+		return report, fmt.Sprintf("unsupported verify result schema %s", fields["schema"])
+	}
+	for _, field := range []string{"evidence_revision", "test_output_hash", "build_output_hash"} {
+		if !sha256IdentityPattern.MatchString(fields[field]) {
+			return report, fmt.Sprintf("invalid %s in verify result envelope", field)
+		}
+	}
+	if !isConcreteEvidence(fields["test_command"]) || !isConcreteEvidence(fields["build_command"]) {
+		return report, "test_command and build_command require concrete current execution evidence"
+	}
+	report.Verdict, report.AuthorityOnly = fields["verdict"], extensionCount != 0
+	for _, target := range []struct {
+		name  string
+		value *int
+	}{{"blockers", &report.Blockers}, {"critical_findings", &report.Critical}, {"test_exit_code", &report.TestExit}, {"build_exit_code", &report.BuildExit}} {
+		value, ok := parseNonnegativeInt(fields[target.name])
+		if !ok {
+			return report, fmt.Sprintf("invalid %s in verify result envelope", target.name)
+		}
+		*target.value = value
+	}
+	var ok bool
+	if report.Requirements, ok = parseVerifyCompletion(fields["requirements"]); !ok {
+		return report, "invalid requirements in verify result envelope"
+	}
+	if report.Scenarios, ok = parseVerifyCompletion(fields["scenarios"]); !ok {
+		return report, "invalid scenarios in verify result envelope"
+	}
+	if report.Verdict != "pass" && report.Verdict != "pass_with_warnings" && report.Verdict != "fail" {
+		return report, fmt.Sprintf("invalid verdict %s", report.Verdict)
+	}
+	if report.AuthorityOnly {
+		for _, pair := range [][2]string{{"authority_only_failure", "true"}, {"missing_review_authority", "true"}, {"substantive_failure", "false"}, {"command_failed", "false"}} {
+			if fields[pair[0]] != pair[1] {
+				return report, "invalid authority-only extension"
+			}
+		}
+		if report.Verdict != "fail" || report.TestExit != 125 || report.BuildExit != 125 || report.Blockers == 0 || report.Critical == 0 || fields["test_output_hash"] != verifyEmptyOutputHash || fields["build_output_hash"] != verifyEmptyOutputHash || !sha256IdentityPattern.MatchString(fields["observed_authority_revision"]) {
+			return report, "invalid authority-only extension"
+		}
+	}
+	return report, ""
+}
+
 func parseLeadingEnvelope(text string) ([]string, int, string) {
 	text = strings.ReplaceAll(text, "\r\n", "\n")
 	lines := strings.Split(strings.TrimSpace(text), "\n")
+	if len(lines) > 0 && strings.TrimSpace(lines[0]) == "---" {
+		return nil, -1, "YAML front matter is unsupported; the first non-empty content must be a fenced yaml envelope"
+	}
 	if len(lines) == 0 || strings.TrimSpace(lines[0]) != "```yaml" {
-		return nil, -1, "missing valid gentle-ai.verify-result/v1 envelope"
+		return nil, -1, "missing valid gentle-ai.verify-result/v1 envelope: the first non-empty content must be fenced yaml"
 	}
 	for index := 1; index < len(lines); index++ {
 		if strings.TrimSpace(lines[index]) == "```" {
@@ -191,13 +258,13 @@ func parseScalarFields(lines []string, allowed map[string]bool, label string) (m
 		key = strings.TrimSpace(key)
 		value = strings.TrimSpace(value)
 		if !ok || key == "" || value == "" {
-			return nil, "malformed " + label + " field"
+			return fields, "malformed " + label + " field"
 		}
 		if !allowed[key] {
-			return nil, fmt.Sprintf("unknown %s field %s", label, key)
+			return fields, fmt.Sprintf("unknown %s field %s", label, key)
 		}
 		if _, duplicate := fields[key]; duplicate {
-			return nil, fmt.Sprintf("duplicate %s field %s", label, key)
+			return fields, fmt.Sprintf("duplicate %s field %s", label, key)
 		}
 		fields[key] = value
 	}

--- a/internal/sddstatus/verification_test.go
+++ b/internal/sddstatus/verification_test.go
@@ -43,6 +43,60 @@ func TestParseVerifyResultFailsClosedAndRequiresCurrentExecutionEvidence(t *test
 	}
 }
 
+func TestValidateVerifyReportAdmission(t *testing.T) {
+	valid := testVerifyEnvelope("pass", 0, 0, "2/2", "3/3", 0, 0)
+	authority := strings.TrimSuffix(testVerifyEnvelope("fail", 1, 1, "0/2", "0/3", 125, 125), "```") + strings.Join([]string{
+		"authority_only_failure: true", "missing_review_authority: true", "substantive_failure: false", "command_failed: false",
+		"observed_authority_revision: sha256:" + strings.Repeat("d", 64), "```\n",
+	}, "\n")
+	authority = strings.Replace(authority, "test_exit_code: 1", "test_exit_code: 125", 1)
+	authority = strings.Replace(authority, "build_exit_code: 1", "build_exit_code: 125", 1)
+	authority = strings.ReplaceAll(authority, "sha256:"+strings.Repeat("b", 64), emptyOutputHash)
+	authority = strings.ReplaceAll(authority, "sha256:"+strings.Repeat("c", 64), emptyOutputHash)
+	tests := []struct {
+		name, report, reason string
+		valid                bool
+	}{
+		{"pass", valid, "", true},
+		{"warning pass with CRLF and prose", strings.ReplaceAll(strings.Replace(valid, "verdict: pass", "verdict: pass_with_warnings", 1)+"\nDetails", "\n", "\r\n"), "", true},
+		{"failed tests", testVerifyEnvelope("fail", 0, 0, "2/2", "3/3", 1, 0), "", true},
+		{"failed build", testVerifyEnvelope("fail", 0, 0, "2/2", "3/3", 0, 1), "", true},
+		{"blocker", testVerifyEnvelope("fail", 1, 0, "2/2", "3/3", 0, 0), "", true},
+		{"critical", testVerifyEnvelope("fail", 0, 1, "2/2", "3/3", 0, 0), "", true},
+		{"incomplete requirement", testVerifyEnvelope("fail", 0, 0, "1/2", "3/3", 0, 0), "", true},
+		{"incomplete scenario", testVerifyEnvelope("fail", 0, 0, "2/2", "2/3", 0, 0), "", true},
+		{"authority-only denial", authority, "", true},
+		{"all-green failure", strings.Replace(valid, "verdict: pass", "verdict: fail", 1), "contradictory", false},
+		{"passing blocker", strings.Replace(valid, "blockers: 0", "blockers: 1", 1), "contradicts", false},
+		{"passing incomplete", strings.Replace(valid, "requirements: 2/2", "requirements: 1/2", 1), "contradicts", false},
+		{"count mismatch", valid, "actual requirement count", false},
+		{"front matter", "---\nverdict: pass\n---\n" + valid, "front matter", false},
+		{"prose first", "Result follows\n" + valid, "first non-empty", false},
+		{"unterminated", strings.TrimSuffix(valid, "```"), "unterminated", false},
+		{"duplicate", strings.Replace(valid, "verdict: pass", "verdict: pass\nverdict: pass", 1), "duplicate", false},
+		{"unknown", strings.Replace(valid, "verdict: pass", "verdict: pass\nextra: value", 1), "unknown", false},
+		{"malformed", strings.Replace(valid, "blockers: 0", "blockers", 1), "malformed", false},
+		{"missing", strings.Replace(valid, "build_command: go test ./cmd/gentle-ai\n", "", 1), "missing build_command", false},
+		{"invalid hash", strings.Replace(valid, "sha256:"+strings.Repeat("b", 64), "sha256:nope", 1), "invalid test_output_hash", false},
+		{"placeholder command", strings.Replace(valid, "test_command: go test ./internal/example", "test_command: placeholder", 1), "concrete", false},
+		{"partial authority extension", strings.TrimSuffix(valid, "```") + "authority_only_failure: true\n```", "authority-only", false},
+		{"invalid authority extension", strings.Replace(authority, "command_failed: false", "command_failed: true", 1), "invalid authority-only", false},
+		{"reserved exit without extension", strings.Replace(strings.Replace(valid, "verdict: pass", "verdict: fail", 1), "test_exit_code: 0", "test_exit_code: 125", 1), "requires the exact authority-only", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			expected := SpecCounts{Requirements: 2, Scenarios: 3}
+			if tt.name == "count mismatch" {
+				expected.Requirements = 3
+			}
+			got := ValidateVerifyReportAdmission(tt.report, expected)
+			if got.Valid != tt.valid || (tt.reason != "" && !strings.Contains(got.Reason, tt.reason)) {
+				t.Fatalf("admission = %#v, want valid=%v reason containing %q", got, tt.valid, tt.reason)
+			}
+		})
+	}
+}
+
 func TestCountSpecRequirementsAndScenariosUsesActualArtifacts(t *testing.T) {
 	counts := countSpecRequirementsAndScenarios([]string{
 		"### Requirement: First\n#### Scenario: A\n#### Scenario: B\n",


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1525

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)

## 📝 Summary

Validate the exact SDD verify-report candidate before any OpenSpec, Engram, or hybrid persistence. The native admission boundary rejects malformed or contradictory envelopes while keeping coherent failed verification reports persistable for bounded remediation.

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/sddstatus` | Added strict report admission separated from archive readiness while preserving historical remediation identity |
| `internal/cli/sdd_verify_validate.go` | Added bounded, side-effect-free `sdd-verify-validate` preflight for files or stdin |
| `internal/app` | Wired command dispatch and help |
| Shared SDD verify/persistence assets | Required exact candidate bytes to pass native preflight before any backend write |
| Tests | Covered exact field sets, coherent failures, contradictions, counts, authority-only envelopes, stale reports, CLI bounds, and write ordering |

## 🧪 Test Plan

```bash
go test ./...
go test -race ./internal/sddstatus ./internal/cli ./internal/app ./internal/assets
go vet ./...
go run ./internal/gofmtcheck
./scripts/test-review-contract-package.sh
./scripts/test-review-capabilities.sh
```

- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — delegated to required CI
- [x] Manually tested valid failure admission and invalid-input rejection locally

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] Maintainer `size:exception` is requested and applied with rationale below
- [x] I have added exactly one `type:*` label
- [x] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — delegated to required CI
- [x] Shared provider documentation is updated
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers

## Size Exception Rationale

This is one 535-line authored safety boundary with no generated lines. Splitting the strict native parser/CLI from provider preflight ordering would create an unsafe intermediate state where invalid reports could still overwrite valid evidence. The work therefore remains one coherent, independently reviewed PR.

## Review Evidence

- Candidate: `fe62ceb5ece617855d48efa84bc4de39978e2e7b`
- Tree: `103b9eb85ad37a674e7470f94c5738298e4810c3`
- Full risk, resilience, reliability, and readability review completed.
- The single corroborated historical-remediation blocker was corrected within budget and independently revalidated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `sdd-verify-validate` command for validating verification reports from a file or standard input.
  * Added validation for report structure, evidence, expected requirement/scenario counts, and input size.
  * Reports now receive clear admission results, including validity, verdict, and rejection reasons.

* **Bug Fixes**
  * Verification reports are validated before persistence, preventing invalid reports from being written or replacing existing reports.
  * Improved handling of malformed and authority-only failure evidence.

* **Documentation**
  * Updated CLI help and verification guidance with the new validation and persistence requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->