### PR TITLE
fix(filemerge): collapse duplicate managed sections

### DIFF
--- a/internal/components/filemerge/section.go
+++ b/internal/components/filemerge/section.go
@@ -290,11 +290,32 @@ func InjectMarkdownSection(existing, sectionID, content string) string {
 
 	// If both markers are found and in the correct order, replace the section.
 	if openIdx >= 0 && closeIdx >= 0 && closeIdx > openIdx {
+		before := existing[:openIdx]
+		after := existing[closeIdx+len(close):]
+
+		var preservedAfter strings.Builder
+		for {
+			duplicateOpen := strings.Index(after, open)
+			if duplicateOpen < 0 {
+				preservedAfter.WriteString(after)
+				break
+			}
+
+			bodyStart := duplicateOpen + len(open)
+			duplicateCloseOffset := strings.Index(after[bodyStart:], close)
+			if duplicateCloseOffset < 0 {
+				preservedAfter.WriteString(after)
+				break
+			}
+
+			duplicateEnd := bodyStart + duplicateCloseOffset + len(close)
+			preservedAfter.WriteString(after[:duplicateOpen])
+			after = after[duplicateEnd:]
+		}
+		after = preservedAfter.String()
+
 		// If content is empty, remove the entire section including markers.
 		if content == "" {
-			before := existing[:openIdx]
-			after := existing[closeIdx+len(close):]
-
 			// Clean up trailing newline after close marker.
 			if len(after) > 0 && after[0] == '\n' {
 				after = after[1:]
@@ -311,9 +332,6 @@ func InjectMarkdownSection(existing, sectionID, content string) string {
 			}
 			return result
 		}
-
-		before := existing[:openIdx]
-		after := existing[closeIdx+len(close):]
 
 		var sb strings.Builder
 		sb.WriteString(before)

--- a/internal/components/filemerge/section_test.go
+++ b/internal/components/filemerge/section_test.go
@@ -87,6 +87,71 @@ func TestInjectMarkdownSection_UpdateExistingSection(t *testing.T) {
 	}
 }
 
+func TestInjectMarkdownSection_CollapsesDuplicateTargetSections(t *testing.T) {
+	const (
+		open  = "<!-- gentle-ai:persona -->"
+		close = "<!-- /gentle-ai:persona -->"
+	)
+
+	first := open + "\nfirst\n" + close
+	second := open + "\nsecond\n" + close
+	third := open + "\nthird\n" + close
+	canonical := open + "\ncurrent\n" + close
+	sdd := "<!-- gentle-ai:sdd -->\nkeep sdd\n<!-- /gentle-ai:sdd -->"
+
+	tests := []struct {
+		name        string
+		existing    string
+		replacement string
+		want        string
+	}{
+		{
+			name:        "adjacent duplicate blocks",
+			existing:    first + second,
+			replacement: "current\n",
+			want:        canonical,
+		},
+		{
+			name:        "user content between duplicate blocks",
+			existing:    "# Before\n\n" + first + "\nUser middle.\n\n" + second + "\n# After\n",
+			replacement: "current\n",
+			want:        "# Before\n\n" + canonical + "\nUser middle.\n\n\n# After\n",
+		},
+		{
+			name:        "three duplicate blocks collapse in one call",
+			existing:    first + "\n" + second + "\n" + third,
+			replacement: "current\n",
+			want:        canonical + "\n\n",
+		},
+		{
+			name:        "unrelated managed section remains unchanged",
+			existing:    first + "\n" + sdd + "\n" + second,
+			replacement: "current\n",
+			want:        canonical + "\n" + sdd + "\n",
+		},
+		{
+			name:        "empty replacement removes every target block",
+			existing:    "# Before\n\n" + first + "\nUser middle.\n\n" + second + "\n# After\n",
+			replacement: "",
+			want:        "# Before\nUser middle.\n\n\n# After\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := InjectMarkdownSection(tt.existing, "persona", tt.replacement)
+			if got != tt.want {
+				t.Fatalf("InjectMarkdownSection() = %q, want %q", got, tt.want)
+			}
+
+			secondRun := InjectMarkdownSection(got, "persona", tt.replacement)
+			if secondRun != got {
+				t.Fatalf("second injection changed result:\nfirst:  %q\nsecond: %q", got, secondRun)
+			}
+		})
+	}
+}
+
 func TestInjectMarkdownSection_MultipleSectionsOnlyTargetedOneUpdated(t *testing.T) {
 	existing := "# Config\n\n<!-- gentle-ai:persona -->\nPersona content.\n<!-- /gentle-ai:persona -->\n\n<!-- gentle-ai:sdd -->\nOld SDD.\n<!-- /gentle-ai:sdd -->\n\n<!-- gentle-ai:skills -->\nSkills content.\n<!-- /gentle-ai:skills -->\n"
 


### PR DESCRIPTION
## Linked Issue

Closes #1675

---

## PR Type

- [x] `type:bug` - Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` - New feature (non-breaking change that adds functionality)
- [ ] `type:docs` - Documentation only
- [ ] `type:refactor` - Code refactoring (no functional changes)
- [ ] `type:chore` - Build, CI, or tooling changes
- [ ] `type:breaking-change` - Breaking change (fix or feature that changes existing behavior)

---

## Summary

- Collapse later complete same-ID managed Markdown sections before refreshing the retained first block.
- Preserve user-authored text and other managed section IDs.
- Cover duplicate refresh, removal, marker count, and byte-idempotence with focused regressions.

---

## Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/components/filemerge/section.go` | Normalize duplicate complete marker pairs before the existing replacement or removal path |
| `internal/components/filemerge/section_test.go` | Add regressions for refresh, removal, external content, other IDs, marker count, and idempotence |

---

## Test Plan

```bash
go test ./internal/components/filemerge -run '^TestInjectMarkdownSection' -count=1 -timeout=2m
go test ./internal/components/filemerge ./internal/components/persona -count=1 -timeout=5m
go run ./internal/gofmtcheck
```

- [x] Focused `InjectMarkdownSection` tests pass
- [x] Affected `filemerge` and `persona` package tests pass
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [x] Full unit suite passes in CI (`go test ./...`)
- [x] E2E tests pass in CI (`cd e2e && ./docker-test.sh`)

---

## Automated Checks

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | Pass | PR has 95 changed lines |
| Check Issue Reference | Pass | Body contains `Closes #1675` |
| Check Issue Has `status:approved` | Pass | Issue has `status:approved` |
| Check PR Has `type:*` Label | Pass | Exactly `type:bug` is applied |
| Unit Tests | Pass | Full suite passed in CI |
| Go Format | Pass | Formatter check passed in CI |
| E2E Tests | Pass | Ubuntu, Arch, and Fedora passed in CI |

---

## Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [x] I have added exactly one appropriate `type:*` label
- [x] Focused and affected-package tests pass locally
- [x] Full unit and E2E suites pass in CI
- [x] Go format passes locally
- [x] Documentation is not required for this internal corrective behavior
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers

---

## Notes for Reviewers

Please focus on whether removing only complete later exact-marker spans preserves the existing malformed-marker repair contract. The helper runs after `stripOrphanMarkers` and before the existing refresh or removal branches.
