### PR TITLE
fix(review): filter unrelated authority before ambiguity

### DIFF
--- a/internal/cli/review_receipt_discovery_test.go
+++ b/internal/cli/review_receipt_discovery_test.go
@@ -397,9 +397,10 @@ func TestUnqualifiedGateDiscoveryRequiresSelectionForMultipleScopeChangedReceipt
 		name       string
 		projection reviewtransaction.Projection
 		gate       reviewtransaction.GateKind
+		status     reviewtransaction.TargetApplicability
 	}{
-		{name: "workspace", projection: reviewtransaction.ProjectionWorkspace, gate: reviewtransaction.GatePostApply},
-		{name: "staged", projection: reviewtransaction.ProjectionStaged, gate: reviewtransaction.GatePreCommit},
+		{name: "workspace", projection: reviewtransaction.ProjectionWorkspace, gate: reviewtransaction.GatePostApply, status: reviewtransaction.TargetApplicabilityUnrelated},
+		{name: "staged", projection: reviewtransaction.ProjectionStaged, gate: reviewtransaction.GatePreCommit, status: reviewtransaction.TargetApplicabilityAmbiguous},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			repo := initReviewCLIRepo(t)
@@ -443,8 +444,9 @@ func TestUnqualifiedGateDiscoveryRequiresSelectionForMultipleScopeChangedReceipt
 			}
 			var status ReviewTargetStatusResult
 			decodeStrictReviewJSON(t, output.Bytes(), &status)
