### PR TITLE
fix(review): ignore unrelated terminal authority

### DIFF
--- a/internal/cli/review_receipt_discovery_test.go
+++ b/internal/cli/review_receipt_discovery_test.go
@@ -443,8 +443,14 @@ func TestUnqualifiedGateDiscoveryRequiresSelectionForMultipleScopeChangedReceipt
 			}
 			var status ReviewTargetStatusResult
 			decodeStrictReviewJSON(t, output.Bytes(), &status)
-			if status.Applicability != reviewtransaction.TargetApplicabilityAmbiguous || status.Action != reviewtransaction.TargetStatusActionSelectLineage ||
-				status.Replayability != reviewtransaction.ReplayabilityStatusRequired || !reflect.DeepEqual(status.Candidates, lineages) {
+			if tt.projection == reviewtransaction.ProjectionWorkspace &&
+				(status.Applicability != reviewtransaction.TargetApplicabilityUnrelated || status.Action != reviewtransaction.TargetStatusActionStart ||
+					status.Replayability != reviewtransaction.ReplayabilityNotReplayable || len(status.Candidates) != 0) {
+				t.Fatalf("multiple scope-changed workspace status = %#v", status)
+			}
+			if tt.projection == reviewtransaction.ProjectionStaged &&
+				(status.Applicability != reviewtransaction.TargetApplicabilityAmbiguous || status.Action != reviewtransaction.TargetStatusActionSelectLineage ||
+					status.Replayability != reviewtransaction.ReplayabilityStatusRequired || !reflect.DeepEqual(status.Candidates, lineages)) {
 				t.Fatalf("multiple scope-changed status = %#v", status)
 			}
 

--- a/internal/cli/review_status_contract_test.go
+++ b/internal/cli/review_status_contract_test.go
@@ -830,7 +830,15 @@ func TestNegotiatedReviewStatusCompletesWithOneHundredHistoricalLeaves(t *testin
 	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("reviewed candidate\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	writeNegotiatedStatusHistory(t, repo, 100)
+	approved, escalated := writeNegotiatedStatusHistory(t, repo, 100)
+	if approved != 50 || escalated != 50 {
+		t.Fatalf("terminal history = %d approved, %d escalated; want 50 of each", approved, escalated)
+	}
+	runReviewCLIGit(t, repo, "add", "tracked.txt")
+	runReviewCLIGit(t, repo, "commit", "-qm", "deliver historical target")
+	commonDir := strings.TrimSpace(runReviewCLIGit(t, repo, "rev-parse", "--path-format=absolute", "--git-common-dir"))
+	authorityRoot := filepath.Join(commonDir, "gentle-ai", "review-transactions", "v2")
+	historyBefore := readReviewAuthorityFiles(t, authorityRoot)
 	if stores, err := reviewtransaction.CompactAuthorityLeaves(context.Background(), repo); err != nil {
 		t.Fatalf("load generated status history: %v", err)
 	} else if len(stores) != 100 {
@@ -854,11 +862,51 @@ func TestNegotiatedReviewStatusCompletesWithOneHundredHistoricalLeaves(t *testin
 	if err := json.Unmarshal(output.Bytes(), &status); err != nil {
 		t.Fatal(err)
 	}
-	if status.Applicability != reviewtransaction.TargetApplicabilityAmbiguous ||
-		status.Action != reviewtransaction.TargetStatusActionSelectLineage || len(status.Candidates) != 100 {
+	if status.Applicability != reviewtransaction.TargetApplicabilityUnrelated ||
+		status.Action != reviewtransaction.TargetStatusActionStart || len(status.Candidates) != 0 {
 		t.Fatalf("negotiated 100-leaf status = %#v", status)
 	}
+	var startOutput bytes.Buffer
+	if err := RunReviewFacadeStart([]string{"--cwd", repo, "--lineage", "unrelated-history-start"}, &startOutput); err != nil {
+		t.Fatal(err)
+	}
+	var startedReview ReviewFacadeStartResult
+	if err := json.Unmarshal(startOutput.Bytes(), &startedReview); err != nil {
+		t.Fatal(err)
+	}
+	if startedReview.Action != string(reviewtransaction.CompactStartCreated) {
+		t.Fatalf("START after unrelated status = %#v", startedReview)
+	}
+	for path, before := range historyBefore {
+		after, readErr := os.ReadFile(path)
+		if readErr != nil || !bytes.Equal(before, after) {
+			t.Fatalf("START changed unrelated authority %q: err=%v", path, readErr)
+		}
+	}
 	t.Logf("negotiated status completed 100 terminal histories in %s within the %s contract deadline", elapsed, reviewFacadeOperationTimeout)
+}
+
+func readReviewAuthorityFiles(t *testing.T, root string) map[string][]byte {
+	t.Helper()
+	files := map[string][]byte{}
+	err := filepath.Walk(root, func(path string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if info.IsDir() {
+			return nil
+		}
+		payload, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		files[path] = payload
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return files
 }
 
 func TestNegotiatedReviewStatusReturnsFailureForUnreadableAuthority(t *testing.T) {
@@ -897,7 +945,7 @@ func TestNegotiatedReviewStatusReturnsFailureForUnreadableAuthority(t *testing.T
 	}
 }
 
-func writeNegotiatedStatusHistory(t *testing.T, repo string, count int) {
+func writeNegotiatedStatusHistory(t *testing.T, repo string, count int) (approvedCount, escalatedCount int) {
 	t.Helper()
 	snapshot, err := (reviewtransaction.SnapshotBuilder{Repo: repo}).Build(context.Background(), reviewtransaction.Target{
 		Kind: reviewtransaction.TargetCurrentChanges, IntendedUntracked: []string{},
@@ -945,8 +993,14 @@ func writeNegotiatedStatusHistory(t *testing.T, repo string, count int) {
 		}); err != nil {
 			t.Fatal(err)
 		}
-		if err := state.CompleteVerification([]byte("verified\n"), true); err != nil {
+		approved := index%2 == 0
+		if err := state.CompleteVerification([]byte("verified\n"), approved); err != nil {
 			t.Fatal(err)
+		}
+		if approved {
+			approvedCount++
+		} else {
+			escalatedCount++
 		}
 		statePayload, err := json.Marshal(state)
 		if err != nil {
@@ -975,4 +1029,5 @@ func writeNegotiatedStatusHistory(t *testing.T, repo string, count int) {
 			t.Fatal(err)
 		}
 	}
+	return approvedCount, escalatedCount
 }

--- a/internal/reviewtransaction/compact_store.go
+++ b/internal/reviewtransaction/compact_store.go
@@ -766,10 +766,11 @@ func StartCompactAuthority(ctx context.Context, repo string, request CompactStar
 	requestedClaims := false
 	for _, store := range leaves {
 		existing := records[store.lineageID].State
-		if existing.State == StateEscalated && compactStartDeliveryScopeMatches(existing, request.State) {
-			if compactEscalatedRecoveryTargetChanged(existing.CurrentSnapshot, request.State.InitialSnapshot) {
+		if existing.State == StateEscalated || existing.State == StateApproved {
+			switch classifyCompactTerminalStartDisposition(existing, request.State.InitialSnapshot) {
+			case compactTerminalStartRecovery:
 				recoveryCandidates = append(recoveryCandidates, store)
-			} else {
+			case compactTerminalStartClaimant:
 				claimants = append(claimants, store)
 				requestedClaims = requestedClaims || store.lineageID == request.State.LineageID
 			}
@@ -788,11 +789,6 @@ func StartCompactAuthority(ctx context.Context, repo string, request CompactStar
 			case compactCorrectionTargetRecover:
 				recoveryCandidates = append(recoveryCandidates, store)
 			}
-			continue
-		}
-		if existing.State == StateApproved && compactStartDeliveryScopeMatches(existing, request.State) &&
-			existing.CurrentSnapshot.CandidateTree != request.State.InitialSnapshot.CandidateTree {
-			recoveryCandidates = append(recoveryCandidates, store)
 			continue
 		}
 		if compactStartClaimsTarget(ctx, requestedStore.repo, existing, request.State) {
@@ -993,6 +989,39 @@ func compactStartClaimsTarget(ctx context.Context, repo string, existing, reques
 	}
 	candidate := requested.InitialSnapshot.CandidateTree
 	return candidate == existing.InitialSnapshot.CandidateTree || candidate == existing.CurrentSnapshot.CandidateTree
+}
+
+type compactTerminalStartDisposition uint8
+
+const (
+	compactTerminalStartUnrelated compactTerminalStartDisposition = iota
+	compactTerminalStartClaimant
+	compactTerminalStartRecovery
+)
+
+// classifyCompactTerminalStartDisposition is shared by STATUS and locked START
+// after graph validation and live-snapshot validation have completed.
+func classifyCompactTerminalStartDisposition(existing CompactState, live Snapshot) compactTerminalStartDisposition {
+	requested := existing
+	requested.InitialSnapshot = live
+	switch existing.State {
+	case StateEscalated:
+		if !compactStartDeliveryScopeMatches(existing, requested) {
+			return compactTerminalStartUnrelated
+		}
+		if compactEscalatedRecoveryTargetChanged(existing.CurrentSnapshot, live) {
+			return compactTerminalStartRecovery
+		}
+		return compactTerminalStartClaimant
+	case StateApproved:
+		if compactLiveTargetMatchesValidatedSnapshot(existing, live, true) {
+			return compactTerminalStartClaimant
+		}
+		if compactStartDeliveryScopeMatches(existing, requested) && existing.CurrentSnapshot.CandidateTree != live.CandidateTree {
+			return compactTerminalStartRecovery
+		}
+	}
+	return compactTerminalStartUnrelated
 }
 
 // compactStartDeliveryScopeMatches compares the immutable delivery boundary

--- a/internal/reviewtransaction/target_status.go
+++ b/internal/reviewtransaction/target_status.go
@@ -146,7 +146,6 @@ func assessTargetStatusSnapshot(ctx context.Context, repo string, request Target
 	}
 
 	candidates := []targetStatusCandidate{}
-	scopeChangedCandidates := []targetStatusCandidate{}
 	for lineage, candidate := range view.compact {
 		if request.LineageID != "" && request.LineageID != lineage {
 			continue
@@ -174,20 +173,20 @@ func assessTargetStatusSnapshot(ctx context.Context, repo string, request Target
 			}
 		}
 		if state.State == StateEscalated {
-			requested := state
-			requested.InitialSnapshot = live
-			if compactStartDeliveryScopeMatches(state, requested) {
-				candidate.correctionRecovery = compactEscalatedRecoveryTargetChanged(state.CurrentSnapshot, live)
-				if candidate.correctionRecovery {
-					candidate.recoveryDisposition = RecoveryEscalated
-				} else if eligibility, ok, inspectErr := InspectCompactFinalVerificationRetrySource(ctx, repo, state.LineageID, candidate.compact.Revision); inspectErr != nil {
+			switch classifyCompactTerminalStartDisposition(state, live) {
+			case compactTerminalStartRecovery:
+				candidate.correctionRecovery = true
+				candidate.recoveryDisposition = RecoveryEscalated
+				candidates = append(candidates, candidate)
+			case compactTerminalStartClaimant:
+				if eligibility, ok, inspectErr := InspectCompactFinalVerificationRetrySource(ctx, repo, state.LineageID, candidate.compact.Revision); inspectErr != nil {
 					return targetStatusFailure(base, inspectErr)
 				} else if ok {
 					candidate.finalVerificationRetry = &eligibility
 				}
 				candidates = append(candidates, candidate)
-				continue
 			}
+			continue
 		} else if state.State == StateCorrectionRequired {
 			claim, claimErr := classifyCompactCorrectionTargetForStatus(ctx, repo, state, live)
 			if claimErr != nil {
@@ -203,14 +202,18 @@ func assessTargetStatusSnapshot(ctx context.Context, repo string, request Target
 				candidates = append(candidates, candidate)
 				continue
 			}
+		} else if state.State == StateApproved {
+			switch classifyCompactTerminalStartDisposition(state, live) {
+			case compactTerminalStartClaimant:
+				candidates = append(candidates, candidate)
+			case compactTerminalStartRecovery:
+				candidate.correctionRecovery = true
+				candidate.recoveryDisposition = RecoveryScopeChanged
+				candidates = append(candidates, candidate)
+			}
+			continue
 		} else if compactLiveTargetMatchesValidatedSnapshot(state, live, true) {
 			candidates = append(candidates, candidate)
-			continue
-		}
-		if request.LineageID == "" && candidate.receiptPublished && (state.State == StateApproved || state.State == StateEscalated) {
-			if projectCompactTerminalHistory(state, live) == compactTerminalHistoryScopeChanged {
-				scopeChangedCandidates = append(scopeChangedCandidates, candidate)
-			}
 		}
 	}
 	for lineage, candidate := range view.legacy {
@@ -240,18 +243,6 @@ func assessTargetStatusSnapshot(ctx context.Context, repo string, request Target
 		}
 		return candidates[i].version < candidates[j].version
 	})
-	sort.Slice(scopeChangedCandidates, func(i, j int) bool {
-		return scopeChangedCandidates[i].lineage < scopeChangedCandidates[j].lineage
-	})
-	if len(candidates) == 0 && len(scopeChangedCandidates) > 1 {
-		base.Applicability = TargetApplicabilityAmbiguous
-		base.Action = TargetStatusActionSelectLineage
-		base.Replayability = ReplayabilityStatusRequired
-		for _, candidate := range scopeChangedCandidates {
-			base.CandidateLineageIDs = append(base.CandidateLineageIDs, candidate.lineage)
-		}
-		return base, nil
-	}
 	switch len(candidates) {
 	case 0:
 		base.Applicability = TargetApplicabilityUnrelated

--- a/internal/reviewtransaction/target_status_projection.go
+++ b/internal/reviewtransaction/target_status_projection.go
@@ -270,41 +270,6 @@ func loadLegacyTargetStatusCandidates(ctx context.Context, repo, lineageID strin
 	return candidates, nil
 }
 
-type compactTerminalHistoryProjection uint8
-
-const (
-	compactTerminalHistoryUnrelated compactTerminalHistoryProjection = iota
-	compactTerminalHistoryScopeChanged
-)
-
-// projectCompactTerminalHistory compares receipt-validated historical
-// authority with the one request-scoped live snapshot. Frozen intended paths
-// remain historical proof; they are never replayed against current tracking or
-// filesystem membership.
-func projectCompactTerminalHistory(state CompactState, live Snapshot) compactTerminalHistoryProjection {
-	if live.BaseTree == state.CurrentSnapshot.CandidateTree {
-		// The reviewed bytes and modes are now the immutable HEAD base. A clean
-		// target or a disjoint next slice is not an applicability claim on the
-		// historical receipt.
-		if len(live.Paths) == 0 || classifyCompactPathSetRelation(state.GenesisPaths, live.Paths) == compactPathsDisjoint {
-			return compactTerminalHistoryUnrelated
-		}
-		return compactTerminalHistoryScopeChanged
-	}
-
-	relation := classifyCompactTargetRelation(state.CurrentSnapshot, live, state.GenesisPaths, compactTargetRelationEvidence{})
-	if relation.Kind != compactTargetUnsafe {
-		return compactTerminalHistoryScopeChanged
-	}
-	// A projection, kind, or base mismatch can make the aggregate relation
-	// unsafe even when live work still contracts or overlaps immutable genesis
-	// scope. That is related evolution and must not be claimed as unrelated.
-	if len(live.Paths) > 0 && relation.Paths != compactPathsDisjoint && relation.Paths != compactPathsInvalid {
-		return compactTerminalHistoryScopeChanged
-	}
-	return compactTerminalHistoryUnrelated
-}
-
 func compactLiveTargetMatchesValidatedSnapshot(state CompactState, live Snapshot, requireCurrentCandidate bool) bool {
 	initial := state.InitialSnapshot
 	proof := initial.IntendedUntrackedProof

--- a/internal/reviewtransaction/target_status_test.go
+++ b/internal/reviewtransaction/target_status_test.go
@@ -959,6 +959,31 @@ func TestClassifyCompactTerminalStartDisposition(t *testing.T) {
 			},
 			want: compactTerminalStartRecovery,
 		},
+		{
+			name: "escalated delivery scope with changed recovery target requires recovery",
+			prepare: func(t *testing.T) (CompactState, Snapshot) {
+				repo := initSnapshotRepo(t)
+				writeSnapshotFile(t, repo, "tracked.txt", "historical candidate\n")
+				state := newCompactTestState(t, repo, "terminal-escalated-recovery")
+				results := make([]LensResult, len(state.SelectedLenses))
+				for index, lens := range state.SelectedLenses {
+					results[index] = LensResult{Lens: lens, Findings: []Finding{}, Evidence: []string{"review completed"}}
+				}
+				if err := state.CompleteReview(CompactReviewInput{LensResults: results, Classifications: []FindingEvidence{}, RefuterOutcomes: []EvidenceResult{}}); err != nil {
+					t.Fatal(err)
+				}
+				if err := state.CompleteVerification([]byte("independent verification failed\n"), false); err != nil {
+					t.Fatal(err)
+				}
+				writeSnapshotFile(t, repo, "tracked.txt", "changed recovery target\n")
+				live, err := (SnapshotBuilder{Repo: repo}).Build(context.Background(), Target{Kind: TargetCurrentChanges, IntendedUntracked: []string{}})
+				if err != nil {
+					t.Fatal(err)
+				}
+				return state, live
+			},
+			want: compactTerminalStartRecovery,
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			state, live := tt.prepare(t)

--- a/internal/reviewtransaction/target_status_test.go
+++ b/internal/reviewtransaction/target_status_test.go
@@ -906,6 +906,69 @@ func TestAssessTargetStatusTreatsCommittedCorrectedIntendedHistoryAsUnrelated(t 
 	}
 }
 
+func TestClassifyCompactTerminalStartDisposition(t *testing.T) {
+	requireSnapshotGit(t)
+	for _, tt := range []struct {
+		name    string
+		prepare func(*testing.T) (CompactState, Snapshot)
+		want    compactTerminalStartDisposition
+	}{
+		{
+			name: "exact approved target claims authority",
+			prepare: func(t *testing.T) (CompactState, Snapshot) {
+				repo := initSnapshotRepo(t)
+				writeSnapshotFile(t, repo, "tracked.txt", "candidate\n")
+				state, _, _ := approvedCompactCurrentChangesFixture(t, repo, "terminal-exact", []string{})
+				live, err := (SnapshotBuilder{Repo: repo}).Build(context.Background(), Target{Kind: TargetCurrentChanges, IntendedUntracked: []string{}})
+				if err != nil {
+					t.Fatal(err)
+				}
+				return state, live
+			},
+			want: compactTerminalStartClaimant,
+		},
+		{
+			name: "delivered authority does not claim a follow-up target",
+			prepare: func(t *testing.T) (CompactState, Snapshot) {
+				repo := initSnapshotRepo(t)
+				writeSnapshotFile(t, repo, "tracked.txt", "historical candidate\n")
+				state, _, _ := approvedCompactCurrentChangesFixture(t, repo, "terminal-unrelated", []string{})
+				gitSnapshot(t, repo, "add", "tracked.txt")
+				gitSnapshot(t, repo, "commit", "-m", "deliver historical target")
+				writeSnapshotFile(t, repo, "tracked.txt", "follow-up target\n")
+				live, err := (SnapshotBuilder{Repo: repo}).Build(context.Background(), Target{Kind: TargetCurrentChanges, IntendedUntracked: []string{}})
+				if err != nil {
+					t.Fatal(err)
+				}
+				return state, live
+			},
+			want: compactTerminalStartUnrelated,
+		},
+		{
+			name: "same delivery scope with changed candidate requires recovery",
+			prepare: func(t *testing.T) (CompactState, Snapshot) {
+				repo := initSnapshotRepo(t)
+				writeSnapshotFile(t, repo, "tracked.txt", "historical candidate\n")
+				state, _, _ := approvedCompactCurrentChangesFixture(t, repo, "terminal-recovery", []string{})
+				writeSnapshotFile(t, repo, "tracked.txt", "changed candidate\n")
+				live, err := (SnapshotBuilder{Repo: repo}).Build(context.Background(), Target{Kind: TargetCurrentChanges, IntendedUntracked: []string{}})
+				if err != nil {
+					t.Fatal(err)
+				}
+				return state, live
+			},
+			want: compactTerminalStartRecovery,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			state, live := tt.prepare(t)
+			if got := classifyCompactTerminalStartDisposition(state, live); got != tt.want {
+				t.Fatalf("terminal disposition = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestAssessTargetStatusTreatsMissingHistoricalIntendedPathAsNonApplicable(t *testing.T) {
 	requireSnapshotGit(t)
 	repo := initSnapshotRepo(t)


### PR DESCRIPTION
## Linked Issue

Closes #1466

---

## PR Type

- [x] `type:bug` - Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` - New feature (non-breaking change that adds functionality)
- [ ] `type:docs` - Documentation only
- [ ] `type:refactor` - Code refactoring (no functional changes)
- [ ] `type:chore` - Build, CI, or tooling changes
- [ ] `type:breaking-change` - Breaking change (fix or feature that changes existing behavior)

---

## Summary

- Share one terminal disposition classifier between negotiated STATUS and ordinary locked START.
- Validate the complete authority graph before target filtering so unrelated terminal history no longer creates false ambiguity.
- Preserve existing schemas, receipts, persisted state, repository locks, and external CLI contracts.

---

## Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/cli/review_receipt_discovery_test.go` | Covers receipt discovery behavior for unrelated terminal authority. |
| `internal/cli/review_status_contract_test.go` | Adds the negotiated STATUS-to-START regression over bounded historical authority. |
| `internal/reviewtransaction/compact_store.go` | Extracts and reuses the shared terminal START disposition classifier. |
| `internal/reviewtransaction/target_status.go` | Classifies validated terminal leaves without unrelated candidates. |
| `internal/reviewtransaction/target_status_projection.go` | Removes the obsolete broad terminal-history projection while retaining graph and stable-read machinery. |
| `internal/reviewtransaction/target_status_test.go` | Covers classifier dispositions, graph validation, deterministic selection, and immutability. |

---

## Test Plan

**Verified evidence**

| Scope | Command | Result |
|-------|---------|--------|
| Focused classifier | `go test ./internal/reviewtransaction -run '^TestClassifyCompactTerminalStartDisposition$' -count=1` | Pass, exit 0 |
| Focused CLI contract | `go test ./internal/cli -run '^TestNegotiatedReviewStatusCompletesWithOneHundredHistoricalLeaves$' -count=1` | Pass, exit 0 |
| Relevant packages | `go test ./internal/reviewtransaction ./internal/cli` | Pass, exit 0 |
| Full suite | `go test ./...` | Pass, exit 0 |
| Race | `go test -race ./internal/reviewtransaction ./internal/cli` | Pass, exit 0 |
| Build | `go build ./...` | Pass, exit 0 |
| Vet | `go vet ./internal/reviewtransaction ./internal/cli` | Pass, exit 0 |
| Diff | `git diff --check 1796b6fb72900feab77cf55ccbd4d403a47f9c0e HEAD` | Pass, exit 0 |

- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`internal/gofmtcheck` runs within `go test ./...`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) - N/A: this internal review-controller change has no E2E runtime boundary.
- [ ] Manually tested locally - N/A: automated CLI contract tests exercise real temporary Git repositories.

---

## Automated Checks

The repository checks run automatically after PR creation.

---

## Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines (263 additions plus deletions)
- [ ] I have added the appropriate `type:*` label to this PR - maintainer action required because the fork contributor cannot apply upstream labels.
- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`, covered by the full suite)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) - N/A: no E2E runtime boundary changes.
- [x] Documentation is unchanged because external contracts and user workflows are unchanged.
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers

---

## Notes for Reviewers

The design keeps STATUS and START on the same pure terminal classifier. Both paths validate the authority graph before filtering; START still performs classification and creation under the existing repository-wide lock. Unrelated state and receipt bytes are not mutation targets. JSON schemas, receipt formats, persisted state formats, lock protocols, and external CLI contracts are unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved `review status` behavior when multiple terminal histories differ by scope or projection, producing deterministic unrelated vs recoverable outcomes.
  - Refined handling of approved vs escalated terminal results, including claimant routing and recovery/scope-change scenarios.
  - Ensures an unrelated `review/start` action no longer changes the authority state used by subsequent review operations.

- **Tests**
  - Added and updated tests covering claimant, unrelated, and recovery classifications, including projection-specific expectations and completion history variations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->