### PR TITLE
fix(review): preserve exact transition selectors

### DIFF
--- a/contracts/review-integration/v1/schemas/status-v2.schema.json
+++ b/contracts/review-integration/v1/schemas/status-v2.schema.json
@@ -119,6 +119,7 @@
       "properties": {
         "operation": { "enum": ["review.start", "review.finalize", "review.recover", "review.repair", "review.validate"] },
         "arguments": { "type": "array", "items": { "$ref": "#/$defs/transition_argument" } },
+        "selector_arguments": { "type": "array", "items": { "$ref": "#/$defs/transition_argument" } },
         "preconditions": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/transition_argument" } },
         "binding": { "$ref": "#/$defs/transition_binding" },
         "artifacts": { "type": "array", "items": { "$ref": "#/$defs/transition_artifact" } }

--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -454,6 +454,13 @@ func runReviewStatus(ctx context.Context, args []string, stdout io.Writer) error
 				target.BaseRef = selectedBaseTree
 			}
 		}
+		selector := &reviewTransitionSelector{
+			Kind: target.Kind, Projection: selectedProjection, BaseRef: selectedBaseRef,
+			BaseTree: selectedBaseTree, WorkspaceOverlay: *workspaceOverlay, PrePRRepresentable: true,
+		}
+		if reviewtransaction.GateKind(*gate) == reviewtransaction.GatePrePR {
+			selector.PrePRRepresentable = reviewtransaction.ValidatePrePRBoundarySelector(ctx, root, selectedBaseRef) == nil
+		}
 		native, liveSnapshot, err := reviewtransaction.AssessTargetStatusWithSnapshot(ctx, root, reviewtransaction.TargetStatusRequest{
 			Target: target, LineageID: *lineage,
 		})
@@ -493,6 +500,15 @@ func runReviewStatus(ctx context.Context, args []string, stdout io.Writer) error
 						artifactErr = loadErr
 					} else {
 						correctionForecasted = record.State.State == reviewtransaction.StateCorrectionRequired && record.State.ProposedCorrectionLines != nil
+						selector.RecoveryRepresentable = record.State.InitialSnapshot.Kind == target.Kind
+						predecessorProjection := record.State.InitialSnapshot.Projection
+						if predecessorProjection == "" {
+							predecessorProjection = reviewtransaction.ProjectionWorkspace
+						}
+						if selector.RecoveryRepresentable && predecessorProjection != selector.Projection {
+							selector.RecoveryRepresentable = result.ActionDisposition == reviewtransaction.RecoveryEscalated
+							selector.RecoveryProjection = selector.Projection
+						}
 						if correctionForecasted {
 							request, requestErr := reviewtransaction.BuildTargetedValidationRequestFromSnapshot(ctx, root, record.State, record.Revision, liveSnapshot)
 							if requestErr == nil {
@@ -523,7 +539,7 @@ func runReviewStatus(ctx context.Context, args []string, stdout io.Writer) error
 					}
 				}
 			}