-			if status.Applicability != reviewtransaction.TargetApplicabilityAmbiguous || status.Action != reviewtransaction.TargetStatusActionSelectLineage ||
-				status.Replayability != reviewtransaction.ReplayabilityStatusRequired || !reflect.DeepEqual(status.Candidates, lineages) {
+			if status.Applicability != tt.status || tt.status == reviewtransaction.TargetApplicabilityAmbiguous &&
+				(status.Action != reviewtransaction.TargetStatusActionSelectLineage || status.Replayability != reviewtransaction.ReplayabilityStatusRequired ||
+					!reflect.DeepEqual(status.Candidates, lineages)) {
 				t.Fatalf("multiple scope-changed status = %#v", status)
 			}
 

--- a/internal/reviewtransaction/target_status.go
+++ b/internal/reviewtransaction/target_status.go
@@ -97,7 +97,6 @@ type targetStatusCandidate struct {
 	legacyStore        *Store
 	receiptIdentity    string
 	receiptPublished   bool
-	receiptCanonical   bool
 	receiptReplayable  bool
 	pendingFinalize    bool
 	correctionRecovery bool
@@ -146,7 +145,6 @@ func assessTargetStatusSnapshot(ctx context.Context, repo string, request Target
 	}
 
 	candidates := []targetStatusCandidate{}
-	scopeChangedCandidates := []targetStatusCandidate{}
 	for lineage, candidate := range view.compact {
 		if request.LineageID != "" && request.LineageID != lineage {
 			continue
@@ -161,12 +159,20 @@ func assessTargetStatusSnapshot(ctx context.Context, repo string, request Target
 			candidates = append(candidates, candidate)
 			continue
 		}
-		if state.State == StateApproved && candidate.receiptPublished && candidate.receiptCanonical {
+		if state.State == StateApproved && candidate.receiptPublished {
 			eligible, eligibilityErr := compactApprovedStagedScopeRecovery(ctx, repo, state, live)
 			if eligibilityErr != nil {
 				return targetStatusFailure(base, eligibilityErr)
 			}
 			if eligible {
+				candidate.correctionRecovery = true
+				candidate.recoveryDisposition = RecoveryScopeChanged
+				candidates = append(candidates, candidate)
+				continue
+			}
+			requested := state
+			requested.InitialSnapshot = live
+			if state.CurrentSnapshot.CandidateTree != live.CandidateTree && compactStartDeliveryScopeMatches(state, requested) {
 				candidate.correctionRecovery = true
 				candidate.recoveryDisposition = RecoveryScopeChanged
 				candidates = append(candidates, candidate)
@@ -207,11 +213,6 @@ func assessTargetStatusSnapshot(ctx context.Context, repo string, request Target
 			candidates = append(candidates, candidate)
 			continue
 		}
-		if request.LineageID == "" && candidate.receiptPublished && (state.State == StateApproved || state.State == StateEscalated) {
-			if projectCompactTerminalHistory(state, live) == compactTerminalHistoryScopeChanged {
-				scopeChangedCandidates = append(scopeChangedCandidates, candidate)
-			}
-		}
 	}
 	for lineage, candidate := range view.legacy {
 		if request.LineageID != "" && request.LineageID != lineage {
@@ -240,18 +241,6 @@ func assessTargetStatusSnapshot(ctx context.Context, repo string, request Target
 		}
 		return candidates[i].version < candidates[j].version
 	})
-	sort.Slice(scopeChangedCandidates, func(i, j int) bool {
-		return scopeChangedCandidates[i].lineage < scopeChangedCandidates[j].lineage
-	})
-	if len(candidates) == 0 && len(scopeChangedCandidates) > 1 {
-		base.Applicability = TargetApplicabilityAmbiguous
-		base.Action = TargetStatusActionSelectLineage
-		base.Replayability = ReplayabilityStatusRequired
-		for _, candidate := range scopeChangedCandidates {
-			base.CandidateLineageIDs = append(base.CandidateLineageIDs, candidate.lineage)
-		}
-		return base, nil
-	}
 	switch len(candidates) {
 	case 0:
 		base.Applicability = TargetApplicabilityUnrelated

--- a/internal/reviewtransaction/target_status_projection.go
+++ b/internal/reviewtransaction/target_status_projection.go
@@ -1,7 +1,6 @@
 package reviewtransaction
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -164,7 +163,6 @@ func loadStableCompactTargetStatusCandidate(ctx context.Context, store CompactSt
 		return targetStatusCandidate{
 			version: AuthorityVersionCompact, lineage: observed.State.LineageID, compact: &copy,
 			receiptIdentity: second.receipt.artifact.identity, receiptPublished: second.receipt.published,
-			receiptCanonical:  bytes.Equal(second.receipt.artifact.content, second.receipt.artifact.canonical),
 			receiptReplayable: second.receipt.replayable, pendingFinalize: second.journal.pending,
 		}, nil
 	}
@@ -268,41 +266,6 @@ func loadLegacyTargetStatusCandidates(ctx context.Context, repo, lineageID strin
 		}
 	}
 	return candidates, nil
-}
-
-type compactTerminalHistoryProjection uint8
-
-const (
-	compactTerminalHistoryUnrelated compactTerminalHistoryProjection = iota
-	compactTerminalHistoryScopeChanged
-)
-
-// projectCompactTerminalHistory compares receipt-validated historical
-// authority with the one request-scoped live snapshot. Frozen intended paths
-// remain historical proof; they are never replayed against current tracking or
-// filesystem membership.
-func projectCompactTerminalHistory(state CompactState, live Snapshot) compactTerminalHistoryProjection {
-	if live.BaseTree == state.CurrentSnapshot.CandidateTree {
-		// The reviewed bytes and modes are now the immutable HEAD base. A clean
-		// target or a disjoint next slice is not an applicability claim on the
-		// historical receipt.
-		if len(live.Paths) == 0 || classifyCompactPathSetRelation(state.GenesisPaths, live.Paths) == compactPathsDisjoint {
-			return compactTerminalHistoryUnrelated
-		}
-		return compactTerminalHistoryScopeChanged
-	}
-
-	relation := classifyCompactTargetRelation(state.CurrentSnapshot, live, state.GenesisPaths, compactTargetRelationEvidence{})
-	if relation.Kind != compactTargetUnsafe {
-		return compactTerminalHistoryScopeChanged
-	}
-	// A projection, kind, or base mismatch can make the aggregate relation
-	// unsafe even when live work still contracts or overlaps immutable genesis
-	// scope. That is related evolution and must not be claimed as unrelated.
-	if len(live.Paths) > 0 && relation.Paths != compactPathsDisjoint && relation.Paths != compactPathsInvalid {
-		return compactTerminalHistoryScopeChanged
-	}
-	return compactTerminalHistoryUnrelated
 }
 
 func compactLiveTargetMatchesValidatedSnapshot(state CompactState, live Snapshot, requireCurrentCandidate bool) bool {

--- a/internal/reviewtransaction/target_status_test.go
+++ b/internal/reviewtransaction/target_status_test.go
@@ -230,6 +230,188 @@ func TestAssessTargetStatusClassifiesAllApplicabilityStates(t *testing.T) {
 	})
 }
 
+func TestHistoricalAuthorityDoesNotMakeFreshBaseDiffAmbiguous(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	writeSnapshotFile(t, repo, "tracked.txt", "historical\n")
+	historical := newCompactTestState(t, repo, "historical-template")
+	results := make([]LensResult, len(historical.SelectedLenses))
+	for index, lens := range historical.SelectedLenses {
+		results[index] = LensResult{Lens: lens, Findings: []Finding{}, Evidence: []string{"reviewed"}}
+	}
+	if err := historical.CompleteReview(CompactReviewInput{LensResults: results, Classifications: []FindingEvidence{}, RefuterOutcomes: []EvidenceResult{}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := historical.CompleteVerification([]byte("verified\n"), true); err != nil {
+		t.Fatal(err)
+	}
+	lineages := make([]string, 20)
+	authorityBefore := map[string][]byte{}
+	rememberAuthority := func(path string) {
+		payload, readErr := os.ReadFile(path)
+		if readErr != nil {
+			t.Fatal(readErr)
+		}
+		authorityBefore[path] = payload
+	}
+	for index := range lineages {
+		lineages[index] = fmt.Sprintf("historical-%02d", index)
+		candidate := historical
+		candidate.LineageID = lineages[index]
+		store := writeTerminalTargetStatusAuthority(t, repo, candidate)
+		rememberAuthority(store.StatePath())
+		rememberAuthority(store.ReceiptPath())
+	}
+	if err := runSnapshotGit(repo, "add", "tracked.txt"); err != nil {
+		t.Fatal(err)
+	}
+	if err := runSnapshotGit(repo, "commit", "-m", "historical target"); err != nil {
+		t.Fatal(err)
+	}
+
+	zero := newCompactTestState(t, repo, "approved-zero-path")
+	if err := zero.CompleteReview(CompactReviewInput{LensResults: []LensResult{}, Classifications: []FindingEvidence{}, RefuterOutcomes: []EvidenceResult{}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := zero.CompleteVerification([]byte("verified\n"), true); err != nil {
+		t.Fatal(err)
+	}
+	zeroStore := writeTerminalTargetStatusAuthority(t, repo, zero)
+	rememberAuthority(zeroStore.StatePath())
+	rememberAuthority(zeroStore.ReceiptPath())
+
+	writeSnapshotFile(t, repo, "tracked.txt", "fresh base diff\n")
+	if err := runSnapshotGit(repo, "add", "tracked.txt"); err != nil {
+		t.Fatal(err)
+	}
+	if err := runSnapshotGit(repo, "commit", "-m", "fresh target"); err != nil {
+		t.Fatal(err)
+	}
+	target := Target{Kind: TargetBaseDiff, BaseRef: "HEAD~1", IntendedUntracked: []string{}}
+	live, err := (SnapshotBuilder{Repo: repo}).Build(context.Background(), target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, lineage := range append(lineages, zero.LineageID) {
+		status, statusErr := AssessTargetStatus(context.Background(), repo, TargetStatusRequest{Target: target, LineageID: lineage})
+		if statusErr != nil || status.Applicability != TargetApplicabilityUnrelated || status.Action != TargetStatusActionStart {
+			t.Fatalf("explicit status for %q = %#v, %v", lineage, status, statusErr)
+		}
+	}
+
+	status, err := AssessTargetStatus(context.Background(), repo, TargetStatusRequest{Target: target})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.Applicability != TargetApplicabilityUnrelated || status.Action != TargetStatusActionStart || len(status.CandidateLineageIDs) != 0 {
+		t.Fatalf("unqualified status = %#v", status)
+	}
+	risk, lines, err := (SnapshotBuilder{Repo: repo}).ClassifySnapshotRisk(context.Background(), live)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lenses := []string{}
+	if risk == RiskMedium {
+		lenses = []string{LensReliability}
+	} else if risk == RiskHigh {
+		lenses = append([]string(nil), supportedLenses...)
+	}
+	started, err := NewCompactState(Start{LineageID: "fresh-base-diff", Mode: ModeOrdinaryBounded, Generation: 1, Snapshot: live, PolicyHash: hash("1"), RiskLevel: risk, SelectedLenses: lenses, OriginalChangedLines: &lines})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := StartCompactAuthority(context.Background(), repo, CompactStartRequest{State: started})
+	if err != nil || result.Action != CompactStartCreated || result.Record.State.InitialSnapshot.Identity != status.TargetIdentity {
+		t.Fatalf("START = %#v, %v; status = %#v", result, err, status)
+	}
+	for path, before := range authorityBefore {
+		if after, readErr := os.ReadFile(path); readErr != nil || !bytes.Equal(before, after) {
+			t.Fatalf("historical authority changed at %q: %v", path, readErr)
+		}
+	}
+}
+
+func TestApprovedSamePathHistoryBehindInterveningBaseIsUnrelated(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	writeSnapshotFile(t, repo, "tracked.txt", "historical\n")
+	historical := newCompactTestState(t, repo, "historical-same-path")
+	results := make([]LensResult, len(historical.SelectedLenses))
+	for index, lens := range historical.SelectedLenses {
+		results[index] = LensResult{Lens: lens, Findings: []Finding{}, Evidence: []string{"reviewed"}}
+	}
+	if err := historical.CompleteReview(CompactReviewInput{LensResults: results}); err != nil {
+		t.Fatal(err)
+	}
+	if err := historical.CompleteVerification([]byte("verified\n"), true); err != nil {
+		t.Fatal(err)
+	}
+	writeTerminalTargetStatusAuthority(t, repo, historical)
+	gitSnapshot(t, repo, "add", "tracked.txt")
+	gitSnapshot(t, repo, "commit", "-m", "historical target")
+	writeSnapshotFile(t, repo, "tracked.txt", "intervening base\n")
+	gitSnapshot(t, repo, "add", "tracked.txt")
+	gitSnapshot(t, repo, "commit", "-m", "intervening base")
+	writeSnapshotFile(t, repo, "tracked.txt", "fresh target\n")
+
+	target := Target{Kind: TargetCurrentChanges, IntendedUntracked: []string{}}
+	status, err := AssessTargetStatus(context.Background(), repo, TargetStatusRequest{Target: target})
+	if err != nil || status.Applicability != TargetApplicabilityUnrelated || status.Action != TargetStatusActionStart {
+		t.Fatalf("STATUS = %#v, %v", status, err)
+	}
+	requested := newCompactTestState(t, repo, "fresh-same-path")
+	started, err := StartCompactAuthority(context.Background(), repo, CompactStartRequest{State: requested})
+	if err != nil || started.Action != CompactStartCreated || started.Record.State.LineageID != requested.LineageID {
+		t.Fatalf("START = %#v, %v", started, err)
+	}
+}
+
+func TestApprovedScopeRelationDoesNotAuthorizeRecovery(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		overlap bool
+	}{
+		{name: "contraction"},
+		{name: "overlap", overlap: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := initSnapshotRepo(t)
+			writeSnapshotFile(t, repo, "a.go", "package a\n")
+			writeSnapshotFile(t, repo, "b.go", "package b\n")
+			approved := newCompactStartStateForTarget(t, repo, "approved-"+tt.name, Target{
+				Kind: TargetCurrentChanges, IntendedUntracked: []string{"a.go", "b.go"},
+			})
+			results := make([]LensResult, len(approved.SelectedLenses))
+			for i, lens := range approved.SelectedLenses {
+				results[i] = LensResult{Lens: lens, Findings: []Finding{}, Evidence: []string{"reviewed"}}
+			}
+			if err := approved.CompleteReview(CompactReviewInput{LensResults: results, Classifications: []FindingEvidence{}, RefuterOutcomes: []EvidenceResult{}}); err != nil {
+				t.Fatal(err)
+			}
+			if err := approved.CompleteVerification([]byte("verified\n"), true); err != nil {
+				t.Fatal(err)
+			}
+			writeTerminalTargetStatusAuthority(t, repo, approved)
+			if err := os.Remove(filepath.Join(repo, "b.go")); err != nil {
+				t.Fatal(err)
+			}
+			intended := []string{"a.go"}
+			if tt.overlap {
+				writeSnapshotFile(t, repo, "x.go", "package x\n")
+				intended = append(intended, "x.go")
+			}
+			target := Target{Kind: TargetCurrentChanges, IntendedUntracked: intended}
+			status, err := AssessTargetStatus(context.Background(), repo, TargetStatusRequest{Target: target})
+			if err != nil || status.Applicability != TargetApplicabilityUnrelated || status.Action != TargetStatusActionStart {
+				t.Fatalf("STATUS = %#v, %v", status, err)
+			}
+			requested := newCompactStartStateForTarget(t, repo, "fresh-"+tt.name, target)
+			started, err := StartCompactAuthority(context.Background(), repo, CompactStartRequest{State: requested})
+			if err != nil || started.Action != CompactStartCreated || started.Record.State.LineageID != requested.LineageID {
+				t.Fatalf("START = %#v, %v", started, err)
+			}
+		})
+	}
+}
+
 func TestAssessTargetStatusRecognizesAuthorizedCorrection(t *testing.T) {
 	repo := initSnapshotRepo(t)
 	writeSnapshotFile(t, repo, "tracked.txt", "base\none\ntwo\nthree\nfour\n")
@@ -650,6 +832,36 @@ func TestAssessTargetStatusReportsAmbiguousApprovedStagedScopeExpansion(t *testi
 	if got.Applicability != TargetApplicabilityAmbiguous || got.Action != TargetStatusActionSelectLineage ||
 		!equalStrings(got.CandidateLineageIDs, []string{"staged-status-first", "staged-status-second"}) {
 		t.Fatalf("ambiguous staged scope status = %#v", got)
+	}
+}
+
+func TestApprovedNoncanonicalRecoveryCandidatesStayAmbiguous(t *testing.T) {
+	repo := initSnapshotRepo(t)
+	writeSnapshotFile(t, repo, "tracked.txt", "reviewed\n")
+	first, firstStore, _ := approvedCompactCurrentChangesFixture(t, repo, "noncanonical-first", []string{})
+	second := first
+	second.LineageID = "noncanonical-second"
+	secondStore := writeTerminalTargetStatusAuthority(t, repo, second)
+	for _, store := range []CompactStore{firstStore, secondStore} {
+		receipt, err := os.ReadFile(store.ReceiptPath())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(store.ReceiptPath(), append(receipt, '\n'), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writeSnapshotFile(t, repo, "tracked.txt", "changed candidate\n")
+	target := Target{Kind: TargetCurrentChanges, IntendedUntracked: []string{}}
+	status, err := AssessTargetStatus(context.Background(), repo, TargetStatusRequest{Target: target})
+	if err != nil || status.Applicability != TargetApplicabilityAmbiguous || status.Action != TargetStatusActionSelectLineage ||
+		!reflect.DeepEqual(status.CandidateLineageIDs, []string{first.LineageID, second.LineageID}) {
+		t.Fatalf("STATUS = %#v, %v", status, err)
+	}
+	requested := newCompactTestState(t, repo, "noncanonical-fresh")
+	started, err := StartCompactAuthority(context.Background(), repo, CompactStartRequest{State: requested})
+	if err != nil || started.Action != CompactStartBlocked {
+		t.Fatalf("START = %#v, %v", started, err)
 	}
 }
 


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #1466

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change)

## 📝 Summary

- Filter receipt-validated historical authority by exact target applicability before declaring ambiguity.
- Keep STATUS, START, and gate discovery aligned for intervening bases, scope contraction/overlap, and canonical or noncanonical valid receipts.
- Preserve fail-closed handling for true ambiguity, recovery candidates, corrupt graphs, receipts, and provenance.

## 📂 Changes

| File / Area | Change |
|---|---|
| `internal/reviewtransaction/target_status.go` | Reuse START delivery-scope predicates for STATUS candidate admission. |
| `internal/reviewtransaction/target_status_projection.go` | Remove historical path-overlap projection that fabricated applicability. |
| `internal/reviewtransaction/target_status_test.go` | Cover unrelated histories, zero-path authority, intervening bases, contraction/overlap, and noncanonical receipts. |
| `internal/cli/review_receipt_discovery_test.go` | Keep gate discovery and target STATUS expectations consistent. |

## 🧪 Test Plan

- [x] Focused #1466 regressions pass.
- [x] `go test -count=1 ./internal/reviewtransaction`
- [x] `go test -race -count=1 ./internal/reviewtransaction`
- [x] Focused CLI receipt-discovery tests.
- [x] `go run ./internal/gofmtcheck`
- [x] `go vet ./...`
- [x] Review contract inventory and capabilities harness.
- [x] `git diff --check`
- [x] Full native 4R review approved; pre-push and pre-PR receipts validated.
- [x] The isolated Kimi installer test passes with `uv` absent from `PATH`; the unrestricted full suite only hits that known environment-sensitive condition because `uv` is installed locally.

## ✅ Contributor Checklist

- [x] Linked approved issue #1466.
- [x] Diff remains below 400 changed lines.
- [x] Exactly one `type:*` label requested.
- [x] Conventional commit, no `Co-Authored-By` trailer.
- [x] Documentation not required for this narrow behavioral correction.

## Rollback

Revert commit `fc9a146710da5e3d4467def6e0261a6ad2af7246`; authority schemas and migrations are unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved target status detection for scope changes and historical authorities.
  * Prevented unrelated historical changes from being treated as ambiguous or eligible for recovery.
  * Improved recovery handling when approved changes have a published receipt.
  * Preserved ambiguity when multiple noncanonical recovery paths exist, prompting lineage selection instead of choosing automatically.
  * Prevented compact operations from starting when recovery authority is unclear.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->