### PR TITLE
fix(review): parse-and-compare maintainer-authorization binding in recover

### DIFF
--- a/internal/reviewtransaction/compact_recovery_binding_test.go
+++ b/internal/reviewtransaction/compact_recovery_binding_test.go
@@ -558,3 +558,121 @@ func advanceChainedRecoveryBoundary(t *testing.T, fixture *chainedRecoveryFixtur
 	gitSnapshot(t, fixture.repo, "fetch", "origin")
 	return strings.TrimSpace(gitSnapshot(t, side, "rev-parse", "HEAD"))
 }
+
+// TestParseCompactRecoveryAuthorizationBinding5FieldForm proves the parser
+// accepts the canonical 5-field binding (without successor_lineage) and
+// round-trips its fields exactly.
+func TestParseCompactRecoveryAuthorizationBinding5FieldForm(t *testing.T) {
+	binding := compactRecoveryAuthorizationBinding("lineage-A", "rev-X", "target-Y", "alice@example.com", "supersede stale review")
+	lineage, revision, target, successor, actor, reason, ok := parseCompactRecoveryAuthorizationBinding(binding)
+	if !ok {
+		t.Fatalf("parser rejected a 5-field binding produced by the canonical constructor")
+	}
+	if lineage != "lineage-A" || revision != "rev-X" || target != "target-Y" ||
+		actor != "alice@example.com" || reason != "supersede stale review" {
+		t.Fatalf("parser fields = (%q,%q,%q,%q,%q), want (lineage-A,rev-X,target-Y,,alice@example.com,supersede stale review)", lineage, revision, target, actor, reason)
+	}
+	if successor != "" {
+		t.Fatalf("parser successor_lineage = %q, want empty", successor)
+	}
+}
+
+// TestParseCompactRecoveryAuthorizationBinding6FieldForm proves the parser
+// accepts the 6-field binding with successor_lineage and exposes it on
+// the returned tuple.
+func TestParseCompactRecoveryAuthorizationBinding6FieldForm(t *testing.T) {
+	binding := compactApprovedStagedScopeRecoveryAuthorizationBinding(
+		"lineage-A", "rev-X", "target-Y", "lineage-B-successor", "alice@example.com", "staged scope expansion")
+	lineage, revision, target, successor, actor, reason, ok := parseCompactRecoveryAuthorizationBinding(binding)
+	if !ok {
+		t.Fatalf("parser rejected a 6-field binding produced by the canonical constructor")
+	}
+	if lineage != "lineage-A" || revision != "rev-X" || target != "target-Y" ||
+		successor != "lineage-B-successor" || actor != "alice@example.com" || reason != "staged scope expansion" {
+		t.Fatalf("parser fields do not match the constructor output")
+	}
+}
+
+// TestParseCompactRecoveryAuthorizationBindingToleratesReorderingAndWhitespace
+// proves the parser accepts arbitrary field order and flexible whitespace
+// around the key=value separators.
+func TestParseCompactRecoveryAuthorizationBindingToleratesReorderingAndWhitespace(t *testing.T) {
+	cases := []string{
+		// trailing LF
+		compactRecoveryAuthorizationBinding("lineage-A", "rev-X", "target-Y", "alice", "reason") + "\n",
+		// leading empty line
+		"\n" + compactRecoveryAuthorizationBinding("lineage-A", "rev-X", "target-Y", "alice", "reason"),
+		// trailing empty lines
+		compactRecoveryAuthorizationBinding("lineage-A", "rev-X", "target-Y", "alice", "reason") + "\n\n",
+		// field order: reason first
+		"gentle-ai.review-recovery-authorization/v1\nreason=reason\nactor=alice\ntarget_identity=target-Y\npredecessor_revision=rev-X\npredecessor_lineage=lineage-A",
+		// generous whitespace around `=`
+		"gentle-ai.review-recovery-authorization/v1\n  predecessor_lineage = lineage-A  \n\tpredecessor_revision\t=\trev-X\n target_identity=target-Y\nactor=alice\nreason=reason",
+		// extra unknown field
+		compactRecoveryAuthorizationBinding("lineage-A", "rev-X", "target-Y", "alice", "reason") + "\nnotes=optional",
+	}
+	for index, binding := range cases {
+		if lineage, revision, target, _, actor, reason, ok := parseCompactRecoveryAuthorizationBinding(binding); !ok ||
+			lineage != "lineage-A" || revision != "rev-X" || target != "target-Y" || actor != "alice" || reason != "reason" {
+			t.Fatalf("case %d failed: ok=%v fields=(%q,%q,%q,%q,%q)", index, ok, lineage, revision, target, actor, reason)
+		}
+	}
+}
+
+// TestParseCompactRecoveryAuthorizationBindingRejectsInvalidForms proves the
+// parser refuses missing schema header, missing required field, and a binding
+// that does not start with the schema header.
+func TestParseCompactRecoveryAuthorizationBindingRejectsInvalidForms(t *testing.T) {
+	cases := []string{
+		"",                                                              // empty
+		"random text",                                                   // not the schema
+		"gentle-ai.review-recovery-authorization/v1",                     // schema but no fields
+		"gentle-ai.review-recovery-authorization/v1\npredecessor_lineage=A", // missing required fields
+		"gentle-ai.review-decide-payload/v1\npredecessor_lineage=A\npredecessor_revision=R\ntarget_identity=T\nactor=a\nreason=r", // wrong schema
+	}
+	for index, binding := range cases {
+		if _, _, _, _, _, _, ok := parseCompactRecoveryAuthorizationBinding(binding); ok {
+			t.Fatalf("case %d accepted an invalid binding:\n%s", index, binding)
+		}
+	}
+}
+
+// TestCompactRecoveryAuthorizationMatchesAcceptsEquivalentForms proves the
+// matcher returns true for canonical, re-ordered, whitespace-tolerant, and
+// 6-field-with-successor bindings; and returns false for fields that differ.
+func TestCompactRecoveryAuthorizationMatchesAcceptsEquivalentForms(t *testing.T) {
+	expected := compactRecoveryAuthorizationBinding("lineage-A", "rev-X", "target-Y", "alice", "reason")
+	cases := []string{
+		expected,                                                      // canonical
+		expected + "\n",                                               // trailing LF
+		expected + "\n\n",                                             // trailing empty lines
+		"gentle-ai.review-recovery-authorization/v1\nreason=reason\nactor=alice\ntarget_identity=target-Y\npredecessor_revision=rev-X\npredecessor_lineage=lineage-A", // re-ordered
+	}
+	for index, binding := range cases {
+		if !compactRecoveryAuthorizationMatches(binding, "lineage-A", "rev-X", "target-Y", "alice", "reason") {
+			t.Fatalf("case %d: matcher rejected an equivalent binding", index)
+		}
+	}
+}
+
+// TestCompactRecoveryAuthorizationMatchesRejectsMismatchedFields proves the
+// matcher returns false when any required field differs from the expected
+// values, even if the binding otherwise parses cleanly.
+func TestCompactRecoveryAuthorizationMatchesRejectsMismatchedFields(t *testing.T) {
+	base := compactRecoveryAuthorizationBinding("lineage-A", "rev-X", "target-Y", "alice", "reason")
+	cases := map[string]string{
+		"wrong predecessor_lineage":  strings.Replace(base, "predecessor_lineage=lineage-A", "predecessor_lineage=lineage-Z", 1),
+		"wrong predecessor_revision":  strings.Replace(base, "predecessor_revision=rev-X", "predecessor_revision=rev-Z", 1),
+		"wrong target_identity":       strings.Replace(base, "target_identity=target-Y", "target_identity=target-Z", 1),
+		"wrong actor":                 strings.Replace(base, "actor=alice", "actor=bob", 1),
+		"wrong reason":                strings.Replace(base, "reason=reason", "reason=something-else", 1),
+		"unparseable schema header":    "different-prefix/v1\npredecessor_lineage=lineage-A\npredecessor_revision=rev-X\ntarget_identity=target-Y\nactor=alice\nreason=reason",
+		"missing required field":      "gentle-ai.review-recovery-authorization/v1\npredecessor_lineage=lineage-A\npredecessor_revision=rev-X\ntarget_identity=target-Y\nactor=alice",
+	}
+	for name, binding := range cases {
+		if compactRecoveryAuthorizationMatches(binding, "lineage-A", "rev-X", "target-Y", "alice", "reason") {
+			t.Fatalf("%s: matcher accepted a mismatched binding:\n%s", name, binding)
+		}
+	}
+}
+

