### PR TITLE
fix(review): preserve exact transition selectors

### DIFF
--- a/internal/cli/review_exact_transition_selector_test.go
+++ b/internal/cli/review_exact_transition_selector_test.go
@@ -1,0 +1,74 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/internal/reviewtransaction"
+)
+
+func TestNegotiatedValidateTransitionPreservesExactBaseRef(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	branch := strings.TrimSpace(runReviewCLIGit(t, repo, "symbolic-ref", "--short", "HEAD"))
+	runReviewCLIGit(t, repo, "branch", "release")
+	configureCLIReviewPublicationRemote(t, repo, branch)
+	runReviewCLIGit(t, repo, "push", "origin", "release")
+	runReviewCLIGit(t, repo, "fetch", "origin", "release:refs/remotes/origin/release")
+	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("candidate\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runReviewCLIGit(t, repo, "add", "tracked.txt")
+	runReviewCLIGit(t, repo, "commit", "-qm", "candidate")
+
+	var startedOutput bytes.Buffer
+	if err := RunReviewFacadeStart([]string{"--cwd", repo, "--base-ref", "origin/release", "--committed-only"}, &startedOutput); err != nil {
+		t.Fatal(err)
+	}
+	var started ReviewFacadeStartResult
+	if err := json.Unmarshal(startedOutput.Bytes(), &started); err != nil {
+		t.Fatal(err)
+	}
+	resultPath := filepath.Join(t.TempDir(), "review.json")
+	evidencePath := filepath.Join(t.TempDir(), "evidence.txt")
+	writeReviewCLIJSON(t, resultPath, facadeReviewerResult{Findings: []facadeFinding{}, Evidence: []string{"candidate reviewed"}})
+	if err := os.WriteFile(evidencePath, []byte("verification passed\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := RunReviewFacadeFinalize([]string{"--cwd", repo, "--lineage", started.LineageID, "--result", resultPath}, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	if err := RunReviewFacadeFinalize([]string{"--cwd", repo, "--lineage", started.LineageID, "--evidence", evidencePath}, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+
+	var statusOutput bytes.Buffer
+	if err := RunReview([]string{"status", "--contract", ReviewIntegrationContractV1, "--next-transition", "--gate", string(reviewtransaction.GatePrePR), "--base-ref", "origin/release", "--cwd", repo, "--lineage", started.LineageID}, &statusOutput); err != nil {
+		t.Fatal(err)
+	}
+	var status ReviewTargetStatusResult
+	decodeStrictReviewJSON(t, statusOutput.Bytes(), &status)
+	if status.NextTransition == nil || status.NextTransition.Execute == nil || status.NextTransition.Execute.Operation != "review.validate" {
+		t.Fatalf("approved status transition = %#v", status.NextTransition)
+	}
+
+	arguments := status.NextTransition.Execute.Arguments
+	validateArgs := []string{"validate", "--cwd", repo}
+	foundBaseRef := false
+	for _, argument := range arguments {
+		if argument.Name == "base-ref" && argument.Value == "origin/release" {
+			foundBaseRef = true
+		}
+		validateArgs = append(validateArgs, "--"+argument.Name, argument.Value)
+	}
+	if !foundBaseRef {
+		t.Fatalf("validate transition arguments = %#v, want base-ref=origin/release", arguments)
+	}
+	if err := RunReview(validateArgs, io.Discard); err != nil {
+		t.Fatalf("execute emitted validate transition: %v", err)
+	}
+}

--- a/internal/cli/review_exact_transition_selector_test.go
+++ b/internal/cli/review_exact_transition_selector_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"os"
@@ -70,5 +71,197 @@ func TestNegotiatedValidateTransitionPreservesExactBaseRef(t *testing.T) {
 	}
 	if err := RunReview(validateArgs, io.Discard); err != nil {
 		t.Fatalf("execute emitted validate transition: %v", err)
+	}
+}
+
+func TestNegotiatedRecoverTransitionPreservesExactBaseDiffSelectors(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	runReviewCLIGit(t, repo, "branch", "review-base")
+	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("candidate\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runReviewCLIGit(t, repo, "add", "tracked.txt")
+	runReviewCLIGit(t, repo, "commit", "-qm", "candidate")
+
+	var startedOutput bytes.Buffer
+	if err := RunReviewFacadeStart([]string{"--cwd", repo, "--base-ref", "review-base", "--committed-only"}, &startedOutput); err != nil {
+		t.Fatal(err)
+	}
+	var started ReviewFacadeStartResult
+	if err := json.Unmarshal(startedOutput.Bytes(), &started); err != nil {
+		t.Fatal(err)
+	}
+	predecessorStore, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, started.LineageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	predecessor, err := predecessorStore.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := RunReviewInvalidate([]string{"--cwd", repo, "--lineage", started.LineageID, "--expected-revision", predecessor.Revision, "--reason", "candidate invalidated"}, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	predecessor, err = predecessorStore.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	status := func(args ...string) ReviewTargetStatusResult {
+		t.Helper()
+		var output bytes.Buffer
+		if err := RunReview(append([]string{"status", "--contract", ReviewIntegrationContractV1, "--base-ref", "review-base", "--cwd", repo, "--lineage", started.LineageID}, args...), &output); err != nil {
+			t.Fatal(err)
+		}
+		var result ReviewTargetStatusResult
+		decodeStrictReviewJSON(t, output.Bytes(), &result)
+		return result
+	}
+	authorization := func(targetIdentity, successor string) []string {
+		return []string{
+			"--next-transition", "--recovery-successor-lineage", successor,
+			"--recovery-actor", "maintainer", "--recovery-reason", "changed base-diff scope",
+			"--recovery-authorization", reviewRecoveryAuthorization(started.LineageID, predecessor.Revision, targetIdentity, "maintainer", "changed base-diff scope"),
+		}
+	}
+
+	probe := status()
+	unchanged := status(authorization(probe.TargetIdentity, "review-unchanged")...)
+	if unchanged.NextTransition == nil || unchanged.NextTransition.Kind != reviewNextTransitionStop || unchanged.NextTransition.Execute != nil || unchanged.NextTransition.Collect != nil {
+		t.Fatalf("unchanged recovery transition = %#v", unchanged.NextTransition)
+	}
+	unchangedStore, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, "review-unchanged")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(unchangedStore.Dir); !os.IsNotExist(err) {
+		t.Fatalf("unchanged successor store exists or cannot be inspected: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("changed candidate\nline two\nline three\nline four\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runReviewCLIGit(t, repo, "add", "tracked.txt")
+	runReviewCLIGit(t, repo, "commit", "-qm", "changed candidate")
+
+	var recoveryStartedOutput bytes.Buffer
+	if err := RunReviewFacadeStart([]string{"--cwd", repo, "--base-ref", "review-base", "--committed-only"}, &recoveryStartedOutput); err != nil {
+		t.Fatal(err)
+	}
+	var recoveryPredecessor ReviewFacadeStartResult
+	if err := json.Unmarshal(recoveryStartedOutput.Bytes(), &recoveryPredecessor); err != nil {
+		t.Fatal(err)
+	}
+	resultPath := filepath.Join(t.TempDir(), "blocking-result.json")
+	writeReviewCLIJSON(t, resultPath, facadeReviewerResult{Lens: recoveryPredecessor.SelectedLenses[0], Findings: []facadeFinding{{Location: "tracked.txt:1", Severity: "CRITICAL", Claim: "candidate regression", ProofRefs: []string{"tracked.txt:1 changed hunk"}, EvidenceClass: reviewtransaction.EvidenceDeterministic, CausalDisposition: reviewtransaction.CausalIntroduced}}, Evidence: []string{"candidate reviewed"}})
+	if err := RunReviewFacadeFinalize([]string{"--cwd", repo, "--lineage", recoveryPredecessor.LineageID, "--result", resultPath, "--correction-lines", "1"}, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	recoveryStore, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, recoveryPredecessor.LineageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	recoveryRecord, err := recoveryStore.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if recoveryRecord.State.State != reviewtransaction.StateCorrectionRequired {
+		t.Fatalf("recovery predecessor state = %q", recoveryRecord.State.State)
+	}
+
+	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("corrected candidate\nline two\nline three\nline four\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	validationPath := filepath.Join(t.TempDir(), "validation.json")
+	writeReviewCLIJSON(t, validationPath, facadeValidationResult{
+		OriginalCriteria:     facadeValidationCheck{Evidence: []string{"acceptance still fails"}},
+		CorrectionRegression: facadeValidationCheck{Evidence: []string{"regression still fails"}},
+		FollowUps:            []reviewtransaction.FollowUp{},
+	})
+	if err := RunReviewFacadeFinalize([]string{"--cwd", repo, "--lineage", recoveryPredecessor.LineageID, "--validation", validationPath}, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	recoveryRecord, err = recoveryStore.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	forecast := 1
+	recoveryRecord.State.State, recoveryRecord.State.ProposedCorrectionLines, recoveryRecord.State.ActualCorrectionLines = reviewtransaction.StateCorrectionRequired, &forecast, nil
+	recoveryRecord.State.FixDeltaHash, recoveryRecord.State.OriginalCriteria, recoveryRecord.State.CorrectionRegression = reviewtransaction.EmptyFixDeltaHash, nil, nil
+	if err := recoveryRecord.State.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	recoveryRecord.Revision, err = reviewtransaction.CompactRevisionForState(recoveryRecord.State)
+	if err != nil {
+		t.Fatal(err)
+	}
+	recoveryRecord.Schema = "gentle-ai.review-state-record/v2"
+	payload, err := json.MarshalIndent(recoveryRecord, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(recoveryStore.StatePath(), append(payload, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(recoveryStore.ReceiptPath()); err != nil && !os.IsNotExist(err) {
+		t.Fatal(err)
+	}
+	if err := os.Remove(filepath.Join(recoveryStore.Dir, "finalize-attempt-journal.json")); err != nil && !os.IsNotExist(err) {
+		t.Fatal(err)
+	}
+	runReviewCLIGit(t, repo, "add", "tracked.txt")
+	runReviewCLIGit(t, repo, "commit", "-qm", "corrected candidate")
+
+	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("recovered candidate\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runReviewCLIGit(t, repo, "add", "tracked.txt")
+	runReviewCLIGit(t, repo, "commit", "-qm", "recovered candidate")
+	committedTree := strings.TrimSpace(runReviewCLIGit(t, repo, "rev-parse", "HEAD^{tree}"))
+	var probeOutput bytes.Buffer
+	if err := RunReview([]string{"status", "--contract", ReviewIntegrationContractV1, "--base-ref", "review-base", "--cwd", repo, "--lineage", recoveryPredecessor.LineageID}, &probeOutput); err != nil {
+		t.Fatal(err)
+	}
+	decodeStrictReviewJSON(t, probeOutput.Bytes(), &probe)
+	var changedOutput bytes.Buffer
+	if err := RunReview([]string{
+		"status", "--contract", ReviewIntegrationContractV1, "--next-transition", "--base-ref", "review-base", "--cwd", repo, "--lineage", recoveryPredecessor.LineageID,
+		"--recovery-successor-lineage", "review-changed", "--recovery-actor", "maintainer", "--recovery-reason", "changed base-diff scope",
+		"--recovery-authorization", reviewRecoveryAuthorization(recoveryPredecessor.LineageID, recoveryRecord.Revision, probe.TargetIdentity, "maintainer", "changed base-diff scope"),
+	}, &changedOutput); err != nil {
+		t.Fatal(err)
+	}
+	var changed ReviewTargetStatusResult
+	decodeStrictReviewJSON(t, changedOutput.Bytes(), &changed)
+	if changed.NextTransition == nil || changed.NextTransition.Execute == nil || changed.NextTransition.Execute.Operation != "review.recover" {
+		t.Fatalf("changed recovery transition = %#v", changed.NextTransition)
+	}
+
+	recoverArgs := []string{"recover", "--cwd", repo}
+	found := map[string]string{}
+	for _, argument := range changed.NextTransition.Execute.Arguments {
+		found[argument.Name] = argument.Value
+		if argument.Name == "committed-only" {
+			recoverArgs = append(recoverArgs, "--"+argument.Name+"="+argument.Value)
+			continue
+		}
+		recoverArgs = append(recoverArgs, "--"+argument.Name, argument.Value)
+	}
+	if found["base-ref"] != "review-base" || found["committed-only"] != "true" || found["projection"] != string(reviewtransaction.ProjectionWorkspace) {
+		t.Fatalf("recover transition arguments = %#v", changed.NextTransition.Execute.Arguments)
+	}
+	if err := RunReview(recoverArgs, io.Discard); err != nil {
+		t.Fatalf("execute emitted recover transition: %v", err)
+	}
+	successorStore, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, "review-changed")
+	if err != nil {
+		t.Fatal(err)
+	}
+	successor, err := successorStore.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if successor.State.InitialSnapshot.Kind != reviewtransaction.TargetBaseDiff || successor.State.InitialSnapshot.CandidateTree != committedTree {
+		t.Fatalf("recovered committed base-diff target = %#v, want candidate tree %s", successor.State.InitialSnapshot, committedTree)
 	}
 }

--- a/internal/cli/review_exact_transition_selector_test.go
+++ b/internal/cli/review_exact_transition_selector_test.go
@@ -241,11 +241,7 @@ func TestNegotiatedRecoverTransitionPreservesExactBaseDiffSelectors(t *testing.T
 	found := map[string]string{}
 	for _, argument := range changed.NextTransition.Execute.Arguments {
 		found[argument.Name] = argument.Value
-		if argument.Name == "committed-only" {
-			recoverArgs = append(recoverArgs, "--"+argument.Name+"="+argument.Value)
-			continue
-		}
-		recoverArgs = append(recoverArgs, "--"+argument.Name, argument.Value)
+		recoverArgs = append(recoverArgs, "--"+argument.Name+"="+argument.Value)
 	}
 	if found["base-ref"] != "review-base" || found["committed-only"] != "true" || found["projection"] != string(reviewtransaction.ProjectionWorkspace) {
 		t.Fatalf("recover transition arguments = %#v", changed.NextTransition.Execute.Arguments)

--- a/internal/cli/review_exact_transition_selector_test.go
+++ b/internal/cli/review_exact_transition_selector_test.go
@@ -265,3 +265,31 @@ func TestNegotiatedRecoverTransitionPreservesExactBaseDiffSelectors(t *testing.T
 		t.Fatalf("recovered committed base-diff target = %#v, want candidate tree %s", successor.State.InitialSnapshot, committedTree)
 	}
 }
+
+func TestTransitionConsumersRejectDuplicateSelectors(t *testing.T) {
+	recoveryBindings := []string{
+		"--predecessor-lineage=review-duplicate-predecessor",
+		"--expected-predecessor-revision=sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		"--successor-lineage=review-duplicate-successor", "--disposition=invalidated",
+		"--reason=duplicate selector probe", "--actor=maintainer",
+	}
+	tests := []struct {
+		name string
+		run  func([]string, io.Writer) error
+		args []string
+		want string
+	}{
+		{"validate base-ref", RunReviewFacadeValidate, []string{"--cwd=/missing", "--gate=pre-pr", "--base-ref=HEAD", "-base-ref=HEAD^"}, "review.validate repeats --base-ref"},
+		{"recover base-ref", RunReviewRecover, append(recoveryBindings, "--cwd=/missing", "--base-ref=HEAD", "-base-ref=HEAD^", "--committed-only"), "review.recover repeats --base-ref"},
+		{"recover committed-only", RunReviewRecover, append(recoveryBindings, "--cwd=/missing", "--base-ref=HEAD", "--committed-only=true", "-committed-only=false"), "review.recover repeats --committed-only"},
+		{"recover projection", RunReviewRecover, append(recoveryBindings, "--cwd=/missing", "--projection=workspace", "-projection=staged"), "review.recover repeats --projection"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.run(tt.args, io.Discard)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}

--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -523,7 +523,7 @@ func runReviewStatus(ctx context.Context, args []string, stdout io.Writer) error
 					}
 				}
 			}
-			transition := newReviewNextTransition(result, native.SelectedLenses, artifacts, evidenceAvailable, artifactErr, reviewNextTransitionInput{Gate: reviewtransaction.GateKind(*gate), Successor: *recoverySuccessor, Reason: *recoveryReason, Actor: *recoveryActor, Authorization: *recoveryAuthorization, RepairActor: *repairActor, RepairReason: *repairReason, RepairAuthorization: *repairAuthorization, StartLineage: strings.TrimSpace(*lineage), RepositoryContext: repositoryContext, ValidationRequest: validationRequest, CorrectionForecasted: correctionForecasted, CaptureContext: captureContext})
+			transition := newReviewNextTransition(result, native.SelectedLenses, artifacts, evidenceAvailable, artifactErr, reviewNextTransitionInput{Gate: reviewtransaction.GateKind(*gate), Successor: *recoverySuccessor, Reason: *recoveryReason, Actor: *recoveryActor, Authorization: *recoveryAuthorization, RepairActor: *repairActor, RepairReason: *repairReason, RepairAuthorization: *repairAuthorization, StartLineage: strings.TrimSpace(*lineage), RepositoryContext: repositoryContext, Target: reviewTransitionTarget{Kind: target.Kind, Projection: selectedProjection, BaseRef: selectedBaseRef}, ValidationRequest: validationRequest, CorrectionForecasted: correctionForecasted, CaptureContext: captureContext})
 			result.NextTransition = &transition
 		}
 		if err := result.Validate(); err != nil {

--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -573,6 +573,9 @@ func RunReviewRecover(args []string, stdout io.Writer) error {
 	if flags.NArg() != 0 {
 		return fmt.Errorf("unexpected review recover argument %q", flags.Arg(0))
 	}
+	if err := rejectRepeatedReviewSelectors(args, "review.recover", "base-ref", "committed-only", "projection"); err != nil {
+		return err
+	}
 	if strings.TrimSpace(*predecessor) == "" || strings.TrimSpace(*expected) == "" || strings.TrimSpace(*successor) == "" || strings.TrimSpace(*reason) == "" || strings.TrimSpace(*actor) == "" || strings.TrimSpace(*disposition) == "" {
 		return errors.New("review recover requires --predecessor-lineage, --expected-predecessor-revision, --successor-lineage, --disposition, --reason, and --actor")
 	}
@@ -1037,7 +1040,7 @@ func runReviewFacadeStart(ctx context.Context, args []string, stdout io.Writer) 
 }
 
 func validateReviewStartBinding(args []string, negotiated bool, target, projection, baseRef, lineage string, committedOnly, workspaceOverlay bool) error {
-	counts := reviewStartBindingFlagCounts(args)
+	counts := reviewBindingFlagCounts(args, "review.start")
 	if !negotiated {
 		if counts["target"] != 0 {
 			return errors.New("review start --target requires --contract")
@@ -1079,9 +1082,9 @@ func validateReviewStartBinding(args []string, negotiated bool, target, projecti
 	return nil
 }
 
-func reviewStartBindingFlagCounts(args []string) map[string]int {
+func reviewBindingFlagCounts(args []string, operation string) map[string]int {
 	counts := make(map[string]int)
-	shape := reviewIntegrationOperationFlagShape("review.start")
+	shape := reviewIntegrationOperationFlagShape(operation)
 	for index := 0; index < len(args); index++ {
 		argument := args[index]
 		if argument == "--" || argument == "" || argument == "-" || argument[0] != '-' {
@@ -1094,7 +1097,14 @@ func reviewStartBindingFlagCounts(args []string) map[string]int {
 		}
 		kind, known := shape[name]
 		if !known {
-			continue
+			switch name {
+			case "projection", "base-ref":
+				kind, known = reviewIntegrationValueFlag, true
+			case "committed-only":
+				kind, known = reviewIntegrationBoolFlag, true
+			default:
+				continue
+			}
 		}
 		switch name {
 		case "contract", "target", "projection", "lineage", "base-ref", "committed-only", "workspace-overlay":
@@ -1105,6 +1115,16 @@ func reviewStartBindingFlagCounts(args []string) map[string]int {
 		}
 	}
 	return counts
+}
+
+func rejectRepeatedReviewSelectors(args []string, operation string, selectors ...string) error {
+	counts := reviewBindingFlagCounts(args, operation)
+	for _, selector := range selectors {
+		if counts[selector] > 1 {
+			return fmt.Errorf("%s repeats --%s", operation, selector)
+		}
+	}
+	return nil
 }
 
 func reviewFacadeStartResultFor(action reviewtransaction.CompactStartAction, lensesRequired bool, authority reviewtransaction.CompactState) ReviewFacadeStartResult {
@@ -1701,6 +1721,9 @@ func runReviewFacadeValidate(ctx context.Context, args []string, stdout io.Write
 	}
 	if flags.NArg() != 0 {
 		return reviewPreflightError(fmt.Errorf("unexpected review validate argument %q", flags.Arg(0)))
+	}
+	if err := rejectRepeatedReviewSelectors(args, "review.validate", "base-ref"); err != nil {
+		return err
 	}
 	negotiated, err := reviewIntegrationNegotiation(flags, *contract)
 	if err != nil {

--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -479,6 +479,7 @@ func runReviewStatus(ctx context.Context, args []string, stdout io.Writer) error
 			artifacts := []ReviewTransitionArtifact{}
 			evidenceAvailable := false
 			repositoryContext := ""
+			transitionTarget := reviewTransitionTarget{Kind: target.Kind, Projection: selectedProjection, BaseRef: selectedBaseRef}
 			var captureContext *reviewCaptureContext
 			var validationRequest *reviewtransaction.TargetedValidationRequest
 			correctionForecasted := false
@@ -492,6 +493,9 @@ func runReviewStatus(ctx context.Context, args []string, stdout io.Writer) error
 					if loadErr != nil {
 						artifactErr = loadErr
 					} else {
+						transitionTarget.RecoveryScopeChanged =
+							record.State.InitialSnapshot.Kind != reviewtransaction.TargetBaseDiff ||
+								liveSnapshot.Identity != record.State.InitialSnapshot.Identity
 						correctionForecasted = record.State.State == reviewtransaction.StateCorrectionRequired && record.State.ProposedCorrectionLines != nil
 						if correctionForecasted {
 							request, requestErr := reviewtransaction.BuildTargetedValidationRequestFromSnapshot(ctx, root, record.State, record.Revision, liveSnapshot)
@@ -523,7 +527,7 @@ func runReviewStatus(ctx context.Context, args []string, stdout io.Writer) error
 					}
 				}
 			}
-			transition := newReviewNextTransition(result, native.SelectedLenses, artifacts, evidenceAvailable, artifactErr, reviewNextTransitionInput{Gate: reviewtransaction.GateKind(*gate), Successor: *recoverySuccessor, Reason: *recoveryReason, Actor: *recoveryActor, Authorization: *recoveryAuthorization, RepairActor: *repairActor, RepairReason: *repairReason, RepairAuthorization: *repairAuthorization, StartLineage: strings.TrimSpace(*lineage), RepositoryContext: repositoryContext, Target: reviewTransitionTarget{Kind: target.Kind, Projection: selectedProjection, BaseRef: selectedBaseRef}, ValidationRequest: validationRequest, CorrectionForecasted: correctionForecasted, CaptureContext: captureContext})
+			transition := newReviewNextTransition(result, native.SelectedLenses, artifacts, evidenceAvailable, artifactErr, reviewNextTransitionInput{Gate: reviewtransaction.GateKind(*gate), Successor: *recoverySuccessor, Reason: *recoveryReason, Actor: *recoveryActor, Authorization: *recoveryAuthorization, RepairActor: *repairActor, RepairReason: *repairReason, RepairAuthorization: *repairAuthorization, StartLineage: strings.TrimSpace(*lineage), RepositoryContext: repositoryContext, Target: transitionTarget, ValidationRequest: validationRequest, CorrectionForecasted: correctionForecasted, CaptureContext: captureContext})
 			result.NextTransition = &transition
 		}
 		if err := result.Validate(); err != nil {

--- a/internal/cli/review_next_transition.go
+++ b/internal/cli/review_next_transition.go
@@ -282,17 +282,21 @@ func (target reviewTransitionTarget) validateArguments() []ReviewTransitionArgum
 }
 
 func (target reviewTransitionTarget) recoveryArguments() ([]ReviewTransitionArgument, bool) {
-	if target.Kind != reviewtransaction.TargetBaseDiff {
+	switch target.Kind {
+	case reviewtransaction.TargetCurrentChanges:
 		return nil, true
-	}
-	if strings.TrimSpace(target.BaseRef) == "" || !target.RecoveryScopeChanged {
+	case reviewtransaction.TargetBaseDiff:
+		if strings.TrimSpace(target.BaseRef) == "" || !target.RecoveryScopeChanged {
+			return nil, false
+		}
+		return []ReviewTransitionArgument{
+			{Name: "base-ref", Value: target.BaseRef},
+			{Name: "committed-only", Value: "true"},
+			{Name: "projection", Value: string(target.Projection)},
+		}, true
+	default:
 		return nil, false
 	}
-	return []ReviewTransitionArgument{
-		{Name: "base-ref", Value: target.BaseRef},
-		{Name: "committed-only", Value: "true"},
-		{Name: "projection", Value: string(target.Projection)},
-	}, true
 }
 
 func reviewStartArguments(status ReviewTargetStatusResult, lineage string) []ReviewTransitionArgument {

--- a/internal/cli/review_next_transition.go
+++ b/internal/cli/review_next_transition.go
@@ -281,6 +281,20 @@ func (target reviewTransitionTarget) validateArguments() []ReviewTransitionArgum
 	return []ReviewTransitionArgument{{Name: "base-ref", Value: target.BaseRef}}
 }
 
+func (target reviewTransitionTarget) recoveryArguments() ([]ReviewTransitionArgument, bool) {
+	if target.Kind != reviewtransaction.TargetBaseDiff {
+		return nil, true
+	}
+	if strings.TrimSpace(target.BaseRef) == "" || !target.RecoveryScopeChanged {
+		return nil, false
+	}
+	return []ReviewTransitionArgument{
+		{Name: "base-ref", Value: target.BaseRef},
+		{Name: "committed-only", Value: "true"},
+		{Name: "projection", Value: string(target.Projection)},
+	}, true
+}
+
 func reviewStartArguments(status ReviewTargetStatusResult, lineage string) []ReviewTransitionArgument {
 	arguments := []ReviewTransitionArgument{
 		{Name: "contract", Value: ReviewIntegrationContractV1},
@@ -357,7 +371,13 @@ func reviewRecoveryCollection(status ReviewTargetStatusResult, binding ReviewTra
 		disposition = reviewtransaction.RecoveryInvalidated
 	}
 	if input.recoveryAuthorized(binding) {
-		return reviewExecuteTransition("recovery_authorized", "review.recover", []ReviewTransitionArgument{{Name: "predecessor-lineage", Value: binding.LineageID}, {Name: "expected-predecessor-revision", Value: binding.Revision}, {Name: "successor-lineage", Value: input.Successor}, {Name: "disposition", Value: string(disposition)}, {Name: "reason", Value: input.Reason}, {Name: "actor", Value: input.Actor}, {Name: "maintainer-authorization", Value: input.Authorization}}, []ReviewTransitionArgument{{Name: "state", Value: string(status.Authority.State)}, {Name: "recovery_authorization", Value: "provided"}}, binding, nil)
+		targetArguments, ok := input.Target.recoveryArguments()
+		if !ok {
+			return reviewStopTransition("recovery_target_unchanged")
+		}
+		arguments := []ReviewTransitionArgument{{Name: "predecessor-lineage", Value: binding.LineageID}, {Name: "expected-predecessor-revision", Value: binding.Revision}, {Name: "successor-lineage", Value: input.Successor}, {Name: "disposition", Value: string(disposition)}, {Name: "reason", Value: input.Reason}, {Name: "actor", Value: input.Actor}, {Name: "maintainer-authorization", Value: input.Authorization}}
+		arguments = append(arguments, targetArguments...)
+		return reviewExecuteTransition("recovery_authorized", "review.recover", arguments, []ReviewTransitionArgument{{Name: "state", Value: string(status.Authority.State)}, {Name: "recovery_authorization", Value: "provided"}}, binding, nil)
 	}
 	return reviewCollectTransition("recovery_authorization_required", ReviewTransitionInput{
 		Name: "recovery_authorization", Schema: "gentle-ai.review-recovery-authorization/v1", CaptureOperation: "external.authorize_recovery",

--- a/internal/cli/review_next_transition.go
+++ b/internal/cli/review_next_transition.go
@@ -162,7 +162,9 @@ func newReviewNextTransition(status ReviewTargetStatusResult, selectedLenses []s
 		return reviewRecoveryCollection(status, binding, input)
 	case reviewtransaction.StateApproved:
 		if status.Receipt.Status == ReviewReceiptPresent {
-			return reviewExecuteTransition("approved_receipt_ready", "review.validate", []ReviewTransitionArgument{{Name: "lineage", Value: binding.LineageID}, {Name: "gate", Value: string(input.gate())}}, []ReviewTransitionArgument{{Name: "state", Value: "approved"}, {Name: "receipt", Value: "present"}}, binding, nil)
+			arguments := []ReviewTransitionArgument{{Name: "lineage", Value: binding.LineageID}, {Name: "gate", Value: string(input.gate())}}
+			arguments = append(arguments, input.Target.validateArguments()...)
+			return reviewExecuteTransition("approved_receipt_ready", "review.validate", arguments, []ReviewTransitionArgument{{Name: "state", Value: "approved"}, {Name: "receipt", Value: "present"}}, binding, nil)
 		}
 		if status.Replayability == reviewtransaction.ReplayabilityExactReplaySafe {
 			return reviewExecuteTransition("exact_receipt_replay", "review.finalize", []ReviewTransitionArgument{{Name: "lineage", Value: binding.LineageID}}, []ReviewTransitionArgument{{Name: "state", Value: "approved"}, {Name: "receipt", Value: "publication_pending"}}, binding, nil)
@@ -259,9 +261,24 @@ type reviewNextTransitionInput struct {
 	RepairActor, RepairReason, RepairAuthorization string
 	StartLineage                                   string
 	RepositoryContext                              string
+	Target                                         reviewTransitionTarget
 	ValidationRequest                              *reviewtransaction.TargetedValidationRequest
 	CorrectionForecasted                           bool
 	CaptureContext                                 *reviewCaptureContext
+}
+
+type reviewTransitionTarget struct {
+	Kind                 reviewtransaction.TargetKind
+	Projection           reviewtransaction.Projection
+	BaseRef              string
+	RecoveryScopeChanged bool
+}
+
+func (target reviewTransitionTarget) validateArguments() []ReviewTransitionArgument {
+	if target.BaseRef == "" {
+		return nil
+	}
+	return []ReviewTransitionArgument{{Name: "base-ref", Value: target.BaseRef}}
 }
 
 func reviewStartArguments(status ReviewTargetStatusResult, lineage string) []ReviewTransitionArgument {

--- a/internal/cli/review_next_transition_test.go
+++ b/internal/cli/review_next_transition_test.go
@@ -379,7 +379,7 @@ func TestReviewNextTransitionStateTable(t *testing.T) {
 				tt.status.Receipt.Status = ReviewReceiptPresent
 			}
 			if tt.status.Action == reviewtransaction.TargetStatusActionRecover {
-				input = reviewNextTransitionInput{Successor: "review-next-successor", Reason: "authorized recovery", Actor: "maintainer"}
+				input = reviewNextTransitionInput{Successor: "review-next-successor", Reason: "authorized recovery", Actor: "maintainer", Target: reviewTransitionTarget{Kind: reviewtransaction.TargetCurrentChanges}}
 				input.Authorization = "gentle-ai.review-recovery-authorization/v1\npredecessor_lineage=" + tt.status.Authority.LineageID + "\npredecessor_revision=" + tt.status.Authority.Revision + "\ntarget_identity=" + tt.status.TargetIdentity + "\nactor=" + input.Actor + "\nreason=" + input.Reason
 			}
 			got := newReviewNextTransition(tt.status, tt.lenses, tt.artifacts, false, nil, input)
@@ -393,6 +393,21 @@ func TestReviewNextTransitionStateTable(t *testing.T) {
 				t.Fatalf("stop exposed a command or template: %#v", got)
 			}
 		})
+	}
+}
+
+func TestReviewRecoveryTransitionStopsForUnsupportedTarget(t *testing.T) {
+	status := ReviewTargetStatusResult{
+		Applicability: reviewtransaction.TargetApplicabilityCurrent, Action: reviewtransaction.TargetStatusActionRecover,
+		TargetIdentity: "sha256:" + strings.Repeat("b", 64),
+		Authority:      &ReviewTargetStatusAuthority{LineageID: "review-overlay", Revision: "sha256:" + strings.Repeat("a", 64), State: reviewtransaction.StateInvalidated},
+	}
+	input := reviewNextTransitionInput{Successor: "review-overlay-successor", Reason: "authorized recovery", Actor: "maintainer", Target: reviewTransitionTarget{Kind: reviewtransaction.TargetBaseWorkspaceOverlay}}
+	input.Authorization = "gentle-ai.review-recovery-authorization/v1\npredecessor_lineage=" + status.Authority.LineageID + "\npredecessor_revision=" + status.Authority.Revision + "\ntarget_identity=" + status.TargetIdentity + "\nactor=" + input.Actor + "\nreason=" + input.Reason
+
+	got := newReviewNextTransition(status, nil, nil, false, nil, input)
+	if got.Kind != reviewNextTransitionStop || got.Execute != nil || got.Collect != nil {
+		t.Fatalf("unsupported recovery transition = %#v", got)
 	}
 }
 


### PR DESCRIPTION
## Linked Issue

Closes #1692

---

## PR Type

- [x] `type:bug` - Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` - New feature (non-breaking change that adds functionality)
- [ ] `type:docs` - Documentation only
- [ ] `type:refactor` - Code refactoring (no functional changes)
- [ ] `type:chore` - Build, CI, or tooling changes
- [ ] `type:breaking-change` - Breaking change (fix or feature that changes existing behavior)

---

## Summary

- Preserve the exact symbolic `base-ref` selected by STATUS in executable VALIDATE transitions.
- Emit complete base-diff RECOVER selectors and stop unchanged or unsupported recovery targets without mutation.
- Reject duplicate VALIDATE/RECOVER target selectors before repository resolution.

---

## Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/cli/review_facade.go` | Carries validated selectors into routing and rejects repeated consumer selectors. |
| `internal/cli/review_next_transition.go` | Builds complete VALIDATE/RECOVER arguments and fails closed for unsupported recovery targets. |
| `internal/cli/review_exact_transition_selector_test.go` | Adds unchanged-execution regressions for custom VALIDATE and base-diff RECOVER targets. |
| `internal/cli/review_next_transition_test.go` | Covers fail-closed workspace-overlay recovery routing. |

---

## Test Plan

**Focused issue coverage**
```bash
go test ./internal/cli -run 'TestReviewRecoveryTransitionStopsForUnsupportedTarget|TestNegotiated(Validate|Recover)Transition|TestTransitionConsumersRejectDuplicateSelectors|TestReviewNextTransitionStateTable|TestConsumedHistoricalCorrectionRoutesToRecoveryOrStop|TestNegotiatedStartRejectsIncompleteBindingsWithoutAuthority' -count=1
```

**Compile every package and test binary**
```bash
go test ./... -run '^$' -count=1
```

**Go Format**
```bash
go run ./internal/gofmtcheck
```

- [ ] Unit tests pass (`go test ./...`) - pending CI/Linux; the Windows host has unrelated symlink, Bash/WSL, and Git-heavy timeout failures in untouched packages.
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) - Docker is unavailable locally; pending CI.
- [x] Manually tested locally through the emitted name/value transition arguments.

---

## Automated Checks

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | Pending | 390 changed lines (`additions + deletions`) |
| Check Issue Reference | Pending | Body contains `Closes #1692` |
| Check Issue Has `status:approved` | Pending | Issue is approved |
| Check PR Has `type:*` Label | Pending | Exactly `type:bug` will be applied |
| Unit Tests | Pending | CI/Linux authority |
| Go Format | Pending | Local check passed |
| E2E Tests | Pending | CI authority |

---

## Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines (390 total)
- [x] I have added the appropriate `type:*` label to this PR
- [ ] Unit tests pass (`go test ./...`) - pending CI/Linux
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) - pending CI
- [x] Documentation is unchanged because the public contract already requires complete executable arguments
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers

---

## Notes for Reviewers

Review the target-selector data flow first: `runReviewStatus` preserves the validated symbolic selector, and `reviewRecoveryCollection` emits only representable targets. The tests execute every emitted name/value pair as `--name=value`, proving the transition can be replayed without consumer inference.

Local focused tests and compilation pass. The complete Windows suite was attempted but is not authoritative because unrelated tests require symlink privileges, Bash/WSL, or exceed aggregate Git timeouts. CI/Linux should provide the complete suite result.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved exact base-reference and base-diff selector settings when preparing validation and recovery transitions.
  - Prevented duplicate `--base-ref`, `--committed-only`, and `--projection` options, with clear error messages.
  - Improved recovery planning when the selected scope changes.
  - Safely stops recovery when the requested target is unsupported, avoiding execution with incomplete settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->