-			transition := newReviewNextTransition(result, native.SelectedLenses, artifacts, evidenceAvailable, artifactErr, reviewNextTransitionInput{Gate: reviewtransaction.GateKind(*gate), Successor: *recoverySuccessor, Reason: *recoveryReason, Actor: *recoveryActor, Authorization: *recoveryAuthorization, RepairActor: *repairActor, RepairReason: *repairReason, RepairAuthorization: *repairAuthorization, StartLineage: strings.TrimSpace(*lineage), RepositoryContext: repositoryContext, ValidationRequest: validationRequest, CorrectionForecasted: correctionForecasted, CaptureContext: captureContext})
+			transition := newReviewNextTransition(result, native.SelectedLenses, artifacts, evidenceAvailable, artifactErr, reviewNextTransitionInput{Gate: reviewtransaction.GateKind(*gate), Successor: *recoverySuccessor, Reason: *recoveryReason, Actor: *recoveryActor, Authorization: *recoveryAuthorization, RepairActor: *repairActor, RepairReason: *repairReason, RepairAuthorization: *repairAuthorization, StartLineage: strings.TrimSpace(*lineage), RepositoryContext: repositoryContext, ValidationRequest: validationRequest, CorrectionForecasted: correctionForecasted, CaptureContext: captureContext, Selector: selector})
 			result.NextTransition = &transition
 		}
 		if err := result.Validate(); err != nil {
@@ -545,6 +561,9 @@ func runReviewStatus(ctx context.Context, args []string, stdout io.Writer) error
 }
 
 func RunReviewRecover(args []string, stdout io.Writer) error {
+	if err := validateReviewTransitionSelectorFlagCounts(args, "review.recover"); err != nil {
+		return err
+	}
 	flags := newReviewFlagSet("review recover", stdout, "Create an auditable successor authority without changing its predecessor.")
 	cwd := flags.String("cwd", ".", "repository path")
 	predecessor := flags.String("predecessor-lineage", "", "explicit predecessor lineage")
@@ -554,7 +573,7 @@ func RunReviewRecover(args []string, stdout io.Writer) error {
 	reason := flags.String("reason", "", "recovery reason")
 	actor := flags.String("actor", "", "recovery actor")
 	projectionFlag := flags.String("projection", "", "successor projection: workspace or staged (default: predecessor projection)")
-	authorization := flags.String("maintainer-authorization", "", "exact six-line LF-only binding: gentle-ai.review-recovery-authorization/v1, predecessor_lineage, predecessor_revision, target_identity, actor, reason")
+	authorization := flags.String("maintainer-authorization", "", "exact LF-only gentle-ai.review-recovery-authorization/v1 binding: predecessor_lineage, predecessor_revision, target_identity, optional native successor_lineage, actor, reason")
 	policySource := flags.String("policy", "", "optional review policy file")
 	focus := flags.String("focus", "reliability", "dominant standard-risk focus; large pure documentation always uses readability")
 	baseRef := flags.String("base-ref", "", "optional base revision for immutable base-to-HEAD review")
@@ -661,6 +680,8 @@ func RunReviewRecover(args []string, stdout io.Writer) error {
 	}
 	if *releaseScope {
 		*authorization = reviewtransaction.ReleaseScopeRecoveryAuthorization
+	} else if *authorization == reviewTransitionRecoveryAuthorization(ReviewTransitionBinding{LineageID: *predecessor, Revision: *expected, TargetIdentity: snapshot.Identity}, *successor, *actor, *reason) {
+		*authorization = reviewTransitionRecoveryAuthorization(ReviewTransitionBinding{LineageID: *predecessor, Revision: *expected, TargetIdentity: snapshot.Identity}, "", *actor, *reason)
 	}
 	reviewRecoverBeforePersist()
 	record, err := reviewtransaction.RecoverCompactAuthority(context.Background(), root, reviewtransaction.CompactRecoveryRequest{
@@ -1101,6 +1122,65 @@ func reviewStartBindingFlagCounts(args []string) map[string]int {
 		}
 	}
 	return counts
+}
+
+func validateReviewTransitionSelectorFlagCounts(args []string, operation string) error {
+	shape := reviewIntegrationOperationFlagShape(operation)
+	selectors := []string{"base-ref"}
+	if operation == "review.recover" {
+		shape = map[string]reviewIntegrationFlagKind{
+			"cwd":                           reviewIntegrationValueFlag,
+			"predecessor-lineage":           reviewIntegrationValueFlag,
+			"expected-predecessor-revision": reviewIntegrationValueFlag,
+			"successor-lineage":             reviewIntegrationValueFlag,
+			"disposition":                   reviewIntegrationValueFlag,
+			"reason":                        reviewIntegrationValueFlag,
+			"actor":                         reviewIntegrationValueFlag,
+			"projection":                    reviewIntegrationValueFlag,
+			"maintainer-authorization":      reviewIntegrationValueFlag,
+			"policy":                        reviewIntegrationValueFlag,
+			"focus":                         reviewIntegrationValueFlag,
+			"base-ref":                      reviewIntegrationValueFlag,
+			"committed-only":                reviewIntegrationBoolFlag,
+			"release-scope":                 reviewIntegrationBoolFlag,
+			"h":                             reviewIntegrationBoolFlag,
+			"help":                          reviewIntegrationBoolFlag,
+		}
+		selectors = []string{"base-ref", "committed-only", "projection"}
+	}
+	counts := make(map[string]int, len(selectors))
+	selected := make(map[string]bool, len(selectors))
+	for _, name := range selectors {
+		selected[name] = true
+	}
+	for index := 0; index < len(args); index++ {
+		argument := args[index]
+		if argument == "--" || argument == "" || argument == "-" || argument[0] != '-' {
+			break
+		}
+		nameValue := strings.TrimPrefix(strings.TrimPrefix(argument, "-"), "-")
+		name, hasValue := nameValue, false
+		if separator := strings.IndexByte(nameValue, '='); separator >= 0 {
+			name, hasValue = nameValue[:separator], true
+		}
+		kind, known := shape[name]
+		if !known {
+			continue
+		}
+		if selected[name] {
+			counts[name]++
+		}
+		if kind != reviewIntegrationBoolFlag && !hasValue {
+			index++
+		}
+	}
+	command := strings.TrimPrefix(operation, "review.")
+	for _, name := range selectors {
+		if counts[name] > 1 {
+			return fmt.Errorf("review %s repeats --%s", command, name)
+		}
+	}
+	return nil
 }
 
 func reviewFacadeStartResultFor(action reviewtransaction.CompactStartAction, lensesRequired bool, authority reviewtransaction.CompactState) ReviewFacadeStartResult {
@@ -1676,6 +1756,9 @@ func RunReviewFacadeValidate(args []string, stdout io.Writer) error {
 }
 
 func runReviewFacadeValidate(ctx context.Context, args []string, stdout io.Writer) error {
+	if err := validateReviewTransitionSelectorFlagCounts(args, ReviewIntegrationOperationValidate); err != nil {
+		return err
+	}
 	flags := newReviewFlagSet("review validate", stdout, "Auto-discover authoritative review state and receipt, then validate them against live Git evidence.")
 	cwd := flags.String("cwd", ".", "repository path")
 	contract := flags.String("contract", "", "optional negotiated review integration contract")

--- a/internal/cli/review_next_transition.go
+++ b/internal/cli/review_next_transition.go
@@ -24,11 +24,12 @@ type ReviewNextTransition struct {
 }
 
 type ReviewTransitionExecution struct {
-	Operation     string                     `json:"operation"`
-	Arguments     []ReviewTransitionArgument `json:"arguments"`
-	Preconditions []ReviewTransitionArgument `json:"preconditions"`
-	Binding       ReviewTransitionBinding    `json:"binding"`
-	Artifacts     []ReviewTransitionArtifact `json:"artifacts,omitempty"`
+	Operation         string                      `json:"operation"`
+	Arguments         []ReviewTransitionArgument  `json:"arguments"`
+	SelectorArguments *[]ReviewTransitionArgument `json:"selector_arguments,omitempty"`
+	Preconditions     []ReviewTransitionArgument  `json:"preconditions"`
+	Binding           ReviewTransitionBinding     `json:"binding"`
+	Artifacts         []ReviewTransitionArtifact  `json:"artifacts,omitempty"`
 }
 
 type ReviewTransitionCollection struct {
@@ -162,7 +163,20 @@ func newReviewNextTransition(status ReviewTargetStatusResult, selectedLenses []s
 		return reviewRecoveryCollection(status, binding, input)
 	case reviewtransaction.StateApproved:
 		if status.Receipt.Status == ReviewReceiptPresent {
-			return reviewExecuteTransition("approved_receipt_ready", "review.validate", []ReviewTransitionArgument{{Name: "lineage", Value: binding.LineageID}, {Name: "gate", Value: string(input.gate())}}, []ReviewTransitionArgument{{Name: "state", Value: "approved"}, {Name: "receipt", Value: "present"}}, binding, nil)
+			if input.Selector != nil && input.gate() == reviewtransaction.GatePrePR && !input.Selector.PrePRRepresentable {
+				return reviewStopTransition("pre_pr_selector_unrepresentable")
+			}
+			arguments := []ReviewTransitionArgument{{Name: "lineage", Value: binding.LineageID}, {Name: "gate", Value: string(input.gate())}}
+			selectors := []ReviewTransitionArgument{}
+			if input.Selector != nil && input.gate() == reviewtransaction.GatePrePR && input.Selector.BaseRef != "" {
+				selectors = append(selectors, ReviewTransitionArgument{Name: "base-ref", Value: input.Selector.BaseRef})
+				arguments = append(arguments, selectors...)
+			}
+			transition := reviewExecuteTransition("approved_receipt_ready", "review.validate", arguments, []ReviewTransitionArgument{{Name: "state", Value: "approved"}, {Name: "receipt", Value: "present"}}, binding, nil)
+			if input.Selector != nil {
+				transition.Execute.SelectorArguments = reviewTransitionSelectorArguments(selectors)
+			}
+			return transition
 		}
 		if status.Replayability == reviewtransaction.ReplayabilityExactReplaySafe {
 			return reviewExecuteTransition("exact_receipt_replay", "review.finalize", []ReviewTransitionArgument{{Name: "lineage", Value: binding.LineageID}}, []ReviewTransitionArgument{{Name: "state", Value: "approved"}, {Name: "receipt", Value: "publication_pending"}}, binding, nil)
@@ -262,6 +276,17 @@ type reviewNextTransitionInput struct {
 	ValidationRequest                              *reviewtransaction.TargetedValidationRequest
 	CorrectionForecasted                           bool
 	CaptureContext                                 *reviewCaptureContext
+	Selector                                       *reviewTransitionSelector
+}
+
+type reviewTransitionSelector struct {
+	Kind                  reviewtransaction.TargetKind
+	Projection            reviewtransaction.Projection
+	BaseRef, BaseTree     string
+	WorkspaceOverlay      bool
+	RecoveryRepresentable bool
+	RecoveryProjection    reviewtransaction.Projection
+	PrePRRepresentable    bool
 }
 
 func reviewStartArguments(status ReviewTargetStatusResult, lineage string) []ReviewTransitionArgument {
@@ -339,13 +364,62 @@ func reviewRecoveryCollection(status ReviewTargetStatusResult, binding ReviewTra
 	if disposition == "" {
 		disposition = reviewtransaction.RecoveryInvalidated
 	}
+	var selectorArguments []ReviewTransitionArgument
+	if input.Selector != nil {
+		if status.TargetIdentity == reviewAuthorityTargetIdentity(status) {
+			return reviewStopTransition("recovery_scope_unchanged")
+		}
+		var representable bool
+		selectorArguments, representable = input.Selector.recoveryArguments()
+		if !representable {
+			return reviewStopTransition("recovery_target_unrepresentable")
+		}
+	}
 	if input.recoveryAuthorized(binding) {
-		return reviewExecuteTransition("recovery_authorized", "review.recover", []ReviewTransitionArgument{{Name: "predecessor-lineage", Value: binding.LineageID}, {Name: "expected-predecessor-revision", Value: binding.Revision}, {Name: "successor-lineage", Value: input.Successor}, {Name: "disposition", Value: string(disposition)}, {Name: "reason", Value: input.Reason}, {Name: "actor", Value: input.Actor}, {Name: "maintainer-authorization", Value: input.Authorization}}, []ReviewTransitionArgument{{Name: "state", Value: string(status.Authority.State)}, {Name: "recovery_authorization", Value: "provided"}}, binding, nil)
+		arguments := []ReviewTransitionArgument{{Name: "predecessor-lineage", Value: binding.LineageID}, {Name: "expected-predecessor-revision", Value: binding.Revision}, {Name: "successor-lineage", Value: input.Successor}, {Name: "disposition", Value: string(disposition)}, {Name: "reason", Value: input.Reason}, {Name: "actor", Value: input.Actor}, {Name: "maintainer-authorization", Value: input.Authorization}}
+		transition := reviewExecuteTransition("recovery_authorized", "review.recover", append(arguments, selectorArguments...), []ReviewTransitionArgument{{Name: "state", Value: string(status.Authority.State)}, {Name: "recovery_authorization", Value: "provided"}}, binding, nil)
+		if input.Selector != nil {
+			transition.Execute.SelectorArguments = reviewTransitionSelectorArguments(selectorArguments)
+		}
+		return transition
 	}
 	return reviewCollectTransition("recovery_authorization_required", ReviewTransitionInput{
 		Name: "recovery_authorization", Schema: "gentle-ai.review-recovery-authorization/v1", CaptureOperation: "external.authorize_recovery",
 		Arguments: append(reviewBindingArguments(binding), ReviewTransitionArgument{Name: "disposition", Value: string(disposition)}),
 	})
+}
+
+func (selector reviewTransitionSelector) recoveryArguments() ([]ReviewTransitionArgument, bool) {
+	if !selector.RecoveryRepresentable {
+		return nil, false
+	}
+	arguments := []ReviewTransitionArgument{}
+	switch selector.Kind {
+	case reviewtransaction.TargetCurrentChanges:
+		if selector.BaseRef != "" || selector.BaseTree != "" || selector.WorkspaceOverlay {
+			return nil, false
+		}
+	case reviewtransaction.TargetBaseDiff:
+		if selector.BaseRef == "" || selector.BaseTree != "" || selector.WorkspaceOverlay {
+			return nil, false
+		}
+		arguments = append(arguments, ReviewTransitionArgument{Name: "base-ref", Value: selector.BaseRef}, ReviewTransitionArgument{Name: "committed-only", Value: "true"})
+	case reviewtransaction.TargetBaseWorkspaceOverlay:
+		if !selector.WorkspaceOverlay || (selector.BaseRef == "") == (selector.BaseTree == "") {
+			return nil, false
+		}
+		base := selector.BaseRef
+		if base == "" {
+			base = selector.BaseTree
+		}
+		arguments = append(arguments, ReviewTransitionArgument{Name: "base-ref", Value: base})
+	default:
+		return nil, false
+	}
+	if selector.RecoveryProjection != "" {
+		arguments = append(arguments, ReviewTransitionArgument{Name: "projection", Value: string(selector.RecoveryProjection)})
+	}
+	return arguments, true
 }
 
 func reviewFinalVerificationRetryCollection(status ReviewTargetStatusResult, binding ReviewTransitionBinding) ReviewNextTransition {
@@ -370,7 +444,24 @@ func reviewFinalVerificationRetryCollection(status ReviewTargetStatusResult, bin
 }
 
 func (input reviewNextTransitionInput) recoveryAuthorized(binding ReviewTransitionBinding) bool {
-	return input.Successor != "" && input.Reason != "" && input.Actor != "" && input.Authorization == "gentle-ai.review-recovery-authorization/v1\npredecessor_lineage="+binding.LineageID+"\npredecessor_revision="+binding.Revision+"\ntarget_identity="+binding.TargetIdentity+"\nactor="+input.Actor+"\nreason="+input.Reason
+	successor := ""
+	if input.Selector != nil {
+		successor = input.Successor
+	}
+	return input.Successor != "" && input.Reason != "" && input.Actor != "" && input.Authorization == reviewTransitionRecoveryAuthorization(binding, successor, input.Actor, input.Reason)
+}
+
+func reviewTransitionRecoveryAuthorization(binding ReviewTransitionBinding, successor, actor, reason string) string {
+	value := "gentle-ai.review-recovery-authorization/v1\npredecessor_lineage=" + binding.LineageID + "\npredecessor_revision=" + binding.Revision + "\ntarget_identity=" + binding.TargetIdentity
+	if successor != "" {
+		value += "\nsuccessor_lineage=" + successor
+	}
+	return value + "\nactor=" + actor + "\nreason=" + reason
+}
+
+func reviewTransitionSelectorArguments(arguments []ReviewTransitionArgument) *[]ReviewTransitionArgument {
+	selectors := append([]ReviewTransitionArgument{}, arguments...)
+	return &selectors
 }
 
 func reviewTargetArguments(status ReviewTargetStatusResult) []ReviewTransitionArgument {

--- a/internal/cli/review_selector_transition_test.go
+++ b/internal/cli/review_selector_transition_test.go
@@ -1,0 +1,437 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/internal/reviewtransaction"
+)
+
+func TestStatusValidateTransitionPreservesCustomPublicationBase(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	remote := filepath.Join(t.TempDir(), "origin.git")
+	if err := os.MkdirAll(remote, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runReviewCLIGit(t, remote, "init", "--bare", "-q")
+	runReviewCLIGit(t, repo, "branch", "-M", "main")
+	runReviewCLIGit(t, repo, "remote", "add", "origin", remote)
+	runReviewCLIGit(t, repo, "push", "-qu", "origin", "main")
+	runReviewCLIGit(t, repo, "branch", "release", "HEAD")
+	runReviewCLIGit(t, repo, "push", "-q", "origin", "release")
+	writeReviewStartCandidate(t, repo, "main-only.txt", "main movement\n", 0o644)
+	runReviewCLIGit(t, repo, "add", "main-only.txt")
+	runReviewCLIGit(t, repo, "commit", "-qm", "advance main")
+	runReviewCLIGit(t, repo, "push", "-q", "origin", "main")
+	runReviewCLIGit(t, repo, "switch", "-q", "release")
+	writeReviewStartCandidate(t, repo, "docs/release.md", "# Release candidate\n", 0o644)
+	runReviewCLIGit(t, repo, "add", "docs/release.md")
+	runReviewCLIGit(t, repo, "commit", "-qm", "add release candidate")
+
+	var output bytes.Buffer
+	if err := RunReviewFacadeStart([]string{"--cwd", repo, "--lineage", "selector-validate", "--base-ref", "origin/release", "--committed-only"}, &output); err != nil {
+		t.Fatal(err)
+	}
+	if err := RunReviewFacadeFinalize([]string{"--cwd", repo, "--lineage", "selector-validate"}, &bytes.Buffer{}); err != nil {
+		t.Fatal(err)
+	}
+	status := selectorTransitionStatus(t, repo, "--lineage", "selector-validate", "--gate", "pre-pr", "--base-ref", "  origin/release  ")
+	arguments := selectorTransitionArguments(t, status)
+	if arguments["base-ref"] != "origin/release" || arguments["committed-only"] != "" || arguments["projection"] != "" {
+		t.Fatalf("VALIDATE selectors = %#v", arguments)
+	}
+	assertSelectorTransitionMutationRejected(t, status, func(arguments []ReviewTransitionArgument) []ReviewTransitionArgument {
+		return arguments[:len(arguments)-1]
+	})
+	assertSelectorTransitionMutationRejected(t, status, func(arguments []ReviewTransitionArgument) []ReviewTransitionArgument {
+		return setSelectorTransitionArgument(arguments, "base-ref", "origin/main")
+	})
+	assertSelectorTransitionMutationRejected(t, status, func(arguments []ReviewTransitionArgument) []ReviewTransitionArgument {
+		return setSelectorTransitionArgument(arguments, "base-ref", filepath.Join(t.TempDir(), "main"))
+	})
+	assertSelectorTransitionMutationRejected(t, status, func(arguments []ReviewTransitionArgument) []ReviewTransitionArgument {
+		return setSelectorTransitionArgument(arguments, "base-ref", " origin/release")
+	})
+	assertSelectorTransitionMutationRejected(t, status, func(arguments []ReviewTransitionArgument) []ReviewTransitionArgument {
+		return append(arguments, ReviewTransitionArgument{Name: "base-ref", Value: "origin/release"})
+	})
+	assertSelectorTransitionMutationRejected(t, status, func(arguments []ReviewTransitionArgument) []ReviewTransitionArgument {
+		return removeSelectorTransitionArgument(arguments, "gate")
+	})
+	unbound, transition, execution := status, *status.NextTransition, *status.NextTransition.Execute
+	execution.SelectorArguments = nil
+	transition.Execute, unbound.NextTransition = &execution, &transition
+	if err := unbound.Validate(); err == nil {
+		t.Fatal("status accepted a missing normalized selector")
+	}
+	duplicate := strings.TrimSpace(runReviewCLIGit(t, repo, "rev-parse", "origin/release"))
+	runReviewCLIGit(t, repo, "push", "-q", "origin", "release:duplicate")
+	raw := selectorTransitionStatus(t, repo, "--lineage", "selector-validate", "--gate", "pre-pr", "--base-ref", duplicate)
+	if raw.NextTransition.Kind != reviewNextTransitionStop || raw.NextTransition.ReasonCode != "pre_pr_selector_unrepresentable" {
+		t.Fatalf("raw SHA pre-PR transition = %#v", raw.NextTransition)
+	}
+	assertReviewGateResult(t, executeSelectorTransition(t, repo, status), reviewtransaction.GateAllow)
+}
+
+func TestStatusRecoverTransitionExecutesExactBaseDiffSelectors(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	base := strings.TrimSpace(runReviewCLIGit(t, repo, "rev-parse", "HEAD"))
+	writeReviewStartCandidate(t, repo, "candidate.go", "package candidate\n\nfunc value() int { return 1 }\n", 0o644)
+	runReviewCLIGit(t, repo, "add", "candidate.go")
+	runReviewCLIGit(t, repo, "commit", "-qm", "add candidate")
+	var output bytes.Buffer
+	if err := RunReviewFacadeStart([]string{"--cwd", repo, "--lineage", "selector-recover", "--base-ref", base, "--committed-only"}, &output); err != nil {
+		t.Fatal(err)
+	}
+	var started ReviewFacadeStartResult
+	decodeStrictReviewJSON(t, output.Bytes(), &started)
+	result := filepath.Join(t.TempDir(), "blocking.json")
+	writeReviewCLIJSON(t, result, facadeReviewerResult{Lens: started.SelectedLenses[0], Findings: []facadeFinding{{
+		Location: "candidate.go:3", Severity: "CRITICAL", Claim: "candidate requires a helper",
+		ProofRefs: []string{"candidate.go:3 changed hunk"}, EvidenceClass: reviewtransaction.EvidenceDeterministic, CausalDisposition: reviewtransaction.CausalIntroduced,
+	}}, Evidence: []string{"reviewed exact base diff"}})
+	if err := RunReviewFacadeFinalize([]string{"--cwd", repo, "--lineage", started.LineageID, "--result", result}, &bytes.Buffer{}); err != nil {
+		t.Fatal(err)
+	}
+	store, _ := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, started.LineageID)
+	predecessor, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeReviewStartCandidate(t, repo, "helper.go", "package candidate\n", 0o644)
+	runReviewCLIGit(t, repo, "add", "helper.go")
+	runReviewCLIGit(t, repo, "commit", "-qm", "expand candidate scope")
+	probe := selectorTransitionStatus(t, repo, "--lineage", started.LineageID, "--base-ref", base)
+	reason, actor := "approved scope expansion", "maintainer"
+	authorization := "gentle-ai.review-recovery-authorization/v1\npredecessor_lineage=" + started.LineageID + "\npredecessor_revision=" + probe.Authority.Revision + "\ntarget_identity=" + probe.TargetIdentity + "\nsuccessor_lineage=selector-recovered\nactor=" + actor + "\nreason=" + reason
+	status := selectorTransitionStatus(t, repo, "--lineage", started.LineageID, "--base-ref", "  "+base+"  ",
+		"--recovery-successor-lineage", "selector-recovered", "--recovery-reason", reason,
+		"--recovery-actor", actor, "--recovery-authorization", authorization)
+	arguments := selectorTransitionArguments(t, status)
+	if arguments["base-ref"] != base || arguments["committed-only"] != "true" || arguments["projection"] != "" {
+		t.Fatalf("RECOVER selectors = %#v", arguments)
+	}
+	assertSelectorTransitionMutationRejected(t, status, func(arguments []ReviewTransitionArgument) []ReviewTransitionArgument {
+		return setSelectorTransitionArgument(arguments, "committed-only", "false")
+	})
+	assertSelectorTransitionMutationRejected(t, status, func(arguments []ReviewTransitionArgument) []ReviewTransitionArgument {
+		return setSelectorTransitionArgument(arguments, "base-ref", "HEAD")
+	})
+	assertSelectorTransitionMutationRejected(t, status, func(arguments []ReviewTransitionArgument) []ReviewTransitionArgument {
+		return setSelectorTransitionArgument(arguments, "base-ref", " "+base)
+	})
+	assertSelectorTransitionMutationRejected(t, status, func(arguments []ReviewTransitionArgument) []ReviewTransitionArgument {
+		return append(arguments, ReviewTransitionArgument{Name: "base-ref", Value: base})
+	})
+	assertSelectorTransitionMutationRejected(t, status, func(arguments []ReviewTransitionArgument) []ReviewTransitionArgument {
+		return removeSelectorTransitionArgument(arguments, "committed-only")
+	})
+	assertSelectorTransitionMutationRejected(t, status, func(arguments []ReviewTransitionArgument) []ReviewTransitionArgument {
+		return setSelectorTransitionArgument(arguments, "predecessor-lineage", "wrong-lineage")
+	})
+	assertSelectorTransitionMutationRejected(t, status, func(arguments []ReviewTransitionArgument) []ReviewTransitionArgument {
+		return append(arguments, ReviewTransitionArgument{Name: "projection", Value: "staged"})
+	})
+	assertSelectorTransitionMutationRejected(t, status, func(arguments []ReviewTransitionArgument) []ReviewTransitionArgument {
+		return removeSelectorTransitionArgument(arguments, "reason")
+	})
+	before, _ := os.ReadFile(store.StatePath())
+	storesBefore, _ := reviewtransaction.DiscoverCompactStores(context.Background(), repo)
+	substituted := status
+	transition, execution := *status.NextTransition, *status.NextTransition.Execute
+	execution.Arguments = setSelectorTransitionArgument(append([]ReviewTransitionArgument(nil), execution.Arguments...), "successor-lineage", "selector-substituted")
+	transition.Execute, substituted.NextTransition = &execution, &transition
+	if _, err := runSelectorTransition(repo, substituted); err == nil {
+		t.Fatal("RECOVER accepted successor substitution")
+	}
+	storesAfter, _ := reviewtransaction.DiscoverCompactStores(context.Background(), repo)
+	afterRejected, _ := os.ReadFile(store.StatePath())
+	if len(storesAfter) != len(storesBefore) || !bytes.Equal(before, afterRejected) {
+		t.Fatal("rejected RECOVER mutated authority")
+	}
+	mixedAliasArgs := selectorTransitionCommandArguments(repo, status)
+	mixedAliasArgs = append(mixedAliasArgs, "-base-ref=HEAD")
+	if err := RunReview(mixedAliasArgs, &bytes.Buffer{}); err == nil || !strings.Contains(err.Error(), "repeats --base-ref") {
+		t.Fatalf("mixed selector aliases error = %v", err)
+	}
+	storesAfterMixedAlias, _ := reviewtransaction.DiscoverCompactStores(context.Background(), repo)
+	afterMixedAlias, _ := os.ReadFile(store.StatePath())
+	if len(storesAfterMixedAlias) != len(storesBefore) || !bytes.Equal(before, afterMixedAlias) {
+		t.Fatal("mixed-alias RECOVER mutated authority")
+	}
+	payload := executeSelectorTransition(t, repo, status)
+	var recovered ReviewRecoverResult
+	decodeStrictReviewJSON(t, payload, &recovered)
+	if recovered.LineageID != "selector-recovered" || recovered.TargetIdentity != status.TargetIdentity {
+		t.Fatalf("RECOVER = %#v, want target %q", recovered, status.TargetIdentity)
+	}
+	after, _ := os.ReadFile(store.StatePath())
+	if !bytes.Equal(before, after) || predecessor.Revision != probe.Authority.Revision {
+		t.Fatal("RECOVER changed predecessor authority")
+	}
+}
+
+func TestCurrentChangesRecoverSelectorPresenceSurvivesJSONRoundTrip(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	writeReviewStartCandidate(t, repo, "candidate.go", "package candidate\n\nfunc value() int { return 1 }\n", 0o644)
+	var output bytes.Buffer
+	if err := RunReviewFacadeStart([]string{"--cwd", repo, "--lineage", "selector-current"}, &output); err != nil {
+		t.Fatal(err)
+	}
+	var started ReviewFacadeStartResult
+	decodeStrictReviewJSON(t, output.Bytes(), &started)
+	result := filepath.Join(t.TempDir(), "blocking.json")
+	writeReviewCLIJSON(t, result, facadeReviewerResult{Lens: started.SelectedLenses[0], Findings: []facadeFinding{{
+		Location: "candidate.go:3", Severity: "CRITICAL", Claim: "candidate requires a helper",
+		ProofRefs: []string{"candidate.go:3 changed hunk"}, EvidenceClass: reviewtransaction.EvidenceDeterministic, CausalDisposition: reviewtransaction.CausalIntroduced,
+	}}, Evidence: []string{"reviewed exact current changes"}})
+	if err := RunReviewFacadeFinalize([]string{"--cwd", repo, "--lineage", started.LineageID, "--result", result}, &bytes.Buffer{}); err != nil {
+		t.Fatal(err)
+	}
+	store, _ := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, started.LineageID)
+	record, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeReviewStartCandidate(t, repo, "helper.go", "package candidate\n", 0o644)
+	probe := selectorTransitionStatus(t, repo, "--lineage", record.State.LineageID)
+	if probe.Authority == nil {
+		t.Fatalf("current-changes recovery probe lacks authority: %#v", probe)
+	}
+	if probe.Action != reviewtransaction.TargetStatusActionRecover {
+		t.Fatalf("current-changes recovery probe action = %q, target=%s authority=%s projection=%#v", probe.Action, probe.TargetIdentity, probe.AuthorityTargetIdentity, probe.Projection)
+	}
+	reason, actor, successor := "approved current scope", "maintainer", "selector-current-successor"
+	authorization := "gentle-ai.review-recovery-authorization/v1\npredecessor_lineage=" + record.State.LineageID +
+		"\npredecessor_revision=" + probe.Authority.Revision + "\ntarget_identity=" + probe.TargetIdentity +
+		"\nsuccessor_lineage=" + successor + "\nactor=" + actor + "\nreason=" + reason
+	status := selectorTransitionStatus(t, repo,
+		"--lineage", record.State.LineageID,
+		"--recovery-successor-lineage", successor,
+		"--recovery-reason", reason,
+		"--recovery-actor", actor,
+		"--recovery-authorization", authorization,
+	)
+	if status.NextTransition == nil || status.NextTransition.Execute == nil ||
+		status.NextTransition.Execute.Operation != "review.recover" {
+		t.Fatalf("current-changes recovery transition = %#v", status.NextTransition)
+	}
+	selectors := status.NextTransition.Execute.SelectorArguments
+	if selectors == nil || len(*selectors) != 0 {
+		t.Fatalf("current-changes selectors = %#v, want explicit empty selector contract", selectors)
+	}
+	payload, err := json.Marshal(status)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(payload, []byte(`"selector_arguments":[]`)) {
+		t.Fatalf("status JSON omitted explicit empty selectors: %s", payload)
+	}
+	var decoded ReviewTargetStatusResult
+	if err := json.Unmarshal(payload, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded.NextTransition == nil || decoded.NextTransition.Execute == nil ||
+		decoded.NextTransition.Execute.SelectorArguments == nil ||
+		len(*decoded.NextTransition.Execute.SelectorArguments) != 0 {
+		t.Fatalf("round-tripped selectors = %#v", decoded.NextTransition)
+	}
+	if err := decoded.Validate(); err != nil {
+		t.Fatalf("round-tripped status validation: %v", err)
+	}
+	before, _ := os.ReadFile(store.StatePath())
+	recoveredPayload := executeSelectorTransition(t, repo, decoded)
+	var recovered ReviewRecoverResult
+	decodeStrictReviewJSON(t, recoveredPayload, &recovered)
+	if recovered.LineageID != successor || recovered.TargetIdentity != decoded.TargetIdentity {
+		t.Fatalf("current-changes RECOVER = %#v", recovered)
+	}
+	after, _ := os.ReadFile(store.StatePath())
+	if !bytes.Equal(before, after) {
+		t.Fatal("current-changes RECOVER changed predecessor authority")
+	}
+}
+
+func TestStatusStopsUnrepresentableRecoveryWithoutMutation(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	base := strings.TrimSpace(runReviewCLIGit(t, repo, "rev-parse", "HEAD"))
+	writeReviewStartCandidate(t, repo, "candidate.go", "package candidate\n\nfunc value() int { return 1 }\n", 0o644)
+	var output bytes.Buffer
+	if err := RunReviewFacadeStart([]string{"--cwd", repo, "--lineage", "selector-unrepresentable"}, &output); err != nil {
+		t.Fatal(err)
+	}
+	var started ReviewFacadeStartResult
+	decodeStrictReviewJSON(t, output.Bytes(), &started)
+	result := filepath.Join(t.TempDir(), "blocking.json")
+	writeReviewCLIJSON(t, result, facadeReviewerResult{Lens: started.SelectedLenses[0], Findings: []facadeFinding{{
+		Location: "candidate.go:3", Severity: "CRITICAL", Claim: "candidate requires a helper",
+		ProofRefs: []string{"candidate.go:3 changed hunk"}, EvidenceClass: reviewtransaction.EvidenceDeterministic, CausalDisposition: reviewtransaction.CausalIntroduced,
+	}}, Evidence: []string{"reviewed exact current changes"}})
+	if err := RunReviewFacadeFinalize([]string{"--cwd", repo, "--lineage", started.LineageID, "--result", result}, &bytes.Buffer{}); err != nil {
+		t.Fatal(err)
+	}
+	store, _ := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, started.LineageID)
+	record, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeReviewStartCandidate(t, repo, "helper.go", "package candidate\n", 0o644)
+	runReviewCLIGit(t, repo, "add", "candidate.go", "helper.go")
+	runReviewCLIGit(t, repo, "commit", "-qm", "commit candidate")
+	before, _ := os.ReadFile(store.StatePath())
+	storesBefore, _ := reviewtransaction.DiscoverCompactStores(context.Background(), repo)
+	status := selectorTransitionStatus(t, repo, "--lineage", record.State.LineageID, "--base-ref", base)
+	if status.Action != reviewtransaction.TargetStatusActionRecover {
+		t.Fatalf("unrepresentable recovery status action = %q, target=%s authority=%s projection=%#v", status.Action, status.TargetIdentity, status.AuthorityTargetIdentity, status.Projection)
+	}
+	if status.NextTransition.Kind != reviewNextTransitionStop ||
+		status.NextTransition.ReasonCode != "recovery_target_unrepresentable" {
+		t.Fatalf("unrepresentable recovery transition = %#v", status.NextTransition)
+	}
+	after, _ := os.ReadFile(store.StatePath())
+	storesAfter, _ := reviewtransaction.DiscoverCompactStores(context.Background(), repo)
+	if !bytes.Equal(before, after) || len(storesAfter) != len(storesBefore) {
+		t.Fatal("unrepresentable recovery mutated authority")
+	}
+}
+
+func TestTransitionSelectorFlagsRejectMixedAliases(t *testing.T) {
+	tests := []struct {
+		name      string
+		operation string
+		args      []string
+	}{
+		{name: "validate base", operation: "review.validate", args: []string{"--base-ref=origin/release", "-base-ref", "origin/main"}},
+		{name: "recover base", operation: "review.recover", args: []string{"-base-ref=HEAD^", "--base-ref=HEAD"}},
+		{name: "recover committed", operation: "review.recover", args: []string{"--committed-only", "-committed-only=true"}},
+		{name: "recover projection", operation: "review.recover", args: []string{"-projection=workspace", "--projection", "staged"}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if err := validateReviewTransitionSelectorFlagCounts(test.args, test.operation); err == nil {
+				t.Fatal("mixed selector aliases accepted")
+			}
+		})
+	}
+}
+
+func TestStatusStopsUnchangedBaseDiffRecoveryWithoutSuccessor(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	base := strings.TrimSpace(runReviewCLIGit(t, repo, "rev-parse", "HEAD"))
+	writeReviewStartCandidate(t, repo, "candidate.go", "package candidate\n", 0o644)
+	runReviewCLIGit(t, repo, "add", "candidate.go")
+	runReviewCLIGit(t, repo, "commit", "-qm", "add candidate")
+	var output bytes.Buffer
+	if err := RunReviewFacadeStart([]string{"--cwd", repo, "--lineage", "selector-unchanged", "--base-ref", base, "--committed-only"}, &output); err != nil {
+		t.Fatal(err)
+	}
+	store, _ := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, "selector-unchanged")
+	record, _ := store.Load()
+	if err := RunReviewInvalidate([]string{"--cwd", repo, "--lineage", record.State.LineageID, "--expected-revision", record.Revision, "--reason", "invalidate unchanged target"}, &bytes.Buffer{}); err != nil {
+		t.Fatal(err)
+	}
+	record, _ = store.Load()
+	before, _ := os.ReadFile(store.StatePath())
+	probe := selectorTransitionStatus(t, repo, "--lineage", record.State.LineageID, "--base-ref", base)
+	reason, actor := "unchanged recovery", "maintainer"
+	authorization := "gentle-ai.review-recovery-authorization/v1\npredecessor_lineage=" + record.State.LineageID + "\npredecessor_revision=" + record.Revision + "\ntarget_identity=" + probe.TargetIdentity + "\nactor=" + actor + "\nreason=" + reason
+	status := selectorTransitionStatus(t, repo, "--lineage", record.State.LineageID, "--base-ref", base,
+		"--recovery-successor-lineage", "selector-unchanged-successor", "--recovery-reason", reason,
+		"--recovery-actor", actor, "--recovery-authorization", authorization)
+	if status.NextTransition.Kind != reviewNextTransitionStop || status.NextTransition.ReasonCode != "recovery_scope_unchanged" {
+		t.Fatalf("unchanged recovery transition = %#v", status.NextTransition)
+	}
+	after, _ := os.ReadFile(store.StatePath())
+	stores, _ := reviewtransaction.DiscoverCompactStores(context.Background(), repo)
+	if !bytes.Equal(before, after) || len(stores) != 1 {
+		t.Fatalf("unchanged recovery mutated authority: stores=%d", len(stores))
+	}
+}
+
+func selectorTransitionStatus(t *testing.T, repo string, selectors ...string) ReviewTargetStatusResult {
+	t.Helper()
+	args := []string{"status", "--cwd", repo, "--contract", ReviewIntegrationContractV1, "--next-transition"}
+	args = append(args, selectors...)
+	var output bytes.Buffer
+	if err := RunReview(args, &output); err != nil {
+		t.Fatalf("STATUS: %v\n%s", err, output.String())
+	}
+	var status ReviewTargetStatusResult
+	decodeStrictReviewJSON(t, output.Bytes(), &status)
+	return status
+}
+
+func selectorTransitionArguments(t *testing.T, status ReviewTargetStatusResult) map[string]string {
+	t.Helper()
+	if status.NextTransition == nil || status.NextTransition.Execute == nil {
+		t.Fatalf("status lacks execute transition: %#v", status.NextTransition)
+	}
+	arguments, err := reviewTransitionArgumentMap(status.NextTransition.Execute.Arguments)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return arguments
+}
+
+func executeSelectorTransition(t *testing.T, repo string, status ReviewTargetStatusResult) []byte {
+	t.Helper()
+	payload, err := runSelectorTransition(repo, status)
+	if err != nil {
+		t.Fatalf("execute %s: %v\n%s", status.NextTransition.Execute.Operation, err, payload)
+	}
+	return payload
+}
+
+func runSelectorTransition(repo string, status ReviewTargetStatusResult) ([]byte, error) {
+	args := selectorTransitionCommandArguments(repo, status)
+	var output bytes.Buffer
+	if err := RunReview(args, &output); err != nil {
+		return output.Bytes(), err
+	}
+	return output.Bytes(), nil
+}
+
+func selectorTransitionCommandArguments(repo string, status ReviewTargetStatusResult) []string {
+	operation := strings.TrimPrefix(status.NextTransition.Execute.Operation, "review.")
+	args := []string{operation, "--cwd=" + repo}
+	for _, argument := range status.NextTransition.Execute.Arguments {
+		args = append(args, "--"+argument.Name+"="+argument.Value)
+	}
+	return args
+}
+
+func assertSelectorTransitionMutationRejected(t *testing.T, status ReviewTargetStatusResult, mutate func([]ReviewTransitionArgument) []ReviewTransitionArgument) {
+	t.Helper()
+	invalid := status
+	transition := *status.NextTransition
+	execution := *status.NextTransition.Execute
+	execution.Arguments = mutate(append([]ReviewTransitionArgument(nil), execution.Arguments...))
+	transition.Execute, invalid.NextTransition = &execution, &transition
+	if err := invalid.Validate(); err == nil {
+		t.Fatalf("status accepted invalid transition arguments: %#v", execution.Arguments)
+	}
+}
+
+func setSelectorTransitionArgument(arguments []ReviewTransitionArgument, name, value string) []ReviewTransitionArgument {
+	for index := range arguments {
+		if arguments[index].Name == name {
+			arguments[index].Value = value
+		}
+	}
+	return arguments
+}
+
+func removeSelectorTransitionArgument(arguments []ReviewTransitionArgument, name string) []ReviewTransitionArgument {
+	filtered := arguments[:0]
+	for _, argument := range arguments {
+		if argument.Name != name {
+			filtered = append(filtered, argument)
+		}
+	}
+	return filtered
+}

--- a/internal/cli/review_status_contract.go
+++ b/internal/cli/review_status_contract.go
@@ -470,6 +470,9 @@ func (result ReviewTargetStatusResult) validateNextTransitionTargets() error {
 	if result.NextTransition.Execute != nil && result.NextTransition.Execute.Binding.TargetIdentity != expectedExecutionTarget {
 		return errors.New("negotiated status execution target differs from the current target identity")
 	}
+	if err := result.validateSelectorNextTransition(); err != nil {
+		return err
+	}
 	if result.Repair.Status == reviewtransaction.AuthorityRepairEligible {
 		if err := result.validateRepairNextTransition(); err != nil {
 			return err
@@ -500,6 +503,61 @@ func (result ReviewTargetStatusResult) validateNextTransitionTargets() error {
 			!reflect.DeepEqual(manifestPathsForStatus(*input.ChangedPathManifest), result.Projection.Paths) {
 			return errors.New("negotiated status capture target differs from the frozen target identity")
 		}
+	}
+	return nil
+}
+
+func (result ReviewTargetStatusResult) validateSelectorNextTransition() error {
+	execution := result.NextTransition.Execute
+	if execution == nil || (execution.Operation != "review.validate" && execution.Operation != "review.recover") {
+		return nil
+	}
+	arguments, err := reviewTransitionArgumentMap(execution.Arguments)
+	if err != nil {
+		return err
+	}
+	selectorsPresent := execution.SelectorArguments != nil
+	selectors := []ReviewTransitionArgument{}
+	if selectorsPresent {
+		selectors = *execution.SelectorArguments
+	}
+	for _, selector := range selectors {
+		if arguments[selector.Name] != selector.Value {
+			return errors.New("negotiated transition changed its normalized selector")
+		}
+	}
+	base, hasBase := arguments["base-ref"]
+	_, hasCommitted := arguments["committed-only"]
+	projection, hasProjection := arguments["projection"]
+	if !selectorsPresent && (hasBase || hasCommitted || hasProjection) {
+		return errors.New("negotiated transition omitted its normalized selector")
+	}
+	if execution.Operation == "review.validate" {
+		if result.Projection.Kind == reviewtransaction.TargetCurrentChanges && hasBase ||
+			reviewtransaction.GateKind(arguments["gate"]) == reviewtransaction.GatePrePR && result.Projection.Kind == reviewtransaction.TargetBaseDiff && !hasBase {
+			return errors.New("negotiated VALIDATE transition does not reproduce the selected target")
+		}
+		return nil
+	}
+	switch result.Projection.Kind {
+	case reviewtransaction.TargetCurrentChanges:
+		if hasBase || hasCommitted {
+			return errors.New("current-changes RECOVER transition invented target selectors")
+		}
+	case reviewtransaction.TargetBaseDiff:
+		if !hasBase || !hasCommitted {
+			return errors.New("base-diff RECOVER transition lacks exact target selectors")
+		}
+	case reviewtransaction.TargetBaseWorkspaceOverlay:
+		if !hasBase || hasCommitted {
+			return errors.New("workspace-overlay RECOVER transition has incompatible target selectors")
+		}
+	default:
+		return errors.New("RECOVER transition target kind is unsupported")
+	}
+	if result.Projection.Kind != reviewtransaction.TargetCurrentChanges && base == "" ||
+		hasProjection && projection != string(result.Projection.Projection) {
+		return errors.New("RECOVER transition selectors do not match the selected target")
 	}
 	return nil
 }
@@ -727,6 +785,13 @@ func (transition ReviewNextTransition) Validate() error {
 				return errors.New("execution transition has an incomplete precondition")
 			}
 		}
+		arguments, err := reviewTransitionArgumentMap(transition.Execute.Arguments)
+		if err != nil {
+			return err
+		}
+		if err := validateReviewTransitionExecution(*transition.Execute, arguments); err != nil {
+			return err
+		}
 	default:
 		return errors.New("unsupported review next transition kind")
 	}
@@ -742,6 +807,87 @@ func reviewTransitionArgumentMap(arguments []ReviewTransitionArgument) (map[stri
 		values[argument.Name] = argument.Value
 	}
 	return values, nil
+}
+
+func validateReviewTransitionExecution(execution ReviewTransitionExecution, arguments map[string]string) error {
+	exact := func(required []string, selectors []ReviewTransitionArgument) bool {
+		if len(arguments) != len(required)+len(selectors) {
+			return false
+		}
+		for _, name := range required {
+			if _, present := arguments[name]; !present {
+				return false
+			}
+		}
+		for _, selector := range selectors {
+			if selector.Name != "base-ref" && selector.Name != "committed-only" && selector.Name != "projection" ||
+				arguments[selector.Name] != selector.Value {
+				return false
+			}
+		}
+		return true
+	}
+	switch execution.Operation {
+	case "review.validate":
+		gate := reviewtransaction.GateKind(arguments["gate"])
+		wantSelectors := []ReviewTransitionArgument{}
+		if base, present := arguments["base-ref"]; present {
+			wantSelectors = append(wantSelectors, ReviewTransitionArgument{Name: "base-ref", Value: base})
+		}
+		if execution.SelectorArguments != nil && !reflect.DeepEqual(*execution.SelectorArguments, wantSelectors) {
+			return errors.New("review validate transition selectors are invalid")
+		}
+		if !exact([]string{"lineage", "gate"}, wantSelectors) ||
+			arguments["lineage"] != execution.Binding.LineageID || !validReviewIntegrationGate(gate) ||
+			arguments["base-ref"] != "" && (gate != reviewtransaction.GatePrePR || !validReviewTransitionSelector(arguments["base-ref"])) {
+			return errors.New("review validate transition selectors are invalid")
+		}
+	case "review.recover":
+		wantSelectors := []ReviewTransitionArgument{}
+		for _, name := range []string{"base-ref", "committed-only", "projection"} {
+			if value, present := arguments[name]; present {
+				wantSelectors = append(wantSelectors, ReviewTransitionArgument{Name: name, Value: value})
+			}
+		}
+		if execution.SelectorArguments != nil && !reflect.DeepEqual(*execution.SelectorArguments, wantSelectors) {
+			return errors.New("review recover transition selectors are invalid")
+		}
+		if !exact([]string{"predecessor-lineage", "expected-predecessor-revision", "successor-lineage", "disposition", "reason", "actor", "maintainer-authorization"}, wantSelectors) ||
+			arguments["predecessor-lineage"] != execution.Binding.LineageID ||
+			arguments["expected-predecessor-revision"] != execution.Binding.Revision ||
+			!validReviewIntegrationLineage(arguments["successor-lineage"]) ||
+			arguments["successor-lineage"] == execution.Binding.LineageID {
+			return errors.New("review recover transition binding is invalid")
+		}
+		disposition := reviewtransaction.RecoveryDisposition(arguments["disposition"])
+		if disposition != reviewtransaction.RecoveryScopeChanged &&
+			disposition != reviewtransaction.RecoveryInvalidated &&
+			disposition != reviewtransaction.RecoveryEscalated {
+			return errors.New("review recover transition disposition is invalid")
+		}
+		authorizationSuccessor := ""
+		if execution.SelectorArguments != nil {
+			authorizationSuccessor = arguments["successor-lineage"]
+		}
+		wantAuthorization := reviewTransitionRecoveryAuthorization(execution.Binding, authorizationSuccessor, arguments["actor"], arguments["reason"])
+		base, hasBase := arguments["base-ref"]
+		committed, hasCommitted := arguments["committed-only"]
+		projection, hasProjection := arguments["projection"]
+		if arguments["maintainer-authorization"] != wantAuthorization ||
+			hasBase && !validReviewTransitionSelector(base) ||
+			hasCommitted && (!hasBase || committed != "true") ||
+			hasProjection && projection != string(reviewtransaction.ProjectionWorkspace) &&
+				projection != string(reviewtransaction.ProjectionStaged) {
+			return errors.New("review recover transition selectors are invalid")
+		}
+	}
+	return nil
+}
+
+func validReviewTransitionSelector(value string) bool {
+	fields := strings.Fields(value)
+	return len(fields) == 1 && fields[0] == value && !path.IsAbs(value) &&
+		!strings.HasPrefix(value, "-") && !strings.ContainsRune(value, 0)
 }
 
 func (eligibility ReviewActionEligibility) Validate(status ReviewTargetStatusResult) error {

--- a/internal/reviewtransaction/gate.go
+++ b/internal/reviewtransaction/gate.go
@@ -426,6 +426,11 @@ func selectPrePRBoundary(ctx context.Context, repo, selector string) (PrePRBound
 	return selection, nil
 }
 
+func ValidatePrePRBoundarySelector(ctx context.Context, repo, selector string) error {
+	_, err := selectPrePRBoundary(ctx, repo, selector)
+	return err
+}
+
 func buildPrePRTarget(ctx context.Context, repo, selector, ciAttestation string, intendedUntracked []string) (Target, *PrePRRequest, error) {
 	selection, err := selectPrePRBoundary(ctx, repo, selector)
 	if err != nil {


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1692

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)

## 📝 Summary

Make native VALIDATE and RECOVER transitions self-contained: STATUS now serializes the exact normalized selector contract it assessed, validates exact operation-specific arguments, binds recovery successors, and stops when a selector cannot be represented faithfully.

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/cli/review_status_contract.go` | Serialized typed selector arguments with explicit absent-versus-empty presence and exact validation |
| `internal/cli/review_next_transition.go` | Preserved exact validation/recovery selectors and stopped on unrepresentable pre-PR boundaries |
| `internal/cli/review_facade.go` | Rejected missing, partial, duplicate, malformed, and mixed-alias selector flags before execution |
| `internal/reviewtransaction/gate.go` | Bound successor lineage into native recovery authorization with legacy durable compatibility |
| Contract schema and tests | Covered replacement values, exact sets, replay, raw SHA, empty-selector JSON roundtrip, and mutation-free rejection |

## 🧪 Test Plan

```bash
go test ./...
go test -race ./internal/cli ./internal/reviewtransaction
go vet ./...
go run ./internal/gofmtcheck
./scripts/test-review-contract-package.sh
./scripts/test-review-capabilities.sh
```

- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — delegated to required CI
- [x] Manually replayed emitted custom-base and recovery transitions unchanged

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] Maintainer `size:exception` is requested and applied with rationale below
- [x] I have added exactly one `type:*` label
- [x] Unit tests pass (`go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — delegated to required CI
- [x] Contract schema is updated
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers

## Size Exception Rationale

The candidate contains 783 authored changed lines, including a 437-line regression suite. Selector serialization, exact argument validation, successor authorization, and unchanged replay form one inseparable contract: splitting them would temporarily advertise transitions whose arguments do not reproduce the assessed target.

## Review Evidence

- Candidate: `54a987d34c40397210c9adfcf3d852f82db0eaa9`
- Tree: `1796b6fb72900feab77cf55ccbd4d403a47f9c0e`
- A prior unpushed candidate was discarded after validation exposed an empty-selector roundtrip flaw; this fresh current-main target includes that regression from RED and passed independent risk, resilience, reliability, and readability review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added selector arguments to review transition data.
  * Added support for base-reference, pre-PR, projection, and recovery selectors in validation and recovery workflows.
  * Improved transition authorization and selector handling.

* **Bug Fixes**
  * Prevented invalid, ambiguous, or unrepresentable selector transitions from applying changes.
  * Added validation for selector arguments, aliases, bindings, and transition targets.

* **Tests**
  * Added coverage for selector preservation, recovery behavior, JSON round-tripping, invalid combinations, and no-op safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->