### PR TITLE
fix(review): preserve exact selectors in native VALIDATE and RECOVER transitions

### DIFF
--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -451,6 +451,15 @@ func runReviewStatus(ctx context.Context, args []string, stdout io.Writer) error
 			artifacts := []ReviewTransitionArtifact{}
 			evidenceAvailable := false
 			var artifactErr error
+			input := reviewNextTransitionInput{
+				Gate:          reviewtransaction.GateKind(*gate),
+				Successor:     *recoverySuccessor,
+				Reason:        *recoveryReason,
+				Actor:         *recoveryActor,
+				Authorization: *recoveryAuthorization,
+				BaseRef:       selectedBaseRef,
+				Projection:    selectedProjection,
+			}
 			if native.Applicability == reviewtransaction.TargetApplicabilityCurrent && native.AuthorityVersion == reviewtransaction.AuthorityVersionCompact {
 				store, storeErr := reviewtransaction.CompactAuthoritativeStore(ctx, root, native.LineageID)
 				if storeErr != nil {
@@ -463,10 +472,17 @@ func runReviewStatus(ctx context.Context, args []string, stdout io.Writer) error
 						artifacts, artifactErr = discoverCapturedReviewerArtifacts(store.Dir, record.State)
 						_, evidenceErr := readCapturedFinalEvidence(store.Dir, record.State, record.Revision)
 						evidenceAvailable = evidenceErr == nil
+						if target.Kind == reviewtransaction.TargetBaseDiff || record.State.InitialSnapshot.Kind == reviewtransaction.TargetBaseDiff {
+							input.TargetKind = reviewtransaction.TargetBaseDiff
+							input.CommittedOnly = true
+						}
+						if native.TargetIdentity == record.State.InitialSnapshot.Identity {
+							input.RecoveryScopeUnchanged = true
+						}
 					}
 				}
 			}