--- a/internal/reviewtransaction/compact_store.go
+++ b/internal/reviewtransaction/compact_store.go
@@ -233,7 +233,7 @@ func RecoverCompactAuthority(ctx context.Context, repo string, request CompactRe
 			return CompactRecord{}, errors.New("approved staged scope recovery is not a complete same-base index expansion")
 		}
 	}
-	if predecessor.State.State == StateCorrectionRequired && request.Disposition != RecoveryEscalated && request.MaintainerAuthorization != compactRecoveryAuthorizationBinding(request.PredecessorLineageID, predecessor.Revision, request.Successor.InitialSnapshot.Identity, request.Actor, request.Reason) {
+	if predecessor.State.State == StateCorrectionRequired && request.Disposition != RecoveryEscalated && !compactRecoveryAuthorizationMatches(request.MaintainerAuthorization, request.PredecessorLineageID, predecessor.Revision, request.Successor.InitialSnapshot.Identity, request.Actor, request.Reason) {
 		return CompactRecord{}, errors.New("correction-required scope recovery requires an exact maintainer authorization binding")
 	}
 	if !sameRecoveryProjection(predecessor.State.InitialSnapshot.Projection, request.Successor.InitialSnapshot.Projection) &&
@@ -242,7 +242,7 @@ func RecoverCompactAuthority(ctx context.Context, repo string, request CompactRe
 	}
 	if !sameRecoveryProjection(predecessor.State.InitialSnapshot.Projection, request.Successor.InitialSnapshot.Projection) &&
 		!stagedScopeRecovery &&
-		request.MaintainerAuthorization != compactRecoveryAuthorizationBinding(request.PredecessorLineageID, predecessor.Revision, request.Successor.InitialSnapshot.Identity, request.Actor, request.Reason) {
+		!compactRecoveryAuthorizationMatches(request.MaintainerAuthorization, request.PredecessorLineageID, predecessor.Revision, request.Successor.InitialSnapshot.Identity, request.Actor, request.Reason) {
 		return CompactRecord{}, compactRecoveryAuthorizationError(request.Successor.InitialSnapshot)
 	}
 	existing, existingErr := successorStore.Load()
@@ -456,7 +456,7 @@ func validateCompactRecoveryEdge(predecessor CompactRecord, successor CompactSta
 		}
 	case RecoveryEscalated:
 		if recovery.Evidence != nil {
-			if recovery.MaintainerAuthorization != compactRecoveryAuthorizationBinding(predecessor.State.LineageID, predecessor.Revision, successor.InitialSnapshot.Identity, recovery.Actor, recovery.Reason) {
+			if !compactRecoveryAuthorizationMatches(recovery.MaintainerAuthorization, predecessor.State.LineageID, predecessor.Revision, successor.InitialSnapshot.Identity, recovery.Actor, recovery.Reason) {
 				return compactRecoveryAuthorizationError(successor.InitialSnapshot)
 			}
 			if err := validateCompactRecoveredEvidenceEdge(predecessor, successor); err != nil {
@@ -471,7 +471,7 @@ func validateCompactRecoveryEdge(predecessor CompactRecord, successor CompactSta
 		if !compactEscalatedRecoveryTargetChanged(predecessor.State.CurrentSnapshot, successor.InitialSnapshot) {
 			return errCompactRecoveryTargetUnchanged
 		}
-		if recovery.MaintainerAuthorization != compactRecoveryAuthorizationBinding(predecessor.State.LineageID, predecessor.Revision, successor.InitialSnapshot.Identity, recovery.Actor, recovery.Reason) {
+		if !compactRecoveryAuthorizationMatches(recovery.MaintainerAuthorization, predecessor.State.LineageID, predecessor.Revision, successor.InitialSnapshot.Identity, recovery.Actor, recovery.Reason) {
 			return compactRecoveryAuthorizationError(successor.InitialSnapshot)
 		}
 	case RecoveryFinalVerificationRetry:
@@ -499,6 +499,55 @@ func compactRecoveryAuthorizationBinding(lineage, revision, targetIdentity, acto
 	return compactRecoveryAuthorizationSchema + "\npredecessor_lineage=" + lineage +
 		"\npredecessor_revision=" + revision + "\ntarget_identity=" + targetIdentity +
 		"\nactor=" + strings.TrimSpace(actor) + "\nreason=" + strings.TrimSpace(reason)
+}
+
+// parseCompactRecoveryAuthorizationBinding parses a maintainer authorization binding
+// for compact recovery. The binding starts with the schema header and continues with
+// key=value pairs, one per line. It tolerates trailing whitespace, optional fields,
+// field reordering, and either the 5-field form (without successor_lineage) or the
+// 6-field form (with successor_lineage). Returns ok=false when the schema header is
+// missing or any required field is absent.
+func parseCompactRecoveryAuthorizationBinding(s string) (lineage, revision, targetIdentity, successor, actor, reason string, ok bool) {
+	prefix := compactRecoveryAuthorizationSchema + "\n"
+	body := strings.TrimLeft(s, "\r\n\t ")
+	if !strings.HasPrefix(body, prefix) {
+		return "", "", "", "", "", "", false
+	}
+	body = body[len(prefix):]
+	fields := map[string]string{}
+	for _, line := range strings.Split(body, "\n") {
+		k, v, hasEq := strings.Cut(line, "=")
+		if !hasEq {
+			continue
+		}
+		fields[strings.TrimSpace(k)] = strings.TrimSpace(v)
+	}
+	lineage, lok := fields["predecessor_lineage"]
+	revision, rok := fields["predecessor_revision"]
+	targetIdentity, tok := fields["target_identity"]
+	actor, aok := fields["actor"]
+	reason, rok2 := fields["reason"]
+	if !lok || !rok || !tok || !aok || !rok2 {
+		return "", "", "", "", "", "", false
+	}
+	successor = fields["successor_lineage"]
+	return lineage, revision, targetIdentity, successor, actor, reason, true
+}
+
+// compactRecoveryAuthorizationMatches reports whether the user-supplied binding string
+// parses cleanly and matches the expected required fields. Field reordering, trailing
+// whitespace, and the optional successor_lineage field are tolerated; missing required
+// fields, wrong schema header, or any field mismatch rejects.
+func compactRecoveryAuthorizationMatches(s, lineage, revision, targetIdentity, actor, reason string) bool {
+	parsedLineage, parsedRevision, parsedTarget, _, parsedActor, parsedReason, ok := parseCompactRecoveryAuthorizationBinding(s)
+	if !ok {
+		return false
+	}
+	return parsedLineage == lineage &&
+		parsedRevision == revision &&
+		parsedTarget == targetIdentity &&
+		parsedActor == actor &&
+		parsedReason == reason
 }
 
 func compactApprovedStagedScopeRecoveryAuthorizationBinding(lineage, revision, targetIdentity, successor, actor, reason string) string {


### PR DESCRIPTION
Closes #1577

### Bug

`gentle-ai review recover --disposition escalated` never accepted the maintainer-authorization binding in v2.1.10 — every attempted binding format was rejected, leaving the documented recovery path for terminal-escalated lineages unusable.

### Root cause

`RecoverCompactAuthority` and `validateCompactRecoveryEdge` compared the user-supplied binding via byte-exact string equality against the canonical `compactRecoveryAuthorizationBinding` output. Any deviation — trailing LF, different field order, missing fields, alternative field naming, whitespace variations — caused the comparison to fail.

### Fix

Replaced byte-exact comparison with semantic field-by-field comparison via two new helpers:

- `parseCompactRecoveryAuthorizationBinding` parses the binding string into a key/value map. Accepts both the 5-field form (no `successor_lineage`) and the 6-field form (with `successor_lineage`), trailing whitespace, leading blank lines, field reordering, generous whitespace around `=`, and unknown extra fields. Rejects missing schema header, missing required fields, or unrecognized schema.
- `compactRecoveryAuthorizationMatches` checks parsed fields against expected values for predecessor_lineage, predecessor_revision, target_identity, actor, reason.

All four byte-exact `!=` comparisons are replaced with `!compactRecoveryAuthorizationMatches(...)`. Error messages are unchanged so existing tests asserting "maintainer authorization" and "authorization binding" substrings continue to pass.

### Acceptance criteria

- [x] A correctly-formed maintainer authorization bound to the changed successor target identity is accepted.
- [x] Trailing LF in the bound value is accepted.
- [x] Authorization passed as a file or as an inline value works identically.
- [x] Simplified actor/reason fields (any field value matching the documented format) are accepted.
- [x] Field reordering and whitespace variations are accepted.
- [x] A wrong binding (wrong predecessor_lineage or wrong predecessor_revision or wrong target_identity) is still rejected.

### Tests added

- `TestParseCompactRecoveryAuthorizationBinding5FieldForm`
- `TestParseCompactRecoveryAuthorizationBinding6FieldForm`
- `TestParseCompactRecoveryAuthorizationBindingToleratesReorderingAndWhitespace`
- `TestParseCompactRecoveryAuthorizationBindingRejectsInvalidForms`
- `TestCompactRecoveryAuthorizationMatchesAcceptsEquivalentForms`
- `TestCompactRecoveryAuthorizationMatchesRejectsMismatchedFields`

All 6 new tests pass. The pre-existing Windows git-timeout test (`TestCompactPrePRChainRejectsInvalidMembersAndBindings/policy_substitution`) is a known environmental issue unrelated to this fix.

### Files

- MODIFY: `internal/reviewtransaction/compact_store.go` — add `parseCompactRecoveryAuthorizationBinding` and `compactRecoveryAuthorizationMatches` helpers, replace 4 byte-exact comparisons with semantic comparisons.
- MODIFY: `internal/reviewtransaction/compact_recovery_binding_test.go` — add 6 new tests covering parser and matcher behavior.

Estimated diff: +171/-4 LOC across 2 files. Well under the 400-LOC review budget.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Recovery authorization bindings now support flexible formatting, including field reordering, whitespace variations, and an optional successor lineage field.

* **Bug Fixes**
  * Valid recovery authorizations are no longer rejected solely because their formatting differs.
  * Invalid or incomplete authorizations continue to be rejected, including those with mismatched required values.

* **Tests**
  * Added coverage for supported binding formats, invalid inputs, formatting variations, and mismatched authorization details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->