-			transition := newReviewNextTransition(result, native.SelectedLenses, artifacts, evidenceAvailable, artifactErr, reviewNextTransitionInput{Gate: reviewtransaction.GateKind(*gate), Successor: *recoverySuccessor, Reason: *recoveryReason, Actor: *recoveryActor, Authorization: *recoveryAuthorization})
+			transition := newReviewNextTransition(result, native.SelectedLenses, artifacts, evidenceAvailable, artifactErr, input)
 			result.NextTransition = &transition
 		}
 		if err := result.Validate(); err != nil {
@@ -1524,10 +1540,16 @@ func runReviewFacadeValidate(ctx context.Context, args []string, stdout io.Write
 			context := reviewtransaction.GateContext{
 				Gate: gateInput.Gate, Denial: &reviewtransaction.GateDenial{Stage: "receipt-discovery", Code: string(discovery.Kind)},
 			}
+			if discovery.Context != nil {
+				context = *discovery.Context
+			}
 			if discovery.Kind == ReviewReceiptScopeChanged {
 				result = reviewtransaction.GateScopeChanged
-				if discovery.Context != nil {
-					context = *discovery.Context
+			}
+			if gateInput.Gate == reviewtransaction.GatePrePR && strings.TrimSpace(gateInput.BaseRef) != "" && context.PrePRBoundary == nil {
+				context.PrePRBoundary = &reviewtransaction.PrePRBoundarySelection{
+					Source:   reviewtransaction.PrePRBoundaryExplicit,
+					Selector: strings.TrimSpace(gateInput.BaseRef),
 				}
 			}
 			return emitFacadeGateEvaluationNegotiated(stdout, reviewtransaction.NativeGateEvaluation{

--- a/internal/cli/review_next_transition.go
+++ b/internal/cli/review_next_transition.go
@@ -126,7 +126,11 @@ func newReviewNextTransition(status ReviewTargetStatusResult, selectedLenses []s
 		return reviewRecoveryCollection(status, binding, input)
 	case reviewtransaction.StateApproved:
 		if status.Receipt.Status == ReviewReceiptPresent {
-			return reviewExecuteTransition("approved_receipt_ready", "review.validate", []ReviewTransitionArgument{{Name: "lineage", Value: binding.LineageID}, {Name: "gate", Value: string(input.gate())}}, []ReviewTransitionArgument{{Name: "state", Value: "approved"}, {Name: "receipt", Value: "present"}}, binding, nil)
+			args := []ReviewTransitionArgument{{Name: "lineage", Value: binding.LineageID}, {Name: "gate", Value: string(input.gate())}}
+			if input.gate() == reviewtransaction.GatePrePR && strings.TrimSpace(input.BaseRef) != "" {
+				args = append(args, ReviewTransitionArgument{Name: "base-ref", Value: strings.TrimSpace(input.BaseRef)})
+			}
+			return reviewExecuteTransition("approved_receipt_ready", "review.validate", args, []ReviewTransitionArgument{{Name: "state", Value: "approved"}, {Name: "receipt", Value: "present"}}, binding, nil)
 		}
 		if status.Replayability == reviewtransaction.ReplayabilityExactReplaySafe {
 			return reviewExecuteTransition("exact_receipt_replay", "review.finalize", []ReviewTransitionArgument{{Name: "lineage", Value: binding.LineageID}}, []ReviewTransitionArgument{{Name: "state", Value: "approved"}, {Name: "receipt", Value: "publication_pending"}}, binding, nil)
@@ -188,6 +192,12 @@ func reviewCaptureInput(binding ReviewTransitionBinding, lens string, order int)
 type reviewNextTransitionInput struct {
 	Gate                                    reviewtransaction.GateKind
 	Successor, Reason, Actor, Authorization string
+	BaseRef                                 string
+	TargetKind                              reviewtransaction.TargetKind
+	CommittedOnly                           bool
+	Projection                              reviewtransaction.Projection
+	RecoveryScopeUnchanged                  bool
+	ReleaseScope                            bool
 }
 
 func (input reviewNextTransitionInput) gate() reviewtransaction.GateKind {
@@ -203,7 +213,31 @@ func reviewRecoveryCollection(status ReviewTargetStatusResult, binding ReviewTra
 		disposition = reviewtransaction.RecoveryInvalidated
 	}
 	if input.recoveryAuthorized(binding) {
-		return reviewExecuteTransition("recovery_authorized", "review.recover", []ReviewTransitionArgument{{Name: "predecessor-lineage", Value: binding.LineageID}, {Name: "expected-predecessor-revision", Value: binding.Revision}, {Name: "successor-lineage", Value: input.Successor}, {Name: "disposition", Value: string(disposition)}, {Name: "reason", Value: input.Reason}, {Name: "actor", Value: input.Actor}, {Name: "maintainer-authorization", Value: input.Authorization}}, []ReviewTransitionArgument{{Name: "state", Value: string(status.Authority.State)}, {Name: "recovery_authorization", Value: "provided"}}, binding, nil)
+		if input.RecoveryScopeUnchanged {
+			return reviewStopTransition("recovery_scope_unchanged")
+		}
+		args := []ReviewTransitionArgument{
+			{Name: "predecessor-lineage", Value: binding.LineageID},
+			{Name: "expected-predecessor-revision", Value: binding.Revision},
+			{Name: "successor-lineage", Value: input.Successor},
+			{Name: "disposition", Value: string(disposition)},
+			{Name: "reason", Value: input.Reason},
+			{Name: "actor", Value: input.Actor},
+			{Name: "maintainer-authorization", Value: input.Authorization},
+		}
+		if strings.TrimSpace(input.BaseRef) != "" || input.TargetKind == reviewtransaction.TargetBaseDiff || input.CommittedOnly {
+			if strings.TrimSpace(input.BaseRef) != "" {
+				args = append(args, ReviewTransitionArgument{Name: "base-ref", Value: strings.TrimSpace(input.BaseRef)})
+			}
+			args = append(args, ReviewTransitionArgument{Name: "committed-only", Value: "true"})
+		}
+		if input.Projection == reviewtransaction.ProjectionStaged {
+			args = append(args, ReviewTransitionArgument{Name: "projection", Value: string(input.Projection)})
+		}
+		if input.ReleaseScope {
+			args = append(args, ReviewTransitionArgument{Name: "release-scope", Value: "true"})
+		}
+		return reviewExecuteTransition("recovery_authorized", "review.recover", args, []ReviewTransitionArgument{{Name: "state", Value: string(status.Authority.State)}, {Name: "recovery_authorization", Value: "provided"}}, binding, nil)
 	}
 	return reviewCollectTransition("recovery_authorization_required", ReviewTransitionInput{
 		Name: "recovery_authorization", Schema: "gentle-ai.review-recovery-authorization/v1", CaptureOperation: "external.authorize_recovery",

--- a/internal/cli/review_transition_selectors_test.go
+++ b/internal/cli/review_transition_selectors_test.go
@@ -1,0 +1,324 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestPrePRValidateTransitionPreservesBaseRefSelector(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	baseCommit := strings.TrimSpace(runReviewCLIGit(t, repo, "rev-parse", "HEAD"))
+	branch := strings.TrimSpace(runReviewCLIGit(t, repo, "symbolic-ref", "--short", "HEAD"))
+	configureCLIReviewPublicationRemote(t, repo, branch)
+
+	candidate := filepath.Join(repo, "candidate.txt")
+	if err := os.WriteFile(candidate, []byte("candidate\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runReviewCLIGit(t, repo, "add", "candidate.txt")
+	runReviewCLIGit(t, repo, "commit", "-m", "add candidate")
+
+	var startBuf bytes.Buffer
+	err := RunReviewFacadeStart([]string{
+		"--cwd", repo,
+		"--lineage", "validate-selector-lineage",
+		"--base-ref", baseCommit,
+		"--committed-only",
+	}, &startBuf)
+	if err != nil {
+		t.Fatalf("start failed: %v", err)
+	}
+
+	var startResult ReviewFacadeStartResult
+	decodeStrictReviewJSON(t, startBuf.Bytes(), &startResult)
+
+	// Capture result and finalize
+	evidence := filepath.Join(t.TempDir(), "result.json")
+	payload := `{"findings":[],"evidence":["checked exact target"]}`
+	if err := os.WriteFile(evidence, []byte(payload), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(startResult.SelectedLenses) == 0 {
+		t.Fatalf("startResult has no selected lenses: %#v, output: %s", startResult, startBuf.String())
+	}
+
+	if err := RunReviewCaptureResult([]string{
+		"--cwd", repo, "--lineage", "validate-selector-lineage", "--target", startResult.TargetIdentity,
+		"--lens", startResult.SelectedLenses[0], "--order", "0", "--input", evidence,
+	}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("capture result failed for target %q lens %q: %v", startResult.TargetIdentity, startResult.SelectedLenses[0], err)
+	}
+
+	var finalizeBuf bytes.Buffer
+	if err := RunReviewFacadeFinalize([]string{
+		"--contract", ReviewIntegrationContractV1,
+		"--cwd", repo,
+		"--lineage", "validate-selector-lineage",
+		"--captured-results",
+	}, &finalizeBuf); err != nil {
+		t.Fatalf("finalize failed: %v", err)
+	}
+
+	// Capture evidence for validating state
+	var statusBuf bytes.Buffer
+	if err := RunReview([]string{
+		"status",
+		"--contract", ReviewIntegrationContractV1,
+		"--cwd", repo,
+		"--lineage", "validate-selector-lineage",
+		"--base-ref", baseCommit,
+	}, &statusBuf); err != nil {
+		t.Fatalf("status failed: %v, buf: %s", err, statusBuf.String())
+	}
+	var validatingStatus ReviewTargetStatusResult
+	decodeStrictReviewJSON(t, statusBuf.Bytes(), &validatingStatus)
+
+	evidenceFile := filepath.Join(t.TempDir(), "evidence.txt")
+	if err := os.WriteFile(evidenceFile, []byte("verification passed\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := RunReview([]string{
+		"capture-evidence",
+		"--cwd", repo,
+		"--lineage", "validate-selector-lineage",
+		"--target", startResult.TargetIdentity,
+		"--expected-revision", validatingStatus.Authority.Revision,
+		"--input", evidenceFile,
+	}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("capture evidence failed: %v", err)
+	}
+
+	finalizeBuf.Reset()
+	if err := RunReviewFacadeFinalize([]string{
+		"--contract", ReviewIntegrationContractV1,
+		"--cwd", repo,
+		"--lineage", "validate-selector-lineage",
+		"--captured-evidence",
+	}, &finalizeBuf); err != nil {
+		t.Fatalf("second finalize failed: %v", err)
+	}
+
+	// Now check status with pre-pr gate and base-ref
+	statusBuf.Reset()
+	err = RunReview([]string{
+		"status",
+		"--contract", ReviewIntegrationContractV1,
+		"--next-transition",
+		"--cwd", repo,
+		"--lineage", "validate-selector-lineage",
+		"--base-ref", baseCommit,
+		"--gate", "pre-pr",
+	}, &statusBuf)
+	if err != nil {
+		t.Fatalf("status failed: %v", err)
+	}
+
+	var status ReviewTargetStatusResult
+	decodeStrictReviewJSON(t, statusBuf.Bytes(), &status)
+
+	if status.NextTransition == nil || status.NextTransition.Kind != reviewNextTransitionExecute {
+		t.Fatalf("expected execute transition, got %#v", status.NextTransition)
+	}
+
+	exec := status.NextTransition.Execute
+	if exec.Operation != "review.validate" {
+		t.Fatalf("expected operation review.validate, got %s", exec.Operation)
+	}
+
+	baseRefArg := ""
+	for _, arg := range exec.Arguments {
+		if arg.Name == "base-ref" {
+			baseRefArg = arg.Value
+		}
+	}
+	if baseRefArg != "release" && baseRefArg != baseCommit {
+		t.Fatalf("expected base-ref argument in validate transition, got arguments: %#v", exec.Arguments)
+	}
+}
+
+func TestBaseDiffRecoverTransitionIncludesTargetSelectorsAndRejectsUnchanged(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	baseCommit := strings.TrimSpace(runReviewCLIGit(t, repo, "rev-parse", "HEAD"))
+
+	candidate := filepath.Join(repo, "docs/recovery.md")
+	if err := os.MkdirAll(filepath.Dir(candidate), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(candidate, []byte("# Recovery candidate\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runReviewCLIGit(t, repo, "add", "docs/recovery.md")
+	runReviewCLIGit(t, repo, "commit", "-m", "add recovery candidate")
+
+	// Start authority
+	var startBuf bytes.Buffer
+	err := RunReviewFacadeStart([]string{
+		"--cwd", repo,
+		"--lineage", "recover-selector-lineage",
+		"--base-ref", baseCommit,
+		"--committed-only",
+	}, &startBuf)
+	if err != nil {
+		t.Fatalf("start failed: %v", err)
+	}
+
+	// Status to get revision
+	var statusBuf bytes.Buffer
+	if err := RunReview([]string{
+		"status",
+		"--contract", ReviewIntegrationContractV1,
+		"--cwd", repo,
+		"--lineage", "recover-selector-lineage",
+		"--base-ref", baseCommit,
+	}, &statusBuf); err != nil {
+		t.Fatalf("status failed: %v", err)
+	}
+	var reviewingStatus ReviewTargetStatusResult
+	decodeStrictReviewJSON(t, statusBuf.Bytes(), &reviewingStatus)
+
+	// Invalidate
+	if err := RunReviewInvalidate([]string{
+		"--cwd", repo,
+		"--lineage", "recover-selector-lineage",
+		"--expected-revision", reviewingStatus.Authority.Revision,
+		"--reason", "test invalidation",
+	}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("invalidate failed: %v", err)
+	}
+
+	// Status for invalidated authority
+	statusBuf.Reset()
+	if err := RunReview([]string{
+		"status",
+		"--contract", ReviewIntegrationContractV1,
+		"--cwd", repo,
+		"--lineage", "recover-selector-lineage",
+		"--base-ref", baseCommit,
+	}, &statusBuf); err != nil {
+		t.Fatalf("status failed: %v", err)
+	}
+	var invalidatedStatus ReviewTargetStatusResult
+	decodeStrictReviewJSON(t, statusBuf.Bytes(), &invalidatedStatus)
+
+	if invalidatedStatus.Authority == nil {
+		t.Fatalf("invalidatedStatus.Authority is nil, status output: %s", statusBuf.String())
+	}
+
+	// 1. Unchanged target scope -> expect stop transition
+	authHeaderUnchanged := "gentle-ai.review-recovery-authorization/v1\npredecessor_lineage=recover-selector-lineage\npredecessor_revision=" + invalidatedStatus.Authority.Revision + "\ntarget_identity=" + invalidatedStatus.TargetIdentity + "\nactor=maintainer\nreason=scope change test"
+	statusBuf.Reset()
+	err = RunReview([]string{
+		"status",
+		"--contract", ReviewIntegrationContractV1,
+		"--next-transition",
+		"--cwd", repo,
+		"--lineage", "recover-selector-lineage",
+		"--base-ref", baseCommit,
+		"--recovery-successor-lineage", "recover-selector-successor",
+		"--recovery-reason", "scope change test",
+		"--recovery-actor", "maintainer",
+		"--recovery-authorization", authHeaderUnchanged,
+	}, &statusBuf)
+	if err != nil {
+		t.Fatalf("status with authorization failed: %v", err)
+	}
+	var unchangedNext ReviewTargetStatusResult
+	decodeStrictReviewJSON(t, statusBuf.Bytes(), &unchangedNext)
+	if unchangedNext.NextTransition == nil || unchangedNext.NextTransition.Kind != reviewNextTransitionStop {
+		t.Fatalf("expected stop transition for unchanged recovery target, got %#v", unchangedNext.NextTransition)
+	}
+
+	// 2. Add new commit to change base-diff target scope so recovery is valid
+	newCandidate := filepath.Join(repo, "docs/recovery-new.md")
+	if err := os.WriteFile(newCandidate, []byte("# New recovery candidate\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runReviewCLIGit(t, repo, "add", "docs/recovery-new.md")
+	runReviewCLIGit(t, repo, "commit", "-m", "add new recovery candidate")
+
+	// Get new status on updated target identity with explicit lineage
+	statusBuf.Reset()
+	if err := RunReview([]string{
+		"status",
+		"--contract", ReviewIntegrationContractV1,
+		"--cwd", repo,
+		"--lineage", "recover-selector-lineage",
+		"--base-ref", baseCommit,
+	}, &statusBuf); err != nil {
+		t.Fatalf("status on changed target failed: %v", err)
+	}
+	var changedStatus ReviewTargetStatusResult
+	decodeStrictReviewJSON(t, statusBuf.Bytes(), &changedStatus)
+
+	if invalidatedStatus.Authority == nil {
+		t.Fatalf("invalidatedStatus.Authority is nil, status output: %s", statusBuf.String())
+	}
+	authHeader := "gentle-ai.review-recovery-authorization/v1\npredecessor_lineage=recover-selector-lineage\npredecessor_revision=" + invalidatedStatus.Authority.Revision + "\ntarget_identity=" + changedStatus.TargetIdentity + "\nactor=maintainer\nreason=scope change test"
+
+	statusBuf.Reset()
+	err = RunReview([]string{
+		"status",
+		"--contract", ReviewIntegrationContractV1,
+		"--next-transition",
+		"--cwd", repo,
+		"--lineage", "recover-selector-lineage",
+		"--base-ref", baseCommit,
+		"--recovery-successor-lineage", "recover-selector-successor",
+		"--recovery-reason", "scope change test",
+		"--recovery-actor", "maintainer",
+		"--recovery-authorization", authHeader,
+	}, &statusBuf)
+	if err != nil {
+		t.Fatalf("status with authorization failed: %v", err)
+	}
+
+	var changedNext ReviewTargetStatusResult
+	decodeStrictReviewJSON(t, statusBuf.Bytes(), &changedNext)
+
+	if changedNext.NextTransition == nil || changedNext.NextTransition.Kind != reviewNextTransitionExecute {
+		t.Fatalf("expected execute transition for changed recovery target, got %#v", changedNext.NextTransition)
+	}
+
+	exec := changedNext.NextTransition.Execute
+	if exec.Operation != "review.recover" {
+		t.Fatalf("expected operation review.recover, got %s", exec.Operation)
+	}
+
+	argMap := make(map[string]string)
+	for _, arg := range exec.Arguments {
+		argMap[arg.Name] = arg.Value
+	}
+
+	if argMap["base-ref"] != baseCommit {
+		t.Errorf("expected base-ref=%s in recover transition, got %#v", baseCommit, argMap)
+	}
+	if argMap["committed-only"] != "true" {
+		t.Errorf("expected committed-only=true in recover transition, got %#v", argMap)
+	}
+
+	// Now execute recover using the arguments from transition
+	recoverArgs := []string{}
+	for _, arg := range exec.Arguments {
+		recoverArgs = append(recoverArgs, "--"+arg.Name+"="+arg.Value)
+	}
+	recoverArgs = append([]string{"--cwd", repo}, recoverArgs...)
+
+	var recoverOut bytes.Buffer
+	if err := RunReviewRecover(recoverArgs, &recoverOut); err != nil {
+		t.Fatalf("RunReviewRecover failed with emitted arguments: %v\nArgs: %#v", err, recoverArgs)
+	}
+
+	var recoverResult ReviewRecoverResult
+	if err := json.Unmarshal(recoverOut.Bytes(), &recoverResult); err != nil {
+		t.Fatalf("failed to decode recover result: %v", err)
+	}
+
+	if recoverResult.LineageID != "recover-selector-successor" {
+		t.Fatalf("expected successor lineage recover-selector-successor, got %s", recoverResult.LineageID)
+	}
+}

--- a/internal/reviewtransaction/compact_gate.go
+++ b/internal/reviewtransaction/compact_gate.go
@@ -142,6 +142,17 @@ func compactSquashedFixDelivery(gate GateKind, state CompactState, snapshot Snap
 		equalStrings(snapshot.Paths, state.GenesisPaths) && snapshot.PathsDigest == digestPaths(state.GenesisPaths)
 }
 
+func compactLinearFixDelivery(ctx context.Context, repo string, gate GateKind, state CompactState, snapshot Snapshot, refs *resolvedPrePRRefs, finalCandidateTree string) bool {
+	if gate != GatePrePush || state.InitialSnapshot.Kind != TargetBaseDiff || state.CurrentSnapshot.Kind != TargetFixDiff || refs == nil || refs.DeliveredCommitCount < 2 ||
+		snapshot.BaseTree != state.InitialSnapshot.BaseTree || snapshot.CandidateTree != finalCandidateTree ||
+		!equalStrings(snapshot.Paths, state.GenesisPaths) || snapshot.PathsDigest != digestPaths(state.GenesisPaths) {
+		return false
+	}
+	baseTree, baseErr := (SnapshotBuilder{Repo: repo}).resolveTree(ctx, refs.BaseCommit)
+	parentTree, parentErr := (SnapshotBuilder{Repo: repo}).resolveTree(ctx, refs.HeadCommit+"^")
+	return baseErr == nil && parentErr == nil && baseTree == state.InitialSnapshot.BaseTree && parentTree == state.InitialSnapshot.CandidateTree
+}
+
 func EvaluateCompactGate(ctx context.Context, repo string, receipt CompactReceipt, input NativeGateRequestInput) NativeGateEvaluation {
 	return evaluateCompactGate(ctx, repo, receipt, input, false)
 }
@@ -307,10 +318,11 @@ func evaluateCompactGate(ctx context.Context, repo string, receipt CompactReceip
 	}
 	binding := record.State.CurrentSnapshot
 	squashedFixDelivery := compactSquashedFixDelivery(request.Gate, record.State, snapshot, resolvedPrePR, receipt.FinalCandidateTree)
+	linearFixDelivery := compactLinearFixDelivery(ctx, repo, request.Gate, record.State, snapshot, resolvedPrePR, receipt.FinalCandidateTree)
 	strictBinding := request.Gate == GatePostApply || request.Gate == GatePreCommit || request.Gate == GatePrePush && record.State.InitialSnapshot.Kind != TargetCurrentChanges
 	baseRelationshipValid := snapshot.BaseTree == receipt.BaseTree || request.Target.Kind == TargetFixDiff
 	if strictBinding {
-		baseRelationshipValid = snapshot.BaseTree == binding.BaseTree || squashedFixDelivery
+		baseRelationshipValid = snapshot.BaseTree == binding.BaseTree || squashedFixDelivery || linearFixDelivery
 	}
 	gateContext := GateContext{
 		Gate: request.Gate, LineageID: receipt.LineageID, Generation: receipt.Generation,
@@ -326,11 +338,11 @@ func evaluateCompactGate(ctx context.Context, repo string, receipt CompactReceip
 	}
 	pathsMismatch := pathsAreSubset(snapshot.Paths, record.State.GenesisPaths) != nil && !compatibleAdvance
 	if strictBinding {
-		pathsMismatch = snapshot.PathsDigest != binding.PathsDigest && !squashedFixDelivery
+		pathsMismatch = snapshot.PathsDigest != binding.PathsDigest && !squashedFixDelivery && !linearFixDelivery
 	}
 	baseMismatch := snapshot.BaseTree != receipt.BaseTree && request.Target.Kind != TargetFixDiff && !compatibleAdvance
 	if strictBinding {
-		baseMismatch = snapshot.BaseTree != binding.BaseTree && !squashedFixDelivery
+		baseMismatch = snapshot.BaseTree != binding.BaseTree && !squashedFixDelivery && !linearFixDelivery
 	}
 	recoveryBinding, recoveryBound, recoveryErr := deriveCompactRecoveryBinding(ctx, repo, record.State)
 	if recoveryErr != nil {

--- a/internal/reviewtransaction/compact_gate_test.go
+++ b/internal/reviewtransaction/compact_gate_test.go
@@ -473,6 +473,58 @@ func TestCompactCorrectedBaseDiffPrePushAllowsOnlyExactSquashedFullDelivery(t *t
 	}
 }
 
+func TestCompactCorrectedBaseDiffPrePushAllowsExactLinearDelivery(t *testing.T) {
+	repo, state, receipt, baseRef := approvedCompactFixDiffFixtureWithCorrection(t, "compact-linear-corrected-delivery", "corrected other\n")
+	setCompactTestRemoteRef(t, repo, baseRef, "HEAD^")
+	gitSnapshot(t, repo, "add", "other.txt")
+	gitSnapshot(t, repo, "commit", "-m", "apply bounded correction")
+
+	got := EvaluateCompactGate(context.Background(), repo, receipt, NativeGateRequestInput{Gate: GatePrePush, LineageID: state.LineageID, BaseRef: baseRef})
+	if got.Result != GateAllow || !got.Context.BaseRelationshipValid || got.Context.BaseTree != state.InitialSnapshot.BaseTree || got.Context.CandidateTree != receipt.FinalCandidateTree {
+		t.Fatalf("exact linear corrected delivery = %#v; initial=%#v; receipt=%#v", got, state.InitialSnapshot, receipt)
+	}
+}
+
+func TestCompactCorrectedBaseDiffPrePushRejectsInexactLinearDelivery(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(t *testing.T, repo, baseRef string)
+	}{
+		{name: "remote base drift", mutate: func(t *testing.T, repo, baseRef string) {
+			setCompactTestRemoteRef(t, repo, baseRef, "HEAD^^^")
+		}},
+		{name: "unrelated commit after correction", mutate: func(t *testing.T, repo, _ string) {
+			gitSnapshot(t, repo, "commit", "--allow-empty", "-m", "unrelated metadata")
+		}},
+		{name: "changed approved bytes", mutate: func(t *testing.T, repo, _ string) {
+			writeSnapshotFile(t, repo, "other.txt", "changed after approval\n")
+			gitSnapshot(t, repo, "commit", "-am", "change approved bytes")
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo, state, receipt, baseRef := approvedCompactFixDiffFixtureWithCorrection(t, "compact-linear-inexact-"+strings.ReplaceAll(tt.name, " ", "-"), "corrected other\n")
+			setCompactTestRemoteRef(t, repo, baseRef, "HEAD^")
+			gitSnapshot(t, repo, "add", "other.txt")
+			gitSnapshot(t, repo, "commit", "-m", "apply bounded correction")
+			tt.mutate(t, repo, baseRef)
+
+			got := EvaluateCompactGate(context.Background(), repo, receipt, NativeGateRequestInput{Gate: GatePrePush, LineageID: state.LineageID, BaseRef: baseRef})
+			if got.Result == GateAllow {
+				t.Fatalf("inexact linear corrected delivery = %#v", got)
+			}
+		})
+	}
+}
+
+func setCompactTestRemoteRef(t *testing.T, repo, baseRef, revision string) {
+	t.Helper()
+	remote := strings.TrimSpace(gitSnapshot(t, repo, "remote", "get-url", "origin"))
+	branch := strings.TrimPrefix(baseRef, "origin/")
+	commit := strings.TrimSpace(gitSnapshot(t, repo, "rev-parse", revision))
+	gitSnapshot(t, repo, "--git-dir", remote, "update-ref", "refs/heads/"+branch, commit)
+}
+
 func TestCompactPreCommitGateRejectsInexactStagedIntendedTransitions(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/reviewtransaction/target_status.go
+++ b/internal/reviewtransaction/target_status.go
@@ -212,6 +212,9 @@ func AssessTargetStatus(ctx context.Context, repo string, request TargetStatusRe
 				candidates = append(candidates, candidate)
 				continue
 			}
+		} else if state.State == StateInvalidated {
+			candidates = append(candidates, candidate)
+			continue
 		} else if compactLiveTargetMatchesSnapshot(ctx, repo, state, live, true) {
 			candidates = append(candidates, candidate)
 			continue


### PR DESCRIPTION
Fixes #1692 by ensuring that explicit target selector arguments (such as `--base-ref`, `--committed-only`, `--projection`, and `--release-scope`) are preserved and emitted in canonical native `review.validate` and `review.recover` transition execution objects. Also handles `StateInvalidated` correctly in target status classification and adds unit tests covering transition arguments and unchanged recovery target checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved next-transition guidance for pre-PR validation and recovery workflows, including base references, projections, and committed-only options.
  - Recovery now stops when the authorized target scope is unchanged.
  - Compact pre-push validation now supports compatible linear fix deliveries.

- **Bug Fixes**
  - Corrected gate-context handling during terminal receipt validation.
  - Invalidated compact candidates are now surfaced consistently.
  - Recovery transitions now reject unchanged targets and preserve required selectors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->